### PR TITLE
Change test config URLs

### DIFF
--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -35,12 +35,12 @@ const (
 
 // Constants for testing deployment.
 const (
-	TestTpDiscAddr          = "http://transport.discovery.skywire.cc"
-	TestDmsgDiscAddr        = "http://dmsg.discovery.skywire.cc"
-	TestServiceDiscAddr     = "http://service.discovery.skywire.cc"
-	TestRouteFinderAddr     = "http://routefinder.skywire.cc"
-	TestUptimeTrackerAddr   = "http://uptime.tracker.skywire.cc"
-	TestAddressResolverAddr = "http://address.resolver.skywire.cc"
+	TestTpDiscAddr          = "http://tpd.skywire.dev/"
+	TestDmsgDiscAddr        = "http://dmsgd.skywire.dev/"
+	TestServiceDiscAddr     = "http://sd.skywire.dev/"
+	TestRouteFinderAddr     = "http://rf.skywire.dev/"
+	TestUptimeTrackerAddr   = "http://ut.skywire.dev/"
+	TestAddressResolverAddr = "http://ar.skywire.dev/"
 	TestSetupPK             = "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
 )
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #937 

 Changes:	
- Replace new URLs for test config generator

How to test this PR:
- use `skywire-cli config gen -t` to see new `http://*.skywire.dev/` URLs.
