### PR TITLE
Add `--retain-keys` flag

### DIFF
--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -1,9 +1,12 @@
 package visor
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -26,6 +29,7 @@ func init() {
 var (
 	output        string
 	replace       bool
+	retainKeys    bool
 	configLocType = pathutil.WorkingDirLoc
 	testenv       bool
 )
@@ -33,6 +37,7 @@ var (
 func init() {
 	genConfigCmd.Flags().StringVarP(&output, "output", "o", "", "path of output config file. Uses default of 'type' flag if unspecified.")
 	genConfigCmd.Flags().BoolVarP(&replace, "replace", "r", false, "whether to allow rewrite of a file that already exists.")
+	genConfigCmd.Flags().BoolVar(&retainKeys, "retain-keys", false, "retain current keys")
 	genConfigCmd.Flags().VarP(&configLocType, "type", "m", fmt.Sprintf("config generation mode. Valid values: %v", pathutil.AllConfigLocationTypes()))
 	genConfigCmd.Flags().BoolVarP(&testenv, "testing-environment", "t", false, "whether to use production or test deployment service.")
 }
@@ -62,8 +67,30 @@ var genConfigCmd = &cobra.Command{
 		default:
 			logger.Fatalln("invalid config type:", configLocType)
 		}
+		if replace && retainKeys && pathutil.Exists(output) {
+			if err := fillInOldKeys(output, conf); err != nil {
+				logger.WithError(err).Fatalln("Error retaining old keys")
+			}
+		}
 		pathutil.WriteJSONConfig(conf, output, replace)
 	},
+}
+
+func fillInOldKeys(confPath string, conf *visor.Config) error {
+	oldConfBytes, err := ioutil.ReadFile(path.Clean(confPath))
+	if err != nil {
+		return fmt.Errorf("error reading old config file: %w", err)
+	}
+
+	var oldConf visor.Config
+	if err := json.Unmarshal(oldConfBytes, &oldConf); err != nil {
+		return fmt.Errorf("invalid old configuration file: %w", err)
+	}
+
+	conf.Visor.StaticPubKey = oldConf.Visor.StaticPubKey
+	conf.Visor.StaticSecKey = oldConf.Visor.StaticSecKey
+
+	return nil
 }
 
 func homeConfig() *visor.Config {

--- a/pkg/app/appcommon/config.go
+++ b/pkg/app/appcommon/config.go
@@ -1,5 +1,6 @@
 package appcommon
 
+// DefaultServerAddr is a default address to run the app server at.
 const DefaultServerAddr = "localhost:5505"
 
 // Config defines configuration parameters for `Proc`.

--- a/pkg/util/pathutil/configpath.go
+++ b/pkg/util/pathutil/configpath.go
@@ -142,6 +142,12 @@ func FindConfigPath(args []string, argsIndex int, env string, defaults ConfigPat
 	return ""
 }
 
+// Exists checks if file or directory specified with `path` exists.
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // WriteJSONConfig is used by config file generators.
 // 'output' specifies the path to save generated config files.
 // 'replace' is true if replacing files is allowed.
@@ -151,7 +157,7 @@ func WriteJSONConfig(conf interface{}, output string, replace bool) {
 		log.WithError(err).Fatal("unexpected error, report to dev")
 	}
 
-	if _, err := os.Stat(output); !replace && err == nil {
+	if !replace && Exists(output) {
 		log.Fatalf("file %s already exists, stopping as 'replace,r' flag is not set", output)
 	}
 


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #239 

 Changes:	
- `--retain-keys` flag was added to the `skywire-cli visor gen-config` command. Works only if `-r` flag is specified

How to test this PR:
Run `skywire-cli visor gen-config -r --retain-keys` with the already existing config file. Static visor keys should not change