### PR TITLE
sd+visor: stop disabling public-visor registrations on transient failures

### DIFF
--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -271,11 +271,7 @@ Example:
 		}
 		defer h.Close()
 
-		// Expose the dmsg client to the API for visor reachability probes.
-		if h.DmsgClient != nil {
-			sdAPI.DmsgClient = h.DmsgClient
-			log.Info("DMSG client available for visor reachability probes")
-		}
+		// (Visor reachability probe gate removed — see api.go.)
 
 		// Wire DHT entry mirroring: every service registration is
 		// also published to the DHT under the visor's PK.

--- a/pkg/app/appdisc/discovery_manager.go
+++ b/pkg/app/appdisc/discovery_manager.go
@@ -54,13 +54,18 @@ func (u *serviceUpdater) Start() {
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is stored in u.cancel and called in Stop()
 	u.cancel = cancel
 
-	// Initial registration
+	// Best-effort initial registration. A failure here used to return
+	// early without starting the heartbeat loop, permanently disabling
+	// re-registration for the rest of the visor's lifetime — which
+	// turned a single transient SD failure (probe timeout, SD restart,
+	// dmsg flake) into "this visor never appears in service-discovery
+	// until it is restarted." Always start the heartbeat: it retries
+	// every ServiceDiscUpdateInterval (90s), which is exactly the
+	// recovery mechanism callers expect.
 	if err := u.client.Register(ctx); err != nil {
-		u.log.WithError(err).Error("Failed to register service")
-		return
+		u.log.WithError(err).Warn("Initial service discovery registration failed; will retry via heartbeat")
 	}
 
-	// Start heartbeat loop
 	u.wg.Add(1)
 	go u.heartbeatLoop(ctx)
 }

--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/geo"
 	"github.com/skycoin/skywire/pkg/httpauth"
 	"github.com/skycoin/skywire/pkg/httputil"
@@ -30,7 +29,6 @@ import (
 	sdmetrics "github.com/skycoin/skywire/pkg/service-discovery/metrics"
 	"github.com/skycoin/skywire/pkg/service-discovery/store"
 	"github.com/skycoin/skywire/pkg/servicedisc"
-	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
 var (
@@ -79,14 +77,6 @@ type API struct {
 	startedAt                   time.Time
 	dmsgAddr                    string
 	DmsgServers                 []string
-	DmsgClient                  *dmsg.Client // set after svcmode.Start; used for visor dmsg reachability probes
-
-	// probeCache caches recent successful dmsg probes so that multiple
-	// service registrations from the same visor within a short window
-	// don't each trigger a separate probe. Key: PK hex, Value: time of
-	// last successful probe.
-	probeCacheMu sync.Mutex
-	probeCache   map[string]time.Time
 
 	// uptimes caches are refreshed every uptimesCacheDelay.
 	uptimesCache   []store.VisorSummary
@@ -177,7 +167,6 @@ func New(log logrus.FieldLogger, db store.Store, nonceDB httpauth.NonceStore,
 		startedAt:                   time.Now(),
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
-		probeCache:                  make(map[string]time.Time),
 	}
 	return api
 }
@@ -429,47 +418,18 @@ func (a *API) postEntry(w http.ResponseWriter, r *http.Request) {
 			a.writeError(w, r, http.StatusForbidden, servicedisc.ErrVisorUnreachable.Error())
 			return
 		}
-
-		// Probe the visor on dmsg port 136 to confirm it's reachable
-		// for route setup. The noise handshake completing confirms the
-		// visor is alive and routable — the visor's router will close
-		// the stream immediately (SD PK is not a whitelisted setup
-		// node) but the handshake success is all we need.
-		//
-		// The SD's direct client doesn't have visor entries in its
-		// local discovery, so every probe falls back to
-		// dialViaConnectedServers which tries servers sequentially.
-		// Budget 15s: enough for 2-3 server attempts at 5s each.
-		// The SD connects to all 6 servers, so there is guaranteed
-		// to be a shared server with any visor on the network.
-		//
-		// Cache successful probes for 5 minutes so the 90s heartbeat
-		// doesn't re-probe every time. Failed probes are cached for
-		// 30s to allow quick retry.
-		if a.DmsgClient != nil {
-			pkHex := se.Addr.PubKey().Hex()
-			needsProbe := true
-
-			a.probeCacheMu.Lock()
-			if last, ok := a.probeCache[pkHex]; ok && time.Since(last) < 5*time.Minute {
-				needsProbe = false
-			}
-			a.probeCacheMu.Unlock()
-
-			if needsProbe {
-				probeCtx, probeCancel := context.WithTimeout(context.Background(), 15*time.Second)
-				reachable := a.DmsgClient.Probe(probeCtx, se.Addr.PubKey(), skyenv.DmsgAwaitSetupPort)
-				probeCancel()
-				if !reachable {
-					a.log.WithField("pk", se.Addr.PubKey()).Warn("Public visor registration rejected: not reachable on dmsg port 136")
-					a.writeError(w, r, http.StatusForbidden, "visor not reachable on dmsg for route setup")
-					return
-				}
-				a.probeCacheMu.Lock()
-				a.probeCache[pkHex] = time.Now()
-				a.probeCacheMu.Unlock()
-			}
-		}
+		// The previous dmsg-port-136 probe gate has been removed: it
+		// rejected registrations whenever the noise handshake didn't
+		// complete inside the 15s budget, which made every transient
+		// flake (SD's own dmsg sessions warming up after restart, a
+		// slow delegated server, a visor briefly between sessions)
+		// look like an unreachable visor. Combined with the visor's
+		// retrier whitelist on ErrVisorUnreachable, that turned a
+		// momentary probe failure into "this visor never appears in
+		// SD again until it restarts." The IP-public check above
+		// already enforces the WAN-reachability invariant SD cares
+		// about; route-setup failures are caught by the route
+		// finder, where they belong.
 	}
 
 	// Combined service update + heartbeat in a single Redis pipeline.


### PR DESCRIPTION
## Summary

`sd.skycoin.com/api/services?type=visor` returned `[]` despite multiple known-public visors being alive on the network with hundreds of transports. Two compounding bugs were turning a single transient SD failure into "this visor never appears in service-discovery for the rest of its lifetime."

## Bug 1 — visor side: Start() returns early on first Register failure

`pkg/app/appdisc/discovery_manager.go` `serviceUpdater.Start()`:

```go
if err := u.client.Register(ctx); err != nil {
    u.log.WithError(err).Error("Failed to register service")
    return                           // ← never starts the heartbeat
}
u.wg.Add(1)
go u.heartbeatLoop(ctx)
```

`HTTPClient.Register` whitelists `ErrVisorUnreachable` in its retrier — a single SD response of "unreachable" exits the retrier immediately. With the early `return` above, the heartbeat goroutine never starts, so the 90s heartbeat re-registration that callers expect never happens. The visor stays deregistered until restart.

**Fix:** always start the heartbeat loop. Each 90s tick is its own retry; that *is* the recovery mechanism.

## Bug 2 — sd side: dmsg-port-136 probe gate is too brittle

`pkg/service-discovery/api/api.go` rejected `type=visor` registrations with 403 if the SD couldn't `Probe(pk, DmsgAwaitSetupPort)` within 15s. Failure modes that fired this gate without the visor being unreachable:

- SD's own dmsg sessions still warming up after restart
- The visor's delegated dmsg-server slow on first dial
- The noise handshake completing after the 15s budget
- The visor briefly between sessions on a server restart

Combined with bug 1, every flaky probe permanently disabled the responding visor. The `ipIsPublic` check above the probe already enforces SD's actual contract (WAN-reachability of the registering visor's IP); route-setup failures are caught by the route finder, where they belong.

**Fix:** remove the probe gate. Drop the now-dead `probeCache`, `probeCacheMu`, `DmsgClient` field, and the wiring in `cmd/svc/service-discovery/commands/root.go`.

## Why this surfaced now

Yesterday SD was redeployed onto the test box and dmsgd was bounced multiple times today during the latency-PR rollout. Each restart created a window where SD's outgoing dmsg sessions were re-establishing, and within that window every visor that called `Register` got `ErrVisorUnreachable`. Bug 1 turned every such response into permanent deregistration, so by the time SD's dmsg fully recovered, every public visor's heartbeat was already dead.

Reproduced live by checking that 3 known-public PKs (`027087fe…`, `03a590ea…`, `03d1d78e…`) are present in dmsgd with fresh entries (<1 min age) and 6 delegated servers each, but absent from SD's `?type=visor` query.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/service-discovery/api/...` passes
- [ ] **After deploy**: confirm `curl https://sd.skycoin.com/api/services?type=visor | jq length` grows past 0 within a few minutes (visors that already gave up will start showing up via the next 90s heartbeat).
- [ ] **After deploy**: confirm `skywire cli tp add pv` succeeds on the host visor (currently fails with "no public visors found").