### PR TITLE
fix(sudph): nil-guard Dial when listen() failed

### DIFF
--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -176,21 +176,21 @@ var summaryCmd = &cobra.Command{
 			summary.Overview.BuildInfo.Version, summary.ConfigVersion, summary.Health.ServicesHealth, summary.Uptime, summary.BuildTag)
 
 		outputJSON := struct {
-			PublicKey      string                     `json:"public_key"`
-			IsSymmetricNAT bool                       `json:"symmetric_nat"`
-			LocalIP        string                     `json:"local_ip"`
-			PublicIP       string                     `json:"public_ip"`
-			CountryCode    string                     `json:"country_code,omitempty"`
-			RegionName     string                     `json:"region_name,omitempty"`
-			CityName       string                     `json:"city_name,omitempty"`
-			DMSGServers    []visor.DMSGServerInfo     `json:"dmsg_servers"`
-			DmsgLatency    string                     `json:"dmsg_latency"`
-			VisorVersion   string                     `json:"visor_version"`
-			ConfigVersion  string                     `json:"config_version"`
-			UptimeTracker  string                     `json:"uptime_tracker"`
-			TimeOnline     float64                    `json:"time_online"`
-			BuildTag       string                     `json:"build_tag"`
-			ARRegistration *visor.ARSelfRegistration  `json:"ar_registration,omitempty"`
+			PublicKey      string                    `json:"public_key"`
+			IsSymmetricNAT bool                      `json:"symmetric_nat"`
+			LocalIP        string                    `json:"local_ip"`
+			PublicIP       string                    `json:"public_ip"`
+			CountryCode    string                    `json:"country_code,omitempty"`
+			RegionName     string                    `json:"region_name,omitempty"`
+			CityName       string                    `json:"city_name,omitempty"`
+			DMSGServers    []visor.DMSGServerInfo    `json:"dmsg_servers"`
+			DmsgLatency    string                    `json:"dmsg_latency"`
+			VisorVersion   string                    `json:"visor_version"`
+			ConfigVersion  string                    `json:"config_version"`
+			UptimeTracker  string                    `json:"uptime_tracker"`
+			TimeOnline     float64                   `json:"time_online"`
+			BuildTag       string                    `json:"build_tag"`
+			ARRegistration *visor.ARSelfRegistration `json:"ar_registration,omitempty"`
 		}{
 			PublicKey:      summary.Overview.PubKey.String(),
 			IsSymmetricNAT: summary.Overview.IsSymmetricNAT,

--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -193,9 +193,29 @@ func (c *sudphClient) acceptAddresses(conn net.PacketConn, addrCh <-chan addrres
 }
 
 // Dial implements interface
+//
+// SUDPH dialing requires a working PacketFilter, which listen() sets up
+// in the goroutine spawned by Start(). If listen() failed (most
+// commonly because BindSUDPH found no UDP target on the address
+// resolver — a DMSG-only AR with no published udp_address), it nils
+// out c.filter and returns. The client stays attached to the network
+// manager and remains dialable. Without the guard below the next dial
+// panics on c.filter.NewConn (nil deref) and crashes the visor
+// process. Production stack:
+//
+//	pfilter.(*PacketFilter).NewConn(0x0, …)  sudph.go:dial
+//	(*sudphClient).dial → dialWithTimeout → resolvedClient.dialVisor
+//	→ ManagedTransport.Dial → saveTransportInternal goroutine
+//
+// Returning a clean error here lets the transport manager log
+// "SUDPH unavailable" and move on instead of taking the whole visor
+// down.
 func (c *sudphClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (Transport, error) {
 	if c.isClosed() {
 		return nil, io.ErrClosedPipe
+	}
+	if c.filter == nil || c.packetListener == nil {
+		return nil, fmt.Errorf("SUDPH not available (listen failed; check address resolver UDP binding)")
 	}
 	// this will lookup visor address in address resolver and then dial that address
 	conn, err := c.dialVisor(ctx, rPK, c.dialWithTimeout)
@@ -241,6 +261,13 @@ func (c *sudphClient) dialWithTimeout(ctx context.Context, addr string) (net.Con
 // dial will send holepunch packet to the remote addr over UDP, and
 // return the connection
 func (c *sudphClient) dial(remoteAddr string) (net.Conn, error) {
+	if c.filter == nil {
+		// Listen() failed earlier and cleared c.filter. Dial() should
+		// have caught this, but a Close() on a parallel path could
+		// race. Bail safely instead of nil-deref'ing.
+		return nil, fmt.Errorf("SUDPH packet filter not initialized")
+	}
+
 	rAddr, err := net.ResolveUDPAddr("udp", remoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("net.ResolveUDPAddr (remote): %w", err)

--- a/pkg/visor/api_ar.go
+++ b/pkg/visor/api_ar.go
@@ -93,13 +93,20 @@ func (s *arSelfState) set(tpType string, d addrresolver.VisorData) {
 	s.entries[tpType] = d
 }
 
-func (s *arSelfState) clear(tpType string) {
+// clear removes the cached AR self-registration for one transport
+// type. Currently unreferenced in-tree but kept on the type for
+// symmetry with set() and to give callers a way to invalidate a
+// stale entry on tear-down.
+func (s *arSelfState) clear(tpType string) { //nolint:unused
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.entries, tpType)
 }
 
-func (s *arSelfState) snapshot() map[string]addrresolver.VisorData {
+// snapshot returns a copy of the AR self-registration map. Currently
+// unreferenced in-tree; intended for diagnostic dumps that walk all
+// configured transport types at once.
+func (s *arSelfState) snapshot() map[string]addrresolver.VisorData { //nolint:unused
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make(map[string]addrresolver.VisorData, len(s.entries))


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference in the SUDPH client that crashes the entire visor process when SUDPH listen failed at startup but the transport manager later attempts to dial via SUDPH.

## Production stack

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x126fbcc]

goroutine 631728 [running]:
github.com/AudriusButkevicius/pfilter.(*PacketFilter).NewConn(0x0, 0x2, ...)
    pfilter@v0.0.11/filter.go:123 +0x2c
(*sudphClient).dial sudph.go:249 +0x1aa
(*sudphClient).dialWithTimeout
(*resolvedClient).dialVisor
(*sudphClient).Dial
(*ManagedTransport).dial
saveTransportInternal goroutine
\`\`\`

\`c.filter\` is initialized in \`listen()\` (line 83) and intentionally nil'd back out (line 98) when \`BindSUDPH\` fails — most commonly when the address resolver has no published \`udp_address\` (DMSG-only AR deployment). \`serve()\` runs in a goroutine, logs a Warn on the listen error, and returns. The client stays attached to the network manager in an unusable state.

A subsequent Dial then walks straight into \`c.filter.NewConn(nil…)\` and panics, **killing the whole visor process**.

## Fix

Defensive nil checks at the two reachable entry points:

- \`Dial()\` at the top, returns a clear \"SUDPH not available\" error so the transport manager can log and move on instead of crashing.
- \`dial()\` as belt-and-suspenders against a \`Close()\` racing in after \`Dial()\` entered.

Long doc comment on \`Dial()\` captures the production stack trace and the listen() failure condition so the next person debugging this finds the root cause without re-reading the whole file.

## Pre-existing lint failures on develop

#2399 (DHT addr mirror + self publish, merged just before this branch) left \`make lint\` failing on develop:

- \`cmd/skywire-cli/commands/visor/info.go:179\` — gofmt
- \`pkg/visor/api_ar.go:96\` — unused \`arSelfState.clear\`
- \`pkg/visor/api_ar.go:102\` — unused \`arSelfState.snapshot\`

gofmt'd the info.go change, and added \`//nolint:unused\` with comments to clear/snapshot — they're symmetric with \`set()\` and likely to be called once a teardown path or diagnostic dump is wired in. Removing them now would force re-adding them later for an obvious purpose.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (was failing on develop pre-this-PR)
- [ ] Public visor with no AR udp_address comes up and stays up; \`tp ls\` shows no SUDPH transports created; \`tp add --type sudph\` returns the new error instead of crashing