### PR TITLE
Fix the auth problems with the UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.component.html
+++ b/static/skywire-manager-src/src/app/app.component.html
@@ -7,6 +7,6 @@
 </div>
 <div class="flex-1 content container-fluid">
   <div [ngClass]="{'background': inVpnClient}"></div>
-  <router-outlet *ngIf="hypervisorPkObtained"></router-outlet>
-  <app-loading-indicator class="h-100" *ngIf="!hypervisorPkObtained"></app-loading-indicator>
+  <router-outlet *ngIf="hypervisorPkObtained || inLoginPage"></router-outlet>
+  <app-loading-indicator class="h-100" *ngIf="!hypervisorPkObtained && !inLoginPage"></app-loading-indicator>
 </div>

--- a/static/skywire-manager-src/src/app/components/pages/login/login.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/login/login.component.ts
@@ -10,6 +10,7 @@ import { SnackbarService } from '../../../services/snackbar.service';
 import { InitialSetupComponent } from './initial-setup/initial-setup.component';
 import { OperationError } from '../../../utils/operation-error';
 import { processServiceError } from '../../../utils/errors';
+import { AppComponent } from 'src/app/app.component';
 
 /**
  * Login page.
@@ -46,8 +47,12 @@ export class LoginComponent implements OnInit, OnDestroy {
       // Check if the user is already logged.
       this.verificationSubscription = this.authService.checkLogin().subscribe(response => {
         if (response !== AuthStates.NotLogged) {
-          const destination = !this.isForVpn ? ['nodes'] : ['vpn', this.vpnKey, 'status'];
-          this.router.navigate(destination, { replaceUrl: true });
+          // Inform about the redirect a frame before it is done, to avoid problems.
+          AppComponent.currentInstance.processLoginDone();
+          setTimeout(() => {
+            const destination = !this.isForVpn ? ['nodes'] : ['vpn', this.vpnKey, 'status'];
+            this.router.navigate(destination, { replaceUrl: true });
+          });
         }
       });
     });
@@ -83,8 +88,12 @@ export class LoginComponent implements OnInit, OnDestroy {
   }
 
   private onLoginSuccess() {
-    const destination = !this.isForVpn ? ['nodes'] : ['vpn', this.vpnKey, 'status'];
-    this.router.navigate(destination, { replaceUrl: true });
+    // Inform about the redirect a frame before it is done, to avoid problems.
+    AppComponent.currentInstance.processLoginDone();
+    setTimeout(() => {
+      const destination = !this.isForVpn ? ['nodes'] : ['vpn', this.vpnKey, 'status'];
+      this.router.navigate(destination, { replaceUrl: true });
+    });
   }
 
   private onLoginError(err: OperationError) {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

Fixes #1357

 Changes:	
- Now the UI works well when auth is enabled in the hypervisor.

How to test this PR:
Use the UI while auth is enable on the Hypervisor.