### PR TITLE
Feature/allow passing hypervisor pk

### DIFF
--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/cipher"
+	coinCipher "github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
 
@@ -76,6 +77,14 @@ var genConfigCmd = &cobra.Command{
 		conf, err := genConf(mLog, output, &sk, hypervisor)
 		if err != nil {
 			logger.WithError(err).Fatal("Failed to create config.")
+		}
+
+		if hypervisorPK != "" {
+			key, err := coinCipher.PubKeyFromHex(hypervisorPK)
+			if err != nil {
+				logger.WithError(err).Fatal("Failed to parse hypervisor private key.")
+			}
+			conf.Hypervisors = append(conf.Hypervisors, cipher.PubKey(key))
 		}
 
 		// Save config to file.

--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -25,6 +25,7 @@ var (
 	testEnv       bool
 	packageConfig bool
 	hypervisor    bool
+	hypervisorPK  string
 )
 
 func init() {
@@ -33,7 +34,8 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&replace, "replace", "r", false, "whether to allow rewrite of a file that already exists (this retains the keys).")
 	genConfigCmd.Flags().BoolVarP(&packageConfig, "package", "p", false, "use defaults for package-based installations")
 	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "whether to use production or test deployment service.")
-	genConfigCmd.Flags().BoolVar(&hypervisor, "hypervisor", false, "whether to generate hypervisor config.")
+	genConfigCmd.Flags().BoolVar(&hypervisor, "hypervisor", false, "whether to generate config to run this visor as a hypervisor.")
+	genConfigCmd.Flags().StringVar(&hypervisorPK, "hypervisor-pk", "", "public key of a hypervisor that should be added to this visor")
 }
 
 var genConfigCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -36,7 +36,7 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&replace, "replace", "r", false, "whether to allow rewrite of a file that already exists (this retains the keys).")
 	genConfigCmd.Flags().BoolVarP(&packageConfig, "package", "p", false, "use defaults for package-based installations")
 	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "whether to use production or test deployment service.")
-	genConfigCmd.Flags().BoolVar(&hypervisor, "hypervisor", false, "whether to generate config to run this visor as a hypervisor.")
+	genConfigCmd.Flags().BoolVar(&hypervisor, "is-hypervisor", false, "whether to generate config to run this visor as a hypervisor.")
 	genConfigCmd.Flags().StringVar(&hypervisorPKs, "hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
 }
 

--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -83,7 +83,7 @@ var genConfigCmd = &cobra.Command{
 		if hypervisorPKs != "" {
 			keys := strings.Split(hypervisorPKs, ",")
 			for _, key := range keys {
-				keyParsed, err := coinCipher.PubKeyFromHex(key)
+				keyParsed, err := coinCipher.PubKeyFromHex(strings.TrimSpace(key))
 				if err != nil {
 					logger.WithError(err).Fatalf("Failed to parse hypervisor private key: %s.", key)
 				}


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #590 

 Changes:	
- adds `hypervisor-pk` to `skywire-cli visor gen-config` which takes a pk of some hypervisor and adds it to the hypervisors list
in the generated config

How to test this PR:
`make test`