### PR TITLE
Fix update endpoint.

### DIFF
--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -173,7 +173,7 @@ func (hv *Hypervisor) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			r.Put("/visors/{pk}/routes/{rid}", hv.putRoute())
 			r.Delete("/visors/{pk}/routes/{rid}", hv.deleteRoute())
 			r.Get("/visors/{pk}/routegroups", hv.getRouteGroups())
-			r.Get("/visors/{pk}/restart", hv.restart())
+			r.Post("/visors/{pk}/restart", hv.restart())
 			r.Post("/visors/{pk}/exec", hv.exec())
 			r.Post("/visors/{pk}/update", hv.update())
 		})

--- a/pkg/restart/restart_test.go
+++ b/pkg/restart/restart_test.go
@@ -66,9 +66,9 @@ func TestContext_Start(t *testing.T) {
 		cc := CaptureContext()
 		assert.NotZero(t, len(cc.cmd.Args))
 
-		cmd := "touch"
-		path := "/tmp/test_start"
-		cc.cmd = exec.Command(cmd, path) // nolint:gosec
+		cmd := "sleep"
+		duration := "5"
+		cc.cmd = exec.Command(cmd, duration) // nolint:gosec
 		cc.appendDelay = false
 
 		errCh := make(chan error, 1)
@@ -82,8 +82,6 @@ func TestContext_Start(t *testing.T) {
 
 		assert.Contains(t, errors, ErrAlreadyStarted)
 		assert.Contains(t, errors, nil)
-
-		assert.NoError(t, os.Remove(path))
 	})
 }
 

--- a/pkg/util/updater/updater.go
+++ b/pkg/util/updater/updater.go
@@ -57,7 +57,7 @@ type Updater struct {
 	log        *logging.Logger
 	restartCtx *restart.Context
 	appsPath   string
-	updating   uint32
+	updating   int32
 }
 
 // New returns a new Updater.
@@ -72,10 +72,13 @@ func New(log *logging.Logger, restartCtx *restart.Context, appsPath string) *Upd
 // Update performs an update operation.
 // NOTE: Update may call os.Exit.
 func (u *Updater) Update() (err error) {
-	if !atomic.CompareAndSwapUint32(&u.updating, 0, 1) {
+	if !atomic.CompareAndSwapInt32(&u.updating, 0, 1) {
 		return ErrAlreadyStarted
 	}
-	defer atomic.StoreUint32(&u.updating, 0)
+	defer func() {
+		// TODO(evanlinjin): Need to reset restartCtx or something.
+		atomic.StoreInt32(&u.updating, 0)
+	}()
 
 	u.log.Infof("Looking for updates")
 

--- a/pkg/util/updater/updater.go
+++ b/pkg/util/updater/updater.go
@@ -75,10 +75,7 @@ func (u *Updater) Update() (err error) {
 	if !atomic.CompareAndSwapInt32(&u.updating, 0, 1) {
 		return ErrAlreadyStarted
 	}
-	defer func() {
-		// TODO(evanlinjin): Need to reset restartCtx or something.
-		atomic.StoreInt32(&u.updating, 0)
-	}()
+	defer atomic.StoreInt32(&u.updating, 0)
 
 	u.log.Infof("Looking for updates")
 

--- a/pkg/util/updater/updater.go
+++ b/pkg/util/updater/updater.go
@@ -75,6 +75,7 @@ func (u *Updater) Update() (err error) {
 	if !atomic.CompareAndSwapUint32(&u.updating, 0, 1) {
 		return ErrAlreadyStarted
 	}
+	defer atomic.StoreUint32(&u.updating, 0)
 
 	u.log.Infof("Looking for updates")
 


### PR DESCRIPTION
Fixes #213

 Changes:	
* Added defer statement to Updater.Update to revert u.updating value back to 0 after updating.
* Make `restart.Context` reset it's internal `exec.Cmd` on failure.
* Changed restart visor endpoint to only accept `POST`.
* Update `restart.Restart` test.


