### PR TITLE
Fix a bug in the visor details page of the manager

### DIFF
--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -265,6 +265,7 @@ export class NodeService {
    */
   stopRequestingSpecificNode() {
     if (this.specificNodeRefreshSubscription) {
+      // The delay allows to recover the connection if the user returns to the node page.
       this.specificNodeStopSubscription = of(1).pipe(delay(4000)).subscribe(() => {
         this.specificNodeRefreshSubscription.unsubscribe();
         this.specificNodeRefreshSubscription = null;
@@ -294,6 +295,12 @@ export class NodeService {
       updatingSubject = this.updatingSpecificNodeSubject;
       dataSubject = this.specificNodeSubject;
       operation = this.getNode(this.specificNodeKey);
+
+      // Cancel any pending stop operation.
+      if (this.specificNodeStopSubscription) {
+        this.specificNodeStopSubscription.unsubscribe();
+        this.specificNodeStopSubscription = null;
+      }
 
       if (this.specificNodeRefreshSubscription) {
         this.specificNodeRefreshSubscription.unsubscribe();


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- A bug which made the visor details page stop loading was solved.

How to test this PR:
The previous bug appeared following these steps:
1. Open the Skywire manager, which will show the visor list.
2. Open the details page of a visor.
3. Return to the visor list.
4. Open the details page of another visor just after 3 or 3.5 seconds. Timing is important as there is a 4 seconds timer involved in the problem.

Under these conditions, the details page of the second visor did not load. With this PR the problem is solved.
