### PR TITLE
fixes trailing slash issue

### DIFF
--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -35,12 +35,12 @@ const (
 
 // Constants for testing deployment.
 const (
-	TestTpDiscAddr          = "http://tpd.skywire.dev/"
-	TestDmsgDiscAddr        = "http://dmsgd.skywire.dev/"
-	TestServiceDiscAddr     = "http://sd.skywire.dev/"
-	TestRouteFinderAddr     = "http://rf.skywire.dev/"
-	TestUptimeTrackerAddr   = "http://ut.skywire.dev/"
-	TestAddressResolverAddr = "http://ar.skywire.dev/"
+	TestTpDiscAddr          = "http://tpd.skywire.dev"
+	TestDmsgDiscAddr        = "http://dmsgd.skywire.dev"
+	TestServiceDiscAddr     = "http://sd.skywire.dev"
+	TestRouteFinderAddr     = "http://rf.skywire.dev"
+	TestUptimeTrackerAddr   = "http://ut.skywire.dev"
+	TestAddressResolverAddr = "http://ar.skywire.dev"
 	TestSetupPK             = "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
 )
 


### PR DESCRIPTION
Did you run `make format && make check`? yes

Fixes cannot connect to dmsg network on test environment

 Changes:	
- Removed trailing slash from test env urls

How to test this PR:

- run visor
- check that `dmsgC` log is able to connect.