### PR TITLE
Combine `skywire-cli` `skywire-visor` `setup-node` binaries

### DIFF
--- a/cmd/setup-node/commands/root.go
+++ b/cmd/setup-node/commands/root.go
@@ -29,13 +29,13 @@ var (
 )
 
 func init() {
-	rootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
-	rootCmd.Flags().StringVar(&syslogAddr, "syslog", "", "syslog server address. E.g. localhost:514")
-	rootCmd.Flags().StringVar(&tag, "tag", "setup_node", "logging tag")
-	rootCmd.Flags().BoolVarP(&cfgFromStdin, "stdin", "i", false, "read config from STDIN")
+	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
+	RootCmd.Flags().StringVar(&syslogAddr, "syslog", "", "syslog server address. E.g. localhost:514")
+	RootCmd.Flags().StringVar(&tag, "tag", "setup_node", "logging tag")
+	RootCmd.Flags().BoolVarP(&cfgFromStdin, "stdin", "i", false, "read config from STDIN")
 }
 
-var rootCmd = &cobra.Command{
+var RootCmd = &cobra.Command{
 	Use:   "setup-node [config.json]",
 	Short: "Route Setup Node for skywire",
 	Long: `
@@ -124,7 +124,7 @@ func prepareMetrics(log logrus.FieldLogger) setupmetrics.Metrics {
 // Execute executes root CLI command.
 func Execute() {
 	cc.Init(&cc.Config{
-		RootCmd:         rootCmd,
+		RootCmd:         RootCmd,
 		Headings:        cc.HiBlue + cc.Bold,
 		Commands:        cc.HiBlue + cc.Bold,
 		CmdShortDescr:   cc.HiBlue,
@@ -136,7 +136,7 @@ func Execute() {
 		NoExtraNewlines: true,
 		NoBottomNewline: true,
 	})
-	if err := rootCmd.Execute(); err != nil {
+	if err := RootCmd.Execute(); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/setup-node/commands/root.go
+++ b/cmd/setup-node/commands/root.go
@@ -35,6 +35,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&cfgFromStdin, "stdin", "i", false, "read config from STDIN")
 }
 
+// RootCmd is the root command for setup node
 var RootCmd = &cobra.Command{
 	Use:   "setup-node [config.json]",
 	Short: "Route Setup Node for skywire",

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -30,7 +30,7 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
-//RootCmd is the root command for skywire-cli
+// RootCmd is the root command for skywire-cli
 var RootCmd = &cobra.Command{
 	Use:   "cli",
 	Short: "Command Line Interface for skywire",

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -30,8 +30,8 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "skywire-cli",
+var RootCmd = &cobra.Command{
+	Use:   "cli",
 	Short: "Command Line Interface for skywire",
 	Long: `
 	┌─┐┬┌─┬ ┬┬ ┬┬┬─┐┌─┐  ┌─┐┬  ┬
@@ -55,8 +55,8 @@ var treeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// You can use a LeveledList here, for easy generation.
 		leveledList := pterm.LeveledList{}
-		leveledList = append(leveledList, pterm.LeveledListItem{Level: 0, Text: rootCmd.Use})
-		for _, j := range rootCmd.Commands() {
+		leveledList = append(leveledList, pterm.LeveledListItem{Level: 0, Text: RootCmd.Use})
+		for _, j := range RootCmd.Commands() {
 			use := strings.Split(j.Use, " ")
 			leveledList = append(leveledList, pterm.LeveledListItem{Level: 1, Text: use[0]})
 			for _, k := range j.Commands() {
@@ -112,9 +112,9 @@ var docCmd = &cobra.Command{
 		fmt.Printf("\n# %s\n", "skywire-cli documentation")
 		fmt.Printf("\n%s\n", "skywire command line interface")
 
-		fmt.Printf("\n## %s\n", rootCmd.Use)
+		fmt.Printf("\n## %s\n", RootCmd.Use)
 		fmt.Printf("\n```\n")
-		rootCmd.Help() //nolint
+		RootCmd.Help() //nolint
 		fmt.Printf("\n```\n")
 		fmt.Printf("\n## %s\n", "global flags")
 		fmt.Printf("\n%s\n", "The skywire-cli interacts with the running visor via rpc calls. By default the rpc server is available on localhost:3435. The rpc address and port the visor is using may be changed in the config file, once generated.")
@@ -133,7 +133,7 @@ var docCmd = &cobra.Command{
 		fmt.Printf("\n```\n")
 
 		var use string
-		for _, j := range rootCmd.Commands() {
+		for _, j := range RootCmd.Commands() {
 			use = strings.Split(j.Use, " ")[0]
 			fmt.Printf("\n### %s\n", use)
 			fmt.Printf("\n```\n")
@@ -177,7 +177,7 @@ var docCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(
+	RootCmd.AddCommand(
 		cliconfig.RootCmd,
 		clidmsgpty.RootCmd,
 		clivisor.RootCmd,
@@ -196,19 +196,19 @@ func init() {
 		docCmd,
 	)
 	var jsonOutput bool
-	rootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
-	rootCmd.PersistentFlags().MarkHidden(internal.JSONString) //nolint
+	RootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
+	RootCmd.PersistentFlags().MarkHidden(internal.JSONString) //nolint
 	var helpflag bool
-	rootCmd.SetUsageTemplate(help)
-	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
-	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	rootCmd.PersistentFlags().MarkHidden("help") //nolint
+	RootCmd.SetUsageTemplate(help)
+	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+RootCmd.Use)
+	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	RootCmd.PersistentFlags().MarkHidden("help") //nolint
 }
 
 // Execute executes root CLI command.
 func Execute() {
 	cc.Init(&cc.Config{
-		RootCmd:       rootCmd,
+		RootCmd:       RootCmd,
 		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
 		Commands:      cc.HiBlue + cc.Bold,
 		CmdShortDescr: cc.HiBlue,
@@ -220,7 +220,7 @@ func Execute() {
 		NoExtraNewlines: true,
 		NoBottomNewline: true,
 	})
-	if err := rootCmd.Execute(); err != nil {
+	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}
 }

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
+//RootCmd is the root command for skywire-cli
 var RootCmd = &cobra.Command{
 	Use:   "cli",
 	Short: "Command Line Interface for skywire",

--- a/cmd/skywire-visor/skywire-visor.go
+++ b/cmd/skywire-visor/skywire-visor.go
@@ -1,6 +1,6 @@
-// /* cmd/skywire-visor/skywire-visor.go
+// /* cmd/skywire/skywire.go
 /*
-skywire visor
+skywire
 */
 package main
 

--- a/cmd/skywire/skywire.go
+++ b/cmd/skywire/skywire.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
-
 	cc "github.com/ivanpirog/coloredcobra"
 
 	"github.com/skycoin/skywire/pkg/visor"
   skywirecli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
+	setupnode "github.com/skycoin/skywire/cmd/setup-node/commands"
 
 )
 
@@ -20,6 +20,7 @@ func init() {
 	rootCmd.AddCommand(
 		visor.RootCmd,
 		skywirecli.RootCmd,
+		setupnode.RootCmd,
 	)
 	var helpflag bool
 	rootCmd.SetUsageTemplate(help)
@@ -63,9 +64,8 @@ func main() {
 		fmt.Println(err)
 	}
 }
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+const help = "{{if gt (len .Aliases) 0}}" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}" +
 	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
 	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
 	"Flags:\r\n" +

--- a/cmd/skywire/skywire.go
+++ b/cmd/skywire/skywire.go
@@ -1,0 +1,74 @@
+// /* cmd/skywire-visor/skywire-visor.go
+/*
+skywire visor
+*/
+package main
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+
+	cc "github.com/ivanpirog/coloredcobra"
+
+	"github.com/skycoin/skywire/pkg/visor"
+  skywirecli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
+
+)
+
+func init() {
+	rootCmd.AddCommand(
+		visor.RootCmd,
+		skywirecli.RootCmd,
+	)
+	var helpflag bool
+	rootCmd.SetUsageTemplate(help)
+	rootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for "+rootCmd.Use)
+	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	rootCmd.PersistentFlags().MarkHidden("help") //nolint
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+}
+
+
+var rootCmd = &cobra.Command{
+	Use:   "skywire",
+	Long: `
+	┌─┐┬┌─┬ ┬┬ ┬┬┬─┐┌─┐
+	└─┐├┴┐└┬┘││││├┬┘├┤
+	└─┘┴ ┴ ┴ └┴┘┴┴└─└─┘`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+}
+
+
+func main() {
+	cc.Init(&cc.Config{
+		RootCmd:         rootCmd,
+		Headings:        cc.HiBlue + cc.Bold,
+		Commands:        cc.HiBlue + cc.Bold,
+		CmdShortDescr:   cc.HiBlue,
+		Example:         cc.HiBlue + cc.Italic,
+		ExecName:        cc.HiBlue + cc.Bold,
+		Flags:           cc.HiBlue + cc.Bold,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+	}
+}
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/skywire/skywire.go
+++ b/cmd/skywire/skywire.go
@@ -6,14 +6,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+
 	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire/pkg/visor"
-  skywirecli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
+	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	setupnode "github.com/skycoin/skywire/cmd/setup-node/commands"
-
+	skywirecli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
+	"github.com/skycoin/skywire/pkg/visor"
 )
 
 func init() {
@@ -31,9 +31,8 @@ func init() {
 
 }
 
-
 var rootCmd = &cobra.Command{
-	Use:   "skywire",
+	Use: "skywire",
 	Long: `
 	┌─┐┬┌─┬ ┬┬ ┬┬┬─┐┌─┐
 	└─┐├┴┐└┬┘││││├┬┘├┤
@@ -44,7 +43,6 @@ var rootCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Version:               buildinfo.Version(),
 }
-
 
 func main() {
 	cc.Init(&cc.Config{
@@ -64,6 +62,7 @@ func main() {
 		fmt.Println(err)
 	}
 }
+
 const help = "{{if gt (len .Aliases) 0}}" +
 	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}" +
 	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -173,7 +173,7 @@ func trimStringFromDot(s string) string {
 
 // RootCmd contains the help command & invocation flags
 var RootCmd = &cobra.Command{
-	Use:   "skywire-visor",
+	Use:   "visor",
 	Short: "Skywire Visor",
 	Long: `
 	┌─┐┬┌─┬ ┬┬ ┬┬┬─┐┌─┐


### PR DESCRIPTION
Since most of the codebase is shared between these compiled binaries, it makes sense to combine them.

Here are the sizes of the binaries compiled with the standard `go build` command


* 16020kb	setup-node
* 27156kb	skywire-visor
* 28328kb	skywire-cli

The size of the combined single binary

* 28520kb	skywire

![image](https://github.com/skycoin/skywire/assets/36607567/1367f81c-127c-4183-9586-3484178daf41)

This change should have broad implications in terms of speeding up build time, saving bandwidth for distribution of binary releases, and saving cpu power for compression and decompression. The time saved on all of this and more may be significant