### PR TITLE
Show the correct error msg in the updater

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.html
@@ -104,7 +104,7 @@
             <div class="list-element">
               <div class="left-part">-</div>
               <div class="right-part">
-                {{ node.label }}: <span class="red-text">{{ node.updateProgressInfo.errorMsg }}</span>
+                {{ node.label }}: <span class="red-text">{{ node.updateProgressInfo.errorMsg | translate }}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Previously, in some cases the updater window was showing this after an error:
![err](https://user-images.githubusercontent.com/34079003/99120305-06f45300-25d1-11eb-96ac-958f78705f2a.png)
This PR makes the UI show the correct error msg. 

How to test this PR:
Use the Skywire manager to update a visor. While the visor is still being updated, close the visor. The modal window in the Skywire manager should show an error msg.