### PR TITLE
Fetch MSI installer images in Windows release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,10 +304,13 @@ jobs:
         shell: pwsh
         run: |
           $base = "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/win_installer"
-          New-Item -ItemType Directory -Force -Path "scripts\win_installer"
+          New-Item -ItemType Directory -Force -Path "scripts\win_installer\images"
           Invoke-WebRequest "$base/Product.wxs" -OutFile "scripts\win_installer\Product.wxs"
           Invoke-WebRequest "$base/UI.wxs" -OutFile "scripts\win_installer\UI.wxs"
           Invoke-WebRequest "$base/skywire.bat" -OutFile "scripts\win_installer\skywire.bat"
+          Invoke-WebRequest "$base/images/Banner.png" -OutFile "scripts\win_installer\images\Banner.png"
+          Invoke-WebRequest "$base/images/Dialog.png" -OutFile "scripts\win_installer\images\Dialog.png"
+          Invoke-WebRequest "$base/images/ico.ico" -OutFile "scripts\win_installer\images\ico.ico"
 
       - name: Build skywire
         env:


### PR DESCRIPTION
## Summary
- Fetch `Banner.png`, `Dialog.png`, and `ico.ico` from `scripts/win_installer/images/`
- WiX linker fails without these files: `error LGHT0103: The system cannot find the file`

Fixes Windows MSI build failure in v1.3.37-alpha5.

## Test plan
- [ ] Windows amd64 MSI builds successfully
- [ ] Windows 386 MSI builds successfully