### PR TITLE
Fix close dmsghttp stream

### DIFF
--- a/cmd/skywire-cli/commands/rtfind/root.go
+++ b/cmd/skywire-cli/commands/rtfind/root.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
@@ -32,7 +33,7 @@ var RootCmd = &cobra.Command{
 	Short: "Queries the Route Finder for available routes between two visors",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(_ *cobra.Command, args []string) {
-		rfc := rfclient.NewHTTP(frAddr, timeout, &http.Client{}, nil)
+		rfc := rfclient.NewHTTP(frAddr, timeout, &http.Client{}, &dmsghttp.StreamCloser{}, nil)
 
 		var srcPK, dstPK cipher.PubKey
 		internal.Catch(srcPK.Set(args[0]))

--- a/internal/httpauth/client_test.go
+++ b/internal/httpauth/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestClient(t *testing.T) {
 	ts := newTestServer(t, pk, headerCh)
 	defer ts.Close()
 
-	c, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, ip, masterLogger)
+	c, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/foo", bytes.NewBufferString(payload))
@@ -75,7 +76,7 @@ func TestClient_BadNonce(t *testing.T) {
 	ts := newTestServer(t, pk, headerCh)
 	defer ts.Close()
 
-	c, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, ip, masterLogger)
+	c, err := NewClient(context.TODO(), ts.URL, pk, sk, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 
 	c.nonce = 999

--- a/internal/utclient/client.go
+++ b/internal/utclient/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/internal/httpauth"
@@ -49,7 +50,7 @@ const (
 // * SW-Public: The specified public key
 // * SW-Nonce:  The nonce for that public key
 // * SW-Sig:    The signature of the payload + the nonce
-func NewHTTP(addr string, pk cipher.PubKey, sk cipher.SecKey, httpC *http.Client, clientPublicIP string, mLogger *logging.MasterLogger) (APIClient, error) {
+func NewHTTP(addr string, pk cipher.PubKey, sk cipher.SecKey, httpC *http.Client, streamCloser *dmsghttp.StreamCloser, clientPublicIP string, mLogger *logging.MasterLogger) (APIClient, error) {
 	var client *httpauth.Client
 	var err error
 
@@ -57,7 +58,7 @@ func NewHTTP(addr string, pk cipher.PubKey, sk cipher.SecKey, httpC *http.Client
 
 	retrier := netutil.NewRetrier(createRetryDelay, 10, 2, log)
 	retrierFunc := func() error {
-		client, err = httpauth.NewClient(context.Background(), addr, pk, sk, httpC, clientPublicIP, mLogger)
+		client, err = httpauth.NewClient(context.Background(), addr, pk, sk, httpC, streamCloser, clientPublicIP, mLogger)
 		if err != nil {
 			return fmt.Errorf("uptime tracker httpauth: %w", err)
 		}

--- a/internal/utclient/client_test.go
+++ b/internal/utclient/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func TestClientAuth(t *testing.T) {
 	))
 	defer srv.Close()
 
-	client, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+	client, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 	c := client.(*httpClient)
 
@@ -72,7 +73,7 @@ func TestUpdateVisorUptime(t *testing.T) {
 
 	defer srv.Close()
 
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 
 	err = c.UpdateVisorUptime(context.TODO())

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/pkg/app/appcommon"
@@ -20,6 +21,7 @@ type Factory struct {
 	SK             cipher.SecKey
 	ServiceDisc    string // Address of service-discovery
 	Client         *http.Client
+	StreamCloser   *dmsghttp.StreamCloser
 	ClientPublicIP string
 }
 
@@ -48,7 +50,7 @@ func (f *Factory) VisorUpdater(port uint16) Updater {
 	}
 
 	return &serviceUpdater{
-		client: servicedisc.NewClient(f.Log, f.MLog, conf, f.Client, f.ClientPublicIP),
+		client: servicedisc.NewClient(f.Log, f.MLog, conf, f.Client, f.StreamCloser, f.ClientPublicIP),
 	}
 }
 
@@ -79,11 +81,11 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 	switch conf.AppName {
 	case skyenv.VPNServerName:
 		return &serviceUpdater{
-			client: servicedisc.NewClient(log, f.MLog, getServiceDiscConf(conf, servicedisc.ServiceTypeVPN), f.Client, f.ClientPublicIP),
+			client: servicedisc.NewClient(log, f.MLog, getServiceDiscConf(conf, servicedisc.ServiceTypeVPN), f.Client, f.StreamCloser, f.ClientPublicIP),
 		}, true
 	case skyenv.SkysocksName:
 		return &serviceUpdater{
-			client: servicedisc.NewClient(log, f.MLog, getServiceDiscConf(conf, servicedisc.ServiceTypeSkysocks), f.Client, f.ClientPublicIP),
+			client: servicedisc.NewClient(log, f.MLog, getServiceDiscConf(conf, servicedisc.ServiceTypeSkysocks), f.Client, f.StreamCloser, f.ClientPublicIP),
 		}, true
 	default:
 		return &emptyUpdater{}, false

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/disc"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/pkg/app/appevent"
@@ -20,7 +21,8 @@ type DmsgConfig struct {
 }
 
 // New makes new dmsg client from configuration
-func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, masterLogger *logging.MasterLogger) *dmsg.Client {
+func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, streamCloser *dmsghttp.StreamCloser,
+	masterLogger *logging.MasterLogger) *dmsg.Client {
 	dmsgConf := &dmsg.Config{
 		MinSessions: conf.SessionsCount,
 		Callbacks: &dmsg.ClientCallbacks{

--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/internal/netutil"
@@ -39,10 +40,10 @@ type autoconnector struct {
 
 // MakeConnector returns a new connector that will try to connect to at most maxConns
 // services
-func MakeConnector(conf Config, maxConns int, tm *transport.Manager, httpC *http.Client, clientPublicIP string,
+func MakeConnector(conf Config, maxConns int, tm *transport.Manager, httpC *http.Client, streamCloser *dmsghttp.StreamCloser, clientPublicIP string,
 	log *logging.Logger, mLog *logging.MasterLogger) Autoconnector {
 	connector := &autoconnector{}
-	connector.client = NewClient(log, mLog, conf, httpC, clientPublicIP)
+	connector.client = NewClient(log, mLog, conf, httpC, streamCloser, clientPublicIP)
 	connector.maxConns = maxConns
 	connector.log = log
 	connector.tm = tm

--- a/pkg/transport/network/addrresolver/client_test.go
+++ b/pkg/transport/network/addrresolver/client_test.go
@@ -50,7 +50,7 @@ func TestClientAuth(t *testing.T) {
 	defer srv.Close()
 	log := logging.MustGetLogger("test_client_auth")
 
-	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, log, masterLogger)
+	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, nil, ip, log, masterLogger)
 	require.NoError(t, err)
 
 	c := apiClient.(*httpClient)
@@ -79,7 +79,7 @@ func TestBind(t *testing.T) {
 
 	defer srv.Close()
 	log := logging.MustGetLogger("test_bind")
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, log, masterLogger)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, nil, ip, log, masterLogger)
 	require.NoError(t, err)
 
 	err = c.BindSTCPR(context.TODO(), "1234")

--- a/pkg/transport/tpdclient/client_test.go
+++ b/pkg/transport/tpdclient/client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,12 +80,12 @@ func TestClientAuth(t *testing.T) {
 	))
 	defer srv.Close()
 
-	client, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+	client, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 	c := client.(*apiClient)
 
 	wg.Add(1)
-	_, err = c.Post(context.Background(), "/", bytes.NewBufferString("test payload"))
+	_, _, err = c.Post(context.Background(), "/", bytes.NewBufferString("test payload"))
 	require.NoError(t, err)
 
 	wg.Wait()
@@ -160,7 +161,7 @@ func TestRegisterTransportResponses(t *testing.T) {
 			})))
 			defer srv.Close()
 
-			c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+			c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 			require.NoError(t, err)
 			err = c.RegisterTransports(context.Background(), &transport.SignedEntry{})
 			if tc.assert != nil {
@@ -186,7 +187,7 @@ func TestRegisterTransports(t *testing.T) {
 	})))
 	defer srv.Close()
 
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 	require.NoError(t, c.RegisterTransports(context.Background(), sEntry))
 }
@@ -199,7 +200,7 @@ func TestGetTransportByID(t *testing.T) {
 	})))
 	defer srv.Close()
 
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 	resEntry, err := c.GetTransportByID(context.Background(), entry.ID)
 	require.NoError(t, err)
@@ -215,7 +216,7 @@ func TestGetTransportsByEdge(t *testing.T) {
 	})))
 	defer srv.Close()
 
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, &dmsghttp.StreamCloser{}, ip, masterLogger)
 	require.NoError(t, err)
 	entries, err := c.GetTransportsByEdge(context.Background(), entry.Edges[0])
 	require.NoError(t, err)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	dmsgdisc "github.com/skycoin/dmsg/disc"
+	"github.com/skycoin/dmsg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/internal/httpauth"
@@ -66,12 +67,13 @@ type Visor struct {
 	updater       *updater.Updater
 	uptimeTracker utclient.APIClient
 
-	ebc      *appevent.Broadcaster // event broadcaster
-	dmsgC    *dmsg.Client
-	dmsgDC   *dmsg.Client       // dmsg direct client
-	dClient  dmsgdisc.APIClient // dmsg direct api client
-	dmsgHTTP *http.Client       // dmsghttp client
-	trackers *dmsgtracker.Manager
+	ebc          *appevent.Broadcaster // event broadcaster
+	dmsgC        *dmsg.Client
+	dmsgDC       *dmsg.Client           // dmsg direct client
+	dClient      dmsgdisc.APIClient     // dmsg direct api client
+	dmsgHTTP     *http.Client           // dmsghttp client
+	streamCloser *dmsghttp.StreamCloser // dmsghttp stream closer
+	trackers     *dmsgtracker.Manager
 
 	stunClient   *network.StunDetails
 	wgStunClient *sync.WaitGroup
@@ -285,7 +287,7 @@ func (v *Visor) HostKeeper(skybianBuildVersion string) {
 
 	logger.WithField("Info", keeperInfo).Info("Host information achieved.")
 
-	client, err := httpauth.NewClient(context.Background(), v.conf.HostKeeper, v.conf.PK, v.conf.SK, &http.Client{}, "", v.MasterLogger())
+	client, err := httpauth.NewClient(context.Background(), v.conf.HostKeeper, v.conf.PK, v.conf.SK, &http.Client{}, &dmsghttp.StreamCloser{}, "", v.MasterLogger())
 	if err != nil {
 		logger.Errorf("Host Keeper httpauth: %v", err)
 		return


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #	

 Changes:	
-	

How to test this PR:
1. Checkout to [#dmsg-148](https://github.com/skycoin/dmsg/pull/148)  in dmsg
2. Uncomment `replace github.com/skycoin/dmsg => ../dmsg` in `go.mod`
3. Run `make dep && make build`
4. Generate dmsghttp config `./skywire-cli config gen -dirt`
5. Start visor `./skywire-visor -c skywire-config.json`
6. Check stream close logs on `dmsg-server`
7. Shutdown the visor with `Ctrl+C`
8. Check stream close logs on `dmsg-server`

Needs: [#dmsg-148](https://github.com/skycoin/dmsg/pull/148) 