### PR TITLE
Skip sum database for skywire module in Docker build

### DIFF
--- a/docker/images/skywire/Dockerfile
+++ b/docker/images/skywire/Dockerfile
@@ -9,7 +9,9 @@ ARG CGO_ENABLED=0
 ENV CGO_ENABLED=${CGO_ENABLED} \
     GOOS=linux  \
     GO111MODULE=on \
-    GOBIN=/release
+    GOBIN=/release \
+    GONOSUMDB=github.com/skycoin/skywire \
+    GONOSUMCHECK=github.com/skycoin/skywire
 
 RUN apk add --no-cache git && \
     if [ "$image_tag" = "integration" ]; then \


### PR DESCRIPTION
GOPROXY=direct fetches from VCS but still verifies against sum.golang.org, which returns 500 for pseudo-versions of this module. Set GONOSUMDB and GONOSUMCHECK to bypass the checksum database for github.com/skycoin/skywire.
