### PR TITLE
Improvements for the updater UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.module.ts
+++ b/static/skywire-manager-src/src/app/app.module.ts
@@ -76,6 +76,7 @@ import { AllLabelsComponent } from './components/pages/settings/all-labels/all-l
 import { LabelListComponent } from './components/pages/settings/all-labels/label-list/label-list.component';
 import { UpdateComponent } from './components/layout/update/update.component';
 import { UpdateHypervisorComponent } from './components/layout/update-hypervisor/update-hypervisor.component';
+import { UpdaterConfigComponent } from './components/pages/settings/updater-config/updater-config.component';
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -134,6 +135,7 @@ const globalRippleConfig: RippleGlobalOptions = {
     LabelListComponent,
     UpdateComponent,
     UpdateHypervisorComponent,
+    UpdaterConfigComponent,
   ],
   imports: [
     BrowserModule,

--- a/static/skywire-manager-src/src/app/app.module.ts
+++ b/static/skywire-manager-src/src/app/app.module.ts
@@ -75,6 +75,7 @@ import { LabeledElementTextComponent } from './components/layout/labeled-element
 import { AllLabelsComponent } from './components/pages/settings/all-labels/all-labels.component';
 import { LabelListComponent } from './components/pages/settings/all-labels/label-list/label-list.component';
 import { UpdateComponent } from './components/layout/update/update.component';
+import { UpdateHypervisorComponent } from './components/layout/update-hypervisor/update-hypervisor.component';
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -132,6 +133,7 @@ const globalRippleConfig: RippleGlobalOptions = {
     AllLabelsComponent,
     LabelListComponent,
     UpdateComponent,
+    UpdateHypervisorComponent,
   ],
   imports: [
     BrowserModule,

--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.html
@@ -1,0 +1,102 @@
+<app-dialog [headline]="(state !== updatingStates.Error ? 'update-hypervisor.title' : 'update.error-title') | translate">
+  <!-- Main black text area. -->
+  <div class="text-container">
+    <ng-container *ngIf="state === updatingStates.InitialProcessing">
+      <mat-spinner class="loading-indicator" [diameter]="12"></mat-spinner>
+      {{ 'update-hypervisor.processing' | translate }}
+    </ng-container>
+    <ng-container *ngIf="state === updatingStates.Error">
+      {{ errorText | translate }}
+    </ng-container>
+    <ng-container *ngIf="state === updatingStates.NoUpdatesFound">
+      {{ 'update-hypervisor.no-update' | translate }}
+    </ng-container>
+  </div>
+
+  <!-- Current version, shown if no update was found. -->
+  <div *ngIf="state === updatingStates.NoUpdatesFound" class="list-container">
+    - {{ currentNodeVersion ? currentNodeVersion : ('common.unknown' | translate) }}
+  </div>
+
+  <!-- Text asking for confirmation before installing the update. -->
+  <ng-container *ngIf="state === updatingStates.Asking">
+    <div class="text-container">
+      {{ 'update-hypervisor.update-available' | translate }}
+    </div>
+    <div class="list-container">
+      - {{ 'update.version-change' | translate:updateFound }}
+    </div>
+    <div class="text-container">
+      {{ 'update-hypervisor.update-instructions' | translate }}
+    </div>
+  </ng-container>
+
+  <!-- Content shown while updating. -->
+  <ng-container *ngIf="state === updatingStates.Updating">
+    <!-- Indications. -->
+    <div class="text-container">
+      {{ 'update-hypervisor.updating' | translate }}
+    </div>
+    <div>
+      <!-- Raw progress text shown if it was not possible to parse it for showing the progrss bar. -->
+      <div *ngIf="!progressInfo.errorMsg && !progressInfo.dataParsed" class="list-container">
+        - <mat-spinner class="loading-indicator" [diameter]="12" *ngIf="!progressInfo.closed"></mat-spinner> {{ 'update-hypervisor.label' | translate }}
+        : <span class="details">{{ progressInfo.rawMsg }}</span>
+        <span *ngIf="progressInfo.closed" class="closed-indication">&nbsp;({{ 'update.finished' | translate }})</span>
+      </div>
+      <!-- Progress bar. -->
+      <div *ngIf="!progressInfo.errorMsg && progressInfo.dataParsed" class="progress-container">
+        <!-- Hypervisor label. -->
+        <div class="name">
+          <mat-spinner class="loading-indicator" [diameter]="12" *ngIf="!progressInfo.closed"></mat-spinner>
+          {{ 'update-hypervisor.label' | translate }}
+        </div>
+        <!-- Bar. -->
+        <mat-progress-bar
+          color="accent"
+          [mode]="'determinate'"
+          [value]="progressInfo.progress">
+        </mat-progress-bar>
+        <!-- Details. -->
+        <div class="details">
+          {{ 'update.downloaded-file-name-prefix' | translate }} {{ progressInfo.fileName }}
+          ({{ progressInfo.progress }}%)
+          <br/>
+          {{ 'update.speed-prefix' | translate }} {{ progressInfo.speed }}
+          <br/>
+          {{ 'update.time-downloading-prefix' | translate }} {{ progressInfo.elapsedTime }}
+          /
+          {{ 'update.time-left-prefix' | translate }} {{ progressInfo.remainingTime }}
+          <ng-container *ngIf="progressInfo.closed">
+            <br/>
+            <span class="closed-indication">{{ 'update.finished' | translate }}</span>
+          </ng-container>
+        </div>
+      </div>
+      <!-- Msg shown if there was an error during the operation. -->
+      <div *ngIf="progressInfo.errorMsg" class="list-container">
+        - {{ 'update-hypervisor.label' | translate }}: <span class="red-text">{{ progressInfo.errorMsg | translate }}</span>
+      </div>
+    </div>
+  </ng-container>
+
+  <!-- Buttons. -->
+  <div class="buttons">
+    <app-button
+      #cancelButton
+      type="mat-raised-button"
+      color="accent"
+      (action)="closeModal()"
+      *ngIf="cancelButtonText">
+        {{ cancelButtonText | translate }}
+    </app-button>
+    <app-button
+      #confirmButton
+      type="mat-raised-button"
+      color="primary"
+      (action)="state === updatingStates.Asking ? update() : closeModal()"
+      *ngIf="confirmButtonText">
+        {{ confirmButtonText | translate }}
+    </app-button>
+  </div>
+</app-dialog>

--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.scss
@@ -1,0 +1,56 @@
+@import 'variables';
+
+.text-container {
+  word-break: break-word;
+}
+
+.list-container {
+  font-size: 14px;
+  margin: 10px;
+  color: $blue-medium;
+  word-break: break-word;
+
+  .details {
+    color: $light-gray;
+  }
+}
+
+.buttons {
+  margin-top: 15px;
+  text-align: right;
+
+  app-button {
+    margin-left: 5px;
+  }
+}
+
+.progress-container {
+  margin: 10px 0;
+
+  .name {
+    font-size: $font-size-mini;
+    color: $blue-medium;
+  }
+
+  ::ng-deep {
+    .mat-progress-bar-fill::after {
+      background-color: $blue-medium !important;
+    }
+  }
+
+  .details {
+    font-size: $font-size-mini;
+    text-align: right;
+    color: $light-gray;
+  }
+}
+
+.closed-indication {
+  color: $yellow;
+}
+
+.loading-indicator {
+  display: inline-block;
+  position: relative;
+  top: 2px;
+}

--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.ts
@@ -7,7 +7,6 @@ import { AppConfig } from 'src/app/app.config';
 import { NodeService } from 'src/app/services/node.service';
 import { OperationError } from 'src/app/utils/operation-error';
 import { processServiceError } from 'src/app/utils/errors';
-import { WebSocketSubject } from 'rxjs/webSocket';
 
 /**
  * States of the modal window.

--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.ts
@@ -1,0 +1,329 @@
+import { Component, OnDestroy, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
+import { Subscription, interval } from 'rxjs';
+
+import { AppConfig } from 'src/app/app.config';
+import { NodeService } from 'src/app/services/node.service';
+import { OperationError } from 'src/app/utils/operation-error';
+import { processServiceError } from 'src/app/utils/errors';
+import { WebSocketSubject } from 'rxjs/webSocket';
+
+/**
+ * States of the modal window.
+ */
+enum UpdatingStates {
+  /**
+   * Looking for updates.
+   */
+  InitialProcessing = 'InitialProcessing',
+  /**
+   * If no update was found.
+   */
+  NoUpdatesFound = 'NoUpdatesFound',
+  /**
+   * Showing the list of updates found and asking for confirmation before installing them.
+   */
+  Asking = 'Asking',
+  /**
+   * Installing the updates.
+   */
+  Updating = 'Updating',
+  /**
+   * Showing an error msg. Operation cancelled.
+   */
+  Error = 'Error',
+}
+
+/**
+ * Info about the current state of the update procedure.
+ */
+export class UpdateProgressInfo {
+  /**
+   * Error found while updating. If it has a valid value, the whole procedure must be
+   * considered as failed.
+   */
+  errorMsg = '';
+  /**
+   * Raw progress text obtained from the backend.
+   */
+  rawMsg = '';
+  /**
+   * If it was posible to parse the raw progress text obtained from the backend and
+   * populate the rest of the vars.
+   */
+  dataParsed = false;
+  /**
+   * Name of the file currently being downloaded (only is dataParsed === true).
+   */
+  fileName = '';
+  /**
+   * Progress downloading the file, in percentage (only is dataParsed === true).
+   */
+  progress = 100;
+  /**
+   * Current download speed (only is dataParsed === true).
+   */
+  speed = '';
+  /**
+   * Time since starting to download the file (only is dataParsed === true).
+   */
+  elapsedTime = '';
+  /**
+   * Expected time for finishing to download the file (only is dataParsed === true).
+   */
+  remainingTime = '';
+  /**
+   * If true, the connection with the backend for getting progress updates has been clo0sed.
+   */
+  closed = false;
+}
+
+/**
+ * Data about an update found.
+ */
+interface UpdateVersion {
+  currentVersion: string;
+  newVersion: string;
+}
+
+/**
+ * Modal window used for updating the hypervisor. NOTE: this is a copy of UpdateComponent with
+ * the changes needed for updating the hypervisor instead of a node. As the hypervisor is going
+ * to be integration in the visors in the near future, this component will no longer be needed.
+ */
+@Component({
+  selector: 'app-update-hypervisor',
+  templateUrl: './update-hypervisor.component.html',
+  styleUrls: ['./update-hypervisor.component.scss'],
+})
+export class UpdateHypervisorComponent implements AfterViewInit, OnDestroy {
+  // Current state of the window.
+  state = UpdatingStates.InitialProcessing;
+
+  // Text to show in the cancel button.
+  cancelButtonText = 'common.cancel';
+  // Text to show in the confirm button.
+  confirmButtonText: string;
+  // Error msg to show if the current state is UpdatingStates.Error.
+  errorText: string;
+  // If no updates were found, this var contains the current version of the hypervisor.
+  currentVersion: string;
+
+  progressInfo = new UpdateProgressInfo();
+
+  // Update found.
+  updateFound: UpdateVersion;
+
+  updatingStates = UpdatingStates;
+
+  private subscription: Subscription;
+  private progressSubscription: Subscription;
+  private uiUpdateSubscription: Subscription;
+
+  /**
+   * Opens the modal window. Please use this function instead of opening the window "by hand".
+   */
+  public static openDialog(dialog: MatDialog): MatDialogRef<UpdateHypervisorComponent, any> {
+    const config = new MatDialogConfig();
+    config.autoFocus = false;
+    config.width = AppConfig.smallModalWidth;
+
+    return dialog.open(UpdateHypervisorComponent, config);
+  }
+
+  constructor(
+    private dialogRef: MatDialogRef<UpdateHypervisorComponent>,
+    private nodeService: NodeService,
+    private translateService: TranslateService,
+    private changeDetectorRef: ChangeDetectorRef,
+  ) { }
+
+  ngAfterViewInit() {
+    this.startChecking();
+  }
+
+  /**
+   * Checks if the hypervisor is already being updated.
+   */
+  private startChecking() {
+    // NOTE: This code is needed for checking if the hypervisor is currently being updated, but
+    // is commented due to a bug with the Hypervisor API. Must be reactivated, and the last
+    // cuerrently uncommented line deleted, after the bug is solved.
+    /*
+    this.subscription = this.nodeService.checkIfUpdating(null).subscribe(result => {
+      if (result.running) {
+        this.update();
+      } else {
+        this.checkUpdates();
+      }
+    }, (err: OperationError) => {
+      this.changeState(UpdatingStates.Error);
+      this.errorText = processServiceError(err).translatableErrorMsg;
+    });
+    */
+    this.checkUpdates();
+  }
+
+  /**
+   * Checks if there are updates available for the hypervisor.
+   */
+  private checkUpdates() {
+    this.subscription = this.nodeService.checkUpdate(null).subscribe(result => {
+      if (result && result.available) {
+        // Save the update.
+        this.updateFound = {
+          currentVersion: result.current_version ?
+          result.current_version : this.translateService.instant('common.unknown'),
+          newVersion: result.available_version,
+        };
+
+        // Go to the next step.
+        this.changeState(UpdatingStates.Asking);
+      } else {
+        this.changeState(UpdatingStates.NoUpdatesFound);
+      }
+    }, (err: OperationError) => {
+      this.changeState(UpdatingStates.Error);
+      this.errorText = processServiceError(err).translatableErrorMsg;
+    });
+  }
+
+  /**
+   * Calls the update API endpoint for the hypervisor. This makes the update procedure to start,
+   * if it was not already started, and starts showing the progress.
+   */
+  update() {
+    this.changeState(UpdatingStates.Updating);
+
+    this.progressInfo.rawMsg = this.translateService.instant('update.starting');
+
+    this.progressSubscription = this.nodeService.update(null).subscribe(response => {
+      // Update the progress.
+      this.updateProgressInfo(response.status);
+    }, (err: OperationError) => {
+      // Save the error msg.
+      this.progressInfo.errorMsg = processServiceError(err).translatableErrorMsg;
+    }, () => {
+      // Indicate that the connection has been closed.
+      this.progressInfo.closed = true;
+    });
+  }
+
+  /**
+   * Tries to parse a response returned by the backend and updates the values of
+   * this.progressInfo with the info it was able to recover.
+   * @param progressMsg Response returned by the backend.
+   */
+  private updateProgressInfo(progressMsg: string) {
+    // Save basic data.
+    this.progressInfo.rawMsg = progressMsg;
+    this.progressInfo.dataParsed = false;
+
+    // Try to get the indexes of parts which are expected to be found in the response.
+    const downloadingIndex = progressMsg.indexOf('Downloading');
+    const initialSpeedIndex = progressMsg.lastIndexOf('(');
+    const finalSpeedIndex = progressMsg.lastIndexOf(')');
+    const initialTimeIndex = progressMsg.lastIndexOf('[');
+    const finalTimeIndex = progressMsg.lastIndexOf(']');
+    const timeSeparatorIndex = progressMsg.lastIndexOf(':');
+    const progressPercentageIndex = progressMsg.lastIndexOf('%');
+
+    // Continue only if all indexes were found.
+    if (
+      downloadingIndex !== -1 &&
+      initialSpeedIndex !== -1 &&
+      finalSpeedIndex !== -1 &&
+      initialTimeIndex !== -1 &&
+      finalTimeIndex !== -1 &&
+      timeSeparatorIndex !== -1
+    ) {
+      // Additional security checks.
+      let errorFound = false;
+      if (initialSpeedIndex > finalSpeedIndex) {
+        errorFound = true;
+      }
+      if (initialTimeIndex > timeSeparatorIndex) {
+        errorFound = true;
+      }
+      if (timeSeparatorIndex > finalTimeIndex) {
+        errorFound = true;
+      }
+      if (progressPercentageIndex > initialSpeedIndex || progressPercentageIndex < downloadingIndex) {
+        errorFound = true;
+      }
+
+      // Try to get all the data.
+      try {
+        if (!errorFound) {
+          const initialFileIndex = downloadingIndex + 'Downloading'.length + 1;
+          const finalFileIndex = progressMsg.indexOf(' ', initialFileIndex);
+
+          if (initialFileIndex !== -1 && finalFileIndex !== -1) {
+            this.progressInfo.fileName = progressMsg.substring(initialFileIndex, finalFileIndex);
+          } else {
+            errorFound = true;
+          }
+        }
+
+        if (!errorFound) {
+          this.progressInfo.speed = progressMsg.substring(initialSpeedIndex + 1, finalSpeedIndex);
+          this.progressInfo.elapsedTime = progressMsg.substring(initialTimeIndex + 1, timeSeparatorIndex);
+          this.progressInfo.remainingTime = progressMsg.substring(timeSeparatorIndex + 1, finalTimeIndex);
+
+          const initialProgressIndex = progressMsg.lastIndexOf(' ', progressPercentageIndex);
+          this.progressInfo.progress = Number(progressMsg.substring(initialProgressIndex + 1, progressPercentageIndex));
+        }
+      } catch (e) {
+        errorFound = true;
+      }
+
+      if (!errorFound) {
+        // Indicate that the response was corrently parsed only if all data was obtained.
+        this.progressInfo.dataParsed = true;
+      }
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+    if (this.uiUpdateSubscription) {
+      this.uiUpdateSubscription.unsubscribe();
+    }
+    if (this.progressSubscription) {
+      this.progressSubscription.unsubscribe();
+    }
+  }
+
+  closeModal() {
+    this.dialogRef.close();
+  }
+
+  /**
+   * Changes the current state of the window. Depending on the new state, it updates some other
+   * properties to ensure the new state is correctly shown.
+   */
+  private changeState(newState: UpdatingStates) {
+    this.state = newState;
+
+    // Update the buttons depending on the new state.
+    if (newState === UpdatingStates.Error) {
+      this.confirmButtonText = 'common.close';
+      this.cancelButtonText = '';
+    } else if (newState === UpdatingStates.Asking) {
+      this.confirmButtonText = 'update-hypervisor.install';
+      this.cancelButtonText = 'common.cancel';
+    } else if (newState === UpdatingStates.NoUpdatesFound) {
+      this.confirmButtonText = 'common.close';
+      this.cancelButtonText = '';
+    } else if (newState === UpdatingStates.Updating) {
+      this.confirmButtonText = 'common.close';
+      this.cancelButtonText = '';
+
+      // Ensure the changes in the properties are shown in the UI periodically.
+      this.uiUpdateSubscription = interval(1000).subscribe(() => this.changeDetectorRef.detectChanges());
+    }
+  }
+}

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
@@ -152,9 +152,6 @@ export class UpdateComponent implements AfterViewInit, OnDestroy {
 
   /**
    * Opens the modal window. Please use this function instead of opening the window "by hand".
-   */
-  /**
-   * Opens the modal window. Please use this function instead of opening the window "by hand".
    * @param nodes Nodes to update.
    */
   public static openDialog(dialog: MatDialog, nodes: NodeData[]): MatDialogRef<UpdateComponent, any> {
@@ -236,7 +233,7 @@ export class UpdateComponent implements AfterViewInit, OnDestroy {
       }
     });
 
-    // Check iof there are updates.
+    // Check if there are updates.
     this.subscription = forkJoin(nodesToCheck.map(node => this.nodeService.checkUpdate(node.key))).subscribe(versionsResponse => {
       // Contains the list of all updates found, without repetitions.
       const updates = new Map<string, boolean>();

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -21,6 +21,7 @@ import { LabeledElementTextComponent } from '../../layout/labeled-element-text/l
 import { SortingModes, SortingColumn, DataSorter } from 'src/app/utils/lists/data-sorter';
 import { DataFilterer } from 'src/app/utils/lists/data-filterer';
 import { UpdateComponent, NodeData } from '../../layout/update/update.component';
+import { UpdateHypervisorComponent } from '../../layout/update-hypervisor/update-hypervisor.component';
 
 /**
  * Page for showing the node list.
@@ -204,8 +205,13 @@ export class NodeListComponent implements OnInit, OnDestroy {
     // Options for the menu shown in the top bar.
     this.options = [
       {
+        name: 'nodes.update-hypervisor',
+        actionName: 'updateHypervisor',
+        icon: 'get_app'
+      },
+      {
         name: 'nodes.update-all',
-        actionName: 'update',
+        actionName: 'updateAll',
         icon: 'get_app'
       },
       {
@@ -259,8 +265,10 @@ export class NodeListComponent implements OnInit, OnDestroy {
   performAction(actionName: string) {
     if (actionName === 'logout') {
       this.logout();
-    } else if (actionName === 'update') {
+    } else if (actionName === 'updateAll') {
       this.updateAll();
+    } else if (actionName === 'updateHypervisor') {
+      this.updateHypervisor();
     }
   }
 
@@ -420,6 +428,11 @@ export class NodeListComponent implements OnInit, OnDestroy {
     });
 
     UpdateComponent.openDialog(this.dialog, nodesData);
+  }
+
+  // Updates the hypervisor.
+  updateHypervisor() {
+    UpdateHypervisorComponent.openDialog(this.dialog);
   }
 
   /**

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.html
@@ -15,5 +15,9 @@
     <app-label-list
       [showShortList]="true">
     </app-label-list>
+    <div class="d-block mt-4" *ngIf="!mustShowUpdaterSettings" (click)="showUpdaterSettings()">
+      <span class="show-link">{{ 'settings.updater-config.open-link' | translate }}</span>
+    </div>
+    <app-updater-config class="d-block mt-4" *ngIf="mustShowUpdaterSettings"></app-updater-config>
   </div>
 </div>

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.scss
@@ -1,0 +1,6 @@
+@import "variables";
+
+.show-link {
+  cursor: pointer;
+  font-size: $font-size-smaller;
+}

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
@@ -6,6 +6,7 @@ import { TabButtonData, MenuOptionData } from '../../layout/top-bar/top-bar.comp
 import { AuthService } from '../../../services/auth.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import GeneralUtils from 'src/app/utils/generalUtils';
+import { UpdaterStorageKeys } from 'src/app/services/node.service';
 
 /**
  * Page with the general settings of the app.
@@ -18,6 +19,7 @@ import GeneralUtils from 'src/app/utils/generalUtils';
 export class SettingsComponent {
   tabsData: TabButtonData[] = [];
   options: MenuOptionData[] = [];
+  mustShowUpdaterSettings = !!localStorage.getItem(UpdaterStorageKeys.UseCustomSettings);
 
   constructor(
     private authService: AuthService,
@@ -74,6 +76,17 @@ export class SettingsComponent {
         () => this.router.navigate(['login']),
         () => this.snackbarService.showError('common.logout-error')
       );
+    });
+  }
+
+  // Opens the updater settings, if the user confirms the operation.
+  showUpdaterSettings() {
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'settings.updater-config.open-confirmation');
+
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      confirmationDialog.close();
+
+      this.mustShowUpdaterSettings = true;
     });
   }
 }

--- a/static/skywire-manager-src/src/app/components/pages/settings/updater-config/updater-config.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/settings/updater-config/updater-config.component.html
@@ -1,0 +1,44 @@
+<div class="rounded-elevated-box"><div class="box-internal-container overflow">
+  <!-- Help icon. -->
+  <div class="white-form-help-icon-container">
+    <mat-icon [inline]="true" [matTooltip]="'settings.updater-config.help' | translate">
+      help
+    </mat-icon>
+  </div>
+  <!-- Form. -->
+  <form [formGroup]="form">
+    <mat-form-field class="white-form-field">
+      <input formControlName="channel" [placeholder]="'settings.updater-config.channel' | translate" maxlength="255" matInput>
+    </mat-form-field>
+
+    <mat-form-field class="white-form-field">
+      <input formControlName="version" [placeholder]="'settings.updater-config.version' | translate" maxlength="255" matInput>
+    </mat-form-field>
+
+    <mat-form-field class="white-form-field">
+      <input formControlName="archiveURL" [placeholder]="'settings.updater-config.archive-url' | translate" maxlength="255" matInput>
+    </mat-form-field>
+
+    <mat-form-field class="white-form-field">
+      <input formControlName="checksumsURL" [placeholder]="'settings.updater-config.checksum-url' | translate" maxlength="255" matInput>
+    </mat-form-field>
+
+    <div class="mt-2 buttons-area">
+      <!-- Alert shown when there are unsaved changes. -->
+      <div class="text-area red-text">
+        <span *ngIf="dataChanged">
+          <mat-icon [inline]="true">warning</mat-icon>
+          {{ 'settings.updater-config.not-saved' | translate }}
+        </span>
+      </div>
+
+      <!-- Buttons. -->
+      <app-button class="app-button left-button" color="primary" (action)="removeSettings()" [forDarkBackground]="true" [disabled]="!hasCustomSettings">
+        {{ 'settings.updater-config.remove-settings' | translate }}
+      </app-button>
+      <app-button class="app-button" color="primary" (action)="saveSettings()" [forDarkBackground]="true" [disabled]="!dataChanged">
+        {{ 'settings.updater-config.save' | translate }}
+      </app-button>
+    </div>
+  </form>
+</div></div>

--- a/static/skywire-manager-src/src/app/components/pages/settings/updater-config/updater-config.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/settings/updater-config/updater-config.component.scss
@@ -1,0 +1,55 @@
+@import "variables";
+@import "bootstrap_overrides";
+
+mat-form-field {
+  margin-right: 32px;
+}
+
+.buttons-area {
+  display: flex;
+
+  @media (max-width: (map-get($grid-breakpoints, md) -  1)) {
+    & {
+      flex-direction: column;
+      align-items: flex-end;
+    }
+  }
+
+  .text-area {
+    margin-right: auto;
+    flex-grow: 1;
+
+    @media (max-width: (map-get($grid-breakpoints, md) -  1)) {
+      & {
+        margin-right: 32px !important;
+      }
+    }
+
+    mat-icon {
+      position: relative;
+      top: 1px;
+    }
+  }
+
+  app-button {
+    float: right;
+    margin-right: 32px;
+    flex-grow: 0;
+
+    @media (max-width: (map-get($grid-breakpoints, md) -  1)) {
+      & {
+        margin-top: 10px;
+      }
+    }
+  }
+
+  .left-button {
+    margin-right: 5px !important;
+
+    @media (max-width: (map-get($grid-breakpoints, md) -  1)) {
+      & {
+        margin-right: 32px !important;
+      }
+    }
+  }
+}

--- a/static/skywire-manager-src/src/app/components/pages/settings/updater-config/updater-config.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/updater-config/updater-config.component.ts
@@ -1,0 +1,141 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
+
+import { SnackbarService } from '../../../../services/snackbar.service';
+import { UpdaterStorageKeys } from 'src/app/services/node.service';
+import GeneralUtils from 'src/app/utils/generalUtils';
+
+/**
+ * Allows to set a custom configuration for the calls to the updater API endpoint.
+ */
+@Component({
+  selector: 'app-updater-config',
+  templateUrl: './updater-config.component.html',
+  styleUrls: ['./updater-config.component.scss']
+})
+export class UpdaterConfigComponent implements OnInit, OnDestroy {
+  form: FormGroup;
+
+  // If there are custom settings saved in the app.
+  hasCustomSettings: boolean;
+
+  // Values currently saved in the app.
+  private initialChannel: string;
+  private initialVersion: string;
+  private initialArchiveURL: string;
+  private initialChecksumsURL: string;
+
+  private subscription: Subscription;
+
+  constructor(
+    private snackbarService: SnackbarService,
+    private dialog: MatDialog,
+  ) { }
+
+  ngOnInit() {
+    // Get the currently saved data.
+    this.initialChannel = localStorage.getItem(UpdaterStorageKeys.Channel);
+    this.initialVersion = localStorage.getItem(UpdaterStorageKeys.Version);
+    this.initialArchiveURL = localStorage.getItem(UpdaterStorageKeys.ArchiveURL);
+    this.initialChecksumsURL = localStorage.getItem(UpdaterStorageKeys.ChecksumsURL);
+    if (!this.initialChannel) { this.initialChannel = ''; }
+    if (!this.initialVersion) { this.initialVersion = ''; }
+    if (!this.initialArchiveURL) { this.initialArchiveURL = ''; }
+    if (!this.initialChecksumsURL) { this.initialChecksumsURL = ''; }
+
+    this.hasCustomSettings =
+      !!this.initialChannel ||
+      !!this.initialVersion ||
+      !!this.initialArchiveURL ||
+      !!this.initialChecksumsURL;
+
+    this.form = new FormGroup({
+      'channel': new FormControl(this.initialChannel),
+      'version': new FormControl(this.initialVersion),
+      'archiveURL': new FormControl(this.initialArchiveURL),
+      'checksumsURL': new FormControl(this.initialChecksumsURL),
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  // Allows to know if the user has modified the data in the form.
+  get dataChanged(): boolean {
+    return this.initialChannel !== (this.form.get('channel').value as string).trim() ||
+      this.initialVersion !== (this.form.get('version').value as string).trim() ||
+      this.initialArchiveURL !== (this.form.get('archiveURL').value as string).trim() ||
+      this.initialChecksumsURL !== (this.form.get('checksumsURL').value as string).trim();
+  }
+
+  // Saves the settings entered in the form.
+  saveSettings() {
+    // Get the data entered in the form.
+    const channel = (this.form.get('channel').value as string).trim();
+    const version = (this.form.get('version').value as string).trim();
+    const archiveURL = (this.form.get('archiveURL').value as string).trim();
+    const checksumsURL = (this.form.get('checksumsURL').value as string).trim();
+
+    if (channel || version || archiveURL || checksumsURL) {
+      // Ask for confirmation.
+      const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'settings.updater-config.save-confirmation');
+
+      confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+        confirmationDialog.close();
+
+        // Save the data and update the form.
+        this.initialChannel = channel;
+        this.initialVersion = version;
+        this.initialArchiveURL = archiveURL;
+        this.initialChecksumsURL = checksumsURL;
+
+        this.hasCustomSettings = true;
+
+        localStorage.setItem(UpdaterStorageKeys.UseCustomSettings, 'true');
+        localStorage.setItem(UpdaterStorageKeys.Channel, channel);
+        localStorage.setItem(UpdaterStorageKeys.Version, version);
+        localStorage.setItem(UpdaterStorageKeys.ArchiveURL, archiveURL);
+        localStorage.setItem(UpdaterStorageKeys.ChecksumsURL, checksumsURL);
+
+        this.snackbarService.showDone('settings.updater-config.saved');
+      });
+    } else {
+      // If all fields are empty, erase the custom settings.
+      this.removeSettings();
+    }
+  }
+
+  // Removes the custom settings and cleans the form.
+  removeSettings() {
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'settings.updater-config.remove-confirmation');
+
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      confirmationDialog.close();
+
+      this.initialChannel = '';
+      this.initialVersion = '';
+      this.initialArchiveURL = '';
+      this.initialChecksumsURL = '';
+
+      this.form.get('channel').setValue('');
+      this.form.get('version').setValue('');
+      this.form.get('archiveURL').setValue('');
+      this.form.get('checksumsURL').setValue('');
+
+      this.hasCustomSettings = false;
+
+      localStorage.removeItem(UpdaterStorageKeys.UseCustomSettings);
+      localStorage.removeItem(UpdaterStorageKeys.Channel);
+      localStorage.removeItem(UpdaterStorageKeys.Version);
+      localStorage.removeItem(UpdaterStorageKeys.ArchiveURL);
+      localStorage.removeItem(UpdaterStorageKeys.ChecksumsURL);
+
+      this.snackbarService.showDone('settings.updater-config.removed');
+    });
+  }
+}

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Observable, Subscription, BehaviorSubject, of, throwError } from 'rxjs';
+import { Observable, Subscription, BehaviorSubject, of } from 'rxjs';
 import { flatMap, map, mergeMap, delay, tap } from 'rxjs/operators';
 import BigNumber from 'bignumber.js';
 
@@ -59,6 +59,20 @@ export class TrafficData {
    * but the service will try it best to provided good data.
    */
   receivedHistory: number[] = [];
+}
+
+/**
+ * Keys for saving custom settings for the calls to the updater API endpoints.
+ */
+export enum UpdaterStorageKeys {
+  /**
+   * If has a value, at least one of the other keys have a value.
+   */
+  UseCustomSettings = 'updaterUseCustomSettings',
+  Channel = 'updaterChannel',
+  Version = 'updaterVersion',
+  ArchiveURL = 'updaterArchiveURL',
+  ChecksumsURL = 'updaterChecksumsURL',
 }
 
 /**
@@ -646,6 +660,19 @@ export class NodeService {
       channel: 'stable'
       // channel: 'testing' // for debugging updater
     };
+
+    // Use any custom settings saved by the user.
+    const useCustomSettings = localStorage.getItem(UpdaterStorageKeys.UseCustomSettings);
+    if (useCustomSettings) {
+      const channel = localStorage.getItem(UpdaterStorageKeys.Channel);
+      if (channel) { body['channel'] = channel; }
+      const version = localStorage.getItem(UpdaterStorageKeys.Version);
+      if (version) { body['version'] = version; }
+      const archiveURL = localStorage.getItem(UpdaterStorageKeys.ArchiveURL);
+      if (archiveURL) { body['archive_url'] = archiveURL; }
+      const checksumsURL = localStorage.getItem(UpdaterStorageKeys.ChecksumsURL);
+      if (checksumsURL) { body['checksums_url'] = checksumsURL; }
+    }
 
     if (!nodeKey) {
       return this.apiService.ws(`update/ws`, body);

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -615,27 +615,41 @@ export class NodeService {
   }
 
   /**
-   * Checks if there are updates available for a node.
+   * Checks if a node is currently being updated. If no node key is provided, checks if the
+   * hypervisor is currently being updated.
    */
   checkIfUpdating(nodeKey: string): Observable<any> {
+    if (!nodeKey) {
+      return this.apiService.get(`update/ws/running`);
+    }
+
     return this.apiService.get(`visors/${nodeKey}/update/ws/running`);
   }
 
   /**
-   * Checks if there are updates available for a node.
+   * Checks if there are updates available for a node. If no node key is provided, checks if
+   * there are updates available for the hypervisor.
    */
   checkUpdate(nodeKey: string): Observable<any> {
+    if (!nodeKey) {
+      return this.apiService.post(`update/available`);
+    }
+
     return this.apiService.get(`visors/${nodeKey}/update/available`);
   }
 
   /**
-   * Updates a node.
+   * Updates a node. If no node key is provided, updates the hypervisor.
    */
   update(nodeKey: string): Observable<any> {
     const body = {
       channel: 'stable'
       // channel: 'testing' // for debugging updater
     };
+
+    if (!nodeKey) {
+      return this.apiService.ws(`update/ws`, body);
+    }
 
     return this.apiService.ws(`visors/${nodeKey}/update/ws`, body);
   }

--- a/static/skywire-manager-src/src/app/utils/errors.ts
+++ b/static/skywire-manager-src/src/app/utils/errors.ts
@@ -57,7 +57,7 @@ export function processErrorMsg(msg: string): string {
  */
 export function processServiceError(error: any): OperationError {
   // Check if the provided error is already an OperationError instance.
-  if (error && error.type) {
+  if (error && error.type && !error.srcElement) {
     return error;
   }
 

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -201,6 +201,22 @@
         "default-password": "Don't use the default password (1234)."
       }
     },
+    "updater-config" : {
+      "open-link": "Show updater settings",
+      "open-confirmation": "The updater settings are for experienced users only. Are you sure you want to continue?",
+      "help": "Use this form for overriding the settings that will be used by the updater. All empty fields will be ignored. The settings will be used for all updating operations, no mater which element is being updated, so please be careful.",
+      "channel": "Channel",
+      "version": "Version",
+      "archive-url": "Archive URL",
+      "checksum-url": "Checksum URL",
+      "not-saved": "The changes have not been saved yet.",
+      "save": "Save changes",
+      "remove-settings": "Remove the settings",
+      "saved": "The custom settings have been saved.",
+      "removed": "The custom settings have been removed.",
+      "save-confirmation": "Are you sure you want to apply the custom settings?",
+      "remove-confirmation": "Are you sure you want to remove the custom settings?"
+    },
     "change-password": "Change password",
     "refresh-rate": "Refresh rate",
     "refresh-rate-help": "Time the system waits to update the data automatically.",

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -131,7 +131,8 @@
   "nodes": {
     "title": "Visor list",
     "dmsg-title": "DMSG",
-    "update-all": "Update all",
+    "update-hypervisor": "Update hypervisor",
+    "update-all": "Update all visors",
     "state": "State",
     "state-tooltip": "Current state",
     "label": "Label",
@@ -257,6 +258,17 @@
     "starting": "Preparing to update",
     "finished": "Status connection finished",
     "install": "Install updates"
+  },
+
+  "update-hypervisor": {
+    "title": "Update Hypervisor",
+    "label": "Hypervisor",
+    "processing": "Looking for updates...",
+    "no-update": "There is no update for the hypervisor. The currently installed version is:",
+    "update-available": "The following update was found:",
+    "update-instructions": "Click the 'Install update' button to continue.",
+    "updating": "The update operation has been started, you can open this window again for checking the progress:",
+    "install": "Install update"
   },
 
   "apps": {

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -128,7 +128,8 @@
   "nodes": {
     "title": "Lista de visores",
     "dmsg-title": "DMSG",
-    "update-all": "Actualizar todo",
+    "update-hypervisor": "Actualizar hypervisor",
+    "update-all": "Actualizar todos los visores",
     "state": "Estado",
     "state-tooltip": "Estado actual",
     "label": "Etiqueta",
@@ -254,6 +255,17 @@
     "starting": "Preparando para actualizar",
     "finished": "Conexión de estado terminada",
     "install": "Instalar actualizaciones"
+  },
+
+  "update-hypervisor": {
+    "title": "Actualizar Hypervisor",
+    "label": "Hypervisor",
+    "processing": "Buscando actualizaciones...",
+    "no-update": "No hay ninguna actualización para el hypervisor. La versión instalada actualmente es:",
+    "update-available": "Las siguiente actualización fue encontrada:",
+    "update-instructions": "Haga clic en el botón 'Instalar actualización' para continuar.",
+    "updating": "La operación de actualización se ha iniciado, puede abrir esta ventana nuevamente para verificar el progreso:",
+    "install": "Instalar actualización"
   },
 
   "apps": {

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -198,6 +198,22 @@
         "default-password": "No utilice la contraseña por defecto (1234)."
       }
     },
+    "updater-config" : {
+      "open-link": "Mostrar la configuración del actualizador",
+      "open-confirmation": "La configuración del actualizador es sólo para usuarios experimentados. Seguro que desea continuar?",
+      "help": "Utilice este formulario para modificar la configuración que utilizará el actualizador. Se ignorarán todos los campos vacíos. La configuración se utilizará para todas las operaciones de actualización, sin importar qué elemento se esté actualizando, así que por favor tenga cuidado.",
+      "channel": "Canal",
+      "version": "Versión",
+      "archive-url": "URL del archivo",
+      "checksum-url": "URL del checksum",
+      "not-saved": "Los cambios aún no se han guardado.",
+      "save": "Guardar cambios",
+      "remove-settings": "Remover la configuración",
+      "saved": "Las configuracion personalizada ha sido guardada.",
+      "removed": "Las configuracion personalizada ha sido removida.",
+      "save-confirmation": "¿Seguro que desea aplicar la configuración personalizada?",
+      "remove-confirmation": "¿Seguro que desea remover la configuración personalizada?"
+    },
     "change-password": "Cambiar contraseña",
     "refresh-rate": "Frecuencia de refrescado",
     "refresh-rate-help": "Tiempo que el sistema espera para actualizar automáticamente los datos.",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -198,6 +198,22 @@
         "default-password": "Don't use the default password (1234)."
       }
     },
+    "updater-config" : {
+      "open-link": "Show updater settings",
+      "open-confirmation": "The updater settings are for experienced users only. Are you sure you want to continue?",
+      "help": "Use this form for overriding the settings that will be used by the updater. All empty fields will be ignored. The settings will be used for all updating operations, no mater which element is being updated, so please be careful.",
+      "channel": "Channel",
+      "version": "Version",
+      "archive-url": "Archive URL",
+      "checksum-url": "Checksum URL",
+      "not-saved": "The changes have not been saved yet.",
+      "save": "Save changes",
+      "remove-settings": "Remove the settings",
+      "saved": "The custom settings have been saved.",
+      "removed": "The custom settings have been removed.",
+      "save-confirmation": "Are you sure you want to apply the custom settings?",
+      "remove-confirmation": "Are you sure you want to remove the custom settings?"
+    },
     "change-password": "Change password",
     "refresh-rate": "Refresh rate",
     "refresh-rate-help": "Time the system waits to update the data automatically.",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -128,7 +128,8 @@
   "nodes": {
     "title": "Visor list",
     "dmsg-title": "DMSG",
-    "update-all": "Update all",
+    "update-hypervisor": "Update hypervisor",
+    "update-all": "Update all visors",
     "state": "State",
     "state-tooltip": "Current state",
     "label": "Label",
@@ -254,6 +255,17 @@
     "starting": "Preparing to update",
     "finished": "Status connection finished",
     "install": "Install updates"
+  },
+
+  "update-hypervisor": {
+    "title": "Update Hypervisor",
+    "label": "Hypervisor",
+    "processing": "Looking for updates...",
+    "no-update": "There is no update for the hypervisor. The currently installed version is:",
+    "update-available": "The following update was found:",
+    "update-instructions": "Click the 'Install update' button to continue.",
+    "updating": "The update operation has been started, you can open this window again for checking the progress:",
+    "install": "Install update"
   },
 
   "apps": {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- An option for updating the hypervisor was added to the menu in the visor list.
- An option for configuring the updater was added to the settings page. For accessing it, you must click the "Show updater settings" link at the bottom of the page.

How to test this PR:
Test the hypervisor updater using the option in the visor list. Test the updater settings using the form at the bottom of the settings page.

Note 1: https://github.com/skycoin/skywire/issues/476 must be solved for the hypervisor update procedure to work totally well.

Note 2: the control for updating the hypervisor has a lot of repeated code from the control for updating a visor. This was made to avoid overcomplicating the control user for updating the visors, as the operation for updating the hypervisor will not be needed after some time.