### PR TITLE
Show the correct app arguments in the UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.ts
@@ -172,8 +172,8 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
         if (this.data.args[i] === '-srv' && i + 1 < this.data.args.length) {
           currentVal = this.data.args[i + 1];
         }
-        if (this.data.args[i] === '-killswitch' && i + 1 < this.data.args.length) {
-          this.killswitch = (this.data.args[i + 1] as string).toLowerCase() === 'true';
+        if ((this.data.args[i] as string).toLowerCase().includes('-killswitch')) {
+          this.killswitch = (this.data.args[i] as string).toLowerCase().includes('true');
           this.initialKillswitchSetting = this.killswitch;
         }
       }

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.ts
@@ -62,8 +62,8 @@ export class SkysocksSettingsComponent implements OnInit, OnDestroy {
     // Get the current values saved on the visor, if returned by the API.
     if (this.data.args && this.data.args.length > 0) {
       for (let i = 0; i < this.data.args.length; i++) {
-        if (this.data.args[i] === '-secure' && i + 1 < this.data.args.length) {
-          this.secureMode = (this.data.args[i + 1] as string).toLowerCase() === 'true';
+        if ((this.data.args[i] as string).toLowerCase().includes('-secure')) {
+          this.secureMode = (this.data.args[i] as string).toLowerCase().includes('true');
         }
       }
     }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #696

 Changes:	
- Now the UI shows the correct value for the `-killswitch` and `-secure` flags when checking the `vpn-client` and `vpn-server` apps.

How to test this PR:
Use the UI to open the configuration of the `vpn-client` and `vpn-server` apps and change the `killswitch` and `secure` values. After closing the configuration and oppening it again, the correct values should be shown.