### PR TITLE
Revert alpine to 3.13

### DIFF
--- a/docker/images/visor/Dockerfile
+++ b/docker/images/visor/Dockerfile
@@ -1,6 +1,6 @@
 # Builder
-ARG base=alpine
-FROM golang:alpine  as builder
+ARG base=alpine3.13
+FROM golang:alpine3.13 as builder
 
 ARG BUILDINFO_LDFLAGS
 ARG CGO_ENABLED=0


### PR DESCRIPTION
Did you run `make format && make check`?
No, changes were only made to the Dockerfile.

Fixes #	

 Changes:	
- Reverted alpine to 3.13 in dockerfile.	

How to test this PR:
