### PR TITLE
add dmsgpty to skywire-cli

### DIFF
--- a/cmd/skywire-cli/commands/visor/dmsgpty.go
+++ b/cmd/skywire-cli/commands/visor/dmsgpty.go
@@ -1,0 +1,13 @@
+package visor
+
+import (
+dmsgcli	"github.com/skycoin/dmsg/cmd/dmsgpty-cli/commands"
+dmsgui	"github.com/skycoin/dmsg/cmd/dmsgpty-ui/commands"
+)
+
+func init() {
+	RootCmd.AddCommand(
+		dmsgui.RootCmd,
+		dmsgcli.RootCmd,
+	)
+}


### PR DESCRIPTION
add dmsgpty-cli and dmsgpty-ui comands to skywire-cli.

This PR depends on:
https://github.com/skycoin/dmsg/pull/101

I've been able to test this by manually changing the dependencies to reflect the pull request in dmsg.
The dmsgpty-cli works, but the dmsgpty-ui does not register as a command, yet there are no errors or any indication why it does not appear.

The ability to launch the dmsgpty-ui from skywire-cli would be nice but is not essential for my purposes

dmsgpty-cli has been missing from skywire-cli; currently dmsgpty-ui is included with the visor.
this is a necessary step for further integration of update functionality into skywire-cli.

 Changes:	
-	add dmsgpty commands

How to test this PR:
```
skywire-cli visor dmsgpty-cli
```