### PR TITLE
Autogenerate changelog on release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Char
 /SkywireInstaller*.pkg
 *.dmg
 /scripts/mac_installer/icon.iconset/
+releaseChangelog.md

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,10 @@ build-deploy: ## Build for deployment Docker images
 	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o /release/apps/skysocks-client ./cmd/apps/skysocks-client
 
 github-release:
-	goreleaser --rm-dist
+	$(eval GITHUB_TAG=$(shell git describe --abbrev=0 --tags | cut -c 2-))
+	sed '/^## ${GITHUB_TAG}$$/,/^## .*/!d;//d;/^$$/d' ./CHANGELOG.md > releaseChangelog.md
+	goreleaser --rm-dist --release-notes releaseChangelog.md 
+
 
 build-docker: ## Build docker image
 	./ci_scripts/docker-push.sh -t ${BRANCH} -b


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #948 

 Changes:	
- Modified `make github-release` command to use tag value and copy related change logs on temporary file, and use it as `--release-notes` goreleaser flag.

How to test this PR:
- export your github token [generated](https://github.com/settings/tokens) as `export GITHUB_TOKEN=...`
- change `github owner` to yours on `.goreleaser.yml`
- push v0.6.0 tag
- `make github-release`