### PR TITLE
Add the build tag to the UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -17,6 +17,7 @@ export class Node {
   dmsgServerPk?: string;
   roundTripPing?: string;
   isHypervisor?: boolean;
+  buildTag: string;
   skybianBuildVersion?: string;
   autoconnectTransports: boolean;
 }

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -38,8 +38,12 @@
       {{ node.version ? node.version : ('common.unknown' | translate) }}
     </span>
     <span class="info-line">
+      <span class="title">{{ 'node.details.node-info.build-type' | translate }}</span>
+      {{ node.buildTag ? node.buildTag : ('node.details.node-info.unknown-build' | translate) }}
+    </span>
+    <span class="info-line" *ngIf="node.skybianBuildVersion">
       <span class="title">{{ 'node.details.node-info.skybian-version' | translate }}</span>
-      {{ node.skybianBuildVersion ? node.skybianBuildVersion : ('node.details.node-info.no-skybian-version' | translate) }}
+      {{ node.skybianBuildVersion }}
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.time.title' | translate }}</span>

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -586,6 +586,7 @@ export class NodeService {
         node.version = response.overview.build_info.version;
         node.secondsOnline = Math.floor(Number.parseFloat(response.uptime));
         node.minHops = response.min_hops;
+        node.buildTag = response.build_tag;
         node.skybianBuildVersion = response.skybian_build_version;
         node.isSymmeticNat = response.overview.is_symmetic_nat;
         node.publicIp = response.overview.public_ip;

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -108,8 +108,9 @@
         "dmsg-server": "DMSG server:",
         "ping": "Ping:",
         "node-version": "Visor version:",
+        "build-type": "Build type:",
         "skybian-version": "Skybian version:",
-        "no-skybian-version": "(not using Skybian)",
+        "unknown-build": "Unknown",
         "time": {
           "title": "Time online:",
           "seconds": "a few seconds",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -108,8 +108,9 @@
         "dmsg-server": "Servidor DMSG:",
         "ping": "Ping:",
         "node-version": "Versión del visor:",
+        "build-type": "Tipo de build:",
         "skybian-version": "Versión de Skybian:",
-        "no-skybian-version": "(no se usa Skybian)",
+        "unknown-build": "Desconocido",
         "time": {
           "title": "Tiempo online:",
           "seconds": "unos segundos",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -108,8 +108,9 @@
         "dmsg-server": "DMSG server:",
         "ping": "Ping:",
         "node-version": "Visor version:",
+        "build-type": "Build type:",
         "skybian-version": "Skybian version:",
-        "no-skybian-version": "(not using Skybian)",
+        "unknown-build": "Unknown",
         "time": {
           "title": "Time online:",
           "seconds": "a few seconds",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #958

 Changes:	
- Now the UI shows the build tag in the info bar.
![_1](https://user-images.githubusercontent.com/34079003/138784393-f20a9264-f167-4c0e-aec1-809cedc86731.jpg)
- Now if the API does not return the `skybian_build_version` param, the Skybian version field is removed, insted of showing `not using Skybian`.
![_2](https://user-images.githubusercontent.com/34079003/138784413-0c674468-70ea-4c87-9995-fb078210b753.jpg)

How to test this PR:
Open the visor details page in the Skywire manager and check the data at the right.