### PR TITLE
skybian defaults from `skywire-cli visor gen-config -s`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ Skywire can be statically built. For instructions check [the docs](docs/static-b
 
 ### Expose hypervisorUI
 
-In order to expose the hypervisor UI, generate a config file with `--is-hypervisor` flag:
+In order to expose the hypervisor UI, generate a config file with `--is-hypervisor` or `-i` flag:
 
 ```bash
-$ skywire-cli visor gen-config --is-hypervisor
+$ skywire-cli visor gen-config -i
 ```
 
 Docker container will create config automatically for you, should you want to run it manually, you can do:
 
 ```bash
 $ docker run --rm -v <YOUR_CONFIG_DIR>:/opt/skywire \
-  skycoin/skywire:test skywire-cli gen-config --is-hypervisor
+  skycoin/skywire:test skywire-cli gen-config -i
 ```
 
 After starting up the visor, the UI will be exposed by default on `localhost:8000`.

--- a/cmd/apps/skychat/chat.go
+++ b/cmd/apps/skychat/chat.go
@@ -4,19 +4,19 @@ skychat app for skywire visor
 package main
 
 import (
-	"embed"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"os"
 	"sync"
 	"time"
 
+	"embed"
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cipher"
+	"io/fs"
 
 	"github.com/skycoin/skywire/internal/netutil"
 	"github.com/skycoin/skywire/pkg/app"

--- a/cmd/apps/skychat/chat.go
+++ b/cmd/apps/skychat/chat.go
@@ -15,6 +15,7 @@ import (
 
 	"embed"
 	"io/fs"
+
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cipher"
 

--- a/cmd/apps/skychat/chat.go
+++ b/cmd/apps/skychat/chat.go
@@ -15,7 +15,6 @@ import (
 
 	"embed"
 	"io/fs"
-
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cipher"
 

--- a/cmd/apps/skychat/chat.go
+++ b/cmd/apps/skychat/chat.go
@@ -14,9 +14,10 @@ import (
 	"time"
 
 	"embed"
+	"io/fs"
+
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cipher"
-	"io/fs"
 
 	"github.com/skycoin/skywire/internal/netutil"
 	"github.com/skycoin/skywire/pkg/app"

--- a/cmd/skywire-cli/README.md
+++ b/cmd/skywire-cli/README.md
@@ -441,32 +441,32 @@ $ skywire-cli visor gen-config
 }
 ```
 
-The default configuration is for a visor only. To generate a configuration which provides the hypervisor web interface, the -i or --is-hypervisor flag should be specified.
+The default configuration is for a visor only. To generate a configuration which provides the hypervisor web interface, the `-i` or `--is-hypervisor` flag should be specified.
 ```
 $ skywire-cli visor gen-config -i
 ```
 
 ##### Example hypervisor configuration for skybian
 ```
-$ skywire-cli visor gen-config -is
+$ skywire-cli visor gen-config -irs
 ```
 ##### Example visor configuration for skybian
 
 It is the typical arrangement to set a visor to use a remote hypervisor if a local instance is not started.
 
-Determine the hypervisor public key by running the following command on the remote machine
+Determine the hypervisor public key by running the following command on the machine running the hypervisor
 
 ```
-_pubkey=$(cat /opt/skywire/skywire.json | grep pk\") _pubkey=${_pubkey#*: } ; echo $_pubkey
+$ skywire-cli visor pk
 ```
 substitute the hypervisor public key in the following command:
 ```
-$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -s
+$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -rs
 ```
 
 ##### Example hypervisor configuration for package based installation
 
-This assumes the skywire installation is at /opt/skywire with binaries and apps in their own subdirectories.
+This assumes the skywire installation is at `/opt/skywire` with binaries and apps in their own subdirectories.
 
 ```
 $ skywire-cli visor gen-config -ip
@@ -581,10 +581,10 @@ The configuration is written (or rewritten)
 It is the typical arrangement to set a visor to use a remote hypervisor if a local instance is not started.
 
 
-Determine the hypervisor public key by running the following command on the remote machine
+Determine the hypervisor public key by running the following command on the machine running the hypervisor
 
 ```
-_pubkey=$(cat /opt/skywire/skywire.json | grep pk\") _pubkey=${_pubkey#*: } ; echo $_pubkey
+$ skywire-cli visor pk
 ```
 
 When running a visor with or without a hypervisor on the same machine, it's wise to keep the same keys for the other config file.
@@ -592,7 +592,7 @@ When running a visor with or without a hypervisor on the same machine, it's wise
 Copy the `skywire.json` config file from the previous example to `skywire-visor.json`; then paste the public key from the above command output into the following command
 
 ```
-$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -p
+$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -pr
 ```
 
 The configuration is written (or rewritten)

--- a/cmd/skywire-cli/README.md
+++ b/cmd/skywire-cli/README.md
@@ -334,12 +334,15 @@ Usage:
 Flags:
   -h, --help                    help for gen-config
       --hypervisor-pks string   public keys of hypervisors that should be added to this visor
-      --is-hypervisor           whether to generate config to run this visor as a hypervisor.
+  -i, --is-hypervisor           generate a hypervisor configuration.
   -o, --output string           path of output config file. (default "skywire-config.json")
-  -p, --package                 use defaults for package-based installations
-  -r, --replace                 whether to allow rewrite of a file that already exists (this retains the keys).
-      --sk cipher.SecKey        if unspecified, a random key pair will be generated. (default 0000000000000000000000000000000000000000000000000000000000000000)
-  -t, --testenv                 whether to use production or test deployment service.
+  -p, --package                 use defaults for package-based installations in /opt/skywire
+  -r, --replace                 rewrite existing config (retains keys).
+      --sk cipher.SecKey        if unspecified, a random key pair will be generated.
+                                 (default 0000000000000000000000000000000000000000000000000000000000000000)
+  -s, --skybian                 use defaults paths found in skybian
+                                 writes config to /etc/skywire-config.json
+  -t, --testenv                 use test deployment service.
 
 Global Flags:
       --rpc string   RPC server address (default "localhost:3435")
@@ -438,9 +441,27 @@ $ skywire-cli visor gen-config
 }
 ```
 
-The default configuration is for a visor only. To generate a configuration which provides the hypervisor web interface, the --is-hypervisor flag can be passed.
+The default configuration is for a visor only. To generate a configuration which provides the hypervisor web interface, the -i or --is-hypervisor flag should be specified.
 ```
-$ skywire-cli visor gen-config --is-hypervisor
+$ skywire-cli visor gen-config -i
+```
+
+##### Example hypervisor configuration for skybian
+```
+$ skywire-cli visor gen-config -is
+```
+##### Example visor configuration for skybian
+
+It is the typical arrangement to set a visor to use a remote hypervisor if a local instance is not started.
+
+Determine the hypervisor public key by running the following command on the remote machine
+
+```
+_pubkey=$(cat /opt/skywire/skywire.json | grep pk\") _pubkey=${_pubkey#*: } ; echo $_pubkey
+```
+substitute the hypervisor public key in the following command:
+```
+$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -s
 ```
 
 ##### Example hypervisor configuration for package based installation
@@ -448,8 +469,7 @@ $ skywire-cli visor gen-config --is-hypervisor
 This assumes the skywire installation is at /opt/skywire with binaries and apps in their own subdirectories.
 
 ```
-$ cd /opt/skywire
-$ skywire-cli visor gen-config --is-hypervisor -pro skywire.json
+$ skywire-cli visor gen-config -ip
 [2021-06-24T09:09:39-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/opt/skywire/skywire.json"
 [2021-06-24T09:09:39-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/opt/skywire/skywire.json"
 [2021-06-24T09:09:39-05:00] INFO [skywire-cli]: Updated file '/opt/skywire/skywire.json' to: {
@@ -572,13 +592,12 @@ When running a visor with or without a hypervisor on the same machine, it's wise
 Copy the `skywire.json` config file from the previous example to `skywire-visor.json`; then paste the public key from the above command output into the following command
 
 ```
-$ cd /opt/skywire
-$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -pro skywire-visor.json
+$ skywire-cli visor gen-config --hypervisor-pks <hypervisor-public-key> -p
 ```
 
 The configuration is written (or rewritten)
 
-The configuration files may be specified in corresponding systemd service files or init / startup scripts to start either a visor or hypervisor instance
+The configuration files should be specified in corresponding systemd service files or init / startup scripts to start either a visor or hypervisor instance
 
 starting the hypervisor intance
 ```

--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -26,17 +26,19 @@ var (
 	replace       bool
 	testEnv       bool
 	packageConfig bool
+	skybianConfig bool
 	hypervisor    bool
 	hypervisorPKs string
 )
 
 func init() {
-	genConfigCmd.Flags().Var(&sk, "sk", "if unspecified, a random key pair will be generated.")
+	genConfigCmd.Flags().Var(&sk, "sk", "if unspecified, a random key pair will be generated.\n")
 	genConfigCmd.Flags().StringVarP(&output, "output", "o", "skywire-config.json", "path of output config file.")
-	genConfigCmd.Flags().BoolVarP(&replace, "replace", "r", false, "whether to allow rewrite of a file that already exists (this retains the keys).")
-	genConfigCmd.Flags().BoolVarP(&packageConfig, "package", "p", false, "use defaults for package-based installations")
-	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "whether to use production or test deployment service.")
-	genConfigCmd.Flags().BoolVar(&hypervisor, "is-hypervisor", false, "whether to generate config to run this visor as a hypervisor.")
+	genConfigCmd.Flags().BoolVarP(&replace, "replace", "r", false, "rewrite existing config (retains keys).")
+	genConfigCmd.Flags().BoolVarP(&packageConfig, "package", "p", false, "use defaults for package-based installations in /opt/skywire")
+	genConfigCmd.Flags().BoolVarP(&skybianConfig, "skybian", "s", false, "use defaults paths found in skybian\n writes config to /etc/skywire-config.json")
+	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "use test deployment service.")
+	genConfigCmd.Flags().BoolVarP(&hypervisor, "is-hypervisor", "i", false, "generate a hypervisor configuration.")
 	genConfigCmd.Flags().StringVar(&hypervisorPKs, "hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
 }
 
@@ -53,6 +55,25 @@ var genConfigCmd = &cobra.Command{
 		mLog := logging.NewMasterLogger()
 		mLog.SetLevel(logrus.InfoLevel)
 
+		//Fail on -pst combination
+		if (packageConfig && skybianConfig) || (packageConfig && testEnv) || (skybianConfig && testEnv) {
+			logger.Fatal("Failed to create config: use of mutually exclusive flags")
+		}
+
+		//set replace flag & output for package and skybian configs
+		if packageConfig {
+			replace = true
+			if hypervisor {
+				output = "/opt/skywire/skywire.json"
+			} else {
+				output = "/opt/skywire/skywire-visor.json"
+			}
+		}
+		if skybianConfig {
+			replace = true
+			output = "/etc/skywire-config.json"
+		}
+
 		// Read in old config (if any) and obtain old secret key.
 		// Otherwise, we generate a new random secret key.
 		var sk cipher.SecKey
@@ -65,9 +86,11 @@ var genConfigCmd = &cobra.Command{
 		// Determine config type to generate.
 		var genConf func(log *logging.MasterLogger, confPath string, sk *cipher.SecKey, hypervisor bool) (*visorconfig.V1, error)
 
-		// to be improved later
+		//  default paths for different installations
 		if packageConfig {
 			genConf = visorconfig.MakePackageConfig
+		} else if skybianConfig {
+			genConf = visorconfig.MakeSkybianConfig
 		} else if testEnv {
 			genConf = visorconfig.MakeTestConfig
 		} else {
@@ -89,7 +112,6 @@ var genConfigCmd = &cobra.Command{
 				}
 				conf.Hypervisors = append(conf.Hypervisors, cipher.PubKey(keyParsed))
 			}
-
 		}
 
 		// Save config to file.
@@ -116,7 +138,7 @@ func readOldConfig(log *logging.MasterLogger, confPath string, replace bool) (*v
 	}
 
 	if !replace {
-		logger.Fatal("Config file already exists. Specify the 'replace,r' flag to replace this.")
+		logger.Fatal("Config file already exists. Specify the 'replace, r' flag to replace this.")
 	}
 
 	conf, err := visorconfig.Parse(log, confPath, raw)

--- a/cmd/skywire-cli/commands/visor/gen-config.go
+++ b/cmd/skywire-cli/commands/visor/gen-config.go
@@ -60,9 +60,8 @@ var genConfigCmd = &cobra.Command{
 			logger.Fatal("Failed to create config: use of mutually exclusive flags")
 		}
 
-		//set replace flag & output for package and skybian configs
+		//set output for package and skybian configs
 		if packageConfig {
-			replace = true
 			if hypervisor {
 				output = "/opt/skywire/skywire.json"
 			} else {
@@ -70,7 +69,6 @@ var genConfigCmd = &cobra.Command{
 			}
 		}
 		if skybianConfig {
-			replace = true
 			output = "/etc/skywire-config.json"
 		}
 

--- a/cmd/skywire-visor/README.md
+++ b/cmd/skywire-visor/README.md
@@ -94,16 +94,14 @@ The configuration file is generated in the following way
 for a visor with local hypervisor:
 
 ```
-$ cd /opt/skywire
-$ skywire-cli visor gen-config --is-hypervisor -pro skywire.json
+$ skywire-cli visor gen-config -ip
 ```
 
 for visor with remote hypervisor; first copy the existing configuration file to keep the same keys.
 
 ```
-$ cd /opt/skywire
-# cp skywire.json skywire-visor.json
-# skywire-cli visor gen-config --hypervisor-pks <remote-hypervisor-public-key> -pro skywire-visor.json
+# cp /opt/skywire/skywire.json /opt/skywire/skywire-visor.json
+# skywire-cli visor gen-config --hypervisor-pks <remote-hypervisor-public-key> -p
 ```
 
 These two configuration files can be referenced in systemd service files or init scripts to start skywire with either a local or remote hypervisor.

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -2,10 +2,8 @@ package commands
 
 import (
 	"context"
-	"embed"
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof" // nolint:gosec // https://golang.org/doc/diagnostics.html#profiling
@@ -15,12 +13,14 @@ import (
 	"syscall"
 	"time"
 
+	"embed"
 	"github.com/pkg/profile"
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cmdutil"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
 	"github.com/toqueteos/webbrowser"
+	"io/fs"
 
 	"github.com/skycoin/skywire/pkg/restart"
 	"github.com/skycoin/skywire/pkg/syslog"

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"context"
+	"embed"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof" // nolint:gosec // https://golang.org/doc/diagnostics.html#profiling
@@ -13,8 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"embed"
-	"io/fs"
 	"github.com/pkg/profile"
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cmdutil"

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -15,7 +15,6 @@ import (
 
 	"embed"
 	"io/fs"
-
 	"github.com/pkg/profile"
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cmdutil"

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -14,13 +14,14 @@ import (
 	"time"
 
 	"embed"
+	"io/fs"
+
 	"github.com/pkg/profile"
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cmdutil"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
 	"github.com/toqueteos/webbrowser"
-	"io/fs"
 
 	"github.com/skycoin/skywire/pkg/restart"
 	"github.com/skycoin/skywire/pkg/syslog"

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -106,7 +106,7 @@ const (
 	DefaultLogLevel       = "info"
 )
 
-// Package defaults - installation path: /opt/skywire
+// Package defaults
 const (
 	PackageAppBinPath       = PackageSkywirePath + "/apps"
 	PackageLocalPath        = PackageSkywirePath + "/local"
@@ -124,8 +124,7 @@ const (
 	DefaultTpLogStore = DefaultSkywirePath + "/transport_logs"
 )
 
-// Skybian defaults - github.com/skycoin/skybian/
-//these should really be imported
+// Skybian defaults
 const (
 	SkybianAppBinPath       = "/usr/bin/apps"
 	SkybianDmsgPtyWhiteList = "/var/skywire-visor/dsmgpty/whitelist.json"

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -61,7 +61,6 @@ const (
 
 	DefaultDmsgPtyCLINet    = "unix"
 	DefaultDmsgPtyCLIAddr   = "/tmp/dmsgpty.sock"
-	DefaultDmsgPtyWhitelist = DefaultSkywirePath + "/dmsgpty/whitelist.json"
 )
 
 // Default STCP constants.
@@ -92,7 +91,7 @@ const (
 
 // RPC constants.
 const (
-	DefaultRPCAddr      = "localhost:3435"
+	DefaultRPCAddr      = "localhost:3435"	DefaultDmsgPtyCLIAddr = "/tmp/dmsgpty.sock"
 	DefaultRPCTimeout   = 20 * time.Second
 	TransportRPCTimeout = 1 * time.Minute
 	UpdateRPCTimeout    = 6 * time.Hour // update requires huge timeout

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -91,7 +91,7 @@ const (
 
 // RPC constants.
 const (
-	DefaultRPCAddr      = "localhost:3435"	DefaultDmsgPtyCLIAddr = "/tmp/dmsgpty.sock"
+	DefaultRPCAddr      = "localhost:3435"
 	DefaultRPCTimeout   = 20 * time.Second
 	TransportRPCTimeout = 1 * time.Minute
 	UpdateRPCTimeout    = 6 * time.Hour // update requires huge timeout

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -59,8 +59,8 @@ const (
 const (
 	DmsgPtyPort uint16 = 22
 
-	DefaultDmsgPtyCLINet    = "unix"
-	DefaultDmsgPtyCLIAddr   = "/tmp/dmsgpty.sock"
+	DefaultDmsgPtyCLINet  = "unix"
+	DefaultDmsgPtyCLIAddr = "/tmp/dmsgpty.sock"
 )
 
 // Default STCP constants.

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -59,8 +59,9 @@ const (
 const (
 	DmsgPtyPort uint16 = 22
 
-	DefaultDmsgPtyCLINet  = "unix"
-	DefaultDmsgPtyCLIAddr = "/tmp/dmsgpty.sock"
+	DefaultDmsgPtyCLINet    = "unix"
+	DefaultDmsgPtyCLIAddr   = "/tmp/dmsgpty.sock"
+	DefaultDmsgPtyWhitelist = DefaultSkywirePath + "/dmsgpty/whitelist.json"
 )
 
 // Default STCP constants.
@@ -103,13 +104,43 @@ const (
 	AppDiscUpdateInterval = time.Minute
 	DefaultAppBinPath     = DefaultSkywirePath + "/apps"
 	DefaultLogLevel       = "info"
-	PackageAppBinPath     = PackageSkywirePath + "/apps"
+)
+
+// Package defaults - installation path: /opt/skywire
+const (
+	PackageAppBinPath       = PackageSkywirePath + "/apps"
+	PackageLocalPath        = PackageSkywirePath + "/local"
+	PackageDmsgPtyWhiteList = PackageSkywirePath + "/dmsgpty/whitelist.json"
+	PackageDmsgPtyCLIAddr   = PackageSkywirePath + "/dmsgpty/cli.sock"
+	PackageTpLogStore       = PackageSkywirePath + "/transport_logs"
+	PackageDBPath           = PackageSkywirePath + "/users.db"
+	PackageEnableTLS        = false
+	PackageTLSKey           = PackageSkywirePath + "/ssl/key.pem"
+	PackageTLSCert          = PackageSkywirePath + "/ssl/cert.pem"
+)
+
+// Default routing constants
+const (
+	DefaultTpLogStore = DefaultSkywirePath + "/transport_logs"
+)
+
+// Skybian defaults - github.com/skycoin/skybian/
+//these should really be imported
+const (
+	SkybianAppBinPath       = "/usr/bin/apps"
+	SkybianDmsgPtyWhiteList = "/var/skywire-visor/dsmgpty/whitelist.json"
+	SkybianDmsgPtyCLIAddr   = "/run/skywire-visor/dmsgpty/cli.sock"
+	SkybianLocalPath        = "/var/skywire-visor/apps"
+	SkybianTpLogStore       = "/var/skywire-visor/transports"
+	SkybianEnableTLS        = false
+	SkybianDBPath           = "/var/skywire-visor/users.db"
+	SkybianTLSKey           = "/var/skywire-visor/ssl/key.pem"
+	SkybianTLSCert          = "/var/skywire-visor/ssl/cert.pem"
 )
 
 // Default local constants
 const (
 	DefaultLocalPath = DefaultSkywirePath + "/local"
-	PackageLocalPath = PackageSkywirePath + "/local"
 )
 
 // Default hypervisor constants
@@ -119,9 +150,6 @@ const (
 	DefaultEnableTLS    = false
 	DefaultTLSKey       = DefaultSkywirePath + "/ssl/key.pem"
 	DefaultTLSCert      = DefaultSkywirePath + "/ssl/cert.pem"
-	PackageEnableTLS    = true
-	PackageTLSKey       = PackageSkywirePath + "/ssl/key.pem"
-	PackageTLSCert      = PackageSkywirePath + "/ssl/cert.pem"
 )
 
 // MustPK unmarshals string PK to cipher.PubKey. It panics if unmarshaling fails.

--- a/pkg/visor/hypervisorconfig/config.go
+++ b/pkg/visor/hypervisorconfig/config.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"io/fs"
-
 	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/skyenv"

--- a/pkg/visor/hypervisorconfig/config.go
+++ b/pkg/visor/hypervisorconfig/config.go
@@ -9,8 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/skycoin/dmsg/cipher"
 	"io/fs"
+
+	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/util/pathutil"

--- a/pkg/visor/hypervisorconfig/config.go
+++ b/pkg/visor/hypervisorconfig/config.go
@@ -3,7 +3,6 @@ package hypervisorconfig
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/skycoin/dmsg/cipher"
+	"io/fs"
 
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/util/pathutil"

--- a/pkg/visor/hypervisorconfig/config.go
+++ b/pkg/visor/hypervisorconfig/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"io/fs"
+
 	"github.com/skycoin/dmsg/cipher"
 
 	"github.com/skycoin/skywire/pkg/skyenv"

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -166,6 +166,32 @@ func MakePackageConfig(log *logging.MasterLogger, confPath string, sk *cipher.Se
 		conf.Hypervisor.EnableTLS = skyenv.PackageEnableTLS
 		conf.Hypervisor.TLSKeyFile = skyenv.PackageTLSKey
 		conf.Hypervisor.TLSCertFile = skyenv.PackageTLSCert
+		conf.Hypervisor.DBPath = skyenv.PackageDBPath
+	}
+	return conf, nil
+}
+
+// MakeSkybianConfig acts like MakeDefaultConfig but uses default paths, etc. as found in skybian / produced by skyimager
+func MakeSkybianConfig(log *logging.MasterLogger, confPath string, sk *cipher.SecKey, hypervisor bool) (*V1, error) {
+	conf, err := MakeDefaultConfig(log, confPath, sk, hypervisor)
+	if err != nil {
+		return nil, err
+	}
+
+	conf.Dmsgpty = &V1Dmsgpty{
+		Port:    skyenv.DmsgPtyPort,
+		CLINet:  skyenv.DefaultDmsgPtyCLINet,
+		CLIAddr: skyenv.SkybianDmsgPtyCLIAddr,
+	}
+	conf.LocalPath = skyenv.SkybianLocalPath
+	conf.Launcher.BinPath = skyenv.SkybianAppBinPath
+
+	if conf.Hypervisor != nil {
+		conf.Hypervisor.EnableAuth = skyenv.DefaultEnableAuth
+		conf.Hypervisor.EnableTLS = skyenv.SkybianEnableTLS
+		conf.Hypervisor.TLSKeyFile = skyenv.SkybianTLSKey
+		conf.Hypervisor.TLSCertFile = skyenv.SkybianTLSCert
+		conf.Hypervisor.DBPath = skyenv.SkybianDBPath
 	}
 	return conf, nil
 }


### PR DESCRIPTION
Did you run `make format && make check`?
yes. There were some errors that appeared to be pre-existing, with `make check`


 Changes:

* Adds the `-s` flag to `skywire-cli visor gen-config` for generating config files with the defaults for skybian.
 
This is useful in the event the config files are messed up, correct config defaults can be re-generated on the running board without the need for skyimager or reflashing the image onto the microSD card.

* Streamlines the behavior of the `-p` and `-s` flags by combining `replace` and setting `output` to the correct / expected path (used by the systemd service)


In a typical instance of configs generated by postinstall scripts of a package, the configuration for the hypervisor was __previously__ accomplished by the following:

```
cd /opt/skywire
skywire-cli visor gen-config --is-hypervisor -pro /opt/skywire/skywire.json
```

with this PR, the same output as the above is accomplished with:
```
skywire-cli visor gen-config -ip
```

Peviously it was not possible to reproduce the configuration file generated by skyimager.
Generating the skybian config file:
Hypervisor
```
skywire-cli visor gen-config -is
```

Visor
```
skywire-cli visor gen-config -s
```

example output:

```
$ sudo go run skywire-cli.go visor gen-config -is
[2021-07-24T15:57:49-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.1.0" filepath="/etc/skywire-config.json"
[2021-07-24T15:57:49-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.1.0" filepath="/etc/skywire-config.json"
[2021-07-24T15:57:49-05:00] INFO [skywire-cli]: Updated file '/etc/skywire-config.json' to: {
	"version": "v1.1.0",
	"sk": "9d7e69eb96e462101bf479505819425c5902894a23f792b2e477072bfdd3ff5a",
	"pk": "035887660f00d5edabc1282228425a70c02171c2b5004f747e2b8e4c94cbb7e9ae",
	"dmsg": {
		"discovery": "http://dmsgd.skywire.skycoin.com",
		"sessions_count": 1
	},
	"dmsgpty": {
		"port": 22,
		"cli_network": "unix",
		"cli_address": "/run/skywire-visor/dmsgpty/cli.sock"
	},
	"stcp": {
		"pk_table": null,
		"local_address": ":7777"
	},
	"transport": {
		"discovery": "http://tpd.skywire.skycoin.com",
		"address_resolver": "http://ar.skywire.skycoin.com",
		"public_autoconnect": false,
		"transport_setup_nodes": null
	},
	"routing": {
		"setup_nodes": [
			"0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
		],
		"route_finder": "http://rf.skywire.skycoin.com",
		"route_finder_timeout": "10s",
		"min_hops": 0
	},
	"uptime_tracker": {
		"addr": "http://ut.skywire.skycoin.com"
	},
	"launcher": {
		"discovery": {
			"update_interval": "1m0s",
			"proxy_discovery_addr": "http://sd.skycoin.com"
		},
		"apps": [
			{
				"name": "skychat",
				"args": [
					"-addr",
					":8001"
				],
				"auto_start": true,
				"port": 1
			},
			{
				"name": "skysocks",
				"auto_start": true,
				"port": 3
			},
			{
				"name": "skysocks-client",
				"auto_start": false,
				"port": 13
			},
			{
				"name": "vpn-server",
				"auto_start": false,
				"port": 44
			},
			{
				"name": "vpn-client",
				"auto_start": false,
				"port": 43
			}
		],
		"server_addr": "localhost:5505",
		"bin_path": "/usr/bin/apps"
	},
	"hypervisors": [],
	"cli_addr": "localhost:3435",
	"log_level": "info",
	"local_path": "/var/skywire-visor/apps",
	"shutdown_timeout": "10s",
	"restart_check_delay": "1s",
	"is_public": false,
	"hypervisor": {
		"db_path": "/var/skywire-visor/users.db",
		"enable_auth": true,
		"cookies": {
			"hash_key": "a0f669a79e5d5ba8ac284cbef9656198cde7a1772884233b8f7a99426ca7e945c5f77b47994987272e0b8fce5fa878f77eb111da7554d1431160856335a669d3",
			"block_key": "1e4a4dd0518b2090b4dc9fe72b150194222ef1e51e735f88e8121dcbac14396b",
			"expires_duration": 43200000000000,
			"path": "/",
			"domain": ""
		},
		"dmsg_port": 46,
		"http_addr": ":8000",
		"enable_tls": false,
		"tls_cert_file": "/var/skywire-visor/ssl/cert.pem",
		"tls_key_file": "/var/skywire-visor/ssl/key.pem"
	}
}

```

