### PR TITLE
Set Status=3 for Connecting of VPN-Client App

### DIFF
--- a/pkg/app/launcher/app_state.go
+++ b/pkg/app/launcher/app_state.go
@@ -12,6 +12,9 @@ const (
 
 	// AppStatusErrored represents status of an errored App.
 	AppStatusErrored
+
+	// AppVPNClientConnecting represents status of VPN client connecting.
+	AppVPNClientConnecting
 )
 
 // AppState defines state parameters for a registered App.

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsg"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/internal/vpn"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -201,6 +202,9 @@ func (l *Launcher) AppStates() []*AppState {
 			connSummary := proc.ConnectionsSummary()
 			if connSummary != nil {
 				state.Status = AppStatusRunning
+			}
+			if state.DetailedStatus == vpn.ClientStatusConnecting {
+				state.Status = AppVPNClientConnecting
 			}
 		}
 		states = append(states, state)


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1096 

 Changes:	
- add status = 3 as VPN connecting

How to test this PR:
- `make build` on this branch, and start visor
- trying to connect to VPN
- during connecting, check `\summary` endpoint and check app status of `vpn-client` should be 3

UI changes:
Hey buddy @Senyoret1, I think you change color of bubbles by status, then seems you should set **Orange** for `status=3`. If you want, I invite you to my repo for change at this PR, if not you can do this on your open PR.