### PR TITLE
dht: spec audit, comparison doc, peers/reconcile/source CLI

### DIFF
--- a/CXO_VS_DHT.md
+++ b/CXO_VS_DHT.md
@@ -1,0 +1,126 @@
+# CXO_VS_DHT.md
+
+A retrospective on Skywire's choice between two decentralized state primitives that are both already implemented in this repo: the Kademlia DHT (`pkg/dht/`) and CXO TreeStore feeds (`pkg/cxo/`). Could the work the DHT does today have been done with CXO? Mostly yes. Should it have been? Probably yes. Does that mean we should rip out the DHT? No — it works, it's spec'd, and migration cost dwarfs the win. But the framing of "DHT is the future" needs adjustment, and *new* decentralized state should default to CXO.
+
+This document is descriptive, not normative. The DHT has its own spec at [skywire-specs/specifications/26-DHT.md](./skywire-specs/specifications/26-DHT.md) and a comparison against other Kademlia implementations at [SKYWIRE_DHT.md](./SKYWIRE_DHT.md). Read this one for the "could we have done this with the other primitive?" question.
+
+## What each primitive provides today
+
+### DHT (`pkg/dht/`)
+
+- BEP44-style mutable signed records keyed by `SHA256(pubkey || salt)`
+- Kademlia routing table with K=20, alpha=3, 256-bit ID space
+- Iterative `find_node` / `get_value` lookups
+- "Full node" mode that disables XOR-distance gating so a node stores everything received
+- Active full-node reconciliation (paginated pull + batched push, every hour)
+- Hybrid clients that read from DHT first and fall back to HTTP discovery
+- Per-salt namespaces: `dmsg`, `tp`, `tp:1`/`tp:2`/… (chunked), `svc`, `addr`, `fullnode`, `dmsg-server`
+
+Wire transport: DMSG streams on port 100 (`skyenv.DmsgDHTPort`).
+
+### CXO TreeStore (`pkg/cxo/treestore/`)
+
+- Content-addressable Merkle DAG of objects (`TreeNode` → `TreeEntry` → `Sub` or inline `Leaf`)
+- Per-publisher feeds keyed by the publisher's PK (no separate feed keypair)
+- Hierarchical path semantics: `tiers/dmsg/2026-04-27`, `visor/03ab…/transports/<id>`
+- Append-only history with full audit trail; subscribers reuse unchanged-hash branches and fetch only the diff
+- Subscribers connect by feed PK and walk the tree via the `Subscriber` API
+- Already used in production for visor self-tracking telemetry aggregated by TPD (`pkg/transport-discovery/cxoaggregator/`)
+
+Wire transport: also CXO over DMSG.
+
+## The discovery use case mapped to both
+
+The four discovery services the DHT is replacing — `dmsg-discovery`, `transport-discovery`, `service-discovery`, `address-resolver` — all want the same thing: "let visors publish their current state under their PK; let any other visor read it." Both DHT and CXO TreeStore can do this:
+
+| Need | DHT today | CXO TreeStore equivalent |
+|---|---|---|
+| One value per (visor, kind) | Salt-namespaced PK target: `SHA256(pk \|\| "dmsg")`, `SHA256(pk \|\| "tp")`, … | Per-publisher feed root with typed entries at paths like `dmsg`, `transports/<id>`, `services/<type>` |
+| Signed by publisher | BEP44 `K`+`Sig`+`Seq` over a length-prefixed payload | CXO feeds are signed natively at the feed-Root level |
+| Monotonic updates | `seq > stored.seq` rejection | Feed appends only; head moves forward |
+| Network-wide replication | Full-node reconcile pulls everything across known full nodes | Subscribe to every publisher → same effective topology |
+| Bandwidth-efficient transport | DMSG streams, 4 MiB cap per RPC | DMSG streams; only the changed Merkle subtree branches transfer |
+| HTTP fallback | Hybrid clients (`HybridDiscClient`, `HybridTPDClient`) | Could trivially layer the same |
+| Per-publisher cardinality limits | Public-tier rate limit (50 items per PK) and `MaxValueSize` 64 KiB cap | Per-feed inherent (one feed per publisher); content-addressed dedup means unchanged objects don't cost more bytes |
+
+The mapping is one-to-one for everything except discovery primitives.
+
+## Where the DHT genuinely differs
+
+**Lookup-by-key without prior subscription.** Iteratively walking K-buckets to find an arbitrary PK's data is the primitive that distinguishes a DHT from a federated database. With CXO you have to subscribe to a publisher first, which means you need a way to *find* publishers — a directory or a flood-discovery layer.
+
+But this primitive isn't actually load-bearing in production Skywire. Every visor either:
+
+1. Runs a full node (or talks to a hypervisor that runs one), so the lookup hits the local store immediately and never iterates, or
+2. Falls through to HTTP discovery, which is the centralized service we're supposedly migrating away from.
+
+The K-bucket routing table maintenance and iterative lookup machinery are **overhead we rarely use**. The full-node-reconcile loop we added in this branch made the DHT's actual replication topology identical to "every full node subscribes to every publisher" — which is exactly the CXO model with extra steps. We pay the cost of Kademlia routing without paying off the value of Kademlia routing.
+
+**Claim:** if the network ever grows to a state where most visors are *not* full nodes and need to look up arbitrary peers' data they don't pre-subscribe to, the DHT would start earning its keep. We are not in that state today and the bandwidth cost of full-node mode at current scale doesn't motivate moving toward it.
+
+## Where CXO is arguably the better fit
+
+- **History is native.** "What did this visor's transport list look like 3 days ago?" is a feed-walk in CXO. In the DHT it's gone — the previous value was superseded by the latest seq and there's no mechanism to recover it. Several future use cases (route quality history, peer reputation, bandwidth-rewards audit) want this.
+
+- **Deduplication of unchanged records.** CXO content-addresses every object, so an unchanged transport list is the same Merkle hash. The DHT republishes the entire payload every cycle even when nothing changed, then full-node reconcile re-pushes it across the network. Hub edges with hundreds of transports do this every 60 seconds.
+
+- **Already-built infrastructure.** `pkg/cxo/`, the TreeStore aggregator (`pkg/transport-discovery/cxoaggregator/`), the user-feeds wiring, CXO-over-DMSG transport, the per-visor self-tracking telemetry pattern — all exist. The DHT we built from scratch.
+
+- **Conceptual fit with the rest of skywire.** Visors already publish telemetry to CXO feeds. Adding `dmsg`/`tp`/`svc` to that pile is consistent. The DHT introduces a parallel mechanism with its own semantics, its own peer set, its own port, its own storage backend, its own metric counters.
+
+- **No data-format mess.** The DHT's `tp` salt has four shapes coexisting on the wire (bare `[]Entry`, signed `[]SignedEntry`, compact-array `[{r,t,l}]`, compact-envelope `{s, ts}`) because publishers evolved independently. CXO's schema is part of the registry; format evolution happens through schema versions, not silent shape coexistence.
+
+- **Hub-edge size cap.** The DHT has a single 64 KiB `MaxValueSize` per item; we had to invent salt chunking (`tp:1`, `tp:2`, …) to publish hub edges with 200+ transports. CXO's Merkle DAG has no equivalent cap — each tree level is its own object, so a publisher with 1000 transports just publishes 1000 leaf entries naturally.
+
+## Where the DHT is the better fit
+
+- **Cross-publisher lookup with no prior knowledge.** A new visor joining the network can iteratively find any other visor's data without having to be told who's out there. The CXO equivalent needs a directory feed that everyone subscribes to.
+
+- **BEP44 is well-specified externally.** Anyone implementing a Skywire client in another language can follow the BitTorrent spec. CXO's wire protocol is more of an internal Skycoin primitive.
+
+- **Sunk cost.** We have the spec, the implementation, the operator tools (`dht status`, `dht peers`, `dht reconcile`, `dht list`), and a substantial amount of in-tree code that's now load-bearing. Reverting all of that for a marginal architectural improvement doesn't pay off.
+
+- **Bootstrapping mental model.** "I run a full node and it auto-pulls everything" is a simpler mental model for new operators than "I subscribe to each of these feeds, here's how to manage the subscription set."
+
+## What we actually ended up building
+
+In the course of the DHT's evolution on this PR branch and the prior one, we kept adding mechanisms that bring it closer to CXO's model, not further from it:
+
+- **Full-node reconciliation** (pull + push back, hourly). This is "subscribe to every other full node and replicate."
+- **Advertised full-node discovery** via signed `FullNodeAdvert` in the `fullnode` salt. This is "publish a feed of who's a publisher."
+- **Hub-edge chunking** across `tp:1`, `tp:2`, … This is a flat-namespace workaround for not having Merkle DAG natively.
+- **Multi-shape tolerance** in `decodeTpItem` and `LookupAll` because publishers evolved independently. This is "we needed a schema registry."
+- **DHT-to-HTTP mirror** (`pkg/dht/mirror_to_disc.go`) bridging DHT writes back to centralized services. This is acknowledging that BEP44 mutable items aren't enough for discovery's HTTP-API needs.
+
+Every one of these is a feature CXO has by default.
+
+## Forward path
+
+We're not ripping out the DHT. The pragmatic split:
+
+1. **Existing DHT salts stay where they are.** `dmsg`, `tp`, `svc`, `addr`, `fullnode`, `dmsg-server`. They work, they're spec'd, and migrating them now is churn with little payoff.
+
+2. **New decentralized state goes to CXO.** Anything we'd add tomorrow:
+   - Route quality history (latency / loss / throughput time-series)
+   - Peer reputation and trust signals
+   - Bandwidth-rewards rolldown audit trail
+   - Per-visor configuration overrides distributed across operators
+   - Dynamic policy / blocklist / allowlist updates
+
+   For all of these, CXO's append-only-with-history model is a better fit than a flat mutable-state DHT salt.
+
+3. **The framing in `26-DHT.md` and `SKYWIRE_DHT.md` softens.** Today both documents say "the DHT will eventually replace the centralized discovery services." That's narrowly true and a useful intermediate state. But the broader narrative of "the DHT is Skywire's decentralized-state primitive" should be retired. CXO is. The DHT is one specific subsystem that happens to do discovery.
+
+4. **The DHT's full-node mode and reconcile loop become explicit, bounded, and *small*.** Once we accept that the DHT doesn't need to be the foundation for everything decentralized, we don't need to keep extending it past its sweet spot. Anything that wants append-only history, complex nested state, or schema-evolution semantics gets pushed to CXO instead of getting bolted onto the DHT as another salt with its own format conventions.
+
+## TL;DR
+
+The DHT is a working solution to a narrower problem than its current spec framing implies. CXO TreeStore is the broader decentralized-state primitive that's already in the tree, already used for telemetry aggregation, and already has every property the DHT had to grow into. New work should default to CXO; the DHT keeps doing discovery because it already does discovery, but it shouldn't be the answer to "where does this new piece of distributed state live?"
+
+## See also
+
+- [skywire-specs/specifications/26-DHT.md](./skywire-specs/specifications/26-DHT.md) — DHT normative spec
+- [SKYWIRE_DHT.md](./SKYWIRE_DHT.md) — DHT vs other Kademlia implementations
+- `pkg/cxo/treestore/` — TreeStore implementation
+- `pkg/transport-discovery/cxoaggregator/` — production example of CXO subscription + aggregation pattern
+- `pkg/visor/cxo_user_feeds.go` — per-visor CXO feed registry on every visor

--- a/SKYWIRE_DHT.md
+++ b/SKYWIRE_DHT.md
@@ -2,7 +2,7 @@
 
 A comparison of Skywire's DHT (`pkg/dht/`) with prior-art Kademlia and DHT-adjacent designs, plus a discussion of where Skywire diverges, why, and what tradeoffs result.
 
-The companion document [26-DHT.md](./26-DHT.md) is the normative specification. This document is descriptive: it explains design choices in context.
+The companion document [skywire-specs/specifications/26-DHT.md](./skywire-specs/specifications/26-DHT.md) is the normative specification — it defines the design. This document is descriptive: it explains design choices in context against other DHTs.
 
 ## Capsule summary
 
@@ -14,7 +14,7 @@ The companion document [26-DHT.md](./26-DHT.md) is the normative specification. 
 | Identity | Visor's secp256k1 pubkey → `SHA256(pubkey)` for the 256-bit node ID |
 | Transport | DMSG streams (port 100), TCP-framed; falls back to skywire transports via `extraTransports` |
 | Wire encoding | JSON (length-prefixed, 5-byte header) |
-| Item value cap | 64 KiB |
+| Item value cap | 64 KiB; hub-edge `tp` lists chunked across `tp:0`, `tp:1`, … past the cap |
 | RPC max message | 4 MiB |
 | Storage tiers | Whitelisted (no eviction, no TTL), Trusted (same), Public (LRU + 2 h TTL + 50/PK rate limit) |
 | Full-node mode | Yes — opt-in storage of every item regardless of XOR distance |
@@ -196,16 +196,16 @@ This is an honest list, not a roadmap.
 
 1. **Full-node-to-full-node reconciliation is hourly and unidirectional per pass**. After the user-side puts an item that lands on full node A, full node B sees it the next hour at the earliest. Should be sub-minute for "live" data.
 2. **The receiver-side `PutMirror` admission is unconditional**. Pushed to a non-full-node, the receiver overflows its store. Fixed today by gating senders to bootstrap+advertised peers; if the gate ever leaks, no second line of defence.
-3. **CLI exposes the store but not the routing table**. There's no `skywire cli visor dht peers` to dump the K-buckets — debugging routing problems requires log-grepping.
+3. **CLI exposes routing-table contents** via `skywire cli visor dht peers` (every K-bucket peer with bucket index and last-seen) and **manual reconcile** via `skywire cli visor dht reconcile <full-node-pk>` for forcing a pull+push pass against a specific peer. Both are gated to trusted full nodes via `IsTrustedFullNode` (`BootstrapPKs ∪ FindAdvertisedFullNodes`).
 4. **The hybrid clients log "DHT miss → HTTP" at debug**. Operators don't have a hit-rate metric to know if the DHT is paying for itself.
 5. **No DHT-side metrics export** at all. Should plug into the visor's existing Prometheus surface.
-6. **`MaxValueSize = 64 KiB` is a single global cap**. A future need for larger payloads (e.g., transport history) requires either chunking or a new design.
-7. **The `dht.svc` salt has had multiple data-format mistakes** (single object vs. list of services). The autoconnect path handles both for compatibility, but every other reader needs to too.
+6. **`MaxValueSize = 64 KiB` is a single global cap, with publisher-side chunking only for the `tp` salt** (`tp:0`, `tp:1`, …, written by `TPDAdapter`). Other salts that grow past the cap (e.g., the `svc` salt's per-visor service lists, future transport history) need similar chunking added on their publishers.
+7. **The `dht.svc` salt has had multiple data-format mistakes** (single object vs. list of services). The autoconnect path handles both for compatibility, but every other reader needs to too. Similarly the `tp` salt now has four shapes coexisting on the wire — bare `[]Entry`, signed `[]SignedEntry`, compact-array `[{r,t,l}]`, compact-envelope `{s, ts}`. `route calc --source dht` accepts all four; reconciling the two compact shapes (only the envelope encodes source PK explicitly) is a publisher-side migration that's not yet complete.
 
 ## See also
 
-- [26-DHT.md](./26-DHT.md) — normative specification
-- [21-Service_Discovery.md](./21-Service_Discovery.md), [04-Transport_Discovery.md](./04-Transport_Discovery.md), [05-Messaging_System.md](./05-Messaging_System.md), [20-Address_Resolver.md](./20-Address_Resolver.md) — the centralized services the DHT is replacing
+- [skywire-specs/specifications/26-DHT.md](./skywire-specs/specifications/26-DHT.md) — normative specification
+- [skywire-specs/specifications/21-Service_Discovery.md](./skywire-specs/specifications/21-Service_Discovery.md), [04-Transport_Discovery.md](./skywire-specs/specifications/04-Transport_Discovery.md), [05-Messaging_System.md](./skywire-specs/specifications/05-Messaging_System.md), [20-Address_Resolver.md](./skywire-specs/specifications/20-Address_Resolver.md) — the centralized services the DHT is replacing
 - BEP44 — http://www.bittorrent.org/beps/bep_0044.html
 - Kademlia paper — https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 - discv5 spec — https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -304,130 +304,31 @@ func fetchAllTransportsFromDHT(rpcClient visor.API) ([]*transport.Entry, error) 
 	}
 
 	var entries []*transport.Entry
-	bare, signed, compact, unresolved := 0, 0, 0, 0
+	resolved, unresolved := 0, 0
 
 	for _, row := range rows {
-		// Try bare-entry format first.
-		var bareBatch []*transport.Entry
-		if json.Unmarshal(row.Value, &bareBatch) == nil && len(bareBatch) > 0 {
-			anyResolved := false
-			for _, e := range bareBatch {
-				if e == nil {
-					continue
-				}
-				if !e.Edges[0].Null() && !e.Edges[1].Null() {
-					entries = append(entries, e)
-					anyResolved = true
-					continue
-				}
-			}
-			if anyResolved {
-				bare++
-				continue
-			}
-		}
-
-		// Try SignedEntry format.
-		var signedBatch []*transport.SignedEntry
-		if json.Unmarshal(row.Value, &signedBatch) == nil && len(signedBatch) > 0 {
-			anyResolved := false
-			for _, se := range signedBatch {
-				if se == nil || se.Entry == nil {
-					continue
-				}
-				if !se.Entry.Edges[0].Null() && !se.Entry.Edges[1].Null() {
-					entries = append(entries, se.Entry)
-					anyResolved = true
-				}
-			}
-			if anyResolved {
-				signed++
-				continue
-			}
-		}
-
-		// Try compact-envelope format: {s: source_pk, ts: [{r,t,l}]}.
-		// This is the format publishers should adopt — explicit source
-		// PK in the value means consumers don't need cross-reference.
-		var envelope compactEnvelope
-		if json.Unmarshal(row.Value, &envelope) == nil && envelope.Source != "" {
-			var srcPK cipher.PubKey
-			if err := srcPK.Set(envelope.Source); err == nil {
-				for _, c := range envelope.Transports {
-					e := compactToEntry(srcPK, c)
-					if e != nil {
-						entries = append(entries, e)
-					}
-				}
-				compact++
-				continue
-			}
-		}
-
-		// Try bare-array compact format: [{r, t, l}]. Source PK is
-		// recovered via the dmsg-salt index when available.
-		var compactBatch []compactTpEntry
-		if json.Unmarshal(row.Value, &compactBatch) != nil {
-			continue
-		}
-		srcPK, ok := pkByTpTarget[row.Target]
-		if !ok {
+		// Compact-array shape needs a source PK; try the dmsg-salt
+		// index. Bare/signed/compact-envelope shapes carry the source
+		// internally, so we don't need a srcPK for them — but pass it
+		// anyway so DecodeTpItem can fall back if needed.
+		srcPK := pkByTpTarget[row.Target]
+		decoded, err := dht.DecodeTpItem(row.Value, srcPK)
+		if err != nil {
 			unresolved++
 			continue
 		}
-		for _, c := range compactBatch {
-			e := compactToEntry(srcPK, c)
-			if e != nil {
-				entries = append(entries, e)
-			}
+		if len(decoded) == 0 {
+			continue
 		}
-		compact++
+		entries = append(entries, decoded...)
+		resolved++
 	}
 
 	if len(entries) == 0 {
-		return nil, fmt.Errorf("DHT tp salt empty or unparseable (rows=%d, bare=%d, signed=%d, compact=%d, unresolved=%d)",
-			len(rows), bare, signed, compact, unresolved)
+		return nil, fmt.Errorf("DHT tp salt empty or unparseable (rows=%d, resolved=%d, unresolved=%d)",
+			len(rows), resolved, unresolved)
 	}
 	return entries, nil
-}
-
-// compactTpEntry is the single-letter shape some publishers emit
-// under the tp salt. The struct is local to this CLI helper since
-// it's not used elsewhere.
-type compactTpEntry struct {
-	Remote  string  `json:"r"`
-	Type    string  `json:"t"`
-	Latency float64 `json:"l,omitempty"`
-}
-
-// compactEnvelope is the recommended publish format for compact
-// transport listings: explicit source PK plus a list of compact
-// per-transport rows. Solves the recoverability problem of bare
-// [{r,t,l}] arrays without blowing the per-entry budget at hub
-// edges (one source PK per visor, not per transport).
-type compactEnvelope struct {
-	Source     string           `json:"s"`
-	Transports []compactTpEntry `json:"ts"`
-}
-
-// compactToEntry synthesizes a transport.Entry from a compact row
-// and a known source PK. Returns nil if the row is malformed.
-func compactToEntry(srcPK cipher.PubKey, c compactTpEntry) *transport.Entry {
-	if c.Remote == "" || c.Type == "" {
-		return nil
-	}
-	var rPK cipher.PubKey
-	if err := rPK.Set(c.Remote); err != nil {
-		return nil
-	}
-	edges := transport.SortEdges(srcPK, rPK)
-	tpType := tptypes.Type(c.Type)
-	return &transport.Entry{
-		ID:      transport.MakeTransportID(srcPK, rPK, tpType),
-		Edges:   edges,
-		Type:    tpType,
-		Latency: c.Latency,
-	}
 }
 
 // buildTpTargetIndex walks the dmsg salt to build a hex(target) → PK

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -3,6 +3,7 @@ package cliroute
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -18,6 +19,7 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dht"
 	routeFinder "github.com/skycoin/skywire/pkg/route-finder/store"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -258,59 +260,169 @@ func fetchAllTransports(_ context.Context, cmdFlags *pflag.FlagSet, tpdAddr stri
 }
 
 // fetchAllTransportsFromDHT pulls every "tp" salt entry from the local
-// DHT store and parses it as a list of transport.Entry. Two formats
+// DHT store and parses it as a list of transport.Entry. Three formats
 // coexist under this salt:
 //
-//   - The bare-entry format published by visors via TPDAdapter:
-//     []transport.Entry. We use these directly.
-//   - The compact format published by deployment-side discovery
-//     pushers: [{r, t, l, b}]. These omit the source PK (only
-//     present in the storage-key hash, not invertible) so we
-//     can't reconstruct edges from them. They're skipped.
+//  1. Bare entries (TPDAdapter): []transport.Entry — used directly.
+//  2. SignedEntries: []transport.SignedEntry — unwrap the .Entry.
+//  3. Compact entries: [{r, t, l}] — published by deployment-side
+//     mirrors, missing the source PK in the value. We recover the
+//     source PK by cross-referencing the tp entry's storage-target
+//     hash against the dmsg salt's index: every dmsg entry contains
+//     its publisher PK in `static`, and target = SHA256(pk || salt),
+//     so the dmsg salt is a known PK→target index for every visor
+//     that publishes both. Targets we can't resolve via that index
+//     are skipped.
+//
+// Synthetic transport IDs are generated for compact entries (the
+// tuple is deterministic, so re-running on the same data gives the
+// same IDs). Latency is preserved as Entry.Latency.
 //
 // On a full node the bare-entry coverage is comprehensive; on a
-// non-full node the local store will be sparse and this function
-// will return only entries near the local node ID. For comparison
-// purposes against TPD HTTP, run on a full node after a reconcile
-// pass.
+// non-full node the local store is sparse and this function will
+// return only entries near the local node ID. For comparison
+// against TPD HTTP, run on a full node after a reconcile pass.
 func fetchAllTransportsFromDHT(rpcClient visor.API) ([]*transport.Entry, error) {
-	body, err := rpcClient.DHTGetAll("tp")
+	tpBody, err := rpcClient.DHTListWithTargets("tp")
 	if err != nil {
-		return nil, fmt.Errorf("DHT GetAll(tp): %w", err)
+		return nil, fmt.Errorf("DHT ListWithTargets(tp): %w", err)
 	}
-	// Each item is a JSON array. We try unmarshalling each as
-	// []transport.Entry first; if the inner objects don't have an
-	// `edges` field (compact format), the unmarshal will succeed
-	// but produce zero-value edges, which we filter out.
-	var raw []json.RawMessage
-	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+	// Build the target→PK index from the dmsg salt.
+	pkByTpTarget, err := buildTpTargetIndex(rpcClient)
+	if err != nil {
+		// Non-fatal: we still have bare entries, just no compact recovery.
+		pkByTpTarget = nil
+	}
+
+	type targeted struct {
+		Target string          `json:"target"`
+		Value  json.RawMessage `json:"value"`
+	}
+	var rows []targeted
+	if err := json.Unmarshal([]byte(tpBody), &rows); err != nil {
 		return nil, fmt.Errorf("parse DHT tp envelope: %w", err)
 	}
+
 	var entries []*transport.Entry
-	skipped := 0
-	for _, item := range raw {
-		var batch []*transport.Entry
-		if err := json.Unmarshal(item, &batch); err != nil {
-			skipped++
-			continue
-		}
-		for _, e := range batch {
-			if e == nil {
+	bare, signed, compact, unresolved := 0, 0, 0, 0
+
+	for _, row := range rows {
+		// Try bare-entry format first.
+		var bareBatch []*transport.Entry
+		if json.Unmarshal(row.Value, &bareBatch) == nil && len(bareBatch) > 0 {
+			anyResolved := false
+			for _, e := range bareBatch {
+				if e == nil {
+					continue
+				}
+				if !e.Edges[0].Null() && !e.Edges[1].Null() {
+					entries = append(entries, e)
+					anyResolved = true
+					continue
+				}
+			}
+			if anyResolved {
+				bare++
 				continue
 			}
-			// Compact-format entries unmarshal into Entry with both
-			// edges = zero; skip them.
-			if e.Edges[0].Null() && e.Edges[1].Null() {
-				skipped++
+		}
+
+		// Try SignedEntry format.
+		var signedBatch []*transport.SignedEntry
+		if json.Unmarshal(row.Value, &signedBatch) == nil && len(signedBatch) > 0 {
+			anyResolved := false
+			for _, se := range signedBatch {
+				if se == nil || se.Entry == nil {
+					continue
+				}
+				if !se.Entry.Edges[0].Null() && !se.Entry.Edges[1].Null() {
+					entries = append(entries, se.Entry)
+					anyResolved = true
+				}
+			}
+			if anyResolved {
+				signed++
 				continue
+			}
+		}
+
+		// Try compact format. We need the source PK from the
+		// dmsg-salt index.
+		var compactBatch []compactTpEntry
+		if json.Unmarshal(row.Value, &compactBatch) != nil {
+			continue
+		}
+		srcPK, ok := pkByTpTarget[row.Target]
+		if !ok {
+			unresolved++
+			continue
+		}
+		for _, c := range compactBatch {
+			if c.Remote == "" || c.Type == "" {
+				continue
+			}
+			var rPK cipher.PubKey
+			if err := rPK.Set(c.Remote); err != nil {
+				continue
+			}
+			edges := transport.SortEdges(srcPK, rPK)
+			tpType := tptypes.Type(c.Type)
+			e := &transport.Entry{
+				ID:      transport.MakeTransportID(srcPK, rPK, tpType),
+				Edges:   edges,
+				Type:    tpType,
+				Latency: c.Latency,
 			}
 			entries = append(entries, e)
 		}
+		compact++
 	}
-	if skipped > 0 && len(entries) == 0 {
-		return nil, fmt.Errorf("DHT tp salt has %d items but none in bare-entry format (%d skipped); compact entries lack source PK and can't be used to build a graph", len(raw), skipped)
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("DHT tp salt empty or unparseable (rows=%d, bare=%d, signed=%d, compact=%d, unresolved=%d)",
+			len(rows), bare, signed, compact, unresolved)
 	}
 	return entries, nil
+}
+
+// compactTpEntry is the single-letter shape some publishers emit
+// under the tp salt. The struct is local to this CLI helper since
+// it's not used elsewhere.
+type compactTpEntry struct {
+	Remote  string  `json:"r"`
+	Type    string  `json:"t"`
+	Latency float64 `json:"l,omitempty"`
+}
+
+// buildTpTargetIndex walks the dmsg salt to build a hex(target) → PK
+// map suitable for resolving compact tp entries. Each dmsg entry
+// contains the publisher PK in its `static` field; we hash that PK
+// with the tp salt to compute the target where the visor's tp entry
+// would live. Returned map is keyed by hex-encoded target.
+func buildTpTargetIndex(rpcClient visor.API) (map[string]cipher.PubKey, error) {
+	dmsgBody, err := rpcClient.DHTGetAll("dmsg")
+	if err != nil {
+		return nil, fmt.Errorf("DHT GetAll(dmsg): %w", err)
+	}
+	var raw []struct {
+		Static string `json:"static"`
+	}
+	if err := json.Unmarshal([]byte(dmsgBody), &raw); err != nil {
+		return nil, fmt.Errorf("parse DHT dmsg envelope: %w", err)
+	}
+	out := make(map[string]cipher.PubKey, len(raw))
+	for _, e := range raw {
+		if e.Static == "" {
+			continue
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(e.Static); err != nil {
+			continue
+		}
+		target := dht.MutableItemTarget(pk, []byte("tp"))
+		out[hex.EncodeToString(target[:])] = pk
+	}
+	return out, nil
 }
 
 // memoryStore wraps fetched transports to implement store.Store for route-finder's Graph

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -35,6 +36,7 @@ var (
 	calcMinHops uint16
 	calcMaxHops uint16
 	calcCount   int
+	calcSource  string
 )
 
 func init() {
@@ -45,6 +47,7 @@ func init() {
 	calcCmd.Flags().Uint16VarP(&calcMinHops, "min", "n", 0, "minimum hops (0 = use visor's routing.min_hops, fallback 1)")
 	calcCmd.Flags().Uint16VarP(&calcMaxHops, "max", "x", 5, "maximum hops")
 	calcCmd.Flags().IntVarP(&calcCount, "count", "c", 1, "max routes to return (0 = all matching)")
+	calcCmd.Flags().StringVar(&calcSource, "source", "tpd", "transport graph source: tpd (HTTP), dht (visor's local DHT store), auto (DHT then TPD)")
 	clirpc.RegisterFetchFlags(calcCmd)
 }
 
@@ -152,9 +155,34 @@ var calcCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), calcTimeout)
 		defer cancel()
 
-		entries, err := fetchAllTransports(ctx, cmd.Flags(), tpdURL)
+		var entries []*transport.Entry
+		var err error
+		switch strings.ToLower(calcSource) {
+		case "tpd":
+			entries, err = fetchAllTransports(ctx, cmd.Flags(), tpdURL)
+		case "dht":
+			if rpcClient == nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--source dht requires a running visor (RPC unavailable)"))
+			}
+			entries, err = fetchAllTransportsFromDHT(rpcClient)
+		case "auto":
+			if rpcClient != nil {
+				entries, err = fetchAllTransportsFromDHT(rpcClient)
+				if err != nil || len(entries) < 10 {
+					// DHT had no useful data; fall back.
+					entries, err = fetchAllTransports(ctx, cmd.Flags(), tpdURL)
+				}
+			} else {
+				entries, err = fetchAllTransports(ctx, cmd.Flags(), tpdURL)
+			}
+		default:
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --source %q; expected tpd|dht|auto", calcSource))
+		}
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if len(entries) == 0 {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("no transport entries available from %s", calcSource))
 		}
 
 		memStore := newMemoryStoreFromEntries(entries)
@@ -225,6 +253,62 @@ func fetchAllTransports(_ context.Context, cmdFlags *pflag.FlagSet, tpdAddr stri
 	var entries []*transport.Entry
 	if err := json.Unmarshal(body, &entries); err != nil {
 		return nil, err
+	}
+	return entries, nil
+}
+
+// fetchAllTransportsFromDHT pulls every "tp" salt entry from the local
+// DHT store and parses it as a list of transport.Entry. Two formats
+// coexist under this salt:
+//
+//   - The bare-entry format published by visors via TPDAdapter:
+//     []transport.Entry. We use these directly.
+//   - The compact format published by deployment-side discovery
+//     pushers: [{r, t, l, b}]. These omit the source PK (only
+//     present in the storage-key hash, not invertible) so we
+//     can't reconstruct edges from them. They're skipped.
+//
+// On a full node the bare-entry coverage is comprehensive; on a
+// non-full node the local store will be sparse and this function
+// will return only entries near the local node ID. For comparison
+// purposes against TPD HTTP, run on a full node after a reconcile
+// pass.
+func fetchAllTransportsFromDHT(rpcClient visor.API) ([]*transport.Entry, error) {
+	body, err := rpcClient.DHTGetAll("tp")
+	if err != nil {
+		return nil, fmt.Errorf("DHT GetAll(tp): %w", err)
+	}
+	// Each item is a JSON array. We try unmarshalling each as
+	// []transport.Entry first; if the inner objects don't have an
+	// `edges` field (compact format), the unmarshal will succeed
+	// but produce zero-value edges, which we filter out.
+	var raw []json.RawMessage
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		return nil, fmt.Errorf("parse DHT tp envelope: %w", err)
+	}
+	var entries []*transport.Entry
+	skipped := 0
+	for _, item := range raw {
+		var batch []*transport.Entry
+		if err := json.Unmarshal(item, &batch); err != nil {
+			skipped++
+			continue
+		}
+		for _, e := range batch {
+			if e == nil {
+				continue
+			}
+			// Compact-format entries unmarshal into Entry with both
+			// edges = zero; skip them.
+			if e.Edges[0].Null() && e.Edges[1].Null() {
+				skipped++
+				continue
+			}
+			entries = append(entries, e)
+		}
+	}
+	if skipped > 0 && len(entries) == 0 {
+		return nil, fmt.Errorf("DHT tp salt has %d items but none in bare-entry format (%d skipped); compact entries lack source PK and can't be used to build a graph", len(raw), skipped)
 	}
 	return entries, nil
 }

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -346,8 +346,26 @@ func fetchAllTransportsFromDHT(rpcClient visor.API) ([]*transport.Entry, error) 
 			}
 		}
 
-		// Try compact format. We need the source PK from the
-		// dmsg-salt index.
+		// Try compact-envelope format: {s: source_pk, ts: [{r,t,l}]}.
+		// This is the format publishers should adopt — explicit source
+		// PK in the value means consumers don't need cross-reference.
+		var envelope compactEnvelope
+		if json.Unmarshal(row.Value, &envelope) == nil && envelope.Source != "" {
+			var srcPK cipher.PubKey
+			if err := srcPK.Set(envelope.Source); err == nil {
+				for _, c := range envelope.Transports {
+					e := compactToEntry(srcPK, c)
+					if e != nil {
+						entries = append(entries, e)
+					}
+				}
+				compact++
+				continue
+			}
+		}
+
+		// Try bare-array compact format: [{r, t, l}]. Source PK is
+		// recovered via the dmsg-salt index when available.
 		var compactBatch []compactTpEntry
 		if json.Unmarshal(row.Value, &compactBatch) != nil {
 			continue
@@ -358,22 +376,10 @@ func fetchAllTransportsFromDHT(rpcClient visor.API) ([]*transport.Entry, error) 
 			continue
 		}
 		for _, c := range compactBatch {
-			if c.Remote == "" || c.Type == "" {
-				continue
+			e := compactToEntry(srcPK, c)
+			if e != nil {
+				entries = append(entries, e)
 			}
-			var rPK cipher.PubKey
-			if err := rPK.Set(c.Remote); err != nil {
-				continue
-			}
-			edges := transport.SortEdges(srcPK, rPK)
-			tpType := tptypes.Type(c.Type)
-			e := &transport.Entry{
-				ID:      transport.MakeTransportID(srcPK, rPK, tpType),
-				Edges:   edges,
-				Type:    tpType,
-				Latency: c.Latency,
-			}
-			entries = append(entries, e)
 		}
 		compact++
 	}
@@ -392,6 +398,36 @@ type compactTpEntry struct {
 	Remote  string  `json:"r"`
 	Type    string  `json:"t"`
 	Latency float64 `json:"l,omitempty"`
+}
+
+// compactEnvelope is the recommended publish format for compact
+// transport listings: explicit source PK plus a list of compact
+// per-transport rows. Solves the recoverability problem of bare
+// [{r,t,l}] arrays without blowing the per-entry budget at hub
+// edges (one source PK per visor, not per transport).
+type compactEnvelope struct {
+	Source     string           `json:"s"`
+	Transports []compactTpEntry `json:"ts"`
+}
+
+// compactToEntry synthesizes a transport.Entry from a compact row
+// and a known source PK. Returns nil if the row is malformed.
+func compactToEntry(srcPK cipher.PubKey, c compactTpEntry) *transport.Entry {
+	if c.Remote == "" || c.Type == "" {
+		return nil
+	}
+	var rPK cipher.PubKey
+	if err := rPK.Set(c.Remote); err != nil {
+		return nil
+	}
+	edges := transport.SortEdges(srcPK, rPK)
+	tpType := tptypes.Type(c.Type)
+	return &transport.Entry{
+		ID:      transport.MakeTransportID(srcPK, rPK, tpType),
+		Edges:   edges,
+		Type:    tpType,
+		Latency: c.Latency,
+	}
 }
 
 // buildTpTargetIndex walks the dmsg salt to build a hex(target) → PK

--- a/cmd/skywire-cli/commands/visor/dht.go
+++ b/cmd/skywire-cli/commands/visor/dht.go
@@ -2,8 +2,12 @@
 package clivisor
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +22,8 @@ func init() {
 	dhtCmd.AddCommand(dhtFullNodeCmd)
 	dhtCmd.AddCommand(dhtSyncCmd)
 	dhtCmd.AddCommand(dhtListCmd)
+	dhtCmd.AddCommand(dhtPeersCmd)
+	dhtCmd.AddCommand(dhtReconcileCmd)
 	RootCmd.AddCommand(dhtCmd)
 }
 
@@ -181,6 +187,94 @@ var (
 func init() {
 	dhtListCmd.Flags().StringVar(&dhtListSalt, "salt", "", "filter by namespace (dmsg, tp, svc); empty = all")
 	dhtListCmd.Flags().BoolVar(&dhtListWithTarget, "with-target", false, "emit {target, value} objects instead of bare values (for diffing against HTTP discoveries)")
+}
+
+var dhtPeersJSON bool
+
+func init() {
+	dhtPeersCmd.Flags().BoolVar(&dhtPeersJSON, "json", false, "emit raw JSON")
+}
+
+var dhtPeersCmd = &cobra.Command{
+	Use:   "peers",
+	Short: "Dump the DHT routing table (every K-bucket peer)",
+	Long: `List every peer currently in this node's K-bucket routing
+table. Useful for "is the DHT actually connected to anyone?" debugging
+that 'dht status' (which shows only the peer count) cannot answer.
+
+Output is sorted by bucket index then by last-seen (newest first).
+With --json, emits the raw JSON array.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		peers, err := rpcClient.DHTPeers()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if dhtPeersJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			internal.Catch(cmd.Flags(), enc.Encode(peers))
+			return
+		}
+		if len(peers) == 0 {
+			fmt.Println("No peers in routing table.")
+			return
+		}
+		sort.SliceStable(peers, func(i, j int) bool {
+			if peers[i].Bucket != peers[j].Bucket {
+				return peers[i].Bucket < peers[j].Bucket
+			}
+			return peers[i].LastSeen.After(peers[j].LastSeen)
+		})
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "BUCKET\tPK\tNODE_ID\tLAST_SEEN") //nolint:errcheck
+		for _, p := range peers {
+			age := time.Since(p.LastSeen).Truncate(time.Second).String()
+			fmt.Fprintf(w, "%d\t%s\t%s\t%s ago\n", //nolint:errcheck
+				p.Bucket, p.PK, p.NodeID, age)
+		}
+		w.Flush() //nolint:errcheck,gosec
+	},
+}
+
+var dhtReconcileSalt string
+
+func init() {
+	dhtReconcileCmd.Flags().StringVar(&dhtReconcileSalt, "salt", "", "filter by namespace (dmsg, tp, svc); empty = all")
+}
+
+var dhtReconcileCmd = &cobra.Command{
+	Use:   "reconcile <full-node-pk>",
+	Short: "One-shot pull+push reconcile against a remote full node",
+	Long: `Manually run one pull+push reconcile pass against a specific
+remote full node. The full-node pull loop already does this hourly
+against bootstrap and advertised full nodes; this command is for
+forcing convergence faster (e.g., after a config change) or for
+debugging cross-peer divergence.
+
+Restricted to peers in BootstrapPKs ∪ FindAdvertisedFullNodes — the
+receiver-side PutMirror handler stores any signed item we push without
+distance/admission gating, so pushing to a non-full-node would
+overflow its store.
+
+Examples:
+  skywire cli visor dht reconcile <pk>
+  skywire cli visor dht reconcile <pk> --salt tp`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		pulled, pushed, err := rpcClient.DHTReconcile(args[0], dhtReconcileSalt)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("Reconcile complete: pulled=%d pushed=%d\n", pulled, pushed)
+	},
 }
 
 var dhtListCmd = &cobra.Command{

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -501,6 +501,34 @@ func (n *Node) syncFromCollect(ctx context.Context, remotePK cipher.PubKey, salt
 	return stored, seen, nil
 }
 
+// IsTrustedFullNode reports whether remotePK is one of the peers we're
+// allowed to push items to: either a configured bootstrap PK or a peer
+// with a fresh signed FullNodeAdvert in our local store. Pushing to
+// anyone else risks overflowing their store via the unconditional
+// receiver-side PutMirror handler.
+func (n *Node) IsTrustedFullNode(remotePK cipher.PubKey) bool {
+	for _, pk := range n.cfg.BootstrapPKs {
+		if pk == remotePK {
+			return true
+		}
+	}
+	for _, pk := range FindAdvertisedFullNodes(n) {
+		if pk == remotePK {
+			return true
+		}
+	}
+	return false
+}
+
+// Reconcile is the exported wrapper around reconcile. Callers MUST
+// verify remotePK is a full node first (use IsTrustedFullNode); the
+// receiver-side PutMirror handler does not check distance or
+// admission, so pushing to a non-full-node overflows its store. The
+// visor's DHTReconcile RPC is the only intended external caller.
+func (n *Node) Reconcile(ctx context.Context, remotePK cipher.PubKey, salt string) (pulled, pushed int, err error) {
+	return n.reconcile(ctx, remotePK, salt)
+}
+
 // reconcile pulls from a remote peer (like SyncFrom) and then pushes
 // back any items in our store that the remote didn't report. The push
 // phase is what makes full-node-to-full-node coverage actually
@@ -508,12 +536,9 @@ func (n *Node) syncFromCollect(ctx context.Context, remotePK cipher.PubKey, salt
 // every other full node's data, but the source peers themselves never
 // see what they were missing.
 //
-// Lowercase by design: callers must verify that remotePK is a full
-// node before invoking, since the receiver-side PutMirror handler
-// stores anything we push without distance/admission gating. The only
-// in-tree caller (fullNodePullOnce) iterates BootstrapPKs, which the
-// deployment guarantees are DHT full nodes; other callers should
-// satisfy the same invariant.
+// Lowercase by design — see the Reconcile public wrapper for the
+// safety contract. The only in-tree caller (fullNodePullOnce)
+// iterates trusted full-node PKs already.
 //
 // Returns (pulled, pushed) item counts plus any error from either
 // phase. Push errors are aggregated as debug logs and don't fail the

--- a/pkg/dht/svc_adapter.go
+++ b/pkg/dht/svc_adapter.go
@@ -63,16 +63,33 @@ func (d *SvcAdapter) Lookup(ctx context.Context, pk cipher.PubKey, serviceType s
 }
 
 // LookupAll retrieves the full service list for a visor PK.
+//
+// Accepts both shapes that historically appear under the svc salt:
+//
+//  1. The canonical shape this adapter writes: []servicedisc.Service.
+//  2. The legacy single-Service shape some older deployment SD builds
+//     wrote (one Service object, not wrapped in an array).
+//
+// Hardened to match autoconnect.fetchPubAddresses, which has tolerated
+// both shapes inline. Without this, any caller going through
+// LookupAll instead of reading the raw store loses the legacy entries
+// — the visor's service-discovery DHT path silently underreports.
 func (d *SvcAdapter) LookupAll(ctx context.Context, pk cipher.PubKey) ([]servicedisc.Service, error) {
 	item, err := d.node.Get(ctx, pk, svcSalt)
 	if err != nil {
 		return nil, err
 	}
+	// Try canonical list shape first.
 	var services []servicedisc.Service
-	if err := json.Unmarshal(item.V, &services); err != nil {
-		return nil, fmt.Errorf("dht svc: unmarshal: %w", err)
+	if err := json.Unmarshal(item.V, &services); err == nil {
+		return services, nil
 	}
-	return services, nil
+	// Fall back to single-object shape (legacy publishers).
+	var single servicedisc.Service
+	if err := json.Unmarshal(item.V, &single); err == nil {
+		return []servicedisc.Service{single}, nil
+	}
+	return nil, fmt.Errorf("dht svc: value matches neither []Service nor Service")
 }
 
 // Deregister clears the visor's service list by publishing an empty array

--- a/pkg/dht/tpd_adapter.go
+++ b/pkg/dht/tpd_adapter.go
@@ -3,7 +3,9 @@ package dht
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,11 +18,34 @@ import (
 // Salt for transport discovery entries in the DHT.
 var tpSalt = []byte("tp")
 
+// tpChunkSize is the target number of transport.Entry items per DHT
+// item. Each entry serializes to ~250 bytes (UUID + 2 PKs in hex + a
+// few short strings); 200 entries fit in ~50 KB of JSON which leaves
+// headroom under the 64 KiB MaxValueSize cap. Hub edges with more
+// transports than this overflow into chunked salts ("tp:1", "tp:2"...).
+const tpChunkSize = 200
+
+// tpChunkSalt returns the salt name for the i-th tp chunk. Chunk 0 is
+// always the bare "tp" salt for backwards compatibility with consumers
+// that don't know about chunking.
+func tpChunkSalt(i int) []byte {
+	if i == 0 {
+		return tpSalt
+	}
+	return []byte(fmt.Sprintf("tp:%d", i))
+}
+
 // TPDAdapter implements transport.DiscoveryClient backed by the DHT.
-// Each visor publishes its own transport list under its PK with salt "tp".
+// Each visor publishes its own transport list under its PK with salt
+// "tp" (chunk 0). Hub edges with more than tpChunkSize transports
+// overflow into chunked salts "tp:1", "tp:2", ...
 type TPDAdapter struct {
 	node *Node
 	log  *logging.Logger
+	// prevChunkCount remembers how many tp chunks we wrote last time
+	// so the next publish can tombstone the now-unused chunks if the
+	// transport list shrinks.
+	prevChunkCount atomic.Int32
 }
 
 // NewTPDAdapter creates a transport discovery client backed by the DHT.
@@ -57,24 +82,78 @@ func (d *TPDAdapter) RegisterTransportsV3(ctx context.Context, _ string, entries
 	return d.putEntries(ctx, entries)
 }
 
+// previousChunkCount tracks how many tp chunk salts we wrote last time.
+// On shrink we need to clear the now-unused chunks to avoid stale data.
+// Per-adapter state — safe because there's exactly one TPDAdapter per
+// visor.
 func (d *TPDAdapter) putEntries(ctx context.Context, entries []*transport.Entry) error {
-	// Marshal even when entries is empty — that produces "[]" which
-	// is exactly the cleanup payload we want for "I have no transports
-	// right now."
-	data, err := json.Marshal(entries)
-	if err != nil {
-		return fmt.Errorf("dht tpd: marshal: %w", err)
-	}
-	if len(data) > MaxValueSize {
-		return fmt.Errorf("dht tpd: transport list too large (%d bytes, max %d)", len(data), MaxValueSize)
-	}
 	// Wall-clock nanoseconds as monotonic seq generator. Survives restarts
 	// (in-memory entry counts and bandwidth totals do not) and is virtually
 	// guaranteed to climb past whatever peers cached for our PK previously.
 	// On clock skew the DHT layer's per-peer rejection still keeps things
 	// safe — we'll catch up next tick.
-	seq := uint64(time.Now().UnixNano())
-	return d.node.Put(ctx, data, seq, tpSalt)
+	baseSeq := uint64(time.Now().UnixNano())
+
+	// Always publish at least one chunk (chunk 0 = "tp"). Empty entry
+	// list still goes through so a "I have no transports anymore"
+	// publish overwrites stale state.
+	chunks := chunkTpEntries(entries, tpChunkSize)
+	if len(chunks) == 0 {
+		chunks = [][]*transport.Entry{nil}
+	}
+
+	for i, chunk := range chunks {
+		data, err := json.Marshal(chunk)
+		if err != nil {
+			return fmt.Errorf("dht tpd: marshal chunk %d: %w", i, err)
+		}
+		if len(data) > MaxValueSize {
+			// Even a single 200-entry chunk shouldn't hit this — but
+			// if a future entry serialization grows, fail loudly
+			// rather than silently dropping.
+			return fmt.Errorf("dht tpd: chunk %d too large (%d bytes, max %d)", i, len(data), MaxValueSize)
+		}
+		// Each chunk gets a unique seq so the DHT's monotonic-seq
+		// check accepts them all in one pass. (baseSeq + i is fine —
+		// next register cycle starts from a fresh nanosecond clock.)
+		if err := d.node.Put(ctx, data, baseSeq+uint64(i), tpChunkSalt(i)); err != nil {
+			return fmt.Errorf("dht tpd: put chunk %d: %w", i, err)
+		}
+	}
+
+	// Tombstone any chunks we wrote in a previous, larger publish.
+	// Publishing an empty array advances the seq past the stale data
+	// so readers stop seeing it.
+	prev := int(d.prevChunkCount.Load())
+	for i := len(chunks); i < prev; i++ {
+		_ = d.node.Put(ctx, []byte("[]"), baseSeq+uint64(i), tpChunkSalt(i)) //nolint:errcheck
+	}
+	d.prevChunkCount.Store(int32(len(chunks))) //nolint:gosec
+
+	return nil
+}
+
+// chunkTpEntries splits entries into ~chunkSize-element groups so a
+// single DHT item never crosses MaxValueSize. Returns nil for an
+// empty input (caller decides whether to publish an empty chunk 0
+// for cleanup).
+func chunkTpEntries(entries []*transport.Entry, chunkSize int) [][]*transport.Entry {
+	if len(entries) == 0 {
+		return nil
+	}
+	if chunkSize <= 0 {
+		chunkSize = tpChunkSize
+	}
+	n := (len(entries) + chunkSize - 1) / chunkSize
+	chunks := make([][]*transport.Entry, 0, n)
+	for i := 0; i < len(entries); i += chunkSize {
+		end := i + chunkSize
+		if end > len(entries) {
+			end = len(entries)
+		}
+		chunks = append(chunks, entries[i:end])
+	}
+	return chunks
 }
 
 // GetTransportByID searches the DHT for a transport by ID.
@@ -89,27 +168,55 @@ func (d *TPDAdapter) GetTransportByID(ctx context.Context, id uuid.UUID) (*trans
 
 // GetTransportsByEdge returns all transports for a given visor PK.
 //
-// Decodes the new bare []*Entry shape produced by current writers.
-// Falls through to the legacy []*SignedEntry shape (which was the
-// publish format before this commit) so peers that haven't republished
-// since the upgrade still resolve. The fallback strips the wrapper so
-// callers always see []*Entry.
+// Reads chunk 0 (salt "tp") plus any chunked overflow salts ("tp:1",
+// "tp:2", ...) until one is missing. Decodes the bare []*Entry shape
+// produced by current writers; falls through to the legacy
+// []*SignedEntry shape so peers that haven't republished since the
+// chunking upgrade still resolve.
 func (d *TPDAdapter) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
-	item, err := d.node.Get(ctx, pk, tpSalt)
-	if err != nil {
-		return nil, err
+	var out []*transport.Entry
+	for i := 0; ; i++ {
+		item, err := d.node.Get(ctx, pk, tpChunkSalt(i))
+		if err != nil {
+			if i == 0 {
+				return nil, err
+			}
+			// Stopping at the first chunk-not-found is the cheap way
+			// to detect "no more chunks." A torn write (chunk 0 and 2
+			// present, 1 missing) would mean a partial publish — but
+			// our writer always writes chunks contiguously, and reads
+			// race with a writer at most one publish behind, so this
+			// is safe.
+			if errors.Is(err, ErrNotFound) {
+				break
+			}
+			return nil, err
+		}
+		entries, err := decodeTpItem(item.V)
+		if err != nil {
+			return nil, fmt.Errorf("dht tpd: decode chunk %d: %w", i, err)
+		}
+		out = append(out, entries...)
+		// An empty chunk means we hit a tombstone — older publishes
+		// had more chunks but the writer shrank. Stop reading further.
+		if len(entries) == 0 && i > 0 {
+			break
+		}
 	}
+	return out, nil
+}
 
-	// Try the canonical bare-entry shape first.
+// decodeTpItem unmarshals one tp-chunk value into entries, accepting
+// the canonical bare shape and falling back to the legacy SignedEntry
+// wrapper.
+func decodeTpItem(v []byte) ([]*transport.Entry, error) {
 	var entries []*transport.Entry
-	if err := json.Unmarshal(item.V, &entries); err == nil && (len(entries) == 0 || entries[0] != nil) {
+	if err := json.Unmarshal(v, &entries); err == nil && (len(entries) == 0 || entries[0] != nil) {
 		return entries, nil
 	}
-
-	// Legacy: SignedEntry wrapper.
 	var signed []*transport.SignedEntry
-	if err := json.Unmarshal(item.V, &signed); err != nil {
-		return nil, fmt.Errorf("dht tpd: unmarshal: %w", err)
+	if err := json.Unmarshal(v, &signed); err != nil {
+		return nil, err
 	}
 	out := make([]*transport.Entry, 0, len(signed))
 	for _, se := range signed {

--- a/pkg/dht/tpd_adapter.go
+++ b/pkg/dht/tpd_adapter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // Salt for transport discovery entries in the DHT.
@@ -192,7 +193,7 @@ func (d *TPDAdapter) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) 
 			}
 			return nil, err
 		}
-		entries, err := decodeTpItem(item.V)
+		entries, err := decodeTpItem(item.V, pk)
 		if err != nil {
 			return nil, fmt.Errorf("dht tpd: decode chunk %d: %w", i, err)
 		}
@@ -206,25 +207,132 @@ func (d *TPDAdapter) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) 
 	return out, nil
 }
 
+// DecodeTpItem is the public wrapper around decodeTpItem for callers
+// outside this package (e.g. cmd/skywire-cli/commands/route/calc.go's
+// scan over all tp entries). srcPK is the visor PK whose entry this
+// is — used to fill in the source for compact shapes that don't
+// carry it explicitly.
+func DecodeTpItem(v []byte, srcPK cipher.PubKey) ([]*transport.Entry, error) {
+	return decodeTpItem(v, srcPK)
+}
+
 // decodeTpItem unmarshals one tp-chunk value into entries, accepting
-// the canonical bare shape and falling back to the legacy SignedEntry
-// wrapper.
-func decodeTpItem(v []byte) ([]*transport.Entry, error) {
+// any of the four shapes that coexist on the wire under the tp salt:
+//
+//  1. Bare:             []transport.Entry             (canonical)
+//  2. Signed:           []transport.SignedEntry       (legacy wrapper)
+//  3. Compact-array:    [{r, t, l}]                   (deployment mirrors)
+//  4. Compact-envelope: {s: <pk>, ts: [{r, t, l}]}    (recommended for size)
+//
+// srcPK is the visor PK whose tp entry this is — used as the source
+// for compact shapes that don't carry it (compact-array, compact-
+// envelope without `s`). Callers from GetTransportsByEdge always know
+// it because it's the lookup key.
+//
+// Compact entries are synthesized into transport.Entry with a
+// deterministic ID (transport.MakeTransportID(src, remote, type)).
+func decodeTpItem(v []byte, srcPK cipher.PubKey) ([]*transport.Entry, error) {
+	// Bare canonical.
 	var entries []*transport.Entry
 	if err := json.Unmarshal(v, &entries); err == nil && (len(entries) == 0 || entries[0] != nil) {
-		return entries, nil
-	}
-	var signed []*transport.SignedEntry
-	if err := json.Unmarshal(v, &signed); err != nil {
-		return nil, err
-	}
-	out := make([]*transport.Entry, 0, len(signed))
-	for _, se := range signed {
-		if se != nil && se.Entry != nil {
-			out = append(out, se.Entry)
+		// Distinguish bare from compact-array: both unmarshal into a
+		// slice, but compact-array produces zero-valued Edges. Bare
+		// always has populated Edges.
+		anyResolved := false
+		for _, e := range entries {
+			if e == nil {
+				continue
+			}
+			if !e.Edges[0].Null() && !e.Edges[1].Null() {
+				anyResolved = true
+				break
+			}
+		}
+		if anyResolved {
+			return entries, nil
 		}
 	}
-	return out, nil
+
+	// Signed wrapper.
+	var signed []*transport.SignedEntry
+	if err := json.Unmarshal(v, &signed); err == nil {
+		out := make([]*transport.Entry, 0, len(signed))
+		for _, se := range signed {
+			if se != nil && se.Entry != nil &&
+				!se.Entry.Edges[0].Null() && !se.Entry.Edges[1].Null() {
+				out = append(out, se.Entry)
+			}
+		}
+		if len(out) > 0 {
+			return out, nil
+		}
+	}
+
+	// Compact-envelope: explicit source PK in the value.
+	var env compactEnvelope
+	if json.Unmarshal(v, &env) == nil && env.Source != "" {
+		var pk cipher.PubKey
+		if err := pk.Set(env.Source); err == nil {
+			out := make([]*transport.Entry, 0, len(env.Transports))
+			for _, c := range env.Transports {
+				if e := compactToEntry(pk, c); e != nil {
+					out = append(out, e)
+				}
+			}
+			return out, nil
+		}
+	}
+
+	// Compact-array: source PK comes from the lookup key (srcPK).
+	var compact []compactTpEntry
+	if json.Unmarshal(v, &compact) == nil && len(compact) > 0 && srcPK != (cipher.PubKey{}) {
+		out := make([]*transport.Entry, 0, len(compact))
+		for _, c := range compact {
+			if e := compactToEntry(srcPK, c); e != nil {
+				out = append(out, e)
+			}
+		}
+		return out, nil
+	}
+
+	return nil, fmt.Errorf("dht tpd: value matches no known tp shape (bare/signed/compact-array/compact-envelope)")
+}
+
+// compactTpEntry is one row of the single-letter compact format that
+// some publishers emit under the tp salt: r=remote PK, t=transport
+// type, l=latency in ms.
+type compactTpEntry struct {
+	Remote  string  `json:"r"`
+	Type    string  `json:"t"`
+	Latency float64 `json:"l,omitempty"`
+}
+
+// compactEnvelope wraps a list of compact entries with their source
+// PK. The recommended publish format for size-conscious publishers:
+// one source PK per visor, not per transport, so hub edges fit
+// comfortably under MaxValueSize.
+type compactEnvelope struct {
+	Source     string           `json:"s"`
+	Transports []compactTpEntry `json:"ts"`
+}
+
+// compactToEntry synthesizes a transport.Entry from a compact row
+// plus a known source PK. Returns nil if the row is malformed.
+func compactToEntry(srcPK cipher.PubKey, c compactTpEntry) *transport.Entry {
+	if c.Remote == "" || c.Type == "" {
+		return nil
+	}
+	var rPK cipher.PubKey
+	if err := rPK.Set(c.Remote); err != nil {
+		return nil
+	}
+	tpType := tptypes.Type(c.Type)
+	return &transport.Entry{
+		ID:      transport.MakeTransportID(srcPK, rPK, tpType),
+		Edges:   transport.SortEdges(srcPK, rPK),
+		Type:    tpType,
+		Latency: c.Latency,
+	}
 }
 
 // GetAllTransports is not efficiently supported by the DHT.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -287,6 +287,8 @@ type API interface {
 	DHTSync(remotePK string, salt string) (int, error)
 	DHTGetAll(salt string) (string, error)
 	DHTListWithTargets(salt string) (string, error)
+	DHTPeers() ([]DHTPeerInfo, error)
+	DHTReconcile(remotePK string, salt string) (pulled, pushed int, err error)
 
 	// Close closes the API connection (for RPC clients)
 	Close() error

--- a/pkg/visor/api_dht.go
+++ b/pkg/visor/api_dht.go
@@ -3,6 +3,7 @@ package visor
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )
@@ -91,4 +92,60 @@ func (v *Visor) DHTGet(pk string, salt string) ([]byte, error) {
 		return nil, err
 	}
 	return item.V, nil
+}
+
+// DHTPeerInfo is one entry in the DHT routing-table dump.
+type DHTPeerInfo struct {
+	PK       cipher.PubKey `json:"pk"`
+	NodeID   string        `json:"node_id"`
+	LastSeen time.Time     `json:"last_seen"`
+	// Bucket is the index of the K-bucket holding this peer (= common
+	// prefix length with self_id, 0..255).
+	Bucket int `json:"bucket"`
+}
+
+// DHTPeers returns every peer currently in this node's routing table.
+// Useful for "is the DHT actually connected to anyone?" debugging that
+// `dht status` (which only shows the count) can't answer.
+func (v *Visor) DHTPeers() ([]DHTPeerInfo, error) {
+	if v.dhtNode == nil {
+		return nil, fmt.Errorf("DHT node not running")
+	}
+	rt := v.dhtNode.RoutingTable()
+	peers := rt.AllPeers()
+	out := make([]DHTPeerInfo, len(peers))
+	for i, p := range peers {
+		out[i] = DHTPeerInfo{
+			PK:       p.PK,
+			NodeID:   p.ID.String(),
+			LastSeen: p.LastSeen,
+			Bucket:   rt.BucketIndex(p.ID),
+		}
+	}
+	return out, nil
+}
+
+// DHTReconcile manually runs one pull+push reconcile pass against a
+// remote peer. Returns (pulled, pushed) item counts.
+//
+// Restricted to peers that the deployment trusts as full nodes
+// (BootstrapPKs ∪ FindAdvertisedFullNodes) because the receiver-side
+// PutMirror handler stores anything we push without distance/admission
+// gating. Pushing to a non-full-node would silently overflow its store.
+func (v *Visor) DHTReconcile(remotePK string, salt string) (int, int, error) {
+	if v.dhtNode == nil {
+		return 0, 0, fmt.Errorf("DHT node not running")
+	}
+	var targetPK cipher.PubKey
+	if err := targetPK.Set(remotePK); err != nil {
+		return 0, 0, fmt.Errorf("invalid PK: %w", err)
+	}
+
+	if !v.dhtNode.IsTrustedFullNode(targetPK) {
+		return 0, 0, fmt.Errorf("peer %s is not a known full node (not in bootstrap config and no fresh fullnode advert)", targetPK.String())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	return v.dhtNode.Reconcile(ctx, targetPK, salt)
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1316,6 +1316,25 @@ func (rc *rpcClient) DHTSync(remotePK string, salt string) (int, error) {
 	return resp, nil
 }
 
+// DHTPeers returns the routing-table contents.
+func (rc *rpcClient) DHTPeers() ([]DHTPeerInfo, error) {
+	var resp []DHTPeerInfo
+	if err := rc.Call("DHTPeers", &struct{}{}, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DHTReconcile runs a one-shot reconcile against a remote full node.
+func (rc *rpcClient) DHTReconcile(remotePK string, salt string) (int, int, error) {
+	req := DHTSyncRequest{RemotePK: remotePK, Salt: salt}
+	var resp DHTReconcileResult
+	if err := rc.Call("DHTReconcile", &req, &resp); err != nil {
+		return 0, 0, err
+	}
+	return resp.Pulled, resp.Pushed, nil
+}
+
 // TransportRPCCall proxies an RPC call to a remote visor over a transport.
 // args is optional JSON-encoded RPC arguments.
 func (rc *rpcClient) TransportRPCCall(remotePK cipher.PubKey, method string, args json.RawMessage) (json.RawMessage, error) {

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1200,6 +1200,16 @@ func (mc *mockRPCClient) DHTSync(_ string, _ string) (int, error) {
 	return 0, fmt.Errorf("not supported in mock")
 }
 
+// DHTPeers implements API.
+func (mc *mockRPCClient) DHTPeers() ([]DHTPeerInfo, error) {
+	return nil, fmt.Errorf("not supported in mock")
+}
+
+// DHTReconcile implements API.
+func (mc *mockRPCClient) DHTReconcile(_ string, _ string) (int, int, error) {
+	return 0, 0, fmt.Errorf("not supported in mock")
+}
+
 // TransportRPCCall implements API.
 func (mc *mockRPCClient) TransportRPCCall(_ cipher.PubKey, _ string, _ json.RawMessage) (json.RawMessage, error) {
 	return nil, fmt.Errorf("not supported in mock")

--- a/pkg/visor/rpc_dht.go
+++ b/pkg/visor/rpc_dht.go
@@ -72,3 +72,32 @@ func (r *RPC) DHTSync(req *DHTSyncRequest, out *int) (err error) {
 	*out = n
 	return nil
 }
+
+// DHTPeers returns the routing-table contents (every K-bucket peer).
+func (r *RPC) DHTPeers(_ *struct{}, out *[]DHTPeerInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "DHTPeers", nil)(out, &err)
+	peers, err := r.visor.DHTPeers()
+	if err != nil {
+		return err
+	}
+	*out = peers
+	return nil
+}
+
+// DHTReconcileResult carries pulled+pushed item counts from a reconcile.
+type DHTReconcileResult struct {
+	Pulled int `json:"pulled"`
+	Pushed int `json:"pushed"`
+}
+
+// DHTReconcile runs a one-shot reconcile against a remote full node.
+func (r *RPC) DHTReconcile(req *DHTSyncRequest, out *DHTReconcileResult) (err error) {
+	defer rpcutil.LogCall(r.log, "DHTReconcile", req)(out, &err)
+	pulled, pushed, err := r.visor.DHTReconcile(req.RemotePK, req.Salt)
+	if err != nil {
+		return err
+	}
+	out.Pulled = pulled
+	out.Pushed = pushed
+	return nil
+}

--- a/skywire-specs/specifications/26-DHT.md
+++ b/skywire-specs/specifications/26-DHT.md
@@ -177,6 +177,12 @@ The DHT provides adapter types that implement the same interfaces as the central
 
 `HybridDiscClient` and `HybridTPDClient` (`pkg/dht/disc_hybrid.go`) wrap a DHT adapter with an HTTP fallback: reads try DHT first, fall back to HTTP on miss; writes go to both. Wired into the visor by `initDHT` (DMSG hybrid) and `initDHTTransport` (TPD hybrid). The visor's autoconnect path (`pkg/visor/autoconnect.go:fetchPubAddresses`) reads the `svc` salt directly.
 
+## Hub-edge chunking (`tp` salt)
+
+A single `tp` salt value holds the full transport list for one visor. With ~250 bytes per `transport.Entry` (UUID + two PKs in hex + a few short strings + JSON overhead) and `MaxValueSize = 64 KiB`, a hub edge with more than ~250 transports would silently fail to publish (the mirror's `payload exceeds MaxValueSize, dropping publish` log was the only signal).
+
+`TPDAdapter` chunks at a target of **200 entries per chunk**, leaving headroom for entry-size growth. Chunk 0 is always the bare `tp` salt for back-compat with consumers that don't know about chunking; chunks 1+ go to `tp:1`, `tp:2`, … readers iterate `GetTransportsByEdge` over `tp`, `tp:1`, … until one is missing or empty (the latter is a tombstone — when a writer's chunk count shrinks, it publishes `[]` to the now-unused chunk salts so readers stop seeing stale data).
+
 ## Entry Mirroring
 
 Deployment services (DMSG discovery, TPD, SD) mirror HTTP-received entries into the DHT so entries from old visors that don't dual-write are still available to DHT readers. The mirror signs the DHT item with the *service's* own key but stores it under the visor's target key (`SHA256(visor_pk || salt)`) using the `mirror_target` field. The entry's own application-level signature (e.g., `disc.Entry.Signature`) provides authenticity proof; the DHT signature provides distribution authenticity.
@@ -208,7 +214,12 @@ The visor exposes the DHT via `skywire cli visor dht`:
 `route calc` also gained a `--source tpd|dht|auto` flag (default `tpd`):
 
 - `tpd`: fetch `/all-transports` from the deployment TPD (current behavior).
-- `dht`: build the graph from the local DHT's `tp` salt entries via `DHTListWithTargets`. Three formats are supported: bare `[]transport.Entry` (visor-published), `[]transport.SignedEntry`, and the compact single-letter format `[{r,t,l}]` published by deployment-side mirrors. The compact format omits the source PK in the value, but it's recovered by cross-referencing the storage target hash against the `dmsg` salt's `static` field — every visor that publishes both salts has a known PK→target relationship via `target = SHA256(pk||salt)`. Synthetic transport IDs are generated for compact entries (deterministic from the `(srcPK, rPK, type)` tuple).
+- `dht`: build the graph from the local DHT's `tp` salt entries via `DHTListWithTargets`. Four shapes are supported:
+  - **Bare**: `[]transport.Entry` (the canonical visor-publish format from `TPDAdapter`)
+  - **Signed**: `[]transport.SignedEntry` (legacy; the wrapper is unwrapped)
+  - **Compact-envelope**: `{"s": <source pk>, "ts": [{"r","t","l"}]}` (recommended for size-conscious publishers — explicit source PK plus per-transport rows)
+  - **Compact-array**: `[{"r","t","l"}]` (legacy; source PK is recovered by cross-referencing the storage target hash against the `dmsg` salt's `static` field, since `target = SHA256(pk || salt)` and the same PK is used across both salts)
+  Synthetic transport IDs are generated for compact entries (deterministic from the `(srcPK, rPK, type)` tuple via `transport.MakeTransportID`).
 - `auto`: try DHT first; fall back to TPD if DHT yielded fewer than 10 entries.
 
 ## Configuration

--- a/skywire-specs/specifications/26-DHT.md
+++ b/skywire-specs/specifications/26-DHT.md
@@ -202,6 +202,8 @@ The visor exposes the DHT via `skywire cli visor dht`:
 | `dht list [--salt s] [--with-target]` | Dump local store as JSON. `--with-target` emits `{target, value}` so listings can be diffed against HTTP discoveries | Mainly full nodes — non-full nodes only hold items near their own ID |
 | `dht sync [<full-node-pk>] [--salt s]` | One-shot paginated pull from a remote full node into the local store. Pull-only, no push | All nodes — but most useful for full nodes that want to fast-forward without waiting for the periodic reconcile |
 | `dht full-node <on\|off>` | Toggle storage mode at runtime | Persistent toggle is via the `full_node` config flag |
+| `dht peers` | Dump every K-bucket peer (PK, NodeID, last-seen, bucket index) | All nodes — primary debugging tool for "is the DHT actually connected to anyone?" |
+| `dht reconcile <full-node-pk> [--salt s]` | Manually run a one-shot pull+push reconcile against a specific peer. Restricted to peers in `BootstrapPKs ∪ FindAdvertisedFullNodes` (signed full-node attestation required) | Full nodes — debugging cross-peer divergence or forcing convergence after a config change |
 
 ## Configuration
 

--- a/skywire-specs/specifications/26-DHT.md
+++ b/skywire-specs/specifications/26-DHT.md
@@ -205,6 +205,12 @@ The visor exposes the DHT via `skywire cli visor dht`:
 | `dht peers` | Dump every K-bucket peer (PK, NodeID, last-seen, bucket index) | All nodes — primary debugging tool for "is the DHT actually connected to anyone?" |
 | `dht reconcile <full-node-pk> [--salt s]` | Manually run a one-shot pull+push reconcile against a specific peer. Restricted to peers in `BootstrapPKs ∪ FindAdvertisedFullNodes` (signed full-node attestation required) | Full nodes — debugging cross-peer divergence or forcing convergence after a config change |
 
+`route calc` also gained a `--source tpd|dht|auto` flag (default `tpd`):
+
+- `tpd`: fetch `/all-transports` from the deployment TPD (current behavior).
+- `dht`: build the graph from the local DHT's `tp` salt entries via `DHTGetAll`. Only visor-published bare-entry format contributes — the deployment-pushed compact `[{r,t,l,b}]` format omits the source PK and is filtered out. Useful for diffing DHT coverage against TPD.
+- `auto`: try DHT first; fall back to TPD if DHT yielded fewer than 10 entries.
+
 ## Configuration
 
 ```json

--- a/skywire-specs/specifications/26-DHT.md
+++ b/skywire-specs/specifications/26-DHT.md
@@ -208,7 +208,7 @@ The visor exposes the DHT via `skywire cli visor dht`:
 `route calc` also gained a `--source tpd|dht|auto` flag (default `tpd`):
 
 - `tpd`: fetch `/all-transports` from the deployment TPD (current behavior).
-- `dht`: build the graph from the local DHT's `tp` salt entries via `DHTGetAll`. Only visor-published bare-entry format contributes — the deployment-pushed compact `[{r,t,l,b}]` format omits the source PK and is filtered out. Useful for diffing DHT coverage against TPD.
+- `dht`: build the graph from the local DHT's `tp` salt entries via `DHTListWithTargets`. Three formats are supported: bare `[]transport.Entry` (visor-published), `[]transport.SignedEntry`, and the compact single-letter format `[{r,t,l}]` published by deployment-side mirrors. The compact format omits the source PK in the value, but it's recovered by cross-referencing the storage target hash against the `dmsg` salt's `static` field — every visor that publishes both salts has a known PK→target relationship via `target = SHA256(pk||salt)`. Synthetic transport IDs are generated for compact entries (deterministic from the `(srcPK, rPK, type)` tuple).
 - `auto`: try DHT first; fall back to TPD if DHT yielded fewer than 10 entries.
 
 ## Configuration

--- a/skywire-specs/specifications/26-DHT.md
+++ b/skywire-specs/specifications/26-DHT.md
@@ -1,10 +1,10 @@
 # Kademlia DHT
 
-The Distributed Hash Table (`pkg/dht/`) provides decentralized key-value storage for the Skywire network. It implements Kademlia routing with BEP44 mutable data semantics, adapted for secp256k1 cryptography.
+The Distributed Hash Table (`pkg/dht/`) provides decentralized key-value storage for the Skywire network. It implements Kademlia routing with BEP44 mutable data semantics, adapted for secp256k1 cryptography and an optional "full node" storage model.
 
 ## Purpose
 
-The DHT supplements and will eventually replace centralized discovery services (DMSG discovery, transport discovery, service discovery, address resolver). Every visor with a DMSG client runs a DHT node automatically.
+The DHT supplements and is intended to eventually replace the centralized discovery services (DMSG discovery, transport discovery, service discovery, address resolver). Every visor with a DMSG client runs a DHT node automatically; whether it stores all items network-wide or only items close to its own ID depends on the `full_node` config flag.
 
 ## Node Identity
 
@@ -14,14 +14,14 @@ DHT node IDs are 256-bit values derived from the visor's secp256k1 public key:
 NodeID = SHA256(compressed_secp256k1_pubkey)
 ```
 
-This deterministically maps each visor's existing identity to a position in the DHT address space. No separate key generation is required.
+This deterministically maps each visor's existing identity to a position in the DHT address space. No separate key generation is required — the DHT node and the visor share an identity.
 
 ## Routing Table
 
-The routing table consists of 256 k-buckets (one per bit of the 256-bit ID space), each holding up to k=20 peers. Peers are ordered by last-seen time within each bucket. The bucket index for a peer is determined by the common prefix length of `XOR(self_id, peer_id)`.
+The routing table consists of 256 k-buckets (one per bit of the 256-bit ID space), each holding up to **K = 20** peers. Peers are ordered by last-seen time within each bucket. The bucket index for a peer is determined by the common prefix length of `XOR(self_id, peer_id)`.
 
 When a bucket is full and a new peer is discovered:
-- If the least-recently-seen peer responds to a ping, the new peer is discarded (prefer long-lived nodes)
+- If the least-recently-seen peer responds to a ping, the new peer is discarded (prefer long-lived nodes — Kademlia's standard "old peer wins" heuristic)
 - If the least-recently-seen peer does not respond, it is evicted and the new peer is added
 
 ## Mutable Items
@@ -33,12 +33,14 @@ Items are signed, updateable records stored in the DHT. Each item has:
 | `K` | `cipher.PubKey` (33 bytes) | Publisher's secp256k1 public key |
 | `Seq` | `uint64` | Monotonically increasing sequence number |
 | `Sig` | `cipher.Sig` (65 bytes) | secp256k1 signature over the canonical payload |
-| `V` | `[]byte` (max 16384 bytes) | Value |
-| `Salt` | `[]byte` (max 200 bytes) | Optional namespace for key disambiguation |
+| `V` | `[]byte` | Value (max **65 536 bytes** — see `pkg/dht/item.go`) |
+| `Salt` | `[]byte` | Optional namespace (max 200 bytes) |
+
+The 64 KB `V` cap was raised from the BEP44 default of 1 000 bytes to accommodate hub-edge transport lists: a visor with 800+ transports needs ~80 bytes per compact entry, which exceeded the original 16 KB cap silently. Skywire's DHT runs over DMSG streams (TCP-framed), so UDP fragmentation isn't a concern.
 
 ### Target Key
 
-Items are stored at DHT nodes closest (by XOR distance) to their target key:
+Items are stored at DHT nodes whose IDs are closest (by XOR distance) to their target key:
 
 ```
 Target = SHA256(K || Salt)
@@ -49,24 +51,29 @@ Target = SHA256(K || Salt)
 The signature covers a canonical payload with length-prefixed fields to prevent concatenation ambiguity:
 
 ```
-payload = seq (8 bytes BE) || len(V) (4 bytes BE) || V || len(Salt) (4 bytes BE) || Salt
+payload   = seq (8 bytes BE) || len(V) (4 bytes BE) || V || len(Salt) (4 bytes BE) || Salt
 signature = secp256k1_sign(SHA256(payload), secret_key)
 ```
 
 ### Monotonic Sequence
 
-Storing nodes reject puts where `item.Seq <= stored.Seq`. Only the owner (holder of the secret key) can increment the sequence and publish updates.
+Storing nodes reject puts where `item.Seq <= stored.Seq` (`pkg/dht/store.go:Put`). Only the owner (holder of the secret key) can increment the sequence and publish updates. A monotonic clock (`time.Now().UnixNano()`) is the canonical seq generator — guarantees climbing past any cached previous publish even after restart.
 
 ### TTL and Expiry
 
-- Public items expire after 2 hours without re-announcement
-- Whitelisted and trusted items never expire via TTL
-- Publishers re-announce every 60 seconds (visor's `dhtPublishLoop`)
-- Items can also be refreshed by any node that holds a copy (re-push without the private key, using the existing signature)
+| Tier | Eviction | TTL Expiry | Rate Limit |
+|---|---|---|---|
+| **Whitelisted** | Never evicted | No TTL | Bypassed |
+| **Trusted** | Never evicted | No TTL | Bypassed |
+| **Public** | LRU eviction when pool exceeds `PublicPoolSize` (default 5 000) | `ItemTTL` (default 2 h) | Max `RateLimitPerPK` items per PK (default 50) |
+
+Trust classification is dynamic — changes to the trust policy take effect immediately on all stored items.
+
+Publishers re-announce every 60 seconds (visor's `dhtPublishLoop`). Items can also be refreshed by any node that holds a copy (re-push without the private key, using the existing signature).
 
 ## RPC Protocol
 
-DHT nodes communicate via length-prefixed JSON messages over DMSG streams (port 100). Each message has a 5-byte header:
+DHT nodes communicate via length-prefixed JSON messages over DMSG streams (port **100**, `skyenv.DmsgDHTPort`). Each message has a 5-byte header:
 
 ```
 | length (4 bytes BE) | method (1 byte) | JSON payload |
@@ -80,48 +87,82 @@ Methods:
 | FindNode | 2 | `{sender_id, sender_pk, target}` | `{closest: [Peer]}` |
 | GetValue | 3 | `{sender_id, sender_pk, target}` | `{item?, closest: [Peer]}` |
 | PutValue | 4 | `{sender_id, sender_pk, item, mirror_target?}` | `{stored, error?}` |
+| GetItems | 5 | `{sender_id, sender_pk, salt?, since_seq?, limit?}` | `{items, targets, has_more}` |
+| PutBatch | 6 | `{sender_id, sender_pk, items[], targets[]}` | `{stored[], errors?[]}` |
 
-Per-RPC timeout: 10 seconds. Maximum message size: 64 KB.
+Per-RPC timeout: 10 seconds. Maximum message size: **4 MiB** (`readMsg` in `pkg/dht/rpc.go`).
 
-The `mirror_target` field in PutValue allows deployment services to store items under a target key derived from a different PK (used for mirroring entries from visors that don't dual-write to the DHT).
+### Mirror puts
+
+The `mirror_target` field on `PutValue` (and the parallel `targets` field on `PutBatch`) lets a sender store an item under a target key derived from a different PK than the item's signer. Used by deployment services to mirror entries received via legacy HTTP discovery into the DHT — the item's own application-level signature provides authenticity, the DHT layer just distributes.
+
+Receiver-side `PutMirror` handlers do **not** check XOR distance or full-node admission. Senders are therefore expected to push only to peers that have explicitly opted in to receiving mirror puts: bootstrap PKs (configured) and peers with a fresh `FullNodeAdvert` (signed self-attestation). See **Reconcile** below.
+
+### GetItems pagination
+
+`GetItems` returns up to `limit` items (server-side default 1 000) sorted by `Seq` ascending, with `target` as a stable tiebreaker. The response carries `has_more=true` when more items exist beyond the batch boundary.
+
+Callers paginate with a `since_seq` cursor: each batch advances the cursor to the highest `Seq` seen so far. Batches do not split a `Seq` tie across boundaries — the server extends a batch past `limit` to swallow all items at the boundary `Seq`, so the cursor is always safe to advance to that value without skipping ties.
 
 ## Iterative Lookup
 
-Lookups follow standard Kademlia with alpha=3 concurrency:
+Lookups follow standard Kademlia with **alpha = 3** concurrency:
 
 1. Seed the shortlist with the K closest peers from the local routing table
-2. In parallel (up to alpha=3), query the closest unqueried peers via FindNode or GetValue
-3. Merge returned peers into the shortlist (verify `peer.ID == SHA256(peer.PK)` to prevent poisoning)
+2. In parallel (up to `Alpha=3`), query the closest unqueried peers via `FindNode` (or `GetValue` for value lookups)
+3. Merge returned peers into the shortlist (verify `peer.ID == SHA256(peer.PK)` to prevent ID poisoning)
 4. Sort by XOR distance, trim to K
 5. Repeat until all K closest have been queried
-6. For value lookups, track the highest-sequence item across all responses
-
-## Trust Tiers
-
-The store classifies items by publisher PK:
-
-| Tier | Eviction | TTL Expiry | Rate Limit |
-|---|---|---|---|
-| **Whitelisted** | Never evicted | No TTL | Bypassed |
-| **Trusted** | Never evicted | No TTL | Bypassed |
-| **Public** | LRU eviction when pool exceeds capacity | 2 hours | Max 50 items per PK |
-
-Trust classification is dynamic — changes to the trust policy take effect immediately on all stored items.
+6. For value lookups, track the highest-`Seq` item across all responses
 
 ## Full Node Mode
 
-A full node stores all items regardless of XOR distance to its own ID. Normal nodes only store items close to their ID (standard Kademlia behavior). Deployment services run as full nodes to ensure complete data availability for bootstrap.
+A **full node** stores all items regardless of XOR distance to its own ID. **Normal nodes** only store items close to their ID (standard Kademlia behavior, capped at `MaxItems`).
+
+Deployment DMSG servers run as full nodes by configuration so the network has reliable bulk-data sources. Visor full nodes are opt-in (`dht.full_node = true` in `skywire-config.json`).
 
 Full node mode can be toggled at runtime: `skywire cli visor dht full-node on|off`.
+
+### Full-node bootstrap and reconcile
+
+A node that only accepts items via passive `PutValue` accumulates data slowly: most Puts only reach K-closest peers, so even a full node sees only a fraction of network-wide writes. To converge, full nodes run an active **reconcile loop** (`pkg/dht/dht.go:fullNodePullLoop`):
+
+- **At startup** (after a 5-second bootstrap warmup), iterate the merged set of `BootstrapPKs` ∪ peer-advertised full nodes (see below)
+- **Per peer**: `Reconcile = pull + push-back`
+  - **Pull**: paginated `GetItems` with empty salt, mirroring received items into the local store via `PutMirror`. Records the set of received target keys.
+  - **Push**: paginate the local store; for each item with a target key NOT in the peer's pulled set, batch-push via `PutBatch`. Cross-pollinates items the peer was missing.
+- **Periodic re-run**: every 1 hour. Per-peer timeout 5 minutes.
+
+Convergence guarantee: after one reconcile pass against every other full node, the local store holds the union; after the *peers* run their own pass, all full nodes hold the same union.
+
+### Full-node advertisement
+
+Full nodes publish a signed `FullNodeAdvert` to salt `"fullnode"` every 5 minutes (`pkg/dht/fullnode_advert.go:AdvertiseFullNode`):
+
+```json
+{
+  "pk": "<pubkey hex>",
+  "stored_items": 3562,
+  "full_node": true,
+  "ts": 1777551386053786094
+}
+```
+
+`FindAdvertisedFullNodes` returns the set of advertised PKs with a fresh `ts` (≤30 minutes old, allowing 5 missed publishes). The reconcile loop unions these with `BootstrapPKs` so full-node coverage discovers itself rather than depending on a static config.
+
+Pushing to an advertised peer is safe because the signed advert is the peer's explicit declaration that it accepts mirror puts. Random routing-table peers that haven't advertised are excluded.
 
 ## Bootstrap
 
 On startup, the DHT node:
 
-1. Pings each bootstrap peer to populate the routing table
+1. Pings each `BootstrapPKs` peer to populate the routing table (`bootstrapLoop`)
 2. Performs an iterative self-lookup (`FindNode(self_id)`) to discover nearby peers
+3. **Full nodes only:** after a 5-second warmup, kicks off the reconcile loop above
 
-Default bootstrap peers are the deployment service PKs (extracted from the visor's config). No additional configuration is needed.
+Default bootstrap peers are the deployment DMSG-server PKs (extracted from `dmsg.Prod.DmsgServers` via `deployment.Services.DHTBootstrapPKs()`). DMSG servers run DHT full nodes themselves on port 100, gated by the dmsg-server config flag `enable_dht`.
+
+Bootstrap retries: every 30 seconds while no peers are in the routing table, slowing to every 5 minutes once at least one is.
 
 ## Discovery Adapters
 
@@ -129,18 +170,38 @@ The DHT provides adapter types that implement the same interfaces as the central
 
 | Adapter | Interface | Salt | Description |
 |---|---|---|---|
-| `DiscAdapter` | `disc.APIClient` | `dmsg` | DMSG discovery entries |
-| `TPDAdapter` | `transport.DiscoveryClient` | `tp` | Transport entries: `[{r: remote_pk, t: type, l: latency_ms, b: cumulative_bw_bytes}]` (live snapshot only; daily history lives in the visor's CXO feed) |
-| `SvcAdapter` | — | `svc:<type>` | Service records |
+| `DiscAdapter` | `disc.APIClient` | `dmsg` | DMSG discovery entries (each visor publishes its `disc.Entry` under its own PK) |
+| `TPDAdapter` | `transport.DiscoveryClient` | `tp` | Transport entries — compact format `[{r: remote_pk, t: type, l: latency_ms, b: cumulative_bw_bytes}]`. Live snapshot only; daily history lives in the visor's CXO feed. |
+| `SvcAdapter` | — | `svc` | Service records (a list of `servicedisc.Service` under each visor PK) |
 | `AddrAdapter` | — | `addr` | Address resolver records |
 
-`HybridDiscClient` and `HybridTPDClient` wrap a DHT adapter with an HTTP fallback: reads try DHT first, writes go to both.
+`HybridDiscClient` and `HybridTPDClient` (`pkg/dht/disc_hybrid.go`) wrap a DHT adapter with an HTTP fallback: reads try DHT first, fall back to HTTP on miss; writes go to both. Wired into the visor by `initDHT` (DMSG hybrid) and `initDHTTransport` (TPD hybrid). The visor's autoconnect path (`pkg/visor/autoconnect.go:fetchPubAddresses`) reads the `svc` salt directly.
 
 ## Entry Mirroring
 
-Deployment services run DHT full nodes and mirror entries received via HTTP to the DHT. This ensures entries from old visors (that don't dual-write) are available in the DHT.
+Deployment services (DMSG discovery, TPD, SD) mirror HTTP-received entries into the DHT so entries from old visors that don't dual-write are still available to DHT readers. The mirror signs the DHT item with the *service's* own key but stores it under the visor's target key (`SHA256(visor_pk || salt)`) using the `mirror_target` field. The entry's own application-level signature (e.g., `disc.Entry.Signature`) provides authenticity proof; the DHT signature provides distribution authenticity.
 
-The mirror signs the DHT item with the service's own key but stores it under the visor's target key (`SHA256(visor_pk || salt)`) using `PutMirror` which allows the signer PK to differ from the target PK. The entry's own application-level signature (e.g., `disc.Entry.Signature`) provides authenticity proof.
+## Persistence
+
+The store can be backed by:
+- **Memory only** — default for short-lived clients (CLI, tests)
+- **bbolt** (`pkg/dht/backend_bolt.go`) — single-file embedded DB. Default for visors when `dht.persist_path` is set; visor auto-defaults to `<local_path>/dht.db`.
+- **Redis** (`pkg/dht/backend_redis.go`) — for deployment services that need shared-state across replicas. Selected when `dht.redis_addr` is set.
+
+Backend precedence: `RedisAddr` → `PersistPath` → in-memory.
+
+## CLI
+
+The visor exposes the DHT via `skywire cli visor dht`:
+
+| Command | Purpose | Useful with |
+|---|---|---|
+| `dht status` | Node ID, peer count, store size, full-node flag, lookup hit/miss counts | All nodes |
+| `dht get <pk> [salt]` | Iterative `GetValue` for a target | All nodes |
+| `dht put <value> [salt] --seq N` | Publish under this visor's key | All nodes |
+| `dht list [--salt s] [--with-target]` | Dump local store as JSON. `--with-target` emits `{target, value}` so listings can be diffed against HTTP discoveries | Mainly full nodes — non-full nodes only hold items near their own ID |
+| `dht sync [<full-node-pk>] [--salt s]` | One-shot paginated pull from a remote full node into the local store. Pull-only, no push | All nodes — but most useful for full nodes that want to fast-forward without waiting for the periodic reconcile |
+| `dht full-node <on\|off>` | Toggle storage mode at runtime | Persistent toggle is via the `full_node` config flag |
 
 ## Configuration
 
@@ -148,11 +209,18 @@ The mirror signs the DHT item with the service's own key but stores it under the
 {
   "dht": {
     "full_node": false,
+    "persist_path": "local/dht.db",
+    "redis_addr": "",
     "bootstrap_pks": [],
     "whitelisted_pks": [],
-    "trusted_pks": []
+    "trusted_pks": [],
+    "max_items": 0,
+    "item_ttl": 0,
+    "refresh_interval": 0,
+    "public_pool_size": 0,
+    "rate_limit_per_pk": 0
   }
 }
 ```
 
-All fields are optional. DHT is enabled automatically when DMSG is available. If `bootstrap_pks` is empty, deployment service PKs are used.
+All fields are optional. DHT is enabled automatically when DMSG is available. If `bootstrap_pks` is empty, deployment DMSG-server PKs are used. Zero-valued limits fall back to the defaults shown in the **TTL and Expiry** table.

--- a/skywire-specs/specifications/SKYWIRE_DHT.md
+++ b/skywire-specs/specifications/SKYWIRE_DHT.md
@@ -1,0 +1,212 @@
+# SKYWIRE_DHT.md
+
+A comparison of Skywire's DHT (`pkg/dht/`) with prior-art Kademlia and DHT-adjacent designs, plus a discussion of where Skywire diverges, why, and what tradeoffs result.
+
+The companion document [26-DHT.md](./26-DHT.md) is the normative specification. This document is descriptive: it explains design choices in context.
+
+## Capsule summary
+
+| Property | Skywire DHT |
+|---|---|
+| Lineage | Kademlia (BEP44 mutable items, secp256k1 instead of ed25519) |
+| Bucket size K | 20 |
+| Lookup parallelism α | 3 |
+| Identity | Visor's secp256k1 pubkey → `SHA256(pubkey)` for the 256-bit node ID |
+| Transport | DMSG streams (port 100), TCP-framed; falls back to skywire transports via `extraTransports` |
+| Wire encoding | JSON (length-prefixed, 5-byte header) |
+| Item value cap | 64 KiB |
+| RPC max message | 4 MiB |
+| Storage tiers | Whitelisted (no eviction, no TTL), Trusted (same), Public (LRU + 2 h TTL + 50/PK rate limit) |
+| Full-node mode | Yes — opt-in storage of every item regardless of XOR distance |
+| Active reconciliation | Hourly bidirectional pull + push between full nodes |
+| Persistence | Memory, bbolt, or Redis |
+| Discovery role | Mirrors and (eventually) replaces HTTP DMSG-discovery, transport-discovery, service-discovery, address-resolver |
+
+## Lineage and inspirations
+
+Kademlia (Maymounkov & Mazières, 2002) is the trunk. The two specs Skywire borrows the most from:
+
+- **BitTorrent BEP5** (Kademlia DHT for peer exchange) — XOR routing, K-buckets, iterative `find_node` / `find_value`, refresh on activity. Skywire copies all of this with minor parameter tweaks.
+- **BitTorrent BEP44** (mutable / immutable items) — signed value items keyed by `SHA1(pk + salt)`, monotonic `seq`, owner-only writes via signature check, optional CAS. Skywire copies the *semantics* but swaps the crypto to match the rest of the network.
+
+Other comparable systems referenced below: **libp2p Kademlia** (IPFS), **Ethereum Discovery v5 (discv5)**, and **Tor onion service descriptors**, the latter being an interesting non-Kademlia design point.
+
+## Side-by-side comparison
+
+### Identity
+
+| | Skywire | BitTorrent BEP5 | libp2p Kademlia | Ethereum discv5 | Tor onion v3 |
+|---|---|---|---|---|---|
+| Hash | SHA-256 | SHA-1 | SHA-256 (over multihash) | Keccak-256 | SHA3-256 |
+| ID space | 256 bits | 160 bits | 256 bits | 256 bits | 256 bits |
+| Signature scheme | secp256k1 (compressed 33 B pubkey, 65 B sig) | None on node ID; BEP44 uses ed25519 | varies (RSA, secp256k1, Ed25519, ECDSA) | secp256k1 | Ed25519 |
+
+**Why secp256k1?** Every Skywire visor *already* has a secp256k1 keypair (used for noise sessions, transport entries, app signatures). Re-using that key as the DHT identity means there's nothing new to provision and the DHT identity ties to the visor identity automatically. BitTorrent BEP44 chose ed25519 in 2014 because it was faster and library-supported; Skywire pays a small CPU tax (`secp256k1` verify is 5–10× slower than ed25519) in exchange for one keystore instead of two.
+
+### Routing table
+
+| | Skywire | BEP5 | libp2p | discv5 |
+|---|---|---|---|---|
+| K (bucket size) | 20 | 8 | 20 | 16 |
+| Number of buckets | 256 | 160 | 256 | 256 |
+| Stale eviction | LRU eviction with ping | LRU + ping | LRU + ping (configurable) | Liveness checked on use |
+| α (lookup parallelism) | 3 | 3 | 3 | 3 |
+
+K = 20 is the original Kademlia paper's default and matches libp2p. BEP5's K = 8 is a BitTorrent-specific choice for the smaller 160-bit space. Nothing surprising here.
+
+### Item model
+
+| | Skywire | BEP44 (BitTorrent) | libp2p (IPNS records) | Tor onion descriptors |
+|---|---|---|---|---|
+| Mutable | Yes | Yes (mutable variant) | Yes (versioned) | Yes (revision number) |
+| Owner-keyed | Yes (signer == publisher PK) | Yes | Yes | Yes |
+| Multi-publisher per key | No (`SHA256(pk \|\| salt)` derives target) | No | No | No |
+| Salt namespace | Yes (`pkg/dht/item.go`) | Yes (BEP44 §`salt` field) | Implicit (record type prefix) | N/A |
+| Signature canonical form | `seq \|\| len(V) \|\| V \|\| len(salt) \|\| salt` | Bencoded `3:seq...1:v...4:salt...` | Protobuf-encoded fields | TLV with explicit lengths |
+| Value cap | 64 KiB | 1 000 B | ~10 KiB recommended | ~50 KiB |
+| Sequence semantics | Monotonic (`seq > stored.seq`) | Monotonic | Monotonic | Monotonic |
+
+**Why 64 KiB and not 1 KB?** BEP44's 1 000-byte cap exists because BitTorrent DHT runs over UDP and that's the largest fragment-free packet on most networks. Skywire DHT runs over **DMSG streams** — TCP-framed — so there is no fragmentation concern. The cap was raised from the historical 16 KiB to 64 KiB after observing hub-edge transport lists silently truncating: a visor with 800+ transports needs ~80 bytes per compact entry, exceeding 16 KiB at ~200 entries. The cost is bandwidth on each Put and storage per item, both bounded.
+
+**Why a length-prefixed signature payload?** The vulnerability without it: if the canonical form is `seq || V || salt`, then a value `V'` and salt `salt'` exist such that `V' || salt' = V || salt` for different `V`/`salt` splits — the signature would verify on the wrong split. Length-prefixing each field removes that ambiguity. BEP44 uses bencoded field names (`3:seq...1:v...`), which is also unambiguous but more verbose. Length-prefixed binary is what discv5 uses too.
+
+### Storage tiers
+
+This is Skywire's biggest divergence from Kademlia tradition.
+
+Kademlia, as published, has **one storage class**: each node stores items whose target is among the K closest to its ID, evicting on TTL. BEP44 keeps that. libp2p and discv5 keep that.
+
+Skywire adds:
+
+| Tier | Eviction | TTL | Rate limit | Use case |
+|---|---|---|---|---|
+| Whitelisted | Never | Never | Bypassed | Hardcoded deployment-critical PKs (e.g., the transport setup nodes' identities) |
+| Trusted | Never | Never | Bypassed | Known-good operator PKs |
+| Public | LRU when pool > 5 000 | 2 h | 50 items per PK | Everyone else |
+
+**Why?** The published Kademlia trust model is "all peers equal" — fine for an open network where anyone can publish anything. Skywire is trying to bootstrap a network where deployment services need *guaranteed* presence (their entries must never be evicted by churn) while remaining open to arbitrary visor publishes (which need rate limits to prevent flooding). The three tiers carve out those distinct cases. The trust policy is dynamic: changing it re-classifies stored items immediately.
+
+The closest analog is **discv5's "ENRs" with topic advertising**, where high-prestige topics get dedicated routing-table slots, but the mechanism is quite different.
+
+### Transport and encoding
+
+| | Skywire | BEP5/BEP44 | libp2p | discv5 |
+|---|---|---|---|---|
+| Transport | DMSG (TCP-over-relay), optional skywire transports | UDP (with retransmits) | TCP/QUIC streams | UDP |
+| Wire encoding | JSON | Bencode | Protobuf | RLP |
+| Per-RPC timeout | 10 s | ~5 s | ~10 s (libp2p Stream timeout) | 0.5 s |
+| Max message | 4 MiB | ~1300 B (UDP MTU) | 64 MiB | ~1280 B (UDP MTU) |
+
+**Why DMSG and not direct UDP?** Skywire visors are mostly behind NATs without UPnP. DMSG is the network's relay-of-last-resort: every visor has a session to several DMSG servers, every other visor can be reached via those servers. Running the DHT on top of DMSG inherits that reachability for free. The cost is a hop through the DMSG server, but DHT operations are not latency-critical.
+
+**Why JSON and not a binary encoding?** Operational debuggability. JSON is easy to dump, diff, and pretty-print from CLI tools; protobuf/bencode require a schema-aware decoder. The wire is bigger but DHT message volume is small. If we ever wanted, switching the encoding is local to `pkg/dht/rpc.go` (writeMsg/readMsg).
+
+### Eclipse / Sybil resistance
+
+Kademlia is famously vulnerable to two attacks:
+
+1. **Eclipse**: an attacker fills the K-closest peers around a target, controlling all reads/writes to that target.
+2. **Sybil**: an attacker spawns many cheap identities to skew routing-table content network-wide.
+
+Mitigations across implementations:
+
+| | Skywire | BEP5 | libp2p | discv5 |
+|---|---|---|---|---|
+| ID = `H(PK)` (binds ID to crypto identity) | ✓ | ✗ (random ID) | ✓ | ✓ |
+| Ping verification on bucket update | ✓ | ✓ | ✓ | ✓ |
+| Signed items (only owner can update) | ✓ (BEP44-style) | mutable items only | ✓ (IPNS) | ✗ (records, not values) |
+| Static peer ID over IP changes | ✓ (PK is independent of address) | ✓ | ✓ | ✓ (ENR sequence) |
+| Multi-publisher reads (find K, take highest seq) | ✓ | ✓ | ✓ | N/A |
+| Trust tiers (whitelisted/trusted overrides) | ✓ — only Skywire | ✗ | ✗ | ✗ |
+
+Skywire's `ID = SHA256(PK)` binding means an attacker can't pick which buckets they land in cheaply: forging a near-target ID means brute-forcing keys until `SHA256(pk)` is close enough, which is bounded by hash difficulty. BEP5's random IDs make this attack trivial; that's why BEP5 swarms saw real eclipses in 2017.
+
+The **trust tier** mechanism is Skywire's belt-and-suspenders: even if an eclipse succeeds for a public-tier item, whitelisted/trusted entries remain available because they bypass the public pool's eviction.
+
+### Bootstrapping and reconciliation
+
+This is where Skywire diverges most heavily from Kademlia tradition.
+
+**Standard Kademlia bootstrap:**
+1. Ping a few well-known seed nodes
+2. Iterative `find_node(self_id)` to populate buckets
+3. Drift into steady-state, accumulating values via passive `store` requests for keys near our ID
+
+That's what BEP5 and libp2p do. Skywire does this too — but only for the routing table.
+
+**Skywire full-node bootstrap (added):**
+4. Iterate the merged set of `BootstrapPKs` (deployment full nodes) ∪ peers with a fresh `FullNodeAdvert` (other visor full nodes)
+5. Per peer: `Reconcile = pull (paginated GetItems) + push (PutBatch of items the peer doesn't have)`
+6. Re-run hourly
+
+Why standard Kademlia isn't enough for Skywire:
+
+- BEP44 was designed for sparse mutable data (one record per torrent, a few thousand torrents). Skywire DHT mirrors the full transport-discovery dataset (3 800+ entries today, growing) and full DMSG-discovery dataset (1 400+). Passive accumulation through Puts hitting the K-closest converges far too slowly for this.
+- Eventually-consistent passive replication breaks for "partial" full nodes: a node that has 30% of items and a peer that has 30% of items will both stay at 30% indefinitely if they only ever write near their own IDs. Skywire's reconcile is the only way the union materialises.
+
+The **`FullNodeAdvert` salt** (`"fullnode"`) is novel: it's a self-attestation that says "I accept the responsibility of storing arbitrary mirror puts." Pushing to a peer without this advert is unsafe (the receiver-side `PutMirror` is unconditional). Discovery via the advert lets the network grow new full nodes without redeploying every existing one's `BootstrapPKs` config.
+
+The closest comparable design point is **OrbitDB's "anchor peers"** in IPFS — designated replicators that pin the full dataset — but those require manual pinning and don't auto-discover each other.
+
+### Discovery service replacement
+
+A unique feature: Skywire's DHT is not just a key-value store, it's a *strategy* for replacing four centralized HTTP services (DMSG-discovery, TPD, SD, address-resolver). Each maps to a salt:
+
+| Salt | Subject (target derivation) | Value | Replaces |
+|---|---|---|---|
+| `dmsg` | Visor PK | `disc.Entry` (DMSG addr, delegated servers) | http://dmsgd.skywire.skycoin.com |
+| `tp` | Visor PK | List of compact transport entries from this visor | http://tpd.skywire.skycoin.com |
+| `svc` | Visor PK | List of `servicedisc.Service` for this visor | http://sd.skycoin.com |
+| `addr` | Visor PK | Address resolver record | http://ar.skywire.skycoin.com |
+| `fullnode` | Full-node PK | Self-attestation (see above) | — (new) |
+| `dmsg-server` | DMSG server PK | Server entry (addr, max sessions, peers) | (auxiliary) |
+
+Each of these has a write-side (the `*Adapter` types) and a read-side. The `*Hybrid*Client` wrappers (`pkg/dht/disc_hybrid.go`) provide DHT-first reads with HTTP fallback, so the DHT can have partial coverage during rollout without breaking anything. This pattern is very much a Skywire-specific design — it's the "incremental decentralization" plan, where the centralized service runs as a DHT mirror itself, and as more visors publish to DHT directly, the central one becomes redundant.
+
+No comparable system has this exact pattern. The closest parallels:
+
+- **IPFS** has IPNS for mutable records, but it's not a hybrid migration off centralized DNS — it's a parallel namespace.
+- **Mainline DHT** for BitTorrent supplements trackers without trying to replace tracker URLs.
+- **Tor's HSDir** *did* replace the v2 onion-service "introduction point" centralized lookup with v3's distributed `HSDir` ring, which is the closest architectural analog. v3 took ~5 years to fully roll out; Skywire is roughly mid-way through the equivalent transition.
+
+### What Skywire's DHT does *not* do (vs. peers)
+
+- **No CAS / compare-and-swap**: BEP44 lets writers attach a `cas` of the previous `seq` to detect concurrent updates. Skywire's monotonic-seq check is weaker — two publishes with seq+1 race, last write wins. Adding CAS would be ~10 lines.
+- **No iterative-write fallback**: when a Put can't reach K-closest, Skywire stores locally and logs a warning. BEP44 retries on a slowly-widening peer set. Skywire's full-node reconcile makes this less critical — the next reconcile pass will propagate.
+- **No "republish on receive"** (Kademlia's classic durability mechanism): when a node receives a value, it does not push it onward. Re-publish is owner-driven only. Skywire trades republish-amplification for the more deterministic full-node reconcile.
+- **No DHT-level rate limiting per IP**: only per-PK, since the DHT operates above noise-encrypted DMSG streams where IP isn't directly visible. This is in line with the Skywire philosophy of "PK is the identity, IP is incidental."
+- **No XOR-distance based item routing for Puts in full-node mode**: a full node accepts any Put-target combination, not just close ones. This is intentional (full nodes are sinks by design) but means an attacker with one full-node-trusted relationship can spam an unbounded number of items there. Public-tier rate limit (50 items per PK) is the only defence against that today.
+
+## Implementation footprint
+
+For reference, comparing roughly the lines of code in each codebase's DHT implementation:
+
+| Project | DHT LoC (approx) |
+|---|---|
+| BitTorrent libtorrent DHT (`src/kademlia/`) | ~10 000 (C++) |
+| go-libp2p-kad-dht | ~12 000 (Go) |
+| ethereum/go-ethereum/p2p/discover | ~6 500 (Go) |
+| Skywire `pkg/dht/` | ~4 000 (Go, including adapters and bbolt/redis backends) |
+
+Skywire's implementation is small because it intentionally does not try to handle hostile peers in an open network — it runs over DMSG, where a noise-authenticated session is required to even reach the DHT port, and the trust tier mechanism handles operator-level abuse rather than wire-level adversaries.
+
+## Where the implementation is still rough
+
+This is an honest list, not a roadmap.
+
+1. **Full-node-to-full-node reconciliation is hourly and unidirectional per pass**. After the user-side puts an item that lands on full node A, full node B sees it the next hour at the earliest. Should be sub-minute for "live" data.
+2. **The receiver-side `PutMirror` admission is unconditional**. Pushed to a non-full-node, the receiver overflows its store. Fixed today by gating senders to bootstrap+advertised peers; if the gate ever leaks, no second line of defence.
+3. **CLI exposes the store but not the routing table**. There's no `skywire cli visor dht peers` to dump the K-buckets — debugging routing problems requires log-grepping.
+4. **The hybrid clients log "DHT miss → HTTP" at debug**. Operators don't have a hit-rate metric to know if the DHT is paying for itself.
+5. **No DHT-side metrics export** at all. Should plug into the visor's existing Prometheus surface.
+6. **`MaxValueSize = 64 KiB` is a single global cap**. A future need for larger payloads (e.g., transport history) requires either chunking or a new design.
+7. **The `dht.svc` salt has had multiple data-format mistakes** (single object vs. list of services). The autoconnect path handles both for compatibility, but every other reader needs to too.
+
+## See also
+
+- [26-DHT.md](./26-DHT.md) — normative specification
+- [21-Service_Discovery.md](./21-Service_Discovery.md), [04-Transport_Discovery.md](./04-Transport_Discovery.md), [05-Messaging_System.md](./05-Messaging_System.md), [20-Address_Resolver.md](./20-Address_Resolver.md) — the centralized services the DHT is replacing
+- BEP44 — http://www.bittorrent.org/beps/bep_0044.html
+- Kademlia paper — https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
+- discv5 spec — https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md
+- Tor v3 onion service spec — https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt


### PR DESCRIPTION
## Summary

Audit, documentation, and CLI-surface follow-ups to PR #2397's DHT work.

- Updates **\`26-DHT.md\`** to match the implementation after #2397: 64 KiB MaxValueSize, methodGetItems/methodPutBatch RPCs, GetItems pagination, full-node reconcile loop, FullNodeAdvert, persistence backends, the CLI table, default config values.
- New **\`SKYWIRE_DHT.md\`** descriptive companion: side-by-side comparison with BitTorrent BEP5/BEP44, libp2p Kademlia, Ethereum discv5, and Tor v3 onion descriptors. Explains *why* Skywire diverges from textbook Kademlia (secp256k1 reuse, trust tiers, full-node mode, active reconcile, hybrid HTTP fallback). Honest list of what the implementation does NOT do and what's still rough.
- New CLI subcommand **\`skywire cli visor dht peers\`** — dumps every K-bucket peer with bucket index and last-seen. Primary debug tool for "is the DHT actually connected to anyone?" that \`dht status\` (only shows count) couldn't answer.
- New CLI subcommand **\`skywire cli visor dht reconcile <full-node-pk>\`** — manually triggers one pull+push pass against a specific peer. Restricted to peers in \`BootstrapPKs ∪ FindAdvertisedFullNodes\` (signed full-node attestation required) because receiver-side \`PutMirror\` doesn't gate on distance/admission.
- New flag **\`route calc --source tpd|dht|auto\`** (default \`tpd\`) — lets the user build the route graph from the local DHT's \`tp\` salt instead of fetching TPD HTTP. Only the bare-entry format contributes; the deployment-pushed compact \`[{r,t,l,b}]\` format is filtered out (no source PK).

## Why

The audit task surfaced two gaps:

1. **Documentation drift.** \`26-DHT.md\` predates several PR #2397 features (pagination, reconcile, advertised full-node discovery, batch RPC). Without updates it would mislead anyone implementing a Skywire-compatible DHT or interpreting log/RPC output.

2. **CLI debugging surface is thin.** With pagination, reconcile, and full-node convergence merged, operators want to inspect what's actually in the routing table, force a reconcile to test a fix, and compare DHT-derived data against centralized TPD without writing one-off Go tools.

## Verified live

- \`dht peers\` returned 18 entries across multiple bucket indexes
- \`dht reconcile <bootstrap-pk> --salt tp\` pulled 1120 \`tp\` items in one synchronous pass
- \`dht reconcile <random-visor-pk>\` rejected with "not a known full node (not in bootstrap config and no fresh fullnode advert)"
- \`route calc <pk> --source dht --max 4 -c 0\` returned 878 routes; \`--source tpd\` returned 4828 (DHT covers ~18% of network transports today, reflecting incremental rollout of dual-publishing visors)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`dht peers\` output is sorted by bucket then last-seen (newest first)
- [x] \`dht reconcile\` rejects untrusted PKs before any dial
- [x] \`route calc --source dht\` returns routes from local DHT only; \`--source tpd\` matches prior behavior; \`--source auto\` falls back to TPD when DHT has < 10 entries