### PR TITLE
Feat/cli json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.2.0
+### Added
+- `skywire-cli` global flag `--json` [#1346](https://github.com/skycoin/skywire/pull/1346)
+
+### Changed
+- `skywire-cli visor route add-rule` subcommands [#1346](https://github.com/skycoin/skywire/pull/1346)
+
+### Removed
+- `skywire-cli visor tp add` flag `--public` [#1346](https://github.com/skycoin/skywire/pull/1346)
+
 ## 1.1.0
 
 ### Added

--- a/cmd/skywire-cli/commands/dmsgpty/hvdmsg.go
+++ b/cmd/skywire-cli/commands/dmsgpty/hvdmsg.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/toqueteos/webbrowser"
 
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -57,7 +58,7 @@ var dmsgUICmd = &cobra.Command{
 var dmsgURLCmd = &cobra.Command{
 	Use:   "url",
 	Short: "Show dmsgpty UI URL",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		if pk == "" {
 			if pkg {
 				path = visorconfig.Pkgpath
@@ -65,20 +66,27 @@ var dmsgURLCmd = &cobra.Command{
 			if path != "" {
 				conf, err := visorconfig.ReadFile(path)
 				if err != nil {
-					log.Fatal("Failed to read in config file:", err)
+					internal.Catch(cmd.Flags(), fmt.Errorf("Failed to read in config file: %v", err))
 				}
 				url = fmt.Sprintf("http://127.0.0.1:8000/pty/%s", conf.PK.Hex())
 			} else {
 				client := rpcClient()
 				overview, err := client.Overview()
 				if err != nil {
-					logger.Fatal("Failed to connect; is skywire running?\n", err)
+					internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
 				}
 				url = fmt.Sprintf("http://127.0.0.1:8000/pty/%s", overview.PubKey.Hex())
 			}
 		} else {
 			url = fmt.Sprintf("http://127.0.0.1:8000/pty/%s", pk)
 		}
-		fmt.Println(url)
+
+		output := struct {
+			URL string `json:"url"`
+		}{
+			URL: url,
+		}
+
+		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintln(url))
 	},
 }

--- a/cmd/skywire-cli/commands/dmsgpty/root.go
+++ b/cmd/skywire-cli/commands/dmsgpty/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"time"
 
@@ -50,19 +49,17 @@ func init() {
 var visorsCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List connected visors",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		remoteVisors, err := rpcClient().RemoteVisors()
 		if err != nil {
-			packageLogger.Fatal("RPC connection failed; is skywire running?\n", err)
+			internal.PrintError(cmd.Flags(), fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
 		}
 
 		var msg string
 		for idx, pk := range remoteVisors {
 			msg += fmt.Sprintf("%d. %s\n", idx+1, pk)
 		}
-		if _, err := os.Stdout.Write([]byte(msg)); err != nil {
-			packageLogger.Fatal("Failed to output build info:", err)
-		}
+		internal.PrintOutput(cmd.Flags(), remoteVisors, msg)
 	},
 }
 

--- a/cmd/skywire-cli/commands/dmsgpty/root.go
+++ b/cmd/skywire-cli/commands/dmsgpty/root.go
@@ -71,9 +71,9 @@ var shellCmd = &cobra.Command{
 	Use:   "start <pk>",
 	Short: "Start dmsgpty session",
 	Args:  cobra.MinimumNArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		cli := dmsgpty.DefaultCLI()
-		addr := internal.ParsePK("pk", args[0])
+		addr := internal.ParsePK(cmd.Flags(), "pk", args[0])
 		port, _ := strconv.ParseUint(ptyPort, 10, 16) //nolint
 		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
 		defer cancel()

--- a/cmd/skywire-cli/commands/dmsgpty/root.go
+++ b/cmd/skywire-cli/commands/dmsgpty/root.go
@@ -21,7 +21,6 @@ var (
 	ptyPort       string
 	masterLogger  = logging.NewMasterLogger()
 	packageLogger = masterLogger.PackageLogger("dmsgpty")
-	logger        = logging.MustGetLogger("skywire-cli")
 	rpcAddr       string
 	path          string
 	pk            string

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -15,6 +15,7 @@ import (
 	clirtfind "github.com/skycoin/skywire/cmd/skywire-cli/commands/rtfind"
 	clivisor "github.com/skycoin/skywire/cmd/skywire-cli/commands/visor"
 	clivpn "github.com/skycoin/skywire/cmd/skywire-cli/commands/vpn"
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
 var rootCmd = &cobra.Command{
@@ -40,8 +41,11 @@ func init() {
 		climdisc.RootCmd,
 		clicompletion.RootCmd,
 	)
+
 	var helpflag bool
+
 	rootCmd.PersistentFlags().StringVarP(&clirpc.Addr, "rpc", "", "localhost:3435", "RPC server address")
+	rootCmd.PersistentFlags().BoolVarP(&internal.JSONOutput, "json", "", false, "print output in json")
 	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.PersistentFlags().MarkHidden("help") //nolint

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -43,9 +43,10 @@ func init() {
 	)
 
 	var helpflag bool
+	var jsonOutput bool
 
-	rootCmd.PersistentFlags().StringVarP(&clirpc.Addr, "rpc", "", "localhost:3435", "RPC server address")
-	rootCmd.PersistentFlags().BoolVarP(&internal.JSONOutput, "json", "", false, "print output in json")
+	rootCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", "localhost:3435", "RPC server address")
+	rootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
 	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.PersistentFlags().MarkHidden("help") //nolint

--- a/cmd/skywire-cli/commands/rtfind/root.go
+++ b/cmd/skywire-cli/commands/rtfind/root.go
@@ -47,7 +47,14 @@ var RootCmd = &cobra.Command{
 			&rfclient.RouteOptions{MinHops: frMinHops, MaxHops: frMaxHops})
 		internal.Catch(cmd.Flags(), err)
 
-		fmt.Println("forward: ", routes[forward][0])
-		fmt.Println("reverse: ", routes[backward][0])
+		output := fmt.Sprintf("forward: %v\n reverse: %v", routes[forward][0], routes[backward][0])
+		outputJSON := struct {
+			Forward []routing.Hop `json:"forward"`
+			Reverse []routing.Hop `json:"reverse"`
+		}{
+			Forward: routes[forward][0],
+			Reverse: routes[backward][0],
+		}
+		internal.PrintOutput(cmd.Flags(), outputJSON, output)
 	},
 }

--- a/cmd/skywire-cli/commands/rtfind/root.go
+++ b/cmd/skywire-cli/commands/rtfind/root.go
@@ -34,18 +34,18 @@ var RootCmd = &cobra.Command{
 	Use:   "rtfind <public-key-visor-1> <public-key-visor-2>",
 	Short: "Query the Route Finder",
 	Args:  cobra.MinimumNArgs(2),
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		rfc := rfclient.NewHTTP(frAddr, timeout, &http.Client{}, nil)
 
 		var srcPK, dstPK cipher.PubKey
-		internal.Catch(srcPK.Set(args[0]))
-		internal.Catch(dstPK.Set(args[1]))
+		internal.Catch(cmd.Flags(), srcPK.Set(args[0]))
+		internal.Catch(cmd.Flags(), dstPK.Set(args[1]))
 		forward := [2]cipher.PubKey{srcPK, dstPK}
 		backward := [2]cipher.PubKey{dstPK, srcPK}
 		ctx := context.Background()
 		routes, err := rfc.FindRoutes(ctx, []routing.PathEdges{forward, backward},
 			&rfclient.RouteOptions{MinHops: frMinHops, MaxHops: frMaxHops})
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 
 		fmt.Println("forward: ", routes[forward][0])
 		fmt.Println("reverse: ", routes[backward][0])

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -82,7 +82,7 @@ var startAppCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.Catch(cmd.Flags(), clirpc.Client().StartApp(args[0]))
-		fmt.Println("OK")
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
 
@@ -92,7 +92,7 @@ var stopAppCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		internal.Catch(cmd.Flags(), clirpc.Client().StopApp(args[0]))
-		fmt.Println("OK")
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
 
@@ -111,13 +111,13 @@ var setAppAutostartCmd = &cobra.Command{
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
 		internal.Catch(cmd.Flags(), clirpc.Client().SetAutoStart(args[0], autostart))
-		fmt.Println("OK")
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
 
 var appLogsSinceCmd = &cobra.Command{
 	Use:   "log <name> <timestamp>",
-	Short: "Logs from app since RFC3339Nano-formated timestamp.\n                    \"beginning\" is a special timestamp to fetch all the logs",
+	Short: "Logs from app since RFC3339Nano-formatted timestamp.\n                    \"beginning\" is a special timestamp to fetch all the logs",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var t time.Time
@@ -132,9 +132,9 @@ var appLogsSinceCmd = &cobra.Command{
 		logs, err := clirpc.Client().LogsSince(t, args[0])
 		internal.Catch(cmd.Flags(), err)
 		if len(logs) > 0 {
-			fmt.Println(logs)
+			internal.PrintOutput(cmd.Flags(), logs, fmt.Sprintf("%v\n", logs))
 		} else {
-			fmt.Println("no logs")
+			internal.PrintOutput(cmd.Flags(), "no logs", "no logs\n")
 		}
 	},
 }

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -34,12 +34,12 @@ var appCmd = &cobra.Command{
 var lsAppsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List apps",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		states, err := clirpc.Client().Apps()
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
 		_, err = fmt.Fprintln(w, "app\tports\tauto_start\tstatus")
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		for _, state := range states {
 			status := "stopped"
 			if state.Status == appserver.AppStatusRunning {
@@ -49,9 +49,9 @@ var lsAppsCmd = &cobra.Command{
 				status = "errored"
 			}
 			_, err = fmt.Fprintf(w, "%s\t%s\t%t\t%s\n", state.Name, strconv.Itoa(int(state.Port)), state.AutoStart, status)
-			internal.Catch(err)
+			internal.Catch(cmd.Flags(), err)
 		}
-		internal.Catch(w.Flush())
+		internal.Catch(cmd.Flags(), w.Flush())
 	},
 }
 
@@ -59,8 +59,8 @@ var startAppCmd = &cobra.Command{
 	Use:   "start <name>",
 	Short: "Launch app",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		internal.Catch(clirpc.Client().StartApp(args[0]))
+	Run: func(cmd *cobra.Command, args []string) {
+		internal.Catch(cmd.Flags(), clirpc.Client().StartApp(args[0]))
 		fmt.Println("OK")
 	},
 }
@@ -69,8 +69,8 @@ var stopAppCmd = &cobra.Command{
 	Use:   "stop <name>",
 	Short: "Halt app",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		internal.Catch(clirpc.Client().StopApp(args[0]))
+	Run: func(cmd *cobra.Command, args []string) {
+		internal.Catch(cmd.Flags(), clirpc.Client().StopApp(args[0]))
 		fmt.Println("OK")
 	},
 }
@@ -79,7 +79,7 @@ var setAppAutostartCmd = &cobra.Command{
 	Use:   "autostart <name> (on|off)",
 	Short: "Autostart app",
 	Args:  cobra.MinimumNArgs(2),
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		var autostart bool
 		switch args[1] {
 		case "on":
@@ -87,9 +87,9 @@ var setAppAutostartCmd = &cobra.Command{
 		case "off":
 			autostart = false
 		default:
-			internal.Catch(fmt.Errorf("invalid args[1] value: %s", args[1]))
+			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(clirpc.Client().SetAutoStart(args[0], autostart))
+		internal.Catch(cmd.Flags(), clirpc.Client().SetAutoStart(args[0], autostart))
 		fmt.Println("OK")
 	},
 }
@@ -98,7 +98,7 @@ var appLogsSinceCmd = &cobra.Command{
 	Use:   "log <name> <timestamp>",
 	Short: "Logs from app since RFC3339Nano-formated timestamp.\n                    \"beginning\" is a special timestamp to fetch all the logs",
 	Args:  cobra.MinimumNArgs(2),
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		var t time.Time
 		if args[1] == "beginning" {
 			t = time.Unix(0, 0)
@@ -106,10 +106,10 @@ var appLogsSinceCmd = &cobra.Command{
 			var err error
 			strTime := args[1]
 			t, err = time.Parse(time.RFC3339Nano, strTime)
-			internal.Catch(err)
+			internal.Catch(cmd.Flags(), err)
 		}
 		logs, err := clirpc.Client().LogsSince(t, args[0])
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		if len(logs) > 0 {
 			fmt.Println(logs)
 		} else {

--- a/cmd/skywire-cli/commands/visor/exec.go
+++ b/cmd/skywire-cli/commands/visor/exec.go
@@ -20,9 +20,9 @@ var execCmd = &cobra.Command{
 	Use:   "exec <command>",
 	Short: "Execute a command",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		out, err := clirpc.Client().Exec(strings.Join(args, " "))
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		fmt.Print(string(out))
 	},
 }

--- a/cmd/skywire-cli/commands/visor/exec.go
+++ b/cmd/skywire-cli/commands/visor/exec.go
@@ -1,7 +1,6 @@
 package clivisor
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -23,6 +22,7 @@ var execCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		out, err := clirpc.Client().Exec(strings.Join(args, " "))
 		internal.Catch(cmd.Flags(), err)
-		fmt.Print(string(out))
+		// since the output of this command can be anything it is not formatted, so it's advisable to not use the `--json` flag for this one
+		internal.PrintOutput(cmd.Flags(), string(out), string(out))
 	},
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -37,7 +37,7 @@ func init() {
 var pkCmd = &cobra.Command{
 	Use:   "pk",
 	Short: "Public key of the visor",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		if pkg {
 			path = visorconfig.Pkgpath
 		}
@@ -45,14 +45,14 @@ var pkCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				internal.PrintFatalError(fmt.Errorf("Failed to read config: %v", err), logger, internal.JSONOutput)
+				internal.PrintFatalError(fmt.Errorf("Failed to read config: %v", err), logger, cmd.Flags())
 			}
 			outputPK = conf.PK.Hex()
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, internal.JSONOutput)
+				internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
 			}
 			pk = overview.PubKey.String()
 			if web {
@@ -63,7 +63,7 @@ var pkCmd = &cobra.Command{
 			outputPK = overview.PubKey.Hex()
 		}
 
-		internal.PrintOutput(outputPK, internal.JSONOutput)
+		internal.PrintOutput(outputPK, cmd.Flags())
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -53,13 +52,13 @@ var pkCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
-			pk = overview.PubKey.String()
+			pk = overview.PubKey.String() + "\n"
 			if web {
 				http.HandleFunc("/", srvpk)
 				logger.Info("\nServing public key " + pk + " on port " + webPort)
 				http.ListenAndServe(":"+webPort, nil) //nolint
 			}
-			outputPK = overview.PubKey.Hex()
+			outputPK = overview.PubKey.Hex() + "\n"
 		}
 
 		internal.PrintOutput(cmd.Flags(), outputPK, outputPK)
@@ -70,7 +69,7 @@ var hvpkCmd = &cobra.Command{
 	Use:   "hvpk",
 	Short: "Public key of remote hypervisor",
 	Run: func(cmd *cobra.Command, _ []string) {
-		var hypervisors []cipher.PubKey
+		var hypervisors string
 
 		if pkg {
 			path = visorconfig.Pkgpath
@@ -81,14 +80,14 @@ var hvpkCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
 			}
-			hypervisors = conf.Hypervisors
+			hypervisors = fmt.Sprintf("%v\n", conf.Hypervisors)
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
 				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
-			hypervisors = overview.Hypervisors
+			hypervisors = fmt.Sprintf("%v\n", overview.Hypervisors)
 		}
 		internal.PrintOutput(cmd.Flags(), hypervisors, hypervisors)
 	},
@@ -103,7 +102,7 @@ var chvpkCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
-		internal.PrintOutput(cmd.Flags(), overview.ConnectedHypervisor, overview.ConnectedHypervisor)
+		internal.PrintOutput(cmd.Flags(), overview.ConnectedHypervisor, fmt.Sprintf("%v\n", overview.ConnectedHypervisor))
 	},
 }
 
@@ -115,7 +114,7 @@ var summaryCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
-		msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\nSymmetric NAT: %t\nIP: %s\nDMSG Server: %q\nPing: %q\nVisor Version: %s\nSkybian Version: %s\nUptime Tracker: %s\nTime Online: %f seconds\nBuild Tag: %s",
+		msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\nSymmetric NAT: %t\nIP: %s\nDMSG Server: %q\nPing: %q\nVisor Version: %s\nSkybian Version: %s\nUptime Tracker: %s\nTime Online: %f seconds\nBuild Tag: %s\n",
 			summary.Overview.PubKey, summary.Overview.IsSymmetricNAT, summary.Overview.LocalIP, summary.DmsgStats.ServerPK, summary.DmsgStats.RoundTrip, summary.Overview.BuildInfo.Version, summary.SkybianBuildVersion,
 			summary.Health.ServicesHealth, summary.Uptime, summary.BuildTag)
 
@@ -156,7 +155,7 @@ var buildInfoCmd = &cobra.Command{
 			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
 		buildInfo := overview.BuildInfo
-		msg := fmt.Sprintf("Version %q built on %q against commit %q", buildInfo.Version, buildInfo.Date, buildInfo.Commit)
+		msg := fmt.Sprintf("Version %q built on %q against commit %q\n", buildInfo.Version, buildInfo.Date, buildInfo.Commit)
 		internal.PrintOutput(cmd.Flags(), buildInfo, msg)
 	},
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -40,12 +41,13 @@ var pkCmd = &cobra.Command{
 		if pkg {
 			path = visorconfig.Pkgpath
 		}
+		var outputPK string
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
 				logger.Fatal("Failed to read config:", err)
 			}
-			fmt.Println(conf.PK.Hex())
+			outputPK = conf.PK.Hex()
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
@@ -58,8 +60,10 @@ var pkCmd = &cobra.Command{
 				logger.Info("\nServing public key " + pk + " on port " + webPort)
 				http.ListenAndServe(":"+webPort, nil) //nolint
 			}
-			fmt.Println(overview.PubKey)
+			outputPK = overview.PubKey.Hex()
 		}
+
+		internal.PrintOutput(outputPK, internal.JSONOutput)
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -2,9 +2,7 @@ package clivisor
 
 import (
 	"fmt"
-	"log"
 	"net/http"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -151,15 +149,15 @@ var summaryCmd = &cobra.Command{
 var buildInfoCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Version and build info",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		client := clirpc.Client()
 		overview, err := client.Overview()
 		if err != nil {
-			log.Fatal("Failed to connect:", err)
+			internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
 		}
-		if _, err := overview.BuildInfo.WriteTo(os.Stdout); err != nil {
-			log.Fatal("Failed to output build info:", err)
-		}
+		buildInfo := overview.BuildInfo
+		msg := fmt.Sprintf("Version %q built on %q against commit %q", buildInfo.Version, buildInfo.Date, buildInfo.Commit)
+		internal.PrintOutput(buildInfo, msg, cmd.Flags())
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -44,14 +44,14 @@ var pkCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
 			}
 			outputPK = conf.PK.Hex()
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
 			pk = overview.PubKey.String()
 			if web {
@@ -79,14 +79,14 @@ var hvpkCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
 			}
 			hypervisors = conf.Hypervisors
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
 			hypervisors = overview.Hypervisors
 		}
@@ -101,7 +101,7 @@ var chvpkCmd = &cobra.Command{
 		client := clirpc.Client()
 		overview, err := client.Overview()
 		if err != nil {
-			internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
 		internal.PrintOutput(cmd.Flags(), overview.ConnectedHypervisor, overview.ConnectedHypervisor)
 	},
@@ -113,7 +113,7 @@ var summaryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		summary, err := clirpc.Client().Summary()
 		if err != nil {
-			internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
 		msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\nSymmetric NAT: %t\nIP: %s\nDMSG Server: %q\nPing: %q\nVisor Version: %s\nSkybian Version: %s\nUptime Tracker: %s\nTime Online: %f seconds\nBuild Tag: %s",
 			summary.Overview.PubKey, summary.Overview.IsSymmetricNAT, summary.Overview.LocalIP, summary.DmsgStats.ServerPK, summary.DmsgStats.RoundTrip, summary.Overview.BuildInfo.Version, summary.SkybianBuildVersion,
@@ -153,7 +153,7 @@ var buildInfoCmd = &cobra.Command{
 		client := clirpc.Client()
 		overview, err := client.Overview()
 		if err != nil {
-			internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
 		buildInfo := overview.BuildInfo
 		msg := fmt.Sprintf("Version %q built on %q against commit %q", buildInfo.Version, buildInfo.Date, buildInfo.Commit)

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -45,14 +45,14 @@ var pkCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				logger.Fatal("Failed to read config:", err)
+				internal.PrintFatalError(fmt.Errorf("Failed to read config: %v", err), logger, internal.JSONOutput)
 			}
 			outputPK = conf.PK.Hex()
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				logger.Fatal("Failed to connect:", err)
+				internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, internal.JSONOutput)
 			}
 			pk = overview.PubKey.String()
 			if web {

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -70,24 +71,28 @@ var pkCmd = &cobra.Command{
 var hvpkCmd = &cobra.Command{
 	Use:   "hvpk",
 	Short: "Public key of remote hypervisor",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
+		var hypervisors []cipher.PubKey
+
 		if pkg {
 			path = visorconfig.Pkgpath
 		}
+
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				logger.Fatal("Failed to read config:", err)
+				internal.PrintFatalError(fmt.Errorf("Failed to read config: %v", err), logger, cmd.Flags())
 			}
-			fmt.Println(conf.Hypervisors)
+			hypervisors = conf.Hypervisors
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				logger.Fatal("Failed to connect:", err)
+				internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
 			}
-			fmt.Println(overview.Hypervisors)
+			hypervisors = overview.Hypervisors
 		}
+		internal.PrintOutput(hypervisors, cmd.Flags())
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -99,13 +99,13 @@ var hvpkCmd = &cobra.Command{
 var chvpkCmd = &cobra.Command{
 	Use:   "chvpk",
 	Short: "Public key of connected hypervisors",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		client := clirpc.Client()
 		overview, err := client.Overview()
 		if err != nil {
-			logger.Fatal("Failed to connect:", err)
+			internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
 		}
-		fmt.Println(overview.ConnectedHypervisor)
+		internal.PrintOutput(overview.ConnectedHypervisor, cmd.Flags())
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -44,14 +44,14 @@ var pkCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				internal.PrintFatalError(fmt.Errorf("Failed to read config: %v", err), logger, cmd.Flags())
+				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
 			}
 			outputPK = conf.PK.Hex()
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
+				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
 			pk = overview.PubKey.String()
 			if web {
@@ -62,7 +62,7 @@ var pkCmd = &cobra.Command{
 			outputPK = overview.PubKey.Hex()
 		}
 
-		internal.PrintOutput(outputPK, outputPK, cmd.Flags())
+		internal.PrintOutput(cmd.Flags(), outputPK, outputPK)
 	},
 }
 
@@ -79,18 +79,18 @@ var hvpkCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				internal.PrintFatalError(fmt.Errorf("Failed to read config: %v", err), logger, cmd.Flags())
+				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to read config: %v", err))
 			}
 			hypervisors = conf.Hypervisors
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
+				internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
 			hypervisors = overview.Hypervisors
 		}
-		internal.PrintOutput(hypervisors, hypervisors, cmd.Flags())
+		internal.PrintOutput(cmd.Flags(), hypervisors, hypervisors)
 	},
 }
 
@@ -101,9 +101,9 @@ var chvpkCmd = &cobra.Command{
 		client := clirpc.Client()
 		overview, err := client.Overview()
 		if err != nil {
-			internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
+			internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
-		internal.PrintOutput(overview.ConnectedHypervisor, overview.ConnectedHypervisor, cmd.Flags())
+		internal.PrintOutput(cmd.Flags(), overview.ConnectedHypervisor, overview.ConnectedHypervisor)
 	},
 }
 
@@ -113,7 +113,7 @@ var summaryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		summary, err := clirpc.Client().Summary()
 		if err != nil {
-			internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
+			internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
 		msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\nSymmetric NAT: %t\nIP: %s\nDMSG Server: %q\nPing: %q\nVisor Version: %s\nSkybian Version: %s\nUptime Tracker: %s\nTime Online: %f seconds\nBuild Tag: %s",
 			summary.Overview.PubKey, summary.Overview.IsSymmetricNAT, summary.Overview.LocalIP, summary.DmsgStats.ServerPK, summary.DmsgStats.RoundTrip, summary.Overview.BuildInfo.Version, summary.SkybianBuildVersion,
@@ -142,7 +142,7 @@ var summaryCmd = &cobra.Command{
 			TimeOnline:     summary.Uptime,
 			BuildTag:       summary.BuildTag,
 		}
-		internal.PrintOutput(outputJSON, msg, cmd.Flags())
+		internal.PrintOutput(cmd.Flags(), outputJSON, msg)
 	},
 }
 
@@ -153,11 +153,11 @@ var buildInfoCmd = &cobra.Command{
 		client := clirpc.Client()
 		overview, err := client.Overview()
 		if err != nil {
-			internal.PrintFatalError(fmt.Errorf("Failed to connect: %v", err), logger, cmd.Flags())
+			internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
 		buildInfo := overview.BuildInfo
 		msg := fmt.Sprintf("Version %q built on %q against commit %q", buildInfo.Version, buildInfo.Date, buildInfo.Commit)
-		internal.PrintOutput(buildInfo, msg, cmd.Flags())
+		internal.PrintOutput(cmd.Flags(), buildInfo, msg)
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/root.go
+++ b/cmd/skywire-cli/commands/visor/root.go
@@ -1,9 +1,9 @@
 package clivisor
 
 import (
-	"github.com/skycoin/skywire-utilities/pkg/logging"
-
 	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire-utilities/pkg/logging"
 )
 
 var logger = logging.MustGetLogger("skywire-cli")

--- a/cmd/skywire-cli/commands/visor/root.go
+++ b/cmd/skywire-cli/commands/visor/root.go
@@ -1,7 +1,8 @@
 package clivisor
 
 import (
-	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/skycoin/skywire-utilities/pkg/logging"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/skywire-cli/commands/visor/route.go
+++ b/cmd/skywire-cli/commands/visor/route.go
@@ -23,8 +23,18 @@ var routeCmd = &cobra.Command{
 	Short: "View and set rules",
 }
 
+var addRuleCmd = &cobra.Command{
+	Use:   "add-rule",
+	Short: "Add routing rule",
+}
+
 func init() {
 	RootCmd.AddCommand(routeCmd)
+	addRuleCmd.AddCommand(
+		addAppRuleCmd,
+		addFwdRuleCmd,
+		addIntFwdRuleCmd,
+	)
 	routeCmd.AddCommand(
 		lsRulesCmd,
 		ruleCmd,
@@ -77,52 +87,121 @@ func init() {
 	addRuleCmd.PersistentFlags().DurationVar(&keepAlive, "keep-alive", router.DefaultRouteKeepAlive, "duration after which routing rule will expire if no activity is present")
 }
 
-var addRuleCmd = &cobra.Command{
-	Use:   "add-rule (app <route-id> <local-pk> <local-port> <remote-pk> <remote-port> | fwd <next-route-id> <next-transport-id>)",
-	Short: "Add routing rule",
+var addAppRuleCmd = &cobra.Command{
+	Use:   "app <route-id> <local-pk> <local-port> <remote-pk> <remote-port>",
+	Short: "Add app/consume routing rule",
 	Args: func(_ *cobra.Command, args []string) error {
 		if len(args) > 0 {
-			switch rt := args[0]; rt {
-			case "app":
-				if len(args[0:]) == 4 {
-					return nil
-				}
-				return errors.New("expected 4 args after 'app'")
-			case "fwd":
-				if len(args[0:]) == 2 {
-					return nil
-				}
-				return errors.New("expected 2 args after 'fwd'")
+			if len(args[0:]) == 5 {
+				return nil
 			}
+			return errors.New("expected 5 args after 'app'")
 		}
-		return errors.New("expected 'app' or 'fwd' after 'add-rule'")
+		return errors.New("expected 5 args after 'app'")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		var rule routing.Rule
-		switch args[0] {
-		case "app":
-			var (
-				routeID    = routing.RouteID(parseUint(cmd.Flags(), "route-id", args[1], 32))
-				localPK    = internal.ParsePK(cmd.Flags(), "local-pk", args[2])
-				localPort  = routing.Port(parseUint(cmd.Flags(), "local-port", args[3], 16))
-				remotePK   = internal.ParsePK(cmd.Flags(), "remote-pk", args[4])
-				remotePort = routing.Port(parseUint(cmd.Flags(), "remote-port", args[5], 16))
-			)
-			rule = routing.ConsumeRule(keepAlive, routeID, localPK, remotePK, localPort, remotePort)
-		case "fwd":
-			var (
-				nextRouteID = routing.RouteID(parseUint(cmd.Flags(), "next-route-id", args[1], 32))
-				nextTpID    = internal.ParseUUID(cmd.Flags(), "next-transport-id", args[2])
-			)
-			rule = routing.IntermediaryForwardRule(keepAlive, 0, nextRouteID, nextTpID)
-		}
+		var (
+			routeID    = routing.RouteID(parseUint(cmd.Flags(), "route-id", args[0], 32))
+			localPK    = internal.ParsePK(cmd.Flags(), "local-pk", args[1])
+			localPort  = routing.Port(parseUint(cmd.Flags(), "local-port", args[2], 16))
+			remotePK   = internal.ParsePK(cmd.Flags(), "remote-pk", args[3])
+			remotePort = routing.Port(parseUint(cmd.Flags(), "remote-port", args[4], 16))
+		)
+		rule = routing.ConsumeRule(keepAlive, routeID, localPK, remotePK, localPort, remotePort)
+
 		var rIDKey routing.RouteID
 		if rule != nil {
 			rIDKey = rule.KeyRouteID()
 		}
 
 		internal.Catch(cmd.Flags(), clirpc.Client().SaveRoutingRule(rule))
-		fmt.Println("Routing Rule Key:", rIDKey)
+
+		output := struct {
+			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
+		}{
+			RoutingRuleKey: rIDKey,
+		}
+
+		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintf("Routing Rule Key: %v\n", rIDKey))
+	},
+}
+
+var addFwdRuleCmd = &cobra.Command{
+	Use:   "fwd <route-id> <next-route-id> <next-transport-id> <local-pk> <local-port> <remote-pk> <remote-port>",
+	Short: "Add forward routing rule",
+	Args: func(_ *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			if len(args[1:]) == 6 {
+				return nil
+			}
+			return errors.New("expected 6 args after 'fwd'")
+		}
+		return errors.New("expected 6 args after 'fwd'")
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		var rule routing.Rule
+		var (
+			routeID     = routing.RouteID(parseUint(cmd.Flags(), "route-id", args[0], 32))
+			nextRouteID = routing.RouteID(parseUint(cmd.Flags(), "next-route-id", args[1], 32))
+			nextTpID    = internal.ParseUUID(cmd.Flags(), "next-transport-id", args[2])
+			localPK     = internal.ParsePK(cmd.Flags(), "local-pk", args[3])
+			localPort   = routing.Port(parseUint(cmd.Flags(), "local-port", args[4], 16))
+			remotePK    = internal.ParsePK(cmd.Flags(), "remote-pk", args[5])
+			remotePort  = routing.Port(parseUint(cmd.Flags(), "remote-port", args[6], 16))
+		)
+		rule = routing.ForwardRule(keepAlive, routeID, nextRouteID, nextTpID, localPK, remotePK, localPort, remotePort)
+		var rIDKey routing.RouteID
+		if rule != nil {
+			rIDKey = rule.KeyRouteID()
+		}
+
+		internal.Catch(cmd.Flags(), clirpc.Client().SaveRoutingRule(rule))
+
+		output := struct {
+			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
+		}{
+			RoutingRuleKey: rIDKey,
+		}
+
+		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintf("Routing Rule Key: %v\n", rIDKey))
+	},
+}
+
+var addIntFwdRuleCmd = &cobra.Command{
+	Use:   "intfwd <route-id> <next-route-id> <next-transport-id>",
+	Short: "Add intermediary forward routing rule",
+	Args: func(_ *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			if len(args[0:]) == 3 {
+				return nil
+			}
+			return errors.New("expected 3 args after 'intfwd'")
+		}
+		return errors.New("expected 3 args after 'intfwd'")
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		var rule routing.Rule
+		var (
+			routeID     = routing.RouteID(parseUint(cmd.Flags(), "route-id", args[0], 32))
+			nextRouteID = routing.RouteID(parseUint(cmd.Flags(), "next-route-id", args[1], 32))
+			nextTpID    = internal.ParseUUID(cmd.Flags(), "next-transport-id", args[2])
+		)
+		rule = routing.IntermediaryForwardRule(keepAlive, routeID, nextRouteID, nextTpID)
+		var rIDKey routing.RouteID
+		if rule != nil {
+			rIDKey = rule.KeyRouteID()
+		}
+
+		internal.Catch(cmd.Flags(), clirpc.Client().SaveRoutingRule(rule))
+
+		output := struct {
+			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
+		}{
+			RoutingRuleKey: rIDKey,
+		}
+
+		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintf("Routing Rule Key: %v\n", rIDKey))
 	},
 }
 
@@ -159,9 +238,28 @@ func printRoutingRules(cmdFlags *pflag.FlagSet, rules ...routing.Rule) {
 		jsonRules = append(jsonRules, jRule)
 		internal.Catch(cmdFlags, err)
 	}
+
 	printFwdRule := func(w io.Writer, id routing.RouteID, s *routing.RuleSummary) {
+		_, err := fmt.Fprintf(w, "%d\t%s\t%d\t%d\t%s\t%d\t%s\t%s\n", id, s.Type, s.ForwardFields.RouteDescriptor.SrcPort,
+			s.ForwardFields.RouteDescriptor.DstPort, s.ForwardFields.RouteDescriptor.DstPK, s.ForwardFields.NextRID, s.ForwardFields.NextTID, s.KeepAlive)
+
+		jRule := jsonRule{
+			ID:          id,
+			Type:        s.Type.String(),
+			LocalPort:   fmt.Sprint(s.ForwardFields.RouteDescriptor.SrcPort),
+			RemotePort:  fmt.Sprint(s.ForwardFields.RouteDescriptor.DstPort),
+			RemotePK:    s.ForwardFields.RouteDescriptor.DstPK.Hex(),
+			NextRouteID: fmt.Sprint(s.ForwardFields.NextRID),
+			NextTpID:    s.ForwardFields.NextTID.String(),
+			ExpireAt:    s.KeepAlive,
+		}
+		jsonRules = append(jsonRules, jRule)
+		internal.Catch(cmdFlags, err)
+	}
+
+	printIntFwdRule := func(w io.Writer, id routing.RouteID, s *routing.RuleSummary) {
 		_, err := fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n", id, s.Type, "-",
-			"-", "-", s.ForwardFields.NextRID, s.ForwardFields.NextTID, s.KeepAlive)
+			"-", "-", s.IntermediaryForwardFields.NextRID, s.IntermediaryForwardFields.NextTID, s.KeepAlive)
 
 		jRule := jsonRule{
 			ID:          id,
@@ -169,8 +267,8 @@ func printRoutingRules(cmdFlags *pflag.FlagSet, rules ...routing.Rule) {
 			LocalPort:   "-",
 			RemotePort:  "-",
 			RemotePK:    "-",
-			NextRouteID: fmt.Sprint(s.ForwardFields.NextRID),
-			NextTpID:    s.ForwardFields.NextTID.String(),
+			NextRouteID: fmt.Sprint(s.IntermediaryForwardFields.NextRID),
+			NextTpID:    s.IntermediaryForwardFields.NextTID.String(),
 			ExpireAt:    s.KeepAlive,
 		}
 		jsonRules = append(jsonRules, jRule)
@@ -184,9 +282,14 @@ func printRoutingRules(cmdFlags *pflag.FlagSet, rules ...routing.Rule) {
 	for _, rule := range rules {
 		if rule.Summary().ConsumeFields != nil {
 			printConsumeRule(w, rule.KeyRouteID(), rule.Summary())
-		} else {
-			printFwdRule(w, rule.NextRouteID(), rule.Summary())
+			continue
 		}
+		if rule.Summary().Type == routing.RuleForward {
+			printFwdRule(w, rule.NextRouteID(), rule.Summary())
+			continue
+		}
+		printIntFwdRule(w, rule.NextRouteID(), rule.Summary())
+
 	}
 	internal.Catch(cmdFlags, w.Flush())
 	internal.PrintOutput(cmdFlags, jsonRules, b.String())
@@ -194,6 +297,8 @@ func printRoutingRules(cmdFlags *pflag.FlagSet, rules ...routing.Rule) {
 
 func parseUint(cmdFlags *pflag.FlagSet, name, v string, bitSize int) uint64 {
 	i, err := strconv.ParseUint(v, 10, bitSize)
-	internal.Catch(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
+	if err != nil {
+		internal.PrintError(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
+	}
 	return i
 }

--- a/cmd/skywire-cli/commands/visor/route.go
+++ b/cmd/skywire-cli/commands/visor/route.go
@@ -67,7 +67,7 @@ var rmRuleCmd = &cobra.Command{
 		id, err := strconv.ParseUint(args[0], 10, 32)
 		internal.Catch(cmd.Flags(), err)
 		internal.Catch(cmd.Flags(), clirpc.Client().RemoveRoutingRule(routing.RouteID(id)))
-		fmt.Println("OK")
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/shutdown.go
+++ b/cmd/skywire-cli/commands/visor/shutdown.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
 func init() {
@@ -15,8 +16,9 @@ func init() {
 var shutdownCmd = &cobra.Command{
 	Use:   "halt",
 	Short: "Stop a running visor",
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		clirpc.Client().Shutdown() //nolint
 		fmt.Println("Visor was shut down")
+		internal.PrintOutput(cmd.Flags(), "Visor was shut down", fmt.Sprintln("Visor was shut down"))
 	},
 }

--- a/cmd/skywire-cli/commands/visor/start.go
+++ b/cmd/skywire-cli/commands/visor/start.go
@@ -1,7 +1,10 @@
 package clivisor
 
 import (
+	"fmt"
 	"os/user"
+
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 
 	"github.com/bitfield/script"
 	"github.com/spf13/cobra"
@@ -22,24 +25,27 @@ func init() {
 	startCmd.Flags().BoolVarP(&sourcerun, "src", "s", false, "'go run' external commands from the skywire sources")
 }
 
+// TODO(ersonp): get help from moses for it's usage
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start a visor",
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
+		var output string
 		var err error
 		if !sourcerun {
 			if root {
 				//if skywire is installed as a command from a package, we can use the -p flag here
-				_, err = script.Exec(`skywire-visor -p`).Stdout()
+				output, err = script.Exec(`skywire-visor -p`).String()
 			} else {
 				//if the config exists in the userspace and this command was not run as root
-				_, err = script.Exec(`skywire-visor -u`).Stdout()
+				output, err = script.Exec(`skywire-visor -u`).String()
 			}
 		} else {
-			_, err = script.Exec(`bash -c 'go run cmd/skywire-visor/skywire-visor.go'`).Stdout()
+			output, err = script.Exec(`bash -c 'go run cmd/skywire-visor/skywire-visor.go'`).String()
 		}
 		if err != nil {
-			logger.WithError(err).Fatalln("Failed to start visor")
+			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to start visor: %v", err))
 		}
+		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintln(output))
 	},
 }

--- a/cmd/skywire-cli/commands/visor/start.go
+++ b/cmd/skywire-cli/commands/visor/start.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os/user"
 
-	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
-
 	"github.com/bitfield/script"
 	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
 var sourcerun bool

--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
@@ -58,9 +59,9 @@ var tpCmd = &cobra.Command{
 
 var lsTypesCmd = &cobra.Command{
 	Use: "type", Short: "Transport types used by the local visor",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		types, err := clirpc.Client().TransportTypes()
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		for _, t := range types {
 			fmt.Println(t)
 		}
@@ -76,10 +77,10 @@ func init() {
 var lsTpCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "Available transports",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		transports, err := clirpc.Client().Transports(filterTypes, filterPubKeys, showLogs)
-		internal.Catch(err)
-		PrintTransports(transports...)
+		internal.Catch(cmd.Flags(), err)
+		PrintTransports(cmd.Flags(), transports...)
 	},
 }
 
@@ -87,11 +88,11 @@ var idCmd = &cobra.Command{
 	Use:   "id <transport-id>",
 	Short: "Transport summary by id",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		tpID := internal.ParseUUID("transport-id", args[0])
+	Run: func(cmd *cobra.Command, args []string) {
+		tpID := internal.ParseUUID(cmd.Flags(), "transport-id", args[0])
 		tp, err := clirpc.Client().Transport(tpID)
-		internal.Catch(err)
-		PrintTransports(tp)
+		internal.Catch(cmd.Flags(), err)
+		PrintTransports(cmd.Flags(), tp)
 	},
 }
 
@@ -118,8 +119,8 @@ var addTpCmd = &cobra.Command{
 	Use:   "add <remote-public-key>",
 	Short: "Add a transport",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		pk := internal.ParsePK("remote-public-key", args[0])
+	Run: func(cmd *cobra.Command, args []string) {
+		pk := internal.ParsePK(cmd.Flags(), "remote-public-key", args[0])
 
 		var tp *visor.TransportSummary
 		var err error
@@ -147,7 +148,7 @@ var addTpCmd = &cobra.Command{
 				logger.WithError(err).Warnf("Failed to establish %v transport", transportType)
 			}
 		}
-		PrintTransports(tp)
+		PrintTransports(cmd.Flags(), tp)
 	},
 }
 
@@ -155,28 +156,28 @@ var rmTpCmd = &cobra.Command{
 	Use:   "rm <transport-id>",
 	Short: "Remove transport(s) by id",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		tID := internal.ParseUUID("transport-id", args[0])
-		internal.Catch(clirpc.Client().RemoveTransport(tID))
+	Run: func(cmd *cobra.Command, args []string) {
+		tID := internal.ParseUUID(cmd.Flags(), "transport-id", args[0])
+		internal.Catch(cmd.Flags(), clirpc.Client().RemoveTransport(tID))
 		fmt.Println("OK")
 	},
 }
 
 // PrintTransports prints transports used by the visor
-func PrintTransports(tps ...*visor.TransportSummary) {
+func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 	sortTransports(tps...)
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
 	_, err := fmt.Fprintln(w, "type\tid\tremote\tmode\tlabel")
-	internal.Catch(err)
+	internal.Catch(cmdFlags, err)
 	for _, tp := range tps {
 		tpMode := "regular"
 		if tp.IsSetup {
 			tpMode = "setup"
 		}
 		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
-		internal.Catch(err)
+		internal.Catch(cmdFlags, err)
 	}
-	internal.Catch(w.Flush())
+	internal.Catch(cmdFlags, w.Flush())
 }
 
 func sortTransports(tps ...*visor.TransportSummary) {
@@ -201,31 +202,31 @@ var discTpCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 
 		if rc := clirpc.Client(); tpPK.Null() {
 			entry, err := rc.DiscoverTransportByID(uuid.UUID(tpID))
-			internal.Catch(err)
-			PrintTransportEntries(entry)
+			internal.Catch(cmd.Flags(), err)
+			PrintTransportEntries(cmd.Flags(), entry)
 		} else {
 			entries, err := rc.DiscoverTransportsByPK(tpPK)
-			internal.Catch(err)
-			PrintTransportEntries(entries...)
+			internal.Catch(cmd.Flags(), err)
+			PrintTransportEntries(cmd.Flags(), entries...)
 		}
 	},
 }
 
 // PrintTransportEntries prints the transport entries
-func PrintTransportEntries(entries ...*transport.Entry) {
+func PrintTransportEntries(cmdFlags *pflag.FlagSet, entries ...*transport.Entry) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
 	_, err := fmt.Fprintln(w, "id\ttype\tedge1\tedge2")
-	internal.Catch(err)
+	internal.Catch(cmdFlags, err)
 	for _, e := range entries {
 		_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 			e.ID, e.Type, e.Edges[0], e.Edges[1])
-		internal.Catch(err)
+		internal.Catch(cmdFlags, err)
 	}
-	internal.Catch(w.Flush())
+	internal.Catch(cmdFlags, w.Flush())
 }
 
 type transportID uuid.UUID

--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -98,7 +98,6 @@ var idCmd = &cobra.Command{
 
 var (
 	transportType string
-	public        bool
 	timeout       time.Duration
 )
 
@@ -106,12 +105,10 @@ func init() {
 	const (
 		typeFlagUsage = "type of transport to add; if unspecified, cli will attempt to establish a transport " +
 			"in the following order: skywire-tcp, stcpr, sudph, dmsg"
-		publicFlagUsage  = "whether to make the transport public (deprecated)"
 		timeoutFlagUsage = "if specified, sets an operation timeout"
 	)
 
 	addTpCmd.Flags().StringVar(&transportType, "type", "", typeFlagUsage)
-	addTpCmd.Flags().BoolVar(&public, "public", true, publicFlagUsage)
 	addTpCmd.Flags().DurationVarP(&timeout, "timeout", "t", 0, timeoutFlagUsage)
 }
 

--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -62,9 +63,7 @@ var lsTypesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		types, err := clirpc.Client().TransportTypes()
 		internal.Catch(cmd.Flags(), err)
-		for _, t := range types {
-			fmt.Println(t)
-		}
+		internal.PrintOutput(cmd.Flags(), types, fmt.Sprintln(strings.Join(types, "\n")))
 	},
 }
 

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -2,18 +2,14 @@ package clivpn
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/skycoin/skywire-utilities/pkg/logging"
 )
 
 var (
-	logger       = logging.MustGetLogger("skywire-cli")
 	path         string
 	isPkg        bool
 	isUnFiltered bool
 	ver          string
 	country      string
-	isSystray    bool
 	isStats      bool
 )
 

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -141,9 +141,9 @@ var vpnStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start the vpn for <public-key>",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(args[0])
-		internal.Catch(clirpc.Client().StartVPNClient(args[0]))
+		internal.Catch(cmd.Flags(), clirpc.Client().StartVPNClient(args[0]))
 		fmt.Println("OK")
 	},
 }
@@ -151,8 +151,8 @@ var vpnStartCmd = &cobra.Command{
 var vpnStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "stop the vpn",
-	Run: func(_ *cobra.Command, _ []string) {
-		internal.Catch(clirpc.Client().StopVPNClient("vpn-client"))
+	Run: func(cmd *cobra.Command, _ []string) {
+		internal.Catch(cmd.Flags(), clirpc.Client().StopVPNClient("vpn-client"))
 		fmt.Println("OK")
 	},
 }
@@ -160,11 +160,11 @@ var vpnStopCmd = &cobra.Command{
 var vpnStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "vpn status",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		states, err := clirpc.Client().Apps()
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 5, ' ', tabwriter.TabIndent)
-		internal.Catch(err)
+		internal.Catch(cmd.Flags(), err)
 		for _, state := range states {
 			if state.Name == "vpn-client" {
 				status := "stopped"
@@ -175,9 +175,9 @@ var vpnStatusCmd = &cobra.Command{
 					status = "errored"
 				}
 				_, err = fmt.Fprintf(w, "%s\n", status)
-				internal.Catch(err)
+				internal.Catch(cmd.Flags(), err)
 			}
 		}
-		internal.Catch(w.Flush())
+		internal.Catch(cmd.Flags(), w.Flush())
 	},
 }

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -139,7 +139,7 @@ var vpnStartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(args[0])
 		internal.Catch(cmd.Flags(), clirpc.Client().StartVPNClient(args[0]))
-		fmt.Println("OK")
+		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }
 
@@ -148,7 +148,7 @@ var vpnStopCmd = &cobra.Command{
 	Short: "stop the vpn",
 	Run: func(cmd *cobra.Command, _ []string) {
 		internal.Catch(cmd.Flags(), clirpc.Client().StopVPNClient("vpn-client"))
-		fmt.Println("OK")
+		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }
 

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -43,7 +43,7 @@ func init() {
 var vpnUICmd = &cobra.Command{
 	Use:   "ui",
 	Short: "Open VPN UI in default browser",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		var url string
 		if isPkg {
 			path = visorconfig.Pkgpath
@@ -51,19 +51,19 @@ var vpnUICmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				log.Fatal("Failed to read in config:", err)
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to read in config: %v", err))
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", conf.PK.Hex())
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				log.Fatal("Failed to connect; is skywire running?\n", err)
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
 		}
 		if err := webbrowser.Open(url); err != nil {
-			log.Fatal("Failed to open VPN UI in browser:", err)
+			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to open VPN UI in browser:: %v", err))
 		}
 	},
 }

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -3,7 +3,6 @@ package clivpn
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -71,7 +70,7 @@ var vpnUICmd = &cobra.Command{
 var vpnURLCmd = &cobra.Command{
 	Use:   "url",
 	Short: "Show VPN UI URL",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		var url string
 		if isPkg {
 			path = visorconfig.Pkgpath
@@ -79,18 +78,25 @@ var vpnURLCmd = &cobra.Command{
 		if path != "" {
 			conf, err := visorconfig.ReadFile(path)
 			if err != nil {
-				log.Fatal("Failed to read in config:", err)
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to read in config: %v", err))
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", conf.PK.Hex())
 		} else {
 			client := clirpc.Client()
 			overview, err := client.Overview()
 			if err != nil {
-				logger.Fatal("Failed to connect; is skywire running?\n", err)
+				internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
 		}
-		fmt.Println(url)
+
+		output := struct {
+			URL string `json:"url"`
+		}{
+			URL: url,
+		}
+
+		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintln(url))
 	},
 }
 

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -44,14 +44,19 @@ func PrintError(cmdFlags *pflag.FlagSet, err error) {
 // ParsePK parses a public key
 func ParsePK(cmdFlags *pflag.FlagSet, name, v string) cipher.PubKey {
 	var pk cipher.PubKey
-	Catch(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, pk.Set(v)))
+	err := pk.Set(v)
+	if err != nil {
+		PrintError(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
+	}
 	return pk
 }
 
 // ParseUUID parses a uuid
 func ParseUUID(cmdFlags *pflag.FlagSet, name, v string) uuid.UUID {
 	id, err := uuid.Parse(v)
-	Catch(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
+	if err != nil {
+		PrintError(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
+	}
 	return id
 }
 

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -18,55 +18,7 @@ var log = logging.MustGetLogger("skywire-cli")
 var JSONString = "json"
 
 // Catch handles errors for skywire-cli commands packages
-func Catch(err error, msgs ...string) {
-	if err != nil {
-		if len(msgs) > 0 {
-			log.Fatalln(append(msgs, err.Error()))
-		} else {
-			log.Fatalln(err)
-		}
-	}
-}
-
-// ParsePK parses a public key
-func ParsePK(name, v string) cipher.PubKey {
-	var pk cipher.PubKey
-	Catch(pk.Set(v), fmt.Sprintf("failed to parse <%s>:", name))
-	return pk
-}
-
-// ParseUUID parses a uuid
-func ParseUUID(name, v string) uuid.UUID {
-	id, err := uuid.Parse(v)
-	Catch(err, fmt.Sprintf("failed to parse <%s>:", name))
-	return id
-}
-
-// CLIOutput ss
-type CLIOutput struct {
-	Output interface{} `json:"output,omitempty"`
-	Err    string      `json:"error,omitempty"`
-}
-
-// PrintOutput ss
-func PrintOutput(outputJSON, output interface{}, cmdFlags *pflag.FlagSet) {
-	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
-	if isJSON {
-		outputJSON := CLIOutput{
-			Output: outputJSON,
-		}
-		b, err := json.MarshalIndent(outputJSON, "", "  ")
-		if err != nil {
-			fmt.Println(err)
-		}
-		fmt.Print(string(b) + "\n")
-		return
-	}
-	fmt.Println(output)
-}
-
-// PrintFatalError ss
-func PrintFatalError(err error, logger *logging.Logger, cmdFlags *pflag.FlagSet) {
+func Catch(cmdFlags *pflag.FlagSet, err error) {
 	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
 	if isJSON {
 		errJSON := CLIOutput{
@@ -80,5 +32,42 @@ func PrintFatalError(err error, logger *logging.Logger, cmdFlags *pflag.FlagSet)
 		os.Exit(1)
 		return
 	}
-	logger.Fatal(err)
+	log.Fatal(err)
+}
+
+// ParsePK parses a public key
+func ParsePK(cmdFlags *pflag.FlagSet, name, v string) cipher.PubKey {
+	var pk cipher.PubKey
+	Catch(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, pk.Set(v)))
+	return pk
+}
+
+// ParseUUID parses a uuid
+func ParseUUID(cmdFlags *pflag.FlagSet, name, v string) uuid.UUID {
+	id, err := uuid.Parse(v)
+	Catch(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
+	return id
+}
+
+// CLIOutput ss
+type CLIOutput struct {
+	Output interface{} `json:"output,omitempty"`
+	Err    string      `json:"error,omitempty"`
+}
+
+// PrintOutput ss
+func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
+	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
+	if isJSON {
+		outputJSON := CLIOutput{
+			Output: outputJSON,
+		}
+		b, err := json.MarshalIndent(outputJSON, "", "  ")
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Print(string(b) + "\n")
+		return
+	}
+	fmt.Println(output)
 }

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -47,14 +47,17 @@ type CLIOutput struct {
 }
 
 // PrintOutput ss
-func PrintOutput(output CLIOutput, isJSON bool) {
+func PrintOutput(output interface{}, isJSON bool) {
 	if isJSON {
-		b, err := json.MarshalIndent(output, "", "  ")
+		outputJSON := CLIOutput{
+			Output: output,
+		}
+		b, err := json.MarshalIndent(outputJSON, "", "  ")
 		if err != nil {
 			fmt.Println(err)
 		}
 		fmt.Print(string(b) + "\n")
 		return
 	}
-	fmt.Println(output.Output)
+	fmt.Println(output)
 }

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -19,6 +19,13 @@ var JSONString = "json"
 
 // Catch handles errors for skywire-cli commands packages
 func Catch(cmdFlags *pflag.FlagSet, err error) {
+	if err != nil {
+		PrintError(cmdFlags, err)
+	}
+}
+
+// PrintError prints errors for skywire-cli commands packages
+func PrintError(cmdFlags *pflag.FlagSet, err error) {
 	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
 	if isJSON {
 		errJSON := CLIOutput{
@@ -30,7 +37,6 @@ func Catch(cmdFlags *pflag.FlagSet, err error) {
 		}
 		fmt.Print(string(b) + "\n")
 		os.Exit(1)
-		return
 	}
 	log.Fatal(err)
 }

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/logging"
@@ -13,8 +14,8 @@ import (
 
 var log = logging.MustGetLogger("skywire-cli")
 
-// JSONOutput prints the cli output in json if true
-var JSONOutput bool
+// JSONString is the name of the json flag
+var JSONString = "json"
 
 // Catch handles errors for skywire-cli commands packages
 func Catch(err error, msgs ...string) {
@@ -48,7 +49,8 @@ type CLIOutput struct {
 }
 
 // PrintOutput ss
-func PrintOutput(output interface{}, isJSON bool) {
+func PrintOutput(output interface{}, cmdFlags *pflag.FlagSet) {
+	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
 	if isJSON {
 		outputJSON := CLIOutput{
 			Output: output,
@@ -64,7 +66,8 @@ func PrintOutput(output interface{}, isJSON bool) {
 }
 
 // PrintFatalError ss
-func PrintFatalError(err error, logger *logging.Logger, isJSON bool) {
+func PrintFatalError(err error, logger *logging.Logger, cmdFlags *pflag.FlagSet) {
+	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
 	if isJSON {
 		errJSON := CLIOutput{
 			Err: err.Error(),

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 
@@ -60,4 +61,21 @@ func PrintOutput(output interface{}, isJSON bool) {
 		return
 	}
 	fmt.Println(output)
+}
+
+// PrintFatalError ss
+func PrintFatalError(err error, logger *logging.Logger, isJSON bool) {
+	if isJSON {
+		errJSON := CLIOutput{
+			Err: err.Error(),
+		}
+		b, err := json.MarshalIndent(errJSON, "", "  ")
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Print(string(b) + "\n")
+		os.Exit(1)
+		return
+	}
+	logger.Fatal(err)
 }

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -75,5 +75,7 @@ func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
 		fmt.Print(string(b) + "\n")
 		return
 	}
-	fmt.Println(output)
+	if output != "" {
+		fmt.Print(output)
+	}
 }

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -49,11 +49,11 @@ type CLIOutput struct {
 }
 
 // PrintOutput ss
-func PrintOutput(output interface{}, cmdFlags *pflag.FlagSet) {
+func PrintOutput(outputJSON, output interface{}, cmdFlags *pflag.FlagSet) {
 	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
 	if isJSON {
 		outputJSON := CLIOutput{
-			Output: output,
+			Output: outputJSON,
 		}
 		b, err := json.MarshalIndent(outputJSON, "", "  ")
 		if err != nil {

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -10,6 +11,9 @@ import (
 )
 
 var log = logging.MustGetLogger("skywire-cli")
+
+// JSONOutput prints the cli output in json if true
+var JSONOutput bool
 
 // Catch handles errors for skywire-cli commands packages
 func Catch(err error, msgs ...string) {
@@ -34,4 +38,23 @@ func ParseUUID(name, v string) uuid.UUID {
 	id, err := uuid.Parse(v)
 	Catch(err, fmt.Sprintf("failed to parse <%s>:", name))
 	return id
+}
+
+// CLIOutput ss
+type CLIOutput struct {
+	Output interface{} `json:"output,omitempty"`
+	Err    string      `json:"error,omitempty"`
+}
+
+// PrintOutput ss
+func PrintOutput(output CLIOutput, isJSON bool) {
+	if isJSON {
+		b, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Print(string(b) + "\n")
+		return
+	}
+	fmt.Println(output.Output)
 }

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/james-barrow/golang-ipc v0.0.0-20210227130457-95e7cc81f5e2
 	github.com/skycoin/skywire-utilities v0.0.0-20220712142443-abafa30105ce
 	github.com/skycoin/systray v1.10.1-0.20220630135132-48d2a1fb85d8
+	github.com/spf13/pflag v1.0.5
 )
 
 require (
@@ -72,7 +73,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/tevino/abool v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.4 // indirect


### PR DESCRIPTION
Did you run `make format && make check`?
yes

Fixes #	

 Changes:	
- Added global flag `--json` to skywire-cli
- Updated `skywire-cli visor route add-rule` 
- Removed depreciated flag `--public` from `skywire-cli visor tp add`

How to test this PR:
1. Test output of all subcommands under `skywire-cli dmsgpty` with and without `--json` flag
2. Test output of all subcommands under `skywire-cli visor` with and without `--json` flag
3. Test output of all subcommands under `skywire-cli vpn` with and without `--json` flag
4. Test output of all subcommands under `skywire-cli rtfind` with and without `--json` flag
5. Test output of all subcommands under `skywire-cli mdisc` with and without `--json` flag