### PR TITLE
Fix manager UI login for HTTP hypervisor's API

### DIFF
--- a/pkg/hypervisor/config.go
+++ b/pkg/hypervisor/config.go
@@ -157,7 +157,7 @@ type CookieConfig struct {
 func (c *CookieConfig) FillDefaults() {
 	c.ExpiresDuration = defaultCookieExpiration
 	c.Path = "/"
-	c.Secure = true
+	c.Secure = false
 	c.HTTPOnly = true
 	c.SameSite = http.SameSiteDefaultMode
 }


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #238 

 Changes:	
- Cookie's `secure` field is false by default now

How to test this PR:
Generate default hypervisor config, enable authentication and try to run it. Try to setup initial authentication and log in