### PR TITLE
More statistics for UT & dmsg discovery

### DIFF
--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -6,15 +6,15 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"text/tabwriter"
 	"time"
-	"os"
 
+	"github.com/bitfield/script"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/disc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/bitfield/script"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/logging"
@@ -23,11 +23,12 @@ import (
 )
 
 var (
-	cacheFileDMSGD   string
-	cacheFilesAge int
-	mdURL string
-	isStats       bool
+	cacheFileDMSGD string
+	cacheFilesAge  int
+	mdURL          string
+	isStats        bool
 )
+
 // var allEntries bool
 var masterLogger = logging.NewMasterLogger()
 var packageLogger = masterLogger.PackageLogger("mdisc:disc")

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"text/tabwriter"
 	"time"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/dmsg/pkg/disc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/bitfield/script"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/logging"
@@ -20,8 +22,12 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
-var mdAddr string
-
+var (
+	cacheFileDMSGD   string
+	cacheFilesAge int
+	mdURL string
+	isStats       bool
+)
 // var allEntries bool
 var masterLogger = logging.NewMasterLogger()
 var packageLogger = masterLogger.PackageLogger("mdisc:disc")
@@ -31,47 +37,47 @@ func init() {
 		entryCmd,
 		availableServersCmd,
 	)
-	entryCmd.PersistentFlags().StringVarP(&mdAddr, "addr", "a", "", "DMSG discovery server address\n"+utilenv.DmsgDiscAddr)
-	//	entryCmd.PersistentFlags().BoolVarP(&allEntries, "entries", "e", "", "get all entries")
-	availableServersCmd.PersistentFlags().StringVar(&mdAddr, "addr", utilenv.DmsgDiscAddr, "address of DMSG discovery server\n")
-	var helpflag bool
-	RootCmd.Flags().BoolVarP(&helpflag, "help", "h", false, "help for "+RootCmd.Use)
-	RootCmd.Flags().MarkHidden("help") //nolint
+	RootCmd.Flags().StringVar(&cacheFileDMSGD, "cfu", os.TempDir()+"/dmsgd.json", "DMSGD cache file location.")
+	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache file if older than n minutes")
+	RootCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "count the number of results")
+	entryCmd.Flags().StringVar(&mdURL, "url", utilenv.DmsgDiscAddr, "specify alternative DMSG discovery url")
+	RootCmd.Flags().StringVar(&mdURL, "url", utilenv.DmsgDiscAddr, "specify alternative DMSG discovery url")
+	availableServersCmd.Flags().StringVar(&mdURL, "url", utilenv.DmsgDiscAddr, "specify alternative DMSG discovery url")
 }
 
 // RootCmd is the command that contains sub-commands which interacts with DMSG services.
 var RootCmd = &cobra.Command{
 	Use:   "mdisc",
-	Short: "Query remote DMSG Discovery",
+	Short: "Query DMSG Discovery",
+	Long: `Query DMSG Discovery
+	list entries in dmsg discovery`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dmsgclientkeys := internal.GetData(cacheFileDMSGD, mdURL+"/dmsg-discovery/entries", cacheFilesAge)
+		if isStats {
+			stats, _ := script.Echo(dmsgclientkeys).JQ(".[]").CountLines() //nolint
+			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d dmsg clients\n", stats), fmt.Sprintf("%d dmsg clients\n", stats))
+			return
+		}
+		script.Echo(dmsgclientkeys).JQ(".[]").Replace("\"", "").Stdout() //nolint
+	},
 }
 
 var entryCmd = &cobra.Command{
 	Use:   "entry <visor-public-key>",
 	Short: "Fetch an entry",
-	//	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		//print help on no args
 		if len(args) == 0 {
 			cmd.Help() //nolint
-		} else {
-			if mdAddr == "" {
-				mdAddr = utilenv.DmsgDiscAddr
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-			defer cancel()
-			pk := internal.ParsePK(cmd.Flags(), "visor-public-key", args[0])
-
-			masterLogger.SetLevel(logrus.InfoLevel)
-
-			//TODO: fetch all entries
-			//		if allEntries {
-			//			entries, err := disc.NewHTTP(mdAddr, &http.Client{}, packageLogger).AvailableServers(ctx)
-			//		}
-
-			entry, err := disc.NewHTTP(mdAddr, &http.Client{}, packageLogger).Entry(ctx, pk)
-			internal.Catch(cmd.Flags(), err)
-			internal.PrintOutput(cmd.Flags(), entry, fmt.Sprintln(entry))
+			return
 		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		pk := internal.ParsePK(cmd.Flags(), "visor-public-key", args[0])
+
+		masterLogger.SetLevel(logrus.InfoLevel)
+		entry, err := disc.NewHTTP(mdURL, &http.Client{}, packageLogger).Entry(ctx, pk)
+		internal.Catch(cmd.Flags(), err)
+		internal.PrintOutput(cmd.Flags(), entry, fmt.Sprintln(entry))
 	},
 }
 
@@ -84,7 +90,7 @@ var availableServersCmd = &cobra.Command{
 
 		masterLogger.SetLevel(logrus.InfoLevel)
 
-		entries, err := disc.NewHTTP(mdAddr, &http.Client{}, packageLogger).AvailableServers(ctx)
+		entries, err := disc.NewHTTP(mdURL, &http.Client{}, packageLogger).AvailableServers(ctx)
 		internal.Catch(cmd.Flags(), err)
 		printAvailableServers(cmd.Flags(), entries)
 	},

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -59,7 +59,7 @@ var RootCmd = &cobra.Command{
 			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d dmsg clients\n", stats), fmt.Sprintf("%d dmsg clients\n", stats))
 			return
 		}
-		script.Echo(dmsgclientkeys).JQ(".[]").Replace("\"", "").Stdout() //nolint
+		script.Echo(dmsgclientkeys).JQ(".[]").Replace("\"", "").Freq().Column(2).Stdout() //nolint
 	},
 }
 

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -99,7 +99,7 @@ var availableServersCmd = &cobra.Command{
 func printAvailableServers(cmdFlags *pflag.FlagSet, entries []*disc.Entry) {
 	var b bytes.Buffer
 	w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
-	_, err := fmt.Fprintln(w, "version\tregistered\tpublic-key\taddress\tavailable-sessions")
+	_, err := fmt.Fprintln(w, "version\tregistered\tpublic-key\taddress\tavail-sess")
 	internal.Catch(cmdFlags, err)
 
 	type serverEntry struct {
@@ -107,7 +107,7 @@ func printAvailableServers(cmdFlags *pflag.FlagSet, entries []*disc.Entry) {
 		Registered        int64         `json:"registered"`
 		PublicKey         cipher.PubKey `json:"public_key"`
 		Address           string        `json:"address"`
-		AvailableSessions int           `json:"available_sessions"`
+		AvailableSessions int           `json:"avail_sess"`
 	}
 
 	var serverEntries []serverEntry

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -19,7 +19,7 @@ var (
 	pk            string
 	online        bool
 	isStats       bool
-	isMoreStats       bool
+	isMoreStats   bool
 	utURL         string
 	cacheFileUT   string
 	cacheFilesAge int


### PR DESCRIPTION
* Add flag to provide version statistics from ut data

```
$ go run cmd/skywire/skywire.go cli ut --help
query uptime tracker

http://ut.skywire.skycoin.com/uptimes?v=v2

Check local visor daily uptime percent with:
 skywire-cli ut -k $(skywire-cli visor pk)n
Set cache file location to "" to avoid using cache files

Flags:
  -m, --cfa int      update cache files if older than n minutes (default 5)
      --cfu string   UT cache file location. (default "/tmp/ut.json")
  -n, --min int      list visors meeting minimum uptime (default 75)
  -o, --on           list currently online visors
  -k, --pk string    check uptime for the specified key
  -s, --stats        count the number of results
  -t, --stats2       count of versions
  -u, --url string   specify alternative uptime tracker url (default "http://ut.skywire.skycoin.com")
```

Showing the version statistics for every visor in the uptime tracker
```
[user@linux skywire]$ go run cmd/skywire/skywire.go cli ut -t
1518 v1.3.19
 470 v1.3.17
 446 null
 226 v1.3.21
 220 v1.3.15
 148 v1.3.13
  55 v1.3.10
  51 v1.3.7
  47 v1.3.11
  22 v1.3.6
  13 v1.3.8
   9 v1.3.20
   8 v1.0.1
   8 v1.3.4
   5 v1.1.0
   4 v1.3.14
   4 v1.3.16
   2 unknown
   1 v1.3.9

```

Showing the version statistics for every online visor in the uptime tracker
```
[user@linux skywire]$ go run cmd/skywire/skywire.go cli ut -ot
1325 v1.3.19
 398 null
 349 v1.3.17
 214 v1.3.21
 195 v1.3.15
  71 v1.3.13
  51 v1.3.10
  46 v1.3.7
  36 v1.3.11
  22 v1.3.6
  13 v1.3.8
   8 v1.0.1
   8 v1.3.4
   6 v1.3.20
   5 v1.1.0
   4 v1.3.16
   3 v1.3.14
   1 v1.3.9

```

* `skywire cli mdisc` will print entries from dmsg discovery

```
$  go run cmd/skywire/skywire.go cli mdisc | head
02000d6d4b1286c42376490d227acbce9c729f43154ebf0b3b1c69a3d35699510c
02001319d25a66609b64cc389bd0dcee6d5b4ab93bd139186c47d1d6cbe955e7e1
0200389579ed15343725d7d0c78890875b15af7ba965a84e53472eff7b5eb5939f
0200479d96f48aa57b03b745808808565fce636361364141869a217fcfa4634fee
02008f71595e5b1267fab5e337e135650fa22164a4ac489546b59492413d9da10d
0200b3c311dba7c90ae6661362534a9e68f2428ca89631cd5fff93143a283a1905
0200b9720b9ea5ead3893c7aa6f7b8b62d51807d869bd79e27f1065dd047bf28f7
0200cbd7e616128b122288d27da84276842952ecf2916fe6e41f3b811341636113
020131ef17620488c31e1c6c8ee3a2cdf24ac037f034be1b1b148767f7330fd3e6
0201392ea1f94bb40140ef6099eb825ad540f54d0b7dd80c2fdd9ebefb30c6fba8
```

* `skywire cli mdisc -s` will print a count of entries from dmsg discovery

```
$  go run cmd/skywire/skywire.go cli mdisc -s
4626 dmsg clients
$  go run cmd/skywire/skywire.go cli mdisc | wc -l
4626
```
