### PR TITLE
transport-discovery: cap UpdateLatency at MaxReasonableRTTMs

### DIFF
--- a/pkg/transport-discovery/store/redis_bandwidth.go
+++ b/pkg/transport-discovery/store/redis_bandwidth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 // Bandwidth key generators
@@ -122,7 +123,17 @@ func (s *redisStore) UpdateLatency(ctx context.Context, transportID string, minM
 	// Defense-in-depth alongside the aggregator gate: any non-positive
 	// field means the snapshot is partial, so reject the whole update
 	// rather than persist a zero in a single field.
-	if minMS <= 0 || maxMS <= 0 || avgMS <= 0 {
+	//
+	// Upper bound: visors running pre-#2421 binaries don't filter
+	// straggler-pong outliers (35s+ RTT from a delayed pong) and push
+	// them via CXO. TPD must reject those at ingest, otherwise the
+	// 35-day lat:<id> retention pins a bogus Max for weeks regardless
+	// of how many later good samples land. transport.MaxReasonableRTTMs
+	// is the same 30s threshold the visor side enforces post-#2421.
+	if minMS <= 0 || maxMS <= 0 || avgMS <= 0 ||
+		minMS > transport.MaxReasonableRTTMs ||
+		maxMS > transport.MaxReasonableRTTMs ||
+		avgMS > transport.MaxReasonableRTTMs {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #2421 (visor-side outlier guard) and #2418 (lat:<id> persistence). Production observation:

- 1846 of 2050 transports (90%) carry latency post-#2418. ✓
- 0 zero-min records. ✓ (#2415 holding)
- **5 transports show max > 30s** — `124,156ms` worst — all written ~10h ago. They'll persist 35 days because the visor pushing them isn't running #2421's outlier filter, and TPD has no upper-bound check to drop them at ingest.

## Fix

Extend `UpdateLatency`'s existing `min/max/avg <= 0` guard with `> transport.MaxReasonableRTTMs` (the same 30s threshold the visor side uses post-#2421). The store package already imports `pkg/transport` via `redis_transport.go`, so the constant is free.

```go
if minMS <= 0 || maxMS <= 0 || avgMS <= 0 ||
    minMS > transport.MaxReasonableRTTMs ||
    maxMS > transport.MaxReasonableRTTMs ||
    avgMS > transport.MaxReasonableRTTMs {
    return nil
}
```

After this lands, old visors keep pushing bogus values, TPD silently drops them, and the next good sample from any peer overwrites the stale stored max — clearing the production outliers without waiting for visor rollout.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./pkg/transport-discovery/...` clean.
- [x] `go test ./pkg/transport-discovery/...` all pass.
- [x] `gofmt` clean.
- [ ] Post-deploy: `skywire cli tp metrics --by-transport --json | jq '[.[] | select(.latency.max > 30000000)] | length'` reaches 0 within ~5 min of any peer pushing a fresh sample for the affected transports.

## Notes

This is purely the symmetric ingest-side cap. The aggregator's `dispatchLeaf` already gates on `> 0` for all three fields; could grow the same upper-bound check there for consistency, but that needs a new `pkg/transport` import in `cxoaggregator` and the store-side guard alone is sufficient since `dispatchLeaf` is the only writer that calls `UpdateLatency`.