### PR TITLE
fix update to uptime tracker

### DIFF
--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -177,7 +177,6 @@ func (cfg *runCfg) runNode() *runCfg {
 			cfg.logger.Error("Failed to connect to uptime tracker: ", err)
 		} else {
 			ticker := time.NewTicker(1 * time.Second)
-			defer ticker.Stop()
 
 			go func() {
 				for range ticker.C {


### PR DESCRIPTION
Fixes # [skywire-services issue #38](https://github.com/SkycoinPro/skywire-services/issues/38)
 Changes:	
-	removed defer ticker.stop() in cmd/skywire-visor/commands/root.go

How to test this PR:
-   Set {**uptime.tracker**: https://uptime-tracker.skywire.skycoin.com } in skywire- 
     services/integration/uptime/nodeA.json 
-    Run an **integration env** (make integration-run-uptime)
-    Check [uptime tracker](https://uptime-tracker.skywire.skycoin.com/nodes)