### PR TITLE
Add min hops manipulation endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - nvm install 10.16
 
 install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.31.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.40.1
   - make dep
 
 before_script:

--- a/cmd/skywire-cli/commands/visor/routes.go
+++ b/cmd/skywire-cli/commands/visor/routes.go
@@ -22,6 +22,8 @@ func init() {
 		ruleCmd,
 		rmRuleCmd,
 		addRuleCmd,
+		getMinHopsCmd,
+		setMinHopsCmd,
 	)
 }
 
@@ -115,6 +117,32 @@ var addRuleCmd = &cobra.Command{
 
 		internal.Catch(rpcClient().SaveRoutingRule(rule))
 		fmt.Println("Routing Rule Key:", rIDKey)
+	},
+}
+
+var getMinHopsCmd = &cobra.Command{
+	Use:   "get-min-hops",
+	Short: "Gets local visor's min_hops routing config",
+	Run: func(_ *cobra.Command, _ []string) {
+		hops, err := rpcClient().GetMinHops()
+		internal.Catch(err)
+
+		_, err = fmt.Fprintf(os.Stdout, "Visor's min hops: %d\n", hops)
+		internal.Catch(err)
+	},
+}
+
+var setMinHopsCmd = &cobra.Command{
+	Use:   "set-min-hops",
+	Short: "Sets the local visor's min_hops routing config",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		hops, err := strconv.ParseUint(args[0], 10, 16)
+		internal.Catch(err)
+
+		err = rpcClient().SetMinHops(uint16(hops))
+		internal.Catch(err)
+		fmt.Printf("Successfully sets min_hops to: %d\n", hops)
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/routes.go
+++ b/cmd/skywire-cli/commands/visor/routes.go
@@ -22,8 +22,6 @@ func init() {
 		ruleCmd,
 		rmRuleCmd,
 		addRuleCmd,
-		getMinHopsCmd,
-		setMinHopsCmd,
 	)
 }
 
@@ -117,32 +115,6 @@ var addRuleCmd = &cobra.Command{
 
 		internal.Catch(rpcClient().SaveRoutingRule(rule))
 		fmt.Println("Routing Rule Key:", rIDKey)
-	},
-}
-
-var getMinHopsCmd = &cobra.Command{
-	Use:   "get-min-hops",
-	Short: "Gets local visor's min_hops routing config",
-	Run: func(_ *cobra.Command, _ []string) {
-		hops, err := rpcClient().GetMinHops()
-		internal.Catch(err)
-
-		_, err = fmt.Fprintf(os.Stdout, "Visor's min hops: %d\n", hops)
-		internal.Catch(err)
-	},
-}
-
-var setMinHopsCmd = &cobra.Command{
-	Use:   "set-min-hops",
-	Short: "Sets the local visor's min_hops routing config",
-	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		hops, err := strconv.ParseUint(args[0], 10, 16)
-		internal.Catch(err)
-
-		err = rpcClient().SetMinHops(uint16(hops))
-		internal.Catch(err)
-		fmt.Printf("Successfully sets min_hops to: %d\n", hops)
 	},
 }
 

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -70,6 +70,9 @@ type API interface {
 	UpdateAvailable(channel updater.Channel) (*updater.Version, error)
 	UpdateStatus() (string, error)
 	RuntimeLogs() (string, error)
+
+	GetMinHops() (uint16, error)
+	SetMinHops(uint16) error
 }
 
 // HealthCheckable resource returns its health status as an integer
@@ -733,4 +736,14 @@ func (v *Visor) RuntimeLogs() (string, error) {
 	builder.WriteString(strings.Join(logs, ","))
 	builder.WriteString("]")
 	return builder.String(), nil
+}
+
+// GetMinHops gets min_hops routing config of visor
+func (v *Visor) GetMinHops() (uint16, error) {
+	return v.conf.Routing.MinHops, nil
+}
+
+// SetMinHops sets min_hops routing config of visor
+func (v *Visor) SetMinHops(in uint16) error {
+	return v.conf.UpdateMinHops(in)
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -71,7 +71,6 @@ type API interface {
 	UpdateStatus() (string, error)
 	RuntimeLogs() (string, error)
 
-	GetMinHops() (uint16, error)
 	SetMinHops(uint16) error
 }
 
@@ -140,6 +139,7 @@ type Summary struct {
 	IsHypervisor bool                           `json:"is_hypervisor,omitempty"`
 	DmsgStats    *dmsgtracker.DmsgClientSummary `json:"dmsg_stats"`
 	Online       bool                           `json:"online"`
+	MinHops      uint16                         `json:"min_hops"`
 }
 
 // Summary implements API.
@@ -178,6 +178,7 @@ func (v *Visor) Summary() (*Summary, error) {
 		Health:   health,
 		Uptime:   uptime,
 		Routes:   extraRoutes,
+		MinHops:  v.conf.Routing.MinHops,
 	}
 
 	return summary, nil
@@ -736,11 +737,6 @@ func (v *Visor) RuntimeLogs() (string, error) {
 	builder.WriteString(strings.Join(logs, ","))
 	builder.WriteString("]")
 	return builder.String(), nil
-}
-
-// GetMinHops gets min_hops routing config of visor
-func (v *Visor) GetMinHops() (uint16, error) {
-	return v.conf.Routing.MinHops, nil
 }
 
 // SetMinHops sets min_hops routing config of visor

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -258,6 +258,8 @@ func (hv *Hypervisor) makeMux() chi.Router {
 				r.Get("/visors/{pk}/update/available", hv.visorUpdateAvailable())
 				r.Get("/visors/{pk}/update/available/{channel}", hv.visorUpdateAvailable())
 				r.Get("/visors/{pk}/runtime-logs", hv.getRuntimeLogs())
+				r.Get("/visors/{pk}/min-hops", hv.getMinHops())
+				r.Post("/visors/{pk}/min-hops", hv.postMinHops())
 			})
 		})
 
@@ -1293,6 +1295,46 @@ func (hv *Hypervisor) getRuntimeLogs() http.HandlerFunc {
 		if err != nil {
 			hv.visor.log.Errorf("Cannot write response: %s", err)
 		}
+	})
+}
+
+func (hv *Hypervisor) getMinHops() http.HandlerFunc {
+	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
+		hops, err := ctx.API.GetMinHops()
+		if err != nil {
+			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
+			return
+		}
+
+		hopsResp := struct {
+			MinHops uint16 `json:"min_hops"`
+		}{
+			MinHops: hops,
+		}
+
+		httputil.WriteJSON(w, r, http.StatusOK, hopsResp)
+	})
+}
+
+func (hv *Hypervisor) postMinHops() http.HandlerFunc {
+	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
+		var reqBody struct {
+			MinHops uint16 `json:"min_hops"`
+		}
+
+		if err := httputil.ReadJSON(r, &reqBody); err != nil {
+			if err != io.EOF {
+				hv.log(r).Warnf("postMinHops request: %v", err)
+			}
+			httputil.WriteJSON(w, r, http.StatusBadRequest, usermanager.ErrMalformedRequest)
+			return
+		}
+
+		if err := ctx.API.SetMinHops(reqBody.MinHops); err != nil {
+			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
+			return
+		}
+		httputil.WriteJSON(w, r, http.StatusOK, struct{}{})
 	})
 }
 

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -258,7 +258,6 @@ func (hv *Hypervisor) makeMux() chi.Router {
 				r.Get("/visors/{pk}/update/available", hv.visorUpdateAvailable())
 				r.Get("/visors/{pk}/update/available/{channel}", hv.visorUpdateAvailable())
 				r.Get("/visors/{pk}/runtime-logs", hv.getRuntimeLogs())
-				r.Get("/visors/{pk}/min-hops", hv.getMinHops())
 				r.Post("/visors/{pk}/min-hops", hv.postMinHops())
 			})
 		})
@@ -1295,24 +1294,6 @@ func (hv *Hypervisor) getRuntimeLogs() http.HandlerFunc {
 		if err != nil {
 			hv.visor.log.Errorf("Cannot write response: %s", err)
 		}
-	})
-}
-
-func (hv *Hypervisor) getMinHops() http.HandlerFunc {
-	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
-		hops, err := ctx.API.GetMinHops()
-		if err != nil {
-			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
-			return
-		}
-
-		hopsResp := struct {
-			MinHops uint16 `json:"min_hops"`
-		}{
-			MinHops: hops,
-		}
-
-		httputil.WriteJSON(w, r, http.StatusOK, hopsResp)
 	})
 }
 

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -548,13 +548,15 @@ func (r *RPC) RuntimeLogs(_ *struct{}, logs *string) (err error) {
 }
 
 // GetMinHops gets min_hops from visor's routing config
-func (r *RPC) GetMinHops() (n uint16, err error) {
+func (r *RPC) GetMinHops(_ *struct{}, hops *uint16) (err error) {
 	defer rpcutil.LogCall(r.log, "GetMinHops", nil)
-	return r.visor.GetMinHops()
+	*hops, err = r.visor.GetMinHops()
+	return
 }
 
 // SetMinHops sets min_hops from visor's routing config
-func (r *RPC) SetMinHops(n uint16) error {
-	defer rpcutil.LogCall(r.log, "SetMinHops", n)
-	return r.visor.SetMinHops(n)
+func (r *RPC) SetMinHops(n *uint16, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetMinHops", *n)
+	err = r.visor.SetMinHops(*n)
+	return
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -1,7 +1,6 @@
 package visor
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/rpc"
@@ -147,40 +146,11 @@ func newTransportSummary(tm *transport.Manager, tp *transport.ManagedTransport, 
 
 // Summary provides an extra summary of the AppNode.
 func (r *RPC) Summary(_ *struct{}, out *Summary) (err error) {
-	overview, err := r.visor.Overview()
+	defer rpcutil.LogCall(r.log, "Summary", nil)(out, &err)
+
+	out, err = r.visor.Summary()
 	if err != nil {
-		return fmt.Errorf("summary")
-	}
-
-	health, err := r.visor.Health()
-	if err != nil {
-		return fmt.Errorf("health")
-	}
-
-	uptime, err := r.visor.Uptime()
-	if err != nil {
-		return fmt.Errorf("uptime")
-	}
-
-	routes, err := r.visor.RoutingRules()
-	if err != nil {
-		return fmt.Errorf("routes")
-	}
-
-	extraRoutes := make([]routingRuleResp, 0, len(routes))
-	for _, route := range routes {
-		extraRoutes = append(extraRoutes, routingRuleResp{
-			Key:     route.KeyRouteID(),
-			Rule:    hex.EncodeToString(route),
-			Summary: route.Summary(),
-		})
-	}
-
-	*out = Summary{
-		Overview: overview,
-		Health:   health,
-		Uptime:   uptime,
-		Routes:   extraRoutes,
+		return err
 	}
 
 	return nil
@@ -544,13 +514,6 @@ func (r *RPC) UpdateStatus(_ *struct{}, status *string) (err error) {
 // RuntimeLogs returns visor runtime logs
 func (r *RPC) RuntimeLogs(_ *struct{}, logs *string) (err error) {
 	*logs, err = r.visor.RuntimeLogs()
-	return
-}
-
-// GetMinHops gets min_hops from visor's routing config
-func (r *RPC) GetMinHops(_ *struct{}, hops *uint16) (err error) {
-	defer rpcutil.LogCall(r.log, "GetMinHops", nil)
-	*hops, err = r.visor.GetMinHops()
 	return
 }
 

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -546,3 +546,15 @@ func (r *RPC) RuntimeLogs(_ *struct{}, logs *string) (err error) {
 	*logs, err = r.visor.RuntimeLogs()
 	return
 }
+
+// GetMinHops gets min_hops from visor's routing config
+func (r *RPC) GetMinHops() (n uint16, err error) {
+	defer rpcutil.LogCall(r.log, "GetMinHops", nil)
+	return r.visor.GetMinHops()
+}
+
+// SetMinHops sets min_hops from visor's routing config
+func (r *RPC) SetMinHops(n uint16) error {
+	defer rpcutil.LogCall(r.log, "SetMinHops", n)
+	return r.visor.SetMinHops(n)
+}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -147,12 +147,11 @@ func newTransportSummary(tm *transport.Manager, tp *transport.ManagedTransport, 
 // Summary provides an extra summary of the AppNode.
 func (r *RPC) Summary(_ *struct{}, out *Summary) (err error) {
 	defer rpcutil.LogCall(r.log, "Summary", nil)(out, &err)
-
-	out, err = r.visor.Summary()
+	sum, err := r.visor.Summary()
 	if err != nil {
 		return err
 	}
-
+	*out = *sum
 	return nil
 }
 

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -338,13 +338,6 @@ func (rc *rpcClient) RuntimeLogs() (string, error) {
 	return logs, err
 }
 
-// GetMinHops gets min_hops from visor routing config
-func (rc *rpcClient) GetMinHops() (uint16, error) {
-	var hops uint16
-	err := rc.Call("GetMinHops", &struct{}{}, &hops)
-	return hops, err
-}
-
 // SetMinHops sets the min_hops from visor routing config
 func (rc *rpcClient) SetMinHops(hops uint16) error {
 	err := rc.Call("SetMinHops", &hops, &struct{}{})

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -331,11 +331,24 @@ func (rc *rpcClient) Update(config updater.UpdateConfig) (bool, error) {
 	return updated, err
 }
 
-// Update calls Update.
+// RuntimeLogs calls RuntimeLogs.
 func (rc *rpcClient) RuntimeLogs() (string, error) {
 	var logs string
 	err := rc.Call("RuntimeLogs", &struct{}{}, &logs)
 	return logs, err
+}
+
+// GetMinHops gets min_hops from visor routing config
+func (rc *rpcClient) GetMinHops() (uint16, error) {
+	var hops uint16
+	err := rc.Call("GetMinHops", &struct{}{}, &hops)
+	return hops, err
+}
+
+// SetMinHops sets the min_hops from visor routing config
+func (rc *rpcClient) SetMinHops(hops uint16) error {
+	err := rc.Call("SetMinHops", &hops, &struct{}{})
+	return err
 }
 
 // StatusMessage defines a status of visor update.
@@ -424,7 +437,7 @@ func (rc *rpcClient) UpdateAvailable(channel updater.Channel) (*updater.Version,
 	return &version, err
 }
 
-// UpdateAvailable calls UpdateAvailable.
+// UpdateStatus calls UpdateStatus
 func (rc *rpcClient) UpdateStatus() (string, error) {
 	var result string
 	err := rc.Call("UpdateStatus", &struct{}{}, &result)
@@ -919,7 +932,17 @@ func (mc *mockRPCClient) UpdateStatus() (string, error) {
 	return "", nil
 }
 
-// UpdateStatus implements API.
+// RuntimeLogs implements API.
 func (mc *mockRPCClient) RuntimeLogs() (string, error) {
 	return "", nil
+}
+
+// GetMinHops implements API.
+func (mc *mockRPCClient) GetMinHops() (uint16, error) {
+	return uint16(0), nil
+}
+
+// SetMinHops implements API
+func (mc *mockRPCClient) SetMinHops(n uint16) error {
+	return nil
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -930,11 +930,6 @@ func (mc *mockRPCClient) RuntimeLogs() (string, error) {
 	return "", nil
 }
 
-// GetMinHops implements API.
-func (mc *mockRPCClient) GetMinHops() (uint16, error) {
-	return uint16(0), nil
-}
-
 // SetMinHops implements API
 func (mc *mockRPCClient) SetMinHops(n uint16) error {
 	return nil

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -174,6 +174,15 @@ func (v1 *V1) UpdateAppArg(launch *launcher.Launcher, appName, argName string, v
 	return v1.flush(v1)
 }
 
+// UpdateMinHops updates min_hops config
+func (v1 *V1) UpdateMinHops(hops uint16) error {
+	v1.mu.Lock()
+	v1.Routing.MinHops = hops
+	v1.mu.Unlock()
+
+	return v1.flush(v1)
+}
+
 // updateStringArg updates the cli non-boolean flag of the specified app config and also within the launcher.
 // It removes argName from app args if value is an empty string.
 // The updated config gets flushed to file if there are any changes.


### PR DESCRIPTION
Did you run `make format && make check`? yes

Fixes #770 

Related to:
- #729 

 Changes:	
- Added `min_hops` endpoint to the http API and rpc one (@jdknives @Senyoret1 not sure about the latter, since there's `route-finder`)

How to test this PR:
- run it in the integration test (using v111 config)
- do an http call to the `/visors/{pk}/min-hops` endpoint (`POST` and `GET`) like:
```bash
$ curl -k https://localhost:8000/api/visors/${PK}/min-hops
$ curl -k -d '{"min_hops": 1}' -H "Content-Type: application/json" -X POST  https://localhost:8000/api/visors/${PK}/min-hops
```
- or do an rpc call via `skywire-cli visor route get-min-hops` and `skywire-cli visor route set-min-hops <some_number>` 