### PR TITLE
Fix datarace on network monitor

### DIFF
--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -118,7 +118,6 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 		v.log.WithError(err).Warn("Failed to read log level from config.")
 	} else {
 		v.conf.MasterLogger().SetLevel(logLvl)
-		logging.SetLevel(logLvl)
 	}
 
 	log := v.MasterLogger().PackageLogger("visor:startup")


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes skywire-services [#492](https://github.com/SkycoinPro/skywire-services/issues/492)

 Changes:	
- Remove wrong log level set.

How to test this PR:
- clone dmsg and this PR skywire
- clone [SkycoinPro/skywire-services](https://github.com/SkycoinPro/skywire-services) at develop branch
- uncomment `replace github.com/skycoin/dmsg => ../dmsg` and `replace github.com/skycoin/skywire => ../skywire` on go.mod
- run interactive env
- close network monitor (tab 8 on tmux)
- no datarace occur