### PR TITLE
Differentiate v0.3.0 visors by URL query instead of entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/shirou/gopsutil v2.20.5+incompatible
 	github.com/sirupsen/logrus v1.6.0
-	github.com/skycoin/dmsg v0.0.0-20201009105839-3b0627b4ffa6
+	github.com/skycoin/dmsg v0.0.0-20201015193122-1cc2b71b0393
 	github.com/skycoin/skycoin v0.26.0
 	github.com/skycoin/yamux v0.0.0-20200803175205-571ceb89da9f
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
@@ -39,4 +39,4 @@ require (
 )
 
 // Uncomment for tests with alternate branches of 'dmsg'
-replace github.com/skycoin/dmsg => ../dmsg
+//replace github.com/skycoin/dmsg => ../dmsg

--- a/go.mod
+++ b/go.mod
@@ -39,4 +39,4 @@ require (
 )
 
 // Uncomment for tests with alternate branches of 'dmsg'
-//replace github.com/skycoin/dmsg => ../dmsg
+replace github.com/skycoin/dmsg => ../dmsg

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/skycoin/dmsg v0.0.0-20201009105839-3b0627b4ffa6 h1:JtzRwMrMS1k+RbwO07jxkrmKVHK/Gw5SWpuncoGtBqU=
-github.com/skycoin/dmsg v0.0.0-20201009105839-3b0627b4ffa6/go.mod h1:xOXuvC+HWwOQsqlUAsf2alDnQPOmS+ecVlFS2YP3Qjk=
+github.com/skycoin/dmsg v0.0.0-20201015193122-1cc2b71b0393 h1:boJJJiT3XYBa27T+hoJ1bNdxukJCbWsn/bapr663QUY=
+github.com/skycoin/dmsg v0.0.0-20201015193122-1cc2b71b0393/go.mod h1:xOXuvC+HWwOQsqlUAsf2alDnQPOmS+ecVlFS2YP3Qjk=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.26.0 h1:xDxe2r8AclMntZ550Y/vUQgwgLtwrf9Wu5UYiYcN5/o=

--- a/vendor/github.com/skycoin/dmsg/disc/client.go
+++ b/vendor/github.com/skycoin/dmsg/disc/client.go
@@ -54,7 +54,9 @@ func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry
 	if err != nil {
 		return nil, err
 	}
+
 	addKeepAlive(req)
+
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
@@ -101,10 +103,16 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 	if err != nil {
 		return err
 	}
-	addKeepAlive(req)
-	req = req.WithContext(ctx)
 
+	addKeepAlive(req)
 	req.Header.Set("Content-Type", "application/json")
+
+	// Since v0.3.0 visors send ?timeout=true, before v0.3.0 do not.
+	q := req.URL.Query()
+	q.Add("timeout", "true")
+	req.URL.RawQuery = q.Encode()
+
+	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
 	if resp != nil {

--- a/vendor/github.com/skycoin/dmsg/disc/entry.go
+++ b/vendor/github.com/skycoin/dmsg/disc/entry.go
@@ -118,10 +118,6 @@ type Entry struct {
 
 	// Signature for proving authenticity of an Entry.
 	Signature string `json:"signature,omitempty"`
-
-	// NeedTimeout defines whether a timeout is needed for an entry.
-	// It is used to differentiate visors up to v0.2.3 as their entries do not need a timeout.
-	NeedTimeout bool `json:"need_timeout,omitempty"`
 }
 
 func (e *Entry) String() string {
@@ -183,24 +179,22 @@ func (s *Server) String() string {
 // should be signed with the private key before sending it to the server
 func NewClientEntry(pubkey cipher.PubKey, sequence uint64, delegatedServers []cipher.PubKey) *Entry {
 	return &Entry{
-		Version:     currentVersion,
-		Sequence:    sequence,
-		Client:      &Client{delegatedServers},
-		Static:      pubkey,
-		Timestamp:   time.Now().UnixNano(),
-		NeedTimeout: true, // v0.3.0+
+		Version:   currentVersion,
+		Sequence:  sequence,
+		Client:    &Client{delegatedServers},
+		Static:    pubkey,
+		Timestamp: time.Now().UnixNano(),
 	}
 }
 
 // NewServerEntry constructs a new Server entry.
 func NewServerEntry(pk cipher.PubKey, seq uint64, addr string, availableSessions int) *Entry {
 	return &Entry{
-		Version:     currentVersion,
-		Sequence:    seq,
-		Server:      &Server{Address: addr, AvailableSessions: availableSessions},
-		Static:      pk,
-		Timestamp:   time.Now().UnixNano(),
-		NeedTimeout: true, // v0.3.0+
+		Version:   currentVersion,
+		Sequence:  seq,
+		Server:    &Server{Address: addr, AvailableSessions: availableSessions},
+		Static:    pk,
+		Timestamp: time.Now().UnixNano(),
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/shirou/gopsutil/process
 ## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v0.0.0-20201009105839-3b0627b4ffa6
+# github.com/skycoin/dmsg v0.0.0-20201009105839-3b0627b4ffa6 => ../dmsg
 ## explicit
 github.com/skycoin/dmsg
 github.com/skycoin/dmsg/buildinfo
@@ -319,3 +319,4 @@ nhooyr.io/websocket/internal/bpool
 nhooyr.io/websocket/internal/errd
 nhooyr.io/websocket/internal/wsjs
 nhooyr.io/websocket/internal/xsync
+# github.com/skycoin/dmsg => ../dmsg

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/shirou/gopsutil/process
 ## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v0.0.0-20201009105839-3b0627b4ffa6 => ../dmsg
+# github.com/skycoin/dmsg v0.0.0-20201015193122-1cc2b71b0393
 ## explicit
 github.com/skycoin/dmsg
 github.com/skycoin/dmsg/buildinfo
@@ -319,4 +319,3 @@ nhooyr.io/websocket/internal/bpool
 nhooyr.io/websocket/internal/errd
 nhooyr.io/websocket/internal/wsjs
 nhooyr.io/websocket/internal/xsync
-# github.com/skycoin/dmsg => ../dmsg


### PR DESCRIPTION
Did you run `make format && make check`? Not yet

Part of https://github.com/skycoin/dmsg/pull/19

 Changes:	
- Differentiate v0.3.0 visors by URL query instead of entry

How to test this PR:
- Run against test deployment
