### PR TITLE
Fix/vpn panic

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -619,6 +619,12 @@ func (rg *RouteGroup) handleNetworkProbePacket(packet routing.Packet) error {
 }
 
 func (rg *RouteGroup) handleDataPacket(packet routing.Packet) error {
+	// not good fix
+	// defer func() {
+	// 	if x := recover(); x != nil {
+	// 		rg.logger.Errorf("run time panic: %v", x)
+	// 	}
+	// }()
 	rg.networkStats.AddBandwidthReceived(uint64(packet.Size()))
 
 	select {

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -632,7 +632,6 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) error {
 	case <-rg.closed:
 		return io.ErrClosedPipe
 	case rg.readCh <- packet.Payload():
-		rg.logger.Errorf("isRemoteClosed:", rg.isRemoteClosed())
 	}
 
 	return nil


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #885

 Changes:	
- Moved `remoteClosed` chan check from `select` to `if`.

How to test this PR:
1. Use the following services
```
dmsg_discovery: http://dmsg.discovery.skywire.cc
transport_discovery: http://transportt.skywire.cc
address_resolver: http://boom.skywire.cc
setup_node: 026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf
route_finder: http://rft.skywire.cc
uptime_tracker: http://uptime.tracker.skywire.cc
service_discovery: http://sdt.skywire.cc
```
2. Run `visorA` with a `vpn-server`
3. On `visorB` make a `dmsg` transport to `visorA`. Will have to make one via `cli` or `perisitent_transports` as UI needs to be rebuilt
- cli 
```
./skywire-cli visor add-tp <visor-a-pk> --type dmsg 
```
- perisitent_transports in config add
```json
"persistent_transports": [
		{
			"pk": "<visor-a-pk>",
			"type": "dmsg"
		}
],
```
4. Add pk of `visorA` to VPN client and start it.
5. Start a video in the background and stop the VPN client.
6. There should be no panic.
