### PR TITLE
Fix public visor autoconnect logic

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -133,7 +133,7 @@ var RootCmd = &cobra.Command{
 			go httpProxy(httpCtx, httpAddr, addr)
 		}
 		defer httpCancel()
-		if err := client.ListenAndServe(addr); err != nil {
+		if err := client.ListenAndServe(addr); err != nil { //nolint
 			print(fmt.Sprintf("Error serving proxy client: %v\n", err))
 		}
 		setAppStatus(appCl, appserver.AppDetailedStatusStopped)

--- a/cmd/skywire-cli/commands/rewards/ui/ui.go
+++ b/cmd/skywire-cli/commands/rewards/ui/ui.go
@@ -279,6 +279,14 @@ func main() {
 				ctx.LinkButton(w, "https://t.me/skywire_reward")
 				w.SetText("@skywire_reward").SetIcon(icons.NotificationImportant)
 			})
+			tree.Add(p, func(w *core.Button) {
+				ctx.LinkButton(w, "https://t.me/skycoin")
+				w.SetText("@skycoin").SetIcon(icons.NotificationImportant)
+			})
+			tree.Add(p, func(w *core.Button) {
+				ctx.LinkButton(w, "https://skycoin.com")
+				w.SetText("Skycoin").SetIcon(icons.Traffic)
+			})
 		})
 	})
 

--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -18,8 +19,8 @@ import (
 )
 
 const (
-	// PublicServiceDelay defines a delay before adding transports to public services.
-	PublicServiceDelay = 10 * time.Second
+	// PublicServiceDelay defines the interval for checking service discovery and adding transports to public visors.
+	PublicServiceDelay = 300 * time.Second
 
 	fetchServicesDelay           = 10 * time.Second
 	maxFailedAddressRetryAttempt = 2
@@ -54,8 +55,19 @@ func MakeConnector(conf Config, maxConns int, tm *transport.Manager, httpC *http
 
 // Run implements Autoconnector interface
 func (a *autoconnector) Run(ctx context.Context) (err error) {
-	// failed addresses will be populated everytime any failed attempt at establishing transport occurs.
-	failedAddresses := map[cipher.PubKey]int{}
+
+	// Wait for a random interval between 0 and 5 minutes before starting public autoconnect.
+	// Prevents a cluster of nodes which was switched on at the same time
+	// from producing concurrent, synchronous requests to SD and subsequent connection attempts to public visors
+	rand.Seed(time.Now().UnixNano())
+	randomDelay := time.Duration(rand.Intn(5*60)) * time.Second
+	a.log.Debugln("Waiting for a random interval before starting public autoconnect: ", randomDelay)
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case <-time.After(randomDelay):
+	}
+
 	publicServiceTicket := time.NewTicker(PublicServiceDelay)
 
 	for {
@@ -82,17 +94,13 @@ func (a *autoconnector) Run(ctx context.Context) (err error) {
 			absent := a.filterDuplicates(addrs, tps)
 
 			for _, pk := range absent {
-				val, ok := failedAddresses[pk]
-				if !ok || val < maxFailedAddressRetryAttempt {
-					a.log.WithField("pk", pk).WithField("attempt", val).Debugln("Trying to add transport to public visor")
-					logger := a.log.WithField("pk", pk).WithField("type", string(network.STCPR))
-					if err = a.tryEstablishTransport(ctx, pk, logger); err != nil {
-						if !errors.Is(err, io.ErrClosedPipe) {
-							logger.WithError(err).Warnln("Failed to add transport to public visor")
-						}
-						failedAddresses[pk]++
-						continue
+				a.log.WithField("pk", pk).Debugln("Trying to add transport to public visor")
+				logger := a.log.WithField("pk", pk).WithField("type", string(network.STCPR))
+				if err = a.tryEstablishTransport(ctx, pk, logger); err != nil {
+					if !errors.Is(err, io.ErrClosedPipe) {
+						logger.WithError(err).Warnln("Failed to add transport to public visor")
 					}
+					continue
 				}
 			}
 		}

--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -23,7 +23,6 @@ const (
 	PublicServiceDelay = 300 * time.Second
 
 	fetchServicesDelay           = 10 * time.Second
-	maxFailedAddressRetryAttempt = 2
 )
 
 // ConnectFn provides a way to connect to remote service

--- a/pkg/servicedisc/autoconnect.go
+++ b/pkg/servicedisc/autoconnect.go
@@ -3,9 +3,10 @@ package servicedisc
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"io"
-	"math/rand"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -22,7 +23,7 @@ const (
 	// PublicServiceDelay defines the interval for checking service discovery and adding transports to public visors.
 	PublicServiceDelay = 300 * time.Second
 
-	fetchServicesDelay           = 10 * time.Second
+	fetchServicesDelay = 10 * time.Second
 )
 
 // ConnectFn provides a way to connect to remote service
@@ -54,13 +55,19 @@ func MakeConnector(conf Config, maxConns int, tm *transport.Manager, httpC *http
 
 // Run implements Autoconnector interface
 func (a *autoconnector) Run(ctx context.Context) (err error) {
-
 	// Wait for a random interval between 0 and 5 minutes before starting public autoconnect.
 	// Prevents a cluster of nodes which was switched on at the same time
 	// from producing concurrent, synchronous requests to SD and subsequent connection attempts to public visors
-	rand.Seed(time.Now().UnixNano())
-	randomDelay := time.Duration(rand.Intn(5*60)) * time.Second
-	a.log.Debugln("Waiting for a random interval before starting public autoconnect: ", randomDelay)
+	const maxDelaySeconds = 5 * 60 // 5 minutes
+
+	randomDelaySeconds, err := randInt(0, maxDelaySeconds)
+	if err != nil {
+		a.log.WithError(err).Warn("Failed to generate secure random delay; falling back to 0")
+		randomDelaySeconds = 0
+	}
+	randomDelay := time.Duration(randomDelaySeconds) * time.Second
+	a.log.Debugln("Waiting for a random interval before starting public autoconnect:", randomDelay)
+
 	select {
 	case <-ctx.Done():
 		return context.Canceled
@@ -74,12 +81,10 @@ func (a *autoconnector) Run(ctx context.Context) (err error) {
 		case <-ctx.Done():
 			return context.Canceled
 		case <-publicServiceTicket.C:
-			// successfully established transports
 			tps := a.tm.GetTransportsByLabel(transport.LabelAutomatic)
 
-			// don't fetch public addresses if there are more or equal to the number of maximum transport defined.
 			if len(tps) >= a.maxConns {
-				a.log.Debugln("autoconnect: maximum number of established transports reached: ", a.maxConns)
+				a.log.Debugln("autoconnect: maximum number of established transports reached:", a.maxConns)
 				return err
 			}
 
@@ -87,9 +92,9 @@ func (a *autoconnector) Run(ctx context.Context) (err error) {
 			addrs, err := a.fetchPubAddresses(ctx)
 			if err != nil {
 				a.log.Errorf("Cannot fetch public services: %s", err)
+				continue
 			}
 
-			// filter out any established transports
 			absent := a.filterDuplicates(addrs, tps)
 
 			for _, pk := range absent {
@@ -153,4 +158,16 @@ func (a *autoconnector) filterDuplicates(pks []cipher.PubKey, trs []*transport.M
 		}
 	}
 	return absent
+}
+
+// randInt returns a secure random integer in [min, max).
+func randInt(n, x int) (int, error) {
+	if n >= x {
+		return n, nil
+	}
+	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(x-n)))
+	if err != nil {
+		return 0, err
+	}
+	return int(nBig.Int64()) + n, nil
 }


### PR DESCRIPTION
* Increase time between SD queries to 5 minutes (300 seconds) from 10 seconds
* Unlimit reconnect attempts to public visors
* add skycoin.com link to reward system UI
* add link to skycoin telegram to reward system UI