### PR TITLE
add BuildTag for MacOS

### DIFF
--- a/scripts/mac_installer/create_installer.sh
+++ b/scripts/mac_installer/create_installer.sh
@@ -13,6 +13,7 @@ staple_notarization=false
 package_path=
 developer_id=
 output=
+BUILDTAG=MacOS
 
 greent='\033[0;32m'
 yellowt='\033[0;33m'
@@ -57,7 +58,7 @@ function build_installer() {
   fi
 
   # build skywire binariea
-  make CGO_ENABLED=1 GOOS=darwin GOARCH="${go_arch}" build-systray
+  make CGO_ENABLED=1 GOOS=darwin GOARCH="${go_arch}" build-systray BUILDTAG=$BUILDTAG
 
   if [ -d ${installer_build_dir}/binaries/Skywire.app ]; then
     rm -rf ${installer_build_dir}/binaries/Skywire.app


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #971

 Changes:	
- add **BUILDTAG** to mac installer `create_installer.sh` script.