### PR TITLE
Fix nil pointer in vpn client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pkg/visor/foo/
 /*-cli
 /*-server
 /*.json
+!/dmsghttp-config.json
 /*.sh
 /*.log
 

--- a/dmsghttp-config.json
+++ b/dmsghttp-config.json
@@ -1,0 +1,52 @@
+{
+  "test": {
+    "dmsg_servers": [
+      {
+        "static":"024716428e6315d954356e9ad72bea32bb2b41aab5a54a9b5cb4313964016e64d8",
+        "server":{
+          "address":"172.104.188.39:30080"
+        }
+      },
+      {
+        "static":"03f6b0a20be8fe0fd2fd0bd850507cfb10d0eaa37dce5c174654d07db5749a41bf",
+        "server":{
+          "address":"192.53.115.181:8083"
+        }
+      },
+      {
+        "static":"02ae49c901480b49f9c40f6f90fa8e775cf9b00b61ded673a9b0776dfb7cccd374",
+        "server":{
+          "address":"139.162.45.141:8083"
+        }
+      }
+    ],
+    "dmsg_discovery": "dmsg://03cd2336e5de74bdab2bbdb44b06b0c8c713a5ee9029615f5526f8c99a6afe87b8:80",
+    "transport_discovery": "dmsg://02703cf828ea11d25b2c8eb0796132ecc7e53b22325b20ce3674ce5cd8693e4fb6:80",
+    "address_resolver": "dmsg://030eb7d8cf6eac40c19bbc433de6d6b9bb7a47f2e1d7095c6a01aa676471670ad2:80",
+    "route_finder": "dmsg://02ece5b69eaee13ef967b7eb67ca93f1dfddad3a51c9cb1808c4bd0d8d8aa32053:80",
+    "uptime_tracker": "dmsg://022c788cca11f208cdfd83ed0c2a8c7b661221736c461adc7c6738a2c1b041c7f8:80",
+    "service_discovery": "dmsg://038f751df4af75fb3d51f6693602bfe8289145e633ffdd1e67d686bea595f84d55:80"
+  },
+  "prod": {
+    "dmsg_servers": [
+      {
+        "static":"03832194c823a39c7b78ff08bddacbd6d6541def182a3f195973ebe7da16fe1b53",
+        "server":{
+          "address":"139.162.45.141:8081"
+        }
+      },
+      {
+        "static":"02e4660279c83bc6ca0122d3a78c0cb3f3564e03e04876ae7fa30b4e0a63217425",
+        "server":{
+          "address":"192.53.115.181:8081"
+        }
+      }
+    ],
+    "dmsg_discovery": "dmsg://pk:port",
+    "transport_discovery": "dmsg://pk:port",
+    "address_resolver": "dmsg://pk:port",
+    "route_finder": "dmsg://pk:port",
+    "uptime_tracker": "dmsg://pk:port",
+    "service_discovery": "dmsg://pk:port"
+  }
+}

--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -792,11 +792,13 @@ func filterOutEqualIPs(ips []net.IP) []net.IP {
 	ipsSet := make(map[string]struct{})
 	var filteredIPs []net.IP
 	for _, ip := range ips {
-		ipStr := ip.String()
+		if ip != nil {
+			ipStr := ip.String()
 
-		if _, ok := ipsSet[ipStr]; !ok {
-			filteredIPs = append(filteredIPs, ip)
-			ipsSet[ip.String()] = struct{}{}
+			if _, ok := ipsSet[ipStr]; !ok {
+				filteredIPs = append(filteredIPs, ip)
+				ipsSet[ip.String()] = struct{}{}
+			}
 		}
 	}
 

--- a/internal/vpn/env.go
+++ b/internal/vpn/env.go
@@ -3,12 +3,12 @@ package vpn
 import (
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsgget"
 )
 
 const (
@@ -127,11 +127,23 @@ func IPFromEnv(key string) (net.IP, bool, error) {
 // - domain without port;
 // - IP with port;
 // - IP without port.
+// - dmshhttp url with port;
+// - dmshhttp url without port.
 // In case domain is provided instead of an IP address, a DNS lookup is also
 // performed to resolve the actual IP address
 func ParseIP(addr string) (net.IP, bool, error) {
 	if addr == "" {
 		return nil, false, nil
+	}
+	var url dmsgget.URL
+
+	// in case dmsghttp url is provided
+	err := url.Fill(addr)
+	if url.Scheme == "dmsg" {
+		if err != nil {
+			return nil, false, err
+		}
+		return nil, true, nil
 	}
 
 	// in case whole URL is passed with the scheme

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -312,7 +312,7 @@ func (v *Visor) StartApp(appName string) error {
 	if appName == skyenv.VPNClientName {
 		// todo: can we use some kind of app start hook that will be used for both autostart
 		// and start? Reason: this is also called in init for autostart
-		maker := vpnEnvMaker(v.conf, v.dmsgC, v.tpM.STCPRRemoteAddrs())
+		maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.STCPRRemoteAddrs())
 		envs, err = maker()
 		if err != nil {
 			return err

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -164,6 +164,10 @@ func initDmsgHTTP(ctx context.Context, v *Visor, log *logging.Logger) error {
 	var keys cipher.PubKeys
 	servers := v.conf.Dmsg.Servers
 
+	if len(servers) == 0 {
+		return nil
+	}
+
 	keys = append(keys, v.conf.PK)
 	dClient := direct.NewDirectClient(direct.GetAllEntries(keys, servers))
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -60,7 +60,8 @@ type Visor struct {
 
 	ebc      *appevent.Broadcaster // event broadcaster
 	dmsgC    *dmsg.Client
-	dClient  direct.APIClient // dmsg direct client
+	dmsgDC   *dmsg.Client     // dmsg direct client
+	dClient  direct.APIClient // dmsg direct api client
 	dmsgHTTP *http.Client     // dmsghttp client
 	trackers *dmsgtracker.Manager
 


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1014 

 Changes:
- Fix nil pointer error
- Fix `dmsghttp` module startup with non dmsg urls
- Exclude `dmsghttp-config.json` from gitignore

How to test this PR:
On test env
1. Run `./skywire-cli config gen -irt`
2. Run `sudo ./skywire-visor -c skywire-config.json`
3. See if visor starts up properly 

And
1. Run `./skywire-cli config gen -dirt`
2. Run `sudo ./skywire-visor -c skywire-config.json`
3. Open hypervisor and Connect to a VPN server 
4. See if everything is running well