### PR TITLE
Change how AuthGuardService works

### DIFF
--- a/static/skywire-manager-src/src/app/app-routing.module.ts
+++ b/static/skywire-manager-src/src/app/app-routing.module.ts
@@ -17,8 +17,7 @@ import { AllLabelsComponent } from './components/pages/settings/all-labels/all-l
 const routes: Routes = [
   {
     path: 'login',
-    component: LoginComponent,
-    canActivate: [AuthGuardService]
+    component: LoginComponent
   },
   {
     path: 'nodes',

--- a/static/skywire-manager-src/src/app/services/auth.service.ts
+++ b/static/skywire-manager-src/src/app/services/auth.service.ts
@@ -7,6 +7,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ApiService, ResponseTypes, RequestOptions } from './api.service';
 import { OperationError } from '../utils/operation-error';
 import { processServiceError } from '../utils/errors';
+import { AuthGuardService } from './auth-guard.service';
 
 export enum AuthStates {
   AuthDisabled, Logged, NotLogged
@@ -22,6 +23,7 @@ export class AuthService {
   constructor(
     private apiService: ApiService,
     private translateService: TranslateService,
+    private authGuardService: AuthGuardService,
   ) { }
 
   /**
@@ -34,6 +36,8 @@ export class AuthService {
           if (status !== true) {
             throw new Error();
           }
+
+          this.authGuardService.forceFail = false;
         }),
       );
   }
@@ -56,6 +60,8 @@ export class AuthService {
 
           // The user is not logged.
           if (err.originalError && (err.originalError as HttpErrorResponse).status === 401) {
+            this.authGuardService.forceFail = true;
+
             return of(AuthStates.NotLogged);
           }
 
@@ -74,6 +80,8 @@ export class AuthService {
           if (status !== true) {
             throw new Error();
           }
+
+          this.authGuardService.forceFail = true;
         }),
       );
   }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- The way in which the service in charge of redirecting the user to the login page when unauthorized was changed. Previously, it checked the auth state before allowing the user to navigate, which made the app slower to respond during the first navigation and provided a very bad UX if the backend was unavailable. Now the API service is the main responsible of checking if the user is unauthorized and redirecting to the login page, while AuthGuardService now only redirects the user if it is already known that the user is unauthorized. This makes the app appear to work faster at launch, especially while using slow remote connections, and prevents problems which made the manager to stay without content for a long time waiting for the backend to respond.

How to test this PR:
Use the manager with and without the auth option active in the hypervisor. Opening any internal page without logging first should make the manager redirect the browser to the login page. Also, if the login page is opened while logged or while the auth option is not active, the manager should redirect the browser to the visor list.