### PR TITLE
Fix panic

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -514,7 +514,8 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 			for _, trans := range transports {
 				ntype := network.Type(trans)
 				// skip if SUDPH is under symmetric NAT / under UDP firewall.
-				if ntype == network.SUDPH && (v.stunClient.NATType == stun.NATSymmetric || v.stunClient.NATType == stun.NATSymmetricUDPFirewall) {
+				if ntype == network.SUDPH && v.stunClient != nil && (v.stunClient.NATType == stun.NATSymmetric ||
+					v.stunClient.NATType == stun.NATSymmetricUDPFirewall) {
 					continue
 				}
 				err := retrier.Do(ctx, func() error {


### PR DESCRIPTION
This commit fixes the panic by checking if the stunClient is initilised or not before checking the NATType.

Did you run `make format && make check`?
yes

Fixes #1027 

 Changes:	
- Added check to see if stunClient is not nil

How to test this PR:
1. On in config with test deployment set the vpn-client as
    ```json
    {
		"name": "vpn-client",
		"args": [
			"-srv",
			"03e6a435b16de6ac49d78dea29e5f136c1b223a2b7128d61c36f29eef343040ad2"
		],
		"auto_start": true,
		"port": 43
    },
    ```
2. Run `sudo ./skywire-visor -c skywire-visor.json`
3. Check if there is no panic