### PR TITLE
Fix cli ls-apps

### DIFF
--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -41,6 +41,9 @@ var lsAppsCmd = &cobra.Command{
 			if state.Status == launcher.AppStatusRunning {
 				status = "running"
 			}
+			if state.Status == launcher.AppStatusErrored {
+				status = "errored"
+			}
 			_, err = fmt.Fprintf(w, "%s\t%s\t%t\t%s\n", state.Name, strconv.Itoa(int(state.Port)), state.AutoStart, status)
 			internal.Catch(err)
 		}


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #	

 Changes:	
- Added `errored` status for `skywire-cli visor ls-apps`.	

How to test this PR:
1. Start visor `./skywire-visor skywire-config.json`
2. Connect to a VPN server that is not working / is offline.
3. Run `./skywire-cli visor ls-apps` on a new terminal