### PR TITLE
Fix CI E2E, add -Q conf flag, runtime hypervisor toggle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
         run: |
-          go install -tags="cgo,withoutsystray,withoutgotop" -trimpath \
+          go install -tags="cgo,withoutsystray" -trimpath \
             -ldflags "-s -w -linkmode external -extldflags '-static' -buildid=" \
             ${{ env.MODULE }}@${{ github.ref_name }}
 

--- a/Makefile
+++ b/Makefile
@@ -533,10 +533,12 @@ e2e-config: ## E2E. Regenerate visor configs from template and deployment config
 e2e-stop: ## E2E. Stop e2e environment without destroying it. Restart with `make e2e-run`
 	bash -c "DOCKER_TAG=e2e docker compose -f ${COMPOSE_FILE} stop"
 	bash -c "DOCKER_TAG=e2e docker compose -f ${COMPOSE_FILE} ps"
+	-sudo ./ci_scripts/cleanup-ip-aliases.sh
 
 e2e-clean: ## E2E. Stop e2e environment and clean everything. Restart only with `make e2e-build && make e2e-run`
 	bash -c "DOCKER_TAG=e2e docker compose -f ${COMPOSE_FILE} down"
 	bash ./docker/docker_clean.sh e2e
+	-sudo ./ci_scripts/cleanup-ip-aliases.sh
 
 e2e-help: ## E2E. Show env-vars and useful commands
 	@echo -e "\nNow you can use docker compose:\n"

--- a/ci_scripts/cleanup-ip-aliases.sh
+++ b/ci_scripts/cleanup-ip-aliases.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remove IP aliases created by setup-sudo-requirements.sh
+# Run after E2E tests: sudo ./ci_scripts/cleanup-ip-aliases.sh
+
+set -euo pipefail
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    echo "Removing IP aliases from lo..."
+    for ((i=1; i<=255; i++)); do
+        ip addr del 12.12.12.$i/32 dev lo 2>/dev/null || true
+    done
+    echo "Done."
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Removing IP aliases from lo0..."
+    for ((i=1; i<=255; i++)); do
+        ifconfig lo0 -alias 12.12.12.$i 2>/dev/null || true
+    done
+    echo "Done."
+fi

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -124,6 +124,7 @@ var (
 	skyenvfile = os.Getenv("SKYENV")
 )
 var envfile string
+var envfileOut string
 
 func init() {
 	var msg string
@@ -143,7 +144,8 @@ func init() {
 	genConfigCmd.Flags().StringVarP(&output, "out", "o", scriptExecString("${OUTPUT}"), msg+"")
 	genConfigCmd.Flags().BoolVarP(&isHide, "hide", "w", false, "dont print the config to the terminal :: show errors with -n flag")
 	gHiddenFlags = append(gHiddenFlags, "hide")
-	genConfigCmd.Flags().BoolVarP(&isEnvs, "envs", "q", false, "show the environmental variable settings")
+	genConfigCmd.Flags().BoolVarP(&isEnvs, "envs", "q", false, "show the conf template (reflects flags passed)")
+	genConfigCmd.Flags().StringVarP(&envfileOut, "envout", "Q", "", "write conf template to file (reflects flags passed)")
 
 	// Config generation flags
 	genConfigCmd.Flags().BoolVarP(&isForce, "force", "f", false, "remove pre-existing config")
@@ -368,13 +370,23 @@ var genConfigCmd = &cobra.Command{
 	}(),
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		log := logger
-		if isEnvs {
+		if isEnvs || envfileOut != "" {
 			if skyenv.OS == "windows" {
 				envfile = envfileWindows
 			} else {
 				envfile = envfileLinux
 			}
-			fmt.Println(envfile)
+			// Uncomment settings that match flags passed on the command line
+			envfile = applyFlagsToConf(envfile, cmd)
+
+			if envfileOut != "" {
+				if err := os.WriteFile(envfileOut, []byte(envfile+"\n"), 0644); err != nil { //nolint:gosec
+					log.Fatalf("Failed to write conf file: %v", err)
+				}
+				fmt.Printf("Conf template written to %s\n", envfileOut)
+			} else {
+				fmt.Println(envfile)
+			}
 			os.Exit(0)
 		}
 
@@ -1468,4 +1480,55 @@ func getInterfaceNames() string { //nolint Note: pending implementation for conf
 	}
 
 	return strings.Join(interfaceNames, ", ")
+}
+
+// applyFlagsToConf uncomments settings in the conf template that correspond
+// to flags passed on the command line. This makes -q/-Q output reflect the
+// user's intent (e.g., `config gen -iq` uncomments ISHYPERVISOR=true).
+func applyFlagsToConf(conf string, cmd *cobra.Command) string {
+	// Map of flag names to the SKYENV variable they control.
+	// When a flag is explicitly set, uncomment the corresponding line.
+	flagToEnv := map[string]string{
+		"pkg":       "PKGENV=true",
+		"bestproto": "BESTPROTO=true",
+		"ishv":      "ISHYPERVISOR=true",
+		"testenv":   "TESTENV=true",
+		"dmsghttp":  "DMSGHTTP=true",
+		"public":    "VISORISPUBLIC=true",
+		"servevpn":  "VPNSERVER=true",
+		"autoconn":  "DISABLEPUBLICAUTOCONN=true",
+		"publicip":  "DISPLAYNODEIP=true",
+	}
+
+	// Also handle string/value flags
+	valueFlagToEnv := map[string]string{
+		"cliaddr": "CLIADDR",
+		"hvaddr":  "HVHTTPADDR",
+		"timeout": "SHUTDOWNTIMEOUT",
+		"reward":  "REWARDSKYADDR",
+	}
+
+	lines := strings.Split(conf, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Check boolean flags
+		for flagName, envSetting := range flagToEnv {
+			if cmd.Flags().Changed(flagName) {
+				commented := "#" + envSetting
+				if strings.HasPrefix(trimmed, commented) || trimmed == commented {
+					lines[i] = strings.Replace(line, "#"+envSetting, envSetting, 1)
+				}
+			}
+		}
+		// Check value flags
+		for flagName, envKey := range valueFlagToEnv {
+			if cmd.Flags().Changed(flagName) {
+				val, _ := cmd.Flags().GetString(flagName) //nolint:errcheck
+				if val != "" && strings.Contains(trimmed, envKey) && strings.HasPrefix(trimmed, "#") {
+					lines[i] = envKey + "='" + val + "'"
+				}
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
 }

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1406,6 +1406,13 @@ func writeConfigOutput(log *logging.Logger) {
 			if err != nil {
 				log.Fatalf("Failed to convert config to setup-node config format: %v", err)
 			}
+			// Re-indent for readable file output
+			var data any
+			if err = json.Unmarshal(jsonData, &data); err == nil {
+				if indented, indentErr := json.MarshalIndent(data, "", "    "); indentErr == nil {
+					jsonData = indented
+				}
+			}
 		}
 		// Write the JSON data back to the file
 		err = os.WriteFile(confPath, jsonData, configFilePerms)

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1460,11 +1460,15 @@ func getInterfaceNames() string { //nolint Note: pending implementation for conf
 	var interfaceNames []string
 	defaultInterface := ""
 	for _, iface := range interfaces {
-		if iface.Flags&net.FlagLoopback == 0 {
-			interfaceNames = append(interfaceNames, iface.Name)
-			if iface.Index == 0 && defaultInterface == "" {
-				defaultInterface = iface.Name
-			}
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if netutil.IsVirtualInterface(iface.Name) {
+			continue
+		}
+		interfaceNames = append(interfaceNames, iface.Name)
+		if iface.Index == 0 && defaultInterface == "" {
+			defaultInterface = iface.Name
 		}
 	}
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1133,8 +1133,11 @@ func configureHypervisor(log *logging.Logger) {
 		}
 	}
 	// Local hypervisor setting
-	if isHypervisor {
+	// Always include hypervisor config (for runtime enable/disable).
+	// The Enable field controls whether it auto-starts.
+	{
 		config := visorconfig.GenerateWorkDirConfig(isTestEnv)
+		config.Enable = isHypervisor
 		if hvHTTPAddr != "" {
 			config.HTTPAddr = hvHTTPAddr
 		} else {

--- a/cmd/skywire-cli/commands/config/gen_test.go
+++ b/cmd/skywire-cli/commands/config/gen_test.go
@@ -201,8 +201,8 @@ func TestConfigGenDefault(t *testing.T) {
 		t.Error("vpn-server app not found in launcher config")
 	}
 
-	if conf.Hypervisor != nil {
-		t.Error("should not be hypervisor by default")
+	if conf.Hypervisor != nil && conf.Hypervisor.Enable {
+		t.Error("hypervisor should not be enabled by default")
 	}
 	if conf.IsPublic {
 		t.Error("should not be public by default")

--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -146,35 +146,62 @@ func extractInterfaces(s *surveyData) (ifc string, macs []string) {
 }
 
 // checkServiceConfig verifies the survey's service configuration against the expected deployment config.
-// Supports both HTTP-only configs and dual HTTP+DMSG configs.
+// Accepts three valid config types:
+//   - HTTP-only: dmsg_discovery is http://, no _dmsg fields
+//   - DMSG-only: dmsg_discovery is dmsg://, all URLs are dmsg://
+//   - Dual (HTTP+DMSG): dmsg_discovery is http://, _dmsg fields also present
+//
+// Each present field is checked against the expected deployment config.
+// Missing optional fields (_dmsg URLs) are not penalized.
 func checkServiceConfig(surveyPath string, sConf, dConf []byte) bool {
-	// Strip fields that may differ between survey and expected config:
-	// - stun_servers: excluded by design
-	// - dmsg_servers: survey doesn't include the server entry list
-	// - conf_dmsg: config-bootstrapper address, not relevant to visor survey
+	// Strip fields not relevant to comparison
 	delFields := `del(.stun_servers, .dmsg_servers, .conf_dmsg)`
 	svcBytes, err := script.File(surveyPath).JQ(`.services | ` + delFields).Bytes()
 	if err != nil {
 		return false
 	}
+
 	confType, _ := script.File(surveyPath).JQ(`.services.dmsg_discovery`).Replace("\"", "").String() //nolint:errcheck
 	confType = strings.TrimRight(confType, "\n")
 
-	if strings.HasPrefix(confType, "http://") {
-		// Strip same fields from expected config for fair comparison
-		stripped, err := script.Echo(string(sConf)).JQ(delFields).Bytes()
-		if err != nil {
-			stripped = sConf
-		}
-		return compareAndPrintDiffs(svcBytes, stripped, true)
-	}
 	if strings.HasPrefix(confType, "dmsg://") {
+		// DMSG-only config: compare against dConf
 		stripped, err := script.Echo(string(dConf)).JQ(delFields).Bytes()
 		if err != nil {
 			stripped = dConf
 		}
 		return compareAndPrintDiffs(svcBytes, stripped, true)
 	}
+
+	if strings.HasPrefix(confType, "http://") {
+		// HTTP or dual config: strip _dmsg and dmsg_servers fields from BOTH sides
+		// so that HTTP-only, dual, and expected configs all compare cleanly.
+		// The _dmsg fields are validated separately if present.
+		httpOnly := `del(.stun_servers, .dmsg_servers, .conf_dmsg, .dmsg_discovery_dmsg, .transport_discovery_dmsg, .address_resolver_dmsg, .route_finder_dmsg, .uptime_tracker_dmsg, .service_discovery_dmsg)`
+		surveyHTTP, err := script.File(surveyPath).JQ(`.services | ` + httpOnly).Bytes()
+		if err != nil {
+			return false
+		}
+		expectedHTTP, err := script.Echo(string(sConf)).JQ(httpOnly).Bytes()
+		if err != nil {
+			return false
+		}
+		httpOK := compareAndPrintDiffs(surveyHTTP, expectedHTTP, true)
+
+		// If survey has _dmsg fields, validate them too (optional — not required for rewards)
+		hasDmsgFields, _ := script.File(surveyPath).JQ(`.services.dmsg_discovery_dmsg`).Replace("\"", "").String() //nolint:errcheck
+		if strings.TrimSpace(hasDmsgFields) != "" && strings.TrimSpace(hasDmsgFields) != "null" {
+			dmsgOnly := `{dmsg_discovery_dmsg, transport_discovery_dmsg, address_resolver_dmsg, route_finder_dmsg, uptime_tracker_dmsg, service_discovery_dmsg}`
+			surveyDmsg, _ := script.File(surveyPath).JQ(`.services | ` + dmsgOnly).Bytes() //nolint:errcheck
+			expectedDmsg, _ := script.Echo(string(sConf)).JQ(dmsgOnly).Bytes()             //nolint:errcheck
+			if len(surveyDmsg) > 0 && len(expectedDmsg) > 0 {
+				compareAndPrintDiffs(surveyDmsg, expectedDmsg, false) // log but don't fail on _dmsg mismatch
+			}
+		}
+
+		return httpOK
+	}
+
 	return false
 }
 

--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -146,9 +146,14 @@ func extractInterfaces(s *surveyData) (ifc string, macs []string) {
 }
 
 // checkServiceConfig verifies the survey's service configuration against the expected deployment config.
+// Supports both HTTP-only configs and dual HTTP+DMSG configs.
 func checkServiceConfig(surveyPath string, sConf, dConf []byte) bool {
-	// Use JQ to extract and compare services (preserving existing behavior for stun_servers exclusion)
-	svcBytes, err := script.File(surveyPath).JQ(`.services | del(.stun_servers)`).Bytes()
+	// Strip fields that may differ between survey and expected config:
+	// - stun_servers: excluded by design
+	// - dmsg_servers: survey doesn't include the server entry list
+	// - conf_dmsg: config-bootstrapper address, not relevant to visor survey
+	delFields := `del(.stun_servers, .dmsg_servers, .conf_dmsg)`
+	svcBytes, err := script.File(surveyPath).JQ(`.services | ` + delFields).Bytes()
 	if err != nil {
 		return false
 	}
@@ -156,10 +161,19 @@ func checkServiceConfig(surveyPath string, sConf, dConf []byte) bool {
 	confType = strings.TrimRight(confType, "\n")
 
 	if strings.HasPrefix(confType, "http://") {
-		return compareAndPrintDiffs(svcBytes, sConf, true)
+		// Strip same fields from expected config for fair comparison
+		stripped, err := script.Echo(string(sConf)).JQ(delFields).Bytes()
+		if err != nil {
+			stripped = sConf
+		}
+		return compareAndPrintDiffs(svcBytes, stripped, true)
 	}
 	if strings.HasPrefix(confType, "dmsg://") {
-		return compareAndPrintDiffs(svcBytes, dConf, true)
+		stripped, err := script.Echo(string(dConf)).JQ(delFields).Bytes()
+		if err != nil {
+			stripped = dConf
+		}
+		return compareAndPrintDiffs(svcBytes, stripped, true)
 	}
 	return false
 }

--- a/cmd/skywire-cli/commands/tp/tp-add-pv.go
+++ b/cmd/skywire-cli/commands/tp/tp-add-pv.go
@@ -94,8 +94,8 @@ var addPvCmd = &cobra.Command{
   transports to the top N visors (by transport count). This is useful for
   improving network connectivity and reachability.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		if pvTransportType != "" && pvTransportType != "dmsg" && pvTransportType != "stcpr" && pvTransportType != "sudph" {
-			logger.Fatal("Invalid transport type specified:", pvTransportType)
+		if pvTransportType != "" && pvTransportType != "stcpr" && pvTransportType != "sudph" {
+			logger.Fatal("Invalid transport type for public visors (use stcpr or sudph):", pvTransportType)
 		}
 
 		isJSON, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
@@ -373,13 +373,14 @@ var addPvCmd = &cobra.Command{
 					continue
 				}
 			} else {
-				// No transport type specified - try stcpr, sudph, dmsg in order
+				// No transport type specified - try p2p types only (stcpr, sudph).
+				// DMSG transports are relay-based and should not be used for
+				// public visor autoconnect — they transit the DMSG server which
+				// adds latency and load. Use `tp add <pk> -t dmsg` explicitly
+				// if a DMSG transport is specifically needed.
 				transportTypes := []types.Type{
 					types.STCPR,
 					types.SUDPH,
-				}
-				if pvForceAttempt || contains(dmsgkeys, pk) {
-					transportTypes = append(transportTypes, types.DMSG)
 				}
 
 			typeLoop:

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -22,6 +22,9 @@ func init() {
 	hvpkCmd.Flags().StringVarP(&path, "input", "i", "", "path of input config file.")
 	hvpkCmd.Flags().BoolVarP(&pkg, "pkg", "p", false, "read from /opt/skywire/skywire.json")
 	hvCmd.AddCommand(chvpkCmd)
+	hvCmd.AddCommand(hvEnableCmd)
+	hvCmd.AddCommand(hvDisableCmd)
+	hvCmd.AddCommand(hvStatusCmd)
 }
 
 var hvCmd = &cobra.Command{
@@ -99,4 +102,50 @@ func HypervisorPort(cmdFlags *pflag.FlagSet) string {
 		return visorconfig.HTTPAddr()
 	}
 	return fmt.Sprintf(":%s", ports["hypervisor"])
+}
+
+var hvEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable hypervisor UI at runtime",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if err := rpcClient.EnableHypervisor(); err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), "Hypervisor enabled\n", "Hypervisor enabled\n")
+	},
+}
+
+var hvDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable hypervisor UI at runtime",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if err := rpcClient.DisableHypervisor(); err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), "Hypervisor disabled\n", "Hypervisor disabled\n")
+	},
+}
+
+var hvStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check if hypervisor is enabled",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if rpcClient.IsHypervisorEnabled() {
+			internal.PrintOutput(cmd.Flags(), "enabled\n", "enabled\n")
+		} else {
+			internal.PrintOutput(cmd.Flags(), "disabled\n", "disabled\n")
+		}
+	},
 }

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -168,9 +168,9 @@ var autoconfigCmd = &cobra.Command{
 
 func generateConfig(hvArg string) error {
 	// Build config gen command.
-	// Only pass -r (regen); all other flags come from SKYENV (/etc/skywire.conf).
-	// The conf file sets PKGENV, BESTPROTO, etc. — no need to hardcode them here.
-	args := []string{"cli", "config", "gen", "-r"}
+	// -r: regen existing config, -p: package mode (forces /opt/skywire paths).
+	// All other flags come from SKYENV (/etc/skywire.conf).
+	args := []string{"cli", "config", "gen", "-r", "-p"}
 
 	// Determine SKYENV path
 	skyenv := os.Getenv("SKYENV")
@@ -230,12 +230,13 @@ func generateTestConfig(hvArg string) error {
 
 	args := []string{"cli", "config", "gen",
 		"-r",           // regen (reuses SK if test config exists, or from SKYENV)
+		"-p",           // package mode
 		"-t",           // test deployment
-		"-o", testConf, // separate config file
+		"-o", testConf, // separate config file (overrides -p default path)
 	}
 
 	// Mirror hypervisor setting from prod
-	conf, _ := visorconfig.ReadFile("/opt/skywire/skywire.json")
+	conf, _ := visorconfig.ReadFile("/opt/skywire/skywire.json") //nolint:errcheck
 	switch hvArg {
 	case "0":
 		args = append(args, "-i")

--- a/pkg/skywire-utilities/pkg/netutil/net.go
+++ b/pkg/skywire-utilities/pkg/netutil/net.go
@@ -151,7 +151,7 @@ func LocalAddresses() ([]string, error) {
 			continue
 		}
 		// Skip Docker/container bridge interfaces
-		if isVirtualInterface(iface.Name) {
+		if IsVirtualInterface(iface.Name) {
 			continue
 		}
 
@@ -176,9 +176,9 @@ func LocalAddresses() ([]string, error) {
 	return result, nil
 }
 
-// isVirtualInterface returns true for Docker bridges, veth pairs, and other
+// IsVirtualInterface returns true for Docker bridges, veth pairs, and other
 // virtual interfaces that shouldn't be registered with the address resolver.
-func isVirtualInterface(name string) bool {
+func IsVirtualInterface(name string) bool {
 	prefixes := []string{"docker", "br-", "veth", "virbr", "lxc", "cni", "flannel", "calico"}
 	for _, p := range prefixes {
 		if len(name) >= len(p) && name[:len(p)] == p {

--- a/pkg/skywire-utilities/pkg/netutil/net.go
+++ b/pkg/skywire-utilities/pkg/netutil/net.go
@@ -140,25 +140,52 @@ func ExtractPort(addr net.Addr) (uint16, error) {
 func LocalAddresses() ([]string, error) {
 	result := make([]string, 0)
 
-	addresses, err := net.InterfaceAddrs()
+	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, addr := range addresses {
-		switch v := addr.(type) {
-		case *net.IPNet:
-			if v.IP.IsGlobalUnicast() || v.IP.IsLoopback() {
-				result = append(result, v.IP.String())
+	for _, iface := range ifaces {
+		// Skip loopback and down interfaces
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		// Skip Docker/container bridge interfaces
+		if isVirtualInterface(iface.Name) {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
 			}
-		case *net.IPAddr:
-			if v.IP.IsGlobalUnicast() || v.IP.IsLoopback() {
-				result = append(result, v.IP.String())
+			if ip != nil && ip.IsGlobalUnicast() {
+				result = append(result, ip.String())
 			}
 		}
 	}
 
 	return result, nil
+}
+
+// isVirtualInterface returns true for Docker bridges, veth pairs, and other
+// virtual interfaces that shouldn't be registered with the address resolver.
+func isVirtualInterface(name string) bool {
+	prefixes := []string{"docker", "br-", "veth", "virbr", "lxc", "cni", "flannel", "calico"}
+	for _, p := range prefixes {
+		if len(name) >= len(p) && name[:len(p)] == p {
+			return true
+		}
+	}
+	return false
 }
 
 // LocalProtocol check a condition to use dmsghttp or direct url

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -29,6 +29,9 @@ type API interface {
 	Summary() (*Summary, error)
 	Health() (*HealthInfo, error)
 	IsStartupComplete() bool
+	EnableHypervisor() error
+	DisableHypervisor() error
+	IsHypervisorEnabled() bool
 	Uptime() (float64, error)
 	RuntimeStats() (*RuntimeStatsInfo, error)
 	Reload() error

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -204,7 +204,7 @@ func (v *Visor) Health() (*HealthInfo, error) {
 // EnableHypervisor implements API.
 func (v *Visor) EnableHypervisor() error {
 	if v.hvInstance == nil {
-		return fmt.Errorf("hypervisor not configured in visor config")
+		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
 	}
 	return v.hvInstance.Enable(context.Background())
 }

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -2,6 +2,7 @@
 package visor
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -198,6 +199,30 @@ func (v *Visor) Health() (*HealthInfo, error) {
 		return &HealthInfo{}, nil
 	}
 	return &HealthInfo{ServicesHealth: v.isServicesHealthy.value()}, nil
+}
+
+// EnableHypervisor implements API.
+func (v *Visor) EnableHypervisor() error {
+	if v.hvInstance == nil {
+		return fmt.Errorf("hypervisor not configured in visor config")
+	}
+	return v.hvInstance.Enable(context.Background())
+}
+
+// DisableHypervisor implements API.
+func (v *Visor) DisableHypervisor() error {
+	if v.hvInstance == nil {
+		return nil
+	}
+	return v.hvInstance.Disable()
+}
+
+// IsHypervisorEnabled implements API.
+func (v *Visor) IsHypervisorEnabled() bool {
+	if v.hvInstance == nil {
+		return false
+	}
+	return v.hvInstance.IsEnabled()
 }
 
 // IsStartupComplete implements API.

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -68,6 +69,12 @@ type Hypervisor struct {
 	logger       *logging.Logger
 	tpvizServer  *tpviz.Server
 	lanDmsg      *LANDmsgServer // embedded LAN DMSG server (nil if disabled)
+
+	// Runtime state for enable/disable toggle
+	httpSrv   *http.Server // nil when disabled
+	srvCancel context.CancelFunc
+	enabled   bool
+	enableMu  sync.Mutex
 }
 
 // NewHypervisor creates a new Hypervisor.
@@ -119,6 +126,122 @@ func NewHypervisor(config visorconfig.HypervisorConfig, visor *Visor, dmsgC *dms
 	}
 
 	return hv, nil
+}
+
+// Enable starts the hypervisor HTTP server and DMSG RPC listener.
+// Safe to call multiple times — no-op if already enabled.
+func (hv *Hypervisor) Enable(ctx context.Context) error {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+
+	if hv.enabled {
+		return nil
+	}
+
+	srvCtx, cancel := context.WithCancel(ctx)
+	hv.srvCancel = cancel
+
+	// Start DMSG RPC listener for remote visors (waits for DMSG to be ready)
+	if hv.dmsgC != nil {
+		go func() {
+			<-hv.dmsgC.Ready()
+			hv.logger.WithField("addr", fmt.Sprintf("%s:%d", hv.c.PK, hv.c.DmsgPort)).
+				Info("Serving hypervisor RPC over DMSG")
+			if err := hv.ServeRPC(srvCtx, hv.c.DmsgPort); err != nil && !errors.Is(err, dmsg.ErrEntityClosed) {
+				hv.logger.WithError(err).Error("Hypervisor DMSG RPC stopped")
+			}
+		}()
+	}
+
+	// Start HTTP server
+	handler := hv.HTTPHandler()
+	hv.httpSrv = &http.Server{
+		Handler:           handler,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	lis, err := net.Listen("tcp", hv.c.HTTPAddr)
+	if err != nil {
+		cancel()
+		return fmt.Errorf("hypervisor HTTP listen %s: %w", hv.c.HTTPAddr, err)
+	}
+
+	go func() {
+		hv.logger.Infof("Hypervisor HTTP serving on %s", hv.c.HTTPAddr)
+		var srvErr error
+		if hv.c.EnableTLS {
+			srvErr = hv.httpSrv.ServeTLS(lis, hv.c.TLSCertFile, hv.c.TLSKeyFile)
+		} else {
+			srvErr = hv.httpSrv.Serve(lis)
+		}
+		if srvErr != nil && !errors.Is(srvErr, http.ErrServerClosed) {
+			hv.logger.WithError(srvErr).Error("Hypervisor HTTP server error")
+		}
+	}()
+
+	// Start tpviz if configured
+	if hv.tpvizServer != nil {
+		hv.tpvizServer.Start()
+	}
+
+	hv.enabled = true
+	hv.logger.Info("Hypervisor enabled")
+	return nil
+}
+
+// Disable stops the hypervisor HTTP server and DMSG RPC listener.
+// Disconnects all remote visors. Safe to call multiple times.
+func (hv *Hypervisor) Disable() error {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+
+	if !hv.enabled {
+		return nil
+	}
+
+	// Stop HTTP server
+	if hv.httpSrv != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := hv.httpSrv.Shutdown(shutdownCtx); err != nil {
+			hv.logger.WithError(err).Warn("Hypervisor HTTP shutdown error")
+		}
+		hv.httpSrv = nil
+	}
+
+	// Cancel DMSG RPC context (stops listener)
+	if hv.srvCancel != nil {
+		hv.srvCancel()
+		hv.srvCancel = nil
+	}
+
+	// Disconnect all remote visors
+	hv.vsMu.Lock()
+	for pk, conn := range hv.remoteVisors {
+		if conn.API != nil {
+			hv.logger.Infof("Disconnecting remote visor %s", pk)
+		}
+		delete(hv.remoteVisors, pk)
+	}
+	hv.vsMu.Unlock()
+
+	// Stop tpviz
+	if hv.tpvizServer != nil {
+		hv.tpvizServer.Stop()
+	}
+
+	hv.enabled = false
+	hv.logger.Info("Hypervisor disabled")
+	return nil
+}
+
+// IsEnabled returns whether the hypervisor is currently serving.
+func (hv *Hypervisor) IsEnabled() bool {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+	return hv.enabled
 }
 
 // ServeRPC serves RPC of a Hypervisor.
@@ -1647,23 +1770,6 @@ func pkSliceFromQuery(r *http.Request, key string, defaultVal []cipher.PubKey) (
 	}
 
 	return pks, nil
-}
-
-func (hv *Hypervisor) serveDmsg(ctx context.Context, log *logging.Logger) {
-	go func() {
-		<-hv.dmsgC.Ready()
-		if err := hv.ServeRPC(ctx, hv.c.DmsgPort); err != nil {
-			log := log.WithError(err)
-			if errors.Is(err, dmsg.ErrEntityClosed) {
-				log.Debug("Dmsg client stopped serving.")
-				return
-			}
-			log.Error("Failed to serve RPC client over dmsg.")
-			return
-		}
-	}()
-	log.WithField("addr", dmsg.Addr{PK: hv.c.PK, Port: hv.c.DmsgPort}).
-		Debug("Serving RPC client over dmsg.")
 }
 
 // dmsgPtyUI servers as a wrapper for `*dmsgpty.UI`. this way source file with

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -591,19 +591,18 @@ func (hv *Hypervisor) getDmsg() http.HandlerFunc {
 
 func (hv *Hypervisor) getDmsgSummary() []dmsgtracker.DmsgClientSummary {
 	hv.mu.RLock()
-	defer hv.mu.RUnlock()
-
 	pks := make([]cipher.PubKey, 0, len(hv.remoteVisors)+1)
 	if hv.visor != nil {
-		// Add hypervisor node.
 		pks = append(pks, hv.visor.conf.PK)
 	}
-
 	for pk := range hv.remoteVisors {
 		pks = append(pks, pk)
 	}
+	hv.mu.RUnlock()
+
 	if hv.visor.isDTMReady() {
-		ctx := context.TODO()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		return hv.visor.dmsgTracker.manager.GetBulk(ctx, pks)
 	}
 	return []dmsgtracker.DmsgClientSummary{}
@@ -665,16 +664,23 @@ func (hv *Hypervisor) getUptime() http.HandlerFunc {
 // provides overview of all visors.
 func (hv *Hypervisor) getVisors() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Snapshot remote visors under lock, then release immediately
 		hv.mu.RLock()
-		wg := new(sync.WaitGroup)
-		wg.Add(len(hv.remoteVisors))
+		type visorEntry struct {
+			pk   cipher.PubKey
+			conn Conn
+		}
+		remotes := make([]visorEntry, 0, len(hv.remoteVisors))
+		for pk, c := range hv.remoteVisors {
+			remotes = append(remotes, visorEntry{pk, c})
+		}
+		hv.mu.RUnlock()
 
 		i := 0
 		if hv.visor != nil {
 			i++
 		}
-
-		overviews := make([]Overview, len(hv.remoteVisors)+i)
+		overviews := make([]Overview, len(remotes)+i)
 
 		if hv.visor != nil {
 			overview, err := hv.visor.Overview()
@@ -682,34 +688,37 @@ func (hv *Hypervisor) getVisors() http.HandlerFunc {
 				hv.logger.WithError(err).Warn("Failed to obtain overview of this visor.")
 				overview = &Overview{PubKey: hv.visor.conf.PK}
 			}
-
 			overviews[0] = *overview
 		}
 
-		for pk, c := range hv.remoteVisors {
-			go func(pk cipher.PubKey, c Conn, i int) {
-				log := hv.log(r).
-					WithField("visor_addr", c.Addr).
-					WithField("func", "getVisors")
-
-				log.Debug("Requesting overview via RPC.")
-
-				overview, err := c.API.Overview()
-				if err != nil {
-					log.WithError(err).
-						Warn("Failed to obtain overview via RPC.")
-					overview = &Overview{PubKey: pk}
-				} else {
-					log.Debug("Obtained overview via RPC.")
+		wg := new(sync.WaitGroup)
+		wg.Add(len(remotes))
+		for _, entry := range remotes {
+			go func(pk cipher.PubKey, c Conn, idx int) {
+				defer wg.Done()
+				// Per-visor timeout prevents one dead visor from blocking everything
+				done := make(chan struct{})
+				var overview *Overview
+				go func() {
+					var err error
+					overview, err = c.API.Overview()
+					if err != nil {
+						hv.logger.WithError(err).WithField("pk", pk).Warn("Failed to obtain overview via RPC")
+						overview = &Overview{PubKey: pk}
+					}
+					close(done)
+				}()
+				select {
+				case <-done:
+					overviews[idx] = *overview
+				case <-time.After(5 * time.Second):
+					hv.logger.WithField("pk", pk).Warn("Remote visor RPC timed out (5s)")
+					overviews[idx] = Overview{PubKey: pk}
 				}
-				overviews[i] = *overview
-				wg.Done()
-			}(pk, c, i)
+			}(entry.pk, entry.conn, i)
 			i++
 		}
-
 		wg.Wait()
-		hv.mu.RUnlock()
 
 		httputil.WriteJSON(w, r, http.StatusOK, overviews)
 	}
@@ -763,64 +772,93 @@ func makeSummaryResp(online, hyper bool, sum *Summary) Summary {
 
 func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Get DMSG stats first (before acquiring lock to avoid deadlock)
+		// Get DMSG stats first (uses its own lock internally)
 		dmsgStats := make(map[string]dmsgtracker.DmsgClientSummary)
 		for _, stat := range hv.getDmsgSummary() {
 			dmsgStats[stat.PK.String()] = stat
 		}
 
+		// Snapshot remote visors under lock, then release immediately
 		hv.mu.RLock()
-		wg := new(sync.WaitGroup)
-		wg.Add(len(hv.remoteVisors))
+		type visorEntry struct {
+			pk   cipher.PubKey
+			conn Conn
+		}
+		remotes := make([]visorEntry, 0, len(hv.remoteVisors))
+		for pk, c := range hv.remoteVisors {
+			remotes = append(remotes, visorEntry{pk, c})
+		}
+		hv.mu.RUnlock()
 
-		summaries := make([]Summary, 0)
+		summaries := make([]Summary, 0, len(remotes)+1)
 
+		// Local visor summary
 		summary, err := hv.visor.Summary()
 		if err != nil {
 			hv.logger.WithError(err).Warn("Failed to obtain summary of this visor.")
 			summary = &Summary{
-				Overview: &Overview{
-					PubKey: hv.visor.conf.PK,
-				},
-				Health: &HealthInfo{},
+				Overview: &Overview{PubKey: hv.visor.conf.PK},
+				Health:   &HealthInfo{},
 			}
 		}
-
 		summaries = append(summaries, makeSummaryResp(err == nil, true, summary))
 
-		for pk, c := range hv.remoteVisors {
+		// Remote visor summaries with per-visor timeout
+		var deadVisors []cipher.PubKey
+		var mu sync.Mutex
+		wg := new(sync.WaitGroup)
+		wg.Add(len(remotes))
+
+		for _, entry := range remotes {
 			go func(pk cipher.PubKey, c Conn) {
-				log := hv.log(r).
-					WithField("visor_addr", c.Addr).
-					WithField("func", "getVisors")
+				defer wg.Done()
 
-				log.Trace("Requesting summary via RPC.")
+				done := make(chan struct{})
+				var sum *Summary
+				var rpcErr error
+				go func() {
+					sum, rpcErr = c.API.Summary()
+					close(done)
+				}()
 
-				summary, err := c.API.Summary()
-				if err != nil {
-					log.WithError(err).
-						Warn("Failed to obtain summary via RPC.", pk)
-					delete(hv.remoteVisors, pk)
-				} else {
-					log.Trace("Obtained summary via RPC.")
-					resp := makeSummaryResp(err == nil, false, summary)
-					hv.vsMu.Lock()
-					summaries = append(summaries, resp)
-					hv.vsMu.Unlock()
+				select {
+				case <-done:
+					if rpcErr != nil {
+						hv.logger.WithError(rpcErr).WithField("pk", pk).Warn("Failed to obtain summary via RPC")
+						mu.Lock()
+						deadVisors = append(deadVisors, pk)
+						mu.Unlock()
+					} else {
+						resp := makeSummaryResp(true, false, sum)
+						mu.Lock()
+						summaries = append(summaries, resp)
+						mu.Unlock()
+					}
+				case <-time.After(5 * time.Second):
+					hv.logger.WithField("pk", pk).Warn("Remote visor summary RPC timed out (5s)")
+					mu.Lock()
+					deadVisors = append(deadVisors, pk)
+					mu.Unlock()
 				}
-				wg.Done()
-			}(pk, c)
+			}(entry.pk, entry.conn)
+		}
+		wg.Wait()
+
+		// Remove dead visors under write lock (safe — no goroutines accessing the map)
+		if len(deadVisors) > 0 {
+			hv.mu.Lock()
+			for _, pk := range deadVisors {
+				delete(hv.remoteVisors, pk)
+			}
+			hv.mu.Unlock()
 		}
 
-		wg.Wait()
+		// Attach DMSG stats
 		for i := 0; i < len(summaries); i++ {
 			if stat, ok := dmsgStats[summaries[i].Overview.PubKey.String()]; ok {
 				summaries[i].DmsgStats = &stat
 			}
-			// If stats not found, leave DmsgStats as nil (don't create empty struct with 0ms latency)
 		}
-
-		hv.mu.RUnlock()
 
 		httputil.WriteJSON(w, r, http.StatusOK, summaries)
 	}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -535,7 +535,7 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 
 func initHypervisor(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if v.conf.Hypervisor == nil {
-		v.log.Error("hypervisor config = nil")
+		v.log.Debug("hypervisor config not present, skipping")
 		return nil
 	}
 
@@ -587,9 +587,13 @@ func initHypervisor(ctx context.Context, v *Visor, log *logging.Logger) error {
 		log.WithError(err).Warn("Unable to register js mime type")
 	}
 
-	// Enable the hypervisor (starts HTTP server + DMSG RPC listener)
-	if err := hv.Enable(ctx); err != nil {
-		return fmt.Errorf("failed to enable hypervisor: %w", err)
+	// Enable the hypervisor if configured to auto-start
+	if conf.Enable {
+		if err := hv.Enable(ctx); err != nil {
+			return fmt.Errorf("failed to enable hypervisor: %w", err)
+		}
+	} else {
+		v.log.Info("Hypervisor configured but not enabled (use 'skywire cli visor hv enable' to start)")
 	}
 
 	v.pushCloseStack("hypervisor", func() error {

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"mime"
 	"net"
-	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -534,12 +533,11 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 	return nil
 }
 
-func initHypervisor(_ context.Context, v *Visor, log *logging.Logger) error {
+func initHypervisor(ctx context.Context, v *Visor, log *logging.Logger) error {
 	if v.conf.Hypervisor == nil {
 		v.log.Error("hypervisor config = nil")
 		return nil
 	}
-	ctx, cancel := context.WithCancel(context.Background())
 
 	conf := *v.conf.Hypervisor
 	conf.PK = v.conf.PK
@@ -549,9 +547,11 @@ func initHypervisor(_ context.Context, v *Visor, log *logging.Logger) error {
 	// Prepare hypervisor.
 	hv, err := NewHypervisor(conf, v, v.dmsgC)
 	if err != nil {
-		cancel()
 		return fmt.Errorf("failed to start hypervisor: %w", err)
 	}
+
+	// Store instance on visor for runtime enable/disable via RPC
+	v.hvInstance = hv
 
 	// Start LAN DMSG server if configured
 	if conf.LANDmsgServer != nil && conf.LANDmsgServer.Enable {
@@ -565,9 +565,6 @@ func initHypervisor(_ context.Context, v *Visor, log *logging.Logger) error {
 				return lanServer.Server.Close()
 			})
 
-			// Connect the hypervisor's own DMSG client to the LAN server.
-			// This makes the hypervisor reachable by LAN visors through the LAN server
-			// instead of routing through public DMSG servers.
 			go func() {
 				lanEntry := &dmsgdisc.Entry{
 					Static: lanServer.PK,
@@ -585,50 +582,18 @@ func initHypervisor(_ context.Context, v *Visor, log *logging.Logger) error {
 		}
 	}
 
-	hv.serveDmsg(ctx, v.log)
-
-	// Serve HTTP(s).
-
-	// Needed to work with modern browsers when serving from windows, which need the correct mime type for javascript.
+	// Needed for modern browsers (correct MIME type for JavaScript).
 	if err := mime.AddExtensionType(".js", "application/javascript"); err != nil {
 		log.WithError(err).Warn("Unable to register js mime type")
 	}
 
-	v.log.WithField("addr", conf.HTTPAddr).
-		WithField("tls", conf.EnableTLS).
-		Info("Serving hypervisor...")
-	tls := ""
-	if conf.EnableTLS {
-		tls = "s"
+	// Enable the hypervisor (starts HTTP server + DMSG RPC listener)
+	if err := hv.Enable(ctx); err != nil {
+		return fmt.Errorf("failed to enable hypervisor: %w", err)
 	}
-	v.log.Info(fmt.Sprintf("Hypervisor UI: http%s://127.0.0.1%s", tls, conf.HTTPAddr))
-
-	handler := hv.HTTPHandler()
-	srv := &http.Server{
-		Addr:              conf.HTTPAddr,
-		Handler:           handler,
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      10 * time.Second,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-
-	go func() {
-		if conf.EnableTLS {
-			err = srv.ListenAndServeTLS(conf.TLSCertFile, conf.TLSKeyFile)
-		} else {
-			err = srv.ListenAndServe()
-		}
-
-		// don't print error if local server is closed
-		if !errors.Is(err, http.ErrServerClosed) {
-			v.log.WithError(err).Error("Hypervisor exited with error.")
-		}
-	}()
 
 	v.pushCloseStack("hypervisor", func() error {
-		err := srv.Shutdown(ctx)
-		cancel()
-		return err
+		return hv.Disable()
 	})
 
 	return nil

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -70,6 +70,24 @@ func (r *RPC) IsStartupComplete(_ *struct{}, out *bool) (err error) {
 	return nil
 }
 
+// EnableHypervisor starts the hypervisor HTTP server and DMSG listener.
+func (r *RPC) EnableHypervisor(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "EnableHypervisor", nil)(nil, &err)
+	return r.visor.EnableHypervisor()
+}
+
+// DisableHypervisor stops the hypervisor HTTP server and disconnects remote visors.
+func (r *RPC) DisableHypervisor(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "DisableHypervisor", nil)(nil, &err)
+	return r.visor.DisableHypervisor()
+}
+
+// IsHypervisorEnabled returns whether the hypervisor is currently serving.
+func (r *RPC) IsHypervisorEnabled(_ *struct{}, out *bool) (err error) {
+	*out = r.visor.IsHypervisorEnabled()
+	return nil
+}
+
 func (r *RPC) Health(_ *struct{}, out *HealthInfo) (err error) {
 	defer rpcutil.LogCall(r.log, "Health", nil)(out, &err)
 

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -131,6 +131,25 @@ func (rc *rpcClient) IsStartupComplete() bool {
 	return out
 }
 
+// EnableHypervisor calls EnableHypervisor
+func (rc *rpcClient) EnableHypervisor() error {
+	return rc.Call("EnableHypervisor", &struct{}{}, &struct{}{})
+}
+
+// DisableHypervisor calls DisableHypervisor
+func (rc *rpcClient) DisableHypervisor() error {
+	return rc.Call("DisableHypervisor", &struct{}{}, &struct{}{})
+}
+
+// IsHypervisorEnabled calls IsHypervisorEnabled
+func (rc *rpcClient) IsHypervisorEnabled() bool {
+	var out bool
+	if err := rc.Call("IsHypervisorEnabled", &struct{}{}, &out); err != nil {
+		return false
+	}
+	return out
+}
+
 // Uptime calls Uptime
 func (rc *rpcClient) Uptime() (float64, error) {
 	var out float64

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -210,6 +210,15 @@ func (mc *mockRPCClient) IsStartupComplete() bool {
 	return true
 }
 
+// EnableHypervisor implements API
+func (mc *mockRPCClient) EnableHypervisor() error { return nil }
+
+// DisableHypervisor implements API
+func (mc *mockRPCClient) DisableHypervisor() error { return nil }
+
+// IsHypervisorEnabled implements API
+func (mc *mockRPCClient) IsHypervisorEnabled() bool { return false }
+
 // Uptime implements API
 func (mc *mockRPCClient) Uptime() (float64, error) {
 	return time.Since(mc.startedAt).Seconds(), nil

--- a/pkg/visor/survey.go
+++ b/pkg/visor/survey.go
@@ -85,6 +85,11 @@ func GenerateSurvey(v *Visor, log *logging.Logger, routine bool) {
 		survey.ServicesURLs.ServiceDiscovery = v.conf.Launcher.ServiceDisc
 		survey.ServicesURLs.SurveyWhitelist = v.conf.SurveyWhitelist
 		survey.ServicesURLs.StunServers = v.conf.StunServers
+		// DMSG endpoints (dual-mode config)
+		survey.ServicesURLs.DmsgDiscoveryDmsg = v.conf.Dmsg.DiscoveryDmsg
+		survey.ServicesURLs.TransportDiscoveryDmsg = v.conf.Transport.DiscoveryDmsg
+		survey.ServicesURLs.AddressResolverDmsg = v.conf.Transport.AddressResolverDmsg
+		survey.ServicesURLs.ServiceDiscoveryDmsg = v.conf.Launcher.ServiceDiscDmsg
 		survey.DmsgServers = v.dmsgC.ConnectedServersPK()
 
 		// Get public IP from DMSG server

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -138,6 +138,9 @@ type Visor struct {
 	// Embedded Route Setup Node (nil if route_setup_sk not configured)
 	embeddedRouteSetup *EmbeddedRouteSetup
 
+	// Hypervisor instance (nil if never initialized; may be enabled/disabled at runtime)
+	hvInstance *Hypervisor
+
 	// Public autoconnect runtime control
 	autoconnect autoconnectState
 

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -51,6 +51,7 @@ func (hk *Key) UnmarshalText(text []byte) error {
 
 // HypervisorConfig configures the hypervisor.
 type HypervisorConfig struct {
+	Enable        bool               `json:"enable"` // Whether the hypervisor is enabled (starts HTTP + DMSG on visor startup).
 	UIAssets      fs.FS              `json:"-"`
 	PK            cipher.PubKey      `json:"-"`
 	SK            cipher.SecKey      `json:"-"`
@@ -65,6 +66,16 @@ type HypervisorConfig struct {
 	TLSKeyFile    string             `json:"tls_key_file"`              // TLS key file location.
 	TPViz         TPVizConfig        `json:"tp_viz"`                    // Transport visualizer config.
 	LANDmsgServer *LANDmsgServerConf `json:"lan_dmsg_server,omitempty"` // LAN DMSG server config.
+}
+
+// DefaultHypervisorConfig returns a HypervisorConfig with sensible defaults.
+// Used when enabling the hypervisor at runtime on a visor that wasn't configured
+// as a hypervisor at startup.
+func DefaultHypervisorConfig() HypervisorConfig {
+	c := HypervisorConfig{}
+	c.FillDefaults(false)
+	c.DBPath = filepath.Join(skyenv.SkywirePath, "local", "hypervisor", "users.db")
+	return c
 }
 
 // LANDmsgServerConf configures an embedded DMSG server for LAN visors.

--- a/pkg/visor/withoutsystray.go
+++ b/pkg/visor/withoutsystray.go
@@ -18,5 +18,8 @@ func runAppSystray() {
 }
 
 func runApp() {
-	// no-op: systray not available
+	err := run(nil)
+	if err != nil {
+		mLog.WithError(err).Fatal("a fatal error occurred")
+	}
 }

--- a/static/skywire-manager-src/src/app/app.component.ts
+++ b/static/skywire-manager-src/src/app/app.component.ts
@@ -151,8 +151,9 @@ export class AppComponent {
         this.pkErrorShown = true;
       }
 
-      if (!this.inLoginPage) {
-        this.checkHypervisorPk(1000);
+      // Retry with increasing delay, max 30 retries before giving up
+      if (!this.inLoginPage && this.pkErrorsFound < 30) {
+        this.checkHypervisorPk(Math.min(this.pkErrorsFound * 1000, 10000));
       }
     });
   }

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -434,6 +434,7 @@ export class NodeListComponent extends PageBaseComponent implements OnInit, OnDe
           }
 
           // Stop the loading indicator and show a warning icon.
+          this.loading = false;
           this.errorsUpdating = true;
           AppComponent.currentInstance.showDataProblemMsg();
         }


### PR DESCRIPTION
## Summary
- Fix E2E tests: SKYDEPLOY, discovery URL, skychat binding, single-hop messaging
- Add -Q flag to write conf template reflecting passed flags
- Autoconfig fixes: SKYENV, suppress debug output, -p flag
- Runtime hypervisor enable/disable (in progress)

## Test plan
- [ ] CI E2E tests pass
- [ ] `skywire cli config gen -ipq` shows ISHYPERVISOR and PKGENV uncommented
- [ ] `skywire autoconfig` uses SKYENV correctly
- [ ] Hypervisor can be enabled/disabled at runtime (pending)