### PR TITLE
Fix EOF error on stratup visor

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -177,7 +177,8 @@ func initDmsgHTTP(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	pk, sk := cipher.GenerateKeyPair()
 	keys = append(keys, pk)
-	dClient := direct.NewClient(direct.GetAllEntries(keys, servers), v.MasterLogger().PackageLogger("dmsg_http:direct_client"))
+	entries := direct.GetAllEntries(keys, servers)
+	dClient := direct.NewClient(entries, v.MasterLogger().PackageLogger("dmsg_http:direct_client"))
 
 	dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx, v.MasterLogger().PackageLogger("dmsg_http:dmsgDC"),
 		pk, sk, dClient, dmsg.DefaultConfig())
@@ -197,6 +198,7 @@ func initDmsgHTTP(ctx context.Context, v *Visor, log *logging.Logger) error {
 	v.dmsgHTTP = &dmsgHTTP
 	v.dmsgDC = dmsgDC
 	v.initLock.Unlock()
+	time.Sleep(time.Duration(len(entries)) * time.Second)
 	return nil
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1036 

 Changes:	
- add an sleep on `initDmsgHTTP` process

How to test this PR:
1. Run `./skywire-cli config gen -dirt`
2. Change `log_level` to `debug` in the config
3. Run `./skywire-visor -c skywire-config.json` (Might have to try multiple times)
4. No warning anymore