### PR TITLE
migrate to dmsghttp on binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - added `--disable-auth` and `--enable-auth` flags to `skywire-cli config gen`
 - added `--best-protocol` flag to `skywire-cli config gen`
 - added `skywire-cli visor vpn-ui` and `skywire-cli visor vpn-url` commands
+- added dsmghttp migration to skywire-visor starting
 ## 0.5.0
 
 ### Changed

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2,9 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +13,7 @@ import (
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/internal/netutil"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -145,7 +144,7 @@ var genConfigCmd = &cobra.Command{
 		}
 
 		if bestProtocol {
-			if dmsgProtocol() {
+			if netutil.LocalProtocol() {
 				dmsgHTTP = true
 			}
 		}
@@ -271,19 +270,4 @@ func readOldConfig(log *logging.MasterLogger, confPath string, replace bool) (*v
 	}
 
 	return conf, true
-}
-
-func dmsgProtocol() bool {
-	resp, err := http.Get("https://ipinfo.io/country")
-	if err != nil {
-		return false
-	}
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false
-	}
-	if string(respBody)[:2] == "CN" {
-		return true
-	}
-	return false
 }

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -22,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/toqueteos/webbrowser"
 
+	"github.com/skycoin/skywire/internal/netutil"
 	"github.com/skycoin/skywire/pkg/restart"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/syslog"
@@ -105,6 +107,28 @@ func runVisor(args []string) {
 	defer stopPProf()
 
 	conf := initConfig(log, args, confPath)
+
+	if netutil.LocalProtocol() {
+		var dmsgHTTPServersList visorconfig.DmsgHTTPServers
+		serversListJSON, err := ioutil.ReadFile("dmsghttp-config.json")
+		if err != nil {
+			log.WithError(err).Fatal("Failed to read servers.json file.")
+		}
+		err = json.Unmarshal(serversListJSON, &dmsgHTTPServersList)
+		if err != nil {
+			log.WithError(err).Fatal("Error during parsing servers list")
+		}
+
+		conf.Dmsg.Servers = dmsgHTTPServersList.Prod.DMSGServers
+		conf.Dmsg.Discovery = dmsgHTTPServersList.Prod.DMSGDiscovery
+		conf.Transport.AddressResolver = dmsgHTTPServersList.Prod.AddressResolver
+		conf.Transport.Discovery = dmsgHTTPServersList.Prod.TransportDiscovery
+		conf.UptimeTracker.Addr = dmsgHTTPServersList.Prod.UptimeTracker
+		conf.Routing.RouteFinder = dmsgHTTPServersList.Prod.RouteFinder
+		conf.Launcher.ServiceDisc = dmsgHTTPServersList.Prod.ServiceDiscovery
+
+		conf.Flush() //nolint
+	}
 
 	vis, ok := visor.NewVisor(conf, restartCtx)
 	if !ok {
@@ -225,7 +249,7 @@ func initConfig(mLog *logging.MasterLogger, args []string, confPath string) *vis
 				WithField("filepath", confPath).
 				Fatal("Failed to read config file.")
 		}
-		defer func() {
+		defer func() { //nolint
 			if err := f.Close(); err != nil {
 				log.WithError(err).Error("Closing config file resulted in error.")
 			}

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -1,6 +1,10 @@
 package netutil
 
-import "net"
+import (
+	"io"
+	"net"
+	"net/http"
+)
 
 // LocalAddresses returns a list of all local addresses
 func LocalAddresses() ([]string, error) {
@@ -25,4 +29,20 @@ func LocalAddresses() ([]string, error) {
 	}
 
 	return result, nil
+}
+
+// LocalProtocol check a condition to use dmsghttp or direct url
+func LocalProtocol() bool {
+	resp, err := http.Get("https://ipinfo.io/country")
+	if err != nil {
+		return false
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	if string(respBody)[:2] == "CN" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1070 

 Changes:	
- Add migration to dmsghttp by checking local location in skywire-visor running

How to test this PR:
1. Open `https://ipinfo.io/country`
2. Change line 44 in `/internal/netutil/netutil.go` to result of step 1
3. Build binaries
4. Run `./skywire-cli config gen`
5. Run `./skywire-visor -c skywire-config.json`
6. Check `skywire-config.json` and see changes on addresses.