### PR TITLE
`--binpath` flag

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -55,6 +55,7 @@ var (
 	svcconf           = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")     //skyenv.DefaultServiceConfAddr
 	testconf          = strings.ReplaceAll(utilenv.TestServiceConfAddr, "http://", "") //skyenv.DefaultServiceConfAddr
 	hiddenflags       []string
+	binPath           string
 )
 
 func init() {
@@ -112,6 +113,8 @@ func init() {
 	genConfigCmd.Flags().StringVar(&ver, "version", "", "custom version testing override")
 	hiddenflags = append(hiddenflags, "version")
 	genConfigCmd.Flags().BoolVar(&all, "all", false, "show all flags")
+	genConfigCmd.Flags().StringVar(&binPath, "binpath", "", "set bin_path")
+	hiddenflags = append(hiddenflags, "binpath")
 
 	for _, j := range hiddenflags {
 		genConfigCmd.Flags().MarkHidden(j) //nolint
@@ -372,6 +375,11 @@ var genConfigCmd = &cobra.Command{
 				conf.Hypervisor.EnableAuth = true
 			}
 		}
+		// check binpath argument and use if set
+		if binPath != "" {
+			conf.Launcher.BinPath = binPath
+		}
+
 		if ver != "" {
 			conf.Common.Version = ver
 		}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1219 

 Changes:	
- add `--binpath` flag to set it during generate config

How to test this PR:
- clone [this](https://github.com/skycoin/dmsg/pull/174) dmsg PRs branch.
- clone current PR branch, comment out `//replace dmsg...` on `go.mod`, then `make dep`
- build binaries
- use `./skywire-cli config gen --binpath /foo/bar` to check bin_path value on config
- run a visor, open dmsgpty full terminal to check `DMSGPTYTERM` env variable set there