### PR TITLE
Update documentation & other small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ run: ## Run skywire visor with skywire-config.json, and start a browser if runni
 run-source: #to standard gopath $HOME/go/src/github.com/skycoin/skywire
 	test -d apps && rm -r apps || true
 	ln -s scripts/_apps apps
+	chmod +x apps/*
 	go run ./cmd/skywire-cli/skywire-cli.go config gen -ibro ./skywire-config.json
 	go run ./cmd/skywire-visor/skywire-visor.go -c ./skywire-config.json || true
 

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ run: ## Run skywire visor with skywire-config.json, and start a browser if runni
 	./skywire-visor -c ./skywire-config.json
 
 ## Run skywire from source, without compiling binaries - requires skywire cloned
-run-source: #to standard gopath $HOME/go/src/github.com/skycoin/skywire
+run-source:
 	test -d apps && rm -r apps || true
 	ln -s scripts/_apps apps
 	chmod +x apps/*

--- a/Makefile
+++ b/Makefile
@@ -223,10 +223,9 @@ run: ## Run skywire visor with skywire-config.json, and start a browser if runni
 ## Run skywire from source, without compiling binaries - requires skywire cloned
 run-source: #to standard gopath $HOME/go/src/github.com/skycoin/skywire
 	test -d apps && rm -r apps || true
-	ln -s _apps apps
-	go run ./cmd/skywire-cli/skywire-cli.go config gen -iro ./skywire-config.json
+	ln -s scripts/_apps apps
+	go run ./cmd/skywire-cli/skywire-cli.go config gen -ibro ./skywire-config.json
 	go run ./cmd/skywire-visor/skywire-visor.go -c ./skywire-config.json || true
-
 
 lint-ui:  ## Lint the UI code
 	cd $(MANAGER_UI_DIR) && npm run lint

--- a/cmd/skywire-cli/README.md
+++ b/cmd/skywire-cli/README.md
@@ -54,6 +54,7 @@ Usage:
   skywire-cli [command]
 
 Available Commands:
+  completion  Generate completion script
   config      Contains sub-commands that interact with the config of local skywire-visor
   help        Help about any command
   mdisc       Contains sub-commands that interact with a remote DMSG Discovery
@@ -64,6 +65,7 @@ Flags:
   -h, --help   help for skywire-cli
 
 Use "skywire-cli [command] --help" for more information about a command.
+
 ```
 
 ### mdisc usage
@@ -143,7 +145,6 @@ $ skywire-cli mdisc entry 03a5a12feb32e26fb73b85639c7e6b54f119c71ff86a6607e5f22c
 
 ```
 $ skywire-cli visor -h
-
 Contains sub-commands that interact with the local Skywire Visor
 
 Usage:
@@ -155,6 +156,7 @@ Available Commands:
   app-logs-since    Gets logs from given app since RFC3339Nano-formated timestamp. "beginning" is a special timestamp to fetch all the logs
   disc-tp           Queries the Transport Discovery to find transport(s) of given transport ID or edge public key
   exec              Executes the given command
+  hvpk              Obtains the public key of the visor
   ls-apps           Lists apps running on the local visor
   ls-rules          Lists the local visor's routing rules
   ls-tp             Lists the available transports with optional filter flags
@@ -166,7 +168,9 @@ Available Commands:
   set-app-autostart Sets the autostart flag for an app of given name
   start-app         Starts an app of given name
   stop-app          Stops an app of given name
+  summary           Obtains summary of visor information
   tp                Returns summary of given transport by id
+  update            Obtains summary of visor information
   version           Obtains version and build info of the node
 
 Flags:
@@ -530,6 +534,32 @@ Usage:
   skywire-cli visor tp <transport-id> [flags]
 ```
 
+
+#### summary
+
+Obtains summary of visor information
+
+```
+$ skywire-cli visor summary
+```
+
+##### Example
+
+```
+$ skywire-cli visor summary
+.:: Visor Summary ::.
+Public key: "027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed"
+Symmetric NAT: false
+IP: 192.168.2.118
+DMSG Server: "000000000000000000000000000000000000000000000000000000000000000000"
+Ping: "0s"
+Visor Version: v0.6.0-rc1
+Skybian Version:
+Uptime Tracker: connecting
+Time Online: 3.581245 seconds
+Build Tag: linux_amd64
+```
+
 #### version
 
 version
@@ -599,20 +629,24 @@ Usage:
   skywire-cli config gen [flags]
 
 Flags:
+  -b, --best-protocol           choose best protocol (dmsg / direct) to connect based on location
+      --disable-apps string     set list of apps to disable, separated by ','
+      --disable-auth            disable auth on hypervisor UI.
+  -d, --dmsghttp                connect to Skywire Services via dmsg
+      --enable-auth             enable auth on hypervisor UI.
   -h, --help                    help for gen
       --hypervisor-pks string   public keys of hypervisors that should be added to this visor
   -i, --is-hypervisor           generate a hypervisor configuration.
+      --os string               generate configuration with paths for 'macos' or 'windows' (default "linux")
   -o, --output string           path of output config file. (default "skywire-config.json")
   -p, --package                 use defaults for package-based installations in /opt/skywire
+      --public-rpc              change rpc service to public.
   -r, --replace                 rewrite existing config (retains keys).
       --sk cipher.SecKey        if unspecified, a random key pair will be generated.
                                  (default 0000000000000000000000000000000000000000000000000000000000000000)
-  -s, --skybian                 use defaults paths found in skybian
-                                 writes config to /etc/skywire-config.json
   -t, --testenv                 use test deployment service.
-
-Global Flags:
-      --rpc string   RPC server address (default "localhost:3435")
+  -x, --use-old-hypervisors     use old hypervisors keys.
+      --vpn-server-enable       enable vpn server in generated config.
 ```
 
 ##### Example defaults
@@ -623,49 +657,49 @@ The default visor config generation assumes the command is run from the root of 
 $ cd $GOPATH/src/github.com/skycoin/skywire
 $ skywire-cli config gen
 [2021-06-24T08:58:56-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/home/user/go/src/github.com/skycoin/skywire/skywire-config.json"
-[2021-06-24T08:58:56-05:00] INFO [skywire-cli]: Updated file '/home/user/go/src/github.com/skycoin/skywire/skywire-config.json' to: {
-	"version": "v1.0.0",
-	"sk": "b65d256d4a2af23e330179d95c9526a6e053479d8b5ca077ecf97dd8ec189876",
-	"pk": "0336d57c96b706b8560223b0fa71e55331ab3dabe34dd464002ab10bf199ada2b3",
+[2021-06-24T08:58:56-05:00] INFO [skywire-cli]: Updated file '/home/user/go/src/github.com/skycoin/skywire/skywire-config.json' to:  {
+	"version": "v1.1.0",
+	"sk": "f3de5a879e4764069c18f442ca7ffcf0fd3a74764d9607a2377e4568648b1da4",
+	"pk": "02f5d539ecfe2a9c4f3c13863ef607c8c1dd24c07114d7a680b0a5536912ea0eb2",
 	"dmsg": {
-		"discovery": "http://dmsg.discovery.skywire.skycoin.com",
-		"sessions_count": 1
+		"discovery": "http://dmsgd.skywire.skycoin.com",
+		"sessions_count": 1,
+		"servers": []
 	},
 	"dmsgpty": {
-		"port": 22,
-		"authorization_file": "./dmsgpty/whitelist.json",
+		"dmsg_port": 22,
 		"cli_network": "unix",
 		"cli_address": "/tmp/dmsgpty.sock"
 	},
-	"stcp": {
+	"skywire-tcp": {
 		"pk_table": null,
-		"local_address": ":7777"
+		"listening_address": ":7777"
 	},
 	"transport": {
-		"discovery": "http://transport.discovery.skywire.skycoin.com",
-		"address_resolver": "http://address.resolver.skywire.skycoin.com",
-		"log_store": {
-			"type": "file",
-			"location": "./transport_logs"
-		},
-		"trusted_visors": null
+		"discovery": "http://tpd.skywire.skycoin.com",
+		"address_resolver": "http://ar.skywire.skycoin.com",
+		"public_autoconnect": true,
+		"transport_setup_nodes": null
 	},
 	"routing": {
 		"setup_nodes": [
 			"0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
 		],
-		"route_finder": "http://routefinder.skywire.skycoin.com",
-		"route_finder_timeout": "10s"
+		"route_finder": "http://rf.skywire.skycoin.com",
+		"route_finder_timeout": "10s",
+		"min_hops": 0
 	},
 	"uptime_tracker": {
-		"addr": "http://uptime-tracker.skywire.skycoin.com"
+		"addr": "http://ut.skywire.skycoin.com"
 	},
 	"launcher": {
-		"discovery": {
-			"update_interval": "30s",
-			"service_discovery": "http://service.discovery.skycoin.com"
-		},
+		"service_discovery": "http://sd.skycoin.com",
 		"apps": [
+			{
+				"name": "vpn-client",
+				"auto_start": false,
+				"port": 43
+			},
 			{
 				"name": "skychat",
 				"args": [
@@ -689,23 +723,31 @@ $ skywire-cli config gen
 				"name": "vpn-server",
 				"auto_start": false,
 				"port": 44
-			},
-			{
-				"name": "vpn-client",
-				"auto_start": false,
-				"port": 43
 			}
 		],
 		"server_addr": "localhost:5505",
-		"bin_path": "./apps",
-		"local_path": "./local"
+		"bin_path": "./apps"
 	},
 	"hypervisors": [],
 	"cli_addr": "localhost:3435",
 	"log_level": "info",
+	"local_path": "./local",
+	"stun_servers": [
+		"45.118.133.242:3478",
+		"192.53.173.68:3478",
+		"192.46.228.39:3478",
+		"192.53.113.106:3478",
+		"192.53.117.158:3478",
+		"192.53.114.142:3478",
+		"139.177.189.166:3478",
+		"192.46.227.227:3478"
+	],
 	"shutdown_timeout": "10s",
-	"restart_check_delay": "1s"
+	"restart_check_delay": "1s",
+	"is_public": false,
+	"persistent_transports": null
 }
+
 ```
 
 The default configuration is for a visor only. To generate a configuration which provides the hypervisor web interface,
@@ -715,10 +757,10 @@ the `-i` or `--is-hypervisor` flag should be specified.
 $ skywire-cli config gen -i
 ```
 
-##### Example hypervisor configuration for skybian
+Note that it is possible to start the visor with the hypervisor interface explicitly now, regardless of how the config was generated; using the -f flag
 
 ```
-$ skywire-cli config gen -irs
+skywire-visor -f sky
 ```
 
 ##### Example visor configuration for skybian
@@ -742,52 +784,52 @@ $ skywire-cli config gen --hypervisor-pks <hypervisor-public-key> -rs
 This assumes the skywire installation is at `/opt/skywire` with binaries and apps in their own subdirectories.
 
 ```
-$ skywire-cli config gen -ip
-[2021-06-24T09:09:39-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/opt/skywire/skywire.json"
-[2021-06-24T09:09:39-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/opt/skywire/skywire.json"
+#   skywire-cli config gen -bipr --enable-auth -o /opt/skywire/skywire.json
+[2021-06-24T09:09:39-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.1.0" filepath="/opt/skywire/skywire.json"
+[2021-06-24T09:09:39-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.1.0" filepath="/opt/skywire/skywire.json"
 [2021-06-24T09:09:39-05:00] INFO [skywire-cli]: Updated file '/opt/skywire/skywire.json' to: {
-	"version": "v1.0.0",
-	"sk": "b65d256d4a2af23e330179d95c9526a6e053479d8b5ca077ecf97dd8ec189876",
-	"pk": "0336d57c96b706b8560223b0fa71e55331ab3dabe34dd464002ab10bf199ada2b3",
+	"version": "v1.1.0",
+  "sk": "f3de5a879e4764069c18f442ca7ffcf0fd3a74764d9607a2377e4568648b1da4",
+	"pk": "02f5d539ecfe2a9c4f3c13863ef607c8c1dd24c07114d7a680b0a5536912ea0eb2",
 	"dmsg": {
-		"discovery": "http://dmsg.discovery.skywire.skycoin.com",
-		"sessions_count": 1
+		"discovery": "http://dmsgd.skywire.skycoin.com",
+		"sessions_count": 1,
+		"servers": []
 	},
 	"dmsgpty": {
-		"port": 22,
-		"authorization_file": "/opt/skywire/dmsgpty/whitelist.json",
+		"dmsg_port": 22,
 		"cli_network": "unix",
 		"cli_address": "/tmp/dmsgpty.sock"
 	},
-	"stcp": {
+	"skywire-tcp": {
 		"pk_table": null,
-		"local_address": ":7777"
+		"listening_address": ":7777"
 	},
 	"transport": {
-		"discovery": "http://transport.discovery.skywire.skycoin.com",
-		"address_resolver": "http://address.resolver.skywire.skycoin.com",
-		"log_store": {
-			"type": "file",
-			"location": "/opt/skywire/transport_logs"
-		},
-		"trusted_visors": null
+		"discovery": "http://tpd.skywire.skycoin.com",
+		"address_resolver": "http://ar.skywire.skycoin.com",
+		"public_autoconnect": true,
+		"transport_setup_nodes": null
 	},
 	"routing": {
 		"setup_nodes": [
 			"0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
 		],
-		"route_finder": "http://routefinder.skywire.skycoin.com",
-		"route_finder_timeout": "10s"
+		"route_finder": "http://rf.skywire.skycoin.com",
+		"route_finder_timeout": "10s",
+		"min_hops": 0
 	},
 	"uptime_tracker": {
-		"addr": "http://uptime-tracker.skywire.skycoin.com"
+		"addr": "http://ut.skywire.skycoin.com"
 	},
 	"launcher": {
-		"discovery": {
-			"update_interval": "30s",
-			"service_discovery": "http://service.discovery.skycoin.com"
-		},
+		"service_discovery": "http://sd.skycoin.com",
 		"apps": [
+			{
+				"name": "vpn-client",
+				"auto_start": false,
+				"port": 43
+			},
 			{
 				"name": "skychat",
 				"args": [
@@ -811,39 +853,47 @@ $ skywire-cli config gen -ip
 				"name": "vpn-server",
 				"auto_start": false,
 				"port": 44
-			},
-			{
-				"name": "vpn-client",
-				"auto_start": false,
-				"port": 43
 			}
 		],
 		"server_addr": "localhost:5505",
-		"bin_path": "/opt/skywire/apps",
-		"local_path": "/opt/skywire/local"
+		"bin_path": "/opt/skywire/apps"
 	},
 	"hypervisors": [],
 	"cli_addr": "localhost:3435",
 	"log_level": "info",
+	"local_path": "/opt/skywire/local",
+	"stun_servers": [
+		"45.118.133.242:3478",
+		"192.53.173.68:3478",
+		"192.46.228.39:3478",
+		"192.53.113.106:3478",
+		"192.53.117.158:3478",
+		"192.53.114.142:3478",
+		"139.177.189.166:3478",
+		"192.46.227.227:3478"
+	],
 	"shutdown_timeout": "10s",
 	"restart_check_delay": "1s",
+	"is_public": false,
+	"persistent_transports": null,
 	"hypervisor": {
 		"db_path": "/opt/skywire/users.db",
 		"enable_auth": true,
 		"cookies": {
-			"hash_key": "fa985b3bb729fb4feedf3c7f6329cc31dcdca4457ac27d11cdeb14b39f248f01c5b784853074be3b95b02a9edeb2a6c721e0ee5675d1d55705cbd670082a107a",
-			"block_key": "7d2f37467789f9bbd9f053b26a2580e03d2e36ecae0ca966ab6ae10a34b1bfbc",
+			"hash_key": "768b85cc73b97f58568fb3daf5bb18b2520e6a2c9fd792fb0e9d5a40581c2b55c358ed3ced74233cba3d1c23224281dd747e915fa604d78820103efb0ab6f3e9",
+			"block_key": "f4c22d5130bd8ff5f8f4201184ab4bdee63146a4b5c4e3c3f559410c70378243",
 			"expires_duration": 43200000000000,
 			"path": "/",
 			"domain": ""
 		},
 		"dmsg_port": 46,
 		"http_addr": ":8000",
-		"enable_tls": true,
+		"enable_tls": false,
 		"tls_cert_file": "/opt/skywire/ssl/cert.pem",
 		"tls_key_file": "/opt/skywire/ssl/key.pem"
 	}
 }
+
 
 ```
 
@@ -866,7 +916,8 @@ Copy the `skywire.json` config file from the previous example to `skywire-visor.
 the above command output into the following command
 
 ```
-$ skywire-cli config gen --hypervisor-pks <hypervisor-public-key> -pr
+# cp /opt/skywire/skywire.json /ot/skywire/skywire-visor.json
+# skywire-cli config gen --hypervisor-pks <hypervisor-public-key> -bpro /opt/skywire/skywire-visor.json
 ```
 
 The configuration is written (or rewritten)
@@ -877,13 +928,13 @@ either a visor or hypervisor instance
 starting the hypervisor intance
 
 ```
-skywire-visor -c /opt/skywire/skywire.json
+# skywire-visor -c /opt/skywire/skywire.json
 ```
 
 starting visor-only or with remote hypervisor
 
 ```
-skywire-visor -c /opt/skywire/skywire-visor.json
+# skywire-visor -c /opt/skywire/skywire-visor.json
 ```
 
 #### update
@@ -907,90 +958,97 @@ Flags:
 ##### Example
 
 ```
-skywire-cli config update
+$ skywire-cli config update
 [2021-06-24T10:42:33-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="skywire-config.json"
 [2021-06-24T10:42:33-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="skywire-config.json"
-[2021-06-24T10:42:33-05:00] INFO [skywire-cli]: Updated file '/home/d0mo/go/src/github.com/skycoin/skywire/skywire-config.json' to: {
- "version": "v1.0.0",
- "sk": "24db3a001c62baaa5b1a05d3f903e708f9ac0d7ed8d49bc4f1223c6fa94d91d1",
- "pk": "02c8ddafcf4d88c0734b98919c4f924ddb542dbba815b0d804e2e0518fa954f096",
- "dmsg": {
-	 "discovery": "http://dmsg.discovery.skywire.skycoin.com",
-	 "sessions_count": 1
- },
- "dmsgpty": {
-	 "port": 22,
-	 "authorization_file": "./dmsgpty/whitelist.json",
-	 "cli_network": "unix",
-	 "cli_address": "/tmp/dmsgpty.sock"
- },
- "stcp": {
-	 "pk_table": null,
-	 "local_address": ":7777"
- },
- "transport": {
-	 "discovery": "http://transport.discovery.skywire.skycoin.com",
-	 "address_resolver": "http://address.resolver.skywire.skycoin.com",
-	 "log_store": {
-		 "type": "file",
-		 "location": "./transport_logs"
-	 },
-	 "trusted_visors": null
- },
- "routing": {
-	 "setup_nodes": [
-		 "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
-	 ],
-	 "route_finder": "http://routefinder.skywire.skycoin.com",
-	 "route_finder_timeout": "10s"
- },
- "uptime_tracker": {
-	 "addr": "http://uptime-tracker.skywire.skycoin.com"
- },
- "launcher": {
-	 "discovery": {
-		 "update_interval": "30s",
-		 "service_discovery": "http://service.discovery.skycoin.com"
-	 },
-	 "apps": [
-		 {
-			 "name": "skychat",
-			 "args": [
-				 "-addr",
-				 ":8001"
-			 ],
-			 "auto_start": true,
-			 "port": 1
-		 },
-		 {
-			 "name": "skysocks",
-			 "auto_start": true,
-			 "port": 3
-		 },
-		 {
-			 "name": "skysocks-client",
-			 "auto_start": false,
-			 "port": 13
-		 },
-		 {
-			 "name": "vpn-server",
-			 "auto_start": false,
-			 "port": 44
-		 },
-		 {
-			 "name": "vpn-client",
-			 "auto_start": false,
-			 "port": 43
-		 }
-	 ],
-	 "server_addr": "localhost:5505",
-	 "bin_path": "./apps",
-	 "local_path": "./local"
- },
- "hypervisors": [],
- "cli_addr": "localhost:3435",
- "log_level": "info",
- "shutdown_timeout": "10s",
- "restart_check_delay": "1s"
+[2021-06-24T10:42:33-05:00] INFO [skywire-cli]: Updated file '/home/user/go/src/github.com/skycoin/skywire/skywire-config.json' to: {
+	"version": "v1.1.0",
+	"sk": "f3de5a879e4764069c18f442ca7ffcf0fd3a74764d9607a2377e4568648b1da4",
+	"pk": "02f5d539ecfe2a9c4f3c13863ef607c8c1dd24c07114d7a680b0a5536912ea0eb2",
+	"dmsg": {
+		"discovery": "http://dmsgd.skywire.skycoin.com",
+		"sessions_count": 1,
+		"servers": []
+	},
+	"dmsgpty": {
+		"dmsg_port": 22,
+		"cli_network": "unix",
+		"cli_address": "/tmp/dmsgpty.sock"
+	},
+	"skywire-tcp": {
+		"pk_table": null,
+		"listening_address": ":7777"
+	},
+	"transport": {
+		"discovery": "http://tpd.skywire.skycoin.com",
+		"address_resolver": "http://ar.skywire.skycoin.com",
+		"public_autoconnect": true,
+		"transport_setup_nodes": null
+	},
+	"routing": {
+		"setup_nodes": [
+			"0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
+		],
+		"route_finder": "http://rf.skywire.skycoin.com",
+		"route_finder_timeout": "10s",
+		"min_hops": 0
+	},
+	"uptime_tracker": {
+		"addr": "http://ut.skywire.skycoin.com"
+	},
+	"launcher": {
+		"service_discovery": "http://sd.skycoin.com",
+		"apps": [
+			{
+				"name": "vpn-client",
+				"auto_start": false,
+				"port": 43
+			},
+			{
+				"name": "skychat",
+				"args": [
+					"-addr",
+					":8001"
+				],
+				"auto_start": true,
+				"port": 1
+			},
+			{
+				"name": "skysocks",
+				"auto_start": true,
+				"port": 3
+			},
+			{
+				"name": "skysocks-client",
+				"auto_start": false,
+				"port": 13
+			},
+			{
+				"name": "vpn-server",
+				"auto_start": false,
+				"port": 44
+			}
+		],
+		"server_addr": "localhost:5505",
+		"bin_path": "./apps"
+	},
+	"hypervisors": [],
+	"cli_addr": "localhost:3435",
+	"log_level": "info",
+	"local_path": "./local",
+	"stun_servers": [
+		"45.118.133.242:3478",
+		"192.53.173.68:3478",
+		"192.46.228.39:3478",
+		"192.53.113.106:3478",
+		"192.53.117.158:3478",
+		"192.53.114.142:3478",
+		"139.177.189.166:3478",
+		"192.46.227.227:3478"
+	],
+	"shutdown_timeout": "10s",
+	"restart_check_delay": "1s",
+	"is_public": false,
+	"persistent_transports": null
 }
 ```

--- a/cmd/skywire-cli/README.md
+++ b/cmd/skywire-cli/README.md
@@ -763,22 +763,6 @@ Note that it is possible to start the visor with the hypervisor interface explic
 skywire-visor -f sky
 ```
 
-##### Example visor configuration for skybian
-
-It is the typical arrangement to set a visor to use a remote hypervisor if a local instance is not started.
-
-Determine the hypervisor public key by running the following command on the machine running the hypervisor
-
-```
-$ skywire-cli visor pk
-```
-
-substitute the hypervisor public key in the following command:
-
-```
-$ skywire-cli config gen --hypervisor-pks <hypervisor-public-key> -rs
-```
-
 ##### Example hypervisor configuration for package based installation
 
 This assumes the skywire installation is at `/opt/skywire` with binaries and apps in their own subdirectories.
@@ -899,7 +883,7 @@ This assumes the skywire installation is at `/opt/skywire` with binaries and app
 
 The configuration is written (or rewritten)
 
-##### Example - visor configuration for package based installation
+##### Example remote hypervisor configuration for package based installation
 
 It is the typical arrangement to set a visor to use a remote hypervisor if a local instance is not started.
 

--- a/cmd/skywire-cli/README.md
+++ b/cmd/skywire-cli/README.md
@@ -172,7 +172,7 @@ Available Commands:
   stop-app          Stops an app of given name
   summary           Obtains summary of visor information
   tp                Returns summary of given transport by id
-  update            Obtains summary of visor information
+  update            Update a visor
   version           Obtains version and build info of the node
 
 Flags:

--- a/cmd/skywire-cli/README.md
+++ b/cmd/skywire-cli/README.md
@@ -26,8 +26,10 @@ skywire command line interface
         - [set app autostart](#set-app-autostart)
         - [start app](#start-app)
         - [stop app](#stop-app)
+        - [summary](#summary)
         - [tp](#tp)
         - [version](#version)
+        - [update](#update)
     - [rtfind usage](#rtfind-usage)
     - [config usage](#config-usage)
         - [gen](#gen)
@@ -573,6 +575,14 @@ $ skywire-cli visor version
 ```
 $ skywire-cli visor version
 Version "0.4.1" built on "2021-03-19T23:26:21Z" against commit "d804a8ce"
+```
+
+#### update
+
+update
+
+```
+$ skywire-cli visor update
 ```
 
 ### rtfind usage

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -87,7 +87,7 @@ var genConfigCmd = &cobra.Command{
 
 		//set output for package and skybian configs
 		if packageConfig {
-			configName := "skywire-config.json"
+			configName := "skywire-visor.json"
 			if hypervisor {
 				configName = "skywire.json"
 			}

--- a/cmd/skywire-cli/commands/visor/update.go
+++ b/cmd/skywire-cli/commands/visor/update.go
@@ -18,7 +18,7 @@ func init() {
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Obtains summary of visor information",
+	Short: "Update the local visor",
 	Run: func(_ *cobra.Command, _ []string) {
 		// Set channel for check/get available update
 		channel := updater.ChannelStable

--- a/cmd/skywire-visor/README.md
+++ b/cmd/skywire-visor/README.md
@@ -4,6 +4,7 @@
 - [Install](#install)
 - [skywire-visor usage](#skywire-visor-usage)
 - [config file generation](#config-file-generation)
+	- [Run from source without compiling](#run-from-source-without-compiling)
 	- [Example running from source dir](#example-running-from-source-dir)
 	- [Example package based installation](#example-package-based-installation)
 
@@ -17,31 +18,48 @@ $ cd $GOPATH/src/github.com/skycoin/skywire/cmd/skywire-visor
 $ go install ./...
 ```
 
-## skywire-visor usage
+or
+
+```
+make install
+```
+
+## Skywire-visor usage
 
 After the installation, you can run `skywire-visor -h` to see the usage:
 
 ```
-$ skywire-visor -h
+$ skywire-visor --help
+$ go run ./cmd/skywire-visor/skywire-visor.go --help
 Skywire visor
 
 Usage:
   skywire-visor [flags]
+  skywire-visor [command]
+
+Available Commands:
+  completion  Generate completion script
+  help        Help about any command
 
 Flags:
-  -c, --config string      config file location. If the value is 'STDIN', config file will be read from stdin.
-      --delay string       start delay (deprecated) (default "0ns")
-  -h, --help               help for skywire-visor
-      --pprofaddr string   pprof http port if mode is 'http' (default "localhost:6060")
-  -p, --pprofmode string   pprof profiling mode. Valid values: cpu, mem, mutex, block, trace, http
-      --syslog string      syslog server address. E.g. localhost:514
-      --tag string         logging tag (default "skywire")
-  -v, --version            version for skywire-visor
+  -c, --config string        config file location. If the value is 'STDIN', config file will be read from stdin.
+      --delay string         start delay (deprecated) (default "0ns")
+  -h, --help                 help for skywire-visor
+      --launch-browser       open hypervisor web ui (hypervisor only) with system browser
+      --pprofaddr string     pprof http port if mode is 'http' (default "localhost:6060")
+  -p, --pprofmode string     pprof profiling mode. Valid values: cpu, mem, mutex, block, trace, http
+      --syslog string        syslog server address. E.g. localhost:514
+      --tag string           logging tag (default "skywire")
+  -v, --version              version for skywire-visor
+  -f, --with-hypervisor-ui   run visor with hypervisor UI config.
+
+Use "skywire-visor [command] --help" for more information about a command.
+
 ```
 
-## config file generation
+## Config file generation
 
-Refer to the skywire-cli documentation for more detailed information regarding additional flags and argument that may be passed to the following command:
+Refer to the [skywire-cli documentation](../skywire-cli/README.md) for more detailed information regarding additional flags and argument that may be passed to the following command:
 
 ```
 skywire-cli config gen
@@ -49,93 +67,216 @@ skywire-cli config gen
 
 With no additional flags or arguments, the configuration is written to skywire-config.json and stdout.
 
+## Run from source without compiling
+
+The bin_path field in the visor config specifies the path where the binaries are called by skywire-visor. default `./apps`
+
+By placing scripts at this paths with the name of the binary, it is possible to run skywire from source without compiling.
+
+An example of the script
+
+```
+#!/bin/bash
+go run ../../cmd/apps/skychat/chat.go
+```
+
+the following runs skywire from source without compiling:
+
+```
+$ ln -s scripts/_apps apps
+$ chmod +x apps/*
+$ go run ./cmd/skywire-cli/skywire-cli.go config gen -ibro ./skywire-config.json
+$ go run ./cmd/skywire-visor/skywire-visor.go -c ./skywire-config.json
+```
+
+Or, shorthand:
+
+```
+make run-source
+```
+
+
 ##### Example running from source dir
 
 The default filename and paths in the skywire-config.json file are designed for the context of running skywire-visor from within the cloned source repository, wherever it may reside. A brief example of the terminal ouput when running skywire-visor where skywire-config.json exists in the current directory:
 
 ```
-$ skywire-visor
-[2021-06-24T22:08:02-05:00] INFO []: Starting
-[2021-06-24T22:08:02-05:00] DEBUG []: Process info delay=0s parent_systemd=false systemd=false
-Version "0.4.1" built on "2021-03-19T23:26:21Z" against commit "d804a8ce"
-[2021-06-24T22:08:02-05:00] INFO [visor:config]: Reading config from file. filepath="/home/user/go/src/github.com/skycoin/skywire/skywire.json"
-[2021-06-24T22:08:02-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/home/user/go/src/github.com/skycoin/skywire/skywire.json"
-[2021-06-24T22:08:02-05:00] INFO [visor:startup]: Begin startup. public_key=03e08185a0328b7cfd06b8a6f89d605396217053fa0868872e1dbe77b8bab92e1c
-[2021-06-24T22:08:02-05:00] INFO [1/14] [visor:startup:updater]: Starting module...
-[2021-06-24T22:08:02-05:00] INFO [1/14] [visor:startup:updater]: Module started successfully. elapsed=21.567µs
-[2021-06-24T22:08:02-05:00] INFO [2/14] [visor:startup:eventbroadcaster]: Starting module...
-[2021-06-24T22:08:02-05:00] INFO [2/14] [visor:startup:eventbroadcaster]: Module started successfully. elapsed=12.082µs
-[2021-06-24T22:08:02-05:00] INFO [3/14] [visor:startup:addressresolver]: Starting module...
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: Remote UDP server: "address.resolver.skywire.skycoin.com:30178"
-[2021-06-24T22:08:02-05:00] INFO [3/14] [visor:startup:addressresolver]: Module started successfully. elapsed=42.696µs
-[2021-06-24T22:08:02-05:00] INFO [4/14] [visor:startup:discovery]: Starting module...
-[2021-06-24T22:08:02-05:00] INFO [4/14] [visor:startup:discovery]: Module started successfully. elapsed=31.709µs
-[2021-06-24T22:08:02-05:00] INFO [5/14] [visor:startup:snet]: Starting module...
-[2021-06-24T22:08:02-05:00] INFO [snet.dmsgC]: Discovering dmsg servers...
-[2021-06-24T22:08:02-05:00] INFO [snet.dmsgC]: Connecting to the dmsg network... timeout=20s
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: BindSUDPR: Address resolver is not ready yet, waiting...
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: BindSTCPR: Address resolver is not ready yet, waiting...
-[2021-06-24T22:08:02-05:00] INFO [stcp]: listening on addr: [::]:7777
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: Connected to address resolver. STCPR/SUDPH services are available.
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: BindSUDPR: Address resolver became ready, binding
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: BindSTCPR: Address resolver became ready, binding
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: SUDPH Local port: 57644
-[2021-06-24T22:08:02-05:00] INFO [address-resolver]: Performing handshake with 172.104.37.46:30178
-[2021-06-24T22:08:03-05:00] INFO [stcpr]: listening on addr: [::]:45999
-[2021-06-24T22:08:03-05:00] INFO [snet.dmsgC]: Dialing session... remote_pk=02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0
+$ skywire-visor -c skywire-config.json
+[2022-02-07T18:49:00-06:00] DEBUG []: Process info build_tag="" delay=0s parent_systemd=false skybian_build_version="" systemd=false
+Version "unknown" built on "unknown" against commit "unknown"
+[2022-02-07T18:49:00-06:00] INFO [visor:config]: Reading config from file. filepath="skywire-config.json"
+[2022-02-07T18:49:00-06:00] INFO [visor:config]: Flushing config to file. config_version="v1.1.0" filepath="skywire-config.json"
+[2022-02-07T18:49:00-06:00] INFO [visor:startup]: Begin startup. public_key=02da35804dd25dbb91e64e64ca43336206538a775054702d2e543299e5168660ef
+[2022-02-07T18:49:00-06:00] INFO [hypervisor]: Starting
+[2022-02-07T18:49:00-06:00] INFO [visor]: Starting
+[2022-02-07T18:49:00-06:00] INFO [transports]: Starting
+[2022-02-07T18:49:00-06:00] INFO [router]: Starting
+[2022-02-07T18:49:00-06:00] INFO [cli]: Starting
+[2022-02-07T18:49:00-06:00] INFO [updater]: Starting
+[2022-02-07T18:49:00-06:00] INFO [dmsg_ctrl]: Starting
+[2022-02-07T18:49:00-06:00] INFO [stcpr]: Starting
+[2022-02-07T18:49:00-06:00] INFO [public_visor]: Starting
+[2022-02-07T18:49:00-06:00] INFO [public_autoconnect]: Starting
+[2022-02-07T18:49:00-06:00] INFO [transport_setup]: Starting
+[2022-02-07T18:49:00-06:00] INFO [discovery]: Starting
+[2022-02-07T18:49:00-06:00] INFO [stcp]: Starting
+[2022-02-07T18:49:00-06:00] INFO [address_resolver]: Starting
+[2022-02-07T18:49:00-06:00] INFO [dmsg_pty]: Starting
+[2022-02-07T18:49:00-06:00] INFO [hypervisors]: Starting
+[2022-02-07T18:49:00-06:00] INFO [uptime_tracker]: Starting
+[2022-02-07T18:49:00-06:00] INFO [transport]: Starting
+[2022-02-07T18:49:00-06:00] INFO [launcher]: Starting
+[2022-02-07T18:49:00-06:00] INFO [event_broadcaster]: Starting
+[2022-02-07T18:49:00-06:00] INFO [event_broadcaster]: Initialized in 2.929µs (3.236µs with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [stun_client]: Starting
+[2022-02-07T18:49:00-06:00] INFO [sudph]: Starting
+[2022-02-07T18:49:00-06:00] INFO [dmsg_http]: Starting
+[2022-02-07T18:49:00-06:00] INFO [dmsg_http]: Initialized in 551ns (797ns with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [dmsg]: Starting
+[2022-02-07T18:49:00-06:00] INFO [updater]: Initialized in 1.984µs (2.375µs with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [dmsgC]: Discovering dmsg servers...
+[2022-02-07T18:49:00-06:00] INFO [discovery]: Initialized in 33.548µs (713.928µs with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [address_resolver]: Remote UDP server: "ar.skywire.skycoin.com:30178"
+[2022-02-07T18:49:00-06:00] INFO [dmsg]: Initialized in 62.689µs (66.823µs with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [hypervisors]: Initialized in 989ns (762.642µs with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [dmsg_pty]: Initialized in 158.188µs (1.009816ms with dependencies)
+[2022-02-07T18:49:00-06:00] INFO [cli]: Initialized in 1.829639ms (1.829877ms with dependencies)
+[2022-02-07T18:49:01-06:00] INFO [uptime_tracker]: Initialized in 432.529335ms (432.952838ms with dependencies)
+[2022-02-07T18:49:01-06:00] INFO [dmsgC]: Dialing session... remote_pk=02347729662a901d03f1a1ab6c189a173349fa11e79fe82117cca0f8d0e4d64a31
+[2022-02-07T18:49:01-06:00] INFO [address_resolver]: Connected to address resolver. STCPR/SUDPH services are available.
+[2022-02-07T18:49:01-06:00] INFO [address_resolver]: Initialized in 987.461316ms (988.050386ms with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [dmsgC]: Serving session. remote_pk=02347729662a901d03f1a1ab6c189a173349fa11e79fe82117cca0f8d0e4d64a31
+[2022-02-07T18:49:02-06:00] INFO [transport]: Initialized in 470.128967ms (1.458111681s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [dmsgC]: Connecting to the dmsg network... timeout=20s
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: transport manager is serving.
+[2022-02-07T18:49:02-06:00] INFO [transport_setup]: Connecting to the dmsg network. local_pk=02da35804dd25dbb91e64e64ca43336206538a775054702d2e543299e5168660ef
+[2022-02-07T18:49:02-06:00] INFO [transport_setup]: Connected! local_pk=02da35804dd25dbb91e64e64ca43336206538a775054702d2e543299e5168660ef
+[2022-02-07T18:49:02-06:00] INFO [transport_setup]: starting listener dmsg_port=47
+[2022-02-07T18:49:02-06:00] INFO [transport_setup]: Accepting dmsg streams. dmsg_port=47
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: Serving stcp network
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: listening on network: stcp
+[2022-02-07T18:49:02-06:00] INFO [stcp]: Initialized in 366.457µs (1.458857374s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [transport_setup]: Initialized in 361.602µs (1.458985676s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: Serving stcpr network
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: listening on network: stcpr
+[2022-02-07T18:49:02-06:00] INFO [stcp]: listening on addr: [::]:7777
+[2022-02-07T18:49:02-06:00] INFO [public_autoconnect]: Initialized in 9.502µs (1.458628811s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [router]: Starting router
+[2022-02-07T18:49:02-06:00] INFO [dmsgC]: Connected to the dmsg network. timeout=20s
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: Serving dmsg network
+[2022-02-07T18:49:02-06:00] INFO [transport_manager]: listening on network: dmsg
+[2022-02-07T18:49:02-06:00] INFO [stcpr]: Not binding STCPR: no public IP address found
+[2022-02-07T18:49:02-06:00] INFO [dmsg_ctrl]: Initialized in 696.857µs (1.459423545s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [router]: Initialized in 642.448µs (1.459665206s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [stcpr]: Initialized in 447.316µs (1.459153332s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [public_visor]: Initialized in 787ns (1.459423411s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [launcher]: Initialized in 21.113327ms (1.480061107s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [visor]: Initialized in 226ns (1.502320595s with dependencies)
+[2022-02-07T18:49:02-06:00] INFO [visor]: Initializing hypervisor
+[2022-02-07T18:49:02-06:00] INFO [visor]: Serving RPC client over dmsg. addr=02da35804dd25dbb91e64e64ca43336206538a775054702d2e543299e5168660ef:46
+[2022-02-07T18:49:02-06:00] INFO [visor]: Serving hypervisor... addr=":8000" tls=false
+[2022-02-07T18:49:02-06:00] INFO [visor]: Hypervisor initialized
+[2022-02-07T18:49:02-06:00] INFO [hypervisor]: Initialized in 19.833078ms (1.526147062s with dependencies)
 ```
 
 ##### Example for package based installation
 
-Assuming that skywire is installed to /opt/skywire; with app binaries installed at /opt/skywire/apps and the main skywire binaries directly in or symlinked to the executable path. All files generated by running skywire-visor will populate in /opt/skywire
+Assuming that skywire is installed to /opt/skywire; with app binaries installed at /opt/skywire/apps and the main skywire binaries directly in or symlinked to the executable path. All files generated by running skywire-visor should populate in /opt/skywire
 
 The configuration file is generated in the following way
 
 for a visor with local hypervisor:
 
 ```
-$ skywire-cli config gen -ip
+$   skywire-cli config gen -bipr --enable-auth -o /opt/skywire/skywire.json
 ```
 
 for visor with remote hypervisor; first copy the existing configuration file to keep the same keys.
 
 ```
 # cp /opt/skywire/skywire.json /opt/skywire/skywire-visor.json
-# skywire-cli config gen --hypervisor-pks <remote-hypervisor-public-key> -p
+# skywire-cli config gen --hypervisor-pks <remote-hypervisor-public-key> -bpo /opt/skywire/skywire-visor.json
 ```
 
-These two configuration files can be referenced in systemd service files or init scripts to start skywire with either a local or remote hypervisor.
+These two configuration files are referenced in systemd service files to start skywire with either a local or remote hypervisor.
 
 To clarify some terminology; a 'visor' is a running instance of skywire-visor. Previously, on the testnet, this was called a 'node'. This was changed for the sake of differentiating the hardware from the software when troubleshooting issues. The 'public key' in the configuration file is referred to as the 'visor key' or the visor's public key. In the context of using a visor which is running a hypervisor instance as a remote hypervisor for another visor, the public key (visor key) of the visor running the hypervisor web instance is referred to as the 'hypervisor key' or the hypervisor's public key. A hypervisor key is a visor key, these terms are used interchangeably and refer to the same thing for a visor running a hypervisor instance.
 
 ```
 # skywire -c /opt/skywire/skywire.json
-[2021-06-25T14:48:16-05:00] INFO []: Starting
-[2021-06-25T14:48:16-05:00] DEBUG []: Process info delay=0s parent_systemd=false systemd=false
-Version "0.4.1" built on "2021-03-19T23:26:21Z" against commit "d804a8ce"
-[2021-06-25T14:48:16-05:00] INFO [visor:config]: Reading config from file. filepath="/opt/skywire/skywire.json"
-[2021-06-25T14:48:16-05:00] INFO [visor:config]: Flushing config to file. config_version="v1.0.0" filepath="/opt/skywire/skywire.json"
-[2021-06-25T14:48:16-05:00] INFO [visor:startup]: Begin startup. public_key=03e08185a0328b7cfd06b8a6f89d605396217053fa0868872e1dbe77b8bab92e1c
-[2021-06-25T14:48:16-05:00] INFO [1/14] [visor:startup:updater]: Starting module...
-[2021-06-25T14:48:16-05:00] INFO [1/14] [visor:startup:updater]: Module started successfully. elapsed=18.498µs
-[2021-06-25T14:48:16-05:00] INFO [2/14] [visor:startup:eventbroadcaster]: Starting module...
-[2021-06-25T14:48:16-05:00] INFO [2/14] [visor:startup:eventbroadcaster]: Module started successfully. elapsed=11.675µs
-[2021-06-25T14:48:16-05:00] INFO [3/14] [visor:startup:addressresolver]: Starting module...
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: Remote UDP server: "address.resolver.skywire.skycoin.com:30178"
-[2021-06-25T14:48:16-05:00] INFO [3/14] [visor:startup:addressresolver]: Module started successfully. elapsed=40.618µs
-[2021-06-25T14:48:16-05:00] INFO [4/14] [visor:startup:discovery]: Starting module...
-[2021-06-25T14:48:16-05:00] INFO [4/14] [visor:startup:discovery]: Module started successfully. elapsed=13.03µs
-[2021-06-25T14:48:16-05:00] INFO [5/14] [visor:startup:snet]: Starting module...
-[2021-06-25T14:48:16-05:00] INFO [snet.dmsgC]: Discovering dmsg servers...
-[2021-06-25T14:48:16-05:00] INFO [snet.dmsgC]: Connecting to the dmsg network... timeout=20s
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: BindSUDPR: Address resolver is not ready yet, waiting...
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: BindSTCPR: Address resolver is not ready yet, waiting...
-[2021-06-25T14:48:16-05:00] INFO [stcp]: listening on addr: [::]:7777
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: Connected to address resolver. STCPR/SUDPH services are available.
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: BindSUDPR: Address resolver became ready, binding
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: BindSTCPR: Address resolver became ready, binding
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: SUDPH Local port: 40418
-[2021-06-25T14:48:16-05:00] INFO [address-resolver]: Performing handshake with 172.104.37.46:30178
-[2021-06-25T14:48:16-05:00] INFO [stcpr]: listening on addr: [::]:35001
-[2021-06-25T14:48:28-05:00] INFO [snet.dmsgC]: Dialing session... remote_pk=02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0
+[2022-02-07T18:54:55-06:00] DEBUG []: Process info build_tag="linux_amd64" delay=0s parent_systemd=false skybian_build_version="" systemd=false
+Version "v0.6.0-rc1" built on "2022-02-04T13:58:58Z" against commit "74fde018"
+[2022-02-07T18:54:55-06:00] INFO [visor:config]: Reading config from file. filepath="/opt/skywire/skywire.json"
+[2022-02-07T18:54:55-06:00] INFO [visor:config]: Flushing config to file. config_version="v1.1.0" filepath="/opt/skywire/skywire.json"
+[2022-02-07T18:54:55-06:00] INFO [visor:startup]: Begin startup. public_key=027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed
+[2022-02-07T18:54:55-06:00] INFO [hypervisor]: Starting
+[2022-02-07T18:54:55-06:00] INFO [visor]: Starting
+[2022-02-07T18:54:55-06:00] INFO [stcpr]: Starting
+[2022-02-07T18:54:55-06:00] INFO [transport]: Starting
+[2022-02-07T18:54:55-06:00] INFO [launcher]: Starting
+[2022-02-07T18:54:55-06:00] INFO [updater]: Starting
+[2022-02-07T18:54:55-06:00] INFO [public_visor]: Starting
+[2022-02-07T18:54:55-06:00] INFO [stcp]: Starting
+[2022-02-07T18:54:55-06:00] INFO [address_resolver]: Starting
+[2022-02-07T18:54:55-06:00] INFO [updater]: Initialized in 3.209µs (3.578µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [router]: Starting
+[2022-02-07T18:54:55-06:00] INFO [dmsg_http]: Starting
+[2022-02-07T18:54:55-06:00] INFO [dmsg_http]: Initialized in 720ns (981ns with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [discovery]: Starting
+[2022-02-07T18:54:55-06:00] INFO [discovery]: Initialized in 13.829µs (15.098µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [dmsg_pty]: Starting
+[2022-02-07T18:54:55-06:00] INFO [uptime_tracker]: Starting
+[2022-02-07T18:54:55-06:00] INFO [transports]: Starting
+[2022-02-07T18:54:55-06:00] INFO [dmsg_ctrl]: Starting
+[2022-02-07T18:54:55-06:00] INFO [event_broadcaster]: Starting
+[2022-02-07T18:54:55-06:00] INFO [sudph]: Starting
+[2022-02-07T18:54:55-06:00] INFO [dmsg]: Starting
+[2022-02-07T18:54:55-06:00] INFO [transport_setup]: Starting
+[2022-02-07T18:54:55-06:00] INFO [public_autoconnect]: Starting
+[2022-02-07T18:54:55-06:00] INFO [cli]: Starting
+[2022-02-07T18:54:55-06:00] INFO [address_resolver]: Remote UDP server: "ar.skywire.skycoin.com:30178"
+[2022-02-07T18:54:55-06:00] INFO [stun_client]: Starting
+[2022-02-07T18:54:55-06:00] INFO [hypervisors]: Starting
+[2022-02-07T18:54:55-06:00] INFO [event_broadcaster]: Initialized in 2.329µs (2.548µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [dmsg]: Initialized in 22.794µs (367.528µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [hypervisors]: Initialized in 915ns (85.737µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [dmsgC]: Discovering dmsg servers...
+[2022-02-07T18:54:55-06:00] INFO [dmsg_pty]: Initialized in 54.266µs (656.963µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [cli]: Initialized in 404.237µs (404.515µs with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [dmsgC]: Dialing session... remote_pk=02347729662a901d03f1a1ab6c189a173349fa11e79fe82117cca0f8d0e4d64a31
+[2022-02-07T18:54:55-06:00] INFO [uptime_tracker]: Initialized in 509.132965ms (509.13433ms with dependencies)
+[2022-02-07T18:54:55-06:00] INFO [address_resolver]: Connected to address resolver. STCPR/SUDPH services are available.
+[2022-02-07T18:54:56-06:00] INFO [address_resolver]: Initialized in 1.03416369s (1.034390128s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [dmsgC]: Serving session. remote_pk=02347729662a901d03f1a1ab6c189a173349fa11e79fe82117cca0f8d0e4d64a31
+[2022-02-07T18:54:56-06:00] INFO [transport]: Initialized in 507.868374ms (1.542672709s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: Serving stcpr network
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: transport manager is serving.
+[2022-02-07T18:54:56-06:00] INFO [transport_setup]: Connecting to the dmsg network. local_pk=027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed
+[2022-02-07T18:54:56-06:00] INFO [transport_setup]: Connected! local_pk=027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: listening on network: stcpr
+[2022-02-07T18:54:56-06:00] INFO [transport_setup]: starting listener dmsg_port=47
+[2022-02-07T18:54:56-06:00] INFO [stcpr]: Initialized in 471.448µs (1.543308565s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [transport_setup]: Accepting dmsg streams. dmsg_port=47
+[2022-02-07T18:54:56-06:00] INFO [stcpr]: Not binding STCPR: no public IP address found
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: Serving stcp network
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: listening on network: stcp
+[2022-02-07T18:54:56-06:00] INFO [transport_setup]: Initialized in 481.348µs (1.542390746s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [public_visor]: Initialized in 641ns (1.543038283s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [dmsgC]: Connecting to the dmsg network... timeout=20s
+[2022-02-07T18:54:56-06:00] INFO [dmsgC]: Connected to the dmsg network. timeout=20s
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: Serving dmsg network
+[2022-02-07T18:54:56-06:00] INFO [public_autoconnect]: Initialized in 67.16µs (1.542018866s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [router]: Starting router
+[2022-02-07T18:54:56-06:00] INFO [router]: Initialized in 926.371µs (1.543240321s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [stcp]: Initialized in 590.35µs (1.54314418s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [stcp]: listening on addr: [::]:7777
+[2022-02-07T18:54:56-06:00] INFO [transport_manager]: listening on network: dmsg
+[2022-02-07T18:54:56-06:00] INFO [dmsg_ctrl]: Initialized in 1.011469ms (1.543159903s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [launcher]: Initialized in 12.681013ms (1.556420507s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [visor]: Initialized in 245ns (1.566227368s with dependencies)
+[2022-02-07T18:54:56-06:00] INFO [visor]: Initializing hypervisor
+[2022-02-07T18:54:56-06:00] INFO [visor]: Serving RPC client over dmsg. addr=027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed:46
+[2022-02-07T18:54:56-06:00] INFO [visor]: Serving hypervisor... addr=":8000" tls=false
+[2022-02-07T18:54:56-06:00] INFO [visor]: Hypervisor initialized
+[2022-02-07T18:54:56-06:00] INFO [hypervisor]: Initialized in 42.392586ms (1.616936619s with dependencies)
 ```

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	_ "net/http/pprof" // nolint:gosec // https://golang.org/doc/diagnostics.html#profiling
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +22,6 @@ import (
 	"github.com/toqueteos/webbrowser"
 
 	"github.com/skycoin/skywire/pkg/restart"
-	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/syslog"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/hypervisorconfig"
@@ -213,7 +211,7 @@ func initConfig(mLog *logging.MasterLogger, args []string, confPath string) *vis
 		}
 
 		if confPath == "" {
-			confPath = filepath.Join(skyenv.PackageSkywirePath(), defaultConfigName)
+			confPath = defaultConfigName
 		}
 
 		fallthrough

--- a/scripts/_apps/skychat
+++ b/scripts/_apps/skychat
@@ -1,0 +1,2 @@
+#!/bin/bash
+go run ../../cmd/apps/skychat/chat.go

--- a/scripts/_apps/skysocks
+++ b/scripts/_apps/skysocks
@@ -1,0 +1,2 @@
+#!/bin/bash
+go run ../../cmd/apps/skysocks/skysocks.go

--- a/scripts/_apps/skysocks-client
+++ b/scripts/_apps/skysocks-client
@@ -1,0 +1,2 @@
+#!/bin/bash
+go run ../../cmd/apps/skysocks-client/skysocks-client.go

--- a/scripts/_apps/vpn-client
+++ b/scripts/_apps/vpn-client
@@ -1,0 +1,2 @@
+#!/bin/bash
+go run ../../cmd/apps/vpn-client/vpn-client.go

--- a/scripts/_apps/vpn-server
+++ b/scripts/_apps/vpn-server
@@ -1,0 +1,2 @@
+#!/bin/bash
+go run ../../cmd/apps/vpn-server/vpn-server.go

--- a/scripts/_apps/vpn-server
+++ b/scripts/_apps/vpn-server
@@ -1,2 +1,2 @@
 #!/bin/bash
-go run ../../cmd/apps/vpn-server/vpn-server.go
+sudo go run ../../cmd/apps/vpn-server/vpn-server.go


### PR DESCRIPTION
 Changes:	
* documents the current state of the command-line functionality for skywire-cli and visor binaries + example config files
* fix `make run-source`
* match the default config (path) used by the visor with the default config path generated by the cli
* fix the behavior of skywire-cli config-gen -p to match the config names used by scripts in the package
