### PR TITLE
Fix/dup syscall portability

### DIFF
--- a/pkg/util/stdio/all_dup.go
+++ b/pkg/util/stdio/all_dup.go
@@ -1,0 +1,11 @@
+// +build !arm64
+
+package stdio
+
+import "syscall"
+
+// DupTo duplicates old fd into the new fd
+// see dup2 and dup3 system calls
+func DupTo(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/pkg/util/stdio/arm_dup.go
+++ b/pkg/util/stdio/arm_dup.go
@@ -1,0 +1,11 @@
+// +build arm64
+
+package stdio
+
+import "syscall"
+
+// DupTo duplicates old fd into the new fd
+// see dup2 and dup3 system calls
+func DupTo(oldfd, newfd int) error {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/pkg/util/stdio/stdio.go
+++ b/pkg/util/stdio/stdio.go
@@ -22,6 +22,7 @@ type OutputCapturer interface {
 	Release() error
 }
 
+// NewCapturer creates a new output capturer
 func NewCapturer() OutputCapturer {
 	return &outputCapturer{}
 }

--- a/pkg/util/stdio/stdio.go
+++ b/pkg/util/stdio/stdio.go
@@ -1,0 +1,122 @@
+package stdio
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+var ErrReleaseNoncaptured = errors.New("releasing non-captured output")
+
+type OutputCapturer interface {
+	CaptureStdout() (io.Writer, error)
+	Release() error
+}
+
+func NewCapturer() OutputCapturer {
+	return &outputCapturer{}
+}
+
+type outputCapturer struct {
+	capturing    bool
+	origStdoutFD int
+	origStderrFD int
+	stdoutReader *os.File
+	stderrReader *os.File
+	stdoutWriter *os.File
+	stderrWriter *os.File
+}
+
+func (oc *outputCapturer) CaptureStdout() (io.Writer, error) {
+	oc.capturing = true
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	oldStdout, err := syscall.Dup(syscall.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Dup2(int(stdoutWriter.Fd()), syscall.Stdout); err != nil {
+		return nil, err
+	}
+
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	oldStderr, err := syscall.Dup(syscall.Stderr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Dup2(int(stderrWriter.Fd()), syscall.Stderr); err != nil {
+		return nil, err
+	}
+
+	oc.origStdoutFD = oldStdout
+	oc.origStderrFD = oldStderr
+	oc.stdoutReader = stdoutReader
+	oc.stderrReader = stderrReader
+	oc.stdoutWriter = stdoutWriter
+	oc.stderrWriter = stderrWriter
+
+	origStdoutWriter := os.NewFile(uintptr(oc.origStdoutFD), "/dev/stdout")
+	return origStdoutWriter, nil
+}
+
+func (oc *outputCapturer) Release() error {
+	if !oc.capturing {
+		return ErrReleaseNoncaptured
+	}
+	if err := oc.stdoutWriter.Close(); err != nil {
+		return err
+	}
+
+	if err := oc.stderrWriter.Close(); err != nil {
+		return err
+	}
+
+	if err := syscall.Close(syscall.Stdout); err != nil {
+		return err
+	}
+
+	if err := syscall.Close(syscall.Stderr); err != nil {
+		return err
+	}
+
+	if err := syscall.Dup2(oc.origStdoutFD, syscall.Stdout); err != nil {
+		return err
+	}
+
+	if err := syscall.Dup2(oc.origStderrFD, syscall.Stderr); err != nil {
+		return err
+	}
+
+	var stdoutBuffer bytes.Buffer
+	var stderrBuffer bytes.Buffer
+
+	if _, err := io.Copy(&stdoutBuffer, oc.stdoutReader); err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(&stderrBuffer, oc.stderrReader); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprint(os.Stdout, stdoutBuffer.String()); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprint(os.Stderr, stderrBuffer.String()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/util/updater/updater.go
+++ b/pkg/util/updater/updater.go
@@ -3,7 +3,6 @@
 package updater
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,7 +16,6 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"unicode"
 
 	"github.com/google/go-github/github"
@@ -29,6 +27,7 @@ import (
 	"github.com/skycoin/skywire/pkg/restart"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/util/rename"
+	"github.com/skycoin/skywire/pkg/util/stdio"
 )
 
 const (
@@ -422,20 +421,19 @@ func (u *Updater) downloadChecksums(url string) (checksums string, err error) {
 		return "", fmt.Errorf("received bad status code: %d", resp.StatusCode)
 	}
 
-	output, err := captureOutput()
+	capturer := stdio.NewCapturer()
+	stdoutWriter, err := capturer.CaptureStdout()
 	if err != nil {
 		return "", err
 	}
 
 	defer func() {
-		if err := output.release(); err != nil {
+		if err := capturer.Release(); err != nil {
 			u.log.Errorf("Failed to release output: %w", err)
 		}
 	}()
 
-	origStdoutWriter := os.NewFile(uintptr(output.origStdout), "/dev/stdout")
-
-	r := io.TeeReader(resp.Body, u.progressBar(origStdoutWriter, resp.ContentLength, checksumsFilename))
+	r := io.TeeReader(resp.Body, u.progressBar(stdoutWriter, resp.ContentLength, checksumsFilename))
 
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -454,103 +452,6 @@ func (u *Updater) progressBar(w io.Writer, contentLength int64, filename string)
 	completion := progressbar.OptionOnCompletion(func() { fmt.Printf("\n") })
 
 	return progressbar.NewOptions64(contentLength, speed, completion, width, theme, desc, writer)
-}
-
-func captureOutput() (output, error) {
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		return output{}, err
-	}
-
-	oldStdout, err := syscall.Dup(syscall.Stdout)
-	if err != nil {
-		return output{}, err
-	}
-
-	if err := syscall.Dup2(int(stdoutWriter.Fd()), syscall.Stdout); err != nil {
-		return output{}, err
-	}
-
-	stderrReader, stderrWriter, err := os.Pipe()
-	if err != nil {
-		return output{}, err
-	}
-
-	oldStderr, err := syscall.Dup(syscall.Stderr)
-	if err != nil {
-		return output{}, err
-	}
-
-	if err := syscall.Dup2(int(stderrWriter.Fd()), syscall.Stderr); err != nil {
-		return output{}, err
-	}
-
-	output := output{
-		origStdout:   oldStdout,
-		origStderr:   oldStderr,
-		stdoutReader: stdoutReader,
-		stderrReader: stderrReader,
-		stdoutWriter: stdoutWriter,
-		stderrWriter: stderrWriter,
-	}
-
-	return output, nil
-}
-
-type output struct {
-	origStdout   int
-	origStderr   int
-	stdoutReader *os.File
-	stderrReader *os.File
-	stdoutWriter *os.File
-	stderrWriter *os.File
-}
-
-func (o *output) release() error {
-	if err := o.stdoutWriter.Close(); err != nil {
-		return err
-	}
-
-	if err := o.stderrWriter.Close(); err != nil {
-		return err
-	}
-
-	if err := syscall.Close(syscall.Stdout); err != nil {
-		return err
-	}
-
-	if err := syscall.Close(syscall.Stderr); err != nil {
-		return err
-	}
-
-	if err := syscall.Dup2(o.origStdout, syscall.Stdout); err != nil {
-		return err
-	}
-
-	if err := syscall.Dup2(o.origStderr, syscall.Stderr); err != nil {
-		return err
-	}
-
-	var stdoutBuffer bytes.Buffer
-	var stderrBuffer bytes.Buffer
-
-	if _, err := io.Copy(&stdoutBuffer, o.stdoutReader); err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(&stderrBuffer, o.stderrReader); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprint(os.Stdout, stdoutBuffer.String()); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprint(os.Stderr, stderrBuffer.String()); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (u *Updater) downloadFile(url, filename string) (path string, err error) {
@@ -584,20 +485,19 @@ func (u *Updater) downloadFile(url, filename string) (path string, err error) {
 		return "", err
 	}
 
-	output, err := captureOutput()
+	capturer := stdio.NewCapturer()
+	stdoutWriter, err := capturer.CaptureStdout()
 	if err != nil {
 		return "", err
 	}
 
 	defer func() {
-		if err := output.release(); err != nil {
+		if err := capturer.Release(); err != nil {
 			u.log.Errorf("Failed to release output: %w", err)
 		}
 	}()
 
-	origStdoutWriter := os.NewFile(uintptr(output.origStdout), "/dev/stdout")
-
-	out := io.MultiWriter(f, u.progressBar(origStdoutWriter, resp.ContentLength, filename))
+	out := io.MultiWriter(f, u.progressBar(stdoutWriter, resp.ContentLength, filename))
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
 		return "", err


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes:
- Release build for arm64

Changes:	

How to test this PR:
make test

dup2 syscall is absent on arm64 architecture, while dup3 is absent on darwin OS. This implements common function that has build-specific implementations