### PR TITLE
Stop requests when not needed

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/login/login.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/login/login.component.ts
@@ -11,6 +11,7 @@ import { InitialSetupComponent } from './initial-setup/initial-setup.component';
 import { OperationError } from '../../../utils/operation-error';
 import { processServiceError } from '../../../utils/errors';
 import { AppComponent } from 'src/app/app.component';
+import { MultipleNodeDataService } from 'src/app/services/multiple-node-data.service';
 
 /**
  * Login page.
@@ -36,9 +37,13 @@ export class LoginComponent implements OnInit, OnDestroy {
     private snackbarService: SnackbarService,
     private dialog: MatDialog,
     private route: ActivatedRoute,
+    private multipleNodeDataService: MultipleNodeDataService,
   ) { }
 
   ngOnInit() {
+    // Stop multiple requests that will fail for auth.
+    this.multipleNodeDataService.stopRequestingData();
+
     this.routeSubscription = this.route.paramMap.subscribe(params => {
       this.vpnKey = params.get('key');
 

--- a/static/skywire-manager-src/src/app/services/multiple-node-data.service.ts
+++ b/static/skywire-manager-src/src/app/services/multiple-node-data.service.ts
@@ -82,6 +82,16 @@ export class MultipleNodeDataService {
   }
 
   /**
+   * Makes the service stop returning the node list.
+   */
+  stopRequestingData() {
+    if (this.updateSubscription) {
+      this.updateSubscription.unsubscribe();
+      this.firstCallToGetDataMade = false;
+    }
+  }
+
+  /**
    * Starts periodically getting the node list.
    * @param delayMs Delay before loading the data.
    */


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- When auth is active, you use the logout button and then the UI returns to the login page, the UI stops making the normal periodical request to the server, to avoid adding unneeded entries to the back-end log, as requested by @0pcom

How to test this PR:
Rebuild the UI. Use the Hypervisor UI with auth active and then press the logout button. When returning to the loging page, no more periodical request to the visors-summary endpoint should be made.