### PR TITLE
Fix close log

### DIFF
--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -2,6 +2,8 @@ package servicedisc
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"time"
 
@@ -81,7 +83,9 @@ func (a *autoconnector) Run(ctx context.Context) (err error) {
 				a.log.WithField("pk", pk).WithField("attempt", val).Debugln("Trying to add transport to public visor")
 				logger := a.log.WithField("pk", pk).WithField("type", string(network.STCPR))
 				if err = a.tryEstablishTransport(ctx, pk, logger); err != nil {
-					logger.WithError(err).Warnln("Failed to add transport to public visor")
+					if !errors.Is(err, io.ErrClosedPipe) {
+						logger.WithError(err).Warnln("Failed to add transport to public visor")
+					}
 					failedAddresses[pk]++
 					continue
 				}

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/skycoin/dmsg"
@@ -150,6 +151,12 @@ func (c *genericClient) acceptTransports(lis net.Listener) {
 			if errors.Is(err, io.EOF) {
 				continue // likely it's a dummy connection from service discovery
 			}
+
+			if c.isClosed() && (errors.Is(err, io.ErrClosedPipe) || strings.Contains(err.Error(), "use of closed network connection")) {
+				c.log.Info("Cleanly stopped serving.")
+				return
+			}
+
 			c.log.Warnf("failed to accept incoming connection: %v", err)
 			if !handshake.IsHandshakeError(err) {
 				c.log.Warnf("stopped serving")


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1053

 Changes:	
- Added a condition in `acceptTransports()` of `genericClient` to check if the `genericClient` is closed

How to test this PR:
1. Run visor `./skywire-visor -c skywire-config.json` (run visor on machine with public IP for `sudph` and `stcpr`)
2. Close visor with `Ctrl + C`
3. See logs