### PR TITLE
Fix goreleaser

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,7 @@ for:
         - job_name: MacOS
 
     install:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
       - make dep
       - sh: ci_scripts/create-ip-aliases.sh
       - make install-deps-ui

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/skywire-visor/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
 
   - id: skywire-cli
     binary: skywire-cli
@@ -55,7 +55,8 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/skywire-cli/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} 
+
   - id: skychat
     binary: apps/skychat
     goos:
@@ -75,7 +76,8 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skychat/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
+
   - id: skysocks
     binary: apps/skysocks
     goos:
@@ -95,7 +97,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skysocks/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
   - id: skysocks-client
     binary: apps/skysocks-client
     goos:
@@ -115,7 +117,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skysocks-client/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
   - id: vpn-server
     binary: apps/vpn-server
     goos:
@@ -135,7 +137,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/vpn-server/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
   - id: vpn-client
     binary: apps/vpn-client
     goos:
@@ -155,7 +157,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/vpn-client/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
 archives:
   - format: tar.gz
     wrap_in_directory: false

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ format: tidy ## Formats the code. Must have goimports and goimports-reviser inst
 	${OPTS} goimports -w -local ${PROJECT_BASE} ./pkg
 	${OPTS} goimports -w -local ${PROJECT_BASE} ./cmd
 	${OPTS} goimports -w -local ${PROJECT_BASE} ./internal
-	find . -type f -name '*.go' -not -path "./vendor/*"  -exec goimports-reviser -project-name ${PROJECT_BASE} -file-path {} \;
+	find . -type f -name '*.go' -not -path "./.git/*" -not -path "./vendor/*"  -exec goimports-reviser -project-name ${PROJECT_BASE} -file-path {} \;
 
 dep: tidy ## Sorts dependencies
 	${OPTS} go mod vendor -v


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes the goreleaser.yml and the `make format` target

 Changes:	
- add `-X` flag to `skywire-visor` build flags in goreleaser.yml
- remove Skybian build tag from all other binaries built via goreleaser
- fix `find` command which executes goimports reviser in `make format`

How to test this PR:
- run `make format`
- run `make snapshot`

Both should run. 