### PR TITLE
Fix vpn-server close err

### DIFF
--- a/internal/vpn/client.go
+++ b/internal/vpn/client.go
@@ -452,6 +452,10 @@ func (c *Client) serveConn(conn net.Conn) error {
 
 		if _, err := io.Copy(tun, conn); err != nil {
 			fmt.Printf("Error resending traffic from TUN %s to VPN server: %v\n", tun.Name(), err)
+			// when the vpn-server is closed we get the error EOF
+			if err.Error() == io.EOF.Error() {
+				c.setAppError(errVPNServerClosed)
+			}
 		}
 	}()
 	go func() {

--- a/internal/vpn/errors.go
+++ b/internal/vpn/errors.go
@@ -17,6 +17,7 @@ var (
 	errHandshakeStatusBadRequest      = errors.New("Request was malformed")
 	errTimeout                        = errors.New("Internal error: Timeout")
 	errNotPermited                    = errors.New("ioctl: operation not permitted")
+	errVPNServerClosed                = errors.New("Vpn-server closed")
 
 	errNoTransportFound = appserver.RPCErr{
 		Err: router.ErrNoTransportFound.Error(),

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -277,7 +277,11 @@ func (r *RPCIngressGateway) Read(req *ReadReq, resp *ReadResp) error {
 		copy(resp.B, buf[:resp.N])
 	}
 	if err != nil {
-		r.log.WithError(err).Warn("Received unexpected error when reading from server.")
+		// we don't print warning if the conn is ready closed
+		_, ok := r.cm.Get(req.ConnID)
+		if ok {
+			r.log.WithError(err).Warn("Received unexpected error when reading from server.")
+		}
 	}
 
 	resp.Err = ioErrToRPCIOErr(err)

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -703,7 +703,11 @@ func (hv *Hypervisor) putApp() http.HandlerFunc {
 					httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
 					return
 				}
-				if err := ctx.API.SetAppDetailedStatus(ctx.App.Name, launcher.AppDetailedStatusStarting); err != nil {
+				appStatus := launcher.AppDetailedStatusStarting
+				if ctx.App.Name == skyenv.VPNClientName {
+					appStatus = launcher.AppDetailedStatusVPNConnecting
+				}
+				if err := ctx.API.SetAppDetailedStatus(ctx.App.Name, appStatus); err != nil {
 					httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
 					return
 				}


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #942 

 Changes:	
- Fixed warn log in method `Read` of `RPCIngressGateway`
- Added vpn-server stopped error

How to test this PR:
1. Start vpn-server on visor A
2. Start vpn-client on visor B and connect to the vpn-server of visor A
3. Stop the vpn-server on visor A
4. See error on UI 