### PR TITLE
Return non-zero status code if added transport is not up

### DIFF
--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -108,6 +108,10 @@ var addTpCmd = &cobra.Command{
 				logger.WithError(err).Fatalf("Failed to establish %v transport", transportType)
 			}
 
+			if !tp.IsUp {
+				logger.Fatalf("Established %v transport to %v with ID %v, but it isn't up", transportType, pk, tp.ID)
+			}
+
 			logger.Infof("Established %v transport to %v", transportType, pk)
 		} else {
 			transportTypes := []string{

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -385,7 +385,7 @@ func (n *Network) Dial(ctx context.Context, network string, pk cipher.PubKey, po
 
 		conn, err := client.Dial(ctx, pk, port)
 		if err != nil {
-			return nil, fmt.Errorf("sudph client: %w", err)
+			return nil, fmt.Errorf("dial: %w", err)
 		}
 
 		log.Infof("Dialed %v, conn local address %q, remote address %q", network, conn.LocalAddr(), conn.RemoteAddr())
@@ -411,7 +411,7 @@ func (n *Network) Listen(network string, port uint16) (*Listener, error) {
 
 		lis, err := client.Listen(port)
 		if err != nil {
-			return nil, fmt.Errorf("sudph client: %w", err)
+			return nil, fmt.Errorf("listen: %w", err)
 		}
 
 		return makeListener(lis, network), nil

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -239,6 +239,7 @@ func (rc *rpcClient) AddTransport(remote cipher.PubKey, tpType string, public bo
 		Public:   public,
 		Timeout:  timeout,
 	}, &summary)
+
 	return &summary, err
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

 Changes:	
- Return non-zero status code if added transport is not up

How to test this PR:
- Set up transport to a non-existing PK in the integration env