### PR TITLE
Update golangci to use revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,7 +151,7 @@ linters-settings:
 
 linters:
   enable:
-    - golint
+    - revive
     - goimports
     - varcheck
     - unparam

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -235,11 +235,7 @@ func (c *Client) AddDirectRoute(ip net.IP) error {
 	}
 	defer c.releaseSysPrivileges()
 
-	if err := c.setupDirectRoute(ip); err != nil {
-		return err
-	}
-
-	return nil
+	return c.setupDirectRoute(ip)
 }
 
 // RemoveDirectRoute removes direct route. Packets destined to `ip` will

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -428,11 +428,7 @@ func (rg *RouteGroup) sendNetworkProbe() error {
 
 	packet := routing.MakeNetworkProbePacket(rule.NextRouteID(), timestamp, throughput)
 
-	if err := rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID()); err != nil {
-		return err
-	}
-
-	return nil
+	return rg.writePacket(context.Background(), tp, packet, rule.KeyRouteID())
 }
 
 func (rg *RouteGroup) networkProbeServiceFn(_ time.Duration) {

--- a/pkg/setup/setupclient/client.go
+++ b/pkg/setup/setupclient/client.go
@@ -69,11 +69,7 @@ func (c *Client) Close() error {
 		return err
 	}
 
-	if err := c.conn.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.conn.Close()
 }
 
 // DialRouteGroup generates rules for routes from a visor and sends them to visors.

--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -230,11 +230,7 @@ func (c *client) acceptConn() error {
 		return err
 	}
 
-	if err := lis.Introduce(wrappedConn); err != nil {
-		return err
-	}
-
-	return nil
+	return lis.Introduce(wrappedConn)
 }
 
 // Dial dials a new Conn to specified remote public key and port.

--- a/pkg/util/pathutil/util.go
+++ b/pkg/util/pathutil/util.go
@@ -45,11 +45,7 @@ func AtomicWriteFile(filename string, data []byte) error {
 		return err
 	}
 
-	if err := rename.Rename(tempFilePath, filename); err != nil {
-		return err
-	}
-
-	return nil
+	return rename.Rename(tempFilePath, filename)
 }
 
 // AtomicAppendToFile calls AtomicWriteFile but appends new data to destiny file


### PR DESCRIPTION
Did you run `make format && make check`? yes

https://github.com/golangci/golangci-lint/pull/1965

 Changes:	
- use revive instead of golint

How to test this PR:
