### PR TITLE
Feature/update config names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - changed proxy_discovery_addr field to service_discovery
 - updated UI
 - removed `--public` flag from `skywire-cli visor add-tp` command
+- replaced stcp field to skywire-tcp in config and comments
+- replaced local_address field to listening_address in config
+- replaced port field to dmsg_port in config
 
 ### Added
 

--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -80,7 +80,7 @@ var (
 func init() {
 	const (
 		typeFlagUsage = "type of transport to add; if unspecified, cli will attempt to establish a transport " +
-			"in the following order: stcp, stcpr, sudph, dmsg"
+			"in the following order: skywire-tcp, stcpr, sudph, dmsg"
 		publicFlagUsage  = "whether to make the transport public (deprecated)"
 		timeoutFlagUsage = "if specified, sets an operation timeout"
 	)

--- a/docs/stcp-setup.md
+++ b/docs/stcp-setup.md
@@ -1,6 +1,6 @@
-## `stcp` setup
+## `skywire-tcp` setup
 
-`stcp` allows establish *skywire transports* to other skywire visors over `tcp`. This transport is used mostly for testing. It requires substantial manual configuration but is more flexible than `stcpr` transport because it can be used between visors in the same network and does not require a connection to an external server. 
+`skywire-tcp` allows establish *skywire transports* to other skywire visors over `tcp`. This transport is used mostly for testing. It requires substantial manual configuration but is more flexible than `stcpr` transport because it can be used between visors in the same network and does not require a connection to an external server. 
 
 As visors are identified with PubKeys rather than IP addresses, 
 we need to directly map their IP address and PubKeys. 
@@ -8,17 +8,17 @@ This is done in the configuration file for `skywire-visor`.
 
 ```json
 {
-  "stcp": {
+  "skywire-tcp": {
     "pk_table": {
       "024a2dd77de324d543561a6d9e62791723be26ddf6b9587060a10b9ba498e096f1": "127.0.0.1:7031",
       "0327396b1241a650163d5bc72a7970f6dfbcca3f3d67ab3b15be9fa5c8da532c08": "127.0.0.1:7032"
     },
-    "local_address": "127.0.0.1:7033"
+    "listening_address": "127.0.0.1:7033"
   }
 }
 ```
 
-In the above example, we have two other visors running on localhost (that we wish to connect to via `stcp`).
-- The field `stcp.pk_table` holds the associations of `<public_key>` to `<ip_address>:<port>`.
-- The field `stcp.local_address` should only be specified if you want the visor in question to listen for incoming 
-`stcp` connection.
+In the above example, we have two other visors running on localhost (that we wish to connect to via `skywire-tcp`).
+- The field `skywire-tcp.pk_table` holds the associations of `<public_key>` to `<ip_address>:<port>`.
+- The field `skywire-tcp.listening_address` should only be specified if you want the visor in question to listen for incoming 
+`skywire-tcp` connection.

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -86,7 +86,7 @@ func NewClient(cfg ClientConfig, appCl *app.Client) (*Client, error) {
 
 	stcpEntities, err := stcpEntitiesFromEnv()
 	if err != nil {
-		return nil, fmt.Errorf("error getting STCP entities: %w", err)
+		return nil, fmt.Errorf("error getting Skywire-TCP entities: %w", err)
 	}
 
 	tpRemoteIPs, err := tpRemoteIPsFromEnv()
@@ -612,7 +612,7 @@ func stcpEntitiesFromEnv() ([]net.IP, error) {
 	if stcpTableLenStr != "" {
 		stcpTableLen, err := strconv.Atoi(stcpTableLenStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid STCP table len: %s: %w", stcpTableLenStr, err)
+			return nil, fmt.Errorf("invalid Skywire-TCP table len: %s: %w", stcpTableLenStr, err)
 		}
 
 		stcpEntities = make([]net.IP, 0, stcpTableLen)
@@ -624,7 +624,7 @@ func stcpEntitiesFromEnv() ([]net.IP, error) {
 
 			stcpAddr, err := ipFromEnv(STCPValueEnvPrefix + stcpKey)
 			if err != nil {
-				return nil, fmt.Errorf("error getting STCP entity IP: %w", err)
+				return nil, fmt.Errorf("error getting Skywire-TCP entity IP: %w", err)
 			}
 
 			stcpEntities = append(stcpEntities, stcpAddr)

--- a/internal/vpn/env.go
+++ b/internal/vpn/env.go
@@ -30,9 +30,9 @@ const (
 
 	// STCPTableLenEnvKey is env arg holding Stcp table length.
 	STCPTableLenEnvKey = "STCP_TABLE_LEN"
-	// STCPKeyEnvPrefix is prefix for each env arg holding STCP entity key.
+	// STCPKeyEnvPrefix is prefix for each env arg holding Skywire-TCP entity key.
 	STCPKeyEnvPrefix = "STCP_TABLE_KEY_"
-	// STCPValueEnvPrefix is prefix for each env arg holding STCP entity value.
+	// STCPValueEnvPrefix is prefix for each env arg holding Skywire-TCP entity value.
 	STCPValueEnvPrefix = "STCP_TABLE_"
 
 	// TPRemoteIPsLenEnvKey is env arg holding TP remote IPs length.

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -66,7 +66,7 @@ const (
 	DefaultDmsgPtyCLIAddr        = "/tmp/dmsgpty.sock"
 )
 
-// Default STCP constants.
+// Default Skywire-TCP constants.
 const (
 	DefaultSTCPAddr = ":7777"
 )

--- a/pkg/transport/network/stcp.go
+++ b/pkg/transport/network/stcp.go
@@ -11,10 +11,10 @@ import (
 	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 )
 
-// STCPConfig defines config for STCP network.
+// STCPConfig defines config for Skywire-TCP network.
 type STCPConfig struct {
-	PKTable   map[cipher.PubKey]string `json:"pk_table"`
-	LocalAddr string                   `json:"local_address"`
+	PKTable          map[cipher.PubKey]string `json:"pk_table"`
+	ListeningAddress string                   `json:"listening_address"`
 }
 
 type stcpClient struct {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -316,7 +316,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	var listenAddr string
 	if v.conf.STCP != nil {
 		table = stcp.NewTable(v.conf.STCP.PKTable)
-		listenAddr = v.conf.STCP.LocalAddr
+		listenAddr = v.conf.STCP.ListeningAddress
 	}
 	factory := network.ClientFactory{
 		PK:         v.conf.PK,

--- a/pkg/visor/init_unix.go
+++ b/pkg/visor/init_unix.go
@@ -55,7 +55,7 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	pty := dmsgpty.NewHost(dmsgC, wl)
 
-	if ptyPort := conf.Port; ptyPort != 0 {
+	if ptyPort := conf.DmsgPort; ptyPort != 0 {
 		serveCtx, cancel := context.WithCancel(context.Background())
 		wg := new(sync.WaitGroup)
 		wg.Add(1)

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -73,9 +73,9 @@ func defaultConfigFromCommon(cc *Common, hypervisor bool) (*V1, error) {
 	conf := MakeBaseConfig(cc)
 
 	conf.Dmsgpty = &V1Dmsgpty{
-		Port:    skyenv.DmsgPtyPort,
-		CLINet:  skyenv.DefaultDmsgPtyCLINet,
-		CLIAddr: skyenv.DefaultDmsgPtyCLIAddr,
+		DmsgPort: skyenv.DmsgPtyPort,
+		CLINet:   skyenv.DefaultDmsgPtyCLINet,
+		CLIAddr:  skyenv.DefaultDmsgPtyCLIAddr,
 	}
 
 	conf.STCP = &network.STCPConfig{

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -79,8 +79,8 @@ func defaultConfigFromCommon(cc *Common, hypervisor bool) (*V1, error) {
 	}
 
 	conf.STCP = &network.STCPConfig{
-		LocalAddr: skyenv.DefaultSTCPAddr,
-		PKTable:   nil,
+		ListeningAddress: skyenv.DefaultSTCPAddr,
+		PKTable:          nil,
 	}
 
 	conf.UptimeTracker = &V1UptimeTracker{
@@ -150,9 +150,9 @@ func MakePackageConfig(log *logging.MasterLogger, confPath string, sk *cipher.Se
 	}
 
 	conf.Dmsgpty = &V1Dmsgpty{
-		Port:    skyenv.DmsgPtyPort,
-		CLINet:  skyenv.DefaultDmsgPtyCLINet,
-		CLIAddr: skyenv.DefaultDmsgPtyCLIAddr,
+		DmsgPort: skyenv.DmsgPtyPort,
+		CLINet:   skyenv.DefaultDmsgPtyCLINet,
+		CLIAddr:  skyenv.DefaultDmsgPtyCLIAddr,
 	}
 	conf.LocalPath = skyenv.PackageAppLocalPath()
 	conf.Launcher.BinPath = skyenv.PackageAppBinPath()
@@ -176,9 +176,9 @@ func MakeSkybianConfig(log *logging.MasterLogger, confPath string, sk *cipher.Se
 	}
 
 	conf.Dmsgpty = &V1Dmsgpty{
-		Port:    skyenv.DmsgPtyPort,
-		CLINet:  skyenv.DefaultDmsgPtyCLINet,
-		CLIAddr: skyenv.SkybianDmsgPtyCLIAddr,
+		DmsgPort: skyenv.DmsgPtyPort,
+		CLINet:   skyenv.DefaultDmsgPtyCLINet,
+		CLIAddr:  skyenv.SkybianDmsgPtyCLIAddr,
 	}
 	conf.LocalPath = skyenv.SkybianLocalPath
 	conf.Launcher.BinPath = skyenv.SkybianAppBinPath

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -47,7 +47,7 @@ type V1 struct {
 
 	Dmsg          *dmsgc.DmsgConfig   `json:"dmsg"`
 	Dmsgpty       *V1Dmsgpty          `json:"dmsgpty,omitempty"`
-	STCP          *network.STCPConfig `json:"stcp,omitempty"`
+	STCP          *network.STCPConfig `json:"skywire-tcp,omitempty"`
 	Transport     *V1Transport        `json:"transport"`
 	Routing       *V1Routing          `json:"routing"`
 	UptimeTracker *V1UptimeTracker    `json:"uptime_tracker,omitempty"`
@@ -70,9 +70,9 @@ type V1 struct {
 
 // V1Dmsgpty configures the dmsgpty-host.
 type V1Dmsgpty struct {
-	Port    uint16 `json:"port"`
-	CLINet  string `json:"cli_network"`
-	CLIAddr string `json:"cli_address"`
+	DmsgPort uint16 `json:"dmsg_port"`
+	CLINet   string `json:"cli_network"`
+	CLIAddr  string `json:"cli_address"`
 }
 
 // V1Transport defines a transport config.

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -35,6 +35,9 @@ const V101Name = "v1.0.1"
 // Added persistent_transports field to the config
 // Changed proxy_discovery_addr field to service_discovery
 // Changed V1AppDisc struct to V1ServiceDisc
+// Changed stcp field to skywire-tcp
+// Changed local_address field to listening_address
+// Changed port field in dmsgpty to dmsg_port
 const V110Name = "v1.1.0"
 
 // V1Name is the semantic version string for the most recent version of V1.


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #386 

 Changes:	
- Changed `stcp` field to `skywire-tcp`
- Changed `local_address` field to `listening_address`
- Changed `port` field in dmsgpty to `dmsg_port`

How to test this PR:
1. Checkout to `master` and run `make build`
2. Run `./skywire-cli visor gen-config --is-hyperviosr`
3. Checkout to this PR and run `make build`
4. Run `./skywire-cli visor gen-config -r --is-hyperviosr`