### PR TITLE
improve SetMinHop api method

### DIFF
--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -257,6 +257,11 @@ func (_m *MockRouter) SetupIsTrusted(_a0 cipher.PubKey) bool {
 	return r0
 }
 
+// SetMinHop provides a mock function with given fields: _a0
+func (_m *MockRouter) SetMinHop(_a0 uint16) {
+	_m.Called(_a0)
+}
+
 type mockConstructorTestingTNewMockRouter interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -140,6 +140,7 @@ type Router interface {
 	IntroduceRules(rules routing.EdgeRules) error
 	Serve(context.Context) error
 	SetupIsTrusted(cipher.PubKey) bool
+	SetMinHop(uint16)
 
 	// Routing table related methods
 	RoutesCount() int
@@ -1166,6 +1167,11 @@ fetchRoutesAgain:
 func (r *router) SetupIsTrusted(sPK cipher.PubKey) bool {
 	_, ok := r.trustedVisors[sPK]
 	return ok
+}
+
+// SetMinHop set minhop when visor running
+func (r *router) SetMinHop(minhop uint16) {
+	r.conf.MinHops = minhop
 }
 
 // Saves `rules` to the routing table.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -1475,6 +1475,7 @@ func (v *Visor) RuntimeLogs() (string, error) {
 
 // SetMinHops sets min_hops routing config of visor
 func (v *Visor) SetMinHops(in uint16) error {
+	v.router.SetMinHop(in)
 	return v.conf.UpdateMinHops(in)
 }
 


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- improve SetMinHop to change router configs too, not just visor config

How to test this PR:
- Run visor with minhop != 0
- Change minhop value when visor running to 0, by UI or cli
- Run app like skysocks-client
- Check logs for this error
  ```
  [2025-01-28T06:44:09.199000149Z] ERROR [router]: Routing disabled. (minhop=0) 
  ```