### PR TITLE
remove useless code

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -263,14 +263,15 @@ func (r *router) DialRoutes(
 
 	if r.conf.MinHops == 1 {
 		r.routeSetupHookMu.Lock()
-		defer r.routeSetupHookMu.Unlock()
 		if len(r.routeSetupHooks) != 0 {
 			for _, rsf := range r.routeSetupHooks {
 				if err := rsf(rPK, r.tm); err != nil {
+					r.routeSetupHookMu.Unlock()
 					return nil, err
 				}
 			}
 		}
+		r.routeSetupHookMu.Unlock()
 	}
 
 	forwardPath, reversePath, err := r.fetchBestRoutes(lPK, rPK, opts)

--- a/pkg/transport/handshake.go
+++ b/pkg/transport/handshake.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/httputil"
@@ -150,23 +149,6 @@ func MakeSettlementHS(init bool, log *logging.Logger) SettlementHS {
 		if err := dc.RegisterTransports(ctx, recvSE); err != nil {
 			if httpErr, ok := err.(*httputil.HTTPError); ok && httpErr.Status == http.StatusConflict {
 				log.WithError(err).Debug("An expected error occurred while trying to register transport.")
-			} else if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
-				// Handle duplicate key constraint error from TPD database.
-				// This can happen if a previous transport registration exists in TPD but not locally
-				// (e.g., after a visor restart or crash). Delete the stale entry and retry.
-				log.WithError(err).Warn("Duplicate transport found in TPD, attempting to clean up and re-register.")
-
-				if deleteErr := dc.DeleteTransport(ctx, entry.ID); deleteErr != nil {
-					log.WithError(deleteErr).Error("Failed to delete stale transport from TPD.")
-				} else {
-					log.Debug("Successfully deleted stale transport from TPD, retrying registration.")
-					// Retry registration after deleting the stale entry
-					if retryErr := dc.RegisterTransports(ctx, recvSE); retryErr != nil {
-						log.WithError(retryErr).Error("Failed to register transport after cleanup.")
-					} else {
-						log.Debug("Successfully registered transport after cleanup.")
-					}
-				}
 			} else {
 				// TODO(evanlinjin): In the future, this should return error and result in failed HS.
 				log.WithError(err).Error("Failed to register transport.")


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #2075

 Changes:	
- check code, everything was well on tpd side
   https://github.com/skycoin/skywire/blob/635440c9d4f4959e02b1a0221c016fde3e0b6183/pkg/transport-discovery/store/postgres_store.go#L50-L53
   Actually on the code, we use `clause.OnConflict`, so, no duplicate transport id error return anymore. Seems tests by Moses on PR (https://github.com/skycoin/skywire/issues/2075#issuecomment-3521777516) was on old tpd code.  
- remove useless code on visor side

How to test this PR:
_