### PR TITLE
Vendor dmsg 28ba3f1a: reduce ping frequency, trace level logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pterm/pterm v0.12.83
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/sirupsen/logrus v1.9.4
-	github.com/skycoin/dmsg v1.3.29-0.20260404170548-2c86ee54ad44
+	github.com/skycoin/dmsg v1.3.29-0.20260407014626-28ba3f1a422e
 	github.com/skycoin/skycoin v0.28.6-0.20260401142608-a27afbb0b33b
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -755,8 +755,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/skycoin/dmsg v1.3.29-0.20260404170548-2c86ee54ad44 h1:izK7Tu9O5lNouApoRBJVyqIVE4t8FS5VT6yyyTm8yq8=
-github.com/skycoin/dmsg v1.3.29-0.20260404170548-2c86ee54ad44/go.mod h1:uh8Nr+E8B3yVt7ciKUk4GdsZax7VoL/L3i1EagXbzjk=
+github.com/skycoin/dmsg v1.3.29-0.20260407014626-28ba3f1a422e h1:T9Fa6h1g9zTEZcskpcVH21R5CXcD2m4ybQCViVR41o0=
+github.com/skycoin/dmsg v1.3.29-0.20260407014626-28ba3f1a422e/go.mod h1:uh8Nr+E8B3yVt7ciKUk4GdsZax7VoL/L3i1EagXbzjk=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9 h1:DElGw1Fhj4amuW1KM5q8Xowosb3RiOQce0lDJw0Qv0Y=
 github.com/skycoin/encodertest v0.0.0-20190217072920-14c2e31898b9/go.mod h1:OQz8NXVJUWEw7PWYASZ/1BIw5GXgVMTGvrCGDlZa9+k=
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0duwyG+7WliWz5u9kgk1h5MnLuA=

--- a/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
+++ b/vendor/github.com/skycoin/dmsg/pkg/dmsg/client.go
@@ -527,8 +527,11 @@ func (ce *Client) reconnectMissing(ctx context.Context) {
 }
 
 // pingSessionsLoop periodically pings all sessions to measure latency.
+// The interval is 1 hour — this is for server selection, not keepalive
+// (yamux handles its own keepalives). 30s was excessive and generated
+// noisy DEBUG logs (N_clients × N_servers pings every 30s).
 func (ce *Client) pingSessionsLoop(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(1 * time.Hour)
 	defer ticker.Stop()
 
 	// Do an initial ping immediately.
@@ -552,11 +555,11 @@ func (ce *Client) pingSessions() {
 		rtt, err := ses.Ping()
 		if err != nil {
 			ce.log.WithError(err).WithField("server", ses.RemotePK()).
-				Debug("Ping failed, keeping previous latency measurement")
+				Trace("Ping failed, keeping previous latency measurement")
 			continue
 		}
 		ses.SetLastPing(rtt)
 		ce.log.WithField("server", ses.RemotePK()).WithField("rtt", rtt).
-			Debug("Session ping measured")
+			Trace("Session ping measured")
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -772,7 +772,7 @@ github.com/shopspring/decimal
 ## explicit; go 1.17
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog
-# github.com/skycoin/dmsg v1.3.29-0.20260404170548-2c86ee54ad44
+# github.com/skycoin/dmsg v1.3.29-0.20260407014626-28ba3f1a422e
 ## explicit; go 1.26.1
 github.com/skycoin/dmsg/cmd/conf/commands
 github.com/skycoin/dmsg/cmd/dial/commands


### PR DESCRIPTION
## Summary
- Vendor dmsg commit 28ba3f1a (skycoin/dmsg#371)
- Session ping interval: 30s → 1 hour
- Ping log level: Debug → Trace

The ping loop measures latency for server selection, not keepalive (yamux handles that). 30s was generating excessive debug logging.

## Test plan
- [x] Build passes
- [ ] CI lint + tests