### PR TITLE
Avoid HTTP body for GET request in route finder

### DIFF
--- a/pkg/routefinder/rfclient/client.go
+++ b/pkg/routefinder/rfclient/client.go
@@ -81,7 +81,7 @@ func (c *apiClient) FindRoutes(ctx context.Context, rts []routing.PathEdges, opt
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, c.addr+"/routes", bytes.NewBuffer(marshaledBody))
+	req, err := http.NewRequest(http.MethodPost, c.addr+"/routes", bytes.NewBuffer(marshaledBody))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Part of https://github.com/SkycoinPro/skywire-services/pull/130

 Changes:	
- Use `POST` instead of `GET` HTTP method for `route-finder` request with HTTP body.
