### PR TITLE
skywire-cli flags for vpn ui and url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - added `--disable-apps` flag to `skywire-cli config gen`
 - added `--disable-auth` and `--enable-auth` flags to `skywire-cli config gen`
 - added `--best-protocol` flag to `skywire-cli config gen`
+- added `skywire-cli visor vpn-ui` and `skywire-cli visor vpn-url` commands
 ## 0.5.0
 
 ### Changed

--- a/cmd/skywire-cli/commands/visor/vpn.go
+++ b/cmd/skywire-cli/commands/visor/vpn.go
@@ -1,0 +1,44 @@
+package visor
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/toqueteos/webbrowser"
+)
+
+func init() {
+	RootCmd.AddCommand(vpnUICmd)
+	RootCmd.AddCommand(vpnURLCmd)
+}
+
+var vpnUICmd = &cobra.Command{
+	Use:   "vpn-ui",
+	Short: "Open VPN UI on browser",
+	Run: func(_ *cobra.Command, _ []string) {
+		client := rpcClient()
+		overview, err := client.Overview()
+		if err != nil {
+			log.Fatal("Failed to connect:", err)
+		}
+		url := fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
+		if err := webbrowser.Open(url); err != nil {
+			log.Fatal("Failed to open VPN UI on browser:", err)
+		}
+	},
+}
+
+var vpnURLCmd = &cobra.Command{
+	Use:   "vpn-url",
+	Short: "Show VPN URL address",
+	Run: func(_ *cobra.Command, _ []string) {
+		client := rpcClient()
+		overview, err := client.Overview()
+		if err != nil {
+			logger.Fatal("Failed to connect:", err)
+		}
+		url := fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
+		fmt.Println(url)
+	},
+}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1079 

 Changes:	
- added two commands to `skywire-cli`
  - `skywire-cli visor vpn-ui` : for running VPN UI on browser
  - `skywire-cli visor vpn-url` : for getting VPN URL on terminal

How to test this PR:
- Build on this branch and start a visor.
- run `./skywire-cli visor vpn-ui` to open VPN UI on browser.
- run `./skywire-cli visor vpn-url` to showing VPN URL on termiunal.