### PR TITLE
move dmsghttp struct to pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - added `update` and `summary` as subcommand to `skywire-cli visor`
 - added multiple new flag to update configuration in `skywire-cli config update`
 - added shell autocompletion command to `skywire-cli` and `skywire-visor`
+- added `dsmgHTTPStruct` in visorconfig pkg to usable other repos, such as `skybian`
 ## 0.5.0
 
 ### Changed

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -106,7 +106,7 @@ var genConfigCmd = &cobra.Command{
 
 		// Use local servers
 		if dmsgHTTP {
-			var dmsgHTTPServersList dmsgHTTPServers
+			var dmsgHTTPServersList visorconfig.DmsgHTTPServers
 			serversListJSON, err := ioutil.ReadFile("localServers.json")
 			if err != nil {
 				logger.WithError(err).Fatal("Failed to read servers.json file.")
@@ -185,18 +185,4 @@ func readOldConfig(log *logging.MasterLogger, confPath string, replace bool) (*v
 	}
 
 	return conf, true
-}
-
-type dmsgHTTPServers struct {
-	Test dmsgHTTPServersData `json:"test"`
-	Prod dmsgHTTPServersData `json:"prod"`
-}
-type dmsgHTTPServersData struct {
-	DMSGServers        []string `json:"dmsg_servers"`
-	DMSGDiscovery      string   `json:"dmsg_discovery"`
-	TransportDiscovery string   `json:"transport_discovery"`
-	AddressResolver    string   `json:"address_resolver"`
-	RouteFinder        string   `json:"route_finder"`
-	UptimeTracker      string   `json:"uptime_tracker"`
-	ServiceDiscovery   string   `json:"service_discovery"`
 }

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -244,3 +244,17 @@ func launcherAddAllApps(launcherCfg []launcher.AppConfig) []launcher.AppConfig {
 	}...)
 	return launcherCfg
 }
+
+type DmsgHTTPServers struct {
+	Test DmsgHTTPServersData `json:"test"`
+	Prod DmsgHTTPServersData `json:"prod"`
+}
+type DmsgHTTPServersData struct {
+	DMSGServers        []string `json:"dmsg_servers"`
+	DMSGDiscovery      string   `json:"dmsg_discovery"`
+	TransportDiscovery string   `json:"transport_discovery"`
+	AddressResolver    string   `json:"address_resolver"`
+	RouteFinder        string   `json:"route_finder"`
+	UptimeTracker      string   `json:"uptime_tracker"`
+	ServiceDiscovery   string   `json:"service_discovery"`
+}

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -245,10 +245,13 @@ func launcherAddAllApps(launcherCfg []launcher.AppConfig) []launcher.AppConfig {
 	return launcherCfg
 }
 
+// DmsgHTTPServers struct use to unmarshal dmsghttp file
 type DmsgHTTPServers struct {
 	Test DmsgHTTPServersData `json:"test"`
 	Prod DmsgHTTPServersData `json:"prod"`
 }
+
+// DmsgHTTPServersData is a part of DmsgHTTPServers
 type DmsgHTTPServersData struct {
 	DMSGServers        []string `json:"dmsg_servers"`
 	DMSGDiscovery      string   `json:"dmsg_discovery"`


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes PR [#131](https://github.com/skycoin/skybian/pull/131) in Skybian

 Changes:	
- move DmsgHTTPServers struct to visorconfig pkg to be usable in other repo same as Skybian.

