### PR TITLE
fix update cmd

### DIFF
--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -186,6 +186,7 @@ func SetDefaultTestingValues(conf *V1) {
 	conf.Transport.Discovery = skyenv.TestTpDiscAddr
 	conf.Transport.AddressResolver = skyenv.TestAddressResolverAddr
 	conf.Routing.RouteFinder = skyenv.TestRouteFinderAddr
+	conf.Routing.SetupNodes = []cipher.PubKey{skyenv.MustPK(skyenv.TestSetupPK)}
 	conf.UptimeTracker.Addr = skyenv.TestUptimeTrackerAddr
 	conf.Launcher.Discovery.ServiceDisc = skyenv.TestServiceDiscAddr
 }
@@ -196,6 +197,7 @@ func SetDefaultProductionValues(conf *V1) {
 	conf.Transport.Discovery = skyenv.DefaultTpDiscAddr
 	conf.Transport.AddressResolver = skyenv.DefaultAddressResolverAddr
 	conf.Routing.RouteFinder = skyenv.DefaultRouteFinderAddr
+	conf.Routing.SetupNodes = []cipher.PubKey{skyenv.MustPK(skyenv.DefaultSetupPK)}
 	conf.UptimeTracker = &V1UptimeTracker{
 		Addr: skyenv.DefaultUptimeTrackerAddr,
 	}


### PR DESCRIPTION
Did you run `make format && make check`?

Yes

Fixes problem with `update-config` cmd. Previously it did not update the Setup Node PK. 

How to test this PR:

-  build this PR and use `update-config -e testing/production`. The Setup Node PK should be updated correspondingly.
