### PR TITLE
UI for turning off the visor

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/actions/node-actions-helper.ts
@@ -35,6 +35,7 @@ export class NodeActionsHelper {
   returnButtonText: string;
 
   private rebootSubscription: Subscription;
+  private shutdownSubscription: Subscription;
   private updateSubscription: Subscription;
 
   // Services this class need.
@@ -83,6 +84,12 @@ export class NodeActionsHelper {
         name: 'actions.menu.reboot',
         actionName: 'reboot',
         icon: 'rotate_right'
+      });
+
+      this.options.push({
+        name: 'actions.menu.turn-off',
+        actionName: 'shutdown',
+        icon: 'power_settings_new'
       });
     }
 
@@ -138,6 +145,8 @@ export class NodeActionsHelper {
       this.runtimeLogs();
     } else if (actionName === 'reboot') {
       this.reboot();
+    } else if (actionName === 'shutdown') {
+      this.shutdown();
     } else if (actionName === null) {
       // Null is returned if the back button was pressed.
       this.back();
@@ -150,6 +159,9 @@ export class NodeActionsHelper {
   dispose() {
     if (this.rebootSubscription) {
       this.rebootSubscription.unsubscribe();
+    }
+    if (this.shutdownSubscription) {
+      this.shutdownSubscription.unsubscribe();
     }
     if (this.updateSubscription) {
       this.updateSubscription.unsubscribe();
@@ -165,6 +177,25 @@ export class NodeActionsHelper {
       this.rebootSubscription = this.nodeService.reboot(this.currentNodeKey).subscribe(() => {
         this.snackbarService.showDone('actions.reboot.done');
         confirmationDialog.close();
+      }, (err: OperationError) => {
+        err = processServiceError(err);
+
+        confirmationDialog.componentInstance.showDone('confirmation.error-header-text', err.translatableErrorMsg);
+      });
+    });
+  }
+
+  shutdown() {
+    const confirmationDialog = GeneralUtils.createConfirmationDialog(this.dialog, 'actions.turn-off.confirmation');
+
+    confirmationDialog.componentInstance.operationAccepted.subscribe(() => {
+      confirmationDialog.componentInstance.showProcessing();
+
+      this.shutdownSubscription = this.nodeService.shutdown(this.currentNodeKey).subscribe(() => {
+        this.snackbarService.showDone('actions.turn-off.done');
+        confirmationDialog.close();
+
+        this.router.navigate(['nodes']);
       }, (err: OperationError) => {
         err = processServiceError(err);
 

--- a/static/skywire-manager-src/src/app/services/node.service.ts
+++ b/static/skywire-manager-src/src/app/services/node.service.ts
@@ -354,6 +354,13 @@ export class NodeService {
   }
 
   /**
+   * Turns off a node.
+   */
+  shutdown(nodeKey: string): Observable<any> {
+    return this.apiService.post(`visors/${nodeKey}/shutdown`);
+  }
+
+  /**
    * Checks if a node is currently being updated.
    */
   checkIfUpdating(nodeKey: string): Observable<any> {

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -337,11 +337,16 @@
       "config": "Configuration",
       "update": "Update",
       "reboot": "Reboot",
+      "turn-off": "Turn off",
       "logs": "View logs"
     },
     "reboot": {
       "confirmation": "Are you sure you want to reboot the visor?",
       "done": "The visor is restarting."
+    },
+    "turn-off": {
+      "confirmation": "Are you sure you want to turn off the visor?",
+      "done": "The visor is shutting down."
     },
     "update": {
       "confirmation": "A terminal will be opened in a new tab and the update procedure will be started automatically. Do you want to continue?"

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -341,11 +341,16 @@
       "config": "Configuración",
       "update": "Actualizar",
       "reboot": "Reiniciar",
+      "turn-off": "Apagar",
       "logs": "Ver logs"
     },
     "reboot": {
       "confirmation": "¿Seguro que desea reiniciar el visor?",
       "done": "El visor se está reiniciando."
+    },
+    "turn-off": {
+      "confirmation": "¿Seguro que desea apagar el visor?",
+      "done": "El visor se está apagando."
     },
     "update": {
       "confirmation": "Una terminal será abierta en una nueva pestaña y el proceso de actualización iniciará automáticamente. ¿Desea continuar?"

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -341,11 +341,16 @@
       "config": "Configuration",
       "update": "Update",
       "reboot": "Reboot",
+      "turn-off": "Turn off",
       "logs": "View logs"
     },
     "reboot": {
       "confirmation": "Are you sure you want to reboot the visor?",
       "done": "The visor is restarting."
+    },
+    "turn-off": {
+      "confirmation": "Are you sure you want to turn off the visor?",
+      "done": "The visor is shutting down."
     },
     "update": {
       "confirmation": "A terminal will be opened in a new tab and the update procedure will be started automatically. Do you want to continue?"


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- There is a new option inside the UI for turning off the visor:
![option](https://github.com/skycoin/skywire/assets/34079003/a0f58370-96fc-4f6e-b5ae-f516849b98f9)


How to test this PR:
This depends on https://github.com/skycoin/skywire/pull/1577#issuecomment-1619166977
