### PR TITLE
Add release URL to update information

### DIFF
--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -484,6 +484,7 @@ func (hv *Hypervisor) hypervisorUpdateAvailable() http.HandlerFunc {
 			Available        bool   `json:"available"`
 			CurrentVersion   string `json:"current_version"`
 			AvailableVersion string `json:"available_version,omitempty"`
+			ReleaseURL       string `json:"release_url,omitempty"`
 		}{
 			Available:      version != nil,
 			CurrentVersion: buildinfo.Version(),
@@ -491,6 +492,7 @@ func (hv *Hypervisor) hypervisorUpdateAvailable() http.HandlerFunc {
 
 		if version != nil {
 			output.AvailableVersion = version.String()
+			output.ReleaseURL = version.ReleaseURL()
 		}
 
 		httputil.WriteJSON(w, r, http.StatusOK, output)
@@ -1189,6 +1191,7 @@ func (hv *Hypervisor) visorUpdateAvailable() http.HandlerFunc {
 			Available        bool   `json:"available"`
 			CurrentVersion   string `json:"current_version"`
 			AvailableVersion string `json:"available_version,omitempty"`
+			ReleaseURL       string `json:"release_url,omitempty"`
 		}{
 			Available:      version != nil,
 			CurrentVersion: summary.BuildInfo.Version,
@@ -1196,6 +1199,7 @@ func (hv *Hypervisor) visorUpdateAvailable() http.HandlerFunc {
 
 		if version != nil {
 			output.AvailableVersion = version.String()
+			output.ReleaseURL = version.ReleaseURL()
 		}
 
 		httputil.WriteJSON(w, r, http.StatusOK, output)

--- a/pkg/util/updater/version.go
+++ b/pkg/util/updater/version.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -63,6 +64,11 @@ func (v *Version) String() string {
 	}
 
 	return version
+}
+
+// ReleaseURL returns GitHub release URL for this version.
+func (v *Version) ReleaseURL() string {
+	return fmt.Sprintf("%s/tag/%s", releaseURL, v.String())
 }
 
 // VersionFromString parses a Version from a string.

--- a/pkg/util/updater/version_test.go
+++ b/pkg/util/updater/version_test.go
@@ -294,3 +294,42 @@ func TestVersion_Cmp(t *testing.T) {
 		})
 	}
 }
+
+func TestVersion_ReleaseURL(t *testing.T) {
+	type fields struct {
+		Major      int
+		Minor      int
+		Patch      int
+		Additional string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			"Case 1",
+			fields{
+				Major:      1,
+				Minor:      2,
+				Patch:      3,
+				Additional: "test",
+			},
+			"https://github.com/skycoin/skywire/releases/tag/v1.2.3-test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Version{
+				Major:      tt.fields.Major,
+				Minor:      tt.fields.Minor,
+				Patch:      tt.fields.Patch,
+				Additional: tt.fields.Additional,
+			}
+			if got := v.ReleaseURL(); got != tt.want {
+				t.Errorf("ReleaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Did you run `make format && make check`? yes

 Changes:	
- Add release URL to update information. A new JSON field `release_url` is returned when checking whether an update is available.

How to test this PR:
- Run the integration env
- Check for an update
- Make sure the output contains `release_url`