### PR TITLE
Logs UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.module.ts
+++ b/static/skywire-manager-src/src/app/app.module.ts
@@ -100,6 +100,7 @@ import { VpnDnsConfigComponent } from './components/vpn/layout/vpn-dns-config/vp
 import { RewardsAddressComponent } from './components/pages/node/node-info/node-info-content/rewards-address-config/rewards-address-config.component';
 import { BulkRewardAddressChangerComponent } from './components/layout/bulk-reward-address-changer/bulk-reward-address-changer.component';
 import { UserAppSettingsComponent } from './components/pages/node/apps/node-apps/user-app-settings/user-app-settings.component';
+import { NodeLogsComponent } from './components/pages/node/actions/node-logs/node-logs.component';
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -176,6 +177,7 @@ const globalRippleConfig: RippleGlobalOptions = {
     RewardsAddressComponent,
     BulkRewardAddressChangerComponent,
     UserAppSettingsComponent,
+    NodeLogsComponent,
   ],
   imports: [
     BrowserModule,

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -13,6 +13,7 @@ import { processServiceError } from 'src/app/utils/errors';
 import { SelectableOption, SelectOptionComponent } from 'src/app/components/layout/select-option/select-option.component';
 import { MenuOptionData } from 'src/app/components/layout/top-bar/top-bar.component';
 import { StorageService } from 'src/app/services/storage.service';
+import { NodeLogsComponent } from './node-logs/node-logs.component';
 
 /**
  * Helper object for managing the options shown in the menu while in the node details page.
@@ -134,7 +135,7 @@ export class NodeActionsHelper {
     } else if (actionName === 'update') {
       this.update();
     } else if (actionName === 'logs') {
-      window.open(window.location.origin + '/api/visors/' + nodePk + '/runtime-logs', '_blank');
+      this.runtimeLogs();
     } else if (actionName === 'reboot') {
       this.reboot();
     } else if (actionName === null) {
@@ -218,6 +219,13 @@ export class NodeActionsHelper {
     const protocol = window.location.protocol;
     const hostname = window.location.host.replace('localhost:4200', '127.0.0.1:8000');
     window.open(protocol + '//' + hostname + '/pty/' + this.currentNodeKey, '_blank', 'noopener noreferrer');
+  }
+
+  /**
+   * Opens the modal window for checking the runtime logs of a node.
+   */
+  runtimeLogs() {
+    NodeLogsComponent.openDialog(this.dialog);
   }
 
   back() {

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-logs/node-logs.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-logs/node-logs.component.html
@@ -1,0 +1,90 @@
+<app-dialog [headline]="'node.logs.title' | translate" [includeVerticalMargins]="false" [includeScrollableArea]="false" [dialog]="dialogRef">
+  <!-- Filter button. -->
+  <div *ngIf="!loading && logEntries && logEntries.length > 0" class="filter-area" (click)="showFilters()">
+    <div class="filter-content">
+      <div>
+        <span>{{ 'node.logs.selected-filter' | translate }} </span>
+        <span class="actual-value">{{ ('node.logs.' + levelDetails.get(currentMinimumLevel).levelFilterName) | translate }}</span>
+      </div>
+      <div *ngIf="logEntries.length > filteredLogEntries.length" class="small">
+        {{ 'node.logs.filter-ignored' | translate:{number: logEntries.length - filteredLogEntries.length} }}
+      </div>
+    </div>
+    <div class="filter-margin"></div>
+  </div>
+
+  <mat-dialog-content #content>
+    <!-- Link for opening all the logs, if there are too much for the modal window. -->
+    <div *ngIf="!loading && hasMoreLogMessages" class="log-entry">
+      <a [href]="getFullLogsUrl()" target="_blank" class="view-raw-link">
+        {{ 'node.logs.view-rest' | translate:{number: totalLogs} }}
+      </a>
+    </div>
+
+    <!-- All entries. -->
+    <ng-container *ngIf="!loading">
+      <div *ngFor="let entry of filteredLogEntries" class="log-entry">
+        <!-- Basic fields. -->
+        <span class="transparent">
+          {{ entry.time }}
+        </span>
+        <span [class]="levelDetails.get(entry.level).colorClass">
+          {{ levelDetails.get(entry.level).name }}
+        </span>
+        [
+        <span class="transparent">
+          {{ entry.func }}
+        </span>
+        <span class="module-color">
+          {{ entry._module }}
+        </span>
+        ]<ng-container *ngIf="entry.msg">:</ng-container>
+        <span *ngIf="entry.msg">
+          {{ entry.msg }}
+        </span>
+
+        <!-- Extra fields. -->
+        <ng-container *ngFor="let extra of entry.extra">
+          <span class="extra-data-color">
+            {{ extra.name }}
+          </span>
+          <span>
+            ="{{ extra.value }}"
+          </span>
+        </ng-container>
+      </div>
+    </ng-container>
+
+    <!-- Link for opening all the logs. -->
+    <div *ngIf="!loading && logEntries && logEntries.length > 0" class="log-entry">
+      <a [href]="getFullLogsUrl()" target="_blank" class="view-raw-link">
+        <ng-container *ngIf="!hasMoreLogMessages">
+          {{ 'node.logs.view-all' | translate }}
+        </ng-container>
+        <ng-container *ngIf="hasMoreLogMessages">
+          {{ 'node.logs.view-rest' | translate:{number: totalLogs} }}
+        </ng-container>
+      </a>
+    </div>
+
+    <!-- Msg if there are no logs. -->
+    <div class="log-empty-msg" *ngIf="!loading && (!logEntries || logEntries.length === 0)">
+      {{ 'node.logs.no-logs' | translate }}
+    </div>
+    <!-- Msg if there are no logs with the current filter. -->
+    <div class="log-empty-msg" *ngIf="!loading && logEntries && logEntries.length > 0 && filteredLogEntries.length < 1">
+      {{ 'node.logs.no-logs-for-filter' | translate }}
+    </div>
+    <!-- Loading animation. -->
+    <app-loading-indicator [showWhite]="false" *ngIf="loading"></app-loading-indicator>
+
+    <!-- Update button. -->
+    <div class="update-button subtle-transparent-button" (click)="loadData(0)">
+      <div *ngIf="!loading" class="update-time">
+        <mat-icon *ngIf="!showAlert" class="icon" [inline]="true">refresh</mat-icon>
+        <span>{{ ('refresh-button.' + elapsedTime.translationVarName) | translate:{time: elapsedTime.elapsedTime} }}</span>
+      </div>
+    </div>
+  </mat-dialog-content>
+</app-dialog>
+

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-logs/node-logs.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-logs/node-logs.component.scss
@@ -1,0 +1,117 @@
+@import "variables";
+
+.filter-area {
+  margin-left: -$mat-dialog-padding;
+  margin-right: -$mat-dialog-padding;
+  font-size: $font-size-smaller;
+  color: $light-gray;
+  background-color: #d9deeb;
+  cursor: pointer;
+
+  &:hover {
+    background-color: darken(#d9deeb, 3%);
+  }
+
+  .filter-content {
+    padding: 10px $mat-dialog-padding;
+    text-align: center;
+
+    .actual-value {
+      color: $black;
+    }
+
+    .small {
+      font-size: $font-size-mini-plus;
+    }
+  }
+
+  .filter-margin {
+    height: 1px;
+    background-color: $modal-separator;
+    margin: 0 12px;
+  }
+}
+
+.log-entry {
+  margin-top: 15px;
+  word-break: break-word;
+
+  .transparent {
+    color: $lighter-gray;
+  }
+}
+
+.log-entry:first-of-type {
+  margin-top: 0px;
+}
+
+.log-entry:last-of-type {
+  margin-bottom: $mat-dialog-padding;
+}
+
+.log-empty-msg {
+  text-align: center;
+}
+
+.view-raw-link {
+  color: $blue-medium;
+}
+
+.update-button {
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+
+  mat-icon {
+    position: relative;
+    top: 5px;
+    margin-right: 5px;
+  }
+
+  .update-time {
+    text-align: center;
+    font-size: $font-size-mini;
+    color: $black;
+    margin: 0 5px;
+  }
+}
+
+.panic-level-color {
+  color: #ff0000;
+}
+
+.fatal-level-color {
+  color: #ff0000;
+}
+
+.error-level-color {
+  color: #d10000;
+}
+
+.warning-level-color {
+  color: #e27505;
+}
+
+.info-level-color {
+  color: #0d9519;
+}
+
+.debug-level-color {
+  color: #0065ff;
+}
+
+.trace-level-color {
+  color: #468cf5;
+}
+
+.unknown-level-color {
+  color: #e27505;
+}
+
+.module-color {
+  color: #a119fc;
+}
+
+.extra-data-color {
+  color: #ad8021;
+}

--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-logs/node-logs.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-logs/node-logs.component.ts
@@ -1,0 +1,368 @@
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { MatDialogConfig, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Subscription, of, timer } from 'rxjs';
+import { delay, mergeMap } from 'rxjs/operators';
+
+import { AppConfig } from 'src/app/app.config';
+import { OperationError } from 'src/app/utils/operation-error';
+import { processServiceError } from 'src/app/utils/errors';
+import { NodeService } from 'src/app/services/node.service';
+import { NodeComponent } from '../../node.component';
+import { environment } from 'src/environments/environment';
+import TimeUtils, { ElapsedTime } from 'src/app/utils/timeUtils';
+import { SnackbarService } from 'src/app/services/snackbar.service';
+import { SelectOptionComponent, SelectableOption } from 'src/app/components/layout/select-option/select-option.component';
+
+/**
+ * Importance levels of the log entries.
+ */
+enum Level {
+  PanicLevel,
+	FatalLevel,
+	ErrorLevel,
+	WarnLevel,
+	InfoLevel,
+	DebugLevel,
+	TraceLevel,
+  Unknown,
+}
+
+/**
+ * Properties of the importance levels.
+ */
+class LevelDetails {
+  // Name to show on the log entries list for the importance level.
+  name: string;
+  // CSS class for showing the name of the level.
+  colorClass: string;
+  // Translatable var for showing the name of a filter which shows entries of this level or more.
+  levelFilterName: string;
+  // Numeric importance of the leve.
+  importance: number;
+}
+
+/**
+ * Represents a log entry.
+ */
+class LogEntry {
+  // Date and hour.
+  time: string;
+  // Importance level.
+  level: Level;
+  // Log msg.
+  msg: string;
+  // Function that originated the msg.
+  func: string;
+  // Module that originated the msg.
+  _module: string;
+  // Collection of extra key value pairs that form part of the log entry.
+  extra: LogEntryExtraValue[] = [];
+}
+
+/**
+ * Unknown key value pairs that can be part of an log entry.
+ */
+class LogEntryExtraValue {
+  name: string;
+  value: string;
+}
+
+/**
+ * Modal window for showing the runtime logs of a node.
+ */
+@Component({
+  selector: 'app-node-logs',
+  templateUrl: './node-logs.component.html',
+  styleUrls: ['./node-logs.component.scss'],
+})
+export class NodeLogsComponent implements OnInit, OnDestroy {
+  @ViewChild('content') content: ElementRef;
+
+  // Map with the properties of each possible log entry importance level.
+  levelDetails: Map<Level, LevelDetails> = new Map([
+    [Level.PanicLevel,
+      {name: 'PANIC', colorClass: 'panic-level-color', levelFilterName: 'filter-panic', importance: 8 }
+    ],
+    [Level.FatalLevel,
+      {name: 'FATAL', colorClass: 'fatal-level-color', levelFilterName: 'filter-faltal', importance: 7 }
+    ],
+    [Level.ErrorLevel,
+      {name: 'ERROR', colorClass: 'error-level-color', levelFilterName: 'filter-error', importance: 6 }
+    ],
+    [Level.WarnLevel,
+      {name: 'WARNING', colorClass: 'warning-level-color', levelFilterName: 'filter-warning', importance: 5 }
+    ],
+    [Level.InfoLevel,
+      {name: 'INFO', colorClass: 'info-level-color', levelFilterName: 'filter-info', importance: 4 }
+    ],
+    [Level.DebugLevel,
+      {name: 'DEBUG', colorClass: 'debug-level-color', levelFilterName: 'filter-debug', importance: 3 }
+    ],
+    [Level.TraceLevel,
+      {name: 'TRACE', colorClass: 'trace-level-color', levelFilterName: 'filter-all', importance: 2 }
+    ],
+    [Level.Unknown,
+      {name: 'UNKNOWN LOG', colorClass: 'unknown-level-color', levelFilterName: 'filter-all', importance: 1 }
+    ]
+  ]);
+
+  // Current minimum importanmce level used as filter.
+  currentMinimumLevel = Level.Unknown;
+
+  loading = true;
+  // Moment in which the data was loaded.
+  LoadingMoment = 0;
+  // How much time has passed since the data was loaded.
+  elapsedTime: ElapsedTime;
+
+  // How many entries the modal window can show, to avoid performance problems.
+  maxElementsPerPage = 1000;
+
+  // All logs entries obtained from the back-end.
+  logEntries: LogEntry[] = [];
+  // Logs entries shown on the UI.
+  filteredLogEntries: LogEntry[] = [];
+  // If not all logs entries ontained from the backend are being shown.
+  hasMoreLogMessages = false;
+  // How many log entries were obtained from the backend.
+  totalLogs = 0;
+
+  /**
+   * Allows to show an error msg in the snack bar only the first time there is an error
+   * getting the data, and not all the automatic attemps.
+   */
+  private shouldShowError = true;
+
+  private subscription: Subscription;
+  private timeUpdateSubscription: Subscription;
+
+  /**
+   * Opens the modal window. Please use this function instead of opening the window "by hand".
+   */
+  public static openDialog(dialog: MatDialog): MatDialogRef<NodeLogsComponent, any> {
+    const config = new MatDialogConfig();
+    config.autoFocus = false;
+    config.width = AppConfig.largeModalWidth;
+
+    return dialog.open(NodeLogsComponent, config);
+  }
+
+  constructor(
+    public dialogRef: MatDialogRef<NodeLogsComponent>,
+    private nodeService: NodeService,
+    private snackbarService: SnackbarService,
+    private ngZone: NgZone,
+    private dialog: MatDialog
+  ) { }
+
+  ngOnInit() {
+    this.loadData(0);
+  }
+
+  ngOnDestroy(): void {
+    this.removeSubscription();
+    this.removeTimeSubscription();
+  }
+
+  // Shows the modal window for selecting the minimum importance level to use as filter.
+  showFilters() {
+    const options: SelectableOption[] = [
+      { icon: '', label: 'node.logs.filter-all' },
+      { icon: '', label: 'node.logs.filter-debug' },
+      { icon: '', label: 'node.logs.filter-info' },
+      { icon: '', label: 'node.logs.filter-warning' },
+      { icon: '', label: 'node.logs.filter-error' },
+      { icon: '', label: 'node.logs.filter-faltal' },
+      { icon: '', label: 'node.logs.filter-panic' }
+    ];
+
+    const optionTypes: Level[] = [
+      Level.Unknown,
+      Level.DebugLevel,
+      Level.InfoLevel,
+      Level.WarnLevel,
+      Level.ErrorLevel,
+      Level.FatalLevel,
+      Level.PanicLevel
+    ];
+
+    // Put the check mark on the currently selected option.
+    for (let i = 0; i <= optionTypes.length; i++) {
+      if (this.currentMinimumLevel === optionTypes[i]) {
+        options[i].icon = 'check';
+      }
+    }
+
+    SelectOptionComponent.openDialog(this.dialog, options, 'node.logs.filter-title').afterClosed().subscribe((selectedOption: number) => {
+      // Use the selected option and update the filtered entries list.
+      this.currentMinimumLevel = optionTypes[selectedOption - 1];
+      this.filter();
+    });
+  }
+
+  /**
+   * Gets the logs from the back-end.
+   * @param delayMilliseconds Delay before getting the data, for retries after errors..
+   */
+  loadData(delayMilliseconds: number) {
+    this.removeSubscription();
+
+    this.loading = true;
+    this.subscription = of(1).pipe(
+      // Wait the delay.
+      delay(delayMilliseconds),
+      // Load the data. The node pk is obtained from the currently openned node page.
+      mergeMap(() => this.nodeService.getRuntimeLogs(NodeComponent.getCurrentNodeKey()))
+    ).subscribe(
+      (log) => this.onLogsReceived(log),
+      (err: OperationError) => this.onLogsError(err)
+    );
+  }
+
+  private removeSubscription() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  private removeTimeSubscription() {
+    if (this.timeUpdateSubscription) {
+      this.timeUpdateSubscription.unsubscribe();
+    }
+  }
+
+  private onLogsReceived(logs: any[]) {
+    let amount = 0;
+    this.totalLogs = logs.length;
+    // Check if the modal window can show all the entries.
+    this.hasMoreLogMessages = this.totalLogs - this.maxElementsPerPage > 0;
+
+    logs.forEach(e => {
+      // Save all the basic data.
+      const entry = new LogEntry();
+      entry.time = e.time;
+      entry._module = e._module;
+      entry.msg = e.msg;
+      entry.func = e.func;
+
+      // Save the importance level.
+      const receivewdLevel = e.level ? (e.level as string).toLowerCase() : '';
+      if (receivewdLevel.includes('panic')) {
+        entry.level = Level.PanicLevel;
+      } else if (receivewdLevel.includes('fatal')) {
+        entry.level = Level.FatalLevel;
+      } else if (receivewdLevel.includes('error')) {
+        entry.level = Level.ErrorLevel;
+      } else if (receivewdLevel.includes('warn')) {
+        entry.level = Level.WarnLevel;
+      } else if (receivewdLevel.includes('info')) {
+        entry.level = Level.InfoLevel;
+      } else if (receivewdLevel.includes('debug')) {
+        entry.level = Level.DebugLevel;
+      } else if (receivewdLevel.includes('trace')) {
+        entry.level = Level.TraceLevel;
+      } else {
+        entry.level = Level.Unknown;
+      }
+
+      // Format the current_backoff value, if any.
+      if (e.current_backoff) {
+        const seg = Math.floor(e.current_backoff / 1000000000);
+        const min = Math.floor(seg / 60);
+        const segs = Math.floor(seg % 60);
+        if (min ) {
+          entry.extra.push({name: 'current_backoff', value: min + 'm' + segs + 's'});
+        } else {
+          entry.extra.push({name: 'current_backoff', value: segs + 's'});
+        }
+      }
+
+      // Save the error msg, is any.
+      if (e.error) {
+        entry.extra.push({name: 'error', value: e.error});
+      }
+
+      // List with the properties that should not be considered as unknown extra properties.
+      const knownProperties = new Set<string>();
+      knownProperties.add('time');
+      knownProperties.add('_module');
+      knownProperties.add('msg');
+      knownProperties.add('func');
+      knownProperties.add('level');
+      knownProperties.add('current_backoff');
+      knownProperties.add('error');
+      knownProperties.add('log_line');
+
+      // Save the unknow extra properties.
+      for(const key in e) {
+        if (!knownProperties.has(key)) {
+          entry.extra.push({name: key, value: e[key]});
+        }
+      }
+
+      // Add to the list.
+      if (this.totalLogs - amount <= this.maxElementsPerPage) {
+        this.logEntries.push(entry);
+      }
+
+      amount += 1;
+    });
+
+    this.loading = false;
+    this.LoadingMoment = Date.now();
+
+    this.startUpdatingTime();
+
+    this.filter();
+  }
+
+  // Removes all the entries that do not meet the filter criteria.
+  private filter() {
+    this.filteredLogEntries = [];
+
+    const minimumimportance = this.levelDetails.get(this.currentMinimumLevel).importance;
+
+    this.logEntries.forEach(e => {
+      const importance = this.levelDetails.get(e.level).importance;
+      if (minimumimportance <= importance) {
+        this.filteredLogEntries.push(e);
+      }
+    });
+
+    // Scroll to the bottom. Use a timer to wait for the UI to be updated.
+    setTimeout(() => {
+      (this.content.nativeElement as HTMLElement).scrollTop = (this.content.nativeElement as HTMLElement).scrollHeight;
+    });
+  }
+
+  // Updates the text which says how much time has passed since the data was loaded. It does it
+  // periodically.
+  startUpdatingTime() {
+    this.elapsedTime = TimeUtils.getElapsedTime(Math.floor((Date.now() - this.LoadingMoment) / 1000));
+
+    this.removeTimeSubscription();
+    this.timeUpdateSubscription = timer(5000, 5000).subscribe(() => this.ngZone.run(() => {
+      this.elapsedTime = TimeUtils.getElapsedTime(Math.floor((Date.now() - this.LoadingMoment) / 1000));
+    }));
+  }
+
+  // Returns the URL with the raw log data.
+  getFullLogsUrl(): string {
+    const apiPrefix = !environment.production && location.protocol.indexOf('http:') !== -1 ? 'http-api' : 'api';
+
+    return window.location.origin + '/' + apiPrefix + '/visors/' + NodeComponent.getCurrentNodeKey() + '/runtime-logs';;
+  }
+
+  private onLogsError(err: OperationError) {
+    err = processServiceError(err);
+
+    // Show an error msg if it has not be done before during the current attempt to obtain the data.
+    if (this.shouldShowError) {
+      this.snackbarService.showError('common.loading-error', null, true, err);
+      this.shouldShowError = false;
+    }
+
+    // Retry after a small delay.
+    this.loadData(AppConfig.connectionRetryDelay);
+  }
+}

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.html
@@ -27,7 +27,12 @@
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.dmsg-server' | translate }} </span>
-      <app-copy-to-clipboard-text text="{{ node.dmsgServerPk }}"></app-copy-to-clipboard-text>
+      <ng-container *ngIf="hasDmsgServer()">
+        <app-copy-to-clipboard-text text="{{ node.dmsgServerPk }}"></app-copy-to-clipboard-text>
+      </ng-container>
+      <ng-container *ngIf="!hasDmsgServer()">
+        {{ 'node.details.node-info.no-dmsg-server' | translate }}
+      </ng-container>
     </span>
     <span class="info-line">
       <span class="title">{{ 'node.details.node-info.ping' | translate }} </span>

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info-content/node-info-content.component.ts
@@ -104,6 +104,17 @@ export class NodeInfoContentComponent implements OnDestroy {
   }
 
   /**
+   * Returns if the node is connected to a valid DMSG server PK.
+   */
+  hasDmsgServer() {
+    if (!this.node || this.node.dmsgServerPk.replace(/0/g, '').length === 0) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Enables or disables the transport.public_autoconnect setting.
    */
   changeTransportsConfig() {

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -333,6 +333,13 @@ export class NodeService {
   }
 
   /**
+   * Gets the runtime logs of the node.
+   */
+  getRuntimeLogs(nodeKey: string) {
+    return this.apiService.get(`visors/${nodeKey}/runtime-logs`);
+  }
+
+  /**
    * Removes the rewards address of the node.
    */
   deleteRewardsAddress(nodeKey: string) {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -87,6 +87,23 @@
   "node": {
     "title": "Visor details",
     "not-found": "Visor not found.",
+    "logs" : {
+      "title": "Runtime Logs",
+      "no-logs": "No runtime logs were found for this visor.",
+      "no-logs-for-filter": "No runtime logs matches the selected filter.",
+      "view-all": "View all logs in raw format >",
+      "view-rest": "View all {{ number }} elements in raw format >",
+      "selected-filter": "Showing:",
+      "filter-ignored": "The filter excluded {{ number }} entries",
+      "filter-title": "Filter",
+      "filter-all": "All logs",
+      "filter-debug": "Debug or more important",
+      "filter-info": "Info or more important",
+      "filter-warning": "Warning or more important",
+      "filter-error": "Error or more important",
+      "filter-faltal": "Faltal or more important",
+      "filter-panic": "Panic"
+    },
     "statuses": {
       "online": "Online",
       "online-tooltip": "The visor is online.",
@@ -108,6 +125,7 @@
         "public-ip": "Public IP:",
         "ip": "IP:",
         "dmsg-server": "DMSG server:",
+        "no-dmsg-server": "Not connected",
         "ping": "Ping:",
         "node-version": "Visor version:",
         "build-type": "Build type:",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -87,6 +87,23 @@
   "node": {
     "title": "Detalles del visor",
     "not-found": "Visor no encontrado.",
+    "logs" : {
+      "title": "Registros de operación",
+      "no-logs": "No se encontraron registros de operación para este visor.",
+      "no-logs-for-filter": "No hay registros de operación que coincidan con el filtro seleccionado.",
+      "view-all": "Ver todos los registros en formato original >",
+      "view-rest": "Ver los {{ number }} elementos en formato original >",
+      "selected-filter": "Mostrando:",
+      "filter-ignored": "En filtro excluyó {{ number }} registros",
+      "filter-title": "Filtro",
+      "filter-all": "Todos los registros",
+      "filter-debug": "Debug o más importante",
+      "filter-info": "Info o más importante",
+      "filter-warning": "Warning o más importante",
+      "filter-error": "Error o más importante",
+      "filter-faltal": "Faltal o más importante",
+      "filter-panic": "Panic"
+    },
     "statuses": {
       "online": "Online",
       "online-tooltip": "El visor se encuentra online.",
@@ -108,6 +125,7 @@
         "public-ip": "IP pública:",
         "ip": "IP:",
         "dmsg-server": "Servidor DMSG:",
+        "no-dmsg-server": "No connectado",
         "ping": "Ping:",
         "node-version": "Versión del visor:",
         "build-type": "Tipo de build:",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -87,6 +87,23 @@
   "node": {
     "title": "Visor details",
     "not-found": "Visor not found.",
+    "logs" : {
+      "title": "Runtime Logs",
+      "no-logs": "No runtime logs were found for this visor.",
+      "no-logs-for-filter": "No runtime logs matches the selected filter.",
+      "view-all": "View all logs in raw format >",
+      "view-rest": "View all {{ number }} elements in raw format >",
+      "selected-filter": "Showing:",
+      "filter-ignored": "The filter excluded {{ number }} entries",
+      "filter-title": "Filter",
+      "filter-all": "All logs",
+      "filter-debug": "Debug or more important",
+      "filter-info": "Info or more important",
+      "filter-warning": "Warning or more important",
+      "filter-error": "Error or more important",
+      "filter-faltal": "Faltal or more important",
+      "filter-panic": "Panic"
+    },
     "statuses": {
       "online": "Online",
       "online-tooltip": "The visor is online.",
@@ -108,6 +125,7 @@
         "public-ip": "Public IP:",
         "ip": "IP:",
         "dmsg-server": "DMSG server:",
+        "no-dmsg-server": "Not connected",
         "ping": "Ping:",
         "node-version": "Visor version:",
         "build-type": "Build type:",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the Skywire manager has an UI for viewing the runtime logs of the visors.
- Now the UI shows an adequate msg if the DMSG server is 00000...

How to test this PR:
Rebuild the UI, go to the visor details page, use the button at the top-right corner of the screen to open the menu and select the "View logs" option.
