### PR TITLE
Add CSRF protection to the Hypervisor API

### DIFF
--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -45,6 +45,7 @@ var (
 	logTag               string
 	hiddenflags          []string
 	all                  bool
+	useCsrf              bool
 	pkg                  bool
 	usr                  bool
 	localIPs             []net.IP //  nolint:unused
@@ -133,6 +134,7 @@ func init() {
 	RootCmd.Flags().BoolVar(&isForceColor, "forcecolor", false, "force color logging when out is not STDOUT")
 	hiddenflags = append(hiddenflags, "forcecolor")
 	RootCmd.Flags().BoolVar(&all, "all", false, "show all flags")
+	RootCmd.Flags().BoolVar(&useCsrf, "csrf", true, "Request a CSRF token for sensitive hypervisor API requests")
 	for _, j := range hiddenflags {
 		RootCmd.Flags().MarkHidden(j) //nolint
 	}

--- a/pkg/visor/csrf.go
+++ b/pkg/visor/csrf.go
@@ -1,0 +1,108 @@
+// Package visor pkg/visor/hypervisor.go
+package visor
+
+import (
+	"time"
+
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+const (
+	// CSRFHeaderName is the name of the CSRF header
+	CSRFHeaderName = "X-CSRF-Token"
+
+	// CSRFMaxAge is the lifetime of a CSRF token in seconds
+	CSRFMaxAge = time.Second * 30
+
+	csrfSecretLength = 64
+
+	csrfNonceLength = 64
+)
+
+var (
+	// ErrCSRFInvalid is returned when the the CSRF token is in invalid format
+	ErrCSRFInvalid = errors.New("invalid CSRF token")
+	// ErrCSRFExpired is returned when the csrf token has expired
+	ErrCSRFExpired = errors.New("csrf token expired")
+)
+
+var csrfSecretKey []byte
+
+func init() {
+	csrfSecretKey = cipher.RandByte(csrfSecretLength)
+}
+
+// CSRFToken csrf token
+type CSRFToken struct {
+	Nonce     []byte
+	ExpiresAt time.Time
+}
+
+// newCSRFToken generates a new CSRF Token
+func newCSRFToken() (string, error) {
+	token := &CSRFToken{
+		Nonce:     cipher.RandByte(csrfNonceLength),
+		ExpiresAt: time.Now().Add(CSRFMaxAge),
+	}
+
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return "", err
+	}
+
+	h := hmac.New(sha256.New, csrfSecretKey)
+	_, err = h.Write([]byte(tokenJSON))
+	if err != nil {
+		return "", err
+	}
+
+	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+
+	signingString := base64.RawURLEncoding.EncodeToString(tokenJSON)
+
+	return strings.Join([]string{signingString, sig}, "."), nil
+}
+
+// verifyCSRFToken checks validity of the given token
+func verifyCSRFToken(headerToken string) error {
+	tokenParts := strings.Split(headerToken, ".")
+	if len(tokenParts) != 2 {
+		return ErrCSRFInvalid
+	}
+
+	signingString, err := base64.RawURLEncoding.DecodeString(tokenParts[0])
+	if err != nil {
+		return err
+	}
+
+	h := hmac.New(sha256.New, csrfSecretKey)
+	_, err = h.Write([]byte(signingString))
+	if err != nil {
+		return err
+	}
+
+	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+
+	if sig != tokenParts[1] {
+		return ErrCSRFInvalid
+	}
+
+	var csrfToken CSRFToken
+	err = json.Unmarshal(signingString, &csrfToken)
+	if err != nil {
+		return err
+	}
+
+	if time.Now().After(csrfToken.ExpiresAt) {
+		return ErrCSRFExpired
+	}
+
+	return nil
+}

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -215,6 +215,8 @@ func (hv *Hypervisor) makeMux() chi.Router {
 
 			r.Get("/ping", hv.getPong())
 
+			r.Get("/csrf", hv.getCsrf())
+
 			if hv.c.EnableAuth {
 				r.Group(func(r chi.Router) {
 					r.Post("/create-account", hv.users.CreateAccount())
@@ -296,6 +298,25 @@ func (hv *Hypervisor) getPong() http.HandlerFunc {
 		if _, err := w.Write([]byte(`"PONG!"`)); err != nil {
 			hv.log(r).WithError(err).Warn("getPong: Failed to send PONG!")
 		}
+	}
+}
+
+// Csrf provides a temporal security token.
+type Csrf struct {
+	Token string `json:"csrf_token"`
+}
+
+func (hv *Hypervisor) getCsrf() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, err := newCSRFToken()
+		if err != nil {
+			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
+			return
+		}
+
+		httputil.WriteJSON(w, r, http.StatusOK, Csrf{
+			Token: token,
+		})
 	}
 }
 
@@ -1344,6 +1365,21 @@ func (hv *Hypervisor) visorCtx(w http.ResponseWriter, r *http.Request) (*httpCtx
 	if err != nil {
 		httputil.WriteJSON(w, r, http.StatusBadRequest, err)
 		return nil, false
+	}
+
+	if r.Method == "POST" || r.Method == "PUT" || r.Method == "DELETE" {
+		csrfToken := r.Header.Get(CSRFHeaderName)
+		if csrfToken == "" {
+			errMsg := fmt.Errorf("no csrf token for %s request", r.Method)
+			httputil.WriteJSON(w, r, http.StatusForbidden, errMsg)
+			return nil, false
+		}
+
+		err = verifyCSRFToken(csrfToken)
+		if err != nil {
+			httputil.WriteJSON(w, r, http.StatusForbidden, err)
+			return nil, false
+		}
 	}
 
 	if pk != hv.c.PK {

--- a/static/skywire-manager-src/src/app/services/api.service.ts
+++ b/static/skywire-manager-src/src/app/services/api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NgZone } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, first, map, mergeMap } from 'rxjs/operators';
 import { webSocket } from 'rxjs/webSocket';
 import { Router } from '@angular/router';
 
@@ -22,6 +22,7 @@ export class RequestOptions {
   requestType = RequestTypes.Json;
   ignoreAuth = false;
   vpnKeyForAuth: string;
+  csrfToken: string;
 
   public constructor(init?: Partial<RequestOptions>) {
     Object.assign(this, init);
@@ -69,7 +70,12 @@ export class ApiService {
    * @param url Endpoint URL, after the "/api/" part.
    */
   post(url: string, body: any = {}, options: RequestOptions = null): Observable<any> {
-    return this.request('POST', url, body, options);
+    return this.getCsrf().pipe(first(), mergeMap(csrf => {
+      options = options ? options : new RequestOptions();
+      options.csrfToken = csrf;
+
+      return this.request('POST', url, body, options);
+    }));
   }
 
   /**
@@ -77,7 +83,12 @@ export class ApiService {
    * @param url Endpoint URL, after the "/api/" part.
    */
   put(url: string, body: any = {}, options: RequestOptions = null): Observable<any> {
-    return this.request('PUT', url, body, options);
+    return this.getCsrf().pipe(first(), mergeMap(csrf => {
+      options = options ? options : new RequestOptions();
+      options.csrfToken = csrf;
+
+      return this.request('PUT', url, body, options);
+    }));
   }
 
   /**
@@ -85,7 +96,19 @@ export class ApiService {
    * @param url Endpoint URL, after the "/api/" part.
    */
   delete(url: string, options: RequestOptions = null): Observable<any> {
-    return this.request('DELETE', url, {}, options);
+    return this.getCsrf().pipe(first(), mergeMap(csrf => {
+      options = options ? options : new RequestOptions();
+      options.csrfToken = csrf;
+
+      return this.request('DELETE', url, {}, options);
+    }));
+  }
+
+  /**
+   * Gets a csrf token from the node, to be able to make protected requests.
+   */
+  private getCsrf(): Observable<string> {
+    return this.get('csrf').pipe(map(response => response.csrf_token));
   }
 
   /**
@@ -136,6 +159,10 @@ export class ApiService {
 
     if (options.requestType === RequestTypes.Json) {
       requestOptions.headers = requestOptions.headers.append('Content-Type', 'application/json');
+    }
+
+    if (options.csrfToken) {
+      requestOptions.headers = requestOptions.headers.append('X-CSRF-Token', options.csrfToken);
     }
 
     return requestOptions;


### PR DESCRIPTION
 Changes:	
- Now the hypervisor request a CSRF token for the POST, PUT and DELETE operations. If the token is not found or invalid, an error is returned. The code is based on the one used on the Skycoin repo, but with various changes.

How to test this PR:
Try to make a POST, PUT or DELETE operation using the hypervisor API, it will return an error. For getting the token, you must first call the `GET /csrf` API endpoint.

The CSRF token should be added to the `X-CSRF-Token` header of the API requests, for the server to check it. The token is valid for 30 seconds only.

If you recompile the UI and make the operations with it, it will get and use the token automatically, so everything should work normally.

NOTE: Maybe a config option should be added to disable the CSRF token protection.