### PR TITLE
Fix GetRewardAddress API

### DIFF
--- a/cmd/skywire-cli/commands/reward/root.go
+++ b/cmd/skywire-cli/commands/reward/root.go
@@ -107,12 +107,6 @@ var rewardCmd = &cobra.Command{
 		if output == "" {
 			output = visorconfig.PackageConfig().LocalPath + "/" + visorconfig.RewardFile
 		}
-		if isDeleteFile {
-			err := os.Remove(output)
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Error deleting file. err=%v", err))
-			}
-		}
 		//print reward address and exit
 		if isRead {
 			dat, err := os.ReadFile(output) //nolint
@@ -146,14 +140,23 @@ var rewardCmd = &cobra.Command{
 			readRewardFile(cmd.Flags())
 			return
 		}
-		rewardaddress, err := client.SetRewardAddress(rewardAddress)
+
+		if isDeleteFile {
+			err := client.DeleteRewardAddress()
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			return
+		}
+
+		rwdAdd, err := client.SetRewardAddress(rewardAddress)
 		if err != nil {
 			internal.PrintError(cmd.Flags(), fmt.Errorf("Failed to connect: %v", err))      //nolint
 			internal.Catch(cmd.Flags(), os.WriteFile(output, []byte(cAddr.String()), 0644)) //nolint
 			readRewardFile(cmd.Flags())
 			return
 		}
-		output := fmt.Sprintf("Reward address:\n  %s\n", rewardaddress)
+		output := fmt.Sprintf("Reward address:\n  %s\n", rwdAdd)
 		internal.PrintOutput(cmd.Flags(), output, output)
 	},
 }

--- a/cmd/skywire-cli/commands/visor/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping.go
@@ -32,7 +32,7 @@ func init() {
 var pingCmd = &cobra.Command{
 	Use:   "ping <pk>",
 	Short: "Ping the visor with given pk",
-	Long:  "\n	Creates a route with the provided pk as a hop and returns latency on the conn",
+	Long:  "\n  Creates a route with the provided pk as a hop and returns latency on the conn",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pk := internal.ParsePK(cmd.Flags(), "pk", args[0])
@@ -58,7 +58,7 @@ var pingCmd = &cobra.Command{
 var testCmd = &cobra.Command{
 	Use:   "test",
 	Short: "Test the visor with public visors on network",
-	Long:  "\n	Creates a route with public visors as a hop and returns latency on the conn",
+	Long:  "\n  Creates a route with public visors as a hop and returns latency on the conn",
 	Run: func(cmd *cobra.Command, args []string) {
 		pingConfig := visor.PingConfig{Tries: tries, PcktSize: pcktSize, PubVisCount: pubVisCount}
 		rpcClient, err := clirpc.Client(cmd.Flags())

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -215,6 +215,7 @@ type Summary struct {
 	MinHops              uint16                           `json:"min_hops"`
 	PersistentTransports []transport.PersistentTransports `json:"persistent_transports"`
 	SkybianBuildVersion  string                           `json:"skybian_build_version"`
+	RewardAddress        string                           `json:"reward_address"`
 	BuildTag             string                           `json:"build_tag"`
 	PublicAutoconnect    bool                             `json:"public_autoconnect"`
 }
@@ -266,6 +267,11 @@ func (v *Visor) Summary() (*Summary, error) {
 		dmsgStatValue = &dmsgTracker
 	}
 
+	rewardAddress, err := v.GetRewardAddress()
+	if err != nil {
+		return nil, fmt.Errorf("reward_address")
+	}
+
 	summary := &Summary{
 		Overview:             overview,
 		Health:               health,
@@ -275,6 +281,7 @@ func (v *Visor) Summary() (*Summary, error) {
 		PersistentTransports: pts,
 		SkybianBuildVersion:  skybianBuildVersion,
 		BuildTag:             BuildTag,
+		RewardAddress:        rewardAddress,
 		PublicAutoconnect:    v.conf.Transport.PublicAutoconnect,
 		DmsgStats:            dmsgStatValue,
 	}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -350,6 +350,17 @@ func (v *Visor) SetRewardAddress(p string) (string, error) {
 // GetRewardAddress implements API.
 func (v *Visor) GetRewardAddress() (string, error) {
 	path := v.conf.LocalPath + "/" + visorconfig.RewardFile
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		file, err := os.Create(filepath.Clean(path))
+		if err != nil {
+			return "", fmt.Errorf("failed to create config file. err=%v", err)
+		}
+		err = file.Close()
+		if err != nil {
+			return "", fmt.Errorf("failed to close config file. err=%v", err)
+		}
+	}
 	rConfig, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return "", fmt.Errorf("failed to read config file. err=%v", err)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -270,7 +270,7 @@ func (v *Visor) Summary() (*Summary, error) {
 
 	rewardAddress, err := v.GetRewardAddress()
 	if err != nil {
-		return nil, fmt.Errorf("reward_address")
+		v.log.Warn(err)
 	}
 
 	summary := &Summary{

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -58,6 +58,7 @@ type API interface {
 	//reward setting
 	SetRewardAddress(string) (string, error)
 	GetRewardAddress() (string, error)
+	DeleteRewardAddress() error
 
 	//app controls
 	App(appName string) (*appserver.AppState, error)
@@ -373,6 +374,17 @@ func (v *Visor) GetRewardAddress() (string, error) {
 		return "", fmt.Errorf("failed to read config file. err=%v", err)
 	}
 	return string(rConfig), nil
+}
+
+// DeleteRewardAddress implements API.
+func (v *Visor) DeleteRewardAddress() error {
+
+	path := v.conf.LocalPath + "/" + visorconfig.RewardFile
+	err := os.Remove(path)
+	if err != nil {
+		return fmt.Errorf("Error deleting file. err=%v", err)
+	}
+	return nil
 }
 
 // Apps implements API.

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -113,6 +113,12 @@ func (r *RPC) GetRewardAddress(_ *struct{}, out *string) (err error) {
 	return err
 }
 
+// DeleteRewardAddress deletes the reward.txt
+func (r *RPC) DeleteRewardAddress(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "DeleteRewardAddress", nil)(nil, &err)
+	return r.visor.DeleteRewardAddress()
+}
+
 /*
 	<<< APP LOGS >>>
 */

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -137,6 +137,11 @@ func (rc *rpcClient) GetRewardAddress() (rConfig string, err error) {
 	return rConfig, err
 }
 
+// DeleteRewardAddress implements API.
+func (rc *rpcClient) DeleteRewardAddress() (err error) {
+	return rc.Call("DeleteRewardAddress", &struct{}{}, &struct{}{})
+}
+
 // Apps calls Apps.
 func (rc *rpcClient) Apps() ([]*appserver.AppState, error) {
 	states := make([]*appserver.AppState, 0)
@@ -751,6 +756,11 @@ func (mc *mockRPCClient) SetRewardAddress(p string) (string, error) {
 // GetRewardAddress implements API.
 func (mc *mockRPCClient) GetRewardAddress() (string, error) {
 	return "", nil
+}
+
+// DeleteRewardAddress implements API.
+func (mc *mockRPCClient) DeleteRewardAddress() error {
+	return nil
 }
 
 // Apps implements API.


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #1435 
Fixes #1437
Fixes #1436 

 Changes:	
- Fixed GetRewardAddress API 
- Added RewardAddress to summary API

How to test this PR:
1. Delete the rewards file from `./local/reward.txt`
2. Build the PR `make build`
3. Run the API `http://127.0.0.1:8000/api/visors/<pk>/reward`
4. Check the output
5. Run the API `http://127.0.0.1:8000/api/visors/<pk>/summary`
6. Check the output
7. Run DELETE `http://127.0.0.1:8000/api/visors/<pk>/reward`
8. Check the rewards file at `./local/reward.txt`