### PR TITLE
Handle ping/latency routes directly in IntroduceRules, bypass accept queue

### DIFF
--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -29,6 +29,7 @@ import (
 	cliskychat "github.com/skycoin/skywire/cmd/skywire-cli/commands/skychat"
 	cliskynet "github.com/skycoin/skywire/cmd/skywire-cli/commands/skynet"
 	clisurvey "github.com/skycoin/skywire/cmd/skywire-cli/commands/survey"
+	clisvc "github.com/skycoin/skywire/cmd/skywire-cli/commands/svc"
 	clitp "github.com/skycoin/skywire/cmd/skywire-cli/commands/tp"
 	clitps "github.com/skycoin/skywire/cmd/skywire-cli/commands/tps"
 	cliut "github.com/skycoin/skywire/cmd/skywire-cli/commands/ut"
@@ -62,6 +63,7 @@ func init() {
 		clilog.RootCmd,
 		cliskysocksc.RootCmd,
 		clipv.RootCmd,
+		clisvc.RootCmd,
 		cliutil.RootCmd,
 		treeCmd,
 		docCmd,

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -1,0 +1,159 @@
+// Package clisvc cmd/skywire-cli/commands/svc/fetch.go
+package clisvc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
+)
+
+func init() {
+	tpdCmd.PersistentFlags().BoolVar(&directQuery, "direct", false, "query directly instead of via visor RPC")
+	tpdCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+
+	arCmd.PersistentFlags().BoolVar(&directQuery, "direct", false, "query directly instead of via visor RPC")
+	arCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+
+	nmCmd.PersistentFlags().BoolVar(&directQuery, "direct", false, "query directly instead of via visor RPC")
+	nmCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+
+	RootCmd.AddCommand(tpdCmd, arCmd, nmCmd)
+}
+
+// fetchViaVisorOrDirect fetches data from a service, preferring visor RPC.
+func fetchViaVisorOrDirect(cmd *cobra.Command, service, path, directURL string) ([]byte, error) {
+	if !directQuery {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err == nil {
+			data, err := rpcClient.FetchServiceData(service, path)
+			if err == nil {
+				return data, nil
+			}
+		}
+	}
+
+	// Direct fallback
+	url := strings.TrimSuffix(directURL, "/") + path
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	return io.ReadAll(resp.Body)
+}
+
+func prettyJSON(data []byte) string {
+	var v interface{}
+	if json.Unmarshal(data, &v) == nil {
+		pretty, err := json.MarshalIndent(v, "", "  ")
+		if err == nil {
+			return string(pretty)
+		}
+	}
+	return string(data)
+}
+
+// --- TPD subcommands ---
+
+var tpdCmd = &cobra.Command{
+	Use:   "tpd",
+	Short: "Transport Discovery endpoints",
+	Long:  "\n    Query Transport Discovery service endpoints",
+}
+
+func init() {
+	tpdCmd.AddCommand(
+		tpdStatsCmd,
+		tpdVersionsCmd,
+		tpdBandwidthCmd,
+	)
+}
+
+var tpdStatsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Network-wide transport statistics",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/all-transports/stats", deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdVersionsCmd = &cobra.Command{
+	Use:   "versions",
+	Short: "Version statistics from transport discovery",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/version", deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdBandwidthVisorPK string
+
+func init() {
+	tpdBandwidthCmd.Flags().StringVarP(&tpdBandwidthVisorPK, "pk", "p", "", "visor public key")
+}
+
+var tpdBandwidthCmd = &cobra.Command{
+	Use:   "bandwidth",
+	Short: "Bandwidth data from transport discovery",
+	Long:  "\n    Query bandwidth data. Use --pk for a specific visor.",
+	Run: func(cmd *cobra.Command, _ []string) {
+		path := "/metric"
+		if tpdBandwidthVisorPK != "" {
+			path = "/bandwidth/visor/" + tpdBandwidthVisorPK
+		}
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", path, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+// --- AR subcommand ---
+
+var arCmd = &cobra.Command{
+	Use:   "ar",
+	Short: "Address Resolver endpoints",
+	Long:  "\n    Query Address Resolver service endpoints",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "ar", "/transports", deployment.Prod.AddressResolver)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+// --- NM subcommand ---
+
+var nmCmd = &cobra.Command{
+	Use:   "nm",
+	Short: "Network Monitor status",
+	Long:  "\n    Query Network Monitor service status",
+	Run: func(cmd *cobra.Command, _ []string) {
+		// Network monitor URL isn't in the standard deployment config,
+		// so we try a known path or fall back
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/health", deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -51,7 +51,7 @@ func fetchViaVisorOrDirect(cmd *cobra.Command, service, path, directURL string) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer resp.Body.Close() //nolint:errcheck,gosec
 	return io.ReadAll(resp.Body)
 }
 
@@ -128,7 +128,7 @@ var tpdVisorStatsPK string
 
 func init() {
 	tpdVisorStatsCmd.Flags().StringVarP(&tpdVisorStatsPK, "pk", "p", "", "visor public key (required)")
-	tpdVisorStatsCmd.MarkFlagRequired("pk") //nolint:errcheck
+	tpdVisorStatsCmd.MarkFlagRequired("pk") //nolint:errcheck,gosec
 }
 
 var tpdVisorStatsCmd = &cobra.Command{
@@ -169,7 +169,7 @@ var tpdBandwidthTpID string
 
 func init() {
 	tpdBandwidthTpCmd.Flags().StringVarP(&tpdBandwidthTpID, "id", "i", "", "transport ID (required)")
-	tpdBandwidthTpCmd.MarkFlagRequired("id") //nolint:errcheck
+	tpdBandwidthTpCmd.MarkFlagRequired("id") //nolint:errcheck,gosec
 }
 
 var tpdBandwidthTpCmd = &cobra.Command{
@@ -188,7 +188,7 @@ var tpdVersionsPKs string
 
 func init() {
 	tpdVersionsPKCmd.Flags().StringVarP(&tpdVersionsPKs, "pks", "p", "", "comma-separated public keys (required)")
-	tpdVersionsPKCmd.MarkFlagRequired("pks") //nolint:errcheck
+	tpdVersionsPKCmd.MarkFlagRequired("pks") //nolint:errcheck,gosec
 }
 
 var tpdVersionsPKCmd = &cobra.Command{
@@ -207,7 +207,7 @@ var tpdMetricsVisorPKs string
 
 func init() {
 	tpdMetricsVisorCmd.Flags().StringVarP(&tpdMetricsVisorPKs, "pks", "p", "", "comma-separated public keys (required)")
-	tpdMetricsVisorCmd.MarkFlagRequired("pks") //nolint:errcheck
+	tpdMetricsVisorCmd.MarkFlagRequired("pks") //nolint:errcheck,gosec
 }
 
 var tpdMetricsVisorCmd = &cobra.Command{
@@ -226,7 +226,7 @@ var tpdMetricsTpIDs string
 
 func init() {
 	tpdMetricsTpCmd.Flags().StringVarP(&tpdMetricsTpIDs, "ids", "i", "", "comma-separated transport IDs (required)")
-	tpdMetricsTpCmd.MarkFlagRequired("ids") //nolint:errcheck
+	tpdMetricsTpCmd.MarkFlagRequired("ids") //nolint:errcheck,gosec
 }
 
 var tpdMetricsTpCmd = &cobra.Command{
@@ -285,7 +285,7 @@ var dmsgdServerClientsPK string
 
 func init() {
 	dmsgdServerClientsPKCmd.Flags().StringVarP(&dmsgdServerClientsPK, "pk", "p", "", "server public key (required)")
-	dmsgdServerClientsPKCmd.MarkFlagRequired("pk") //nolint:errcheck
+	dmsgdServerClientsPKCmd.MarkFlagRequired("pk") //nolint:errcheck,gosec
 }
 
 var dmsgdServerClientsPKCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -26,7 +26,10 @@ func init() {
 	nmCmd.PersistentFlags().BoolVar(&directQuery, "direct", false, "query directly instead of via visor RPC")
 	nmCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 
-	RootCmd.AddCommand(tpdCmd, arCmd, nmCmd)
+	dmsgdCmd.PersistentFlags().BoolVar(&directQuery, "direct", false, "query directly instead of via visor RPC")
+	dmsgdCmd.PersistentFlags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+
+	RootCmd.AddCommand(tpdCmd, dmsgdCmd, arCmd, nmCmd)
 }
 
 // fetchViaVisorOrDirect fetches data from a service, preferring visor RPC.
@@ -74,8 +77,14 @@ var tpdCmd = &cobra.Command{
 func init() {
 	tpdCmd.AddCommand(
 		tpdStatsCmd,
+		tpdPerKeyStatsCmd,
+		tpdVisorStatsCmd,
 		tpdVersionsCmd,
+		tpdVersionsPKCmd,
 		tpdBandwidthCmd,
+		tpdBandwidthTpCmd,
+		tpdMetricsVisorCmd,
+		tpdMetricsTpCmd,
 	)
 }
 
@@ -103,22 +112,187 @@ var tpdVersionsCmd = &cobra.Command{
 	},
 }
 
+var tpdPerKeyStatsCmd = &cobra.Command{
+	Use:   "per-key-stats",
+	Short: "Per-visor transport statistics",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/all-transports/per-key-stats", deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdVisorStatsPK string
+
+func init() {
+	tpdVisorStatsCmd.Flags().StringVarP(&tpdVisorStatsPK, "pk", "p", "", "visor public key (required)")
+	tpdVisorStatsCmd.MarkFlagRequired("pk") //nolint:errcheck
+}
+
+var tpdVisorStatsCmd = &cobra.Command{
+	Use:   "visor-stats",
+	Short: "Transport count statistics for a specific visor",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/transports/stats/"+tpdVisorStatsPK, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
 var tpdBandwidthVisorPK string
 
 func init() {
-	tpdBandwidthCmd.Flags().StringVarP(&tpdBandwidthVisorPK, "pk", "p", "", "visor public key")
+	tpdBandwidthCmd.Flags().StringVarP(&tpdBandwidthVisorPK, "pk", "p", "", "visor public key (omit for network-wide)")
 }
 
 var tpdBandwidthCmd = &cobra.Command{
 	Use:   "bandwidth",
-	Short: "Bandwidth data from transport discovery",
-	Long:  "\n    Query bandwidth data. Use --pk for a specific visor.",
+	Short: "Bandwidth data (network-wide or per-visor)",
 	Run: func(cmd *cobra.Command, _ []string) {
 		path := "/metric"
 		if tpdBandwidthVisorPK != "" {
 			path = "/bandwidth/visor/" + tpdBandwidthVisorPK
 		}
 		data, err := fetchViaVisorOrDirect(cmd, "tpd", path, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdBandwidthTpID string
+
+func init() {
+	tpdBandwidthTpCmd.Flags().StringVarP(&tpdBandwidthTpID, "id", "i", "", "transport ID (required)")
+	tpdBandwidthTpCmd.MarkFlagRequired("id") //nolint:errcheck
+}
+
+var tpdBandwidthTpCmd = &cobra.Command{
+	Use:   "bandwidth-tp",
+	Short: "Bandwidth history for a specific transport",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/bandwidth/transport/"+tpdBandwidthTpID, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdVersionsPKs string
+
+func init() {
+	tpdVersionsPKCmd.Flags().StringVarP(&tpdVersionsPKs, "pks", "p", "", "comma-separated public keys (required)")
+	tpdVersionsPKCmd.MarkFlagRequired("pks") //nolint:errcheck
+}
+
+var tpdVersionsPKCmd = &cobra.Command{
+	Use:   "versions-pk",
+	Short: "Version info for specific public keys",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/versions/"+tpdVersionsPKs, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdMetricsVisorPKs string
+
+func init() {
+	tpdMetricsVisorCmd.Flags().StringVarP(&tpdMetricsVisorPKs, "pks", "p", "", "comma-separated public keys (required)")
+	tpdMetricsVisorCmd.MarkFlagRequired("pks") //nolint:errcheck
+}
+
+var tpdMetricsVisorCmd = &cobra.Command{
+	Use:   "metrics-visor",
+	Short: "Metrics for specific visor(s)",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/metrics/visor/"+tpdMetricsVisorPKs, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var tpdMetricsTpIDs string
+
+func init() {
+	tpdMetricsTpCmd.Flags().StringVarP(&tpdMetricsTpIDs, "ids", "i", "", "comma-separated transport IDs (required)")
+	tpdMetricsTpCmd.MarkFlagRequired("ids") //nolint:errcheck
+}
+
+var tpdMetricsTpCmd = &cobra.Command{
+	Use:   "metrics-tp",
+	Short: "Metrics for specific transport(s)",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", "/metrics/"+tpdMetricsTpIDs, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+// --- DMSG Discovery subcommands ---
+
+var dmsgdCmd = &cobra.Command{
+	Use:   "dmsgd",
+	Short: "DMSG Discovery endpoints",
+	Long:  "\n    Query DMSG Discovery service endpoints",
+}
+
+func init() {
+	dmsgdCmd.AddCommand(
+		dmsgdAllServersCmd,
+		dmsgdServerClientsCmd,
+		dmsgdServerClientsPKCmd,
+	)
+}
+
+var dmsgdAllServersCmd = &cobra.Command{
+	Use:   "all-servers",
+	Short: "List all DMSG servers",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "dmsgd", "/dmsg-discovery/all_servers", deployment.Prod.DmsgDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var dmsgdServerClientsCmd = &cobra.Command{
+	Use:   "server-clients",
+	Short: "List all clients grouped by server",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "dmsgd", "/dmsg-discovery/servers/clients", deployment.Prod.DmsgDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(prettyJSON(data))
+	},
+}
+
+var dmsgdServerClientsPK string
+
+func init() {
+	dmsgdServerClientsPKCmd.Flags().StringVarP(&dmsgdServerClientsPK, "pk", "p", "", "server public key (required)")
+	dmsgdServerClientsPKCmd.MarkFlagRequired("pk") //nolint:errcheck
+}
+
+var dmsgdServerClientsPKCmd = &cobra.Command{
+	Use:   "clients",
+	Short: "List clients for a specific DMSG server",
+	Run: func(cmd *cobra.Command, _ []string) {
+		data, err := fetchViaVisorOrDirect(cmd, "dmsgd", "/dmsg-discovery/server/"+dmsgdServerClientsPK+"/clients", deployment.Prod.DmsgDiscovery)
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -11,9 +11,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
 	"github.com/skycoin/skywire/deployment"
+	skyvisor "github.com/skycoin/skywire/pkg/visor"
 )
+
+var directQuery bool
 
 // RootCmd is the svc command
 var RootCmd = &cobra.Command{
@@ -23,88 +27,107 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
+	healthCmd.Flags().BoolVar(&directQuery, "direct", false, "query services directly instead of via visor RPC")
+	healthCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 	RootCmd.AddCommand(healthCmd)
-}
-
-type serviceHealth struct {
-	Name    string `json:"name"`
-	URL     string `json:"url"`
-	Status  string `json:"status"`
-	Version string `json:"version,omitempty"`
-	Latency string `json:"latency,omitempty"`
 }
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
 	Short: "Check health of all deployment services",
-	Long:  "\n    Check the /health endpoint of all skywire deployment services",
+	Long: `    Check the /health endpoint of all skywire deployment services.
+
+    By default queries via the local visor RPC (uses visor's configured URLs).
+    Use --direct to query services directly from the CLI.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		services := map[string]string{
-			"Transport Discovery": deployment.Prod.TransportDiscovery,
-			"DMSG Discovery":      deployment.Prod.DmsgDiscovery,
-			"Address Resolver":    deployment.Prod.AddressResolver,
-			"Route Finder":        deployment.Prod.RouteFinder,
-			"Uptime Tracker":      deployment.Prod.UptimeTracker,
-			"Service Discovery":   deployment.Prod.ServiceDiscovery,
-		}
+		var results []skyvisor.ServiceHealthEntry
 
-		client := &http.Client{Timeout: 10 * time.Second}
-		var results []serviceHealth
-
-		for name, baseURL := range services {
-			if baseURL == "" {
-				continue
-			}
-			url := strings.TrimSuffix(baseURL, "/") + "/health"
-			result := serviceHealth{Name: name, URL: baseURL}
-
-			start := time.Now()
-			resp, err := client.Get(url) //nolint:gosec
-			latency := time.Since(start)
-			result.Latency = fmt.Sprintf("%dms", latency.Milliseconds())
-
-			if err != nil {
-				result.Status = "DOWN"
-				results = append(results, result)
-				continue
-			}
-			defer resp.Body.Close() //nolint:errcheck
-
-			if resp.StatusCode != http.StatusOK {
-				result.Status = fmt.Sprintf("ERROR(%d)", resp.StatusCode)
-				results = append(results, result)
-				continue
-			}
-
-			body, _ := io.ReadAll(resp.Body) //nolint:errcheck
-			var health map[string]interface{}
-			if json.Unmarshal(body, &health) == nil {
-				if bi, ok := health["build_info"].(map[string]interface{}); ok {
-					if v, ok := bi["version"].(string); ok {
-						result.Version = v
-					}
-				}
-				// Some services put version at top level
-				if result.Version == "" {
-					if v, ok := health["version"].(string); ok {
-						result.Version = v
-					}
+		if !directQuery {
+			// Try via visor RPC first
+			rpcClient, err := clirpc.Client(cmd.Flags())
+			if err == nil {
+				results, err = rpcClient.ServiceHealth()
+				if err == nil && len(results) > 0 {
+					printHealthResults(cmd, results)
+					return
 				}
 			}
-			result.Status = "OK"
-			results = append(results, result)
+			// Fall through to direct query
+			fmt.Println("(visor not available, querying services directly)")
 		}
 
-		// Print results
-		for _, r := range results {
-			status := r.Status
-			ver := ""
-			if r.Version != "" {
-				ver = " (" + r.Version + ")"
-			}
-			fmt.Printf("%-22s %-6s %s%s\n", r.Name, status, r.Latency, ver)
-		}
-
-		internal.PrintOutput(cmd.Flags(), results, "")
+		// Direct query fallback
+		results = queryServicesDirect()
+		printHealthResults(cmd, results)
 	},
+}
+
+func printHealthResults(cmd *cobra.Command, results []skyvisor.ServiceHealthEntry) {
+	for _, r := range results {
+		ver := ""
+		if r.Version != "" {
+			ver = " (" + r.Version + ")"
+		}
+		fmt.Printf("%-22s %-6s %dms%s\n", r.Name, r.Status, r.LatencyMs, ver)
+	}
+	internal.PrintOutput(cmd.Flags(), results, "")
+}
+
+func queryServicesDirect() []skyvisor.ServiceHealthEntry {
+	services := map[string]string{
+		"Transport Discovery": deployment.Prod.TransportDiscovery,
+		"DMSG Discovery":      deployment.Prod.DmsgDiscovery,
+		"Address Resolver":    deployment.Prod.AddressResolver,
+		"Route Finder":        deployment.Prod.RouteFinder,
+		"Uptime Tracker":      deployment.Prod.UptimeTracker,
+		"Service Discovery":   deployment.Prod.ServiceDiscovery,
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	var results []skyvisor.ServiceHealthEntry
+
+	for name, baseURL := range services {
+		if baseURL == "" {
+			continue
+		}
+		url := strings.TrimSuffix(baseURL, "/") + "/health"
+		entry := skyvisor.ServiceHealthEntry{Name: name, URL: baseURL}
+
+		start := time.Now()
+		resp, err := client.Get(url) //nolint:gosec
+		entry.LatencyMs = time.Since(start).Milliseconds()
+
+		if err != nil {
+			entry.Status = "DOWN"
+			results = append(results, entry)
+			continue
+		}
+
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+		resp.Body.Close()                //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			entry.Status = fmt.Sprintf("ERROR(%d)", resp.StatusCode)
+			results = append(results, entry)
+			continue
+		}
+
+		var health map[string]interface{}
+		if json.Unmarshal(body, &health) == nil {
+			if bi, ok := health["build_info"].(map[string]interface{}); ok {
+				if v, ok := bi["version"].(string); ok {
+					entry.Version = v
+				}
+			}
+			if entry.Version == "" {
+				if v, ok := health["version"].(string); ok {
+					entry.Version = v
+				}
+			}
+		}
+		entry.Status = "OK"
+		results = append(results, entry)
+	}
+
+	return results
 }

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -1,0 +1,110 @@
+// Package clisvc cmd/skywire-cli/commands/svc/health.go
+package clisvc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/skywire-cli/internal"
+	"github.com/skycoin/skywire/deployment"
+)
+
+// RootCmd is the svc command
+var RootCmd = &cobra.Command{
+	Use:   "svc",
+	Short: "Query skywire deployment services",
+	Long:  "\n    Query skywire deployment services (health, stats)",
+}
+
+func init() {
+	RootCmd.AddCommand(healthCmd)
+}
+
+type serviceHealth struct {
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Status  string `json:"status"`
+	Version string `json:"version,omitempty"`
+	Latency string `json:"latency,omitempty"`
+}
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Check health of all deployment services",
+	Long:  "\n    Check the /health endpoint of all skywire deployment services",
+	Run: func(cmd *cobra.Command, _ []string) {
+		services := map[string]string{
+			"Transport Discovery": deployment.Prod.TransportDiscovery,
+			"DMSG Discovery":      deployment.Prod.DmsgDiscovery,
+			"Address Resolver":    deployment.Prod.AddressResolver,
+			"Route Finder":        deployment.Prod.RouteFinder,
+			"Uptime Tracker":      deployment.Prod.UptimeTracker,
+			"Service Discovery":   deployment.Prod.ServiceDiscovery,
+		}
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		var results []serviceHealth
+
+		for name, baseURL := range services {
+			if baseURL == "" {
+				continue
+			}
+			url := strings.TrimSuffix(baseURL, "/") + "/health"
+			result := serviceHealth{Name: name, URL: baseURL}
+
+			start := time.Now()
+			resp, err := client.Get(url) //nolint:gosec
+			latency := time.Since(start)
+			result.Latency = fmt.Sprintf("%dms", latency.Milliseconds())
+
+			if err != nil {
+				result.Status = "DOWN"
+				results = append(results, result)
+				continue
+			}
+			defer resp.Body.Close() //nolint:errcheck
+
+			if resp.StatusCode != http.StatusOK {
+				result.Status = fmt.Sprintf("ERROR(%d)", resp.StatusCode)
+				results = append(results, result)
+				continue
+			}
+
+			body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+			var health map[string]interface{}
+			if json.Unmarshal(body, &health) == nil {
+				if bi, ok := health["build_info"].(map[string]interface{}); ok {
+					if v, ok := bi["version"].(string); ok {
+						result.Version = v
+					}
+				}
+				// Some services put version at top level
+				if result.Version == "" {
+					if v, ok := health["version"].(string); ok {
+						result.Version = v
+					}
+				}
+			}
+			result.Status = "OK"
+			results = append(results, result)
+		}
+
+		// Print results
+		for _, r := range results {
+			status := r.Status
+			ver := ""
+			if r.Version != "" {
+				ver = " (" + r.Version + ")"
+			}
+			fmt.Printf("%-22s %-6s %s%s\n", r.Name, status, r.Latency, ver)
+		}
+
+		internal.PrintOutput(cmd.Flags(), results, "")
+	},
+}

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -103,8 +103,8 @@ func queryServicesDirect() []skyvisor.ServiceHealthEntry {
 			continue
 		}
 
-		body, _ := io.ReadAll(resp.Body) //nolint:errcheck
-		resp.Body.Close()                //nolint:errcheck
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck,gosec
+		resp.Body.Close()                //nolint:errcheck,gosec
 
 		if resp.StatusCode != http.StatusOK {
 			entry.Status = fmt.Sprintf("ERROR(%d)", resp.StatusCode)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1808,6 +1808,31 @@ func (r *router) IntroduceRules(rules routing.EdgeRules) error {
 	}
 	r.mx.Unlock()
 
+	// Handle ping/latency probe routes (port 46) directly without going through
+	// the accept channel. These are ephemeral routes from other visors measuring
+	// transport latency — they don't need to be delivered to any application.
+	// Processing them in-line prevents them from blocking application routes
+	// (proxy, VPN) in the accept queue, where each route blocks for up to the
+	// handshake timeout (30s).
+	if rules.Desc.DstPort() == routing.Port(skyenv.LatencyProbePort) || rules.Desc.SrcPort() == routing.Port(skyenv.LatencyProbePort) {
+		go func() {
+			nsConf := noise.Config{
+				LocalPK:   r.conf.PubKey,
+				LocalSK:   r.conf.SecKey,
+				RemotePK:  rules.Desc.SrcPK(),
+				Initiator: false,
+			}
+			nrg, err := r.saveRouteGroupRules(context.Background(), rules, nsConf)
+			if err != nil {
+				r.logger.WithError(err).Debug("Failed to setup ping route group (non-blocking)")
+				r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+				return
+			}
+			nrg.rg.startOffServiceLoops()
+		}()
+		return nil
+	}
+
 	select {
 	case <-r.done:
 		return io.ErrClosedPipe

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -140,6 +140,7 @@ type API interface {
 	RemoveRoutingRule(key routing.RouteID) error
 	RouteGroups() ([]RouteGroupInfo, error)
 	ServiceHealth() ([]ServiceHealthEntry, error)
+	FetchServiceData(service, path string) ([]byte, error)
 	SetMinHops(uint16) error
 	SetCalculateRoutes(enabled bool) error
 	GetCalculateRoutes() (bool, error)
@@ -3039,6 +3040,51 @@ func (v *Visor) ServiceHealth() ([]ServiceHealthEntry, error) {
 	}
 
 	return results, nil
+}
+
+// FetchServiceData fetches data from a deployment service endpoint via the visor's
+// configured URLs. service is one of: tpd, ut, sd, ar, rf, dmsgd.
+// path is the URL path (e.g., "/all-transports/stats").
+func (v *Visor) FetchServiceData(service, path string) ([]byte, error) {
+	baseURL := ""
+	switch service {
+	case "tpd":
+		baseURL = v.conf.Transport.Discovery
+	case "ut":
+		if v.conf.UptimeTracker != nil {
+			baseURL = v.conf.UptimeTracker.Addr
+		}
+	case "sd":
+		baseURL = v.conf.Launcher.ServiceDisc
+	case "ar":
+		baseURL = v.conf.Transport.AddressResolver
+	case "rf":
+		baseURL = v.conf.Routing.RouteFinder
+	case "dmsgd":
+		baseURL = v.conf.Dmsg.Discovery
+	default:
+		return nil, fmt.Errorf("unknown service: %s (valid: tpd, ut, sd, ar, rf, dmsgd)", service)
+	}
+	if baseURL == "" {
+		return nil, fmt.Errorf("service %s not configured", service)
+	}
+
+	url := strings.TrimSuffix(baseURL, "/") + path
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("service returned %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
 }
 
 // Reload implements API.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -139,6 +139,7 @@ type API interface {
 	SaveRoutingRule(rule routing.Rule) error
 	RemoveRoutingRule(key routing.RouteID) error
 	RouteGroups() ([]RouteGroupInfo, error)
+	ServiceHealth() ([]ServiceHealthEntry, error)
 	SetMinHops(uint16) error
 	SetCalculateRoutes(enabled bool) error
 	GetCalculateRoutes() (bool, error)
@@ -2968,6 +2969,76 @@ func (v *Visor) RouteGroups() (rgs []RouteGroupInfo, err error) {
 	}
 
 	return rgs, nil
+}
+
+// ServiceHealthEntry represents the health status of a deployment service.
+type ServiceHealthEntry struct {
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	Status    string `json:"status"`
+	Version   string `json:"version,omitempty"`
+	LatencyMs int64  `json:"latency_ms"`
+}
+
+// ServiceHealth checks the health of all configured deployment services.
+func (v *Visor) ServiceHealth() ([]ServiceHealthEntry, error) {
+	services := map[string]string{
+		"Transport Discovery": v.conf.Transport.Discovery,
+		"Address Resolver":    v.conf.Transport.AddressResolver,
+		"Route Finder":        v.conf.Routing.RouteFinder,
+		"DMSG Discovery":      v.conf.Dmsg.Discovery,
+	}
+	if v.conf.UptimeTracker != nil {
+		services["Uptime Tracker"] = v.conf.UptimeTracker.Addr
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	var results []ServiceHealthEntry
+
+	for name, baseURL := range services {
+		if baseURL == "" {
+			continue
+		}
+		url := strings.TrimSuffix(baseURL, "/") + "/health"
+		entry := ServiceHealthEntry{Name: name, URL: baseURL}
+
+		start := time.Now()
+		resp, err := client.Get(url) //nolint:gosec
+		entry.LatencyMs = time.Since(start).Milliseconds()
+
+		if err != nil {
+			entry.Status = "DOWN"
+			results = append(results, entry)
+			continue
+		}
+
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+		resp.Body.Close()                //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			entry.Status = fmt.Sprintf("ERROR(%d)", resp.StatusCode)
+			results = append(results, entry)
+			continue
+		}
+
+		var health map[string]interface{}
+		if json.Unmarshal(body, &health) == nil {
+			if bi, ok := health["build_info"].(map[string]interface{}); ok {
+				if ver, ok := bi["version"].(string); ok {
+					entry.Version = ver
+				}
+			}
+			if entry.Version == "" {
+				if ver, ok := health["version"].(string); ok {
+					entry.Version = ver
+				}
+			}
+		}
+		entry.Status = "OK"
+		results = append(results, entry)
+	}
+
+	return results, nil
 }
 
 // Reload implements API.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -3013,8 +3013,8 @@ func (v *Visor) ServiceHealth() ([]ServiceHealthEntry, error) {
 			continue
 		}
 
-		body, _ := io.ReadAll(resp.Body) //nolint:errcheck
-		resp.Body.Close()                //nolint:errcheck
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck,gosec
+		resp.Body.Close()                //nolint:errcheck,gosec
 
 		if resp.StatusCode != http.StatusOK {
 			entry.Status = fmt.Sprintf("ERROR(%d)", resp.StatusCode)
@@ -3075,7 +3075,7 @@ func (v *Visor) FetchServiceData(service, path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer resp.Body.Close() //nolint:errcheck,gosec
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -670,6 +670,14 @@ func (r *RPC) RouteGroups(_ *struct{}, out *[]RouteGroupInfo) (err error) {
 	return err
 }
 
+// ServiceHealth checks all deployment services.
+func (r *RPC) ServiceHealth(_ *struct{}, out *[]ServiceHealthEntry) (err error) {
+	defer rpcutil.LogCall(r.log, "ServiceHealth", nil)(out, &err)
+	entries, err := r.visor.ServiceHealth()
+	*out = entries
+	return err
+}
+
 /*
 	<<< VISOR MANAGEMENT >>>
 */

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -670,6 +670,20 @@ func (r *RPC) RouteGroups(_ *struct{}, out *[]RouteGroupInfo) (err error) {
 	return err
 }
 
+// FetchServiceDataIn is the input for FetchServiceData RPC.
+type FetchServiceDataIn struct {
+	Service string
+	Path    string
+}
+
+// FetchServiceData proxies a GET request to a deployment service.
+func (r *RPC) FetchServiceData(in *FetchServiceDataIn, out *[]byte) (err error) {
+	defer rpcutil.LogCall(r.log, "FetchServiceData", in)(out, &err)
+	data, err := r.visor.FetchServiceData(in.Service, in.Path)
+	*out = data
+	return err
+}
+
 // ServiceHealth checks all deployment services.
 func (r *RPC) ServiceHealth(_ *struct{}, out *[]ServiceHealthEntry) (err error) {
 	defer rpcutil.LogCall(r.log, "ServiceHealth", nil)(out, &err)

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -517,6 +517,13 @@ func (rc *rpcClient) RouteGroups() ([]RouteGroupInfo, error) {
 	return routegroups, err
 }
 
+// ServiceHealth calls ServiceHealth.
+func (rc *rpcClient) ServiceHealth() ([]ServiceHealthEntry, error) {
+	var entries []ServiceHealthEntry
+	err := rc.Call("ServiceHealth", &struct{}{}, &entries)
+	return entries, err
+}
+
 // Reload calls Reload.
 func (rc *rpcClient) Reload() error {
 	return rc.Call("Reload", &struct{}{}, &struct{}{})
@@ -1646,6 +1653,11 @@ func (mc *mockRPCClient) RouteGroups() ([]RouteGroupInfo, error) {
 	}
 
 	return routeGroups, nil
+}
+
+// ServiceHealth implements API.
+func (mc *mockRPCClient) ServiceHealth() ([]ServiceHealthEntry, error) {
+	return nil, nil
 }
 
 // Reload implements API.

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -517,6 +517,13 @@ func (rc *rpcClient) RouteGroups() ([]RouteGroupInfo, error) {
 	return routegroups, err
 }
 
+// FetchServiceData calls FetchServiceData.
+func (rc *rpcClient) FetchServiceData(service, path string) ([]byte, error) {
+	var data []byte
+	err := rc.Call("FetchServiceData", &FetchServiceDataIn{Service: service, Path: path}, &data)
+	return data, err
+}
+
 // ServiceHealth calls ServiceHealth.
 func (rc *rpcClient) ServiceHealth() ([]ServiceHealthEntry, error) {
 	var entries []ServiceHealthEntry
@@ -1653,6 +1660,11 @@ func (mc *mockRPCClient) RouteGroups() ([]RouteGroupInfo, error) {
 	}
 
 	return routeGroups, nil
+}
+
+// FetchServiceData implements API.
+func (mc *mockRPCClient) FetchServiceData(_, _ string) ([]byte, error) {
+	return nil, nil
 }
 
 // ServiceHealth implements API.


### PR DESCRIPTION
Ping routes (port 46) from other visors measuring transport latency were flooding the accept channel. Each one blocks AcceptRoutes for up to 30s (handshake timeout), creating a queue that prevents application routes (proxy, VPN) from being processed in time.

Fix: detect latency probe routes by port number in IntroduceRules and handle them in a goroutine directly, bypassing the accept channel. These routes don't need application delivery — they just need a RouteGroup for the ping/pong exchange. Application routes now get immediate access to AcceptRoutes without waiting behind ping routes.

