### PR TITLE
Remove the update and restart buttons

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -29,6 +29,8 @@ export class NodeActionsHelper {
   private canBeUpdated = false;
   private canBeRestarted = false;
 
+  options: MenuOptionData[] = [];
+
   returnButtonText: string;
 
   private rebootSubscription: Subscription;
@@ -51,13 +53,15 @@ export class NodeActionsHelper {
 
     this.showingFullList = showingFullList;
     this.returnButtonText = !showingFullList ? 'nodes.title' : 'node.title';
+
+    this.updateOptions();
   }
 
   /**
    * Options for the menu shown in the top bar.
    */
-  get options(): MenuOptionData[] {
-    const response = [
+  private updateOptions() {
+    this.options = [
       {
         name: 'actions.menu.terminal',
         actionName: 'terminal',
@@ -71,7 +75,7 @@ export class NodeActionsHelper {
     ];
 
     if (this.canBeRestarted) {
-      response.push({
+      this.options.push({
         name: 'actions.menu.reboot',
         actionName: 'reboot',
         icon: 'rotate_right'
@@ -79,14 +83,12 @@ export class NodeActionsHelper {
     }
 
     if (this.canBeUpdated) {
-      response.push({
+      this.options.push({
         name: 'actions.menu.update',
         actionName: 'update',
         icon: 'get_app',
       });
     }
-
-    return response;
   }
 
   /**
@@ -102,6 +104,8 @@ export class NodeActionsHelper {
       this.canBeUpdated = false;
       this.canBeRestarted = false;
     }
+
+    this.updateOptions();
   }
 
   /**

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -480,6 +480,7 @@ export class NodeService {
           node.online = response.online;
           node.localPk = response.overview.local_pk;
           node.autoconnectTransports = response.public_autoconnect;
+          node.buildTag = response.build_tag ? response.build_tag : '';
 
           // Ip.
           if (response.overview && response.overview.local_ip && (response.overview.local_ip as string).trim()) {

--- a/static/skywire-manager-src/src/app/utils/generalUtils.ts
+++ b/static/skywire-manager-src/src/app/utils/generalUtils.ts
@@ -27,4 +27,24 @@ export default class GeneralUtils {
 
     return dialog.open(ConfirmationComponent, config);
   }
+
+  /**
+   * Checks the tag of a node, to know if the node is updatable via API calls.
+   */
+  static checkIfTagIsUpdatable(tag: string) {
+    if (
+      tag === undefined ||
+      tag === null ||
+      tag.toUpperCase() === 'Windows'.toUpperCase() ||
+      tag.toUpperCase() === 'Win'.toUpperCase() ||
+      tag.toUpperCase() === 'Mac'.toUpperCase() ||
+      tag.toUpperCase() === 'Macos'.toUpperCase() ||
+      tag.toUpperCase() === 'Mac OS'.toUpperCase() ||
+      tag.toUpperCase() === 'Darwin'.toUpperCase()
+    ) {
+      return false;
+    }
+
+    return true;
+  }
 }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #1098

 Changes:	
- Now the restart and update buttons are hidden if the visor has any of the following values in the `build_tag` property: `windows`, `win`, `mac`, `macos`, `mac os`, `darwin`.

How to test this PR:
Run a visor with any of the indicated build tags. The restart and update buttons should not be visible in the options menu of the visor details page, in the Skywire Manager. Also, in the visor list, the button for updating all online visors should not be visible if all the online visor have any of those tags. If there are some visors with the tags, only those visors are updated.

NOTE: maybe there are other visors for which the buttons should be removed too.