### PR TITLE
remove transports cache system

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ for:
         - job_name: MacOS
 
     install:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
       - make dep
       - sh: ci_scripts/create-ip-aliases.sh
     
@@ -71,7 +71,7 @@ for:
 
     install:
       - choco install make
-      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
       - make dep
       - set PATH=C:\Users\appveyor\go\bin;C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - config updated to `v1.1.1`
 - remove dsmghttp migration to skywire-visor starting
+- remove transports cache from visor initialization and check them before make route
 
 ### Added
 - added `add-rhv` and `disable-rhv` flags to `skywire-visor` for adding remote hypervisor PK and disable remote hypervisor PK(s) on config file

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -400,7 +400,7 @@ func ioErrToRPCIOErr(err error) *RPCIOErr {
 	if netErr, ok := err.(net.Error); ok {
 		rpcIOErr.IsNetErr = true
 		rpcIOErr.IsTimeoutErr = netErr.Timeout()
-		rpcIOErr.IsTemporaryErr = netErr.Temporary()
+		rpcIOErr.IsTemporaryErr = netErr.Temporary() // nolint
 	}
 
 	return rpcIOErr

--- a/pkg/restart/restart_test.go
+++ b/pkg/restart/restart_test.go
@@ -100,7 +100,7 @@ func TestContext_SetCheckDelay(t *testing.T) {
 	cc := CaptureContext()
 	require.Equal(t, DefaultCheckDelay, cc.checkDelay)
 
-	const oneSecond = 1 * time.Second
+	const oneSecond = 1 * time.Second // nolint
 
 	cc.SetCheckDelay(oneSecond)
 	require.Equal(t, oneSecond, cc.checkDelay)

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -342,7 +342,7 @@ func (mt *ManagedTransport) deleteFromDiscovery() error {
 	return retrier.Do(context.Background(), func() error {
 		err := mt.dc.DeleteTransport(context.Background(), mt.Entry.ID)
 		mt.log.WithField("tp-id", mt.Entry.ID).WithError(err).Debug("Error deleting transport")
-		if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+		if netErr, ok := err.(net.Error); ok && netErr.Temporary() { // nolint
 			mt.log.
 				WithError(err).
 				WithField("temporary", true).

--- a/pkg/util/rename/rename.go
+++ b/pkg/util/rename/rename.go
@@ -55,7 +55,7 @@ func move(oldPath string, newPath string) error {
 		}
 	}()
 
-	outputFile, err := os.Create(newPath)
+	outputFile, err := os.Create(newPath) // nolint:gosec
 	if err != nil {
 		return fmt.Errorf("create: %w", err)
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -13,7 +13,6 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsg"
 	"github.com/skycoin/skycoin/src/util/logging"
 
-	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/internal/utclient"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
@@ -84,8 +83,6 @@ type Visor struct {
 	runtimeErrors chan error
 
 	isServicesHealthy *internalHealthInfo
-	transportCacheMu  *sync.Mutex
-	transportsCache   map[cipher.PubKey][]string
 }
 
 // todo: consider moving module closing to the module system
@@ -118,7 +115,6 @@ func NewVisor(conf *visorconfig.V1, restartCtx *restart.Context) (*Visor, bool) 
 		isServicesHealthy: newInternalHealthInfo(),
 		wgTrackers:        new(sync.WaitGroup),
 		wgStunClient:      new(sync.WaitGroup),
-		transportCacheMu:  new(sync.Mutex),
 	}
 	v.wgStunClient.Add(1)
 	v.isServicesHealthy.init()


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes _	

 Changes:	
- remove transports cache logic, and fetch AR data before make transport instead

How to test this PR:
- `make build`
- run visor
- run vpn-server
- trying to connect to vpn-server