### PR TITLE
Ignore darwin_arm64 target for release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/skywire-visor/
@@ -47,6 +49,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/skywire-cli/
@@ -66,6 +70,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skychat/
@@ -85,6 +91,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skysocks/
@@ -104,6 +112,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skysocks-client/
@@ -123,6 +133,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/vpn-server/
@@ -142,6 +154,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: arm64
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/vpn-client/


### PR DESCRIPTION
Did you run `make format && make check`?
No need to, only .yml file is changed

Fixes #701

 Changes:	
- Remove darwin_arm64 build target for goreleaser

How to test this PR:
Make a release with golang 1.16 and goreleaser 0.157.0+