### PR TITLE
Include .git in Docker build for automatic version embedding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ ci_scripts
 apps
 integration
 skywrie-services
-.git
 .gitignore
 .github
 .vscode

--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -54,7 +54,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -378,7 +378,7 @@ func init() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long: fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache dir to \"\" to avoid using cache files\ndefault virtual port of servers: %v\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", serviceType, getDeployment().ServiceDiscovery, serviceType, getDeployment().ServiceDiscovery, serviceType, serverPort),
+	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache dir to \"\" to avoid using cache files\ndefault virtual port of servers: %v\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", serviceType, getDeployment().ServiceDiscovery, serviceType, getDeployment().ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
 		if testEnv && !isTestEnv() {

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -43,7 +43,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 

--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -68,7 +68,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 

--- a/cmd/skywire-cli/commands/sd/root.go
+++ b/cmd/skywire-cli/commands/sd/root.go
@@ -49,7 +49,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -47,7 +47,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 
@@ -128,7 +128,7 @@ func init() {
 var utCmd = &cobra.Command{
 	Use:   "ut",
 	Short: "query uptime tracker",
-	Long: fmt.Sprintf("query uptime tracker\n\n%v/uptimes?v=v2\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache dir to \"\" to avoid using cache files\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", getDeployment().UptimeTracker),
+	Long:  fmt.Sprintf("query uptime tracker\n\n%v/uptimes?v=v2\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache dir to \"\" to avoid using cache files\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", getDeployment().UptimeTracker),
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
 		if testEnv && !isTestEnv() {

--- a/cmd/skywire-cli/commands/visor/ping/tree.go
+++ b/cmd/skywire-cli/commands/visor/ping/tree.go
@@ -52,7 +52,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -43,7 +43,7 @@ func cacheFile(cacheDir, fullURL string) string {
 	}
 
 	// Create cache directory if it doesn't exist
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0750); err != nil {
 		return ""
 	}
 

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -230,7 +230,7 @@ func init() {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List servers",
-	Long: fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache dir to \"\" to avoid using cache files\ndefault virtual port of servers: %v\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", serviceType, getDeployment().ServiceDiscovery, serviceType, getDeployment().ServiceDiscovery, serviceType, serverPort),
+	Long:  fmt.Sprintf("List %v servers from service discovery\n%v/api/services?type=%v\n%v/api/services?type=%v&country=US\n\nSet cache dir to \"\" to avoid using cache files\ndefault virtual port of servers: %v\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", serviceType, getDeployment().ServiceDiscovery, serviceType, getDeployment().ServiceDiscovery, serviceType, serverPort),
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
 		if testEnv && !isTestEnv() {

--- a/pkg/tpviz/wasm/ui/app.go
+++ b/pkg/tpviz/wasm/ui/app.go
@@ -101,12 +101,12 @@ type App struct {
 	globeActive   bool
 
 	// Pick modes (matching TypeScript state.ts)
-	pingPickMode        bool
-	localTpPickMode     bool
-	tpsPickMode         string // "target" or "remote"
-	tpsGroupPickMode    string // "target" or "remote" for group mode
-	dmsgHealthPickMode  bool
-	mhPickMode          bool
+	pingPickMode       bool
+	localTpPickMode    bool
+	tpsPickMode        string // "target" or "remote"
+	tpsGroupPickMode   string // "target" or "remote" for group mode
+	dmsgHealthPickMode bool
+	mhPickMode         bool
 
 	// TPS state
 	tpsTargetPK string

--- a/pkg/tpviz/wasm/ui/fetch.go
+++ b/pkg/tpviz/wasm/ui/fetch.go
@@ -104,7 +104,7 @@ type AppState struct {
 
 // PingResponse represents the /api/ping response (matching TypeScript types.ts PingResponse)
 type PingResponse struct {
-	Status     string    `json:"status"`      // "success", "timeout", "error"
+	Status     string    `json:"status"` // "success", "timeout", "error"
 	Error      string    `json:"error,omitempty"`
 	Mode       string    `json:"mode,omitempty"`
 	Latencies  []float64 `json:"latencies,omitempty"`

--- a/pkg/tpviz/wasm/ui/globe.go
+++ b/pkg/tpviz/wasm/ui/globe.go
@@ -25,10 +25,10 @@ type GlobeRenderer struct {
 	nodePos3D map[string]Vec3
 
 	// Earth texture
-	earthImage   js.Value
-	earthLoaded  bool
-	earthCanvas  js.Value // Offscreen canvas for texture rendering
-	earthCtx     js.Value
+	earthImage  js.Value
+	earthLoaded bool
+	earthCanvas js.Value // Offscreen canvas for texture rendering
+	earthCtx    js.Value
 }
 
 // GlobeRotation holds the current rotation angles
@@ -87,22 +87,22 @@ var countryCoords = map[string]CountryCoord{
 	"CO": {4.5709, -74.2973},
 	"PE": {-9.1900, -75.0152},
 	"VE": {6.4238, -66.5897},
-	"UY": {-32.5228, -55.7658},  // Uruguay
-	"PY": {-23.4425, -58.4438},  // Paraguay
-	"BO": {-16.2902, -63.5887},  // Bolivia
-	"EC": {-1.8312, -78.1834},   // Ecuador
-	"PA": {8.5380, -80.7821},    // Panama
-	"CR": {9.7489, -83.7534},    // Costa Rica
-	"NI": {12.8654, -85.2072},   // Nicaragua
-	"HN": {15.2, -86.2419},      // Honduras
-	"SV": {13.7942, -88.8965},   // El Salvador
-	"GT": {15.7835, -90.2308},   // Guatemala
-	"BZ": {17.1899, -88.4976},   // Belize
-	"CU": {21.5218, -77.7812},   // Cuba
-	"DO": {18.7357, -70.1627},   // Dominican Republic
-	"JM": {18.1096, -77.2975},   // Jamaica
-	"PR": {18.2208, -66.5901},   // Puerto Rico
-	"TT": {10.6918, -61.2225},   // Trinidad and Tobago
+	"UY": {-32.5228, -55.7658}, // Uruguay
+	"PY": {-23.4425, -58.4438}, // Paraguay
+	"BO": {-16.2902, -63.5887}, // Bolivia
+	"EC": {-1.8312, -78.1834},  // Ecuador
+	"PA": {8.5380, -80.7821},   // Panama
+	"CR": {9.7489, -83.7534},   // Costa Rica
+	"NI": {12.8654, -85.2072},  // Nicaragua
+	"HN": {15.2, -86.2419},     // Honduras
+	"SV": {13.7942, -88.8965},  // El Salvador
+	"GT": {15.7835, -90.2308},  // Guatemala
+	"BZ": {17.1899, -88.4976},  // Belize
+	"CU": {21.5218, -77.7812},  // Cuba
+	"DO": {18.7357, -70.1627},  // Dominican Republic
+	"JM": {18.1096, -77.2975},  // Jamaica
+	"PR": {18.2208, -66.5901},  // Puerto Rico
+	"TT": {10.6918, -61.2225},  // Trinidad and Tobago
 	"GB": {55.3781, -3.4360},
 	"DE": {51.1657, 10.4515},
 	"FR": {46.2276, 2.2137},
@@ -157,23 +157,23 @@ var countryCoords = map[string]CountryCoord{
 	"EG": {26.8206, 30.8025},
 	"NG": {9.0820, 8.6753},
 	"KE": {-0.0236, 37.9062},
-	"MA": {31.7917, -7.0926},  // Morocco
-	"DZ": {28.0339, 1.6596},   // Algeria
-	"TN": {33.8869, 9.5375},   // Tunisia
-	"GH": {7.9465, -1.0232},   // Ghana
-	"TZ": {-6.3690, 34.8888},  // Tanzania
-	"ET": {9.1450, 40.4897},   // Ethiopia
+	"MA": {31.7917, -7.0926}, // Morocco
+	"DZ": {28.0339, 1.6596},  // Algeria
+	"TN": {33.8869, 9.5375},  // Tunisia
+	"GH": {7.9465, -1.0232},  // Ghana
+	"TZ": {-6.3690, 34.8888}, // Tanzania
+	"ET": {9.1450, 40.4897},  // Ethiopia
 	"IL": {31.0461, 34.8516},
 	"AE": {23.4241, 53.8478},
 	"SA": {23.8859, 45.0792},
 	"IR": {32.4279, 53.6880},
-	"IQ": {33.2232, 43.6793},  // Iraq
-	"JO": {30.5852, 36.2384},  // Jordan
-	"LB": {33.8547, 35.8623},  // Lebanon
-	"KW": {29.3117, 47.4818},  // Kuwait
-	"QA": {25.3548, 51.1839},  // Qatar
-	"OM": {21.4735, 55.9754},  // Oman
-	"BH": {26.0667, 50.5577},  // Bahrain
+	"IQ": {33.2232, 43.6793}, // Iraq
+	"JO": {30.5852, 36.2384}, // Jordan
+	"LB": {33.8547, 35.8623}, // Lebanon
+	"KW": {29.3117, 47.4818}, // Kuwait
+	"QA": {25.3548, 51.1839}, // Qatar
+	"OM": {21.4735, 55.9754}, // Oman
+	"BH": {26.0667, 50.5577}, // Bahrain
 	"PK": {30.3753, 69.3451},
 	"BD": {23.6850, 90.3563},
 	"HK": {22.3193, 114.1694},
@@ -545,8 +545,8 @@ func (g *GlobeRenderer) drawGrid(radius, scale float64) {
 
 // drawContinents draws filled continent shapes
 func (g *GlobeRenderer) drawContinents(radius, scale float64) {
-	landColor := "rgba(34, 85, 51, 0.8)"      // Dark green for land
-	outlineColor := "rgba(0, 217, 165, 0.6)"  // Teal outline
+	landColor := "rgba(34, 85, 51, 0.8)"     // Dark green for land
+	outlineColor := "rgba(0, 217, 165, 0.6)" // Teal outline
 
 	for _, outline := range continentOutlines {
 		points := make([]Point, 0, len(outline))
@@ -863,7 +863,7 @@ func (g *GlobeRenderer) drawNodes(radius, scale float64) {
 			// Project directly to screen without rotation (XZ plane, Y=0)
 			sx = centerX + pos3D.X*scale
 			sy = centerY - pos3D.Z*scale // Z becomes Y on screen
-			visible = true                // Satellites are always visible
+			visible = true               // Satellites are always visible
 		} else {
 			// Use geo position in geographic mode
 			pos, ok := g.nodeGeoPos[node.ID]

--- a/pkg/tpviz/wasm/ui/render.go
+++ b/pkg/tpviz/wasm/ui/render.go
@@ -2,7 +2,9 @@
 
 package ui
 
-import "strings"
+import (
+	"strings"
+)
 
 // draw renders the entire scene
 func (a *App) draw() {

--- a/pkg/visnetwork/physics/engine.go
+++ b/pkg/visnetwork/physics/engine.go
@@ -1,6 +1,8 @@
 package physics
 
-import "math"
+import (
+	"math"
+)
 
 // PhysicsEngine orchestrates the physics simulation, combining
 // node repulsion (Barnes-Hut), edge springs, and central gravity

--- a/pkg/visnetwork/physics/gravity.go
+++ b/pkg/visnetwork/physics/gravity.go
@@ -1,6 +1,8 @@
 package physics
 
-import "math"
+import (
+	"math"
+)
 
 // CentralGravitySolver applies a force pulling all nodes toward the center
 // This prevents the graph from drifting off-screen

--- a/pkg/visnetwork/physics/spring.go
+++ b/pkg/visnetwork/physics/spring.go
@@ -1,6 +1,8 @@
 package physics
 
-import "math"
+import (
+	"math"
+)
 
 // SpringSolver calculates spring forces for edges, pulling connected
 // nodes toward their ideal edge length


### PR DESCRIPTION
Remove .git from .dockerignore so that go install can read VCS info and automatically embed version via runtime/debug.BuildInfo.

This allows proper versioning without manually specifying version via ldflags.
