### PR TITLE
Hide the update options

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -244,12 +244,14 @@ export class NodeListComponent implements OnInit, OnDestroy {
       icon: 'edit'
     });
 
+    // TODO: remove if the option will not be added again. Delete the translatable strings too.
+    /*
     this.options.push({
       name: 'nodes.update-all',
       actionName: 'updateAll',
       icon: 'get_app'
     });
-
+    */
     if (this.canLogOut) {
       this.options.push({
         name: 'common.logout',

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -85,6 +85,8 @@ export class NodeActionsHelper {
       });
     }
 
+    // TODO: remove if the option will not be added again. Delete the translatable strings too.
+    /*
     if (this.canBeUpdated) {
       this.options.push({
         name: 'actions.menu.update',
@@ -92,6 +94,7 @@ export class NodeActionsHelper {
         icon: 'get_app',
       });
     }
+    */
   }
 
   /**


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- The update options were removed from the hypervisor UI.

How to test this PR:
Rebuild the UI and check the menu (pressing the button at the top right part of the screen) on the visor list page and the visor details page. The options for updating all the visors and the current visor should not appear.