### PR TITLE
Batch TPD deletions, STCP transport support, transport stats, STCPR retry, dmsg update

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-add.go
+++ b/cmd/skywire-cli/commands/tp/tp-add.go
@@ -64,7 +64,10 @@ func init() {
 	addTpCmd.Flags().BoolVarP(&userLabel, "user", "u", false, "set transport label to 'user' (default is 'skycoin')")
 	addTpCmd.Flags().BoolVar(&noRegister, "no-register", false, "skip transport discovery registration (implies --user)")
 	addTpCmd.Flags().StringSliceVar(&remoteVisorPKs, "remote", nil, "request transport via TPS on remote visor(s) (comma-separated PKs)")
+	addTpCmd.Flags().StringVar(&stcpAddr, "addr", "", "remote address (ip:port) for stcp transport")
 }
+
+var stcpAddr string
 
 var addTpCmd = &cobra.Command{
 	Use:   "add <public-key> [public-key]...",
@@ -78,8 +81,14 @@ var addTpCmd = &cobra.Command{
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		if transportType != "dmsg" && transportType != "stcpr" && transportType != "sudph" && transportType != "" {
+		if transportType != "dmsg" && transportType != "stcpr" && transportType != "sudph" && transportType != "stcp" && transportType != "" {
 			logger.Fatal("Invalid transport type specified:", transportType)
+		}
+		if stcpAddr != "" && transportType != "stcp" {
+			logger.Fatal("--addr flag requires -t stcp")
+		}
+		if transportType == "stcp" && stcpAddr == "" {
+			logger.Fatal("stcp transport requires --addr ip:port")
 		}
 		// --no-register implies --user label
 		if noRegister {
@@ -110,6 +119,15 @@ var addTpCmd = &cobra.Command{
 
 		if len(pks) == 0 {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("no public keys specified"))
+		}
+
+		// For stcp, inject the address into the visor's PK table before dialing
+		if transportType == "stcp" && stcpAddr != "" {
+			for _, pk := range pks {
+				if err := rpcClient.SetSTCPAddr(pk, stcpAddr); err != nil {
+					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set STCP address: %w", err))
+				}
+			}
 		}
 
 		// Handle --remote flag: request transport via TPS on remote visor(s)

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -35,6 +35,7 @@ var (
 	showInactive     bool
 	logger           = logging.MustGetLogger("skywire-cli")
 	tpTypes          bool
+	showStats        bool
 	utURL            string
 	sdURL            string
 	listRemoteVisors []string
@@ -74,6 +75,7 @@ func init() {
 	tpCmd.Flags().StringVarP(&utURL, "uturl", "w", deployment.Prod.UptimeTracker, "uptime tracker url")
 	tpCmd.Flags().StringVarP(&tpID, "id", "i", "", "display transport matching ID")
 	tpCmd.Flags().BoolVarP(&tpTypes, "tptypes", "u", false, "display transport types used by the local visor")
+	tpCmd.Flags().BoolVarP(&showStats, "stats", "s", false, "show transport statistics (count by type, unique visors)")
 	tpCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 	tpCmd.Flags().StringSliceVar(&listRemoteVisors, "remote", nil, "list transports on remote visor(s) via TPS (comma-separated PKs)")
 }
@@ -213,6 +215,45 @@ var tpCmd = &cobra.Command{
 			types, err := rpcClient.TransportTypes()
 			internal.Catch(cmd.Flags(), err)
 			internal.PrintOutput(cmd.Flags(), types, fmt.Sprintln(strings.Join(types, "\n")))
+			return
+		}
+
+		if showStats {
+			transports, err := rpcClient.Transports(filterTypes, nil, false)
+			internal.Catch(cmd.Flags(), err)
+
+			byType := make(map[string]int)
+			uniqueVisors := make(map[cipher.PubKey]struct{})
+			for _, tp := range transports {
+				byType[string(tp.Type)]++
+				uniqueVisors[tp.Remote] = struct{}{}
+			}
+
+			type statsOutput struct {
+				Total        int            `json:"total"`
+				UniqueVisors int            `json:"unique_visors"`
+				ByType       map[string]int `json:"by_type"`
+			}
+			stats := statsOutput{
+				Total:        len(transports),
+				UniqueVisors: len(uniqueVisors),
+				ByType:       byType,
+			}
+
+			var b strings.Builder
+			fmt.Fprintf(&b, "Total transports:  %d\n", stats.Total)
+			fmt.Fprintf(&b, "Unique visors:     %d\n", stats.UniqueVisors)
+			// Sort type names for consistent output
+			typeNames := make([]string, 0, len(byType))
+			for t := range byType {
+				typeNames = append(typeNames, t)
+			}
+			sort.Strings(typeNames)
+			for _, t := range typeNames {
+				fmt.Fprintf(&b, "  %-10s %d\n", t+":", byType[t])
+			}
+
+			internal.PrintOutput(cmd.Flags(), stats, b.String())
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pterm/pterm v0.12.83
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/sirupsen/logrus v1.9.4
-	github.com/skycoin/dmsg v1.3.29-0.20260316193050-4ed20dc75c05
+	github.com/skycoin/dmsg v1.3.29-0.20260318145752-f02092dd2230
 	github.com/skycoin/skycoin v0.28.4-0.20260318005924-e381a501582c
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/skycoin/dmsg v1.3.29-0.20260316193050-4ed20dc75c05 h1:kXhBs0hMlVua64GCwANbMM7bmF3Ic/SZtRZZRkY3C20=
-github.com/skycoin/dmsg v1.3.29-0.20260316193050-4ed20dc75c05/go.mod h1:5EIwtsJgR0RSndqKrKz/yY3MSu2NU5k7hOz2NWDiF44=
+github.com/skycoin/dmsg v1.3.29-0.20260318145752-f02092dd2230 h1:m+LbRc4zsSh0RUgHyjeaA4GWO0zRcQetJrFEAGK7dCQ=
+github.com/skycoin/dmsg v1.3.29-0.20260318145752-f02092dd2230/go.mod h1:5EIwtsJgR0RSndqKrKz/yY3MSu2NU5k7hOz2NWDiF44=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9 h1:DElGw1Fhj4amuW1KM5q8Xowosb3RiOQce0lDJw0Qv0Y=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9/go.mod h1:OQz8NXVJUWEw7PWYASZ/1BIw5GXgVMTGvrCGDlZa9+k=
 github.com/skycoin/hardware-wallet-protob v0.0.0-20250805154629-410561e1bc2f h1:wKpqEhubs7kKtb7nqU4V8zkTxwnnwcB2797elV2z1t8=

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -46,6 +48,9 @@ type ManagedTransportConfig struct {
 	TransportLabel  Label
 	InactiveTimeout time.Duration
 	mlog            *logging.MasterLogger
+	// QueueDeletion, when set, defers TPD deregistration to the manager's batch
+	// deletion loop instead of making an HTTP call per transport close.
+	QueueDeletion func(id uuid.UUID)
 }
 
 // ManagedTransport manages a direct line of communication between two visor nodes.
@@ -71,7 +76,8 @@ type ManagedTransport struct {
 	done chan struct{}
 	wg   sync.WaitGroup
 
-	timeout time.Duration
+	timeout       time.Duration
+	queueDeletion func(id uuid.UUID)
 
 	latencyStats LatencyStats
 	latencyMx    sync.RWMutex
@@ -95,16 +101,17 @@ func NewManagedTransport(conf ManagedTransportConfig) *ManagedTransport {
 	logEntry := MakeLogEntry(conf.LS, entry.ID, log)
 
 	mt := &ManagedTransport{
-		log:         log,
-		rPK:         conf.RemotePK,
-		dc:          conf.DC,
-		ls:          conf.LS,
-		client:      conf.client,
-		Entry:       entry,
-		LogEntry:    logEntry,
-		transportCh: make(chan struct{}, 1),
-		done:        make(chan struct{}),
-		timeout:     conf.InactiveTimeout,
+		log:           log,
+		rPK:           conf.RemotePK,
+		dc:            conf.DC,
+		ls:            conf.LS,
+		client:        conf.client,
+		Entry:         entry,
+		LogEntry:      logEntry,
+		transportCh:   make(chan struct{}, 1),
+		done:          make(chan struct{}),
+		timeout:       conf.InactiveTimeout,
+		queueDeletion: conf.QueueDeletion,
 	}
 	return mt
 }
@@ -259,11 +266,9 @@ func (mt *ManagedTransport) IsClosed() bool {
 	}
 }
 
-// close underlying transport and remove the entry from transport discovery
-// todo: this currently performs http request to discovery service
-// it only makes sense to wait for the completion if we are closing the visor itself,
-// regular transport close operations should probably call it concurrently
-// need to find a way to handle this properly (done channel in return?)
+// close underlying transport and queue deregistration from transport discovery.
+// If queueDeletion is set (manager-level batch deletion), the transport ID is
+// queued for deferred batch deletion instead of making an individual HTTP call.
 func (mt *ManagedTransport) close() {
 	select {
 	case <-mt.done:
@@ -280,7 +285,11 @@ func (mt *ManagedTransport) close() {
 		mt.transport = nil
 	}
 	mt.transportMx.Unlock()
-	_ = mt.deleteFromDiscovery() //nolint:errcheck
+	if mt.queueDeletion != nil {
+		mt.queueDeletion(mt.Entry.ID)
+	} else {
+		_ = mt.deleteFromDiscovery() //nolint:errcheck
+	}
 }
 
 // closeWithoutDeregister closes the transport without deregistering from TPD.

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -84,6 +84,12 @@ type Manager struct {
 	// regNudge signals the re-registration loop to run soon (after a short debounce).
 	// Sent after accepting a new transport so it gets batch-registered quickly.
 	regNudge chan struct{}
+
+	// delQueue collects transport IDs for deferred batch deletion from TPD.
+	// Transports queue their ID here on close instead of making individual HTTP calls.
+	delQueue   []uuid.UUID
+	delQueueMu sync.Mutex
+	delNudge   chan struct{}
 }
 
 // NewManager creates a Manager with the provided configuration and transport factories.
@@ -104,6 +110,7 @@ func NewManager(log *logging.Logger, arClient addrresolver.APIClient, ebc *appev
 		factory:    factory,
 		ebc:        ebc,
 		regNudge:   make(chan struct{}, 1),
+		delNudge:   make(chan struct{}, 1),
 	}
 	return tm, nil
 }
@@ -118,11 +125,12 @@ func (tm *Manager) InitDmsgClient(ctx context.Context, dmsgC *dmsg.Client) {
 // from all those clients
 // Additionally, it runs cleanup and persistent reconnection routines
 func (tm *Manager) Serve(ctx context.Context) {
-	// for cleanup, reconnect and re-registration goroutines
-	tm.wg.Add(3)
+	// for cleanup, reconnect, re-registration, and deferred deletion goroutines
+	tm.wg.Add(4)
 	go tm.cleanupTransports(ctx)
 	go tm.runReconnectPersistent(ctx)
 	go tm.runReRegisterTransports(ctx)
+	go tm.runDeferredDeletions(ctx)
 	tm.Logger.Debug("transport manager is serving.")
 }
 
@@ -194,6 +202,79 @@ func (tm *Manager) runReRegisterTransports(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// queueDeletion adds a transport ID to the deferred deletion queue.
+// Called by ManagedTransport.close() instead of making individual HTTP calls.
+func (tm *Manager) queueDeletion(id uuid.UUID) {
+	tm.delQueueMu.Lock()
+	tm.delQueue = append(tm.delQueue, id)
+	tm.delQueueMu.Unlock()
+	// Non-blocking nudge
+	select {
+	case tm.delNudge <- struct{}{}:
+	default: // nudge already pending
+	}
+}
+
+const deletionDebounce = 5 * time.Second
+
+// runDeferredDeletions batch-deletes transport IDs that were queued by closing transports.
+// Uses the same debounce pattern as registration nudges to avoid flooding TPD.
+func (tm *Manager) runDeferredDeletions(ctx context.Context) {
+	defer tm.wg.Done()
+	for {
+		select {
+		case <-tm.delNudge:
+			// Debounce: wait for burst of closures to settle
+			tm.Logger.Debug("Deletion nudge received, debouncing...")
+			select {
+			case <-time.After(deletionDebounce):
+			case <-tm.done:
+				tm.flushDeletionQueue()
+				return
+			case <-ctx.Done():
+				return
+			}
+			// Drain any additional nudges
+			for {
+				select {
+				case <-tm.delNudge:
+				default:
+					goto flush
+				}
+			}
+		flush:
+			tm.flushDeletionQueue()
+		case <-tm.done:
+			tm.flushDeletionQueue()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// flushDeletionQueue batch-deletes all queued transport IDs from TPD.
+func (tm *Manager) flushDeletionQueue() {
+	tm.delQueueMu.Lock()
+	ids := tm.delQueue
+	tm.delQueue = nil
+	tm.delQueueMu.Unlock()
+
+	if len(ids) == 0 {
+		return
+	}
+
+	tm.Logger.Debugf("Batch deleting %d transports from TPD", len(ids))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	deleted, err := tm.Conf.DiscoveryClient.DeleteTransports(ctx, ids)
+	cancel()
+	if err != nil {
+		tm.Logger.WithError(err).Warnf("Batch delete completed with error: %d/%d deleted", deleted, len(ids))
+	} else {
+		tm.Logger.Debugf("Batch deleted %d/%d transports from TPD", deleted, len(ids))
 	}
 }
 
@@ -513,6 +594,7 @@ func (tm *Manager) acceptTransport(ctx context.Context, lis network.Listener) er
 			TransportLabel: LabelUser,
 			ebc:            tm.ebc,
 			mlog:           tm.factory.MLogger,
+			QueueDeletion:  tm.queueDeletion,
 		})
 
 		go func() {
@@ -704,6 +786,7 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 		RemotePK:       remote,
 		TransportLabel: label,
 		mlog:           tm.factory.MLogger,
+		QueueDeletion:  tm.queueDeletion,
 	})
 
 	tm.Logger.Debugf("Dialing transport to %v via %v", mTp.Remote(), mTp.client.Type())
@@ -814,7 +897,7 @@ func (tm *Manager) DeleteAllTransports() {
 
 	select {
 	case <-done:
-		// All transports closed and deregistered from TPD
+		// All transports closed; TPD deregistration queued for batch processing
 		tm.Logger.Debug("All transports closed successfully")
 	case <-time.After(30 * time.Second):
 		// Timeout - some transports may not have completed TPD cleanup

--- a/pkg/transport/network/stcp/pktable.go
+++ b/pkg/transport/network/stcp/pktable.go
@@ -14,10 +14,11 @@ import (
 
 const expectedFieldsLen = 2
 
-// PKTable associates public keys to udp addresses.
+// PKTable associates public keys to tcp addresses.
 type PKTable interface {
 	Addr(pk cipher.PubKey) (string, bool)
 	PubKey(addr string) (cipher.PubKey, bool)
+	SetAddr(pk cipher.PubKey, addr string)
 	Count() int
 }
 
@@ -91,6 +92,12 @@ func (mt *memoryTable) Addr(pk cipher.PubKey) (string, bool) {
 func (mt *memoryTable) PubKey(addr string) (cipher.PubKey, bool) {
 	pk, ok := mt.reverse[addr]
 	return pk, ok
+}
+
+// SetAddr associates a public key with an address at runtime.
+func (mt *memoryTable) SetAddr(pk cipher.PubKey, addr string) {
+	mt.entries[pk] = addr
+	mt.reverse[addr] = pk
 }
 
 // Count returns the number of entries within the PKTable implementation.

--- a/pkg/transport/network/stcpr.go
+++ b/pkg/transport/network/stcpr.go
@@ -111,7 +111,10 @@ func (c *stcprClient) serve() {
 	c.acceptTransports(lis)
 }
 
-// reRegisterLoop periodically re-registers with address resolver to keep the entry alive
+// reRegisterLoop periodically re-registers with address resolver to keep the entry alive.
+// The AR server sets a 2-minute TTL on re-registered entries, so missing a single
+// re-registration makes the visor invisible. On failure, retry with backoff rather
+// than waiting the full interval.
 func (c *stcprClient) reRegisterLoop(port string) {
 	ticker := time.NewTicker(stcprReRegisterInterval)
 	defer ticker.Stop()
@@ -124,7 +127,24 @@ func (c *stcprClient) reRegisterLoop(port string) {
 		case <-ticker.C:
 			c.log.Debug("Re-registering STCPR with address resolver")
 			if err := c.ar.BindSTCPR(context.Background(), port); err != nil {
-				c.log.WithError(err).Warn("Failed to re-register STCPR with address resolver")
+				c.log.WithError(err).Warn("Failed to re-register STCPR, retrying...")
+				// Retry with backoff — a missed re-registration means a 2min blackout
+				delay := stcprBindRetryDelay
+				for attempt := 1; attempt <= 3; attempt++ {
+					if c.isClosed() {
+						return
+					}
+					time.Sleep(delay)
+					if err := c.ar.BindSTCPR(context.Background(), port); err == nil {
+						c.log.Debugf("Successfully re-registered STCPR after %d retries", attempt)
+						break
+					}
+					c.log.WithError(err).Warnf("STCPR re-registration retry %d/3 failed", attempt)
+					delay *= 2
+					if delay > stcprBindMaxRetryDelay {
+						delay = stcprBindMaxRetryDelay
+					}
+				}
 			} else {
 				c.log.Debug("Successfully re-registered STCPR")
 			}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -119,6 +119,7 @@ type API interface {
 	Transports(types []string, pks []cipher.PubKey, logs bool) ([]*TransportSummary, error)
 	Transport(tid uuid.UUID) (*TransportSummary, error)
 	AddTransport(remote cipher.PubKey, tpType string, timeout time.Duration, label string, noRegister bool, skipLatencyProbe bool) (*TransportSummary, error)
+	SetSTCPAddr(pk cipher.PubKey, addr string) error
 	RemoveTransport(tid uuid.UUID) error
 	RemoveAllTransports() error
 	SetPublicAutoconnect(pAc bool) error
@@ -1512,6 +1513,17 @@ func (v *Visor) AddTransport(remote cipher.PubKey, tpType string, timeout time.D
 	v.log.Debugf("Saved transport to %v via %v, label %s", remote, tpType, tp.Entry.Label)
 
 	return newTransportSummary(v.tpM, tp, false, v.router.SetupIsTrusted(tp.Remote())), nil
+}
+
+// SetSTCPAddr injects an STCP PK table entry at runtime, mapping a public key to a TCP address.
+// This allows creating STCP transports to visors not preconfigured in the STCP config.
+func (v *Visor) SetSTCPAddr(pk cipher.PubKey, addr string) error {
+	if v.stcpTable == nil {
+		return fmt.Errorf("STCP is not configured on this visor")
+	}
+	v.stcpTable.SetAddr(pk, addr)
+	v.log.Infof("Set STCP address for %s -> %s", pk, addr)
+	return nil
 }
 
 // RemoveTransport implements API.

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -748,6 +748,7 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		table = stcp.NewTable(v.conf.STCP.PKTable)
 		listenAddr = v.conf.STCP.ListeningAddress
 	}
+	v.stcpTable = table
 	factory := network.ClientFactory{
 		PK:         v.conf.PK,
 		SK:         v.conf.SK,

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -561,6 +561,18 @@ func (r *RPC) AddTransport(in *AddTransportIn, out *TransportSummary) (err error
 	return err
 }
 
+// SetSTCPAddrIn is input for SetSTCPAddr.
+type SetSTCPAddrIn struct {
+	PK   cipher.PubKey
+	Addr string
+}
+
+// SetSTCPAddr injects an STCP PK table entry at runtime.
+func (r *RPC) SetSTCPAddr(in *SetSTCPAddrIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetSTCPAddr", in)(nil, &err)
+	return r.visor.SetSTCPAddr(in.PK, in.Addr)
+}
+
 // RemoveTransport removes a Transport from the visor.
 func (r *RPC) RemoveTransport(tid *uuid.UUID, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "RemoveTransport", tid)(nil, &err)

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -427,6 +427,11 @@ func (rc *rpcClient) AddTransport(remote cipher.PubKey, tpType string, timeout t
 	return &summary, err
 }
 
+// SetSTCPAddr injects an STCP PK table entry at runtime.
+func (rc *rpcClient) SetSTCPAddr(pk cipher.PubKey, addr string) error {
+	return rc.Call("SetSTCPAddr", &SetSTCPAddrIn{PK: pk, Addr: addr}, &struct{}{})
+}
+
 // RemoveTransport calls RemoveTransport.
 func (rc *rpcClient) RemoveTransport(tid uuid.UUID) error {
 	return rc.Call("RemoveTransport", &tid, &struct{}{})
@@ -1521,6 +1526,11 @@ func (mc *mockRPCClient) AddTransport(remote cipher.PubKey, tpType string, _ tim
 		mc.o.Transports = append(mc.o.Transports, summary)
 		return nil
 	})
+}
+
+// SetSTCPAddr implements API.
+func (mc *mockRPCClient) SetSTCPAddr(_ cipher.PubKey, _ string) error {
+	return nil
 }
 
 // RemoveTransport implements API.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/utclient"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
@@ -160,6 +161,9 @@ type Visor struct {
 	// Log server API references for health stats
 	logServerAPI      *logserver.API
 	localLogServerAPI *logserver.API // Localhost log server (optional)
+
+	// STCP PK table for runtime address injection (tp add -t stcp --addr)
+	stcpTable stcp.PKTable
 }
 
 // todo: consider moving module closing to the module system

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsgctrl/serve_listener.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsgctrl/serve_listener.go
@@ -2,9 +2,11 @@
 package dmsgctrl
 
 import (
+	"errors"
 	"net"
 	"strings"
 
+	"github.com/skycoin/dmsg/pkg/dmsg"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 )
 
@@ -21,7 +23,7 @@ func ServeListener(l net.Listener, chanLen int) <-chan *Control {
 		for {
 			conn, err := l.Accept()
 			if err != nil {
-				if strings.Contains(err.Error(), "use of closed") {
+				if errors.Is(err, dmsg.ErrEntityClosed) || strings.Contains(err.Error(), "use of closed") {
 					return
 				}
 				log.Warnf("Failed to accept dmsgctrl conn, continuing: %v", err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1003,7 +1003,7 @@ github.com/shopspring/decimal
 ## explicit; go 1.17
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.29-0.20260316193050-4ed20dc75c05
+# github.com/skycoin/dmsg v1.3.29-0.20260318145752-f02092dd2230
 ## explicit; go 1.25.6
 github.com/skycoin/dmsg/cmd/conf/commands
 github.com/skycoin/dmsg/cmd/dial/commands


### PR DESCRIPTION

- Defer transport deletion to manager-level batch queue with 5s debounce, preventing TPD 429 rate limit errors when many transports close at once
- Add `tp add -t stcp --addr ip:port` for manual STCP transport creation with runtime PKTable injection via new SetSTCPAddr RPC/API
- Add `tp --stats/-s` flag showing transport count by type and unique visors
- Add retry with backoff on STCPR re-registration failure (up to 3 retries) to prevent 2-minute AR blackout from a single missed re-registration
- Update dmsg dependency to f02092dd (dmsgctrl shutdown fix)
