### PR TITLE
Fix `skywire-cli config gen -r`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 updates may be generated with `scripts/changelog.sh <PR#lowest> <PR#highest>`
 
+## 1.3.9
+
+-   Fix `skywire-cli config gen -r`
+
 ## 1.3.8
 
+-   Rebuild Hypervisor UI  [#1583](https://github.com/skycoin/skywire/pull/1583)
 -   Rebuild Hypervisor UI  [#1583](https://github.com/skycoin/skywire/pull/1583)
 -   Change Logserver to use c.JSON method ; remove variable for endpoint name '/node-info'  [#1582](https://github.com/skycoin/skywire/pull/1582)
 -   update changelog  [#1580](https://github.com/skycoin/skywire/pull/1580)

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -332,17 +332,15 @@ var genConfigCmd = &cobra.Command{
 			oldConfJSON, err := os.ReadFile(confPath)
 			if err != nil {
 				if !isStdout || isStdout && isHide {
-					log.Fatalf("Failed to read config file: %v", err)
+					log.Errorf("Failed to read config file: %v", err)
 				}
-			}
+			} else {
 			// Decode JSON data
 			err = json.Unmarshal(oldConfJSON, &oldConf)
 			if err != nil {
 				if !isStdout || isStdout && isHide {
 					log.WithError(err).Fatal("Failed to unmarshal old config json")
 				}
-			}
-			if err != nil {
 				_, sk = cipher.GenerateKeyPair()
 			} else {
 				sk = oldConf.SK
@@ -356,6 +354,7 @@ var genConfigCmd = &cobra.Command{
 				}
 			}
 		}
+	}
 
 		//determine best protocol
 		if isBestProtocol && netutil.LocalProtocol() {

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -335,26 +335,26 @@ var genConfigCmd = &cobra.Command{
 					log.Errorf("Failed to read config file: %v", err)
 				}
 			} else {
-			// Decode JSON data
-			err = json.Unmarshal(oldConfJSON, &oldConf)
-			if err != nil {
-				if !isStdout || isStdout && isHide {
-					log.WithError(err).Fatal("Failed to unmarshal old config json")
-				}
-				_, sk = cipher.GenerateKeyPair()
-			} else {
-				sk = oldConf.SK
-				if isRetainHypervisors {
-					for _, j := range oldConf.Hypervisors {
-						hypervisorPKs = hypervisorPKs + "," + fmt.Sprintf("\t%s\n", j)
+				// Decode JSON data
+				err = json.Unmarshal(oldConfJSON, &oldConf)
+				if err != nil {
+					if !isStdout || isStdout && isHide {
+						log.WithError(err).Fatal("Failed to unmarshal old config json")
 					}
-					for _, j := range oldConf.Dmsgpty.Whitelist {
-						dmsgptyWlPKs = dmsgptyWlPKs + "," + fmt.Sprintf("\t%s\n", j)
+					_, sk = cipher.GenerateKeyPair()
+				} else {
+					sk = oldConf.SK
+					if isRetainHypervisors {
+						for _, j := range oldConf.Hypervisors {
+							hypervisorPKs = hypervisorPKs + "," + fmt.Sprintf("\t%s\n", j)
+						}
+						for _, j := range oldConf.Dmsgpty.Whitelist {
+							dmsgptyWlPKs = dmsgptyWlPKs + "," + fmt.Sprintf("\t%s\n", j)
+						}
 					}
 				}
 			}
 		}
-	}
 
 		//determine best protocol
 		if isBestProtocol && netutil.LocalProtocol() {

--- a/cmd/skywire-cli/commands/reward/root.go
+++ b/cmd/skywire-cli/commands/reward/root.go
@@ -74,7 +74,7 @@ func longText() string {
 		if err != nil {
 			fmt.Errorf("    reward settings misconfigured!") //nolint
 		}
-		_, err = coincipher.DecodeBase58Address(string(reward))
+		_, err = coincipher.DecodeBase58Address(strings.TrimSpace(string(reward)))
 		if err != nil {
 			fmt.Errorf("    invalid address in reward config %v", err) //nolint
 		}


### PR DESCRIPTION
* Remove fatal error on `config gen -r` when old config is not found
* trim space from string of reward address input to `skywire-cli reward`