### PR TITLE
transport: don't zero-clobber latency on partial measurements

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1258,6 +1258,14 @@ func (rg *RouteGroup) MeasureLatency(ctx context.Context, count int) (min, max, 
 		// Wait for pong with timeout
 		select {
 		case latencyMs := <-pongCh:
+			// Drop non-positive samples — a 0 here would seed min/max
+			// at 0 and produce a snapshot {min:0, max:X, avg:Y} that
+			// downstream consumers (TPD, /stats) treat as "no min
+			// measurement" and either reject or display misleadingly.
+			if latencyMs <= 0 {
+				rg.logger.Debugf("Ping %d/%d: dropped non-positive sample (%.6f ms)", i+1, count, latencyMs)
+				continue
+			}
 			measurements = append(measurements, latencyMs)
 			rg.logger.Debugf("Ping %d/%d: %.2f ms", i+1, count, latencyMs)
 		case <-time.After(timeout):

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -359,7 +359,11 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 	if err := a.sink.UpdateBandwidth(ctx, id.String(), reporter, snap.SentBytes, snap.RecvBytes); err != nil {
 		a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateBandwidth failed")
 	}
-	if snap.LatencyAvgMS > 0 {
+	// Both edges of a transport publish their own snapshot, and TPD's
+	// store is last-writer-wins. Require all three fields to be > 0 so
+	// a partial-zero snapshot from an edge whose probe never completed
+	// can't clobber a good record written by the other edge.
+	if snap.LatencyMinMS > 0 && snap.LatencyMaxMS > 0 && snap.LatencyAvgMS > 0 {
 		if err := a.sink.UpdateLatency(ctx, id.String(), snap.LatencyMinMS, snap.LatencyMaxMS, snap.LatencyAvgMS); err != nil {
 			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateLatency failed")
 		}

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -1,9 +1,16 @@
 package cxoaggregator
 
 import (
+	"context"
+	"encoding/json"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
 )
 
 func TestParseCurrentTransportPath(t *testing.T) {
@@ -29,5 +36,84 @@ func TestParseCurrentTransportPath(t *testing.T) {
 		if c.want && gotID != id {
 			t.Errorf("parseCurrentTransportPath(%q) id = %v, want %v", c.path, gotID, id)
 		}
+	}
+}
+
+// recordingSink captures sink calls so tests can assert what dispatchLeaf
+// chose to forward (vs drop on the partial-zero gate).
+type recordingSink struct {
+	mu         sync.Mutex
+	bandwidths int
+	latencies  []struct{ min, max, avg float64 }
+}
+
+func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey, _, _ uint64) error {
+	s.mu.Lock()
+	s.bandwidths++
+	s.mu.Unlock()
+	return nil
+}
+func (s *recordingSink) UpdateLatency(_ context.Context, _ string, minMS, maxMS, avgMS float64) error {
+	s.mu.Lock()
+	s.latencies = append(s.latencies, struct{ min, max, avg float64 }{minMS, maxMS, avgMS})
+	s.mu.Unlock()
+	return nil
+}
+
+func TestDispatchLeafLatencyGate(t *testing.T) {
+	id := uuid.New()
+	pk := cipher.PubKey{}
+	now := time.Now().UTC()
+
+	cases := []struct {
+		name      string
+		snap      liveSnapshot
+		wantBwHit bool
+		wantLat   bool
+	}{
+		{
+			name:      "all zero — bandwidth still fires (so tx counters update), latency dropped",
+			snap:      liveSnapshot{SampledAt: now},
+			wantBwHit: true,
+			wantLat:   false,
+		},
+		{
+			name:      "min=0, partial measurement — must NOT clobber stored latency",
+			snap:      liveSnapshot{LatencyMinMS: 0, LatencyMaxMS: 30, LatencyAvgMS: 18, SampledAt: now},
+			wantBwHit: true,
+			wantLat:   false,
+		},
+		{
+			name:      "max=0, partial measurement — drop",
+			snap:      liveSnapshot{LatencyMinMS: 10, LatencyMaxMS: 0, LatencyAvgMS: 18, SampledAt: now},
+			wantBwHit: true,
+			wantLat:   false,
+		},
+		{
+			name:      "all positive — write through",
+			snap:      liveSnapshot{LatencyMinMS: 10, LatencyMaxMS: 30, LatencyAvgMS: 18, SampledAt: now},
+			wantBwHit: true,
+			wantLat:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sink := &recordingSink{}
+			a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+			leaf, err := json.Marshal(c.snap)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			a.dispatchLeaf("transports/"+id.String()+"/current", leaf, pk)
+			if c.wantBwHit && sink.bandwidths != 1 {
+				t.Errorf("expected 1 bandwidth call, got %d", sink.bandwidths)
+			}
+			if c.wantLat && len(sink.latencies) != 1 {
+				t.Errorf("expected latency forwarded, got %d calls", len(sink.latencies))
+			}
+			if !c.wantLat && len(sink.latencies) != 0 {
+				t.Errorf("expected latency dropped, got %+v", sink.latencies)
+			}
+		})
 	}
 }

--- a/pkg/transport-discovery/store/redis_bandwidth.go
+++ b/pkg/transport-discovery/store/redis_bandwidth.go
@@ -116,7 +116,10 @@ func (s *redisStore) UpdateBandwidth(ctx context.Context, transportID string,
 // blob from a latency report alone — registration is the only path that
 // knows the canonical edges/type.
 func (s *redisStore) UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error {
-	if avgMS <= 0 {
+	// Defense-in-depth alongside the aggregator gate: any non-positive
+	// field means the snapshot is partial, so reject the whole update
+	// rather than persist a zero in a single field.
+	if minMS <= 0 || maxMS <= 0 || avgMS <= 0 {
 		return nil
 	}
 

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -154,11 +154,19 @@ func (mt *ManagedTransport) GetLatencyStats() LatencyStats {
 
 // SetLatency sets the average inter-visor ping latency in milliseconds.
 // For backwards compatibility; prefer SetLatencyStats for full statistics.
+//
+// A non-positive sample is dropped: ns-resolution timestamps can produce
+// rttMs == 0 on a sub-microsecond loopback, and a 0 here would clobber
+// Avg and (via the `latencyMs < Min` branch) Min, leaving Max as the only
+// surviving field. Round-trip time is strictly positive in any real
+// measurement, so treating 0 as "no sample" is correct.
 func (mt *ManagedTransport) SetLatency(latencyMs float64) {
+	if latencyMs <= 0 {
+		return
+	}
 	mt.latencyMx.Lock()
 	defer mt.latencyMx.Unlock()
 	mt.latencyStats.Avg = latencyMs
-	// If min/max not set, initialize them
 	if mt.latencyStats.Min == 0 || latencyMs < mt.latencyStats.Min {
 		mt.latencyStats.Min = latencyMs
 	}
@@ -167,8 +175,14 @@ func (mt *ManagedTransport) SetLatency(latencyMs float64) {
 	}
 }
 
-// SetLatencyStats sets the full latency statistics.
+// SetLatencyStats sets the full latency statistics. A snapshot with any
+// non-positive field is rejected: a partial measurement (e.g. all five
+// pings timed out except one that returned in <1µs) would otherwise
+// overwrite a previously good record with a zero in min or max.
 func (mt *ManagedTransport) SetLatencyStats(stats LatencyStats) {
+	if stats.Min <= 0 || stats.Max <= 0 || stats.Avg <= 0 {
+		return
+	}
 	mt.latencyMx.Lock()
 	defer mt.latencyMx.Unlock()
 	mt.latencyStats = stats
@@ -395,8 +409,8 @@ func (mt *ManagedTransport) handleTransportPong(p routing.Packet) {
 	}
 	sentAt := int64(binary.BigEndian.Uint64(payload[:8])) //nolint:gosec
 	rttMs := float64(time.Now().UnixNano()-sentAt) / 1e6
-	if rttMs < 0 {
-		return // clock skew or corrupted timestamp
+	if rttMs <= 0 {
+		return // clock skew, corrupted timestamp, or sub-µs RTT we can't represent
 	}
 	mt.SetLatency(rttMs)
 	mt.log.WithField("rtt_ms", fmt.Sprintf("%.2f", rttMs)).Trace("Transport ping RTT")

--- a/pkg/transport/managed_transport_test.go
+++ b/pkg/transport/managed_transport_test.go
@@ -163,3 +163,48 @@ func TestReadLoopDropsPacketOnFullChannel(t *testing.T) {
 		t.Fatal("readLoop did not exit after transport close")
 	}
 }
+
+// A 0 or negative sample must not overwrite the running stats — that
+// path was the source of the "TPD says min=0" production bug.
+func TestSetLatencyDropsNonPositive(t *testing.T) {
+	mt := &ManagedTransport{}
+	mt.SetLatency(15.5)
+	require.Equal(t, LatencyStats{Min: 15.5, Max: 15.5, Avg: 15.5}, mt.GetLatencyStats())
+
+	mt.SetLatency(0)
+	require.Equal(t, LatencyStats{Min: 15.5, Max: 15.5, Avg: 15.5}, mt.GetLatencyStats(),
+		"a 0 sample wiped the existing stats")
+
+	mt.SetLatency(-1)
+	require.Equal(t, LatencyStats{Min: 15.5, Max: 15.5, Avg: 15.5}, mt.GetLatencyStats(),
+		"a negative sample wiped the existing stats")
+
+	mt.SetLatency(8.2)
+	require.Equal(t, LatencyStats{Min: 8.2, Max: 15.5, Avg: 8.2}, mt.GetLatencyStats(),
+		"a valid sample after rejected ones must still update")
+}
+
+// SetLatencyStats must reject any partial-zero snapshot — otherwise a
+// MeasureLatency result with min=0 (e.g. a sub-µs ping included in
+// `measurements`) would replace a previously-good record.
+func TestSetLatencyStatsDropsPartialZero(t *testing.T) {
+	mt := &ManagedTransport{}
+	good := LatencyStats{Min: 10, Max: 30, Avg: 20}
+	mt.SetLatencyStats(good)
+	require.Equal(t, good, mt.GetLatencyStats())
+
+	for _, bad := range []LatencyStats{
+		{Min: 0, Max: 30, Avg: 20},
+		{Min: 10, Max: 0, Avg: 20},
+		{Min: 10, Max: 30, Avg: 0},
+		{Min: -1, Max: 30, Avg: 20},
+	} {
+		mt.SetLatencyStats(bad)
+		require.Equal(t, good, mt.GetLatencyStats(),
+			"partial-zero snapshot %+v overwrote good stats", bad)
+	}
+
+	better := LatencyStats{Min: 5, Max: 40, Avg: 18}
+	mt.SetLatencyStats(better)
+	require.Equal(t, better, mt.GetLatencyStats())
+}


### PR DESCRIPTION
## Summary

Both edges of a transport now publish their own latency snapshot via the CXO aggregator, and TPD's `UpdateLatency` is last-writer-wins. A single partial-zero sample on either edge could overwrite a good record on the other. In production, this manifests as latency missing from nearly every transport in `/metrics` (only the few transports lucky enough to have both edges report cleanly in the same window survive); when it does land, `min=0` shows up next to a non-zero max/avg.

The root cause was four write paths that didn't reject non-positive samples:

- `ManagedTransport.SetLatency(latencyMs)` had no `latencyMs <= 0` guard, and used `Min == 0 || latencyMs < Min` for the min update. A 0-rtt sample (reachable on sub-µs LAN — `rttMs` is `(now-sentAt) / 1e6` of int64 ns timestamps) zeroed Avg and Min while leaving Max stale. `handleTransportPong` only filtered `< 0`, not `<= 0`.
- `SetLatencyStats` took whatever the caller passed. `router.MeasureTransportLatency` computes min/max/avg from a `measurements` slice that included 0-rtt pongs, so its output could be `{min:0, max:X, avg:Y}` after even one such sample.
- The aggregator's `dispatchLeaf` and `redisStore.UpdateLatency` both gated on `Avg > 0` only, letting partial-zero snapshots through.

## Fix

- `SetLatency` / `SetLatencyStats` reject any non-positive field.
- `handleTransportPong` tightens `rttMs < 0` to `rttMs <= 0`.
- `RouteGroup.MeasureLatency` drops non-positive pong samples before appending.
- `cxoaggregator.dispatchLeaf` requires all three of min/max/avg > 0 before forwarding.
- `redisStore.UpdateLatency` rejects the same case at the store boundary (defense in depth).

`UpdateLatency` stays last-writer-wins — round-trip is symmetric, latency shouldn't be summed/averaged like bandwidth, and the existing per-transport semantic is preserved. The change is purely about which writes are accepted.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./pkg/transport/... ./pkg/transport-discovery/... ./pkg/router/... ./pkg/visor/stats/...` clean.
- [x] `go test ./pkg/transport/ ./pkg/transport-discovery/... ./pkg/router/ ./pkg/visor/stats/` all pass.
- [x] New unit tests:
  - `TestSetLatencyDropsNonPositive` — a 0 or negative sample must not wipe existing stats; a valid sample after must still update.
  - `TestSetLatencyStatsDropsPartialZero` — rejects `{Min:0,...}`, `{Max:0,...}`, `{Avg:0,...}`, and negatives; accepts a fully-positive replacement.
  - `TestDispatchLeafLatencyGate` — table test: all-zero / min=0 / max=0 / all-positive snapshots; bandwidth flows in every case, latency only when all three are positive.
- [ ] After deploy: poll `GET /metrics` on TPD across a window of several minutes and verify (a) more transports carry latency, (b) no record shows `min:0` alongside a non-zero max/avg.