### PR TITLE
Fix CopyReadWriteCloser goroutine leak + DialStream race

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1527,7 +1527,7 @@ func server() {
 						continue
 					}
 					pkStr, _ := script.Echo(line).Column(2).String() //nolint:errcheck,gosec
-					pkStr = strings.TrimSpace(pkStr)
+					pkStr = strings.TrimRight(strings.TrimSpace(pkStr), ",")
 					if pkStr == pk {
 						shareStr, _ := script.Echo(line).Column(3).String()                                     //nolint:errcheck,gosec
 						skyStr, _ := script.Echo(line).Column(4).String()                                       //nolint:errcheck,gosec

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -36,7 +36,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	if discErr != nil {
 		// Discovery lookup failed. For direct clients or when the destination
 		// doesn't register in discovery, try all connected servers as forwarders.
-		// Only attempt if context is still valid (avoid races on cancelled contexts).
+		// Only attempt if context is still valid (avoid races on canceled contexts).
 		if ctx.Err() == nil {
 			ce.log.WithError(discErr).Debug("Discovery lookup failed, trying connected servers")
 			stream, err := ce.dialViaConnectedServers(ctx, addr)

--- a/pkg/dmsg/dmsgtest/mesh_test.go
+++ b/pkg/dmsg/dmsgtest/mesh_test.go
@@ -88,7 +88,8 @@ func TestServerMesh_CrossServerDial(t *testing.T) {
 	}
 
 	// Give peer connections time to establish.
-	time.Sleep(2 * time.Second)
+	// macOS CI runners need extra time for noise handshakes between servers.
+	time.Sleep(5 * time.Second)
 
 	// --- Client 1: only sees Server A ---
 	dcA := disc.NewMock(0)
@@ -139,7 +140,16 @@ func TestServerMesh_CrossServerDial(t *testing.T) {
 	require.NoError(t, err)
 	defer lis2.Close()
 
-	stream1, err := client1.DialStream(ctx, dmsg.Addr{PK: pk2, Port: port})
+	// Retry cross-server dial — peer mesh connection may still be establishing.
+	var stream1 *dmsg.Stream
+	for attempt := 0; attempt < 3; attempt++ {
+		stream1, err = client1.DialStream(ctx, dmsg.Addr{PK: pk2, Port: port})
+		if err == nil {
+			break
+		}
+		t.Logf("Cross-server dial attempt %d failed: %v", attempt+1, err)
+		time.Sleep(2 * time.Second)
+	}
 	require.NoError(t, err, "Cross-server dial should succeed via peer mesh")
 	defer stream1.Close()
 


### PR DESCRIPTION
## Summary
- Simplify CopyReadWriteCloser: don't wait for second goroutine (fixes 25K+ goroutine leak on dmsg servers)
- Fix DialStream fallback race condition: check context before fallback, use per-attempt timeout
- Fix misspell lint

## Test plan
- [ ] CI lint + tests pass
- [ ] Deploy and verify dmsg-server goroutine counts stabilize