### PR TITLE
Service TTL fixes: SD, AR, TPD

### DIFF
--- a/cmd/address-resolver/commands/root.go
+++ b/cmd/address-resolver/commands/root.go
@@ -124,7 +124,11 @@ func init() {
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
 	RootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\n\r")
 	RootCmd.Flags().IntVar(&redisPoolSize, "redis-pool-size", 10, "redis connection pool size\n\r")
-	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 2*time.Minute, "timeout for address entry expiration\n\r")
+	// 5 min is ~3.3× the 90s client refresh interval
+	// (sudphReRegisterInterval in pkg/transport/network/addrresolver/client.go),
+	// giving safe margin for one or two dropped refreshes without
+	// expiring a live binding.
+	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 5*time.Minute, "address binding TTL (0 to disable)\n\r")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "[info|error|warn|debug|trace|panic]\n\r")
 	RootCmd.Flags().StringVar(&tag, "tag", "address_resolver", "logging tag\n\r")
 	RootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis")

--- a/cmd/service-discovery/commands/root.go
+++ b/cmd/service-discovery/commands/root.go
@@ -124,7 +124,10 @@ func init() {
 	RootCmd.Flags().VarP(&sk, "sk", "s", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
-	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 2*time.Minute, "timeout for service entry expiration\n\r")
+	// 5 min is ~3.3× the 90s client refresh interval
+	// (skyenv.ServiceDiscUpdateInterval), giving safe margin for one
+	// or two dropped refreshes without expiring a live entry.
+	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 5*time.Minute, "client service entry TTL (0 to disable)\n\r")
 }
 
 // RootCmd contains the root service-discovery command

--- a/cmd/transport-discovery/commands/root.go
+++ b/cmd/transport-discovery/commands/root.go
@@ -65,7 +65,13 @@ func init() {
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
 	RootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\n\r")
 	RootCmd.Flags().IntVar(&redisPoolSize, "redis-pool-size", 10, "redis connection pool size\n\r")
-	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 2*time.Minute, "timeout for transport entry expiration\n\r")
+	// 5 min is ~3.3× the 90s client refresh interval
+	// (transportReRegisterInterval in pkg/transport/manager.go),
+	// giving safe margin for one or two dropped refreshes without
+	// expiring a live transport. Prior default of 2m allowed only
+	// ~1.33 refreshes per TTL window — one missed refresh and the
+	// transport would briefly drop from discovery.
+	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 5*time.Minute, "transport entry TTL (0 to disable)\n\r")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "[info|error|warn|debug|trace|panic]\n\r")
 	RootCmd.Flags().StringVar(&tag, "tag", "transport_discovery", "logging tag\n\r")
 	RootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis")

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -106,15 +106,16 @@ func (s *redisStore) bind(ctx context.Context, key string, visorData addrresolve
 		return err
 	}
 
-	// Only apply TTL on re-registration (key already exists).
-	// First-time registrations get no TTL for backward compatibility with old visors.
-	exists, _ := s.client.Exists(ctx, key).Result() //nolint:errcheck
-	ttl := time.Duration(0)
-	if exists > 0 {
-		ttl = s.ttl
-	}
-
-	if _, err := s.client.Set(ctx, key, string(raw), ttl).Result(); err != nil {
+	// Always apply TTL so stale bindings expire when clients stop
+	// re-registering. The prior behavior skipped TTL on first-time
+	// bindings "for backward compatibility with old visors", which
+	// let crashed / offline clients leave infinite-lifetime entries
+	// in Redis — same anti-pattern as the dmsg-discovery bug fixed
+	// in #2305. Clients refresh their STCPR/SUDPH binding every
+	// 90s (see sudphReRegisterInterval in addrresolver/client.go),
+	// so a TTL >= ~2× refresh (configured via --entry-timeout,
+	// default 5m) gives safe margin for dropped or slow refreshes.
+	if _, err := s.client.Set(ctx, key, string(raw), s.ttl).Result(); err != nil {
 		return err
 	}
 

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -15,7 +15,7 @@ import (
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 )
 
-// Note: HeartbeatInterval default is skyenv.ServiceDiscUpdateInterval (10 minutes)
+// Note: HeartbeatInterval default is skyenv.ServiceDiscUpdateInterval (90 seconds)
 
 // Factory creates appdisc.Updater instances based on the app name.
 type Factory struct {

--- a/pkg/service-discovery/store/redis_store.go
+++ b/pkg/service-discovery/store/redis_store.go
@@ -200,16 +200,17 @@ func (s *redisStore) UpdateService(ctx context.Context, se *servicedisc.Service)
 		return s.processErr(err, http.StatusInternalServerError)
 	}
 
-	// Only apply TTL on re-registration (key already exists).
-	// First-time registrations get no TTL for backward compatibility with old visors.
-	exists, _ := s.client.Exists(ctx, key).Result() //nolint: errcheck
-	ttl := time.Duration(0)
-	if exists > 0 {
-		ttl = s.ttl
-	}
-
+	// Always apply TTL so stale services expire when clients stop
+	// re-registering. The prior behavior skipped TTL on first-time
+	// registrations "for backward compatibility with old visors",
+	// which let crashed / offline clients accumulate in Redis
+	// forever — same anti-pattern as the dmsg-discovery bug fixed
+	// in #2305. Clients refresh their service entry every 90s (see
+	// skyenv.ServiceDiscUpdateInterval), so a TTL >= ~2× refresh
+	// (configured via --entry-timeout, default 5m) gives safe
+	// margin for dropped or slow refreshes.
 	pipe := s.client.Pipeline()
-	pipe.Set(ctx, key, data, ttl)
+	pipe.Set(ctx, key, data, s.ttl)
 	pipe.SAdd(ctx, setKey, se.Addr.PubKey().String())
 	pipe.SAdd(ctx, serviceTypesSetKey, se.Type)
 


### PR DESCRIPTION
## Summary

Follow-up to #2305. The dmsg-discovery TTL fix in that PR revealed that **service-discovery (SD)** and **address-resolver (AR)** had the exact same anti-pattern: client entries got `ttl := time.Duration(0)` on first-time registration "for backward compatibility with old visors", so crashed/offline clients accumulated in Redis forever.

This PR fixes both and also widens the transport-discovery (TPD) default TTL to match.

## Root cause (SD / AR)

`pkg/service-discovery/store/redis_store.go:203-209` and `pkg/address-resolver/store/redis_store.go:109-115` had:

```go
exists, _ := s.client.Exists(ctx, key).Result()
ttl := time.Duration(0)
if exists > 0 {
    ttl = s.ttl
}
```

First-time write → infinite retention. Re-registration → TTL applied. Same bug as dmsg-discovery before #2305.

Impact: a dead VPN/proxy service advertised in SD would stay listed indefinitely; a stale STCPR/SUDPH binding in AR would keep resolving to an unreachable address for every visor that queried it.

## Changes

### Commit 1 — SD: apply TTL unconditionally
`pkg/service-discovery/store/redis_store.go` — remove the existence check, always pass `s.ttl` to `Set`. CLI `--entry-timeout` default widened from 2m → 5m (~3.3× the 90s `ServiceDiscUpdateInterval` vs prior 1.33×).

### Commit 2 — AR: apply TTL unconditionally
`pkg/address-resolver/store/redis_store.go` — same fix, same widened default. AR does not need a cleanup loop: it lists entries via Redis `SCAN` on key prefixes rather than maintained sets, so expired keys naturally disappear.

### Commit 3 — TPD: widen default TTL from 2m → 5m
`cmd/transport-discovery/commands/root.go` — not a bug fix (TPD was structurally correct, `pkg/transport-discovery/store/redis_store.go:133` has an explicit "always apply TTL" comment). Just tuning to match SD and AR and give a safer margin against the 90s `transportReRegisterInterval`.

## Escape hatch

All three now accept `--entry-timeout=0` to disable expiration, restoring the pre-fix behavior for operators who need it during migration.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean
- [x] `make lint` clean
- [x] `pkg/service-discovery/api` + `pkg/transport-discovery/api` tests pass
- [ ] CI: linux / darwin / windows
- [ ] Post-deploy: verify stale SD service entries age out within 5 min; verify AR bindings age out within 5 min.