### PR TITLE
perf(tpd): bulk-read uptime timeline bitmaps with one GET per day

### DIFF
--- a/pkg/transport-discovery/store/redis_uptime.go
+++ b/pkg/transport-discovery/store/redis_uptime.go
@@ -139,40 +139,13 @@ func (s *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.
 // 5-minute slot, ' ' = missed.
 func (s *redisStore) GetDailyTimeline(ctx context.Context, pkHex string, now time.Time) map[string]string {
 	timelines := make(map[string]string)
-
 	for i := 0; i < uptimeHistoryDays; i++ {
 		date := now.AddDate(0, 0, -i).Format("2006-01-02")
 		tlKey := uptimeTimelineKey(pkHex, date)
-
-		// Read all 288 bits. Redis GETBIT returns 0 for unset bits
-		// and for keys that don't exist, so this is safe.
-		var buf [timelineSlots]byte
-		pipe := s.client.Pipeline()
-		cmds := make([]*redis.IntCmd, timelineSlots)
-		for slot := 0; slot < timelineSlots; slot++ {
-			cmds[slot] = pipe.GetBit(ctx, tlKey, int64(slot))
-		}
-		_, err := pipe.Exec(ctx)
-		if err != nil {
-			continue
-		}
-
-		hasAny := false
-		for slot := 0; slot < timelineSlots; slot++ {
-			if cmds[slot].Val() == 1 {
-				buf[slot] = '.'
-				hasAny = true
-			} else {
-				buf[slot] = ' '
-			}
-		}
-
-		// Only include days that have at least one heartbeat.
-		if hasAny {
-			timelines[date] = string(buf[:])
+		if line, ok := readTimelineLine(ctx, s.client, tlKey); ok {
+			timelines[date] = line
 		}
 	}
-
 	return timelines
 }
 
@@ -374,30 +347,49 @@ func (s *redisStore) GetTransportDailyTimeline(ctx context.Context, tpID string,
 	for i := 0; i < uptimeHistoryDays; i++ {
 		date := now.AddDate(0, 0, -i).Format("2006-01-02")
 		tlKey := tpUptimeTimelineKey(tpID, date)
-
-		pipe := s.client.Pipeline()
-		cmds := make([]*redis.IntCmd, timelineSlots)
-		for slot := 0; slot < timelineSlots; slot++ {
-			cmds[slot] = pipe.GetBit(ctx, tlKey, int64(slot))
-		}
-		_, err := pipe.Exec(ctx)
-		if err != nil {
-			continue
-		}
-
-		var buf [timelineSlots]byte
-		hasAny := false
-		for slot := 0; slot < timelineSlots; slot++ {
-			if cmds[slot].Val() == 1 {
-				buf[slot] = '.'
-				hasAny = true
-			} else {
-				buf[slot] = ' '
-			}
-		}
-		if hasAny {
-			timelines[date] = string(buf[:])
+		if line, ok := readTimelineLine(ctx, s.client, tlKey); ok {
+			timelines[date] = line
 		}
 	}
 	return timelines
+}
+
+// readTimelineLine fetches a 288-bit / 36-byte daily uptime bitmap
+// from redis with a single GET and renders it to the conventional
+// "." / " " text form. Returns (line, false) when the key doesn't
+// exist OR when no bits are set — matching the prior "skip empty
+// days" behavior of the per-bit pipeline this replaces.
+//
+// Was: Pipeline + 288 GETBIT calls per day, each allocating an
+// *IntCmd. With uptimeHistoryDays=7 that's 2,016 commands per
+// summary call; in production /uptimes?v=v3 served at p2p churn
+// rates this dominated TPD's GC (>70% CPU in runtime.scanObject /
+// spanClass.sizeclass per pprof). One GET per day reads the same
+// bytes server-side; same wire format the SETBIT writers use.
+func readTimelineLine(ctx context.Context, client redis.UniversalClient, tlKey string) (string, bool) {
+	raw, err := client.Get(ctx, tlKey).Bytes()
+	if err != nil || len(raw) == 0 {
+		return "", false
+	}
+	var buf [timelineSlots]byte
+	hasAny := false
+	for slot := 0; slot < timelineSlots; slot++ {
+		byteIdx := slot / 8
+		if byteIdx >= len(raw) {
+			buf[slot] = ' '
+			continue
+		}
+		// Redis SETBIT stores bits MSB-first within each byte —
+		// matching pkg/visor/stats/bitmap.go and pkg/serviceuptime.
+		if raw[byteIdx]&(1<<uint(7-slot%8)) != 0 {
+			buf[slot] = '.'
+			hasAny = true
+		} else {
+			buf[slot] = ' '
+		}
+	}
+	if !hasAny {
+		return "", false
+	}
+	return string(buf[:]), true
 }


### PR DESCRIPTION
## Symptom

Production TPD running at 172% CPU continuously. \`docker stats\` snapshot:

\`\`\`
transport-discovery   172.33%   1.533GiB / 7.755GiB   27.1GB / 101GB
dmsg-server-6          47.70%
address-resolver       23.25%
redis                  25.36%
\`\`\`

System load average ~11. RestartCount 0 across all containers — this is busy CPU, not crash-loop.

## Diagnosis

30s CPU profile via \`/debug/pprof/profile\`:

| node | flat % | cum % | function |
|---|---|---|---|
| 1 | 43.85% | 43.85% | \`runtime.spanClass.sizeclass\` |
| 2 | 8.24% | 53.11% | \`runtime.tryDeferToSpanScan\` |
| 3 | 2.80% | 59.43% | \`runtime.scanObject\` |
| 4 | 2.06% | 68.11% | \`runtime.scanObjectsSmall\` |
| 5 | 2.06% | 70.17% | \`runtime.sweepone\` |

\~75% of CPU in GC. Application code below the rounding error.

Heap profile by alloc_objects:

| flat % | cum % | function |
|---|---|---|
| 16.88% | 25.36% | \`go-redis/redis/v8.cmdable.GetBit\` |
| 11.46% | 11.46% | \`encoding/hex.EncodeToString\` |
| 8.41% | 8.41% | \`go-redis/redis/v8.NewIntCmd\` |
| 5.42% | 16.22% | \`pkg/cipher.PubKey.MarshalText\` |

\`pprof -peek GetBit\` traced 100% of GetBit allocations to a single caller: \`(*redisStore).GetDailyTimeline\`.

## Root cause

\`GetDailyTimeline\` and its per-transport sibling \`GetTransportDailyTimeline\` pipelined **288 GETBIT commands per day** — one per 5-minute slot — and allocated 288 \`*redis.IntCmd\` values per day per call. With \`uptimeHistoryDays=7\` each call cost **2,016 redis commands** and **\~2,016 heap allocations**.

\`\`\`go
// before
pipe := s.client.Pipeline()
cmds := make([]*redis.IntCmd, timelineSlots)
for slot := 0; slot < timelineSlots; slot++ {
    cmds[slot] = pipe.GetBit(ctx, tlKey, int64(slot))
}
\`\`\`

\### Why it ran so hot

\`UptimeCXOPublisher.publishOnce\` (\`cxo_uptime_publisher.go:144\`) runs every **60 seconds** and walks every visor in the fleet:

\`\`\`go
for i := range enriched {
    enriched[i].Timeline = u.api.store.GetDailyTimeline(ctx, enriched[i].PK.Hex(), now)
}
\`\`\`

With ~200 visors: **~400,000 redis commands and ~400,000 \`*IntCmd\` allocations per minute**, all churning short-lived garbage. That's where the 75%-of-CPU-in-GC came from.

The CXO publisher path generates zero HTTP access-log entries (subscribers reach it through their visor's CXO subscriber, not \`GET /uptimes\`), which is why \`docker logs --since 5m | grep /uptimes\` showed 0 hits despite the path being the dominant CPU sink.

## Fix

Each 288-slot daily bitmap is **36 bytes**. Replace the 288-call pipeline with one \`GET\` per day and decode bits locally:

\`\`\`go
raw, err := client.Get(ctx, tlKey).Bytes()
// ...
for slot := 0; slot < timelineSlots; slot++ {
    if raw[slot/8] & (1<<uint(7-slot%8)) != 0 { ... }
}
\`\`\`

288× fewer commands per call. Wire format is bit-identical — Redis SETBIT writes MSB-first within each byte, same as \`pkg/visor/stats/bitmap.go\` and \`pkg/serviceuptime/bitmap.go\`. The "skip empty days" semantic of the prior code is preserved: a missing key OR an all-zero bitmap returns \`("", false)\` so days with no heartbeats stay out of the response map.

Extracted into a \`readTimelineLine\` helper shared by both \`GetDailyTimeline\` (visor) and \`GetTransportDailyTimeline\` (per-transport).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./pkg/transport-discovery/...\` clean.
- [x] \`go test ./pkg/transport-discovery/...\` all pass.
- [x] \`gofmt\` clean.
- [ ] Post-deploy on the prod host: TPD CPU drops from ~170% to baseline (<30%); load average drops; \`runtime.spanClass.sizeclass\` no longer dominates the CPU profile; \`/uptimes?v=v3\` and \`/uptimes/transports?v=v3\` return identical wire output (same per-day timeline strings).

## Diff stat

\`\`\`
1 file changed, 42 insertions(+), 50 deletions(-)
\`\`\`