### PR TITLE
Fix login chain funding: use CLI for signed transactions

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/login.go
+++ b/cmd/skywire-cli/commands/rewards/server/login.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bitfield/script"
 	"github.com/gin-gonic/gin"
 
 	"github.com/skycoin/skywire/pkg/visor/rewardconfig"
@@ -115,57 +116,47 @@ func checkBalanceOnLoginChain(nodeURL, address string) (coins uint64, hours uint
 }
 
 // sendCoinsOnLoginChain sends coins from the genesis wallet to the target address
-// via the login chain node's API. Returns the transaction ID.
+// using the skycoin CLI (createRawTransaction + injectTransaction).
+// The CLI loads the genesis wallet file directly for signing.
 func sendCoinsOnLoginChain(nodeURL, destAddress string, coins string) (string, error) {
-	// Get CSRF token (optional — disabled on login chain)
-	var csrfToken string
-	csrfResp, err := http.Get(fmt.Sprintf("%s/api/v1/csrf", nodeURL)) //nolint:gosec
-	if err == nil {
-		defer csrfResp.Body.Close() //nolint:errcheck,gosec
-		if csrfResp.StatusCode == http.StatusOK {
-			csrfBody, _ := io.ReadAll(csrfResp.Body) //nolint:errcheck,gosec
-			var csrfData struct {
-				Token string `json:"csrf_token"`
-			}
-			if json.Unmarshal(csrfBody, &csrfData) == nil {
-				csrfToken = csrfData.Token
-			}
-		}
-	}
+	genesisPath := filepath.Join(wd, "login_genesis.json")
+	fiberTOMLPath := filepath.Join(wd, "login_fiber.toml")
 
-	// Create transaction using the genesis address as the funding source
-	txReq := fmt.Sprintf(`{"addresses":["%s"],"hours_selection":{"type":"auto","mode":"share","share_factor":"0.5"},"to":[{"address":"%s","coins":"%s"}]}`,
-		loginGenesisAddress, destAddress, coins)
-
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v2/transaction", nodeURL), strings.NewReader(txReq))
+	skywireBin, err := os.Executable()
 	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if csrfToken != "" {
-		req.Header.Set("X-CSRF-Token", csrfToken)
+		skywireBin = "skywire"
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	// Create raw transaction using the genesis wallet
+	rawTxStr, err := script.Exec(fmt.Sprintf(`bash -c 'FIBER_TOML=%s RPC_ADDR=%s %s skycoin cli createRawTransaction %s %s %s'`,
+		fiberTOMLPath, nodeURL, skywireBin, genesisPath, destAddress, coins)).String()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("createRawTransaction failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck,gosec
-
-	body, _ := io.ReadAll(resp.Body) //nolint:errcheck,gosec
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("transaction failed (%d): %s", resp.StatusCode, string(body))
+	rawTxStr = strings.TrimSpace(rawTxStr)
+	if rawTxStr == "" {
+		return "", fmt.Errorf("createRawTransaction returned empty output")
 	}
 
-	var txResult struct {
-		TxID string `json:"txid"`
+	// Inject transaction with no_broadcast
+	injectBody := fmt.Sprintf(`{"rawtx":"%s","no_broadcast":true}`, rawTxStr)
+	injectReq, err := http.NewRequest("POST", nodeURL+"/api/v1/injectTransaction", strings.NewReader(injectBody))
+	if err != nil {
+		return "", fmt.Errorf("inject request: %w", err)
 	}
-	if err := json.Unmarshal(body, &txResult); err != nil {
-		return "", fmt.Errorf("parse tx result: %w", err)
+	injectReq.Header.Set("Content-Type", "application/json")
+	injectResp, err := http.DefaultClient.Do(injectReq)
+	if err != nil {
+		return "", fmt.Errorf("inject failed: %w", err)
+	}
+	defer injectResp.Body.Close()               //nolint:errcheck,gosec
+	injectOut, _ := io.ReadAll(injectResp.Body) //nolint:errcheck,gosec
+	if injectResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("inject failed (%d): %s", injectResp.StatusCode, string(injectOut))
 	}
 
-	return txResult.TxID, nil
+	txID := strings.Trim(strings.TrimSpace(string(injectOut)), `"`)
+	return txID, nil
 }
 
 // checkTransactionToAddress checks if there's a confirmed transaction

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pterm/pterm v0.12.83
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/sirupsen/logrus v1.9.4
-	github.com/skycoin/dmsg v1.3.29-0.20260325174532-01564b1076f1
+	github.com/skycoin/dmsg v1.3.29-0.20260326182411-b57639cfb52f
 	github.com/skycoin/skycoin v0.28.6-0.20260325014814-f48988877c68
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -812,8 +812,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/skycoin/dmsg v1.3.29-0.20260325174532-01564b1076f1 h1:XLclFygF7BnjBkN8BjGhSBVW1taR91Ff/4UnvSLWtFg=
-github.com/skycoin/dmsg v1.3.29-0.20260325174532-01564b1076f1/go.mod h1:pmvwMUcHrNTKzx6+tEPcx4/5dJtvK/HtPI/7jA0+mig=
+github.com/skycoin/dmsg v1.3.29-0.20260326182411-b57639cfb52f h1:ZJ/7cS0gPGC2fCpaJ8+Q431MIfFVOvjMBNav1gHHkbA=
+github.com/skycoin/dmsg v1.3.29-0.20260326182411-b57639cfb52f/go.mod h1:pmvwMUcHrNTKzx6+tEPcx4/5dJtvK/HtPI/7jA0+mig=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9 h1:DElGw1Fhj4amuW1KM5q8Xowosb3RiOQce0lDJw0Qv0Y=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9/go.mod h1:OQz8NXVJUWEw7PWYASZ/1BIw5GXgVMTGvrCGDlZa9+k=
 github.com/skycoin/hardware-wallet-protob v0.0.0-20250805154629-410561e1bc2f h1:wKpqEhubs7kKtb7nqU4V8zkTxwnnwcB2797elV2z1t8=

--- a/vendor/github.com/skycoin/dmsg/pkg/cmdutil/pprof.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/cmdutil/pprof.go
@@ -21,30 +21,7 @@ func InitPProf(log *logging.Logger, mode string, addr string) func() { //nolint:
 
 	switch mode {
 	case "http":
-		go func() {
-			mux := http.NewServeMux()
-			mux.HandleFunc("/debug/pprof/", pprof.Index)
-			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-			for _, profile := range []string{"heap", "goroutine", "threadcreate", "block", "mutex", "allocs"} {
-				mux.Handle("/debug/pprof/"+profile, pprof.Handler(profile))
-			}
-
-			srv := &http.Server{
-				Addr:              addr,
-				Handler:           mux,
-				ReadHeaderTimeout: 5 * time.Second,
-				WriteTimeout:      30 * time.Second,
-			}
-			log.Infof("Serving pprof on http://%s", addr)
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Errorf("pprof http server failed: %v", err)
-			}
-		}()
-
+		startPProfHTTP(log, addr, false)
 		time.Sleep(100 * time.Millisecond)
 		return noop
 
@@ -122,21 +99,7 @@ func InitPProf(log *logging.Logger, mode string, addr string) func() { //nolint:
 		}
 
 	case "trace":
-		go func() {
-			mux := http.NewServeMux()
-			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-			srv := &http.Server{
-				Addr:              addr,
-				Handler:           mux,
-				ReadHeaderTimeout: 5 * time.Second,
-				WriteTimeout:      60 * time.Second,
-			}
-			log.Infof("Serving trace endpoint on http://%s/debug/pprof/trace", addr)
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Errorf("pprof trace server failed: %v", err)
-			}
-		}()
-
+		startPProfHTTP(log, addr, true)
 		time.Sleep(100 * time.Millisecond)
 		return noop
 
@@ -148,4 +111,48 @@ func InitPProf(log *logging.Logger, mode string, addr string) func() { //nolint:
 	}
 
 	return noop
+}
+
+// startPProfHTTP starts a pprof HTTP server on a dedicated OS thread.
+// Locking the goroutine to its own thread ensures the kernel scheduler
+// gives it CPU time even when the Go runtime is saturated with goroutines,
+// which is exactly when pprof is needed most.
+func startPProfHTTP(log *logging.Logger, addr string, traceOnly bool) {
+	// Reserve an extra OS thread for the pprof server so it doesn't
+	// compete with application goroutines for GOMAXPROCS slots.
+	runtime.GOMAXPROCS(runtime.GOMAXPROCS(0) + 1)
+
+	go func() {
+		// Pin this goroutine to a dedicated OS thread so the kernel
+		// scheduler guarantees it CPU time independent of Go's
+		// cooperative goroutine scheduler.
+		runtime.LockOSThread()
+
+		mux := http.NewServeMux()
+		if traceOnly {
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+			log.Infof("Serving trace endpoint on http://%s/debug/pprof/trace (dedicated thread)", addr)
+		} else {
+			mux.HandleFunc("/debug/pprof/", pprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+			for _, profile := range []string{"heap", "goroutine", "threadcreate", "block", "mutex", "allocs"} {
+				mux.Handle("/debug/pprof/"+profile, pprof.Handler(profile))
+			}
+			log.Infof("Serving pprof on http://%s (dedicated thread)", addr)
+		}
+
+		srv := &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+			WriteTimeout:      30 * time.Second,
+		}
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Errorf("pprof http server failed: %v", err)
+		}
+	}()
 }

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/server.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/server.go
@@ -150,7 +150,6 @@ func (s *Server) Serve(lis net.Listener, addr string) error {
 			return err
 		}
 
-		// TODO(evanlinjin): Implement proper load-balancing.
 		if s.SessionCount() >= s.maxSessions {
 			s.log.
 				WithField("max_sessions", s.maxSessions).

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/server_session.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/server_session.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"github.com/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,16 @@ import (
 
 	"github.com/skycoin/dmsg/pkg/dmsg/metrics"
 	"github.com/skycoin/dmsg/pkg/noise"
+)
+
+const (
+	// maxConcurrentStreams limits how many streams can be served concurrently
+	// per session to prevent a single session from exhausting server resources.
+	maxConcurrentStreams = 2048
+
+	// streamErrorBackoff is the delay after a non-fatal stream accept error
+	// to prevent CPU spin on persistent errors.
+	streamErrorBackoff = 50 * time.Millisecond
 )
 
 // ServerSession represents a session from the perspective of a dmsg server.
@@ -45,6 +56,10 @@ func (ss *ServerSession) Close() error {
 func (ss *ServerSession) Serve() {
 	ss.m.RecordSession(metrics.DeltaConnect)          // record successful connection
 	defer ss.m.RecordSession(metrics.DeltaDisconnect) // record disconnection
+
+	// Semaphore to limit concurrent streams per session.
+	sem := make(chan struct{}, maxConcurrentStreams)
+
 	if ss.sm.smux != nil {
 		for {
 			sStr, err := ss.sm.smux.AcceptStream()
@@ -54,13 +69,24 @@ func (ss *ServerSession) Serve() {
 					return
 				}
 				ss.log.WithError(err).Warn("Failed to accept smux stream, continuing...")
+				time.Sleep(streamErrorBackoff)
 				continue
 			}
 
 			log := ss.log.WithField("smux_id", sStr.ID())
-			log.Info("Initiating stream.")
 
+			// Acquire semaphore slot; if full, reject the stream.
+			select {
+			case sem <- struct{}{}:
+			default:
+				log.Warn("Max concurrent streams reached, rejecting stream.")
+				sStr.Close() //nolint:errcheck,gosec
+				continue
+			}
+
+			log.Info("Initiating stream.")
 			go func(sStr *smux.Stream) {
+				defer func() { <-sem }()
 				defer func() {
 					if r := recover(); r != nil {
 						log.WithField("panic", r).Error("Recovered from panic in serveStream")
@@ -79,13 +105,24 @@ func (ss *ServerSession) Serve() {
 					return
 				}
 				ss.log.WithError(err).Warn("Failed to accept yamux stream, continuing...")
+				time.Sleep(streamErrorBackoff)
 				continue
 			}
 
 			log := ss.log.WithField("yamux_id", yStr.StreamID())
-			log.Info("Initiating stream.")
 
+			// Acquire semaphore slot; if full, reject the stream.
+			select {
+			case sem <- struct{}{}:
+			default:
+				log.Warn("Max concurrent streams reached, rejecting stream.")
+				yStr.Close() //nolint:errcheck,gosec
+				continue
+			}
+
+			log.Info("Initiating stream.")
 			go func(yStr *yamux.Stream) {
+				defer func() { <-sem }()
 				defer func() {
 					if r := recover(); r != nil {
 						log.WithField("panic", r).Error("Recovered from panic in serveStream")
@@ -101,6 +138,14 @@ func (ss *ServerSession) Serve() {
 // struct
 
 func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCloser, addr net.Addr) error {
+	// Set a deadline for the initial stream request read so a slow or
+	// malicious client cannot hold a goroutine and semaphore slot indefinitely.
+	if conn, ok := yStr.(net.Conn); ok {
+		if err := conn.SetReadDeadline(time.Now().Add(HandshakeTimeout)); err != nil {
+			return fmt.Errorf("set read deadline: %w", err)
+		}
+	}
+
 	readRequest := func() (StreamRequest, error) {
 		obj, err := ss.readObject(yStr)
 		if err != nil {
@@ -182,6 +227,11 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 		return err
 	}
 	log.Debug("Forwarded stream response.")
+
+	// Clear the read deadline before the long-lived bidirectional copy.
+	if conn, ok := yStr.(net.Conn); ok {
+		conn.SetReadDeadline(time.Time{}) //nolint:errcheck,gosec
+	}
 
 	// Serve stream.
 	log.Info("Serving stream.")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1014,7 +1014,7 @@ github.com/shopspring/decimal
 ## explicit; go 1.17
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.29-0.20260325174532-01564b1076f1
+# github.com/skycoin/dmsg v1.3.29-0.20260326182411-b57639cfb52f
 ## explicit; go 1.26.1
 github.com/skycoin/dmsg/cmd/conf/commands
 github.com/skycoin/dmsg/cmd/dial/commands


### PR DESCRIPTION
## Summary
- `/api/v2/transaction` creates unsigned transactions — it can't sign without a wallet loaded on the node
- Replace with `createRawTransaction` CLI which loads `login_genesis.json` as a wallet file and signs locally
- Inject via `/api/v1/injectTransaction` with `no_broadcast: true`
- Same approach that works for the bootstrap step

## Test plan
- [ ] Login chain running with `skywire cli rewards loginchain`
- [ ] Reward server with `--login-node http://127.0.0.1:6421`
- [ ] Enter xpub on login page — verify "funded login address" appears in logs
- [ ] Full login flow end-to-end