### PR TITLE
dmsg: fix ClientSession.serve killing sessions on stream-handshake errors

### DIFF
--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -4,6 +4,7 @@ package dmsg
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -213,6 +214,25 @@ func (cs *ClientSession) LookupIP(dst Addr) (myIP net.IP, err error) {
 }
 
 // serve accepts incoming streams from remote clients.
+//
+// The accept loop is split into two error classes:
+//
+//   - Session-level errors (yamux.ErrSessionShutdown, or any error from
+//     the yamux AcceptStream call itself): the underlying yamux session
+//     is gone, there's nothing to accept anymore. Return the error so
+//     the enclosing dialSession goroutine cleans up via delSession and
+//     the reconnect loop re-dials.
+//
+//   - Stream-level errors (a single incoming stream failed its noise
+//     handshake — bad peer, handshake deadline hit, peer disconnected
+//     mid-handshake, garbled request bytes, etc.): the session itself
+//     is still alive and should continue accepting other streams. Log
+//     at Debug level and loop. Previously any such error terminated
+//     the whole session, causing long-running visors to decay their
+//     dmsg session count as random bad peers triggered session kills
+//     — the root cause of the "zero delegated servers" partial-failure
+//     pattern seen in production (e.g. visors at sequence >1000
+//     accumulating from 6 servers down to 0 over days of uptime).
 func (cs *ClientSession) serve() error {
 	defer func() {
 		if err := cs.Close(); err != nil {
@@ -221,61 +241,72 @@ func (cs *ClientSession) serve() error {
 		}
 	}()
 	for {
-		if _, err := cs.acceptStream(); err != nil {
-			if netErr, ok := err.(net.Error); ok && netErr.Temporary() { //nolint
-				cs.log.
-					WithError(err).
-					Debug("Failed to accept stream.")
-				continue
-			}
-
-			if errors.Is(err, yamux.ErrSessionShutdown) {
-				cs.log.WithError(err).Debug("Stopped accepting streams.")
+		dStr, err := cs.acceptYamuxStream()
+		if err != nil {
+			// yamux-level failure. Shutdown / closed / EOF are
+			// terminal — the underlying session is dead. Everything
+			// else is treated as potentially-transient and retried
+			// with a short backoff, mirroring the server-side loop
+			// in ServerSession.Serve (streamErrorBackoff = 50ms).
+			if errors.Is(err, yamux.ErrSessionShutdown) || errors.Is(err, io.EOF) || cs.sm.yamux.IsClosed() {
+				cs.log.WithError(err).Debug("Session shut down, stopping accept loop.")
 				return err
 			}
-			cs.log.WithError(err).Warn("Stopped accepting streams.")
-			return err
+			cs.log.WithError(err).Warn("Failed to accept yamux stream, continuing...")
+			time.Sleep(streamErrorBackoff)
+			continue
+		}
+
+		if err := cs.handshakeResponder(dStr); err != nil {
+			// Stream-level handshake failure: close the one bad
+			// stream and keep the session alive. Previously
+			// returned from serve, killing the whole session —
+			// the root cause of the dmsg session rot seen in
+			// long-running visors (sessions decayed from 6 to 0
+			// as random bad peers triggered session kills).
+			cs.log.WithError(err).Debug("Stream handshake failed, continuing.")
+			if closeErr := dStr.Close(); closeErr != nil {
+				cs.log.WithError(closeErr).
+					Debug("On handshakeResponder failure, close stream resulted in error.")
+			}
+			continue
 		}
 	}
 }
 
-func (cs *ClientSession) acceptStream() (dStr *Stream, err error) {
-	if dStr, err = newRespondingStream(cs); err != nil {
-		return nil, err
-	}
+// acceptYamuxStream performs only the yamux-level accept. Errors from
+// this function indicate the session itself is dead (or about to be).
+func (cs *ClientSession) acceptYamuxStream() (*Stream, error) {
+	return newRespondingStream(cs)
+}
 
-	// Close stream on failure.
-	defer func() {
-		if err != nil {
-			if scErr := dStr.Close(); scErr != nil {
-				cs.log.WithError(scErr).
-					Debug("On (*ClientSession).acceptStream() failure, close stream resulted in error.")
-			}
-		}
-	}()
-
+// handshakeResponder performs the noise handshake on an already-
+// accepted yamux stream. Errors from this function are stream-level
+// and should NOT terminate the enclosing session; the caller is
+// responsible for closing dStr on failure.
+func (cs *ClientSession) handshakeResponder(dStr *Stream) error {
 	// Prepare deadline.
-	if err = dStr.SetDeadline(time.Now().Add(HandshakeTimeout)); err != nil {
-		return nil, err
+	if err := dStr.SetDeadline(time.Now().Add(HandshakeTimeout)); err != nil {
+		return err
 	}
 
 	// Do stream handshake.
 	req, err := dStr.readRequest()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err = dStr.writeResponse(req.raw.Hash()); err != nil {
-		return nil, err
+	if err := dStr.writeResponse(req.raw.Hash()); err != nil {
+		return err
 	}
 
 	// Set idle timeout — refreshed on each successful read.
-	if err = dStr.SetReadDeadline(time.Now().Add(StreamIdleTimeout)); err != nil {
-		return nil, err
+	if err := dStr.SetReadDeadline(time.Now().Add(StreamIdleTimeout)); err != nil {
+		return err
 	}
 	// Clear the write deadline so writes are not affected.
-	if err = dStr.SetWriteDeadline(time.Time{}); err != nil {
-		return nil, err
+	if err := dStr.SetWriteDeadline(time.Time{}); err != nil {
+		return err
 	}
 
-	return dStr, err
+	return nil
 }


### PR DESCRIPTION
## Summary

Root cause of the dmsg session rot observed in production where long-running visors decayed from 6 connected servers down to 0 over days of uptime. The visor process kept running and kept POSTing its discovery entry, but its dmsg client had zero live sessions and was therefore unreachable for inbound route setups — even though its stcpr/sudph TCP/KCP listeners were still working fine and peers were happily maintaining direct transports to it. This produced the "zero delegated_servers zombie visor" entries with sequence numbers > 1000.

## The bug

`ClientSession.serve` called the old `acceptStream` which bundled **two** phases:

1. `yamux.AcceptStream` — session-level
2. the per-stream noise handshake — stream-level

Any error from either phase propagated up to `serve`. The error classification was:

```go
if netErr, ok := err.(net.Error); ok && netErr.Temporary() { continue }
if errors.Is(err, yamux.ErrSessionShutdown) { return err }
cs.log.WithError(err).Warn("Stopped accepting streams.")
return err   // ← ANY OTHER ERROR KILLED THE ENTIRE SESSION
```

Phase-2 errors (noise handshake: `io.EOF` from a disconnecting peer, `context.DeadlineExceeded` from a slow peer, malformed request bytes from a garbled peer, etc.) are **neither** `net.Error Temporary()` **nor** `yamux.ErrSessionShutdown`. They fell through to the default branch and **killed the entire session** to that dmsg server over a single misbehaving peer stream.

Every bad stream a visor received tore down its whole session to the dmsg server that forwarded it. The session would then be re-dialed by the reconnect loop, only to be killed again by the next bad stream. Over days of runtime the session-kill rate exceeds the re-dial rate and the session count decays monotonically toward zero.

## Evidence

Cross-referencing production dmsg-discovery entries against local RSN breaker state:

| visor | sequence | # servers | RSN breaker |
|---|---:|---:|---|
| 027087fe… | **38** | **6** (all) | closed, ~40% fail |
| 03dc5fa2… | 164 | 2 | OPEN |
| 03dc3488… | 807 | 3 | OPEN |
| 02bdefc2… | **1063** | **0** | OPEN |
| 02cd5a51… | 865 | 3 | closed, ~48% fail |
| 03a36de4… | 1426 | 2 | closed, ~40% fail |
| 0238a70c… | **3501** | **0** | OPEN |

Clear correlation: **longer runtime → fewer sessions → more broken**. Visors with seq >1000 have literally zero delegated servers in their discovery entries (their `updateClientEntry` calls run with an empty `srvPKs` list because the sessions map is empty).

Also confirmed by direct probe: STCPR transports to these "broken" visors **do** establish successfully (address resolver returns their bindings, TCP connects, noise handshake completes) — so TCP/KCP listeners are fine. Only their dmsg stack is decayed. `dmsg curl` and `visor ping` both fail regardless of port, because the victim's dmsg client has no live sessions to accept inbound streams from.

## The fix

Split `acceptStream` into two explicit phases:

- **`acceptYamuxStream`**: only the `yamux.AcceptStream` call. Errors here are session-level. On `io.EOF` / `ErrSessionShutdown` / `IsClosed()` we return from serve (session is really dead); on anything else we log a warning, sleep `streamErrorBackoff` (50ms), and continue — mirroring the existing `ServerSession.Serve` pattern.

- **`handshakeResponder`**: only the noise-handshake-on-an-already-accepted-stream code. Errors here are stream-level: the one bad stream is closed, the error is logged at Debug, and `serve` continues accepting the next stream. The session stays alive.

This matches the existing server-side accept loop in `server_session.go` which already correctly distinguishes yamux-level errors from per-stream errors and retries non-fatal cases with `streamErrorBackoff`.

## Test plan

- [x] `pkg/dmsg/dmsg` + `pkg/dmsg/dmsgtest` full suites pass
- [x] `TestMultiServerStreams` 100× stress: 100 pass
- [x] `TestConcurrentStreams` 50× stress: 50 pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [ ] CI: linux / darwin / windows
- [ ] **Post-deploy verification**: watch `skywire cli mdisc entry <pk>` for visors with high sequence numbers. Visors that were stuck at 0-2 servers should recover back toward their full server set within 15-60 seconds of their reconnect loop firing. RSN breakers that were tripped open on those visors should naturally close as id_reservation dials start succeeding.

## Why this didn't show in tests before

All existing dmsgtest integration tests use well-behaved clients — no one sends garbage or disconnects mid-handshake, so `acceptStream` never hit the phase-2 error paths and the session-kill never triggered. The bug only surfaced under real production traffic with occasional misbehaving peers.