### PR TITLE
update golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Requirements
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
           make dep
           chmod +x ./ci_scripts/create-ip-aliases.sh
           ./ci_scripts/create-ip-aliases.sh
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Requirements
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.1
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
           make dep
           chmod +x ./ci_scripts/create-ip-aliases.sh
           ./ci_scripts/create-ip-aliases.sh
@@ -49,7 +49,7 @@ jobs:
       - name: Install Requirements
         run: |
           choco install make
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.1
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
           make dep
       - name: Testing
         run:  |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -163,7 +163,6 @@ linters:
     - megacheck
     - misspell
     - nakedret
-    - depguard
   enable-all: false
   disable-all: true
   presets:

--- a/cmd/skywire-cli/commands/dmsghttp/root.go
+++ b/cmd/skywire-cli/commands/dmsghttp/root.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -53,7 +52,7 @@ var dmsghttpCmd = &cobra.Command{
 			log.WithError(err).Error("Error accurs during marshal content to json file")
 		}
 
-		err = ioutil.WriteFile(path, file, 0600)
+		err = os.WriteFile(path, file, 0600)
 		if err != nil {
 			log.WithError(err).Errorf("Cannot save new dmsghttp-config.json file at %s", path)
 		}


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- upgrade golangci-lint to v1.55.2
- remove depguard from linting list config, because of its issue with newer version of golangci-lint (look at this issue https://github.com/golangci/golangci-lint/issues/3906)

How to test this PR:
_