### PR TITLE
fix missing `skywire` command in MacOS

### DIFF
--- a/scripts/mac_installer/create_installer.sh
+++ b/scripts/mac_installer/create_installer.sh
@@ -48,7 +48,7 @@ function build_installer() {
   fi
 
   # fetch skywire binaries from last release
-  download_url=$(eval curl https://api.github.com/repos/skycoin/skywire/releases | jq '.[0].assets[] | select(.name|match("darwin-'${go_arch}'.tar.gz")) | .browser_download_url')
+  download_url=$(eval curl --url https://api.github.com/repos/skycoin/skywire/releases --header 'authorization: Bearer $GITHUB_TOKEN' | jq '.[0].assets[] | select(.name|match("darwin-'${go_arch}'.tar.gz")) | .browser_download_url')
   wget ${download_url:1:$((${#download_url} - 2))} -O - | tar -xz
   
   if [ -d ${installer_build_dir}/binaries/Skywire.app ]; then

--- a/scripts/mac_installer/install_scripts/postinstall
+++ b/scripts/mac_installer/install_scripts/postinstall
@@ -55,3 +55,6 @@ if [[ ! -d /usr/local/bin ]]; then
   mkdir /usr/local/bin
 fi
 
+if [[ ! -L /usr/local/bin/skywire ]]; then
+  ln -s /Applications/Skywire.app/Contents/MacOS/skywire /usr/local/bin/skywire
+fi


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add missing `skywire` command to MacOS installer postscript
- fix `late limits` issue on release darwin	

How to test this PR (on darwin machine):
- change line 51 of _scripts/mac_installer/create_installer.sh_ and put direct download link of darwin archive tar.gz file there as **download_url** value
- run `make mac-installer`
- install skywire by created installer
- check `skywire` command in terminal
- should see something like this:  
  <img width="566" alt="image" src="https://github.com/skycoin/skywire/assets/79150699/77a66cfe-9971-40b1-9e82-5c8ed171e973">
