### PR TITLE
Fix concurrent map writes panic

### DIFF
--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -299,12 +299,16 @@ func (n *Network) Close() error {
 		}()
 	}
 
+	var directErrorsMu sync.Mutex
 	directErrors := make(map[string]error)
 
 	for k, v := range n.clients.Direct {
 		if v != nil {
 			wg.Add(1)
 			go func() {
+				directErrorsMu.Lock()
+				defer directErrorsMu.Unlock()
+
 				directErrors[k] = v.Close()
 				wg.Done()
 			}()

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -306,10 +306,12 @@ func (n *Network) Close() error {
 		if v != nil {
 			wg.Add(1)
 			go func() {
-				directErrorsMu.Lock()
-				defer directErrorsMu.Unlock()
+				err := v.Close()
 
-				directErrors[k] = v.Close()
+				directErrorsMu.Lock()
+				directErrors[k] = err
+				directErrorsMu.Unlock()
+
 				wg.Done()
 			}()
 		}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #514

 Changes:	
- Fix concurrent map writes panic

How to test this PR:
- Run visor
- Wait until it's initialized
- Press Ctrl-C
- There should be no concurrent map writes panic
