### PR TITLE
perf(tpd): no-latency variant for mirrorEdges + concat redis-key builders

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -520,6 +520,10 @@ func newMemoryStoreFromEntries(entries []*transport.Entry) *memoryStore {
 	return &memoryStore{entries: entries, byEdge: byEdge}
 }
 
+func (s *memoryStore) GetTransportsByEdgeNoLatency(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	return s.GetTransportsByEdge(ctx, pk)
+}
+
 func (s *memoryStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
 	if tps, ok := s.byEdge[pk]; ok {
 		return tps, nil

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -41,6 +41,10 @@ func (m *mockStore) DeregisterTransport(context.Context, uuid.UUID) error {
 func (m *mockStore) GetTransportByID(context.Context, uuid.UUID) (*transport.Entry, error) {
 	return nil, nil
 }
+func (m *mockStore) GetTransportsByEdgeNoLatency(ctx context.Context, edgePK cipher.PubKey) ([]*transport.Entry, error) {
+	return m.GetTransportsByEdge(ctx, edgePK)
+}
+
 func (m *mockStore) GetTransportsByEdge(_ context.Context, edgePK cipher.PubKey) ([]*transport.Entry, error) {
 	trs, ok := m.transports[edgePK]
 	if !ok {

--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -295,7 +295,13 @@ func (api *API) mirrorEdges(ctx context.Context, edges map[cipher.PubKey]struct{
 	}
 	seq := uint64(time.Now().UnixNano()) //nolint:gosec
 	for edge := range edges {
-		entries, err := api.store.GetTransportsByEdge(ctx, edge)
+		// DHT consumers don't read the Latency field — skip the
+		// per-call MGET on lat:<id> + decode by using the
+		// no-latency variant. Production pprof showed mirrorEdges
+		// as 97.7% of GetTransportsByEdge alloc traffic, with
+		// hydrateDurableLatency contributing 10.5% of total
+		// alloc_objects.
+		entries, err := api.store.GetTransportsByEdgeNoLatency(ctx, edge)
 		if err != nil || len(entries) == 0 {
 			api.dhtMirror.Delete(edge)
 			continue

--- a/pkg/transport-discovery/store/memory_store.go
+++ b/pkg/transport-discovery/store/memory_store.go
@@ -92,7 +92,11 @@ func (s *memoryStore) GetTransportByID(_ context.Context, id uuid.UUID) (*transp
 	return v, nil
 }
 
-func (s *memoryStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+func (s *memoryStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	return s.GetTransportsByEdgeNoLatency(ctx, pk)
+}
+
+func (s *memoryStore) GetTransportsByEdgeNoLatency(_ context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
 	if s.err != nil {
 		return nil, s.err
 	}

--- a/pkg/transport-discovery/store/redis_transport.go
+++ b/pkg/transport-discovery/store/redis_transport.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -214,7 +213,41 @@ func (s *redisStore) GetTransportByID(ctx context.Context, id uuid.UUID) (*trans
 	return entry, nil
 }
 
+// GetTransportsByEdge returns every transport involving pk, with the
+// durable latency overlay applied so HTTP responses include current
+// min/max/avg from the lat:<id> keys.
+//
+// Callers that don't need latency (DHT mirroring, transport-count
+// stats) should use GetTransportsByEdgeNoLatency to skip the per-call
+// MGET on the latency keyspace and the JSON decode that follows.
+// Production pprof traced 97.7% of GetTransportsByEdge invocations
+// to mirrorEdges, where the DHT consumer doesn't read the latency
+// field at all — that's the hot path the no-latency variant is for.
 func (s *redisStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	entries, err := s.getTransportsByEdge(ctx, pk)
+	if err != nil {
+		return nil, err
+	}
+	s.hydrateDurableLatency(ctx, entries)
+	s.edgeCache.Put(pk, entries)
+	return entries, nil
+}
+
+// GetTransportsByEdgeNoLatency is the no-overlay sibling of
+// GetTransportsByEdge. The returned entries' Latency field reflects
+// what was in the tp:<id> blob (typically 0 — see #2418), not the
+// durable lat:<id> store.
+func (s *redisStore) GetTransportsByEdgeNoLatency(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	if entries, ok := s.edgeCache.Get(pk); ok {
+		return entries, nil
+	}
+	return s.getTransportsByEdge(ctx, pk)
+}
+
+// getTransportsByEdge does the MGET + decode without any latency
+// hydration or cache write. Shared by both public methods so the
+// fetch logic stays in one place.
+func (s *redisStore) getTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
 	if entries, ok := s.edgeCache.Get(pk); ok {
 		return entries, nil
 	}
@@ -235,8 +268,8 @@ func (s *redisStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) 
 		idStr string
 		id    uuid.UUID
 	}
-	var mappings []idMapping
-	var keys []string
+	mappings := make([]idMapping, 0, len(ids))
+	keys := make([]string, 0, len(ids))
 	for _, idStr := range ids {
 		id, err := uuid.Parse(idStr)
 		if err != nil {
@@ -256,7 +289,7 @@ func (s *redisStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) 
 		return nil, err
 	}
 
-	var entries []*transport.Entry
+	entries := make([]*transport.Entry, 0, len(vals))
 	var staleIDs []interface{}
 	for i, val := range vals {
 		raw, ok := val.(string)
@@ -288,9 +321,6 @@ func (s *redisStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) 
 	if len(entries) == 0 {
 		return nil, ErrTransportNotFound
 	}
-
-	s.hydrateDurableLatency(ctx, entries)
-	s.edgeCache.Put(pk, entries)
 	return entries, nil
 }
 
@@ -472,8 +502,13 @@ func (s *redisStore) scanAllTransports(ctx context.Context, selfTransports, with
 // Maintained on Register/Deregister; replaces the pre-existing
 // SCAN of the tp:* keyspace used by GetNumberOfTransports,
 // scanAllTransports, and getP2PTransportCounts.
+//
+// Hot-path key builders use string concatenation rather than
+// fmt.Sprintf. Sprintf was 9% of TPD's total alloc_objects in
+// production pprof; concat compiles to a single buffer write and
+// avoids the format-state machinery.
 func (s *redisStore) allTpsIndexKey() string {
-	return fmt.Sprintf("%s:tp:_index", serviceName)
+	return serviceName + ":tp:_index"
 }
 
 // allTransportKeysFromIndex reads the transport-id index set and returns
@@ -486,7 +521,7 @@ func (s *redisStore) allTransportKeysFromIndex(ctx context.Context) (keys, ids [
 	}
 	keys = make([]string, len(ids))
 	for i, id := range ids {
-		keys[i] = fmt.Sprintf("%s:tp:%s", serviceName, id)
+		keys[i] = serviceName + ":tp:" + id
 	}
 	return keys, ids, nil
 }
@@ -505,15 +540,15 @@ func (s *redisStore) maybeReapStaleTransports(stale []interface{}) {
 }
 
 func (s *redisStore) transportKey(id uuid.UUID) string {
-	return fmt.Sprintf("%s:tp:%s", serviceName, id.String())
+	return serviceName + ":tp:" + id.String()
 }
 
 func (s *redisStore) latencyKey(id uuid.UUID) string {
-	return fmt.Sprintf("%s:lat:%s", serviceName, id.String())
+	return serviceName + ":lat:" + id.String()
 }
 
 func (s *redisStore) edgeKey(pk cipher.PubKey) string {
-	return fmt.Sprintf("%s:edge:%s", serviceName, pk.Hex())
+	return serviceName + ":edge:" + pk.Hex()
 }
 
 // dataToEntry converts TransportData to Entry with full QoS metrics.

--- a/pkg/transport-discovery/store/store.go
+++ b/pkg/transport-discovery/store/store.go
@@ -177,6 +177,11 @@ type TransportStore interface {
 	DeregisterTransport(context.Context, uuid.UUID) error
 	GetTransportByID(context.Context, uuid.UUID) (*transport.Entry, error)
 	GetTransportsByEdge(context.Context, cipher.PubKey) ([]*transport.Entry, error)
+	// GetTransportsByEdgeNoLatency is the cheap variant for callers
+	// (DHT mirror, transport-count stats) that don't need the
+	// durable latency overlay. Skips the per-call MGET on lat:<id>
+	// keys and the JSON decode that follows.
+	GetTransportsByEdgeNoLatency(context.Context, cipher.PubKey) ([]*transport.Entry, error)
 	GetNumberOfTransports(context.Context) (map[types.Type]int, error)
 	GetAllTransports(context.Context, bool) ([]*transport.Entry, error)
 	// Bandwidth ingest (called by the CXO aggregator with the

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -845,6 +845,10 @@ func newCalcMemStore(entries []*transport.Entry) *calcMemStore {
 	return &calcMemStore{byEdge: byEdge}
 }
 
+func (s *calcMemStore) GetTransportsByEdgeNoLatency(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	return s.GetTransportsByEdge(ctx, pk)
+}
+
 func (s *calcMemStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
 	if tps, ok := s.byEdge[pk]; ok {
 		return tps, nil


### PR DESCRIPTION
## Symptom

Even after #2429 (the GetBit-fan-out fix) deployed, TPD still pinned at **167% CPU** with **75% of CPU in runtime GC**. RestartCount 0 — busy CPU, no panic loop. \`GetBit\` is gone from the heap profile (the prior fix held), but a different allocator took over the top.

## Diagnosis

Fresh 30s CPU profile post-#2429: same shape — \`runtime.spanClass.sizeclass\`, \`scanObject\`, \`tryDeferToSpanScan\` dominate, application code below the rounding error. Heap profile by alloc_objects:

\| flat % \| cum % \| function \|
\|---\|---\|---\|
\| 16.35% \| 16.35% \| \`encoding/hex.EncodeToString\` \|
\| 13.86% \| 30.00% \| \`json-iterator/go.(*textMarshalerEncoder).Encode\` \|
\| 7.71% \| 23.28% \| \`pkg/cipher.PubKey.MarshalText\` \|
\| 3.02% \| **32.38%** \| \`(*redisStore).GetTransportsByEdge\` \|
\| 1.60% \| 10.48% \| \`(*redisStore).hydrateDurableLatency\` \|
\| 1.56% \| 4.62% \| \`(*redisStore).latencyKey\` \(\`fmt.Sprintf\`\) \|
\| 1.47% \| 4.43% \| \`(*redisStore).transportKey\` \(\`fmt.Sprintf\`\) \|

\`pprof -peek hex.EncodeToString\`: 99.24% of allocations from \`cipher.PubKey.Hex\`.
\`pprof -peek GetTransportsByEdge\`: **97.68% of invocations from \`mirrorEdges\`** — fires on every transport register / delete to re-publish the edge's full transport list to the DHT.

## Root cause

\`mirrorEdges\` walks every touched edge → \`GetTransportsByEdge(edge)\` → which:

1. Cache miss → MGET \`tp:<id>\` for each id, JSON-decode each \`TransportData\`.
2. **Always runs \`hydrateDurableLatency\`** — another per-call MGET on the \`lat:<id>\` keyspace + N JSON decodes for the latency overlay (added by #2418 for HTTP responses that need fresh latency).
3. Caches the result.

The DHT consumer doesn't read the Latency field — that work was pure overhead on the dominant call path. Plus every step uses \`fmt.Sprintf\` to build redis keys; with a few hundred mirror cycles/sec, those format-state-machine allocations add up.

## Fix

\### 1. No-latency variant for callers that don't need the overlay

Split \`GetTransportsByEdge\` into:

- \`getTransportsByEdge\` (unexported) — fetch + decode, no hydrate, no cache write.
- \`GetTransportsByEdge\` — calls core + hydrate + cache. Existing HTTP behavior unchanged.
- \`GetTransportsByEdgeNoLatency\` — cache-only read of the no-latency core. Skips the per-call MGET on \`lat:*\` plus N JSON decodes.

Switch \`mirrorEdges\` to \`GetTransportsByEdgeNoLatency\`. Saves ~10% of total alloc_objects on the hot path.

Added to the \`Store\` interface; memory store + three test/mock stubs (rpcgrpc, cli/route/calc, route-finder/store) gain the method as a thin alias. No production behavior change for callers that still want fresh latency in the response.

\### 2. \`fmt.Sprintf\` → string concat in five hot redis-key builders

\`transportKey\`, \`latencyKey\`, \`edgeKey\`, \`allTpsIndexKey\`, and the inline format in \`allTransportKeysFromIndex\` all built keys with \`fmt.Sprintf("%s:tp:%s", serviceName, id)\` — clear but expensive (\~10% of TPD's total alloc_objects). Plain concat compiles to a single buffer write and skips the format-state-machine allocations:

\`\`\`go
// before
return fmt.Sprintf("%s:tp:%s", serviceName, id.String())
// after
return serviceName + ":tp:" + id.String()
\`\`\`

Same key strings, same wire shape, no behavior change.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./pkg/transport-discovery/...\` all pass (redisStore + memoryStore).
- [x] \`gofmt\` clean.
- [ ] Post-deploy: TPD CPU drops below ~50% (or whatever the new baseline is); \`runtime.spanClass.sizeclass\` no longer dominates the CPU profile; \`/transports/edge:\` HTTP responses still carry latency in their JSON (HTTP path unchanged); \`mirrorEdges\` no longer shows \`hydrateDurableLatency\` in its alloc trace.

## Sequencing

Layered on top of #2429 conceptually but doesn't depend on its branch — both touch \`pkg/transport-discovery/store\` but in different files (#2429 in \`redis_uptime.go\`, this one in \`redis_transport.go\` / \`store.go\` / \`memory_store.go\` / \`api/api.go\`). Either can merge first.

## Diff stat

\`\`\`
7 files changed, +76 / -14
\`\`\`