### PR TITLE
UI for managing the reward addresses

### DIFF
--- a/static/skywire-manager-src/src/app/app.datatypes.ts
+++ b/static/skywire-manager-src/src/app/app.datatypes.ts
@@ -20,6 +20,7 @@ export class Node {
   buildTag: string;
   skybianBuildVersion?: string;
   autoconnectTransports: boolean;
+  rewardsAddress: string;
 }
 
 export interface Application {

--- a/static/skywire-manager-src/src/app/app.module.ts
+++ b/static/skywire-manager-src/src/app/app.module.ts
@@ -97,6 +97,8 @@ import { VpnServerNameComponent } from './components/vpn/layout/vpn-server-name/
 import { EnterVpnServerPasswordComponent } from './components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component';
 import { UpdateAllComponent } from './components/layout/update-all/update-all.component';
 import { VpnDnsConfigComponent } from './components/vpn/layout/vpn-dns-config/vpn-dns-config.component';
+import { RewardsAddressComponent } from './components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component';
+import { BulkRewardAddressChangerComponent } from './components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component';
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -170,6 +172,8 @@ const globalRippleConfig: RippleGlobalOptions = {
     EnterVpnServerPasswordComponent,
     UpdateAllComponent,
     VpnDnsConfigComponent,
+    RewardsAddressComponent,
+    BulkRewardAddressChangerComponent,
   ],
   imports: [
     BrowserModule,

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.html
@@ -2,7 +2,10 @@
   <form [formGroup]="form">
     <!-- Info. -->
     <div class="text-container">
-      {{ 'bulk-rewards.info' | translate }}
+      <span>{{ 'bulk-rewards.info' | translate }} </span>
+      <a href="https://github.com/skycoin/skywire/blob/master/mainnet_rules.md" target="_blank" rel="noreferrer nofollow noopener">
+        {{'bulk-rewards.more-info-link' | translate}}
+      </a>
     </div>
 
     <!-- Address field. -->

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.html
@@ -1,0 +1,80 @@
+<app-dialog [headline]="'bulk-rewards.title' | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
+  <form [formGroup]="form">
+    <!-- Info. -->
+    <div class="text-container">
+      {{ 'bulk-rewards.info' | translate }}
+    </div>
+
+    <!-- Address field. -->
+    <mat-form-field>
+      <input
+        [ngClass]="{'element-disabled' : processingStarted}"
+        [placeholder]="'rewards-address-config.address' | translate"
+        formControlName="address"
+        maxlength="40"
+        matInput
+      >
+    </mat-form-field>
+
+    <div class="text-container">
+      {{ 'bulk-rewards.select-visors' | translate }}
+    </div>
+
+    <div class="list-container" formArrayName="nodes">
+
+      <!-- Nodes list, before starting the procedure. -->
+      <div *ngFor="let node of nodesToEdit; let i = index;" class="list-element" [ngClass]="{'element-margin' : processingStarted}">
+        <ng-container *ngIf="!processingStarted" [formGroupName]="i">
+          <mat-checkbox color="primary" formControlName="selected">
+            <div>
+              <div class="contents">
+                {{ node.label }}
+              </div>
+              <div class="address contents">
+                <span class="address-label">{{ 'bulk-rewards.current-address' | translate }}</span>
+                <span class="blinking" *ngIf="node.currentAddress === null && !node.operationError"> {{ 'bulk-rewards.checking' | translate }}</span>
+                <span class="red-text" *ngIf="node.operationError">
+                  <span> {{ 'bulk-rewards.error-checking' | translate }}</span>
+                  <span> {{ node.operationError | translate }}</span>
+                </span>
+                <span *ngIf="node.currentAddress && !node.operationError"> {{ node.currentAddress }}</span>
+                <span *ngIf="node.currentAddress === '' && !node.operationError"> {{ 'bulk-rewards.not-registered' | translate }}</span>
+              </div>
+            </div>
+          </mat-checkbox>
+        </ng-container>
+
+        <!-- Nodes list, after starting the procedure. -->
+        <ng-container *ngIf="processingStarted">
+          <div class="left-area">-</div>
+          <div class="right-area contents">
+            {{ node.label }}
+            <div class="address">
+              <span class="blinking" *ngIf="node.processing && !node.operationError"> {{ 'bulk-rewards.processing' | translate }}</span>
+              <span class="red-text" *ngIf="node.operationError">
+                <span> {{ 'bulk-rewards.error-processing' | translate }}</span>
+                <span> {{ node.operationError | translate }}</span>
+              </span>
+              <span class="green-text" *ngIf="!node.processing && !node.operationError"> {{ 'bulk-rewards.done' | translate }}</span>
+            </div>
+          </div>
+        </ng-container>
+      </div>
+
+    </div>
+  </form>
+
+  <!-- Buttons. -->
+  <div class="buttons">
+    <app-button
+      #button
+      type="mat-raised-button"
+      color="primary"
+      (action)="!processingStarted ? checkBeforeProcessing() : closeModal()"
+      [disabled]="!formValid()"
+    >
+      <ng-container *ngIf="!processingStarted">{{ 'bulk-rewards.perform-changes' | translate }}</ng-container>
+      <ng-container *ngIf="processingStarted">{{ 'common.close' | translate }}</ng-container>
+    </app-button>
+  </div>
+</app-dialog>

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.scss
@@ -1,0 +1,57 @@
+@import 'variables';
+
+.text-container {
+  word-break: break-word;
+}
+
+mat-form-field {
+  margin-top: 10px;
+}
+
+.list-container {
+  font-size: 14px;
+  margin: 10px;
+  color: $blue-medium;
+  word-break: break-word;
+
+  .element-margin {
+    margin: 15px 0;
+  }
+
+  .list-element {
+    display: flex;
+
+    .left-area {
+      width: 12px;
+      flex-grow: 0;
+      flex-shrink: 0;
+    }
+
+    .right-area {
+      flex-grow: 1;
+    }
+
+    .contents {
+      white-space: normal;
+      line-height: 1.2;
+    }
+
+    .address {
+      font-size: 12px;
+      color: $light-gray;
+
+      .address-label {
+        opacity: 0.7;
+      }
+    }
+  }
+}
+
+.buttons {
+  margin-top: 15px;
+  text-align: right;
+
+  app-button {
+    margin-left: 5px;
+  }
+}

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.scss
@@ -37,7 +37,7 @@ mat-form-field {
     }
 
     .address {
-      font-size: 12px;
+      font-size: $font-size-mini;
       color: $light-gray;
 
       .address-label {

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnDestroy, AfterViewInit, ViewChild } from '@angular/core';
+import { Component, Inject, OnDestroy, ViewChild } from '@angular/core';
 import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialog as MatDialog, MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
 import { Subscription, of, Observable } from 'rxjs';
 
@@ -42,7 +42,7 @@ interface NodeToEditCompleteData extends NodeToEditData {
   templateUrl: './bulk-reward-address-changer.component.html',
   styleUrls: ['./bulk-reward-address-changer.component.scss'],
 })
-export class BulkRewardAddressChangerComponent implements AfterViewInit, OnDestroy {
+export class BulkRewardAddressChangerComponent implements OnDestroy {
   @ViewChild('button') button: ButtonComponent;
 
   // If the process for changing the addresses has already started.
@@ -92,6 +92,8 @@ export class BulkRewardAddressChangerComponent implements AfterViewInit, OnDestr
       });
       (this.form.get('nodes') as FormArray).push(nodeFormData);
     });
+
+    this.startChecking();
   }
 
   formValid(): boolean {
@@ -111,10 +113,6 @@ export class BulkRewardAddressChangerComponent implements AfterViewInit, OnDestr
     }
 
     return true;
-  }
-
-  ngAfterViewInit() {
-    this.startChecking();
   }
 
   /**

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.ts
@@ -1,0 +1,246 @@
+import { Component, Inject, OnDestroy, AfterViewInit, ViewChild } from '@angular/core';
+import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialog as MatDialog, MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
+import { Subscription, of, Observable } from 'rxjs';
+
+import { AppConfig } from 'src/app/app.config';
+import { NodeService } from 'src/app/services/node.service';
+import { OperationError } from 'src/app/utils/operation-error';
+import { FormArray, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ButtonComponent } from '../button/button.component';
+import { delay, mergeMap } from 'rxjs/operators';
+import GeneralUtils from 'src/app/utils/generalUtils';
+
+/**
+ * Params for BulkRewardAddressChangerComponent.
+ */
+export interface BulkRewardAddressParams {
+  nodes: NodeToEditData[];
+}
+
+/**
+ * Data about a node for BulkRewardAddressChangerComponent.
+ */
+export interface NodeToEditData {
+  key: string;
+  label: string;
+}
+
+/**
+ * Extended data about a node, for internal use.
+ */
+interface NodeToEditCompleteData extends NodeToEditData {
+  currentAddress?: string;
+  operationError: string;
+  processing: boolean;
+}
+
+/**
+ * Modal window used for changing the rewards addresses of a list of nodes.
+ */
+@Component({
+  selector: 'app-bulk-reward-address-changer',
+  templateUrl: './bulk-reward-address-changer.component.html',
+  styleUrls: ['./bulk-reward-address-changer.component.scss'],
+})
+export class BulkRewardAddressChangerComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('button') button: ButtonComponent;
+
+  // If the process for changing the addresses has already started.
+  processingStarted = false;
+  // If the process for changing the addresses has already finished.
+  processingFinished = false;
+  // For how many nodes the procedure has already finished.
+  currentlyProcessed = 0;
+
+  // List with all the nodes that should be processed. At the start, it includes all nodes passed when the
+  // window was opened. After the process starts, it only includes the nodes the user selected.
+  nodesToEdit: NodeToEditCompleteData[];
+
+  form: UntypedFormGroup;
+
+  private operationSubscriptions: Subscription[];
+
+  /**
+   * Opens the modal window. Please use this function instead of opening the window "by hand".
+   * @param nodes Nodes to process.
+   */
+  public static openDialog(dialog: MatDialog, nodes: BulkRewardAddressParams): MatDialogRef<BulkRewardAddressChangerComponent, any> {
+    const config = new MatDialogConfig();
+    config.data = nodes;
+    config.autoFocus = false;
+    config.width = AppConfig.smallModalWidth;
+
+    return dialog.open(BulkRewardAddressChangerComponent, config);
+  }
+
+  constructor(
+    public dialogRef: MatDialogRef<BulkRewardAddressChangerComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: BulkRewardAddressParams,
+    private nodeService: NodeService,
+    private formBuilder: UntypedFormBuilder,
+    private dialog: MatDialog,
+  ) {
+    this.form = formBuilder.group({
+      address: ['', Validators.compose([Validators.minLength(20), Validators.maxLength(40)])],
+      nodes: formBuilder.array([]),
+    });
+
+    // Create an entry for each node, to let the user select and deselect nodes.
+    data.nodes.forEach(n => {
+      const nodeFormData = this.formBuilder.group({
+        selected: [true],
+      });
+      (this.form.get('nodes') as FormArray).push(nodeFormData);
+    });
+  }
+
+  formValid(): boolean {
+    if (!this.processingStarted) {
+      if (!this.form.valid) {
+        return false;
+      }
+
+      let selected = 0;
+      (this.form.get('nodes') as FormArray).controls.forEach((n, i) => {
+        if (n.get('selected')?.value) {
+          selected += 1;
+        }
+      });
+
+      return selected > 0;
+    }
+
+    return true;
+  }
+
+  ngAfterViewInit() {
+    this.startChecking();
+  }
+
+  /**
+   * If true, all the ways provided by default by the UI for closing the modal window are disabled.
+   */
+  get disableDismiss(): boolean {
+    return this.processingStarted && !this.processingFinished;
+  }
+
+  private startChecking() {
+    // Create the list that will be shown on the UI.
+    this.nodesToEdit = [];
+    this.data.nodes.forEach(node => {
+      this.nodesToEdit.push({
+        key: node.key,
+        label: node.label,
+        currentAddress: null,
+        operationError: '',
+        processing: false,
+      });
+    });
+
+    // Check the address currently configured on each node.
+    this.operationSubscriptions = [];
+    this.nodesToEdit.forEach((node, i) => {
+      this.operationSubscriptions.push(
+        this.nodeService.getRewardsAddress(node.key).subscribe(response => {
+          this.nodesToEdit[i].currentAddress = response;
+        }, (err: OperationError) => {
+          this.nodesToEdit[i].operationError = err.translatableErrorMsg ? err.translatableErrorMsg : err.originalServerErrorMsg;
+        })
+      );
+    });
+  }
+
+  /**
+   * Checks the data entered by the user and ask for confirmation, if needed, before starting the
+   * saving procedure.
+   */
+  checkBeforeProcessing() {
+    if (!this.form.valid) {
+      return;
+    }
+
+    const address = this.form.get('address').value as string;
+
+    if (address) {
+      this.startProcessing();
+    } else {
+      const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'bulk-rewards.empty-warning');
+      confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+        confirmationDialog.componentInstance.closeModal();
+        this.startProcessing();
+      });
+    }
+  }
+
+  /**
+   * Makes the changes on the selected nodes.
+   */
+  private startProcessing() {
+    this.processingStarted = true;
+    this.button.showLoading();
+
+    this.closeoperationSubscriptions();
+
+    // Remove the unselected nodes.
+    const newList: NodeToEditCompleteData[] = [];
+    (this.form.get('nodes') as FormArray).controls.forEach((n, i) => {
+      if (n.get('selected')?.value) {
+        this.nodesToEdit[i].operationError = '';
+        this.nodesToEdit[i].processing = true;
+        newList.push(this.nodesToEdit[i]);
+      }
+    });
+    this.nodesToEdit = newList;
+
+    const newAddress = this.form.get('address').value;
+    this.form.get('address').disable();
+
+    this.currentlyProcessed = 0;
+
+    this.operationSubscriptions = [];
+    this.nodesToEdit.forEach((node, i) => {
+      // If the user entered an address, the operation must save it. If not, the operation is for
+      // removing the currently saved address.
+      let operation: Observable<any> = this.nodeService.setRewardsAddress(node.key, newAddress);
+      if (!newAddress) {
+        operation = this.nodeService.deleteRewardsAddress(node.key);
+      }
+
+      this.operationSubscriptions.push(
+        of(0).pipe(delay(100), mergeMap(() => operation)).subscribe(response => {
+          this.nodesToEdit[i].processing = false;
+
+          this.currentlyProcessed += 1;
+          if (this.currentlyProcessed === this.nodesToEdit.length) {
+            this.processingFinished = true;
+            this.button.reset();
+          }
+
+        }, (err: OperationError) => {
+          this.nodesToEdit[i].processing = false;
+          this.nodesToEdit[i].operationError = err.translatableErrorMsg ? err.translatableErrorMsg : err.originalServerErrorMsg;
+
+          this.currentlyProcessed += 1;
+          if (this.currentlyProcessed === this.nodesToEdit.length) {
+            this.processingFinished = true;
+            this.button.reset();
+          }
+        })
+      );
+    });
+  }
+
+  ngOnDestroy() {
+    this.closeoperationSubscriptions();
+  }
+
+  private closeoperationSubscriptions() {
+    if (this.operationSubscriptions) {
+      this.operationSubscriptions.forEach(e => e.unsubscribe());
+    }
+  }
+
+  closeModal() {
+    this.dialogRef.close();
+  }
+}

--- a/static/skywire-manager-src/src/app/components/layout/copy-to-clipboard-text/copy-to-clipboard-text.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/copy-to-clipboard-text/copy-to-clipboard-text.component.html
@@ -5,11 +5,11 @@
   [matTooltipClass]="{ 'tooltip-word-break': true }"
 >
   <ng-container *ngIf="!shortSimple">
-    <app-truncated-text [short]="short" [showTooltip]="false" [shortTextLength]="shortTextLength" [text]="text"></app-truncated-text>
-    &nbsp;<mat-icon [inline]="true">filter_none</mat-icon>
+    <app-truncated-text class="text-margin" [short]="short" [showTooltip]="false" [shortTextLength]="shortTextLength" [text]="text"></app-truncated-text>
+    <mat-icon [inline]="true">filter_none</mat-icon>
   </ng-container>
   <div *ngIf="shortSimple" class="d-flex">
-    <div class="single-line">{{text}}</div>
-    &nbsp;<mat-icon [inline]="true">filter_none</mat-icon>
+    <div class="single-line text-margin">{{text}}</div>
+    <mat-icon [inline]="true">filter_none</mat-icon>
   </div>
 </div>

--- a/static/skywire-manager-src/src/app/components/layout/copy-to-clipboard-text/copy-to-clipboard-text.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/copy-to-clipboard-text/copy-to-clipboard-text.component.scss
@@ -6,9 +6,14 @@
   /* Needed because the tooltip blocks the ability to select the text. */
   @extend .reactivate-mouse;
 
+  .text-margin {
+    margin-right: 5px;
+  }
+
   mat-icon {
     font-size: $font-size-mini-plus;
     user-select: none;
     flex-shrink: 0;
+    display: inline !important;
   }
 }

--- a/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.scss
+++ b/static/skywire-manager-src/src/app/components/layout/update-all/update-all.component.scss
@@ -8,7 +8,9 @@
 .list-container {
   font-size: 14px;
   margin: 10px;
+  color: $blue-medium;
   word-break: break-word;
+  line-height: 1.2;
 
   .list-element {
     display: flex;
@@ -22,8 +24,6 @@
       min-width: 0;
 
       .name {
-        font-size: $font-size-base;
-        line-height: 1.5;
         display: block;
         white-space: nowrap;
         overflow: hidden;
@@ -38,8 +38,7 @@
 
       .version {
         font-size: $font-size-mini;
-        line-height: 1.5;
-        color: $blue-medium;
+        color: $light-gray;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -21,6 +21,7 @@ import { LabeledElementTextComponent } from '../../layout/labeled-element-text/l
 import { SortingModes, SortingColumn, DataSorter } from 'src/app/utils/lists/data-sorter';
 import { DataFilterer } from 'src/app/utils/lists/data-filterer';
 import { NodeData, UpdateAllComponent } from '../../layout/update-all/update-all.component';
+import { BulkRewardAddressChangerComponent, BulkRewardAddressParams, NodeToEditData } from '../../layout/bulk-reward-address-changer/bulk-reward-address-changer.component';
 
 /**
  * Page for showing the node list.
@@ -238,6 +239,12 @@ export class NodeListComponent implements OnInit, OnDestroy {
     this.options = [];
 
     this.options.push({
+      name: 'nodes.modify-rewards-all',
+      actionName: 'modifyRewardsAll',
+      icon: 'edit'
+    });
+
+    this.options.push({
       name: 'nodes.update-all',
       actionName: 'updateAll',
       icon: 'get_app'
@@ -294,6 +301,8 @@ export class NodeListComponent implements OnInit, OnDestroy {
       this.logout();
     } else if (actionName === 'updateAll') {
       this.updateAll();
+    } else if (actionName === 'modifyRewardsAll') {
+      this.changeRewardsToAll();
     }
   }
 
@@ -479,6 +488,30 @@ export class NodeListComponent implements OnInit, OnDestroy {
     });
 
     UpdateAllComponent.openDialog(this.dialog, updatableNodes, nonUpdatableNodes);
+  }
+
+  // Opens the modal window for changing the rewards address of all online nodes.
+  changeRewardsToAll() {
+    if (!this.dataSource || this.dataSource.length === 0) {
+      this.snackbarService.showError('nodes.no-visors-to-modify');
+
+      return;
+    }
+
+    const nodesToModify: NodeToEditData[] = [];
+    this.dataSource.forEach(node => {
+      if (node.online) {
+        const nodeData: NodeToEditData = {
+          key: node.localPk,
+          label: node.label,
+        };
+        nodesToModify.push(nodeData);
+      }
+    });
+
+    const params: BulkRewardAddressParams = { nodes: nodesToModify };
+
+    BulkRewardAddressChangerComponent.openDialog(this.dialog, params);
   }
 
   /**

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -3,50 +3,50 @@
   <div class="d-flex flex-column">
     <span class="section-title">{{ 'node.details.node-info.title' | translate }}</span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.label' | translate }}</span>
+      <span class="title">{{ 'node.details.node-info.label' | translate }} </span>
       <span class="highlight-internal-icon" (click)="showEditLabelDialog()">
-        {{ node.label }}
-        <mat-icon [inline]="true">edit</mat-icon>
+        <span class="text-with-small-right-margin">{{ node.label }}</span>
+        <mat-icon class="edit-icon" [inline]="true">edit</mat-icon>
       </span>
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.public-key' | translate }}&nbsp;</span>
+      <span class="title">{{ 'node.details.node-info.public-key' | translate }} </span>
       <app-copy-to-clipboard-text text="{{ node.localPk }}"></app-copy-to-clipboard-text>
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.symmetic-nat' | translate }}&nbsp;</span>
+      <span class="title">{{ 'node.details.node-info.symmetic-nat' | translate }} </span>
       {{ (node.isSymmeticNat ? 'common.yes' : 'common.no') | translate }}
     </span>
     <span class="info-line" *ngIf="!node.isSymmeticNat">
-      <span class="title">{{ 'node.details.node-info.public-ip' | translate }}&nbsp;</span>
+      <span class="title">{{ 'node.details.node-info.public-ip' | translate }} </span>
       <app-copy-to-clipboard-text text="{{ node.publicIp }}"></app-copy-to-clipboard-text>
     </span>
     <span class="info-line" *ngIf="node.ip">
-      <span class="title">{{ 'node.details.node-info.ip' | translate }}&nbsp;</span>
+      <span class="title">{{ 'node.details.node-info.ip' | translate }} </span>
       <app-copy-to-clipboard-text text="{{ node.ip }}"></app-copy-to-clipboard-text>
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.dmsg-server' | translate }}&nbsp;</span>
+      <span class="title">{{ 'node.details.node-info.dmsg-server' | translate }} </span>
       <app-copy-to-clipboard-text text="{{ node.dmsgServerPk }}"></app-copy-to-clipboard-text>
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.ping' | translate }}&nbsp;</span>
+      <span class="title">{{ 'node.details.node-info.ping' | translate }} </span>
       {{ 'common.time-in-ms' | translate:{ time: node.roundTripPing } }}
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.node-version' | translate }}</span>
+      <span class="title">{{ 'node.details.node-info.node-version' | translate }} </span>
       {{ node.version ? node.version : ('common.unknown' | translate) }}
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.build-type' | translate }}</span>
+      <span class="title">{{ 'node.details.node-info.build-type' | translate }} </span>
       {{ node.buildTag ? node.buildTag : ('node.details.node-info.unknown-build' | translate) }}
     </span>
     <span class="info-line" *ngIf="node.skybianBuildVersion">
-      <span class="title">{{ 'node.details.node-info.skybian-version' | translate }}</span>
+      <span class="title">{{ 'node.details.node-info.skybian-version' | translate }} </span>
       {{ node.skybianBuildVersion }}
     </span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.node-info.time.title' | translate }}</span>
+      <span class="title">{{ 'node.details.node-info.time.title' | translate }} </span>
       {{ ('node.details.node-info.time.' + timeOnline.translationVarName) | translate:{time: timeOnline.elapsedTime} }}
 
       <mat-icon
@@ -63,8 +63,15 @@
   <div class="d-flex flex-column">
     <span class="section-title">{{ 'node.details.rewards-info.title' | translate }}</span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.rewards-info.rewards-address' | translate }}&nbsp;</span>
-      <app-copy-to-clipboard-text text="{{ node.rewardsAddress }}" *ngIf="node.rewardsAddress"></app-copy-to-clipboard-text>
+      <span class="title">{{ 'node.details.rewards-info.rewards-address' | translate }} </span>
+      <ng-container *ngIf="node.rewardsAddress">
+        <app-copy-to-clipboard-text class="text-with-right-margin" text="{{ node.rewardsAddress }}"></app-copy-to-clipboard-text> 
+        <a [href]="'https://explorer.skycoin.com/app/address/' + node.rewardsAddress" target="_blank" rel="noreferrer nofollow noopener">
+          <mat-icon [inline]="true" class="link-icon transparent-button" [matTooltip]="'node.details.rewards-info.open-in-explorer' | translate">
+            open_in_browser
+          </mat-icon>
+        </a>
+      </ng-container>
       <ng-container *ngIf="!node.rewardsAddress">
         {{ 'node.details.rewards-info.not-registered' | translate }}
         <mat-icon [inline]="true" [matTooltip]="'node.details.rewards-info.not-registered-info' | translate">info</mat-icon>
@@ -86,7 +93,7 @@
   <div class="d-flex flex-column">
     <span class="section-title">{{ 'node.details.transports-info.title' | translate }}</span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.transports-info.autoconnect' | translate }}</span>
+      <span class="title">{{ 'node.details.transports-info.autoconnect' | translate }} </span>
       {{ ('node.details.transports-info.' + (node.autoconnectTransports ? 'enabled' : 'disabled')) | translate }}
       <mat-icon [inline]="true" [matTooltip]="'node.details.transports-info.autoconnect-info' | translate">info</mat-icon>
     </span>
@@ -101,7 +108,7 @@
   <div class="d-flex flex-column">
     <span class="section-title">{{ 'node.details.router-info.title' | translate }}</span>
     <span class="info-line">
-      <span class="title">{{ 'node.details.router-info.min-hops' | translate }}</span>
+      <span class="title">{{ 'node.details.router-info.min-hops' | translate }} </span>
       {{ node.minHops }}
     </span>
     <div class="config-button-container">
@@ -113,7 +120,7 @@
   <div class="separator"></div>
   <!-- Health info section. -->
   <div class="d-flex flex-column">
-    <span class="section-title">{{ 'node.details.node-health.title' | translate }}</span>
+    <span class="section-title">{{ 'node.details.node-health.title' | translate }} </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-health.uptime-tracker' | translate }}</span>
       <i [class]="nodeHealthClass"></i>

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -59,6 +59,29 @@
     </span>
   </div>
   <div class="separator"></div>
+  <!-- Rewards info section. -->
+  <div class="d-flex flex-column">
+    <span class="section-title">{{ 'node.details.rewards-info.title' | translate }}</span>
+    <span class="info-line">
+      <span class="title">{{ 'node.details.rewards-info.rewards-address' | translate }}&nbsp;</span>
+      <app-copy-to-clipboard-text text="{{ node.rewardsAddress }}" *ngIf="node.rewardsAddress"></app-copy-to-clipboard-text>
+      <ng-container *ngIf="!node.rewardsAddress">
+        {{ 'node.details.rewards-info.not-registered' | translate }}
+        <mat-icon [inline]="true" [matTooltip]="'node.details.rewards-info.not-registered-info' | translate">info</mat-icon>
+      </ng-container>
+    </span>
+    <div class="config-button-container">
+      <app-button color="primary" (action)="changeRewardsAddressConfig()" [forDarkBackground]="true">
+        <ng-container *ngIf="node.rewardsAddress">
+          {{ 'node.details.rewards-info.change-address-button' | translate }}
+        </ng-container>
+        <ng-container *ngIf="!node.rewardsAddress">
+          {{ 'node.details.rewards-info.set-address-button' | translate }}
+        </ng-container>
+      </app-button>
+    </div>
+  </div>
+  <div class="separator"></div>
   <!-- Transports info section. -->
   <div class="d-flex flex-column">
     <span class="section-title">{{ 'node.details.transports-info.title' | translate }}</span>

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.scss
@@ -7,12 +7,31 @@
 }
 
 .info-line {
-  word-break: break-all;
+  word-break: break-word;
   margin-top: 7px;
+
+  .text-with-right-margin {
+    margin-right: 5px;
+  }
+
+  .text-with-small-right-margin {
+    margin-right: 3px;
+  }
+
+  .link-icon {
+    font-size: 20px;
+    line-height: 1;
+    color: white !important;
+    cursor: pointer;
+  }
+
+  .edit-icon {
+    display: inline !important;
+  }
 
   mat-icon {
     position: relative;
-    top: 2px;
+    top: 3px;
     user-select: none;
   }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
@@ -14,6 +14,7 @@ import { TransportService } from 'src/app/services/transport.service';
 import { SnackbarService } from 'src/app/services/snackbar.service';
 import { OperationError } from 'src/app/utils/operation-error';
 import { processServiceError } from 'src/app/utils/errors';
+import { RewardsAddressComponent, RewardsAddressConfigParams } from './rewards-address-config/rewards-address-config.component';
 
 /**
  * Shows the basic info of a node.
@@ -74,6 +75,16 @@ export class NodeInfoContentComponent implements OnDestroy {
     }
 
     EditLabelComponent.openDialog(this.dialog, labelInfo).afterClosed().subscribe((changed: boolean) => {
+      if (changed) {
+        NodeComponent.refreshCurrentDisplayedData();
+      }
+    });
+  }
+
+  // Opens the modal window for changing the rewards address.
+  changeRewardsAddressConfig() {
+    const params: RewardsAddressConfigParams = {nodePk: this.node.localPk, currentAddress: this.node.rewardsAddress};
+    RewardsAddressComponent.openDialog(this.dialog, params).afterClosed().subscribe((changed: boolean) => {
       if (changed) {
         NodeComponent.refreshCurrentDisplayedData();
       }

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.html
@@ -1,0 +1,23 @@
+<app-dialog [headline]="'rewards-address-config.title' | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
+  <div class="info-container">{{'rewards-address-config.info' | translate}}</div>
+  <form [formGroup]="form" [ngClass]="{'element-disabled' : disableDismiss}">
+    <mat-form-field>
+      <input
+        #firstInput
+        [placeholder]="'rewards-address-config.address' | translate"
+        formControlName="address"
+        maxlength="40"
+        matInput
+      >
+    </mat-form-field>
+  </form>
+  <app-button
+    #button
+    class="float-right"
+    color="primary"
+    (action)="startSaving()"
+    [disabled]="!form.valid"
+  >
+    {{ 'rewards-address-config.save-config-button' | translate }}
+  </app-button>
+</app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.html
@@ -1,5 +1,10 @@
 <app-dialog [headline]="'rewards-address-config.title' | translate" [dialog]="dialogRef" [disableDismiss]="disableDismiss">
-  <div class="info-container">{{'rewards-address-config.info' | translate}}</div>
+  <div class="info-container">
+    <span>{{'rewards-address-config.info' | translate}} </span>
+    <a href="https://github.com/skycoin/skywire/blob/master/mainnet_rules.md" target="_blank" rel="noreferrer nofollow noopener">
+      {{'rewards-address-config.more-info-link' | translate}}
+    </a>
+  </div>
   <form [formGroup]="form" [ngClass]="{'element-disabled' : disableDismiss}">
     <mat-form-field>
       <input

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.scss
@@ -1,0 +1,5 @@
+@import 'variables';
+
+.info-container {
+  margin-bottom: 10px;
+}

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.ts
@@ -1,0 +1,139 @@
+import { Component, Inject, ViewChild, ElementRef, OnInit, OnDestroy } from '@angular/core';
+import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialogRef as MatDialogRef, MatLegacyDialogConfig as MatDialogConfig, MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { Observable, Subscription } from 'rxjs';
+
+import { SnackbarService } from '../../../../../../services/snackbar.service';
+import { AppConfig } from 'src/app/app.config';
+import { ButtonComponent } from 'src/app/components/layout/button/button.component';
+import { OperationError } from 'src/app/utils/operation-error';
+import { processServiceError } from 'src/app/utils/errors';
+import { NodeService } from 'src/app/services/node.service';
+import GeneralUtils from 'src/app/utils/generalUtils';
+
+/**
+ * Params for RewardsAddressComponent.
+ */
+export interface RewardsAddressConfigParams {
+  /**
+   * PK of the node.
+   */
+  nodePk: string;
+  /**
+   * Current rewards address in the node.
+   */
+   currentAddress: string;
+}
+
+/**
+ * Modal window for changing the rewards address of a node. It changes the values
+ * and shows a confirmation msg by itself.
+ */
+@Component({
+  selector: 'app-rewards-address-config',
+  templateUrl: './rewards-address-config.component.html',
+  styleUrls: ['./rewards-address-config.component.scss']
+})
+export class RewardsAddressComponent implements OnInit, OnDestroy {
+  @ViewChild('button') button: ButtonComponent;
+  @ViewChild('firstInput') firstInput: ElementRef;
+
+  form: UntypedFormGroup;
+
+  private operationSubscription: Subscription;
+
+  /**
+   * Opens the modal window. Please use this function instead of opening the window "by hand".
+   */
+  public static openDialog(dialog: MatDialog, node: RewardsAddressConfigParams): MatDialogRef<RewardsAddressComponent, any> {
+    const config = new MatDialogConfig();
+    config.data = node;
+    config.autoFocus = false;
+    config.width = AppConfig.smallModalWidth;
+
+    return dialog.open(RewardsAddressComponent, config);
+  }
+
+  constructor(
+    public dialogRef: MatDialogRef<RewardsAddressComponent>,
+    @Inject(MAT_DIALOG_DATA) private data: RewardsAddressConfigParams,
+    private formBuilder: UntypedFormBuilder,
+    private snackbarService: SnackbarService,
+    private nodeService: NodeService,
+    private dialog: MatDialog,
+  ) { }
+
+  ngOnInit() {
+    this.form = this.formBuilder.group({
+      address: [this.data.currentAddress, Validators.compose([Validators.minLength(20), Validators.maxLength(40)])],
+    });
+
+    setTimeout(() => (this.firstInput.nativeElement as HTMLElement).focus());
+  }
+
+  ngOnDestroy() {
+    if (this.operationSubscription) {
+      this.operationSubscription.unsubscribe();
+    }
+  }
+
+  /**
+   * If true, all the ways provided by default by the UI for closing the modal window are disabled.
+   */
+  get disableDismiss(): boolean {
+    return this.button ? this.button.isLoading : false;
+  }
+
+  /**
+   * Checks the data entered by the user and ask for confirmation, if needed, before starting the
+   * saving procedure.
+   */
+  startSaving() {
+    if (!this.form.valid || this.operationSubscription) {
+      return;
+    }
+
+    const address = this.form.get('address').value as string;
+
+    if (address) {
+      this.finishSaving();
+    } else {
+      const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'rewards-address-config.empty-warning');
+      confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+        confirmationDialog.componentInstance.closeModal();
+        this.finishSaving();
+      });
+    }
+  }
+
+  // Makes the change on the back-end.
+  private finishSaving() {
+    this.button.showLoading();
+    const newAddress = this.form.get('address').value;
+
+    // If the user entered an address, the operation must save it. If not, the operation is for
+    // removing the currently saved address.
+    let operation: Observable<any> = this.nodeService.setRewardsAddress(this.data.nodePk, newAddress);
+    if (!newAddress) {
+      operation = this.nodeService.deleteRewardsAddress(this.data.nodePk);
+    }
+
+    this.operationSubscription = operation.subscribe({
+      next: this.onSuccess.bind(this),
+      error: this.onError.bind(this)
+    });
+  }
+
+  private onSuccess(response: any) {
+    this.dialogRef.close(true);
+    this.snackbarService.showDone('rewards-address-config.done');
+  }
+
+  private onError(err: OperationError) {
+    this.button.showError();
+    this.operationSubscription = null;
+    err = processServiceError(err);
+
+    this.snackbarService.showError(err);
+  }
+}

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -482,6 +482,7 @@ export class NodeService {
           node.version = response.overview.build_info.version;
           node.autoconnectTransports = response.public_autoconnect;
           node.buildTag = response.build_tag ? response.build_tag : '';
+          node.rewardsAddress = response.reward_address;
 
           // Ip.
           if (response.overview && response.overview.local_ip && (response.overview.local_ip as string).trim()) {
@@ -599,6 +600,7 @@ export class NodeService {
         node.isSymmeticNat = response.overview.is_symmetic_nat;
         node.publicIp = response.overview.public_ip;
         node.autoconnectTransports = response.public_autoconnect;
+        node.rewardsAddress = response.reward_address;
 
         // Ip.
         if (response.overview.local_ip && (response.overview.local_ip as string).trim()) {
@@ -731,6 +733,31 @@ export class NodeService {
         return node;
       })
     );
+  }
+
+  /**
+   * Sets the rewards address of the node.
+   */
+  setRewardsAddress(nodeKey: string, address: string) {
+    const data = {
+      reward_address: address,
+    };
+
+    return this.apiService.put(`visors/${nodeKey}/reward`, data);
+  }
+
+  /**
+   * Gets the rewards address of the node.
+   */
+  getRewardsAddress(nodeKey: string) {
+    return this.apiService.get(`visors/${nodeKey}/reward`);
+  }
+
+  /**
+   * Removes the rewards address of the node.
+   */
+  deleteRewardsAddress(nodeKey: string) {
+    return this.apiService.delete(`visors/${nodeKey}/reward`);
   }
 
   /**

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -125,6 +125,14 @@
           "weeks": "{{ time }} weeks"
         }
       },
+      "rewards-info": {
+        "title": "Rewards Info",
+        "rewards-address": "Rewards address:",
+        "not-registered": "Not registered",
+        "not-registered-info": "You have not specified a Skycoin address for receiving rewards for this visor. If you want to register for receiving rewards, press the \"Set address\" button and set a Skycoin address.",
+        "set-address-button": "Set address",
+        "change-address-button": "Change address"
+      },
       "transports-info": {
         "title": "Transports Info",
         "autoconnect": "Autoconnect:",
@@ -160,6 +168,15 @@
     "error-load": "An error occurred while refreshing the data. Retrying..."
   },
 
+  "rewards-address-config": {
+    "title": "Rewards Address Configuration",
+    "info": "Here you can set to which Skycoin address you want the rewards to be sent. If you leave the address empty, the registration will be deleted and the visor will not receive rewards.",
+    "address": "Address",
+    "save-config-button": "Save configuration",
+    "done": "Changes saved.",
+    "empty-warning": "The address in empty, so the registration will be deleted and no rewards will be received. Do you really want to continue?"
+  },
+
   "router-config": {
     "title": "Router Configuration",
     "info": "Here you can configure how many hops the connections must pass through other Skywire visors before reaching the final destination. NOTE: the changes will not affect the existing routes.",
@@ -171,6 +188,7 @@
   "nodes": {
     "title": "Visor list",
     "dmsg-title": "DMSG",
+    "modify-rewards-all": "Change rewards address",
     "update-all": "Update all online visors",
     "hypervisor": "Hypervisor",
     "state": "State",
@@ -196,6 +214,7 @@
     "deleted-singular": "1 offline visor removed.",
     "deleted-plural": "{{ number }} offline visors removed.",
     "no-visors-to-update": "There are no visors to update.",
+    "no-visors-to-modify": "There are no visors to modify.",
     "filter-dialog": {
       "online": "The visor must be",
       "label": "The label must contain",
@@ -208,6 +227,22 @@
         "offline": "Offline"
       }
     }
+  },
+
+  "bulk-rewards": {
+    "title": "Change rewards address",
+    "info": "Enter the Skycoin address where you want to receive the rewards. The address will be set on all the selected visors. If you leave the address empty, the registration will be deleted and the visors will not receive rewards. You can also set the rewards address of each node individually using the option on the visor details page.",
+    "address": "New address",
+    "select-visors": "Visors to alter:",
+    "current-address": "Current address:",
+    "not-registered": "None (not registered on the rewards program).",
+    "checking": "Checking...",
+    "error-checking": "Error checking:",
+    "processing": "Processing...",
+    "error-processing": "Error making the change:",
+    "done": "Change done.",
+    "perform-changes": "Perform changes",
+    "empty-warning": "The address in empty, so the registration will be deleted and no rewards will be received. Do you really want to continue?"
   },
 
   "edit-label": {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -126,10 +126,11 @@
         }
       },
       "rewards-info": {
-        "title": "Rewards Info",
-        "rewards-address": "Rewards address:",
+        "title": "Reward Info",
+        "rewards-address": "Reward address:",
         "not-registered": "Not registered",
-        "not-registered-info": "You have not specified a Skycoin address for receiving rewards for this visor. If you want to register for receiving rewards, press the \"Set address\" button and set a Skycoin address.",
+        "not-registered-info": "You have not specified a Skycoin address for receiving rewards for this visor. If you want to register the visor for receiving rewards, press the \"Set address\" button and set a Skycoin address.",
+        "open-in-explorer": "Open in blockchain explorer",
         "set-address-button": "Set address",
         "change-address-button": "Change address"
       },
@@ -169,8 +170,9 @@
   },
 
   "rewards-address-config": {
-    "title": "Rewards Address Configuration",
+    "title": "Reward Address Configuration",
     "info": "Here you can set to which Skycoin address you want the rewards to be sent. If you leave the address empty, the registration will be deleted and the visor will not receive rewards.",
+    "more-info-link": "(More info about the reward system)",
     "address": "Address",
     "save-config-button": "Save configuration",
     "done": "Changes saved.",
@@ -230,19 +232,20 @@
   },
 
   "bulk-rewards": {
-    "title": "Change rewards address",
-    "info": "Enter the Skycoin address where you want to receive the rewards. The address will be set on all the selected visors. If you leave the address empty, the registration will be deleted and the visors will not receive rewards. You can also set the rewards address of each node individually using the option on the visor details page.",
+    "title": "Change reward address",
+    "info": "Enter the Skycoin address where you want to receive the rewards. The address will be set on all the selected visors. If you leave the address empty, the registration will be deleted and the visors will not receive rewards. You can also set the reward address of each node individually using the option on the visor details page.",
+    "more-info-link": "(More info about the reward system)",
     "address": "New address",
     "select-visors": "Visors to alter:",
     "current-address": "Current address:",
-    "not-registered": "None (not registered on the rewards program).",
+    "not-registered": "None (not registered on the reward program).",
     "checking": "Checking...",
     "error-checking": "Error checking:",
     "processing": "Processing...",
     "error-processing": "Error making the change:",
     "done": "Change done.",
     "perform-changes": "Perform changes",
-    "empty-warning": "The address in empty, so the registration will be deleted and no rewards will be received. Do you really want to continue?"
+    "empty-warning": "The address in empty, so the registrations will be deleted and no rewards will be received. Do you really want to continue?"
   },
 
   "edit-label": {

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -125,6 +125,15 @@
           "weeks": "{{ time }} semanas"
         }
       },
+      "rewards-info": {
+        "title": "Información de Recompensas",
+        "rewards-address": "Dirección de recompensas:",
+        "not-registered": "No registrado",
+        "not-registered-info": "No ha especificado una dirección de Skycoin para recibir recompensas para este visor. Si quiere registrar el visor para recibir recompensas, presione el botón \"Establecer dirección\" e introduzca la una dirección de Skycoin.",
+        "open-in-explorer": "Abrir en el explorador de blockchain",
+        "set-address-button": "Establecer dirección",
+        "change-address-button": "Cambiar dirección"
+      },
       "transports-info": {
         "title": "Información de Transportes",
         "autoconnect": "Autoconectar:",
@@ -164,6 +173,16 @@
     "error-load": "Hubo un error al intentar refrescar los datos. Reintentando..."
   },
 
+  "rewards-address-config": {
+    "title": "Configuración de dirección de recompensas",
+    "info": "Aquí usted puede establecer la dirección de Skycoin a la que quiere que se envíen las recompensas. Si deja la dirección vacía, el registro será eliminado y el visor no recibirá recompensas.",
+    "more-info-link": "(Más información acerca del sistema de recompensas)",
+    "address": "Dirección ",
+    "save-config-button": "Guardar configuración",
+    "done": "Cambios guardados.",
+    "empty-warning": "La dirección está vacía, así que el registro será eliminado y no recibirá recompensas. ¿Realmente desea continuar?"
+  },
+
   "router-config": {
     "title": "Configuración del Enrutador",
     "info": "Aquí podrá configurar cuantos saltos la conexión deberá realizar a través de otros visores de Skywire antes de alcanzar el destino final. NOTA: los cambios no afectarán a las rutas ya existentes.",
@@ -175,6 +194,7 @@
   "nodes": {
     "title": "Lista de visores",
     "dmsg-title": "DMSG",
+    "modify-rewards-all": "Cambiar dirección de recompensas",
     "update-all": "Actualizar todos los visores online",
     "hypervisor": "Hypervisor",
     "state": "Estado",
@@ -200,6 +220,7 @@
     "deleted-singular": "1 visor offline removido.",
     "deleted-plural": "{{ number }} visores offline removidos.",
     "no-visors-to-update": "No hay visores para actualizar.",
+    "no-visors-to-modify": "No hay visores para modificar.",
     "filter-dialog": {
       "online": "El visor debe estar",
       "label": "La etiqueta debe contener",
@@ -212,6 +233,23 @@
         "offline": "Offline"
       }
     }
+  },
+
+  "bulk-rewards": {
+    "title": "Cambiar dirección de recompensas",
+    "info": "Introduzca la dirección de Skycoin donde desea recibir las recompensas. La dirección será establecida en todos los visores seleccionados. Si deja la dirección vacía, el registro será eliminado y los visores no recibirán recompensas. También puede colocar la dirección de recompensas de cada visor individualmente usando la opción en la pantalla de detalles del visor.",
+    "more-info-link": "(Más información acerca del sistema de recompensas)",
+    "address": "Nueva dirección",
+    "select-visors": "Visores a modificar:",
+    "current-address": "Dirección actual:",
+    "not-registered": "Ninguna (no registrado para recompensas).",
+    "checking": "Consultando...",
+    "error-checking": "Error consultando:",
+    "processing": "Procesando...",
+    "error-processing": "Error realizando el cambio:",
+    "done": "Cambio realizado.",
+    "perform-changes": "Aplicar cambios",
+    "empty-warning": "La dirección está vacía, así que los registros serán eliminados y no recibirá recompensas. ¿Realmente desea continuar?"
   },
 
   "edit-label": {

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -125,6 +125,15 @@
           "weeks": "{{ time }} weeks"
         }
       },
+      "rewards-info": {
+        "title": "Reward Info",
+        "rewards-address": "Reward address:",
+        "not-registered": "Not registered",
+        "not-registered-info": "You have not specified a Skycoin address for receiving rewards for this visor. If you want to register the visor for receiving rewards, press the \"Set address\" button and set a Skycoin address.",
+        "open-in-explorer": "Open in blockchain explorer",
+        "set-address-button": "Set address",
+        "change-address-button": "Change address"
+      },
       "transports-info": {
         "title": "Transports Info",
         "autoconnect": "Autoconnect:",
@@ -164,6 +173,16 @@
     "error-load": "An error occurred while refreshing the data. Retrying..."
   },
 
+  "rewards-address-config": {
+    "title": "Reward Address Configuration",
+    "info": "Here you can set to which Skycoin address you want the rewards to be sent. If you leave the address empty, the registration will be deleted and the visor will not receive rewards.",
+    "more-info-link": "(More info about the reward system)",
+    "address": "Address",
+    "save-config-button": "Save configuration",
+    "done": "Changes saved.",
+    "empty-warning": "The address in empty, so the registrations will be deleted and no rewards will be received. Do you really want to continue?"
+  },
+
   "router-config": {
     "title": "Router Configuration",
     "info": "Here you can configure how many hops the connections must pass through other Skywire visors before reaching the final destination.  NOTE: the changes will not affect the existing routes.",
@@ -175,6 +194,7 @@
   "nodes": {
     "title": "Visor list",
     "dmsg-title": "DMSG",
+    "modify-rewards-all": "Change rewards address",
     "update-all": "Update all online visors",
     "hypervisor": "Hypervisor",
     "state": "State",
@@ -200,6 +220,7 @@
     "deleted-singular": "1 offline visor removed.",
     "deleted-plural": "{{ number }} offline visors removed.",
     "no-visors-to-update": "There are no visors to update.",
+    "no-visors-to-modify": "There are no visors to modify.",
     "filter-dialog": {
       "online": "The visor must be",
       "label": "The label must contain",
@@ -212,6 +233,23 @@
         "offline": "Offline"
       }
     }
+  },
+
+  "bulk-rewards": {
+    "title": "Change reward address",
+    "info": "Enter the Skycoin address where you want to receive the rewards. The address will be set on all the selected visors. If you leave the address empty, the registration will be deleted and the visors will not receive rewards. You can also set the reward address of each node individually using the option on the visor details page.",
+    "more-info-link": "(More info about the reward system)",
+    "address": "New address",
+    "select-visors": "Visors to alter:",
+    "current-address": "Current address:",
+    "not-registered": "None (not registered on the reward program).",
+    "checking": "Checking...",
+    "error-checking": "Error checking:",
+    "processing": "Processing...",
+    "error-processing": "Error making the change:",
+    "done": "Change done.",
+    "perform-changes": "Perform changes",
+    "empty-warning": "The address in empty, so the registration will be deleted and no rewards will be received. Do you really want to continue?"
   },
 
   "edit-label": {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the hypervisor UI has options for adding and removing the reward addresses.

How to test this PR:
- On the visor list, press the menu button at the top-right part of the screen. There is an option for changing the address for all visors.
- On the visor details page, the current address is shown on the info bar at the right. There is a button for changing the address.

Note: for seing the changes, you must recompile the UI with `make build-ui`