### PR TITLE
Update skywire-utilities dependency - fix `skywire-cli vpn list`

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -152,7 +152,7 @@ var proxyStatusCmd = &cobra.Command{
 var proxyListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long:  "List proxy servers from service discovery\n http://sd.skycoin.com/api/services?type=proxy\n http://sd.skycoin.com/api/services?type=vpn&country=US",
+	Long:  "List proxy servers from service discovery\n http://sd.skycoin.com/api/services?type=proxy\n http://sd.skycoin.com/api/services?type=proxy&country=US",
 	Run: func(cmd *cobra.Command, args []string) {
 		if pk != "" {
 			err := pubkey.Set(pk)

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -250,7 +250,7 @@ func directQuerySD(cmdFlags *pflag.FlagSet) (s []servicedisc.Service) {
 	if err != nil {
 		internal.PrintFatalError(cmdFlags, fmt.Errorf("error fetching servers from service discovery: %w", err))
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	// Decode JSON response into struct
 	err = json.NewDecoder(resp.Body).Decode(&s)
 	if err != nil {

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -3,16 +3,20 @@ package skysocksc
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+	"github.com/skycoin/skywire-utilities/pkg/skyenv"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -22,34 +26,35 @@ import (
 func init() {
 	RootCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", "localhost:3435", "RPC server address")
 	RootCmd.AddCommand(
-		proxyStartCmd,
-		proxyStopCmd,
-		proxyStatusCmd,
-		proxyListCmd,
+		startCmd,
+		stopCmd,
+		statusCmd,
+		listCmd,
 	)
 	version := buildinfo.Version()
 	if version == "unknown" {
 		version = ""
 	}
-	proxyStartCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
-	proxyListCmd.Flags().StringVarP(&pk, "pk", "k", "", "check proxy service discovery for public key")
-	proxyListCmd.Flags().IntVarP(&count, "num", "n", 0, "number of results to return")
-	proxyListCmd.Flags().BoolVarP(&isUnFiltered, "unfilter", "u", false, "provide unfiltered results")
-	proxyListCmd.Flags().StringVarP(&ver, "ver", "v", version, "filter results by version")
-	proxyListCmd.Flags().StringVarP(&country, "country", "c", "", "filter results by country")
-	proxyListCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
+	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
+	listCmd.Flags().StringVarP(&sdURL, "url", "a", "", "service discovery url default:\n"+skyenv.ServiceDiscAddr)
+	listCmd.Flags().BoolVarP(&directQuery, "direct", "b", false, "query service discovery directly")
+	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
+	listCmd.Flags().IntVarP(&count, "num", "n", 0, "number of results to return (0 = all)")
+	listCmd.Flags().BoolVarP(&isUnFiltered, "unfilter", "u", false, "provide unfiltered results")
+	listCmd.Flags().StringVarP(&ver, "ver", "v", version, "filter results by version")
+	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter results by country")
+	listCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 }
 
-var proxyStartCmd = &cobra.Command{
+var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "start the proxy client",
-	//	Args:  cobra.MinimumNArgs(0),
+	Short: "start the " + serviceType + " client",
 	Run: func(cmd *cobra.Command, args []string) {
 		//check that a valid public key is provided
 		err := pubkey.Set(pk)
 		if err != nil {
 			if len(args) > 0 {
-				err := pubkey.Set(args[0])
+				err := pubkey.Set(args[1])
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), err)
 				}
@@ -57,10 +62,9 @@ var proxyStartCmd = &cobra.Command{
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Invalid or missing public key"))
 			}
 		}
-		//connect to RPC
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 		//TODO: implement operational timeout
 		internal.Catch(cmd.Flags(), rpcClient.StartSkysocksClient(pubkey.String()))
@@ -77,7 +81,7 @@ var proxyStartCmd = &cobra.Command{
 			}
 
 			for _, state := range states {
-				if state.Name == "skysocks-client" {
+				if state.Name == stateName {
 					if state.Status == appserver.AppStatusRunning {
 						startProcess = false
 						internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
@@ -95,27 +99,27 @@ var proxyStartCmd = &cobra.Command{
 	},
 }
 
-var proxyStopCmd = &cobra.Command{
+var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "stop the proxy client",
+	Short: "stop the " + serviceType + " client",
 	Run: func(cmd *cobra.Command, args []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 		internal.Catch(cmd.Flags(), rpcClient.StopSkysocksClient())
 		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }
 
-var proxyStatusCmd = &cobra.Command{
+var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "proxy client(s) status",
+	Short: serviceType + " client status",
 	Run: func(cmd *cobra.Command, args []string) {
 		//TODO: check status of multiple clients
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 		states, err := rpcClient.Apps()
 		internal.Catch(cmd.Flags(), err)
@@ -128,7 +132,7 @@ var proxyStatusCmd = &cobra.Command{
 		}
 		var jsonAppStatus appState
 		for _, state := range states {
-			if state.Name == "skysocks-client" {
+			if state.Name == stateName {
 
 				status := "stopped"
 				if state.Status == appserver.AppStatusRunning {
@@ -149,31 +153,45 @@ var proxyStatusCmd = &cobra.Command{
 	},
 }
 
-var proxyListCmd = &cobra.Command{
+var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long:  "List proxy servers from service discovery\n http://sd.skycoin.com/api/services?type=proxy\n http://sd.skycoin.com/api/services?type=proxy&country=US",
+	Long:  "List " + serviceType + " servers from service discovery\n " + skyenv.ServiceDiscAddr + "/api/services?type=" + serviceType + "\n " + skyenv.ServiceDiscAddr + "/api/services?type=" + serviceType + "&country=US",
 	Run: func(cmd *cobra.Command, args []string) {
+		//validate any specified public key
 		if pk != "" {
 			err := pubkey.Set(pk)
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Invalid or missing public key"))
 			}
 		}
-		rpcClient, err := clirpc.Client(cmd.Flags())
-		if err != nil {
-			internal.PrintFatalRPCError(cmd.Flags(), err)
+		if sdURL == "" {
+			sdURL = skyenv.ServiceDiscAddr
 		}
 		if isUnFiltered {
 			ver = ""
 			country = ""
 		}
-		servers, err := rpcClient.ProxyServers(ver, country)
-		if err != nil {
-			internal.PrintFatalRPCError(cmd.Flags(), err)
+		if directQuery {
+			servers = directQuerySD(cmd.Flags())
+		} else {
+			rpcClient, err := clirpc.Client(cmd.Flags())
+			if err != nil {
+				internal.PrintError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+				internal.PrintOutput(cmd.Flags(), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType))
+				servers = directQuerySD(cmd.Flags())
+			} else {
+				servers, err = rpcClient.ProxyServers(ver, country)
+				if err != nil {
+					internal.PrintError(cmd.Flags(), err)
+					internal.PrintOutput(cmd.Flags(), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType))
+					servers = directQuerySD(cmd.Flags())
+				}
+			}
 		}
 		if len(servers) == 0 {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("No Servers found"))
+			internal.PrintOutput(cmd.Flags(), "No Servers found", "No Servers found")
+			os.Exit(0)
 		}
 		if isStats {
 			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d Servers\n", len(servers)), fmt.Sprintf("%d Servers\n", len(servers)))
@@ -186,7 +204,7 @@ var proxyListCmd = &cobra.Command{
 			}
 			if pk != "" {
 				for _, server := range servers {
-					if strings.Replace(server.Addr.String(), ":44", "", 1) == pk {
+					if strings.Replace(server.Addr.String(), servicePort, "", 1) == pk {
 						results = append(results, server.Addr.String())
 					}
 				}
@@ -195,11 +213,13 @@ var proxyListCmd = &cobra.Command{
 					results = append(results, server.Addr.String())
 				}
 			}
+
+			//randomize the order of the displayed results
 			rand.Shuffle(len(results), func(i, j int) {
 				results[i], results[j] = results[j], results[i]
 			})
 			for i := 0; i < limit && i < len(results); i++ {
-				msg += strings.Replace(results[i], ":44", "", 1)
+				msg += strings.Replace(results[i], servicePort, "", 1)
 				if server := findServerByPK(servers, results[i]); server != nil && server.Geo != nil {
 					if server.Geo.Country != "" {
 						msg += fmt.Sprintf(" | %s\n", server.Geo.Country)
@@ -213,6 +233,30 @@ var proxyListCmd = &cobra.Command{
 			internal.PrintOutput(cmd.Flags(), servers, msg)
 		}
 	},
+}
+
+func directQuerySD(cmdFlags *pflag.FlagSet) (s []servicedisc.Service) {
+	//url/uri format
+	//https://sd.skycoin.com/api/services?type=proxy&country=US&version=v1.3.7
+	sdURL += "/api/services?type=" + serviceType
+	if country != "" {
+		sdURL += "&country=" + country
+	}
+	if ver != "" {
+		sdURL += "&version=" + ver
+	}
+	//preform http get request for the service discovery URL
+	resp, err := (&http.Client{Timeout: time.Duration(30 * time.Second)}).Get(sdURL)
+	if err != nil {
+		internal.PrintFatalError(cmdFlags, fmt.Errorf("error fetching servers from service discovery: %w", err))
+	}
+	defer resp.Body.Close()
+	// Decode JSON response into struct
+	err = json.NewDecoder(resp.Body).Decode(&s)
+	if err != nil {
+		internal.PrintFatalError(cmdFlags, fmt.Errorf("error decoding json to struct: %w", err))
+	}
+	return s
 }
 
 func findServerByPK(servers []servicedisc.Service, addr string) *servicedisc.Service {

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -5,9 +5,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/servicedisc"
 )
 
 var (
+	stateName    string = "skysocks-client"
+	serviceType  string = servicedisc.ServiceTypeProxy
+	servicePort  string = ":44"
 	isUnFiltered bool
 	ver          string
 	country      string
@@ -15,6 +19,9 @@ var (
 	pubkey       cipher.PubKey
 	pk           string
 	count        int
+	sdURL        string
+	directQuery  bool
+	servers      []servicedisc.Service
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	stateName    string = "skysocks-client"
-	serviceType  string = servicedisc.ServiceTypeProxy
-	servicePort  string = ":44"
+	stateName    = "skysocks-client"
+	serviceType  = servicedisc.ServiceTypeProxy
+	servicePort  = ":44"
 	isUnFiltered bool
 	ver          string
 	country      string

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	stateName    string = "vpn-clent"
-	serviceType  string = servicedisc.ServiceTypeVPN
-	servicePort  string = ":3"
+	stateName    = "vpn-clent"
+	serviceType  = servicedisc.ServiceTypeVPN
+	servicePort  = ":3"
 	path         string
 	isPkg        bool
 	isUnFiltered bool

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -5,10 +5,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
-	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/servicedisc"
 )
 
 var (
+	stateName    string = "vpn-clent"
+	serviceType  string = servicedisc.ServiceTypeVPN
+	servicePort  string = ":3"
 	path         string
 	isPkg        bool
 	isUnFiltered bool
@@ -18,11 +21,10 @@ var (
 	pubkey       cipher.PubKey
 	pk           string
 	count        int
+	sdURL        string
+	directQuery  bool
+	servers      []servicedisc.Service
 )
-
-func init() {
-	RootCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", "localhost:3435", "RPC server address")
-}
 
 // RootCmd contains commands that interact with the skywire-visor
 var RootCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -3,16 +3,20 @@ package clivpn
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+	"github.com/skycoin/skywire-utilities/pkg/skyenv"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -21,89 +25,26 @@ import (
 )
 
 func init() {
+	RootCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", "localhost:3435", "RPC server address")
 	RootCmd.AddCommand(
-		vpnStartCmd,
-		vpnStopCmd,
-		vpnStatusCmd,
-		vpnListCmd,
+		startCmd,
+		stopCmd,
+		statusCmd,
+		listCmd,
 	)
 	version := buildinfo.Version()
 	if version == "unknown" {
 		version = ""
 	}
-	vpnStartCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
-	vpnListCmd.Flags().StringVarP(&pk, "pk", "k", "", "check proxy service discovery for public key")
-	vpnListCmd.Flags().IntVarP(&count, "num", "n", 0, "number of results to return")
-	vpnListCmd.Flags().BoolVarP(&isUnFiltered, "unfilter", "u", false, "provide unfiltered results")
-	vpnListCmd.Flags().StringVarP(&ver, "ver", "v", version, "filter results by version")
-	vpnListCmd.Flags().StringVarP(&country, "country", "c", "", "filter results by country")
-	vpnListCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
-}
-
-var vpnListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List servers",
-	Long:  "List vpn servers from service discovery\n http://sd.skycoin.com/api/services?type=vpn\n http://sd.skycoin.com/api/services?type=vpn&country=US",
-	Run: func(cmd *cobra.Command, args []string) {
-		if pk != "" {
-			err := pubkey.Set(pk)
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Invalid or missing public key"))
-			}
-		}
-		rpcClient, err := clirpc.Client(cmd.Flags())
-		if err != nil {
-			internal.PrintFatalRPCError(cmd.Flags(), err)
-		}
-		if isUnFiltered {
-			ver = ""
-			country = ""
-		}
-		servers, err := rpcClient.VPNServers(ver, country)
-		if err != nil {
-			internal.PrintFatalRPCError(cmd.Flags(), err)
-		}
-		if len(servers) == 0 {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("No Servers found"))
-		}
-		if isStats {
-			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d Servers\n", len(servers)), fmt.Sprintf("%d Servers\n", len(servers)))
-		} else {
-			var msg string
-			var results []string
-			limit := len(servers)
-			if count > 0 && count < limit {
-				limit = count
-			}
-			if pk != "" {
-				for _, server := range servers {
-					if strings.Replace(server.Addr.String(), ":3", "", 1) == pk {
-						results = append(results, server.Addr.String())
-					}
-				}
-			} else {
-				for _, server := range servers {
-					results = append(results, server.Addr.String())
-				}
-			}
-			rand.Shuffle(len(results), func(i, j int) {
-				results[i], results[j] = results[j], results[i]
-			})
-			for i := 0; i < limit && i < len(results); i++ {
-				msg += strings.Replace(results[i], ":3", "", 1)
-				if server := findServerByPK(servers, results[i]); server != nil && server.Geo != nil {
-					if server.Geo.Country != "" {
-						msg += fmt.Sprintf(" | %s\n", server.Geo.Country)
-					} else {
-						msg += "\n"
-					}
-				} else {
-					msg += "\n"
-				}
-			}
-			internal.PrintOutput(cmd.Flags(), servers, msg)
-		}
-	},
+	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
+	listCmd.Flags().StringVarP(&sdURL, "url", "a", "", "service discovery url default:\n"+skyenv.ServiceDiscAddr)
+	listCmd.Flags().BoolVarP(&directQuery, "direct", "b", false, "query service discovery directly")
+	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
+	listCmd.Flags().IntVarP(&count, "num", "n", 0, "number of results to return")
+	listCmd.Flags().BoolVarP(&isUnFiltered, "unfilter", "u", false, "provide unfiltered results")
+	listCmd.Flags().StringVarP(&ver, "ver", "v", version, "filter results by version")
+	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter results by country")
+	listCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 }
 
 func findServerByPK(servers []servicedisc.Service, addr string) *servicedisc.Service {
@@ -115,16 +56,16 @@ func findServerByPK(servers []servicedisc.Service, addr string) *servicedisc.Ser
 	return nil
 }
 
-var vpnStartCmd = &cobra.Command{
+var startCmd = &cobra.Command{
 	Use:   "start <public-key>",
-	Short: "start the vpn for <public-key>",
+	Short: "start the " + serviceType + " for <public-key>",
 	//	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		//check that a valid public key is provided
 		err := pubkey.Set(pk)
 		if err != nil {
 			if len(args) > 0 {
-				err := pubkey.Set(args[0])
+				err := pubkey.Set(args[1])
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), err)
 				}
@@ -133,10 +74,9 @@ var vpnStartCmd = &cobra.Command{
 			}
 		}
 		//connect to RPC
-		internal.Catch(cmd.Flags(), pubkey.Set(args[0]))
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 		internal.Catch(cmd.Flags(), rpcClient.StartVPNClient(pubkey))
 		internal.PrintOutput(cmd.Flags(), nil, "Starting.")
@@ -153,7 +93,7 @@ var vpnStartCmd = &cobra.Command{
 			}
 
 			for _, state := range states {
-				if state.Name == "vpn-client" {
+				if state.Name == stateName {
 					if state.Status == appserver.AppStatusRunning {
 						startProcess = false
 						internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
@@ -178,22 +118,22 @@ var vpnStartCmd = &cobra.Command{
 	},
 }
 
-var vpnStopCmd = &cobra.Command{
+var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "stop the vpn",
+	Short: "stop the " + serviceType + "client",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
-			os.Exit(1)
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
-		internal.Catch(cmd.Flags(), rpcClient.StopVPNClient("vpn-client"))
+		internal.Catch(cmd.Flags(), rpcClient.StopVPNClient(stateName))
 		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
 	},
 }
 
-var vpnStatusCmd = &cobra.Command{
+var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "vpn status",
+	Short: serviceType + " client status",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -210,7 +150,7 @@ var vpnStatusCmd = &cobra.Command{
 		}
 		var jsonAppStatus appState
 		for _, state := range states {
-			if state.Name == "vpn-client" {
+			if state.Name == stateName {
 
 				status := "stopped"
 				if state.Status == appserver.AppStatusRunning {
@@ -229,4 +169,110 @@ var vpnStatusCmd = &cobra.Command{
 		internal.Catch(cmd.Flags(), w.Flush())
 		internal.PrintOutput(cmd.Flags(), jsonAppStatus, b.String())
 	},
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List " + serviceType + " servers",
+	Long:  "List " + serviceType + " servers from service discovery\n " + skyenv.ServiceDiscAddr + "/api/services?type=" + serviceType + "\n " + skyenv.ServiceDiscAddr + "/api/services?type=" + serviceType + "&country=US",
+	Run: func(cmd *cobra.Command, args []string) {
+		//validate any specified public key
+		if pk != "" {
+			err := pubkey.Set(pk)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Invalid or missing public key"))
+			}
+		}
+		if sdURL == "" {
+			sdURL = skyenv.ServiceDiscAddr
+		}
+		if isUnFiltered {
+			ver = ""
+			country = ""
+		}
+		if directQuery {
+			servers = directQuerySD(cmd.Flags())
+		} else {
+			rpcClient, err := clirpc.Client(cmd.Flags())
+			if err != nil {
+				internal.PrintError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+				internal.PrintOutput(cmd.Flags(), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType))
+				servers = directQuerySD(cmd.Flags())
+			} else {
+				servers, err = rpcClient.VPNServers(ver, country)
+				if err != nil {
+					internal.PrintError(cmd.Flags(), err)
+					internal.PrintOutput(cmd.Flags(), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType), fmt.Sprintf("directly querying service discovery\n%s/api/services?type=%s\n", sdURL, serviceType))
+					servers = directQuerySD(cmd.Flags())
+				}
+			}
+		}
+		if len(servers) == 0 {
+			internal.PrintOutput(cmd.Flags(), "No Servers found", "No Servers found")
+			os.Exit(0)
+		}
+		if isStats {
+			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d Servers\n", len(servers)), fmt.Sprintf("%d Servers\n", len(servers)))
+		} else {
+			var msg string
+			var results []string
+			limit := len(servers)
+			if count > 0 && count < limit {
+				limit = count
+			}
+			if pk != "" {
+				for _, server := range servers {
+					if strings.Replace(server.Addr.String(), servicePort, "", 1) == pk {
+						results = append(results, server.Addr.String())
+					}
+				}
+			} else {
+				for _, server := range servers {
+					results = append(results, server.Addr.String())
+				}
+			}
+
+			//randomize the order of the displayed results
+			rand.Shuffle(len(results), func(i, j int) {
+				results[i], results[j] = results[j], results[i]
+			})
+			for i := 0; i < limit && i < len(results); i++ {
+				msg += strings.Replace(results[i], servicePort, "", 1)
+				if server := findServerByPK(servers, results[i]); server != nil && server.Geo != nil {
+					if server.Geo.Country != "" {
+						msg += fmt.Sprintf(" | %s\n", server.Geo.Country)
+					} else {
+						msg += "\n"
+					}
+				} else {
+					msg += "\n"
+				}
+			}
+			internal.PrintOutput(cmd.Flags(), servers, msg)
+		}
+	},
+}
+
+func directQuerySD(cmdFlags *pflag.FlagSet) (s []servicedisc.Service) {
+	//url/uri format
+	//https://sd.skycoin.com/api/services?type=vpn&country=US&version=v1.3.7
+	sdURL += "/api/services?type=" + serviceType
+	if country != "" {
+		sdURL += "&country=" + country
+	}
+	if ver != "" {
+		sdURL += "&version=" + ver
+	}
+	//preform http get request for the service discovery URL
+	resp, err := (&http.Client{Timeout: time.Duration(30 * time.Second)}).Get(sdURL)
+	if err != nil {
+		internal.PrintFatalError(cmdFlags, fmt.Errorf("error fetching servers from service discovery: %w", err))
+	}
+	defer resp.Body.Close()
+	// Decode JSON response into struct
+	err = json.NewDecoder(resp.Body).Decode(&s)
+	if err != nil {
+		internal.PrintFatalError(cmdFlags, fmt.Errorf("error decoding json to struct: %w", err))
+	}
+	return s
 }

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -268,7 +268,7 @@ func directQuerySD(cmdFlags *pflag.FlagSet) (s []servicedisc.Service) {
 	if err != nil {
 		internal.PrintFatalError(cmdFlags, fmt.Errorf("error fetching servers from service discovery: %w", err))
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	// Decode JSON response into struct
 	err = json.NewDecoder(resp.Body).Decode(&s)
 	if err != nil {

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -43,6 +43,7 @@ func init() {
 var vpnListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
+	Long:  "List vpn servers from service discovery\n http://sd.skycoin.com/api/services?type=vpn\n http://sd.skycoin.com/api/services?type=vpn&country=US",
 	Run: func(cmd *cobra.Command, args []string) {
 		if pk != "" {
 			err := pubkey.Set(pk)

--- a/cmd/skywire-cli/internal/internal.go
+++ b/cmd/skywire-cli/internal/internal.go
@@ -42,9 +42,14 @@ func PrintFatalError(cmdFlags *pflag.FlagSet, err error) {
 	log.Fatal(err)
 }
 
-// PrintFatalRPCError prints errors for skywire-cli commands packages
+// PrintFatalRPCError prints fatal RPC errors for skywire-cli commands packages
 func PrintFatalRPCError(cmdFlags *pflag.FlagSet, err error) {
-	PrintFatalError(cmdFlags, fmt.Errorf("Failed to connect; is skywire running?: %v", err))
+	PrintFatalError(cmdFlags, fmt.Errorf("Failed to connect to visor RPC or RPC method not found; is skywire running?: %v", err))
+}
+
+// PrintRPCError prints nonfatal RPC errors for skywire-cli commands packages
+func PrintRPCError(cmdFlags *pflag.FlagSet, err error) {
+	PrintError(cmdFlags, fmt.Errorf("Failed to connect to visor RPC or RPC method not found; is skywire running?: %v", err))
 }
 
 // PrintError prints errors for skywire-cli commands packages

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/orandin/lumberjackrus v1.0.1
 	github.com/pterm/pterm v0.12.49
 	github.com/skycoin/dmsg v1.3.0-rc1.0.20230224131835-1c194ef9791e
-	github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a
+	github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c
 	github.com/skycoin/systray v1.10.0
 	github.com/spf13/pflag v1.0.5
 	github.com/zcalusic/sysinfo v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -544,9 +544,8 @@ github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=
 github.com/skycoin/skycoin v0.27.1/go.mod h1:78nHjQzd8KG0jJJVL/j0xMmrihXi70ti63fh8vXScJw=
+github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c h1:jYHyLwSyRVR/TmT4WWIGAeFX4FawGHA4Gaeic0zX3KI=
 github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c/go.mod h1:X5H+fKC3rD11/sm4t9V2FWy/aet7OdEilaO2Ar3waXY=
-github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a h1:hTqQ+8G/2Y+vd4qXoTbm7gfj+mjil2zDnGSS8i8V4LQ=
-github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a/go.mod h1:X5H+fKC3rD11/sm4t9V2FWy/aet7OdEilaO2Ar3waXY=
 github.com/skycoin/systray v1.10.0 h1:fQZJHMylpVvfmOOTLvUssfyHVDoC8Idx6Ba2BlLEuGg=
 github.com/skycoin/systray v1.10.0/go.mod h1:/i17Eni5GxFiboIZceeamY5LktDSFFRCvd3fBMerQ+4=
 github.com/skycoin/yamux v0.0.0-20200803175205-571ceb89da9f h1:A5dEM1OE9YhN3LciZU9qPjo7fJ46JeHNi3JCroDkK0Y=

--- a/vendor/github.com/skycoin/skywire-utilities/pkg/logging/logger.go
+++ b/vendor/github.com/skycoin/skywire-utilities/pkg/logging/logger.go
@@ -43,7 +43,6 @@ func NewMasterLogger() *MasterLogger {
 				ForceFormatting:    true,
 				DisableColors:      false,
 				ForceColors:        false,
-				TimestampFormat:    "2006-01-02T15:04:05.999999999Z07:00",
 			},
 			Hooks: hooks,
 			Level: logrus.DebugLevel,

--- a/vendor/github.com/skycoin/skywire-utilities/pkg/skyenv/values.go
+++ b/vendor/github.com/skycoin/skywire-utilities/pkg/skyenv/values.go
@@ -11,7 +11,7 @@ const (
 	UptimeTrackerAddr   = "http://ut.skywire.skycoin.com"
 	AddressResolverAddr = "http://ar.skywire.skycoin.com"
 	SetupPK             = "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557"
-	NetworkMonitorPK    = "0380ea88f0ad0aa4d93c330ba5f97aabca1d892190b94db69eee140b549d2817dd,0283bddb4357e2c4de0d470032cd809966aec65ce57e1188143ab32c7b589b38b6,02f4e33b75307267229b0c3d679d08dd23374333f558288cfcb114311a52199358,02090f03cb26c71779b8327067e2e37314d2db3e31dfe4f8f3cdd8e088a98eb7ec"
+	NetworkMonitorPK    = "0380ea88f0ad0aa4d93c330ba5f97aabca1d892190b94db69eee140b549d2817dd"
 )
 
 // Constants for testing deployment.
@@ -24,20 +24,20 @@ const (
 	TestUptimeTrackerAddr   = "http://ut.skywire.dev"
 	TestAddressResolverAddr = "http://ar.skywire.dev"
 	TestSetupPK             = "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
-	TestNetworkMonitorPK    = "0218905f5d9079bab0b62985a05bd162623b193e948e17e7b719133f2c60b92093,0214456f6727b0dffacc3e4a9b331ff9bf7b7d97a9810c213772199f0f7ee59247,0394b6e4bdb50977658013089523cc77a9c3af8d1a1581855b496b9ae3126deea0,027f978ca206f00e052561b82a62e6405763f833779b1693fee9cc3c87caad26be"
+	TestNetworkMonitorPK    = "0218905f5d9079bab0b62985a05bd162623b193e948e17e7b719133f2c60b92093,0218905f5d9079bab0b62985a05bd162623b193e948e17e7b719133f2c60b92093,0394b6e4bdb50977658013089523cc77a9c3af8d1a1581855b496b9ae3126deea0"
 )
 
 // GetStunServers gives back default Stun Servers
 func GetStunServers() []string {
 	return []string{
-		"139.162.12.30:3478",
-		"170.187.228.181:3478",
-		"172.104.161.184:3478",
-		"170.187.231.137:3478",
-		"143.42.74.91:3478",
-		"170.187.225.78:3478",
-		"143.42.78.123:3478",
-		"139.162.12.244:3478",
+		"192.46.224.108:3478",
+		"139.177.185.210:3478",
+		"139.162.17.54:3478",
+		"139.162.17.107:3478",
+		"139.162.17.156:3478",
+		"45.118.134.168:3478",
+		"139.177.185.180:3478",
+		"139.162.17.48:3478",
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -278,7 +278,7 @@ github.com/skycoin/skycoin/src/cipher/ripemd160
 github.com/skycoin/skycoin/src/cipher/secp256k1-go
 github.com/skycoin/skycoin/src/cipher/secp256k1-go/secp256k1-go2
 github.com/skycoin/skycoin/src/util/logging
-# github.com/skycoin/skywire-utilities v0.0.0-20230315234948-7c62dc34c53a
+# github.com/skycoin/skywire-utilities v0.0.0-20230110132024-c5536ba8e22c
 ## explicit; go 1.17
 github.com/skycoin/skywire-utilities/pkg/buildinfo
 github.com/skycoin/skywire-utilities/pkg/cipher


### PR DESCRIPTION
Changes:

* manually removed skywire-utilities from go.mod, then ran `go mod tidy ; go mod vendor` to add it back and update skywire-utilities to the latest commits.

Fixes #1543

![image](https://github.com/skycoin/skywire/assets/36607567/c5b03cf7-ef0c-4717-9b1a-4e8d710ca455)


```
[user@linux skywire]$ go run cmd/*/*cli.go proxy list -n10
02cb4a91b599daac8b86c897fd1f273a40a4e52c98216ae34a42d84380aec7ae34:3 | HK
02aa4893366f4629a91f5f763061feb8e204e4835001c90f4e3393dabbe90e42e4:3 | ID
02a47adc3fd737aa80444fdb7958f1926e3ce878b86218c3b4cec92e2b130f5b55:3 | ID
021d56f4e398eda6b17f3b281d6ffacd702d3f41e0cc3a803ab40c128c27a65479:3 | ID
032ee2c686fef36f89745d8bf5fbaec260707e836c9eff5a2d59859227c551a4ab:3 | ID
02834489bfd832fc00b8e299202b3b33da3f70abbb6975571b5554b14dc99d898d:3 | ID
03cff3eebafd307d0a302308c7f85af2292e1cc310e4157f17086f80ef38734496:3 | ID
03585b9ebfe6d5cd41078a56bea003b8bb577d98eef2b4b220af90ec05277b8a7f:3 | US
02a143bec57860fb3e379276e986910cb3a8d46f9415008f958923639ce9bbed8d:3 | ID
02c3067bce0edde054f03c019632c10e662b9a95c5bc712ea9296f8545300f8d3a:3 | ID
[user@linux skywire]$ go run cmd/*/*cli.go vpn list -n10
03676bc54270d7dca85ccc3248f6a26595319805e3b7ec3f9f615186b7602d0852:44 | ID
020d18ace3964b262f2b8235fe539ea933eaa62b4b9bdc1ef2ed7fc374b04abb1c:44 | ID
02d5e670934b354c6bbbe78ab44baf631ca1f3f951b0a8ba2f6e2907feb3367c58:44 | SG
037c16c5b90a8f07813ffb455a14c340284ce21a0af2432c9955eb5626c96bc3b5:44 | ID
03b13ac4fed2ca5d732e9ad11bd5005d9b2bd358321845b715ff2168238235e6c4:44 | CA
0264d39990f6104b862862c09838f099f592d5494b721eeaea4a953e012eef46c5:44 | ID
027f929f89625037bc0be9a584c6c2d1e64499a5f9249d6c860d04cb13f163cae2:44 | IT
03265333ee78efad8ff03a8078cc417487751c5149c99a37d8af634aa73b8858a0:44 | ID
0338dad3035a7634887a65b955e4f7e3a5708ef4b9632f52e4c59b633a176ba0f8:44 | ID
024bfe6fa8753469661fe80941d619f649a2a466ff1a5b1acb14bacb4cd6b648be:44 | ID

```