### PR TITLE
Dmsgpty whitelist

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1302,11 +1302,16 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	wl := dmsgpty.NewMemoryWhitelist()
 
+	// Initialize the dmsgpty whitelist
+	if err := wl.Add(v.conf.Dmsgpty.Whitelist...); err != nil {
+		return err
+	}
+
 	// Ensure hypervisors are added to the whitelist.
 	if err := wl.Add(v.conf.Hypervisors...); err != nil {
 		return err
 	}
-	// add itself to the whitelist to allow local pty
+	// add the visor's own public key to the whitelist to allow local pty
 	if err := wl.Add(v.conf.PK); err != nil {
 		v.log.Errorf("Cannot add itself to the pty whitelist: %s", err)
 	}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -44,9 +44,10 @@ type V1 struct {
 
 // Dmsgpty configures the dmsgpty-host.
 type Dmsgpty struct {
-	DmsgPort uint16 `json:"dmsg_port"`
-	CLINet   string `json:"cli_network"`
-	CLIAddr  string `json:"cli_address"`
+	DmsgPort  uint16          `json:"dmsg_port"`
+	CLINet    string          `json:"cli_network"`
+	CLIAddr   string          `json:"cli_address"`
+	Whitelist []cipher.PubKey `json:"whitelist"`
 }
 
 // Transport defines a transport config.


### PR DESCRIPTION
Fixes: #1542

The dmsgpty-host whitelist was, until now, only whitelisting the hypervisor ; which is always being dialed and having the rpc served to regardless of the availability or online state of the hypervisor.

By integrating the existing dmsgpty-host whitelist into the visor's config, and adding public keys to the whitelist, it allows for pseudo-terminal (pty) access over dmsg which is explicitly configurable, and avoid constant attempts by the visor to serve rpc to the hypervisor instance.

It should be noted that in having pty access, the rpc of the remote visor may be accessed through the pty via skywire-cli on the remote visor. This is a sufficient substitute for the hypervisor ui interface, in many cases.