### PR TITLE
Fix nil pointer panic in transport setup

### DIFF
--- a/pkg/transport/setup/visor.go
+++ b/pkg/transport/setup/visor.go
@@ -63,6 +63,7 @@ func (ts *TransportListener) Serve(ctx context.Context) {
 		conn, err := lis.AcceptStream()
 		if err != nil {
 			ts.log.WithError(err).Error("failed to accept")
+			break
 		}
 		remotePK := conn.RawRemoteAddr().PK
 		found := false


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #788

 Changes:	
- Fix panic when shutting down

How to test this PR:
Run visor and hit ctrl+c. This might only reproduce when running a vpn server or under certain load/environment (see issue).