### PR TITLE
Fix the discovery service URL

### DIFF
--- a/static/skywire-manager-src/src/app/services/proxy-discovery.service.ts
+++ b/static/skywire-manager-src/src/app/services/proxy-discovery.service.ts
@@ -16,7 +16,7 @@ export class ProxyDiscoveryService {
   /**
    * URL of the discovery service.
    */
-  private readonly discoveryServiceUrl = 'https://service.discovery.skycoin.com/api/services?type=';
+  private readonly discoveryServiceUrl = 'https://sd.skycoin.com/api/services?type=';
 
   constructor(
     private http: HttpClient,


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- The discovery service URL used by the popup for configuring the skysocks and vpn apps was updated.

How to test this PR:
Use the Skywire manager for configuring the skysocks-client and vpn-client apps. With this PR, the “Search” tab of the modal window should not stay loading forever.