### PR TITLE
TPD concurrency

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -314,20 +314,23 @@ var discTpCmd = &cobra.Command{
 	Short:                 "Discover remote transport(s)",
 	Long:                  "\n    Discover remote transport(s) by ID or public key",
 	DisableFlagsInUseLine: true,
-	Args: func(_ *cobra.Command, _ []string) error {
+	Run: func(cmd *cobra.Command, _ []string) {
 		if tpID == "" && tpPK == "" {
-			return errors.New("must specify either transport id or public key")
+			internal.PrintFatalError(cmd.Flags(), errors.New("must specify either transport id or public key"))
+			return
 		}
 		if tpID != "" && tpPK != "" {
-			return errors.New("cannot specify both transport id and public key")
+			internal.PrintFatalError(cmd.Flags(), errors.New("cannot specify both transport id and public key"))
+			return
 		}
-		return nil
-	},
-	Run: func(cmd *cobra.Command, _ []string) {
 		var tppk cipher.PubKey
 		var tpid transportID
-		internal.Catch(cmd.Flags(), tpid.Set(tpID))
-		internal.Catch(cmd.Flags(), tppk.Set(tpPK))
+		if tpID != "" {
+			internal.Catch(cmd.Flags(), tpid.Set(tpID))
+		}
+		if tpPK != "" {
+			internal.Catch(cmd.Flags(), tppk.Set(tpPK))
+		}
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			os.Exit(1)

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -97,7 +97,7 @@ var (
 	// Transportability checker ensures the visor can accept transports by creating a self-transport or exiting after 3 failed attempts to create one
 	tc vinit.Module
 	// TPD concurrency checker removes transports from tpd that the visor does not have registered locally
-	tpdc vinit.Module
+	tpdco vinit.Module
 	// Transport manager
 	tr vinit.Module
 	// Transport setup
@@ -178,9 +178,9 @@ func registerModules(logger *logging.MasterLogger) {
 	skyFwd = maker("sky_forward_conn", initSkywireForwardConn, &dmsgC, &dmsgCtrl, &tr, &launch)
 	pi = maker("ping", initPing, &dmsgC, &tm)
 	tc = maker("transportable", initEnsureVisorIsTransportable, &dmsgC, &tm)
-	tpdc = maker("tpd_concurrency", initEnsureTPDConcurrency, &dmsgC, &tm)
+	tpdco = maker("tpd_concurrency", initEnsureTPDConcurrency, &dmsgC, &tm)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &pty,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &systemSurvey, &tc)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &systemSurvey, &tc, &tpdco)
 
 	hv = maker("hypervisor", initHypervisor, &vis)
 }

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -1345,7 +1345,7 @@ func initEnsureTPDConcurrency(ctx context.Context, v *Visor, log *logging.Logger
 						for _, rm := range rmtpids {
 							err = tpdC.DeleteTransport(ctx, rm)
 							if err != nil {
-								log.WithError(err).Warn("Failed to remove transport from discovery %v", rm)
+								log.WithError(err).Warn(fmt.Sprintf("Failed to remove transport from tpd %v", rm))
 							}
 						}
 					}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/ccding/go-stun/stun"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/direct"
 	dmsgdisc "github.com/skycoin/dmsg/pkg/disc"
@@ -95,6 +96,8 @@ var (
 	dmsgC vinit.Module
 	// Transportability checker ensures the visor can accept transports by creating a self-transport or exiting after 3 failed attempts to create one
 	tc vinit.Module
+	// TPD concurrency checker removes transports from tpd that the visor does not have registered locally
+	tpdc vinit.Module
 	// Transport manager
 	tr vinit.Module
 	// Transport setup
@@ -175,6 +178,7 @@ func registerModules(logger *logging.MasterLogger) {
 	skyFwd = maker("sky_forward_conn", initSkywireForwardConn, &dmsgC, &dmsgCtrl, &tr, &launch)
 	pi = maker("ping", initPing, &dmsgC, &tm)
 	tc = maker("transportable", initEnsureVisorIsTransportable, &dmsgC, &tm)
+	tpdc = maker("tpd_concurrency", initEnsureTPDConcurrency, &dmsgC, &tm)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &pty,
 		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &systemSurvey, &tc)
 
@@ -1291,6 +1295,70 @@ func initEnsureVisorIsTransportable(ctx context.Context, v *Visor, log *logging.
 		return nil
 	})
 
+	return nil
+}
+
+func initEnsureTPDConcurrency(ctx context.Context, v *Visor, log *logging.Logger) error { //nolint:all
+	const tickDuration = 5 * time.Minute
+	ticker := time.NewTicker(tickDuration)
+	go func() {
+		time.Sleep(time.Minute)
+		for range ticker.C {
+			entries, err := v.DiscoverTransportsByPK(v.conf.PK)
+			if err != nil {
+				v.isServicesHealthy.unset()
+				log.WithError(err).Warn("Cannot ensure concurrency with TPD")
+				//reduce tick duration on non nil error
+				ticker.Reset(time.Minute)
+			} else {
+				var dtpids []uuid.UUID
+				var rmtpids []uuid.UUID
+				var tpids []uuid.UUID
+				for _, e := range entries {
+					if e.Edges[0] != e.Edges[1] {
+						dtpids = append(dtpids, e.ID)
+					}
+				}
+				transports, err := v.Transports(nil, nil, false)
+				for _, t := range transports {
+					if t.Local != t.Remote {
+						tpids = append(tpids, t.ID)
+					}
+				}
+				for _, t := range dtpids {
+					var found bool
+					for _, tt := range tpids {
+						if tt == t {
+							found = true
+						}
+					}
+					if !found {
+						rmtpids = append(rmtpids, t)
+					}
+				}
+				if 0 < len(rmtpids) {
+					log.WithError(err).Warn(fmt.Sprintf("Found %v transports in transport discovery not registered locally", len(rmtpids)))
+					tpdC, err := connectToTpDisc(ctx, v, v.MasterLogger().PackageLogger("tpd_concurrency"))
+					if err != nil {
+						log.WithError(err).Warn("failed to create transport discovery client")
+					} else {
+						for _, rm := range rmtpids {
+							err = tpdC.DeleteTransport(ctx, rm)
+							if err != nil {
+								log.WithError(err).Warn("Failed to remove transport from discovery %v", rm)
+							}
+						}
+					}
+				}
+				ticker.Reset(tickDuration)
+			}
+		}
+	}()
+
+	v.pushCloseStack("tpd_concurrency", func() error {
+		ticker.Stop()
+		return nil
+	})
 	return nil
 }
 


### PR DESCRIPTION
Ensure that the transports in transport discovery agree with those the visor has registered locally ; remove any transports which the visor does not have registered locally from TPD.

for example, my visor shows no transports locally

```
$ skywire cli tp
type     id     remote_pk     mode     label

```

but shows the following transports in TPD

```
$ skywire cli tp disc -p $(skywire cli visor pk)
id                                       type      edge1                                                                  edge2
f1983e71-1681-0bda-bb08-c8ac60f1d6ac     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03ec4f6221e6b41b3740369fd8146c1be6229c7b265723b473c9822034bdbe1aa3
7b4eda5b-327b-092a-adee-a066430f68ad     sudph     0202037ce4ca982cb8d4b2c1b41df1ccc64ffcf58dfbb38ed0c3c7e41465668545     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
5c202a3e-dea2-0ac8-ae1d-31f0d536ed19     sudph     0219453427908bc29cc532906878f9d9693c2692fa2569d92f2f7236d749c88233     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
45fd12bb-7fbe-036d-9e1c-437dccf928d3     sudph     024287a15bb9234517196fdaefc8c43f86e3e0c045952fa7aedfef001c5f5cb6bd     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
b5435542-c7bc-0ae9-a362-7760e0e428ff     sudph     024b69b74c096d0521f6e90683242c182b45c60bc99b0b56d1b7b6230d26ebe537     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
7adfabb7-e341-0160-bb05-09f775e55dcb     sudph     02614bcd6acc3e39b6b5fa5747f6fa649eabdcc1398ad2071fc740b93462fef050     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
0abf6455-90ee-0e34-a373-2284d14ce236     sudph     0263ac560727647d5fc4ff8d2e9de443b07f3f35ad1afda8c7672e678e48332b70     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
3c500af0-fc9f-0092-8dab-1717d3bb6857     sudph     02657f8daf2dfd723a50a2d69efcb03fa0b719695cd12a78e26534e8adf7ac1d9c     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
4b8aab22-0aab-05ca-9dc9-60dff6dfef64     sudph     026b7a3108d6b75bb883d4caa8bdf1095fb87185452db2b55f138baf6233539767     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
3ce4f182-d857-0ffd-828b-e1594dff6732     sudph     0274afd56f6129bbed148ca45bb856c72052cfd67b4ce5981c899fb8762148d922     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
de2fc411-a83c-0b07-b364-d3f85afb7b99     sudph     0274bd1ed89452f8edc41e3e8dde72b076f235e003e7b17043aad6b6c1c8a02ed0     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
6f627ad7-3796-08ec-8e01-7b36de169ba9     sudph     0275c19a58765e4a1bb2e8e1a543a717b7da1e8e1d12cf35c39fbbc8fab5af1128     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
181221ec-d15d-0598-bfac-b742cc6e240f     sudph     027d8dc3b54367df8b81cbefd3ff3fcbbbd9775f448b80e3bb11e97a174c4cbb22     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
bf4e5739-3444-01a0-ab4d-b35f58f5fbfe     sudph     027d9f7a06b679fb08e2692c54b363f5fdade2fb51115498793dc35a035c44aa45     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
ac975c2f-c355-0daa-9ba4-4d64ccd20c1c     sudph     027de4d55634c3fa238786c79a0cfe56874a9a4e00e4c79485a8bb353e5dcbea87     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
36abe2f6-f3f5-0f56-b517-9c254633fdf1     sudph     027f929f89625037bc0be9a584c6c2d1e64499a5f9249d6c860d04cb13f163cae2     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
7af73671-03de-01ba-9682-06db3293a8e1     sudph     027fc6d3588565371683a3790368cf753c9a3b0fd8314390f78f92aba1a7c4afc8     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
7ca65a38-009a-06a2-a1b9-3504105f9897     sudph     02849c4c43f63fa0b9a88e3db4ebe35ef09a632b72353a4fe530c85eac7f6e7ca1     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
f2676fb6-b1d6-000d-aca7-0830774c11a1     sudph     028b975aa48ee9a3e5514c38c1e742957e934e3dd6cd9fb357963dcbc7a58171fd     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
5905acb1-0297-0609-bfb2-32a88984b1a8     sudph     028dc6d77fe37ff5aca0dc33c0fda68e418870ea344aa9ad1d09327b500ad97b55     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
bb035648-66ca-084c-b5f7-d3def80f91da     sudph     028fb9f508b93df5e25bfba4e4cc2b39b56734019901df9c6624313d0025f96deb     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
33ed65ee-cf01-036d-b3db-849809a02599     sudph     0293203176d7f19fcda20030af5f6263955e243859b8ec6fa706854524482357e8     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
b994ca0a-7049-0c97-8c45-892e81a61dbc     sudph     0293c60f05a6426a532db10b1e0c22fd351bd6c8d2a169b6cae3e9ebab52dc2711     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
c0f3f2d9-2e06-085c-9b1b-0a1e004af05c     sudph     0294f43592a4320ba7f87291c105f5426398120073c5077479ca3d939eb6f2a881     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
cdec010c-1270-04ce-ae19-07a3b713ab1a     sudph     02994a796168e5edc7c6392daefa290518192f023669c3515330b818e473d0a750     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
391b419a-7fbe-0bab-8381-adf02c97aea3     sudph     02a122cb7f20427e1b1e8c90545c19d48b1d934d0e1adfa112ce4b3004106c26fb     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
be301a3f-eac3-0067-b39b-5af83a24a7ce     sudph     02a38cad8004b37589a3a54cb376b8fd089266e8c76ca3402fc265ab336f5590a6     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
17f3a3dc-57b9-06ec-9934-106a6fdeeaac     sudph     02a83b467366c6fa97b28dda8c6d76d59ffeacf0a2b31938fb4b989ea3d337cd75     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
5cddb0ec-0b2b-0eb2-a26e-7f3b84fffbdb     sudph     02a8c9f42eb7ce566a17f7992216e09ab428eff4a24c9dd3d1d2bc8d1f1cb5833c     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
075f569f-a5f1-03a1-8624-e2ee85c84fce     sudph     02aaa20a2e5d41203c2a3a7bc251353a0b5cc67840eeefe9e7277a5908df0a54b7     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
b63a71f2-0344-0167-bbe2-39f83771e57a     sudph     02aab9c57b16dbf149d558980b7b10030dc9da6a226e0f80f8275e61705d794516     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
df5105cf-d861-06e2-9baf-eea2672291d9     sudph     02ab890f40eddfe98af1786aa3265928f663a02aa3d73f3660d626890aeaee1b57     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
dc4941e8-e157-0242-9526-f515f8e31d2f     sudph     02b98456044502e3f7a1b9f7a034f6886e892a144a0b140b725ab218c747ba5038     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
66253304-f7ee-0bf6-b301-e0be67829048     sudph     02c7db2c636a05427608c6e5db65ef067a73718b62605fbf49bcb7d5e1edcd5086     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
63d21db7-da64-0c20-b9b7-f5ffb68727df     sudph     02c9daeef5602b49a516b822319781cee1753438738e18b80536d07d9428203cdc     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
2be95b6c-d3d7-0145-9204-818a12c1a5fa     sudph     02f215c4bc1eb2811fc20d19a9183b502e6a45db6b3d2783bef9386ded7a7d9705     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
c709e290-6051-06ac-a78a-cc5d0aa5d851     sudph     02f24e4486423155af1db8417b9ef1ea204dda3b8112ee31c9f95951b7f915b033     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
01af17df-fb72-0e96-8ebf-9c2e5e47e4e8     sudph     02f94b2e604de694d42fbcb8e7f0c809a1447a460895c7ce0563bbfa2ab89ce71f     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
ed7f5d68-e189-0bf8-b4e2-b891f53f91dc     sudph     02fbc0d51c702544aaf8363d2294714162d4516ba99414f4e37f1107af7ea62b3b     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
bb26cb02-8f0d-0d1d-beac-b88be4f6033e     sudph     02fd2028438db31619b6475bc7e0117641b18f19dea37f3009a5df76f67882435c     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
723bf75e-b398-014a-beb7-f0d5729607da     sudph     0305918027b75cabffab6f0f7a50c6eee59c3c6f994687ea23a7ea477ec195d753     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
4ed8c8ae-2c9e-0eb1-8241-9d9bb96e2e17     sudph     0318998f04813b5ededcbaf7866151cd36e101decfe5ba080aa820e141fe130445     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
3f28d41a-9932-03a7-9707-5a18f38fc375     sudph     0318a346074afc99b69688219b421ce361a21cc2f2395d5411d311192c9ce5e1c7     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
8c3a83c1-924c-06c0-8bbc-14ddb9f9f5c3     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     032e032b7f6bb3afb8f0f7a0ee9f66cbbeaa6969dc448eb44676934f2689623739
9b071a2d-a3a2-07a0-998d-6a46c74346fd     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     032f6a721c23654584ceaaa96a66e41d360ce95275c04c6e0e2bcfa62d6e148582
c21014af-e0d8-0eb1-adb7-0ccf29d82472     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     033115b2b3de1605ad33fa63d6eda3f35de6f281c052daebab98804b6826b93848
2d25912f-c689-0357-b63b-9a9c2b9d7193     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     033d5c3463cf5cba2bcdb0ff84e755c4e5cf63797ec5c93c165f0c02078bafcfa4
b6616eeb-96df-0f73-872e-facd394e8885     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03565f7a89092173eea510c05f928bb8c00c6e4a6b75bf75af13b17c48f86f9ce3
b193b16a-16e1-0901-ae74-eb95e5f747a8     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     035be5a50f9d9d09092ad6c114a4303178bb0baf306012a6cb64c4656d7359e16f
6f197a6f-2eef-0c78-b6c7-fc4862c8673c     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     035c78892260e453c98e28bbebf5815180d043dafad2bba094ba86ee210a28bb75
2ea1316b-2a31-0a45-b9c4-4273c99ef371     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     0360889c923eb2d898044f1e6f8e3012cc919bda20c8b81a9a9d86f802ac850cda
58deb7cf-4e63-0104-99c1-53b5665b5a7b     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     036990d5e3f9e41ae6d9fc3cc8be93f43458016d99b596d57fe49b58bec6a51618
7622075a-3b19-0c20-b9f0-fd5da1ce815c     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     0374623449e68528ff4c18a8cba9b42c424c2dd4ee7e2b38b18aa7828b014a72e5
2929d1bb-6d64-09d7-8a78-80a8bc7fc56c     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     0374ca547005308bf19a69d1ecc060db658c2387d7682fb81cecb8079bcd19f904
d20838e0-8dc0-0596-aba2-34cb20e4bc47     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     037538b1ccaa1bfa7c855ed9053474be112b92dbcece9abf403bab8d9d9feb3258
573cf3d4-a8b3-09be-b0c7-6c78225d9e5f     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03792bb9ef0f42cd700f126f55f44fd82f9064231ab24649dc92e69d7de9745f6f
647f6b8f-04fd-0970-9ab8-773f2eee0852     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     037c7a2d33ea018a940123e9b3a251f311a5cafe4f3ccc8270bb737c93a7046b01
2d89a824-27b7-059c-8823-b0d6293d0e63     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     037ff2962022c4b13cdd3fa641c1abae5abe862fe42fb46f1acd8d7e1a4bfe08b3
8707324e-032e-064f-b073-b0506b92f4c9     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03813e416e16656c0fac0ad55ce78010881e0c46a0a0a682052bf99a6c4bc9683f
855f05bd-2cf1-0764-9ad7-18b17b322335     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03816e897427cebfcee607e5075c2b634daa4cb8ca1879ada28cff951e0f3158b4
927f0720-55af-051b-aed3-e266d1e7ecd8     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     038c3edebf222556c3d91e51fb5de886e5a58f1a974450942e44db6ca8f1240a64
c136a12e-e65e-00e8-b63a-a3b9718ed4da     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     038e561e9fa30232ade9e7c684bb76741cea486235a28916b1085f441f9c9925c4
693f1565-3fab-0071-bc7f-7a4c1506f05d     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     0385e2c3c7d01d8e05967ddb0fb9d1386604f546dc72503ccdc8146d848f217e57
6e0819ab-f85a-0b31-8e8b-911911c43291     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03cd4107e85376462b6e6fa13cdfd4012229f28cc66e256ff87b6de1a5c0fb35a4
642a84b9-57b8-0014-8ecc-4e64179c9ebc     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03cd96e30da8f7467191199ff087c14b64f08f7e7bcc0ba2cce85f240c5a0ddcf7
a9378aa2-83e8-0492-b65f-f798af904be1     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     039599f58f650bb9559c2d2f2b4f53c238e65c91fdda3328cd3daf4ec31df1fa39
d144d953-b0fe-0e61-b5b1-b4ddbe5a2871     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     0395f5ed0599c9661d0d18c826aaa8178aebe58916b038ad2e577a926384ffe81e
ac66314d-f311-0fa8-b348-02668dc8678d     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     039cc33881d74429b412e10d4ec2f03cf0fac525dd301b6d9bfb38e3eba08751ae
652e4a5d-941e-05d4-94af-07bf2ce7bc0f     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     039f40cd99f0ccf9eeb3263c6e1e95eac75fd16506aba5162ee92c3e9c50959428
8c59ef2b-fba0-0e98-b9d5-718af50bc64a     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03a2b9d8d0b3a0b1aac19180645ec1bcf6a0d47cb28b5589b907c096631a66f34f
3d079f64-31e4-0b27-9f2f-e16608247864     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03a456b571242d85dcaa8850d0435c4894d0636487f14d77f38e4f502fb34c38eb
4e4b662b-1a03-0324-8a48-5fdd64c09201     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03a7efdc82481e3fcab06fe5480b1e1ee6bfcafa1a669755f6fec886fe23b0a002
1627ab5a-ed47-0f13-862b-8e904b8fc2de     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03b373db3a587c9f020284bb026799fd3debe9ca8c867a8d42c5f5703ffdd38c4f
5450e6df-1e82-094e-a849-d2dbbf782ee7     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03b45d667325990992bbdd8bf9d1eeb3a8bd8957142d2299e3a121e39a722c3363
4c3fc52c-43fe-094a-b6a2-c99f337e055d     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03d8b12934ba2d23271d58a62f43cfa194d6b9f9ea94a39072e218d24957963a3e
7113fc7f-8155-0925-9300-d7f361fbd32b     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03dac9a858ada2154bca05c1f774375e34c590d81af0ecc399f0a96e32d210d086
18103368-803c-0d96-b73d-54fc37499bff     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03e6c137593b1847969667adc3a1eb0e14a1e24f5c4467830a7b031f1bcabb48c0
62b89596-264b-03d4-a04d-7bfa6625bd0b     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03ece940ea117b6a4ab79bcd9b31bf9e5f29ca6fde80dfe756a5a0c5d143d55141
1c1c28fe-70b3-04db-bad7-b7a654effb85     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03f11384d588a54cd60c7e026d16bd259a37807cd249b7b33da839f8537921a1e3
6b188449-1ece-0468-9c11-ea0494ce6444     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03f1a1b354e412340ca1e8c3e59e738f1879d52213d973ad1a102c2f6e192033d8
b34b548a-1730-0031-bef4-2c4984ffb994     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03f343f305ab69977c5dde60fb91353eff9861cbfeda01dd60b4b0caaca0ecded0
1d23bfed-28e5-0714-89d4-3b080ab71f6d     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03f818a2e86a065a7624cf818f382403859afc79d6f147018672f3f6cec2ffcb98
773e3731-45db-0081-ae61-1eefc3e1c5a1     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03fabaf862fc1edef98ed9c7975016eee0bede3becd08f655bf019a078f9fdae67
d9dbb119-5710-083d-89b4-f6991dab254f     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03fb02df0a6ba22dbebefc70b3efff02f286173557d3261cecfd0602fcf8bcf0d4
b96c9a99-259a-00b4-9307-eaa4f0b38a4d     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03fb5e9e121223317394ef279e8a793f3254cebed858179af29d8dd57ba4366776
4995bd31-f15b-0d73-86e7-5704201bf701     sudph     0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c     03c9d52022927908bb9288e8b72f36fda7db3b6b65de490f2997119439165354fb

```

After running the upgraded visor:

```
$ skywire cli tp disc -p $(skywire cli visor pk)
id     type     edge1     edge2

```

Success!