### PR TITLE
Update goreleaser.yml to build only armv6

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -48,7 +47,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -69,7 +67,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -90,7 +87,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -110,7 +106,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -130,7 +125,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -150,7 +144,6 @@ builds:
       - arm
     goarm:
       - 6
-      - 7
     ignore:
       - goos: darwin
         goarch: 386
@@ -161,7 +154,7 @@ builds:
 archives:
   - format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes issue with updating discovered in discussion.

 Changes:	
Removed build targets for armv7 in goreleaser.yml. Our inubilt updater
does not distinguish between armv6 and armv7 and always tries to fetch
`linux-arm.tar.gz` archive. In order to make both armv6 and armv7 update
suceed, we ship the former to both via the `linux-arm.tar.gz package.

How to test this PR:

Update from Skybian board with current version of Skywire `v0.4.x` to pre-release. Check logs to see whether it works. 