### PR TITLE
Add an option for removing all offline transports

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -55,7 +55,7 @@
             *ngIf="dataSource.length > 0"
           >more_horiz</mat-icon>
           <mat-menu #selectionMenu="matMenu" [overlapTrigger]="false">
-            <div mat-menu-item (click)="removeOffline()">
+            <div mat-menu-item disabled="{{ !hasOfflineNodes }}" (click)="removeOffline()">
               {{ 'nodes.delete-all-offline' | translate }}
             </div>
           </mat-menu>

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -58,6 +58,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
   allNodes: Node[];
   filteredNodes: Node[];
   nodesToShow: Node[];
+  hasOfflineNodes = false;
   numberOfPages = 1;
   currentPage = 1;
   // Used as a helper var, as the URL is read asynchronously.
@@ -165,6 +166,15 @@ export class NodeListComponent implements OnInit, OnDestroy {
     );
     this.dataFiltererSubscription = this.dataFilterer.dataFiltered.subscribe(data => {
       this.filteredNodes = data;
+
+      // Check if there are offline nodes.
+      this.hasOfflineNodes = false;
+      this.filteredNodes.forEach(node => {
+        if (!node.online) {
+          this.hasOfflineNodes = true;
+        }
+      });
+
       this.dataSorter.setData(this.filteredNodes);
     });
 
@@ -583,14 +593,19 @@ export class NodeListComponent implements OnInit, OnDestroy {
    * Removes all offline nodes from the list, until seeing them online again.
    */
   removeOffline() {
-    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'nodes.delete-all-offline-confirmation');
+    let confirmationText = 'nodes.delete-all-offline-confirmation';
+    if (this.dataFilterer.currentFiltersTexts && this.dataFilterer.currentFiltersTexts.length > 0) {
+      confirmationText = 'nodes.delete-all-filtered-offline-confirmation';
+    }
+
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, confirmationText);
 
     confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
       confirmationDialog.close();
 
       // Prepare all offline nodes to be removed.
       const nodesToRemove: string[] = [];
-      this.allNodes.forEach(node => {
+      this.filteredNodes.forEach(node => {
         if (!node.online) {
           nodesToRemove.push(node.local_pk);
         }
@@ -607,8 +622,6 @@ export class NodeListComponent implements OnInit, OnDestroy {
         } else {
           this.snackbarService.showDone('nodes.deleted-plural', { number: nodesToRemove.length });
         }
-      } else {
-        this.snackbarService.showWarning('nodes.no-offline-nodes');
       }
     });
   }

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.html
@@ -32,6 +32,9 @@
         *ngIf="dataSource && dataSource.length > 0"
       >more_horiz</mat-icon>
       <mat-menu #selectionMenu="matMenu" [overlapTrigger]="false">
+        <div mat-menu-item disabled="{{ !hasOfflineTransports }}" (click)="removeOffline()">
+          {{ 'transports.remove-all-offline' | translate }}
+        </div>
         <div mat-menu-item (click)="changeAllSelections(true)">
           {{ 'selection.select-all' | translate }}
         </div>

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -149,10 +149,10 @@
     "empty-with-filter": "No visor matches the selected filtering criteria.",
     "delete-node-confirmation": "Are you sure you want to remove the visor from the list?",
     "delete-all-offline-confirmation": "Are you sure you want to remove all offline visors from the list?",
+    "delete-all-filtered-offline-confirmation": "All offline visors satisfying the current filtering criteria will be removed from the list. Are you sure you want to continue?",
     "deleted": "Visor removed.",
     "deleted-singular": "1 offline visor removed.",
     "deleted-plural": "{{ number }} offline visors removed.",
-    "no-offline-nodes": "No offline visors found.",
     "no-visors-to-update": "There are no visors to update.",
     "filter-dialog": {
       "online": "The visor must be",
@@ -384,6 +384,9 @@
 
   "transports": {
     "title": "Transports",
+    "remove-all-offline": "Remove all offline transports",
+    "remove-all-offline-confirmation": "Are you sure you want to remove all offline transports?",
+    "remove-all-filtered-offline-confirmation": "All offline transports satisfying the current filtering criteria will be removed. Are you sure you want to continue?",
     "info": "Connections you have with remote Skywire visors, to allow local Skywire apps to communicate with apps running on those remote visors.",
     "list-title": "Transport list",
     "state": "State",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -146,6 +146,7 @@
     "empty-with-filter": "Ningun visor coincide con los criterios de filtrado seleccionados.",
     "delete-node-confirmation": "¿Seguro que desea remover el visor de la lista?",
     "delete-all-offline-confirmation": "¿Seguro que desea remover todos los visores offline de la lista?",
+    "delete-all-filtered-offline-confirmation": "Todos los visores offline que satisfagan los criterios de filtrado actuales serán removidos de la lista. ¿Seguro que desea continuar?",
     "deleted": "Visor removido.",
     "deleted-singular": "1 visor offline removido.",
     "deleted-plural": "{{ number }} visores offline removidos.",
@@ -381,6 +382,9 @@
 
   "transports": {
     "title": "Transportes",
+    "remove-all-offline": "Remover todos los transportes offline",
+    "remove-all-offline-confirmation": "¿Seguro que desea remover todos los transportes offline?",
+    "remove-all-filtered-offline-confirmation": "Todos los transportes offline que satisfagan los criterios de filtrado actuales serán removidos. ¿Seguro que desea continuar?",
     "list-title": "Lista de transportes",
     "state": "Estado",
     "state-tooltip": "Estado actual",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -146,6 +146,7 @@
     "empty-with-filter": "No visor matches the selected filtering criteria.",
     "delete-node-confirmation": "Are you sure you want to remove the visor from the list?",
     "delete-all-offline-confirmation": "Are you sure you want to remove all offline visors from the list?",
+    "delete-all-filtered-offline-confirmation": "All offline visors satisfying the current filtering criteria will be removed from the list. Are you sure you want to continue?",
     "deleted": "Visor removed.",
     "deleted-singular": "1 offline visor removed.",
     "deleted-plural": "{{ number }} offline visors removed.",
@@ -381,6 +382,9 @@
 
   "transports": {
     "title": "Transports",
+    "remove-all-offline": "Remove all offline transports",
+    "remove-all-offline-confirmation": "Are you sure you want to remove all offline transports?",
+    "remove-all-filtered-offline-confirmation": "All offline transports satisfying the current filtering criteria will be removed. Are you sure you want to continue?",
     "list-title": "Transport list",
     "state": "State",
     "state-tooltip": "Current state",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- The transport list now has an option for removing all offline transports. This helps to manage large amounts of unused transports when using the vpn apps.

- Now the option for removing all offline visors, in the visor list, takes into account the filters and shows an alert informing that. There are also some small UX improvements. The option for removings all offline transports also have those changes.

How to test this PR:
Using the Skywire manager, go to the transport list of a visor. The option is shown by clicking the button with the 3 horizontal dots at the top-right corner of the transport list.