### PR TITLE
Selected DMSG Server

### DIFF
--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -78,12 +78,13 @@ var (
 	root bool // nolint:unused
 	// visorBuildInfo holds information about the build
 	visorBuildInfo *buildinfo.Info
+	dmsgServer     string
 )
 
 func init() {
 	root = skyenv.IsRoot()
-
-	localIPs, err := netutil.DefaultNetworkInterfaceIPs()
+	var err error
+	localIPs, err = netutil.DefaultNetworkInterfaceIPs()
 	if err != nil {
 		logger.WithError(err).Warn("Could not determine network interface IP address")
 		if len(localIPs) == 0 {
@@ -140,6 +141,8 @@ func init() {
 	hiddenflags = append(hiddenflags, "syslog")
 	rootCmd.Flags().StringVarP(&completion, "completion", "z", "", "[ bash | zsh | fish | powershell ]")
 	hiddenflags = append(hiddenflags, "completion")
+	rootCmd.Flags().StringVar(&dmsgServer, "dmsg-server", "", "selected dmsg server by user public key")
+	hiddenflags = append(hiddenflags, "dmsg-server")
 	rootCmd.Flags().BoolVar(&all, "all", false, "show all flags")
 
 	for _, j := range hiddenflags {
@@ -393,7 +396,7 @@ func runVisor(conf *visorconfig.V1) {
 	}
 
 	ctx, cancel := cmdutil.SignalContext(context.Background(), log)
-	vis, ok := visor.NewVisor(ctx, conf, restartCtx, isAutoPeer, autoPeerIP)
+	vis, ok := visor.NewVisor(ctx, conf, restartCtx, isAutoPeer, autoPeerIP, dmsgServer)
 	if !ok {
 		select {
 		case <-ctx.Done():

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -295,12 +295,11 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 		return err
 	}
 	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, v.conf.Dmsg, httpC, v.MasterLogger())
-
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		dmsgC.Serve(context.Background())
+		dmsgC.Serve(ctx)
 	}()
 
 	v.pushCloseStack("dmsg", func() error {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -144,7 +144,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, restartCtx *restart.Con
 	v.runtimeErrors = make(chan error)
 	ctx = context.WithValue(ctx, runtimeErrsKey, v.runtimeErrors)
 	if dmsgServer != "" {
-		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer)
+		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer) //nolint
 	}
 	registerModules(v.MasterLogger())
 	var mainModule visorinit.Module

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -116,7 +116,7 @@ func (v *Visor) MasterLogger() *logging.MasterLogger {
 }
 
 // NewVisor constructs new Visor.
-func NewVisor(ctx context.Context, conf *visorconfig.V1, restartCtx *restart.Context, autoPeer bool, autoPeerIP string) (*Visor, bool) {
+func NewVisor(ctx context.Context, conf *visorconfig.V1, restartCtx *restart.Context, autoPeer bool, autoPeerIP string, dmsgServer string) (*Visor, bool) {
 
 	v := &Visor{
 		log:                  conf.MasterLogger().PackageLogger("visor"),
@@ -143,6 +143,9 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, restartCtx *restart.Con
 	ctx = context.WithValue(ctx, visorKey, v)
 	v.runtimeErrors = make(chan error)
 	ctx = context.WithValue(ctx, runtimeErrsKey, v.runtimeErrors)
+	if dmsgServer != "" {
+		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer)
+	}
 	registerModules(v.MasterLogger())
 	var mainModule visorinit.Module
 	if v.conf.Hypervisor == nil {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1387 

 Changes:	
- new flag for `skywire-visor` as `--dmsg-server <pk>` for set specific dmsg server during running visor. 
- pass this flag to `visor.New()` and set in context in `initDmsg` for `dmsg.Server()` part

How to test this PR:
- checkout dmsg to https://github.com/skycoin/dmsg/pull/199
- on `go.mod` comment out replace part for dmsg
- run `make dep` then `make build`
- from dmsg discovery all lists ([prod](http://dmsgd.skywire.skycoin.com/dmsg-discovery/all_servers) or [test](http://dmsgd.skywire.dev/dmsg-discovery/all_servers), based on your visor config) choosing one dmsg server public key
- run visor by that key as --dmsg-server flag like `./skywire-visor -c skywire-config.json --dmsg-server 02113579604c79b704e169a4fd94fd78167b86fe40da1016f8146935babcc9abcb`
- check logs of visor