### PR TITLE
fix systray xfce

### DIFF
--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -14,6 +14,7 @@ release:
 before:
   hooks:
     - go mod tidy
+    - sed -i '/go conn.handleCall(msg)/c\conn.handleCall(msg)' ./vendor/github.com/godbus/dbus/v5/conn.go
 builds:
 
   - id: skywire-visor-amd64

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ bin-systray-windows-appveyor: ## Build `skywire-visor` and `skywire-cli` with sy
 	powershell 'Get-ChildItem .\cmd | % { ${OPTS} go build -tags systray -o ./ $$_.FullName }'
 
 bin-systray: ## Build `skywire-visor`, `skywire-cli`
+	sed -i '/go conn.handleCall(msg)/c\conn.handleCall(msg)' ./vendor/github.com/godbus/dbus/v5/conn.go
 	CGO_ENABLED=${SYSTRAY_CGO_ENABLED} ${OPTS} go build ${BUILD_OPTS} -tags systray -o ./ ./cmd/skywire-visor
 	${OPTS} go build ${BUILD_OPTS} -o ./ ./cmd/skywire-cli
 	${OPTS} go build ${BUILD_OPTS} -o ./ ./cmd/setup-node


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #	

 Changes:	
- add a sed command to change dbus vendor `conn.go` file, both for `Makefile` (build locally) and `.goreleaser-linux.yml`

How to test this PR:
- `make build-systray` and run on xfce desktop
- also can download my built from [here](https://freeshell.de/~mrpalide/skywire.tar.xz), extract it and test

Screencast:

https://user-images.githubusercontent.com/79150699/175022020-3db0604e-5a73-4bd2-b91e-ab4b706e5a65.mov


