### PR TITLE
Build from vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ BUILDINFO_COMMIT := -X $(BUILDINFO_PATH).commit=$(COMMIT)
 
 BUILDINFO?=$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)
 
-BUILD_OPTS?="-ldflags=$(BUILDINFO) -mod=vendor"
+BUILD_OPTS?="-ldflags=$(BUILDINFO)" -mod=vendor
 BUILD_OPTS_DEPLOY?="-ldflags=$(BUILDINFO) -w -s"
 
 check: lint test ## Run linters and tests

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ BUILD_OPTS_DEPLOY?="-ldflags=$(BUILDINFO) -w -s"
 
 check: lint test ## Run linters and tests
 
-build: dep host-apps bin ## Install dependencies, build apps and binaries. `go build` with ${OPTS}
+build: host-apps bin ## Build apps and binaries. `go build` with ${OPTS}
 
-build-static: dep host-apps-static bin-static ## Install dependencies, build apps and binaries. `go build` with ${OPTS}
+build-static: host-apps-static bin-static ## Build apps and binaries. `go build` with ${OPTS}
 
 run: stop build	config  ## Run skywire-visor on host
 	./skywire-visor skywire.json

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ BUILDINFO_COMMIT := -X $(BUILDINFO_PATH).commit=$(COMMIT)
 
 BUILDINFO?=$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)
 
-BUILD_OPTS?="-ldflags=$(BUILDINFO)"
+BUILD_OPTS?="-ldflags=$(BUILDINFO) -mod=vendor"
 BUILD_OPTS_DEPLOY?="-ldflags=$(BUILDINFO) -w -s"
 
 check: lint test ## Run linters and tests


### PR DESCRIPTION
Did you run `make format && make check`?
Yes
Fixes #682 

 Changes:	
- `build` and `build-static` targets now do not update dependencies, build straight from vendor folder.

How to test this PR:
Run `make build` and `make build-static`