### PR TITLE
fixing skywire-cli reward freezing issue

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -20,11 +20,12 @@ var (
 )
 
 // Client is used by other skywire-cli commands to query the visor rpc
-func Client(cmdFlags *pflag.FlagSet) visor.API {
+func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	const rpcDialTimeout = time.Second * 5
 	conn, err := net.DialTimeout("tcp", Addr, rpcDialTimeout)
 	if err != nil {
-		internal.PrintFatalError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
+		internal.PrintError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
+		return nil, err
 	}
-	return visor.NewRPCClient(logger, conn, visor.RPCPrefix, 0)
+	return visor.NewRPCClient(logger, conn, visor.RPCPrefix, 0), nil
 }

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -4,6 +4,7 @@ package clivisor
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strconv"
 	"text/tabwriter"
 	"time"
@@ -50,7 +51,11 @@ var lsAppsCmd = &cobra.Command{
 	Short: "List apps",
 	Long:  "\n  List apps",
 	Run: func(cmd *cobra.Command, _ []string) {
-		states, err := clirpc.Client(cmd.Flags()).Apps()
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		states, err := rpcClient.Apps()
 		internal.Catch(cmd.Flags(), err)
 		var b bytes.Buffer
 		w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
@@ -97,7 +102,11 @@ var startAppCmd = &cobra.Command{
 	Long:  "\n  Launch app",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).StartApp(args[0]))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.StartApp(args[0]))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -108,7 +117,11 @@ var stopAppCmd = &cobra.Command{
 	Long:  "\n  Halt app",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).StopApp(args[0]))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.StopApp(args[0]))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -127,7 +140,11 @@ var setAppAutostartCmd = &cobra.Command{
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAutoStart(args[0], autostart))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SetAutoStart(args[0], autostart))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -147,7 +164,11 @@ var setAppKillswitchCmd = &cobra.Command{
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppKillswitch(args[0], killswitch))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SetAppKillswitch(args[0], killswitch))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -167,7 +188,11 @@ var setAppSecureCmd = &cobra.Command{
 		default:
 			internal.Catch(cmd.Flags(), fmt.Errorf("invalid args[1] value: %s", args[1]))
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppSecure(args[0], secure))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SetAppSecure(args[0], secure))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -182,7 +207,11 @@ var setAppPasscodeCmd = &cobra.Command{
 		if args[1] == "remove" {
 			passcode = ""
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppPassword(args[0], passcode))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SetAppPassword(args[0], passcode))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -197,7 +226,11 @@ var setAppNetworkInterfaceCmd = &cobra.Command{
 		if args[1] == "remove" {
 			netifc = ""
 		}
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SetAppNetworkInterface(args[0], netifc))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SetAppNetworkInterface(args[0], netifc))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
 }
@@ -217,7 +250,11 @@ var appLogsSinceCmd = &cobra.Command{
 			t, err = time.Parse(time.RFC3339Nano, strTime)
 			internal.Catch(cmd.Flags(), err)
 		}
-		logs, err := clirpc.Client(cmd.Flags()).LogsSince(t, args[0])
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		logs, err := rpcClient.LogsSince(t, args[0])
 		internal.Catch(cmd.Flags(), err)
 		if len(logs) > 0 {
 			internal.PrintOutput(cmd.Flags(), logs, fmt.Sprintf("%v\n", logs))

--- a/cmd/skywire-cli/commands/visor/exec.go
+++ b/cmd/skywire-cli/commands/visor/exec.go
@@ -2,6 +2,7 @@
 package clivisor
 
 import (
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -22,7 +23,11 @@ var execCmd = &cobra.Command{
 	Long:  "\n  Execute a command",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		out, err := clirpc.Client(cmd.Flags()).Exec(strings.Join(args, " "))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		out, err := rpcClient.Exec(strings.Join(args, " "))
 		internal.Catch(cmd.Flags(), err)
 		// since the output of this command can be anything it is not formatted, so it's advisable to not use the `--json` flag for this one
 		internal.PrintOutput(cmd.Flags(), string(out), string(out))

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -3,6 +3,7 @@ package clivisor
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/toqueteos/webbrowser"
@@ -60,8 +61,11 @@ var hvpkCmd = &cobra.Command{
 			}
 			hypervisors = conf.Hypervisors
 		} else {
-			client := clirpc.Client(cmd.Flags())
-			overview, err := client.Overview()
+			rpcClient, err := clirpc.Client(cmd.Flags())
+			if err != nil {
+				os.Exit(1)
+			}
+			overview, err := rpcClient.Overview()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
@@ -76,8 +80,11 @@ var chvpkCmd = &cobra.Command{
 	Short: "Public key of remote hypervisor(s)",
 	Long:  "Public key of remote hypervisor(s) which are currently connected to",
 	Run: func(cmd *cobra.Command, _ []string) {
-		client := clirpc.Client(cmd.Flags())
-		overview, err := client.Overview()
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		overview, err := rpcClient.Overview()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -4,6 +4,7 @@ package clivisor
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -45,8 +46,11 @@ var pkCmd = &cobra.Command{
 			}
 			outputPK = conf.PK.Hex()
 		} else {
-			client := clirpc.Client(cmd.Flags())
-			overview, err := client.Overview()
+			rpcClient, err := clirpc.Client(cmd.Flags())
+			if err != nil {
+				os.Exit(1)
+			}
+			overview, err := rpcClient.Overview()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 			}
@@ -67,7 +71,11 @@ var summaryCmd = &cobra.Command{
 	Short: "Summary of visor info",
 	Long:  "\n  Summary of visor info",
 	Run: func(cmd *cobra.Command, _ []string) {
-		summary, err := clirpc.Client(cmd.Flags()).Summary()
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		summary, err := rpcClient.Summary()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
@@ -107,8 +115,11 @@ var buildInfoCmd = &cobra.Command{
 	Short: "Version and build info",
 	Long:  "\n  Version and build info",
 	Run: func(cmd *cobra.Command, _ []string) {
-		client := clirpc.Client(cmd.Flags())
-		overview, err := client.Overview()
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		overview, err := rpcClient.Overview()
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}

--- a/cmd/skywire-cli/commands/visor/route.go
+++ b/cmd/skywire-cli/commands/visor/route.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"text/tabwriter"
 	"time"
@@ -41,7 +42,11 @@ var lsRulesCmd = &cobra.Command{
 	Short: "List routing rules",
 	Long:  "\n    List routing rules",
 	Run: func(cmd *cobra.Command, _ []string) {
-		rules, err := clirpc.Client(cmd.Flags()).RoutingRules()
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		rules, err := rpcClient.RoutingRules()
 		internal.Catch(cmd.Flags(), err)
 
 		printRoutingRules(cmd.Flags(), rules...)
@@ -56,8 +61,11 @@ var ruleCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		id, err := strconv.ParseUint(args[0], 10, 32)
 		internal.Catch(cmd.Flags(), err)
-
-		rule, err := clirpc.Client(cmd.Flags()).RoutingRule(routing.RouteID(id))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		rule, err := rpcClient.RoutingRule(routing.RouteID(id))
 		internal.Catch(cmd.Flags(), err)
 
 		printRoutingRules(cmd.Flags(), rule)
@@ -82,7 +90,11 @@ var rmRuleCmd = &cobra.Command{
 		//} else {
 		id, err := strconv.ParseUint(args[0], 10, 32)
 		internal.Catch(cmd.Flags(), err)
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).RemoveRoutingRule(routing.RouteID(id)))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.RemoveRoutingRule(routing.RouteID(id)))
 		//}
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
 	},
@@ -204,7 +216,11 @@ var addAppRuleCmd = &cobra.Command{
 			rIDKey = rule.KeyRouteID()
 		}
 
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SaveRoutingRule(rule))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SaveRoutingRule(rule))
 
 		output := struct {
 			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
@@ -262,7 +278,11 @@ var addFwdRuleCmd = &cobra.Command{
 			rIDKey = rule.KeyRouteID()
 		}
 
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SaveRoutingRule(rule))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SaveRoutingRule(rule))
 
 		output := struct {
 			RoutingRuleKey routing.RouteID `json:"routing_route_key"`
@@ -312,7 +332,11 @@ var addIntFwdRuleCmd = &cobra.Command{
 			rIDKey = rule.KeyRouteID()
 		}
 
-		internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).SaveRoutingRule(rule))
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		internal.Catch(cmd.Flags(), rpcClient.SaveRoutingRule(rule))
 
 		output := struct {
 			RoutingRuleKey routing.RouteID `json:"routing_route_key"`

--- a/cmd/skywire-cli/commands/visor/shutdown.go
+++ b/cmd/skywire-cli/commands/visor/shutdown.go
@@ -3,6 +3,7 @@ package clivisor
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -19,7 +20,11 @@ var shutdownCmd = &cobra.Command{
 	Short: "Stop a running visor",
 	Long:  "\n  Stop a running visor",
 	Run: func(cmd *cobra.Command, args []string) {
-		clirpc.Client(cmd.Flags()).Shutdown() //nolint
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		rpcClient.Shutdown() //nolint
 		fmt.Println("Visor was shut down")
 		internal.PrintOutput(cmd.Flags(), "Visor was shut down", fmt.Sprintln("Visor was shut down"))
 	},

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -42,6 +42,22 @@ func PrintFatalError(cmdFlags *pflag.FlagSet, err error) {
 	log.Fatal(err)
 }
 
+// PrintError prints errors for skywire-cli commands packages
+func PrintError(cmdFlags *pflag.FlagSet, err error) {
+	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck
+	if isJSON {
+		errJSON := CLIOutput{
+			Err: err.Error(),
+		}
+		b, err := json.MarshalIndent(errJSON, "", "  ")
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Print(string(b) + "\n")
+	}
+	log.Error(err)
+}
+
 // ParsePK parses a public key
 func ParsePK(cmdFlags *pflag.FlagSet, name, v string) cipher.PubKey {
 	var pk cipher.PubKey


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- Refactor `rpccli.Client` logic and add returning `Error` on its logic. 
- Fix freezing issue on `skywire-cli reward` command

How to test this PR:
- `make build`
- test `skywire-cli reward` on running visor, running visor on package installation, stopping visor