### PR TITLE
add `--json` flag back to vpn and proxy `list` subcommand

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/routing"
+	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -263,6 +264,7 @@ var statusCmd = &cobra.Command{
 }
 
 var isLabel bool
+var jsonOutput bool
 
 func init() {
 	var envServices skywire.EnvServices
@@ -287,16 +289,26 @@ func init() {
 	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter results by country")
 	listCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 	listCmd.Flags().BoolVarP(&isLabel, "label", "l", false, "label keys by country \033[91m(SLOW)\033[0m")
+
+	listCmd.Flags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
+	listCmd.Flags().MarkHidden(internal.JSONString) //nolint
 }
 
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
 	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files", serviceType, svcDiscURL, serviceType, svcDiscURL, serviceType),
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {
 			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint
+			return
+		}
+		if jsonOutput {
+			var list []services.Service
+			json.Unmarshal([]byte(sds), &list) //nolint
+			var b bytes.Buffer
+			internal.PrintOutput(cmd.Flags(), list, b.String())
 			return
 		}
 		if pk != "" {

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -20,6 +20,7 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
+	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/visor"
 )
@@ -164,6 +165,7 @@ var statusCmd = &cobra.Command{
 }
 
 var isLabel bool
+var jsonOutput bool
 
 func init() {
 	var envServices skywire.EnvServices
@@ -188,18 +190,30 @@ func init() {
 	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter results by country")
 	listCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 	listCmd.Flags().BoolVarP(&isLabel, "label", "l", false, "label keys by country \033[91m(SLOW)\033[0m")
+
+	listCmd.Flags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
+	listCmd.Flags().MarkHidden(internal.JSONString) //nolint
 }
 
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
 	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files", serviceType, sdURL, serviceType, sdURL, serviceType),
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {
 			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint
 			return
 		}
+
+		if jsonOutput {
+			var list []services.Service
+			json.Unmarshal([]byte(sds), &list) //nolint
+			var b bytes.Buffer
+			internal.PrintOutput(cmd.Flags(), list, b.String())
+			return
+		}
+
 		if pk != "" {
 			if isStats {
 				count, _ := script.Echo(sds).JQ(`map(select(.address == "`+pk+`:3"))`).Replace("\"", "").Replace(":", " ").Column(1).CountLines() //nolint


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add `--json` flag back to `cli vpn list` and `cli proxy list` due to https://github.com/skycoin/skywire-services/pull/98

How to test this PR:
- run visor
- run command `skywire cli visor list --json`
- check output