### PR TITLE
turn off build-ui on windows appveyor (timeout)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,7 +68,6 @@ for:
       - choco install make
       - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
       - make dep
-      - make install-deps-ui
       - set PATH=C:\Users\appveyor\go\bin;C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
 
     before_build:
@@ -78,7 +77,6 @@ for:
   
     build_script:
       - make build-windows
-      - make build-ui-windows
 
   - # Linux and MacOS (Release)
     skip_non_tags: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,7 +73,6 @@ for:
     before_build:
       - set GO111MODULE=on
       - make check-windows
-      - make lint-ui
   
     build_script:
       - make build-windows


### PR DESCRIPTION
Did you run `make format && make check`? yes

Fixes #1020	

 Changes:	
-	Turn off timed out windows build-ui recipe in appveyor only.

How to test this PR:
