### PR TITLE
Fix bool flag config representation

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -323,17 +323,10 @@ func (v *Visor) SetAppKillswitch(appName string, killswitch bool) error {
 	v.log.Infof("Setting %s killswitch to %q", appName, killswitch)
 
 	const (
-		killSwitchArg = "-killswitch"
+		killSwitchArg = "--killswitch"
 	)
 
-	var value string
-	if killswitch {
-		value = "true"
-	} else {
-		value = "false"
-	}
-
-	if err := v.conf.UpdateAppArg(v.appL, appName, killSwitchArg, value); err != nil {
+	if err := v.conf.UpdateAppArg(v.appL, appName, killSwitchArg, killswitch); err != nil {
 		return err
 	}
 
@@ -351,17 +344,10 @@ func (v *Visor) SetAppSecure(appName string, isSecure bool) error {
 	v.log.Infof("Setting %s secure to %q", appName, isSecure)
 
 	const (
-		secureArgName = "-secure"
+		secureArgName = "--secure"
 	)
 
-	var value string
-	if isSecure {
-		value = "true"
-	} else {
-		value = "false"
-	}
-
-	if err := v.conf.UpdateAppArg(v.appL, appName, secureArgName, value); err != nil {
+	if err := v.conf.UpdateAppArg(v.appL, appName, secureArgName, isSecure); err != nil {
 		return err
 	}
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -203,7 +203,7 @@ func updateStringArg(conf *V1Launcher, appName, argName, value string) bool {
 }
 
 // updateBoolArg updates the cli boolean flag of the specified app config and also within the launcher.
-// All flag names and values are formatted as "name=value" to allow arbitrary values with respect to different
+// All flag names and values are formatted as "-name=value" to allow arbitrary values with respect to different
 // possible default values.
 // The updated config gets flushed to file if there are any changes.
 func updateBoolArg(conf *V1Launcher, appName, argName string, value bool) bool {
@@ -216,10 +216,10 @@ func updateBoolArg(conf *V1Launcher, appName, argName string, value bool) bool {
 			continue
 		}
 
-		// we format it to have two dashes, just to unify representation
+		// we format it to have a single dash, just to unify representation
 		fmtedArgName := argName
-		if argName[1] != '-' {
-			fmtedArgName = "-" + argName
+		if argName[1] == '-' {
+			fmtedArgName = fmtedArgName[1:]
 		}
 
 		arg := fmt.Sprintf(argFmt, fmtedArgName, value)
@@ -228,9 +228,9 @@ func updateBoolArg(conf *V1Launcher, appName, argName string, value bool) bool {
 
 		argChanged := false
 		for j := 0; j < len(conf.Apps[i].Args); j++ {
-			equalArgName := conf.Apps[i].Args[j][1] == '-' && strings.HasPrefix(conf.Apps[i].Args[j], fmtedArgName)
-			if conf.Apps[i].Args[j][1] != '-' {
-				equalArgName = strings.HasPrefix("-"+conf.Apps[i].Args[j], fmtedArgName)
+			equalArgName := conf.Apps[i].Args[j][1] != '-' && strings.HasPrefix(conf.Apps[i].Args[j], fmtedArgName)
+			if conf.Apps[i].Args[j][1] == '-' {
+				equalArgName = strings.HasPrefix(conf.Apps[i].Args[j], "-"+fmtedArgName)
 			}
 
 			if !equalArgName {

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -1,6 +1,8 @@
 package visorconfig
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/skycoin/dmsg/cipher"
@@ -128,15 +130,22 @@ func (v1 *V1) UpdateAppAutostart(launch *launcher.Launcher, appName string, auto
 }
 
 // UpdateAppArg updates the cli flag of the specified app config and also within the launcher.
-// It removes argName from app args if value is an empty string.
 // The updated config gets flushed to file if there are any changes.
-func (v1 *V1) UpdateAppArg(launch *launcher.Launcher, appName, argName, value string) error {
+func (v1 *V1) UpdateAppArg(launch *launcher.Launcher, appName, argName string, value interface{}) error {
 	v1.mu.Lock()
 	defer v1.mu.Unlock()
 
 	conf := v1.Launcher
 
-	configChanged := updateArg(conf, appName, argName, value)
+	var configChanged bool
+	switch val := value.(type) {
+	case string:
+		configChanged = updateStringArg(conf, appName, argName, val)
+	case bool:
+		configChanged = updateBoolArg(conf, appName, argName, val)
+	default:
+		return fmt.Errorf("invalid arg type %T", value)
+	}
 
 	if !configChanged {
 		return nil
@@ -151,32 +160,108 @@ func (v1 *V1) UpdateAppArg(launch *launcher.Launcher, appName, argName, value st
 	return v1.flush(v1)
 }
 
-func updateArg(conf *V1Launcher, appName, argName, value string) bool {
+// updateStringArg updates the cli non-boolean flag of the specified app config and also within the launcher.
+// It removes argName from app args if value is an empty string.
+// The updated config gets flushed to file if there are any changes.
+func updateStringArg(conf *V1Launcher, appName, argName, value string) bool {
 	configChanged := false
 
 	for i := range conf.Apps {
-		if conf.Apps[i].Name == appName {
-			configChanged = true
+		if conf.Apps[i].Name != appName {
+			continue
+		}
 
-			argChanged := false
-			l := len(conf.Apps[i].Args)
-			for j := 0; j < l; j++ {
-				if conf.Apps[i].Args[j] == argName && j+1 < len(conf.Apps[i].Args) {
-					if value == "" {
-						conf.Apps[i].Args = append(conf.Apps[i].Args[:j], conf.Apps[i].Args[j+2:]...)
-						j--
+		configChanged = true
+
+		argChanged := false
+		l := len(conf.Apps[i].Args)
+		for j := 0; j < l; j++ {
+			equalArgName := conf.Apps[i].Args[j] == argName && j+1 < len(conf.Apps[i].Args)
+			if !equalArgName {
+				continue
+			}
+
+			if value == "" {
+				conf.Apps[i].Args = append(conf.Apps[i].Args[:j], conf.Apps[i].Args[j+2:]...)
+				j-- //nolint:ineffassign
+			} else {
+				conf.Apps[i].Args[j+1] = value
+			}
+
+			argChanged = true
+			break
+		}
+
+		if !argChanged {
+			conf.Apps[i].Args = append(conf.Apps[i].Args, argName, value)
+		}
+
+		break
+	}
+
+	return configChanged
+}
+
+// updateBoolArg updates the cli boolean flag of the specified app config and also within the launcher.
+// All flag names and values are formatted as "name=value" to allow arbitrary values with respect to different
+// possible default values.
+// The updated config gets flushed to file if there are any changes.
+func updateBoolArg(conf *V1Launcher, appName, argName string, value bool) bool {
+	const argFmt = "%s=%v"
+
+	configChanged := false
+
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+
+		// we format it to have two dashes, just to unify representation
+		fmtedArgName := argName
+		if argName[1] != '-' {
+			fmtedArgName = "-" + argName
+		}
+
+		arg := fmt.Sprintf(argFmt, fmtedArgName, value)
+
+		configChanged = true
+
+		argChanged := false
+		for j := 0; j < len(conf.Apps[i].Args); j++ {
+			equalArgName := conf.Apps[i].Args[j][1] == '-' && strings.HasPrefix(conf.Apps[i].Args[j], fmtedArgName)
+			if conf.Apps[i].Args[j][1] != '-' {
+				equalArgName = strings.HasPrefix("-"+conf.Apps[i].Args[j], fmtedArgName)
+			}
+
+			if !equalArgName {
+				continue
+			}
+
+			// check next value. currently we store value along with the flag name in a single string,
+			// but there're may be some broken configs because of the previous functionality, so we
+			// make our best effort to fix this on the go
+			if (j + 1) < len(conf.Apps[i].Args) {
+				// bool value shouldn't be present there, so we remove it, if it is
+				if conf.Apps[i].Args[j+1] == "true" || conf.Apps[i].Args[j+1] == "false" {
+					if (j + 2) < len(conf.Apps[i].Args) {
+						conf.Apps[i].Args = append(conf.Apps[i].Args[:j+1], conf.Apps[i].Args[j+2:]...)
 					} else {
-						conf.Apps[i].Args[j+1] = value
+						conf.Apps[i].Args = conf.Apps[i].Args[:j+1]
 					}
-					argChanged = true
-					break
 				}
 			}
 
-			if !argChanged {
-				conf.Apps[i].Args = append(conf.Apps[i].Args, argName, value)
-			}
+			conf.Apps[i].Args[j] = arg
+			argChanged = true
+
+			break
 		}
+
+		if !argChanged {
+			conf.Apps[i].Args = append(conf.Apps[i].Args, arg)
+		}
+
+		break
 	}
 
 	return configChanged

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -228,6 +228,12 @@ func updateBoolArg(conf *V1Launcher, appName, argName string, value bool) bool {
 
 		argChanged := false
 		for j := 0; j < len(conf.Apps[i].Args); j++ {
+			// there shouldn't be such values if config is modified automatically,
+			// but might happen if done manually, so we avoid further panic with this check
+			if len(conf.Apps[i].Args[j]) < 2 {
+				continue
+			}
+
 			equalArgName := conf.Apps[i].Args[j][1] != '-' && strings.HasPrefix(conf.Apps[i].Args[j], fmtedArgName)
 			if conf.Apps[i].Args[j][1] == '-' {
 				equalArgName = strings.HasPrefix(conf.Apps[i].Args[j], "-"+fmtedArgName)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -192,7 +192,7 @@ func updateStringArg(conf *V1Launcher, appName, argName, value string) bool {
 			break
 		}
 
-		if !argChanged {
+		if !argChanged && value != "" {
 			conf.Apps[i].Args = append(conf.Apps[i].Args, argName, value)
 		}
 

--- a/pkg/visor/visorconfig/v1_test.go
+++ b/pkg/visor/visorconfig/v1_test.go
@@ -3,11 +3,10 @@ package visorconfig
 import (
 	"testing"
 
-	"github.com/skycoin/skywire/pkg/skyenv"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/skycoin/skywire/pkg/app/launcher"
+	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
 func Test_updateStringArg(t *testing.T) {
@@ -144,6 +143,29 @@ func Test_updateStringArg(t *testing.T) {
 					{
 						Name: "skysocks-client",
 						Args: []string{"-t", "-passcode", "1234", "-test", "abc"},
+					},
+				},
+			},
+		},
+		{
+			name: "Case 6",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: "skysocks-client",
+						},
+					},
+				},
+				appName: "skysocks-client",
+				argName: "-passcode",
+				value:   "",
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: "skysocks-client",
 					},
 				},
 			},
@@ -305,6 +327,30 @@ func Test_updateBoolArg(t *testing.T) {
 						{
 							Name: skyenv.VPNClientName,
 							Args: []string{"--killswitch", "true"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   false,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-killswitch=false"},
+					},
+				},
+			},
+		},
+		{
+			name: "Empty args list",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
 						},
 					},
 				},

--- a/pkg/visor/visorconfig/v1_test.go
+++ b/pkg/visor/visorconfig/v1_test.go
@@ -368,6 +368,31 @@ func Test_updateBoolArg(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "List with a single arg and empty value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"-passcode", ""},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   false,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-passcode", "", "-killswitch=false"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/visor/visorconfig/v1_test.go
+++ b/pkg/visor/visorconfig/v1_test.go
@@ -192,7 +192,7 @@ func Test_updateBoolArg(t *testing.T) {
 				Apps: []launcher.AppConfig{
 					{
 						Name: skyenv.VPNClientName,
-						Args: []string{"-passcode", "1234", "--killswitch=true"},
+						Args: []string{"-passcode", "1234", "-killswitch=true"},
 					},
 				},
 			},
@@ -217,7 +217,7 @@ func Test_updateBoolArg(t *testing.T) {
 				Apps: []launcher.AppConfig{
 					{
 						Name: skyenv.VPNClientName,
-						Args: []string{"-passcode", "1234", "--killswitch=false"},
+						Args: []string{"-passcode", "1234", "-killswitch=false"},
 					},
 				},
 			},
@@ -242,7 +242,7 @@ func Test_updateBoolArg(t *testing.T) {
 				Apps: []launcher.AppConfig{
 					{
 						Name: skyenv.VPNClientName,
-						Args: []string{"-passcode", "1234", "--killswitch=false"},
+						Args: []string{"-passcode", "1234", "-killswitch=false"},
 					},
 				},
 			},
@@ -267,7 +267,7 @@ func Test_updateBoolArg(t *testing.T) {
 				Apps: []launcher.AppConfig{
 					{
 						Name: skyenv.VPNClientName,
-						Args: []string{"-passcode", "1234", "--killswitch=true"},
+						Args: []string{"-passcode", "1234", "-killswitch=true"},
 					},
 				},
 			},
@@ -292,7 +292,7 @@ func Test_updateBoolArg(t *testing.T) {
 				Apps: []launcher.AppConfig{
 					{
 						Name: skyenv.VPNClientName,
-						Args: []string{"-passcode", "1234", "--killswitch=true"},
+						Args: []string{"-passcode", "1234", "-killswitch=true"},
 					},
 				},
 			},
@@ -317,7 +317,7 @@ func Test_updateBoolArg(t *testing.T) {
 				Apps: []launcher.AppConfig{
 					{
 						Name: skyenv.VPNClientName,
-						Args: []string{"--killswitch=false"},
+						Args: []string{"-killswitch=false"},
 					},
 				},
 			},

--- a/pkg/visor/visorconfig/v1_test.go
+++ b/pkg/visor/visorconfig/v1_test.go
@@ -3,12 +3,14 @@ package visorconfig
 import (
 	"testing"
 
+	"github.com/skycoin/skywire/pkg/skyenv"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/skycoin/skywire/pkg/app/launcher"
 )
 
-func Test_updateArg(t *testing.T) {
+func Test_updateStringArg(t *testing.T) {
 	type args struct {
 		conf    *V1Launcher
 		appName string
@@ -150,9 +152,183 @@ func Test_updateArg(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := updateArg(tt.args.conf, tt.args.appName, tt.args.argName, tt.args.value)
-			assert.Equal(t, result, tt.wantResult)
-			assert.EqualValues(t, tt.args.conf, tt.wantConf)
+			result := updateStringArg(tt.args.conf, tt.args.appName, tt.args.argName, tt.args.value)
+			assert.Equal(t, tt.wantResult, result)
+			assert.EqualValues(t, tt.wantConf, tt.args.conf)
+		})
+	}
+}
+
+func Test_updateBoolArg(t *testing.T) {
+	type args struct {
+		conf    *V1Launcher
+		appName string
+		argName string
+		value   bool
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult bool
+		wantConf   *V1Launcher
+	}{
+		{
+			name: "Single dash flag, absent value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"-passcode", "1234"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "-killswitch",
+				value:   true,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-passcode", "1234", "--killswitch=true"},
+					},
+				},
+			},
+		},
+		{
+			name: "Double dash flag, absent value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"-passcode", "1234"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   false,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-passcode", "1234", "--killswitch=false"},
+					},
+				},
+			},
+		},
+		{
+			name: "Present valid double-dash-named value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"-passcode", "1234", "--killswitch=true"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   false,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-passcode", "1234", "--killswitch=false"},
+					},
+				},
+			},
+		},
+		{
+			name: "Present valid single-dash-named value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"-passcode", "1234", "-killswitch=false"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   true,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-passcode", "1234", "--killswitch=true"},
+					},
+				},
+			},
+		},
+		{
+			name: "Present invalid single-dash-named value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"-passcode", "1234", "-killswitch", "false"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   true,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"-passcode", "1234", "--killswitch=true"},
+					},
+				},
+			},
+		},
+		{
+			name: "Present invalid double-dash-named value",
+			args: args{
+				conf: &V1Launcher{
+					Apps: []launcher.AppConfig{
+						{
+							Name: skyenv.VPNClientName,
+							Args: []string{"--killswitch", "true"},
+						},
+					},
+				},
+				appName: skyenv.VPNClientName,
+				argName: "--killswitch",
+				value:   false,
+			},
+			wantResult: true,
+			wantConf: &V1Launcher{
+				Apps: []launcher.AppConfig{
+					{
+						Name: skyenv.VPNClientName,
+						Args: []string{"--killswitch=false"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := updateBoolArg(tt.args.conf, tt.args.appName, tt.args.argName, tt.args.value)
+			assert.Equal(t, tt.wantResult, result)
+			assert.EqualValues(t, tt.wantConf, tt.args.conf)
 		})
 	}
 }


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #691 

 Changes:	
- All boolean flags that we support are now represented in format of `--flag_name=value` in the app args.
