### PR TITLE
Fix bundle.js 404 on rewards UI transport graph

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -202,6 +202,7 @@ func server(e error) {
 		r1.GET("/api/services", gin.WrapH(tpvizHandler))
 		r1.GET("/api/health", gin.WrapH(tpvizHandler))
 		r1.GET("/api/ip-groups", gin.WrapH(tpvizHandler))
+		r1.GET("/bundle.js", gin.WrapH(tpvizHandler))
 
 		r1.GET("/transport-graph", func(c *gin.Context) {
 			c.Writer.Header().Set("Server", "")


### PR DESCRIPTION
The /transport-graph page serves HTML that references bundle.js, but the gin router was missing a route for it. Added route to delegate /bundle.js to the tpviz handler.
