### PR TITLE
New update procedure for the UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.module.ts
+++ b/static/skywire-manager-src/src/app/app.module.ts
@@ -95,6 +95,7 @@ import { VpnSettingsComponent } from './components/vpn/pages/vpn-settings/vpn-se
 import { VpnErrorComponent } from './components/vpn/pages/vpn-error/vpn-error.component';
 import { VpnServerNameComponent } from './components/vpn/layout/vpn-server-name/vpn-server-name.component';
 import { EnterVpnServerPasswordComponent } from './components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component';
+import { UpdateAllComponent } from './components/layout/update-all/update-all.component';
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -166,6 +167,7 @@ const globalRippleConfig: RippleGlobalOptions = {
     EditVpnServerValueComponent,
     VpnServerNameComponent,
     EnterVpnServerPasswordComponent,
+    UpdateAllComponent,
   ],
   imports: [
     BrowserModule,

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.html
@@ -1,0 +1,37 @@
+<app-dialog [headline]="'update-all.title' | translate">
+  <ng-container *ngIf="updatableNodes && updatableNodes.length > 0">
+    <div class="text-container">
+      {{ 'update-all.updatable-list-text' | translate }}
+    </div>
+
+    <div class="list-container">
+      <div class="list-element" *ngFor="let node of updatableNodes">
+        <div class="left-part">
+          <div class="name">{{node.label}}</div>
+          <div class="version">{{node.version}}</div>
+        </div>
+        <div class="right-part">
+          <app-button color="primary" (click)="openTerminal(node.key)">
+            {{ 'update-all.update-button' | translate }}
+          </app-button>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-container *ngIf="nonUpdatableNodes && nonUpdatableNodes.length > 0">
+    <div class="text-container">
+      {{ 'update-all.non-updatable-list-text' | translate }}
+    </div>
+
+    <div class="list-container">
+      <div class="list-element" *ngFor="let node of nonUpdatableNodes">
+        <div class="left-part">
+          <div class="name">{{node.label}}</div>
+          <div class="version">{{node.version}}</div>
+          <div class="version" *ngIf="node.tag">{{node.tag}}</div>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</app-dialog>

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.scss
@@ -1,0 +1,58 @@
+@import 'variables';
+@import "bootstrap_overrides";
+
+.text-container {
+  word-break: break-word;
+}
+
+.list-container {
+  font-size: 14px;
+  margin: 10px;
+  word-break: break-word;
+
+  .list-element {
+    display: flex;
+    margin-bottom: 10px;
+
+    .left-part {
+      flex-grow: 1;
+      flex-shrink: 1;
+      align-self: center;
+      margin-right: 10px;
+      min-width: 0;
+
+      .name {
+        font-size: $font-size-base;
+        line-height: 1.5;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        @media (max-width: (map-get($grid-breakpoints, sm) - 1)) {
+          & {
+            font-size: $font-size-mini;
+          }
+        }
+      }
+
+      .version {
+        font-size: $font-size-mini;
+        line-height: 1.5;
+        color: $blue-medium;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .right-part {
+      flex-basis: 0;
+      flex-shrink: 0;
+    }
+  }
+
+  .details {
+    color: $light-gray;
+  }
+}

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.ts
@@ -50,6 +50,6 @@ export class UpdateAllComponent {
   openTerminal(key: string) {
     const protocol = window.location.protocol;
     const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8000');
-    window.open(protocol + '//' + hostname + '/pty/' + key, '_blank', 'noopener noreferrer');
+    window.open(protocol + '//' + hostname + '/pty/' + key + '?commands=update', '_blank', 'noopener noreferrer');
   }
 }

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.ts
@@ -1,0 +1,55 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
+
+import { AppConfig } from 'src/app/app.config';
+
+
+/**
+ * Data about a node.
+ */
+export interface NodeData {
+  key: string;
+  label: string;
+  version: string;
+  tag: string;
+}
+
+/**
+ * Modal window used for updating all the nodes.
+ */
+@Component({
+  selector: 'app-update-all',
+  templateUrl: './update-all.component.html',
+  styleUrls: ['./update-all.component.scss'],
+})
+export class UpdateAllComponent {
+  updatableNodes: NodeData[];
+  nonUpdatableNodes: NodeData[];
+
+  /**
+   * Opens the modal window. Please use this function instead of opening the window "by hand".
+   * @param updatableNodes List with the nodes that can be updated with the terminal.
+   * @param nonUpdatableNodes List with the nodes that can not be updated with the terminal.
+   */
+  public static openDialog(dialog: MatDialog, updatableNodes: NodeData[], nonUpdatableNodes: NodeData[]): MatDialogRef<UpdateAllComponent, any> {
+    const config = new MatDialogConfig();
+    config.data = [updatableNodes, nonUpdatableNodes];
+    config.autoFocus = false;
+    config.width = AppConfig.smallModalWidth;
+
+    return dialog.open(UpdateAllComponent, config);
+  }
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) data: NodeData[][],
+  ) {
+    this.updatableNodes = data[0];
+    this.nonUpdatableNodes = data[1];
+  }
+
+  openTerminal(key: string) {
+    const protocol = window.location.protocol;
+    const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8000');
+    window.open(protocol + '//' + hostname + '/pty/' + key, '_blank', 'noopener noreferrer');
+  }
+}

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
@@ -1,3 +1,9 @@
+/**
+ * TODO: remove.
+ *
+ * Not used anymore, still here just as a precaution.
+ */
+
 import { Component, Inject, OnDestroy, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -175,7 +175,9 @@ export class NodeActionsHelper {
     confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
       const protocol = window.location.protocol;
       const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8000');
-      window.open(protocol + '//' + hostname + '/pty/' + this.currentNodeKey, '_blank', 'noopener noreferrer');
+      window.open(protocol + '//' + hostname + '/pty/' + this.currentNodeKey + '?commands=update', '_blank', 'noopener noreferrer');
+
+      confirmationDialog.close();
     });
   }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -12,7 +12,6 @@ import { OperationError } from 'src/app/utils/operation-error';
 import { processServiceError } from 'src/app/utils/errors';
 import { SelectableOption, SelectOptionComponent } from 'src/app/components/layout/select-option/select-option.component';
 import { MenuOptionData } from 'src/app/components/layout/top-bar/top-bar.component';
-import { UpdateComponent } from 'src/app/components/layout/update/update.component';
 import { StorageService } from 'src/app/services/storage.service';
 
 /**
@@ -171,9 +170,13 @@ export class NodeActionsHelper {
   }
 
   update() {
-    const labelInfo = this.storageService.getLabelInfo(this.currentNodeKey);
-    const label = labelInfo ? labelInfo.label : '';
-    UpdateComponent.openDialog(this.dialog, [{key: this.currentNodeKey, label: label}]);
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'actions.update.confirmation');
+
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      const protocol = window.location.protocol;
+      const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8000');
+      window.open(protocol + '//' + hostname + '/pty/' + this.currentNodeKey, '_blank', 'noopener noreferrer');
+    });
   }
 
   terminal() {

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -479,6 +479,7 @@ export class NodeService {
           // Basic data.
           node.online = response.online;
           node.localPk = response.overview.local_pk;
+          node.version = response.overview.build_info.version;
           node.autoconnectTransports = response.public_autoconnect;
           node.buildTag = response.build_tag ? response.build_tag : '';
 

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -282,6 +282,9 @@
       "confirmation": "Are you sure you want to reboot the visor?",
       "done": "The visor is restarting."
     },
+    "update": {
+      "confirmation": "A terminal will be opened in a new tab, so you can start the update process. Do you want to continue?"
+    },
     "terminal-options": {
       "full": "Full terminal",
       "simple": "Simple terminal"
@@ -317,6 +320,13 @@
     "starting": "Preparing to update",
     "finished": "Status connection finished",
     "install": "Install updates"
+  },
+
+  "update-all": {
+    "title": "Update",
+    "updatable-list-text": "Please press the buttons of the visors you want to update. A terminal will be opened in a new tab for each visor, so you can start the update procedure.",
+    "non-updatable-list-text": "The following visors can not be updated via the terminal:",
+    "update-button": "Update"
   },
 
   "apps": {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -283,7 +283,7 @@
       "done": "The visor is restarting."
     },
     "update": {
-      "confirmation": "A terminal will be opened in a new tab, so you can start the update process. Do you want to continue?"
+      "confirmation": "A terminal will be opened in a new tab and the update procedure will be started automatically. Do you want to continue?"
     },
     "terminal-options": {
       "full": "Full terminal",
@@ -324,7 +324,7 @@
 
   "update-all": {
     "title": "Update",
-    "updatable-list-text": "Please press the buttons of the visors you want to update. A terminal will be opened in a new tab for each visor, so you can start the update procedure.",
+    "updatable-list-text": "Please press the buttons of the visors you want to update. A terminal will be opened in a new tab for each visor and the update procedure will be started automatically.",
     "non-updatable-list-text": "The following visors can not be updated via the terminal:",
     "update-button": "Update"
   },

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -286,6 +286,9 @@
       "confirmation": "¿Seguro que desea reiniciar el visor?",
       "done": "El visor se está reiniciando."
     },
+    "update": {
+      "confirmation": "Una terminal será abierta en una nueva pestaña, para que pueda iniciar el proceso de actualización. ¿Desea continuar?"
+    },
     "terminal-options": {
       "full": "Terminal completa",
       "simple": "Terminal simple"
@@ -321,6 +324,13 @@
     "starting": "Preparando para actualizar",
     "finished": "Conexión de estado terminada",
     "install": "Instalar actualizaciones"
+  },
+
+  "update-all": {
+    "title": "Actualizar",
+    "updatable-list-text": "Por favor, presione los botones de los visores que desea actualizar. Una terminal será abierta en una nueva pestaña por cada visor, para que pueda iniciar el proceso de actualización.",
+    "non-updatable-list-text": "Los siguientes visores no pueden ser actualizados vía la terminal:",
+    "update-button": "Actualizar"
   },
 
   "apps": {

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -287,7 +287,7 @@
       "done": "El visor se está reiniciando."
     },
     "update": {
-      "confirmation": "Una terminal será abierta en una nueva pestaña, para que pueda iniciar el proceso de actualización. ¿Desea continuar?"
+      "confirmation": "Una terminal será abierta en una nueva pestaña y el proceso de actualización iniciará automáticamente. ¿Desea continuar?"
     },
     "terminal-options": {
       "full": "Terminal completa",
@@ -328,7 +328,7 @@
 
   "update-all": {
     "title": "Actualizar",
-    "updatable-list-text": "Por favor, presione los botones de los visores que desea actualizar. Una terminal será abierta en una nueva pestaña por cada visor, para que pueda iniciar el proceso de actualización.",
+    "updatable-list-text": "Por favor, presione los botones de los visores que desea actualizar. Una terminal será abierta en una nueva pestaña por cada visor y el proceso de actualización iniciará automáticamente.",
     "non-updatable-list-text": "Los siguientes visores no pueden ser actualizados vía la terminal:",
     "update-button": "Actualizar"
   },

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -286,6 +286,9 @@
       "confirmation": "Are you sure you want to reboot the visor?",
       "done": "The visor is restarting."
     },
+    "update": {
+      "confirmation": "A terminal will be opened in a new tab and the update procedure will be started automatically. Do you want to continue?"
+    },
     "terminal-options": {
       "full": "Full terminal",
       "simple": "Simple terminal"
@@ -321,6 +324,13 @@
     "starting": "Preparing to update",
     "finished": "Status connection finished",
     "install": "Install updates"
+  },
+
+  "update-all": {
+    "title": "Update",
+    "updatable-list-text": "Please press the buttons of the visors you want to update. A terminal will be opened in a new tab for each visor and the update procedure will be started automatically.",
+    "non-updatable-list-text": "The following visors can not be updated via the terminal:",
+    "update-button": "Update"
   },
 
   "apps": {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now, the option for updating all the visors opens this modal window:
![p](https://user-images.githubusercontent.com/34079003/175839571-e1c168de-2330-48cb-9dbb-3afef94e2ca2.png)
Visors with Mac and Windows tags are added to the non-updatable list.

- When trying to update a single node, a confirmation modal window is shown, for opening the terminal.

How to test this PR:
Use the update options in the visor list and in the visor details page.