### PR TITLE
Add --testenv flag and SKYWIRETEST env for cli commands

### DIFF
--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -22,28 +25,96 @@ import (
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 )
 
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "entries.json").
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Extract a simple, meaningful name from the URL
+	var name string
+
+	// Check for service type in query (e.g., ?type=visor -> visor.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /dmsg-discovery/entries -> entries.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
+
 var (
-	cacheFileDMSGD string
-	cacheFilesAge  int
-	mdURL          string
-	isStats        bool
+	cacheDirDMSGD string
+	cacheFilesAge int
+	mdURL         string
+	isStats       bool
+	testEnv       bool
 	// allEntries bool
 	masterLogger  = logging.NewMasterLogger()
 	packageLogger = masterLogger.PackageLogger("mdisc:disc")
-	dmsgDiscURL   = deployment.Prod.DmsgDiscovery
 )
 
 func init() {
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
 	RootCmd.AddCommand(
 		entryCmd,
 		availableServersCmd,
 	)
-	RootCmd.Flags().StringVar(&cacheFileDMSGD, "cfu", os.TempDir()+"/dmsgd.json", "DMSGD cache file location.")
+	RootCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
+	RootCmd.Flags().StringVar(&cacheDirDMSGD, "cdd", cacheDirPath(dep.DmsgDiscovery), "DMSG cache dir (\"\" to disable)")
 	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache file if older than n minutes")
 	RootCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "count the number of results")
-	entryCmd.Flags().StringVar(&mdURL, "url", dmsgDiscURL, "specify alternative DMSG discovery url")
-	RootCmd.Flags().StringVar(&mdURL, "url", dmsgDiscURL, "specify alternative DMSG discovery url")
-	availableServersCmd.Flags().StringVar(&mdURL, "url", dmsgDiscURL, "specify alternative DMSG discovery url")
+	entryCmd.Flags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
+	RootCmd.Flags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
+	availableServersCmd.Flags().StringVar(&mdURL, "url", dep.DmsgDiscovery, "specify alternative DMSG discovery url")
 }
 
 // RootCmd is the command that contains sub-commands which interacts with DMSG services.
@@ -51,9 +122,24 @@ var RootCmd = &cobra.Command{
 	Use:   "mdisc",
 	Short: "Query DMSG Discovery",
 	Long: `Query DMSG Discovery
-	list entries in dmsg discovery`,
+	list entries in dmsg discovery
+
+Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		dmsgclientkeys := internal.GetData(cacheFileDMSGD, mdURL+"/dmsg-discovery/entries", cacheFilesAge)
+		// Handle --testenv flag: override URL and cache dir that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("url") {
+				mdURL = deployment.Test.DmsgDiscovery
+			}
+			if !cmd.Flags().Changed("cdd") {
+				cacheDirDMSGD = cacheDirPath(deployment.Test.DmsgDiscovery)
+			}
+		}
+
+		// Build full URL
+		dmsgFullURL := mdURL + "/dmsg-discovery/entries"
+
+		dmsgclientkeys := internal.GetData(cacheFile(cacheDirDMSGD, dmsgFullURL), dmsgFullURL, cacheFilesAge)
 		if isStats {
 			stats, _ := script.Echo(dmsgclientkeys).JQ(".[]").CountLines() //nolint:errcheck
 			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d dmsg clients\n", stats), fmt.Sprintf("%d dmsg clients\n", stats))

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -80,16 +80,20 @@ func init() {
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
 	// test command flags
+	testCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
 	testCmd.Flags().StringVarP(&testURL, "url", "u", "https://ip.skycoin.com", "URL to fetch through proxy for testing")
 	testCmd.Flags().IntVarP(&testTimeout, "timeout", "t", 10, "timeout in seconds for HTTP request (route setup has separate 30s timeout)")
 	testCmd.Flags().IntVarP(&testBatchSize, "batch", "b", 1, "number of proxies to test (1=sequential/stable, >1=parallel/experimental)")
 	testCmd.Flags().BoolVarP(&testOnlyWithTp, "transport", "p", false, "only test proxies that have an existing transport")
 	testCmd.Flags().BoolVarP(&testVerbose, "verbose", "v", false, "verbose output")
-	testCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
-	testCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
-	testCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/proxysd.json", "SD cache file location")
-	testCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location")
+	testCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
+	testCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	testCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
+	testCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
 	testCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	testCmd.Flags().StringVarP(&country, "country", "k", "", "filter proxies by country code")
 	testCmd.Flags().BoolVarP(&testConnectOnly, "connect", "c", false, "connect only mode: add transports without HTTP testing")
@@ -350,12 +354,16 @@ var (
 )
 
 func init() {
-	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
-	listCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	listCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
+	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
+	listCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
 	listCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "print raw json data")
 	listCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
-	listCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/proxysd.json", "SD cache file location")
-	listCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location.")
+	listCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
+	listCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
 	listCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
 	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
@@ -370,10 +378,30 @@ func init() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, deployment.Prod.ServiceDiscovery, serviceType, deployment.Prod.ServiceDiscovery, serviceType, serverPort),
+	Long: fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache dir to \"\" to avoid using cache files\ndefault virtual port of servers: %v\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", serviceType, getDeployment().ServiceDiscovery, serviceType, getDeployment().ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("sdurl") {
+				sdURL = deployment.Test.ServiceDiscovery
+			}
+			if !cmd.Flags().Changed("uturl") {
+				utURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("cds") {
+				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
+			}
+			if !cmd.Flags().Changed("cdu") {
+				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+		}
+
+		// Build full URLs
+		sdFullURL := sdURL + "/api/services?type=" + serviceType
+		utFullURL := utURL + "/uptimes?v=v2"
+
 		// --- Fetch SD ---
-		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
+		sds := internal.GetData(cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
 		if rawData {
 			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint:errcheck,gosec
 			return
@@ -445,7 +473,7 @@ var listCmd = &cobra.Command{
 
 		// --- Show only offline servers ---
 		if showOffline {
-			uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+			uts := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 
 			// Parse SD and UT data
 			var sdEntries []services.Service
@@ -589,7 +617,7 @@ var listCmd = &cobra.Command{
 		}
 
 		// --- Filtering by online status ---
-		uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+		uts := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 
 		// Use Go-based filtering when minVersion or maxVersion is specified (jq can't do semver comparison)
 		if minVersion != "" || maxVersion != "" {
@@ -729,8 +757,28 @@ make an HTTP request through the proxy to verify it's working.
 With --connect flag, connects to all online proxies (adds transports)
 without HTTP testing. Use --version to filter by visor version.
 
-Results show which proxies are reachable and their response latency.`,
+Results show which proxies are reachable and their response latency.
+
+Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("sdurl") {
+				sdURL = deployment.Test.ServiceDiscovery
+			}
+			if !cmd.Flags().Changed("uturl") {
+				utURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("cds") {
+				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
+			}
+			if !cmd.Flags().Changed("cdu") {
+				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+		}
+
+		// Build full URL for cache file
+		sdFullURL := sdURL + "/api/services?type=" + serviceType
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
@@ -926,7 +974,7 @@ Results show which proxies are reachable and their response latency.`,
 			}
 		} else {
 			// Fetch proxy servers from service discovery
-			sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
+			sds := internal.GetData(cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
 			var proxyServices []services.Service
 			if err := json.Unmarshal([]byte(sds), &proxyServices); err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse service discovery response: %w", err))

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -2,11 +2,81 @@
 package skysocksc
 
 import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 )
+
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "proxy.json", "uptimes.json").
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Extract a simple, meaningful name from the URL
+	var name string
+
+	// Check for service type in query (e.g., ?type=proxy -> proxy.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /uptimes -> uptimes.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
 
 var (
 	binaryName      = "skysocks-client"
@@ -15,8 +85,8 @@ var (
 	rawData         bool
 	sdURL           string
 	utURL           string
-	cacheFileSD     string
-	cacheFileUT     string
+	cacheDirSD      string
+	cacheDirUT      string
 	cacheFilesAge   int
 	isStats         bool
 	pubkey          cipher.PubKey
@@ -50,6 +120,7 @@ var (
 	forceLocalRoutes bool
 	// multi-hop testing
 	viaVisor string
+	testEnv  bool
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -4,8 +4,11 @@ package pv
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/bitfield/script"
 	"github.com/spf13/cobra"
@@ -22,9 +25,9 @@ var (
 	sdURL          string
 	utURL          string
 	tpdURL         string
-	cacheFileSD    string
-	cacheFileUT    string
-	cacheFileTPD   string
+	cacheDirSD     string
+	cacheDirUT     string
+	cacheDirTPD    string
 	cacheFilesAge  int
 	rawData        bool
 	noFilterOnline bool
@@ -33,17 +36,76 @@ var (
 	isStats        bool
 	showTransports bool
 	minTransports  int
+	testEnv        bool
 )
 
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Sanitize the path for use as a filename
+	// e.g., "/api/services?type=visor" -> "api-services-type=visor.json"
+	pathAndQuery := strings.TrimPrefix(u.Path, "/")
+	if u.RawQuery != "" {
+		pathAndQuery += "-" + u.RawQuery
+	}
+	// Replace path separators with dashes
+	pathAndQuery = strings.ReplaceAll(pathAndQuery, "/", "-")
+	// Remove any other problematic characters
+	pathAndQuery = strings.ReplaceAll(pathAndQuery, "?", "-")
+
+	return filepath.Join(cacheDir, pathAndQuery+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
+
 func init() {
-	RootCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
-	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
-	RootCmd.Flags().StringVarP(&tpdURL, "tpdurl", "d", deployment.Prod.TransportDiscovery, "transport discovery url")
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	RootCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
+	RootCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
+	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	RootCmd.Flags().StringVarP(&tpdURL, "tpdurl", "d", dep.TransportDiscovery, "transport discovery url")
 	RootCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "print raw json data")
 	RootCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
-	RootCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/visorsd.json", "SD cache file location")
-	RootCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location")
-	RootCmd.Flags().StringVar(&cacheFileTPD, "cft", os.TempDir()+"/tpd.json", "TPD cache file location")
+	RootCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
+	RootCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	RootCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)")
 	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	RootCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
 	RootCmd.Flags().StringVarP(&version, "version", "v", "", "filter by version")
@@ -61,10 +123,43 @@ var RootCmd = &cobra.Command{
 
 Returns only public keys, one per line.
 Use -t to show transport counts per visor.
-Set cache file location to "" to avoid using cache files`, deployment.Prod.ServiceDiscovery, serviceType),
+
+Cache files are stored in directories named after service hosts.
+Set cache dir to "" to disable caching for that service.
+
+Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment().ServiceDiscovery, serviceType),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			// --testenv was specified at runtime (not via SKYWIRETEST env)
+			// Override values that weren't explicitly changed by user
+			if !cmd.Flags().Changed("sdurl") {
+				sdURL = deployment.Test.ServiceDiscovery
+			}
+			if !cmd.Flags().Changed("uturl") {
+				utURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("tpdurl") {
+				tpdURL = deployment.Test.TransportDiscovery
+			}
+			if !cmd.Flags().Changed("cds") {
+				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
+			}
+			if !cmd.Flags().Changed("cdu") {
+				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+			if !cmd.Flags().Changed("cdt") {
+				cacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
+			}
+		}
+
+		// Build full URLs with endpoints
+		sdFullURL := sdURL + "/api/services?type=" + serviceType
+		utFullURL := utURL + "/uptimes?v=v2"
+		tpdFullURL := tpdURL + "/all-transports"
+
 		// Fetch SD
-		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
+		sds := internal.GetData(cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
 		if rawData {
 			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint:errcheck,gosec
 			return
@@ -101,7 +196,7 @@ Set cache file location to "" to avoid using cache files`, deployment.Prod.Servi
 			pks, _ = script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Slice() //nolint:errcheck
 		} else {
 			// Filter by online status via jq join
-			uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+			uts := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 			joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
 
 			// Build jq filter with optional country and version conditions
@@ -139,7 +234,7 @@ Set cache file location to "" to avoid using cache files`, deployment.Prod.Servi
 		}
 
 		// Show transports mode - fetch TPD and count transports per visor
-		tpd := internal.GetData(cacheFileTPD, tpdURL+"/all-transports", cacheFilesAge)
+		tpd := internal.GetData(cacheFile(cacheDirTPD, tpdFullURL), tpdFullURL, cacheFilesAge)
 
 		var entries []*transport.Entry
 		if err := json.Unmarshal([]byte(tpd), &entries); err != nil {

--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -56,6 +56,7 @@ func cacheDirPath(serviceURL string) string {
 // cacheFile returns the full cache file path for a given URL.
 // If cacheDir is empty, returns "" (disables caching).
 // Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "visor.json", "uptimes.json").
 func cacheFile(cacheDir, fullURL string) string {
 	if cacheDir == "" {
 		return ""
@@ -71,18 +72,27 @@ func cacheFile(cacheDir, fullURL string) string {
 		return ""
 	}
 
-	// Sanitize the path for use as a filename
-	// e.g., "/api/services?type=visor" -> "api-services-type=visor.json"
-	pathAndQuery := strings.TrimPrefix(u.Path, "/")
-	if u.RawQuery != "" {
-		pathAndQuery += "-" + u.RawQuery
-	}
-	// Replace path separators with dashes
-	pathAndQuery = strings.ReplaceAll(pathAndQuery, "/", "-")
-	// Remove any other problematic characters
-	pathAndQuery = strings.ReplaceAll(pathAndQuery, "?", "-")
+	// Extract a simple, meaningful name from the URL
+	var name string
 
-	return filepath.Join(cacheDir, pathAndQuery+".json")
+	// Check for service type in query (e.g., ?type=visor -> visor.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /all-transports -> all-transports.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
 }
 
 // getDeployment returns the appropriate deployment config based on test env

--- a/cmd/skywire-cli/commands/sd/root.go
+++ b/cmd/skywire-cli/commands/sd/root.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -18,28 +20,97 @@ import (
 	"github.com/skycoin/skywire/pkg/servicedisc"
 )
 
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "visor.json", "uptimes.json").
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Extract a simple, meaningful name from the URL
+	var name string
+
+	// Check for service type in query (e.g., ?type=visor -> visor.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /all-transports -> all-transports.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
+
 var (
 	sdURL          string
 	tpdURL         string
 	utURL          string
-	cacheFileSD    string
-	cacheFileTPD   string
-	cacheFileUT    string
+	cacheDirSD     string
+	cacheDirTPD    string
+	cacheDirUT     string
 	cacheFilesAge  int
 	country        string
 	version        string
 	minTransports  int
 	noFilterOnline bool
 	jsonOutput     bool
+	testEnv        bool
 )
 
 func init() {
-	RootCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
-	RootCmd.Flags().StringVarP(&tpdURL, "tpdurl", "b", deployment.Prod.TransportDiscovery, "transport discovery url")
-	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
-	RootCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/networksd.json", "SD cache file location")
-	RootCmd.Flags().StringVar(&cacheFileTPD, "cft", os.TempDir()+"/networktpd.json", "TPD cache file location")
-	RootCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/networkut.json", "UT cache file location")
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	RootCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
+	RootCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
+	RootCmd.Flags().StringVarP(&tpdURL, "tpdurl", "b", dep.TransportDiscovery, "transport discovery url")
+	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	RootCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
+	RootCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)")
+	RootCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
 	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	RootCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
 	RootCmd.Flags().StringVarP(&version, "version", "e", "", "filter by version")
@@ -58,17 +129,50 @@ Combines data from:
 - Service Discovery: %v/api/services
 - Transport Discovery: %v/all-transports
 
-Shows public keys with their services and transport counts by type.`,
-		deployment.Prod.ServiceDiscovery,
-		deployment.Prod.TransportDiscovery),
+Shows public keys with their services and transport counts by type.
+
+Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
+		getDeployment().ServiceDiscovery,
+		getDeployment().TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			// --testenv was specified at runtime (not via SKYWIRETEST env)
+			// Override values that weren't explicitly changed by user
+			if !cmd.Flags().Changed("sdurl") {
+				sdURL = deployment.Test.ServiceDiscovery
+			}
+			if !cmd.Flags().Changed("tpdurl") {
+				tpdURL = deployment.Test.TransportDiscovery
+			}
+			if !cmd.Flags().Changed("uturl") {
+				utURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("cds") {
+				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
+			}
+			if !cmd.Flags().Changed("cdt") {
+				cacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
+			}
+			if !cmd.Flags().Changed("cdu") {
+				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+		}
+
+		// Build full URLs with endpoints
+		sdProxyURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeProxy
+		sdVpnURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeVPN
+		sdVisorURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeVisor
+		tpdFullURL := tpdURL + "/all-transports"
+		utFullURL := utURL + "/uptimes?v=v2"
+
 		// Fetch service discovery data for all service types
-		proxyData := internal.GetData(cacheFileSD+"_proxy", sdURL+"/api/services?type="+servicedisc.ServiceTypeProxy, cacheFilesAge)
-		vpnData := internal.GetData(cacheFileSD+"_vpn", sdURL+"/api/services?type="+servicedisc.ServiceTypeVPN, cacheFilesAge)
-		visorData := internal.GetData(cacheFileSD+"_visor", sdURL+"/api/services?type="+servicedisc.ServiceTypeVisor, cacheFilesAge)
+		proxyData := internal.GetData(cacheFile(cacheDirSD, sdProxyURL), sdProxyURL, cacheFilesAge)
+		vpnData := internal.GetData(cacheFile(cacheDirSD, sdVpnURL), sdVpnURL, cacheFilesAge)
+		visorData := internal.GetData(cacheFile(cacheDirSD, sdVisorURL), sdVisorURL, cacheFilesAge)
 
 		// Fetch transport discovery data
-		tpdData := internal.GetData(cacheFileTPD, tpdURL+"/all-transports", cacheFilesAge)
+		tpdData := internal.GetData(cacheFile(cacheDirTPD, tpdFullURL), tpdFullURL, cacheFilesAge)
 
 		// Parse service discovery data
 		type sdEntry struct {
@@ -133,7 +237,7 @@ Shows public keys with their services and transport counts by type.`,
 		}
 
 		// Always fetch UT data for status tracking
-		utData := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+		utData := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 
 		type utEntry struct {
 			PK string `json:"pk"`

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -4,7 +4,9 @@ package cliut
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -16,6 +18,70 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "visor.json", "uptimes.json").
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Extract a simple, meaningful name from the URL
+	var name string
+
+	// Check for service type in query (e.g., ?type=visor -> visor.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /all-transports -> all-transports.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
+
 // RootCmd is utCmd
 var RootCmd = utCmd
 
@@ -24,29 +90,35 @@ var (
 	online        bool
 	isStats       bool
 	isMoreStats   bool
-	utURL         = deployment.Prod.UptimeTracker
-	tpdURL        = deployment.Prod.TransportDiscovery
-	cacheFileUT   string
-	cacheFileTPD  string
+	utURL         string
+	tpdURL        string
+	cacheDirUT    string
+	cacheDirTPD   string
 	cacheFilesAge int
 	versionFilter string
 	minVersion    string
 	listVersions  bool
 	maxTP         int
+	testEnv       bool
 )
 
 var minUT int
 
 func init() {
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	utCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
 	utCmd.Flags().StringVarP(&pk, "pk", "k", "", "check uptime for the specified key")
 	utCmd.Flags().BoolVarP(&online, "on", "o", false, "list currently online visors")
 	utCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "count the number of results")
 	utCmd.Flags().BoolVarP(&isMoreStats, "stats2", "t", false, "count of versions")
 	utCmd.Flags().IntVarP(&minUT, "min", "n", 75, "list visors meeting minimum uptime percentage\n\r")
-	utCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location\n\r")
-	utCmd.Flags().StringVar(&cacheFileTPD, "cft", os.TempDir()+"/tpd.json", "TPD cache file location\n\r")
+	utCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)\n\r")
+	utCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)\n\r")
 	utCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes\n\r")
-	utCmd.Flags().StringVarP(&utURL, "url", "u", utURL, "specify alternative uptime tracker url\n\r")
+	utCmd.Flags().StringVarP(&utURL, "url", "u", dep.UptimeTracker, "specify alternative uptime tracker url\n\r")
+	utCmd.Flags().StringVar(&tpdURL, "tpdurl", dep.TransportDiscovery, "transport discovery url")
 	utCmd.Flags().StringVarP(&versionFilter, "version", "v", "", "filter visors by exact version")
 	utCmd.Flags().StringVar(&minVersion, "min-version", "", "filter visors with version >= specified (e.g. v1.3.34)")
 	utCmd.Flags().BoolVarP(&listVersions, "list-versions", "l", false, "list PKs with their versions")
@@ -56,14 +128,34 @@ func init() {
 var utCmd = &cobra.Command{
 	Use:   "ut",
 	Short: "query uptime tracker",
-	Long:  fmt.Sprintf("query uptime tracker\n\n%v/uptimes?v=v2\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache file location to \"\" to avoid using cache files", utURL),
+	Long: fmt.Sprintf("query uptime tracker\n\n%v/uptimes?v=v2\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache dir to \"\" to avoid using cache files\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", getDeployment().UptimeTracker),
 	Run: func(cmd *cobra.Command, _ []string) {
-		uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("url") {
+				utURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("tpdurl") {
+				tpdURL = deployment.Test.TransportDiscovery
+			}
+			if !cmd.Flags().Changed("cdu") {
+				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+			if !cmd.Flags().Changed("cdt") {
+				cacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
+			}
+		}
+
+		// Build full URLs
+		utFullURL := utURL + "/uptimes?v=v2"
+		tpdFullURL := tpdURL + "/all-transports"
+
+		uts := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 
 		// Build transport count map if --max-tp is specified
 		var tpCount map[string]int
 		if maxTP >= 0 {
-			tpd := internal.GetData(cacheFileTPD, tpdURL+"/all-transports", cacheFilesAge)
+			tpd := internal.GetData(cacheFile(cacheDirTPD, tpdFullURL), tpdFullURL, cacheFilesAge)
 			var entries []*transport.Entry
 			if err := json.Unmarshal([]byte(tpd), &entries); err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse TPD data: %w", err))

--- a/cmd/skywire-cli/commands/ut/tpd.go
+++ b/cmd/skywire-cli/commands/ut/tpd.go
@@ -1,0 +1,235 @@
+// Package cliut cmd/skywire-cli/ut/tpd.go
+package cliut
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bitfield/script"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
+)
+
+// TPD subcommand variables (separate from main ut command)
+var (
+	tpdPK            string
+	tpdOnline        bool
+	tpdIsStats       bool
+	tpdIsMoreStats   bool
+	tpdCacheDirTPD   string
+	tpdCacheFilesAge int
+	tpdVersionFilter string
+	tpdMinVersion    string
+	tpdListVersions  bool
+	tpdMinUT         int
+	tpdTestEnv       bool
+	tpdUptimeURL     string
+)
+
+func init() {
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	utCmd.AddCommand(tpdCmd)
+
+	tpdCmd.Flags().BoolVar(&tpdTestEnv, "testenv", defaultTestEnv, "use test deployment")
+	tpdCmd.Flags().StringVarP(&tpdPK, "pk", "k", "", "check uptime for the specified key")
+	tpdCmd.Flags().BoolVarP(&tpdOnline, "on", "o", false, "list currently online visors")
+	tpdCmd.Flags().BoolVarP(&tpdIsStats, "stats", "s", false, "count the number of results")
+	tpdCmd.Flags().BoolVarP(&tpdIsMoreStats, "stats2", "t", false, "count of versions")
+	tpdCmd.Flags().IntVarP(&tpdMinUT, "min", "n", 75, "list visors meeting minimum uptime percentage")
+	tpdCmd.Flags().StringVar(&tpdCacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)")
+	tpdCmd.Flags().IntVarP(&tpdCacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
+	tpdCmd.Flags().StringVar(&tpdUptimeURL, "url", dep.TransportDiscovery, "transport discovery url")
+	tpdCmd.Flags().StringVarP(&tpdVersionFilter, "version", "v", "", "filter visors by exact version")
+	tpdCmd.Flags().StringVar(&tpdMinVersion, "min-version", "", "filter visors with version >= specified (e.g. v1.3.34)")
+	tpdCmd.Flags().BoolVarP(&tpdListVersions, "list-versions", "l", false, "list PKs with their versions")
+}
+
+var tpdCmd = &cobra.Command{
+	Use:   "tpd",
+	Short: "query TPD integrated uptime tracker",
+	Long: fmt.Sprintf(`Query the TPD integrated uptime tracker
+
+%v/uptimes
+
+This queries the uptime data from the Transport Discovery service
+instead of the separate Uptime Tracker service.
+
+Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment().TransportDiscovery),
+	Run: func(cmd *cobra.Command, _ []string) {
+		// Handle --testenv flag: override URL and cache dir that weren't explicitly set
+		if tpdTestEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("url") {
+				tpdUptimeURL = deployment.Test.TransportDiscovery
+			}
+			if !cmd.Flags().Changed("cdt") {
+				tpdCacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
+			}
+		}
+
+		// Build full URL - TPD integrated uptime endpoint
+		// Note: TPD uses /uptimes (same as separate UT but on TPD host)
+		tpdFullURL := tpdUptimeURL + "/uptimes"
+
+		uts := internal.GetData(cacheFile(tpdCacheDirTPD, tpdFullURL), tpdFullURL, tpdCacheFilesAge)
+
+		// Build the base selector based on online flag
+		baseSelector := ".[]"
+		if tpdOnline {
+			baseSelector = ".[] | select(.on)"
+		}
+
+		// Helper to parse version string like "v1.3.34" or "v1.3.34 dirty"
+		parseVersion := func(v string) (major, minor, patch int, ok bool) {
+			if v == "" {
+				return 0, 0, 0, false
+			}
+			// Remove "v" prefix and anything after space
+			v = strings.TrimPrefix(v, "v")
+			if idx := strings.Index(v, " "); idx != -1 {
+				v = v[:idx]
+			}
+			parts := strings.Split(v, ".")
+			if len(parts) < 3 {
+				return 0, 0, 0, false
+			}
+			var err error
+			major, err = strconv.Atoi(parts[0])
+			if err != nil {
+				return 0, 0, 0, false
+			}
+			minor, err = strconv.Atoi(parts[1])
+			if err != nil {
+				return 0, 0, 0, false
+			}
+			patch, err = strconv.Atoi(parts[2])
+			if err != nil {
+				return 0, 0, 0, false
+			}
+			return major, minor, patch, true
+		}
+
+		// Helper to check if version a >= version b
+		versionGTE := func(a, b string) bool {
+			aMaj, aMin, aPatch, aOK := parseVersion(a)
+			bMaj, bMin, bPatch, bOK := parseVersion(b)
+			if !aOK || !bOK {
+				return false
+			}
+			if aMaj != bMaj {
+				return aMaj > bMaj
+			}
+			if aMin != bMin {
+				return aMin > bMin
+			}
+			return aPatch >= bPatch
+		}
+
+		// Handle min-version filter
+		if tpdMinVersion != "" {
+			// Parse UT data to filter by version
+			type utEntry struct {
+				PK      string `json:"pk"`
+				On      bool   `json:"on"`
+				Version string `json:"version"`
+			}
+			var utEntries []utEntry
+			if err := json.Unmarshal([]byte(uts), &utEntries); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse TPD uptime data: %w", err))
+			}
+
+			var keys []string
+			for _, e := range utEntries {
+				if tpdOnline && !e.On {
+					continue
+				}
+				if !versionGTE(e.Version, tpdMinVersion) {
+					continue
+				}
+				if tpdPK != "" && !strings.Contains(e.PK, tpdPK) {
+					continue
+				}
+				keys = append(keys, e.PK)
+			}
+
+			if tpdIsStats {
+				label := "visors"
+				if tpdOnline {
+					label = "online visors"
+				}
+				internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d %s with version >= %s\n", len(keys), label, tpdMinVersion), fmt.Sprintf("%d %s with version >= %s\n", len(keys), label, tpdMinVersion))
+				return
+			}
+			for _, k := range keys {
+				internal.PrintOutput(cmd.Flags(), k+"\n", k+"\n")
+			}
+			return
+		}
+
+		// Handle exact version filter
+		if tpdVersionFilter != "" {
+			versionSelector := baseSelector + " | select(.version == \"" + tpdVersionFilter + "\")"
+			keys, _ := script.Echo(uts).JQ(versionSelector+" | .pk").Match(tpdPK).Replace("\"", "").Slice() //nolint:errcheck
+			if tpdIsStats {
+				label := "visors"
+				if tpdOnline {
+					label = "online visors"
+				}
+				internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d %s with version %s\n", len(keys), label, tpdVersionFilter), fmt.Sprintf("%d %s with version %s\n", len(keys), label, tpdVersionFilter))
+				return
+			}
+			if tpdListVersions {
+				for _, k := range keys {
+					fmt.Printf("%s %s\n", k, tpdVersionFilter)
+				}
+				return
+			}
+			for _, i := range keys {
+				internal.PrintOutput(cmd.Flags(), i+"\n", i+"\n")
+			}
+			return
+		}
+
+		// Handle list-versions flag (without version filter)
+		if tpdListVersions {
+			if tpdIsStats {
+				script.Echo(uts).JQ(baseSelector+" | .version").Freq().Replace("\"", "").Stdout() //nolint:errcheck,gosec
+				return
+			}
+			script.Echo(uts).JQ(baseSelector+" | \"\\(.pk) \\(.version)\"").Match(tpdPK).Replace("\"", "").Stdout() //nolint:errcheck,gosec
+			return
+		}
+
+		if tpdOnline {
+			utKeysOnline, _ := script.Echo(uts).JQ(".[] | select(.on) | .pk").Match(tpdPK).Replace("\"", "").Slice() //nolint:errcheck
+			if tpdIsStats {
+				internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d visors online\n", len(utKeysOnline)), fmt.Sprintf("%d visors online\n", len(utKeysOnline)))
+				return
+			}
+			if tpdIsMoreStats {
+				script.Echo(uts).JQ(".[] | select(.on) | .version").Freq().Replace("\"", "").Stdout() //nolint:errcheck,gosec
+				return
+			}
+			for _, i := range utKeysOnline {
+				internal.PrintOutput(cmd.Flags(), i+"\n", i+"\n")
+			}
+			return
+		}
+		if tpdIsStats {
+			keys, _ := script.Echo(uts).JQ(".[] | .pk").Replace("\"", "").Slice() //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), fmt.Sprintf("%d visors\n", len(keys)), fmt.Sprintf("%d visors\n", len(keys)))
+			return
+		}
+		if tpdIsMoreStats {
+			script.Echo(uts).JQ(".[] | .version").Freq().Replace("\"", "").Stdout() //nolint:errcheck,gosec
+			return
+		}
+
+		script.Echo(uts).JQ(".[] | \"\\(.pk) \\(.daily | to_entries[] | select(.value | tonumber > "+fmt.Sprintf("%d", tpdMinUT)+") | \"\\(.key) \\(.value)\")\"").Match(tpdPK).Replace("\"", "").Stdout() //nolint:errcheck,gosec
+	},
+}

--- a/cmd/skywire-cli/commands/visor/ping/tree.go
+++ b/cmd/skywire-cli/commands/visor/ping/tree.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -21,6 +23,70 @@ import (
 	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "all-transports.json", "uptimes.json").
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Extract a simple, meaningful name from the URL
+	var name string
+
+	// Check for service type in query (e.g., ?type=visor -> visor.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /all-transports -> all-transports.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
+
 // Flags for ping tree command (separate from ping graph for cleaner interface)
 var (
 	treeVersion        string
@@ -29,9 +95,9 @@ var (
 	treeSetupTimeout   time.Duration
 	treeTries          int
 	treePcktSize       int
-	treeCacheTPD       string
-	treeCacheUT        string
-	treeCacheDMSG      string
+	treeCacheDirTPD    string
+	treeCacheDirUT     string
+	treeCacheDirDMSG   string
 	treeCacheAge       int
 	treeTPDURL         string
 	treeUTURL          string
@@ -54,6 +120,7 @@ var (
 	treeRemakeTp       bool
 	treeRemakeRemoteTp bool
 	treeConcurrency    int
+	treeTestEnv        bool
 )
 
 func init() {
@@ -86,19 +153,23 @@ Use --dmsg-only to ping via DMSG servers instead of transport routes.
 Use --dmsg to pre-check visor reachability over DMSG before route ping (skips unreachable).
 Use --dmsg-all-servers to ping via all DMSG servers (not just first success).`
 
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	pingTreeCmd.Flags().BoolVar(&treeTestEnv, "testenv", defaultTestEnv, "use test deployment")
 	pingTreeCmd.Flags().StringVarP(&treeVersion, "version", "v", "", "filter by minimum version")
 	pingTreeCmd.Flags().IntVarP(&treeMaxLevel, "max-level", "l", 0, "maximum hop level (0 = unlimited)")
 	pingTreeCmd.Flags().DurationVarP(&treeTimeout, "timeout", "o", 30*time.Second, "timeout per ping attempt")
 	pingTreeCmd.Flags().DurationVar(&treeSetupTimeout, "setup-timeout", 30*time.Second, "timeout for route setup phase")
 	pingTreeCmd.Flags().IntVarP(&treeTries, "tries", "t", 1, "ping attempts per transport")
 	pingTreeCmd.Flags().IntVarP(&treePcktSize, "size", "s", 2, "packet size in KB")
-	pingTreeCmd.Flags().StringVar(&treeCacheTPD, "cft", os.TempDir()+"/tpd.json", "TPD cache file location")
-	pingTreeCmd.Flags().StringVar(&treeCacheUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location")
-	pingTreeCmd.Flags().StringVar(&treeCacheDMSG, "cfd", os.TempDir()+"/dmsg-clients.json", "DMSG clients cache file location")
+	pingTreeCmd.Flags().StringVar(&treeCacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)")
+	pingTreeCmd.Flags().StringVar(&treeCacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	pingTreeCmd.Flags().StringVar(&treeCacheDirDMSG, "cdd", cacheDirPath(dep.DmsgDiscovery), "DMSG cache dir (\"\" to disable)")
 	pingTreeCmd.Flags().IntVarP(&treeCacheAge, "cfa", "m", 5, "update cache files if older than n minutes")
-	pingTreeCmd.Flags().StringVar(&treeTPDURL, "tpdurl", deployment.Prod.TransportDiscovery, "transport discovery URL")
-	pingTreeCmd.Flags().StringVar(&treeUTURL, "uturl", deployment.Prod.UptimeTracker, "uptime tracker URL")
-	pingTreeCmd.Flags().StringVar(&treeDMSGURL, "dmsgurl", deployment.Prod.DmsgDiscovery, "DMSG discovery URL")
+	pingTreeCmd.Flags().StringVar(&treeTPDURL, "tpdurl", dep.TransportDiscovery, "transport discovery URL")
+	pingTreeCmd.Flags().StringVar(&treeUTURL, "uturl", dep.UptimeTracker, "uptime tracker URL")
+	pingTreeCmd.Flags().StringVar(&treeDMSGURL, "dmsgurl", dep.DmsgDiscovery, "DMSG discovery URL")
 	pingTreeCmd.Flags().BoolVarP(&treeOnlineOnly, "online", "g", false, "only ping visors marked online in UT")
 	pingTreeCmd.Flags().StringVarP(&treeOutput, "output", "O", "", "output base filename (writes .json file)")
 	pingTreeCmd.Flags().UintVar(&treeHops, "hops", 0, "exact hop level to ping (0 = all levels)")
@@ -125,6 +196,33 @@ var pingTreeCmd = &cobra.Command{
 	Use:   "tree",
 	Short: "Ping visors via transport routes (tree view)",
 	Run: func(cmd *cobra.Command, _ []string) {
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if treeTestEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("tpdurl") {
+				treeTPDURL = deployment.Test.TransportDiscovery
+			}
+			if !cmd.Flags().Changed("uturl") {
+				treeUTURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("dmsgurl") {
+				treeDMSGURL = deployment.Test.DmsgDiscovery
+			}
+			if !cmd.Flags().Changed("cdt") {
+				treeCacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
+			}
+			if !cmd.Flags().Changed("cdu") {
+				treeCacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+			if !cmd.Flags().Changed("cdd") {
+				treeCacheDirDMSG = cacheDirPath(deployment.Test.DmsgDiscovery)
+			}
+		}
+
+		// Build full URLs for cache file paths
+		tpdFullURL := treeTPDURL + "/all-transports"
+		utFullURL := treeUTURL + "/uptimes?v=v2"
+		dmsgFullURL := treeDMSGURL + "/dmsg-discovery/entries"
+
 		// Force pterm styling so tree output works even when redirected to file
 		pterm.EnableStyling()
 
@@ -135,9 +233,9 @@ var pingTreeCmd = &cobra.Command{
 		graphSetupTimeout = treeSetupTimeout
 		graphTries = treeTries
 		graphPcktSize = treePcktSize
-		graphCacheTPD = treeCacheTPD
-		graphCacheUT = treeCacheUT
-		graphCacheDMSG = treeCacheDMSG
+		graphCacheTPD = cacheFile(treeCacheDirTPD, tpdFullURL)
+		graphCacheUT = cacheFile(treeCacheDirUT, utFullURL)
+		graphCacheDMSG = cacheFile(treeCacheDirDMSG, dmsgFullURL)
 		graphCacheAge = treeCacheAge
 		graphTPDURL = treeTPDURL
 		graphUTURL = treeUTURL

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -2,11 +2,81 @@
 package clivpn
 
 import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/spf13/cobra"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 )
+
+// isTestEnv checks if test environment is enabled via SKYWIRETEST env var
+func isTestEnv() bool {
+	return os.Getenv("SKYWIRETEST") == "1"
+}
+
+// cacheDirPath returns a cache directory path based on the service URL host
+func cacheDirPath(serviceURL string) string {
+	u, err := url.Parse(serviceURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return filepath.Join(os.TempDir(), u.Host)
+}
+
+// cacheFile returns the full cache file path for a given URL.
+// If cacheDir is empty, returns "" (disables caching).
+// Creates the cache directory if it doesn't exist.
+// Generates simple, descriptive filenames (e.g., "vpn.json", "uptimes.json").
+func cacheFile(cacheDir, fullURL string) string {
+	if cacheDir == "" {
+		return ""
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return ""
+	}
+
+	// Create cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return ""
+	}
+
+	// Extract a simple, meaningful name from the URL
+	var name string
+
+	// Check for service type in query (e.g., ?type=vpn -> vpn.json)
+	if typeVal := u.Query().Get("type"); typeVal != "" {
+		name = typeVal
+	} else {
+		// Use the last path segment (e.g., /uptimes -> uptimes.json)
+		path := strings.TrimSuffix(u.Path, "/")
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			name = path[idx+1:]
+		} else {
+			name = strings.TrimPrefix(path, "/")
+		}
+	}
+
+	if name == "" {
+		name = "cache"
+	}
+
+	return filepath.Join(cacheDir, name+".json")
+}
+
+// getDeployment returns the appropriate deployment config based on test env
+func getDeployment() deployment.Services {
+	if isTestEnv() {
+		return deployment.Test
+	}
+	return deployment.Prod
+}
 
 var (
 	stateName        = "vpn-client"
@@ -14,8 +84,8 @@ var (
 	rawData          bool
 	sdURL            string
 	utURL            string
-	cacheFileSD      string
-	cacheFileUT      string
+	cacheDirSD       string
+	cacheDirUT       string
 	cacheFilesAge    int
 	noFilterOnline   bool
 	path             string
@@ -35,6 +105,7 @@ var (
 	useExternal      bool
 	existingTpOnly   bool
 	forceLocalRoutes bool
+	testEnv          bool
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -206,12 +206,16 @@ var (
 )
 
 func init() {
-	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", deployment.Prod.ServiceDiscovery, "service discovery url")
-	listCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
+	dep := getDeployment()
+	defaultTestEnv := isTestEnv()
+
+	listCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
+	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
+	listCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
 	listCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "pretty print json data")
 	listCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
-	listCmd.Flags().StringVar(&cacheFileSD, "cfs", os.TempDir()+"/vpnsd.json", "SD cache file location")
-	listCmd.Flags().StringVar(&cacheFileUT, "cfu", os.TempDir()+"/ut.json", "UT cache file location.")
+	listCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
+	listCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
 	listCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
 	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
@@ -226,10 +230,30 @@ func init() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache file location to \"\" to avoid using cache files\ndefault virtual port of servers: %v", serviceType, deployment.Prod.ServiceDiscovery, serviceType, deployment.Prod.ServiceDiscovery, serviceType, serverPort),
+	Long: fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache dir to \"\" to avoid using cache files\ndefault virtual port of servers: %v\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", serviceType, getDeployment().ServiceDiscovery, serviceType, getDeployment().ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
+		if testEnv && !isTestEnv() {
+			if !cmd.Flags().Changed("sdurl") {
+				sdURL = deployment.Test.ServiceDiscovery
+			}
+			if !cmd.Flags().Changed("uturl") {
+				utURL = deployment.Test.UptimeTracker
+			}
+			if !cmd.Flags().Changed("cds") {
+				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
+			}
+			if !cmd.Flags().Changed("cdu") {
+				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+			}
+		}
+
+		// Build full URLs
+		sdFullURL := sdURL + "/api/services?type=" + serviceType
+		utFullURL := utURL + "/uptimes?v=v2"
+
 		// --- Fetch SD ---
-		sds := internal.GetData(cacheFileSD, sdURL+"/api/services?type="+serviceType, cacheFilesAge)
+		sds := internal.GetData(cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
 		if rawData {
 			script.Echo(string(pretty.Color(pretty.Pretty([]byte(sds)), nil))).Stdout() //nolint:errcheck,gosec
 			return
@@ -301,7 +325,7 @@ var listCmd = &cobra.Command{
 
 		// --- Show only offline servers ---
 		if showOffline {
-			uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+			uts := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 
 			// Parse SD and UT data
 			var sdEntries []services.Service
@@ -445,7 +469,7 @@ var listCmd = &cobra.Command{
 		}
 
 		// --- Filtering by online status ---
-		uts := internal.GetData(cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+		uts := internal.GetData(cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
 
 		// Use Go-based filtering when minVersion or maxVersion is specified (jq can't do semver comparison)
 		if minVersion != "" || maxVersion != "" {

--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -131,6 +131,9 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 	r.Get("/metrics/visor/{pks}", api.getTransportMetricsByVisors)
 
 	r.Get("/uptimes", api.getUptimes)
+	r.Get("/version", api.getVersionStats)
+	r.Get("/versions", api.getVersions)
+	r.Get("/versions/{pks}", api.getVersionsByPKs)
 	r.Post("/statuses", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusGone)
 	})

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -502,4 +503,202 @@ func (api *API) getUptimes(w http.ResponseWriter, r *http.Request) {
 		api.log(r).WithError(err).Error("Error encoding uptimes")
 		api.writeError(w, r, err)
 	}
+}
+
+// GET /version - returns version statistics (count by version)
+// Query params: on=true|false|all|none (filter by online status)
+func (api *API) getVersionStats(w http.ResponseWriter, r *http.Request) {
+	uptimes := api.getUptimesFromCache()
+	if uptimes == nil {
+		uptimes = []store.VisorSummary{}
+	}
+
+	// Parse 'on' query parameter for online filtering
+	onParam := r.URL.Query().Get("on")
+
+	// Count versions
+	versionCounts := make(map[string]int)
+	for _, vs := range uptimes {
+		// Apply online filter
+		switch onParam {
+		case "true":
+			if !vs.Online {
+				continue
+			}
+		case "false":
+			if vs.Online {
+				continue
+			}
+		case "all":
+			// Include all
+		case "none", "":
+			// Default: include all (no filtering)
+		}
+
+		version := vs.Version
+		if version == "" {
+			version = "unknown"
+		}
+		versionCounts[version]++
+	}
+
+	if err := json.NewEncoder(w).Encode(versionCounts); err != nil {
+		api.log(r).WithError(err).Error("Error encoding version stats")
+		api.writeError(w, r, err)
+	}
+}
+
+// VersionEntry is a response entry for version endpoints
+type VersionEntry struct {
+	PK      string `json:"pk"`
+	Version string `json:"version"`
+	Online  *bool  `json:"on,omitempty"` // Only included if status=true
+}
+
+// GET /versions - returns all PKs with their versions
+// Query params:
+//   - on=true|false|all|none (filter by online status)
+//   - status=true (include online status in response)
+func (api *API) getVersions(w http.ResponseWriter, r *http.Request) {
+	uptimes := api.getUptimesFromCache()
+	if uptimes == nil {
+		uptimes = []store.VisorSummary{}
+	}
+
+	// Parse query parameters
+	onParam := r.URL.Query().Get("on")
+	includeStatus := r.URL.Query().Get("status") == "true"
+
+	var result []VersionEntry
+	for _, vs := range uptimes {
+		// Apply online filter
+		switch onParam {
+		case "true":
+			if !vs.Online {
+				continue
+			}
+		case "false":
+			if vs.Online {
+				continue
+			}
+		case "all":
+			// Include all
+		case "none", "":
+			// Default: include all (no filtering)
+		}
+
+		entry := VersionEntry{
+			PK:      vs.PK.Hex(),
+			Version: vs.Version,
+		}
+		if includeStatus {
+			online := vs.Online
+			entry.Online = &online
+		}
+		result = append(result, entry)
+	}
+
+	if result == nil {
+		result = []VersionEntry{}
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		api.log(r).WithError(err).Error("Error encoding versions")
+		api.writeError(w, r, err)
+	}
+}
+
+// GET /versions/{pks} - returns versions for specific PKs (comma-separated)
+// Query params:
+//   - on=true|false|all|none (filter by online status)
+//   - status=true (include online status in response)
+func (api *API) getVersionsByPKs(w http.ResponseWriter, r *http.Request) {
+	pksParam := chi.URLParam(r, "pks")
+	if pksParam == "" {
+		api.writeError(w, r, ErrEmptyPubKey)
+		return
+	}
+
+	uptimes := api.getUptimesFromCache()
+	if uptimes == nil {
+		uptimes = []store.VisorSummary{}
+	}
+
+	// Build a map for quick lookup
+	uptimeMap := make(map[string]store.VisorSummary)
+	for _, vs := range uptimes {
+		uptimeMap[vs.PK.Hex()] = vs
+	}
+
+	// Parse query parameters
+	onParam := r.URL.Query().Get("on")
+	includeStatus := r.URL.Query().Get("status") == "true"
+
+	// Parse the comma-separated PKs
+	pkStrings := splitPKs(pksParam)
+
+	var result []VersionEntry
+	for _, pkStr := range pkStrings {
+		vs, found := uptimeMap[pkStr]
+		if !found {
+			// Include entry with empty version if not found
+			entry := VersionEntry{
+				PK:      pkStr,
+				Version: "",
+			}
+			if includeStatus {
+				online := false
+				entry.Online = &online
+			}
+			result = append(result, entry)
+			continue
+		}
+
+		// Apply online filter
+		switch onParam {
+		case "true":
+			if !vs.Online {
+				continue
+			}
+		case "false":
+			if vs.Online {
+				continue
+			}
+		case "all":
+			// Include all
+		case "none", "":
+			// Default: include all (no filtering)
+		}
+
+		entry := VersionEntry{
+			PK:      vs.PK.Hex(),
+			Version: vs.Version,
+		}
+		if includeStatus {
+			online := vs.Online
+			entry.Online = &online
+		}
+		result = append(result, entry)
+	}
+
+	if result == nil {
+		result = []VersionEntry{}
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		api.log(r).WithError(err).Error("Error encoding versions")
+		api.writeError(w, r, err)
+	}
+}
+
+// splitPKs splits a comma-separated list of public keys
+func splitPKs(pks string) []string {
+	var result []string
+	for _, pk := range strings.Split(pks, ",") {
+		pk = strings.TrimSpace(pk)
+		if pk != "" {
+			result = append(result, pk)
+		}
+	}
+	return result
 }

--- a/pkg/transport-discovery/store/memory_store.go
+++ b/pkg/transport-discovery/store/memory_store.go
@@ -252,7 +252,7 @@ func (s *memoryStore) buildTransportMetrics(entries []*transport.Entry, query Me
 			ID:    entry.ID.String(),
 			Type:  string(entry.Type),
 			Live:  true, // All in-memory transports are considered live
-			Daily: []DailyEdgeMetric{},
+			Daily: []DailyEdgeBandwidth{},
 		}
 
 		if query.Edges {

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -26,14 +26,16 @@ const (
 
 // TransportData stores transport entry with additional metadata.
 type TransportData struct {
-	ID         string  `json:"id"`
-	EdgeA      string  `json:"edge_a"`
-	EdgeB      string  `json:"edge_b"`
-	Type       string  `json:"type"`
-	Label      string  `json:"label"`
-	Latency    float64 `json:"latency"`     // Inter-visor ping latency in milliseconds
-	Bandwidth  uint64  `json:"bandwidth"`   // Total bytes (sent + recv)
-	LastUpdate int64   `json:"last_update"` // Unix timestamp of last update
+	ID         string `json:"id"`
+	EdgeA      string `json:"edge_a"`
+	EdgeB      string `json:"edge_b"`
+	Type       string `json:"type"`
+	Label      string `json:"label"`
+	LatencyMin int64  `json:"lat_min"`     // Minimum latency in microseconds
+	LatencyMax int64  `json:"lat_max"`     // Maximum latency in microseconds
+	LatencyAvg int64  `json:"lat_avg"`     // Average latency in microseconds
+	Bandwidth  uint64 `json:"bandwidth"`   // Total bytes (sent + recv)
+	LastUpdate int64  `json:"last_update"` // Unix timestamp of last update
 }
 
 type redisStore struct {
@@ -77,11 +79,6 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 }
 
 func (s *redisStore) RegisterTransport(ctx context.Context, sEntry *transport.SignedEntry) error {
-	return s.RegisterTransportWithLatency(ctx, sEntry, sEntry.Latency)
-}
-
-// RegisterTransportWithLatency registers transport with latency value.
-func (s *redisStore) RegisterTransportWithLatency(ctx context.Context, sEntry *transport.SignedEntry, latency float64) error {
 	entry := sEntry.Entry
 	if entry == nil {
 		return ErrBadEntry
@@ -96,8 +93,14 @@ func (s *redisStore) RegisterTransportWithLatency(ctx context.Context, sEntry *t
 		EdgeB:      entry.Edges[1].Hex(),
 		Type:       string(entry.Type),
 		Label:      string(entry.Label),
-		Latency:    latency,
 		LastUpdate: now.Unix(),
+	}
+
+	// Handle latency if provided
+	if sEntry.Latency != nil {
+		data.LatencyMin = sEntry.Latency.Min
+		data.LatencyMax = sEntry.Latency.Max
+		data.LatencyAvg = sEntry.Latency.Avg
 	}
 
 	// Handle bandwidth if provided
@@ -360,7 +363,8 @@ func (s *redisStore) dataToEntry(data TransportData) (*transport.Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entry.Latency = data.Latency
+	// Convert latency from microseconds to milliseconds for backwards compatibility
+	entry.Latency = float64(data.LatencyAvg) / 1000.0
 	entry.Bandwidth = data.Bandwidth
 	return entry, nil
 }
@@ -876,62 +880,55 @@ func (s *redisStore) buildTransportMetrics(ctx context.Context, entries []*trans
 			ID:    entry.ID.String(),
 			Type:  string(entry.Type),
 			Live:  isLive,
-			Daily: make([]DailyEdgeMetric, 0, days),
+			Daily: make([]DailyEdgeBandwidth, 0, days),
 		}
 
 		if query.Edges {
 			metric.Edges = []string{entry.Edges[0].Hex(), entry.Edges[1].Hex()}
 		}
 
-		// Get daily metrics
-		for d := 0; d < days; d++ {
-			t := now.AddDate(0, 0, -d)
-			dateStr := t.Format("2006-01-02")
-
-			dailyMetric := DailyEdgeMetric{Date: dateStr}
-
-			// Get bandwidth for this transport on this day
-			key := s.bandwidthDailyKey(entry.ID.String(), t)
-			bwResult, err := s.client.HGetAll(ctx, key).Result()
-			if err == nil && len(bwResult) > 0 {
-				var bw uint64
-				if val, ok := bwResult["bandwidth"]; ok {
-					fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
-				}
-
-				if bw > 0 {
-					// Split bandwidth between edges (estimate)
-					halfBW := bw / 2
-
-					if query.Bandwidth && query.Latency {
-						dailyMetric.A = &EdgeMetricFull{
-							Bandwidth: &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
-							Latency:   &EdgeLatency{AvgMs: entry.Latency, MinMs: entry.Latency, MaxMs: entry.Latency},
-						}
-						dailyMetric.B = &EdgeMetricFull{
-							Bandwidth: &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
-							Latency:   &EdgeLatency{AvgMs: entry.Latency, MinMs: entry.Latency, MaxMs: entry.Latency},
-						}
-					} else if query.Bandwidth {
-						dailyMetric.A = &EdgeMetricFull{
-							Bandwidth: &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
-						}
-						dailyMetric.B = &EdgeMetricFull{
-							Bandwidth: &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
-						}
-					} else if query.Latency && entry.Latency > 0 {
-						dailyMetric.A = &EdgeMetricFull{
-							Latency: &EdgeLatency{AvgMs: entry.Latency, MinMs: entry.Latency, MaxMs: entry.Latency},
-						}
-						dailyMetric.B = &EdgeMetricFull{
-							Latency: &EdgeLatency{AvgMs: entry.Latency, MinMs: entry.Latency, MaxMs: entry.Latency},
-						}
+		// Get transport data from Redis to retrieve latency
+		if query.Latency {
+			tpKey := s.transportKey(entry.ID)
+			dataJSON, err := s.client.Get(ctx, tpKey).Result()
+			if err == nil {
+				var data TransportData
+				if json.Unmarshal([]byte(dataJSON), &data) == nil && data.LatencyAvg > 0 {
+					metric.Latency = &TransportLatency{
+						Min: data.LatencyMin,
+						Max: data.LatencyMax,
+						Avg: data.LatencyAvg,
 					}
 				}
 			}
+		}
 
-			if dailyMetric.A != nil || dailyMetric.B != nil {
-				metric.Daily = append(metric.Daily, dailyMetric)
+		// Get daily bandwidth metrics
+		if query.Bandwidth {
+			for d := 0; d < days; d++ {
+				t := now.AddDate(0, 0, -d)
+				dateStr := t.Format("2006-01-02")
+
+				// Get bandwidth for this transport on this day
+				key := s.bandwidthDailyKey(entry.ID.String(), t)
+				bwResult, err := s.client.HGetAll(ctx, key).Result()
+				if err == nil && len(bwResult) > 0 {
+					var bw uint64
+					if val, ok := bwResult["bandwidth"]; ok {
+						fmt.Sscanf(val, "%d", &bw) //nolint:errcheck,gosec
+					}
+
+					if bw > 0 {
+						// Split bandwidth between edges (estimate)
+						halfBW := bw / 2
+						dailyMetric := DailyEdgeBandwidth{
+							Date: dateStr,
+							A:    &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
+							B:    &EdgeBandwidth{Sent: halfBW, Recv: halfBW},
+						}
+						metric.Daily = append(metric.Daily, dailyMetric)
+					}
+				}
 			}
 		}
 

--- a/pkg/transport-discovery/store/store.go
+++ b/pkg/transport-discovery/store/store.go
@@ -62,33 +62,30 @@ type EdgeBandwidth struct {
 	Recv uint64 `json:"recv"` // Cumulative bytes received
 }
 
-// EdgeLatency contains latency data from one edge's perspective.
-type EdgeLatency struct {
-	AvgMs float64 `json:"avg_ms"` // Average latency in milliseconds
-	MinMs float64 `json:"min_ms"` // Minimum observed latency
-	MaxMs float64 `json:"max_ms"` // Maximum observed latency
+// TransportLatency contains latency statistics for a transport in microseconds.
+// Latency is at the transport level (not per-edge) since it's round-trip.
+type TransportLatency struct {
+	Min int64 `json:"min"` // Minimum observed latency in microseconds
+	Max int64 `json:"max"` // Maximum observed latency in microseconds
+	Avg int64 `json:"avg"` // Average latency in microseconds
 }
 
-// EdgeMetricFull contains combined bandwidth and latency for one edge.
-type EdgeMetricFull struct {
-	Bandwidth *EdgeBandwidth `json:"bandwidth,omitempty"`
-	Latency   *EdgeLatency   `json:"latency,omitempty"`
+// DailyEdgeBandwidth contains per-day bandwidth with edge A and B data.
+type DailyEdgeBandwidth struct {
+	Date string         `json:"date"`
+	A    *EdgeBandwidth `json:"a,omitempty"`
+	B    *EdgeBandwidth `json:"b,omitempty"`
 }
 
-// DailyEdgeMetric contains per-day metrics with edge A and B data.
-type DailyEdgeMetric struct {
-	Date string          `json:"date"`
-	A    *EdgeMetricFull `json:"a,omitempty"`
-	B    *EdgeMetricFull `json:"b,omitempty"`
-}
-
-// TransportMetric contains per-transport metrics with daily breakdowns.
+// TransportMetric contains per-transport metrics with latency at transport level
+// and daily bandwidth breakdowns per edge.
 type TransportMetric struct {
-	ID    string            `json:"id"`
-	Type  string            `json:"type"`
-	Live  bool              `json:"live"`
-	Edges []string          `json:"edges,omitempty"` // Only included if query.Edges=true
-	Daily []DailyEdgeMetric `json:"daily"`
+	ID      string               `json:"id"`
+	Type    string               `json:"type"`
+	Live    bool                 `json:"live"`
+	Edges   []string             `json:"edges,omitempty"`   // Only included if query.Edges=true
+	Latency *TransportLatency    `json:"latency,omitempty"` // Transport-level latency stats
+	Daily   []DailyEdgeBandwidth `json:"daily"`             // Per-day bandwidth by edge
 }
 
 // TypeMetricAggregate contains aggregate metrics for a transport type.

--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -145,6 +145,7 @@ type SignedEntry struct {
 	Registered int64          `json:"registered,omitempty"`
 	Latency    float64        `json:"latency_ms,omitempty"` // Inter-visor latency in milliseconds, measured via ping/pong
 	Bandwidth  *BandwidthData `json:"bandwidth,omitempty"`  // Cumulative bandwidth data
+	Version    string         `json:"version,omitempty"`    // Visor version reporting this entry
 }
 
 // Sign sets Signature for a given PubKey in correct position

--- a/pkg/transport/entry.go
+++ b/pkg/transport/entry.go
@@ -137,15 +137,22 @@ type BandwidthData struct {
 	RecvBytes uint64 `json:"recv_bytes"` // Total bytes received (cumulative)
 }
 
+// LatencyData represents latency statistics for a transport in microseconds
+type LatencyData struct {
+	Min int64 `json:"min"` // Minimum observed latency in microseconds
+	Max int64 `json:"max"` // Maximum observed latency in microseconds
+	Avg int64 `json:"avg"` // Average latency in microseconds
+}
+
 // SignedEntry holds an Entry and it's associated signatures.
 // The signatures should be ordered as the contained 'Entry.Edges'.
 type SignedEntry struct {
 	Entry      *Entry         `json:"entry"`
 	Signatures [2]cipher.Sig  `json:"signatures"`
 	Registered int64          `json:"registered,omitempty"`
-	Latency    float64        `json:"latency_ms,omitempty"` // Inter-visor latency in milliseconds, measured via ping/pong
-	Bandwidth  *BandwidthData `json:"bandwidth,omitempty"`  // Cumulative bandwidth data
-	Version    string         `json:"version,omitempty"`    // Visor version reporting this entry
+	Latency    *LatencyData   `json:"latency,omitempty"`   // Latency statistics in microseconds
+	Bandwidth  *BandwidthData `json:"bandwidth,omitempty"` // Cumulative bandwidth data
+	Version    string         `json:"version,omitempty"`   // Visor version reporting this entry
 }
 
 // Sign sets Signature for a given PubKey in correct position

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -177,10 +177,20 @@ func (tm *Manager) reRegisterTransports(ctx context.Context) {
 		if tp.IsClosed() {
 			continue
 		}
-		// Create signed entry for re-registration with previous latency, current bandwidth, and version
+		// Create signed entry for re-registration with latency stats, current bandwidth, and version
+		stats := tp.GetLatencyStats()
+		var latencyData *LatencyData
+		if stats.Avg > 0 {
+			// Convert milliseconds to microseconds
+			latencyData = &LatencyData{
+				Min: int64(stats.Min * 1000),
+				Max: int64(stats.Max * 1000),
+				Avg: int64(stats.Avg * 1000),
+			}
+		}
 		se := &SignedEntry{
 			Entry:     &tp.Entry,
-			Latency:   tp.GetLatency(),
+			Latency:   latencyData,
 			Bandwidth: tp.GetBandwidth(),
 			Version:   tm.Conf.Version,
 		}

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -41,6 +41,7 @@ type ManagerConfig struct {
 	LatencyLogStore           LatencyLogStore
 	PersistentTransportsCache []PersistentTransports
 	PTpsCacheMu               sync.RWMutex
+	Version                   string // Visor version for reporting to TPD
 }
 
 // TransportCreatedCallback is called after a transport is successfully created.
@@ -176,11 +177,12 @@ func (tm *Manager) reRegisterTransports(ctx context.Context) {
 		if tp.IsClosed() {
 			continue
 		}
-		// Create signed entry for re-registration with previous latency and current bandwidth
+		// Create signed entry for re-registration with previous latency, current bandwidth, and version
 		se := &SignedEntry{
 			Entry:     &tp.Entry,
 			Latency:   tp.GetLatency(),
 			Bandwidth: tp.GetBandwidth(),
+			Version:   tm.Conf.Version,
 		}
 		entries = append(entries, se)
 	}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -48,6 +48,7 @@ import (
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
@@ -735,6 +736,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		LogStore:                  logS,
 		LatencyLogStore:           latencyLogS,
 		PersistentTransportsCache: pTps,
+		Version:                   buildinfo.Version(),
 	}
 
 	// todo: pass down configuration?

--- a/skywire-specs/specifications/04-Transport_Discovery.md
+++ b/skywire-specs/specifications/04-Transport_Discovery.md
@@ -141,6 +141,9 @@ The following endpoints are implemented in the Transport Discovery service. See 
 - `GET /all-transports/stats` - Get aggregate statistics
 - `GET /all-transports/per-key-stats` - Get per-visor statistics
 - `GET /uptimes` - Get visor uptime data
+- `GET /version` - Network-wide version statistics (count by version)
+- `GET /versions` - All visor PKs with versions (supports `on`, `status` params)
+- `GET /versions/{pks}` - Versions for specific PKs (supports `status` param)
 - `GET /metric` - Network-wide aggregate stats (supports `bandwidth`, `latency` params)
 - `GET /metric/visor/{pks}` - Visor aggregate stats (accepts comma-separated PKs)
 - `GET /metrics` - Per-transport metrics (supports `bandwidth`, `latency` params)
@@ -607,6 +610,168 @@ GET /uptimes
 | `on` | boolean | Current online status |
 | `version` | string | Skywire version running on the visor |
 | `daily` | object | Map of date (YYYY-MM-DD) to uptime percentage |
+
+---
+
+## Version Endpoints
+
+The Transport Discovery tracks visor versions as part of uptime registration. These endpoints provide access to version information for network analysis and compatibility checking.
+
+### GET /version
+
+Returns network-wide version statistics - a count of visors grouped by version.
+
+**Request:**
+
+```
+GET /version
+```
+
+**Response:**
+
+- 200 OK (Success).
+    ```json
+    {
+        "v1.3.34": 150,
+        "v1.3.33": 85,
+        "v1.3.32": 23,
+        "v1.3.31": 12
+    }
+    ```
+
+**Response Fields:**
+
+The response is a map where each key is a version string and the value is the count of visors running that version.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `{version}` | integer | Number of visors running this version |
+
+---
+
+### GET /versions
+
+Returns all visor public keys with their versions.
+
+**Request:**
+
+```
+GET /versions
+GET /versions?on=true
+GET /versions?status=true
+GET /versions?on=true&status=true
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `on` | string | `none` | Filter by online status: `true` (online only), `false` (offline only), `all` (no filter), `none` (no filter) |
+| `status` | boolean | false | Include `"on"` field in response showing online status |
+
+**Response (default, no status field):**
+
+- 200 OK (Success).
+    ```json
+    {
+        "<public-key-1>": "v1.3.34",
+        "<public-key-2>": "v1.3.33",
+        "<public-key-3>": "v1.3.34"
+    }
+    ```
+
+**Response (with `status=true`):**
+
+- 200 OK (Success).
+    ```json
+    {
+        "<public-key-1>": { "version": "v1.3.34", "on": true },
+        "<public-key-2>": { "version": "v1.3.33", "on": false },
+        "<public-key-3>": { "version": "v1.3.34", "on": true }
+    }
+    ```
+
+**Response Fields (default):**
+
+The response is a map where each key is a visor public key and the value is the version string.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `{pk}` | string | Version string for this visor |
+
+**Response Fields (with `status=true`):**
+
+The response is a map where each key is a visor public key and the value is an object.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Skywire version running on the visor |
+| `on` | boolean | Current online status |
+
+**Examples:**
+
+| Request | Description |
+|---------|-------------|
+| `/versions` | All PKs with versions, no online status field |
+| `/versions?on=true` | Only online PKs with versions, no online status field |
+| `/versions?on=false` | Only offline PKs with versions, no online status field |
+| `/versions?status=true` | All PKs with versions AND online status field |
+| `/versions?on=true&status=true` | Only online PKs with versions AND online status field |
+| `/versions?on=all&status=true` | All PKs with versions AND online status field (same as `status=true` alone) |
+
+---
+
+### GET /versions/{pks}
+
+Returns versions for specific visor public keys. Accepts comma-separated PKs.
+
+**Request:**
+
+```
+GET /versions/{pk}
+GET /versions/{pk1},{pk2},{pk3}
+GET /versions/{pks}?status=true
+```
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pks` | string | One or more visor public keys, comma-separated |
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `status` | boolean | false | Include `"on"` field in response showing online status |
+
+**Note:** The `on` filter parameter is not applicable to this endpoint since specific PKs are requested.
+
+**Response (default):**
+
+- 200 OK (Success).
+    ```json
+    {
+        "<public-key-1>": "v1.3.34",
+        "<public-key-2>": "v1.3.33"
+    }
+    ```
+
+**Response (with `status=true`):**
+
+- 200 OK (Success).
+    ```json
+    {
+        "<public-key-1>": { "version": "v1.3.34", "on": true },
+        "<public-key-2>": { "version": "v1.3.33", "on": false }
+    }
+    ```
+
+**Error Responses:**
+
+- 400 Bad Request (Invalid public key format).
+- 404 Not Found (None of the specified PKs found).
+- 500 Internal Server Error (Server error).
 
 ---
 
@@ -1240,6 +1405,9 @@ GET /health
 | `/all-transports/stats` | GET | No | Get aggregate stats |
 | `/all-transports/per-key-stats` | GET | No | Get per-visor stats |
 | `/uptimes` | GET | No | Get visor uptimes |
+| `/version` | GET | No | Network-wide version statistics |
+| `/versions` | GET | No | All visor PKs with versions |
+| `/versions/{pks}` | GET | No | Versions for specific PKs |
 | `/health` | GET | No | Health check |
 
 ### Metrics Endpoints


### PR DESCRIPTION
* Add SKYWIRETEST=1 environment variable support to switch to test deployment. When set, all default flag values change to test URLs and the help menu reflects these changes. Flags can be set on command invocation to further modify defaults.

* Add --testenv flag to switch to test deployment for cli commands at runtime. **Only overrides values not explicitly set by the user**

* Change cache structure to use directories named after service hosts (e.g., `/tmp/sd.skycoin.com/`) with endpoint-derived filenames (e.g., `visor.json`). This prevents cache conflicts between deployments and allows multiple endpoints per service.

- Rename cache flags from --cfs/--cfu/--cft to --cds/--cdu/--cdt to reflect that they now specify directories, not files.

- Preserve ability to disable caching with --cds "" etc.

