### PR TITLE
Make the UI show the last version of the selected channel

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.html
@@ -42,6 +42,7 @@
         <div class="right-part">
           {{ 'update.version-change' | translate:update }}
           <a [href]="update.updateLink" target="_blank" rel="noreferrer nofollow noopener">{{ update.updateLink }}</a>
+          <span class="channel" *ngIf="customChannel">{{ 'update.selected-channel' | translate }} {{ customChannel }}</span>
         </div>
       </div>
     </div>

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.scss
@@ -29,6 +29,11 @@
         line-height: 1;
         display: block;
       }
+
+      .channel {
+        font-size: $font-size-mini;
+        line-height: 1;
+      }
     }
   }
 

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
@@ -4,7 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subscription, forkJoin, interval } from 'rxjs';
 
 import { AppConfig } from 'src/app/app.config';
-import { NodeService } from 'src/app/services/node.service';
+import { NodeService, UpdaterStorageKeys } from 'src/app/services/node.service';
 import { StorageService } from 'src/app/services/storage.service';
 import { OperationError } from 'src/app/utils/operation-error';
 import { processServiceError } from 'src/app/utils/errors';
@@ -144,6 +144,9 @@ export class UpdateComponent implements AfterViewInit, OnDestroy {
   // How many nodes inside nodesToUpdate have updates available and are not currently
   // being updated.
   nodesForUpdatesFound: number;
+
+  // Custom channel set by the user for downloading the updates.
+  customChannel: string = localStorage.getItem(UpdaterStorageKeys.Channel);
 
   updatingStates = UpdatingStates;
 

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -781,7 +781,13 @@ export class NodeService {
    * Checks if there are updates available for a node.
    */
   checkUpdate(nodeKey: string): Observable<any> {
-    return this.apiService.get(`visors/${nodeKey}/update/available`);
+    let channel = 'stable';
+
+    // Use the custom channel saved by the user, if any.
+    const savedChannel = localStorage.getItem(UpdaterStorageKeys.Channel);
+    channel = savedChannel ? savedChannel : channel;
+
+    return this.apiService.get(`visors/${nodeKey}/update/available/${channel}`);
   }
 
   /**

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -270,6 +270,7 @@
     "update-instructions": "Click the 'Install updates' button to continue.",
     "updating": "The update operation has been started, you can open this window again for checking the progress:",
     "version-change": "From {{ currentVersion }} to {{ newVersion }}",
+    "selected-channel": "Selected channel:",
     "downloaded-file-name-prefix": "Downloading: ",
     "speed-prefix": "Speed: ",
     "time-downloading-prefix": "Time downloading: ",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -268,6 +268,7 @@
     "update-instructions": "Haga clic en el botón 'Instalar actualizaciones' para continuar.",
     "updating": "La operación de actualización se ha iniciado, puede abrir esta ventana nuevamente para verificar el progreso:",
     "version-change": "De {{ currentVersion }} a {{ newVersion }}",
+    "selected-channel": "Canal seleccionado:",
     "downloaded-file-name-prefix": "Descargando: ",
     "speed-prefix": "Velocidad: ",
     "time-downloading-prefix": "Tiempo descargando: ",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -268,6 +268,7 @@
     "update-instructions": "Click the 'Install updates' button to continue.",
     "updating": "The update operation has been started, you can open this window again for checking the progress:",
     "version-change": "From {{ currentVersion }} to {{ newVersion }}",
+    "selected-channel": "Selected channel:",
     "downloaded-file-name-prefix": "Downloading: ",
     "speed-prefix": "Speed: ",
     "time-downloading-prefix": "Time downloading: ",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Before this PR, if a custom channel for getting updates was set in the settings page, the manager used it for downloading the update, but the UI always showed the last version of the `stable` channel as the one that was going to be installed, which was obviously wrong if the user selected other channel. This PR solves that problem.

How to test this PR:
Set a custom channel for getting updates, using the form in the settings page, and try to update a visor. The updater modal window should show the last version of the selected channel as the one that will be installed and the dev tools should show a call to `/api/visors/{pk}/update/available/{channel}` instead of `/api/visors/{pk}/update/available`.