### PR TITLE
Fix a problem while navigating with the manager

### DIFF
--- a/static/skywire-manager-src/src/app/services/auth-guard.service.ts
+++ b/static/skywire-manager-src/src/app/services/auth-guard.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, CanActivateChild } from '@angular/router';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 
 import { AuthService, AuthStates } from './auth.service';
@@ -28,7 +28,9 @@ export class AuthGuardService implements CanActivate, CanActivateChild {
   }
 
   private checkIfCanActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
-    return this.authService.checkLogin().pipe(map((authState: AuthStates) => {
+    return this.authService.checkLogin().pipe(catchError(() => {
+      return of(AuthStates.AuthDisabled);
+    }), map((authState: AuthStates) => {
       // If the user is trying to access "Login" page while he is already logged in or the
       // auth is disabled, redirect him to "Nodes" page
       if (route.routeConfig.path === 'login' && (authState === AuthStates.Logged || authState === AuthStates.AuthDisabled)) {

--- a/static/skywire-manager-src/src/app/services/auth.service.ts
+++ b/static/skywire-manager-src/src/app/services/auth.service.ts
@@ -57,6 +57,8 @@ export class AuthService {
           if (err.originalError && (err.originalError as HttpErrorResponse).status === 401) {
             return of(AuthStates.NotLogged);
           }
+
+          return throwError(err);
         })
       );
   }


### PR DESCRIPTION
Did you run `make format && make check`?
Go code was not changed.

 Changes:	
-	If the hypervisor is not accessible and the user tries to navigate in the manager, there is a bug that makes the manager appear to be not responsive. This pr fixes that bug.

How to test this PR:
Navigate to a another page in the manager while the hypervisor is not accessible. It should navigate and there should be an error while trying to get the data.