### PR TITLE
`make config` directive & Makefile optimizations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
       - name: Install Requirements
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
-          make -j8 dep
+          make dep
           chmod +x ./ci_scripts/create-ip-aliases.sh
           ./ci_scripts/create-ip-aliases.sh
         shell: bash
       - name: Checking Format and Testing
-        run: make -j8 check
+        run: make check
       - name: Build
-        run: make -j8 build
+        run: make build
 
   darwin:
     runs-on: macos-latest
@@ -35,9 +35,9 @@ jobs:
           ./ci_scripts/create-ip-aliases.sh
         shell: bash
       - name: Checking Format and Testing
-        run: make -j8 check
+        run: make check
       - name: Build
-        run: make -j8 build
+        run: make build
 
   windows:
     runs-on: windows-latest
@@ -50,10 +50,10 @@ jobs:
         run: |
           choco install make
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
-          make -j8 dep
+          make dep
       - name: Testing
         run:  |
           set GO111MODULE=on
-          make -j8 test-windows
+          make test-windows
       - name: Build
-        run: make -j8 build-windows
+        run: make build-windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ jobs:
       - name: Install Requirements
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
-          make dep
+          make -j8 dep
           chmod +x ./ci_scripts/create-ip-aliases.sh
           ./ci_scripts/create-ip-aliases.sh
         shell: bash
       - name: Checking Format and Testing
-        run: make check
+        run: make -j8 check
       - name: Build
-        run: make build
-  
+        run: make -j8 build
+
   darwin:
     runs-on: macos-latest
     steps:
@@ -35,10 +35,10 @@ jobs:
           ./ci_scripts/create-ip-aliases.sh
         shell: bash
       - name: Checking Format and Testing
-        run: make check
+        run: make -j8 check
       - name: Build
-        run: make build
-  
+        run: make -j8 build
+
   windows:
     runs-on: windows-latest
     steps:
@@ -50,10 +50,10 @@ jobs:
         run: |
           choco install make
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
-          make dep
+          make -j8 dep
       - name: Testing
         run:  |
           set GO111MODULE=on
-          make test-windows
+          make -j8 test-windows
       - name: Build
-        run: make build-windows
+        run: make -j8 build-windows

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,6 @@ check-windows: lint-windows test-windows ## Run linters and tests on appveyor wi
 
 build: host-apps bin ## Install dependencies, build apps and binaries. `go build` with ${OPTS}
 
-build1: BUILD_PATH = ./
-
-build1: build ## Install dependencies, build apps and binaries in root folder. `go build` with ${OPTS}
-
 build-windows: host-apps-windows bin-windows ## Install dependencies, build apps and binaries. `go build` with ${OPTS}
 
 build-windows-appveyor: host-apps-windows-appveyor bin-windows-appveyor ## Install dependencies, build apps and binaries. `go build` with ${OPTS} for AppVeyor image
@@ -120,23 +116,18 @@ build-example: host-apps example-apps bin ## Build apps, example apps and binari
 installer: mac-installer ## Builds MacOS installer for skywire-visor
 
 install-system-linux: build ## Install apps and binaries over those provided by the linux package - linux package must be installed first!
-	sudo install -Dm755 $(BUILD_PATH)skywire-cli /opt/skywire/bin/
-	sudo install -Dm755 $(BUILD_PATH)skywire-visor /opt/skywire/bin/
-	sudo install -Dm755 $(BUILD_PATH)apps/vpn-server /opt/skywire/apps/
-	sudo install -Dm755 $(BUILD_PATH)apps/vpn-client /opt/skywire/apps/
-	sudo install -Dm755 $(BUILD_PATH)apps/skysocks-client /opt/skywire/apps/
-	sudo install -Dm755 $(BUILD_PATH)apps/skysocks /opt/skywire/apps/
-	sudo install -Dm755 $(BUILD_PATH)apps/skychat /opt/skywire/apps/
+	sudo echo "sudo cache"
+	sudo install -Dm755 $(BUILD_PATH){skywire-cli,skywire-visor} /opt/skywire/bin/ & \
+	sudo install -Dm755 $(BUILD_PATH)apps/{vpn-server,vpn-client,skysocks-client,skysocks,skychat} /opt/skywire/apps/
 
 install-generate: ## Installs required execs for go generate.
-	${OPTS} go install github.com/mjibson/esc
-	${OPTS} go install github.com/vektra/mockery/v2@latest
+	${OPTS} go install github.com/mjibson/esc github.com/vektra/mockery/v2@latest
 
 generate: ## Generate mocks and config README's
 	go generate ./...
 
 clean: ## Clean project: remove created binaries and apps
-	-rm -f ./build
+	-rm -rf ./build
 
 clean-windows: ## Clean project: remove created binaries and apps
 	powershell -Command Remove-Item -Path ./build -Force -Recurse
@@ -164,28 +155,25 @@ lint-appveyor-windows: ## Run linters for appveyor only on windows
 
 test: ## Run tests
 	-go clean -testcache &>/dev/null
-	${OPTS} go test ${TEST_OPTS} ./internal/...
-	${OPTS} go test ${TEST_OPTS} ./pkg/...
+	${OPTS} go test ${TEST_OPTS} ./internal/... ./pkg/...
+	${OPTS} go test ${TEST_OPTS}
 
 test-windows: ## Run tests on windows
 	@go clean -testcache
-	${OPTS} go test ${TEST_OPTS} ./internal/...
-	${OPTS} go test ${TEST_OPTS} ./pkg/...
+	${OPTS} go test ${TEST_OPTS} ./internal/... ./pkg/...
 
 install-linters: ## Install linters
 	- VERSION=latest ./ci_scripts/install-golangci-lint.sh
-	${OPTS} go install golang.org/x/tools/cmd/goimports@latest
-	${OPTS} go install github.com/incu6us/goimports-reviser/v2@latest
+	${OPTS} go install golang.org/x/tools/cmd/goimports@latest github.com/incu6us/goimports-reviser/v2@latest
 
 install-linters-windows: ## Install linters
-	${OPTS} go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	${OPTS} go install golang.org/x/tools/cmd/goimports@latest
+	${OPTS} go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest golang.org/x/tools/cmd/goimports@latest
 
 tidy: ## Tidies and vendors dependencies.
 	${OPTS} go mod tidy -v
 
 format: tidy ## Formats the code. Must have goimports and goimports-reviser installed (use make install-linters).
-	${OPTS} goimports -w -local ${PROJECT_BASE} ./pkg & ${OPTS} goimports -w -local ${PROJECT_BASE} ./cmd &	${OPTS} goimports -w -local ${PROJECT_BASE} ./internal
+	${OPTS} goimports -w -local ${PROJECT_BASE} ./pkg ./cmd ./internal
 	find . -type f -name '*.go' -not -path "./.git/*" -not -path "./vendor/*"  -exec goimports-reviser -project-name ${PROJECT_BASE} {} \;
 
 format-windows: tidy ## Formats the code. Must have goimports and goimports-reviser installed (use make install-linters).
@@ -206,15 +194,10 @@ snapshot-clean: ## Cleans snapshot / release
 host-apps: ## Build app
 	test -d $(BUILD_PATH) && rm -r $(BUILD_PATH) || true
 	mkdir -p $(BUILD_PATH)apps
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./cmd/apps/skychat
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks-client
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-server
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-client
+	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./cmd/apps/...
 
 example-apps: ## Build example apps
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./example/example-client-app
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./example/example-server-app
+	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH)apps/ ./example/...
 
 host-apps-windows: ## build apps on windows
 	powershell -Command new-item .\apps -itemtype directory -force
@@ -228,37 +211,23 @@ host-apps-windows-appveyor: ## build apps on windows. `go build` with ${OPTS} fo
 host-apps-static: ## Build app
 	test -d apps && rm -r apps || true
 	mkdir -p ./apps
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)apps/ ./cmd/apps/skychat
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks-client
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-server
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-client
+	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)apps/ ./cmd/apps/...
 
 host-apps-deploy: ## Build app
 	test -d apps && rm -r apps || true
 	mkdir -p ./apps
-	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o $(BUILD_PATH)apps/ ./cmd/apps/skychat
-	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks
-	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks-client
-	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-server
-	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-client
+	${OPTS} go build ${BUILD_OPTS_DEPLOY} -o $(BUILD_PATH)apps/ ./cmd/apps/...
 
 host-apps-race: ## Build app
 	test -d apps && rm -r apps || true
 	mkdir -p ./apps
-	CGO_ENABLED=1${OPTS} go build ${BUILD_OPTS} -race -o $(BUILD_PATH)apps/ ./cmd/apps/skychat
-	CGO_ENABLED=1${OPTS} go build ${BUILD_OPTS} -race -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks
-	CGO_ENABLED=1${OPTS} go build ${BUILD_OPTS} -race -o $(BUILD_PATH)apps/ ./cmd/apps/skysocks-client
-	CGO_ENABLED=1${OPTS} go build ${BUILD_OPTS} -race -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-server
-	CGO_ENABLED=1${OPTS} go build ${BUILD_OPTS} -race -o $(BUILD_PATH)apps/ ./cmd/apps/vpn-client
+	CGO_ENABLED=1${OPTS} go build ${BUILD_OPTS} -race -o $(BUILD_PATH)apps/ ./cmd/apps/...
 
 # Bin
 bin: fix-systray-vendor bin-fix unfix-systray-vendor
 
 bin-fix: ## Build `skywire-visor`, `skywire-cli`
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH) ./cmd/skywire-visor
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH) ./cmd/skywire-cli
-	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH) ./cmd/setup-node
+	${OPTS} go build ${BUILD_OPTS} -o $(BUILD_PATH) ./cmd/skywire-visor ./cmd/skywire-cli ./cmd/setup-node
 
 fix-systray-vendor:
 	@if [ $(UNAME_S) = "Linux" ]; then\
@@ -278,15 +247,12 @@ bin-windows-appveyor: ## Build `skywire-visor`, `skywire-cli`
 
 # Static Bin
 bin-static: ## Build `skywire-visor`, `skywire-cli`
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)skywire-visor ./cmd/skywire-visor
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)skywire-cli  ./cmd/skywire-cli
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)setup-node ./cmd/setup-node
+	${STATIC_OPTS} go build 8 -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH) ./cmd/skywire-visor ./cmd/skywire-cli ./cmd/setup-node
 
 # Static Bin without Systray
 bin-static-wos: ## Build `skywire-visor`, `skywire-cli`
 	${STATIC_OPTS} go build -tags withoutsystray -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)skywire-visor ./cmd/skywire-visor
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)skywire-cli  ./cmd/skywire-cli
-	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)setup-node ./cmd/setup-node
+	${STATIC_OPTS} go build -trimpath --ldflags '-linkmode external -extldflags "-static" -buildid=' -o $(BUILD_PATH)  ./cmd/skywire-cli ./cmd/setup-node
 
 build-deploy: host-apps-deploy ## Build for deployment Docker images
 	${OPTS} go build -tags netgo ${BUILD_OPTS_DEPLOY} -o /release/skywire-visor ./cmd/skywire-visor
@@ -344,6 +310,9 @@ build-docker: ## Build docker image
 install-deps-ui:  ## Install the UI dependencies
 	cd $(MANAGER_UI_DIR) && npm ci
 
+config: ## Create or regenerate a config with correct default app bin_path for `make build`
+	$(BUILD_PATH)skywire-cli config gen -irx --binpath $(BUILD_PATH)apps
+
 run: ## Run skywire visor with skywire-config.json, and start a browser if running a hypervisor
 	$(BUILD_PATH)skywire-visor -bc ./skywire-config.json
 
@@ -365,7 +334,6 @@ run-source: prepare ## Run skywire from source, without compiling binaries
 run-systray: prepare ## Run skywire from source, with vpn server enabled
 	go run ./cmd/skywire-cli/skywire-cli.go config gen -ni | sudo go run ./cmd/skywire-visor/skywire-visor.go -n --systray || true
 
-
 run-vpnsrv: prepare ## Run skywire from source, without compiling binaries
 	go run ./cmd/skywire-cli/skywire-cli.go config gen -in --servevpn | sudo go run ./cmd/skywire-visor/skywire-visor.go -n || true
 
@@ -376,19 +344,19 @@ run-vpnsrv-test: prepare ## Run skywire from source, with vpn server enabled
 	go run ./cmd/skywire-cli/skywire-cli.go config gen -nit --servevpn | sudo go run ./cmd/skywire-visor/skywire-visor.go -n || true
 
 run-systray-test: prepare ## Run skywire from source, with vpn server enabled
-	go run ./cmd/skywire-cli/skywire-cli.go config gen -nit | sudo go run ./cmd/skywire-visor/skywire-visor.go --systray -nb || true
+	go run ./cmd/skywire-cli/skywire-cli.go config gen -nit | sudo go run ./cmd/skywire-visor/skywire-visor.go --systray -n || true
 
 run-source-dmsghttp: prepare ## Run skywire from source with dmsghttp config
-	go run ./cmd/skywire-cli/skywire-cli.go config gen -din | sudo go run ./cmd/skywire-visor/skywire-visor.go -nb || true
+	go run ./cmd/skywire-cli/skywire-cli.go config gen -din | sudo go run ./cmd/skywire-visor/skywire-visor.go -n || true
 
 run-vpnsrv-dmsghttp: prepare ## Run skywire from source with dmsghttp config and vpn server
-	go run ./cmd/skywire-cli/skywire-cli.go config gen -din --servevpn | sudo go run ./cmd/skywire-visor/skywire-visor.go -nb || true
+	go run ./cmd/skywire-cli/skywire-cli.go config gen -din --servevpn | sudo go run ./cmd/skywire-visor/skywire-visor.go -n || true
 
 run-source-dmsghttp-test: prepare ## Run skywire from source with dmsghttp config and test endpoints
-	go run ./cmd/skywire-cli/skywire-cli.go config gen -dint | sudo go run ./cmd/skywire-visor/skywire-visor.go -nb || true
+	go run ./cmd/skywire-cli/skywire-cli.go config gen -dint | sudo go run ./cmd/skywire-visor/skywire-visor.go -n || true
 
 run-vpnsrv-dmsghttp-test: prepare ## Run skywire from source with dmsghttp config, vpn server, and test endpoints
-	go run ./cmd/skywire-cli/skywire-cli.go config gen -dint --servevpn | sudo go run ./cmd/skywire-visor/skywire-visor.go -nb || true
+	go run ./cmd/skywire-cli/skywire-cli.go config gen -dint --servevpn | sudo go run ./cmd/skywire-visor/skywire-visor.go -n || true
 
 lint-ui:  ## Lint the UI code
 	cd $(MANAGER_UI_DIR) && npm run lint
@@ -405,16 +373,6 @@ build-ui-windows: install-deps-ui ## Builds the UI on windows
 	powershell 'Remove-Item -Recurse -Force -Path ${MANAGER_UI_BUILT_DIR}'
 	powershell 'New-Item -Path ${MANAGER_UI_BUILT_DIR} -ItemType Directory'
 	powershell 'Copy-Item -Recurse ${MANAGER_UI_DIR}\dist\* ${MANAGER_UI_BUILT_DIR}'
-
-deb-install-prequisites: ## Create unsigned application
-	sudo chmod +x ./scripts/deb_installer/prequisites.sh
-	./scripts/deb_installer/prequisites.sh
-
-deb-package: deb-install-prequisites ## Create unsigned application
-	./scripts/deb_installer/package_deb.sh
-
-deb-package-help: ## Show installer creation help
-	./scripts/deb_installer/package_deb.sh -h
 
 mac-installer: ## Create unsigned and not-notarized application, run make mac-installer-help for more
 	./scripts/mac_installer/create_installer.sh


### PR DESCRIPTION
Fixes #1547 

 Changes:	
-	Adds `config` directive to generate or update a config in the current dir with a bin_path at `./build/apps` which matches the path the apps will be created at via `make build`
- Removes redundant invocations of commands which will work from a single invocation
- adds `make -j8` to the test workflow for github-actions to parallelize the tests and building via `make check` and `make build`