### PR TITLE
Mark visors with problematic services in the visor list

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -53,6 +53,8 @@ export interface HealthInfo {
   transport_discovery?: number;
   route_finder?: number;
   setup_node?: number;
+  uptime_tracker?: number;
+  address_resolver?: number;
 }
 
 export class ProxyDiscoveryEntry {

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -123,7 +123,6 @@
           </td>
           <td>
             {{ node.local_pk }}
-            <!--<app-copy-to-clipboard-text [short]="true" text="{{ node.local_pk }}" shortTextLength="5"></app-copy-to-clipboard-text>-->
           </td>
           <td *ngIf="showDmsgInfo">
             <app-labeled-element-text

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.scss
@@ -30,3 +30,13 @@
 .small-column {
   width: 1px;
 }
+
+.online-warning {
+  animation: alert-blinking 1s linear infinite;
+}
+
+@keyframes alert-blinking {
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -5,7 +5,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { catchError, mergeMap } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 
-import { NodeService, BackendData } from '../../../services/node.service';
+import { NodeService, BackendData, HealthStatus } from '../../../services/node.service';
 import { Node } from '../../../app.datatypes';
 import { AuthService, AuthStates } from '../../../services/auth.service';
 import { EditLabelComponent } from '../../layout/edit-label/edit-label.component';
@@ -51,6 +51,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
   loading = true;
   dataSource: Node[];
+  nodesHealthInfo: Map<string, HealthStatus>;
   tabsData: TabButtonData[] = [];
   options: MenuOptionData[] = [];
   showDmsgInfo = false;
@@ -304,7 +305,9 @@ export class NodeListComponent implements OnInit, OnDestroy {
   nodeStatusClass(node: Node, forDot: boolean): string {
     switch (node.online) {
       case true:
-        return forDot ? 'dot-green' : 'green-text';
+        return this.nodesHealthInfo.get(node.local_pk).allServicesOk ?
+          (forDot ? 'dot-green' : 'green-text') :
+          (forDot ? 'dot-yellow online-warning' : 'yellow-text');
       default:
         return forDot ? 'dot-red' : 'red-text';
     }
@@ -318,7 +321,9 @@ export class NodeListComponent implements OnInit, OnDestroy {
   nodeStatusText(node: Node, forTooltip: boolean): string {
     switch (node.online) {
       case true:
-        return 'node.statuses.online' + (forTooltip ? '-tooltip' : '');
+        return this.nodesHealthInfo.get(node.local_pk).allServicesOk ?
+          ('node.statuses.online' + (forTooltip ? '-tooltip' : '')) :
+          ('node.statuses.partially-online' + (forTooltip ? '-tooltip' : ''));
       default:
         return 'node.statuses.offline' + (forTooltip ? '-tooltip' : '');
     }
@@ -418,6 +423,12 @@ export class NodeListComponent implements OnInit, OnDestroy {
     } else {
       this.nodesToShow = null;
     }
+
+    // Get the health status of each node.
+    this.nodesHealthInfo = new Map<string, HealthStatus>();
+    this.nodesToShow.forEach(node => {
+      this.nodesHealthInfo.set(node.local_pk, this.nodeService.getHealthStatus(node));
+    });
 
     this.dataSource = this.nodesToShow;
   }

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -46,70 +46,15 @@
   <!-- Health info section. -->
   <div class="d-flex flex-column">
     <span class="section-title">{{ 'node.details.node-health.title' | translate }}</span>
-    <span class="info-line">
-      <span class="title">{{ 'node.details.node-health.status' | translate }}</span>
-      <ng-container *ngIf="node.health.status && node.health.status === 200">
+    <span *ngFor="let service of nodeHealthInfo.services" class="info-line">
+      <span class="title">{{ service.name | translate }}</span>
+      <ng-container *ngIf="service.isOk">
         <i class="dot-green"></i>
         {{ 'common.ok' | translate }}
       </ng-container>
-      <ng-container *ngIf="!node.health.status || node.health.status !== 200">
+      <ng-container *ngIf="!service.isOk">
         <i class="dot-red"></i>
-        {{ node.health.status ? node.health.status : ('node.details.node-health.element-offline' | translate) }}
-      </ng-container>
-    </span>
-    <span class="info-line">
-      <span class="title">{{ 'node.details.node-health.transport-discovery' | translate }}</span>
-      <ng-container *ngIf="node.health.transport_discovery && node.health.transport_discovery === 200">
-        <i class="dot-green"></i>
-        {{ 'common.ok' | translate }}
-      </ng-container>
-      <ng-container *ngIf="!node.health.transport_discovery || node.health.transport_discovery !== 200">
-        <i class="dot-red"></i>
-        {{ node.health.transport_discovery ? node.health.transport_discovery : ('node.details.node-health.element-offline' | translate) }}
-      </ng-container>
-    </span>
-    <span class="info-line">
-      <span class="title">{{ 'node.details.node-health.route-finder' | translate }}</span>
-      <ng-container *ngIf="node.health.route_finder && node.health.route_finder === 200">
-        <i class="dot-green"></i>
-        {{ 'common.ok' | translate }}
-      </ng-container>
-      <ng-container *ngIf="!node.health.route_finder || node.health.route_finder !== 200">
-        <i class="dot-red"></i>
-        {{ node.health.route_finder ? node.health.route_finder : ('node.details.node-health.element-offline' | translate) }}
-      </ng-container>
-    </span>
-    <span class="info-line">
-      <span class="title">{{ 'node.details.node-health.setup-node' | translate }}</span>
-      <ng-container *ngIf="node.health.setup_node && node.health.setup_node === 200">
-        <i class="dot-green"></i>
-        {{ 'common.ok' | translate }}
-      </ng-container>
-      <ng-container *ngIf="!node.health.setup_node || node.health.setup_node !== 200">
-        <i class="dot-red"></i>
-        {{ node.health.setup_node ? node.health.setup_node : ('node.details.node-health.element-offline' | translate) }}
-      </ng-container>
-    </span>
-    <span class="info-line">
-      <span class="title">{{ 'node.details.node-health.uptime-tracker' | translate }}</span>
-      <ng-container *ngIf="node.health.uptime_tracker && node.health.uptime_tracker === 200">
-        <i class="dot-green"></i>
-        {{ 'common.ok' | translate }}
-      </ng-container>
-      <ng-container *ngIf="!node.health.uptime_tracker || node.health.uptime_tracker !== 200">
-        <i class="dot-red"></i>
-        {{ node.health.uptime_tracker ? node.health.uptime_tracker : ('node.details.node-health.element-offline' | translate) }}
-      </ng-container>
-    </span>
-    <span class="info-line">
-      <span class="title">{{ 'node.details.node-health.address-resolver' | translate }}</span>
-      <ng-container *ngIf="node.health.address_resolver && node.health.address_resolver === 200">
-        <i class="dot-green"></i>
-        {{ 'common.ok' | translate }}
-      </ng-container>
-      <ng-container *ngIf="!node.health.address_resolver || node.health.address_resolver !== 200">
-        <i class="dot-red"></i>
-        {{ node.health.address_resolver ? node.health.address_resolver : ('node.details.node-health.element-offline' | translate) }}
+        {{ service.originalValue ? service.originalValue : ('node.details.node-health.element-offline' | translate) }}
       </ng-container>
     </span>
   </div>

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
@@ -6,6 +6,7 @@ import { EditLabelComponent } from 'src/app/components/layout/edit-label/edit-la
 import { NodeComponent } from '../../node.component';
 import TimeUtils, { ElapsedTime } from 'src/app/utils/timeUtils';
 import { LabeledElementTypes, StorageService } from 'src/app/services/storage.service';
+import { NodeService, HealthStatus } from 'src/app/services/node.service';
 
 /**
  * Shows the basic info of a node.
@@ -18,15 +19,18 @@ import { LabeledElementTypes, StorageService } from 'src/app/services/storage.se
 export class NodeInfoContentComponent {
   @Input() set nodeInfo(val: Node) {
     this.node = val;
+    this.nodeHealthInfo = this.nodeService.getHealthStatus(val);
     this.timeOnline = TimeUtils.getElapsedTime(val.seconds_online);
   }
 
   node: Node;
+  nodeHealthInfo: HealthStatus;
   timeOnline: ElapsedTime;
 
   constructor(
     private dialog: MatDialog,
     public storageService: StorageService,
+    private nodeService: NodeService,
   ) { }
 
   showEditLabelDialog() {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -82,9 +82,11 @@
     "not-found": "Visor not found.",
     "statuses": {
       "online": "Online",
-      "online-tooltip": "Visor is online",
+      "online-tooltip": "Visor is online.",
+      "partially-online": "Online with problems",
+      "partially-online-tooltip": "Visor is online but not all services are working. For more information, open the details page and check the \"Health info\" section.",
       "offline": "Offline",
-      "offline-tooltip": "Visor is offline"
+      "offline-tooltip": "Visor is offline."
     },
     "details": {
       "node-info": {
@@ -116,7 +118,7 @@
         "setup-node": "Setup node:",
         "uptime-tracker": "Uptime tracker:",
         "address-resolver": "Address resolver:",
-        "element-offline": "offline"
+        "element-offline": "Offline"
       },
       "node-traffic-data": "Traffic data"
     },

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -79,9 +79,11 @@
     "not-found": "Visor no encontrado.",
     "statuses": {
       "online": "Online",
-      "online-tooltip": "El visor está online",
+      "online-tooltip": "El visor se encuentra online.",
+      "partially-online": "Online con problemas",
+      "partially-online-tooltip": "El visor se encuentra online pero no todos los servicios están funcionando. Para más información, abra la página de detalles y consulte la sección \"Información de salud\".",
       "offline": "Offline",
-      "offline-tooltip": "El visor está offline"
+      "offline-tooltip": "El visor se encuentra offline."
     },
     "details": {
       "node-info": {
@@ -113,7 +115,7 @@
         "setup-node": "Setup node:",
         "uptime-tracker": "Uptime tracker:",
         "address-resolver": "Address resolver:",
-        "element-offline": "offline"
+        "element-offline": "Offline"
       },
       "node-traffic-data": "Datos de tráfico"
     },

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -79,9 +79,11 @@
     "not-found": "Visor not found.",
     "statuses": {
       "online": "Online",
-      "online-tooltip": "Visor is online",
+      "online-tooltip": "Visor is online.",
+      "partially-online": "Online with problems",
+      "partially-online-tooltip": "Visor is online but not all services are working. For more information, open the details page and check the \"Health info\" section.",
       "offline": "Offline",
-      "offline-tooltip": "Visor is offline"
+      "offline-tooltip": "Visor is offline."
     },
     "details": {
       "node-info": {
@@ -113,7 +115,7 @@
         "setup-node": "Setup node:",
         "uptime-tracker": "Uptime tracker:",
         "address-resolver": "Address resolver:",
-        "element-offline": "offline"
+        "element-offline": "Offline"
       },
       "node-traffic-data": "Traffic data"
     },

--- a/static/skywire-manager-src/src/assets/scss/_icons.scss
+++ b/static/skywire-manager-src/src/assets/scss/_icons.scss
@@ -2,6 +2,7 @@
 $dot-icons: (
   green: theme-color(green),
   red: theme-color(red),
+  yellow: theme-color(yellow),
 );
 
 $dot-size:    10px;

--- a/static/skywire-manager-src/src/assets/scss/_variables.scss
+++ b/static/skywire-manager-src/src/assets/scss/_variables.scss
@@ -26,6 +26,7 @@ $grey-separator: rgba(0, 0, 0, 0.12);
 $theme-colors: (
   green:              $green,
   red:                $red,
+  yellow:             $yellow,
   translucid-hover:   rgba(0, 0, 0, 0.2),
   white:              $white,
   light-gray:         $light-gray


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now, if one or more services of a visor is not working, the dot shown at the left of the visor in the visor list is shown yellow and blinking, to make it easier to know when a visor has a problem.
- The code for checking the state of the visor services was changed, to make it centralized and use the same code in the visor details page and the visor list. This was made to make the code more maintainable and to avoid potential errors in the future, if changes are made only in one page.

How to test this PR:
Make one of the visors have trouble connecting with a service (like the uptime tracker or the transport discovery). The affected visor must have a yellow dot at the left in the visor list, instead of the green dot used for indicating that the visor is working well. Also, the “health info” section of the visor details page should continue working well.