### PR TITLE
improve ping command output

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping.go
@@ -47,7 +47,7 @@ var pingCmd = &cobra.Command{
 		internal.Catch(cmd.Flags(), err)
 
 		for _, latency := range latencies {
-			internal.PrintOutput(cmd.Flags(), fmt.Sprint(latency), fmt.Sprintf(fmt.Sprint(latency)+"\n"))
+			internal.PrintOutput(cmd.Flags(), latency, fmt.Sprintf("Latency: %0.2f ms | Speed: %0.3f KB/s\n", 1000*latency.Seconds(), float64(pcktSize)/float64(latency.Seconds())))
 		}
 		err = rpcClient.StopPing(pk)
 		internal.Catch(cmd.Flags(), err)


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- improve `ping` command output

How to test this PR:
- Do a ping to a visor by `skywire-cli visor ping <pk> -t 5 -s 5`