### PR TITLE
Add app arg cli subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 1.2.0
 
 ### Added
+- `skywire-cli` subcommand `arg` under `visor app` [#1356](https://github.com/skycoin/skywire/pull/1356)
 
 ### Changed
+- moved `skywire-cli` subcommand `autoconnect` from `visor app` to `visor app arg` [#1356](https://github.com/skycoin/skywire/pull/1356)
 
 ### Removed
 

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -22,9 +22,21 @@ func init() {
 		lsAppsCmd,
 		startAppCmd,
 		stopAppCmd,
-		setAppAutostartCmd,
 		appLogsSinceCmd,
+		argCmd,
 	)
+	argCmd.AddCommand(
+		setAppAutostartCmd,
+		setAppPasscodeCmd,
+		setAppKillswitchCmd,
+		setAppSecureCmd,
+		setAppNetworkInterfaceCmd,
+	)
+}
+
+var argCmd = &cobra.Command{
+	Use:   "arg",
+	Short: "App args",
 }
 
 var appCmd = &cobra.Command{
@@ -99,7 +111,7 @@ var stopAppCmd = &cobra.Command{
 
 var setAppAutostartCmd = &cobra.Command{
 	Use:   "autostart <name> (on|off)",
-	Short: "Autostart app",
+	Short: "Set app autostart",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var autostart bool
@@ -116,9 +128,75 @@ var setAppAutostartCmd = &cobra.Command{
 	},
 }
 
+var setAppKillswitchCmd = &cobra.Command{
+	Use:   "killswitch <name> (on|off)",
+	Short: "Set app killswitch",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var killswitch bool
+		switch args[1] {
+		case "on":
+			killswitch = true
+		case "off":
+			killswitch = false
+		default:
+			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
+		}
+		internal.Catch(cmd.Flags(), clirpc.Client().SetAppKillswitch(args[0], killswitch))
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+	},
+}
+
+var setAppSecureCmd = &cobra.Command{
+	Use:   "secure <name> (on|off)",
+	Short: "Set app secure",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var secure bool
+		switch args[1] {
+		case "on":
+			secure = true
+		case "off":
+			secure = false
+		default:
+			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
+		}
+		internal.Catch(cmd.Flags(), clirpc.Client().SetAppSecure(args[0], secure))
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+	},
+}
+
+var setAppPasscodeCmd = &cobra.Command{
+	Use:   "passcode <name> <passcode>",
+	Short: "Set app passcode.\n\"remove\" is a special arg to remove the passcode",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		passcode := args[1]
+		if args[1] == "remove" {
+			passcode = ""
+		}
+		internal.Catch(cmd.Flags(), clirpc.Client().SetAppPassword(args[0], passcode))
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+	},
+}
+
+var setAppNetworkInterfaceCmd = &cobra.Command{
+	Use:   "netifc <name> <interface>",
+	Short: "Set app network interface.\n\"remove\" is a special arg to remove the netifc",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		netifc := args[1]
+		if args[1] == "remove" {
+			netifc = ""
+		}
+		internal.Catch(cmd.Flags(), clirpc.Client().SetAppNetworkInterface(args[0], netifc))
+		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+	},
+}
+
 var appLogsSinceCmd = &cobra.Command{
 	Use:   "log <name> <timestamp>",
-	Short: "Logs from app since RFC3339Nano-formatted timestamp.\n                    \"beginning\" is a special timestamp to fetch all the logs",
+	Short: "Logs from app since RFC3339Nano-formatted timestamp.\n\"beginning\" is a special timestamp to fetch all the logs",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var t time.Time

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -27,9 +27,9 @@ func init() {
 	)
 	argCmd.AddCommand(
 		setAppAutostartCmd,
-		setAppPasscodeCmd,
 		setAppKillswitchCmd,
 		setAppSecureCmd,
+		setAppPasscodeCmd,
 		setAppNetworkInterfaceCmd,
 	)
 }

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -110,15 +110,15 @@ var stopAppCmd = &cobra.Command{
 }
 
 var setAppAutostartCmd = &cobra.Command{
-	Use:   "autostart <name> (on|off)",
+	Use:   "autostart <name> (true|false)",
 	Short: "Set app autostart",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var autostart bool
 		switch args[1] {
-		case "on":
+		case "true":
 			autostart = true
-		case "off":
+		case "false":
 			autostart = false
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
@@ -129,15 +129,15 @@ var setAppAutostartCmd = &cobra.Command{
 }
 
 var setAppKillswitchCmd = &cobra.Command{
-	Use:   "killswitch <name> (on|off)",
+	Use:   "killswitch <name> (true|false)",
 	Short: "Set app killswitch",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var killswitch bool
 		switch args[1] {
-		case "on":
+		case "true":
 			killswitch = true
-		case "off":
+		case "false":
 			killswitch = false
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
@@ -148,15 +148,15 @@ var setAppKillswitchCmd = &cobra.Command{
 }
 
 var setAppSecureCmd = &cobra.Command{
-	Use:   "secure <name> (on|off)",
+	Use:   "secure <name> (true|false)",
 	Short: "Set app secure",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		var secure bool
 		switch args[1] {
-		case "on":
+		case "true":
 			secure = true
-		case "off":
+		case "false":
 			secure = false
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -490,7 +490,7 @@ func (v *Visor) SetAppNetworkInterface(appName, netifc string) error {
 		return fmt.Errorf("app %s is not allowed to set network interface", appName)
 	}
 
-	v.log.Infof("Changing %s network interface to %q", appName, netifc)
+	v.log.Infof("Changing %s network interface to %v", appName, netifc)
 
 	const (
 		netifcArgName = "--netifc"
@@ -511,7 +511,7 @@ func (v *Visor) SetAppKillswitch(appName string, killswitch bool) error {
 		return fmt.Errorf("app %s is not allowed to set killswitch", appName)
 	}
 
-	v.log.Infof("Setting %s killswitch to %q", appName, killswitch)
+	v.log.Infof("Setting %s killswitch to %v", appName, killswitch)
 
 	const (
 		killSwitchArg = "--killswitch"
@@ -532,7 +532,7 @@ func (v *Visor) SetAppSecure(appName string, isSecure bool) error {
 		return fmt.Errorf("app %s is not allowed to change 'secure' parameter", appName)
 	}
 
-	v.log.Infof("Setting %s secure to %q", appName, isSecure)
+	v.log.Infof("Setting %s secure to %v", appName, isSecure)
 
 	const (
 		secureArgName = "--secure"


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #	

 Changes:	
- Added subcommand `arg` to `skywire-cli visor app`
- Moved subcommand `autoconnect` from `skywire-cli visor app` to `skywire-cli visor app arg`

How to test this PR:
1. Run a visor `./skywire-visor -c skywire-config.json`
2. Run the command `./skywire-cli visor app arg passcode vpn-client test` and check the config
3. Run the command `./skywire-cli visor app arg passcode vpn-client remove` and check the config
4. Run the command `./skywire-cli visor app arg netifc vpn-server test` and check the config
5. Run the command `./skywire-cli visor app arg netifc vpn-server remove` and check the config
6. Run the command `./skywire-cli visor app arg autostart vpn-server true` and check the config
7. Run the command `./skywire-cli visor app arg killswitch vpn-server true` and check the config
8. Run the command `./skywire-cli visor app arg secure vpn-server true` and check the config
9. Run the command `./skywire-cli visor app arg autostart vpn-server false` and check the config
10. Run the command `./skywire-cli visor app arg killswitch vpn-server false` and check the config
11. Run the command `./skywire-cli visor app arg secure vpn-server false` and check the config