### PR TITLE
Add endpoints for bulk deletes.

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -847,11 +847,8 @@ func (hv *Hypervisor) deleteRoutes() http.HandlerFunc {
 			httputil.WriteJSON(w, r, http.StatusNotFound, err)
 			return
 		}
-		hv.log(r).Info(rids)
 		for _, rid := range rids {
-			hv.log(r).Info(rid)
 			ridUint64, err := strconv.ParseUint(rid, 10, 32)
-			hv.log(r).Info(ridUint64, err)
 			if err != nil {
 				httputil.WriteJSON(w, r, http.StatusBadRequest, err)
 				return

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -147,7 +147,7 @@ type MockConfig struct {
 	EnableAuth        bool
 }
 
-type ElementResponse struct {
+type elementResponse struct {
 	Success bool   `json:"success"`
 	Error   string `json:"error"`
 }
@@ -698,7 +698,7 @@ func (hv *Hypervisor) deleteTransport() http.HandlerFunc {
 func (hv *Hypervisor) deleteTransports() http.HandlerFunc {
 	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
 		var transports []string
-		response := make(map[string]ElementResponse)
+		response := make(map[string]elementResponse)
 		err := json.NewDecoder(r.Body).Decode(&transports)
 		if err != nil {
 			httputil.WriteJSON(w, r, http.StatusBadRequest, err)
@@ -707,20 +707,20 @@ func (hv *Hypervisor) deleteTransports() http.HandlerFunc {
 		for _, transport := range transports {
 			transportBoxed, err := uuid.Parse(transport)
 			if err != nil {
-				response[transport] = ElementResponse{
+				response[transport] = elementResponse{
 					Success: false,
 					Error:   err.Error(),
 				}
 				continue
 			}
 			if err := ctx.API.RemoveTransport(transportBoxed); err != nil {
-				response[transport] = ElementResponse{
+				response[transport] = elementResponse{
 					Success: false,
 					Error:   err.Error(),
 				}
 				continue
 			}
-			response[transport] = ElementResponse{
+			response[transport] = elementResponse{
 				Success: true,
 			}
 		}
@@ -858,7 +858,7 @@ func (hv *Hypervisor) deleteRoute() http.HandlerFunc {
 func (hv *Hypervisor) deleteRoutes() http.HandlerFunc {
 	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
 		var rids []string
-		response := make(map[string]ElementResponse)
+		response := make(map[string]elementResponse)
 		err := json.NewDecoder(r.Body).Decode(&rids)
 		if err != nil {
 			httputil.WriteJSON(w, r, http.StatusNotFound, err)
@@ -867,7 +867,7 @@ func (hv *Hypervisor) deleteRoutes() http.HandlerFunc {
 		for _, rid := range rids {
 			ridUint64, err := strconv.ParseUint(rid, 10, 32)
 			if err != nil {
-				response[rid] = ElementResponse{
+				response[rid] = elementResponse{
 					Success: false,
 					Error:   err.Error(),
 				}
@@ -875,7 +875,7 @@ func (hv *Hypervisor) deleteRoutes() http.HandlerFunc {
 			}
 			boxedRID := routing.RouteID(ridUint64)
 			if err := ctx.API.RemoveRoutingRule(boxedRID); err != nil {
-				response[rid] = ElementResponse{
+				response[rid] = elementResponse{
 					Success: false,
 					Error:   err.Error(),
 				}

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -876,7 +876,11 @@ func (hv *Hypervisor) deleteRoutes() http.HandlerFunc {
 			httputil.WriteJSON(w, r, http.StatusNotFound, err)
 			return
 		}
-		rules, _ := ctx.API.RoutingRules()
+		rules, err := ctx.API.RoutingRules()
+		if err != nil {
+			httputil.WriteJSON(w, r, http.StatusNotFound, err)
+			return
+		}
 		for _, rid := range rids {
 			ridUint64, err := strconv.ParseUint(rid, 10, 32)
 			if err != nil {


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #500 

 Changes:	
-	Add endpoints for bulk deletes of the routes and transports.

How to test this PR:
1. Create a few transports and routes 
2. Run next code to delete routes:
```
curl 'http://localhost:8000/api/visors/02db5bda652554bef5b6166be2cd41f9dec75eff39bd31af0764028b3db921a5ff/routes/' -X DELETE -H 'Content-Type: application/json' --data '["1","2"]'
```
3. Run next code to delete transports:
```
 curl 'http://localhost:8000/api/visors/02db5bda652554bef5b6166be2cd41f9dec75eff39bd31af0764028b3db921a5ff/transports/' -X DELETE -H 'Content-Type: application/json'   --data '["b02db85f-1b5c-0c6d-b76f-9bd974e03aa9", "82a61140-03c8-0766-aca8-e7f078aef46b"]'  
```

