### PR TITLE
Fix the VPN status in the UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.html
@@ -96,10 +96,7 @@
         </mat-checkbox>
       </td>
       <td>
-        <i
-          [class]="app.status === 1 ? 'dot-green' : 'dot-red'"
-          [matTooltip]="(app.status === 1 ? 'apps.status-running-tooltip' : 'apps.status-stopped-tooltip') | translate"
-        ></i>
+        <i [class]="getStateClass(app)" [matTooltip]="getStateTooltip(app) | translate"></i>
       </td>
       <td>
         {{ app.name }}

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
@@ -232,6 +232,32 @@ export class NodeAppsListComponent implements OnDestroy {
   }
 
   /**
+   * Gets the class for the app status dot.
+   */
+  getStateClass(app: Application): string {
+    if (app.status === 1) {
+      return 'dot-green';
+    } else if (app.name === 'vpn-client' && app.status === 3) {
+      return 'dot-yellow';
+    }
+
+    return 'dot-red';
+  }
+
+  /**
+   * Gets the tooltip text for the app status dot.
+   */
+  getStateTooltip(app: Application): string {
+    if (app.status === 1) {
+      return 'apps.status-running-tooltip';
+    } else if (app.name === 'vpn-client' && app.status === 3) {
+      return 'apps.status-connecting-tooltip';
+    }
+
+    return 'apps.status-stopped-tooltip';
+  }
+
+  /**
    * Changes the selection state of an entry (modifies the state of its checkbox).
    */
   changeSelection(app: Application) {

--- a/static/skywire-manager-src/src/app/services/vpn-client.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client.service.ts
@@ -680,7 +680,7 @@ export class VpnClientService {
       // Get the required data from the app properties.
       if (appData) {
         vpnClientData = new VpnClientAppData();
-        vpnClientData.running = appData.status === 1;
+        vpnClientData.running = appData.status === 1 || appData.status === 3;
         vpnClientData.connectionDuration = appData.connection_duration;
 
         vpnClientData.appState = AppState.Stopped;

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -464,6 +464,7 @@
     "status-stopped": "Stopped",
     "status-failed": "Failed",
     "status-running-tooltip": "App is currently running",
+    "status-connecting-tooltip": "App is currently connecting",
     "status-stopped-tooltip": "App is currently stopped",
     "status-failed-tooltip": "Something went wrong. Check the app's messages for more information"
   },

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -468,6 +468,7 @@
     "status-stopped": "Detenida",
     "status-failed": "Fallida",
     "status-running-tooltip": "La aplicación está actualmente corriendo",
+    "status-connecting-tooltip": "La aplicación está actualmente conectando",
     "status-stopped-tooltip": "La aplicación está actualmente detenida",
     "status-failed-tooltip": "Algo salió mal. Revise los mensajes de la aplicación para más información"
   },

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -468,6 +468,7 @@
     "status-stopped": "Stopped",
     "status-failed": "Failed",
     "status-running-tooltip": "App is currently running",
+    "status-connecting-tooltip": "App is currently connecting",
     "status-stopped-tooltip": "App is currently stopped",
     "status-failed-tooltip": "Something went wrong. Check the app's messages for more information"
   },


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #1096

 Changes:	
- Now the Skywire Manager and the VPN UI manages well the change made to the status code in #1141

How to test this PR:
Start the vpn-clien t app using the Skywire Manager and the VPN UI. It should show the "connecting" state while connecting to the server.