### PR TITLE
`skywire-cli config gen` flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `autoConn` and `isPublic` flag for `skywire-cli`
 
+### Changed
+
+- improve UI reaction while system is busy
+- hide password options in UI if authentication is disabled
+
+### Removed
+
+- remove updater settings from UI
+
 ## 1.0.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.2
+
+### Added
+
+- `autoConn` and `isPublic` flag for `skywire-cli`
+
 ## 1.0.0
 
 ### Changed

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -30,22 +30,22 @@ func init() {
 	ghiddenflags = append(ghiddenflags, "url")
 	genConfigCmd.Flags().StringVar(&logLevel, "log-level", "info", "level of logging in config")
 	ghiddenflags = append(ghiddenflags, "log-level")
-	genConfigCmd.Flags().BoolVarP(&bestProtocol, "bestproto", "b", false, "best protocol (dmsg | direct) based on location")
-	genConfigCmd.Flags().BoolVarP(&disableauth, "noauth", "c", false, "disable authentication for hypervisor UI")
+	genConfigCmd.Flags().BoolVarP(&isBestProtocol, "bestproto", "b", false, "best protocol (dmsg | direct) based on location")
+	genConfigCmd.Flags().BoolVarP(&isDisableauth, "noauth", "c", false, "disable authentication for hypervisor UI")
 	ghiddenflags = append(ghiddenflags, "noauth")
-	genConfigCmd.Flags().BoolVarP(&dmsgHTTP, "dmsghttp", "d", false, "use dmsg connection to skywire services")
+	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", false, "use dmsg connection to skywire services")
 	ghiddenflags = append(ghiddenflags, "dmsghttp")
-	genConfigCmd.Flags().BoolVarP(&enableauth, "auth", "e", false, "enable auth on hypervisor UI")
+	genConfigCmd.Flags().BoolVarP(&isEnableauth, "auth", "e", false, "enable auth on hypervisor UI")
 	ghiddenflags = append(ghiddenflags, "auth")
-	genConfigCmd.Flags().BoolVarP(&force, "force", "f", false, "remove pre-existing config")
+	genConfigCmd.Flags().BoolVarP(&isForce, "force", "f", false, "remove pre-existing config")
 	ghiddenflags = append(ghiddenflags, "force")
 	genConfigCmd.Flags().StringVarP(&disableApps, "disableapps", "g", "", "comma separated list of apps to disable")
 	ghiddenflags = append(ghiddenflags, "disableapps")
-	genConfigCmd.Flags().BoolVarP(&hypervisor, "ishv", "i", false, "local hypervisor configuration")
+	genConfigCmd.Flags().BoolVarP(&isHypervisor, "ishv", "i", false, "local hypervisor configuration")
 	genConfigCmd.Flags().StringVarP(&hypervisorPKs, "hvpks", "j", "", "list of public keys to use as hypervisor")
 	genConfigCmd.Flags().StringVarP(&selectedOS, "os", "k", skyenv.OS, "(linux / mac / win) paths")
 	ghiddenflags = append(ghiddenflags, "os")
-	genConfigCmd.Flags().BoolVarP(&stdout, "stdout", "n", false, "write config to stdout")
+	genConfigCmd.Flags().BoolVarP(&isStdout, "stdout", "n", false, "write config to stdout")
 	ghiddenflags = append(ghiddenflags, "stdout")
 	genConfigCmd.Flags().StringVarP(&output, "out", "o", "", "output config: "+skyenv.ConfigName)
 	if skyenv.OS == "win" {
@@ -57,31 +57,31 @@ func init() {
 	if skyenv.OS == "mac" {
 		ptext = "use mac installation path: "
 	}
-	genConfigCmd.Flags().BoolVarP(&pkgEnv, "pkg", "p", false, ptext+skyenv.SkywirePath)
+	genConfigCmd.Flags().BoolVarP(&isPkgEnv, "pkg", "p", false, ptext+skyenv.SkywirePath)
 	homepath := skyenv.HomePath()
 	if homepath != "" {
-		genConfigCmd.Flags().BoolVarP(&usrEnv, "user", "u", false, "use paths for user space: "+homepath)
+		genConfigCmd.Flags().BoolVarP(&isUsrEnv, "user", "u", false, "use paths for user space: "+homepath)
 	}
-	genConfigCmd.Flags().BoolVarP(&publicRPC, "publicrpc", "q", false, "allow rpc requests from LAN")
+	genConfigCmd.Flags().BoolVarP(&isPublicRPC, "publicrpc", "q", false, "allow rpc requests from LAN")
 	ghiddenflags = append(ghiddenflags, "publicrpc")
-	genConfigCmd.Flags().BoolVarP(&regen, "regen", "r", false, "re-generate existing config & retain keys")
+	genConfigCmd.Flags().BoolVarP(&isRegen, "regen", "r", false, "re-generate existing config & retain keys")
 	genConfigCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
 	ghiddenflags = append(ghiddenflags, "sk")
-	genConfigCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "use test deployment "+testconf)
+	genConfigCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", false, "use test deployment "+testconf)
 	ghiddenflags = append(ghiddenflags, "testenv")
-	genConfigCmd.Flags().BoolVarP(&vpnServerEnable, "servevpn", "v", false, "enable vpn server")
+	genConfigCmd.Flags().BoolVarP(&isVpnServerEnable, "servevpn", "v", false, "enable vpn server")
 	ghiddenflags = append(ghiddenflags, "servevpn")
-	genConfigCmd.Flags().BoolVarP(&hide, "hide", "w", false, "dont print the config to the terminal")
+	genConfigCmd.Flags().BoolVarP(&isHide, "hide", "w", false, "dont print the config to the terminal")
 	ghiddenflags = append(ghiddenflags, "hide")
-	genConfigCmd.Flags().BoolVarP(&retainHypervisors, "retainhv", "x", false, "retain existing hypervisors with regen")
+	genConfigCmd.Flags().BoolVarP(&isRetainHypervisors, "retainhv", "x", false, "retain existing hypervisors with regen")
 	ghiddenflags = append(ghiddenflags, "retainhv")
-	genConfigCmd.Flags().BoolVarP(&publicautoconn, "autoconn", "y", false, "disable autoconnect to public visors")
+	genConfigCmd.Flags().BoolVarP(&isPublicAutoConn, "autoconn", "y", false, "disable autoconnect to public visors")
 	ghiddenflags = append(ghiddenflags, "hide")
-	genConfigCmd.Flags().BoolVarP(&ispublic, "ispublic", "z", false, "publicize visor in service discovery")
-	ghiddenflags = append(ghiddenflags, "ispublic")
+	genConfigCmd.Flags().BoolVarP(&isPublic, "public", "z", false, "publicize visor in service discovery")
+	ghiddenflags = append(ghiddenflags, "public")
 	genConfigCmd.Flags().StringVar(&ver, "version", "", "custom version testing override")
 	ghiddenflags = append(ghiddenflags, "version")
-	genConfigCmd.Flags().BoolVar(&all, "all", false, "show all flags")
+	genConfigCmd.Flags().BoolVar(&isAll, "all", false, "show all flags")
 	genConfigCmd.Flags().StringVar(&binPath, "binpath", "", "set bin_path")
 	ghiddenflags = append(ghiddenflags, "binpath")
 	for _, j := range ghiddenflags {
@@ -94,7 +94,7 @@ var genConfigCmd = &cobra.Command{
 	Short: "Generate a config file",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		//--all unhides flags, prints help menu, and exits
-		if all {
+		if isAll {
 			for _, j := range ghiddenflags {
 				f := cmd.Flags().Lookup(j) //nolint
 				f.Hidden = false
@@ -105,7 +105,7 @@ var genConfigCmd = &cobra.Command{
 		}
 		//set default output filename
 		if output == "" {
-			outunset = true
+			isOutUnset = true
 			confPath = skyenv.ConfigName
 			output = confPath
 		} else {
@@ -113,47 +113,47 @@ var genConfigCmd = &cobra.Command{
 		}
 
 		if output == visorconfig.StdoutName {
-			stdout = true
-			force = false
+			isStdout = true
+			isForce = false
 		}
-		if stdout {
-			regen = false
+		if isStdout {
+			isRegen = false
 		}
 		//hide defeats the purpose of stdout.
-		if (stdout) && (hide) {
-			logger.Info("Use of mutually exclusive flags: -w --hide and -n --stdout")
+		if (isStdout) && (isHide) {
+			logger.Warn("Use of mutually exclusive flags: -w --hide and -n --stdout")
 		}
 		//--force will delete a config, which excludes --regen
-		if (force) && (regen) {
+		if (isForce) && (isRegen) {
 			logger.Fatal("Use of mutually exclusive flags: -f --force cannot override -r --regen")
 		}
 		// these flags overwrite each other
-		if (usrEnv) && (pkgEnv) {
+		if (isUsrEnv) && (isPkgEnv) {
 			logger.Fatal("Use of mutually exclusive flags: -u --user and -p --pkg")
 		}
 		//enable local hypervisor by default for user
-		if usrEnv {
-			hypervisor = true
+		if isUsrEnv {
+			isHypervisor = true
 		}
 		var err error
-		if dmsgHTTP {
+		if isDmsgHTTP {
 			dmsgHTTPPath := skyenv.DMSGHTTPName
-			if pkgEnv {
+			if isPkgEnv {
 				dmsgHTTPPath = skyenv.SkywirePath + "/" + skyenv.DMSGHTTPName
 			}
 			if _, err := os.Stat(dmsgHTTPPath); err == nil {
-				if !stdout {
+				if !isStdout {
 					logger.Info("Found Dmsghttp config: ", dmsgHTTPPath)
 				}
 			} else {
 				logger.Fatal("Dmsghttp config not found at: ", dmsgHTTPPath)
 			}
 		}
-		if !stdout {
+		if !isStdout {
 			if confPath, err = filepath.Abs(confPath); err != nil {
 				logger.WithError(err).Fatal("Invalid output provided.")
 			}
-			if force {
+			if isForce {
 				if _, err := os.Stat(confPath); err == nil {
 					err := os.Remove(confPath)
 					if err != nil {
@@ -165,18 +165,18 @@ var genConfigCmd = &cobra.Command{
 			}
 		}
 		// skywire-cli config gen -p
-		if !stdout && outunset {
-			if pkgEnv && (selectedOS == "linux") {
+		if !isStdout && isOutUnset {
+			if isPkgEnv && (selectedOS == "linux") {
 				configName = skyenv.Configjson
 				confPath = skyenv.SkywirePath + "/" + configName
 				output = confPath
 			}
-			if usrEnv {
+			if isUsrEnv {
 				confPath = skyenv.HomePath() + "/" + skyenv.ConfigName
 				output = confPath
 			}
 		}
-		if !regen && !stdout {
+		if !isRegen && !isStdout {
 			//check if the config exists
 			if _, err := os.Stat(confPath); err == nil {
 				//error config exists !regen
@@ -184,14 +184,14 @@ var genConfigCmd = &cobra.Command{
 			}
 		}
 		//don't write file with stdout
-		if !stdout {
+		if !isStdout {
 			if skyenv.OS == "linux" {
 				userLvl, err := user.Current()
 				if err != nil {
 					logger.WithError(err).Error("Failed to detect user.")
 				} else {
 					if userLvl.Username == "root" {
-						root = true
+						isRoot = true
 					}
 				}
 				//warn when writing config as root to non root owned dir & fail on the reverse instance
@@ -208,10 +208,10 @@ var genConfigCmd = &cobra.Command{
 					if err != nil {
 						logger.Error("cannot stat: /root")
 					}
-					if (owner != rootOwner) && root {
+					if (owner != rootOwner) && isRoot {
 						logger.Warn("writing config as root to directory not owned by root")
 					}
-					if !root && (owner == rootOwner) {
+					if !isRoot && (owner == rootOwner) {
 						logger.Fatal("Insufficient permissions to write to the specified path")
 					}
 				}
@@ -223,21 +223,21 @@ var genConfigCmd = &cobra.Command{
 		mLog.SetLevel(logrus.InfoLevel)
 		serviceConfURL = svcconf
 		//use test deployment
-		if testEnv {
+		if isTestEnv {
 			serviceConfURL = testconf
 		}
 		//fetch the service endpoints
-		services = visorconfig.Fetch(mLog, serviceConfURL, stdout)
+		services = visorconfig.Fetch(mLog, serviceConfURL, isStdout)
 		// Read in old config and obtain old secret key or generate a new random secret key
 		// and obtain old hypervisors (if any)
 		var sk cipher.SecKey
 		if oldConf, err := visorconfig.ReadFile(confPath); err != nil {
-			if !stdout {
+			if !isStdout {
 				_, sk = cipher.GenerateKeyPair()
 			}
 		} else {
 			sk = oldConf.SK
-			if retainHypervisors {
+			if isRetainHypervisors {
 				for _, j := range oldConf.Hypervisors {
 					hypervisorPKs = hypervisorPKs + "," + fmt.Sprintf("\t%s\n", j)
 				}
@@ -245,22 +245,22 @@ var genConfigCmd = &cobra.Command{
 		}
 
 		//determine best protocol
-		if bestProtocol && netutil.LocalProtocol() {
-			dmsgHTTP = true
+		if isBestProtocol && netutil.LocalProtocol() {
+			isDmsgHTTP = true
 		}
 
 		//create the conf
-		conf, err := visorconfig.MakeDefaultConfig(mLog, &sk, usrEnv, pkgEnv, testEnv, dmsgHTTP, hypervisor, confPath, hypervisorPKs, services)
+		conf, err := visorconfig.MakeDefaultConfig(mLog, &sk, isUsrEnv, isPkgEnv, isTestEnv, isDmsgHTTP, isHypervisor, confPath, hypervisorPKs, services)
 		if err != nil {
 			logger.WithError(err).Fatal("Failed to create config.")
 		}
 		//edit the conf
 		// Change rpc address from local to public
-		if publicRPC {
+		if isPublicRPC {
 			conf.CLIAddr = ":3435"
 		}
 		// Set autostart enable vpn-server
-		if vpnServerEnable {
+		if isVpnServerEnable {
 			for i, app := range conf.Launcher.Apps {
 				if app.Name == "vpn-server" {
 					conf.Launcher.Apps[i].AutoStart = true
@@ -268,8 +268,8 @@ var genConfigCmd = &cobra.Command{
 			}
 		}
 		skywire := os.Args[0]
-		match := strings.Contains("/tmp/", skywire)
-		if (!stdout) || (!match) {
+		isMatch := strings.Contains("/tmp/", skywire)
+		if (!isStdout) || (!isMatch) {
 			//binaries have .exe extension on windows
 			var exe string
 			if skyenv.OS == "win" {
@@ -328,19 +328,19 @@ var genConfigCmd = &cobra.Command{
 			conf.Launcher.Apps = newConfLauncherApps
 		}
 		// Set EnableAuth true  hypervisor UI by --enable-auth flag
-		if hypervisor {
+		if isHypervisor {
 			// Make false EnableAuth hypervisor UI by --disable-auth flag
-			if disableauth {
+			if isDisableauth {
 				conf.Hypervisor.EnableAuth = false
 			}
 			// Set EnableAuth true  hypervisor UI by --enable-auth flag
-			if enableauth {
+			if isEnableauth {
 				conf.Hypervisor.EnableAuth = true
 			}
 		}
 		// Check OS and enable auth windows or macos
 		if (selectedOS == "win") || (selectedOS == "mac") {
-			if hypervisor {
+			if isHypervisor {
 				conf.Hypervisor.EnableAuth = true
 			}
 		}
@@ -358,15 +358,15 @@ var genConfigCmd = &cobra.Command{
 		if ver != "" {
 			conf.Common.Version = ver
 		}
-		if publicautoconn {
+		if isPublicAutoConn {
 			conf.Transport.PublicAutoconnect = false
 		}
-		if ispublic {
+		if isPublic {
 			conf.IsPublic = true
 		}
 
 		//don't write file with stdout
-		if !stdout {
+		if !isStdout {
 			// Save config to file.
 			if err := conf.Flush(); err != nil {
 				logger.WithError(err).Fatal("Failed to flush config to file.")
@@ -379,12 +379,12 @@ var genConfigCmd = &cobra.Command{
 		}
 		//omit logging messages with stdout
 		//print config to stdout, omit logging messages, exit
-		if stdout {
+		if isStdout {
 			fmt.Printf("%s", j)
 			os.Exit(0)
 		}
 		//hide the printing of the config to the terminal
-		if hide {
+		if isHide {
 			logger.Infof("Updated file '%s'\n", output)
 			os.Exit(0)
 		}

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -358,11 +358,11 @@ var genConfigCmd = &cobra.Command{
 		if ver != "" {
 			conf.Common.Version = ver
 		}
-		if conf.Transport.PublicAutoconnect == publicautoconn {
-			conf.Transport.PublicAutoconnect = !publicautoconn
+		if publicautoconn {
+			conf.Transport.PublicAutoconnect = false
 		}
-		if ispublic != conf.IsPublic {
-			conf.IsPublic = ispublic
+		if ispublic {
+			conf.IsPublic = true
 		}
 
 		//don't write file with stdout

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -75,6 +75,10 @@ func init() {
 	ghiddenflags = append(ghiddenflags, "hide")
 	genConfigCmd.Flags().BoolVarP(&retainHypervisors, "retainhv", "x", false, "retain existing hypervisors with regen")
 	ghiddenflags = append(ghiddenflags, "retainhv")
+	genConfigCmd.Flags().BoolVarP(&publicautoconn, "autoconn", "y", false, "disable autoconnect to public visors")
+	ghiddenflags = append(ghiddenflags, "hide")
+	genConfigCmd.Flags().BoolVarP(&ispublic, "ispublic", "z", false, "publicize visor in service discovery")
+	ghiddenflags = append(ghiddenflags, "ispublic")
 	genConfigCmd.Flags().StringVar(&ver, "version", "", "custom version testing override")
 	ghiddenflags = append(ghiddenflags, "version")
 	genConfigCmd.Flags().BoolVar(&all, "all", false, "show all flags")
@@ -117,7 +121,7 @@ var genConfigCmd = &cobra.Command{
 		}
 		//hide defeats the purpose of stdout.
 		if (stdout) && (hide) {
-			logger.Fatal("Use of mutually exclusive flags: -w --hide and -n --stdout")
+			logger.Info("Use of mutually exclusive flags: -w --hide and -n --stdout")
 		}
 		//--force will delete a config, which excludes --regen
 		if (force) && (regen) {
@@ -354,6 +358,13 @@ var genConfigCmd = &cobra.Command{
 		if ver != "" {
 			conf.Common.Version = ver
 		}
+		if conf.Transport.PublicAutoconnect == publicautoconn {
+			conf.Transport.PublicAutoconnect = !publicautoconn
+		}
+		if ispublic != conf.IsPublic {
+			conf.IsPublic = ispublic
+		}
+
 		//don't write file with stdout
 		if !stdout {
 			// Save config to file.

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -18,61 +18,61 @@ var (
 	output                 string
 	confPath               string
 	configName             string
-	stdout                 bool
-	regen                  bool
-	retainHypervisors      bool
-	testEnv                bool
+	isStdout               bool
+	isRegen                bool
+	isRetainHypervisors    bool
+	isTestEnv              bool
 	ptext                  string
-	pkgEnv                 bool
-	usrEnv                 bool
-	hypervisor             bool
+	isPkgEnv               bool
+	isUsrEnv               bool
+	isHypervisor           bool
 	hypervisorPKs          string
-	dmsgHTTP               bool
-	publicRPC              bool
-	vpnServerEnable        bool
-	disableauth            bool
-	enableauth             bool
+	isDmsgHTTP             bool
+	isPublicRPC            bool
+	isVpnServerEnable      bool
+	isDisableauth          bool
+	isEnableauth           bool
 	selectedOS             string
 	disableApps            string
-	bestProtocol           bool
+	isBestProtocol         bool
 	serviceConfURL         string
 	services               *visorconfig.Services
-	force                  bool
-	hide                   bool
-	all                    bool
-	outunset               bool
+	isForce                bool
+	isHide                 bool
+	isAll                  bool
+	isOutUnset             bool
 	ver                    string
-	root                   bool
+	isRoot                 bool
 	svcconf                = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")     //skyenv.DefaultServiceConfAddr
 	testconf               = strings.ReplaceAll(utilenv.TestServiceConfAddr, "http://", "") //skyenv.DefaultServiceConfAddr
 	ghiddenflags           []string
 	uhiddenflags           []string
 	binPath                string
 	logLevel               string
-	pkg                    bool
+	isPkg                  bool
 	input                  string
-	updateEndpoints        bool
+	isUpdateEndpoints      bool
 	addHypervisorPKs       string
-	resetHypervisor        bool
+	isResetHypervisor      bool
 	setVPNClientKillswitch string
 	addVPNClientSrv        string
 	addVPNClientPasscode   string
-	resetVPNclient         bool
+	isResetVPNclient       bool
 	addVPNServerPasscode   string
 	setVPNServerSecure     string
 	setVPNServerAutostart  string
 	setVPNServerNetIfc     string
-	resetVPNServer         bool
+	isResetVPNServer       bool
 	addSkysocksClientSrv   string
-	resetSkysocksClient    bool
+	isResetSkysocksClient  bool
 	skysocksPasscode       string
-	resetSkysocks          bool
+	isResetSkysocks        bool
 	setPublicAutoconnect   string
 	minHops                int
 	conf                   *visorconfig.V1
-	usr                    bool
-	ispublic               bool
-	publicautoconn         bool
+	isUsr                  bool
+	isPublic               bool
+	isPublicAutoConn       bool
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -71,6 +71,8 @@ var (
 	minHops                int
 	conf                   *visorconfig.V1
 	usr                    bool
+	ispublic               bool
+	publicautoconn         bool
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/cmd/skywire-cli/commands/config/update.go
+++ b/cmd/skywire-cli/commands/config/update.go
@@ -24,29 +24,29 @@ func init() {
 		panic(err)
 	}
 	if usrLvl.Username == "root" {
-		root = true
+		isRoot = true
 	}
 	RootCmd.AddCommand(updateCmd)
 
 	updateCmd.Flags().SortFlags = false
-	updateCmd.Flags().BoolVarP(&updateEndpoints, "endpoints", "a", false, "update server endpoints")
+	updateCmd.Flags().BoolVarP(&isUpdateEndpoints, "endpoints", "a", false, "update server endpoints")
 	updateCmd.Flags().StringVar(&logLevel, "log-level", "", "level of logging in config")
 	updateCmd.Flags().StringVarP(&serviceConfURL, "url", "b", "", "service config URL: "+svcconf)
-	updateCmd.Flags().BoolVarP(&testEnv, "testenv", "t", false, "use test deployment: "+testconf)
+	updateCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", false, "use test deployment: "+testconf)
 	updateCmd.Flags().StringVar(&setPublicAutoconnect, "public-autoconn", "", "change public autoconnect configuration")
 	updateCmd.Flags().IntVar(&minHops, "set-minhop", -1, "change min hops value")
 	updateCmd.PersistentFlags().StringVarP(&input, "input", "i", "", "path of input config file.")
 	uhiddenflags = append(uhiddenflags, "input")
 	updateCmd.PersistentFlags().StringVarP(&output, "output", "o", "", "config file to output")
-	if root {
+	if isRoot {
 		if _, err := os.Stat(skyenv.SkywirePath + "/" + skyenv.Configjson); err == nil {
-			updateCmd.PersistentFlags().BoolVarP(&pkg, "pkg", "p", false, "update package config "+skyenv.SkywirePath+"/"+skyenv.Configjson)
+			updateCmd.PersistentFlags().BoolVarP(&isPkg, "pkg", "p", false, "update package config "+skyenv.SkywirePath+"/"+skyenv.Configjson)
 			uhiddenflags = append(uhiddenflags, "pkg")
 		}
 	}
-	if !root {
+	if !isRoot {
 		if _, err := os.Stat(skyenv.HomePath() + "/" + skyenv.ConfigName); err == nil {
-			updateCmd.PersistentFlags().BoolVarP(&usr, "user", "u", false, "update config at: $HOME/"+skyenv.ConfigName)
+			updateCmd.PersistentFlags().BoolVarP(&isUsr, "user", "u", false, "update config at: $HOME/"+skyenv.ConfigName)
 		}
 	}
 
@@ -57,24 +57,24 @@ func init() {
 	updateCmd.AddCommand(hyperVisorUpdateCmd)
 	hyperVisorUpdateCmd.Flags().SortFlags = false
 	hyperVisorUpdateCmd.Flags().StringVarP(&addHypervisorPKs, "add-pks", "+", "", "public keys of hypervisors that should be added to this visor")
-	hyperVisorUpdateCmd.Flags().BoolVarP(&resetHypervisor, "reset", "r", false, "resets hypervisor configuration")
+	hyperVisorUpdateCmd.Flags().BoolVarP(&isResetHypervisor, "reset", "r", false, "resets hypervisor configuration")
 
 	updateCmd.AddCommand(skySocksClientUpdateCmd)
 	skySocksClientUpdateCmd.Flags().SortFlags = false
 	skySocksClientUpdateCmd.Flags().StringVarP(&addSkysocksClientSrv, "add-server", "+", "", "add skysocks server address to skysock-client")
-	skySocksClientUpdateCmd.Flags().BoolVarP(&resetSkysocksClient, "reset", "r", false, "reset skysocks-client configuration")
+	skySocksClientUpdateCmd.Flags().BoolVarP(&isResetSkysocksClient, "reset", "r", false, "reset skysocks-client configuration")
 
 	updateCmd.AddCommand(skySocksServerUpdateCmd)
 	skySocksServerUpdateCmd.Flags().SortFlags = false
 	skySocksServerUpdateCmd.Flags().StringVarP(&skysocksPasscode, "passwd", "s", "", "add passcode to skysocks server")
-	skySocksServerUpdateCmd.Flags().BoolVarP(&resetSkysocks, "reset", "r", false, "reset skysocks configuration")
+	skySocksServerUpdateCmd.Flags().BoolVarP(&isResetSkysocks, "reset", "r", false, "reset skysocks configuration")
 
 	updateCmd.AddCommand(vpnClientUpdateCmd)
 	vpnClientUpdateCmd.Flags().SortFlags = false
 	vpnClientUpdateCmd.Flags().StringVarP(&setVPNClientKillswitch, "killsw", "x", "", "change killswitch status of vpn-client")
 	vpnClientUpdateCmd.Flags().StringVar(&addVPNClientSrv, "add-server", "", "add server address to vpn-client")
 	vpnClientUpdateCmd.Flags().StringVarP(&addVPNClientPasscode, "pass", "s", "", "add passcode of server if needed")
-	vpnClientUpdateCmd.Flags().BoolVarP(&resetVPNclient, "reset", "r", false, "reset vpn-client configurations")
+	vpnClientUpdateCmd.Flags().BoolVarP(&isResetVPNclient, "reset", "r", false, "reset vpn-client configurations")
 
 	updateCmd.AddCommand(vpnServerUpdateCmd)
 	vpnServerUpdateCmd.Flags().SortFlags = false
@@ -82,15 +82,15 @@ func init() {
 	vpnServerUpdateCmd.Flags().StringVar(&setVPNServerSecure, "secure", "", "change secure mode status of vpn-server")
 	vpnServerUpdateCmd.Flags().StringVar(&setVPNServerAutostart, "autostart", "", "change autostart of vpn-server")
 	vpnServerUpdateCmd.Flags().StringVar(&setVPNServerNetIfc, "netifc", "", "set default network interface")
-	vpnServerUpdateCmd.Flags().BoolVarP(&resetVPNServer, "reset", "r", false, "reset vpn-server configurations")
+	vpnServerUpdateCmd.Flags().BoolVarP(&isResetVPNServer, "reset", "r", false, "reset vpn-server configurations")
 }
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a config file",
 	PreRun: func(_ *cobra.Command, _ []string) {
-		if updateEndpoints && (serviceConfURL == "") {
-			if !testEnv {
+		if isUpdateEndpoints && (serviceConfURL == "") {
+			if !isTestEnv {
 				serviceConfURL = svcconf
 			} else {
 				serviceConfURL = testconf
@@ -101,16 +101,16 @@ var updateCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, _ []string) {
 		if cmd.Flags().Changed("serviceConfURL") {
-			updateEndpoints = true
+			isUpdateEndpoints = true
 		}
 		conf = initUpdate()
-		if updateEndpoints {
-			if testEnv {
+		if isUpdateEndpoints {
+			if isTestEnv {
 				serviceConfURL = testconf
 			}
 			mLog := logging.NewMasterLogger()
 			mLog.SetLevel(logrus.InfoLevel)
-			services := visorconfig.Fetch(mLog, serviceConfURL, stdout)
+			services := visorconfig.Fetch(mLog, serviceConfURL, isStdout)
 			conf.Dmsg = &dmsgc.DmsgConfig{
 				Discovery: services.DmsgDiscovery, //utilenv.DefaultDmsgDiscAddr,
 			}
@@ -240,11 +240,11 @@ func setDefaults() {
 	if (input != "") && (output == "") {
 		output = input
 	}
-	if pkg {
+	if isPkg {
 		output = skyenv.SkywirePath + "/" + skyenv.Configjson
 		input = skyenv.SkywirePath + "/" + skyenv.Configjson
 	}
-	if usr {
+	if isUsr {
 		output = skyenv.HomePath() + "/" + skyenv.ConfigName
 		input = skyenv.HomePath() + "/" + skyenv.ConfigName
 	}
@@ -270,7 +270,7 @@ var hyperVisorUpdateCmd = &cobra.Command{
 				conf.Hypervisors = append(conf.Hypervisors, cipher.PubKey(keyParsed))
 			}
 		}
-		if resetHypervisor {
+		if isResetHypervisor {
 			conf.Hypervisors = []cipher.PubKey{}
 		}
 		saveConfig(conf)
@@ -293,7 +293,7 @@ var skySocksClientUpdateCmd = &cobra.Command{
 			}
 			changeAppsConfig(conf, "skysocks-client", "--srv", keyParsed.Hex())
 		}
-		if resetSkysocksClient {
+		if isResetSkysocksClient {
 			resetAppsConfig(conf, "skysocks-client")
 		}
 		saveConfig(conf)
@@ -313,7 +313,7 @@ var skySocksServerUpdateCmd = &cobra.Command{
 		if skysocksPasscode != "" {
 			changeAppsConfig(conf, "skysocks", "--passcode", skysocksPasscode)
 		}
-		if resetSkysocks {
+		if isResetSkysocks {
 			resetAppsConfig(conf, "skysocks")
 		}
 		saveConfig(conf)
@@ -350,7 +350,7 @@ var vpnClientUpdateCmd = &cobra.Command{
 		if addVPNClientPasscode != "" {
 			changeAppsConfig(conf, "vpn-client", "--passcode", addVPNClientPasscode)
 		}
-		if resetVPNclient {
+		if isResetVPNclient {
 			resetAppsConfig(conf, "vpn-client")
 		}
 		saveConfig(conf)
@@ -400,7 +400,7 @@ var vpnServerUpdateCmd = &cobra.Command{
 		default:
 			logger.Fatal("Unrecognized vpn server autostart value: ", setVPNServerSecure)
 		}
-		if resetVPNServer {
+		if isResetVPNServer {
 			resetAppsConfig(conf, "vpn-server")
 		}
 		saveConfig(conf)

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,6 @@ github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=
 github.com/skycoin/skycoin v0.27.1/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=
 github.com/skycoin/skywire-utilities v0.0.0-20220617085111-5c8c8d3ced14/go.mod h1:B63p56igl38Ha+zjqi26d2om6XEe9jozwB6kzAWMnm0=
-github.com/skycoin/skywire-utilities v0.0.0-20220706133229-02cc62ac2323 h1:W+LSTySKEg3/UyVZXziQYyIdIo66g28VuKBk7sl0718=
-github.com/skycoin/skywire-utilities v0.0.0-20220706133229-02cc62ac2323/go.mod h1:B63p56igl38Ha+zjqi26d2om6XEe9jozwB6kzAWMnm0=
 github.com/skycoin/skywire-utilities v0.0.0-20220712142443-abafa30105ce h1:+AkZeazhMXpzdPhAG2tn71ubVSPwUECMXYK/LIIVQSU=
 github.com/skycoin/skywire-utilities v0.0.0-20220712142443-abafa30105ce/go.mod h1:B63p56igl38Ha+zjqi26d2om6XEe9jozwB6kzAWMnm0=
 github.com/skycoin/systray v1.10.1-0.20220630135132-48d2a1fb85d8 h1:2IA2Iw6rgNpbd/rogzBbmNpfGLPhf9zYE68RY8CmU4k=

--- a/pkg/skyenv/values.go
+++ b/pkg/skyenv/values.go
@@ -35,7 +35,8 @@ const (
 
 // Transport port constants.
 const (
-	TransportPort uint16 = 45 // Listening port of a visor for incoming transports.
+	TransportPort     uint16 = 45 // Listening port of a visor for incoming transports.
+	PublicAutoconnect        = true
 )
 
 // Dmsgpty constants.
@@ -114,6 +115,11 @@ const (
 const (
 	// IPCShutdownMessageType sends IPC shutdown message type
 	IPCShutdownMessageType = 68
+)
+
+const (
+	//IsPublic advertises the visor in the service discovery
+	IsPublic = false
 )
 
 // PkgConfig struct contains paths specific to the linux packages

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -46,7 +46,7 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 	conf.Transport = &Transport{
 		Discovery:         services.TransportDiscovery, //utilenv.TpDiscAddr,
 		AddressResolver:   services.AddressResolver,    //utilenv.AddressResolverAddr,
-		PublicAutoconnect: true,
+		PublicAutoconnect: skyenv.PublicAutoconnect,
 	}
 	conf.Routing = &Routing{
 		RouteFinder:        services.RouteFinder, //utilenv.RouteFinderAddr,
@@ -101,7 +101,7 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 			}
 		}
 	}
-
+	conf.IsPublic = skyenv.IsPublic
 	return conf
 }
 


### PR DESCRIPTION
To save users from needing to edit the .json by hand, and to integrate with package / installer configuration scripts; here are `skywire-cli config gen` flags to set the public_autoconnect and is_public fields in the skywire config

Did you run `make format && make check`?
yes

 Changes:	
-	add `skywire cli config gen -y --autoconn`
-	add `skywire cli config gen -z --ispublic`

test:
```
go run cmd/skywire-cli/skywire-cli.go config gen --all
go run cmd/skywire-cli/skywire-cli.go config gen -yn
go run cmd/skywire-cli/skywire-cli.go config gen -zn
```