### PR TITLE
Fix login chain bootstrap: three fixes for working startup

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/loginchain.go
+++ b/cmd/skywire-cli/commands/rewards/server/loginchain.go
@@ -175,6 +175,7 @@ func runLoginChain() {
 		"--block-publisher",
 		"--localhost-only",
 		"--download-peerlist=false",
+		"--disable-csrf",
 		"--data-dir="+publisherDataDir,
 		"--web-interface-port=6421",
 		"--port=6001",
@@ -239,7 +240,9 @@ func runLoginChain() {
 		"--port=6002",
 		"--log-level=warn",
 	)
-	peerCmd.Env = append(sharedEnv, "FIBER_TOML="+peerTOMLPath)
+	// Peer does NOT use GENESIS env — the signed fiber.toml has all credentials.
+	// GENESIS would clear the genesis signature, causing "Failed to recover pubkey".
+	peerCmd.Env = append(os.Environ(), "FIBER_TOML="+peerTOMLPath)
 	peerCmd.Stdout = os.Stdout
 	peerCmd.Stderr = os.Stderr
 
@@ -325,7 +328,7 @@ func bootstrapLoginChain(skywireBin, publisherURL, fiberTOMLPath, genesisPath, g
 	}
 
 	fmt.Println("Login chain: injecting bootstrap transaction...")
-	injectBody := fmt.Sprintf(`{"rawtx":"%s"}`, rawTxStr)
+	injectBody := fmt.Sprintf(`{"rawtx":"%s","no_broadcast":true}`, rawTxStr)
 	injectReq, err := http.NewRequest("POST", publisherURL+"/api/v1/injectTransaction", strings.NewReader(injectBody))
 	if err != nil {
 		return fmt.Errorf("inject request: %w", err)


### PR DESCRIPTION
## Summary
Three fixes tested and verified locally:

1. **Publisher needs `--disable-csrf`** — the bootstrap inject API call was getting 403 Forbidden
2. **Peer must NOT receive `GENESIS` env** — `GENESIS` clears `genesis_signature_str`, causing "Failed to recover pubkey from signature" even though the signed toml has the correct signature
3. **Inject uses `no_broadcast: true`** — P2P between localhost nodes is unstable (mirror detection), so inject without broadcast and let the block publisher include the tx

## Tested locally
```
Login chain: publisher is healthy
Login chain: peer is healthy
Login chain: creating bootstrap transaction...
Login chain: injecting bootstrap transaction...
Login chain: bootstrap tx injected: "fd46c06..."
Login chain: bootstrap complete — block #1 confirmed on peer
Login chain is running.
```