### PR TITLE
Improvements for the updater on the manager

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.ts
@@ -39,9 +39,9 @@ export interface ConfirmationData {
  * is shown.
  */
 enum ConfirmationStates {
-  Asking,
-  Processing,
-  Done,
+  Asking = 'Asking',
+  Processing = 'Processing',
+  Done = 'Done',
 }
 
 /**
@@ -97,6 +97,25 @@ export class ConfirmationComponent implements AfterViewInit, OnDestroy {
     this.operationAccepted.emit();
   }
 
+  /**
+   * Puts the modal window in the state in which it is waiting for confirmation.
+   * @param newData New configuration for the modal window.
+   */
+  showAsking(newData: ConfirmationData | null) {
+    if (newData) {
+      this.data = newData;
+    }
+
+    this.state = ConfirmationStates.Asking;
+    this.confirmButton.reset();
+    this.disableDismiss = false;
+    this.dialogRef.disableClose = this.disableDismiss;
+
+    if (this.cancelButton) {
+      this.cancelButton.showEnabled();
+    }
+  }
+
   showProcessing() {
     this.state = ConfirmationStates.Processing;
     this.disableDismiss = true;
@@ -112,8 +131,12 @@ export class ConfirmationComponent implements AfterViewInit, OnDestroy {
    * @param newTitle New title for the modal window.
    * @param newText New main text for the modal window.
    */
-  showDone(newTitle: string, newText: string) {
-    this.doneTitle = newTitle;
+  showDone(newTitle: string | null, newText: string) {
+    if (newTitle) {
+      this.doneTitle = newTitle;
+    } else {
+      this.doneTitle = this.data.headerText;
+    }
     this.doneText = newText;
 
     this.confirmButton.reset();

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/update-node/update-node.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/update-node/update-node.component.ts
@@ -1,3 +1,6 @@
+// NOTE: The updater has been implemented without using this component, so it could be
+// removed soon.
+
 import { Component, OnInit } from '@angular/core';
 import {NodeService} from '../../../../../services/node.service';
 import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material/dialog';

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -139,6 +139,13 @@ export class NodeService {
   }
 
   /**
+   * Checks if there are updates available for a node.
+   */
+  checkUpdate(nodeKey: string): Observable<any> {
+    return this.apiService.get(`visors/${nodeKey}/update/available`).pipe();
+  }
+
+  /**
    * Updates a node.
    */
   update(nodeKey: string): Observable<any> {

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -135,7 +135,7 @@ export class NodeService {
    * Restarts a node.
    */
   reboot(nodeKey: string): Observable<any> {
-    return this.apiService.get(`visors/${nodeKey}/restart`).pipe();
+    return this.apiService.post(`visors/${nodeKey}/restart`).pipe();
   }
 
   /**

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -2,6 +2,7 @@
   "common": {
     "save": "Save",
     "edit": "Edit",
+    "cancel": "Cancel",
     "node-key": "Node Key",
     "app-key": "App Key",
     "discovery": "Discovery",
@@ -172,14 +173,14 @@
       "error": "Unexpected error while trying to execute the command."
     },
     "update": {
-      "title": "Check node update",
-      "no-update": "Currently, there is no update for the node.",
-      "update-available": "There is an update available for the node. Click the 'Install update' button to continue.",
-      "update-error": "Could not install node update. Please, try again later.",
-      "install": "Install update",
-      "update-success": "Node updated successfully, reboot the node and refresh this site to apply changes.",
-      "confirmation": "Are you sure you want to update the visor?",
-      "done": "The visor is being updated."
+      "title": "Update",
+      "processing": "Looking for updates...",
+      "processing-button": "Please wait",
+      "no-update": "Currently, there is no update for the visor. The currently installed version is {{ version }}.",
+      "update-available": "There is an update available for the visor. Click the 'Install update' button to continue. The currently installed version is {{ currentVersion }} and the new version is {{ newVersion }}.",
+      "done": "The visor is being updated.",
+      "update-error": "Could not install the update. Please, try again later.",
+      "install": "Install update"
     }
   },
 

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -2,6 +2,7 @@
   "common": {
     "save": "Guardar",
     "edit": "Editar",
+    "cancel": "Cancelar",
     "node-key": "Llave del Nodo",
     "app-key": "Llave de la App",
     "discovery": "Discovery",
@@ -172,14 +173,14 @@
       "error": "Error inesperado mientras se intentaba ejecutar el comando."
     },
     "update": {
-      "title": "Revisar actualización del nodo",
-      "no-update": "Actualmente no hay actualizaciones para el nodo.",
-      "update-available": "Hay una actualización disponible para el nodo. Presione el botón 'Instalar actualización' para continuar.",
-      "update-error": "No se pudo instalar la actualización del nodo. Por favor inténtelo nuevamente luego.",
-      "install": "Instalar actualización",
-      "update-success": "Nodo actualizado exitosamente, reinicie el nodo y refresque este sitio para aplicar los cambios.",
-      "confirmation": "¿Seguro que desea actualizar el visor?",
-      "done": "El visor está siendo actualizado."
+      "title": "Actualizar",
+      "processing": "Buscando actualizaciones...",
+      "processing-button": "Por favor espere",
+      "no-update": "Actualmente no hay actualizaciones para el visor. Actualmente está instalada la versión {{ version }}.",
+      "update-available": "Hay una actualización disponible para el visor. Presione el botón 'Instalar actualización' para continuar. Actualmente está instalada la versión {{ currentVersion }} y la nueva versión es la {{ newVersion }}.",
+      "done": "El visor está siendo actualizado.",
+      "update-error": "No se pudo instalar la actualización. Por favor inténtelo nuevamente luego.",
+      "install": "Instalar actualización"
     }
   },
 

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -2,6 +2,7 @@
   "common": {
     "save": "Save",
     "edit": "Edit",
+    "cancel": "Cancel",
     "node-key": "Node Key",
     "app-key": "App Key",
     "discovery": "Discovery",
@@ -172,14 +173,14 @@
       "error": "Unexpected error while trying to execute the command."
     },
     "update": {
-      "title": "Check node update",
-      "no-update": "Currently, there is no update for the node.",
-      "update-available": "There is an update available for the node. Click the 'Install update' button to continue.",
-      "update-error": "Could not install node update. Please, try again later.",
-      "install": "Install update",
-      "update-success": "Node updated successfully, reboot the node and refresh this site to apply changes.",
-      "confirmation": "Are you sure you want to update the visor?",
-      "done": "The visor is being updated."
+      "title": "Update",
+      "processing": "Looking for updates...",
+      "processing-button": "Please wait",
+      "no-update": "Currently, there is no update for the visor. The currently installed version is {{ version }}.",
+      "update-available": "There is an update available for the visor. Click the 'Install update' button to continue. The currently installed version is {{ currentVersion }} and the new version is {{ newVersion }}.",
+      "done": "The visor is being updated.",
+      "update-error": "Could not install the update. Please, try again later.",
+      "install": "Install update"
     }
   },
 


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

 Changes:	
-  Now, before updating a visor, the manager checks if there is an update available, blocks the operation if there is not and shows info about the versions.
- The update procedure was modified to work with the changes made to the API endpoint.
- The Spanish translation was updated.

NOTE: for this PR to work, the changes made in https://github.com/SkycoinProject/skywire-mainnet/pull/217 are needed.

How to test this PR:
Use the update button on the visor details page.