### PR TITLE
Use page state management

### DIFF
--- a/static/skywire-manager-src/src/app/app.component.ts
+++ b/static/skywire-manager-src/src/app/app.component.ts
@@ -48,13 +48,17 @@ export class AppComponent {
     // Close the snackbar when opening a modal window.
     dialog.afterOpened.subscribe(() => snackbarService.closeCurrent());
 
+    // Prevent automatic scroll retoration during navigation.
+    if (history.scrollRestoration) {
+      history.scrollRestoration = 'manual';
+    }
+
     // Scroll to the top after navigating.
     // When navigating, scroll to the top and close the snackbar and all modal windows.
     router.events.subscribe(e => {
       if (e instanceof NavigationEnd) {
         snackbarService.closeCurrent();
         dialog.closeAll();
-        window.scrollTo(0, 0);
       }
     });
 

--- a/static/skywire-manager-src/src/app/components/pages/login/login.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/login/login.component.ts
@@ -12,6 +12,7 @@ import { OperationError } from '../../../utils/operation-error';
 import { processServiceError } from '../../../utils/errors';
 import { AppComponent } from 'src/app/app.component';
 import { MultipleNodeDataService } from 'src/app/services/multiple-node-data.service';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Login page.
@@ -21,7 +22,7 @@ import { MultipleNodeDataService } from 'src/app/services/multiple-node-data.ser
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })
-export class LoginComponent implements OnInit, OnDestroy {
+export class LoginComponent extends PageBaseComponent implements OnInit, OnDestroy {
   form: UntypedFormGroup;
   loading = false;
   isForVpn = false;
@@ -38,7 +39,9 @@ export class LoginComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private route: ActivatedRoute,
     private multipleNodeDataService: MultipleNodeDataService,
-  ) { }
+  ) {
+    super();
+  }
 
   ngOnInit() {
     // Stop multiple requests that will fail for auth.
@@ -57,7 +60,7 @@ export class LoginComponent implements OnInit, OnDestroy {
           setTimeout(() => {
             const destination = !this.isForVpn ? ['nodes'] : ['vpn', this.vpnKey, 'status'];
             this.router.navigate(destination, { replaceUrl: true });
-          });
+          }, 5);
         }
       });
     });
@@ -65,6 +68,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.form = new UntypedFormGroup({
       password: new UntypedFormControl('', Validators.required),
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -23,6 +23,7 @@ import { DataFilterer } from 'src/app/utils/lists/data-filterer';
 import { NodeData, UpdateAllComponent } from '../../layout/update-all/update-all.component';
 import { BulkRewardAddressChangerComponent, BulkRewardAddressParams, NodeToEditData } from '../../layout/bulk-reward-address-changer/bulk-reward-address-changer.component';
 import { MultipleNodeDataService, MultipleNodesBackendData } from 'src/app/services/multiple-node-data.service';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page for showing the node list.
@@ -32,7 +33,10 @@ import { MultipleNodeDataService, MultipleNodesBackendData } from 'src/app/servi
   templateUrl: './node-list.component.html',
   styleUrls: ['./node-list.component.scss'],
 })
-export class NodeListComponent implements OnInit, OnDestroy {
+export class NodeListComponent extends PageBaseComponent implements OnInit, OnDestroy {
+  // Keys for persisting the server data, to be able to restore the state after navigation.
+  private readonly persistentServerDataResponseKey = 'serv-dat-response';
+
   // Small texts for identifying the list, needed for the helper objects.
   private readonly nodesListId = 'nl';
   private readonly dmsgListId = 'dl';
@@ -141,6 +145,8 @@ export class NodeListComponent implements OnInit, OnDestroy {
     private translateService: TranslateService,
     route: ActivatedRoute,
   ) {
+    super();
+
     // Configure the options menu shown in the top bar.
     this.updateOptionsMenu();
 
@@ -265,7 +271,7 @@ export class NodeListComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     // Load the data.
-    this.startGettingData();
+    this.startGettingData(true);
 
     // Procedure to keep updated the variable that indicates how long ago the data was updated.
     this.ngZone.runOutsideAngular(() => {
@@ -274,6 +280,8 @@ export class NodeListComponent implements OnInit, OnDestroy {
           this.secondsSinceLastUpdate = Math.floor((Date.now() - this.lastUpdate) / 1000);
         }));
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {
@@ -364,58 +372,70 @@ export class NodeListComponent implements OnInit, OnDestroy {
   /**
    * Starts getting the data from the backend.
    */
-  private startGettingData() {
-    this.ngZone.runOutsideAngular(() => {
-      // Get the node list.
-      this.dataSubscription = this.multipleNodeDataService.startRequestingData().subscribe((result: MultipleNodesBackendData) => {
-        this.ngZone.run(() => {
-          this.updating = result ? result.updating : true;
+  private startGettingData(checkSavedData: boolean) {
+    // Use saved data or get from the server. If there is no saved data, savedData is null.
+    let savedData = checkSavedData ? this.getLocalValue(this.persistentServerDataResponseKey) : null;
+    let nextOperation: Observable<any> = this.multipleNodeDataService.startRequestingData();
+    if (savedData) {
+      nextOperation = of(JSON.parse(savedData.value));
+    }
 
-          if (result && !result.updating) {
-            // If the data was obtained.
-            if (result.data && !result.error) {
-              this.allNodes = result.data as Node[];
+    // Get the node list.
+    this.dataSubscription = nextOperation.subscribe((result: MultipleNodesBackendData) => {        
+      if (!savedData) {
+        this.saveLocalValue(this.persistentServerDataResponseKey, JSON.stringify(result));
+      }
 
-              if (this.showDmsgInfo) {
-                // Add the label data to the array, to be able to use it for filtering and sorting.
-                this.allNodes.forEach(node => {
-                  node['dmsgServerPk_label'] =
-                    LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, node.dmsgServerPk);
-                });
-              }
-              this.dataFilterer.setData(this.allNodes);
+      this.updating = result ? result.updating : true;
 
-              this.loading = false;
-              // Close any previous temporary loading error msg.
-              this.snackbarService.closeCurrentIfTemporaryError();
+      if (result && !result.updating) {
+        // If the data was obtained.
+        if (result.data && !result.error) {
+          this.allNodes = result.data as Node[];
 
-              this.lastUpdate = result.momentOfLastCorrectUpdate;
-              this.secondsSinceLastUpdate = Math.floor((Date.now() - result.momentOfLastCorrectUpdate) / 1000);
-              this.errorsUpdating = false;
+          if (this.showDmsgInfo) {
+            // Add the label data to the array, to be able to use it for filtering and sorting.
+            this.allNodes.forEach(node => {
+              node['dmsgServerPk_label'] =
+                LabeledElementTextComponent.getCompleteLabel(this.storageService, this.translateService, node.dmsgServerPk);
+            });
+          }
+          this.dataFilterer.setData(this.allNodes);
 
-              if (this.lastUpdateRequestedManually) {
-                // Show a confirmation msg.
-                this.snackbarService.showDone('common.refreshed', null);
-                this.lastUpdateRequestedManually = false;
-              }
+          this.loading = false;
+          // Close any previous temporary loading error msg.
+          this.snackbarService.closeCurrentIfTemporaryError();
 
-            // If there was an error while obtaining the data.
-            } else if (result.error) {
-              // Show an error msg if it has not be done before during the current attempt to obtain the data.
-              if (!this.errorsUpdating) {
-                if (this.loading) {
-                  this.snackbarService.showError('common.loading-error', null, true, result.error);
-                } else {
-                  this.snackbarService.showError('nodes.error-load', null, true, result.error);
-                }
-              }
+          this.lastUpdate = result.momentOfLastCorrectUpdate;
+          this.secondsSinceLastUpdate = Math.floor((Date.now() - result.momentOfLastCorrectUpdate) / 1000);
+          this.errorsUpdating = false;
 
-              // Stop the loading indicator and show a warning icon.
-              this.errorsUpdating = true;
+          if (this.lastUpdateRequestedManually) {
+            // Show a confirmation msg.
+            this.snackbarService.showDone('common.refreshed', null);
+            this.lastUpdateRequestedManually = false;
+          }
+
+        // If there was an error while obtaining the data.
+        } else if (result.error) {
+          // Show an error msg if it has not be done before during the current attempt to obtain the data.
+          if (!this.errorsUpdating) {
+            if (this.loading) {
+              this.snackbarService.showError('common.loading-error', null, true, result.error);
+            } else {
+              this.snackbarService.showError('nodes.error-load', null, true, result.error);
             }
           }
-        });
-      });
+
+          // Stop the loading indicator and show a warning icon.
+          this.errorsUpdating = true;
+        }
+      }
+
+      // If old saved data was used, repeat the operation, ignoring the saved data.
+      if (savedData) {
+        this.startGettingData(false);
+      }
     });
   }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/all-apps/all-apps.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/all-apps/all-apps.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 
 import { Node, Application } from '../../../../../app.datatypes';
 import { NodeComponent } from '../../node.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page for showing the complete list of the apps of a node.
@@ -12,7 +13,7 @@ import { NodeComponent } from '../../node.component';
   templateUrl: './all-apps.component.html',
   styleUrls: ['./all-apps.component.scss']
 })
-export class AllAppsComponent implements OnInit, OnDestroy {
+export class AllAppsComponent extends PageBaseComponent implements OnInit, OnDestroy {
   apps: Application[];
   nodePK: string;
 
@@ -24,6 +25,8 @@ export class AllAppsComponent implements OnInit, OnDestroy {
       this.nodePK = node.localPk;
       this.apps = node.apps;
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/apps.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/apps.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 
 import { Application, Node } from '../../../../app.datatypes';
 import { NodeComponent } from '../node.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page that shows the apps summary. It is a subpage of the Node page.
@@ -12,7 +13,7 @@ import { NodeComponent } from '../node.component';
   templateUrl: './apps.component.html',
   styleUrls: ['./apps.component.scss']
 })
-export class AppsComponent implements OnInit, OnDestroy {
+export class AppsComponent extends PageBaseComponent implements OnInit, OnDestroy {
   apps: Application[];
   nodePK: string;
   nodeIp: string;
@@ -26,6 +27,8 @@ export class AppsComponent implements OnInit, OnDestroy {
       this.apps = node.apps;
       this.nodeIp = node.ip;
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node-info/node-info.component.ts
@@ -4,6 +4,7 @@ import { TrafficData } from 'src/app/services/single-node-data.service';
 
 import { Node } from '../../../../app.datatypes';
 import { NodeComponent } from '../node.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page for showing the basic info of a node.
@@ -13,7 +14,7 @@ import { NodeComponent } from '../node.component';
   templateUrl: './node-info.component.html',
   styleUrls: ['./node-info.component.scss']
 })
-export class NodeInfoComponent implements OnInit, OnDestroy {
+export class NodeInfoComponent extends PageBaseComponent implements OnInit, OnDestroy {
   node: Node;
   trafficData: TrafficData;
 
@@ -28,6 +29,8 @@ export class NodeInfoComponent implements OnInit, OnDestroy {
     this.trafficDataSubscription = NodeComponent.currentTrafficData.subscribe((data: TrafficData) => {
       this.trafficData = data;
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/node/node.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/node.component.ts
@@ -11,6 +11,7 @@ import { TabButtonData } from '../../layout/top-bar/top-bar.component';
 import { SnackbarService } from '../../../services/snackbar.service';
 import { NodeActionsHelper } from './actions/node-actions-helper';
 import { SingleNodeBackendData, SingleNodeDataService, TrafficData } from 'src/app/services/single-node-data.service';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Main page used for showing the details of a node. It is in charge of loading
@@ -22,7 +23,10 @@ import { SingleNodeBackendData, SingleNodeDataService, TrafficData } from 'src/a
   templateUrl: './node.component.html',
   styleUrls: ['./node.component.scss']
 })
-export class NodeComponent implements OnInit, OnDestroy {
+export class NodeComponent extends PageBaseComponent implements OnInit, OnDestroy {
+  // Keys for persisting the server data, to be able to restore the state after navigation.
+  private readonly persistentDataResponseKey = 'serv-dat-response';
+
   /**
    * Mantains a reference to the currently active instance of this page.
    */
@@ -124,6 +128,8 @@ export class NodeComponent implements OnInit, OnDestroy {
     private injector: Injector,
     router: Router,
   ) {
+    super();
+
     NodeComponent.nodeSubject = new ReplaySubject<Node>(1);
     NodeComponent.trafficDataSubject = new ReplaySubject<TrafficData>(1);
     NodeComponent.currentInstanceInternal = this;
@@ -152,6 +158,8 @@ export class NodeComponent implements OnInit, OnDestroy {
         this.processRouteUpdate();
       }
     });
+
+    return super.ngOnInit();
   }
 
   private processRouteUpdate() {
@@ -163,7 +171,7 @@ export class NodeComponent implements OnInit, OnDestroy {
     this.navigationsSubscription.unsubscribe();
 
     // Load the data.
-    this.startGettingData();
+    this.startGettingData(true);
   }
 
   private updateTabBar() {
@@ -278,61 +286,73 @@ export class NodeComponent implements OnInit, OnDestroy {
   /**
    * Starts getting the data from the backend.
    */
-  private startGettingData() {
-    this.ngZone.runOutsideAngular(() => {
-      // Get the node info.
-      this.dataSubscription = this.singleNodeDataService.startRequestingData(NodeComponent.currentNodeKey).subscribe((result: SingleNodeBackendData) => {
-        this.ngZone.run(() => {
-          this.updating = result ? result.updating : true;
+  private startGettingData(checkSavedData: boolean) {
+    // Use saved data or get from the server. If there is no saved data, savedData is null.
+    let savedData = checkSavedData ? this.getLocalValue(this.persistentDataResponseKey) : null;
+    let nextOperation: Observable<any> = this.singleNodeDataService.startRequestingData(NodeComponent.currentNodeKey);
+    if (savedData) {
+      nextOperation = of(JSON.parse(savedData.value));
+    }
 
-          if (result && !result.updating) {
-            // If the data was obtained.
-            if (result.data && !result.error) {
-              this.node = result.data;
-              this.trafficData = result.trafficData;
-              NodeComponent.nodeSubject.next(this.node);
-              NodeComponent.trafficDataSubject.next(this.trafficData);
-              if (this.nodeActionsHelper) {
-                this.nodeActionsHelper.setCurrentNode(this.node);
-              }
+    // Get the node info.
+    this.dataSubscription = nextOperation.subscribe((result: SingleNodeBackendData) => {
+      if (!savedData) {
+        this.saveLocalValue(this.persistentDataResponseKey, JSON.stringify(result));
+      }
 
-              // Close any previous temporary loading error msg.
-              this.snackbarService.closeCurrentIfTemporaryError();
+      this.updating = result ? result.updating : true;
 
-              this.lastUpdate = result.momentOfLastCorrectUpdate;
-              this.secondsSinceLastUpdate = Math.floor((Date.now() - result.momentOfLastCorrectUpdate) / 1000);
-              this.errorsUpdating = false;
+      if (result && !result.updating) {
+        // If the data was obtained.
+        if (result.data && !result.error) {
+          this.node = result.data;
+          this.trafficData = result.trafficData;
+          NodeComponent.nodeSubject.next(this.node);
+          NodeComponent.trafficDataSubject.next(this.trafficData);
+          if (this.nodeActionsHelper) {
+            this.nodeActionsHelper.setCurrentNode(this.node);
+          }
 
-              if (this.lastUpdateRequestedManually) {
-                // Show a confirmation msg.
-                this.snackbarService.showDone('common.refreshed', null);
-                this.lastUpdateRequestedManually = false;
-              }
+          // Close any previous temporary loading error msg.
+          this.snackbarService.closeCurrentIfTemporaryError();
 
-            // If there was an error while obtaining the data.
-            } else if (result.error) {
-              // If the node was not found, show a msg telling the user and stop the operation.
-              if (result.error.originalError && ((result.error.originalError as HttpErrorResponse).status === 400)) {
-                this.notFound = true;
+          this.lastUpdate = result.momentOfLastCorrectUpdate;
+          this.secondsSinceLastUpdate = Math.floor((Date.now() - result.momentOfLastCorrectUpdate) / 1000);
+          this.errorsUpdating = false;
 
-                return;
-              }
+          if (this.lastUpdateRequestedManually) {
+            // Show a confirmation msg.
+            this.snackbarService.showDone('common.refreshed', null);
+            this.lastUpdateRequestedManually = false;
+          }
 
-              // Show an error msg if it has not be done before during the current attempt to obtain the data.
-              if (!this.errorsUpdating) {
-                if (!this.node) {
-                  this.snackbarService.showError('common.loading-error', null, true, result.error);
-                } else {
-                  this.snackbarService.showError('node.error-load', null, true, result.error);
-                }
-              }
+        // If there was an error while obtaining the data.
+        } else if (result.error) {
+          // If the node was not found, show a msg telling the user and stop the operation.
+          if (result.error.originalError && ((result.error.originalError as HttpErrorResponse).status === 400)) {
+            this.notFound = true;
 
-              // Stop the loading indicator and show a warning icon.
-              this.errorsUpdating = true;
+            return;
+          }
+
+          // Show an error msg if it has not be done before during the current attempt to obtain the data.
+          if (!this.errorsUpdating) {
+            if (!this.node) {
+              this.snackbarService.showError('common.loading-error', null, true, result.error);
+            } else {
+              this.snackbarService.showError('node.error-load', null, true, result.error);
             }
           }
-        });
-      });
+
+          // Stop the loading indicator and show a warning icon.
+          this.errorsUpdating = true;
+        }
+      }
+
+      // If old saved data was used, repeat the operation, ignoring the saved data.
+      if (savedData) {
+        this.startGettingData(false);
+      }
     });
   }
 

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/all-routes/all-routes.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/all-routes/all-routes.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 
 import { Node, Route } from '../../../../../app.datatypes';
 import { NodeComponent } from '../../node.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page for showing the complete list of the routes of a node.
@@ -12,7 +13,7 @@ import { NodeComponent } from '../../node.component';
   templateUrl: './all-routes.component.html',
   styleUrls: ['./all-routes.component.scss']
 })
-export class AllRoutesComponent implements OnInit, OnDestroy {
+export class AllRoutesComponent extends PageBaseComponent implements OnInit, OnDestroy {
   routes: Route[];
   nodePK: string;
 
@@ -24,6 +25,8 @@ export class AllRoutesComponent implements OnInit, OnDestroy {
       this.nodePK = node.localPk;
       this.routes = node.routes;
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/all-transports/all-transports.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/all-transports/all-transports.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 
 import { Node } from '../../../../../app.datatypes';
 import { NodeComponent } from '../../node.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page for showing the complete list of the transports of a node.
@@ -12,7 +13,7 @@ import { NodeComponent } from '../../node.component';
   templateUrl: './all-transports.component.html',
   styleUrls: ['./all-transports.component.scss']
 })
-export class AllTransportsComponent implements OnInit, OnDestroy {
+export class AllTransportsComponent extends PageBaseComponent implements OnInit, OnDestroy {
   node: Node;
 
   private dataSubscription: Subscription;
@@ -20,6 +21,8 @@ export class AllTransportsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // Get the node data from the parent page.
     this.dataSubscription = NodeComponent.currentNode.subscribe((node: Node) => this.node = node);
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/node/routing/routing.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/routing/routing.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 
 import { Node, Route } from '../../../../app.datatypes';
 import { NodeComponent } from '../node.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page that shows the routing summary. It is a subpage of the Node page.
@@ -12,7 +13,7 @@ import { NodeComponent } from '../node.component';
   templateUrl: './routing.component.html',
   styleUrls: ['./routing.component.scss']
 })
-export class RoutingComponent implements OnInit, OnDestroy {
+export class RoutingComponent extends PageBaseComponent implements OnInit, OnDestroy {
   node: Node;
   routes: Route[];
   nodePK: string;
@@ -26,6 +27,8 @@ export class RoutingComponent implements OnInit, OnDestroy {
       this.node = node;
       this.routes = node.routes;
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/settings/settings.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { of, Subscription } from 'rxjs';
+import { Observable, of, Subscription } from 'rxjs';
 import { delay, mergeMap } from 'rxjs/operators';
 
 import { TabButtonData, MenuOptionData } from '../../layout/top-bar/top-bar.component';
 import { AuthService, AuthStates } from '../../../services/auth.service';
 import { SnackbarService } from '../../../services/snackbar.service';
 import GeneralUtils from 'src/app/utils/generalUtils';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page with the general settings of the app.
@@ -17,7 +18,10 @@ import GeneralUtils from 'src/app/utils/generalUtils';
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss']
 })
-export class SettingsComponent implements OnInit, OnDestroy {
+export class SettingsComponent extends PageBaseComponent implements OnInit, OnDestroy {
+  // Keys for persisting the server data, to be able to restore the state after navigation.
+  private readonly persistentAuthDataResponseKey = 'serv-aut-response';
+
   tabsData: TabButtonData[] = [];
   options: MenuOptionData[] = [];
 
@@ -38,6 +42,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private snackbarService: SnackbarService,
     private dialog: MatDialog,
   ) {
+    super();
+
     // Data for populating the tab bar.
     this.tabsData = [
       {
@@ -66,28 +72,46 @@ export class SettingsComponent implements OnInit, OnDestroy {
       this.waitBeforeShowingLoading = false;
     }, 500);
 
-    this.checkAuth(0);
+    this.checkAuth(0, true);
+
+    return super.ngOnInit();
   }
 
   /**
    * Checks if the auth options are active and the user is authenticated.
    */
-  private checkAuth(delayMilliseconds: number) {
+  private checkAuth(delayMilliseconds: number, checkSavedData: boolean) {
+    // Use saved data or get from the server. If there is no saved data, savedData is null.
+    let savedData = checkSavedData ? this.getLocalValue(this.persistentAuthDataResponseKey) : null;
+    let nextOperation: Observable<any> = this.authService.checkLogin();
+    if (savedData) {
+      nextOperation = of(JSON.parse(savedData.value));
+    }
+
     this.authSubscription = of(1).pipe(
       // Wait the delay.
       delay(delayMilliseconds),
       // Load the data. The node pk is obtained from the currently openned node page.
-      mergeMap(() => this.authService.checkLogin())
+      mergeMap(() => nextOperation)
     ).subscribe(
       result => {
+        if (!savedData) {
+          this.saveLocalValue(this.persistentAuthDataResponseKey, JSON.stringify(result));
+        }
+
         this.authChecked = true;
         this.authActive = result === AuthStates.Logged;
 
         this.updateOptionsMenu();
+
+        // If old saved data was used, repeat the operation, ignoring the saved data.
+        if (savedData) {
+          this.checkAuth(0, false);
+        }
       },
       () => {
         // Retry after a small delay.
-        this.checkAuth(15000);
+        this.checkAuth(15000, false);
       },
     );
   }

--- a/static/skywire-manager-src/src/app/components/pages/start/start.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/start/start.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { AuthService, AuthStates } from '../../../services/auth.service';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Initial utility page for redirecting the user to the real appropriate initial page.
@@ -14,13 +15,15 @@ import { AuthService, AuthStates } from '../../../services/auth.service';
   templateUrl: './start.component.html',
   styleUrls: ['./start.component.scss']
 })
-export class StartComponent implements OnInit, OnDestroy {
+export class StartComponent extends PageBaseComponent implements OnInit, OnDestroy {
   private verificationSubscription: Subscription;
 
   constructor(
     private authService: AuthService,
     private router: Router,
-  ) { }
+  ) {
+    super();
+  }
 
   ngOnInit() {
     // Check if the user is unauthorized.
@@ -35,6 +38,8 @@ export class StartComponent implements OnInit, OnDestroy {
       // comprobations will be performed in that page.
       this.router.navigate(['nodes'], { replaceUrl: true });
     });
+
+    return super.ngOnInit();
   }
 
   ngOnDestroy() {

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-error/vpn-error.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-error/vpn-error.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs/internal/Subscription';
 
 import { VpnAuthGuardService } from 'src/app/services/vpn-auth-guard.service';
 import { VpnClientService } from 'src/app/services/vpn-client.service';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Errors VpnErrorComponent can show.
@@ -26,7 +27,7 @@ enum KnownProblems {
   templateUrl: './vpn-error.component.html',
   styleUrls: ['./vpn-error.component.scss'],
 })
-export class VpnErrorComponent {
+export class VpnErrorComponent extends PageBaseComponent {
   private problem = null;
 
   private navigationsSubscription: Subscription;
@@ -36,6 +37,8 @@ export class VpnErrorComponent {
     private vpnAuthGuardService: VpnAuthGuardService,
     private vpnClientService: VpnClientService,
   ) {
+    super();
+    
     // Get the query string.
     this.navigationsSubscription = this.route.queryParamMap.subscribe(queryParams => {
       this.problem = queryParams.get('problem');

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-settings/vpn-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-settings/vpn-settings.component.ts
@@ -14,6 +14,7 @@ import { SelectableOption, SelectOptionComponent } from 'src/app/components/layo
 import { TopBarComponent } from 'src/app/components/layout/top-bar/top-bar.component';
 import { RouterConfigComponent, RouterConfigParams } from 'src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component';
 import { VpnDnsConfigComponent, VpnDnsConfigParams } from '../../layout/vpn-dns-config/vpn-dns-config.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Options that VpnSettingsComponent might be changing asynchronously.
@@ -31,7 +32,7 @@ enum WorkingOptions {
   templateUrl: './vpn-settings.component.html',
   styleUrls: ['./vpn-settings.component.scss'],
 })
-export class VpnSettingsComponent implements OnDestroy {
+export class VpnSettingsComponent extends PageBaseComponent implements OnDestroy {
   @ViewChild('topBarLoading') topBarLoading: TopBarComponent;
   @ViewChild('topBarLoaded') topBarLoaded: TopBarComponent;
 
@@ -65,6 +66,8 @@ export class VpnSettingsComponent implements OnDestroy {
     private dialog: MatDialog,
     route: ActivatedRoute,
   ) {
+    super();
+    
     this.navigationsSubscription = route.paramMap.subscribe(params => {
       // Get the PK of the current local visor.
       if (params.has('key')) {

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-status/vpn-status.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-status/vpn-status.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { interval, Subscription } from 'rxjs';
+import { interval, Observable, of, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
@@ -12,6 +12,7 @@ import { DataUnits, LocalServerData, ServerFlags, VpnSavedDataService } from 'sr
 import { countriesList } from 'src/app/utils/countries-list';
 import { SnackbarService } from 'src/app/services/snackbar.service';
 import { LineChartComponent } from 'src/app/components/layout/line-chart/line-chart.component';
+import { PageBaseComponent } from 'src/app/utils/page-base';
 
 /**
  * Page with the current state of the VPN. It also allows to start/stop the VPN protection.
@@ -21,7 +22,11 @@ import { LineChartComponent } from 'src/app/components/layout/line-chart/line-ch
   templateUrl: './vpn-status.component.html',
   styleUrls: ['./vpn-status.component.scss'],
 })
-export class VpnStatusComponent implements OnInit, OnDestroy {
+export class VpnStatusComponent extends PageBaseComponent implements OnInit, OnDestroy {
+  // Keys for persisting the server data, to be able to restore the state after navigation.
+  private readonly persistentServerDataResponseKey = 'serv-dat-response';
+  private readonly persistentIpResponseKey = 'serv-ip-response';
+  
   // Data for populating the tabs of the top bar.
   tabsData = VpnHelpers.vpnTabsData;
 
@@ -105,6 +110,8 @@ export class VpnStatusComponent implements OnInit, OnDestroy {
     private dialog: MatDialog,
     private router: Router,
   ) {
+    super();
+
     this.ipInfoAllowed = this.vpnSavedDataService.getCheckIpSetting();
 
     // Set which units must be used for showing the data stats.
@@ -132,112 +139,139 @@ export class VpnStatusComponent implements OnInit, OnDestroy {
 
       setTimeout(() => this.navigationsSubscription.unsubscribe());
 
-      // Start getting and updating the state of the backend.
-      this.dataSubscription = this.vpnClientService.backendState.subscribe(data => {
-        if (data && data.serviceState !== VpnServiceStates.PerformingInitialCheck) {
-          const firstEventExecution = !!!this.backendState;
-          this.backendState = data;
-
-          if (!firstEventExecution) {
-            // If the app enters or leaves the Running state, update the IP.
-            if (
-              (this.lastAppState === AppState.Running && data.vpnClientAppData.appState !== AppState.Running) ||
-              (this.lastAppState !== AppState.Running && data.vpnClientAppData.appState === AppState.Running)
-            ) {
-              this.getIp(true);
-            }
-          } else {
-            // Get the ip data for the first time.
-            this.getIp(true);
-          }
-
-          this.showStarted = data.vpnClientAppData.running || data.vpnClientAppData.appState !== AppState.Stopped;
-          if (this.showStartedLastValue !== this.showStarted) {
-            // If the running state changed, restart the values for the data graphs.
-
-            // Avoid replacing the whole arrays to prevent problems with the graphs.
-            for (let i = 0; i < 10; i++) {
-              this.receivedHistory[i] = 0;
-              this.sentHistory[i] = 0;
-              this.latencyHistory[i] = 0;
-            }
-            this.updateGraphLimits();
-
-            this.uploadSpeed = 0;
-            this.downloadSpeed = 0;
-            this.totalUploaded = 0;
-            this.totalDownloaded = 0;
-            this.latency = 0;
-          }
-
-          this.lastAppState = data.vpnClientAppData.appState;
-          this.showStartedLastValue = this.showStarted;
-          if (!this.stopRequested) {
-            this.showBusy = data.busy;
-          } else if (!this.showStarted) {
-            this.stopRequested = false;
-            this.showBusy = data.busy;
-          }
-
-          // Update the values for the data graphs.
-          if (data.vpnClientAppData.connectionData) {
-            // Avoid replacing the whole arrays to prevent problems with the graphs.
-            for (let i = 0; i < 10; i++) {
-              this.receivedHistory[i] = data.vpnClientAppData.connectionData.downloadSpeedHistory[i];
-              this.sentHistory[i] = data.vpnClientAppData.connectionData.uploadSpeedHistory[i];
-              this.latencyHistory[i] = data.vpnClientAppData.connectionData.latencyHistory[i];
-            }
-
-            this.updateGraphLimits();
-
-            this.uploadSpeed = data.vpnClientAppData.connectionData.uploadSpeed;
-            this.downloadSpeed = data.vpnClientAppData.connectionData.downloadSpeed;
-            this.totalUploaded = data.vpnClientAppData.connectionData.totalUploaded;
-            this.totalDownloaded = data.vpnClientAppData.connectionData.totalDownloaded;
-            this.latency = data.vpnClientAppData.connectionData.latency;
-          }
-
-          if (
-            data.vpnClientAppData.running &&
-            data.vpnClientAppData.appState === AppState.Running &&
-            data.vpnClientAppData.connectionData &&
-            data.vpnClientAppData.connectionData.connectionDuration
-          ) {
-            if (
-              this.calculatedSegs === -1 ||
-              data.vpnClientAppData.connectionData.connectionDuration > this.calculatedSegs + 2 ||
-              data.vpnClientAppData.connectionData.connectionDuration < this.calculatedSegs - 2
-            ) {
-              this.calculatedSegs = data.vpnClientAppData.connectionData.connectionDuration;
-              this.refreshConnectionTimeString();
-
-              if (this.timeUpdateSubscription) {
-                this.timeUpdateSubscription.unsubscribe();
-              }
-
-              this.timeUpdateSubscription = interval(1000).subscribe(() => {
-                this.calculatedSegs += 1;
-                this.refreshConnectionTimeString();
-              });
-            }
-          } else {
-            if (this.timeUpdateSubscription) {
-              this.timeUpdateSubscription.unsubscribe();
-              this.timeUpdateSubscription = null;
-
-              this.calculatedSegs = -1;
-              this.connectionTimeString = '00:00:00';
-            }
-          }
-
-          this.loading = false;
-        }
-      });
+      this.startGettingData(true);
 
       // Get or update the currently selected server.
       this.currentRemoteServerSubscription = this.vpnSavedDataService.currentServerObservable.subscribe(server => {
         this.currentRemoteServer = server;
       });
+    });
+
+    return super.ngOnInit();
+  }
+
+  /**
+   * Start getting and updating the state of the backend.
+   */
+  private startGettingData(checkSavedData: boolean) {
+    // Use saved data or get from the server. If there is no saved data, savedData is null.
+    let savedData = checkSavedData ? this.getLocalValue(this.persistentServerDataResponseKey) : null;
+    let nextOperation: Observable<any> = this.vpnClientService.backendState;
+    if (savedData) {
+      nextOperation = of(JSON.parse(savedData.value));
+    }
+
+    this.dataSubscription = nextOperation.subscribe(data => {
+      if (!savedData) {
+        this.saveLocalValue(this.persistentServerDataResponseKey, JSON.stringify(data));
+      }
+
+      if (data && data.serviceState !== VpnServiceStates.PerformingInitialCheck) {
+        const firstEventExecution = !!!this.backendState;
+        this.backendState = data;
+
+        if (!firstEventExecution) {
+          // If the app enters or leaves the Running state, update the IP.
+          if (
+            (this.lastAppState === AppState.Running && data.vpnClientAppData.appState !== AppState.Running) ||
+            (this.lastAppState !== AppState.Running && data.vpnClientAppData.appState === AppState.Running)
+          ) {
+            this.getIp(true, checkSavedData);
+            console.info(1);
+          }
+        } else {
+          // Get the ip data for the first time.
+          this.getIp(true, checkSavedData);
+          console.info(2);
+          console.info(checkSavedData);
+        }
+
+        this.showStarted = data.vpnClientAppData.running || data.vpnClientAppData.appState !== AppState.Stopped;
+        if (this.showStartedLastValue !== this.showStarted) {
+          // If the running state changed, restart the values for the data graphs.
+
+          // Avoid replacing the whole arrays to prevent problems with the graphs.
+          for (let i = 0; i < 10; i++) {
+            this.receivedHistory[i] = 0;
+            this.sentHistory[i] = 0;
+            this.latencyHistory[i] = 0;
+          }
+          this.updateGraphLimits();
+
+          this.uploadSpeed = 0;
+          this.downloadSpeed = 0;
+          this.totalUploaded = 0;
+          this.totalDownloaded = 0;
+          this.latency = 0;
+        }
+
+        this.lastAppState = data.vpnClientAppData.appState;
+        this.showStartedLastValue = this.showStarted;
+        if (!this.stopRequested) {
+          this.showBusy = data.busy;
+        } else if (!this.showStarted) {
+          this.stopRequested = false;
+          this.showBusy = data.busy;
+        }
+
+        // Update the values for the data graphs.
+        if (data.vpnClientAppData.connectionData) {
+          // Avoid replacing the whole arrays to prevent problems with the graphs.
+          for (let i = 0; i < 10; i++) {
+            this.receivedHistory[i] = data.vpnClientAppData.connectionData.downloadSpeedHistory[i];
+            this.sentHistory[i] = data.vpnClientAppData.connectionData.uploadSpeedHistory[i];
+            this.latencyHistory[i] = data.vpnClientAppData.connectionData.latencyHistory[i];
+          }
+
+          this.updateGraphLimits();
+
+          this.uploadSpeed = data.vpnClientAppData.connectionData.uploadSpeed;
+          this.downloadSpeed = data.vpnClientAppData.connectionData.downloadSpeed;
+          this.totalUploaded = data.vpnClientAppData.connectionData.totalUploaded;
+          this.totalDownloaded = data.vpnClientAppData.connectionData.totalDownloaded;
+          this.latency = data.vpnClientAppData.connectionData.latency;
+        }
+
+        if (
+          data.vpnClientAppData.running &&
+          data.vpnClientAppData.appState === AppState.Running &&
+          data.vpnClientAppData.connectionData &&
+          data.vpnClientAppData.connectionData.connectionDuration
+        ) {
+          if (
+            this.calculatedSegs === -1 ||
+            data.vpnClientAppData.connectionData.connectionDuration > this.calculatedSegs + 2 ||
+            data.vpnClientAppData.connectionData.connectionDuration < this.calculatedSegs - 2
+          ) {
+            this.calculatedSegs = data.vpnClientAppData.connectionData.connectionDuration;
+            this.refreshConnectionTimeString();
+
+            if (this.timeUpdateSubscription) {
+              this.timeUpdateSubscription.unsubscribe();
+            }
+
+            this.timeUpdateSubscription = interval(1000).subscribe(() => {
+              this.calculatedSegs += 1;
+              this.refreshConnectionTimeString();
+            });
+          }
+        } else {
+          if (this.timeUpdateSubscription) {
+            this.timeUpdateSubscription.unsubscribe();
+            this.timeUpdateSubscription = null;
+
+            this.calculatedSegs = -1;
+            this.connectionTimeString = '00:00:00';
+          }
+        }
+
+        this.loading = false;
+      }
+
+      // If old saved data was used, repeat the operation, ignoring the saved data.
+      if (savedData) {
+        this.startGettingData(false);
+      }
     });
   }
 
@@ -468,7 +502,7 @@ export class VpnStatusComponent implements OnInit, OnDestroy {
    * @param ignoreTimeCheck If true, the operation will be performed even if the function
    * was called shortly before.
    */
-  public getIp(ignoreTimeCheck = false) {
+  public getIp(ignoreTimeCheck = false, checkSavedData = false) {
     // Cancel the operation if the used blocked the IP checking functionality.
     if (!this.ipInfoAllowed) {
       return;
@@ -502,8 +536,19 @@ export class VpnStatusComponent implements OnInit, OnDestroy {
     // Indicate that the IP and its country are being loaded.
     this.loadingCurrentIp = true;
 
+    // Use saved data or get from the server. If there is no saved data, savedData is null.
+    let savedData = checkSavedData ? this.getLocalValue(this.persistentIpResponseKey) : null;
+    let nextOperation: Observable<any> = this.vpnClientService.getIpData();
+    if (savedData) {
+      nextOperation = of(JSON.parse(savedData.value));
+    }
+
     // Get the IP and country.
-    this.ipSubscription = this.vpnClientService.getIpData().subscribe(response => {
+    this.ipSubscription = nextOperation.subscribe(response => {
+      if (!savedData) {
+        this.saveLocalValue(this.persistentIpResponseKey, JSON.stringify(response));
+      }
+
       this.loadingCurrentIp = false;
       this.lastIpRefresDate = Date.now();
 
@@ -515,6 +560,11 @@ export class VpnStatusComponent implements OnInit, OnDestroy {
       } else {
         // Indicate that there was a problem.
         this.problemGettingIp = true;
+      }
+
+      // If old saved data was used, repeat the operation, ignoring the saved data.
+      if (savedData) {
+        this.getIp(ignoreTimeCheck, false);
       }
     }, () => {
       // Indicate that there was a problem.

--- a/static/skywire-manager-src/src/app/services/vpn-client-discovery.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client-discovery.service.ts
@@ -110,43 +110,45 @@ export class VpnClientDiscoveryService {
       map((result: any[]) => {
         const response: VpnServer[] = [];
 
-        // Process the data.
-        result.forEach(entry => {
-          const currentEntry = new VpnServer();
+        if (result) {
+          // Process the data.
+          result.forEach(entry => {
+            const currentEntry = new VpnServer();
 
-          // The address must have 2 parts: the pk and the port.
-          const addressParts = (entry.address as string).split(':');
-          if (addressParts.length === 2) {
-            currentEntry.pk = addressParts[0];
+            // The address must have 2 parts: the pk and the port.
+            const addressParts = (entry.address as string).split(':');
+            if (addressParts.length === 2) {
+              currentEntry.pk = addressParts[0];
 
-            // Process the location.
-            currentEntry.location = '';
-            if (entry.geo) {
-              if (entry.geo.country) {
-                currentEntry.countryCode = entry.geo.country;
+              // Process the location.
+              currentEntry.location = '';
+              if (entry.geo) {
+                if (entry.geo.country) {
+                  currentEntry.countryCode = entry.geo.country;
+                }
+                if (entry.geo.region) {
+                  currentEntry.location = entry.geo.region;
+                }
               }
-              if (entry.geo.region) {
-                currentEntry.location = entry.geo.region;
-              }
+
+              currentEntry.name = addressParts[0];
+              /*
+              // TODO: used only for columns that are currently deactivated in the server list. Must
+              // be deleted or reactivated depending on what happens to the columns.
+              currentEntry.congestion = 20;
+              currentEntry.congestionRating = Ratings.Gold;
+              currentEntry.latency = 123;
+              currentEntry.latencyRating = Ratings.Gold;
+              currentEntry.hops = 3;
+              */
+
+              // TODO: still not added to the discovery service.
+              currentEntry.note = '';
+
+              response.push(currentEntry);
             }
-
-            currentEntry.name = addressParts[0];
-            /*
-            // TODO: used only for columns that are currently deactivated in the server list. Must
-            // be deleted or reactivated depending on what happens to the columns.
-            currentEntry.congestion = 20;
-            currentEntry.congestionRating = Ratings.Gold;
-            currentEntry.latency = 123;
-            currentEntry.latencyRating = Ratings.Gold;
-            currentEntry.hops = 3;
-            */
-
-            // TODO: still not added to the discovery service.
-            currentEntry.note = '';
-
-            response.push(currentEntry);
-          }
-        });
+          });
+        }
 
         this.servers = response;
 

--- a/static/skywire-manager-src/src/app/utils/page-base.ts
+++ b/static/skywire-manager-src/src/app/utils/page-base.ts
@@ -1,0 +1,77 @@
+import { Component, HostListener, OnInit } from '@angular/core';
+
+/**
+ * Info about a value saved using the functions from PageBase.
+ */
+export class LocalValueData {
+  /**
+   * Actual value.
+   */
+  value: any;
+  /**
+   * Moment in which the value was updated for the last time. It is the value
+   * of new Date().getTime().
+   */
+  date: number;
+}
+
+/**
+ * Base class for the pages. It restores the scroll position when navigating back to the page
+ * and provides functions for saving data on the browser history state.
+ */
+@Component({
+  selector: 'app-page-base',
+  template: '',
+  styles: [],
+})
+export class PageBaseComponent implements OnInit {
+  // Key for saving the scroll position.
+  private readonly persistentScrollPosKey = 'scroll-pos';
+
+  // Property to make mandatory calling super.ngOnInit on child classes.
+  private static mustCallNgOnInitSuper = Symbol('You must call super.ngOnInit.');
+  ngOnInit() {
+    // Restore the scroll position. If there is no saved value, go to the top.
+    let lastScrollPos = this.getLocalValue(this.persistentScrollPosKey);
+    lastScrollPos = lastScrollPos ? lastScrollPos.value : '0';
+    window.scrollTo(0, Number(lastScrollPos));
+    setTimeout(() => window.scrollTo(0, Number(lastScrollPos)), 1);
+
+    return undefined as typeof PageBaseComponent.mustCallNgOnInitSuper & never;
+  }
+
+  // Saves the scroll position after each change.
+  @HostListener('window:scroll', ['$event'])
+  saveScrollPosition(event: any) {
+    this.saveLocalValue(this.persistentScrollPosKey, window.scrollY + '');
+  }
+
+  /**
+   * Saves a value on the state inside window.history.
+   *
+   * @param key Key for identifying the value.
+   * @param value Value to save.
+   */
+  saveLocalValue(key: string, value: any) {
+    const state = window.history.state;
+    state[key] = value;
+    state[key + '_time'] = new Date().getTime();
+    window.history.replaceState(state, '', window.location.pathname + window.location.hash);
+  }
+
+  /**
+   * Gets a value from window.history. If the value is not found, it returns null.
+   *
+   * @param key Key that identifies the value.
+   */
+  getLocalValue(key: string): LocalValueData | null {
+    if (!window.history.state || window.history.state[key] === undefined) {
+      return null;
+    }
+
+    const response = new LocalValueData();
+    response.value = window.history.state[key];
+    response.date = window.history.state[key + '_time'];
+    return response;
+  }
+}


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run build` wes used. `npm run lint` could have problems for the update to Angular 16.

 Changes:	
- The last commit makes the whole app use page state management, as it is more usable with the new verisons of Angular. This makes the app remember the system state while navigating, which means remembering the scroll position, avoid reloading previously loaded data from the server and other usability improvements. This should be more noticeable on mobile devices.

This is similar a previous change made to the explorer, but with some changes, because the router strategy used by the Hypervisor UI in the router config is different.

How to test this PR:
After recompiling the front-end, when navigating with the browser buttons the app should now remember the scroll position and some parts of the app should load a bit faster.