### PR TITLE
Sanitize the URLs used by the manager

### DIFF
--- a/static/skywire-manager-src/src/app/services/api.service.ts
+++ b/static/skywire-manager-src/src/app/services/api.service.ts
@@ -86,6 +86,11 @@ export class ApiService {
     body = body ? body : {};
     options = options ? options : new RequestOptions();
 
+    // Sanitize the URL.
+    if (url.startsWith('/')) {
+      url = url.substr(1, url.length - 1);
+    }
+
     return this.http.request(method, this.apiPrefix + url, {
       ...this.getRequestOptions(options),
       responseType: options.responseType,


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Code was added to avoid the manager to try to use URLs with two `/` characters in the path. Example, if `http://first/second//third` is detected, the code calls `http://first/second/third`.

How to test this PR:
The URL used to connect to the `exec` endpoint in the simple terminal now should work well.