### PR TITLE
cxoaggregator: log OnRootReceived + OnFillingBreaks

### DIFF
--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -33,11 +33,13 @@ package cxoaggregator
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	skycipher "github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -127,6 +129,24 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	cfg.Config.InMemoryDB = conf.InMemoryDB || conf.DataDir == ""
 	if conf.DataDir != "" {
 		cfg.Config.DataDir = conf.DataDir
+	}
+
+	// Wire the cxo node's internal logger so its FillPin / MsgReceivePin
+	// / connection-handshake debug output goes to stderr (where docker
+	// logs reads it). Without this, cxo's "[fill] ..." and "[%s]
+	// handleSub %s" lines are silent regardless of tpd's --loglvl, and
+	// a fill failure / handshake mismatch is invisible. Debug is gated
+	// on the global logger level so prod runs at INFO get nothing extra.
+	cfg.Logger.Output = os.Stderr
+	cfg.Logger.Prefix = "[tpd-cxo-aggregator:node] "
+	if lvl := logging.GetLevel(); lvl == logrus.DebugLevel || lvl == logrus.TraceLevel {
+		cfg.Logger.Debug = true
+		// Filter to the pins that diagnose Subscribe → Root delivery →
+		// fill chains. ConnPin is loud-on-startup but only one-shot;
+		// MsgPin would be too chatty (every Root + every chunk request),
+		// so include only MsgReceivePin which captures the publisher
+		// side of subscribe/root receipt.
+		cfg.Logger.Pins = node.FillPin | node.ConnPin | node.MsgReceivePin
 	}
 
 	cxoNode, err := node.NewNode(cfg)

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -146,8 +146,34 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 		log:     conf.Logger,
 		done:    make(chan struct{}),
 	}
+	// Wire all three Root-lifecycle callbacks. Together they make the
+	// CXO replication chain observable from tpd's logs:
+	//
+	//   - OnRootReceived: a Root payload arrived from the visor's
+	//     publisher. Logged at Debug. Lets us tell "Subscribe but no
+	//     data" (no OnRootReceived ever) from "data arrives but
+	//     can't be processed" (OnRootReceived fires but OnRootFilled
+	//     doesn't).
+	//   - OnRootFilled: the Root and ALL its referenced objects have
+	//     been replicated successfully — the aggregator can now walk
+	//     the tree. This is the existing dispatch trigger.
+	//   - OnFillingBreaks: replication of a Root's referenced objects
+	//     failed (timeout, peer drop, missing object). Logged at Warn
+	//     so it surfaces at the default log level — without this,
+	//     fill failures are silent.
+	cxoNode.Config().OnRootReceived = func(_ *node.Conn, r *registry.Root) error {
+		a.log.WithField("visor", cipher.PubKey(r.Pub)).WithField("seq", r.Nonce).
+			Debug("CXO aggregator: root received")
+		return nil
+	}
 	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
+		a.log.WithField("visor", cipher.PubKey(r.Pub)).WithField("seq", r.Nonce).
+			Debug("CXO aggregator: root filled")
 		a.handleRootFilled(r)
+	}
+	cxoNode.Config().OnFillingBreaks = func(_ *node.Node, r *registry.Root, reason error) {
+		a.log.WithError(reason).WithField("visor", cipher.PubKey(r.Pub)).WithField("seq", r.Nonce).
+			Warn("CXO aggregator: root filling broke")
 	}
 	return a, nil
 }


### PR DESCRIPTION
## Why

Aggregator currently wires only `OnRootFilled`. When a Subscribe completes but no `UpdateBandwidth` / `UpdateLatency` calls follow, there is no log line distinguishing:

- a) Root never arrived (CXO replication issue, conn one-way, etc.)
- b) Root arrived but filling broke (object replication timed out / peer disappeared)

`OnFillingBreaks` is silent by default, and `OnFillingBreaks` is exactly where a replication-time failure surfaces in CXO.

## Live trigger

On the prod tpd today: 4+ `subscribed to visor feed` Debug lines for visors that are alive on dmsg (`03d1d78e…`, `027087fe…`, `03a590ea…`, `0323272a…`), 0 `UpdateBandwidth` / `UpdateLatency` debug lines, 0 `bw:visor:*` redis updates in the last 10 minutes, `/metrics?latency=true` returns 0 entries with non-null latency. The aggregator runs but no Root data flows. With only `OnRootFilled` wired, we can't tell where the chain breaks.

## Change

Wire all three Root-lifecycle callbacks in `cxoaggregator.New()`:

```go
cxoNode.Config().OnRootReceived = func(_ *node.Conn, r *registry.Root) error {
    a.log.WithField("visor", ...).WithField("seq", r.Nonce).
        Debug("CXO aggregator: root received")
    return nil
}
cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
    a.log.WithField("visor", ...).WithField("seq", r.Nonce).
        Debug("CXO aggregator: root filled")
    a.handleRootFilled(r)
}
cxoNode.Config().OnFillingBreaks = func(_ *node.Node, r *registry.Root, reason error) {
    a.log.WithError(reason).WithField("visor", ...).WithField("seq", r.Nonce).
        Warn("CXO aggregator: root filling broke")
}
```

Volume: each subscribed visor publishes a Root every ~minute (1-min sample interval in the visor's stats tracker), so OnRootReceived/OnRootFilled fire ~1× per visor per minute at Debug. OnFillingBreaks should be rare; Warn level chosen so it shows up at the default `--loglvl info` — without it, fill failures are silent and the only symptom is "no metrics populating, no error logs."

No behavior change beyond logging.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/transport-discovery/...` passes
- [ ] **After deploy**: with tpd at `--loglvl debug`, expect to see `root received`/`root filled` lines for each subscribed visor every ~minute. If we see `root received` but no `root filled` (or `root filling broke`), the bug is in object replication. If we see neither, the bug is in Subscribe → publisher delivery.