### PR TITLE
re-implement country and version filtering for proxy & vpn list

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -286,7 +286,7 @@ var listCmd = &cobra.Command{
 		// --- Fetch SD ---
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {
-			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout()
+			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint
 			return
 		}
 
@@ -306,7 +306,7 @@ var listCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout()
+			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout() //nolint
 			return
 		}
 
@@ -326,10 +326,10 @@ var listCmd = &cobra.Command{
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 				}
-				script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
+				script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
 				return
 			}
-			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout()
+			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout() //nolint
 			return
 		}
 
@@ -359,10 +359,10 @@ var listCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
+			script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
 			return
 		}
 
-		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout()
+		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout() //nolint
 	},
 }

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -258,7 +258,10 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-var serverPort = visorconfig.SkysocksPort
+var (
+	serverPort       = visorconfig.SkysocksPort
+	serverPortString = fmt.Sprintf("%v", serverPort)
+)
 
 func init() {
 	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
@@ -269,6 +272,8 @@ func init() {
 	listCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location.")
 	listCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
+	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
+	listCmd.Flags().StringVarP(&version, "version", "v", "", "filter by version")
 	listCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 	listCmd.Flags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
 }
@@ -278,11 +283,14 @@ var listCmd = &cobra.Command{
 	Short: "List servers",
 	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, deployment.Prod.ServiceDiscovery, serviceType, deployment.Prod.ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// --- Fetch SD ---
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {
-			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint
+			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout()
 			return
 		}
+
+		// --- If JSON output requested ---
 		if jsonOutput {
 			var list []services.Service
 			json.Unmarshal([]byte(sds), &list) //nolint
@@ -290,47 +298,71 @@ var listCmd = &cobra.Command{
 			internal.PrintOutput(cmd.Flags(), list, b.String())
 			return
 		}
+
+		// --- Lookup by PK ---
 		if pk != "" {
-			jsonOut, err := script.Echo(sds).JQ(`map(select(.address == "` + pk + `:` + fmt.Sprintf("%v", serverPort) + `"))`).Bytes()
+			jsonOut, err := script.Echo(sds).
+				JQ(`map(select(.address == "` + pk + `:` + serverPortString + `"))`).Bytes()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout() //nolint
+			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout()
 			return
 		}
-		sdJQ := `.[] .address`
-		//DEBUG: script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Replace(":", " ").Column(1).Stdout()
-		var sdkeys string
-		sdkeys, err := script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Replace(":", " ").Column(1).String()
-		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
-		}
+
+		// --- No filtering case ---
 		if noFilterOnline {
+			sdJQ := `.[]`
+			if country != "" {
+				sdJQ += ` | select(.geo.country == "` + country + `")`
+			}
+			if version != "" {
+				sdJQ += ` | select(.version == "` + version + `")`
+			}
+			sdJQ += ` | "\(.address | split(":")[0]) \(.geo.country) \(.version)"`
+
 			if isStats {
-				count, err := script.Echo(sdkeys).CountLines()
+				count, err := script.Echo(sds).JQ(sdJQ).Replace(`"`, "").CountLines()
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 				}
-				script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
+				script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
 				return
 			}
-			script.Echo(sdkeys).Stdout() //nolint
+			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout()
 			return
 		}
 
+		// --- Filtering by online status via jq join ---
 		uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
-		utkeys, _ := script.Echo(uts).JQ(".[] | select(.on) | .pk").Replace("\"", "").String() //nolint
+		joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
+
+		// Build jq filter with optional country and version conditions
+		countryCond := ""
+		if country != "" {
+			countryCond = ` | select(.geo.country == "` + country + `")`
+		}
+		versionCond := ""
+		if version != "" {
+			versionCond = ` | select(.version == "` + version + `")`
+		}
+
+		jqFilter := `
+		[ .ut[] | select(.on) | .pk ] as $online
+		| .sd[]
+		| select((.address | split(":")[0]) as $pk | $pk | IN($online[]))` + countryCond + versionCond + `
+		| "\((.address | split(":")[0])) \(.geo.country) \(.version)"
+		`
 
 		if isStats {
-			count, err := script.Echo(sdkeys + utkeys).Freq().Match("2 ").Column(2).CountLines()
+			count, err := script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").CountLines()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
+			script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
 			return
 		}
 
-		script.Echo(sdkeys + utkeys).Freq().Match("2 ").Column(2).Stdout() //nolint
-
+		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout()
 	},
 }

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -24,6 +24,8 @@ var (
 	allClients      bool
 	noFilterOnline  bool
 	clientName      string
+	country         string
+	version         string
 	addr            string
 	startingTimeout int
 	httpAddr        string

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -3,6 +3,7 @@ package clitp
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -23,6 +24,7 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -39,6 +41,7 @@ var (
 	removeAll     bool
 	tpTypes       bool
 	utURL         string
+	sdURL         string
 )
 
 func init() {
@@ -57,6 +60,11 @@ func init() {
 	tpCmd.Flags().StringSliceVarP(&filterPubKeys, "pks", "p", filterPubKeys, "show transport(s) for public key(s) comma-separated")
 	tpCmd.Flags().BoolVarP(&showLogs, "logs", "l", true, "show transport logs")
 	tpCmd.Flags().BoolVarP(&showMore, "more", "m", false, "show more info")
+	tpCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location.")
+	tpCmd.Flags().StringVar(&cacheFileSDProxy, "cfsp", os.TempDir()+"/proxysd.json", "SD cache file location")
+	tpCmd.Flags().StringVar(&cacheFileSDVPN, "cfsv", os.TempDir()+"/vpnsd.json", "SD cache file location")
+	tpCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
+	tpCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
 	tpCmd.Flags().StringVarP(&tpID, "id", "i", "", "display transport matching ID")
 	tpCmd.Flags().BoolVarP(&tpTypes, "tptypes", "u", false, "display transport types used by the local visor")
 	tpCmd.Flags().StringVar(&clirpc.Addr, "rpc", "localhost:3435", "RPC server address")
@@ -106,25 +114,93 @@ var tpCmd = &cobra.Command{
 		}
 		transports, err := rpcClient.Transports(filterTypes, pks, showLogs)
 		internal.Catch(cmd.Flags(), err)
+
+		if showMore {
+			utData = internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+			proxyData = internal.GetData(cacheFileSDProxy, sdURL+"/api/services?type="+servicedisc.ServiceTypeProxy, cacheFilesAge)
+			vpnData = internal.GetData(cacheFileSDVPN, sdURL+"/api/services?type="+servicedisc.ServiceTypeVPN, cacheFilesAge)
+		}
+
 		PrintTransports(cmd.Flags(), transports...)
 	},
 }
+
+var utData string
+var vpnData string
+var proxyData string
 
 // PrintTransports prints transports used by the visor
 func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 	sortTransports(tps...)
 
+	var versionsByPK map[string]string
+	if showMore && len(utData) > 0 {
+		type uptimeEntry struct {
+			PK      string `json:"pk"`
+			Version string `json:"version"`
+		}
+		var utEntries []uptimeEntry
+		err := json.Unmarshal([]byte(utData), &utEntries)
+		internal.Catch(cmdFlags, err)
+
+		versionsByPK = make(map[string]string, len(utEntries))
+		for _, e := range utEntries {
+			versionsByPK[e.PK] = e.Version
+		}
+	}
+
+	type geoInfo struct {
+		Country string `json:"country"`
+	}
+
+	type serviceEntry struct {
+		Address string  `json:"address"`
+		Geo     geoInfo `json:"geo"`
+	}
+
+	proxyByPK := make(map[string]string)
+	vpnByPK := make(map[string]string)
+
+	if showMore && len(proxyData) > 0 {
+		var proxyEntries []serviceEntry
+		err := json.Unmarshal([]byte(proxyData), &proxyEntries)
+		internal.Catch(cmdFlags, err)
+		for _, e := range proxyEntries {
+			pk := strings.SplitN(e.Address, ":", 2)[0]
+			proxyByPK[pk] = e.Geo.Country
+		}
+	}
+
+	if showMore && len(vpnData) > 0 {
+		var vpnEntries []serviceEntry
+		err := json.Unmarshal([]byte(vpnData), &vpnEntries)
+		internal.Catch(cmdFlags, err)
+		for _, e := range vpnEntries {
+			pk := strings.SplitN(e.Address, ":", 2)[0]
+			vpnByPK[pk] = e.Geo.Country
+		}
+	}
+
 	var b bytes.Buffer
 	w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
-	_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel")
-	internal.Catch(cmdFlags, err)
+
+	if showMore {
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tversion\tcountry\tservices")
+		internal.Catch(cmdFlags, err)
+	} else {
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel")
+		internal.Catch(cmdFlags, err)
+	}
 
 	type outputTP struct {
-		Type   types.Type      `json:"type"`
-		ID     uuid.UUID       `json:"id"`
-		Remote cipher.PubKey   `json:"remote_pk"`
-		TpMode string          `json:"mode"`
-		Label  transport.Label `json:"label"`
+		Type     types.Type      `json:"type"`
+		ID       uuid.UUID       `json:"id"`
+		Remote   cipher.PubKey   `json:"remote_pk"`
+		TpMode   string          `json:"mode"`
+		Label    transport.Label `json:"label"`
+		Version  string          `json:"version,omitempty"`
+		Country  string          `json:"country,omitempty"`
+		Services string          `json:"services,omitempty"`
 	}
 
 	var outputTPS []outputTP
@@ -137,19 +213,55 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 			tpMode = "setup"
 		}
 		tp.Log = nil
+
+		version := ""
+		if showMore && versionsByPK != nil {
+			version = versionsByPK[tp.Remote.String()]
+		}
+
+		var country, services string
+		pk := tp.Remote.String()
+		proxyCountry, inProxy := proxyByPK[pk]
+		vpnCountry, inVPN := vpnByPK[pk]
+
+		if inProxy && inVPN {
+			services = "proxy,vpn"
+			if proxyCountry == vpnCountry {
+				country = proxyCountry
+			} else {
+				country = proxyCountry + "/" + vpnCountry
+			}
+		} else if inProxy {
+			services = "proxy"
+			country = proxyCountry
+		} else if inVPN {
+			services = "vpn"
+			country = vpnCountry
+		}
+
 		oTP := outputTP{
-			Type:   tp.Type,
-			ID:     tp.ID,
-			Remote: tp.Remote,
-			TpMode: tpMode,
-			Label:  tp.Label,
+			Type:     tp.Type,
+			ID:       tp.ID,
+			Remote:   tp.Remote,
+			TpMode:   tpMode,
+			Label:    tp.Label,
+			Version:  version,
+			Country:  country,
+			Services: services,
 		}
 		outputTPS = append(outputTPS, oTP)
 
-		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
-		internal.Catch(cmdFlags, err)
-
+		if showMore {
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, version, country, services)
+			internal.Catch(cmdFlags, err)
+		} else {
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
+			internal.Catch(cmdFlags, err)
+		}
 	}
+
 	internal.Catch(cmdFlags, w.Flush())
 	internal.PrintOutput(cmdFlags, outputTPS, b.String())
 }
@@ -161,29 +273,31 @@ func sortTransports(tps ...*visor.TransportSummary) {
 }
 
 var (
-	sortedEdgeKeys []string
-	tpdURL         string
-	rootNode       string
-	lastNode       string
-	rootnode       cipher.PubKey
-	lastnode       cipher.PubKey
-	cacheFileTPD   string
-	cacheFileDmsgD string
-	cacheFileUT    string
-	padSpaces      int
-	isStats        bool
-	rawData        bool
-	refinedData    bool
-	noFilterOnline bool
-	onlyOnline     bool
-	transportType  string
-	timeout        time.Duration
-	rpk            string
-	cacheFileAR    string
-	cacheFilesAge  int
-	forceAttempt   bool
-	arURL          string
-	dmsgdURL       string
+	sortedEdgeKeys   []string
+	tpdURL           string
+	rootNode         string
+	lastNode         string
+	rootnode         cipher.PubKey
+	lastnode         cipher.PubKey
+	cacheFileTPD     string
+	cacheFileDmsgD   string
+	cacheFileUT      string
+	cacheFileSDProxy string
+	cacheFileSDVPN   string
+	padSpaces        int
+	isStats          bool
+	rawData          bool
+	refinedData      bool
+	noFilterOnline   bool
+	onlyOnline       bool
+	transportType    string
+	timeout          time.Duration
+	rpk              string
+	cacheFileAR      string
+	cacheFilesAge    int
+	forceAttempt     bool
+	arURL            string
+	dmsgdURL         string
 
 // queryHealth	bool
 )

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -34,6 +34,7 @@ var (
 	filterTypes   []string
 	filterPubKeys []string
 	showLogs      bool
+	showMore      bool
 	logger        = logging.MustGetLogger("skywire-cli")
 	removeAll     bool
 	tpTypes       bool
@@ -55,6 +56,7 @@ func init() {
 	tpCmd.Flags().StringSliceVarP(&filterTypes, "types", "t", filterTypes, "show transport(s) type(s) comma-separated")
 	tpCmd.Flags().StringSliceVarP(&filterPubKeys, "pks", "p", filterPubKeys, "show transport(s) for public key(s) comma-separated")
 	tpCmd.Flags().BoolVarP(&showLogs, "logs", "l", true, "show transport logs")
+	tpCmd.Flags().BoolVarP(&showMore, "more", "m", false, "show more info")
 	tpCmd.Flags().StringVarP(&tpID, "id", "i", "", "display transport matching ID")
 	tpCmd.Flags().BoolVarP(&tpTypes, "tptypes", "u", false, "display transport types used by the local visor")
 	tpCmd.Flags().StringVar(&clirpc.Addr, "rpc", "localhost:3435", "RPC server address")
@@ -106,6 +108,56 @@ var tpCmd = &cobra.Command{
 		internal.Catch(cmd.Flags(), err)
 		PrintTransports(cmd.Flags(), transports...)
 	},
+}
+
+// PrintTransports prints transports used by the visor
+func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
+	sortTransports(tps...)
+
+	var b bytes.Buffer
+	w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
+	_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel")
+	internal.Catch(cmdFlags, err)
+
+	type outputTP struct {
+		Type   types.Type      `json:"type"`
+		ID     uuid.UUID       `json:"id"`
+		Remote cipher.PubKey   `json:"remote_pk"`
+		TpMode string          `json:"mode"`
+		Label  transport.Label `json:"label"`
+	}
+
+	var outputTPS []outputTP
+	for _, tp := range tps {
+		if tp == nil {
+			continue
+		}
+		tpMode := "regular"
+		if tp.IsSetup {
+			tpMode = "setup"
+		}
+		tp.Log = nil
+		oTP := outputTP{
+			Type:   tp.Type,
+			ID:     tp.ID,
+			Remote: tp.Remote,
+			TpMode: tpMode,
+			Label:  tp.Label,
+		}
+		outputTPS = append(outputTPS, oTP)
+
+		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
+		internal.Catch(cmdFlags, err)
+
+	}
+	internal.Catch(cmdFlags, w.Flush())
+	internal.PrintOutput(cmdFlags, outputTPS, b.String())
+}
+
+func sortTransports(tps ...*visor.TransportSummary) {
+	sort.Slice(tps, func(i, j int) bool {
+		return tps[i].ID.String() < tps[j].ID.String()
+	})
 }
 
 var (
@@ -309,56 +361,6 @@ var rmTpCmd = &cobra.Command{
 			internal.PrintOutput(cmd.Flags(), "", cmd.Help())
 		}
 	},
-}
-
-// PrintTransports prints transports used by the visor
-func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
-	sortTransports(tps...)
-
-	var b bytes.Buffer
-	w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
-	_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel")
-	internal.Catch(cmdFlags, err)
-
-	type outputTP struct {
-		Type   types.Type      `json:"type"`
-		ID     uuid.UUID       `json:"id"`
-		Remote cipher.PubKey   `json:"remote_pk"`
-		TpMode string          `json:"mode"`
-		Label  transport.Label `json:"label"`
-	}
-
-	var outputTPS []outputTP
-	for _, tp := range tps {
-		if tp == nil {
-			continue
-		}
-		tpMode := "regular"
-		if tp.IsSetup {
-			tpMode = "setup"
-		}
-		tp.Log = nil
-		oTP := outputTP{
-			Type:   tp.Type,
-			ID:     tp.ID,
-			Remote: tp.Remote,
-			TpMode: tpMode,
-			Label:  tp.Label,
-		}
-		outputTPS = append(outputTPS, oTP)
-
-		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
-		internal.Catch(cmdFlags, err)
-
-	}
-	internal.Catch(cmdFlags, w.Flush())
-	internal.PrintOutput(cmdFlags, outputTPS, b.String())
-}
-
-func sortTransports(tps ...*visor.TransportSummary) {
-	sort.Slice(tps, func(i, j int) bool {
-		return tps[i].ID.String() < tps[j].ID.String()
-	})
 }
 
 var (

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -25,6 +25,8 @@ var (
 	pk              string
 	startingTimeout int
 	jsonOutput      bool
+	country         string
+	version         string
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -196,7 +196,7 @@ var listCmd = &cobra.Command{
 		// --- Fetch SD ---
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {
-			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout()
+			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint
 			return
 		}
 
@@ -216,7 +216,7 @@ var listCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout()
+			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout() //nolint
 			return
 		}
 
@@ -236,10 +236,10 @@ var listCmd = &cobra.Command{
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 				}
-				script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
+				script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
 				return
 			}
-			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout()
+			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout() //nolint
 			return
 		}
 
@@ -269,10 +269,10 @@ var listCmd = &cobra.Command{
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
+			script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
 			return
 		}
 
-		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout()
+		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout() //nolint
 	},
 }

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -168,7 +168,10 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-var serverPort = visorconfig.VPNServerPort
+var (
+	serverPort       = visorconfig.VPNServerPort
+	serverPortString = fmt.Sprintf("%v", serverPort)
+)
 
 func init() {
 	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
@@ -179,6 +182,8 @@ func init() {
 	listCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location.")
 	listCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
+	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
+	listCmd.Flags().StringVarP(&version, "version", "v", "", "filter by version")
 	listCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 	listCmd.Flags().BoolVar(&jsonOutput, internal.JSONString, false, "print output in json")
 }
@@ -188,11 +193,14 @@ var listCmd = &cobra.Command{
 	Short: "List servers",
 	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, deployment.Prod.ServiceDiscovery, serviceType, deployment.Prod.ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// --- Fetch SD ---
 		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
 		if rawData {
-			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint
+			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout()
 			return
 		}
+
+		// --- If JSON output requested ---
 		if jsonOutput {
 			var list []services.Service
 			json.Unmarshal([]byte(sds), &list) //nolint
@@ -200,47 +208,71 @@ var listCmd = &cobra.Command{
 			internal.PrintOutput(cmd.Flags(), list, b.String())
 			return
 		}
+
+		// --- Lookup by PK ---
 		if pk != "" {
-			jsonOut, err := script.Echo(sds).JQ(`map(select(.address == "` + pk + `:` + fmt.Sprintf("%v", serverPort) + `"))`).Bytes()
+			jsonOut, err := script.Echo(sds).
+				JQ(`map(select(.address == "` + pk + `:` + serverPortString + `"))`).Bytes()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout() //nolint
+			script.Echo(string(pretty.Color(pretty.Pretty(jsonOut), nil))).Stdout()
 			return
 		}
-		sdJQ := `.[] .address`
-		//DEBUG: script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Replace(":", " ").Column(1).Stdout()
-		var sdkeys string
-		sdkeys, err := script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Replace(":", " ").Column(1).String()
-		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
-		}
+
+		// --- No filtering case ---
 		if noFilterOnline {
+			sdJQ := `.[]`
+			if country != "" {
+				sdJQ += ` | select(.geo.country == "` + country + `")`
+			}
+			if version != "" {
+				sdJQ += ` | select(.version == "` + version + `")`
+			}
+			sdJQ += ` | "\(.address | split(":")[0]) \(.geo.country) \(.version)"`
+
 			if isStats {
-				count, err := script.Echo(sdkeys).CountLines()
+				count, err := script.Echo(sds).JQ(sdJQ).Replace(`"`, "").CountLines()
 				if err != nil {
 					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 				}
-				script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
+				script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
 				return
 			}
-			script.Echo(sdkeys).Stdout() //nolint
+			script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Stdout()
 			return
 		}
 
+		// --- Filtering by online status via jq join ---
 		uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
-		utkeys, _ := script.Echo(uts).JQ(".[] | select(.on) | .pk").Replace("\"", "").String() //nolint
+		joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
+
+		// Build jq filter with optional country and version conditions
+		countryCond := ""
+		if country != "" {
+			countryCond = ` | select(.geo.country == "` + country + `")`
+		}
+		versionCond := ""
+		if version != "" {
+			versionCond = ` | select(.version == "` + version + `")`
+		}
+
+		jqFilter := `
+		[ .ut[] | select(.on) | .pk ] as $online
+		| .sd[]
+		| select((.address | split(":")[0]) as $pk | $pk | IN($online[]))` + countryCond + versionCond + `
+		| "\((.address | split(":")[0])) \(.geo.country) \(.version)"
+		`
 
 		if isStats {
-			count, err := script.Echo(sdkeys + utkeys).Freq().Match("2 ").Column(2).CountLines()
+			count, err := script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").CountLines()
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error: %w", err))
 			}
-			script.Echo(fmt.Sprintf("%v\n", count)).Stdout() //nolint
+			script.Echo(fmt.Sprintf("%v\n", count)).Stdout()
 			return
 		}
 
-		script.Echo(sdkeys + utkeys).Freq().Match("2 ").Column(2).Stdout() //nolint
-
+		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout()
 	},
 }


### PR DESCRIPTION

```
$ go run . cli proxy list --help
List proxy servers from service discovery
http://sd.skycoin.com/api/services?type=proxy
http://sd.skycoin.com/api/services?type=proxy&country=US

Set cache file location to "" to avoid using cache files
default virtual port of servers: 3

Flags:
  -m, --cfa int          update cache files if older than n minutes (default 5)
      --cfs string       SD cache file location (default "/tmp/proxysd.json")
      --cfu string       UT cache file location. (default "/tmp/ut.json")
  -c, --country string   filter by country code
      --json             print output in json
  -o, --noton            do not filter by online status in UT
  -k, --pk string        check proxy service discovery for public key
  -r, --raw              print raw json data
  -a, --sdurl string     service discovery url (default "http://sd.skycoin.com")
  -s, --stats            return only a count of the results
  -w, --uturl string     uptime tracker url (default "http://ut.skywire.skycoin.com")
  -v, --version string   filter by version

Global Flags:
      --rpc string   RPC server address (default "localhost:3435")
```
```
$ go run . cli vpn list --help
List vpn servers from service discovery
http://sd.skycoin.com/api/services?type=vpn
http://sd.skycoin.com/api/services?type=vpn&country=US

Set cache file location to "" to avoid using cache files
default virtual port of servers: 44

Flags:
  -m, --cfa int          update cache files if older than n minutes (default 5)
      --cfs string       SD cache file location (default "/tmp/vpnsd.json")
      --cfu string       UT cache file location. (default "/tmp/ut.json")
  -c, --country string   filter by country code
      --json             print output in json
  -o, --noton            do not filter by online status in UT
  -k, --pk string        check vpn service discovery for public key
  -r, --raw              pretty print json data
  -a, --sdurl string     service discovery url (default "http://sd.skycoin.com")
  -s, --stats            return only a count of the results
  -w, --uturl string     uptime tracker url (default "http://ut.skywire.skycoin.com")
  -v, --version string   filter by version

Global Flags:
      --rpc string   RPC server address (default "localhost:3435")
```
```
go run . cli vpn list
02c3648ddbe44ffbcb7b40c7d5e53c446eb169bd4c56d0d525d56f02162d2cc882 ID v1.3.21
03892486d66c8463cf37498f0f9cfa48c0734eb49df197ced6b41670b772131e74 SG v1.3.30
02a74c74ca599732f1ab73d930efaa51d1d03cbacb12a2c3394f356a863dec0f86 MY v1.3.28
02dc1678999a287fa76782b88e06bd71e6f5422e79522fa847a441c3a5a3055f65 US v1.3.30
037f79097d005bf8e538b2d230d581f8ce26e7b9996fbbf1d90556bc8d2020b7c0 ID v1.3.30
030f9a9d0078118e574de3b305b7da0f666a4b78d9e62e30d58c95bf41b30bc5cc JP v1.3.28
025206355cc4d05fe34e4f2fda598cb517c3d21c16327eb5bb3e5ec534853d74c5 ID v1.3.30
02043e7e93b400e871ea3d7a053a887bff9111a3afd05079ca39ce8f703d20496e SG v1.3.30
0238a63328103c2c4e77c6b952bebe50e53afb0924e5c94b44aad9978f64e909d8 ID v1.3.21

```

```
go run . cli proxy list
02d6d70125d10c2cb5f67d159a000189b3d9446488d9be68792fc00fa2bf90258b US v0.6.0
02dc1678999a287fa76782b88e06bd71e6f5422e79522fa847a441c3a5a3055f65 US v1.3.30
025206355cc4d05fe34e4f2fda598cb517c3d21c16327eb5bb3e5ec534853d74c5 ID v1.3.30
037f79097d005bf8e538b2d230d581f8ce26e7b9996fbbf1d90556bc8d2020b7c0 ID v1.3.30
02a74c74ca599732f1ab73d930efaa51d1d03cbacb12a2c3394f356a863dec0f86 MY v1.3.28
02eda6534ec4df10edc83ce46dd810f105f9578acc9d3eed7f09be307cfe68f395 ID v1.3.28
02e7c436bd969588bb8fd9164fea1a86b62c4430d3efd003201334ada3c47c9d19 ID v1.3.28
028e05eb7dbfe3fe8ec70eb0193c8a0054738f8d1022b5d95e8d06dec3fd3bbb83 ID v1.3.30
0362aae9abdff59026a881fe1991e8262a2047c26842334b23744a942b2f298e0c CA v1.3.30
030f9a9d0078118e574de3b305b7da0f666a4b78d9e62e30d58c95bf41b30bc5cc JP v1.3.28
03dd849be2d3fb7ef77e2583f558c1d073360d1766adb349918b96a5d8ecad657d CA v1.3.30
02c3648ddbe44ffbcb7b40c7d5e53c446eb169bd4c56d0d525d56f02162d2cc882 ID v1.3.21
03b28cd0f35d7ecec0d3125f414a56d1865344561e00db48040c59da8eabe794a2 ID v1.3.30

```