### PR TITLE
Add update-config command to visor-cli.

### DIFF
--- a/cmd/skywire-cli/commands/visor/update-config.go
+++ b/cmd/skywire-cli/commands/visor/update-config.go
@@ -32,8 +32,8 @@ func init() {
 	updateConfigCmd.Flags().StringVarP(&addOutput, "output", "o", "skywire-config.json", "path of output config file.")
 	updateConfigCmd.Flags().StringVarP(&addInput, "input", "i", "skywire-config.json", "path of input config file.")
 	updateConfigCmd.Flags().StringVarP(&environment, "environment", "e", "production", "desired environment (values production or testing)")
-	updateConfigCmd.Flags().StringVar(&addHypervisorPKs, "hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
-	updateConfigCmd.Flags().BoolVar(&resetHypervisor, "reset", false, "resets hypervisor`s configuration")
+	updateConfigCmd.Flags().StringVar(&addHypervisorPKs, "add-hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
+	updateConfigCmd.Flags().BoolVar(&resetHypervisor, "reset-hypervisor-pks", false, "resets hypervisor`s configuration")
 }
 
 var updateConfigCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/visor/update-config.go
+++ b/cmd/skywire-cli/commands/visor/update-config.go
@@ -1,0 +1,115 @@
+package visor
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/skycoin/dmsg/cipher"
+	coinCipher "github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/skyenv"
+
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+func init() {
+	RootCmd.AddCommand(updateConfigCmd)
+}
+
+var (
+	addOutput        string
+	addInput         string
+	environment      string
+	resetHypervisor  bool
+	addHypervisorPKs string
+)
+
+func init() {
+	updateConfigCmd.Flags().StringVarP(&addOutput, "output", "o", "skywire-config.json", "path of output config file.")
+	updateConfigCmd.Flags().StringVarP(&addInput, "input", "i", "skywire-config.json", "path of input config file.")
+	updateConfigCmd.Flags().StringVarP(&environment, "environment", "e", "production", "desired environment (values production or testing)")
+	updateConfigCmd.Flags().StringVar(&addHypervisorPKs, "hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
+	updateConfigCmd.Flags().BoolVarP(&resetHypervisor, "reset", "r", false, "resets hypervisor`s configuration")
+}
+
+var updateConfigCmd = &cobra.Command{
+	Use:   "update-config",
+	Short: "Updates a config file",
+	PreRun: func(_ *cobra.Command, _ []string) {
+		var err error
+		if output, err = filepath.Abs(addOutput); err != nil {
+			logger.WithError(err).Fatal("Invalid output provided.")
+		}
+	},
+	Run: func(_ *cobra.Command, _ []string) {
+		mLog := logging.NewMasterLogger()
+		mLog.SetLevel(logrus.InfoLevel)
+		f, err := os.Open(addInput) // nolint: gosec
+		if err != nil {
+			mLog.WithError(err).
+				WithField("filepath", addInput).
+				Fatal("Failed to read config file.")
+		}
+
+		raw, err := ioutil.ReadAll(f)
+		if err != nil {
+			mLog.WithError(err).Fatal("Failed to read config.")
+		}
+		conf, ok := visorconfig.Parse(mLog, addInput, raw)
+		if ok != nil {
+			mLog.WithError(err).Fatal("Failed to parse config.")
+
+		}
+
+		if addHypervisorPKs != "" {
+			keys := strings.Split(addHypervisorPKs, ",")
+			for _, key := range keys {
+				keyParsed, err := coinCipher.PubKeyFromHex(strings.TrimSpace(key))
+				if err != nil {
+					logger.WithError(err).Fatalf("Failed to parse hypervisor private key: %s.", key)
+				}
+				conf.Hypervisors = append(conf.Hypervisors, cipher.PubKey(keyParsed))
+			}
+
+		}
+		if environment == "production" {
+			conf.Dmsg.Discovery = skyenv.DefaultDmsgDiscAddr
+			conf.Transport.Discovery = skyenv.DefaultTpDiscAddr
+			conf.Transport.AddressResolver = skyenv.DefaultAddressResolverAddr
+			conf.Routing.RouteFinder = skyenv.DefaultRouteFinderAddr
+			conf.UptimeTracker = &visorconfig.V1UptimeTracker{
+				Addr: skyenv.DefaultUptimeTrackerAddr,
+			}
+		}
+
+		if environment == "testing" {
+			conf.Dmsg.Discovery = skyenv.TestDmsgDiscAddr
+			conf.Transport.Discovery = skyenv.TestTpDiscAddr
+			conf.Transport.AddressResolver = skyenv.TestAddressResolverAddr
+			conf.Routing.RouteFinder = skyenv.TestRouteFinderAddr
+			conf.UptimeTracker.Addr = skyenv.TestUptimeTrackerAddr
+			conf.Launcher.Discovery.ServiceDisc = skyenv.TestServiceDiscAddr
+
+		}
+		if resetHypervisor {
+			conf.Hypervisors = []cipher.PubKey{}
+		}
+		// Save config to file.
+		if err := conf.Flush(); err != nil {
+			logger.WithError(err).Fatal("Failed to flush config to file.")
+		}
+
+		// Print results.
+		j, err := json.MarshalIndent(conf, "", "\t")
+		if err != nil {
+			logger.WithError(err).Fatal("An unexpected error occurred. Please contact a developer.")
+		}
+		logger.Infof("Updated file '%s' to: %s", output, j)
+	},
+}

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -141,14 +141,7 @@ func MakeTestConfig(log *logging.MasterLogger, confPath string, sk *cipher.SecKe
 	if err != nil {
 		return nil, err
 	}
-
-	conf.Dmsg.Discovery = skyenv.TestDmsgDiscAddr
-	conf.Transport.Discovery = skyenv.TestTpDiscAddr
-	conf.Transport.AddressResolver = skyenv.TestAddressResolverAddr
-	conf.Routing.RouteFinder = skyenv.TestRouteFinderAddr
-	conf.Routing.SetupNodes = []cipher.PubKey{skyenv.MustPK(skyenv.TestSetupPK)}
-	conf.UptimeTracker.Addr = skyenv.TestUptimeTrackerAddr
-	conf.Launcher.Discovery.ServiceDisc = skyenv.TestServiceDiscAddr
+	SetDefaultTestingValues(conf)
 	if conf.Hypervisor != nil {
 		conf.Hypervisor.DmsgDiscovery = conf.Transport.Discovery
 	}
@@ -185,4 +178,27 @@ func MakePackageConfig(log *logging.MasterLogger, confPath string, sk *cipher.Se
 		conf.Hypervisor.TLSCertFile = skyenv.PackageTLSCert
 	}
 	return conf, nil
+}
+
+func SetDefaultTestingValues(conf *V1) {
+	conf.Dmsg.Discovery = skyenv.TestDmsgDiscAddr
+	conf.Transport.Discovery = skyenv.TestTpDiscAddr
+	conf.Transport.AddressResolver = skyenv.TestAddressResolverAddr
+	conf.Routing.RouteFinder = skyenv.TestRouteFinderAddr
+	conf.UptimeTracker.Addr = skyenv.TestUptimeTrackerAddr
+	conf.Launcher.Discovery.ServiceDisc = skyenv.TestServiceDiscAddr
+}
+
+func SetDefaultProductionValues(conf *V1) {
+	conf.Dmsg.Discovery = skyenv.DefaultDmsgDiscAddr
+	conf.Transport.Discovery = skyenv.DefaultTpDiscAddr
+	conf.Transport.AddressResolver = skyenv.DefaultAddressResolverAddr
+	conf.Routing.RouteFinder = skyenv.DefaultRouteFinderAddr
+	conf.UptimeTracker = &V1UptimeTracker{
+		Addr: skyenv.DefaultUptimeTrackerAddr,
+	}
+	conf.Launcher.Discovery = &V1AppDisc{
+		UpdateInterval: Duration(skyenv.AppDiscUpdateInterval),
+		ServiceDisc:    skyenv.DefaultServiceDiscAddr,
+	}
 }

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -180,6 +180,7 @@ func MakePackageConfig(log *logging.MasterLogger, confPath string, sk *cipher.Se
 	return conf, nil
 }
 
+// SetDefaultTestingValues mutates configuration to use testing values
 func SetDefaultTestingValues(conf *V1) {
 	conf.Dmsg.Discovery = skyenv.TestDmsgDiscAddr
 	conf.Transport.Discovery = skyenv.TestTpDiscAddr
@@ -189,6 +190,7 @@ func SetDefaultTestingValues(conf *V1) {
 	conf.Launcher.Discovery.ServiceDisc = skyenv.TestServiceDiscAddr
 }
 
+// SetDefaultProductionValues mutates configuration to use production values
 func SetDefaultProductionValues(conf *V1) {
 	conf.Dmsg.Discovery = skyenv.DefaultDmsgDiscAddr
 	conf.Transport.Discovery = skyenv.DefaultTpDiscAddr


### PR DESCRIPTION
Did you run `make format && make check`?
yes
Fixes #610 

 Changes:	
- Add update-config command to visor-cli.

How to test this PR:
1. Run one of next possible commands:
```
go run cmd/skywire-cli/skywire-cli.go visor update-config --reset
go run cmd/skywire-cli/skywire-cli.go visor update-config -e production
go run cmd/skywire-cli/skywire-cli.go visor update-config -e testing
go run cmd/skywire-cli/skywire-cli.go visor update-config --hypervisor-pks=023d1dc11119a7e2d2207f6c9e94ee88a5801702616ca1ff72bc3b2af785b7c1b8,023d1dc11119a7e2d2207f6c9e94ee88a5801702616ca1ff72bc3b2af785b7c1b8
```
