### PR TITLE
change transport_logs folder to 755 permissions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -161,7 +161,7 @@ linters:
     - unused
     - ineffassign
     - typecheck
-#    - gosec
+    - gosec
     - megacheck
     - misspell
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -161,7 +161,7 @@ linters:
     - unused
     - ineffassign
     - typecheck
-    - gosec
+#    - gosec
     - megacheck
     - misspell
     - nakedret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.3.0
 
+-   change transport_logs folder to 755 permissions & various similar fixes  [#1447](https://github.com/skycoin/skywire/pull/1447)
+-   Fix warn logs  [#1446](https://github.com/skycoin/skywire/pull/1446)
+-   move survey generation to its own goroutine  [#1445](https://github.com/skycoin/skywire/pull/1445)
+-   rebuild UI  [#1444](https://github.com/skycoin/skywire/pull/1444)
 -   add hypervisor UI integration for managing the reward address [#1442](https://github.com/skycoin/skywire/pull/1442)
 -   update mainnet rules for collecting rewards under the new system [#1443](https://github.com/skycoin/skywire/pull/1443)
 -   omit all language differentiating types of miners (official, DIY) from mainnet_rules.md [#1443](https://github.com/skycoin/skywire/pull/1443)

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -341,7 +341,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil {
+	if err := os.MkdirAll(*path, 0755); err != nil { /* nosec */
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -341,7 +341,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0707); err != nil {
+	if err := os.MkdirAll(*path, 0755); err != nil {
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -341,7 +341,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil { // #nosec
+	if err := os.MkdirAll(*path, 0755); err != nil { /* #nosec */
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -341,7 +341,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil { /* nosec */
+	if err := os.MkdirAll(*path, 0755); err != nil { // #nosec
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -341,7 +341,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil { /* #nosec */
+	if err := os.MkdirAll(*path, 0755); err != nil { //nolint
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -317,7 +317,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil { /* nosec */
+	if err := os.MkdirAll(*path, 0755); err != nil { // #nosec
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -317,7 +317,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil { /* #nosec */
+	if err := os.MkdirAll(*path, 0755); err != nil { //nolint
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -317,7 +317,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil { // #nosec
+	if err := os.MkdirAll(*path, 0755); err != nil { /* #nosec */
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -317,7 +317,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0707); err != nil {
+	if err := os.MkdirAll(*path, 0755); err != nil {
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -317,7 +317,7 @@ func ensureDir(path *string) error {
 	if _, err := os.Stat(*path); !os.IsNotExist(err) {
 		return nil
 	}
-	if err := os.MkdirAll(*path, 0755); err != nil {
+	if err := os.MkdirAll(*path, 0755); err != nil { /* nosec */
 		return fmt.Errorf("failed to create dir: %s", err)
 	}
 	return nil

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -180,7 +180,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil { /* nosec */
+	if err := os.MkdirAll(dir, 0755); err != nil { // #nosec
 		return nil, err
 	}
 

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -180,7 +180,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0744); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -180,7 +180,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil { /* #nosec */
+	if err := os.MkdirAll(dir, 0755); err != nil { //nolint
 		return nil, err
 	}
 

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -180,7 +180,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil { // #nosec
+	if err := os.MkdirAll(dir, 0755); err != nil { /* #nosec */
 		return nil, err
 	}
 

--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -180,7 +180,7 @@ type fileTransportLogStore struct {
 
 // FileTransportLogStore implements file TransportLogStore.
 func FileTransportLogStore(ctx context.Context, dir string, rInterval time.Duration, log *logging.Logger) (LogStore, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil { /* nosec */
 		return nil, err
 	}
 

--- a/pkg/util/pathutil/configpath.go
+++ b/pkg/util/pathutil/configpath.go
@@ -148,7 +148,7 @@ func WriteJSONConfig(conf interface{}, output string, replace bool) {
 		log.Fatalf("file %s already exists, stopping as 'replace,r' flag is not set", output)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { /* nosec */
+	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { // #nosec
 		log.WithError(err).Fatalln("failed to create output directory")
 	}
 

--- a/pkg/util/pathutil/configpath.go
+++ b/pkg/util/pathutil/configpath.go
@@ -148,7 +148,7 @@ func WriteJSONConfig(conf interface{}, output string, replace bool) {
 		log.Fatalf("file %s already exists, stopping as 'replace,r' flag is not set", output)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { // #nosec
+	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { /* #nosec */
 		log.WithError(err).Fatalln("failed to create output directory")
 	}
 

--- a/pkg/util/pathutil/configpath.go
+++ b/pkg/util/pathutil/configpath.go
@@ -148,7 +148,7 @@ func WriteJSONConfig(conf interface{}, output string, replace bool) {
 		log.Fatalf("file %s already exists, stopping as 'replace,r' flag is not set", output)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { /* nosec */
 		log.WithError(err).Fatalln("failed to create output directory")
 	}
 

--- a/pkg/util/pathutil/configpath.go
+++ b/pkg/util/pathutil/configpath.go
@@ -148,12 +148,12 @@ func WriteJSONConfig(conf interface{}, output string, replace bool) {
 		log.Fatalf("file %s already exists, stopping as 'replace,r' flag is not set", output)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(output), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil {
 		log.WithError(err).Fatalln("failed to create output directory")
 	}
 
 	// nolint:gosec
-	if err := os.WriteFile(output, raw, 0744); err != nil {
+	if err := os.WriteFile(output, raw, 0644); err != nil {
 		log.WithError(err).Fatalln("failed to write file")
 	}
 

--- a/pkg/util/pathutil/configpath.go
+++ b/pkg/util/pathutil/configpath.go
@@ -148,7 +148,7 @@ func WriteJSONConfig(conf interface{}, output string, replace bool) {
 		log.Fatalf("file %s already exists, stopping as 'replace,r' flag is not set", output)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { /* #nosec */
+	if err := os.MkdirAll(filepath.Dir(output), 0755); err != nil { //nolint
 		log.WithError(err).Fatalln("failed to create output directory")
 	}
 

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist.go
@@ -37,7 +37,7 @@ func NewConfigWhitelist(confPath string) (Whitelist, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = os.MkdirAll(filepath.Dir(confPath), 0750); err != nil {
+	if err = os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
 		return nil, err
 	}
 

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist.go
@@ -37,7 +37,7 @@ func NewConfigWhitelist(confPath string) (Whitelist, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
+	if err = os.MkdirAll(filepath.Dir(confPath), 0755); err != nil { /* nosec */
 		return nil, err
 	}
 

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgpty/whitelist.go
@@ -1,10 +1,10 @@
-// Package dmsgpty pkg/dmsgpty/whitelist.go
 package dmsgpty
 
 import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 )
 
@@ -37,7 +38,7 @@ func NewConfigWhitelist(confPath string) (Whitelist, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = os.MkdirAll(filepath.Dir(confPath), 0755); err != nil { /* nosec */
+	if err = os.MkdirAll(filepath.Dir(confPath), 0750); err != nil {
 		return nil, err
 	}
 
@@ -170,8 +171,8 @@ func (w *configWhitelist) open() error {
 		}
 	}
 
-	// read file
-	file, err := os.ReadFile(w.confPath)
+	// read file using ioutil
+	file, err := ioutil.ReadFile(w.confPath)
 	if err != nil {
 		return err
 	}
@@ -199,7 +200,7 @@ func updateFile(confPath string) error {
 		return err
 	}
 	// write to config file
-	err = os.WriteFile(confPath, b, 0600)
+	err = ioutil.WriteFile(confPath, b, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

 Changes:	
-	 transport_logs folder to 755 permissions

NOTE we still have other folders created with nonstandard permissions.

```
find . -type f -print | xargs grep "os.MkdirAll"
```

permissions are standardly either 755 or 644

folders created with `mkdir` are 755 permissions by default. All folders we create should likely use that permission unless we have a good reason to diverge from that - with examples of this being done from somewhere else in the filesystem that we can cite.

Configs and non-executable files should have 0644 permissions