### PR TITLE
Parallelize health requests

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -65,6 +66,13 @@ type API interface {
 	UpdateWithStatus(config updater.UpdateConfig) <-chan StatusMessage
 	UpdateAvailable(channel updater.Channel) (*updater.Version, error)
 	UpdateStatus() (string, error)
+}
+
+// HealthCheckable resource returns its health status as an integer
+// that corresponds to HTTP status code returned from the resource
+// 200 codes correspond to a healthy resource
+type HealthCheckable interface {
+	Health(ctx context.Context) (int, error)
 }
 
 // Summary provides a summary of a Skywire Visor.
@@ -154,6 +162,40 @@ func (v *Visor) ExtraSummary() (*ExtraSummary, error) {
 	return extraSummary, nil
 }
 
+// collectHealthStats for given services and return health statuses
+func (v *Visor) collectHealthStats(services map[string]HealthCheckable) map[string]int {
+	type healthResponse struct {
+		name   string
+		status int
+	}
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	responses := make(chan healthResponse, len(services))
+	wg.Add(len(services))
+	for name, service := range services {
+		if service == nil {
+			responses <- healthResponse{name, http.StatusNotFound}
+			continue
+		}
+		go func(name string, service HealthCheckable) {
+			status, err := service.Health(ctx)
+			if err != nil {
+				v.log.WithError(err).Warnf("Failed to check service health, service name: %s", name)
+				status = http.StatusInternalServerError
+			}
+			responses <- healthResponse{name, status}
+			wg.Done()
+		}(name, service)
+	}
+	wg.Wait()
+	close(responses)
+	results := make(map[string]int)
+	for response := range responses {
+		results[response.name] = response.status
+	}
+	return results
+}
+
 // HealthInfo carries information about visor's external services health represented as http status codes
 type HealthInfo struct {
 	TransportDiscovery int `json:"transport_discovery"`
@@ -165,65 +207,25 @@ type HealthInfo struct {
 
 // Health implements API.
 func (v *Visor) Health() (*HealthInfo, error) {
-	ctx := context.Background()
+	services := map[string]HealthCheckable{
+		"td": v.tpDiscClient(),
+		"rf": v.routeFinderClient(),
+		"ut": v.uptimeTrackerClient(),
+		"ar": v.addressResolverClient(),
+	}
 
+	stats := v.collectHealthStats(services)
 	healthInfo := &HealthInfo{
-		TransportDiscovery: http.StatusNotFound,
-		RouteFinder:        http.StatusNotFound,
-		SetupNode:          http.StatusNotFound,
-		UptimeTracker:      http.StatusNotFound,
-		AddressResolver:    http.StatusNotFound,
+		TransportDiscovery: stats["td"],
+		RouteFinder:        stats["rf"],
+		UptimeTracker:      stats["ut"],
+		AddressResolver:    stats["ar"],
 	}
-
-	if tdClient := v.tpDiscClient(); tdClient != nil {
-		tdStatus, err := tdClient.Health(ctx)
-		if err != nil {
-			v.log.WithError(err).Warnf("Failed to check transport discovery health")
-
-			healthInfo.TransportDiscovery = http.StatusInternalServerError
-		}
-
-		healthInfo.TransportDiscovery = tdStatus
-	}
-
-	if rfClient := v.routeFinderClient(); rfClient != nil {
-		rfStatus, err := rfClient.Health(ctx)
-		if err != nil {
-			v.log.WithError(err).Warnf("Failed to check route finder health")
-
-			healthInfo.RouteFinder = http.StatusInternalServerError
-		}
-
-		healthInfo.RouteFinder = rfStatus
-	}
-
 	// TODO(evanlinjin): This should actually poll the setup nodes services.
 	if len(v.conf.Routing.SetupNodes) == 0 {
 		healthInfo.SetupNode = http.StatusNotFound
 	} else {
 		healthInfo.SetupNode = http.StatusOK
-	}
-
-	if utClient := v.uptimeTrackerClient(); utClient != nil {
-		utStatus, err := utClient.Health(ctx)
-		if err != nil {
-			v.log.WithError(err).Warnf("Failed to check uptime tracker health")
-
-			healthInfo.UptimeTracker = http.StatusInternalServerError
-		}
-
-		healthInfo.UptimeTracker = utStatus
-	}
-
-	if arClient := v.addressResolverClient(); arClient != nil {
-		arStatus, err := arClient.Health(ctx)
-		if err != nil {
-			v.log.WithError(err).Warnf("Failed to check address resolver health")
-
-			healthInfo.AddressResolver = http.StatusInternalServerError
-		}
-
-		healthInfo.AddressResolver = arStatus
 	}
 
 	return healthInfo, nil

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -173,11 +173,12 @@ func (v *Visor) collectHealthStats(services map[string]HealthCheckable) map[stri
 	responses := make(chan healthResponse, len(services))
 	wg.Add(len(services))
 	for name, service := range services {
-		if service == nil {
-			responses <- healthResponse{name, http.StatusNotFound}
-			continue
-		}
 		go func(name string, service HealthCheckable) {
+			if service == nil {
+				responses <- healthResponse{name, http.StatusNotFound}
+				wg.Done()
+				return
+			}
 			status, err := service.Health(ctx)
 			if err != nil {
 				v.log.WithError(err).Warnf("Failed to check service health, service name: %s", name)


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #670

 Changes:	
- Improve performance of `/api/visors/{pk}/health`

How to test this PR:
Run a hypervisor and hit `GET /api/visors/{pk}/health` for a pk that runs under that hypervisor