### PR TITLE
Send visor version on update uptime

### DIFF
--- a/pkg/utclient/client.go
+++ b/pkg/utclient/client.go
@@ -18,7 +18,7 @@ import (
 
 // APIClient implements uptime tracker API client.
 type APIClient interface {
-	UpdateVisorUptime(context.Context) error
+	UpdateVisorUptime(context.Context, string) error
 }
 
 // httpClient implements Client for uptime tracker API.
@@ -79,7 +79,8 @@ func (c *httpClient) Get(ctx context.Context, path string) (*http.Response, erro
 }
 
 // UpdateVisorUptime updates visor uptime.
-func (c *httpClient) UpdateVisorUptime(ctx context.Context) error {
+func (c *httpClient) UpdateVisorUptime(ctx context.Context, version string) error {
+	ctx = context.WithValue(ctx, "version", version) //nolint
 	resp, err := c.Get(ctx, "/v4/update")
 	if err != nil {
 		return err

--- a/pkg/utclient/client.go
+++ b/pkg/utclient/client.go
@@ -80,8 +80,7 @@ func (c *httpClient) Get(ctx context.Context, path string) (*http.Response, erro
 
 // UpdateVisorUptime updates visor uptime.
 func (c *httpClient) UpdateVisorUptime(ctx context.Context, version string) error {
-	ctx = context.WithValue(ctx, "version", version) //nolint
-	resp, err := c.Get(ctx, "/v4/update")
+	resp, err := c.Get(ctx, fmt.Sprintf("/v4/update?version=%s", version))
 	if err != nil {
 		return err
 	}

--- a/pkg/utclient/client_test.go
+++ b/pkg/utclient/client_test.go
@@ -76,7 +76,7 @@ func TestUpdateVisorUptime(t *testing.T) {
 	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, ip, masterLogger)
 	require.NoError(t, err)
 
-	err = c.UpdateVisorUptime(context.TODO())
+	err = c.UpdateVisorUptime(context.TODO(), "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "/v4/update", <-urlCh)

--- a/pkg/utclient/client_test.go
+++ b/pkg/utclient/client_test.go
@@ -79,7 +79,7 @@ func TestUpdateVisorUptime(t *testing.T) {
 	err = c.UpdateVisorUptime(context.TODO(), "")
 	require.NoError(t, err)
 
-	assert.Equal(t, "/v4/update", <-urlCh)
+	assert.Equal(t, "/v4/update?version=", <-urlCh)
 }
 
 func authHandler(next http.Handler) http.Handler {

--- a/pkg/utclient/mock_api_client.go
+++ b/pkg/utclient/mock_api_client.go
@@ -35,7 +35,7 @@ func (_m *MockAPIClient) Health(ctx context.Context) (int, error) {
 }
 
 // UpdateVisorUptime provides a mock function with given fields: _a0
-func (_m *MockAPIClient) UpdateVisorUptime(_a0 context.Context) error {
+func (_m *MockAPIClient) UpdateVisorUptime(_a0 context.Context, version string) error {
 	ret := _m.Called(_a0)
 
 	var r0 error

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1274,7 +1274,7 @@ func initUptimeTracker(ctx context.Context, v *Visor, log *logging.Logger) error
 	go func() {
 		for range ticker.C {
 			c := context.Background()
-			if err := ut.UpdateVisorUptime(c); err != nil {
+			if err := ut.UpdateVisorUptime(c, v.conf.Version); err != nil {
 				v.isServicesHealthy.unset()
 				log.WithError(err).Warn("Failed to update visor uptime.")
 			} else {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- sending version of visor during update uptime 

How to test this PR:
Check here: https://github.com/SkycoinPro/skywire-services/pull/625