### PR TITLE
Improve route logic in visor side

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -35,16 +35,20 @@ const (
 )
 
 var (
-	r        = netutil.NewRetrier(nil, time.Second, netutil.DefaultMaxBackoff, 0, 1)
-	addr     string
-	serverPK string
-	httpAddr string
+	r          *netutil.Retrier
+	addr       string
+	serverPK   string
+	httpAddr   string
+	retryDelay int64
+	tries      int64
 )
 
 func init() {
 	RootCmd.Flags().StringVar(&addr, "addr", visorconfig.SkysocksClientAddr, "Client address to listen on")
 	RootCmd.Flags().StringVar(&serverPK, "srv", "", "PubKey of the server to connect to")
 	RootCmd.Flags().StringVar(&httpAddr, "http", "", "http proxy mode")
+	RootCmd.Flags().Int64Var(&tries, "tries", 3, "number of tries")
+	RootCmd.Flags().Int64Var(&retryDelay, "retry-time", 5, "delay between each try")
 }
 
 // RootCmd is the root command for skysocks
@@ -61,6 +65,8 @@ var RootCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Version:               buildinfo.Version(),
 	Run: func(_ *cobra.Command, _ []string) {
+		r = netutil.NewRetrier(nil, time.Duration(retryDelay)*time.Second, netutil.DefaultMaxBackoff, tries, 1)
+
 		appCl := app.NewClient(nil)
 		defer appCl.Close()
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -622,6 +622,7 @@ var genConfigCmd = &cobra.Command{
 			RouteFinder:        services.RouteFinder,     //utilenv.RouteFinderAddr,
 			RouteSetupNodes:    services.RouteSetupNodes, //[]cipher.PubKey{utilenv.MustPK(utilenv.SetupPK)},
 			RouteFinderTimeout: visorconfig.DefaultTimeout,
+			MinHops:            1,
 		}
 		conf.Launcher = &visorconfig.Launcher{
 			ServiceDisc:   services.ServiceDiscovery, //utilenv.ServiceDiscAddr,

--- a/cmd/skywire-cli/commands/route/route.go
+++ b/cmd/skywire-cli/commands/route/route.go
@@ -67,6 +67,10 @@ Assumes the local visor public key as an argument if only one argument is given`
 			cmd.Help() //nolint
 			os.Exit(0)
 		}
+		// disble finding route, because of minhop value that set 0
+		if frMinHops == 0 {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Routing disabled. (minhop=0)"))
+		}
 		//set the routefinder address. It's not used as the default value to fix the display of the help command
 		if frAddr == "" {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Route Finder URL not specified"))

--- a/internal/skysocks/client.go
+++ b/internal/skysocks/client.go
@@ -60,14 +60,12 @@ func (c *Client) ListenAndServe(addr string) error {
 	fmt.Printf("Listening skysocks client on %s", addr)
 
 	c.listener = l
+	go func() {
+		<-c.closeC
+		l.Close() //nolint
+	}()
 
 	for {
-		select {
-		case <-c.closeC:
-			return nil
-		default:
-		}
-
 		conn, err := l.Accept()
 		if err != nil {
 			fmt.Printf("Error accepting: %v\n", err)
@@ -187,8 +185,6 @@ func (c *Client) Close() error {
 		fmt.Println("Closing proxy client")
 
 		close(c.closeC)
-
-		err = c.listener.Close()
 	})
 
 	return err

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -39,6 +39,8 @@ var (
 	ErrRuleTransportMismatch = errors.New("rule/transport mismatch")
 	// ErrNoSuitableTransport is returned when no suitable transport was found.
 	ErrNoSuitableTransport = errors.New("no suitable transport")
+	// ErrNoRouteFound is return when no route founds after specific tries
+	ErrNoRouteFound = errors.New("no route founds")
 )
 
 type timeoutError struct{}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -35,7 +35,7 @@ const (
 
 	handshakeAwaitTimeout = 2 * time.Second
 
-	maxHops       = 7
+	maxHops       = 1000
 	retryDuration = 2 * time.Second
 	retryInterval = 500 * time.Millisecond
 )

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -245,6 +245,11 @@ func (r *router) DialRoutes(
 		return nil, fmt.Errorf("failed to dial routes: %w", err)
 	}
 
+	if r.conf.MinHops == 0 {
+		r.logger.Error("Routing disabled. (minhop=0)")
+		return nil, fmt.Errorf("Routing disabled. (minhop=0)")
+	}
+
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, rPK, lPort, rPort)
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -251,10 +251,10 @@ func (r *router) DialRoutes(
 	// check if transport exist, then skip minhop value and consider it equal 0
 	defaultMinHops := r.conf.MinHops
 	if r.isTpdExist(rPK) {
-		r.conf.MinHops = 0
+		r.conf.MinHops = 1
 	}
 
-	if r.conf.MinHops == 0 {
+	if r.conf.MinHops == 1 {
 		r.routeSetupHookMu.Lock()
 		defer r.routeSetupHookMu.Unlock()
 		if len(r.routeSetupHooks) != 0 {
@@ -306,7 +306,7 @@ func (r *router) DialRoutes(
 	r.logger.Debugf("Created new routes to %s on port %d", rPK, lPort)
 
 	// reset MinHops default value if changed before
-	if defaultMinHops != 0 {
+	if defaultMinHops != 1 {
 		r.conf.MinHops = defaultMinHops
 	}
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -98,6 +98,7 @@ type DialOptions struct {
 	MaxForwardRts int
 	MinConsumeRts int
 	MaxConsumeRts int
+	Retries       int
 }
 
 // DefaultDialOptions returns default dial options.
@@ -108,6 +109,7 @@ func DefaultDialOptions() *DialOptions {
 		MaxForwardRts: 1,
 		MinConsumeRts: 1,
 		MaxConsumeRts: 1,
+		Retries:       3,
 	}
 }
 
@@ -1048,6 +1050,8 @@ func (r *router) fetchBestRoutes(src, dst cipher.PubKey, opts *DialOptions) (fwd
 		opts = DefaultDialOptions() // nolint
 	}
 
+	retries := opts.Retries
+
 	r.logger.Debugf("Requesting new routes from %s to %s", src, dst)
 
 	timer := time.NewTimer(retryDuration)
@@ -1064,6 +1068,14 @@ fetchRoutesAgain:
 
 	if err == rfclient.ErrTransportNotFound {
 		return nil, nil, err
+	}
+	// simple retries condition
+	if retries == 0 {
+		r.logger.Errorf(ErrNoRouteFound.Error())
+		return nil, nil, ErrNoRouteFound
+	}
+	if retries > 0 {
+		retries--
 	}
 
 	if err != nil {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -35,7 +35,7 @@ const (
 
 	handshakeAwaitTimeout = 2 * time.Second
 
-	maxHops       = 50
+	maxHops       = 7
 	retryDuration = 2 * time.Second
 	retryInterval = 500 * time.Millisecond
 )

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -246,20 +246,22 @@ func (r *router) DialRoutes(
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, rPK, lPort, rPort)
 
-	r.routeSetupHookMu.Lock()
-	defer r.routeSetupHookMu.Unlock()
-	if len(r.routeSetupHooks) != 0 {
-		for _, rsf := range r.routeSetupHooks {
-			if err := rsf(rPK, r.tm); err != nil {
-				return nil, err
-			}
-		}
+	// check if transport exist, then skip minhop value and consider it equal 0
+	defaultMinHops := r.conf.MinHops
+	if r.isTpdExist(rPK) {
+		r.conf.MinHops = 0
 	}
 
-	// check if transports are available
-	ok := r.checkIfTransportAvailable()
-	if !ok {
-		return nil, ErrNoTransportFound
+	if r.conf.MinHops == 0 {
+		r.routeSetupHookMu.Lock()
+		defer r.routeSetupHookMu.Unlock()
+		if len(r.routeSetupHooks) != 0 {
+			for _, rsf := range r.routeSetupHooks {
+				if err := rsf(rPK, r.tm); err != nil {
+					return nil, err
+				}
+			}
+		}
 	}
 
 	forwardPath, reversePath, err := r.fetchBestRoutes(lPK, rPK, opts)
@@ -301,6 +303,11 @@ func (r *router) DialRoutes(
 
 	r.logger.Debugf("Created new routes to %s on port %d", rPK, lPort)
 
+	// reset MinHops default value if changed before
+	if defaultMinHops != 0 {
+		r.conf.MinHops = defaultMinHops
+	}
+
 	return nrg, nil
 }
 
@@ -328,11 +335,6 @@ func (r *router) PingRoute(
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, lPK, lPort, rPort)
 
-	// check if transports are available
-	ok := r.checkIfTransportAvailable()
-	if !ok {
-		return nil, ErrNoTransportFound
-	}
 	forwardPath, reversePath, err := r.fetchPingRoute(lPK, rPK, opts)
 	if err != nil {
 		return nil, fmt.Errorf("route finder: %w", err)
@@ -1330,10 +1332,18 @@ func (r *router) removeRouteGroupOfRule(rule routing.Rule) {
 	log.Debug("Noise route group closed.")
 }
 
-func (r *router) checkIfTransportAvailable() (ok bool) {
-	r.tm.WalkTransports(func(_ *transport.ManagedTransport) bool {
-		ok = true
-		return ok
-	})
-	return ok
+func (r *router) isTpdExist(rPK cipher.PubKey) bool {
+	// check stcpr transport if exist
+	_, err := r.tm.GetTransport(rPK, network.STCPR)
+	if err == nil {
+		return true
+	}
+	// check sudph transport if exist
+	_, err = r.tm.GetTransport(rPK, network.SUDPH)
+	if err == nil {
+		return true
+	}
+	// check dmsg transport if exist
+	_, err = r.tm.GetTransport(rPK, network.DMSG)
+	return err == nil
 }

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -68,6 +68,7 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		RouteFinder:        services.RouteFinder,
 		RouteSetupNodes:    services.RouteSetupNodes,
 		RouteFinderTimeout: DefaultTimeout,
+		MinHops:            1,
 	}
 	conf.Launcher = &Launcher{
 		ServiceDisc:   services.ServiceDiscovery,


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- [x] change default (and hardcoded) value of `max_hop` from 50 to 1000. (not included on visor config)
- [x] change default value of min_hop in config from 0 to 1. 0 was meaningless.
- [x] add retrier on trying find route by skysocks-client
- [x] fix data race found in skysocks-client (#1923)

How to test this PR:
- for check change minhop value in config, generate a config
- for retry function, run visor, start skysock-client with dummy but correct PK as skysocks server PK, check logs