### PR TITLE
Fix real port leak: auto-release reservation on Read/Write errors

### DIFF
--- a/pkg/dmsg/dmsg/stream.go
+++ b/pkg/dmsg/dmsg/stream.go
@@ -332,18 +332,43 @@ func (s *Stream) StreamID() uint32 {
 // It refreshes the idle timeout on each successful read so that active
 // streams are never killed, while stale streams stuck in waitRead with
 // no incoming data will time out and release their ephemeral port.
+//
+// On a terminal read error (EOF, remote close, deadline exceeded), we
+// call s.close (the porter freer) to release the ephemeral port
+// immediately, without waiting for the caller to call Close(). This is
+// necessary because rpc.Client.input() does not call codec.Close() when
+// the remote side closes the stream — it just marks the client as
+// shutdown — so the port would otherwise leak until the owning session
+// dies (which may be hours or days on a long-lived visor). Auto-releasing
+// on read error is safe because a dmsg stream is single-use: once Read
+// fails, the stream is dead and the caller must either close it or
+// discard it. Releasing the port is idempotent (sync.Once in makePortFreer),
+// and we keep the underlying yamux stream intact for the caller's Close()
+// to handle.
 func (s *Stream) Read(b []byte) (int, error) {
 	n, err := s.nsConn.Read(b)
 	if n > 0 {
 		// Reset the read deadline on successful read to keep the stream alive.
 		s.SetReadDeadline(time.Now().Add(StreamIdleTimeout)) //nolint:errcheck,gosec
 	}
+	if err != nil && s != nil && s.close != nil {
+		// Terminal read error — release the porter reservation so we don't
+		// rely on an explicit Close() from the caller's code path.
+		s.close()
+	}
 	return n, err
 }
 
-// Write implements io.Writer
+// Write implements io.Writer.
+// Like Read, a terminal write error means the stream is dead, so we
+// release the porter reservation immediately to prevent a leak when
+// the caller doesn't follow up with Close().
 func (s *Stream) Write(b []byte) (int, error) {
-	return s.nsConn.Write(b)
+	n, err := s.nsConn.Write(b)
+	if err != nil && s != nil && s.close != nil {
+		s.close()
+	}
+	return n, err
 }
 
 // SetDeadline implements net.Conn

--- a/rewards/mainnet_rules.md
+++ b/rewards/mainnet_rules.md
@@ -52,7 +52,7 @@ The bandwidth considered for this pool excludes same-LAN transports (where both 
 To receive Skycoin rewards for running skywire, the following requirements must be met:
 
 
-* [1)](#Version) **Minimum skywire [version](#Version) v1.3.36** - Cutoff March 20th 2026
+* [1)](#Version) **Minimum skywire [version](#Version) v1.3.43** - Cutoff April 23rd 2026
 
 * [2)](#Uptime) **75% [uptime](#Uptime) per day** minimum is required to be eligible to receive rewards
 
@@ -139,6 +139,30 @@ Rewards Cutoff date for updating 02-25-2026
 Requirement established 03-06-2026
 
 Rewards Cutoff date for updating 03-20-2026
+
+**Reward eligibility after 04-18-2026 requires Skywire v1.3.40**
+
+Requirement established 04-04-2026
+
+Rewards Cutoff date for updating 04-18-2026
+
+**Reward eligibility after 04-19-2026 requires Skywire v1.3.41**
+
+Requirement established 04-05-2026
+
+Rewards Cutoff date for updating 04-19-2026
+
+**Reward eligibility after 04-23-2026 requires Skywire v1.3.42**
+
+Requirement established 04-09-2026
+
+Rewards Cutoff date for updating 04-23-2026
+
+**Reward eligibility after 04-23-2026 requires Skywire v1.3.43**
+
+Requirement established 04-09-2026
+
+Rewards Cutoff date for updating 04-23-2026
 
 ### Uptime
 


### PR DESCRIPTION
## Root cause

The periodic porter reap loop added in #2300 was only catching streams whose session had died. It didn't help with the dominant leak: streams on LIVE sessions whose caller saw a terminal error but never explicitly Close()d the stream.

Specifically, Go's standard \`net/rpc.Client.input()\` goroutine, on detecting EOF or any terminal read error, marks the client as shutdown and terminates pending calls — but it does **not** call \`codec.Close()\`. If the caller's code then returns on the error without explicitly calling \`client.Close()\`, the underlying \`dmsg.Stream\` is orphaned. The porter reservation stays held until either the session dies (rare on a healthy visor) or something else explicitly closes the stream.

Observed on the local visor's \`embedded_route_setup\` dmsg client as ~120 ports/minute leak rate while sessions to all DMSG servers stayed alive for hours.

## Fix

Release the porter reservation inside \`dmsg.Stream.Read\` and \`dmsg.Stream.Write\` the moment any terminal error is observed. A dmsg stream is single-use — once a read or write errors, the stream is dead and the caller must either close it or discard it. Releasing the reservation eagerly doesn't change that contract, and \`sync.Once\` in \`makePortFreer\` makes double-release (Read + Write + explicit Close) safe.

The underlying yamux stream is left alone for the caller's normal \`Close()\` to handle.

## Also in this PR

Updated \`rewards/mainnet_rules.md\` with the recent version deadlines (v1.3.40, v1.3.41, v1.3.42, v1.3.43), each with a 2-week update window from the release date per the policy.

## Test plan
- [ ] pkg/dmsg/dmsg tests pass
- [ ] pkg/dmsg/dmsgtest tests pass with race
- [ ] Local visor porter count stays bounded after halt + restart with new binary
- [ ] Deployment shows no port exhaustion errors after rollout