### PR TITLE
Fix/auto transport logic

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -514,7 +514,6 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 			// try to establish direct connection to rPK (single hop) using SUDPH or STCPR
 			trySTCPR := false
 			trySUDPH := false
-			errSlice := make([]error, 0, 2)
 
 			for _, trans := range transports {
 				ntype := network.Type(trans)
@@ -540,11 +539,7 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 					_, err := tm.SaveTransport(ctx, rPK, network.STCPR, transport.LabelAutomatic)
 					return err
 				})
-				if err != nil {
-					errSlice = append(errSlice, err)
-				} else {
-					return nil
-				}
+				return err
 			}
 			// trying to establish direct connection to rPK using SUDPH
 			if trySUDPH {
@@ -552,18 +547,10 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 					_, err := tm.SaveTransport(ctx, rPK, network.SUDPH, transport.LabelAutomatic)
 					return err
 				})
-				if err != nil {
-					errSlice = append(errSlice, err)
-				} else {
-					return nil
-				}
+				return err
 			}
 
-			if len(errSlice) == 2 {
-				return dmsgFallback()
-			}
-
-			return errors.New(errSlice[0].Error())
+			return dmsgFallback()
 		},
 	}
 }

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -512,9 +512,16 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 				return dmsgFallback()
 			}
 			// try to establish direct connection to rPK (single hop) using SUDPH or STCPR
+			trySTCPR := false
+			trySUDPH := false
 			errSlice := make([]error, 0, 2)
+
 			for _, trans := range transports {
 				ntype := network.Type(trans)
+				if ntype == network.STCPR {
+					trySTCPR = true
+					continue
+				}
 
 				// Wait until stun client is ready
 				<-v.stunReady
@@ -524,17 +531,38 @@ func getRouteSetupHooks(ctx context.Context, v *Visor, log *logging.Logger) []ro
 					v.stunClient.NATType == stun.NATSymmetricUDPFirewall) {
 					continue
 				}
+				trySUDPH = true
+			}
+
+			// trying to establish direct connection to rPK using STCPR
+			if trySTCPR {
 				err := retrier.Do(ctx, func() error {
-					_, err := tm.SaveTransport(ctx, rPK, ntype, transport.LabelAutomatic)
+					_, err := tm.SaveTransport(ctx, rPK, network.STCPR, transport.LabelAutomatic)
 					return err
 				})
 				if err != nil {
 					errSlice = append(errSlice, err)
+				} else {
+					return nil
 				}
 			}
-			if len(errSlice) != 2 {
-				return nil
+			// trying to establish direct connection to rPK using SUDPH
+			if trySUDPH {
+				err := retrier.Do(ctx, func() error {
+					_, err := tm.SaveTransport(ctx, rPK, network.SUDPH, transport.LabelAutomatic)
+					return err
+				})
+				if err != nil {
+					errSlice = append(errSlice, err)
+				} else {
+					return nil
+				}
 			}
+
+			if len(errSlice) == 2 {
+				return dmsgFallback()
+			}
+
 			return errors.New(errSlice[0].Error())
 		},
 	}


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #1211 

 Changes:	
- change logic of getRouteSetupHooks() (aka auto-transport)

How to test this PR:
- Start Visor A with public IP and start vpn-server.
- Start Visor B with public IP.
- Connect vpn-client of visor B to the vpn-server of visor A.
- Check the transports in the UI. Not same situation on #1211 be there.
