### PR TITLE
Fix  header SW-PublicIP

### DIFF
--- a/internal/httpauth/client.go
+++ b/internal/httpauth/client.go
@@ -237,6 +237,9 @@ func (c *Client) doRequest(client *http.Client, req *http.Request, body []byte) 
 	req.Header.Set("SW-Nonce", strconv.FormatUint(uint64(nonce), 10))
 	req.Header.Set("SW-Sig", sign.Hex())
 	req.Header.Set("SW-Public", c.key.Hex())
+	if c.clientPublicIP != "" {
+		req.Header.Set("SW-PublicIP", c.clientPublicIP)
+	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -384,6 +384,15 @@ func initDmsgCtrl(ctx context.Context, v *Visor, _ *logging.Logger) error {
 }
 
 func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
+
+	var serviceURL dmsgget.URL
+	_ = serviceURL.Fill(v.conf.Transport.AddressResolver)
+	// don't start sudph if we are connection to AR via dmsghttp
+	if serviceURL.Scheme != "dmsg" {
+		log.Info("SUDPH transport wont be available under dmsghttp")
+		return nil
+	}
+
 	switch v.stunClient.NATType {
 	case stun.NATSymmetric, stun.NATSymmetricUDPFirewall:
 		log.Infof("SUDPH transport wont be available as visor is under %v", v.stunClient.NATType.String())

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -386,7 +386,7 @@ func initDmsgCtrl(ctx context.Context, v *Visor, _ *logging.Logger) error {
 func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	var serviceURL dmsgget.URL
-	_ = serviceURL.Fill(v.conf.Transport.AddressResolver)
+	_ = serviceURL.Fill(v.conf.Transport.AddressResolver) //nolint:errcheck
 	// don't start sudph if we are connection to AR via dmsghttp
 	if serviceURL.Scheme == "dmsg" {
 		log.Info("SUDPH transport wont be available under dmsghttp")

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -388,7 +388,7 @@ func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 	var serviceURL dmsgget.URL
 	_ = serviceURL.Fill(v.conf.Transport.AddressResolver)
 	// don't start sudph if we are connection to AR via dmsghttp
-	if serviceURL.Scheme != "dmsg" {
+	if serviceURL.Scheme == "dmsg" {
 		log.Info("SUDPH transport wont be available under dmsghttp")
 		return nil
 	}


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #	

 Changes:	
- Added `SW-PublicIP` header in `doRequest()`
- Disabled `sudph` over `dmsghttp`

How to test this PR:
1. Build this PR `make build`
2. Build dmsghttp config `./skywire-cli config gen -dirt`
3. Run visor `./skywire-visor -c skywire-config.json`
4. Check `https://sd.skywire.dev/api/services?type=skysocks` and see if the country and region code is correct.
5. If your machine has public IP then make it `"is_public": true,` in the config and check `https://sd.skywire.dev/api/services?type=visor` and see if the IP is correct.
6. See if `stcpr` has been binded properly by establishing `stcpr` from another visor to this.