### PR TITLE
Add build information for deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ BUILDINFO_VERSION := -X $(BUILDINFO_PATH).version=$(VERSION)
 BUILDINFO_DATE := -X $(BUILDINFO_PATH).date=$(DATE)
 BUILDINFO_COMMIT := -X $(BUILDINFO_PATH).commit=$(COMMIT)
 
-BUILDINFO?=-ldflags="$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)"
+BUILDINFO?=$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)
 
-BUILD_OPTS?=$(BUILDINFO)
+BUILD_OPTS?="-ldflags=$(BUILDINFO)"
+BUILD_OPTS_DEPLOY?="-ldflags=$(BUILDINFO) -w -s"
 
 check: lint test ## Run linters and tests
 
@@ -160,6 +161,14 @@ release: ## Build `skywire-visor`, `skywire-cli`, `hypervisor` and apps without 
 	${OPTS} go build ${BUILD_OPTS} -o ./apps/skysocks-client  ./cmd/apps/skysocks-client
 	${OPTS} go build ${BUILD_OPTS} -o ./apps/vpn-server ./cmd/apps/vpn-server
 	${OPTS} go build ${BUILD_OPTS} -o ./apps/vpn-client ./cmd/apps/vpn-client
+
+build-deploy: ## Build for deployment Docker images
+	${OPTS} go build -tags netgo ${BUILD_OPTS_DEPLOY} -o /release/skywire-visor ./cmd/skywire-visor
+	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o /release/skywire-cli ./cmd/skywire-cli
+	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o /release/apps/skychat ./cmd/apps/skychat
+	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o /release/apps/helloworld ./cmd/apps/helloworld
+	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o /release/apps/skysocks ./cmd/apps/skysocks
+	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o /release/apps/skysocks-client ./cmd/apps/skysocks-client
 
 package-amd64: install-deps-ui lint-ui build-ui ## Build the debian package.
 	scripts/dPKGBUILD.sh amd64


### PR DESCRIPTION
Did you run `make format && make check`?

Part of https://github.com/SkycoinPro/skywire-services/issues/248

 Changes:	
- Add build information for deployment

How to test this PR:
- Run `make build`
- Run compiled files
- Check if they contain build info
- In `make build-deploy` change output folder to something valid
- Run `make build-deploy`
- Run compiled files
- Check if they contain build info
