### PR TITLE
Add keep-alive packet propagation between nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,4 @@ require (
 	golang.org/x/net v0.0.0-20191204025024-5ee1b9f4859a
 )
 
-// replace github.com/SkycoinProject/dmsg => ../dmsg
+//replace github.com/SkycoinProject/dmsg => ../dmsg

--- a/vendor/github.com/SkycoinProject/dmsg/go.mod
+++ b/vendor/github.com/SkycoinProject/dmsg/go.mod
@@ -5,10 +5,8 @@ go 1.12
 require (
 	github.com/SkycoinProject/skycoin v0.26.0
 	github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6
-	github.com/mattn/go-colorable v0.1.4 // indirect
-	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/sirupsen/logrus v1.4.2
-	github.com/skycoin/skycoin v0.26.0 // indirect
+	github.com/skycoin/dmsg v0.0.0-20190805065636-70f4c32a994f
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582

--- a/vendor/github.com/SkycoinProject/dmsg/go.sum
+++ b/vendor/github.com/SkycoinProject/dmsg/go.sum
@@ -5,7 +5,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -14,8 +13,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
-github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
@@ -24,6 +21,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/skycoin/dmsg v0.0.0-20190805065636-70f4c32a994f h1:WWjaxOXoj6oYelm67MNtJbg51HQALjKAyhs2WAHgpZs=
+github.com/skycoin/dmsg v0.0.0-20190805065636-70f4c32a994f/go.mod h1:obZYZp8eKR7Xqz+KNhJdUE6Gvp6rEXbDO8YTlW2YXgU=
 github.com/skycoin/skycoin v0.26.0 h1:xDxe2r8AclMntZ550Y/vUQgwgLtwrf9Wu5UYiYcN5/o=
 github.com/skycoin/skycoin v0.26.0/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
@@ -26,6 +26,7 @@ The tool is sponsored by the [marvin + konsorten GmbH](http://www.konsorten.de).
 We thank all the authors who provided code to this library:
 
 * Felix Kollmann
+* Nicolas Perraut
 
 ## License
 

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences_dummy.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences_dummy.go
@@ -1,0 +1,11 @@
+// +build linux darwin
+
+package sequences
+
+import (
+	"fmt"
+)
+
+func EnableVirtualTerminalProcessing(stream uintptr, enable bool) error {
+	return fmt.Errorf("windows only package")
+}

--- a/vendor/github.com/mattn/go-colorable/colorable_appengine.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_appengine.go
@@ -9,7 +9,7 @@ import (
 	_ "github.com/mattn/go-isatty"
 )
 
-// NewColorable returns new instance of Writer which handles escape sequence.
+// NewColorable return new instance of Writer which handle escape sequence.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
@@ -18,12 +18,12 @@ func NewColorable(file *os.File) io.Writer {
 	return file
 }
 
-// NewColorableStdout returns new instance of Writer which handles escape sequence for stdout.
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
 func NewColorableStdout() io.Writer {
 	return os.Stdout
 }
 
-// NewColorableStderr returns new instance of Writer which handles escape sequence for stderr.
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
 func NewColorableStderr() io.Writer {
 	return os.Stderr
 }

--- a/vendor/github.com/mattn/go-colorable/colorable_others.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_others.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/mattn/go-isatty"
 )
 
-// NewColorable returns new instance of Writer which handles escape sequence.
+// NewColorable return new instance of Writer which handle escape sequence.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
@@ -19,12 +19,12 @@ func NewColorable(file *os.File) io.Writer {
 	return file
 }
 
-// NewColorableStdout returns new instance of Writer which handles escape sequence for stdout.
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
 func NewColorableStdout() io.Writer {
 	return os.Stdout
 }
 
-// NewColorableStderr returns new instance of Writer which handles escape sequence for stderr.
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
 func NewColorableStderr() io.Writer {
 	return os.Stderr
 }

--- a/vendor/github.com/mattn/go-colorable/colorable_windows.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_windows.go
@@ -81,7 +81,7 @@ var (
 	procCreateConsoleScreenBuffer  = kernel32.NewProc("CreateConsoleScreenBuffer")
 )
 
-// Writer provides colorable Writer to the console
+// Writer provide colorable Writer to the console
 type Writer struct {
 	out       io.Writer
 	handle    syscall.Handle
@@ -91,7 +91,7 @@ type Writer struct {
 	rest      bytes.Buffer
 }
 
-// NewColorable returns new instance of Writer which handles escape sequence from File.
+// NewColorable return new instance of Writer which handle escape sequence from File.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
@@ -106,12 +106,12 @@ func NewColorable(file *os.File) io.Writer {
 	return file
 }
 
-// NewColorableStdout returns new instance of Writer which handles escape sequence for stdout.
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
 func NewColorableStdout() io.Writer {
 	return NewColorable(os.Stdout)
 }
 
-// NewColorableStderr returns new instance of Writer which handles escape sequence for stderr.
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
 func NewColorableStderr() io.Writer {
 	return NewColorable(os.Stderr)
 }
@@ -414,15 +414,7 @@ func doTitleSequence(er *bytes.Reader) error {
 	return nil
 }
 
-// returns Atoi(s) unless s == "" in which case it returns def
-func atoiWithDefault(s string, def int) (int, error) {
-	if s == "" {
-		return def, nil
-	}
-	return strconv.Atoi(s)
-}
-
-// Write writes data on console
+// Write write data on console
 func (w *Writer) Write(data []byte) (n int, err error) {
 	var csbi consoleScreenBufferInfo
 	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
@@ -508,7 +500,7 @@ loop:
 
 		switch m {
 		case 'A':
-			n, err = atoiWithDefault(buf.String(), 1)
+			n, err = strconv.Atoi(buf.String())
 			if err != nil {
 				continue
 			}
@@ -516,7 +508,7 @@ loop:
 			csbi.cursorPosition.y -= short(n)
 			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'B':
-			n, err = atoiWithDefault(buf.String(), 1)
+			n, err = strconv.Atoi(buf.String())
 			if err != nil {
 				continue
 			}
@@ -524,7 +516,7 @@ loop:
 			csbi.cursorPosition.y += short(n)
 			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'C':
-			n, err = atoiWithDefault(buf.String(), 1)
+			n, err = strconv.Atoi(buf.String())
 			if err != nil {
 				continue
 			}
@@ -532,7 +524,7 @@ loop:
 			csbi.cursorPosition.x += short(n)
 			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'D':
-			n, err = atoiWithDefault(buf.String(), 1)
+			n, err = strconv.Atoi(buf.String())
 			if err != nil {
 				continue
 			}
@@ -564,9 +556,6 @@ loop:
 			n, err = strconv.Atoi(buf.String())
 			if err != nil {
 				continue
-			}
-			if n < 1 {
-				n = 1
 			}
 			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
 			csbi.cursorPosition.x = short(n - 1)
@@ -646,20 +635,6 @@ loop:
 			}
 			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 			procFillConsoleOutputAttribute.Call(uintptr(handle), uintptr(csbi.attributes), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
-		case 'X':
-			n := 0
-			if buf.Len() > 0 {
-				n, err = strconv.Atoi(buf.String())
-				if err != nil {
-					continue
-				}
-			}
-			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
-			var cursor coord
-			var written dword
-			cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
-			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(n), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
-			procFillConsoleOutputAttribute.Call(uintptr(handle), uintptr(csbi.attributes), uintptr(n), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 		case 'm':
 			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
 			attr := csbi.attributes

--- a/vendor/github.com/mattn/go-colorable/noncolorable.go
+++ b/vendor/github.com/mattn/go-colorable/noncolorable.go
@@ -5,17 +5,17 @@ import (
 	"io"
 )
 
-// NonColorable holds writer but removes escape sequence.
+// NonColorable hold writer but remove escape sequence.
 type NonColorable struct {
 	out io.Writer
 }
 
-// NewNonColorable returns new instance of Writer which removes escape sequence from Writer.
+// NewNonColorable return new instance of Writer which remove escape sequence from Writer.
 func NewNonColorable(w io.Writer) io.Writer {
 	return &NonColorable{out: w}
 }
 
-// Write writes data on console
+// Write write data on console
 func (w *NonColorable) Write(data []byte) (n int, err error) {
 	er := bytes.NewReader(data)
 	var bw [1]byte

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/SkycoinProject/dmsg v0.0.0-20191106075825-cabc26522b11 => ../dmsg
+# github.com/SkycoinProject/dmsg v0.0.0-20191106075825-cabc26522b11
 github.com/SkycoinProject/dmsg
 github.com/SkycoinProject/dmsg/cipher
 github.com/SkycoinProject/dmsg/disc
@@ -40,9 +40,9 @@ github.com/gorilla/handlers
 github.com/gorilla/securecookie
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/konsorten/go-windows-terminal-sequences v1.0.1
+# github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/mattn/go-colorable v0.1.4
+# github.com/mattn/go-colorable v0.1.2
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.8
 github.com/mattn/go-isatty


### PR DESCRIPTION
Fixes #81 

 Changes:	
- Proper keep-alive packets propagation was added. Now when router receives the keep-alive packet, assuming that we talk about the intermediary node, the packet is being forwarded to the next node along the route. This way all the rules have their activity up to date, preventing unwanted expiry