### PR TITLE
Make the manager work with http while using the test server

### DIFF
--- a/static/skywire-manager-src/README.md
+++ b/static/skywire-manager-src/README.md
@@ -13,7 +13,7 @@ The Skywire Manager requires Node 10.9.0 or higher, together with NPM 6.0.0 or h
 Dependencies needed for this app are managed with NPM and are not included in the repository, so you must run the `npm install`
 command on this folder before being able to tun the app.
 
-Also, as the app needs a HTTPS connection to work, you may want to create a SSL certificate for the dev server. This step is
+Also, if you are going to use an HTTPS connection, you may want to create a SSL certificate for the dev server. This step is
 optional, as the dev server can create its own certificate, but there are 2 reasons for manually creating one: to avoid a bug
 in the dev server that sometimes makes it to reload the app when it shouild not
 (https://github.com/angular/angular-cli/issues/5826) and to have more freedom managing the trusted certificates. For creating
@@ -21,24 +21,20 @@ a custom certificate, follow the steps in the [ssl folder](./ssl/README.md)
 
 ## Hypervisor configuration
 
-For the app to work, the Hypervisor instance must be running with authentication disabled or with a password set for the
-"admin" account. For running the hypervisor instance without authentication, start it with the `enable_auth` configuration
-value set to `false` in the Hypervisor configuration file or using the `-m` flag. For setting a password for the "admin"
-account, use the `/create-account` API endpoint.
-
-Also, the Hypervisor instance must be running in `http://localhost:8080`. If it is running in another URL, you can change it in
+The Hypervisor instance must be running in `http://127.0.0.1:8080`. If it is running in another URL, you can change it in
 [proxy.config.json](proxy.config.json) before running the app.
 
 ## Running the app
 
-Run `npm run start` to start a dev server. If you followed the steps indicated in the [ssl folder](./ssl/README.md), the server
-will use your custom SSL certificate. If not, the server will use an automatically created one. Alternatively, if you don't
-want to use a https connection you can start the dev server by running `npm run start-no-ssl`, but the manager will not work
-unless the hypervisor instance has the autentication options deactivated.
+If the hypervisor instance is running with TLS active (check the hypervisor configuration file) Run `npm run start` to start a
+dev server. If you followed the steps indicated in the [ssl folder](./ssl/README.md), the server will use your custom SSL
+certificate. If not, the server will use an automatically created one. Alternatively, If the hypervisor instance is running
+without TLS, you can start the dev server by running `npm run start-no-ssl`.
 
-After the server is started, you can access the app by navigating to `http://localhost:4200` with a web browser (note
-that you could get a security warning if the SSL certificate is not in the trusted certificates list). The app will
-automatically reload if you change any of the source files.
+After starting the server with `npm run start`, you can access the app by navigating to `https://localhost:4200` with a web
+browser (note that you could get a security warning if the SSL certificate is not in the trusted certificates list). Yo can use
+`https://localhost:4200` if you started the dev server with `npm run start-no-ssl`. The app will be automatically reloaded if you
+change any of the source files.
 
 ## Build
 

--- a/static/skywire-manager-src/proxy.config.json
+++ b/static/skywire-manager-src/proxy.config.json
@@ -1,7 +1,15 @@
 {
   "/api": {
-    "target": "https://192.168.0.108:8080",
+    "target": "https://127.0.0.1:8080",
     "secure": false,
     "changeOrigin": true
+  },
+  "/http-api": {
+    "target": "http://127.0.0.1:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/http-api" : "/api"
+    }
   }
 }

--- a/static/skywire-manager-src/src/app/services/api.service.ts
+++ b/static/skywire-manager-src/src/app/services/api.service.ts
@@ -5,6 +5,7 @@ import { catchError, map } from 'rxjs/operators';
 import { Router } from '@angular/router';
 
 import { processServiceError } from '../utils/errors';
+import { environment } from 'src/environments/environment';
 
 export enum ResponseTypes {
   Json = 'json',
@@ -32,6 +33,14 @@ export class RequestOptions {
   providedIn: 'root'
 })
 export class ApiService {
+  /**
+   * URL prefix for the API routes. The 'http-api/' prefix is used if the app is running
+   * with the dev server using the http protocol, because the dev server proxy uses it to
+   * route the request to the appropiate url.
+   */
+  private readonly apiPrefix = !environment.production && location.protocol.indexOf('http:') !== -1 ?
+    'http-api/' : 'api/';
+
   constructor(
     private http: HttpClient,
     private router: Router,
@@ -77,7 +86,7 @@ export class ApiService {
     body = body ? body : {};
     options = options ? options : new RequestOptions();
 
-    return this.http.request(method, `api/${url}`, {
+    return this.http.request(method, this.apiPrefix + url, {
       ...this.getRequestOptions(options),
       responseType: options.responseType,
       // Use the session cookies.


### PR DESCRIPTION
Did you run `make format && make check`?
Go code was not changed.

 Changes:	
- The `npm run start-no-ssl` starts the dev server for checking the manager, but while using it the manager was not able to connect to the hypervisor instance, no mater if the hypervisor was running with or without tls. Now it is possible to use that command to open the manager and connect it to a hypervisor instance which is running without tls. It is still possible to use `npm start` to run the test server and connect the manager to a hypervisor instance which is running with tls.

- The proxy configuration of the test server was changed to make the manager connect to a hypervisor instance running on `127.0.0.1:8080`.

- The documentation was updated.

How to test this PR:
Instruction on the readme file