### PR TITLE
Allow to set a label when creating a transport with the UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/labeled-element-text/labeled-element-text.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/labeled-element-text/labeled-element-text.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
 
 import { SelectOptionComponent, SelectableOption } from '../select-option/select-option.component';
 import { StorageService, LabelInfo, LabeledElementTypes } from 'src/app/services/storage.service';
@@ -7,7 +8,6 @@ import { ClipboardService } from 'src/app/services/clipboard.service';
 import { SnackbarService } from 'src/app/services/snackbar.service';
 import { EditLabelComponent } from '../edit-label/edit-label.component';
 import GeneralUtils from 'src/app/utils/generalUtils';
-import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Represents the parts of a label.

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
@@ -20,6 +20,15 @@
     </mat-form-field>
 
     <mat-form-field>
+      <input
+        formControlName="label"
+        maxlength="66"
+        [placeholder]="'transports.dialog.label' | translate"
+        matInput
+      >
+    </mat-form-field>
+
+    <mat-form-field>
       <mat-select
         formControlName="type"
         [placeholder]="'transports.dialog.transport-type' | translate"

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -471,8 +471,10 @@
     },
     "dialog": {
       "remote-key": "Remote public key",
+      "label": "Identification name (optional)",
       "transport-type": "Transport type",
       "success": "Transport created.",
+      "success-without-label": "The transport was created, but it was not possible to save the label.",
       "errors": {
         "remote-key-length-error": "The remote public key must be 66 characters long.",
         "remote-key-chars-error": "The remote public key must only contain hexadecimal characters.",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -468,8 +468,10 @@
     },
     "dialog": {
       "remote-key": "Llave pública remota",
+      "label": "Nombre del transporte (opcional)",
       "transport-type": "Tipo de transporte",
       "success": "Transporte creado.",
+      "success-without-label": "El transporte fue creado, pero no fue posible guardar la etiqueta.",
       "errors": {
         "remote-key-length-error": "La llave pública remota debe tener 66 caracteres.",
         "remote-key-chars-error": "La llave pública remota sólo debe contener caracteres hexadecimales.",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -468,8 +468,10 @@
     },
     "dialog": {
       "remote-key": "Remote public key",
+      "label": "Identification name (optional)",
       "transport-type": "Transport type",
       "success": "Transport created.",
+      "success-without-label": "The transport was created, but it was not possible to save the label.",
       "errors": {
         "remote-key-length-error": "The remote public key must be 66 characters long.",
         "remote-key-chars-error": "The remote public key must only contain hexadecimal characters.",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #661

 Changes:	
- Now the form for creating a transport has a field for setting the label. It is identified as “name” as that way it should be easier for the users to know what the field is for.

How to test this PR:
Create a new transport using the Skywire manager.