### PR TITLE
Change perm of pid and logstore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,6 @@ BUILD_OPTS_DEPLOY?="-ldflags=$(BUILDINFO) -w -s"
 
 check: lint test ## Run linters and tests
 
-move-built-frontend:
-	rm -rf ${MANAGER_UI_BUILT_DIR}
-	mkdir ${MANAGER_UI_BUILT_DIR}
-	cp -r ${MANAGER_UI_DIR}/dist/. ${MANAGER_UI_BUILT_DIR}
-
 build: host-apps bin ## Install dependencies, build apps and binaries. `go build` with ${OPTS}
 
 build-static: host-apps-static bin-static ## Build apps and binaries. `go build` with ${OPTS}
@@ -145,13 +140,18 @@ github-release: ## Create a GitHub release
 install-deps-ui:  ## Install the UI dependencies
 	cd $(MANAGER_UI_DIR) && npm ci
 
+run: ## Run skywire visor with skywire-config.json, and start a browser if running a hypervisor
+	./skywire-visor -c ./skywire-config.json
+
 lint-ui:  ## Lint the UI code
 	cd $(MANAGER_UI_DIR) && npm run lint
 
 build-ui: install-deps-ui  ## Builds the UI
 	cd $(MANAGER_UI_DIR) && npm run build
 	mkdir -p ${PWD}/bin
-	make move-built-frontend
+	rm -rf ${MANAGER_UI_BUILT_DIR}
+	mkdir ${MANAGER_UI_BUILT_DIR}
+	cp -r ${MANAGER_UI_DIR}/dist/. ${MANAGER_UI_BUILT_DIR}
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/pkg/app/appcommon/log_store.go
+++ b/pkg/app/appcommon/log_store.go
@@ -65,7 +65,7 @@ type bBoltLogStore struct {
 
 // NewBBoltLogStore returns a bbolt implementation of an app log store.
 func NewBBoltLogStore(path, appName string) (_ LogStore, err error) {
-	db, err := bbolt.Open(path, 0600, nil)
+	db, err := bbolt.Open(path, 0606, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -312,7 +312,7 @@ func ensureDir(path *string) error {
 */
 
 func (l *Launcher) pidFile() (*os.File, error) {
-	return os.OpenFile(filepath.Join(l.conf.LocalPath, appsPIDFileName), os.O_RDWR|os.O_CREATE, 0600)
+	return os.OpenFile(filepath.Join(l.conf.LocalPath, appsPIDFileName), os.O_RDWR|os.O_CREATE, 0606) //nolint:gosec
 }
 
 func (l *Launcher) persistPID(appName string, pid appcommon.ProcID) error {

--- a/pkg/util/pathutil/util.go
+++ b/pkg/util/pathutil/util.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	tmpSuffix      = ".tmp"
-	ownerRW        = 0600
+	ownerRW        = 0606
 	userRWXGroupRX = 0750
 )
 

--- a/pkg/util/pathutil/util.go
+++ b/pkg/util/pathutil/util.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	tmpSuffix      = ".tmp"
-	ownerRW        = 0606
+	ownerRWOtherRW = 0606
 	userRWXGroupRX = 0750
 )
 
@@ -41,7 +41,7 @@ func AtomicWriteFile(filename string, data []byte) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(tempFilePath, data, ownerRW); err != nil {
+	if err := ioutil.WriteFile(tempFilePath, data, ownerRWOtherRW); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #808 

 Changes:	
- Changed `ownerRW` to `ownerRWOtherRW`
- Changed file perm of `pidFile`, `ownerRWOtherRW` and `NewBBoltLogStore`  from `600` to `606`
- Added `make run`
- Combined `make move-built-frontend` and `make build-ui` into `make build-ui`.

How to test this PR:
1. Delete local folder `sudo rm -rf local/`
2. Run visor `sudo ./skywire-visor skywire-config.json`
3. Ctrl+C
4. Run `./ci_scripts/docker-push.sh -t $(git rev-parse --abbrev HEAD) -b`
5. No file permission error should be observed