### PR TITLE
Fix skywire verson in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/skywire-visor/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag=skybian
 
   - id: skywire-cli
     binary: skywire-cli
@@ -53,7 +53,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/skywire-cli/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} 
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}} 
 
   - id: skychat
     binary: apps/skychat
@@ -73,7 +73,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skychat/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
 
   - id: skysocks
     binary: apps/skysocks
@@ -93,7 +93,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skysocks/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
   - id: skysocks-client
     binary: apps/skysocks-client
     goos:
@@ -112,7 +112,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/skysocks-client/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
   - id: vpn-server
     binary: apps/vpn-server
     goos:
@@ -131,7 +131,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/vpn-server/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
   - id: vpn-client
     binary: apps/vpn-client
     goos:
@@ -150,7 +150,7 @@ builds:
     env:
       - CGO_ENABLED=0
     main: ./cmd/apps/vpn-client/
-    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version={{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
+    ldflags: -s -w -X github.com/skycoin/dmsg/buildinfo.version=v{{.Version}} -X github.com/skycoin/dmsg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/dmsg/buildinfo.date={{.Date}}
 archives:
   - format: tar.gz
     wrap_in_directory: false


### PR DESCRIPTION
Did you run `make format && make check`?
Yes 

Fixes #961 	

 Changes:	
- Added `v` before the Version in the `ldflags` flags

How to test this PR:
