### PR TITLE
improve log collecting logic

### DIFF
--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -68,7 +68,7 @@ var logCmd = &cobra.Command{
 			os.Exit(1)
 		}()
 		// Fetch visors data from uptime tracker
-		endpoint := "https://run.mocky.io/v3/0dd37be5-c4d1-468b-9f7c-7ca57c0b6179"
+		endpoint := "https://ut.skywire.skycoin.com/uptimes?v=v2"
 		if env == "test" {
 			endpoint = "https://ut.skywire.dev/uptimes?v=v2"
 		}

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	env      string
-	duration int
-	minv     string
+	env       string
+	duration  int
+	minv      string
+	allVisors bool
 )
 
 func init() {
@@ -33,6 +34,7 @@ func init() {
 	logCmd.Flags().StringVarP(&env, "env", "e", "prod", "selecting env to fetch uptimes, default is prod")
 	logCmd.Flags().StringVar(&minv, "minv", "v1.3.4", "minimum version for get logs, default is 1.3.4")
 	logCmd.Flags().IntVarP(&duration, "duration", "d", 1, "count of days before today to fetch logs")
+	logCmd.Flags().BoolVar(&allVisors, "all", false, "consider all visors, actually skip filtering on version")
 }
 
 // RootCmd is surveyCmd
@@ -90,7 +92,7 @@ var logCmd = &cobra.Command{
 		// Get visors data
 		var wg sync.WaitGroup
 		for _, v := range uptimes {
-			if v.Version < minv {
+			if !allVisors && v.Version < minv {
 				continue
 			}
 			wg.Add(1)

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -46,14 +46,12 @@ var logCmd = &cobra.Command{
 		log := logging.MustGetLogger("log-collecting")
 
 		// Preparing directories
-		if _, err := os.ReadDir("log_collecting"); err == nil {
-			if err := os.RemoveAll("log_collecting"); err != nil {
-				log.Panic("Unable to remove old log_collecting directory")
+		if _, err := os.ReadDir("log_collecting"); err != nil {
+			if err := os.Mkdir("log_collecting", 0750); err != nil {
+				log.Panic("Unable to log_collecting directory")
 			}
 		}
-		if err := os.Mkdir("log_collecting", 0750); err != nil {
-			log.Panic("Unable to log_collecting directory")
-		}
+
 		if err := os.Chdir("log_collecting"); err != nil {
 			log.Panic("Unable to change directory to log_collecting")
 		}
@@ -70,7 +68,7 @@ var logCmd = &cobra.Command{
 			os.Exit(1)
 		}()
 		// Fetch visors data from uptime tracker
-		endpoint := "https://ut.skywire.skycoin.com/uptimes?v=v2"
+		endpoint := "https://run.mocky.io/v3/0dd37be5-c4d1-468b-9f7c-7ca57c0b6179"
 		if env == "test" {
 			endpoint = "https://ut.skywire.dev/uptimes?v=v2"
 		}
@@ -100,8 +98,10 @@ var logCmd = &cobra.Command{
 				defer wg.Done()
 				var infoErr, shaErr error
 
-				if err := os.Mkdir(key, 0750); err != nil {
-					log.Panicf("Unable to create directory for visor %s", key)
+				if _, err := os.ReadDir(key); err != nil {
+					if err := os.Mkdir(key, 0750); err != nil {
+						log.Panicf("Unable to create directory for visor %s", key)
+					}
 				}
 
 				infoErr = download(ctx, log, httpC, "node-info.json", "node-info.json", key)


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add minimum visor version as `minv` flag to collecting logs, the default value is v1.3.4 now.
- keep old fetched logs.

How to test this PR:
- replace endpoint value in line 71 with `https://run.mocky.io/v3/0dd37be5-c4d1-468b-9f7c-7ca57c0b6179`
- run command by `go run cmd/skywire-cli/skywire-cli.go log collecting`