### PR TITLE
Fixes for the modal windows bottom margin

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.html
@@ -3,6 +3,6 @@
     <mat-form-field>
       <input #firstInput [placeholder]="'edit-label.label' | translate" formControlName="label" maxlength="66" matInput>
     </mat-form-field>
-    <app-button class="float-right" color="primary" (action)="save()">{{ 'common.save' | translate }}</app-button>
   </form>
+  <app-button class="float-right" color="primary" (action)="save()">{{ 'common.save' | translate }}</app-button>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.html
@@ -21,15 +21,15 @@
         </mat-select>
       </mat-form-field>
     </ng-container>
-
-    <!-- button. -->
-    <app-button
-      #button
-      (action)="apply()"
-      color="primary"
-      class="float-right"
-    >
-      {{ 'common.ok' | translate }}
-    </app-button>
   </form>
+
+  <!-- button. -->
+  <app-button
+    #button
+    (action)="apply()"
+    color="primary"
+    class="float-right"
+  >
+    {{ 'common.ok' | translate }}
+  </app-button>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/edit-skysocks-client-note/edit-skysocks-client-note.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/edit-skysocks-client-note/edit-skysocks-client-note.component.html
@@ -3,6 +3,6 @@
     <mat-form-field>
       <input #firstInput [placeholder]="'apps.vpn-socks-client-settings.change-note-dialog.note' | translate" formControlName="note" maxlength="100" matInput>
     </mat-form-field>
-    <app-button class="float-right" color="primary" type="mat-raised-button" (action)="finish()">{{ 'common.save' | translate }}</app-button>
   </form>
+  <app-button class="float-right" color="primary" type="mat-raised-button" (action)="finish()">{{ 'common.save' | translate }}</app-button>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-filter/skysocks-client-filter.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-filter/skysocks-client-filter.component.html
@@ -45,16 +45,16 @@
         matInput
       >
     </mat-form-field>
-
-    <!-- button. -->
-    <app-button
-      #button
-      (action)="apply()"
-      type="mat-raised-button"
-      color="primary"
-      class="float-right"
-    >
-      {{ 'apps.vpn-socks-client-settings.filter-dialog.apply' | translate }}
-    </app-button>
   </form>
+
+  <!-- button. -->
+  <app-button
+    #button
+    (action)="apply()"
+    type="mat-raised-button"
+    color="primary"
+    class="float-right"
+  >
+    {{ 'apps.vpn-socks-client-settings.filter-dialog.apply' | translate }}
+  </app-button>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-password/skysocks-client-password.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-password/skysocks-client-password.component.html
@@ -12,8 +12,9 @@
         matInput
       >
     </mat-form-field>
-    <app-button class="float-right" color="primary" type="mat-raised-button" (action)="finish()">
-      {{ 'apps.vpn-socks-client-settings.password-dialog.continue-button' | translate }}
-    </app-button>
   </form>
+
+  <app-button class="float-right" color="primary" type="mat-raised-button" (action)="finish()">
+    {{ 'apps.vpn-socks-client-settings.password-dialog.continue-button' | translate }}
+  </app-button>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
@@ -37,15 +37,15 @@
         <mat-icon [inline]="true" class="help-icon" [matTooltip]="'apps.vpn-socks-server-settings.secure-mode-info' | translate">help</mat-icon>
       </mat-checkbox>
     </div>
-
-    <app-button
-      #button
-      (action)="saveChanges()"
-      [disabled]="!form.valid"
-      color="primary"
-      class="float-right"
-    >
-      {{ 'apps.vpn-socks-server-settings.save' | translate }}
-    </app-button>
   </form>
+
+  <app-button
+    #button
+    (action)="saveChanges()"
+    [disabled]="!form.valid"
+    color="primary"
+    class="float-right"
+  >
+    {{ 'apps.vpn-socks-server-settings.save' | translate }}
+  </app-button>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
@@ -39,15 +39,15 @@
         {{ 'transports.dialog.errors.transport-type-error' | translate }}
       </mat-error>
     </mat-form-field>
-
-    <app-button
-      #button
-      (action)="create()"
-      [disabled]="!form.valid"
-      color="primary"
-      class="float-right"
-    >
-      {{ 'transports.create' | translate }}
-    </app-button>
   </form>
+
+  <app-button
+    #button
+    (action)="create()"
+    [disabled]="!form.valid"
+    color="primary"
+    class="float-right"
+  >
+    {{ 'transports.create' | translate }}
+  </app-button>
 </app-dialog>


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Previously, if a modal window with a form and a button at the bottom needed scroll bars, the bottom marging was ignored:
![m](https://user-images.githubusercontent.com/34079003/109355255-59dad900-7855-11eb-9275-79d6de2c1d0e.png)
This PR solves that problem.

How to test this PR:
Open a modal window with a form and a button at the bottom (add transport, edit label, VPN server config, etc.) and resize the browser so that the modal window needs vertical scroll bars. The margin at the bottom should be present.