### PR TITLE
Netutil fixes

### DIFF
--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -90,3 +90,16 @@ func IsPublicIP(IP net.IP) bool {
 	}
 	return false
 }
+
+// DefaultNetworkInterfaceIPs returns IP addresses for the default network interface
+func DefaultNetworkInterfaceIPs() ([]net.IP, error) {
+	networkIfc, err := DefaultNetworkInterface()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default network interface: %w", err)
+	}
+	localIPs, err := NetworkInterfaceIPs(networkIfc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get IPs of %s: %w", networkIfc, err)
+	}
+	return localIPs, nil
+}

--- a/pkg/util/netutil/net_darwin.go
+++ b/pkg/util/netutil/net_darwin.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultNetworkInterfaceCMD = "netstat -rn | sed -n '/Internet/,/Internet6/p' | grep default | awk '{print $4}'"
+	defaultNetworkInterfaceCMD = "route -n get default | awk 'FNR == 5 {print $2}'"
 )
 
 // DefaultNetworkInterface fetches default network interface name.

--- a/pkg/util/netutil/net_linux.go
+++ b/pkg/util/netutil/net_linux.go
@@ -5,7 +5,6 @@ package netutil
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"os/exec"
 )
 
@@ -24,17 +23,4 @@ func DefaultNetworkInterface() (string, error) {
 	outputBytes = bytes.TrimRight(outputBytes, "\n")
 
 	return string(outputBytes), nil
-}
-
-// DefaultNetworkInterfaceIPs returns IP addresses for the default network interface
-func DefaultNetworkInterfaceIPs() ([]net.IP, error) {
-	networkIfc, err := DefaultNetworkInterface()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default network interface: %w", err)
-	}
-	localIPs, err := NetworkInterfaceIPs(networkIfc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get IPs of %s: %w", networkIfc, err)
-	}
-	return localIPs, nil
 }

--- a/pkg/util/netutil/net_test.go
+++ b/pkg/util/netutil/net_test.go
@@ -1,0 +1,15 @@
+package netutil_test
+
+import (
+	"github.com/skycoin/skywire/pkg/util/netutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDefaultNetworkInterfaceIPs(t *testing.T) {
+	req := require.New(t)
+
+	ifaceIPs, err := netutil.DefaultNetworkInterfaceIPs()
+	req.NoError(err)
+	t.Logf("interface IP: %v", ifaceIPs)
+}

--- a/pkg/util/netutil/net_test.go
+++ b/pkg/util/netutil/net_test.go
@@ -1,9 +1,11 @@
 package netutil_test
 
 import (
-	"github.com/skycoin/skywire/pkg/util/netutil"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/util/netutil"
 )
 
 func TestDefaultNetworkInterfaceIPs(t *testing.T) {

--- a/pkg/util/netutil/net_windows.go
+++ b/pkg/util/netutil/net_windows.go
@@ -2,7 +2,14 @@
 
 package netutil
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os/exec"
+	"regexp"
+	"strings"
+)
 
 const (
 	defaultNetworkInterfaceCMD = `netsh int ip show config | findstr /r "IP Address.*([0-9]{1,3}\.|){4}"`
@@ -45,5 +52,5 @@ func DefaultNetworkInterface() (string, error) {
 		return "", fmt.Errorf("unable to get default interface: %v", err)
 	}
 
-	return strings.TrimSpace(output), nil
+	return strings.TrimSpace(string(output)), nil
 }

--- a/pkg/util/netutil/net_windows.go
+++ b/pkg/util/netutil/net_windows.go
@@ -25,7 +25,6 @@ func DefaultNetworkInterface() (string, error) {
 			ipAddr := re.Split(strings.TrimSpace(line), -1)
 
 			if len(ipAddr) > 2 {
-				fmt.Printf("Ip address is %s\n", ipAddr[2])
 				ip := net.ParseIP(ipAddr[2])
 				if ip != nil && !ip.IsLoopback() {
 					ips[i] = ipAddr[2]

--- a/pkg/util/netutil/net_windows.go
+++ b/pkg/util/netutil/net_windows.go
@@ -2,7 +2,49 @@
 
 package netutil
 
+import "strings"
+
+const (
+	defaultNetworkInterfaceCMD = `netsh int ip show config | findstr /r "IP Address.*([0-9]{1,3}\.|){4}"`
+)
+
 // DefaultNetworkInterface fetches default network interface name.
 func DefaultNetworkInterface() (string, error) {
-	return "", errServerMethodsNotSupported
+	cmd := exec.Command("powershell", defaultNetworkInterfaceCMD)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	// parse output
+	splitLines := strings.Split(string(output), "\n")
+	ips := make([]string, len(splitLines))
+
+	if len(splitLines) > 0 {
+		re := regexp.MustCompile("\\s+")
+		for i, line := range splitLines {
+			ipAddr := re.Split(strings.TrimSpace(line), -1)
+
+			if len(ipAddr) > 2 {
+				fmt.Printf("Ip address is %s\n", ipAddr[2])
+				ip := net.ParseIP(ipAddr[2])
+				if ip != nil && !ip.IsLoopback() {
+					ips[i] = ipAddr[2]
+				}
+			}
+		}
+	}
+
+	if len(ips) == 0 {
+		return "", errors.New("no active ip found")
+	}
+
+	// get default network interface based on its ip
+	findInterfaceCmd := fmt.Sprintf("Get-NetIpAddress -IPAddress '%s' | %%{$_.InterfaceAlias}", ips[0])
+	cmd = exec.Command("powershell", findInterfaceCmd)
+	output, err = cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("unable to get default interface: %v", err)
+	}
+
+	return strings.TrimSpace(output), nil
 }

--- a/pkg/util/netutil/net_windows.go
+++ b/pkg/util/netutil/net_windows.go
@@ -24,7 +24,7 @@ func DefaultNetworkInterface() (string, error) {
 	}
 	// parse output
 	splitLines := strings.Split(string(output), "\n")
-	ips := make([]string, len(splitLines))
+	var ips []string
 
 	if len(splitLines) > 0 {
 		re := regexp.MustCompile("\\s+")
@@ -34,7 +34,7 @@ func DefaultNetworkInterface() (string, error) {
 			if len(ipAddr) > 2 {
 				ip := net.ParseIP(ipAddr[2])
 				if ip != nil && !ip.IsLoopback() {
-					ips[i] = ipAddr[2]
+					ips = append(ips, ipAddr[2])
 				}
 			}
 		}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes https://travis-ci.com/github/skycoin/skywire/jobs/505838265 (`pkg/servicedisc/client.go:158:15: undefined: "github.com/skycoin/skywire/pkg/util/netutil".DefaultNetworkInterfaceIPs`)

 Changes:	
- Moved `DefaultNetworkInterfaceIPs` function to `netutil`
- Added unit test for it.

TODO:
- [x] Test on Linux
- [x] Test on Windows

How to test this PR:
- Build it on `darwin` or `linux`
- Run the VPN, check if the default network interface IP is showing the correct value depending on your network.