### PR TITLE
Fix linter and tests on 32-bit architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ DOCKER_NETWORK?=SKYNET
 DOCKER_NODE?=SKY01
 DOCKER_OPTS?=GO111MODULE=on GOOS=linux # go options for compiling for docker container
 
-TEST_OPTS_BASE:=-cover -timeout=1m
+TEST_OPTS_BASE:=-cover -timeout=5m
 
 RACE_FLAG:=-race
 GOARCH:=$(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ ifneq (,$(findstring 64,$(GOARCH)))
 endif
 
 # TODO: Remove after https://github.com/etcd-io/bbolt/pull/201 is closed.
-GO_VERSION:=$(shell go version)
 DISABLE_CHECKPTR_FLAG:=-gcflags=all=-d=checkptr=0
+GO_VERSION:=$(shell go version)
 
 ifneq (,$(findstring go1.14,$(GO_VERSION)))
     TEST_OPTS_BASE:=$(TEST_OPTS_BASE) $(DISABLE_CHECKPTR_FLAG)

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,25 @@ DOCKER_NETWORK?=SKYNET
 DOCKER_NODE?=SKY01
 DOCKER_OPTS?=GO111MODULE=on GOOS=linux # go options for compiling for docker container
 
-GO_VERSION=$(shell go version)
-# TODO: Remove after https://github.com/etcd-io/bbolt/pull/201 is closed.
-DISABLE_CHECKPTR=-gcflags=all=-d=checkptr=0
-OPTIONAL_FLAGS=
-ifneq (,$(findstring go1.14,$(GO_VERSION)))
-    OPTIONAL_FLAGS=$(DISABLE_CHECKPTR)
+TEST_OPTS_BASE:=-cover -timeout=1m
+
+RACE_FLAG:=-race
+GOARCH:=$(shell go env GOARCH)
+
+ifneq (,$(findstring 64,$(GOARCH)))
+    TEST_OPTS_BASE:=$(TEST_OPTS_BASE) $(RACE_FLAG)
 endif
 
-TEST_OPTS?=-race $(OPTIONAL_FLAGS) -tags no_ci -cover -timeout=5m
-TEST_OPTS_NOCI?=-race $(OPTIONAL_FLAGS) -cover -timeout=5m -v
+# TODO: Remove after https://github.com/etcd-io/bbolt/pull/201 is closed.
+GO_VERSION:=$(shell go version)
+DISABLE_CHECKPTR_FLAG:=-gcflags=all=-d=checkptr=0
+
+ifneq (,$(findstring go1.14,$(GO_VERSION)))
+    TEST_OPTS_BASE:=$(TEST_OPTS_BASE) $(DISABLE_CHECKPTR_FLAG)
+endif
+
+TEST_OPTS_NOCI:=-$(TEST_OPTS_BASE) -v
+TEST_OPTS:=$(TEST_OPTS_BASE) -tags no_ci
 
 BUILDINFO_PATH := $(PROJECT_BASE)/pkg/util/buildinfo
 

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -67,6 +67,8 @@ type RouteGroup struct {
 	desc   routing.RouteDescriptor // describes the route group
 	rt     routing.Table
 
+	lastSent int64
+
 	// 'tps' is transports used for writing/forward rules.
 	// It should have the same number of elements as 'fwd'
 	// where each element corresponds with the adjacent element in 'fwd'.
@@ -79,15 +81,12 @@ type RouteGroup struct {
 	fwd []routing.Rule // forward rules (for writing)
 	rvs []routing.Rule // reverse rules (for reading)
 
-	lastSent int64
-
 	// 'readCh' reads in incoming packets of this route group.
 	// - Router should serve call '(*transport.Manager).ReadPacket' in a loop,
 	//      and push to the appropriate '(RouteGroup).readCh'.
 	readCh   chan []byte // push reads from Router
 	readChMu sync.Mutex
 	readBuf  bytes.Buffer // for read overflow
-	once     sync.Once
 
 	readDeadline  deadline.PipeDeadline
 	writeDeadline deadline.PipeDeadline
@@ -99,6 +98,7 @@ type RouteGroup struct {
 	closed           chan struct{}
 	// used to wait for all the `Close` packets to run through the loop and come back
 	closeDone sync.WaitGroup
+	once      sync.Once
 }
 
 // NewRouteGroup creates a new RouteGroup.

--- a/pkg/router/route_group_test.go
+++ b/pkg/router/route_group_test.go
@@ -28,6 +28,13 @@ func TestNewRouteGroup(t *testing.T) {
 	require.Equal(t, DefaultRouteGroupConfig(), rg.cfg)
 }
 
+// Uncomment for debugging
+/*
+func TestRouteGroupAlignment(t *testing.T) {
+	alignment.PrintStruct(RouteGroup{})
+}
+*/
+
 func TestRouteGroup_Close(t *testing.T) {
 	rg1, rg2, m1, m2, teardown := setupEnv(t)
 

--- a/pkg/util/alignment/alignment.go
+++ b/pkg/util/alignment/alignment.go
@@ -1,0 +1,20 @@
+package alignment
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// PrintStruct prints detailed information of struct fields alignment.
+func PrintStruct(v interface{}) {
+	typ := reflect.TypeOf(v)
+	fmt.Printf("Struct is %d bytes long\n", typ.Size())
+	// We can run through the fields in the structure in order
+	n := typ.NumField()
+	for i := 0; i < n; i++ {
+		field := typ.Field(i)
+		fmt.Printf("%s at offset %v, size=%d, align=%d\n",
+			field.Name, field.Offset, field.Type.Size(),
+			field.Type.Align())
+	}
+}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #194

 Changes:
- Implement struct fields alignment calculation
- Fix linter on 32-bit ARM
- Remove `-race` flag for tests on 32-bit architectures because it's not supported, so tests failed

How to test this PR:
Run `make check` on 32-bit ARM.