### PR TITLE
Update the Spanish translation of the manager

### DIFF
--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -53,7 +53,7 @@
         "label": "Etiqueta:",
         "public-key": "Llave pública:",
         "port": "Puerto:",
-        "node-version": "Versión del nodo:",
+        "node-version": "Versión del visor:",
         "app-protocol-version": "Versión del protocolo de app:",
         "time": {
           "title": "Tiempo online:",
@@ -256,9 +256,33 @@
       "autostart-disabled": "Autoinicio deshabilitado",
       "autostart-enabled": "Autoinicio habilitado"
     },
+    "skysocks-settings": {
+      "title": "Configuración de Skysocks",
+      "new-password": "Nueva contraseña (dejar en blanco para eliminar la contraseña)",
+      "repeat-password": "Repita la contraseña",
+      "passwords-not-match": "Las contraseñas no coinciden.",
+      "save": "Guardar",
+      "remove-passowrd-confirmation": "Ha dejado el campo de contraseña vacío. ¿Seguro que desea eliminar la contraseña?",
+      "change-passowrd-confirmation": "¿Seguro que desea cambiar la contraseña?",
+      "changes-made": "Los cambios han sido realizados."
+    },
+    "skysocks-client-settings": {
+      "title": "Configuración de Skysocks-Client",
+      "remote-visor-tab": "Visor Remoto",
+      "history-tab": "Historial",
+      "public-key": "Llave pública del visor remoto",
+      "remote-key-length-error": "La llave pública debe tener 66 caracteres.",
+      "remote-key-chars-error": "La llave pública sólo debe contener caracteres hexadecimales.",
+      "save": "Guardar",
+      "change-key-confirmation": "¿Seguro que desea cambiar la llave pública del visor remoto?",
+      "changes-made": "Los cambios han sido realizados.",
+      "no-history": "Esta pestaña mostrará las últimas {{ number }} llaves públicas usadas."
+    },
     "stop-app": "Detener",
     "start-app": "Iniciar",
     "view-logs": "Ver logs",
+    "settings": "Configuración",
+    "error": "Se produjo un error y no fue posible realizar la operación.",
     "stop-confirmation": "¿Seguro que desea detener la aplicación?",
     "stop-selected-confirmation": "¿Seguro que desea detener las aplicaciones seleccionadas?",
     "disable-autostart-confirmation": "¿Seguro que desea deshabilitar el autoinicio de la aplicación?",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -53,7 +53,7 @@
         "label": "Label:",
         "public-key": "Public key:",
         "port": "Port:",
-        "node-version": "Node version:",
+        "node-version": "Visor version:",
         "app-protocol-version": "App protocol version:",
         "time": {
           "title": "Time online:",
@@ -256,9 +256,33 @@
       "autostart-disabled": "Autostart disabled",
       "autostart-enabled": "Autostart enabled"
     },
+    "skysocks-settings": {
+      "title": "Skysocks Settings",
+      "new-password": "New password (Leave empty to remove the password)",
+      "repeat-password": "Repeat password",
+      "passwords-not-match": "Passwords do not match.",
+      "save": "Save",
+      "remove-passowrd-confirmation": "You left the password field empty. Are you sure you want to remove the password?",
+      "change-passowrd-confirmation": "Are you sure you want to change the password?",
+      "changes-made": "The changes have been made."
+    },
+    "skysocks-client-settings": {
+      "title": "Skysocks-Client Settings",
+      "remote-visor-tab": "Remote Visor",
+      "history-tab": "History",
+      "public-key": "Remote visor public key",
+      "remote-key-length-error": "The public key must be 66 characters long.",
+      "remote-key-chars-error": "The public key must only contain hexadecimal characters.",
+      "save": "Save",
+      "change-key-confirmation": "Are you sure you want to change the remote visor public key?",
+      "changes-made": "The changes have been made.",
+      "no-history": "This tab will show the last {{ number }} public keys used."
+    },
     "stop-app": "Stop",
     "start-app": "Start",
     "view-logs": "View logs",
+    "settings": "Settings",
+    "error": "An error has occured and it was not possible to perform the operation.",
     "stop-confirmation": "Are you sure you want to stop the app?",
     "stop-selected-confirmation": "Are you sure you want to stop the selected apps?",
     "disable-autostart-confirmation": "Are you sure you want to disable autostart for the app?",


### PR DESCRIPTION
Did you run `make format && make check`?
Go code was not changed.

 Changes:	
- The Spanish translation of the manager was updated, to include the changes made in the recently merger PRs.

How to test this PR:
Run the `node check.js es` command while on the `static/skywire-manager-src/src/assets/i18n` directory.