### PR TITLE
Fix +dirty version suffix in Docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,22 +1,4 @@
-bin
-skywire
-ci_scripts
-apps
-integration
-skywrie-services
-.gitignore
-.github
-.vscode
-.idea
-
-# Local development files
-local/
-*.log
-*.txt
-*.md
-!README.md
-!CHANGELOG.md
-
-# Build artifacts not needed
-build/
-dist/
+# Only docker/common/ is needed from the build context.
+# The Go source is fetched directly via go install @commit.
+*
+!docker/

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,11 @@ tidy: ## Tidies and vendors dependencies.
 	${OPTS} go mod tidy -v
 
 format: tidy ## Formats the code. Must have goimports and goimports-reviser installed (use make install-linters).
+	@if grep -qE '^(replace|exclude)' go.mod; then \
+		echo "ERROR: go.mod contains replace or exclude directives which break go install @version and Docker builds"; \
+		grep -E '^(replace|exclude)' go.mod; \
+		exit 1; \
+	fi
 	${OPTS} goimports -w -local ${PROJECT_BASE} ./pkg ./cmd ./internal
 	find . -type f -name '*.go' -not -path "./.git/*" -not -path "./vendor/*"  -exec goimports-reviser -project-name ${PROJECT_BASE} {} \;
 

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -6,6 +6,7 @@ image_tag="$1"
 go_buildopts="$2"
 build_arch="$3"
 git_branch="$(git rev-parse --abbrev-ref HEAD)"
+git_commit="$(git rev-parse HEAD)"
 bldkit="1"
 platform="--platform=linux/amd64"
 
@@ -88,11 +89,11 @@ if [[ "$image_tag" == "integration" ]]; then
   rm -rf ./tmp/*
 fi
 
-echo "Build Skywire Image"
+echo "Build Skywire Image (commit: $git_commit)"
 DOCKER_BUILDKIT="$bldkit" docker build -f docker/images/skywire/Dockerfile \
   --build-arg base_image="$base_image" \
-  --build-arg build_opts="$go_buildopts" \
   --build-arg image_tag="$image_tag" \
+  --build-arg commit="$git_commit" \
   $platform \
   -t "$registry"/skywire:"$image_tag" .
 

--- a/docker/images/skywire/Dockerfile
+++ b/docker/images/skywire/Dockerfile
@@ -3,6 +3,7 @@ ARG base_image
 ARG image_tag
 FROM ${base_image} AS builder
 ARG image_tag
+ARG commit
 
 ARG CGO_ENABLED=0
 ENV CGO_ENABLED=${CGO_ENABLED} \
@@ -10,29 +11,21 @@ ENV CGO_ENABLED=${CGO_ENABLED} \
     GO111MODULE=on \
     GOBIN=/release
 
-COPY . /skywire
-WORKDIR /skywire
-
-# Install git for VCS version stamping (go install needs git to read .git directory)
-RUN apk add --no-cache git
-
-# Build using go install to get proper version info from runtime/debug.ReadBuildInfo()
-# The -w -s flags strip debug info to reduce binary size
 RUN if [ "$image_tag" = "integration" ]; then \
         apk add --no-cache build-base && \
-        CGO_ENABLED=1 go install -ldflags="-w -s" -race .; \
+        CGO_ENABLED=1 GOPROXY=direct go install -ldflags="-w -s" -race github.com/skycoin/skywire@${commit}; \
     else \
-        go install -ldflags="-w -s" .; \
+        GOPROXY=direct go install -ldflags="-w -s" github.com/skycoin/skywire@${commit}; \
     fi
 
 ## Resulting image
 FROM ${base_image} AS visor-runner
 
-COPY --from=builder /skywire/docker/common/install-prequisites.sh /release/install-prequisites.sh
+COPY docker/common/install-prequisites.sh /tmp/install-prequisites.sh
 COPY --from=builder /release /release
 
-RUN sh -c /release/install-prequisites.sh \
-    && rm -rf /release/install-prequisites.sh \
+RUN sh -c /tmp/install-prequisites.sh \
+    && rm -rf /tmp/install-prequisites.sh \
     && mkdir -p /opt/skywire \
     && apk add curl
 


### PR DESCRIPTION
Use go install @commit to fetch and build directly from the upstream module rather than copying source into the build context. This avoids the .git/.dockerignore conflict that caused dirty version stamps and eliminates the source COPY entirely — only docker/common/ is needed in the build context now.

Also add a replace/exclude directive check to make format, since go install @version fails when go.mod contains either.
