### PR TITLE
fix(visor.summary): data race condition

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -179,6 +179,8 @@ var BuildTag string
 
 // Summary implements API.
 func (v *Visor) Summary() (*Summary, error) {
+	v.wgTrackers.Wait()
+
 	overview, err := v.Overview()
 	if err != nil {
 		return nil, fmt.Errorf("overview")

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -70,6 +70,7 @@ type Visor struct {
 	appL        *launcher.Launcher    // app launcher
 	serviceDisc appdisc.Factory
 	initLock    *sync.Mutex
+	wgTrackers  *sync.WaitGroup
 	// when module is failed it pushes its error to this channel
 	// used by init and shutdown to show/check for any residual errors
 	// produced by concurrent parts of modules
@@ -106,7 +107,10 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 		restartCtx:        restartCtx,
 		initLock:          new(sync.Mutex),
 		isServicesHealthy: newInternalHealthInfo(),
+		wgTrackers:        new(sync.WaitGroup),
 	}
+	v.wgTrackers.Add(1)
+	defer v.wgTrackers.Done()
 
 	v.isServicesHealthy.init()
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes, the `make check` accused 4 errors (`G307`, `time-naming`) in the files: `pkg/util/rename/rename.go`, `pkg/transport/network/stcp/pktable.go`, `pkg/restart/restart_test.go`). However, since the code is already using [this](https://github.com/securego/gosec/issues/512#issuecomment-675286833) workaround, I didn't change it.

Fixes #998 

Changes:	
-  It adds a wg variable inside the `Visor` struct to force the `(*Visor).Summary` await until `NewVisor` finish.

How to test this PR:
1. Clone this repository
2. In the same folder, clone the repository [skywire-services](https://github.com/SkycoinPro/skywire-services)
3. Run the [interactive environment](https://github.com/SkycoinPro/skywire-services/blob/master/docs/InteractiveEnvironments.md) 