### PR TITLE
reduce `transport_manager` timeout on module shutting down

### DIFF
--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -485,11 +485,6 @@ func (v *Visor) Close() error {
 		errCh := make(chan error, 1)
 		t := time.NewTimer(moduleShutdownTimeout)
 
-		// should keep transport.manager shutdown continue till all transports delete there
-		if cl.src == "transport.manager" {
-			t = time.NewTimer(2 * time.Hour)
-		}
-
 		log := v.MasterLogger().PackageLogger(fmt.Sprintf("visor:shutdown:%s", cl.src)).
 			WithField("func", fmt.Sprintf("[%d/%d]", i+1, len(v.closeStack)))
 		log.Debug("Shutting down module...")


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1544 

 Changes:	
- remove 2hours timeout shutting down module for transport_manager

How to test this PR:
- run integration env
- stop `tp-discovery`
- shutdown a visor by `Ctrl+c`
- check logs for **timeout error** on `transport_manager` module shutting down