### PR TITLE
Make the manager work in 0.4.0

### DIFF
--- a/static/skywire-manager-src/src/app/services/route.service.ts
+++ b/static/skywire-manager-src/src/app/services/route.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { ApiService } from './api.service';
 import { Route } from '../app.datatypes';
@@ -19,7 +20,15 @@ export class RouteService {
    * Get a list with the routes of a node.
    */
   getRoutes(nodeKey: string): Observable<Route[]> {
-    return this.apiService.get(`visors/${nodeKey}/routes`);
+    return this.apiService.get(`visors/${nodeKey}/routes`).pipe(
+      map(val => {
+        if (!val) {
+          return [];
+        }
+
+        return val;
+      })
+    );
   }
 
   /**

--- a/static/skywire-manager-src/src/app/services/transport.service.ts
+++ b/static/skywire-manager-src/src/app/services/transport.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { ApiService } from './api.service';
 import { Transport } from '../app.datatypes';
@@ -19,7 +20,15 @@ export class TransportService {
    * Get a list with the transports of a node.
    */
   getTransports(nodeKey: string): Observable<Transport[]> {
-    return this.apiService.get(`visors/${nodeKey}/transports`);
+    return this.apiService.get(`visors/${nodeKey}/transports`).pipe(
+      map(val => {
+        if (!val) {
+          return [];
+        }
+
+        return val;
+      })
+    );
   }
 
   create(nodeKey: string, remoteKey: string, type: string): Observable<any> {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #538 

 Changes:	
- The manager now works well when the hypervisor is part of the visor.

How to test this PR:
Follow the instruction of the original issue.