### PR TITLE
Fix skychat --addr parsing, show app errors on proxy start failure

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -152,12 +152,12 @@ func RunSkychat(ctx context.Context, args []string) error {
 
 	url := ""
 	address := addr
-	if len(address) < 5 || (address[:1] != ":" && address[:2] != "*:") {
-		url = "127.0.0.1:8001"
-	} else if address[:1] == ":" {
-		url = "127.0.0.1" + address
-	} else if address[:2] == "*:" {
+	if len(address) >= 2 && address[:2] == "*:" {
 		url = "0.0.0.0" + address[1:]
+	} else if len(address) >= 1 && address[:1] == ":" {
+		url = "127.0.0.1" + address
+	} else if host, port, err := net.SplitHostPort(address); err == nil && host != "" && port != "" {
+		url = address
 	} else {
 		url = "127.0.0.1:8001"
 	}

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -243,10 +243,20 @@ var startCmd = &cobra.Command{
 					}
 					if state.Status == appserver.AppStatusStopped {
 						startProcess = false
-						out := output{
-							AppError: state.DetailedStatus,
+						// Brief wait to let error propagate from proc cleanup
+						time.Sleep(500 * time.Millisecond)
+						// Re-fetch to get the error if it was set after stop
+						if updatedState, err := rpcClient.App(stateName); err == nil && updatedState != nil {
+							state = updatedState
 						}
-						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln("\nStopped!"+state.DetailedStatus))
+						errMsg := state.DetailedStatus
+						if errMsg == "" || errMsg == string(appserver.AppDetailedStatusStopped) {
+							errMsg = "(check visor logs for details)"
+						}
+						out := output{
+							AppError: errMsg,
+						}
+						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln("\nStopped! "+errMsg))
 					}
 				}
 			}

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -167,26 +167,34 @@ func (l *AppLauncher) AppState(name string) (*appserver.AppState, bool) {
 		return nil, false
 	}
 	state := &appserver.AppState{AppConfig: ac, Status: appserver.AppStatusStopped}
-	if err, ok := l.procM.ErrorByName(ac.Name); ok {
-		if err != "" {
-			state.DetailedStatus = err
-			state.Status = appserver.AppStatusErrored
-		}
+	// Check for stored error first (persists after proc cleanup)
+	var savedError string
+	if err, ok := l.procM.ErrorByName(ac.Name); ok && err != "" {
+		savedError = err
+		state.DetailedStatus = err
+		state.Status = appserver.AppStatusErrored
 	}
 	if proc, ok := l.procM.ProcByName(ac.Name); ok {
-		state.DetailedStatus = proc.DetailedStatus()
+		procStatus := proc.DetailedStatus()
 		connSummary := proc.ConnectionsSummary()
 		if connSummary != nil {
 			state.Status = appserver.AppStatusRunning
-		}
-		// Check if the proc is actually running - this handles apps that don't use connections
-		// (like skynet server which only registers ports via RPC)
-		if proc.IsRunning() && state.DetailedStatus == appserver.AppDetailedStatusRunning {
+			state.DetailedStatus = procStatus
+		} else if proc.IsRunning() && procStatus == appserver.AppDetailedStatusRunning {
+			// App is running but doesn't use connections (e.g. skynet server)
 			state.Status = appserver.AppStatusRunning
+			state.DetailedStatus = procStatus
+		} else if savedError != "" {
+			// Proc exists but not running — preserve the saved error
+			state.DetailedStatus = savedError
+			state.Status = appserver.AppStatusErrored
+		} else {
+			state.DetailedStatus = procStatus
 		}
-		switch state.DetailedStatus {
+		switch procStatus {
 		case appserver.AppDetailedStatusVPNConnecting, appserver.AppDetailedStatusStarting, appserver.AppDetailedStatusReconnecting:
 			state.Status = appserver.AppStatusStarting
+			state.DetailedStatus = procStatus
 		}
 	}
 	return state, true


### PR DESCRIPTION
- Fix skychat ignoring --addr when full host:port is provided (e.g. 127.0.0.1:9001 fell through to hardcoded 127.0.0.1:8001)
- Show actual app error when proxy client stops unexpectedly instead of just printing "Stopped!Stopped"
- Fix AppState() overwriting saved error with generic proc status during cleanup race window
