### PR TITLE
Remove the basic terminal from the UI

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -185,6 +185,8 @@ export class NodeActionsHelper {
   }
 
   terminal() {
+    // TODO: remove if the basic terminal is going to be removed definitely.
+    /*
     const options: SelectableOption[] = [
       {
         icon: 'launch',
@@ -210,6 +212,12 @@ export class NodeActionsHelper {
         });
       }
     });
+    */
+
+    // Open the complete terminal in a new tab.
+    const protocol = window.location.protocol;
+    const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8000');
+    window.open(protocol + '//' + hostname + '/pty/' + this.currentNodeKey, '_blank', 'noopener noreferrer');
   }
 
   back() {


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- As requested, this PR removes the basic terminal as an option from the UI. The code remains, just in case.

How to test this PR:
Rebuild the UI and use the "Terminal" option on the visor details page, it will open the full terminal.