### PR TITLE
add `install-system-linux` makefile directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `run-source-dmsghttp-test` makefile directive
 - `run-vpnsrv-dmsghttp` makefile directive
 - `run-vpnsrv -dmsghttp-test` makefile directive
+- `install-system-linux` and `install-system-linux-systray` makefile directives
 
 ## 0.6.0
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,24 @@ build-static: host-apps-static bin-static ## Build apps and binaries. `go build`
 
 installer: mac-installer ## Builds MacOS installer for skywire-visor
 
+install-system-linux: build # Workaround for debugging linux package installation
+	sudo install -Dm755 skywire-cli /opt/skywire/bin/
+	sudo install -Dm755 skywire-visor /opt/skywire/bin/
+	sudo install -Dm755 apps/vpn-server /opt/skywire/apps/
+	sudo install -Dm755 apps/vpn-client /opt/skywire/apps/
+	sudo install -Dm755 apps/skysocks-client /opt/skywire/apps/
+	sudo install -Dm755 apps/skysocks /opt/skywire/apps/
+	sudo install -Dm755 apps/skychat /opt/skywire/apps/
+
+install-system-linux-systray: build-systray # Workaround for debugging linux package installation
+	sudo install -Dm755 skywire-cli /opt/skywire/bin/
+	sudo install -Dm755 skywire-visor /opt/skywire/bin/
+	sudo install -Dm755 apps/vpn-server /opt/skywire/apps/
+	sudo install -Dm755 apps/vpn-client /opt/skywire/apps/
+	sudo install -Dm755 apps/skysocks-client /opt/skywire/apps/
+	sudo install -Dm755 apps/skysocks /opt/skywire/apps/
+	sudo install -Dm755 apps/skychat /opt/skywire/apps/
+
 install-generate: ## Installs required execs for go generate.
 	${OPTS} go install github.com/mjibson/esc
 	${OPTS} go install github.com/vektra/mockery/cmd/mockery

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -16,8 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/skycoin/systray"
-
 	"github.com/gen2brain/dlgs"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/direct"
@@ -26,6 +24,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsgget"
 	"github.com/skycoin/dmsg/pkg/dmsghttp"
 	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/skycoin/systray"
 	"github.com/toqueteos/webbrowser"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"


### PR DESCRIPTION

Did you run `make format && make check`?
yes

 Changes:	
-	add `install-system-linux` and `install-system-linux-systray` makefile directives


We have a situation now with glibc or possibly other runtime dependencies (possibly introduced by the systray app) which cannot be overcome via static compilation with musl. As a consequence, packages compiled __for testing__ may contain binaries which cannot be executed on the machine the package is distributed to.

As a workaround for this, I have added a makefile directive which will 'hotfix' an existing package installation with natively compiled binaries, in order that scripts and other functionality can be tested and verified

this directive is meant to explicitly work with the installed package. Follow the [package installation guide](https://github.com/skycoin/skywire/wiki/Skywire-Package-Installation) to test:
```
make install-system-linux
sudo skywire-autoconfig

make install-system-linux-systray
sudo skywire-autoconfig
skywire-autoconfig
```