### PR TITLE
Allow to update all visors

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -347,8 +347,10 @@ export class NodeListComponent implements OnInit, OnDestroy {
       this.updateSubscription.unsubscribe();
     }
 
+    const nodesToCheck = this.dataSource.filter(node => node.online).map(node => node.local_pk);
+
     // Check if there are updates available.
-    this.updateSubscription = forkJoin(this.dataSource.map(node => this.nodeService.checkUpdate(node.local_pk))).subscribe(response => {
+    this.updateSubscription = forkJoin(nodesToCheck.map(pk => this.nodeService.checkUpdate(pk))).subscribe(response => {
       // Check how many visors have to be updated.
       let visorsWithUpdate = 0;
       let currentVersion = '';
@@ -367,7 +369,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
         }
       });
 
-      if (visorsWithUpdate > 1) {
+      if (visorsWithUpdate > 0) {
         // Text for asking for confirmation before updating.
         let newText: string;
         if (!differentCurrentVersions) {

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnDestroy, OnInit, NgZone } from '@angular/core';
-import { Subscription, of, timer } from 'rxjs';
-import { MatDialog } from '@angular/material/dialog';
+import { Subscription, of, timer, forkJoin, Observable } from 'rxjs';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { delay, flatMap, tap } from 'rxjs/operators';
+import { delay, flatMap, tap, catchError, mergeMap } from 'rxjs/operators';
+import { TranslateService } from '@ngx-translate/core';
 
 import { NodeService } from '../../../services/node.service';
 import { Node } from '../../../app.datatypes';
@@ -17,6 +18,9 @@ import GeneralUtils from 'src/app/utils/generalUtils';
 import { SelectOptionComponent, SelectableOption } from '../../layout/select-option/select-option.component';
 import { processServiceError } from 'src/app/utils/errors';
 import { ClipboardService } from 'src/app/services/clipboard.service';
+import { ConfirmationData, ConfirmationComponent } from '../../layout/confirmation/confirmation.component';
+import { AppConfig } from 'src/app/app.config';
+import { OperationError } from 'src/app/utils/operation-error';
 
 /**
  * List of the columns that can be used to sort the data.
@@ -56,6 +60,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
   private dataSubscription: Subscription;
   private updateTimeSubscription: Subscription;
   private menuSubscription: Subscription;
+  private updateSubscription: Subscription;
 
   // Vars for keeping track of the data updating.
   secondsSinceLastUpdate = 0;
@@ -72,7 +77,8 @@ export class NodeListComponent implements OnInit, OnDestroy {
     private ngZone: NgZone,
     private snackbarService: SnackbarService,
     private sidenavService: SidenavService,
-    private clipboardService: ClipboardService
+    private clipboardService: ClipboardService,
+    private translateService: TranslateService,
   ) {
     // Data for populating the tab bar.
     this.tabsData = [
@@ -105,6 +111,11 @@ export class NodeListComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       this.menuSubscription = this.sidenavService.setContents([
         {
+          name: 'nodes.update-all',
+          actionName: 'update',
+          icon: 'get_app'
+        },
+        {
           name: 'common.logout',
           actionName: 'logout',
           icon: 'power_settings_new'
@@ -112,6 +123,8 @@ export class NodeListComponent implements OnInit, OnDestroy {
           // React to the events of the left options bar.
           if (actionName === 'logout') {
             this.logout();
+          } else if (actionName === 'update') {
+            this.updateAll();
           }
         }
       );
@@ -124,6 +137,9 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
     if (this.menuSubscription) {
       this.menuSubscription.unsubscribe();
+    }
+    if (this.updateSubscription) {
+      this.updateSubscription.unsubscribe();
     }
   }
 
@@ -300,6 +316,157 @@ export class NodeListComponent implements OnInit, OnDestroy {
       () => this.router.navigate(['login']),
       () => this.snackbarService.showError('common.logout-error')
     );
+  }
+
+  // Updates all visors.
+  updateAll() {
+    if (!this.dataSource || this.dataSource.length === 0) {
+      this.snackbarService.showError('nodes.update.no-visors');
+
+      return;
+    }
+
+    // Configuration for the confirmation modal window used as the main UI element for the
+    // updating process.
+    const confirmationData: ConfirmationData = {
+      text: 'nodes.update.processing',
+      headerText: 'nodes.update.title',
+      confirmButtonText: 'nodes.update.processing-button',
+      disableDismiss: true,
+    };
+
+    // Show the confirmation window in a "loading" state while checking if there are updates.
+    const config = new MatDialogConfig();
+    config.data = confirmationData;
+    config.autoFocus = false;
+    config.width = AppConfig.smallModalWidth;
+    const confirmationDialog = this.dialog.open(ConfirmationComponent, config);
+    setTimeout(() => confirmationDialog.componentInstance.showProcessing());
+
+    if (this.updateSubscription) {
+      this.updateSubscription.unsubscribe();
+    }
+
+    // Check if there are updates available.
+    this.updateSubscription = forkJoin(this.dataSource.map(node => this.nodeService.checkUpdate(node.local_pk))).subscribe(response => {
+      // Check how many visors have to be updated.
+      let visorsWithUpdate = 0;
+      let currentVersion = '';
+      let differentCurrentVersions = false;
+      let newVersion = '';
+      response.forEach(updateInfo => {
+        if (updateInfo && updateInfo.available) {
+          visorsWithUpdate += 1;
+
+          if (currentVersion && currentVersion !== updateInfo.current_version) {
+            differentCurrentVersions = true;
+          }
+
+          currentVersion = updateInfo.current_version;
+          newVersion = updateInfo.available_version;
+        }
+      });
+
+      if (visorsWithUpdate > 1) {
+        // Text for asking for confirmation before updating.
+        let newText: string;
+        if (!differentCurrentVersions) {
+          newText = this.translateService.instant('nodes.update.update-available',
+            { number: visorsWithUpdate, currentVersion: currentVersion, newVersion: newVersion }
+          );
+        } else {
+          newText = this.translateService.instant('nodes.update.update-available-different',
+            { number: visorsWithUpdate, newVersion: newVersion }
+          );
+        }
+
+        // New configuration for asking for confirmation.
+        const newConfirmationData: ConfirmationData = {
+          text: newText,
+          headerText: 'nodes.update.title',
+          confirmButtonText: 'nodes.update.install',
+          cancelButtonText: 'common.cancel',
+        };
+
+        // Ask for confirmation.
+        setTimeout(() => {
+          confirmationDialog.componentInstance.showAsking(newConfirmationData);
+        });
+      } else {
+        // Inform that there are no updates available.
+        const newText = this.translateService.instant('nodes.update.no-update');
+        setTimeout(() => {
+          confirmationDialog.componentInstance.showDone(null, newText);
+        });
+      }
+    }, (err: OperationError) => {
+      err = processServiceError(err);
+
+      // Must wait because the loading state is activated after a frame.
+      setTimeout(() => {
+        confirmationDialog.componentInstance.showDone('confirmation.error-header-text', err.translatableErrorMsg);
+      });
+    });
+
+    // React if the user confirms the update.
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      confirmationDialog.componentInstance.showProcessing();
+
+      // Keys and labels of all visors.
+      const keys = this.dataSource.map(node => node.local_pk);
+      const labels = this.dataSource.map(node => node.label);
+      // Update all visors.
+      this.updateSubscription = this.recursivelyUpdateWallets(keys, labels).subscribe(response => {
+        if (response === 0) {
+          // If everything was ok, show a confirmation.
+          confirmationDialog.componentInstance.showDone('confirmation.done-header-text', 'nodes.update.done-all');
+        } else if (response === this.dataSource.length) {
+          // Error if no visor was updated.
+          confirmationDialog.componentInstance.showDone('confirmation.error-header-text', 'nodes.update.all-failed-error');
+        } else {
+          // Error if only some visors were updated.
+          confirmationDialog.componentInstance.showDone(
+            'confirmation.error-header-text',
+            this.translateService.instant('nodes.update.some-updated-error',
+              {failedNumber: response, updatedNumber: this.dataSource.length - response}
+            )
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Recursively updates the visors in the list. It returns how many visors the function was not
+   * able to update.
+   * @param keys Keys of the visors to update. The list will be altered by the function.
+   * @param labels Labels of the visors to update. The list will be altered by the function.
+   * @param errors Errors found during the process. For internal use.
+   */
+  private recursivelyUpdateWallets(keys: string[], labels: string[], errors = 0): Observable<number> {
+    return this.nodeService.update(keys[keys.length - 1]).pipe(catchError(() => {
+      // If there is a problem updating a visor, return null to be able to continue with
+      // the process.
+      return of(null);
+    }), mergeMap(response => {
+      // Show the result of the current step.
+      if (response && response.updated) {
+        this.snackbarService.showDone(this.translateService.instant('nodes.update.done', { name: labels[labels.length - 1] }));
+      } else {
+        this.snackbarService.showError(this.translateService.instant('nodes.update.update-error', { name: labels[labels.length - 1] }));
+        errors += 1;
+      }
+
+      keys.pop();
+      labels.pop();
+
+      // Go to the next step.
+      if (keys.length >= 1) {
+        return this.recursivelyUpdateWallets(keys, labels, errors);
+      }
+
+      return of(errors);
+    }));
   }
 
   /**

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -88,6 +88,7 @@
 
   "nodes": {
     "title": "Visor list",
+    "update-all": "Update all",
     "state": "State",
     "state-tooltip": "Current state",
     "label": "Label",
@@ -98,7 +99,23 @@
     "error-load": "An error occurred while refreshing the list. Retrying...",
     "empty": "There aren't any visors connected to this hypervisor.",
     "delete-node-confirmation": "Are you sure you want to remove the visor from the list?",
-    "deleted": "Visor removed."
+    "deleted": "Visor removed.",
+
+    "update": {
+      "no-visors": "There are no visors to update. Please wait.",
+      "title": "Update visors",
+      "processing": "Looking for updates...",
+      "processing-button": "Please wait",
+      "no-update": "Currently, there are no new updates for the visors.",
+      "update-available": "There is an update available for {{ number }} visors. Click the 'Install update' button to continue. The currently installed version is {{ currentVersion }} and the new version is {{ newVersion }}.",
+      "update-available-different": "There is an update available for {{ number }} visors. Click the 'Install update' button to continue. There are different versions installed in the visors and the new version is {{ newVersion }}.",
+      "done": "The visor {{ name }} is being updated.",
+      "done-all": "Operation completed. All visors are being updated.",
+      "update-error": "Could not install the update in visor {{ name }}. Please, try again later.",
+      "all-failed-error": "Could not update any of the visors. Please, try again later.",
+      "some-updated-error": "{{ updatedNumber }} visors were updated and there were problems for updating {{ failedNumber }}. Please, try again later.",
+      "install": "Install updates"
+    }
   },
 
   "edit-label": {
@@ -434,7 +451,8 @@
     "confirm-button": "Yes",
     "cancel-button": "No",
     "close": "Close",
-    "error-header-text": "Error"
+    "error-header-text": "Error",
+    "done-header-text": "Done"
   },
 
   "language" : {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #408

 Changes:	
- A button for updating all visors was added to the left bar in the visor list.

How to test this PR:
Use the button in the left bar in the visor list.

NOTE: the hipervisor API only returns an answer to the update request after finishing the procedure. This causes the hypervisor to return an error response if the internet connection is not fast enough to download everything before the timeout. Related issue: https://github.com/SkycoinProject/skywire-mainnet/issues/413