### PR TITLE
Improve VPN and Proxy cli command

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -42,6 +42,7 @@ func init() {
 	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
 	startCmd.Flags().StringVarP(&addr, "addr", "a", "", "address of proxy for use")
 	startCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of skysocks client")
+	startCmd.Flags().IntVarP(&startingTimeout, "timeout", "t", 20, "starting timeout value in second")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
 	listCmd.Flags().StringVarP(&sdURL, "url", "a", "", "service discovery url default:\n"+skyenv.ServiceDiscAddr)
@@ -124,7 +125,11 @@ var startCmd = &cobra.Command{
 			return
 		}
 
-		ctx, cancel := cmdutil.SignalContext(context.Background(), &logrus.Logger{})
+		tCtc := context.Background() //nolint
+		if startingTimeout != 0 {
+			tCtc, _ = context.WithTimeout(context.Background(), time.Duration(startingTimeout)*time.Second) //nolint
+		}
+		ctx, cancel := cmdutil.SignalContext(tCtc, &logrus.Logger{})
 		go func() {
 			<-ctx.Done()
 			cancel()

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -9,23 +9,24 @@ import (
 )
 
 var (
-	binaryName   = "skysocks-client"
-	stateName    = "skysocks-client"
-	serviceType  = servicedisc.ServiceTypeProxy
-	servicePort  = ":44"
-	isUnFiltered bool
-	ver          string
-	country      string
-	isStats      bool
-	pubkey       cipher.PubKey
-	pk           string
-	count        int
-	sdURL        string
-	directQuery  bool
-	servers      []servicedisc.Service
-	allClients   bool
-	clientName   string
-	addr         string
+	binaryName      = "skysocks-client"
+	stateName       = "skysocks-client"
+	serviceType     = servicedisc.ServiceTypeProxy
+	servicePort     = ":44"
+	isUnFiltered    bool
+	ver             string
+	country         string
+	isStats         bool
+	pubkey          cipher.PubKey
+	pk              string
+	count           int
+	sdURL           string
+	directQuery     bool
+	servers         []servicedisc.Service
+	allClients      bool
+	clientName      string
+	addr            string
+	startingTimeout int
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -9,21 +9,22 @@ import (
 )
 
 var (
-	stateName    = "vpn-client"
-	serviceType  = servicedisc.ServiceTypeVPN
-	servicePort  = ":3"
-	path         string
-	isPkg        bool
-	isUnFiltered bool
-	ver          string
-	country      string
-	isStats      bool
-	pubkey       cipher.PubKey
-	pk           string
-	count        int
-	sdURL        string
-	directQuery  bool
-	servers      []servicedisc.Service
+	stateName       = "vpn-client"
+	serviceType     = servicedisc.ServiceTypeVPN
+	servicePort     = ":3"
+	path            string
+	isPkg           bool
+	isUnFiltered    bool
+	ver             string
+	country         string
+	isStats         bool
+	pubkey          cipher.PubKey
+	pk              string
+	count           int
+	sdURL           string
+	directQuery     bool
+	servers         []servicedisc.Service
+	startingTimeout int
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -40,6 +40,7 @@ func init() {
 		version = ""
 	}
 	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
+	startCmd.Flags().IntVarP(&startingTimeout, "timeout", "t", 20, "starting timeout value in second")
 	listCmd.Flags().StringVarP(&sdURL, "url", "a", "", "service discovery url default:\n"+skyenv.ServiceDiscAddr)
 	listCmd.Flags().BoolVarP(&directQuery, "direct", "b", false, "query service discovery directly")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
@@ -83,7 +84,11 @@ var startCmd = &cobra.Command{
 		}
 		internal.Catch(cmd.Flags(), rpcClient.StartVPNClient(pubkey))
 		internal.PrintOutput(cmd.Flags(), nil, "Starting.")
-		ctx, cancel := cmdutil.SignalContext(context.Background(), &logrus.Logger{})
+		tCtc := context.Background() //nolint
+		if startingTimeout != 0 {
+			tCtc, _ = context.WithTimeout(context.Background(), time.Duration(startingTimeout)*time.Second) //nolint
+		}
+		ctx, cancel := cmdutil.SignalContext(tCtc, &logrus.Logger{})
 		go func() {
 			<-ctx.Done()
 			cancel()


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1714

 Changes:	
- add `--timeout` (`-t`) flag to proxy cli command as `skywire-cli proxy start --timeout 30`
- add `--timeout` (`-t`) flag to vpn cli command as `skywire-cli vpn start -t 30`

Note: Default value of timeout is 20 second. If you pass zero value as `skywire-cli proxy start -t 0` then no timeout be there, for both vpn and proxy command.

How to test this PR:
- build
- trying to start proxy/vpn by cli command with small value like 2 as `skywire-cli proxy start --pk 0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7 -t 2`, it should stop after two second. (Note: key here is dummy, not valid proxy server)