### PR TITLE
Feature/new skywire visor flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.7.0
+
+### Changed
+
+
+### Added
+- added `add-rhv` and `disable-rhv` flags to `skywire-visor` for adding remote hypervisor PK and disable remote hypervisor PK(s) on config file
+
 ## 0.6.0
 
 ### Changed

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/profile"
 	"github.com/skycoin/dmsg/buildinfo"
+	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/cmdutil"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
@@ -41,16 +42,18 @@ const (
 )
 
 var (
-	tag           string
-	syslogAddr    string
-	pprofMode     string
-	pprofAddr     string
-	confPath      string
-	delay         string
-	launchBrowser bool
-	hypervisorUI  bool
-	stopVisorFn   func() // nolint:unused
-	stopVisorWg   sync.WaitGroup
+	tag                  string
+	syslogAddr           string
+	pprofMode            string
+	pprofAddr            string
+	confPath             string
+	delay                string
+	launchBrowser        bool
+	hypervisorUI         bool
+	remoteHypervisorPKs  string
+	disableHypervisorPKs bool
+	stopVisorFn          func() // nolint:unused
+	stopVisorWg          sync.WaitGroup
 )
 
 var rootCmd = &cobra.Command{
@@ -72,6 +75,8 @@ func init() {
 	rootCmd.Flags().StringVar(&delay, "delay", "0ns", "start delay (deprecated)") // deprecated
 	rootCmd.Flags().BoolVarP(&hypervisorUI, "with-hypervisor-ui", "f", false, "run visor with hypervisor UI config.")
 	rootCmd.Flags().BoolVar(&launchBrowser, "launch-browser", false, "open hypervisor web ui (hypervisor only) with system browser")
+	rootCmd.Flags().StringVar(&remoteHypervisorPKs, "add-rhv", "", "add remote hypervisor PKs in runtime")
+	rootCmd.Flags().BoolVar(&disableHypervisorPKs, "disable-rhv", false, "disable remote hypervisor PKs on config file")
 	extraFlags()
 }
 
@@ -126,6 +131,23 @@ func runVisor(args []string) {
 		conf.Launcher.ServiceDisc = dmsgHTTPServersList.Prod.ServiceDiscovery
 
 		conf.Flush() //nolint
+	}
+
+	if disableHypervisorPKs {
+		conf.Hypervisors = []cipher.PubKey{}
+	}
+
+	if remoteHypervisorPKs != "" {
+		hypervisorPKsSlice := strings.Split(remoteHypervisorPKs, ",")
+		for _, pubkeyString := range hypervisorPKsSlice {
+			pubkey := cipher.PubKey{}
+			if err := pubkey.Set(pubkeyString); err != nil {
+				log.Warnf("Cannot add %s PK as remote hypervisor PK due to: %s", pubkeyString, err)
+				continue
+			}
+			log.Infof("%s PK added as remote hypervisor PK", pubkeyString)
+			conf.Hypervisors = append(conf.Hypervisors, pubkey)
+		}
 	}
 
 	vis, ok := visor.NewVisor(conf, restartCtx)


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1110

 Changes:	
- add two new flag `add-rhv` and `disable-rhv` for adding new or disable old remote hypervisor PKs in runtime.

How to test this PR:
- `make build`
- `skywire-visor -c skywire-config.json --add-rhv <PK(s)>`
- `skywire-visor -c skywire-config.json --disable-rhv`

Note: For multiple PKs, use `,` as separator.