### PR TITLE
Fix binary path detection for native vs cross-compiled builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,13 +118,21 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
         run: |
-          # Cross-compiled binaries go to $GOPATH/bin/$GOOS_$GOARCH/
           go install -tags cgo -trimpath -ldflags "-s -w -linkmode external -extldflags '-static' -buildid=" \
             github.com/skycoin/skywire@${{ github.ref_name }}
 
-          # Copy to workspace for archiving
+          # Copy to workspace for archiving (check both native and cross-compile paths)
           mkdir -p bin
-          cp "$(go env GOPATH)/bin/linux_${{ matrix.goarch }}/skywire" bin/
+          GOPATH_BIN="$(go env GOPATH)/bin"
+          if [ -f "${GOPATH_BIN}/linux_${{ matrix.goarch }}/skywire" ]; then
+            cp "${GOPATH_BIN}/linux_${{ matrix.goarch }}/skywire" bin/
+          elif [ -f "${GOPATH_BIN}/skywire" ]; then
+            cp "${GOPATH_BIN}/skywire" bin/
+          else
+            echo "Binary not found in expected locations"
+            find "${GOPATH_BIN}" -name "skywire*" -type f
+            exit 1
+          fi
 
           # Show version to verify it's clean (only works for amd64 on amd64 runner)
           echo "Built binary version:"
@@ -260,13 +268,23 @@ jobs:
           GOOS: windows
           GOARCH: ${{ matrix.goarch }}
         run: |
-          # Cross-compiled binaries go to $GOPATH/bin/$GOOS_$GOARCH/
           go install -trimpath -ldflags "-s -w" github.com/skycoin/skywire@${{ github.ref_name }}
 
-          # Copy to workspace for archiving
+          # Copy to workspace for archiving (check both native and cross-compile paths)
           New-Item -ItemType Directory -Force -Path "bin"
           $gopath = go env GOPATH
-          Copy-Item "$gopath\bin\windows_${{ matrix.goarch }}\skywire.exe" "bin\"
+          $crossPath = "$gopath\bin\windows_${{ matrix.goarch }}\skywire.exe"
+          $nativePath = "$gopath\bin\skywire.exe"
+
+          if (Test-Path $crossPath) {
+            Copy-Item $crossPath "bin\"
+          } elseif (Test-Path $nativePath) {
+            Copy-Item $nativePath "bin\"
+          } else {
+            Write-Error "Binary not found in expected locations"
+            Get-ChildItem -Recurse "$gopath\bin" -Filter "skywire*"
+            exit 1
+          }
 
           # Show version (works for amd64 on amd64 runner)
           if ("${{ matrix.arch }}" -eq "amd64") {


### PR DESCRIPTION
go install places binaries in different locations:
- Native builds: $GOPATH/bin/skywire
- Cross-compiled: $GOPATH/bin/$GOOS_$GOARCH/skywire

Check both paths to handle amd64 builds on amd64 runners.
