### PR TITLE
fix skywire-cli config gen -a

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -222,7 +222,9 @@ var genConfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		mLog := logging.NewMasterLogger()
 		mLog.SetLevel(logrus.InfoLevel)
-		serviceConfURL = svcConf
+		if serviceConfURL == "" {
+			serviceConfURL = svcConf
+		}
 		//use test deployment
 		if isTestEnv {
 			serviceConfURL = testConf


### PR DESCRIPTION
the value set by the -a flag was accidentally being ignored