### PR TITLE
Revert ineffective changes to InitDmsgHTTP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 on: [pull_request]
 name: Test
+
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -10,25 +11,25 @@ jobs:
 
       - uses: actions/checkout@v4
 
-- name: Install Dependencies
-  shell: bash
-  run: |
-    set -euo pipefail
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
 
-    go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
-    sudo apt-get update
-    sudo apt-get install -y \
-      libglfw3-dev \
-      libgl1-mesa-dev \
-      xorg-dev \
-      libglu1-mesa-dev \
-      shellcheck
+          sudo apt-get update
+          sudo apt-get install -y \
+            libglfw3-dev \
+            libgl1-mesa-dev \
+            xorg-dev \
+            libglu1-mesa-dev \
+            shellcheck
 
-    make dep
-    ./ci_scripts/create-ip-aliases.sh
+          make dep
+          ./ci_scripts/create-ip-aliases.sh
 
-  - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.1
 
@@ -57,14 +58,15 @@ jobs:
       - name: Clean E2E
         run: make e2e-stop
 
-
   darwin:
     runs-on: macos-latest
     steps:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
+
       - uses: actions/checkout@v4
+
       - name: Install Requirements
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.1
@@ -72,8 +74,10 @@ jobs:
           make dep
           brew install glfw
         shell: bash
+
       - name: Checking Format and Testing
         run: make check
+
       - name: Build
         run: make build
 
@@ -83,16 +87,20 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
+
       - uses: actions/checkout@v4
+
       - name: Install Requirements
         run: |
           choco install make
           go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.1.1
           make dep
+
       - name: Testing
-        run:  |
+        run: |
           set GO111MODULE=on
           make test-windows
+
       - name: Build
         run: make build-windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
           make dep
           ./ci_scripts/create-ip-aliases.sh
 
+          make install-shellcheck
+
       - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,24 +10,25 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install Dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
+- name: Install Dependencies
+  shell: bash
+  run: |
+    set -euo pipefail
 
-          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+    go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
-          sudo apt-get update
-          sudo apt-get install -y \
-            libglfw3-dev \
-            libgl1-mesa-dev \
-            xorg-dev \
-            libglu1-mesa-dev
+    sudo apt-get update
+    sudo apt-get install -y \
+      libglfw3-dev \
+      libgl1-mesa-dev \
+      xorg-dev \
+      libglu1-mesa-dev \
+      shellcheck
 
-          make dep
-          ./ci_scripts/create-ip-aliases.sh
+    make dep
+    ./ci_scripts/create-ip-aliases.sh
 
-      - uses: golangci/golangci-lint-action@v7
+  - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           make dep
           ./ci_scripts/create-ip-aliases.sh
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,36 +7,55 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x
+
       - uses: actions/checkout@v4
-      - name: Install Requirements
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.1
-          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-          sudo apt install libglfw3-dev libgl1-mesa-dev xorg-dev libglu1-mesa-dev
-          make dep
-          chmod +x ./ci_scripts/create-ip-aliases.sh
-          ./ci_scripts/create-ip-aliases.sh
-          make install-shellcheck
+
+      - name: Install Dependencies
         shell: bash
-      - name: Checking Format and Testing
         run: |
-          make check
-          make lint-shell
+          set -euo pipefail
+
+          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+
+          sudo apt-get update
+          sudo apt-get install -y \
+            libglfw3-dev \
+            libgl1-mesa-dev \
+            xorg-dev \
+            libglu1-mesa-dev
+
+          make dep
+          ./ci_scripts/create-ip-aliases.sh
+
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.1.1
+
+      - name: Lint Shell Scripts
+        run: make lint-shell
+
+      - name: Check Format and Run Tests
+        run: make check
+
       - name: Build
         run: make build
-      - name: Setup SSH Key Build and run e2e
-        run : |
+
+      - name: Setup SSH Key, Build and Run E2E
+        shell: bash
+        run: |
+          set -e
           make e2e-build
           make e2e-run
-        shell: bash
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Test e2e
+
+      - name: Test E2E
         run: make e2e-test
-      - name: Clean e2e
-        run: |
-          make e2e-stop
+
+      - name: Clean E2E
+        run: make e2e-stop
+
 
   darwin:
     runs-on: macos-latest

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -191,77 +191,24 @@ func registerModules(logger *logging.MasterLogger) {
 type initFn func(context.Context, *Visor, *logging.Logger) error
 
 func initDmsgHTTP(ctx context.Context, v *Visor, log *logging.Logger) error { //nolint:all
+	var keys cipher.PubKeys
 	servers := shuffleServers(v.conf.Dmsg.Servers)
+
 	if len(servers) == 0 {
 		return nil
 	}
 
-	keys := cipher.PubKeys{v.conf.PK}
-	var (
-		dmsgDC      *dmsg.Client
-		dClient     dmsgdisc.APIClient
-		dmsgHTTP    http.Client
-		closeDmsgDC func()
-		err         error
-	)
+	keys = append(keys, v.conf.PK)
+	entries := direct.GetAllEntries(keys, servers)
+	dClient := direct.NewClient(entries, v.MasterLogger().PackageLogger("dmsg_http:direct_client"))
 
-	for i := 0; i < len(servers); i++ {
-		rotateServers(servers)
-		entries := direct.GetAllEntries(keys, servers)
-		dClient = direct.NewClient(entries, v.MasterLogger().PackageLogger("dmsg_http:direct_client"))
-		// Post client entry with all delegated servers
-		var delegatedServers []cipher.PubKey
-		for _, srv := range servers {
-			delegatedServers = append(delegatedServers, srv.Static)
-		}
-		var pk cipher.PubKey
-		err = pk.Set(dmsg.ExtractPKFromDmsgAddr(v.conf.Dmsg.Discovery))
-		if err == nil {
-			clientEntry := &dmsgdisc.Entry{
-				Client: &dmsgdisc.Client{
-					DelegatedServers: delegatedServers,
-				},
-				Static: pk,
-			}
-			if err := dClient.PostEntry(ctx, clientEntry); err != nil {
-				log.WithError(err).Error("failed to post client entry")
-				continue
-			}
-		}
-
-		dmsgDC, closeDmsgDC, err = direct.StartDmsg(ctx, v.MasterLogger().PackageLogger("dmsg_http:dmsgDC"), v.conf.PK, v.conf.SK, dClient, dmsg.DefaultConfig())
-		if err != nil {
-			log.WithError(err).Error("Failed to start dmsg direct client")
-			continue
-		}
-
-		dmsgHTTP = http.Client{
-			Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgDC),
-		}
-
-		if v.conf.Dmsg.Discovery == "" {
-			break
-		}
-		resp, err := dmsgHTTP.Get(v.conf.Dmsg.Discovery + "/health")
-		if err != nil {
-			closeDmsgDC()
-			log.WithError(err).Error("dmsgHTTP client could not access dmsg-discovery server; reconfiguring...")
-			continue
-		}
-		defer resp.Body.Close() //nolint
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			closeDmsgDC()
-			log.WithError(err).Error("Failed to read /health response body from dmsg-discovery server via dmsgHTTP client")
-			continue
-		}
-		log.Debugf("dmsg-discovery server %s/health:\n%s", v.conf.Dmsg.Discovery, string(body))
-		break
+	dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx, v.MasterLogger().PackageLogger("dmsg_http:dmsgDC"),
+		v.conf.PK, v.conf.SK, dClient, dmsg.DefaultConfig())
+	if err != nil {
+		return fmt.Errorf("failed to start dmsg: %w", err)
 	}
 
-	if dmsgDC == nil {
-		return fmt.Errorf("dmsgHTTP client cannot reach dmsg-discovery; reconfiguration attempts exhausted")
-	}
+	dmsgHTTP := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgDC)}
 
 	v.pushCloseStack("dmsg_http", func() error {
 		closeDmsgDC()
@@ -270,11 +217,10 @@ func initDmsgHTTP(ctx context.Context, v *Visor, log *logging.Logger) error { //
 
 	v.initLock.Lock()
 	v.dClient = dClient
-	v.dmsgDC = dmsgDC
 	v.dmsgHTTP = &dmsgHTTP
+	v.dmsgDC = dmsgDC
 	v.initLock.Unlock()
-
-	time.Sleep(time.Second * time.Duration(len(servers)))
+	time.Sleep(time.Duration(len(entries)) * time.Second)
 	return nil
 }
 
@@ -291,6 +237,7 @@ func shuffleServers(in []*dmsgdisc.Entry) []*dmsgdisc.Entry {
 	return in
 }
 
+/*
 func rotateServers(servers []*dmsgdisc.Entry) {
 	if len(servers) == 0 {
 		return
@@ -299,6 +246,7 @@ func rotateServers(servers []*dmsgdisc.Entry) {
 	copy(servers, servers[1:])
 	servers[len(servers)-1] = first
 }
+*/
 
 func initEventBroadcaster(ctx context.Context, v *Visor, log *logging.Logger) error { //nolint:all
 	const ebcTimeout = time.Second


### PR DESCRIPTION
After much consideration, the issue is better addressed by:

* ensuring all deployment services are accessible from all dmsg servers (or don't use dmsg direct client for services - which would make the services depend on dmsg-disc)
* revisions to the fall-over or fall-back to other dmsg servers via dmsg direct client

https://github.com/skycoin/skywire/issues/2006