### PR TITLE
--best-protocol flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - added `--os` flag to `skywire-cli config gen`
 - added `--disable-apps` flag to `skywire-cli config gen`
 - added `--disable-auth` and `--enable-auth` flags to `skywire-cli config gen`
+- added `--best-protocol` flag to `skywire-cli config gen`
 ## 0.5.0
 
 ### Changed


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes skywire-services [#525](https://github.com/SkycoinPro/skywire-services/issues/525)

 Changes:	
- added `--best-protocol` or `-b` flag to determine `dmsghttp` or `direct` for services address

How to test this PR:
- clone and build at this branch
- check it with `skywrie-cli config gen -b`