### PR TITLE
Fix version parsing

### DIFF
--- a/cmd/skywire-cli/commands/config/parse.go
+++ b/cmd/skywire-cli/commands/config/parse.go
@@ -3,13 +3,13 @@ package cliconfig
 
 import (
 	"bytes"
-
 	"os"
 	"path/filepath"
-	"github.com/spf13/cobra"
-	"github.com/skycoin/skywire/pkg/visor/visorconfig"
-	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 var parseCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/config/parse.go
+++ b/cmd/skywire-cli/commands/config/parse.go
@@ -1,0 +1,39 @@
+// Package cliconfig cmd/skywire-cli/commands/config/parse.go
+package cliconfig
+
+import (
+	"bytes"
+
+	"os"
+	"path/filepath"
+	"github.com/spf13/cobra"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
+
+)
+
+var parseCmd = &cobra.Command{
+	Use:   "parse <skywire-config.json>",
+	Short: "check for errors in parsing skywire config",
+	Args:  cobra.ExactArgs(1), // Require exactly one argument
+	Run: func(_ *cobra.Command, args []string) {
+		logger.WithField("filepath", args[0]).Info()
+		f, err := os.ReadFile(filepath.Clean(args[0]))
+		if err != nil {
+			logger.WithError(err).Fatal("Failed to read config file.")
+		}
+		r := bytes.NewReader(f)
+		_, compat, err := visorconfig.Parse(logger, r, args[0], buildinfo.Get())
+		if err != nil {
+			logger.WithError(err).Fatal("Failed to read in config.")
+		}
+		if !compat {
+			logger.Fatalf("config version is incompatible")
+		}
+		logger.Info("Config successfully parsed.")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(parseCmd)
+}

--- a/pkg/visor/visorconfig/parse.go
+++ b/pkg/visor/visorconfig/parse.go
@@ -24,16 +24,19 @@ func Parse(log *logging.Logger, r io.Reader, confPath string, visorBuildInfo *bu
 
 	conf, err = Reader(r, confPath)
 	if err != nil {
+		log.Debug(`error on Reader(r, confPath)`)
 		return nil, compat, err
 	}
 	// we check if the version of the visor and config are the same
 	if (conf.Version != "unknown") && (visorBuildInfo.Version != "unknown") {
 		cVer, err := semver.Make(strings.TrimPrefix(conf.Version, "v"))
 		if err != nil {
+			log.Debug(`error on semver.Make(strings.TrimPrefix(conf.Version, "v"))`)
 			return conf, compat, err
 		}
 		vVer, err := semver.Make(strings.TrimPrefix(visorBuildInfo.Version, "v"))
 		if err != nil {
+			log.Debug(`error on semver.Make(strings.TrimPrefix(visorBuildInfo.Version, "v"))`)
 			return conf, compat, err
 		}
 		if cVer.Major == vVer.Major {


### PR DESCRIPTION
an error was observed when attempting to run the visor on develop branch:

```
$ go run github.com/skycoin/skywire/cmd/skywire@develop visor -pl debug
[2025-04-15T08:32:26.136132555-05:00] INFO [buildinfo]:  version="v1.3.29-rc7.0." built on="2025-04-14T13:29:07Z" commit="330ec8cce85f"
[2025-04-15T08:32:26.137875053-05:00] INFO [visor:config]: filepath="/opt/skywire/skywire.json"
[2025-04-15T08:32:26.139153164-05:00] FATAL [visor:config]: Failed to read in config. error="Prerelease is empty"
```

The error does not manifest when the visor is run from source, only when it's `go run` remotely.

* added debug logging for config parse function
* added `skywire cli config parse` command