### PR TITLE
Fix missing port in address resolver response

### DIFF
--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -414,7 +414,12 @@ func (c *client) dialVisor(visorData arclient.VisorData) (net.Conn, error) {
 		}
 	}
 
-	return c.dial(visorData.RemoteAddr)
+	addr := visorData.RemoteAddr
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		addr = net.JoinHostPort(addr, visorData.Port)
+	}
+
+	return c.dial(addr)
 }
 
 // Listen creates a new listener for sudp.


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #493

 Changes:	
- Fix missing port in address resolver response

How to test this PR:
- Follow instructions in #493