### PR TITLE
Fix for the updater UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -460,10 +460,12 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
     const nodesData: NodeData[] = [];
     this.dataSource.forEach(node => {
-      nodesData.push({
-        key: node.localPk,
-        label: node.label,
-      });
+      if (node.online) {
+        nodesData.push({
+          key: node.localPk,
+          label: node.label,
+        });
+      }
     });
 
     UpdateComponent.openDialog(this.dialog, nodesData);

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -134,7 +134,7 @@
   "nodes": {
     "title": "Visor list",
     "dmsg-title": "DMSG",
-    "update-all": "Update all visors",
+    "update-all": "Update all online visors",
     "hypervisor": "Hypervisor",
     "state": "State",
     "state-tooltip": "Current state",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -131,7 +131,7 @@
   "nodes": {
     "title": "Lista de visores",
     "dmsg-title": "DMSG",
-    "update-all": "Actualizar todos los visores",
+    "update-all": "Actualizar todos los visores online",
     "hypervisor": "Hypervisor",
     "state": "Estado",
     "state-tooltip": "Estado actual",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -131,7 +131,7 @@
   "nodes": {
     "title": "Visor list",
     "dmsg-title": "DMSG",
-    "update-all": "Update all visors",
+    "update-all": "Update all online visors",
     "hypervisor": "Hypervisor",
     "state": "State",
     "state-tooltip": "Current state",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #727

 Changes:	
- Now the offline visors are ignored when using the option for updating all the visors, in the visor list.

How to test this PR:
Open the Skywire manager, open the visor list, make sure that at least one visor is offline and use the option for updating all visors. The updater should not show errors like it did before this PR.