### PR TITLE
Automate trusted visor functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mmcloughlin/avo v0.0.0-20200523190732-4439b6b2c061 // indirect
 	github.com/pkg/profile v1.5.0
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/common v0.10.0 // indirect
 	github.com/rakyll/statik v0.1.7
 	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/shirou/gopsutil v2.20.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,10 @@ github.com/SkycoinProject/yamux v0.0.0-20191213015001-a36efeefbf6a/go.mod h1:IaE
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 h1:bZ28Hqta7TFAK3Q08CMvv8y3/8ATaEqv2nGoc6yff6c=
 github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6/go.mod h1:+lx6/Aqd1kLJ1GQfkvOnaZ1WGmLpMpbprPuIOOZX30U=
@@ -362,6 +364,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -1,0 +1,78 @@
+package netutil
+
+import "net"
+
+func LocalAddresses() ([]string, error) {
+	result := make([]string, 0)
+
+	addresses, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, addr := range addresses {
+		switch v := addr.(type) {
+		case *net.IPNet:
+			if v.IP.IsGlobalUnicast() || v.IP.IsLoopback() {
+				result = append(result, v.IP.String())
+			}
+		case *net.IPAddr:
+			if v.IP.IsGlobalUnicast() || v.IP.IsLoopback() {
+				result = append(result, v.IP.String())
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func HasPublicIP() (bool, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return false, err
+	}
+
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return false, err
+		}
+
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			if isPublicIP(ip) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func isPublicIP(IP net.IP) bool {
+	if IP.IsLoopback() || IP.IsLinkLocalMulticast() || IP.IsLinkLocalUnicast() {
+		return false
+	}
+
+	if ip4 := IP.To4(); ip4 != nil {
+		switch {
+		case ip4[0] == 10:
+			return false
+		case ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31:
+			return false
+		case ip4[0] == 192 && ip4[1] == 168:
+			return false
+		default:
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -2,6 +2,7 @@ package netutil
 
 import "net"
 
+// LocalAddresses returns a list of all local addresses
 func LocalAddresses() ([]string, error) {
 	result := make([]string, 0)
 
@@ -24,55 +25,4 @@ func LocalAddresses() ([]string, error) {
 	}
 
 	return result, nil
-}
-
-func HasPublicIP() (bool, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return false, err
-	}
-
-	for _, i := range ifaces {
-		addrs, err := i.Addrs()
-		if err != nil {
-			return false, err
-		}
-
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-
-			if isPublicIP(ip) {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
-}
-
-func isPublicIP(IP net.IP) bool {
-	if IP.IsLoopback() || IP.IsLinkLocalMulticast() || IP.IsLinkLocalUnicast() {
-		return false
-	}
-
-	if ip4 := IP.To4(); ip4 != nil {
-		switch {
-		case ip4[0] == 10:
-			return false
-		case ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31:
-			return false
-		case ip4[0] == 192 && ip4[1] == 168:
-			return false
-		default:
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -35,7 +35,28 @@ func (f *Factory) setDefaults() {
 }
 
 // Updater obtains an updater based on the app name and configuration.
-func (f *Factory) Updater(conf appcommon.ProcConfig) (Updater, bool) {
+func (f *Factory) VisorUpdater() Updater {
+	// Always return empty updater if keys are not set.
+	if f.setDefaults(); f.PK.Null() || f.SK.Null() {
+		return &emptyUpdater{}
+	}
+
+	conf := servicedisc.Config{
+		Type:     servicedisc.ServiceTypeVisor,
+		PK:       f.PK,
+		SK:       f.SK,
+		Port:     0,
+		DiscAddr: f.ProxyDisc,
+	}
+
+	return &serviceUpdater{
+		client:   servicedisc.NewClient(f.Log, conf),
+		interval: f.UpdateInterval,
+	}
+}
+
+// AppUpdater obtains an updater based on the app name and configuration.
+func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 	// Always return empty updater if keys are not set.
 	if f.setDefaults(); f.PK.Null() || f.SK.Null() {
 		return &emptyUpdater{}, false

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -34,7 +34,7 @@ func (f *Factory) setDefaults() {
 	}
 }
 
-// Updater obtains an updater based on the app name and configuration.
+// VisorUpdater obtains a visor updater.
 func (f *Factory) VisorUpdater(port uint16) Updater {
 	// Always return empty updater if keys are not set.
 	if f.setDefaults(); f.PK.Null() || f.SK.Null() {
@@ -55,7 +55,7 @@ func (f *Factory) VisorUpdater(port uint16) Updater {
 	}
 }
 
-// AppUpdater obtains an updater based on the app name and configuration.
+// AppUpdater obtains an app updater based on the app name and configuration.
 func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 	// Always return empty updater if keys are not set.
 	if f.setDefaults(); f.PK.Null() || f.SK.Null() {

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -35,7 +35,7 @@ func (f *Factory) setDefaults() {
 }
 
 // Updater obtains an updater based on the app name and configuration.
-func (f *Factory) VisorUpdater() Updater {
+func (f *Factory) VisorUpdater(port uint16) Updater {
 	// Always return empty updater if keys are not set.
 	if f.setDefaults(); f.PK.Null() || f.SK.Null() {
 		return &emptyUpdater{}
@@ -45,7 +45,7 @@ func (f *Factory) VisorUpdater() Updater {
 		Type:     servicedisc.ServiceTypeVisor,
 		PK:       f.PK,
 		SK:       f.SK,
-		Port:     0,
+		Port:     port,
 		DiscAddr: f.ProxyDisc,
 	}
 

--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -189,7 +189,7 @@ func (m *procManager) Start(conf appcommon.ProcConfig) (appcommon.ProcID, error)
 		break
 	}
 
-	disc, ok := m.discF.Updater(conf)
+	disc, ok := m.discF.AppUpdater(conf)
 	if !ok {
 		log.WithField("appName", conf.AppName).
 			Debug("No app discovery associated with app.")

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -35,12 +35,17 @@ type HTTPClient struct {
 
 // NewClient creates a new HTTPClient.
 func NewClient(log logrus.FieldLogger, conf Config) *HTTPClient {
+	var stats *Stats
+	if conf.Type != ServiceTypeVisor {
+		stats = &Stats{ConnectedClients: 0}
+	}
+
 	return &HTTPClient{
 		log:  log,
 		conf: conf,
 		entry: Service{
 			Addr:  NewSWAddr(conf.PK, conf.Port),
-			Stats: &Stats{ConnectedClients: 0},
+			Stats: stats,
 			Type:  conf.Type,
 		},
 		client: http.Client{},
@@ -62,10 +67,12 @@ func (c *HTTPClient) Auth(ctx context.Context) (*httpauth.Client, error) {
 	if c.auth != nil {
 		return c.auth, nil
 	}
+
 	auth, err := httpauth.NewClient(ctx, c.conf.DiscAddr, c.conf.PK, c.conf.SK)
 	if err != nil {
 		return nil, err
 	}
+
 	c.auth = auth
 	return auth, nil
 }
@@ -81,6 +88,7 @@ func (c *HTTPClient) Services(ctx context.Context) (out []Service, err error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if resp != nil {
 		defer func() {
 			if cErr := resp.Body.Close(); cErr != nil && err == nil {

--- a/pkg/servicedisc/types.go
+++ b/pkg/servicedisc/types.go
@@ -15,6 +15,8 @@ const (
 	ServiceTypeProxy = "proxy"
 	// ServiceTypeVPN stands for the VPN discovery.
 	ServiceTypeVPN = "vpn"
+	// ServiceTypeVisor stands for visor.
+	ServiceTypeVisor = "visor"
 )
 
 // Errors associated with service discovery types.

--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -139,6 +140,10 @@ func (c *client) Serve() error {
 
 		for {
 			if err := c.acceptConn(); err != nil {
+				if strings.Contains(err.Error(), io.EOF.Error()) {
+					continue // likely it's a dummy connection from service discovery
+				}
+
 				c.log.Warnf("failed to accept incoming connection: %v", err)
 
 				if !tphandshake.IsHandshakeError(err) {

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/SkycoinProject/dmsg/disc"
 	"github.com/SkycoinProject/skycoin/src/util/logging"
 
+	"github.com/SkycoinProject/skywire-mainnet/pkg/app/appdisc"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/app/appevent"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/snet/arclient"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/snet/directtp"
@@ -81,6 +83,8 @@ type Config struct {
 	SecKey         cipher.SecKey
 	ARClient       arclient.APIClient
 	NetworkConfigs NetworkConfigs
+	ServiceDisc    appdisc.Factory
+	PublicTrusted  bool
 }
 
 // NetworkConfigs represents all network configs.
@@ -97,10 +101,11 @@ type NetworkClients struct {
 
 // Network represents a network between nodes in Skywire.
 type Network struct {
-	conf    Config
-	netsMu  sync.RWMutex
-	nets    map[string]struct{} // networks to be used with transports
-	clients NetworkClients
+	conf         Config
+	netsMu       sync.RWMutex
+	nets         map[string]struct{} // networks to be used with transports
+	clients      NetworkClients
+	visorUpdater appdisc.Updater
 
 	onNewNetworkTypeMu sync.Mutex
 	onNewNetworkType   func(netType string)
@@ -212,6 +217,10 @@ func (n *Network) Init() error {
 			if err := client.Serve(); err != nil {
 				return fmt.Errorf("failed to initiate 'stcpr': %w", err)
 			}
+
+			if n.conf.PublicTrusted {
+				n.registerPublicTrusted(client)
+			}
 		} else {
 			log.Infof("No config found for stcpr")
 		}
@@ -226,6 +235,31 @@ func (n *Network) Init() error {
 	}
 
 	return nil
+}
+
+func (n *Network) registerPublicTrusted(client directtp.Client) {
+	la, err := client.LocalAddr()
+	if err != nil {
+		log.WithError(err).Errorf("Failed to get STCPR local addr")
+		return
+	}
+
+	_, portStr, err := net.SplitHostPort(la.String())
+	if err != nil {
+		log.WithError(err).Errorf("Failed to extract port from addr %v", la.String())
+		return
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to convert port to int")
+		return
+	}
+
+	n.visorUpdater = n.conf.ServiceDisc.VisorUpdater(uint16(port))
+	n.visorUpdater.Start()
+
+	log.Infof("Registered visor as public trusted")
 }
 
 // OnNewNetworkType sets callback to be called when new network type is ready.
@@ -247,6 +281,8 @@ func (n *Network) IsNetworkReady(netType string) bool {
 func (n *Network) Close() error {
 	n.netsMu.Lock()
 	defer n.netsMu.Unlock()
+
+	n.visorUpdater.Stop()
 
 	wg := new(sync.WaitGroup)
 

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -219,7 +219,7 @@ func (n *Network) Init() error {
 			}
 
 			if n.conf.PublicTrusted {
-				n.registerPublicTrusted(client)
+				go n.registerPublicTrusted(client)
 			}
 		} else {
 			log.Infof("No config found for stcpr")
@@ -238,6 +238,8 @@ func (n *Network) Init() error {
 }
 
 func (n *Network) registerPublicTrusted(client directtp.Client) {
+	log.Infof("Trying to register visor as public trusted")
+
 	la, err := client.LocalAddr()
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get STCPR local addr")
@@ -259,7 +261,7 @@ func (n *Network) registerPublicTrusted(client directtp.Client) {
 	n.visorUpdater = n.conf.ServiceDisc.VisorUpdater(uint16(port))
 	n.visorUpdater.Start()
 
-	log.Infof("Registered visor as public trusted")
+	log.Infof("Sent request to register visor as public trusted")
 }
 
 // OnNewNetworkType sets callback to be called when new network type is ready.

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -282,7 +282,9 @@ func (n *Network) Close() error {
 	n.netsMu.Lock()
 	defer n.netsMu.Unlock()
 
-	n.visorUpdater.Stop()
+	if n.visorUpdater != nil {
+		n.visorUpdater.Stop()
+	}
 
 	wg := new(sync.WaitGroup)
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/SkycoinProject/skywire-mainnet/internal/utclient"
+	"github.com/SkycoinProject/skywire-mainnet/pkg/app/appdisc"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/app/appevent"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/app/appserver"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/app/launcher"
@@ -67,8 +68,9 @@ type Visor struct {
 	router   router.Router
 	rfClient rfclient.Client
 
-	procM appserver.ProcManager // proc manager
-	appL  *launcher.Launcher    // app launcher
+	procM       appserver.ProcManager // proc manager
+	appL        *launcher.Launcher    // app launcher
+	serviceDisc appdisc.Factory
 }
 
 type vReport struct {

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -33,6 +33,8 @@ type V1 struct {
 	LogLevel          string   `json:"log_level"`
 	ShutdownTimeout   Duration `json:"shutdown_timeout,omitempty"` // time value, examples: 10s, 1m, etc
 	RestartCheckDelay string   `json:"restart_check_delay,omitempty"`
+
+	PublicTrustedVisor bool `json:"public_trusted_visor,omitempty"`
 }
 
 // V1Dmsgpty configures the dmsgpty-host.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -151,6 +151,7 @@ github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.10.0
+## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model


### PR DESCRIPTION
Did you run `make format && make check`? Not yet

Fixes #431

 Changes:	
- Register trusted visor in service discovery

How to test this PR:
- Append `"public_trusted_visor": true` to visor's config that is going to be tested
- Run integration env
- If the visor is available from the internet, `Sent request to register visor as public trusted` followed by no errors would appear in logs; otherwise, the error `Unable to register visor as public trusted as it's unreachable from WAN` would appear.
- If the visor is available from the internet, it should appear here: http://service.discovery.skywire.cc/api/services?type=visor