### PR TITLE
Fix UI update button

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/skycoin/skywire-utilities v0.0.0-20220712142443-abafa30105ce
 	github.com/skycoin/systray v1.10.1-0.20220630135132-48d2a1fb85d8
 	github.com/spf13/pflag v1.0.5
+	periph.io/x/periph v3.6.8+incompatible
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1056,6 +1056,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 nhooyr.io/websocket v1.8.2 h1:LwdzfyyOZKtVFoXay6A39Acu03KmidSZ3YUUvPa13PA=
 nhooyr.io/websocket v1.8.2/go.mod h1:LiqdCg1Cu7TPWxEvPjPa0TGYxCsy4pHNTN9gGluwBpQ=
+periph.io/x/periph v3.6.8+incompatible h1:lki0ie6wHtvlilXhIkabdCUQMpb5QN4Fx33yNQdqnaA=
+periph.io/x/periph v3.6.8+incompatible/go.mod h1:EWr+FCIU2dBWz5/wSWeiIUJTriYv9v2j2ENBmgYyy7Y=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/pkg/skyenv/values_darwin.go
+++ b/pkg/skyenv/values_darwin.go
@@ -31,3 +31,8 @@ func UserConfig() PkgConfig {
 	usrconfig.Hypervisor.EnableAuth = true
 	return usrconfig
 }
+
+// UpdateCommand returns the commands which are run when the update button is clicked in the ui
+func UpdateCommand() []string {
+	return `echo "update not implemented for macOS. Download a new version from the release section here: https://github.com/skycoin/skywire/releases"`
+}

--- a/pkg/skyenv/values_darwin.go
+++ b/pkg/skyenv/values_darwin.go
@@ -34,5 +34,5 @@ func UserConfig() PkgConfig {
 
 // UpdateCommand returns the commands which are run when the update button is clicked in the ui
 func UpdateCommand() []string {
-	return `echo "update not implemented for macOS. Download a new version from the release section here: https://github.com/skycoin/skywire/releases"`
+	return []string{`echo "update not implemented for macOS. Download a new version from the release section here: https://github.com/skycoin/skywire/releases"`}
 }

--- a/pkg/skyenv/values_linux.go
+++ b/pkg/skyenv/values_linux.go
@@ -3,6 +3,10 @@
 
 package skyenv
 
+import (
+	"periph.io/x/periph/host/distro"
+)
+
 const (
 	//OS detection at runtime
 	OS = "linux"
@@ -30,4 +34,14 @@ func UserConfig() PkgConfig {
 	usrconfig.Hypervisor.DbPath = HomePath() + "/.skywire/users.db"
 	usrconfig.Hypervisor.EnableAuth = true
 	return usrconfig
+}
+
+// UpdateCommand returns the commands which are run when the update button is clicked in the ui
+func UpdateCommand() []string {
+	if distro.IsArmbian() || distro.IsDebian() || distro.IsRaspbian() || distro.IsUbuntu() {
+		//enabling install-skyire.service and rebooting is required to avoid interrupting an update when the running visor is stopped
+		//install-skywire.service is provided by the skybian package and calls install-skywire.sh
+		return []string{`systemctl enable install-skywire.service && systemctl reboot || echo -e "Resource unavailable.\nPlease update manually as specified here:\nhttps://github.com/skycoin/skywire/wiki/Skywire-Package-Installation"`}
+	}
+	return []string{`echo -e "Update not implemented for this linux distro.\nPlease update skywire the same way you installed it."`}
 }

--- a/pkg/skyenv/values_windows.go
+++ b/pkg/skyenv/values_windows.go
@@ -31,3 +31,8 @@ func UserConfig() PkgConfig {
 	usrconfig.Hypervisor.EnableAuth = true
 	return usrconfig
 }
+
+// UpdateCommand returns the commands which are run when the update button is clicked in the ui
+func UpdateCommand() []string {
+	return `echo "Update not implemented for windows. Download a new version from the release section here: https://github.com/skycoin/skywire/releases"`
+}

--- a/pkg/skyenv/values_windows.go
+++ b/pkg/skyenv/values_windows.go
@@ -34,5 +34,5 @@ func UserConfig() PkgConfig {
 
 // UpdateCommand returns the commands which are run when the update button is clicked in the ui
 func UpdateCommand() []string {
-	return `echo "Update not implemented for windows. Download a new version from the release section here: https://github.com/skycoin/skywire/releases"`
+	return []string{`echo "Update not implemented for windows. Download a new version from the release section here: https://github.com/skycoin/skywire/releases"`}
 }

--- a/vendor/github.com/godbus/dbus/v5/conn.go
+++ b/vendor/github.com/godbus/dbus/v5/conn.go
@@ -432,7 +432,7 @@ func (conn *Conn) inWorker() {
 		case TypeSignal:
 			conn.handleSignal(sequence, msg)
 		case TypeMethodCall:
-conn.handleCall(msg)
+			go conn.handleCall(msg)
 		}
 
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -317,3 +317,6 @@ nhooyr.io/websocket/internal/bpool
 nhooyr.io/websocket/internal/errd
 nhooyr.io/websocket/internal/wsjs
 nhooyr.io/websocket/internal/xsync
+# periph.io/x/periph v3.6.8+incompatible
+## explicit
+periph.io/x/periph/host/distro


### PR DESCRIPTION
The purpose of this PR i to decouple the process which updates the skywire package installation from the running visor process.
With v1.1.0, the update may succeed in terms of the visor restarting on the new version; however, at the moment the process is restarted dpkg has not finished installing the package and was interrupted from doing so. This leaves the system and installation in an unclean state and will require manual intervention from users to fix it.

I have also defined UpdateCommand functions for windows and mac without actually implementing any update for these.

Did you run `make format && make check`?
yes

Depends:
-	[Dmsg PR #187](https://github.com/skycoin/dmsg/pull/187)


Fixes unclean update when UI button is clicked

 Changes:	
-	Add os-specific UpdateCommand functions to pkg/skyenv.
- Remove hardcoded update commands from skycoin/dmsg/pkg/dmsgpty/ui

How to test this PR:

click the update button in the UI.

robust testing is not possible at the moment because updating assumes that you have a package-based installation and the repository configured via the skybian package.

The skywire-install.service is itself working and currently used in the new skybian images
this service and the repository configuration are proided by the skybian package in the apt repo at  [deb.skywire.skycoin.com](https://deb.skywire.skycoin.com/).