### PR TITLE
Add NAT info to the UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -1,6 +1,8 @@
 export class Node {
   label: string;
   localPk: string;
+  isSymmeticNat?: boolean;
+  publicIp?: string;
   ip: string;
   version: string;
   apps: Application[];

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -13,6 +13,14 @@
       <span class="title">{{ 'node.details.node-info.public-key' | translate }}&nbsp;</span>
       <app-copy-to-clipboard-text text="{{ node.localPk }}"></app-copy-to-clipboard-text>
     </span>
+    <span class="info-line">
+      <span class="title">{{ 'node.details.node-info.symmetic-nat' | translate }}&nbsp;</span>
+      {{ (node.isSymmeticNat ? 'common.yes' : 'common.no') | translate }}
+    </span>
+    <span class="info-line" *ngIf="!node.isSymmeticNat">
+      <span class="title">{{ 'node.details.node-info.public-ip' | translate }}&nbsp;</span>
+      <app-copy-to-clipboard-text text="{{ node.publicIp }}"></app-copy-to-clipboard-text>
+    </span>
     <span class="info-line" *ngIf="node.ip">
       <span class="title">{{ 'node.details.node-info.ip' | translate }}&nbsp;</span>
       <app-copy-to-clipboard-text text="{{ node.ip }}"></app-copy-to-clipboard-text>

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -614,6 +614,8 @@ export class NodeService {
         node.secondsOnline = Math.floor(Number.parseFloat(response.uptime));
         node.minHops = response.min_hops;
         node.skybianBuildVersion = response.skybian_build_version;
+        node.isSymmeticNat = response.overview.is_symmetic_nat;
+        node.publicIp = response.overview.public_ip;
 
         // Ip.
         if (response.overview.local_ip && (response.overview.local_ip as string).trim()) {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -16,6 +16,8 @@
     "time-in-ms": "{{ time }}ms.",
     "time-in-segs": "{{ time }}s.",
     "ok": "Ok",
+    "yes": "Yes",
+    "no": "No",
     "unknown": "Unknown",
     "close": "Close",
     "window-size-error": "The window is too narrow for the content."
@@ -96,6 +98,8 @@
         "title": "Visor Info",
         "label": "Label:",
         "public-key": "Public key:",
+        "symmetic-nat": "Symmetic NAT:",
+        "public-ip": "Public IP:",
         "ip": "IP:",
         "dmsg-server": "DMSG server:",
         "ping": "Ping:",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -16,6 +16,8 @@
     "time-in-ms": "{{ time }}ms.",
     "time-in-segs": "{{ time }}s.",
     "ok": "Ok",
+    "yes": "Yes",
+    "no": "No",
     "unknown": "Desconocido",
     "close": "Cerrar",
     "window-size-error": "La ventana es demasiado estrecha para el contenido."
@@ -96,6 +98,8 @@
         "title": "Información del visor",
         "label": "Etiqueta:",
         "public-key": "Llave pública:",
+        "symmetic-nat": "NAT simétrica:",
+        "public-ip": "IP pública:",
         "ip": "IP:",
         "dmsg-server": "Servidor DMSG:",
         "ping": "Ping:",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -16,6 +16,8 @@
     "time-in-ms": "{{ time }}ms.",
     "time-in-segs": "{{ time }}s.",
     "ok": "Ok",
+    "yes": "Yes",
+    "no": "No",
     "unknown": "Unknown",
     "close": "Close",
     "window-size-error": "The window is too narrow for the content."
@@ -96,6 +98,8 @@
         "title": "Visor Info",
         "label": "Label:",
         "public-key": "Public key:",
+        "symmetic-nat": "Symmetic NAT:",
+        "public-ip": "Public IP:",
         "ip": "IP:",
         "dmsg-server": "DMSG server:",
         "ping": "Ping:",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the visor details bar in the Skywire manager shows the value of the `is_symmetic_nat` property.
- If `is_symmetic_nat` is `false`, the value of `public_ip` is also shown.

How to test this PR:
Check the values in the visor details bar of the Skywire manager.