### PR TITLE
Fix warn logs

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1522,14 +1522,14 @@ func initHypervisor(_ context.Context, v *Visor, log *logging.Logger) error {
 			err = srv.ListenAndServe()
 		}
 
-		if err != nil {
+		// don't print error if local server is closed
+		if !errors.Is(err, http.ErrServerClosed) {
 			v.log.WithError(err).Error("Hypervisor exited with error.")
 		}
-		//		cancel()
 	}()
 
 	v.pushCloseStack("hypervisor", func() error {
-		srv.Shutdown(ctx) //nolint
+		err := srv.Shutdown(ctx) //nolint
 		cancel()
 		return err
 	})

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -196,7 +196,7 @@ func run(conf *visorconfig.V1) error {
 	}
 
 	ctx, cancel := cmdutil.SignalContext(context.Background(), mLog)
-	vis, ok := newVisor(ctx, conf)
+	vis, ok := NewVisor(ctx, conf)
 	if !ok {
 		select {
 		case <-ctx.Done():
@@ -228,8 +228,8 @@ func run(conf *visorconfig.V1) error {
 	return nil
 }
 
-// newVisor constructs new Visor.
-func newVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
+// NewVisor constructs new Visor.
+func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	if conf == nil {
 		conf = initConfig()
 	}


### PR DESCRIPTION
Did you run `make format && make check`?

Fixes #	

 Changes:	
- Fixed shutdown warning logs

How to test this PR:
1. Start visor `./skywire-visor`
2. Stop visor `Ctrl+C`
3. Check shutdown logs