### PR TITLE
Fix/dmsghttp config missed

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -155,6 +155,8 @@ archives:
   - format: tar.gz
     wrap_in_directory: false
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    files:
+      - dmsghttp-config.json
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/scripts/mac_installer/create_installer.sh
+++ b/scripts/mac_installer/create_installer.sh
@@ -83,6 +83,7 @@ function build_installer() {
   mv ./skywire-visor ${installer_package_dir}/Contents/MacOS/skywire-visor
   mv ./skywire-cli ${installer_package_dir}/Contents/MacOS/skywire-cli
   mv ./apps/vpn-client ${installer_package_dir}/Contents/MacOS/apps/vpn-client
+  cp ./dmsghttp-config.json ${installer_package_dir}/Contents/MacOS/dmsghttp-config.json
 
   cat <<EOF >${installer_package_dir}/Contents/MacOS/Skywire
 #!/bin/bash

--- a/scripts/win_installer/README.md
+++ b/scripts/win_installer/README.md
@@ -1,7 +1,7 @@
 ## Windows installer
 
 ### Requirments
-- windows machine
+- Windows Machine
 - Install **chocolatey** by its instruction [here](https://chocolatey.org/install).
 - Install **GNU Make** by choco
   ```
@@ -20,6 +20,7 @@ You can build **skywire.msi** by
 ```
 make win-installer
 ```
+__Note:__ _Make sure cloned this repo in `C:\` (or other partition that Windows installed)._
 
 ### Install
 Double click the created installer to install skywire.

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -10,7 +10,7 @@ mkdir -p ".\build\amd64\apps" > $null
 mv ..\..\skywire-visor.exe .\build\amd64\skywire-visor.exe
 mv ..\..\skywire-cli.exe .\build\amd64\skywire-cli.exe
 mv ..\..\apps\vpn-client .\build\amd64\apps\vpn-client.exe
-cp ..\..\dmsghttp-config.json .\build\amd64\apps\dmsghttp-config.json
+cp ..\..\dmsghttp-config.json .\build\amd64\dmsghttp-config.json
 rm ..\..\setup-node.exe
 rm -r -fo ..\..\apps
 cp skywire.bat .\build\amd64\skywire.bat

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -10,6 +10,7 @@ mkdir -p ".\build\amd64\apps" > $null
 mv ..\..\skywire-visor.exe .\build\amd64\skywire-visor.exe
 mv ..\..\skywire-cli.exe .\build\amd64\skywire-cli.exe
 mv ..\..\apps\vpn-client .\build\amd64\apps\vpn-client.exe
+cp ..\..\dmsghttp-config.json .\build\amd64\apps\dmsghttp-config.json
 rm ..\..\setup-node.exe
 rm -r -fo ..\..\apps
 cp skywire.bat .\build\amd64\skywire.bat

--- a/scripts/win_installer/wix.json
+++ b/scripts/win_installer/wix.json
@@ -10,7 +10,8 @@
       "build/amd64/apps/vpn-client.exe",
       "build/amd64/skywire.bat",
       "ico.ico",
-      "build/amd64/wintun.dll"
+      "build/amd64/wintun.dll",
+      "build/amd64/dmsghttp-config.json"
     ]
   },
   "env": {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1090 

 Changes:	
- add `dmsghttp-config.json` to win-installer script and goreleaser config.

How to test this PR:
1. goreleaser:
    - Install goreleaser by `sudo snap install --classic goreleaser`
    - Use `goreleaser release --snapshot --rm-dist`
    - Check released archive in `dist` folder and confirm `dmsghttp-config.json` included in built archives.
2. win-installer:
    - Create `.msi` installation by its [instruction](https://github.com/skycoin/skywire/blob/develop/scripts/win_installer/README.md)
    - Install it, then check installation folder for `dsmghttp-config.json`