### PR TITLE
visor: register RuntimeLogs on the RPC server

### DIFF
--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -151,6 +151,16 @@ func (r *RPC) GetRuntimeConfig(_ *struct{}, out *[]byte) (err error) {
 	return err
 }
 
+// RuntimeLogs returns the visor's accumulated runtime log buffer.
+// Used by the hypervisor UI's "view logs" action and the
+// `skywire cli visor logs` command.
+func (r *RPC) RuntimeLogs(_ *struct{}, out *string) (err error) {
+	defer rpcutil.LogCall(r.log, "RuntimeLogs", nil)(out, &err)
+	logs, err := r.visor.RuntimeLogs()
+	*out = logs
+	return err
+}
+
 // GetConfigPath returns the filesystem path the visor loaded its config from.
 func (r *RPC) GetConfigPath(_ *struct{}, out *string) (err error) {
 	defer rpcutil.LogCall(r.log, "GetConfigPath", nil)(out, &err)


### PR DESCRIPTION
The hypervisor UI's "view logs" action and 'cli visor logs' both hit Visor.RuntimeLogs() through the RPC client, but the RPC server type (*RPC) had no RuntimeLogs method registered. Stock net/rpc exposes only methods on the registered receiver via reflection, so client calls came back with

  Rpc: can't find method app-visor.RuntimeLogs.

API.RuntimeLogs, Visor.RuntimeLogs, and the rpcClient.RuntimeLogs client wrapper were already in place — the dispatcher in pkg/visor/rpc_visor.go was the missing piece. Add it next to GetRuntimeConfig (same shape: zero-arg in, *string out).

Did you run `make format && make check`?

Fixes #	

 Changes:	
-	

How to test this PR:
