### PR TITLE
Make the updater work with problematic visors

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.html
@@ -50,6 +50,21 @@
       {{ 'update.update-instructions' | translate }}
     </div>
   </ng-container>
+  <!-- List with the nodes with errors during the initial check, shown while asking for confirmation and when there are no updates. -->
+  <ng-container *ngIf="(state === updatingStates.Asking || state === updatingStates.NoUpdatesFound) && nodesWithError.length > 0">
+    <div style="height: 10px;"></div>
+    <div class="text-container">
+      {{ 'update.with-error' | translate }}
+    </div>
+    <div class="list-container">
+      <div *ngFor="let node of nodesWithError" class="list-element">
+        <div class="left-part">-</div>
+        <div class="right-part">
+          {{ node.nodeLabel }}: <span class="red-text">{{ node.errorMsg | translate }}</span>
+        </div>
+      </div>
+    </div>
+  </ng-container>
 
   <!-- Content shown while updating. -->
   <ng-container *ngIf="state === updatingStates.Updating">

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -299,6 +299,7 @@
     "no-update": "There is no update for the visor. The currently installed version is:",
     "no-updates": "No new updates were found.",
     "already-updating": "Some visors are already being updated:",
+    "with-error": "It was not possible to check the following visors:",
     "update-available": "The following updates were found:",
     "update-available-singular": "The following updates for 1 visor were found:",
     "update-available-plural": "The following updates for {{ number }} visors were found:",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -303,6 +303,7 @@
     "no-update": "No hay ninguna actualización para el visor. La versión instalada actualmente es:",
     "no-updates": "No se encontraron nuevas actualizaciones.",
     "already-updating": "Algunos visores ya están siendo actualizandos:",
+    "with-error": "No fue posible verificar los siguientes visores:",
     "update-available": "Las siguientes actualizaciones fueron encontradas:",
     "update-available-singular": "Las siguientes actualizaciones para 1 visor fueron encontradas:",
     "update-available-plural": "Las siguientes actualizaciones para {{ number }} visores fueron encontradas:",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -303,6 +303,7 @@
     "no-update": "There is no update for the visor. The currently installed version is:",
     "no-updates": "No new updates were found.",
     "already-updating": "Some visors are already being updated:",
+    "with-error": "It was not possible to check the following visors:",
     "update-available": "The following updates were found:",
     "update-available-singular": "The following updates for 1 visor were found:",
     "update-available-plural": "The following updates for {{ number }} visors were found:",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the updater continues working if there is a connection problem with a visor.

How to test this PR:
For testing, you need a visor appearing as online in the visor list but with connection problems with the hypervisor. Having a visor like that, you just have to open the updater modal window using the option for updating all the visors. It will show that there was a problem checking that wisor, but will continue working.
