### PR TITLE
remove autopeering

### DIFF
--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -31,7 +31,7 @@ var (
 	stopVisorWg          sync.WaitGroup //nolint:unused
 	launchBrowser        bool
 	syslogAddr           string
-	logger               = logging.MustGetLogger("skywire-visor")
+	logger               = logging.MustGetLogger("skywire-visor") //nolint:unused
 	logLvl               string
 	pprofMode            string
 	pprofAddr            string
@@ -162,6 +162,7 @@ func trimStringFromDot(s string) string {
 	return s
 }
 */
+
 // RootCmd contains the help command & invocation flags
 var RootCmd = &cobra.Command{
 	Use:   "skywire-visor",

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -18,17 +18,16 @@ import (
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/logging"
-	"github.com/skycoin/skywire-utilities/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/restart"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 var (
-	restartCtx           = restart.CaptureContext()
-	pkgconfigexists      bool
-	userconfigexists     bool
-	isAutoPeer           bool
-	autoPeerIP           string
+	restartCtx       = restart.CaptureContext()
+	pkgconfigexists  bool
+	userconfigexists bool
+	//	isAutoPeer           bool
+	//	autoPeerIP           string
 	stopVisorWg          sync.WaitGroup //nolint:unused
 	launchBrowser        bool
 	syslogAddr           string
@@ -115,7 +114,7 @@ func init() {
 	hiddenflags = append(hiddenflags, "hv")
 	RootCmd.Flags().BoolVarP(&disableHypervisorPKs, "xhv", "k", false, "disable remote hypervisors \u001b[0m*")
 	hiddenflags = append(hiddenflags, "xhv")
-	initAutoPeerFlags()
+	//	initAutoPeerFlags()
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "s", "", "[ debug | warn | error | fatal | panic | trace ] \u001b[0m*")
 	hiddenflags = append(hiddenflags, "loglvl")
 	RootCmd.Flags().StringVarP(&pprofMode, "pprofmode", "q", "", "[ cpu | mem | mutex | block | trace | http ]")
@@ -136,6 +135,9 @@ func init() {
 	RootCmd.SetUsageTemplate(help)
 
 }
+
+//omit due to possible panic
+/*
 func initAutoPeerFlags() {
 	localIPs, err := netutil.DefaultNetworkInterfaceIPs()
 	if err != nil {
@@ -159,7 +161,7 @@ func trimStringFromDot(s string) string {
 	}
 	return s
 }
-
+*/
 // RootCmd contains the help command & invocation flags
 var RootCmd = &cobra.Command{
 	Use:   "skywire-visor",

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1220,15 +1220,16 @@ func initHypervisors(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 		go func(hvErrs chan error) {
 			defer wg.Done()
-			var autoPeerIP string
-			if v.autoPeer {
-				autoPeerIP = v.autoPeerIP
-			} else {
-				autoPeerIP = ""
-			}
+			//			var autoPeerIP string
+			//			if v.autoPeer {
+			//				autoPeerIP = v.autoPeerIP
+			//			} else {
+			//				autoPeerIP = ""
+			//			}
 			defer delete(v.connectedHypervisors, hvPK)
 			v.connectedHypervisors[hvPK] = true
-			ServeRPCClient(ctx, log, autoPeerIP, v.dmsgC, rpcS, addr, hvErrs)
+			ServeRPCClient(ctx, log, v.dmsgC, rpcS, addr, hvErrs)
+			//			ServeRPCClient(ctx, log, autoPeerIP, v.dmsgC, rpcS, addr, hvErrs)
 
 		}(hvErrs)
 

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"net"
 	"net/rpc"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/dmsg"
 
-	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/netutil"
 )
 
@@ -25,32 +23,35 @@ func isDone(ctx context.Context) bool {
 }
 
 // ServeRPCClient repetitively dials to a remote dmsg address and serves a RPC server to that address.
-func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, autoPeerIP string, dmsgC *dmsg.Client, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
+func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Client, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
+	//func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, autoPeerIP string, dmsgC *dmsg.Client, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
 	const maxBackoff = time.Second * 5
 	retry := netutil.NewRetrier(log, netutil.DefaultInitBackoff, maxBackoff, netutil.DefaultTries, netutil.DefaultFactor)
-	pubkey := cipher.PubKey{}
+	//	pubkey := cipher.PubKey{}
 	for {
 		var conn net.Conn
 		err := retry.Do(ctx, func() (rErr error) {
 			log.Info("Dialing...")
 			addr := dmsg.Addr{PK: rAddr.PK, Port: rAddr.Port}
-			if autoPeerIP != "" {
-				hvkey, err := FetchHvPk(autoPeerIP)
-				if err != nil {
-					log.Error("error autopeering")
-				} else {
-					hvkey = strings.TrimSuffix(hvkey, "\n")
-					hypervisorPKsSlice := strings.Split(hvkey, ",")
-					for _, pubkeyString := range hypervisorPKsSlice {
-						//use pubkey.Set as validation or to convert the string to a pubkey
-						if err := pubkey.Set(pubkeyString); err != nil {
-							log.Warnf("Cannot add %s PK as remote hypervisor PK due to: %s", pubkeyString, err)
-							continue
+			/*
+				if autoPeerIP != "" {
+					hvkey, err := FetchHvPk(autoPeerIP)
+					if err != nil {
+						log.Error("error autopeering")
+					} else {
+						hvkey = strings.TrimSuffix(hvkey, "\n")
+						hypervisorPKsSlice := strings.Split(hvkey, ",")
+						for _, pubkeyString := range hypervisorPKsSlice {
+							//use pubkey.Set as validation or to convert the string to a pubkey
+							if err := pubkey.Set(pubkeyString); err != nil {
+								log.Warnf("Cannot add %s PK as remote hypervisor PK due to: %s", pubkeyString, err)
+								continue
+							}
+							addr.PK = pubkey
 						}
-						addr.PK = pubkey
 					}
 				}
-			}
+			*/
 			conn, rErr = dmsgC.Dial(ctx, addr)
 			return rErr
 		})

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -101,9 +101,9 @@ type Visor struct {
 	// produced by concurrent parts of modules
 	runtimeErrors chan error
 
-	isServicesHealthy    *internalHealthInfo
-	autoPeer             bool                   // autoPeer=true tells the visor to query the http endpoint of the hypervisor on the local network for the hypervisor's public key when connectio to the hypervisor is lost
-	autoPeerIP           string                 // autoPeerCmd is the command string used to return the public key of the hypervisor
+	isServicesHealthy *internalHealthInfo
+	//	autoPeer             bool                   // autoPeer=true tells the visor to query the http endpoint of the hypervisor on the local network for the hypervisor's public key when connectio to the hypervisor is lost
+	//	autoPeerIP           string                 // autoPeerCmd is the command string used to return the public key of the hypervisor
 	remoteVisors         map[cipher.PubKey]Conn // remote hypervisors the visor is attempting to connect to
 	connectedHypervisors map[cipher.PubKey]bool // remote hypervisors the visor is currently connected to
 	allowedPorts         map[int]bool
@@ -176,9 +176,9 @@ func run(conf *visorconfig.V1) error {
 		}
 	}
 
-	if isAutoPeer {
-		conf = initAutopeer(conf)
-	}
+	//	if isAutoPeer {
+	//		conf = initAutopeer(conf)
+	//	}
 
 	if logLvl != "" {
 		//validate & set log level
@@ -304,10 +304,10 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	if !v.processRuntimeErrs() {
 		return nil, false
 	}
-	if isAutoPeer {
-		v.autoPeer = true
-		v.autoPeerIP = autoPeerIP
-	}
+	//	if isAutoPeer {
+	//		v.autoPeer = true
+	//		v.autoPeerIP = autoPeerIP
+	//	}
 	log.Info("Startup complete.")
 	return v, true
 }
@@ -334,6 +334,7 @@ func (v *Visor) isStunReady() bool {
 	}
 }
 
+/*
 func initAutopeer(conf *visorconfig.V1) *visorconfig.V1 {
 	log := mLog.PackageLogger("visor:autopeer")
 
@@ -377,6 +378,7 @@ func initAutopeer(conf *visorconfig.V1) *visorconfig.V1 {
 
 	return conf
 }
+*/
 
 func initLogger() *logging.MasterLogger {
 	mLog := logging.NewMasterLogger()


### PR DESCRIPTION
the autopeering is causing a panic on certain systems. The cause is not entirely clear, since it happens for config gen, which has nothing to do with the autopeering

the autopeering was designed to engage only when no local or remote hypervisors were set in the config.

there have only been issues with the autopeering system, mostly caused by an existing power distribution / hardware issue which will require a hardware-based solution to address. Specifically, a redesign of the power distribution bus for the official miner.

So the autopeering is commented out for now

![image](https://user-images.githubusercontent.com/36607567/215340065-9bcb09c7-7963-490f-924a-e3b37d440f41.png)
