### PR TITLE
Add stcpr dependency to PublicVisor

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -260,7 +260,7 @@ func (tm *Manager) Networks() []network.Type {
 
 // Stcpr returns stcpr client
 func (tm *Manager) Stcpr() (network.Client, bool) {
-	c, ok := tm.netClients[network.STCP]
+	c, ok := tm.netClients[network.STCPR]
 	return c, ok
 }
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -130,7 +130,7 @@ func registerModules(logger *logging.MasterLogger) {
 	cli = maker("cli", initCLI)
 	hvs = maker("hypervisors", initHypervisors, &dmsgC)
 	ut = maker("uptime_tracker", initUptimeTracker)
-	pv = maker("public_visors", initPublicVisors, &tr)
+	pv = maker("public_autoconnect", initPublicAutoconnect, &tr)
 	trs = maker("transport_setup", initTransportSetup, &dmsgC, &tr)
 	tm = vinit.MakeModule("transports", vinit.DoNothing, logger, &sc, &sudphC, &dmsgCtrl)
 	pvs = maker("public_visor", initPublicVisor, &tr, &ar, &disc, &stcprC)
@@ -666,7 +666,7 @@ func initPublicVisor(_ context.Context, v *Visor, log *logging.Logger) error {
 	return nil
 }
 
-func initPublicVisors(ctx context.Context, v *Visor, log *logging.Logger) error {
+func initPublicAutoconnect(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if !v.conf.Transport.PublicAutoconnect {
 		return nil
 	}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -133,7 +133,7 @@ func registerModules(logger *logging.MasterLogger) {
 	pv = maker("public_visors", initPublicVisors, &tr)
 	trs = maker("transport_setup", initTransportSetup, &dmsgC, &tr)
 	tm = vinit.MakeModule("transports", vinit.DoNothing, logger, &sc, &sudphC, &dmsgCtrl)
-	pvs = maker("public_visor", initPublicVisor, &tr, &ar, &disc)
+	pvs = maker("public_visor", initPublicVisor, &tr, &ar, &disc, &stcprC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &up, &ebc, &ar, &disc, &pty,
 		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC)
 


### PR DESCRIPTION
The commit commit contains addition to the dependency of the PublicVisor module. StcprClient is added as a dependency.

Did you run `make format && make check`?

Fixes #	

 Changes:	
-	

How to test this PR:
