### PR TITLE
Hot fix on Launcher panic

### DIFF
--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -46,6 +46,8 @@ var (
 	ErrProcNotAvailable = errors.New("no process manager available")
 	// ErrTrpMangerNotAvailable represents error for unavailable transport manager
 	ErrTrpMangerNotAvailable = errors.New("no transport manager available")
+	// ErrAppLauncherNotAvailable represents error for unavailable app launcher
+	ErrAppLauncherNotAvailable = errors.New("no app launcher available")
 )
 
 const (


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add app launcher checker before each related method in visor

How to test this PR:
- add `time.Sleep(30 * time.Second)` on line 1045 of `pkg > visor > init.go`
- run visor
- run `skywire-cli skysocks status`, should get error
- wait 30 seconds, run last command again, should get correct return