### PR TITLE
Show an alert when openning the logs of a stopped app

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
@@ -406,7 +406,11 @@ export class NodeAppsListComponent implements OnDestroy {
    * Shows a modal window with the logs of an app.
    */
   viewLogs(app: Application): void {
-    LogComponent.openDialog(this.dialog, app);
+    if (app.status === 1) {
+      LogComponent.openDialog(this.dialog, app);
+    } else {
+      this.snackbarService.showError('apps.apps-list.unavailable-logs-error');
+    }
   }
 
   /**

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -309,6 +309,8 @@
       "enable-autostart": "Enable autostart",
       "autostart-disabled": "Autostart disabled",
       "autostart-enabled": "Autostart enabled",
+      "unavailable-logs-error": "Unable to show the logs while the app is not running.",
+
       "filter-dialog": {
         "state": "The state must be",
         "name": "The name must contain",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -307,6 +307,8 @@
       "enable-autostart": "Habilitar autoinicio",
       "autostart-disabled": "Autoinicio deshabilitado",
       "autostart-enabled": "Autoinicio habilitado",
+      "unavailable-logs-error": "No es posible mostrar los logs mientras la aplicación no se está ejecutando.",
+
       "filter-dialog": {
         "state": "El estado debe ser",
         "name": "El nombre debe contener",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -307,6 +307,8 @@
       "enable-autostart": "Enable autostart",
       "autostart-disabled": "Autostart disabled",
       "autostart-enabled": "Autostart enabled",
+      "unavailable-logs-error": "Unable to show the logs while the app is not running.",
+
       "filter-dialog": {
         "state": "The state must be",
         "name": "The name must contain",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the manager shows an alert and does not open the logs modal window if the user tries to open the logs of a stopped app. This is because the window is not able to show the logs if the app is not running.

How to test this PR:
Try to use the Skywire manager to view the logs of an stopped app.