### PR TITLE
Fix/close vpn conn gracefully

### DIFF
--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -300,7 +300,7 @@ func (r *RPCIngressGateway) CloseConn(connID *uint16, _ *struct{}) (err error) {
 
 // CloseListener closes listener specified by `lisID`.
 func (r *RPCIngressGateway) CloseListener(lisID *uint16, _ *struct{}) (err error) {
-	defer rpcutil.LogCall(r.log, "CloseConn", lisID)(nil, &err)
+	defer rpcutil.LogCall(r.log, "CloseListener", lisID)(nil, &err)
 
 	lis, err := r.popListener(*lisID)
 	if err != nil {

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -578,9 +578,6 @@ func (rg *RouteGroup) close(code routing.CloseCode) error {
 func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 	switch packet.Type() {
 	case routing.ClosePacket:
-		rg.mu.Lock()
-		defer rg.mu.Unlock()
-
 		return rg.handleClosePacket(routing.CloseCode(packet.Payload()[0]))
 	case routing.DataPacket:
 		rg.handshakeProcessedOnce.Do(func() {


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1095 

 Changes:	
- Removed mutex lock

How to test this PR:
1. Start vpn-server on visor A
2. Start Visor B and connect to the vpn-server
3. Stop the vpn-client on visor B
4. Check logs of visor B