### PR TITLE
Fix rpc error in cli for json

### DIFF
--- a/cmd/skywire-cli/commands/dmsgpty/hvdmsg.go
+++ b/cmd/skywire-cli/commands/dmsgpty/hvdmsg.go
@@ -28,7 +28,7 @@ func init() {
 var dmsgUICmd = &cobra.Command{
 	Use:   "ui",
 	Short: "Open dmsgpty UI in default browser",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		if pk == "" {
 			if pkg {
 				path = visorconfig.Pkgpath
@@ -40,7 +40,7 @@ var dmsgUICmd = &cobra.Command{
 				}
 				url = fmt.Sprintf("http://127.0.0.1:8000/pty/%s", conf.PK.Hex())
 			} else {
-				client := rpcClient()
+				client := rpcClient(cmd.Flags())
 				overview, err := client.Overview()
 				if err != nil {
 					log.Fatal("Failed to connect; is skywire running?\n", err)
@@ -71,7 +71,7 @@ var dmsgURLCmd = &cobra.Command{
 				}
 				url = fmt.Sprintf("http://127.0.0.1:8000/pty/%s", conf.PK.Hex())
 			} else {
-				client := rpcClient()
+				client := rpcClient(cmd.Flags())
 				overview, err := client.Overview()
 				if err != nil {
 					internal.Catch(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))

--- a/cmd/skywire-cli/commands/dmsgpty/root.go
+++ b/cmd/skywire-cli/commands/dmsgpty/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/skycoin/dmsg/pkg/dmsgpty"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire-utilities/pkg/logging"
@@ -50,7 +51,7 @@ var visorsCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List connected visors",
 	Run: func(cmd *cobra.Command, _ []string) {
-		remoteVisors, err := rpcClient().RemoteVisors()
+		remoteVisors, err := rpcClient(cmd.Flags()).RemoteVisors()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
 		}
@@ -77,11 +78,11 @@ var shellCmd = &cobra.Command{
 	},
 }
 
-func rpcClient() visor.API {
+func rpcClient(cmdFlags *pflag.FlagSet) visor.API {
 	const rpcDialTimeout = time.Second * 5
 	conn, err := net.DialTimeout("tcp", rpcAddr, rpcDialTimeout)
 	if err != nil {
-		packageLogger.Fatal("RPC connection failed; is skywire running?\n", err)
+		internal.PrintFatalError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
 	}
 	return visor.NewRPCClient(packageLogger, conn, visor.RPCPrefix, 0)
 }

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -2,11 +2,14 @@
 package clirpc
 
 import (
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/skycoin/skywire-utilities/pkg/logging"
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -16,11 +19,11 @@ var (
 )
 
 // Client is used by other skywire-cli commands to query the visor rpc
-func Client() visor.API {
+func Client(cmdFlags *pflag.FlagSet) visor.API {
 	const rpcDialTimeout = time.Second * 5
 	conn, err := net.DialTimeout("tcp", Addr, rpcDialTimeout)
 	if err != nil {
-		logger.Fatal("RPC connection failed; is skywire running?\n", err)
+		internal.PrintFatalError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
 	}
 	return visor.NewRPCClient(logger, conn, visor.RPCPrefix, 0)
 }

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skycoin/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor"
+
 	"github.com/spf13/pflag"
 )
 

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -48,7 +48,7 @@ var lsAppsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List apps",
 	Run: func(cmd *cobra.Command, _ []string) {
-		states, err := clirpc.Client().Apps()
+		states, err := clirpc.Client(cmd.Flags()).Apps()
 		internal.Catch(cmd.Flags(), err)
 		var b bytes.Buffer
 		w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
@@ -94,7 +94,7 @@ var startAppCmd = &cobra.Command{
 	Short: "Launch app",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client().StartApp(args[0]))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).StartApp(args[0]))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -104,7 +104,7 @@ var stopAppCmd = &cobra.Command{
 	Short: "Halt app",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client().StopApp(args[0]))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).StopApp(args[0]))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -123,7 +123,7 @@ var setAppAutostartCmd = &cobra.Command{
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client().SetAutoStart(args[0], autostart))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAutoStart(args[0], autostart))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -142,7 +142,7 @@ var setAppKillswitchCmd = &cobra.Command{
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client().SetAppKillswitch(args[0], killswitch))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppKillswitch(args[0], killswitch))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -161,7 +161,7 @@ var setAppSecureCmd = &cobra.Command{
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client().SetAppSecure(args[0], secure))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppSecure(args[0], secure))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -175,7 +175,7 @@ var setAppPasscodeCmd = &cobra.Command{
 		if args[1] == "remove" {
 			passcode = ""
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client().SetAppPassword(args[0], passcode))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppPassword(args[0], passcode))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -189,7 +189,7 @@ var setAppNetworkInterfaceCmd = &cobra.Command{
 		if args[1] == "remove" {
 			netifc = ""
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client().SetAppNetworkInterface(args[0], netifc))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppNetworkInterface(args[0], netifc))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -208,7 +208,7 @@ var appLogsSinceCmd = &cobra.Command{
 			t, err = time.Parse(time.RFC3339Nano, strTime)
 			internal.Catch(cmd.Flags(), err)
 		}
-		logs, err := clirpc.Client().LogsSince(t, args[0])
+		logs, err := clirpc.Client(cmd.Flags()).LogsSince(t, args[0])
 		internal.Catch(cmd.Flags(), err)
 		if len(logs) > 0 {
 			internal.PrintOutput(cmd.Flags(), logs, fmt.Sprintf("%v\n", logs))

--- a/cmd/skywire-cli/commands/visor/exec.go
+++ b/cmd/skywire-cli/commands/visor/exec.go
@@ -20,7 +20,7 @@ var execCmd = &cobra.Command{
 	Short: "Execute a command",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		out, err := clirpc.Client().Exec(strings.Join(args, " "))
+		out, err := clirpc.Client(cmd.Flags()).Exec(strings.Join(args, " "))
 		internal.Catch(cmd.Flags(), err)
 		// since the output of this command can be anything it is not formatted, so it's advisable to not use the `--json` flag for this one
 		internal.PrintOutput(cmd.Flags(), string(out), string(out))

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -49,7 +49,7 @@ var pkCmd = &cobra.Command{
 			}
 			outputPK = conf.PK.Hex()
 		} else {
-			client := clirpc.Client()
+			client := clirpc.Client(cmd.Flags())
 			overview, err := client.Overview()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
@@ -83,7 +83,7 @@ var hvpkCmd = &cobra.Command{
 			}
 			hypervisors = conf.Hypervisors
 		} else {
-			client := clirpc.Client()
+			client := clirpc.Client(cmd.Flags())
 			overview, err := client.Overview()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
@@ -98,7 +98,7 @@ var chvpkCmd = &cobra.Command{
 	Use:   "chvpk",
 	Short: "Public key of connected hypervisors",
 	Run: func(cmd *cobra.Command, _ []string) {
-		client := clirpc.Client()
+		client := clirpc.Client(cmd.Flags())
 		overview, err := client.Overview()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
@@ -111,7 +111,7 @@ var summaryCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Summary of visor info",
 	Run: func(cmd *cobra.Command, _ []string) {
-		summary, err := clirpc.Client().Summary()
+		summary, err := clirpc.Client(cmd.Flags()).Summary()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
@@ -150,7 +150,7 @@ var buildInfoCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Version and build info",
 	Run: func(cmd *cobra.Command, _ []string) {
-		client := clirpc.Client()
+		client := clirpc.Client(cmd.Flags())
 		overview, err := client.Overview()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))

--- a/cmd/skywire-cli/commands/visor/route.go
+++ b/cmd/skywire-cli/commands/visor/route.go
@@ -47,7 +47,7 @@ var lsRulesCmd = &cobra.Command{
 	Use:   "ls-rules",
 	Short: "List routing rules",
 	Run: func(cmd *cobra.Command, _ []string) {
-		rules, err := clirpc.Client().RoutingRules()
+		rules, err := clirpc.Client(cmd.Flags()).RoutingRules()
 		internal.Catch(cmd.Flags(), err)
 
 		printRoutingRules(cmd.Flags(), rules...)
@@ -62,7 +62,7 @@ var ruleCmd = &cobra.Command{
 		id, err := strconv.ParseUint(args[0], 10, 32)
 		internal.Catch(cmd.Flags(), err)
 
-		rule, err := clirpc.Client().RoutingRule(routing.RouteID(id))
+		rule, err := clirpc.Client(cmd.Flags()).RoutingRule(routing.RouteID(id))
 		internal.Catch(cmd.Flags(), err)
 
 		printRoutingRules(cmd.Flags(), rule)
@@ -76,7 +76,7 @@ var rmRuleCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		id, err := strconv.ParseUint(args[0], 10, 32)
 		internal.Catch(cmd.Flags(), err)
-		internal.Catch(cmd.Flags(), clirpc.Client().RemoveRoutingRule(routing.RouteID(id)))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).RemoveRoutingRule(routing.RouteID(id)))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -115,7 +115,7 @@ var addAppRuleCmd = &cobra.Command{
 			rIDKey = rule.KeyRouteID()
 		}
 
-		internal.Catch(cmd.Flags(), clirpc.Client().SaveRoutingRule(rule))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SaveRoutingRule(rule))
 
 		output := struct {
 			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
@@ -156,7 +156,7 @@ var addFwdRuleCmd = &cobra.Command{
 			rIDKey = rule.KeyRouteID()
 		}
 
-		internal.Catch(cmd.Flags(), clirpc.Client().SaveRoutingRule(rule))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SaveRoutingRule(rule))
 
 		output := struct {
 			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
@@ -193,7 +193,7 @@ var addIntFwdRuleCmd = &cobra.Command{
 			rIDKey = rule.KeyRouteID()
 		}
 
-		internal.Catch(cmd.Flags(), clirpc.Client().SaveRoutingRule(rule))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SaveRoutingRule(rule))
 
 		output := struct {
 			RoutingRuleKey routing.RouteID `json:"routing_route_key"`

--- a/cmd/skywire-cli/commands/visor/shutdown.go
+++ b/cmd/skywire-cli/commands/visor/shutdown.go
@@ -17,7 +17,7 @@ var shutdownCmd = &cobra.Command{
 	Use:   "halt",
 	Short: "Stop a running visor",
 	Run: func(cmd *cobra.Command, args []string) {
-		clirpc.Client().Shutdown() //nolint
+		clirpc.Client(cmd.Flags()).Shutdown() //nolint
 		fmt.Println("Visor was shut down")
 		internal.PrintOutput(cmd.Flags(), "Visor was shut down", fmt.Sprintln("Visor was shut down"))
 	},

--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -61,7 +61,7 @@ var tpCmd = &cobra.Command{
 var lsTypesCmd = &cobra.Command{
 	Use: "type", Short: "Transport types used by the local visor",
 	Run: func(cmd *cobra.Command, _ []string) {
-		types, err := clirpc.Client().TransportTypes()
+		types, err := clirpc.Client(cmd.Flags()).TransportTypes()
 		internal.Catch(cmd.Flags(), err)
 		internal.PrintOutput(cmd.Flags(), types, fmt.Sprintln(strings.Join(types, "\n")))
 	},
@@ -77,7 +77,7 @@ var lsTpCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "Available transports",
 	Run: func(cmd *cobra.Command, _ []string) {
-		transports, err := clirpc.Client().Transports(filterTypes, filterPubKeys, showLogs)
+		transports, err := clirpc.Client(cmd.Flags()).Transports(filterTypes, filterPubKeys, showLogs)
 		internal.Catch(cmd.Flags(), err)
 		PrintTransports(cmd.Flags(), transports...)
 	},
@@ -89,7 +89,7 @@ var idCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		tpID := internal.ParseUUID(cmd.Flags(), "transport-id", args[0])
-		tp, err := clirpc.Client().Transport(tpID)
+		tp, err := clirpc.Client(cmd.Flags()).Transport(tpID)
 		internal.Catch(cmd.Flags(), err)
 		PrintTransports(cmd.Flags(), tp)
 	},
@@ -124,7 +124,7 @@ var addTpCmd = &cobra.Command{
 		var err error
 
 		if transportType != "" {
-			tp, err = clirpc.Client().AddTransport(pk, transportType, timeout)
+			tp, err = clirpc.Client(cmd.Flags()).AddTransport(pk, transportType, timeout)
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to establish %v transport: %v", transportType, err))
 			}
@@ -139,7 +139,7 @@ var addTpCmd = &cobra.Command{
 				network.STCP,
 			}
 			for _, transportType := range transportTypes {
-				tp, err = clirpc.Client().AddTransport(pk, string(transportType), timeout)
+				tp, err = clirpc.Client(cmd.Flags()).AddTransport(pk, string(transportType), timeout)
 				if err == nil {
 					if !isJSON {
 						logger.Infof("Established %v transport to %v", transportType, pk)
@@ -161,7 +161,7 @@ var rmTpCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		tID := internal.ParseUUID(cmd.Flags(), "transport-id", args[0])
-		internal.Catch(cmd.Flags(), clirpc.Client().RemoveTransport(tID))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).RemoveTransport(tID))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -231,7 +231,7 @@ var discTpCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, _ []string) {
 
-		if rc := clirpc.Client(); tpPK.Null() {
+		if rc := clirpc.Client(cmd.Flags()); tpPK.Null() {
 			entry, err := rc.DiscoverTransportByID(uuid.UUID(tpID))
 			internal.Catch(cmd.Flags(), err)
 			PrintTransportEntries(cmd.Flags(), entry)

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -54,7 +54,7 @@ var vpnUICmd = &cobra.Command{
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", conf.PK.Hex())
 		} else {
-			client := clirpc.Client()
+			client := clirpc.Client(cmd.Flags())
 			overview, err := client.Overview()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
@@ -82,7 +82,7 @@ var vpnURLCmd = &cobra.Command{
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", conf.PK.Hex())
 		} else {
-			client := clirpc.Client()
+			client := clirpc.Client(cmd.Flags())
 			overview, err := client.Overview()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
@@ -104,7 +104,7 @@ var vpnListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List public VPN servers",
 	Run: func(cmd *cobra.Command, _ []string) {
-		client := clirpc.Client()
+		client := clirpc.Client(cmd.Flags())
 		if isUnFiltered {
 			ver = ""
 			country = ""
@@ -139,7 +139,7 @@ var vpnStartCmd = &cobra.Command{
 	Short: "start the vpn for <public-key>",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client().StartVPNClient(args[0]))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).StartVPNClient(args[0]))
 		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }
@@ -148,7 +148,7 @@ var vpnStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "stop the vpn",
 	Run: func(cmd *cobra.Command, _ []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client().StopVPNClient("vpn-client"))
+		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).StopVPNClient("vpn-client"))
 		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }
@@ -157,7 +157,7 @@ var vpnStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "vpn status",
 	Run: func(cmd *cobra.Command, _ []string) {
-		states, err := clirpc.Client().Apps()
+		states, err := clirpc.Client(cmd.Flags()).Apps()
 		internal.Catch(cmd.Flags(), err)
 
 		var b bytes.Buffer


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #	

 Changes:	
- Fixed rpc error

How to test this PR:
1. Run `./skywire-cli vpn --rpc visor-b:3435 start 024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7 --json`