### PR TITLE
Fix/shutdown race

### DIFF
--- a/pkg/app/appdisc/discovery_manager.go
+++ b/pkg/app/appdisc/discovery_manager.go
@@ -2,6 +2,7 @@ package appdisc
 
 import (
 	"context"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/servicedisc"
 )
@@ -24,7 +25,8 @@ func (emptyUpdater) Stop()  {}
 
 // serviceUpdater updates service-discovery entry of locally running App.
 type serviceUpdater struct {
-	client *servicedisc.HTTPClient
+	client   *servicedisc.HTTPClient
+	stopOnce sync.Once
 }
 
 func (u *serviceUpdater) Start() {
@@ -35,8 +37,10 @@ func (u *serviceUpdater) Start() {
 }
 
 func (u *serviceUpdater) Stop() {
-	ctx := context.Background()
-	if err := u.client.DeleteEntry(ctx); err != nil {
-		return
-	}
+	u.stopOnce.Do(func() {
+		ctx := context.Background()
+		if err := u.client.DeleteEntry(ctx); err != nil {
+			return
+		}
+	})
 }

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -45,7 +45,7 @@ type HTTPClient struct {
 	log     logrus.FieldLogger
 	conf    Config
 	entry   Service
-	entryMx sync.Mutex // only used if UpdateLoop && UpdateStats functions are used.
+	entryMx sync.Mutex // only used if RegisterEntry && DeleteEntry functions are used.
 	client  http.Client
 }
 

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -166,6 +166,7 @@ func (c *HTTPClient) RegisterEntry(ctx context.Context) error {
 		return err
 	}
 	c.entry = entry
+	c.log.WithField("entry", c.entry).Debug("Entry registered successfully")
 	return nil
 }
 
@@ -263,6 +264,7 @@ func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
 		}
 		return &hErr
 	}
+	c.log.WithField("entry", c.entry).Debug("Entry deleted successfully")
 	return nil
 }
 

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -226,6 +226,9 @@ func (c *HTTPClient) postEntry(ctx context.Context) (Service, error) {
 
 // DeleteEntry calls 'DELETE /api/services/{entry_addr}'.
 func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
+	c.entryMx.Lock()
+	defer c.entryMx.Unlock()
+
 	auth, err := c.Auth(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #890 	

 Changes:	
- Added mutex lock to `DeleteEntry` and updated mutex comment.
- Added `stopOnce` for `Stop()` in service updater to fix [this](https://github.com/SkycoinPro/skycoin-service-discovery/pull/67#issuecomment-928975237).
- Added debug logs to `DeleteEntry` and `RegisterEntry`.

How to test this PR:
1. Start the visor `./skywire-visor skywire-config.json`
2. Wait for the start to complete and close it with `Ctrl+C`
3. See if there is no datarace.