### PR TITLE
Increase uptime update delay, and use v3 endpoint

### DIFF
--- a/internal/utclient/client.go
+++ b/internal/utclient/client.go
@@ -66,7 +66,7 @@ func (c *httpClient) Get(ctx context.Context, path string) (*http.Response, erro
 
 // UpdateVisorUptime updates visor uptime.
 func (c *httpClient) UpdateVisorUptime(ctx context.Context) error {
-	resp, err := c.Get(ctx, "/v2/update")
+	resp, err := c.Get(ctx, "/v3/update")
 	if err != nil {
 		return err
 	}

--- a/internal/utclient/client_test.go
+++ b/internal/utclient/client_test.go
@@ -73,7 +73,7 @@ func TestUpdateVisorUptime(t *testing.T) {
 	err = c.UpdateVisorUptime(context.TODO())
 	require.NoError(t, err)
 
-	assert.Equal(t, "/v2/update", <-urlCh)
+	assert.Equal(t, "/v3/update", <-urlCh)
 }
 
 func authHandler(next http.Handler) http.Handler {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -453,7 +453,7 @@ func initHypervisors(v *Visor) bool {
 }
 
 func initUptimeTracker(v *Visor) bool {
-	const tickDuration = 10 * time.Second
+	const tickDuration = 1 * time.Minute
 
 	report := v.makeReporter("uptime_tracker")
 	conf := v.conf.UptimeTracker


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes [#314](https://github.com/SkycoinPro/skywire-services/issues/314)

 Changes:	
- uptime update interval is increased to 1 minute. Uptime client now uses `v3/update` api endpoint 

How to test this PR:
`make test`
