### PR TITLE
cxo/node: guard fillHead nil-deref races (closeFiller + handleDelConn)

### DIFF
--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -217,6 +217,13 @@ func (n *nodeHead) handle() {
 func (f *fillHead) handleRequest(key cipher.SHA256) {
 	f.node().Debugln(FillPin, "[fill] handleRequest", key.Hex()[:7])
 
+	// closeFiller niled f.rqo before this message drained — drop the
+	// stale request rather than nil-deref. See closeFiller for the
+	// race: in-flight Filler goroutines can land here after the
+	// fillHead's lists were torn down.
+	if f.rqo == nil {
+		return
+	}
 	f.rqo.PushBack(key)
 	f.triggerRequest()
 }
@@ -225,6 +232,12 @@ func (f *fillHead) handleSuccess(c *Conn) {
 	f.node().Debugln(FillPin, "[fill] handleSuccess", c.String())
 
 	f.requesting--
+	if f.fc == nil {
+		// Same closeFiller race as handleRequest — production saw
+		// "panic: runtime error: invalid memory address" at the
+		// PushBack below until this guard landed.
+		return
+	}
 	f.fc.PushBack(c) // push
 	f.triggerRequest()
 }
@@ -259,6 +272,9 @@ func (f *fillHead) handleRequestFailure(fr failedRequest) {
 
 	}
 
+	if f.rqo == nil {
+		return // closeFiller race; see handleRequest
+	}
 	f.rqo.PushFront(fr.key) // shift
 	f.triggerRequest()
 
@@ -279,6 +295,9 @@ func (f *fillHead) handleReceivedRoot(cr connRoot) {
 		f.cs.addKnown(cr.c, cr.r.Seq) // add to known
 
 		if cr.r.Seq == f.r.r.Seq {
+			if f.fc == nil {
+				return // closeFiller race
+			}
 			f.fc.PushBack(cr.c) // add to filling connections
 			f.triggerRequest()
 			return
@@ -335,6 +354,18 @@ func (f *fillHead) maxParallel() (mp int) {
 }
 
 func (f *fillHead) createFiller(cr connRoot) {
+	// handleDelConn nils out connRoot.c when the source connection is
+	// removed (line 517 in handleDelConn). The connRoot may still
+	// have a non-zero r, so the f.p == (connRoot{}) check at
+	// handleFillingResult does NOT catch the nil-c case. Without
+	// this guard, cr.c.String() below nil-derefs and panics the
+	// process. The fill simply can't proceed without a source
+	// connection — drop it.
+	if cr.c == nil {
+		f.node().Debugln(FillPin, "[fill] createFiller: source connection gone, skipping",
+			cr.r.Short())
+		return
+	}
 	f.node().Debugln(FillPin, "[fill] createFiller", cr.c.String(),
 		cr.r.Short())
 


### PR DESCRIPTION
## Summary

Follow-up to #2422. After the Finc-clamp + short-write fixes deployed, prod TPD's `RestartCount` dropped from ~556/6h to 2/10min. The two remaining panics are nil-derefs in `pkg/cxo/node/head.go`:

### 1. `createFiller` line 338 — `cr.c.String()` on nil `*Conn`

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/skycoin/skywire/pkg/cxo/node.(*Conn).String(0x0)        conn.go:225
github.com/skycoin/skywire/pkg/cxo/node.(*fillHead).createFiller   head.go:338
github.com/skycoin/skywire/pkg/cxo/node.(*fillHead).handleFillingResult head.go:416
```

`handleDelConn` (head.go:517) sets `f.p.c = nil` when the source connection drops. `f.p.r` remains non-zero, so the `f.p == (connRoot{})` zero-value gate at `handleFillingResult` does **not** catch the nil-c case, and `createFiller(f.p)` runs with a nil source — `cr.c.String()` panics on the first line.

Fix: nil-c short-circuit at the top of `createFiller`. The fill can't proceed without a source connection — log and return.

### 2. `handleSuccess` line 228 (and three parallel sites) — `PushBack` on nil `*list.List`

```
panic: runtime error: invalid memory address or nil pointer dereference
container/list.(*List).PushBack(...)
github.com/skycoin/skywire/pkg/cxo/node.(*fillHead).handleSuccess  head.go:228
```

`closeFiller` (head.go:384) sets `f.rqo, f.fc, f.rq = nil, nil, nil`. Any in-flight Filler-goroutine messages still draining through `f.successq` / `f.requestq` / `f.failureq` after the close land on a nil list and panic.

Fix: nil-guard each `PushBack`/`PushFront` site (4 sites: `handleRequest`, `handleSuccess`, `handleRequestFailure`, `handleReceivedRoot`'s same-Seq branch). Same recovery as #2422's panic→drop pattern: the closed filler's work is no longer relevant.

## What this isn't

The "real" fix is to drain or signal-shutdown the channels before nilling state — that's a larger structural change to the fillHead's close protocol. These guards stop the process kill while preserving observability so a follow-up PR can address the underlying race without prod restarting every few minutes.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./pkg/cxo/...` clean.
- [x] `go test ./pkg/cxo/...` (including `pkg/cxo/node`'s own 8s suite) all pass.
- [x] `gofmt` clean.
- [ ] Post-deploy: `docker logs transport-discovery --since 10m | grep -c panic:` reaches 0 and `RestartCount` stops climbing.

## Sequencing

Sits cleanly on top of #2422 (already merged into develop at `80fef7159`).