### PR TITLE
Fix flag on skysocks-client

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -4,7 +4,6 @@ package commands
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -70,8 +69,6 @@ var RootCmd = &cobra.Command{
 		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
 			print(fmt.Sprintf("Failed to output build info: %v\n", err))
 		}
-
-		flag.Parse()
 
 		if serverPK == "" {
 			err := errors.New("Empty server PubKey. Exiting")


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- remove flag.Parse() from skysocks-client code

How to test this PR:
_