### PR TITLE
Health endpoint: 3 states => connecting, healthy, and unhealthy

### DIFF
--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -640,7 +640,7 @@ func (mc *mockRPCClient) Summary() (*Summary, error) {
 // Health implements API
 func (mc *mockRPCClient) Health() (*HealthInfo, error) {
 	hi := &HealthInfo{
-		ServicesHealth: true,
+		ServicesHealth: "healthy",
 	}
 
 	return hi, nil

--- a/pkg/visor/rpc_test.go
+++ b/pkg/visor/rpc_test.go
@@ -46,6 +46,7 @@ func TestHealth(t *testing.T) {
 			uptimeTracker:     utClient,
 			isServicesHealthy: newInternalHealthInfo(),
 		}
+		v.isServicesHealthy.init()
 
 		rpc := &RPC{visor: v, log: logrus.New()}
 		// mock initUptimeTracker
@@ -54,10 +55,10 @@ func TestHealth(t *testing.T) {
 		err := rpc.Health(nil, h)
 		require.NoError(t, err)
 
-		assert.Equal(t, true, h.ServicesHealth)
+		assert.Equal(t, "healthy", h.ServicesHealth)
 	})
 
-	t.Run("Report as unavailable", func(t *testing.T) {
+	t.Run("Report as connecting", func(t *testing.T) {
 		c := baseConfig(t)
 		c.Routing = &visorconfig.V1Routing{}
 
@@ -69,13 +70,15 @@ func TestHealth(t *testing.T) {
 			isServicesHealthy: newInternalHealthInfo(),
 		}
 
+		v.isServicesHealthy.init()
 		rpc := &RPC{visor: v, log: logrus.New()}
 		h := &HealthInfo{}
 		err := rpc.Health(nil, h)
 		require.NoError(t, err)
 
-		assert.Equal(t, false, h.ServicesHealth)
+		assert.Equal(t, "connecting", h.ServicesHealth)
 	})
+
 }
 
 func TestUptime(t *testing.T) {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -106,7 +106,7 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 		isServicesHealthy: newInternalHealthInfo(),
 	}
 
-	v.isServicesHealthy.unset()
+	v.isServicesHealthy.init()
 
 	if logLvl, err := logging.LevelFromString(conf.LogLevel); err != nil {
 		v.log.WithError(err).Warn("Failed to read log level from config.")


### PR DESCRIPTION
Did you run `make format && make check`? yes

Fixes #

 Changes:	
- On initialize, the visor will return "connecting" as its health status.
- On failure updating visor uptime, it will return "unhealthy"
- On success, it will return "healthy"

How to test this PR:

- Run visor
- `curl -sL http://localhost:8000/api/visors/<PK>/summary | jq -r .health`