### PR TITLE
automigrate from direct url to dmsghttp in local visors

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -132,6 +132,7 @@ var genConfigCmd = &cobra.Command{
 				conf.Routing.RouteFinder = dmsgHTTPServersList.Prod.RouteFinder
 				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Prod.ServiceDiscovery
 			}
+			conf.ConnectionType = "dmsghttp"
 		}
 
 		// Read in old config (if any) and obtain old hypervisors.

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -112,6 +112,11 @@ func runVisor(args []string) {
 		quitSystray()
 		return
 	}
+
+	if vis.MigrateLocalVisor() {
+		vis.Restart()
+	}
+
 	vis.SetLogstore(store)
 
 	go vis.HostKeeper(os.Getenv("SKYBIAN_BUILD_VERSION"))

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -114,7 +114,11 @@ func runVisor(args []string) {
 	}
 
 	if vis.MigrateLocalVisor() {
-		vis.Restart()
+		err := vis.Restart()
+		if err != nil {
+			log.Errorln("Failed to restart visor.")
+			return
+		}
 	}
 
 	vis.SetLogstore(store)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -358,7 +358,7 @@ func (v *Visor) isLocalVisor() bool {
 		return false
 	}
 
-	return string(body) != "CN\n"
+	return string(body) == "CN\n"
 }
 
 func (v *Visor) setDMSGHTTP() bool {

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -53,6 +53,7 @@ func MakeBaseConfig(common *Common) *V1 {
 	conf.ShutdownTimeout = DefaultTimeout
 	conf.RestartCheckDelay = Duration(restart.DefaultCheckDelay)
 	conf.HostKeeper = skyenv.DefaultHostKeeperAddr
+	conf.ConnectionType = "direct"
 	return conf
 }
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -68,6 +68,8 @@ type V1 struct {
 	PersistentTransports []transport.PersistentTransports `json:"persistent_transports"`
 
 	Hypervisor *hypervisorconfig.Config `json:"hypervisor,omitempty"`
+
+	ConnectionType string `json:"connection_type"`
 }
 
 // V1Dmsgpty configures the dmsgpty-host.


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes skywire-services [#525](https://github.com/SkycoinPro/skywire-services/issues/525)

 Changes:	
- add MigrateLocalVisor process during starting visor process
- add new field `connection_type` on config file to distinguish between `direct` (normal URL) and `dmsghttp` connection type

How to test this PR:
- generate a config without `-d` flag, check connection_type
- generate a config / update current config with `-d` flag and check connection_type again