### PR TITLE
change port logic on sudph and stcpr init

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -84,7 +84,7 @@ func NewManager(log *logging.Logger, arClient addrresolver.APIClient, ebc *appev
 // InitDmsgClient initilizes the dmsg client and also adds dmsgC to the factory
 func (tm *Manager) InitDmsgClient(ctx context.Context, dmsgC *dmsg.Client) {
 	tm.factory.DmsgC = dmsgC
-	tm.InitClient(ctx, network.DMSG)
+	tm.InitClient(ctx, network.DMSG, 0)
 }
 
 // Serve starts all network clients and starts accepting connections
@@ -146,9 +146,8 @@ func (tm *Manager) SetPTpsCache(pTps []PersistentTransports) {
 }
 
 // InitClient initilizes a network client
-func (tm *Manager) InitClient(ctx context.Context, netType network.Type) {
-
-	client, err := tm.factory.MakeClient(netType)
+func (tm *Manager) InitClient(ctx context.Context, netType network.Type, port int) {
+	client, err := tm.factory.MakeClient(netType, port)
 	if err != nil {
 		tm.Logger.Warnf("Cannot initialize %s transport client", netType)
 	}

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -62,7 +62,7 @@ type ClientFactory struct {
 }
 
 // MakeClient creates a new client of specified type
-func (f *ClientFactory) MakeClient(netType Type) (Client, error) {
+func (f *ClientFactory) MakeClient(netType Type, port int) (Client, error) {
 	log := logging.MustGetLogger(string(netType))
 	if f.MLogger != nil {
 		log = f.MLogger.PackageLogger(string(netType))
@@ -88,9 +88,9 @@ func (f *ClientFactory) MakeClient(netType Type) (Client, error) {
 	case STCP:
 		return newStcp(generic, f.PKTable), nil
 	case STCPR:
-		return newStcpr(resolved), nil
+		return newStcpr(resolved, port), nil
 	case SUDPH:
-		return newSudph(resolved), nil
+		return newSudph(resolved, port), nil
 	case DMSG:
 		return newDmsgClient(f.DmsgC), nil
 	}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -466,20 +466,20 @@ func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 		case stun.NATSymmetric, stun.NATSymmetricUDPFirewall:
 			log.Warnf("SUDPH transport wont be available as visor is under %v", v.stunClient.NATType.String())
 		default:
-			v.tpM.InitClient(ctx, network.SUDPH)
+			v.tpM.InitClient(ctx, network.SUDPH, v.conf.Transport.SudphPort)
 		}
 	}
 	return nil
 }
 
 func initStcprClient(ctx context.Context, v *Visor, log *logging.Logger) error {
-	v.tpM.InitClient(ctx, network.STCPR)
+	v.tpM.InitClient(ctx, network.STCPR, v.conf.Transport.StcprPort)
 	return nil
 }
 
 func initStcpClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if v.conf.STCP != nil {
-		v.tpM.InitClient(ctx, network.STCP)
+		v.tpM.InitClient(ctx, network.STCP, 0)
 	}
 	return nil
 }

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -73,8 +73,8 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 			Location:         LocalPath + "/" + TpLogStore,
 			RotationInterval: DefaultLogRotationInterval,
 		},
-		SudphPort: "",
-		StcprPort: "",
+		SudphPort: 0,
+		StcprPort: 0,
 	}
 	conf.Routing = &Routing{
 		RouteFinder:        services.RouteFinder, //utilenv.RouteFinderAddr,

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -73,6 +73,8 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 			Location:         LocalPath + "/" + TpLogStore,
 			RotationInterval: DefaultLogRotationInterval,
 		},
+		SudphPort: "",
+		StcprPort: "",
 	}
 	conf.Routing = &Routing{
 		RouteFinder:        services.RouteFinder, //utilenv.RouteFinderAddr,

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -56,6 +56,8 @@ type Transport struct {
 	PublicAutoconnect bool            `json:"public_autoconnect"`
 	TransportSetup    []cipher.PubKey `json:"transport_setup_nodes"`
 	LogStore          *LogStore       `json:"log_store"`
+	StcprPort         string          `json:"stcpr_port"`
+	SudphPort         string          `json:"sudph_port"`
 }
 
 // LogStore configures a LogStore.

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -56,8 +56,8 @@ type Transport struct {
 	PublicAutoconnect bool            `json:"public_autoconnect"`
 	TransportSetup    []cipher.PubKey `json:"transport_setup_nodes"`
 	LogStore          *LogStore       `json:"log_store"`
-	StcprPort         string          `json:"stcpr_port"`
-	SudphPort         string          `json:"sudph_port"`
+	StcprPort         int             `json:"stcpr_port"`
+	SudphPort         int             `json:"sudph_port"`
 }
 
 // LogStore configures a LogStore.


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add two new fields, `stcpr_port` and `sudph_port` for fixed port instead random
- default values in new config are 0, that means use random port. if fixed port was used, trying to test increased port by one, and this process continue till binding

How to test this PR:
- `make build`
- generate new config, `skywire-cli config gen`
- run visor `skywire-visor -c skywire-config.json`