### PR TITLE
Fix refreshing of state of the app.

### DIFF
--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -180,8 +180,11 @@ func (l *Launcher) AppStates() []*AppState {
 	var states []*AppState
 	for _, app := range l.apps {
 		state := &AppState{AppConfig: app, Status: AppStatusStopped}
-		if _, ok := l.procM.ProcByName(app.Name); ok {
-			state.Status = AppStatusRunning
+		if proc, ok := l.procM.ProcByName(app.Name); ok {
+			summary := proc.ConnectionsSummary()
+			if summary != nil {
+				state.Status = AppStatusRunning
+			}
 		}
 		states = append(states, state)
 	}


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #571

 Changes:	
-	Add an extended check for the status of the app. 

How to test this PR:
1. Start VPN-client
2. Check the state of the app on the page of the visor
3. Kill the process of the app 
4. Check if the status on-page of the app changed after some delay. 
