### PR TITLE
fixing VPN server problem with multiple network interface

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,12 +41,30 @@ environment:
     appveyor_build_worker_image: ubuntu2004
   
 for:
-  - # Linux and MacOS
+  - # Linux
     skip_tags: true
     matrix:
       only:
         - job_name: Linux
-        - job_name: MacOS
+
+    install:
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
+      - sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev
+      - make dep
+      - sh: ci_scripts/create-ip-aliases.sh
+    
+    before_build:
+      - make check
+   
+    build_script:
+      - make build
+      - make build-systray
+
+  - # MacOS
+    skip_tags: true
+    matrix:
+      only:
+        - job_name: Linux
 
     install:
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ for:
 
     install:
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
-      - sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev
+      - sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev -y
       - make dep
       - sh: ci_scripts/create-ip-aliases.sh
     

--- a/cmd/apps/vpn-server/vpn-server.go
+++ b/cmd/apps/vpn-server/vpn-server.go
@@ -30,6 +30,7 @@ var (
 	localPKStr = flag.String("pk", "", "Local PubKey")
 	localSKStr = flag.String("sk", "", "Local SecKey")
 	passcode   = flag.String("passcode", "", "Passcode to authenticate connecting users")
+	networkIfc = flag.String("netifc", "", "Default network interface for multiple available interfaces")
 	secure     = flag.Bool("secure", true, "Forbid connections from clients to server local network")
 )
 
@@ -73,8 +74,9 @@ func main() {
 	log.Infof("Got app listener, bound to %d", vpnPort)
 
 	srvCfg := vpn.ServerConfig{
-		Passcode: *passcode,
-		Secure:   *secure,
+		Passcode:        *passcode,
+		Secure:          *secure,
+		NetworkInteface: *networkIfc,
 	}
 	srv, err := vpn.NewServer(srvCfg, log)
 	if err != nil {

--- a/cmd/apps/vpn-server/vpn-server.go
+++ b/cmd/apps/vpn-server/vpn-server.go
@@ -74,9 +74,9 @@ func main() {
 	log.Infof("Got app listener, bound to %d", vpnPort)
 
 	srvCfg := vpn.ServerConfig{
-		Passcode:        *passcode,
-		Secure:          *secure,
-		NetworkInteface: *networkIfc,
+		Passcode:         *passcode,
+		Secure:           *secure,
+		NetworkInterface: *networkIfc,
 	}
 	srv, err := vpn.NewServer(srvCfg, log)
 	if err != nil {

--- a/cmd/skywire-cli/commands/config/update/root.go
+++ b/cmd/skywire-cli/commands/config/update/root.go
@@ -30,6 +30,7 @@ var (
 	addVPNServerPasscode   string
 	setVPNServerSecure     string
 	setVPNServerAutostart  string
+	setVPNServerNetIfc     string
 	resetVPNServer         bool
 	addSkysocksClientSrv   string
 	resetSkysocksClient    bool

--- a/cmd/skywire-cli/commands/config/update/update.go
+++ b/cmd/skywire-cli/commands/config/update/update.go
@@ -202,7 +202,7 @@ var vpnServerUpdateCmd = &cobra.Command{
 			changeAppsConfig(conf, "vpn-server", "--passcode", addVPNServerPasscode)
 		}
 		if setVPNServerNetIfc != "" {
-			changeAppsConfig(conf, "vpn-server", "-netifc", setVPNServerNetIfc)
+			changeAppsConfig(conf, "vpn-server", "--netifc", setVPNServerNetIfc)
 		}
 		switch setVPNServerSecure {
 		case "true":

--- a/cmd/skywire-cli/commands/config/update/update.go
+++ b/cmd/skywire-cli/commands/config/update/update.go
@@ -43,6 +43,7 @@ func init() {
 	vpnServerUpdateCmd.Flags().StringVarP(&addVPNServerPasscode, "passwd", "s", "", "add passcode to vpn-server")
 	vpnServerUpdateCmd.Flags().StringVar(&setVPNServerSecure, "secure", "", "change secure mode status of vpn-server")
 	vpnServerUpdateCmd.Flags().StringVar(&setVPNServerAutostart, "autostart", "", "change autostart of vpn-server")
+	vpnServerUpdateCmd.Flags().StringVar(&setVPNServerNetIfc, "netifc", "", "set default network interface")
 	vpnServerUpdateCmd.Flags().BoolVarP(&resetVPNServer, "reset", "r", false, "reset vpn-server configurations")
 }
 
@@ -199,6 +200,9 @@ var vpnServerUpdateCmd = &cobra.Command{
 		}
 		if addVPNServerPasscode != "" {
 			changeAppsConfig(conf, "vpn-server", "--passcode", addVPNServerPasscode)
+		}
+		if setVPNServerNetIfc != "" {
+			changeAppsConfig(conf, "vpn-server", "-netifc", setVPNServerNetIfc)
 		}
 		switch setVPNServerSecure {
 		case "true":

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -138,7 +138,7 @@ func initAdvancedButton(conf *visorconfig.V1) {
 	// if it's not installed via package, hide the uninstall button
 	initUninstallBtn()
 	//hide the buttons which could launch the browser if the process is run as root
-	if checkRoot() {
+	if isRoot() {
 		mAdvancedButton.Hide()
 		mOpenHypervisor.Hide()
 		return
@@ -178,7 +178,7 @@ func initAdvancedButton(conf *visorconfig.V1) {
 
 func initOpenVPNLinkBtn(vc *visorconfig.V1) {
 	mVPNLink = systray.AddMenuItem("Open VPN UI", "Open VPN UI in browser")
-	if checkRoot() {
+	if isRoot() {
 		mVPNLink.Hide()
 		return
 	}

--- a/internal/vpn/server.go
+++ b/internal/vpn/server.go
@@ -37,18 +37,18 @@ func NewServer(cfg ServerConfig, l logrus.FieldLogger) (*Server, error) {
 		ipGen: NewIPGenerator(),
 	}
 
-	if cfg.NetworkInteface == "" {
+	if cfg.NetworkInterface == "" {
 		defaultNetworkIfcs, err := netutil.DefaultNetworkInterface()
 		if err != nil {
 			return nil, fmt.Errorf("error getting default network interface: %w", err)
 		}
-		netIfcs, isMultiple := s.checkingNetworkInterface(defaultNetworkIfcs)
-		if isMultiple {
-			return nil, fmt.Errorf("multiple default network interface detected, please set once in setting or be single: %v", netIfcs)
+		ifcs, hasMultiple := s.hasMutipleNetworkInterfaces(defaultNetworkIfcs)
+		if hasMultiple {
+			return nil, fmt.Errorf("multiple default network interfaces detected...set a default one for VPN server or remove one: %v", ifcs)
 		}
 		defaultNetworkIfc = defaultNetworkIfcs
 	} else {
-		defaultNetworkIfc = cfg.NetworkInteface
+		defaultNetworkIfc = cfg.NetworkInterface
 	}
 
 	l.Infof("Got default network interface: %s", defaultNetworkIfc)
@@ -328,7 +328,7 @@ func (s *Server) sendServerErrHello(conn net.Conn, status HandshakeStatus) {
 	}
 }
 
-func (s *Server) checkingNetworkInterface(defaultNetworkInterface string) ([]string, bool) {
+func (s *Server) hasMutipleNetworkInterfaces(defaultNetworkInterface string) ([]string, bool) {
 	networkInterfaces := strings.Split(defaultNetworkInterface, "\n")
 	if len(networkInterfaces) > 1 {
 		return networkInterfaces, true

--- a/internal/vpn/server.go
+++ b/internal/vpn/server.go
@@ -36,16 +36,17 @@ func NewServer(cfg ServerConfig, l logrus.FieldLogger) (*Server, error) {
 		log:   l,
 		ipGen: NewIPGenerator(),
 	}
+
 	if cfg.NetworkInteface == "" {
-		defaultNetworkIfc, err := netutil.DefaultNetworkInterface()
+		defaultNetworkIfcs, err := netutil.DefaultNetworkInterface()
 		if err != nil {
 			return nil, fmt.Errorf("error getting default network interface: %w", err)
 		}
-
-		netIfcs, isMultiple := s.checkingNetworkInterface(defaultNetworkIfc)
+		netIfcs, isMultiple := s.checkingNetworkInterface(defaultNetworkIfcs)
 		if isMultiple {
 			return nil, fmt.Errorf("multiple default network interface detected, please set once in setting or be single: %v", netIfcs)
 		}
+		defaultNetworkIfc = defaultNetworkIfcs
 	} else {
 		defaultNetworkIfc = cfg.NetworkInteface
 	}

--- a/internal/vpn/server_config.go
+++ b/internal/vpn/server_config.go
@@ -2,7 +2,7 @@ package vpn
 
 // ServerConfig is a configuration for VPN server.
 type ServerConfig struct {
-	Passcode        string
-	Secure          bool
-	NetworkInteface string
+	Passcode         string
+	Secure           bool
+	NetworkInterface string
 }

--- a/internal/vpn/server_config.go
+++ b/internal/vpn/server_config.go
@@ -2,6 +2,7 @@ package vpn
 
 // ServerConfig is a configuration for VPN server.
 type ServerConfig struct {
-	Passcode string
-	Secure   bool
+	Passcode        string
+	Secure          bool
+	NetworkInteface string
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -421,7 +421,7 @@ func (v *Visor) SetAppNetworkInterface(appName, netifc string) error {
 	v.log.Infof("Changing %s network interface to %q", appName, netifc)
 
 	const (
-		netifcArgName = "-netifc"
+		netifcArgName = "--netifc"
 	)
 
 	if err := v.conf.UpdateAppArg(v.appL, appName, netifcArgName, netifc); err != nil {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -47,6 +47,7 @@ type API interface {
 	SetAppPK(appName string, pk cipher.PubKey) error
 	SetAppSecure(appName string, isSecure bool) error
 	SetAppKillswitch(appName string, killswitch bool) error
+	SetAppNetworkInterface(appName string, netifc string) error
 	LogsSince(timestamp time.Time, appName string) ([]string, error)
 	GetAppStats(appName string) (appserver.AppStats, error)
 	GetAppError(appName string) (string, error)
@@ -407,6 +408,27 @@ func (v *Visor) SetAppPassword(appName, password string) error {
 	}
 
 	v.log.Infof("Updated %v password", appName)
+
+	return nil
+}
+
+// SetAppNetworkInterface implements API.
+func (v *Visor) SetAppNetworkInterface(appName, netifc string) error {
+	if skyenv.VPNServerName != appName {
+		return fmt.Errorf("app %s is not allowed to set network interface", appName)
+	}
+
+	v.log.Infof("Changing %s network interface to %q", appName, netifc)
+
+	const (
+		netifcArgName = "-netifc"
+	)
+
+	if err := v.conf.UpdateAppArg(v.appL, appName, netifcArgName, netifc); err != nil {
+		return err
+	}
+
+	v.log.Infof("Updated %v network interface", appName)
 
 	return nil
 }

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -604,13 +604,14 @@ func (hv *Hypervisor) putApp() http.HandlerFunc {
 			Secure     *bool          `json:"secure,omitempty"`
 			Status     *int           `json:"status,omitempty"`
 			Passcode   *string        `json:"passcode,omitempty"`
+			NetIfc     *string        `json:"netifc,omitempty"`
 			PK         *cipher.PubKey `json:"pk,omitempty"`
 		}
 
 		shouldRestartApp := func(r req) bool {
 			// we restart the app if one of these fields was changed
 			return r.Killswitch != nil || r.Secure != nil || r.Passcode != nil ||
-				r.PK != nil
+				r.PK != nil || r.NetIfc != nil
 		}
 
 		var reqBody req
@@ -656,6 +657,13 @@ func (hv *Hypervisor) putApp() http.HandlerFunc {
 
 		if reqBody.Secure != nil {
 			if err := ctx.API.SetAppSecure(ctx.App.Name, *reqBody.Secure); err != nil {
+				httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
+				return
+			}
+		}
+
+		if reqBody.NetIfc != nil {
+			if err := ctx.API.SetAppNetworkInterface(ctx.App.Name, *reqBody.NetIfc); err != nil {
 				httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
 				return
 			}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -253,6 +253,19 @@ func (r *RPC) SetAppPassword(in *SetAppPasswordIn, _ *struct{}) (err error) {
 	return r.visor.SetAppPassword(in.AppName, in.Password)
 }
 
+// SetAppNetworkInterfaceIn is input for SetAppNetworkInterface.
+type SetAppNetworkInterfaceIn struct {
+	AppName string
+	NetIfc  string
+}
+
+// SetAppNetworkInterface sets network interface for the app.
+func (r *RPC) SetAppNetworkInterface(in *SetAppNetworkInterfaceIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetAppNetworkInterface", in)(nil, &err)
+
+	return r.visor.SetAppNetworkInterface(in.AppName, in.NetIfc)
+}
+
 // SetAppPKIn is input for SetAppPK.
 type SetAppPKIn struct {
 	AppName string

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -190,6 +190,14 @@ func (rc *rpcClient) SetAppKillswitch(appName string, killswitch bool) error {
 	}, &struct{}{})
 }
 
+// SetAppKillswitch implements API.
+func (rc *rpcClient) SetAppNetworkInterface(appName, netifc string) error {
+	return rc.Call("SetAppNetworkInterface", &SetAppNetworkInterfaceIn{
+		AppName: appName,
+		NetIfc:  netifc,
+	}, &struct{}{})
+}
+
 // SetAppSecure implements API.
 func (rc *rpcClient) SetAppSecure(appName string, isSecure bool) error {
 	return rc.Call("SetAppSecure", &SetAppBoolIn{
@@ -740,6 +748,21 @@ func (mc *mockRPCClient) SetAppPassword(string, string) error {
 		}
 
 		return fmt.Errorf("app of name '%s' does not exist", socksName)
+	})
+}
+
+// SetAppPassword implements API.
+func (mc *mockRPCClient) SetAppNetworkInterface(string, string) error {
+	return mc.do(true, func() error {
+		const vpnServerName = "vpn-server"
+
+		for i := range mc.o.Apps {
+			if mc.o.Apps[i].Name == vpnServerName {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("app of name '%s' does not exist", vpnServerName)
 	})
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1145

 Changes:	
- add new argument to vpn-server `-netifc`
- add cli related command

How to test this PR:
- check you have more than one default network interface by `ip r` command, if not make it.
- `make build`
- start vpn-server from UI and check logs, you should see an error like this:
  `[2022-04-19T04:45:50+04:30] INFO (STDERR) [proc:vpn-server:8ba78bc35b91411081c546dbb5ca1edd]: time="2022-04-19T04:45:50+04:30" level=fatal msg="Error creating VPN server" error="multiple default network interface detected, please set once in setting or be single: [enp0s20u3 wlp7s0]"`
- set `-netifc` argument in vpn-server part of config
- start vpn-server again, and would start normaly
- actually, you can set it by `skywire-cli config update vpns --netifc xxx` [Not work now, get an error `FATAL []: Failed to parse config. error="open : no such file or directory"`, need handle by @0pcom help ]
- and, you can set it by hypervisor UI too [need #1158] 