### PR TITLE
fix tpd panic loop: cxo Finc-to-negative + httputil short-write discriminator

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -2,6 +2,7 @@ package skyobject
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"sync"
 	"time"
@@ -1186,7 +1187,18 @@ func (c *Cache) Finc(
 		}
 
 		if it.fc < 0 {
-			panic("Finc to negative for: " + key.Hex()[:7])
+			// Refcount inconsistency: a filler decremented fc by
+			// more than the cache's recorded Inc total. Likely a
+			// duplicate Finc on the same filler.incs map, or an
+			// Inc/Finc mismatch across overlapping fillers. The
+			// historical behavior was to panic — that's a hard
+			// process kill that observably restarts TPD on prod
+			// every 30-40s. Clamp to zero and continue so the
+			// process stays alive; the worst case is a leaked
+			// filling-item slot, not data corruption.
+			log.Printf("[CXO] Finc apply clamped negative fc to 0 for %s (was %d, inc %d)",
+				key.Hex(), it.fc+inc, inc)
+			it.fc = 0
 		}
 
 		// the fc is zero
@@ -1213,7 +1225,10 @@ func (c *Cache) Finc(
 	it.fc += inc // fc = fc - abs(inc)
 
 	if it.fc < 0 {
-		panic("Finc to negative for: " + key.Hex()[:7])
+		// Same recovery as the apply branch — see comment above.
+		log.Printf("[CXO] Finc reject clamped negative fc to 0 for %s (was %d, inc %d)",
+			key.Hex(), it.fc-inc, inc)
+		it.fc = 0
 	}
 
 	// and if it.fc turns to be zero, then the

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -76,11 +76,21 @@ func isIOError(err error) bool {
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
-	// String-match fallback for syscall errors that have no clean Go sentinel
-	// (kernel-side errno wrappings that surface as descriptive strings).
+	// String-match fallback for errors that have no clean Go sentinel,
+	// or whose value differs from a sentinel that shares its message.
+	//
+	// "short write" specifically: http.timeoutWriter (from net/http's
+	// per-write deadline machinery) returns its own error when the
+	// response deadline expires mid-write — same text as io.ErrShortWrite,
+	// different identity, so errors.Is misses it. Production TPD was
+	// panicking every ~30s on large /all-transports responses to slow
+	// clients before this case was added.
 	errStr := err.Error()
 	if strings.Contains(errStr, "broken pipe") ||
-		strings.Contains(errStr, "connection reset") {
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "short write") ||
+		strings.Contains(errStr, "i/o timeout") ||
+		strings.Contains(errStr, "deadline exceeded") {
 		return true
 	}
 	return false

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -1,0 +1,50 @@
+package httputil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+)
+
+// TestIsIOErrorShortWriteVariants pins the fix for the production
+// panic loop where http.timeoutWriter's "short write: i/o deadline
+// reached" failed errors.Is(io.ErrShortWrite) (different sentinel)
+// and slipped past the discriminator, causing WriteJSON to panic
+// rather than return on a slow-client write timeout.
+func TestIsIOErrorShortWriteVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"random unrelated", errors.New("malformed UTF-8"), false},
+
+		// sentinels: must keep working
+		{"io.ErrShortWrite sentinel", io.ErrShortWrite, true},
+		{"io.ErrClosedPipe sentinel", io.ErrClosedPipe, true},
+		{"net.ErrClosed sentinel", net.ErrClosed, true},
+		{"os.ErrDeadlineExceeded sentinel", os.ErrDeadlineExceeded, true},
+		{"wrapped io.ErrShortWrite", fmt.Errorf("foo: %w", io.ErrShortWrite), true},
+
+		// the production case: same message, different identity
+		{"http.timeoutWriter short-write text", errors.New("short write: i/o deadline reached"), true},
+		{"i/o timeout text", errors.New("write tcp 10.0.0.1:443: i/o timeout"), true},
+		{"deadline exceeded text", errors.New("context deadline exceeded"), true},
+
+		// existing string-match fallbacks still work
+		{"broken pipe text", errors.New("write tcp: broken pipe"), true},
+		{"connection reset text", errors.New("read tcp: connection reset by peer"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isIOError(c.err)
+			if got != c.want {
+				t.Errorf("isIOError(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Production TPD has been restarting every 30-40 seconds (`RestartCount: 556` over 6 hours on the prod host running develop tip `96ee3806c`). Two distinct panics, found by greping the container logs, are tearing down the process:

### 1. `pkg/cxo/skyobject/cache.go` — `(*Cache).Finc` to negative

Stack:
```
panic: Finc to negative for: <hash>
github.com/skycoin/skywire/pkg/cxo/skyobject.(*Cache).Finc cache.go:1189
github.com/skycoin/skywire/pkg/cxo/skyobject.(*Filler).apply fill.go:225
github.com/skycoin/skywire/pkg/cxo/skyobject.(*Filler).Run.func1 fill.go:297
```

The filling-refcount goes below zero — likely a duplicate `Finc` on a `Filler.incs` map, or an `Inc`/`Finc` mismatch across overlapping fillers. The historical behavior was to panic, which became visible after #2420 increased the rate of fill churn (or the bug was always latent and load surfaced it).

`Filler.apply` and `Filler.reject` already consume `Finc`'s error return and just log:
```go
if err := f.c.Finc(key, inc); err != nil {
    log.Printf("[CXO] filler apply: failed to increment ref count for %s: %v", key.Hex(), err)
}
```

So surfacing the inconsistency through that path costs nothing extra. The fix clamps `fc` to 0, logs the offending key + inc, and continues. Worst case is a leaked filling-item slot — orders of magnitude better than a process kill every 30 seconds.

### 2. `pkg/httputil/httputil.go` — `WriteJSON` panic on slow-client timeout

Stack:
```
panic: short write: i/o deadline reached
github.com/skycoin/skywire/pkg/httputil.WriteJSON httputil.go:50
github.com/skycoin/skywire/pkg/transport-discovery/api.(*API).getAllTransports endpoints.go:319
```

`getAllTransports` writes ~1MB JSON. On a slow client, `net/http`'s per-write deadline expires mid-response, and the response writer returns an error whose message is `"short write: i/o deadline reached"`. The body is `io.ErrShortWrite`'s text, but the **value** is `net/http.timeoutWriter`'s own error — `errors.Is(err, io.ErrShortWrite)` returns false. The fallback string match in `isIOError` only checked `"broken pipe"` and `"connection reset"`, so the discriminator returned `false` and `WriteJSON` ran the panic branch.

Added `"short write"`, `"i/o timeout"`, and `"deadline exceeded"` to the string-match fallback. `TestIsIOErrorShortWriteVariants` pins both sentinel and string-match cases.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./pkg/cxo/... ./pkg/httputil/...` clean.
- [x] `go test ./pkg/httputil/ ./pkg/cxo/skyobject/ ./pkg/transport-discovery/...` all pass.
- [x] `gofmt` clean.
- [x] New unit test `TestIsIOErrorShortWriteVariants` covers nil, all four current sentinels, the production short-write case, the i/o-timeout / deadline-exceeded text variants, and the existing broken-pipe / connection-reset cases.
- [ ] Post-deploy: TPD container `RestartCount` no longer climbing; `docker logs transport-discovery | grep -c panic:` reaches 0 within a few minutes.

## Notes

Neither bug is caused by the recent latency PRs (#2415, #2418, #2421); the panics' stacks make that explicit. They've just been hammering the deployment more visibly since latency persistence and outlier filtering landed back-to-back, because every TPD bounce now drops registration TTLs on visors that haven't re-pushed yet. Fixing these two restores normal TPD uptime.