### PR TITLE
docker: propagate build failures; use proxy.golang.org for go install

### DIFF
--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Fail loudly: any non-zero exit (docker build, missing args, broken
+# pipe in a sub-pipeline) propagates to the caller. Without this,
+# `make docker-push-test` reports success after a failed build and
+# the workflow declares deploy "successful" while no image was pushed.
+set -eo pipefail
 trap "exit" INT
 
 ## Variables

--- a/docker/docker_push.sh
+++ b/docker/docker_push.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Fail loudly so a missing local image (e.g., docker_build.sh failed
+# upstream) doesn't get masked as a successful push.
+set -eo pipefail
 
 tag="$1"
 
@@ -24,6 +27,10 @@ echo "Pushing to $registry using tag: $tag"
 commit_sha="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
 
 for c in "${images_arr[@]}"; do
+  if ! docker image inspect "$registry"/"$c":"$tag" >/dev/null 2>&1; then
+    echo "No local image $registry/$c:$tag — upstream build likely failed; aborting push." >&2
+    exit 1
+  fi
   docker push "$registry"/"$c":"$tag"
   if [ -n "$commit_sha" ]; then
     docker tag "$registry"/"$c":"$tag" "$registry"/"$c":"$commit_sha"

--- a/docker/images/skywire/Dockerfile
+++ b/docker/images/skywire/Dockerfile
@@ -15,13 +15,18 @@ ENV CGO_ENABLED=${CGO_ENABLED} \
 
 COPY . /src
 
+# Use proxy.golang.org first, fall back to `direct` for any module
+# the proxy doesn't have (e.g. a brand-new commit not yet mirrored).
+# Pure `GOPROXY=direct` makes every module — including stable upstream
+# deps like `gopkg.in/yaml.v3` — depend on `gopkg.in`'s redirect server,
+# which has flaked the build (`gopkg.in i/o timeout`) before.
 RUN apk add --no-cache git && \
     if [ -n "$commit" ]; then \
         if [ "$image_tag" = "integration" ]; then \
             apk add --no-cache build-base && \
-            CGO_ENABLED=1 GOPROXY=direct go install -ldflags="-w -s" -race github.com/skycoin/skywire@${commit}; \
+            CGO_ENABLED=1 GOPROXY=https://proxy.golang.org,direct go install -ldflags="-w -s" -race github.com/skycoin/skywire@${commit}; \
         else \
-            GOPROXY=direct go install -ldflags="-w -s" github.com/skycoin/skywire@${commit}; \
+            GOPROXY=https://proxy.golang.org,direct go install -ldflags="-w -s" github.com/skycoin/skywire@${commit}; \
         fi; \
     else \
         cd /src && \


### PR DESCRIPTION
## Summary

The 2026-05-01 push of develop@4febea6e to Docker Hub `:test` was silently skipped — three "Deploy" workflow runs reported success, but the actual image tag on the registry never moved off the Apr-30 manifest. Diagnosed: the docker scripts were swallowing build failures, and the underlying build was failing because of a transient `gopkg.in` outage exposed by `GOPROXY=direct`.

## Why this happened

1. **`docker/docker_build.sh`** had no `set -e`. A non-zero `docker build` exit was lost; the Makefile recipe ran `docker_push.sh` next as if everything were fine.

2. **`docker/docker_push.sh`** had no `set -e` either. `docker push` against a missing local tag prints `An image does not exist locally with the tag: skycoin/skywire` and exits non-zero per push attempt — the loop kept going and the script exited 0.

3. The Dockerfile pinned `GOPROXY=direct` for the `go install github.com/skycoin/skywire@${commit}` path. With `direct`, every transitive `gopkg.in/*` import resolves via Canonical's redirect server (`gopkg.in` → `185.125.188.x`). On 2026-05-01 that server timed out for four separate dependencies:

   ```
   unrecognized import path "gopkg.in/yaml.v3":             dial tcp 185.125.188.236:443: i/o timeout
   unrecognized import path "gopkg.in/natefinch/lumberjack.v2": ... 185.125.188.236:443: i/o timeout
   unrecognized import path "gopkg.in/telebot.v3":          dial tcp 185.125.188.113:443: i/o timeout
   unrecognized import path "gopkg.in/yaml.v2":             dial tcp 185.125.188.128:443: i/o timeout
   ```

   None of those are skywire deps directly — they come from `stretchr/testify`, `orandin/lumberjackrus`, the rewards CLI, etc. — but `direct` mode forces every module lookup, no matter how stable, through `gopkg.in`.

## Changes

- **`docker/docker_build.sh`**: `set -eo pipefail` (kept `-u` off — script intentionally references possibly-unset `$REGISTRY`, `$DOCKER_USERNAME`, `$DOCKER_PASSWORD`).
- **`docker/docker_push.sh`**: `set -eo pipefail` + explicit early-bail (`docker image inspect ... || exit 1`) so the failure mode is one clean error instead of N misleading per-tag push attempts.
- **`docker/images/skywire/Dockerfile`**: `GOPROXY=https://proxy.golang.org,direct` for both the `integration` and the regular `go install ...@${commit}` paths. Proxy first means cached modules (including all the `gopkg.in/*` ones) come from Google's mirror; `direct` is the fallback for modules the proxy doesn't have yet — i.e. a brand-new `skycoin/skywire@<commit>` from the same commit's deploy run.

## Test plan

- [x] `bash -n docker/docker_build.sh` — syntax clean
- [x] `bash -n docker/docker_push.sh` — syntax clean
- [x] `docker buildx build --check -f docker/images/skywire/Dockerfile docker/` — passes (3 pre-existing `InvalidDefaultArgInFrom` warnings unchanged)
- [ ] **After merge**: the `Deploy` workflow run on the merge commit should both succeed AND actually update `skycoin/skywire:test`. Verify with `docker pull skycoin/skywire:test` from anywhere — image ID should be different from `c70577b8e6e2`.
- [ ] If the build fails (e.g. proxy.golang.org also has a bad day), the workflow should now go red so we notice immediately.