### PR TITLE
add Skybian build version to summary of visor API and debugging

### DIFF
--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -75,6 +75,7 @@ var rootCmd = &cobra.Command{
 		log.WithField("delay", delayDuration).
 			WithField("systemd", restartCtx.Systemd()).
 			WithField("parent_systemd", restartCtx.ParentSystemd()).
+			WithField("skybian_build_version", os.Getenv("SKYBIAN_BUILD_VERSION")).
 			Debugf("Process info")
 
 		// Versions v0.2.3 and below return 0 exit-code after update and do not trigger systemd to restart a process

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -133,14 +134,15 @@ func (v *Visor) Overview() (*Overview, error) {
 
 // Summary provides detailed info including overview and health of the visor.
 type Summary struct {
-	Overview     *Overview                      `json:"overview"`
-	Health       *HealthInfo                    `json:"health"`
-	Uptime       float64                        `json:"uptime"`
-	Routes       []routingRuleResp              `json:"routes"`
-	IsHypervisor bool                           `json:"is_hypervisor,omitempty"`
-	DmsgStats    *dmsgtracker.DmsgClientSummary `json:"dmsg_stats"`
-	Online       bool                           `json:"online"`
-	MinHops      uint16                         `json:"min_hops"`
+	Overview            *Overview                      `json:"overview"`
+	Health              *HealthInfo                    `json:"health"`
+	Uptime              float64                        `json:"uptime"`
+	Routes              []routingRuleResp              `json:"routes"`
+	IsHypervisor        bool                           `json:"is_hypervisor,omitempty"`
+	DmsgStats           *dmsgtracker.DmsgClientSummary `json:"dmsg_stats"`
+	Online              bool                           `json:"online"`
+	MinHops             uint16                         `json:"min_hops"`
+	SkybianBuildVersion string                         `json:"skybian_build_version"`
 }
 
 // Summary implements API.
@@ -165,6 +167,8 @@ func (v *Visor) Summary() (*Summary, error) {
 		return nil, fmt.Errorf("routes")
 	}
 
+	skybianBuildVersion := v.SkybianBuildVersion()
+
 	extraRoutes := make([]routingRuleResp, 0, len(routes))
 	for _, route := range routes {
 		extraRoutes = append(extraRoutes, routingRuleResp{
@@ -175,11 +179,12 @@ func (v *Visor) Summary() (*Summary, error) {
 	}
 
 	summary := &Summary{
-		Overview: overview,
-		Health:   health,
-		Uptime:   uptime,
-		Routes:   extraRoutes,
-		MinHops:  v.conf.Routing.MinHops,
+		Overview:            overview,
+		Health:              health,
+		Uptime:              uptime,
+		Routes:              extraRoutes,
+		MinHops:             v.conf.Routing.MinHops,
+		SkybianBuildVersion: skybianBuildVersion,
 	}
 
 	return summary, nil
@@ -272,6 +277,11 @@ func (v *Visor) Uptime() (float64, error) {
 // Apps implements API.
 func (v *Visor) Apps() ([]*launcher.AppState, error) {
 	return v.appL.AppStates(), nil
+}
+
+// SkybianBuildVersion implements API.
+func (v *Visor) SkybianBuildVersion() string {
+	return os.Getenv("SKYBIAN_BUILD_VERSION")
 }
 
 // StartApp implements API.


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes: Related to issue [99](https://github.com/skycoin/skybian/issues/99) in Skybian

 Changes:
- read from env variables and use in [process info](https://github.com/mrpalide/skywire/blob/3afefd726d462cf858647378e9b0f280529f3729/cmd/skywire-visor/commands/root.go#L78) at starting skywire-visor and its [summary endpoint](https://github.com/mrpalide/skywire/blob/3afefd726d462cf858647378e9b0f280529f3729/pkg/visor/api.go#L187) API

How to test this PR:
You should build a new image from skybian, or add `Environment=SKYBIAN_BUILD_VERSION=vX.Y.Z` on `skywire-visor.service` file.