### PR TITLE
Save data in the UI per Hypervisor PK

### DIFF
--- a/static/skywire-manager-src/src/app/app.component.html
+++ b/static/skywire-manager-src/src/app/app.component.html
@@ -7,5 +7,6 @@
 </div>
 <div class="flex-1 content container-fluid">
   <div [ngClass]="{'background': inVpnClient}"></div>
-  <router-outlet></router-outlet>
+  <router-outlet *ngIf="hypervisorPkObtained"></router-outlet>
+  <app-loading-indicator class="h-100" *ngIf="!hypervisorPkObtained"></app-loading-indicator>
 </div>

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -167,7 +167,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
       sortableColumns.push(this.pingSortData);
     }
     this.dataSorter = new DataSorter(
-      this.dialog, this.translateService, sortableColumns, 3, this.showDmsgInfo ? this.dmsgListId : this.nodesListId
+      this.dialog, this.translateService, this.storageService, sortableColumns, 3, this.showDmsgInfo ? this.dmsgListId : this.nodesListId
     );
     this.dataSortedSubscription = this.dataSorter.dataSorted.subscribe(() => {
       // When this happens, the data in allNodes has already been sorted.

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/node-apps-list.component.ts
@@ -3,6 +3,8 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Observable, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
+import { map } from 'rxjs/operators';
+import { StorageService } from 'src/app/services/storage.service';
 
 import { Application } from '../../../../../app.datatypes';
 import { AppsService } from '../../../../../services/apps.service';
@@ -20,7 +22,6 @@ import { SkysocksClientSettingsComponent } from '../node-apps/skysocks-client-se
 import { FilterProperties, FilterFieldTypes } from 'src/app/utils/filters';
 import { SortingColumn, SortingModes, DataSorter } from 'src/app/utils/lists/data-sorter';
 import { DataFilterer } from 'src/app/utils/lists/data-filterer';
-import { map } from 'rxjs/operators';
 
 /**
  * Shows the list of applications of a node. I can be used to show a short preview, with just some
@@ -158,6 +159,7 @@ export class NodeAppsListComponent implements OnDestroy {
     private router: Router,
     private snackbarService: SnackbarService,
     private translateService: TranslateService,
+    private storageService: StorageService,
   ) {
     // Initialize the data sorter.
     const sortableColumns: SortingColumn[] = [
@@ -166,7 +168,7 @@ export class NodeAppsListComponent implements OnDestroy {
       this.portSortData,
       this.autoStartSortData,
     ];
-    this.dataSorter = new DataSorter(this.dialog, this.translateService, sortableColumns, 1, this.listId);
+    this.dataSorter = new DataSorter(this.dialog, this.translateService, this.storageService, sortableColumns, 1, this.listId);
     this.dataSortedSubscription = this.dataSorter.dataSorted.subscribe(() => {
       // When this happens, the data in allApps has already been sorted.
       this.recalculateElementsToShow();

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/route-list/route-list.component.ts
@@ -169,7 +169,7 @@ export class RouteListComponent implements OnDestroy {
       this.sourceSortData,
       this.destinationSortData,
     ];
-    this.dataSorter = new DataSorter(this.dialog, this.translateService, sortableColumns, 0, this.listId);
+    this.dataSorter = new DataSorter(this.dialog, this.translateService, this.storageService, sortableColumns, 0, this.listId);
     this.dataSortedSubscription = this.dataSorter.dataSorted.subscribe(() => {
       // When this happens, the data in allRoutes has already been sorted.
       this.recalculateElementsToShow();

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/transport-list.component.ts
@@ -183,7 +183,7 @@ export class TransportListComponent implements OnDestroy {
       this.uploadedSortData,
       this.downloadedSortData,
     ];
-    this.dataSorter = new DataSorter(this.dialog, this.translateService, sortableColumns, 1, this.listId);
+    this.dataSorter = new DataSorter(this.dialog, this.translateService, this.storageService, sortableColumns, 1, this.listId);
     this.dataSortedSubscription = this.dataSorter.dataSorted.subscribe(() => {
       // When this happens, the data in allTransports has already been sorted.
       this.recalculateElementsToShow();

--- a/static/skywire-manager-src/src/app/components/pages/settings/all-labels/label-list/label-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/all-labels/label-list/label-list.component.ts
@@ -118,7 +118,7 @@ export class LabelListComponent implements OnDestroy {
       this.idSortData,
       this.typeSortData,
     ];
-    this.dataSorter = new DataSorter(this.dialog, this.translateService, sortableColumns, 0, this.listId);
+    this.dataSorter = new DataSorter(this.dialog, this.translateService, this.storageService, sortableColumns, 0, this.listId);
     this.dataSortedSubscription = this.dataSorter.dataSorted.subscribe(() => {
       // When this happens, the data in allLabels has already been sorted.
       this.recalculateElementsToShow();

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/vpn-server-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-server-list/vpn-server-list.component.ts
@@ -16,6 +16,7 @@ import { AddVpnServerComponent } from './add-vpn-server/add-vpn-server.component
 import { VpnSavedDataService, LocalServerData, ServerFlags } from 'src/app/services/vpn-saved-data.service';
 import GeneralUtils from 'src/app/utils/generalUtils';
 import { EnterVpnServerPasswordComponent } from './enter-vpn-server-password/enter-vpn-server-password.component';
+import { StorageService } from 'src/app/services/storage.service';
 
 /**
  * Server lists VpnServerListComponent can show.
@@ -226,6 +227,7 @@ export class VpnServerListComponent implements OnDestroy {
     private vpnClientService: VpnClientService,
     private vpnSavedDataService: VpnSavedDataService,
     private snackbarService: SnackbarService,
+    private storageService: StorageService,
   ) {
     this.navigationsSubscription = route.paramMap.subscribe(params => {
       // Get which list must be shown.
@@ -597,7 +599,7 @@ export class VpnServerListComponent implements OnDestroy {
       defaultColumn = this.currentList === Lists.History ? 0 : 1;
       tieBreakerColumn = this.currentList === Lists.History ? 2 : 3;
     }
-    this.dataSorter = new DataSorter(this.dialog, this.translateService, sortableColumns, defaultColumn, this.listId);
+    this.dataSorter = new DataSorter(this.dialog, this.translateService, this.storageService, sortableColumns, defaultColumn, this.listId);
     this.dataSorter.setTieBreakerColumnIndex(tieBreakerColumn);
     this.dataSortedSubscription = this.dataSorter.dataSorted.subscribe(() => {
       // When this happens, the data in allServers has already been sorted.

--- a/static/skywire-manager-src/src/app/utils/lists/data-sorter.ts
+++ b/static/skywire-manager-src/src/app/utils/lists/data-sorter.ts
@@ -3,6 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subject, Observable } from 'rxjs';
 
 import { SelectableOption, SelectOptionComponent } from 'src/app/components/layout/select-option/select-option.component';
+import { StorageService } from 'src/app/services/storage.service';
 
 /**
  * Data about a column that can be used to sort the data of a list.
@@ -147,6 +148,7 @@ export class DataSorter {
   constructor(
     private dialog: MatDialog,
     private translateService: TranslateService,
+    private storageService: StorageService,
     columns: SortingColumn[],
     defaultColumnIndex: number,
     id: string,
@@ -157,7 +159,7 @@ export class DataSorter {
     this.sortBy = columns[defaultColumnIndex];
 
     // Restore any previously saved configuration.
-    const savedColumn = localStorage.getItem(this.columnStorageKeyPrefix + id);
+    const savedColumn = this.storageService.getDataForHv(this.columnStorageKeyPrefix + id);
     if (savedColumn) {
       const savedColumnData = columns.find(column => column.id === savedColumn);
       if (savedColumnData) {
@@ -165,8 +167,8 @@ export class DataSorter {
       }
     }
 
-    this.sortReverse = localStorage.getItem(this.orderStorageKeyPrefix + id) === 'true';
-    this.sortByLabel = localStorage.getItem(this.labelStorageKeyPrefix + id) === 'true';
+    this.sortReverse = this.storageService.getDataForHv(this.orderStorageKeyPrefix + id) === 'true';
+    this.sortByLabel = this.storageService.getDataForHv(this.labelStorageKeyPrefix + id) === 'true';
   }
 
   /**
@@ -227,7 +229,7 @@ export class DataSorter {
     } else {
       // If the same column was selected, change the order.
       this.sortReverse = !this.sortReverse;
-      localStorage.setItem(this.orderStorageKeyPrefix + this.id, String(this.sortReverse));
+      this.storageService.setDataForHv(this.orderStorageKeyPrefix + this.id, String(this.sortReverse));
 
       this.sortData();
     }
@@ -241,9 +243,9 @@ export class DataSorter {
     this.sortByLabel = sortByLabel;
     this.sortReverse = sortReverse;
 
-    localStorage.setItem(this.columnStorageKeyPrefix + this.id, column.id);
-    localStorage.setItem(this.orderStorageKeyPrefix + this.id, String(this.sortReverse));
-    localStorage.setItem(this.labelStorageKeyPrefix + this.id, String(this.sortByLabel));
+    this.storageService.setDataForHv(this.columnStorageKeyPrefix + this.id, column.id);
+    this.storageService.setDataForHv(this.orderStorageKeyPrefix + this.id, String(this.sortReverse));
+    this.storageService.setDataForHv(this.labelStorageKeyPrefix + this.id, String(this.sortByLabel));
 
     this.sortData();
   }

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -79,7 +79,8 @@
   },
 
   "start": {
-    "title": "Start"
+    "title": "Start",
+    "loading-error": "An error occurred while getting the initial data. Retrying..."
   },
 
   "node": {

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -79,7 +79,8 @@
   },
 
   "start": {
-    "title": "Inicio"
+    "title": "Inicio",
+    "loading-error": "Hubo un error obteniendo los datos iniciales. Reintentando..."
   },
 
   "node": {

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -79,7 +79,8 @@
   },
 
   "start": {
-    "title": "Start"
+    "title": "Start",
+    "loading-error": "An error occurred while getting the initial data. Retrying..."
   },
 
   "node": {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- As requested some time ago, now the UI saves the data associated with the hypervisor PK. This means that the data saved by the user while connected to a hypervisor will not appear when connection to another hypervisor.

This prevents problems when testing with different hypervisor PKs in the same machine and any situation in which the hypervisor PK is changed but the URL stays the same.

How to test this PR:
Open the Skywire manager and VPN UI in the browser and make some changes (like adding labels to a transport or selecting a VPN server). After that, change the hypervisor PK but not the URL (you can create a new config file for the hypervisor just for the test).

Using the previous version, the UI shows for the second hypervisor the same data saved for the first hypervisor (same custom labels and same selected VPN server), as the data is saved only associated with the URL used for accessing the UI. With the changes on this PR, the data saved for the first hypervisor will not be available for the second one, as the data is saved assiciated with the URL and also with the PK of the hypervisor. If you return to the first hypervisor PK, its data is available again.

NOTE: the first time you open the UI with the changes on this PR, all old data is migrated to the new format and associated with the PK of the hypervisor you are using at that time.