### PR TITLE
Fix/data race

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -179,8 +179,6 @@ var BuildTag string
 
 // Summary implements API.
 func (v *Visor) Summary() (*Summary, error) {
-	v.wgTrackers.Wait()
-
 	overview, err := v.Overview()
 	if err != nil {
 		return nil, fmt.Errorf("overview")
@@ -218,6 +216,7 @@ func (v *Visor) Summary() (*Summary, error) {
 	}
 
 	dmsgStatValue := &dmsgtracker.DmsgClientSummary{}
+	v.wgTrackers.Wait()
 	if v.trackers != nil {
 		if dmsgTracker := v.trackers.GetBulk([]cipher.PubKey{v.conf.PK}); len(dmsgTracker) > 0 {
 			dmsgStatValue = &dmsgTracker[0]

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -66,11 +66,12 @@ type Visor struct {
 	dmsgHTTP *http.Client       // dmsghttp client
 	trackers *dmsgtracker.Manager
 
-	stunClient *network.StunDetails
-	tpM        *transport.Manager
-	arClient   addrresolver.APIClient
-	router     router.Router
-	rfClient   rfclient.Client
+	stunClient   *network.StunDetails
+	wgStunClient *sync.WaitGroup
+	tpM          *transport.Manager
+	arClient     addrresolver.APIClient
+	router       router.Router
+	rfClient     rfclient.Client
 
 	procM       appserver.ProcManager // proc manager
 	appL        *launcher.Launcher    // app launcher
@@ -116,6 +117,7 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 		initLock:          new(sync.Mutex),
 		isServicesHealthy: newInternalHealthInfo(),
 		wgTrackers:        new(sync.WaitGroup),
+		wgStunClient:      new(sync.WaitGroup),
 		transportCacheMu:  new(sync.Mutex),
 	}
 	v.wgTrackers.Add(1)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -120,8 +120,6 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 		wgStunClient:      new(sync.WaitGroup),
 		transportCacheMu:  new(sync.Mutex),
 	}
-	v.wgTrackers.Add(1)
-	defer v.wgTrackers.Done()
 
 	v.isServicesHealthy.init()
 
@@ -157,6 +155,8 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 	if !v.processRuntimeErrs() {
 		return nil, false
 	}
+	v.wgTrackers.Add(1)
+	defer v.wgTrackers.Done()
 	v.trackers = dmsgtracker.NewDmsgTrackerManager(v.MasterLogger(), v.dmsgC, 0, 0)
 	return v, true
 }


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1027 

 Changes:	
- Added waitgroup for stun module
- Moved wgTrackers

How to test this PR:
1. Start hypervisor `./skywire-visor -c skywire-config.json`
2. Immediatly start the vpn-client
