### PR TITLE
Fix config fallback in cli

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -136,6 +136,7 @@ var genConfigCmd = &cobra.Command{
 		if output == "" {
 			outunset = true
 			confPath = skyenv.ConfigName
+			output = confPath
 		} else {
 			confPath = output
 		}

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -232,9 +232,11 @@ func serversBtn(conf *visorconfig.V1, servers []*systray.MenuItem, rpcClient vis
 	btnChannel := make(chan int)
 	for index, server := range servers {
 		go func(chn chan int, server *systray.MenuItem, index int) {
-			select {
-			case <-server.ClickedCh:
-				chn <- index
+			for {
+				select {
+				case <-server.ClickedCh:
+					chn <- index
+				}
 			}
 		}(btnChannel, server, index)
 	}

--- a/pkg/visor/visorconfig/services.go
+++ b/pkg/visor/visorconfig/services.go
@@ -10,16 +10,10 @@ import (
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
-	utilenv "github.com/skycoin/skywire-utilities/pkg/skyenv"
 )
 
-var (
-	services *Services
-	svcconf  = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")
-)
-
-//Fetch fetches the service URLs & ip:ports from the config service endpoint
-func Fetch(mLog *logging.MasterLogger, serviceConfURL string, stdout bool) *Services {
+// Fetch fetches the service URLs & ip:ports from the config service endpoint
+func Fetch(mLog *logging.MasterLogger, serviceConfURL string, stdout bool) (services *Services) {
 
 	urlstr := []string{"http://", serviceConfURL}
 	serviceConf := strings.Join(urlstr, "")
@@ -34,15 +28,10 @@ func Fetch(mLog *logging.MasterLogger, serviceConfURL string, stdout bool) *Serv
 	//check for errors in the response
 	res, err := client.Do(req)
 	if err != nil {
-		if serviceConfURL != svcconf {
-			//if serviceConfURL was changed this error should be fatal
-			mLog.WithError(err).Fatal("Failed to fetch servers\n")
-		} else { //otherwise just error and continue
-			//silence errors for stdout
-			if !stdout {
-				mLog.WithError(err).Error("Failed to fetch servers\n")
-				mLog.Warn("Falling back on hardcoded servers")
-			}
+		//silence errors for stdout
+		if !stdout {
+			mLog.WithError(err).Error("Failed to fetch servers\n")
+			mLog.Warn("Falling back on hardcoded servers")
 		}
 	} else {
 		// nil error from client.Do(req)


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1192 

 Changes:	
- Fixed output var 
- Fixed conf fallback logic

How to test this PR:
1. Run `./skywire-cli config gen -rt -a test.skywire.dev`
2. Check if it works
