### PR TITLE
Add color functions to custom help template for usage=false mode

### DIFF
--- a/pkg/skywire-utilities/pkg/flags/flags.go
+++ b/pkg/skywire-utilities/pkg/flags/flags.go
@@ -39,16 +39,17 @@ func InitFlags(cmd *cobra.Command, usage bool) {
 
 const helpTemplateNoUsage = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
-{{end}}{{if .HasAvailableSubCommands}}Available Commands:{{range .Commands}}{{if and (ne .Name "completion") .IsAvailableCommand}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+{{end}}{{if .HasAvailableSubCommands}}{{HeadingStyle "Available Commands:"}}{{range .Commands}}{{if and (ne .Name "completion") .IsAvailableCommand}}
+  {{rpad (CommandStyle .Name) (sum .NamePadding 12) }} {{CmdShortStyle .Short}}{{end}}{{end}}
 
-{{end}}{{if .HasAvailableLocalFlags}}Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{end}}{{if .HasAvailableLocalFlags}}{{HeadingStyle "Flags:"}}
+{{FlagStyle .LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
+{{HeadingStyle "Global Flags:"}}
+{{FlagStyle .InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 `
 
+// help is used as usage template (coloredcobra will add colors to it)
 const help = `{{if gt (len .Aliases) 0}}{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}Available Commands:{{range .Commands}}{{if and (ne .Name "completion") .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 


### PR DESCRIPTION
When usage=false, a custom help template (helpTemplateNoUsage) is used which bypasses coloredcobra's automatic colorization. This adds the color template functions (HeadingStyle, CommandStyle, CmdShortStyle, FlagStyle) directly to the custom help template so colors display correctly in both usage=true and usage=false modes.

The help and helpUsage templates remain plain since they are used as usage templates and coloredcobra automatically adds colors to them.
