### PR TITLE
fix `ping` command logic

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -328,16 +328,6 @@ func (r *router) PingRoute(
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, lPK, lPort, rPort)
 
-	r.routeSetupHookMu.Lock()
-	defer r.routeSetupHookMu.Unlock()
-	if len(r.routeSetupHooks) != 0 {
-		for _, rsf := range r.routeSetupHooks {
-			if err := rsf(rPK, r.tm); err != nil {
-				return nil, err
-			}
-		}
-	}
-
 	// check if transports are available
 	ok := r.checkIfTransportAvailable()
 	if !ok {


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- remove auto-transport logic from `ping` command logic

How to test this PR:
- Run visor
- Trying to make ping to arbitrary PK
- Check visor logs and output of `ping` command