### PR TITLE
Put stcp at the end of the transport types list

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.ts
@@ -221,7 +221,16 @@ export class CreateTransportComponent implements OnInit, OnDestroy {
     ).subscribe(
       types => {
         // Sort the types and select dmsg as default, if posible.
-        types.sort((a, b) => a.localeCompare(b));
+        types.sort((a, b) => {
+          // Put stcp at the end.
+          if (a.toLowerCase() === 'stcp') {
+            return 1;
+          } else if (b.toLowerCase() === 'stcp') {
+            return -1;
+          }
+
+          return a.localeCompare(b);
+        });
         let defaultIndex = types.findIndex(type => type.toLowerCase() === 'dmsg');
         defaultIndex = defaultIndex !== -1 ? defaultIndex : 0;
 


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #1007

 Changes:	
- If the Hypervisor API returns stcp as one of the available transport types, it is put at the bottom of the types list, in the popup used for creating new transports.

How to test this PR:
Use the Skywire manager to create a new transport. If the stcp is in the available types list, it should be at the bottom.

@jdknives Would you like something like “(for testing only)” added at the end?