### PR TITLE
Make the manager open the terminal with the same protocol

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/actions/actions.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/actions.component.ts
@@ -240,8 +240,9 @@ export class ActionsComponent implements AfterViewInit, OnDestroy {
     SelectOptionComponent.openDialog(this.dialog, options).afterClosed().subscribe((selectedOption: number) => {
       if (selectedOption === 1) {
         // Open the complete terminal in a new tab.
+        const protocol = window.location.protocol;
         const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8080');
-        window.open('https://' + hostname + '/pty/' + NodeComponent.getCurrentNodeKey(), '_blank', 'noopener noreferrer');
+        window.open(protocol + '//' + hostname + '/pty/' + NodeComponent.getCurrentNodeKey(), '_blank', 'noopener noreferrer');
       } else if (selectedOption === 2) {
         // Open the simple terminal in a modal window.
         BasicTerminalComponent.openDialog(this.dialog, {


### PR DESCRIPTION
Did you run `make format && make check`?
Go code was not changed.

 Changes:	
-	Now the manager opens the terminal using the same protocol in which the manager itself was openned (http or https).

How to test this PR:
Use the manager to open the full terminal.