### PR TITLE
transport uptime: CXO-driven heartbeats + slot-accurate timeline + visor-published bitmap merge

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -563,7 +563,7 @@ func (s *memoryStore) RecordHeartbeat(context.Context, cipher.PubKey, string) er
 func (s *memoryStore) GetDailyTimeline(context.Context, string, time.Time) map[string]string {
 	return nil
 }
-func (s *memoryStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string) error {
+func (s *memoryStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string, time.Time) error {
 	return nil
 }
 func (s *memoryStore) GetTransportUptimeSummaries(context.Context, []uuid.UUID, bool, bool) ([]store.TransportUptimeSummary, error) {

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -566,6 +566,9 @@ func (s *memoryStore) GetDailyTimeline(context.Context, string, time.Time) map[s
 func (s *memoryStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string, time.Time) error {
 	return nil
 }
+func (s *memoryStore) IngestTransportTimeline(context.Context, uuid.UUID, string, []byte) error {
+	return nil
+}
 func (s *memoryStore) GetTransportUptimeSummaries(context.Context, []uuid.UUID, bool, bool) ([]store.TransportUptimeSummary, error) {
 	return nil, nil
 }

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -89,6 +89,10 @@ func (m *mockStore) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, _ s
 	return nil
 }
 
+func (m *mockStore) IngestTransportTimeline(_ context.Context, _ uuid.UUID, _ string, _ []byte) error {
+	return nil
+}
+
 func (m *mockStore) GetTransportUptimeSummaries(_ context.Context, _ []uuid.UUID, _ bool, _ bool) ([]tpdstore.TransportUptimeSummary, error) {
 	return nil, nil
 }

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -85,7 +85,7 @@ func (m *mockStore) GetDailyTimeline(_ context.Context, _ string, _ time.Time) m
 	return nil
 }
 
-func (m *mockStore) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, _ string) error {
+func (m *mockStore) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, _ string, _ time.Time) error {
 	return nil
 }
 

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -91,7 +91,7 @@ func (api *API) registerTransportV3(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, sEntry := range signed {
-		if err := api.store.RecordTransportHeartbeat(r.Context(), sEntry.Entry.ID, string(sEntry.Entry.Type)); err != nil {
+		if err := api.store.RecordTransportHeartbeat(r.Context(), sEntry.Entry.ID, string(sEntry.Entry.Type), time.Time{}); err != nil {
 			api.log(r).WithError(err).Debug("Failed to record transport heartbeat")
 		}
 	}
@@ -169,7 +169,7 @@ func (api *API) registerTransport(w http.ResponseWriter, r *http.Request) {
 		if entryVersion == "" && entry.Version != "" {
 			entryVersion = entry.Version
 		}
-		if err := api.store.RecordTransportHeartbeat(r.Context(), entry.Entry.ID, string(entry.Entry.Type)); err != nil {
+		if err := api.store.RecordTransportHeartbeat(r.Context(), entry.Entry.ID, string(entry.Entry.Type), time.Time{}); err != nil {
 			api.log(r).WithError(err).Debug("Failed to record transport heartbeat")
 		}
 	}

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -54,11 +54,15 @@ import (
 
 // Sink receives per-transport telemetry updates from visor TreeStore
 // feeds. The TPD's redis store satisfies this via UpdateBandwidth (per
-// reporter, cumulative counters) and UpdateLatency (per transport, RTT
-// min/max/avg in ms).
+// reporter, cumulative counters), UpdateLatency (per transport, RTT
+// min/max/avg in ms), and RecordTransportHeartbeat (per-transport
+// uptime — sets today's 5-min slot bit and the "online today" set
+// member; previously written only via the HTTP /transports/ register
+// path).
 type Sink interface {
 	UpdateBandwidth(ctx context.Context, transportID string, reporterPK cipher.PubKey, sent, recv uint64) error
 	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
+	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string) error
 }
 
 // BandwidthSink is retained as an alias for callers that only need the
@@ -79,6 +83,7 @@ type liveSnapshot struct {
 	LatencyMaxMS float64   `json:"latency_max_ms,omitempty"`
 	LatencyAvgMS float64   `json:"latency_avg_ms,omitempty"`
 	SampledAt    time.Time `json:"sampled_at"`
+	Type         string    `json:"type,omitempty"`
 }
 
 // Config configures the Aggregator.
@@ -366,6 +371,17 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 	if snap.LatencyMinMS > 0 && snap.LatencyMaxMS > 0 && snap.LatencyAvgMS > 0 {
 		if err := a.sink.UpdateLatency(ctx, id.String(), snap.LatencyMinMS, snap.LatencyMaxMS, snap.LatencyAvgMS); err != nil {
 			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: UpdateLatency failed")
+		}
+	}
+	// Heartbeat into the per-transport uptime tables (tp-uptime:*),
+	// previously written only by the HTTP /transports/ register path.
+	// Type is empty on snapshots from pre-uptime visors — skip those
+	// rather than push a heartbeat the store would have to drop on
+	// the type filter (RecordTransportHeartbeat early-returns on any
+	// non-p2p type, but routing here saves the redis round-trip).
+	if snap.Type != "" {
+		if err := a.sink.RecordTransportHeartbeat(ctx, id, snap.Type); err != nil {
+			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: RecordTransportHeartbeat failed")
 		}
 	}
 }

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -62,7 +62,10 @@ import (
 type Sink interface {
 	UpdateBandwidth(ctx context.Context, transportID string, reporterPK cipher.PubKey, sent, recv uint64) error
 	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
-	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string) error
+	// at is the visor-side observation time (snap.SampledAt), so a
+	// heartbeat that crosses a 5-minute slot boundary in transit
+	// still credits the slot the visor was actually online for.
+	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string, at time.Time) error
 }
 
 // BandwidthSink is retained as an alias for callers that only need the
@@ -380,7 +383,7 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 	// the type filter (RecordTransportHeartbeat early-returns on any
 	// non-p2p type, but routing here saves the redis round-trip).
 	if snap.Type != "" {
-		if err := a.sink.RecordTransportHeartbeat(ctx, id, snap.Type); err != nil {
+		if err := a.sink.RecordTransportHeartbeat(ctx, id, snap.Type, snap.SampledAt); err != nil {
 			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: RecordTransportHeartbeat failed")
 		}
 	}

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -66,6 +66,11 @@ type Sink interface {
 	// heartbeat that crosses a 5-minute slot boundary in transit
 	// still credits the slot the visor was actually online for.
 	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string, at time.Time) error
+	// IngestTransportTimeline OR-merges a visor-supplied 36-byte
+	// per-transport uptime bitmap into the persistent timeline for
+	// (tpID, date). Used by dispatchLeaf to absorb the
+	// transports/<id>/<date>/timeline leaves.
+	IngestTransportTimeline(ctx context.Context, tpID uuid.UUID, date string, bitmap []byte) error
 }
 
 // BandwidthSink is retained as an alias for callers that only need the
@@ -348,11 +353,24 @@ func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, 
 	}
 }
 
-// dispatchLeaf is the path → action dispatcher. Today it only
-// recognizes transports/<uuid>/current; tier and service bitmaps
-// arrive into the CXO cache but aren't yet written into TPD's redis
-// uptime tables.
+// dispatchLeaf is the path → action dispatcher. Recognized leaf
+// shapes:
+//
+//	transports/<uuid>/current             → bandwidth + latency + heartbeat
+//	transports/<uuid>/<YYYY-MM-DD>/timeline → per-transport uptime bitmap
+//
+// Tier and service bitmaps still flow through the CXO cache but
+// aren't yet projected into TPD's redis uptime tables.
 func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubKey) {
+	if tpID, date, ok := parseTransportTimelinePath(path); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.sink.IngestTransportTimeline(ctx, tpID, date, leaf); err != nil {
+			a.log.WithError(err).WithField("transport", tpID).WithField("date", date).
+				Debug("CXO aggregator: IngestTransportTimeline failed")
+		}
+		return
+	}
 	id, ok := parseCurrentTransportPath(path)
 	if !ok {
 		return
@@ -387,6 +405,41 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 			a.log.WithError(err).WithField("transport", id).Debug("CXO aggregator: RecordTransportHeartbeat failed")
 		}
 	}
+}
+
+// parseTransportTimelinePath returns the transport UUID and date for
+// paths shaped "transports/<uuid>/<YYYY-MM-DD>/timeline", or false
+// otherwise. Date format is validated as fixed-width 10 chars with
+// dashes at positions 4 and 7 — same shape MarshalBinary on a UTC
+// date emits via time.Format("2006-01-02").
+func parseTransportTimelinePath(path string) (uuid.UUID, string, bool) {
+	const prefix = "transports/"
+	const suffix = "/timeline"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return uuid.UUID{}, "", false
+	}
+	mid := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	parts := strings.Split(mid, "/")
+	if len(parts) != 2 {
+		return uuid.UUID{}, "", false
+	}
+	id, err := uuid.Parse(parts[0])
+	if err != nil {
+		return uuid.UUID{}, "", false
+	}
+	date := parts[1]
+	if len(date) != len("2006-01-02") || date[4] != '-' || date[7] != '-' {
+		return uuid.UUID{}, "", false
+	}
+	for i, c := range date {
+		if i == 4 || i == 7 {
+			continue
+		}
+		if c < '0' || c > '9' {
+			return uuid.UUID{}, "", false
+		}
+	}
+	return id, date, true
 }
 
 // parseCurrentTransportPath returns the transport UUID for paths

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -45,6 +45,7 @@ type recordingSink struct {
 	mu         sync.Mutex
 	bandwidths int
 	latencies  []struct{ min, max, avg float64 }
+	heartbeats []struct{ tpType string }
 }
 
 func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey, _, _ uint64) error {
@@ -56,6 +57,12 @@ func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.Pu
 func (s *recordingSink) UpdateLatency(_ context.Context, _ string, minMS, maxMS, avgMS float64) error {
 	s.mu.Lock()
 	s.latencies = append(s.latencies, struct{ min, max, avg float64 }{minMS, maxMS, avgMS})
+	s.mu.Unlock()
+	return nil
+}
+func (s *recordingSink) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, tpType string) error {
+	s.mu.Lock()
+	s.heartbeats = append(s.heartbeats, struct{ tpType string }{tpType})
 	s.mu.Unlock()
 	return nil
 }
@@ -113,6 +120,68 @@ func TestDispatchLeafLatencyGate(t *testing.T) {
 			}
 			if !c.wantLat && len(sink.latencies) != 0 {
 				t.Errorf("expected latency dropped, got %+v", sink.latencies)
+			}
+		})
+	}
+}
+
+// Heartbeats are gated on snap.Type — old visors that don't carry
+// the field must not produce a sink call (the store would early-return
+// on the type filter, but routing here saves the round-trip and keeps
+// the dispatch contract observable).
+func TestDispatchLeafHeartbeatGate(t *testing.T) {
+	id := uuid.New()
+	pk := cipher.PubKey{}
+	now := time.Now().UTC()
+
+	cases := []struct {
+		name       string
+		snap       liveSnapshot
+		wantHB     bool
+		wantHBType string
+	}{
+		{
+			name:   "no type — pre-uptime visor, skip heartbeat",
+			snap:   liveSnapshot{SentBytes: 100, SampledAt: now},
+			wantHB: false,
+		},
+		{
+			name:       "stcpr — record heartbeat",
+			snap:       liveSnapshot{Type: "stcpr", SentBytes: 100, SampledAt: now},
+			wantHB:     true,
+			wantHBType: "stcpr",
+		},
+		{
+			name:       "sudph — record heartbeat",
+			snap:       liveSnapshot{Type: "sudph", SentBytes: 100, SampledAt: now},
+			wantHB:     true,
+			wantHBType: "sudph",
+		},
+		{
+			name:       "type pass-through (filter happens in store, not dispatch)",
+			snap:       liveSnapshot{Type: "dmsg", SampledAt: now},
+			wantHB:     true,
+			wantHBType: "dmsg",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sink := &recordingSink{}
+			a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+			leaf, err := json.Marshal(c.snap)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			a.dispatchLeaf("transports/"+id.String()+"/current", leaf, pk)
+			if c.wantHB {
+				if len(sink.heartbeats) != 1 {
+					t.Fatalf("expected 1 heartbeat call, got %d", len(sink.heartbeats))
+				}
+				if got := sink.heartbeats[0].tpType; got != c.wantHBType {
+					t.Errorf("heartbeat type = %q, want %q", got, c.wantHBType)
+				}
+			} else if len(sink.heartbeats) != 0 {
+				t.Errorf("expected no heartbeat, got %+v", sink.heartbeats)
 			}
 		})
 	}

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -39,6 +39,85 @@ func TestParseCurrentTransportPath(t *testing.T) {
 	}
 }
 
+func TestParseTransportTimelinePath(t *testing.T) {
+	id := uuid.New()
+	cases := []struct {
+		path     string
+		want     bool
+		wantDate string
+	}{
+		{"transports/" + id.String() + "/2026-05-04/timeline", true, "2026-05-04"},
+		{"transports/" + id.String() + "/current", false, ""},
+		{"transports/" + id.String() + "/2026-05-04", false, ""},
+		{"transports/" + id.String() + "/2026/05/04/timeline", false, ""},
+		{"transports/not-a-uuid/2026-05-04/timeline", false, ""},
+		{"transports/" + id.String() + "/26-05-04/timeline", false, ""},
+		{"transports/" + id.String() + "/2026-AB-04/timeline", false, ""},
+		{"tiers/dmsg/2026-05-04/timeline", false, ""},
+		{"", false, ""},
+	}
+	for _, c := range cases {
+		gotID, gotDate, ok := parseTransportTimelinePath(c.path)
+		if ok != c.want {
+			t.Errorf("parseTransportTimelinePath(%q) ok = %v, want %v", c.path, ok, c.want)
+			continue
+		}
+		if c.want {
+			if gotID != id {
+				t.Errorf("parseTransportTimelinePath(%q) id = %v, want %v", c.path, gotID, id)
+			}
+			if gotDate != c.wantDate {
+				t.Errorf("parseTransportTimelinePath(%q) date = %q, want %q", c.path, gotDate, c.wantDate)
+			}
+		}
+	}
+}
+
+// Dispatcher routes timeline-shaped leaves into IngestTransportTimeline
+// without disturbing the bandwidth/latency/heartbeat path. Verifies
+// payload pass-through (the leaf bytes are the bitmap; no JSON parse).
+func TestDispatchLeafTimeline(t *testing.T) {
+	id := uuid.New()
+	pk := cipher.PubKey{}
+	bitmap := make([]byte, 36)
+	for i := range bitmap {
+		bitmap[i] = byte(i)
+	}
+
+	sink := &recordingSink{}
+	a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+	a.dispatchLeaf("transports/"+id.String()+"/2026-05-04/timeline", bitmap, pk)
+
+	if len(sink.timelines) != 1 {
+		t.Fatalf("expected 1 timeline call, got %d", len(sink.timelines))
+	}
+	if sink.timelines[0].tpID != id {
+		t.Errorf("tpID = %v, want %v", sink.timelines[0].tpID, id)
+	}
+	if sink.timelines[0].date != "2026-05-04" {
+		t.Errorf("date = %q, want %q", sink.timelines[0].date, "2026-05-04")
+	}
+	if !bytesEqual(sink.timelines[0].bitmap, bitmap) {
+		t.Errorf("bitmap mismatch: got %x want %x", sink.timelines[0].bitmap, bitmap)
+	}
+	// No bandwidth/latency/heartbeat side-effects.
+	if sink.bandwidths != 0 || len(sink.latencies) != 0 || len(sink.heartbeats) != 0 {
+		t.Errorf("unexpected side effects: bw=%d lat=%d hb=%d", sink.bandwidths, len(sink.latencies), len(sink.heartbeats))
+	}
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // recordingSink captures sink calls so tests can assert what dispatchLeaf
 // chose to forward (vs drop on the partial-zero gate).
 type recordingSink struct {
@@ -48,6 +127,11 @@ type recordingSink struct {
 	heartbeats []struct {
 		tpType string
 		at     time.Time
+	}
+	timelines []struct {
+		tpID   uuid.UUID
+		date   string
+		bitmap []byte
 	}
 }
 
@@ -69,6 +153,17 @@ func (s *recordingSink) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID,
 		tpType string
 		at     time.Time
 	}{tpType, at})
+	s.mu.Unlock()
+	return nil
+}
+func (s *recordingSink) IngestTransportTimeline(_ context.Context, tpID uuid.UUID, date string, bitmap []byte) error {
+	s.mu.Lock()
+	cp := append([]byte(nil), bitmap...)
+	s.timelines = append(s.timelines, struct {
+		tpID   uuid.UUID
+		date   string
+		bitmap []byte
+	}{tpID, date, cp})
 	s.mu.Unlock()
 	return nil
 }

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -45,7 +45,10 @@ type recordingSink struct {
 	mu         sync.Mutex
 	bandwidths int
 	latencies  []struct{ min, max, avg float64 }
-	heartbeats []struct{ tpType string }
+	heartbeats []struct {
+		tpType string
+		at     time.Time
+	}
 }
 
 func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey, _, _ uint64) error {
@@ -60,9 +63,12 @@ func (s *recordingSink) UpdateLatency(_ context.Context, _ string, minMS, maxMS,
 	s.mu.Unlock()
 	return nil
 }
-func (s *recordingSink) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, tpType string) error {
+func (s *recordingSink) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, tpType string, at time.Time) error {
 	s.mu.Lock()
-	s.heartbeats = append(s.heartbeats, struct{ tpType string }{tpType})
+	s.heartbeats = append(s.heartbeats, struct {
+		tpType string
+		at     time.Time
+	}{tpType, at})
 	s.mu.Unlock()
 	return nil
 }
@@ -179,6 +185,13 @@ func TestDispatchLeafHeartbeatGate(t *testing.T) {
 				}
 				if got := sink.heartbeats[0].tpType; got != c.wantHBType {
 					t.Errorf("heartbeat type = %q, want %q", got, c.wantHBType)
+				}
+				// Slot accuracy: the at field must be the snap's
+				// SampledAt, not a re-clocked time.Now() inside the
+				// dispatcher. Otherwise leaf-arrival skew would
+				// shift the slot bit.
+				if !sink.heartbeats[0].at.Equal(c.snap.SampledAt) {
+					t.Errorf("heartbeat at = %v, want SampledAt %v", sink.heartbeats[0].at, c.snap.SampledAt)
 				}
 			} else if len(sink.heartbeats) != 0 {
 				t.Errorf("expected no heartbeat, got %+v", sink.heartbeats)

--- a/pkg/transport-discovery/store/memory_store.go
+++ b/pkg/transport-discovery/store/memory_store.go
@@ -202,7 +202,7 @@ func (s *memoryStore) GetDailyTimeline(_ context.Context, _ string, _ time.Time)
 	return nil
 }
 
-func (s *memoryStore) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, _ string) error {
+func (s *memoryStore) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, _ string, _ time.Time) error {
 	return nil
 }
 

--- a/pkg/transport-discovery/store/memory_store.go
+++ b/pkg/transport-discovery/store/memory_store.go
@@ -206,6 +206,10 @@ func (s *memoryStore) RecordTransportHeartbeat(_ context.Context, _ uuid.UUID, _
 	return nil
 }
 
+func (s *memoryStore) IngestTransportTimeline(_ context.Context, _ uuid.UUID, _ string, _ []byte) error {
+	return nil
+}
+
 func (s *memoryStore) GetTransportUptimeSummaries(_ context.Context, _ []uuid.UUID, _ bool, _ bool) ([]TransportUptimeSummary, error) {
 	return []TransportUptimeSummary{}, nil
 }

--- a/pkg/transport-discovery/store/redis_uptime.go
+++ b/pkg/transport-discovery/store/redis_uptime.go
@@ -220,6 +220,59 @@ func (s *redisStore) RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUI
 	return err
 }
 
+// transportTimelineBitmapBytes is the expected wire size of a single
+// day's bitmap (288 5-min slots, MSB-first, matches the visor side).
+const transportTimelineBitmapBytes = 36
+
+// IngestTransportTimeline OR-merges a visor-supplied per-transport
+// uptime bitmap into TPD's stored bitmap for that day. Both edges of
+// a transport publish their own bitmap independently, and the existing
+// per-tick heartbeat path also sets bits in the same key, so UNION
+// semantics (rather than overwrite) keeps every observation.
+//
+// Implementation: write the incoming blob into a short-lived key,
+// BITOP OR into the persistent key, then clean up. Server-side OR is
+// O(36 bytes) and avoids any client-side read-modify-write race.
+func (s *redisStore) IngestTransportTimeline(ctx context.Context, tpID uuid.UUID, date string, bitmap []byte) error {
+	if len(bitmap) != transportTimelineBitmapBytes {
+		return fmt.Errorf("transport timeline: expected %d bytes, got %d", transportTimelineBitmapBytes, len(bitmap))
+	}
+	if !validDateKey(date) {
+		return fmt.Errorf("transport timeline: invalid date %q", date)
+	}
+	idStr := tpID.String()
+	tlKey := tpUptimeTimelineKey(idStr, date)
+	stagingKey := tlKey + ":ingest"
+
+	pipe := s.client.Pipeline()
+	pipe.Set(ctx, stagingKey, string(bitmap), time.Minute)
+	pipe.BitOpOr(ctx, tlKey, tlKey, stagingKey)
+	pipe.Expire(ctx, tlKey, 8*24*time.Hour)
+	pipe.Del(ctx, stagingKey)
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// validDateKey rejects anything that isn't a YYYY-MM-DD string. Defends
+// the redis keyspace against malformed leaf paths.
+func validDateKey(date string) bool {
+	if len(date) != len("2006-01-02") {
+		return false
+	}
+	if date[4] != '-' || date[7] != '-' {
+		return false
+	}
+	for i, c := range date {
+		if i == 4 || i == 7 {
+			continue
+		}
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *redisStore) GetTransportUptimeSummaries(ctx context.Context, tpIDs []uuid.UUID, v2 bool, timeline bool) ([]TransportUptimeSummary, error) {
 	now := time.Now().UTC()
 	today := now.Format("2006-01-02")

--- a/pkg/transport-discovery/store/redis_uptime.go
+++ b/pkg/transport-discovery/store/redis_uptime.go
@@ -188,14 +188,17 @@ func tpUptimeTimelineKey(tpID string, date string) string {
 	return fmt.Sprintf("%s:tp-uptime:%s:%s:timeline", serviceName, tpID, date)
 }
 
-func (s *redisStore) RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string) error {
+func (s *redisStore) RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string, at time.Time) error {
 	// Only track p2p transport types.
 	if tpType != "stcpr" && tpType != "sudph" {
 		return nil
 	}
 
-	now := time.Now().UTC()
-	date := now.Format("2006-01-02")
+	if at.IsZero() {
+		at = time.Now()
+	}
+	at = at.UTC()
+	date := at.Format("2006-01-02")
 	idStr := tpID.String()
 	key := tpUptimeKey(idStr, date)
 
@@ -203,14 +206,14 @@ func (s *redisStore) RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUI
 
 	pipe.HIncrBy(ctx, key, "count", 1)
 	pipe.HSet(ctx, key, "type", tpType)
-	pipe.HSet(ctx, key, "last_seen", now.Unix())
+	pipe.HSet(ctx, key, "last_seen", at.Unix())
 	pipe.Expire(ctx, key, 8*24*time.Hour)
 
 	pipe.SAdd(ctx, tpUptimeOnlineKey(date), idStr)
 	pipe.Expire(ctx, tpUptimeOnlineKey(date), 8*24*time.Hour)
 
 	tlKey := tpUptimeTimelineKey(idStr, date)
-	pipe.SetBit(ctx, tlKey, currentTimelineSlot(now), 1)
+	pipe.SetBit(ctx, tlKey, currentTimelineSlot(at), 1)
 	pipe.Expire(ctx, tlKey, 8*24*time.Hour)
 
 	_, err := pipe.Exec(ctx)

--- a/pkg/transport-discovery/store/store.go
+++ b/pkg/transport-discovery/store/store.go
@@ -194,7 +194,12 @@ type TransportStore interface {
 	RecordHeartbeat(ctx context.Context, pk cipher.PubKey, version string) error
 	GetDailyTimeline(ctx context.Context, pkHex string, now time.Time) map[string]string
 	// Transport uptime tracking (stcpr/sudph only).
-	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string) error
+	// at is the time the heartbeat was *observed* on the visor side
+	// (snap.SampledAt for the CXO path, time.Now() for the HTTP
+	// register path); the slot bit and date bucket derive from it,
+	// so leaf-arrival skew that crosses a 5-minute boundary still
+	// credits the correct slot. Zero time falls back to time.Now().
+	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string, at time.Time) error
 	GetTransportUptimeSummaries(ctx context.Context, tpIDs []uuid.UUID, v2 bool, timeline bool) ([]TransportUptimeSummary, error)
 	GetTransportUptimeByVisor(ctx context.Context, pk cipher.PubKey, v2 bool, timeline bool) ([]TransportUptimeSummary, error)
 	GetTransportDailyTimeline(ctx context.Context, tpID string, now time.Time) map[string]string

--- a/pkg/transport-discovery/store/store.go
+++ b/pkg/transport-discovery/store/store.go
@@ -200,6 +200,13 @@ type TransportStore interface {
 	// so leaf-arrival skew that crosses a 5-minute boundary still
 	// credits the correct slot. Zero time falls back to time.Now().
 	RecordTransportHeartbeat(ctx context.Context, tpID uuid.UUID, tpType string, at time.Time) error
+	// IngestTransportTimeline OR-merges a visor-supplied per-transport
+	// uptime bitmap into the persistent timeline. Used by the CXO
+	// aggregator to absorb the visor's locally-tracked bitmap, which
+	// captures slots TPD's heartbeat path never observed (e.g.
+	// during TPD downtime). bitmap must be 36 bytes; date is the
+	// UTC YYYY-MM-DD the bitmap covers.
+	IngestTransportTimeline(ctx context.Context, tpID uuid.UUID, date string, bitmap []byte) error
 	GetTransportUptimeSummaries(ctx context.Context, tpIDs []uuid.UUID, v2 bool, timeline bool) ([]TransportUptimeSummary, error)
 	GetTransportUptimeByVisor(ctx context.Context, pk cipher.PubKey, v2 bool, timeline bool) ([]TransportUptimeSummary, error)
 	GetTransportDailyTimeline(ctx context.Context, tpID string, now time.Time) map[string]string

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -891,6 +891,9 @@ func (s *calcMemStore) GetDailyTimeline(context.Context, string, time.Time) map[
 func (s *calcMemStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string, time.Time) error {
 	return nil
 }
+func (s *calcMemStore) IngestTransportTimeline(context.Context, uuid.UUID, string, []byte) error {
+	return nil
+}
 func (s *calcMemStore) GetTransportUptimeSummaries(context.Context, []uuid.UUID, bool, bool) ([]tpdstore.TransportUptimeSummary, error) {
 	return nil, nil
 }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -888,7 +888,7 @@ func (s *calcMemStore) RecordHeartbeat(context.Context, cipher.PubKey, string) e
 func (s *calcMemStore) GetDailyTimeline(context.Context, string, time.Time) map[string]string {
 	return nil
 }
-func (s *calcMemStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string) error {
+func (s *calcMemStore) RecordTransportHeartbeat(context.Context, uuid.UUID, string, time.Time) error {
 	return nil
 }
 func (s *calcMemStore) GetTransportUptimeSummaries(context.Context, []uuid.UUID, bool, bool) ([]tpdstore.TransportUptimeSummary, error) {

--- a/pkg/visor/stats/schema.go
+++ b/pkg/visor/stats/schema.go
@@ -33,6 +33,12 @@ type TransportRecord struct {
 }
 
 // LiveSnapshot is the most recent observation for a transport.
+//
+// Type carries the wire-protocol type ("stcpr"/"sudph"/"stcp"/"dmsg")
+// so TPD's CXO aggregator can record per-transport uptime heartbeats
+// without a redis lookup. Empty on snapshots produced before the
+// field was added — TPD treats that as "skip uptime, but bandwidth
+// and latency still apply" so old visors keep working.
 type LiveSnapshot struct {
 	SentBytes    uint64    `json:"sent_bytes"`
 	RecvBytes    uint64    `json:"recv_bytes"`
@@ -40,6 +46,7 @@ type LiveSnapshot struct {
 	LatencyMaxMS float64   `json:"latency_max_ms,omitempty"`
 	LatencyAvgMS float64   `json:"latency_avg_ms,omitempty"`
 	SampledAt    time.Time `json:"sampled_at"`
+	Type         string    `json:"type,omitempty"`
 }
 
 // DailyRollup is the sealed per-day view. Bandwidth values are deltas

--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -11,10 +11,11 @@
 //
 // Path conventions (matching §07 of skywire-specs):
 //
-//	transports/<uuid>/current          → live snapshot (JSON)
-//	transports/<uuid>/<YYYY-MM-DD>     → that day's rollup (JSON)
-//	tiers/<tier>/<YYYY-MM-DD>          → 36-byte bitmap
-//	services/<slug>/<YYYY-MM-DD>       → 36-byte bitmap
+//	transports/<uuid>/current                 → live snapshot (JSON)
+//	transports/<uuid>/<YYYY-MM-DD>            → that day's rollup (JSON)
+//	transports/<uuid>/<YYYY-MM-DD>/timeline   → 36-byte uptime bitmap
+//	tiers/<tier>/<YYYY-MM-DD>                 → 36-byte bitmap
+//	services/<slug>/<YYYY-MM-DD>              → 36-byte bitmap
 //
 // Sinks are expected to be non-blocking; the Tracker invokes them
 // from the sampler goroutine and does not wait for completion.
@@ -149,6 +150,33 @@ func HydrateSink(store *Store, sink Sink, publishWindowDays int, now time.Time) 
 			pushed++
 		}
 	}
+
+	// Per-transport timeline bitmaps: same wire shape as tier/service.
+	tpIDs, err := store.TransportBitmapIDs()
+	if err != nil {
+		return pushed, fmt.Errorf("hydrate transport bitmaps: %w", err)
+	}
+	for _, id := range tpIDs {
+		dates, err := store.TransportBitmapDates(id)
+		if err != nil {
+			continue
+		}
+		for _, date := range dates {
+			if date < cutoff {
+				continue
+			}
+			d, err := time.Parse(dateFmt, date)
+			if err != nil {
+				continue
+			}
+			bm, err := store.TransportBitmap(id, d)
+			if err != nil {
+				continue
+			}
+			sink.Put(transportTimelinePath(id, date), bm)
+			pushed++
+		}
+	}
 	return pushed, nil
 }
 
@@ -161,6 +189,10 @@ func currentTransportPath(id string) string {
 
 func dailyTransportPath(id, date string) string {
 	return "transports/" + id + "/" + date
+}
+
+func transportTimelinePath(id, date string) string {
+	return "transports/" + id + "/" + date + "/timeline"
 }
 
 func tierBitmapPath(tier, date string) string {

--- a/pkg/visor/stats/store.go
+++ b/pkg/visor/stats/store.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	bucketMeta       = []byte("meta")
-	bucketTransports = []byte("transports")
-	bucketTiers      = []byte("tiers")
-	bucketServices   = []byte("services")
+	bucketMeta             = []byte("meta")
+	bucketTransports       = []byte("transports")
+	bucketTiers            = []byte("tiers")
+	bucketServices         = []byte("services")
+	bucketTransportBitmaps = []byte("transport_bitmaps")
 
 	keySchemaVersion = []byte("schema_version")
 	keyCreatedAt     = []byte("created_at")
@@ -50,7 +51,12 @@ func OpenStore(path string) (*Store, error) {
 	}
 
 	if err := db.Update(func(tx *bbolt.Tx) error {
-		for _, b := range [][]byte{bucketMeta, bucketTransports, bucketTiers, bucketServices} {
+		// Adding bucketTransportBitmaps preserves SchemaVersion: existing
+		// stores at version 1 simply gain the new (empty) bucket on
+		// next open. CreateBucketIfNotExists is idempotent and the
+		// version check below only fires when the on-disk version
+		// doesn't match the binary's, so this is forward-compatible.
+		for _, b := range [][]byte{bucketMeta, bucketTransports, bucketTiers, bucketServices, bucketTransportBitmaps} {
 			if _, err := tx.CreateBucketIfNotExists(b); err != nil {
 				return fmt.Errorf("create bucket %s: %w", b, err)
 			}
@@ -159,6 +165,15 @@ func (s *Store) MarkServiceSlot(service string, date time.Time, slot int) error 
 	return s.markSlot(bucketServices, service, date, slot)
 }
 
+// MarkTransportSlot is the per-transport analog of MarkTierSlot. The
+// transport ID (UUID string) is the sub-bucket key. Same wire format
+// as the tier/service bitmaps — 36 raw bytes, MSB-first, 288 5-min
+// slots — and bit-identical to TPD's tp-uptime:<id>:<date>:timeline
+// redis bitmap so the two views can be ORed without translation.
+func (s *Store) MarkTransportSlot(tpID string, date time.Time, slot int) error {
+	return s.markSlot(bucketTransportBitmaps, tpID, date, slot)
+}
+
 func (s *Store) markSlot(top []byte, name string, date time.Time, slot int) error {
 	if slot < 0 || slot >= SlotsPerDay {
 		return fmt.Errorf("stats: slot %d out of range", slot)
@@ -191,6 +206,11 @@ func (s *Store) ServiceBitmap(service string, date time.Time) ([]byte, error) {
 	return s.getBitmap(bucketServices, service, date)
 }
 
+// TransportBitmap is the per-transport analog of TierBitmap.
+func (s *Store) TransportBitmap(tpID string, date time.Time) ([]byte, error) {
+	return s.getBitmap(bucketTransportBitmaps, tpID, date)
+}
+
 func (s *Store) getBitmap(top []byte, name string, date time.Time) ([]byte, error) {
 	dateKey := []byte(date.UTC().Format(dateFmt))
 	out := make([]byte, BitmapSize)
@@ -217,6 +237,11 @@ func (s *Store) TierDates(tier string) ([]string, error) {
 // ServiceDates is the per-service analog of TierDates.
 func (s *Store) ServiceDates(service string) ([]string, error) {
 	return s.listDates(bucketServices, service)
+}
+
+// TransportBitmapDates is the per-transport analog of TierDates.
+func (s *Store) TransportBitmapDates(tpID string) ([]string, error) {
+	return s.listDates(bucketTransportBitmaps, tpID)
 }
 
 func (s *Store) listDates(top []byte, name string) ([]string, error) {
@@ -246,6 +271,13 @@ func (s *Store) ServiceNames() ([]string, error) {
 	return s.listNames(bucketServices)
 }
 
+// TransportBitmapIDs lists every transport ID with a stored bitmap.
+// Returned values are the UUID strings, suitable for re-keying the
+// sink path (transports/<id>/<date>/timeline).
+func (s *Store) TransportBitmapIDs() ([]string, error) {
+	return s.listNames(bucketTransportBitmaps)
+}
+
 func (s *Store) listNames(top []byte) ([]string, error) {
 	var names []string
 	err := s.db.View(func(tx *bbolt.Tx) error {
@@ -265,7 +297,7 @@ func (s *Store) PruneBitmaps(cutoff time.Time) (int, error) {
 	cutoffKey := cutoff.UTC().Format(dateFmt)
 	removed := 0
 	err := s.db.Update(func(tx *bbolt.Tx) error {
-		for _, top := range [][]byte{bucketTiers, bucketServices} {
+		for _, top := range [][]byte{bucketTiers, bucketServices, bucketTransportBitmaps} {
 			b := tx.Bucket(top)
 			if err := b.ForEach(func(name, _ []byte) error {
 				sub := b.Bucket(name)

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -309,6 +309,7 @@ func (t *Tracker) recordTransport(tp TransportProbe, now time.Time, today string
 		LatencyMaxMS: tp.LatencyMS.Max,
 		LatencyAvgMS: tp.LatencyMS.Avg,
 		SampledAt:    now,
+		Type:         rec.Type,
 	}
 
 	t.mu.Lock()

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -352,6 +352,19 @@ func (t *Tracker) recordTransport(tp TransportProbe, now time.Time, today string
 	if data, err := json.Marshal(row); err == nil {
 		t.sinkPut(dailyTransportPath(idStr, today), data)
 	}
+
+	// Per-transport uptime bitmap: set this tick's 5-min slot and
+	// mirror the post-update bitmap. CXO content-addressing means an
+	// unchanged bitmap (subsequent ticks within the same slot)
+	// produces a stable Root and no wire republish — only slot
+	// rollovers actually transit DMSG.
+	slot := SlotForTime(now)
+	if err := t.store.MarkTransportSlot(idStr, now, slot); err != nil {
+		t.log.WithError(err).WithField("tp_id", idStr).
+			Debug("Stats: MarkTransportSlot failed")
+	} else if bm, bErr := t.store.TransportBitmap(idStr, now); bErr == nil {
+		t.sinkPut(transportTimelinePath(idStr, today), bm)
+	}
 	return nil
 }
 
@@ -427,6 +440,7 @@ func (t *Tracker) runRetention(now time.Time) {
 		}
 		for date := range droppedFromBolt {
 			t.sinkDelete(dailyTransportPath(rec.ID.String(), date))
+			t.sinkDelete(transportTimelinePath(rec.ID.String(), date))
 		}
 		if len(trimmed) != len(rec.Daily) {
 			rec.Daily = trimmed
@@ -465,6 +479,7 @@ func (t *Tracker) sinkPruneOutsidePublishWindow(now time.Time) {
 		for _, d := range rec.Daily {
 			if d.Date < publishCutoff {
 				t.sinkDelete(dailyTransportPath(rec.ID.String(), d.Date))
+				t.sinkDelete(transportTimelinePath(rec.ID.String(), d.Date))
 			}
 		}
 	}
@@ -499,6 +514,27 @@ func (t *Tracker) sinkPruneOutsidePublishWindow(now time.Time) {
 		for _, d := range dates {
 			if d < publishCutoff {
 				t.sinkDelete(serviceBitmapPath(svc, d))
+			}
+		}
+	}
+
+	// Transport timeline bitmaps. Walk the bucket directly rather
+	// than rec.Daily — bitmaps can persist for transports whose
+	// TransportRecord was deleted (e.g. closed transports during
+	// retention) until the bbolt prune sweep drops them.
+	tpIDs, err := t.store.TransportBitmapIDs()
+	if err != nil {
+		t.log.WithError(err).Warn("Stats: enumerate transport bitmaps for publish-window prune failed")
+	}
+	for _, id := range tpIDs {
+		dates, dErr := t.store.TransportBitmapDates(id)
+		if dErr != nil {
+			t.log.WithError(dErr).WithField("tp_id", id).Debug("Stats: TransportBitmapDates failed during prune")
+			continue
+		}
+		for _, d := range dates {
+			if d < publishCutoff {
+				t.sinkDelete(transportTimelinePath(id, d))
 			}
 		}
 	}


### PR DESCRIPTION
Three stacked commits closing the TODO at `pkg/transport-discovery/cxoaggregator/aggregator.go:walkAndDispatch`. Each commit stands alone; together they make CXO the symmetric write side for transport uptime, parallel to bandwidth and latency.

## 1. \`a19b8045b\` — heartbeat ingest from \`current\` leaves

Every visor sampler tick already publishes `transports/<id>/current` (bandwidth + latency live snapshot). After this commit, that same dispatch path also feeds `RecordTransportHeartbeat` — until now the only writer was `POST /transports/` register. Wire shape: added `Type string` (omitempty) to `LiveSnapshot` on both visor and TPD sides; populated from existing `TransportRecord.Type`. `dispatchLeaf` gates the heartbeat call on `snap.Type != ""` so older visors don't generate sink no-ops.

## 2. \`47080f79b\` — slot-accurate timeline via \`SampledAt\`

`RecordTransportHeartbeat` was using `time.Now()` internally, so a leaf in transit across a 5-minute slot boundary credited the wrong slot. Plumb the visor's observation time end to end: `Sink.RecordTransportHeartbeat` gains an `at time.Time` parameter; `redisStore` consumes it for date / slot / `last_seen`, falling back to `time.Now()` on `at.IsZero()`. HTTP path passes `time.Time{}` (no behavior change — register is observed at receipt). CXO path passes `snap.SampledAt`. All four stub implementations (memory store, mocks, route-finder, cli/route, rpcgrpc) updated for interface conformance.

## 3. \`c67b87935\` — visor publishes a per-transport uptime bitmap; TPD OR-merges at ingest

Per-tick heartbeats only set slots the dispatcher observes in real time — they miss any slot the visor was online for but TPD never received an event (TPD restart, partition, subscriber lag). Mirror the existing tier/service bitmap pattern for transports.

**Visor side (\`pkg/visor/stats\`):**
- New bbolt bucket \`transport_bitmaps\`. Schema version stays at 1 — \`OpenStore\` adds the bucket lazily; existing stores upgrade in place, no migration.
- \`Store.MarkTransportSlot\` / \`TransportBitmap\` / \`TransportBitmapIDs\` / \`TransportBitmapDates\` parallel the tier/service helpers; \`PruneBitmaps\` sweeps the new bucket too.
- \`Tracker.recordTransport\` sets this tick's 5-min slot bit and mirrors the post-update bitmap to sink at \`transports/<id>/<date>/timeline\`. CXO content-addressing means unchanged bitmaps (subsequent ticks within the same slot) don't republish.
- \`HydrateSink\` includes the new bucket so cold subscribers see the rolling window. \`runRetention\` and \`sinkPruneOutsidePublishWindow\` keep the sink view bounded.

**TPD side (\`pkg/transport-discovery\`):**
- \`Sink.IngestTransportTimeline(ctx, tpID, date, bitmap []byte)\` added.
- \`redisStore\` implementation OR-merges the incoming 36-byte bitmap into \`tp-uptime:<id>:<date>:timeline\` via a staging key + BITOP OR — server-side, O(36 bytes), no read-modify-write race, 8-day TTL preserved, date format validated.
- \`parseTransportTimelinePath\` parses \`transports/<uuid>/<YYYY-MM-DD>/timeline\` (UUID + date format validated) and routes early in \`dispatchLeaf\` so the bitmap bytes pass through raw (no JSON decode).
- \`memoryStore\` and four other stub implementations gain no-op stubs.

## End state

\`tp-uptime:<id>:<date>:timeline\` is populated by three converging sources — HTTP register cycles, per-tick CXO heartbeats, and the visor's own slot-accurate bitmap merged on each leaf arrival. UNION semantics ensure a slot stays set if any of the three saw the visor online for it.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./pkg/transport-discovery/... ./pkg/visor/... ./pkg/route-finder/... ./pkg/cxo/...\` all pass.
- [x] \`gofmt\` clean across \`pkg/\` and \`cmd/\`.
- [x] New unit tests:
  - \`TestDispatchLeafHeartbeatGate\` — type gate (skip on empty), stcpr/sudph record, pass-through other type, AND \`at\` equality with \`snap.SampledAt\` (slot-accuracy contract).
  - \`TestParseTransportTimelinePath\` — accepted shape, malformed UUID, malformed date, alternative path prefixes.
  - \`TestDispatchLeafTimeline\` — bitmap bytes pass through to \`IngestTransportTimeline\` unchanged; no bandwidth/latency/heartbeat side effects.
- [ ] Post-deploy: \`tp-uptime:<id>:<date>:timeline\` keys gain bits within ~30s of visor stats samples that don't correspond to register events; bitmap-merge ingest visible via \`MONITOR\` showing \`BITOP OR ... :ingest\` ops.

## Out of scope (still)

- Tier and service bitmaps still flow into the CXO cache but aren't projected into TPD's redis. The dispatcher comment now reflects the partial coverage. Adding tier/service ingest would mirror the timeline path verbatim — same parser shape, same OR-merge logic — but is its own concern with a different consumer (per-visor uptime, not per-transport).