### PR TITLE
randomize the order of survey collection with `skywire-cli log`

### DIFF
--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os"
 	"sync"
@@ -87,6 +88,10 @@ var logCmd = &cobra.Command{
 		if err != nil {
 			log.WithError(err).Panic("Unable to get data from uptime tracker.")
 		}
+		//randomize the order of the fetching - prevents observed hanging
+		rand.Shuffle(len(uptimes), func(i, j int) {
+			uptimes[i], uptimes[j] = uptimes[j], uptimes[i]
+		})
 		// Create dmsg http client
 		pk, sk, _ := genKeys("") //nolint
 		dmsgC, closeDmsg, err := dg.StartDmsg(ctx, log, pk, sk)


### PR DESCRIPTION
In practice, collecting all the surveys by going down the list of public keys hangs at a certain point, which has previously caused a cascade of errors in the new reward system.

a simple rand.Shuffle on the keys fetched from the uptime tracker remedies this situation.