### PR TITLE
enable autopeering via environmental variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - store UI settings per hypervisor key [#1329](https://github.com/skycoin/skywire/pull/1329)
 
 ### Changed
-
+- Autopeer on env `AUTOPEER=1`
 - improve UI reaction while system is busy
 - hide password options in UI if authentication is disabled
 - fix freezing hypervisor UI on hypervisor disconnection [#1321](https://github.com/skycoin/skywire/issues/1321)

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -105,7 +105,11 @@ func init() {
 	if os.Getenv("SKYBIAN") == "true" {
 		rootCmd.Flags().StringVarP(&autoPeerIP, "hvip", "l", trimStringFromDot(localIPs[0].String())+".2:7998", "set hypervisor by ip")
 		hiddenflags = append(hiddenflags, "hvip")
-		rootCmd.Flags().BoolVarP(&isAutoPeer, "autopeer", "m", false, "enable autopeering")
+		isDefaultAutopeer := false
+		if os.Getenv("AUTOPEER") == "1" {
+			isDefaultAutopeer = true
+		}
+		rootCmd.Flags().BoolVarP(&isAutoPeer, "autopeer", "m", isDefaultAutopeer, "enable autopeering")
 		hiddenflags = append(hiddenflags, "autopeer")
 	}
 	rootCmd.Flags().BoolVarP(&stdin, "stdin", "n", false, "read config from stdin")


### PR DESCRIPTION
The reasoning behind this PR is that I was unable to successfully modify the systemd service for skywire via a drop-in override configuration file to change `ExecStart` to include the `-m` flag for enabling the autopeering ; nor was I able to render an env in ExecStart to provide the -m flag. The variable could only render the flag in quotes, at best, which does not work with cobra.

My solution to this is to set the env either in the systemd drop-in ; and have the visor detect this env directly rather than requiring it's flag.

The default value of the `-m` flag for skywire-visor is changed to true if the `AUTOPEER` env equals the string "1"

Did you run `make format && make check`?
yes

 Changes:	
-	activate autopeering on `AUTOPEER=1` if `SKYBIAN=true`

How to test this PR:
```
AUTOPEER=1 SKYBIAN=true skywire-visor --all
```