### PR TITLE
remove .asc file from archives of release

### DIFF
--- a/.goreleaser-archlinux.yml
+++ b/.goreleaser-archlinux.yml
@@ -290,7 +290,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-amd64
       - skywire-cli-amd64
@@ -306,7 +305,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-arm64
       - skywire-cli-arm64
@@ -322,7 +320,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-arm
       - skywire-cli-arm

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -86,7 +86,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor
       - skywire-cli

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -472,7 +472,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-amd64
       - skywire-cli-amd64
@@ -488,7 +487,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-arm64
       - skywire-cli-arm64
@@ -504,7 +502,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-arm
       - skywire-cli-arm
@@ -520,7 +517,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}hf'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-armhf
       - skywire-cli-armhf
@@ -536,7 +532,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor-riscv64
       - skywire-cli-riscv64

--- a/.goreleaser-windows.yml
+++ b/.goreleaser-windows.yml
@@ -58,7 +58,6 @@ archives:
     name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
-      - skycoin.asc
     builds:
       - skywire-visor
       - skywire-cli


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- remove `.asc` file from release pipeline, we never need this anymore

How to test this PR:
_