### PR TITLE
Add own PK to hypervisors list.

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -418,9 +418,10 @@ func initCLI(v *Visor) bool {
 
 func initHypervisors(v *Visor) bool {
 	report := v.makeReporter("hypervisors")
-
-	hvErrs := make(map[cipher.PubKey]chan error, len(v.conf.Hypervisors))
-	for _, hv := range v.conf.Hypervisors {
+	hypervisors := v.conf.Hypervisors
+	hypervisors = append(hypervisors, v.conf.PK)
+	hvErrs := make(map[cipher.PubKey]chan error, len(hypervisors))
+	for _, hv := range hypervisors {
 		hvErrs[hv] = make(chan error, 1)
 	}
 


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #568	

 Changes:	
-	implicitly own visor PK to hypervisors list. 

How to test this PR:
Generate hypervisor config, start hypervisor, wait for 30 seconds and check if ping appears on the page of your own visor.