### PR TITLE
Improvements for the visor list

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -126,6 +126,7 @@
           </td>
           <td *ngIf="showDmsgInfo">
             <app-labeled-element-text
+              *ngIf="node.dmsgServerPk"
               [short]="true"
               id="{{ node.dmsgServerPk }}"
               shortTextLength="4"
@@ -134,7 +135,9 @@
             </app-labeled-element-text>
           </td>
           <td *ngIf="showDmsgInfo">
-            {{ 'common.time-in-ms' | translate:{ time: node.roundTripPing } }}
+            <ng-container *ngIf="node.dmsgServerPk">
+              {{ 'common.time-in-ms' | translate:{ time: node.roundTripPing } }}
+            </ng-container>
           </td>
           <td (click)="$event.stopPropagation()" class="actions">
             <button

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -486,9 +486,8 @@ export class NodeService {
    */
   private getNodes(): Observable<Node[]> {
     let nodes: Node[] = [];
-    let dmsgInfo: any[];
 
-    return this.apiService.get('visors').pipe(mergeMap((result: any[]) => {
+    return this.apiService.get('visors-summary').pipe(map((result: any[]) => {
       // Save the visor list.
       if (result) {
         result.forEach(response => {
@@ -499,62 +498,44 @@ export class NodeService {
           node.tcpAddr = response.tcp_addr;
           node.ip = this.getAddressPart(node.tcpAddr, 0);
           node.port = this.getAddressPart(node.tcpAddr, 1);
-          node.localPk = response.local_pk;
+          node.localPk = response.summary.local_pk;
 
           // Label.
           const labelInfo = this.storageService.getLabelInfo(node.localPk);
           node.label = labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.localPk);
 
+          // Health data.
+          node.health = {
+            status: 200,
+            addressResolver: response.health.address_resolver,
+            routeFinder: response.health.route_finder,
+            setupNode: response.health.setup_node,
+            transportDiscovery: response.health.transport_discovery,
+            uptimeTracker: response.health.uptime_tracker,
+          };
+
+          // DMSG info.
+          node.dmsgServerPk = response.dmsg_stats.server_public_key;
+          node.roundTripPing = this.nsToMs(response.dmsg_stats.round_trip);
+
+          // Check if is hypervisor.
+          node.isHypervisor = response.is_hypervisor;
+
           nodes.push(node);
         });
       }
 
-      // Get the dmsg info.
-      return this.apiService.get('dmsg');
-    }), mergeMap((result: any[]) => {
-      dmsgInfo = result;
-
-      // Get the health info of each node.
-      return forkJoin(nodes.map(node => this.apiService.get(`visors/${node.localPk}/health`)));
-    }), mergeMap((result: any[]) => {
-      nodes.forEach((node, i) => {
-        node.health = {
-          status: result[i].status,
-          addressResolver: result[i].address_resolver,
-          routeFinder: result[i].route_finder,
-          setupNode: result[i].setup_node,
-          transportDiscovery: result[i].transport_discovery,
-          uptimeTracker: result[i].uptime_tracker,
-        };
-      });
-
-      // Get the basic info about the hypervisor.
-      return this.apiService.get('about');
-    }), map((aboutInfo: any) => {
-      // Create a map to associate the dmsg info with the visors.
-      const dmsgInfoMap = new Map<string, any>();
-      dmsgInfo.forEach(info => dmsgInfoMap.set(info.public_key, info));
-
-      // Process the node data and create a helper map.
+      // Create lists with the nodes returned by the api.
       const obtainedNodes = new Map<string, Node>();
       const nodesToRegisterInLocalStorageAsOnline: string[] = [];
       nodes.forEach(node => {
-        if (dmsgInfoMap.has(node.localPk)) {
-          node.dmsgServerPk = dmsgInfoMap.get(node.localPk).server_public_key;
-          node.roundTripPing = this.nsToMs(dmsgInfoMap.get(node.localPk).round_trip);
-        } else {
-          node.dmsgServerPk = '-';
-          node.roundTripPing = '-1';
-        }
-
-        node.isHypervisor = node.localPk === aboutInfo.public_key;
-
         obtainedNodes.set(node.localPk, node);
         if (node.online) {
           nodesToRegisterInLocalStorageAsOnline.push(node.localPk);
         }
       });
 
+      // Save all online nodes.
       this.storageService.includeVisibleLocalNodes(nodesToRegisterInLocalStorageAsOnline);
 
       const missingSavedNodes: Node[] = [];
@@ -566,6 +547,8 @@ export class NodeService {
           const labelInfo = this.storageService.getLabelInfo(node.publicKey);
           newNode.label = labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.publicKey);
           newNode.online = false;
+          newNode.dmsgServerPk = "";
+          newNode.roundTripPing = "";
 
           missingSavedNodes.push(newNode);
         }

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -547,8 +547,8 @@ export class NodeService {
           const labelInfo = this.storageService.getLabelInfo(node.publicKey);
           newNode.label = labelInfo && labelInfo.label ? labelInfo.label : this.storageService.getDefaultLabel(node.publicKey);
           newNode.online = false;
-          newNode.dmsgServerPk = "";
-          newNode.roundTripPing = "";
+          newNode.dmsgServerPk = '';
+          newNode.roundTripPing = '';
 
           missingSavedNodes.push(newNode);
         }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the UI uses the new `GET /api//visors-summary` API endpoint, added in https://github.com/skycoin/skywire/pull/666 , for populating the visor list. This change allows to load the visor list faster.

- A problem with the offline visors in the DMSG tab was solved. Before the changes, part of the data of the offline visors in the DMSG tab was shown like this:
![D](https://user-images.githubusercontent.com/34079003/109359947-b988b280-785c-11eb-895c-6eb598a78328.png)

How to test this PR:
For the first change, refresh the visor list, the data should load faster. For the second change, open the DMSG tab in the visor list while there is an offline node on it, the list should not show invalid data.

NOTE: this PR needs the changes from https://github.com/skycoin/skywire/pull/666 to work well.