### PR TITLE
cxo/node: evict dead DMSG conns from cache on Conn cleanup

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -114,12 +114,22 @@ func (c *Conn) run() {
 	// have IsTCP()==false and don't have a UDP transport. Nil-check
 	// each so a DMSG-only node (NewWithDMSG path: TCP/UDP listeners
 	// disabled) doesn't panic when its conns close.
+	//
+	// DMSG cleanup runs unconditionally for any node that has a DMSG
+	// transport: closeConn is a no-op if c isn't in the DMSG cache,
+	// and without this, a DMSG-only node never evicted dead conns —
+	// turning a single tpd restart into "this publisher's AnnounceTo
+	// returns the dead cached conn forever" until the publisher
+	// itself restarted.
 	if c.IsTCP() {
 		if c.n.tcp != nil {
 			c.n.tcp.closeConn(c.Address()) //nolint:errcheck,gosec
 		}
 	} else if c.n.udp != nil {
 		c.n.udp.closeConn(c.Address()) //nolint:errcheck,gosec
+	}
+	if c.n.dmsg != nil {
+		c.n.dmsg.closeConn(c)
 	}
 
 	// Determine which error to report.

--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -116,6 +116,32 @@ func (d *DMSG) acceptConn(fc *transport.Connection) {
 	}
 }
 
+// closeConn removes the cached entry that matches the given conn.
+// Called from Conn.run() cleanup so a dead DMSG conn does not persist
+// in d.cs and short-circuit subsequent ConnectPK calls.
+//
+// Without this, when the *remote* CXO node restarts (and its old
+// per-conn state goes away) the local side's dmsg session survives
+// — but the cxo Conn on top is dead. ConnectPK's existing-conn
+// cache hit then returns the dead conn, the publisher's AnnounceTo
+// never re-handshakes, and from the remote aggregator's point of
+// view that publisher is silent forever (until the publisher itself
+// restarts). closeConn is the symmetric undo for addConn so the
+// cache stays consistent with the live conn set.
+//
+// Iterating to find c is fine: d.cs is bounded by peer count, and
+// this fires only on conn teardown — not in the hot path.
+func (d *DMSG) closeConn(c *Conn) {
+	d.mx.Lock()
+	defer d.mx.Unlock()
+	for pk, cached := range d.cs {
+		if cached == c {
+			delete(d.cs, pk)
+			return
+		}
+	}
+}
+
 // CloseConn closes a connection by remote public key.
 func (d *DMSG) CloseConn(pk cipher.PubKey) error {
 	d.mx.Lock()


### PR DESCRIPTION
## Summary

The CXO Conn cleanup in `pkg/cxo/node/conn.go` only called `closeConn` on TCP and UDP transports, never on DMSG. So the DMSG transport's `d.cs[remotePK]` cache stayed populated with dead conns indefinitely. The next `ConnectPK(remotePK)` returned the dead cached conn without redialing — and any higher-level code on top (publisher `AnnounceTo`, subscriber `Connect`, the RPC handler) got back a Conn that could no longer send, receive, or re-handshake.

```go
// pkg/cxo/node/transport_dmsg.go ConnectPK — current behavior
if c := d.getConn(remotePK); c != nil {
    return c, nil   // dead conn, but cached → returned anyway
}
```

## Live failure mode (just observed)

Diagnosed via PR #2411's observability on the prod transport-discovery aggregator. After tpd's restart, only **one** visor was successfully delivering CXO telemetry — Moe Narrow's network monitor, which happened to have been freshly restarted itself after the last deploy and so re-handshaked from scratch.

The host visor + three other public visors all had **dmsg-alive / cxo-dead** conns from before the latest tpd restart. Their `pub.AnnounceTo(tpdPK)` was a no-op every 30s because `ConnectPK` short-circuited on the cached dead conn. The aggregator never saw `Sub` from them; nothing flowed; transport bw/latency stayed zero in redis.

Halting and restarting the host visor immediately recovered it — `cli visor halt`, wait 90s, fresh subscribe + `root received` + `root filled` events for that PK, latency entries appeared in `/metrics`. But that workaround doesn't scale: every tpd restart silently breaks every visor that had a stable conn through it.

## Fix

Add `DMSG.closeConn(c *Conn)` — direct analog of `TCP.closeConn` and `UDP.closeConn` — that finds the cache entry matching `c` and deletes it. Call it unconditionally in `Conn.run()` cleanup whenever `c.n.dmsg != nil`:

```go
if c.IsTCP() {
    if c.n.tcp != nil { c.n.tcp.closeConn(c.Address()) }
} else if c.n.udp != nil {
    c.n.udp.closeConn(c.Address())
}
if c.n.dmsg != nil {
    c.n.dmsg.closeConn(c)            // NEW
}
```

The DMSG variant takes `*Conn` (not addr) because DMSG keys its cache by remote PK, not by Address(). Iteration is bounded by peer count and only fires on conn teardown — not the hot path. Safe no-op when c isn't in the DMSG cache (e.g., TCP-only conns).

After the fix, when a DMSG conn dies the cache is consistent with the live conn set, and the next `ConnectPK` / inbound accept actually re-handshakes. `AnnounceTo`'s idempotency continues to work correctly for *live* conns and stops papering over dead ones.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/cxo/...` clean (8.5s for `pkg/cxo/node`)
- [ ] **After deploy**: trigger a tpd restart. The visor population that was previously stuck after each tpd restart should now self-heal within ~30s (one AnnounceTo cycle) instead of needing a visor-side restart. Verify via the `root received` / `root filled` debug log lines from #2411 — should see entries from many visors, not just one.