### PR TITLE
Remove go mod tidy/vendor hooks from goreleaser configs

### DIFF
--- a/.goreleaser-darwin-amd64.yml
+++ b/.goreleaser-darwin-amd64.yml
@@ -8,11 +8,6 @@ release:
     owner: skycoin
     name: skywire
 
-before:
-  hooks:
-    - go mod tidy
-    - go mod vendor
-
 builds:
   - id: skywire
     binary: skywire

--- a/.goreleaser-darwin-arm64.yml
+++ b/.goreleaser-darwin-arm64.yml
@@ -8,11 +8,6 @@ release:
     owner: skycoin
     name: skywire
 
-before:
-  hooks:
-    - go mod tidy
-    - go mod vendor
-
 builds:
   - id: skywire
     binary: skywire

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -8,11 +8,6 @@ release:
     owner: skycoin
     name: skywire
 
-before:
-  hooks:
-    - go mod tidy
-    - go mod vendor
-
 builds:
   - id: skywire
     binary: skywire

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -9,11 +9,6 @@ release:
     owner: skycoin
     name: skywire
 
-before:
-  hooks:
-    - go mod tidy
-    - go mod vendor
-
 builds:
   - id: skywire-amd64
     binary: skywire

--- a/.goreleaser-windows.yml
+++ b/.goreleaser-windows.yml
@@ -9,11 +9,6 @@ release:
     owner: skycoin
     name: skywire
 
-before:
-  hooks:
-    - go mod tidy
-    - go mod vendor
-
 builds:
   - id: skywire-amd64
     binary: skywire


### PR DESCRIPTION
These hooks modify the working directory during build, causing the version to be marked as 'dirty'. The vendor directory should already be committed and up to date before release.
