### PR TITLE
fix(cxo): drop superseded roots + sticky Unpack.created for dedup safety

### DIFF
--- a/pkg/cxo/skyobject/unpack.go
+++ b/pkg/cxo/skyobject/unpack.go
@@ -47,7 +47,15 @@ func (u *Unpack) Set(key cipher.SHA256, val []byte) (err error) {
 	}
 
 	ui.inc++
-	ui.created = (rc == 1)
+	// Sticky: a later duplicate Set returning rc>1 must not clobber
+	// created=true from the first Set, otherwise Save's walk skips the
+	// dedup'd subtree (deepper=false), its children end up at ui.dec=0
+	// ui.inc=N, and the post-walk decrement drives them to rc=0 even
+	// though the new Root still references them through the dedup'd
+	// parent — which a later RemoveObjects sweep then deletes.
+	if rc == 1 {
+		ui.created = true
+	}
 
 	return
 }

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -53,7 +53,7 @@ type Publisher struct {
 	// is no window where the gate is unconfigured.
 	allow *allowState
 
-	batchWindow time.Duration
+	batchWindow  time.Duration
 	wakeup       chan struct{}
 	done         chan struct{}
 	cleanupNudge chan struct{} // 1-buffered; non-blocking send from publishRoot

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -19,6 +19,7 @@ import (
 	skycipher "github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
 	"github.com/skycoin/skywire/pkg/cxo/node"
 	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
 	"github.com/skycoin/skywire/pkg/cxo/skyobject"
@@ -53,9 +54,11 @@ type Publisher struct {
 	allow *allowState
 
 	batchWindow time.Duration
-	wakeup      chan struct{}
-	done        chan struct{}
-	stopOnce    sync.Once
+	wakeup       chan struct{}
+	done         chan struct{}
+	cleanupNudge chan struct{} // 1-buffered; non-blocking send from publishRoot
+	cleanupDone  chan struct{} // closed when the cleanup goroutine exits
+	stopOnce     sync.Once
 }
 
 // memNode is the in-memory mirror of a TreeNode. Children are kept
@@ -235,17 +238,20 @@ func New(cxoNode *node.Node, sk cipher.SecKey, conf Config) (*Publisher, error) 
 	}
 
 	p := &Publisher{
-		log:         conf.Logger,
-		cxoNode:     cxoNode,
-		pk:          pk,
-		sk:          sk,
-		root:        newMemNode(),
-		allow:       allow,
-		batchWindow: conf.BatchWindow,
-		wakeup:      make(chan struct{}, 1),
-		done:        make(chan struct{}),
+		log:          conf.Logger,
+		cxoNode:      cxoNode,
+		pk:           pk,
+		sk:           sk,
+		root:         newMemNode(),
+		allow:        allow,
+		batchWindow:  conf.BatchWindow,
+		wakeup:       make(chan struct{}, 1),
+		done:         make(chan struct{}),
+		cleanupNudge: make(chan struct{}, 1),
+		cleanupDone:  make(chan struct{}),
 	}
 	go p.runLoop()
+	go p.runCleanupLoop()
 	return p, nil
 }
 
@@ -451,6 +457,10 @@ func (p *Publisher) Close() error {
 		// Best-effort flush before signaling stop.
 		firstErr = p.Flush()
 		close(p.done)
+		// Wait for the cleanup goroutine to drain its final sweep.
+		// Bounded since RemoveObjects is O(CXDS size), but for
+		// in-memory CXDS this completes in milliseconds.
+		<-p.cleanupDone
 		if p.ownsNode && p.cxoNode != nil {
 			if err := p.cxoNode.Close(); err != nil && firstErr == nil {
 				firstErr = err
@@ -458,6 +468,49 @@ func (p *Publisher) Close() error {
 		}
 	})
 	return firstErr
+}
+
+// runCleanupLoop drops superseded Roots and frees CXDS entries whose
+// reference count fell to zero. CXO never auto-deletes — every
+// publish leaves the previous Root and its tree at rc≥1, and the
+// changed leaves from the prior tree become orphaned (rc=0 but
+// kept in CXDS). Without this sweep, in-process memory grows by
+// roughly one published payload per publish (60s tick × ~5 MB/publish
+// = ~5 GB / day for the TPD metrics+uptime publishers — exactly the
+// leak that hit production with 96.8% of TPD's heap living under
+// treestore.Publisher.publishIfDirty / encoder.Serialize).
+//
+// The loop runs OUTSIDE p.mu so it doesn't extend Flush's polling
+// window, and at most once per nudge (publishRoot fires a
+// non-blocking send into cleanupNudge after each successful Save).
+// Errors are logged and discarded — a missed sweep is recovered on
+// the next nudge. RemoveRootObjects (keepLast=1) decrements rc
+// throughout the previous Root's tree; RemoveObjects then deletes
+// every CXDS entry whose rc reached zero AND isn't currently in
+// the LRU cache.
+func (p *Publisher) runCleanupLoop() {
+	defer close(p.cleanupDone)
+	for {
+		select {
+		case <-p.done:
+			// One last sweep to catch the final publish.
+			p.runCleanup()
+			return
+		case <-p.cleanupNudge:
+			p.runCleanup()
+		}
+	}
+}
+
+func (p *Publisher) runCleanup() {
+	c := p.cxoNode.Container()
+	if err := cxoutils.RemoveRootObjects(c, 1); err != nil {
+		p.log.WithError(err).Debug("treestore: RemoveRootObjects failed; will retry next publish")
+		return
+	}
+	if err := cxoutils.RemoveObjects(c); err != nil {
+		p.log.WithError(err).Debug("treestore: RemoveObjects failed; will retry next publish")
+	}
 }
 
 // markDirty notes that the in-memory tree has unpublished changes
@@ -572,6 +625,15 @@ func (p *Publisher) publishRoot(root *memNode) error {
 	for _, fs := range freshSubs {
 		fs.n.pubHash = fs.hash
 		fs.n.cached = true
+	}
+
+	// Nudge the cleanup goroutine. Non-blocking: if cleanup is already
+	// running or pending, we don't need to enqueue another. The cleanup
+	// runs outside the publisher mutex so it doesn't extend Flush's
+	// polling window.
+	select {
+	case p.cleanupNudge <- struct{}{}:
+	default:
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

The treestore publisher never dropped prior Roots — every 60s publish left the full prior tree at rc≥1 in CXDS, accumulating ~5 MB/publish → ~5 GB/day in production TPD (96.8% of heap traced to `treestore.Publisher.publishIfDirty` / `encoder.Serialize`).

This PR:

- **Wires a cleanup goroutine** in `pkg/cxo/treestore/publisher.go`. After each successful publish, `cxoutils.RemoveRootObjects(keepLast=1)` drops superseded Roots and `cxoutils.RemoveObjects` reclaims rc=0/uncached entries. Nudged via 1-buffered channel from `publishRoot`; drains a final sweep on `Close`. Cleanup runs outside `p.mu` so it does not extend `Flush`'s polling window.

- **Fixes a latent bug in `skyobject.Unpack.Set`** that the cleanup exposed. When content-addressed dedup caused the same key to be Set N times (e.g. four leaves with identical value collapse to one hash), the second Set's `rc==2` clobbered `ui.created` from the first Set's `rc==1`. `Save`'s walk then returned `deepper=false` at the dedup'd parent, its children ended up at `ui.dec=0 ui.inc=N`, and the post-walk decrement drove them to rc=0 even though the new Root still references them through the dedup'd parent. A subsequent `RemoveObjects` sweep then deleted live objects, breaking the next publish with `not found`. Fix: make `ui.created` sticky — the first creating Set wins.

## Test plan

- [x] `go test ./pkg/cxo/treestore/ -run TestEncodeCacheInvalidatesOnlyAffectedPath` — passes (used to hang in an infinite "publish failed: not found" loop without the unpack fix).
- [x] `go test ./pkg/cxo/...` — all packages pass (treestore, skyobject, registry, statutil, node, data, data/cxds, data/idxdb, node/log).
- [x] `go build ./...` — clean.
- [ ] Production TPD restart + 24h heap watch to confirm steady-state allocation.