### PR TITLE
Fix duplicate /health endpoint registration in reward server

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -192,12 +192,12 @@ func server(e error) {
 		tpvizServer := tpviz.NewServer(tpvizCfg)
 		tpvizServer.Start() // Initialize cache and start auto-refresh
 
-		// Delegate /api/* and /health to tpviz server (uses file caching to avoid rate limits)
+		// Delegate /api/* to tpviz server (uses file caching to avoid rate limits)
+		// Note: /health is already registered above with system health info
 		tpvizHandler := tpvizServer.Handler()
 		r1.GET("/api/transports", gin.WrapH(tpvizHandler))
 		r1.GET("/api/uptimes", gin.WrapH(tpvizHandler))
 		r1.GET("/api/services", gin.WrapH(tpvizHandler))
-		r1.GET("/health", gin.WrapH(tpvizHandler))
 
 		r1.GET("/transport-graph", func(c *gin.Context) {
 			c.Writer.Header().Set("Server", "")


### PR DESCRIPTION
The /health endpoint was already registered at line 115 with system health info. Registering it again for tpviz caused a panic on startup.
