### PR TITLE
Fix panic on `skywire-cli visor tp rm` command

### DIFF
--- a/cmd/skywire-cli/commands/visor/transports.go
+++ b/cmd/skywire-cli/commands/visor/transports.go
@@ -203,25 +203,20 @@ var rmTpCmd = &cobra.Command{
 	Long:                  "\n    Remove transport(s) by id",
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		//TODO
-		//if removeAll {
-		//	var pks cipher.PubKeys
-		//	internal.Catch(cmd.Flags(), pks.Set(strings.Join(filterPubKeys, ",")))
-		//	tID, err := clirpc.Client(cmd.Flags()).Transports(filterTypes, pks, showLogs)
-		//	internal.Catch(cmd.Flags(), err)
-		//	internal.Catch(cmd.Flags(), clirpc.Client(cmd.Flags()).RemoveTransport(tID))
-		//} else {
-		if args[0] != "" {
-			tpID = args[0]
-		}
-		tID := internal.ParseUUID(cmd.Flags(), "transport-id", tpID)
 		rpcClient, err := clirpc.Client(cmd.Flags())
-		if err != nil {
-			os.Exit(1)
+		if removeAll {
+			internal.Catch(cmd.Flags(), rpcClient.RemoveAllTransports())
+			internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+		} else if tpID != "" {
+			tID := internal.ParseUUID(cmd.Flags(), "transport-id", tpID)
+			if err != nil {
+				os.Exit(1)
+			}
+			internal.Catch(cmd.Flags(), rpcClient.RemoveTransport(tID))
+			internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
+		} else {
+			internal.PrintOutput(cmd.Flags(), "", cmd.Help())
 		}
-		internal.Catch(cmd.Flags(), rpcClient.RemoveTransport(tID))
-		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")
-		//}
 	},
 }
 

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -482,6 +482,22 @@ func (tm *Manager) DeleteTransport(id uuid.UUID) {
 	}
 }
 
+// DeleteAllTransports deregisters all Transports in transport discovery and deletes them locally.
+func (tm *Manager) DeleteAllTransports() {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+
+	if tm.isClosing() {
+		return
+	}
+
+	// Deregister transports before closing the underlying transport.
+	for _, tp := range tm.tps {
+		tp.close()
+		delete(tm.tps, tp.Entry.ID)
+	}
+}
+
 // ReadPacket reads data packets from routes.
 func (tm *Manager) ReadPacket() (routing.Packet, error) {
 	p, ok := <-tm.readCh

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -99,6 +99,7 @@ type API interface {
 	Transport(tid uuid.UUID) (*TransportSummary, error)
 	AddTransport(remote cipher.PubKey, tpType string, timeout time.Duration) (*TransportSummary, error)
 	RemoveTransport(tid uuid.UUID) error
+	RemoveAllTransports() error
 	SetPublicAutoconnect(pAc bool) error
 	GetPersistentTransports() ([]transport.PersistentTransports, error)
 	SetPersistentTransports([]transport.PersistentTransports) error
@@ -1189,6 +1190,12 @@ func (v *Visor) AddTransport(remote cipher.PubKey, tpType string, timeout time.D
 // RemoveTransport implements API.
 func (v *Visor) RemoveTransport(tid uuid.UUID) error {
 	v.tpM.DeleteTransport(tid)
+	return nil
+}
+
+// RemoveAllTransports implements API
+func (v *Visor) RemoveAllTransports() error {
+	v.tpM.DeleteAllTransports()
 	return nil
 }
 

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -527,6 +527,13 @@ func (r *RPC) RemoveTransport(tid *uuid.UUID, _ *struct{}) (err error) {
 	return r.visor.RemoveTransport(*tid)
 }
 
+// RemoveAllTransports removes all Transports from the visor.
+func (r *RPC) RemoveAllTransports(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "RemoveAllTransports", nil)(nil, &err)
+
+	return r.visor.RemoveAllTransports()
+}
+
 /*
 	<<< AVAILABLE TRANSPORTS >>>
 */

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -394,6 +394,11 @@ func (rc *rpcClient) RemoveTransport(tid uuid.UUID) error {
 	return rc.Call("RemoveTransport", &tid, &struct{}{})
 }
 
+// RemoveAllTransports calls RemoveAllTransports.
+func (rc *rpcClient) RemoveAllTransports() error {
+	return rc.Call("RemoveAllTransports", &struct{}{}, &struct{}{})
+}
+
 func (rc *rpcClient) DiscoverTransportsByPK(pk cipher.PubKey) ([]*transport.Entry, error) {
 	entries := make([]*transport.Entry, 0)
 	err := rc.Call("DiscoverTransportsByPK", &pk, &entries)
@@ -1155,6 +1160,14 @@ func (mc *mockRPCClient) RemoveTransport(tid uuid.UUID) error {
 			}
 		}
 		return fmt.Errorf("transport of id '%s' is not found", tid)
+	})
+}
+
+// RemoveAllTransports implements API.
+func (mc *mockRPCClient) RemoveAllTransports() error {
+	return mc.do(true, func() error {
+		mc.o.Transports = []*TransportSummary{}
+		return nil
 	})
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #1712 

 Changes:	
- implement `-a` flag on remove transports
- fix no argument panic and show `help` command output

How to test this PR:
- build and run visor
- make dmsg transport to visor (as fastest way to create transport)
- check `skywire-cli visor tp rm` to show help
- check `skywire-cli visor tp rm -a` for remove all transports
- check `skywire-cli visor tp ls` for approve removing transports