### PR TITLE
Fix vpn reconnecting status

### DIFF
--- a/pkg/app/launcher/app_state.go
+++ b/pkg/app/launcher/app_state.go
@@ -15,9 +15,6 @@ const (
 
 	// AppStatusStarting represents status of an app starting.
 	AppStatusStarting
-
-	// AppStatusReconnecting represents status of VPN client re-connecting.
-	AppStatusReconnecting
 )
 
 // AppState defines state parameters for a registered App.
@@ -34,15 +31,15 @@ const (
 	// AppDetailedStatusStarting is set during app initilization process.
 	AppDetailedStatusStarting = "Starting"
 
+	// AppDetailedStatusRunning is set when the app is running.
+	AppDetailedStatusRunning = "Running"
+
 	// AppDetailedStatusVPNConnecting is set during VPN-client session establishment (including handshake).
 	AppDetailedStatusVPNConnecting = "Connecting"
 
-	// AppDetailedStatusRunning is set when all establishment is done and / or app is running.
-	AppDetailedStatusRunning = "Running"
+	// AppDetailedStatusVPNReconnecting is set after connection failure in VPN-client, during reconnection.
+	AppDetailedStatusVPNReconnecting = "Connection failed, reconnecting"
 
 	// AppDetailedStatusShuttingDown is set during shutdown.
 	AppDetailedStatusShuttingDown = "Shutting down"
-
-	// AppDetailedStatusVPNReconnecting is set after connection failure in VPN-client, during reconnection.
-	AppDetailedStatusVPNReconnecting = "Connection failed, reconnecting"
 )

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -190,7 +190,8 @@ func (l *Launcher) AppState(name string) (*AppState, bool) {
 			state.DetailedStatus = AppDetailedStatusStarting
 			state.Status = AppStatusStarting
 		}
-		if state.DetailedStatus == AppDetailedStatusVPNConnecting || state.DetailedStatus == AppDetailedStatusStarting {
+		switch state.DetailedStatus {
+		case AppDetailedStatusVPNConnecting, AppDetailedStatusStarting, AppDetailedStatusVPNReconnecting:
 			state.Status = AppStatusStarting
 		}
 	}


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1221 

 Changes:	
- Removed unused status `AppStatusReconnecting`
- Fixed status for `AppDetailedStatusVPNReconnecting`

How to test this PR:
1. Start visor
2. Connect to a vpn-server that is not online
3. keep checking the API `http://localhost:8000/api/visors/<pk>/summary`
4. Check the apps UI in visor details
5. Check if the status is `3` for the detailed status `Connection failed, reconnecting`