### PR TITLE
serviceuptime: per-service self-uptime + version provenance via local bbolt

### DIFF
--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -3,13 +3,16 @@ package clisvc
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
 )
 
 func init() {
@@ -79,8 +82,20 @@ func init() {
 		tpdBandwidthTpCmd,
 		tpdMetricsVisorCmd,
 		tpdMetricsTpCmd,
+		tpdUptimeCmd,
 	)
+	tpdUptimeCmd.Flags().IntVarP(&svcUptimeLimit, "limit", "n", 0, "show only the most-recent N session rows (0 = all)")
+	tpdUptimeCmd.Flags().DurationVar(&svcUptimeGapThreshold, "gap-threshold", 30*time.Second,
+		"render a (down: ...) row between sessions whose gap exceeds this")
+	tpdUptimeCmd.Flags().DurationVar(&svcUptimeRestartLoopMax, "restart-loop-threshold", 30*time.Second,
+		"sessions shorter than this get a (restart loop?) tag")
 }
+
+var (
+	svcUptimeLimit          int
+	svcUptimeGapThreshold   time.Duration
+	svcUptimeRestartLoopMax time.Duration
+)
 
 var tpdStatsCmd = &cobra.Command{
 	Use:   "stats",
@@ -306,6 +321,52 @@ var arCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		emitPretty(cmd, data)
+	},
+}
+
+// tpdUptimeCmd renders TPD's own session history (one row per process
+// incarnation, version-tagged) — recorded by pkg/serviceuptime in the
+// service's local bbolt store. Gaps between sessions = TPD was actually
+// down. Sessions shorter than --restart-loop-threshold get tagged so
+// an operator can spot a TPD that's bouncing.
+var tpdUptimeCmd = &cobra.Command{
+	Use:   "uptime",
+	Short: "TPD session history (version-tagged, with restart-loop / down-window detection)",
+	Long: `
+Render the TPD service's own session history recorded locally by
+pkg/serviceuptime. Each session is one process incarnation: started_at,
+last_seen, and the running binary's Version. Gaps between adjacent
+sessions show as "(down: <duration>)"; sessions shorter than
+--restart-loop-threshold get a "(restart loop?)" tag.
+
+	skywire cli svc tpd uptime
+	skywire cli svc tpd uptime -n 20
+	skywire cli svc tpd uptime --json | jq '.[].version' | sort -u
+`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		path := "/uptime/sessions"
+		if svcUptimeLimit > 0 {
+			path = fmt.Sprintf("%s?limit=%d", path, svcUptimeLimit)
+		}
+		data, err := fetchViaVisorOrDirect(cmd, "tpd", path, deployment.Prod.TransportDiscovery)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		var sessions []serviceuptime.SessionRecord
+		if jErr := json.Unmarshal(data, &sessions); jErr != nil {
+			// Service responded but with something other than a session
+			// list — most likely a 503 (recorder not configured) or an
+			// older binary without /uptime. Surface the raw body.
+			emitPretty(cmd, data)
+			return
+		}
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			b, _ := json.MarshalIndent(sessions, "", "  ") //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), sessions, string(b)+"\n")
+			return
+		}
+		human := serviceuptime.FormatHistory(sessions, svcUptimeGapThreshold, svcUptimeRestartLoopMax)
+		internal.PrintOutput(cmd.Flags(), sessions, human)
 	},
 }
 

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -360,8 +360,8 @@ sessions show as "(down: <duration>)"; sessions shorter than
 			emitPretty(cmd, data)
 			return
 		}
-		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
-			b, _ := json.MarshalIndent(sessions, "", "  ") //nolint:errcheck
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut { //nolint:errcheck
+			b, _ := json.MarshalIndent(sessions, "", "  ")           //nolint:errcheck
 			internal.PrintOutput(cmd.Flags(), sessions, string(b)+"\n")
 			return
 		}

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -361,7 +361,7 @@ sessions show as "(down: <duration>)"; sessions shorter than
 			return
 		}
 		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut { //nolint:errcheck
-			b, _ := json.MarshalIndent(sessions, "", "  ")           //nolint:errcheck
+			b, _ := json.MarshalIndent(sessions, "", "  ") //nolint:errcheck
 			internal.PrintOutput(cmd.Flags(), sessions, string(b)+"\n")
 			return
 		}

--- a/cmd/skywire-cli/commands/visor/uptime.go
+++ b/cmd/skywire-cli/commands/visor/uptime.go
@@ -86,7 +86,7 @@ a "(restart loop?)" tag.
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 
-		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut { //nolint:errcheck
 			b, _ := json.MarshalIndent(hist, "", "  ") //nolint:errcheck
 			internal.PrintOutput(cmd.Flags(), hist, string(b)+"\n")
 			return

--- a/cmd/skywire-cli/commands/visor/uptime.go
+++ b/cmd/skywire-cli/commands/visor/uptime.go
@@ -1,0 +1,149 @@
+// Package clivisor cmd/skywire-cli/commands/visor/uptime.go: renders
+// the visor's own session-history (started_at, last_seen, version per
+// process incarnation) recorded by pkg/serviceuptime. Pulls data via
+// the visor RPC's UptimeHistory method, so works whether or not the
+// visor's logserver is reachable from the CLI host.
+package clivisor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+var (
+	uptimeLimit          int
+	uptimeSince          string
+	uptimeWithTimeline   bool
+	uptimeTimelineDate   string
+	uptimeGapThreshold   time.Duration
+	uptimeRestartLoopMax time.Duration
+)
+
+func init() {
+	uptimeCmd.Flags().IntVarP(&uptimeLimit, "limit", "n", 0, "show only the most-recent N session rows (0 = all)")
+	uptimeCmd.Flags().StringVar(&uptimeSince, "since", "", "show sessions starting at or after this time (RFC3339 or unix seconds)")
+	uptimeCmd.Flags().BoolVarP(&uptimeWithTimeline, "timeline", "t", false, "also render today's 5-min slot bitmap")
+	uptimeCmd.Flags().StringVar(&uptimeTimelineDate, "date", "", "render the bitmap for a specific UTC date (YYYY-MM-DD); implies --timeline")
+	uptimeCmd.Flags().DurationVar(&uptimeGapThreshold, "gap-threshold", 30*time.Second,
+		"render a (down: ...) row between sessions whose gap exceeds this")
+	uptimeCmd.Flags().DurationVar(&uptimeRestartLoopMax, "restart-loop-threshold", 30*time.Second,
+		"sessions shorter than this get a (restart loop?) tag")
+	RootCmd.AddCommand(uptimeCmd)
+}
+
+var uptimeCmd = &cobra.Command{
+	Use:   "uptime",
+	Short: "Visor session history (version-tagged, with restart-loop / down-window detection)",
+	Long: `
+Render the visor's own session history recorded locally by pkg/serviceuptime.
+
+Each session is one process incarnation: started_at, last_seen, and the
+running binary's Version. Gaps between adjacent sessions show as
+"(down: <duration>)"; sessions shorter than --restart-loop-threshold get
+a "(restart loop?)" tag.
+
+	skywire cli visor uptime
+	skywire cli visor uptime -n 20
+	skywire cli visor uptime --timeline
+	skywire cli visor uptime --date 2026-05-04 -t
+	skywire cli visor uptime --json | jq '.sessions[-5:]'
+`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		args := visor.UptimeHistoryArgs{Limit: uptimeLimit}
+		if uptimeSince != "" {
+			t, err := parseSince(uptimeSince)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --since: %w", err))
+			}
+			args.Since = t
+		}
+		if uptimeTimelineDate != "" {
+			d, err := time.Parse("2006-01-02", uptimeTimelineDate)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --date: %w", err))
+			}
+			args.IncludeTimeline = true
+			args.TimelineDate = d
+		} else if uptimeWithTimeline {
+			args.IncludeTimeline = true
+		}
+
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		hist, err := rpcClient.UptimeHistory(args)
+		if err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			b, _ := json.MarshalIndent(hist, "", "  ") //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), hist, string(b)+"\n")
+			return
+		}
+
+		var human string
+		if hist.Current.StartedAt.IsZero() && len(hist.Sessions) == 0 {
+			human = "(no sessions recorded — recorder may be unavailable)\n"
+		} else {
+			human = fmt.Sprintf("running: %s (since %s, %s)  pid=%d  instance=%s\n\n",
+				nonEmpty(hist.Current.Version, "?"),
+				hist.Current.StartedAt.UTC().Format("2006-01-02 15:04:05Z"),
+				humanSince(hist.Current.StartedAt, hist.Current.LastSeen),
+				hist.Current.PID,
+				hist.Current.InstanceID,
+			)
+			human += serviceuptime.FormatHistory(hist.Sessions, uptimeGapThreshold, uptimeRestartLoopMax)
+			if args.IncludeTimeline && len(hist.Timeline) > 0 {
+				human += fmt.Sprintf("\nTimeline %s (288 5-min slots, '#' = online):\n%s\n",
+					hist.TimelineDate, serviceuptime.FormatBitmap(hist.Timeline))
+			}
+		}
+		internal.PrintOutput(cmd.Flags(), hist, human)
+	},
+}
+
+func parseSince(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	var unix int64
+	if _, err := fmt.Sscanf(s, "%d", &unix); err == nil && unix > 0 {
+		return time.Unix(unix, 0).UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("want RFC3339 or unix seconds, got %q", s)
+}
+
+func humanSince(start, last time.Time) string {
+	if last.Before(start) {
+		return "0s"
+	}
+	d := last.Sub(start)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%.0fs", d.Seconds())
+	case d < time.Hour:
+		return fmt.Sprintf("%.0fm", d.Minutes())
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%.1fh", d.Hours())
+	default:
+		return fmt.Sprintf("%.1fd", d.Hours()/24)
+	}
+}
+
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/httpauth"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/metricsutil"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
 	"github.com/skycoin/skywire/pkg/storeconfig"
 	"github.com/skycoin/skywire/pkg/svcmode"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -86,7 +87,12 @@ func init() {
 	RootCmd.Flags().StringVar(&storeDataPath, "store-data-path", "/var/lib/skywire/tpd/bandwidth", "path for bandwidth backup files\n\r")
 	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO feed for transport data distribution over DMSG")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
+	RootCmd.Flags().StringVar(&uptimeDB, "uptime-db", "/var/lib/skywire/tpd/uptime.db", "path for the service-self uptime bbolt store (empty disables)")
 }
+
+// uptimeDB is the path for the local self-uptime store. Open early
+// in Run so a panic during subsystem init still leaves a session row.
+var uptimeDB string
 
 // exampleJSON marshals v to indented JSON with color, returning empty string on error
 func exampleJSON(v interface{}) string {
@@ -248,6 +254,26 @@ Example:
 
 		logging.SetLevel(lvl)
 
+		// Service-self uptime recorder. Opened before subsystem init so
+		// a panic in the redis or DMSG bring-up still leaves a session
+		// row with the running binary's version. Failure is non-fatal
+		// — TPD continues without the /uptime/* surface.
+		var uptimeRec *serviceuptime.Recorder
+		if uptimeDB != "" {
+			rec, rErr := serviceuptime.New(uptimeDB, serviceuptime.Config{
+				Service: "transport-discovery",
+				Version: buildinfo.Version(),
+				Commit:  buildinfo.Commit(),
+			})
+			if rErr != nil {
+				logger.WithError(rErr).Warn("Service-self uptime recorder unavailable")
+			} else {
+				uptimeRec = rec
+				defer func() { _ = uptimeRec.Close() }() //nolint:errcheck
+				uptimeRec.Start()
+			}
+		}
+
 		metricsutil.ServePProf(logger, pprofAddr, "transport-discovery")
 
 		var whitelistPKs []string
@@ -309,6 +335,9 @@ Example:
 
 		enableMetrics := metricsAddr != ""
 		tpdAPI := api.New(logger, s, nonceStore, enableMetrics, m, dmsgAddr, storeDataPath)
+		if uptimeRec != nil {
+			tpdAPI.SetUptimeRecorder(uptimeRec)
+		}
 
 		logger.Infof("Listening on %s", addr)
 		logger.Infof("Transport entry timeout: %v", entryTimeout)

--- a/pkg/serviceuptime/api.go
+++ b/pkg/serviceuptime/api.go
@@ -1,0 +1,115 @@
+// Package serviceuptime — pkg/serviceuptime/api.go: HTTP handlers
+// that surface the Recorder's history. Exported as plain
+// http.HandlerFunc so callers can wrap with chi (services) or gin
+// (the visor's logserver) without dragging either framework into
+// this package.
+package serviceuptime
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// CurrentSessionHandler serves GET /uptime/now → JSON SessionRecord.
+// Reads the in-flight session row directly from the recorder, so a
+// caller can ask "what version is running right now" without a bbolt
+// round-trip.
+func CurrentSessionHandler(recorder *Recorder) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, recorder.CurrentSession())
+	}
+}
+
+// SessionsHandler serves GET /uptime/sessions → JSON []SessionRecord.
+// Query: since=<RFC3339|unix>, limit=<n> (most-recent N rows).
+func SessionsHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var since time.Time
+		if s := r.URL.Query().Get("since"); s != "" {
+			if t, err := time.Parse(time.RFC3339, s); err == nil {
+				since = t
+			} else if u, err := strconv.ParseInt(s, 10, 64); err == nil {
+				since = time.Unix(u, 0).UTC()
+			} else {
+				http.Error(w, "invalid since (want RFC3339 or unix seconds)", http.StatusBadRequest)
+				return
+			}
+		}
+		out, err := store.Sessions(since)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if l := r.URL.Query().Get("limit"); l != "" {
+			if n, err := strconv.Atoi(l); err == nil && n >= 0 && n < len(out) {
+				out = out[len(out)-n:]
+			}
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// TimelineHandler serves GET /uptime/timeline → 36-byte octet-stream.
+// Query: date=YYYY-MM-DD (defaults to today UTC).
+func TimelineHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dateStr := r.URL.Query().Get("date")
+		if dateStr == "" {
+			dateStr = time.Now().UTC().Format(dateFmt)
+		}
+		date, err := time.Parse(dateFmt, dateStr)
+		if err != nil {
+			http.Error(w, "invalid date (want YYYY-MM-DD)", http.StatusBadRequest)
+			return
+		}
+		bm, err := store.Bitmap(date)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("X-Uptime-Date", dateStr)
+		_, _ = w.Write(bm) //nolint:errcheck
+	}
+}
+
+// DatesHandler serves GET /uptime/dates → JSON []string.
+func DatesHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		dates, err := store.Dates()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, dates)
+	}
+}
+
+// RegisterRoutes is a chi.Router convenience wrapper that mounts all
+// /uptime/* routes on r. Services using chi (TPD, AR, RF, UT) call
+// this from their api.New constructor.
+func RegisterRoutes(r chi.Router, recorder *Recorder) {
+	r.Get("/uptime/now", CurrentSessionHandler(recorder))
+	r.Get("/uptime/sessions", SessionsHandler(recorder.Store()))
+	r.Get("/uptime/timeline", TimelineHandler(recorder.Store()))
+	r.Get("/uptime/dates", DatesHandler(recorder.Store()))
+}
+
+// RegisterReadOnlyRoutes mounts the read endpoints minus /uptime/now,
+// for callers with a Store but no live Recorder (e.g. an inspector
+// tool reading a copied bbolt file).
+func RegisterReadOnlyRoutes(r chi.Router, store *Store) {
+	r.Get("/uptime/sessions", SessionsHandler(store))
+	r.Get("/uptime/timeline", TimelineHandler(store))
+	r.Get("/uptime/dates", DatesHandler(store))
+}
+
+func writeJSON(w http.ResponseWriter, code int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v) //nolint:errcheck
+}

--- a/pkg/serviceuptime/bitmap.go
+++ b/pkg/serviceuptime/bitmap.go
@@ -1,0 +1,59 @@
+// Package serviceuptime — pkg/serviceuptime/bitmap.go: 288-bit-per-day
+// uptime bitmap helpers, bit-identical to pkg/visor/stats/bitmap.go
+// and pkg/transport-discovery/store/redis_uptime.go's timeline format.
+//
+// Each UTC day is encoded as 288 bits (one per 5-minute slot) in 36
+// raw bytes, MSB-first. Bit set = the recording process was alive
+// during at least one keepalive within the slot. Duplicated from the
+// visor's stats package to keep this package leaf-importable from
+// services without pulling in pkg/visor/...; consolidate if a third
+// caller needs the same helpers.
+package serviceuptime
+
+import "time"
+
+// SlotsPerDay is the number of 5-minute slots in a UTC day.
+const SlotsPerDay = 24 * 60 / 5 // 288
+
+// BitmapSize is the byte length of a one-day bitmap.
+const BitmapSize = SlotsPerDay / 8 // 36
+
+// SlotForTime returns the 0-based 5-minute slot index for t (in UTC).
+func SlotForTime(t time.Time) int {
+	utc := t.UTC()
+	return (utc.Hour()*60 + utc.Minute()) / 5
+}
+
+// SetSlot sets the bit for the given slot index in bm. bm must be at
+// least BitmapSize bytes; out-of-range slots are ignored so the
+// helper is safe to call with computed indices at day boundaries.
+func SetSlot(bm []byte, slot int) {
+	if slot < 0 || slot >= SlotsPerDay {
+		return
+	}
+	bm[slot/8] |= 1 << uint(7-slot%8) // MSB-first to match Redis SETBIT
+}
+
+// GetSlot reports whether the bit for slot is set in bm.
+func GetSlot(bm []byte, slot int) bool {
+	if slot < 0 || slot >= SlotsPerDay || len(bm) < BitmapSize {
+		return false
+	}
+	return bm[slot/8]&(1<<uint(7-slot%8)) != 0
+}
+
+// CountSlots returns how many bits are set across the bitmap.
+func CountSlots(bm []byte) int {
+	if len(bm) < BitmapSize {
+		return 0
+	}
+	n := 0
+	for i := 0; i < BitmapSize; i++ {
+		b := bm[i]
+		for b != 0 {
+			n += int(b & 1)
+			b >>= 1
+		}
+	}
+	return n
+}

--- a/pkg/serviceuptime/recorder.go
+++ b/pkg/serviceuptime/recorder.go
@@ -1,0 +1,236 @@
+// Package serviceuptime — pkg/serviceuptime/recorder.go: long-running
+// recorder that turns "this process is alive" into bbolt rows.
+//
+// Lifecycle:
+//
+//  1. New() opens the Store and writes the session-start row
+//     immediately, so a process that crashes during config parsing
+//     still leaves a trace.
+//  2. Start() kicks off the keepalive goroutine, which on every tick
+//     refreshes the session row's LastSeen and sets the current 5-min
+//     slot bit.
+//  3. Close() flushes the final keepalive write and shuts down.
+//
+// Lifecycle is split so callers can write the session row before any
+// subsystem init (cheap), then defer Start() until after the bind /
+// listener is up (avoiding ticks that would mark slots while the
+// service can't actually serve).
+package serviceuptime
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// DefaultKeepaliveInterval is how often the recorder refreshes
+// LastSeen and sets the current slot bit. 60s gives one mark per
+// minute, well below the 5-min slot resolution and inexpensive on
+// bbolt (one Put per tick).
+const DefaultKeepaliveInterval = 60 * time.Second
+
+// DefaultRetention is the trailing window the recorder retains in
+// bbolt. Matches the visor stats package's default so visor and
+// services share retention semantics.
+const DefaultRetention = 35 * 24 * time.Hour
+
+// DefaultPruneInterval is how often the recorder runs Prune in the
+// background. Once an hour is enough — retention is in days, missing
+// a sweep by an hour doesn't change anything observable.
+const DefaultPruneInterval = time.Hour
+
+// Config tunes the Recorder. Zero values get the Default* constants.
+type Config struct {
+	// Service is the identifier written into each session row's
+	// Service field — "skywire-visor", "transport-discovery", etc.
+	Service string
+	// Version / Commit identify the running binary. Captured at New()
+	// and stamped into the session row; never refreshed mid-session
+	// (a binary's version doesn't change without a restart).
+	Version string
+	Commit  string
+	// KeepaliveInterval, Retention, PruneInterval override the
+	// defaults. Zero leaves the default in place.
+	KeepaliveInterval time.Duration
+	Retention         time.Duration
+	PruneInterval     time.Duration
+	// Now overrides the wall clock for tests. Production callers leave nil.
+	Now func() time.Time
+}
+
+// Recorder owns a running service's session row and slot bitmap.
+type Recorder struct {
+	store *Store
+	cfg   Config
+
+	mu      sync.Mutex
+	session SessionRecord
+
+	cancel  context.CancelFunc
+	stopped chan struct{}
+}
+
+// New opens the store and writes the initial session row. The
+// recorder is ready to read but does not start the keepalive ticker
+// until Start() is called.
+//
+// path is the bbolt file location. If the file is missing it's
+// created; if it exists with a different schema version the call
+// errors out so the operator can decide whether to migrate.
+func New(path string, cfg Config) (*Recorder, error) {
+	store, err := OpenStore(path)
+	if err != nil {
+		return nil, err
+	}
+	now := cfg.now()
+	r := &Recorder{
+		store: store,
+		cfg:   cfg,
+		session: SessionRecord{
+			StartedAt:  now,
+			LastSeen:   now,
+			Version:    cfg.Version,
+			Commit:     cfg.Commit,
+			PID:        os.Getpid(),
+			InstanceID: store.InstanceID(),
+			Service:    cfg.Service,
+		},
+	}
+	if err := store.PutSession(r.session); err != nil {
+		store.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("serviceuptime: write session row: %w", err)
+	}
+	if err := store.MarkSlot(now, SlotForTime(now)); err != nil {
+		store.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("serviceuptime: mark initial slot: %w", err)
+	}
+	return r, nil
+}
+
+// Start launches the keepalive + prune goroutines. Idempotent: a
+// second Start is a no-op.
+func (r *Recorder) Start() {
+	r.mu.Lock()
+	if r.cancel != nil {
+		r.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	r.stopped = make(chan struct{})
+	r.mu.Unlock()
+
+	keepalive := r.cfg.KeepaliveInterval
+	if keepalive <= 0 {
+		keepalive = DefaultKeepaliveInterval
+	}
+	pruneEvery := r.cfg.PruneInterval
+	if pruneEvery <= 0 {
+		pruneEvery = DefaultPruneInterval
+	}
+	retention := r.cfg.Retention
+	if retention <= 0 {
+		retention = DefaultRetention
+	}
+
+	go func() {
+		defer close(r.stopped)
+		kaT := time.NewTicker(keepalive)
+		defer kaT.Stop()
+		prT := time.NewTicker(pruneEvery)
+		defer prT.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				// One last keepalive on the way out so the session's
+				// LastSeen reflects the actual shutdown moment, not
+				// the previous ticker fire.
+				r.tick()
+				return
+			case <-kaT.C:
+				r.tick()
+			case <-prT.C:
+				cutoff := r.cfg.now().Add(-retention)
+				_, _, _ = r.store.Prune(cutoff) //nolint:errcheck
+			}
+		}
+	}()
+}
+
+// tick refreshes the session row + sets the current slot bit. Called
+// from the keepalive goroutine and once on shutdown.
+func (r *Recorder) tick() {
+	now := r.cfg.now()
+	r.mu.Lock()
+	r.session.LastSeen = now
+	rec := r.session
+	r.mu.Unlock()
+	_ = r.store.PutSession(rec)                 //nolint:errcheck
+	_ = r.store.MarkSlot(now, SlotForTime(now)) //nolint:errcheck
+}
+
+// Close stops the keepalive goroutine, performs one final tick so
+// LastSeen reflects shutdown time, and closes the underlying store.
+// Safe to call from a signal handler.
+func (r *Recorder) Close() error {
+	r.mu.Lock()
+	cancel := r.cancel
+	stopped := r.stopped
+	r.cancel = nil
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if stopped != nil {
+		<-stopped
+	} else {
+		// Start was never called — fire one tick so the session's
+		// LastSeen at least matches the close time.
+		r.tick()
+	}
+	return r.store.Close()
+}
+
+// Store returns the underlying read/write store. Callers (HTTP
+// handlers, CLI rendering) use this to query history. Writes
+// outside the keepalive loop are tolerated but not expected.
+func (r *Recorder) Store() *Store { return r.store }
+
+// CurrentSession returns a copy of the in-flight session row, useful
+// for /uptime/now style endpoints that want to surface the running
+// binary's version without a bbolt round-trip.
+func (r *Recorder) CurrentSession() SessionRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.session
+}
+
+func (c Config) now() time.Time {
+	if c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// readRandom is a thin wrapper around crypto/rand.Read so newInstanceID
+// (in store.go) can fall back without dragging crypto/rand into every
+// caller's mock setup. Centralized here so test builds can override
+// via build tags if ever needed.
+func readRandom(buf []byte) (int, error) {
+	n, err := rand.Read(buf)
+	if err != nil {
+		return n, err
+	}
+	if n != len(buf) {
+		return n, errors.New("short random read")
+	}
+	return n, nil
+}
+
+// Compile-time check that Recorder implements io.Closer.
+var _ io.Closer = (*Recorder)(nil)

--- a/pkg/serviceuptime/recorder_test.go
+++ b/pkg/serviceuptime/recorder_test.go
@@ -1,0 +1,163 @@
+package serviceuptime
+
+import (
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClock returns successive times from a slice. Used to drive
+// keepalive ticks deterministically in tests without depending on
+// wall time.
+type fakeClock struct {
+	idx atomic.Int64
+	ts  []time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	i := c.idx.Add(1) - 1
+	if int(i) >= len(c.ts) {
+		return c.ts[len(c.ts)-1]
+	}
+	return c.ts[int(i)]
+}
+
+func TestNewWritesInitialSessionAndSlot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "uptime.db")
+	t0 := time.Date(2026, 4, 28, 12, 5, 0, 0, time.UTC)
+	cfg := Config{
+		Service: "tester",
+		Version: "v0.0.1",
+		Now:     (&fakeClock{ts: []time.Time{t0, t0}}).Now,
+	}
+	r, err := New(path, cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer r.Close() //nolint:errcheck
+
+	got, err := r.Store().Sessions(time.Time{})
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 session, got %d", len(got))
+	}
+	if got[0].Version != "v0.0.1" || got[0].Service != "tester" {
+		t.Errorf("session metadata mismatch: %+v", got[0])
+	}
+	if !got[0].StartedAt.Equal(t0) {
+		t.Errorf("StartedAt = %v, want %v", got[0].StartedAt, t0)
+	}
+	bm, err := r.Store().Bitmap(t0)
+	if err != nil {
+		t.Fatalf("Bitmap: %v", err)
+	}
+	if !GetSlot(bm, SlotForTime(t0)) {
+		t.Errorf("initial slot %d not set", SlotForTime(t0))
+	}
+}
+
+func TestCloseFlushesFinalKeepalive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "uptime.db")
+	t0 := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	tEnd := t0.Add(30 * time.Minute) // a different slot
+	clk := &fakeClock{ts: []time.Time{t0, tEnd, tEnd}}
+	cfg := Config{
+		Service: "tester",
+		Version: "v0.0.2",
+		Now:     clk.Now,
+	}
+	r, err := New(path, cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Don't Start(); just Close. That exercises the "Start was never
+	// called → Close still ticks once" fallback so a short-lived
+	// process leaves a usable LastSeen.
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Re-open and read.
+	s, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck
+	got, err := s.Sessions(time.Time{})
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 session, got %d", len(got))
+	}
+	if !got[0].LastSeen.Equal(tEnd) {
+		t.Errorf("LastSeen = %v, want %v (final tick should fire on Close)", got[0].LastSeen, tEnd)
+	}
+	bm, _ := s.Bitmap(tEnd)
+	if !GetSlot(bm, SlotForTime(tEnd)) {
+		t.Errorf("final slot %d not set", SlotForTime(tEnd))
+	}
+}
+
+func TestKeepaliveAdvancesSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "uptime.db")
+	t0 := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	// Provide enough fake-now values for: New (1) + several ticks.
+	clk := &fakeClock{ts: []time.Time{
+		t0,
+		t0.Add(5 * time.Minute),
+		t0.Add(10 * time.Minute),
+		t0.Add(15 * time.Minute),
+		t0.Add(20 * time.Minute),
+	}}
+	cfg := Config{
+		Service:           "tester",
+		Version:           "v0.0.3",
+		KeepaliveInterval: 5 * time.Millisecond,
+		PruneInterval:     time.Hour, // don't trigger prune in this test
+		Now:               clk.Now,
+	}
+	r, err := New(path, cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	r.Start()
+	// Wait for the goroutine to land at least 2 ticks.
+	deadline := time.Now().Add(2 * time.Second)
+	var got []SessionRecord
+	for time.Now().Before(deadline) {
+		got, _ = r.Store().Sessions(time.Time{})
+		if len(got) == 1 && got[0].LastSeen.After(t0) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 session, got %d", len(got))
+	}
+	if !got[0].LastSeen.After(t0) {
+		t.Errorf("LastSeen %v should be after t0 %v", got[0].LastSeen, t0)
+	}
+}
+
+func TestNewIsCheapEnoughForEarlyMain(t *testing.T) {
+	// Sanity: New must be a single bbolt open + two writes. Anything
+	// more risks slowing the canary-process startup we depend on for
+	// recording crashes during config parsing.
+	path := filepath.Join(t.TempDir(), "uptime.db")
+	start := time.Now()
+	r, err := New(path, Config{Service: "tester", Version: "v0.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	took := time.Since(start)
+	if took > 500*time.Millisecond {
+		t.Errorf("New took %v, expected <500ms", took)
+	}
+	_ = r.Close() //nolint:errcheck
+}

--- a/pkg/serviceuptime/recorder_test.go
+++ b/pkg/serviceuptime/recorder_test.go
@@ -95,7 +95,7 @@ func TestCloseFlushesFinalKeepalive(t *testing.T) {
 	if !got[0].LastSeen.Equal(tEnd) {
 		t.Errorf("LastSeen = %v, want %v (final tick should fire on Close)", got[0].LastSeen, tEnd)
 	}
-	bm, _ := s.Bitmap(tEnd)
+	bm, _ := s.Bitmap(tEnd) //nolint:errcheck
 	if !GetSlot(bm, SlotForTime(tEnd)) {
 		t.Errorf("final slot %d not set", SlotForTime(tEnd))
 	}
@@ -128,7 +128,7 @@ func TestKeepaliveAdvancesSession(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	var got []SessionRecord
 	for time.Now().Before(deadline) {
-		got, _ = r.Store().Sessions(time.Time{})
+		got, _ = r.Store().Sessions(time.Time{}) //nolint:errcheck
 		if len(got) == 1 && got[0].LastSeen.After(t0) {
 			break
 		}

--- a/pkg/serviceuptime/render.go
+++ b/pkg/serviceuptime/render.go
@@ -1,0 +1,97 @@
+// Package serviceuptime — pkg/serviceuptime/render.go: shared text
+// renderer for the CLI. Both `skywire cli visor uptime` and
+// `skywire cli svc <name> uptime` go through here so the output is
+// uniform across a deployment.
+package serviceuptime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FormatHistory renders sessions as a chronological table. Gaps
+// between adjacent sessions where the next StartedAt is more than
+// gapThreshold after the previous LastSeen surface as "(down: <dur>)"
+// rows so an operator can see when the service wasn't running.
+//
+// Output shape:
+//
+//	2026-04-28 12:00:11Z  →  2026-04-28 12:00:14Z   3.0s   v1.3.46  (restart loop?)
+//	2026-04-28 12:00:18Z  →  2026-04-28 12:00:21Z   3.0s   v1.3.46  (restart loop?)
+//	2026-04-28 12:00:25Z  →  2026-04-29 04:31:07Z  16.5h   v1.3.46
+//	                                  (down: 4m12s)
+//	2026-04-29 04:35:19Z  →  2026-05-04 21:00:00Z   5.7d   v1.3.47
+//
+// Sessions whose Duration is below restartLoopThreshold are tagged.
+func FormatHistory(sessions []SessionRecord, gapThreshold, restartLoopThreshold time.Duration) string {
+	if len(sessions) == 0 {
+		return "(no sessions recorded)\n"
+	}
+	var sb strings.Builder
+	for i, s := range sessions {
+		if i > 0 {
+			gap := s.StartedAt.Sub(sessions[i-1].LastSeen)
+			if gap > gapThreshold {
+				fmt.Fprintf(&sb, "%-72s(down: %s)\n", "", humanDuration(gap))
+			}
+		}
+		dur := s.Duration()
+		ver := s.Version
+		if ver == "" {
+			ver = "?"
+		}
+		tag := ""
+		if dur > 0 && dur < restartLoopThreshold {
+			tag = "  (restart loop?)"
+		}
+		fmt.Fprintf(&sb, "%s  →  %s   %-7s  %s%s\n",
+			s.StartedAt.UTC().Format("2006-01-02 15:04:05Z"),
+			s.LastSeen.UTC().Format("2006-01-02 15:04:05Z"),
+			humanDuration(dur),
+			ver,
+			tag,
+		)
+	}
+	return sb.String()
+}
+
+// FormatBitmap renders a 36-byte bitmap as a 288-character ASCII line
+// — '#' for set bits, '.' for unset — matching TPD's v3 timeline
+// shape. For dashboards that want a one-liner per day.
+func FormatBitmap(bm []byte) string {
+	if len(bm) < BitmapSize {
+		return strings.Repeat(".", SlotsPerDay)
+	}
+	out := make([]byte, SlotsPerDay)
+	for i := 0; i < SlotsPerDay; i++ {
+		if GetSlot(bm, i) {
+			out[i] = '#'
+		} else {
+			out[i] = '.'
+		}
+	}
+	return string(out)
+}
+
+// humanDuration is a compact short form ("3.0s", "5m12s", "16.5h",
+// "5.7d") suitable for table cells.
+func humanDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	case d < time.Hour:
+		m := int(d / time.Minute)
+		s := int((d % time.Minute) / time.Second)
+		return fmt.Sprintf("%dm%02ds", m, s)
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%.1fh", d.Hours())
+	default:
+		return fmt.Sprintf("%.1fd", d.Hours()/24)
+	}
+}

--- a/pkg/serviceuptime/store.go
+++ b/pkg/serviceuptime/store.go
@@ -1,0 +1,305 @@
+// Package serviceuptime — pkg/serviceuptime/store.go: bbolt-backed
+// persistence for a service's own uptime / version history.
+//
+// On-disk layout:
+//
+//	meta/                  — schema version, instance ID
+//	sessions/              — keyed by start_unix_ts (8-byte big-endian);
+//	                         value JSON SessionRecord
+//	slots/                 — sub-buckets per UTC YYYY-MM-DD; value 36-byte bitmap
+//
+// Source-of-truth for the running process. A Recorder wraps the Store
+// and drives the keepalive loop that turns "process is alive" into
+// rows + bits. Anything reading the data (HTTP handler, CLI) goes
+// through the Store directly.
+package serviceuptime
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.etcd.io/bbolt"
+)
+
+const dateFmt = "2006-01-02"
+
+// SchemaVersion is bumped on any breaking change to bucket layout.
+const SchemaVersion = 1
+
+var (
+	bucketMeta     = []byte("meta")
+	bucketSessions = []byte("sessions")
+	bucketSlots    = []byte("slots")
+
+	keySchemaVersion = []byte("schema_version")
+	keyInstanceID    = []byte("instance_id")
+)
+
+// ErrSchemaMismatch is returned by OpenStore when the persisted schema
+// version doesn't match the binary's.
+var ErrSchemaMismatch = errors.New("serviceuptime: schema version mismatch")
+
+// SessionRecord is one process incarnation: the span between a binary
+// starting and either shutting down cleanly or the next start. The
+// recorder writes this row at startup with StartedAt and Version,
+// then refreshes LastSeen on every keepalive tick. Gaps between
+// adjacent sessions' LastSeen → next StartedAt are "service was not
+// running" intervals; tightly-packed sessions with short
+// LastSeen-StartedAt durations are restart-loop signal.
+type SessionRecord struct {
+	StartedAt  time.Time `json:"started_at"`
+	LastSeen   time.Time `json:"last_seen"`
+	Version    string    `json:"version,omitempty"`
+	Commit     string    `json:"commit,omitempty"`
+	PID        int       `json:"pid,omitempty"`
+	InstanceID string    `json:"instance_id,omitempty"`
+	// Service is the human-readable service name ("skywire-visor",
+	// "transport-discovery", etc.) — purely informational, useful when
+	// rendering history from a copied or shared bbolt file.
+	Service string `json:"service,omitempty"`
+}
+
+// Duration returns LastSeen − StartedAt, the observed up-time of this
+// session. Returns 0 when the row is malformed (LastSeen before start).
+func (r SessionRecord) Duration() time.Duration {
+	if r.LastSeen.Before(r.StartedAt) {
+		return 0
+	}
+	return r.LastSeen.Sub(r.StartedAt)
+}
+
+// Store is the bbolt-backed persistence layer. Safe for concurrent
+// use. Paths and TTL are caller-supplied.
+type Store struct {
+	db         *bbolt.DB
+	instanceID string
+}
+
+// OpenStore opens (or creates) the bbolt database at path and ensures
+// the schema is at the expected version. instanceID is set on first
+// open and never rewritten; it identifies the on-disk database
+// independently of any single session.
+func OpenStore(path string) (*Store, error) {
+	db, err := bbolt.Open(path, 0600, &bbolt.Options{
+		NoSync:  false,
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("serviceuptime: open %s: %w", path, err)
+	}
+	s := &Store{db: db}
+	if err := db.Update(func(tx *bbolt.Tx) error {
+		for _, b := range [][]byte{bucketMeta, bucketSessions, bucketSlots} {
+			if _, err := tx.CreateBucketIfNotExists(b); err != nil {
+				return fmt.Errorf("create bucket %s: %w", b, err)
+			}
+		}
+		meta := tx.Bucket(bucketMeta)
+		raw := meta.Get(keySchemaVersion)
+		if raw == nil {
+			vbuf := make([]byte, 8)
+			binary.BigEndian.PutUint64(vbuf, SchemaVersion)
+			if err := meta.Put(keySchemaVersion, vbuf); err != nil {
+				return err
+			}
+		} else if got := binary.BigEndian.Uint64(raw); got != SchemaVersion {
+			return fmt.Errorf("%w: on-disk %d, code %d", ErrSchemaMismatch, got, SchemaVersion)
+		}
+		idRaw := meta.Get(keyInstanceID)
+		if idRaw == nil {
+			id := newInstanceID()
+			if err := meta.Put(keyInstanceID, []byte(id)); err != nil {
+				return err
+			}
+			s.instanceID = id
+		} else {
+			s.instanceID = string(idRaw)
+		}
+		return nil
+	}); err != nil {
+		db.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return s, nil
+}
+
+// Close releases the bbolt file handle.
+func (s *Store) Close() error { return s.db.Close() }
+
+// InstanceID returns the durable per-database identifier set at first
+// open. Useful for distinguishing two copies of the same service that
+// share a deployment but differ in their on-disk state.
+func (s *Store) InstanceID() string { return s.instanceID }
+
+func sessionKey(t time.Time) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(t.UTC().UnixNano()))
+	return buf
+}
+
+// PutSession overwrites the row keyed by rec.StartedAt. Callers
+// (the Recorder) read-modify-write under their own mutex; the store
+// does not merge.
+func (s *Store) PutSession(rec SessionRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketSessions).Put(sessionKey(rec.StartedAt), data)
+	})
+}
+
+// Sessions returns rows with StartedAt ≥ since, sorted ascending.
+// Pass a zero time to read everything in the bucket.
+func (s *Store) Sessions(since time.Time) ([]SessionRecord, error) {
+	var out []SessionRecord
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		c := tx.Bucket(bucketSessions).Cursor()
+		var seek []byte
+		if !since.IsZero() {
+			seek = sessionKey(since)
+		}
+		var k, v []byte
+		if seek == nil {
+			k, v = c.First()
+		} else {
+			k, v = c.Seek(seek)
+		}
+		for ; k != nil; k, v = c.Next() {
+			r := SessionRecord{}
+			if err := json.Unmarshal(v, &r); err != nil {
+				continue
+			}
+			out = append(out, r)
+		}
+		return nil
+	})
+	return out, err
+}
+
+// MarkSlot sets the bit for slot in today's bitmap (UTC). The
+// read-modify-write happens inside a single bbolt transaction; the OR
+// is idempotent so concurrent ticks for the same slot race safely.
+func (s *Store) MarkSlot(date time.Time, slot int) error {
+	if slot < 0 || slot >= SlotsPerDay {
+		return fmt.Errorf("serviceuptime: slot %d out of range", slot)
+	}
+	dateKey := []byte(date.UTC().Format(dateFmt))
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		bm := tx.Bucket(bucketSlots).Get(dateKey)
+		buf := make([]byte, BitmapSize)
+		if bm != nil {
+			copy(buf, bm)
+		}
+		SetSlot(buf, slot)
+		return tx.Bucket(bucketSlots).Put(dateKey, buf)
+	})
+}
+
+// Bitmap returns the persisted bitmap for the given UTC date, or a
+// zero-filled bitmap if none exists. The result is a copy.
+func (s *Store) Bitmap(date time.Time) ([]byte, error) {
+	dateKey := []byte(date.UTC().Format(dateFmt))
+	out := make([]byte, BitmapSize)
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		bm := tx.Bucket(bucketSlots).Get(dateKey)
+		if bm != nil {
+			copy(out, bm)
+		}
+		return nil
+	})
+	return out, err
+}
+
+// Dates lists every UTC date that has a stored bitmap, sorted
+// ascending.
+func (s *Store) Dates() ([]string, error) {
+	var dates []string
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketSlots).ForEach(func(k, _ []byte) error {
+			dates = append(dates, string(k))
+			return nil
+		})
+	})
+	sort.Strings(dates)
+	return dates, err
+}
+
+// Prune drops rows older than cutoff: sessions whose LastSeen is
+// strictly before cutoff, and slot bitmaps whose date is strictly
+// before cutoff's UTC date. Returns sessions removed + bitmaps
+// removed.
+func (s *Store) Prune(cutoff time.Time) (sessions, bitmaps int, err error) {
+	cutoffUTC := cutoff.UTC()
+	cutoffDate := cutoffUTC.Format(dateFmt)
+	err = s.db.Update(func(tx *bbolt.Tx) error {
+		// Sessions: walk and delete by key (which is StartedAt). A
+		// session that started before the cutoff but has a fresh
+		// LastSeen is preserved — that's a long-running incarnation
+		// crossing the retention boundary.
+		var sessKeys [][]byte
+		if err := tx.Bucket(bucketSessions).ForEach(func(k, v []byte) error {
+			r := SessionRecord{}
+			if err := json.Unmarshal(v, &r); err == nil {
+				if r.LastSeen.UTC().Before(cutoffUTC) {
+					sessKeys = append(sessKeys, append([]byte(nil), k...))
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		for _, k := range sessKeys {
+			if err := tx.Bucket(bucketSessions).Delete(k); err != nil {
+				return err
+			}
+			sessions++
+		}
+		// Slot bitmaps: keys are YYYY-MM-DD strings; lex order matches
+		// chronological order, so a < cutoffDate is "older".
+		var dateKeys [][]byte
+		if err := tx.Bucket(bucketSlots).ForEach(func(k, _ []byte) error {
+			if string(k) < cutoffDate {
+				dateKeys = append(dateKeys, append([]byte(nil), k...))
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		for _, k := range dateKeys {
+			if err := tx.Bucket(bucketSlots).Delete(k); err != nil {
+				return err
+			}
+			bitmaps++
+		}
+		return nil
+	})
+	return sessions, bitmaps, err
+}
+
+// newInstanceID produces a short opaque identifier for the on-disk
+// database. Generated via crypto/rand so two services on the same
+// host get distinct IDs even if they happen to start at the same
+// nanosecond.
+func newInstanceID() string {
+	// Inlined to avoid an import cycle if a higher layer wants to
+	// depend on this package; crypto/rand failures fall back to a
+	// time-based id since the value is informational.
+	var buf [12]byte
+	if _, err := readRandom(buf[:]); err != nil {
+		now := time.Now().UnixNano()
+		return fmt.Sprintf("ts-%d", now)
+	}
+	const hex = "0123456789abcdef"
+	out := make([]byte, len(buf)*2)
+	for i, b := range buf {
+		out[i*2] = hex[b>>4]
+		out[i*2+1] = hex[b&0x0f]
+	}
+	return string(out)
+}

--- a/pkg/serviceuptime/store_test.go
+++ b/pkg/serviceuptime/store_test.go
@@ -1,0 +1,172 @@
+package serviceuptime
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTempStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "uptime.db")
+	s, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() { s.Close() }) //nolint:errcheck
+	return s
+}
+
+func TestSessionRoundTrip(t *testing.T) {
+	s := newTempStore(t)
+	t0 := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	rec := SessionRecord{
+		StartedAt: t0,
+		LastSeen:  t0.Add(2 * time.Hour),
+		Version:   "v1.3.46",
+		Service:   "test-svc",
+	}
+	if err := s.PutSession(rec); err != nil {
+		t.Fatalf("PutSession: %v", err)
+	}
+	got, err := s.Sessions(time.Time{})
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1", len(got))
+	}
+	if !got[0].StartedAt.Equal(rec.StartedAt) || got[0].Version != "v1.3.46" {
+		t.Errorf("round-trip mismatch: %+v", got[0])
+	}
+	if d := got[0].Duration(); d != 2*time.Hour {
+		t.Errorf("Duration = %v, want 2h", d)
+	}
+}
+
+func TestSessionsSinceFiltersAndOrders(t *testing.T) {
+	s := newTempStore(t)
+	base := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	for i, h := range []int{0, 5, 1, 10, 3} {
+		st := base.Add(time.Duration(h) * time.Hour)
+		if err := s.PutSession(SessionRecord{
+			StartedAt: st,
+			LastSeen:  st.Add(time.Hour),
+			Version:   "v1",
+			Service:   "test",
+		}); err != nil {
+			t.Fatalf("PutSession %d: %v", i, err)
+		}
+	}
+	all, err := s.Sessions(time.Time{})
+	if err != nil {
+		t.Fatalf("Sessions all: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("want 5, got %d", len(all))
+	}
+	// Cursor is sorted ascending by StartedAt key.
+	for i := 1; i < len(all); i++ {
+		if all[i].StartedAt.Before(all[i-1].StartedAt) {
+			t.Errorf("not sorted: %v before %v", all[i-1].StartedAt, all[i].StartedAt)
+		}
+	}
+	// since=base+2h: should drop the rows starting at +0 and +1.
+	got, err := s.Sessions(base.Add(2 * time.Hour))
+	if err != nil {
+		t.Fatalf("Sessions since: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 since +2h, got %d", len(got))
+	}
+}
+
+func TestMarkSlotAndBitmap(t *testing.T) {
+	s := newTempStore(t)
+	day := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	slots := []int{0, 100, 287, 50, 0 /* duplicate idempotent */}
+	for _, slot := range slots {
+		if err := s.MarkSlot(day, slot); err != nil {
+			t.Fatalf("MarkSlot %d: %v", slot, err)
+		}
+	}
+	bm, err := s.Bitmap(day)
+	if err != nil {
+		t.Fatalf("Bitmap: %v", err)
+	}
+	for _, slot := range []int{0, 50, 100, 287} {
+		if !GetSlot(bm, slot) {
+			t.Errorf("slot %d should be set", slot)
+		}
+	}
+	if GetSlot(bm, 1) {
+		t.Errorf("slot 1 should not be set")
+	}
+	if got := CountSlots(bm); got != 4 {
+		t.Errorf("CountSlots = %d, want 4", got)
+	}
+}
+
+func TestPruneDropsOldSessionsAndBitmaps(t *testing.T) {
+	s := newTempStore(t)
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+
+	// Old session — both StartedAt and LastSeen before cutoff.
+	old := now.Add(-40 * 24 * time.Hour)
+	_ = s.PutSession(SessionRecord{StartedAt: old, LastSeen: old.Add(time.Hour), Service: "old"})
+	// Long-running session that crosses the cutoff. LastSeen is fresh,
+	// StartedAt is old. Must be preserved.
+	straddle := now.Add(-50 * 24 * time.Hour)
+	_ = s.PutSession(SessionRecord{StartedAt: straddle, LastSeen: now.Add(-1 * time.Hour), Service: "straddle"})
+	// Recent session.
+	recent := now.Add(-1 * time.Hour)
+	_ = s.PutSession(SessionRecord{StartedAt: recent, LastSeen: now, Service: "recent"})
+
+	_ = s.MarkSlot(now.Add(-40*24*time.Hour), 0) // old date
+	_ = s.MarkSlot(now, 0)                       // today
+
+	cutoff := now.Add(-35 * 24 * time.Hour)
+	sessions, bitmaps, err := s.Prune(cutoff)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if sessions != 1 {
+		t.Errorf("sessions removed = %d, want 1", sessions)
+	}
+	if bitmaps != 1 {
+		t.Errorf("bitmaps removed = %d, want 1", bitmaps)
+	}
+	all, _ := s.Sessions(time.Time{})
+	if len(all) != 2 {
+		t.Fatalf("after prune want 2 sessions, got %d", len(all))
+	}
+	for _, r := range all {
+		if r.Service == "old" {
+			t.Errorf("old session not pruned: %+v", r)
+		}
+	}
+}
+
+func TestInstanceIDStablePerDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "uptime.db")
+	s1, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("open #1: %v", err)
+	}
+	id1 := s1.InstanceID()
+	if len(id1) == 0 {
+		t.Fatal("instance ID is empty")
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("close #1: %v", err)
+	}
+
+	s2, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("open #2: %v", err)
+	}
+	defer s2.Close() //nolint:errcheck
+	if s2.InstanceID() != id1 {
+		t.Errorf("InstanceID changed across reopens: %q vs %q", id1, s2.InstanceID())
+	}
+}

--- a/pkg/serviceuptime/store_test.go
+++ b/pkg/serviceuptime/store_test.go
@@ -13,7 +13,7 @@ func newTempStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("OpenStore: %v", err)
 	}
-	t.Cleanup(func() { s.Close() }) //nolint:errcheck
+	t.Cleanup(func() { _ = s.Close() }) //nolint:errcheck,gosec
 	return s
 }
 
@@ -113,17 +113,17 @@ func TestPruneDropsOldSessionsAndBitmaps(t *testing.T) {
 
 	// Old session — both StartedAt and LastSeen before cutoff.
 	old := now.Add(-40 * 24 * time.Hour)
-	_ = s.PutSession(SessionRecord{StartedAt: old, LastSeen: old.Add(time.Hour), Service: "old"})
+	_ = s.PutSession(SessionRecord{StartedAt: old, LastSeen: old.Add(time.Hour), Service: "old"}) //nolint:errcheck
 	// Long-running session that crosses the cutoff. LastSeen is fresh,
 	// StartedAt is old. Must be preserved.
 	straddle := now.Add(-50 * 24 * time.Hour)
-	_ = s.PutSession(SessionRecord{StartedAt: straddle, LastSeen: now.Add(-1 * time.Hour), Service: "straddle"})
+	_ = s.PutSession(SessionRecord{StartedAt: straddle, LastSeen: now.Add(-1 * time.Hour), Service: "straddle"}) //nolint:errcheck
 	// Recent session.
 	recent := now.Add(-1 * time.Hour)
-	_ = s.PutSession(SessionRecord{StartedAt: recent, LastSeen: now, Service: "recent"})
+	_ = s.PutSession(SessionRecord{StartedAt: recent, LastSeen: now, Service: "recent"}) //nolint:errcheck
 
-	_ = s.MarkSlot(now.Add(-40*24*time.Hour), 0) // old date
-	_ = s.MarkSlot(now, 0)                       // today
+	_ = s.MarkSlot(now.Add(-40*24*time.Hour), 0) //nolint:errcheck // old date
+	_ = s.MarkSlot(now, 0)                       //nolint:errcheck // today
 
 	cutoff := now.Add(-35 * 24 * time.Hour)
 	sessions, bitmaps, err := s.Prune(cutoff)
@@ -136,7 +136,7 @@ func TestPruneDropsOldSessionsAndBitmaps(t *testing.T) {
 	if bitmaps != 1 {
 		t.Errorf("bitmaps removed = %d, want 1", bitmaps)
 	}
-	all, _ := s.Sessions(time.Time{})
+	all, _ := s.Sessions(time.Time{}) //nolint:errcheck
 	if len(all) != 2 {
 		t.Fatalf("after prune want 2 sessions, got %d", len(all))
 	}

--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/metricsutil"
 	"github.com/skycoin/skywire/pkg/networkmonitor"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
 	"github.com/skycoin/skywire/pkg/transport"
 	tpdiscmetrics "github.com/skycoin/skywire/pkg/transport-discovery/metrics"
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
@@ -69,6 +70,11 @@ type API struct {
 	uptimesCache   []store.VisorSummary
 	uptimesV2Cache []store.VisorSummary
 	uptimesMu      sync.RWMutex
+
+	// Service-self uptime recorder (nil until SetUptimeRecorder).
+	// Surfaces /uptime/* routes; 503s until wired.
+	uptimeRecorder *serviceuptime.Recorder
+	uptimeMu       sync.RWMutex
 
 	// cxoPublisher is an optional CXO publisher for distributing transport data.
 	// When set, transport register/deregister operations publish to CXO subscribers.
@@ -194,9 +200,73 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 	nonceHandler := &httpauth.NonceHandler{Store: nonceStore}
 	r.Get("/security/nonces/{pk}", nonceHandler.ServeHTTP)
 
+	// /uptime/* — service-self uptime store. Routes are wired
+	// unconditionally; until SetUptimeRecorder is called they 503,
+	// matching the visor's logserver pattern. No auth: this is the
+	// service's own version-history, useful for unauth'd monitoring.
+	r.Group(func(r chi.Router) {
+		r.Get("/uptime/now", api.uptimeNow)
+		r.Get("/uptime/sessions", api.uptimeSessions)
+		r.Get("/uptime/timeline", api.uptimeTimeline)
+		r.Get("/uptime/dates", api.uptimeDates)
+	})
+
 	api.Handler = r
 
 	return api
+}
+
+// SetUptimeRecorder wires a service-self uptime recorder onto the API.
+// Idempotent re-attach is a no-op (first writer wins). Until set, the
+// /uptime/* routes return 503.
+func (api *API) SetUptimeRecorder(r *serviceuptime.Recorder) {
+	api.uptimeMu.Lock()
+	defer api.uptimeMu.Unlock()
+	if api.uptimeRecorder == nil {
+		api.uptimeRecorder = r
+	}
+}
+
+func (api *API) getUptimeRecorder() *serviceuptime.Recorder {
+	api.uptimeMu.RLock()
+	defer api.uptimeMu.RUnlock()
+	return api.uptimeRecorder
+}
+
+func (api *API) uptimeNow(w http.ResponseWriter, r *http.Request) {
+	rec := api.getUptimeRecorder()
+	if rec == nil {
+		http.Error(w, "uptime recorder not configured", http.StatusServiceUnavailable)
+		return
+	}
+	serviceuptime.CurrentSessionHandler(rec).ServeHTTP(w, r)
+}
+
+func (api *API) uptimeSessions(w http.ResponseWriter, r *http.Request) {
+	rec := api.getUptimeRecorder()
+	if rec == nil {
+		http.Error(w, "uptime recorder not configured", http.StatusServiceUnavailable)
+		return
+	}
+	serviceuptime.SessionsHandler(rec.Store()).ServeHTTP(w, r)
+}
+
+func (api *API) uptimeTimeline(w http.ResponseWriter, r *http.Request) {
+	rec := api.getUptimeRecorder()
+	if rec == nil {
+		http.Error(w, "uptime recorder not configured", http.StatusServiceUnavailable)
+		return
+	}
+	serviceuptime.TimelineHandler(rec.Store()).ServeHTTP(w, r)
+}
+
+func (api *API) uptimeDates(w http.ResponseWriter, r *http.Request) {
+	rec := api.getUptimeRecorder()
+	if rec == nil {
+		http.Error(w, "uptime recorder not configured", http.StatusServiceUnavailable)
+		return
+	}
+	serviceuptime.DatesHandler(rec.Store()).ServeHTTP(w, r)
 }
 
 // SetDHTMirror sets a mirror that publishes transport lists to the DHT.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/servicedisc"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
@@ -39,6 +40,7 @@ type API interface {
 	DisableHypervisorPersist(persist bool) error
 	IsHypervisorEnabled() bool
 	Uptime() (float64, error)
+	UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error)
 	RuntimeStats() (*RuntimeStatsInfo, error)
 	Reload() error
 	Shutdown() error
@@ -452,6 +454,31 @@ type HealthInfo struct {
 	UptimeTrackerHealth    string `json:"uptime_tracker_health,omitempty"`
 	AutoconnectHealth      string `json:"autoconnect_health,omitempty"`
 	TransportabilityHealth string `json:"transportability_health,omitempty"`
+}
+
+// UptimeHistoryArgs is the request shape for API.UptimeHistory. All
+// fields are optional: empty Since reads everything in retention,
+// zero Limit returns all rows, IncludeTimeline=false skips the
+// timeline byte slice.
+type UptimeHistoryArgs struct {
+	Since           time.Time
+	Limit           int
+	IncludeTimeline bool
+	// TimelineDate, when set with IncludeTimeline, returns the bitmap
+	// for that UTC date instead of today.
+	TimelineDate time.Time
+}
+
+// UptimeHistoryResponse carries the visor's own session history.
+// Current is the in-flight session row; Sessions is everything the
+// recorder has retained, oldest first. Timeline (when requested) is
+// the 36-byte 288-slot bitmap for TimelineDate, suitable for
+// rendering with serviceuptime.FormatBitmap.
+type UptimeHistoryResponse struct {
+	Current      serviceuptime.SessionRecord   `json:"current"`
+	Sessions     []serviceuptime.SessionRecord `json:"sessions"`
+	Timeline     []byte                        `json:"timeline,omitempty"`
+	TimelineDate string                        `json:"timeline_date,omitempty"`
 }
 
 // RuntimeStatsInfo carries Go runtime statistics for the visor process.

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -4,6 +4,7 @@ package visor
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -295,6 +296,48 @@ func (v *Visor) IsStartupComplete() bool {
 func (v *Visor) Uptime() (float64, error) {
 	return time.Since(v.startedAt).Seconds(), nil
 }
+
+// UptimeHistory implements API. Reads from the service-self uptime
+// recorder's bbolt store. Returns ErrUptimeRecorderUnavailable when
+// the recorder isn't wired (recorder open failed at startup or the
+// visor is running without LocalPath access).
+func (v *Visor) UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error) {
+	rec := v.UptimeRecorder()
+	if rec == nil {
+		return nil, ErrUptimeRecorderUnavailable
+	}
+	store := rec.Store()
+	sessions, err := store.Sessions(args.Since)
+	if err != nil {
+		return nil, fmt.Errorf("read sessions: %w", err)
+	}
+	if args.Limit > 0 && args.Limit < len(sessions) {
+		sessions = sessions[len(sessions)-args.Limit:]
+	}
+	resp := &UptimeHistoryResponse{
+		Current:  rec.CurrentSession(),
+		Sessions: sessions,
+	}
+	if args.IncludeTimeline {
+		date := args.TimelineDate
+		if date.IsZero() {
+			date = time.Now().UTC()
+		}
+		bm, err := store.Bitmap(date)
+		if err != nil {
+			return nil, fmt.Errorf("read timeline: %w", err)
+		}
+		resp.Timeline = bm
+		resp.TimelineDate = date.UTC().Format("2006-01-02")
+	}
+	return resp, nil
+}
+
+// ErrUptimeRecorderUnavailable is returned by UptimeHistory when the
+// recorder failed to open or wasn't wired into the visor (e.g. the
+// LocalPath is unwritable). Callers should distinguish this from a
+// "the recorder ran but has no data yet" empty response.
+var ErrUptimeRecorderUnavailable = errors.New("service-self uptime recorder not configured")
 
 // RuntimeStats implements API.
 func (v *Visor) RuntimeStats() (*RuntimeStatsInfo, error) {

--- a/pkg/visor/init_uptime.go
+++ b/pkg/visor/init_uptime.go
@@ -1,0 +1,52 @@
+// Package visor — pkg/visor/init_uptime.go: glue for the
+// service-self uptime recorder. The recorder itself is constructed
+// in run() (so a panic during NewVisor still leaves a session row);
+// this file owns the wireup that connects an existing recorder to
+// the rest of the visor — logserver routes, RPC accessor, close
+// stack — once NewVisor has succeeded.
+package visor
+
+import (
+	"github.com/skycoin/skywire/pkg/serviceuptime"
+)
+
+// SetUptimeRecorder attaches a serviceuptime.Recorder to the visor.
+// Idempotent re-attach is a no-op (first writer wins). Wires:
+//
+//   - the running recorder onto the logserver so /uptime/* routes
+//     surface live data over HTTP.
+//
+// The recorder's keepalive lifecycle is owned by the caller; this
+// method only stores the handle and registers it with surfaces that
+// need to read from it.
+func (v *Visor) SetUptimeRecorder(r *serviceuptime.Recorder) {
+	if r == nil {
+		return
+	}
+	v.initLock.Lock()
+	if v.uptimeRecorder != nil {
+		v.initLock.Unlock()
+		return
+	}
+	v.uptimeRecorder = r
+	v.initLock.Unlock()
+
+	// Wire the logserver. Constructed earlier in initDmsg, so the
+	// handle is available by the time run() calls us. Defensive
+	// nil-check keeps the code robust against init-order drift.
+	v.initLock.RLock()
+	lsAPI := v.logServer.api
+	v.initLock.RUnlock()
+	if lsAPI != nil {
+		lsAPI.SetUptimeRecorder(r)
+	}
+}
+
+// UptimeRecorder returns the wired recorder, or nil if SetUptimeRecorder
+// was never called (e.g. recorder open failed at startup). RPC and
+// inspection paths should nil-check.
+func (v *Visor) UptimeRecorder() *serviceuptime.Recorder {
+	v.initLock.RLock()
+	defer v.initLock.RUnlock()
+	return v.uptimeRecorder
+}

--- a/pkg/visor/init_uptime.go
+++ b/pkg/visor/init_uptime.go
@@ -31,14 +31,22 @@ func (v *Visor) SetUptimeRecorder(r *serviceuptime.Recorder) {
 	v.uptimeRecorder = r
 	v.initLock.Unlock()
 
-	// Wire the logserver. Constructed earlier in initDmsg, so the
-	// handle is available by the time run() calls us. Defensive
-	// nil-check keeps the code robust against init-order drift.
+	// Wire BOTH logservers — initDmsg builds two independent
+	// instances: the auth'd DMSG-port one (.api, served on
+	// DmsgHTTPPort with PK whitelist) and the localhost-only one
+	// (.localAPI, no auth, used by `skywire cli` and local curl).
+	// Each has its own *logserver.API value, so a single recorder
+	// must be registered on both. Defensive nil-checks cover
+	// init-order drift and the case where LocalAddr binding fails.
 	v.initLock.RLock()
 	lsAPI := v.logServer.api
+	lsLocal := v.logServer.localAPI
 	v.initLock.RUnlock()
 	if lsAPI != nil {
 		lsAPI.SetUptimeRecorder(r)
+	}
+	if lsLocal != nil {
+		lsLocal.SetUptimeRecorder(r)
 	}
 }
 

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -91,8 +92,9 @@ type API struct {
 	serviceLister       ServiceLister
 	forwardedPortLister ForwardedPortLister
 	cxoFeedsLister      CXOFeedsLister
-	statsReader         StatsReader  // visor-local telemetry store, set via SetStatsReader
-	websiteHandler      http.Handler // optional: serves unmatched routes (custom website)
+	statsReader         StatsReader             // visor-local telemetry store, set via SetStatsReader
+	uptimeRecorder      *serviceuptime.Recorder // service-self uptime, set via SetUptimeRecorder
+	websiteHandler      http.Handler            // optional: serves unmatched routes (custom website)
 	// ptyHandler serves /pty (web terminal) when set by the visor.
 	// Gated by ptyWhitelist — typically the dmsgpty whitelist (configured
 	// PKs + hypervisor PKs + the visor's own PK).
@@ -199,6 +201,10 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 	// /stats/* (auth'd) — visor-local telemetry store. Handlers
 	// degrade to 503 when SetStatsReader hasn't been called.
 	api.registerStatsRoutes(authRoute)
+
+	// /uptime/* (auth'd) — service-self uptime store. Handlers
+	// degrade to 503 when SetUptimeRecorder hasn't been called.
+	api.registerUptimeRoutes(authRoute)
 
 	// /pty (web terminal) — gated by ptyWhitelist (set via
 	// SetPtyHandler). Until the visor calls SetPtyHandler, the

--- a/pkg/visor/logserver/uptime.go
+++ b/pkg/visor/logserver/uptime.go
@@ -1,0 +1,56 @@
+// Package logserver — pkg/visor/logserver/uptime.go: gin shim for the
+// pkg/serviceuptime HTTP handlers. Wires /uptime/* onto the visor's
+// existing logserver router so a CLI client can render the visor's
+// session history without going through the unix-socket RPC.
+package logserver
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/skycoin/skywire/pkg/serviceuptime"
+)
+
+// SetUptimeRecorder wires the recorder into the log server. Safe
+// to call before or after handler registration; the routes nil-check
+// at request time, so a recorder attached after some early traffic
+// still works for subsequent requests.
+func (api *API) SetUptimeRecorder(r *serviceuptime.Recorder) {
+	api.uptimeRecorder = r
+}
+
+// registerUptimeRoutes mounts /uptime/* on authRoute. Each handler
+// degrades to 503 when api.uptimeRecorder is nil so the path stays
+// available for monitoring scrapes that don't want to special-case
+// pre-recorder visors.
+func (api *API) registerUptimeRoutes(authRoute *gin.RouterGroup) {
+	authRoute.GET("/uptime/now", func(c *gin.Context) {
+		if api.uptimeRecorder == nil {
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+		serviceuptime.CurrentSessionHandler(api.uptimeRecorder).ServeHTTP(c.Writer, c.Request)
+	})
+	authRoute.GET("/uptime/sessions", func(c *gin.Context) {
+		if api.uptimeRecorder == nil {
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+		serviceuptime.SessionsHandler(api.uptimeRecorder.Store()).ServeHTTP(c.Writer, c.Request)
+	})
+	authRoute.GET("/uptime/timeline", func(c *gin.Context) {
+		if api.uptimeRecorder == nil {
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+		serviceuptime.TimelineHandler(api.uptimeRecorder.Store()).ServeHTTP(c.Writer, c.Request)
+	})
+	authRoute.GET("/uptime/dates", func(c *gin.Context) {
+		if api.uptimeRecorder == nil {
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+		serviceuptime.DatesHandler(api.uptimeRecorder.Store()).ServeHTTP(c.Writer, c.Request)
+	})
+}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -175,6 +175,15 @@ func (rc *rpcClient) Uptime() (float64, error) {
 	return out, err
 }
 
+// UptimeHistory calls UptimeHistory.
+func (rc *rpcClient) UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error) {
+	var resp UptimeHistoryResponse
+	if err := rc.Call("UptimeHistory", &args, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // SetRewardAddress implements API.
 func (rc *rpcClient) SetRewardAddress(r string) (rConfig string, err error) {
 	err = rc.Call("SetRewardAddress", &r, &rConfig)

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -234,6 +234,11 @@ func (mc *mockRPCClient) Uptime() (float64, error) {
 	return time.Since(mc.startedAt).Seconds(), nil
 }
 
+// UptimeHistory implements API.
+func (mc *mockRPCClient) UptimeHistory(_ UptimeHistoryArgs) (*UptimeHistoryResponse, error) {
+	return &UptimeHistoryResponse{}, nil
+}
+
 // SetRewardAddress implements API
 func (mc *mockRPCClient) SetRewardAddress(_ string) (string, error) {
 	return "", nil

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -59,6 +59,23 @@ func (r *RPC) RuntimeStats(_ *struct{}, out *RuntimeStatsInfo) (err error) {
 	return err
 }
 
+// UptimeHistory returns the visor's session-level uptime history
+// (one row per process incarnation, version-tagged) plus optionally
+// today's 5-minute slot bitmap. Surfaces ErrUptimeRecorderUnavailable
+// when the recorder isn't wired so the CLI can render a clear
+// "(recorder unavailable)" instead of an empty list.
+func (r *RPC) UptimeHistory(in *UptimeHistoryArgs, out *UptimeHistoryResponse) (err error) {
+	defer rpcutil.LogCall(r.log, "UptimeHistory", in)(out, &err)
+	if in == nil {
+		in = &UptimeHistoryArgs{}
+	}
+	hist, err := r.visor.UptimeHistory(*in)
+	if hist != nil {
+		*out = *hist
+	}
+	return err
+}
+
 // Uptime returns for how long the visor has been running in seconds
 func (r *RPC) Uptime(_ *struct{}, out *float64) (err error) {
 	defer rpcutil.LogCall(r.log, "Uptime", nil)(out, &err)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
+	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dht"
@@ -33,6 +34,7 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/serviceuptime"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
@@ -187,6 +189,15 @@ type Visor struct {
 	// and is read by the /stats/* HTTP handlers and the CXO
 	// publisher.
 	statsTracker *stats.Tracker
+
+	// Service-self uptime recorder (nil when not wired). Owns the
+	// bbolt store at <local_path>/uptime.db, refreshes the current
+	// session row on a 60s tick, and surfaces both the visor's
+	// running version and its session history via /uptime/* HTTP
+	// endpoints. Distinct from statsTracker: this is for
+	// "was-the-visor-itself-running" with version provenance, not
+	// transport/tier/service uptime.
+	uptimeRecorder *serviceuptime.Recorder
 
 	// User-registered CXO TreeStore feeds keyed by name. Each feed
 	// is its own dmsg listener on a distinct port; the system feed
@@ -418,6 +429,24 @@ func run(conf *visorconfig.V1) error {
 		conf.Hypervisor.UIAssets = *uiAssets
 	}
 
+	// Open the service-self uptime recorder before NewVisor so a panic
+	// during subsystem init still leaves a session row with the
+	// running binary's version. Failure to open is non-fatal — the
+	// visor brings up without it; only the /uptime/* surface is missing.
+	uptimeRec, uptimeErr := serviceuptime.New(
+		filepath.Join(conf.LocalPath, "uptime.db"),
+		serviceuptime.Config{
+			Service: "skywire-visor",
+			Version: buildinfo.Version(),
+			Commit:  buildinfo.Commit(),
+		},
+	)
+	if uptimeErr != nil {
+		mLog.WithError(uptimeErr).Warn("Service-self uptime recorder unavailable")
+	} else {
+		defer func() { _ = uptimeRec.Close() }() //nolint:errcheck
+	}
+
 	ctx, cancel := cmdutil.SignalContext(context.Background(), mLog)
 	vis, ok := NewVisor(ctx, conf)
 	if !ok {
@@ -428,6 +457,11 @@ func run(conf *visorconfig.V1) error {
 			return fmt.Errorf("failed to start visor")
 		}
 		return nil
+	}
+
+	if uptimeRec != nil {
+		vis.SetUptimeRecorder(uptimeRec)
+		uptimeRec.Start()
 	}
 
 	stopVisorFn = func() {


### PR DESCRIPTION
## Motivation

Today there's no easy way to ask a service "when were you running, and which build?". The visor's stats package tracks the *visor's view* of tier/service uptime, but every period the visor itself was down records as a gap that's indistinguishable from "everything else was up". And **no service records its own restart history** — each restart wipes whatever ephemeral state the container had. Operators can't tell a 5-second restart loop from a clean run unless they correlate against external infrastructure.

This PR introduces \`pkg/serviceuptime\`: a small bbolt-backed recorder each long-running binary owns, plus visor + TPD adoption, plus CLI commands.

## What's in the box

### \`pkg/serviceuptime/\` (new package)

Bbolt store at \`<data>/uptime.db\` with three buckets:

| bucket | shape | semantics |
|---|---|---|
| \`meta/\` | k/v | schema version, durable per-DB instance ID |
| \`sessions/\` | start_unix_ts (8B BE) → JSON \`SessionRecord\` | one row per process incarnation |
| \`slots/\` | UTC date sub-buckets → 36-byte bitmap | 288 5-min slots per day, MSB-first |

Bitmap format is bit-identical to \`pkg/visor/stats/bitmap.go\` and TPD's \`tp-uptime:*:timeline\` redis format, so renderers can consume any of the three sources unchanged.

\`Recorder\` lifecycle is split: \`New()\` writes the session row + initial slot bit cheaply (asserted to be <500ms by test) so a service that crashes during config parsing still leaves a trace; \`Start()\` kicks off keepalive (60s) + prune (1h) goroutines; \`Close()\` does a final tick so \`LastSeen\` reflects shutdown. 35-day default retention.

HTTP handlers exported as plain \`http.HandlerFunc\` so callers using gin (visor's logserver) or chi (deployment services) wrap without either framework leaking into the package. \`FormatHistory\` / \`FormatBitmap\` render the typical "table of session spans" and "288-char ASCII timeline" so any consumer (CLI, web UI) is uniform.

### Visor wiring

- \`run()\` opens the recorder right after \`initConfig()\` and **before** \`NewVisor\`, with \`defer Close\`. A panic during any subsystem bring-up still leaves a session row.
- \`SetUptimeRecorder\` on \`Visor\` stores the handle; \`init_uptime.go\` forwards it to **both** logserver instances (DMSG-auth'd \`.api\` and the localhost-only \`.localAPI\` used by local tools).
- \`pkg/visor/logserver\`: new \`SetUptimeRecorder\` setter; new \`/uptime/{now,sessions,timeline,dates}\` gin routes alongside \`/stats/*\`, gated behind the same auth. Each handler 503s until the recorder is wired.

### Transport-discovery wiring (template)

- \`cmd/svc/transport-discovery\`: new \`--uptime-db\` flag (default \`/var/lib/skywire/tpd/uptime.db\`); recorder opened early in \`Run\` with version/commit from \`buildinfo\`; deferred Close.
- \`pkg/transport-discovery/api\`: \`SetUptimeRecorder\` method; chi routes mirroring the visor's shape (no auth, matches the unauth'd \`/health\`).
- The same wiring (~4 lines in main + \`SetUptimeRecorder\`) drops into AR/RF/UT/SD in a follow-up.

### CLI

- \`skywire cli visor uptime\` — visor RPC. New \`UptimeHistory(args)\` method on the visor's \`API\` interface, plumbed through the standard 5-file path (interface, impl, rpc server, rpc client, mock client). Flags: \`--limit\`, \`--since\` (RFC3339 \| unix), \`--timeline\`, \`--date\` YYYY-MM-DD, \`--gap-threshold\`, \`--restart-loop-threshold\`, \`--json\`.
- \`skywire cli svc tpd uptime\` — reuses the existing \`fetchViaVisorOrDirect\` infra (visor proxies via \`FetchServiceData("tpd", "/uptime/sessions")\`, \`--direct\` hits TPD's HTTP endpoint directly). No new TPD-specific RPC. Falls back to \`emitPretty\` on a non-array body so an older TPD or 503 is surfaced rather than parse-failing.

Both render through \`serviceuptime.FormatHistory\` so output is uniform.

Sample human output:

\`\`\`
running: v1.3.48-0-ebde67f5c (since 2026-05-04 15:25:46Z, 6.8h)  pid=1234  instance=7f9ac0e4...

2026-05-03 21:38:02Z  →  2026-05-03 22:14:00Z  35m58s  v1.3.48-0-80fef7159
                                                        (down: 4m12s)
2026-05-03 22:18:12Z  →  2026-05-03 22:18:15Z  3.0s    v1.3.48-0-80fef7159  (restart loop?)
2026-05-03 22:18:18Z  →  2026-05-03 22:18:21Z  3.0s    v1.3.48-0-80fef7159  (restart loop?)
2026-05-04 03:00:32Z  →  2026-05-04 15:25:46Z  12.4h   v1.3.48-0-969ce9cd0
                                                        (down: 0s)
2026-05-04 15:25:46Z  →  2026-05-04 22:14:00Z  6.8h    v1.3.48-0-ebde67f5c
\`\`\`

## Distinguishes

- **"Service was not running"** → gap between adjacent sessions' \`LastSeen\` and next \`StartedAt\` renders as \`(down: <duration>)\`.
- **"Restart looping"** → sessions clustered with short \`Duration()\`s tagged at render time. Operators can immediately see "started, ran for 3s, restarted; …" without grepping container logs.
- **"Which version was running when"** → \`Version\` + \`Commit\` on every session row.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./pkg/serviceuptime/ ./pkg/transport-discovery/... ./pkg/visor/...\` all pass.
- [x] \`gofmt\` clean across \`pkg/\` and \`cmd/\`.
- [x] Built CLI (\`go build ./cmd/skywire-cli/\`) and verified \`skywire-cli visor uptime --help\` and \`skywire-cli svc tpd uptime --help\` show the new commands with their flag set.
- [x] **9 unit tests** in \`pkg/serviceuptime\` cover round-trip, since-filter ordering, slot idempotency, prune retention (including a long-running session whose \`StartedAt\` is older than the cutoff but \`LastSeen\` is fresh — preserved), instance-ID durability, fast-\`New()\`, and keepalive advancement via a fake clock.
- [ ] Post-deploy on the prod host:
  - Restart the visor; \`skywire cli visor uptime\` shows the previous session and the new one with \`Version\` matching \`skywire cli visor info\`.
  - Restart TPD (or stop+start); \`skywire cli svc tpd uptime\` shows the gap as \`(down: ...)\` and the new session row.
  - \`skywire cli visor uptime --timeline --date $(date -u +%F)\` renders the day's bitmap.

## Out of scope (still)

- **AR/RF/UT/SD wiring** — TPD is the template; rolling out to the rest is mechanical (~10 lines per service) and should land in a follow-up PR per service so each can be reviewed against its own command's flags.
- **compose.yaml volume mounts** — the \`--uptime-db\` flag defaults to \`/var/lib/skywire/<svc>/uptime.db\`. Production deployment will need a persistent volume per service; that's a deployment-side change, not a code-side one.

## Diff stat

\`\`\`
17 files changed, +1100 / -7
\`\`\`