### PR TITLE
Fix dmsg goroutine leak: force-close in ForceReadDeadline

### DIFF
--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -289,11 +290,15 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 type idleTimeoutConn struct {
 	rwc     io.ReadWriteCloser
 	timeout time.Duration
+	forced  atomic.Bool
 }
 
 func (c *idleTimeoutConn) Read(p []byte) (int, error) {
-	if conn, ok := c.rwc.(net.Conn); ok {
-		conn.SetReadDeadline(time.Now().Add(c.timeout)) //nolint:errcheck,gosec
+	// Don't reset deadline if ForceReadDeadline was called
+	if !c.forced.Load() {
+		if conn, ok := c.rwc.(net.Conn); ok {
+			conn.SetReadDeadline(time.Now().Add(c.timeout)) //nolint:errcheck,gosec
+		}
 	}
 	return c.rwc.Read(p)
 }
@@ -311,7 +316,9 @@ func (c *idleTimeoutConn) Close() error {
 
 // ForceReadDeadline sets an immediate read deadline to unblock any pending Read.
 // This is needed because yamux Stream.Close() does NOT unblock a local Read().
+// It also sets a flag to prevent Read() from resetting the deadline.
 func (c *idleTimeoutConn) ForceReadDeadline() {
+	c.forced.Store(true)
 	if conn, ok := c.rwc.(net.Conn); ok {
 		conn.SetReadDeadline(time.Now().Add(-time.Second)) //nolint:errcheck,gosec
 	}

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -314,14 +314,21 @@ func (c *idleTimeoutConn) Close() error {
 	return c.rwc.Close()
 }
 
-// ForceReadDeadline sets an immediate read deadline to unblock any pending Read.
-// This is needed because yamux Stream.Close() does NOT unblock a local Read().
-// It also sets a flag to prevent Read() from resetting the deadline.
+// ForceReadDeadline forces the connection to stop reading by:
+// 1. Setting the forced flag so Read() won't reset the deadline
+// 2. Setting an expired deadline to wake any blocked Read
+// 3. Resetting the yamux stream to forcibly unblock Read
+// This is needed because yamux Stream.Close() sends FIN but does NOT
+// unblock a concurrent local Read() on the same stream.
 func (c *idleTimeoutConn) ForceReadDeadline() {
 	c.forced.Store(true)
 	if conn, ok := c.rwc.(net.Conn); ok {
 		conn.SetReadDeadline(time.Now().Add(-time.Second)) //nolint:errcheck,gosec
 	}
+	// Also close the underlying connection to guarantee unblocking.
+	// This is a last resort — if SetReadDeadline doesn't work,
+	// closing the connection will cause Read to return an error.
+	c.rwc.Close() //nolint:errcheck
 }
 
 // forwardViaPeer tries to forward a stream request through peer server sessions.


### PR DESCRIPTION
## Summary
The previous ForceReadDeadline fix (atomic flag + expired deadline) did
not fully resolve the goroutine leak. 20K+ goroutines still accumulate
because SetReadDeadline alone doesn't reliably unblock yamux Stream.Read.

This adds rwc.Close() inside ForceReadDeadline as a last resort to
guarantee the blocked Read returns immediately.

## Test plan
- [ ] Deploy and monitor dmsg-server goroutine counts
- [ ] Counts should stabilize instead of growing at 5K/5min