### PR TITLE
improve transport logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/pterm/pterm v0.12.49
 	github.com/skycoin/dmsg v1.3.0-rc1.0.20230224131835-1c194ef9791e
-	github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c
+	github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a
 	github.com/skycoin/systray v1.10.0
 	github.com/spf13/pflag v1.0.5
 	github.com/zcalusic/sysinfo v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -544,6 +544,8 @@ github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9
 github.com/skycoin/skycoin v0.27.1/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=
 github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c h1:jYHyLwSyRVR/TmT4WWIGAeFX4FawGHA4Gaeic0zX3KI=
 github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c/go.mod h1:X5H+fKC3rD11/sm4t9V2FWy/aet7OdEilaO2Ar3waXY=
+github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a h1:hTqQ+8G/2Y+vd4qXoTbm7gfj+mjil2zDnGSS8i8V4LQ=
+github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a/go.mod h1:X5H+fKC3rD11/sm4t9V2FWy/aet7OdEilaO2Ar3waXY=
 github.com/skycoin/systray v1.10.0 h1:fQZJHMylpVvfmOOTLvUssfyHVDoC8Idx6Ba2BlLEuGg=
 github.com/skycoin/systray v1.10.0/go.mod h1:/i17Eni5GxFiboIZceeamY5LktDSFFRCvd3fBMerQ+4=
 github.com/skycoin/yamux v0.0.0-20200803175205-571ceb89da9f h1:A5dEM1OE9YhN3LciZU9qPjo7fJ46JeHNi3JCroDkK0Y=

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -149,7 +149,7 @@ func (c *genericClient) acceptTransports(lis net.Listener) {
 	c.log.Debugf("listening on addr: %v", c.connListener.Addr())
 	for {
 		if err := c.acceptTransport(); err != nil {
-			if errors.Is(err, io.EOF) {
+			if errors.Is(err, io.EOF) || strings.Contains(err.Error(), "encrypt connection to") {
 				continue // likely it's a dummy connection from service discovery
 			}
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -474,6 +474,11 @@ func (v *Visor) Close() error {
 		errCh := make(chan error, 1)
 		t := time.NewTimer(moduleShutdownTimeout)
 
+		// should keep transport.manager shutdown continue till all transports delete there
+		if cl.src == "transport.manager" {
+			t = time.NewTimer(2 * time.Hour)
+		}
+
 		log := v.MasterLogger().PackageLogger(fmt.Sprintf("visor:shutdown:%s", cl.src)).
 			WithField("func", fmt.Sprintf("[%d/%d]", i+1, len(v.closeStack)))
 		log.Debug("Shutting down module...")

--- a/vendor/github.com/skycoin/skywire-utilities/pkg/logging/logger.go
+++ b/vendor/github.com/skycoin/skywire-utilities/pkg/logging/logger.go
@@ -43,6 +43,7 @@ func NewMasterLogger() *MasterLogger {
 				ForceFormatting:    true,
 				DisableColors:      false,
 				ForceColors:        false,
+				TimestampFormat:    "2006-01-02T15:04:05.999999999Z07:00",
 			},
 			Hooks: hooks,
 			Level: logrus.DebugLevel,

--- a/vendor/github.com/skycoin/skywire-utilities/pkg/skyenv/values.go
+++ b/vendor/github.com/skycoin/skywire-utilities/pkg/skyenv/values.go
@@ -11,7 +11,7 @@ const (
 	UptimeTrackerAddr   = "http://ut.skywire.skycoin.com"
 	AddressResolverAddr = "http://ar.skywire.skycoin.com"
 	SetupPK             = "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
-	NetworkMonitorPK    = "0380ea88f0ad0aa4d93c330ba5f97aabca1d892190b94db69eee140b549d2817dd"
+	NetworkMonitorPK    = "0380ea88f0ad0aa4d93c330ba5f97aabca1d892190b94db69eee140b549d2817dd,0283bddb4357e2c4de0d470032cd809966aec65ce57e1188143ab32c7b589b38b6,02f4e33b75307267229b0c3d679d08dd23374333f558288cfcb114311a52199358,02090f03cb26c71779b8327067e2e37314d2db3e31dfe4f8f3cdd8e088a98eb7ec"
 )
 
 // Constants for testing deployment.
@@ -24,20 +24,20 @@ const (
 	TestUptimeTrackerAddr   = "http://ut.skywire.dev"
 	TestAddressResolverAddr = "http://ar.skywire.dev"
 	TestSetupPK             = "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
-	TestNetworkMonitorPK    = "0218905f5d9079bab0b62985a05bd162623b193e948e17e7b719133f2c60b92093,0218905f5d9079bab0b62985a05bd162623b193e948e17e7b719133f2c60b92093,0394b6e4bdb50977658013089523cc77a9c3af8d1a1581855b496b9ae3126deea0"
+	TestNetworkMonitorPK    = "0218905f5d9079bab0b62985a05bd162623b193e948e17e7b719133f2c60b92093,0214456f6727b0dffacc3e4a9b331ff9bf7b7d97a9810c213772199f0f7ee59247,0394b6e4bdb50977658013089523cc77a9c3af8d1a1581855b496b9ae3126deea0,027f978ca206f00e052561b82a62e6405763f833779b1693fee9cc3c87caad26be"
 )
 
 // GetStunServers gives back default Stun Servers
 func GetStunServers() []string {
 	return []string{
-		"192.46.224.108:3478",
-		"139.177.185.210:3478",
-		"139.162.17.54:3478",
-		"139.162.17.107:3478",
-		"139.162.17.156:3478",
-		"45.118.134.168:3478",
-		"139.177.185.180:3478",
-		"139.162.17.48:3478",
+		"139.162.12.30:3478",
+		"170.187.228.181:3478",
+		"172.104.161.184:3478",
+		"170.187.231.137:3478",
+		"143.42.74.91:3478",
+		"170.187.225.78:3478",
+		"143.42.78.123:3478",
+		"139.162.12.244:3478",
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -275,7 +275,7 @@ github.com/skycoin/skycoin/src/cipher/ripemd160
 github.com/skycoin/skycoin/src/cipher/secp256k1-go
 github.com/skycoin/skycoin/src/cipher/secp256k1-go/secp256k1-go2
 github.com/skycoin/skycoin/src/util/logging
-# github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c
+# github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a
 ## explicit; go 1.17
 github.com/skycoin/skywire-utilities/pkg/buildinfo
 github.com/skycoin/skywire-utilities/pkg/cipher


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- update skywire-utilities
- remove (actually change it to 2 hours) timeout of shutting down transport.manager module
- skip stopping stcpr serve when encryption error occurs

How to test this PR:
_