### PR TITLE
Fix bug with handshake error type

### DIFF
--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -220,11 +220,11 @@ func (c *client) acceptConn() error {
 
 	wrappedConn, err := tpconn.NewConn(connConfig)
 	if err != nil {
-		return fmt.Errorf("newConn: %w", err)
+		return err
 	}
 
 	if err := lis.Introduce(wrappedConn); err != nil {
-		return fmt.Errorf("introduce: %w", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Did you run `make format && make check`? Yes

 Changes:	
- Fix bug with handshake error type

How to test this PR:
- Run the integration env
- Run `nc localhost 9496` and send any data, e.g. `123<Enter>`. Repeat the same one more time.
- The second `nc` should exit correctly, not hang. `VisorA` shouldn't contain `stopped serving` logs