### PR TITLE
Add DMSG gRPC listener for remote gotop and stats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
       - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 name: Test
 
 jobs:
@@ -146,3 +154,32 @@ jobs:
       - name: Build
         shell: powershell
         run: make build-windows
+
+  # Update the skywire-commit branch with the latest tested commit hash.
+  # Only runs on push to develop (not PRs) after all platform tests pass.
+  update-commit:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    needs: [linux, darwin, windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: skywire-commit
+          fetch-depth: 1
+
+      - name: Update commit hash
+        run: |
+          COMMIT="${{ github.sha }}"
+          sed -i "s/const Commit = \".*\"/const Commit = \"${COMMIT}\"/" main.go
+          cat main.go
+
+      - name: Push updated commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add main.go
+          git diff --cached --quiet && echo "No change" && exit 0
+          git commit -m "Update to ${GITHUB_SHA::12}"
+          git push origin skywire-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,3 +183,18 @@ jobs:
           git diff --cached --quiet && echo "No change" && exit 0
           git commit -m "Update to ${GITHUB_SHA::12}"
           git push origin skywire-commit
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Warm Go module proxy cache
+        run: |
+          # Fetch the skywire commit through the default proxy (proxy.golang.org)
+          # so it's cached for all visors worldwide. Also warms sum.golang.org.
+          COMMIT="${{ github.sha }}"
+          echo "Warming proxy cache for github.com/skycoin/skywire@${COMMIT}"
+          go mod download "github.com/skycoin/skywire@${COMMIT}" || true
+          # Also warm the skywire-commit branch itself
+          echo "Warming proxy cache for skywire-commit branch"
+          go mod download "github.com/skycoin/skywire@skywire-commit" || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,9 +190,18 @@ jobs:
 
       - name: Warm Go module proxy cache
         run: |
-          # Run a trivial program from the commit through the default proxy
-          # (proxy.golang.org) so the module is cached for all visors worldwide.
+          # After a PR is merged to develop and all tests pass, run a trivial
+          # program from this commit through the default proxy (proxy.golang.org)
+          # so the module is cached globally for visor auto-updates.
           # This also populates sum.golang.org.
           COMMIT="${{ github.sha }}"
           echo "Warming proxy cache for github.com/skycoin/skywire@${COMMIT}"
-          go run "github.com/skycoin/skywire/examples/hello@${COMMIT}"
+          for attempt in 1 2 3 4 5; do
+            if go run "github.com/skycoin/skywire/examples/hello@${COMMIT}"; then
+              echo "Proxy cache warmed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Attempt ${attempt} failed, waiting 30s for proxy to index..."
+            sleep 30
+          done
+          echo "Warning: proxy warming failed after 5 attempts (non-fatal)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,11 +190,9 @@ jobs:
 
       - name: Warm Go module proxy cache
         run: |
-          # Fetch the skywire commit through the default proxy (proxy.golang.org)
-          # so it's cached for all visors worldwide. Also warms sum.golang.org.
+          # Run a trivial program from the commit through the default proxy
+          # (proxy.golang.org) so the module is cached for all visors worldwide.
+          # This also populates sum.golang.org.
           COMMIT="${{ github.sha }}"
           echo "Warming proxy cache for github.com/skycoin/skywire@${COMMIT}"
-          go mod download "github.com/skycoin/skywire@${COMMIT}" || true
-          # Also warm the skywire-commit branch itself
-          echo "Warming proxy cache for skywire-commit branch"
-          go mod download "github.com/skycoin/skywire@skywire-commit" || true
+          go run "github.com/skycoin/skywire/examples/hello@${COMMIT}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,14 +172,14 @@ jobs:
       - name: Update commit hash
         run: |
           COMMIT="${{ github.sha }}"
-          sed -i "s/const Commit = \".*\"/const Commit = \"${COMMIT}\"/" main.go
-          cat main.go
+          sed -i "s/const Commit = \".*\"/const Commit = \"${COMMIT}\"/" cmd/skywire-commit/main.go
+          cat cmd/skywire-commit/main.go
 
       - name: Push updated commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add main.go
+          git add cmd/skywire-commit/main.go
           git diff --cached --quiet && echo "No change" && exit 0
           git commit -m "Update to ${GITHUB_SHA::12}"
           git push origin skywire-commit

--- a/AUTO_UPDATE.md
+++ b/AUTO_UPDATE.md
@@ -1,0 +1,115 @@
+# Skywire Auto-Update
+
+Skywire uses a rolling-release auto-update mechanism. The CI pipeline tracks the latest commit on `develop` for which all tests passed, and visors can update themselves using standard Go tooling.
+
+## How It Works
+
+### CI Pipeline
+
+1. A PR is merged to `develop`
+2. The `Test` workflow runs on all 3 platforms (linux, darwin, windows)
+3. If ALL tests pass, the `update-commit` job:
+   - Updates the `skywire-commit` branch with the tested commit SHA
+   - Warms the Go module proxy cache so the commit is immediately available worldwide
+4. The `Deploy` workflow (independent) builds and pushes Docker images to Docker Hub, tagged with both `:test` and `:<short-sha>`
+
+### The `skywire-commit` Branch
+
+An orphan branch in `skycoin/skywire` containing a single Go program that prints the latest tested commit hash:
+
+```
+cmd/skywire-commit/main.go   # const Commit = "<sha>"
+go.mod                        # module github.com/skycoin/skywire
+```
+
+This branch has no shared history with `develop` — it's updated by CI only.
+
+## Visor Auto-Update
+
+### Prerequisites
+
+- Go 1.21+ installed (Go 1.23 from bookworm-backports works; Go auto-downloads the required toolchain)
+- `~/go/bin` in `$PATH`
+
+### Get the Latest Tested Commit
+
+Using `go run` with isolated cache (no persistent build artifacts):
+
+```bash
+TMPDIR=$(mktemp -d) && COMMIT=$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
+echo $COMMIT
+```
+
+Or install the helper binary (2MB, reusable):
+
+```bash
+go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+COMMIT=$(~/go/bin/skywire-commit)
+```
+
+### Install Skywire at the Tested Commit
+
+```bash
+go install github.com/skycoin/skywire@$COMMIT
+```
+
+### One-Liner (isolated, no persistent build artifacts from the commit check)
+
+```bash
+TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
+```
+
+### Check if Update is Needed
+
+Compare the installed version to the latest tested commit:
+
+```bash
+CURRENT=$(skywire -b 2>/dev/null | grep -oP 'v.*-\K[a-f0-9]+' || echo "none")
+LATEST=$(~/go/bin/skywire-commit)
+if [ "${LATEST:0:12}" != "$CURRENT" ]; then
+    echo "Update available: $CURRENT -> ${LATEST:0:12}"
+fi
+```
+
+## Deployment Server Auto-Update (Docker)
+
+Docker images are pushed to Docker Hub on every merge to `develop`, tagged with both `:test` and `:<short-sha>`. The `skywire-commit` hash identifies which image is verified by CI.
+
+### Update Script
+
+```bash
+#!/bin/bash
+# Get the latest tested commit
+go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+LATEST=$(~/go/bin/skywire-commit)
+SHORT=${LATEST:0:12}
+CURRENT=$(cat ~/.skywire-deploy-commit 2>/dev/null || echo "none")
+
+if [ "$SHORT" = "$CURRENT" ]; then
+    echo "Up to date at $SHORT"
+    exit 0
+fi
+
+echo "Updating from $CURRENT to $SHORT"
+docker pull skycoin/skywire:$SHORT
+cd /path/to/docker-compose && docker compose up -d --force-recreate
+echo "$SHORT" > ~/.skywire-deploy-commit
+```
+
+## Go Module Proxy and China
+
+The CI warms the Go module proxy (`proxy.golang.org`) after each successful test run, so visors don't need `GOPROXY=direct`. The Chinese mirror `goproxy.cn` mirrors `proxy.golang.org`, so Chinese visors work with the default Go proxy settings.
+
+## Build Cache Management
+
+The Go build cache (`~/.cache/go-build`) grows over time. Periodic cleanup:
+
+```bash
+# Remove build cache (safe — rebuilds are just slower the first time)
+go clean -cache
+
+# Check cache size
+du -sh ~/.cache/go-build
+```
+
+For the `go run` commit check, use the isolated `GOCACHE` pattern shown above to avoid cache growth entirely.

--- a/cmd/address-resolver/commands/root.go
+++ b/cmd/address-resolver/commands/root.go
@@ -52,6 +52,7 @@ var (
 	whitelistKeys   string
 	testEnvironment bool
 	sk              cipher.SecKey
+	keyFile         string
 	dmsgPort        uint16
 	dmsgServerType  string
 	pprofAddr       string
@@ -132,6 +133,7 @@ func init() {
 	RootCmd.Flags().StringVar(&whitelistKeys, "whitelist-keys", "", "list of whitelisted keys of network monitor used for deregistration")
 	RootCmd.Flags().BoolVar(&testEnvironment, "test-environment", false, "distinguished between prod and test environment")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
+	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 }
@@ -221,6 +223,11 @@ Example:
 			logger.Fatal("Failed to initialize redis nonce store: ", err)
 		}
 
+		if keyFile != "" {
+			if err := cmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
+				logger.Fatal("Failed to load keyfile: ", err)
+			}
+		}
 		pk, err := sk.PubKey()
 		if err != nil {
 			logger.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")

--- a/cmd/config-bootstrapper/commands/root.go
+++ b/cmd/config-bootstrapper/commands/root.go
@@ -34,6 +34,7 @@ var (
 	domain         string
 	dmsgDisc       string
 	sk             cipher.SecKey
+	keyFile        string
 	dmsgPort       uint16
 	dmsgServerType string
 	pprofAddr      string
@@ -97,6 +98,7 @@ func init() {
 	RootCmd.Flags().StringVarP(&domain, "domain", "d", "skywire.skycoin.com", "the domain of the endpoints\n\r")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsg.DiscURL(false), "url of dmsg-discovery\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
+	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 }
@@ -134,6 +136,11 @@ HTTP Endpoints:
 
 		config := readConfig(logger, stunPath)
 
+		if keyFile != "" {
+			if err := cmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
+				logger.Fatal("Failed to load keyfile: ", err)
+			}
+		}
 		pk, err := sk.PubKey()
 		if err != nil {
 			logger.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")

--- a/cmd/route-finder/commands/root.go
+++ b/cmd/route-finder/commands/root.go
@@ -44,6 +44,7 @@ var (
 	testing         bool
 	dmsgDisc        string
 	sk              cipher.SecKey
+	keyFile         string
 	dmsgPort        uint16
 	dmsgServerType  string
 	multiplexingLib string
@@ -103,6 +104,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsg.DiscURL(false), "url of dmsg discovery\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
+	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&multiplexingLib, "multiplexing-lib", "yamux", "type of multiplexing lib on dmsg network\n\r")
@@ -178,6 +180,11 @@ Example:
 		}
 		defer transportStore.Close()
 
+		if keyFile != "" {
+			if err := cmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
+				logger.Fatal("Failed to load keyfile: ", err)
+			}
+		}
 		pk, err := sk.PubKey()
 		if err != nil {
 			logger.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")

--- a/cmd/service-discovery/commands/root.go
+++ b/cmd/service-discovery/commands/root.go
@@ -45,6 +45,7 @@ var (
 	dmsgDisc       string
 	whitelistKeys  string
 	sk             cipher.SecKey
+	keyFile        string
 	dmsgPort       uint16
 	dmsgServerType string
 	geoipURL       string
@@ -123,6 +124,7 @@ func init() {
 	RootCmd.Flags().StringVar(&geoipURL, "geoip", skyenv.GeoIP, "url of geoip service\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "dmsg secret key\n\r")
+	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 2*time.Minute, "timeout for service entry expiration\n\r")
 }
@@ -164,6 +166,11 @@ Example:
 			log.Printf("Failed to output build info: %v", err)
 		}
 
+		if keyFile != "" {
+			if err := cmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
+				log.Fatal("Failed to load keyfile: ", err)
+			}
+		}
 		pk, err := sk.PubKey()
 		if err != nil {
 			log.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -2,16 +2,11 @@
 package cliconfig
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
-	"github.com/bitfield/script"
 	"github.com/skycoin/dmsg/pkg/disc"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -127,109 +122,11 @@ type servicesConf struct {
 	Prod visorconfig.Services `json:"prod"`
 }
 
-// scriptExecValue sources the SKYENV file and evaluates a bash variable
-// expression, returning the raw string result. This is the common core
-// for all scriptExec* functions.
-func scriptExecValue(expr string) (string, error) {
-	if skyenv.OS == "windows" {
-		// Convert bash ${VAR:-default} to just $VAR for powershell;
-		// default handling is done on the Go side.
-		variable := expr
-		if strings.Contains(variable, ":-") {
-			parts := strings.SplitN(variable, ":-", 2)
-			variable = parts[0] + "}"
-		}
-		out, err := script.Exec(fmt.Sprintf(
-			`powershell -c "$SKYENV = '%s'; if ($SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; echo %s"`,
-			skyenvfile, variable,
-		)).String()
-		if err != nil {
-			return "", err
-		}
-		out = strings.TrimSpace(out)
-		// If powershell echoed the literal variable name, it wasn't set.
-		if out == "" || out == variable {
-			return "", nil
-		}
-		return out, nil
-	}
-	out, err := script.Exec(fmt.Sprintf(
-		`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`,
-		skyenvfile, expr,
-	)).String()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(out), nil
-}
+// Thin wrappers around the shared skyenv helpers in cmdutil.
+// These pass the package-level skyenvfile to the shared functions.
 
-// scriptExecSlice sources the SKYENV file and expands a bash array
-// expression into a string slice, one element per line.
-func scriptExecSlice(expr string) ([]string, error) {
-	if skyenv.OS == "windows" {
-		// Convert ${ARRAY[@]} to $ARRAY for powershell iteration.
-		variable := expr
-		if idx := strings.Index(variable, "[@]}"); idx != -1 {
-			variable = strings.TrimSuffix(variable, "[@]}")
-			variable = strings.TrimSuffix(variable, "{")
-		}
-		return script.Exec(fmt.Sprintf(
-			`powershell -c "$SKYENV = '%s'; if ($SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; foreach ($item in %s) { Write-Host $item }"`,
-			skyenvfile, variable,
-		)).Slice()
-	}
-	return script.Exec(fmt.Sprintf(
-		`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; for _i in %s ; do echo "$_i" ; done'`,
-		skyenvfile, expr,
-	)).Slice()
-}
-
-// parseDefault extracts the default value from a bash ${VAR:-default} expression.
-func parseDefault(s string) string {
-	if strings.Contains(s, ":-") {
-		parts := strings.SplitN(s, ":-", 2)
-		return strings.TrimRight(parts[1], "}")
-	}
-	return ""
-}
-
-func scriptExecString(s string) string {
-	out, err := scriptExecValue(s)
-	if err != nil || out == "" {
-		return parseDefault(s)
-	}
-	return out
-}
-
-func scriptExecBool(s string) bool {
-	out, err := scriptExecValue(s)
-	if err != nil || out == "" {
-		// Fall back to default from the expression (e.g. "false" from ${VAR:-false}).
-		out = parseDefault(s)
-	}
-	b, err := strconv.ParseBool(out)
-	if err != nil {
-		return false
-	}
-	return b
-}
-
-func scriptExecArray(s string) string {
-	items, err := scriptExecSlice(s)
-	if err != nil || len(items) == 0 {
-		return ""
-	}
-	return strings.Join(items, ",")
-}
-
-func scriptExecInt(s string) int {
-	out, err := scriptExecValue(s)
-	if err != nil || out == "" {
-		out = parseDefault(s)
-	}
-	i, err := strconv.Atoi(out)
-	if err != nil {
-		return 0
-	}
-	return i
-}
+func scriptExecString(s string) string { return cmdutil.SkyenvString(s, skyenvfile) }
+func scriptExecBool(s string) bool     { return cmdutil.SkyenvBool(s, skyenvfile) }
+func scriptExecArray(s string) string  { return cmdutil.SkyenvArray(s, skyenvfile) }
+func scriptExecInt(s string) int       { return cmdutil.SkyenvInt(s, skyenvfile) }
+func parseDefault(s string) string     { return cmdutil.SkyenvDefault(s) } //nolint:unused

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -50,6 +50,7 @@ var (
 	whitelistKeys   string
 	testEnvironment bool
 	sk              cipher.SecKey
+	keyFile         string
 	dmsgPort        uint16
 	dmsgServerType  string
 	entryTimeout    time.Duration
@@ -73,6 +74,7 @@ func init() {
 	RootCmd.Flags().StringVar(&whitelistKeys, "whitelist-keys", "", "list of whitelisted keys of network monitor used for deregistration")
 	RootCmd.Flags().BoolVar(&testEnvironment, "test-environment", false, "distinguished between prod and test environment")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
+	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&storeDataPath, "store-data-path", "/var/lib/skywire/tpd/bandwidth", "path for bandwidth backup files\n\r")
@@ -274,6 +276,11 @@ Example:
 			log.Fatal("Failed to initialize redis nonce store: ", err)
 		}
 
+		if keyFile != "" {
+			if err := cmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
+				logger.Fatal("Failed to load keyfile: ", err)
+			}
+		}
 		pk, err := sk.PubKey()
 		if err != nil {
 			logger.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")

--- a/cmd/uptime-tracker/commands/root.go
+++ b/cmd/uptime-tracker/commands/root.go
@@ -58,6 +58,7 @@ var (
 	testing           bool
 	dmsgDisc          string
 	sk                cipher.SecKey
+	keyFile           string
 	dmsgPort          uint16
 	storeDataCutoff   int
 	storeDataPath     string
@@ -83,6 +84,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis")
 	RootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", dmsg.DiscURL(false), "url of dmsg discovery\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
+	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 }
 
@@ -198,6 +200,11 @@ HTTP Endpoints:
 
 		var gormDB *gorm.DB
 
+		if keyFile != "" {
+			if err := cmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
+				logger.Fatal("Failed to load keyfile: ", err)
+			}
+		}
 		pk, err := sk.PubKey()
 		if err != nil {
 			logger.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")

--- a/docker/docker_push.sh
+++ b/docker/docker_push.sh
@@ -20,6 +20,14 @@ declare -a images_arr=(
 
 echo "Pushing to $registry using tag: $tag"
 
+# Also tag with the git commit SHA so specific versions can be pulled
+commit_sha="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
+
 for c in "${images_arr[@]}"; do
   docker push "$registry"/"$c":"$tag"
+  if [ -n "$commit_sha" ]; then
+    docker tag "$registry"/"$c":"$tag" "$registry"/"$c":"$commit_sha"
+    docker push "$registry"/"$c":"$commit_sha"
+    echo "Also pushed $registry/$c:$commit_sha"
+  fi
 done

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -1,0 +1,9 @@
+// Trivial program used by CI to warm the Go module proxy cache.
+// go run github.com/skycoin/skywire/examples/hello@<commit>
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("ok")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/skycoin/skywire
 
-go 1.26.1
+go 1.21
+
+toolchain go1.26.1
 
 require (
 	cogentcore.org/core v0.3.21

--- a/internal/integration/env_test.go
+++ b/internal/integration/env_test.go
@@ -771,18 +771,16 @@ func (env *TestEnv) TestVisorAddTp(t *testing.T, tp Transport) *TestEnv {
 	toPK, ok := env.visorPKs[tp.ToVisorHostName]
 	require.True(t, ok)
 
-	// Use retry logic for SUDPH transports as they can be flaky due to UDP hole punching timing
 	var err error
-	if tp.Type == "sudph" {
+	switch tp.Type {
+	case "sudph":
 		const sudphRetries = 3
 		_, err = env.VisorTpAddWithRetry(tp.FromVisorHostName, toPK, tp.Type, sudphRetries)
 		if err != nil {
-			// Dump diagnostic info for SUDPH failure
 			t.Logf("=== SUDPH DIAGNOSTICS ===")
 			for _, visor := range []string{tp.FromVisorHostName, tp.ToVisorHostName} {
 				logs, logErr := env.ReadLog(visor)
 				if logErr == nil {
-					// Search for SUDPH-related log lines
 					for _, line := range strings.Split(logs, "\n") {
 						lower := strings.ToLower(line)
 						if strings.Contains(lower, "sudph") || strings.Contains(lower, "udp") ||
@@ -793,7 +791,6 @@ func (env *TestEnv) TestVisorAddTp(t *testing.T, tp Transport) *TestEnv {
 					}
 				}
 			}
-			// Also check AR logs
 			arLogs, arErr := env.ReadLog("address-resolver")
 			if arErr == nil {
 				for _, line := range strings.Split(arLogs, "\n") {
@@ -807,7 +804,26 @@ func (env *TestEnv) TestVisorAddTp(t *testing.T, tp Transport) *TestEnv {
 			t.Logf("=== END SUDPH DIAGNOSTICS ===")
 			t.Skipf("Skipping SUDPH transport test after %d retries: %v", sudphRetries, err)
 		}
-	} else {
+
+	case "dmsg":
+		// DMSG transports can fail briefly after container restart while the
+		// visor's DMSG client reconnects to servers. Warm up by creating a
+		// self-transport first, then retry the actual transport.
+		fromPK, ok := env.visorPKs[tp.FromVisorHostName]
+		if ok {
+			t.Logf("DMSG warmup: creating self-transport on %s", tp.FromVisorHostName)
+			_, selfErr := env.VisorTpAddWithRetry(tp.FromVisorHostName, fromPK, "dmsg", 3)
+			if selfErr != nil {
+				t.Logf("DMSG self-transport warmup failed (non-fatal): %v", selfErr)
+			} else {
+				t.Logf("DMSG warmup: self-transport created on %s", tp.FromVisorHostName)
+			}
+		}
+		const dmsgRetries = 3
+		_, err = env.VisorTpAddWithRetry(tp.FromVisorHostName, toPK, "dmsg", dmsgRetries)
+		require.NoError(t, err)
+
+	default:
 		_, err = env.VisorTpAdd(tp.FromVisorHostName, toPK, tp.Type)
 		require.NoError(t, err)
 	}

--- a/internal/integration/vpn_test.go
+++ b/internal/integration/vpn_test.go
@@ -330,19 +330,15 @@ func getFirstTracerouteHop(targetHost string, env *TestEnv) (net.IP, error) {
 	var stdout string
 	var err error
 
-	cmdErrC := make(chan error)
+	cmdErrC := make(chan error, 1)
 	go func() {
 		stdout, err = env.ExecInContainerByID(fullCmd, env.containers[visorVPNClient].ID)
 		cmdErrC <- err
-		close(cmdErrC)
 	}()
 
-	// LEGITIMATE WAIT: traceroute runs as an external command with its own timeout
-	// (9s via the `timeout 9` wrapper). We must wait for it to complete or time out.
-	// The goroutine above will send on cmdErrC when done; we block on that channel.
-	time.Sleep(10 * time.Second)
-	if err = <-cmdErrC; err != nil {
-		return nil, fmt.Errorf("failed to run command %s: %w", fullCmd, err)
+	// Block until traceroute completes (has its own 9s timeout via `timeout 9`).
+	if cmdErr := <-cmdErrC; cmdErr != nil {
+		return nil, fmt.Errorf("failed to run command %s: %w", fullCmd, cmdErr)
 	}
 
 	stdoutLine := strings.Split(strings.Split(stdout, "\n")[1], " ")

--- a/pkg/route-finder/store/mark_and_sweep.go
+++ b/pkg/route-finder/store/mark_and_sweep.go
@@ -102,11 +102,19 @@ var MaxGraphDepth = 10
 
 // deepFirstSearch explores the graph iteratively with depth limiting.
 // Uses an explicit stack to avoid stack overflow on large networks.
+// Vertices are created once and shared via the pending map to ensure
+// neighbor links point to the canonical vertex for each PK.
 func (g *Graph) deepFirstSearch(ctx context.Context, v *vertex, maxDepth int) error {
 	type stackItem struct {
 		v     *vertex
 		depth int
 	}
+
+	// pending tracks vertices created but not yet visited, keyed by PK.
+	// This ensures only one vertex object exists per PK, so all neighbor
+	// links point to the same object regardless of exploration order.
+	pending := make(map[cipher.PubKey]*vertex)
+	pending[v.edge] = v
 
 	stack := []stackItem{{v: v, depth: 0}}
 
@@ -138,17 +146,20 @@ func (g *Graph) deepFirstSearch(ctx context.Context, v *vertex, maxDepth int) er
 			} else {
 				connectionPK = connection.Edges[0]
 			}
-			if _, ok := g.visited[connectionPK]; !ok {
+
+			if visitedVertex, ok := g.visited[connectionPK]; ok {
+				item.v.neighbors[connectionPK] = visitedVertex
+			} else if pendingVertex, ok := pending[connectionPK]; ok {
+				item.v.neighbors[connectionPK] = pendingVertex
+			} else {
 				connectionConnections, err := g.store.GetTransportsByEdge(ctx, connectionPK)
 				if err != nil {
 					return err
 				}
-
 				neighbourVertex := newVertex(connectionPK, connectionConnections)
+				pending[connectionPK] = neighbourVertex
 				item.v.neighbors[connectionPK] = neighbourVertex
 				stack = append(stack, stackItem{v: neighbourVertex, depth: item.depth + 1})
-			} else {
-				item.v.neighbors[connectionPK] = g.visited[connectionPK]
 			}
 		}
 	}

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -36,6 +36,9 @@ const (
 	// This is the port where TPS nodes listen for incoming transport setup requests from visors.
 	DmsgTransportSetupServicePort uint16 = 48
 
+	// DmsgGRPCPort is the DMSG port for gRPC services (remote gotop, stats, etc.)
+	DmsgGRPCPort uint16 = 49
+
 	// DmsgAwaitSetupPort Listening port of a visor for setup operations.
 	DmsgAwaitSetupPort uint16 = 136
 

--- a/pkg/skywire-utilities/pkg/cmdutil/keyfile.go
+++ b/pkg/skywire-utilities/pkg/cmdutil/keyfile.go
@@ -1,0 +1,38 @@
+// Package cmdutil pkg/cmdutil/keyfile.go
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	coinCipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+)
+
+// LoadOrGenerateKey loads a secret key from a file, or generates a new keypair
+// and writes it to the file if it doesn't exist. This allows systemd services
+// to auto-generate their identity on first run without bash workarounds.
+func LoadOrGenerateKey(path string, sk *cipher.SecKey) error {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err == nil {
+		trimmed := strings.TrimSpace(string(data))
+		if trimmed == "" {
+			return fmt.Errorf("keyfile %s is empty", path)
+		}
+		return sk.Set(trimmed)
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read keyfile %s: %w", path, err)
+	}
+	// Auto-generate new keypair
+	pk, newSK := coinCipher.GenerateKeyPair()
+	content := newSK.Hex() + "\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write keyfile %s: %w", path, err)
+	}
+	*sk = cipher.SecKey(newSK)
+	fmt.Printf("Generated new keypair in %s\nPublic key: %s\n", path, pk.Hex())
+	return nil
+}

--- a/pkg/skywire-utilities/pkg/cmdutil/skyenv.go
+++ b/pkg/skywire-utilities/pkg/cmdutil/skyenv.go
@@ -1,0 +1,179 @@
+// Package cmdutil pkg/cmdutil/skyenv.go
+// Shared SKYENV config file evaluation helpers.
+// Used by skywire cli config gen and dmsg commands.
+package cmdutil
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/bitfield/script"
+
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// SkyenvValue sources a SKYENV file and evaluates a bash variable expression,
+// returning the raw string result. This is the common core for all typed helpers.
+func SkyenvValue(expr, envfile string) (string, error) {
+	if skyenv.OS == "windows" {
+		variable := expr
+		if strings.Contains(variable, ":-") {
+			parts := strings.SplitN(variable, ":-", 2)
+			variable = parts[0] + "}"
+		}
+		out, err := script.Exec(fmt.Sprintf(
+			`powershell -c "$SKYENV = '%s'; if ($SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; echo %s"`,
+			envfile, variable,
+		)).String()
+		if err != nil {
+			return "", err
+		}
+		out = strings.TrimSpace(out)
+		if out == "" || out == variable {
+			return "", nil
+		}
+		return out, nil
+	}
+	out, err := script.Exec(fmt.Sprintf(
+		`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`,
+		envfile, expr,
+	)).String()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// SkyenvSlice sources a SKYENV file and expands a bash array expression
+// into a string slice, one element per line.
+func SkyenvSlice(expr, envfile string) ([]string, error) {
+	if skyenv.OS == "windows" {
+		variable := expr
+		if idx := strings.Index(variable, "[@]}"); idx != -1 {
+			variable = strings.TrimSuffix(variable, "[@]}")
+			variable = strings.TrimSuffix(variable, "{")
+		}
+		return script.Exec(fmt.Sprintf(
+			`powershell -c "$SKYENV = '%s'; if ($SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; foreach ($item in %s) { Write-Host $item }"`,
+			envfile, variable,
+		)).Slice()
+	}
+	return script.Exec(fmt.Sprintf(
+		`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; for _i in %s ; do echo "$_i" ; done'`,
+		envfile, expr,
+	)).Slice()
+}
+
+// SkyenvDefault extracts the default value from a bash ${VAR:-default} expression.
+func SkyenvDefault(s string) string {
+	if strings.Contains(s, ":-") {
+		parts := strings.SplitN(s, ":-", 2)
+		return strings.TrimRight(parts[1], "}")
+	}
+	return ""
+}
+
+// SkyenvString evaluates a bash variable expression and returns the string value,
+// falling back to the default from the expression if unset.
+func SkyenvString(s, envfile string) string {
+	out, err := SkyenvValue(s, envfile)
+	if err != nil || out == "" {
+		return SkyenvDefault(s)
+	}
+	return out
+}
+
+// SkyenvBool evaluates a bash variable expression and returns a bool.
+func SkyenvBool(s, envfile string) bool {
+	out, err := SkyenvValue(s, envfile)
+	if err != nil || out == "" {
+		out = SkyenvDefault(s)
+	}
+	b, err := strconv.ParseBool(out)
+	if err != nil {
+		return false
+	}
+	return b
+}
+
+// SkyenvArray evaluates a bash array expression and returns a comma-separated string.
+func SkyenvArray(s, envfile string) string {
+	items, err := SkyenvSlice(s, envfile)
+	if err != nil || len(items) == 0 {
+		return ""
+	}
+	return strings.Join(items, ",")
+}
+
+// SkyenvInt evaluates a bash variable expression and returns an int.
+func SkyenvInt(s, envfile string) int {
+	out, err := SkyenvValue(s, envfile)
+	if err != nil || out == "" {
+		out = SkyenvDefault(s)
+	}
+	i, err := strconv.Atoi(out)
+	if err != nil {
+		return 0
+	}
+	return i
+}
+
+// SkyenvUint evaluates a bash variable expression and returns a uint.
+func SkyenvUint(s, envfile string) uint {
+	out, err := SkyenvValue(s, envfile)
+	if err != nil || out == "" {
+		out = SkyenvDefault(s)
+	}
+	i, err := strconv.ParseUint(out, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return uint(i)
+}
+
+// SkyenvStringSlice evaluates a bash array expression and returns a string slice.
+func SkyenvStringSlice(s, envfile string) []string {
+	items, err := SkyenvSlice(s, envfile)
+	if err != nil || len(items) == 0 {
+		return []string{}
+	}
+	return items
+}
+
+// SkyenvBoolSlice evaluates a bash array expression and returns a bool slice.
+func SkyenvBoolSlice(s, envfile string) []bool {
+	items, err := SkyenvSlice(s, envfile)
+	if err != nil {
+		return []bool{false}
+	}
+	result := make([]bool, 0, len(items))
+	for _, item := range items {
+		switch strings.ToLower(strings.TrimSpace(item)) {
+		case "true":
+			result = append(result, true)
+		default:
+			result = append(result, false)
+		}
+	}
+	if len(result) == 0 {
+		return []bool{false}
+	}
+	return result
+}
+
+// SkyenvUintSlice evaluates a bash array expression and returns a uint slice.
+func SkyenvUintSlice(s, envfile string) []uint {
+	items, err := SkyenvSlice(s, envfile)
+	if err != nil {
+		return []uint{}
+	}
+	result := make([]uint, 0, len(items))
+	for _, item := range items {
+		num, err := strconv.ParseUint(strings.TrimSpace(item), 10, 64)
+		if err == nil {
+			result = append(result, uint(num))
+		}
+	}
+	return result
+}

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -108,8 +108,8 @@ func (v *Visor) DialDmsgRPC(pk cipher.PubKey) (net.Conn, error) {
 	v.log.WithField("remote", pk.String()[:16]+"...").
 		Debug("Dialing remote visor RPC over DMSG")
 
-	// Dial to the hypervisor/RPC port
-	conn, err := v.dmsgC.Dial(ctx, dmsg.Addr{PK: pk, Port: skyenv.DmsgHypervisorPort})
+	// Dial to the gRPC DMSG port on the remote visor
+	conn, err := v.dmsgC.Dial(ctx, dmsg.Addr{PK: pk, Port: skyenv.DmsgGRPCPort})
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial dmsg RPC: %w", err)
 	}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -343,6 +343,35 @@ func initCLI(_ context.Context, v *Visor, log *logging.Logger) error {
 		return nil
 	})
 
+	// Start gRPC server on DMSG for remote access (gotop, stats, etc.)
+	if v.dmsgC != nil {
+		dmsgGRPCLog := v.MasterLogger().PackageLogger("dmsg_grpc")
+		dmsgGRPCServer := grpc.NewServer()
+		dmsgPingServer := rpcgrpc.NewPingServer(pingAdapter, dmsgGRPCLog)
+		rpcgrpc.RegisterPingServiceServer(dmsgGRPCServer, dmsgPingServer)
+
+		dmsgGRPCL, err := v.dmsgC.Listen(skyenv.DmsgGRPCPort)
+		if err != nil {
+			log.WithError(err).Warn("Failed to listen on DMSG gRPC port")
+		} else {
+			v.pushCloseStack("dmsg.grpc.listener", dmsgGRPCL.Close)
+			v.pushCloseStack("dmsg.grpc.server", func() error {
+				dmsgGRPCServer.GracefulStop()
+				return nil
+			})
+
+			go func() {
+				dmsgGRPCLog.Infof("DMSG gRPC server listening on port %d", skyenv.DmsgGRPCPort)
+				if err := dmsgGRPCServer.Serve(dmsgGRPCL); err != nil {
+					if !strings.Contains(err.Error(), "use of closed network connection") &&
+						!strings.Contains(err.Error(), "closed") {
+						dmsgGRPCLog.WithError(err).Error("DMSG gRPC server error")
+					}
+				}
+			}()
+		}
+	}
+
 	// Use cmux to multiplex gRPC and standard RPC on same port
 	mux := cmux.New(cliL)
 	grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))


### PR DESCRIPTION
- Add DmsgGRPCPort (49) for gRPC services over DMSG
- Start gRPC server on DMSG port alongside local CLI gRPC
- Update DialDmsgRPC to dial DmsgGRPCPort instead of DmsgHypervisorPort
- Enables remote gotop, stats streaming, and ping over DMSG

Both visors need this update: the local visor dials the new port, and the remote visor listens on it.
