### PR TITLE
Add the Skybian version to the UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -14,6 +14,7 @@ export class Node {
   dmsgServerPk?: string;
   roundTripPing?: string;
   isHypervisor?: boolean;
+  skybianBuildVersion?: string;
 }
 
 export interface Application {

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -30,6 +30,10 @@
       {{ node.version ? node.version : ('common.unknown' | translate) }}
     </span>
     <span class="info-line">
+      <span class="title">{{ 'node.details.node-info.skybian-version' | translate }}</span>
+      {{ node.skybianBuildVersion ? node.skybianBuildVersion : ('node.details.node-info.no-skybian-version' | translate) }}
+    </span>
+    <span class="info-line">
       <span class="title">{{ 'node.details.node-info.time.title' | translate }}</span>
       {{ ('node.details.node-info.time.' + timeOnline.translationVarName) | translate:{time: timeOnline.elapsedTime} }}
 

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -613,6 +613,7 @@ export class NodeService {
         node.version = response.overview.build_info.version;
         node.secondsOnline = Math.floor(Number.parseFloat(response.uptime));
         node.minHops = response.min_hops;
+        node.skybianBuildVersion = response.skybian_build_version;
 
         // Ip.
         if (response.overview.local_ip && (response.overview.local_ip as string).trim()) {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -100,6 +100,8 @@
         "dmsg-server": "DMSG server:",
         "ping": "Ping:",
         "node-version": "Visor version:",
+        "skybian-version": "Skybian version:",
+        "no-skybian-version": "(not using Skybian)",
         "time": {
           "title": "Time online:",
           "seconds": "a few seconds",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -100,6 +100,8 @@
         "dmsg-server": "Servidor DMSG:",
         "ping": "Ping:",
         "node-version": "Versión del visor:",
+        "skybian-version": "Versión de Skybian:",
+        "no-skybian-version": "(no se usa Skybian)",
         "time": {
           "title": "Tiempo online:",
           "seconds": "unos segundos",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -100,6 +100,8 @@
         "dmsg-server": "DMSG server:",
         "ping": "Ping:",
         "node-version": "Visor version:",
+        "skybian-version": "Skybian version:",
+        "no-skybian-version": "(not using Skybian)",
         "time": {
           "title": "Time online:",
           "seconds": "a few seconds",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Changes:	
- Now the Skybian version is shown in the UI. If no Skybian version is returned by the API, a msg indicating that Skybian is not being used is shown.
![v](https://user-images.githubusercontent.com/34079003/126993402-be88577b-3752-4db7-a541-0c9999d58b97.png)
NOTE: this needs the changes from https://github.com/skycoin/skywire/pull/849 to work.

How to test this PR:
Open the details page of a visor, using the Skywire manager. The value is shown in the visor info area, at the right.