### PR TITLE
Fix hanging health

### DIFF
--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -80,7 +80,7 @@ func NewClient(cfg ClientConfig, appCl *app.Client) (*Client, error) {
 
 	utIP, err := uptimeTrackerIPFromEnv()
 	if err != nil {
-		return nil, fmt.Errorf("error getting UT IP: %w")
+		return nil, fmt.Errorf("error getting UT IP: %w", err)
 	}
 
 	stcpEntities, err := stcpEntitiesFromEnv()

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -78,6 +78,11 @@ func NewClient(cfg ClientConfig, appCl *app.Client) (*Client, error) {
 		return nil, fmt.Errorf("error getting RF IP: %w", err)
 	}
 
+	utIP, err := uptimeTrackerIPFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("error getting UT IP: %w")
+	}
+
 	stcpEntities, err := stcpEntitiesFromEnv()
 	if err != nil {
 		return nil, fmt.Errorf("error getting STCP entities: %w", err)
@@ -97,6 +102,10 @@ func NewClient(cfg ClientConfig, appCl *app.Client) (*Client, error) {
 
 	if arIP != nil {
 		directIPs = append(directIPs, arIP)
+	}
+
+	if utIP != nil {
+		directIPs = append(directIPs, utIP)
 	}
 
 	const (
@@ -550,6 +559,10 @@ func addressResolverIPFromEnv() (net.IP, error) {
 
 func rfIPFromEnv() (net.IP, error) {
 	return ipFromEnv(RFAddrEnvKey)
+}
+
+func uptimeTrackerIPFromEnv() (net.IP, error) {
+	return ipFromEnv(UptimeTrackerAddrEnvKey)
 }
 
 func tpRemoteIPsFromEnv() ([]net.IP, error) {

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -394,18 +394,24 @@ func (hv *Hypervisor) getVisors() http.HandlerFunc {
 		wg := new(sync.WaitGroup)
 		wg.Add(len(hv.visors))
 
+		log.Infof("ADDING TO WG %d", len(hv.visors))
+
 		i := 0
 		if hv.visor != nil {
 			i++
 		}
 
+		log.Infof("CREATING %d SUMMARIES", len(hv.visors)+i)
 		summaries := make([]summaryResp, len(hv.visors)+i)
 
 		if hv.visor != nil {
+			log.Infoln("GETTING SUMMARY FOR LOCAL VISOR")
 			summary, err := hv.visor.Summary()
 			if err != nil {
 				log.WithError(err).Warn("Failed to obtain summary of this visor.")
 				summary = &Summary{PubKey: hv.visor.conf.PK}
+			} else {
+				log.Infoln("GOT LOCAL VISOR SUMMARY")
 			}
 
 			addr := dmsg.Addr{PK: hv.c.PK, Port: hv.c.DmsgPort}
@@ -442,7 +448,9 @@ func (hv *Hypervisor) getVisors() http.HandlerFunc {
 			i++
 		}
 
+		log.Infoln("WAITING FOR ROUTINES")
 		wg.Wait()
+		log.Infoln("ROUTINES DONE")
 		hv.mu.RUnlock()
 
 		httputil.WriteJSON(w, r, http.StatusOK, summaries)

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -394,24 +394,18 @@ func (hv *Hypervisor) getVisors() http.HandlerFunc {
 		wg := new(sync.WaitGroup)
 		wg.Add(len(hv.visors))
 
-		log.Infof("ADDING TO WG %d", len(hv.visors))
-
 		i := 0
 		if hv.visor != nil {
 			i++
 		}
 
-		log.Infof("CREATING %d SUMMARIES", len(hv.visors)+i)
 		summaries := make([]summaryResp, len(hv.visors)+i)
 
 		if hv.visor != nil {
-			log.Infoln("GETTING SUMMARY FOR LOCAL VISOR")
 			summary, err := hv.visor.Summary()
 			if err != nil {
 				log.WithError(err).Warn("Failed to obtain summary of this visor.")
 				summary = &Summary{PubKey: hv.visor.conf.PK}
-			} else {
-				log.Infoln("GOT LOCAL VISOR SUMMARY")
 			}
 
 			addr := dmsg.Addr{PK: hv.c.PK, Port: hv.c.DmsgPort}
@@ -448,9 +442,7 @@ func (hv *Hypervisor) getVisors() http.HandlerFunc {
 			i++
 		}
 
-		log.Infoln("WAITING FOR ROUTINES")
 		wg.Wait()
-		log.Infoln("ROUTINES DONE")
 		hv.mu.RUnlock()
 
 		httputil.WriteJSON(w, r, http.StatusOK, summaries)


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #674 

 Changes:	
- Uptime Tracker IP is now properly passed to the VPN client. So client now can establish direct connection to it.

How to test this PR:
1. Run visor with the hypervisor on the same machine.
2. Run VPN client.
3. Try accessing current visor in the list. Page should open with no timeout.