### PR TITLE
Add GOPROXY=direct to bypass module proxy for new tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Build skywire via go install
         env:
+          GOPROXY: direct
           CGO_ENABLED: "1"
           CC: ${{ github.workspace }}/musl-data/${{ matrix.toolchain }}-cross/bin/${{ matrix.toolchain }}-gcc
           GOOS: linux
@@ -139,6 +140,7 @@ jobs:
 
       - name: Build skywire
         env:
+          GOPROXY: direct
           CGO_ENABLED: "1"
         run: |
           # Native build on Intel runner
@@ -194,6 +196,7 @@ jobs:
 
       - name: Build skywire
         env:
+          GOPROXY: direct
           CGO_ENABLED: "1"
         run: |
           # Native build - install directly
@@ -262,6 +265,7 @@ jobs:
 
       - name: Build skywire
         env:
+          GOPROXY: direct
           CGO_ENABLED: "0"  # No CGO on Windows for simpler builds
           GOOS: windows
           GOARCH: ${{ matrix.goarch }}


### PR DESCRIPTION
The Go module proxy may not have indexed freshly tagged versions, causing 'invalid version: unknown revision' errors. Using GOPROXY=direct fetches directly from the source repository.
