### PR TITLE
Fix panic

### DIFF
--- a/cmd/skywire-cli/commands/visor/routes.go
+++ b/cmd/skywire-cli/commands/visor/routes.go
@@ -127,7 +127,7 @@ func printRoutingRules(rules ...routing.Rule) {
 	}
 	printFwdRule := func(w io.Writer, id routing.RouteID, s *routing.RuleSummary) {
 		_, err := fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n", id, s.Type, "-",
-			"-", "-", "-", s.IntermediaryForwardFields.NextRID, s.IntermediaryForwardFields.NextTID, s.KeepAlive)
+			"-", "-", "-", s.ForwardFields.NextRID, s.ForwardFields.NextTID, s.KeepAlive)
 		internal.Catch(err)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1023 

 Changes:	
- Changed `IntermediaryForwardFields` to `ForwardFields` in `printFwdRule`

How to test this PR:
1. Start a visor and connect to a VPN server
2. In new terminal run `./skywire-cli visor ls-rules`
3. See if there is no panic