### PR TITLE
Fix VPN client duplicates

### DIFF
--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -667,10 +667,23 @@ func (c *Client) dialServer(appCl *app.Client, pk cipher.PubKey) (net.Conn, erro
 			PubKey: pk,
 			Port:   vpnPort,
 		})
+
+		if c.isClosed() {
+			// in this case client got closed, we return no error,
+			// so that retrier could stop gracefully
+			return nil
+		}
+
 		return err
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if c.isClosed() {
+		// we need to signal outer code that connection object is inalid
+		// in this case
+		return nil, errors.New("client got closed")
 	}
 
 	return conn, nil


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #641 #636 

 Changes:	
- Now VPN client exits gracefully during dialing. Previously dialing couldn't be interrupted. So, when we changed anything or tried to stop the app, the request just hung waiting for the process to stop. And this waiting eventually gets interrupted with an error. In this case we just decouple process from the visor due to the internal architecture, therefore allowing app duplicates. However, this shouldn't be a problem for a well-written (in terms of interruption) apps

How to test this PR:
Repeat steps from the original ticket. Step 3 should complete and app should be restarted. Also VPN client should be closed on visor shut down without any duplicates. Also, previously issue could be reproduced not by changing the app arg, but just stopping it and refreshing page afterwards (when stop hung). This should work too, app should be stopped ok during dialing