### PR TITLE
add skywire version to `skywire-cli log`

### DIFF
--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -243,7 +243,7 @@ func download(ctx context.Context, log *logging.Logger, httpC http.Client, targe
 	defer file.Close()                            //nolint
 
 	if err := downloadDmsg(ctx, log, &httpC, file, target, maxSize); err != nil {
-		log.WithError(err).Errorf("The %s for visor %s not available. The version of visor is %s", fileName, pubkey, version.String())
+		log.WithError(err).Errorf("The %s for visor %s not available. The version of visor is %s.", fileName, pubkey, version.String())
 		return err
 	}
 	return nil


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1638 

 Changes:	
- add skywire version on error log in `skywire-cli log` commnad. We have same on not satisfied version, so we just add it for error on downloading files.

How to test this PR:
- checkout to this branch
- build by `make build`
- run `skywire-cli log`

Output Example:
```
[2023-11-02T02:36:39.018016+03:30] ERROR [log-collecting]: The 2023-11-01.csv for visor 02132cb9f9b8d7f1441b04cbf27b78eff05c5c419efda177b5fe9a2843f8e107b5 not available. The version of visor is 1.3.13. error="http error: 404"
```