### PR TITLE
Fix dmsg server goroutine leak: atomic flag in idleTimeoutConn

### DIFF
--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -289,11 +290,15 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 type idleTimeoutConn struct {
 	rwc     io.ReadWriteCloser
 	timeout time.Duration
+	forced  atomic.Bool
 }
 
 func (c *idleTimeoutConn) Read(p []byte) (int, error) {
-	if conn, ok := c.rwc.(net.Conn); ok {
-		conn.SetReadDeadline(time.Now().Add(c.timeout)) //nolint:errcheck,gosec
+	// Don't reset deadline if ForceReadDeadline was called
+	if !c.forced.Load() {
+		if conn, ok := c.rwc.(net.Conn); ok {
+			conn.SetReadDeadline(time.Now().Add(c.timeout)) //nolint:errcheck,gosec
+		}
 	}
 	return c.rwc.Read(p)
 }
@@ -311,7 +316,9 @@ func (c *idleTimeoutConn) Close() error {
 
 // ForceReadDeadline sets an immediate read deadline to unblock any pending Read.
 // This is needed because yamux Stream.Close() does NOT unblock a local Read().
+// It also sets a flag to prevent Read() from resetting the deadline.
 func (c *idleTimeoutConn) ForceReadDeadline() {
+	c.forced.Store(true)
 	if conn, ok := c.rwc.(net.Conn); ok {
 		conn.SetReadDeadline(time.Now().Add(-time.Second)) //nolint:errcheck,gosec
 	}


### PR DESCRIPTION
## Summary
Fix the dmsg server goroutine leak that was causing 25K-47K leaked
goroutines per server in production.

Root cause: `ForceReadDeadline()` set an expired deadline to unblock
pending reads, but `idleTimeoutConn.Read()` immediately overwrote it
with a fresh 5-minute deadline on every `io.Copy` iteration. The
force was completely ineffective.

Fix: add atomic `forced` flag that prevents `Read()` from resetting
the deadline after `ForceReadDeadline()` is called.

## Test plan
- [ ] Deploy and monitor dmsg-server goroutine counts via pprof
- [ ] Goroutine counts should stabilize instead of growing unbounded