### PR TITLE
Change json.NewDecoder to json.Unmarshal in binaries

### DIFF
--- a/cmd/setup-node/commands/root.go
+++ b/cmd/setup-node/commands/root.go
@@ -73,7 +73,7 @@ var rootCmd = &cobra.Command{
 			logger.WithField("raw", string(raw)).Fatalf("Failed to decode config: %s", err)
 		}
 
-		logger.Infof("Config: %+v", conf)
+		logger.Infof("Config: %#v", conf)
 
 		sn, err := setup.NewNode(conf, metrics.NewPrometheus("setupnode"))
 		if err != nil {

--- a/cmd/setup-node/commands/root.go
+++ b/cmd/setup-node/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"log"
 	"log/syslog"
 	"net/http"
@@ -62,9 +63,17 @@ var rootCmd = &cobra.Command{
 		}
 
 		conf := &setup.Config{}
-		if err := json.NewDecoder(rdr).Decode(&conf); err != nil {
-			log.Fatalf("Failed to decode %s: %s", rdr, err)
+
+		raw, err := ioutil.ReadAll(rdr)
+		if err != nil {
+			logger.Fatalf("Failed to read config: %v", err)
 		}
+
+		if err := json.Unmarshal(raw, &conf); err != nil {
+			logger.WithField("raw", string(raw)).Fatalf("Failed to decode config: %s", err)
+		}
+
+		logger.Infof("Config: %+v", conf)
 
 		sn, err := setup.NewNode(conf, metrics.NewPrometheus("setupnode"))
 		if err != nil {

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -171,9 +171,16 @@ func (cfg *runCfg) readConfig() *runCfg {
 		rdr = bufio.NewReader(os.Stdin)
 	}
 
-	if err := json.NewDecoder(rdr).Decode(&cfg.conf); err != nil {
-		cfg.logger.Fatalf("Failed to decode %s: %s", rdr, err)
+	raw, err := ioutil.ReadAll(rdr)
+	if err != nil {
+		cfg.logger.Fatalf("Failed to read config: %v", err)
 	}
+
+	if err := json.Unmarshal(raw, &cfg.conf); err != nil {
+		cfg.logger.WithField("raw", string(raw)).Fatalf("Failed to decode config: %s", err)
+	}
+
+	cfg.logger.Infof("Config: %+v", &cfg.conf)
 
 	cfg.conf.Path = configPath
 

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -180,7 +180,7 @@ func (cfg *runCfg) readConfig() *runCfg {
 		cfg.logger.WithField("raw", string(raw)).Fatalf("Failed to decode config: %s", err)
 	}
 
-	cfg.logger.Infof("Config: %+v", &cfg.conf)
+	cfg.logger.Infof("Config: %#v", &cfg.conf)
 
 	cfg.conf.Path = configPath
 

--- a/pkg/visor/config.go
+++ b/pkg/visor/config.go
@@ -85,7 +85,7 @@ func (c *Config) flush() error {
 		return ErrNoConfigPath
 	}
 
-	c.log.Infof("Updating visor config to %+v", c)
+	c.log.Infof("Updating visor config to %#v", c)
 
 	bytes, err := json.MarshalIndent(c, "", "\t")
 	if err != nil {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Changes:	
- Change `json.NewDecoder` to `json.Unmarshal` in binaries to avoid `EOF` errors
- Add extra logs

How to test this PR:
- Run integration env
