### PR TITLE
fix '/log-collection/tree/:pk' route on reward system ui

### DIFF
--- a/cmd/skywire-cli/commands/rewards/ui.go
+++ b/cmd/skywire-cli/commands/rewards/ui.go
@@ -380,8 +380,8 @@ func server() {
 		surveycount, _ := script.FindFiles("rewards/log_backups/").Match("node-info.json").CountLines() //nolint
 		c.Writer.Write([]byte(fmt.Sprintf("Total surveys: %v\n", surveycount)))                         //nolint
 		c.Writer.Flush()
-		st, _ := script.Exec(`skywire cli log st -d rewards/log_backups -e rewards/tp_setup -rup ` + c.Param("pk")).Bytes() //nolint
-		c.Writer.Write(ansihtml.ConvertToHTML(st))                                                                          //nolint
+		st, _ := script.Exec(`skywire cli log st -d rewards/log_backups -rup ` + c.Param("pk")).Bytes() //nolint
+		c.Writer.Write(ansihtml.ConvertToHTML(st))                                                      //nolint
 		c.Writer.Flush()
 		c.Writer.Write([]byte(htmltoplink)) //nolint
 		c.Writer.Flush()


### PR DESCRIPTION
Flags were changed on `skywire cli log st` but not updated on the aforementioned reward system UI route when the transport setup-node tests were stopped / omitted, which caused the following error due to unknown / missing flag:

![image](https://github.com/user-attachments/assets/1281ccd1-60c5-474f-9edc-baf8b6b01419)

The flag was omitted in this PR , restoring functionality for that endpoint

thanks @Kulubali Eric Edmond for reporting this issue