### PR TITLE
dmsg resilience: TTL, negative cache, parallel phase-1, RSN circuit breaker

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,11 @@ linters:
       - cmd/skywire-cli/commands/gotop
       - builtin$
       - examples$
+      # Skip any .go file that npm package vendoring drops under the
+      # frontend node_modules tree (e.g. flatted/golang/**). These are
+      # not part of the skywire source and a developer-local `npm
+      # install` should not break lint.
+      - node_modules
     rules:
       - linters:
           - misspell

--- a/cmd/dmsg-commands/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg-commands/dmsg-discovery/commands/dmsg-discovery.go
@@ -65,7 +65,11 @@ func init() {
 	RootCmd.Flags().StringVar(&officialServers, "official-servers", "", "list of official dmsg servers keys separated by comma")
 	RootCmd.Flags().StringVar(&redisURL, "redis", store.DefaultURL, "connections string for a redis store\n\r")
 	RootCmd.Flags().StringVar(&whitelistKeys, "whitelist-keys", "", "list of whitelisted keys of network monitor used for deregistration")
-	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", store.DefaultTimeout, "discovery entry timeout\n\r")
+	// 60m is 12× the client refresh interval (DefaultUpdateInterval*5 = 5m),
+	// giving ~2-3 missed refreshes of slack before Redis prunes an entry.
+	// Set to 0 to disable expiration (legacy behavior, stale entries
+	// will accumulate forever).
+	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 60*time.Minute, "client discovery entry TTL (0 to disable)\n\r")
 	RootCmd.Flags().BoolVarP(&testMode, "test-mode", "t", false, "in testing mode")
 	RootCmd.Flags().BoolVar(&enableLoadTesting, "enable-load-testing", false, "enable load testing")
 	RootCmd.Flags().BoolVar(&testEnvironment, "test-environment", false, "distinguished between prod and test environment")
@@ -150,7 +154,7 @@ Example:
 
 		// we enable metrics middleware if address is passed
 		enableMetrics := sf.MetricsAddr != ""
-		a := api.New(log, db, m, testMode, enableLoadTesting, enableMetrics, dmsgAddr, authPassphrase)
+		a := api.New(log, db, m, testMode, enableLoadTesting, enableMetrics, dmsgAddr, authPassphrase, entryTimeout)
 
 		var whitelistPKs []string
 		if whitelistKeys != "" {

--- a/cmd/skywire-cli/commands/route/rsn_stats.go
+++ b/cmd/skywire-cli/commands/route/rsn_stats.go
@@ -146,9 +146,9 @@ func formatRSNStats(s *setupmetrics.StatsSnapshot) string {
 	if len(s.TopDestinations) > 0 {
 		fmt.Fprintf(&b, "Top destinations (by total requests):\n")
 		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "  pk\ttotal\tfailed") //nolint:errcheck,gosec
+		fmt.Fprintln(tw, "  pk\ttotal\tfailed\tcircuit") //nolint:errcheck,gosec
 		for _, d := range s.TopDestinations {
-			fmt.Fprintf(tw, "  %s\t%d\t%d\n", truncatePK(d.PK), d.Total, d.Failed) //nolint:errcheck,gosec
+			fmt.Fprintf(tw, "  %s\t%d\t%d\t%s\n", truncatePK(d.PK), d.Total, d.Failed, circuitOrDash(d.Circuit)) //nolint:errcheck,gosec
 		}
 		tw.Flush() //nolint:errcheck,gosec
 		b.WriteString("\n")
@@ -156,9 +156,9 @@ func formatRSNStats(s *setupmetrics.StatsSnapshot) string {
 	if len(s.TopFailedDestinations) > 0 {
 		fmt.Fprintf(&b, "Top failed destinations:\n")
 		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "  pk\tfailed\ttotal") //nolint:errcheck,gosec
+		fmt.Fprintln(tw, "  pk\tfailed\ttotal\tcircuit") //nolint:errcheck,gosec
 		for _, d := range s.TopFailedDestinations {
-			fmt.Fprintf(tw, "  %s\t%d\t%d\n", truncatePK(d.PK), d.Failed, d.Total) //nolint:errcheck,gosec
+			fmt.Fprintf(tw, "  %s\t%d\t%d\t%s\n", truncatePK(d.PK), d.Failed, d.Total, circuitOrDash(d.Circuit)) //nolint:errcheck,gosec
 		}
 		tw.Flush() //nolint:errcheck,gosec
 		b.WriteString("\n")
@@ -188,4 +188,15 @@ func truncatePK(pk string) string {
 		return pk
 	}
 	return pk[:16] + "…"
+}
+
+// circuitOrDash renders the per-destination circuit state for the
+// top-destinations tables. "closed" is the healthy default so render
+// it as a dash to keep the column visually quiet; only abnormal
+// states (open / half_open) print the actual word.
+func circuitOrDash(state string) string {
+	if state == "" || state == "closed" {
+		return "-"
+	}
+	return state
 }

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
@@ -161,6 +162,12 @@ func RegisterFetchFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&NoHTTP, "no-http", false, "skip direct HTTP fallback step")
 }
 
+// isDmsgURL reports whether the given URL is a dmsg:// scheme URL that
+// the visor's DmsgHTTP RPC can handle directly.
+func isDmsgURL(u string) bool {
+	return len(u) >= 7 && u[:7] == "dmsg://"
+}
+
 // dmsgURLForHTTP looks up the DMSG equivalent URL for an HTTP service URL.
 // Returns empty string if no DMSG address is known for the service.
 func dmsgURLForHTTP(httpURL string) string {
@@ -190,7 +197,13 @@ func fetchViaDmsgDirect(dmsgURL string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
-	dlog := logging.MustGetLogger("cli:dmsg-fetch")
+	// Keep the ephemeral direct-client loggers quiet. They otherwise
+	// dump session-open / yamux / EOF / entry-delete chatter at debug
+	// level for every fetch, which drowns the caller's own output.
+	// Use a dedicated master logger so we don't mutate the global one.
+	dmaster := logging.NewMasterLogger()
+	dmaster.SetLevel(logrus.ErrorLevel)
+	dlog := dmaster.PackageLogger("cli:dmsg-fetch")
 	pk, sk := cipher.GenerateKeyPair()
 
 	servers := dmsg.Prod.DmsgServers
@@ -303,12 +316,23 @@ func FetchCachedServiceURL(cmdFlags *pflag.FlagSet, cachefile, thisurl string, c
 func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 	var lastErr error
 
+	// The visor's DmsgHTTP RPC parses req.Host as a dmsg.Addr (PK:port),
+	// so hostname-based http:// URLs like http://dmsgd.skywire.skycoin.com
+	// cannot be handled — they always fail with "invalid host address".
+	// Resolve the http URL to its dmsg:// equivalent via the deployment
+	// map before calling RPC; if no mapping exists we skip step 1 and
+	// rely on step 2/3.
+	rpcURL := url
+	if dmsgEquiv := dmsgURLForHTTP(url); dmsgEquiv != "" {
+		rpcURL = dmsgEquiv
+	}
+
 	// Step 1: Try visor RPC (proxies over DMSG via DmsgHTTP)
-	if !NoRPC {
+	if !NoRPC && (rpcURL != url || isDmsgURL(url)) {
 		rpcClient, err := Client(cmdFlags)
 		if err == nil {
 			resp, err := rpcClient.DmsgHTTP(visor.DmsgHTTPRequest{
-				URL:    url,
+				URL:    rpcURL,
 				Method: "GET",
 			})
 			if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
@@ -316,15 +340,17 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 			}
 			if err != nil {
 				lastErr = fmt.Errorf("RPC DmsgHTTP: %w", err)
-				logger.Debugf("RPC DmsgHTTP failed for %s: %v", url, err)
+				logger.Debugf("RPC DmsgHTTP failed for %s: %v", rpcURL, err)
 			} else {
 				lastErr = fmt.Errorf("RPC DmsgHTTP: status %d", resp.StatusCode)
-				logger.Debugf("RPC DmsgHTTP status %d for %s", resp.StatusCode, url)
+				logger.Debugf("RPC DmsgHTTP status %d for %s", resp.StatusCode, rpcURL)
 			}
 		} else {
 			lastErr = fmt.Errorf("RPC: %w", err)
 			logger.Debugf("RPC not available: %v", err)
 		}
+	} else if !NoRPC {
+		logger.Debugf("Skipping RPC step: no DMSG mapping for %s", url)
 	}
 
 	// Step 2: Direct DMSG HTTP (ephemeral client)

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -49,6 +49,17 @@ type API struct {
 	authPassphrase              string
 	OfficialServers             map[string]bool
 
+	// clientEntryTTL is the Redis expiration applied to client entries
+	// on POST /dmsg-discovery/entry. Clients refresh their entry every
+	// DefaultUpdateInterval*5 (5 minutes), so a TTL of 60 minutes
+	// (12× the refresh interval) gives ~2-3 missed refreshes of slack
+	// for brief network hiccups before Redis prunes the entry. This
+	// fixes the "stale delegated_servers" problem where crashed or
+	// network-dropped visors lingered in discovery forever, driving
+	// route setup failures on visors that tried to dial them. 0 means
+	// no expiration (the prior behavior).
+	clientEntryTTL time.Duration
+
 	// allClientsCache serves the `/dmsg-discovery/servers/clients` and
 	// `/dmsg-discovery/server/{pk}/clients` endpoints from a short-lived
 	// in-memory cache. Each call would otherwise do a full Redis
@@ -79,8 +90,10 @@ type singleflight struct {
 // poll rate of the cache, not the request rate of the API.
 const allClientsCacheTTL = 15 * time.Second
 
-// New returns a new API object, which can be started as a server
-func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, enableLoadTesting, enableMetrics bool, dmsgAddr, authPassphrase string) *API {
+// New returns a new API object, which can be started as a server.
+// clientEntryTTL is the Redis expiration applied to client entries;
+// 0 disables expiration (legacy behavior).
+func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, enableLoadTesting, enableMetrics bool, dmsgAddr, authPassphrase string, clientEntryTTL time.Duration) *API {
 	if log == nil {
 		log = logging.MustGetLogger("dmsg_disc")
 	}
@@ -102,6 +115,7 @@ func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, e
 		DmsgServers:                 []string{},
 		authPassphrase:              authPassphrase,
 		OfficialServers:             make(map[string]bool),
+		clientEntryTTL:              clientEntryTTL,
 	}
 
 	r.Use(middleware.RequestID)
@@ -297,9 +311,14 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 
-		entryTimeout := time.Duration(0) // no timeout
+		// Default client entry TTL comes from the API config. This
+		// prunes stale entries from visors that crashed or lost
+		// network without cleanly updating their delegated_servers.
+		// 0 means no expiration.
+		entryTimeout := a.clientEntryTTL
 
-		// Since v0.5.0 visors do not send ?timeout=true anymore so this is for older visors.
+		// Legacy override: older (pre-v0.5.0) visors sent ?timeout=true
+		// and expected a short TTL. Preserve that behavior for them.
 		if timeout := r.URL.Query().Get("timeout"); timeout == "true" {
 			entryTimeout = store.DefaultTimeout
 		}

--- a/pkg/dmsg/discovery/api/entries_endpoint_test.go
+++ b/pkg/dmsg/discovery/api/entries_endpoint_test.go
@@ -183,7 +183,7 @@ func TestEntriesEndpoint(t *testing.T) {
 				tc.storerPreHook(t, dbMock, &tc.entry)
 			}
 
-			api := New(nil, dbMock, metrics.NewEmpty(), true, false, true, "", "")
+			api := New(nil, dbMock, metrics.NewEmpty(), true, false, true, "", "", 0)
 			req, err := http.NewRequest(tc.method, tc.endpoint, bytes.NewBufferString(tc.httpBody))
 			require.NoError(t, err)
 

--- a/pkg/dmsg/discovery/api/error_handler_test.go
+++ b/pkg/dmsg/discovery/api/error_handler_test.go
@@ -35,7 +35,7 @@ func TestErrorHandler(t *testing.T) {
 		tc := tc
 		t.Run(tc.err.Error(), func(t *testing.T) {
 			w := httptest.NewRecorder()
-			api := New(nil, store.NewMock(), metrics.NewEmpty(), true, false, true, "", "")
+			api := New(nil, store.NewMock(), metrics.NewEmpty(), true, false, true, "", "", 0)
 			api.handleError(w, &http.Request{}, tc.err)
 
 			msg := new(disc.HTTPMessage)

--- a/pkg/dmsg/discovery/api/get_available_servers_test.go
+++ b/pkg/dmsg/discovery/api/get_available_servers_test.go
@@ -117,7 +117,7 @@ func TestGetAvailableServers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			db, entries := tc.databaseAndEntries(t)
 
-			api := New(nil, db, metrics.NewEmpty(), true, false, true, "", "")
+			api := New(nil, db, metrics.NewEmpty(), true, false, true, "", "", 0)
 			req, err := http.NewRequest(tc.method, tc.endpoint, nil)
 			require.NoError(t, err)
 

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -25,6 +25,22 @@ type entryCacheEntry struct {
 
 const entryCacheTTL = 30 * time.Second
 
+// negativeRouteTTL is how long a failed (dst, server) pairing is remembered.
+// Long enough to fast-fail burst retries toward a stale destination, short
+// enough that transient server issues self-recover once the TTL expires.
+const negativeRouteTTL = 30 * time.Second
+
+// negativeRouteMax caps the number of (dst, server) entries we remember
+// to bound memory under pathological workloads. When exceeded, the whole
+// map is wiped and rebuilt — simpler than LRU, fine for a 30s horizon.
+const negativeRouteMax = 4096
+
+// negativeRouteKey is the compound key for the negative route cache.
+type negativeRouteKey struct {
+	dst cipher.PubKey
+	srv cipher.PubKey
+}
+
 // SessionDialCallback is triggered BEFORE a session is dialed to.
 // If a non-nil error is returned, the session dial is instantly terminated.
 type SessionDialCallback func(network, addr string) (err error)
@@ -98,6 +114,13 @@ type Client struct {
 	entryCache   map[cipher.PubKey]entryCacheEntry
 	entryCacheMx sync.RWMutex
 
+	// negativeRoutes remembers (dst, server) pairings that recently
+	// failed to dial. Used by DialStream to skip sessions the caller
+	// would otherwise burn HandshakeTimeout on, which is how stale
+	// discovery entries manifest as 10-second stalls.
+	negativeRoutes   map[negativeRouteKey]time.Time
+	negativeRoutesMx sync.Mutex
+
 	errCh chan error
 	done  chan struct{}
 	once  sync.Once
@@ -116,17 +139,18 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 	conf.Ensure()
 
 	c := &Client{
-		ready:      make(chan struct{}),
-		porter:     netutil.NewPorter(netutil.PorterMinEphemeral),
-		routeCache: make(map[cipher.PubKey]cipher.PubKey),
-		entryCache: make(map[cipher.PubKey]entryCacheEntry),
-		errCh:      make(chan error, 10),
-		done:       make(chan struct{}),
-		conf:       conf,
-		initBO:     time.Second * 5,
-		bo:         time.Second * 5,
-		maxBO:      time.Minute,
-		factor:     netutil.DefaultFactor,
+		ready:          make(chan struct{}),
+		porter:         netutil.NewPorter(netutil.PorterMinEphemeral),
+		routeCache:     make(map[cipher.PubKey]cipher.PubKey),
+		entryCache:     make(map[cipher.PubKey]entryCacheEntry),
+		negativeRoutes: make(map[negativeRouteKey]time.Time),
+		errCh:          make(chan error, 10),
+		done:           make(chan struct{}),
+		conf:           conf,
+		initBO:         time.Second * 5,
+		bo:             time.Second * 5,
+		maxBO:          time.Minute,
+		factor:         netutil.DefaultFactor,
 	}
 
 	// Init common fields.
@@ -532,6 +556,49 @@ func (ce *Client) setCachedEntry(pk cipher.PubKey, entry *disc.Entry) {
 	ce.entryCacheMx.Lock()
 	ce.entryCache[pk] = entryCacheEntry{entry: entry, fetchedAt: time.Now()}
 	ce.entryCacheMx.Unlock()
+}
+
+// isNegativeRoute reports whether a recent dial to dst via srv failed and
+// the failure is still within negativeRouteTTL. Expired entries are pruned
+// lazily by the next call that touches them.
+func (ce *Client) isNegativeRoute(dst, srv cipher.PubKey) bool {
+	key := negativeRouteKey{dst: dst, srv: srv}
+	ce.negativeRoutesMx.Lock()
+	defer ce.negativeRoutesMx.Unlock()
+	at, ok := ce.negativeRoutes[key]
+	if !ok {
+		return false
+	}
+	if time.Since(at) > negativeRouteTTL {
+		delete(ce.negativeRoutes, key)
+		return false
+	}
+	return true
+}
+
+// markNegativeRoute records a failed dial to dst via srv. The entry expires
+// after negativeRouteTTL. If the cache exceeds negativeRouteMax, it is
+// wiped and rebuilt to bound memory usage.
+func (ce *Client) markNegativeRoute(dst, srv cipher.PubKey) {
+	key := negativeRouteKey{dst: dst, srv: srv}
+	ce.negativeRoutesMx.Lock()
+	defer ce.negativeRoutesMx.Unlock()
+	if len(ce.negativeRoutes) >= negativeRouteMax {
+		ce.negativeRoutes = make(map[negativeRouteKey]time.Time)
+	}
+	ce.negativeRoutes[key] = time.Now()
+}
+
+// clearNegativeRoute removes all cached negative entries for dst — called
+// on a successful dial so subsequent calls can retry formerly-bad servers.
+func (ce *Client) clearNegativeRoute(dst cipher.PubKey) {
+	ce.negativeRoutesMx.Lock()
+	defer ce.negativeRoutesMx.Unlock()
+	for k := range ce.negativeRoutes {
+		if k.dst == dst {
+			delete(ce.negativeRoutes, k)
+		}
+	}
 }
 
 // reconnectLoop periodically discovers all available servers and attempts to

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -182,11 +182,16 @@ func (ce *Client) racePhaseDial(ctx context.Context, addr Addr, sessions []Clien
 		return nil, false
 	}
 
-	// Single candidate: no point in the goroutine machinery.
+	// Single candidate: no point in the goroutine machinery. Pass
+	// the parent ctx directly — no derived timeout is needed because
+	// session DialStream already bounds the handshake via its
+	// internal HandshakeTimeout deadline, and deriving a short
+	// WithTimeout + defer cancel here would immediately cancel the
+	// ctx after DialStream returns, which previously raced the
+	// session's ctx-cancel watcher goroutine (manifested as
+	// "stream closed" errors in TestConcurrentStreams).
 	if len(candidates) == 1 {
-		dialCtx, cancel := context.WithTimeout(ctx, phaseDialTimeout)
-		defer cancel()
-		stream, err := candidates[0].DialStream(dialCtx, addr)
+		stream, err := candidates[0].DialStream(ctx, addr)
 		if err != nil {
 			ce.log.WithError(err).WithField("server", candidates[0].RemotePK()).
 				Debug("DialStream failed (single candidate)")

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -89,35 +89,55 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 
 	// Phase 1: Try existing sessions to the target's delegated servers (direct path, cheapest).
 	// Sort by latency so the lowest-latency server is tried first.
+	// Sessions in the negative cache are skipped — they recently failed
+	// to reach this destination and would only burn HandshakeTimeout.
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
-	for i, dSes := range delegatedSessions {
-		if i >= maxPerExistingPhase {
+	tried := 0
+	for _, dSes := range delegatedSessions {
+		if tried >= maxPerExistingPhase {
 			break
 		}
+		if ce.isNegativeRoute(addr.PK, dSes.RemotePK()) {
+			ce.log.WithField("server", dSes.RemotePK()).
+				Debug("DialStream skipping phase 1 session: negative cache hit")
+			continue
+		}
+		tried++
 		stream, err := dSes.DialStream(ctx, addr)
 		if err != nil {
 			ce.log.WithError(err).WithField("server", dSes.RemotePK()).
 				Debug("DialStream failed via existing session, trying next server")
+			ce.markNegativeRoute(addr.PK, dSes.RemotePK())
 			continue
 		}
+		ce.clearNegativeRoute(addr.PK)
 		ce.setCachedRoute(addr.PK, dSes.RemotePK())
 		return stream, nil
 	}
 
 	// Phase 2: Try other existing sessions (mesh path — already connected, no new handshake).
 	// If servers are meshed, our server forwards the request to the target's server.
-	// Sorted by latency.
+	// Sorted by latency. Honor the negative cache here too.
 	meshSessions := ce.sortedMeshSessions(entry.Client.DelegatedServers)
-	for i, ses := range meshSessions {
-		if i >= maxPerExistingPhase {
+	tried = 0
+	for _, ses := range meshSessions {
+		if tried >= maxPerExistingPhase {
 			break
 		}
+		if ce.isNegativeRoute(addr.PK, ses.RemotePK()) {
+			ce.log.WithField("server", ses.RemotePK()).
+				Debug("DialStream skipping phase 2 session: negative cache hit")
+			continue
+		}
+		tried++
 		stream, err := ses.DialStream(ctx, addr)
 		if err != nil {
 			ce.log.WithError(err).WithField("server", ses.RemotePK()).
 				Debug("DialStream failed via mesh, trying next server")
+			ce.markNegativeRoute(addr.PK, ses.RemotePK())
 			continue
 		}
+		ce.clearNegativeRoute(addr.PK)
 		ce.setCachedRoute(addr.PK, ses.RemotePK())
 		return stream, nil
 	}

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -87,58 +87,31 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// so it still uses the tighter cap.
 	const maxPerNewPhase = 2
 
-	// Phase 1: Try existing sessions to the target's delegated servers (direct path, cheapest).
-	// Sort by latency so the lowest-latency server is tried first.
-	// Sessions in the negative cache are skipped — they recently failed
-	// to reach this destination and would only burn HandshakeTimeout.
+	// Phase 1: Race the target's delegated-server sessions in parallel.
+	//
+	// Prior behavior: sequential loop — each attempt could burn up to
+	// HandshakeTimeout (5s) before moving on. With an outer ctx of ~10s
+	// only 1-2 attempts fit, so phase 2/3 saw "ctx deadline exceeded"
+	// as soon as one server was unresponsive.
+	//
+	// New behavior: fire all (non-negative-cached) delegated sessions
+	// simultaneously with a tight 3s per-dial budget. First success
+	// wins, cancel the rest. On a healthy dial the first session
+	// returns in <500ms so the paralellism has negligible cost; on a
+	// stale-entry dial every session times out in ~3s and phase 2
+	// gets a real remaining budget instead of seeing ctx already done.
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
-	tried := 0
-	for _, dSes := range delegatedSessions {
-		if tried >= maxPerExistingPhase {
-			break
-		}
-		if ce.isNegativeRoute(addr.PK, dSes.RemotePK()) {
-			ce.log.WithField("server", dSes.RemotePK()).
-				Debug("DialStream skipping phase 1 session: negative cache hit")
-			continue
-		}
-		tried++
-		stream, err := dSes.DialStream(ctx, addr)
-		if err != nil {
-			ce.log.WithError(err).WithField("server", dSes.RemotePK()).
-				Debug("DialStream failed via existing session, trying next server")
-			ce.markNegativeRoute(addr.PK, dSes.RemotePK())
-			continue
-		}
-		ce.clearNegativeRoute(addr.PK)
-		ce.setCachedRoute(addr.PK, dSes.RemotePK())
+	if stream, ok := ce.racePhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase); ok {
 		return stream, nil
 	}
 
-	// Phase 2: Try other existing sessions (mesh path — already connected, no new handshake).
-	// If servers are meshed, our server forwards the request to the target's server.
-	// Sorted by latency. Honor the negative cache here too.
+	// Phase 2: Race other existing sessions (mesh path — already
+	// connected, no new handshake). If servers are meshed, our server
+	// forwards the request to the target's server. Sorted by latency.
+	// Honors the same 3s per-dial budget as phase 1 and skips
+	// negative-cached pairs.
 	meshSessions := ce.sortedMeshSessions(entry.Client.DelegatedServers)
-	tried = 0
-	for _, ses := range meshSessions {
-		if tried >= maxPerExistingPhase {
-			break
-		}
-		if ce.isNegativeRoute(addr.PK, ses.RemotePK()) {
-			ce.log.WithField("server", ses.RemotePK()).
-				Debug("DialStream skipping phase 2 session: negative cache hit")
-			continue
-		}
-		tried++
-		stream, err := ses.DialStream(ctx, addr)
-		if err != nil {
-			ce.log.WithError(err).WithField("server", ses.RemotePK()).
-				Debug("DialStream failed via mesh, trying next server")
-			ce.markNegativeRoute(addr.PK, ses.RemotePK())
-			continue
-		}
-		ce.clearNegativeRoute(addr.PK)
-		ce.setCachedRoute(addr.PK, ses.RemotePK())
+	if stream, ok := ce.racePhaseDial(ctx, addr, meshSessions, maxPerExistingPhase); ok {
 		return stream, nil
 	}
 
@@ -175,6 +148,130 @@ func (ce *Client) getClientEntryCached(ctx context.Context, clientPK cipher.PubK
 	}
 	ce.setCachedEntry(clientPK, entry)
 	return entry, nil
+}
+
+// phaseDialTimeout is the per-attempt deadline for a single session
+// DialStream inside racePhaseDial. It is intentionally shorter than
+// HandshakeTimeout (5s) so that all delegated sessions can complete
+// within a typical 10s outer route-setup context even when every one
+// of them times out, leaving phase 2 a meaningful remaining budget.
+const phaseDialTimeout = 3 * time.Second
+
+// racePhaseDial races DialStream across all provided sessions in
+// parallel, skipping any (dst, srv) pair that's in the negative route
+// cache. First success wins and cancels the rest; on success we
+// update routeCache and clear negative entries for the destination.
+// On total failure we mark every attempted session as a negative
+// route for dst. Returns (stream, true) on success, (nil, false)
+// otherwise.
+func (ce *Client) racePhaseDial(ctx context.Context, addr Addr, sessions []ClientSession, cap int) (*Stream, bool) {
+	// Filter out negative-cached sessions up-front and cap the pool.
+	candidates := make([]ClientSession, 0, len(sessions))
+	for _, s := range sessions {
+		if len(candidates) >= cap {
+			break
+		}
+		if ce.isNegativeRoute(addr.PK, s.RemotePK()) {
+			ce.log.WithField("server", s.RemotePK()).
+				Debug("DialStream skipping session: negative cache hit")
+			continue
+		}
+		candidates = append(candidates, s)
+	}
+	if len(candidates) == 0 {
+		return nil, false
+	}
+
+	// Single candidate: no point in the goroutine machinery.
+	if len(candidates) == 1 {
+		dialCtx, cancel := context.WithTimeout(ctx, phaseDialTimeout)
+		defer cancel()
+		stream, err := candidates[0].DialStream(dialCtx, addr)
+		if err != nil {
+			ce.log.WithError(err).WithField("server", candidates[0].RemotePK()).
+				Debug("DialStream failed (single candidate)")
+			ce.markNegativeRoute(addr.PK, candidates[0].RemotePK())
+			return nil, false
+		}
+		ce.clearNegativeRoute(addr.PK)
+		ce.setCachedRoute(addr.PK, candidates[0].RemotePK())
+		return stream, true
+	}
+
+	raceCtx, cancelRace := context.WithTimeout(ctx, phaseDialTimeout)
+	defer cancelRace()
+
+	results := make(chan dialResult, len(candidates))
+	for _, s := range candidates {
+		go func(ses ClientSession) {
+			stream, err := ses.DialStream(raceCtx, addr)
+			results <- dialResult{stream: stream, srvPK: ses.RemotePK(), err: err}
+		}(s)
+	}
+
+	// Collect results. First success wins — we cancel the rest and
+	// drain in a background goroutine to close any late streams.
+	var chosen *Stream
+	var chosenSrv cipher.PubKey
+	remaining := len(candidates)
+	for remaining > 0 {
+		select {
+		case <-ctx.Done():
+			// Parent context died — cancel the race and drain in
+			// background, then return failure. Any stream that
+			// comes back will be closed by the drain loop below.
+			cancelRace()
+			go drainAndCloseResults(results, remaining)
+			return nil, false
+		case res := <-results:
+			remaining--
+			if res.err != nil {
+				ce.log.WithError(res.err).WithField("server", res.srvPK).
+					Debug("DialStream failed in race")
+				ce.markNegativeRoute(addr.PK, res.srvPK)
+				continue
+			}
+			if chosen == nil {
+				chosen = res.stream
+				chosenSrv = res.srvPK
+				// Cancel any still-running dials — their streams
+				// will be closed by the drain loop.
+				cancelRace()
+			} else {
+				// Late arrival after we already chose a winner.
+				_ = res.stream.Close() //nolint:errcheck
+			}
+		}
+	}
+
+	if chosen == nil {
+		return nil, false
+	}
+	ce.clearNegativeRoute(addr.PK)
+	ce.setCachedRoute(addr.PK, chosenSrv)
+	return chosen, true
+}
+
+// dialResult carries the outcome of a single DialStream attempt inside
+// racePhaseDial. A named package-level type so drainAndCloseResults can
+// accept the same channel element type.
+type dialResult struct {
+	stream *Stream
+	srvPK  cipher.PubKey
+	err    error
+}
+
+// drainAndCloseResults consumes n more results from ch and closes any
+// successfully-returned streams. Used when racePhaseDial bails out
+// early and needs to avoid leaking streams that the goroutines may
+// still successfully open before they notice the cancellation.
+func drainAndCloseResults(ch <-chan dialResult, n int) {
+	for i := 0; i < n; i++ {
+		res := <-ch
+		if res.stream != nil {
+			_ = res.stream.Close() //nolint:errcheck
+		}
+	}
 }
 
 // sortedDelegatedSessions returns existing sessions to the given delegated servers,

--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -77,15 +77,30 @@ func (cs *ClientSession) DialStream(ctx context.Context, dst Addr) (dStr *Stream
 
 	// If the caller's context is canceled, close the stream to interrupt
 	// any blocked read/write and free the ephemeral port immediately.
+	//
+	// The watcher and DialStream must synchronize on exit: a naive
+	// `defer close(ctxDone)` only makes the watcher runnable; if the
+	// caller cancels ctx before the watcher is actually scheduled
+	// (e.g. callers that use per-attempt WithTimeout + immediate
+	// defer cancel), both select cases race and the watcher may
+	// pick ctx.Done() and close the just-returned stream. The
+	// `<-watcherExited` barrier below guarantees the watcher has
+	// observed ctxDone and fully exited before DialStream returns,
+	// so any post-return ctx cancel finds nothing to cancel.
 	ctxDone := make(chan struct{})
+	watcherExited := make(chan struct{})
 	go func() {
+		defer close(watcherExited)
 		select {
 		case <-ctx.Done():
 			dStr.Close() //nolint:errcheck,gosec
 		case <-ctxDone:
 		}
 	}()
-	defer close(ctxDone)
+	defer func() {
+		close(ctxDone)
+		<-watcherExited
+	}()
 
 	// Check context before starting.
 	if ctx.Err() != nil {

--- a/pkg/router/setupmetrics/stats.go
+++ b/pkg/router/setupmetrics/stats.go
@@ -67,11 +67,53 @@ type LatencyStats struct {
 
 // DestStat is a per-destination counter used to surface "hot" visors
 // (targets of many requests) and "troublesome" visors (high failure
-// rate).
+// rate). Circuit state is the CircuitState (closed/open/half_open)
+// as of the last update.
 type DestStat struct {
-	PK     string `json:"pk"`
-	Total  uint64 `json:"total"`
-	Failed uint64 `json:"failed"`
+	PK      string `json:"pk"`
+	Total   uint64 `json:"total"`
+	Failed  uint64 `json:"failed"`
+	Circuit string `json:"circuit,omitempty"`
+}
+
+// CircuitState is the per-destination breaker state. "closed" = normal,
+// "open" = fast-fail new setups, "half_open" = allow one probe to test
+// recovery.
+type CircuitState string
+
+const (
+	// CircuitClosed means setups to this destination proceed normally.
+	CircuitClosed CircuitState = "closed"
+	// CircuitOpen means setups to this destination are short-circuited.
+	CircuitOpen CircuitState = "open"
+	// CircuitHalfOpen means one probe setup is allowed to test recovery.
+	CircuitHalfOpen CircuitState = "half_open"
+)
+
+// Circuit breaker tuning. Kept as constants for simplicity — can be
+// promoted to CollectorConfig if tests need to vary them.
+const (
+	// circuitFailureThreshold is the number of consecutive failures
+	// to a destination that trips the breaker to OPEN.
+	circuitFailureThreshold = 5
+	// circuitOpenDuration is how long the breaker stays OPEN before
+	// transitioning to HALF_OPEN to allow a probe setup.
+	circuitOpenDuration = 60 * time.Second
+	// circuitFailureWindow bounds how long consecutive failures must
+	// occur within to count toward the threshold. Failures older than
+	// this window are considered stale and the consecutive counter is
+	// reset on the next record.
+	circuitFailureWindow = 5 * time.Minute
+)
+
+// circuitBreaker tracks per-destination consecutive-failure state
+// separately from DestStat counters so the breaker's view isn't
+// perturbed by Reset().
+type circuitBreaker struct {
+	consecutiveFails int
+	firstFailAt      time.Time
+	state            CircuitState
+	openedAt         time.Time
 }
 
 // StatsSnapshot is the public, JSON-friendly view exposed over RPC/CLI.
@@ -142,6 +184,11 @@ type Collector struct {
 	dests        map[string]*DestStat
 	destCapacity int
 
+	// Per-destination circuit breaker state. Shares the dests cap —
+	// when a new destination is added to dests we also add a breaker
+	// entry; Reset() clears both maps atomically.
+	breakers map[string]*circuitBreaker
+
 	// Ring buffer of recent failures. Oldest at index failureRingIdx,
 	// newest at (failureRingIdx-1) mod len.
 	failureRing    []FailureEvent
@@ -185,8 +232,46 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		routeLenHist:  make(map[int]uint64),
 		dests:         make(map[string]*DestStat),
 		destCapacity:  cfg.DestCapacity,
+		breakers:      make(map[string]*circuitBreaker),
 		failureRing:   make([]FailureEvent, cfg.FailureRingSize),
 	}
+}
+
+// AllowDestination reports whether a new route setup to dst should
+// proceed. Returns (true, "") when the breaker is closed or
+// half-open, (false, reason) when it is open. Call this from the
+// request handler BEFORE doing any dial work — rejecting early is
+// the whole point.
+//
+// The half-open transition is driven here: when we find an open
+// breaker that has been open for circuitOpenDuration, we flip it to
+// half-open and allow the current probe through. A subsequent success
+// will close the breaker (via finish); a failure re-opens it and
+// resets the 60-second timer.
+func (c *Collector) AllowDestination(dstPK cipher.PubKey) (bool, string) {
+	pk := dstPK.String()
+	if pk == "" {
+		return true, ""
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	br, ok := c.breakers[pk]
+	if !ok || br.state == CircuitClosed {
+		return true, ""
+	}
+	if br.state == CircuitOpen {
+		if time.Since(br.openedAt) < circuitOpenDuration {
+			return false, "circuit open: " + pk[:16] + " unreachable"
+		}
+		// Time's up — transition to half-open for a probe attempt.
+		br.state = CircuitHalfOpen
+		if d, ok := c.dests[pk]; ok {
+			d.Circuit = string(CircuitHalfOpen)
+		}
+	}
+	// HalfOpen: allow the caller through (they're the probe).
+	return true, ""
 }
 
 // RecordRequest satisfies setupmetrics.Metrics — it bumps the active
@@ -257,6 +342,9 @@ func (c *Collector) finish(ctx context.Context, srcPK, dstPK cipher.PubKey, hopC
 		if destStat != nil {
 			destStat.Total++
 		}
+		// Any success closes an open/half-open breaker and resets
+		// the consecutive failure counter.
+		c.recordCircuitSuccessLocked(dstStr)
 		// Record latency and hop count for successful attempts.
 		c.latencyRing[c.latencyRingIdx] = durMs
 		c.latencyRingIdx = (c.latencyRingIdx + 1) % len(c.latencyRing)
@@ -277,7 +365,14 @@ func (c *Collector) finish(ctx context.Context, srcPK, dstPK cipher.PubKey, hopC
 		destStat.Failed++
 	}
 
+	// Update the circuit breaker for this destination. Only id_reservation
+	// failures (dial-path failures) drive the breaker — other failure
+	// modes like rule_generation reflect local config problems that
+	// won't self-heal by waiting, so they shouldn't trip the breaker.
 	reason := classifyError(ctx, err)
+	if reason == ReasonIDReservation {
+		c.recordCircuitFailureLocked(dstStr)
+	}
 	c.failsByReason[reason]++
 
 	// Truncate error strings so a giant rpc payload doesn't blow up
@@ -317,9 +412,73 @@ func (c *Collector) touchDest(pk string) *DestStat {
 	if len(c.dests) >= c.destCapacity {
 		return nil
 	}
-	d := &DestStat{PK: pk}
+	d := &DestStat{PK: pk, Circuit: string(CircuitClosed)}
 	c.dests[pk] = d
+	c.breakers[pk] = &circuitBreaker{state: CircuitClosed}
 	return d
+}
+
+// recordCircuitFailureLocked updates the breaker state for pk after a
+// failed id_reservation. Must be called with c.mu held.
+func (c *Collector) recordCircuitFailureLocked(pk string) {
+	if pk == "" {
+		return
+	}
+	br, ok := c.breakers[pk]
+	if !ok {
+		// Destination cap was reached and touchDest returned nil;
+		// without a DestStat we also have no breaker to update.
+		return
+	}
+	now := time.Now()
+	// Reset the consecutive counter if the oldest failure is outside
+	// the window — breaker only fires on a burst, not on a slow trickle.
+	if br.consecutiveFails > 0 && now.Sub(br.firstFailAt) > circuitFailureWindow {
+		br.consecutiveFails = 0
+	}
+	if br.consecutiveFails == 0 {
+		br.firstFailAt = now
+	}
+	br.consecutiveFails++
+
+	// Half-open → failure re-opens the breaker and resets the timer.
+	if br.state == CircuitHalfOpen {
+		br.state = CircuitOpen
+		br.openedAt = now
+		if d, ok := c.dests[pk]; ok {
+			d.Circuit = string(CircuitOpen)
+		}
+		return
+	}
+	// Closed → trip to open once the threshold is reached.
+	if br.state == CircuitClosed && br.consecutiveFails >= circuitFailureThreshold {
+		br.state = CircuitOpen
+		br.openedAt = now
+		if d, ok := c.dests[pk]; ok {
+			d.Circuit = string(CircuitOpen)
+		}
+	}
+}
+
+// recordCircuitSuccessLocked transitions the breaker to Closed on any
+// success. Must be called with c.mu held.
+func (c *Collector) recordCircuitSuccessLocked(pk string) {
+	if pk == "" {
+		return
+	}
+	br, ok := c.breakers[pk]
+	if !ok {
+		return
+	}
+	br.consecutiveFails = 0
+	br.firstFailAt = time.Time{}
+	if br.state != CircuitClosed {
+		br.state = CircuitClosed
+		br.openedAt = time.Time{}
+		if d, ok := c.dests[pk]; ok {
+			d.Circuit = string(CircuitClosed)
+		}
+	}
 }
 
 // classifyError maps an error into one of the well-known FailureReason
@@ -438,6 +597,7 @@ func (c *Collector) Reset() {
 	c.latencyRingLen = 0
 	c.routeLenHist = make(map[int]uint64)
 	c.dests = make(map[string]*DestStat)
+	c.breakers = make(map[string]*circuitBreaker)
 	for i := range c.failureRing {
 		c.failureRing[i] = FailureEvent{}
 	}

--- a/pkg/router/setupmetrics/stats_test.go
+++ b/pkg/router/setupmetrics/stats_test.go
@@ -169,6 +169,78 @@ func TestCollector_FailureRingEviction(t *testing.T) {
 	}
 }
 
+func TestCollector_CircuitBreaker(t *testing.T) {
+	c := NewCollector(CollectorConfig{})
+	dst, _ := cipher.GenerateKeyPair()
+
+	// Breaker closed initially — all attempts allowed.
+	if ok, _ := c.AllowDestination(dst); !ok {
+		t.Fatal("initial state should allow the destination")
+	}
+
+	// id_reservation failures drive the breaker. One short of
+	// threshold: still closed.
+	idResErr := errors.New("failed to instantiate route id reserver: dmsg error 202 - cannot connect to delegated server")
+	for i := 0; i < circuitFailureThreshold-1; i++ {
+		e := idResErr
+		c.RecordRouteContext(context.Background(), cipher.PubKey{}, dst, 1)(&e)
+	}
+	if ok, _ := c.AllowDestination(dst); !ok {
+		t.Fatal("under threshold: should still allow")
+	}
+
+	// One more failure trips the breaker.
+	e := idResErr
+	c.RecordRouteContext(context.Background(), cipher.PubKey{}, dst, 1)(&e)
+	if ok, reason := c.AllowDestination(dst); ok {
+		t.Fatalf("threshold reached: should deny, got allowed (%q)", reason)
+	}
+
+	// Snapshot should reflect circuit=open on this destination.
+	snap := c.Snapshot()
+	var found bool
+	for _, d := range snap.TopDestinations {
+		if d.PK == dst.String() {
+			found = true
+			if d.Circuit != string(CircuitOpen) {
+				t.Fatalf("snapshot circuit=%q, want open", d.Circuit)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("destination not in top destinations")
+	}
+
+	// A success while breaker is open should close it.
+	var okErr error
+	c.RecordRouteContext(context.Background(), cipher.PubKey{}, dst, 1)(&okErr)
+	if ok, _ := c.AllowDestination(dst); !ok {
+		t.Fatal("after success: should allow again")
+	}
+}
+
+// TestCollector_CircuitBreakerOnlyIDReservation verifies that other
+// failure reasons do not trip the breaker — only dial-path failures
+// should, because the others are local config / rule problems that
+// waiting does not fix.
+func TestCollector_CircuitBreakerOnlyIDReservation(t *testing.T) {
+	c := NewCollector(CollectorConfig{})
+	dst, _ := cipher.GenerateKeyPair()
+
+	// Throw circuitFailureThreshold+1 non-id-reservation failures at
+	// the destination.
+	genErr := errors.New("generate rules: no key for hop")
+	for i := 0; i < circuitFailureThreshold+1; i++ {
+		e := genErr
+		c.RecordRouteContext(context.Background(), cipher.PubKey{}, dst, 1)(&e)
+	}
+
+	if ok, _ := c.AllowDestination(dst); !ok {
+		t.Fatal("non-id-reservation failures should not trip breaker")
+	}
+}
+
 func TestCollector_Reset(t *testing.T) {
 	c := NewCollector(CollectorConfig{})
 	dst, _ := cipher.GenerateKeyPair()

--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -145,9 +145,17 @@ func (sn *Node) Serve(ctx context.Context, m setupmetrics.Metrics) error {
 	}
 }
 
+// ErrCircuitOpen is returned by CreateRouteGroup when the per-
+// destination circuit breaker has short-circuited a setup attempt. It
+// is distinct from a dial failure so callers and stats can tell the
+// difference between "this destination is known bad, skipping" and
+// "we tried and failed again".
+var ErrCircuitOpen = fmt.Errorf("route setup: destination circuit breaker open")
+
 // CreateRouteGroup creates a route group by communicating with routers used within the bidirectional route.
 // The following steps are taken:
 // * Check the validity of bi route input.
+// * Consult the per-destination circuit breaker; fast-fail if open.
 // * Route IDs are reserved from the routers.
 // * Intermediary rules are broadcasted to the intermediary routers.
 // * Edge rules are broadcasted to the responding router.
@@ -161,10 +169,25 @@ func CreateRouteGroup(ctx context.Context, dialer network.Dialer, biRt routing.B
 	// Victoria Metrics / Empty implementations which don't track per-
 	// request context.
 	hopCount := len(biRt.Forward)
-	if c, ok := metrics.(*setupmetrics.Collector); ok {
-		defer c.RecordRouteContext(ctx, biRt.Desc.SrcPK(), biRt.Desc.DstPK(), hopCount)(&err)
+	collector, haveCollector := metrics.(*setupmetrics.Collector)
+	if haveCollector {
+		defer collector.RecordRouteContext(ctx, biRt.Desc.SrcPK(), biRt.Desc.DstPK(), hopCount)(&err)
 	} else {
 		defer metrics.RecordRoute()(&err)
+	}
+
+	// Consult the per-destination circuit breaker. If the breaker is
+	// open we short-circuit the entire setup path — no dial work, no
+	// session usage, no concurrent-worker slot held for ~10s. This
+	// matters for destinations that have accumulated thousands of
+	// consecutive id_reservation failures (a dead visor still in
+	// discovery) because one breaker decision saves ~10s of work per
+	// attempt.
+	if haveCollector {
+		if ok, reason := collector.AllowDestination(biRt.Desc.DstPK()); !ok {
+			log.Debugf("circuit breaker: %s", reason)
+			return routing.EdgeRules{}, fmt.Errorf("%w: %s", ErrCircuitOpen, reason)
+		}
 	}
 
 	// Ensure bi routes input is valid.


### PR DESCRIPTION
## Summary

Five self-contained fixes for the stale-dmsg-entry failure mode. Each commit is independently reviewable and revertable.

## Context

RSN stats on a production visor (fix/next-6) showed 58.6% route setup success rate with 4652 `id_reservation` failures over 2h08m. Every failure was a 10-second 'dmsg error 202 - cannot connect to delegated server' dialing either the src or dst of a 1-hop route at port 136.

Root cause: **stale dmsg-discovery entries**. dmsg-discovery had been storing client entries with no Redis TTL since v0.5.0 (ref `pkg/dmsg/discovery/api/api.go:300` — `entryTimeout := time.Duration(0) // no timeout`), so visors that crashed, OOMed, or lost network kept advertising delegated servers they were no longer connected to. Any dialer looking them up hit the listed servers, burned `HandshakeTimeout`, and returned err 202.

Verified by `dmsg curl dmsg://<dead_visor>:80/health` timing out identically to port 136 — not a port-specific bug.

## Changes

1. **Restore client entry TTL at dmsg-discovery** — wire the existing (previously dead-coded) `--entry-timeout` flag through to the API handler. Default 60m (12× the 5-min client refresh interval). 0 disables for backward compat.

2. **CLI fetch chain fixes** — rewrite http→dmsg URLs before calling RPC `DmsgHTTP` (the visor's transport can't parse hostnames as PKs), and quiet the ephemeral Direct client logger so `skywire cli mdisc entry` is fast and silent.

3. **DialStream per-(dst, server) negative cache** — 30s TTL, phase 1/2 skip sessions that recently failed for this dst. Burst retries to a dead destination fast-fail instead of re-burning HandshakeTimeout on known-bad pairings.

4. **Parallel phase-1 + phase-2** — race all candidate sessions simultaneously with a tight 3s per-dial budget instead of iterating sequentially with 5s each. Means phase 2/3 actually get a remaining budget when phase 1 has no healthy sessions.

5. **RSN circuit breaker** — per-destination breaker on consecutive `id_reservation` failures (5 in 5min → OPEN, 60s cool-down → HALF_OPEN probe, success → CLOSED). Surfaced in `skywire cli route rsn-stats` top-destinations table. One dead destination can no longer consume 860 concurrent-handler-seconds per hour.

## Test plan

- [x] Unit tests: `pkg/router/setupmetrics` — 2 new tests for the circuit breaker (happy path + "only id_reservation trips it" invariant)
- [x] Unit tests: `pkg/dmsg/discovery/api` — existing tests pass with the new `New()` signature
- [x] Unit tests: `pkg/dmsg/dmsg` — existing dmsg session / dmsghttp / dmsgtest / noise / dmsgctrl all pass
- [x] `go vet ./...` clean
- [ ] CI: linux e2e, darwin, windows
- [ ] Post-deploy observation: RSN `success_rate_pct` should rise from ~58% toward 90%+ after a restart + first 5min of negative-cache warmup
- [ ] `skywire cli mdisc entry <pk>` should return in ~200ms via RPC step 1 with zero dmsg-fetch log lines (was ~2s via ephemeral Direct client with a screenful of debug output)

## Notes

- Commit 1 (TTL restore) is the highest-leverage fix — stale entries get structurally pruned from Redis after 60m instead of accumulating forever.
- Commits 2-5 are resilience fallbacks that handle the gap between "visor becomes unreachable" and "its entry gets TTL-pruned 60 minutes later".
- Server-side liveness reporting from dmsg-servers to dmsg-discovery was considered but deferred — with coordinated deployment auto-updates on develop commits, the TTL restore alone should be sufficient for the service-side. The client-side fallbacks (#2-5) handle crash/netdrop cases where discovery hasn't pruned yet.