### PR TITLE
add network monitor value to skyenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - added `--best-protocol` flag to `skywire-cli config gen`
 - added `skywire-cli visor vpn-ui` and `skywire-cli visor vpn-url` commands
 - added dsmghttp migration to skywire-visor starting
+- added network monitor PKs to skyenv
 ## 0.5.0
 
 ### Changed

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -32,6 +32,7 @@ const (
 	DefaultUptimeTrackerAddr   = "http://ut.skywire.skycoin.com"
 	DefaultAddressResolverAddr = "http://ar.skywire.skycoin.com"
 	DefaultSetupPK             = "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
+	DefaultNetworkMonitorPKs   = ""
 )
 
 // Constants for testing deployment.
@@ -43,6 +44,7 @@ const (
 	TestUptimeTrackerAddr   = "http://ut.skywire.dev"
 	TestAddressResolverAddr = "http://ar.skywire.dev"
 	TestSetupPK             = "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
+	TestNetworkMonitorPKs   = ""
 )
 
 // Dmsg port constants.


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes  skywire-service [#484](https://github.com/SkycoinPro/skywire-services/issues/484)

 Changes:	
- add two default and test env variable on skyenv

How to test this PR:
Follow instruction on skywire-services [#501](https://github.com/SkycoinPro/skywire-services/pull/501)