### PR TITLE
Add Debug log and fix retrier log

### DIFF
--- a/cmd/apps/skychat/chat.go
+++ b/cmd/apps/skychat/chat.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/skycoin/dmsg/buildinfo"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/internal/netutil"
 	"github.com/skycoin/skywire/pkg/app"
@@ -29,8 +30,9 @@ const (
 	port    = routing.Port(1)
 )
 
+var log = logging.MustGetLogger("chat")
 var addr = flag.String("addr", ":8001", "address to bind")
-var r = netutil.NewRetrier(50*time.Millisecond, 5, 2)
+var r = netutil.NewRetrier(50*time.Millisecond, 5, 2, log)
 
 var (
 	appC     *app.Client

--- a/cmd/apps/skysocks-client/skysocks-client.go
+++ b/cmd/apps/skysocks-client/skysocks-client.go
@@ -29,7 +29,7 @@ const (
 
 var log = logrus.New()
 
-var r = netutil.NewRetrier(time.Second, 0, 1)
+var r = netutil.NewRetrier(time.Second, 0, 1, nil)
 
 func dialServer(appCl *app.Client, pk cipher.PubKey) (net.Conn, error) {
 	var conn net.Conn

--- a/cmd/apps/skysocks-client/skysocks-client.go
+++ b/cmd/apps/skysocks-client/skysocks-client.go
@@ -29,7 +29,7 @@ const (
 
 var log = logrus.New()
 
-var r = netutil.NewRetrier(time.Second, 0, 1, nil)
+var r = netutil.NewRetrier(time.Second, 0, 1, log)
 
 func dialServer(appCl *app.Client, pk cipher.PubKey) (net.Conn, error) {
 	var conn net.Conn

--- a/internal/netutil/retrier.go
+++ b/internal/netutil/retrier.go
@@ -12,8 +12,6 @@ var (
 	ErrMaximumRetriesReached = errors.New("maximum retries attempted without success")
 )
 
-var log = logging.MustGetLogger("retrier")
-
 // RetryFunc is a function used as argument of (*Retrier).Do(), which will retry on error unless it is whitelisted
 type RetryFunc func() error
 
@@ -23,15 +21,18 @@ type Retrier struct {
 	exponentialFactor  uint32        // multiplier for the backoff duration that is applied on every retry
 	times              uint32        // number of times that the given function is going to be retried until success, if 0 it will be retried forever until success
 	errWhitelist       map[error]struct{}
+	log                *logging.Logger
 }
 
 // NewRetrier returns a retrier that is ready to call Do() method
-func NewRetrier(exponentialBackoff time.Duration, times, factor uint32) *Retrier {
+func NewRetrier(exponentialBackoff time.Duration, times, factor uint32, log *logging.Logger) *Retrier {
+	log = logging.MustGetLogger("retrier")
 	return &Retrier{
 		exponentialBackoff: exponentialBackoff,
 		times:              times,
 		exponentialFactor:  factor,
 		errWhitelist:       make(map[error]struct{}),
+		log:                log,
 	}
 }
 
@@ -67,8 +68,8 @@ func (r Retrier) retryNTimes(f RetryFunc) error {
 				return err
 			}
 
-			log.Warn(err)
-			log.Warn("zzzzzzzzzzzzzzzzzzzzzzzzz")
+			r.log.Warn(err)
+			r.log.Warn("zzzzzzzzzzzzzzzzzzzzzzzzz")
 			currentBackoff *= time.Duration(r.exponentialFactor)
 			time.Sleep(currentBackoff)
 			continue
@@ -90,8 +91,8 @@ func (r Retrier) retryUntilSuccess(f RetryFunc) error {
 				return err
 			}
 
-			log.Warn(err)
-			log.Warn("dddddddddddddddddddddddddd")
+			r.log.Warn(err)
+			r.log.Warn("dddddddddddddddddddddddddd")
 			currentBackoff *= time.Duration(r.exponentialFactor)
 			time.Sleep(currentBackoff)
 			continue

--- a/internal/netutil/retrier.go
+++ b/internal/netutil/retrier.go
@@ -26,6 +26,7 @@ type Retrier struct {
 
 // NewRetrier returns a retrier that is ready to call Do() method
 func NewRetrier(exponentialBackoff time.Duration, times, factor uint32, log *logging.Logger) *Retrier {
+	log.WithField("func", "retrier")
 	return &Retrier{
 		exponentialBackoff: exponentialBackoff,
 		times:              times,

--- a/internal/netutil/retrier.go
+++ b/internal/netutil/retrier.go
@@ -26,7 +26,6 @@ type Retrier struct {
 
 // NewRetrier returns a retrier that is ready to call Do() method
 func NewRetrier(exponentialBackoff time.Duration, times, factor uint32, log *logging.Logger) *Retrier {
-	log = logging.MustGetLogger("retrier")
 	return &Retrier{
 		exponentialBackoff: exponentialBackoff,
 		times:              times,

--- a/internal/netutil/retrier.go
+++ b/internal/netutil/retrier.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 // Package errors
@@ -22,11 +21,11 @@ type Retrier struct {
 	exponentialFactor  uint32        // multiplier for the backoff duration that is applied on every retry
 	times              uint32        // number of times that the given function is going to be retried until success, if 0 it will be retried forever until success
 	errWhitelist       map[error]struct{}
-	log                *logrus.Entry
+	log                logrus.FieldLogger
 }
 
 // NewRetrier returns a retrier that is ready to call Do() method
-func NewRetrier(exponentialBackoff time.Duration, times, factor uint32, log *logging.Logger) *Retrier {
+func NewRetrier(exponentialBackoff time.Duration, times, factor uint32, log logrus.FieldLogger) *Retrier {
 	logger := log.WithField("func", "retrier")
 	return &Retrier{
 		exponentialBackoff: exponentialBackoff,

--- a/internal/netutil/retrier.go
+++ b/internal/netutil/retrier.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skycoin/src/util/logging"
 )
 
@@ -21,18 +22,18 @@ type Retrier struct {
 	exponentialFactor  uint32        // multiplier for the backoff duration that is applied on every retry
 	times              uint32        // number of times that the given function is going to be retried until success, if 0 it will be retried forever until success
 	errWhitelist       map[error]struct{}
-	log                *logging.Logger
+	log                *logrus.Entry
 }
 
 // NewRetrier returns a retrier that is ready to call Do() method
 func NewRetrier(exponentialBackoff time.Duration, times, factor uint32, log *logging.Logger) *Retrier {
-	log.WithField("func", "retrier")
+	logger := log.WithField("func", "retrier")
 	return &Retrier{
 		exponentialBackoff: exponentialBackoff,
 		times:              times,
 		exponentialFactor:  factor,
 		errWhitelist:       make(map[error]struct{}),
-		log:                log,
+		log:                logger,
 	}
 }
 
@@ -69,7 +70,6 @@ func (r Retrier) retryNTimes(f RetryFunc) error {
 			}
 
 			r.log.Warn(err)
-			r.log.Warn("zzzzzzzzzzzzzzzzzzzzzzzzz")
 			currentBackoff *= time.Duration(r.exponentialFactor)
 			time.Sleep(currentBackoff)
 			continue
@@ -92,7 +92,6 @@ func (r Retrier) retryUntilSuccess(f RetryFunc) error {
 			}
 
 			r.log.Warn(err)
-			r.log.Warn("dddddddddddddddddddddddddd")
 			currentBackoff *= time.Duration(r.exponentialFactor)
 			time.Sleep(currentBackoff)
 			continue

--- a/internal/netutil/retrier.go
+++ b/internal/netutil/retrier.go
@@ -68,6 +68,7 @@ func (r Retrier) retryNTimes(f RetryFunc) error {
 			}
 
 			log.Warn(err)
+			log.Warn("zzzzzzzzzzzzzzzzzzzzzzzzz")
 			currentBackoff *= time.Duration(r.exponentialFactor)
 			time.Sleep(currentBackoff)
 			continue
@@ -90,6 +91,7 @@ func (r Retrier) retryUntilSuccess(f RetryFunc) error {
 			}
 
 			log.Warn(err)
+			log.Warn("dddddddddddddddddddddddddd")
 			currentBackoff *= time.Duration(r.exponentialFactor)
 			time.Sleep(currentBackoff)
 			continue

--- a/internal/netutil/retrier_test.go
+++ b/internal/netutil/retrier_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRetrier_Do(t *testing.T) {
-	r := NewRetrier(time.Millisecond*100, 3, 2)
+	log := logging.MustGetLogger("test")
+	r := NewRetrier(time.Millisecond*100, 3, 2, log)
 	c := 0
 	threshold := 2
 	f := func() error {
@@ -41,7 +43,7 @@ func TestRetrier_Do(t *testing.T) {
 
 	t.Run("should return whitelisted errors if any instead of retry", func(t *testing.T) {
 		bar := errors.New("bar")
-		wR := NewRetrier(50*time.Millisecond, 1, 2).WithErrWhitelist(bar)
+		wR := NewRetrier(50*time.Millisecond, 1, 2, log).WithErrWhitelist(bar)
 		barF := func() error {
 			return bar
 		}
@@ -52,7 +54,7 @@ func TestRetrier_Do(t *testing.T) {
 
 	t.Run("if times is 0, should retry until success", func(t *testing.T) {
 		c = 0
-		loopR := NewRetrier(50*time.Millisecond, 0, 1)
+		loopR := NewRetrier(50*time.Millisecond, 0, 1, log)
 		err := loopR.Do(f)
 		require.NoError(t, err)
 

--- a/internal/utclient/client.go
+++ b/internal/utclient/client.go
@@ -54,7 +54,7 @@ func NewHTTP(addr string, pk cipher.PubKey, sk cipher.SecKey) (APIClient, error)
 	var client *httpauth.Client
 	var err error
 
-	retrier := netutil.NewRetrier(createRetryDelay, 10, 2)
+	retrier := netutil.NewRetrier(createRetryDelay, 10, 2, log)
 	retrierFunc := func() error {
 		client, err = httpauth.NewClient(context.Background(), addr, pk, sk)
 		if err != nil {

--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -89,7 +89,7 @@ func (a *autoconnector) Run(ctx context.Context) (err error) {
 }
 
 func (a *autoconnector) fetchPubAddresses(ctx context.Context) ([]cipher.PubKey, error) {
-	retrier := netutil.NewRetrier(fetchServicesDelay, 5, 3)
+	retrier := netutil.NewRetrier(fetchServicesDelay, 5, 3, a.log)
 	var services []Service
 	fetch := func() (err error) {
 		// "return" services up from the closure

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -277,7 +277,7 @@ func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
 // it performs exponential backoff in case of errors during register, unless
 // the error is unrecoverable from
 func (c *HTTPClient) Register(ctx context.Context) error {
-	retrier := nu.NewRetrier(updateRetryDelay, 0, 2, nil).WithErrWhitelist(ErrVisorUnreachable)
+	retrier := nu.NewRetrier(updateRetryDelay, 0, 2, c.log).WithErrWhitelist(ErrVisorUnreachable)
 	run := func() error {
 		err := c.RegisterEntry(ctx)
 

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -277,7 +277,7 @@ func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
 // it performs exponential backoff in case of errors during register, unless
 // the error is unrecoverable from
 func (c *HTTPClient) Register(ctx context.Context) error {
-	retrier := nu.NewRetrier(updateRetryDelay, 0, 2).WithErrWhitelist(ErrVisorUnreachable)
+	retrier := nu.NewRetrier(updateRetryDelay, 0, 2, nil).WithErrWhitelist(ErrVisorUnreachable)
 	run := func() error {
 		err := c.RegisterEntry(ctx)
 

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -335,7 +335,7 @@ func (mt *ManagedTransport) deleteFromDiscovery() error {
 	retrier := netutil.NewRetrier(1*time.Second, 5, 2, mt.log)
 	return retrier.Do(func() error {
 		err := mt.dc.DeleteTransport(context.Background(), mt.Entry.ID)
-		mt.log.WithField("tp-id", mt.Entry.ID).Debug(err)
+		mt.log.WithField("tp-id", mt.Entry.ID).WithError(err).Debug("Error deleting transport")
 		if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
 			mt.log.
 				WithError(err).

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -332,7 +332,7 @@ func (mt *ManagedTransport) setTransport(newTransport network.Transport) error {
 }
 
 func (mt *ManagedTransport) deleteFromDiscovery() error {
-	retrier := netutil.NewRetrier(1*time.Second, 5, 2)
+	retrier := netutil.NewRetrier(1*time.Second, 5, 2, mt.log)
 	return retrier.Do(func() error {
 		err := mt.dc.DeleteTransport(context.Background(), mt.Entry.ID)
 		if netErr, ok := err.(net.Error); ok && netErr.Temporary() {

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -335,6 +335,7 @@ func (mt *ManagedTransport) deleteFromDiscovery() error {
 	retrier := netutil.NewRetrier(1*time.Second, 5, 2, mt.log)
 	return retrier.Do(func() error {
 		err := mt.dc.DeleteTransport(context.Background(), mt.Entry.ID)
+		mt.log.Error(mt.Entry.ID, err)
 		if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
 			mt.log.
 				WithError(err).

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -335,7 +335,7 @@ func (mt *ManagedTransport) deleteFromDiscovery() error {
 	retrier := netutil.NewRetrier(1*time.Second, 5, 2, mt.log)
 	return retrier.Do(func() error {
 		err := mt.dc.DeleteTransport(context.Background(), mt.Entry.ID)
-		mt.log.Error(mt.Entry.ID, err)
+		mt.log.WithField("tp-id", mt.Entry.ID).Debug(err)
 		if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
 			mt.log.
 				WithError(err).

--- a/pkg/transport/tpdclient/client.go
+++ b/pkg/transport/tpdclient/client.go
@@ -156,6 +156,7 @@ func (c *apiClient) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) (
 func (c *apiClient) DeleteTransport(ctx context.Context, id uuid.UUID) error {
 	resp, err := c.Delete(ctx, fmt.Sprintf("/transports/id:%s", id.String()))
 	if err != nil {
+		log.WithError(err).Warnf("Failed to delete transport with ID %v", id)
 		return err
 	}
 

--- a/pkg/transport/tpdclient/client.go
+++ b/pkg/transport/tpdclient/client.go
@@ -105,6 +105,7 @@ func (c *apiClient) RegisterTransports(ctx context.Context, entries ...*transpor
 func (c *apiClient) GetTransportByID(ctx context.Context, id uuid.UUID) (*transport.Entry, error) {
 	resp, err := c.Get(ctx, fmt.Sprintf("/transports/id:%s", id.String()))
 	if err != nil {
+		log.WithError(err).Warnf("Failed to get transport of ID %v", id)
 		return nil, err
 	}
 

--- a/pkg/transport/tpdclient/client.go
+++ b/pkg/transport/tpdclient/client.go
@@ -105,7 +105,6 @@ func (c *apiClient) RegisterTransports(ctx context.Context, entries ...*transpor
 func (c *apiClient) GetTransportByID(ctx context.Context, id uuid.UUID) (*transport.Entry, error) {
 	resp, err := c.Get(ctx, fmt.Sprintf("/transports/id:%s", id.String()))
 	if err != nil {
-		log.WithError(err).Warnf("Failed to get transport of ID %v", id)
 		return nil, err
 	}
 
@@ -156,7 +155,6 @@ func (c *apiClient) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) (
 func (c *apiClient) DeleteTransport(ctx context.Context, id uuid.UUID) error {
 	resp, err := c.Delete(ctx, fmt.Sprintf("/transports/id:%s", id.String()))
 	if err != nil {
-		log.WithError(err).Warnf("Failed to delete transport with ID %v", id)
 		return err
 	}
 


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #975 

 Changes:	
- Added debug log in `deleteFromDiscovery()`
- Updated the log in `netutl.retrier`

How to test this PR:
1. Run a visor with [this](https://github.com/skycoin/skywire/files/7428479/barebones-config.txt) config (on server with public IP) with log level as debug.
2. Check logs