### PR TITLE
Remove the secure setting from the skysocks config

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
@@ -27,7 +27,7 @@
         {{ 'apps.vpn-socks-server-settings.passwords-not-match' | translate }}
       </mat-error>
     </mat-form-field>
-    <div class="main-theme settings-option">
+    <div class="main-theme settings-option" *ngIf="configuringVpn">
       <mat-checkbox
         color="primary"
         [checked]="secureMode"

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.ts
@@ -119,11 +119,17 @@ export class SkysocksSettingsComponent implements OnInit, OnDestroy {
   private continueSavingChanges() {
     this.button.showLoading();
 
+    const data = { passcode: this.form.get('password').value };
+    // The "secure" value is only for the VPN app.
+    if (this.configuringVpn) {
+      data['secure'] = this.secureMode;
+    }
+
     this.operationSubscription = this.appsService.changeAppSettings(
       // The node pk is obtained from the currently openned node page.
       NodeComponent.getCurrentNodeKey(),
       this.data.name,
-      { passcode: this.form.get('password').value, secure: this.secureMode },
+      data,
     ).subscribe({
       next: this.onSuccess.bind(this),
       error: this.onError.bind(this)


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- The `secure` option was removed prom the codal window used for configuring the `skysocks` app.

How to test this PR:
Open the modal window used for configuring the `skysocks` app and use it for changing the settings, it should work well. The modal window for the `vpn-server` should continue working as before.