### PR TITLE
Fix hypervisor disconnection issue.

### DIFF
--- a/cmd/skywire-cli/commands/visor/root.go
+++ b/cmd/skywire-cli/commands/visor/root.go
@@ -2,8 +2,9 @@ package visor
 
 import (
 	"net"
-	"net/rpc"
 	"time"
+
+	"github.com/SkycoinProject/skywire-mainnet/pkg/skyenv"
 
 	"github.com/SkycoinProject/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func rpcClient() visor.RPCClient {
 	if err := conn.SetDeadline(time.Now().Add(rpcConnDuration)); err != nil {
 		logger.Fatal("RPC connection failed:", err)
 	}
-	return visor.NewRPCClient(rpc.NewClient(conn), visor.RPCPrefix)
+	return visor.NewRPCClient(logger, conn, visor.RPCPrefix, skyenv.DefaultRPCTimeout)
 }
 
 const (

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"net/rpc"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,9 +88,10 @@ func (hv *Hypervisor) ServeRPC(dmsgC *dmsg.Client, lis *dmsg.Listener) error {
 		}
 		addr := conn.RawRemoteAddr()
 		ptyDialer := dmsgpty.DmsgUIDialer(dmsgC, dmsg.Addr{PK: addr.PK, Port: skyenv.DmsgPtyPort})
+		log := logging.MustGetLogger(fmt.Sprintf("rpc_client:%s", addr.PK))
 		visorConn := VisorConn{
 			Addr:  addr,
-			RPC:   visor.NewRPCClient(rpc.NewClient(conn), visor.RPCPrefix),
+			RPC:   visor.NewRPCClient(log, conn, visor.RPCPrefix, skyenv.DefaultRPCTimeout),
 			PtyUI: dmsgpty.NewUI(ptyDialer, dmsgpty.DefaultUIConfig()),
 		}
 		log.WithField("remote_addr", addr).Info("Accepted.")

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -1,6 +1,8 @@
 package skyenv
 
 import (
+	"time"
+
 	"github.com/SkycoinProject/dmsg/cipher"
 )
 
@@ -49,6 +51,11 @@ const (
 	SkysocksClientName = "skysocks-client"
 	SkysocksClientPort = uint16(13)
 	SkysocksClientAddr = ":1080"
+)
+
+// RPC constants.
+const (
+	DefaultRPCTimeout = time.Second * 5
 )
 
 // MustPK unmarshals string PK to cipher.PubKey. It panics if unmarshaling fails.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -11,11 +11,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/SkycoinProject/dmsg/cipher"
 	"github.com/SkycoinProject/skycoin/src/util/logging"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/skywire-mainnet/pkg/app"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/router"

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -4,11 +4,14 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/rpc"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/dmsg/cipher"
 	"github.com/SkycoinProject/skycoin/src/util/logging"
@@ -27,6 +30,9 @@ var (
 	// ErrAlreadyServing is returned when an operation fails due to an operation
 	// that is currently running.
 	ErrAlreadyServing = errors.New("already serving")
+
+	// ErrTimeout represents a timed-out call.
+	ErrTimeout = errors.New("rpc client timeout")
 )
 
 // RPCClient represents a RPC Client implementation.
@@ -69,18 +75,42 @@ type RPCClient interface {
 // RPCClient provides methods to call an RPC Server.
 // It implements RPCClient
 type rpcClient struct {
-	client *rpc.Client
-	prefix string
+	log     logrus.FieldLogger
+	timeout time.Duration
+	conn    io.ReadWriteCloser
+	client  *rpc.Client
+	prefix  string
 }
 
 // NewRPCClient creates a new RPCClient.
-func NewRPCClient(rc *rpc.Client, prefix string) RPCClient {
-	return &rpcClient{client: rc, prefix: prefix}
+func NewRPCClient(log logrus.FieldLogger, conn io.ReadWriteCloser, prefix string, timeout time.Duration) RPCClient {
+	if log == nil {
+		log = logging.MustGetLogger("visor_rpc_client")
+	}
+	return &rpcClient{
+		log:     log,
+		timeout: timeout,
+		conn:    conn,
+		client:  rpc.NewClient(conn),
+		prefix:  prefix,
+	}
 }
 
 // Call calls the internal rpc.Client with the serviceMethod arg prefixed.
 func (rc *rpcClient) Call(method string, args, reply interface{}) error {
-	return rc.client.Call(rc.prefix+"."+method, args, reply)
+	timer := time.NewTimer(rc.timeout)
+	defer timer.Stop()
+
+	call := rc.client.Go(method, args, reply, nil)
+	select {
+	case <-call.Done:
+		return call.Error
+	case <-timer.C:
+		if err := rc.conn.Close(); err != nil {
+			rc.log.WithError(err).Warn("failed to close underlying rpc connection after timeout error")
+		}
+		return ErrTimeout
+	}
 }
 
 // Summary calls Summary.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -101,9 +101,8 @@ func (rc *rpcClient) Call(method string, args, reply interface{}) error {
 	timer := time.NewTimer(rc.timeout)
 	defer timer.Stop()
 
-	call := rc.client.Go(method, args, reply, nil)
 	select {
-	case <-call.Done:
+	case call := <-rc.client.Go(rc.prefix+"."+method, args, reply, nil).Done:
 		return call.Error
 	case <-timer.C:
 		if err := rc.conn.Close(); err != nil {

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -3,6 +3,7 @@ package visor
 import (
 	"context"
 	"net/rpc"
+	"time"
 
 	"github.com/SkycoinProject/dmsg"
 	"github.com/SkycoinProject/dmsg/netutil"
@@ -22,9 +23,13 @@ func isDone(ctx context.Context) bool {
 
 // ServeRPCClient repetitively dials to a remote dmsg address and serves a RPC server to that address.
 func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, n *snet.Network, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
+
+	const MaxBackoff = time.Second * 5
+	retry := netutil.NewRetrier(log, netutil.DefaultInitBackoff, MaxBackoff, netutil.DefaultTries, netutil.DefaultFactor)
+
 	for {
 		var conn *snet.Conn
-		err := netutil.NewDefaultRetrier(log).Do(ctx, func() (rErr error) {
+		err := retry.Do(ctx, func() (rErr error) {
 			log.Info("Dialing...")
 			conn, rErr = n.Dial(ctx, snet.DmsgType, rAddr.PK, rAddr.Port)
 			return rErr
@@ -38,8 +43,8 @@ func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, n *snet.Network
 			return
 		}
 		if conn == nil {
-			log.WithField("conn == nil", conn == nil).
-				Fatal("An unexpected occurrence happened.")
+			log.WithField("conn == nil", conn == nil).Warn("An unexpected occurrence happened.")
+			continue
 		}
 
 		log.Info("Serving RPC client...")

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -24,8 +24,8 @@ func isDone(ctx context.Context) bool {
 // ServeRPCClient repetitively dials to a remote dmsg address and serves a RPC server to that address.
 func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, n *snet.Network, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
 
-	const MaxBackoff = time.Second * 5
-	retry := netutil.NewRetrier(log, netutil.DefaultInitBackoff, MaxBackoff, netutil.DefaultTries, netutil.DefaultFactor)
+	const maxBackoff = time.Second * 5
+	retry := netutil.NewRetrier(log, netutil.DefaultInitBackoff, maxBackoff, netutil.DefaultTries, netutil.DefaultFactor)
 
 	for {
 		var conn *snet.Conn


### PR DESCRIPTION
Fixes #346

 Changes:	
-	 Added a timeout to `visor.RPCClient` in which it closes the underlying connection.

To do:
- [x] Test this.