### PR TITLE
add missing entry to mac windows survey

### DIFF
--- a/pkg/visor/visorconfig/values_darwin.go
+++ b/pkg/visor/visorconfig/values_darwin.go
@@ -4,9 +4,12 @@
 package visorconfig
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
 	"os/user"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,7 +59,7 @@ func SystemSurvey() (Survey, error) {
 		Timestamp:      time.Now(),
 		GOOS:           runtime.GOOS,
 		GOARCH:         runtime.GOARCH,
-		SYSINFO:        getMacAddr(),
+		SYSINFO:        genSysInfo(),
 		UUID:           uuid.New(),
 		Disks:          disks,
 		SkywireVersion: Version(),
@@ -72,22 +75,69 @@ func IsRoot() bool {
 
 type customSysinfo struct {
 	Network []sysinfo.NetworkDevice `json:"network,omitempty"`
+	Node    sysinfo.Node            `json:"node,omitempty"`
 }
 
-func getMacAddr() customSysinfo {
+func genSysInfo() customSysinfo {
 	var sysInfo customSysinfo
+	sysInfo.Network = getMacAddr()
+	sysInfo.Node.Hypervisor = getNodeHypervisor()
+	return sysInfo
+}
+
+func getMacAddr() []sysinfo.NetworkDevice {
 	si := make([]sysinfo.NetworkDevice, 1)
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return sysInfo
+		return si
 	}
-
 	for _, ifa := range interfaces {
 		si[0].MACAddress = ifa.HardwareAddr.String()
 		if si[0].MACAddress != "" {
-			sysInfo.Network = si
-			return sysInfo
+			return si
 		}
 	}
-	return sysInfo
+	return si
+}
+
+func getNodeHypervisor() string {
+	// Check docker
+	// Check for the /.dockerenv file
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return "docker"
+	}
+	// Check for cgroup indicating Docker or container environment
+	data, err := ioutil.ReadFile("/proc/self/cgroup")
+	if err == nil && strings.Contains(string(data), "docker") {
+		return "docker"
+	}
+
+	// Check other virtualization: kvm, xenhvm, virtualbox, vmware, qemu, hyperv
+	dmiFiles := []string{
+		"/sys/class/dmi/id/product_name",
+		"/sys/class/dmi/id/sys_vendor",
+	}
+
+	for _, file := range dmiFiles {
+		data, err := os.ReadFile(file) //nolint: gosec
+		if err == nil {
+			content := strings.ToLower(string(data))
+			if strings.Contains(content, "kvm") {
+				return "kvm"
+			} else if strings.Contains(content, "xenhvm") {
+				return "xenhvm"
+			} else if strings.Contains(content, "virtualbox") {
+				return "virtualbox"
+			} else if strings.Contains(content, "vmware") {
+				return "vmware"
+			} else if strings.Contains(content, "qemu") {
+				return "qemu"
+			} else if strings.Contains(content, "hyperv") {
+				return "hyperv"
+			}
+		}
+	}
+
+	// no virtual
+	return ""
 }

--- a/pkg/visor/visorconfig/values_darwin.go
+++ b/pkg/visor/visorconfig/values_darwin.go
@@ -4,7 +4,6 @@
 package visorconfig
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -107,7 +106,7 @@ func getNodeHypervisor() string {
 		return "docker"
 	}
 	// Check for cgroup indicating Docker or container environment
-	data, err := ioutil.ReadFile("/proc/self/cgroup")
+	data, err := os.ReadFile("/proc/self/cgroup")
 	if err == nil && strings.Contains(string(data), "docker") {
 		return "docker"
 	}

--- a/pkg/visor/visorconfig/values_windows.go
+++ b/pkg/visor/visorconfig/values_windows.go
@@ -4,9 +4,12 @@
 package visorconfig
 
 import (
+	"io/ioutil"
 	"log"
 	"net"
+	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/windows"
@@ -68,7 +71,7 @@ func SystemSurvey() (Survey, error) {
 		Timestamp:      time.Now(),
 		GOOS:           runtime.GOOS,
 		GOARCH:         runtime.GOARCH,
-		SYSINFO:        getMacAddr(),
+		SYSINFO:        genSysInfo(),
 		UUID:           uuid.New(),
 		Disks:          disks,
 		Product:        product,
@@ -80,27 +83,78 @@ func SystemSurvey() (Survey, error) {
 
 type customSysinfo struct {
 	Network []networkDevice `json:"network,omitempty"`
+	Node    node            `json:"node,omitempty"`
 }
 type networkDevice struct {
 	MACAddress string `json:"macaddress,omitempty"`
 }
 
-func getMacAddr() customSysinfo {
+type node struct {
+	Hypervisor string `json:"hypervisor,omitempty"`
+}
+
+func genSysInfo() customSysinfo {
 	var sysInfo customSysinfo
+	sysInfo.Network = getMacAddr()
+	sysInfo.Node.Hypervisor = getNodeHypervisor()
+	return sysInfo
+}
+
+func getMacAddr() []networkDevice {
 	si := make([]networkDevice, 1)
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return sysInfo
+		return si
 	}
-
 	for _, ifa := range interfaces {
 		si[0].MACAddress = ifa.HardwareAddr.String()
 		if si[0].MACAddress != "" {
-			sysInfo.Network = si
-			return sysInfo
+			return si
 		}
 	}
-	return sysInfo
+	return si
+}
+
+func getNodeHypervisor() string {
+	// Check docker
+	// Check for the /.dockerenv file
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return "docker"
+	}
+	// Check for cgroup indicating Docker or container environment
+	data, err := ioutil.ReadFile("/proc/self/cgroup")
+	if err == nil && strings.Contains(string(data), "docker") {
+		return "docker"
+	}
+
+	// Check other virtualization: kvm, xenhvm, virtualbox, vmware, qemu, hyperv
+	dmiFiles := []string{
+		"/sys/class/dmi/id/product_name",
+		"/sys/class/dmi/id/sys_vendor",
+	}
+
+	for _, file := range dmiFiles {
+		data, err := os.ReadFile(file) //nolint: gosec
+		if err == nil {
+			content := strings.ToLower(string(data))
+			if strings.Contains(content, "kvm") {
+				return "kvm"
+			} else if strings.Contains(content, "xenhvm") {
+				return "xenhvm"
+			} else if strings.Contains(content, "virtualbox") {
+				return "virtualbox"
+			} else if strings.Contains(content, "vmware") {
+				return "vmware"
+			} else if strings.Contains(content, "qemu") {
+				return "qemu"
+			} else if strings.Contains(content, "hyperv") {
+				return "hyperv"
+			}
+		}
+	}
+
+	// no virtual
+	return ""
 }
 
 // IsRoot checks for root permissions

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -25,11 +25,7 @@ function InstallWix
 
 function BuildInstaller($arch)
 {
-    if ($arch -eq "386") {
-        $wintun_arch="x86"
-        $arch_title="386  "
-        $wix_arch="x86"
-    } else {
+    if ($arch -eq "amd64") {
         $wintun_arch="amd64"
         $arch_title="amd64"
         $wix_arch="x64"
@@ -100,6 +96,5 @@ Write-Output "`n##########################################################"
 Write-Output "#                                                        #"
 Write-Output "#        .:::: Create MSI Installer Package ::::.        #"
 BuildInstaller("amd64")
-BuildInstaller("386")
 Write-Output "#                                                        #"
 Write-Output "##########################################################`n"


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:
- get rid from x86 windows installer	
- handle missing value `node.hypervisor` for Windows and Mac survey	

How to test this PR:
- Run visor in Mac or Windows (with reward address set) as root or admin
- Check `node-info.json` generated file

Screenshot:
- Mac:
   <img width="338" alt="image" src="https://github.com/user-attachments/assets/8a2b20a0-fc3c-49f4-98c4-6303a755357a">
