### PR TITLE
Comment out redundant release upload which breaks checksums

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,23 +100,6 @@ for:
     build_script:
       - make build
 
-    after_build:
-      - tar -cvzf skywire-$APPVEYOR_REPO_TAG_NAME-$APPVEYOR_JOB_NAME.tar.gz ./apps/* ./skywire-visor ./skywire-cli ./setup-node
-
-    artifacts:
-      - path: skywire-$(APPVEYOR_REPO_TAG_NAME)-$(APPVEYOR_JOB_NAME).tar.gz
-        name: deploy
-
-    deploy:
-      - provider: GitHub
-        release: $(APPVEYOR_REPO_TAG_NAME)
-        auth_token:
-          secure: ZrbNBE2wSfGvHzEq5GqEAUmNy7myDIl7KK05CKlZdQfieV7XdIAPXpkdHNEyZbvT
-        draft: true
-        artifact: deploy
-        on:
-          APPVEYOR_REPO_TAG: true
-          
   - # Windows (Release)
     skip_non_tags: true
     matrix:


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes redudndant release upload on tags that breaks updater due to incorrect checksums. 	

 Changes:	
-	comment out `on_tag` deploy stage in .appveyor.yml

How to test this PR:
