### PR TITLE
Fix dmsgpty in manager UI

### DIFF
--- a/pkg/hypervisor/config.go
+++ b/pkg/hypervisor/config.go
@@ -146,18 +146,32 @@ type CookieConfig struct {
 
 	ExpiresDuration time.Duration `json:"expires_duration"` // Used for determining the 'expires' value for cookies.
 
-	Path     string        `json:"path"`   // optional
-	Domain   string        `json:"domain"` // optional
-	Secure   bool          `json:"secure"`
-	HTTPOnly bool          `json:"http_only"`
-	SameSite http.SameSite `json:"same_site"`
+	Path   string `json:"path"`   // optional
+	Domain string `json:"domain"` // optional
+
+	TLS bool `json:"-"`
 }
 
 // FillDefaults fills config with default values.
 func (c *CookieConfig) FillDefaults() {
 	c.ExpiresDuration = defaultCookieExpiration
 	c.Path = "/"
-	c.Secure = false
-	c.HTTPOnly = true
-	c.SameSite = http.SameSiteDefaultMode
+
+	c.TLS = false
+}
+
+// Secure gets cookie's `Secure` value.
+func (c *CookieConfig) Secure() bool {
+	return c.TLS
+}
+
+// HTTPOnly gets cookie's `HTTPOnly` value.
+func (c *CookieConfig) HTTPOnly() bool {
+	return !c.TLS
+}
+
+// SameSite gets cookie's `SameSite` value.
+func (c *CookieConfig) SameSite() http.SameSite {
+	// using default value for now
+	return http.SameSiteDefaultMode
 }

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -61,6 +61,8 @@ type Hypervisor struct {
 
 // New creates a new Hypervisor.
 func New(config Config) (*Hypervisor, error) {
+	config.Cookies.TLS = config.EnableTLS
+
 	boltUserDB, err := NewBoltUserStore(config.DBPath)
 	if err != nil {
 		return nil, err

--- a/pkg/hypervisor/user_manager.go
+++ b/pkg/hypervisor/user_manager.go
@@ -299,9 +299,9 @@ func (s *UserManager) newSession(w http.ResponseWriter, session Session) error {
 		Value:    value,
 		Domain:   s.c.Domain,
 		Expires:  time.Now().Add(s.c.ExpiresDuration),
-		Secure:   s.c.Secure,
-		HttpOnly: s.c.HTTPOnly,
-		SameSite: s.c.SameSite,
+		Secure:   s.c.Secure(),
+		HttpOnly: s.c.HTTPOnly(),
+		SameSite: s.c.SameSite(),
 	})
 
 	return nil
@@ -326,9 +326,9 @@ func (s *UserManager) delSession(w http.ResponseWriter, r *http.Request) error {
 		Name:     sessionCookieName,
 		Domain:   s.c.Domain,
 		MaxAge:   -1,
-		Secure:   s.c.Secure,
-		HttpOnly: s.c.HTTPOnly,
-		SameSite: s.c.SameSite,
+		Secure:   s.c.Secure(),
+		HttpOnly: s.c.HTTPOnly(),
+		SameSite: s.c.SameSite(),
 	})
 
 	return nil


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #248 

 Changes:	
- Cookie config now doesn't contain `HTTPOnly`, `Secure` and `SameSite` fields. `SameSite` is not allowed to be changed for simplicity, `HTTPOnly` and `Secure` are calculated from the `EnableTLS` value of hypervisor's config