### PR TITLE
Make app exit on VPN server failure

### DIFF
--- a/cmd/apps/vpn-server/vpn-server.go
+++ b/cmd/apps/vpn-server/vpn-server.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -32,6 +33,10 @@ var (
 )
 
 func main() {
+	if runtime.GOOS != "linux" {
+		log.Fatalln("OS is not supported")
+	}
+
 	flag.Parse()
 
 	localPK := cipher.PubKey{}


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #464 	

 Changes:	
- VPN server app now exists if `Serve` call failed
- VPN server now exists immediately if run on non-Linux OS
