### PR TITLE
Fix `proxy start` and `proxy stop`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,21 @@ commit:
 check: lint check-cg test ## Run linters and tests
 
 check-cg: ## Cursory check of the main help menu, offline dmsghttp config gen and offline config gen
+	@echo "checking help menu for compilation without errors"
+	@echo
 	go run cmd/skywire-deployment/skywire.go --help
+	@echo
+	@echo "checking dmsghttp offline config gen"
+	@echo
 	go run cmd/skywire-deployment/skywire.go cli config gen --nofetch -dnw
+	@echo
+	@echo "checking offline config gen"
+	@echo
 	go run cmd/skywire-deployment/skywire.go cli config gen --nofetch -nw
+	@echo
+	@echo "config gen succeeded without error"
+	@echo
+
 
 check-windows: lint-windows test-windows ## Run linters and tests on windows image
 

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -34,7 +34,7 @@ func init() {
 	)
 	version := buildinfo.Version()
 	if version == "unknown" {
-		version = ""
+		version = "" //nolint
 	}
 	startCmd.Flags().StringVarP(&pk, "pk", "k", "", "server public key")
 	startCmd.Flags().StringVarP(&addr, "addr", "a", "", "address of proxy for use")
@@ -240,7 +240,7 @@ var isLabel bool
 
 func init() {
 	if version == "unknown" {
-		version = ""
+		version = "" //nolint
 	}
 	version = strings.Split(version, "-")[0]
 	listCmd.Flags().StringVarP(&utURL, "uturl", "w", skyenv.UptimeTrackerAddr, "uptime tracker url")

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -10,28 +10,29 @@ import (
 )
 
 var (
-	version         = buildinfo.Version()
-	binaryName      = "skysocks-client"
-	stateName       = "skysocks-client"
-	serviceType     = servicedisc.ServiceTypeProxy
-	isUnFiltered    bool
-	rawData         bool
-	utURL           string
-	sdURL           string
-	cacheFileSD     string
-	cacheFileUT     string
-	cacheFilesAge   int
-	ver             string
-	country         string
-	isStats         bool
-	pubkey          cipher.PubKey
-	pk              string
-	allClients      bool
-	noFilterOnline  bool
-	clientName      string
-	addr            string
-	startingTimeout int
-	httpProxy       string
+	version        = buildinfo.Version()
+	binaryName     = "skysocks-client"
+	stateName      = "skysocks-client"
+	serviceType    = servicedisc.ServiceTypeProxy
+	isUnFiltered   bool
+	rawData        bool
+	utURL          string
+	sdURL          string
+	cacheFileSD    string
+	cacheFileUT    string
+	cacheFilesAge  int
+	ver            string
+	country        string
+	isStats        bool
+	pubkey         cipher.PubKey
+	pk             string
+	allClients     bool
+	noFilterOnline bool
+	clientName     string
+	addr           string
+
+// startingTimeout int
+// httpProxy       string
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -33,6 +33,32 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
+func init() {
+	RootCmd.AddCommand(
+		cliconfig.RootCmd,
+		clidmsgpty.RootCmd,
+		clivisor.RootCmd,
+		clivpn.RootCmd,
+		cliut.RootCmd,
+		cliskyfwd.RootCmd,
+		cliskyrev.RootCmd,
+		clireward.RootCmd,
+		clirewards.RootCmd,
+		clisurvey.RootCmd,
+		clirtfind.RootCmd,
+		clirtree.RootCmd,
+		climdisc.RootCmd,
+		clicompletion.RootCmd,
+		clilog.RootCmd,
+		cliskysocksc.RootCmd,
+		treeCmd,
+		docCmd,
+	)
+	var jsonOutput bool
+	RootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
+	RootCmd.PersistentFlags().MarkHidden(internal.JSONString) //nolint
+}
+
 // RootCmd is the root command for skywire-cli
 var RootCmd = &cobra.Command{
 	Use: func() string {
@@ -180,32 +206,6 @@ var docCmd = &cobra.Command{
 			}
 		}
 	},
-}
-
-func init() {
-	RootCmd.AddCommand(
-		cliconfig.RootCmd,
-		clidmsgpty.RootCmd,
-		clivisor.RootCmd,
-		clivpn.RootCmd,
-		cliut.RootCmd,
-		cliskyfwd.RootCmd,
-		cliskyrev.RootCmd,
-		clireward.RootCmd,
-		clirewards.RootCmd,
-		clisurvey.RootCmd,
-		clirtfind.RootCmd,
-		clirtree.RootCmd,
-		climdisc.RootCmd,
-		clicompletion.RootCmd,
-		clilog.RootCmd,
-		cliskysocksc.RootCmd,
-		treeCmd,
-		docCmd,
-	)
-	var jsonOutput bool
-	RootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
-	RootCmd.PersistentFlags().MarkHidden(internal.JSONString) //nolint
 }
 
 // Execute executes root CLI command.


### PR DESCRIPTION
revert recent changes to proxy start and stop to restore functionality
Interim fix for https://github.com/skycoin/skywire/issues/1753

@mrpalide please re-implement the recent changes to `proxy start` / `stop` and `vpn start` / `stop` which are reverted by this PR

