### PR TITLE
move survey generation to its own goroutine

### DIFF
--- a/cmd/skywire-cli/commands/survey/root.go
+++ b/cmd/skywire-cli/commands/survey/root.go
@@ -22,7 +22,6 @@ var (
 func init() {
 	surveyCmd.Flags().SortFlags = false
 	surveyCmd.Flags().BoolVarP(&isCksum, "sha", "s", false, "generate checksum of system survey")
-
 }
 
 // RootCmd is surveyCmd

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -180,7 +180,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0644); err != nil {
+	if err := os.MkdirAll(dir, 0744); err != nil {
 		return nil, err
 	}
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -438,63 +438,64 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, log *logging.Logger) e
 }
 
 func initSystemSurvey(ctx context.Context, v *Visor, log *logging.Logger) error {
-
-	if visorconfig.IsRoot() {
-		//check for valid reward address set as prerequisite for generating the system survey
-		rewardAddressBytes, err := os.ReadFile(visorconfig.PackageConfig().LocalPath + "/" + visorconfig.RewardFile) //nolint
-		if err == nil {
-			//remove any newline from rewardAddress string
-			rewardAddress := strings.TrimSuffix(string(rewardAddressBytes), "\n")
-			//validate the skycoin address
-			cAddr, err := coincipher.DecodeBase58Address(rewardAddress)
-			if err != nil {
-				log.WithError(err).Error("Invalid skycoin reward address.")
-				return err
-			}
-			log.Info("Skycoin reward address: ", cAddr.String())
-			//generate the system survey
-			pathutil.EnsureDir(v.conf.LocalPath) //nolint
-			survey, err := visorconfig.SystemSurvey()
-			if err != nil {
-				log.WithError(err).Error("Could not read system info.")
-				return err
-			}
-			survey.PubKey = v.conf.PK
-			survey.SkycoinAddress = cAddr.String()
-			// Print results.
-			s, err := json.MarshalIndent(survey, "", "\t")
-			if err != nil {
-				log.WithError(err).Error("Could not marshal json.")
-				return err
-			}
-			err = os.WriteFile(v.conf.LocalPath+"/"+visorconfig.NodeInfo, s, 0644) //nolint
-			if err != nil {
-				log.WithError(err).Error("Failed to write system hardware survey to file.")
-				return err
-			}
-			log.Info("Generating system survey")
-			f, err := os.ReadFile(filepath.Clean(v.conf.LocalPath + "/" + visorconfig.NodeInfo))
-			if err != nil {
-				log.WithError(err).Error("Failed to write system hardware survey to file.")
-				return err
-			}
-			srvySha256Byte32 := sha256.Sum256([]byte(f))
-			err = os.WriteFile(v.conf.LocalPath+"/"+visorconfig.NodeInfoSha256, srvySha256Byte32[:], 0644) //nolint
-			if err != nil {
-				log.WithError(err).Error("Failed to write system hardware survey to file.")
-				return err
-			}
-		} else {
-			err := os.Remove(visorconfig.PackageConfig().LocalPath + "/" + visorconfig.NodeInfo)
+	go func() {
+		if visorconfig.IsRoot() {
+			//check for valid reward address set as prerequisite for generating the system survey
+			rewardAddressBytes, err := os.ReadFile(visorconfig.PackageConfig().LocalPath + "/" + visorconfig.RewardFile) //nolint
 			if err == nil {
-				log.Debug("Removed hadware survey for visor not seeking rewards")
-			}
-			err = os.Remove(visorconfig.PackageConfig().LocalPath + "/" + visorconfig.NodeInfoSha256)
-			if err == nil {
-				log.Debug("Removed hadware survey checksum file")
+				//remove any newline from rewardAddress string
+				rewardAddress := strings.TrimSuffix(string(rewardAddressBytes), "\n")
+				//validate the skycoin address
+				cAddr, err := coincipher.DecodeBase58Address(rewardAddress)
+				if err != nil {
+					log.WithError(err).Error("Invalid skycoin reward address.")
+					return
+				}
+				log.Info("Skycoin reward address: ", cAddr.String())
+				//generate the system survey
+				pathutil.EnsureDir(v.conf.LocalPath) //nolint
+				survey, err := visorconfig.SystemSurvey()
+				if err != nil {
+					log.WithError(err).Error("Could not read system info.")
+					return
+				}
+				survey.PubKey = v.conf.PK
+				survey.SkycoinAddress = cAddr.String()
+				// Print results.
+				s, err := json.MarshalIndent(survey, "", "\t")
+				if err != nil {
+					log.WithError(err).Error("Could not marshal json.")
+					return
+				}
+				err = os.WriteFile(v.conf.LocalPath+"/"+visorconfig.NodeInfo, s, 0644) //nolint
+				if err != nil {
+					log.WithError(err).Error("Failed to write system hardware survey to file.")
+					return
+				}
+				log.Info("Generating system survey")
+				f, err := os.ReadFile(filepath.Clean(v.conf.LocalPath + "/" + visorconfig.NodeInfo))
+				if err != nil {
+					log.WithError(err).Error("Failed to write system hardware survey to file.")
+					return
+				}
+				srvySha256Byte32 := sha256.Sum256([]byte(f))
+				err = os.WriteFile(v.conf.LocalPath+"/"+visorconfig.NodeInfoSha256, srvySha256Byte32[:], 0644) //nolint
+				if err != nil {
+					log.WithError(err).Error("Failed to write system hardware survey to file.")
+					return
+				}
+			} else {
+				err := os.Remove(visorconfig.PackageConfig().LocalPath + "/" + visorconfig.NodeInfo)
+				if err == nil {
+					log.Debug("Removed hadware survey for visor not seeking rewards")
+				}
+				err = os.Remove(visorconfig.PackageConfig().LocalPath + "/" + visorconfig.NodeInfoSha256)
+				if err == nil {
+					log.Debug("Removed hadware survey checksum file")
+				}
 			}
 		}
-	}
+	}()
 	return nil
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- move survey generation step to its own goroutine for fixing delay in running visor

How to test this PR:
- after line 441 of `pkg>visor>init.go` file add `time.Sleep(30 * time.Second)`
- make builld
- run visor as root with debug log level in config
- check logs after 30 second