### PR TITLE
ar: trust visor-declared PublicIP when AR's observed source is non-public

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -306,13 +306,26 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !netutil.IsPublicIP(net.ParseIP(remoteAddr)) {
-		// the ip of the visor is either private(because of proxy/loadbalancer) or ipv6
-		err := fmt.Sprintf("Cannot bind %v to %v (STCPR). Invalid IP address in request: %v", pk, remoteAddr, localAddresses)
-		a.logger(r).Errorf(err)
-		a.writeJSON(w, r, http.StatusBadRequest, &Error{
-			Error: err,
-		})
-		return
+		// Observed source IP is non-public — typically because the visor
+		// shares a host with AR and reaches it via hairpin SNAT through
+		// a Docker bridge (e.g., 172.x.y.z) rather than its real public
+		// IP. If the visor declared a known-public PublicIP in the bind
+		// payload, trust that instead; rejecting the bind would lose all
+		// AR coverage for that visor's STCPR. Visors that don't declare
+		// (older clients, or genuinely-misconfigured proxy/IPv6 traffic)
+		// still hit the original reject below.
+		if localAddresses.PublicIP != "" && netutil.IsPublicIP(net.ParseIP(localAddresses.PublicIP)) {
+			a.logger(r).Infof("STCPR: observed %v non-public; using declared PublicIP %v for %v",
+				remoteAddr, localAddresses.PublicIP, pk)
+			remoteAddr = localAddresses.PublicIP
+		} else {
+			err := fmt.Sprintf("Cannot bind %v to %v (STCPR). Invalid IP address in request: %v", pk, remoteAddr, localAddresses)
+			a.logger(r).Errorf(err)
+			a.writeJSON(w, r, http.StatusBadRequest, &Error{
+				Error: err,
+			})
+			return
+		}
 	}
 
 	if !a.hasAddress(remoteAddr, localAddresses) {
@@ -780,8 +793,28 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 		return
 	}
 
+	// Override the observed UDP source when it's non-public AND the visor
+	// declared a known-public PublicIP. The hairpin-SNAT case (visor and
+	// AR on the same Docker host) rewrites BOTH the source IP (to the
+	// docker bridge gateway) and the source port (to a kernel-chosen
+	// ephemeral) — neither is reachable from external peers. Use the
+	// visor's listen port (LocalAddresses.Port), which IS the externally-
+	// reachable UDP port. Visors with public observed sources (the
+	// common case, including legitimate NAT'd visors that need
+	// hole-punching to retain the NAT-mapped source port) keep the
+	// observed value unchanged.
+	effectiveRemoteAddr := remoteAddr
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil && !netutil.IsPublicIP(net.ParseIP(host)) {
+		if localAddresses.PublicIP != "" && localAddresses.Port != "" &&
+			netutil.IsPublicIP(net.ParseIP(localAddresses.PublicIP)) {
+			effectiveRemoteAddr = net.JoinHostPort(localAddresses.PublicIP, localAddresses.Port)
+			a.log.Infof("SUDPH: observed %v non-public; using declared %v for %v",
+				remoteAddr, effectiveRemoteAddr, pk)
+		}
+	}
+
 	visorData := addrresolver.VisorData{
-		RemoteAddr:     remoteAddr,
+		RemoteAddr:     effectiveRemoteAddr,
 		LocalAddresses: localAddresses,
 	}
 

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -293,6 +293,16 @@ type BindRequest struct {
 type LocalAddresses struct {
 	Port      string   `json:"port"`
 	Addresses []string `json:"addresses"`
+	// PublicIP is the visor's STUN- or dmsg-derived public IP, if known.
+	// AR uses this to override the observed source IP when the latter is
+	// non-public (e.g., a visor running on the same Docker host as AR
+	// reaches it via hairpin SNAT, so AR's UDP socket sees the docker
+	// bridge gateway IP — 172.x.y.z — instead of the visor's actual public
+	// IP). Old visors that don't set this field leave AR's behavior
+	// unchanged: AR falls back to the observed source IP, which is
+	// correct for any visor whose path to AR is not NAT'd into a private
+	// space. Empty string means "let AR decide."
+	PublicIP string `json:"public_ip,omitempty"`
 }
 
 func (c *httpClient) Addresses(_ context.Context) string {
@@ -354,6 +364,7 @@ func (c *httpClient) BindSTCPR(ctx context.Context, port string) error {
 	localAddresses := LocalAddresses{
 		Addresses: addresses,
 		Port:      port,
+		PublicIP:  c.LocalPublicIP(),
 	}
 	log.Debugf("Address resolver binding with: %v", addresses)
 	resp, err := c.Post(ctx, stcprBindPath, localAddresses)
@@ -491,6 +502,7 @@ func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (n
 	localAddresses := LocalAddresses{
 		Addresses: addresses,
 		Port:      localPort,
+		PublicIP:  c.LocalPublicIP(),
 	}
 
 	laData, err := json.Marshal(localAddresses)


### PR DESCRIPTION
## Summary

When a public visor and the address-resolver container live on the same Docker host, the visor's bind packets to AR hit the host's public IP and hairpin back through Docker's NAT. Linux MASQUERADE rewrites the source IP (and, for UDP, the source port). AR records that as the visor's externally-reachable address, so peers later fetch a record that points at the docker bridge gateway and an ephemeral port — both unreachable from outside.

Live symptom on the prod host (visor PK `02f9aa58…` running on the same box as the prod deployment):

```
AR Registration:
  STCPR  139.162.160.227:33983
  SUDPH  172.18.0.1:35530:35530    ← bridge gateway IP, unreachable
```

STCPR is correct because that registration goes through caddy via HTTP and caddy preserves the visor's public IP. SUDPH is direct UDP, so AR sees the post-SNAT source.

## Approach

The visor already knows its public IP from STUN/dmsg (`addrresolver.httpClient.LocalPublicIP()`). Plumb it into the bind payload, and have AR honor it whenever the observed source is non-public.

Wire change (`pkg/transport/network/addrresolver/client.go`):

```go
type LocalAddresses struct {
    Port      string   `json:"port"`
    Addresses []string `json:"addresses"`
    PublicIP  string   `json:"public_ip,omitempty"`   // NEW
}
```

`PublicIP` is `omitempty` — old visors send the field empty and AR's behavior for them is unchanged.

Visor side (`BindSTCPR` and `connectSUDPH`): set `PublicIP: c.LocalPublicIP()`.

AR side (`pkg/address-resolver/api/api.go`):

- **STCPR `bind`** previously rejected the request with 400 if the observed source IP wasn't public. Now: if `PublicIP` is set and is itself a public IP, accept the bind using the declared IP. Visors with no declared `PublicIP` still hit the original reject (preserves safety for genuinely-misconfigured proxy / IPv6 traffic).
- **SUDPH `bindSUDPH`** previously stored the observed `IP:port` verbatim. Now: when the observed IP is non-public AND `PublicIP` is set + public, build `RemoteAddr` as `<PublicIP>:<LocalAddresses.Port>` (the visor's actual listen port). The observed port is correct for legitimate NAT'd visors (it's the NAT-mapped port hole-punching needs) — but for hairpin SNAT it's a kernel-chosen ephemeral that's useless. Branching on "observed source is non-public" reliably distinguishes the two cases (legit NAT visors have public observed sources because their NAT translates to the WAN IP; only the visor-and-AR-share-a-host case yields a private observed source).

## Trust model

The override only fires when the observed source IP is non-public. A visor with a public source IP cannot lie about its address and cause peers to dial an innocent third party. The hairpin-from-Docker-host scenario is the only realistic source of "observed non-public" today — that's the case this fix targets.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/transport/network/addrresolver/...` passes
- [x] `go test ./pkg/address-resolver/...` passes (excluding the pre-existing `TestRedis` that requires unauthenticated redis — unrelated to this change)
- [ ] **After deploy**: on the prod host, `skywire cli visor info` should show the SUDPH AR registration with the public IP `139.162.160.227:35530` instead of `172.18.0.1:35530:35530`.
- [ ] **After deploy**: peers attempting SUDPH transports to the host visor should now succeed.