### PR TITLE
Several improvements for the UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/layout/button/button.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/button/button.component.ts
@@ -91,4 +91,11 @@ export class ButtonComponent implements OnDestroy {
       this.disabled = false;
     }
   }
+
+  /**
+   * Returns true if the button is showing the loading animation.
+   */
+  get isLoading(): boolean {
+    return this.state === ButtonStates.Loading;
+  }
 }

--- a/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="(state !== confirmationStates.Done ? data.headerText : doneTitle) | translate" [disableDismiss]="disableDismiss">
+<app-dialog [headline]="(state !== confirmationStates.Done ? data.headerText : doneTitle) | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
   <div class="text-container">
     {{ (state !== confirmationStates.Done ? data.text : doneText) | translate }}
   </div>

--- a/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/confirmation/confirmation.component.ts
@@ -79,7 +79,7 @@ export class ConfirmationComponent implements AfterViewInit, OnDestroy {
   @Output() operationAccepted = new EventEmitter();
 
   constructor(
-    private dialogRef: MatDialogRef<ConfirmationComponent>,
+    public dialogRef: MatDialogRef<ConfirmationComponent>,
     @Inject(MAT_DIALOG_DATA) public data: ConfirmationData,
   ) {
     this.disableDismiss = !!data.disableDismiss;

--- a/static/skywire-manager-src/src/app/components/layout/dialog/dialog.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/dialog/dialog.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input } from '@angular/core';
+import { Component, HostListener, Input } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
 /**
  * Base component for all the modal windows. Its main function is to show the title bar.
@@ -11,7 +12,7 @@ import { Component, Input } from '@angular/core';
 export class DialogComponent {
   @Input() headline: string;
   /**
-   * Hides the close button.
+   * Disables all the ways provided by default by the UI for closing the modal window.
    */
   @Input() disableDismiss: boolean;
   /**
@@ -23,4 +24,30 @@ export class DialogComponent {
    * If true, vertical margins will be added to the content.
    */
   @Input() includeVerticalMargins = true;
+
+  // MatDialogRef of the modal window component which is using this component for wrapping
+  // the contents.
+  private dialogInternal: MatDialogRef<any>;
+  @Input() set dialog(val: MatDialogRef<any>) {
+    val.disableClose = true;
+    this.dialogInternal = val;
+  }
+
+  constructor(
+    private matDialog: MatDialog,
+  ) { }
+
+  @HostListener('window:keyup.esc')
+  onKeyUp() {
+    this.closePopup();
+  }
+
+  closePopup() {
+    if (!this.disableDismiss) {
+      // Continue only if the current modal window is the topmost one.
+      if (this.matDialog.openDialogs[this.matDialog.openDialogs.length - 1].id === this.dialogInternal.id) {
+        this.dialogInternal.close();
+      }
+    }
+  }
 }

--- a/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'labeled-element.edit-label' | translate">
+<app-dialog [headline]="'labeled-element.edit-label' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <mat-form-field>
       <input #firstInput [placeholder]="'edit-label.label' | translate" formControlName="label" maxlength="66" matInput>

--- a/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/edit-label/edit-label.component.ts
@@ -33,7 +33,7 @@ export class EditLabelComponent implements OnInit, AfterViewInit {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<EditLabelComponent>,
+    public dialogRef: MatDialogRef<EditLabelComponent>,
     @Inject(MAT_DIALOG_DATA) private data: LabelInfo,
     private formBuilder: FormBuilder,
     private storageService: StorageService,

--- a/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'filters.filter-action' | translate">
+<app-dialog [headline]="'filters.filter-action' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <!-- Form fields. -->
     <ng-container *ngFor="let fieldParams of data.filterPropertiesList">

--- a/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/filters-selection/filters-selection.component.ts
@@ -51,7 +51,7 @@ export class FiltersSelectionComponent implements OnInit {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: FiltersSelectiondParams,
-    private dialogRef: MatDialogRef<FiltersSelectionComponent>,
+    public dialogRef: MatDialogRef<FiltersSelectionComponent>,
     private formBuilder: FormBuilder,
   ) { }
 

--- a/static/skywire-manager-src/src/app/components/layout/select-language/select-language.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/select-language/select-language.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'language.title' | translate">
+<app-dialog [headline]="'language.title' | translate" [dialog]="dialogRef">
   <div class="options-container">
     <button
       mat-button

--- a/static/skywire-manager-src/src/app/components/layout/select-language/select-language.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/select-language/select-language.component.ts
@@ -30,7 +30,7 @@ export class SelectLanguageComponent implements OnInit, OnDestroy {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<SelectLanguageComponent>,
+    public dialogRef: MatDialogRef<SelectLanguageComponent>,
     private languageService: LanguageService,
   ) { }
 

--- a/static/skywire-manager-src/src/app/components/layout/select-option/select-option.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/select-option/select-option.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="data.title | translate" [includeVerticalMargins]="false">
+<app-dialog [headline]="data.title | translate" [dialog]="dialogRef" [includeVerticalMargins]="false">
   <div class="options-list-button-container" *ngFor="let option of data.options; let i = index">
     <button
       mat-button

--- a/static/skywire-manager-src/src/app/components/layout/select-option/select-option.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/select-option/select-option.component.ts
@@ -50,7 +50,7 @@ export class SelectOptionComponent {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: ComponentData,
-    private dialogRef: MatDialogRef<SelectOptionComponent>,
+    public dialogRef: MatDialogRef<SelectOptionComponent>,
   ) { }
 
   closePopup(selectedOption: number) {

--- a/static/skywire-manager-src/src/app/components/layout/top-bar/top-bar.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/top-bar/top-bar.component.scss
@@ -281,7 +281,7 @@ $top-bar-height: 56px;
   font-size: $font-size-mini-plus;
 
   .connection-error-msg-vpn {
-    margin: -5px 0px 5px 10px;
+    margin: -5px 5px 5px 10px;
     color: $yellow-clear;
   }
 

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'update-all.title' | translate">
+<app-dialog [headline]="'update-all.title' | translate" [dialog]="dialogRef">
   <ng-container *ngIf="updatableNodes && updatableNodes.length > 0">
     <div class="text-container">
       {{ 'update-all.updatable-list-text' | translate }}

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.ts
@@ -3,7 +3,6 @@ import { MatDialogRef, MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angu
 
 import { AppConfig } from 'src/app/app.config';
 
-
 /**
  * Data about a node.
  */
@@ -41,6 +40,7 @@ export class UpdateAllComponent {
   }
 
   constructor(
+    public dialogRef: MatDialogRef<UpdateAllComponent>,
     @Inject(MAT_DIALOG_DATA) data: NodeData[][],
   ) {
     this.updatableNodes = data[0];

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="(state !== updatingStates.Error ? 'update.title' : 'update.error-title') | translate">
+<app-dialog [headline]="(state !== updatingStates.Error ? 'update.title' : 'update.error-title') | translate" [dialog]="dialogRef">
   <!-- Main black text area. -->
   <div class="text-container">
     <ng-container *ngIf="state === updatingStates.InitialProcessing">

--- a/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/update/update.component.ts
@@ -188,7 +188,7 @@ export class UpdateComponent implements AfterViewInit, OnDestroy {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<UpdateComponent>,
+    public dialogRef: MatDialogRef<UpdateComponent>,
     @Inject(MAT_DIALOG_DATA) public data: NodeData[],
     private nodeService: NodeService,
     private translateService: TranslateService,

--- a/static/skywire-manager-src/src/app/components/pages/login/initial-setup/initial-setup.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/login/initial-setup/initial-setup.component.html
@@ -1,3 +1,3 @@
-<app-dialog [headline]="'settings.password.initial-config.title' | translate">
+<app-dialog [headline]="'settings.password.initial-config.title' | translate" [dialog]="dialogRef">
   <app-password [forInitialConfig]="true"></app-password>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/login/initial-setup/initial-setup.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/login/initial-setup/initial-setup.component.ts
@@ -23,4 +23,8 @@ export class InitialSetupComponent {
 
     return dialog.open(InitialSetupComponent, config);
   }
+
+  constructor(
+    public dialogRef: MatDialogRef<InitialSetupComponent>,
+  ) { }
 }

--- a/static/skywire-manager-src/src/app/components/pages/login/login.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/login/login.component.html
@@ -5,7 +5,7 @@
   >
     <img src="/assets/img/logo-v.png" class="logo" />
     <form class="mt-5" [formGroup]="form">
-      <div class="login-input">
+      <div class="login-input" [ngClass]="{'element-disabled' : loading}">
         <input
           type="password"
           formControlName="password"

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -111,7 +111,12 @@
         </tr>
 
         <!-- Values. -->
-        <tr *ngFor="let node of dataSource" (click)="open(node)" class="selectable">
+        <a
+          *ngFor="let node of dataSource"
+          [ngClass]="{'click-effect': node.online, 'non-selectable': !node.online}"
+          class="selectable link-row"
+          [routerLink]="node.online ? ['/nodes', node.localPk] : null"
+        >
           <td>
             <mat-icon *ngIf="node.isHypervisor" class="hypervisor-icon" [inline]="true" [matTooltip]="'nodes.hypervisor-info' | translate">star</mat-icon>
           </td>
@@ -139,9 +144,9 @@
               {{ 'common.time-in-ms' | translate:{ time: node.roundTripPing } }}
             </ng-container>
           </td>
-          <td (click)="$event.stopPropagation()" class="actions">
+          <td class="actions">
             <button
-              (click)="copyToClipboard(node)"
+              (click)="$event.stopPropagation(); $event.preventDefault(); copyToClipboard(node);"
               mat-icon-button
               [matTooltip]="(showDmsgInfo ? 'nodes.copy-data' : 'nodes.copy-key') | translate"
               class="big-action-button transparent-button"
@@ -149,7 +154,7 @@
               <mat-icon [inline]="true">filter_none</mat-icon>
             </button>
             <button
-              (click)="showEditLabelDialog(node)"
+              (click)="$event.stopPropagation(); $event.preventDefault(); showEditLabelDialog(node);"
               mat-icon-button
               [matTooltip]="'labeled-element.edit-label' | translate"
               class="big-action-button transparent-button"
@@ -158,7 +163,6 @@
             </button>
             <button
               *ngIf="node.online"
-              (click)="open(node)"
               mat-icon-button
               [matTooltip]="'nodes.view-node' | translate"
               class="big-action-button transparent-button"
@@ -167,7 +171,7 @@
             </button>
             <button
               *ngIf="!node.online"
-              (click)="deleteNode(node)"
+              (click)="$event.stopPropagation(); $event.preventDefault(); deleteNode(node);"
               mat-icon-button
               [matTooltip]="'nodes.delete-node' | translate"
               class="big-action-button transparent-button"
@@ -175,7 +179,7 @@
               <mat-icon>close</mat-icon>
             </button>
           </td>
-        </tr>
+        </a>
       </table>
 
       <!-- List for small screens. -->
@@ -185,7 +189,7 @@
         cellspacing="0" cellpadding="0"
       >
         <!-- Sorting button. -->
-        <tr class="selectable" (click)="dataSorter.openSortingOrderModal()"><td>
+        <tr class="selectable click-effect" (click)="dataSorter.openSortingOrderModal()"><td>
           <div class="list-item-container">
             <div class="left-part">
               <div class="title">{{ 'tables.sorting-title' | translate }}</div>
@@ -200,7 +204,7 @@
           </div>
         </td></tr>
         <!-- Values. -->
-        <tr *ngFor="let node of dataSource" (click)="open(node)" class="selectable"><td>
+        <a *ngFor="let node of dataSource" class="link-row" [ngClass]="{'selectable click-effect': node.online}" [routerLink]="node.online ? ['/nodes', node.localPk] : null"><tr class="d-block"><td class="d-block">
           <div class="list-item-container">
             <div class="left-part">
               <div class="list-row" *ngIf="node.isHypervisor">
@@ -235,7 +239,7 @@
             <div class="margin-part"></div>
             <div class="right-part">
               <button
-                (click)="$event.stopPropagation(); showOptionsDialog(node)"
+                (click)="$event.stopPropagation(); $event.preventDefault(); showOptionsDialog(node);"
                 mat-icon-button
                 [matTooltip]="'common.options' | translate"
                 class="transparent-button"
@@ -244,7 +248,7 @@
               </button>
             </div>
           </div>
-        </td></tr>
+        </td></tr></a>
       </table>
     </div></div>
 

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.scss
@@ -26,3 +26,7 @@
 .small-column {
   width: 1px;
 }
+
+.non-selectable {
+  cursor: not-allowed;
+}

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -677,13 +677,4 @@ export class NodeListComponent implements OnInit, OnDestroy {
       }
     });
   }
-
-  /**
-   * Opens the page with the details of the node.
-   */
-  open(node: Node) {
-    if (node.online) {
-      this.router.navigate(['nodes', node.localPk]);
-    }
-  }
 }

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/basic-terminal/basic-terminal.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/basic-terminal/basic-terminal.component.html
@@ -2,6 +2,7 @@
   [headline]="('actions.terminal.title' | translate) + ' - ' + this.data.label + ' (' + this.data.pk + ')'"
   [includeScrollableArea]="false"
   [includeVerticalMargins]="false"
+  [dialog]="dialogRef"
 >
   <mat-dialog-content #dialogContent (click)="focusTerminal()">
     <div class="wrapper">

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/basic-terminal/basic-terminal.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/basic-terminal/basic-terminal.component.ts
@@ -64,6 +64,7 @@ export class BasicTerminalComponent implements AfterViewInit, OnDestroy {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: BasicTerminalData,
+    public dialogRef: MatDialogRef<BasicTerminalComponent>,
     private renderer: Renderer2,
     private apiService: ApiService,
     private translate: TranslateService,

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log-filter/log-filter.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log-filter/log-filter.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'apps.log.filter.title' | translate">
+<app-dialog [headline]="'apps.log.filter.title' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <mat-form-field>
       <mat-select

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log-filter/log-filter.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log-filter/log-filter.component.ts
@@ -49,7 +49,7 @@ export class LogFilterComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: LogsFilter,
-    private dialogRef: MatDialogRef<LogFilterComponent>,
+    public dialogRef: MatDialogRef<LogFilterComponent>,
     private formBuilder: FormBuilder,
   ) { }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'apps.log.title' | translate" [includeVerticalMargins]="false" [includeScrollableArea]="false">
+<app-dialog [headline]="'apps.log.title' | translate" [includeVerticalMargins]="false" [includeScrollableArea]="false" [dialog]="dialogRef">
   <div class="filter-link-container">
     <div class="filter-link subtle-transparent-button" (click)="filter()">
       <span class="transparent">{{ 'apps.log.filter-button' | translate }}</span>&nbsp;

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.ts
@@ -66,6 +66,7 @@ export class LogComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: Application,
+    public dialogRef: MatDialogRef<LogComponent>,
     private appsService: AppsService,
     private dialog: MatDialog,
     private snackbarService: SnackbarService,

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/edit-skysocks-client-note/edit-skysocks-client-note.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/edit-skysocks-client-note/edit-skysocks-client-note.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'apps.vpn-socks-client-settings.change-note-dialog.title' | translate">
+<app-dialog [headline]="'apps.vpn-socks-client-settings.change-note-dialog.title' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <mat-form-field>
       <input #firstInput [placeholder]="'apps.vpn-socks-client-settings.change-note-dialog.note' | translate" formControlName="note" maxlength="100" matInput>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/edit-skysocks-client-note/edit-skysocks-client-note.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/edit-skysocks-client-note/edit-skysocks-client-note.component.ts
@@ -33,7 +33,7 @@ export class EditSkysocksClientNoteComponent implements OnInit {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<EditSkysocksClientNoteComponent>,
+    public dialogRef: MatDialogRef<EditSkysocksClientNoteComponent>,
     @Inject(MAT_DIALOG_DATA) private data: string,
     private formBuilder: FormBuilder,
   ) { }

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-filter/skysocks-client-filter.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-filter/skysocks-client-filter.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'apps.vpn-socks-client-settings.filter-dialog.title' | translate">
+<app-dialog [headline]="'apps.vpn-socks-client-settings.filter-dialog.title' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
 
     <!-- Country. -->

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-filter/skysocks-client-filter.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-filter/skysocks-client-filter.component.ts
@@ -53,7 +53,7 @@ export class SkysocksClientFilterComponent implements OnInit {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: FilterWindowData,
-    private dialogRef: MatDialogRef<SkysocksClientFilterComponent>,
+    public dialogRef: MatDialogRef<SkysocksClientFilterComponent>,
     private formBuilder: FormBuilder,
   ) { }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-password/skysocks-client-password.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-password/skysocks-client-password.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'apps.vpn-socks-client-settings.password-dialog.title' | translate">
+<app-dialog [headline]="'apps.vpn-socks-client-settings.password-dialog.title' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <div class="info">{{ 'apps.vpn-socks-client-settings.password-dialog.info' | translate }}</div>
     <mat-form-field>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-password/skysocks-client-password.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-password/skysocks-client-password.component.ts
@@ -32,7 +32,7 @@ export class SkysocksClientPasswordComponent implements OnInit {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<SkysocksClientPasswordComponent>,
+    public dialogRef: MatDialogRef<SkysocksClientPasswordComponent>,
     private formBuilder: FormBuilder,
   ) { }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.html
@@ -1,9 +1,13 @@
-<app-dialog [headline]="('apps.vpn-socks-client-settings.' + ( configuringVpn ? 'vpn-title' : 'socks-title')) | translate">
+<app-dialog
+  [headline]="('apps.vpn-socks-client-settings.' + ( configuringVpn ? 'vpn-title' : 'socks-title')) | translate"
+  [dialog]="dialogRef"
+  [disableDismiss]="disableDismiss"
+>
   <mat-tab-group>
     <!-- Form. -->
     <mat-tab [label]="'apps.vpn-socks-client-settings.remote-visor-tab' | translate">
       <form [formGroup]="form">
-        <mat-form-field>
+        <mat-form-field [ngClass]="{'element-disabled' : disableDismiss}">
           <input
             id="pk"
             formControlName="pk"
@@ -22,7 +26,7 @@
           </ng-template>
         </mat-form-field>
 
-        <mat-form-field *ngIf="configuringVpn">
+        <mat-form-field *ngIf="configuringVpn" [ngClass]="{'element-disabled' : disableDismiss}">
           <input
             id="password"
             type="password"

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.ts
@@ -128,7 +128,7 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: Application,
-    private dialogRef: MatDialogRef<SkysocksClientSettingsComponent>,
+    public dialogRef: MatDialogRef<SkysocksClientSettingsComponent>,
     private appsService: AppsService,
     private formBuilder: FormBuilder,
     private snackbarService: SnackbarService,
@@ -197,6 +197,13 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
     if (this.operationSubscription) {
       this.operationSubscription.unsubscribe();
     }
+  }
+
+  /**
+   * If true, all the ways provided by default by the UI for closing the modal window are disabled.
+   */
+   get disableDismiss(): boolean {
+    return this.button && this.settingsButton ? (this.button.isLoading || this.settingsButton.isLoading) : false;
   }
 
   // Used by the checkbox for the killswitch setting.

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.html
@@ -1,8 +1,10 @@
 <app-dialog
   [headline]="('apps.vpn-socks-server-settings.' + ( configuringVpn ? 'vpn-title' : 'socks-title')) | translate"
+  [dialog]="dialogRef"
+  [disableDismiss]="disableDismiss"
 >
   <form [formGroup]="form">
-    <mat-form-field>
+    <mat-form-field [ngClass]="{'element-disabled' : disableDismiss}">
       <input
         id="password"
         type="password"
@@ -13,7 +15,7 @@
         matInput
       >
     </mat-form-field>
-    <mat-form-field>
+    <mat-form-field [ngClass]="{'element-disabled' : disableDismiss}">
       <input
         id="passwordConfirmation"
         type="password"
@@ -27,7 +29,7 @@
         {{ 'apps.vpn-socks-server-settings.passwords-not-match' | translate }}
       </mat-error>
     </mat-form-field>
-    <mat-form-field *ngIf="configuringVpn">
+    <mat-form-field *ngIf="configuringVpn" [ngClass]="{'element-disabled' : disableDismiss}">
       <input
         id="netifc"
         type="text"
@@ -41,6 +43,7 @@
         color="primary"
         [checked]="secureMode"
         (change)="setSecureMode($event)"
+        [ngClass]="{'element-disabled' : disableDismiss}"
       >
         {{ 'apps.vpn-socks-server-settings.secure-mode-check' | translate }}
         <mat-icon [inline]="true" class="help-icon" [matTooltip]="'apps.vpn-socks-server-settings.secure-mode-info' | translate">help</mat-icon>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-settings/skysocks-settings.component.ts
@@ -51,7 +51,7 @@ export class SkysocksSettingsComponent implements OnInit, OnDestroy {
     @Inject(MAT_DIALOG_DATA) private data: Application,
     private appsService: AppsService,
     private formBuilder: FormBuilder,
-    private dialogRef: MatDialogRef<SkysocksSettingsComponent>,
+    public dialogRef: MatDialogRef<SkysocksSettingsComponent>,
     private snackbarService: SnackbarService,
     private dialog: MatDialog,
   ) {
@@ -92,6 +92,13 @@ export class SkysocksSettingsComponent implements OnInit, OnDestroy {
     if (this.operationSubscription) {
       this.operationSubscription.unsubscribe();
     }
+  }
+
+  /**
+   * If true, all the ways provided by default by the UI for closing the modal window are disabled.
+   */
+   get disableDismiss(): boolean {
+    return this.button ? this.button.isLoading : false;
   }
 
   // Used by the checkbox for the secure mode setting.

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component.html
@@ -1,7 +1,7 @@
-<app-dialog [headline]="'router-config.title' | translate">
+<app-dialog [headline]="'router-config.title' | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
   <!-- TODO: add help text. -->
   <div class="info-container">{{'router-config.info' | translate}}</div>
-  <form [formGroup]="form">
+  <form [formGroup]="form" [ngClass]="{'element-disabled' : disableDismiss}">
     <mat-form-field>
       <input
         #firstInput

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component.ts
@@ -55,7 +55,7 @@ export class RouterConfigComponent implements OnInit, OnDestroy {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<RouterConfigComponent>,
+    public dialogRef: MatDialogRef<RouterConfigComponent>,
     @Inject(MAT_DIALOG_DATA) private data: RouterConfigParams,
     private formBuilder: FormBuilder,
     private snackbarService: SnackbarService,
@@ -78,6 +78,13 @@ export class RouterConfigComponent implements OnInit, OnDestroy {
     if (this.operationSubscription) {
       this.operationSubscription.unsubscribe();
     }
+  }
+
+  /**
+   * If true, all the ways provided by default by the UI for closing the modal window are disabled.
+   */
+   get disableDismiss(): boolean {
+    return this.button ? this.button.isLoading : false;
   }
 
   save() {

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.html
@@ -1,4 +1,4 @@
-<app-dialog class="info-dialog" [headline]="'routes.details.title' | translate">
+<app-dialog class="info-dialog" [headline]="'routes.details.title' | translate" [dialog]="dialogRef">
   <div>
     <!-- Basic info. -->
     <div class="title mt-0">

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-details/route-details.component.ts
@@ -39,7 +39,7 @@ export class RouteDetailsComponent {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) data: Route,
-    private dialogRef: MatDialogRef<RouteDetailsComponent>,
+    public dialogRef: MatDialogRef<RouteDetailsComponent>,
     private storageService: StorageService,
   ) {
     this.routeRule = data;

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.html
@@ -1,7 +1,7 @@
-<app-dialog [headline]="'transports.create' | translate">
+<app-dialog [headline]="'transports.create' | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
   <app-loading-indicator [showWhite]="false" *ngIf="!types"></app-loading-indicator>
   <form [formGroup]="form" *ngIf="types">
-    <mat-form-field>
+    <mat-form-field [ngClass]="{'element-disabled' : disableDismiss}">
       <input
         formControlName="remoteKey"
         maxlength="66"
@@ -19,7 +19,7 @@
       </ng-template>
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-form-field  [ngClass]="{'element-disabled' : disableDismiss}">
       <input
         formControlName="label"
         maxlength="66"
@@ -28,7 +28,7 @@
       >
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-form-field  [ngClass]="{'element-disabled' : disableDismiss}">
       <mat-select
         formControlName="type"
         [placeholder]="'transports.dialog.transport-type' | translate"
@@ -44,6 +44,7 @@
       color="primary"
       [checked]="makePersistent"
       (change)="setMakePersistent($event)"
+      [ngClass]="{'element-disabled' : disableDismiss}"
     >
       {{ 'transports.dialog.make-persistent' | translate }}
       <mat-icon [inline]="true" class="help-icon" [matTooltip]="'transports.dialog.persistent-tooltip' | translate">help</mat-icon>

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.ts
@@ -50,7 +50,7 @@ export class CreateTransportComponent implements OnInit, OnDestroy {
   constructor(
     private transportService: TransportService,
     private formBuilder: FormBuilder,
-    private dialogRef: MatDialogRef<CreateTransportComponent>,
+    public dialogRef: MatDialogRef<CreateTransportComponent>,
     private snackbarService: SnackbarService,
     private storageService: StorageService,
     private nodeService: NodeService,
@@ -77,6 +77,13 @@ export class CreateTransportComponent implements OnInit, OnDestroy {
     if (this.operationSubscription) {
       this.operationSubscription.unsubscribe();
     }
+  }
+
+  /**
+   * If true, all the ways provided by default by the UI for closing the modal window are disabled.
+   */
+  get disableDismiss(): boolean {
+    return this.button ? this.button.isLoading : false;
   }
 
   /**

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-details/transport-details.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-details/transport-details.component.html
@@ -1,4 +1,4 @@
-<app-dialog class="info-dialog" [headline]="'transports.details.title' | translate">
+<app-dialog class="info-dialog" [headline]="'transports.details.title' | translate" [dialog]="dialogRef">
   <div>
     <div class="title mt-0">
       <mat-icon [inline]="true">list</mat-icon>{{ 'transports.details.basic.title' | translate }}

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-details/transport-details.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-details/transport-details.component.ts
@@ -28,5 +28,6 @@ export class TransportDetailsComponent {
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: Transport,
+    public dialogRef: MatDialogRef<TransportDetailsComponent>,
   ) { }
 }

--- a/static/skywire-manager-src/src/app/components/pages/settings/password/password.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/settings/password/password.component.html
@@ -5,7 +5,7 @@
     </mat-icon>
   </div>
   <form [formGroup]="form">
-    <mat-form-field *ngIf="!forInitialConfig" class="white-form-field">
+    <mat-form-field *ngIf="!forInitialConfig" class="white-form-field" [ngClass]="{'element-disabled' : working}">
       <input
         type="password"
         formControlName="oldPassword"
@@ -18,7 +18,7 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field [ngClass]="{'white-form-field': !forInitialConfig}">
+    <mat-form-field [ngClass]="{'white-form-field': !forInitialConfig, 'element-disabled' : working}">
       <input
         type="password"
         formControlName="newPassword"
@@ -32,7 +32,7 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field [ngClass]="{'white-form-field': !forInitialConfig}">
+    <mat-form-field [ngClass]="{'white-form-field': !forInitialConfig, 'element-disabled' : working}">
       <input
         type="password"
         formControlName="newPasswordConfirmation"

--- a/static/skywire-manager-src/src/app/components/pages/settings/password/password.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/password/password.component.ts
@@ -66,6 +66,13 @@ export class PasswordComponent implements OnInit, AfterViewInit, OnDestroy {
     this.formSubscription.unsubscribe();
   }
 
+  /**
+   * If true, the component is working and the form must be disabled.
+   */
+   get working(): boolean {
+    return this.button ? this.button.isLoading : false;
+  }
+
   changePassword() {
     if (this.form.valid && !this.button.disabled) {
       this.button.showLoading();

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.html
@@ -11,13 +11,20 @@
   </div>
   <div class="content col-12 mt-4.5">
     <app-refresh-rate class="d-block mb-4"></app-refresh-rate>
-    <app-password></app-password>
+
+    <app-password *ngIf="authChecked && authActive"></app-password>
+    <div class="white-theme checking-container" *ngIf="!authChecked && !waitBeforeShowingLoading">
+      <mat-spinner [diameter]="11"></mat-spinner> {{ 'settings.checking-auth' | translate }}
+    </div>
+
     <app-label-list
       [showShortList]="true">
     </app-label-list>
+    <!-- TODO: must be removed, with the text, if the old updater is removed.
     <div class="d-block mt-4" *ngIf="!mustShowUpdaterSettings" (click)="showUpdaterSettings()">
       <span class="show-link">{{ 'settings.updater-config.open-link' | translate }}</span>
     </div>
     <app-updater-config class="d-block mt-4" *ngIf="mustShowUpdaterSettings"></app-updater-config>
+    -->
   </div>
 </div>

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.scss
@@ -1,5 +1,14 @@
 @import "variables";
 
+.checking-container {
+  font-size: 10px;
+  opacity: 0.5;
+
+  .mat-spinner {
+    display: inline-block;
+  }
+}
+
 .show-link {
   cursor: pointer;
   font-size: $font-size-smaller;

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
@@ -1,9 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
+import { of, Subscription } from 'rxjs';
+import { delay, flatMap } from 'rxjs/operators';
 
 import { TabButtonData, MenuOptionData } from '../../layout/top-bar/top-bar.component';
-import { AuthService } from '../../../services/auth.service';
+import { AuthService, AuthStates } from '../../../services/auth.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import GeneralUtils from 'src/app/utils/generalUtils';
 import { UpdaterStorageKeys } from 'src/app/services/node.service';
@@ -16,10 +18,20 @@ import { UpdaterStorageKeys } from 'src/app/services/node.service';
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss']
 })
-export class SettingsComponent {
+export class SettingsComponent implements OnInit, OnDestroy {
   tabsData: TabButtonData[] = [];
   options: MenuOptionData[] = [];
-  mustShowUpdaterSettings = !!localStorage.getItem(UpdaterStorageKeys.UseCustomSettings);
+
+  // If true, the animation telling the user that the auth settings are being checked isn't shown.
+  waitBeforeShowingLoading = true;
+  authChecked = false;
+  // Removes the password settings if the auth option is not active in the back-end.
+  authActive = false;
+
+  private authSubscription: Subscription;
+
+  // TODO: must be removed if the old updater is removed.
+  //mustShowUpdaterSettings = !!localStorage.getItem(UpdaterStorageKeys.UseCustomSettings);
 
   constructor(
     private authService: AuthService,
@@ -56,6 +68,39 @@ export class SettingsComponent {
     ];
   }
 
+  ngOnInit() {
+    setTimeout(() => {
+      this.waitBeforeShowingLoading = false;
+    }, 500);
+
+    this.checkAuth(0);
+  }
+
+  /**
+   * Checks if the auth options are active and the user is authenticated.
+   */
+  private checkAuth(delayMilliseconds: number) {
+    this.authSubscription = of(1).pipe(
+      // Wait the delay.
+      delay(delayMilliseconds),
+      // Load the data. The node pk is obtained from the currently openned node page.
+      flatMap(() => this.authService.checkLogin())
+    ).subscribe(
+      result => {
+        //this.authChecked = true;
+        this.authActive = result === AuthStates.Logged;
+      },
+      () => {
+        // Retry after a small delay.
+        this.checkAuth(15000);
+      },
+    );
+  }
+
+  ngOnDestroy() {
+    this.authSubscription.unsubscribe();
+  }
+
   /**
    * Called when an option form the top bar is selected.
    * @param actionName Name of the selected option, as defined in the this.options array.
@@ -79,6 +124,8 @@ export class SettingsComponent {
     });
   }
 
+  // TODO: must be removed, with the text, if the old updater is removed.
+  /*
   // Opens the updater settings, if the user confirms the operation.
   showUpdaterSettings() {
     const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'settings.updater-config.open-confirmation');
@@ -89,4 +136,5 @@ export class SettingsComponent {
       this.mustShowUpdaterSettings = true;
     });
   }
+  */
 }

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
@@ -87,7 +87,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       flatMap(() => this.authService.checkLogin())
     ).subscribe(
       result => {
-        //this.authChecked = true;
+        this.authChecked = true;
         this.authActive = result === AuthStates.Logged;
       },
       () => {

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/add-vpn-server/add-vpn-server.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/add-vpn-server/add-vpn-server.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'vpn.server-list.add-server-dialog.title' | translate">
+<app-dialog [headline]="'vpn.server-list.add-server-dialog.title' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <!-- Public key. -->
     <mat-form-field>

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/add-vpn-server/add-vpn-server.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/add-vpn-server/add-vpn-server.component.ts
@@ -44,7 +44,7 @@ export class AddVpnServerComponent implements OnInit {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<AddVpnServerComponent>,
+    public dialogRef: MatDialogRef<AddVpnServerComponent>,
     @Inject(MAT_DIALOG_DATA) private data: string,
     private formBuilder: FormBuilder,
     private dialog: MatDialog,

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/edit-vpn-server-value/edit-vpn-server-value.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/edit-vpn-server-value/edit-vpn-server-value.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="('vpn.server-options.edit-value.' + (data.editName ? 'name' : 'note' ) + '-title') | translate">
+<app-dialog [headline]="('vpn.server-options.edit-value.' + (data.editName ? 'name' : 'note' ) + '-title') | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <!-- Value field. -->
     <mat-form-field>

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/edit-vpn-server-value/edit-vpn-server-value.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/edit-vpn-server-value/edit-vpn-server-value.component.ts
@@ -45,7 +45,7 @@ export class EditVpnServerValueComponent implements OnInit {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<EditVpnServerValueComponent>,
+    public dialogRef: MatDialogRef<EditVpnServerValueComponent>,
     @Inject(MAT_DIALOG_DATA) public data: EditVpnServerParams,
     private formBuilder: FormBuilder,
     private snackbarService: SnackbarService,

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component.html
@@ -1,4 +1,4 @@
-<app-dialog [headline]="'vpn.server-list.password-dialog.title' | translate">
+<app-dialog [headline]="'vpn.server-list.password-dialog.title' | translate" [dialog]="dialogRef">
   <form [formGroup]="form">
     <!-- Password field. -->
     <mat-form-field>

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component.ts
@@ -32,7 +32,7 @@ export class EnterVpnServerPasswordComponent implements OnInit {
   }
 
   constructor(
-    private dialogRef: MatDialogRef<EnterVpnServerPasswordComponent>,
+    public dialogRef: MatDialogRef<EnterVpnServerPasswordComponent>,
     @Inject(MAT_DIALOG_DATA) public data: boolean,
     private formBuilder: FormBuilder,
   ) { }

--- a/static/skywire-manager-src/src/app/utils/generalUtils.ts
+++ b/static/skywire-manager-src/src/app/utils/generalUtils.ts
@@ -17,7 +17,7 @@ export default class GeneralUtils {
       headerText: 'confirmation.header-text',
       confirmButtonText: 'confirmation.confirm-button',
       cancelButtonText: 'confirmation.cancel-button',
-      disableDismiss: true,
+      disableDismiss: false,
     };
 
     const config = new MatDialogConfig();

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -217,6 +217,7 @@
 
   "settings": {
     "title": "Settings",
+    "checking-auth": "Checking authentication settings.",
     "password" : {
       "initial-config-help": "Use this option for setting the initial password. After a password has been set, it is not possible to use this option to modify it.",
       "help": "Options for changing your password.",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -221,6 +221,7 @@
 
   "settings": {
     "title": "Configuración",
+    "checking-auth": "Revisando configuración de autenticación.",
     "password" : {
       "initial-config-help": "Use esta opción para establecer la contraseña inicial. Después de establecer una contraseña no es posible usar esta opción para modificarla.",
       "help": "Opciones para cambiar la contraseña.",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -221,6 +221,7 @@
 
   "settings": {
     "title": "Settings",
+    "checking-auth": "Checking authentication settings.",
     "password" : {
       "initial-config-help": "Use this option for setting the initial password. After a password has been set, it is not possible to use this option to modify it.",
       "help": "Options for changing your password.",

--- a/static/skywire-manager-src/src/assets/scss/_forms.scss
+++ b/static/skywire-manager-src/src/assets/scss/_forms.scss
@@ -34,3 +34,9 @@ mat-form-field {
   @extend .form-help-icon-container;
   color: scale-color($white, $alpha: -20%);
 }
+
+// Used for showing a form field disabled.
+.element-disabled {
+  pointer-events: none !important;
+  opacity: 0.5 !important;
+}

--- a/static/skywire-manager-src/src/assets/scss/_responsive_tables.scss
+++ b/static/skywire-manager-src/src/assets/scss/_responsive_tables.scss
@@ -18,7 +18,7 @@ $responsive-table-colors: (
 
     td, th {
       color: nth($colors, 3) !important;
-      padding: 12px 10px !important;
+      padding: 12px 10px;
       border-bottom: 1px solid $separator;
     }
 
@@ -44,6 +44,14 @@ $responsive-table-colors: (
           top: 2px;
         }
       }      
+    }
+
+    .link-row {
+      display: table-row;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
 
     // Column used for the check boxes.

--- a/static/skywire-manager-src/src/styles.scss
+++ b/static/skywire-manager-src/src/styles.scss
@@ -124,3 +124,7 @@ button:focus {
   line-height: 1.8;
   padding: 7px 14px !important;
 }
+
+.mat-tooltip-panel {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now it is not possible to close the modal windows while the system is busy, to avoid incorrect expectations from the users about the state of the operations.

- Now the forms are deactivated while the system is busy.

- Now the rows of the visor list are links, which means that the option for opening the details in a news tab is now available.

- Now it is possible to close the confirmation dialogs by pressing esc.

- The old updater options were removed from the settings tab.

- Now the options for changing the password are not visible in the settings tab if the authentication features are not enabled in the back-end.

- Now the tooltips don't stay open if the mouse is over them, this prevents really annoying behaviors in small lists.

- Now the visor list has the click effect used in the list of the VPN UI. Also, the rows for offline visors are not highlighted while the mouse is over them.

How to test this PR:
- Use a modal window to create a transport and try to close it while the operation is in progrees. It should not be posible to close it and the form should be disabled during the operation.

- Select a row in the visor list, with the right mouse button. The menu should show the option for opening in a new tab.

- Use any option that needs confirmation. You should be able to close the confirmation modal window by pressing esc.

- Open the settings tab. It must not show the updater options. The password options should only appear if the auth options are active in the hypervisor.

- Open the server list in the VPN UI. Move the mouse from the top row to the bottom one, over the column with the options icons. You should see the tooltip saying "Options" for each icon and the tooltip should not interfere with the ability to display the tooltip of any other icon.