### PR TITLE
Make the UI work with the new app statuses

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -27,6 +27,7 @@ export interface Application {
   autostart: boolean;
   port: number;
   status: number;
+  detailedStatus: string;
   args: any[];
 }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.html
@@ -96,7 +96,13 @@
         </mat-checkbox>
       </td>
       <td>
-        <i [class]="getStateClass(app)" [matTooltip]="getStateTooltip(app) | translate"></i>
+        <i *ngIf="app.status !== 2" [class]="getStateClass(app)" [matTooltip]="getStateTooltip(app) | translate"></i>
+        <mat-icon
+          *ngIf="app.status === 2"
+          class="red-text"
+          [inline]="true"
+          [matTooltip]="'apps.status-failed-tooltip' | translate:{error: app.detailedStatus ? app.detailedStatus : ''}"
+        >warning</mat-icon>
       </td>
       <td>
         {{ app.name }}
@@ -144,10 +150,10 @@
         <button
           (click)="changeAppState(app)"
           mat-icon-button
-          [matTooltip]="('apps.' + (app.status === 1 ? 'stop-app' : 'start-app')) | translate"
+          [matTooltip]="('apps.' + (app.status === 0 || app.status === 2 ? 'start-app' : 'stop-app')) | translate"
           class="big-action-button transparent-button"
         >
-          <mat-icon [inline]="true">{{ app.status === 1 ? 'stop' : 'play_arrow' }}</mat-icon>
+          <mat-icon [inline]="true">{{ app.status === 0 || app.status === 2 ? 'play_arrow' : 'stop' }}</mat-icon>
         </button>
       </td>
     </tr>
@@ -194,8 +200,8 @@
           </div>
           <div class="list-row">
             <span class="title">{{ 'apps.apps-list.state' | translate }}</span>:
-            <span [class]="(app.status === 1 ? 'green-clear-text' : 'red-clear-text') + ' title'">
-              {{ (app.status === 1 ? 'apps.status-running' : 'apps.status-stopped') | translate }}
+            <span [class]="getSmallScreenStateClass(app) + ' title'">
+              {{ getSmallScreenStateTextVar(app) | translate:{error: app.detailedStatus ? app.detailedStatus : ''} }}
             </span>
           </div>
           <div class="list-row">

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
@@ -20,6 +20,7 @@ import { SkysocksClientSettingsComponent } from '../node-apps/skysocks-client-se
 import { FilterProperties, FilterFieldTypes } from 'src/app/utils/filters';
 import { SortingColumn, SortingModes, DataSorter } from 'src/app/utils/lists/data-sorter';
 import { DataFilterer } from 'src/app/utils/lists/data-filterer';
+import { map } from 'rxjs/operators';
 
 /**
  * Shows the list of applications of a node. I can be used to show a short preview, with just some
@@ -588,7 +589,18 @@ export class NodeAppsListComponent implements OnDestroy {
    * subscribe to the response.
    */
   private startChangingAppState(appName: string, startApp: boolean): Observable<any> {
-    return this.appsService.changeAppState(NodeComponent.getCurrentNodeKey(), appName, startApp);
+    return this.appsService.changeAppState(NodeComponent.getCurrentNodeKey(), appName, startApp).pipe(map(response => {
+      if (response.status !== null && response.status !== undefined) {
+        this.dataSource.forEach(app => {
+          if (app.name === appName) {
+            app.status = response.status;
+            app.detailedStatus = response.detailed_status;
+          }
+        });
+      }
+
+      return response;
+    }));
   }
 
   /**

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -707,6 +707,7 @@ export class NodeService {
               status: app.status,
               port: app.port,
               autostart: app.auto_start,
+              detailedStatus: app.detailed_status,
               args: app.args,
             });
           });

--- a/static/skywire-manager-src/src/app/services/vpn-client.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client.service.ts
@@ -680,7 +680,7 @@ export class VpnClientService {
       // Get the required data from the app properties.
       if (appData) {
         vpnClientData = new VpnClientAppData();
-        vpnClientData.running = appData.status === 1 || appData.status === 3;
+        vpnClientData.running = appData.status !== 0 || appData.status !== 2;
         vpnClientData.connectionDuration = appData.connection_duration;
 
         vpnClientData.appState = AppState.Stopped;

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -462,12 +462,13 @@
     "operation-completed": "Operation completed.",
     "operation-unnecessary": "The selection already has the requested setting.",
     "status-running": "Running",
+    "status-connecting": "Connecting",
     "status-stopped": "Stopped",
-    "status-failed": "Failed",
+    "status-failed": "Ended with the following error: {{ error }}",
     "status-running-tooltip": "App is currently running",
     "status-connecting-tooltip": "App is currently connecting",
     "status-stopped-tooltip": "App is currently stopped",
-    "status-failed-tooltip": "Something went wrong. Check the app's messages for more information"
+    "status-failed-tooltip": "The app finished with the following error: {{ error }}"
   },
 
   "transports": {

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -466,12 +466,13 @@
     "operation-completed": "Operación completada.",
     "operation-unnecessary": "La selección ya tiene la configuración solicitada.",
     "status-running": "Corriendo",
+    "status-connecting": "Conectando",
     "status-stopped": "Detenida",
-    "status-failed": "Fallida",
+    "status-failed": "Finalizó con el siguiente error: {{ error }}",
     "status-running-tooltip": "La aplicación está actualmente corriendo",
     "status-connecting-tooltip": "La aplicación está actualmente conectando",
     "status-stopped-tooltip": "La aplicación está actualmente detenida",
-    "status-failed-tooltip": "Algo salió mal. Revise los mensajes de la aplicación para más información"
+    "status-failed-tooltip": "La app finalizó con el siguiente error: {{ error }}"
   },
 
   "transports": {

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -466,12 +466,13 @@
     "operation-completed": "Operation completed.",
     "operation-unnecessary": "The selection already has the requested setting.",
     "status-running": "Running",
+    "status-connecting": "Connecting",
     "status-stopped": "Stopped",
-    "status-failed": "Failed",
+    "status-failed": "Ended with the following error: {{ error }}",
     "status-running-tooltip": "App is currently running",
     "status-connecting-tooltip": "App is currently connecting",
     "status-stopped-tooltip": "App is currently stopped",
-    "status-failed-tooltip": "Something went wrong. Check the app's messages for more information"
+    "status-failed-tooltip": "The app finished with the following error: {{ error }}"
   },
 
   "transports": {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #1214

 Changes:	
- Now the UI considers an app running if the status is not 0 (stopped) or 2 (failed).
- Now the status 3 is considered “connecting” for all apps.
- Now the UI shows the error message if an app is in status 2.

How to test this PR:
Go to the app list in the Skywire Manager and start an app. While it is connecting, the status will be yellow. This works on big and small screen sizes.

Also, in the same list, try to start an app and make it end with an error (like stating the vpn-client app with an invalid server). The app status should show the error.

NOTE: the original issue listed status 2 as “connecting”, but that code was used as “failed” and status 3 was the one used as “connecting”, as that is what was seen while testing.