### PR TITLE
[WIP] App/Services showing ports subcommand `skywire-cli visor ports`

### DIFF
--- a/cmd/apps/skychat/skychat.go
+++ b/cmd/apps/skychat/skychat.go
@@ -118,6 +118,8 @@ func listenLoop() {
 		return
 	}
 
+	setAppPort(appCl, port)
+
 	for {
 		fmt.Println("Accepting skychat conn...")
 		conn, err := l.Accept()
@@ -278,5 +280,11 @@ func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
 func setAppError(appCl *app.Client, appErr error) {
 	if err := appCl.SetError(appErr.Error()); err != nil {
 		print(fmt.Sprintf("Failed to set error %v: %v\n", appErr, err))
+	}
+}
+
+func setAppPort(appCl *app.Client, port routing.Port) {
+	if err := appCl.SetAppPort(port); err != nil {
+		print(fmt.Sprintf("Failed to set port %v: %v\n", port, err))
 	}
 }

--- a/cmd/apps/skysocks-client/skysocks-client.go
+++ b/cmd/apps/skysocks-client/skysocks-client.go
@@ -79,6 +79,7 @@ func main() {
 		os.Exit(1)
 	}
 	defer setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+	setAppPort(appCl, socksPort)
 	for {
 		conn, err := dialServer(ctx, appCl, pk)
 		if err != nil {
@@ -121,5 +122,11 @@ func setAppErr(appCl *app.Client, err error) {
 func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
 	if err := appCl.SetDetailedStatus(string(status)); err != nil {
 		print(fmt.Sprintf("Failed to set status %v: %v\n", status, err))
+	}
+}
+
+func setAppPort(appCl *app.Client, port routing.Port) {
+	if err := appCl.SetAppPort(port); err != nil {
+		print(fmt.Sprintf("Failed to set port %v: %v\n", port, err))
 	}
 }

--- a/cmd/apps/skysocks/skysocks.go
+++ b/cmd/apps/skysocks/skysocks.go
@@ -52,6 +52,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	setAppPort(appCl, port)
+
 	fmt.Println("Starting serving proxy server")
 
 	if runtime.GOOS == "windows" {
@@ -92,5 +94,11 @@ func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
 func setAppError(appCl *app.Client, appErr error) {
 	if err := appCl.SetError(appErr.Error()); err != nil {
 		print(fmt.Sprintf("Failed to set error %v: %v\n", appErr, err))
+	}
+}
+
+func setAppPort(appCl *app.Client, port routing.Port) {
+	if err := appCl.SetAppPort(port); err != nil {
+		print(fmt.Sprintf("Failed to set port %v: %v\n", port, err))
 	}
 }

--- a/cmd/apps/skysocks/skysocks.go
+++ b/cmd/apps/skysocks/skysocks.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	netType              = appnet.TypeSkynet
-	port    routing.Port = 3
+	netType = appnet.TypeSkynet
+	port    = routing.Port(3)
 )
 
 func main() {

--- a/cmd/apps/vpn-client/vpn-client.go
+++ b/cmd/apps/vpn-client/vpn-client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
@@ -106,6 +107,7 @@ func main() {
 		}
 	}
 
+	setAppPort(appCl, appCl.Config().RoutingPort)
 	fmt.Printf("Connecting to VPN server %s\n", serverPK.String())
 
 	vpnClientCfg := vpn.ClientConfig{
@@ -188,5 +190,11 @@ func setAppErr(appCl *app.Client, err error) {
 func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
 	if err := appCl.SetDetailedStatus(string(status)); err != nil {
 		print(fmt.Sprintf("Failed to set status %v: %v\n", status, err))
+	}
+}
+
+func setAppPort(appCl *app.Client, port routing.Port) {
+	if err := appCl.SetAppPort(port); err != nil {
+		print(fmt.Sprintf("Failed to set port %v: %v\n", port, err))
 	}
 }

--- a/cmd/apps/vpn-server/vpn-server.go
+++ b/cmd/apps/vpn-server/vpn-server.go
@@ -82,7 +82,7 @@ func main() {
 		setAppErr(appCl, err)
 		os.Exit(1)
 	}
-
+	setAppPort(appCl, vpnPort)
 	fmt.Printf("Got app listener, bound to %d\n", vpnPort)
 
 	srvCfg := vpn.ServerConfig{
@@ -129,5 +129,11 @@ func setAppErr(appCl *app.Client, err error) {
 func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
 	if err := appCl.SetDetailedStatus(string(status)); err != nil {
 		print(fmt.Sprintf("Failed to set status %v: %v\n", status, err))
+	}
+}
+
+func setAppPort(appCl *app.Client, port routing.Port) {
+	if err := appCl.SetAppPort(port); err != nil {
+		print(fmt.Sprintf("Failed to set port %v: %v\n", port, err))
 	}
 }

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -18,6 +18,7 @@ func init() {
 	RootCmd.AddCommand(hvCmd)
 	hvCmd.AddCommand(hvuiCmd)
 	hvCmd.AddCommand(hvpkCmd)
+//	hvCmd.AddCommand(portCmd)
 	hvpkCmd.Flags().StringVarP(&path, "input", "i", "", "path of input config file.")
 	hvpkCmd.Flags().BoolVarP(&pkg, "pkg", "p", false, "read from /opt/skywire/skywire.json")
 	hvpkCmd.Flags().BoolVarP(&web, "http", "w", false, "serve public key via http")
@@ -67,7 +68,7 @@ var hvpkCmd = &cobra.Command{
 			}
 			overview, err := rpcClient.Overview()
 			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+				internal.PrintFatalRPCError(cmd.Flags(), err)
 			}
 			hypervisors = overview.Hypervisors
 		}
@@ -82,12 +83,43 @@ var chvpkCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		overview, err := rpcClient.Overview()
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		internal.PrintOutput(cmd.Flags(), overview.ConnectedHypervisor, fmt.Sprintf("%v\n", overview.ConnectedHypervisor))
 	},
 }
+/*
+var portCmd = &cobra.Command{
+	Use:   "port",
+	Short: "",
+	Long:  "",
+	Run: func(cmd *cobra.Command, _ []string) {
+//func HypervisorPort() string {
+rpcClient, err := clirpc.Client(cmd.Flags())
+if err != nil {
+	os.Exit(1)
+}
+ports, err := rpcClient.Ports()
+if err != nil {
+	internal.PrintFatalRPCError(cmd.Flags(), err)
+}
+var msg string
+portsName := make([]string, 0, len(ports))
+for portName := range ports {
+	portsName = append(portsName, portName)
+}
+sort.Strings(portsName)
+
+for _, portName := range portsName {
+	msg += fmt.Sprintf("| %-21s | %7s |\n", portName, ports[portName])
+}
+
+msg += "+---------------------------------+\n"
+internal.PrintOutput(cmd.Flags(), ports, msg)
+},
+}
+*/

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -28,6 +28,7 @@ func init() {
 	pkCmd.Flags().StringVarP(&webPort, "prt", "x", "7998", "serve public key via http")
 	RootCmd.AddCommand(summaryCmd)
 	RootCmd.AddCommand(buildInfoCmd)
+	RootCmd.AddCommand(portsCmd)
 }
 
 var pkCmd = &cobra.Command{
@@ -126,6 +127,27 @@ var buildInfoCmd = &cobra.Command{
 		buildInfo := overview.BuildInfo
 		msg := fmt.Sprintf("Version %q built on %q against commit %q\n", buildInfo.Version, buildInfo.Date, buildInfo.Commit)
 		internal.PrintOutput(cmd.Flags(), buildInfo, msg)
+	},
+}
+
+var portsCmd = &cobra.Command{
+	Use:   "ports",
+	Short: "List of Ports",
+	Long:  "\n  List of all ports used by visor services and apps",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		ports, err := rpcClient.Ports()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+		}
+		msg := "App/Service : Port\n"
+		for i, v := range ports {
+			msg += fmt.Sprintf("%s : %d\n", i, v)
+		}
+		internal.PrintOutput(cmd.Flags(), ports, msg)
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -54,7 +54,7 @@ var pkCmd = &cobra.Command{
 			}
 			overview, err := rpcClient.Overview()
 			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+				internal.PrintFatalRPCError(cmd.Flags(), err)
 			}
 			pk = overview.PubKey.String() + "\n"
 			if web {
@@ -79,7 +79,7 @@ var summaryCmd = &cobra.Command{
 		}
 		summary, err := rpcClient.Summary()
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\nSymmetric NAT: %t\nIP: %s\nDMSG Server: %q\nPing: %q\nVisor Version: %s\nSkybian Version: %s\nUptime Tracker: %s\nTime Online: %f seconds\nBuild Tag: %s\n",
 			summary.Overview.PubKey, summary.Overview.IsSymmetricNAT, summary.Overview.LocalIP, summary.DmsgStats.ServerPK, summary.DmsgStats.RoundTrip, summary.Overview.BuildInfo.Version, summary.SkybianBuildVersion,
@@ -123,7 +123,7 @@ var buildInfoCmd = &cobra.Command{
 		}
 		overview, err := rpcClient.Overview()
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		buildInfo := overview.BuildInfo
 		msg := fmt.Sprintf("Version %q built on %q against commit %q\n", buildInfo.Version, buildInfo.Date, buildInfo.Commit)
@@ -142,7 +142,7 @@ var portsCmd = &cobra.Command{
 		}
 		ports, err := rpcClient.Ports()
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		msg := "+---------------------------------+\n"
 		msg += fmt.Sprintf("| %-21s | %7s |\n", "App/Service", "Port")

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -143,10 +144,21 @@ var portsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))
 		}
-		msg := "App/Service : Port\n"
-		for i, v := range ports {
-			msg += fmt.Sprintf("%s : %d\n", i, v)
+		msg := "+---------------------------------+\n"
+		msg += fmt.Sprintf("| %-21s | %7s |\n", "App/Service", "Port")
+		msg += "|---------------------------------|\n"
+
+		portsName := make([]string, 0, len(ports))
+		for portName := range ports {
+			portsName = append(portsName, portName)
 		}
+		sort.Strings(portsName)
+
+		for _, portName := range portsName {
+			msg += fmt.Sprintf("| %-21s | %7s |\n", portName, ports[portName])
+		}
+
+		msg += "+---------------------------------+\n"
 		internal.PrintOutput(cmd.Flags(), ports, msg)
 	},
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -144,9 +144,9 @@ var portsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
-		msg := "+---------------------------------+\n"
-		msg += fmt.Sprintf("| %-21s | %7s |\n", "App/Service", "Port")
-		msg += "|---------------------------------|\n"
+		msg := "+------------------------------------------+\n"
+		msg += fmt.Sprintf("| %-21s | %-6s | %-7s |\n", "App/Service", "Type", "Port")
+		msg += "|------------------------------------------|\n"
 
 		portsName := make([]string, 0, len(ports))
 		for portName := range ports {
@@ -155,10 +155,10 @@ var portsCmd = &cobra.Command{
 		sort.Strings(portsName)
 
 		for _, portName := range portsName {
-			msg += fmt.Sprintf("| %-21s | %7s |\n", portName, ports[portName])
+			msg += fmt.Sprintf("| %-21s | %-6s | %7s |\n", portName, "skynet", ports[portName])
 		}
 
-		msg += "+---------------------------------+\n"
+		msg += "+------------------------------------------+\n"
 		internal.PrintOutput(cmd.Flags(), ports, msg)
 	},
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -144,9 +144,9 @@ var portsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
-		msg := "+------------------------------------------+\n"
-		msg += fmt.Sprintf("| %-21s | %-6s | %-7s |\n", "App/Service", "Type", "Port")
-		msg += "|------------------------------------------|\n"
+		msg := "+-------------------------------------------+\n"
+		msg += fmt.Sprintf("| %-21s | %-7s | %-7s |\n", "App/Service", "Type", "Port")
+		msg += "|-------------------------------------------|\n"
 
 		portsName := make([]string, 0, len(ports))
 		for portName := range ports {
@@ -155,10 +155,13 @@ var portsCmd = &cobra.Command{
 		sort.Strings(portsName)
 
 		for _, portName := range portsName {
-			msg += fmt.Sprintf("| %-21s | %-6s | %7s |\n", portName, ports[portName].Type, ports[portName].Port)
+			msg += fmt.Sprintf("| %-21s | %-7s | %7s |\n", portName, ports[portName].Type, ports[portName].Port)
 		}
 
-		msg += "+------------------------------------------+\n"
+		msg += "|===========================================|\n"
+		msg += "| SKYNET: connection between apps and visor |\n"
+		msg += "| DMSG: connection by dmsg service          |\n"
+		msg += "+-------------------------------------------+\n"
 		internal.PrintOutput(cmd.Flags(), ports, msg)
 	},
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -155,7 +155,7 @@ var portsCmd = &cobra.Command{
 		sort.Strings(portsName)
 
 		for _, portName := range portsName {
-			msg += fmt.Sprintf("| %-21s | %-6s | %7s |\n", portName, "skynet", ports[portName])
+			msg += fmt.Sprintf("| %-21s | %-6s | %7s |\n", portName, ports[portName].Type, ports[portName].Port)
 		}
 
 		msg += "+------------------------------------------+\n"

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	clivisor "github.com/skycoin/skywire/cmd/skywire-cli/commands/visor"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/visor"
@@ -58,7 +59,7 @@ var vpnUICmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to read in config: %v", err))
 			}
-			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", conf.PK.Hex())
+			url = fmt.Sprintf("http://127.0.0.1%s/#/vpn/%s/", clivisor.HypervisorPort(cmd.Flags()), conf.PK.Hex())
 		} else {
 			rpcClient, err := clirpc.Client(cmd.Flags())
 			if err != nil {
@@ -68,7 +69,7 @@ var vpnUICmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
 			}
-			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
+			url = fmt.Sprintf("http://127.0.0.1%s/#/vpn/%s/", clivisor.HypervisorPort(cmd.Flags()), overview.PubKey.Hex())
 		}
 		if err := webbrowser.Open(url); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to open VPN UI in browser:: %v", err))
@@ -89,7 +90,7 @@ var vpnURLCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to read in config: %v", err))
 			}
-			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", conf.PK.Hex())
+			url = fmt.Sprintf("http://127.0.0.1%s/#/vpn/%s/", clivisor.HypervisorPort(cmd.Flags()), conf.PK.Hex())
 		} else {
 			rpcClient, err := clirpc.Client(cmd.Flags())
 			if err != nil {
@@ -99,7 +100,7 @@ var vpnURLCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalRPCError(cmd.Flags(), err)
 			}
-			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
+			url = fmt.Sprintf("http://127.0.0.1%s/#/vpn/%s/", clivisor.HypervisorPort(cmd.Flags()), overview.PubKey.Hex())
 		}
 
 		output := struct {
@@ -111,7 +112,6 @@ var vpnURLCmd = &cobra.Command{
 		internal.PrintOutput(cmd.Flags(), output, fmt.Sprintln(url))
 	},
 }
-
 
 var vpnListCmd = &cobra.Command{
 	Use:   "list",

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -97,7 +97,7 @@ var vpnURLCmd = &cobra.Command{
 			}
 			overview, err := rpcClient.Overview()
 			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Failed to connect; is skywire running?: %v", err))
+				internal.PrintFatalRPCError(cmd.Flags(), err)
 			}
 			url = fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s/", overview.PubKey.Hex())
 		}
@@ -112,13 +112,14 @@ var vpnURLCmd = &cobra.Command{
 	},
 }
 
+
 var vpnListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List public VPN servers",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		if isUnFiltered {
 			ver = ""
@@ -126,7 +127,7 @@ var vpnListCmd = &cobra.Command{
 		}
 		servers, err := rpcClient.VPNServers(ver, country)
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), err)
+			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 		if len(servers) == 0 {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("No VPN Servers found"))

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -42,6 +42,11 @@ func PrintFatalError(cmdFlags *pflag.FlagSet, err error) {
 	log.Fatal(err)
 }
 
+// PrintFatalRPCError prints errors for skywire-cli commands packages
+func PrintFatalRPCError(cmdFlags *pflag.FlagSet, err error) {
+	PrintFatalError(cmdFlags, fmt.Errorf("Failed to connect; is skywire running?: %v", err))
+}
+
 // PrintError prints errors for skywire-cli commands packages
 func PrintError(cmdFlags *pflag.FlagSet, err error) {
 	isJSON, _ := cmdFlags.GetBool(JSONString) //nolint:errcheck

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -198,6 +198,21 @@ func (_m *MockRPCIngressClient) SetError(appErr string) error {
 	return r0
 }
 
+
+// SetDetailedStatus provides a mock function with given fields: status
+func (_m *MockRPCIngressClient) SetAppPort(port routing.Port) error {
+	ret := _m.Called(port)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(routing.Port) error); ok {
+		r0 = rf(port)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SetReadDeadline provides a mock function with given fields: connID, d
 func (_m *MockRPCIngressClient) SetReadDeadline(connID uint16, d time.Time) error {
 	ret := _m.Called(connID, d)

--- a/pkg/app/appserver/proc.go
+++ b/pkg/app/appserver/proc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
@@ -67,6 +68,9 @@ type Proc struct {
 
 	errMx sync.RWMutex
 	err   string
+
+	portMx sync.RWMutex
+	port   routing.Port
 
 	cmdStderr io.ReadCloser
 
@@ -373,6 +377,21 @@ func (p *Proc) SetError(appErr string) {
 	defer p.errMx.Unlock()
 
 	p.err = appErr
+}
+
+// SetAppPort sets the proc's connection port
+func (p *Proc) SetAppPort(port routing.Port) {
+	p.portMx.Lock()
+	defer p.portMx.Unlock()
+	p.port = port
+}
+
+// GetAppPort gets the proc's connection port
+func (p *Proc) GetAppPort() routing.Port {
+	p.portMx.Lock()
+	defer p.portMx.Unlock()
+
+	return p.port
 }
 
 // Error gets proc's error.

--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
+	"github.com/skycoin/skywire/pkg/routing"
 )
 
 //go:generate mockery -name ProcManager -case underscore -inpkg
@@ -46,6 +47,7 @@ type ProcManager interface {
 	Stats(appName string) (AppStats, error)
 	SetDetailedStatus(appName, status string) error
 	DetailedStatus(appName string) (string, error)
+	GetAppPort(appName string) (routing.Port, error)
 	ConnectionsSummary(appName string) ([]ConnectionSummary, error)
 	Addr() net.Addr
 }
@@ -330,6 +332,16 @@ func (m *procManager) SetError(appName, appErr string) error {
 	m.errors[appName] = appErr
 
 	return nil
+}
+
+// GetAppPort gets port of the app `appName`.
+func (m *procManager) GetAppPort(appName string) (routing.Port, error) {
+	p, err := m.get(appName)
+	if err != nil {
+		return routing.Port(0), err
+	}
+
+	return p.GetAppPort(), nil
 }
 
 // ConnectionsSummary gets connections info for the app `appName`.

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -18,6 +18,7 @@ type RPCIngressClient interface {
 	SetDetailedStatus(status string) error
 	SetConnectionDuration(dur int64) error
 	SetError(appErr string) error
+	SetAppPort(appPort routing.Port) error
 	Dial(remote appnet.Addr) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
@@ -57,6 +58,11 @@ func (c *rpcIngressClient) SetConnectionDuration(dur int64) error {
 // SetError sets error of an app.
 func (c *rpcIngressClient) SetError(appErr string) error {
 	return c.rpc.Call(c.formatMethod("SetError"), &appErr, nil)
+}
+
+// SetAppPort sets port of an app.
+func (c *rpcIngressClient) SetAppPort(port routing.Port) error {
+	return c.rpc.Call(c.formatMethod("SetAppPort"), &port, nil)
 }
 
 // RPCErr is used to preserve the type of the errors we return via RPC

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -99,6 +99,13 @@ func (r *RPCIngressGateway) SetError(appErr *string, _ *struct{}) (err error) {
 	return nil
 }
 
+// SetAppPort sets the connection port of an app (vpn-client in this instance)
+func (r *RPCIngressGateway) SetAppPort(port routing.Port, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetAppPort", port)(nil, &err)
+	r.proc.SetAppPort(port)
+	return nil
+}
+
 // DialResp contains response parameters for `Dial`.
 type DialResp struct {
 	ConnID    uint16

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -79,6 +79,11 @@ func (c *Client) SetError(appErr string) error {
 	return c.rpcC.SetError(appErr)
 }
 
+// SetAppPort sets app port within the visor.
+func (c *Client) SetAppPort(appPort routing.Port) error {
+	return c.rpcC.SetAppPort(appPort)
+}
+
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
 	connID, localPort, err := c.rpcC.Dial(remote)

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -58,6 +59,7 @@ type APIClient interface {
 	BindSUDPH(filter *pfilter.PacketFilter, handshake Handshake) (<-chan RemoteVisor, error)
 	Resolve(ctx context.Context, netType string, pk cipher.PubKey) (VisorData, error)
 	Transports(ctx context.Context) (map[cipher.PubKey][]string, error)
+	Addresses(ctx context.Context) string
 	Close() error
 }
 
@@ -207,6 +209,13 @@ type BindRequest struct {
 type LocalAddresses struct {
 	Port      string   `json:"port"`
 	Addresses []string `json:"addresses"`
+}
+
+func (c *httpClient) Addresses(ctx context.Context) string {
+	if c.sudphConn != nil {
+		return strings.Split(c.sudphConn.LocalAddr().String(), ":")[3]
+	}
+	return ""
 }
 
 // BindSTCPR binds client PK to IP:port on address resolver.

--- a/pkg/transport/network/addrresolver/mock_api_client.go
+++ b/pkg/transport/network/addrresolver/mock_api_client.go
@@ -109,6 +109,6 @@ func (_m *MockAPIClient) Resolve(ctx context.Context, netType string, pk cipher.
 	return r0, r1
 }
 
-func (_m *MockAPIClient)Addresses(ctx context.Context)(string,error) {
-	return "",nil
+func (_m *MockAPIClient) Addresses(ctx context.Context) (string, error) {
+	return "", nil
 }

--- a/pkg/transport/network/addrresolver/mock_api_client.go
+++ b/pkg/transport/network/addrresolver/mock_api_client.go
@@ -108,3 +108,7 @@ func (_m *MockAPIClient) Resolve(ctx context.Context, netType string, pk cipher.
 
 	return r0, r1
 }
+
+func (_m *MockAPIClient)Addresses(ctx context.Context)(string,error) {
+	return "",nil
+}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -696,7 +696,7 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 	var ports = make(map[string]PortDetail)
 
 	if v.conf.Hypervisor != nil {
-		ports["hypervisor"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1]), Type: "TCP/IP"}
+		ports["hypervisor"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1]), Type: "TCP"}
 	}
 
 	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgPtyPort)}
@@ -707,26 +707,23 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 	ports["dmsg_htttp_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgHTTPPort)}
 	ports["dmsg_await_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgAwaitSetupPort)}
 
-	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1]), Type: "TCP/IP"}
-
-	ports["skychat_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkychatAddr, ":")[1]), Type: "TCP/IP"}
-	ports["skysocks_client_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkysocksClientAddr, ":")[1]), Type: "TCP/IP"}
+	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1]), Type: "TCP"}
 
 	if v.arClient != nil {
 		sudphPort := v.arClient.Addresses(ctx)
 		if sudphPort != "" {
-			ports["sudph"] = PortDetail{Port: sudphPort, Type: "TCP/IP"}
+			ports["sudph"] = PortDetail{Port: sudphPort, Type: "UDP"}
 		}
 	}
 	if v.stunClient != nil {
 		if v.stunClient.PublicIP != nil {
-			ports["public_visor"] = PortDetail{Port: fmt.Sprint(v.stunClient.PublicIP.Port()), Type: "TCP/IP"}
+			ports["public_visor"] = PortDetail{Port: fmt.Sprint(v.stunClient.PublicIP.Port()), Type: "TCP"}
 		}
 	}
 	if v.dmsgC != nil {
 		dmsgSessions := v.dmsgC.AllSessions()
 		for i, session := range dmsgSessions {
-			ports[fmt.Sprintf("dmsg_session_%d", i)] = PortDetail{Port: strings.Split(session.LocalTCPAddr().String(), ":")[1]}
+			ports[fmt.Sprintf("dmsg_session_%d", i)] = PortDetail{Port: strings.Split(session.LocalTCPAddr().String(), ":")[1], Type: "TCP"}
 		}
 
 		dmsgStreams := v.dmsgC.AllStreams()
@@ -740,6 +737,13 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 			port, err := v.procM.GetAppPort(app.Name)
 			if err == nil {
 				ports[app.Name] = PortDetail{Port: fmt.Sprint(port), Type: "SKYNET"}
+
+				switch app.Name {
+				case "skysocks_client":
+					ports["skysocks_client_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkysocksClientAddr, ":")[1]), Type: "TCP"}
+				case "skychat":
+					ports["skychat_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkychatAddr, ":")[1]), Type: "TCP"}
+				}
 			}
 		}
 	}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -699,7 +699,7 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 		ports["hypervisor"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1]), Type: "TCP"}
 	}
 
-	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgPtyPort)}
+	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(v.conf.Dmsgpty.DmsgPort), Type: "DMSG"}
 
 	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1]), Type: "TCP"}
 

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -700,8 +700,9 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 	}
 
 	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(v.conf.Dmsgpty.DmsgPort), Type: "DMSG"}
-
-	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1]), Type: "TCP"}
+	ports["cli_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.CLIAddr, ":")[1]), Type: "TCP"}
+	ports["proc_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Launcher.ServerAddr, ":")[1]), Type: "TCP"}
+	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.STCP.ListeningAddress, ":")[1]), Type: "TCP"}
 
 	if v.arClient != nil {
 		sudphPort := v.arClient.Addresses(ctx)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -62,6 +62,7 @@ type API interface {
 	GetAppConnectionsSummary(appName string) ([]appserver.ConnectionSummary, error)
 	VPNServers(version, country string) ([]servicedisc.Service, error)
 	RemoteVisors() ([]string, error)
+	Ports() (map[string]int, error)
 
 	TransportTypes() ([]string, error)
 	Transports(types []string, pks []cipher.PubKey, logs bool) ([]*TransportSummary, error)
@@ -681,6 +682,13 @@ func (v *Visor) RemoteVisors() ([]string, error) {
 		visors = append(visors, conn.Addr.PK.String())
 	}
 	return visors, nil
+}
+
+// Ports return list of all ports used by visor services and apps
+func (v *Visor) Ports() (map[string]int, error) {
+	var ports = make(map[string]int)
+	ports["rpc"] = 22
+	return ports, nil
 }
 
 // TransportTypes implements API.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -700,12 +700,6 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 	}
 
 	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgPtyPort)}
-	ports["dmsg_ctrl"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgCtrlPort)}
-	ports["dmsg_setup_node"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgSetupPort)}
-	ports["dmsg_hypervisor"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgHypervisorPort)}
-	ports["dmsg_transport_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgTransportSetupPort)}
-	ports["dmsg_htttp_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgHTTPPort)}
-	ports["dmsg_await_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgAwaitSetupPort)}
 
 	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1]), Type: "TCP"}
 
@@ -728,7 +722,7 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 
 		dmsgStreams := v.dmsgC.AllStreams()
 		for i, stream := range dmsgStreams {
-			ports[fmt.Sprintf("dmsg_stream_%d", i)] = PortDetail{Port: strings.Split(stream.LocalAddr().String(), ":")[1]}
+			ports[fmt.Sprintf("dmsg_stream_%d", i)] = PortDetail{Port: strings.Split(stream.LocalAddr().String(), ":")[1], Type: "DMSG"}
 		}
 	}
 	if v.procM != nil {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -689,6 +689,9 @@ func (v *Visor) Ports() (map[string]string, error) {
 	ctx := context.Background()
 	var ports = make(map[string]string)
 
+	if v.conf.Hypervisor != nil {
+		ports["hypervisor"] = fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1])
+	}
 	ports["dmsg_pty"] = fmt.Sprint(skyenv.DmsgPtyPort)
 	ports["dmsg_ctrl"] = fmt.Sprint(skyenv.DmsgCtrlPort)
 	ports["dmsg_setup_node"] = fmt.Sprint(skyenv.DmsgSetupPort)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -696,8 +696,9 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 	var ports = make(map[string]PortDetail)
 
 	if v.conf.Hypervisor != nil {
-		ports["hypervisor"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1])}
+		ports["hypervisor"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1]), Type: "TCP/IP"}
 	}
+
 	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgPtyPort)}
 	ports["dmsg_ctrl"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgCtrlPort)}
 	ports["dmsg_setup_node"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgSetupPort)}
@@ -705,19 +706,21 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 	ports["dmsg_transport_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgTransportSetupPort)}
 	ports["dmsg_htttp_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgHTTPPort)}
 	ports["dmsg_await_setup"] = PortDetail{Port: fmt.Sprint(skyenv.DmsgAwaitSetupPort)}
-	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1])}
-	ports["skychat_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkychatAddr, ":")[1])}
-	ports["skysocks_client_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkysocksClientAddr, ":")[1])}
+
+	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.STCPAddr, ":")[1]), Type: "TCP/IP"}
+
+	ports["skychat_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkychatAddr, ":")[1]), Type: "TCP/IP"}
+	ports["skysocks_client_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(skyenv.SkysocksClientAddr, ":")[1]), Type: "TCP/IP"}
 
 	if v.arClient != nil {
 		sudphPort := v.arClient.Addresses(ctx)
 		if sudphPort != "" {
-			ports["sudph"] = PortDetail{Port: sudphPort}
+			ports["sudph"] = PortDetail{Port: sudphPort, Type: "TCP/IP"}
 		}
 	}
 	if v.stunClient != nil {
 		if v.stunClient.PublicIP != nil {
-			ports["public_visor"] = PortDetail{Port: fmt.Sprint(v.stunClient.PublicIP.Port())}
+			ports["public_visor"] = PortDetail{Port: fmt.Sprint(v.stunClient.PublicIP.Port()), Type: "TCP/IP"}
 		}
 	}
 	if v.dmsgC != nil {
@@ -736,7 +739,7 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 		for _, app := range apps {
 			port, err := v.procM.GetAppPort(app.Name)
 			if err == nil {
-				ports[app.Name] = PortDetail{Port: fmt.Sprint(port)}
+				ports[app.Name] = PortDetail{Port: fmt.Sprint(port), Type: "SKYNET"}
 			}
 		}
 	}

--- a/pkg/visor/hypervisorconfig/config.go
+++ b/pkg/visor/hypervisorconfig/config.go
@@ -24,6 +24,11 @@ const (
 	blockKeyLen      = 32
 )
 
+// HTTPAddr returns the httpAddr
+func HTTPAddr() string {
+	return httpAddr
+}
+
 // Key allows a byte slice to be marshaled or unmarshaled from a hex string.
 type Key []byte
 

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -612,7 +612,7 @@ func (r *RPC) RemoteVisors(_ *struct{}, out *[]string) (err error) {
 }
 
 // Ports return list of all ports used by visor services and apps
-func (r *RPC) Ports(_ *struct{}, out *map[string]int) (err error) {
+func (r *RPC) Ports(_ *struct{}, out *map[string]string) (err error) {
 	defer rpcutil.LogCall(r.log, "Ports", nil)(out, &err)
 	ports, err := r.visor.Ports()
 	if ports != nil {

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -612,7 +612,7 @@ func (r *RPC) RemoteVisors(_ *struct{}, out *[]string) (err error) {
 }
 
 // Ports return list of all ports used by visor services and apps
-func (r *RPC) Ports(_ *struct{}, out *map[string]string) (err error) {
+func (r *RPC) Ports(_ *struct{}, out *map[string]PortDetail) (err error) {
 	defer rpcutil.LogCall(r.log, "Ports", nil)(out, &err)
 	ports, err := r.visor.Ports()
 	if ports != nil {

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -611,6 +611,16 @@ func (r *RPC) RemoteVisors(_ *struct{}, out *[]string) (err error) {
 	return err
 }
 
+// Ports return list of all ports used by visor services and apps
+func (r *RPC) Ports(_ *struct{}, out *map[string]int) (err error) {
+	defer rpcutil.LogCall(r.log, "Ports", nil)(out, &err)
+	ports, err := r.visor.Ports()
+	if ports != nil {
+		*out = ports
+	}
+	return err
+}
+
 // IsDMSGClientReady return status of dmsg client
 func (r *RPC) IsDMSGClientReady(_ *struct{}, out *bool) (err error) {
 	defer rpcutil.LogCall(r.log, "IsDMSGClientReady", nil)(out, &err)

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -456,8 +456,8 @@ func (rc *rpcClient) RemoteVisors() ([]string, error) {
 }
 
 // Ports calls Ports.
-func (rc *rpcClient) Ports() (map[string]string, error) {
-	output := map[string]string{}
+func (rc *rpcClient) Ports() (map[string]PortDetail, error) {
+	output := map[string]PortDetail{}
 	rc.Call("Ports", &struct{}{}, &output) // nolint
 	return output, nil
 }
@@ -1053,8 +1053,8 @@ func (mc *mockRPCClient) RemoteVisors() ([]string, error) {
 }
 
 // Ports implements API
-func (mc *mockRPCClient) Ports() (map[string]string, error) {
-	return map[string]string{}, nil
+func (mc *mockRPCClient) Ports() (map[string]PortDetail, error) {
+	return map[string]PortDetail{}, nil
 }
 
 // IsDMSGClientReady implements API.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -456,8 +456,8 @@ func (rc *rpcClient) RemoteVisors() ([]string, error) {
 }
 
 // Ports calls Ports.
-func (rc *rpcClient) Ports() (map[string]int, error) {
-	output := map[string]int{}
+func (rc *rpcClient) Ports() (map[string]string, error) {
+	output := map[string]string{}
 	rc.Call("Ports", &struct{}{}, &output) // nolint
 	return output, nil
 }
@@ -1053,8 +1053,8 @@ func (mc *mockRPCClient) RemoteVisors() ([]string, error) {
 }
 
 // Ports implements API
-func (mc *mockRPCClient) Ports() (map[string]int, error) {
-	return map[string]int{}, nil
+func (mc *mockRPCClient) Ports() (map[string]string, error) {
+	return map[string]string{}, nil
 }
 
 // IsDMSGClientReady implements API.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -455,6 +455,13 @@ func (rc *rpcClient) RemoteVisors() ([]string, error) {
 	return output, nil
 }
 
+// Ports calls Ports.
+func (rc *rpcClient) Ports() (map[string]int, error) {
+	output := map[string]int{}
+	rc.Call("Ports", &struct{}{}, &output) // nolint
+	return output, nil
+}
+
 // IsDMSGClientReady return availability of dsmg client
 func (rc *rpcClient) IsDMSGClientReady() (bool, error) {
 	var out bool
@@ -1043,6 +1050,11 @@ func (mc *mockRPCClient) VPNServers(_, _ string) ([]servicedisc.Service, error) 
 // RemoteVisors implements API
 func (mc *mockRPCClient) RemoteVisors() ([]string, error) {
 	return []string{}, nil
+}
+
+// Ports implements API
+func (mc *mockRPCClient) Ports() (map[string]int, error) {
+	return map[string]int{}, nil
 }
 
 // IsDMSGClientReady implements API.


### PR DESCRIPTION
Did you run `make format && make check`? Yes

**Fixes** #1404 

**Changes**:
- [x] add new subcommand to skywire-cli as `skywire-cli visor ports` to list of all involved ports
- [x] add new methods GetAppPort and SetAppPort to app-cl
- [ ] add flag to show all/running ports, running ports as default and `--all` flag will show all ports

**How to test this PR**:
- run visor
- run `skywire-cli visor ports`

**Screenshot**:
`lsof`
![image](https://user-images.githubusercontent.com/79150699/203728665-9cb0ba37-c059-4605-a8d2-98f304c5ee62.png)


`skywire-cli visor ports`
![image](https://user-images.githubusercontent.com/79150699/203728567-442ec874-ad89-4ed2-b02d-0750532b67b8.png)

