### PR TITLE
Fix `rewards calc` ; update mainnet rules regarding new reward pool

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -74,7 +74,7 @@ func init() {
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "s", "info", "[ debug | warn | error | fatal | panic | trace ] \u001b[0m*")
 	RootCmd.Flags().StringVarP(&wdate, "date", "d", wdate, "date for which to calculate reward")
 	RootCmd.Flags().StringVarP(&pubkey, "pk", "k", pubkey, "check reward for pubkey")
-	RootCmd.Flags().StringVarP(&disallowArchitectures, "noarch", "n", "amd64", "disallowed architectures, comma separated")
+	RootCmd.Flags().StringVarP(&disallowArchitectures, "noarch", "n", "amd64,null", "disallowed architectures, comma separated")
 	RootCmd.Flags().IntVarP(&yearlyTotal, "year", "y", yearlyTotalRewards, "yearly total rewards")
 	RootCmd.Flags().StringVarP(&utfile, "utfile", "u", "ut.txt", "uptime tracker data file")
 	RootCmd.Flags().StringVarP(&hwSurveyPath, "lpath", "p", "log_collecting", "path to the surveys")
@@ -196,7 +196,7 @@ Fetch uptimes:    skywire-cli ut > ut.txt`,
 			}
 			sky, _ = script.File(nodeInfoDotJSON).JQ(".skycoin_address").Replace(" ", "").Replace(`"`, "").String() //nolint
 			sky = strings.TrimRight(sky, "\n")
-			arch, _ = script.File(nodeInfoDotJSON).JQ(".go_arch").Replace(" ", "").Replace(`"`, "").String() //nolint
+			arch, _ = script.File(nodeInfoDotJSON).JQ(`if .zcalusic_sysinfo.os.architecture == null or .go_arch == .zcalusic_sysinfo.os.architecture then .go_arch else null end`).Replace(" ", "").Replace(`"`, "").String() //nolint
 			arch = strings.TrimRight(arch, "\n")
 			uu, _ = script.File(nodeInfoDotJSON).JQ(".uuid").Replace(" ", "").Replace(`"`, "").String() //nolint
 			uu = strings.TrimRight(uu, "\n")

--- a/cmd/skywire-cli/commands/rewards/ui.go
+++ b/cmd/skywire-cli/commands/rewards/ui.go
@@ -1487,7 +1487,7 @@ func scriptExecUint(s string) uint {
 			}
 			i, err := strconv.Atoi(strings.TrimSpace(strings.TrimRight(out, "\n")))
 			if err == nil {
-				return uint(i)
+				return uint(i) //nolint
 			}
 			return 0
 		}
@@ -1500,7 +1500,7 @@ func scriptExecUint(s string) uint {
 		}
 		i, err := strconv.Atoi(z)
 		if err == nil {
-			return uint(i)
+			return uint(i) //nolint
 		}
 	}
 	return uint(0)

--- a/internal/httpauth/client_test.go
+++ b/internal/httpauth/client_test.go
@@ -101,14 +101,14 @@ func checkResp(t *testing.T, headers http.Header, body []byte, pk cipher.PubKey,
 	require.Equal(t, pk.Hex(), headers.Get("Sw-Public"))
 	sig := cipher.Sig{}
 	require.NoError(t, sig.UnmarshalText([]byte(headers.Get("Sw-Sig"))))
-	require.NoError(t, cipher.VerifyPubKeySignedPayload(pk, sig, PayloadWithNonce(body, Nonce(nonce))))
+	require.NoError(t, cipher.VerifyPubKeySignedPayload(pk, sig, PayloadWithNonce(body, Nonce(nonce)))) //nolint
 }
 
 func newTestServer(t *testing.T, pk cipher.PubKey, headerCh chan<- http.Header) *httptest.Server {
 	nonce := 1
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() == fmt.Sprintf("/security/nonces/%s", pk) {
-			require.NoError(t, json.NewEncoder(w).Encode(&NextNonceResponse{pk, Nonce(nonce)}))
+			require.NoError(t, json.NewEncoder(w).Encode(&NextNonceResponse{pk, Nonce(nonce)})) //nolint
 		} else {
 			body, err := io.ReadAll(r.Body)
 			if body != nil {

--- a/mainnet_rules.md
+++ b/mainnet_rules.md
@@ -39,15 +39,17 @@ Reward distribution notifications are on telegram [@skywire_reward](https://t.me
 
 Information about reward distribution as well as other metrics for the skywire network can be found at [fiber.skywire.dev](https://fiber.skywire.dev)
 
-# Uptime Reward Pool
+# Uptime Reward Pools
 
-408000 Skycoin are distributed annually to those visors which meet the mimimum uptime and the other requirements listed below.
+816000 Skycoin are distributed annually to those visors which meet the mimimum uptime and the other requirements listed below, in two equally sized reward pools.
 
-The reward amount for a day is evenly divided among those eligible participants on the basis of having met uptime and other requirements, for the previous day.
+The reward amount for a day is evenly divided among those eligible participants for a given reward pool on the basis of having met uptime and other requirements, for the previous day.
 
-A total of up to ~1117.808 Skycoin are distributed daily in non leap-years.
+A total of up to ~1117.808 Skycoin __per pool__ are distributed daily in non leap-years.
 
-A total of up to ~1114.754  Skycoin are distributed daily in leap-years.
+A total of up to ~1114.754  Skycoin __per pool__ are distributed daily in leap-years.
+
+The two reward pools are differentiated by architecture ; one pool for ARM / RISC / MIPS architectures, the other pool for AMD64 / x86_64 / i686 architecture machines. The requirements are otherwise identical for reward eligibility in these pools.
 
 ## Rules & Requirements
 
@@ -58,7 +60,7 @@ To receive Skycoin rewards for running skywire, the following requirements must 
 
 * 2) **75% [uptime](#uptime) per day** minimum is required to be eligible to receive rewards
 
-* 3) The visor must be an **ARM or RISC architecture SBC** ~running on approved [hardware](#hardware)~
+* 3) ~The visor must be an **ARM or RISC architecture SBC** running on approved [hardware](#hardware)~
 
 * 4) Visors must be running on **[the skywire production deployment](#deployment)** with a config that is updated on every version. No default keys or addresses of this configuration may be removed - but you can add keys where applicable.
 

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -141,8 +141,8 @@ func MakePingPacket(id RouteID, timestamp, throughput int64) Packet {
 	packet[PacketTypeOffset] = byte(PingPacket)
 	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
 	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(16))
-	binary.BigEndian.PutUint64(packet[PacketPayloadOffset:], uint64(timestamp))
-	binary.BigEndian.PutUint64(packet[PacketPayloadOffset+8:], uint64(throughput))
+	binary.BigEndian.PutUint64(packet[PacketPayloadOffset:], uint64(timestamp))    //nolint
+	binary.BigEndian.PutUint64(packet[PacketPayloadOffset+8:], uint64(throughput)) //nolint
 
 	return packet
 }
@@ -154,7 +154,7 @@ func MakePongPacket(id RouteID, timestamp int64) Packet {
 	packet[PacketTypeOffset] = byte(PongPacket)
 	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
 	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(16))
-	binary.BigEndian.PutUint64(packet[PacketPayloadOffset:], uint64(timestamp))
+	binary.BigEndian.PutUint64(packet[PacketPayloadOffset:], uint64(timestamp)) //nolint
 
 	return packet
 }

--- a/pkg/routing/rule.go
+++ b/pkg/routing/rule.go
@@ -76,7 +76,7 @@ func (r Rule) setKeepAlive(keepAlive time.Duration) {
 		keepAlive = 0
 	}
 
-	binary.BigEndian.PutUint64(r[0:8], uint64(keepAlive))
+	binary.BigEndian.PutUint64(r[0:8], uint64(keepAlive)) //nolint
 }
 
 // Type returns type of a rule.

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -374,7 +374,7 @@ func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Pack
 		return err
 	}
 	if n > routing.PacketHeaderSize {
-		mt.logSent(uint64(n - routing.PacketHeaderSize))
+		mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint
 	}
 	return nil
 }
@@ -412,7 +412,7 @@ func (mt *ManagedTransport) readPacket() (packet routing.Packet, err error) {
 
 	packet = append(h, p...)
 	if n := len(packet); n > routing.PacketHeaderSize {
-		mt.logRecv(uint64(n - routing.PacketHeaderSize))
+		mt.logRecv(uint64(n - routing.PacketHeaderSize)) //nolint
 	}
 
 	log.WithField("type", packet.Type().String()).


### PR DESCRIPTION
* changed reward calc to return null when the zclaustic sysinfo os architecture does not match the go_arch of the compiled binary in the survey.
* update mainnet_rules.md about reward pool for amd64 / x86_64
*  add `//nolint` on integer conversion CI errors