### PR TITLE
Use go install in Dockerfile for proper version info

### DIFF
--- a/docker/images/skywire/Dockerfile
+++ b/docker/images/skywire/Dockerfile
@@ -2,24 +2,24 @@
 ARG base_image
 ARG image_tag
 FROM ${base_image} AS builder
-ARG build_opts
 ARG image_tag
 
-ARG BUILDINFO_LDFLAGS
 ARG CGO_ENABLED=0
 ENV CGO_ENABLED=${CGO_ENABLED} \
     GOOS=linux  \
-    GO111MODULE=on
+    GO111MODULE=on \
+    GOBIN=/release
 
 COPY . /skywire
 WORKDIR /skywire
 
-# Build with or without race detector
+# Build using go install to get proper version info from runtime/debug.ReadBuildInfo()
+# The -w -s flags strip debug info to reduce binary size
 RUN if [ "$image_tag" = "integration" ]; then \
         apk add --no-cache build-base && \
-        CGO_ENABLED=1 go build "${build_opts}" -race -o /release/skywire ./cmd/skywire; \
+        CGO_ENABLED=1 go install -ldflags="-w -s" -race ./cmd/skywire; \
     else \
-        go build "${build_opts}" -o /release/skywire ./cmd/skywire; \
+        go install -ldflags="-w -s" ./cmd/skywire; \
     fi
 
 ## Resulting image


### PR DESCRIPTION
- Replace go build with go install to get full version from runtime/debug.ReadBuildInfo() (includes timestamp and commit hash)
- Set GOBIN=/release so binary is installed to correct location
- Remove unused build_opts ARG since version is now automatic
- Keep -w -s ldflags to strip debug info and reduce binary size
