### PR TITLE
new flag `--confpath` on generate config

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -188,7 +188,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "envs")
 	genConfigCmd.Flags().BoolVar(&noFetch, "nofetch", false, "do not fetch the services from the service conf url")
 	gHiddenFlags = append(gHiddenFlags, "nofetch")
-	genConfigCmd.Flags().StringVar(&configServicePath, "config-service", "", "path of config-service offline file")
+	genConfigCmd.Flags().StringVar(&configServicePath, "confpath", "", "path of config-service offline file")
 	genConfigCmd.Flags().BoolVar(&noDefaults, "nodefaults", false, "do not use hardcoded defaults for production / test services")
 	gHiddenFlags = append(gHiddenFlags, "nodefaults")
 	genConfigCmd.Flags().StringVar(&ver, "version", scriptExecString("${VERSION}"), "custom version testing override\033[0m")

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -92,6 +92,7 @@ var (
 	disableProxyServerAutostart bool
 	proxyServerPass             string
 	proxyClientPass             string
+	configServicePath           string
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add `--confpath` flag as path of offline file of https://conf.skywire.skycoin.com service that could read from file instead server for times that conf service not available.

How to test this PR:
- build binaries
- save https://conf.skywire.skycoin.com data into file like `conf.json`
- trying to create config by `skywire-cli config gen --confpath path/to/conf.json` command