### PR TITLE
Add GOSUMDB=off to bypass checksum database for new tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Build skywire via go install
         env:
           GOPROXY: direct
+          GOSUMDB: "off"
           CGO_ENABLED: "1"
           CC: ${{ github.workspace }}/musl-data/${{ matrix.toolchain }}-cross/bin/${{ matrix.toolchain }}-gcc
           GOOS: linux
@@ -141,6 +142,7 @@ jobs:
       - name: Build skywire
         env:
           GOPROXY: direct
+          GOSUMDB: "off"
           CGO_ENABLED: "1"
         run: |
           # Native build on Intel runner
@@ -197,6 +199,7 @@ jobs:
       - name: Build skywire
         env:
           GOPROXY: direct
+          GOSUMDB: "off"
           CGO_ENABLED: "1"
         run: |
           # Native build - install directly
@@ -266,6 +269,7 @@ jobs:
       - name: Build skywire
         env:
           GOPROXY: direct
+          GOSUMDB: "off"
           CGO_ENABLED: "0"  # No CGO on Windows for simpler builds
           GOOS: windows
           GOARCH: ${{ matrix.goarch }}


### PR DESCRIPTION
The checksum database (sum.golang.org) returns 500 errors for freshly tagged versions that haven't been indexed yet. Using GOSUMDB=off with GOPROXY=direct allows building from new tags immediately.
