### PR TITLE
Document hypervisor auth states.

### DIFF
--- a/cmd/hypervisor/README.md
+++ b/cmd/hypervisor/README.md
@@ -23,3 +23,9 @@ By default, the RESTful API is served on `:8080`.
 ## Endpoints Documentation
 
 Endpoints are documented in the provided [Postman](https://www.getpostman.com/) file: `hypervisor.postman_collection.json`.
+
+### Authentication information
+
+- When the authentication cookie is invalid, the hypervisor will return code `401`.
+- The default authentication cookie timeout is 12 hours. This can be configured in the hypervisor config file: `cookies.expires_duration`.
+- There is currently no enforcement of when a user should change their password.

--- a/cmd/hypervisor/README.md
+++ b/cmd/hypervisor/README.md
@@ -5,16 +5,12 @@ Hypervisor exposes node management operations via web API.
 **Generate config file:**
 
 ```bash
-
+$ hypervisor gen-config
 ```
 
 **Run with mock data:**
 
 ```bash
-# Generate config file.
-$ hypervisor gen-config
-
-# Run.
 $ hypervisor --mock
 ```
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/SkycoinProject/dmsg v0.0.0-20200116114634-91be578a1895 => ../dmsg
+# github.com/SkycoinProject/dmsg v0.0.0-20200116114634-91be578a1895
 github.com/SkycoinProject/dmsg
 github.com/SkycoinProject/dmsg/cipher
 github.com/SkycoinProject/dmsg/disc


### PR DESCRIPTION
Did you run `make format && make check`?
> No need as this is fixing documentation.

Fixes #19 

 Changes:	
- Additions to [`cmd/hypervisor/README.md`](https://github.com/evanlinjin/skywire-mainnet/blob/fix/m2-doc-hypervisor-auth-states/cmd/hypervisor/README.md).
