### PR TITLE
Fix/check empty password

### DIFF
--- a/pkg/app/appcommon/proc_config.go
+++ b/pkg/app/appcommon/proc_config.go
@@ -107,6 +107,7 @@ func (c *ProcConfig) Envs() []string {
 	return append(c.ProcEnvs, fmt.Sprintf(format, EnvProcConfig, string(c.encodeJSON())))
 }
 
+// ContainsFlag checks if a given flag has been passed to the ProcConfig.
 func (c *ProcConfig) ContainsFlag(flag string) bool {
 	for _, arg := range c.ProcArgs {
 		if argEqualsFlag(arg, flag) {
@@ -116,6 +117,7 @@ func (c *ProcConfig) ContainsFlag(flag string) bool {
 	return false
 }
 
+// ArgVal returns the value associated in ProcConfig with a given flag.
 func (c *ProcConfig) ArgVal(flag string) string {
 	for idx, arg := range c.ProcArgs {
 		if argEqualsFlag(arg, flag) && idx+1 < len(c.ProcArgs) {

--- a/pkg/app/appcommon/proc_config.go
+++ b/pkg/app/appcommon/proc_config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/skycoin/dmsg/cipher"
@@ -104,6 +105,46 @@ func (c *ProcConfig) EnsureKey() {
 func (c *ProcConfig) Envs() []string {
 	const format = "%s=%s"
 	return append(c.ProcEnvs, fmt.Sprintf(format, EnvProcConfig, string(c.encodeJSON())))
+}
+
+func (c *ProcConfig) ContainsFlag(flag string) bool {
+	for _, arg := range c.ProcArgs {
+		if argEqualsFlag(arg, flag) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *ProcConfig) ArgVal(flag string) string {
+	for idx, arg := range c.ProcArgs {
+		if argEqualsFlag(arg, flag) && idx+1 < len(c.ProcArgs) {
+			return c.ProcArgs[idx+1]
+		}
+	}
+
+	return ""
+}
+
+func argEqualsFlag(arg, flag string) bool {
+	arg = strings.TrimSpace(arg)
+
+	// strip prefixed '-'s.
+	for {
+		if len(arg) < 1 {
+			return false
+		}
+		if arg[0] == '-' {
+			arg = arg[1:]
+			continue
+		}
+		break
+	}
+
+	// strip anything after (inclusive) of '='.
+	arg = strings.Split(arg, "=")[0]
+
+	return arg == flag
 }
 
 func (c *ProcConfig) encodeJSON() []byte {

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -127,7 +127,7 @@ func argEqualsFlag(arg, flag string) bool {
 
 func argVal(args []string, flag string) string {
 	for idx, arg := range args {
-		if argEqualsFlag(arg, flag) {
+		if argEqualsFlag(arg, flag) && idx+1 < len(args) {
 			return args[idx+1]
 		}
 	}

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -65,7 +65,7 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 	log := f.Log.WithField("appName", conf.AppName)
 
 	// Do not update in proxy discovery if passcode-protected.
-	if containsFlag(conf.ProcArgs, "passcode") {
+	if containsFlag(conf.ProcArgs, "passcode") && argVal(conf.ProcArgs, "passcode") != "" {
 		return &emptyUpdater{}, false
 	}
 
@@ -123,4 +123,14 @@ func argEqualsFlag(arg, flag string) bool {
 	arg = strings.Split(arg, "=")[0]
 
 	return arg == flag
+}
+
+func argVal(args []string, flag string) string {
+	for idx, arg := range args {
+		if argEqualsFlag(arg, flag) {
+			return args[idx+1]
+		}
+	}
+
+	return ""
 }

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -1,7 +1,6 @@
 package appdisc
 
 import (
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -65,7 +64,7 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 	log := f.Log.WithField("appName", conf.AppName)
 
 	// Do not update in proxy discovery if passcode-protected.
-	if containsFlag(conf.ProcArgs, "passcode") && argVal(conf.ProcArgs, "passcode") != "" {
+	if conf.ContainsFlag("passcode") && conf.ArgVal("passcode") != "" {
 		return &emptyUpdater{}, false
 	}
 
@@ -93,44 +92,4 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 	default:
 		return &emptyUpdater{}, false
 	}
-}
-
-func containsFlag(args []string, flag string) bool {
-	for _, arg := range args {
-		if argEqualsFlag(arg, flag) {
-			return true
-		}
-	}
-	return false
-}
-
-func argEqualsFlag(arg, flag string) bool {
-	arg = strings.TrimSpace(arg)
-
-	// strip prefixed '-'s.
-	for {
-		if len(arg) < 1 {
-			return false
-		}
-		if arg[0] == '-' {
-			arg = arg[1:]
-			continue
-		}
-		break
-	}
-
-	// strip anything after (inclusive) of '='.
-	arg = strings.Split(arg, "=")[0]
-
-	return arg == flag
-}
-
-func argVal(args []string, flag string) string {
-	for idx, arg := range args {
-		if argEqualsFlag(arg, flag) && idx+1 < len(args) {
-			return args[idx+1]
-		}
-	}
-
-	return ""
 }


### PR DESCRIPTION
Did you run `make format && make check`?

Yes

Fixes #660 at least the bug. The inconsistency remains. 

 Changes:	
- adds check to verify if password is empty. If password is empty, the appupdater is being created. Previously empty string password would lead to appdiscupdater not being created which is not the correct behavior. 

How to test this PR:

- run VPN-server with passcode arg set to empty string against prod deployment
- verify the VPN server gets registered here: https://service.discovery.skycoin.com/api/services?type=vpn

