### PR TITLE
Fix config gen -x flag

### DIFF
--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -142,9 +142,7 @@ func MakeDefaultConfig(log *logging.MasterLogger, sk *cipher.SecKey, usrEnv bool
 
 	// Manipulate Hypervisor PKs
 	if hypervisorPKs != "" {
-		log.Info("hypervisorPKs: ", hypervisorPKs)
 		keys := strings.Split(hypervisorPKs, ",")
-		log.Info("keys: ", keys)
 		for _, key := range keys {
 			if key != "" {
 				keyParsed, err := coinCipher.PubKeyFromHex(strings.TrimSpace(key))

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -142,18 +142,23 @@ func MakeDefaultConfig(log *logging.MasterLogger, sk *cipher.SecKey, usrEnv bool
 
 	// Manipulate Hypervisor PKs
 	if hypervisorPKs != "" {
+		log.Info("hypervisorPKs: ", hypervisorPKs)
 		keys := strings.Split(hypervisorPKs, ",")
+		log.Info("keys: ", keys)
 		for _, key := range keys {
-			keyParsed, err := coinCipher.PubKeyFromHex(strings.TrimSpace(key))
-			if err != nil {
-				log.WithError(err).Fatalf("Failed to parse hypervisor private key: %s.", key)
-			}
-			conf.Hypervisors = append(conf.Hypervisors, cipher.PubKey(keyParsed))
-			// Compare key value and visor PK, if same, then this visor should be hypervisor
-			if key == conf.PK.Hex() {
-				hypervisor = true
-				conf.Hypervisors = []cipher.PubKey{}
-				break
+			if key != "" {
+				keyParsed, err := coinCipher.PubKeyFromHex(strings.TrimSpace(key))
+				if err != nil {
+					log.WithError(err).Fatalf("Failed to parse hypervisor public key: %s.", key)
+				}
+				conf.Hypervisors = append(conf.Hypervisors, cipher.PubKey(keyParsed))
+
+				// Compare key value and visor PK, if same, then this visor should be hypervisor
+				if key == conf.PK.Hex() {
+					hypervisor = true
+					conf.Hypervisors = []cipher.PubKey{}
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Did you run `make format && make check`?
yes
 Changes:	
-	fix retain remote hypervisor configuration; `skywie-cli config gen -x` flag

How to test this PR:

```
git clone https://github.com/the-skycoin-project/skywire
cd skywire
git checkout fix-xflag
go run cmd/skywire-cli/skywire-cli.go config gen -r --hvpks 022769f159bb6f67c13140a214d5da0f2192d0881f00449460c458e17eb60115a7
 go run cmd/skywire-cli/skywire-cli.go config gen -rx
```
the config is successfully regenerated and the remote hypervisor configuration is retained

compare to the current behavior of the rc2 release candidate binaries