### PR TITLE
Show the visor version on the manager

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -19,7 +19,7 @@
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.node-version' | translate }}</span>
-      {{ node.node_version }}
+      {{ node.build_info.version }}
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.app-protocol-version' | translate }}</span>

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -53,7 +53,7 @@
         "label": "Label:",
         "public-key": "Public key:",
         "port": "Port:",
-        "node-version": "Node version:",
+        "node-version": "Visor version:",
         "app-protocol-version": "App protocol version:",
         "time": {
           "title": "Time online:",


### PR DESCRIPTION
Did you run `make format && make check`?
Go code was not changed.

Fixes #269 

 Changes:	
-	Now the manager shows "Visor version" instead of "Node version" and the correct value is displayed.

How to test this PR:
Check the node info column in the visor overview page of the manager.