### PR TITLE
Improvements for the snackbar

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/snack-bar/snack-bar.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/snack-bar/snack-bar.component.scss
@@ -29,6 +29,7 @@
   margin-right: 10px;
   font-size: $font-size-base;
   margin-top: 2px;
+  word-break: break-word;
 
   .second-line {
     font-size: $font-size-smaller;

--- a/static/skywire-manager-src/src/styles.scss
+++ b/static/skywire-manager-src/src/styles.scss
@@ -78,3 +78,6 @@ button:focus {
   flex: 1;
 }
 
+.mat-snack-bar-container {
+  max-width: 90vw !important;
+}


### PR DESCRIPTION
Did you run `make format && make check`?
Only scss styles were changed.

 Changes:	
- In some cases the snackbars was having problems for showing long texts:
![msg1](https://user-images.githubusercontent.com/34079003/80317363-60319c00-87d1-11ea-9526-20c2a51f1c4e.png)
Now the snakck bar can be longer, to accommodate the text:
![msg2](https://user-images.githubusercontent.com/34079003/80317369-658ee680-87d1-11ea-9b16-86d47b96743a.png)
Also, if even after that change the texts is still too long, the snackbar cuts it in multiple lines as it should.

How to test this PR:
Not sure about how to reproduce the original error, which was in an image shared on Telegram. However, the snackbar should now be longer in most cases.