### PR TITLE
Use logging package from skycoin for retrier

### DIFF
--- a/cmd/apps/skysocks-client/skysocks-client.go
+++ b/cmd/apps/skysocks-client/skysocks-client.go
@@ -28,7 +28,7 @@ const (
 	socksPort = routing.Port(3)
 )
 
-var log = logging.MustGetLogger("chat")
+var log = logging.MustGetLogger("skysocks-client")
 
 var r = netutil.NewRetrier(log, time.Second, netutil.DefaultMaxBackoff, 0, 1)
 

--- a/cmd/apps/skysocks-client/skysocks-client.go
+++ b/cmd/apps/skysocks-client/skysocks-client.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
@@ -28,7 +28,7 @@ const (
 	socksPort = routing.Port(3)
 )
 
-var log = logrus.New()
+var log = logging.MustGetLogger("chat")
 
 var r = netutil.NewRetrier(log, time.Second, netutil.DefaultMaxBackoff, 0, 1)
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/ccding/go-stun/stun"
-	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/direct"
 	dmsgdisc "github.com/skycoin/dmsg/pkg/disc"
 	"github.com/skycoin/dmsg/pkg/dmsg"
@@ -646,7 +645,8 @@ func vpnEnvMaker(conf *visorconfig.V1, dmsgC, dmsgDC *dmsg.Client, tpRemoteAddrs
 		if conf.Dmsg != nil {
 			envCfg.DmsgDiscovery = conf.Dmsg.Discovery
 
-			r := netutil.NewRetrier(logrus.New(), 1*time.Second, 10*time.Second, 0, 1)
+			log := conf.MasterLogger().PackageLogger("vpn_env_maker")
+			r := netutil.NewRetrier(log, 1*time.Second, 10*time.Second, 0, 1)
 			err := r.Do(context.Background(), func() error {
 				for _, ses := range dmsgC.AllSessions() {
 					envCfg.DmsgServers = append(envCfg.DmsgServers, ses.RemoteTCPAddr().String())


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1133 

 Changes:	
- Used logging package from `skycoin/src/util/logging`

How to test this PR:
1. Make config for test `./skywire-cli config gen -irt`
2. Run `./skywire-visor -c skywire-config.json`
3. Try to connect to a vpn-server (online vpn-server is not needed)
4. Check logs