### PR TITLE
Add a view logs option to he UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -67,6 +67,11 @@ export class NodeActionsHelper {
         name: 'actions.menu.update',
         actionName: 'update',
         icon: 'get_app',
+      },
+      {
+        name: 'actions.menu.logs',
+        actionName: 'logs',
+        icon: 'subject',
       }
     ];
 
@@ -92,12 +97,14 @@ export class NodeActionsHelper {
    * Must be called when an option form the top bar is selected.
    * @param actionName Name of the selected option, as defined in the options array.
    */
-  performAction(actionName: string) {
+  performAction(actionName: string, nodePk: string) {
     // Call the adequate function if the user clicks any of the options.
     if (actionName === 'terminal') {
       this.terminal();
     } else if (actionName === 'update') {
       this.update();
+    } else if (actionName === 'logs') {
+      window.open(window.location.origin + '/api/visors/' + nodePk + '/runtime-logs', '_blank');
     } else if (actionName === 'reboot') {
       this.reboot();
     } else if (actionName === null) {

--- a/static/skywire-manager-src/src/app/components/pages/node/node.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node.component.ts
@@ -229,7 +229,7 @@ export class NodeComponent implements OnInit, OnDestroy {
    */
   performAction(actionName: string) {
     // The helper object manages the event.
-    this.nodeActionsHelper.performAction(actionName);
+    this.nodeActionsHelper.performAction(actionName, NodeComponent.currentNodeKey);
   }
 
   /**

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -242,7 +242,8 @@
       "terminal": "Terminal",
       "config": "Configuration",
       "update": "Update",
-      "reboot": "Reboot"
+      "reboot": "Reboot",
+      "logs": "View logs"
     },
     "reboot": {
       "confirmation": "Are you sure you want to reboot the visor?",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -242,7 +242,8 @@
       "terminal": "Terminal",
       "config": "Configuración",
       "update": "Actualizar",
-      "reboot": "Reiniciar"
+      "reboot": "Reiniciar",
+      "logs": "Ver logs"
     },
     "reboot": {
       "confirmation": "¿Seguro que desea reiniciar el visor?",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -242,7 +242,8 @@
       "terminal": "Terminal",
       "config": "Configuration",
       "update": "Update",
-      "reboot": "Reboot"
+      "reboot": "Reboot",
+      "logs": "View logs"
     },
     "reboot": {
       "confirmation": "Are you sure you want to reboot the visor?",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #758 

 Changes:	
- Now the menu of the visor details page has a `View logs` option, which opens the visor logs in a new tab or window.

How to test this PR:
Open the Skywire manager, enter to the details page of a visor, open the menu using the top-right button and select the `View logs` option.
