### PR TITLE
Bug fixes for the UI

### DIFF
--- a/static/skywire-manager-src/src/app/services/proxy-discovery.service.ts
+++ b/static/skywire-manager-src/src/app/services/proxy-discovery.service.ts
@@ -34,6 +34,10 @@ export class ProxyDiscoveryService {
       // In case of error, retry.
       retryWhen(errors => errors.pipe(delay(4000))),
       map((result: any[]) => {
+        if (!result) {
+          result = [];
+        }
+
         // Process the data.
         result.forEach(proxy => {
           const currentEntry = new ProxyDiscoveryEntry();


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the app shows that there are no results when the discovery service returns null.
- Now the app reloads well if the user presses the refresh button of the web browser while checking the app list of a node.

How to test this PR:
- Now the search tab of the skysocks-client app should show that there are no results, instead of showing the loading animation forever.
- If you press the refresh button of the web browser while checking the app list of a node, the page should be reloaded correctly, instead of showing the loading animation forever.