### PR TITLE
Skywire build from repo root

### DIFF
--- a/cmd/conf/commands/root.go
+++ b/cmd/conf/commands/root.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 )
 
 func init() {
@@ -38,7 +38,7 @@ var ServicesConfCmd = &cobra.Command{
 	DisableSuggestions:    true,
 	DisableFlagsInUseLine: true,
 	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("%s\n", string(skywire.ServicesJSON))
+		fmt.Printf("%s\n", string(deployment.ServicesJSON))
 	},
 }
 
@@ -52,7 +52,7 @@ var DmsghttpConfCmd = &cobra.Command{
 	DisableSuggestions:    true,
 	DisableFlagsInUseLine: true,
 	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("%s\n", string(skywire.DmsghttpJSON))
+		fmt.Printf("%s\n", string(deployment.DmsghttpJSON))
 	},
 }
 

--- a/cmd/setup-node/commands/root.go
+++ b/cmd/setup-node/commands/root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsg"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -145,7 +145,7 @@ var checkHealthCmd = &cobra.Command{
 
 		// Start DMSG client
 		ctx := context.Background()
-		dmsgDisc := disc.NewHTTP(skywire.Prod.DmsgDiscovery, &http.Client{}, log)
+		dmsgDisc := disc.NewHTTP(deployment.Prod.DmsgDiscovery, &http.Client{}, log)
 		dmsgC := dmsg.NewClient(pk, sk, dmsgDisc, &dmsg.Config{MinSessions: 1})
 
 		go dmsgC.Serve(ctx)

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -19,7 +19,7 @@ import (
 	coinCipher "github.com/skycoin/skycoin/src/cipher"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/dmsgc"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -399,7 +399,7 @@ var genConfigCmd = &cobra.Command{
 					log.WithError(err).Error("Failed to fetch servers")
 					log.Warn("Falling back on services-config.json")
 				}
-				body := skywire.ServicesJSON
+				body := deployment.ServicesJSON
 				if configServicePath != "" {
 					body, err = os.ReadFile(configServicePath)
 					if err != nil {
@@ -439,7 +439,7 @@ var genConfigCmd = &cobra.Command{
 				}
 			}
 		} else {
-			body := skywire.ServicesJSON
+			body := deployment.ServicesJSON
 			if configServicePath != "" {
 				body, err = os.ReadFile(configServicePath)
 				if err != nil {
@@ -531,7 +531,7 @@ var genConfigCmd = &cobra.Command{
 			//if isUsrEnv {
 			//	dmsgHTTPPath = homepath + "/" + visorconfig.DMSGHTTPName
 			//}
-			dmsghttpConfigData := skywire.DmsghttpJSON
+			dmsghttpConfigData := deployment.DmsghttpJSON
 			if dmsgHTTPPath != "" {
 				// Read the JSON configuration file
 				dmsghttpConfigData, err = os.ReadFile(dmsgHTTPPath) //nolint

--- a/cmd/skywire-cli/commands/config/update.go
+++ b/cmd/skywire-cli/commands/config/update.go
@@ -12,7 +12,7 @@ import (
 	coinCipher "github.com/skycoin/skycoin/src/cipher"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/dmsgc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
@@ -32,7 +32,7 @@ func init() {
 	updateCmd.Flags().SortFlags = false
 	updateCmd.Flags().BoolVarP(&isUpdateEndpoints, "endpoints", "a", false, "update server endpoints")
 	updateCmd.Flags().StringVar(&logLevel, "log-level", "", "level of logging in config")
-	updateCmd.Flags().StringVarP(&serviceConfURL, "url", "b", skywire.ProdConf.Conf, "service config URL")
+	updateCmd.Flags().StringVarP(&serviceConfURL, "url", "b", deployment.ProdConf.Conf, "service config URL")
 	updateCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", false, "use test deployment")
 	updateCmd.Flags().StringVar(&setPublicAutoconnect, "public-autoconn", "", "change public autoconnect configuration")
 	updateCmd.Flags().IntVar(&minHops, "set-minhop", -1, "change min hops value")
@@ -92,9 +92,9 @@ var updateCmd = &cobra.Command{
 	PreRun: func(_ *cobra.Command, _ []string) {
 		if isUpdateEndpoints && (serviceConfURL == "") {
 			if !isTestEnv {
-				serviceConfURL = skywire.ProdConf.Conf
+				serviceConfURL = deployment.ProdConf.Conf
 			} else {
-				serviceConfURL = skywire.TestConf.Conf
+				serviceConfURL = deployment.TestConf.Conf
 			}
 		}
 		setDefaults()
@@ -107,7 +107,7 @@ var updateCmd = &cobra.Command{
 		conf = initUpdate()
 		if isUpdateEndpoints {
 			if isTestEnv {
-				serviceConfURL = skywire.TestConf.Conf
+				serviceConfURL = deployment.TestConf.Conf
 			}
 			mLog := logging.NewMasterLogger()
 			mLog.SetLevel(logrus.InfoLevel)

--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -22,22 +22,12 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsghttp"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 )
 
 func init() {
-	var envServices skywire.EnvServices
-	var services skywire.Services
-	if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
-		if err := json.Unmarshal(envServices.Prod, &services); err == nil {
-			dmsgDiscURL = services.DmsgDiscovery
-			utURL = services.UptimeTracker
-		}
-	}
-
 	logCmd.Flags().SortFlags = false
 	logCmd.Flags().BoolVarP(&logOnly, "log", "l", false, "fetch only transport logs")
 	logCmd.Flags().BoolVarP(&surveyOnly, "survey", "v", false, "fetch only surveys")

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -2,12 +2,13 @@
 package clilog
 
 import (
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 )
 
 var (
-	dmsgDiscURL    string
-	utURL          string
+	dmsgDiscURL = deployment.Prod.DmsgDiscovery
+	utURL = deployment.Prod.UptimeTracker
 	pubKey         string
 	duration       int
 	minv           string

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	dmsgDiscURL = deployment.Prod.DmsgDiscovery
-	utURL = deployment.Prod.UptimeTracker
+	dmsgDiscURL    = deployment.Prod.DmsgDiscovery
+	utURL          = deployment.Prod.UptimeTracker
 	pubKey         string
 	duration       int
 	minv           string

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -4,7 +4,6 @@ package climdisc
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -17,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
@@ -28,21 +27,13 @@ var (
 	cacheFilesAge  int
 	mdURL          string
 	isStats        bool
-	dmsgDiscURL    string
+// allEntries bool
+ masterLogger = logging.NewMasterLogger()
+ packageLogger = masterLogger.PackageLogger("mdisc:disc")
+ dmsgDiscURL = deployment.Prod.DmsgDiscovery
 )
 
-// var allEntries bool
-var masterLogger = logging.NewMasterLogger()
-var packageLogger = masterLogger.PackageLogger("mdisc:disc")
-
 func init() {
-	var envServices skywire.EnvServices
-	var services skywire.Services
-	if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
-		if err := json.Unmarshal(envServices.Prod, &services); err == nil {
-			dmsgDiscURL = services.DmsgDiscovery
-		}
-	}
 	RootCmd.AddCommand(
 		entryCmd,
 		availableServersCmd,

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -16,8 +16,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 )
@@ -27,10 +27,10 @@ var (
 	cacheFilesAge  int
 	mdURL          string
 	isStats        bool
-// allEntries bool
- masterLogger = logging.NewMasterLogger()
- packageLogger = masterLogger.PackageLogger("mdisc:disc")
- dmsgDiscURL = deployment.Prod.DmsgDiscovery
+	// allEntries bool
+	masterLogger  = logging.NewMasterLogger()
+	packageLogger = masterLogger.PackageLogger("mdisc:disc")
+	dmsgDiscURL   = deployment.Prod.DmsgDiscovery
 )
 
 func init() {

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -261,8 +261,8 @@ var statusCmd = &cobra.Command{
 var serverPort = visorconfig.SkysocksPort
 
 func init() {
-	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", skywire.Prod.ServiceDiscovery, "service discovery url")
-	listCmd.Flags().StringVarP(&utURL, "uturl", "w", skywire.Prod.UptimeTracker, "uptime tracker url")
+	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
+	listCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
 	listCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "print raw json data")
 	listCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
 	listCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/proxysd.json", "SD cache file location")
@@ -276,7 +276,7 @@ func init() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, skywire.Prod.ServiceDiscovery, serviceType, skywire.Prod.ServiceDiscovery, serviceType, serverPort),
+	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, deployment.Prod.ServiceDiscovery, serviceType, deployment.Prod.ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -15,9 +15,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/routing"
 	services "github.com/skycoin/skywire/pkg/servicedisc"

--- a/cmd/skywire-cli/commands/reward/rules.go
+++ b/cmd/skywire-cli/commands/reward/rules.go
@@ -14,7 +14,7 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 	"golang.org/x/term"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/rewards"
 )
 
 var asHTML bool
@@ -32,13 +32,13 @@ var rulesCmd = &cobra.Command{
 	Long:  "display the mainnet rules",
 	Run: func(_ *cobra.Command, _ []string) {
 		if rawFile {
-			fmt.Println(skywire.MainnetRules)
+			fmt.Println(rewards.MainnetRules)
 			os.Exit(0)
 		}
 		if asHTML {
 			// Preprocess to replace ~text~ with ~~text~~ for strikethrough
 			re := regexp.MustCompile(`~(.*?)~`)
-			rules := re.ReplaceAllString(skywire.MainnetRules, "~~$1~~")
+			rules := re.ReplaceAllString(rewards.MainnetRules, "~~$1~~")
 			var buf bytes.Buffer
 			md := goldmark.New(
 				goldmark.WithExtensions(extension.Strikethrough),
@@ -56,6 +56,6 @@ var rulesCmd = &cobra.Command{
 			terminalWidth = 80
 		}
 		leftPad := 6
-		fmt.Printf("%s\n", markdown.Render(skywire.MainnetRules, terminalWidth, leftPad))
+		fmt.Printf("%s\n", markdown.Render(rewards.MainnetRules, terminalWidth, leftPad))
 	},
 }

--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -17,11 +17,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire/deployment"
-	"github.com/skycoin/skywire/rewards"
 	tgbot "github.com/skycoin/skywire/cmd/skywire-cli/commands/rewards/tgbot"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
+	"github.com/skycoin/skywire/rewards"
 )
 
 const yearlyTotalRewardsPerPool int = 408000

--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -17,7 +17,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/rewards"
 	tgbot "github.com/skycoin/skywire/cmd/skywire-cli/commands/rewards/tgbot"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
@@ -93,7 +94,7 @@ func init() {
 			}
 		}
 		return res
-	}(skywire.Architectures, []string{"wasm", "amd64", "386"}), "pool 1 allowed arch, comma separated")
+	}(rewards.Architectures, []string{"wasm", "amd64", "386"}), "pool 1 allowed arch, comma separated")
 
 	RootCmd.Flags().StringSliceVarP(&allowArchitectures2, "a2", "x", func(all []string, dis []string) (res []string) {
 		for _, v := range all {
@@ -109,7 +110,7 @@ func init() {
 			}
 		}
 		return res
-	}(skywire.Architectures, []string{"wasm", "arm64", "arm", "ppc64", "riscv64", "loong64", "mips", "mips64", "mips64le", "mipsle", "ppc64le", "s390x"}), "pool 2 allowed arch, comma separated")
+	}(rewards.Architectures, []string{"wasm", "arm64", "arm", "ppc64", "riscv64", "loong64", "mips", "mips64", "mips64le", "mipsle", "ppc64le", "s390x"}), "pool 2 allowed arch, comma separated")
 	RootCmd.Flags().IntVarP(&yearlyTotal, "year", "y", yearlyTotalRewardsPerPool, "yearly total rewards per pool")
 	RootCmd.Flags().StringVarP(&utfile, "utfile", "u", "ut.txt", "uptime tracker data file")
 	RootCmd.Flags().StringVarP(&hwSurveyPath, "lpath", "p", "log_collecting", "path to the surveys")
@@ -128,7 +129,7 @@ Collect surveys:  skywire-cli log
 Fetch uptimes:    skywire-cli ut > ut.txt
 
 Architectures:
-` + fmt.Sprintf("%v", append(skywire.Architectures, "null", "all")) + `
+` + fmt.Sprintf("%v", append(rewards.Architectures, "null", "all")) + `
 
 `,
 	Run: func(_ *cobra.Command, _ []string) {
@@ -142,11 +143,11 @@ Architectures:
 			}
 		}
 
-		sConf, err := script.Echo(string(skywire.ServicesJSON)).JQ(`.prod  | del(.stun_servers)`).Bytes()
+		sConf, err := script.Echo(string(deployment.ServicesJSON)).JQ(`.prod  | del(.stun_servers)`).Bytes()
 		if err != nil {
 			log.Fatal("error parsing json with jq:\n", err)
 		}
-		dConf, err := script.Echo(string(skywire.DmsghttpJSON)).JQ(`.prod`).Bytes()
+		dConf, err := script.Echo(string(deployment.DmsghttpJSON)).JQ(`.prod`).Bytes()
 		if err != nil {
 			log.Fatal("error parsing json with jq:\n", err)
 		}
@@ -178,7 +179,7 @@ Architectures:
 
 		// Create a map for quick lookup of skywire architectures
 		supportedArchitecturesMap := make(map[string]struct{})
-		for _, arch := range skywire.Architectures {
+		for _, arch := range rewards.Architectures {
 			supportedArchitecturesMap[arch] = struct{}{}
 		}
 
@@ -604,11 +605,11 @@ var testCmd = &cobra.Command{
 			log.Fatal("error parsing json with jq:\n", err)
 		}
 
-		sConf, err := script.Echo(string(skywire.ServicesJSON)).JQ(`.prod  | del(.stun_servers)`).Bytes()
+		sConf, err := script.Echo(string(deployment.ServicesJSON)).JQ(`.prod  | del(.stun_servers)`).Bytes()
 		if err != nil {
 			log.Fatal("error parsing json with jq:\n", err)
 		}
-		dConf, err := script.Echo(string(skywire.DmsghttpJSON)).JQ(`.prod`).Bytes()
+		dConf, err := script.Echo(string(deployment.DmsghttpJSON)).JQ(`.prod`).Bytes()
 		if err != nil {
 			log.Fatal("error parsing json with jq:\n", err)
 		}

--- a/cmd/skywire-cli/commands/rewards/server.go
+++ b/cmd/skywire-cli/commands/rewards/server.go
@@ -30,7 +30,7 @@ import (
 	dmsg "github.com/skycoin/dmsg/pkg/dmsg"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
@@ -76,7 +76,7 @@ func init() {
 		log.Fatal("Error getting current directory:", err)
 	}
 	serverCmd.Flags().StringVarP(&wd, "wd", "W", wd, "location of dir containing 'log_collection' & reward 'hist' dirs")
-	serverCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", skywire.Prod.DmsgDiscovery, "dmsg discovery url")
+	serverCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", deployment.Prod.DmsgDiscovery, "dmsg discovery url")
 	serverCmd.Flags().StringVarP(&ensureOnlineURL, "ensure-online", "O", scriptExecString("${ENSUREONLINE}"), "Exit when the specified URL cannot be fetched;\ni.e. https://fiber.skywire.dev")
 	if os.Getenv("DMSGHTTP_SK") != "" {
 		sk.Set(os.Getenv("DMSGHTTP_SK")) //nolint
@@ -1601,12 +1601,12 @@ func init() {
 	nl = append(nl, "  <a href='/log-collection'>log collection</a>")
 	nl = append(nl, "  <a href='/log-collection/tree'>survey index</a>")
 	nl = append(nl, "  <a href='/log-collection/tplogs'>transport logging</a>")
-	nl = append(nl, "  <a href='"+strings.ReplaceAll(skywire.Prod.UptimeTracker, "http://", "https://")+"/uptimes?v=v2'>uptime tracker</a>")
-	nl = append(nl, "  <a href='"+strings.ReplaceAll(skywire.Prod.AddressResolver, "http://", "https://")+"'>address resolver</a>")
-	nl = append(nl, "  <a href='"+strings.ReplaceAll(skywire.Prod.TransportDiscovery, "http://", "https://")+"/all-transports'>transport discovery</a>")
-	nl = append(nl, "  <a href='"+strings.ReplaceAll(skywire.Prod.DmsgDiscovery, "http://", "https://")+"/dmsg-discovery/entries'>dmsgd entries</a>")
-	nl = append(nl, "  <a href='"+strings.ReplaceAll(skywire.Prod.DmsgDiscovery, "http://", "https://")+"/dmsg-discovery/all_servers'>all dmsg servers</a>")
-	nl = append(nl, "  <a href='"+strings.ReplaceAll(skywire.Prod.DmsgDiscovery, "http://", "https://")+"/dmsg-discovery/available_servers'>available dmsg servers</a>")
+	nl = append(nl, "  <a href='"+strings.ReplaceAll(deployment.Prod.UptimeTracker, "http://", "https://")+"/uptimes?v=v2'>uptime tracker</a>")
+	nl = append(nl, "  <a href='"+strings.ReplaceAll(deployment.Prod.AddressResolver, "http://", "https://")+"'>address resolver</a>")
+	nl = append(nl, "  <a href='"+strings.ReplaceAll(deployment.Prod.TransportDiscovery, "http://", "https://")+"/all-transports'>transport discovery</a>")
+	nl = append(nl, "  <a href='"+strings.ReplaceAll(deployment.Prod.DmsgDiscovery, "http://", "https://")+"/dmsg-discovery/entries'>dmsgd entries</a>")
+	nl = append(nl, "  <a href='"+strings.ReplaceAll(deployment.Prod.DmsgDiscovery, "http://", "https://")+"/dmsg-discovery/all_servers'>all dmsg servers</a>")
+	nl = append(nl, "  <a href='"+strings.ReplaceAll(deployment.Prod.DmsgDiscovery, "http://", "https://")+"/dmsg-discovery/available_servers'>available dmsg servers</a>")
 	nl = append(nl, "\n<br>\n")
 	navlinks = strings.Join(nl, "")
 
@@ -1859,12 +1859,12 @@ var htmlMainPageTemplate = `
   <a href='/log-collection'>log collection</a>
   <a href='/log-collection/tree'>survey index</a>
   <a href='/log-collection/tplogs'>transport logging</a>
-  <a href='` + strings.ReplaceAll(skywire.Prod.UptimeTracker, "http://", "https://") + `/uptimes?v=v2'>uptime tracker</a>
-  <a href='` + strings.ReplaceAll(skywire.Prod.AddressResolver, "http://", "https://") + `'>address resolver</a>
-  <a href='` + strings.ReplaceAll(skywire.Prod.TransportDiscovery, "http://", "https://") + `/all-transports'>transport discovery</a>
-  <a href='` + strings.ReplaceAll(skywire.Prod.DmsgDiscovery, "http://", "https://") + `/dmsg-discovery/entries'>dmsgd entries</a>
-  <a href='` + strings.ReplaceAll(skywire.Prod.DmsgDiscovery, "http://", "https://") + `/dmsg-discovery/all_servers'>all dmsg servers</a>
-  <a href='` + strings.ReplaceAll(skywire.Prod.DmsgDiscovery, "http://", "https://") + `/dmsg-discovery/available_servers'>available dmsg servers</a>
+  <a href='` + strings.ReplaceAll(deployment.Prod.UptimeTracker, "http://", "https://") + `/uptimes?v=v2'>uptime tracker</a>
+  <a href='` + strings.ReplaceAll(deployment.Prod.AddressResolver, "http://", "https://") + `'>address resolver</a>
+  <a href='` + strings.ReplaceAll(deployment.Prod.TransportDiscovery, "http://", "https://") + `/all-transports'>transport discovery</a>
+  <a href='` + strings.ReplaceAll(deployment.Prod.DmsgDiscovery, "http://", "https://") + `/dmsg-discovery/entries'>dmsgd entries</a>
+  <a href='` + strings.ReplaceAll(deployment.Prod.DmsgDiscovery, "http://", "https://") + `/dmsg-discovery/all_servers'>all dmsg servers</a>
+  <a href='` + strings.ReplaceAll(deployment.Prod.DmsgDiscovery, "http://", "https://") + `/dmsg-discovery/available_servers'>available dmsg servers</a>
 	<a title='@skywire telegram' href='https://t.me/skywire'>skywire telegram</a>
 	<a title='@skywire_reward telegram' href='https://t.me/skywire_reward'>reward notifications</a>
   </nav>

--- a/cmd/skywire-cli/commands/rewards/ui/ui.go
+++ b/cmd/skywire-cli/commands/rewards/ui/ui.go
@@ -22,7 +22,7 @@ import (
 	"cogentcore.org/core/text/text"
 	"cogentcore.org/core/tree"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/calvin"
 )
 

--- a/cmd/skywire-cli/commands/rewards/ui/ui.go
+++ b/cmd/skywire-cli/commands/rewards/ui/ui.go
@@ -22,7 +22,7 @@ import (
 	"cogentcore.org/core/text/text"
 	"cogentcore.org/core/tree"
 
-	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/calvin"
 )
 

--- a/cmd/skywire-cli/commands/route/route.go
+++ b/cmd/skywire-cli/commands/route/route.go
@@ -3,7 +3,6 @@ package cliroute
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,7 +17,7 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/routefinder/rfclient"
@@ -34,17 +33,10 @@ var (
 	frMinHops, frMaxHops uint16
 	timeout              time.Duration
 	skywireconfig        string
-	rfURL                string
+	rfURL = deployment.Prod.RouteFinder
 )
 
 func init() {
-	var envServices skywire.EnvServices
-	var services skywire.Services
-	if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
-		if err := json.Unmarshal(envServices.Prod, &services); err == nil {
-			rfURL = services.RouteFinder
-		}
-	}
 	findCmd.Flags().SortFlags = false
 	findCmd.Flags().Uint16VarP(&frMinHops, "min", "n", 1, "minimum hops")
 	findCmd.Flags().Uint16VarP(&frMaxHops, "max", "x", 1000, "maximum hops")

--- a/cmd/skywire-cli/commands/route/route.go
+++ b/cmd/skywire-cli/commands/route/route.go
@@ -17,9 +17,9 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
 
-	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/routefinder/rfclient"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -33,7 +33,7 @@ var (
 	frMinHops, frMaxHops uint16
 	timeout              time.Duration
 	skywireconfig        string
-	rfURL = deployment.Prod.RouteFinder
+	rfURL                = deployment.Prod.RouteFinder
 )
 
 func init() {

--- a/cmd/skywire-cli/commands/survey/root.go
+++ b/cmd/skywire-cli/commands/survey/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsg"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
@@ -37,13 +36,6 @@ var (
 )
 
 func init() {
-	var envServices skywire.EnvServices
-	var services skywire.Services
-	if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
-		if err := json.Unmarshal(envServices.Prod, &services); err == nil {
-			dmsgDiscURL = services.DmsgDiscovery
-		}
-	}
 	surveyCmd.Flags().SortFlags = false
 	surveyCmd.Flags().StringVarP(&confPath, "config", "c", "", "optionl config file to use (i.e.: "+visorconfig.ConfigName+")")
 	surveyCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDiscURL, "value of dmsg discovery")

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
@@ -140,8 +140,8 @@ func init() {
 	addTpCmd.Flags().StringVarP(&rpk, "rpk", "r", "", "remote public key.")
 	addTpCmd.Flags().StringVarP(&transportType, "type", "t", "", "type of transport to add.")
 	addTpCmd.Flags().DurationVarP(&timeout, "timeout", "o", 0, "if specified, sets an operation timeout")
-	addTpCmd.Flags().StringVarP(&arURL, "ar", "a", skywire.Prod.AddressResolver, "address resolver URL")
-	addTpCmd.Flags().StringVarP(&dmsgdURL, "dmsg", "d", skywire.Prod.DmsgDiscovery, "dmsg discovery URL")
+	addTpCmd.Flags().StringVarP(&arURL, "ar", "a", deployment.Prod.AddressResolver, "address resolver URL")
+	addTpCmd.Flags().StringVarP(&dmsgdURL, "dmsg", "d", deployment.Prod.DmsgDiscovery, "dmsg discovery URL")
 	//TODO
 	//	listCmd.Flags().BoolVarP(&queryHealth, "health", "q", false, "check /health of remote visor over dmsg before creating transport")
 	addTpCmd.Flags().BoolVarP(&forceAttempt, "force", "f", false, "attempt transport creation without check of SD") // or visor /health over dmsg
@@ -466,8 +466,8 @@ func init() {
 
 	treeCmd.Flags().StringVarP(&rootNode, "source", "k", "", "root node ; defaults to visor with most transports")
 	treeCmd.Flags().StringVarP(&lastNode, "dest", "d", "", "map route between source and dest")
-	treeCmd.Flags().StringVarP(&tpdURL, "tpdurl", "a", skywire.Prod.TransportDiscovery, "transport discovery url")
-	treeCmd.Flags().StringVarP(&utURL, "uturl", "w", skywire.Prod.UptimeTracker, "uptime tracker url")
+	treeCmd.Flags().StringVarP(&tpdURL, "tpdurl", "a", deployment.Prod.TransportDiscovery, "transport discovery url")
+	treeCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
 	treeCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "print raw json data")
 	treeCmd.Flags().BoolVarP(&refinedData, "pretty", "p", false, "print pretty json data")
 	treeCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
@@ -483,7 +483,7 @@ func init() {
 var treeCmd = &cobra.Command{
 	Use:   "tree",
 	Short: "tree map of transports on the skywire network",
-	Long:  fmt.Sprintf("display a tree representation of transports from TPD\n\n%v/all-transports\n\nSet cache file location to \"\" to avoid using cache files", skywire.Prod.TransportDiscovery),
+	Long:  fmt.Sprintf("display a tree representation of transports from TPD\n\n%v/all-transports\n\nSet cache file location to \"\" to avoid using cache files", deployment.Prod.TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
 		if rootNode != "" {
 			err := rootnode.Set(rootNode)

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -20,9 +20,9 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/transport"

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bitfield/script"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 )
 
@@ -20,7 +20,7 @@ var (
 	online        bool
 	isStats       bool
 	isMoreStats   bool
-	utURL         = skywire.Prod.UptimeTracker
+	utURL         = deployment.Prod.UptimeTracker
 	cacheFileUT   string
 	cacheFilesAge int
 )

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -8,8 +8,8 @@ import (
 	"github.com/bitfield/script"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
 )
 
 // RootCmd is utCmd

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -15,9 +15,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -171,8 +171,8 @@ var statusCmd = &cobra.Command{
 var serverPort = visorconfig.VPNServerPort
 
 func init() {
-	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", skywire.Prod.ServiceDiscovery, "service discovery url")
-	listCmd.Flags().StringVarP(&utURL, "uturl", "w", skywire.Prod.UptimeTracker, "uptime tracker url")
+	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
+	listCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
 	listCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "pretty print json data")
 	listCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
 	listCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/vpnsd.json", "SD cache file location")
@@ -186,7 +186,7 @@ func init() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, skywire.Prod.ServiceDiscovery, serviceType, skywire.Prod.ServiceDiscovery, serviceType, serverPort),
+	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, deployment.Prod.ServiceDiscovery, serviceType, deployment.Prod.ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -53,7 +53,7 @@ var (
 	dmsgPort        uint16
 	dmsgServerType  string
 	pgMaxOpenConn   int
-	dmsgDisc = deployment.Prod.DmsgDiscovery
+	dmsgDisc        = deployment.Prod.DmsgDiscovery
 )
 
 func init() {

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -3,7 +3,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -17,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"gorm.io/gorm"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/internal/pg"
 	"github.com/skycoin/skywire/internal/tpdiscmetrics"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
@@ -48,23 +47,16 @@ var (
 	logLvl          string
 	tag             string
 	testing         bool
-	dmsgDisc        string
 	whitelistKeys   string
 	testEnvironment bool
 	sk              cipher.SecKey
 	dmsgPort        uint16
 	dmsgServerType  string
 	pgMaxOpenConn   int
+	dmsgDisc = deployment.Prod.DmsgDiscovery
 )
 
 func init() {
-	var envServices skywire.EnvServices
-	var services skywire.Services
-	if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
-		if err := json.Unmarshal(envServices.Prod, &services); err == nil {
-			dmsgDisc = services.DmsgDiscovery
-		}
-	}
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9091", "address to bind to\033[0m")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to\033[0m")
 	RootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\033[0m")

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -1,0 +1,97 @@
+// Package deployment github.com/skycoin/skywire/deployment/config.go
+package deployment
+
+import (
+	_ "embed"
+	"encoding/json"
+	"log"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+)
+
+/*
+Embedded Deployment Defaults
+
+Change the contents of services-config.json and / or dmsghttp-config.json to embed updated values
+*/
+
+// ServicesJSON is the embedded services-config.json file
+//
+//go:embed services-config.json
+var ServicesJSON []byte
+
+// DmsghttpJSON is the embedded dmsghttp-config.json file
+//
+//go:embed dmsghttp-config.json
+var DmsghttpJSON []byte
+
+// EnvServices is the wrapper struct for the outer JSON - i.e. 'prod' or 'test' deployment config
+type EnvServices struct {
+	Test json.RawMessage `json:"test"`
+	Prod json.RawMessage `json:"prod"`
+}
+
+// Services are URLs, IP addresses, and public keys of the skywire services as deployed
+type Services struct {
+	DmsgDiscovery      string          `json:"dmsg_discovery,omitempty"`
+	TransportDiscovery string          `json:"transport_discovery,omitempty"`
+	AddressResolver    string          `json:"address_resolver,omitempty"`
+	RouteFinder        string          `json:"route_finder,omitempty"`
+	RouteSetupNodes    []cipher.PubKey `json:"route_setup_nodes,omitempty"`
+	TransportSetupPKs  []cipher.PubKey `json:"transport_setup,omitempty"`
+	UptimeTracker      string          `json:"uptime_tracker,omitempty"`
+	ServiceDiscovery   string          `json:"service_discovery,omitempty"`
+	StunServers        []string        `json:"stun_servers,omitempty"`
+	DNSServer          string          `json:"dns_server,omitempty"`
+	SurveyWhitelist    []cipher.PubKey `json:"survey_whitelist,omitempty"`
+}
+
+// Conf is the configuration URL for the deployment which may be fetched on `skywire cli config gen`
+type Conf struct {
+	Conf string `json:"conf,omitempty"`
+}
+
+// Prod is the production deployment services
+var Prod Services
+
+// ProdConf is the service configuration address / URL for the skywire production deployment
+var ProdConf Conf
+
+// Test is the test deployment services
+var Test Services
+
+// TestConf is the service configuration address / URL for the skywire test deployment
+var TestConf Conf
+
+func init() {
+	var js interface{}
+	err := json.Unmarshal(ServicesJSON, &js)
+	if err != nil {
+		log.Panic("services-config.json ", err)
+	}
+	err = json.Unmarshal(DmsghttpJSON, &js)
+	if err != nil {
+		log.Panic("dmsghttp-config.json ", err)
+	}
+	var envServices EnvServices
+	err = json.Unmarshal(ServicesJSON, &envServices)
+	if err != nil {
+		log.Panic(err)
+	}
+	err = json.Unmarshal(envServices.Prod, &Prod)
+	if err != nil {
+		log.Panic(err)
+	}
+	err = json.Unmarshal(envServices.Prod, &ProdConf)
+	if err != nil {
+		log.Panic(err)
+	}
+	err = json.Unmarshal(envServices.Test, &Test)
+	if err != nil {
+		log.Panic(err)
+	}
+	err = json.Unmarshal(envServices.Test, &TestConf)
+	if err != nil {
+		log.Panic(err)
+	}
+}

--- a/deployment/dmsghttp-config.json
+++ b/deployment/dmsghttp-config.json
@@ -1,0 +1,64 @@
+{
+  "test": {
+    "dmsg_servers": [
+      {
+        "static": "024716428e6315d954356e9ad72bea32bb2b41aab5a54a9b5cb4313964016e64d8",
+        "server": {
+          "address": "139.144.183.24:30080"
+        }
+      }
+    ],
+    "dmsg_discovery": "dmsg://024a7b9b7db1626d46777e5c665333afa57f48934b57652305fc7a2b19dc4c65d4:80",
+    "transport_discovery": "dmsg://02703cf828ea11d25b2c8eb0796132ecc7e53b22325b20ce3674ce5cd8693e4fb6:80",
+    "address_resolver": "dmsg://030eb7d8cf6eac40c19bbc433de6d6b9bb7a47f2e1d7095c6a01aa676471670ad2:80",
+    "route_finder": "dmsg://02ece5b69eaee13ef967b7eb67ca93f1dfddad3a51c9cb1808c4bd0d8d8aa32053:80",
+    "uptime_tracker": "dmsg://022c788cca11f208cdfd83ed0c2a8c7b661221736c461adc7c6738a2c1b041c7f8:80",
+    "service_discovery": "dmsg://038f751df4af75fb3d51f6693602bfe8289145e633ffdd1e67d686bea595f84d55:80"
+  },
+  "prod": {
+    "dmsg_servers": [
+      {
+        "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
+        "server": {
+          "address": "139.162.160.227:30087"
+        }
+      },
+      {
+        "static": "030c83534af1041aee60c2f124b682a9d60c6421876db7c67fc83a73c5effdbd96",
+        "server": {
+          "address": "188.121.99.59:8081"
+        }
+      },
+      {
+        "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
+        "server": {
+          "address": "70.121.13.123:9083"
+        }
+      },
+      {
+        "static": "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb",
+        "server": {
+          "address": "139.162.160.227:30086"
+        }
+      },
+      {
+        "static": "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4",
+        "server": {
+          "address": "139.162.173.101:30083"
+        }
+      },
+      {
+        "static": "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd",
+        "server": {
+          "address": "139.162.173.101:30082"
+        }
+      }
+    ],
+    "dmsg_discovery": "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",
+    "transport_discovery": "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80",
+    "address_resolver": "dmsg://03234b2ee4128d1f78c180d06911102906c80795dfe41bd6253f2619c8b6252a02:80",
+    "route_finder": "dmsg://039d89c5eedfda4a28b0c58b0b643eff949f08e4f68c8357278081d26f5a592d74:80",
+    "uptime_tracker": "dmsg://022c424caa6239ba7d1d9d8f7dab56cd5ec6ae2ea9ad97bb94ad4b48f62a540d3f:80",
+    "service_discovery": "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80"
+  }
+}

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -1,0 +1,80 @@
+{
+  "test": {
+    "conf": "http://conf.skywire.dev",
+    "dmsg_discovery": "http://dmsgd.skywire.dev",
+    "transport_discovery": "http://tpd.skywire.dev",
+    "address_resolver": "http://ar.skywire.dev",
+    "route_finder": "http://rf.skywire.dev",
+    "route_setup_nodes": [
+      "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
+    ],
+    "transport_setup": [
+      "03530b786c670fc7f5ab9021478c7ec9cd06a03f3ea1416c50c4a8889ef5bba80e",
+      "03271c0de223b80400d9bd4b7722b536a245eb6c9c3176781ee41e7bac8f9bad21",
+      "03a792e6d960c88c6fb2184ee4f16714c58b55f0746840617a19f7dd6e021699d9",
+      "0313efedc579f57f05d4f5bc3fbf0261f31e51cdcfde7e568169acf92c78868926",
+      "025c7bbf23e3441a36d7e8a1e9d717921e2a49a2ce035680fec4808a048d244c8a",
+      "030eb6967f6e23e81db0d214f925fc5ce3371e1b059fb8379ae3eb1edfc95e0b46",
+      "02e582c0a5e5563aad47f561b272e4c3a9f7ac716258b58e58eb50afd83c286a7f",
+      "02ddc6c749d6ed067bb68df19c9bcb1a58b7587464043b1707398ffa26a9746b26",
+      "03aa0b1c4e23616872058c11c6efba777c130a85eaf909945d697399a1eb08426d",
+      "03adb2c924987d8deef04d02bd95236c5ae172fe5dfe7273e0461d96bf4bc220be"
+    ],
+    "uptime_tracker": "http://ut.skywire.dev",
+    "service_discovery": "http://sd.skywire.dev",
+    "stun_servers": [
+      "139.162.160.227:3479",
+      "172.104.145.184:3479"
+    ],
+    "dns_server": "1.1.1.1",
+    "survey_whitelist": [
+      "02b5ee5333aa6b7f5fc623b7d5f35f505cb7f974e98a70751cf41962f84c8c4637",
+      "03714c8bdaee0fb48f47babbc47c33e1880752b6620317c9d56b30f3b0ff58a9c3",
+      "020d35bbaf0a5abc8ec0ba33cde219fde734c63e7202098e1f9a6cf9daaeee55a9",
+      "027f7dec979482f418f01dfabddbd750ad036c579a16422125dd9a313eaa59c8e1",
+      "031d4cf1b7ab4c789b56c769f2888e4a61c778dfa5fe7e5cd0217fc41660b2eb65",
+      "0327e2cf1d2e516ecbfdbd616a87489cc92a73af97335d5c8c29eafb5d8882264a",
+      "03abbb3eff140cf3dce468b3fa5a28c80fa02c6703d7b952be6faaf2050990ebf4"
+    ]
+  },
+  "prod": {
+    "conf": "http://conf.skywire.skycoin.com",
+    "dmsg_discovery": "http://dmsgd.skywire.skycoin.com",
+    "transport_discovery": "http://tpd.skywire.skycoin.com",
+    "address_resolver": "http://ar.skywire.skycoin.com",
+    "route_finder": "http://rf.skywire.skycoin.com",
+    "route_setup_nodes": [
+      "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
+      "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438",
+      "03b87c282f6e9f70d97aeea90b07cf09864a235ef718725632d067873431dd1015"
+    ],
+    "transport_setup": [
+      "03530b786c670fc7f5ab9021478c7ec9cd06a03f3ea1416c50c4a8889ef5bba80e",
+      "03271c0de223b80400d9bd4b7722b536a245eb6c9c3176781ee41e7bac8f9bad21",
+      "03a792e6d960c88c6fb2184ee4f16714c58b55f0746840617a19f7dd6e021699d9",
+      "0313efedc579f57f05d4f5bc3fbf0261f31e51cdcfde7e568169acf92c78868926",
+      "025c7bbf23e3441a36d7e8a1e9d717921e2a49a2ce035680fec4808a048d244c8a",
+      "030eb6967f6e23e81db0d214f925fc5ce3371e1b059fb8379ae3eb1edfc95e0b46",
+      "02e582c0a5e5563aad47f561b272e4c3a9f7ac716258b58e58eb50afd83c286a7f",
+      "02ddc6c749d6ed067bb68df19c9bcb1a58b7587464043b1707398ffa26a9746b26",
+      "03aa0b1c4e23616872058c11c6efba777c130a85eaf909945d697399a1eb08426d",
+      "03adb2c924987d8deef04d02bd95236c5ae172fe5dfe7273e0461d96bf4bc220be"
+    ],
+    "uptime_tracker": "http://ut.skywire.skycoin.com",
+    "service_discovery": "http://sd.skycoin.com",
+    "stun_servers": [
+      "139.162.160.227:3479",
+      "172.104.145.184:3479"
+    ],
+    "dns_server": "1.1.1.1",
+    "survey_whitelist": [
+      "02b5ee5333aa6b7f5fc623b7d5f35f505cb7f974e98a70751cf41962f84c8c4637",
+      "03714c8bdaee0fb48f47babbc47c33e1880752b6620317c9d56b30f3b0ff58a9c3",
+      "020d35bbaf0a5abc8ec0ba33cde219fde734c63e7202098e1f9a6cf9daaeee55a9",
+      "027f7dec979482f418f01dfabddbd750ad036c579a16422125dd9a313eaa59c8e1",
+      "031d4cf1b7ab4c789b56c769f2888e4a61c778dfa5fe7e5cd0217fc41660b2eb65",
+      "0327e2cf1d2e516ecbfdbd616a87489cc92a73af97335d5c8c29eafb5d8882264a",
+      "03abbb3eff140cf3dce468b3fa5a28c80fa02c6703d7b952be6faaf2050990ebf4"
+    ]
+  }
+}

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -2,12 +2,11 @@
 package appdisc
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -32,15 +31,7 @@ func (f *Factory) setDefaults() {
 		f.Log = logging.MustGetLogger("appdisc")
 	}
 	if f.ServiceDisc == "" {
-		var envServices skywire.EnvServices
-		var services skywire.Services
-		var sdURL string
-		if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
-			if err := json.Unmarshal(envServices.Prod, &services); err == nil {
-				sdURL = services.ServiceDiscovery
-			}
-		}
-		f.ServiceDisc = sdURL
+		f.ServiceDisc = deployment.Prod.ServiceDiscovery
 	}
 }
 

--- a/pkg/config-bootstrapper/api/api.go
+++ b/pkg/config-bootstrapper/api/api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sirupsen/logrus"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/httputil"
@@ -63,10 +63,7 @@ type Config struct {
 
 // New creates a new api.
 func New(log *logging.Logger, conf Config, domain, dmsgAddr string) *API {
-	var envServices skywire.EnvServices
-	var svcs skywire.Services
-	json.Unmarshal([]byte(skywire.ServicesJSON), &envServices) //nolint
-	json.Unmarshal(envServices.Prod, &svcs)                    //nolint
+	svcs := deployment.Prod
 
 	sd := strings.Replace(svcs.ServiceDiscovery, "skycoin.com", domain, -1)
 	if domain == "skywire.skycoin.com" {

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -32,7 +32,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsghttp"
 	"github.com/skycoin/dmsg/pkg/dmsgpty"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/internal/vpn"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/app/appevent"
@@ -1582,7 +1582,7 @@ func initPublicAutoconnect(ctx context.Context, v *Visor, log *logging.Logger) e
 	}
 	serviceDisc := v.conf.Launcher.ServiceDisc
 	if serviceDisc == "" { //it might be intentionally blank ; consider revising.
-		serviceDisc = skywire.Prod.ServiceDiscovery
+		serviceDisc = deployment.Prod.ServiceDiscovery
 	}
 
 	// todo: refactor updatedisc: split connecting to services in updatedisc and

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/skycoin/dmsg/pkg/dmsgpty"
 	coinCipher "github.com/skycoin/skycoin/src/cipher"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/dmsgc"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -28,8 +28,8 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 
 	//check if any services were passed
 	if services == nil {
-		var envServices skywire.EnvServices
-		if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err != nil {
+		var envServices deployment.EnvServices
+		if err := json.Unmarshal(deployment.ServicesJSON, &envServices); err != nil {
 			return nil
 		}
 		if !testEnv {
@@ -140,9 +140,9 @@ func MakeDefaultConfig(log *logging.MasterLogger, sk *cipher.SecKey, usrEnv bool
 	}
 	dnsServer := ""
 	var dmsgHTTPServersList *DmsgHTTPServers
-	var envServices skywire.EnvServices
-	var svcs skywire.Services
-	if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err != nil {
+	var envServices deployment.EnvServices
+	var svcs deployment.Services
+	if err := json.Unmarshal(deployment.ServicesJSON, &envServices); err != nil {
 		return nil, nil
 	}
 	if !testEnv {

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/skycoin/skywire"
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/util/pathutil"
 )
@@ -114,7 +114,7 @@ func (c *HypervisorConfig) FillDefaults(testEnv bool) {
 	if c.DmsgDiscovery == "" {
 		var envServices EnvServices
 		var services Services
-		if err := json.Unmarshal(skywire.ServicesJSON, &envServices); err == nil {
+		if err := json.Unmarshal(deployment.ServicesJSON, &envServices); err == nil {
 			if testEnv {
 				if err := json.Unmarshal(envServices.Test, &services); err != nil {
 					return

--- a/rewards/arches.json
+++ b/rewards/arches.json
@@ -1,0 +1,1 @@
+["amd64","arm64","386","arm","ppc64","riscv64","wasm","loong64","mips","mips64","mips64le","mipsle","ppc64le","s390x"]

--- a/rewards/mainnet_rules.md
+++ b/rewards/mainnet_rules.md
@@ -1,0 +1,450 @@
+![skywire logo](https://user-images.githubusercontent.com/26845312/32426764-3495e3d8-c282-11e7-8fe8-8e60e90cb906.png)
+
+# Skywire Reward Eligibility Rules
+
+**We have transitioned to a new system with daily reward distribution**
+
+
+* The rules in this article may change at any time, depending on if there are problems
+* We will attempt to address any issues reported via [@skywire](https://t.me/skywire) Telegram channel
+* Reward corrections are not possible after the rewards for a day have been distributed.
+
+The required minimum Skywire version will be incremented periodically.
+
+## Introduction
+
+<div align="center"><em> Updates to this article will be followed by a notification via the <a href="https://t.me/SkywirePSA">official Skywire PSA channel</a> on Telegram.</em>
+</div>
+<br>
+
+All information about rewards will be published here. Please ask for clarification in the [@skywire](https://t.me/skywire) Telegram channel if some things appear to not be covered.
+
+Please join [@SkywirePSA](https://t.me/SkywirePSA) for public service announcements (PSA) regarding the skywire network, update notices, changes to this article, etc.
+
+Reward distribution notifications are on telegram [@skywire_reward](https://t.me/skywire_reward).
+
+Information about reward distribution as well as other metrics for the skywire network can be found at [fiber.skywire.dev](https://fiber.skywire.dev)
+
+# Uptime Reward Pools
+
+816000 Skycoin are distributed annually to those visors which meet the mimimum uptime and the other requirements listed below, in two equally sized reward pools.
+
+The reward amount for a day is evenly divided among those eligible participants for a given reward pool on the basis of having met uptime and other requirements, for the previous day.
+
+A total of up to ~1117.808 Skycoin __per pool__ are distributed daily in non leap-years.
+
+A total of up to ~1114.754  Skycoin __per pool__ are distributed daily in leap-years.
+
+The two reward pools are differentiated by architecture ; one pool for ARM / RISC / MIPS architectures, the other pool for AMD64 / x86_64 / i686 architecture machines. The requirements are otherwise identical for reward eligibility in these pools.
+
+## Rules & Requirements
+
+To receive Skycoin rewards for running skywire, the following requirements must be met:
+
+
+* [1)](#Version) **Minimum skywire [version](#Version) v1.3.28** - Cutoff February 1st 2024
+
+* [2)](#Uptime) **75% [uptime](#Uptime) per day** minimum is required to be eligible to receive rewards
+
+* [3)](#Architercture) ~The visor must be an **ARM or RISC architecture SBC** running on approved [hardware](#hardware)~
+
+* [4)](#Deployment) Visors must be running on **[the skywire production deployment](#Deployment)** with a config that is updated on every version. No default keys or addresses of this configuration may be removed - but you can add keys where applicable.
+
+* [5)](#Per-Machine-Limit) **Only 1 (one) visor per machine** - virtual machines are ineligible
+
+* [6)](#Per-IP-Limit) **Up to 8 (eight) visors may each receive 1 (one) reward share per location (ip address)** - with 8 shares divided between all visors at that ip address which achieved the minimum uptime.
+
+* [7)](#Skycoin-Address) **A valid [skycoin address](#Skycoin-Address)** must be set for the visor
+
+* [8)](#Connection-To-DMSG-Network) The visor must be **[connected to the DMSG network](#Connection-To-DMSG-Network)**
+
+* [9)](#Transportability) **[Transports](#Transportability) can be established to the visor**
+
+* [10)](#Transport-Setup-Node) **The visor responds to [Transport Setup-Node requests](#Transport-Setup-Node)**
+
+* [11)](#Ping-Latency-Metric) **The visor responds to [pings](#Ping-Latency-Metric)** - needed for latency-based rewards
+
+* [12)](#Transport-Bandwidth-Logs) **The visor produces [transport bandwidth logs](#Transport-Bandwidth-Logs)** - needed for bandwidth-based rewards
+
+* [13)](#Survey) **The visor produces a [survey](#Survey)** when queried over dmsg by any keys in the survey_whitelist array by default
+
+
+### Exceptions for Deployment Changes with dmsghttp-config (Chinese users)
+
+All the production deployment services may be accessed by the visor over the dmsg network when the visor runs with a dmsghttp config.
+
+This type of config is generated automatically based on region via:
+```
+skywire cli config gen -b --bestproto
+```
+to circumvent ISP blocking of http requests.
+
+In order to bootstrap the visor's to connection to the dmsg network (via TCP connection to an individual dmsg server) the [dmsghttp-config.json](/dmsghttp-config.json) is provided with the skywire binary release.
+
+In the instance that the skywire production deployment changes - specifically the dmsg servers:
+* it will be necessary to update to the next version or package release which fixes the dmsg servers.
+OR
+* it will be necessary to manually update the [dmsghttp-config.json](/dmsghttp-config.json) which is provided by your skywire installation.
+
+Currently, **there is no mechanism for updating the dmsghttp-config.json which does not require an http request** ; a request which may be blocked depending on region.
+
+In this instance, the visor will not connect to any service because it is not connected to the dmsg network, so it will not be possible for the visor to accumulate uptime or for the reward system to collect the survey, which are prerequisites for reward eligibility.
+
+As a consequence of this; any visors running a dmsghttp-config, and hence any visors running in regions such as China, the minimum version requirement for obtaining rewards is not only the latest available version,
+but __the latest release of the package__ unless the dmsghttp-config.json is updated manually within your installation.
+
+## Verifying Requirements & Eligibility
+
+### 1) Version
+
+View the version of skywire you are running with:
+```
+skywire cli -v
+skywire visor -v
+```
+
+NOTE: the uptime tracker and other services consider the visor's config version - not the actual binary version. It is expected that the visor's config is re-generated on every update in order to include any config changes which may have been introduced
+
+The update deadlines specify the version of software required as of (i.e. on or before) the specified date in order to maintain reward eligibility:
+
+**Reward eligibility after 10-01-2024 requires Skywire v1.3.26**
+
+Requirement established 09-24-2024
+
+Rewards Cutoff date for updating 10-01-2024
+
+**Reward eligibility after 02-01-2025 requires Skywire v1.3.28**
+
+Requirement established 01-09-2025
+
+Rewards Cutoff date for updating 02-01-2025
+
+
+### Uptime
+
+
+Daily uptime statistics for all visors may be accessed via the
+
+- [uptime tracker](https://ut.skywire.skycoin.com/uptimes?v=v2)
+
+or using skywire cli
+
+```
+skywire cli ut -n0 -k <public-key>
+```
+
+For example with a locally running visor:
+```
+skywire cli ut -n0 -k $(skywire cli visor pk)
+```
+
+The uptime for all visors are tracked via the visor connecting to the [uptime tracker](https://ut.skywire.skycoin.com/uptimes?v=v2) at regular intervals (currently, every 5 minutes).
+
+It's possible to check uptime for a given visor's public key in the following ways:
+
+* Directly in the browser
+
+![image](https://github.com/user-attachments/assets/01a13a32-0382-4119-b104-96ff16dfd5d2)
+
+* Using an http client such as `curl` with an appropriate json parser such as `jq` - for exaple:
+
+```
+$ curl -sL https://ut.skywire.skycoin.com/uptimes?v=v2 | jq '[.[] | select(.pk == "02006214d489aee383dc14dea22d1c308a547520f545b914c1e476a7a87064e77b" or .pk == "02001319d25a66609b64cc389bd0dcee6d5b4ab93bd139186c47d1d6cbe955e7e1")]'
+[
+  {
+    "pk": "02001319d25a66609b64cc389bd0dcee6d5b4ab93bd139186c47d1d6cbe955e7e1",
+    "on": false,
+    "version": "v1.3.28",
+    "daily": {
+      "2025-01-03": "86.11",
+      "2025-01-05": "88.89",
+      "2025-01-06": "100.00",
+      "2025-01-07": "100.00",
+      "2025-01-08": "87.15"
+    }
+  },
+  {
+    "pk": "02006214d489aee383dc14dea22d1c308a547520f545b914c1e476a7a87064e77b",
+    "on": true,
+    "version": "v1.3.28",
+    "daily": {
+      "2025-01-03": "100.00",
+      "2025-01-04": "100.00",
+      "2025-01-05": "100.00",
+      "2025-01-06": "100.00",
+      "2025-01-07": "95.14",
+      "2025-01-08": "99.65",
+      "2025-01-09": "71.18"
+    }
+  }
+]
+
+```
+
+* Using `skywire cli ut` is the recommended approach, as it avoids rate-limiting of requests by caching the data which is fetched from the uptime tracker
+
+```
+$ skywire cli ut --help
+query uptime tracker
+
+Check local visor daily uptime percent with:
+ skywire-cli ut -k $(skywire cli visor pk)
+Set cache file location to "" to avoid using cache files
+
+
+
+Flags:
+  -m, --cfa int      update cache files if older than n minutes (default 5)
+      --cfu string   UT cache file location. (default "/tmp/ut.json")
+  -n, --min int      list visors meeting minimum uptime (default 75)
+  -o, --on           list currently online visors
+  -k, --pk string    check uptime for the specified key
+  -s, --stats        count the number of results
+  -t, --stats2       count of versions
+  -u, --url string   specify alternative uptime tracker url (default "http://ut.skywire.skycoin.com")
+
+```
+
+### Architecture
+
+We are pleased to state as of November 1, 2024 Rewards are open to all architectures, with a reward pool added for non-ARM architectures (amd64 & i386)
+
+### Deployment
+
+The deployment your visor is running on can be verified by comparing the services configured in the visor's .json config against [conf.skywire.skycoin.com](https://conf.skywire.skycoin.com)
+
+```
+cat /opt/skywire/skywire.json
+```
+
+The service configuration will be automatically updated any time a config is generated or regenerated.
+
+For those visors in china or those running a dmsghttp-config, compare the dmsghttp-config of your current installation with the dmsghttp-config on the develop branch of [github.com/skycoin/skywire](https://github.com/skycoin/skywire)
+
+The same data in a different format should be displayed in the [dmsg-discovery all_servers](https://dmsgd.skywire.skycoin.com/dmsg-discovery/all_servers) page. Ensure that the dmsghttp-config.json in your installation has the same ip addresses and ports for the dmsg server keys.
+
+The data from the dmsg discovery should be considered authoritative or current.
+
+### Per Machine Limit
+
+Virtual machines are not eligible for rewards, as there is no way to limit the number of instances of skywire running on the same machine if they are running in virtual machines.
+
+The visor is determined to be running on a virtual machine if a `hypervisor` is listed in it's survey such as `kvm`, `xenhvm`, or `hyperv` - (not to be confused with a skywire hypervisor)
+
+Multiple instances of skywire which are otherwise determined to be running on the same machine (via their mac address) will have one reward share divided between all the skycoin reward addresses which are set for those visors.
+
+### Per IP Limit
+
+A maximum of 8 reward shares per ip address is divided between all visors which made uptime at a given ip address.
+
+For example, if 9 visors at a given ip address meet the minimum uptime requirement, the reward share for each visor will be 8/9ths of a share (~0.8888) which sum to a total of ~7.99999 shares.
+
+### Skycoin Address
+
+The skycoin address to be rewarded can be set from the cli:
+
+```
+skywire cli reward <skycoin-address>
+```
+
+![image](https://user-images.githubusercontent.com/36607567/213941582-f57213b8-2acd-4c9a-a2c0-9089a8c2604e.png)
+
+
+```
+$ skywire cli reward --help
+
+	reward address setting
+
+	Sets the skycoin reward address for the visor.
+	The config is written to the root of the default local directory
+
+	this config is served via dmsghttp along with transport logs
+	and the system hardware survey for automating reward distribution
+
+Flags:
+      --all   show all flags
+
+```
+
+```
+$ skywire cli reward 2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6
+Reward address:
+  2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6
+```
+
+```
+$ skywire cli reward --help
+
+    skycoin reward address set to:
+    2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6
+
+Flags:
+      --all   show all flags
+```
+
+or via the hypervisor UI.
+
+![image](https://user-images.githubusercontent.com/36607567/213941478-34c81493-9c3c-40c2-ac22-e33e3683a16f.png)
+
+the example above shows the genesis address for the skycoin blockchain. **Please do not use the genesis address.**
+
+It is __highly recommended__ to set the reward address in the file '/etc/skywire.conf' by adding this line to the file:
+
+```
+echo "REWARDSKYADDR=('2jBbGxZRGoQG1mqhPBnXnLTxK6oxsTf8os6')" | sudo tee -a /etc/skywire.conf
+```
+
+**PLEASE DO NOT USE THE GENESIS ADDRESS!**
+
+
+Add your skycoin address there and run:
+```
+skywire-autoconfig
+```
+
+on linux (assumes you have installed the package)
+
+If this file does not exist for you, it can be created with
+```
+skywire cli config gen -q | sudo tee /etc/skywire.conf
+```
+
+**If you do this, YOU MUST UNCOMMENT THE FOLLOWING LINES OF THE FILE:**
+```
+PKGENV=true
+BESTPROTO=TRUE
+```
+
+you can open the file in an editor to make that change, for instance nano
+
+```
+sudo nano /etc/skywire.conf
+```
+
+### Connection To DMSG Network
+
+For any given visor, the system hardware survey, transport setup-node survey, and transport bandwidth logs are collected **hourly** by the reward system over dmsg.
+
+This can be verified by examining the visor's logging:
+
+![image](https://github.com/skycoin/skywire/assets/36607567/eb66bca1-fc9e-4c80-a38a-e00a73f675d0)
+
+```
+[DMSGHTTP] 2024/10/09 - 22:31:45 | 200 |        47.2µs |                 | 03714c8bdaee0fb48f47babbc47c33e1880752b6620317c9d56b30f3b0ff58a9c3:51405 | GET      /health
+[DMSGHTTP] 2024/10/09 - 22:31:46 | 200 |     193.325µs |                 | 03714c8bdaee0fb48f47babbc47c33e1880752b6620317c9d56b30f3b0ff58a9c3:51457 | GET      /node-info
+[DMSGHTTP] 2024/10/09 - 22:31:47 | 200 |       98.93µs |                 | 03714c8bdaee0fb48f47babbc47c33e1880752b6620317c9d56b30f3b0ff58a9c3:51503 | GET      /2024-10-10.csv
+```
+
+The collected surveys and transport bandwidth log files should be visible in the survey index here:
+
+[fiber.skywire.dev/log-collection/tree](https://fiber.skywire.dev/log-collection/tree)
+
+An example of one such entry:
+```
+├─┬025e3e4e324a3ac2771e32b798ca3d8859e585ac36938b15a31d20982de6aa31fc
+│ ├──2024-05-02.csv
+│ ├──2024-05-03.csv
+│ ├──2024-05-04.csv
+│ ├──2024-05-05.csv
+│ ├──2024-05-06.csv
+│ ├──2024-05-07.csv
+│ ├──health.json     Age: 13m5s {"build_info":{"version":"v1.3.21","commit":"5131943","date":"2024-04-13T15:03:26Z"},"started_at":"2024-05-07T08:52:09.895919222Z"}
+│ ├──node-info.json          "v1.3.21"
+│ └──tp.json         Age: 6m56s []
+```
+
+Note: the transport bandwidth logging CSV files will only exist if it was generated; i.e. if there were transports to that visor which handled traffic.
+
+Note: the system survey (node-info.json) will only exist if the reward address is set.
+
+If your visor is not generating such logging or errors are indicated, please reach out to us on telegram [@skywire](https://t.me/skywire) for assistance
+
+### Transportability
+
+It is not required that a visor run any service, such as a vpn or socks5 proxy server, which permits direct access to the internet from your ip address.
+However, it is required that the visor is able to act as a hop along a route.
+A module is active at runtime which checks that transports may be established to that visor - the visor creates a dmsg transport to itself every few minutes to ensure transportability.
+If it's not possible to create a dmsg transport to the same visor after three attempts,the visor will shut down automatically.
+**It is expected that the visor will be restarted by a process control mechanism if the visor shuts down for any reason.** In the officially supported linux packages, systemd will restart the visor if it stops; regardless of the exit status of the process.
+
+### Transport Setup Node
+
+Previously, the transport setup node was run continuously as part of the reward system to ensure that visors were responding as expected to transport setup-node requests.
+However, there were intermittent issues with reliability of the results ; because there is no caching mechanism for responsiveness to transport setup-node requests as there exists for uptime.
+
+Currently, the transport setup-nodes which are configured for the visor are included in the survey and verified as an eligibility requirement for rewards by the reward system.
+
+### Ping Latency metric
+
+Not yet implemented
+
+### Transport Bandwidth Logs
+
+The visor will only produce transport bandwidth logs in response to transports being established to them. These are collected, along with the system survey, and are displayed on the reward system [here](https://fiber.skywire.dev/log-collection/tplogs)
+
+In the future, it is anticipated that the transport bandwidth logs and ping metric will be collected by the transport discovery automatically.
+
+### Survey
+
+On setting the skycoin reward address, the visor will generate and serve a system survey over dmsg.
+
+Only keys which are whitelisted in the survey_whitelist array of the visor's config will have access to collect the survey.
+
+To print the survey (approximately) as it would be served, one can use:
+```
+skywire cli survey -p
+```
+
+**The purpose of the survey is strictly for checking [eligibility requirements](#rules--requirements) numbers 3 through 7.**
+
+**Setting a skycoin address is considered as consent for collecting the survey ; the survey is not generated unless you set a skycoin address**
+
+We respect your privacy.
+
+### Verifying Other Requirements
+
+If the visor is not able to meet the [eligibility requirements](#rules--requirements) numbers 8 through 13, that is usually not the fault of the user - nor is it something the user is expected to troubleshoot on their own at this time. Please ask for assistance on telegram [@skywire](https://t.me/skywire)
+
+## Reward System Overview
+
+The skycoin reward address may be set for each visor using `skywire cli` or for all visors connected to a hypervisor from the hypervisor UI
+
+The skycoin reward address is in a text file contained in the "local" folder (local_path in the skywire config file) i.e `local/reward.txt`.
+
+The skycoin reward address is also included with the [system hardware survey](https://github.com/skycoin/skywire/tree/develop/cmd/skywire/README.md#survey) and served, along with transport logs, via dmsghttp.
+
+The system survey ('local/node-info.json') is fetched hourly by the reward system via
+```
+skywire cli log
+```
+along with transport bandwidth logs.
+
+The index of the collected files may be viewed at [fiber.skywire.dev/log-collection/tree](https://fiber.skywire.dev/log-collection/tree)
+
+Once collected from the nodes, the surveys for those visors which met uptime are checked to verify hardware and other requirements, etc.
+
+The system survey is only made available to those keys which are whitelisted for survey collection, but is additionally available to any `hypervisor` or `dmsgpty_whitelist` keys set in the config for a given visor.
+
+**Setting a skycoin address is considered as consent for collecting the survey.**
+
+The public keys which require to be whitelisted in order to collect the surveys, for the purpose of reward eligibility verification, should populate in the visor's config automatically when the config is generated.
+
+## Reward System Funding & Distributions
+
+The reward system is funded on a monthly basis. **Sometimes there are unexpected or unavoidable delays in the funding.** In these instances, rewards will be distributed based on the data generated when the system is funded.
+In some instances, it's necessary to discard previous reward data and do multiple distributions to handle backlog of reward system funds.
+
+**We do our best to ensure fair reward distribution** - but the system itself is not infinitely flexible.
+If there is no good way to rectify historical or undistributed rewards backlog, it will be distributed going forward as multiple distributions on the same day to those current active participants in the network.
+
+## Deployment Outages
+
+While we do our best to maintain the skywire production deployment, there have been instances of issues or outages in the past. We attempt to correct these outages as soon as possible and avoid recurrent disruptions.
+
+The policy for handling rewards in the instance of a deployment outage is to repeat the distribution for the last day where uptime was unaffected by the outage; for the duration of the outage.
+
+## Hardware
+
+As of November 2024, skywire rewards are open to all computer hardware and architectures.
+
+If there is not a release for your desired architecture, we can attempt to add it, on request.

--- a/rewards/rewards.go
+++ b/rewards/rewards.go
@@ -25,7 +25,6 @@ var Architectures []string
 //go:embed mainnet_rules.md
 var MainnetRules string
 
-
 func init() {
 	err := json.Unmarshal(ArchesJSON, &Architectures)
 	if err != nil {

--- a/rewards/rewards.go
+++ b/rewards/rewards.go
@@ -1,4 +1,4 @@
-// Package skywire github.com/skycoin/skywire/rewards/rewards.go
+// Package rewards github.com/skycoin/skywire/rewards/rewards.go
 //
 //go:generate go run ../cmd/gen/gen.go -jo arches.json
 package rewards

--- a/rewards/rewards.go
+++ b/rewards/rewards.go
@@ -1,0 +1,34 @@
+// Package skywire github.com/skycoin/skywire/rewards/rewards.go
+//
+//go:generate go run ../cmd/gen/gen.go -jo arches.json
+package rewards
+
+import (
+	_ "embed"
+	"encoding/json"
+	"log"
+)
+
+// ArchesJSON is the embedded arches.json file
+// go run ../cmd/gen/gen.go -jo arches.json
+// ["amd64","arm64","386","arm","ppc64","riscv64","wasm","loong64","mips","mips64","mips64le","mipsle","ppc64le","s390x"]
+//
+//go:embed arches.json
+var ArchesJSON []byte
+
+// Architectures is an array of GOARCH architectures
+var Architectures []string
+
+// MainnetRules is the mainnet_rules.md
+// print the mainnet rules with `skywire cli reward rules`
+//
+//go:embed mainnet_rules.md
+var MainnetRules string
+
+
+func init() {
+	err := json.Unmarshal(ArchesJSON, &Architectures)
+	if err != nil {
+		log.Panic("arches.json ", err)
+	}
+}


### PR DESCRIPTION
Considering the fact that a single binary includes all the services, utilities, etc, as subcommands, it would be optimal to include cmd/skywire/skywire.go at the root of this repo.

My thinking is that it makes it easier to build / install.

Instead of
```
go run github.com/skycoin/skywire/cmd/skywire@develop
#OR
go install github.com/skycoin/skywire/cmd/skywire@develop
```
that would shorten to
```
go run github.com/skycoin/skywire@develop
#OR
go install github.com/skycoin/skywire@develop
```
and instead of
```
go build cmd/skywire/skywire.go
```
that would just become
```
go build
#OR
go build .
```

* split deployment config from rewards-related embedded files
* copy embedded deployment config to deployment/config.go from skywire.go
* copy embedded mainnet rules article and arches.json to rewards/rewards.go
* change import path "github.com/skycoin/skywire" to "github.com/skycoin/skywire/deployment" or "github.com/skycoin/skywire/rewards" where appropriate

This PR needs to be merged and another PR created in dmsg, along these same lines. When that one is merged I can change out skywire.go at the repo root for cmd/skywire/skywire.go