### PR TITLE
update mainnet rules for collecting rewards under the new system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.3.0
 
+-   update mainnet rules for collecting rewards under the new system [#1443](https://github.com/skycoin/skywire/pull/1443)
+-   omit all language differentiating types of miners (official, DIY) from mainnet_rules.md [#1443](https://github.com/skycoin/skywire/pull/1443)
+-   omit references to the whitelist, which will be deprecated, from mainnet_rules.md [#1443](https://github.com/skycoin/skywire/pull/1443)
+-   add description of reward tiers to mainnet_rules.md [#1443](https://github.com/skycoin/skywire/pull/1443)
+-   add description of how the new reward system will work to mainnet_rules.md [#1443](https://github.com/skycoin/skywire/pull/1443)
+-   Increment minimum required skywire version for rewards to 1.3.0 in mainnet_rules.md [#1443](https://github.com/skycoin/skywire/pull/1443)
 -   Fix delete reward file [#1441](https://github.com/skycoin/skywire/pull/1441)
 -   Show reward address on autoconfig [#1441](https://github.com/skycoin/skywire/pull/1441)
 -   disable public autoconnect logic for `config gen -b` [#1440](https://github.com/skycoin/skywire/pull/1440)

--- a/mainnet_rules.md
+++ b/mainnet_rules.md
@@ -1,209 +1,61 @@
 ![skywire logo](https://user-images.githubusercontent.com/26845312/32426764-3495e3d8-c282-11e7-8fe8-8e60e90cb906.png)
 
-# Skywire Mainnet Rules
-<div align="center"><em> Disclaimer: The rewards in this post are subject to change. Updates in this post will be followed by a notification via the <a href="https://t.me/SkywirePSA">official Skywire PSA channel</a> on Telegram.</em>
-</div>
+# Skywire Reward Eligibility Rules
 
 #### Table of Contents
 * [Introduction](#introduction)
-* [Rules](#rules)
+* [Rules & Requirements](#rules-&-requirements)
 * [Rewards](#rewards)
-   * [Official Skyminers ](#official-skyminers)
-   * [Official Skyminers - New Batches](#official-skyminers---new-batches)
-   * [DIY Skyminers](#diy-skyminers)   
-* [Requirements](#Requirements)
-* [Whitelist](#whitelist)
-   * [Facts](#facts)
-* [Hardware ](#hardware)
+  * [Reward Tiers](#reward-tiers)
+* [Hardware](#hardware)
 
 ## Introduction
-This article represents the central source of information for the Skywire mainnet. All information about rewards and potential changes will be published here, so check in regularely.
 
-* Read this information thoroughly and ask in the [Skywire](https://t.me/skywire) Telegram channel if some things appear to not be covered. 
-* Please join [SkywirePSA](https://t.me/SkywirePSA) as well to get structured public service announcements (PSA) about the Skywire project.
-* In case you bought an official Skyminer in the [Skycoin hardware store](https://store.skycoin.com/) please read [the Official Skyminer Guide](https://github.com/skycoin/skywire/wiki/Skyminer-Official-Guide) if you haven't done that already. 
-* Participants will be contacted at the beginning of every month via the so-called *Skywire Status Update Emails* including details of their last month's Skywire mainnet participation.
-* You can contact support at store.skycoin.com/pages/support or via email at `support [at] skycoin.com`
+<div align="center"><em> Disclaimer: The rewards in this post are subject to change. Updates to this article will be followed by a notification via the <a href="https://t.me/SkywirePSA">official Skywire PSA channel</a> on Telegram.</em>
+</div>
+
+All information about rewards will be published here. Please ask for clarification in the [@skywire](https://t.me/skywire) Telegram channel if some things appear to not be covered. Join [@SkywirePSA](https://t.me/SkywirePSA) for public service announcements (PSA) regarding the skywire network.
+
+Reward notifications will happen via the skychat app, which is included with the skywire release (PENDING IMPLEMENTATION)
 
 ***
 
-## Rules
-This section covers the rules of the mainnet. Dependent on the amount of miners that are associated with your emails, some of these rules may apply to you or not.
+## Rules & Requirements
 
-Currently, each person participating in the Skywire mainnet may own one DIY miner and/or multiple official Skyminers to be eligible for rewards.
-<div align="center"><b>A DIY miner cannot be in the same location as another DIY or official Skyminer.</b></div><br>
-
-Based on this central rule, each whitelisted person is eligible to receive rewards for:
-* one or multiple official Skyminers 
-
-*and/or*
-
-* one DIY miner with up to 8 (eight) visors, (provided it is at a different location if you also have an official Skyminer).
-
-<div align="center"><b>You must use the <a href="https://whitelist.skycoin.com">Skywire Whitelisting System</a> to keep your submitted data up-to-date</b>
-<br><em> Read<a href="https://github.com/skycoin/skywire/wiki/Skywire-Whitelisting-System"> the Skywire whitelisting system user guide</a> to familiarize yourself with the new system.</em></div>
-<br>
-Different locations are required due to the fact that we want to spread out the meshnet and not create built-up areas. This prevents paying people to simply run single board computers (SBC) and to require them to provide a service to the network.
-
-* If you are running two separate miners in the same location because you're joining the network with someone living in the same house you still have to move one of your miners to another location. 
-
-<div align="center"><em>Submitting miners under multiple email addresses is forbidden and very likely to be detected - measures will be taken if such actions are recognized.</em></div>
+* Up to 8 (eight) visors may receive rewards per location (ip address)
+* 75% uptime is required to be eligible to receive rewards
+* A valid skycoin address must be set for the visor
+* The visor must be running on approved [hardware](#hardware)
 
 ***
 
 ## Rewards
-**Skywire Visors must be running Skywire v0.4.2 or higher to receive rewards.** Note that the required minimal Skywire version is subject to change and will be updated from time-to-time. We'll keep the minimal version requirement at least one release behind the most recent one to provide everyone with sufficient time to upgrade.
-<br>
-* The rewards are **paid every subsequent month around the 5th** (short delays are possible)
-* Adjustments of previous months are included in these reward distributions on the 5th.
-* The deadline to submit complaints is being published in the monthly Skywire status update emails and in the [Skywire PSA channel on Telegram](https://t.me/SkywirePSA).
-* Eligible for rewards are only the whitelisted visors that **comply with the Skywire mainnet rules** and **meet the uptime requirement** of the respective month (usually 75%).
-* Updates of user data in the Skywire Whitelisting System are only guaranteed to be recognized for reward distributions if they are submitted during the respective calendar month for which the rewards are being calculated.
 
-### Official Skyminers 
+**The new reward system requires Skywire >v1.3.0.**
 
-There are two different reward methods for official miners:
-* official Skyminers Skycoin Pool Method:
-  - first & second batch official Skyminer
-  - third batch official Skyminers that have received all of the 24 fixed Skycoin payments
-* official Skyminers SKY/USD Method:
-  - **sold through** the [hardware store](https://store.skycoin.com)
+The required minimal Skywire version will be incremented periodically.
 
-<em>Faulty Orange Pi Primes/routers of official Skyminers will be rewarded regardless of your uptime until you receive a replacement. If the replacement doesn't arrive in time for you to make the uptime requirement because it arrived on short notice or not on the schedule at all you will be rewarded as well. Since we are taking care of this manually you are requested to contact one of our team members on Telegram (@Paperstream @asxtree) or at store.skycoin.com/pages/support</em>
+The rewards in the new system will be **paid daily or weekly**
 
-<h4>Official Skyminers - Pool Method</h4>
+The skycoin address to be rewarded can be set from the cli:
 
-Rewards are being paid on a visor by visor basis. The total amount of rewards is limited by a pool size that is subject to change:
-* You can receive a maximum of 12.0 Skycoin per visor
-    - official Skyminers consist of eight visors and one visor that may be additionally serving as hypervisor
-* Rewards are being calculated on a visor by visor basis
-    - you'll receive up to 8 Skycoin per-visor rewards
-* The total pool size is being divided evenly between all visors eligible for receiving rewards. This implies that you will receive less than 12.0 Skycoin per-visor rewards in case the pool size would be surpassed. 
+```
+skywire-cli reward <skycoin-address>
+```
 
-***
+or via the hypervisor UI.
 
-### Official Skyminers - New Batches
+### Reward tiers
 
-<h4>Official Skyminers - SKY/USD Method</h4>
-
-<div align="center">
-<em><u>Fixed Skycoin payments can be claimed within three years after purchase.</u></em><br/><br/>
-You will receive a fixed Skycoin payments per month <b>in addition</b> to any traffic forwarding payments <br/> that you will receive in the Skywire mainnet.<br/><strong>
-Fixed Skycoin payments per month = USD Miner Price / 24 = $83.30 USD.</strong>
-<br>
-</div>
-<br/>
-<div align="center"><i>Your fixed Skycoin payments are dependent on the uptime of your visors. All of your 8 visors must meet the uptime requirement for you to receive the full $83.30 USD, it is therefore <strong>super important to keep your visors online.</strong></i></div>
-<br>
-<em>Faulty Orange Pi Primes/Orange Pi 3s or Skyminer Routers of official Skyminers will be rewarded regardless of your uptime until you receive a replacement. If the replacement doesn't arrive in time for you to make the uptime requirement because it arrived on short notice or not on the schedule at all you will be rewarded as well. Since we are taking care of this manually you are requested to contact one of our team members on Telegram (@Paperstream @asxtree) or at store.skycoin.com/pages/support</em>
-
-Summary:
-* You are eligible to receive 24 fixed Skycoin payments ($83.30 USD)
-* The 24 fixed Skycoin payments are comprised of 8 Skycoin visor payments ($10.4125 USD)
-    - official Skyminers consist of eight visors and one visor that may be additionally serving as hypervisor
-    - you'll receive up to 8 Skycoin visor payments per month based on the individual uptime of your visors 
-* The uptime of all visors in your official Skyminer is being evaluated on a visor-by-visor basis
-* After these 24 payments, the reward model automatically changes to the [pool method reward model](https://github.com/skycoin/skywire/blob/master/mainnet_rules.md#official-skyminers)
-* *You will receive traffic forwarding payments once the Skywire mainnet with bandwidth metering is live*
-
-#### Skycoin Price Calculation
-We are calculating the underlying Skycoin price for your rewards based on the moving average exponential method:
-- timespan 1M on the Tradingview SKY/USD chart
-- 30 day length
-- starting on the 1st day of the subsequent month at 00:00
-
-***
-
-### DIY Skyminers
-
-- Rewards are being paid on a visor-by-visor basis according to the uptime requirement of 75%.
-- You can receive a maximum of 6.0 Skycoin per visor
-- Up to eight (8) DIY visors are being rewarded per user account in the Skywire Whitelisting System.
-- The total amount of DIY rewards is limited by a pool size that is subject to change. 
-
-***
-
-## Requirements
-
-<div align="center"><b>Each visor must have at least 75% uptime during the month to be eligible for rewards.</b></div> 
-
-As of now, you are provided with two tools to check whether or not you're online and generating uptime:
-* The [discovery website](https://uptime-tracker.skywire.skycoin.com/uptimes)
-* The [Skywire whitelisting system](https://whitelist.skycoin.com)
-   - along with the [Skywire whitelisting system user guide](https://github.com/skycoin/skywire/wiki/Skywire-Whitelisting-System)
-
-You are advised to use [this guide](https://github.com/skycoin/skywire/wiki/Troubleshooting#online-status-verification) to **verify that your visors are online & connected to the discovery server**.
-<div align="center"><em><b>Make sure to verify the online status of your visors on a regular basis!</em></b></div>
-
-***
-## Whitelist
-
-<div align="center">Whitelist applications must be submitted using the <a href="https://whitelist.skycoin.com">Skywire Whitelisting System</a>.<br> 
-All necessary steps to get up and running are described in  <a href="https://github.com/skycoin/skywire/wiki/Skywire-Whitelisting-System">this guide</a><br></div>
-
-
-<div align="center">
-     <p>
-          <em>
-               The previously submitted data using skycoin.net/whitelist was imported into the new system & accounts were created for you. Check your emails for an invite link to assign your own password and follow the instructions in the email & the guide referenced above. <br> Make sure to double check your data and adjust it if necessary.
-          </em>
-     </p>
-</div>
-
-- The whitelist is being **updated retroactively on a monthly basis** so it is **not important** in which week you are being approved for the whitelist.
-- **Official Skyminers are whitelisted by default after purchase.**
-- There is no waiting period at the moment
-- Whitelist applications are being updated every couple days (potentially up to a week).
-    
-#### View & change your data
-    - Login to the [Skywire Whitelisting System](https://whitelist.skycoin.com) to:
-          - review your current application state
-          - view your whitelisted miners 
-          - adjust public keys if necessary
-          - adjust your Skycoin wallet reward address as you like
-    - Contact support@skycoin.com in case your account is disabled or other issues occur
-    - You can double check with our team members (see above) if we received your application.
-
-
-### Facts
-
-<div align="center"><b>You must use the <a href="https://whitelist.skycoin.com">Skywire Whitelisting System</a> to keep your submitted data up to date</b>
-<br><em> Read<a href="https://github.com/skycoin/skywire/wiki/Skywire-Whitelisting-System"> this guide</a> to familiarize yourself with the new system.</em></div>
-<br>
-
-* Keep your account data up to date using the [Skywire Whitelisting System](https://whitelist.skycoin.com)
-     - Update Skycoin Wallet Address
-     - Update public keys if it's necessary
-     - Add more boards and include new pictures to receive the verification of an admin
-     - Transfer your whitelisted miner to another email address
-* The whitelist is a queue based on a first come first served basis, the benchmark for applications is the hardware list above + the official miner specifications.
-* For email address changes of official miners please use the [transfer miner function](https://github.com/skycoin/skywire/wiki/Skywire-Whitelisting-System#transfer-miner) of the Skywire Whitelisting System.
-
-#### Official Miner - Required Data for the Whitelisting System
-     - MUST NOT USE THE APPLICATION FORM SINCE THEY ARE BEING AUTOMATICALLY WHITELISTED!
-     - Skycoin wallet reward address.
-     - Your 7 public keys. Simply submit less public keys if you have DOA components (reward will be paid regardless until you receive your replacement(s)).
-
-<div align="center"><b>Please note that your account was pre-made for you after purchasing.<br> You received an email with all necessary links & instructions, please check your inbox and follow the steps in the <a href="https://github.com/skycoin/skywire/wiki/Skyminer-Official-Guide">Official Skyminer Guide</a>!</b></div>
-
-#### DIY Miner - Required Data for the Whitelisting System
-     - Location; doesn't have to be 100% precise.
-     - Skycoin wallet reward address.
-     - Miner photos: At least three photos, each from a different perspective and max. 3 MB in size.
-     - Description: Go into detail of the used hardware components (the router, boards etc. which are presented in the pictures
-          - Telegram account. Join us, there is an awesome community waiting for you!
-          - Visor quantity: The number of pis you're running in your miner.
-          - Visor Hardware: Specify the hardware you're using. Add a note if you have merged more than 1 type of board in your miner. Elaborate on boards that may be in the pictures but were not (yet) submitted.
-          - Visor OS: The OS you're running on the boards.
-     - Your public keys.
+There are three tiers for rewards. The lowest tier is distributed to all nodes which meet the basic requirements. Other tiers are based on bandwidth which was processed by the visor. If the visor processed **any** verifiable bandwidth, according to the transport logs, the visor will gain the rewards of the second tier plus the lowest tier. If the visor processed above the average amount of bandwidth, it will receive first tier rewards, in addition to the lowest tier.
 
 ***
 
 ## Hardware
 
-**VM's, servers or personal computers are not 'allowed' in the mainnet, i.e. they will not be whitelisted and receive rewards.** 
+**VM's, servers or personal computers are not permitted to collect rewards**
 
-The following hardware is accepted in the Skywire mainnet:
+The following hardware is eligible for rewards:
 
 #### Orange Pi
      - Prime
@@ -348,11 +200,11 @@ The following hardware is accepted in the Skywire mainnet:
      - Neo
      - Quad
      - X86
-     
+
 #### X96 Android TV Box
      - X96 mini
-     
-#### Dolamee 
+
+#### Dolamee
      - A95X F1 Smart TV Box
 
 #### Radxa
@@ -360,5 +212,5 @@ The following hardware is accepted in the Skywire mainnet:
 
 #### ZTE
      - ZXV10 B860H
-     
-**If you like to use other boards please contact the team first to be approved before you buy them, only the boards on the list are guaranteed to be whitelisted.**
+
+**If you would like to use other boards please contact the team first for approval ; only the boards on the list are guaranteed to be eligible for rewards.**

--- a/mainnet_rules.md
+++ b/mainnet_rules.md
@@ -2,9 +2,13 @@
 
 # Skywire Reward Eligibility Rules
 
+* We are transitioning to new system for rewards, deprecating the skywire whitelist
+* The rules in this article may change at any time, depending on if there are problems
+* We will attempt to address any issues reported via [@skywire](https://t.me/skywire) Telegram channel
+
 #### Table of Contents
 * [Introduction](#introduction)
-* [Rules & Requirements](#rules-&-requirements)
+* [Rules & Requirements](#rules--requirements)
 * [Rewards](#rewards)
   * [How it works](#how-it-works)
   * [Reward Tiers](#reward-tiers)
@@ -12,14 +16,14 @@
 
 ## Introduction
 
-<div align="center"><em> Disclaimer: The rewards in this post are subject to change. Updates to this article will be followed by a notification via the <a href="https://t.me/SkywirePSA">official Skywire PSA channel</a> on Telegram.</em>
+<div align="center"><em> Updates to this article will be followed by a notification via the <a href="https://t.me/SkywirePSA">official Skywire PSA channel</a> on Telegram.</em>
 </div>
+<br>
 
 All information about rewards will be published here. Please ask for clarification in the [@skywire](https://t.me/skywire) Telegram channel if some things appear to not be covered. Join [@SkywirePSA](https://t.me/SkywirePSA) for public service announcements (PSA) regarding the skywire network.
 
 Reward notifications will happen via the skychat app, which is included with the skywire release (PENDING IMPLEMENTATION)
 
-***
 
 ## Rules & Requirements
 
@@ -28,7 +32,7 @@ Reward notifications will happen via the skychat app, which is included with the
 * A valid skycoin address must be set for the visor
 * The visor must be running on approved [hardware](#hardware)
 * the visor responds to intermittent pings (i.e. it's possible to establish transports to that visor)
-***
+
 
 ## Rewards
 
@@ -44,19 +48,31 @@ The skycoin address to be rewarded can be set from the cli:
 skywire-cli reward <skycoin-address>
 ```
 
+![image](https://user-images.githubusercontent.com/36607567/213941582-f57213b8-2acd-4c9a-a2c0-9089a8c2604e.png)
+
+
 or via the hypervisor UI.
+
+![image](https://user-images.githubusercontent.com/36607567/213941478-34c81493-9c3c-40c2-ac22-e33e3683a16f.png)
+
+the example above shows the genesis address for the skycoin blockchain. **Please do not use the genesis address.**
 
 ### How it works
 
-The skycoin reward address is set per the visor via the cli or the hypervisor, in a text file contained in the "local" folder (local_path in the skywire config file). This address is written into the system survey and served, along with transport logs, via dmsghttp.
+The skycoin reward address is set per the visor via the cli or the hypervisor, in a text file contained in the "local" folder (local_path in the skywire config file). This address is written into the [system survey](https://github.com/skycoin/skywire/tree/develop/cmd/skywire-cli#survey) and served, along with transport logs, via dmsghttp.
 
-This survey will be fetched on a daily basis, along with the transport logs, and checked to verify hardware requirements, etc. The transport logs from both ends of any given transport are compared and verified.
+This survey will be fetched on a daily basis with [`dmsgget`](https://github.com/skycoin/dmsg/tree/develop/cmd/dmsgget), along with the transport logs, and checked to verify hardware and other requirements, etc. The transport logs from both ends of any given transport are compared and verified.
 
 ### Reward tiers
 
-There are three tiers for rewards. The lowest tier is distributed to all nodes which meet the basic requirements. Other tiers are based on bandwidth which was processed by the visor. If the visor processed **any** verifiable bandwidth, according to the transport logs, the visor will gain the rewards of the second tier plus the lowest tier. If the visor processed above the average amount of bandwidth, it will receive first tier rewards, in addition to the lowest tier.
+There are three tiers for rewards.
 
-***
+* **TIER 3** The lowest tier is distributed to all nodes which meet the basic requirements.
+
+Other tiers are based on bandwidth which was handled by the visor. Meaning the logs from each end of the transport were fetched and agree
+ 
+* **TIER 2** If the visor processed **any** verifiable bandwidth, the visor will have earned the rewards of the second tier plus those of the lowest tier.
+* **TIER 1** If the visor processed above the average amount of bandwidth, it will receive first tier rewards, in addition to the lowest tier.
 
 ## Hardware
 

--- a/mainnet_rules.md
+++ b/mainnet_rules.md
@@ -6,6 +6,7 @@
 * [Introduction](#introduction)
 * [Rules & Requirements](#rules-&-requirements)
 * [Rewards](#rewards)
+  * [How it works](#how-it-works)
   * [Reward Tiers](#reward-tiers)
 * [Hardware](#hardware)
 
@@ -26,7 +27,7 @@ Reward notifications will happen via the skychat app, which is included with the
 * 75% uptime is required to be eligible to receive rewards
 * A valid skycoin address must be set for the visor
 * The visor must be running on approved [hardware](#hardware)
-
+* the visor responds to intermittent pings (i.e. it's possible to establish transports to that visor)
 ***
 
 ## Rewards
@@ -44,6 +45,12 @@ skywire-cli reward <skycoin-address>
 ```
 
 or via the hypervisor UI.
+
+### How it works
+
+The skycoin reward address is set per the visor via the cli or the hypervisor, in a text file contained in the "local" folder (local_path in the skywire config file). This address is written into the system survey and served, along with transport logs, via dmsghttp.
+
+This survey will be fetched on a daily basis, along with the transport logs, and checked to verify hardware requirements, etc. The transport logs from both ends of any given transport are compared and verified.
 
 ### Reward tiers
 


### PR DESCRIPTION
 Changes:	
-	omit all language differentiating types of miners (official, DIY)
-	omit references to the whitelist, which will be deprecated
-	add description of reward teirs
-	add description of how the new reward system will work
-       Increment minimum required skywire version to 1.3.0
