### PR TITLE
Fix StartVPNCient logic

### DIFF
--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -10,6 +10,7 @@ import (
 	"github.com/toqueteos/webbrowser"
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -139,7 +140,10 @@ var vpnStartCmd = &cobra.Command{
 	Short: "start the vpn for <public-key>",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client().StartVPNClient(args[0]))
+
+		var pk cipher.PubKey
+		internal.Catch(cmd.Flags(), pk.Set(args[0]))
+		internal.Catch(cmd.Flags(), clirpc.Client().StartVPNClient(pk))
 		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -368,33 +368,41 @@ func (v *Visor) StartVPNClient(pubkey string) error {
 	if v.tpM == nil {
 		return ErrTrpMangerNotAvailable
 	}
-	if len(v.conf.Launcher.Apps) > 0 {
-		v.conf.Launcher.Apps[0].Args = []string{"-srv", pubkey}
-	} else {
+
+	if len(v.conf.Launcher.Apps) == 0 {
 		return errors.New("no vpn app configuration found")
 	}
-	maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.STCPRRemoteAddrs())
-	envs, err = maker()
-	if err != nil {
-		return err
-	}
 
-	if v.GetVPNClientAddress() == "" {
-		return errors.New("VPN server pub key is missing")
-	}
-	var pk cipher.PubKey
-	err = pk.Set(pubkey)
-	if err != nil {
-		return err
-	}
+	for index, app := range v.conf.Launcher.Apps {
+		if app.Name == skyenv.VPNClientName {
+			// we set the args in memory and pass it in `v.appL.StartApp`
+			// unlike the api method `StartApp` where `nil` is passed in `v.appL.StartApp` as args
+			// but the args are set in the config
+			v.conf.Launcher.Apps[index].Args = []string{"-srv", pubkey}
+			maker := vpnEnvMaker(v.conf, v.dmsgC, v.dmsgDC, v.tpM.STCPRRemoteAddrs())
+			envs, err = maker()
+			if err != nil {
+				return err
+			}
 
-	getRouteSetupHooks(context.Background(), v, v.log)
-	// check process manager availability
-	if v.procM != nil {
-		return v.appL.StartApp(skyenv.VPNClientName, v.conf.Launcher.Apps[0].Args, envs)
-		//		return v.appL.StartApp(skyenv.VPNClientName, v.conf.Launcher.Apps[appindex].Args, envs)
+			if v.GetVPNClientAddress() == "" {
+				return errors.New("VPN server pub key is missing")
+			}
+
+			var pk cipher.PubKey
+			err = pk.Set(pubkey)
+			if err != nil {
+				return err
+			}
+
+			// check process manager availability
+			if v.procM != nil {
+				return v.appL.StartApp(skyenv.VPNClientName, v.conf.Launcher.Apps[index].Args, envs)
+			}
+			return ErrProcNotAvailable
+		}
 	}
-	return ErrProcNotAvailable
+	return errors.New("no vpn app configuration found")
 }
 
 // StopVPNClient implements API.

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -220,10 +220,10 @@ func (r *RPC) StopApp(name *string, _ *struct{}) (err error) {
 }
 
 // StartVPNClient starts VPNClient App
-func (r *RPC) StartVPNClient(pubkey *string, _ *struct{}) (err error) {
-	defer rpcutil.LogCall(r.log, "StartApp", pubkey)(nil, &err)
+func (r *RPC) StartVPNClient(pk *cipher.PubKey, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "StartApp", pk)(nil, &err)
 
-	return r.visor.StartVPNClient(*pubkey)
+	return r.visor.StartVPNClient(*pk)
 }
 
 // StopVPNClient stops VPNClient App

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -145,8 +145,8 @@ func (rc *rpcClient) StopApp(appName string) error {
 }
 
 // StartVPNClient calls StartVPNClient.
-func (rc *rpcClient) StartVPNClient(pubkey string) error {
-	return rc.Call("StartVPNClient", &pubkey, &struct{}{})
+func (rc *rpcClient) StartVPNClient(pk cipher.PubKey) error {
+	return rc.Call("StartVPNClient", &pk, &struct{}{})
 }
 
 // StopVPNClient calls StopVPNClient.
@@ -647,7 +647,7 @@ func (*mockRPCClient) StopApp(string) error {
 }
 
 // StartVPNClient implements API.
-func (*mockRPCClient) StartVPNClient(string) error {
+func (*mockRPCClient) StartVPNClient(cipher.PubKey) error {
 	return nil
 }
 


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #1359 (only fixes the logic in StartVPNCient)

 Changes:	
- Updated `StartVPNCient`

How to test this PR:
1. Start `vpn-server`
2. Start `vpn-client`
3. From the machine with `vpn-client` run `skywire-cli vpn start <server-pk>` cnad see if it works
4. Change the order of apps in the `visor-config.json` and try agan