### PR TITLE
Add hypervisor to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,22 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/skywire-cli/
     ldflags: -s -w -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.version={{.Version}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.commit={{.ShortCommit}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.date={{.Date}}
+  - id: hypervisor
+    binary: hypervisor
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - 386
+      - arm64
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/hypervisor/
+    ldflags: -s -w -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.version={{.Version}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.commit={{.ShortCommit}} -X github.com/SkycoinProject/skywire-mainnet/pkg/util/buildinfo.date={{.Date}}
   - id: skychat
     binary: apps/skychat
     goos:

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,6 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
-go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
-go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #284

 Changes:	
- Add hypervisor binary to the list of released files

How to test this PR:
- `git tag -a v0.1.2 -m "v0.1.2"`
- `goreleaser --skip-publish --rm-dist`
- `git tag -d v0.1.2`