### PR TITLE
Fix the js mime type

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -1449,6 +1450,11 @@ func initHypervisor(_ context.Context, v *Visor, log *logging.Logger) error {
 	hv.serveDmsg(ctx, v.log)
 
 	// Serve HTTP(s).
+
+	// Needed to work with modern browsers when serving from windows, which need the correct mime type for javascript.
+	if err := mime.AddExtensionType(".js", "application/javascript"); err != nil {
+		log.Fatalln("Unable to register js mime type.")
+	}
 
 	v.log.WithField("addr", conf.HTTPAddr).
 		WithField("tls", conf.EnableTLS).


### PR DESCRIPTION
Did you run `make format && make check`?
Can’t from my dev enviroment, will fix any problem form another machine if a problem appears.

 Changes:	
- The correct mime type for .js files was added. This is because, on Windows, the server returns “text/plain” as the mime type of the .js files and that does not allow to open the Hypervisor UI, as modern browsers block the excecution if the mime type is not correct. This is similar to a change that was made to the explorer: https://github.com/skycoin/skycoin-explorer/pull/424#issuecomment-1510505072

How to test this PR:
Opening the Hypervisor UI from localhost:8000 should work well on Windows.
