### PR TITLE
Fix stcpr transport establishment issues

### DIFF
--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/snet/directtp/tphandshake"
 	"github.com/skycoin/skywire/pkg/snet/directtp/tplistener"
 	"github.com/skycoin/skywire/pkg/snet/directtp/tptypes"
+	"github.com/skycoin/skywire/pkg/util/netutil"
 )
 
 const (
@@ -136,7 +137,14 @@ func (c *client) Serve() error {
 				c.log.Errorf("Failed to extract port from addr %v: %v", err)
 				return
 			}
-
+			hasPublic, err := netutil.HasPublicIP()
+			if err != nil {
+				c.log.Errorf("Failed to check for public IP: %v", err)
+			}
+			if !hasPublic {
+				c.log.Infof("Not binding STCPR: no public IP address found")
+				return
+			}
 			if err := c.conf.AddressResolver.BindSTCPR(context.Background(), port); err != nil {
 				c.log.Errorf("Failed to bind STCPR: %v", err)
 				return

--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -60,13 +60,6 @@ func MakeEntry(initiator, target cipher.PubKey, tpType string, public bool, labe
 	return entry
 }
 
-// SetEdges sets edges of Entry
-func (e *Entry) SetEdges(initiator, target cipher.PubKey) {
-	e.ID = MakeTransportID(initiator, target, e.Type)
-	e.Edges[0] = initiator
-	e.Edges[1] = target
-}
-
 // RemoteEdge returns the remote edge's public key.
 func (e *Entry) RemoteEdge(local cipher.PubKey) cipher.PubKey {
 	for _, pk := range e.Edges {

--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -33,7 +33,8 @@ type Entry struct {
 	// ID is the Transport ID that uniquely identifies the Transport.
 	ID uuid.UUID `json:"t_id"`
 
-	// Edges contains the public keys of the Transport's edge nodes (should only have 2 edges and the least-significant edge should come first).
+	// Edges contains the public keys of the Transport's edge nodes
+	// (should only have 2 edges and the first edge is transport original initiator).
 	Edges [2]cipher.PubKey `json:"edges"`
 
 	// Type represents the transport type.
@@ -47,20 +48,23 @@ type Entry struct {
 }
 
 // MakeEntry creates a new transport entry
-func MakeEntry(pk1, pk2 cipher.PubKey, tpType string, public bool, label Label) Entry {
-	return Entry{
-		ID:     MakeTransportID(pk1, pk2, tpType),
-		Edges:  SortEdges(pk1, pk2),
+func MakeEntry(initiator, target cipher.PubKey, tpType string, public bool, label Label) Entry {
+	entry := Entry{
+		ID:     MakeTransportID(initiator, target, tpType),
 		Type:   tpType,
 		Public: public,
 		Label:  label,
 	}
+	entry.Edges[0] = initiator
+	entry.Edges[1] = target
+	return entry
 }
 
 // SetEdges sets edges of Entry
-func (e *Entry) SetEdges(localPK, remotePK cipher.PubKey) {
-	e.ID = MakeTransportID(localPK, remotePK, e.Type)
-	e.Edges = SortEdges(localPK, remotePK)
+func (e *Entry) SetEdges(initiator, target cipher.PubKey) {
+	e.ID = MakeTransportID(initiator, target, e.Type)
+	e.Edges[0] = initiator
+	e.Edges[1] = target
 }
 
 // RemoteEdge returns the remote edge's public key.
@@ -106,8 +110,8 @@ func (e *Entry) String() string {
 	res += fmt.Sprintf("\ttype: %s\n", e.Type)
 	res += fmt.Sprintf("\tid: %s\n", e.ID)
 	res += "\tedges:\n"
-	res += fmt.Sprintf("\t\tedge 1: %s\n", e.Edges[0])
-	res += fmt.Sprintf("\t\tedge 2: %s\n", e.Edges[1])
+	res += fmt.Sprintf("\t\tedge 1 (initiator): %s\n", e.Edges[0])
+	res += fmt.Sprintf("\t\tedge 2 (target): %s\n", e.Edges[1])
 	return res
 }
 

--- a/pkg/transport/entry_test.go
+++ b/pkg/transport/entry_test.go
@@ -23,21 +23,6 @@ func TestNewEntry(t *testing.T) {
 	assert.NotNil(t, entryBA.ID)
 }
 
-func TestEntry_SetEdges(t *testing.T) {
-	pkA, _ := cipher.GenerateKeyPair()
-	pkB, _ := cipher.GenerateKeyPair()
-
-	entryAB, entryBA := transport.Entry{}, transport.Entry{}
-
-	entryAB.SetEdges(pkA, pkB)
-	entryBA.SetEdges(pkA, pkB)
-
-	assert.True(t, entryAB.Edges == entryBA.Edges)
-	assert.True(t, entryAB.ID == entryBA.ID)
-	assert.NotNil(t, entryAB.ID)
-	assert.NotNil(t, entryBA.ID)
-}
-
 func ExampleSignedEntry_Sign() {
 	pkA, skA := cipher.GenerateKeyPair()
 	pkB, skB := cipher.GenerateKeyPair()

--- a/pkg/transport/handshake.go
+++ b/pkg/transport/handshake.go
@@ -144,12 +144,12 @@ func MakeSettlementHS(init bool) SettlementHS {
 		// receive, verify and sign entry.
 		recvSE, err := receiveAndVerifyEntry(conn, &entry, conn.RemotePK())
 		if err != nil {
-			writeHsResponse(conn, responseInvalidEntry)
+			writeHsResponse(conn, responseInvalidEntry) //nolint:errcheck, gosec
 			return err
 		}
 
 		if err := recvSE.Sign(conn.LocalPK(), sk); err != nil {
-			writeHsResponse(conn, responseSignatureErr)
+			writeHsResponse(conn, responseSignatureErr) //nolint:errcheck, gosec
 			return fmt.Errorf("failed to sign received entry: %w", err)
 		}
 

--- a/pkg/transport/handshake.go
+++ b/pkg/transport/handshake.go
@@ -17,8 +17,8 @@ import (
 type hsResponse byte
 
 const (
-	responseOK hsResponse = iota
-	responseFailure
+	responseFailure hsResponse = iota
+	responseOK
 	responseSignatureErr
 	responseInvalidEntry
 )

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -205,8 +205,8 @@ func (mt *ManagedTransport) Serve(readCh chan<- routing.Packet) {
 				continue
 			}
 
-			// Only least significant edge is responsible for redialing.
-			if !mt.isLeastSignificantEdge() {
+			// Only initiator is responsible for redialing.
+			if !mt.isInitiator() {
 				continue
 			}
 
@@ -384,6 +384,11 @@ func (mt *ManagedTransport) redialLoop(ctx context.Context) error {
 }
 
 func (mt *ManagedTransport) isLeastSignificantEdge() bool {
+	sorted := SortEdges(mt.Entry.Edges[0], mt.Entry.Edges[1])
+	return sorted[0] == mt.n.LocalPK()
+}
+
+func (mt *ManagedTransport) isInitiator() bool {
 	return mt.Entry.EdgeIndex(mt.n.LocalPK()) == 0
 }
 

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -93,7 +93,11 @@ type ManagedTransport struct {
 }
 
 // NewManagedTransport creates a new ManagedTransport.
-func NewManagedTransport(conf ManagedTransportConfig) *ManagedTransport {
+func NewManagedTransport(conf ManagedTransportConfig, isInitiator bool) *ManagedTransport {
+	initiator, target := conf.Net.LocalPK(), conf.RemotePK
+	if !isInitiator {
+		initiator, target = target, initiator
+	}
 	mt := &ManagedTransport{
 		log:         logging.MustGetLogger(fmt.Sprintf("tp:%s", conf.RemotePK.String()[:6])),
 		rPK:         conf.RemotePK,
@@ -101,7 +105,7 @@ func NewManagedTransport(conf ManagedTransportConfig) *ManagedTransport {
 		n:           conf.Net,
 		dc:          conf.DC,
 		ls:          conf.LS,
-		Entry:       MakeEntry(conf.Net.LocalPK(), conf.RemotePK, conf.NetName, true, conf.TransportLabel),
+		Entry:       MakeEntry(initiator, target, conf.NetName, true, conf.TransportLabel),
 		LogEntry:    new(LogEntry),
 		connCh:      make(chan struct{}, 1),
 		done:        make(chan struct{}),

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -40,7 +40,7 @@ const (
 	tpMaxBO   = time.Minute
 	tpTries   = 0
 	tpFactor  = 2
-	tpTimeout = time.Second * 3 // timeout for a sigle try
+	tpTimeout = time.Second * 3 // timeout for a single try
 )
 
 // ManagedTransportConfig is a configuration for managed transport.

--- a/pkg/transport/tpdclient/client_test.go
+++ b/pkg/transport/tpdclient/client_test.go
@@ -45,7 +45,8 @@ func newTestEntry() *transport.Entry {
 		Type:   "dmsg",
 		Public: true,
 	}
-	entry.SetEdges(pk1, testPubKey)
+	entry.Edges[0] = pk1
+	entry.Edges[1] = testPubKey
 
 	return entry
 }

--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -103,3 +103,18 @@ func DefaultNetworkInterfaceIPs() ([]net.IP, error) {
 	}
 	return localIPs, nil
 }
+
+// HasPublicIP returns true if this machine has at least one
+// publically available IP address
+func HasPublicIP() (bool, error) {
+	localIPs, err := LocalNetworkInterfaceIPs()
+	if err != nil {
+		return false, err
+	}
+	for _, IP := range localIPs {
+		if IsPublicIP(IP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #806

 Changes:	
- stcp and stcpr single redial try now has a timeout of 3 seconds
- changed transport entry structure: first key is original connection initiator
- connection initiator is now responsible for redialing
- added error responses to transport handshake
- prevent visors that do not have public IP to perform stcpr bind operation

How to test this PR:
Run two visors v1 and v2. v1 should have public IP, v2 shouldn't. Public Key of v1 should be less than Public Key of v2. 
Set up an stcpr transport from v2 to v1 manually, then stop v2. Restart v2, remove transport and establish it again. Transport should be added in UP state.
Stop v2 again. Start it again, transport should automatically switch to UP state on both ends.