### PR TITLE
Bugfix/panic on shutdown

### DIFF
--- a/pkg/snet/arclient/client.go
+++ b/pkg/snet/arclient/client.go
@@ -432,9 +432,8 @@ func (c *httpClient) Close() error {
 		if err := c.sudphConn.Close(); err != nil {
 			c.log.WithError(err).Errorf("Failed to close SUDPH")
 		}
+		close(c.closed)
 	}
-
-	close(c.closed)
 
 	return nil
 }

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -274,16 +274,11 @@ func (n *Network) Close() error {
 		if directClient == nil {
 			continue
 		}
-		wg.Add(1)
-		go func(client directtp.Client) {
-			err := client.Close()
-			if err != nil {
-				directErrors <- err
-			}
-			wg.Done()
-		}(directClient)
+		err := directClient.Close()
+		if err != nil {
+			directErrors <- err
+		}
 	}
-	wg.Wait()
 	close(directErrors)
 
 	if dmsgErr != nil {

--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -280,7 +280,7 @@ func (n *Network) Close() error {
 		}
 	}
 	close(directErrors)
-
+	wg.Wait()
 	if dmsgErr != nil {
 		return dmsgErr
 	}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #828 

 Changes:	
- For closing `address_resolver` we pass all clients (STCP, STCPR, SUDPH), but because of the same `sudphConn` for those, the race condition happens sometimes and trying to close the closed channel and get panic. Because of the same `sudphConn`, the concurrent process to closing clients without race condition is impossible, so I change concurrently to a normal process (as a queue of clients).

How to test this PR:
