### PR TITLE
Feature/makefile cleanup

### DIFF
--- a/ci_scripts/docker-push.sh
+++ b/ci_scripts/docker-push.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function extra_ldflags() {
+  local build_dir="github.com/skycoin/dmsg/buildinfo"
+  local version="$(git describe)"
+  local commit="$(git rev-parse HEAD)"
+  local build_date="$(date -u "+%Y-%m-%d%T%H:%M:%SZ")"
+  echo "-X ${build_dir}.version=${version} -X ${build_dir}.commit=${commit} -X ${build_dir}.date=${build_date}"
+}
+
 function print_usage() {
   echo "Use: $0 [-t <docker_image_tag_name>] [-p | -b]"
   echo "use -p for push (it builds and push the image)"
@@ -14,13 +22,14 @@ fi
 function docker_build() {
   docker image build \
     --tag=skycoin/skywire:"$tag" \
+    --build-arg BUILDINFO_LDFLAGS="$(extra_ldflags)" \
     -f ./docker/images/visor/Dockerfile .
 }
 
 function docker_push() {
-    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-    docker tag skycoin/skywire:"$tag" skycoin/skywire:"$tag"
-    docker image push skycoin/skywire:"$tag"
+  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  docker tag skycoin/skywire:"$tag" skycoin/skywire:"$tag"
+  docker image push skycoin/skywire:"$tag"
 }
 
 while getopts ":t:pb" o; do
@@ -29,6 +38,8 @@ while getopts ":t:pb" o; do
     tag="$(echo "${OPTARG}" | tr -d '[:space:]')"
     if [[ $tag == "develop" ]]; then
       tag="test"
+    elif [[ $tag == "master" ]]; then
+      tag="latest"
     fi
     ;;
   p)

--- a/docker/images/visor/Dockerfile
+++ b/docker/images/visor/Dockerfile
@@ -2,6 +2,7 @@
 ARG base=alpine
 FROM golang:alpine  as builder
 
+ARG BUILDINFO_LDFLAGS
 ARG CGO_ENABLED=0
 ENV CGO_ENABLED=${CGO_ENABLED} \
     GOOS=linux  \
@@ -12,14 +13,16 @@ COPY . skywire
 
 WORKDIR skywire
 
-RUN go build -mod=vendor -tags netgo -ldflags="-w -s" \
+RUN echo $BUILDINFO_LDFLAGS
+
+RUN go build -mod=vendor -tags netgo -ldflags="-w -s ${BUILDINFO_LDFLAGS}" \
       -o skywire-visor cmd/skywire-visor/skywire-visor.go &&\
-    go build -mod=vendor -ldflags="-w -s" -o skywire-cli ./cmd/skywire-cli	&&\
-    go build -mod=vendor -ldflags="-w -s" -o ./apps/skychat ./cmd/apps/skychat	&&\
-	go build -mod=vendor -ldflags="-w -s" -o ./apps/skysocks ./cmd/apps/skysocks &&\
-	go build -mod=vendor -ldflags="-w -s" -o ./apps/skysocks-client  ./cmd/apps/skysocks-client && \
-	go build -mod=vendor -ldflags="-w -s" -o ./apps/vpn-server ./cmd/apps/vpn-server && \
-	go build -mod=vendor -ldflags="-w -s" -o ./apps/vpn-client ./cmd/apps/vpn-client
+    go build -mod=vendor -ldflags="-w -s ${BUILDINFO_LDFLAGS}" -o skywire-cli ./cmd/skywire-cli	&&\
+    go build -mod=vendor -ldflags="-w -s ${BUILDINFO_LDFLAGS}" -o ./apps/skychat ./cmd/apps/skychat	&&\
+	go build -mod=vendor -ldflags="-w -s ${BUILDINFO_LDFLAGS}" -o ./apps/skysocks ./cmd/apps/skysocks &&\
+	go build -mod=vendor -ldflags="-w -s ${BUILDINFO_LDFLAGS}" -o ./apps/skysocks-client  ./cmd/apps/skysocks-client && \
+	go build -mod=vendor -ldflags="-w -s ${BUILDINFO_LDFLAGS}" -o ./apps/vpn-server ./cmd/apps/vpn-server && \
+	go build -mod=vendor -ldflags="-w -s ${BUILDINFO_LDFLAGS}" -o ./apps/vpn-client ./cmd/apps/vpn-client
 
 
 ## Resulting image

--- a/skywire-runner.Dockerfile
+++ b/skywire-runner.Dockerfile
@@ -1,7 +1,0 @@
-FROM debian:stretch-slim
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		wget \
-	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Did you run `make format && make check`? yes

Fixes #747 

 Changes:	
- Makefiles cleanup (many recipes are actually for skywire-services instead of `skywire`, one such example is the `setup-node container`)
- Remove skywire-runner, as it is not being used anywhere
- Added buildinfo ldflags to docker build script 

How to test this PR:
- Follow the instruction on the README.md for running the docker container.
