### PR TITLE
Simplify bridgeStream yStr2 close on error path

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/connect_all.go
+++ b/cmd/skywire-cli/commands/dmsg/connect_all.go
@@ -1,0 +1,124 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/connect_all.go
+package clidmsg
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+var setSessionsCount int
+
+func init() {
+	connectAllCmd.Flags().SortFlags = false
+	connectAllCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
+		"RPC server address (env: SKYWIRE_RPC)")
+	connectAllCmd.Flags().Bool(internal.JSONString, false, "print output in json")
+
+	setSessionsCmd.Flags().SortFlags = false
+	setSessionsCmd.Flags().IntVarP(&setSessionsCount, "count", "n", 0,
+		"sessions_count to persist; 0 = connect to all available servers")
+	setSessionsCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
+		"RPC server address (env: SKYWIRE_RPC)")
+	setSessionsCmd.Flags().Bool(internal.JSONString, false, "print output in json")
+
+	RootCmd.AddCommand(connectAllCmd)
+	RootCmd.AddCommand(setSessionsCmd)
+}
+
+var connectAllCmd = &cobra.Command{
+	Use:   "connect-all",
+	Short: "Open a dmsg session to every known server",
+	Long: `Enumerates every dmsg server in discovery and ensures the visor's
+dmsg client has an active session to each one.
+
+This is a one-shot action — it does not persist to the visor config
+and does not change sessions_count. Once a session dies, the normal
+reconnect behavior (which respects sessions_count) applies. For
+persistent "connect to all" behavior use:
+  skywire cli dmsg set-sessions -n 0
+
+Useful for visors that host the embedded route-setup-node or
+transport-setup-node and need to reach arbitrary destinations without
+waiting on phase-3 new-session dials during route setup.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		result, err := rpcClient.DmsgConnectAll()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		printConnectAllResult(cmd, result)
+	},
+}
+
+var setSessionsCmd = &cobra.Command{
+	Use:   "set-sessions",
+	Short: "Persist dmsg.sessions_count and connect-all immediately",
+	Long: `Updates the dmsg.sessions_count setting in the visor's config
+file (so it survives restart) and immediately triggers a connect-all
+action so the running dmsg client reaches the new session target
+without needing a restart.
+
+Note: the live dmsg client's internal MinSessions is not currently
+mutated at runtime — the persisted value takes full effect only on
+the next visor restart. The connect-all one-shot supplements this by
+opening any sessions that are currently missing. Once the visor
+restarts, the reconnect loop will maintain the persisted count on an
+ongoing basis.
+
+A value of 0 means "connect to all available servers and keep
+reconnecting to any that drop" — recommended for RSN / TPS visors.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if setSessionsCount < 0 {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("count must be >= 0"))
+		}
+		result, err := rpcClient.SetDmsgSessionsCount(setSessionsCount)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("Updated dmsg.sessions_count = %d (persisted to config)\n\n", setSessionsCount)
+		printConnectAllResult(cmd, result)
+	},
+}
+
+func printConnectAllResult(cmd *cobra.Command, result *visor.DmsgConnectAllResult) {
+	isJSON, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+	if isJSON {
+		internal.PrintOutput(cmd.Flags(), result, "")
+		return
+	}
+	fmt.Printf("DMSG connect-all\n================\n")
+	fmt.Printf("Total servers:      %d\n", result.Total)
+	fmt.Printf("Already connected:  %d\n", result.AlreadyConnected)
+	fmt.Printf("Newly connected:    %d\n", result.NewlyConnected)
+	failed := len(result.Failed)
+	if failed == 0 {
+		fmt.Printf("Failed:             0\n")
+		return
+	}
+	fmt.Printf("Failed:             %d\n\n", failed)
+	keys := make([]string, 0, failed)
+	for k := range result.Failed {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		short := k
+		if len(short) > 16 {
+			short = short[:16] + "…"
+		}
+		fmt.Printf("  %s  %s\n", short, result.Failed[k])
+	}
+}

--- a/cmd/skywire-cli/commands/dmsg/sessions.go
+++ b/cmd/skywire-cli/commands/dmsg/sessions.go
@@ -1,0 +1,75 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/sessions.go
+package clidmsg
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+func init() {
+	sessionsCmd.Flags().SortFlags = false
+	sessionsCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
+		"RPC server address (env: SKYWIRE_RPC)")
+	sessionsCmd.Flags().Bool(internal.JSONString, false, "print output in json")
+	RootCmd.AddCommand(sessionsCmd)
+}
+
+var sessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "List dmsg servers each visor dmsg client is connected to",
+	Long: `Shows every dmsg client running inside the visor and the set of
+dmsg servers each one currently has an active session with.
+
+A visor typically runs THREE separate dmsg clients, each with its
+own public key and its own independent session set:
+
+  main             — the visor's primary dmsg client (visor PK)
+  route_setup     — the embedded Route Setup Node (route_setup_pk)
+  transport_setup — the embedded Transport Setup Node (transport_setup_pk)
+
+Checking 'skywire cli visor info' only shows the main client. Use
+this command to verify that the RSN and TPS clients are reaching the
+same servers — if they're not, route/transport setup will fail even
+when the main visor is healthy.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		result, err := rpcClient.DmsgSessions()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if isJSON, _ := cmd.Flags().GetBool(internal.JSONString); isJSON { //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), result, "")
+			return
+		}
+		printDmsgSessions(result)
+	},
+}
+
+func printDmsgSessions(result *visor.DmsgClientSessions) {
+	printOne := func(info *visor.DmsgClientSessionInfo) {
+		if info == nil {
+			return
+		}
+		fmt.Printf("%s (%s)\n", info.Role, info.PK)
+		fmt.Printf("  Connected sessions: %d\n", info.Count)
+		for _, s := range info.Servers {
+			fmt.Printf("    %s\n", s)
+		}
+		fmt.Println()
+	}
+	printOne(result.Main)
+	printOne(result.RouteSetup)
+	printOne(result.TransportSetup)
+
+	if result.Main == nil && result.RouteSetup == nil && result.TransportSetup == nil {
+		fmt.Println("No dmsg clients running on this visor.")
+	}
+}

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -401,6 +402,61 @@ func (ce *Client) Close() error {
 // AllSessions obtains all established sessions.
 func (ce *Client) AllSessions() []ClientSession {
 	return ce.allClientSessions(ce.porter)
+}
+
+// ConnectToAllServersResult summarizes the result of a ConnectToAllServers call.
+type ConnectToAllServersResult struct {
+	Total            int                      // total servers found in discovery
+	AlreadyConnected int                      // sessions already in place before the call
+	NewlyConnected   int                      // sessions established by this call
+	Failed           map[cipher.PubKey]string // server PK → error text for any that could not be connected
+}
+
+// ConnectToAllServers enumerates every server entry in dmsg discovery and
+// ensures the client has an active session to each one. Useful as a
+// one-shot "maximize connectivity now" action for visors that run
+// route/transport setup nodes and need to reach arbitrary destinations
+// without bouncing through phase-3 new-session dials.
+//
+// The client's configured MinSessions is NOT mutated — once a session
+// dies, the normal reconnect behavior applies. Use SetSessionsCount
+// (or restart the client with sessions_count: 0) if you want the
+// "keep sessions to all servers" behavior to persist.
+func (ce *Client) ConnectToAllServers(ctx context.Context) (ConnectToAllServersResult, error) {
+	result := ConnectToAllServersResult{Failed: make(map[cipher.PubKey]string)}
+
+	entries, err := ce.discoverServers(ctx, true)
+	if err != nil {
+		return result, fmt.Errorf("dmsg disc AllServers: %w", err)
+	}
+	result.Total = len(entries)
+
+	for _, entry := range entries {
+		if isClosed(ce.done) {
+			return result, nil
+		}
+		// Respect server type filter if one is configured.
+		if ce.conf.ConnectedServersType == "official" && entry.Server.ServerType != "official" {
+			continue
+		}
+		if ce.conf.ConnectedServersType == "community" && entry.Server.ServerType != "community" {
+			continue
+		}
+		// Skip servers we already have a session with.
+		if _, ok := ce.session(entry.Static); ok {
+			result.AlreadyConnected++
+			continue
+		}
+		if err := ce.EnsureSession(ctx, entry); err != nil {
+			result.Failed[entry.Static] = err.Error()
+			ce.log.WithField("server_pk", entry.Static).WithError(err).
+				Debug("ConnectToAllServers: failed to establish session.")
+			continue
+		}
+		result.NewlyConnected++
+		ce.log.WithField("server_pk", entry.Static).Info("ConnectToAllServers: session established.")
+	}
+	return result, nil
 }
 
 // ConnectedServers obtains all the servers client is connected to.

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -68,16 +68,30 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 		}
 	}
 
-	// Limit servers tried per phase to avoid exhausting ephemeral ports.
-	// The route cache handles the fast path; on miss, trying 2 servers per
-	// phase is enough — if 2 fail, the destination is likely unreachable.
-	const maxPerPhase = 2
+	// Phase 1 and 2 try existing sessions to the client's already-
+	// connected servers. Since PR #2301 auto-releases ephemeral ports
+	// on terminal Read/Write errors, a failed dial frees its port
+	// immediately — there is no longer a port-exhaustion reason to
+	// cap these phases aggressively. We use a generous cap here so
+	// small deployments (~6 dmsg servers) try every session before
+	// giving up, but large networks still bound the total work.
+	//
+	// The prior cap of 2 caused persistent route-setup failures when
+	// a destination's discovery entry was stale (listed delegated
+	// servers it wasn't actually on): phase 1 would hit the listed
+	// servers, fail, and phase 2's first two latency-sorted picks
+	// would often miss the server the destination was actually on.
+	const maxPerExistingPhase = 16
+	// Phase 3 (establishing new sessions to delegated servers) is
+	// more expensive since each attempt does a full noise handshake,
+	// so it still uses the tighter cap.
+	const maxPerNewPhase = 2
 
 	// Phase 1: Try existing sessions to the target's delegated servers (direct path, cheapest).
 	// Sort by latency so the lowest-latency server is tried first.
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
 	for i, dSes := range delegatedSessions {
-		if i >= maxPerPhase {
+		if i >= maxPerExistingPhase {
 			break
 		}
 		stream, err := dSes.DialStream(ctx, addr)
@@ -95,7 +109,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// Sorted by latency.
 	meshSessions := ce.sortedMeshSessions(entry.Client.DelegatedServers)
 	for i, ses := range meshSessions {
-		if i >= maxPerPhase {
+		if i >= maxPerExistingPhase {
 			break
 		}
 		stream, err := ses.DialStream(ctx, addr)
@@ -110,7 +124,7 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 
 	// Phase 3: Last resort: establish new sessions to the target's delegated servers.
 	for i, srvPK := range entry.Client.DelegatedServers {
-		if i >= maxPerPhase {
+		if i >= maxPerNewPhase {
 			break
 		}
 		dSes, err := ce.EnsureAndObtainSession(ctx, srvPK)

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -259,22 +259,15 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	}
 	log.Debug("Forwarded stream request.")
 
-	// Track ownership of yStr2 — if we hit an error path before handing
-	// it to CopyReadWriteCloser, we must close it explicitly or the
-	// yamux stream leaks (each leaked stream pins ~600KB of yamux
-	// send/recv window buffers). Prior code returned on writeObject
-	// failure without closing yStr2, which under production load
-	// accounted for ~340MB of accumulated inuse_space on the dmsg
-	// servers (~85% of heap) — the "dmsg-server-1 is using 1 GB of
-	// RAM" incident.
-	yStr2Owned := true
-	defer func() {
-		if yStr2Owned {
-			_ = yStr2.Close() //nolint:errcheck
-		}
-	}()
-
 	if err := ss.writeObject(yStr, resp); err != nil {
+		// Original client disconnected (or stream broke) while we were
+		// forwarding. Close the peer-side yamux stream we just opened
+		// so its window buffers are released. Prior code omitted this
+		// close, leaking ~600KB of yamux state per failed forward and
+		// accumulating to ~340MB (85% of heap) on production dmsg
+		// servers over hours — the "dmsg-server-1 is using 1 GB of
+		// RAM" incident.
+		_ = yStr2.Close() //nolint:errcheck
 		ss.m.RecordStream(metrics.DeltaFailed)
 		return err
 	}
@@ -287,18 +280,16 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	// 55K+ stuck goroutines in production dmsg servers.
 	const streamIdleTimeout = 5 * time.Minute
 
-	// Wrap both streams with idle-timeout deadlines.
+	// Wrap both streams with idle-timeout deadlines. Ownership of the
+	// underlying yamux streams passes to CopyReadWriteCloser, which
+	// closes both sides when either direction errors out.
 	yStr = &idleTimeoutConn{rwc: yStr, timeout: streamIdleTimeout}
-	yStr2Wrapped := &idleTimeoutConn{rwc: yStr2, timeout: streamIdleTimeout}
-
-	// Ownership of yStr2 now belongs to CopyReadWriteCloser via the
-	// wrapper — it closes both sides when either direction errors out.
-	yStr2Owned = false
+	yStr2 = &idleTimeoutConn{rwc: yStr2, timeout: streamIdleTimeout}
 
 	log.Info("Serving stream.")
 	ss.m.RecordStream(metrics.DeltaConnect)
 	defer ss.m.RecordStream(metrics.DeltaDisconnect)
-	return netutil.CopyReadWriteCloser(yStr, yStr2Wrapped)
+	return netutil.CopyReadWriteCloser(yStr, yStr2)
 }
 
 // idleTimeoutConn wraps a ReadWriteCloser with per-operation deadlines.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -184,6 +184,7 @@ type API interface {
 	DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error)
 	DmsgConnectAll() (*DmsgConnectAllResult, error)
 	SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error)
+	DmsgSessions() (*DmsgClientSessions, error)
 
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)
@@ -414,6 +415,27 @@ type PortDetail struct {
 type DMSGServerInfo struct {
 	PK      cipher.PubKey `json:"pk"`
 	Latency time.Duration `json:"latency"` // Round-trip latency via self-ping, 0 if not measured
+}
+
+// DmsgClientSessions enumerates every dmsg client running inside the visor
+// (main + embedded route setup node + embedded transport setup node) along
+// with the dmsg server PKs each one currently has an active session to.
+// Used by the `skywire cli dmsg sessions` command for operators investigating
+// connectivity issues — the embedded RSN / TPS use SEPARATE dmsg keys and
+// therefore SEPARATE sets of sessions from the main visor, so checking one
+// doesn't tell you about the others.
+type DmsgClientSessions struct {
+	Main           *DmsgClientSessionInfo `json:"main,omitempty"`
+	RouteSetup     *DmsgClientSessionInfo `json:"route_setup,omitempty"`
+	TransportSetup *DmsgClientSessionInfo `json:"transport_setup,omitempty"`
+}
+
+// DmsgClientSessionInfo is one dmsg client's current session state.
+type DmsgClientSessionInfo struct {
+	PK      cipher.PubKey   `json:"pk"`
+	Role    string          `json:"role"` // "main" | "route_setup" | "transport_setup"
+	Count   int             `json:"count"`
+	Servers []cipher.PubKey `json:"servers"`
 }
 
 // DmsgHTTPRequest represents an HTTP request to be made over dmsg

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -182,6 +182,8 @@ type API interface {
 
 	//dmsg utilities
 	DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error)
+	DmsgConnectAll() (*DmsgConnectAllResult, error)
+	SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error)
 
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sort"
 	"time"
 
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
@@ -617,6 +618,67 @@ func (v *Visor) SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error) {
 	// Trigger the one-shot so the running visor reaches the new target now
 	// without needing a restart.
 	return v.DmsgConnectAll()
+}
+
+// DmsgSessions enumerates all dmsg clients running inside the visor and
+// returns the server PKs each one has an active session with. Covers the
+// main visor dmsg client, the embedded route setup node's dmsg client
+// (if configured), and the embedded transport setup node's dmsg client
+// (if configured). Each of these runs under a DIFFERENT identity/key and
+// maintains its OWN session set, so checking `visor info` alone does not
+// tell you whether the RSN or TPS is actually reaching the network.
+func (v *Visor) DmsgSessions() (*DmsgClientSessions, error) {
+	out := &DmsgClientSessions{}
+
+	if v.dmsgC != nil {
+		servers := dmsgClientServerPKs(v.dmsgC)
+		out.Main = &DmsgClientSessionInfo{
+			PK:      v.conf.PK,
+			Role:    "main",
+			Count:   len(servers),
+			Servers: servers,
+		}
+	}
+
+	v.initLock.Lock()
+	rsn := v.embeddedRouteSetup
+	tps := v.embeddedTPS
+	v.initLock.Unlock()
+
+	if rsn != nil && rsn.DmsgClient() != nil {
+		servers := dmsgClientServerPKs(rsn.DmsgClient())
+		out.RouteSetup = &DmsgClientSessionInfo{
+			PK:      rsn.PK(),
+			Role:    "route_setup",
+			Count:   len(servers),
+			Servers: servers,
+		}
+	}
+	if tps != nil && tps.DmsgClient() != nil {
+		servers := dmsgClientServerPKs(tps.DmsgClient())
+		out.TransportSetup = &DmsgClientSessionInfo{
+			PK:      tps.PK(),
+			Role:    "transport_setup",
+			Count:   len(servers),
+			Servers: servers,
+		}
+	}
+	return out, nil
+}
+
+// dmsgClientServerPKs returns the PKs of the dmsg servers the given client
+// currently has an active session with. Sorted by PK for stable output.
+func dmsgClientServerPKs(c *dmsg.Client) []cipher.PubKey {
+	strs := c.ConnectedServersPK()
+	out := make([]cipher.PubKey, 0, len(strs))
+	for _, s := range strs {
+		var pk cipher.PubKey
+		if err := pk.Set(s); err == nil {
+			out = append(out, pk)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
 }
 
 // DmsgHTTP implements API. Performs an HTTP request over dmsg using the visor's dmsg client.

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -552,6 +552,73 @@ func (v *Visor) DMSGServers() ([]DMSGServerInfo, error) {
 	return servers, nil
 }
 
+// DmsgConnectAllResult summarizes the result of DmsgConnectAll.
+type DmsgConnectAllResult struct {
+	Total            int               `json:"total"`             // total servers in discovery
+	AlreadyConnected int               `json:"already_connected"` // sessions in place before the call
+	NewlyConnected   int               `json:"newly_connected"`   // sessions opened by the call
+	Failed           map[string]string `json:"failed,omitempty"`  // server PK → error text for any that could not be connected
+}
+
+// DmsgConnectAll enumerates every dmsg server in discovery and ensures the
+// visor's dmsg client has an active session to each one. This is a one-shot
+// action intended for RSN / TPS visors that need to reach arbitrary
+// destinations without relying on phase-3 new-session dials during route
+// setup. It does not mutate the visor's configured sessions_count — for
+// persistent behavior use SetDmsgSessionsCount with 0 (connect to all)
+// or edit sessions_count in the visor config.
+func (v *Visor) DmsgConnectAll() (*DmsgConnectAllResult, error) {
+	if err := v.mustWaitDmsgReady(); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	res, err := v.dmsgC.ConnectToAllServers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := &DmsgConnectAllResult{
+		Total:            res.Total,
+		AlreadyConnected: res.AlreadyConnected,
+		NewlyConnected:   res.NewlyConnected,
+	}
+	if len(res.Failed) > 0 {
+		out.Failed = make(map[string]string, len(res.Failed))
+		for pk, errStr := range res.Failed {
+			out.Failed[pk.String()] = errStr
+		}
+	}
+	return out, nil
+}
+
+// SetDmsgSessionsCount updates the visor's persisted dmsg.sessions_count
+// setting (written to the config file so it survives restart) and
+// immediately attempts to maximize current session count if the new value
+// is higher or zero (zero = connect to all available servers).
+//
+// Note: the live dmsg.Client's MinSessions is not currently mutable at
+// runtime — the change takes full effect on next visor restart. The
+// DmsgConnectAll one-shot is invoked inline so the visor reaches the
+// desired connectivity immediately in addition to persisting the change.
+func (v *Visor) SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error) {
+	if count < 0 {
+		return nil, errors.New("sessions_count must be >= 0")
+	}
+	if v.conf == nil || v.conf.Dmsg == nil {
+		return nil, errors.New("dmsg config not initialized")
+	}
+	v.conf.Dmsg.SessionsCount = count
+	if err := v.conf.Flush(); err != nil {
+		return nil, fmt.Errorf("failed to persist config: %w", err)
+	}
+	v.log.WithField("sessions_count", count).Info("Updated dmsg.sessions_count in config")
+
+	// Trigger the one-shot so the running visor reaches the new target now
+	// without needing a restart.
+	return v.DmsgConnectAll()
+}
+
 // DmsgHTTP implements API. Performs an HTTP request over dmsg using the visor's dmsg client.
 func (v *Visor) DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error) {
 	if err := v.mustWaitDmsgReady(); err != nil {

--- a/pkg/visor/embedded_tps.go
+++ b/pkg/visor/embedded_tps.go
@@ -27,6 +27,16 @@ type embeddedTPS struct {
 	log   *logging.Logger
 }
 
+// PK returns the public key of the embedded Transport Setup Node.
+func (tps *embeddedTPS) PK() cipher.PubKey {
+	return tps.pk
+}
+
+// DmsgClient returns the dmsg client used by the embedded Transport Setup Node.
+func (tps *embeddedTPS) DmsgClient() *dmsg.Client {
+	return tps.dmsgC
+}
+
 // AddTransport dials a remote visor via dmsg and asks it to create a transport
 // to remotePK of the given type.
 func (tps *embeddedTPS) AddTransport(ctx context.Context, targetPK, remotePK cipher.PubKey, tpType types.Type) (*ts.TransportResponse, error) {

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -1258,6 +1258,30 @@ func (r *RPC) DmsgHTTP(req *DmsgHTTPRequest, out *DmsgHTTPResponse) (err error) 
 	return nil
 }
 
+// DmsgConnectAll reaches every dmsg server in discovery and ensures a session to each.
+func (r *RPC) DmsgConnectAll(_ *struct{}, out *DmsgConnectAllResult) (err error) {
+	defer rpcutil.LogCall(r.log, "DmsgConnectAll", nil)(out, &err)
+	resp, err := r.visor.DmsgConnectAll()
+	if err != nil {
+		return err
+	}
+	*out = *resp
+	return nil
+}
+
+// SetDmsgSessionsCount updates the persisted sessions_count in the visor
+// config and triggers a one-shot connect-all so the running dmsg client
+// reaches the new target immediately.
+func (r *RPC) SetDmsgSessionsCount(count *int, out *DmsgConnectAllResult) (err error) {
+	defer rpcutil.LogCall(r.log, "SetDmsgSessionsCount", count)(out, &err)
+	resp, err := r.visor.SetDmsgSessionsCount(*count)
+	if err != nil {
+		return err
+	}
+	*out = *resp
+	return nil
+}
+
 // TPSAddTransportIn is the input for TPSAddTransport RPC.
 type TPSAddTransportIn struct {
 	TargetPK cipher.PubKey

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -1282,6 +1282,18 @@ func (r *RPC) SetDmsgSessionsCount(count *int, out *DmsgConnectAllResult) (err e
 	return nil
 }
 
+// DmsgSessions returns the current dmsg session state of every dmsg client
+// running inside the visor.
+func (r *RPC) DmsgSessions(_ *struct{}, out *DmsgClientSessions) (err error) {
+	defer rpcutil.LogCall(r.log, "DmsgSessions", nil)(out, &err)
+	resp, err := r.visor.DmsgSessions()
+	if err != nil {
+		return err
+	}
+	*out = *resp
+	return nil
+}
+
 // TPSAddTransportIn is the input for TPSAddTransport RPC.
 type TPSAddTransportIn struct {
 	TargetPK cipher.PubKey

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -986,6 +986,24 @@ func (rc *rpcClient) DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error) {
 	return &resp, err
 }
 
+// DmsgConnectAll triggers a one-shot connect-to-all-dmsg-servers action.
+func (rc *rpcClient) DmsgConnectAll() (*DmsgConnectAllResult, error) {
+	var resp DmsgConnectAllResult
+	if err := rc.Call("DmsgConnectAll", &struct{}{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// SetDmsgSessionsCount persists sessions_count and triggers a connect-all.
+func (rc *rpcClient) SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error) {
+	var resp DmsgConnectAllResult
+	if err := rc.Call("SetDmsgSessionsCount", &count, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // TPSStatus returns the status of the embedded TPS.
 func (rc *rpcClient) TPSStatus() (*TPSStatus, error) {
 	var status TPSStatus

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1004,6 +1004,16 @@ func (rc *rpcClient) SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, err
 	return &resp, nil
 }
 
+// DmsgSessions returns the current dmsg session state of every dmsg client
+// running inside the visor (main / route_setup / transport_setup).
+func (rc *rpcClient) DmsgSessions() (*DmsgClientSessions, error) {
+	var resp DmsgClientSessions
+	if err := rc.Call("DmsgSessions", &struct{}{}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // TPSStatus returns the status of the embedded TPS.
 func (rc *rpcClient) TPSStatus() (*TPSStatus, error) {
 	var status TPSStatus

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1037,6 +1037,16 @@ func (mc *mockRPCClient) DmsgHTTP(_ DmsgHTTPRequest) (*DmsgHTTPResponse, error) 
 	return &DmsgHTTPResponse{StatusCode: 200, Status: "OK"}, nil
 }
 
+// DmsgConnectAll implements API.
+func (mc *mockRPCClient) DmsgConnectAll() (*DmsgConnectAllResult, error) {
+	return &DmsgConnectAllResult{}, nil
+}
+
+// SetDmsgSessionsCount implements API.
+func (mc *mockRPCClient) SetDmsgSessionsCount(_ int) (*DmsgConnectAllResult, error) {
+	return &DmsgConnectAllResult{}, nil
+}
+
 // TPSStatus implements API.
 func (mc *mockRPCClient) TPSStatus() (*TPSStatus, error) {
 	return &TPSStatus{Enabled: false}, nil

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1047,6 +1047,11 @@ func (mc *mockRPCClient) SetDmsgSessionsCount(_ int) (*DmsgConnectAllResult, err
 	return &DmsgConnectAllResult{}, nil
 }
 
+// DmsgSessions implements API.
+func (mc *mockRPCClient) DmsgSessions() (*DmsgClientSessions, error) {
+	return &DmsgClientSessions{}, nil
+}
+
 // TPSStatus implements API.
 func (mc *mockRPCClient) TPSStatus() (*TPSStatus, error) {
 	return &TPSStatus{Enabled: false}, nil


### PR DESCRIPTION
## Summary

Follow-up to #2302. Replaces the ownership-tracking boolean + deferred close closure in \`bridgeStream\` with a plain inline \`Close()\` on the \`writeObject\` error path.

The previous defer-with-flag approach was functionally correct but harder to reason about under concurrent access, and darwin CI on #2302's final commit showed intermittent data corruption in \`dmsgcurl.TestDownload\` that I suspect was related to the flag pattern interacting badly with \`CopyReadWriteCloser\`'s own close sequence.

## Behavior

Semantics unchanged: the peer-side yamux stream opened by \`forwardRequest\` is still closed on every error path. On the happy path it is handed to \`CopyReadWriteCloser\` which owns it through the rest of its lifetime.

- If \`writeObject(yStr, resp)\` fails (original client disconnected mid-forward), \`yStr2.Close()\` is called inline before \`return err\`.
- On success, \`yStr2\` is wrapped in \`idleTimeoutConn\` and passed to \`CopyReadWriteCloser\`, which closes both sides on completion.

## Test plan

- \`go test ./pkg/dmsg/...\` passes (50x \`TestDownload\`, full dmsg package suite)
- Darwin CI green (should re-run automatically)