### PR TITLE
Add RPC func

### DIFF
--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -527,9 +527,30 @@ func (r *RPC) RuntimeLogs(_ *struct{}, logs *string) (err error) {
 	return
 }
 
-// SetMinHops sets min_hops from visor's routing config
+// SetMinHops sets min_hops in visor's routing config
 func (r *RPC) SetMinHops(n *uint16, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "SetMinHops", *n)
 	err = r.visor.SetMinHops(*n)
 	return
+}
+
+// GetPersistentTransports gets persistent_transports from visor's routing config
+func (r *RPC) GetPersistentTransports(n *uint16, _ *struct{}) (pTs []transport.PersistentTransports, err error) {
+	defer rpcutil.LogCall(r.log, "GetPersistentTransports", *n)
+	pTs, err = r.visor.GetPersistentTransports()
+	return pTs, err
+}
+
+// SetPersistentTransports sets persistent_transports in visor's routing config
+func (r *RPC) SetPersistentTransports(pTs *[]transport.PersistentTransports, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetPersistentTransports", *pTs)
+	err = r.visor.SetPersistentTransports(*pTs)
+	return err
+}
+
+// SetPublicAutoconnect sets public_autoconnect in visor's routing config
+func (r *RPC) SetPublicAutoconnect(pAc *bool, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetPublicAutoconnect", *pAc)
+	err = r.visor.SetPublicAutoconnect(*pAc)
+	return err
 }


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes [#issue-mentioned-here](https://github.com/skycoin/skywire/pull/924)

 Changes:	
- Added `GetPersistentTransports`, `SetPersistentTransports`, `SetPublicAutoconnect` in `RPC`

How to test this PR:
1. Start Integration env from `skywire-services`
2. Open Hypervisor B's UI `https://localhost:8000/#/nodes/list/1`
3. Make a persistent transport from Visor A to Visor B
4. Change Public Autoconnect of visor A