### PR TITLE
Update Mainnet rules minimum version requirement

### DIFF
--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsghttp"
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire-utilities/pkg/logging"

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -56,7 +56,7 @@ func init() {
 	logCmd.Flags().StringVarP(&fetchFrom, "pks", "k", "", "fetch only from specific public keys ; semicolon separated")
 	logCmd.Flags().StringVarP(&writeDir, "dir", "d", "log_collecting", "save files to specified dir")
 	logCmd.Flags().BoolVarP(&deleteOnErrors, "clean", "c", false, "delete files and folders on errors")
-	logCmd.Flags().StringVar(&minv, "minv", "v1.3.11", "minimum visor version to fetch from")
+	logCmd.Flags().StringVar(&minv, "minv", buildinfo.Version(), "minimum visor version to fetch from")
 	logCmd.Flags().StringVar(&incVer, "include-versions", "", "list of version that not satisfy our minimum version condition, but we want include them")
 	logCmd.Flags().IntVarP(&duration, "duration", "n", 0, "number of days before today to fetch transport logs for")
 	logCmd.Flags().BoolVar(&allVisors, "all", false, "consider all visors ; no version filtering")

--- a/mainnet_rules.md
+++ b/mainnet_rules.md
@@ -39,7 +39,7 @@ A total of up to ~1117.808 Skycoin are distributed daily in non leap-years; even
 
 ## Rules & Requirements
 
-* **Minimum skywire version v1.3.13** - Cutoff October 1st 2023
+* **Minimum skywire version v1.3.14** - Cutoff December 1st 2023
 
 * The visor must be an **ARM architecture SBC running on approved [hardware](#hardware)**
 
@@ -70,11 +70,11 @@ skywire-cli -v
 skywire-visor -v
 ```
 
-**Reward eligibility requires Skywire v1.3.13**
+**Reward eligibility requires Skywire v1.3.14**
 
-Requirement established 8-29-2023
+Requirement established 11-10-2023
 
-Rewards Cutoff date for updating 10-1-2023
+Rewards Cutoff date for updating 12-1-2023
 
 ### Deployment
 


### PR DESCRIPTION
* updated mainnet rules minimum version requirement to v1.3.14 (the next release version)

* Set reward cutoff date to December 1st since there are breaking issues addressed by v1.3.14 release (dmsghttp-config)

* removed hardcoded version from skywire-cli log ; use current version