### PR TITLE
Fix a problem with the app names in the manager

### DIFF
--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -89,7 +89,7 @@ export class NodeService {
         // Needed for a change made to the names on the backend.
         if (node.apps) {
           node.apps.forEach(app => {
-            app.name = (app as any).app;
+            app.name = (app as any).name ? (app as any).name : (app as any).app;
             app.autostart = (app as any).auto_start;
           });
         }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
-	As the property in which the Hypervisor API returns the app names was changed, this PR makes the Manager UI use the new property.

How to test this PR:
Check the UI with the lastest backends from the develop branch.