### PR TITLE
feat(dmsg-disc): decouple discovery from HTTP-bootstrap loop

### DIFF
--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
@@ -52,6 +52,7 @@ var (
 	dmsgPort          uint16
 	authPassphrase    string
 	officialServers   string
+	dmsgServersFlag   string
 	dmsgServerType    string
 	pprofMode         string
 	pprofAddr         string
@@ -80,6 +81,14 @@ func init() {
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
+	// Bootstrap dmsg-servers used to start the local direct.Client BEFORE
+	// any HTTP-side registration has happened. Without this, dmsg-discovery
+	// has to wait for dmsg-servers to HTTP-POST their entries to it before
+	// it can dial dmsg — a circular dependency on a fresh deployment.
+	// Format: comma-separated PK@host:port pairs. Empty defaults to the
+	// embedded deployment keyring (deployment.Prod or deployment.Test
+	// when --test-environment is set).
+	RootCmd.Flags().StringVar(&dmsgServersFlag, "dmsg-servers", "", "bootstrap dmsg-servers (PK@host:port,…); empty = embedded deployment keyring")
 	// dmsg-discovery cannot run in dmsg-only mode because dmsg-servers
 	// themselves register with it over plain HTTP (see
 	// cmd/dmsg-commands/dmsg-server/commands/start/root.go). http and
@@ -199,7 +208,11 @@ Example:
 			}
 		}()
 		if !pk.Null() && resolvedMode.IncludesDmsg() {
-			servers := getServers(ctx, a, dmsgServerType, log)
+			servers := bootstrapServers(dmsgServersFlag, testEnvironment, dmsgServerType, log)
+			if len(servers) == 0 {
+				log.Warn("no dmsg-servers preloaded from --dmsg-servers or embedded keyring; falling back to API self-poll (legacy behavior; will block until at least one server registers over HTTP)")
+				servers = getServers(ctx, a, dmsgServerType, log)
+			}
 			config := &dmsg.Config{
 				MinSessions:          0, // listen on all available servers
 				UpdateInterval:       dmsg.DefaultUpdateInterval,
@@ -285,6 +298,63 @@ func prepareDB(ctx context.Context, log *logging.Logger) store.Storer {
 	}
 
 	return db
+}
+
+// bootstrapServers resolves the initial dmsg-server list used to seed
+// the direct.Client before dmsg-discovery has any HTTP registrations.
+// The flag takes priority; on empty flag, the embedded deployment
+// keyring is used (Prod, or Test when testEnvironment is set). When
+// dmsgServerType is set, the embedded keyring path returns all entries
+// (the type filter only applies when fetched via the runtime API since
+// the embedded keyring doesn't carry server-type metadata).
+func bootstrapServers(flag string, testEnv bool, _ string, log logrus.FieldLogger) []*disc.Entry {
+	if flag != "" {
+		entries := parseDmsgServersFlag(flag, log)
+		if len(entries) > 0 {
+			log.WithField("count", len(entries)).Info("preloading dmsg-servers from --dmsg-servers")
+			return entries
+		}
+	}
+	src := deployment.Prod
+	srcName := "deployment.Prod"
+	if testEnv {
+		src = deployment.Test
+		srcName = "deployment.Test"
+	}
+	entries := src.ToDiscEntries()
+	if len(entries) > 0 {
+		log.WithField("count", len(entries)).WithField("source", srcName).Info("preloading dmsg-servers from embedded deployment keyring")
+	}
+	return entries
+}
+
+// parseDmsgServersFlag parses a comma-separated list of PK@host:port
+// pairs into disc.Entry values. Malformed entries are logged and
+// skipped — a typo in one entry should not disable the whole flag.
+func parseDmsgServersFlag(flag string, log logrus.FieldLogger) []*disc.Entry {
+	parts := strings.Split(flag, ",")
+	entries := make([]*disc.Entry, 0, len(parts))
+	for _, raw := range parts {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		at := strings.IndexByte(raw, '@')
+		if at <= 0 || at == len(raw)-1 {
+			log.WithField("entry", raw).Warn("skipping malformed --dmsg-servers entry; expected PK@host:port")
+			continue
+		}
+		var entryPK cipher.PubKey
+		if err := entryPK.Set(raw[:at]); err != nil {
+			log.WithField("entry", raw).WithError(err).Warn("skipping --dmsg-servers entry with invalid PK")
+			continue
+		}
+		entries = append(entries, &disc.Entry{
+			Static: entryPK,
+			Server: &disc.Server{Address: raw[at+1:]},
+		})
+	}
+	return entries
 }
 
 func getServers(ctx context.Context, a *api.API, dmsgServerType string, log logrus.FieldLogger) (servers []*disc.Entry) {

--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -29,6 +29,7 @@ import (
 	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/disc/dmsgfirst"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
@@ -128,9 +129,32 @@ var RootCmd = &cobra.Command{
 			AuthPassphrase: authPassphrase,
 			Peers:          peers,
 		}
-		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, disc.NewHTTP(conf.Discovery, &http.Client{}, log), &srvConf, m)
+
+		// Resolve the configured discoveries. NormalizedDiscoveries
+		// folds the legacy single-discovery fields into a one-element
+		// list so existing config files continue to work unchanged.
+		discoveriesCfg := conf.NormalizedDiscoveries()
+		if len(discoveriesCfg) == 0 {
+			log.Fatal("no dmsg-discoveries configured; set 'discovery' or 'discoveries' in config")
+		}
+
+		// Primary discovery is the first in the list. NewServer takes a
+		// single primary; we attach extras via srv.AddDiscovery once the
+		// server is constructed. Using plain HTTP at construction time;
+		// once the server's outbound dmsg.Client is up later, the
+		// discovery clients are swapped for dmsgfirst-wrapped versions
+		// so registration prefers DMSG when available.
+		primaryHTTP := disc.NewHTTP(discoveriesCfg[0].URL, &http.Client{}, log)
+		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, primaryHTTP, &srvConf, m)
 		srv.SetLogger(log)
 		srv.SetDHTBootstrap(conf.EnableDHT)
+		// Attach extras (each with its own per-discovery advertised
+		// address). The primary's advertised address is passed through
+		// the legacy Serve(..., conf.PublicAddress) path below.
+		for i := 1; i < len(discoveriesCfg); i++ {
+			extra := discoveriesCfg[i]
+			srv.AddDiscovery(disc.NewHTTP(extra.URL, &http.Client{}, log), extra.AdvertisedAddress, extra.PK)
+		}
 
 		srvAPI.SetDmsgServer(srv)
 		defer func() { log.WithError(srvAPI.Close()).Info("Closed server.") }()
@@ -138,10 +162,19 @@ var RootCmd = &cobra.Command{
 		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
 		defer cancel()
 
+		// The Server's primary discovery uses the first entry's
+		// advertised address as the default (passed through Serve).
+		// AdvertisedAddress on extras overrides per-endpoint inside
+		// EntityCommon's update loop.
+		primaryAdvertised := discoveriesCfg[0].AdvertisedAddress
+		if primaryAdvertised == "" {
+			primaryAdvertised = conf.PublicAddress
+		}
+
 		go srvAPI.RunBackgroundTasks(ctx)
 		log.WithField("addr", conf.HTTPAddress).Info("Serving server API...")
 		go func() {
-			if err := srvAPI.ListenAndServe(conf.LocalAddress, conf.PublicAddress, conf.HTTPAddress); err != nil {
+			if err := srvAPI.ListenAndServe(conf.LocalAddress, primaryAdvertised, conf.HTTPAddress); err != nil {
 				log.Errorf("Serve: %v", err)
 				cancel()
 			}
@@ -194,6 +227,24 @@ var RootCmd = &cobra.Command{
 				return
 			}
 			defer closeDebug()
+
+			// Upgrade each configured discovery client from plain HTTP
+			// to dmsgfirst — registration then tries DMSG first and
+			// only falls back to HTTP if the dmsg dial fails. Discoveries
+			// without a configured PK can't use DMSG (dmsgfirst.New
+			// needs the discovery's own PK to dial it), so we leave
+			// those as plain HTTP and log it.
+			upgraded := make([]disc.APIClient, len(discoveriesCfg))
+			for i, d := range discoveriesCfg {
+				if d.PK == (cipher.PubKey{}) {
+					upgraded[i] = disc.NewHTTP(d.URL, &http.Client{}, log)
+					log.WithField("url", d.URL).Debug("discovery has no PK; staying on plain HTTP")
+					continue
+				}
+				upgraded[i] = dmsgfirst.New(dmsgC, d.PK, d.URL, &http.Client{}, log)
+				log.WithField("url", d.URL).WithField("pk", d.PK).Info("discovery upgraded to dmsg-first registration")
+			}
+			srv.SetDiscoveryClients(upgraded)
 
 			// Shared DHT node reference — set by the DHT goroutine,
 			// read by the HTTP handler. Access is safe because the

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -203,6 +203,10 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "tpsetup")
 	genConfigCmd.Flags().BoolVar(&snConfig, "sn", false, "generate config for route setup node")
 	gHiddenFlags = append(gHiddenFlags, "sn")
+	genConfigCmd.Flags().BoolVar(&dmsgDiscConfig, "dmsgdisc", false, "generate config for dmsg-discovery service")
+	gHiddenFlags = append(gHiddenFlags, "dmsgdisc")
+	genConfigCmd.Flags().BoolVar(&dmsgSrvConfig, "dmsgsrv", false, "generate config for dmsg-server service")
+	gHiddenFlags = append(gHiddenFlags, "dmsgsrv")
 	genConfigCmd.Flags().BoolVar(&enableCalculateRoutes, "calculate-routes", scriptExecBool("${CALCULATEROUTES:-false}"), "enable local route calculation")
 	gHiddenFlags = append(gHiddenFlags, "calculate-routes")
 
@@ -891,24 +895,42 @@ func configureServices(log *logging.Logger) {
 	}
 }
 
+// serviceProjectionJQ returns the JQ filter to project the generated
+// visor config into a service-specific config shape. Returns empty
+// string when no projection flag is set, so writeConfigOutput emits
+// the regular visor config. The projections deliberately mirror the
+// existing fields the target service already accepts — they don't
+// invent new schema, only rearrange the visor config's keys.
+//
+// Mutually-exclusive flags: only the FIRST set flag wins, in
+// precedence order sn → dmsgsrv → dmsgdisc. The CLI rejects multiple
+// flags upstream of this helper, but the precedence here keeps
+// behavior deterministic if that check is ever bypassed.
+func serviceProjectionJQ() string {
+	switch {
+	case snConfig:
+		return "{public_key: .pk, secret_key: .sk, dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}, transport_discovery: (.transport.discovery_dmsg // .transport.discovery), log_level: .log_level}"
+	case dmsgSrvConfig:
+		// Project to a dmsg-server config. Keys map onto
+		// pkg/dmsg/dmsgserver.Config exactly. The discoveries[] list
+		// is synthesized from the visor's dmsg.discovery /
+		// dmsg.discovery_dmsg pair so a single config command can
+		// produce a dmsg-server config that registers with the same
+		// discovery the visor uses.
+		return "{public_key: .pk, secret_key: .sk, discoveries: [{url: .dmsg.discovery, dmsg_url: .dmsg.discovery_dmsg, advertised_address: \"\"}], local_address: \":8081\", health_endpoint_address: \":8082\", log_level: .log_level, max_sessions: 2048}"
+	case dmsgDiscConfig:
+		// Project to a dmsg-discovery config. dmsg-discovery has no
+		// JSON config file today (CLI flags only), but emitting a
+		// JSON-shaped config makes it scriptable: tooling can read
+		// {public_key, secret_key, addr, dmsg_servers} and pass the
+		// fields to the dmsg-discovery binary as flags.
+		return "{public_key: .pk, secret_key: .sk, addr: \":9090\", dmsg_port: 80, dmsg_servers: .dmsg.servers, log_level: .log_level}"
+	}
+	return ""
+}
+
 // configureDMSG sets up the DMSG configuration on conf, preserving protocol
 // from a previous config if regenerating.
-// serviceDmsgServerEntries converts DmsgServerEntry to []*disc.Entry
-// for use in the visor's DMSG config.
-func serviceDmsgServerEntries() []*disc.Entry {
-	var entries []*disc.Entry
-	for _, s := range services.DmsgServers { //nolint:gocritic
-		var pk cipher.PubKey
-		if err := pk.UnmarshalText([]byte(s.Static)); err != nil {
-			continue
-		}
-		entries = append(entries, &disc.Entry{
-			Static: pk,
-			Server: &disc.Server{Address: s.Server.Address},
-		})
-	}
-	return entries
-}
 
 func configureDMSG() {
 	conf.Dmsg = &dmsgc.DmsgConfig{
@@ -1075,7 +1097,7 @@ func configureLauncher(log *logging.Logger) {
 		// Prefer unified services config; fall back to legacy dmsgHTTPServersList
 		if services.HasDmsgEndpoints() {
 			// Unified config: DMSG fields from services-config.json
-			conf.Dmsg.Servers = serviceDmsgServerEntries()
+			conf.Dmsg.Servers = deployment.DmsgServerEntriesToDisc(services.DmsgServers)
 
 			if isDmsgHTTP {
 				conf.Dmsg.Discovery = services.DmsgDiscoveryDmsg
@@ -1462,10 +1484,10 @@ func writeConfigOutput(log *logging.Logger) {
 		if err != nil {
 			log.WithError(err).Fatal("Failed to marshal config to indented JSON")
 		}
-		if snConfig {
-			jsonData, err = script.Echo(string(jsonData)).JQ("{public_key: .pk, secret_key: .sk, dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}, transport_discovery: (.transport.discovery_dmsg // .transport.discovery), log_level: .log_level}").Bytes()
+		if filter := serviceProjectionJQ(); filter != "" {
+			jsonData, err = script.Echo(string(jsonData)).JQ(filter).Bytes()
 			if err != nil {
-				log.Fatalf("Failed to convert config to setup-node config format: %v", err)
+				log.Fatalf("Failed to convert config to service config format: %v", err)
 			}
 			// Re-indent for readable file output
 			var data any
@@ -1486,14 +1508,14 @@ func writeConfigOutput(log *logging.Logger) {
 	if err != nil {
 		log.WithError(err).Fatal("Failed to marshal config to indented JSON")
 	}
-	if snConfig {
-		j, err = script.Echo(string(j)).JQ("{public_key: .pk, secret_key: .sk, dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}, transport_discovery: (.transport.discovery_dmsg // .transport.discovery), log_level: .log_level}").Bytes()
+	if filter := serviceProjectionJQ(); filter != "" {
+		j, err = script.Echo(string(j)).JQ(filter).Bytes()
 		if err != nil {
-			log.Fatalf("Failed to convert config to setup-node config format: %v", err)
+			log.Fatalf("Failed to convert config to service config format: %v", err)
 		}
 		var data any
 		if err = json.Unmarshal(j, &data); err != nil {
-			log.Fatalf("Failed to convert config to setup-node config format: %v", err)
+			log.Fatalf("Failed to convert config to service config format: %v", err)
 		}
 		j, err = json.MarshalIndent(data, "", "    ")
 		if err != nil {

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -101,6 +101,8 @@ var (
 	configServicePath          string
 	dmsgHTTPPath               string
 	snConfig                   bool
+	dmsgDiscConfig             bool
+	dmsgSrvConfig              bool
 	externalApps               bool
 	enableCalculateRoutes      bool
 	isSkychatEnable            bool

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 )
 
 /*
@@ -48,6 +49,35 @@ type DmsgServerEntry struct {
 // HasDmsgServers returns true if the deployment has DMSG server entries.
 func (s *Services) HasDmsgServers() bool {
 	return len(s.DmsgServers) > 0
+}
+
+// DmsgServerEntriesToDisc converts a list of DmsgServerEntry to
+// []*disc.Entry suitable for direct.NewClient / direct.GetAllEntries.
+// Entries whose Static field is not a valid public key are skipped
+// silently — the deployment file is the source of truth and a single
+// malformed entry should not abort the whole preload.
+func DmsgServerEntriesToDisc(in []DmsgServerEntry) []*disc.Entry {
+	if len(in) == 0 {
+		return nil
+	}
+	entries := make([]*disc.Entry, 0, len(in))
+	for _, srv := range in {
+		var pk cipher.PubKey
+		if err := pk.Set(srv.Static); err != nil {
+			continue
+		}
+		entries = append(entries, &disc.Entry{
+			Static: pk,
+			Server: &disc.Server{Address: srv.Server.Address},
+		})
+	}
+	return entries
+}
+
+// ToDiscEntries is the method form of DmsgServerEntriesToDisc, scoped
+// to the receiver's DmsgServers list.
+func (s *Services) ToDiscEntries() []*disc.Entry {
+	return DmsgServerEntriesToDisc(s.DmsgServers)
 }
 
 // HasDmsgEndpoints returns true if the deployment has DMSG service endpoints.

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -118,6 +118,27 @@ type Client struct {
 	sesMx sync.Mutex
 }
 
+// AddDiscovery registers an additional dmsg-discovery this client
+// should publish its entry to. discPK, when set, identifies the
+// discovery's own dmsg-server PK so the client can detect inbound
+// sessions originated by this discovery (currently unused on the
+// client side; reserved for symmetry with Server).
+//
+// Safe to call before or after Serve. Subsequent updateClientEntry
+// iterations pick up the new endpoint automatically.
+func (c *Client) AddDiscovery(client disc.APIClient, discPK cipher.PubKey) {
+	c.addDiscovery(client, "", discPK)
+}
+
+// SetDiscoveryClients replaces the underlying disc.APIClient on each
+// configured discovery endpoint, preserving PKs. The lengths must
+// match the current endpoint count, otherwise the call is a no-op.
+// Used to upgrade plain HTTP clients to dmsgfirst-wrapped clients
+// once an outbound dmsg.Client is available.
+func (c *Client) SetDiscoveryClients(clients []disc.APIClient) {
+	c.setDiscoveryClients(clients)
+}
+
 // NewClient creates a dmsg client entity.
 func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Config) *Client {
 	log := logging.MustGetLogger("dmsg_client")

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -17,6 +17,20 @@ import (
 	"github.com/skycoin/skywire/pkg/netutil"
 )
 
+// discoveryEndpoint represents one dmsg-discovery the entity registers
+// with. AdvertisedAddr applies to servers only — clients pass empty.
+// When non-empty, AdvertisedAddr overrides the addr passed to
+// updateServerEntryLoop for THIS discovery only, supporting the
+// "advertise LAN to local-disc, advertise public IP to internet-disc"
+// pattern. PK, when set, identifies the discovery's own dmsg-server
+// PK so the entity can recognize an inbound session as originating
+// from that discovery and trigger an immediate registration push.
+type discoveryEndpoint struct {
+	Client        disc.APIClient
+	AdvertisedAddr string
+	PK            cipher.PubKey
+}
+
 // EntityCommon contains the common fields and methods for server and client entities.
 type EntityCommon struct {
 	// atomic requires 64-bit alignment for struct field access
@@ -24,7 +38,17 @@ type EntityCommon struct {
 
 	pk cipher.PubKey
 	sk cipher.SecKey
+	// dc is the primary discovery — kept as a separate field for
+	// backward compatibility with constructors and zero-value behavior.
+	// Equivalent to discoveries[0].Client when discoveries is non-empty.
 	dc disc.APIClient
+	// discoveries holds the primary plus any additional dmsg-discoveries
+	// the entity registers with. The primary is always discoveries[0]
+	// (mirror of c.dc) when discoveries is non-empty. Extra discoveries
+	// are appended via addDiscovery; ordering is preserved so callers
+	// can control which is "first" for read fallback.
+	discoveries   []*discoveryEndpoint
+	discoveriesMx sync.RWMutex
 
 	sessions   map[cipher.PubKey]*SessionCommon
 	sessionsMx *sync.Mutex
@@ -73,11 +97,83 @@ func (c *EntityCommon) init(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClien
 	c.pk = pk
 	c.sk = sk
 	c.dc = dc
+	c.discoveries = []*discoveryEndpoint{{Client: dc}}
 	c.sessions = make(map[cipher.PubKey]*SessionCommon)
 	c.sessionsMx = new(sync.Mutex)
 	c.updateInterval = updateInterval
 	c.entryNudge = make(chan struct{}, 1)
 	c.log = log
+}
+
+// addDiscovery appends an additional dmsg-discovery to register with.
+// advertisedAddr, when non-empty, overrides the entity's default addr
+// for this discovery (servers only — clients should pass empty). pk,
+// when non-zero, identifies the discovery's own dmsg-server PK so the
+// entity can detect inbound sessions from this discovery.
+//
+// Safe to call after init/Serve has started — subsequent
+// updateServerEntryLoop iterations will pick up the new endpoint.
+func (c *EntityCommon) addDiscovery(client disc.APIClient, advertisedAddr string, pk cipher.PubKey) {
+	if client == nil {
+		return
+	}
+	c.discoveriesMx.Lock()
+	c.discoveries = append(c.discoveries, &discoveryEndpoint{
+		Client:        client,
+		AdvertisedAddr: advertisedAddr,
+		PK:            pk,
+	})
+	c.discoveriesMx.Unlock()
+}
+
+// setDiscoveryClients replaces the disc.APIClient on each existing
+// endpoint, in-place. The lengths must match, otherwise the call is a
+// no-op. Used to upgrade plain HTTP clients to dmsgfirst-wrapped
+// clients once an outbound dmsg.Client is ready, without reordering
+// or losing per-discovery advertised addresses / PKs.
+func (c *EntityCommon) setDiscoveryClients(clients []disc.APIClient) {
+	c.discoveriesMx.Lock()
+	defer c.discoveriesMx.Unlock()
+	if len(clients) != len(c.discoveries) {
+		return
+	}
+	for i, cl := range clients {
+		if cl != nil {
+			c.discoveries[i].Client = cl
+		}
+	}
+	if len(c.discoveries) > 0 {
+		c.dc = c.discoveries[0].Client
+	}
+}
+
+// snapshotDiscoveries returns a copy of the discovery list, safe for
+// iteration outside the lock. The returned slice may be empty when
+// init has not yet been called.
+func (c *EntityCommon) snapshotDiscoveries() []*discoveryEndpoint {
+	c.discoveriesMx.RLock()
+	defer c.discoveriesMx.RUnlock()
+	if len(c.discoveries) == 0 {
+		return nil
+	}
+	out := make([]*discoveryEndpoint, len(c.discoveries))
+	copy(out, c.discoveries)
+	return out
+}
+
+// matchDiscoveryByPK returns the discoveryEndpoint configured with the
+// given PK, or nil if none. Used by setSession callbacks to recognize
+// an inbound session originated by a configured dmsg-discovery and
+// trigger an immediate registration push.
+func (c *EntityCommon) matchDiscoveryByPK(pk cipher.PubKey) *discoveryEndpoint {
+	c.discoveriesMx.RLock()
+	defer c.discoveriesMx.RUnlock()
+	for _, ep := range c.discoveries {
+		if ep.PK == pk && pk != (cipher.PubKey{}) {
+			return ep
+		}
+	}
+	return nil
 }
 
 // LocalPK returns the local public key of the entity.
@@ -192,34 +288,67 @@ func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey) {
 	}
 }
 
-// updateServerEntry updates the dmsg server's entry within dmsg discovery.
-// If 'addr' is an empty string, the Entry.addr field will not be updated in discovery.
+// updateServerEntry updates the dmsg server's entry within all
+// configured dmsg-discoveries. Each endpoint is updated independently
+// — a per-discovery advertised address (when set) overrides the
+// default addr argument for that endpoint only.
+//
+// If 'addr' is an empty string AND no endpoint provides its own
+// advertised address, no update is performed for that endpoint
+// (preserving the legacy "empty addr = skip update" semantics).
+//
 // Caller must hold c.sessionsMx.
 func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSessions int, authPassphrase string) (err error) {
-	if addr == "" {
-		return errors.New("updateServerEntry cannot accept empty 'addr' input")
+	endpoints := c.snapshotDiscoveries()
+	if len(endpoints) == 0 {
+		return errors.New("updateServerEntry: no discoveries configured")
 	}
-
-	// Record last update on success.
-	defer func() {
-		if err == nil {
-			c.recordUpdate()
-		}
-	}()
 
 	availableSessions := maxSessions - len(c.sessions)
 	if availableSessions < 0 {
 		availableSessions = 0
 	}
 
-	entry, err := c.dc.Entry(ctx, c.pk)
+	// Aggregate errors across endpoints. We return the first non-nil
+	// error so the caller's existing "log on error, retry on next
+	// tick" behavior keeps working — a transient failure on one
+	// discovery doesn't mask a successful update to another.
+	var firstErr error
+	anyOK := false
+	for _, ep := range endpoints {
+		epAddr := addr
+		if ep.AdvertisedAddr != "" {
+			epAddr = ep.AdvertisedAddr
+		}
+		if epAddr == "" {
+			continue
+		}
+		if updateErr := c.updateServerEntryOnEndpoint(ctx, ep, epAddr, availableSessions, authPassphrase); updateErr != nil {
+			if firstErr == nil {
+				firstErr = updateErr
+			}
+			c.log.WithError(updateErr).WithField("discovery_pk", ep.PK).Debug("server entry update failed for discovery; will retry next tick")
+			continue
+		}
+		anyOK = true
+	}
+	if anyOK {
+		c.recordUpdate()
+	}
+	return firstErr
+}
+
+// updateServerEntryOnEndpoint runs the read-modify-write registration
+// cycle against a single discovery endpoint.
+func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, addr string, availableSessions int, authPassphrase string) error {
+	entry, err := ep.Client.Entry(ctx, c.pk)
 	if err != nil {
 		entry = disc.NewServerEntry(c.pk, 0, addr, availableSessions)
 		entry.Server.DHTBootstrap = c.dhtBootstrap
 		if err := entry.Sign(c.sk); err != nil {
 			return err
 		}
-		return c.dc.PostEntry(ctx, entry)
+		return ep.Client.PostEntry(ctx, entry)
 	}
 
 	if entry.Server == nil {
@@ -251,7 +380,7 @@ func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSe
 	entry.Server.DHTBootstrap = c.dhtBootstrap
 	log.Debug("Updating entry.\n")
 
-	return c.dc.PutEntry(ctx, c.sk, entry)
+	return ep.Client.PutEntry(ctx, c.sk, entry)
 }
 
 func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, maxSessions int, authPassphrase string) {
@@ -307,12 +436,10 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, m
 }
 
 func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType string, protocol string) (err error) {
-	// Record last update on success.
-	defer func() {
-		if err == nil {
-			c.recordUpdate()
-		}
-	}()
+	endpoints := c.snapshotDiscoveries()
+	if len(endpoints) == 0 {
+		return errors.New("initilizeClientEntry: no discoveries configured")
+	}
 
 	c.sessionsMx.Lock()
 	srvPKs := make([]cipher.PubKey, 0, len(c.sessions))
@@ -321,17 +448,34 @@ func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType stri
 	}
 	c.sessionsMx.Unlock()
 
-	_, err = c.dc.Entry(ctx, c.pk)
-	if err != nil {
+	var firstErr error
+	anyOK := false
+	for _, ep := range endpoints {
+		if _, lookupErr := ep.Client.Entry(ctx, c.pk); lookupErr == nil {
+			anyOK = true
+			continue
+		}
 		entry := disc.NewClientEntry(c.pk, 0, srvPKs)
 		entry.ClientType = clientType
 		entry.Protocol = protocol
-		if err := entry.Sign(c.sk); err != nil {
-			return err
+		if signErr := entry.Sign(c.sk); signErr != nil {
+			if firstErr == nil {
+				firstErr = signErr
+			}
+			continue
 		}
-		return c.dc.PostEntry(ctx, entry)
+		if postErr := ep.Client.PostEntry(ctx, entry); postErr != nil {
+			if firstErr == nil {
+				firstErr = postErr
+			}
+			continue
+		}
+		anyOK = true
 	}
-	return nil
+	if anyOK {
+		c.recordUpdate()
+	}
+	return firstErr
 }
 
 func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}, clientType string) (err error) {
@@ -339,26 +483,15 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 		return nil
 	}
 
+	endpoints := c.snapshotDiscoveries()
+	if len(endpoints) == 0 {
+		return errors.New("updateClientEntry: no discoveries configured")
+	}
+
 	srvPKs := make([]cipher.PubKey, 0, len(c.sessions))
 	for pk := range c.sessions {
 		srvPKs = append(srvPKs, pk)
 	}
-
-	// Record last update on success AND cache the set of delegated
-	// server PKs we just pushed, so the next call can short-circuit.
-	defer func() {
-		if err == nil {
-			c.recordUpdate()
-			c.pushedSrvPKsMx.Lock()
-			// Make a defensive copy — the srvPKs slice is a local
-			// snapshot but the caller may hold a reference in log
-			// output, so copying is cheap and keeps ownership clean.
-			pushed := make([]cipher.PubKey, len(srvPKs))
-			copy(pushed, srvPKs)
-			c.lastPushedSrvPKs = pushed
-			c.pushedSrvPKsMx.Unlock()
-		}
-	}()
 
 	// Short-circuit: if the delegated server set we're about to publish
 	// is identical to what we last successfully pushed AND an update
@@ -374,14 +507,42 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 		return nil
 	}
 
-	entry, err := c.dc.Entry(ctx, c.pk)
+	var firstErr error
+	anyOK := false
+	for _, ep := range endpoints {
+		if updateErr := c.updateClientEntryOnEndpoint(ctx, ep, clientType, srvPKs); updateErr != nil {
+			if firstErr == nil {
+				firstErr = updateErr
+			}
+			c.log.WithError(updateErr).Debug("client entry update failed for discovery; will retry next tick")
+			continue
+		}
+		anyOK = true
+	}
+	if anyOK {
+		c.recordUpdate()
+		c.pushedSrvPKsMx.Lock()
+		// Defensive copy — caller may retain srvPKs in log output, so
+		// copying is cheap and keeps ownership clean.
+		pushed := make([]cipher.PubKey, len(srvPKs))
+		copy(pushed, srvPKs)
+		c.lastPushedSrvPKs = pushed
+		c.pushedSrvPKsMx.Unlock()
+	}
+	return firstErr
+}
+
+// updateClientEntryOnEndpoint runs the read-modify-write registration
+// cycle against a single discovery endpoint.
+func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, clientType string, srvPKs []cipher.PubKey) error {
+	entry, err := ep.Client.Entry(ctx, c.pk)
 	if err != nil {
 		entry = disc.NewClientEntry(c.pk, 0, srvPKs)
 		entry.ClientType = clientType
 		if err := entry.Sign(c.sk); err != nil {
 			return err
 		}
-		return c.dc.PostEntry(ctx, entry)
+		return ep.Client.PostEntry(ctx, entry)
 	}
 
 	// The entry might be a server entry (e.g., debug client running on a dmsg server).
@@ -392,7 +553,7 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 		if err := entry.Sign(c.sk); err != nil {
 			return err
 		}
-		return c.dc.PostEntry(ctx, entry)
+		return ep.Client.PostEntry(ctx, entry)
 	}
 
 	// Whether the client's CURRENT delegated servers is the same as what would be advertised.
@@ -406,7 +567,7 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	entry.ClientType = clientType
 	entry.Client.DelegatedServers = srvPKs
 	c.log.WithField("entry", entry).Debug("Updating entry.\n")
-	return c.dc.PutEntry(ctx, c.sk, entry)
+	return ep.Client.PutEntry(ctx, c.sk, entry)
 }
 
 // entryUpdateDebounce is how long to wait after a nudge before updating
@@ -478,21 +639,23 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 }
 
 func (c *EntityCommon) entryProtocol(ctx context.Context, pk cipher.PubKey) string {
-	entry, err := c.dc.Entry(ctx, pk)
-	if err != nil {
-		c.log.WithField("entry", entry).WithError(err).Warn("Entry not found, so return empty as protocol.\n")
-		return ""
+	endpoints := c.snapshotDiscoveries()
+	for _, ep := range endpoints {
+		entry, err := ep.Client.Entry(ctx, pk)
+		if err != nil {
+			continue
+		}
+		c.log.WithField("entry", entry).Debug("Entry's protocol fetch.\n")
+		return entry.Protocol
 	}
-
-	c.log.WithField("entry", entry).Debug("Entry's protocol fetch.\n")
-	return entry.Protocol
+	c.log.WithField("pk", pk).Warn("Entry not found in any discovery; returning empty protocol.\n")
+	return ""
 }
 
 func (c *EntityCommon) delEntry(ctx context.Context) (err error) {
-
-	entry, err := c.dc.Entry(ctx, c.pk)
-	if err != nil {
-		return err
+	endpoints := c.snapshotDiscoveries()
+	if len(endpoints) == 0 {
+		return errors.New("delEntry: no discoveries configured")
 	}
 
 	defer func() {
@@ -501,8 +664,21 @@ func (c *EntityCommon) delEntry(ctx context.Context) (err error) {
 		}
 	}()
 
-	c.log.WithField("entry", entry).Debug("Deleting entry.\n")
-	return c.dc.DelEntry(ctx, entry)
+	var firstErr error
+	for _, ep := range endpoints {
+		entry, lookupErr := ep.Client.Entry(ctx, c.pk)
+		if lookupErr != nil {
+			if firstErr == nil {
+				firstErr = lookupErr
+			}
+			continue
+		}
+		c.log.WithField("entry", entry).Debug("Deleting entry.\n")
+		if delErr := ep.Client.DelEntry(ctx, entry); delErr != nil && firstErr == nil {
+			firstErr = delErr
+		}
+	}
+	return firstErr
 }
 
 func getServerEntry(ctx context.Context, dc disc.APIClient, srvPK cipher.PubKey) (*disc.Entry, error) {

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -26,9 +26,9 @@ import (
 // PK so the entity can recognize an inbound session as originating
 // from that discovery and trigger an immediate registration push.
 type discoveryEndpoint struct {
-	Client        disc.APIClient
+	Client         disc.APIClient
 	AdvertisedAddr string
-	PK            cipher.PubKey
+	PK             cipher.PubKey
 }
 
 // EntityCommon contains the common fields and methods for server and client entities.
@@ -119,9 +119,9 @@ func (c *EntityCommon) addDiscovery(client disc.APIClient, advertisedAddr string
 	}
 	c.discoveriesMx.Lock()
 	c.discoveries = append(c.discoveries, &discoveryEndpoint{
-		Client:        client,
+		Client:         client,
 		AdvertisedAddr: advertisedAddr,
-		PK:            pk,
+		PK:             pk,
 	})
 	c.discoveriesMx.Unlock()
 }
@@ -159,21 +159,6 @@ func (c *EntityCommon) snapshotDiscoveries() []*discoveryEndpoint {
 	out := make([]*discoveryEndpoint, len(c.discoveries))
 	copy(out, c.discoveries)
 	return out
-}
-
-// matchDiscoveryByPK returns the discoveryEndpoint configured with the
-// given PK, or nil if none. Used by setSession callbacks to recognize
-// an inbound session originated by a configured dmsg-discovery and
-// trigger an immediate registration push.
-func (c *EntityCommon) matchDiscoveryByPK(pk cipher.PubKey) *discoveryEndpoint {
-	c.discoveriesMx.RLock()
-	defer c.discoveriesMx.RUnlock()
-	for _, ep := range c.discoveries {
-		if ep.PK == pk && pk != (cipher.PubKey{}) {
-			return ep
-		}
-	}
-	return nil
 }
 
 // LocalPK returns the local public key of the entity.

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -235,6 +235,32 @@ func (s *Server) AdvertisedAddr() string {
 	return s.addr
 }
 
+// AddDiscovery registers an additional dmsg-discovery this server
+// should publish its entry to. advertisedAddr, when non-empty,
+// overrides the server's default AdvertisedAddr() for THIS discovery
+// only — useful for advertising a LAN address to a local discovery
+// and a public address to an internet discovery. discPK, when set,
+// lets the server recognize an inbound DMSG session originated by
+// this discovery and trigger an immediate registration push.
+//
+// Safe to call before or after Serve. Subsequent updateServerEntry
+// iterations pick up the new endpoint automatically.
+func (s *Server) AddDiscovery(client disc.APIClient, advertisedAddr string, discPK cipher.PubKey) {
+	s.addDiscovery(client, advertisedAddr, discPK)
+}
+
+// SetDiscoveryClients replaces the underlying disc.APIClient on each
+// configured discovery endpoint, preserving advertised addresses and
+// PKs. The lengths must match the current endpoint count, otherwise
+// the call is a no-op. Used to upgrade plain HTTP clients to
+// dmsgfirst-wrapped clients once the server's outbound dmsg.Client is
+// available — registration then prefers DMSG over HTTP, which keeps
+// the server reachable from local discoveries when the public internet
+// is unavailable.
+func (s *Server) SetDiscoveryClients(clients []disc.APIClient) {
+	s.setDiscoveryClients(clients)
+}
+
 // SetAdvertisedAddr sets the advertised TCP address in which the dmsg server is advertised by.
 // This should only be called once.
 func (s *Server) SetAdvertisedAddr(lis net.Listener, addr *string) {

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -32,14 +32,36 @@ type PeerConfig struct {
 	Address string        `json:"address"`
 }
 
+// DiscoveryConfig represents a single dmsg-discovery this server should
+// register with. AdvertisedAddress is the address this server should
+// advertise to THIS discovery — for example a server may advertise a
+// LAN address (192.168.x.x:8081) to a local discovery and a public
+// address (1.2.3.4:8081) to an internet discovery. PK, when set, lets
+// the server detect inbound DMSG sessions originated by this discovery
+// and trigger an immediate registration push back over that session
+// (see Config.NormalizedDiscoveries for backward-compat fallback).
+type DiscoveryConfig struct {
+	URL               string        `json:"url"`
+	DmsgURL           string        `json:"dmsg_url,omitempty"`
+	PK                cipher.PubKey `json:"public_key,omitempty"`
+	AdvertisedAddress string        `json:"advertised_address,omitempty"`
+}
+
 // Config is structure of config file
 type Config struct {
 	Path string `json:"-"`
 
-	PubKey           cipher.PubKey `json:"public_key"`
-	SecKey           cipher.SecKey `json:"secret_key"`
-	Discovery        string        `json:"discovery"`
-	PublicAddress    string        `json:"public_address"`
+	PubKey cipher.PubKey `json:"public_key"`
+	SecKey cipher.SecKey `json:"secret_key"`
+	// Discoveries is the list of dmsg-discoveries this server registers
+	// with. When empty, the legacy Discovery + PublicAddress fields are
+	// folded into a single-element list (see NormalizedDiscoveries).
+	Discoveries []DiscoveryConfig `json:"discoveries,omitempty"`
+	// Discovery and PublicAddress are the legacy single-discovery
+	// fields. Superseded by Discoveries; kept so existing config files
+	// continue to work without edits.
+	Discovery        string        `json:"discovery,omitempty"`
+	PublicAddress    string        `json:"public_address,omitempty"`
 	LocalAddress     string        `json:"local_address"`
 	HTTPAddress      string        `json:"health_endpoint_address"`
 	LogLevel         string        `json:"log_level"`
@@ -77,6 +99,21 @@ func GenerateDefaultConfig(c *Config) {
 	c.HTTPAddress = defaultHTTPAddress
 	c.LogLevel = "info"
 	c.MaxSessions = dmsg.DefaultMaxSessions
+}
+
+// NormalizedDiscoveries returns the discovery list the server should
+// actually register with. When the modern Discoveries field is set,
+// it's returned as-is; otherwise a single-element list is synthesized
+// from the legacy Discovery + PublicAddress fields so existing config
+// files keep working unchanged. Returns nil when neither is set.
+func (c *Config) NormalizedDiscoveries() []DiscoveryConfig {
+	if len(c.Discoveries) > 0 {
+		return c.Discoveries
+	}
+	if c.Discovery == "" {
+		return nil
+	}
+	return []DiscoveryConfig{{URL: c.Discovery, AdvertisedAddress: c.PublicAddress}}
 }
 
 // Flush trying to save config file

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -117,8 +117,7 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		configs = []DiscoveryConfig{{URL: conf.Discovery, DmsgURL: conf.DiscoveryDmsg}}
 	}
 
-	primaryHTTP := disc.NewHTTP(configs[0].URL, httpC, masterLogger.PackageLogger("dmsgC:disc"))
-	var primary disc.APIClient = primaryHTTP
+	primary := disc.NewHTTP(configs[0].URL, httpC, masterLogger.PackageLogger("dmsgC:disc"))
 	if len(conf.LANServers) > 0 {
 		masterLogger.PackageLogger("dmsgC").Infof("Using %d LAN DMSG servers (tried first)", len(conf.LANServers))
 		primary = &lanPriorityDisc{APIClient: primary, lanEntries: conf.LANServers}

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -12,15 +12,48 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
+// DiscoveryConfig represents a single dmsg-discovery this client
+// should register with. URL is the plain-HTTP endpoint; DmsgURL, when
+// set, is the dmsg-HTTP endpoint used by dmsgfirst as the DMSG-side
+// fallback target. PK, when set, identifies the discovery's own
+// dmsg-server PK so dmsgfirst can dial it over DMSG before falling
+// back to HTTP.
+type DiscoveryConfig struct {
+	URL     string        `json:"url"`
+	DmsgURL string        `json:"dmsg_url,omitempty"`
+	PK      cipher.PubKey `json:"public_key,omitempty"`
+}
+
 // DmsgConfig defines config for Dmsg network.
 type DmsgConfig struct {
-	Discovery            string        `json:"discovery"`
-	DiscoveryDmsg        string        `json:"discovery_dmsg,omitempty"`
-	SessionsCount        int           `json:"sessions_count"`
-	Servers              []*disc.Entry `json:"servers"`
-	ConnectedServersType string        `json:"servers_type"`
-	Protocol             string        `json:"protocol"`
-	LANServers           []*disc.Entry `json:"lan_servers,omitempty"` // Static LAN DMSG servers (tried first, auto-populated by hypervisor)
+	// Configs is the list of dmsg-discoveries this client registers
+	// with. When non-empty it supersedes Discovery / DiscoveryDmsg —
+	// the legacy fields are kept so existing visor configs keep working
+	// and so a single-discovery deployment doesn't need the verbose
+	// multi-discovery shape.
+	Configs              []DiscoveryConfig `json:"configs,omitempty"`
+	Discovery            string            `json:"discovery"`
+	DiscoveryDmsg        string            `json:"discovery_dmsg,omitempty"`
+	SessionsCount        int               `json:"sessions_count"`
+	Servers              []*disc.Entry     `json:"servers"`
+	ConnectedServersType string            `json:"servers_type"`
+	Protocol             string            `json:"protocol"`
+	LANServers           []*disc.Entry     `json:"lan_servers,omitempty"` // Static LAN DMSG servers (tried first, auto-populated by hypervisor)
+}
+
+// NormalizedConfigs returns the discovery list this client should
+// register with. When the modern Configs field is non-empty, it's
+// returned as-is; otherwise a single-element list is synthesized
+// from the legacy Discovery + DiscoveryDmsg fields. Returns nil
+// when neither is set (deserves a hard error from the caller).
+func (c *DmsgConfig) NormalizedConfigs() []DiscoveryConfig {
+	if len(c.Configs) > 0 {
+		return c.Configs
+	}
+	if c.Discovery == "" && c.DiscoveryDmsg == "" {
+		return nil
+	}
+	return []DiscoveryConfig{{URL: c.Discovery, DmsgURL: c.DiscoveryDmsg}}
 }
 
 // lanPriorityDisc wraps a disc.APIClient to prepend LAN server entries
@@ -76,15 +109,30 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 	}
 	dmsgConf.ClientType = "visor"
 
-	var dc disc.APIClient
-	dc = disc.NewHTTP(conf.Discovery, httpC, masterLogger.PackageLogger("dmsgC:disc"))
-	if len(conf.LANServers) > 0 {
-		masterLogger.PackageLogger("dmsgC").Infof("Using %d LAN DMSG servers (tried first)", len(conf.LANServers))
-		dc = &lanPriorityDisc{APIClient: dc, lanEntries: conf.LANServers}
+	configs := conf.NormalizedConfigs()
+	if len(configs) == 0 {
+		// Preserve legacy zero-value behavior: a Discovery="" config
+		// produced an HTTP client pointed at "" (effectively dead) but
+		// the caller didn't explode. Mirror that here.
+		configs = []DiscoveryConfig{{URL: conf.Discovery, DmsgURL: conf.DiscoveryDmsg}}
 	}
 
-	dmsgC := dmsg.NewClient(pk, sk, dc, dmsgConf)
+	primaryHTTP := disc.NewHTTP(configs[0].URL, httpC, masterLogger.PackageLogger("dmsgC:disc"))
+	var primary disc.APIClient = primaryHTTP
+	if len(conf.LANServers) > 0 {
+		masterLogger.PackageLogger("dmsgC").Infof("Using %d LAN DMSG servers (tried first)", len(conf.LANServers))
+		primary = &lanPriorityDisc{APIClient: primary, lanEntries: conf.LANServers}
+	}
+
+	dmsgC := dmsg.NewClient(pk, sk, primary, dmsgConf)
 	dmsgC.SetLogger(masterLogger.PackageLogger("dmsgC"))
 	dmsgC.SetMasterLogger(masterLogger)
+	// Attach extra discoveries so the visor publishes its client entry
+	// to all configured discoveries. Plain HTTP at construction time;
+	// the visor's init_dmsg path can later swap these for dmsgfirst-
+	// wrapped clients once dmsgC has a usable session.
+	for i := 1; i < len(configs); i++ {
+		dmsgC.AddDiscovery(disc.NewHTTP(configs[i].URL, httpC, masterLogger.PackageLogger("dmsgC:disc")), configs[i].PK)
+	}
 	return dmsgC
 }

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -128,22 +128,34 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 		return fmt.Errorf("cannot initialize dmsg: empty configuration")
 	}
 
+	// When the modern Configs[] schema is set, we use its first entry
+	// as the primary discovery (DMSG URL preferred when dmsgHTTP is
+	// ready, else HTTP URL); the rest are attached as additional
+	// discoveries inside dmsgc.New. This keeps the legacy single-
+	// discovery code path identical when Configs is empty.
+	primary := v.conf.Dmsg.Discovery
+	primaryDmsg := v.conf.Dmsg.DiscoveryDmsg
+	if cfgs := v.conf.Dmsg.Configs; len(cfgs) > 0 {
+		primary = cfgs[0].URL
+		primaryDmsg = cfgs[0].DmsgURL
+	}
+
 	// Prefer DMSG-HTTP for discovery if configured (more private, no DNS dependency),
 	// fall back to plain HTTP URL. If HTTP URL is empty (DMSG-only deployment),
 	// DMSG is required — not optional.
-	discURL := v.conf.Dmsg.Discovery
-	if v.conf.Dmsg.DiscoveryDmsg != "" && v.dmsgHTTP != nil {
-		if _, err := getHTTPClient(ctx, v, v.conf.Dmsg.DiscoveryDmsg); err == nil {
-			discURL = v.conf.Dmsg.DiscoveryDmsg
+	discURL := primary
+	if primaryDmsg != "" && v.dmsgHTTP != nil {
+		if _, err := getHTTPClient(ctx, v, primaryDmsg); err == nil {
+			discURL = primaryDmsg
 			log.Info("Using DMSG-HTTP for dmsg discovery")
 		} else if discURL != "" {
 			log.WithError(err).Warn("DMSG-HTTP discovery failed, using plain HTTP")
 		} else {
 			return fmt.Errorf("DMSG-only deployment but DMSG discovery unreachable: %w", err)
 		}
-	} else if discURL == "" && v.conf.Dmsg.DiscoveryDmsg != "" {
+	} else if discURL == "" && primaryDmsg != "" {
 		// DMSG URL set but dmsgHTTP not ready — can't proceed without either
-		discURL = v.conf.Dmsg.DiscoveryDmsg
+		discURL = primaryDmsg
 		log.Warn("HTTP discovery URL empty, attempting DMSG discovery without dmsgHTTP transport")
 	}
 


### PR DESCRIPTION
## Summary

Closes the HTTP-bootstrap loop that left a skywire deployment dead in the water without the public internet. After this change, a local LAN deployment + a local dmsg-server form a self-contained network: dmsg-discovery preloads its server list from the embedded keyring (no self-poll), dmsg-servers register over DMSG first (HTTP fallback), and the visor / dmsg-server multi-discovery schemas let one node register with multiple discoveries simultaneously.

Five pieces, all in one branch per the consolidation request:

1. **dmsg-discovery preload** — `cmd/dmsg/dmsg-discovery`, `deployment`
   - New `--dmsg-servers PK@addr[,…]` flag seeds `direct.Client` at startup.
   - Empty flag falls back to the embedded `deployment.Prod` (or `deployment.Test` with `--test-environment`) keyring.
   - Legacy self-poll stays as a last-resort fallback so existing deployments without the flag don't break.
   - New `deployment.DmsgServerEntriesToDisc(...)` helper shares the conversion with `skywire-cli config gen` (replaces an inline copy).

2. **dmsg-server multi-discovery schema** — `pkg/dmsg/dmsgserver`, `pkg/dmsg/dmsg`, `cmd/dmsg/dmsg-server`
   - `Config` gains `Discoveries []DiscoveryConfig` with per-entry `advertised_address` (advertise LAN to local discovery, public IP to internet discovery).
   - Backward compat: `NormalizedDiscoveries()` folds the legacy `Discovery` + `PublicAddress` fields into a one-element list — existing config files keep working unchanged.
   - `EntityCommon` now holds a `discoveries[]` slice; `updateServerEntry`, `updateClientEntry`, `initilizeClientEntry`, `delEntry`, and `entryProtocol` all iterate (best-effort: a transient failure on one discovery doesn't block the others).

3. **DMSG-first registration** — `pkg/dmsg/dmsg{server,client}`
   - Once the dmsg-server's outbound `dmsg.Client` is up, each configured discovery client is swapped from plain `disc.NewHTTP` to `dmsgfirst.New(dmsgC, pk, url)` (PR #2433).
   - Registration prefers DMSG; HTTP fallback on transport-class errors.
   - Inbound-session-triggered push works through the existing `setSessionCallback → entryNudge` path: a new session triggers a registration push, which now iterates all discoveries.

4. **Visor multi-discovery** — `pkg/dmsgc`, `pkg/visor/init_dmsg.go`
   - `DmsgConfig` gains `Configs []DiscoveryConfig` with the same shape.
   - `dmsgc.New` iterates and attaches extras via `dmsgC.AddDiscovery`; `init_dmsg` picks the primary URL from `Configs[0]` when set, else from the legacy `Discovery` / `DiscoveryDmsg` pair.

5. **`config gen --dmsgdisc` / `--dmsgsrv`** — `cmd/skywire-cli`
   - Mirror the existing `--sn` JQ projection pattern.
   - `--dmsgsrv` emits a dmsg-server JSON config (`discoveries[]` folded from the visor's dmsg pair).
   - `--dmsgdisc` emits a dmsg-discovery flag-shaped config (`addr`, `dmsg_port`, `dmsg_servers`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/dmsg/dmsg/ ./pkg/dmsgc/ ./pkg/dmsg/dmsgserver/ ./pkg/visor/... ./deployment/ ./cmd/skywire-cli/... ./cmd/dmsg/...` — all green (Redis-backed `pkg/dmsg/discovery/store` integration tests are skipped — they need an unauthenticated local Redis; pre-existing local-env limitation, unrelated to this change)
- [x] `go run ./cmd/skywire-cli config gen -n --dmsgsrv` produces a valid dmsg-server config shape
- [x] `go run ./cmd/skywire-cli config gen -n --dmsgdisc` produces a dmsg-discovery flag-shaped config
- [x] `go run ./cmd/skywire-cli config gen -n --sn` unchanged (regression check)
- [ ] Production verification (after deploy): TPD + dmsg-server + dmsg-discovery start cleanly, dmsg-server registers via DMSG (visible in logs), `--dmsg-servers` flag accepted by dmsg-discovery