### PR TITLE
Fix/disable keepalives

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -776,7 +776,7 @@ func initHypervisors(ctx context.Context, v *Visor, log *logging.Logger) error {
 }
 
 func initUptimeTracker(ctx context.Context, v *Visor, log *logging.Logger) error {
-	const tickDuration = 1 * time.Minute
+	const tickDuration = 5 * time.Minute
 
 	conf := v.conf.UptimeTracker
 
@@ -1164,7 +1164,11 @@ func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client,
 		}
 		return v.dmsgHTTP, nil
 	}
-	return &http.Client{}, nil
+	return &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+		},
+	}, nil
 }
 
 func getPublicIP(v *Visor, service string) (pIP string, err error) {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1167,6 +1167,7 @@ func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client,
 	return &http.Client{
 		Transport: &http.Transport{
 			DisableKeepAlives: true,
+			IdleConnTimeout:   time.Second * 5,
 		},
 	}, nil
 }


### PR DESCRIPTION
Did you run `make format && make check`?
Yes

Fixes #1314 	

 Changes:	
- disable `http.Transport` keepalives
- change interval for uptime tracker to expected 5 minutes

How to test this PR:

This was tested with running a visor against production deployment while looping over `netstat -ntpw | grep skywire-visor`. Without these changes, the visor has permanently 3-5 connections to the deployment open while after these changes, there is only one permanent connection to a given dmsg server. 

Note: We need to think about if the additional overhead of re-establishing connections is worth the improvement in concurrent connections to our loadbalancer. 