### PR TITLE
add alpha and beta to tag detection on winget for skip winget request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ github.ref_name }}" -replace '^v',''
-          if ($tag -match '-rc') {
+          if ($tag -match '-(rc|alpha|beta)') {
             Write-Host "Pre-release detected ($tag), skipping WinGet publish."
             exit 0
           }


### PR DESCRIPTION
Did you run `make format && make check`? Yes

Fixes #_

 Changes:	
- add `-alpha` and `-beta` to condition of skip winget step in release stage of GitHub action

How to test this PR:
_