### PR TITLE
Make VPN work properly over stcpr

### DIFF
--- a/cmd/apps/vpn-client/vpn-client.go
+++ b/cmd/apps/vpn-client/vpn-client.go
@@ -9,14 +9,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/skycoin/skywire/pkg/app/appevent"
-
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/netutil"
 
 	"github.com/skycoin/skywire/internal/vpn"
 	"github.com/skycoin/skywire/pkg/app"
+	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"

--- a/cmd/apps/vpn-client/vpn-client.go
+++ b/cmd/apps/vpn-client/vpn-client.go
@@ -76,10 +76,6 @@ func main() {
 	eventSub := appevent.NewSubscriber()
 
 	eventSub.OnTCPDial(func(data appevent.TCPDialData) {
-		log.WithField("event_type", data.Type()).
-			WithField("event_data", data).
-			Info("GOT EVENT")
-
 		ip, ok, err := vpn.ParseIP(data.RemoteAddr)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to parse IP %s", data.RemoteAddr)

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -97,6 +97,8 @@ func NewClient(cfg ClientConfig, l logrus.FieldLogger, conn net.Conn) (*Client, 
 	}, nil
 }
 
+// AddDirectRoute adds new direct route. Packets destined to `ip` will
+// go directly, ignoring VPN.
 func (c *Client) AddDirectRoute(ip net.IP) error {
 	c.directIPSMu.Lock()
 	defer c.directIPSMu.Unlock()

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -323,8 +323,6 @@ func tpRemoteIPsFromEnv() ([]net.IP, error) {
 			return nil, fmt.Errorf("env arg %s is not provided", key)
 		}
 
-		fmt.Printf("PARSING TP REMOTE IP %s\n", ipStr)
-
 		ip, err := ipFromEnv(key)
 		if err != nil {
 			return nil, fmt.Errorf("error getting TP remote IP: %w", err)
@@ -370,12 +368,6 @@ func (c *Client) shakeHands() (TUNIP, TUNGateway net.IP, err error) {
 		return nil, nil, fmt.Errorf("error getting unavailable private IPs: %w", err)
 	}
 
-	if c.defaultGateway == nil {
-		c.log.Infoln("DEFAULT GATEWAY IS NIL")
-	}
-	if unavailableIPs == nil {
-		c.log.Infoln("UNAVAILABLE IPS IS NIL")
-	}
 	unavailableIPs = append(unavailableIPs, c.defaultGateway)
 
 	cHello := ClientHello{

--- a/internal/vpn/env.go
+++ b/internal/vpn/env.go
@@ -101,7 +101,17 @@ func AppEnvArgs(config DirectRoutesEnvConfig) map[string]string {
 // - IP with port;
 // - IP without port.
 func IPFromEnv(key string) (net.IP, bool, error) {
-	addr := os.Getenv(key)
+	return ParseIP(os.Getenv(key))
+}
+
+// ParseIP parses IP string `addr`. `addr` may be on of:
+// - full URL with port;
+// - full URL without port;
+// - domain with port;
+// - domain without port;
+// - IP with port;
+// - IP without port.
+func ParseIP(addr string) (net.IP, bool, error) {
 	if addr == "" {
 		return nil, false, nil
 	}

--- a/internal/vpn/env.go
+++ b/internal/vpn/env.go
@@ -34,6 +34,9 @@ const (
 	STCPKeyEnvPrefix = "STCP_TABLE_KEY_"
 	// STCPValueEnvPrefix is prefix for each env arg holding STCP entity value.
 	STCPValueEnvPrefix = "STCP_TABLE_"
+
+	TPRemoteIPsLenEnvKey = "TP_REMOTE_IPS_LEN"
+	TPRemoteIPsEnvPrefix = "ADDR_TP_REMOTE_"
 )
 
 // DirectRoutesEnvConfig contains all the addresses which need to be communicated directly,
@@ -45,6 +48,7 @@ type DirectRoutesEnvConfig struct {
 	RF              string
 	UptimeTracker   string
 	AddressResolver string
+	TPRemoteIPs     []string
 	STCPTable       map[cipher.PubKey]string
 }
 
@@ -87,6 +91,14 @@ func AppEnvArgs(config DirectRoutesEnvConfig) map[string]string {
 
 		for i := range config.DmsgServers {
 			envs[DmsgAddrEnvPrefix+strconv.FormatInt(int64(i), 10)] = config.DmsgServers[i]
+		}
+	}
+
+	if len(config.TPRemoteIPs) != 0 {
+		envs[TPRemoteIPsLenEnvKey] = strconv.FormatInt(int64(len(config.TPRemoteIPs)), 10)
+
+		for i := range config.TPRemoteIPs {
+			envs[TPRemoteIPsEnvPrefix+strconv.FormatInt(int64(i), 10)] = config.TPRemoteIPs[i]
 		}
 	}
 

--- a/internal/vpn/env.go
+++ b/internal/vpn/env.go
@@ -35,7 +35,9 @@ const (
 	// STCPValueEnvPrefix is prefix for each env arg holding STCP entity value.
 	STCPValueEnvPrefix = "STCP_TABLE_"
 
+	// TPRemoteIPsLenEnvKey is env arg holding TP remote IPs length.
 	TPRemoteIPsLenEnvKey = "TP_REMOTE_IPS_LEN"
+	// TPRemoteIPsEnvPrefix is prefix for each env arg holding TP remote IP.
 	TPRemoteIPsEnvPrefix = "ADDR_TP_REMOTE_"
 )
 

--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -64,38 +64,45 @@ type Client interface {
 
 // Config configures Client.
 type Config struct {
-	Type            string
-	PK              cipher.PubKey
-	SK              cipher.SecKey
-	LocalAddr       string
-	Table           pktable.PKTable
-	AddressResolver arclient.APIClient
+	Type               string
+	PK                 cipher.PubKey
+	SK                 cipher.SecKey
+	LocalAddr          string
+	Table              pktable.PKTable
+	AddressResolver    arclient.APIClient
+	BeforeDialCallback BeforeDialCallback
 }
 
+// BeforeDialCallback is triggered before client dials.
+// If a non-nil error is returned, the dial is instantly terminated.
+type BeforeDialCallback func(network, addr string) (err error)
+
 type client struct {
-	conf              Config
-	mu                sync.Mutex
-	done              chan struct{}
-	once              sync.Once
-	log               *logging.Logger
-	porter            *porter.Porter
-	listener          net.Listener
-	listening         chan struct{}
-	listeners         map[uint16]*tplistener.Listener // key: lPort
-	sudphPacketFilter *pfilter.PacketFilter
-	sudphListener     net.PacketConn
-	sudphVisorsConn   net.PacketConn
+	conf               Config
+	mu                 sync.Mutex
+	done               chan struct{}
+	once               sync.Once
+	log                *logging.Logger
+	porter             *porter.Porter
+	listener           net.Listener
+	listening          chan struct{}
+	listeners          map[uint16]*tplistener.Listener // key: lPort
+	sudphPacketFilter  *pfilter.PacketFilter
+	sudphListener      net.PacketConn
+	sudphVisorsConn    net.PacketConn
+	beforeDialCallback BeforeDialCallback
 }
 
 // NewClient creates a net Client.
 func NewClient(conf Config) Client {
 	return &client{
-		conf:      conf,
-		log:       logging.MustGetLogger(conf.Type),
-		porter:    porter.New(porter.MinEphemeral),
-		listeners: make(map[uint16]*tplistener.Listener),
-		done:      make(chan struct{}),
-		listening: make(chan struct{}),
+		conf:               conf,
+		log:                logging.MustGetLogger(conf.Type),
+		porter:             porter.New(porter.MinEphemeral),
+		listeners:          make(map[uint16]*tplistener.Listener),
+		done:               make(chan struct{}),
+		listening:          make(chan struct{}),
+		beforeDialCallback: conf.BeforeDialCallback,
 	}
 }
 
@@ -407,6 +414,12 @@ func (c *client) dialVisor(visorData arclient.VisorData) (net.Conn, error) {
 		for _, host := range visorData.Addresses {
 			addr := net.JoinHostPort(host, visorData.Port)
 
+			if c.beforeDialCallback != nil {
+				if err := c.beforeDialCallback(c.conf.Type, addr); err != nil {
+					return nil, err
+				}
+			}
+
 			conn, err := c.dial(addr)
 			if err == nil {
 				return conn, nil
@@ -417,6 +430,12 @@ func (c *client) dialVisor(visorData arclient.VisorData) (net.Conn, error) {
 	addr := visorData.RemoteAddr
 	if _, _, err := net.SplitHostPort(addr); err != nil {
 		addr = net.JoinHostPort(addr, visorData.Port)
+	}
+
+	if c.beforeDialCallback != nil {
+		if err := c.beforeDialCallback(c.conf.Type, addr); err != nil {
+			return nil, err
+		}
 	}
 
 	return c.dial(addr)

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -146,6 +146,12 @@ func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 			SK:        conf.SecKey,
 			Table:     pktable.NewTable(conf.NetworkConfigs.STCP.PKTable),
 			LocalAddr: conf.NetworkConfigs.STCP.LocalAddr,
+			BeforeDialCallback: func(network, addr string) error {
+				data := appevent.TCPDialData{RemoteNet: network, RemoteAddr: addr}
+				event := appevent.NewEvent(appevent.TCPDial, data)
+				_ = eb.Broadcast(context.Background(), event) //nolint:errcheck
+				return nil
+			},
 		}
 		clients.Direct[tptypes.STCP] = directtp.NewClient(conf)
 	}
@@ -156,6 +162,12 @@ func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 			PK:              conf.PubKey,
 			SK:              conf.SecKey,
 			AddressResolver: conf.ARClient,
+			BeforeDialCallback: func(network, addr string) error {
+				data := appevent.TCPDialData{RemoteNet: network, RemoteAddr: addr}
+				event := appevent.NewEvent(appevent.TCPDial, data)
+				_ = eb.Broadcast(context.Background(), event) //nolint:errcheck
+				return nil
+			},
 		}
 
 		clients.Direct[tptypes.STCPR] = directtp.NewClient(stcprConf)

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -111,6 +111,10 @@ type Network struct {
 	onNewNetworkType   func(netType string)
 }
 
+func (n *Network) Conf() Config {
+	return n.conf
+}
+
 // New creates a network from a config.
 func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 	clients := NetworkClients{

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -111,10 +111,6 @@ type Network struct {
 	onNewNetworkType   func(netType string)
 }
 
-func (n *Network) Conf() Config {
-	return n.conf
-}
-
 // New creates a network from a config.
 func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 	clients := NetworkClients{
@@ -208,6 +204,11 @@ func NewRaw(conf Config, clients NetworkClients) *Network {
 	}
 
 	return n
+}
+
+// Conf gets network configuration.
+func (n *Network) Conf() Config {
+	return n.conf
 }
 
 // Init initiates server connections.

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -74,6 +74,8 @@ type ManagedTransport struct {
 	done chan struct{}
 	once sync.Once
 	wg   sync.WaitGroup
+
+	remoteAddrs []string
 }
 
 // NewManagedTransport creates a new ManagedTransport.

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -331,7 +331,8 @@ func (tm *Manager) saveTransport(remote cipher.PubKey, netName string) (*Managed
 	return mTp, nil
 }
 
-func (tm *Manager) RemoteAddrs() []string {
+// STCPRRemoteAddrs gets remote IPs for all known STCPR transports.
+func (tm *Manager) STCPRRemoteAddrs() []string {
 	var addrs []string
 
 	tm.mx.RLock()

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -9,6 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/snet/arclient"
+
+	"github.com/skycoin/skywire/pkg/snet/directtp/tptypes"
+
 	"github.com/google/uuid"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -302,6 +306,19 @@ func (tm *Manager) saveTransport(remote cipher.PubKey, netName string) (*Managed
 	}
 
 	mTp := NewManagedTransport(tm.n, tm.Conf.DiscoveryClient, tm.Conf.LogStore, remote, netName)
+	if mTp.netName == tptypes.STCPR {
+		ar := mTp.n.Conf().ARClient
+		if ar != nil {
+			visorData, err := ar.Resolve(context.Background(), mTp.netName, remote)
+			if err == nil {
+				mTp.remoteAddrs = append(mTp.remoteAddrs, visorData.RemoteAddr)
+			} else {
+				if err != arclient.ErrNoEntry {
+					return nil, fmt.Errorf("failed to resolve %s: %w", remote, err)
+				}
+			}
+		}
+	}
 	go func() {
 		mTp.Serve(tm.readCh)
 		tm.mx.Lock()
@@ -312,6 +329,21 @@ func (tm *Manager) saveTransport(remote cipher.PubKey, netName string) (*Managed
 
 	tm.Logger.Infof("saved transport: remote(%s) type(%s) tpID(%s)", remote, netName, tpID)
 	return mTp, nil
+}
+
+func (tm *Manager) RemoteAddrs() []string {
+	var addrs []string
+
+	tm.mx.RLock()
+	defer tm.mx.RUnlock()
+
+	for _, tp := range tm.tps {
+		if tp.Entry.Type == tptypes.STCPR && len(tp.remoteAddrs) > 0 {
+			addrs = append(addrs, tp.remoteAddrs...)
+		}
+	}
+
+	return addrs
 }
 
 // DeleteTransport deregisters the Transport of Transport ID in transport discovery and deletes it locally.

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -9,10 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/skywire/pkg/snet/arclient"
-
-	"github.com/skycoin/skywire/pkg/snet/directtp/tptypes"
-
 	"github.com/google/uuid"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -20,6 +16,8 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/snet"
+	"github.com/skycoin/skywire/pkg/snet/arclient"
+	"github.com/skycoin/skywire/pkg/snet/directtp/tptypes"
 	"github.com/skycoin/skywire/pkg/snet/snettest"
 )
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -307,8 +307,8 @@ func initLauncher(v *Visor) bool {
 	}
 
 	err = launch.AutoStart(map[string]func() ([]string, error){
-		skyenv.VPNClientName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net) },
-		skyenv.VPNServerName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net) },
+		skyenv.VPNClientName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net, v.tpM.RemoteAddrs()) },
+		skyenv.VPNServerName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net, nil) },
 	})
 
 	if err != nil {
@@ -321,7 +321,7 @@ func initLauncher(v *Visor) bool {
 	return report(nil)
 }
 
-func makeVPNEnvs(conf *visorconfig.V1, n *snet.Network) ([]string, error) {
+func makeVPNEnvs(conf *visorconfig.V1, n *snet.Network, tpRemoteAddrs []string) ([]string, error) {
 	var envCfg vpn.DirectRoutesEnvConfig
 
 	if conf.Dmsg != nil {
@@ -361,6 +361,8 @@ func makeVPNEnvs(conf *visorconfig.V1, n *snet.Network) ([]string, error) {
 	if conf.STCP != nil && len(conf.STCP.PKTable) != 0 {
 		envCfg.STCPTable = conf.STCP.PKTable
 	}
+
+	envCfg.TPRemoteIPs = tpRemoteAddrs
 
 	envMap := vpn.AppEnvArgs(envCfg)
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -307,7 +307,7 @@ func initLauncher(v *Visor) bool {
 	}
 
 	err = launch.AutoStart(map[string]func() ([]string, error){
-		skyenv.VPNClientName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net, v.tpM.RemoteAddrs()) },
+		skyenv.VPNClientName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net, v.tpM.STCPRRemoteAddrs()) },
 		skyenv.VPNServerName: func() ([]string, error) { return makeVPNEnvs(v.conf, v.net, nil) },
 	})
 

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -281,7 +281,7 @@ func (r *RPC) StartApp(name *string, _ *struct{}) (err error) {
 
 	var envs []string
 	if *name == skyenv.VPNClientName {
-		envs, err = makeVPNEnvs(r.visor.conf, r.visor.net)
+		envs, err = makeVPNEnvs(r.visor.conf, r.visor.net, r.visor.tpM.RemoteAddrs())
 		if err != nil {
 			return err
 		}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -281,7 +281,7 @@ func (r *RPC) StartApp(name *string, _ *struct{}) (err error) {
 
 	var envs []string
 	if *name == skyenv.VPNClientName {
-		envs, err = makeVPNEnvs(r.visor.conf, r.visor.net, r.visor.tpM.RemoteAddrs())
+		envs, err = makeVPNEnvs(r.visor.conf, r.visor.net, r.visor.tpM.STCPRRemoteAddrs())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #517, partially implements #383 

 Changes:	
- Callbacks for stcpr/stcp connection establishment implemented;
- These callbacks are properly used by the VPN client app;
- Remote IPs for all of the known STCPR transports are now passed to the VPN client on start;

How to test this PR:
Setup VPN connection over STCPR transport