### PR TITLE
Fix stun client datarace

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -122,7 +122,8 @@ func (v *Visor) Overview() (*Overview, error) {
 			newTransportSummary(v.tpM, tp, true, v.router.SetupIsTrusted(tp.Remote())))
 		return true
 	})
-	if v.stunClient != nil {
+
+	if v.isStunReady() {
 		switch v.stunClient.NATType {
 		case stun.NATNone, stun.NATFull, stun.NATRestricted, stun.NATPortRestricted:
 			publicIP = v.stunClient.PublicIP.IP()

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -279,12 +279,13 @@ func initDiscovery(ctx context.Context, v *Visor, log *logging.Logger) error {
 }
 
 func initStunClient(ctx context.Context, v *Visor, log *logging.Logger) error {
-	defer v.wgStunClient.Done()
 
 	sc := network.GetStunDetails(v.conf.StunServers, log)
 	v.initLock.Lock()
 	v.stunClient = sc
+	time.Sleep(time.Second * 5)
 	v.initLock.Unlock()
+	v.stunReadyOnce.Do(func() { close(v.stunReady) })
 	return nil
 }
 
@@ -517,7 +518,7 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 				ntype := network.Type(trans)
 
 				// Wait until stun client is ready
-				v.wgStunClient.Wait()
+				<-v.stunReady
 
 				// skip if SUDPH is under symmetric NAT / under UDP firewall.
 				if ntype == network.SUDPH && (v.stunClient.NATType == stun.NATSymmetric ||
@@ -1157,7 +1158,7 @@ func getPublicIP(v *Visor, service string) (pIP string, err error) {
 	}
 
 	// Wait until stun client is ready
-	v.wgStunClient.Wait()
+	<-v.stunReady
 
 	pIP = v.stunClient.PublicIP.IP()
 	return pIP, nil

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -283,7 +283,6 @@ func initStunClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 	sc := network.GetStunDetails(v.conf.StunServers, log)
 	v.initLock.Lock()
 	v.stunClient = sc
-	time.Sleep(time.Second * 5)
 	v.initLock.Unlock()
 	v.stunReadyOnce.Do(func() { close(v.stunReady) })
 	return nil


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1236 

 Changes:	
- Added stunReady and stunReadyOnce to Visor
- Removed wgStunClient from Visor

How to test this PR:
1. Add the line `time.Sleep(time.Second * 5)` before [this](https://github.com/skycoin/skywire/blob/89b22ba8f9b21f7c51ec51f4c5f72fcb01a23f75/pkg/visor/init.go#L287) 
2. Build the visor with `-race` flag
3. Start the visor
4. Open UI and keep refreshing