### PR TITLE
Improve Windows Installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Char
 /scripts/mac_installer/icon.iconset/
 releaseChangelog.md
 skywire.msi
+/scripts/win_installer/build/

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -136,7 +136,6 @@ func initAdvancedButton(conf *visorconfig.V1) {
 	// if it's not installed via package, hide the uninstall button
 	if !checkIsPackage() {
 		mAdvancedButton.Hide()
-		mUninstall.Hide()
 	}
 }
 

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -69,11 +69,8 @@ func GetOnGUIReady(icon []byte, conf *visorconfig.V1) func() {
 	logger := logging.NewMasterLogger()
 	logger.SetLevel(logrus.InfoLevel)
 
-	go func() {
-
-	}()
-
 	httpC := getHTTPClient(conf, context.Background(), logger)
+
 	if isRoot() {
 		return func() {
 			systray.SetTemplateIcon(icon, icon)

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -274,7 +274,7 @@ func serversBtn(conf *visorconfig.V1, servers []*systray.MenuItem, rpcClient vis
 	for {
 		selectedServer := servers[<-btnChannel]
 		serverTempValue := strings.Split(selectedServer.String(), ",")[2]
-		serverPK := serverTempValue[2 : len(serverTempValue)-5]
+		serverPK := serverTempValue[2 : len(serverTempValue)-7]
 		for _, server := range servers {
 			server.Uncheck()
 			server.Enable()
@@ -351,7 +351,7 @@ func getAvailPublicVPNServers(conf *visorconfig.V1, httpC *http.Client, logger *
 		if server.Geo != nil {
 			serverAddrs[idx] = server.Addr.PubKey().String() + " | " + server.Geo.Country
 		} else {
-			serverAddrs[idx] = server.Addr.PubKey().String() + " | N/A"
+			serverAddrs[idx] = server.Addr.PubKey().String() + " | NA"
 		}
 	}
 	return serverAddrs

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -540,12 +540,15 @@ func (v *Visor) GetAppError(appName string) (string, error) {
 
 // GetAppConnectionsSummary implements API.
 func (v *Visor) GetAppConnectionsSummary(appName string) ([]appserver.ConnectionSummary, error) {
-	cSummary, err := v.procM.ConnectionsSummary(appName)
-	if err != nil {
-		return nil, err
-	}
+	if v.procM != nil {
+		cSummary, err := v.procM.ConnectionsSummary(appName)
+		if err != nil {
+			return nil, err
+		}
 
-	return cSummary, nil
+		return cSummary, nil
+	}
+	return nil, nil
 }
 
 // TransportTypes implements API.

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -14,6 +14,8 @@ cp ..\..\dmsghttp-config.json .\build\amd64\dmsghttp-config.json
 rm ..\..\setup-node.exe
 rm -r -fo ..\..\apps
 cp skywire.bat .\build\amd64\skywire.bat
+ni new.update
+mv new.update .\build\amd64\new.update
 curl "https://www.wintun.net/builds/wintun-0.14.1.zip" -o wintun.zip
 tar -xf wintun.zip
 cp .\wintun\bin\amd64\wintun.dll .\build\amd64\wintun.dll

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -23,30 +23,30 @@ echo:
 
 :: Creating logs folder if not exist [Run just in first time after installing]
 if not exist "local\logs\" (
-	mkdir "local\logs"  >nul 2>&1
+	mkdir "local\logs" >nul 2>&1
 )
 
 :: Moving vpn-client.exe to its path
 if exist vpn-client.exe (
     if not exist "apps\" (
-        mkdir apps  >nul 2>&1
+        mkdir apps >nul 2>&1
     )
     move /Y vpn-client.exe apps >nul 2>&1
 )
 
 :: Moving wintun.dll to system32 path
 if exist "wintun.dll" (
-    move /Y wintun.dll "C:\Windows\System32"  >nul 2>&1
+    move /Y wintun.dll "C:\Windows\System32" >nul 2>&1
 )
 
 :: Moving existed config file in user home to installation path
 if exist "%HOMEPATH%\skywire-config.json" (
-	move /Y "%HOMEPATH%\skywire-config.json" .  >nul 2>&1
+	move /Y "%HOMEPATH%\skywire-config.json" . >nul 2>&1
 )
 
 :: Generating new config file if not exist
 if not exist "skywire-config.json" (
-    skywire-cli config gen -birpw --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server  >nul 2>&1
+    skywire-cli config gen -birpw --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server >nul 2>&1
 )
 
 :: Regenerating config file after update and install new version of Skywire

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -1,32 +1,32 @@
 @Echo Off
-:: Open Powershell with Administrator privilege
+:: Opening Powershell with Administrator privilege
 %1 mshta vbscript:CreateObject("Shell.Application").ShellExecute("powershell.exe","/c %~s0 ::","","runas",1)(window.close)&&exit
 cd /d "%~dp0"
 
-:: Set start time
+:: Setting start time
 for /f "tokens=2 delims==" %%a in ('wmic OS Get localdatetime /value') do set "dt=%%a"
 set "YYYY=%dt:~0,4%" & set "MM=%dt:~4,2%" & set "DD=%dt:~6,2%" & set "HH=%dt:~8,2%" & set "Min=%dt:~10,2%" & set "Sec=%dt:~12,2%"
 set "start_time=%YYYY%-%MM%-%DD%_%HH%-%Min%-%Sec%"
 
-:: Print screen message to users
+:: Printing screen message to users
 echo:  
-echo        #######################################################################
-echo        #                                                                     #
-echo        #                    Welcome to Skywire [Windows]                     #
-echo        #                                                                     #
-echo        #     - You have access to Hyperviro UI by http://127.0.0.1:8000      #
-echo        #     - All logs available in C:\Program Files\Skywire\local\logs     #
-echo        #     - You can terminate skywire by Ctrl+C command                   #
-echo        #                                                                     #
-echo        #######################################################################
+echo        ########################################################################
+echo        #                                                                      #
+echo        #                     Welcome to Skywire [Windows]                     #
+echo        #                                                                      #
+echo        #    - You have access to Hypervisor UI by http://127.0.0.1:8000       #
+echo        #    - All logs be available in C:\Program Files\Skywire\local\logs    #
+echo        #    - You can terminate Skywire by Ctrl+C command.                    #
+echo        #                                                                      #
+echo        ########################################################################
 echo:
 
-:: Create logs folder if not exist. Run just in first time after install
+:: Creating logs folder if not exist [Run just in first time after installing]
 if not exist "local\logs\" (
 	mkdir "local\logs"
 )
 
-:: Move vpn-client.exe to its path
+:: Moving vpn-client.exe to its path
 if exist vpn-client.exe (
     if not exist "apps\" (
         mkdir apps
@@ -34,29 +34,29 @@ if exist vpn-client.exe (
     move /Y vpn-client.exe apps
 )
 
-:: Move wintun.dll to system32 path
+:: Moving wintun.dll to system32 path
 if exist "wintun.dll" (
     move /Y wintun.dll "C:\Windows\System32"
 )
 
-:: Move existed config file in user home to here
+:: Moving existed config file in user home to installation path
 if exist "%HOMEPATH%\skywire-config.json" (
 	move /Y "%HOMEPATH%\skywire-config.json" .
 )
 
-:: Genereate new config file if not exist
+:: Generating new config file if not exist
 if not exist "skywire-config.json" (
     skywire-cli config gen -birp --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
 )
 
-:: After update and install new version of skywire, regenerate config file for update values and version
+:: Regenerating config file after update and install new version of Skywire
 if exist "new.update" (
     skywire-cli config gen -birpx --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
     del new.update
 )
 
-:: Open UI
+:: Opening UI
 start "" http://127.0.0.1:8000
 
-:: Run skywire
+:: Running Skywire
 skywire-visor.exe -c "skywire-config.json" >> local\logs\skywire_%start_time%.log

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -23,36 +23,36 @@ echo:
 
 :: Creating logs folder if not exist [Run just in first time after installing]
 if not exist "local\logs\" (
-	mkdir "local\logs"
+	mkdir "local\logs"  >nul 2>&1
 )
 
 :: Moving vpn-client.exe to its path
 if exist vpn-client.exe (
     if not exist "apps\" (
-        mkdir apps
+        mkdir apps  >nul 2>&1
     )
-    move /Y vpn-client.exe apps
+    move /Y vpn-client.exe apps >nul 2>&1
 )
 
 :: Moving wintun.dll to system32 path
 if exist "wintun.dll" (
-    move /Y wintun.dll "C:\Windows\System32"
+    move /Y wintun.dll "C:\Windows\System32"  >nul 2>&1
 )
 
 :: Moving existed config file in user home to installation path
 if exist "%HOMEPATH%\skywire-config.json" (
-	move /Y "%HOMEPATH%\skywire-config.json" .
+	move /Y "%HOMEPATH%\skywire-config.json" .  >nul 2>&1
 )
 
 :: Generating new config file if not exist
 if not exist "skywire-config.json" (
-    skywire-cli config gen -birp --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
+    skywire-cli config gen -birpw --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server  >nul 2>&1
 )
 
 :: Regenerating config file after update and install new version of Skywire
 if exist "new.update" (
-    skywire-cli config gen -birpx --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
-    del new.update
+    skywire-cli config gen -birpwx --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server >nul 2>&1
+    del new.update >nul 2>&1
 )
 
 :: Opening UI

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -1,24 +1,62 @@
 @Echo Off
+:: Open Powershell with Administrator privilege
 %1 mshta vbscript:CreateObject("Shell.Application").ShellExecute("powershell.exe","/c %~s0 ::","","runas",1)(window.close)&&exit
 cd /d "%~dp0"
+
+:: Set start time
+for /f "tokens=2 delims==" %%a in ('wmic OS Get localdatetime /value') do set "dt=%%a"
+set "YYYY=%dt:~0,4%" & set "MM=%dt:~4,2%" & set "DD=%dt:~6,2%" & set "HH=%dt:~8,2%" & set "Min=%dt:~10,2%" & set "Sec=%dt:~12,2%"
+set "start_time=%YYYY%-%MM%-%DD%_%HH%-%Min%-%Sec%"
+
+:: Print screen message to users
+echo:  
+echo        #######################################################################
+echo        #                                                                     #
+echo        #                    Welcome to Skywire [Windows]                     #
+echo        #                                                                     #
+echo        #     - You have access to Hyperviro UI by http://127.0.0.1:8000      #
+echo        #     - All logs available in C:\Program Files\Skywire\local\logs     #
+echo        #     - You can terminate skywire by Ctrl+C command                   #
+echo        #                                                                     #
+echo        #######################################################################
+echo:
+
+:: Create logs folder if not exist. Run just in first time after install
+if not exist "local\logs\" (
+	mkdir "local\logs"
+)
+
+:: Move vpn-client.exe to its path
 if exist vpn-client.exe (
     if not exist "apps\" (
         mkdir apps
     )
     move /Y vpn-client.exe apps
 )
+
+:: Move wintun.dll to system32 path
 if exist "wintun.dll" (
     move /Y wintun.dll "C:\Windows\System32"
 )
+
+:: Move existed config file in user home to here
 if exist "%HOMEPATH%\skywire-config.json" (
 	move /Y "%HOMEPATH%\skywire-config.json" .
 )
+
+:: Genereate new config file if not exist
 if not exist "skywire-config.json" (
     skywire-cli config gen -birp --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
 )
+
+:: After update and install new version of skywire, regenerate config file for update values and version
 if exist "new.update" (
     skywire-cli config gen -birpx --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
     del new.update
 )
+
+:: Open UI
 start "" http://127.0.0.1:8000
-skywire-visor.exe -c "skywire-config.json"
+
+:: Run skywire
+skywire-visor.exe -c "skywire-config.json" >> local\logs\skywire_%start_time%.log

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -14,7 +14,11 @@ if exist "%HOMEPATH%\skywire-config.json" (
 	move /Y "%HOMEPATH%\skywire-config.json" .
 )
 if not exist "skywire-config.json" (
-skywire-cli config gen -birp --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
+    skywire-cli config gen -birp --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
+)
+if exist "new.update" (
+    skywire-cli config gen -birpx --os windows --disableapps skychat,skysocks,skysocks-client,vpn-server
+    del new.update
 )
 start "" http://127.0.0.1:8000
 skywire-visor.exe -c "skywire-config.json"

--- a/scripts/win_installer/wix.json
+++ b/scripts/win_installer/wix.json
@@ -11,7 +11,8 @@
       "build/amd64/skywire.bat",
       "ico.ico",
       "build/amd64/wintun.dll",
-      "build/amd64/dmsghttp-config.json"
+      "build/amd64/dmsghttp-config.json",
+      "build/amd64/new.update"
     ]
   },
   "env": {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes: -

 Changes:	
- improve skywire.bat
- add regenerating config for update skywire
- store logs for windows installer in `C:\Program Files\Skywire\local\logs`

How to test this PR:
- `make win-installer`, then install new version
- run by skywire shortcut on start menu or type in cmd/powershell
- see user message of app in Powershell like this
![image](https://user-images.githubusercontent.com/79150699/167062213-7a7ded5a-fef9-4eba-8e6d-8ed0d088b6d7.png)
- check `C:\Program Files\Skywire\local\logs` for logs

Note: You can download `.msi` installer from this link too: https://drive.protonmail.com/urls/Q1S5Y6A8F8#3Sw4ftqrILMC