### PR TITLE
Survey collection whitelist

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -388,7 +388,7 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, log *logging.Logger) e
 		printLog = true
 	}
 
-	lsAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, v.conf.DmsgHTTPServerPath, printLog)
+	lsAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, v.conf.DmsgHTTPServerPath, v.conf.SurveyWhitelist, v.conf.Hypervisors, printLog)
 
 	lis, err := dmsgC.Listen(visorconfig.DmsgHTTPPort)
 	if err != nil {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1302,11 +1302,16 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	wl := dmsgpty.NewMemoryWhitelist()
 
+	// Initialize the dmsgpty whitelist
+	if err := wl.Add(v.conf.Dmsgpty.Whitelist...); err != nil {
+		return err
+	}
+
 	// Ensure hypervisors are added to the whitelist.
 	if err := wl.Add(v.conf.Hypervisors...); err != nil {
 		return err
 	}
-	// add itself to the whitelist to allow local pty
+	// add the visor's own public key to the whitelist to allow local pty
 	if err := wl.Add(v.conf.PK); err != nil {
 		v.log.Errorf("Cannot add itself to the pty whitelist: %s", err)
 	}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -388,7 +388,13 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, log *logging.Logger) e
 		printLog = true
 	}
 
-	lsAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, v.conf.DmsgHTTPServerPath, v.conf.SurveyWhitelist, v.conf.Hypervisors, printLog)
+	//whitelist access to the surveys for the hypervisor, dmsggpty whitelist, and for the surveywhitelist of keys which is fetched from the conf service
+	var whitelistedPKs []cipher.PubKey
+	whitelistedPKs = append(whitelistedPKs, v.conf.SurveyWhitelist...)
+	whitelistedPKs = append(whitelistedPKs, v.conf.Hypervisors...)
+	whitelistedPKs = append(whitelistedPKs, v.conf.Dmsgpty.Whitelist...)
+
+	lsAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, v.conf.DmsgHTTPServerPath, whitelistedPKs, printLog)
 
 	lis, err := dmsgC.Listen(visorconfig.DmsgHTTPPort)
 	if err != nil {

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -3,7 +3,13 @@ package logserver
 
 import (
 	"encoding/json"
+	"log"
+	"mime"
+	"net"
 	"net/http"
+	"os"
+	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -11,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/httputil"
 	"github.com/skycoin/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -26,7 +33,7 @@ type API struct {
 }
 
 // New creates a new api.
-func New(log *logging.Logger, tpLogPath, localPath, customPath string, printLog bool) *API {
+func New(log *logging.Logger, tpLogPath, localPath, customPath string, surveyWhitelist []cpher.PubKey, hypervisors []cpher.PubKey, printLog bool) *API {
 	api := &API{
 		logger:    log,
 		startedAt: time.Now(),
@@ -49,7 +56,6 @@ func New(log *logging.Logger, tpLogPath, localPath, customPath string, printLog 
 
 	fsLocal := http.FileServer(http.Dir(localPath))
 	r.Handle("/"+skyenv.NodeInfo, http.StripPrefix("/", fsLocal))
-	r.Handle("/"+skyenv.RewardFile, http.StripPrefix("/", fsLocal))
 	r.Handle("/transport_logs/*", http.StripPrefix("/", fsLocal))
 
 	fsCustom := http.FileServer(http.Dir(customPath))
@@ -87,4 +93,50 @@ func (api *API) writeJSON(w http.ResponseWriter, r *http.Request, code int, obje
 
 func (api *API) log(r *http.Request) logrus.FieldLogger {
 	return httputil.GetLogger(r)
+}
+
+func fileServerHandler(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	// Get the remote PK.
+	remotePK, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	// Check if the remote PK is whitelisted.
+	whitelisted := false
+	if len(wlkeys) == 0 {
+		whitelisted = true
+	} else {
+		for _, pk2 := range wlkeys {
+			if remotePK == pk2.String() {
+				whitelisted = true
+				break
+			}
+		}
+	}
+	// If the remote PK is whitelisted, serve the file.
+	if whitelisted {
+		filePath := serveDir + r.URL.Path
+		file, err := os.Open(filePath) //nolint
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		defer file.Close() //nolint
+
+		_, filename := path.Split(filePath)
+		w.Header().Set("Content-Type", mime.TypeByExtension(filepath.Ext(filename)))
+		http.ServeContent(w, r, filename, time.Time{}, file)
+
+		// Log the response status and time taken.
+		elapsed := time.Since(start)
+		log.Printf("[DMSGHTTP] %s %s | %d | %v | %s | %s %s\n", start.Format("2006/01/02 - 15:04:05"), r.RemoteAddr, http.StatusOK, elapsed, r.Method, r.Proto, r.URL)
+		return
+	}
+	// Otherwise, return a 403 Forbidden error.
+	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+	// Log the response status and time taken.
+	elapsed := time.Since(start)
+	log.Printf("[DMSGHTTP] %s %s | %d | %v | %s | %s %s\n", start.Format("2006/01/02 - 15:04:05"), r.RemoteAddr, http.StatusForbidden, elapsed, r.Method, r.Proto, r.URL)
 }

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -111,8 +111,8 @@ func whitelistFSHandler(w http.ResponseWriter, r *http.Request, serveDir string,
 	if len(whitelistedPKs) == 0 {
 		whitelisted = true
 	} else {
-		for _, pk2 := range whitelistedPKs {
-			if remotePK == pk2.String() {
+		for _, whitelistedPK := range whitelistedPKs {
+			if remotePK == whitelistedPK.String() {
 				whitelisted = true
 				break
 			}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -27,7 +27,7 @@ type V1 struct {
 	UptimeTracker *UptimeTracker      `json:"uptime_tracker,omitempty"`
 	Launcher      *Launcher           `json:"launcher"`
 
-	SurveyWhitelist []cipher.PubKey `json:"hypervisors"`
+	SurveyWhitelist []cipher.PubKey `json:"survey_whitelist"`
 	Hypervisors     []cipher.PubKey `json:"hypervisors"`
 	CLIAddr         string          `json:"cli_addr"`
 

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -27,8 +27,9 @@ type V1 struct {
 	UptimeTracker *UptimeTracker      `json:"uptime_tracker,omitempty"`
 	Launcher      *Launcher           `json:"launcher"`
 
-	Hypervisors []cipher.PubKey `json:"hypervisors"`
-	CLIAddr     string          `json:"cli_addr"`
+	SurveyWhitelist []cipher.PubKey `json:"hypervisors"`
+	Hypervisors     []cipher.PubKey `json:"hypervisors"`
+	CLIAddr         string          `json:"cli_addr"`
 
 	LogLevel             string                           `json:"log_level"`
 	LocalPath            string                           `json:"local_path"`

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -44,9 +44,10 @@ type V1 struct {
 
 // Dmsgpty configures the dmsgpty-host.
 type Dmsgpty struct {
-	DmsgPort uint16 `json:"dmsg_port"`
-	CLINet   string `json:"cli_network"`
-	CLIAddr  string `json:"cli_address"`
+	DmsgPort  uint16          `json:"dmsg_port"`
+	CLINet    string          `json:"cli_network"`
+	CLIAddr   string          `json:"cli_address"`
+	Whitelist []cipher.PubKey `json:"whitelist"`
 }
 
 // Transport defines a transport config.


### PR DESCRIPTION
This PR comprises minor changes which will enable whitelist-based authentication for the dmsghttp log server, specifically and only implemented for the system survey itself (node-info.json)

these changes reflect those in [DMSG PR #219](https://github.com/skycoin/dmsg/pull/219)

* Added `SurveyWhitelist []cipher.PubKey` array to config << **This needs a corresponding change in the conf service to provide the keys we want to whitelist**

The whitelisted keys for survey collection will also always include those keys in the hypervisor field as well as those in the dmsgpty whitelist, so that node operators can also collect the surveys from their visors once they have set either a remote hypervisor or added a key to the dmsgpty whitelist

__Note: It is still necessary to add an api endpoint for the `skywire-cli log` survey & transport log collection to optionally use the visor's public key / existing dmsg client to download the surveys, among other minor changes.__