### PR TITLE
nix: derive source-build version from flake git metadata, fix readme flake input

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -31,7 +31,7 @@ From a checkout of this repo:
 Or as a flake input from somewhere else:
 
     {
-      inputs.skywire.url = "github:0pcom/skywire/nix/packaging";
+      inputs.skywire.url = "github:skycoin/skywire?dir=nix";
       # …
       outputs = { self, nixpkgs, skywire, ... }: {
         # nixosConfigurations / systemPackages / etc.
@@ -50,14 +50,16 @@ into the `hashes` attrset in `flake.nix` and rebuild. Repeat for
 each arch you want to support.
 
 `skywire.nix` defaults to building from the **local working tree**
-(handy for iterating on a branch). To build a tagged release from
-upstream instead, override `rev` and `version` when calling it from
-the flake (the parameter for an explicit src tree is `srcOverride`,
-to dodge a `pkgs.src` callPackage auto-bind collision in nixpkgs):
+(handy for iterating on a branch); the flake hands it a
+`git describe`-style version derived from `self.shortRev`, so
+`skywire --bv` reports the actual commit you built. To build a
+tagged release from upstream instead, override `rev` when calling
+it (version is auto-derived by stripping the leading `v`); the
+parameter for an explicit src tree is `srcOverride`, to dodge a
+`pkgs.src` callPackage auto-bind collision in nixpkgs:
 
     pkgs.callPackage ./skywire.nix {
-      rev     = "v1.3.50";
-      version = "1.3.50";
+      rev = "v1.3.50";
     }
 
 The first such build will fail with the expected `hash` for

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -24,14 +24,26 @@
             ];
         };
 
-        # Pin the version once for both packages. Bump this when
-        # cutting a new release — the source build picks the matching
-        # git tag (or the working tree, the default), and the
-        # binary build expects upstream tarballs at v${version}.
-        version = "1.3.50";
+        # Source-build version comes from the flake's own git
+        # metadata — analogous to the Makefile's
+        # `git describe --always`. Clean tree → short commit SHA;
+        # dirty tree → short SHA with a `-dirty` suffix; no git info
+        # at all → "dev". For a tagged release build, override `rev`
+        # in the call below (or pass `version` directly) and
+        # skywire.nix will strip the leading "v" off the rev.
+        sourceVersion =
+          if self ? shortRev then self.shortRev
+          else if self ? dirtyShortRev then self.dirtyShortRev
+          else "dev";
+
+        # The binary build downloads a release tarball whose URL
+        # encodes the semver, so this one stays a hand-written
+        # constant. Bump on each release. The source build does not
+        # use this — it derives version from git above.
+        binaryVersion = "1.3.50";
 
         skywire = pkgs.callPackage ./skywire.nix {
-          inherit version;
+          version = sourceVersion;
           # Default: build from the local working tree (../..). To
           # build a tagged release from upstream instead, override:
           #
@@ -41,7 +53,7 @@
         };
 
         skywire-bin = pkgs.callPackage ./skywire-bin.nix {
-          inherit version;
+          version = binaryVersion;
           # Fill in real hashes here once the release is cut. First
           # `nix build .#skywire-bin` will print the expected hash
           # for whichever arch you're on; copy it in.

--- a/nix/skywire-bin.nix
+++ b/nix/skywire-bin.nix
@@ -3,7 +3,10 @@
   stdenvNoCC,
   fetchurl,
   runtimeShell,
-  version ? "1.3.50",
+  # Required: the release tarball URL encodes the semver, so unlike
+  # the source build there is nothing to derive it from. Callers
+  # (the flake, or a direct callPackage) must supply it.
+  version,
   hashes ? null,
 }:
 

--- a/nix/skywire.nix
+++ b/nix/skywire.nix
@@ -5,7 +5,15 @@
   fetchFromGitHub,
   runtimeShell,
   rev ? null,
-  version ? "1.3.50",
+  # If the caller passes `rev = "v1.3.50"`, strip the leading "v"
+  # and use the rest as version — saves having to repeat the same
+  # number twice. Otherwise the flake derives a git-describe-style
+  # version from `self` and passes it in explicitly; bare callers
+  # that pass neither end up with a "dev" tag in --bv.
+  version ?
+    if rev != null
+    then lib.removePrefix "v" rev
+    else "dev",
   # Renamed from `src` because callPackage auto-binding hits the
   # nixpkgs `pkgs.src` throw alias (renamed to
   # `simple-revision-control` in 2025-11) before applying our


### PR DESCRIPTION
## Summary
- `nix/README.md` flake-input snippet pointed at a fork URL by mistake; it now matches the top-level README's `github:skycoin/skywire?dir=nix`.
- `flake.nix` derives the source-build version from `self.shortRev` (or `self.dirtyShortRev` with a `-dirty` suffix), analogous to the Makefile's `git describe --always` (`Makefile:13`). `skywire-bin` keeps an explicit `binaryVersion` because the release tarball URL encodes the semver.
- `skywire.nix` auto-strips the leading `v` off `rev` when `version` is omitted, so a tagged build only needs `rev = "v1.3.50"` instead of repeating the same number twice.
- `skywire-bin.nix` makes `version` a required argument instead of carrying a stale default that would silently drift away from the flake's `binaryVersion`.

## Test plan
- [ ] `cd nix && nix build .#skywire` from a clean tree → `skywire --bv` reports the short rev
- [ ] dirty tree → `--bv` reports `<rev>-dirty`
- [ ] `pkgs.callPackage ./skywire.nix { rev = "v1.3.50"; }` → derived version is `1.3.50`
- [ ] `nix build .#skywire-bin` still works against the pinned `binaryVersion`