### PR TITLE
Fix remote throughput calculation

### DIFF
--- a/pkg/router/network_stats.go
+++ b/pkg/router/network_stats.go
@@ -58,8 +58,7 @@ func (s *networkStats) RemoteThroughput() int64 {
 	s.bandwidthReceivedRecStart = time.Now()
 	s.bandwidthReceivedRecStartMu.Unlock()
 
-	bandwidth := atomic.LoadUint64(&s.bandwidthReceived)
-	atomic.StoreUint64(&s.bandwidthReceived, 0)
+	bandwidth := atomic.SwapUint64(&s.bandwidthReceived, 0)
 
 	throughput := float64(bandwidth) / timePassed.Seconds()
 


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Might be part of #688 

 Changes:	
- Remote throughput previously had a data lag between `atomic.LoadValue` and `atomic.StoreValue`. Not very crucial, but under load, calculation might have been a mess. Now this is done with a single atomic call
