### PR TITLE
fix app stopping error status

### DIFF
--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -191,8 +191,10 @@ func (l *Launcher) AppStates() []*AppState {
 	for _, app := range l.apps {
 		state := &AppState{AppConfig: app, Status: AppStatusStopped}
 		if err, ok := l.procM.ErrorByName(app.Name); ok {
-			state.DetailedStatus = err
-			state.Status = AppStatusErrored
+			if err != "" {
+				state.DetailedStatus = err
+				state.Status = AppStatusErrored
+			}
 		}
 		if proc, ok := l.procM.ProcByName(app.Name); ok {
 			state.DetailedStatus = proc.DetailedStatus()


### PR DESCRIPTION
Did you run `make format && make check`? yes

Fixes #942 , #943

 Changes:	
- Fixes error when vpn-client is closed normally

How to test this PR:
- Start vpn-client normally
- Stop it normally as well.
- See #942 for details on how to run it. It shouldn't return `2` if there are no errors anymore