### PR TITLE
Fix Persistent transports cancel issue

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -137,11 +137,11 @@ func (tm *Manager) getPTpsCache() []PersistentTransports {
 }
 
 // SetPTpsCache sets the PersistentTransportsCache
-func (tm *Manager) SetPTpsCache(ptps []PersistentTransports) {
+func (tm *Manager) SetPTpsCache(pTps []PersistentTransports) {
 	tm.Conf.PTpsCacheMu.Lock()
 	defer tm.Conf.PTpsCacheMu.Unlock()
 
-	tm.Conf.PersistentTransportsCache = ptps
+	tm.Conf.PersistentTransportsCache = pTps
 }
 
 // InitClient initilizes a network client

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -785,9 +785,9 @@ func (v *Visor) SetMinHops(in uint16) error {
 }
 
 // SetPersistentTransports sets min_hops routing config of visor
-func (v *Visor) SetPersistentTransports(ptps []transport.PersistentTransports) error {
-	v.tpM.SetPTpsCache(ptps)
-	return v.conf.UpdatePersistentTransports(ptps)
+func (v *Visor) SetPersistentTransports(pTps []transport.PersistentTransports) error {
+	v.tpM.SetPTpsCache(pTps)
+	return v.conf.UpdatePersistentTransports(pTps)
 }
 
 // GetPersistentTransports sets min_hops routing config of visor

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -785,8 +785,9 @@ func (v *Visor) SetMinHops(in uint16) error {
 }
 
 // SetPersistentTransports sets min_hops routing config of visor
-func (v *Visor) SetPersistentTransports(pts []transport.PersistentTransports) error {
-	return v.conf.UpdatePersistentTransports(pts)
+func (v *Visor) SetPersistentTransports(ptps []transport.PersistentTransports) error {
+	v.tpM.SetPTpsCache(ptps)
+	return v.conf.UpdatePersistentTransports(ptps)
 }
 
 // GetPersistentTransports sets min_hops routing config of visor

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -286,12 +286,18 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	logS := transport.InMemoryTransportLogStore()
 
+	ptps, err := v.conf.GetPersistentTransports()
+	if err != nil {
+		err := fmt.Errorf("failed to get persistent transports: %w", err)
+		return err
+	}
+
 	tpMConf := transport.ManagerConfig{
-		PubKey:               v.conf.PK,
-		SecKey:               v.conf.SK,
-		DiscoveryClient:      tpdC,
-		LogStore:             logS,
-		PersistentTransports: v.conf.PersistentTransports,
+		PubKey:                    v.conf.PK,
+		SecKey:                    v.conf.SK,
+		DiscoveryClient:           tpdC,
+		LogStore:                  logS,
+		PersistentTransportsCache: ptps,
 	}
 	managerLogger := v.MasterLogger().PackageLogger("transport_manager")
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -286,7 +286,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	logS := transport.InMemoryTransportLogStore()
 
-	ptps, err := v.conf.GetPersistentTransports()
+	pTps, err := v.conf.GetPersistentTransports()
 	if err != nil {
 		err := fmt.Errorf("failed to get persistent transports: %w", err)
 		return err
@@ -297,7 +297,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		SecKey:                    v.conf.SK,
 		DiscoveryClient:           tpdC,
 		LogStore:                  logS,
-		PersistentTransportsCache: ptps,
+		PersistentTransportsCache: pTps,
 	}
 	managerLogger := v.MasterLogger().PackageLogger("transport_manager")
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -191,16 +191,16 @@ func (v1 *V1) UpdateMinHops(hops uint16) error {
 	return v1.flush(v1)
 }
 
-// UpdatePersistentTransports updates min_hops config
-func (v1 *V1) UpdatePersistentTransports(pts []transport.PersistentTransports) error {
+// UpdatePersistentTransports updates persistent_transports in config
+func (v1 *V1) UpdatePersistentTransports(ptps []transport.PersistentTransports) error {
 	v1.mu.Lock()
-	v1.PersistentTransports = pts
+	v1.PersistentTransports = ptps
 	v1.mu.Unlock()
 
 	return v1.flush(v1)
 }
 
-// GetPersistentTransports updates min_hops config
+// GetPersistentTransports gets persistent_transports from config
 func (v1 *V1) GetPersistentTransports() ([]transport.PersistentTransports, error) {
 	v1.mu.Lock()
 	defer v1.mu.Unlock()

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -192,9 +192,9 @@ func (v1 *V1) UpdateMinHops(hops uint16) error {
 }
 
 // UpdatePersistentTransports updates persistent_transports in config
-func (v1 *V1) UpdatePersistentTransports(ptps []transport.PersistentTransports) error {
+func (v1 *V1) UpdatePersistentTransports(pTps []transport.PersistentTransports) error {
 	v1.mu.Lock()
-	v1.PersistentTransports = ptps
+	v1.PersistentTransports = pTps
 	v1.mu.Unlock()
 
 	return v1.flush(v1)


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #	

 Changes:	
- Fixed `GetPersistentTransports` and `UpdatePersistentTransports` comments in `visorconfig`
- Fixed  cancel persistent transport issue

How to test this PR:
1. Build with UI `make build-ui; make move-built-frontend ; make build; make install`
2. Run visor `./skywire-visor skywire-config.json`
3. Add a persistent transport that is not working. Check logs for connection reattempts.
4. Click on the star on the greyed-out transport to remove it from persistent transports.
5. Check if the reconnect loop stops.