### PR TITLE
Little Change on visor test subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - add `--systray` flag to run visor as systray
+- add `test` and `ping` command to `skywire-cli` as `skywire-cli visor ping <pk>` and `skywire-cli visor test`
 
 ### Changed
 - remove `make build-systray` and `make build-windows-systray`, and just keep `make build` and `make build-windows`

--- a/cmd/skywire-cli/commands/visor/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping.go
@@ -67,7 +67,7 @@ var testCmd = &cobra.Command{
 		results, err := rpcClient.TestVisor(pingConfig)
 		internal.Catch(cmd.Flags(), err)
 		for i, result := range results {
-			internal.PrintOutput(cmd.Flags(), result, fmt.Sprintf("Test No. %d\nPK: %s\nMax: %s\nMin: %s\nMean: %s\n\n", i+1, result.PK, result.Max, result.Min, result.Mean))
+			internal.PrintOutput(cmd.Flags(), result, fmt.Sprintf("Test No. %d\nPK: %s\nMax: %s\nMin: %s\nMean: %s\nStatus: %s\n\n", i+1, result.PK, result.Max, result.Min, result.Mean, result.Status))
 		}
 	},
 }

--- a/cmd/skywire-cli/commands/visor/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping.go
@@ -12,16 +12,20 @@ import (
 	"github.com/skycoin/skywire/pkg/visor"
 )
 
-var tries int
-var pcktSize int
+var (
+	tries       int
+	pcktSize    int
+	pubVisCount int
+)
 
 func init() {
 	RootCmd.AddCommand(pingCmd)
-	pingCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of pings")
-	pingCmd.Flags().IntVarP(&pcktSize, "size", "s", 32, "Size of packet, in KB, default is 32KB")
+	pingCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of tries")
+	pingCmd.Flags().IntVarP(&pcktSize, "size", "s", 2, "Size of packet, in KB, default is 2KB")
 	RootCmd.AddCommand(testCmd)
-	testCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of tests per public visors")
-	testCmd.Flags().IntVarP(&pcktSize, "size", "s", 32, "Size of packet, in KB, default is 32KB")
+	testCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of tries per public visors")
+	testCmd.Flags().IntVarP(&pcktSize, "size", "s", 2, "Size of packet, in KB, default is 2KB")
+	testCmd.Flags().IntVarP(&pubVisCount, "count", "c", 2, "Count of Public Visors for using in test.")
 }
 
 var pingCmd = &cobra.Command{
@@ -55,7 +59,7 @@ var testCmd = &cobra.Command{
 	Short: "Test the visor with public visors on network",
 	Long:  "\n	Creates a route with public visors as a hop and returns latency on the conn",
 	Run: func(cmd *cobra.Command, args []string) {
-		pingConfig := visor.PingConfig{Tries: tries, PcktSize: pcktSize}
+		pingConfig := visor.PingConfig{Tries: tries, PcktSize: pcktSize, PubVisCount: pubVisCount}
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/jaypipes/ghw v0.9.0
 	github.com/lib/pq v1.10.7
 	github.com/pterm/pterm v0.12.49
-	github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0
+	github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8
 	github.com/skycoin/skywire-utilities v0.0.0-20220812192633-7137eb730383
 	github.com/skycoin/systray v1.10.1-0.20220630135132-48d2a1fb85d8
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/jaypipes/ghw v0.9.0
 	github.com/lib/pq v1.10.7
 	github.com/pterm/pterm v0.12.49
-	github.com/skycoin/dmsg v0.0.0-20221210172640-25f2ccd24123
+	github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0
 	github.com/skycoin/skywire-utilities v0.0.0-20220812192633-7137eb730383
 	github.com/skycoin/systray v1.10.1-0.20220630135132-48d2a1fb85d8
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0 h1:aHBAkFDXda86Oo8zvHxKGNV5uBdWITY95kYYtNLuMvU=
-github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
+github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8 h1:5DvXRbadJCPP+eSwVFpb/apTWTt+An7iIva8SqoWius=
+github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,6 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/skycoin/dmsg v0.0.0-20221210172640-25f2ccd24123 h1:yCZem366UX05jbiVoe4dKXYU+NRxZbnJjRu1CcNZBXg=
-github.com/skycoin/dmsg v0.0.0-20221210172640-25f2ccd24123/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
 github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0 h1:aHBAkFDXda86Oo8zvHxKGNV5uBdWITY95kYYtNLuMvU=
 github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=

--- a/go.sum
+++ b/go.sum
@@ -535,6 +535,8 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skycoin/dmsg v0.0.0-20221210172640-25f2ccd24123 h1:yCZem366UX05jbiVoe4dKXYU+NRxZbnJjRu1CcNZBXg=
 github.com/skycoin/dmsg v0.0.0-20221210172640-25f2ccd24123/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
+github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0 h1:aHBAkFDXda86Oo8zvHxKGNV5uBdWITY95kYYtNLuMvU=
+github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1029,10 +1029,11 @@ func (v *Visor) StopPing(pk cipher.PubKey) error {
 
 // TestResult type of test result
 type TestResult struct {
-	PK   string
-	Max  string
-	Min  string
-	Mean string
+	PK     string
+	Max    string
+	Min    string
+	Mean   string
+	Status string
 }
 
 // TestVisor trying to test visor
@@ -1061,13 +1062,13 @@ func (v *Visor) TestVisor(conf PingConfig) ([]TestResult, error) {
 		}
 		err := v.DialPing(conf)
 		if err != nil {
-			result = append(result, TestResult{PK: conf.PK.String(), Max: fmt.Sprint(0), Min: fmt.Sprint(0), Mean: fmt.Sprint(0)})
+			result = append(result, TestResult{PK: conf.PK.String(), Max: fmt.Sprint(0), Min: fmt.Sprint(0), Mean: fmt.Sprint(0), Status: "Failed"})
 			continue
 		}
 		latencies, err := v.Ping(conf)
 		if err != nil {
 			go v.StopPing(conf.PK) //nolint
-			result = append(result, TestResult{PK: conf.PK.String(), Max: fmt.Sprint(0), Min: fmt.Sprint(0), Mean: fmt.Sprint(0)})
+			result = append(result, TestResult{PK: conf.PK.String(), Max: fmt.Sprint(0), Min: fmt.Sprint(0), Mean: fmt.Sprint(0), Status: "Failed"})
 			continue
 		}
 		var max, min, mean, sumLatency time.Duration
@@ -1082,7 +1083,7 @@ func (v *Visor) TestVisor(conf PingConfig) ([]TestResult, error) {
 			sumLatency += latency
 		}
 		mean = sumLatency / time.Duration(len(latencies))
-		result = append(result, TestResult{PK: conf.PK.String(), Max: fmt.Sprint(max), Min: fmt.Sprint(min), Mean: fmt.Sprint(mean)})
+		result = append(result, TestResult{PK: conf.PK.String(), Max: fmt.Sprint(max), Min: fmt.Sprint(min), Mean: fmt.Sprint(mean), Status: "Success"})
 		v.StopPing(conf.PK) //nolint
 	}
 	return result, nil

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1043,7 +1043,7 @@ func (v *Visor) TestVisor(conf PingConfig) ([]TestResult, error) {
 		return result, errors.New("dmsgC is not available")
 	}
 
-	publicVisors, err := v.dmsgC.AllEntries()
+	publicVisors, err := v.dmsgC.AllEntries(context.TODO())
 	if err != nil {
 		return result, err
 	}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1052,6 +1052,10 @@ func (v *Visor) TestVisor(conf PingConfig) ([]TestResult, error) {
 	}
 
 	for _, publicVisor := range publicVisors {
+		if publicVisor == conf.PK.Hex() {
+			continue
+		}
+
 		if err := conf.PK.UnmarshalText([]byte(publicVisor)); err != nil {
 			continue
 		}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1038,11 +1038,11 @@ type TestResult struct {
 // TestVisor trying to test visor
 func (v *Visor) TestVisor(conf PingConfig) ([]TestResult, error) {
 	result := []TestResult{}
-	if v.dClient == nil {
-		return result, errors.New("dClient not available")
+	if v.dmsgC == nil {
+		return result, errors.New("dmsgC is not available")
 	}
 
-	publicVisors, err := v.dClient.AllEntries(context.TODO())
+	publicVisors, err := v.dmsgC.AllEntries()
 	if err != nil {
 		return result, err
 	}

--- a/vendor/github.com/godbus/dbus/v5/conn.go
+++ b/vendor/github.com/godbus/dbus/v5/conn.go
@@ -432,7 +432,7 @@ func (conn *Conn) inWorker() {
 		case TypeSignal:
 			conn.handleSignal(sequence, msg)
 		case TypeMethodCall:
-conn.handleCall(msg)
+			go conn.handleCall(msg)
 		}
 
 	}

--- a/vendor/github.com/skycoin/dmsg/internal/servermetrics/empty.go
+++ b/vendor/github.com/skycoin/dmsg/internal/servermetrics/empty.go
@@ -1,3 +1,4 @@
+// Package servermetrics internal/servermetrics/empty.go
 package servermetrics
 
 // NewEmpty constructs new empty metrics.

--- a/vendor/github.com/skycoin/dmsg/internal/servermetrics/metrics.go
+++ b/vendor/github.com/skycoin/dmsg/internal/servermetrics/metrics.go
@@ -1,3 +1,4 @@
+// Package servermetrics internal/servermetrics/metrics.go
 package servermetrics
 
 // Metrics collects metrics for metrics tracking system.

--- a/vendor/github.com/skycoin/dmsg/internal/servermetrics/victoria_metrics.go
+++ b/vendor/github.com/skycoin/dmsg/internal/servermetrics/victoria_metrics.go
@@ -1,3 +1,4 @@
+// Package servermetrics internal/servermetrics/victoria_metrics.go
 package servermetrics
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/direct/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/direct/client.go
@@ -92,3 +92,13 @@ func (c *directClient) AllServers(ctx context.Context) (entries []*disc.Entry, e
 	}
 	return entries, nil
 }
+
+// AllEntries return list of all entries of directClient
+func (c *directClient) AllEntries(ctx context.Context) (entries []string, err error) {
+	c.mx.RLock()
+	defer c.mx.RUnlock()
+	for _, entry := range c.entries {
+		entries = append(entries, entry.Static.Hex())
+	}
+	return entries, nil
+}

--- a/vendor/github.com/skycoin/dmsg/pkg/direct/direct.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/direct/direct.go
@@ -1,3 +1,4 @@
+// Package direct pkg/direct/direct.go
 package direct
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/direct/entries.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/direct/entries.go
@@ -1,3 +1,4 @@
+// Package direct pkg/direct/entries.go
 package direct
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/disc/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/disc/client.go
@@ -1,4 +1,4 @@
-// Package disc implements client for dmsg discovery.
+// Package disc pkg/disc/client.go
 package disc
 
 import (
@@ -25,6 +25,7 @@ type APIClient interface {
 	DelEntry(context.Context, *Entry) error
 	AvailableServers(context.Context) ([]*Entry, error)
 	AllServers(context.Context) ([]*Entry, error)
+	AllEntries(ctx context.Context) ([]string, error)
 }
 
 // HTTPClient represents a client that communicates with a dmsg-discovery service through http, it
@@ -277,6 +278,48 @@ func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 func (c *httpClient) AllServers(ctx context.Context) ([]*Entry, error) {
 	var entries []*Entry
 	endpoint := c.address + "/dmsg-discovery/all_servers"
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := c.client.Do(req)
+	if resp != nil {
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				c.log.WithError(err).Warn("Failed to close response body")
+			}
+		}()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// if the response is an error it will be codified as an HTTPMessage
+	if resp.StatusCode != http.StatusOK {
+		var message HTTPMessage
+		err = json.NewDecoder(resp.Body).Decode(&message)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, errFromString(message.Message)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&entries)
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// AllEntries returns list of all entries.
+func (c *httpClient) AllEntries(ctx context.Context) ([]string, error) {
+	var entries []string
+	endpoint := c.address + "/dmsg-discovery/entries"
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/vendor/github.com/skycoin/dmsg/pkg/disc/entry.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/disc/entry.go
@@ -1,3 +1,4 @@
+// Package disc pkg/disc/entry.go
 package disc
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/disc/http_message.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/disc/http_message.go
@@ -1,3 +1,4 @@
+// Package disc pkg/disc/http_message.go
 package disc
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/disc/testing.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/disc/testing.go
@@ -1,3 +1,4 @@
+// Package disc pkg/disc/testing.go
 package disc
 
 import (
@@ -151,6 +152,17 @@ func (m *mockClient) AllServers(_ context.Context) ([]*Entry, error) {
 		if e := e; e.Server != nil {
 			list = append(list, &e)
 		}
+	}
+	return list, nil
+}
+
+// AllEntries returns all entries that the APIClient mock has
+func (m *mockClient) AllEntries(_ context.Context) ([]string, error) {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+	list := make([]string, 0, len(m.entries))
+	for _, e := range m.entries {
+		list = append(list, e.Static.Hex())
 	}
 	return list, nil
 }

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
@@ -463,6 +463,15 @@ func (ce *Client) AllStreams() (out []*Stream) {
 	return out
 }
 
+// AllEntries returns all the entries registered in discovery
+func (ce *Client) AllEntries(ctx context.Context) (entries []string, err error) {
+	err = netutil.NewDefaultRetrier(ce.log).Do(ctx, func() error {
+		entries, err = ce.dc.AllEntries(ctx)
+		return err
+	})
+	return entries, err
+}
+
 // ConnectionsSummary associates connected clients, and the servers that connect such clients.
 // Key: Client PK, Value: Slice of Server PKs
 type ConnectionsSummary map[cipher.PubKey][]cipher.PubKey

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/client_session.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/client_session.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/client_session.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/const.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/const.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/const.go
 package dmsg
 
 import "time"

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/entity_common.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/entity_common.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/entity_common.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/errors.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/errors.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/errors.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/listener.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/listener.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/listener.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/server_session.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/server_session.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/server_session.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/session_common.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/session_common.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/session_common.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/stream.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/stream.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/stream.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/types.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/types.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/types.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/util.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/util.go
@@ -1,3 +1,4 @@
+// Package dmsg pkg/dmsg/util.go
 package dmsg
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgctrl/serve_listener.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgctrl/serve_listener.go
@@ -1,3 +1,4 @@
+// Package dmsgctrl pkg/dmsgctrl/serve_listener.go
 package dmsgctrl
 
 import "net"

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgget/flags.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgget/flags.go
@@ -1,3 +1,4 @@
+// Package dmsgget pkg/dmsgget/flags.go
 package dmsgget
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgget/progress_writer.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgget/progress_writer.go
@@ -1,3 +1,4 @@
+// Package dmsgget pkg/dmsgget/progress_writer.go
 package dmsgget
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgget/url.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgget/url.go
@@ -1,3 +1,4 @@
+// Package dmsgget pkg/dmsgget/url.go
 package dmsgget
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsghttp/http_transport.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsghttp/http_transport.go
@@ -1,3 +1,4 @@
+// Package dmsghttp pkg/dmsghttp/http_transport.go
 package dmsghttp
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsghttp/util.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsghttp/util.go
@@ -1,3 +1,4 @@
+// Package dmsghttp pkg/dmsghttp/util.go
 package dmsghttp
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/cli_unix.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/cli_unix.go
@@ -1,6 +1,7 @@
 //go:build !windows
 // +build !windows
 
+// Package dmsgpty pkg/dmsgpty/cli_unix.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/cli_windows.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/cli_windows.go
@@ -1,6 +1,7 @@
 //go:build windows
 // +build windows
 
+// Package dmsgpty pkg/dmsgpty/cli_windows.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/conf.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/conf.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/conf.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/const.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/const.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/const.go
 package dmsgpty
 
 // Constants related to pty.

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/const_unix.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/const_unix.go
@@ -1,6 +1,7 @@
 //go:build !windows
 // +build !windows
 
+// Package dmsgpty pkg/dmsgpty/const_unix.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/const_windows.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/const_windows.go
@@ -1,6 +1,7 @@
 //go:build windows
 // +build windows
 
+// Package dmsgpty pkg/dmsgpty/const_windows.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/host.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/host.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/host.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/host_mux.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/host_mux.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/host_mux.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_client.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/pty_client.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_client_windows.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_client_windows.go
@@ -1,6 +1,7 @@
 //go:build windows
 // +build windows
 
+// Package dmsgpty pkg/dmsgpty/pty_client_windows.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_gateway.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_gateway.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/pty_gateway.go
 package dmsgpty
 
 // WinSize wraps around pty.Winsize and *windows.Coord

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_gateway_unix.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_gateway_unix.go
@@ -1,6 +1,7 @@
 //go:build !windows
 // +build !windows
 
+// Package dmsgpty pkg/dmsgpty/pty_gateway_unix.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_gateway_windows.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_gateway_windows.go
@@ -1,6 +1,7 @@
 //go:build windows
 // +build windows
 
+// Package dmsgpty pkg/dmsgpty/pty_gateway_windows.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_unix.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_unix.go
@@ -1,6 +1,7 @@
 //go:build !windows
 // +build !windows
 
+// Package dmsgpty pkg/dmsgpty/pty_unix.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_windows.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/pty_windows.go
@@ -1,6 +1,7 @@
 //go:build windows
 // +build windows
 
+// Package dmsgpty pkg/dmsgpty/pty_windows.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/rpc_util.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/rpc_util.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/rpc_util.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/ui.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_dialer.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_dialer.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/ui_dialer.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_html.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_html.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/ui_html.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_unix.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_unix.go
@@ -1,6 +1,7 @@
 //go:build !windows
 // +build !windows
 
+// Package dmsgpty pkg/dmsgpty/ui_unix.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_windows.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/ui_windows.go
@@ -1,6 +1,7 @@
 //go:build windows
 // +build windows
 
+// Package dmsgpty pkg/dmsgpty/ui_windows.go
 package dmsgpty
 
 import "golang.org/x/sys/windows"

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist_client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist_client.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/whitelist_client.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist_gateway.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist_gateway.go
@@ -1,3 +1,4 @@
+// Package dmsgpty pkg/dmsgpty/whitelist_gateway.go
 package dmsgpty
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgtest/env.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgtest/env.go
@@ -1,3 +1,4 @@
+// Package dmsgtest pkg/dmsgtest/env.go
 package dmsgtest
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/ioutil/buf_read.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/ioutil/buf_read.go
@@ -1,4 +1,4 @@
-// Package ioutil pkg/dmsghttp/examples_test.go
+// Package ioutil pkg/ioutil/buf_read.go
 package ioutil
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/ioutil/logging.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/ioutil/logging.go
@@ -1,3 +1,4 @@
+// Package ioutil pkg/ioutil/logging.go
 package ioutil
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/noise/dh.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/noise/dh.go
@@ -1,3 +1,4 @@
+// Package noise pkg/noise/dh.go
 package noise
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/noise/net.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/noise/net.go
@@ -1,3 +1,4 @@
+// Package noise pkg/noise/net.go
 package noise
 
 import (

--- a/vendor/github.com/skycoin/dmsg/pkg/noise/read_writer.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/noise/read_writer.go
@@ -1,3 +1,4 @@
+// Package noise pkg/noise/read_write.go
 package noise
 
 import (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/shirou/gopsutil/v3/process
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0
+# github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8
 ## explicit; go 1.16
 github.com/skycoin/dmsg/internal/servermetrics
 github.com/skycoin/dmsg/pkg/direct

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/shirou/gopsutil/v3/process
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v0.0.0-20221210172640-25f2ccd24123
+# github.com/skycoin/dmsg v1.3.0-rc1.0.20230105091948-3046bfc90fc0
 ## explicit; go 1.16
 github.com/skycoin/dmsg/internal/servermetrics
 github.com/skycoin/dmsg/pkg/direct


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- use AllEntries in dmsgC instead uptime tracker on get Public Visors
- improve output of command with add `Status` field
- decrease Retrier config to 1, means 3 times test on each protocol (in order stcpr, sudph and dmsg)
- add new flag `-c` to count of public visors that use in test. if the value be bigger than all visors then all visors in network will test. the default value is 2

How to test this PR:
- build by `make build`
- run visor (both test and prod env available for test)
- run command `skywire-cli visor test -c <count-of-visor> -t <count-of-pings-on-each-visor> -s <size-of-packet>`