### PR TITLE
Show more info about the routes in the manager

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.html
@@ -54,6 +54,11 @@
               routeRule.forwardFields.nextTid :
               routeRule.intermediaryForwardFields.nextTid
           }}
+          {{
+            getLabel(routeRule.forwardFields ?
+            routeRule.forwardFields.nextTid :
+            routeRule.intermediaryForwardFields.nextTid)
+          }}
         </div>
       </div>
 
@@ -69,6 +74,11 @@
               routeRule.appFields.routeDescriptor.dstPk :
               routeRule.forwardFields.routeDescriptor.dstPk
           }}
+          {{
+            getLabel(routeRule.appFields ?
+            routeRule.appFields.routeDescriptor.dstPk :
+            routeRule.forwardFields.routeDescriptor.dstPk)
+          }}
         </div>
         <div class="item">
           <span>{{ 'routes.details.specific-fields.source-pk' | translate }}</span>
@@ -76,6 +86,11 @@
             routeRule.appFields ?
               routeRule.appFields.routeDescriptor.srcPk :
               routeRule.forwardFields.routeDescriptor.srcPk
+          }}
+          {{
+            getLabel(routeRule.appFields ?
+            routeRule.appFields.routeDescriptor.srcPk :
+            routeRule.forwardFields.routeDescriptor.srcPk)
           }}
         </div>
         <div class="item">

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.ts
@@ -3,6 +3,7 @@ import { MatDialogRef, MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angu
 
 import { AppConfig } from 'src/app/app.config';
 import { Route } from 'src/app/app.datatypes';
+import { StorageService } from 'src/app/services/storage.service';
 
 /**
  * Modal window for showing the details of a route.
@@ -39,6 +40,7 @@ export class RouteDetailsComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA) data: Route,
     private dialogRef: MatDialogRef<RouteDetailsComponent>,
+    private storageService: StorageService,
   ) {
     this.routeRule = data;
   }
@@ -53,5 +55,18 @@ export class RouteDetailsComponent {
 
   closePopup() {
     this.dialogRef.close();
+  }
+
+  /**
+   * Gets the label the user has set for an ID or pk.
+   */
+  getLabel(id: string) {
+    const label = this.storageService.getLabelInfo(id);
+
+    if (label) {
+      return ' (' + label.label + ')';
+    }
+
+    return '';
   }
 }

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.html
@@ -67,9 +67,17 @@
         {{ 'routes.key' | translate }}
         <mat-icon *ngIf="dataSorter.currentSortingColumn === keySortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
       </th>
-      <th class="sortable-column"  (click)="dataSorter.changeSortingOrder(ruleSortData)">
-        {{ 'routes.rule' | translate }}
-        <mat-icon *ngIf="dataSorter.currentSortingColumn === ruleSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+      <th class="sortable-column" (click)="dataSorter.changeSortingOrder(typeSortData)">
+        {{ 'routes.type' | translate }}
+        <mat-icon *ngIf="dataSorter.currentSortingColumn === typeSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+      </th>
+      <th class="sortable-column" (click)="dataSorter.changeSortingOrder(sourceSortData)">
+        {{ 'routes.source' | translate }}
+        <mat-icon *ngIf="dataSorter.currentSortingColumn === sourceSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
+      </th>
+      <th class="sortable-column" (click)="dataSorter.changeSortingOrder(destinationSortData)">
+        {{ 'routes.destination' | translate }}
+        <mat-icon *ngIf="dataSorter.currentSortingColumn === destinationSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
       </th>
       <th class="actions"></th>
     </tr>
@@ -85,8 +93,47 @@
         {{ route.key }}
       </td>
       <td>
-        <app-copy-to-clipboard-text [text]="route.rule"></app-copy-to-clipboard-text>
+        {{ getTypeName(route.type) }}
       </td>
+      <!-- Source and destination for app and forward routes. -->
+      <ng-container *ngIf="route.appFields || route.forwardFields">
+        <td>
+          <app-labeled-element-text
+            [short]="true"
+            id="{{ route.src }}"
+            shortTextLength="7"
+            (labelEdited)="refreshData()"
+            [elementType]="labeledElementTypes.Node">
+          </app-labeled-element-text>
+        </td>
+        <td>
+          <app-labeled-element-text
+            [short]="true"
+            id="{{ route.dst }}"
+            shortTextLength="7"
+            (labelEdited)="refreshData()"
+            [elementType]="labeledElementTypes.Node">
+          </app-labeled-element-text>
+        </td>
+      </ng-container>
+      <!-- Source and destination for intermediary forward routes. -->
+      <ng-container *ngIf="(!route.appFields && !route.forwardFields) && route.intermediaryForwardFields">
+        <td>---</td>
+        <td>
+          <app-labeled-element-text
+            [short]="true"
+            id="{{ route.dst }}"
+            shortTextLength="5"
+            (labelEdited)="refreshData()"
+            [elementType]="labeledElementTypes.Transport">
+          </app-labeled-element-text>
+        </td>
+      </ng-container>
+      <!-- Source and destination for special cases. -->
+      <ng-container *ngIf="!route.appFields && !route.forwardFields && !route.intermediaryForwardFields">
+        <td>---</td>
+        <td>---</td>
+      </ng-container>
       <td class="actions">
         <button
           (click)="details(route)"
@@ -144,9 +191,54 @@
             {{ route.key }}
           </div>
           <div class="list-row long-content">
-            <span class="title">{{ 'routes.rule' | translate }}</span>:
-            <app-copy-to-clipboard-text text="{{ route.rule }}"></app-copy-to-clipboard-text>
+            <span class="title">{{ 'routes.type' | translate }}</span>:
+            {{ getTypeName(route.type) }}
           </div>
+          <!-- Source and destination for app and forward routes. -->
+          <ng-container *ngIf="route.appFields || route.forwardFields">
+            <div class="list-row long-content">
+              <span class="title">{{ 'routes.source' | translate }}</span>:
+              <app-labeled-element-text
+                id="{{ route.src }}"
+                (labelEdited)="refreshData()"
+                [elementType]="labeledElementTypes.Node">
+              </app-labeled-element-text>
+            </div>
+            <div class="list-row long-content">
+              <span class="title">{{ 'routes.destination' | translate }}</span>:
+              <app-labeled-element-text
+                id="{{ route.dst }}"
+                (labelEdited)="refreshData()"
+                [elementType]="labeledElementTypes.Node">
+              </app-labeled-element-text>
+            </div>
+          </ng-container>
+          <!-- Source and destination for intermediary forward routes. -->
+          <ng-container *ngIf="(!route.appFields && !route.forwardFields) && route.intermediaryForwardFields">
+            <div class="list-row long-content">
+              <span class="title">{{ 'routes.source' | translate }}</span>:
+              ---
+            </div>
+            <div class="list-row long-content">
+              <span class="title">{{ 'routes.destination' | translate }}</span>:
+              <app-labeled-element-text
+                id="{{ route.dst }}"
+                (labelEdited)="refreshData()"
+                [elementType]="labeledElementTypes.Transport">
+              </app-labeled-element-text>
+            </div>
+          </ng-container>
+          <!-- Source and destination for special cases. -->
+          <ng-container *ngIf="!route.appFields && !route.forwardFields && !route.intermediaryForwardFields">
+            <div class="list-row long-content">
+              <span class="title">{{ 'routes.source' | translate }}</span>:
+              ---
+            </div>
+            <div class="list-row long-content">
+              <span class="title">{{ 'routes.destination' | translate }}</span>:
+              ---
+            </div>
+          </ng-container>
         </div>
         <div class="margin-part"></div>
         <div class="right-part">

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -494,7 +494,9 @@
     "info": "Paths used to reach the remote visors to which transports have been established. Routes are automatically generated as needed.",
     "list-title": "Route list",
     "key": "Key",
-    "rule": "Rule",
+    "type": "Type",
+    "source": "Source",
+    "destination": "Destination",
     "delete-confirmation": "Are you sure you want to delete the route?",
     "delete-selected-confirmation": "Are you sure you want to delete the selected routes?",
     "delete": "Delete route",
@@ -530,7 +532,10 @@
     },
     "filter-dialog": {
       "key": "The key must contain",
-      "rule": "The rule must contain"
+      "type": "The type must be",
+      "source": "The source must contain",
+      "destination": "The destination must contain",
+      "any-type-option": "Any"
     }
   },
 

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -490,7 +490,9 @@
     "title": "Rutas",
     "list-title": "Lista de rutas",
     "key": "Llave",
-    "rule": "Regla",
+    "type": "Tipo",
+    "source": "Inicio",
+    "destination": "Destino",
     "delete-confirmation": "¿Seguro que desea borrar la ruta?",
     "delete-selected-confirmation": "¿Seguro que desea borrar las rutas seleccionadas?",
     "delete": "Borrar ruta",
@@ -526,7 +528,10 @@
     },
     "filter-dialog": {
       "key": "La llave debe contener",
-      "rule": "La regla debe contener"
+      "type": "El tipo debe ser",
+      "source": "El inicio debe contener",
+      "destination": "El destino debe contener",
+      "any-type-option": "Cualquiera"
     }
   },
 

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -490,7 +490,9 @@
     "title": "Routes",
     "list-title": "Route list",
     "key": "Key",
-    "rule": "Rule",
+    "type": "Type",
+    "source": "Source",
+    "destination": "Destination",
     "delete-confirmation": "Are you sure you want to delete the route?",
     "delete-selected-confirmation": "Are you sure you want to delete the selected routes?",
     "delete": "Delete route",
@@ -526,7 +528,10 @@
     },
     "filter-dialog": {
       "key": "The key must contain",
-      "rule": "The rule must contain"
+      "type": "The type must be",
+      "source": "The source must contain",
+      "destination": "The destination must contain",
+      "any-type-option": "Any"
     }
   },
 


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #429

 Changes:	
- The rule string was removed from the routes list. Now it shows the route type, source and destination.
![rt](https://user-images.githubusercontent.com/34079003/102650579-7fef4900-4141-11eb-80d3-b00139813250.png)
- The route details popup now shows the labels associated with the PKs and IDs, if any.

How to test this PR:
Check the route list of a visor using the Skywire manager.