### PR TITLE
Put apps in a separate directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ builds:
     main: ./cmd/skywire-cli/
     ldflags: -s -w -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.version={{.Version}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.commit={{.ShortCommit}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.date={{.Date}}
   - id: skychat
-    binary: skychat
+    binary: apps/skychat
     goos:
       - linux
       - darwin
@@ -53,7 +53,7 @@ builds:
     main: ./cmd/apps/skychat/
     ldflags: -s -w -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.version={{.Version}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.commit={{.ShortCommit}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.date={{.Date}}
   - id: skysocks
-    binary: skysocks
+    binary: apps/skysocks
     goos:
       - linux
       - darwin
@@ -69,7 +69,7 @@ builds:
     main: ./cmd/apps/skysocks/
     ldflags: -s -w -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.version={{.Version}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.commit={{.ShortCommit}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.date={{.Date}}
   - id: skysocks-client
-    binary: skysocks-client
+    binary: apps/skysocks-client
     goos:
       - linux
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,7 +87,7 @@ builds:
 archives:
   - format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/securecookie v1.1.1
-	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mholt/archiver/v3 v3.3.0
 	github.com/pkg/profile v1.3.0
 	github.com/prometheus/client_golang v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/SkycoinProject/dmsg v0.0.0-20200306152741-acee74fa4514/go.mod h1:Dzyk
 github.com/SkycoinProject/skycoin v0.26.0/go.mod h1:xqPLOKh5B6GBZlGA7B5IJfQmCy7mwimD9NlqxR3gMXo=
 github.com/SkycoinProject/skycoin v0.27.0 h1:N3IHxj8ossHOcsxLYOYugT+OaELLncYHJHxbbYLPPmY=
 github.com/SkycoinProject/skycoin v0.27.0/go.mod h1:xqPLOKh5B6GBZlGA7B5IJfQmCy7mwimD9NlqxR3gMXo=
-github.com/SkycoinProject/skywire-mainnet v0.0.0-20200309204032-14af5342da86/go.mod h1:xuOpE5ZZU2kR39u0tJWtOpak/sJpnEFj1HpTxtyPU/A=
 github.com/SkycoinProject/yamux v0.0.0-20191213015001-a36efeefbf6a h1:6nHCJqh7trsuRcpMC5JmtDukUndn2VC9sY64K6xQ7hQ=
 github.com/SkycoinProject/yamux v0.0.0-20191213015001-a36efeefbf6a/go.mod h1:IaE1dxncLQs4RJcQTZPikJfAZY4szH87u2h0lT0SDuM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -118,12 +117,9 @@ github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -131,12 +127,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
-github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
-github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
@@ -237,8 +229,6 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -269,10 +259,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
-golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/util/updater/updater.go
+++ b/pkg/util/updater/updater.go
@@ -37,6 +37,7 @@ const (
 	permRWX           = 0755
 	exitDelay         = 100 * time.Millisecond
 	oldSuffix         = ".old"
+	appsSubfolder     = "apps"
 	archiveFormat     = ".tar.gz"
 	visorBinary       = "skywire-visor"
 	cliBinary         = "skywire-cli"
@@ -166,6 +167,10 @@ func (u *Updater) updateBinaries(downloadedBinariesPath string, currentBasePath 
 
 func (u *Updater) updateBinary(downloadedBinariesPath, basePath, binary string) error {
 	downloadedBinaryPath := filepath.Join(downloadedBinariesPath, binary)
+	if _, err := os.Stat(downloadedBinaryPath); os.IsNotExist(err) {
+		downloadedBinaryPath = filepath.Join(downloadedBinariesPath, appsSubfolder, binary)
+	}
+
 	currentBinaryPath := filepath.Join(basePath, binary)
 	oldBinaryPath := downloadedBinaryPath + oldSuffix
 

--- a/pkg/util/updater/updater_test.go
+++ b/pkg/util/updater/updater_test.go
@@ -20,8 +20,8 @@ func Test_extractLatestVersion(t *testing.T) {
 	}{
 		{
 			name:   "Simple HTML",
-			buffer: `<a href="/SkycoinProject/skywire-mainnet/releases/tag/0.1.0">`,
-			want:   "0.1.0",
+			buffer: `<a href="/SkycoinProject/skywire-mainnet/releases/tag/v0.1.0">`,
+			want:   "v0.1.0",
 		},
 		{
 			name:   "Empty buffer",
@@ -49,54 +49,54 @@ func Test_getChecksum(t *testing.T) {
 		{
 			name: "No Error 1",
 			checksums: `
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92470 skywire-visor-0.1.0-linux-amd64
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92471 skywire-visor-0.1.0-linux-386
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92472 skywire-visor-0.1.0-darwin-amd64
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92473 skywire-visor-0.1.0-windows-amd64
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92474 skywire-visor-0.1.0-linux-arm64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92470 skywire-visor-v0.1.0-linux-amd64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92471 skywire-visor-v0.1.0-linux-386
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92472 skywire-visor-v0.1.0-darwin-amd64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92473 skywire-visor-v0.1.0-windows-amd64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92474 skywire-visor-v0.1.0-linux-arm64
 `,
-			filename: "skywire-visor-0.1.0-darwin-amd64",
+			filename: "skywire-visor-v0.1.0-darwin-amd64",
 			want:     "2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92472",
 			wantErr:  nil,
 		},
 		{
 			name: "No Error 2",
 			checksums: `
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92470     	   skywire-visor-0.1.0-linux-amd64
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92471     	   skywire-visor-0.1.0-linux-386
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92472     	   skywire-visor-0.1.0-darwin-amd64
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92473     	   skywire-visor-0.1.0-windows-amd64
-2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92474     	   skywire-visor-0.1.0-linux-arm64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92470     	   skywire-visor-v0.1.0-linux-amd64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92471     	   skywire-visor-v0.1.0-linux-386
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92472     	   skywire-visor-v0.1.0-darwin-amd64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92473     	   skywire-visor-v0.1.0-windows-amd64
+2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92474     	   skywire-visor-v0.1.0-linux-arm64
 `,
-			filename: "skywire-visor-0.1.0-darwin-amd64",
+			filename: "skywire-visor-v0.1.0-darwin-amd64",
 			want:     "2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92472",
 			wantErr:  nil,
 		},
 		{
 			name:      "ErrMalformedChecksumFile 1",
-			checksums: "skywire-visor-0.1.0-darwin-amd64",
-			filename:  "skywire-visor-0.1.0-darwin-amd64",
+			checksums: "skywire-visor-v0.1.0-darwin-amd64",
+			filename:  "skywire-visor-v0.1.0-darwin-amd64",
 			want:      "",
 			wantErr:   ErrMalformedChecksumFile,
 		},
 		{
 			name:      "ErrMalformedChecksumFile 2",
-			checksums: " skywire-visor-0.1.0-darwin-amd64",
-			filename:  " skywire-visor-0.1.0-darwin-amd64",
+			checksums: " skywire-visor-v0.1.0-darwin-amd64",
+			filename:  " skywire-visor-v0.1.0-darwin-amd64",
 			want:      "",
 			wantErr:   ErrMalformedChecksumFile,
 		},
 		{
 			name:      "ErrMalformedChecksumFile 3",
-			checksums: "  \t skywire-visor-0.1.0-darwin-amd64",
-			filename:  "  \t skywire-visor-0.1.0-darwin-amd64",
+			checksums: "  \t skywire-visor-v0.1.0-darwin-amd64",
+			filename:  "  \t skywire-visor-v0.1.0-darwin-amd64",
 			want:      "",
 			wantErr:   ErrMalformedChecksumFile,
 		},
 		{
 			name:      "ErrNoChecksumFound",
-			checksums: `2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92470 skywire-visor-0.1.0-linux-amd64`,
-			filename:  "skywire-visor-0.1.0-darwin-amd64",
+			checksums: `2f505da2a905889aa978597814f91dbe32ee46fffe44657bd7af56a942d92470 skywire-visor-v0.1.0-linux-amd64`,
+			filename:  "skywire-visor-v0.1.0-darwin-amd64",
 			want:      "",
 			wantErr:   ErrNoChecksumFound,
 		},
@@ -150,10 +150,10 @@ func Test_fileURL(t *testing.T) {
 	}{
 		{
 			name:     "Case 1",
-			version:  "1.2.3",
-			filename: "skywire-visor-1.2.3-linux-amd64",
-			want: "https://github.com/SkycoinProject/skywire-mainnet/releases/download/1.2.3/" +
-				"skywire-visor-1.2.3-linux-amd64",
+			version:  "v1.2.3",
+			filename: "skywire-visor-v1.2.3-linux-amd64",
+			want: "https://github.com/SkycoinProject/skywire-mainnet/releases/download/v1.2.3/" +
+				"skywire-visor-v1.2.3-linux-amd64",
 		},
 	}
 
@@ -177,10 +177,10 @@ func Test_binaryFilename(t *testing.T) {
 		{
 			name:    "Case 1",
 			file:    "skywire-visor",
-			version: "1.2.3",
+			version: "v1.2.3",
 			os:      "linux",
 			arch:    "amd64",
-			want:    "skywire-visor-1.2.3-linux-amd64.tar.gz",
+			want:    "skywire-visor-v1.2.3-linux-amd64.tar.gz",
 		},
 	}
 

--- a/pkg/util/updater/version.go
+++ b/pkg/util/updater/version.go
@@ -53,7 +53,7 @@ func (v *Version) Cmp(v2 *Version) int {
 
 // String converts Version to string.
 func (v *Version) String() string {
-	version := strconv.Itoa(v.Major) + "." + strconv.Itoa(v.Minor) + "." + strconv.Itoa(v.Patch)
+	version := "v" + strconv.Itoa(v.Major) + "." + strconv.Itoa(v.Minor) + "." + strconv.Itoa(v.Patch)
 	if v.Additional != "" {
 		version += "-" + v.Additional
 	}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #227.

 Changes:	
- Put apps in a separate directory
- Fix `updater` for `v` version prefix in releases

How to test this PR:
1. In `skywire-mainnet`'s `Makefile` replace `VERSION := $(shell git describe)` with `VERSION := 0.1.0`.
2. Run the generic integration environment.
3. In the `shell` pane, run `curl -k -X POST https://localhost:8080/api/visors/024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7/update` and wait until it finishes.
4. Check if output equals `{"updated":true}` and if an update in the `VisorA` pane finished successfully with no error.
5. After updating, run the previous command, the output should be `{"updated":false}`.
6. Run `make integration-startup-dmsg` to add transports and then `curl --data '{"recipient":"024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7", "message":"PING!"}' -X POST http://localhost:8001/message` to send a message via `skychat`. The message should appear in `VisorA`s logs.
7. Check if apps in archives in https://github.com/SkycoinProject/skywire-mainnet/releases/tag/v0.1.1 are located in `apps` subfolder.

NOTE: The https://github.com/SkycoinProject/skywire-mainnet/releases/tag/v0.1.1 release was created for testing this PR and should be deleted after merging it!