### PR TITLE
backport release config changes

### DIFF
--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -12,14 +12,24 @@ const (
 	PackageSkywirePath = "/opt/skywire"
 )
 
-// Constants for default services.
+// Constants for old default services.
 const (
-	DefaultTpDiscAddr          = "http://transport.discovery.skywire.skycoin.com"
-	DefaultDmsgDiscAddr        = "http://dmsg.discovery.skywire.skycoin.com"
-	DefaultServiceDiscAddr     = "http://service.discovery.skycoin.com"
-	DefaultRouteFinderAddr     = "http://routefinder.skywire.skycoin.com"
-	DefaultUptimeTrackerAddr   = "http://uptime-tracker.skywire.skycoin.com"
-	DefaultAddressResolverAddr = "http://address.resolver.skywire.skycoin.com"
+	OldDefaultTpDiscAddr          = "http://transport.discovery.skywire.skycoin.com"
+	OldDefaultDmsgDiscAddr        = "http://dmsg.discovery.skywire.skycoin.com"
+	OldDefaultServiceDiscAddr     = "http://service.discovery.skycoin.com"
+	OldDefaultRouteFinderAddr     = "http://routefinder.skywire.skycoin.com"
+	OldDefaultUptimeTrackerAddr   = "http://uptime-tracker.skywire.skycoin.com"
+	OldDefaultAddressResolverAddr = "http://address.resolver.skywire.skycoin.com"
+)
+
+// Constants for new default services.
+const (
+	DefaultTpDiscAddr          = "http://tpd.skywire.skycoin.com"
+	DefaultDmsgDiscAddr        = "http://dmsgd.skywire.skycoin.com"
+	DefaultServiceDiscAddr     = "http://sd.skycoin.com"
+	DefaultRouteFinderAddr     = "http://rf.skywire.skycoin.com"
+	DefaultUptimeTrackerAddr   = "http://ut.skywire.skycoin.com"
+	DefaultAddressResolverAddr = "http://ar.skywire.skycoin.com"
 	DefaultSetupPK             = "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
 )
 

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -32,10 +32,15 @@ func MakeBaseConfig(common *Common) *V1 {
 		RouteFinderTimeout: DefaultTimeout,
 	}
 	conf.Launcher = &V1Launcher{
-		Discovery:  nil,
+		Discovery: &V1AppDisc{
+			ServiceDisc: skyenv.DefaultServiceDiscAddr,
+		},
 		Apps:       nil,
 		ServerAddr: skyenv.DefaultAppSrvAddr,
 		BinPath:    skyenv.DefaultAppBinPath,
+	}
+	conf.UptimeTracker = &V1UptimeTracker{
+		Addr: skyenv.DefaultUptimeTrackerAddr,
 	}
 	conf.CLIAddr = skyenv.DefaultRPCAddr
 	conf.LogLevel = skyenv.DefaultLogLevel

--- a/pkg/visor/visorconfig/parse.go
+++ b/pkg/visor/visorconfig/parse.go
@@ -37,6 +37,8 @@ func Parse(log *logging.MasterLogger, path string, raw []byte) (*V1, error) {
 	// parse any v1-compatible version with v1 parse procedure
 	case V110Name:
 		fallthrough
+	case V101Name:
+		return parseV1(cc, raw)
 	case V100Name:
 		return parseV1(cc, raw)
 	case V0Name, V0NameOldFormat, "":
@@ -56,6 +58,7 @@ func parseV1(cc *Common, raw []byte) (*V1, error) {
 	if err := conf.ensureKeys(); err != nil {
 		return nil, fmt.Errorf("%v: %w", ErrInvalidSK, err)
 	}
+	conf = updateUrls(conf)
 	conf.Version = V1Name
 	return conf, conf.flush(conf)
 }
@@ -154,4 +157,25 @@ func parseV0(cc *Common, raw []byte) (*V1, error) {
 	conf.RestartCheckDelay = old.RestartCheckDelay
 
 	return conf, conf.flush(conf)
+}
+func updateUrls(conf *V1) *V1 {
+	if conf.Dmsg.Discovery == skyenv.OldDefaultDmsgDiscAddr {
+		conf.Dmsg.Discovery = skyenv.DefaultDmsgDiscAddr
+	}
+	if conf.Transport.Discovery == skyenv.OldDefaultTpDiscAddr {
+		conf.Transport.Discovery = skyenv.DefaultTpDiscAddr
+	}
+	if conf.Transport.AddressResolver == skyenv.OldDefaultAddressResolverAddr {
+		conf.Transport.AddressResolver = skyenv.DefaultAddressResolverAddr
+	}
+	if conf.Routing.RouteFinder == skyenv.OldDefaultRouteFinderAddr {
+		conf.Routing.RouteFinder = skyenv.DefaultRouteFinderAddr
+	}
+	if conf.UptimeTracker.Addr == skyenv.OldDefaultUptimeTrackerAddr {
+		conf.UptimeTracker.Addr = skyenv.DefaultUptimeTrackerAddr
+	}
+	if conf.Launcher.Discovery.ServiceDisc == skyenv.OldDefaultServiceDiscAddr {
+		conf.Launcher.Discovery.ServiceDisc = skyenv.DefaultServiceDiscAddr
+	}
+	return conf
 }

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -17,7 +17,7 @@ import (
 // V100Name is the semantic version string for v1.0.0.
 const V100Name = "v1.0.0"
 
-// V100Name is the semantic version string for v1.0.1.
+// V101Name is the semantic version string for v1.0.1.
 const V101Name = "v1.0.1"
 
 // V110Name is the semantic version string for v1.1.0.

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -17,6 +17,9 @@ import (
 // V100Name is the semantic version string for v1.0.0.
 const V100Name = "v1.0.0"
 
+// V100Name is the semantic version string for v1.0.1.
+const V101Name = "v1.0.1"
+
 // V110Name is the semantic version string for v1.1.0.
 // Added MinHops field to V1Routing section of config
 // Removed public_trusted_visor field from root section
@@ -25,6 +28,7 @@ const V100Name = "v1.0.0"
 // Added public_autoconnect field to transport section
 // Added transport_setup_nodes field to transport section
 // Removed authorization_file field from dmsgpty section
+// Default urls are changed to newer shortned ones
 const V110Name = "v1.1.0"
 
 // V1Name is the semantic version string for the most recent version of V1.


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #	

 Changes:	
- Added config migration from `v1.0.1` to `v1.1.0`

How to test this PR:
1. Build a `v1.0.0` config from master branch
2. Switch to this PR and run the visor and check if the config is successfully migrated to `v1.1.0`
3. Build a `v1.0.1` config from release branch
4. Switch to this PR and run the visor and check if the config is successfully migrated to `v1.1.0`