### PR TITLE
improve survey logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/gocarina/gocsv v0.0.0-20220927221512-ad3251f9fa25
 	github.com/ivanpirog/coloredcobra v1.0.0
 	github.com/james-barrow/golang-ipc v0.0.0-20210227130457-95e7cc81f5e2
-	github.com/jaypipes/ghw v0.9.0
+	github.com/jaypipes/ghw v0.10.0
 	github.com/lib/pq v1.10.7
 	github.com/pkg/profile v1.7.0
 	github.com/pterm/pterm v0.12.49

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/ivanpirog/coloredcobra v1.0.0 h1:MY8hiTd5pfXE6K2OPDAUZvx7M8N2rXmd0hyW
 github.com/ivanpirog/coloredcobra v1.0.0/go.mod h1:iho4nEKcnwZFiniGSdcgdvRgZNjxm+h20acv8vqmN6Q=
 github.com/james-barrow/golang-ipc v0.0.0-20210227130457-95e7cc81f5e2 h1:lnIIG509NeyPk/15ZHqP3DwTTQXqp2PoQoxGdYDC2h4=
 github.com/james-barrow/golang-ipc v0.0.0-20210227130457-95e7cc81f5e2/go.mod h1:M3eGiVVY7bdtqyWT+gtbIqji7CqHi3PKJHSPl2pP40c=
-github.com/jaypipes/ghw v0.9.0 h1:TWF4wNIGtZcgDJaiNcFgby5BR8s2ixcUe0ydxNO2McY=
-github.com/jaypipes/ghw v0.9.0/go.mod h1:dXMo19735vXOjpIBDyDYSp31sB2u4hrtRCMxInqQ64k=
+github.com/jaypipes/ghw v0.10.0 h1:UHu9UX08Py315iPojADFPOkmjTsNzHj4g4adsNKKteY=
+github.com/jaypipes/ghw v0.10.0/go.mod h1:jeJGbkRB2lL3/gxYzNYzEDETV1ZJ56OKr+CSeSEym+g=
 github.com/jaypipes/pcidb v1.0.0 h1:vtZIfkiCUE42oYbJS0TAq9XSfSmcsgo9IdxSm9qzYU8=
 github.com/jaypipes/pcidb v1.0.0/go.mod h1:TnYUvqhPBzCKnH34KrIX22kAeEbDCSRJ9cqLRCuNDfk=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
@@ -431,7 +431,6 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
-github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -566,12 +565,10 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
-github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.10.0/go.mod h1:SoyBPwAtKDzypXNDFKN5kzH7ppppbGZtls1UpIy5AsM=

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -357,7 +357,7 @@ func (v *Visor) SetRewardAddress(p string) (string, error) {
 		return p, fmt.Errorf("failed to write config to file. err=%v", err)
 	}
 	// generate survey after set/update reward address
-	visorconfig.GenerateSurvey(v.conf, v.log)
+	visorconfig.GenerateSurvey(v.conf, v.log, v.rawSurvey)
 	return p, nil
 }
 

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -54,6 +54,7 @@ var (
 	// visorBuildInfo holds information about the build
 	visorBuildInfo *buildinfo.Info
 	dmsgServer     string
+	rawSurvey      bool
 )
 
 func init() {
@@ -127,6 +128,8 @@ func init() {
 	hiddenflags = append(hiddenflags, "syslog")
 	RootCmd.Flags().StringVarP(&completion, "completion", "z", "", "[ bash | zsh | fish | powershell ]")
 	hiddenflags = append(hiddenflags, "completion")
+	RootCmd.Flags().BoolVar(&rawSurvey, "raw-survey", false, "survey will generate and store decrypted if pass this flag")
+	hiddenflags = append(hiddenflags, "raw-survey")
 	RootCmd.Flags().BoolVar(&all, "all", false, "show all flags")
 
 	for _, j := range hiddenflags {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -434,7 +434,7 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, log *logging.Logger) e
 }
 
 func initSystemSurvey(ctx context.Context, v *Visor, log *logging.Logger) error {
-	go visorconfig.GenerateSurvey(v.conf, log)
+	go visorconfig.GenerateSurvey(v.conf, log, v.rawSurvey)
 	return nil
 }
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -112,6 +112,8 @@ type Visor struct {
 	pingConns    map[cipher.PubKey]ping
 	pingConnMx   *sync.Mutex
 	pingPcktSize int
+
+	rawSurvey bool
 }
 
 // todo: consider moving module closing to the module system
@@ -246,6 +248,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 		pingConns:            make(map[cipher.PubKey]ping),
 		pingConnMx:           new(sync.Mutex),
 		allowedPorts:         make(map[int]bool),
+		rawSurvey:            rawSurvey,
 	}
 	v.isServicesHealthy.init()
 

--- a/pkg/visor/visorconfig/survey.go
+++ b/pkg/visor/visorconfig/survey.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ProtonMail/gopenpgp/v2/helper"
 	coincipher "github.com/skycoin/skycoin/src/cipher"
@@ -15,73 +16,84 @@ import (
 )
 
 // GenerateSurvey generate survey handler
-func GenerateSurvey(conf *V1, log *logging.Logger) {
+func GenerateSurvey(conf *V1, log *logging.Logger, rawSurvey bool) {
 	if IsRoot() {
-		//check for valid reward address set as prerequisite for generating the system survey
-		rewardAddressBytes, err := os.ReadFile(PackageConfig().LocalPath + "/" + RewardFile) //nolint
-		if err == nil {
-			//remove any newline from rewardAddress string
-			rewardAddress := strings.TrimSuffix(string(rewardAddressBytes), "\n")
-			//validate the skycoin address
-			cAddr, err := coincipher.DecodeBase58Address(rewardAddress)
-			if err != nil {
-				log.WithError(err).Error("Invalid skycoin reward address.")
-				return
-			}
-			log.Info("Skycoin reward address: ", cAddr.String())
-			//generate the system survey
-			pathutil.EnsureDir(conf.LocalPath) //nolint
-			survey, err := SystemSurvey()
-			if err != nil {
-				log.WithError(err).Error("Could not read system info.")
-				return
-			}
-			survey.PubKey = conf.PK
-			survey.SkycoinAddress = cAddr.String()
-			// Print results.
-			s, err := json.MarshalIndent(survey, "", "\t")
-			if err != nil {
-				log.WithError(err).Error("Could not marshal json.")
-				return
-			}
-
-			skycoinKeyPath := SkywirePath + "/" + SkycoinKeyName
-			skycoinKey, err := os.ReadFile(skycoinKeyPath)
-			if err != nil {
-				log.WithError(err).Error("Could not find skycoin key.")
-			}
-			skycoinKeyString := string(skycoinKey)
-			encryptedNodeInfo, err := helper.EncryptBinaryMessageArmored(skycoinKeyString, s)
-			if err != nil {
-				log.WithError(err).Error("Could not encrypt survey.")
-			}
-
-			err = os.WriteFile(conf.LocalPath+"/"+NodeInfo, []byte(encryptedNodeInfo), 0644) //nolint
-			if err != nil {
-				log.WithError(err).Error("Failed to write system hardware survey to file.")
-				return
-			}
-			log.Info("Generating system survey")
-			f, err := os.ReadFile(filepath.Clean(conf.LocalPath + "/" + NodeInfo))
-			if err != nil {
-				log.WithError(err).Error("Failed to write system hardware survey to file.")
-				return
-			}
-			srvySha256Byte32 := sha256.Sum256([]byte(f))
-			err = os.WriteFile(conf.LocalPath+"/"+NodeInfoSha256, srvySha256Byte32[:], 0644) //nolint
-			if err != nil {
-				log.WithError(err).Error("Failed to write system hardware survey to file.")
-				return
-			}
-		} else {
-			err := os.Remove(PackageConfig().LocalPath + "/" + NodeInfo)
+		for {
+			//check for valid reward address set as prerequisite for generating the system survey
+			rewardAddressBytes, err := os.ReadFile(PackageConfig().LocalPath + "/" + RewardFile) //nolint
 			if err == nil {
-				log.Debug("Removed hadware survey for visor not seeking rewards")
+				//remove any newline from rewardAddress string
+				rewardAddress := strings.TrimSuffix(string(rewardAddressBytes), "\n")
+				//validate the skycoin address
+				cAddr, err := coincipher.DecodeBase58Address(rewardAddress)
+				if err != nil {
+					log.WithError(err).Error("Invalid skycoin reward address.")
+					return
+				}
+				log.Info("Skycoin reward address: ", cAddr.String())
+				//generate the system survey
+				pathutil.EnsureDir(conf.LocalPath) //nolint
+				survey, err := SystemSurvey()
+				if err != nil {
+					log.WithError(err).Error("Could not read system info.")
+					return
+				}
+				survey.PubKey = conf.PK
+				survey.SkycoinAddress = cAddr.String()
+				// Print results.
+				s, err := json.MarshalIndent(survey, "", "\t")
+				if err != nil {
+					log.WithError(err).Error("Could not marshal json.")
+					return
+				}
+
+				if rawSurvey {
+					err = os.WriteFile(conf.LocalPath+"/"+NodeInfo, []byte(s), 0644) //nolint
+					if err != nil {
+						log.WithError(err).Error("Failed to write system hardware survey to file.")
+						return
+					}
+				} else {
+					skycoinKeyPath := SkywirePath + "/" + SkycoinKeyName
+					skycoinKey, err := os.ReadFile(skycoinKeyPath)
+					if err != nil {
+						log.WithError(err).Error("Could not find skycoin key.")
+					}
+					skycoinKeyString := string(skycoinKey)
+					encryptedNodeInfo, err := helper.EncryptBinaryMessageArmored(skycoinKeyString, s)
+					if err != nil {
+						log.WithError(err).Error("Could not encrypt survey.")
+					}
+
+					err = os.WriteFile(conf.LocalPath+"/"+NodeInfo, []byte(encryptedNodeInfo), 0644) //nolint
+					if err != nil {
+						log.WithError(err).Error("Failed to write system hardware survey to file.")
+						return
+					}
+				}
+				log.Info("Generating system survey")
+				f, err := os.ReadFile(filepath.Clean(conf.LocalPath + "/" + NodeInfo))
+				if err != nil {
+					log.WithError(err).Error("Failed to write system hardware survey to file.")
+					return
+				}
+				srvySha256Byte32 := sha256.Sum256([]byte(f))
+				err = os.WriteFile(conf.LocalPath+"/"+NodeInfoSha256, srvySha256Byte32[:], 0644) //nolint
+				if err != nil {
+					log.WithError(err).Error("Failed to write system hardware survey to file.")
+					return
+				}
+			} else {
+				err := os.Remove(PackageConfig().LocalPath + "/" + NodeInfo)
+				if err == nil {
+					log.Debug("Removed hadware survey for visor not seeking rewards")
+				}
+				err = os.Remove(PackageConfig().LocalPath + "/" + NodeInfoSha256)
+				if err == nil {
+					log.Debug("Removed hadware survey checksum file")
+				}
 			}
-			err = os.Remove(PackageConfig().LocalPath + "/" + NodeInfoSha256)
-			if err == nil {
-				log.Debug("Removed hadware survey checksum file")
-			}
+			time.Sleep(24 * time.Hour)
 		}
 	}
 }

--- a/vendor/github.com/jaypipes/ghw/README.md
+++ b/vendor/github.com/jaypipes/ghw/README.md
@@ -530,6 +530,12 @@ Each `ghw.Partition` struct contains these fields:
 
 * `ghw.Partition.Name` contains a string with the short name of the partition,
   e.g. "sda1"
+* `ghw.Partition.Label` contains the label for the partition itself. On Linux
+  systems, this is derived from the `ID_PART_ENTRY_NAME` udev entry for the
+  partition.
+* `ghw.Partition.FilesystemLabel` contains the label for the filesystem housed
+  on the partition. On Linux systems, this is derived from the `ID_FS_NAME`
+  udev entry for the partition.
 * `ghw.Partition.SizeBytes` contains the amount of storage the partition
   provides
 * `ghw.Partition.MountPoint` contains a string with the partition's mount
@@ -540,8 +546,10 @@ Each `ghw.Partition` struct contains these fields:
 * `ghw.Partition.Disk` is a pointer to the `ghw.Disk` object associated with
   the partition. This will be `nil` if the `ghw.Partition` struct was returned
   by the `ghw.DiskPartitions()` library function.
-* `ghw.Partition.UUID` is a string containing the volume UUID on Linux, the
-  partition UUID on MacOS and nothing on Windows.
+* `ghw.Partition.UUID` is a string containing the partition UUID on Linux, the
+  partition UUID on MacOS and nothing on Windows. On Linux
+  systems, this is derived from the `ID_PART_ENTRY_UUID` udev entry for the
+  partition.
 
 ```go
 package main

--- a/vendor/github.com/jaypipes/ghw/pkg/block/block.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/block/block.go
@@ -29,6 +29,7 @@ const (
 	DRIVE_TYPE_FDD               // Floppy disk drive
 	DRIVE_TYPE_ODD               // Optical disk drive
 	DRIVE_TYPE_SSD               // Solid-state drive
+	DRIVE_TYPE_VIRTUAL           // virtual drive i.e. loop devices
 )
 
 var (
@@ -38,6 +39,7 @@ var (
 		DRIVE_TYPE_FDD:     "FDD",
 		DRIVE_TYPE_ODD:     "ODD",
 		DRIVE_TYPE_SSD:     "SSD",
+		DRIVE_TYPE_VIRTUAL: "virtual",
 	}
 
 	// NOTE(fromani): the keys are all lowercase and do not match
@@ -51,6 +53,7 @@ var (
 		"fdd":     DRIVE_TYPE_FDD,
 		"odd":     DRIVE_TYPE_ODD,
 		"ssd":     DRIVE_TYPE_SSD,
+		"virtual": DRIVE_TYPE_VIRTUAL,
 	}
 )
 
@@ -93,6 +96,7 @@ const (
 	STORAGE_CONTROLLER_NVME                      // Non-volatile Memory Express
 	STORAGE_CONTROLLER_VIRTIO                    // Virtualized storage controller/driver
 	STORAGE_CONTROLLER_MMC                       // Multi-media controller (used for mobile phone storage devices)
+	STORAGE_CONTROLLER_LOOP                      // loop device
 )
 
 var (
@@ -103,6 +107,7 @@ var (
 		STORAGE_CONTROLLER_NVME:    "NVMe",
 		STORAGE_CONTROLLER_VIRTIO:  "virtio",
 		STORAGE_CONTROLLER_MMC:     "MMC",
+		STORAGE_CONTROLLER_LOOP:    "loop",
 	}
 
 	// NOTE(fromani): the keys are all lowercase and do not match
@@ -117,6 +122,7 @@ var (
 		"nvme":    STORAGE_CONTROLLER_NVME,
 		"virtio":  STORAGE_CONTROLLER_VIRTIO,
 		"mmc":     STORAGE_CONTROLLER_MMC,
+		"loop":    STORAGE_CONTROLLER_LOOP,
 	}
 )
 
@@ -169,14 +175,15 @@ type Disk struct {
 
 // Partition describes a logical division of a Disk.
 type Partition struct {
-	Disk       *Disk  `json:"-"`
-	Name       string `json:"name"`
-	Label      string `json:"label"`
-	MountPoint string `json:"mount_point"`
-	SizeBytes  uint64 `json:"size_bytes"`
-	Type       string `json:"type"`
-	IsReadOnly bool   `json:"read_only"`
-	UUID       string `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	Disk            *Disk  `json:"-"`
+	Name            string `json:"name"`
+	Label           string `json:"label"`
+	MountPoint      string `json:"mount_point"`
+	SizeBytes       uint64 `json:"size_bytes"`
+	Type            string `json:"type"`
+	IsReadOnly      bool   `json:"read_only"`
+	UUID            string `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	FilesystemLabel string `json:"filesystem_label"`
 }
 
 // Info describes all disk drives and partitions in the host system.

--- a/vendor/github.com/jaypipes/ghw/pkg/block/block_windows.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/block/block_windows.go
@@ -115,7 +115,10 @@ func (i *Info) load() error {
 		}
 		for _, diskpartition := range win32DiskPartitionDescriptions {
 			// Finding disk partition linked to current disk drive
-			if diskdrive.Index == diskpartition.DiskIndex {
+			if diskdrive.Index == nil || diskpartition.DiskIndex == nil {
+				continue
+			}
+			if *diskdrive.Index == *diskpartition.DiskIndex {
 				disk.PhysicalBlockSizeBytes = *diskpartition.BlockSize
 				// Finding logical partition linked to current disk partition
 				for _, logicaldisk := range win32LogicalDiskDescriptions {

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
@@ -160,9 +160,9 @@ func parseModaliasData(data string) *deviceModaliasInfo {
 	productID := strings.ToLower(data[18:22])
 	subvendorID := strings.ToLower(data[28:32])
 	subproductID := strings.ToLower(data[38:42])
-	classID := data[44:46]
-	subclassID := data[48:50]
-	progIfaceID := data[51:53]
+	classID := strings.ToLower(data[44:46])
+	subclassID := strings.ToLower(data[48:50])
+	progIfaceID := strings.ToLower(data[51:53])
 	return &deviceModaliasInfo{
 		vendorID:     vendorID,
 		productID:    productID,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -147,8 +147,8 @@ github.com/ivanpirog/coloredcobra
 # github.com/james-barrow/golang-ipc v0.0.0-20210227130457-95e7cc81f5e2
 ## explicit; go 1.15
 github.com/james-barrow/golang-ipc
-# github.com/jaypipes/ghw v0.9.0
-## explicit; go 1.15
+# github.com/jaypipes/ghw v0.10.0
+## explicit; go 1.18
 github.com/jaypipes/ghw
 github.com/jaypipes/ghw/pkg/baseboard
 github.com/jaypipes/ghw/pkg/bios


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add `--raw-survey` command to skywire-visor, to generate survey in raw. (plain-text, without encryption)
- add routine to re-generate survey each 24h

How to test this PR:
- run visor with and without `--raw-survey` flag, check node-info.json file.