### PR TITLE
Defer transport registration to batch re-registration loop

### DIFF
--- a/pkg/transport/handshake.go
+++ b/pkg/transport/handshake.go
@@ -7,11 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
-	"time"
 
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
@@ -131,7 +128,10 @@ func MakeSettlementHS(init bool, log *logging.Logger, label Label) SettlementHS 
 	}
 
 	// responding logic.
-	respHS := func(ctx context.Context, dc DiscoveryClient, transport network.Transport, sk cipher.SecKey) (Label, error) {
+	// NOTE: Registration with TPD is NOT done here. The transport manager's
+	// periodic re-registration loop handles batch registration of all transports,
+	// which avoids per-transport HTTP calls that hit TPD rate limits on public visors.
+	respHS := func(ctx context.Context, _ DiscoveryClient, transport network.Transport, sk cipher.SecKey) (Label, error) {
 		// Use LabelUser for local comparison entry; compareEntries does not check label,
 		// so this is backward-compatible with older visors that always send LabelUser.
 		entry := makeEntryFromTransport(transport, LabelUser)
@@ -152,30 +152,6 @@ func MakeSettlementHS(init bool, log *logging.Logger, label Label) SettlementHS 
 		entry = *recvSE.Entry
 		receivedLabel := entry.Label
 
-		// Ensure transport is registered.
-		if err := dc.RegisterTransports(ctx, recvSE); err != nil {
-			if httpErr, ok := err.(*httputil.HTTPError); ok && httpErr.Status == http.StatusConflict {
-				log.WithError(err).Debug("An expected error occurred while trying to register transport.")
-			} else {
-				// Retry registration with exponential backoff for transient errors
-				log.WithError(err).Warn("Failed to register transport, retrying with backoff...")
-				maxRetries := 3
-				for attempt := 1; attempt <= maxRetries; attempt++ {
-					backoff := time.Duration(attempt) * time.Second
-					time.Sleep(backoff)
-
-					if retryErr := dc.RegisterTransports(ctx, recvSE); retryErr != nil {
-						log.WithError(retryErr).Warnf("Registration retry %d/%d failed", attempt, maxRetries)
-						if attempt == maxRetries {
-							log.WithError(retryErr).Error("Failed to register transport after all retries.")
-						}
-					} else {
-						log.Infof("Successfully registered transport after %d retries", attempt)
-						break
-					}
-				}
-			}
-		}
 		return receivedLabel, writeHsResponse(transport, responseOK)
 	}
 

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -80,6 +80,10 @@ type Manager struct {
 	// tpdCache stores the cached transport discovery data for local route calculation
 	tpdCache   []*Entry
 	tpdCacheMu sync.RWMutex
+
+	// regNudge signals the re-registration loop to run soon (after a short debounce).
+	// Sent after accepting a new transport so it gets batch-registered quickly.
+	regNudge chan struct{}
 }
 
 // NewManager creates a Manager with the provided configuration and transport factories.
@@ -99,6 +103,7 @@ func NewManager(log *logging.Logger, arClient addrresolver.APIClient, ebc *appev
 		arClient:   arClient,
 		factory:    factory,
 		ebc:        ebc,
+		regNudge:   make(chan struct{}, 1),
 	}
 	return tm, nil
 }
@@ -162,6 +167,28 @@ func (tm *Manager) runReRegisterTransports(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			tm.reRegisterTransports(ctx)
+		case <-tm.regNudge:
+			// New transport accepted — debounce 5s to batch concurrent accepts,
+			// then register all transports in one call.
+			tm.Logger.Debug("Registration nudge received, debouncing...")
+			select {
+			case <-time.After(5 * time.Second):
+			case <-tm.done:
+				return
+			case <-ctx.Done():
+				return
+			}
+			// Drain any additional nudges that arrived during debounce
+			for {
+				select {
+				case <-tm.regNudge:
+				default:
+					goto register
+				}
+			}
+		register:
+			tm.reRegisterTransports(ctx)
+			ticker.Reset(transportReRegisterInterval)
 		case <-tm.done:
 			return
 		case <-ctx.Done():
@@ -510,6 +537,13 @@ func (tm *Manager) acceptTransport(ctx context.Context, lis network.Listener) er
 	}
 
 	tm.Logger.Debugf("accepted tp: type(%s) remote(%s) tpID(%s) new(%v)", lis.Network(), transport.RemotePK(), tpID, !ok)
+
+	// Nudge the re-registration loop to batch-register this transport with TPD soon.
+	// Registration is deferred to avoid per-transport HTTP calls that hit rate limits.
+	select {
+	case tm.regNudge <- struct{}{}:
+	default: // nudge already pending
+	}
 
 	// NOTE: Do NOT measure latency on the accepting side.
 	// Only the initiating side measures latency to avoid race conditions where


### PR DESCRIPTION
Remove per-transport RegisterTransports call from the settlement handshake responder. Instead, newly accepted transports are registered in batch by the existing re-registration loop via a nudge/debounce mechanism: on accept, a nudge is sent; the loop waits 5s to collect concurrent accepts, then registers all transports in one HTTP call.

This avoids hitting TPD's 30 req/min rate limit when a public visor receives many incoming transports at startup. The transport's data connection is usable immediately — TPD registration is only needed for discovery by other visors.
