### PR TITLE
fix dmsghttp-config.json file path in skywire config

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -149,7 +149,7 @@ var genConfigCmd = &cobra.Command{
 		// Use dmsg urls for services and add dmsg-servers
 		if dmsgHTTP {
 			var dmsgHTTPServersList visorconfig.DmsgHTTPServers
-			serversListJSON, err := ioutil.ReadFile("dmsghttp-config.json")
+			serversListJSON, err := ioutil.ReadFile(conf.DMSGHTTPPath)
 			if err != nil {
 				logger.WithError(err).Fatal("Failed to read servers.json file.")
 			}

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -108,7 +108,7 @@ func runVisor(args []string) {
 
 	if netutil.LocalProtocol() {
 		var dmsgHTTPServersList visorconfig.DmsgHTTPServers
-		serversListJSON, err := ioutil.ReadFile("dmsghttp-config.json")
+		serversListJSON, err := ioutil.ReadFile(conf.DMSGHTTPPath)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to read servers.json file.")
 		}

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -138,6 +138,11 @@ const (
 	DefaultLocalPath = DefaultSkywirePath + "/local"
 )
 
+// Default dmsghttp config constants
+const (
+	DefaultDMSGHTTPPath = DefaultSkywirePath + "/dmsghttp-config.json"
+)
+
 // Default hypervisor constants
 const (
 	DefaultHypervisorDB      = ".skycoin/hypervisor/users.db"
@@ -181,6 +186,11 @@ func PackageAppLocalPath() string {
 // PackageAppBinPath gets apps path for installed Skywire.
 func PackageAppBinPath() string {
 	return filepath.Join(appBinPath(), "apps")
+}
+
+// PackageDMSGHTTPPath gets dmsghttp path for installed Skywire.
+func PackageDMSGHTTPPath() string {
+	return filepath.Join(appBinPath(), "dmsghttp-config.json")
 }
 
 // PackageTpLogStore gets transport logs path for installed Skywire.

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -50,6 +50,7 @@ func MakeBaseConfig(common *Common) *V1 {
 	conf.StunServers = skyenv.GetStunServers()
 	conf.ShutdownTimeout = DefaultTimeout
 	conf.RestartCheckDelay = Duration(restart.DefaultCheckDelay)
+	conf.DMSGHTTPPath = skyenv.DefaultDMSGHTTPPath
 	return conf
 }
 
@@ -132,6 +133,7 @@ func MakePackageConfig(log *logging.MasterLogger, confPath string, sk *cipher.Se
 	}
 	conf.LocalPath = skyenv.PackageAppLocalPath()
 	conf.Launcher.BinPath = skyenv.PackageAppBinPath()
+	conf.DMSGHTTPPath = skyenv.PackageDMSGHTTPPath()
 
 	if conf.Hypervisor != nil {
 		conf.Hypervisor.EnableAuth = skyenv.DefaultPackageEnableAuth

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -63,6 +63,7 @@ type V1 struct {
 	ShutdownTimeout   Duration `json:"shutdown_timeout,omitempty"`    // time value, examples: 10s, 1m, etc
 	RestartCheckDelay Duration `json:"restart_check_delay,omitempty"` // time value, examples: 10s, 1m, etc
 	IsPublic          bool     `json:"is_public"`
+	DMSGHTTPPath      string   `json:"dmsghttp_path"`
 
 	PersistentTransports []transport.PersistentTransports `json:"persistent_transports"`
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -36,6 +36,7 @@ const V101Name = "v1.0.1"
 // Changed stcp field to skywire-tcp
 // Changed local_address field to listening_address
 // Changed port field in dmsgpty to dmsg_port
+// Added dmsghttp_path field to the config
 const V110Name = "v1.1.0"
 
 // V1Name is the semantic version string for the most recent version of V1.


### PR DESCRIPTION
Did you run `make format && make check`?

 Changes:	
- set fix path for `dmsghttp-config.json` on `skywire-config.json`.

How to test this PR:
- `make build`
- `./skywire-cli config gen -d` to check `dmsghttp_path` field on generated configuration