### PR TITLE
visor: wire --pprofmode through dmsg cmdutil so non-http modes work

### DIFF
--- a/pkg/visor/etc.go
+++ b/pkg/visor/etc.go
@@ -3,47 +3,13 @@ package visor
 
 import (
 	"fmt"
-	"net/http"
-	nethttppprof "net/http/pprof" //nolint:gosec // https://golang.org/doc/diagnostics.html#profiling
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/logging"
 )
-
-func initPProf(log *logging.MasterLogger, profMode string, profAddr string) (stop func()) {
-	switch profMode {
-	case "http":
-		go func() {
-			// Use a dedicated mux to avoid conflicts with DefaultServeMux
-			// (which other components like skychat may register on).
-			mux := http.NewServeMux()
-			mux.HandleFunc("/debug/pprof/", nethttppprof.Index)
-			mux.HandleFunc("/debug/pprof/cmdline", nethttppprof.Cmdline)
-			mux.HandleFunc("/debug/pprof/profile", nethttppprof.Profile)
-			mux.HandleFunc("/debug/pprof/symbol", nethttppprof.Symbol)
-			mux.HandleFunc("/debug/pprof/trace", nethttppprof.Trace)
-			srv := &http.Server{ //nolint:gosec
-				Addr:              profAddr,
-				Handler:           mux,
-				ReadHeaderTimeout: 5 * time.Second,
-				WriteTimeout:      30 * time.Second,
-			}
-			log.WithField("addr", profAddr).Info("Serving pprof on http")
-			err := srv.ListenAndServe()
-			log.WithError(err).
-				WithField("mode", profMode).
-				WithField("addr", profAddr).
-				Info("Stopped serving pprof on http.")
-		}()
-	}
-
-	stop = func() {}
-	return stop
-}
 
 func logBuildInfo(mLog *logging.MasterLogger) {
 	log := mLog.PackageLogger("buildinfo")

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dht"
+	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -387,7 +388,7 @@ func run(conf *visorconfig.V1) error {
 	logBroadcaster := logging.NewBroadcaster()
 	mLog.AddHook(logBroadcaster)
 
-	stopPProf := initPProf(mLog, pprofMode, pprofAddr)
+	stopPProf := dmsgcmdutil.InitPProf(mLog.PackageLogger("pprof"), pprofMode, pprofAddr)
 	defer stopPProf()
 
 	if conf == nil {


### PR DESCRIPTION
## Summary
- `pkg/visor/cmd.go:121` advertises `--pprofmode [ cpu | mem | mutex | block | trace | http ]`, but the local `initPProf` in `pkg/visor/etc.go` only implemented `"http"` — every other mode silently no-oped.
- The full implementation already exists at `pkg/dmsg/cmdutil/pprof.go` (`InitPProf`) and is used by every dmsg/svc binary. This PR routes the visor through the same function and deletes the redundant local copy.
- The `http` mode also picks up the dedicated-OS-thread treatment (`runtime.LockOSThread` + extra `GOMAXPROCS` slot) and the additional handler registrations (`heap`, `goroutine`, `threadcreate`, `block`, `mutex`, `allocs`) that the standalone implementation already had.

## Test plan
- [ ] `--pprofmode=http`: hit `http://localhost:6060/debug/pprof/` and confirm all profile types are listed
- [ ] `--pprofmode=cpu`: confirm a `cpu.pprof` is written on shutdown
- [ ] `--pprofmode=mem|mutex|block`: confirm respective `.pprof` is written on shutdown
- [ ] `--pprofmode=trace`: confirm `/debug/pprof/trace` works on the configured addr