### PR TITLE
Fix creating transports from the UI

### DIFF
--- a/static/skywire-manager-src/src/app/services/transport.service.ts
+++ b/static/skywire-manager-src/src/app/services/transport.service.ts
@@ -23,7 +23,6 @@ export class TransportService {
   create(nodeKey: string, remoteKey: string, type: string): Observable<any> {
     const data = {
       remote_pk: remoteKey,
-      public: true,
     };
 
     if (type) {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the front-end code does not send the public field to the API when creating transports. This allows the option for creating transports to work again.

How to test this PR:
Create a transport using the hypervisor UI.