### PR TITLE
built tag for non-systray skywire-visor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - add `--systray` flag to run visor as systray
+- add tag `withoutsystray` to build skywire-visor without systray library
+- add `build-static-wos` for build static without systray skywire-visor
 
 ### Changed
 - remove `make build-systray` and `make build-windows-systray`, and just keep `make build` and `make build-windows`

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,8 @@ build-windows-appveyor: host-apps-windows-appveyor bin-windows-appveyor ## Insta
 
 build-static: host-apps-static bin-static ## Build apps and binaries. `go build` with ${OPTS}
 
+build-static-wos: host-apps-static bin-static-wos ## Build apps and binaries. `go build` with ${OPTS}
+
 installer: mac-installer ## Builds MacOS installer for skywire-visor
 
 install-system-linux: build # Workaround for debugging linux package installation
@@ -260,6 +262,12 @@ bin-windows-appveyor: ## Build `skywire-visor`, `skywire-cli`
 # Static Bin
 bin-static: ## Build `skywire-visor`, `skywire-cli`
 	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o ./skywire-visor ./cmd/skywire-visor
+	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o ./skywire-cli  ./cmd/skywire-cli
+	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o ./setup-node ./cmd/setup-node
+
+# Static Bin without Systray
+bin-static-wos: ## Build `skywire-visor`, `skywire-cli`
+	${STATIC_OPTS} go build -tags withoutsystray -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o ./skywire-visor ./cmd/skywire-visor
 	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o ./skywire-cli  ./cmd/skywire-cli
 	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o ./setup-node ./cmd/setup-node
 

--- a/cmd/skywire-visor/commands/root.go
+++ b/cmd/skywire-visor/commands/root.go
@@ -406,6 +406,8 @@ func runVisor(conf *visorconfig.V1) {
 		}
 		if runAsSystray {
 			quitSystray()
+		} else {
+			quit()
 		}
 		return
 	}

--- a/cmd/skywire-visor/commands/systray.go
+++ b/cmd/skywire-visor/commands/systray.go
@@ -1,3 +1,6 @@
+//go:build !withoutsystray
+// +build !withoutsystray
+
 // Package commands cmd/skywire-visor/commands/systray.go
 package commands
 
@@ -65,4 +68,8 @@ func setStopFunction(log *logging.MasterLogger, cancel context.CancelFunc, fn fu
 		cancel()
 		stopVisorWg.Wait()
 	}
+}
+
+func quit() {
+
 }

--- a/cmd/skywire-visor/commands/withoutsystray.go
+++ b/cmd/skywire-visor/commands/withoutsystray.go
@@ -1,0 +1,45 @@
+//go:build withoutsystray
+// +build withoutsystray
+
+// Package commands cmd/skywire-visor/commands/systray.go
+package commands
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire-utilities/pkg/logging"
+)
+
+func runAppSystray() {
+	runVisor(nil)
+}
+
+func setStopFunctionSystray(log *logging.MasterLogger, cancel context.CancelFunc, fn func() error) {
+	setStopFunction(log, cancel, fn)
+}
+
+func quitSystray() {
+	quit()
+}
+
+func runApp() {
+	runVisor(nil)
+}
+
+// setStopFunction sets the stop function
+func setStopFunction(log *logging.MasterLogger, cancel context.CancelFunc, fn func() error) {
+	stopVisorWg.Add(1)
+	defer stopVisorWg.Done()
+
+	stopVisorFn = func() {
+		if err := fn(); err != nil {
+			log.WithError(err).Error("Visor closed with error.")
+		}
+		cancel()
+		stopVisorWg.Wait()
+	}
+}
+
+func quit() {
+
+}

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -1,3 +1,6 @@
+//go:build !withoutsystray
+// +build !withoutsystray
+
 // Package gui internal/gui/gui.go
 package gui
 

--- a/internal/gui/gui_darwin.go
+++ b/internal/gui/gui_darwin.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build darwin && !withoutsystray
+// +build darwin,!withoutsystray
 
 package gui
 

--- a/internal/gui/gui_linux.go
+++ b/internal/gui/gui_linux.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !withoutsystray
+// +build linux,!withoutsystray
 
 package gui
 

--- a/internal/gui/gui_test.go
+++ b/internal/gui/gui_test.go
@@ -1,3 +1,6 @@
+//go:build !withoutsystray
+// +build !withoutsystray
+
 // Package gui internal/gui/gui_test.go
 package gui
 

--- a/internal/gui/gui_unix.go
+++ b/internal/gui/gui_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !withoutsystray
+// +build !windows,!withoutsystray
 
 package gui
 

--- a/internal/gui/gui_windows.go
+++ b/internal/gui/gui_windows.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows && !withoutsystray
+// +build windows,!withoutsystray
 
 package gui
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add `withoutsystray` tag for build	skywire-visor without systray library
- add `build-static-wos` for build static binaries that skywire-visor build with `withoutsystray` tag

How to test this PR:
_