### PR TITLE
Fix data race in hypervisor

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -118,7 +118,9 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 	}
 
 	// setup
+	hv.mu.Lock()
 	hv.selfConn.PtyUI = setupDmsgPtyUI(hv.dmsgC, hv.c.PK)
+	hv.mu.Unlock()
 
 	for {
 		conn, err := lis.AcceptStream()
@@ -1377,9 +1379,12 @@ func (hv *Hypervisor) visorCtx(w http.ResponseWriter, r *http.Request) (*httpCtx
 			Conn: v,
 		}, true
 	}
+	hv.mu.Lock()
+	conn := hv.selfConn
+	hv.mu.Unlock()
 
 	return &httpCtx{
-		Conn: hv.selfConn,
+		Conn: conn,
 	}, true
 }
 


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #803 

 Changes:	
- Added lock to `hv.selfConn` usage

How to test this PR:
1. Run `go build -race -o ./skywire-visor ./cmd/skywire-visor`
2. Run `sudo ./skywire-visor skywire-config.json`
3. Open UI in browser `http://localhost:8000/`
4. Go to visor details
5. No error should be seen