### PR TITLE
Fix/panic and datarace

### DIFF
--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -121,8 +121,12 @@ func (le *LogEntry) GobDecode(b []byte) error {
 	if err := dec.Decode(&sb); err != nil {
 		return err
 	}
-	atomic.StoreUint64(le.RecvBytes, rb)
-	atomic.StoreUint64(le.SentBytes, sb)
+	if le.RecvBytes != nil {
+		atomic.StoreUint64(le.RecvBytes, rb)
+	}
+	if le.SentBytes != nil {
+		atomic.StoreUint64(le.SentBytes, sb)
+	}
 	return nil
 }
 

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -258,6 +258,8 @@ func (tm *Manager) Networks() []network.Type {
 
 // Stcpr returns stcpr client
 func (tm *Manager) Stcpr() (network.Client, bool) {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
 	c, ok := tm.netClients[network.STCPR]
 	return c, ok
 }


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #1371 

 Changes:	
- Made `GobDecode` nil safe
- Added `logMx` to transport
- Fixed `Stcpr()` in transport manager

How to test this PR:
1. Run integration env and check visor logs for datarace
2. Run `./skywire-cli visor --rpc visor-a:3435 pk` to see if panic is fixed