### PR TITLE
`skywire-cli log` collect transport bandwidth logging for today

### DIFF
--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -42,14 +42,14 @@ var (
 
 func init() {
 	logCmd.Flags().SortFlags = false
-	logCmd.Flags().StringVarP(&env, "env", "e", "prod", "selecting env to fetch uptimes, default is prod")
+	logCmd.Flags().StringVarP(&env, "env", "e", "prod", "deployment to get uptimes from")
 	logCmd.Flags().BoolVarP(&logOnly, "log", "l", false, "fetch only transport logs")
 	logCmd.Flags().BoolVarP(&surveyOnly, "survey", "v", false, "fetch only surveys")
 	logCmd.Flags().BoolVarP(&deleteOnErrors, "clean", "c", false, "delete files and folders on errors")
-	logCmd.Flags().StringVar(&minv, "minv", "v1.3.4", "minimum version for get logs, default is 1.3.4")
-	logCmd.Flags().IntVarP(&duration, "duration", "n", 1, "numberof days before today to fetch transport logs for")
+	logCmd.Flags().StringVar(&minv, "minv", "v1.3.4", "minimum visor version to fetch from")
+	logCmd.Flags().IntVarP(&duration, "duration", "n", 0, "numberof days before today to fetch transport logs for")
 	logCmd.Flags().BoolVar(&allVisors, "all", false, "consider all visors ; no version filtering")
-	logCmd.Flags().IntVar(&batchSize, "batchSize", 50, "number of visor in each batch, default is 50")
+	logCmd.Flags().IntVar(&batchSize, "batchSize", 50, "number of visor in each batch")
 	logCmd.Flags().Int64Var(&maxFileSize, "maxfilesize", 30, "maximum file size allowed to download during collecting logs, in KB")
 	logCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", skyenv.DmsgDiscAddr, "dmsg discovery url\n")
 	logCmd.Flags().StringVarP(&utAddr, "ut", "u", "", "custom uptime tracker url")
@@ -175,14 +175,9 @@ var logCmd = &cobra.Command{
 						download(ctx, log, httpC, "node-info.json", "node-info.json", key, maxFileSize) //nolint
 					}
 					if !surveyOnly {
-						if duration == 1 {
-							yesterday := time.Now().AddDate(0, 0, -1).UTC().Format("2006-01-02")
-							download(ctx, log, httpC, "transport_logs/"+yesterday+".csv", yesterday+".csv", key, maxFileSize) //nolint
-						} else {
-							for i := 1; i <= duration; i++ {
-								date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
-								download(ctx, log, httpC, "transport_logs/"+date+".csv", date+".csv", key, maxFileSize) //nolint
-							}
+						for i := 0; i <= duration; i++ {
+							date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
+							download(ctx, log, httpC, "transport_logs/"+date+".csv", date+".csv", key, maxFileSize) //nolint
 						}
 					}
 				}(v.PubKey, &wg)


### PR DESCRIPTION
This changes the default behavior of `skywire-cli log` to collect transport bandwidth logging for the current day instead of yesterday.

This will enable hourly updates of transport bandwidth logging for the current day.

It's prudent to still collect those logs for the previous day in addition to the current day with:

```
skywire-cli log -n1
```