### PR TITLE
Fix panic on migration of old key pair

### DIFF
--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -86,8 +86,7 @@ func fillInOldKeys(confPath string, conf *visor.Config) error {
 		return fmt.Errorf("invalid old configuration file: %w", err)
 	}
 
-	conf.KeyPair.PubKey = oldConf.KeyPair.PubKey
-	conf.KeyPair.SecKey = oldConf.KeyPair.SecKey
+	conf.KeyPair = oldConf.KeyPair
 
 	return nil
 }


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #266 

 Changes:	
- Fix panic on migration of old key pair

How to test this PR:
`skywire-cli visor gen-config -r --retain-keys`
