### PR TITLE
Add /all-transports/per-key-stats endpoint

### DIFF
--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -106,6 +106,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 	r.Get("/health", api.health)
 	r.Get("/all-transports", api.getAllTransports)
 	r.Get("/all-transports/stats", api.getAllTransportsStats)
+	r.Get("/all-transports/per-key-stats", api.getAllTransportsPerKeyStats)
 	r.Get("/transports/stats/{edge}", api.getTransportStats)
 	r.Delete("/transports/deregister", api.deregisterTransport)
 	r.Post("/statuses", func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -186,6 +186,62 @@ func (api *API) getAllTransportsStats(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// PerKeyStats represents transport statistics for a single public key
+type PerKeyStats struct {
+	PK     string         `json:"pk"`
+	Total  int            `json:"total"`
+	ByType map[string]int `json:"by_type"`
+}
+
+func (api *API) getAllTransportsPerKeyStats(w http.ResponseWriter, r *http.Request) {
+	selfTransports := true
+	query := r.URL.Query()
+	selfTransportsParam := query.Get("selfTransports")
+	if selfTransportsParam == "hide" {
+		selfTransports = false
+	}
+
+	entries, err := api.store.GetAllTransports(r.Context(), selfTransports)
+	if err != nil {
+		if err != store.ErrTransportNotFound {
+			api.log(r).WithError(err).Error("Error getting transports for per-key stats")
+		}
+		api.writeError(w, r, err)
+		return
+	}
+
+	// Build per-key statistics
+	perKeyStats := make(map[cipher.PubKey]map[string]int)
+
+	for _, entry := range entries {
+		for _, edge := range entry.Edges {
+			if perKeyStats[edge] == nil {
+				perKeyStats[edge] = make(map[string]int)
+			}
+			perKeyStats[edge][string(entry.Type)]++
+		}
+	}
+
+	// Convert to response format
+	var result []PerKeyStats
+	for pk, byType := range perKeyStats {
+		total := 0
+		for _, count := range byType {
+			total += count
+		}
+		result = append(result, PerKeyStats{
+			PK:     pk.String(),
+			Total:  total,
+			ByType: byType,
+		})
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		api.log(r).WithError(err).Error("Error encoding per-key stats")
+		api.writeError(w, r, err)
+	}
+}
+
 func (api *API) deleteTransport(w http.ResponseWriter, r *http.Request) {
 	pk, ok := r.Context().Value(httpauth.ContextAuthKey).(cipher.PubKey)
 	if !ok {


### PR DESCRIPTION
Add new endpoint that returns transport statistics per public key for all keys in the transport discovery data.

Response format:
```
[
  {"pk": "...", "total": N, "by_type": {"stcpr": X, "sudph": Y}},
  ...
]
```
Supports ?selfTransports=hide query param to exclude self-transports.