### PR TITLE
Fix incorrectly renamed "Uptime" to "UptimeTracker"

### DIFF
--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -98,7 +98,7 @@ func (r *RPC) Health(_ *struct{}, out *HealthInfo) (err error) {
 
 // Uptime returns for how long the visor has been running in seconds
 func (r *RPC) Uptime(_ *struct{}, out *float64) (err error) {
-	defer rpcutil.LogCall(r.log, "UptimeTracker", nil)(out, &err)
+	defer rpcutil.LogCall(r.log, "Uptime", nil)(out, &err)
 
 	*out = time.Since(r.visor.startedAt).Seconds()
 	return nil

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -97,10 +97,10 @@ func (rc *rpcClient) Health() (*HealthInfo, error) {
 	return hi, err
 }
 
-// UptimeTracker calls UptimeTracker
+// Uptime calls Uptime
 func (rc *rpcClient) Uptime() (float64, error) {
 	var out float64
-	err := rc.Call("UptimeTracker", &struct{}{}, &out)
+	err := rc.Call("Uptime", &struct{}{}, &out)
 	return out, err
 }
 
@@ -410,7 +410,7 @@ func (mc *mockRPCClient) Health() (*HealthInfo, error) {
 	return hi, nil
 }
 
-// UptimeTracker implements RPCClient
+// Uptime implements RPCClient
 func (mc *mockRPCClient) Uptime() (float64, error) {
 	return time.Since(mc.startedAt).Seconds(), nil
 }


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes bug in https://github.com/SkycoinProject/skywire-mainnet/pull/246

How to test this PR:
- `make integration-run-proxy`