### PR TITLE
tpd+visor: per-transport latency end-to-end (with --mux 0 = unlimited)

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/deployment"
@@ -77,6 +78,15 @@ Example URLs:
 		if logLvl != "" {
 			if lvl, err := logging.LevelFromString(logLvl); err == nil {
 				logging.SetLevel(lvl)
+				// --loglvl=debug|trace implies --verbose unless the
+				// user explicitly opted out. Mirrors the standalone
+				// 'skywire dmsg curl' which prints dmsg-layer chatter
+				// at debug level natively — when the request is
+				// proxied through the visor, we want the same
+				// experience by default.
+				if !cmd.Flags().Changed("verbose") && lvl >= logrus.DebugLevel {
+					curlVerbose = true
+				}
 			}
 		}
 

--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -112,8 +112,18 @@ Example URLs:
 	},
 }
 
-// curlViaVisor performs the curl request using the visor's dmsg client via RPC
-func curlViaVisor(cmd *cobra.Command, _ context.Context, log *logging.Logger, dmsgURL string) error {
+// curlViaVisor performs the curl request using the visor's dmsg client via RPC.
+//
+// net/rpc.Call is synchronous and ignores context, so a slow visor-side
+// dial — which is exactly what happens when the target DMSG peer is
+// unreachable, the visor sits in DialStream until its 15s server-side
+// HTTP timeout — would leave the CLI unresponsive to ctrl+c. We
+// dispatch the RPC in a goroutine and select against ctx.Done() so
+// SIGINT / per-attempt timeout cancels the wait promptly. The RPC
+// itself still runs to completion on the visor (we can't actually
+// abort net/rpc); ctrl+c just lets the CLI exit cleanly while the
+// visor side cleans itself up via its own timeout.
+func curlViaVisor(cmd *cobra.Command, ctx context.Context, log *logging.Logger, dmsgURL string) error {
 	rpcClient, err := rpcClient(cmd)
 	if err != nil {
 		return fmt.Errorf("RPC connection failed; is skywire running?: %w", err)
@@ -154,11 +164,34 @@ func curlViaVisor(cmd *cobra.Command, _ context.Context, log *logging.Logger, dm
 	var lastErr error
 	for i := 0; i < tries; i++ {
 		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Duration(curlWait) * time.Second):
+			}
 			log.Debugf("Attempt %d/%d...", i+1, curlTries)
-			time.Sleep(time.Duration(curlWait) * time.Second)
 		}
 
-		resp, err := rpcClient.DmsgHTTP(req)
+		// Run the RPC in a goroutine so SIGINT / ctx cancellation
+		// can interrupt the wait. The visor's server-side handler
+		// has its own 15s HTTP timeout, so it returns regardless.
+		type result struct {
+			resp *visor.DmsgHTTPResponse
+			err  error
+		}
+		done := make(chan result, 1)
+		go func() {
+			resp, err := rpcClient.DmsgHTTP(req)
+			done <- result{resp, err}
+		}()
+
+		var resp *visor.DmsgHTTPResponse
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case r := <-done:
+			resp, err = r.resp, r.err
+		}
 		if err != nil {
 			lastErr = err
 			log.WithError(err).Debug("Request failed")

--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -24,15 +24,18 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 var (
-	curlData    string
-	curlOutput  string
-	curlAgent   string
-	curlTries   int
-	curlWait    int
-	curlReplace bool
+	curlData         string
+	curlOutput       string
+	curlAgent        string
+	curlTries        int
+	curlWait         int
+	curlReplace      bool
+	curlVerbose      bool
+	curlVerboseLevel string
 )
 
 func init() {
@@ -46,6 +49,8 @@ func init() {
 	curlCmd.Flags().IntVarP(&curlTries, "try", "t", 1, "download attempts (0 unlimits)")
 	curlCmd.Flags().IntVarP(&curlWait, "wait", "w", 0, "time to wait between attempts (seconds)")
 	curlCmd.Flags().StringVarP(&curlAgent, "agent", "a", "skywire-cli/"+buildinfo.Version(), "HTTP user agent")
+	curlCmd.Flags().BoolVarP(&curlVerbose, "verbose", "v", false, "stream visor's dmsg-layer logs to stderr while the request is in flight")
+	curlCmd.Flags().StringVar(&curlVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	if os.Getenv("DMSG_SK") != "" {
 		sk.Set(os.Getenv("DMSG_SK")) //nolint
 	}
@@ -129,6 +134,50 @@ func curlViaVisor(cmd *cobra.Command, ctx context.Context, log *logging.Logger, 
 		return fmt.Errorf("RPC connection failed; is skywire running?: %w", err)
 	}
 	defer rpcClient.Close() //nolint:errcheck
+
+	// --verbose: open a gRPC log stream filtered to dmsg-layer modules
+	// BEFORE the request fires so we capture the full DialStream lifecycle
+	// (lookup → server delegate → handshake → http roundtrip). The
+	// 'subscribed' sentinel ensures the subscription is live by the time
+	// we issue the RPC. Canceling ctx (SIGINT) tears the stream down.
+	var verboseDone chan struct{}
+	if curlVerbose {
+		grpcClient, gerr := rpcgrpc.NewPingClient(rpcAddr)
+		if gerr != nil {
+			return fmt.Errorf("verbose: gRPC dial failed: %w", gerr)
+		}
+		modules := []string{"dmsgC", "dmsghttp", "dmsg_grpc", "dmsg_disc", "dmsg_tracker"}
+		subscribedCh := make(chan struct{})
+		verboseDone = make(chan struct{})
+		go func() {
+			defer close(verboseDone)
+			defer grpcClient.Close() //nolint:errcheck,gosec
+			err := grpcClient.StreamAppLogs(ctx, "", false, curlVerboseLevel, modules, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
+				ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
+				module := e.Module
+				if module == "" {
+					module = "-"
+				}
+				fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
+			})
+			if err != nil && ctx.Err() == nil {
+				fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
+			}
+		}()
+		// Block briefly until the server confirms the subscription is live.
+		select {
+		case <-subscribedCh:
+		case <-time.After(2 * time.Second):
+			fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	defer func() {
+		if verboseDone != nil {
+			<-verboseDone
+		}
+	}()
 
 	// Prepare output
 	output := os.Stdout

--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -25,7 +26,6 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor"
-	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 var (
@@ -148,44 +148,25 @@ func curlViaVisor(cmd *cobra.Command, ctx context.Context, log *logging.Logger, 
 	// --verbose: open a gRPC log stream filtered to dmsg-layer modules
 	// BEFORE the request fires so we capture the full DialStream lifecycle
 	// (lookup → server delegate → handshake → http roundtrip). The
-	// 'subscribed' sentinel ensures the subscription is live by the time
-	// we issue the RPC. Canceling ctx (SIGINT) tears the stream down.
-	var verboseDone chan struct{}
+	// helper handles the subscribe-handshake race. Canceling ctx (SIGINT)
+	// tears the stream down.
+	var verboseStream *clirpc.VerboseStream
 	if curlVerbose {
-		grpcClient, gerr := rpcgrpc.NewPingClient(rpcAddr)
-		if gerr != nil {
-			return fmt.Errorf("verbose: gRPC dial failed: %w", gerr)
+		vs, vErr := clirpc.OpenVerbose(ctx, rpcAddr, clirpc.VerboseFilter{
+			Modules: []string{"dmsgC", "dmsghttp", "dmsg_grpc", "dmsg_disc", "dmsg_tracker"},
+			Level:   curlVerboseLevel,
+		})
+		if vErr != nil {
+			return vErr
 		}
-		modules := []string{"dmsgC", "dmsghttp", "dmsg_grpc", "dmsg_disc", "dmsg_tracker"}
-		subscribedCh := make(chan struct{})
-		verboseDone = make(chan struct{})
-		go func() {
-			defer close(verboseDone)
-			defer grpcClient.Close() //nolint:errcheck,gosec
-			err := grpcClient.StreamAppLogs(ctx, "", false, curlVerboseLevel, modules, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
-				ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
-				module := e.Module
-				if module == "" {
-					module = "-"
-				}
-				fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
-			})
-			if err != nil && ctx.Err() == nil {
-				fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
-			}
-		}()
-		// Block briefly until the server confirms the subscription is live.
-		select {
-		case <-subscribedCh:
-		case <-time.After(2 * time.Second):
-			fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
-		case <-ctx.Done():
+		verboseStream = vs
+		if err := vs.WaitSubscribed(ctx, 2*time.Second); err != nil && ctx.Err() != nil {
 			return ctx.Err()
 		}
 	}
 	defer func() {
-		if verboseDone != nil {
-			<-verboseDone
+		if verboseStream != nil {
+			verboseStream.Close()
 		}
 	}()
 

--- a/cmd/skywire-cli/commands/dmsg/probe.go
+++ b/cmd/skywire-cli/commands/dmsg/probe.go
@@ -15,10 +15,16 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-var standalone bool
+var (
+	standalone        bool
+	probeVerbose      bool
+	probeVerboseLevel string
+)
 
 func init() {
 	probeCmd.Flags().BoolVarP(&standalone, "standalone", "s", false, "use a standalone dmsg client (no running visor needed)")
+	probeCmd.Flags().BoolVarP(&probeVerbose, "verbose", "v", false, "stream visor's dmsg-layer logs to stderr while probing")
+	probeCmd.Flags().StringVar(&probeVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	RootCmd.AddCommand(probeCmd)
 }
 
@@ -66,6 +72,22 @@ Examples:
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		// --verbose: subscribe to dmsg-layer logs for the duration of
+		// the probe so DialStream activity is visible in real time.
+		if probeVerbose {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			vs, vErr := clirpc.OpenVerbose(ctx, clirpc.Addr, clirpc.VerboseFilter{
+				Modules: []string{"dmsgC", "dmsg_grpc", "dmsg_disc", "dmsg_tracker"},
+				Level:   probeVerboseLevel,
+			})
+			if vErr != nil {
+				internal.PrintFatalError(cmd.Flags(), vErr)
+			}
+			_ = vs.WaitSubscribed(ctx, 2*time.Second) //nolint:errcheck
+			defer vs.Close()
 		}
 
 		start := time.Now()

--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -1,0 +1,214 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/mux_info.go
+package skysocksc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+)
+
+var (
+	muxInfoApp     string
+	muxInfoWatch   time.Duration
+	muxInfoVerbose bool
+)
+
+func init() {
+	muxInfoCmd.Flags().StringVarP(&muxInfoApp, "name", "n", "skysocks-client", "app name to query (e.g. skysocks-client, vpn-client)")
+	muxInfoCmd.Flags().DurationVarP(&muxInfoWatch, "watch", "w", 0, "refresh interval; 0 prints once and exits (e.g. 1s, 500ms)")
+	muxInfoCmd.Flags().BoolVarP(&muxInfoVerbose, "verbose", "v", false, "show full PKs / transport IDs (default: short hex prefixes)")
+	RootCmd.AddCommand(muxInfoCmd)
+}
+
+var muxInfoCmd = &cobra.Command{
+	Use:   "mux-info",
+	Short: "Show per-mux-leg traffic for an active proxy session",
+	Long: `Show per-mux-leg traffic for active route groups belonging to a named app.
+
+Each row is one route within a mux'd route group. Sent/recv counts
+are rg-scoped (only what this rg pushed through this leg) — distinct
+from the transport-level totals 'tp ls' shows, which span all rg's
+on that transport.
+
+The query is local to this visor; what you see is your visor's view
+of what it sent/received on each leg, not the peer's view.
+
+Examples:
+  skywire cli proxy mux-info                   # one snapshot, default app
+  skywire cli proxy mux-info --watch 1s        # refresh every second
+  skywire cli proxy mux-info -n vpn-client     # query a different app
+  skywire cli proxy mux-info --json            # machine-readable`,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
+		}
+		defer rpcClient.Close() //nolint:errcheck,gosec
+
+		// One-shot
+		if muxInfoWatch <= 0 {
+			infos, err := rpcClient.RouteGroupMuxInfo(muxInfoApp)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("RouteGroupMuxInfo: %w", err))
+			}
+			renderMuxInfo(cmd, infos)
+			return
+		}
+
+		// Watch mode: clear screen between refreshes for a top-style view.
+		// First emit fires immediately, then every muxInfoWatch.
+		ticker := time.NewTicker(muxInfoWatch)
+		defer ticker.Stop()
+		for {
+			fmt.Print("\033[H\033[2J") // clear screen
+			infos, err := rpcClient.RouteGroupMuxInfo(muxInfoApp)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "RouteGroupMuxInfo: %v\n", err)
+			} else {
+				renderMuxInfo(cmd, infos)
+			}
+			fmt.Printf("\n[refresh %s — ctrl+c to stop]\n", muxInfoWatch)
+			<-ticker.C
+		}
+	},
+}
+
+// muxRouteGroupInfo is a CLI-side mirror of visor.MuxRouteGroupInfo.
+// We unmarshal the visor JSON into this rather than importing the
+// visor package's struct because the json struct tags are the
+// stable contract.
+type muxRouteGroupInfo struct {
+	Desc struct {
+		DstPK   string `json:"dst_pk"`
+		SrcPK   string `json:"src_pk"`
+		DstPort int    `json:"dst_port"`
+		SrcPort int    `json:"src_port"`
+	} `json:"desc"`
+	MuxEnabled  bool         `json:"mux_enabled"`
+	SACKEnabled bool         `json:"sack_enabled"`
+	Legs        []muxLegInfo `json:"legs"`
+}
+
+type muxLegInfo struct {
+	Index       int     `json:"index"`
+	TransportID string  `json:"transport_id"`
+	TpType      string  `json:"tp_type"`
+	RemotePK    string  `json:"remote_pk"`
+	LatencyMS   float64 `json:"latency_ms,omitempty"`
+	SentBytes   uint64  `json:"sent_bytes"`
+	SentPackets uint64  `json:"sent_packets"`
+	RecvBytes   uint64  `json:"recv_bytes"`
+	RecvPackets uint64  `json:"recv_packets"`
+}
+
+// renderMuxInfo prints the visor's mux-info response. We re-marshal/
+// unmarshal through the local muxRouteGroupInfo struct so the CLI's
+// render logic doesn't reach into the visor package's internal type
+// — the JSON contract is the stable boundary.
+//
+// infos is the value returned by rpcClient.RouteGroupMuxInfo; we
+// take it as 'any' so the CLI doesn't import the visor type
+// directly.
+func renderMuxInfo(cmd *cobra.Command, infos any) {
+	// JSON path: marshal the wire response directly. Re-encoding via
+	// our local mirror struct preserves field naming and avoids
+	// importing the visor type for json contract reasons.
+	isJSON, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+	if isJSON {
+		raw, _ := json.Marshal(infos) //nolint:errcheck
+		var roundTripped []muxRouteGroupInfo
+		_ = json.Unmarshal(raw, &roundTripped)               //nolint:errcheck
+		out, _ := json.MarshalIndent(roundTripped, "", "  ") //nolint:errcheck
+		fmt.Println(string(out))
+		return
+	}
+
+	// Re-marshal for the text path's data shape too — same JSON
+	// contract end-to-end so add-fields-on-server-only never silently
+	// drops out of the CLI render.
+	raw, _ := json.Marshal(infos) //nolint:errcheck
+	var rgs []muxRouteGroupInfo
+	_ = json.Unmarshal(raw, &rgs) //nolint:errcheck
+
+	if len(rgs) == 0 {
+		fmt.Printf("no active route groups for app=%s\n", muxInfoApp)
+		return
+	}
+
+	for ri, rg := range rgs {
+		fmt.Printf("rg[%d] %s:%d → %s:%d  mux=%v sack=%v  legs=%d\n",
+			ri,
+			shortPK(rg.Desc.SrcPK), rg.Desc.SrcPort,
+			shortPK(rg.Desc.DstPK), rg.Desc.DstPort,
+			rg.MuxEnabled, rg.SACKEnabled, len(rg.Legs))
+
+		// Sort legs by index so the row order is stable across snapshots.
+		sort.SliceStable(rg.Legs, func(i, j int) bool { return rg.Legs[i].Index < rg.Legs[j].Index })
+
+		var b bytes.Buffer
+		w := tabwriter.NewWriter(&b, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "  leg\ttp_id\ttype\tremote\tlatency\tsent\tsent_pkts\trecv\trecv_pkts") //nolint:errcheck
+		for _, leg := range rg.Legs {
+			lat := "-"
+			if leg.LatencyMS > 0 {
+				lat = fmt.Sprintf("%.0fms", leg.LatencyMS)
+			}
+			fmt.Fprintf(w, "  %d\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%d\n", //nolint:errcheck
+				leg.Index,
+				shortTpID(leg.TransportID),
+				leg.TpType,
+				shortPK(leg.RemotePK),
+				lat,
+				humanBytes(leg.SentBytes), leg.SentPackets,
+				humanBytes(leg.RecvBytes), leg.RecvPackets,
+			)
+		}
+		w.Flush() //nolint:errcheck,gosec
+		fmt.Print(b.String())
+		if ri < len(rgs)-1 {
+			fmt.Println()
+		}
+	}
+}
+
+func shortPK(pk string) string {
+	if muxInfoVerbose || len(pk) <= 12 {
+		return pk
+	}
+	return pk[:8] + "…" + pk[len(pk)-4:]
+}
+
+func shortTpID(id string) string {
+	if muxInfoVerbose || len(id) <= 12 {
+		return id
+	}
+	return id[:8] + "…"
+}
+
+func humanBytes(n uint64) string {
+	const (
+		k = 1024
+		m = k * 1024
+		g = m * 1024
+	)
+	switch {
+	case n >= g:
+		return fmt.Sprintf("%.1fG", float64(n)/float64(g))
+	case n >= m:
+		return fmt.Sprintf("%.1fM", float64(n)/float64(m))
+	case n >= k:
+		return fmt.Sprintf("%.1fK", float64(n)/float64(k))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -213,10 +213,11 @@ var startCmd = &cobra.Command{
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", err))
 			}
 			verboseDone = make(chan struct{})
+			subscribedCh := make(chan struct{})
 			go func() {
 				defer close(verboseDone)
 				defer grpcClient.Close() //nolint:errcheck,gosec
-				err := grpcClient.StreamAppLogs(ctx, clientName, false, startVerboseLevel, func(e *rpcgrpc.AppLogEntry) {
+				err := grpcClient.StreamAppLogs(ctx, clientName, false, startVerboseLevel, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
 					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
 					module := e.Module
 					if module == "" {
@@ -228,6 +229,17 @@ var startCmd = &cobra.Command{
 					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
 				}
 			}()
+			// Block briefly until the server confirms the subscription
+			// is live. Otherwise StartAppWithMode below races with the
+			// subscription handshake and we lose the first ~50ms of
+			// setup logs (route calculation, transport selection).
+			select {
+			case <-subscribedCh:
+			case <-time.After(2 * time.Second):
+				fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
+			case <-ctx.Done():
+				return
+			}
 		}
 
 		if pk != "" {

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -79,7 +80,7 @@ func init() {
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 	startCmd.Flags().BoolVar(&existingTpOnly, "existing-tp", false, "only use existing transports, don't create new ones")
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
-	startCmd.Flags().IntVar(&muxRoutes, "mux", 0, "number of parallel mux routes (0=disabled, 2+=enabled)")
+	startCmd.Flags().IntVar(&muxRoutes, "mux", 1, "parallel mux routes: 0=unlimited (every distinct path), 1=disabled (default), 2+=N routes")
 	startCmd.Flags().StringVar(&muxMode, "mux-mode", "auto", "mux weight distribution mode: auto (latency-based) or equal (round-robin)")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
@@ -144,9 +145,21 @@ var startCmd = &cobra.Command{
 			}
 		}
 
-		// If --mux flag is set, enable route multiplexing
-		if muxRoutes > 1 {
-			if err := rpcClient.SetMuxRoutes(muxRoutes); err != nil {
+		// If --mux flag is set, enable route multiplexing.
+		// 0 means "unlimited" — translate to a large sentinel that
+		// establishMuxRoutes (router_dial.go) iterates against; that
+		// loop already breaks on the first fetchBestRoutes error, so
+		// passing a high number stops naturally at the discoverable
+		// path count.
+		// 1 (default) means "no mux"; SetMuxRoutes is skipped so the
+		// router uses its existing single-route path.
+		// 2+ means N parallel routes, same as before.
+		muxArg := muxRoutes
+		if muxArg == 0 {
+			muxArg = math.MaxInt32
+		}
+		if muxArg > 1 {
+			if err := rpcClient.SetMuxRoutes(muxArg); err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set mux routes: %w", err))
 			}
 		}

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -34,6 +34,7 @@ import (
 	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 // proxyTestClient is a minimal interface for proxy testing
@@ -82,6 +83,8 @@ func init() {
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
 	startCmd.Flags().IntVar(&muxRoutes, "mux", 1, "parallel mux routes: 0=unlimited (every distinct path), 1=disabled (default), 2+=N routes")
 	startCmd.Flags().StringVar(&muxMode, "mux-mode", "auto", "mux weight distribution mode: auto (latency-based) or equal (round-robin)")
+	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream visor debug logs scoped to this app's session; ctrl+c stops the proxy and exits")
+	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
 	dep := getDeployment()
@@ -171,6 +174,11 @@ var startCmd = &cobra.Command{
 			}
 		}
 
+		// In --verbose mode the SignalContext-driven cleanup path needs
+		// to print after the streamer has flushed its last entries, so
+		// the os.Exit(1) is gated on a non-verbose run. Verbose mode
+		// instead returns from the Run func — letting the deferred
+		// rpcClient.Close + grpc.Close run cleanly.
 		var tCtxCancelFunc context.CancelFunc
 		tCtx := context.Background()
 		if startingTimeout != 0 {
@@ -183,10 +191,44 @@ var startCmd = &cobra.Command{
 			if tCtxCancelFunc != nil {
 				tCtxCancelFunc()
 			}
+			if startVerbose {
+				return // let the main goroutine exit gracefully
+			}
 			rpcClient.KillApp(clientName) //nolint:errcheck,gosec
 			fmt.Print("\nStopped!")
 			os.Exit(1)
 		}()
+
+		// --verbose: open a gRPC log stream BEFORE StartAppWithMode so
+		// startup entries (route setup, transport probe, app spawn) are
+		// captured. The goroutine runs until ctx is canceled (SIGINT)
+		// or the visor closes the stream.
+		var verboseDone chan struct{}
+		if startVerbose {
+			if clientName == "" {
+				clientName = "skysocks-client"
+			}
+			grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", err))
+			}
+			verboseDone = make(chan struct{})
+			go func() {
+				defer close(verboseDone)
+				defer grpcClient.Close() //nolint:errcheck,gosec
+				err := grpcClient.StreamAppLogs(ctx, clientName, true, startVerboseLevel, func(e *rpcgrpc.AppLogEntry) {
+					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
+					module := e.Module
+					if module == "" {
+						module = "-"
+					}
+					fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
+				})
+				if err != nil && ctx.Err() == nil {
+					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
+				}
+			}()
+		}
 
 		if pk != "" {
 			err := pubkey.Set(pk)
@@ -252,6 +294,7 @@ var startCmd = &cobra.Command{
 		}
 
 		startProcess := true
+		appReachedRunning := false
 		for startProcess {
 			time.Sleep(time.Second * 1)
 			internal.PrintOutput(cmd.Flags(), nil, ".")
@@ -266,6 +309,7 @@ var startCmd = &cobra.Command{
 				if state.Name == stateName {
 					if state.Status == appserver.AppStatusRunning {
 						startProcess = false
+						appReachedRunning = true
 						internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
 					}
 					if state.Status == appserver.AppStatusErrored {
@@ -293,6 +337,20 @@ var startCmd = &cobra.Command{
 						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln("\nStopped! "+errMsg))
 					}
 				}
+			}
+		}
+
+		// --verbose: stay in the foreground, streaming logs until the
+		// user hits ctrl+c. Then stop the app cleanly and exit.
+		if startVerbose && appReachedRunning {
+			fmt.Fprintln(os.Stderr, "\n--- streaming visor logs (ctrl+c to stop the proxy and exit) ---")
+			<-ctx.Done()
+			fmt.Fprintln(os.Stderr, "\nstopping app...")
+			if err := rpcClient.StopApp(clientName); err != nil {
+				fmt.Fprintf(os.Stderr, "stop app: %v\n", err)
+			}
+			if verboseDone != nil {
+				<-verboseDone
 			}
 		}
 	},

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -83,7 +83,7 @@ func init() {
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
 	startCmd.Flags().IntVar(&muxRoutes, "mux", 1, "parallel mux routes: 0=unlimited (every distinct path), 1=disabled (default), 2+=N routes")
 	startCmd.Flags().StringVar(&muxMode, "mux-mode", "auto", "mux weight distribution mode: auto (latency-based) or equal (round-robin)")
-	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream visor debug logs scoped to this app's session; ctrl+c stops the proxy and exits")
+	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream the visor's logs scoped to this app's session (app stdout + tagged router/mux/setup events); ctrl+c stops the proxy and exits")
 	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
@@ -216,7 +216,7 @@ var startCmd = &cobra.Command{
 			go func() {
 				defer close(verboseDone)
 				defer grpcClient.Close() //nolint:errcheck,gosec
-				err := grpcClient.StreamAppLogs(ctx, clientName, true, startVerboseLevel, func(e *rpcgrpc.AppLogEntry) {
+				err := grpcClient.StreamAppLogs(ctx, clientName, false, startVerboseLevel, func(e *rpcgrpc.AppLogEntry) {
 					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
 					module := e.Module
 					if module == "" {
@@ -284,20 +284,26 @@ var startCmd = &cobra.Command{
 				}
 			}
 			internal.Catch(cmd.Flags(), rpcClient.StartAppWithMode(clientName, getLauncherMode()))
-			internal.PrintOutput(cmd.Flags(), nil, "Starting.")
+			if !startVerbose {
+				internal.PrintOutput(cmd.Flags(), nil, "Starting.")
+			}
 		} else {
 			if clientName == "" {
 				clientName = "skysocks-client"
 			}
 			internal.Catch(cmd.Flags(), rpcClient.StartAppWithMode(clientName, getLauncherMode()))
-			internal.PrintOutput(cmd.Flags(), nil, "Starting.")
+			if !startVerbose {
+				internal.PrintOutput(cmd.Flags(), nil, "Starting.")
+			}
 		}
 
 		startProcess := true
 		appReachedRunning := false
 		for startProcess {
 			time.Sleep(time.Second * 1)
-			internal.PrintOutput(cmd.Flags(), nil, ".")
+			if !startVerbose {
+				internal.PrintOutput(cmd.Flags(), nil, ".")
+			}
 			states, err := rpcClient.Apps()
 			internal.Catch(cmd.Flags(), err)
 
@@ -310,14 +316,20 @@ var startCmd = &cobra.Command{
 					if state.Status == appserver.AppStatusRunning {
 						startProcess = false
 						appReachedRunning = true
-						internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
+						if !startVerbose {
+							internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
+						}
 					}
 					if state.Status == appserver.AppStatusErrored {
 						startProcess = false
 						out := output{
 							AppError: state.DetailedStatus,
 						}
-						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln("\nError! > "+state.DetailedStatus))
+						leader := "\n"
+						if startVerbose {
+							leader = ""
+						}
+						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln(leader+"Error! > "+state.DetailedStatus))
 					}
 					if state.Status == appserver.AppStatusStopped {
 						startProcess = false
@@ -334,7 +346,11 @@ var startCmd = &cobra.Command{
 						out := output{
 							AppError: errMsg,
 						}
-						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln("\nStopped! "+errMsg))
+						leader := "\n"
+						if startVerbose {
+							leader = ""
+						}
+						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln(leader+"Stopped! "+errMsg))
 					}
 				}
 			}
@@ -343,9 +359,9 @@ var startCmd = &cobra.Command{
 		// --verbose: stay in the foreground, streaming logs until the
 		// user hits ctrl+c. Then stop the app cleanly and exit.
 		if startVerbose && appReachedRunning {
-			fmt.Fprintln(os.Stderr, "\n--- streaming visor logs (ctrl+c to stop the proxy and exit) ---")
+			fmt.Fprintln(os.Stderr, "--- app running; streaming logs (ctrl+c to stop) ---")
 			<-ctx.Done()
-			fmt.Fprintln(os.Stderr, "\nstopping app...")
+			fmt.Fprintln(os.Stderr, "stopping app...")
 			if err := rpcClient.StopApp(clientName); err != nil {
 				fmt.Fprintf(os.Stderr, "stop app: %v\n", err)
 			}

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -34,7 +34,6 @@ import (
 	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor"
-	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 // proxyTestClient is a minimal interface for proxy testing
@@ -201,43 +200,24 @@ var startCmd = &cobra.Command{
 
 		// --verbose: open a gRPC log stream BEFORE StartAppWithMode so
 		// startup entries (route setup, transport probe, app spawn) are
-		// captured. The goroutine runs until ctx is canceled (SIGINT)
-		// or the visor closes the stream.
-		var verboseDone chan struct{}
+		// captured. Stream tears down when ctx cancels (SIGINT).
+		var verboseStream *clirpc.VerboseStream
 		if startVerbose {
 			if clientName == "" {
 				clientName = "skysocks-client"
 			}
-			grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
+			vs, err := clirpc.OpenVerbose(ctx, clirpc.Addr, clirpc.VerboseFilter{
+				AppName: clientName,
+				Level:   startVerboseLevel,
+			})
 			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", err))
+				internal.PrintFatalError(cmd.Flags(), err)
 			}
-			verboseDone = make(chan struct{})
-			subscribedCh := make(chan struct{})
-			go func() {
-				defer close(verboseDone)
-				defer grpcClient.Close() //nolint:errcheck,gosec
-				err := grpcClient.StreamAppLogs(ctx, clientName, false, startVerboseLevel, nil, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
-					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
-					module := e.Module
-					if module == "" {
-						module = "-"
-					}
-					fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
-				})
-				if err != nil && ctx.Err() == nil {
-					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
-				}
-			}()
-			// Block briefly until the server confirms the subscription
-			// is live. Otherwise StartAppWithMode below races with the
-			// subscription handshake and we lose the first ~50ms of
-			// setup logs (route calculation, transport selection).
-			select {
-			case <-subscribedCh:
-			case <-time.After(2 * time.Second):
-				fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
-			case <-ctx.Done():
+			verboseStream = vs
+			// Block until the server confirms the subscription is live.
+			// Otherwise StartAppWithMode below races with the handshake
+			// and we lose the first ~50ms of setup logs.
+			if err := vs.WaitSubscribed(ctx, 2*time.Second); err != nil && ctx.Err() != nil {
 				return
 			}
 		}
@@ -377,8 +357,8 @@ var startCmd = &cobra.Command{
 			if err := rpcClient.StopApp(clientName); err != nil {
 				fmt.Fprintf(os.Stderr, "stop app: %v\n", err)
 			}
-			if verboseDone != nil {
-				<-verboseDone
+			if verboseStream != nil {
+				verboseStream.Close()
 			}
 		}
 	},

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -217,7 +217,7 @@ var startCmd = &cobra.Command{
 			go func() {
 				defer close(verboseDone)
 				defer grpcClient.Close() //nolint:errcheck,gosec
-				err := grpcClient.StreamAppLogs(ctx, clientName, false, startVerboseLevel, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
+				err := grpcClient.StreamAppLogs(ctx, clientName, false, startVerboseLevel, nil, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
 					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
 					module := e.Module
 					if module == "" {

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -116,10 +116,12 @@ var (
 	testConnectOnly bool
 	testVersion     string
 	// existing transport flag
-	existingTpOnly   bool
-	forceLocalRoutes bool
-	muxRoutes        int
-	muxMode          string
+	existingTpOnly    bool
+	forceLocalRoutes  bool
+	muxRoutes         int
+	muxMode           string
+	startVerbose      bool
+	startVerboseLevel string
 	// multi-hop testing
 	viaVisor string
 	testEnv  bool

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -404,6 +404,9 @@ func (s *memoryStore) GetAllTransports(context.Context, bool) ([]*transport.Entr
 func (s *memoryStore) UpdateBandwidth(context.Context, string, cipher.PubKey, uint64, uint64) error {
 	return nil
 }
+func (s *memoryStore) UpdateLatency(context.Context, string, float64, float64, float64) error {
+	return nil
+}
 func (s *memoryStore) GetTransportBandwidth(context.Context, uuid.UUID, string, int) ([]store.BandwidthAggregation, error) {
 	return nil, nil
 }

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -216,6 +216,7 @@ var calcCmd = &cobra.Command{
 			}
 			fmt.Fprintf(&textBuf, "forward: %v\nreverse: %v", fwd, rev)
 		}
+		textBuf.WriteString("\n")
 
 		// Preserve the single-route shape for back-compat when --count=1.
 		if calcCount == 1 && len(pairs) == 1 {

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -145,17 +146,32 @@ var calcCmd = &cobra.Command{
 			}
 		}
 
-		// 0 means "every route the BFS finds". GetRoute walks the slice
-		// returned by finder until it hits the cap, so a large sentinel
-		// is equivalent to "all".
+		ctx, cancel := context.WithTimeout(context.Background(), calcTimeout)
+		defer cancel()
+
+		// Prefer streaming via the local visor's gRPC endpoint when
+		// available. The server-side BFS emits each path as soon as
+		// it's found; the CLI prints them as they arrive without
+		// holding the full result set in memory. This is the only
+		// path that can handle --count 0 (unbounded) on dense graphs
+		// without OOMing the CLI.
+		if rpcClient != nil && strings.ToLower(calcSource) != "dht" {
+			if err := streamRoutesViaGRPC(ctx, cmd, srcPK, dstPK, minHops, calcMaxHops, calcCount, calcSource, tpdURL); err == nil {
+				return
+			} else if !isFallbackEligible(err) {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			// fallback to local compute below
+		}
+
+		// Local fallback path: bounded count only. The streaming path
+		// above is the right tool for unbounded; this branch is for
+		// offline use (no visor RPC) where memory pressure is on the
+		// caller's machine but they explicitly chose this mode.
 		count := calcCount
 		if count <= 0 {
 			count = math.MaxInt32
 		}
-
-		// Fetch all transports and calculate route
-		ctx, cancel := context.WithTimeout(context.Background(), calcTimeout)
-		defer cancel()
 
 		var entries []*transport.Entry
 		var err error
@@ -225,6 +241,127 @@ var calcCmd = &cobra.Command{
 		}
 		internal.PrintOutput(cmd.Flags(), pairs, textBuf.String())
 	},
+}
+
+// streamRoutesViaGRPC opens the visor's StreamCalcRoutes gRPC stream and
+// prints each route as it arrives. JSON mode collects routes into a slice
+// and emits one final array; text mode writes one route per arrival
+// directly to stdout (no full-result buffering, so --count 0 is safe).
+func streamRoutesViaGRPC(
+	ctx context.Context,
+	cmd *cobra.Command,
+	srcPK, dstPK cipher.PubKey,
+	minHops, maxHops uint16,
+	count int,
+	source, tpdU string,
+) error {
+	grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
+	if err != nil {
+		return fmt.Errorf("grpc dial: %w", err)
+	}
+	defer grpcClient.Close() //nolint:errcheck,gosec
+
+	type routePair struct {
+		Forward []routing.Hop `json:"forward"`
+		Reverse []routing.Hop `json:"reverse"`
+	}
+	isJSON, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+	var collected []routePair
+
+	emitted := 0
+	cb := func(r *rpcgrpc.CalcRoute) bool {
+		fwd, err := protoHopsToRouting(r.Hops)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "calc: skipping malformed route: %v\n", err)
+			return true
+		}
+		rev := reverseHops(fwd)
+		emitted++
+
+		if isJSON {
+			collected = append(collected, routePair{Forward: fwd, Reverse: rev})
+			return count == 0 || emitted < count
+		}
+
+		// Text streaming: print as it arrives.
+		if emitted > 1 {
+			fmt.Println()
+		}
+		if count != 1 {
+			fmt.Printf("[%d]\n", emitted)
+		}
+		fmt.Printf("forward: %v\nreverse: %v\n", fwd, rev)
+		return count == 0 || emitted < count
+	}
+
+	if err := grpcClient.StreamCalcRoutes(
+		ctx,
+		srcPK.String(),
+		dstPK.String(),
+		int32(minHops), //nolint:gosec
+		int32(maxHops), //nolint:gosec
+		int32(count),   //nolint:gosec
+		source,
+		tpdU,
+		cb,
+	); err != nil {
+		if emitted == 0 {
+			return fmt.Errorf("no route found: %w", err)
+		}
+		// Some routes arrived before the stream errored; treat as success.
+		fmt.Fprintf(os.Stderr, "calc: stream ended early: %v\n", err)
+	}
+
+	if emitted == 0 {
+		return fmt.Errorf("no route found: %w", routeFinder.ErrRouteNotFound)
+	}
+	if isJSON {
+		// Single-route back-compat shape preserved when count=1.
+		if count == 1 && len(collected) == 1 {
+			out, _ := json.Marshal(collected[0]) //nolint:errcheck
+			fmt.Println(string(out))
+		} else {
+			out, _ := json.Marshal(collected) //nolint:errcheck
+			fmt.Println(string(out))
+		}
+	}
+	return nil
+}
+
+// protoHopsToRouting decodes the wire-form CalcHops back into the
+// routing.Hop shape used by the rest of the CLI's printing/JSON code.
+func protoHopsToRouting(hops []*rpcgrpc.CalcHop) ([]routing.Hop, error) {
+	out := make([]routing.Hop, 0, len(hops))
+	for _, h := range hops {
+		tpID, err := uuid.Parse(h.TpId)
+		if err != nil {
+			return nil, fmt.Errorf("tp_id: %w", err)
+		}
+		var from, to cipher.PubKey
+		if err := from.Set(h.From); err != nil {
+			return nil, fmt.Errorf("from: %w", err)
+		}
+		if err := to.Set(h.To); err != nil {
+			return nil, fmt.Errorf("to: %w", err)
+		}
+		out = append(out, routing.Hop{TpID: tpID, From: from, To: to})
+	}
+	return out, nil
+}
+
+// isFallbackEligible reports whether a gRPC-side calc error should
+// trigger the local fallback path. A connection error (gRPC server not
+// up, address invalid) is eligible; a logical error from the server
+// (no route, invalid PK) is final.
+func isFallbackEligible(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "grpc dial") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "transport: Error")
 }
 
 func findConfig() string {

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -32,14 +32,15 @@ import (
 )
 
 var (
-	calcEnable  bool
-	calcDisable bool
-	calcTimeout time.Duration
-	tpdURL      string
-	calcMinHops uint16
-	calcMaxHops uint16
-	calcCount   int
-	calcSource  string
+	calcEnable   bool
+	calcDisable  bool
+	calcTimeout  time.Duration
+	tpdURL       string
+	calcMinHops  uint16
+	calcMaxHops  uint16
+	calcCount    int
+	calcSource   string
+	calcQueueCap int
 )
 
 func init() {
@@ -51,6 +52,7 @@ func init() {
 	calcCmd.Flags().Uint16VarP(&calcMaxHops, "max", "x", 5, "maximum hops")
 	calcCmd.Flags().IntVarP(&calcCount, "count", "c", 1, "max routes to return (0 = all matching)")
 	calcCmd.Flags().StringVar(&calcSource, "source", "tpd", "transport graph source: tpd (HTTP), dht (visor's local DHT store), auto (DHT then TPD)")
+	calcCmd.Flags().IntVar(&calcQueueCap, "queue-cap", 0, "BFS queue cap (0 = server/local default ~200K, negative = unbounded)")
 	clirpc.RegisterFetchFlags(calcCmd)
 }
 
@@ -156,7 +158,7 @@ var calcCmd = &cobra.Command{
 		// path that can handle --count 0 (unbounded) on dense graphs
 		// without OOMing the CLI.
 		if rpcClient != nil && strings.ToLower(calcSource) != "dht" {
-			if err := streamRoutesViaGRPC(ctx, cmd, srcPK, dstPK, minHops, calcMaxHops, calcCount, calcSource, tpdURL); err == nil {
+			if err := streamRoutesViaGRPC(ctx, cmd, srcPK, dstPK, minHops, calcMaxHops, calcCount, calcQueueCap, calcSource, tpdURL); err == nil {
 				return
 			} else if !isFallbackEligible(err) {
 				internal.PrintFatalError(cmd.Flags(), err)
@@ -252,7 +254,7 @@ func streamRoutesViaGRPC(
 	cmd *cobra.Command,
 	srcPK, dstPK cipher.PubKey,
 	minHops, maxHops uint16,
-	count int,
+	count, queueCap int,
 	source, tpdU string,
 ) error {
 	grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
@@ -298,9 +300,10 @@ func streamRoutesViaGRPC(
 		ctx,
 		srcPK.String(),
 		dstPK.String(),
-		int32(minHops), //nolint:gosec
-		int32(maxHops), //nolint:gosec
-		int32(count),   //nolint:gosec
+		int32(minHops),  //nolint:gosec
+		int32(maxHops),  //nolint:gosec
+		int32(count),    //nolint:gosec
+		int32(queueCap), //nolint:gosec
 		source,
 		tpdU,
 		cb,

--- a/cmd/skywire-cli/commands/rpc/verbose.go
+++ b/cmd/skywire-cli/commands/rpc/verbose.go
@@ -1,0 +1,153 @@
+// Package clirpc cmd/skywire-cli/commands/rpc/verbose.go
+//
+// Verbose log-streaming helper for cli commands that block on a
+// visor-side RPC and want to surface what the visor is doing in
+// real time.
+//
+// Two APIs:
+//
+//   - OpenVerbose returns a *VerboseStream the caller drives by hand.
+//     Use this when the calling command needs to interleave the
+//     stream with its own RPCs (proxy start / vpn start: subscribe,
+//     start app, poll for Running, wait on ctx.Done, stop app).
+//
+//   - WithVerbose wraps a single bounded operation. Use this for the
+//     RPC-and-done shape (dmsg curl, skynet curl, tp add, dmsg probe).
+//     Callers in this form don't need to know the stream exists
+//     when --verbose is off — the helper short-circuits.
+//
+// Both wait for a subscribe-handshake sentinel before the wrapped
+// action runs so the first ~50ms of visor activity isn't lost to the
+// stream-handshake race.
+package clirpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+)
+
+// VerboseFilter is the per-command filter spec passed to the
+// gRPC StreamAppLogs request.
+type VerboseFilter struct {
+	// AppName matches by _module exact equality OR app/app_name
+	// field. Empty when scoping by Modules only (e.g. dmsg curl).
+	AppName string
+	// Modules is a prefix list matched against the _module field.
+	// OR-merged with AppName.
+	Modules []string
+	// Level is the minimum severity ("trace"|"debug"|"info"|"warn"|"error").
+	// Empty defaults to "debug".
+	Level string
+}
+
+// VerboseStream is a live subscription to the visor's master logger.
+// Entries are formatted and written to stderr by a goroutine until
+// ctx is canceled or Close is called.
+type VerboseStream struct {
+	grpc       *rpcgrpc.PingClient
+	subscribed chan struct{}
+	done       chan struct{}
+}
+
+// OpenVerbose dials the visor's gRPC endpoint and starts streaming
+// matching entries to stderr. Returns immediately; caller calls
+// WaitSubscribed before the action they want to observe, and Close
+// when done.
+//
+// Either filter.AppName or filter.Modules must be non-empty.
+//
+// rpcAddr is typically clirpc.Addr; the gRPC server is multiplexed
+// onto the same port as the standard RPC server via cmux.
+func OpenVerbose(ctx context.Context, rpcAddr string, filter VerboseFilter) (*VerboseStream, error) {
+	if filter.AppName == "" && len(filter.Modules) == 0 {
+		return nil, errors.New("verbose: filter requires AppName or Modules")
+	}
+	grpcClient, err := rpcgrpc.NewPingClient(rpcAddr)
+	if err != nil {
+		return nil, fmt.Errorf("verbose: gRPC dial failed: %w", err)
+	}
+	level := filter.Level
+	if level == "" {
+		level = "debug"
+	}
+
+	v := &VerboseStream{
+		grpc:       grpcClient,
+		subscribed: make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	go func() {
+		defer close(v.done)
+		defer grpcClient.Close() //nolint:errcheck,gosec
+		err := grpcClient.StreamAppLogs(ctx, filter.AppName, false, level, filter.Modules, v.subscribed, func(e *rpcgrpc.AppLogEntry) {
+			emitEntry(os.Stderr, e)
+		})
+		if err != nil && ctx.Err() == nil {
+			fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
+		}
+	}()
+	return v, nil
+}
+
+// WaitSubscribed blocks until the server confirms the subscription
+// is live (the Subscribed sentinel was received) or timeout fires.
+// Returns context.DeadlineExceeded on timeout — callers usually
+// proceed anyway, since the stream may still attach mid-action.
+func (v *VerboseStream) WaitSubscribed(ctx context.Context, timeout time.Duration) error {
+	select {
+	case <-v.subscribed:
+		return nil
+	case <-time.After(timeout):
+		fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within timeout; proceeding anyway")
+		return context.DeadlineExceeded
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close waits for the stream goroutine to exit, tearing down the
+// underlying gRPC client. Safe to call once. Caller is responsible
+// for canceling ctx (or letting it cancel naturally) so the stream
+// goroutine returns.
+func (v *VerboseStream) Close() {
+	<-v.done
+}
+
+// WithVerbose is the function-wrapper convenience. If filter is the
+// zero value (empty AppName + empty Modules), it is a no-op and just
+// runs fn. Otherwise it opens the stream, waits up to 2s for the
+// subscribe handshake, runs fn, and waits for the stream goroutine
+// to exit (ctx-canceled by the caller or naturally drained).
+//
+// Returns whatever fn returned.
+func WithVerbose(ctx context.Context, rpcAddr string, filter VerboseFilter, fn func() error) error {
+	if filter.AppName == "" && len(filter.Modules) == 0 {
+		return fn()
+	}
+	v, err := OpenVerbose(ctx, rpcAddr, filter)
+	if err != nil {
+		return err
+	}
+	defer v.Close()
+	_ = v.WaitSubscribed(ctx, 2*time.Second) //nolint:errcheck // best-effort
+	return fn()
+}
+
+// emitEntry writes one log line to w in the verbose-stream format
+// the cli uses across commands: HH:MM:SS.mmm  LEVEL [module] message.
+// Exported via the helper so refactored callers stay consistent.
+func emitEntry(w io.Writer, e *rpcgrpc.AppLogEntry) {
+	ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
+	module := e.Module
+	if module == "" {
+		module = "-"
+	}
+	fmt.Fprintf(w, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message) //nolint:errcheck,gosec
+}

--- a/cmd/skywire-cli/commands/skynet/curl.go
+++ b/cmd/skywire-cli/commands/skynet/curl.go
@@ -2,28 +2,37 @@
 package skynet
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 var (
-	curlData   string
-	curlOutput string
+	curlData    string
+	curlOutput  string
+	curlVerbose bool
+	curlVLevel  string
 )
 
 func init() {
 	curlCmd.Flags().StringVarP(&curlData, "data", "d", "", "HTTP POST data")
 	curlCmd.Flags().StringVarP(&curlOutput, "out", "o", "", "output file path")
+	curlCmd.Flags().BoolVarP(&curlVerbose, "verbose", "v", false, "stream visor's router/transport logs to stderr while the request is in flight")
+	curlCmd.Flags().StringVar(&curlVLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	RootCmd.AddCommand(curlCmd)
 }
 
@@ -62,15 +71,79 @@ Examples:
 			body = []byte(curlData)
 		}
 
+		ctx, cancel := cmdutil.SignalContext(context.Background(), logging.MustGetLogger("skynet-curl"))
+		defer cancel()
+
+		// --verbose: subscribe to the visor's router/transport layer
+		// logs BEFORE issuing the RPC. The skynet stack reuses the
+		// same router as proxy/vpn, so the same module set surfaces
+		// route setup, mux setup, transport probe activity. Different
+		// from dmsg curl which scopes to dmsgC modules — skynet goes
+		// over routes, not direct dmsg.
+		var verboseDone chan struct{}
+		if curlVerbose {
+			grpcClient, gerr := rpcgrpc.NewPingClient(clirpc.Addr)
+			if gerr != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", gerr))
+			}
+			modules := []string{"router", "route_setup", "setup_node", "mux_setup", "transport_manager", "skynet"}
+			subscribedCh := make(chan struct{})
+			verboseDone = make(chan struct{})
+			go func() {
+				defer close(verboseDone)
+				defer grpcClient.Close() //nolint:errcheck,gosec
+				err := grpcClient.StreamAppLogs(ctx, "", false, curlVLevel, modules, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
+					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
+					module := e.Module
+					if module == "" {
+						module = "-"
+					}
+					fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
+				})
+				if err != nil && ctx.Err() == nil {
+					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
+				}
+			}()
+			select {
+			case <-subscribedCh:
+			case <-time.After(2 * time.Second):
+				fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
+			case <-ctx.Done():
+				return
+			}
+		}
+		defer func() {
+			if verboseDone != nil {
+				<-verboseDone
+			}
+		}()
+
 		fmt.Fprintf(os.Stderr, "Dialing %s:%d%s...\n", target.pk.String(), target.port, target.path)
 
-		resp, err := rpcClient.SkynetHTTP(visor.SkynetHTTPRequest{
-			PK:     target.pk,
-			Port:   target.port,
-			Path:   target.path,
-			Method: method,
-			Body:   body,
-		})
+		// Run RPC in a goroutine so SIGINT can interrupt the wait
+		// (net/rpc.Call ignores context); same pattern as dmsg curl.
+		type result struct {
+			resp *visor.SkynetHTTPResponse
+			err  error
+		}
+		done := make(chan result, 1)
+		go func() {
+			r, e := rpcClient.SkynetHTTP(visor.SkynetHTTPRequest{
+				PK:     target.pk,
+				Port:   target.port,
+				Path:   target.path,
+				Method: method,
+				Body:   body,
+			})
+			done <- result{r, e}
+		}()
+		var resp *visor.SkynetHTTPResponse
+		select {
+		case <-ctx.Done():
+			internal.PrintFatalError(cmd.Flags(), ctx.Err())
+		case r := <-done:
+			resp, err = r.resp, r.err
+		}
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("skynet request failed: %w", err))
 		}

--- a/cmd/skywire-cli/commands/skynet/curl.go
+++ b/cmd/skywire-cli/commands/skynet/curl.go
@@ -18,7 +18,6 @@ import (
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor"
-	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 var (
@@ -80,41 +79,23 @@ Examples:
 		// route setup, mux setup, transport probe activity. Different
 		// from dmsg curl which scopes to dmsgC modules — skynet goes
 		// over routes, not direct dmsg.
-		var verboseDone chan struct{}
+		var verboseStream *clirpc.VerboseStream
 		if curlVerbose {
-			grpcClient, gerr := rpcgrpc.NewPingClient(clirpc.Addr)
-			if gerr != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", gerr))
+			vs, vErr := clirpc.OpenVerbose(ctx, clirpc.Addr, clirpc.VerboseFilter{
+				Modules: []string{"router", "route_setup", "setup_node", "mux_setup", "transport_manager", "skynet"},
+				Level:   curlVLevel,
+			})
+			if vErr != nil {
+				internal.PrintFatalError(cmd.Flags(), vErr)
 			}
-			modules := []string{"router", "route_setup", "setup_node", "mux_setup", "transport_manager", "skynet"}
-			subscribedCh := make(chan struct{})
-			verboseDone = make(chan struct{})
-			go func() {
-				defer close(verboseDone)
-				defer grpcClient.Close() //nolint:errcheck,gosec
-				err := grpcClient.StreamAppLogs(ctx, "", false, curlVLevel, modules, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
-					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
-					module := e.Module
-					if module == "" {
-						module = "-"
-					}
-					fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
-				})
-				if err != nil && ctx.Err() == nil {
-					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
-				}
-			}()
-			select {
-			case <-subscribedCh:
-			case <-time.After(2 * time.Second):
-				fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
-			case <-ctx.Done():
+			verboseStream = vs
+			if err := vs.WaitSubscribed(ctx, 2*time.Second); err != nil && ctx.Err() != nil {
 				return
 			}
 		}
 		defer func() {
-			if verboseDone != nil {
-				<-verboseDone
+			if verboseStream != nil {
+				verboseStream.Close()
 			}
 		}()
 

--- a/cmd/skywire-cli/commands/tp/tp-add.go
+++ b/cmd/skywire-cli/commands/tp/tp-add.go
@@ -2,6 +2,7 @@
 package clitp
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -41,6 +42,8 @@ var (
 	noRegister       bool
 	noProbe          bool
 	remoteVisorPKs   []string
+	addVerbose       bool
+	addVerboseLevel  string
 )
 
 func init() {
@@ -54,6 +57,8 @@ func init() {
 	addTpCmd.Flags().BoolVar(&noProbe, "no-probe", false, "skip dmsg port 136 reachability probe before adding transport")
 	addTpCmd.Flags().StringSliceVar(&remoteVisorPKs, "remote", nil, "request transport via TPS on remote visor(s) (comma-separated PKs)")
 	addTpCmd.Flags().StringVar(&stcpAddr, "addr", "", "remote address (ip:port) for stcp transport")
+	addTpCmd.Flags().BoolVarP(&addVerbose, "verbose", "v", false, "stream the visor's transport-layer logs (transport_manager, dmsgC, stcpr, sudph, address_resolver) while dialing")
+	addTpCmd.Flags().StringVar(&addVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 	clirpc.RegisterFetchFlags(addTpCmd)
 }
 
@@ -93,6 +98,24 @@ var addTpCmd = &cobra.Command{
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		// --verbose: subscribe to transport-layer logs for the
+		// duration of this command. AddTransport routinely hangs in
+		// the underlying dial when a peer is unreachable; this lights
+		// up the actual handshake / AR / dmsg sequence in real time.
+		if addVerbose {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			vs, vErr := clirpc.OpenVerbose(ctx, clirpc.Addr, clirpc.VerboseFilter{
+				Modules: []string{"transport_manager", "dmsgC", "stcpr", "sudph", "address_resolver", "tp"},
+				Level:   addVerboseLevel,
+			})
+			if vErr != nil {
+				internal.PrintFatalError(cmd.Flags(), vErr)
+			}
+			_ = vs.WaitSubscribed(ctx, 2*time.Second) //nolint:errcheck
+			defer vs.Close()
 		}
 
 		// Collect public keys from args and -r flag

--- a/cmd/skywire-cli/commands/tp/tp-metrics.go
+++ b/cmd/skywire-cli/commands/tp/tp-metrics.go
@@ -212,10 +212,13 @@ func printByTransport(cmd *cobra.Command, metrics []store.TransportMetric) {
 
 func printByVisor(cmd *cobra.Command, metrics []store.TransportMetric) {
 	type visorBW struct {
-		Sent       uint64 `json:"sent"`
-		Recv       uint64 `json:"recv"`
-		Bandwidth  uint64 `json:"bandwidth"`
-		Transports int    `json:"transports"`
+		Sent         uint64 `json:"sent"`
+		Recv         uint64 `json:"recv"`
+		Bandwidth    uint64 `json:"bandwidth"`
+		Transports   int    `json:"transports"`
+		LatencySumUS int64  `json:"-"` // running sum for averaging
+		LatencyN     int    `json:"-"`
+		LatencyAvgMS int64  `json:"latency_avg_ms,omitempty"`
 	}
 	byPK := make(map[string]*visorBW)
 
@@ -244,6 +247,10 @@ func printByVisor(cmd *cobra.Command, metrics []store.TransportMetric) {
 			vbw.Sent += aToB
 			vbw.Recv += bToA
 			vbw.Bandwidth += tpBW
+			if m.Latency != nil && m.Latency.Avg > 0 {
+				vbw.LatencySumUS += m.Latency.Avg
+				vbw.LatencyN++
+			}
 		}
 
 		// Edge B sent b→a, received a→b
@@ -257,6 +264,16 @@ func printByVisor(cmd *cobra.Command, metrics []store.TransportMetric) {
 			vbw.Sent += bToA
 			vbw.Recv += aToB
 			vbw.Bandwidth += tpBW
+			if m.Latency != nil && m.Latency.Avg > 0 {
+				vbw.LatencySumUS += m.Latency.Avg
+				vbw.LatencyN++
+			}
+		}
+	}
+
+	for _, vbw := range byPK {
+		if vbw.LatencyN > 0 {
+			vbw.LatencyAvgMS = (vbw.LatencySumUS / int64(vbw.LatencyN)) / 1000
 		}
 	}
 
@@ -283,12 +300,16 @@ func printByVisor(cmd *cobra.Command, metrics []store.TransportMetric) {
 
 	var b bytes.Buffer
 	w := tabwriter.NewWriter(&b, 0, 0, 3, ' ', tabwriter.TabIndent)
-	fmt.Fprintln(w, "public_key\ttransports\tsent\trecv\tbandwidth") //nolint:errcheck
+	fmt.Fprintln(w, "public_key\ttransports\tsent\trecv\tbandwidth\tavg_latency") //nolint:errcheck
 	for _, v := range sorted {
-		fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n", //nolint:errcheck
+		latStr := "-"
+		if v.BW.LatencyAvgMS > 0 {
+			latStr = fmt.Sprintf("%dms", v.BW.LatencyAvgMS)
+		}
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\n", //nolint:errcheck
 			v.PK, v.BW.Transports,
 			formatBytes(v.BW.Sent), formatBytes(v.BW.Recv),
-			formatBytes(v.BW.Bandwidth))
+			formatBytes(v.BW.Bandwidth), latStr)
 	}
 	w.Flush() //nolint:errcheck,gosec
 

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -417,7 +417,7 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tlatency\trecv\tsent")
 		internal.Catch(cmdFlags, err)
 	} else {
-		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tlatency")
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel")
 		internal.Catch(cmdFlags, err)
 	}
 
@@ -530,8 +530,8 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 				formatBytes(recvBytes), formatBytes(sentBytes))
 			internal.Catch(cmdFlags, err)
 		} else {
-			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, latency)
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
 			internal.Catch(cmdFlags, err)
 		}
 	}

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -408,16 +408,16 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 	w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
 
 	if showMore && bwDays > 0 {
-		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tversion\tcountry\tservices\trecv\tsent")
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tversion\tcountry\tservices\tlatency\trecv\tsent")
 		internal.Catch(cmdFlags, err)
 	} else if showMore {
-		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tversion\tcountry\tservices")
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tversion\tcountry\tservices\tlatency")
 		internal.Catch(cmdFlags, err)
 	} else if bwDays > 0 {
-		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\trecv\tsent")
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tlatency\trecv\tsent")
 		internal.Catch(cmdFlags, err)
 	} else {
-		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel")
+		_, err := fmt.Fprintln(w, "type\tid\tremote_pk\tmode\tlabel\tlatency")
 		internal.Catch(cmdFlags, err)
 	}
 
@@ -430,6 +430,7 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 		Version   string          `json:"version,omitempty"`
 		Country   string          `json:"country,omitempty"`
 		Services  string          `json:"services,omitempty"`
+		LatencyMS float64         `json:"latency_ms,omitempty"`
 		RecvBytes uint64          `json:"recv_bytes,omitempty"`
 		SentBytes uint64          `json:"sent_bytes,omitempty"`
 	}
@@ -507,34 +508,46 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 			Version:   version,
 			Country:   country,
 			Services:  services,
+			LatencyMS: tp.LatencyMS,
 			RecvBytes: recvBytes,
 			SentBytes: sentBytes,
 		}
 		outputTPS = append(outputTPS, oTP)
 
+		latency := formatLatencyMS(tp.LatencyMS)
 		if showMore && bwDays > 0 {
-			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, version, country, services,
-				formatBytes(recvBytes), formatBytes(sentBytes))
+				latency, formatBytes(recvBytes), formatBytes(sentBytes))
 			internal.Catch(cmdFlags, err)
 		} else if showMore {
-			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, version, country, services)
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, version, country, services, latency)
 			internal.Catch(cmdFlags, err)
 		} else if bwDays > 0 {
-			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label,
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, latency,
 				formatBytes(recvBytes), formatBytes(sentBytes))
 			internal.Catch(cmdFlags, err)
 		} else {
-			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label)
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				tp.Type, tp.ID, tp.Remote, tpMode, tp.Label, latency)
 			internal.Catch(cmdFlags, err)
 		}
 	}
 
 	internal.Catch(cmdFlags, w.Flush())
 	internal.PrintOutput(cmdFlags, outputTPS, b.String())
+}
+
+// formatLatencyMS renders a transport-level latency value in ms;
+// "-" when unmeasured. Sister to formatLatency in tp-metrics.go,
+// which works on the store.TransportLatency aggregate type.
+func formatLatencyMS(ms float64) string {
+	if ms <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.0fms", ms)
 }
 
 func sortTransports(tps ...*visor.TransportSummary) {

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -176,21 +176,21 @@ var summaryCmd = &cobra.Command{
 			summary.Overview.BuildInfo.Version, summary.ConfigVersion, summary.Health.ServicesHealth, summary.Uptime, summary.BuildTag)
 
 		outputJSON := struct {
-			PublicKey      string                     `json:"public_key"`
-			IsSymmetricNAT bool                       `json:"symmetric_nat"`
-			LocalIP        string                     `json:"local_ip"`
-			PublicIP       string                     `json:"public_ip"`
-			CountryCode    string                     `json:"country_code,omitempty"`
-			RegionName     string                     `json:"region_name,omitempty"`
-			CityName       string                     `json:"city_name,omitempty"`
-			DMSGServers    []visor.DMSGServerInfo     `json:"dmsg_servers"`
-			DmsgLatency    string                     `json:"dmsg_latency"`
-			VisorVersion   string                     `json:"visor_version"`
-			ConfigVersion  string                     `json:"config_version"`
-			UptimeTracker  string                     `json:"uptime_tracker"`
-			TimeOnline     float64                    `json:"time_online"`
-			BuildTag       string                     `json:"build_tag"`
-			ARRegistration *visor.ARSelfRegistration  `json:"ar_registration,omitempty"`
+			PublicKey      string                    `json:"public_key"`
+			IsSymmetricNAT bool                      `json:"symmetric_nat"`
+			LocalIP        string                    `json:"local_ip"`
+			PublicIP       string                    `json:"public_ip"`
+			CountryCode    string                    `json:"country_code,omitempty"`
+			RegionName     string                    `json:"region_name,omitempty"`
+			CityName       string                    `json:"city_name,omitempty"`
+			DMSGServers    []visor.DMSGServerInfo    `json:"dmsg_servers"`
+			DmsgLatency    string                    `json:"dmsg_latency"`
+			VisorVersion   string                    `json:"visor_version"`
+			ConfigVersion  string                    `json:"config_version"`
+			UptimeTracker  string                    `json:"uptime_tracker"`
+			TimeOnline     float64                   `json:"time_online"`
+			BuildTag       string                    `json:"build_tag"`
+			ARRegistration *visor.ARSelfRegistration `json:"ar_registration,omitempty"`
 		}{
 			PublicKey:      summary.Overview.PubKey.String(),
 			IsSymmetricNAT: summary.Overview.IsSymmetricNAT,

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -79,33 +79,35 @@ func getDeployment() deployment.Services {
 }
 
 var (
-	stateName        = "vpn-client"
-	serviceType      = servicedisc.ServiceTypeVPN
-	rawData          bool
-	sdURL            string
-	utURL            string
-	cacheDirSD       string
-	cacheDirUT       string
-	cacheFilesAge    int
-	noFilterOnline   bool
-	path             string
-	isPkg            bool
-	isStats          bool
-	pubkey           cipher.PubKey
-	pk               string
-	startingTimeout  int
-	jsonOutput       bool
-	country          string
-	version          string
-	minVersion       string
-	maxVersion       string
-	showOffline      bool
-	geoipURL         string
-	useInternal      bool
-	useExternal      bool
-	existingTpOnly   bool
-	forceLocalRoutes bool
-	testEnv          bool
+	stateName         = "vpn-client"
+	serviceType       = servicedisc.ServiceTypeVPN
+	rawData           bool
+	sdURL             string
+	utURL             string
+	cacheDirSD        string
+	cacheDirUT        string
+	cacheFilesAge     int
+	noFilterOnline    bool
+	path              string
+	isPkg             bool
+	isStats           bool
+	pubkey            cipher.PubKey
+	pk                string
+	startingTimeout   int
+	jsonOutput        bool
+	country           string
+	version           string
+	minVersion        string
+	maxVersion        string
+	showOffline       bool
+	geoipURL          string
+	useInternal       bool
+	useExternal       bool
+	existingTpOnly    bool
+	forceLocalRoutes  bool
+	testEnv           bool
+	startVerbose      bool
+	startVerboseLevel string
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -27,6 +27,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 func init() {
@@ -45,6 +46,8 @@ func init() {
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 	startCmd.Flags().BoolVar(&existingTpOnly, "existing-tp", false, "only use existing transports, don't create new ones")
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
+	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream the visor's logs scoped to vpn-client (app stdout + tagged router/mux/setup events); ctrl+c stops the vpn and exits")
+	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
 }
 
 var startCmd = &cobra.Command{
@@ -89,8 +92,6 @@ var startCmd = &cobra.Command{
 			launcherMode = "external"
 		}
 
-		internal.Catch(cmd.Flags(), rpcClient.StartVPNClientWithMode(pubkey, launcherMode))
-		internal.PrintOutput(cmd.Flags(), nil, "Starting.")
 		var tCtxCancelFunc context.CancelFunc
 		tCtx := context.Background()
 		if startingTimeout != 0 {
@@ -103,14 +104,63 @@ var startCmd = &cobra.Command{
 			if tCtxCancelFunc != nil {
 				tCtxCancelFunc()
 			}
+			if startVerbose {
+				return // let the main goroutine exit gracefully
+			}
 			rpcClient.KillApp("vpn-client") //nolint:errcheck,gosec
 			fmt.Print("\nStopped!")
 			os.Exit(1)
 		}()
+
+		// --verbose: open a gRPC log stream BEFORE StartVPNClientWithMode
+		// so startup entries (route setup, transport probe, app spawn) are
+		// captured. Mirrors 'proxy start --verbose'.
+		var verboseDone chan struct{}
+		if startVerbose {
+			grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", err))
+			}
+			verboseDone = make(chan struct{})
+			subscribedCh := make(chan struct{})
+			go func() {
+				defer close(verboseDone)
+				defer grpcClient.Close() //nolint:errcheck,gosec
+				err := grpcClient.StreamAppLogs(ctx, stateName, false, startVerboseLevel, nil, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
+					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
+					module := e.Module
+					if module == "" {
+						module = "-"
+					}
+					fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
+				})
+				if err != nil && ctx.Err() == nil {
+					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
+				}
+			}()
+			// Block until subscription handshake completes so StartVPN's
+			// initial setup chatter isn't lost to the race.
+			select {
+			case <-subscribedCh:
+			case <-time.After(2 * time.Second):
+				fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		internal.Catch(cmd.Flags(), rpcClient.StartVPNClientWithMode(pubkey, launcherMode))
+		if !startVerbose {
+			internal.PrintOutput(cmd.Flags(), nil, "Starting.")
+		}
+
 		startProcess := true
+		appReachedRunning := false
 		for startProcess {
 			time.Sleep(time.Second * 1)
-			internal.PrintOutput(cmd.Flags(), nil, ".")
+			if !startVerbose {
+				internal.PrintOutput(cmd.Flags(), nil, ".")
+			}
 			states, err := rpcClient.Apps()
 			internal.Catch(cmd.Flags(), err)
 
@@ -123,7 +173,10 @@ var startCmd = &cobra.Command{
 				if state.Name == stateName {
 					if state.Status == appserver.AppStatusRunning {
 						startProcess = false
-						internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
+						appReachedRunning = true
+						if !startVerbose {
+							internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
+						}
 						// Query the configured geoip URL through the VPN to confirm
 						// the exit IP changed. The visor itself uses an embedded
 						// MaxMind database now; this is one of the few remaining
@@ -142,9 +195,27 @@ var startCmd = &cobra.Command{
 						out := output{
 							AppError: state.DetailedStatus,
 						}
-						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln("\nError! > "+state.DetailedStatus))
+						leader := "\n"
+						if startVerbose {
+							leader = ""
+						}
+						internal.PrintOutput(cmd.Flags(), out, fmt.Sprintln(leader+"Error! > "+state.DetailedStatus))
 					}
 				}
+			}
+		}
+
+		// --verbose: stay in the foreground, streaming logs until the
+		// user hits ctrl+c. Then stop the app cleanly and exit.
+		if startVerbose && appReachedRunning {
+			fmt.Fprintln(os.Stderr, "--- vpn running; streaming logs (ctrl+c to stop) ---")
+			<-ctx.Done()
+			fmt.Fprintln(os.Stderr, "stopping app...")
+			if err := rpcClient.StopApp(stateName); err != nil {
+				fmt.Fprintf(os.Stderr, "stop app: %v\n", err)
+			}
+			if verboseDone != nil {
+				<-verboseDone
 			}
 		}
 	},

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -27,7 +27,6 @@ import (
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
-	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 func init() {
@@ -115,36 +114,17 @@ var startCmd = &cobra.Command{
 		// --verbose: open a gRPC log stream BEFORE StartVPNClientWithMode
 		// so startup entries (route setup, transport probe, app spawn) are
 		// captured. Mirrors 'proxy start --verbose'.
-		var verboseDone chan struct{}
+		var verboseStream *clirpc.VerboseStream
 		if startVerbose {
-			grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
+			vs, err := clirpc.OpenVerbose(ctx, clirpc.Addr, clirpc.VerboseFilter{
+				AppName: stateName,
+				Level:   startVerboseLevel,
+			})
 			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("verbose: gRPC dial failed: %w", err))
+				internal.PrintFatalError(cmd.Flags(), err)
 			}
-			verboseDone = make(chan struct{})
-			subscribedCh := make(chan struct{})
-			go func() {
-				defer close(verboseDone)
-				defer grpcClient.Close() //nolint:errcheck,gosec
-				err := grpcClient.StreamAppLogs(ctx, stateName, false, startVerboseLevel, nil, subscribedCh, func(e *rpcgrpc.AppLogEntry) {
-					ts := time.Unix(0, e.TimestampNs).Format("15:04:05.000")
-					module := e.Module
-					if module == "" {
-						module = "-"
-					}
-					fmt.Fprintf(os.Stderr, "%s %5s [%s] %s\n", ts, strings.ToUpper(e.Level), module, e.Message)
-				})
-				if err != nil && ctx.Err() == nil {
-					fmt.Fprintf(os.Stderr, "verbose stream ended: %v\n", err)
-				}
-			}()
-			// Block until subscription handshake completes so StartVPN's
-			// initial setup chatter isn't lost to the race.
-			select {
-			case <-subscribedCh:
-			case <-time.After(2 * time.Second):
-				fmt.Fprintln(os.Stderr, "verbose: subscription not confirmed within 2s; proceeding anyway")
-			case <-ctx.Done():
+			verboseStream = vs
+			if err := vs.WaitSubscribed(ctx, 2*time.Second); err != nil && ctx.Err() != nil {
 				return
 			}
 		}
@@ -214,8 +194,8 @@ var startCmd = &cobra.Command{
 			if err := rpcClient.StopApp(stateName); err != nil {
 				fmt.Fprintf(os.Stderr, "stop app: %v\n", err)
 			}
-			if verboseDone != nil {
-				<-verboseDone
+			if verboseStream != nil {
+				verboseStream.Close()
 			}
 		}
 	},

--- a/pkg/app/appcommon/log_store.go
+++ b/pkg/app/appcommon/log_store.go
@@ -34,14 +34,25 @@ func NewProcLogger(conf ProcConfig, mLog *logging.MasterLogger) (appLog *logging
 	}
 
 	// Create isolated MasterLogger for this app instead of reusing shared one.
-	// This prevents hooks from one app affecting logs from other apps.
-	// We copy the essential settings (Out, Formatter, Level) from the parent logger
-	// to ensure consistent behavior.
+	// This prevents hooks from one app affecting logs from other apps —
+	// specifically the bbolt LogStore, which is per-app.
+	// We copy the essential settings (Out, Formatter, Level) from the parent
+	// logger to ensure consistent behavior, and re-attach the parent's
+	// existing hooks (e.g. the runtime logstore + the gRPC log Broadcaster
+	// used by 'cli proxy start --verbose') so cross-cutting observers see
+	// every app's logs. The per-app bbolt store is then layered on top —
+	// it's still scoped to this AppName via the bucket key, so isolation
+	// at the storage layer is preserved.
 	appLog = logging.NewMasterLogger()
 	appLog.SetLevel(mLog.GetLevel())
 	appLog.Logger.Out = mLog.Logger.Out
 	if mLog.Logger.Formatter != nil {
 		appLog.Logger.Formatter = mLog.Logger.Formatter
+	}
+	for _, hooks := range mLog.Logger.Hooks {
+		for _, h := range hooks {
+			appLog.Logger.AddHook(h)
+		}
 	}
 	appLog.Logger.AddHook(db)
 

--- a/pkg/app/appnet/networker.go
+++ b/pkg/app/appnet/networker.go
@@ -28,6 +28,32 @@ var (
 	networkersMx sync.RWMutex
 )
 
+// appNameCtxKey is the context key used to thread the calling app's
+// name from RPCIngressGateway.Dial through appnet.DialContext into
+// SkywireNetworker.DialContextWithOptions, where it lands on
+// router.DialOptions.AppName so router-side log entries get tagged
+// for 'cli proxy start --verbose'.
+type appNameCtxKey struct{}
+
+// WithAppName returns a derived context that carries the given app
+// name. SkywireNetworker reads it via AppNameFromContext.
+func WithAppName(ctx context.Context, appName string) context.Context {
+	if appName == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, appNameCtxKey{}, appName)
+}
+
+// AppNameFromContext returns the app name stored on ctx by
+// WithAppName, or "" if none.
+func AppNameFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	v, _ := ctx.Value(appNameCtxKey{}).(string)
+	return v
+}
+
 // AddNetworker associates Networker with the `network`.
 func AddNetworker(t Type, n Networker) error {
 	networkersMx.Lock()

--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -73,6 +73,12 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 	if r.MuxRoutes > 1 && opts.MuxRoutes == 0 {
 		opts.MuxRoutes = r.MuxRoutes
 	}
+	// If the caller threaded an app name on the context (e.g.
+	// RPCIngressGateway.Dial), surface it on opts so router-side
+	// rg-scoped logs get tagged with app_name=<n>.
+	if opts.AppName == "" {
+		opts.AppName = AppNameFromContext(ctx)
+	}
 
 	conn, err = r.r.DialRoutes(ctx, addr.PubKey, routing.Port(localPort), addr.Port, opts)
 	if err != nil {

--- a/pkg/app/appserver/mock_proc_manager.go
+++ b/pkg/app/appserver/mock_proc_manager.go
@@ -187,6 +187,34 @@ func (_m *MockProcManager) GetAppPort(appName string) (routing.Port, error) {
 	return r0, r1
 }
 
+// AppByPort provides a mock function with given fields: p
+func (_m *MockProcManager) AppByPort(p routing.Port) (string, bool) {
+	ret := _m.Called(p)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AppByPort")
+	}
+
+	var r0 string
+	var r1 bool
+	if rf, ok := ret.Get(0).(func(routing.Port) (string, bool)); ok {
+		return rf(p)
+	}
+	if rf, ok := ret.Get(0).(func(routing.Port) string); ok {
+		r0 = rf(p)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(routing.Port) bool); ok {
+		r1 = rf(p)
+	} else {
+		r1 = ret.Bool(1)
+	}
+
+	return r0, r1
+}
+
 // ProcByName provides a mock function with given fields: appName
 func (_m *MockProcManager) ProcByName(appName string) (*Proc, bool) {
 	ret := _m.Called(appName)

--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -50,6 +50,12 @@ type ProcManager interface {
 	SetDetailedStatus(appName, status string) error
 	DetailedStatus(appName string) (string, error)
 	GetAppPort(appName string) (routing.Port, error)
+	// AppByPort is the inverse of GetAppPort: given a routing port,
+	// returns the app name registered for that port. Used by the
+	// router/setup-node layers to tag rg-scoped log entries with the
+	// originating app, so 'cli proxy start --verbose' can scope to a
+	// session.
+	AppByPort(p routing.Port) (string, bool)
 	ConnectionsSummary(appName string) ([]ConnectionSummary, error)
 	Addr() net.Addr
 }
@@ -422,6 +428,21 @@ func (m *procManager) GetAppPort(appName string) (routing.Port, error) {
 	}
 
 	return p.GetAppPort(), nil
+}
+
+// AppByPort returns the app name registered for routing.Port p, if any.
+// Linear scan over the proc map: small N (typically <10) and only
+// called on rg setup, so a reverse index isn't worth the extra
+// invariants.
+func (m *procManager) AppByPort(p routing.Port) (string, bool) {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+	for name, proc := range m.procs {
+		if proc != nil && proc.GetAppPort() == p {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // ConnectionsSummary gets connections info for the app `appName`.

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -124,7 +124,13 @@ func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error
 
 	// Thread the calling app's name on the dial context so router-side
 	// log entries pick up app_name=<n> for 'cli proxy start --verbose'.
-	dialCtx := appnet.WithAppName(context.Background(), r.proc.conf.AppName)
+	// r.proc may be nil in unit tests that exercise the gateway in
+	// isolation (see pkg/app/conn_test.go); fall back to "" then.
+	var appName string
+	if r.proc != nil {
+		appName = r.proc.conf.AppName
+	}
+	dialCtx := appnet.WithAppName(context.Background(), appName)
 	conn, err := appnet.DialContext(dialCtx, *remote)
 	if err != nil {
 		free()

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -2,6 +2,7 @@
 package appserver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -121,7 +122,10 @@ func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error
 		return err
 	}
 
-	conn, err := appnet.Dial(*remote)
+	// Thread the calling app's name on the dial context so router-side
+	// log entries pick up app_name=<n> for 'cli proxy start --verbose'.
+	dialCtx := appnet.WithAppName(context.Background(), r.proc.conf.AppName)
+	conn, err := appnet.DialContext(dialCtx, *remote)
 	if err != nil {
 		free()
 		return err

--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -137,7 +137,17 @@ func (s *subscription) matches(e *logrus.Entry) bool {
 	}
 
 	if s.filter.AppName != "" {
-		if module == s.filter.AppName {
+		// _module conventions in the visor:
+		//   - <AppName>                       — app-internal package logger
+		//   - proc:<AppName>:<procKey>        — appserver Proc logger and stdout/stderr forwarder
+		//   - app:<AppName>                   — older app-side convention (treated as alias)
+		// Match either an exact equality or a known prefix that names
+		// the app explicitly, so app stdout (which carries
+		// _module=proc:<n>:<key>) reaches the subscriber.
+		if module == s.filter.AppName ||
+			strings.HasPrefix(module, "proc:"+s.filter.AppName+":") ||
+			strings.HasPrefix(module, "app:"+s.filter.AppName+":") ||
+			strings.HasPrefix(module, "app:"+s.filter.AppName) {
 			return true
 		}
 		// The visor's various subsystems use different field names for

--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -29,14 +29,24 @@ func NewBroadcaster() *Broadcaster {
 
 // Filter selects which entries reach a subscriber.
 //
+// AppName, when set, matches entries whose _module equals AppName
+// OR whose "app" or "app_name" field equals AppName. The launcher
+// and proc-manager tag their per-app calls with app_name=<n>, and
+// each app's stdout/stderr is field-tagged _module=<n> by the
+// proc-spawning code, so AppName-only mode picks up everything that
+// is genuinely scoped to the named app.
+//
 // Module is matched as a prefix on the _module field (e.g. "router"
 // matches "router", "router_setup", "router/foo"). Multiple modules
-// are OR'd together. Empty Modules means "all modules".
+// are OR'd together. Empty Modules means "no module-prefix match";
+// AppName is the only path to acceptance.
 //
-// AppName, when set, also matches entries whose "app" field equals
-// AppName, and entries whose _module equals AppName. Together with
-// Modules this is OR-merged: an entry passes if either the module
-// prefix or the app match fires.
+// AppName + Modules are OR-merged: an entry passes if either the
+// app match fires or one of the module prefixes matches. With
+// Modules non-empty the filter is a firehose for those modules —
+// the visor has no per-app tagging on router/transport/AR entries,
+// so prefix-matching them is "show me anything from layer X" rather
+// than "show me what layer X is doing for app Y".
 //
 // MinLevel is inclusive — entries strictly less severe than MinLevel
 // are dropped. logrus levels descend from Panic (0) to Trace (6), so
@@ -126,16 +136,16 @@ func (s *subscription) matches(e *logrus.Entry) bool {
 		}
 	}
 
-	app := ""
-	if v, ok := e.Data["app"]; ok {
-		if a, ok := v.(string); ok {
-			app = a
-		}
-	}
-
 	if s.filter.AppName != "" {
-		if app == s.filter.AppName || module == s.filter.AppName {
+		if module == s.filter.AppName {
 			return true
+		}
+		for _, k := range []string{"app", "app_name"} {
+			if v, ok := e.Data[k]; ok {
+				if a, ok := v.(string); ok && a == s.filter.AppName {
+					return true
+				}
+			}
 		}
 	}
 

--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -140,7 +140,12 @@ func (s *subscription) matches(e *logrus.Entry) bool {
 		if module == s.filter.AppName {
 			return true
 		}
-		for _, k := range []string{"app", "app_name"} {
+		// The visor's various subsystems use different field names for
+		// the originating app: launcher uses "cmd", proc_manager uses
+		// "appName" / "app" / "app_name" depending on the call site,
+		// router rg-scoped logs use "app_name". Match any of them to
+		// catch the full lifecycle.
+		for _, k := range []string{"app", "app_name", "appName", "cmd"} {
 			if v, ok := e.Data[k]; ok {
 				if a, ok := v.(string); ok && a == s.filter.AppName {
 					return true

--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -1,0 +1,156 @@
+// Package logging pkg/logging/broadcaster.go
+package logging
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Broadcaster is a logrus.Hook that fans out entries to a set of
+// subscriber channels. Subscribers register a Filter; only entries
+// that pass the filter are delivered.
+//
+// The hook is on the hot logging path, so delivery is non-blocking:
+// each subscriber owns a bounded channel, and entries are dropped on
+// full rather than back-pressuring the producer. Drops are counted
+// per-subscriber so the consumer can tell how lossy its window was.
+type Broadcaster struct {
+	mu   sync.RWMutex
+	subs map[*subscription]struct{}
+}
+
+// NewBroadcaster constructs an empty Broadcaster.
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{subs: make(map[*subscription]struct{})}
+}
+
+// Filter selects which entries reach a subscriber.
+//
+// Module is matched as a prefix on the _module field (e.g. "router"
+// matches "router", "router_setup", "router/foo"). Multiple modules
+// are OR'd together. Empty Modules means "all modules".
+//
+// AppName, when set, also matches entries whose "app" field equals
+// AppName, and entries whose _module equals AppName. Together with
+// Modules this is OR-merged: an entry passes if either the module
+// prefix or the app match fires.
+//
+// MinLevel is inclusive — entries strictly less severe than MinLevel
+// are dropped. logrus levels descend from Panic (0) to Trace (6), so
+// "less severe" means "higher numerically".
+type Filter struct {
+	AppName  string
+	Modules  []string
+	MinLevel logrus.Level
+}
+
+type subscription struct {
+	filter  Filter
+	ch      chan *logrus.Entry
+	dropped uint64 // atomic
+	closed  atomic.Bool
+}
+
+// Levels reports all logrus levels — Broadcaster does its own level
+// filtering per-subscriber so the hook itself runs on every level.
+func (b *Broadcaster) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire delivers e to every subscriber whose filter matches. Never
+// blocks on a slow consumer: full subscriber channels increment a
+// drop counter and continue.
+func (b *Broadcaster) Fire(e *logrus.Entry) error {
+	b.mu.RLock()
+	for sub := range b.subs {
+		if !sub.matches(e) {
+			continue
+		}
+		select {
+		case sub.ch <- e:
+		default:
+			atomic.AddUint64(&sub.dropped, 1)
+		}
+	}
+	b.mu.RUnlock()
+	return nil
+}
+
+// Subscribe returns a receive-only channel of matching entries plus a
+// cancel func. The channel is closed when cancel is called. Capacity
+// is the per-subscriber buffer — entries beyond it are dropped (see
+// Dropped).
+func (b *Broadcaster) Subscribe(f Filter, capacity int) (<-chan *logrus.Entry, func() uint64) {
+	if capacity <= 0 {
+		capacity = 256
+	}
+	if f.MinLevel == 0 {
+		f.MinLevel = logrus.DebugLevel
+	}
+	sub := &subscription{
+		filter: f,
+		ch:     make(chan *logrus.Entry, capacity),
+	}
+	b.mu.Lock()
+	b.subs[sub] = struct{}{}
+	b.mu.Unlock()
+
+	cancel := func() uint64 {
+		if !sub.closed.CompareAndSwap(false, true) {
+			return atomic.LoadUint64(&sub.dropped)
+		}
+		// Take the write lock so any in-flight Fire holding RLock has
+		// finished iterating before we delete and close — no chance of
+		// sending to a closed channel.
+		b.mu.Lock()
+		delete(b.subs, sub)
+		b.mu.Unlock()
+		close(sub.ch)
+		return atomic.LoadUint64(&sub.dropped)
+	}
+	return sub.ch, cancel
+}
+
+func (s *subscription) matches(e *logrus.Entry) bool {
+	if e.Level > s.filter.MinLevel {
+		return false
+	}
+
+	module := ""
+	if v, ok := e.Data[logModuleKey]; ok {
+		if m, ok := v.(string); ok {
+			module = m
+		}
+	}
+
+	app := ""
+	if v, ok := e.Data["app"]; ok {
+		if a, ok := v.(string); ok {
+			app = a
+		}
+	}
+
+	if s.filter.AppName != "" {
+		if app == s.filter.AppName || module == s.filter.AppName {
+			return true
+		}
+	}
+
+	if len(s.filter.Modules) == 0 {
+		// No module filter: AppName-only mode.
+		return s.filter.AppName == ""
+	}
+
+	for _, m := range s.filter.Modules {
+		if m == "" {
+			continue
+		}
+		if strings.HasPrefix(module, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -24,6 +24,17 @@ func (logger *Logger) WithTime(t time.Time) *logrus.Entry {
 	return logger.WithFields(logrus.Fields{}).WithTime(t)
 }
 
+// WithAppName returns a derived Logger that attaches app_name=<name>
+// to every entry. Empty name is a no-op (returns the receiver).
+// Used by router-side scoping so 'cli proxy start --verbose' can
+// match on the field.
+func (logger *Logger) WithAppName(name string) *Logger {
+	if name == "" {
+		return logger
+	}
+	return &Logger{FieldLogger: logger.WithField("app_name", name)}
+}
+
 // MasterLogger wraps logrus.Logger and is able to create new package-aware loggers
 type MasterLogger struct {
 	*logrus.Logger

--- a/pkg/route-finder/store/finder.go
+++ b/pkg/route-finder/store/finder.go
@@ -44,29 +44,37 @@ func (g *Graph) GetRoute(ctx context.Context, source, destination cipher.PubKey,
 	return routes, nil
 }
 
-// MaxBFSQueue caps the size of StreamRoutes' BFS queue as a memory
-// safety net. Dense graphs with high maxLen can grow the queue
-// exponentially; once it exceeds the cap, StreamRoutes stops adding
-// new neighbors but continues draining what it has. Set to 0 to
-// disable (use with caution).
-var MaxBFSQueue = 200000
+// DefaultMaxBFSQueue is the default per-call BFS queue cap when the
+// caller of StreamRoutesWithCap passes 0 / negative. Conservative
+// enough to fit comfortably on a CLI/visor without OOMing dense
+// networks at high --max.
+const DefaultMaxBFSQueue = 200000
 
 // StreamRoutes is the streaming form of GetRoute: it yields each valid path
 // as soon as the BFS finds it, by invoking onRoute. Returning false from
 // onRoute stops the search.
 //
+// Equivalent to StreamRoutesWithCap with the default queue cap.
+func (g *Graph) StreamRoutes(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen int, onRoute func(routing.Route) bool) error {
+	return g.StreamRoutesWithCap(ctx, source, destination, minLen, maxLen, DefaultMaxBFSQueue, onRoute)
+}
+
+// StreamRoutesWithCap is StreamRoutes with an explicit per-call queue
+// cap. queueCap <= 0 means unbounded (use with caution; dense graphs at
+// high maxLen can OOM).
+//
 // BFS naturally explores by increasing hop length, so paths are emitted in
-// shortest-first order — no post-search sort is needed for the streaming
-// caller, and the caller can stop after collecting enough short paths
-// without paying for deeper exploration.
+// shortest-first order — no post-search sort is needed, and the caller
+// can stop after collecting enough short paths without paying for deeper
+// exploration.
 //
 // Memory: the working set is the BFS queue + the path being emitted; we
 // never accumulate every valid path. The queue itself is capped by
-// MaxBFSQueue, so even count=0 (unbounded) requests have a hard memory
+// queueCap, so even count=0 (unbounded) requests have a hard memory
 // ceiling. When the cap is hit, neighbor expansion is suppressed —
 // already-queued paths still drain and emit, but new branches are
-// dropped, so coverage degrades while the visor stays alive.
-func (g *Graph) StreamRoutes(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen int, onRoute func(routing.Route) bool) error {
+// dropped, so coverage degrades while the process stays alive.
+func (g *Graph) StreamRoutesWithCap(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen, queueCap int, onRoute func(routing.Route) bool) error {
 	sourceVertex, ok := g.graph[source]
 	if !ok {
 		return ErrNoRoute
@@ -132,7 +140,7 @@ func (g *Graph) StreamRoutes(ctx context.Context, source, destination cipher.Pub
 			// Memory safety: once the queue hits the cap, stop pushing
 			// new items but let the existing ones drain. The flag is
 			// sticky so we don't oscillate.
-			if MaxBFSQueue > 0 && len(queue) >= MaxBFSQueue {
+			if queueCap > 0 && len(queue) >= queueCap {
 				queueCapHit = true
 				break
 			}
@@ -151,7 +159,7 @@ func (g *Graph) StreamRoutes(ctx context.Context, source, destination cipher.Pub
 
 	if emitted == 0 {
 		if queueCapHit {
-			return fmt.Errorf("BFS queue cap (%d) hit before any route found; try lower --max", MaxBFSQueue)
+			return fmt.Errorf("BFS queue cap (%d) hit before any route found; try lower --max", queueCap)
 		}
 		return ErrRouteNotFound
 	}

--- a/pkg/route-finder/store/finder.go
+++ b/pkg/route-finder/store/finder.go
@@ -4,7 +4,7 @@ package store
 import (
 	"context"
 	"errors"
-	"sort"
+	"fmt"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -22,133 +22,160 @@ var (
 
 // GetRoute returns routes from source to destination with hop counts within [minLen, maxLen],
 // prioritized by shortest hop count first, with no duplicate vertices in the route.
+//
+// Bounded variant: stops the BFS as soon as `number` valid routes have been
+// collected. Use StreamRoutes for the unbounded streaming form when memory
+// matters more than the convenience of a slice.
 func (g *Graph) GetRoute(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen, number int) ([]routing.Route, error) {
-	sourceVertex, ok := g.graph[source]
-	if !ok {
-		return nil, ErrNoRoute
+	if number <= 0 {
+		number = 1
 	}
-
-	destinationVertex, ok := g.graph[destination]
-	if !ok {
-		return nil, ErrNoRoute
-	}
-
-	paths, err := g.finder(ctx, sourceVertex, destinationVertex, minLen, maxLen)
+	routes := make([]routing.Route, 0, number)
+	err := g.StreamRoutes(ctx, source, destination, minLen, maxLen, func(r routing.Route) bool {
+		routes = append(routes, r)
+		return len(routes) < number
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Cap preallocated capacity to the number of paths the BFS actually
-	// found. Callers may pass a large sentinel (e.g., math.MaxInt32) to
-	// request "all routes"; pre-sizing to that would OOM the process.
-	cap := number
-	if len(paths) < cap {
-		cap = len(paths)
-	}
-	routes := make([]routing.Route, 0, cap)
-	for _, path := range paths {
-		if len(routes) == number {
-			break
-		}
-
-		var route routing.Route
-		for i := 0; i < len(path)-1; i++ {
-			from := path[i]
-			to := path[i+1]
-			conn, ok := from.connections[to.edge]
-			if !ok {
-				return nil, errors.New("connection not found between vertices")
-			}
-			route.Hops = append(route.Hops, routing.Hop{
-				From: from.edge,
-				To:   to.edge,
-				TpID: conn.ID,
-			})
-		}
-		routes = append(routes, route)
-	}
-
 	if len(routes) == 0 {
 		return nil, ErrRouteNotFound
 	}
 	return routes, nil
 }
 
-// finder performs BFS to find all paths from source to destination with hop counts between minLen and maxLen,
-// ensuring no duplicate vertices in each path.
-func (g *Graph) finder(ctx context.Context, source, destination *vertex, minLen, maxLen int) ([][]*vertex, error) {
+// MaxBFSQueue caps the size of StreamRoutes' BFS queue as a memory
+// safety net. Dense graphs with high maxLen can grow the queue
+// exponentially; once it exceeds the cap, StreamRoutes stops adding
+// new neighbors but continues draining what it has. Set to 0 to
+// disable (use with caution).
+var MaxBFSQueue = 200000
+
+// StreamRoutes is the streaming form of GetRoute: it yields each valid path
+// as soon as the BFS finds it, by invoking onRoute. Returning false from
+// onRoute stops the search.
+//
+// BFS naturally explores by increasing hop length, so paths are emitted in
+// shortest-first order — no post-search sort is needed for the streaming
+// caller, and the caller can stop after collecting enough short paths
+// without paying for deeper exploration.
+//
+// Memory: the working set is the BFS queue + the path being emitted; we
+// never accumulate every valid path. The queue itself is capped by
+// MaxBFSQueue, so even count=0 (unbounded) requests have a hard memory
+// ceiling. When the cap is hit, neighbor expansion is suppressed —
+// already-queued paths still drain and emit, but new branches are
+// dropped, so coverage degrades while the visor stays alive.
+func (g *Graph) StreamRoutes(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen int, onRoute func(routing.Route) bool) error {
+	sourceVertex, ok := g.graph[source]
+	if !ok {
+		return ErrNoRoute
+	}
+	destinationVertex, ok := g.graph[destination]
+	if !ok {
+		return ErrNoRoute
+	}
+
 	type queueItem struct {
 		current *vertex
 		path    []*vertex
 		hops    int
 	}
 
-	validPaths := make([][]*vertex, 0)
-	queue := []queueItem{{
-		current: source,
-		path:    []*vertex{source},
-		hops:    0,
-	}}
+	queue := []queueItem{{current: sourceVertex, path: []*vertex{sourceVertex}, hops: 0}}
+	emitted := 0
+	queueCapHit := false
 
 	for len(queue) > 0 {
 		select {
 		case <-ctx.Done():
-			return nil, ErrContextClosed
+			return ErrContextClosed
 		default:
-			item := queue[0]
-			queue = queue[1:]
+		}
 
-			if item.current == destination {
-				if item.hops >= minLen && item.hops <= maxLen {
-					validPath := make([]*vertex, len(item.path))
-					copy(validPath, item.path)
-					validPaths = append(validPaths, validPath)
+		item := queue[0]
+		queue = queue[1:]
+
+		if item.current == destinationVertex {
+			if item.hops >= minLen && item.hops <= maxLen {
+				route, err := buildRoute(item.path)
+				if err != nil {
+					return err
 				}
+				if !onRoute(route) {
+					return nil
+				}
+				emitted++
+			}
+			continue
+		}
+
+		if item.hops >= maxLen {
+			continue
+		}
+
+		for _, neighbor := range item.current.neighbors {
+			if containsVertex(item.path, neighbor) {
+				continue // avoid cycles
+			}
+
+			// DMSG transports can only appear as the last hop in a route.
+			// A dmsg transport is brokered by a dmsg server intermediary that
+			// is not visible to the route. Allowing two dmsg hops in one route
+			// risks looping traffic through the same dmsg server, and there
+			// is no way to detect or prevent that at route-build time.
+			if conn, ok := item.current.connections[neighbor.edge]; ok &&
+				conn.Type == tptypes.DMSG && neighbor != destinationVertex {
 				continue
 			}
 
-			if item.hops >= maxLen {
-				continue
+			// Memory safety: once the queue hits the cap, stop pushing
+			// new items but let the existing ones drain. The flag is
+			// sticky so we don't oscillate.
+			if MaxBFSQueue > 0 && len(queue) >= MaxBFSQueue {
+				queueCapHit = true
+				break
 			}
 
-			for _, neighbor := range item.current.neighbors {
-				if containsVertex(item.path, neighbor) {
-					continue // Skip to avoid cycles
-				}
+			newPath := make([]*vertex, len(item.path)+1)
+			copy(newPath, item.path)
+			newPath[len(item.path)] = neighbor
 
-				// DMSG transports can only appear as the last hop in a route.
-				// A dmsg transport is brokered by a dmsg server intermediary that
-				// is not visible to the route. Allowing two dmsg hops in one route
-				// risks looping traffic through the same dmsg server, and there is
-				// no way to detect or prevent that at route-build time.
-				if conn, ok := item.current.connections[neighbor.edge]; ok &&
-					conn.Type == tptypes.DMSG && neighbor != destination {
-					continue
-				}
-
-				newPath := make([]*vertex, len(item.path)+1)
-				copy(newPath, item.path)
-				newPath[len(item.path)] = neighbor
-
-				queue = append(queue, queueItem{
-					current: neighbor,
-					path:    newPath,
-					hops:    item.hops + 1,
-				})
-			}
+			queue = append(queue, queueItem{
+				current: neighbor,
+				path:    newPath,
+				hops:    item.hops + 1,
+			})
 		}
 	}
 
-	if len(validPaths) == 0 {
-		return nil, ErrRouteNotFound
+	if emitted == 0 {
+		if queueCapHit {
+			return fmt.Errorf("BFS queue cap (%d) hit before any route found; try lower --max", MaxBFSQueue)
+		}
+		return ErrRouteNotFound
 	}
+	return nil
+}
 
-	// Sort paths by hop count (ascending)
-	sort.Slice(validPaths, func(i, j int) bool {
-		return len(validPaths[i])-1 < len(validPaths[j])-1
-	})
-
-	return validPaths, nil
+// buildRoute converts a vertex path into a routing.Route by looking up
+// the edge transports between consecutive hops.
+func buildRoute(path []*vertex) (routing.Route, error) {
+	var route routing.Route
+	for i := 0; i < len(path)-1; i++ {
+		from := path[i]
+		to := path[i+1]
+		conn, ok := from.connections[to.edge]
+		if !ok {
+			return routing.Route{}, errors.New("connection not found between vertices")
+		}
+		route.Hops = append(route.Hops, routing.Hop{
+			From: from.edge,
+			To:   to.edge,
+			TpID: conn.ID,
+		})
+	}
+	return route, nil
 }
 
 // containsVertex checks if a vertex exists in the path.

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -61,6 +61,10 @@ func (m *mockStore) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey
 	return nil
 }
 
+func (m *mockStore) UpdateLatency(_ context.Context, _ string, _, _, _ float64) error {
+	return nil
+}
+
 func (m *mockStore) GetTransportBandwidth(_ context.Context, _ uuid.UUID, _ string, _ int) ([]tpdstore.BandwidthAggregation, error) {
 	return []tpdstore.BandwidthAggregation{}, nil
 }

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -375,6 +375,35 @@ func (_m *MockRouter) RouteGroupHops(_a0 routing.RouteDescriptor) []RouteHopInfo
 	return r0
 }
 
+// RouteGroupMuxInfo provides a mock function
+func (_m *MockRouter) RouteGroupMuxInfo(_a0 routing.RouteDescriptor) (MuxInfo, bool) {
+	ret := _m.Called(_a0)
+	var r0 MuxInfo
+	var r1 bool
+	if rf, ok := ret.Get(0).(func(routing.RouteDescriptor) (MuxInfo, bool)); ok {
+		return rf(_a0)
+	}
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(MuxInfo)
+	}
+	if ret.Get(1) != nil {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
+}
+
+// RouteGroupMuxInfoForApp provides a mock function
+func (_m *MockRouter) RouteGroupMuxInfoForApp(_a0 string) []MuxInfo {
+	ret := _m.Called(_a0)
+	var r0 []MuxInfo
+	if rf, ok := ret.Get(0).(func(string) []MuxInfo); ok {
+		r0 = rf(_a0)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]MuxInfo)
+	}
+	return r0
+}
+
 // ActiveRouteStatuses provides a mock function with no fields
 func (_m *MockRouter) ActiveRouteStatuses() []RouteStatus {
 	ret := _m.Called()

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -84,6 +84,13 @@ type RouteGroup struct {
 	logger *logging.Logger
 	desc   routing.RouteDescriptor // describes the route group
 	rt     routing.Table
+	// appName is the originating app's name for the dialing side
+	// (skysocks-client, vpn-client, etc.). Empty for accept-side
+	// rg's where the app context isn't available locally. Set via
+	// SetAppName from saveRouteGroupRules. Used for app-scoped mux
+	// info lookups since the descriptor's SrcPort is ephemeral and
+	// doesn't resolve through procManager.AppByPort.
+	appName string
 
 	handshakeProcessed     chan struct{}
 	handshakeProcessedOnce sync.Once
@@ -179,15 +186,90 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 }
 
 // SetAppName attaches app_name=<n> as a logrus field on the route
-// group's logger. Used by the router-side rg saver so 'cli proxy
-// start --verbose' can scope rg-internal events (handshake, mux
-// enablement, transport churn) to the originating app's session.
+// group's logger AND records it on the rg for later lookups (mux
+// info by app, etc.). Used by the router-side rg saver so 'cli
+// proxy start --verbose' can scope rg-internal events to the
+// originating app's session.
 // No-op when name is empty.
 func (rg *RouteGroup) SetAppName(name string) {
 	if name == "" {
 		return
 	}
+	rg.appName = name
 	rg.logger = &logging.Logger{FieldLogger: rg.logger.WithField("app_name", name)}
+}
+
+// AppName returns the rg's stored app name (set via SetAppName).
+// Empty when the rg was created without app context (accept-side).
+func (rg *RouteGroup) AppName() string {
+	return rg.appName
+}
+
+// MuxInfo is a point-in-time snapshot of one route group's
+// multiplexing state — per-leg byte/packet counters plus the
+// transport identity each leg maps to. Returned by Router.MuxInfo
+// for 'cli proxy mux-info'.
+type MuxInfo struct {
+	// Desc identifies the route group.
+	Desc routing.RouteDescriptor
+	// MuxEnabled is false for non-mux'd rg's; the per-leg counters
+	// are still populated for the single transport in that case.
+	MuxEnabled bool
+	// SACKEnabled is true when the peers negotiated SACK retx.
+	SACKEnabled bool
+	// Legs is in tps[] order. One entry per active mux leg.
+	Legs []MuxLeg
+}
+
+// MuxLeg pairs the per-leg counters with the transport identity.
+// The transport's own Latency / SentBytes / RecvBytes counters are
+// the *transport-level* totals (across all rg's that share the
+// transport); the LegStats here are *rg-scoped* (only what this
+// rg sent through this leg).
+type MuxLeg struct {
+	LegStats
+	TransportID string `json:"transport_id"`
+	TpType      string `json:"tp_type"`
+	RemotePK    string `json:"remote_pk"`
+	// LatencyMS is the transport-level smoothed RTT in ms (the same
+	// value 'tp ls' shows). Zero when no measurement yet.
+	LatencyMS float64 `json:"latency_ms"`
+}
+
+// MuxStats returns a point-in-time snapshot of the rg's per-leg
+// counters paired with each leg's transport identity.
+func (rg *RouteGroup) MuxStats() MuxInfo {
+	info := MuxInfo{Desc: rg.desc}
+	rg.mu.Lock()
+	if rg.mux != nil {
+		info.MuxEnabled = true
+		info.SACKEnabled = rg.mux.sackEnabled
+	}
+	tpsCopy := append([]*transport.ManagedTransport(nil), rg.tps...)
+	rg.mu.Unlock()
+
+	var stats []LegStats
+	if rg.mux != nil {
+		stats = rg.mux.snapshotLegs()
+	}
+
+	info.Legs = make([]MuxLeg, 0, len(tpsCopy))
+	for i, tp := range tpsCopy {
+		leg := MuxLeg{}
+		if i < len(stats) {
+			leg.LegStats = stats[i]
+		} else {
+			leg.Index = i
+		}
+		if tp != nil {
+			leg.TransportID = tp.Entry.ID.String()
+			leg.TpType = string(tp.Entry.Type)
+			leg.RemotePK = tp.Remote().String()
+			leg.LatencyMS = tp.GetLatency()
+		}
+		info.Legs = append(info.Legs, leg)
+	}
+	return info
 }
 
 // Read reads the next packet payload of a RouteGroup.
@@ -225,14 +307,14 @@ func (rg *RouteGroup) Write(p []byte) (n int, err error) {
 	}
 
 	rg.mu.Lock()
-	tp, rule, err := rg.nextTransport()
+	tp, rule, leg, err := rg.nextTransport()
 	if err != nil {
 		rg.mu.Unlock()
 		return 0, err
 	}
 	rg.mu.Unlock()
 
-	return rg.write(p, tp, rule)
+	return rg.write(p, tp, rule, leg)
 }
 
 // Close closes a RouteGroup.
@@ -366,7 +448,7 @@ func (rg *RouteGroup) read(p []byte) (int, error) {
 	}
 }
 
-func (rg *RouteGroup) write(data []byte, tp *transport.ManagedTransport, rule routing.Rule) (int, error) {
+func (rg *RouteGroup) write(data []byte, tp *transport.ManagedTransport, rule routing.Rule, leg int) (int, error) {
 	var packet routing.Packet
 	var err error
 	if rg.mux != nil {
@@ -395,6 +477,15 @@ func (rg *RouteGroup) write(data []byte, tp *transport.ManagedTransport, rule ro
 		}
 
 		atomic.StoreInt64(&rg.lastSent, time.Now().UnixNano())
+
+		// Per-mux-leg sent counter. The aggregate networkStats is
+		// already updated inside writePacket (and gates on packet
+		// type); this records the same packet against the specific
+		// leg that carried it so 'proxy mux-info' can show
+		// where bandwidth is going across the mux'd routes.
+		if rg.mux != nil && leg >= 0 {
+			rg.mux.recordSent(leg, uint64(packet.Size()))
+		}
 
 		return len(data), nil
 	}
@@ -440,16 +531,19 @@ func (rg *RouteGroup) writePacket(ctx context.Context, tp *transport.ManagedTran
 // multiple transports exist, uses latency-weighted selection. Falls back to
 // round-robin when latency data is unavailable, and to index 0 for single
 // transport (legacy behavior).
+// Returns the leg index (position in rg.tps) so the caller can record
+// per-leg byte counts after a successful write; -1 for the
+// single-transport / legacy path.
 // NOTE: not thread-safe, caller must hold rg.mu.
-func (rg *RouteGroup) nextTransport() (*transport.ManagedTransport, routing.Rule, error) {
+func (rg *RouteGroup) nextTransport() (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(rg.tps) == 0 {
-		return nil, nil, ErrNoTransports
+		return nil, nil, -1, ErrNoTransports
 	}
 	if len(rg.fwd) == 0 {
-		return nil, nil, ErrNoRules
+		return nil, nil, -1, ErrNoRules
 	}
 	if len(rg.tps) != len(rg.fwd) {
-		return nil, nil, ErrRuleTransportMismatch
+		return nil, nil, -1, ErrRuleTransportMismatch
 	}
 
 	if rg.mux != nil && len(rg.tps) > 1 {
@@ -457,9 +551,9 @@ func (rg *RouteGroup) nextTransport() (*transport.ManagedTransport, routing.Rule
 	}
 
 	if rg.tps[0] == nil {
-		return nil, nil, ErrBadTransport
+		return nil, nil, -1, ErrBadTransport
 	}
-	return rg.tps[0], rg.fwd[0], nil
+	return rg.tps[0], rg.fwd[0], 0, nil
 }
 
 // RouteHops returns the list of visor public keys that form the route path.
@@ -878,6 +972,11 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 			if remoteCaps&routing.CapMux != 0 {
 				sack := remoteCaps&routing.CapSACK != 0
 				rg.mux = newRouteMux(rg.logger, sack)
+				// rg.tps already has the primary transport at this
+				// point; size the leg counters to match. Subsequent
+				// AppendRoute calls (mux 2/N+) extend the slice via
+				// appendRules.
+				rg.mux.growLegs(len(rg.tps))
 				rg.logger.Debug("Route multiplexing enabled (both peers support CapMux)")
 				if sack {
 					rg.logger.Debug("SACK retransmission enabled (both peers support CapSACK)")
@@ -909,6 +1008,23 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) error {
 		return nil
 	}
 	rg.networkStats.AddBandwidthReceived(uint64(packet.Size()))
+
+	// Per-mux-leg recv counter. We resolve the leg from the
+	// packet's route ID (which matches one of rg.rvs[].KeyRouteID,
+	// each leg has its own consume rule). The lookup is O(legs)
+	// but legs is small (typically 1-16) and this only runs for
+	// data packets after we've already paid for noise decryption.
+	if rg.mux != nil {
+		rg.mu.Lock()
+		rid := packet.RouteID()
+		for i, rule := range rg.rvs {
+			if rule != nil && rule.KeyRouteID() == rid {
+				rg.mux.recordRecv(i, uint64(packet.Size()))
+				break
+			}
+		}
+		rg.mu.Unlock()
+	}
 
 	if rg.mux != nil {
 		seq := packet.SequenceNumber()
@@ -1005,7 +1121,7 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 		}
 
 		rg.mu.Lock()
-		tp, rule, err := rg.nextTransport()
+		tp, rule, leg, err := rg.nextTransport()
 		rg.mu.Unlock()
 		if err != nil {
 			return err
@@ -1018,6 +1134,11 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 
 		if err := rg.writePacket(context.Background(), tp, retxPacket, rule.KeyRouteID()); err != nil {
 			rg.logger.WithError(err).Warnf("SACK: failed to retransmit seq %d", seq)
+		} else if leg >= 0 {
+			// Count retransmits against the leg that carried them
+			// (which may differ from the original send leg — the
+			// retx selector picks fresh, mirroring the data path).
+			rg.mux.recordSent(leg, uint64(retxPacket.Size()))
 		}
 	}
 	return nil
@@ -1243,6 +1364,10 @@ func (rg *RouteGroup) appendRules(forward, reverse routing.Rule, tp *transport.M
 	// Rebuild transport weights when transports change
 	if rg.mux != nil && len(rg.tps) > 1 {
 		rg.mux.rebuildWeights(rg.tps)
+	}
+	// Keep per-leg counters parallel to tps[].
+	if rg.mux != nil {
+		rg.mux.growLegs(len(rg.tps))
 	}
 }
 

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -178,6 +178,18 @@ func NewRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDe
 	return rg
 }
 
+// SetAppName attaches app_name=<n> as a logrus field on the route
+// group's logger. Used by the router-side rg saver so 'cli proxy
+// start --verbose' can scope rg-internal events (handshake, mux
+// enablement, transport churn) to the originating app's session.
+// No-op when name is empty.
+func (rg *RouteGroup) SetAppName(name string) {
+	if name == "" {
+		return
+	}
+	rg.logger = &logging.Logger{FieldLogger: rg.logger.WithField("app_name", name)}
+}
+
 // Read reads the next packet payload of a RouteGroup.
 // The Router, via transport.Manager, is responsible for reading incoming packets and pushing it
 // to the appropriate RouteGroup via (*RouteGroup).readCh.

--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -188,7 +188,7 @@ func TestMuxSelectTransportSkipsDead(t *testing.T) {
 
 	// Select should return transport 2 (the only alive one)
 	rg.mu.Lock()
-	tp, _, err := rg.mux.selectTransport(rg.tps, rg.fwd)
+	tp, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd)
 	rg.mu.Unlock()
 
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestMuxSelectTransportFailsAllDead(t *testing.T) {
 	}
 
 	rg.mu.Lock()
-	_, _, err := rg.mux.selectTransport(rg.tps, rg.fwd)
+	_, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd)
 	rg.mu.Unlock()
 
 	require.ErrorIs(t, err, ErrNoSuitableTransport)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -2,12 +2,44 @@
 package router
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 )
+
+// LegStats is a snapshot of per-mux-leg traffic counters at a point
+// in time. One entry per active route in the rg's tps[] order.
+//
+// Counters are cumulative since route-group creation (atomic uint64);
+// callers wanting rates take two snapshots and divide by elapsed time.
+// Used by 'cli proxy mux-info' to show where bandwidth is going across
+// the mux'd routes — the missing piece for verifying that adding more
+// routes actually aggregates throughput rather than just trading share.
+type LegStats struct {
+	// Index in the rg's tps[] slice. Stable for the rg's lifetime
+	// (transports are appended, never re-ordered) so the index is
+	// also a stable identifier for runtime add/remove operations.
+	Index int
+	// SentBytes / SentPackets are what THIS leg carried outbound.
+	SentBytes   uint64
+	SentPackets uint64
+	// RecvBytes / RecvPackets are what THIS leg carried inbound.
+	// Resolved from the reverse-rule's KeyRouteID at packet-handle
+	// time, so it reflects what actually arrived on this transport,
+	// not what the peer said it sent.
+	RecvBytes   uint64
+	RecvPackets uint64
+}
+
+type legCounters struct {
+	sentBytes   uint64 // atomic
+	sentPackets uint64 // atomic
+	recvBytes   uint64 // atomic
+	recvPackets uint64 // atomic
+}
 
 // routeMux encapsulates route multiplexing state and logic.
 // It is composed into RouteGroup as an optional field (nil when mux is not negotiated).
@@ -30,6 +62,13 @@ type routeMux struct {
 	sackEnabled bool         // true when both peers advertised CapSACK
 	sackTracker *sackTracker // receiver: tracks received seqs for SACK generation
 	retxBuf     *retxBuffer  // sender: holds unACKed packets for retransmission
+
+	// Per-leg traffic counters parallel to the rg's tps[] / fwd[] /
+	// rvs[] slices. Mutated atomically. Read via Snapshot().
+	// legMu guards the slice itself (extended on AppendRoute), not
+	// the individual counters.
+	legMu sync.RWMutex
+	legs  []*legCounters
 }
 
 // newRouteMux creates a new routeMux instance with all sub-components initialized.
@@ -47,13 +86,15 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 
 // selectTransport picks the next transport/rule pair for sending.
 // Uses latency-weighted selection when data is available, falls back to round-robin.
+// Returns the index in tps[] alongside the tp/rule so the caller can
+// record per-leg byte counts after a successful write.
 // NOTE: not thread-safe, caller must hold the RouteGroup mu.
-func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule) (*transport.ManagedTransport, routing.Rule, error) {
+func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule) (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(tps) == 0 {
-		return nil, nil, ErrNoTransports
+		return nil, nil, -1, ErrNoTransports
 	}
 	if len(fwd) == 0 {
-		return nil, nil, ErrNoRules
+		return nil, nil, -1, ErrNoRules
 	}
 
 	// Use weighted selector if available
@@ -62,7 +103,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		if idx < len(tps) {
 			tp := tps[idx]
 			if tp != nil && !tp.IsClosed() {
-				return tp, fwd[idx], nil
+				return tp, fwd[idx], idx, nil
 			}
 		}
 	}
@@ -71,13 +112,74 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 	n := uint32(len(tps)) //nolint:gosec
 	start := atomic.AddUint32(&m.tpIndex, 1) - 1
 	for i := uint32(0); i < n; i++ {
-		idx := (start + i) % n
+		idx := int((start + i) % n) //nolint:gosec
 		tp := tps[idx]
 		if tp != nil && !tp.IsClosed() {
-			return tp, fwd[idx], nil
+			return tp, fwd[idx], idx, nil
 		}
 	}
-	return nil, nil, ErrNoSuitableTransport
+	return nil, nil, -1, ErrNoSuitableTransport
+}
+
+// growLegs extends the per-leg counter slice to cover at least n
+// legs. Called when transports are appended to the rg (initial setup
+// + AppendRoute). Idempotent — extending past the current size is a
+// no-op for legs that already exist.
+func (m *routeMux) growLegs(n int) {
+	m.legMu.Lock()
+	for len(m.legs) < n {
+		m.legs = append(m.legs, &legCounters{})
+	}
+	m.legMu.Unlock()
+}
+
+// recordSent atomically increments the sent-bytes/packets counters
+// for leg idx. Bounds-checked; out-of-range indices are silently
+// dropped (defensive: a leg can be removed between selectTransport
+// and the actual write returning).
+func (m *routeMux) recordSent(idx int, n uint64) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.RLock()
+	if idx < len(m.legs) {
+		atomic.AddUint64(&m.legs[idx].sentBytes, n)
+		atomic.AddUint64(&m.legs[idx].sentPackets, 1)
+	}
+	m.legMu.RUnlock()
+}
+
+// recordRecv atomically increments the recv-bytes/packets counters
+// for leg idx. Same bounds-check semantics as recordSent.
+func (m *routeMux) recordRecv(idx int, n uint64) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.RLock()
+	if idx < len(m.legs) {
+		atomic.AddUint64(&m.legs[idx].recvBytes, n)
+		atomic.AddUint64(&m.legs[idx].recvPackets, 1)
+	}
+	m.legMu.RUnlock()
+}
+
+// snapshotLegs returns a stable copy of the current per-leg counters.
+// Atomic loads, no locking against in-flight increments — the
+// snapshot is point-in-time and the underlying counters keep moving.
+func (m *routeMux) snapshotLegs() []LegStats {
+	m.legMu.RLock()
+	out := make([]LegStats, len(m.legs))
+	for i, c := range m.legs {
+		out[i] = LegStats{
+			Index:       i,
+			SentBytes:   atomic.LoadUint64(&c.sentBytes),
+			SentPackets: atomic.LoadUint64(&c.sentPackets),
+			RecvBytes:   atomic.LoadUint64(&c.recvBytes),
+			RecvPackets: atomic.LoadUint64(&c.recvPackets),
+		}
+	}
+	m.legMu.RUnlock()
+	return out
 }
 
 // wrapPayload creates a sequenced data packet and optionally stores it for retransmission.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -122,6 +122,13 @@ type DialOptions struct {
 	ExcludeTransportIDs []uuid.UUID   // Transport IDs to exclude from route calculation (for mux)
 	ExcludeDMSG         bool          // Exclude DMSG transports (for mux — DMSG is a relay, not suitable for multiplexing)
 	KeepAlive           time.Duration // Route keepalive (0 = DefaultRouteKeepAlive). Routes idle longer expire.
+	// AppName is the originating app's name. Set by appnet's
+	// DialContextWithOptions when the caller threaded a context
+	// carrying it (RPCIngressGateway.Dial uses appnet.WithAppName).
+	// router-side: scopedLog prefers this over AppLookup-by-port,
+	// since DialRoutes is invoked with an ephemeral source port that
+	// isn't the app's registered SetAppPort value.
+	AppName string
 }
 
 // DefaultDialOptions returns default dial options.
@@ -235,7 +242,20 @@ func (r *router) scopedLog(lPort routing.Port) *logging.Logger {
 	if !ok || name == "" {
 		return r.logger
 	}
-	return &logging.Logger{FieldLogger: r.logger.WithField("app_name", name)}
+	return r.logger.WithAppName(name)
+}
+
+// scopedLogForOpts returns a logger augmented with app_name=<n> when
+// opts carries an AppName (set via the appnet.WithAppName context
+// path), falling back to the port-based scopedLog. Used in DialRoutes
+// where the lPort is an ephemeral port that doesn't resolve via
+// AppLookup, but the caller has already threaded the canonical name
+// through DialOptions.
+func (r *router) scopedLogForOpts(opts *DialOptions, lPort routing.Port) *logging.Logger {
+	if opts != nil && opts.AppName != "" {
+		return r.logger.WithAppName(opts.AppName)
+	}
+	return r.scopedLog(lPort)
 }
 
 // New constructs a new Router.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -185,6 +185,19 @@ type Router interface {
 	// matching route group is found.
 	RouteGroupHops(desc routing.RouteDescriptor) []RouteHopInfo
 
+	// RouteGroupMuxInfo returns a snapshot of per-leg mux state for
+	// the rg matching desc (or its inversion). Returns false when no
+	// matching active rg is found. Used by 'cli proxy mux-info' to
+	// surface per-leg bandwidth + latency for diagnostic purposes.
+	RouteGroupMuxInfo(desc routing.RouteDescriptor) (MuxInfo, bool)
+
+	// RouteGroupMuxInfoForApp returns mux snapshots for every active
+	// rg whose source port maps (via AppLookup) to the named app.
+	// One app may have multiple rg's at once (e.g. each SOCKS5
+	// client connection to skysocks-client gets its own rg). Returns
+	// an empty slice if no rg's are active for the app.
+	RouteGroupMuxInfoForApp(appName string) []MuxInfo
+
 	// Routing table related methods
 	RoutesCount() int
 	Rules() []routing.Rule

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -80,6 +80,12 @@ type Config struct {
 	// dialing it during the router-init window don't hit "request has no
 	// associated listener" warnings.
 	AwaitSetupListener *dmsg.Listener
+	// AppLookup, if set, resolves a routing.Port to the originating
+	// app name. Used to tag rg-scoped log entries with app_name=<n>
+	// so 'cli proxy start --verbose' can scope to a session. nil
+	// means no lookup is performed and entries are emitted untagged
+	// (the existing behavior).
+	AppLookup func(routing.Port) (string, bool)
 }
 
 // SetDefaults sets default values for certain empty values.
@@ -213,6 +219,23 @@ type router struct {
 	muxMode            WeightMode       // default weight mode for new mux connections
 	lastRouteCalcTime  time.Duration    // last route calculation time (for local routes)
 	lastRouteCalcMu    sync.Mutex       // protects lastRouteCalcTime
+}
+
+// scopedLog returns a logger augmented with app_name=<n> when the
+// configured AppLookup resolves lPort to an app, otherwise the
+// router's bare logger. Callers use the returned logger for
+// rg-scoped entries so 'cli proxy start --verbose' can filter on
+// the field. Cheap on the no-lookup path (returns the bare logger
+// directly).
+func (r *router) scopedLog(lPort routing.Port) *logging.Logger {
+	if r.conf == nil || r.conf.AppLookup == nil {
+		return r.logger
+	}
+	name, ok := r.conf.AppLookup(lPort)
+	if !ok || name == "" {
+		return r.logger
+	}
+	return &logging.Logger{FieldLogger: r.logger.WithField("app_name", name)}
 }
 
 // New constructs a new Router.

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -138,7 +138,11 @@ func (r *router) DialRoutes(
 			Initiator: true,
 		}
 
-		nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf)
+		appName := ""
+		if opts != nil {
+			appName = opts.AppName
+		}
+		nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, appName)
 		if err != nil {
 			// Clean up saved rules on failure
 			r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
@@ -233,7 +237,11 @@ func (r *router) setupPingRoute(
 		Initiator: true,
 	}
 
-	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf)
+	appName := ""
+	if opts != nil {
+		appName = opts.AppName
+	}
+	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, appName)
 	if err != nil {
 		// Clean up saved rules if route group setup fails
 		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
@@ -676,7 +684,7 @@ func (r *router) establishMuxRoutes(
 	forwardDesc routing.RouteDescriptor,
 	primaryTpID uuid.UUID,
 ) {
-	log := r.scopedLog(forwardDesc.SrcPort())
+	log := r.scopedLogForOpts(opts, forwardDesc.SrcPort())
 	muxCount := 1
 	if opts != nil && opts.MuxRoutes > 1 {
 		muxCount = opts.MuxRoutes

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -36,14 +36,16 @@ func (r *router) DialRoutes(
 	opts *DialOptions,
 ) (net.Conn, error) {
 
+	log := r.scopedLog(lPort)
+
 	if rPK.Null() {
 		err := ErrRemoteEmptyPK
-		r.logger.WithError(err).Error("Failed to dial routes.")
+		log.WithError(err).Error("Failed to dial routes.")
 		return nil, fmt.Errorf("failed to dial routes: %w", err)
 	}
 
 	if r.conf.MinHops == 0 {
-		r.logger.Error("Routing disabled. (minhop=0)")
+		log.Error("Routing disabled. (minhop=0)")
 		return nil, fmt.Errorf("routing disabled. (minhop=0)")
 	}
 
@@ -76,7 +78,7 @@ func (r *router) DialRoutes(
 		}
 		r.routeSetupHookMu.Unlock()
 	} else if useExistingOnly {
-		r.logger.Debug("UseExistingTpOnly is set, skipping transport creation hooks")
+		log.Debug("UseExistingTpOnly is set, skipping transport creation hooks")
 	}
 
 	// Retry route setup with fresh routes if it fails due to stale TPD data.
@@ -87,7 +89,7 @@ func (r *router) DialRoutes(
 		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, lPK, rPK, opts)
 		if err != nil {
 			if attempt < maxRetries {
-				r.logger.WithError(err).Warnf("Route finder failed (attempt %d/%d), retrying with fresh query...", attempt, maxRetries)
+				log.WithError(err).Warnf("Route finder failed (attempt %d/%d), retrying with fresh query...", attempt, maxRetries)
 				continue
 			}
 			return nil, fmt.Errorf("route finder: %w", err)
@@ -104,13 +106,13 @@ func (r *router) DialRoutes(
 			Reverse:   reversePath,
 		}
 
-		rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(ctx, r.logger, r.dmsgC, r.conf.SetupNodes, req)
+		rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, req)
 		if err != nil {
 			if attempt < maxRetries {
-				r.logger.WithError(err).Warnf("Route setup failed (attempt %d/%d), retrying with fresh route...", attempt, maxRetries)
+				log.WithError(err).Warnf("Route setup failed (attempt %d/%d), retrying with fresh route...", attempt, maxRetries)
 				continue
 			}
-			r.logger.WithError(err).Error("Error dialing route group")
+			log.WithError(err).Error("Error dialing route group")
 			return nil, err
 		}
 
@@ -121,10 +123,10 @@ func (r *router) DialRoutes(
 
 		if err := r.SaveRoutingRules(rules.Forward, rules.Reverse); err != nil {
 			if attempt < maxRetries {
-				r.logger.WithError(err).Warnf("Saving routing rules failed (attempt %d/%d), retrying with fresh route...", attempt, maxRetries)
+				log.WithError(err).Warnf("Saving routing rules failed (attempt %d/%d), retrying with fresh route...", attempt, maxRetries)
 				continue
 			}
-			r.logger.WithError(err).Error("Error saving routing rules")
+			log.WithError(err).Error("Error saving routing rules")
 			return nil, err
 		}
 
@@ -146,7 +148,7 @@ func (r *router) DialRoutes(
 			// Check if this is a "no suitable transport" error (stale TPD data)
 			if strings.Contains(err.Error(), "no suitable transport") || strings.Contains(err.Error(), "transport") {
 				if attempt < maxRetries {
-					r.logger.WithError(err).Warnf("Route handshake failed due to transport issue (attempt %d/%d), querying route-finder for fresh route...", attempt, maxRetries)
+					log.WithError(err).Warnf("Route handshake failed due to transport issue (attempt %d/%d), querying route-finder for fresh route...", attempt, maxRetries)
 					continue
 				}
 			}
@@ -158,7 +160,7 @@ func (r *router) DialRoutes(
 
 		nrg.rg.startOffServiceLoops()
 
-		r.logger.Debugf("Created new routes to %s on port %d", rPK, lPort)
+		log.Debugf("Created new routes to %s on port %d", rPK, lPort)
 
 		// Establish additional mux routes if requested
 		r.establishMuxRoutes(ctx, nrg, opts, forwardDesc, rules.Forward.NextTransportID())
@@ -184,6 +186,7 @@ func (r *router) setupPingRoute(
 	rPK cipher.PubKey,
 	opts *DialOptions,
 ) (net.Conn, error) {
+	log := r.scopedLog(forwardDesc.SrcPort())
 	keepAlive := DefaultRouteKeepAlive
 	if opts != nil && opts.KeepAlive > 0 {
 		keepAlive = opts.KeepAlive
@@ -196,19 +199,19 @@ func (r *router) setupPingRoute(
 	}
 
 	// Debug: log route details before sending to setup node
-	r.logger.Debugf("setupPingRoute: Desc.SrcPK=%s, Desc.DstPK=%s", forwardDesc.SrcPK(), forwardDesc.DstPK())
+	log.Debugf("setupPingRoute: Desc.SrcPK=%s, Desc.DstPK=%s", forwardDesc.SrcPK(), forwardDesc.DstPK())
 	// Log all forward hops with their transport IDs
 	for i, hop := range forwardPath {
-		r.logger.Debugf("setupPingRoute: Forward[%d] TpID=%s From=%s To=%s", i, hop.TpID, hop.From, hop.To)
+		log.Debugf("setupPingRoute: Forward[%d] TpID=%s From=%s To=%s", i, hop.TpID, hop.From, hop.To)
 	}
 	// Log all reverse hops with their transport IDs
 	for i, hop := range reversePath {
-		r.logger.Debugf("setupPingRoute: Reverse[%d] TpID=%s From=%s To=%s", i, hop.TpID, hop.From, hop.To)
+		log.Debugf("setupPingRoute: Reverse[%d] TpID=%s From=%s To=%s", i, hop.TpID, hop.From, hop.To)
 	}
 
-	rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(ctx, r.logger, r.dmsgC, r.conf.SetupNodes, req)
+	rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, req)
 	if err != nil {
-		r.logger.WithError(err).Error("Error dialing ping route group")
+		log.WithError(err).Error("Error dialing ping route group")
 		return nil, err
 	}
 
@@ -218,7 +221,7 @@ func (r *router) setupPingRoute(
 	}
 
 	if err := r.SaveRoutingRules(rules.Forward, rules.Reverse); err != nil {
-		r.logger.WithError(err).Error("Error saving ping routing rules")
+		log.WithError(err).Error("Error saving ping routing rules")
 		return nil, err
 	}
 
@@ -242,7 +245,7 @@ func (r *router) setupPingRoute(
 	nrg.rg.startOffServiceLoops()
 
 	lPort := forwardDesc.SrcPort()
-	r.logger.Debugf("Created new ping route to %s on port %d", rPK, lPort)
+	log.Debugf("Created new ping route to %s on port %d", rPK, lPort)
 
 	return nrg, nil
 }
@@ -664,6 +667,7 @@ func (r *router) establishMuxRoutes(
 	forwardDesc routing.RouteDescriptor,
 	primaryTpID uuid.UUID,
 ) {
+	log := r.scopedLog(forwardDesc.SrcPort())
 	muxCount := 1
 	if opts != nil && opts.MuxRoutes > 1 {
 		muxCount = opts.MuxRoutes
@@ -680,7 +684,7 @@ func (r *router) establishMuxRoutes(
 	for _, tp := range nrg.rg.tps {
 		if tp != nil && tp.Entry.Type == tptypes.DMSG {
 			nrg.rg.mu.Unlock()
-			r.logger.Debug("Skipping mux setup: primary route contains a DMSG transport")
+			log.Debug("Skipping mux setup: primary route contains a DMSG transport")
 			return
 		}
 	}
@@ -703,7 +707,7 @@ func (r *router) establishMuxRoutes(
 
 		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, lPK, rPK, muxOpts)
 		if err != nil {
-			r.logger.Debugf("Mux route %d/%d: no additional route found: %v", i+1, muxCount, err)
+			log.Debugf("Mux route %d/%d: no additional route found: %v", i+1, muxCount, err)
 			break
 		}
 
@@ -718,18 +722,18 @@ func (r *router) establishMuxRoutes(
 			Reverse:   muxRev,
 		}
 
-		muxRules, _, err := r.conf.RouteGroupDialer.Dial(ctx, r.logger, r.dmsgC, r.conf.SetupNodes, muxReq)
+		muxRules, _, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, muxReq)
 		if err != nil {
-			r.logger.Debugf("Mux route %d/%d: setup failed: %v", i+1, muxCount, err)
+			log.Debugf("Mux route %d/%d: setup failed: %v", i+1, muxCount, err)
 			break
 		}
 
 		if err := r.appendRouteToGroup(nrg, muxRules); err != nil {
-			r.logger.Debugf("Mux route %d/%d: append failed: %v", i+1, muxCount, err)
+			log.Debugf("Mux route %d/%d: append failed: %v", i+1, muxCount, err)
 			break
 		}
 
 		excludeIDs = append(excludeIDs, muxRules.Forward.NextTransportID())
-		r.logger.Infof("Mux route %d/%d established via transport %s", i+1, muxCount, muxRules.Forward.NextTransportID())
+		log.Infof("Mux route %d/%d established via transport %s", i+1, muxCount, muxRules.Forward.NextTransportID())
 	}
 }

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -37,7 +37,7 @@ func (r *router) DialRoutes(
 	opts *DialOptions,
 ) (net.Conn, error) {
 
-	log := r.scopedLog(lPort)
+	log := r.scopedLogForOpts(opts, lPort)
 
 	if rPK.Null() {
 		err := ErrRemoteEmptyPK

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -86,7 +87,7 @@ func (r *router) DialRoutes(
 	// so we query for fresh routes on each retry instead of retrying the same bad route.
 	const maxRetries = 3
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, lPK, rPK, opts)
+		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
 		if err != nil {
 			if attempt < maxRetries {
 				log.WithError(err).Warnf("Route finder failed (attempt %d/%d), retrying with fresh query...", attempt, maxRetries)
@@ -262,9 +263,11 @@ func (r *router) PingRoute(
 	opts *DialOptions,
 ) (net.Conn, error) {
 
+	log := r.scopedLog(lPort)
+
 	if rPK.Null() {
 		err := ErrRemoteEmptyPK
-		r.logger.WithError(err).Error("Failed to dial ping route.")
+		log.WithError(err).Error("Failed to dial ping route.")
 		return nil, fmt.Errorf("failed to dial ping route: %w", err)
 	}
 
@@ -276,11 +279,11 @@ func (r *router) PingRoute(
 	forwardDesc := routing.NewRouteDescriptor(lPK, rPK, lPort, rPort)
 
 	// Debug: log what options we received
-	r.logger.Debugf("PingRoute opts: TransportID=%s, ForwardHops=%d, ReverseHops=%d", opts.TransportID, len(opts.ForwardHops), len(opts.ReverseHops))
+	log.Debugf("PingRoute opts: TransportID=%s, ForwardHops=%d, ReverseHops=%d", opts.TransportID, len(opts.ForwardHops), len(opts.ReverseHops))
 
 	// If full route is specified, use it directly without route calculation
 	if len(opts.ForwardHops) > 0 && len(opts.ReverseHops) > 0 {
-		r.logger.Debugf("Using specified %d-hop route to %s", len(opts.ForwardHops), rPK)
+		log.Debugf("Using specified %d-hop route to %s", len(opts.ForwardHops), rPK)
 		r.lastRouteCalcMu.Lock()
 		r.lastRouteCalcTime = 0 // No calculation needed
 		r.lastRouteCalcMu.Unlock()
@@ -289,7 +292,7 @@ func (r *router) PingRoute(
 
 	// If TransportID is specified, use it directly without route calculation (single hop)
 	if opts.TransportID != (uuid.UUID{}) {
-		r.logger.Debugf("Using specified transport %s for direct route to %s", opts.TransportID, rPK)
+		log.Debugf("Using specified transport %s for direct route to %s", opts.TransportID, rPK)
 		forwardPath := []routing.Hop{{TpID: opts.TransportID, From: lPK, To: rPK}}
 		reversePath := []routing.Hop{{TpID: opts.TransportID, From: rPK, To: lPK}}
 		r.lastRouteCalcMu.Lock()
@@ -301,11 +304,11 @@ func (r *router) PingRoute(
 	const maxRetries = 3
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, lPK, rPK, opts)
+		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
 		if err != nil {
 			lastErr = fmt.Errorf("route finder: %w", err)
 			if attempt < maxRetries {
-				r.logger.WithError(err).Warnf("Ping route finder failed (attempt %d/%d), retrying...", attempt, maxRetries)
+				log.WithError(err).Warnf("Ping route finder failed (attempt %d/%d), retrying...", attempt, maxRetries)
 				continue
 			}
 			return nil, lastErr
@@ -315,7 +318,7 @@ func (r *router) PingRoute(
 		if err != nil {
 			lastErr = err
 			if attempt < maxRetries {
-				r.logger.WithError(err).Warnf("Ping route setup failed (attempt %d/%d), retrying...", attempt, maxRetries)
+				log.WithError(err).Warnf("Ping route setup failed (attempt %d/%d), retrying...", attempt, maxRetries)
 				continue
 			}
 			return nil, lastErr
@@ -371,7 +374,10 @@ func (r *router) MeasureTransportLatency(ctx context.Context, remote cipher.PubK
 	return avg, nil
 }
 
-func (r *router) fetchBestRoutes(ctx context.Context, src, dst cipher.PubKey, opts *DialOptions) (fwd, rev []routing.Hop, err error) {
+func (r *router) fetchBestRoutes(ctx context.Context, log *logging.Logger, src, dst cipher.PubKey, opts *DialOptions) (fwd, rev []routing.Hop, err error) {
+	if log == nil {
+		log = r.logger
+	}
 	if opts == nil {
 		opts = DefaultDialOptions() // nolint
 	}
@@ -382,22 +388,22 @@ func (r *router) fetchBestRoutes(ctx context.Context, src, dst cipher.PubKey, op
 	r.forceLocalRoutesMu.Unlock()
 
 	if forceLocal {
-		r.logger.Info("Calculating route locally (--local-route enabled)")
+		log.Info("Calculating route locally (--local-route enabled)")
 		calcStart := time.Now()
-		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, src, dst, opts)
+		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 		calcTime := time.Since(calcStart)
 		r.lastRouteCalcMu.Lock()
 		r.lastRouteCalcTime = calcTime
 		r.lastRouteCalcMu.Unlock()
 		if localErr == nil {
-			r.logger.Infof("Local route calculated in %v: Forward=%v, Reverse=%v", calcTime, localFwd, localRev)
+			log.Infof("Local route calculated in %v: Forward=%v, Reverse=%v", calcTime, localFwd, localRev)
 		}
 		return localFwd, localRev, localErr
 	}
 
 	retries := opts.Retries
 
-	r.logger.Debugf("Requesting new routes from %s to %s", src, dst)
+	log.Debugf("Requesting new routes from %s to %s", src, dst)
 
 	timer := time.NewTimer(retryDuration)
 	defer timer.Stop()
@@ -416,26 +422,26 @@ fetchRoutesAgain:
 
 	if err == rfclient.ErrTransportNotFound {
 		// Try local route calculation - may find a local transport that's not yet in TPD
-		r.logger.Info("Route finder returned transport not found, attempting local route calculation...")
-		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, src, dst, opts)
+		log.Info("Route finder returned transport not found, attempting local route calculation...")
+		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 		if localErr == nil {
-			r.logger.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
+			log.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
 			return localFwd, localRev, nil
 		}
-		r.logger.WithError(localErr).Debug("Local route calculation also failed")
+		log.WithError(localErr).Debug("Local route calculation also failed")
 		return nil, nil, err
 	}
 	// simple retries condition
 	if retries == 0 {
 		// Try local route calculation as fallback before giving up
-		r.logger.Info("Route finder exhausted retries, attempting local route calculation...")
-		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, src, dst, opts)
+		log.Info("Route finder exhausted retries, attempting local route calculation...")
+		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 		if localErr == nil {
-			r.logger.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
+			log.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
 			return localFwd, localRev, nil
 		}
-		r.logger.WithError(localErr).Warn("Local route calculation also failed")
-		r.logger.Errorf(ErrNoRouteFound.Error())
+		log.WithError(localErr).Warn("Local route calculation also failed")
+		log.Errorf(ErrNoRouteFound.Error())
 		return nil, nil, ErrNoRouteFound
 	}
 	if retries > 0 {
@@ -446,13 +452,13 @@ fetchRoutesAgain:
 		select {
 		case <-timer.C:
 			// Try local route calculation as fallback
-			r.logger.Info("Route finder timed out, attempting local route calculation...")
-			localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, src, dst, opts)
+			log.Info("Route finder timed out, attempting local route calculation...")
+			localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
 			if localErr == nil {
-				r.logger.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
+				log.Infof("Local route calculation succeeded: Forward=%v, Reverse=%v", localFwd, localRev)
 				return localFwd, localRev, nil
 			}
-			r.logger.WithError(localErr).Warn("Local route calculation also failed")
+			log.WithError(localErr).Warn("Local route calculation also failed")
 			return nil, nil, err
 		default:
 			time.Sleep(retryInterval)
@@ -460,7 +466,7 @@ fetchRoutesAgain:
 		}
 	}
 
-	r.logger.Debugf("Found routes Forward: %s. Reverse %s", paths[forward], paths[backward])
+	log.Debugf("Found routes Forward: %s. Reverse %s", paths[forward], paths[backward])
 
 	return paths[forward][0], paths[backward][0], nil
 }
@@ -468,7 +474,10 @@ fetchRoutesAgain:
 // calculateLocalRoutes attempts to calculate routes locally using the transport manager
 // and transport discovery data, without relying on the route finder service.
 // It supports 1-hop (direct), 2-hop routes, and self-ping (src == dst).
-func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKey, opts *DialOptions) (fwd, rev []routing.Hop, err error) {
+func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, src, dst cipher.PubKey, opts *DialOptions) (fwd, rev []routing.Hop, err error) {
+	if log == nil {
+		log = r.logger
+	}
 	dialOpts := opts
 	if r.tm == nil {
 		return nil, nil, errors.New("transport manager not available")
@@ -480,7 +489,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 	}
 
 	isSelfPing := src == dst
-	r.logger.Debugf("Calculating route locally from %s to %s (self-ping=%v)", src, dst, isSelfPing)
+	log.Debugf("Calculating route locally from %s to %s (self-ping=%v)", src, dst, isSelfPing)
 
 	// Collect local transports
 	type localTp struct {
@@ -518,14 +527,14 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 			tptypes.TypePreference(tptypes.Type(localTps[j].tpType))
 	})
 
-	r.logger.Debugf("Found %d local transports", len(localTps))
+	log.Debugf("Found %d local transports", len(localTps))
 
 	// Check for direct (1-hop) route first
 	for _, tp := range localTps {
 		if tp.remotePK == dst {
 			// Skip DMSG transports for mux (DMSG is a relay, not suitable for multiplexing)
 			if dialOpts != nil && dialOpts.ExcludeDMSG && tp.tpType == "dmsg" {
-				r.logger.Debugf("Skipping DMSG transport %s (excluded for mux)", tp.id)
+				log.Debugf("Skipping DMSG transport %s (excluded for mux)", tp.id)
 				continue
 			}
 			// Skip excluded transport IDs (used by mux to get different transports)
@@ -539,10 +548,10 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 				}
 			}
 			if excluded {
-				r.logger.Debugf("Skipping excluded transport %s to destination", tp.id)
+				log.Debugf("Skipping excluded transport %s to destination", tp.id)
 				continue
 			}
-			r.logger.Debugf("Found direct transport to destination: %s (type=%s)", tp.id, tp.tpType)
+			log.Debugf("Found direct transport to destination: %s (type=%s)", tp.id, tp.tpType)
 			fwdHop := routing.Hop{TpID: tp.id, From: src, To: dst}
 			revHop := routing.Hop{TpID: tp.id, From: dst, To: src}
 			return []routing.Hop{fwdHop}, []routing.Hop{revHop}, nil
@@ -553,7 +562,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 	// This replaces N individual GetTransportsByEdge API calls with one bulk fetch
 	allEntries, err := dc.GetAllTransports(ctx)
 	if err != nil {
-		r.logger.WithError(err).Warn("Failed to fetch all transports for route calculation")
+		log.WithError(err).Warn("Failed to fetch all transports for route calculation")
 		return nil, nil, fmt.Errorf("failed to fetch transport discovery data: %w", err)
 	}
 
@@ -580,12 +589,12 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 				tptypes.TypePreference(entries[j].Type)
 		})
 	}
-	r.logger.Debugf("Built transport cache with %d entries covering %d visors", len(allEntries), len(transportsByEdge))
+	log.Debugf("Built transport cache with %d entries covering %d visors", len(allEntries), len(transportsByEdge))
 
 	// For self-ping, try 2-hop route through any available transport partner
 	// This allows testing the full route setup even without a direct self-transport
 	if isSelfPing {
-		r.logger.Debug("Self-ping: looking for 2-hop loopback route through transport partner")
+		log.Debug("Self-ping: looking for 2-hop loopback route through transport partner")
 		for _, tp := range localTps {
 			intermediatePK := tp.remotePK
 			if intermediatePK == src {
@@ -606,7 +615,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 				}
 				remotePK := entry.RemoteEdge(intermediatePK)
 				if remotePK == src {
-					r.logger.Debugf("Found 2-hop self-ping route via %s (tp1=%s, tp2=%s)", intermediatePK, tp.id, entry.ID)
+					log.Debugf("Found 2-hop self-ping route via %s (tp1=%s, tp2=%s)", intermediatePK, tp.id, entry.ID)
 					// Build loopback route: src -> intermediate -> src
 					fwdHop1 := routing.Hop{TpID: tp.id, From: src, To: intermediatePK}
 					fwdHop2 := routing.Hop{TpID: entry.ID, From: intermediatePK, To: src}
@@ -640,7 +649,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, src, dst cipher.PubKe
 			// Check if this transport connects to our destination
 			remotePK := entry.RemoteEdge(intermediatePK)
 			if remotePK == dst {
-				r.logger.Debugf("Found 2-hop route via %s (tp1=%s, tp2=%s)", intermediatePK, tp.id, entry.ID)
+				log.Debugf("Found 2-hop route via %s (tp1=%s, tp2=%s)", intermediatePK, tp.id, entry.ID)
 
 				// Build forward route: src -> intermediate -> dst
 				fwdHop1 := routing.Hop{TpID: tp.id, From: src, To: intermediatePK}
@@ -705,7 +714,7 @@ func (r *router) establishMuxRoutes(
 			ExcludeDMSG:         true,
 		}
 
-		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, lPK, rPK, muxOpts)
+		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts)
 		if err != nil {
 			log.Debugf("Mux route %d/%d: no additional route found: %v", i+1, muxCount, err)
 			break

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -77,6 +77,7 @@ func (r *router) AddMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.
 
 	lPK := desc.DstPK()
 	rPK := desc.SrcPK()
+	log := r.scopedLog(desc.SrcPort())
 
 	// Build a route that uses this specific transport
 	opts := &DialOptions{
@@ -97,7 +98,7 @@ func (r *router) AddMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	fwd, rev, err := r.fetchBestRoutes(ctx, lPK, rPK, opts)
+	fwd, rev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
 	if err != nil {
 		return fmt.Errorf("failed to find route via transport: %w", err)
 	}
@@ -114,7 +115,7 @@ func (r *router) AddMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.
 		Reverse:   rev,
 	}
 
-	rules, _, err := r.conf.RouteGroupDialer.Dial(ctx, r.logger, r.dmsgC, r.conf.SetupNodes, req)
+	rules, _, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, req)
 	if err != nil {
 		return fmt.Errorf("route setup failed: %w", err)
 	}

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -72,6 +72,49 @@ func (r *router) RouteGroupHops(desc routing.RouteDescriptor) []RouteHopInfo {
 	return nil
 }
 
+// RouteGroupMuxInfo implements Router. Tries desc and its inversion
+// in case the rg is keyed by the mirrored descriptor.
+func (r *router) RouteGroupMuxInfo(desc routing.RouteDescriptor) (MuxInfo, bool) {
+	if nrg, ok := r.noiseRouteGroup(desc); ok && nrg != nil && nrg.rg != nil {
+		return nrg.rg.MuxStats(), true
+	}
+	inv := desc.Invert()
+	if nrg, ok := r.noiseRouteGroup(inv); ok && nrg != nil && nrg.rg != nil {
+		return nrg.rg.MuxStats(), true
+	}
+	return MuxInfo{}, false
+}
+
+// RouteGroupMuxInfoForApp implements Router. Walks every active rg
+// and returns mux snapshots for the ones tagged with appName at
+// dial time (saveRouteGroupRules calls SetAppName from opts.AppName).
+// Empty slice when no rg's are tagged for the app — typically because
+// nothing is currently dialed via that app, or the rg's are still
+// initializing (the rgsRaw map; we only walk rgsNs since those are
+// the established sessions).
+func (r *router) RouteGroupMuxInfoForApp(appName string) []MuxInfo {
+	if appName == "" {
+		return nil
+	}
+	r.mx.Lock()
+	rgs := make([]*NoiseRouteGroup, 0, len(r.rgsNs))
+	for _, nrg := range r.rgsNs {
+		if nrg != nil && nrg.rg != nil {
+			rgs = append(rgs, nrg)
+		}
+	}
+	r.mx.Unlock()
+
+	out := make([]MuxInfo, 0, len(rgs))
+	for _, nrg := range rgs {
+		if nrg.rg.AppName() != appName {
+			continue
+		}
+		out = append(out, nrg.rg.MuxStats())
+	}
+	return out
+}
+
 func (r *router) initializingRouteGroup(desc routing.RouteDescriptor) (*RouteGroup, bool) {
 	r.mx.Lock()
 	defer r.mx.Unlock()

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -144,7 +144,11 @@ func (r *router) IntroduceRules(rules routing.EdgeRules) error {
 				RemotePK:  rules.Desc.SrcPK(),
 				Initiator: false,
 			}
-			nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf)
+			// AcceptRoutes path: no opts available, so app_name comes
+			// from the port→app lookup if it resolves (the SrcPort on
+			// inbound rules is the dialing peer's port, not ours, so
+			// this is best-effort only).
+			nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, "")
 			if err != nil {
 				r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
 				return

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -173,7 +173,8 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	r.logger.Debugf("Saving route group rules with desc: %s", &rules.Desc)
+	log := r.scopedLog(rules.Desc.SrcPort())
+	log.Debugf("Saving route group rules with desc: %s", &rules.Desc)
 
 	// When route group is wrapped with noise, it's put into `nrgs`. but before that,
 	// in the process of wrapping we still need to use this route group to handle
@@ -185,7 +186,7 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	// first ensure that this rg is not being wrapped with noise right now
 	if _, ok := r.rgsRaw[rules.Desc]; ok {
 		r.mx.Unlock()
-		r.logger.Warnf("Desc %s already reserved, skipping...", &rules.Desc)
+		log.Warnf("Desc %s already reserved, skipping...", &rules.Desc)
 		return nil, fmt.Errorf("noise route group with desc %s already being initialized", &rules.Desc)
 	}
 
@@ -209,10 +210,10 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 
 	if nsConf.Initiator {
 		if err := rg.sendHandshake(true); err != nil {
-			r.logger.WithError(err).Errorf("Failed to send handshake from route group (%s): %v, closing...",
+			log.WithError(err).Errorf("Failed to send handshake from route group (%s): %v, closing...",
 				&rules.Desc, err)
 			if err := rg.Close(); err != nil {
-				r.logger.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
+				log.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
 			}
 			// Clean up rgsRaw on failure to prevent blocking future connections
 			r.mx.Lock()
@@ -232,10 +233,10 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	case <-hsCtx.Done():
 		// Check if parent context was canceled (e.g., setup timeout)
 		if ctx.Err() != nil {
-			r.logger.Debugf("Route group setup canceled for %s: %v", &rules.Desc, ctx.Err())
+			log.Debugf("Route group setup canceled for %s: %v", &rules.Desc, ctx.Err())
 			// Clean up
 			if err := rg.Close(); err != nil {
-				r.logger.WithError(err).Warnf("Failed to close route group on context cancellation")
+				log.WithError(err).Warnf("Failed to close route group on context cancellation")
 			}
 			r.mx.Lock()
 			delete(r.rgsRaw, rules.Desc)
@@ -253,10 +254,10 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 
 	if !nsConf.Initiator {
 		if err := rg.sendHandshake(true); err != nil {
-			r.logger.WithError(err).Errorf("Failed to send handshake from route group (%s): %v, closing...",
+			log.WithError(err).Errorf("Failed to send handshake from route group (%s): %v, closing...",
 				&rules.Desc, err)
 			if err := rg.Close(); err != nil {
-				r.logger.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
+				log.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
 			}
 			// Clean up rgsRaw on failure to prevent blocking future connections
 			r.mx.Lock()
@@ -269,22 +270,22 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 
 	if ok && nrg != nil {
 		// if already functioning wrapped rg exists, we safely close it here
-		r.logger.Debugf("Noise route group with desc %s already exists, closing the old one and replacing...", &rules.Desc)
+		log.Debugf("Noise route group with desc %s already exists, closing the old one and replacing...", &rules.Desc)
 
 		if err := nrg.Close(); err != nil {
-			r.logger.Errorf("Error closing already existing noise route group: %v", err)
+			log.Errorf("Error closing already existing noise route group: %v", err)
 		}
 
-		r.logger.Debugf("Successfully closed old noise route group")
+		log.Debugf("Successfully closed old noise route group")
 	}
 
 	if rg.encrypt {
 		// wrapping rg with noise
 		wrappedRG, err := network.EncryptConn(nsConf, rg)
 		if err != nil {
-			r.logger.WithError(err).Errorf("Failed to wrap route group (%s): %v, closing...", &rules.Desc, err)
+			log.WithError(err).Errorf("Failed to wrap route group (%s): %v, closing...", &rules.Desc, err)
 			if err := rg.Close(); err != nil {
-				r.logger.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
+				log.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
 			}
 			// Clean up rgsRaw on failure to prevent blocking future connections
 			r.mx.Lock()

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
@@ -55,7 +56,8 @@ func (r *router) AcceptRoutes(ctx context.Context) (net.Conn, error) {
 		Initiator: false,
 	}
 
-	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf)
+	// IntroduceRules / accepted-route path: no app context to thread.
+	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, "")
 	if err != nil {
 		// Clean up saved rules if route group setup fails
 		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
@@ -168,12 +170,17 @@ func (r *router) serveSetup() {
 // nolint: gocyclo
 //
 //gocyclo:ignore
-func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRules, nsConf noise.Config) (*NoiseRouteGroup, error) {
+func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRules, nsConf noise.Config, appName string) (*NoiseRouteGroup, error) {
 	// Check context before starting
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	log := r.scopedLog(rules.Desc.SrcPort())
+	var log *logging.Logger
+	if appName != "" {
+		log = r.logger.WithAppName(appName)
+	} else {
+		log = r.scopedLog(rules.Desc.SrcPort())
+	}
 	log.Debugf("Saving route group rules with desc: %s", &rules.Desc)
 
 	// When route group is wrapped with noise, it's put into `nrgs`. but before that,
@@ -202,6 +209,7 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	}
 
 	rg := NewRouteGroup(DefaultRouteGroupConfig(), r.rt, rules.Desc, r.mLogger)
+	rg.SetAppName(appName)
 	rg.initiator = nsConf.Initiator
 	rg.appendRules(rules.Forward, rules.Reverse, tp)
 	// we put raw rg so it can be accessible to the router when handshake packets come in

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -185,7 +185,7 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	// first ensure that this rg is not being wrapped with noise right now
 	if _, ok := r.rgsRaw[rules.Desc]; ok {
 		r.mx.Unlock()
-		r.logger.Warnf("Desc %s already reserved, skipping...", rules.Desc)
+		r.logger.Warnf("Desc %s already reserved, skipping...", &rules.Desc)
 		return nil, fmt.Errorf("noise route group with desc %s already being initialized", &rules.Desc)
 	}
 

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -50,11 +50,21 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// BandwidthSink receives per-transport cumulative-counter updates.
-// The TPD's redis store satisfies this via UpdateBandwidth.
-type BandwidthSink interface {
+// Sink receives per-transport telemetry updates from visor TreeStore
+// feeds. The TPD's redis store satisfies this via UpdateBandwidth (per
+// reporter, cumulative counters) and UpdateLatency (per transport, RTT
+// min/max/avg in ms).
+type Sink interface {
 	UpdateBandwidth(ctx context.Context, transportID string, reporterPK cipher.PubKey, sent, recv uint64) error
+	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
 }
+
+// BandwidthSink is retained as an alias for callers that only need the
+// bandwidth half of the contract.
+//
+// Deprecated: use Sink. Kept so external embedders that implemented
+// BandwidthSink keep compiling until they migrate.
+type BandwidthSink = Sink
 
 // liveSnapshot mirrors pkg/visor/stats.LiveSnapshot. Re-declared on
 // the TPD side to keep the dependency direction one-way: visor →
@@ -92,7 +102,7 @@ type Config struct {
 // TreeStore tree to feed BandwidthSink.
 type Aggregator struct {
 	cxoNode *node.Node
-	sink    BandwidthSink
+	sink    Sink
 	conf    Config
 	log     *logging.Logger
 
@@ -104,7 +114,7 @@ type Aggregator struct {
 // New constructs an Aggregator. Sets up a CXO Node, enables DMSG so
 // remote visors can dial in, and wires OnRootFilled to walk
 // TreeStore Roots and dispatch to sink.
-func New(dmsgC *dmsg.Client, sink BandwidthSink, conf Config) (*Aggregator, error) {
+func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	if conf.ReconcileInterval <= 0 {
 		conf.ReconcileInterval = 30 * time.Second
 	}
@@ -302,6 +312,11 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 	defer cancel()
 	if err := a.sink.UpdateBandwidth(ctx, id.String(), reporter, snap.SentBytes, snap.RecvBytes); err != nil {
 		a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateBandwidth failed")
+	}
+	if snap.LatencyAvgMS > 0 {
+		if err := a.sink.UpdateLatency(ctx, id.String(), snap.LatencyMinMS, snap.LatencyMaxMS, snap.LatencyAvgMS); err != nil {
+			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateLatency failed")
+		}
 	}
 }
 

--- a/pkg/transport-discovery/store/memory_store.go
+++ b/pkg/transport-discovery/store/memory_store.go
@@ -151,6 +151,11 @@ func (s *memoryStore) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubK
 	return nil
 }
 
+// UpdateLatency is a no-op for the same reason as UpdateBandwidth.
+func (s *memoryStore) UpdateLatency(_ context.Context, _ string, _, _, _ float64) error {
+	return nil
+}
+
 // GetTransportBandwidth returns empty slice for memory store (no bandwidth tracking).
 func (s *memoryStore) GetTransportBandwidth(_ context.Context, _ uuid.UUID, _ string, _ int) ([]BandwidthAggregation, error) {
 	return []BandwidthAggregation{}, nil

--- a/pkg/transport-discovery/store/redis_bandwidth.go
+++ b/pkg/transport-discovery/store/redis_bandwidth.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -102,6 +103,62 @@ func (s *redisStore) UpdateBandwidth(ctx context.Context, transportID string,
 
 	_, err = pipe.Exec(ctx)
 	return err
+}
+
+// UpdateLatency stores the most recent latency snapshot for a transport
+// inside its TransportData blob. Called by the CXO aggregator when a
+// visor's TreeStore feed reports a fresh transports/<id>/current
+// snapshot. Latency is round-trip — both edges should converge on
+// similar values, so last-writer-wins keeps this lock-free.
+//
+// If the transport hasn't been registered (or its TTL'd out), the
+// snapshot is dropped. We intentionally do not fabricate a TransportData
+// blob from a latency report alone — registration is the only path that
+// knows the canonical edges/type.
+func (s *redisStore) UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error {
+	if avgMS <= 0 {
+		return nil
+	}
+
+	id, err := uuid.Parse(transportID)
+	if err != nil {
+		return fmt.Errorf("invalid transport id %q: %w", transportID, err)
+	}
+
+	tpKey := s.transportKey(id)
+	raw, err := s.client.Get(ctx, tpKey).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var data TransportData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return fmt.Errorf("decode TransportData: %w", err)
+	}
+
+	// ms → us, matching the TransportData latency field unit.
+	data.LatencyMin = int64(minMS * 1000)
+	data.LatencyMax = int64(maxMS * 1000)
+	data.LatencyAvg = int64(avgMS * 1000)
+	data.LastUpdate = time.Now().UTC().Unix()
+
+	updated, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	// Preserve the registration TTL — KEEPTTL is the obvious idiom but
+	// requires Redis 6+. Read TTL, fall back to the configured default
+	// if Redis returns -1 (no expiry) or -2 (key vanished between GET
+	// and TTL).
+	ttl, err := s.client.TTL(ctx, tpKey).Result()
+	if err != nil || ttl <= 0 {
+		ttl = s.ttl
+	}
+	return s.client.Set(ctx, tpKey, string(updated), ttl).Err()
 }
 
 // GetTransportBandwidth retrieves bandwidth aggregations for a transport.

--- a/pkg/transport-discovery/store/store.go
+++ b/pkg/transport-discovery/store/store.go
@@ -183,6 +183,10 @@ type TransportStore interface {
 	// reporter's cumulative counters; deltas are computed
 	// internally against the per-reporter previous snapshot).
 	UpdateBandwidth(ctx context.Context, transportID string, reporterPK cipher.PubKey, sent, recv uint64) error
+	// Latency ingest (called by the CXO aggregator with the
+	// reporter's window min/max/avg in milliseconds). RTT-symmetric,
+	// so last-writer-wins across the two edges is acceptable.
+	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
 	// Bandwidth query methods (legacy)
 	GetTransportBandwidth(ctx context.Context, tpID uuid.UUID, period string, limit int) ([]BandwidthAggregation, error)
 	GetVisorBandwidth(ctx context.Context, pk cipher.PubKey, period string, limit int) ([]BandwidthAggregation, error)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -132,6 +132,11 @@ type API interface {
 	SaveRoutingRule(rule routing.Rule) error
 	RemoveRoutingRule(key routing.RouteID) error
 	RouteGroups() ([]RouteGroupInfo, error)
+	// RouteGroupMuxInfo returns per-mux-leg byte/packet/latency
+	// counters for every active route group tagged with the named
+	// app (skysocks-client, vpn-client, etc.). Empty slice when
+	// nothing is currently dialed via that app.
+	RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error)
 	ActiveRoutes() ([]AppRouteStatus, error)
 	AddMuxRoute(appName string, tpID uuid.UUID) error
 	RemoveMuxRoute(appName string, tpID uuid.UUID) error

--- a/pkg/visor/api_ar.go
+++ b/pkg/visor/api_ar.go
@@ -93,13 +93,20 @@ func (s *arSelfState) set(tpType string, d addrresolver.VisorData) {
 	s.entries[tpType] = d
 }
 
-func (s *arSelfState) clear(tpType string) {
+// clear removes the cached AR self-registration for one transport
+// type. Currently unreferenced in-tree but kept on the type for
+// symmetry with set() and to give callers a way to invalidate a
+// stale entry on tear-down.
+func (s *arSelfState) clear(tpType string) { //nolint:unused
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.entries, tpType)
 }
 
-func (s *arSelfState) snapshot() map[string]addrresolver.VisorData {
+// snapshot returns a copy of the AR self-registration map. Currently
+// unreferenced in-tree; intended for diagnostic dumps that walk all
+// configured transport types at once.
+func (s *arSelfState) snapshot() map[string]addrresolver.VisorData { //nolint:unused
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make(map[string]addrresolver.VisorData, len(s.entries))

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -88,6 +88,46 @@ func (v *Visor) RouteGroups() (rgs []RouteGroupInfo, err error) {
 	return rgs, nil
 }
 
+// RouteGroupMuxInfo implements API. Returns per-mux-leg byte/packet/
+// latency counters for every active route group tagged with the
+// named app. The visor's router holds the rg's; we just transcribe
+// the internal MuxInfo into the wire-friendly visor-level shape.
+func (v *Visor) RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error) {
+	if v.router == nil {
+		return nil, nil
+	}
+	infos := v.router.RouteGroupMuxInfoForApp(appName)
+	out := make([]MuxRouteGroupInfo, 0, len(infos))
+	for _, info := range infos {
+		entry := MuxRouteGroupInfo{
+			Desc: routing.RouteDescriptorFields{
+				DstPK:   info.Desc.DstPK(),
+				SrcPK:   info.Desc.SrcPK(),
+				DstPort: info.Desc.DstPort(),
+				SrcPort: info.Desc.SrcPort(),
+			},
+			MuxEnabled:  info.MuxEnabled,
+			SACKEnabled: info.SACKEnabled,
+			Legs:        make([]MuxLegInfo, 0, len(info.Legs)),
+		}
+		for _, leg := range info.Legs {
+			entry.Legs = append(entry.Legs, MuxLegInfo{
+				Index:       leg.Index,
+				TransportID: leg.TransportID,
+				TpType:      leg.TpType,
+				RemotePK:    leg.RemotePK,
+				LatencyMS:   leg.LatencyMS,
+				SentBytes:   leg.SentBytes,
+				SentPackets: leg.SentPackets,
+				RecvBytes:   leg.RecvBytes,
+				RecvPackets: leg.RecvPackets,
+			})
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
 // ActiveRoutes implements API.
 // Returns all active routes with their app associations and live stats.
 func (v *Visor) ActiveRoutes() ([]AppRouteStatus, error) {

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 
@@ -305,6 +306,10 @@ func (a *visorPingAdapter) GetDmsgPingServerPK(pk cipher.PubKey) (cipher.PubKey,
 
 func (a *visorPingAdapter) GetRemoteDmsgServers(pk cipher.PubKey) ([]cipher.PubKey, error) {
 	return a.v.GetRemoteDmsgServers(pk)
+}
+
+func (a *visorPingAdapter) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.Entry, func() uint64) {
+	return a.v.SubscribeLogs(f, capacity)
 }
 
 func (a *visorPingAdapter) DialDmsgRPC(pk cipher.PubKey) (net.Conn, error) {

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -23,6 +23,7 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 	"github.com/skycoin/skywire/pkg/vpn"
@@ -310,6 +311,14 @@ func (a *visorPingAdapter) GetRemoteDmsgServers(pk cipher.PubKey) ([]cipher.PubK
 
 func (a *visorPingAdapter) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.Entry, func() uint64) {
 	return a.v.SubscribeLogs(f, capacity)
+}
+
+func (a *visorPingAdapter) LocalPK() cipher.PubKey {
+	return a.v.LocalPK()
+}
+
+func (a *visorPingAdapter) FetchAllTransportEntries(ctx context.Context) ([]*transport.Entry, error) {
+	return a.v.FetchAllTransportEntries(ctx)
 }
 
 func (a *visorPingAdapter) DialDmsgRPC(pk cipher.PubKey) (net.Conn, error) {

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -162,6 +162,16 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 		RulesGCInterval:    0, // 0 = DefaultRulesGCInterval (10s)
 		MinHops:            v.conf.Routing.MinHops,
 		AwaitSetupListener: v.awaitSetupListener,
+		// Tag rg-scoped log entries with the originating app's name so
+		// 'cli proxy start --verbose' can scope to a session. Resolved
+		// lazily via the proc manager — the manager owns the port↔app
+		// mapping and is the only authoritative source.
+		AppLookup: func(p routing.Port) (string, bool) {
+			if v.procM == nil {
+				return "", false
+			}
+			return v.procM.AppByPort(p)
+		},
 	}
 
 	routeSetupHooks := getRouteSetupHooks(ctx, v, log)

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -178,6 +178,28 @@ type RouteGroupInfo struct {
 	// for this route group, populated when the route group is active.
 	Hops []RouteHopInfo `json:"hops,omitempty"`
 }
+
+// MuxRouteGroupInfo is one route-group's mux state plus per-leg
+// counters. Returned by RouteGroupMuxInfo for 'cli proxy mux-info'.
+type MuxRouteGroupInfo struct {
+	Desc        routing.RouteDescriptorFields `json:"desc"`
+	MuxEnabled  bool                          `json:"mux_enabled"`
+	SACKEnabled bool                          `json:"sack_enabled"`
+	Legs        []MuxLegInfo                  `json:"legs"`
+}
+
+// MuxLegInfo is one route in a mux'd group.
+type MuxLegInfo struct {
+	Index       int     `json:"index"`
+	TransportID string  `json:"transport_id"`
+	TpType      string  `json:"tp_type"`
+	RemotePK    string  `json:"remote_pk"`
+	LatencyMS   float64 `json:"latency_ms,omitempty"`
+	SentBytes   uint64  `json:"sent_bytes"`
+	SentPackets uint64  `json:"sent_packets"`
+	RecvBytes   uint64  `json:"recv_bytes"`
+	RecvPackets uint64  `json:"recv_packets"`
+}
 type FetchServiceDataIn struct {
 	Service string
 	Path    string

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -70,6 +70,11 @@ type TransportSummary struct {
 	Log     *transport.LogEntry `json:"log,omitempty"`
 	IsSetup bool                `json:"is_setup"`
 	Label   transport.Label     `json:"label"`
+	// LatencyMS is the smoothed average inter-visor RTT for this
+	// transport in milliseconds, measured by transport-level
+	// ping/pong (or RSN-fallback for old peers). Zero means no
+	// measurement yet. Populated from tp.GetLatency().
+	LatencyMS float64 `json:"latency_ms,omitempty"`
 }
 type TransportLogEntry struct {
 	TpID      uuid.UUID `json:"tp_id"`
@@ -80,12 +85,13 @@ type TransportLogEntry struct {
 
 func newTransportSummary(tm *transport.Manager, tp *transport.ManagedTransport, includeLogs, isSetup bool) *TransportSummary {
 	summary := &TransportSummary{
-		ID:      tp.Entry.ID,
-		Local:   tm.Local(),
-		Remote:  tp.Remote(),
-		Type:    tp.Type(),
-		IsSetup: isSetup,
-		Label:   tp.Entry.Label,
+		ID:        tp.Entry.ID,
+		Local:     tm.Local(),
+		Remote:    tp.Remote(),
+		Type:      tp.Type(),
+		IsSetup:   isSetup,
+		Label:     tp.Entry.Label,
+		LatencyMS: tp.GetLatency(),
 	}
 	if includeLogs {
 		summary.Log = tp.LogEntry

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -617,6 +617,13 @@ func (rc *rpcClient) RouteGroups() ([]RouteGroupInfo, error) {
 	return routegroups, err
 }
 
+// RouteGroupMuxInfo calls RouteGroupMuxInfo.
+func (rc *rpcClient) RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error) {
+	var infos []MuxRouteGroupInfo
+	err := rc.Call("RouteGroupMuxInfo", &appName, &infos)
+	return infos, err
+}
+
 // FetchServiceData calls FetchServiceData.
 func (rc *rpcClient) FetchServiceData(service, path string) ([]byte, error) {
 	var data []byte

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -757,6 +757,11 @@ func (mc *mockRPCClient) RouteGroups() ([]RouteGroupInfo, error) {
 	return routeGroups, nil
 }
 
+// RouteGroupMuxInfo implements API.
+func (mc *mockRPCClient) RouteGroupMuxInfo(_ string) ([]MuxRouteGroupInfo, error) {
+	return nil, nil
+}
+
 // FetchServiceData implements API.
 func (mc *mockRPCClient) FetchServiceData(_, _ string) ([]byte, error) {
 	return nil, nil

--- a/pkg/visor/rpc_routing.go
+++ b/pkg/visor/rpc_routing.go
@@ -46,6 +46,19 @@ func (r *RPC) RouteGroups(_ *struct{}, out *[]RouteGroupInfo) (err error) {
 	return err
 }
 
+// RouteGroupMuxInfo retrieves per-mux-leg counters for active rg's
+// tagged with the named app.
+func (r *RPC) RouteGroupMuxInfo(in *string, out *[]MuxRouteGroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "RouteGroupMuxInfo", in)(out, &err)
+	if in == nil {
+		empty := ""
+		in = &empty
+	}
+	infos, err := r.visor.RouteGroupMuxInfo(*in)
+	*out = infos
+	return err
+}
+
 // FetchServiceData proxies a GET request to a deployment service.
 func (r *RPC) FetchServiceData(in *FetchServiceDataIn, out *[]byte) (err error) {
 	defer rpcutil.LogCall(r.log, "FetchServiceData", in)(out, &err)

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -323,7 +323,14 @@ type AppLogCallback func(entry *AppLogEntry)
 // StreamAppLogs subscribes to the visor's master logger and calls cb
 // for each entry that matches the filter. Blocks until ctx is canceled
 // or the stream errors. Used by 'proxy start --verbose'.
-func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeRouter bool, minLevel string, cb AppLogCallback) error {
+//
+// If subscribed is non-nil, it is closed once the server confirms the
+// subscription is live (via the Subscribed sentinel entry). Callers
+// should wait on this channel before triggering downstream RPCs whose
+// log output they want to capture, so the first burst of activity
+// isn't lost to the subscription handshake. The sentinel itself is
+// not delivered to cb.
+func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeRouter bool, minLevel string, subscribed chan<- struct{}, cb AppLogCallback) error {
 	stream, err := c.client.StreamAppLogs(ctx, &AppLogStreamRequest{
 		AppName:       appName,
 		IncludeRouter: includeRouter,
@@ -333,6 +340,7 @@ func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeR
 		return fmt.Errorf("failed to start app log stream: %w", err)
 	}
 
+	signaled := false
 	for {
 		entry, err := stream.Recv()
 		if err == io.EOF {
@@ -340,6 +348,13 @@ func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeR
 		}
 		if err != nil {
 			return fmt.Errorf("stream error: %w", err)
+		}
+		if entry.Subscribed && !signaled {
+			signaled = true
+			if subscribed != nil {
+				close(subscribed)
+			}
+			continue
 		}
 		cb(entry)
 	}

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -320,6 +320,60 @@ func (c *PingClient) GetSystemStats(ctx context.Context, includeProcesses bool, 
 // AppLogCallback is called for each log entry received from the stream.
 type AppLogCallback func(entry *AppLogEntry)
 
+// CalcRouteCallback is called once per route received from
+// StreamCalcRoutes. Returning false stops further reception (the
+// underlying gRPC stream is canceled, signaling the server to stop
+// the BFS as well).
+type CalcRouteCallback func(route *CalcRoute) bool
+
+// StreamCalcRoutes runs a server-side route-finder BFS and invokes cb
+// for each path the server emits. count == 0 means "until exhausted";
+// the streaming wire shape lets the caller dump every route as it
+// arrives without buffering the whole set, which matters when the
+// server's BFS is exploring an unbounded result space.
+//
+// Source PK empty means "use the receiving visor's PK".
+func (c *PingClient) StreamCalcRoutes(
+	ctx context.Context,
+	srcPK, dstPK string,
+	minHops, maxHops, count int32,
+	source, tpdURL string,
+	cb CalcRouteCallback,
+) error {
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := c.client.StreamCalcRoutes(streamCtx, &CalcRoutesRequest{
+		SrcPk:   srcPK,
+		DstPk:   dstPK,
+		MinHops: minHops,
+		MaxHops: maxHops,
+		Count:   count,
+		Source:  source,
+		TpdUrl:  tpdURL,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start calc routes stream: %w", err)
+	}
+
+	for {
+		route, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("stream error: %w", err)
+		}
+		if !cb(route) {
+			// Cancel the stream context so the server-side BFS
+			// stops searching too — saves work on the visor when
+			// the user has seen enough.
+			cancel()
+			return nil
+		}
+	}
+}
+
 // StreamAppLogs subscribes to the visor's master logger and calls cb
 // for each entry that matches the filter. Blocks until ctx is canceled
 // or the stream errors. Used by 'proxy start --verbose'.

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -317,6 +317,34 @@ func (c *PingClient) GetSystemStats(ctx context.Context, includeProcesses bool, 
 	return stats, nil
 }
 
+// AppLogCallback is called for each log entry received from the stream.
+type AppLogCallback func(entry *AppLogEntry)
+
+// StreamAppLogs subscribes to the visor's master logger and calls cb
+// for each entry that matches the filter. Blocks until ctx is canceled
+// or the stream errors. Used by 'proxy start --verbose'.
+func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeRouter bool, minLevel string, cb AppLogCallback) error {
+	stream, err := c.client.StreamAppLogs(ctx, &AppLogStreamRequest{
+		AppName:       appName,
+		IncludeRouter: includeRouter,
+		MinLevel:      minLevel,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start app log stream: %w", err)
+	}
+
+	for {
+		entry, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("stream error: %w", err)
+		}
+		cb(entry)
+	}
+}
+
 // StreamRemoteSystemStats streams system stats from a remote visor via DMSG.
 // The local visor proxies the connection to the remote visor using its DMSG client.
 func (c *PingClient) StreamRemoteSystemStats(ctx context.Context, remotePK string, updateInterval time.Duration, includeProcesses bool, processLimit int32, cb SystemStatsCallback) error {

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -378,7 +378,10 @@ func (c *PingClient) StreamCalcRoutes(
 
 // StreamAppLogs subscribes to the visor's master logger and calls cb
 // for each entry that matches the filter. Blocks until ctx is canceled
-// or the stream errors. Used by 'proxy start --verbose'.
+// or the stream errors. Used by 'proxy start --verbose' (app-name
+// scoped) and 'dmsg curl --verbose' (module-prefix scoped).
+//
+// modules is OR-merged with appName; either or both must be non-empty.
 //
 // If subscribed is non-nil, it is closed once the server confirms the
 // subscription is live (via the Subscribed sentinel entry). Callers
@@ -386,11 +389,12 @@ func (c *PingClient) StreamCalcRoutes(
 // log output they want to capture, so the first burst of activity
 // isn't lost to the subscription handshake. The sentinel itself is
 // not delivered to cb.
-func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeRouter bool, minLevel string, subscribed chan<- struct{}, cb AppLogCallback) error {
+func (c *PingClient) StreamAppLogs(ctx context.Context, appName string, includeRouter bool, minLevel string, modules []string, subscribed chan<- struct{}, cb AppLogCallback) error {
 	stream, err := c.client.StreamAppLogs(ctx, &AppLogStreamRequest{
 		AppName:       appName,
 		IncludeRouter: includeRouter,
 		MinLevel:      minLevel,
+		Modules:       modules,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start app log stream: %w", err)

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -333,10 +333,11 @@ type CalcRouteCallback func(route *CalcRoute) bool
 // server's BFS is exploring an unbounded result space.
 //
 // Source PK empty means "use the receiving visor's PK".
+// queueCap caps the server's BFS queue (0 = server default).
 func (c *PingClient) StreamCalcRoutes(
 	ctx context.Context,
 	srcPK, dstPK string,
-	minHops, maxHops, count int32,
+	minHops, maxHops, count, queueCap int32,
 	source, tpdURL string,
 	cb CalcRouteCallback,
 ) error {
@@ -344,13 +345,14 @@ func (c *PingClient) StreamCalcRoutes(
 	defer cancel()
 
 	stream, err := c.client.StreamCalcRoutes(streamCtx, &CalcRoutesRequest{
-		SrcPk:   srcPK,
-		DstPk:   dstPK,
-		MinHops: minHops,
-		MaxHops: maxHops,
-		Count:   count,
-		Source:  source,
-		TpdUrl:  tpdURL,
+		SrcPk:    srcPK,
+		DstPk:    dstPK,
+		MinHops:  minHops,
+		MaxHops:  maxHops,
+		Count:    count,
+		Source:   source,
+		TpdUrl:   tpdURL,
+		QueueCap: queueCap,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to start calc routes stream: %w", err)

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -7,12 +7,11 @@
 package rpcgrpc
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1279,6 +1278,151 @@ func (x *TempStat) GetCritical() float64 {
 	return 0
 }
 
+// AppLogStreamRequest configures app-scoped log streaming.
+type AppLogStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// AppName scopes the stream to entries originating from this app's
+	// module or carrying app=<name> as a logrus field. Required.
+	AppName string `protobuf:"bytes,1,opt,name=app_name,json=appName,proto3" json:"app_name,omitempty"`
+	// IncludeRouter also forwards entries from router/transport/route_setup
+	// modules — the layers that build mux routes for the app. Default false:
+	// app-only logs.
+	IncludeRouter bool `protobuf:"varint,2,opt,name=include_router,json=includeRouter,proto3" json:"include_router,omitempty"`
+	// MinLevel filters out lower-severity entries: trace|debug|info|warn|error.
+	// Default debug.
+	MinLevel      string `protobuf:"bytes,3,opt,name=min_level,json=minLevel,proto3" json:"min_level,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AppLogStreamRequest) Reset() {
+	*x = AppLogStreamRequest{}
+	mi := &file_ping_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AppLogStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AppLogStreamRequest) ProtoMessage() {}
+
+func (x *AppLogStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AppLogStreamRequest.ProtoReflect.Descriptor instead.
+func (*AppLogStreamRequest) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *AppLogStreamRequest) GetAppName() string {
+	if x != nil {
+		return x.AppName
+	}
+	return ""
+}
+
+func (x *AppLogStreamRequest) GetIncludeRouter() bool {
+	if x != nil {
+		return x.IncludeRouter
+	}
+	return false
+}
+
+func (x *AppLogStreamRequest) GetMinLevel() string {
+	if x != nil {
+		return x.MinLevel
+	}
+	return ""
+}
+
+// AppLogEntry is one log line forwarded to the gRPC client.
+type AppLogEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TimestampNs   int64                  `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`                                             // entry time as Unix nanoseconds
+	Level         string                 `protobuf:"bytes,2,opt,name=level,proto3" json:"level,omitempty"`                                                                             // "trace"|"debug"|"info"|"warn"|"error"|"fatal"|"panic"
+	Module        string                 `protobuf:"bytes,3,opt,name=module,proto3" json:"module,omitempty"`                                                                           // _module field (e.g. "router", "skysocks-client")
+	Message       string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`                                                                         // formatted message text
+	Fields        map[string]string      `protobuf:"bytes,5,rep,name=fields,proto3" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // remaining structured fields
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AppLogEntry) Reset() {
+	*x = AppLogEntry{}
+	mi := &file_ping_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AppLogEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AppLogEntry) ProtoMessage() {}
+
+func (x *AppLogEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AppLogEntry.ProtoReflect.Descriptor instead.
+func (*AppLogEntry) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *AppLogEntry) GetTimestampNs() int64 {
+	if x != nil {
+		return x.TimestampNs
+	}
+	return 0
+}
+
+func (x *AppLogEntry) GetLevel() string {
+	if x != nil {
+		return x.Level
+	}
+	return ""
+}
+
+func (x *AppLogEntry) GetModule() string {
+	if x != nil {
+		return x.Module
+	}
+	return ""
+}
+
+func (x *AppLogEntry) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *AppLogEntry) GetFields() map[string]string {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
 // ProcessStat contains information about a running process
 type ProcessStat struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1295,7 +1439,7 @@ type ProcessStat struct {
 
 func (x *ProcessStat) Reset() {
 	*x = ProcessStat{}
-	mi := &file_ping_proto_msgTypes[16]
+	mi := &file_ping_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1307,7 +1451,7 @@ func (x *ProcessStat) String() string {
 func (*ProcessStat) ProtoMessage() {}
 
 func (x *ProcessStat) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[16]
+	mi := &file_ping_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1320,7 +1464,7 @@ func (x *ProcessStat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessStat.ProtoReflect.Descriptor instead.
 func (*ProcessStat) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{16}
+	return file_ping_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ProcessStat) GetPid() int32 {
@@ -1500,7 +1644,20 @@ const file_ping_proto_rawDesc = "" +
 	"sensor_key\x18\x01 \x01(\tR\tsensorKey\x12 \n" +
 	"\vtemperature\x18\x02 \x01(\x01R\vtemperature\x12\x12\n" +
 	"\x04high\x18\x03 \x01(\x01R\x04high\x12\x1a\n" +
-	"\bcritical\x18\x04 \x01(\x01R\bcritical\"\xce\x01\n" +
+	"\bcritical\x18\x04 \x01(\x01R\bcritical\"t\n" +
+	"\x13AppLogStreamRequest\x12\x19\n" +
+	"\bapp_name\x18\x01 \x01(\tR\aappName\x12%\n" +
+	"\x0einclude_router\x18\x02 \x01(\bR\rincludeRouter\x12\x1b\n" +
+	"\tmin_level\x18\x03 \x01(\tR\bminLevel\"\xed\x01\n" +
+	"\vAppLogEntry\x12!\n" +
+	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12\x14\n" +
+	"\x05level\x18\x02 \x01(\tR\x05level\x12\x16\n" +
+	"\x06module\x18\x03 \x01(\tR\x06module\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\x128\n" +
+	"\x06fields\x18\x05 \x03(\v2 .rpcgrpc.AppLogEntry.FieldsEntryR\x06fields\x1a9\n" +
+	"\vFieldsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xce\x01\n" +
 	"\vProcessStat\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1f\n" +
@@ -1510,7 +1667,7 @@ const file_ping_proto_rawDesc = "" +
 	"\n" +
 	"memory_rss\x18\x05 \x01(\x04R\tmemoryRss\x12\x1a\n" +
 	"\busername\x18\x06 \x01(\tR\busername\x12\x16\n" +
-	"\x06status\x18\a \x01(\tR\x06status2\xe3\x04\n" +
+	"\x06status\x18\a \x01(\tR\x06status2\xaa\x05\n" +
 	"\vPingService\x129\n" +
 	"\n" +
 	"StreamPing\x12\x14.rpcgrpc.PingRequest\x1a\x13.rpcgrpc.PingResult0\x01\x12=\n" +
@@ -1520,7 +1677,8 @@ const file_ping_proto_rawDesc = "" +
 	"\x14GetRemoteDmsgServers\x12\x1b.rpcgrpc.DmsgServersRequest\x1a\x1c.rpcgrpc.DmsgServersResponse\x12H\n" +
 	"\x11StreamSystemStats\x12\x1b.rpcgrpc.SystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01\x12C\n" +
 	"\x0eGetSystemStats\x12\x1b.rpcgrpc.SystemStatsRequest\x1a\x14.rpcgrpc.SystemStats\x12T\n" +
-	"\x17StreamRemoteSystemStats\x12!.rpcgrpc.RemoteSystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
+	"\x17StreamRemoteSystemStats\x12!.rpcgrpc.RemoteSystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01\x12E\n" +
+	"\rStreamAppLogs\x12\x1c.rpcgrpc.AppLogStreamRequest\x1a\x14.rpcgrpc.AppLogEntry0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -1534,7 +1692,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -1552,7 +1710,10 @@ var file_ping_proto_goTypes = []any{
 	(*DiskStat)(nil),                 // 13: rpcgrpc.DiskStat
 	(*NetworkStat)(nil),              // 14: rpcgrpc.NetworkStat
 	(*TempStat)(nil),                 // 15: rpcgrpc.TempStat
-	(*ProcessStat)(nil),              // 16: rpcgrpc.ProcessStat
+	(*AppLogStreamRequest)(nil),      // 16: rpcgrpc.AppLogStreamRequest
+	(*AppLogEntry)(nil),              // 17: rpcgrpc.AppLogEntry
+	(*ProcessStat)(nil),              // 18: rpcgrpc.ProcessStat
+	nil,                              // 19: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -1565,28 +1726,31 @@ var file_ping_proto_depIdxs = []int32{
 	13, // 7: rpcgrpc.SystemStats.disks:type_name -> rpcgrpc.DiskStat
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
-	16, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	0,  // 11: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 12: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 13: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 14: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 15: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 16: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 17: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 18: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	1,  // 19: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 20: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 21: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 22: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 23: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 24: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 25: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 26: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	19, // [19:27] is the sub-list for method output_type
-	11, // [11:19] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	18, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
+	19, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	0,  // 12: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 13: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 14: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 15: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 16: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 17: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 18: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 19: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 20: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	1,  // 21: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 22: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 23: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 24: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 25: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 26: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 27: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 28: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 29: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	21, // [21:30] is the sub-list for method output_type
+	12, // [12:21] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -1600,7 +1764,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -1282,15 +1282,22 @@ func (x *TempStat) GetCritical() float64 {
 type AppLogStreamRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// AppName scopes the stream to entries originating from this app's
-	// module or carrying app=<name> as a logrus field. Required.
+	// module or carrying app=<name> as a logrus field. Either AppName
+	// or Modules (or both) must be set.
 	AppName string `protobuf:"bytes,1,opt,name=app_name,json=appName,proto3" json:"app_name,omitempty"`
-	// IncludeRouter also forwards entries from router/transport/route_setup
-	// modules — the layers that build mux routes for the app. Default false:
-	// app-only logs.
+	// IncludeRouter is retained on the wire for forward compatibility
+	// but is ignored — the app_name field tagging now covers what it
+	// used to do, and Modules below is the explicit path for non-app
+	// scoping (e.g. 'cli dmsg curl --verbose' picking up dmsg layers).
 	IncludeRouter bool `protobuf:"varint,2,opt,name=include_router,json=includeRouter,proto3" json:"include_router,omitempty"`
 	// MinLevel filters out lower-severity entries: trace|debug|info|warn|error.
 	// Default debug.
-	MinLevel      string `protobuf:"bytes,3,opt,name=min_level,json=minLevel,proto3" json:"min_level,omitempty"`
+	MinLevel string `protobuf:"bytes,3,opt,name=min_level,json=minLevel,proto3" json:"min_level,omitempty"`
+	// Modules filters by _module prefix, OR-merged with the AppName
+	// match. Use this when no app context exists — e.g. 'dmsg curl
+	// --verbose' sends ["dmsgC","dmsghttp","dmsg_grpc"]. Empty means
+	// "no module-prefix match"; AppName is then the only path.
+	Modules       []string `protobuf:"bytes,4,rep,name=modules,proto3" json:"modules,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1344,6 +1351,13 @@ func (x *AppLogStreamRequest) GetMinLevel() string {
 		return x.MinLevel
 	}
 	return ""
+}
+
+func (x *AppLogStreamRequest) GetModules() []string {
+	if x != nil {
+		return x.Modules
+	}
+	return nil
 }
 
 // AppLogEntry is one log line forwarded to the gRPC client.
@@ -1884,11 +1898,12 @@ const file_ping_proto_rawDesc = "" +
 	"sensor_key\x18\x01 \x01(\tR\tsensorKey\x12 \n" +
 	"\vtemperature\x18\x02 \x01(\x01R\vtemperature\x12\x12\n" +
 	"\x04high\x18\x03 \x01(\x01R\x04high\x12\x1a\n" +
-	"\bcritical\x18\x04 \x01(\x01R\bcritical\"t\n" +
+	"\bcritical\x18\x04 \x01(\x01R\bcritical\"\x8e\x01\n" +
 	"\x13AppLogStreamRequest\x12\x19\n" +
 	"\bapp_name\x18\x01 \x01(\tR\aappName\x12%\n" +
 	"\x0einclude_router\x18\x02 \x01(\bR\rincludeRouter\x12\x1b\n" +
-	"\tmin_level\x18\x03 \x01(\tR\bminLevel\"\x8d\x02\n" +
+	"\tmin_level\x18\x03 \x01(\tR\bminLevel\x12\x18\n" +
+	"\amodules\x18\x04 \x03(\tR\amodules\"\x8d\x02\n" +
 	"\vAppLogEntry\x12!\n" +
 	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12\x14\n" +
 	"\x05level\x18\x02 \x01(\tR\x05level\x12\x16\n" +

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -1439,6 +1439,219 @@ func (x *AppLogEntry) GetSubscribed() bool {
 	return false
 }
 
+// CalcRoutesRequest configures server-side route calculation streaming.
+type CalcRoutesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SrcPk is the source visor public key. Empty means use the receiving
+	// visor's own PK (the common case — calc routes from this visor).
+	SrcPk string `protobuf:"bytes,1,opt,name=src_pk,json=srcPk,proto3" json:"src_pk,omitempty"`
+	// DstPk is the destination visor public key. Required.
+	DstPk string `protobuf:"bytes,2,opt,name=dst_pk,json=dstPk,proto3" json:"dst_pk,omitempty"`
+	// MinHops is the minimum hop count. 0 falls back to the visor's
+	// routing.min_hops, then 1.
+	MinHops int32 `protobuf:"varint,3,opt,name=min_hops,json=minHops,proto3" json:"min_hops,omitempty"`
+	// MaxHops is the maximum hop count. 0 falls back to a safe default.
+	MaxHops int32 `protobuf:"varint,4,opt,name=max_hops,json=maxHops,proto3" json:"max_hops,omitempty"`
+	// Count caps how many routes to return. 0 means unbounded (the BFS
+	// runs until the search space is exhausted; the streaming wire
+	// protocol means the caller can still dump them as they arrive
+	// without buffering the whole set).
+	Count int32 `protobuf:"varint,5,opt,name=count,proto3" json:"count,omitempty"`
+	// Source selects the transport-graph data source. "tpd" (HTTP),
+	// "dht" (visor's local DHT store), or "auto" (DHT then TPD fallback).
+	Source string `protobuf:"bytes,6,opt,name=source,proto3" json:"source,omitempty"`
+	// TpdUrl optionally overrides the default transport-discovery URL.
+	TpdUrl        string `protobuf:"bytes,7,opt,name=tpd_url,json=tpdUrl,proto3" json:"tpd_url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CalcRoutesRequest) Reset() {
+	*x = CalcRoutesRequest{}
+	mi := &file_ping_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CalcRoutesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CalcRoutesRequest) ProtoMessage() {}
+
+func (x *CalcRoutesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CalcRoutesRequest.ProtoReflect.Descriptor instead.
+func (*CalcRoutesRequest) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *CalcRoutesRequest) GetSrcPk() string {
+	if x != nil {
+		return x.SrcPk
+	}
+	return ""
+}
+
+func (x *CalcRoutesRequest) GetDstPk() string {
+	if x != nil {
+		return x.DstPk
+	}
+	return ""
+}
+
+func (x *CalcRoutesRequest) GetMinHops() int32 {
+	if x != nil {
+		return x.MinHops
+	}
+	return 0
+}
+
+func (x *CalcRoutesRequest) GetMaxHops() int32 {
+	if x != nil {
+		return x.MaxHops
+	}
+	return 0
+}
+
+func (x *CalcRoutesRequest) GetCount() int32 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
+func (x *CalcRoutesRequest) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
+}
+
+func (x *CalcRoutesRequest) GetTpdUrl() string {
+	if x != nil {
+		return x.TpdUrl
+	}
+	return ""
+}
+
+// CalcRoute is one path the BFS found. Hops are listed in forward order
+// from src to dst; the caller can derive the reverse by mirroring.
+type CalcRoute struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Hops          []*CalcHop             `protobuf:"bytes,1,rep,name=hops,proto3" json:"hops,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CalcRoute) Reset() {
+	*x = CalcRoute{}
+	mi := &file_ping_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CalcRoute) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CalcRoute) ProtoMessage() {}
+
+func (x *CalcRoute) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CalcRoute.ProtoReflect.Descriptor instead.
+func (*CalcRoute) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *CalcRoute) GetHops() []*CalcHop {
+	if x != nil {
+		return x.Hops
+	}
+	return nil
+}
+
+// CalcHop is one edge in a route.
+type CalcHop struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TpId          string                 `protobuf:"bytes,1,opt,name=tp_id,json=tpId,proto3" json:"tp_id,omitempty"`
+	From          string                 `protobuf:"bytes,2,opt,name=from,proto3" json:"from,omitempty"`
+	To            string                 `protobuf:"bytes,3,opt,name=to,proto3" json:"to,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CalcHop) Reset() {
+	*x = CalcHop{}
+	mi := &file_ping_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CalcHop) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CalcHop) ProtoMessage() {}
+
+func (x *CalcHop) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CalcHop.ProtoReflect.Descriptor instead.
+func (*CalcHop) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *CalcHop) GetTpId() string {
+	if x != nil {
+		return x.TpId
+	}
+	return ""
+}
+
+func (x *CalcHop) GetFrom() string {
+	if x != nil {
+		return x.From
+	}
+	return ""
+}
+
+func (x *CalcHop) GetTo() string {
+	if x != nil {
+		return x.To
+	}
+	return ""
+}
+
 // ProcessStat contains information about a running process
 type ProcessStat struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1455,7 +1668,7 @@ type ProcessStat struct {
 
 func (x *ProcessStat) Reset() {
 	*x = ProcessStat{}
-	mi := &file_ping_proto_msgTypes[18]
+	mi := &file_ping_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1467,7 +1680,7 @@ func (x *ProcessStat) String() string {
 func (*ProcessStat) ProtoMessage() {}
 
 func (x *ProcessStat) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[18]
+	mi := &file_ping_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1480,7 +1693,7 @@ func (x *ProcessStat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessStat.ProtoReflect.Descriptor instead.
 func (*ProcessStat) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{18}
+	return file_ping_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ProcessStat) GetPid() int32 {
@@ -1676,7 +1889,21 @@ const file_ping_proto_rawDesc = "" +
 	"subscribed\x1a9\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xce\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbe\x01\n" +
+	"\x11CalcRoutesRequest\x12\x15\n" +
+	"\x06src_pk\x18\x01 \x01(\tR\x05srcPk\x12\x15\n" +
+	"\x06dst_pk\x18\x02 \x01(\tR\x05dstPk\x12\x19\n" +
+	"\bmin_hops\x18\x03 \x01(\x05R\aminHops\x12\x19\n" +
+	"\bmax_hops\x18\x04 \x01(\x05R\amaxHops\x12\x14\n" +
+	"\x05count\x18\x05 \x01(\x05R\x05count\x12\x16\n" +
+	"\x06source\x18\x06 \x01(\tR\x06source\x12\x17\n" +
+	"\atpd_url\x18\a \x01(\tR\x06tpdUrl\"1\n" +
+	"\tCalcRoute\x12$\n" +
+	"\x04hops\x18\x01 \x03(\v2\x10.rpcgrpc.CalcHopR\x04hops\"B\n" +
+	"\aCalcHop\x12\x13\n" +
+	"\x05tp_id\x18\x01 \x01(\tR\x04tpId\x12\x12\n" +
+	"\x04from\x18\x02 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x03 \x01(\tR\x02to\"\xce\x01\n" +
 	"\vProcessStat\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1f\n" +
@@ -1686,7 +1913,7 @@ const file_ping_proto_rawDesc = "" +
 	"\n" +
 	"memory_rss\x18\x05 \x01(\x04R\tmemoryRss\x12\x1a\n" +
 	"\busername\x18\x06 \x01(\tR\busername\x12\x16\n" +
-	"\x06status\x18\a \x01(\tR\x06status2\xaa\x05\n" +
+	"\x06status\x18\a \x01(\tR\x06status2\xf0\x05\n" +
 	"\vPingService\x129\n" +
 	"\n" +
 	"StreamPing\x12\x14.rpcgrpc.PingRequest\x1a\x13.rpcgrpc.PingResult0\x01\x12=\n" +
@@ -1697,7 +1924,8 @@ const file_ping_proto_rawDesc = "" +
 	"\x11StreamSystemStats\x12\x1b.rpcgrpc.SystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01\x12C\n" +
 	"\x0eGetSystemStats\x12\x1b.rpcgrpc.SystemStatsRequest\x1a\x14.rpcgrpc.SystemStats\x12T\n" +
 	"\x17StreamRemoteSystemStats\x12!.rpcgrpc.RemoteSystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01\x12E\n" +
-	"\rStreamAppLogs\x12\x1c.rpcgrpc.AppLogStreamRequest\x1a\x14.rpcgrpc.AppLogEntry0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
+	"\rStreamAppLogs\x12\x1c.rpcgrpc.AppLogStreamRequest\x1a\x14.rpcgrpc.AppLogEntry0\x01\x12D\n" +
+	"\x10StreamCalcRoutes\x12\x1a.rpcgrpc.CalcRoutesRequest\x1a\x12.rpcgrpc.CalcRoute0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -1711,7 +1939,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -1731,8 +1959,11 @@ var file_ping_proto_goTypes = []any{
 	(*TempStat)(nil),                 // 15: rpcgrpc.TempStat
 	(*AppLogStreamRequest)(nil),      // 16: rpcgrpc.AppLogStreamRequest
 	(*AppLogEntry)(nil),              // 17: rpcgrpc.AppLogEntry
-	(*ProcessStat)(nil),              // 18: rpcgrpc.ProcessStat
-	nil,                              // 19: rpcgrpc.AppLogEntry.FieldsEntry
+	(*CalcRoutesRequest)(nil),        // 18: rpcgrpc.CalcRoutesRequest
+	(*CalcRoute)(nil),                // 19: rpcgrpc.CalcRoute
+	(*CalcHop)(nil),                  // 20: rpcgrpc.CalcHop
+	(*ProcessStat)(nil),              // 21: rpcgrpc.ProcessStat
+	nil,                              // 22: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -1745,31 +1976,34 @@ var file_ping_proto_depIdxs = []int32{
 	13, // 7: rpcgrpc.SystemStats.disks:type_name -> rpcgrpc.DiskStat
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
-	18, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	19, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
-	0,  // 12: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 13: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 14: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 15: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 16: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 17: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 18: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 19: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 20: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	1,  // 21: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 22: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 23: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 24: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 25: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 26: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 27: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 28: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 29: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	21, // [21:30] is the sub-list for method output_type
-	12, // [12:21] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	21, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
+	22, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
+	0,  // 13: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 14: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 15: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 16: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 17: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 18: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 19: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 20: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 21: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 22: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	1,  // 23: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 24: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 25: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 26: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 27: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 28: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 29: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 30: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 31: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 32: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	23, // [23:33] is the sub-list for method output_type
+	13, // [13:23] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -1783,7 +2017,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -1348,12 +1348,21 @@ func (x *AppLogStreamRequest) GetMinLevel() string {
 
 // AppLogEntry is one log line forwarded to the gRPC client.
 type AppLogEntry struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	TimestampNs   int64                  `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`                                             // entry time as Unix nanoseconds
-	Level         string                 `protobuf:"bytes,2,opt,name=level,proto3" json:"level,omitempty"`                                                                             // "trace"|"debug"|"info"|"warn"|"error"|"fatal"|"panic"
-	Module        string                 `protobuf:"bytes,3,opt,name=module,proto3" json:"module,omitempty"`                                                                           // _module field (e.g. "router", "skysocks-client")
-	Message       string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`                                                                         // formatted message text
-	Fields        map[string]string      `protobuf:"bytes,5,rep,name=fields,proto3" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // remaining structured fields
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	TimestampNs int64                  `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`                                             // entry time as Unix nanoseconds
+	Level       string                 `protobuf:"bytes,2,opt,name=level,proto3" json:"level,omitempty"`                                                                             // "trace"|"debug"|"info"|"warn"|"error"|"fatal"|"panic"
+	Module      string                 `protobuf:"bytes,3,opt,name=module,proto3" json:"module,omitempty"`                                                                           // _module field (e.g. "router", "skysocks-client")
+	Message     string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`                                                                         // formatted message text
+	Fields      map[string]string      `protobuf:"bytes,5,rep,name=fields,proto3" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // remaining structured fields
+	// Subscribed is set on a sentinel entry the server sends
+	// immediately after it has registered the subscription with the
+	// broadcaster. Clients use this to know that any subsequent log
+	// activity will reach them — letting them gate downstream RPC
+	// calls (e.g. StartAppWithMode) on subscription readiness so the
+	// first ~50ms of setup logs aren't lost to the race between
+	// subscription handshake and the action that triggers them.
+	// The other fields are unused on the sentinel.
+	Subscribed    bool `protobuf:"varint,6,opt,name=subscribed,proto3" json:"subscribed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1421,6 +1430,13 @@ func (x *AppLogEntry) GetFields() map[string]string {
 		return x.Fields
 	}
 	return nil
+}
+
+func (x *AppLogEntry) GetSubscribed() bool {
+	if x != nil {
+		return x.Subscribed
+	}
+	return false
 }
 
 // ProcessStat contains information about a running process
@@ -1648,13 +1664,16 @@ const file_ping_proto_rawDesc = "" +
 	"\x13AppLogStreamRequest\x12\x19\n" +
 	"\bapp_name\x18\x01 \x01(\tR\aappName\x12%\n" +
 	"\x0einclude_router\x18\x02 \x01(\bR\rincludeRouter\x12\x1b\n" +
-	"\tmin_level\x18\x03 \x01(\tR\bminLevel\"\xed\x01\n" +
+	"\tmin_level\x18\x03 \x01(\tR\bminLevel\"\x8d\x02\n" +
 	"\vAppLogEntry\x12!\n" +
 	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12\x14\n" +
 	"\x05level\x18\x02 \x01(\tR\x05level\x12\x16\n" +
 	"\x06module\x18\x03 \x01(\tR\x06module\x12\x18\n" +
 	"\amessage\x18\x04 \x01(\tR\amessage\x128\n" +
-	"\x06fields\x18\x05 \x03(\v2 .rpcgrpc.AppLogEntry.FieldsEntryR\x06fields\x1a9\n" +
+	"\x06fields\x18\x05 \x03(\v2 .rpcgrpc.AppLogEntry.FieldsEntryR\x06fields\x12\x1e\n" +
+	"\n" +
+	"subscribed\x18\x06 \x01(\bR\n" +
+	"subscribed\x1a9\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xce\x01\n" +

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -1461,7 +1461,11 @@ type CalcRoutesRequest struct {
 	// "dht" (visor's local DHT store), or "auto" (DHT then TPD fallback).
 	Source string `protobuf:"bytes,6,opt,name=source,proto3" json:"source,omitempty"`
 	// TpdUrl optionally overrides the default transport-discovery URL.
-	TpdUrl        string `protobuf:"bytes,7,opt,name=tpd_url,json=tpdUrl,proto3" json:"tpd_url,omitempty"`
+	TpdUrl string `protobuf:"bytes,7,opt,name=tpd_url,json=tpdUrl,proto3" json:"tpd_url,omitempty"`
+	// QueueCap caps the per-call BFS queue size on the server. 0 falls
+	// back to the route-finder package's DefaultMaxBFSQueue. Negative
+	// means unbounded (use with caution on dense graphs).
+	QueueCap      int32 `protobuf:"varint,8,opt,name=queue_cap,json=queueCap,proto3" json:"queue_cap,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1543,6 +1547,13 @@ func (x *CalcRoutesRequest) GetTpdUrl() string {
 		return x.TpdUrl
 	}
 	return ""
+}
+
+func (x *CalcRoutesRequest) GetQueueCap() int32 {
+	if x != nil {
+		return x.QueueCap
+	}
+	return 0
 }
 
 // CalcRoute is one path the BFS found. Hops are listed in forward order
@@ -1889,7 +1900,7 @@ const file_ping_proto_rawDesc = "" +
 	"subscribed\x1a9\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbe\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdb\x01\n" +
 	"\x11CalcRoutesRequest\x12\x15\n" +
 	"\x06src_pk\x18\x01 \x01(\tR\x05srcPk\x12\x15\n" +
 	"\x06dst_pk\x18\x02 \x01(\tR\x05dstPk\x12\x19\n" +
@@ -1897,7 +1908,8 @@ const file_ping_proto_rawDesc = "" +
 	"\bmax_hops\x18\x04 \x01(\x05R\amaxHops\x12\x14\n" +
 	"\x05count\x18\x05 \x01(\x05R\x05count\x12\x16\n" +
 	"\x06source\x18\x06 \x01(\tR\x06source\x12\x17\n" +
-	"\atpd_url\x18\a \x01(\tR\x06tpdUrl\"1\n" +
+	"\atpd_url\x18\a \x01(\tR\x06tpdUrl\x12\x1b\n" +
+	"\tqueue_cap\x18\b \x01(\x05R\bqueueCap\"1\n" +
 	"\tCalcRoute\x12$\n" +
 	"\x04hops\x18\x01 \x03(\v2\x10.rpcgrpc.CalcHopR\x04hops\"B\n" +
 	"\aCalcHop\x12\x13\n" +

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -30,6 +30,11 @@ service PingService {
   // StreamRemoteSystemStats proxies system stats from a remote visor via DMSG
   // The local visor dials the remote visor over DMSG and forwards the stats stream
   rpc StreamRemoteSystemStats(RemoteSystemStatsRequest) returns (stream SystemStats);
+
+  // StreamAppLogs streams visor log entries scoped to one app's session.
+  // Used by 'skywire-cli proxy start --verbose' to surface what the visor is
+  // doing while spinning up an app's transports/routes.
+  rpc StreamAppLogs(AppLogStreamRequest) returns (stream AppLogEntry);
 }
 
 message PingRequest {
@@ -171,6 +176,29 @@ message TempStat {
   double temperature = 2;     // Temperature in Celsius
   double high = 3;            // High threshold (if available)
   double critical = 4;        // Critical threshold (if available)
+}
+
+// AppLogStreamRequest configures app-scoped log streaming.
+message AppLogStreamRequest {
+  // AppName scopes the stream to entries originating from this app's
+  // module or carrying app=<name> as a logrus field. Required.
+  string app_name = 1;
+  // IncludeRouter also forwards entries from router/transport/route_setup
+  // modules — the layers that build mux routes for the app. Default false:
+  // app-only logs.
+  bool include_router = 2;
+  // MinLevel filters out lower-severity entries: trace|debug|info|warn|error.
+  // Default debug.
+  string min_level = 3;
+}
+
+// AppLogEntry is one log line forwarded to the gRPC client.
+message AppLogEntry {
+  int64 timestamp_ns = 1;        // entry time as Unix nanoseconds
+  string level = 2;              // "trace"|"debug"|"info"|"warn"|"error"|"fatal"|"panic"
+  string module = 3;             // _module field (e.g. "router", "skysocks-client")
+  string message = 4;            // formatted message text
+  map<string, string> fields = 5; // remaining structured fields
 }
 
 // ProcessStat contains information about a running process

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -187,15 +187,22 @@ message TempStat {
 // AppLogStreamRequest configures app-scoped log streaming.
 message AppLogStreamRequest {
   // AppName scopes the stream to entries originating from this app's
-  // module or carrying app=<name> as a logrus field. Required.
+  // module or carrying app=<name> as a logrus field. Either AppName
+  // or Modules (or both) must be set.
   string app_name = 1;
-  // IncludeRouter also forwards entries from router/transport/route_setup
-  // modules — the layers that build mux routes for the app. Default false:
-  // app-only logs.
+  // IncludeRouter is retained on the wire for forward compatibility
+  // but is ignored — the app_name field tagging now covers what it
+  // used to do, and Modules below is the explicit path for non-app
+  // scoping (e.g. 'cli dmsg curl --verbose' picking up dmsg layers).
   bool include_router = 2;
   // MinLevel filters out lower-severity entries: trace|debug|info|warn|error.
   // Default debug.
   string min_level = 3;
+  // Modules filters by _module prefix, OR-merged with the AppName
+  // match. Use this when no app context exists — e.g. 'dmsg curl
+  // --verbose' sends ["dmsgC","dmsghttp","dmsg_grpc"]. Empty means
+  // "no module-prefix match"; AppName is then the only path.
+  repeated string modules = 4;
 }
 
 // AppLogEntry is one log line forwarded to the gRPC client.

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -199,6 +199,15 @@ message AppLogEntry {
   string module = 3;             // _module field (e.g. "router", "skysocks-client")
   string message = 4;            // formatted message text
   map<string, string> fields = 5; // remaining structured fields
+  // Subscribed is set on a sentinel entry the server sends
+  // immediately after it has registered the subscription with the
+  // broadcaster. Clients use this to know that any subsequent log
+  // activity will reach them — letting them gate downstream RPC
+  // calls (e.g. StartAppWithMode) on subscription readiness so the
+  // first ~50ms of setup logs aren't lost to the race between
+  // subscription handshake and the action that triggers them.
+  // The other fields are unused on the sentinel.
+  bool subscribed = 6;
 }
 
 // ProcessStat contains information about a running process

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -35,6 +35,12 @@ service PingService {
   // Used by 'skywire-cli proxy start --verbose' to surface what the visor is
   // doing while spinning up an app's transports/routes.
   rpc StreamAppLogs(AppLogStreamRequest) returns (stream AppLogEntry);
+
+  // StreamCalcRoutes runs a route-finder BFS server-side and streams each
+  // valid route back as it's discovered. Lets the CLI display routes
+  // incrementally and avoids accumulating every result in memory before
+  // returning — important when count is large or unbounded.
+  rpc StreamCalcRoutes(CalcRoutesRequest) returns (stream CalcRoute);
 }
 
 message PingRequest {
@@ -208,6 +214,43 @@ message AppLogEntry {
   // subscription handshake and the action that triggers them.
   // The other fields are unused on the sentinel.
   bool subscribed = 6;
+}
+
+// CalcRoutesRequest configures server-side route calculation streaming.
+message CalcRoutesRequest {
+  // SrcPk is the source visor public key. Empty means use the receiving
+  // visor's own PK (the common case — calc routes from this visor).
+  string src_pk = 1;
+  // DstPk is the destination visor public key. Required.
+  string dst_pk = 2;
+  // MinHops is the minimum hop count. 0 falls back to the visor's
+  // routing.min_hops, then 1.
+  int32 min_hops = 3;
+  // MaxHops is the maximum hop count. 0 falls back to a safe default.
+  int32 max_hops = 4;
+  // Count caps how many routes to return. 0 means unbounded (the BFS
+  // runs until the search space is exhausted; the streaming wire
+  // protocol means the caller can still dump them as they arrive
+  // without buffering the whole set).
+  int32 count = 5;
+  // Source selects the transport-graph data source. "tpd" (HTTP),
+  // "dht" (visor's local DHT store), or "auto" (DHT then TPD fallback).
+  string source = 6;
+  // TpdUrl optionally overrides the default transport-discovery URL.
+  string tpd_url = 7;
+}
+
+// CalcRoute is one path the BFS found. Hops are listed in forward order
+// from src to dst; the caller can derive the reverse by mirroring.
+message CalcRoute {
+  repeated CalcHop hops = 1;
+}
+
+// CalcHop is one edge in a route.
+message CalcHop {
+  string tp_id = 1;
+  string from = 2;
+  string to = 3;
 }
 
 // ProcessStat contains information about a running process

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -238,6 +238,10 @@ message CalcRoutesRequest {
   string source = 6;
   // TpdUrl optionally overrides the default transport-discovery URL.
   string tpd_url = 7;
+  // QueueCap caps the per-call BFS queue size on the server. 0 falls
+  // back to the route-finder package's DefaultMaxBFSQueue. Negative
+  // means unbounded (use with caution on dense graphs).
+  int32 queue_cap = 8;
 }
 
 // CalcRoute is one path the BFS found. Hops are listed in forward order

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	PingService_GetSystemStats_FullMethodName          = "/rpcgrpc.PingService/GetSystemStats"
 	PingService_StreamRemoteSystemStats_FullMethodName = "/rpcgrpc.PingService/StreamRemoteSystemStats"
 	PingService_StreamAppLogs_FullMethodName           = "/rpcgrpc.PingService/StreamAppLogs"
+	PingService_StreamCalcRoutes_FullMethodName        = "/rpcgrpc.PingService/StreamCalcRoutes"
 )
 
 // PingServiceClient is the client API for PingService service.
@@ -57,6 +58,11 @@ type PingServiceClient interface {
 	// Used by 'skywire-cli proxy start --verbose' to surface what the visor is
 	// doing while spinning up an app's transports/routes.
 	StreamAppLogs(ctx context.Context, in *AppLogStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AppLogEntry], error)
+	// StreamCalcRoutes runs a route-finder BFS server-side and streams each
+	// valid route back as it's discovered. Lets the CLI display routes
+	// incrementally and avoids accumulating every result in memory before
+	// returning — important when count is large or unbounded.
+	StreamCalcRoutes(ctx context.Context, in *CalcRoutesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CalcRoute], error)
 }
 
 type pingServiceClient struct {
@@ -220,6 +226,25 @@ func (c *pingServiceClient) StreamAppLogs(ctx context.Context, in *AppLogStreamR
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamAppLogsClient = grpc.ServerStreamingClient[AppLogEntry]
 
+func (c *pingServiceClient) StreamCalcRoutes(ctx context.Context, in *CalcRoutesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CalcRoute], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &PingService_ServiceDesc.Streams[7], PingService_StreamCalcRoutes_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[CalcRoutesRequest, CalcRoute]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamCalcRoutesClient = grpc.ServerStreamingClient[CalcRoute]
+
 // PingServiceServer is the server API for PingService service.
 // All implementations must embed UnimplementedPingServiceServer
 // for forward compatibility.
@@ -247,6 +272,11 @@ type PingServiceServer interface {
 	// Used by 'skywire-cli proxy start --verbose' to surface what the visor is
 	// doing while spinning up an app's transports/routes.
 	StreamAppLogs(*AppLogStreamRequest, grpc.ServerStreamingServer[AppLogEntry]) error
+	// StreamCalcRoutes runs a route-finder BFS server-side and streams each
+	// valid route back as it's discovered. Lets the CLI display routes
+	// incrementally and avoids accumulating every result in memory before
+	// returning — important when count is large or unbounded.
+	StreamCalcRoutes(*CalcRoutesRequest, grpc.ServerStreamingServer[CalcRoute]) error
 	mustEmbedUnimplementedPingServiceServer()
 }
 
@@ -283,6 +313,9 @@ func (UnimplementedPingServiceServer) StreamRemoteSystemStats(*RemoteSystemStats
 }
 func (UnimplementedPingServiceServer) StreamAppLogs(*AppLogStreamRequest, grpc.ServerStreamingServer[AppLogEntry]) error {
 	return status.Error(codes.Unimplemented, "method StreamAppLogs not implemented")
+}
+func (UnimplementedPingServiceServer) StreamCalcRoutes(*CalcRoutesRequest, grpc.ServerStreamingServer[CalcRoute]) error {
+	return status.Error(codes.Unimplemented, "method StreamCalcRoutes not implemented")
 }
 func (UnimplementedPingServiceServer) mustEmbedUnimplementedPingServiceServer() {}
 func (UnimplementedPingServiceServer) testEmbeddedByValue()                     {}
@@ -418,6 +451,17 @@ func _PingService_StreamAppLogs_Handler(srv interface{}, stream grpc.ServerStrea
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamAppLogsServer = grpc.ServerStreamingServer[AppLogEntry]
 
+func _PingService_StreamCalcRoutes_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(CalcRoutesRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(PingServiceServer).StreamCalcRoutes(m, &grpc.GenericServerStream[CalcRoutesRequest, CalcRoute]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamCalcRoutesServer = grpc.ServerStreamingServer[CalcRoute]
+
 // PingService_ServiceDesc is the grpc.ServiceDesc for PingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -468,6 +512,11 @@ var PingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamAppLogs",
 			Handler:       _PingService_StreamAppLogs_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamCalcRoutes",
+			Handler:       _PingService_StreamCalcRoutes_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -8,7 +8,6 @@ package rpcgrpc
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -28,6 +27,7 @@ const (
 	PingService_StreamSystemStats_FullMethodName       = "/rpcgrpc.PingService/StreamSystemStats"
 	PingService_GetSystemStats_FullMethodName          = "/rpcgrpc.PingService/GetSystemStats"
 	PingService_StreamRemoteSystemStats_FullMethodName = "/rpcgrpc.PingService/StreamRemoteSystemStats"
+	PingService_StreamAppLogs_FullMethodName           = "/rpcgrpc.PingService/StreamAppLogs"
 )
 
 // PingServiceClient is the client API for PingService service.
@@ -53,6 +53,10 @@ type PingServiceClient interface {
 	// StreamRemoteSystemStats proxies system stats from a remote visor via DMSG
 	// The local visor dials the remote visor over DMSG and forwards the stats stream
 	StreamRemoteSystemStats(ctx context.Context, in *RemoteSystemStatsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SystemStats], error)
+	// StreamAppLogs streams visor log entries scoped to one app's session.
+	// Used by 'skywire-cli proxy start --verbose' to surface what the visor is
+	// doing while spinning up an app's transports/routes.
+	StreamAppLogs(ctx context.Context, in *AppLogStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AppLogEntry], error)
 }
 
 type pingServiceClient struct {
@@ -197,6 +201,25 @@ func (c *pingServiceClient) StreamRemoteSystemStats(ctx context.Context, in *Rem
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamRemoteSystemStatsClient = grpc.ServerStreamingClient[SystemStats]
 
+func (c *pingServiceClient) StreamAppLogs(ctx context.Context, in *AppLogStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[AppLogEntry], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &PingService_ServiceDesc.Streams[6], PingService_StreamAppLogs_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[AppLogStreamRequest, AppLogEntry]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamAppLogsClient = grpc.ServerStreamingClient[AppLogEntry]
+
 // PingServiceServer is the server API for PingService service.
 // All implementations must embed UnimplementedPingServiceServer
 // for forward compatibility.
@@ -220,6 +243,10 @@ type PingServiceServer interface {
 	// StreamRemoteSystemStats proxies system stats from a remote visor via DMSG
 	// The local visor dials the remote visor over DMSG and forwards the stats stream
 	StreamRemoteSystemStats(*RemoteSystemStatsRequest, grpc.ServerStreamingServer[SystemStats]) error
+	// StreamAppLogs streams visor log entries scoped to one app's session.
+	// Used by 'skywire-cli proxy start --verbose' to surface what the visor is
+	// doing while spinning up an app's transports/routes.
+	StreamAppLogs(*AppLogStreamRequest, grpc.ServerStreamingServer[AppLogEntry]) error
 	mustEmbedUnimplementedPingServiceServer()
 }
 
@@ -253,6 +280,9 @@ func (UnimplementedPingServiceServer) GetSystemStats(context.Context, *SystemSta
 }
 func (UnimplementedPingServiceServer) StreamRemoteSystemStats(*RemoteSystemStatsRequest, grpc.ServerStreamingServer[SystemStats]) error {
 	return status.Error(codes.Unimplemented, "method StreamRemoteSystemStats not implemented")
+}
+func (UnimplementedPingServiceServer) StreamAppLogs(*AppLogStreamRequest, grpc.ServerStreamingServer[AppLogEntry]) error {
+	return status.Error(codes.Unimplemented, "method StreamAppLogs not implemented")
 }
 func (UnimplementedPingServiceServer) mustEmbedUnimplementedPingServiceServer() {}
 func (UnimplementedPingServiceServer) testEmbeddedByValue()                     {}
@@ -377,6 +407,17 @@ func _PingService_StreamRemoteSystemStats_Handler(srv interface{}, stream grpc.S
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamRemoteSystemStatsServer = grpc.ServerStreamingServer[SystemStats]
 
+func _PingService_StreamAppLogs_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(AppLogStreamRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(PingServiceServer).StreamAppLogs(m, &grpc.GenericServerStream[AppLogStreamRequest, AppLogEntry]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamAppLogsServer = grpc.ServerStreamingServer[AppLogEntry]
+
 // PingService_ServiceDesc is the grpc.ServiceDesc for PingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -422,6 +463,11 @@ var PingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamRemoteSystemStats",
 			Handler:       _PingService_StreamRemoteSystemStats_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamAppLogs",
+			Handler:       _PingService_StreamAppLogs_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -638,26 +638,27 @@ func (s *PingServer) GetSystemStats(ctx context.Context, req *SystemStatsRequest
 }
 
 // StreamAppLogs subscribes to the visor's master logger and forwards
-// matching entries to the gRPC client. Used by 'proxy start --verbose'.
+// matching entries to the gRPC client. Used by 'proxy start --verbose'
+// and 'dmsg curl --verbose'.
 //
-// Filtering: entries pass if _module == AppName, or app field ==
-// AppName, or app_name field == AppName. The visor's router/mux/setup
-// layers attach app_name=<n> to rg-scoped entries (see router.Config
-// .AppLookup wired in init_router.go), so this filter genuinely scopes
-// to one app's session — including layered events (route setup, mux
-// negotiation) that happen on behalf of the app, not just the app
-// process's own stdout. transport_manager and address_resolver
-// entries remain untagged because they are shared across apps.
+// Filtering: AppName matches by _module exact equality OR app/app_name
+// field. Modules matches by _module prefix. The two are OR-merged; at
+// least one must be specified (AppName="*" enables wildcard mode for
+// diagnostics).
+//
+// The visor's router/mux/setup layers attach app_name=<n> to rg-scoped
+// entries (see router.Config.AppLookup), so AppName filtering scopes
+// to one app's session — including layered events that happen on
+// behalf of the app, not just app stdout.
 //
 // IncludeRouter is retained on the wire for forward compatibility but
-// is currently ignored — the field-based filter already covers what
-// IncludeRouter=true used to attempt with much less noise.
+// is currently ignored — Modules is the explicit replacement.
 //
 // The subscription's per-stream buffer is bounded; bursts beyond it
 // are dropped and counted (cancel returns the count).
 func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_StreamAppLogsServer) error {
-	if req.AppName == "" {
-		return fmt.Errorf("app_name is required")
+	if req.AppName == "" && len(req.Modules) == 0 {
+		return fmt.Errorf("app_name or modules required")
 	}
 
 	level, err := logging.LevelFromString(req.MinLevel)
@@ -668,6 +669,7 @@ func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_
 
 	filter := logging.Filter{
 		AppName:  req.AppName,
+		Modules:  req.Modules,
 		MinLevel: level,
 	}
 	// Wildcard: AppName "*" disables app-scoping for diagnostic

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -788,8 +788,12 @@ func (s *PingServer) StreamCalcRoutes(req *CalcRoutesRequest, stream PingService
 		return fmt.Errorf("build graph: %w", err)
 	}
 
+	queueCap := int(req.QueueCap)
+	if queueCap == 0 {
+		queueCap = routeFinder.DefaultMaxBFSQueue
+	}
 	sent := int32(0)
-	streamErr := graph.StreamRoutes(stream.Context(), srcPK, dstPK, minHops, maxHops, func(r routing.Route) bool {
+	streamErr := graph.StreamRoutesWithCap(stream.Context(), srcPK, dstPK, minHops, maxHops, queueCap, func(r routing.Route) bool {
 		out := &CalcRoute{Hops: make([]*CalcHop, 0, len(r.Hops))}
 		for _, h := range r.Hops {
 			out.Hops = append(out.Hops, &CalcHop{

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -42,6 +43,10 @@ type VisorAPI interface {
 	GetRemoteDmsgServers(pk cipher.PubKey) ([]cipher.PubKey, error)
 	// DialDmsgRPC dials a remote visor's gRPC/RPC port over DMSG and returns the connection
 	DialDmsgRPC(pk cipher.PubKey) (net.Conn, error)
+	// SubscribeLogs returns a channel of logrus entries matching the
+	// filter; cancel() unsubscribes and returns the dropped count.
+	// Both may be nil (visor without a broadcaster wired up).
+	SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.Entry, func() uint64)
 }
 
 // PingConf mirrors visor.PingConfig to avoid import cycles
@@ -617,6 +622,94 @@ func (s *PingServer) GetSystemStats(ctx context.Context, req *SystemStatsRequest
 	}
 
 	return stats, nil
+}
+
+// StreamAppLogs subscribes to the visor's master logger and forwards
+// matching entries to the gRPC client. Used by 'proxy start --verbose'.
+//
+// Filtering: entries match when their _module starts with one of the
+// router/transport/route layers (when IncludeRouter is set) or when
+// the entry carries app=<AppName>. Levels strictly less severe than
+// the requested MinLevel are dropped on the server side.
+//
+// The subscription's per-stream buffer is bounded — bursts beyond it
+// are dropped and reported in the final entry's "_dropped" field.
+func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_StreamAppLogsServer) error {
+	if req.AppName == "" {
+		return fmt.Errorf("app_name is required")
+	}
+
+	level, err := logging.LevelFromString(req.MinLevel)
+	if err != nil {
+		// Default to debug — verbose mode is the use case.
+		level = logrus.DebugLevel
+	}
+
+	filter := logging.Filter{
+		AppName:  req.AppName,
+		MinLevel: level,
+	}
+	if req.IncludeRouter {
+		filter.Modules = []string{
+			"router",
+			"route_setup",
+			"transport",
+			"transport_manager",
+			"setup_node",
+			"mux_setup",
+			"address_resolver",
+			"app_launcher",
+			"appserver",
+		}
+	}
+
+	const subBuffer = 512
+	ch, cancel := s.visor.SubscribeLogs(filter, subBuffer)
+	if ch == nil {
+		return fmt.Errorf("log broadcaster not available on this visor")
+	}
+	defer cancel()
+
+	s.log.Debugf("gRPC StreamAppLogs: subscribed app=%s include_router=%v min_level=%s",
+		req.AppName, req.IncludeRouter, level)
+
+	for {
+		select {
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		case e, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			if err := stream.Send(toAppLogEntry(e)); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// toAppLogEntry converts a logrus.Entry to the wire AppLogEntry. The
+// _module field, when present, is hoisted into Module; remaining
+// fields land in Fields as strings (best-effort fmt.Sprint).
+func toAppLogEntry(e *logrus.Entry) *AppLogEntry {
+	module := ""
+	fields := make(map[string]string, len(e.Data))
+	for k, v := range e.Data {
+		if k == "_module" {
+			if m, ok := v.(string); ok {
+				module = m
+				continue
+			}
+		}
+		fields[k] = fmt.Sprintf("%v", v)
+	}
+	return &AppLogEntry{
+		TimestampNs: e.Time.UnixNano(),
+		Level:       e.Level.String(),
+		Module:      module,
+		Message:     e.Message,
+		Fields:      fields,
+	}
 }
 
 // StreamRemoteSystemStats proxies system stats from a remote visor via DMSG.

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -627,13 +627,21 @@ func (s *PingServer) GetSystemStats(ctx context.Context, req *SystemStatsRequest
 // StreamAppLogs subscribes to the visor's master logger and forwards
 // matching entries to the gRPC client. Used by 'proxy start --verbose'.
 //
-// Filtering: entries match when their _module starts with one of the
-// router/transport/route layers (when IncludeRouter is set) or when
-// the entry carries app=<AppName>. Levels strictly less severe than
-// the requested MinLevel are dropped on the server side.
+// Filtering: entries pass if _module == AppName, or app field ==
+// AppName, or app_name field == AppName. The visor's router/mux/setup
+// layers attach app_name=<n> to rg-scoped entries (see router.Config
+// .AppLookup wired in init_router.go), so this filter genuinely scopes
+// to one app's session — including layered events (route setup, mux
+// negotiation) that happen on behalf of the app, not just the app
+// process's own stdout. transport_manager and address_resolver
+// entries remain untagged because they are shared across apps.
 //
-// The subscription's per-stream buffer is bounded — bursts beyond it
-// are dropped and reported in the final entry's "_dropped" field.
+// IncludeRouter is retained on the wire for forward compatibility but
+// is currently ignored — the field-based filter already covers what
+// IncludeRouter=true used to attempt with much less noise.
+//
+// The subscription's per-stream buffer is bounded; bursts beyond it
+// are dropped and counted (cancel returns the count).
 func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_StreamAppLogsServer) error {
 	if req.AppName == "" {
 		return fmt.Errorf("app_name is required")
@@ -648,19 +656,6 @@ func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_
 	filter := logging.Filter{
 		AppName:  req.AppName,
 		MinLevel: level,
-	}
-	if req.IncludeRouter {
-		filter.Modules = []string{
-			"router",
-			"route_setup",
-			"transport",
-			"transport_manager",
-			"setup_node",
-			"mux_setup",
-			"address_resolver",
-			"app_launcher",
-			"appserver",
-		}
 	}
 
 	const subBuffer = 512

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -657,6 +657,11 @@ func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_
 		AppName:  req.AppName,
 		MinLevel: level,
 	}
+	// Wildcard: AppName "*" disables app-scoping for diagnostic
+	// purposes — useful for verifying the stream pipe itself.
+	if req.AppName == "*" {
+		filter.AppName = ""
+	}
 
 	const subBuffer = 512
 	ch, cancel := s.visor.SubscribeLogs(filter, subBuffer)

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -673,6 +673,18 @@ func (s *PingServer) StreamAppLogs(req *AppLogStreamRequest, stream PingService_
 	s.log.Debugf("gRPC StreamAppLogs: subscribed app=%s include_router=%v min_level=%s",
 		req.AppName, req.IncludeRouter, level)
 
+	// Sentinel: tell the client the subscription is live so it can
+	// race-safely trigger downstream RPCs whose log output we want
+	// to capture. Sent BEFORE entering the dispatch loop so any
+	// activity from the moment the client sees this entry forward
+	// is guaranteed to reach the broadcaster.
+	if err := stream.Send(&AppLogEntry{
+		TimestampNs: time.Now().UnixNano(),
+		Subscribed:  true,
+	}); err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-stream.Context().Done():

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -8,12 +8,18 @@ import (
 	"net"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	routeFinder "github.com/skycoin/skywire/pkg/route-finder/store"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	tpdstore "github.com/skycoin/skywire/pkg/transport-discovery/store"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // RouteHopInfo contains detailed information about a single hop in a route.
@@ -47,6 +53,13 @@ type VisorAPI interface {
 	// filter; cancel() unsubscribes and returns the dropped count.
 	// Both may be nil (visor without a broadcaster wired up).
 	SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.Entry, func() uint64)
+	// LocalPK returns the visor's own public key. Used by route-calc
+	// gRPC handlers that default the src PK to the local visor.
+	LocalPK() cipher.PubKey
+	// FetchAllTransportEntries pulls every transport entry from TPD via
+	// the visor's existing discovery client. The route-calc gRPC
+	// handler builds the BFS graph from this slice.
+	FetchAllTransportEntries(ctx context.Context) ([]*transport.Entry, error)
 }
 
 // PingConf mirrors visor.PingConfig to avoid import cycles
@@ -723,6 +736,181 @@ func toAppLogEntry(e *logrus.Entry) *AppLogEntry {
 		Fields:      fields,
 	}
 }
+
+// StreamCalcRoutes runs a route-finder BFS server-side and streams each
+// valid path back to the caller as it's discovered. The streaming wire
+// shape lets callers consume routes incrementally — neither side has to
+// hold every result in memory at once, which matters for unbounded
+// requests on dense graphs.
+//
+// Source PK defaults to this visor's own. Max-hops defaults to a safe
+// 5 if zero. count == 0 means "until exhausted"; the server will keep
+// emitting until no more routes exist or the client disconnects.
+//
+// The route-finder package's StreamRoutes drives the search; the loop
+// here is just transport-graph fetch + protocol marshaling.
+func (s *PingServer) StreamCalcRoutes(req *CalcRoutesRequest, stream PingService_StreamCalcRoutesServer) error {
+	var dstPK cipher.PubKey
+	if err := dstPK.Set(req.DstPk); err != nil {
+		return fmt.Errorf("invalid dst_pk: %w", err)
+	}
+	srcPK := s.visor.LocalPK()
+	if req.SrcPk != "" {
+		if err := srcPK.Set(req.SrcPk); err != nil {
+			return fmt.Errorf("invalid src_pk: %w", err)
+		}
+	}
+
+	maxHops := int(req.MaxHops)
+	if maxHops <= 0 {
+		maxHops = 5
+	}
+	minHops := int(req.MinHops)
+	if minHops < 0 {
+		minHops = 0
+	}
+
+	// Fetch the transport graph. Only TPD is wired here — DHT-source
+	// support can land separately if the offline-DHT path is needed
+	// from the gRPC side. The CLI's local-fallback path still has it
+	// for visor-less use.
+	entries, err := s.visor.FetchAllTransportEntries(stream.Context())
+	if err != nil {
+		return fmt.Errorf("fetch transports: %w", err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("no transport entries available")
+	}
+
+	memStore := newCalcMemStore(entries)
+	graph, err := routeFinder.NewGraphWithDepth(stream.Context(), memStore, srcPK, maxHops)
+	if err != nil {
+		return fmt.Errorf("build graph: %w", err)
+	}
+
+	sent := int32(0)
+	streamErr := graph.StreamRoutes(stream.Context(), srcPK, dstPK, minHops, maxHops, func(r routing.Route) bool {
+		out := &CalcRoute{Hops: make([]*CalcHop, 0, len(r.Hops))}
+		for _, h := range r.Hops {
+			out.Hops = append(out.Hops, &CalcHop{
+				TpId: h.TpID.String(),
+				From: h.From.String(),
+				To:   h.To.String(),
+			})
+		}
+		if err := stream.Send(out); err != nil {
+			s.log.WithError(err).Debug("StreamCalcRoutes: send failed; aborting search")
+			return false
+		}
+		sent++
+		if req.Count > 0 && sent >= req.Count {
+			return false
+		}
+		return true
+	})
+	// ErrRouteNotFound is informational: the search ran clean to
+	// completion without finding any matching path. Translate it to
+	// nil here when at least one route was sent (hop-length retries
+	// can hit ErrRouteNotFound after emitting valid paths).
+	if streamErr != nil && (sent == 0 || streamErr != routeFinder.ErrRouteNotFound) {
+		return streamErr
+	}
+	return nil
+}
+
+// calcMemStore is a tiny in-process store.Store impl for the route-finder
+// package. It only needs to answer GetTransportsByEdge during graph
+// construction — every other method is a stub.
+type calcMemStore struct {
+	byEdge map[cipher.PubKey][]*transport.Entry
+}
+
+func newCalcMemStore(entries []*transport.Entry) *calcMemStore {
+	byEdge := make(map[cipher.PubKey][]*transport.Entry)
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		byEdge[e.Edges[0]] = append(byEdge[e.Edges[0]], e)
+		if e.Edges[0] != e.Edges[1] {
+			byEdge[e.Edges[1]] = append(byEdge[e.Edges[1]], e)
+		}
+	}
+	return &calcMemStore{byEdge: byEdge}
+}
+
+func (s *calcMemStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	if tps, ok := s.byEdge[pk]; ok {
+		return tps, nil
+	}
+	return nil, tpdstore.ErrTransportNotFound
+}
+
+// Unused store.Store stubs.
+func (s *calcMemStore) RegisterTransport(context.Context, *transport.SignedEntry) error {
+	return nil
+}
+func (s *calcMemStore) RegisterTransportsBatch(context.Context, []*transport.SignedEntry) error {
+	return nil
+}
+func (s *calcMemStore) DeregisterTransport(context.Context, uuid.UUID) error { return nil }
+func (s *calcMemStore) GetTransportByID(context.Context, uuid.UUID) (*transport.Entry, error) {
+	return nil, tpdstore.ErrTransportNotFound
+}
+func (s *calcMemStore) GetNumberOfTransports(context.Context) (map[tptypes.Type]int, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetAllTransports(context.Context, bool) ([]*transport.Entry, error) {
+	return nil, nil
+}
+func (s *calcMemStore) UpdateBandwidth(context.Context, string, cipher.PubKey, uint64, uint64) error {
+	return nil
+}
+func (s *calcMemStore) UpdateLatency(context.Context, string, float64, float64, float64) error {
+	return nil
+}
+func (s *calcMemStore) GetTransportBandwidth(context.Context, uuid.UUID, string, int) ([]tpdstore.BandwidthAggregation, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetVisorBandwidth(context.Context, cipher.PubKey, string, int) ([]tpdstore.BandwidthAggregation, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetAllVisorSummaries(context.Context, bool, bool) ([]tpdstore.VisorSummary, error) {
+	return nil, nil
+}
+func (s *calcMemStore) RecordHeartbeat(context.Context, cipher.PubKey, string) error { return nil }
+func (s *calcMemStore) GetDailyTimeline(context.Context, string, time.Time) map[string]string {
+	return nil
+}
+func (s *calcMemStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string) error {
+	return nil
+}
+func (s *calcMemStore) GetTransportUptimeSummaries(context.Context, []uuid.UUID, bool, bool) ([]tpdstore.TransportUptimeSummary, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetTransportUptimeByVisor(context.Context, cipher.PubKey, bool, bool) ([]tpdstore.TransportUptimeSummary, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetTransportDailyTimeline(context.Context, string, time.Time) map[string]string {
+	return nil
+}
+func (s *calcMemStore) BackupAndCleanOldBandwidth(context.Context, string) error { return nil }
+func (s *calcMemStore) GetNetworkMetrics(context.Context, tpdstore.MetricsQuery) (*tpdstore.NetworkMetricResponse, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetVisorAggregateMetrics(context.Context, []cipher.PubKey, tpdstore.MetricsQuery) (map[string]*tpdstore.VisorMetricResponse, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetAllTransportMetrics(context.Context, tpdstore.MetricsQuery) ([]tpdstore.TransportMetric, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetTransportMetricsByIDs(context.Context, []uuid.UUID, tpdstore.MetricsQuery) ([]tpdstore.TransportMetric, error) {
+	return nil, nil
+}
+func (s *calcMemStore) GetTransportMetricsByVisors(context.Context, []cipher.PubKey, tpdstore.MetricsQuery) ([]tpdstore.TransportMetric, error) {
+	return nil, nil
+}
+func (s *calcMemStore) Close() {}
 
 // StreamRemoteSystemStats proxies system stats from a remote visor via DMSG.
 // The local visor dials the remote visor over DMSG and forwards the stats stream.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/orandin/lumberjackrus"
 	"github.com/sirupsen/logrus"
 	"github.com/toqueteos/webbrowser"
@@ -719,6 +720,57 @@ func (v *Visor) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.En
 // tpDiscClient is a convenience function to obtain transport discovery client.
 func (v *Visor) tpDiscClient() transport.DiscoveryClient {
 	return v.tpM.Conf.DiscoveryClient
+}
+
+// LocalPK returns this visor's public key. Used by gRPC handlers that need
+// to default the source PK on calc-route style requests.
+func (v *Visor) LocalPK() cipher.PubKey {
+	return v.conf.PK
+}
+
+// FetchAllTransportEntries pulls every transport from the configured TPD
+// client AND merges in the local transport manager's view. The TPD bulk
+// endpoint can lag behind reality (its cache is async-refreshed), so a
+// transport this visor has actively negotiated may not be present yet.
+// The local transport manager is authoritative for "what this visor can
+// actually dial right now"; merging avoids missed 1-hop routes in calc
+// responses while the BFS depth limit + streaming output bound memory.
+//
+// Dedup is by transport ID — TPD's view is preferred when it has a
+// matching entry (it carries label/QoS metadata the local view lacks).
+func (v *Visor) FetchAllTransportEntries(ctx context.Context) ([]*transport.Entry, error) {
+	tpD := v.tpDiscClient()
+	if tpD == nil {
+		return nil, errors.New("transport discovery client not available")
+	}
+	entries, err := tpD.GetAllTransports(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.tpM == nil {
+		return entries, nil
+	}
+
+	seen := make(map[uuid.UUID]struct{}, len(entries))
+	for _, e := range entries {
+		if e != nil {
+			seen[e.ID] = struct{}{}
+		}
+	}
+	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if tp == nil {
+			return true
+		}
+		if _, dup := seen[tp.Entry.ID]; dup {
+			return true
+		}
+		seen[tp.Entry.ID] = struct{}{}
+		entry := tp.Entry
+		entries = append(entries, &entry)
+		return true
+	})
+	return entries, nil
 }
 
 //go:embed static

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -82,6 +82,7 @@ type Visor struct {
 	conf     *visorconfig.V1
 	log      *logging.Logger
 	logstore logstore.Store
+	logBcast *logging.Broadcaster // fans entries out to gRPC StreamAppLogs subscribers
 
 	startedAt       time.Time
 	startupComplete chan struct{}
@@ -342,6 +343,13 @@ func run(conf *visorconfig.V1) error {
 	store, hook := logstore.MakeStore(runtimeLogMaxEntries)
 	mLog.AddHook(hook)
 
+	// logBroadcaster fans out logrus entries to gRPC StreamAppLogs
+	// subscribers. Attached to both the package-default mLog and the
+	// config's MasterLogger so PackageLogger entries from anywhere in
+	// the visor end up visible.
+	logBroadcaster := logging.NewBroadcaster()
+	mLog.AddHook(logBroadcaster)
+
 	stopPProf := initPProf(mLog, pprofMode, pprofAddr)
 	defer stopPProf()
 
@@ -350,6 +358,7 @@ func run(conf *visorconfig.V1) error {
 	}
 
 	conf.MasterLogger().AddHook(hook)
+	conf.MasterLogger().AddHook(logBroadcaster)
 
 	if disableHypervisorPKs {
 		conf.Hypervisors = []cipher.PubKey{}
@@ -402,6 +411,7 @@ func run(conf *visorconfig.V1) error {
 		cancel()
 	}
 	vis.SetLogstore(store)
+	vis.SetLogBroadcaster(logBroadcaster)
 	//	vis.uiAssets = uiAssets
 	if launchBrowser {
 		if conf.Hypervisor == nil {
@@ -686,6 +696,24 @@ func (v *Visor) isDTMReady() bool {
 // SetLogstore sets visor runtime logstore
 func (v *Visor) SetLogstore(store logstore.Store) {
 	v.logstore = store
+}
+
+// SetLogBroadcaster wires the visor with the master logger's
+// Broadcaster hook. Stored on the Visor so the gRPC adapter can
+// forward Subscribe calls through to it.
+func (v *Visor) SetLogBroadcaster(b *logging.Broadcaster) {
+	v.logBcast = b
+}
+
+// SubscribeLogs subscribes to log entries matching the filter.
+// Wraps the broadcaster so callers don't need a direct handle.
+// Returns nil channel + nil cancel when the broadcaster is not
+// installed (e.g. tests).
+func (v *Visor) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.Entry, func() uint64) {
+	if v.logBcast == nil {
+		return nil, func() uint64 { return 0 }
+	}
+	return v.logBcast.Subscribe(f, capacity)
 }
 
 // tpDiscClient is a convenience function to obtain transport discovery client.


### PR DESCRIPTION
## Summary

End-to-end plumbing of transport latency from the visor through TPD to the CLI, plus a small UX change to `proxy start --mux`.

Visors already measured inter-visor RTT internally (transport-level ping/pong, RSN fallback) and wrote it into `liveSnapshot.latency_avg_ms` on their CXO TreeStore feeds. Every layer above that knew about it on paper:

- `pkg/visor/rpc.TransportSummary` had no latency field — `tp ls` couldn't show it.
- `pkg/transport-discovery/cxoaggregator` parsed the snapshot's latency fields and threw them away.
- `pkg/transport-discovery/store/redis_metrics.go` already read `data.LatencyMin/Max/Avg` from `TransportData` and emitted `*TransportLatency` in `/metrics` responses — but nothing wrote those fields, so they were always 0.

This PR closes the gap.

### `cli: 'proxy start --mux 0' now means unlimited`
Previously `--mux 0` was a no-op. Adopting the more useful semantic: `--mux 0` = every distinct first-hop path `establishMuxRoutes` can find (`fetchBestRoutes` returns `ErrRouteNotFound` on exhaustion so the loop terminates naturally). `--mux 1` (new default) = single route. `--mux N` unchanged.

### `visor: expose per-transport latency in TransportSummary + 'tp ls'`
Add `LatencyMS` to `TransportSummary`, populated from `tp.GetLatency()`. Add a `latency` column to all four header/print modes of `tp ls`. Format `<n>ms` or `-` when no measurement yet (transient case for newly-formed transports / peers without ping/pong+RSN).

### `tpd: persist and surface per-transport latency end-to-end`
- `store.TransportStore` gains `UpdateLatency(transportID, min, max, avg_ms)`.
- Redis impl reads the `TransportData` JSON, overwrites `lat_min/lat_max/lat_avg` (ms→μs to match existing field unit), refreshes `last_update`, and `SET`s back with the registration TTL preserved. Snapshots for unknown transport-ids are quiet no-ops.
- Last-writer-wins across the two edges is intentional: latency is RTT, both edges should converge, and a strict per-reporter min/max would just track which edge had the noisier window. Keeps the path lock-free.
- `cxoaggregator.BandwidthSink` → `Sink` (alias retained for embedders). `dispatchLeaf` calls `UpdateLatency` when `LatencyAvgMS > 0`.
- `tp metrics` per-visor view (the default) gains an `avg_latency` column averaged across the visor's transports. `--by-transport` and `--tree` already showed latency once data was there.

### `chore: clear pre-existing develop-branch lint failures`
Unrelated lint drift on `develop` blocked CI before this PR could go green: `info.go` gofmt + `arSelfState.clear()/snapshot()` `//nolint:unused` annotations.

## Test plan

- [ ] `go build ./...` and `make lint` clean — done locally.
- [ ] On a deployed TPD: visors on this build start populating `lat_min/lat_max/lat_avg` in `TransportData`.
- [ ] `curl tpd.example/metrics` returns `Latency` populated for active transports.
- [ ] `skywire cli tp metrics --by-transport` / `--tree` show non-zero latency.
- [ ] `skywire cli tp ls` shows the new `latency` column locally for established transports (verify after transport-ping grace).
- [ ] `skywire cli proxy start --mux 0 …` opens routes through every distinct first-hop the network exposes.