### PR TITLE
Fix transport logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `skywire-cli` subcommand `arg` under `visor app` [#1356](https://github.com/skycoin/skywire/pull/1356)
-- `log_rotation_interval` field to config [#1374](https://github.com/skycoin/skywire/pull/1374)
+- `log_store` field to `transport` in config [#1386](https://github.com/skycoin/skywire/pull/1386)
+- `type`, `location`, `rotation_interval`, field to `log_store` inside `transport` in config [#1374](https://github.com/skycoin/skywire/pull/1374)
+- transport file logging to CSV [#1374](https://github.com/skycoin/skywire/pull/1374)
+- transport file logging to CSV [#1374](https://github.com/skycoin/skywire/pull/1374)
+- dmsghttp server [#1364](https://github.com/skycoin/skywire/issues/1364)
 
 ### Changed
 - moved `skywire-cli` subcommand `autoconnect` from `visor app` to `visor app arg` [#1356](https://github.com/skycoin/skywire/pull/1356)

--- a/pkg/servicedisc/types.go
+++ b/pkg/servicedisc/types.go
@@ -124,14 +124,14 @@ type Service struct {
 	Geo       *geo.LocationData `json:"geo,omitempty" gorm:"embedded"`
 	Version   string            `json:"version,omitempty"`
 	LocalIPs  pq.StringArray    `json:"local_ips,omitempty" gorm:"type:text[]"`
-	Info      VPNInfo           `json:"info,omitempty" gorm:"-"`
+	Info      *VPNInfo          `json:"info,omitempty" gorm:"-"`
 }
 
 // VPNInfo used for showing VPN metrics info, like latency, uptime and count of connections
 type VPNInfo struct {
-	Latency     float64
-	Uptime      float64
-	Connections int
+	Latency     float64 `json:"latency,omitempty"`
+	Uptime      float64 `json:"uptime,omitempty"`
+	Connections int     `json:"connections,omitempty"`
 }
 
 // MarshalBinary implements encoding.BinaryMarshaller

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -23,7 +23,7 @@ type CsvEntry struct {
 	TpID uuid.UUID `csv:"tp_id"`
 	// atomic requires 64-bit alignment for struct field access
 	LogEntry
-	TimeStamp time.Time `csv:"time_stamp"` // TimeStamp should be time.RFC3339Nano formatted
+	TimeStamp int64 `csv:"time_stamp"` // TimeStamp should be time.RFC3339Nano formatted
 }
 
 // LogEntry represents a logging entry for a given Transport.
@@ -159,7 +159,7 @@ func (tls *fileTransportLogStore) Record(id uuid.UUID, entry *LogEntry) error {
 	cEntry := &CsvEntry{
 		TpID:      id,
 		LogEntry:  *entry,
-		TimeStamp: time.Now().UTC(),
+		TimeStamp: time.Now().UTC().Unix(),
 	}
 
 	return tls.writeToCSV(cEntry)

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -135,7 +135,7 @@ func FileTransportLogStore(dir string) (LogStore, error) {
 }
 
 func (tls *fileTransportLogStore) Entry(tpID uuid.UUID) (*LogEntry, error) {
-	entries, err := tls.readFromCSV(tls.today())
+	entries, err := tls.readFromCSV(tls.todayFileName())
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (tls *fileTransportLogStore) Record(id uuid.UUID, entry *LogEntry) error {
 }
 
 func (tls *fileTransportLogStore) writeToCSV(cEntry *CsvEntry) error {
-	f, err := os.OpenFile(filepath.Join(tls.dir, fmt.Sprintf("%s.csv", tls.today())), os.O_RDWR|os.O_CREATE, os.ModePerm)
+	f, err := os.OpenFile(filepath.Join(tls.dir, fmt.Sprint(tls.todayFileName())), os.O_RDWR|os.O_CREATE, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -228,6 +228,6 @@ func (tls *fileTransportLogStore) readFromCSV(fileName string) ([]*CsvEntry, err
 	return readClients, nil
 }
 
-func (tls *fileTransportLogStore) today() string {
-	return time.Now().UTC().Format("2006-01-02")
+func (tls *fileTransportLogStore) todayFileName() string {
+	return fmt.Sprintf("%s.csv", time.Now().UTC().Format("2006-01-02"))
 }

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -165,7 +165,7 @@ func (tls *fileTransportLogStore) writeToCSV(cEntry *CsvEntry) error {
 
 	defer func() {
 		if err := f.Close(); err != nil {
-			tls.log.WithError(err).Errorln("Failed to close hypervisor response body")
+			tls.log.WithError(err).Errorln("Failed to close csv file")
 		}
 	}()
 
@@ -216,7 +216,7 @@ func (tls *fileTransportLogStore) readFromCSV(fileName string) ([]*CsvEntry, err
 
 	defer func() {
 		if err := f.Close(); err != nil {
-			tls.log.WithError(err).Errorln("Failed to close hypervisor response body")
+			tls.log.WithError(err).Errorln("Failed to close csv file")
 		}
 	}()
 

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -6,7 +6,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -159,11 +158,10 @@ type fileTransportLogStore struct {
 }
 
 // FileTransportLogStore implements file TransportLogStore.
-func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration) (LogStore, error) {
+func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
 	if err := os.MkdirAll(dir, 0644); err != nil {
 		return nil, err
 	}
-	log := logging.MustGetLogger("transport")
 
 	fLogStore := &fileTransportLogStore{
 		dir: dir,
@@ -305,7 +303,7 @@ func (tls *fileTransportLogStore) readFromCSV(fileName string) ([]*CsvEntry, err
 // CleanLogs cleans the logs that are older than the given log rotation interval
 func (tls *fileTransportLogStore) cleanLogs(rInterval time.Duration) {
 
-	files, err := ioutil.ReadDir(tls.dir)
+	files, err := os.ReadDir(tls.dir)
 	if err != nil {
 		tls.log.Warn(err)
 	}

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -176,16 +176,20 @@ func (tls *fileTransportLogStore) writeToCSV(cEntry *CsvEntry) error {
 		return err
 	}
 
-	if len(readClients) == 0 {
-		writeClients = append(writeClients, cEntry)
-	}
-
+	var update bool
 	for _, client := range readClients {
+		// update if readClients contains the cEntry
 		if client.TpID == cEntry.TpID {
 			writeClients = append(writeClients, cEntry)
+			update = true
 			continue
 		}
 		writeClients = append(writeClients, client)
+	}
+
+	// write when the readClients are does not contain cEntry
+	if !update {
+		writeClients = append(writeClients, cEntry)
 	}
 
 	if _, err := f.Seek(0, 0); err != nil { // Go to the start of the file

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -51,7 +51,7 @@ func TestFileTransportLogStore(t *testing.T) {
 	}()
 
 	log := logging.MustGetLogger("transport")
-	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Minute*10, log)
+	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Hour*10, log)
 	require.NoError(t, err)
 	testTransportLogStore(t, ls)
 }

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -1,10 +1,12 @@
 package transport_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +48,7 @@ func TestFileTransportLogStore(t *testing.T) {
 		require.NoError(t, os.RemoveAll(dir))
 	}()
 
-	ls, err := transport.FileTransportLogStore(dir)
+	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Minute*10)
 	require.NoError(t, err)
 	testTransportLogStore(t, ls)
 }

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -51,7 +51,7 @@ func TestFileTransportLogStore(t *testing.T) {
 	}()
 
 	log := logging.MustGetLogger("transport")
-	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Hour*256, log)
+	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Hour*24*7, log)
 	require.NoError(t, err)
 	testTransportLogStore(t, ls)
 }

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -20,12 +20,13 @@ func testTransportLogStore(t *testing.T, logStore transport.LogStore) {
 	t.Helper()
 
 	id1 := uuid.New()
-	entry1 := new(transport.LogEntry)
+
+	entry1 := transport.NewLogEntry()
 	entry1.AddRecv(100)
 	entry1.AddSent(200)
 
 	id2 := uuid.New()
-	entry2 := new(transport.LogEntry)
+	entry2 := transport.NewLogEntry()
 	entry2.AddRecv(300)
 	entry2.AddSent(400)
 
@@ -34,8 +35,8 @@ func testTransportLogStore(t *testing.T, logStore transport.LogStore) {
 
 	entry, err := logStore.Entry(id2)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(300), entry.RecvBytes)
-	assert.Equal(t, uint64(400), entry.SentBytes)
+	assert.Equal(t, uint64(300), *entry.RecvBytes)
+	assert.Equal(t, uint64(400), *entry.SentBytes)
 }
 
 func TestInMemoryTransportLogStore(t *testing.T) {
@@ -56,7 +57,7 @@ func TestFileTransportLogStore(t *testing.T) {
 }
 
 func TestLogEntry_MarshalJSON(t *testing.T) {
-	entry := new(transport.LogEntry)
+	entry := transport.NewLogEntry()
 	entry.AddSent(10)
 	entry.AddRecv(100)
 	b, err := json.Marshal(entry)
@@ -68,7 +69,7 @@ func TestLogEntry_MarshalJSON(t *testing.T) {
 }
 
 func TestLogEntry_GobEncode(t *testing.T) {
-	var entry transport.LogEntry
+	entry := transport.NewLogEntry()
 
 	enc, err := entry.GobEncode()
 	require.NoError(t, err)

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -51,7 +51,7 @@ func TestFileTransportLogStore(t *testing.T) {
 	}()
 
 	log := logging.MustGetLogger("transport")
-	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Hour*10, log)
+	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Hour*256, log)
 	require.NoError(t, err)
 	testTransportLogStore(t, ls)
 }

--- a/pkg/transport/log_test.go
+++ b/pkg/transport/log_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/skycoin/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
@@ -48,7 +49,8 @@ func TestFileTransportLogStore(t *testing.T) {
 		require.NoError(t, os.RemoveAll(dir))
 	}()
 
-	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Minute*10)
+	log := logging.MustGetLogger("transport")
+	ls, err := transport.FileTransportLogStore(context.TODO(), dir, time.Minute*10, log)
 	require.NoError(t, err)
 	testTransportLogStore(t, ls)
 }

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -80,6 +80,8 @@ func NewManagedTransport(conf ManagedTransportConfig) *ManagedTransport {
 	if conf.mlog != nil {
 		log = conf.mlog.PackageLogger(fmt.Sprintf("tp:%s", conf.RemotePK.String()[:6]))
 	}
+	entry := MakeEntry(aPK, bPK, conf.client.Type(), conf.TransportLabel)
+	logEntry := MakeLogEntry(conf.LS, entry.ID, log)
 
 	mt := &ManagedTransport{
 		log:         log,
@@ -87,8 +89,8 @@ func NewManagedTransport(conf ManagedTransportConfig) *ManagedTransport {
 		dc:          conf.DC,
 		ls:          conf.LS,
 		client:      conf.client,
-		Entry:       MakeEntry(aPK, bPK, conf.client.Type(), conf.TransportLabel),
-		LogEntry:    new(LogEntry),
+		Entry:       entry,
+		LogEntry:    logEntry,
 		transportCh: make(chan struct{}, 1),
 		done:        make(chan struct{}),
 		timeout:     conf.InactiveTimeout,

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -354,15 +354,12 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, log *logging.Logger) e
 	}
 	logger := v.MasterLogger().PackageLogger("dmsghttp_logserver")
 
-	tpLogPath := v.conf.LocalPath + "/" + skyenv.TpLogStore
-	customPath := v.conf.LocalPath + "/" + skyenv.Custom
-
 	var printLog bool
 	if v.MasterLogger().GetLevel() == logrus.DebugLevel || v.MasterLogger().GetLevel() == logrus.TraceLevel {
 		printLog = true
 	}
 
-	lsAPI := logserver.New(logger, tpLogPath, v.conf.LocalPath, customPath, printLog)
+	lsAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, v.conf.CustomDmsgHTTPPath, printLog)
 
 	lis, err := dmsgC.Listen(skyenv.DmsgHTTPPort)
 	if err != nil {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -461,11 +461,10 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	var logS transport.LogStore
-	log.Errorf(v.conf.Transport.LogStore.Type)
 	if v.conf.Transport.LogStore.Type == visorconfig.MemoryLogStore {
 		logS = transport.InMemoryTransportLogStore()
 	} else if v.conf.Transport.LogStore.Type == visorconfig.FileLogStore {
-		logS, err = transport.FileTransportLogStore(v.conf.Transport.LogStore.Location)
+		logS, err = transport.FileTransportLogStore(ctx, v.conf.Transport.LogStore.Location, time.Duration(v.conf.Transport.LogStore.RotationInterval))
 		if err != nil {
 			return err
 		}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -463,9 +463,17 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		return err
 	}
 
-	logS, err := transport.FileTransportLogStore(v.conf.LocalPath + "/" + skyenv.TpLogStore)
-	if err != nil {
-		return err
+	var logS transport.LogStore
+	log.Errorf(v.conf.Transport.LogStore.Type)
+	if v.conf.Transport.LogStore.Type == visorconfig.MemoryLogStore {
+		logS = transport.InMemoryTransportLogStore()
+	} else if v.conf.Transport.LogStore.Type == visorconfig.FileLogStore {
+		logS, err = transport.FileTransportLogStore(v.conf.Transport.LogStore.Location)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("invalid store type: %v", v.conf.Transport.LogStore.Type)
 	}
 
 	pTps, err := v.conf.GetPersistentTransports()

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -464,7 +464,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if v.conf.Transport.LogStore.Type == visorconfig.MemoryLogStore {
 		logS = transport.InMemoryTransportLogStore()
 	} else if v.conf.Transport.LogStore.Type == visorconfig.FileLogStore {
-		logS, err = transport.FileTransportLogStore(ctx, v.conf.Transport.LogStore.Location, time.Duration(v.conf.Transport.LogStore.RotationInterval))
+		logS, err = transport.FileTransportLogStore(ctx, v.conf.Transport.LogStore.Location, time.Duration(v.conf.Transport.LogStore.RotationInterval), log)
 		if err != nil {
 			return err
 		}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -482,7 +482,7 @@ func NewMockRPCClient(r *rand.Rand, maxTps int, maxRules int) (cipher.PubKey, AP
 			Local:  localPK,
 			Remote: remotePK,
 			Type:   types[r.Int()%len(types)],
-			Log:    new(transport.LogEntry),
+			Log:    transport.NewLogEntry(),
 		}
 		log.Infof("tp[%2d]: %v", i, tps[i])
 	}
@@ -903,7 +903,7 @@ func (mc *mockRPCClient) AddTransport(remote cipher.PubKey, tpType string, _ tim
 		Local:  mc.o.PubKey,
 		Remote: remote,
 		Type:   network.Type(tpType),
-		Log:    new(transport.LogEntry),
+		Log:    transport.NewLogEntry(),
 	}
 	return summary, mc.do(true, func() error {
 		mc.o.Transports = append(mc.o.Transports, summary)

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -89,6 +89,7 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 	conf.CLIAddr = skyenv.RPCAddr
 	conf.LogLevel = skyenv.LogLevel
 	conf.LocalPath = skyenv.LocalPath
+	conf.CustomDmsgHTTPPath = skyenv.LocalPath + "/" + skyenv.Custom
 	conf.StunServers = services.StunServers //utilenv.GetStunServers()
 	conf.ShutdownTimeout = DefaultTimeout
 	conf.RestartCheckDelay = Duration(restart.DefaultCheckDelay)
@@ -191,7 +192,9 @@ func MakeDefaultConfig(log *logging.MasterLogger, sk *cipher.SecKey, usrEnv bool
 	if pkgEnv {
 		pkgConfig := skyenv.PackageConfig()
 		conf.LocalPath = pkgConfig.LocalPath
+		conf.CustomDmsgHTTPPath = pkgConfig.LocalPath + "/" + skyenv.Custom
 		conf.Launcher.BinPath = pkgConfig.Launcher.BinPath
+		conf.Transport.LogStore.Location = pkgConfig.LocalPath + "/" + skyenv.TpLogStore
 		if conf.Hypervisor != nil {
 			conf.Hypervisor.EnableAuth = pkgConfig.Hypervisor.EnableAuth
 			conf.Hypervisor.DBPath = pkgConfig.Hypervisor.DbPath
@@ -200,7 +203,9 @@ func MakeDefaultConfig(log *logging.MasterLogger, sk *cipher.SecKey, usrEnv bool
 	if usrEnv {
 		usrConfig := skyenv.UserConfig()
 		conf.LocalPath = usrConfig.LocalPath
+		conf.CustomDmsgHTTPPath = usrConfig.LocalPath + "/" + skyenv.Custom
 		conf.Launcher.BinPath = usrConfig.Launcher.BinPath
+		conf.Transport.LogStore.Location = usrConfig.LocalPath + "/" + skyenv.TpLogStore
 		if conf.Hypervisor != nil {
 			conf.Hypervisor.EnableAuth = usrConfig.Hypervisor.EnableAuth
 			conf.Hypervisor.DBPath = usrConfig.Hypervisor.DbPath

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -66,6 +66,11 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		Discovery:         services.TransportDiscovery, //utilenv.TpDiscAddr,
 		AddressResolver:   services.AddressResolver,    //utilenv.AddressResolverAddr,
 		PublicAutoconnect: skyenv.PublicAutoconnect,
+		LogStore: &LogStore{
+			Type:             FileLogStore,
+			Location:         skyenv.LocalPath + "/" + skyenv.TpLogStore,
+			RotationInterval: DefaultLogRotationInterval,
+		},
 	}
 	conf.Routing = &Routing{
 		RouteFinder:        services.RouteFinder, //utilenv.RouteFinderAddr,
@@ -87,7 +92,6 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 	conf.StunServers = services.StunServers //utilenv.GetStunServers()
 	conf.ShutdownTimeout = DefaultTimeout
 	conf.RestartCheckDelay = Duration(restart.DefaultCheckDelay)
-	conf.LogRotationInterval = DefaultTimeout
 
 	conf.Dmsgpty = &Dmsgpty{
 		DmsgPort: skyenv.DmsgPtyPort,

--- a/pkg/visor/visorconfig/types.go
+++ b/pkg/visor/visorconfig/types.go
@@ -15,6 +15,8 @@ const (
 const (
 	// DefaultTimeout is used for default config generation and if it is not set in config.
 	DefaultTimeout = Duration(10 * time.Second)
+	// DefaultLogRotationInterval is used as default for RotationInterval and if it is not set in Log.
+	DefaultLogRotationInterval = Duration(time.Hour * 24 * 7)
 )
 
 // Duration wraps around time.Duration to allow parsing from and to JSON

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -35,7 +35,6 @@ type V1 struct {
 	StunServers          []string                         `json:"stun_servers"`
 	ShutdownTimeout      Duration                         `json:"shutdown_timeout,omitempty"`    // time value, examples: 10s, 1m, etc
 	RestartCheckDelay    Duration                         `json:"restart_check_delay,omitempty"` // time value, examples: 10s, 1m, etc
-	LogRotationInterval  Duration                         `json:"log_rotation_interval"`         // time value, examples: 10s, 1m, etc
 	IsPublic             bool                             `json:"is_public"`
 	PersistentTransports []transport.PersistentTransports `json:"persistent_transports"`
 
@@ -55,13 +54,15 @@ type Transport struct {
 	AddressResolver   string          `json:"address_resolver"`
 	PublicAutoconnect bool            `json:"public_autoconnect"`
 	TransportSetup    []cipher.PubKey `json:"transport_setup_nodes"`
+	LogStore          *LogStore       `json:"log_store"`
 }
 
 // LogStore configures a LogStore.
 type LogStore struct {
 	// Type defines the log store type. Valid values: file, memory.
-	Type     string `json:"type"`
-	Location string `json:"location"`
+	Type             string   `json:"type"`
+	Location         string   `json:"location"`
+	RotationInterval Duration `json:"rotation_interval"` // time value, examples: 10s, 1m, 1h etc
 }
 
 // Routing configures routing.
@@ -181,7 +182,7 @@ func (v1 *V1) GetPersistentTransports() ([]transport.PersistentTransports, error
 // UpdateLogRotationInterval updates log_rotation_interval in config
 func (v1 *V1) UpdateLogRotationInterval(d Duration) error {
 	v1.mu.Lock()
-	v1.LogRotationInterval = d
+	v1.Transport.LogStore.RotationInterval = d
 	v1.mu.Unlock()
 
 	return v1.flush(v1)
@@ -191,7 +192,7 @@ func (v1 *V1) UpdateLogRotationInterval(d Duration) error {
 func (v1 *V1) GetLogRotationInterval() (Duration, error) {
 	v1.mu.Lock()
 	defer v1.mu.Unlock()
-	return v1.LogRotationInterval, nil
+	return v1.Transport.LogStore.RotationInterval, nil
 }
 
 // UpdatePublicAutoconnect updates public_autoconnect in config

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -32,6 +32,7 @@ type V1 struct {
 
 	LogLevel             string                           `json:"log_level"`
 	LocalPath            string                           `json:"local_path"`
+	CustomDmsgHTTPPath   string                           `json:"custom_dmsg_http_path"`
 	StunServers          []string                         `json:"stun_servers"`
 	ShutdownTimeout      Duration                         `json:"shutdown_timeout,omitempty"`    // time value, examples: 10s, 1m, etc
 	RestartCheckDelay    Duration                         `json:"restart_check_delay,omitempty"` // time value, examples: 10s, 1m, etc


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #1363	
Fixes #1388

 Changes:	
- Fixed failing tests
- Fixed tp log failure on second start
- Fixed log data reset (now the data is persisted between visor restarts)

How to test this PR:
1. To test interday logs change [`2006-01-02`](https://github.com/ersonp/skywire/blob/1ed23d0fa6b12efb1c633138bb909492b5e278d6/pkg/transport/log.go#L23) to this `2006-01-02--3:4`
2. Build `make build`
3. Check the data in the new files that are created resets or not
4. Revert the changes and build again `make build`
5. Create CSV files older than 7 days in `./local/transport_logs` eg `2022-10-08.csv` (yyyy-mm-dd)
6. Check if they are deleted on visor startup
7. Start a vpn-server
8. Start a vpn-client and connect to it
9. Check logs (check if the logs sent and received bytes in csv reset every day (minute) file)
10. Stop visor
11. Restart the vpn-client and connect to the server again
12. Check logs (test with at least 2 transports and 2 different servers)
13. Run `./skywire-cli config gen -ir` check the location of `transport_logs` and `custom`
14. Run `./skywire-cli config gen -irp` check the location of `transport_logs` and `custom`
15. Run `./skywire-cli config gen -iru` check the location of `transport_logs` and `custom`