### PR TITLE
fix missing skycoin.asc

### DIFF
--- a/scripts/mac_installer/create_installer.sh
+++ b/scripts/mac_installer/create_installer.sh
@@ -75,6 +75,7 @@ function build_installer() {
   mv ./skywire-cli ${installer_package_dir}/Contents/MacOS/skywire-cli
   mv ./apps/vpn-client ${installer_package_dir}/Contents/MacOS/apps/vpn-client
   cp ./dmsghttp-config.json ${installer_package_dir}/Contents/MacOS/dmsghttp-config.json
+  cp ./skycoin.asc ${installer_package_dir}/Contents/MacOS/skycoin.asc
 
   cat <<EOF >${installer_package_dir}/Contents/MacOS/Skywire
 #!/bin/bash

--- a/scripts/win_installer/Product.wxs
+++ b/scripts/win_installer/Product.wxs
@@ -37,6 +37,7 @@
                     <File Id="ICON" Source=".\images\ico.ico"/>
                     <File Id="WINTUN" Source=".\build\wintun.dll"/>
                     <File Id="DMSGHTTPCONFIG" Source=".\build\dmsghttp-config.json"/>
+                    <File Id="SKYCOINASC" Source=".\build\skycoin.asc"/>
                     <File Id="NEWUPDATE" Source=".\build\new.update"/>
                </Component>
                <Directory Id="APPS" Name="apps">

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -69,6 +69,7 @@ function BuildInstaller($arch)
     Move-Item ..\..\archive\skywire-cli.exe .\build\skywire-cli.exe
     Move-Item ..\..\archive\apps\vpn-client.exe .\build\apps\vpn-client.exe
     Copy-Item ..\..\archive\dmsghttp-config.json .\build\dmsghttp-config.json
+    Copy-Item ..\..\archive\skycoin.asc .\build\skycoin.asc
     Copy-Item skywire.bat .\build\skywire.bat
     New-Item new.update  > $null
     Move-Item new.update .\build\new.update


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- fix missing `skycoin.asc` in Windows and Mac installer

How to test this PR:
_