### PR TITLE
vpn start command

### DIFF
--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -65,7 +65,7 @@ var startCmd = &cobra.Command{
 		err := pubkey.Set(pk)
 		if err != nil {
 			if len(args) > 0 {
-				err := pubkey.Set(args[1])
+				err := pubkey.Set(args[0])
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), err)
 				}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- fix index of array in vpn start command of skywire-cli

How to test this PR:
_