### PR TITLE
Transport setup-node config gen

### DIFF
--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -101,7 +101,8 @@ var (
 	proxyClientPass             string
 	configServicePath           string
 	dmsgHTTPPath                string
-	snConfig                    bool
+	rsnConfig                   bool
+	tpsnConfig                  bool
 )
 
 // RootCmd contains commands that interact with the config of local skywire-visor


### PR DESCRIPTION
![image](https://github.com/skycoin/skywire/assets/36607567/4a9c8e4c-a85d-4cf6-a74a-891e1401fc45)

```
[user@linux skywire]$ go run cmd/skywire/skywire.go cli config gen -n --tpsn
{
    "dmsg": {
        "discovery": "http://dmsgd.skywire.skycoin.com",
        "servers": [],
        "sessions_count": 2
    },
    "log_level": "",
    "public_key": "02c2a16ce0c69f704a0af06527936d7eaca5e3516716471e9d63fa27d74d6ebb3c",
    "secret_key": "d41efb5c132c0f8246fb090cd2a4d60ffb09c07c9fbb84d7145b6499396ab609"
}
```

```
[user@linux skywire]$ go run cmd/skywire/skywire.go cli config gen -n --rsn
{
    "dmsg": {
        "discovery": "http://dmsgd.skywire.skycoin.com",
        "servers": [],
        "sessions_count": 2
    },
    "log_level": "",
    "public_key": "0298e7e0290fceab92420f283233df06d1135f968245a26e5177e63e57df6940ff",
    "secret_key": "9ec9c701e5b4691a97a358a9e79db29bdc6cfaf1caee812868cc7b5dfbf842b0",
    "transport_discovery": "http://tpd.skywire.skycoin.com"

```