### PR TITLE
Change file perm

### DIFF
--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -301,7 +301,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0750); err != nil {
+	if err := os.MkdirAll(*path, 0707); err != nil {
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -115,7 +115,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(dir string) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0707); err != nil {
 		return nil, err
 	}
 	return &fileTransportLogStore{dir}, nil


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #	

 Changes:	
- Changed file perm of `local` folder from `0750` to `0707`
- Changed file perm of `transport_logs` folder from `0700` to `0707`

How to test this PR:
1. Run `sudo rm -rf transport_logs/; sudo rm -rf local/`
2. Run `make build; make install`
3. Run `sudo ./skywire-visor skywire-config`
4. Press Ctrl+C
5. Run `go mod vendor`
6. Should not get `permission denied` error for `local` and `transport_logs`
