### PR TITLE
[WIP] Improvements for the VPN client

### DIFF
--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/vpn-server-list.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/vpn-server-list.component.html
@@ -145,6 +145,8 @@
               <mat-icon *ngIf="dataSorter.currentSortingColumn === pkSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
             </div>
           </th>
+          <!--
+          // TODO: these columns are for data not yet available in the discovery service. should be reactivated or removed later.
           <th *ngIf="currentList === lists.Public" class="sortable-column short-column center click-effect" (click)="dataSorter.changeSortingOrder(congestionSortData)" [matTooltip]="'vpn.server-list.congestion-info' | translate">
             <div class="header-container">
               <mat-icon [inline]="true">person</mat-icon>
@@ -185,6 +187,7 @@
               <mat-icon *ngIf="dataSorter.currentSortingColumn === hopsSortData" [inline]="true">{{ dataSorter.sortingArrow }}</mat-icon>
             </div>
           </th>
+          -->
           <th class="sortable-column note-column center click-effect" (click)="dataSorter.changeSortingOrder(noteSortData)" [matTooltip]="'vpn.server-list.note-info' | translate">
             <div class="header-container">
               <mat-icon [inline]="true">info_outline</mat-icon>
@@ -231,9 +234,15 @@
               {{ 'vpn.server-list.unknown' | translate }}
             </ng-container>
           </td>
+          <!--
+          // TODO: this should be used, instead of the currently active version, if the extra columns are reactivated.
           <td class="pk-column" [ngClass]="{'public-pk-column': currentList === lists.Public, 'history-pk-column': currentList === lists.History}">
+          -->
+          <td class="pk-column history-pk-column">
             <app-copy-to-clipboard-text (click)="$event.stopPropagation()" class="d-inline-block w-100" [shortSimple]="true" [text]="server.pk"></app-copy-to-clipboard-text>
           </td>
+          <!--
+          // TODO: these columns are for data not yet available in the discovery service. should be reactivated or removed later.
           <td *ngIf="currentList === lists.Public" [class]="getCongestionTextColorClass(server.congestion) + ' center short-column'">
             {{ server.congestion }}%
           </td>
@@ -257,6 +266,7 @@
           <td *ngIf="currentList === lists.Public" [class]="getHopsTextColorClass(server.hops) + ' center mini-column'">
             {{ server.hops }}
           </td>
+          -->
           <td class="center note-column">
             <mat-icon
               *ngIf="server.note || server.personalNote"
@@ -285,7 +295,7 @@
       *ngIf="numberOfPages > 1"
       [currentPage]="currentPage"
       [numberOfPages]="numberOfPages"
-      [linkParts]="['/vpn']"
+      [linkParts]="['/vpn', currentLocalPk, 'servers', currentList]"
       [queryParams]="dataFilterer.currentUrlQueryParams">
     </app-paginator>
 

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/vpn-server-list.component.scss
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/vpn-server-list.component.scss
@@ -140,7 +140,8 @@ tr {
 .history-pk-column {
   width: 20% !important;
 }
-
+/*
+// TODO: for currently commented columns, must be deleted or reactivated depending on what happens to the columns.
 .public-pk-column {
   width: 12% !important;
 }
@@ -158,7 +159,7 @@ tr {
   min-width: 60px;
   @extend .single-line;
 }
-
+*/
 .icon-fixer {
   line-height: 0px;
 }
@@ -193,7 +194,8 @@ tr {
     @extend .single-line;
     flex-grow: 1;
   }
-
+  /*
+  // TODO: for currently commented columns, must be deleted or reactivated depending on what happens to the columns.
   .star-container {
     height: 0px;
     position: relative;
@@ -203,6 +205,7 @@ tr {
       font-size: 10px;
     }
   }
+  */
 }
 
 .flag {
@@ -220,15 +223,16 @@ tr {
   }
 }
 
+.center {
+  text-align: center;
+}
+/*
+// TODO: for currently commented columns, must be deleted or reactivated depending on what happens to the columns.
 .rating {
   width: 14px;
   height: 14px;
   display: inline-block;
   background-size: contain;
-}
-
-.center {
-  text-align: center;
 }
 
 .green-value {
@@ -242,7 +246,7 @@ tr {
 .red-value {
   color: $red-clear !important;
 }
-
+*/
 .alert-icon {
   vertical-align: middle;
   margin-right: 10px;

--- a/static/skywire-manager-src/src/app/services/vpn-client-discovery.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client-discovery.service.ts
@@ -5,12 +5,17 @@ import { retryWhen, delay, map } from 'rxjs/operators';
 
 /**
  * Ratings some properties of a server can have.
+ *
+ * TODO: used only for columns that are currently deactivated in the server list. Must
+ * be deleted or reactivated depending on what happens to the columns.
  */
+/*
 export enum Ratings {
   Gold = 0,
   Silver = 1,
   Bronze = 2,
 }
+*/
 
 /**
  * Data of a server obtained from the discovery service.
@@ -32,26 +37,32 @@ export class VpnServer {
    * Public key.
    */
   pk: string;
+
+
+  // TODO: used only for columns that are currently deactivated in the server list. Must
+  // be deleted or reactivated depending on what happens to the columns.
   /**
    * Current congestion of the server.
    */
-  congestion: number;
+   // congestion: number;
   /**
    * Rating of the congestion the server normally has.
    */
-  congestionRating: Ratings;
+  // congestionRating: Ratings;
   /**
    * Latency of the server.
    */
-  latency: number;
+  // latency: number;
   /**
    * Rating of the latency the server normally has.
    */
-  latencyRating: Ratings;
+  // latencyRating: Ratings;
   /**
    * Hops needed for reaching the server.
    */
-  hops: number;
+  // hops: number;
+
+
   /**
    * Note the server has in the discovery service.
    */
@@ -119,13 +130,18 @@ export class VpnClientDiscoveryService {
               }
             }
 
-            // Data that must be obtained after the changes in the service.
             currentEntry.name = addressParts[0];
+            /*
+            // TODO: used only for columns that are currently deactivated in the server list. Must
+            // be deleted or reactivated depending on what happens to the columns.
             currentEntry.congestion = 20;
             currentEntry.congestionRating = Ratings.Gold;
             currentEntry.latency = 123;
             currentEntry.latencyRating = Ratings.Gold;
             currentEntry.hops = 3;
+            */
+
+            // TODO: still not added to the discovery service.
             currentEntry.note = '';
 
             response.push(currentEntry);

--- a/static/skywire-manager-src/src/app/services/vpn-client.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client.service.ts
@@ -712,8 +712,8 @@ export class VpnClientService {
               vpnClientData.serverPk = appData.args[i + 1];
             }
 
-            if (appData.args[i] === '-killswitch' && i + 1 < appData.args.length) {
-              vpnClientData.killswitch = (appData.args[i + 1] as string).toLowerCase() === 'true';
+            if (appData.args[i].toLowerCase().includes('-killswitch')) {
+              vpnClientData.killswitch = (appData.args[i] as string).toLowerCase().includes('true');
             }
           }
         }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the sevcer list is populated with data obtained from the discovery service. All columns not returned by the discovery service were removed from the UI. The code related to the removed columns and not longer used was not removed, but commented, just in case it is needed in the future.

- A bug which made the paginator of the server list page work incorrectly was solved.

- Now the countries are sorted by country name, not by country code. The previous method had problems with some countries and the list appeared to be wrongly sorted.

- Now the correct value of the `killswitch` property is shown. Related to https://github.com/skycoin/skywire/pull/720

How to test this PR:
For checking the server list, use a web browser to open `{SkywireManagerUrl}/#/vpn/{visorPk}/servers/public/1`. That will show the list with the servers obtained from the discovery service. Use the paginator at the bottom of the page and check if it works well. Also, pressing the flag icon at the top of the country column should order the server by country name.

For checking the value of the `killswitch` property, go to the settings tab.
