### PR TITLE
AR: SUDPH handshake bounds + fix TestMultiServerStreams race

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -511,19 +511,66 @@ func (a *API) writeJSON(w http.ResponseWriter, r *http.Request, code int, object
 	}
 }
 
+// sudphHandshakeTimeout is the per-connection deadline for completing the
+// SUDPH responder handshake. Legitimate clients complete the 3-frame
+// exchange in well under a second; the default handshake.Timeout of 10s
+// is needlessly generous for a public-facing UDP listener and lets
+// scanner / broken-client connections accumulate one goroutine and one
+// KCP session each for the full 10s.
+const sudphHandshakeTimeout = 3 * time.Second
+
+// sudphMaxInFlightHandshakes caps the number of concurrent in-flight
+// SUDPH handshakes. Any new UDP connection arriving while this many
+// handshakes are already in progress is immediately closed rather than
+// queued, providing hard backpressure against scanner floods. In
+// steady state a healthy AR sees ~10 concurrent handshakes, so 256 is
+// ~25× headroom for legitimate bursts while still bounding resource
+// usage.
+const sudphMaxInFlightHandshakes = 256
+
 // ListenUDP listens for UDP connections for SUDPH.
 func (a *API) ListenUDP(listener net.Listener) {
 	a.log.Infof("Listening UDP on %v", listener.Addr())
 
+	// Semaphore bounding in-flight handshake goroutines.
+	sem := make(chan struct{}, sudphMaxInFlightHandshakes)
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			a.log.Fatal(err)
+			// Accept errors on a KCP listener can occur under load
+			// (EMFILE, invalid peer packets). Previously this was a
+			// Fatal that killed the whole AR process; continue the
+			// loop instead so transient errors don't take the
+			// service down.
+			a.log.WithError(err).Warn("SUDPH listener Accept error, continuing")
+			select {
+			case <-a.closeC:
+				return
+			default:
+			}
+			continue
 		}
 
-		a.log.Infof("Accepted new UDP connection from %q", conn.RemoteAddr())
+		// Non-blocking acquire: if the semaphore is full, drop
+		// the connection immediately rather than queueing.
+		select {
+		case sem <- struct{}{}:
+		default:
+			a.log.Warnf("SUDPH handshake queue full (%d in flight), dropping %s",
+				sudphMaxInFlightHandshakes, conn.RemoteAddr())
+			if closeErr := conn.Close(); closeErr != nil {
+				a.log.WithError(closeErr).Debug("Failed to close dropped SUDPH connection")
+			}
+			continue
+		}
 
-		go a.sudphConnHandshake(conn)
+		a.log.Debugf("Accepted new UDP connection from %q", conn.RemoteAddr())
+
+		go func(c net.Conn) {
+			defer func() { <-sem }()
+			a.sudphConnHandshake(c)
+		}(conn)
 	}
 }
 
@@ -532,7 +579,7 @@ func (a *API) sudphConnHandshake(conn net.Conn) {
 
 	hs := handshake.ResponderHandshake(func(_ handshake.Frame2) error { return nil })
 
-	wrapped, err := network.DoHandshake(conn, hs, types.SUDPH, a.log)
+	wrapped, err := network.DoHandshakeWithTimeout(conn, hs, types.SUDPH, sudphHandshakeTimeout, a.log)
 	if err != nil {
 		// Close the connection on handshake failure to prevent KCP session goroutine leak.
 		if closeErr := conn.Close(); closeErr != nil {

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -87,31 +87,32 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 	// so it still uses the tighter cap.
 	const maxPerNewPhase = 2
 
-	// Phase 1: Race the target's delegated-server sessions in parallel.
+	// Phase 1: Iterate the target's delegated-server sessions serially
+	// with a tight per-attempt timeout. Each candidate gets at most
+	// phaseDialTimeout (3s), so a full 16-candidate scan fits in the
+	// ~48s worst case — in practice the negative cache fast-fails
+	// known-bad pairings so the typical traversal is much shorter.
 	//
-	// Prior behavior: sequential loop — each attempt could burn up to
-	// HandshakeTimeout (5s) before moving on. With an outer ctx of ~10s
-	// only 1-2 attempts fit, so phase 2/3 saw "ctx deadline exceeded"
-	// as soon as one server was unresponsive.
-	//
-	// New behavior: fire all (non-negative-cached) delegated sessions
-	// simultaneously with a tight 3s per-dial budget. First success
-	// wins, cancel the rest. On a healthy dial the first session
-	// returns in <500ms so the paralellism has negligible cost; on a
-	// stale-entry dial every session times out in ~3s and phase 2
-	// gets a real remaining budget instead of seeing ctx already done.
+	// Why sequential rather than parallel: a parallel race opens N
+	// yamux streams on the destination's listener simultaneously, then
+	// cancels N-1 losers. The destination's listener accepts the
+	// loser streams into its accept queue before they can be
+	// canceled, leaving orphan streams that subsequent AcceptStream
+	// calls consume — breaking any caller that expects consecutive
+	// dials to produce consecutive, usable streams (the exact failure
+	// mode of TestMultiServerStreams).
 	delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
-	if stream, ok := ce.racePhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase); ok {
+	if stream, ok := ce.sequentialPhaseDial(ctx, addr, delegatedSessions, maxPerExistingPhase); ok {
 		return stream, nil
 	}
 
-	// Phase 2: Race other existing sessions (mesh path — already
+	// Phase 2: Iterate other existing sessions (mesh path — already
 	// connected, no new handshake). If servers are meshed, our server
 	// forwards the request to the target's server. Sorted by latency.
-	// Honors the same 3s per-dial budget as phase 1 and skips
-	// negative-cached pairs.
+	// Honors the same per-attempt deadline and skips negative-cached
+	// pairs.
 	meshSessions := ce.sortedMeshSessions(entry.Client.DelegatedServers)
-	if stream, ok := ce.racePhaseDial(ctx, addr, meshSessions, maxPerExistingPhase); ok {
+	if stream, ok := ce.sequentialPhaseDial(ctx, addr, meshSessions, maxPerExistingPhase); ok {
 		return stream, nil
 	}
 
@@ -151,132 +152,59 @@ func (ce *Client) getClientEntryCached(ctx context.Context, clientPK cipher.PubK
 }
 
 // phaseDialTimeout is the per-attempt deadline for a single session
-// DialStream inside racePhaseDial. It is intentionally shorter than
-// HandshakeTimeout (5s) so that all delegated sessions can complete
-// within a typical 10s outer route-setup context even when every one
-// of them times out, leaving phase 2 a meaningful remaining budget.
+// DialStream inside sequentialPhaseDial. It is intentionally shorter
+// than HandshakeTimeout (5s) so that multiple delegated sessions can
+// be tried serially within a typical 10s outer route-setup context.
+// With the per-attempt deadline at 3s, a full 16-candidate scan fits
+// in the 48s worst case, but in practice the negative cache short-
+// circuits known-bad pairings so traversal is much shorter.
 const phaseDialTimeout = 3 * time.Second
 
-// racePhaseDial races DialStream across all provided sessions in
-// parallel, skipping any (dst, srv) pair that's in the negative route
-// cache. First success wins and cancels the rest; on success we
-// update routeCache and clear negative entries for the destination.
-// On total failure we mark every attempted session as a negative
-// route for dst. Returns (stream, true) on success, (nil, false)
-// otherwise.
-func (ce *Client) racePhaseDial(ctx context.Context, addr Addr, sessions []ClientSession, cap int) (*Stream, bool) {
-	// Filter out negative-cached sessions up-front and cap the pool.
-	candidates := make([]ClientSession, 0, len(sessions))
+// sequentialPhaseDial iterates sessions in order, skipping any
+// (dst, server) pair in the negative route cache. Each attempt uses
+// a per-call context with phaseDialTimeout so a dead session doesn't
+// burn the whole outer context budget. On success it updates the
+// route cache and clears negative entries for dst; on failure it
+// marks the attempted pair as a negative route. Returns
+// (stream, true) on success, (nil, false) if every attempt failed
+// or the pool was empty / fully negative-cached.
+//
+// Sequential rather than parallel because parallel racing opens N
+// yamux streams on the destination simultaneously and leaves N-1
+// orphan streams in the destination's accept queue after cancellation
+// — the destination cannot distinguish "this stream was canceled"
+// from "this stream is for you to accept", and consumes the orphans
+// on subsequent AcceptStream calls.
+func (ce *Client) sequentialPhaseDial(ctx context.Context, addr Addr, sessions []ClientSession, cap int) (*Stream, bool) {
+	tried := 0
 	for _, s := range sessions {
-		if len(candidates) >= cap {
+		if tried >= cap {
 			break
+		}
+		if ctx.Err() != nil {
+			return nil, false
 		}
 		if ce.isNegativeRoute(addr.PK, s.RemotePK()) {
 			ce.log.WithField("server", s.RemotePK()).
 				Debug("DialStream skipping session: negative cache hit")
 			continue
 		}
-		candidates = append(candidates, s)
-	}
-	if len(candidates) == 0 {
-		return nil, false
-	}
+		tried++
 
-	// Single candidate: no point in the goroutine machinery. Pass
-	// the parent ctx directly — no derived timeout is needed because
-	// session DialStream already bounds the handshake via its
-	// internal HandshakeTimeout deadline, and deriving a short
-	// WithTimeout + defer cancel here would immediately cancel the
-	// ctx after DialStream returns, which previously raced the
-	// session's ctx-cancel watcher goroutine (manifested as
-	// "stream closed" errors in TestConcurrentStreams).
-	if len(candidates) == 1 {
-		stream, err := candidates[0].DialStream(ctx, addr)
+		dialCtx, cancel := context.WithTimeout(ctx, phaseDialTimeout)
+		stream, err := s.DialStream(dialCtx, addr)
+		cancel()
 		if err != nil {
-			ce.log.WithError(err).WithField("server", candidates[0].RemotePK()).
-				Debug("DialStream failed (single candidate)")
-			ce.markNegativeRoute(addr.PK, candidates[0].RemotePK())
-			return nil, false
+			ce.log.WithError(err).WithField("server", s.RemotePK()).
+				Debug("DialStream failed, trying next session")
+			ce.markNegativeRoute(addr.PK, s.RemotePK())
+			continue
 		}
 		ce.clearNegativeRoute(addr.PK)
-		ce.setCachedRoute(addr.PK, candidates[0].RemotePK())
+		ce.setCachedRoute(addr.PK, s.RemotePK())
 		return stream, true
 	}
-
-	raceCtx, cancelRace := context.WithTimeout(ctx, phaseDialTimeout)
-	defer cancelRace()
-
-	results := make(chan dialResult, len(candidates))
-	for _, s := range candidates {
-		go func(ses ClientSession) {
-			stream, err := ses.DialStream(raceCtx, addr)
-			results <- dialResult{stream: stream, srvPK: ses.RemotePK(), err: err}
-		}(s)
-	}
-
-	// Collect results. First success wins — we cancel the rest and
-	// drain in a background goroutine to close any late streams.
-	var chosen *Stream
-	var chosenSrv cipher.PubKey
-	remaining := len(candidates)
-	for remaining > 0 {
-		select {
-		case <-ctx.Done():
-			// Parent context died — cancel the race and drain in
-			// background, then return failure. Any stream that
-			// comes back will be closed by the drain loop below.
-			cancelRace()
-			go drainAndCloseResults(results, remaining)
-			return nil, false
-		case res := <-results:
-			remaining--
-			if res.err != nil {
-				ce.log.WithError(res.err).WithField("server", res.srvPK).
-					Debug("DialStream failed in race")
-				ce.markNegativeRoute(addr.PK, res.srvPK)
-				continue
-			}
-			if chosen == nil {
-				chosen = res.stream
-				chosenSrv = res.srvPK
-				// Cancel any still-running dials — their streams
-				// will be closed by the drain loop.
-				cancelRace()
-			} else {
-				// Late arrival after we already chose a winner.
-				_ = res.stream.Close() //nolint:errcheck
-			}
-		}
-	}
-
-	if chosen == nil {
-		return nil, false
-	}
-	ce.clearNegativeRoute(addr.PK)
-	ce.setCachedRoute(addr.PK, chosenSrv)
-	return chosen, true
-}
-
-// dialResult carries the outcome of a single DialStream attempt inside
-// racePhaseDial. A named package-level type so drainAndCloseResults can
-// accept the same channel element type.
-type dialResult struct {
-	stream *Stream
-	srvPK  cipher.PubKey
-	err    error
-}
-
-// drainAndCloseResults consumes n more results from ch and closes any
-// successfully-returned streams. Used when racePhaseDial bails out
-// early and needs to avoid leaking streams that the goroutines may
-// still successfully open before they notice the cancellation.
-func drainAndCloseResults(ch <-chan dialResult, n int) {
-	for i := 0; i < n; i++ {
-		res := <-ch
-		if res.stream != nil {
-			_ = res.stream.Close() //nolint:errcheck
-		}
-	}
+	return nil, false
 }
 
 // sortedDelegatedSessions returns existing sessions to the given delegated servers,

--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -78,28 +79,61 @@ func (cs *ClientSession) DialStream(ctx context.Context, dst Addr) (dStr *Stream
 	// If the caller's context is canceled, close the stream to interrupt
 	// any blocked read/write and free the ephemeral port immediately.
 	//
-	// The watcher and DialStream must synchronize on exit: a naive
-	// `defer close(ctxDone)` only makes the watcher runnable; if the
-	// caller cancels ctx before the watcher is actually scheduled
-	// (e.g. callers that use per-attempt WithTimeout + immediate
-	// defer cancel), both select cases race and the watcher may
-	// pick ctx.Done() and close the just-returned stream. The
-	// `<-watcherExited` barrier below guarantees the watcher has
-	// observed ctxDone and fully exited before DialStream returns,
-	// so any post-return ctx cancel finds nothing to cancel.
+	// Synchronization is non-trivial. A naive watcher goroutine that
+	// just `select`s on ctx.Done() vs a ctxDone signal races with the
+	// post-handshake cleanup: if ctx is canceled *around the same
+	// time* the handshake finishes (e.g. a sibling racePhaseDial
+	// goroutine that canceled the shared raceCtx as soon as its own
+	// winning dial returned), both select cases become ready
+	// concurrently and the runtime picks one randomly. Picking
+	// ctx.Done() in that instant closes the stream that DialStream
+	// is about to return successfully, and the caller sees the Write
+	// fail with "stream closed" or reads EOF.
+	//
+	// The fix is a mutex that serializes the decision. The watcher
+	// grabs `mu` before inspecting `finished`; the main-flow defer
+	// grabs `mu` first, marks `finished=true`, releases. Whichever
+	// wins the mutex decides. If the watcher won and closed the
+	// stream, it also sets `closedByWatcher=true` so the defer can
+	// surface the race as a proper error to the caller rather than
+	// handing them a dead stream.
+	var (
+		mu              sync.Mutex
+		finished        bool
+		closedByWatcher bool
+	)
 	ctxDone := make(chan struct{})
-	watcherExited := make(chan struct{})
 	go func() {
-		defer close(watcherExited)
 		select {
 		case <-ctx.Done():
-			dStr.Close() //nolint:errcheck,gosec
+			mu.Lock()
+			if !finished {
+				closedByWatcher = true
+				dStr.Close() //nolint:errcheck,gosec
+			}
+			mu.Unlock()
 		case <-ctxDone:
 		}
 	}()
 	defer func() {
+		mu.Lock()
+		finished = true
+		wasClosed := closedByWatcher
+		mu.Unlock()
 		close(ctxDone)
-		<-watcherExited
+		// If the watcher fired and closed the stream but the main
+		// flow also finished the handshake with err==nil, the
+		// returned stream is unusable. Report it as a cancellation
+		// and release the now-nil pointer so the outer failure
+		// defer at line 69 becomes a no-op.
+		if wasClosed && err == nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err = ctxErr
+			} else {
+				err = context.Canceled
+			}
+			dStr = nil
+		}
 	}()
 
 	// Check context before starting.

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -178,7 +178,7 @@ func (c *genericClient) acceptTransports(lis net.Listener) {
 // wrapTransport performs handshake over provided raw connection and wraps it in
 // network.Transport type using the data obtained from handshake process
 func (c *genericClient) wrapTransport(rawConn net.Conn, hs handshake.Handshake, initiator bool, onClose func()) (*transport, error) {
-	transport, err := doHandshake(rawConn, hs, c.netType, c.log)
+	transport, err := doHandshake(rawConn, hs, c.netType, handshake.Timeout, c.log)
 	if err != nil {
 		onClose()
 		return nil, err

--- a/pkg/transport/network/connection.go
+++ b/pkg/transport/network/connection.go
@@ -58,15 +58,23 @@ type transport struct {
 }
 
 // DoHandshake performs given handshake over given raw connection and wraps
-// connection in network.Transport
+// connection in network.Transport. Uses the default handshake.Timeout (10s).
 func DoHandshake(rawConn net.Conn, hs handshake.Handshake, netType types.Type, log *logging.Logger) (Transport, error) {
-	return doHandshake(rawConn, hs, netType, log)
+	return DoHandshakeWithTimeout(rawConn, hs, netType, handshake.Timeout, log)
+}
+
+// DoHandshakeWithTimeout is the same as DoHandshake but lets the caller pick
+// a per-call handshake deadline. Useful for public-facing listeners (e.g. the
+// address-resolver's SUDPH accept loop) that need a tighter timeout than the
+// 10-second default to resist scanner / broken-client accumulation.
+func DoHandshakeWithTimeout(rawConn net.Conn, hs handshake.Handshake, netType types.Type, timeout time.Duration, log *logging.Logger) (Transport, error) {
+	return doHandshake(rawConn, hs, netType, timeout, log)
 }
 
 // handshake performs given handshake over given raw connection and wraps
 // connection in network.transport
-func doHandshake(rawConn net.Conn, hs handshake.Handshake, netType types.Type, log *logging.Logger) (*transport, error) {
-	lAddr, rAddr, err := hs(rawConn, time.Now().Add(handshake.Timeout))
+func doHandshake(rawConn net.Conn, hs handshake.Handshake, netType types.Type, timeout time.Duration, log *logging.Logger) (*transport, error) {
+	lAddr, rAddr, err := hs(rawConn, time.Now().Add(timeout))
 	if err != nil {
 		if err := rawConn.Close(); err != nil {
 			log.WithError(err).Warnf("Failed to close connection")

--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -105,7 +105,7 @@ func (c *sudphClient) makeBindHandshake() func(in net.Conn) (net.Conn, error) {
 	emptyAddr := dmsg.Addr{PK: cipher.PubKey{}, Port: 0}
 	hs := handshake.InitiatorHandshake(c.SK(), dmsg.Addr{PK: c.PK(), Port: 0}, emptyAddr)
 	return func(in net.Conn) (net.Conn, error) {
-		return doHandshake(in, hs, types.SUDPH, c.log)
+		return doHandshake(in, hs, types.SUDPH, handshake.Timeout, c.log)
 	}
 }
 


### PR DESCRIPTION
## Summary

Branch now carries two independent fixes — the AR SUDPH follow-up from task #24 and a fix for the TestMultiServerStreams CI failure that's been flaking PRs #2305/#2306/#2307.

## Commit 1 — AR: bound SUDPH handshake queue + tighten timeout + fix Accept Fatal

Follow-up to the pprof observation from #2307. Production AR was showing 180 goroutines and 48% CPU, ~38 of them persistently stuck in `sudphConnHandshake → ResponderHandshake → readFrame0 → kcp.Read`.

- **3s handshake timeout** (vs the 10s default): legitimate SUDPH handshakes complete in well under a second; scanner / broken-client connections no longer burn 10s of goroutine + KCP retransmit time. New `network.DoHandshakeWithTimeout` variant; old `DoHandshake` keeps the 10s default for non-AR callers.
- **256-slot semaphore** on concurrent SUDPH handshakes. New connections that arrive while the semaphore is full are closed immediately. Hard backpressure against scanner floods.
- **Fix `a.log.Fatal` on Accept error**: previously any transient Accept error (EMFILE, malformed UDP, etc.) killed the whole AR process. Changed to Warn + continue, with close-channel check for clean shutdown.

## Commit 2 — dmsg: replace parallel phase-dial with sequential + fix session race

CI on PR #2306 (fix/svc-ttl, run 24290764220) failed on all three platforms with `TestMultiServerStreams` — "stream closed" / EOF. Reproduced locally at ~33% flake rate on `develop`. Two independent bugs:

### 2a. Parallel `racePhaseDial` orphans streams in the accept queue

My earlier "race phase 1 and phase 2 sessions in parallel" commit (9cf4a93ff, part of #2305) opened N yamux streams in parallel per logical dial and cancelled N-1 losers. But opening a yamux stream isn't local: the server forwards a stream-open frame to the destination, whose listener enqueues it **before** the initiator's cancellation reaches it. Subsequent `AcceptStream` calls consume the orphan streams, and the caller gets a stream that was already closed on the initiator side — manifesting as "stream closed" on Write and EOF on Read.

`TestMultiServerStreams` reproduces this precisely: the test's second DialStream → AcceptStream pair picks up an orphaned loser from the first dial's race.

**Fix**: revert to sequential phase dialing. New `sequentialPhaseDial` iterates candidates serially with per-call `phaseDialTimeout` (3s). The negative cache from #2305 still fast-fails known-bad pairings so traversal stays short in practice. Removes `racePhaseDial`, `dialResult`, `drainAndCloseResults`.

### 2b. Session `DialStream` watcher race with post-handshake cancel

The `watcherExited` barrier from ab3ba6bf2 (part of #2305) waited for the watcher goroutine to exit but didn't **influence** which branch the watcher took — `select { case <-ctx.Done(): ... case <-ctxDone: ... }` picks randomly when both are ready. A sibling goroutine (or a caller's `WithTimeout + defer cancel`) cancelling ctx around the same time the handshake finished could let the watcher pick `ctx.Done()` and close the just-returned stream.

**Fix**: replace the barrier with a mutex + `finished` / `closedByWatcher` flags. Watcher grabs the mutex before checking `finished`; defer grabs it first and sets `finished=true`. Whichever wins decides. If the watcher raced in and closed the stream, the defer detects it and converts the "success" return into a proper `ctx.Err()` + nil stream, so the caller never sees a zombie stream.

This is strictly no longer necessary after reverting the parallel dial (which was the only caller that routinely cancelled a derived ctx right after DialStream return), but it's a correctness improvement worth keeping — any future caller using the `WithTimeout + defer cancel` pattern gets a proper error instead of a closed stream.

## Test plan

- [x] `TestMultiServerStreams` stress: 100× → 100 pass (was ~67% pass rate on develop)
- [x] `pkg/dmsg/dmsg` + `pkg/dmsg/dmsgtest` full suites pass cleanly
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [ ] CI: linux / darwin / windows
- [ ] Post-deploy verification (AR fix): production AR goroutine count should stabilize at ~10–15 (was ~35) and CPU should drop from ~48% to a much lower baseline. Compare pprof `:6093` before/after.