### PR TITLE
Use local servers to generate config file

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -31,7 +31,7 @@ var (
 	skybianConfig      bool
 	hypervisor         bool
 	hypervisorPKs      string
-	dmsgHttp           bool
+	dmsgHTTP           bool
 )
 
 func init() {
@@ -44,7 +44,7 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "use test deployment service.")
 	genConfigCmd.Flags().BoolVarP(&hypervisor, "is-hypervisor", "i", false, "generate a hypervisor configuration.")
 	genConfigCmd.Flags().StringVar(&hypervisorPKs, "hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
-	genConfigCmd.Flags().BoolVarP(&dmsgHttp, "dmsghttp", "d", false, "connect to Skywire Services via dmsg")
+	genConfigCmd.Flags().BoolVarP(&dmsgHTTP, "dmsghttp", "d", false, "connect to Skywire Services via dmsg")
 }
 
 var genConfigCmd = &cobra.Command{
@@ -105,7 +105,7 @@ var genConfigCmd = &cobra.Command{
 		}
 
 		// Use local servers
-		if dmsgHttp {
+		if dmsgHTTP {
 			var localServersData localServers
 			serversListJSON, err := ioutil.ReadFile("localServers.json")
 			if err != nil {

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -115,13 +115,13 @@ var genConfigCmd = &cobra.Command{
 			if err != nil {
 				logger.WithError(err).Fatal("Error during parsing servers list")
 			}
-			conf.IsPublic = true
-			conf.Dmsg.Servers = localServersData.DSMG
+			conf.Dmsg.Servers = localServersData.DMSGServers
+			conf.Dmsg.Discovery = localServersData.DMSGDiscovery
 			conf.Transport.AddressResolver = localServersData.AddressResolver
-			conf.Transport.Discovery = localServersData.Transport
+			conf.Transport.Discovery = localServersData.TransportDiscovery
 			conf.UptimeTracker.Addr = localServersData.UptimeTracker
-			conf.Routing.RouteFinder = localServersData.Routing
-			conf.Launcher.ServiceDisc = localServersData.Launcher
+			conf.Routing.RouteFinder = localServersData.RouteFinder
+			conf.Launcher.ServiceDisc = localServersData.ServiceDiscovery
 		}
 
 		// Read in old config (if any) and obtain old hypervisors.
@@ -178,10 +178,11 @@ func readOldConfig(log *logging.MasterLogger, confPath string, replace bool) (*v
 }
 
 type localServers struct {
-	DSMG            []string `json:"dmsg"`
-	Transport       string   `json:"transport"`
-	AddressResolver string   `json:"address_resolver"`
-	Routing         string   `json:"routing"`
-	UptimeTracker   string   `json:"uptime_tracker"`
-	Launcher        string   `json:"launcher"`
+	DMSGServers        []string `json:"dmsg_servers"`
+	DMSGDiscovery      string   `json:"dmsg_discovery"`
+	TransportDiscovery string   `json:"transport_discovery"`
+	AddressResolver    string   `json:"address_resolver"`
+	RouteFinder        string   `json:"route_finder"`
+	UptimeTracker      string   `json:"uptime_tracker"`
+	ServiceDiscovery   string   `json:"service_discovery"`
 }

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -115,13 +115,23 @@ var genConfigCmd = &cobra.Command{
 			if err != nil {
 				logger.WithError(err).Fatal("Error during parsing servers list")
 			}
-			conf.Dmsg.Servers = localServersData.DMSGServers
-			conf.Dmsg.Discovery = localServersData.DMSGDiscovery
-			conf.Transport.AddressResolver = localServersData.AddressResolver
-			conf.Transport.Discovery = localServersData.TransportDiscovery
-			conf.UptimeTracker.Addr = localServersData.UptimeTracker
-			conf.Routing.RouteFinder = localServersData.RouteFinder
-			conf.Launcher.ServiceDisc = localServersData.ServiceDiscovery
+			if testEnv {
+				conf.Dmsg.Servers = localServersData.Test.DMSGServers
+				conf.Dmsg.Discovery = localServersData.Test.DMSGDiscovery
+				conf.Transport.AddressResolver = localServersData.Test.AddressResolver
+				conf.Transport.Discovery = localServersData.Test.TransportDiscovery
+				conf.UptimeTracker.Addr = localServersData.Test.UptimeTracker
+				conf.Routing.RouteFinder = localServersData.Test.RouteFinder
+				conf.Launcher.ServiceDisc = localServersData.Test.ServiceDiscovery
+			} else {
+				conf.Dmsg.Servers = localServersData.Prod.DMSGServers
+				conf.Dmsg.Discovery = localServersData.Prod.DMSGDiscovery
+				conf.Transport.AddressResolver = localServersData.Prod.AddressResolver
+				conf.Transport.Discovery = localServersData.Prod.TransportDiscovery
+				conf.UptimeTracker.Addr = localServersData.Prod.UptimeTracker
+				conf.Routing.RouteFinder = localServersData.Prod.RouteFinder
+				conf.Launcher.ServiceDisc = localServersData.Prod.ServiceDiscovery
+			}
 		}
 
 		// Read in old config (if any) and obtain old hypervisors.
@@ -178,6 +188,10 @@ func readOldConfig(log *logging.MasterLogger, confPath string, replace bool) (*v
 }
 
 type localServers struct {
+	Test localServersData `json:"test"`
+	Prod localServersData `json:"prod"`
+}
+type localServersData struct {
 	DMSGServers        []string `json:"dmsg_servers"`
 	DMSGDiscovery      string   `json:"dmsg_discovery"`
 	TransportDiscovery string   `json:"transport_discovery"`

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -31,7 +31,7 @@ var (
 	skybianConfig      bool
 	hypervisor         bool
 	hypervisorPKs      string
-	localConfig        bool
+	dmsgHttp           bool
 )
 
 func init() {
@@ -44,7 +44,7 @@ func init() {
 	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "use test deployment service.")
 	genConfigCmd.Flags().BoolVarP(&hypervisor, "is-hypervisor", "i", false, "generate a hypervisor configuration.")
 	genConfigCmd.Flags().StringVar(&hypervisorPKs, "hypervisor-pks", "", "public keys of hypervisors that should be added to this visor")
-	genConfigCmd.Flags().BoolVarP(&localConfig, "local", "l", false, "use local servers PK instead global")
+	genConfigCmd.Flags().BoolVarP(&dmsgHttp, "dmsghttp", "d", false, "connect to Skywire Services via dmsg")
 }
 
 var genConfigCmd = &cobra.Command{
@@ -105,7 +105,7 @@ var genConfigCmd = &cobra.Command{
 		}
 
 		// Use local servers
-		if localConfig {
+		if dmsgHttp {
 			var localServersData localServers
 			serversListJSON, err := ioutil.ReadFile("localServers.json")
 			if err != nil {

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -106,31 +106,31 @@ var genConfigCmd = &cobra.Command{
 
 		// Use local servers
 		if dmsgHTTP {
-			var localServersData localServers
+			var dmsgHTTPServersList dmsgHTTPServers
 			serversListJSON, err := ioutil.ReadFile("localServers.json")
 			if err != nil {
 				logger.WithError(err).Fatal("Failed to read servers.json file.")
 			}
-			err = json.Unmarshal(serversListJSON, &localServersData)
+			err = json.Unmarshal(serversListJSON, &dmsgHTTPServersList)
 			if err != nil {
 				logger.WithError(err).Fatal("Error during parsing servers list")
 			}
 			if testEnv {
-				conf.Dmsg.Servers = localServersData.Test.DMSGServers
-				conf.Dmsg.Discovery = localServersData.Test.DMSGDiscovery
-				conf.Transport.AddressResolver = localServersData.Test.AddressResolver
-				conf.Transport.Discovery = localServersData.Test.TransportDiscovery
-				conf.UptimeTracker.Addr = localServersData.Test.UptimeTracker
-				conf.Routing.RouteFinder = localServersData.Test.RouteFinder
-				conf.Launcher.ServiceDisc = localServersData.Test.ServiceDiscovery
+				conf.Dmsg.Servers = dmsgHTTPServersList.Test.DMSGServers
+				conf.Dmsg.Discovery = dmsgHTTPServersList.Test.DMSGDiscovery
+				conf.Transport.AddressResolver = dmsgHTTPServersList.Test.AddressResolver
+				conf.Transport.Discovery = dmsgHTTPServersList.Test.TransportDiscovery
+				conf.UptimeTracker.Addr = dmsgHTTPServersList.Test.UptimeTracker
+				conf.Routing.RouteFinder = dmsgHTTPServersList.Test.RouteFinder
+				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Test.ServiceDiscovery
 			} else {
-				conf.Dmsg.Servers = localServersData.Prod.DMSGServers
-				conf.Dmsg.Discovery = localServersData.Prod.DMSGDiscovery
-				conf.Transport.AddressResolver = localServersData.Prod.AddressResolver
-				conf.Transport.Discovery = localServersData.Prod.TransportDiscovery
-				conf.UptimeTracker.Addr = localServersData.Prod.UptimeTracker
-				conf.Routing.RouteFinder = localServersData.Prod.RouteFinder
-				conf.Launcher.ServiceDisc = localServersData.Prod.ServiceDiscovery
+				conf.Dmsg.Servers = dmsgHTTPServersList.Prod.DMSGServers
+				conf.Dmsg.Discovery = dmsgHTTPServersList.Prod.DMSGDiscovery
+				conf.Transport.AddressResolver = dmsgHTTPServersList.Prod.AddressResolver
+				conf.Transport.Discovery = dmsgHTTPServersList.Prod.TransportDiscovery
+				conf.UptimeTracker.Addr = dmsgHTTPServersList.Prod.UptimeTracker
+				conf.Routing.RouteFinder = dmsgHTTPServersList.Prod.RouteFinder
+				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Prod.ServiceDiscovery
 			}
 		}
 
@@ -187,11 +187,11 @@ func readOldConfig(log *logging.MasterLogger, confPath string, replace bool) (*v
 	return conf, true
 }
 
-type localServers struct {
-	Test localServersData `json:"test"`
-	Prod localServersData `json:"prod"`
+type dmsgHTTPServers struct {
+	Test dmsgHTTPServersData `json:"test"`
+	Prod dmsgHTTPServersData `json:"prod"`
 }
-type localServersData struct {
+type dmsgHTTPServersData struct {
 	DMSGServers        []string `json:"dmsg_servers"`
 	DMSGDiscovery      string   `json:"dmsg_discovery"`
 	TransportDiscovery string   `json:"transport_discovery"`

--- a/localServers.json
+++ b/localServers.json
@@ -1,13 +1,13 @@
 {
-  "dmsg": [
-    "dmsg://pk:port",
-    "dmsg://pk:port",
-    "dmsg://pk:port",
-    "dmsg://pk:port"
+  "dmsg_servers": [
+    "ip:port",
+    "ip:port",
+    "ip:port"
   ],
-  "transport": "dmsg://pk:port",
+  "dmsg_discovery": "dmsg://pk:port",
+  "transport_discovery": "dmsg://pk:port",
   "address_resolver": "dmsg://pk:port",
-  "routing": "dmsg://pk:port",
+  "route_finder": "dmsg://pk:port",
   "uptime_tracker": "dmsg://pk:port",
-  "launcher": "dmsg://pk:port"
+  "service_discovery": "dmsg://pk:port"
 }

--- a/localServers.json
+++ b/localServers.json
@@ -1,0 +1,13 @@
+{
+  "dmsg": [
+    "dmsg://pk:port",
+    "dmsg://pk:port",
+    "dmsg://pk:port",
+    "dmsg://pk:port"
+  ],
+  "transport": "dmsg://pk:port",
+  "address_resolver": "dmsg://pk:port",
+  "routing": "dmsg://pk:port",
+  "uptime_tracker": "dmsg://pk:port",
+  "launcher": "dmsg://pk:port"
+}

--- a/localServers.json
+++ b/localServers.json
@@ -1,4 +1,18 @@
 {
+  "test": {
+    "dmsg_servers": [
+      "ip:port",
+      "ip:port",
+      "ip:port"
+    ],
+    "dmsg_discovery": "dmsg://pk:port",
+    "transport_discovery": "dmsg://pk:port",
+    "address_resolver": "dmsg://pk:port",
+    "route_finder": "dmsg://pk:port",
+    "uptime_tracker": "dmsg://pk:port",
+    "service_discovery": "dmsg://pk:port"
+  },
+"prod": {
   "dmsg_servers": [
     "ip:port",
     "ip:port",
@@ -10,4 +24,5 @@
   "route_finder": "dmsg://pk:port",
   "uptime_tracker": "dmsg://pk:port",
   "service_discovery": "dmsg://pk:port"
+}
 }

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -13,8 +13,10 @@ import (
 
 // DmsgConfig defines config for Dmsg network.
 type DmsgConfig struct {
-	Discovery     string `json:"discovery"`
-	SessionsCount int    `json:"sessions_count"`
+	Discovery     string   `json:"discovery"`
+	SessionsCount int      `json:"sessions_count"`
+	IsLocal       bool     `json:"is_local"`
+	Servers       []string `json:"servers"`
 }
 
 // New makes new dmsg client from configuration

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -15,7 +15,6 @@ import (
 type DmsgConfig struct {
 	Discovery     string   `json:"discovery"`
 	SessionsCount int      `json:"sessions_count"`
-	IsLocal       bool     `json:"is_local"`
 	Servers       []string `json:"servers"`
 }
 

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -24,6 +24,8 @@ func MakeBaseConfig(common *Common) *V1 {
 	conf.Dmsg = &dmsgc.DmsgConfig{
 		Discovery:     skyenv.DefaultDmsgDiscAddr,
 		SessionsCount: 1,
+		IsLocal:       false,
+		Servers:       nil,
 	}
 	conf.Transport = &V1Transport{
 		Discovery:         skyenv.DefaultTpDiscAddr,

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -24,8 +24,7 @@ func MakeBaseConfig(common *Common) *V1 {
 	conf.Dmsg = &dmsgc.DmsgConfig{
 		Discovery:     skyenv.DefaultDmsgDiscAddr,
 		SessionsCount: 1,
-		IsLocal:       false,
-		Servers:       nil,
+		Servers:       []string{},
 	}
 	conf.Transport = &V1Transport{
 		Discovery:         skyenv.DefaultTpDiscAddr,


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes skywire-services [#423](https://github.com/SkycoinPro/skywire-services/issues/423)

 Changes:	
- Add flag `-d` to use addresses in `localServers.json` file as services address.

How to test this PR:
- `make build`
- `./skywire-cli config gen -d` for production, or `./skywire-cli config gen -d -t` for test.
- check `skywire-config.json` for local servers addresses