### PR TITLE
log collection size limit | improve survey logic

### DIFF
--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -39,7 +39,7 @@ func init() {
 	logCmd.Flags().IntVarP(&duration, "duration", "d", 1, "count of days before today to fetch logs")
 	logCmd.Flags().BoolVar(&allVisors, "all", false, "consider all visors, actually skip filtering on version")
 	logCmd.Flags().IntVar(&batchSize, "batchSize", 50, "number of visor in each batch, default is 50")
-	logCmd.Flags().Int64Var(&maxFileSize, "filesize", 10, "maximum file size allowed to download during collecting logs, on KB")
+	logCmd.Flags().Int64Var(&maxFileSize, "maxfilesize", 30, "maximum file size allowed to download during collecting logs, on KB")
 	logCmd.Flags().StringVar(&utAddr, "ut", "", "custom uptime tracker url, usable for get specific(s) visors log data")
 }
 

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -23,12 +23,13 @@ import (
 )
 
 var (
-	env       string
-	duration  int
-	minv      string
-	allVisors bool
-	batchSize int
-	utAddr    string
+	env         string
+	duration    int
+	minv        string
+	allVisors   bool
+	batchSize   int
+	maxFileSize int64
+	utAddr      string
 )
 
 func init() {
@@ -38,6 +39,7 @@ func init() {
 	logCmd.Flags().IntVarP(&duration, "duration", "d", 1, "count of days before today to fetch logs")
 	logCmd.Flags().BoolVar(&allVisors, "all", false, "consider all visors, actually skip filtering on version")
 	logCmd.Flags().IntVar(&batchSize, "batchSize", 50, "number of visor in each batch, default is 50")
+	logCmd.Flags().Int64Var(&maxFileSize, "filesize", 10, "maximum file size allowed to download during collecting logs, on KB")
 	logCmd.Flags().StringVar(&utAddr, "ut", "", "custom uptime tracker url, usable for get specific(s) visors log data")
 }
 
@@ -121,7 +123,7 @@ var logCmd = &cobra.Command{
 					deleteOnError = true
 				}
 
-				err = download(ctx, log, httpC, "node-info.json", "node-info.json", key)
+				err = download(ctx, log, httpC, "node-info.json", "node-info.json", key, maxFileSize)
 				if err != nil {
 					if deleteOnError {
 						bulkFolders = append(bulkFolders, key)
@@ -129,7 +131,7 @@ var logCmd = &cobra.Command{
 					return
 				}
 
-				err = download(ctx, log, httpC, "node-info.sha", "node-info.sha", key)
+				err = download(ctx, log, httpC, "node-info.sha", "node-info.sha", key, maxFileSize)
 				if err != nil {
 					if deleteOnError {
 						bulkFolders = append(bulkFolders, key)
@@ -139,11 +141,11 @@ var logCmd = &cobra.Command{
 
 				if duration == 1 {
 					yesterday := time.Now().AddDate(0, 0, -1).UTC().Format("2006-01-02")
-					download(ctx, log, httpC, "transport_logs/"+yesterday+".csv", yesterday+".csv", key) //nolint
+					download(ctx, log, httpC, "transport_logs/"+yesterday+".csv", yesterday+".csv", key, maxFileSize) //nolint
 				} else {
 					for i := 1; i <= duration; i++ {
 						date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
-						download(ctx, log, httpC, "transport_logs/"+date+".csv", date+".csv", key) //nolint
+						download(ctx, log, httpC, "transport_logs/"+date+".csv", date+".csv", key, maxFileSize) //nolint
 					}
 				}
 
@@ -165,12 +167,12 @@ var logCmd = &cobra.Command{
 	},
 }
 
-func download(ctx context.Context, log *logging.Logger, httpC http.Client, targetPath, fileName, pubkey string) error {
+func download(ctx context.Context, log *logging.Logger, httpC http.Client, targetPath, fileName, pubkey string, maxSize int64) error {
 	target := fmt.Sprintf("dmsg://%s:80/%s", pubkey, targetPath)
 	file, _ := os.Create(pubkey + "/" + fileName) //nolint
 	defer file.Close()                            //nolint
 
-	if err := dmsgget.Download(ctx, log, &httpC, file, target); err != nil {
+	if err := dmsgget.Download(ctx, log, &httpC, file, target, maxSize); err != nil {
 		log.WithError(err).Errorf("The %s for visor %s not available", fileName, pubkey)
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/pkg/profile v1.7.0
 	github.com/pterm/pterm v0.12.49
-	github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8
+	github.com/skycoin/dmsg v1.3.0-rc1.0.20230224131835-1c194ef9791e
 	github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c
 	github.com/skycoin/systray v1.10.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -546,6 +546,8 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8 h1:5DvXRbadJCPP+eSwVFpb/apTWTt+An7iIva8SqoWius=
 github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8/go.mod h1:ykPIRMpkSLssjwNKJpD/DF+F2NVTA/7Ja59gfOSDoh0=
+github.com/skycoin/dmsg v1.3.0-rc1.0.20230224131835-1c194ef9791e h1:Kfc+orJNSDsoBNWJhk0OOIr2wqwd9NaG9Ru2sBouwLs=
+github.com/skycoin/dmsg v1.3.0-rc1.0.20230224131835-1c194ef9791e/go.mod h1:BEG64opSTUwP8bPFbHg9CBs6vmoLvDxlBipamb4sUA4=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -357,7 +357,7 @@ func (v *Visor) SetRewardAddress(p string) (string, error) {
 		return p, fmt.Errorf("failed to write config to file. err=%v", err)
 	}
 	// generate survey after set/update reward address
-	visorconfig.GenerateSurvey(v.conf, v.log, v.rawSurvey)
+	visorconfig.GenerateSurvey(v.conf, v.log, false, v.rawSurvey)
 	return p, nil
 }
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -434,7 +434,7 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, log *logging.Logger) e
 }
 
 func initSystemSurvey(ctx context.Context, v *Visor, log *logging.Logger) error {
-	go visorconfig.GenerateSurvey(v.conf, log, v.rawSurvey)
+	go visorconfig.GenerateSurvey(v.conf, log, true, v.rawSurvey)
 	return nil
 }
 

--- a/pkg/visor/visorconfig/survey.go
+++ b/pkg/visor/visorconfig/survey.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GenerateSurvey generate survey handler
-func GenerateSurvey(conf *V1, log *logging.Logger, rawSurvey bool) {
+func GenerateSurvey(conf *V1, log *logging.Logger, routine, rawSurvey bool) {
 	if IsRoot() {
 		for {
 			//check for valid reward address set as prerequisite for generating the system survey
@@ -92,6 +92,10 @@ func GenerateSurvey(conf *V1, log *logging.Logger, rawSurvey bool) {
 				if err == nil {
 					log.Debug("Removed hadware survey checksum file")
 				}
+			}
+			// break loop for generate each 24hours if just reward address chenged
+			if !routine {
+				break
 			}
 			time.Sleep(24 * time.Hour)
 		}

--- a/pkg/visor/visorconfig/values.go
+++ b/pkg/visor/visorconfig/values.go
@@ -272,7 +272,7 @@ func IPSkycoinFetch() (ipskycoin *IPSkycoin) {
 
 	url := fmt.Sprint("http://", "ip.skycoin.com")
 	client := http.Client{
-		Timeout: time.Second * 15, // Timeout after 15 seconds
+		Timeout: time.Second * 45, // Timeout after 45 seconds
 	}
 	//create the http request
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/pkg/visor/visorconfig/values_linux.go
+++ b/pkg/visor/visorconfig/values_linux.go
@@ -107,6 +107,12 @@ func SystemSurvey() (Survey, error) {
 	if err != nil {
 		return Survey{}, err
 	}
+	for {
+		ipInfo := IPSkycoinFetch()
+		if ipInfo != nil {
+			break
+		}
+	}
 	s := Survey{
 		Timestamp:      time.Now(),
 		IPInfo:         IPSkycoinFetch(),

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
@@ -433,7 +433,7 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 			// We should only report an error when client is not closed.
 			// Also, when the client is closed, it will automatically delete all sessions.
 			ce.errCh <- fmt.Errorf("failed to serve dialed session to %s: %v", dSes.RemotePK(), err)
-			ce.delSession(ctx, dSes.RemotePK(), false)
+			ce.delSession(ctx, dSes.RemotePK())
 		}
 
 		// Trigger disconnect callback.

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/entity_common.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/entity_common.go
@@ -127,13 +127,9 @@ func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) bool
 	return true
 }
 
-func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey, serverEndSession bool) {
+func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey) {
 	c.sessionsMx.Lock()
-	defer c.sessionsMx.Unlock()
 	delete(c.sessions, pk)
-	if serverEndSession {
-		return
-	}
 	if c.delSessionCallback != nil {
 		if err := c.delSessionCallback(ctx); err != nil {
 			c.log.
@@ -142,6 +138,7 @@ func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey, serverE
 				Warn("Callback returned non-nil error.")
 		}
 	}
+	c.sessionsMx.Unlock()
 }
 
 // updateServerEntry updates the dmsg server's entry within dmsg discovery.

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/server.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/server.go
@@ -225,6 +225,6 @@ func (s *Server) handleSession(conn net.Conn) {
 		dSes.Serve()
 	}
 
-	s.delSession(ctx, dSes.RemotePK(), true)
+	s.delSession(ctx, dSes.RemotePK())
 	cancel()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -260,7 +260,7 @@ github.com/shirou/gopsutil/v3/process
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.0-rc1.0.20230105101327-c8f2541c3de8
+# github.com/skycoin/dmsg v1.3.0-rc1.0.20230224131835-1c194ef9791e
 ## explicit; go 1.16
 github.com/skycoin/dmsg/internal/servermetrics
 github.com/skycoin/dmsg/pkg/direct


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- improve survey IP fetching timeout to 45s
- set `maxfilesize` flag to add limitation on log collection process

How to test this PR:
- clone current PR branch
- `make build`
- trying to collecting log from my vpn server at these three type:
  - for collecting without size limitation : `./skywire-cli log collection --ut "https://ut.skywire.skycoin.com/uptimes?v=v2&visors=030d3535b3620b270689894fe26f67e5dbd604df5d7c43432519787c072af6b992" --all --maxfilesize 0` -> work fine, as before
  - for collecting with 5 KB limitaiton: `./skywire-cli log collection --ut "https://ut.skywire.skycoin.com/uptimes?v=v2&visors=030d3535b3620b270689894fe26f67e5dbd604df5d7c43432519787c072af6b992" --all --maxfilesize 5` -> this should get fail
  - for collecting with 12 KB limitation size: `./skywire-cli log collection --ut "https://ut.skywire.skycoin.com/uptimes?v=v2&visors=030d3535b3620b270689894fe26f67e5dbd604df5d7c43432519787c072af6b992" --all --maxfilesize 12` -> this work fine again. `node-info.json` file has ~11KB size on my server