### PR TITLE
Update service discovery update interval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/shirou/gopsutil v2.20.5+incompatible
 	github.com/sirupsen/logrus v1.8.1
-	github.com/skycoin/dmsg v0.0.0-20210603142231-3cba29fefe94
+	github.com/skycoin/dmsg v0.0.0-20210607131549-0c02e58ac5ee
 	github.com/skycoin/skycoin v0.27.1
 	github.com/skycoin/yamux v0.0.0-20200803175205-571ceb89da9f
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skycoin/dmsg v0.0.0-20210603142231-3cba29fefe94 h1:pEXB812hRagn23n/SJQkFE/Pj0CJ1L5bA3qWSbUyC9M=
 github.com/skycoin/dmsg v0.0.0-20210603142231-3cba29fefe94/go.mod h1:kd73tig/WUzBvcRmR7UwPi1JprzDDBUcSSBmF7RTJjo=
+github.com/skycoin/dmsg v0.0.0-20210607131549-0c02e58ac5ee h1:amNDcQH4yce7nqs+P8RptKWhloC5q2upsQOk4YTXOKs=
+github.com/skycoin/dmsg v0.0.0-20210607131549-0c02e58ac5ee/go.mod h1:kd73tig/WUzBvcRmR7UwPi1JprzDDBUcSSBmF7RTJjo=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.26.0/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -92,7 +92,7 @@ const (
 // Default skywire app server and discovery constants
 const (
 	DefaultAppSrvAddr     = "localhost:5505"
-	AppDiscUpdateInterval = 30 * time.Second
+	AppDiscUpdateInterval = time.Minute
 	DefaultAppLocalPath   = DefaultSkywirePath + "/local"
 	DefaultAppBinPath     = DefaultSkywirePath + "/apps"
 	DefaultLogLevel       = "info"

--- a/vendor/github.com/skycoin/dmsg/const.go
+++ b/vendor/github.com/skycoin/dmsg/const.go
@@ -8,7 +8,7 @@ const (
 
 	DefaultMinSessions = 1
 
-	DefaultUpdateInterval = time.Second * 15
+	DefaultUpdateInterval = time.Minute
 
 	DefaultMaxSessions = 100
 )

--- a/vendor/github.com/skycoin/dmsg/disc/client.go
+++ b/vendor/github.com/skycoin/dmsg/disc/client.go
@@ -57,8 +57,6 @@ func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry
 		return nil, err
 	}
 
-	addKeepAlive(req)
-
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
@@ -106,7 +104,6 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 		return err
 	}
 
-	addKeepAlive(req)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Since v0.3.0 visors send ?timeout=true, before v0.3.0 do not.
@@ -190,7 +187,7 @@ func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	addKeepAlive(req)
+
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
@@ -222,8 +219,4 @@ func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 	}
 
 	return entries, nil
-}
-
-func addKeepAlive(req *http.Request) {
-	req.Header.Add("Connection", "keep-alive")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,7 +125,7 @@ github.com/shirou/gopsutil/process
 ## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v0.0.0-20210603142231-3cba29fefe94
+# github.com/skycoin/dmsg v0.0.0-20210607131549-0c02e58ac5ee
 ## explicit
 github.com/skycoin/dmsg
 github.com/skycoin/dmsg/buildinfo


### PR DESCRIPTION
Did you run `make format && make check`?
yes
Fixes [#417](https://github.com/SkycoinPro/skywire-services/issues/417)	

 Changes:	
- Updated `Service Discovery` interval from 30 s to 60 s.

How to test this PR:
1. Change `log_level` to `debug` in visor config.
2. Run `./skywire-cli visor gen-config -r`
3. Run `./skywire-visor skywire-config`
4. Check if `app_discovery` updates it's entries every 60 seconds or not.

The heartbeat rate of the `uptime-tracker` is already 60 seconds.