### PR TITLE
Fix dmsgtracker fails to connect

### DIFF
--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -379,10 +379,6 @@ func (api *API) health(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (api *API) logger(r *http.Request) logrus.FieldLogger {
-	return httputil.GetLogger(r)
-}
-
 // GET /bandwidth/transport/{id}?period=daily&limit=7
 func (api *API) getTransportBandwidth(w http.ResponseWriter, r *http.Request) {
 	idParam := chi.URLParam(r, "id")

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -50,17 +50,11 @@ func (api *API) registerTransport(w http.ResponseWriter, r *http.Request) {
 			api.writeError(w, r, err)
 			return
 		}
-		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(allEntries); err != nil {
-			api.writeError(w, r, err)
-		}
+		httputil.WriteJSON(w, r, http.StatusCreated, allEntries)
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
-	if err := json.NewEncoder(w).Encode(entries); err != nil {
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusCreated, entries)
 }
 
 func (api *API) getTransportByID(w http.ResponseWriter, r *http.Request) {
@@ -78,9 +72,7 @@ func (api *API) getTransportByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(entry); err != nil {
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, entry)
 }
 
 func (api *API) getTransportByEdge(w http.ResponseWriter, r *http.Request) {
@@ -101,10 +93,7 @@ func (api *API) getTransportByEdge(w http.ResponseWriter, r *http.Request) {
 		api.writeError(w, r, err)
 		return
 	}
-	if err := json.NewEncoder(w).Encode(entries); err != nil {
-		api.log(r).WithError(err).Error("Error encoding entries")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, entries)
 }
 
 func (api *API) getTransportStats(w http.ResponseWriter, r *http.Request) {
@@ -137,10 +126,7 @@ func (api *API) getTransportStats(w http.ResponseWriter, r *http.Request) {
 		"by_type": byType,
 	}
 
-	if err := json.NewEncoder(w).Encode(stats); err != nil {
-		api.log(r).WithError(err).Error("Error encoding stats")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, stats)
 }
 
 func (api *API) getAllTransports(w http.ResponseWriter, r *http.Request) {
@@ -158,10 +144,7 @@ func (api *API) getAllTransports(w http.ResponseWriter, r *http.Request) {
 		api.writeError(w, r, err)
 		return
 	}
-	if err := json.NewEncoder(w).Encode(entries); err != nil {
-		api.log(r).WithError(err).Error("Error encoding entries")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, entries)
 }
 
 func (api *API) getAllTransportsStats(w http.ResponseWriter, r *http.Request) {
@@ -198,10 +181,7 @@ func (api *API) getAllTransportsStats(w http.ResponseWriter, r *http.Request) {
 		"unique_visors":    len(uniqueVisors),
 	}
 
-	if err := json.NewEncoder(w).Encode(stats); err != nil {
-		api.log(r).WithError(err).Error("Error encoding stats")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, stats)
 }
 
 func (api *API) getAllTransportsPerKeyStats(w http.ResponseWriter, r *http.Request) {
@@ -236,10 +216,7 @@ func (api *API) getAllTransportsPerKeyStats(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		api.log(r).WithError(err).Error("Error encoding per-key stats")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, result)
 }
 
 func (api *API) deleteTransport(w http.ResponseWriter, r *http.Request) {
@@ -329,7 +306,7 @@ func (api *API) deleteTransportsBatch(w http.ResponseWriter, r *http.Request) {
 		deleted++
 	}
 
-	api.writeJSON(w, r, http.StatusOK, map[string]int{"deleted": deleted, "skipped": skipped})
+	httputil.WriteJSON(w, r, http.StatusOK, map[string]int{"deleted": deleted, "skipped": skipped})
 }
 
 func (api *API) deregisterTransport(w http.ResponseWriter, r *http.Request) {
@@ -389,35 +366,17 @@ func (api *API) deregisterTransport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	api.log(r).WithFields(logrus.Fields{"Number of Transports": len(tps), "Transports": tps}).Info("Deregistration process completed.")
-	api.writeJSON(w, r, http.StatusOK, nil)
+	httputil.WriteJSON(w, r, http.StatusOK, nil)
 }
 
 func (api *API) health(w http.ResponseWriter, r *http.Request) {
 	info := buildinfo.Get()
-	api.writeJSON(w, r, http.StatusOK, HealthCheckResponse{
+	httputil.WriteJSON(w, r, http.StatusOK, HealthCheckResponse{
 		BuildInfo:   info,
 		StartedAt:   api.startedAt,
 		DmsgAddr:    api.dmsgAddr,
 		DmsgServers: api.DmsgServers,
 	})
-}
-
-func (api *API) writeJSON(w http.ResponseWriter, r *http.Request, code int, object interface{}) {
-	jsonObject, err := json.Marshal(object)
-	if err != nil {
-		api.logger(r).WithError(err).Errorf("failed to encode json response")
-		w.WriteHeader(http.StatusInternalServerError)
-
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-
-	_, err = w.Write(jsonObject)
-	if err != nil {
-		api.logger(r).WithError(err).Errorf("failed to write json response")
-	}
 }
 
 func (api *API) logger(r *http.Request) logrus.FieldLogger {
@@ -451,10 +410,7 @@ func (api *API) getTransportBandwidth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(history); err != nil {
-		api.log(r).WithError(err).Error("Error encoding bandwidth history")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, history)
 }
 
 // GET /bandwidth/visor/{pk}?period=daily&limit=7
@@ -486,10 +442,7 @@ func (api *API) getVisorBandwidth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(history); err != nil {
-		api.log(r).WithError(err).Error("Error encoding bandwidth history")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, history)
 }
 
 // GET /uptimes
@@ -499,10 +452,7 @@ func (api *API) getUptimes(w http.ResponseWriter, r *http.Request) {
 		uptimes = []store.VisorSummary{}
 	}
 
-	if err := json.NewEncoder(w).Encode(uptimes); err != nil {
-		api.log(r).WithError(err).Error("Error encoding uptimes")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, uptimes)
 }
 
 // GET /version - returns version statistics (count by version)
@@ -542,10 +492,7 @@ func (api *API) getVersionStats(w http.ResponseWriter, r *http.Request) {
 		versionCounts[version]++
 	}
 
-	if err := json.NewEncoder(w).Encode(versionCounts); err != nil {
-		api.log(r).WithError(err).Error("Error encoding version stats")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, versionCounts)
 }
 
 // VersionEntry is a response entry for version endpoints
@@ -602,10 +549,7 @@ func (api *API) getVersions(w http.ResponseWriter, r *http.Request) {
 		result = []VersionEntry{}
 	}
 
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		api.log(r).WithError(err).Error("Error encoding versions")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, result)
 }
 
 // GET /versions/{pks} - returns versions for specific PKs (comma-separated)
@@ -685,10 +629,7 @@ func (api *API) getVersionsByPKs(w http.ResponseWriter, r *http.Request) {
 		result = []VersionEntry{}
 	}
 
-	if err := json.NewEncoder(w).Encode(result); err != nil {
-		api.log(r).WithError(err).Error("Error encoding versions")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, result)
 }
 
 // splitPKs splits a comma-separated list of public keys

--- a/pkg/transport-discovery/api/metrics.go
+++ b/pkg/transport-discovery/api/metrics.go
@@ -2,7 +2,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
@@ -103,10 +103,7 @@ func (api *API) getNetworkMetric(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(metrics); err != nil {
-		api.log(r).WithError(err).Error("Error encoding network metrics")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, metrics)
 }
 
 // GET /metric/visor/{pks}
@@ -134,10 +131,7 @@ func (api *API) getVisorAggregateMetric(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(metrics); err != nil {
-		api.log(r).WithError(err).Error("Error encoding visor aggregate metrics")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, metrics)
 }
 
 // GET /metrics
@@ -151,10 +145,7 @@ func (api *API) getAllTransportMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(metrics); err != nil {
-		api.log(r).WithError(err).Error("Error encoding transport metrics")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, metrics)
 }
 
 // GET /metrics/{ids}
@@ -182,10 +173,7 @@ func (api *API) getTransportMetricsByIDs(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(metrics); err != nil {
-		api.log(r).WithError(err).Error("Error encoding transport metrics by IDs")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, metrics)
 }
 
 // GET /metrics/visor/{pks}
@@ -213,8 +201,5 @@ func (api *API) getTransportMetricsByVisors(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(metrics); err != nil {
-		api.log(r).WithError(err).Error("Error encoding transport metrics by visors")
-		api.writeError(w, r, err)
-	}
+	httputil.WriteJSON(w, r, http.StatusOK, metrics)
 }

--- a/pkg/visor/dmsgtracker/dmsg_tracker.go
+++ b/pkg/visor/dmsgtracker/dmsg_tracker.go
@@ -261,6 +261,7 @@ func (dtm *Manager) GetBulk(ctx context.Context, pks []cipher.PubKey) []DmsgClie
 		if !ok {
 			// we establish tracker if there is none
 			go dtm.establishTracker(ctx, pk)
+			continue // Don't append empty summary with 0ms latency
 		}
 		out = append(out, ds)
 	}

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -546,9 +546,8 @@ func (hv *Hypervisor) getVisorSummary() http.HandlerFunc {
 
 		if stat, ok := dmsgStats[summary.Overview.PubKey.String()]; ok {
 			summary.DmsgStats = &stat
-		} else {
-			summary.DmsgStats = &dmsgtracker.DmsgClientSummary{}
 		}
+		// If stats not found, leave DmsgStats as nil (don't create empty struct with 0ms latency)
 
 		// Check if this is the local visor (hypervisor)
 		summary.IsHypervisor = summary.Overview.PubKey == hv.visor.conf.PK
@@ -618,9 +617,8 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 		for i := 0; i < len(summaries); i++ {
 			if stat, ok := dmsgStats[summaries[i].Overview.PubKey.String()]; ok {
 				summaries[i].DmsgStats = &stat
-			} else {
-				summaries[i].DmsgStats = &dmsgtracker.DmsgClientSummary{}
 			}
+			// If stats not found, leave DmsgStats as nil (don't create empty struct with 0ms latency)
 		}
 
 		hv.mu.RUnlock()


### PR DESCRIPTION
When the dmsgtracker couldn't establish a connection to a visor (timeout/EOF), it was returning empty DmsgClientSummary with RoundTrip=0, which appeared as 'Ping: 0ms' in the UI - incorrectly appearing as the lowest (best) latency.

Fixes:
- GetBulk() now skips appending summaries when tracker not established
- Hypervisor leaves DmsgStats as nil instead of creating empty struct
