### PR TITLE
Fix accept loop crash on stale route with missing transport

### DIFF
--- a/cmd/skywire-cli/commands/route/route.go
+++ b/cmd/skywire-cli/commands/route/route.go
@@ -150,6 +150,7 @@ func init() {
 		addRuleCmd,
 		findCmd,
 		calcCmd,
+		groupsCmd,
 	)
 	addRuleCmd.PersistentFlags().DurationVarP(&keepAlive, "keep-alive", "a", router.DefaultRouteKeepAlive, "timeout for rule expiration")
 	addRuleCmd.AddCommand(
@@ -501,4 +502,42 @@ func parseUint(cmdFlags *pflag.FlagSet, name, v string, bitSize int) uint64 {
 		internal.PrintFatalError(cmdFlags, fmt.Errorf("failed to parse <%s>: %v", name, err))
 	}
 	return i
+}
+
+var groupsCmd = &cobra.Command{
+	Use:   "groups",
+	Short: "List active route groups",
+	Long:  "\n    List active route groups with their consume and forward rules",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		rgs, err := rpcClient.RouteGroups()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to get route groups: %w", err))
+		}
+		if len(rgs) == 0 {
+			fmt.Println("No active route groups")
+			return
+		}
+
+		var b bytes.Buffer
+		w := tabwriter.NewWriter(&b, 0, 0, 3, ' ', tabwriter.TabIndent)
+		fmt.Fprintln(w, "index\tlocal_pk\tremote_pk\tlocal_port\tremote_port\tfwd_id\tconsume_id") //nolint:errcheck
+		for i, rg := range rgs {
+			desc := rg.FwdRule.RouteDescriptor()
+			fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%d\t%d\t%d\n", //nolint:errcheck
+				i,
+				desc.SrcPK(),
+				desc.DstPK(),
+				desc.SrcPort(),
+				desc.DstPort(),
+				rg.FwdRule.KeyRouteID(),
+				rg.ConsumeRule.KeyRouteID(),
+			)
+		}
+		internal.Catch(cmd.Flags(), w.Flush())
+		internal.PrintOutput(cmd.Flags(), rgs, b.String())
+	},
 }

--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -170,8 +170,15 @@ func (r *SkywireNetworker) serveRouteGroup(ctx context.Context) error {
 
 		conn, err := r.r.AcceptRoutes(ctx)
 		if err != nil {
-			log.WithError(err).Debug("Stopped accepting routes.")
-			return err
+			// Check if context was canceled (normal shutdown)
+			if ctx.Err() != nil {
+				log.WithError(err).Debug("Stopped accepting routes.")
+				return err
+			}
+			// Non-fatal error (e.g., missing transport for a stale route).
+			// Log and continue accepting — don't kill the accept loop.
+			log.WithError(err).Warn("Failed to accept route group, continuing...")
+			continue
 		}
 
 		log.

--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -86,7 +86,11 @@ func (sn *Node) Serve(ctx context.Context, m setupmetrics.Metrics) error {
 	for {
 		conn, err := lis.AcceptStream()
 		if err != nil {
-			return err
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.WithError(err).Warn("Failed to accept dmsg stream, continuing...")
+			continue
 		}
 		gw := &SetupRPCGateway{
 			Metrics: m,
@@ -98,7 +102,9 @@ func (sn *Node) Serve(ctx context.Context, m setupmetrics.Metrics) error {
 		}
 		rpcS := rpc.NewServer()
 		if err := rpcS.Register(gw); err != nil {
-			return err
+			log.WithError(err).Error("Failed to register RPC gateway")
+			conn.Close() //nolint:errcheck,gosec
+			continue
 		}
 		go rpcS.ServeConn(conn)
 	}

--- a/pkg/transport-setup/api/rpc_gateway.go
+++ b/pkg/transport-setup/api/rpc_gateway.go
@@ -161,12 +161,12 @@ func (api *API) ServeDmsg(ctx context.Context) error {
 	for {
 		conn, err := lis.AcceptStream()
 		if err != nil {
-			if errors.Is(err, dmsg.ErrEntityClosed) {
+			if errors.Is(err, dmsg.ErrEntityClosed) || ctx.Err() != nil {
 				log.Debug("Dmsg client stopped serving")
 				return nil
 			}
-			log.WithError(err).Error("Failed to accept dmsg stream")
-			return err
+			log.WithError(err).Warn("Failed to accept dmsg stream, continuing...")
+			continue
 		}
 
 		remotePK := conn.RawRemoteAddr().PK

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -2917,20 +2917,20 @@ func (v *Visor) RouteGroups() ([]RouteGroupInfo, error) {
 	var routegroups []RouteGroupInfo
 
 	rules := v.router.Rules()
-	for _, rule := range rules {
-		if rule.Type() != routing.RuleReverse {
+	for _, consumeRule := range rules {
+		if consumeRule.Type() != routing.RuleReverse {
 			continue
 		}
 
-		fwdRID := rule.NextRouteID()
-		rule, err := v.router.Rule(fwdRID)
+		fwdRID := consumeRule.NextRouteID()
+		fwdRule, err := v.router.Rule(fwdRID)
 		if err != nil {
-			return nil, err
+			continue // forward rule may have been GC'd
 		}
 
 		routegroups = append(routegroups, RouteGroupInfo{
-			ConsumeRule: rule,
-			FwdRule:     rule,
+			ConsumeRule: consumeRule,
+			FwdRule:     fwdRule,
 		})
 	}
 

--- a/pkg/visor/embedded_tps.go
+++ b/pkg/visor/embedded_tps.go
@@ -108,8 +108,8 @@ func (tps *embeddedTPS) Serve(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return nil
 			}
-			tps.log.WithError(err).Error("Failed to accept dmsg stream")
-			return err
+			tps.log.WithError(err).Warn("Failed to accept dmsg stream, continuing...")
+			continue
 		}
 
 		remotePK := conn.RawRemoteAddr().PK

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -129,7 +129,11 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 	for {
 		conn, err := lis.AcceptStream()
 		if err != nil {
-			return err
+			if ctx.Err() != nil {
+				return nil
+			}
+			hv.visor.MasterLogger().PackageLogger("hypervisor").WithError(err).Warn("Failed to accept dmsg stream, continuing...")
+			continue
 		}
 
 		addr := conn.RawRemoteAddr()

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -654,8 +654,8 @@ func (r *RPC) RemoveRoutingRule(key *routing.RouteID, _ *struct{}) (err error) {
 
 // RouteGroupInfo is a human-understandable representation of a RouteGroup.
 type RouteGroupInfo struct {
-	ConsumeRule routing.Rule
-	FwdRule     routing.Rule
+	ConsumeRule routing.Rule `json:"consume_rule"`
+	FwdRule     routing.Rule `json:"fwd_rule"`
 }
 
 // RouteGroups retrieves routegroups via rules of the routing table.


### PR DESCRIPTION
The serveRouteGroup accept loop would permanently die when AcceptRoutes returned an error from saveRouteGroupRules (e.g., "transport not found locally" for a stale route from a disconnected visor). After this, no new connections could be accepted — including valid proxy connections.

Fix: distinguish fatal errors (context canceled) from per-route errors. On per-route errors, log a warning and continue the accept loop instead of returning and killing the goroutine.
