### PR TITLE
Show the update links in the manager

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.html
@@ -15,7 +15,9 @@
 
   <!-- Current version, shown if no update was found. -->
   <div *ngIf="state === updatingStates.NoUpdatesFound" class="list-container">
-    - {{ currentNodeVersion ? currentNodeVersion : ('common.unknown' | translate) }}
+    <div class="list-element">
+      <div class="left-part">-</div><div class="right-part">{{ currentNodeVersion ? currentNodeVersion : ('common.unknown' | translate) }}</div>
+    </div>
   </div>
 
   <!-- Text asking for confirmation before installing the update. -->
@@ -24,7 +26,13 @@
       {{ 'update-hypervisor.update-available' | translate }}
     </div>
     <div class="list-container">
-      - {{ 'update.version-change' | translate:updateFound }}
+      <div class="list-element">
+        <div class="left-part">-</div>
+        <div class="right-part">
+          {{ 'update.version-change' | translate:updateFound }}
+          <a [href]="updateFound.updateLink" target="_blank" rel="noreferrer nofollow noopener">{{ updateFound.updateLink }}</a>
+        </div>
+      </div>
     </div>
     <div class="text-container">
       {{ 'update-hypervisor.update-instructions' | translate }}
@@ -40,9 +48,14 @@
     <div>
       <!-- Raw progress text shown if it was not possible to parse it for showing the progrss bar. -->
       <div *ngIf="!progressInfo.errorMsg && !progressInfo.dataParsed" class="list-container">
-        - <mat-spinner class="loading-indicator" [diameter]="12" *ngIf="!progressInfo.closed"></mat-spinner> {{ 'update-hypervisor.label' | translate }}
-        : <span class="details">{{ progressInfo.rawMsg }}</span>
-        <span *ngIf="progressInfo.closed" class="closed-indication">&nbsp;({{ 'update.finished' | translate }})</span>
+        <div class="list-element">
+          <div class="left-part">-</div>
+          <div class="right-part">
+            <mat-spinner class="loading-indicator" [diameter]="12" *ngIf="!progressInfo.closed"></mat-spinner> {{ 'update-hypervisor.label' | translate }}
+            : <span class="details">{{ progressInfo.rawMsg }}</span>
+            <span *ngIf="progressInfo.closed" class="closed-indication">&nbsp;({{ 'update.finished' | translate }})</span>
+          </div>
+        </div>
       </div>
       <!-- Progress bar. -->
       <div *ngIf="!progressInfo.errorMsg && progressInfo.dataParsed" class="progress-container">
@@ -75,7 +88,12 @@
       </div>
       <!-- Msg shown if there was an error during the operation. -->
       <div *ngIf="progressInfo.errorMsg" class="list-container">
-        - {{ 'update-hypervisor.label' | translate }}: <span class="red-text">{{ progressInfo.errorMsg | translate }}</span>
+        <div class="list-element">
+          <div class="left-part">-</div>
+          <div class="right-part">
+            {{ 'update-hypervisor.label' | translate }}: <span class="red-text">{{ progressInfo.errorMsg | translate }}</span>
+          </div>
+        </div>
       </div>
     </div>
   </ng-container>

--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.scss
@@ -10,6 +10,28 @@
   color: $blue-medium;
   word-break: break-word;
 
+  .list-element {
+    display: flex;
+
+    .left-part {
+      width: 12px;
+      flex-grow: 0;
+      flex-shrink: 0;
+    }
+
+    .right-part {
+      flex-grow: 1;
+
+      a {
+        text-decoration: none;
+        color: $blue-medium;
+        font-size: $font-size-mini;
+        line-height: 1;
+        display: block;
+      }
+    }
+  }
+
   .details {
     color: $light-gray;
   }

--- a/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update-hypervisor/update-hypervisor.component.ts
@@ -84,6 +84,7 @@ export class UpdateProgressInfo {
 interface UpdateVersion {
   currentVersion: string;
   newVersion: string;
+  updateLink: string;
 }
 
 /**
@@ -146,10 +147,6 @@ export class UpdateHypervisorComponent implements AfterViewInit, OnDestroy {
    * Checks if the hypervisor is already being updated.
    */
   private startChecking() {
-    // NOTE: This code is needed for checking if the hypervisor is currently being updated, but
-    // is commented due to a bug with the Hypervisor API. Must be reactivated, and the last
-    // cuerrently uncommented line deleted, after the bug is solved.
-    /*
     this.subscription = this.nodeService.checkIfUpdating(null).subscribe(result => {
       if (result.running) {
         this.update();
@@ -160,8 +157,6 @@ export class UpdateHypervisorComponent implements AfterViewInit, OnDestroy {
       this.changeState(UpdatingStates.Error);
       this.errorText = processServiceError(err).translatableErrorMsg;
     });
-    */
-    this.checkUpdates();
   }
 
   /**
@@ -173,8 +168,9 @@ export class UpdateHypervisorComponent implements AfterViewInit, OnDestroy {
         // Save the update.
         this.updateFound = {
           currentVersion: result.current_version ?
-          result.current_version : this.translateService.instant('common.unknown'),
+            result.current_version : this.translateService.instant('common.unknown'),
           newVersion: result.available_version,
+          updateLink: result.release_url,
         };
 
         // Go to the next step.

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.html
@@ -15,7 +15,9 @@
 
   <!-- Current version, shown if no update was found and only one node was going to be updated. -->
   <div *ngIf="state === updatingStates.NoUpdatesFound && data.length === 1" class="list-container">
-    - {{ currentNodeVersion ? currentNodeVersion : ('common.unknown' | translate) }}
+    <div class="list-element">
+      <div class="left-part">-</div><div class="right-part">{{ currentNodeVersion ? currentNodeVersion : ('common.unknown' | translate) }}</div>
+    </div>
   </div>
 
   <!-- List with the nodes currently being updated, shown while asking for confirmation before installing the updates. -->
@@ -24,8 +26,8 @@
       {{ 'update.already-updating' | translate }}
     </div>
     <div class="list-container">
-      <div *ngFor="let index of indexesAlreadyBeingUpdated">
-        - {{ nodesToUpdate[index].label }}
+      <div *ngFor="let index of indexesAlreadyBeingUpdated" class="list-element">
+        <div class="left-part">-</div><div class="right-part">{{ nodesToUpdate[index].label }}</div>
       </div>
     </div>
   </ng-container>
@@ -35,8 +37,12 @@
       {{ updateAvailableText | translate:{number: nodesForUpdatesFound} }}
     </div>
     <div class="list-container">
-      <div *ngFor="let update of updatesFound">
-        - {{ 'update.version-change' | translate:update }}
+      <div *ngFor="let update of updatesFound" class="list-element">
+        <div class="left-part">-</div>
+        <div class="right-part">
+          {{ 'update.version-change' | translate:update }}
+          <a [href]="update.updateLink" target="_blank" rel="noreferrer nofollow noopener">{{ update.updateLink }}</a>
+        </div>
       </div>
     </div>
     <div class="text-container">
@@ -55,9 +61,14 @@
         <ng-container *ngIf="node.update">
           <!-- Raw progress text shown if it was not possible to parse it for showing the progrss bar. -->
           <div *ngIf="!node.updateProgressInfo.errorMsg && !node.updateProgressInfo.dataParsed" class="list-container">
-            - <mat-spinner class="loading-indicator" [diameter]="12" *ngIf="!node.updateProgressInfo.closed"></mat-spinner> {{ node.label }}
-            : <span class="details">{{ node.updateProgressInfo.rawMsg }}</span>
-            <span *ngIf="node.updateProgressInfo.closed" class="closed-indication">&nbsp;({{ 'update.finished' | translate }})</span>
+            <div class="list-element">
+              <div class="left-part">-</div>
+              <div class="right-part">
+                <mat-spinner class="loading-indicator" [diameter]="12" *ngIf="!node.updateProgressInfo.closed"></mat-spinner> {{ node.label }}
+                : <span class="details">{{ node.updateProgressInfo.rawMsg }}</span>
+                <span *ngIf="node.updateProgressInfo.closed" class="closed-indication">&nbsp;({{ 'update.finished' | translate }})</span>
+              </div>
+            </div>
           </div>
           <!-- Progress bar. -->
           <div *ngIf="!node.updateProgressInfo.errorMsg && node.updateProgressInfo.dataParsed" class="progress-container">
@@ -90,7 +101,12 @@
           </div>
           <!-- Msg shown if there was an error during the operation. -->
           <div *ngIf="node.updateProgressInfo.errorMsg" class="list-container">
-            - {{ node.label }}: <span class="red-text">{{ node.updateProgressInfo.errorMsg }}</span>
+            <div class="list-element">
+              <div class="left-part">-</div>
+              <div class="right-part">
+                {{ node.label }}: <span class="red-text">{{ node.updateProgressInfo.errorMsg }}</span>
+              </div>
+            </div>
           </div>
         </ng-container>
       </ng-container>

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.scss
@@ -10,6 +10,28 @@
   color: $blue-medium;
   word-break: break-word;
 
+  .list-element {
+    display: flex;
+
+    .left-part {
+      width: 12px;
+      flex-grow: 0;
+      flex-shrink: 0;
+    }
+
+    .right-part {
+      flex-grow: 1;
+
+      a {
+        text-decoration: none;
+        color: $blue-medium;
+        font-size: $font-size-mini;
+        line-height: 1;
+        display: block;
+      }
+    }
+  }
+
   .details {
     color: $light-gray;
   }

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
@@ -108,6 +108,7 @@ export class UpdateProgressInfo {
 interface UpdateVersion {
   currentVersion: string;
   newVersion: string;
+  updateLink: string;
 }
 
 /**
@@ -251,6 +252,7 @@ export class UpdateComponent implements AfterViewInit, OnDestroy {
               currentVersion: updateInfo.current_version ?
                 updateInfo.current_version : this.translateService.instant('common.unknown'),
               newVersion: updateInfo.available_version,
+              updateLink: updateInfo.release_url,
             });
 
             updates.set(updateInfo.current_version + updateInfo.available_version, true);


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the update windows of the manager show links for accessing the Github page with the updated release.
- As https://github.com/skycoin/skywire/issues/476 has been solved, the code needed for correctly checking if the hypervisor is being updated was uncommented.

How to test this PR:
Use the manager to update the nodes and the hypervisor. The Github link will appear below the update version number. For testing the second change, just update the hypervisor, close the update window and open it again, the window will show the update progress again (before this PR you had to accept the update again before being able to see the update progress).