### PR TITLE
Avoid the cache while getting the IP

### DIFF
--- a/static/skywire-manager-src/src/app/services/vpn-client.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client.service.ts
@@ -295,7 +295,10 @@ export class VpnClientService {
       return of(['8.8.8.8 (testing)', 'United States (testing)']);
     }
 
-    return this.http.request('GET', window.location.protocol + '//ip.skycoin.com/').pipe(
+    // The date is added to avoid the browser cache.
+    const date = (new Date()).getTime();
+
+    return this.http.request('GET', window.location.protocol + '//ip.skycoin.com/?t=' + date).pipe(
       retryWhen(errors => concat(errors.pipe(delay(this.standardWaitTime), take(4)), throwError(''))),
       map(data => {
         let ip = '';


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the request for getting the IP in the VPN client are made to https://ip.skycoin.com/?t={currentTime} . This last part at the end, with the time, is ignored by the server and allows to avoid the browser cache.

How to test this PR:
Check if the VPN client continues caching the IP.