### PR TITLE
Fix dmsghttp datarace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/shirou/gopsutil/v3 v3.21.4
 	github.com/sirupsen/logrus v1.8.1
-	github.com/skycoin/dmsg v0.0.0-20211207135321-02790298e924
+	github.com/skycoin/dmsg v0.0.0-20211229130221-70e9ab64c1be
 	github.com/skycoin/skycoin v0.27.1
 	github.com/skycoin/yamux v0.0.0-20200803175205-571ceb89da9f
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5k
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/skycoin/dmsg v0.0.0-20211207135321-02790298e924 h1:GHrjhqJgB+jE8KrYQrHIS0qnblfJX6Kl0CIjWar94MY=
-github.com/skycoin/dmsg v0.0.0-20211207135321-02790298e924/go.mod h1:EgRg8fy5RjF67OJlh9w+vhq3+Phyn6AXKSedkzhf1ww=
+github.com/skycoin/dmsg v0.0.0-20211229130221-70e9ab64c1be h1:M+f0VZ7I7Yt/sI4tcKFIpU0nPWdRKz5e0+xLjvjm6iI=
+github.com/skycoin/dmsg v0.0.0-20211229130221-70e9ab64c1be/go.mod h1:EgRg8fy5RjF67OJlh9w+vhq3+Phyn6AXKSedkzhf1ww=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.26.0/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1096,7 +1096,7 @@ func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client,
 		if err != nil {
 			return nil, fmt.Errorf("provided URL is invalid: %w", err)
 		}
-		// get delegated servers and add the, to the client entry
+		// get delegated servers and add them to the client entry
 		servers, err := v.dClient.AvailableServers(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("Error getting AvailableServers: %w", err)

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1089,17 +1089,30 @@ func getErrors(ctx context.Context) chan error {
 func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client, error) {
 
 	var serviceURL dmsgget.URL
-
+	var delegatedServers []cipher.PubKey
 	err := serviceURL.Fill(service)
 
 	if serviceURL.Scheme == "dmsg" {
 		if err != nil {
 			return nil, fmt.Errorf("provided URL is invalid: %w", err)
 		}
+		// get delegated servers and add the, to the client entry
+		servers, err := v.dClient.AvailableServers(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting AvailableServers: %w", err)
+		}
+
+		for _, server := range servers {
+			delegatedServers = append(delegatedServers, server.Static)
+		}
+
 		clientEntry := &dmsgdisc.Entry{
-			Client: &dmsgdisc.Client{},
+			Client: &dmsgdisc.Client{
+				DelegatedServers: delegatedServers,
+			},
 			Static: serviceURL.Addr.PK,
 		}
+
 		err = v.dClient.PostEntry(ctx, clientEntry)
 		if err != nil {
 			return nil, fmt.Errorf("Error saving clientEntry: %w", err)

--- a/vendor/github.com/skycoin/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/client.go
@@ -181,7 +181,7 @@ func (ce *Client) Serve(ctx context.Context) {
 				}
 			}
 
-			if err := ce.ensureSession(cancellabelCtx, entry); err != nil {
+			if err := ce.EnsureSession(cancellabelCtx, entry); err != nil {
 				ce.log.WithField("remote_pk", entry.Static).WithError(err).Warn("Failed to establish session.")
 				if err == context.Canceled || err == context.DeadlineExceeded {
 					return
@@ -331,9 +331,9 @@ func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKe
 	return ce.dialSession(ctx, srvEntry)
 }
 
-// ensureSession ensures the existence of a session.
+// EnsureSession ensures the existence of a session.
 // It returns an error if the session does not exist AND cannot be established.
-func (ce *Client) ensureSession(ctx context.Context, entry *disc.Entry) error {
+func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 	ce.sesMx.Lock()
 	defer ce.sesMx.Unlock()
 

--- a/vendor/github.com/skycoin/dmsg/direct/direct.go
+++ b/vendor/github.com/skycoin/dmsg/direct/direct.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 // StartDmsg starts dmsg directly without the discovery
 func StartDmsg(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey,
-	dClient APIClient, config *dmsg.Config) (dmsgDC *dmsg.Client, stop func(), err error) {
+	dClient disc.APIClient, config *dmsg.Config) (dmsgDC *dmsg.Client, stop func(), err error) {
 
 	dmsgDC = dmsg.NewClient(pk, sk, dClient, config)
 	dmsgDC.SetLogger(log)

--- a/vendor/github.com/skycoin/dmsg/disc/client.go
+++ b/vendor/github.com/skycoin/dmsg/disc/client.go
@@ -91,11 +91,11 @@ func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry
 }
 
 // PostEntry creates a new Entry.
-func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
+func (c *httpClient) PostEntry(ctx context.Context, entry *Entry) error {
 	endpoint := c.address + "/dmsg-discovery/entry/"
 	log := c.log.WithField("endpoint", endpoint)
 
-	marshaledEntry, err := json.Marshal(e)
+	marshaledEntry, err := json.Marshal(entry)
 	if err != nil {
 		return err
 	}
@@ -145,11 +145,11 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 }
 
 // DelEntry deletes an Entry.
-func (c *httpClient) DelEntry(ctx context.Context, e *Entry) error {
+func (c *httpClient) DelEntry(ctx context.Context, entry *Entry) error {
 	endpoint := c.address + "/dmsg-discovery/entry"
 	log := c.log.WithField("endpoint", endpoint)
 
-	marshaledEntry, err := json.Marshal(e)
+	marshaledEntry, err := json.Marshal(entry)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/skycoin/dmsg/dmsgget/dmsgget.go
+++ b/vendor/github.com/skycoin/dmsg/dmsgget/dmsgget.go
@@ -69,7 +69,7 @@ func (dg *DmsgGet) flagGroups() []FlagGroup {
 }
 
 // Run runs the download logic.
-func (dg *DmsgGet) Run(ctx context.Context, log logrus.FieldLogger, skStr string, args []string) (err error) {
+func (dg *DmsgGet) Run(ctx context.Context, log *logging.Logger, skStr string, args []string) (err error) {
 	if log == nil {
 		log = logging.MustGetLogger("dmsgget")
 	}
@@ -191,8 +191,8 @@ func parseOutputFile(name string, urlPath string) (*os.File, error) {
 	return nil, os.ErrExist
 }
 
-func (dg *DmsgGet) startDmsg(ctx context.Context, log logrus.FieldLogger, pk cipher.PubKey, sk cipher.SecKey) (dmsgC *dmsg.Client, stop func(), err error) {
-	dmsgC = dmsg.NewClient(pk, sk, disc.NewHTTP(dg.dmsgF.Disc, &http.Client{}, nil), &dmsg.Config{MinSessions: dg.dmsgF.Sessions})
+func (dg *DmsgGet) startDmsg(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey) (dmsgC *dmsg.Client, stop func(), err error) {
+	dmsgC = dmsg.NewClient(pk, sk, disc.NewHTTP(dg.dmsgF.Disc, &http.Client{}, log), &dmsg.Config{MinSessions: dg.dmsgF.Sessions})
 	go dmsgC.Serve(context.Background())
 
 	stop = func() {

--- a/vendor/github.com/skycoin/dmsg/dmsghttp/http.go
+++ b/vendor/github.com/skycoin/dmsg/dmsghttp/http.go
@@ -7,19 +7,14 @@ import (
 
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
-	"github.com/skycoin/dmsg/direct"
+	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 // ListenAndServe serves http over dmsg
-func ListenAndServe(ctx context.Context, pk cipher.PubKey, sk cipher.SecKey, a http.Handler, dClient direct.APIClient, dmsgPort uint16,
-	config *dmsg.Config, log *logging.Logger) error {
-	dmsgC, closeDmsg, err := direct.StartDmsg(ctx, log, pk, sk, dClient, config)
-	if err != nil {
-		return fmt.Errorf("failed to start dmsg: %w", err)
-	}
-	defer closeDmsg()
+func ListenAndServe(ctx context.Context, pk cipher.PubKey, sk cipher.SecKey, a http.Handler, dClient disc.APIClient, dmsgPort uint16,
+	config *dmsg.Config, dmsgC *dmsg.Client, log *logging.Logger) error {
 
 	lis, err := dmsgC.Listen(dmsgPort)
 	if err != nil {

--- a/vendor/github.com/skycoin/dmsg/dmsghttp/util.go
+++ b/vendor/github.com/skycoin/dmsg/dmsghttp/util.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/skycoin/dmsg/direct"
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -35,7 +35,7 @@ func GetServers(ctx context.Context, dmsgDisc string, log *logging.Logger) (entr
 }
 
 // UpdateServers is used to update the servers in the direct client.
-func UpdateServers(ctx context.Context, dClient direct.APIClient, dmsgDisc string, log *logging.Logger) (entries []*disc.Entry) {
+func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string, dmsgC *dmsg.Client, log *logging.Logger) (entries []*disc.Entry) {
 	dmsgclient := disc.NewHTTP(dmsgDisc, &http.Client{}, log)
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
@@ -50,7 +50,8 @@ func UpdateServers(ctx context.Context, dClient direct.APIClient, dmsgDisc strin
 				break
 			}
 			for _, server := range servers {
-				dClient.PostEntry(ctx, server) //nolint
+				dClient.PostEntry(ctx, server)   //nolint
+				dmsgC.EnsureSession(ctx, server) //nolint
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -198,7 +198,7 @@ github.com/shirou/gopsutil/v3/process
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v0.0.0-20211207135321-02790298e924
+# github.com/skycoin/dmsg v0.0.0-20211229130221-70e9ab64c1be
 ## explicit; go 1.16
 github.com/skycoin/dmsg
 github.com/skycoin/dmsg/buildinfo


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes [#dmsg-137](https://github.com/skycoin/dmsg/issues/137)	

 Changes:	
- Update `getHTTPClient` logic

How to test this PR:
1. Checkout [#dmsg-138](https://github.com/skycoin/dmsg/pull/138)
2. Uncomment `replace github.com/skycoin/dmsg => ../dmsg` in `go.mod` in skywire and run `make dep`
3. Build the visor with the `go build -race -o ./ ./cmd/skywire-visor`
4. Gen config `./skywire-cli config gen -dirt`
5. Restart the visor multiple times (10-20 times) and see if you get the datarace

Needs:
[#dmsg-138](https://github.com/skycoin/dmsg/pull/138)