### PR TITLE
Fix wrong config generation with t flag

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -477,7 +477,7 @@ var genConfigCmd = &cobra.Command{
 				serviceConfURL = utilenv.ServiceConfAddr
 			}
 			//use test deployment
-			if serviceConfURL == "" && isTestEnv {
+			if isTestEnv {
 				serviceConfURL = utilenv.TestServiceConfAddr
 			}
 			// enable errors from service conf fetch from the combination of these flags


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1660 

 Changes:	
- fix condition on use testEnv config URLs

How to test this PR:
- just run `skywire-cli config gen` with and without `-t` flag, and check generated output.