### PR TITLE
Fix single vpn-server conn issue

### DIFF
--- a/internal/vpn/tun_device_unix.go
+++ b/internal/vpn/tun_device_unix.go
@@ -12,9 +12,6 @@ import (
 func newTUNDevice() (TUNDevice, error) {
 	tun, err := water.New(water.Config{
 		DeviceType: water.TUN,
-		PlatformSpecificParams: water.PlatformSpecificParams{
-			Name: "utun4",
-		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error allocating TUN interface: %w", err)


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #1256 

 Changes:	
- Removed `PlatformSpecificParams` from `water.Config`

How to test this PR:
1. Start 1 vpn-server and 2 vpn-clients
2. Connect both clients to vpn-server
3. Scheck if both connect properly