### PR TITLE
Fix logic of `-o` flag in generate config

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -79,18 +79,15 @@ var genConfigCmd = &cobra.Command{
 			logger.Fatal("Failed to create config: use of mutually exclusive flags")
 		}
 
-		//check -o --output flag set manually or not, if yes override package and skybian config flag
-		if cmd.Flags().Changed("output") {
-			packageConfig = false
-		}
-
 		//set output for package and skybian configs
 		if packageConfig {
 			configName := "skywire-visor.json"
 			if hypervisor {
 				configName = "skywire.json"
 			}
-			output = filepath.Join(skyenv.PackageSkywirePath(), configName)
+			if !cmd.Flags().Changed("output") {
+				output = filepath.Join(skyenv.PackageSkywirePath(), configName)
+			}
 		}
 
 		// Read in old config (if any) and obtain old secret key.


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes the problem with using `p` and `o` flag together.

 Changes:	
- Change condition logic of `o` flag

How to test this PR:
- `make build`
- `./skywire-cli config gen -pio skywire-config.json`
- checking locations in `skywrie-config.json` file