### PR TITLE
dmsg_servers: refresh embedded list, live confbs response, visor-side disk cache

### DIFF
--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -41,15 +41,39 @@
     ],
     "dmsg_servers": [
       {
+        "static": "0281a102c82820e811368c8d028cf11b1a985043b726b1bcdb8fce89b27384b2cb",
+        "server": {
+          "address": "139.162.160.227:30086"
+        }
+      },
+      {
+        "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
+        "server": {
+          "address": "45.79.213.251:30087"
+        }
+      },
+      {
         "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
         "server": {
-          "address": "45.79.213.251:30080"
+          "address": "143.42.59.213:30081"
         }
       },
       {
         "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
         "server": {
           "address": "70.121.13.123:9082"
+        }
+      },
+      {
+        "static": "02a2d4c346dabd165fd555dfdba4a7f4d18786fe7e055e562397cd5102bdd7f8dd",
+        "server": {
+          "address": "139.162.173.101:30082"
+        }
+      },
+      {
+        "static": "03717576ada5b1744e395c66c2bb11cea73b0e23d0dcd54422139b1a7f12e962c4",
+        "server": {
+          "address": "139.162.173.101:30083"
         }
       }
     ],
@@ -112,19 +136,19 @@
       {
         "static": "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13",
         "server": {
-          "address": "139.162.160.227:30087"
+          "address": "45.79.213.251:30087"
         }
       },
       {
         "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
         "server": {
-          "address": "139.162.160.227:30081"
+          "address": "143.42.59.213:30081"
         }
       },
       {
         "static": "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7",
         "server": {
-          "address": "70.121.13.123:9083"
+          "address": "70.121.13.123:9082"
         }
       },
       {

--- a/pkg/config-bootstrapper/api/api.go
+++ b/pkg/config-bootstrapper/api/api.go
@@ -30,6 +30,11 @@ type API struct {
 	startedAt time.Time
 
 	services *deployment.Services
+	// servicesMu guards services.DmsgServers, which is refreshed in the
+	// background from dmsg-discovery so the served bootstrap list reflects
+	// the actual current addresses of each known dmsg-server PK rather
+	// than the addresses baked into services-config.json at build time.
+	servicesMu sync.RWMutex
 
 	dmsghttpConf   httputil.DMSGHTTPConf
 	dmsghttpConfTs time.Time
@@ -39,6 +44,10 @@ type API struct {
 
 	dmsgAddr string
 }
+
+// dmsgServersRefreshInterval is how often the bootstrap dmsg_servers list is
+// refreshed from dmsg-discovery. 5m matches the dmsghttp endpoint cache.
+const dmsgServersRefreshInterval = 5 * time.Minute
 
 // HealthCheckResponse is struct of /health endpoint
 type HealthCheckResponse struct {
@@ -113,6 +122,8 @@ func New(log *logging.Logger, conf Config, domain, dmsgAddr string) *API {
 
 	api.Handler = r
 
+	go api.refreshDmsgServersLoop()
+
 	return api
 }
 
@@ -121,6 +132,53 @@ func (a *API) Close() {
 	a.closeOnce.Do(func() {
 		close(a.closeC)
 	})
+}
+
+// refreshDmsgServersLoop refreshes services.DmsgServers from dmsg-discovery
+// at startup and then on a fixed interval. If dmsgd is unreachable or returns
+// no entries, the previous in-memory list is kept (which on first attempt is
+// the embedded list from services-config.json). This means the served
+// bootstrap list converges on the live state without ever falling back to a
+// stale-at-build-time response.
+func (a *API) refreshDmsgServersLoop() {
+	a.refreshDmsgServers()
+	t := time.NewTicker(dmsgServersRefreshInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-a.closeC:
+			return
+		case <-t.C:
+			a.refreshDmsgServers()
+		}
+	}
+}
+
+func (a *API) refreshDmsgServers() {
+	a.servicesMu.RLock()
+	dmsgdURL := a.services.DmsgDiscovery
+	a.servicesMu.RUnlock()
+	if dmsgdURL == "" {
+		return
+	}
+	live := fetchDMSGServers(dmsgdURL)
+	if len(live) == 0 {
+		// Either dmsgd unreachable or no servers registered — keep the
+		// previous list (embedded on first call, last-known-good after).
+		a.log.Debug("dmsg_servers refresh returned 0 entries; keeping previous list")
+		return
+	}
+	entries := make([]deployment.DmsgServerEntry, 0, len(live))
+	for _, s := range live {
+		var e deployment.DmsgServerEntry
+		e.Static = s.Static
+		e.Server.Address = s.Server.Address
+		entries = append(entries, e)
+	}
+	a.servicesMu.Lock()
+	a.services.DmsgServers = entries
+	a.servicesMu.Unlock()
+	a.log.WithField("count", len(entries)).Debug("dmsg_servers refreshed from dmsg-discovery")
 }
 
 func (a *API) logger(r *http.Request) logrus.FieldLogger {
@@ -138,7 +196,12 @@ func (a *API) health(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) config(w http.ResponseWriter, r *http.Request) {
-	a.writeJSON(w, r, http.StatusOK, a.services)
+	a.servicesMu.RLock()
+	// Snapshot under the lock so the JSON encoder doesn't see a torn
+	// state if refreshDmsgServers swaps the slice mid-encode.
+	resp := *a.services
+	a.servicesMu.RUnlock()
+	a.writeJSON(w, r, http.StatusOK, &resp)
 }
 
 func (a *API) writeJSON(w http.ResponseWriter, r *http.Request, code int, object interface{}) {

--- a/pkg/visor/dmsg_servers_cache.go
+++ b/pkg/visor/dmsg_servers_cache.go
@@ -1,0 +1,164 @@
+// Package visor pkg/visor/dmsg_servers_cache.go
+//
+// DmsgServersCache persists dmsg-server discovery entries (the
+// "static" PK plus the live `server.address` and metadata) to a JSON
+// file in the visor's local_path. Its purpose is to remember the
+// addresses learned from dmsg-discovery across visor restarts so the
+// bootstrap direct client doesn't have to start from the addresses
+// frozen into skywire.json (which can be months stale).
+//
+// Read order at startup:
+//
+//	1. cache file  (`<local_path>/dmsg_servers.json`)
+//	2. main config (`v.conf.Dmsg.Servers` — typically /opt/skywire/skywire.json)
+//
+// The two are merged: for any PK present in the cache, the cached
+// entry wins; PKs only in the config are kept; PKs only in the cache
+// are also included. This way a server that has rotated its address
+// is reached via the new address without losing PKs the cache hasn't
+// seen yet.
+//
+// Write trigger: a background loop in initDmsg refreshes the cache
+// from dmsg-discovery once dmsgC is connected, then on a fixed
+// interval. If dmsgd is unreachable, the previous cache contents are
+// kept (no destructive write on transient errors).
+package visor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// DmsgServersCache is a thread-safe map of dmsg-server PK → entry,
+// optionally backed by a JSON file on disk.
+type DmsgServersCache struct {
+	mu       sync.RWMutex
+	entries  map[cipher.PubKey]*dmsgdisc.Entry
+	filePath string // empty means in-memory only
+}
+
+// NewDmsgServersCache creates a cache backed by the given file. If
+// filePath is empty the cache is in-memory only. If the file exists it
+// is loaded immediately; a missing file is not an error (first run).
+func NewDmsgServersCache(filePath string) *DmsgServersCache {
+	c := &DmsgServersCache{
+		entries:  make(map[cipher.PubKey]*dmsgdisc.Entry),
+		filePath: filePath,
+	}
+	if filePath != "" {
+		_ = c.load() // missing file or unreadable cache -> start empty
+	}
+	return c
+}
+
+// Set replaces the entry for one PK and saves to disk.
+func (c *DmsgServersCache) Set(e *dmsgdisc.Entry) error {
+	if e == nil || e.Server == nil || e.Server.Address == "" {
+		return fmt.Errorf("dmsg-servers cache: invalid entry")
+	}
+	c.mu.Lock()
+	c.entries[e.Static] = e
+	c.mu.Unlock()
+	return c.save()
+}
+
+// Replace swaps the entire map for the given list and saves. Entries
+// without a Server.Address are dropped. Use this when a refresh
+// returned a complete fresh list — PKs no longer present in dmsgd
+// are pruned. An empty input list is treated as a no-op (callers
+// should check for and skip empty refreshes themselves to avoid
+// destroying the cache during a dmsgd outage).
+func (c *DmsgServersCache) Replace(es []*dmsgdisc.Entry) error {
+	if len(es) == 0 {
+		return nil
+	}
+	fresh := make(map[cipher.PubKey]*dmsgdisc.Entry, len(es))
+	for _, e := range es {
+		if e == nil || e.Server == nil || e.Server.Address == "" {
+			continue
+		}
+		fresh[e.Static] = e
+	}
+	if len(fresh) == 0 {
+		return nil
+	}
+	c.mu.Lock()
+	c.entries = fresh
+	c.mu.Unlock()
+	return c.save()
+}
+
+// All returns a copy of the cached entries as a slice.
+func (c *DmsgServersCache) All() []*dmsgdisc.Entry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]*dmsgdisc.Entry, 0, len(c.entries))
+	for _, e := range c.entries {
+		out = append(out, e)
+	}
+	return out
+}
+
+// MergePreferringCache returns a list of dmsg-server entries built by
+// preferring the cached entry for any PK present in the cache, and
+// using the corresponding entry from `configured` for PKs only in the
+// configured list. PKs in the cache but not configured are appended.
+//
+// Used by the bootstrap path so that on restart the visor connects
+// using the address it last learned from dmsg-discovery, not whatever
+// address was in skywire.json when it was generated.
+func (c *DmsgServersCache) MergePreferringCache(configured []*dmsgdisc.Entry) []*dmsgdisc.Entry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]*dmsgdisc.Entry, 0, len(configured)+len(c.entries))
+	seen := make(map[cipher.PubKey]bool, len(configured))
+	for _, e := range configured {
+		if e == nil {
+			continue
+		}
+		if cached, ok := c.entries[e.Static]; ok {
+			out = append(out, cached)
+		} else {
+			out = append(out, e)
+		}
+		seen[e.Static] = true
+	}
+	for pk, e := range c.entries {
+		if !seen[pk] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (c *DmsgServersCache) save() error {
+	if c.filePath == "" {
+		return nil
+	}
+	c.mu.RLock()
+	data, err := json.MarshalIndent(c.entries, "", "  ")
+	c.mu.RUnlock()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(c.filePath), 0o750); err != nil { //nolint:gosec
+		return err
+	}
+	return os.WriteFile(c.filePath, data, 0o600)
+}
+
+func (c *DmsgServersCache) load() error {
+	data, err := os.ReadFile(c.filePath) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return json.Unmarshal(data, &c.entries)
+}

--- a/pkg/visor/dmsg_servers_cache.go
+++ b/pkg/visor/dmsg_servers_cache.go
@@ -9,8 +9,8 @@
 //
 // Read order at startup:
 //
-//	1. cache file  (`<local_path>/dmsg_servers.json`)
-//	2. main config (`v.conf.Dmsg.Servers` — typically /opt/skywire/skywire.json)
+//  1. cache file  (`<local_path>/dmsg_servers.json`)
+//  2. main config (`v.conf.Dmsg.Servers` — typically /opt/skywire/skywire.json)
 //
 // The two are merged: for any PK present in the cache, the cached
 // entry wins; PKs only in the config are kept; PKs only in the cache
@@ -52,7 +52,7 @@ func NewDmsgServersCache(filePath string) *DmsgServersCache {
 		filePath: filePath,
 	}
 	if filePath != "" {
-		_ = c.load() // missing file or unreadable cache -> start empty
+		_ = c.load() //nolint:errcheck,gosec // missing file or unreadable cache -> start empty
 	}
 	return c
 }

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -39,7 +39,16 @@ import (
 
 func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	var keys cipher.PubKeys
-	servers := shuffleServers(v.conf.Dmsg.Servers)
+	// Prefer entries the visor has previously learned from dmsg-discovery
+	// (cached on disk in <local_path>/dmsg_servers.json) over the addresses
+	// in skywire.json — those can be months stale if a server has rotated
+	// IP since the config was generated. The cache is written by the
+	// background refresh loop in initDmsg.
+	configured := v.conf.Dmsg.Servers
+	if v.dmsgServersCache != nil {
+		configured = v.dmsgServersCache.MergePreferringCache(configured)
+	}
+	servers := shuffleServers(configured)
 
 	if len(servers) == 0 {
 		return nil
@@ -189,7 +198,55 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// Start periodic config refresh for dynamic key sets
 	go v.startConfigRefresh(ctx) //nolint:errcheck,gosec
 
+	// Refresh the on-disk dmsg-servers cache from dmsg-discovery so the
+	// next bootstrap uses the live addresses, not whatever's in
+	// skywire.json. Uses a separate disc.HTTP client (the dmsg.Client
+	// doesn't expose its inner discovery client).
+	if v.dmsgServersCache != nil && discURL != "" {
+		go v.refreshDmsgServersCacheLoop(ctx, discURL, httpC)
+	}
+
 	return nil
+}
+
+// dmsgServersCacheRefreshInterval is how often the cache is refreshed
+// from dmsg-discovery once dmsgC is up. 5m is short enough that the
+// cache converges on the live state within a few minutes of a server
+// rotating its address, long enough that the refresh isn't a load
+// concern on dmsgd.
+const dmsgServersCacheRefreshInterval = 5 * time.Minute
+
+// refreshDmsgServersCacheLoop runs until ctx is canceled, refreshing
+// v.dmsgServersCache from dmsg-discovery's all_servers endpoint at a
+// fixed interval. Empty refreshes (dmsgd unreachable, no entries) are
+// skipped — DmsgServersCache.Replace treats empty input as a no-op so
+// a transient outage doesn't wipe the cache.
+func (v *Visor) refreshDmsgServersCacheLoop(ctx context.Context, discURL string, httpC *http.Client) {
+	cacheLog := v.MasterLogger().PackageLogger("dmsg_servers_cache")
+	dc := dmsgdisc.NewHTTP(discURL, httpC, cacheLog)
+	refresh := func() {
+		entries, err := dc.AllServers(ctx)
+		if err != nil {
+			cacheLog.WithError(err).Debug("Skipping cache refresh (dmsgd error)")
+			return
+		}
+		if err := v.dmsgServersCache.Replace(entries); err != nil {
+			cacheLog.WithError(err).Warn("Failed to write dmsg-servers cache file")
+			return
+		}
+		cacheLog.WithField("count", len(entries)).Debug("dmsg-servers cache refreshed")
+	}
+	refresh()
+	t := time.NewTicker(dmsgServersCacheRefreshInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			refresh()
+		}
+	}
 }
 
 // dmsgServicePKs extracts public keys from dmsg:// URLs in the visor config.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -134,6 +134,11 @@ type Visor struct {
 	// Rich port forwarding with metadata, whitelist, landing page integration
 	forwardedPorts *ForwardedPorts
 
+	// Persisted dmsg-server discovery entries — survives restarts so the
+	// bootstrap direct client uses the addresses last learned from
+	// dmsg-discovery, not the (potentially stale) addresses in skywire.json.
+	dmsgServersCache *DmsgServersCache
+
 	// DMSG listeners for forwarded ports (dmsg=true). Each entry is a
 	// cancel function that stops the listener goroutine.
 	dmsgFwdMu        sync.Mutex
@@ -442,6 +447,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 			mu:    new(sync.RWMutex),
 		},
 		forwardedPorts:   NewForwardedPorts(filepath.Join(conf.LocalPath, "forwarded_ports.json")),
+		dmsgServersCache: NewDmsgServersCache(filepath.Join(conf.LocalPath, "dmsg_servers.json")),
 		dmsgFwdListeners: make(map[int]context.CancelFunc),
 		dmsgTracker: dtmState{
 			ready: make(chan struct{}),


### PR DESCRIPTION
## Summary

Three changes that fix the stale-dmsg-server-addresses problem at every layer it shows up.

### Why

When a dmsg server rotates IP, **every** snapshot of its address goes stale at once: `services-config.json` baked into the binary, the response from `conf.skywire.skycoin.com`, and any visor's `skywire.json` that was generated before the rotation. Restarting any of those — visor, tpd, sd, etc. — loses the live address until the binary's bootstrap loop happens to reach a non-rotated server in the static list.

This came to a head when we moved dmsg-server-7 from prod's IP to the test box's IP last night: every restart of the deployment services on prod logged `connection refused` warnings dialing the old `139.162.160.227:30087` for several seconds before recovering via other servers in the embedded list.

### What

**1. `deployment: refresh embedded dmsg_servers; identical list in test and prod`**

Three addresses in the embedded list were stale, including `0371ab4b...` which we just moved last night. The `test` block had only 2 entries, both stale — replaced with the same list as `prod` since the two deployments share dmsgd PKs.

| PK | Was | Now |
|---|---|---|
| `0371ab4b…` | `139.162.160.227:30087` | `45.79.213.251:30087` |
| `02a49bc0…` | `139.162.160.227:30081` | `143.42.59.213:30081` |
| `0326978f…` (prod block) | `:9083` | `:9082` (long-standing typo) |

Bootstrap only — once a visor reaches any reachable server in the list it learns the live addresses for everyone else from dmsgd. But on cold start with all-stale entries, bootstrap is slow.

**2. `config-bootstrapper: refresh dmsg_servers from dmsg-discovery in background`**

Adds a background loop in `pkg/config-bootstrapper/api/api.go` that calls `dmsg-discovery /dmsg-discovery/all_servers` every 5m (mirroring the existing `dmsghttp` endpoint cache interval) and swaps the in-memory `services.DmsgServers` slice. The `/config` handler snapshots under a read lock so the JSON encoder cannot observe a torn state. Empty refreshes are ignored — a transient dmsgd outage doesn't regress the served list to an empty slice.

Net effect: a freshly-installed visor that bootstraps via `conf.skywire.skycoin.com` always gets the *current* dmsg_servers list, not whatever was baked into the confbs binary at build time.

**3. `visor: persist learned dmsg-server addresses to <local_path>/dmsg_servers.json`**

The fix per @0pcom's design: visor writes the entries it learns from dmsg-discovery to `<local_path>/dmsg_servers.json`, and at startup uses cache → fall back to `skywire.json`'s `dmsg.servers`. Modeled on `ForwardedPorts` (`pkg/visor/forwarded_ports.go`).

| Component | New |
|---|---|
| `pkg/visor/dmsg_servers_cache.go` | `DmsgServersCache` type (in-memory map keyed by PK + JSON file backing, mutex-protected; `Set` / `Replace` / `MergePreferringCache` / `All`) |
| `pkg/visor/visor.go` | New `dmsgServersCache *DmsgServersCache` field on `Visor`, constructed in `NewVisor` at `<local_path>/dmsg_servers.json` |
| `pkg/visor/init_dmsg.go` `initDmsgHTTP` | Before building bootstrap direct-client entries, merge cache over `v.conf.Dmsg.Servers` (cache wins per PK) |
| `pkg/visor/init_dmsg.go` `initDmsg` | After `dmsgC.Ready()`, kick off `refreshDmsgServersCacheLoop` — calls `dmsg-discovery /all_servers` every 5m via a fresh `disc.NewHTTP` client, calls `cache.Replace(entries)` |

A `disc.NewHTTP` is built fresh in the refresh loop because `dmsg.Client` doesn't expose its internal discovery client (the `dc` field on `EntityCommon` is unexported and there's no accessor). Same `httpC` and `discURL` that `initDmsg` already built.

The embedded deployment config is **not** read at visor runtime — config-gen only. Per @0pcom's clarification the visor's source of truth is its config file, and the cache should layer on top of that, not below it.

### What this PR does *not* do

- **Service-side cache (deployment containers).** Same problem exists for tpd / ar / rf / etc. on restart, but applying the same pattern needs more design: services typically run in Docker with ephemeral filesystem, so the cache needs a flagged state-dir + persistent volume in compose, or factoring the cache into `pkg/svcmode/`. Worth a follow-up after this lands.
- **Removing the dual-write** to HTTP transport-discovery from the visor. The cxoaggregator on tpd still has to be enabled (`--cxo` flag) per-deployment, and no PR has wired up a visor-side flag to disable HTTP writes. Out of scope.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean on every affected package: `pkg/visor/...`, `pkg/config-bootstrapper/...`, `deployment/...`
- [ ] **After deploy**: confirm `<local_path>/dmsg_servers.json` appears on the host visor within ~5m of startup and contains live addresses for the 6 known PKs
- [ ] **After deploy**: confirm `curl conf.skywire.skycoin.com | jq .dmsg_servers` reflects the same live addresses (within 5m of confbs start)
- [ ] **After deploy + a restart**: visor should not log `connect: connection refused` for `dmsg-server` entries with addresses that have since rotated