### PR TITLE
Fix setup node PKs

### DIFF
--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -143,6 +143,7 @@ func defaultConfig() *visor.Config {
 		conf.Dmsg.Discovery = skyenv.TestDmsgDiscAddr
 		conf.Transport.Discovery = skyenv.TestTpDiscAddr
 		conf.Routing.RouteFinder = skyenv.TestRouteFinderAddr
+		conf.Routing.SetupNodes = []cipher.PubKey{skyenv.MustPK(skyenv.TestSetupPK)}
 	}
 
 	conf.Hypervisors = []visor.HypervisorConfig{}

--- a/internal/skyenv/values.go
+++ b/internal/skyenv/values.go
@@ -10,24 +10,15 @@ const (
 	DefaultDmsgDiscAddr      = "http://dmsg.discovery.skywire.skycoin.com"
 	DefaultRouteFinderAddr   = "http://routefinder.skywire.skycoin.com"
 	DefaultUptimeTrackerAddr = "http://uptime-tracker.skywire.skycoin.com"
-	DefaultSetupPK           = "026c5a07de617c5c488195b76e8671bf9e7ee654d0633933e202af9e111ffa358d"
+	DefaultSetupPK           = "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
 )
-
-// MustDefaultSetupPK returns DefaultSetupPK as cipher.PubKey. It panics if unmarshaling fails.
-func MustDefaultSetupPK() cipher.PubKey {
-	var sPK cipher.PubKey
-	if err := sPK.UnmarshalText([]byte(DefaultSetupPK)); err != nil {
-		panic(err)
-	}
-
-	return sPK
-}
 
 // Constants for testing deployment.
 const (
 	TestTpDiscAddr      = "http://transport.discovery.skywire.cc"
 	TestDmsgDiscAddr    = "http://dmsg.discovery.skywire.cc"
 	TestRouteFinderAddr = "http://routefinder.skywire.cc"
+	TestSetupPK         = "026c5a07de617c5c488195b76e8671bf9e7ee654d0633933e202af9e111ffa358d"
 )
 
 // Dmsg port constants.
@@ -59,3 +50,13 @@ const (
 	SkysocksClientPort = uint16(13)
 	SkysocksClientAddr = ":1080"
 )
+
+// MustPK unmarshals string PK to cipher.PubKey. It panics if unmarshaling fails.
+func MustPK(pk string) cipher.PubKey {
+	var sPK cipher.PubKey
+	if err := sPK.UnmarshalText([]byte(pk)); err != nil {
+		panic(err)
+	}
+
+	return sPK
+}

--- a/pkg/visor/config.go
+++ b/pkg/visor/config.go
@@ -440,7 +440,7 @@ func DefaultLogStoreConfig() *LogStoreConfig {
 
 // RoutingConfig configures routing.
 type RoutingConfig struct {
-	SetupNodes         []cipher.PubKey `json:"setup_nodes"`
+	SetupNodes         []cipher.PubKey `json:"setup_nodes,omitempty"`
 	RouteFinder        string          `json:"route_finder"`
 	RouteFinderTimeout Duration        `json:"route_finder_timeout,omitempty"`
 }
@@ -448,7 +448,7 @@ type RoutingConfig struct {
 // DefaultRoutingConfig returns default routing config.
 func DefaultRoutingConfig() *RoutingConfig {
 	return &RoutingConfig{
-		SetupNodes:         []cipher.PubKey{skyenv.MustDefaultSetupPK()},
+		SetupNodes:         []cipher.PubKey{skyenv.MustPK(skyenv.DefaultSetupPK)},
 		RouteFinder:        skyenv.DefaultRouteFinderAddr,
 		RouteFinderTimeout: DefaultTimeout,
 	}
@@ -477,7 +477,7 @@ type AppConfig struct {
 	App       string       `json:"app"`
 	AutoStart bool         `json:"auto_start"`
 	Port      routing.Port `json:"port"`
-	Args      []string     `json:"args"`
+	Args      []string     `json:"args,omitempty"`
 }
 
 // InterfaceConfig defines listening interfaces for skywire visor.


### PR DESCRIPTION
Did you run `make format && make check`? Yes

 Changes:	
- Fix default setup node PK
- Generate test setup node PK it `-t` is passed to `gen-config`

How to test this PR:
- `make build`
- `./skywire-cli visor gen-config -o ./skywire-config.json -r`
- `./skywire-cli visor gen-config -o ./skywire-config.json -r -t`