### PR TITLE
service discovery query filtering

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
     appveyor_build_worker_image: macos-bigsur
     GOARCH: amd64
   - job_name: Windows
-    appveyor_build_worker_image: Visual Studio 2019
+    appveyor_build_worker_image: Previous Visual Studio 2019
     GOARCH: amd64
 
   # For release, by pushing tag
@@ -23,7 +23,7 @@ environment:
     appveyor_build_worker_image: macos-bigsur
     GOARCH: amd64
   - job_name: make-release-windows
-    appveyor_build_worker_image: Visual Studio 2019
+    appveyor_build_worker_image: Previous Visual Studio 2019
     GOARCH: amd64
 
   - job_name: DockerDeployMaster

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -142,7 +142,7 @@ var vpnStartCmd = &cobra.Command{
 	Short: "start the vpn for <public-key>",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(_ *cobra.Command, args []string) {
-		fmt.Println("%s", args[0])
+		fmt.Println(args[0])
 		internal.Catch(clirpc.Client().StartVPNClient(args[0]))
 		fmt.Println("OK")
 	},

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -105,7 +105,7 @@ var vpnListCmd = &cobra.Command{
 		}
 		servers, err := client.VPNServers(ver, country)
 		if err != nil {
-			logger.Fatal("Failed to connect; is skywire running?\n", err)
+			logger.Fatal(err)
 		}
 		if len(servers) == 0 {
 			fmt.Printf("No VPN Servers found\n")

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -15,7 +15,6 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
-	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -104,35 +103,10 @@ var vpnListCmd = &cobra.Command{
 			ver = ""
 			country = ""
 		}
-		//		servers, err := client.VPNServers(ver, country)		//query filtering
-		servers, err := client.VPNServers()
+		servers, err := client.VPNServers(ver, country)
 		if err != nil {
 			logger.Fatal("Failed to connect; is skywire running?\n", err)
 		}
-
-		/*vv remove when query filtering is implemented vv*/
-		var a []servicedisc.Service
-		for _, i := range servers {
-			if (ver == "") || (ver == "unknown") || (strings.Replace(i.Version, "v", "", 1) == ver) {
-				a = append(a, i)
-			}
-		}
-		if len(a) > 0 {
-			servers = a
-			a = []servicedisc.Service{}
-		}
-		if country != "" {
-			for _, i := range servers {
-				if i.Geo != nil {
-					if i.Geo.Country == country {
-						a = append(a, i)
-					}
-				}
-			}
-			servers = a
-		}
-		/*^^ remove when query filtering is implemented ^^*/
-
 		if len(servers) == 0 {
 			fmt.Printf("No VPN Servers found\n")
 			os.Exit(0)

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -303,7 +303,7 @@ func getAvailPublicVPNServers(conf *visorconfig.V1, httpC *http.Client, logger *
 		DiscAddr: conf.Launcher.ServiceDisc,
 	}
 	sdClient := servicedisc.NewClient(log, log, svrConfig, httpC, "")
-	vpnServers, err := sdClient.Services(context.Background(), 0)
+	vpnServers, err := sdClient.Services(context.Background(), 0, "", "")
 	if err != nil {
 		logger.Error("Error getting vpn servers: ", err)
 		return nil

--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -113,8 +113,7 @@ func (a *autoconnector) fetchPubAddresses(ctx context.Context) ([]cipher.PubKey,
 	var services []Service
 	fetch := func() (err error) {
 		// "return" services up from the closure
-		//services, err = a.client.Services(ctx, a.maxConns, "", "")		//query filtering
-		services, err = a.client.Services(ctx, a.maxConns)
+		services, err = a.client.Services(ctx, a.maxConns, "", "")
 		if err != nil {
 			return err
 		}

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -26,12 +26,11 @@ import (
 var ErrVisorUnreachable = errors.New("visor is unreachable")
 
 const (
-	updateRetryDelay     = 5 * time.Second
-	discServiceTypeParam = "type"
-	discServiceQtyParam  = "quantity"
-
-//	discServiceCountryParam = "country"		//query filtering
-//	discServiceVersionParam = "version"		//query filtering
+	updateRetryDelay        = 5 * time.Second
+	discServiceTypeParam    = "type"
+	discServiceQtyParam     = "quantity"
+	discServiceCountryParam = "country"
+	discServiceVersionParam = "version"
 )
 
 // Config configures the HTTPClient.
@@ -70,8 +69,7 @@ func NewClient(log logrus.FieldLogger, mLog *logging.MasterLogger, conf Config, 
 	}
 }
 
-func (c *HTTPClient) addr(path, serviceType string, quantity int) (string, error) {
-	//func (c *HTTPClient) addr(path, serviceType, version, country string, quantity int) (string, error) {		//query filtering
+func (c *HTTPClient) addr(path, serviceType, version, country string, quantity int) (string, error) {
 	addr := c.conf.DiscAddr
 	url, err := url.Parse(addr)
 	if err != nil {
@@ -85,15 +83,12 @@ func (c *HTTPClient) addr(path, serviceType string, quantity int) (string, error
 	if quantity > 1 {
 		q.Set(discServiceQtyParam, strconv.Itoa(quantity))
 	}
-	//query filtering
-	/*
-		if version != "" {
-			q.Set(discServiceVersionParam, version)
-		}
-		if country != "" {
-			q.Set(discServiceCountryParam, country)
-		}
-	*/
+	if version != "" {
+		q.Set(discServiceVersionParam, version)
+	}
+	if country != "" {
+		q.Set(discServiceCountryParam, country)
+	}
 	url.RawQuery = q.Encode()
 	return url.String(), nil
 }
@@ -124,10 +119,8 @@ func (c *HTTPClient) Auth(ctx context.Context) (*httpauth.Client, error) {
 }
 
 // Services calls 'GET /api/services'.
-func (c *HTTPClient) Services(ctx context.Context, quantity int) (out []Service, err error) {
-	//func (c *HTTPClient) Services(ctx context.Context, quantity int, version, country string) (out []Service, err error) {		//query filtering
-	//url, err := c.addr("/api/services", c.entry.Type, version, country, quantity)
-	url, err := c.addr("/api/services", c.entry.Type, quantity)
+func (c *HTTPClient) Services(ctx context.Context, quantity int, version, country string) (out []Service, err error) {
+	url, err := c.addr("/api/services", c.entry.Type, version, country, quantity)
 	if err != nil {
 		return nil, err
 	}
@@ -202,8 +195,7 @@ func (c *HTTPClient) postEntry(ctx context.Context) (Service, error) {
 		return Service{}, err
 	}
 
-	//	url, err := c.addr("/api/services", "", "", "", 1)		//query filtering
-	url, err := c.addr("/api/services", "", 1)
+	url, err := c.addr("/api/services", "", "", "", 1)
 	if err != nil {
 		return Service{}, nil
 	}
@@ -260,8 +252,7 @@ func (c *HTTPClient) DeleteEntry(ctx context.Context) (err error) {
 		return err
 	}
 
-	//	url, err := c.addr("/api/services/"+c.entry.Addr.String(), c.entry.Type, "", "", 1)		//query filtering
-	url, err := c.addr("/api/services/"+c.entry.Addr.String(), c.entry.Type, 1)
+	url, err := c.addr("/api/services/"+c.entry.Addr.String(), c.entry.Type, "", "", 1)
 	if err != nil {
 		return err
 	}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -55,8 +55,7 @@ type API interface {
 	GetAppStats(appName string) (appserver.AppStats, error)
 	GetAppError(appName string) (string, error)
 	GetAppConnectionsSummary(appName string) ([]appserver.ConnectionSummary, error)
-	//	VPNServers(version, country string) ([]servicedisc.Service, error)	//query filtering
-	VPNServers() ([]servicedisc.Service, error)
+	VPNServers(version, country string) ([]servicedisc.Service, error)
 	RemoteVisors() ([]string, error)
 
 	TransportTypes() ([]string, error)
@@ -624,8 +623,7 @@ func (v *Visor) GetAppConnectionsSummary(appName string) ([]appserver.Connection
 }
 
 // VPNServers gets available public VPN server from service discovery URL
-func (v *Visor) VPNServers() ([]servicedisc.Service, error) {
-	//func (v *Visor) VPNServers(version, country string) ([]servicedisc.Service, error) {	//query filtering
+func (v *Visor) VPNServers(version, country string) ([]servicedisc.Service, error) {
 	log := logging.MustGetLogger("vpnservers")
 	vlog := logging.NewMasterLogger()
 	vlog.SetLevel(logrus.InfoLevel)
@@ -636,8 +634,7 @@ func (v *Visor) VPNServers() ([]servicedisc.Service, error) {
 		SK:       v.conf.SK,
 		DiscAddr: v.conf.Launcher.ServiceDisc,
 	}, &http.Client{Timeout: time.Duration(1) * time.Second}, "")
-	//	vpnServers, err := sdClient.Services(context.Background(), 0, version, country)	//query filtering
-	vpnServers, err := sdClient.Services(context.Background(), 0)
+	vpnServers, err := sdClient.Services(context.Background(), 0, version, country)
 	if err != nil {
 		v.log.Error("Error getting public vpn servers: ", err)
 		return nil, err

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -556,20 +556,16 @@ func (r *RPC) SetPublicAutoconnect(pAc *bool, _ *struct{}) (err error) {
 	return err
 }
 
-/* //query filtering
 // FilterVPNServersIn is input for VPNServers
 type FilterVPNServersIn struct {
 	Version string
 	Country string
 }
-*/
 
 // VPNServers gets available public VPN server from service discovery URL
-func (r *RPC) VPNServers(_ *struct{}, out *[]servicedisc.Service) (err error) {
-	//func (r *RPC) VPNServers(vc *FilterVPNServersIn, _ *struct{}, out *[]servicedisc.Service) (err error) {		//query filtering
+func (r *RPC) VPNServers(vc *FilterVPNServersIn, _ *struct{}, out *[]servicedisc.Service) (err error) {
 	defer rpcutil.LogCall(r.log, "VPNServers", nil)(out, &err)
-	//	vpnServers, err := r.visor.VPNServers(vc.Version, vc.Country)		//query filtering
-	vpnServers, err := r.visor.VPNServers()
+	vpnServers, err := r.visor.VPNServers(vc.Version, vc.Country)
 	if vpnServers != nil {
 		*out = vpnServers
 	}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -563,7 +563,7 @@ type FilterVPNServersIn struct {
 }
 
 // VPNServers gets available public VPN server from service discovery URL
-func (r *RPC) VPNServers(vc *FilterVPNServersIn, _ *struct{}, out *[]servicedisc.Service) (err error) {
+func (r *RPC) VPNServers(vc *FilterVPNServersIn, out *[]servicedisc.Service) (err error) {
 	defer rpcutil.LogCall(r.log, "VPNServers", nil)(out, &err)
 	vpnServers, err := r.visor.VPNServers(vc.Version, vc.Country)
 	if vpnServers != nil {

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -411,11 +411,11 @@ type StatusMessage struct {
 // VPNServers calls VPNServers.
 func (rc *rpcClient) VPNServers(version, country string) ([]servicedisc.Service, error) {
 	output := []servicedisc.Service{}
-	rc.Call("VPNServers", &FilterVPNServersIn{ // nolint
+	err := rc.Call("VPNServers", &FilterVPNServersIn{ // nolint
 		Version: version,
 		Country: country,
 	}, &output)
-	return output, nil
+	return output, err
 }
 
 // RemoteVisors calls RemoteVisors.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -409,16 +409,12 @@ type StatusMessage struct {
 }
 
 // VPNServers calls VPNServers.
-func (rc *rpcClient) VPNServers() ([]servicedisc.Service, error) {
-	//func (rc *rpcClient) VPNServers(version, country string) ([]servicedisc.Service, error) {		//query filtering
+func (rc *rpcClient) VPNServers(version, country string) ([]servicedisc.Service, error) {
 	output := []servicedisc.Service{}
-	/* //query filtering
-	rc.Call("VPNServers", &FilterVPNServersIn{
+	rc.Call("VPNServers", &FilterVPNServersIn{ // nolint
 		Version: version,
 		Country: country,
-	}, &output) // nolint
-	*/
-	rc.Call("VPNServers", &struct{}{}, &output) // nolint
+	}, &output)
 	return output, nil
 }
 
@@ -982,8 +978,7 @@ func (mc *mockRPCClient) GetPersistentTransports() ([]transport.PersistentTransp
 }
 
 // VPNServers implements API
-func (mc *mockRPCClient) VPNServers() ([]servicedisc.Service, error) {
-	//func (mc *mockRPCClient) VPNServers(_, _ string) ([]servicedisc.Service, error) {		//query filtering
+func (mc *mockRPCClient) VPNServers(_, _ string) ([]servicedisc.Service, error) {
 	return []servicedisc.Service{}, nil
 }
 


### PR DESCRIPTION
 Changes:	
-	apply version and country filter for service discovery queries - `skywire-cli vpn list`

How to test this PR:

First, run a visor
_Note that query filtering is only currently implemented on the test deployment_
```
git checkout feature/query-filtering
make run-source-test
```

query the service discovery for available vpn servers
```
skywire-cli vpn list
skywire-cli vpn list -v 1.0.1
skywire-cli vpn list -c DE
skywire-cli vpn list -n
```