### PR TITLE
Increase backoff factor and limit

### DIFF
--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -38,9 +38,9 @@ var (
 // @evanlinjin: I see no need to make these configurable.
 const (
 	tpInitBO = time.Millisecond * 500
-	tpMaxBO  = time.Second * 10
+	tpMaxBO  = time.Minute
 	tpTries  = 0
-	tpFactor = 1.3
+	tpFactor = 2
 )
 
 // ManagedTransportConfig is a configuration for managed transport.

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -35,7 +35,6 @@ var (
 )
 
 // Constants associated with transport redial loop.
-// @evanlinjin: I see no need to make these configurable.
 const (
 	tpInitBO = time.Millisecond * 500
 	tpMaxBO  = time.Minute


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #712 

 Changes:	
- Maximum backoff and multiplication factor for tp redialing backoff were increased to 1 minute and 2 respectively

