### PR TITLE
Remove secp256k1 build from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 env:
   GO_VERSION: '1.25.6'
   MUSL_RELEASE: 'v1.3.29'  # Release containing musl toolchains
-  SECP256K1_VERSION: 'v0.6.0'
   LIBUSB_VERSION: 'v1.0.27'
 
 jobs:
@@ -70,26 +69,6 @@ jobs:
           wget -q "https://github.com/skycoin/skywire/releases/download/${{ env.MUSL_RELEASE }}/${{ matrix.toolchain_file }}"
           tar -xzf "${{ matrix.toolchain_file }}" -C ./musl-data
           rm "${{ matrix.toolchain_file }}"
-
-      - name: Build secp256k1
-        if: matrix.arch != '386'  # 386 doesn't need hardware wallet support
-        run: |
-          SYSROOT="$(pwd)/musl-data/${{ matrix.toolchain }}-cross"
-          BUILD_DIR="/tmp/secp256k1-build"
-          rm -rf "${BUILD_DIR}" && mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}"
-          wget -q "https://github.com/bitcoin-core/secp256k1/archive/refs/tags/${{ env.SECP256K1_VERSION }}.tar.gz"
-          tar -xzf "${{ env.SECP256K1_VERSION }}.tar.gz"
-          cd "secp256k1-${SECP256K1_VERSION#v}"
-          ./autogen.sh
-          ./configure \
-              --host="${{ matrix.toolchain }}" \
-              CC="${SYSROOT}/bin/${{ matrix.toolchain }}-gcc" \
-              --prefix="${SYSROOT}/${{ matrix.toolchain }}" \
-              --enable-static --disable-shared \
-              --enable-module-recovery \
-              --disable-benchmark --disable-tests --disable-exhaustive-tests
-          make -j$(nproc)
-          make install
 
       - name: Build libusb
         if: matrix.arch != '386'  # 386 uses stub


### PR DESCRIPTION
Using pure Go secp256k1 implementation now, no need to build C library

Did you run `make format && make check`?

Fixes #	

 Changes:	
-	

How to test this PR:
