### PR TITLE
Make the session cookie work with the terminal

### DIFF
--- a/pkg/hypervisor/user_manager.go
+++ b/pkg/hypervisor/user_manager.go
@@ -297,6 +297,7 @@ func (s *UserManager) newSession(w http.ResponseWriter, session Session) error {
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    value,
+		Path:     s.c.Path,
 		Domain:   s.c.Domain,
 		Expires:  time.Now().Add(s.c.ExpiresDuration),
 		Secure:   s.c.Secure,
@@ -324,6 +325,7 @@ func (s *UserManager) delSession(w http.ResponseWriter, r *http.Request) error {
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
+		Path:     s.c.Path,
 		Domain:   s.c.Domain,
 		MaxAge:   -1,
 		Secure:   s.c.Secure,


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #248 

 Changes:	
- Now the `Path` param, set in the hypervisor configuration file, is added to the session cookie. This makes the web browser start sending the session cookie to the terminal window while using the default config, as previously web browsers were sending the cookie only to the `/api` paths (default browser behavior if the `Path` param is not set). This makes the terminal work with https connections while auth is activated.

How to test this PR:
Open the full terminal using the manager while auth and tls are active. See note below.