### PR TITLE
Change the API for getting the VPN IP

### DIFF
--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-status/vpn-status.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-status/vpn-status.component.html
@@ -288,9 +288,9 @@
             <div class="title">{{ 'vpn.status-page.data.country' | translate }}</div>
             <div class="big-text" *ngIf="ipInfoAllowed">
               <ng-container *ngIf="ipCountry">{{ ipCountry }}</ng-container>
-              <ng-container *ngIf="!ipCountry && !loadingIpCountry">{{ 'common.unknown' | translate }}</ng-container>
-              <mat-spinner *ngIf="loadingIpCountry" [diameter]="20"></mat-spinner>
-              <mat-icon *ngIf="problemGettingIpCountry" class="small-icon blinking" [inline]="true" [matTooltip]="'vpn.status-page.data.ip-country-problem-info' | translate">warning</mat-icon>
+              <ng-container *ngIf="!ipCountry && !loadingCurrentIp">{{ 'common.unknown' | translate }}</ng-container>
+              <mat-spinner *ngIf="loadingCurrentIp" [diameter]="20"></mat-spinner>
+              <mat-icon *ngIf="problemGettingIp" class="small-icon blinking" [inline]="true" [matTooltip]="'vpn.status-page.data.ip-country-problem-info' | translate">warning</mat-icon>
             </div>
             <div class="big-text" *ngIf="!ipInfoAllowed">
               {{ 'vpn.status-page.data.unavailable' | translate }}

--- a/static/skywire-manager-src/src/app/services/vpn-client.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client.service.ts
@@ -289,49 +289,30 @@ export class VpnClientService {
    * Gets the public IP of the machine running this app. If there is an error, it could
    * return null.
    */
-  getIp(): Observable<string> {
+   getIpData(): Observable<string[]> {
     // Use a test value if in development mode.
     if (!environment.production && AppConfig.vpn.hardcodedIpWhileDeveloping) {
-      return of('8.8.8.8 (testing)');
+      return of(['8.8.8.8 (testing)', 'United States (testing)']);
     }
 
-    return this.http.request('GET', 'https://api.ipify.org?format=json').pipe(
+    return this.http.request('GET', window.location.protocol + '//ip.skycoin.com/').pipe(
       retryWhen(errors => concat(errors.pipe(delay(this.standardWaitTime), take(4)), throwError(''))),
       map(data => {
-        if (data && data['ip']) {
-          return  data['ip'];
+        let ip = '';
+        if (data && data['ip_address']) {
+          ip = data['ip_address'];
+        } else {
+          ip = this.translateService.instant('common.unknown');
         }
 
-        return null;
-      })
-    );
-  }
-
-  /**
-   * Gets the country of the public IP of the machine running this app. If there is an error,
-   * it could return null.
-   */
-  getIpCountry(ip: string): Observable<string> {
-    // Use a test value if in development mode.
-    if (!environment.production && AppConfig.vpn.hardcodedIpWhileDeveloping) {
-      return of('United States (testing)');
-    }
-
-    return this.http.request('GET', 'https://ip2c.org/' + ip, { responseType: 'text' }).pipe(
-      retryWhen(errors => concat(errors.pipe(delay(2000), take(4)), throwError(''))),
-      map(data => {
-        let country: string = null;
-
-        // The name must be the fourth element of the retrieved value.
-        if (data) {
-          const dataParts: string[] = data.split(';');
-
-          if (dataParts.length === 4) {
-            country = dataParts[3];
-          }
+        let country = '';
+        if (data && data['country_name']) {
+          country = data['country_name'];
+        } else {
+          country = this.translateService.instant('common.unknown');
         }
 
-        return country;
+        return [ip, country];
       })
     );
   }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #1075

 Changes:	
- Now the VPN client uses `ip.skycoin.com` for showing the IP and country to the user.

How to test this PR:
Open the VPN client and check the IP and country shown by the UI. You can check the connection made for getting the data using the browser developer tools.