### PR TITLE
Verify public key before requesting routes

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -3,6 +3,7 @@ package appnet
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -50,7 +51,12 @@ func (r *SkywireNetworker) DialContext(ctx context.Context, addr Addr) (net.Conn
 		return nil, err
 	}
 
-	rg, err := r.r.DialRoutes(ctx, addr.PubKey, routing.Port(localPort), addr.Port, router.DefaultDialOptions())
+	rPK := addr.PubKey
+	if rPK.Null() {
+		return nil, fmt.Errorf("Empty public key: %s", rPK)
+	}
+
+	rg, err := r.r.DialRoutes(ctx, rPK, routing.Port(localPort), addr.Port, router.DefaultDialOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -3,7 +3,6 @@ package appnet
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -53,7 +52,7 @@ func (r *SkywireNetworker) DialContext(ctx context.Context, addr Addr) (net.Conn
 
 	rPK := addr.PubKey
 	if rPK.Null() {
-		return nil, fmt.Errorf("Empty public key: %s", rPK)
+		return nil, errors.New("cannot dial to address with empty public key")
 	}
 
 	rg, err := r.r.DialRoutes(ctx, rPK, routing.Port(localPort), addr.Port, router.DefaultDialOptions())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/SkycoinProject/dmsg v0.0.0-20200306131535-fabb2c8177e9
+# github.com/SkycoinProject/dmsg v0.0.0-20200306131535-fabb2c8177e9 => ../dmsg
 github.com/SkycoinProject/dmsg
 github.com/SkycoinProject/dmsg/cipher
 github.com/SkycoinProject/dmsg/disc

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/SkycoinProject/dmsg v0.0.0-20200306131535-fabb2c8177e9 => ../dmsg
+# github.com/SkycoinProject/dmsg v0.0.0-20200306152741-acee74fa4514
 github.com/SkycoinProject/dmsg
 github.com/SkycoinProject/dmsg/cipher
 github.com/SkycoinProject/dmsg/disc


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #172 	

 Changes:	
-	Verified public key before call to `(*router).DialContext` in `(*SkywireNetworker).DialContext`

How to test this PR: Run the integaration-env, run`make integration-startup`, open [http://localhost:8000/](http://localhost:8000/) and type a message. Then check associated visor for logs.
