### PR TITLE
fix visor uses default config with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - revise versioning - move to skyenv
 - remove transports cache from visor initialization and check them before make route
 - `run-source` makefile directive write config to stdout & read config from stdin
+- fixed skywire-visor uses skywire-config.json (default config name) without needing to specify
 
 ### Added
 - added `add-rhv` and `disable-rhv` flags to `skywire-visor` for adding remote hypervisor PK and disable remote hypervisor PK(s) on config file

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -181,6 +181,9 @@ var rootCmd = &cobra.Command{
 			if usr {
 				confPath = skyenv.HomePath() + "/" + skyenv.ConfigName
 			}
+			if confPath == "" {
+				confPath = skyenv.ConfigName
+			}
 			//enforce .json extension
 			if !strings.HasSuffix(confPath, ".json") {
 				//append .json


### PR DESCRIPTION
Did you run `make format && make check`?
yes

visor uses skywire-config.json with no arguments by default

 Changes:	
-	visor should use the default config if present without needing to specify `-c skywire-config.json`

How to test this PR:
```
git clone --single-branch -b fix-visor-default-config https://github.com/the-skycoin-project/skywire
cd skywire
make build
./skywire-cli config gen -r
./skywire-visor

```