### PR TITLE
Remove FillDefaults to keep hypervisor parsed settings

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -538,8 +538,6 @@ func initHypervisor(v *Visor) bool {
 	conf.SK = v.conf.SK
 	conf.DmsgDiscovery = v.conf.Dmsg.Discovery
 
-	conf.FillDefaults(false)
-
 	// Prepare hypervisor.
 	hv, err := New(conf, assets, v, v.net.Dmsg())
 	if err != nil {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes:  [#321](https://github.com/SkycoinPro/skywire-services/issues/321)

 Changes:	
-	Remove FillDefaults to keep hypervisor parsed settings

How to test this PR:
`make test`