### PR TITLE
fix release pipeline issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.21.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Requirements
         run: |
           sudo apt update
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.21.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Requirements
         run: |
           brew install goreleaser
@@ -46,10 +46,10 @@ jobs:
     needs: darwin
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v
         with:
           go-version: 1.21.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Requirements
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
     needs: linux
     runs-on: macos-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
     needs: darwin
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-go@v
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.21.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Requirements
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.21.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Requirements
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.21.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Requirements
         run: |
           choco install make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
   darwin:
     runs-on: macos-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -196,11 +196,11 @@ format-windows: tidy ## Formats the code. Must have goimports and goimports-revi
 dep: tidy ## Sorts dependencies
 	${OPTS} go mod vendor -v
 
-snapshot: ## goreleaser --snapshot --skip-publish --rm-dist
-	goreleaser --snapshot --skip-publish --rm-dist
+snapshot: ## goreleaser --snapshot --skip-publish --clean
+	goreleaser --snapshot --skip-publish --clean
 
-snapshot-linux: ## 	goreleaser --snapshot --config .goreleaser-linux.yml --skip-publish --rm-dist
-	goreleaser --snapshot --config .goreleaser-linux.yml --skip-publish --rm-dist
+snapshot-linux: ## 	goreleaser --snapshot --config .goreleaser-linux.yml --skip-publish --clean
+	goreleaser --snapshot --config .goreleaser-linux.yml --skip-publish --clean
 
 snapshot-clean: ## Cleans snapshot / release
 	rm -rf ./dist
@@ -246,10 +246,10 @@ github-prepare-release:
 	sed '/^## ${GITHUB_TAG}$$/,/^## .*/!d;//d;/^$$/d' ./CHANGELOG.md > releaseChangelog.md
 
 github-release: github-prepare-release
-	goreleaser --rm-dist --config .goreleaser-linux.yml --release-notes releaseChangelog.md
+	goreleaser --clean --config .goreleaser-linux.yml --release-notes releaseChangelog.md
 
 github-release-darwin:
-	goreleaser --rm-dist  --config .goreleaser-darwin.yml --skip-publish
+	goreleaser --clean  --config .goreleaser-darwin.yml --skip-publish
 	$(eval GITHUB_TAG=$(shell git describe --abbrev=0 --tags))
 	gh release upload --repo skycoin/skywire ${GITHUB_TAG} ./dist/skywire-${GITHUB_TAG}-darwin-amd64.tar.gz
 	gh release upload --repo skycoin/skywire ${GITHUB_TAG} ./dist/skywire-${GITHUB_TAG}-darwin-arm64.tar.gz
@@ -258,7 +258,7 @@ github-release-darwin:
 	gh release upload --repo skycoin/skywire ${GITHUB_TAG} --clobber ./checksums.txt
 
 github-release-windows:
-	.\goreleaser\goreleaser.exe --rm-dist  --config .goreleaser-windows.yml --skip-publish
+	.\goreleaser\goreleaser.exe --clean  --config .goreleaser-windows.yml --skip-publish
 	$(eval GITHUB_TAG=$(shell powershell git describe --abbrev=0 --tags))
 	gh release upload --repo skycoin/skywire ${GITHUB_TAG} ./dist/skywire-${GITHUB_TAG}-windows-amd64.zip
 	gh release upload --repo skycoin/skywire ${GITHUB_TAG} ./dist/skywire-${GITHUB_TAG}-windows-386.zip


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_	

 Changes:	
- fix deprecated goreleaser flags
- use checkout@v4 and setup-go@v4 in github action for handle node16 dead warning

How to test this PR:
_