### PR TITLE
fix autopeering

### DIFF
--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -290,10 +290,11 @@ func runVisor(conf *visorconfig.V1) {
 		}
 	}
 	//autopeering should only happen when there is no local or remote hypervisor set in the config.
+	if conf.Hypervisor != nil {
+		isAutoPeer = false
+	}
 	if conf.Hypervisors != nil {
-		if conf.Hypervisor != nil {
-			isAutoPeer = false
-		}
+		isAutoPeer = false
 	}
 	if isAutoPeer {
 		hvkey, err := visor.FetchHvPk(autoPeerIP)

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -290,10 +290,7 @@ func runVisor(conf *visorconfig.V1) {
 		}
 	}
 	//autopeering should only happen when there is no local or remote hypervisor set in the config.
-	if conf.Hypervisor != nil {
-		isAutoPeer = false
-	}
-	if conf.Hypervisors != nil {
+	if conf.Hypervisor != nil || conf.Hypervisors != nil {
 		isAutoPeer = false
 	}
 	if isAutoPeer {


### PR DESCRIPTION
Did you run `make format && make check`?
yes

 Changes:	
- fix logic for the conditions required for autopeering / auto disable in the instance remote or loccal hypervisors exist

How to test this PR:
```
SKYBIAN=true skywire-visor -m
```