### PR TITLE
Fix two panic issues on `skywire-cli` commands

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -153,10 +153,10 @@ func (v *Visor) Overview() (*Overview, error) {
 	var publicIP string
 	var isSymmetricNAT bool
 	if v == nil {
-		panic("v is nil")
+		return &Overview{}, errors.New("v is nil")
 	}
 	if v.tpM == nil {
-		panic("tpM is nil")
+		return &Overview{}, errors.New("tpM is nil")
 	}
 	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
 		tSummaries = append(tSummaries,

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -153,10 +153,10 @@ func (v *Visor) Overview() (*Overview, error) {
 	var publicIP string
 	var isSymmetricNAT bool
 	if v == nil {
-		return &Overview{}, errors.New("v is nil")
+		return &Overview{}, ErrVisorNotAvailable
 	}
 	if v.tpM == nil {
-		return &Overview{}, errors.New("tpM is nil")
+		return &Overview{}, ErrTrpMangerNotAvailable
 	}
 	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
 		tSummaries = append(tSummaries,

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1064,12 +1064,14 @@ func (v *Visor) Transports(types []string, pks []cipher.PubKey, logs bool) ([]*T
 		}
 		return true
 	}
-	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
-		if typeIncluded(tp.Type()) && pkIncluded(v.tpM.Local(), tp.Remote()) {
-			result = append(result, newTransportSummary(v.tpM, tp, logs, v.router.SetupIsTrusted(tp.Remote())))
-		}
-		return true
-	})
+	if v.tpM != nil {
+		v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
+			if typeIncluded(tp.Type()) && pkIncluded(v.tpM.Local(), tp.Remote()) {
+				result = append(result, newTransportSummary(v.tpM, tp, logs, v.router.SetupIsTrusted(tp.Remote())))
+			}
+			return true
+		})
+	}
 
 	return result, nil
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1032,6 +1032,9 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 // TransportTypes implements API.
 func (v *Visor) TransportTypes() ([]string, error) {
 	var types []string
+	if v.tpM == nil {
+		return types, ErrTrpMangerNotAvailable
+	}
 	for _, netType := range v.tpM.Networks() {
 		types = append(types, string(netType))
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -42,6 +42,8 @@ import (
 )
 
 var (
+	// ErrVisorNotAvailable represents error for unavailable visor
+	ErrVisorNotAvailable = errors.New("no visor available")
 	// ErrAppProcNotRunning represents lookup error for App related calls.
 	ErrAppProcNotRunning = errors.New("no process of given app is running")
 	// ErrProcNotAvailable represents error for unavailable process manager


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1492 #1596

 Changes:	
- replace `panic` with `error` on `Overview` rpc implementation
- add some condition for check `tpM` is available or not

How to test this PR:
- build on this branch
- run a visor
- check commands `skywire-cli visor tp ls` and `skywire-cli visor info` immediately after running visor, how introduce on issues