### PR TITLE
Improvements for how the manager gets the data

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -1,20 +1,16 @@
-// Most classes are based on the responses returned by the API, but
-// sometimes with some extra fields which are calculated internally in the app.
-
 export class Node {
-  tcp_addr: string;
+  label: string;
+  localPk: string;
+  tcpAddr: string;
   ip: string;
   port: string;
-  local_pk: string;
-  node_version: string;
-  app_protocol_version: string;
+  version: string;
   apps: Application[];
   transports: Transport[];
-  routes_count: number;
+  routesCount: number;
   routes?: Route[];
-  label?: string;
   online?: boolean;
-  seconds_online?: number;
+  secondsOnline?: number;
   health?: HealthInfo;
   dmsgServerPk?: string;
   roundTripPing?: string;
@@ -26,19 +22,15 @@ export interface Application {
   autostart: boolean;
   port: number;
   status: number;
-  args?: any[];
+  args: any[];
 }
 
 export interface Transport {
+  isUp: boolean;
   id: string;
-  local_pk: string;
-  remote_pk: string;
+  localPk: string;
+  remotePk: string;
   type: string;
-  log?: TransportLog;
-  is_up: boolean;
-}
-
-export interface TransportLog {
   recv: number|null;
   sent: number|null;
 }
@@ -46,15 +38,42 @@ export interface TransportLog {
 export interface Route {
   key: number;
   rule: string;
+  ruleSummary?: RouteRuleSummary;
+  appFields?: RouteAppRuleSumary;
+  forwardFields?: RouteForwardRuleSumary;
+  intermediaryForwardFields?: RouteForwardRuleSumary;
+}
+
+export interface RouteRuleSummary {
+  keepAlive: number;
+  ruleType: number;
+  keyRouteId: number;
+}
+
+interface RouteAppRuleSumary {
+  routeDescriptor: RouteDescriptor;
+}
+
+interface RouteForwardRuleSumary {
+  nextRid: number;
+  nextTid: string;
+  routeDescriptor?: RouteDescriptor;
+}
+
+interface RouteDescriptor {
+  dstPk: string;
+  srcPk: string;
+  dstPort: number;
+  srcPort: number;
 }
 
 export interface HealthInfo {
-  status?: number;
-  transport_discovery?: number;
-  route_finder?: number;
-  setup_node?: number;
-  uptime_tracker?: number;
-  address_resolver?: number;
+  status: number;
+  transportDiscovery: number;
+  routeFinder: number;
+  setupNode: number;
+  uptimeTracker: number;
+  addressResolver: number;
 }
 
 export class ProxyDiscoveryEntry {

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -122,7 +122,7 @@
             {{ node.label }}
           </td>
           <td>
-            {{ node.local_pk }}
+            {{ node.localPk }}
           </td>
           <td *ngIf="showDmsgInfo">
             <app-labeled-element-text
@@ -214,7 +214,7 @@
               </div>
               <div class="list-row long-content">
                 <span class="title">{{ 'nodes.key' | translate }}</span>:
-                {{ node.local_pk }}
+                {{ node.localPk }}
               </div>
               <div class="list-row long-content" *ngIf="showDmsgInfo">
                 <span class="title">{{ 'nodes.dmsg-server' | translate }}</span>:

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -39,7 +39,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
   hypervisorSortData = new SortingColumn(['isHypervisor'], 'nodes.hypervisor', SortingModes.Boolean);
   stateSortData = new SortingColumn(['online'], 'nodes.state', SortingModes.Boolean);
   labelSortData = new SortingColumn(['label'], 'nodes.label', SortingModes.Text);
-  keySortData = new SortingColumn(['local_pk'], 'nodes.key', SortingModes.Text);
+  keySortData = new SortingColumn(['localPk'], 'nodes.key', SortingModes.Text);
   dmsgServerSortData = new SortingColumn(['dmsgServerPk'], 'nodes.dmsg-server', SortingModes.Text, ['dmsgServerPk_label']);
   pingSortData = new SortingColumn(['roundTripPing'], 'nodes.ping', SortingModes.Number);
 
@@ -95,7 +95,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
     },
     {
       filterName: 'nodes.filter-dialog.key',
-      keyNameInElementsArray: 'local_pk',
+      keyNameInElementsArray: 'localPk',
       type: FilterFieldTypes.TextInput,
       maxlength: 66,
     },
@@ -305,7 +305,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
   nodeStatusClass(node: Node, forDot: boolean): string {
     switch (node.online) {
       case true:
-        return this.nodesHealthInfo.get(node.local_pk).allServicesOk ?
+        return this.nodesHealthInfo.get(node.localPk).allServicesOk ?
           (forDot ? 'dot-green' : 'green-text') :
           (forDot ? 'dot-yellow online-warning' : 'yellow-text');
       default:
@@ -321,7 +321,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
   nodeStatusText(node: Node, forTooltip: boolean): string {
     switch (node.online) {
       case true:
-        return this.nodesHealthInfo.get(node.local_pk).allServicesOk ?
+        return this.nodesHealthInfo.get(node.localPk).allServicesOk ?
           ('node.statuses.online' + (forTooltip ? '-tooltip' : '')) :
           ('node.statuses.partially-online' + (forTooltip ? '-tooltip' : ''));
       default:
@@ -424,13 +424,15 @@ export class NodeListComponent implements OnInit, OnDestroy {
       this.nodesToShow = null;
     }
 
-    // Get the health status of each node.
-    this.nodesHealthInfo = new Map<string, HealthStatus>();
-    this.nodesToShow.forEach(node => {
-      this.nodesHealthInfo.set(node.local_pk, this.nodeService.getHealthStatus(node));
-    });
+    if (this.nodesToShow) {
+      // Get the health status of each node.
+      this.nodesHealthInfo = new Map<string, HealthStatus>();
+      this.nodesToShow.forEach(node => {
+        this.nodesHealthInfo.set(node.localPk, this.nodeService.getHealthStatus(node));
+      });
 
-    this.dataSource = this.nodesToShow;
+      this.dataSource = this.nodesToShow;
+    }
   }
 
   logout() {
@@ -457,7 +459,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
     const nodesData: NodeData[] = [];
     this.dataSource.forEach(node => {
       nodesData.push({
-        key: node.local_pk,
+        key: node.localPk,
         label: node.label,
       });
     });
@@ -530,7 +532,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
     SelectOptionComponent.openDialog(this.dialog, options, 'common.options').afterClosed().subscribe((selectedOption: number) => {
       if (selectedOption === 1) {
-        this.copySpecificTextToClipboard(node.local_pk);
+        this.copySpecificTextToClipboard(node.localPk);
       } else if (this.showDmsgInfo) {
         if (selectedOption === 2) {
           this.copySpecificTextToClipboard(node.dmsgServerPk);
@@ -555,7 +557,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
    */
   copyToClipboard(node: Node) {
     if (!this.showDmsgInfo) {
-      this.copySpecificTextToClipboard(node.local_pk);
+      this.copySpecificTextToClipboard(node.localPk);
     } else {
       const options: SelectableOption[] = [
         {
@@ -570,7 +572,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
       SelectOptionComponent.openDialog(this.dialog, options, 'common.options').afterClosed().subscribe((selectedOption: number) => {
         if (selectedOption === 1) {
-          this.copySpecificTextToClipboard(node.local_pk);
+          this.copySpecificTextToClipboard(node.localPk);
         } else if (selectedOption === 2) {
           this.copySpecificTextToClipboard(node.dmsgServerPk);
         }
@@ -592,10 +594,10 @@ export class NodeListComponent implements OnInit, OnDestroy {
    * Opens the modal window for changing the label of a node.
    */
   showEditLabelDialog(node: Node) {
-    let labelInfo =  this.storageService.getLabelInfo(node.local_pk);
+    let labelInfo =  this.storageService.getLabelInfo(node.localPk);
     if (!labelInfo) {
       labelInfo = {
-        id: node.local_pk,
+        id: node.localPk,
         label: '',
         identifiedElementType: LabeledElementTypes.Node,
       };
@@ -616,7 +618,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
     confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
       confirmationDialog.close();
-      this.storageService.setLocalNodesAsHidden([node.local_pk]);
+      this.storageService.setLocalNodesAsHidden([node.localPk]);
       this.forceDataRefresh();
       this.snackbarService.showDone('nodes.deleted');
     });
@@ -640,7 +642,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
       const nodesToRemove: string[] = [];
       this.filteredNodes.forEach(node => {
         if (!node.online) {
-          nodesToRemove.push(node.local_pk);
+          nodesToRemove.push(node.localPk);
         }
       });
 
@@ -664,7 +666,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
    */
   open(node: Node) {
     if (node.online) {
-      this.router.navigate(['nodes', node.local_pk]);
+      this.router.navigate(['nodes', node.localPk]);
     }
   }
 }

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -1,5 +1,4 @@
-import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { Component, AfterViewInit, OnDestroy, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
@@ -13,8 +12,6 @@ import { NodeService } from 'src/app/services/node.service';
 import { OperationError } from 'src/app/utils/operation-error';
 import { processServiceError } from 'src/app/utils/errors';
 import { SelectableOption, SelectOptionComponent } from 'src/app/components/layout/select-option/select-option.component';
-import { ConfirmationData, ConfirmationComponent } from 'src/app/components/layout/confirmation/confirmation.component';
-import { AppConfig } from 'src/app/app.config';
 import { MenuOptionData } from 'src/app/components/layout/top-bar/top-bar.component';
 import { UpdateComponent } from 'src/app/components/layout/update/update.component';
 import { StorageService } from 'src/app/services/storage.service';

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/all-apps/all-apps.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/all-apps/all-apps.component.ts
@@ -21,7 +21,7 @@ export class AllAppsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Get the node data from the parent page.
     this.dataSubscription = NodeComponent.currentNode.subscribe((node: Node) => {
-      this.nodePK = node.local_pk;
+      this.nodePK = node.localPk;
       this.apps = node.apps;
     });
   }

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/apps.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/apps.component.ts
@@ -21,7 +21,7 @@ export class AppsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Get the node data from the parent page.
     this.dataSubscription = NodeComponent.currentNode.subscribe((node: Node) => {
-      this.nodePK = node.local_pk;
+      this.nodePK = node.localPk;
       this.apps = node.apps;
     });
   }

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -11,7 +11,7 @@
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.public-key' | translate }}&nbsp;</span>
-      <app-copy-to-clipboard-text text="{{ node.local_pk }}"></app-copy-to-clipboard-text>
+      <app-copy-to-clipboard-text text="{{ node.localPk }}"></app-copy-to-clipboard-text>
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.port' | translate }}&nbsp;</span>
@@ -27,7 +27,7 @@
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.node-version' | translate }}</span>
-      {{ node.build_info.version ? node.build_info.version : ('common.unknown' | translate) }}
+      {{ node.version ? node.version : ('common.unknown' | translate) }}
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.time.title' | translate }}</span>

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
@@ -20,7 +20,7 @@ export class NodeInfoContentComponent {
   @Input() set nodeInfo(val: Node) {
     this.node = val;
     this.nodeHealthInfo = this.nodeService.getHealthStatus(val);
-    this.timeOnline = TimeUtils.getElapsedTime(val.seconds_online);
+    this.timeOnline = TimeUtils.getElapsedTime(val.secondsOnline);
   }
 
   node: Node;
@@ -34,10 +34,10 @@ export class NodeInfoContentComponent {
   ) { }
 
   showEditLabelDialog() {
-    let labelInfo =  this.storageService.getLabelInfo(this.node.local_pk);
+    let labelInfo =  this.storageService.getLabelInfo(this.node.localPk);
     if (!labelInfo) {
       labelInfo = {
-        id: this.node.local_pk,
+        id: this.node.localPk,
         label: '',
         identifiedElementType: LabeledElementTypes.Node,
       };

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/all-routes/all-routes.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/all-routes/all-routes.component.ts
@@ -21,7 +21,7 @@ export class AllRoutesComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Get the node data from the parent page.
     this.dataSubscription = NodeComponent.currentNode.subscribe((node: Node) => {
-      this.nodePK = node.local_pk;
+      this.nodePK = node.localPk;
       this.routes = node.routes;
     });
   }

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/all-transports/all-transports.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/all-transports/all-transports.component.ts
@@ -21,7 +21,7 @@ export class AllTransportsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Get the node data from the parent page.
     this.dataSubscription = NodeComponent.currentNode.subscribe((node: Node) => {
-      this.nodePK = node.local_pk;
+      this.nodePK = node.localPk;
       this.transports = node.transports;
     });
   }

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.html
@@ -1,6 +1,5 @@
 <app-dialog class="info-dialog" [headline]="'routes.details.title' | translate">
-  <app-loading-indicator [showWhite]="false" *ngIf="!routeRule"></app-loading-indicator>
-  <div *ngIf="routeRule">
+  <div>
     <!-- Basic info. -->
     <div class="title mt-0">
       <mat-icon [inline]="true">list</mat-icon>{{ 'routes.details.basic.title' | translate }}
@@ -13,89 +12,86 @@
     </div>
 
     <!-- Rule summary. -->
-    <div *ngIf="routeRule.rule_summary">
+    <div *ngIf="routeRule.ruleSummary">
       <div class="title">
         <mat-icon [inline]="true">list</mat-icon>{{ 'routes.details.summary.title' | translate }}
       </div>
       <div class="item">
-        <span>{{ 'routes.details.summary.keep-alive' | translate }}</span> {{ routeRule.rule_summary.keep_alive }}
+        <span>{{ 'routes.details.summary.keep-alive' | translate }}</span> {{ routeRule.ruleSummary.keepAlive }}
       </div>
       <div class="item">
-        <span>{{ 'routes.details.summary.type' | translate }}</span> {{ getRuleTypeName(routeRule.rule_summary.rule_type) }}
+        <span>{{ 'routes.details.summary.type' | translate }}</span> {{ getRuleTypeName(routeRule.ruleSummary.ruleType) }}
       </div>
       <div class="item">
-        <span>{{ 'routes.details.summary.key-route-id' | translate }}</span> {{ routeRule.rule_summary.key_route_id }}
+        <span>{{ 'routes.details.summary.key-route-id' | translate }}</span> {{ routeRule.ruleSummary.keyRouteId }}
       </div>
 
       <!-- Title for the specific rule type. -->
-      <div *ngIf="routeRule.rule_summary.app_fields" class="title">
+      <div *ngIf="routeRule.appFields" class="title">
         <mat-icon [inline]="true">settings</mat-icon>{{ 'routes.details.specific-fields-titles.app' | translate }}
       </div>
-      <div *ngIf="routeRule.rule_summary.forward_fields" class="title">
+      <div *ngIf="routeRule.forwardFields" class="title">
         <mat-icon [inline]="true">swap_horiz</mat-icon>{{ 'routes.details.specific-fields-titles.forward' | translate }}
       </div>
-      <div *ngIf="routeRule.rule_summary.intermediary_forward_fields" class="title">
+      <div *ngIf="routeRule.intermediaryForwardFields" class="title">
         <mat-icon [inline]="true">arrow_forward</mat-icon>{{ 'routes.details.specific-fields-titles.intermediary-forward' | translate }}
       </div>
 
       <!-- Fields for the forward and intermediary forward rules. -->
-      <div *ngIf="
-        (routeRule.rule_summary.forward_fields ||
-        routeRule.rule_summary.intermediary_forward_fields)"
-      >
+      <div *ngIf="(routeRule.forwardFields || routeRule.intermediaryForwardFields)">
         <div class="item">
           <span>{{ 'routes.details.specific-fields.route-id' | translate }}</span>
           {{
-            routeRule.rule_summary.forward_fields ?
-              routeRule.rule_summary.forward_fields.next_rid :
-              routeRule.rule_summary.intermediary_forward_fields.next_rid
+            routeRule.forwardFields ?
+              routeRule.forwardFields.nextRid :
+              routeRule.intermediaryForwardFields.nextRid
           }}
         </div>
         <div class="item">
           <span>{{ 'routes.details.specific-fields.transport-id' | translate }}</span>
           {{
-            routeRule.rule_summary.forward_fields ?
-              routeRule.rule_summary.forward_fields.next_tid :
-              routeRule.rule_summary.intermediary_forward_fields.next_tid
+            routeRule.forwardFields ?
+              routeRule.forwardFields.nextTid :
+              routeRule.intermediaryForwardFields.nextTid
           }}
         </div>
       </div>
 
       <!-- Fields for the app and forward rules. -->
       <div *ngIf="
-        ((routeRule.rule_summary.app_fields && routeRule.rule_summary.app_fields.route_descriptor) ||
-        (routeRule.rule_summary.forward_fields && routeRule.rule_summary.forward_fields.route_descriptor))"
+        ((routeRule.appFields && routeRule.appFields.routeDescriptor) ||
+        (routeRule.forwardFields && routeRule.forwardFields.routeDescriptor))"
       >
         <div class="item">
           <span>{{ 'routes.details.specific-fields.destination-pk' | translate }}</span>
           {{
-            routeRule.rule_summary.app_fields ?
-              routeRule.rule_summary.app_fields.route_descriptor.dst_pk :
-              routeRule.rule_summary.forward_fields.route_descriptor.dst_pk
+            routeRule.appFields ?
+              routeRule.appFields.routeDescriptor.dstPk :
+              routeRule.forwardFields.routeDescriptor.dstPk
           }}
         </div>
         <div class="item">
           <span>{{ 'routes.details.specific-fields.source-pk' | translate }}</span>
           {{
-            routeRule.rule_summary.app_fields ?
-              routeRule.rule_summary.app_fields.route_descriptor.src_pk :
-              routeRule.rule_summary.forward_fields.route_descriptor.src_pk
+            routeRule.appFields ?
+              routeRule.appFields.routeDescriptor.srcPk :
+              routeRule.forwardFields.routeDescriptor.srcPk
           }}
         </div>
         <div class="item">
           <span>{{ 'routes.details.specific-fields.destination-port' | translate }}</span>
           {{
-            routeRule.rule_summary.app_fields ?
-              routeRule.rule_summary.app_fields.route_descriptor.dst_port :
-              routeRule.rule_summary.forward_fields.route_descriptor.dst_port
+            routeRule.appFields ?
+              routeRule.appFields.routeDescriptor.dstPort :
+              routeRule.forwardFields.routeDescriptor.dstPort
           }}
         </div>
         <div class="item">
           <span>{{ 'routes.details.specific-fields.source-port' | translate }}</span>
           {{
-            routeRule.rule_summary.app_fields ?
-              routeRule.rule_summary.app_fields.route_descriptor.src_port :
-              routeRule.rule_summary.forward_fields.route_descriptor.src_port
+            routeRule.appFields ?
+              routeRule.appFields.routeDescriptor.srcPort :
+              routeRule.forwardFields.routeDescriptor.srcPort
           }}
         </div>
       </div>

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.html
@@ -89,7 +89,7 @@
       </td>
       <td class="actions">
         <button
-          (click)="details(route.key)"
+          (click)="details(route)"
           mat-icon-button
           [matTooltip]="'routes.details.title' | translate"
           class="action-button transparent-button"

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.ts
@@ -218,7 +218,7 @@ export class RouteListComponent implements OnDestroy {
 
     SelectOptionComponent.openDialog(this.dialog, options, 'common.options').afterClosed().subscribe((selectedOption: number) => {
       if (selectedOption === 1) {
-        this.details(route.key.toString());
+        this.details(route);
       } else if (selectedOption === 2) {
         this.delete(route.key);
       }
@@ -228,7 +228,7 @@ export class RouteListComponent implements OnDestroy {
   /**
    * Shows a modal window with the details of a route.
    */
-  details(route: string) {
+  details(route: Route) {
     RouteDetailsComponent.openDialog(this.dialog, route);
   }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/routing.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/routing.component.ts
@@ -22,7 +22,7 @@ export class RoutingComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Get the node data from the parent page.
     this.dataSubscription = NodeComponent.currentNode.subscribe((node: Node) => {
-      this.nodePK = node.local_pk;
+      this.nodePK = node.localPk;
       this.transports = node.transports;
       this.routes = node.routes;
     });

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-details/transport-details.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-details/transport-details.component.html
@@ -5,18 +5,18 @@
     </div>
     <div class="item">
       <span>{{ 'transports.details.basic.state' | translate }}</span>
-      <div [class]="'d-inline ' + (data.is_up ? 'green-text' : 'red-text')">
-        {{ ('transports.statuses.' + (data.is_up ? 'online' : 'offline')) | translate }}
+      <div [class]="'d-inline ' + (data.isUp ? 'green-text' : 'red-text')">
+        {{ ('transports.statuses.' + (data.isUp ? 'online' : 'offline')) | translate }}
       </div>
     </div>
     <div class="item">
       <span>{{ 'transports.details.basic.id' | translate }}</span> {{ data.id }}
     </div>
     <div class="item">
-      <span>{{ 'transports.details.basic.local-pk' | translate }}</span> {{ data.local_pk }}
+      <span>{{ 'transports.details.basic.local-pk' | translate }}</span> {{ data.localPk }}
     </div>
     <div class="item">
-      <span>{{ 'transports.details.basic.remote-pk' | translate }}</span> {{ data.remote_pk }}
+      <span>{{ 'transports.details.basic.remote-pk' | translate }}</span> {{ data.remotePk }}
     </div>
     <div class="item">
       <span>{{ 'transports.details.basic.type' | translate }}</span> {{ data.type }}
@@ -26,10 +26,10 @@
       <mat-icon [inline]="true">import_export</mat-icon>{{ 'transports.details.data.title' | translate }}
     </div>
     <div class="item">
-      <span>{{ 'transports.details.data.uploaded' | translate }}</span> {{ data.log.sent | autoScale }}
+      <span>{{ 'transports.details.data.uploaded' | translate }}</span> {{ data.sent | autoScale }}
     </div>
     <div class="item">
-      <span>{{ 'transports.details.data.downloaded' | translate }}</span> {{ data.log.recv | autoScale }}
+      <span>{{ 'transports.details.data.downloaded' | translate }}</span> {{ data.recv | autoScale }}
     </div>
   </div>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.html
@@ -125,7 +125,7 @@
       <td>
         <app-labeled-element-text
           [short]="true"
-          id="{{ transport.remote_pk }}"
+          id="{{ transport.remotePk }}"
           shortTextLength="4"
           (labelEdited)="refreshData()">
         </app-labeled-element-text>
@@ -134,10 +134,10 @@
         {{ transport.type }}
       </td>
       <td>
-        {{ transport.log.sent | autoScale }}
+        {{ transport.sent | autoScale }}
       </td>
       <td>
-        {{ transport.log.recv | autoScale }}
+        {{ transport.recv | autoScale }}
       </td>
       <td class="actions">
         <button
@@ -206,7 +206,7 @@
           <div class="list-row long-content">
             <span class="title">{{ 'transports.remote-node' | translate }}</span>:
             <app-labeled-element-text
-              id="{{ transport.remote_pk }}"
+              id="{{ transport.remotePk }}"
               (labelEdited)="refreshData()">
             </app-labeled-element-text>
           </div>
@@ -216,11 +216,11 @@
           </div>
           <div class="list-row">
             <span class="title">{{ 'common.uploaded' | translate }}</span>:
-            {{ transport.log.sent | autoScale }}
+            {{ transport.sent | autoScale }}
           </div>
           <div class="list-row">
             <span class="title">{{ 'common.downloaded' | translate }}</span>:
-            {{ transport.log.recv | autoScale }}
+            {{ transport.recv | autoScale }}
           </div>
         </div>
         <div class="margin-part"></div>

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.ts
@@ -38,12 +38,12 @@ export class TransportListComponent implements OnDestroy {
   @Input() nodePK: string;
 
   // Vars with the data of the columns used for sorting the data.
-  stateSortData = new SortingColumn(['is_up'], 'transports.state', SortingModes.Boolean);
+  stateSortData = new SortingColumn(['isUp'], 'transports.state', SortingModes.Boolean);
   idSortData = new SortingColumn(['id'], 'transports.id', SortingModes.Text, ['id_label']);
-  remotePkSortData = new SortingColumn(['remote_pk'], 'transports.remote-node', SortingModes.Text, ['remote_pk_label']);
+  remotePkSortData = new SortingColumn(['remotePk'], 'transports.remote-node', SortingModes.Text, ['remote_pk_label']);
   typeSortData = new SortingColumn(['type'], 'transports.type', SortingModes.Text);
-  uploadedSortData = new SortingColumn(['log', 'sent'], 'common.uploaded', SortingModes.NumberReversed);
-  downloadedSortData = new SortingColumn(['log', 'recv'], 'common.downloaded', SortingModes.NumberReversed);
+  uploadedSortData = new SortingColumn(['sent'], 'common.uploaded', SortingModes.NumberReversed);
+  downloadedSortData = new SortingColumn(['recv'], 'common.downloaded', SortingModes.NumberReversed);
 
   private dataSortedSubscription: Subscription;
   private dataFiltererSubscription: Subscription;
@@ -86,7 +86,7 @@ export class TransportListComponent implements OnDestroy {
         LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, transport.id);
 
       transport['remote_pk_label'] =
-        LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, transport.remote_pk);
+        LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, transport.remotePk);
     });
 
     this.dataFilterer.setData(this.allTransports);
@@ -96,7 +96,7 @@ export class TransportListComponent implements OnDestroy {
   filterProperties: FilterProperties[] = [
     {
       filterName: 'transports.filter-dialog.online',
-      keyNameInElementsArray: 'is_up',
+      keyNameInElementsArray: 'isUp',
       type: FilterFieldTypes.Select,
       printableLabelsForValues: [
         {
@@ -122,7 +122,7 @@ export class TransportListComponent implements OnDestroy {
     },
     {
       filterName: 'transports.filter-dialog.remote-node',
-      keyNameInElementsArray: 'remote_pk',
+      keyNameInElementsArray: 'remotePk',
       secondaryKeyNameInElementsArray: 'remote_pk_label',
       type: FilterFieldTypes.TextInput,
       maxlength: 66,
@@ -166,7 +166,7 @@ export class TransportListComponent implements OnDestroy {
       // Check if there are offline transports.
       this.hasOfflineTransports = false;
       this.filteredTransports.forEach(transport => {
-        if (!transport.is_up) {
+        if (!transport.isUp) {
           this.hasOfflineTransports = true;
         }
       });
@@ -213,7 +213,7 @@ export class TransportListComponent implements OnDestroy {
    * returns a class for a colored text.
    */
   transportStatusClass(transport: Transport, forDot: boolean): string {
-    switch (transport.is_up) {
+    switch (transport.isUp) {
       case true:
         return forDot ? 'dot-green' : 'green-text';
       default:
@@ -227,7 +227,7 @@ export class TransportListComponent implements OnDestroy {
    * text for the transport list shown on small screens.
    */
   transportStatusText(transport: Transport, forTooltip: boolean): string {
-    switch (transport.is_up) {
+    switch (transport.isUp) {
       case true:
         return 'transports.statuses.online' + (forTooltip ? '-tooltip' : '');
       default:
@@ -309,7 +309,7 @@ export class TransportListComponent implements OnDestroy {
       // Prepare all offline transports to be removed.
       const transportsToRemove: string[] = [];
       this.filteredTransports.forEach(transport => {
-        if (!transport.is_up) {
+        if (!transport.isUp) {
           transportsToRemove.push(transport.id);
         }
       });

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -418,8 +418,8 @@ export class NodeService {
     currentData.totalSent = 0;
     currentData.totalReceived = 0;
     if (transports && transports.length > 0) {
-      currentData.totalSent = transports.reduce((total, transport) => total + transport.log.sent, 0);
-      currentData.totalReceived = transports.reduce((total, transport) => total + transport.log.recv, 0);
+      currentData.totalSent = transports.reduce((total, transport) => total + transport.sent, 0);
+      currentData.totalReceived = transports.reduce((total, transport) => total + transport.recv, 0);
     }
 
     // Update the history.
@@ -490,12 +490,29 @@ export class NodeService {
    * Gets the list of the nodes connected to the hypervisor.
    */
   private getNodes(): Observable<Node[]> {
-    let nodes: Node[];
+    let nodes: Node[] = [];
     let dmsgInfo: any[];
 
-    return this.apiService.get('visors').pipe(mergeMap((result: Node[]) => {
+    return this.apiService.get('visors').pipe(mergeMap((result: any[]) => {
       // Save the visor list.
-      nodes = result || [];
+      if (result) {
+        result.forEach(response => {
+          const node = new Node();
+
+          // Basic data.
+          node.online = response.online;
+          node.tcpAddr = response.tcp_addr;
+          node.ip = this.getAddressPart(node.tcpAddr, 0);
+          node.port = this.getAddressPart(node.tcpAddr, 1);
+          node.localPk = response.local_pk;
+
+          // Label.
+          const labelInfo = this.storageService.getLabelInfo(node.localPk);
+          node.label = labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.localPk);
+
+          nodes.push(node);
+        });
+      }
 
       // Get the dmsg info.
       return this.apiService.get('dmsg');
@@ -503,10 +520,17 @@ export class NodeService {
       dmsgInfo = result;
 
       // Get the health info of each node.
-      return forkJoin(nodes.map(node => this.apiService.get(`visors/${node.local_pk}/health`)));
+      return forkJoin(nodes.map(node => this.apiService.get(`visors/${node.localPk}/health`)));
     }), mergeMap((result: any[]) => {
       nodes.forEach((node, i) => {
-        node.health = result[i];
+        node.health = {
+          status: result[i].status,
+          addressResolver: result[i].address_resolver,
+          routeFinder: result[i].route_finder,
+          setupNode: result[i].setup_node,
+          transportDiscovery: result[i].transport_discovery,
+          uptimeTracker: result[i].uptime_tracker,
+        };
       });
 
       // Get the basic info about the hypervisor.
@@ -520,25 +544,19 @@ export class NodeService {
       const obtainedNodes = new Map<string, Node>();
       const nodesToRegisterInLocalStorageAsOnline: string[] = [];
       nodes.forEach(node => {
-        if (dmsgInfoMap.has(node.local_pk)) {
-          node.dmsgServerPk = dmsgInfoMap.get(node.local_pk).server_public_key;
-          node.roundTripPing = this.nsToMs(dmsgInfoMap.get(node.local_pk).round_trip);
+        if (dmsgInfoMap.has(node.localPk)) {
+          node.dmsgServerPk = dmsgInfoMap.get(node.localPk).server_public_key;
+          node.roundTripPing = this.nsToMs(dmsgInfoMap.get(node.localPk).round_trip);
         } else {
           node.dmsgServerPk = '-';
           node.roundTripPing = '-1';
         }
 
-        node.isHypervisor = node.local_pk === aboutInfo.public_key;
+        node.isHypervisor = node.localPk === aboutInfo.public_key;
 
-        node.ip = this.getAddressPart(node.tcp_addr, 0);
-        node.port = this.getAddressPart(node.tcp_addr, 1);
-        const labelInfo = this.storageService.getLabelInfo(node.local_pk);
-        node.label =
-          labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.local_pk);
-
-        obtainedNodes.set(node.local_pk, node);
+        obtainedNodes.set(node.localPk, node);
         if (node.online) {
-          nodesToRegisterInLocalStorageAsOnline.push(node.local_pk);
+          nodesToRegisterInLocalStorageAsOnline.push(node.localPk);
         }
       });
 
@@ -549,10 +567,9 @@ export class NodeService {
         // If the backend did not return a saved node, add it to the response as an offline node.
         if (!obtainedNodes.has(node.publicKey) && !node.hidden) {
           const newNode: Node = new Node();
-          newNode.local_pk = node.publicKey;
+          newNode.localPk = node.publicKey;
           const labelInfo = this.storageService.getLabelInfo(node.publicKey);
-          newNode.label =
-            labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.publicKey);
+          newNode.label = labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.publicKey);
           newNode.online = false;
 
           missingSavedNodes.push(newNode);
@@ -593,68 +610,139 @@ export class NodeService {
    * Gets the details of a specific node.
    */
   private getNode(nodeKey: string): Observable<Node> {
-    let currentNode: Node;
+    // Get the node data.
+    return this.apiService.get(`visors/${nodeKey}/summary`).pipe(
+      map((response: any) => {
+        const node = new Node();
 
-    // Get the basic node data.
-    return this.apiService.get(`visors/${nodeKey}`).pipe(
-      flatMap((node: Node) => {
-        node.ip = this.getAddressPart(node.tcp_addr, 0);
-        node.port = this.getAddressPart(node.tcp_addr, 1);
-        const labelInfo = this.storageService.getLabelInfo(node.local_pk);
-        node.label =
-          labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.local_pk);
-        currentNode = node;
+        // Basic data.
+        node.online = response.online;
+        node.tcpAddr = response.tcp_addr;
+        node.ip = this.getAddressPart(node.tcpAddr, 0);
+        node.port = this.getAddressPart(node.tcpAddr, 1);
+        node.localPk = response.summary.local_pk;
+        node.version = response.summary.build_info.version;
+        node.secondsOnline = Math.floor(Number.parseFloat(response.uptime));
 
-        // Needed for a change made to the names on the backend.
-        if (node.apps) {
-          node.apps.forEach(app => {
-            app.name = (app as any).name ? (app as any).name : (app as any).app;
-            app.autostart = (app as any).auto_start;
+        // Label.
+        const labelInfo = this.storageService.getLabelInfo(node.localPk);
+        node.label = labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.localPk);
+
+        // Health info.
+        node.health = {
+          status: 200,
+          addressResolver: response.health.address_resolver,
+          routeFinder: response.health.route_finder,
+          setupNode: response.health.setup_node,
+          transportDiscovery: response.health.transport_discovery,
+          uptimeTracker: response.health.uptime_tracker,
+        };
+
+        // Transports.
+        node.transports = [];
+        if (response.summary.transports) {
+          (response.summary.transports as any[]).forEach(transport => {
+            node.transports.push({
+              isUp: transport.is_up,
+              id: transport.id,
+              localPk: transport.local_pk,
+              remotePk: transport.remote_pk,
+              type: transport.type,
+              recv: transport.log.recv,
+              sent: transport.log.sent,
+            });
           });
         }
 
-        // Get the dmsg info.
-        return this.apiService.get('dmsg');
-      }),
-      flatMap((dmsgInfo: any[]) => {
-        for (let i = 0; i < dmsgInfo.length; i++) {
-          if (dmsgInfo[i].public_key === currentNode.local_pk) {
-            currentNode.dmsgServerPk = dmsgInfo[i].server_public_key;
-            currentNode.roundTripPing = this.nsToMs(dmsgInfo[i].round_trip);
+        // Routes.
+        node.routes = [];
+        if (response.routes) {
+          (response.routes as any[]).forEach(route => {
+            // Basic data.
+            node.routes.push({
+              key: route.key,
+              rule: route.rule,
+            });
 
-            // Get the health info.
-            return this.apiService.get(`visors/${nodeKey}/health`);
+            if (route.rule_summary) {
+              // Rule summary.
+              node.routes[node.routes.length - 1].ruleSummary = {
+                keepAlive: route.rule_summary.keep_alive,
+                ruleType: route.rule_summary.rule_type,
+                keyRouteId: route.rule_summary.key_route_id,
+              };
+
+              // App fields, if any.
+              if (route.rule_summary.app_fields && route.rule_summary.app_fields.route_descriptor) {
+                node.routes[node.routes.length - 1].appFields = {
+                  routeDescriptor: {
+                    dstPk: route.rule_summary.app_fields.route_descriptor.dst_pk,
+                    dstPort: route.rule_summary.app_fields.route_descriptor.dst_port,
+                    srcPk: route.rule_summary.app_fields.route_descriptor.src_pk,
+                    srcPort: route.rule_summary.app_fields.route_descriptor.src_port,
+                  },
+                };
+              }
+
+              // Forward fields, if any.
+              if (route.rule_summary.forward_fields) {
+                node.routes[node.routes.length - 1].forwardFields = {
+                  nextRid: route.rule_summary.forward_fields.next_rid,
+                  nextTid: route.rule_summary.forward_fields.next_tid,
+                };
+
+                if (route.rule_summary.forward_fields.route_descriptor) {
+                  node.routes[node.routes.length - 1].forwardFields.routeDescriptor = {
+                    dstPk: route.rule_summary.forward_fields.route_descriptor.dst_pk,
+                    dstPort: route.rule_summary.forward_fields.route_descriptor.dst_port,
+                    srcPk: route.rule_summary.forward_fields.route_descriptor.src_pk,
+                    srcPort: route.rule_summary.forward_fields.route_descriptor.src_port,
+                  };
+                }
+              }
+
+              // Intermediary forward fields, if any.
+              if (route.rule_summary.intermediary_forward_fields) {
+                node.routes[node.routes.length - 1].intermediaryForwardFields = {
+                  nextRid: route.rule_summary.intermediary_forward_fields.next_rid,
+                  nextTid: route.rule_summary.intermediary_forward_fields.next_tid,
+                };
+              }
+            }
+          });
+        }
+
+        // Apps.
+        node.apps = [];
+        if (response.summary.apps) {
+          (response.summary.apps as any[]).forEach(app => {
+            node.apps.push({
+              name: app.name,
+              status: app.status,
+              port: app.port,
+              autostart: app.auto_start,
+              args: app.args,
+            });
+          });
+        }
+
+        let dmsgServerFound = false;
+        for (let i = 0; i < response.dmsg.length; i++) {
+          if (response.dmsg[i].public_key === node.localPk) {
+            node.dmsgServerPk = response.dmsg[i].server_public_key;
+            node.roundTripPing = this.nsToMs(response.dmsg[i].round_trip);
+
+            dmsgServerFound = true;
+            break;
           }
         }
 
-        currentNode.dmsgServerPk = '-';
-        currentNode.roundTripPing = '-1';
+        if (!dmsgServerFound) {
+          node.dmsgServerPk = '-';
+          node.roundTripPing = '-1';
+        }
 
-        // Get the health info.
-        return this.apiService.get(`visors/${nodeKey}/health`);
-      }),
-      flatMap((health: HealthInfo) => {
-        currentNode.health = health;
-
-        // Get the node uptime.
-        return this.apiService.get(`visors/${nodeKey}/uptime`);
-      }),
-      flatMap((secondsOnline: string) => {
-        currentNode.seconds_online = Math.floor(Number.parseFloat(secondsOnline));
-
-        // Get the complete transports info.
-        return this.transportService.getTransports(nodeKey);
-      }),
-      flatMap((transports: Transport[]) => {
-        currentNode.transports = transports;
-
-        // Get the complete routes info.
-        return this.routeService.getRoutes(nodeKey);
-      }),
-      map((routes: Route[]) => {
-        currentNode.routes = routes;
-
-        return currentNode;
+        return node;
       })
     );
   }
@@ -741,40 +829,40 @@ export class NodeService {
       // Transport discovery.
       service = {
         name: 'node.details.node-health.transport-discovery',
-        isOk: node.health.transport_discovery && node.health.transport_discovery === 200,
-        originalValue: node.health.transport_discovery + ''
+        isOk: node.health.transportDiscovery && node.health.transportDiscovery === 200,
+        originalValue: node.health.transportDiscovery + ''
       };
       response.services.push(service);
 
       // Route finder.
       service = {
         name: 'node.details.node-health.route-finder',
-        isOk: node.health.route_finder && node.health.route_finder === 200,
-        originalValue: node.health.route_finder + ''
+        isOk: node.health.routeFinder && node.health.routeFinder === 200,
+        originalValue: node.health.routeFinder + ''
       };
       response.services.push(service);
 
       // Setup node.
       service = {
         name: 'node.details.node-health.setup-node',
-        isOk: node.health.setup_node && node.health.setup_node === 200,
-        originalValue: node.health.setup_node + ''
+        isOk: node.health.setupNode && node.health.setupNode === 200,
+        originalValue: node.health.setupNode + ''
       };
       response.services.push(service);
 
       // Uptime tracker.
       service = {
         name: 'node.details.node-health.uptime-tracker',
-        isOk: node.health.uptime_tracker && node.health.uptime_tracker === 200,
-        originalValue: node.health.uptime_tracker + ''
+        isOk: node.health.uptimeTracker && node.health.uptimeTracker === 200,
+        originalValue: node.health.uptimeTracker + ''
       };
       response.services.push(service);
 
       // Address resolver.
       service = {
         name: 'node.details.node-health.address-resolver',
-        isOk: node.health.address_resolver && node.health.address_resolver === 200,
-        originalValue: node.health.address_resolver + ''
+        isOk: node.health.addressResolver && node.health.addressResolver === 200,
+        originalValue: node.health.addressResolver + ''
       };
       response.services.push(service);
 

--- a/static/skywire-manager-src/src/app/services/route.service.ts
+++ b/static/skywire-manager-src/src/app/services/route.service.ts
@@ -1,9 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { ApiService } from './api.service';
-import { Route } from '../app.datatypes';
 
 /**
  * Allows to work with the routes of a node.
@@ -15,21 +12,6 @@ export class RouteService {
   constructor(
     private apiService: ApiService,
   ) { }
-
-  /**
-   * Get a list with the routes of a node.
-   */
-  getRoutes(nodeKey: string): Observable<Route[]> {
-    return this.apiService.get(`visors/${nodeKey}/routes`).pipe(
-      map(val => {
-        if (!val) {
-          return [];
-        }
-
-        return val;
-      })
-    );
-  }
 
   /**
    * Gets the details of a specific route.

--- a/static/skywire-manager-src/src/app/services/transport.service.ts
+++ b/static/skywire-manager-src/src/app/services/transport.service.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { ApiService } from './api.service';
-import { Transport } from '../app.datatypes';
 
 /**
  * Allows to work with the transports of a node.
@@ -15,21 +13,6 @@ export class TransportService {
   constructor(
     private apiService: ApiService,
   ) { }
-
-  /**
-   * Get a list with the transports of a node.
-   */
-  getTransports(nodeKey: string): Observable<Transport[]> {
-    return this.apiService.get(`visors/${nodeKey}/transports`).pipe(
-      map(val => {
-        if (!val) {
-          return [];
-        }
-
-        return val;
-      })
-    );
-  }
 
   create(nodeKey: string, remoteKey: string, type: string): Observable<any> {
     return this.apiService.post(`visors/${nodeKey}/transports`, {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #446

 Changes:	
- The manager now gets the visor data by calling the `GET api/visors/{nodeKey}/summary` API endpoint, instead of making several API requests. This makes the manager load the visor detail pages faster.
- The objects used for representing the server responses were changed, as the codes was previously imitating the exact objects returned by the API and that causes problems which propagates fast to several parts of the app if changes are made to the API.
- The code for showing the route details was simplified.

How to test this PR:
Select a visor in the visor list of the Skywire manager, the details page should open faster than before. Also open the details of a route, the data should be displaying immediately, without loading time.