### PR TITLE
disable public autoconnect logic for `config gen -b`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.3.0
 
--   disable public autoconnect logic for `config gen -b` [#1439](https://github.com/skycoin/skywire/pull/1440)
+-   disable public autoconnect logic for `config gen -b` [#1440](https://github.com/skycoin/skywire/pull/1440)
 -   Add changelog generation script [#1439](https://github.com/skycoin/skywire/pull/1439)
 -   Fix GetRewardAddress API  [#1438](https://github.com/skycoin/skywire/pull/1438)
 -   fix release issues  [#1432](https://github.com/skycoin/skywire/pull/1432) [#1434](https://github.com/skycoin/skywire/pull/1434) [#1433](https://github.com/skycoin/skywire/pull/1433)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.3.0
 
+-   disable public autoconnect logic for `config gen -b` [#1439](https://github.com/skycoin/skywire/pull/1440)
 -   Add changelog generation script [#1439](https://github.com/skycoin/skywire/pull/1439)
 -   Fix GetRewardAddress API  [#1438](https://github.com/skycoin/skywire/pull/1438)
 -   fix release issues  [#1432](https://github.com/skycoin/skywire/pull/1432) [#1434](https://github.com/skycoin/skywire/pull/1434) [#1433](https://github.com/skycoin/skywire/pull/1433)

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -31,7 +31,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "url")
 	genConfigCmd.Flags().StringVar(&logLevel, "log-level", "info", "level of logging in config")
 	gHiddenFlags = append(gHiddenFlags, "log-level")
-	genConfigCmd.Flags().BoolVarP(&isBestProtocol, "bestproto", "b", false, "best protocol (dmsg | direct) based on location")
+	genConfigCmd.Flags().BoolVarP(&isBestProtocol, "bestproto", "b", false, "best protocol (dmsg | direct) based on location") //this will also disable public autoconnect based on location
 	genConfigCmd.Flags().BoolVarP(&isDisableAuth, "noauth", "c", false, "disable authentication for hypervisor UI")
 	gHiddenFlags = append(gHiddenFlags, "noauth")
 	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", false, "use dmsg connection to skywire services")
@@ -80,7 +80,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isRetainHypervisors, "retainhv", "x", false, "retain existing hypervisors with regen")
 	gHiddenFlags = append(gHiddenFlags, "retainhv")
-	genConfigCmd.Flags().BoolVarP(&isPublicAutoConn, "autoconn", "y", false, "disable autoconnect to public visors")
+	genConfigCmd.Flags().BoolVarP(&isDisablePublicAutoConn, "autoconn", "y", false, "disable autoconnect to public visors")
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isPublic, "public", "z", false, "publicize visor in service discovery")
 	gHiddenFlags = append(gHiddenFlags, "public")
@@ -247,7 +247,9 @@ var genConfigCmd = &cobra.Command{
 
 		//determine best protocol
 		if isBestProtocol && netutil.LocalProtocol() {
+			isDisablePublicAutoConn = true
 			isDmsgHTTP = true
+
 		}
 
 		//create the conf
@@ -372,7 +374,7 @@ var genConfigCmd = &cobra.Command{
 		if ver != "" {
 			conf.Common.Version = ver
 		}
-		if isPublicAutoConn {
+		if isDisablePublicAutoConn {
 			conf.Transport.PublicAutoconnect = false
 		}
 		if isPublic {

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -80,7 +80,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isRetainHypervisors, "retainhv", "x", false, "retain existing hypervisors with regen")
 	gHiddenFlags = append(gHiddenFlags, "retainhv")
-	genConfigCmd.Flags().BoolVarP(&isDisablePublicAutoConn, "autoconn", "y", false, "disable autoconnect to public visors")
+	genConfigCmd.Flags().BoolVarP(&disablePublicAutoConn, "autoconn", "y", false, "disable autoconnect to public visors")
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isPublic, "public", "z", false, "publicize visor in service discovery")
 	gHiddenFlags = append(gHiddenFlags, "public")
@@ -247,7 +247,7 @@ var genConfigCmd = &cobra.Command{
 
 		//determine best protocol
 		if isBestProtocol && netutil.LocalProtocol() {
-			isDisablePublicAutoConn = true
+			disablePublicAutoConn = true
 			isDmsgHTTP = true
 
 		}
@@ -374,7 +374,7 @@ var genConfigCmd = &cobra.Command{
 		if ver != "" {
 			conf.Common.Version = ver
 		}
-		if isDisablePublicAutoConn {
+		if disablePublicAutoConn {
 			conf.Transport.PublicAutoconnect = false
 		}
 		if isPublic {

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -73,7 +73,7 @@ var (
 	conf                   *visorconfig.V1
 	isUsr                  bool
 	isPublic               bool
-	isPublicAutoConn       bool
+	disablePublicAutoConn  bool
 	isDisplayNodeIP        bool
 	addExampleApps         bool
 )

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -15,67 +15,67 @@ import (
 var logger = logging.MustGetLogger("skywire-cli")
 
 var (
-	sk                      cipher.SecKey
-	output                  string
-	confPath                string
-	configName              string //nolint Note: configName used, but golangci-lint marked it unused in wrong
-	isStdout                bool
-	isRegen                 bool
-	isRetainHypervisors     bool
-	isTestEnv               bool
-	pText                   string
-	isPkgEnv                bool
-	isUsrEnv                bool
-	isHypervisor            bool
-	hypervisorPKs           string
-	isDmsgHTTP              bool
-	isPublicRPC             bool
-	isVpnServerEnable       bool
-	isDisableAuth           bool
-	isEnableAuth            bool
-	selectedOS              string
-	disableApps             string
-	isBestProtocol          bool
-	serviceConfURL          string
-	services                *visorconfig.Services
-	isForce                 bool
-	isHide                  bool
-	isAll                   bool
-	isOutUnset              bool
-	ver                     string
-	isRoot                  = visorconfig.IsRoot()
-	svcConf                 = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")     //visorconfig.DefaultServiceConfAddr
-	testConf                = strings.ReplaceAll(utilenv.TestServiceConfAddr, "http://", "") //visorconfig.DefaultServiceConfAddr
-	gHiddenFlags            []string
-	uHiddenFlags            []string
-	binPath                 string
-	logLevel                string
-	isPkg                   bool
-	input                   string
-	isUpdateEndpoints       bool
-	addHypervisorPKs        string
-	isResetHypervisor       bool
-	setVPNClientKillswitch  string
-	addVPNClientSrv         string
-	addVPNClientPasscode    string
-	isResetVPNclient        bool
-	addVPNServerPasscode    string
-	setVPNServerSecure      string
-	setVPNServerAutostart   string
-	setVPNServerNetIfc      string
-	isResetVPNServer        bool
-	addSkysocksClientSrv    string
-	isResetSkysocksClient   bool
-	skysocksPasscode        string
-	isResetSkysocks         bool
-	setPublicAutoconnect    string
-	minHops                 int
-	conf                    *visorconfig.V1
-	isUsr                   bool
-	isPublic                bool
-	isDisablePublicAutoConn bool
-	isDisplayNodeIP         bool
-	addExampleApps          bool
+	sk                     cipher.SecKey
+	output                 string
+	confPath               string
+	configName             string //nolint Note: configName used, but golangci-lint marked it unused in wrong
+	isStdout               bool
+	isRegen                bool
+	isRetainHypervisors    bool
+	isTestEnv              bool
+	pText                  string
+	isPkgEnv               bool
+	isUsrEnv               bool
+	isHypervisor           bool
+	hypervisorPKs          string
+	isDmsgHTTP             bool
+	isPublicRPC            bool
+	isVpnServerEnable      bool
+	isDisableAuth          bool
+	isEnableAuth           bool
+	selectedOS             string
+	disableApps            string
+	isBestProtocol         bool
+	serviceConfURL         string
+	services               *visorconfig.Services
+	isForce                bool
+	isHide                 bool
+	isAll                  bool
+	isOutUnset             bool
+	ver                    string
+	isRoot                 = visorconfig.IsRoot()
+	svcConf                = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")     //visorconfig.DefaultServiceConfAddr
+	testConf               = strings.ReplaceAll(utilenv.TestServiceConfAddr, "http://", "") //visorconfig.DefaultServiceConfAddr
+	gHiddenFlags           []string
+	uHiddenFlags           []string
+	binPath                string
+	logLevel               string
+	isPkg                  bool
+	input                  string
+	isUpdateEndpoints      bool
+	addHypervisorPKs       string
+	isResetHypervisor      bool
+	setVPNClientKillswitch string
+	addVPNClientSrv        string
+	addVPNClientPasscode   string
+	isResetVPNclient       bool
+	addVPNServerPasscode   string
+	setVPNServerSecure     string
+	setVPNServerAutostart  string
+	setVPNServerNetIfc     string
+	isResetVPNServer       bool
+	addSkysocksClientSrv   string
+	isResetSkysocksClient  bool
+	skysocksPasscode       string
+	isResetSkysocks        bool
+	setPublicAutoconnect   string
+	minHops                int
+	conf                   *visorconfig.V1
+	isUsr                  bool
+	isPublic               bool
+	isPublicAutoConn       bool
+	isDisplayNodeIP        bool
+	addExampleApps         bool
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -73,7 +73,7 @@ var (
 	conf                   *visorconfig.V1
 	isUsr                  bool
 	isPublic               bool
-	isPublicAutoConn       bool
+	isDisablePublicAutoConn       bool
 	isDisplayNodeIP        bool
 	addExampleApps         bool
 )

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -15,67 +15,67 @@ import (
 var logger = logging.MustGetLogger("skywire-cli")
 
 var (
-	sk                     cipher.SecKey
-	output                 string
-	confPath               string
-	configName             string //nolint Note: configName used, but golangci-lint marked it unused in wrong
-	isStdout               bool
-	isRegen                bool
-	isRetainHypervisors    bool
-	isTestEnv              bool
-	pText                  string
-	isPkgEnv               bool
-	isUsrEnv               bool
-	isHypervisor           bool
-	hypervisorPKs          string
-	isDmsgHTTP             bool
-	isPublicRPC            bool
-	isVpnServerEnable      bool
-	isDisableAuth          bool
-	isEnableAuth           bool
-	selectedOS             string
-	disableApps            string
-	isBestProtocol         bool
-	serviceConfURL         string
-	services               *visorconfig.Services
-	isForce                bool
-	isHide                 bool
-	isAll                  bool
-	isOutUnset             bool
-	ver                    string
-	isRoot                 = visorconfig.IsRoot()
-	svcConf                = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")     //visorconfig.DefaultServiceConfAddr
-	testConf               = strings.ReplaceAll(utilenv.TestServiceConfAddr, "http://", "") //visorconfig.DefaultServiceConfAddr
-	gHiddenFlags           []string
-	uHiddenFlags           []string
-	binPath                string
-	logLevel               string
-	isPkg                  bool
-	input                  string
-	isUpdateEndpoints      bool
-	addHypervisorPKs       string
-	isResetHypervisor      bool
-	setVPNClientKillswitch string
-	addVPNClientSrv        string
-	addVPNClientPasscode   string
-	isResetVPNclient       bool
-	addVPNServerPasscode   string
-	setVPNServerSecure     string
-	setVPNServerAutostart  string
-	setVPNServerNetIfc     string
-	isResetVPNServer       bool
-	addSkysocksClientSrv   string
-	isResetSkysocksClient  bool
-	skysocksPasscode       string
-	isResetSkysocks        bool
-	setPublicAutoconnect   string
-	minHops                int
-	conf                   *visorconfig.V1
-	isUsr                  bool
-	isPublic               bool
-	isDisablePublicAutoConn       bool
-	isDisplayNodeIP        bool
-	addExampleApps         bool
+	sk                      cipher.SecKey
+	output                  string
+	confPath                string
+	configName              string //nolint Note: configName used, but golangci-lint marked it unused in wrong
+	isStdout                bool
+	isRegen                 bool
+	isRetainHypervisors     bool
+	isTestEnv               bool
+	pText                   string
+	isPkgEnv                bool
+	isUsrEnv                bool
+	isHypervisor            bool
+	hypervisorPKs           string
+	isDmsgHTTP              bool
+	isPublicRPC             bool
+	isVpnServerEnable       bool
+	isDisableAuth           bool
+	isEnableAuth            bool
+	selectedOS              string
+	disableApps             string
+	isBestProtocol          bool
+	serviceConfURL          string
+	services                *visorconfig.Services
+	isForce                 bool
+	isHide                  bool
+	isAll                   bool
+	isOutUnset              bool
+	ver                     string
+	isRoot                  = visorconfig.IsRoot()
+	svcConf                 = strings.ReplaceAll(utilenv.ServiceConfAddr, "http://", "")     //visorconfig.DefaultServiceConfAddr
+	testConf                = strings.ReplaceAll(utilenv.TestServiceConfAddr, "http://", "") //visorconfig.DefaultServiceConfAddr
+	gHiddenFlags            []string
+	uHiddenFlags            []string
+	binPath                 string
+	logLevel                string
+	isPkg                   bool
+	input                   string
+	isUpdateEndpoints       bool
+	addHypervisorPKs        string
+	isResetHypervisor       bool
+	setVPNClientKillswitch  string
+	addVPNClientSrv         string
+	addVPNClientPasscode    string
+	isResetVPNclient        bool
+	addVPNServerPasscode    string
+	setVPNServerSecure      string
+	setVPNServerAutostart   string
+	setVPNServerNetIfc      string
+	isResetVPNServer        bool
+	addSkysocksClientSrv    string
+	isResetSkysocksClient   bool
+	skysocksPasscode        string
+	isResetSkysocks         bool
+	setPublicAutoconnect    string
+	minHops                 int
+	conf                    *visorconfig.V1
+	isUsr                   bool
+	isPublic                bool
+	isDisablePublicAutoConn bool
+	isDisplayNodeIP         bool
+	addExampleApps          bool
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor

--- a/cmd/skywire-cli/commands/visor/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
-
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/visor"
 )

--- a/cmd/skywire-systray/skywire-systray.go
+++ b/cmd/skywire-systray/skywire-systray.go
@@ -12,11 +12,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/systray"
-
 	"github.com/bitfield/script"
 	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/skycoin/src/util/logging"
+	"github.com/skycoin/systray"
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"

--- a/pkg/visor/gui.go
+++ b/pkg/visor/gui.go
@@ -15,8 +15,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/skycoin/systray"
-
 	"github.com/gen2brain/dlgs"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/direct"
@@ -24,6 +22,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsg"
 	"github.com/skycoin/dmsg/pkg/dmsgget"
 	"github.com/skycoin/dmsg/pkg/dmsghttp"
+	"github.com/skycoin/systray"
 	"github.com/toqueteos/webbrowser"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"


### PR DESCRIPTION
Did you run `make format && make check`?
yes

- `skywire-cli config gen -b` flag can disable public autoconnect if dmsg protocol is selected based on the user's location