### PR TITLE
Remove the terminal button

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -28,6 +28,7 @@ export class NodeActionsHelper {
   private currentNodeKey: string;
   private canBeUpdated = false;
   private canBeRestarted = false;
+  private canOpenTerminal = false;
 
   options: MenuOptionData[] = [];
 
@@ -61,18 +62,21 @@ export class NodeActionsHelper {
    * Options for the menu shown in the top bar.
    */
   private updateOptions() {
-    this.options = [
-      {
+    this.options = [];
+
+    if (this.canOpenTerminal) {
+      this.options.push({
         name: 'actions.menu.terminal',
         actionName: 'terminal',
         icon: 'laptop'
-      },
-      {
-        name: 'actions.menu.logs',
-        actionName: 'logs',
-        icon: 'subject',
-      }
-    ];
+      });
+    }
+
+    this.options.push({
+      name: 'actions.menu.logs',
+      actionName: 'logs',
+      icon: 'subject',
+    });
 
     if (this.canBeRestarted) {
       this.options.push({
@@ -104,6 +108,8 @@ export class NodeActionsHelper {
       this.canBeUpdated = false;
       this.canBeRestarted = false;
     }
+
+    this.canOpenTerminal = GeneralUtils.checkIfTagCanOpenterminal(currentNode.buildTag);
 
     this.updateOptions();
   }

--- a/static/skywire-manager-src/src/app/utils/generalUtils.ts
+++ b/static/skywire-manager-src/src/app/utils/generalUtils.ts
@@ -47,4 +47,20 @@ export default class GeneralUtils {
 
     return true;
   }
+
+  /**
+   * Checks the tag of a node, to know if the terminal window can be openned for it.
+   */
+   static checkIfTagCanOpenterminal(tag: string) {
+    if (
+      tag === undefined ||
+      tag === null ||
+      tag.toUpperCase() === 'Windows'.toUpperCase() ||
+      tag.toUpperCase() === 'Win'.toUpperCase()
+    ) {
+      return false;
+    }
+
+    return true;
+  }
 }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the terminal button is hidden if the visor has any of the following values in the `build_tag` property: `windows`, `win`.

How to test this PR:
Run a visor with any of the indicated build tags. The terminal button should not be visible in the options menu of the visor details page, in the Skywire Manager.