### PR TITLE
solve typo issue on state name

### DIFF
--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	stateName    = "vpn-clent"
+	stateName    = "vpn-client"
 	serviceType  = servicedisc.ServiceTypeVPN
 	servicePort  = ":3"
 	path         string


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- fix stateName of vpn-client

How to test this PR:
_