### PR TITLE
Fix delete inactive client log

### DIFF
--- a/pkg/app/appevent/broadcaster.go
+++ b/pkg/app/appevent/broadcaster.go
@@ -69,11 +69,13 @@ func (mc *Broadcaster) Broadcast(ctx context.Context, e *Event) error {
 	// Delete inactive clients and associated error channels.
 	for client, errCh := range mc.clients {
 		if err := <-errCh; err != nil {
-			mc.log.
-				WithError(err).
-				WithField("close_error", client.Close()).
-				WithField("hello", client.Hello().String()).
-				Warn("Events RPC client closed due to error.")
+			if err.Error() != "connection is shut down" {
+				mc.log.
+					WithError(err).
+					WithField("close_error", client.Close()).
+					WithField("hello", client.Hello().String()).
+					Warn("Events RPC client closed due to error.")
+			}
 
 			delete(mc.clients, client)
 			close(errCh)


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1074 

 Changes:	
- Fixed log

How to test this PR:
1. Start visor `sudo ./skywire-visor -c skywire-config.json`
2. Connect to a `vpn-server` via the `vpn-client`
3. Stop the `vpn-client`
4. Stop visor with `Ctrl+C`
5. See if there is a warning