### PR TITLE
add heartbeat logic for stcpr and dmsg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/skycoin/dmsg v1.3.21
+	github.com/skycoin/dmsg v1.3.22-0.20240502214137-b684f7064155
 	github.com/skycoin/skycoin v0.27.1
 	github.com/skycoin/skycoin-service-discovery v0.0.0-20240306165129-2af10aca698e
 	github.com/skycoin/skywire-services v0.0.0-20240403004908-50ccbbf07004

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skycoin/dmsg v1.3.21 h1:31Jx5pPAUDNUxZmLUORSspvo9OTdtXOBY++Tzb/jotM=
 github.com/skycoin/dmsg v1.3.21/go.mod h1:INEDx+ECwCGQWw/Kd0QcLmSWMhbeRRcfkxj+xATQGFg=
+github.com/skycoin/dmsg v1.3.22-0.20240502214137-b684f7064155 h1:yy/bheBsI2PXGgl3ose3avsBGSJnI0ukrCTdbB92pSc=
+github.com/skycoin/dmsg v1.3.22-0.20240502214137-b684f7064155/go.mod h1:INEDx+ECwCGQWw/Kd0QcLmSWMhbeRRcfkxj+xATQGFg=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.27.1 h1:HatxsRwVSPaV4qxH6290xPBmkH/HgiuAoY2qC+e8C9I=

--- a/pkg/transport/network/stcpr.go
+++ b/pkg/transport/network/stcpr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/netutil"
@@ -89,6 +90,17 @@ func (c *stcprClient) serve() {
 		c.log.Errorf("Failed to bind STCPR: %v", err)
 		return
 	}
+	// simple heartbeat process for stcpr
+	go func() {
+		for {
+			time.Sleep(5 * time.Minute)
+			if err := c.ar.BindSTCPR(context.Background(), port); err != nil {
+				c.log.Errorf("Failed to bind STCPR: %v", err)
+				continue
+			}
+			c.log.Infof("STCPR rebinded in heartbeating process")
+		}
+	}()
 	c.log.Debugf("Successfully bound stcpr to port %s", port)
 	c.acceptTransports(lis)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -486,7 +486,7 @@ github.com/shirou/gopsutil/process
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.21
+# github.com/skycoin/dmsg v1.3.22-0.20240502214137-b684f7064155
 ## explicit; go 1.21
 github.com/skycoin/dmsg/cmd/dmsg-discovery/commands
 github.com/skycoin/dmsg/cmd/dmsg-server/commands


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes Part of https://github.com/skycoin/skywire-services/issues/63

 Changes:	
- add heartbeat logic for stcpr
- add dmsg client heartbeat (should update dmsg repo first)

How to test this PR:
Run visor and check heartbeat log after 5 minutes