### PR TITLE
Move `run` command from `vpn` to `osutil`, add `RunWithResult`

### DIFF
--- a/internal/vpn/errors.go
+++ b/internal/vpn/errors.go
@@ -1,30 +1,7 @@
 package vpn
 
-import (
-	"errors"
-)
+import "errors"
 
 var (
 	errCouldFindDefaultNetworkGateway = errors.New("could not find default network gateway")
 )
-
-// ErrorWithStderr is an error raised by the external process.
-// `Err` is an actual error coming from `exec`, while `Stderr` contains
-// stderr output of the process.
-type ErrorWithStderr struct {
-	Err    error
-	Stderr []byte
-}
-
-// NewErrorWithStderr constructs new `ErrorWithStderr`.
-func NewErrorWithStderr(err error, stderr []byte) *ErrorWithStderr {
-	return &ErrorWithStderr{
-		Err:    err,
-		Stderr: stderr,
-	}
-}
-
-// Error implements `error`.
-func (e *ErrorWithStderr) Error() string {
-	return e.Err.Error() + ": " + string(e.Stderr)
-}

--- a/internal/vpn/os.go
+++ b/internal/vpn/os.go
@@ -1,13 +1,8 @@
 package vpn
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"net"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 // LocalNetworkInterfaceIPs gets IPs of all local interfaces.
@@ -82,24 +77,4 @@ func parseCIDR(ipCIDR string) (ipStr, netmask string, err error) {
 	}
 
 	return ip.String(), fmt.Sprintf("%d.%d.%d.%d", net.Mask[0], net.Mask[1], net.Mask[2], net.Mask[3]), nil
-}
-
-//nolint:unparam
-func run(bin string, args ...string) error {
-	fullCmd := bin + " " + strings.Join(args, " ")
-
-	cmd := exec.Command(bin, args...) //nolint:gosec
-
-	stderrBuf := bytes.NewBuffer(nil)
-
-	cmd.Stderr = io.MultiWriter(os.Stderr, stderrBuf)
-	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
-
-	if err := cmd.Run(); err != nil {
-		return NewErrorWithStderr(fmt.Errorf("error running command \"%s\": %w", fullCmd, err),
-			stderrBuf.Bytes())
-	}
-
-	return nil
 }

--- a/internal/vpn/os_client_darwin.go
+++ b/internal/vpn/os_client_darwin.go
@@ -4,9 +4,7 @@ package vpn
 
 import (
 	"bytes"
-	"fmt"
 	"net"
-	"syscall"
 
 	"github.com/skycoin/skywire/pkg/util/osutil"
 )
@@ -39,16 +37,10 @@ func DefaultNetworkGateway() (net.IP, error) {
 	return nil, errCouldFindDefaultNetworkGateway
 }
 
-func setupClientSysPrivileges() (suid int, err error) {
-	suid = syscall.Getuid()
-
-	if err := syscall.Setuid(0); err != nil {
-		return 0, fmt.Errorf("failed to setuid 0: %w", err)
-	}
-
-	return suid, nil
+func setupClientSysPrivileges() (int, error) {
+	return osutil.GainRoot()
 }
 
-func releaseClientSysPrivileges(suid int) error {
-	return syscall.Setuid(suid)
+func releaseClientSysPrivileges(oldUID int) error {
+	return osutil.ReleaseRoot(oldUID)
 }

--- a/internal/vpn/os_client_darwin.go
+++ b/internal/vpn/os_client_darwin.go
@@ -5,9 +5,11 @@ package vpn
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net"
-	"os/exec"
 	"syscall"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
 )
 
 const (
@@ -16,9 +18,14 @@ const (
 
 // DefaultNetworkGateway fetches system's default network gateway.
 func DefaultNetworkGateway() (net.IP, error) {
-	outputBytes, err := exec.Command("sh", "-c", defaultNetworkGatewayCMD).Output()
+	output, err := osutil.RunWithResult("sh", "-c", defaultNetworkGatewayCMD)
 	if err != nil {
 		return nil, fmt.Errorf("error running command %s: %w", defaultNetworkGatewayCMD, err)
+	}
+
+	outputBytes, err := ioutil.ReadAll(output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdout: %w", err)
 	}
 
 	outputBytes = bytes.TrimRight(outputBytes, "\n")

--- a/internal/vpn/os_client_darwin.go
+++ b/internal/vpn/os_client_darwin.go
@@ -5,7 +5,6 @@ package vpn
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"syscall"
 
@@ -18,14 +17,9 @@ const (
 
 // DefaultNetworkGateway fetches system's default network gateway.
 func DefaultNetworkGateway() (net.IP, error) {
-	output, err := osutil.RunWithResult("sh", "-c", defaultNetworkGatewayCMD)
+	outputBytes, err := osutil.RunWithResult("sh", "-c", defaultNetworkGatewayCMD)
 	if err != nil {
-		return nil, fmt.Errorf("error running command %s: %w", defaultNetworkGatewayCMD, err)
-	}
-
-	outputBytes, err := ioutil.ReadAll(output)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stdout: %w", err)
+		return nil, err
 	}
 
 	outputBytes = bytes.TrimRight(outputBytes, "\n")

--- a/internal/vpn/os_client_linux.go
+++ b/internal/vpn/os_client_linux.go
@@ -5,12 +5,14 @@ package vpn
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net"
-	"os/exec"
 	"sync"
 
 	"github.com/syndtr/gocapability/capability"
 	"golang.org/x/sys/unix"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
 )
 
 const (
@@ -19,9 +21,14 @@ const (
 
 // DefaultNetworkGateway fetches system's default network gateway.
 func DefaultNetworkGateway() (net.IP, error) {
-	outBytes, err := exec.Command("sh", "-c", defaultNetworkGatewayCMD).Output() //nolint:gosec
+	out, err := osutil.RunWithResult("sh", "-c", defaultNetworkGatewayCMD)
 	if err != nil {
 		return nil, fmt.Errorf("error running command %s: %w", defaultNetworkGatewayCMD, err)
+	}
+
+	outBytes, err := ioutil.ReadAll(out)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdout: %w", err)
 	}
 
 	outBytes = bytes.TrimRight(outBytes, "\n")

--- a/internal/vpn/os_client_linux.go
+++ b/internal/vpn/os_client_linux.go
@@ -5,7 +5,6 @@ package vpn
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"sync"
 
@@ -21,14 +20,9 @@ const (
 
 // DefaultNetworkGateway fetches system's default network gateway.
 func DefaultNetworkGateway() (net.IP, error) {
-	out, err := osutil.RunWithResult("sh", "-c", defaultNetworkGatewayCMD)
+	outBytes, err := osutil.RunWithResult("sh", "-c", defaultNetworkGatewayCMD)
 	if err != nil {
-		return nil, fmt.Errorf("error running command %s: %w", defaultNetworkGatewayCMD, err)
-	}
-
-	outBytes, err := ioutil.ReadAll(out)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stdout: %w", err)
+		return nil, err
 	}
 
 	outBytes = bytes.TrimRight(outBytes, "\n")

--- a/internal/vpn/os_client_windows.go
+++ b/internal/vpn/os_client_windows.go
@@ -4,10 +4,7 @@ package vpn
 
 import (
 	"bytes"
-	"fmt"
-	"io/ioutil"
 	"net"
-	"os/exec"
 	"regexp"
 
 	"github.com/skycoin/skywire/pkg/util/osutil"
@@ -21,14 +18,9 @@ var redundantWhitespacesCleanupRegex = regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 
 // DefaultNetworkGateway fetches system's default network gateway.
 func DefaultNetworkGateway() (net.IP, error) {
-	out, err := osutil.RunWithResult("cmd", "/C", defaultNetworkGatewayCMD)
+	outBytes, err := osutil.RunWithResult("cmd", "/C", defaultNetworkGatewayCMD)
 	if err != nil {
-		return nil, fmt.Errorf("error running command %s: %w", defaultNetworkGatewayCMD, err)
-	}
-
-	outBytes, err := ioutil.ReadAll(out)
-	if err != nil {
-		cmd := exec.Command("cmd", "/C", defaultNetworkGatewayCMD)
+		return nil, err
 	}
 
 	outBytes = bytes.TrimRight(outBytes, "\n\r")

--- a/internal/vpn/os_client_windows.go
+++ b/internal/vpn/os_client_windows.go
@@ -5,9 +5,12 @@ package vpn
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os/exec"
 	"regexp"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
 )
 
 const (
@@ -18,10 +21,14 @@ var redundantWhitespacesCleanupRegex = regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 
 // DefaultNetworkGateway fetches system's default network gateway.
 func DefaultNetworkGateway() (net.IP, error) {
-	cmd := exec.Command("cmd", "/C", defaultNetworkGatewayCMD)
-	outBytes, err := cmd.Output() //nolint:gosec
+	out, err := osutil.RunWithResult("cmd", "/C", defaultNetworkGatewayCMD)
 	if err != nil {
 		return nil, fmt.Errorf("error running command %s: %w", defaultNetworkGatewayCMD, err)
+	}
+
+	outBytes, err := ioutil.ReadAll(out)
+	if err != nil {
+		cmd := exec.Command("cmd", "/C", defaultNetworkGatewayCMD)
 	}
 
 	outBytes = bytes.TrimRight(outBytes, "\n\r")

--- a/internal/vpn/os_darwin.go
+++ b/internal/vpn/os_darwin.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
 )
 
 // SetupTUN sets the allocated TUN interface up, setting its IP, gateway, netmask and MTU.
@@ -16,7 +18,7 @@ func SetupTUN(ifcName, ipCIDR, gateway string, mtu int) error {
 		return fmt.Errorf("error parsing IP CIDR: %w", err)
 	}
 
-	return run("ifconfig", ifcName, ip, gateway, "mtu", strconv.Itoa(mtu), "netmask", netmask, "up")
+	return osutil.Run("ifconfig", ifcName, ip, gateway, "mtu", strconv.Itoa(mtu), "netmask", netmask, "up")
 }
 
 // ChangeRoute changes current route to `ipCIDR` to go through the `gateway`
@@ -28,7 +30,7 @@ func ChangeRoute(ipCIDR, gateway string) error {
 // AddRoute adds route to `ipCIDR` through the `gateway` to the OS routing table.
 func AddRoute(ipCIDR, gateway string) error {
 	if err := modifyRoutingTable("add", ipCIDR, gateway); err != nil {
-		var e *ErrorWithStderr
+		var e *osutil.ErrorWithStderr
 		if errors.As(err, &e) {
 			if strings.Contains(string(e.Stderr), "File exists") {
 				return nil
@@ -52,5 +54,5 @@ func modifyRoutingTable(action, ipCIDR, gateway string) error {
 		return fmt.Errorf("error parsing IP CIDR: %w", err)
 	}
 
-	return run("route", action, "-net", ip, gateway, netmask)
+	return osutil.Run("route", action, "-net", ip, gateway, netmask)
 }

--- a/internal/vpn/os_linux.go
+++ b/internal/vpn/os_linux.go
@@ -7,15 +7,17 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/util/osutil"
 )
 
 // SetupTUN sets the allocated TUN interface up, setting its IP, gateway, netmask and MTU.
 func SetupTUN(ifcName, ipCIDR, gateway string, mtu int) error {
-	if err := run("ip", "a", "add", ipCIDR, "dev", ifcName); err != nil {
+	if err := osutil.Run("ip", "a", "add", ipCIDR, "dev", ifcName); err != nil {
 		return fmt.Errorf("error assigning IP: %w", err)
 	}
 
-	if err := run("ip", "link", "set", "dev", ifcName, "mtu", strconv.Itoa(mtu)); err != nil {
+	if err := osutil.Run("ip", "link", "set", "dev", ifcName, "mtu", strconv.Itoa(mtu)); err != nil {
 		return fmt.Errorf("error setting MTU: %w", err)
 	}
 
@@ -24,7 +26,7 @@ func SetupTUN(ifcName, ipCIDR, gateway string, mtu int) error {
 		return fmt.Errorf("error parsing IP CIDR: %w", err)
 	}
 
-	if err := run("ip", "link", "set", ifcName, "up"); err != nil {
+	if err := osutil.Run("ip", "link", "set", ifcName, "up"); err != nil {
 		return fmt.Errorf("error setting interface up: %w", err)
 	}
 
@@ -45,7 +47,7 @@ func ChangeRoute(ip, gateway string) error {
 func AddRoute(ip, gateway string) error {
 	err := run("ip", "r", "add", ip, "via", gateway)
 
-	var e *ErrorWithStderr
+	var e *osutil.ErrorWithStderr
 	if errors.As(err, &e) {
 		if strings.Contains(string(e.Stderr), "File exists") {
 			return nil
@@ -57,5 +59,5 @@ func AddRoute(ip, gateway string) error {
 
 // DeleteRoute removes route to `ip` with `netmask` through the `gateway` from the OS routing table.
 func DeleteRoute(ip, gateway string) error {
-	return run("ip", "r", "del", ip, "via", gateway)
+	return osutil.Run("ip", "r", "del", ip, "via", gateway)
 }

--- a/internal/vpn/os_linux.go
+++ b/internal/vpn/os_linux.go
@@ -40,12 +40,12 @@ func SetupTUN(ifcName, ipCIDR, gateway string, mtu int) error {
 // ChangeRoute changes current route to `ip` to go through the `gateway`
 // in the OS routing table.
 func ChangeRoute(ip, gateway string) error {
-	return run("ip", "r", "change", ip, "via", gateway)
+	return osutil.Run("ip", "r", "change", ip, "via", gateway)
 }
 
 // AddRoute adds route to `ip` with `netmask` through the `gateway` to the OS routing table.
 func AddRoute(ip, gateway string) error {
-	err := run("ip", "r", "add", ip, "via", gateway)
+	err := osutil.Run("ip", "r", "add", ip, "via", gateway)
 
 	var e *osutil.ErrorWithStderr
 	if errors.As(err, &e) {

--- a/internal/vpn/os_server_linux.go
+++ b/internal/vpn/os_server_linux.go
@@ -5,7 +5,6 @@ package vpn
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"strings"
 
@@ -28,14 +27,9 @@ const (
 
 // GetIPTablesForwardPolicy gets current policy for iptables `forward` chain.
 func GetIPTablesForwardPolicy() (string, error) {
-	output, err := osutil.RunWithResult("sh", "-c", getIPTablesForwardPolicyCMD)
+	outputBytes, err := osutil.RunWithResult("sh", "-c", getIPTablesForwardPolicyCMD)
 	if err != nil {
-		return "", fmt.Errorf("error running command %s: %w", getIPTablesForwardPolicyCMD, err)
-	}
-
-	outputBytes, err := ioutil.ReadAll(output)
-	if err != nil {
-		return "", fmt.Errorf("failed to read stdout: %w", err)
+		return "", err
 	}
 
 	return strings.TrimRight(string(outputBytes), "\n"), nil
@@ -44,11 +38,7 @@ func GetIPTablesForwardPolicy() (string, error) {
 // SetIPTablesForwardPolicy sets `policy` for iptables `forward` chain.
 func SetIPTablesForwardPolicy(policy string) error {
 	cmd := fmt.Sprintf(setIPTablesForwardPolicyCMDFmt, policy)
-	if err := osutil.Run("sh", "-c", cmd); err != nil { //nolint:gosec
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 // SetIPTablesForwardAcceptPolicy sets ACCEPT policy for iptables `forward` chain.
@@ -61,34 +51,21 @@ func SetIPTablesForwardAcceptPolicy() error {
 // to private IP ranges.
 func AllowIPToLocalNetwork(src, dst net.IP) error {
 	cmd := fmt.Sprintf(allowIPToLocalNetCMDFmt, src, src)
-	if err := osutil.Run("sh", "-c", cmd); err != nil { //nolint:gosec
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 // BlockIPToLocalNetwork blocks all the packets coming from `source`
 // to private IP ranges.
 func BlockIPToLocalNetwork(src, dst net.IP) error {
 	cmd := fmt.Sprintf(blockIPToLocalNetCMDFmt, src, src)
-	if err := osutil.Run("sh", "-c", cmd); err != nil { //nolint:gosec
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 // DefaultNetworkInterface fetches default network interface name.
 func DefaultNetworkInterface() (string, error) {
-	output, err := osutil.RunWithResult("sh", "-c", defaultNetworkInterfaceCMD)
+	outputBytes, err := osutil.RunWithResult("sh", "-c", defaultNetworkInterfaceCMD)
 	if err != nil {
-		return "", fmt.Errorf("error running command %s: %w", defaultNetworkInterfaceCMD, err)
-	}
-
-	outputBytes, err := ioutil.ReadAll(output)
-	if err != nil {
-		return "", fmt.Errorf("failed to read stdout: %w", err)
+		return "", err
 	}
 
 	// just in case
@@ -110,21 +87,13 @@ func GetIPv6ForwardingValue() (string, error) {
 // SetIPv4ForwardingValue sets `val` value of IPv4 forwarding.
 func SetIPv4ForwardingValue(val string) error {
 	cmd := fmt.Sprintf(setIPv4ForwardingCMDFmt, val)
-	if err := osutil.Run("sh", "-c", cmd); err != nil { //nolint:gosec
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 // SetIPv6ForwardingValue sets `val` value of IPv6 forwarding.
 func SetIPv6ForwardingValue(val string) error {
 	cmd := fmt.Sprintf(setIPv6ForwardingCMDFmt, val)
-	if err := osutil.Run("sh", "-c", cmd); err != nil { //nolint:gosec
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 // EnableIPv4Forwarding enables IPv4 forwarding.
@@ -140,32 +109,19 @@ func EnableIPv6Forwarding() error {
 // EnableIPMasquerading enables IP masquerading for the interface with name `ifcName`.
 func EnableIPMasquerading(ifcName string) error {
 	cmd := fmt.Sprintf(enableIPMasqueradingCMDFmt, ifcName)
-	if err := osutil.Run("sh", "-c", cmd); err != nil {
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 // DisableIPMasquerading disables IP masquerading for the interface with name `ifcName`.
 func DisableIPMasquerading(ifcName string) error {
 	cmd := fmt.Sprintf(disableIPMasqueradingCMDFmt, ifcName)
-	if err := osutil.Run("sh", "-c", cmd); err != nil {
-		return fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	return nil
+	return osutil.Run("sh", "-c", cmd)
 }
 
 func getIPForwardingValue(cmd string) (string, error) {
-	out, err := osutil.RunWithResult("sh", "-c", cmd)
+	outBytes, err := osutil.RunWithResult("sh", "-c", cmd)
 	if err != nil {
-		return "", fmt.Errorf("error running command %s: %w", cmd, err)
-	}
-
-	outBytes, err := ioutil.ReadAll(out)
-	if err != nil {
-		return "", fmt.Errorf("failed to read stdout: %w", err)
+		return "", err
 	}
 
 	val, err := parseIPForwardingOutput(outBytes)

--- a/internal/vpn/os_server_linux.go
+++ b/internal/vpn/os_server_linux.go
@@ -35,7 +35,7 @@ func GetIPTablesForwardPolicy() (string, error) {
 
 	outputBytes, err := ioutil.ReadAll(output)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read stdout: %w", err)
+		return "", fmt.Errorf("failed to read stdout: %w", err)
 	}
 
 	return strings.TrimRight(string(outputBytes), "\n"), nil
@@ -88,7 +88,7 @@ func DefaultNetworkInterface() (string, error) {
 
 	outputBytes, err := ioutil.ReadAll(output)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read stdout: %w", err)
+		return "", fmt.Errorf("failed to read stdout: %w", err)
 	}
 
 	// just in case
@@ -163,9 +163,9 @@ func getIPForwardingValue(cmd string) (string, error) {
 		return "", fmt.Errorf("error running command %s: %w", cmd, err)
 	}
 
-	outBytes, err := ioutil.ReadAll()
+	outBytes, err := ioutil.ReadAll(out)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read stdout: %w", err)
+		return "", fmt.Errorf("failed to read stdout: %w", err)
 	}
 
 	val, err := parseIPForwardingOutput(outBytes)

--- a/pkg/util/osutil/errors.go
+++ b/pkg/util/osutil/errors.go
@@ -1,0 +1,22 @@
+package osutil
+
+// ErrorWithStderr is an error raised by the external process.
+// `Err` is an actual error coming from `exec`, while `Stderr` contains
+// stderr output of the process.
+type ErrorWithStderr struct {
+	Err    error
+	Stderr []byte
+}
+
+// NewErrorWithStderr constructs new `ErrorWithStderr`.
+func NewErrorWithStderr(err error, stderr []byte) *ErrorWithStderr {
+	return &ErrorWithStderr{
+		Err:    err,
+		Stderr: stderr,
+	}
+}
+
+// Error implements `error`.
+func (e *ErrorWithStderr) Error() string {
+	return e.Err.Error() + ": " + string(e.Stderr)
+}

--- a/pkg/util/osutil/privileges.go
+++ b/pkg/util/osutil/privileges.go
@@ -1,0 +1,22 @@
+package osutil
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// GainRoot escalates privileges to gain root access. Returns `uid` to be stored.
+func GainRoot() (int, error) {
+	uid := syscall.Getuid()
+
+	if err := syscall.Setuid(0); err != nil {
+		return 0, fmt.Errorf("failed to setuid 0: %w", err)
+	}
+
+	return uid, nil
+}
+
+// ReleaseRoot releases root privileges, setting `oldUID`.
+func ReleaseRoot(oldUID int) error {
+	return syscall.Setuid(oldUID)
+}

--- a/pkg/util/osutil/run.go
+++ b/pkg/util/osutil/run.go
@@ -1,0 +1,41 @@
+package osutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Run runs binary `bin` with `args`.
+func Run(bin string, args ...string) error {
+	return run(bin, os.Stdout, args...)
+}
+
+// RunWithResult runs binary `bin` with `args` returning stdout contents.
+func RunWithResult(bin string, args ...string) (io.Reader, error) {
+	stdout := bytes.NewBuffer(nil)
+
+	return stdout, run(bin, stdout, args...)
+}
+
+func run(bin string, stdout io.Writer, args ...string) error {
+	fullCmd := bin + " " + strings.Join(args, " ")
+
+	cmd := exec.Command(bin, args...) //nolint:gosec
+
+	stderrBuf := bytes.NewBuffer(nil)
+
+	cmd.Stderr = io.MultiWriter(os.Stderr, stderrBuf)
+	cmd.Stdout = stdout
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return NewErrorWithStderr(fmt.Errorf("error running command \"%s\": %w", fullCmd, err),
+			stderrBuf.Bytes())
+	}
+
+	return nil
+}

--- a/pkg/util/osutil/run.go
+++ b/pkg/util/osutil/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,11 +15,26 @@ func Run(bin string, args ...string) error {
 	return run(bin, os.Stdout, args...)
 }
 
-// RunWithResult runs binary `bin` with `args` returning stdout contents.
-func RunWithResult(bin string, args ...string) (io.Reader, error) {
+// RunWithResultReader runs binary `bin` with `args` returning stdout contents as `io.Reader`.
+func RunWithResultReader(bin string, args ...string) (io.Reader, error) {
 	stdout := bytes.NewBuffer(nil)
 
 	return stdout, run(bin, stdout, args...)
+}
+
+// RunWithResult runs binary `bin` with `args` returning stdout contents as bytes.
+func RunWithResult(bin string, args ...string) ([]byte, error) {
+	stdout, err := RunWithResultReader(bin, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	stdoutBytes, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdout: %w", err)
+	}
+
+	return stdoutBytes, nil
 }
 
 func run(bin string, stdout io.Writer, args ...string) error {


### PR DESCRIPTION
Did you run `make format && make check`?

 Changes:	
- `run` func was made public and moved to `osutil`;
- `RunWithResult` was added to `osutil` to run OS command and fetch output reader.