### PR TITLE
Add separate timeout for /health requests done by visor

### DIFF
--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -22,8 +22,12 @@ import (
 const (
 	// RPCPrefix is the prefix used with all RPC calls.
 	RPCPrefix = "app-visor"
-	// HealthTimeout defines timeout for /health endpoint calls.
+	// HealthTimeout defines timeout for /health endpoint calls done from hypervisor.
 	HealthTimeout = 5 * time.Second
+	// InnerHealthTimeout defines timeout for /health endpoint calls done from visor.
+	// We keep it is less than the `HealthTimeout`, so that the outer call would
+	// definitely complete.
+	InnerHealthTimeout = 4 * time.Second
 )
 
 var (

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -27,7 +27,7 @@ const (
 	// InnerHealthTimeout defines timeout for /health endpoint calls done from visor.
 	// We keep it is less than the `HealthTimeout`, so that the outer call would
 	// definitely complete.
-	InnerHealthTimeout = 4 * time.Second
+	InnerHealthTimeout = 3 * time.Second
 )
 
 var (


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #676 

 Changes:	
- Now `/health` requests done by the visor have separate timeout which is lower than for the hypervisor's `/health` request.
