### PR TITLE
Config Changes [WIP]

### DIFF
--- a/cmd/skywire-cli/commands/config/update.go
+++ b/cmd/skywire-cli/commands/config/update.go
@@ -125,9 +125,9 @@ var updateCmd = &cobra.Command{
 			conf.Launcher = &visorconfig.Launcher{
 				ServiceDisc: services.ServiceDiscovery, //utilenv.DefaultServiceDiscAddr,
 			}
-			conf.UptimeTracker = &visorconfig.UptimeTracker{
-				Addr: services.UptimeTracker, //utilenv.DefaultUptimeTrackerAddr,
-			}
+			utconf := *conf.UptimeTracker
+			utconf = append(utconf, services.UptimeTracker) //utilenv.DefaultUptimeTrackerAddr,
+			*conf.UptimeTracker = utconf
 			conf.StunServers = services.StunServers //utilenv.GetStunServers()
 		}
 

--- a/internal/vpn/env.go
+++ b/internal/vpn/env.go
@@ -50,7 +50,7 @@ type DirectRoutesEnvConfig struct {
 	DmsgServers     []string
 	TPDiscovery     string
 	RF              string
-	UptimeTracker   string
+	UptimeTracker   []string
 	AddressResolver string
 	TPRemoteIPs     []string
 	STCPTable       map[cipher.PubKey]string
@@ -76,8 +76,9 @@ func AppEnvArgs(config DirectRoutesEnvConfig) map[string]string {
 		envs[RFAddrEnvKey] = config.RF
 	}
 
-	if config.UptimeTracker != "" {
-		envs[UptimeTrackerAddrEnvKey] = config.UptimeTracker
+	if len(config.UptimeTracker) != 0 {
+		//TODO: Fix this placeholder logic after converting underlying types
+		envs[UptimeTrackerAddrEnvKey] = config.UptimeTracker[1]
 	}
 
 	if len(config.STCPTable) != 0 {

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -86,9 +86,9 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		BinPath:       AppBinPath,
 		DisplayNodeIP: false,
 	}
-	conf.UptimeTracker = &UptimeTracker{
-		Addr: services.UptimeTracker, //utilenv.UptimeTrackerAddr,
-	}
+	var utconf []string
+	utconf = append(utconf, services.UptimeTracker) //utilenv.UptimeTrackerAddr,
+	conf.UptimeTracker = &utconf
 	conf.CLIAddr = RPCAddr
 	conf.LogLevel = LogLevel
 	conf.LocalPath = LocalPath
@@ -115,7 +115,9 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 				conf.Dmsg.Discovery = dmsgHTTPServersList.Test.DMSGDiscovery
 				conf.Transport.AddressResolver = dmsgHTTPServersList.Test.AddressResolver
 				conf.Transport.Discovery = dmsgHTTPServersList.Test.TransportDiscovery
-				conf.UptimeTracker.Addr = dmsgHTTPServersList.Test.UptimeTracker
+				var utconf []string
+				utconf = append(utconf, dmsgHTTPServersList.Test.UptimeTracker) //utilenv.UptimeTrackerAddr,
+				conf.UptimeTracker = &utconf
 				conf.Routing.RouteFinder = dmsgHTTPServersList.Test.RouteFinder
 				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Test.ServiceDiscovery
 			} else {
@@ -123,7 +125,9 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 				conf.Dmsg.Discovery = dmsgHTTPServersList.Prod.DMSGDiscovery
 				conf.Transport.AddressResolver = dmsgHTTPServersList.Prod.AddressResolver
 				conf.Transport.Discovery = dmsgHTTPServersList.Prod.TransportDiscovery
-				conf.UptimeTracker.Addr = dmsgHTTPServersList.Prod.UptimeTracker
+				var utconf []string
+				utconf = append(utconf, dmsgHTTPServersList.Prod.UptimeTracker) //utilenv.UptimeTrackerAddr,
+				conf.UptimeTracker = &utconf
 				conf.Routing.RouteFinder = dmsgHTTPServersList.Prod.RouteFinder
 				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Prod.ServiceDiscovery
 			}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -24,7 +24,7 @@ type V1 struct {
 	STCP          *network.STCPConfig `json:"skywire-tcp,omitempty"`
 	Transport     *Transport          `json:"transport"`
 	Routing       *Routing            `json:"routing"`
-	UptimeTracker *UptimeTracker      `json:"uptime_tracker,omitempty"`
+	UptimeTracker *[]string           `json:"uptime_tracker,omitempty"`
 	Launcher      *Launcher           `json:"launcher"`
 
 	Hypervisors []cipher.PubKey `json:"hypervisors"`
@@ -72,11 +72,6 @@ type Routing struct {
 	RouteFinder        string          `json:"route_finder"`
 	RouteFinderTimeout Duration        `json:"route_finder_timeout,omitempty"`
 	MinHops            uint16          `json:"min_hops"`
-}
-
-// UptimeTracker configures uptime tracker.
-type UptimeTracker struct {
-	Addr string `json:"addr"`
 }
 
 // Launcher configures the app


### PR DESCRIPTION
This PR attempts to add support for configuring multiple services of the same type, considering that the production deployment is now open source.

FIXES: #1535

Secondary objectives include:
* simplifying types or eliminating custom types where possible
* changing config field names to be unique and grep-able

Included in this PR initially is support for multiple uptime trackers, _as a test_.

A few logical issues arise such as when it is desirable to maintain simultaneous connections, how to handle fall-over, etc. My main concern is to change the config itself and the cli interface for setting these config values as this will need package level support and changes to the skywire-autoconfig script in order to persist updates.