### PR TITLE
Fix a problem with the time since last update

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -357,7 +357,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
         this.ngZone.run(() => {
           if (result) {
             // If the data was obtained.
-            if (result.data) {
+            if (result.data && !result.error) {
               this.allNodes = result.data as Node[];
               if (this.showDmsgInfo) {
                 // Add the label data to the array, to be able to use it for filtering and sorting.


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Solves a problem which made the visor list show that the data was updated more than 2000 weeks ago:
![e](https://user-images.githubusercontent.com/34079003/115875041-d1bb1f00-a412-11eb-98f7-6a995b80ad93.jpg)
The problem happened if the user tried to refresh the data by pressing the refresh button but the procedure failed.

How to test this PR:
-	Open the Skywire manager and enter to the visor list.
-	Use the web developer tools to block the network connection and immediately after that press the refresh button at the top-right part of the visor list page.You should see an error message indicating that the data was not updated.
-	Use the web developer tools to allow network access again. That data should be updated automatically after a moment.

Those steps caused the error before this PR.