### PR TITLE
Multiple improvements for the manager

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/button/button.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/button/button.component.html
@@ -1,29 +1,12 @@
-<ng-template #contentTpl>
-  <mat-spinner *ngIf="state === buttonStates.Loading" [diameter]="loadingSize"></mat-spinner>
-  <mat-icon *ngIf="state === buttonStates.Success">done</mat-icon>
-  <mat-icon *ngIf="state === buttonStates.Error">error_outline</mat-icon>
-  <ng-content></ng-content>
-  <i *ngIf="notification" class="dot-red sm"></i>
-</ng-template>
-
 <button
-  *ngIf="type === 'mat-button'"
-  mat-button
-  (click)="click()"
-  [disabled]="disabled"
-  [color]="color"
-  [ngClass]="{'grey-button-background': !disabled}"
-  #button1
->
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
-</button>
-<button
-  *ngIf="type === 'mat-raised-button'"
   mat-raised-button
   (click)="click()"
   [disabled]="disabled"
   [color]="color"
+  [ngClass]="{'for-dark-background': forDarkBackground}"
   #button2
 >
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <mat-spinner *ngIf="state === buttonStates.Loading" [diameter]="loadingSize"></mat-spinner>
+  <mat-icon *ngIf="state === buttonStates.Error">error_outline</mat-icon>
+  <ng-content></ng-content>
 </button>

--- a/static/skywire-manager-src/src/app/components/layout/button/button.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/button/button.component.scss
@@ -9,10 +9,6 @@ button {
   mat-spinner ::ng-deep circle {
     stroke: $white;
   }
-
-  .dot-red {
-    margin-left: 10px;
-  }
 }
 
 mat-icon, mat-spinner {
@@ -20,4 +16,10 @@ mat-icon, mat-spinner {
   margin-right: 20px;
   position: relative;
   top: -2px;
+}
+
+.for-dark-background:disabled {
+  background-color: #000000 !important;
+  color: white !important;
+  opacity: 0.3;
 }

--- a/static/skywire-manager-src/src/app/components/layout/button/button.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/button/button.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, Output, ViewChild, OnDestroy } from '@a
 import { MatButton } from '@angular/material/button';
 
 enum ButtonStates {
-  Normal, Success, Error, Loading
+  Normal, Error, Loading
 }
 
 /**
@@ -17,19 +17,16 @@ export class ButtonComponent implements OnDestroy {
   @ViewChild('button1') button1: MatButton;
   @ViewChild('button2') button2: MatButton;
 
-  // Should be be 'mat-button' or 'mat-raised-button'.
-  @Input() type = 'mat-button';
+  // If the button will be in front of the dark background.
+  @Input() forDarkBackground = false;
   @Input() disabled = false;
   // Must be one of the colors defined on the default theme.
   @Input() color = '';
   @Input() loadingSize = 24;
   // Click event.
   @Output() action = new EventEmitter();
-  notification = false;
   state = ButtonStates.Normal;
   buttonStates = ButtonStates;
-
-  private readonly successDuration = 3000;
 
   ngOnDestroy() {
     this.action.complete();
@@ -45,7 +42,6 @@ export class ButtonComponent implements OnDestroy {
   reset() {
     this.state = ButtonStates.Normal;
     this.disabled = false;
-    this.notification = false;
   }
 
   focus() {
@@ -70,19 +66,8 @@ export class ButtonComponent implements OnDestroy {
     this.disabled = true;
   }
 
-  showSuccess() {
-    this.state = ButtonStates.Success;
-    this.disabled = false;
-
-    setTimeout(() => this.state = ButtonStates.Normal, this.successDuration);
-  }
-
   showError() {
     this.state = ButtonStates.Error;
     this.disabled = false;
-  }
-
-  notify(notification: boolean) {
-    this.notification = notification;
   }
 }

--- a/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.html
@@ -14,7 +14,6 @@
   <div class="buttons">
     <app-button
       #cancelButton
-      type="mat-raised-button"
       color="accent"
       (action)="closeModal()"
       *ngIf="data.cancelButtonText && state !== confirmationStates.Done">
@@ -22,7 +21,6 @@
     </app-button>
     <app-button
       #confirmButton
-      type="mat-raised-button"
       color="primary"
       (action)="state === confirmationStates.Asking ? sendOperationAcceptedEvent() : closeModal()">
       {{ (state !== confirmationStates.Done ? data.confirmButtonText : 'confirmation.close') | translate }}

--- a/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.html
@@ -3,6 +3,6 @@
     <mat-form-field>
       <input #firstInput [placeholder]="'edit-label.label' | translate" formControlName="label" maxlength="66" matInput>
     </mat-form-field>
-    <app-button class="float-right" color="primary" type="mat-raised-button" (action)="save()">{{ 'common.save' | translate }}</app-button>
+    <app-button class="float-right" color="primary" (action)="save()">{{ 'common.save' | translate }}</app-button>
   </form>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.html
@@ -26,7 +26,6 @@
     <app-button
       #button
       (action)="apply()"
-      type="mat-raised-button"
       color="primary"
       class="float-right"
     >

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -29,15 +29,14 @@
 
     <!-- Header. -->
     <div class="generic-title-container mt-4.5 d-flex" [ngClass]="{'paginator-icons-fixer': numberOfPages > 1}">
-      <div class="title ml-3.5">
+      <div class="title">
         <div class="filter-label subtle-transparent-button cursor-pointer" (click)="dataFilterer.removeFilters()" *ngIf="dataFilterer.currentFiltersTexts && dataFilterer.currentFiltersTexts.length > 0">
-          {{ 'filters.active-filters' | translate }}
           <div *ngFor="let filterTexts of dataFilterer.currentFiltersTexts" class="item">
             <span>{{ filterTexts.filterName | translate }}: </span>
             <ng-container *ngIf="filterTexts.translatableValue">{{ filterTexts.translatableValue | translate }}</ng-container>
             <ng-container *ngIf="filterTexts.value">{{ filterTexts.value }}</ng-container>
           </div>
-          <div>{{ 'filters.press-to-remove' | translate }}</div>
+          <div class="transparent-50">{{ 'filters.press-to-remove' | translate }}</div>
         </div>
       </div>
       <div class="options">
@@ -93,7 +92,10 @@
           </th>
           <th *ngIf="showDmsgInfo" class="sortable-column" (click)="dataSorter.changeSortingOrder(dmsgServerSortData)">
             {{ 'nodes.dmsg-server' | translate }}
-            <mat-icon *ngIf="dataSorter.currentSortingColumn === dmsgServerSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+            <ng-container *ngIf="dataSorter.currentSortingColumn === dmsgServerSortData">
+              <mat-icon [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+              <ng-container *ngIf="dataSorter.currentlySortingByLabel">*</ng-container>
+            </ng-container>
           </th>
           <th *ngIf="showDmsgInfo" class="sortable-column" (click)="dataSorter.changeSortingOrder(pingSortData)">
             {{ 'nodes.ping' | translate }}
@@ -177,7 +179,8 @@
             <div class="left-part">
               <div class="title">{{ 'tables.sorting-title' | translate }}</div>
               <div>{{ dataSorter.currentSortingColumn.label | translate }}
-                {{ (!dataSorter.sortingInReverseOrder ? 'tables.ascending-order' : 'tables.descending-order') | translate }}
+                <ng-container *ngIf="dataSorter.currentlySortingByLabel">{{ 'tables.label' | translate }}</ng-container>
+                <ng-container *ngIf="dataSorter.sortingInReverseOrder">{{ 'tables.inverted-order' | translate }}</ng-container>
               </div>
             </div>
             <div class="right-part">

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -42,7 +42,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
   stateSortData = new SortingColumn(['online'], 'transports.state', SortingModes.Boolean);
   labelSortData = new SortingColumn(['label'], 'nodes.label', SortingModes.Text);
   keySortData = new SortingColumn(['local_pk'], 'nodes.key', SortingModes.Text);
-  dmsgServerSortData = new SortingColumn(['dmsgServerPk'], 'nodes.dmsg-server', SortingModes.Text);
+  dmsgServerSortData = new SortingColumn(['dmsgServerPk'], 'nodes.dmsg-server', SortingModes.Text, ['dmsgServerPk_label']);
   pingSortData = new SortingColumn(['roundTripPing'], 'nodes.ping', SortingModes.Number);
 
   private dataSortedSubscription: Subscription;
@@ -324,7 +324,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
             if (result.data) {
               this.allNodes = result.data as Node[];
               if (this.showDmsgInfo) {
-                // Add the label data to the array, to be able to use it for filtering.
+                // Add the label data to the array, to be able to use it for filtering and sorting.
                 this.allNodes.forEach(node => {
                   node['dmsgServerPk_label'] =
                     LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, node.dmsgServerPk);
@@ -394,10 +394,16 @@ export class NodeListComponent implements OnInit, OnDestroy {
   }
 
   logout() {
-    this.authService.logout().subscribe(
-      () => this.router.navigate(['login']),
-      () => this.snackbarService.showError('common.logout-error')
-    );
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'common.logout-confirmation');
+
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      confirmationDialog.componentInstance.closeModal();
+
+      this.authService.logout().subscribe(
+        () => this.router.navigate(['login']),
+        () => this.snackbarService.showError('common.logout-error')
+      );
+    });
   }
 
   // Updates all visors.

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.html
@@ -1,15 +1,14 @@
 <!-- Header. -->
 <div class="generic-title-container mt-4.5 d-flex" [ngClass]="{'paginator-icons-fixer': !showShortList_ && numberOfPages > 1 && dataSource}">
-  <div class="title ml-3.5">
+  <div class="title">
     <span *ngIf="showShortList_" class="uppercase">{{ 'apps.apps-list.title' | translate }}</span>
     <div class="filter-label subtle-transparent-button cursor-pointer" (click)="dataFilterer.removeFilters()" *ngIf="dataFilterer.currentFiltersTexts && dataFilterer.currentFiltersTexts.length > 0">
-      {{ 'filters.active-filters' | translate }}
       <div *ngFor="let filterTexts of dataFilterer.currentFiltersTexts" class="item">
         <span>{{ filterTexts.filterName | translate }}: </span>
         <ng-container *ngIf="filterTexts.translatableValue">{{ filterTexts.translatableValue | translate }}</ng-container>
         <ng-container *ngIf="filterTexts.value">{{ filterTexts.value }}</ng-container>
       </div>
-      <div>{{ 'filters.press-to-remove' | translate }}</div>
+      <div class="transparent-50">{{ 'filters.press-to-remove' | translate }}</div>
     </div>
   </div>
   <div class="options">
@@ -160,7 +159,8 @@
         <div class="left-part">
           <div class="title">{{ 'tables.sorting-title' | translate }}</div>
           <div>{{ dataSorter.currentSortingColumn.label | translate }}
-            {{ (!dataSorter.sortingInReverseOrder ? 'tables.ascending-order' : 'tables.descending-order') | translate }}
+            <ng-container *ngIf="dataSorter.currentlySortingByLabel">{{ 'tables.label' | translate }}</ng-container>
+            <ng-container *ngIf="dataSorter.sortingInReverseOrder">{{ 'tables.inverted-order' | translate }}</ng-container>
           </div>
         </div>
         <div class="right-part">

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.html
@@ -25,7 +25,6 @@
         <app-button
           #button
           (action)="saveChanges()"
-          type="mat-raised-button"
           [disabled]="!form.valid"
           color="primary"
           class="float-right"

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
@@ -29,7 +29,6 @@
     <app-button
       #button
       (action)="saveChanges()"
-      type="mat-raised-button"
       [disabled]="!form.valid"
       color="primary"
       class="float-right"

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.html
@@ -1,15 +1,17 @@
 <!-- Header. -->
 <div class="generic-title-container mt-4.5 d-flex" [ngClass]="{'paginator-icons-fixer': !showShortList_ && numberOfPages > 1 && dataSource}">
-  <div class="title ml-3.5">
-    <span *ngIf="showShortList_"  class="uppercase">{{ 'routes.title' | translate }}</span>
+  <div class="title">
+    <span *ngIf="showShortList_"  class="uppercase">
+      {{ 'routes.title' | translate }}
+      <mat-icon [inline]="true" class="help d-none d-md-inline" [matTooltip]="'routes.info' | translate">help</mat-icon>
+    </span>
     <div class="filter-label subtle-transparent-button cursor-pointer" (click)="dataFilterer.removeFilters()" *ngIf="dataFilterer.currentFiltersTexts && dataFilterer.currentFiltersTexts.length > 0">
-      {{ 'filters.active-filters' | translate }}
       <div *ngFor="let filterTexts of dataFilterer.currentFiltersTexts" class="item">
         <span>{{ filterTexts.filterName | translate }}: </span>
         <ng-container *ngIf="filterTexts.translatableValue">{{ filterTexts.translatableValue | translate }}</ng-container>
         <ng-container *ngIf="filterTexts.value">{{ filterTexts.value }}</ng-container>
       </div>
-      <div>{{ 'filters.press-to-remove' | translate }}</div>
+      <div class="transparent-50">{{ 'filters.press-to-remove' | translate }}</div>
     </div>
   </div>
   <div class="options">
@@ -118,7 +120,8 @@
         <div class="left-part">
           <div class="title">{{ 'tables.sorting-title' | translate }}</div>
           <div>{{ dataSorter.currentSortingColumn.label | translate }}
-            {{ (!dataSorter.sortingInReverseOrder ? 'tables.ascending-order' : 'tables.descending-order') | translate }}
+            <ng-container *ngIf="dataSorter.currentlySortingByLabel">{{ 'tables.label' | translate }}</ng-container>
+            <ng-container *ngIf="dataSorter.sortingInReverseOrder">{{ 'tables.inverted-order' | translate }}</ng-container>
           </div>
         </div>
         <div class="right-part">

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
@@ -34,7 +34,6 @@
     <app-button
       #button
       (action)="create()"
-      type="mat-raised-button"
       [disabled]="!form.valid"
       color="primary"
       class="float-right"

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.html
@@ -1,15 +1,17 @@
 <!-- Header. -->
 <div class="generic-title-container mt-4.5 d-flex" [ngClass]="{'paginator-icons-fixer': !showShortList_ && numberOfPages > 1 && dataSource}">
-  <div class="title ml-3.5">
-    <span *ngIf="showShortList_" class="uppercase">{{ 'transports.title' | translate }}</span>
+  <div class="title">
+    <span *ngIf="showShortList_" class="uppercase">
+      {{ 'transports.title' | translate }}
+      <mat-icon [inline]="true" class="help d-none d-md-inline" [matTooltip]="'transports.info' | translate">help</mat-icon>
+    </span>
     <div class="filter-label subtle-transparent-button cursor-pointer" (click)="dataFilterer.removeFilters()" *ngIf="dataFilterer.currentFiltersTexts && dataFilterer.currentFiltersTexts.length > 0">
-      {{ 'filters.active-filters' | translate }}
       <div *ngFor="let filterTexts of dataFilterer.currentFiltersTexts" class="item">
         <span>{{ filterTexts.filterName | translate }}: </span>
         <ng-container *ngIf="filterTexts.translatableValue">{{ filterTexts.translatableValue | translate }}</ng-container>
         <ng-container *ngIf="filterTexts.value">{{ filterTexts.value }}</ng-container>
       </div>
-      <div>{{ 'filters.press-to-remove' | translate }}</div>
+      <div class="transparent-50">{{ 'filters.press-to-remove' | translate }}</div>
     </div>
   </div>
   <div class="options">
@@ -17,12 +19,10 @@
       <mat-icon
         [inline]="true"
         (click)="create()"
-        [matTooltip]="'transports.create' | translate"
       >add</mat-icon>
       <mat-icon
         [inline]="true"
         (click)="dataFilterer.changeFilters()"
-        [matTooltip]="'filters.filter-action' | translate"
         class="small-icon"
         *ngIf="allTransports && allTransports.length > 0"
       >filter_list</mat-icon>
@@ -73,11 +73,17 @@
       </th>
       <th class="sortable-column" (click)="dataSorter.changeSortingOrder(idSortData)">
         {{ 'transports.id' | translate }}
-        <mat-icon *ngIf="dataSorter.currentSortingColumn === idSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+        <ng-container *ngIf="dataSorter.currentSortingColumn === idSortData">
+          <mat-icon [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+          <ng-container *ngIf="dataSorter.currentlySortingByLabel">*</ng-container>
+        </ng-container>
       </th>
       <th class="sortable-column" (click)="dataSorter.changeSortingOrder(remotePkSortData)">
         {{ 'transports.remote-node' | translate }}
-        <mat-icon *ngIf="dataSorter.currentSortingColumn === remotePkSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+        <ng-container *ngIf="dataSorter.currentSortingColumn === remotePkSortData">
+          <mat-icon [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+          <ng-container *ngIf="dataSorter.currentlySortingByLabel">*</ng-container>
+        </ng-container>
       </th>
       <th class="sortable-column" (click)="dataSorter.changeSortingOrder(typeSortData)">
         {{ 'transports.type' | translate }}
@@ -163,7 +169,8 @@
         <div class="left-part">
           <div class="title">{{ 'tables.sorting-title' | translate }}</div>
           <div>{{ dataSorter.currentSortingColumn.label | translate }}
-            {{ (!dataSorter.sortingInReverseOrder ? 'tables.ascending-order' : 'tables.descending-order') | translate }}
+            <ng-container *ngIf="dataSorter.currentlySortingByLabel">{{ 'tables.label' | translate }}</ng-container>
+            <ng-container *ngIf="dataSorter.sortingInReverseOrder">{{ 'tables.inverted-order' | translate }}</ng-container>
           </div>
         </div>
         <div class="right-part">

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.ts
@@ -39,8 +39,8 @@ export class TransportListComponent implements OnDestroy {
 
   // Vars with the data of the columns used for sorting the data.
   stateSortData = new SortingColumn(['is_up'], 'transports.state', SortingModes.Boolean);
-  idSortData = new SortingColumn(['id'], 'transports.id', SortingModes.Text);
-  remotePkSortData = new SortingColumn(['remote_pk'], 'transports.remote-node', SortingModes.Text);
+  idSortData = new SortingColumn(['id'], 'transports.id', SortingModes.Text, ['id_label']);
+  remotePkSortData = new SortingColumn(['remote_pk'], 'transports.remote-node', SortingModes.Text, ['remote_pk_label']);
   typeSortData = new SortingColumn(['type'], 'transports.type', SortingModes.Text);
   uploadedSortData = new SortingColumn(['log', 'sent'], 'common.uploaded', SortingModes.NumberReversed);
   downloadedSortData = new SortingColumn(['log', 'recv'], 'common.downloaded', SortingModes.NumberReversed);
@@ -79,7 +79,7 @@ export class TransportListComponent implements OnDestroy {
   @Input() set transports(val: Transport[]) {
     this.allTransports = val;
 
-    // Add the label data to the array, to be able to use it for filtering.
+    // Add the label data to the array, to be able to use it for filtering and sorting.
     this.allTransports.forEach(transport => {
       transport['id_label'] =
         LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, transport.id);

--- a/static/skywire-manager-src/src/app/components/pages/settings/all-labels/label-list/label-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/settings/all-labels/label-list/label-list.component.html
@@ -1,15 +1,17 @@
 <!-- Header. -->
 <div class="generic-title-container mt-4.5 d-flex" [ngClass]="{'paginator-icons-fixer': !showShortList_ && numberOfPages > 1 && dataSource}">
-  <div class="title ml-3.5">
-    <span *ngIf="showShortList_" class="uppercase">{{ 'labels.title' | translate }}</span>
+  <div class="title">
+    <span *ngIf="showShortList_" class="uppercase">
+      {{ 'labels.title' | translate }}
+      <mat-icon [inline]="true" class="help d-none d-md-inline" [matTooltip]="'labels.info' | translate">help</mat-icon>
+    </span>
     <div class="filter-label subtle-transparent-button cursor-pointer" (click)="dataFilterer.removeFilters()" *ngIf="dataFilterer.currentFiltersTexts && dataFilterer.currentFiltersTexts.length > 0">
-      {{ 'filters.active-filters' | translate }}
       <div *ngFor="let filterTexts of dataFilterer.currentFiltersTexts" class="item">
         <span>{{ filterTexts.filterName | translate }}: </span>
         <ng-container *ngIf="filterTexts.translatableValue">{{ filterTexts.translatableValue | translate }}</ng-container>
         <ng-container *ngIf="filterTexts.value">{{ filterTexts.value }}</ng-container>
       </div>
-      <div>{{ 'filters.press-to-remove' | translate }}</div>
+      <div class="transparent-50">{{ 'filters.press-to-remove' | translate }}</div>
     </div>
   </div>
   <div class="options">
@@ -118,7 +120,8 @@
         <div class="left-part">
           <div class="title">{{ 'tables.sorting-title' | translate }}</div>
           <div>{{ dataSorter.currentSortingColumn.label | translate }}
-            {{ (!dataSorter.sortingInReverseOrder ? 'tables.ascending-order' : 'tables.descending-order') | translate }}
+            <ng-container *ngIf="dataSorter.currentlySortingByLabel">{{ 'tables.label' | translate }}</ng-container>
+            <ng-container *ngIf="dataSorter.sortingInReverseOrder">{{ 'tables.inverted-order' | translate }}</ng-container>
           </div>
         </div>
         <div class="right-part">

--- a/static/skywire-manager-src/src/app/components/pages/settings/password/password.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/settings/password/password.component.html
@@ -48,9 +48,9 @@
     <app-button
       [ngClass]="{ 'mt-2 app-button': !forInitialConfig, 'float-right': forInitialConfig }"
       color="primary"
-      type="mat-raised-button"
       [disabled]="!form.valid"
       (action)="changePassword()"
+      [forDarkBackground]="!forInitialConfig"
       #button
     >
       {{ (forInitialConfig ? 'settings.password.initial-config.set-password': 'settings.change-password') | translate }}

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
@@ -1,11 +1,13 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
 
 import { TabButtonData } from '../../layout/tab-bar/tab-bar.component';
 import { AuthService } from '../../../services/auth.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { SidenavService } from 'src/app/services/sidenav.service';
+import GeneralUtils from 'src/app/utils/generalUtils';
 
 /**
  * Page with the general settings of the app.
@@ -25,6 +27,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private router: Router,
     private snackbarService: SnackbarService,
     private sidenavService: SidenavService,
+    private dialog: MatDialog,
   ) {
     // Data for populating the tab bar.
     this.tabsData = [
@@ -71,9 +74,15 @@ export class SettingsComponent implements OnInit, OnDestroy {
   }
 
   logout() {
-    this.authService.logout().subscribe(
-      () => this.router.navigate(['login']),
-      () => this.snackbarService.showError('common.logout-error')
-    );
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'common.logout-confirmation');
+
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      confirmationDialog.componentInstance.closeModal();
+
+      this.authService.logout().subscribe(
+        () => this.router.navigate(['login']),
+        () => this.snackbarService.showError('common.logout-error')
+      );
+    });
   }
 }

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -12,6 +12,7 @@
     "options": "Options",
     "logout": "Logout",
     "logout-error": "Error logging out.",
+    "logout-confirmation": "Are you sure you want to log out?",
     "time-in-ms": "{{ time }}ms",
     "ok": "Ok",
     "unknown": "Unknown"
@@ -31,6 +32,7 @@
 
   "labels": {
     "title": "Labels",
+    "info": "Labels you have entered to easily identify visors, transports and other elements, instead of having to read machine generated identifiers.",
     "list-title": "Label list",
     "label": "Label",
     "id": "Element ID",
@@ -57,16 +59,17 @@
 
   "filters": {
     "filter-action": "Filter",
-    "active-filters": "Active filters: ",
-    "press-to-remove": "(Press to remove)",
+    "press-to-remove": "(Press to remove the filters)",
     "remove-confirmation": "Are you sure you want to remove the filters?"
   },
 
   "tables": {
     "title": "Order by",
     "sorting-title": "Ordered by:",
-    "ascending-order": "(ascending)",
-    "descending-order": "(descending)"
+    "sort-by-value": "Value",
+    "sort-by-label": "Label",
+    "label": "(label)",
+    "inverted-order": "(inverted)"
   },
 
   "start": {
@@ -355,6 +358,7 @@
 
   "transports": {
     "title": "Transports",
+    "info": "Connections you have with remote Skywire visors, to allow local Skywire apps to communicate with apps running on those remote visors.",
     "list-title": "Transport list",
     "state": "State",
     "state-tooltip": "Current state",
@@ -415,6 +419,7 @@
 
   "routes": {
     "title": "Routes",
+    "info": "Paths used to reach the remote visors to which transports have been established. Routes are automatically generated as needed.",
     "list-title": "Route list",
     "key": "Key",
     "rule": "Rule",

--- a/static/skywire-manager-src/src/assets/scss/_responsive_tables.scss
+++ b/static/skywire-manager-src/src/assets/scss/_responsive_tables.scss
@@ -178,16 +178,38 @@ $responsive-table-colors: (
 
 // Styles for the headers shown above most of the tables.
 .generic-title-container {
-  padding-right: 5px;
+  @media (min-width: map-get($grid-breakpoints, md)) {
+    & {
+      padding-right: 5px;
+    }
+  }
+
+  @media (max-width: (map-get($grid-breakpoints, md) - 1)) {
+    & {
+      margin-right: -15px;
+    }
+  }
 
   .title {
     margin-right: auto;
     font-size: $font-size-base;
     font-weight: bold;
 
+    @media (min-width: map-get($grid-breakpoints, md)) {
+      & {
+        margin-left: 1.25rem !important;
+      }
+    }
+
     .filter-label {
       font-size: $font-size-mini;
       font-weight: lighter;
+    }
+
+    .help {
+      opacity: 0.5;
+      font-size: 14px;
+      cursor: default;
     }
   }
 

--- a/static/skywire-manager-src/src/assets/scss/utilities/_utilities.scss
+++ b/static/skywire-manager-src/src/assets/scss/utilities/_utilities.scss
@@ -27,10 +27,6 @@
   margin-top: 2rem !important;
 }
 
-.ml-3\.5 {
-  margin-left: 1.25rem !important;
-}
-
 .highlight-internal-icon {
   @extend .cursor-pointer;
 

--- a/static/skywire-manager-src/src/styles.scss
+++ b/static/skywire-manager-src/src/styles.scss
@@ -76,3 +76,7 @@ button:focus {
 .mat-snack-bar-container {
   max-width: 90vw !important;
 }
+
+.transparent-50 {
+  opacity: 0.5;
+}


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the tables can be sorted by element label.
- The "ascending" and "descending" texts shown to indicate how the data is sorted were changed to normal and inverted mode, as the previous texts were not always correct, due to the way in which some columns are sorted.
- Some additional help messages were added.
- A problem with the color of disabled buttons in front of the dark background was solved. Also, the code of the button component was cleaned.
- The design of the filter list was polished a bit.
- Now the user is asked for confirmation before logging out.
- Some improvements to the responsive design.

How to test this PR:
Just use the manager normally and check the changes in the list.