### PR TITLE
Complete Visor Logs

### DIFF
--- a/pkg/snet/arclient/client.go
+++ b/pkg/snet/arclient/client.go
@@ -87,7 +87,7 @@ type httpClient struct {
 // * SW-Public: The specified public key.
 // * SW-Nonce:  The nonce for that public key.
 // * SW-Sig:    The signature of the payload + the nonce.
-func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey) (APIClient, error) {
+func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, log *logging.Logger) (APIClient, error) {
 	remoteURL, err := url.Parse(remoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("parse URL: %w", err)
@@ -99,7 +99,7 @@ func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey) (APIClient, 
 	}
 
 	client := &httpClient{
-		log:            logging.MustGetLogger("address-resolver"),
+		log:            log,
 		pk:             pk,
 		sk:             sk,
 		remoteHTTPAddr: remoteAddr,

--- a/pkg/snet/arclient/client_test.go
+++ b/pkg/snet/arclient/client_test.go
@@ -44,7 +44,7 @@ func TestClientAuth(t *testing.T) {
 
 	defer srv.Close()
 
-	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey)
+	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, &logging.Logger{})
 	require.NoError(t, err)
 
 	c := apiClient.(*httpClient)
@@ -73,7 +73,7 @@ func TestBind(t *testing.T) {
 
 	defer srv.Close()
 
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &logging.Logger{})
 	require.NoError(t, err)
 
 	err = c.BindSTCPR(context.TODO(), "1234")

--- a/pkg/snet/arclient/client_test.go
+++ b/pkg/snet/arclient/client_test.go
@@ -43,8 +43,8 @@ func TestClientAuth(t *testing.T) {
 	))
 
 	defer srv.Close()
-
-	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, &logging.Logger{})
+	log := logging.MustGetLogger("test_client_auth")
+	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, log)
 	require.NoError(t, err)
 
 	c := apiClient.(*httpClient)
@@ -72,8 +72,8 @@ func TestBind(t *testing.T) {
 	})))
 
 	defer srv.Close()
-
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &logging.Logger{})
+	log := logging.MustGetLogger("test_bind")
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, log)
 	require.NoError(t, err)
 
 	err = c.BindSTCPR(context.TODO(), "1234")

--- a/pkg/snet/directtp/client.go
+++ b/pkg/snet/directtp/client.go
@@ -95,10 +95,10 @@ type client struct {
 }
 
 // NewClient creates a net Client.
-func NewClient(conf Config) Client {
+func NewClient(conf Config, masterLogger *logging.MasterLogger) Client {
 	return &client{
 		conf:               conf,
-		log:                logging.MustGetLogger(conf.Type),
+		log:                masterLogger.PackageLogger(conf.Type),
 		porter:             porter.New(porter.MinEphemeral),
 		listeners:          make(map[uint16]*tplistener.Listener),
 		done:               make(chan struct{}),

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -99,7 +99,7 @@ type Network struct {
 }
 
 // New creates a network from a config.
-func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
+func New(conf Config, eb *appevent.Broadcaster, masterLogger *logging.MasterLogger) (*Network, error) {
 	clients := NetworkClients{
 		Direct: make(map[string]directtp.Client),
 	}
@@ -123,7 +123,7 @@ func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 			},
 		}
 		clients.DmsgC = dmsg.NewClient(conf.PubKey, conf.SecKey, disc.NewHTTP(conf.NetworkConfigs.Dmsg.Discovery), dmsgConf)
-		clients.DmsgC.SetLogger(logging.MustGetLogger("snet.dmsgC"))
+		clients.DmsgC.SetLogger(masterLogger.PackageLogger("snet.dmsgC"))
 	}
 
 	if conf.NetworkConfigs.STCP != nil {
@@ -140,7 +140,7 @@ func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 				return nil
 			},
 		}
-		clients.Direct[tptypes.STCP] = directtp.NewClient(conf)
+		clients.Direct[tptypes.STCP] = directtp.NewClient(conf, masterLogger)
 	}
 
 	if conf.ARClient != nil {
@@ -157,7 +157,7 @@ func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 			},
 		}
 
-		clients.Direct[tptypes.STCPR] = directtp.NewClient(stcprConf)
+		clients.Direct[tptypes.STCPR] = directtp.NewClient(stcprConf, masterLogger)
 
 		sudphConf := directtp.Config{
 			Type:            tptypes.SUDPH,
@@ -166,7 +166,7 @@ func New(conf Config, eb *appevent.Broadcaster) (*Network, error) {
 			AddressResolver: conf.ARClient,
 		}
 
-		clients.Direct[tptypes.SUDPH] = directtp.NewClient(sudphConf)
+		clients.Direct[tptypes.SUDPH] = directtp.NewClient(sudphConf, masterLogger)
 	}
 
 	return NewRaw(conf, clients), nil

--- a/pkg/snet/snettest/env.go
+++ b/pkg/snet/snettest/env.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/disc"
+	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/nettest"
@@ -115,7 +116,7 @@ func NewEnv(t *testing.T, keys []KeyPair, networks []string) *Env {
 				LocalAddr: networkConfigs.STCP.LocalAddr,
 			}
 
-			clients.Direct[tptypes.STCP] = directtp.NewClient(conf)
+			clients.Direct[tptypes.STCP] = directtp.NewClient(conf, logging.NewMasterLogger())
 		}
 
 		if hasStcpr {
@@ -126,7 +127,7 @@ func NewEnv(t *testing.T, keys []KeyPair, networks []string) *Env {
 				AddressResolver: addressResolver,
 			}
 
-			clients.Direct[tptypes.STCPR] = directtp.NewClient(conf)
+			clients.Direct[tptypes.STCPR] = directtp.NewClient(conf, logging.NewMasterLogger())
 		}
 
 		if hasSudph {
@@ -137,7 +138,7 @@ func NewEnv(t *testing.T, keys []KeyPair, networks []string) *Env {
 				AddressResolver: addressResolver,
 			}
 
-			clients.Direct[tptypes.SUDPH] = directtp.NewClient(conf)
+			clients.Direct[tptypes.SUDPH] = directtp.NewClient(conf, logging.NewMasterLogger())
 		}
 
 		snetConfig := snet.Config{

--- a/pkg/transport/setup/visor.go
+++ b/pkg/transport/setup/visor.go
@@ -23,8 +23,8 @@ type TransportListener struct {
 }
 
 // NewTransportListener makes a TransportListener from configuration
-func NewTransportListener(ctx context.Context, conf *visorconfig.V1, dmsgC *dmsg.Client, tm *transport.Manager) (*TransportListener, error) {
-	log := logging.MustGetLogger("transport_setup")
+func NewTransportListener(ctx context.Context, conf *visorconfig.V1, dmsgC *dmsg.Client, tm *transport.Manager, masterLogger *logging.MasterLogger) (*TransportListener, error) {
+	log := masterLogger.PackageLogger("transport_setup")
 	log.WithField("local_pk", conf.PK).Info("Connecting to the dmsg network.")
 
 	go dmsgC.Serve(ctx)

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -149,7 +149,7 @@ func initEventBroadcaster(ctx context.Context, v *Visor, log *logging.Logger) er
 func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) error {
 	conf := v.conf.Transport
 
-	arClient, err := arclient.NewHTTP(conf.AddressResolver, v.conf.PK, v.conf.SK)
+	arClient, err := arclient.NewHTTP(conf.AddressResolver, v.conf.PK, v.conf.SK, log)
 	if err != nil {
 		err := fmt.Errorf("failed to create address resolver client: %w", err)
 		return err
@@ -193,7 +193,7 @@ func initSNet(ctx context.Context, v *Visor, log *logging.Logger) error {
 		NetworkConfigs: nc,
 	}
 
-	n, err := snet.New(conf, v.ebc)
+	n, err := snet.New(conf, v.ebc, v.MasterLogger())
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 func initTransportSetup(ctx context.Context, v *Visor, log *logging.Logger) error {
 	ctx, cancel := context.WithCancel(ctx)
-	ts, err := ts.NewTransportListener(ctx, v.conf, v.net.Dmsg(), v.tpM)
+	ts, err := ts.NewTransportListener(ctx, v.conf, v.net.Dmsg(), v.tpM, v.MasterLogger())
 	if err != nil {
 		cancel()
 		return err


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #795 

 Changes:
- The visor logs API returns logs that stored in visor store, so we change inner loggers in some functions to visor loggers to store those logs.

How to test this PR:
