### PR TITLE
remove hf from 386 release

### DIFF
--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -137,7 +137,7 @@ archives:
   - id: 386
     format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}hf'
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     files:
       - dmsghttp-config.json
       - services-config.json


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- fix release name of x86 linux

How to test this PR:
_