### PR TITLE
Fix nil pointer error on dmsghttp config with offline stun server

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -474,15 +474,12 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/skycoin/dmsg v0.0.0-20220617100223-c17f98a92a47 h1:d/KdILjeiZOj3QFOm8KkOwIr5wwx9zWCl+oGVXPln1o=
-github.com/skycoin/dmsg v0.0.0-20220617100223-c17f98a92a47/go.mod h1:7ixxeJVjbe3lxDkI4Yizj/TWoafYxs8cPJfxjlDeG+w=
 github.com/skycoin/dmsg v0.0.0-20220704102949-fece1bd9c40c h1:v7d+0yOp066U8FmcUdQ0Nh9Q+qshBO7+w3ZybGJlBnk=
 github.com/skycoin/dmsg v0.0.0-20220704102949-fece1bd9c40c/go.mod h1:7ixxeJVjbe3lxDkI4Yizj/TWoafYxs8cPJfxjlDeG+w=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=
 github.com/skycoin/skycoin v0.27.1/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=
-github.com/skycoin/skywire-utilities v0.0.0-20220617085111-5c8c8d3ced14 h1:u8NYb1CX3l3I6wy6RWy2lQM6iqA6XbFex6Q/4MmEyfA=
 github.com/skycoin/skywire-utilities v0.0.0-20220617085111-5c8c8d3ced14/go.mod h1:B63p56igl38Ha+zjqi26d2om6XEe9jozwB6kzAWMnm0=
 github.com/skycoin/skywire-utilities v0.0.0-20220630144749-6ea8913bf1e8 h1:xUPi4duqObtDt4BYiNhbwssiUOFTor67Nftqx1F6/uc=
 github.com/skycoin/skywire-utilities v0.0.0-20220630144749-6ea8913bf1e8/go.mod h1:B63p56igl38Ha+zjqi26d2om6XEe9jozwB6kzAWMnm0=

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1199,7 +1199,7 @@ func getPublicIP(v *Visor, service string) (string, error) {
 }
 
 type ipAPI struct {
-	PublicIP string `json:"public_ip"`
+	PublicIP string `json:"ip_address"`
 }
 
 func getIP() (string, error) {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1173,7 +1173,7 @@ func getPublicIP(v *Visor, service string) (string, error) {
 	var serviceURL dmsgget.URL
 	var pIP string
 	err := serviceURL.Fill(service)
-	// only get the IP from the stun client if the url is of dmsg
+	// only get the IP if the url is of dmsg
 	// else just send empty string as ip
 	if serviceURL.Scheme != "dmsg" {
 		return pIP, nil

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1181,7 +1181,9 @@ func getPublicIP(v *Visor, service string) (pIP string, err error) {
 
 	// Wait until stun client is ready
 	<-v.stunReady
-
+	if v.stunClient.PublicIP == nil {
+		return "", fmt.Errorf("all STUN servers are offline, use direct URL config instead dmsghttp")
+	}
 	pIP = v.stunClient.PublicIP.IP()
 	return pIP, nil
 }

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1182,7 +1182,11 @@ func getPublicIP(service string) (string, error) {
 		return pIP, fmt.Errorf("provided URL is invalid: %w", err)
 	}
 
-	pIP = getip2()
+	pIP, err = getip2()
+	if err != nil {
+		return pIP, fmt.Errorf("cannot fetch public ip")
+	}
+
 	return pIP, nil
 }
 
@@ -1190,20 +1194,23 @@ type ipAPI struct {
 	Query string
 }
 
-func getip2() string {
+func getip2() (string, error) {
 	req, err := http.Get("http://ip-api.com/json/")
 	if err != nil {
-		return err.Error()
+		return "", err
 	}
-	defer req.Body.Close()
+	defer req.Body.Close() // nolint
 
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		return err.Error()
+		return "", err
 	}
 
 	var ip ipAPI
-	json.Unmarshal(body, &ip)
+	err = json.Unmarshal(body, &ip)
+	if err != nil {
+		return "", err
+	}
 
-	return ip.Query
+	return ip.Query, nil
 }


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1274 #1044

 Changes:	
- return error when all stun servers was offline

How to test this PR:
- `make build`
- generate dsmghttp config `skywire-cli config gen -dit`
- put arbitrary URL on stun_servers value in config, like:
  ```
  "stun_servers": [
	"172.112.20.3:3478"
  ],
  ```
- start visor and check logs