### PR TITLE
own goroutine for dmsg trackers

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -218,7 +218,6 @@ func (v *Visor) Summary() (*Summary, error) {
 	}
 
 	dmsgStatValue := &dmsgtracker.DmsgClientSummary{}
-	v.wgTrackers.Wait()
 	if v.trackers != nil {
 		if dmsgTracker := v.trackers.GetBulk([]cipher.PubKey{v.conf.PK}); len(dmsgTracker) > 0 {
 			dmsgStatValue = &dmsgTracker[0]

--- a/pkg/visor/dmsgtracker/dmsg_tracker.go
+++ b/pkg/visor/dmsgtracker/dmsg_tracker.go
@@ -94,7 +94,6 @@ type Manager struct {
 
 // NewDmsgTrackerManager creates a new dmsg tracker manager.
 func NewDmsgTrackerManager(mLog *logging.MasterLogger, dc *dmsg.Client, updateInterval, updateTimeout time.Duration) *Manager {
-
 	log := mLog.PackageLogger("dmsg_trackers")
 	if updateInterval == 0 {
 		updateInterval = DefaultDTMUpdateInterval

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -91,11 +91,10 @@ func New(config hypervisorconfig.Config, visor *Visor, dmsgC *dmsg.Client) (*Hyp
 	}
 
 	hv := &Hypervisor{
-		c:      config,
-		visor:  visor,
-		dmsgC:  dmsgC,
-		visors: make(map[cipher.PubKey]Conn),
-		// trackers:     dmsgtracker.NewDmsgTrackerManager(mLogger, dmsgC, 0, 0),
+		c:            config,
+		visor:        visor,
+		dmsgC:        dmsgC,
+		visors:       make(map[cipher.PubKey]Conn),
 		users:        usermanager.NewUserManager(mLogger, singleUserDB, config.Cookies),
 		mu:           new(sync.RWMutex),
 		visorChanMux: make(map[cipher.PubKey]*chanMux),


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1093 

 Changes:	
- make own goroutine for hypervisor and visor dsmgtracker

How to test this PR:
- clone this branch
- add `time.Sleep(30*time.Second)` at the beginning of `NewDmsgTrackerManager` function. [here](https://github.com/mrpalide/skywire/blob/4328efeacb52c08950acf850841f40e0ec9f0475/pkg/visor/dmsgtracker/dmsg_tracker.go#L96)
- `make build`
- create hypervisor config `skywire-cli config gen -tir` and run it
- check hypervisor UI and RPC summary by `skywire-cli visor info`
- wait for 30 seconds
- check hypervisor UI and RPC summary again