### PR TITLE
fix logic of close app by sigterm

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -125,7 +125,6 @@ var startCmd = &cobra.Command{
 		}
 
 		ctx, cancel := cmdutil.SignalContext(context.Background(), &logrus.Logger{})
-		defer cancel()
 		go func() {
 			<-ctx.Done()
 			cancel()

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -84,7 +84,6 @@ var startCmd = &cobra.Command{
 		internal.Catch(cmd.Flags(), rpcClient.StartVPNClient(pubkey))
 		internal.PrintOutput(cmd.Flags(), nil, "Starting.")
 		ctx, cancel := cmdutil.SignalContext(context.Background(), &logrus.Logger{})
-		defer cancel()
 		go func() {
 			<-ctx.Done()
 			cancel()


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- fix `cancel()` func on sigterm close of `skysocks-client` and `vpn-client`	

How to test this PR:
_