### PR TITLE
Improvements for the UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.component.ts
+++ b/static/skywire-manager-src/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { of, Subscription } from 'rxjs';
-import { delay, flatMap } from 'rxjs/operators';
+import { delay, mergeMap } from 'rxjs/operators';
 
 import { StorageService } from './services/storage.service';
 import { SnackbarService } from './services/snackbar.service';
@@ -111,7 +111,7 @@ export class AppComponent {
     if (this.obtainPkSubscription) {
       this.obtainPkSubscription.unsubscribe();
     }
-    this.obtainPkSubscription = of(1).pipe(delay(delayMs), flatMap(() => this.apiService.get('about'))).subscribe(result => {
+    this.obtainPkSubscription = of(1).pipe(delay(delayMs), mergeMap(() => this.apiService.get('about'))).subscribe(result => {
       if (result.public_key) {
         this.finishStartup(result.public_key);
         this.hypervisorPkObtained = true;

--- a/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component.html
@@ -19,6 +19,9 @@
           matInput
         >
       </div>
+      <mat-error>
+        <span>{{ 'rewards-address-config.address-error' | translate }}</span>
+      </mat-error>
     </mat-form-field>
 
     <div class="text-container">

--- a/static/skywire-manager-src/src/app/components/layout/labeled-element-text/labeled-element-text.component.html
+++ b/static/skywire-manager-src/src/app/components/layout/labeled-element-text/labeled-element-text.component.html
@@ -1,7 +1,7 @@
 <div class="wrapper highlight-internal-icon"
   [matTooltip]="(!short ? 'labeled-element.tooltip' : 'labeled-element.tooltip-with-text') | translate:{ text: id }"
   [matTooltipClass]="{ 'tooltip-word-break': true }"
-  (click)="$event.stopPropagation(); processClick();"
+  (click)="$event.stopPropagation(); $event.preventDefault(); processClick();"
 >
   <span class="label">
     <!-- Label prefix. -->

--- a/static/skywire-manager-src/src/app/components/layout/labeled-element-text/labeled-element-text.component.ts
+++ b/static/skywire-manager-src/src/app/components/layout/labeled-element-text/labeled-element-text.component.ts
@@ -8,6 +8,7 @@ import { ClipboardService } from 'src/app/services/clipboard.service';
 import { SnackbarService } from 'src/app/services/snackbar.service';
 import { EditLabelComponent } from '../edit-label/edit-label.component';
 import GeneralUtils from 'src/app/utils/generalUtils';
+import { Router } from '@angular/router';
 
 /**
  * Represents the parts of a label.
@@ -142,6 +143,7 @@ export class LabeledElementTextComponent implements OnDestroy {
     private storageService: StorageService,
     private clipboardService: ClipboardService,
     private snackbarService: SnackbarService,
+    private router: Router,
   ) { }
 
   ngOnDestroy() {
@@ -168,6 +170,11 @@ export class LabeledElementTextComponent implements OnDestroy {
       });
     }
 
+    options.push({
+      icon: 'settings',
+      label: 'labeled-element.go-to-settings',
+    });
+
     // Show the options modal window.
     SelectOptionComponent.openDialog(this.dialog, options, 'common.options').afterClosed().subscribe((selectedOption: number) => {
       if (selectedOption === 1) {
@@ -175,18 +182,23 @@ export class LabeledElementTextComponent implements OnDestroy {
         if (this.clipboardService.copy(this.id)) {
           this.snackbarService.showDone('copy.copied');
         }
-      } else if (selectedOption === 3) {
-        // Ask for confirmation and remove the label.
-        const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'labeled-element.remove-label-confirmation');
+      } else if (selectedOption > 2) {
+        if (selectedOption === 3 && this.labelComponents.labelInfo) {
+          // Ask for confirmation and remove the label.
+          const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'labeled-element.remove-label-confirmation');
 
-        confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
-          confirmationDialog.componentInstance.closeModal();
+          confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+            confirmationDialog.componentInstance.closeModal();
 
-          this.storageService.saveLabel(this.id, null, this.elementType);
-          this.snackbarService.showDone('edit-label.label-removed-warning');
+            this.storageService.saveLabel(this.id, null, this.elementType);
+            this.snackbarService.showDone('edit-label.label-removed-warning');
 
-          this.labelEdited.emit();
-        });
+            this.labelEdited.emit();
+          });
+        } else {
+          // Navigate to the settings page.
+          this.router.navigate(['/settings']);
+        }
       } else {
         // Params for the edit label modal window.
         if (selectedOption === 2) {

--- a/static/skywire-manager-src/src/app/components/pages/login/login.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/login/login.component.scss
@@ -5,6 +5,7 @@ app-lang-button {
   position: fixed;
   right: 10px;
   top: 10px;
+  z-index: 10;
 }
 
 .main-container {

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.html
@@ -6,12 +6,24 @@
     </div>
   </div>
   <mat-dialog-content #content>
+    <!-- Button for opening all the logs. -->
+    <a [href]="getLogsUrl()" target="_blank">
+      <app-button *ngIf="hasMoreLogMessages" class="full-logs-button" color="primary">
+        <div class="text-container">
+          {{ 'apps.log.view-all' | translate:{ totalLogs: totalLogs } }}
+        </div>
+      </app-button>
+    </a>
+
+    <!-- All entries. -->
     <div *ngFor="let message of logMessages" class="app-log-message">
       <span class="transparent">
         {{ message.time }}
       </span>
       {{ message.msg }}
     </div>
+
+    <!-- Msg if empty. -->
     <div class="app-log-empty mt-3" *ngIf="!loading && (!logMessages || logMessages.length === 0)">
       {{ 'apps.log.empty' | translate }}
     </div>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps-list/log/log.component.scss
@@ -40,3 +40,16 @@
     }
   }
 }
+
+.full-logs-button {
+  ::ng-deep button {
+    width: 100% !important;
+    display: block;
+    text-align: center;
+    margin-bottom: 15px;
+  }
+
+  .text-container {
+    width: 100%;
+  }
+}

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component.html
@@ -16,6 +16,9 @@
           matInput
         >
       </div>
+      <mat-error>
+        <span>{{ 'rewards-address-config.address-error' | translate }}</span>
+      </mat-error>
     </mat-form-field>
   </form>
   <app-button

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component.html
@@ -12,6 +12,9 @@
           matInput
         >
       </div>
+      <mat-error>
+        <span>{{ 'router-config.min-hops-error' | translate }}</span>
+      </mat-error>
     </mat-form-field>
   </form>
   <app-button

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/transport-list/create-transport/create-transport.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ViewChild, OnDestroy, ElementRef } from '@angular/co
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { Subscription, of } from 'rxjs';
-import { delay, flatMap } from 'rxjs/operators';
+import { delay, mergeMap } from 'rxjs/operators';
 
 import { TransportService } from '../../../../../../services/transport.service';
 import { ButtonComponent } from '../../../../../layout/button/button.component';
@@ -224,7 +224,7 @@ export class CreateTransportComponent implements OnInit, OnDestroy {
       // Wait the delay.
       delay(delayMilliseconds),
       // Load the data. The node pk is obtained from the currently openned node page.
-      flatMap(() => this.transportService.types(NodeComponent.getCurrentNodeKey()))
+      mergeMap(() => this.transportService.types(NodeComponent.getCurrentNodeKey()))
     ).subscribe(
       types => {
         // Sort the types and select dmsg as default, if posible.

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { of, Subscription } from 'rxjs';
-import { delay, flatMap } from 'rxjs/operators';
+import { delay, mergeMap } from 'rxjs/operators';
 
 import { TabButtonData, MenuOptionData } from '../../layout/top-bar/top-bar.component';
 import { AuthService, AuthStates } from '../../../services/auth.service';
@@ -77,7 +77,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       // Wait the delay.
       delay(delayMilliseconds),
       // Load the data. The node pk is obtained from the currently openned node page.
-      flatMap(() => this.authService.checkLogin())
+      mergeMap(() => this.authService.checkLogin())
     ).subscribe(
       result => {
         this.authChecked = true;

--- a/static/skywire-manager-src/src/app/services/api.service.ts
+++ b/static/skywire-manager-src/src/app/services/api.service.ts
@@ -40,7 +40,7 @@ export class ApiService {
    * with the dev server using the http protocol, because the dev server proxy uses it to
    * route the request to the appropiate url.
    */
-  private readonly apiPrefix = !environment.production && location.protocol.indexOf('http:') !== -1 ?
+  public readonly apiPrefix = !environment.production && location.protocol.indexOf('http:') !== -1 ?
     'http-api/' : 'api/';
 
   /**

--- a/static/skywire-manager-src/src/app/services/apps.service.ts
+++ b/static/skywire-manager-src/src/app/services/apps.service.ts
@@ -47,7 +47,14 @@ export class AppsService {
     const since = days !== -1 ? Date.now() - (days * 86400000) : 0;
     const sinceString = formatDate(since, 'yyyy-MM-ddTHH:mm:ssZZZZZ', 'en-US');
 
-    return this.apiService.get(`visors/${nodeKey}/apps/${encodeURIComponent(appName)}/logs?since=${sinceString}`
+    return this.apiService.get(this.getLogMessagesUrl(nodeKey, appName) + `?since=${sinceString}`
     ).pipe(map(response => response.logs));
+  }
+
+  /**
+   * Gets the partial URL for getting the logs of an app.
+   */
+  getLogMessagesUrl(nodeKey: string, appName: string) {
+    return `visors/${nodeKey}/apps/${encodeURIComponent(appName)}/logs`;
   }
 }

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, Subscription, BehaviorSubject, of } from 'rxjs';
-import { flatMap, map, delay, tap } from 'rxjs/operators';
+import { map, delay, tap, mergeMap } from 'rxjs/operators';
 import BigNumber from 'bignumber.js';
 
 import { StorageService } from './storage.service';
@@ -324,7 +324,7 @@ export class NodeService {
       tap(() => updatingSubject.next(true)),
       delay(120),
       // Load the data.
-      flatMap(() => operation))
+      mergeMap(() => operation))
     .subscribe(result => {
       updatingSubject.next(false);
 

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -26,6 +26,7 @@
   "labeled-element": {
     "edit-label": "Edit label",
     "remove-label": "Remove label",
+    "go-to-settings": "Go to settings",
     "copy": "Copy",
     "remove-label-confirmation": "Do you really want to remove the label?",
     "unnamed-element": "Unnamed",
@@ -174,6 +175,7 @@
     "info": "Here you can set to which Skycoin address you want the rewards to be sent. If you leave the address empty, the registration will be deleted and the visor will not receive rewards.",
     "more-info-link": "(More info about the reward system)",
     "address": "Address",
+    "address-error": "Please enter a valid Skycoin address.",
     "save-config-button": "Save configuration",
     "done": "Changes saved.",
     "empty-warning": "The address in empty, so the registration will be deleted and no rewards will be received. Do you really want to continue?"
@@ -183,6 +185,7 @@
     "title": "Router Configuration",
     "info": "Here you can configure how many hops the connections must pass through other Skywire visors before reaching the final destination. NOTE: the changes will not affect the existing routes.",
     "min-hops": "Min hops",
+    "min-hops-error": "Please enter a valid number.",
     "save-config-button": "Save configuration",
     "done": "Changes saved."
   },
@@ -374,6 +377,7 @@
       "title": "Log",
       "empty": "There are no log messages for the selected time range.",
       "filter-button": "Only showing logs generated since:",
+      "view-all": "View all {{ totalLogs }} entries",
       "filter": {
         "title": "Filter",
         "filter": "Only show logs generated since",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -26,6 +26,7 @@
   "labeled-element": {
     "edit-label": "Editar etiqueta",
     "remove-label": "Remover etiqueta",
+    "go-to-settings": "Ir a la configuración",
     "copy": "Copiar",
     "remove-label-confirmation": "¿Realmente desea eliminar la etiqueta?",
     "unnamed-element": "Sin nombre",
@@ -178,6 +179,7 @@
     "info": "Aquí usted puede establecer la dirección de Skycoin a la que quiere que se envíen las recompensas. Si deja la dirección vacía, el registro será eliminado y el visor no recibirá recompensas.",
     "more-info-link": "(Más información acerca del sistema de recompensas)",
     "address": "Dirección ",
+    "address-error": "Por favor, coloque una dirección Skycoin valida.",
     "save-config-button": "Guardar configuración",
     "done": "Cambios guardados.",
     "empty-warning": "La dirección está vacía, así que el registro será eliminado y no recibirá recompensas. ¿Realmente desea continuar?"
@@ -187,6 +189,7 @@
     "title": "Configuración del Enrutador",
     "info": "Aquí podrá configurar cuantos saltos la conexión deberá realizar a través de otros visores de Skywire antes de alcanzar el destino final. NOTA: los cambios no afectarán a las rutas ya existentes.",
     "min-hops": "Saltos mínimos",
+    "min-hops-error": "Por favor, coloque un número valido.",
     "save-config-button": "Guardar configuración",
     "done": "Cambios guardados."
   },
@@ -378,6 +381,7 @@
       "title": "Log",
       "empty": "No hay mensajes de log para el rango de fecha seleccionado.",
       "filter-button": "Mostrando sólo logs generados desde:",
+      "view-all": "Ver todas las {{ totalLogs }} entradas",
       "filter": {
         "title": "Filtro",
         "filter": "Mostrar sólo logs generados desde",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -26,6 +26,7 @@
   "labeled-element": {
     "edit-label": "Edit label",
     "remove-label": "Remove label",
+    "go-to-settings": "Go to settings",
     "copy": "Copy",
     "remove-label-confirmation": "Do you really want to remove the label?",
     "unnamed-element": "Unnamed",
@@ -178,6 +179,7 @@
     "info": "Here you can set to which Skycoin address you want the rewards to be sent. If you leave the address empty, the registration will be deleted and the visor will not receive rewards.",
     "more-info-link": "(More info about the reward system)",
     "address": "Address",
+    "address-error": "Please enter a valid Skycoin address.",
     "save-config-button": "Save configuration",
     "done": "Changes saved.",
     "empty-warning": "The address in empty, so the registrations will be deleted and no rewards will be received. Do you really want to continue?"
@@ -187,6 +189,7 @@
     "title": "Router Configuration",
     "info": "Here you can configure how many hops the connections must pass through other Skywire visors before reaching the final destination.  NOTE: the changes will not affect the existing routes.",
     "min-hops": "Min hops",
+    "min-hops-error": "Please enter a valid number.",
     "save-config-button": "Save configuration",
     "done": "Changes saved."
   },
@@ -378,6 +381,7 @@
       "title": "Log",
       "empty": "There are no log messages for the selected time range.",
       "filter-button": "Only showing logs generated since:",
+      "view-all": "View all {{ totalLogs }} entries",
       "filter": {
         "title": "Filter",
         "filter": "Only show logs generated since",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the app logs modal window has a limit of 5000 entries, to avoid performance issues making the app unresponsive. If there are more entries, there is a button for showing all the entries.
- A problem that did not let to click on the labeled value components on the DMSG tab of the main page was fixed.
- Now the modal window with the options for labeled elements has a link to the settings page.
- Validation error msgs were added to the modal windows used for configuring the reward address.
- A problem that did not allow to press the language button on small screens on the login page was fixed.
- The deprecated flatMap function was replaced with mergeMap.

How to test this PR:
1 - If you have a lot of logs, after pressing the logs button on the app list, the modal window should show on 5000 entries and a button for opening all the logs if you scroll to the top.
2 and 3 - On the main page, select the DMGS tab and click on the PK of the DMSG server of a visor. The options for changing the label should appear. There should also be a button for opening the settings page.
4 - Open the modal windows for changing the reward address of a visor or all visor. If you enter an invalid value on the address fiend, an error msg will appear.
5 - Go to the login page on a phone and press the language button. It should work.