### PR TITLE
improve `skywire-cli proxy` command

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -907,6 +907,7 @@ var genConfigCmd = &cobra.Command{
 				Binary:    visorconfig.SkysocksClientName,
 				AutoStart: false,
 				Port:      routing.Port(visorconfig.SkysocksClientPort),
+				Args:      []string{"-addr", visorconfig.SkysocksClientAddr},
 			},
 			{
 				Name:      visorconfig.VPNServerName,

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -118,11 +118,11 @@ var stopCmd = &cobra.Command{
 		}
 		if allClients {
 			internal.Catch(cmd.Flags(), rpcClient.StopSkysocksClients())
-			internal.PrintOutput(cmd.Flags(), "All Skysocks Client stopped", fmt.Sprintln("All Skysocks Client stopped"))
+			internal.PrintOutput(cmd.Flags(), "all skysocks client stopped", fmt.Sprintln("all skysocks clients stopped"))
 			return
 		}
 		internal.Catch(cmd.Flags(), rpcClient.StopApp(clientName))
-		internal.PrintOutput(cmd.Flags(), fmt.Sprintf("Skysocks Client %s stopped", clientName), fmt.Sprintf("Skysocks Client %s stopped\n", clientName))
+		internal.PrintOutput(cmd.Flags(), fmt.Sprintf("skysocks client %s stopped", clientName), fmt.Sprintf("skysocks client %s stopped\n", clientName))
 	},
 }
 

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -37,6 +37,8 @@ func init() {
 		version = ""
 	}
 	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
+	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
+	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
 	listCmd.Flags().StringVarP(&sdURL, "url", "a", "", "service discovery url default:\n"+skyenv.ServiceDiscAddr)
 	listCmd.Flags().BoolVarP(&directQuery, "direct", "b", false, "query service discovery directly")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
@@ -108,8 +110,16 @@ var stopCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
-		internal.Catch(cmd.Flags(), rpcClient.StopSkysocksClient())
-		internal.PrintOutput(cmd.Flags(), "OK", fmt.Sprintln("OK"))
+		if allClients && clientName != "" {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("cannot use both --all and --name flag in together"))
+		}
+		if allClients {
+			internal.Catch(cmd.Flags(), rpcClient.StopSkysocksClients())
+			internal.PrintOutput(cmd.Flags(), "All Skysocks Client stopped", fmt.Sprintln("All Skysocks Client stopped"))
+			return
+		}
+		internal.Catch(cmd.Flags(), rpcClient.StopApp(clientName))
+		internal.PrintOutput(cmd.Flags(), fmt.Sprintf("Skysocks Client %s stopped", clientName), fmt.Sprintf("Skysocks Client %s stopped\n", clientName))
 	},
 }
 

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -113,6 +113,9 @@ var stopCmd = &cobra.Command{
 		if allClients && clientName != "" {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("cannot use both --all and --name flag in together"))
 		}
+		if !allClients && clientName == "" {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("you should use one of flags, --all or --name"))
+		}
 		if allClients {
 			internal.Catch(cmd.Flags(), rpcClient.StopSkysocksClients())
 			internal.PrintOutput(cmd.Flags(), "All Skysocks Client stopped", fmt.Sprintln("All Skysocks Client stopped"))

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -9,6 +9,7 @@ import (
 )
 
 var (
+	binaryName   = "skysocks-client"
 	stateName    = "skysocks-client"
 	serviceType  = servicedisc.ServiceTypeProxy
 	servicePort  = ":44"

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -25,6 +25,7 @@ var (
 	servers      []servicedisc.Service
 	allClients   bool
 	clientName   string
+	addr         string
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -23,6 +23,8 @@ var (
 	sdURL        string
 	directQuery  bool
 	servers      []servicedisc.Service
+	allClients   bool
+	clientName   string
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -3,6 +3,7 @@ package clivpn
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -12,10 +13,12 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
+	"github.com/skycoin/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire-utilities/pkg/skyenv"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
@@ -80,6 +83,14 @@ var startCmd = &cobra.Command{
 		}
 		internal.Catch(cmd.Flags(), rpcClient.StartVPNClient(pubkey))
 		internal.PrintOutput(cmd.Flags(), nil, "Starting.")
+		ctx, cancel := cmdutil.SignalContext(context.Background(), &logrus.Logger{})
+		defer cancel()
+		go func() {
+			<-ctx.Done()
+			cancel()
+			rpcClient.StopVPNClient("vpn-client") //nolint
+			os.Exit(1)
+		}()
 		startProcess := true
 		for startProcess {
 			time.Sleep(time.Second * 1)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -89,7 +89,7 @@ type API interface {
 
 	//skysocks-client controls
 	StartSkysocksClient(pk string) error
-	StopSkysocksClient() error
+	StopSkysocksClients() error
 	ProxyServers(version, country string) ([]servicedisc.Service, error)
 
 	//transports
@@ -598,15 +598,19 @@ func (v *Visor) StartSkysocksClient(serverKey string) error {
 	return errors.New("no skysocks-client app configuration found")
 }
 
-// StopSkysocksClient implements API.
-func (v *Visor) StopSkysocksClient() error {
+// StopSkysocksClients implements API.
+func (v *Visor) StopSkysocksClients() error {
 	// check process manager and app launcher availability
 	if v.appL == nil {
 		return ErrAppLauncherNotAvailable
 	}
 	if v.procM != nil {
-		_, err := v.appL.StopApp(visorconfig.SkysocksClientName) //nolint:errcheck
-		return err
+		for _, app := range v.conf.Launcher.Apps {
+			if app.Binary == visorconfig.SkysocksClientName {
+				v.appL.StopApp(app.Name) //nolint
+			}
+		}
+		return nil
 	}
 	return ErrProcNotAvailable
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -62,6 +62,7 @@ type API interface {
 	App(appName string) (*appserver.AppState, error)
 	Apps() ([]*appserver.AppState, error)
 	StartApp(appName string) error
+	AddApp(appName, binaryName string) error
 	RegisterApp(procConf appcommon.ProcConfig) (appcommon.ProcKey, error)
 	DeregisterApp(procKey appcommon.ProcKey) error
 	StopApp(appName string) error
@@ -457,6 +458,15 @@ func (v *Visor) StartApp(appName string) error {
 		return v.appL.StartApp(appName, nil, envs)
 	}
 	return ErrProcNotAvailable
+}
+
+// AddApp implement API.
+func (v *Visor) AddApp(appName, binaryName string) error {
+	// check process manager and app launcher availability
+	if v.appL == nil {
+		return ErrAppLauncherNotAvailable
+	}
+	return v.conf.AddAppConfig(v.appL, appName, binaryName)
 }
 
 // RegisterApp implements API.

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -261,17 +261,10 @@ func (r *RPC) AddApp(in *SetAppAddIn, _ *struct{}) (err error) {
 	return r.visor.AddApp(in.AppName, in.BinaryName)
 }
 
-// DoCustomSettingIn is input for DoCustomSetting
-type DoCustomSettingIn struct {
-	AppName       string
-	CustomSetting map[string]string
-}
-
 // DoCustomSetting set custom setting to apps arguments
-func (r *RPC) DoCustomSetting(in *DoCustomSettingIn, _ *struct{}) (err error) {
+func (r *RPC) DoCustomSetting(in *SetAppMapIn, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "DoCustomSetting", in)(nil, &err)
-
-	return r.visor.DoCustomSetting(in.AppName, in.CustomSetting)
+	return r.visor.DoCustomSetting(in.AppName, in.Val)
 }
 
 // RegisterApp registers a App with provided proc config.

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -248,6 +248,32 @@ func (r *RPC) StartApp(name *string, _ *struct{}) (err error) {
 	return r.visor.StartApp(*name)
 }
 
+// SetAppAddIn is input for SetAppAdd.
+type SetAppAddIn struct {
+	AppName    string
+	BinaryName string
+}
+
+// AddApp add app to config
+func (r *RPC) AddApp(in *SetAppAddIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "AddApp", in)(nil, &err)
+
+	return r.visor.AddApp(in.AppName, in.BinaryName)
+}
+
+// DoCustomSettingIn is input for DoCustomSetting
+type DoCustomSettingIn struct {
+	AppName       string
+	CustomSetting map[string]string
+}
+
+// DoCustomSetting set custom setting to apps arguments
+func (r *RPC) DoCustomSetting(in *DoCustomSettingIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "DoCustomSetting", in)(nil, &err)
+
+	return r.visor.DoCustomSetting(in.AppName, in.CustomSetting)
+}
+
 // RegisterApp registers a App with provided proc config.
 func (r *RPC) RegisterApp(procConf *appcommon.ProcConfig, reply *appcommon.ProcKey) (err error) {
 	defer rpcutil.LogCall(r.log, "RegisterApp", procConf)(reply, &err)

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -290,11 +290,11 @@ func (r *RPC) StartSkysocksClient(pk string, _ *struct{}) (err error) {
 	return r.visor.StartSkysocksClient(pk)
 }
 
-// StopSkysocksClient stops SkysocksClient App
-func (r *RPC) StopSkysocksClient(_ *struct{}, _ *struct{}) (err error) {
-	defer rpcutil.LogCall(r.log, "StopSkysocksClient", nil)(nil, &err)
+// StopSkysocksClients stops all SkysocksClient Apps
+func (r *RPC) StopSkysocksClients(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "StopSkysocksClients", nil)(nil, &err)
 
-	return r.visor.StopSkysocksClient()
+	return r.visor.StopSkysocksClients()
 }
 
 // RestartApp restarts App with provided name.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -193,9 +193,9 @@ func (rc *rpcClient) StartSkysocksClient(pk string) error {
 	return rc.Call("StartSkysocksClient", pk, &struct{}{})
 }
 
-// StopSkysocksClient calls StopSkysocksClient.
-func (rc *rpcClient) StopSkysocksClient() error {
-	return rc.Call("StopSkysocksClient", &struct{}{}, &struct{}{})
+// StopSkysocksCliens calls StopSkysocksCliens.
+func (rc *rpcClient) StopSkysocksClients() error {
+	return rc.Call("StopSkysocksClients", &struct{}{}, &struct{}{})
 }
 
 // SetAppDetailedStatus sets app's detailed state.
@@ -857,8 +857,8 @@ func (*mockRPCClient) StartSkysocksClient(string) error {
 	return nil
 }
 
-// StopSkysocksClient implements API.
-func (*mockRPCClient) StopSkysocksClient() error {
+// StopSkysocksClients implements API.
+func (*mockRPCClient) StopSkysocksClients() error {
 	return nil
 }
 

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -161,6 +161,14 @@ func (rc *rpcClient) StartApp(appName string) error {
 	return rc.Call("StartApp", &appName, &struct{}{})
 }
 
+// AddApp calls AddApp.
+func (rc *rpcClient) AddApp(appName, binaryName string) error {
+	return rc.Call("AddApp", &SetAppAddIn{
+		AppName:    appName,
+		BinaryName: binaryName,
+	}, &struct{}{})
+}
+
 // RegisterApp calls RegisterApp.
 func (rc *rpcClient) RegisterApp(procConf appcommon.ProcConfig) (appcommon.ProcKey, error) {
 	var procKey appcommon.ProcKey
@@ -824,6 +832,11 @@ func (mc *mockRPCClient) App(appName string) (*appserver.AppState, error) {
 
 // StartApp implements API.
 func (*mockRPCClient) StartApp(string) error {
+	return nil
+}
+
+// AddApp implement API.
+func (*mockRPCClient) AddApp(string, string) error {
 	return nil
 }
 

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -257,6 +257,7 @@ func makeDefaultLauncherAppsConfig(dnsServer string) []appserver.AppConfig {
 			Binary:    SkysocksClientName,
 			AutoStart: false,
 			Port:      routing.Port(skyenv.SkysocksClientPort),
+			Args:      []string{"-addr", SkysocksClientAddr},
 		},
 		{
 			Name:      VPNServerName,

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -256,7 +256,7 @@ func (v1 *V1) AddAppConfig(launch *launcher.AppLauncher, appName, binaryName str
 	for {
 		min := 10
 		max := 99
-		randomNumber := rand.Intn(max-min+1) + min //nolint
+		randomNumber = rand.Intn(max-min+1) + min //nolint
 		if _, ok := busyPorts[routing.Port(randomNumber)]; !ok {
 			break
 		}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -3,6 +3,7 @@ package visorconfig
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/dmsgc"
+	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
@@ -234,6 +236,40 @@ func (v1 *V1) UpdatePublicAutoconnect(pAc bool) error {
 	v1.Transport.PublicAutoconnect = pAc
 	v1.mu.Unlock()
 
+	return v1.flush(v1)
+}
+
+// AddAppConfig add new config to apps if name was not same
+func (v1 *V1) AddAppConfig(launch *launcher.AppLauncher, appName, binaryName string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	busyPorts := map[routing.Port]bool{}
+	for _, app := range conf.Apps {
+		busyPorts[app.Port] = true
+		if app.Name == appName {
+			return fmt.Errorf("the app exist")
+		}
+	}
+	var randomNumber int
+	for {
+		min := 10
+		max := 99
+		randomNumber := rand.Intn(max-min+1) + min //nolint
+		if _, ok := busyPorts[routing.Port(randomNumber)]; !ok {
+			break
+		}
+	}
+
+	conf.Apps = append(conf.Apps, appserver.AppConfig{Name: appName, Binary: binaryName, Port: routing.Port(randomNumber)})
+
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
 	return v1.flush(v1)
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1675 #1682

 Changes:
- [x] reimplement `skywire-cli proxy status` output
- [x] improve `skywire-cli proxy stop` command by add two flags `--all` and `--name`
- [x] reimplementation `skywire-cli proxy start` command 
- [x] add `ctrl+c` signal to `skywire-cli proxy start` and `skywire-cli vpn start` commands 

How to test this PR:
- build skywire at this branch and run a visor
- run `skywire-cli proxy status` for check status of proxies that available in skywire-config.json file
- run proxy and check status command again
- add new custom proxy to config like this: `skywire-cli proxy start --name uk-proxy --pk 0216f90f998b11e83b0fa8eb76e5ba03c5dd72ab68432264f37e282f704992cd9f --addr :9090`. By this command, we trying to add new custom proxy named `uk-proxy` with `-srv` flag as PubKey we use here `0216...` and `-addr` flag as port available for proxy `127.0.0.1`. Check status of proxies by `skywire-cli proxy status` again after running custom proxy.
- `skywire-cli proxy stop --name uk-proxy` will stop uk-proxy. If you want stop all running proxies use `--all` flag as `skywire-cli proxy stop --all`
- use arbitrary PK and start proxy or vpn, then trying `ctrl+c` shutdown signal shortcut.