### PR TITLE
Add fallback for old per-key-stats JSON format ; update test deployment config

### DIFF
--- a/cmd/skywire-cli/commands/rewards/transports.go
+++ b/cmd/skywire-cli/commands/rewards/transports.go
@@ -139,6 +139,41 @@ This is designed to be run hourly by the reward service.`,
 	},
 }
 
+// oldFormatEntry represents the old TPD per-key-stats format
+type oldFormatEntry struct {
+	PK     string         `json:"pk"`
+	Total  int            `json:"total"`
+	ByType map[string]int `json:"by_type"`
+}
+
+// parsePerKeyStats tries to parse data as new format, falling back to old format
+func parsePerKeyStats(data []byte) (PerKeyStats, error) {
+	// Try new format first: {"pk1": {"total": N, "type": N}, ...}
+	var stats PerKeyStats
+	if err := json.Unmarshal(data, &stats); err == nil {
+		return stats, nil
+	}
+
+	// Fallback to old format: [{"pk":"...", "total":N, "by_type":{...}}, ...]
+	var oldStats []oldFormatEntry
+	if err := json.Unmarshal(data, &oldStats); err != nil {
+		return nil, fmt.Errorf("failed to parse as new or old format: %w", err)
+	}
+
+	// Convert old format to new format
+	stats = make(PerKeyStats, len(oldStats))
+	for _, entry := range oldStats {
+		counts := make(map[string]int, len(entry.ByType)+1)
+		counts["total"] = entry.Total
+		for tpType, count := range entry.ByType {
+			counts[tpType] = count
+		}
+		stats[entry.PK] = counts
+	}
+
+	return stats, nil
+}
+
 // fetchTPDData fetches transport per-key stats from TPD, using cache if valid
 func fetchTPDData(tpLog *logging.Logger, bypassCache bool) (PerKeyStats, error) {
 	// Check cache
@@ -148,8 +183,8 @@ func fetchTPDData(tpLog *logging.Logger, bypassCache bool) (PerKeyStats, error) 
 				tpLog.Debug("Using cached TPD data")
 				data, err := os.ReadFile(tpdCacheFile)
 				if err == nil {
-					var stats PerKeyStats
-					if err := json.Unmarshal(data, &stats); err == nil {
+					stats, err := parsePerKeyStats(data)
+					if err == nil {
 						return stats, nil
 					}
 					tpLog.WithError(err).Debug("Failed to parse cached data, fetching fresh")
@@ -177,8 +212,8 @@ func fetchTPDData(tpLog *logging.Logger, bypassCache bool) (PerKeyStats, error) 
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	var stats PerKeyStats
-	if err := json.Unmarshal(body, &stats); err != nil {
+	stats, err := parsePerKeyStats(body)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 

--- a/cmd/skywire-cli/commands/visor/ping/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping/ping.go
@@ -33,18 +33,22 @@ var (
 )
 
 func init() {
-	RootCmd.AddCommand(pingCmd)
-	pingCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of tries")
-	pingCmd.Flags().IntVarP(&pcktSize, "size", "s", 2, "Size of packet, in KB, default is 2KB")
-	pingCmd.Flags().BoolVar(&localRoute, "local-route", false, "Calculate routes locally using cached TPD data instead of querying route finder")
-	pingCmd.Flags().BoolVar(&createTp, "create-tp", false, "Create a direct transport to the target if none exists")
-	pingCmd.Flags().StringVar(&tpType, "tp-type", "stcpr", "Transport type to create when using --create-tp (stcpr or sudph)")
-	pingCmd.Flags().BoolVar(&useDmsg, "dmsg", false, "Ping over dmsg connection instead of skywire route")
-	pingCmd.Flags().BoolVar(&showRoute, "show-route", false, "Show the route hops used for the ping")
-	pingCmd.Flags().DurationVarP(&pingTimeout, "timeout", "o", 0, "Timeout per ping attempt; fails if exceeded (e.g., 5s, 30s)")
-	pingCmd.Flags().DurationVar(&setupTimeout, "setup-timeout", 30*time.Second, "Timeout for route setup phase")
-	pingCmd.Flags().BoolVar(&allDmsgServers, "all-servers", false, "Ping through all DMSG servers the remote visor is connected to (only with --dmsg)")
-	pingCmd.Flags().StringVar(&dmsgServerPK, "via-server", "", "Ping through specific DMSG server (only with --dmsg)")
+	// Register flags on RootCmd so they work with `ping <pk> --flags`
+	RootCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of tries")
+	RootCmd.Flags().IntVarP(&pcktSize, "size", "s", 2, "Size of packet, in KB, default is 2KB")
+	RootCmd.Flags().BoolVar(&localRoute, "local-route", false, "Calculate routes locally using cached TPD data instead of querying route finder")
+	RootCmd.Flags().BoolVar(&createTp, "create-tp", false, "Create a direct transport to the target if none exists")
+	RootCmd.Flags().StringVar(&tpType, "tp-type", "stcpr", "Transport type to create when using --create-tp (stcpr or sudph)")
+	RootCmd.Flags().BoolVar(&useDmsg, "dmsg", false, "Ping over dmsg connection instead of skywire route")
+	RootCmd.Flags().BoolVar(&showRoute, "show-route", false, "Show the route hops used for the ping")
+	RootCmd.Flags().DurationVarP(&pingTimeout, "timeout", "o", 0, "Timeout per ping attempt; fails if exceeded (e.g., 5s, 30s)")
+	RootCmd.Flags().DurationVar(&setupTimeout, "setup-timeout", 30*time.Second, "Timeout for route setup phase")
+	RootCmd.Flags().BoolVar(&allDmsgServers, "all-servers", false, "Ping through all DMSG servers the remote visor is connected to (only with --dmsg)")
+	RootCmd.Flags().StringVar(&dmsgServerPK, "via-server", "", "Ping through specific DMSG server (only with --dmsg)")
+
+	// Set RootCmd.Run to handle direct PK arguments
+	RootCmd.Run = pingCmd.Run
+	RootCmd.Args = cobra.ArbitraryArgs // Allow args so subcommands or PK can be passed
 
 	RootCmd.AddCommand(testCmd)
 	testCmd.Flags().IntVarP(&tries, "tries", "t", 1, "Number of tries per public visors")
@@ -68,8 +72,12 @@ var pingCmd = &cobra.Command{
   Use --all-servers with --dmsg to ping through all DMSG servers the
   remote visor is connected to. This helps identify which servers have
   the best connectivity.`,
-	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		// If no args provided, show help
+		if len(args) == 0 {
+			cmd.Help() //nolint:errcheck
+			return
+		}
 		pk := internal.ParsePK(cmd.Flags(), "pk", args[0])
 
 		// Create transport if requested (only for skywire route mode)

--- a/cmd/skywire-cli/commands/visor/ping/ping.go
+++ b/cmd/skywire-cli/commands/visor/ping/ping.go
@@ -75,7 +75,7 @@ var pingCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// If no args provided, show help
 		if len(args) == 0 {
-			cmd.Help() //nolint:errcheck
+			cmd.Help() //nolint:errcheck,gosec
 			return
 		}
 		pk := internal.ParsePK(cmd.Flags(), "pk", args[0])

--- a/cmd/skywire-cli/commands/visor/ping/root.go
+++ b/cmd/skywire-cli/commands/visor/ping/root.go
@@ -7,10 +7,13 @@ import (
 
 // RootCmd is the ping command that subcommands attach to
 // Subcommands register themselves in their own init() functions
+// When called with a PK argument directly, it delegates to pingCmd
 var RootCmd = &cobra.Command{
-	Use:   "ping",
+	Use:   "ping [pk]",
 	Short: "Ping commands for testing visor connectivity",
 	Long: `Ping commands for testing visor connectivity.
+
+When called with a public key argument, pings that visor directly.
 
 Available subcommands:
   ping <pk>     - Ping a specific visor

--- a/deployment/dmsghttp-config.json
+++ b/deployment/dmsghttp-config.json
@@ -2,18 +2,24 @@
   "test": {
     "dmsg_servers": [
       {
+        "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
+        "server": {
+          "address": "70.121.13.123:9082"
+        }
+      },
+      {
         "static": "024716428e6315d954356e9ad72bea32bb2b41aab5a54a9b5cb4313964016e64d8",
         "server": {
           "address": "45.79.213.251:30080"
         }
       }
     ],
-    "dmsg_discovery": "dmsg://024a7b9b7db1626d46777e5c665333afa57f48934b57652305fc7a2b19dc4c65d4:80",
-    "transport_discovery": "dmsg://02703cf828ea11d25b2c8eb0796132ecc7e53b22325b20ce3674ce5cd8693e4fb6:80",
-    "address_resolver": "dmsg://030eb7d8cf6eac40c19bbc433de6d6b9bb7a47f2e1d7095c6a01aa676471670ad2:80",
-    "route_finder": "dmsg://02ece5b69eaee13ef967b7eb67ca93f1dfddad3a51c9cb1808c4bd0d8d8aa32053:80",
-    "uptime_tracker": "dmsg://022c788cca11f208cdfd83ed0c2a8c7b661221736c461adc7c6738a2c1b041c7f8:80",
-    "service_discovery": "dmsg://038f751df4af75fb3d51f6693602bfe8289145e633ffdd1e67d686bea595f84d55:80"
+    "dmsg_discovery": "dmsg://022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa:80",
+    "transport_discovery": "dmsg://02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:80",
+    "address_resolver": "dmsg://03234b2ee4128d1f78c180d06911102906c80795dfe41bd6253f2619c8b6252a02:80",
+    "route_finder": "dmsg://039d89c5eedfda4a28b0c58b0b643eff949f08e4f68c8357278081d26f5a592d74:80",
+    "uptime_tracker": "dmsg://022c424caa6239ba7d1d9d8f7dab56cd5ec6ae2ea9ad97bb94ad4b48f62a540d3f:80",
+    "service_discovery": "dmsg://0204890f9def4f9a5448c2e824c6a4afc85fd1f877322320898fafdf407cc6fef7:80"
   },
   "prod": {
     "dmsg_servers": [

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -6,7 +6,8 @@
     "address_resolver": "http://ar.skywire.dev",
     "route_finder": "http://rf.skywire.dev",
     "route_setup_nodes": [
-      "026c2a3e92d6253c5abd71a42628db6fca9dd9aa037ab6f4e3a31108558dfd87cf"
+      "0324579f003e6b4048bae2def4365e634d8e0e3054a20fc7af49daf2a179658557",
+      "024fbd3997d4260f731b01abcfce60b8967a6d4c6a11d1008812810ea1437ce438"
     ],
     "transport_setup": [
       "03530b786c670fc7f5ab9021478c7ec9cd06a03f3ea1416c50c4a8889ef5bba80e",

--- a/pkg/transport/tpdclient/client.go
+++ b/pkg/transport/tpdclient/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -236,6 +237,7 @@ func (c *apiClient) GetAllTransportsStats(ctx context.Context) (*transport.Netwo
 // GetAllTransportsPerKeyStats returns transport counts per public key.
 // Format: {"pk1": {"total": 15, "stcpr": 1, "sudph": 14}, ...}
 // This is useful for finding well-connected visors as fallback when service discovery is empty.
+// Supports fallback to old array format: [{"pk":"...", "total":N, "by_type":{...}}, ...]
 func (c *apiClient) GetAllTransportsPerKeyStats(ctx context.Context) (transport.PerKeyStats, error) {
 	resp, err := c.Get(ctx, "/all-transports/per-key-stats")
 	if err != nil {
@@ -252,9 +254,38 @@ func (c *apiClient) GetAllTransportsPerKeyStats(ctx context.Context) (transport.
 		return nil, err
 	}
 
+	// Read the body once so we can try multiple parse formats
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	// Try new format first: {"pk1": {"total": N, "type": N}, ...}
 	var stats transport.PerKeyStats
-	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
-		return nil, fmt.Errorf("json: %w", err)
+	if err := json.Unmarshal(body, &stats); err == nil {
+		return stats, nil
+	}
+
+	// Fallback to old format: [{"pk":"...", "total":N, "by_type":{...}}, ...]
+	type oldFormatEntry struct {
+		PK     string         `json:"pk"`
+		Total  int            `json:"total"`
+		ByType map[string]int `json:"by_type"`
+	}
+	var oldStats []oldFormatEntry
+	if err := json.Unmarshal(body, &oldStats); err != nil {
+		return nil, fmt.Errorf("json: failed to parse as new or old format: %w", err)
+	}
+
+	// Convert old format to new format
+	stats = make(transport.PerKeyStats, len(oldStats))
+	for _, entry := range oldStats {
+		counts := make(map[string]int, len(entry.ByType)+1)
+		counts["total"] = entry.Total
+		for tpType, count := range entry.ByType {
+			counts[tpType] = count
+		}
+		stats[entry.PK] = counts
 	}
 
 	return stats, nil


### PR DESCRIPTION
The /all-transports/per-key-stats endpoint format changed from array to map, but the new format isn't deployed yet. This adds fallback logic to handle both formats:

Old format: [{"pk":"...", "total":N, "by_type":{...}}, ...]
New format: {"pk1": {"total": N, "type": N}, ...}

Both tpdclient and rewards CLI now try new format first, then fall back to old format if parsing fails.

----------------

updated test deployment config to use same keys as prod. Now the only difference is the URLs and the number of dmsg servers.

I'm running the same things on prod as on test:

* public visor
* visor (whitelisted as network monitor)
* route setup-node
* transport setup-node
* dmsg server