### PR TITLE
Printing new IP after connecting to VPN in CLI

### DIFF
--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -164,7 +164,7 @@ var vpnStartCmd = &cobra.Command{
 						internal.Catch(cmd.Flags(), w.Flush())
 						internal.PrintOutput(cmd.Flags(), "\nRunning!", fmt.Sprintln("\nRunning!"))
 						ip, err := visor.GetIP()
-						if err != nil {
+						if err == nil {
 							internal.PrintOutput(cmd.Flags(), fmt.Sprintf("\nYour current IP is %s!\n", ip), fmt.Sprintf("\nYour current IP is %s!\n", ip))
 						}
 					}

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -15,6 +15,7 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -162,6 +163,10 @@ var vpnStartCmd = &cobra.Command{
 						startProcess = false
 						internal.Catch(cmd.Flags(), w.Flush())
 						internal.PrintOutput(cmd.Flags(), "\nRunning!", fmt.Sprintln("\nRunning!"))
+						ip, err := visor.GetIP()
+						if err != nil {
+							internal.PrintOutput(cmd.Flags(), fmt.Sprintf("\nYour current IP is %s!\n", ip), fmt.Sprintf("\nYour current IP is %s!\n", ip))
+						}
 					}
 					if state.Status == appserver.AppStatusErrored {
 						startProcess = false

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -165,7 +165,7 @@ var vpnStartCmd = &cobra.Command{
 						internal.PrintOutput(cmd.Flags(), "\nRunning!", fmt.Sprintln("\nRunning!"))
 						ip, err := visor.GetIP()
 						if err == nil {
-							internal.PrintOutput(cmd.Flags(), fmt.Sprintf("\nYour current IP is %s!\n", ip), fmt.Sprintf("\nYour current IP is %s!\n", ip))
+							internal.PrintOutput(cmd.Flags(), fmt.Sprintf("\nYour current IP: %s", ip), fmt.Sprintf("Your current IP: %s\n", ip))
 						}
 					}
 					if state.Status == appserver.AppStatusErrored {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1293,7 +1293,7 @@ func getPublicIP(v *Visor, service string) (string, error) {
 		return pIP, fmt.Errorf("provided URL is invalid: %w", err)
 	}
 
-	pIP, err = getIP()
+	pIP, err = GetIP()
 	if err != nil {
 		<-v.stunReady
 		if v.stunClient.PublicIP != nil {
@@ -1313,7 +1313,8 @@ type ipAPI struct {
 	PublicIP string `json:"ip_address"`
 }
 
-func getIP() (string, error) {
+// GetIP used for getting current IP of visor
+func GetIP() (string, error) {
 	req, err := http.Get("http://ip.skycoin.com")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- Printing IP after connecting to VPN Server when using `skywire-cli vpn start <pk>` command.

Screencast:
![output](https://user-images.githubusercontent.com/79150699/196892904-0a72db16-55cd-47d2-9a05-e4c97a4e9048.gif)


How to test this PR:
- `make build`
- run visor
- trying connect to VPN server by `./skywire-cli vpn start <pk>` command