### PR TITLE
feat(dmsg-disc): polymorphic dmsg config; per-deployment servers

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -130,12 +130,13 @@ var RootCmd = &cobra.Command{
 			Peers:          peers,
 		}
 
-		// Resolve the configured discoveries. NormalizedDiscoveries
-		// folds the legacy single-discovery fields into a one-element
-		// list so existing config files continue to work unchanged.
-		discoveriesCfg := conf.NormalizedDiscoveries()
-		if len(discoveriesCfg) == 0 {
-			log.Fatal("no dmsg-discoveries configured; set 'discovery' or 'discoveries' in config")
+		// Resolve the configured deployments. NormalizedDeployments
+		// folds the legacy Discovery / DiscoveryDmsg / PublicAddress
+		// fields into a one-element list so existing config files
+		// continue to work unchanged.
+		deployments := conf.NormalizedDeployments()
+		if len(deployments) == 0 {
+			log.Fatal("no dmsg-discoveries configured; set 'discovery' or 'dmsg' in config")
 		}
 
 		// Primary discovery is the first in the list. NewServer takes a
@@ -144,16 +145,20 @@ var RootCmd = &cobra.Command{
 		// once the server's outbound dmsg.Client is up later, the
 		// discovery clients are swapped for dmsgfirst-wrapped versions
 		// so registration prefers DMSG when available.
-		primaryHTTP := disc.NewHTTP(discoveriesCfg[0].URL, &http.Client{}, log)
+		primaryHTTP := disc.NewHTTP(deployments[0].Discovery, &http.Client{}, log)
 		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, primaryHTTP, &srvConf, m)
 		srv.SetLogger(log)
 		srv.SetDHTBootstrap(conf.EnableDHT)
-		// Attach extras (each with its own per-discovery advertised
+		// Attach extras (each with its own per-deployment advertised
 		// address). The primary's advertised address is passed through
-		// the legacy Serve(..., conf.PublicAddress) path below.
-		for i := 1; i < len(discoveriesCfg); i++ {
-			extra := discoveriesCfg[i]
-			srv.AddDiscovery(disc.NewHTTP(extra.URL, &http.Client{}, log), extra.AdvertisedAddress, extra.PK)
+		// the legacy Serve(..., publicAddr) path below.
+		for i := 1; i < len(deployments); i++ {
+			extra := deployments[i]
+			srv.AddDiscovery(
+				disc.NewHTTP(extra.Discovery, &http.Client{}, log),
+				extra.AdvertisedAddress,
+				dmsgserver.PKFromDmsgURL(extra.DiscoveryDmsg),
+			)
 		}
 
 		srvAPI.SetDmsgServer(srv)
@@ -162,11 +167,11 @@ var RootCmd = &cobra.Command{
 		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
 		defer cancel()
 
-		// The Server's primary discovery uses the first entry's
+		// The Server's primary discovery uses the first deployment's
 		// advertised address as the default (passed through Serve).
 		// AdvertisedAddress on extras overrides per-endpoint inside
 		// EntityCommon's update loop.
-		primaryAdvertised := discoveriesCfg[0].AdvertisedAddress
+		primaryAdvertised := deployments[0].AdvertisedAddress
 		if primaryAdvertised == "" {
 			primaryAdvertised = conf.PublicAddress
 		}
@@ -207,13 +212,33 @@ var RootCmd = &cobra.Command{
 			// peer wound up cached as non-DHT until restart. Mirrors
 			// the BootstrapDmsg helper that every other deployment
 			// service uses (pkg/cmdutil/dmsg_bootstrap.go).
+			// Build the transit set: the union of (a) per-discovery
+			// servers from the config (multi-deployment case where
+			// each discovery has its own disjoint server set), (b) the
+			// embedded deployment keyring (single-deployment fallback),
+			// minus this server itself. Each discovery's `servers` list
+			// expresses which dmsg-servers reach THAT discovery; the
+			// union ensures dmsgC has a session-relayable path to every
+			// configured discovery.
 			servers := []*disc.Entry{serverEntry}
-			for i := range dmsg.Prod.DmsgServers {
-				peer := &dmsg.Prod.DmsgServers[i]
-				if peer.Static == conf.PubKey {
-					continue
+			seenPK := map[cipher.PubKey]struct{}{conf.PubKey: {}}
+			addServer := func(e *disc.Entry) {
+				if e == nil {
+					return
 				}
-				servers = append(servers, peer)
+				if _, ok := seenPK[e.Static]; ok {
+					return
+				}
+				seenPK[e.Static] = struct{}{}
+				servers = append(servers, e)
+			}
+			for _, d := range deployments {
+				for _, e := range d.Servers {
+					addServer(e)
+				}
+			}
+			for i := range dmsg.Prod.DmsgServers {
+				addServer(&dmsg.Prod.DmsgServers[i])
 			}
 			entries := direct.GetAllEntries(cipher.PubKeys{conf.PubKey}, servers)
 			dClient := direct.NewClient(entries, log)
@@ -230,19 +255,20 @@ var RootCmd = &cobra.Command{
 
 			// Upgrade each configured discovery client from plain HTTP
 			// to dmsgfirst — registration then tries DMSG first and
-			// only falls back to HTTP if the dmsg dial fails. Discoveries
-			// without a configured PK can't use DMSG (dmsgfirst.New
-			// needs the discovery's own PK to dial it), so we leave
-			// those as plain HTTP and log it.
-			upgraded := make([]disc.APIClient, len(discoveriesCfg))
-			for i, d := range discoveriesCfg {
-				if d.PK == (cipher.PubKey{}) {
-					upgraded[i] = disc.NewHTTP(d.URL, &http.Client{}, log)
-					log.WithField("url", d.URL).Debug("discovery has no PK; staying on plain HTTP")
+			// only falls back to HTTP if the dmsg dial fails. The PK
+			// is extracted from the deployment's discovery_dmsg URL;
+			// when discovery_dmsg is unset, dmsgfirst can't dial it
+			// over DMSG, so we leave that entry on plain HTTP and log it.
+			upgraded := make([]disc.APIClient, len(deployments))
+			for i, d := range deployments {
+				pk := dmsgserver.PKFromDmsgURL(d.DiscoveryDmsg)
+				if pk == (cipher.PubKey{}) {
+					upgraded[i] = disc.NewHTTP(d.Discovery, &http.Client{}, log)
+					log.WithField("url", d.Discovery).Debug("discovery_dmsg unset; staying on plain HTTP")
 					continue
 				}
-				upgraded[i] = dmsgfirst.New(dmsgC, d.PK, d.URL, &http.Client{}, log)
-				log.WithField("url", d.URL).WithField("pk", d.PK).Info("discovery upgraded to dmsg-first registration")
+				upgraded[i] = dmsgfirst.New(dmsgC, pk, d.Discovery, &http.Client{}, log)
+				log.WithField("url", d.Discovery).WithField("pk", pk).Info("discovery upgraded to dmsg-first registration")
 			}
 			srv.SetDiscoveryClients(upgraded)
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -911,13 +911,17 @@ func serviceProjectionJQ() string {
 	case snConfig:
 		return "{public_key: .pk, secret_key: .sk, dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}, transport_discovery: (.transport.discovery_dmsg // .transport.discovery), log_level: .log_level}"
 	case dmsgSrvConfig:
-		// Project to a dmsg-server config. Keys map onto
-		// pkg/dmsg/dmsgserver.Config exactly. The discoveries[] list
-		// is synthesized from the visor's dmsg.discovery /
-		// dmsg.discovery_dmsg pair so a single config command can
-		// produce a dmsg-server config that registers with the same
-		// discovery the visor uses.
-		return "{public_key: .pk, secret_key: .sk, discoveries: [{url: .dmsg.discovery, dmsg_url: .dmsg.discovery_dmsg, advertised_address: \"\"}], local_address: \":8081\", health_endpoint_address: \":8082\", log_level: .log_level, max_sessions: 2048}"
+		// Project to a dmsg-server config. The output `dmsg` block
+		// mirrors the visor's `dmsg` block shape — same fields,
+		// `discovery` / `discovery_dmsg` / `servers` / `sessions_count`
+		// carried straight over. Single-deployment shape (object form)
+		// by default; users with multi-deployment requirements hand-
+		// edit the `dmsg` field into an array of the same per-element
+		// shape. `public_address` lives at the top level (one external
+		// address for the single TCP listener); the per-deployment
+		// override `advertised_address` inside `dmsg[i]` is only set
+		// when the multi-network NAT case requires it.
+		return "{public_key: .pk, secret_key: .sk, dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}, public_address: \"\", local_address: \":8081\", health_endpoint_address: \":8082\", log_level: .log_level, max_sessions: 2048}"
 	case dmsgDiscConfig:
 		// Project to a dmsg-discovery config. dmsg-discovery has no
 		// JSON config file today (CLI flags only), but emitting a

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -2,13 +2,17 @@
 package dmsgserver
 
 import (
+	"bytes"
 	"encoding/json"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/skycoin/skycoin/src/util/logging"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 )
 
@@ -32,19 +36,56 @@ type PeerConfig struct {
 	Address string        `json:"address"`
 }
 
-// DiscoveryConfig represents a single dmsg-discovery this server should
-// register with. AdvertisedAddress is the address this server should
-// advertise to THIS discovery — for example a server may advertise a
-// LAN address (192.168.x.x:8081) to a local discovery and a public
-// address (1.2.3.4:8081) to an internet discovery. PK, when set, lets
-// the server detect inbound DMSG sessions originated by this discovery
-// and trigger an immediate registration push back over that session
-// (see Config.NormalizedDiscoveries for backward-compat fallback).
-type DiscoveryConfig struct {
-	URL               string        `json:"url"`
-	DmsgURL           string        `json:"dmsg_url,omitempty"`
-	PK                cipher.PubKey `json:"public_key,omitempty"`
+// Deployment is one (dmsg-discovery, transit-servers) pair this server
+// should register with. AdvertisedAddress is the address THIS server
+// should advertise to THIS discovery — for example a server may
+// advertise a LAN address (192.168.x.x:8081) to a local discovery and
+// a public address (1.2.3.4:8081) to an internet discovery. Servers is
+// the dmsg-server transit set this server uses to reach this
+// discovery; the union of all deployments' Servers is preloaded into
+// the server's outbound dmsg.Client so it can dial any configured
+// discovery via any reachable transit.
+//
+// The discovery's PK is encoded in DiscoveryDmsg (form
+// `dmsg://<PK>:<port>`); there is no separate PK field. Callers
+// extract it on demand for dmsgfirst registration.
+type Deployment struct {
+	Discovery         string        `json:"discovery,omitempty"`
+	DiscoveryDmsg     string        `json:"discovery_dmsg,omitempty"`
+	SessionsCount     int           `json:"sessions_count,omitempty"`
+	Servers           []*disc.Entry `json:"servers,omitempty"`
 	AdvertisedAddress string        `json:"advertised_address,omitempty"`
+}
+
+// DmsgConfig is the per-server `dmsg` block. JSON polymorphism
+// mirrors pkg/dmsgc.DmsgConfig: a single Deployment object for
+// single-deployment configs, an array of Deployments for
+// multi-deployment configs.
+type DmsgConfig struct {
+	Deployments []Deployment `json:"-"`
+}
+
+// UnmarshalJSON accepts either a single Deployment object or an array.
+func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimLeft(data, " \t\n\r")
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		return json.Unmarshal(data, &c.Deployments)
+	}
+	var single Deployment
+	if err := json.Unmarshal(data, &single); err != nil {
+		return err
+	}
+	c.Deployments = []Deployment{single}
+	return nil
+}
+
+// MarshalJSON emits the single-object shape for a one-element list,
+// otherwise the array shape.
+func (c DmsgConfig) MarshalJSON() ([]byte, error) {
+	if len(c.Deployments) == 1 {
+		return json.Marshal(c.Deployments[0])
+	}
+	return json.Marshal(c.Deployments)
 }
 
 // Config is structure of config file
@@ -53,14 +94,23 @@ type Config struct {
 
 	PubKey cipher.PubKey `json:"public_key"`
 	SecKey cipher.SecKey `json:"secret_key"`
-	// Discoveries is the list of dmsg-discoveries this server registers
-	// with. When empty, the legacy Discovery + PublicAddress fields are
-	// folded into a single-element list (see NormalizedDiscoveries).
-	Discoveries []DiscoveryConfig `json:"discoveries,omitempty"`
-	// Discovery and PublicAddress are the legacy single-discovery
-	// fields. Superseded by Discoveries; kept so existing config files
-	// continue to work without edits.
+
+	// Dmsg holds the discovery / servers configuration. Polymorphic
+	// JSON: a single object describes a single deployment, an array
+	// describes multiple. Folded from the legacy Discovery /
+	// DiscoveryDmsg / PublicAddress fields by NormalizedDeployments
+	// when this field is unset.
+	Dmsg DmsgConfig `json:"dmsg,omitempty"`
+
+	// Discovery, DiscoveryDmsg, and PublicAddress are the legacy
+	// single-discovery fields kept so existing config files continue
+	// to work without restructuring. NormalizedDeployments folds them
+	// into a one-element list when Dmsg.Deployments is empty. When
+	// DiscoveryDmsg is set (URL form `dmsg://<PK>:<port>`), the PK is
+	// extracted automatically and used to upgrade registration from
+	// plain HTTP to dmsgfirst.
 	Discovery        string        `json:"discovery,omitempty"`
+	DiscoveryDmsg    string        `json:"discovery_dmsg,omitempty"`
 	PublicAddress    string        `json:"public_address,omitempty"`
 	LocalAddress     string        `json:"local_address"`
 	HTTPAddress      string        `json:"health_endpoint_address"`
@@ -101,19 +151,64 @@ func GenerateDefaultConfig(c *Config) {
 	c.MaxSessions = dmsg.DefaultMaxSessions
 }
 
-// NormalizedDiscoveries returns the discovery list the server should
-// actually register with. When the modern Discoveries field is set,
-// it's returned as-is; otherwise a single-element list is synthesized
-// from the legacy Discovery + PublicAddress fields so existing config
-// files keep working unchanged. Returns nil when neither is set.
-func (c *Config) NormalizedDiscoveries() []DiscoveryConfig {
-	if len(c.Discoveries) > 0 {
-		return c.Discoveries
-	}
-	if c.Discovery == "" {
+// NormalizedDeployments returns the deployment list this server
+// should register with. The modern Dmsg.Deployments field wins;
+// otherwise a one-element list is synthesized from the legacy
+// Discovery + DiscoveryDmsg fields.
+//
+// AdvertisedAddress resolution: a non-empty per-deployment value wins;
+// otherwise the top-level PublicAddress is used as the default. This
+// keeps single-listener servers simple (set public_address once) while
+// still supporting the multi-network case where the same listener is
+// reachable via different addresses depending on the discovery's
+// clients (LAN address to LAN discovery, NAT'd public IP to internet
+// discovery). Empty string after both layers passes through, and
+// dmsg.SetAdvertisedAddr falls back to the local listener address.
+//
+// Returns nil when neither shape is populated. Returns a fresh slice
+// so callers can mutate without affecting Dmsg.Deployments.
+func (c *Config) NormalizedDeployments() []Deployment {
+	var src []Deployment
+	switch {
+	case len(c.Dmsg.Deployments) > 0:
+		src = c.Dmsg.Deployments
+	case c.Discovery != "" || c.DiscoveryDmsg != "":
+		src = []Deployment{{Discovery: c.Discovery, DiscoveryDmsg: c.DiscoveryDmsg}}
+	default:
 		return nil
 	}
-	return []DiscoveryConfig{{URL: c.Discovery, AdvertisedAddress: c.PublicAddress}}
+	out := make([]Deployment, len(src))
+	for i, d := range src {
+		if d.AdvertisedAddress == "" {
+			d.AdvertisedAddress = c.PublicAddress
+		}
+		out[i] = d
+	}
+	return out
+}
+
+// PKFromDmsgURL extracts the dmsg PK from a URL of the form
+// `dmsg://<PK>:<port>[/path]`. Exported so dmsg-server's start path
+// can use it on Deployment.DiscoveryDmsg without re-implementing the
+// parser. Returns the zero PK when the URL is empty, malformed, or
+// doesn't contain a valid PK in the host part.
+func PKFromDmsgURL(s string) cipher.PubKey {
+	if s == "" {
+		return cipher.PubKey{}
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return cipher.PubKey{}
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = strings.SplitN(u.Host, ":", 2)[0]
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(host); err != nil {
+		return cipher.PubKey{}
+	}
+	return pk
 }
 
 // Flush trying to save config file

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -2,8 +2,12 @@
 package dmsgc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -12,48 +16,192 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// DiscoveryConfig represents a single dmsg-discovery this client
-// should register with. URL is the plain-HTTP endpoint; DmsgURL, when
-// set, is the dmsg-HTTP endpoint used by dmsgfirst as the DMSG-side
-// fallback target. PK, when set, identifies the discovery's own
-// dmsg-server PK so dmsgfirst can dial it over DMSG before falling
-// back to HTTP.
-type DiscoveryConfig struct {
-	URL     string        `json:"url"`
-	DmsgURL string        `json:"dmsg_url,omitempty"`
-	PK      cipher.PubKey `json:"public_key,omitempty"`
+// Deployment is one (dmsg-discovery, transit-servers) pair. Each
+// Deployment is independent — different deployments may use different
+// servers, sessions counts, protocols, or LAN preferences.
+//
+// The discovery's PK is encoded in DiscoveryDmsg (form
+// `dmsg://<PK>:<port>`) and is extracted on demand by callers that
+// need it for dmsgfirst registration; there is no separate PK field.
+type Deployment struct {
+	Discovery            string        `json:"discovery,omitempty"`
+	DiscoveryDmsg        string        `json:"discovery_dmsg,omitempty"`
+	SessionsCount        int           `json:"sessions_count,omitempty"`
+	Servers              []*disc.Entry `json:"servers,omitempty"`
+	ConnectedServersType string        `json:"servers_type,omitempty"`
+	Protocol             string        `json:"protocol,omitempty"`
+	LANServers           []*disc.Entry `json:"lan_servers,omitempty"`
 }
 
-// DmsgConfig defines config for Dmsg network.
+// DmsgConfig is the visor-side dmsg subsystem configuration.
+//
+// JSON polymorphism: a single Deployment object is the single-
+// deployment shape that visor configs have always used; an array of
+// Deployments is the multi-deployment shape, where each entry pairs
+// a dmsg-discovery with the dmsg-servers that reach it. Internally
+// the type stores a slice; the single-object shape unmarshals into
+// a one-element slice and marshals back to an object.
+//
+// For backward compatibility with code that reads
+// `v.conf.Dmsg.Discovery` etc. directly, the legacy top-level fields
+// are kept as a mirror of Deployments[0]. Writers that build a
+// DmsgConfig by setting top-level fields directly still work — the
+// MarshalJSON synthesizes a one-element Deployments from the
+// top-level fields when Deployments is empty.
 type DmsgConfig struct {
-	// Configs is the list of dmsg-discoveries this client registers
-	// with. When non-empty it supersedes Discovery / DiscoveryDmsg —
-	// the legacy fields are kept so existing visor configs keep working
-	// and so a single-discovery deployment doesn't need the verbose
-	// multi-discovery shape.
-	Configs              []DiscoveryConfig `json:"configs,omitempty"`
-	Discovery            string            `json:"discovery"`
-	DiscoveryDmsg        string            `json:"discovery_dmsg,omitempty"`
-	SessionsCount        int               `json:"sessions_count"`
-	Servers              []*disc.Entry     `json:"servers"`
-	ConnectedServersType string            `json:"servers_type"`
-	Protocol             string            `json:"protocol"`
-	LANServers           []*disc.Entry     `json:"lan_servers,omitempty"` // Static LAN DMSG servers (tried first, auto-populated by hypervisor)
+	// Deployments is the canonical list, populated by UnmarshalJSON.
+	Deployments []Deployment `json:"-"`
+
+	// Top-level mirror fields. Read-only after UnmarshalJSON; the
+	// canonical state lives in Deployments. Kept to avoid churning
+	// the many existing call sites that read Dmsg.Discovery /
+	// Dmsg.DiscoveryDmsg / Dmsg.Servers / etc. directly.
+	Discovery            string        `json:"-"`
+	DiscoveryDmsg        string        `json:"-"`
+	SessionsCount        int           `json:"-"`
+	Servers              []*disc.Entry `json:"-"`
+	ConnectedServersType string        `json:"-"`
+	Protocol             string        `json:"-"`
+	LANServers           []*disc.Entry `json:"-"`
 }
 
-// NormalizedConfigs returns the discovery list this client should
-// register with. When the modern Configs field is non-empty, it's
-// returned as-is; otherwise a single-element list is synthesized
-// from the legacy Discovery + DiscoveryDmsg fields. Returns nil
-// when neither is set (deserves a hard error from the caller).
-func (c *DmsgConfig) NormalizedConfigs() []DiscoveryConfig {
-	if len(c.Configs) > 0 {
-		return c.Configs
+// UnmarshalJSON accepts either a single Deployment object or an array
+// of Deployments and populates Deployments + the legacy top-level
+// mirror fields accordingly.
+func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimLeft(data, " \t\n\r")
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		if err := json.Unmarshal(data, &c.Deployments); err != nil {
+			return err
+		}
+	} else {
+		var single Deployment
+		if err := json.Unmarshal(data, &single); err != nil {
+			return err
+		}
+		c.Deployments = []Deployment{single}
 	}
-	if c.Discovery == "" && c.DiscoveryDmsg == "" {
+	c.mirrorPrimary()
+	return nil
+}
+
+// MarshalJSON emits the single-deployment object shape when there is
+// exactly one deployment, otherwise the array shape. When Deployments
+// is empty but the top-level fields are populated (e.g. a writer that
+// only set Discovery + Servers directly), a one-element Deployments
+// is synthesized from the mirror fields so the JSON output is correct.
+func (c DmsgConfig) MarshalJSON() ([]byte, error) {
+	deployments := c.Deployments
+	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0) {
+		deployments = []Deployment{c.toDeployment()}
+	}
+	if len(deployments) == 1 {
+		return json.Marshal(deployments[0])
+	}
+	return json.Marshal(deployments)
+}
+
+// mirrorPrimary copies Deployments[0] into the legacy top-level fields
+// so existing readers keep working in the single-deployment case. For
+// multi-deployment configs the mirror reflects the first entry — code
+// that needs to iterate uses Deployments directly.
+func (c *DmsgConfig) mirrorPrimary() {
+	if len(c.Deployments) == 0 {
+		return
+	}
+	d := c.Deployments[0]
+	c.Discovery = d.Discovery
+	c.DiscoveryDmsg = d.DiscoveryDmsg
+	c.SessionsCount = d.SessionsCount
+	c.Servers = d.Servers
+	c.ConnectedServersType = d.ConnectedServersType
+	c.Protocol = d.Protocol
+	c.LANServers = d.LANServers
+}
+
+// toDeployment snapshots the legacy top-level fields into a Deployment.
+func (c *DmsgConfig) toDeployment() Deployment {
+	return Deployment{
+		Discovery:            c.Discovery,
+		DiscoveryDmsg:        c.DiscoveryDmsg,
+		SessionsCount:        c.SessionsCount,
+		Servers:              c.Servers,
+		ConnectedServersType: c.ConnectedServersType,
+		Protocol:             c.Protocol,
+		LANServers:           c.LANServers,
+	}
+}
+
+// Primary returns the first deployment, synthesizing one from the
+// legacy top-level fields when Deployments is empty. Callers can rely
+// on Primary always returning a non-nil pointer for any non-empty
+// DmsgConfig.
+func (c *DmsgConfig) Primary() *Deployment {
+	if len(c.Deployments) > 0 {
+		return &c.Deployments[0]
+	}
+	d := c.toDeployment()
+	return &d
+}
+
+// AllDeployments returns the list of deployments, synthesizing a
+// one-element list from the legacy top-level fields when Deployments
+// is empty. Returns nil only when the config is fully zero.
+func (c *DmsgConfig) AllDeployments() []Deployment {
+	if len(c.Deployments) > 0 {
+		return c.Deployments
+	}
+	if c.Discovery == "" && c.DiscoveryDmsg == "" && len(c.Servers) == 0 {
 		return nil
 	}
-	return []DiscoveryConfig{{URL: c.Discovery, DmsgURL: c.DiscoveryDmsg}}
+	return []Deployment{c.toDeployment()}
+}
+
+// ResolvedServers unions servers from all deployments, deduping by PK.
+// The result is what the direct.Client should be preloaded with so the
+// client can dmsg-dial every configured discovery — whether
+// deployments share a server set or have disjoint per-deployment sets.
+func (c *DmsgConfig) ResolvedServers() []*disc.Entry {
+	seen := make(map[cipher.PubKey]struct{})
+	var out []*disc.Entry
+	add := func(e *disc.Entry) {
+		if e == nil {
+			return
+		}
+		if _, ok := seen[e.Static]; ok {
+			return
+		}
+		seen[e.Static] = struct{}{}
+		out = append(out, e)
+	}
+	for _, d := range c.AllDeployments() {
+		for _, e := range d.Servers {
+			add(e)
+		}
+	}
+	return out
+}
+
+// pkFromDmsgURL extracts the dmsg PK from a URL of the form
+// `dmsg://<PK>:<port>[/path]`. Returns the zero PK when the URL is
+// empty, malformed, or doesn't contain a valid PK in the host part.
+func pkFromDmsgURL(s string) cipher.PubKey {
+	if s == "" {
+		return cipher.PubKey{}
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return cipher.PubKey{}
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = strings.SplitN(u.Host, ":", 2)[0]
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(host); err != nil {
+		return cipher.PubKey{}
+	}
+	return pk
 }
 
 // lanPriorityDisc wraps a disc.APIClient to prepend LAN server entries
@@ -88,8 +236,9 @@ func (d *lanPriorityDisc) AllServers(ctx context.Context) ([]*disc.Entry, error)
 
 // New makes new dmsg client from configuration
 func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, masterLogger *logging.MasterLogger) *dmsg.Client {
+	primary := conf.Primary()
 	dmsgConf := &dmsg.Config{
-		MinSessions: conf.SessionsCount,
+		MinSessions: primary.SessionsCount,
 		Callbacks: &dmsg.ClientCallbacks{
 			OnSessionDial: func(network, addr string) error {
 				data := appevent.TCPDialData{RemoteNet: network, RemoteAddr: addr}
@@ -104,34 +253,34 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 				_ = eb.Broadcast(context.Background(), event) //nolint:errcheck
 			},
 		},
-		ConnectedServersType: conf.ConnectedServersType,
-		Protocol:             conf.Protocol,
+		ConnectedServersType: primary.ConnectedServersType,
+		Protocol:             primary.Protocol,
 	}
 	dmsgConf.ClientType = "visor"
 
-	configs := conf.NormalizedConfigs()
-	if len(configs) == 0 {
-		// Preserve legacy zero-value behavior: a Discovery="" config
-		// produced an HTTP client pointed at "" (effectively dead) but
-		// the caller didn't explode. Mirror that here.
-		configs = []DiscoveryConfig{{URL: conf.Discovery, DmsgURL: conf.DiscoveryDmsg}}
+	deployments := conf.AllDeployments()
+	if len(deployments) == 0 {
+		deployments = []Deployment{{}}
 	}
 
-	primary := disc.NewHTTP(configs[0].URL, httpC, masterLogger.PackageLogger("dmsgC:disc"))
-	if len(conf.LANServers) > 0 {
-		masterLogger.PackageLogger("dmsgC").Infof("Using %d LAN DMSG servers (tried first)", len(conf.LANServers))
-		primary = &lanPriorityDisc{APIClient: primary, lanEntries: conf.LANServers}
+	primaryC := disc.NewHTTP(deployments[0].Discovery, httpC, masterLogger.PackageLogger("dmsgC:disc"))
+	if len(primary.LANServers) > 0 {
+		masterLogger.PackageLogger("dmsgC").Infof("Using %d LAN DMSG servers (tried first)", len(primary.LANServers))
+		primaryC = &lanPriorityDisc{APIClient: primaryC, lanEntries: primary.LANServers}
 	}
 
-	dmsgC := dmsg.NewClient(pk, sk, primary, dmsgConf)
+	dmsgC := dmsg.NewClient(pk, sk, primaryC, dmsgConf)
 	dmsgC.SetLogger(masterLogger.PackageLogger("dmsgC"))
 	dmsgC.SetMasterLogger(masterLogger)
-	// Attach extra discoveries so the visor publishes its client entry
-	// to all configured discoveries. Plain HTTP at construction time;
-	// the visor's init_dmsg path can later swap these for dmsgfirst-
-	// wrapped clients once dmsgC has a usable session.
-	for i := 1; i < len(configs); i++ {
-		dmsgC.AddDiscovery(disc.NewHTTP(configs[i].URL, httpC, masterLogger.PackageLogger("dmsgC:disc")), configs[i].PK)
+	// Attach extra deployments so the visor publishes its client entry
+	// to every configured discovery. Plain HTTP at construction time;
+	// the visor's init_dmsg path can swap these for dmsgfirst-wrapped
+	// clients once dmsgC has a usable session.
+	for i := 1; i < len(deployments); i++ {
+		dmsgC.AddDiscovery(
+			disc.NewHTTP(deployments[i].Discovery, httpC, masterLogger.PackageLogger("dmsgC:disc")),
+			pkFromDmsgURL(deployments[i].DiscoveryDmsg),
+		)
 	}
 	return dmsgC
 }

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -43,8 +43,11 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	// (cached on disk in <local_path>/dmsg_servers.json) over the addresses
 	// in skywire.json — those can be months stale if a server has rotated
 	// IP since the config was generated. The cache is written by the
-	// background refresh loop in initDmsg.
-	configured := v.conf.Dmsg.Servers
+	// background refresh loop in initDmsg. ResolvedServers unions the
+	// top-level Servers list with any per-discovery Configs[].Servers,
+	// so multi-deployment configs (each discovery with its own disjoint
+	// server set) are honored.
+	configured := v.conf.Dmsg.ResolvedServers()
 	if v.dmsgServersCache != nil {
 		configured = v.dmsgServersCache.MergePreferringCache(configured)
 	}
@@ -128,17 +131,13 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 		return fmt.Errorf("cannot initialize dmsg: empty configuration")
 	}
 
-	// When the modern Configs[] schema is set, we use its first entry
-	// as the primary discovery (DMSG URL preferred when dmsgHTTP is
-	// ready, else HTTP URL); the rest are attached as additional
-	// discoveries inside dmsgc.New. This keeps the legacy single-
-	// discovery code path identical when Configs is empty.
+	// Pick the primary deployment for the discovery dial choice. The
+	// top-level Discovery / DiscoveryDmsg mirror Deployments[0] after
+	// UnmarshalJSON, so single-deployment configs work without
+	// changes; multi-deployment configs surface deployments[0] here
+	// and the rest are attached inside dmsgc.New.
 	primary := v.conf.Dmsg.Discovery
 	primaryDmsg := v.conf.Dmsg.DiscoveryDmsg
-	if cfgs := v.conf.Dmsg.Configs; len(cfgs) > 0 {
-		primary = cfgs[0].URL
-		primaryDmsg = cfgs[0].DmsgURL
-	}
 
 	// Prefer DMSG-HTTP for discovery if configured (more private, no DNS dependency),
 	// fall back to plain HTTP URL. If HTTP URL is empty (DMSG-only deployment),


### PR DESCRIPTION
## Summary

Schema rework on top of #2436 to give the dmsg-server config the same shape as the visor's \`dmsg\` block, and to make multi-deployment a natural extension of single-deployment instead of a separate parallel field.

### JSON shape

\`\`\`jsonc
// single-deployment (visor's existing shape; dmsg-server now mirrors it)
"dmsg": {
  "discovery": "http://...",
  "discovery_dmsg": "dmsg://<PK>:<port>",
  "sessions_count": 2,
  "servers": [ ... ],
  "advertised_address": "1.2.3.4:8081"   // dmsg-server only
}

// multi-deployment (same per-element shape)
"dmsg": [
  { "discovery": "...", "discovery_dmsg": "...", "servers": [ ... ] },
  { "discovery": "...", "discovery_dmsg": "...", "servers": [ ... ] }
]
\`\`\`

### Implementation

- \`pkg/dmsgc.DmsgConfig\` and \`pkg/dmsg/dmsgserver.DmsgConfig\` implement custom \`Marshal/UnmarshalJSON\`. Internally always a slice; an object on disk becomes a one-element slice.
- The visor-side type keeps the legacy top-level mirror fields (\`Discovery\`, \`DiscoveryDmsg\`, \`Servers\`, \`SessionsCount\`, \`Protocol\`, \`LANServers\`) populated from \`Deployments[0]\`, so all the existing call sites that read \`v.conf.Dmsg.Discovery\` etc. work unchanged for single-deployment configs.
- Multi-deployment readers iterate \`Deployments\` / use \`ResolvedServers()\` for the union.
- Discovery PK is no longer a separate field — it's encoded in \`discovery_dmsg\` (\`dmsg://<PK>:<port>\`) and extracted on demand. Single source of truth, no drift.
- Per-deployment \`servers\` replaces a global "dmsg.servers" pool for multi-deployment configs. The dmsg-server's outbound \`dmsgC\` is preloaded with the union (per-deployment servers ∪ embedded keyring), deduped by PK.
- \`cli config gen --dmsgsrv\` emits the new shape.

### Backward compat

- Existing visor configs (\`dmsg: { discovery, discovery_dmsg, servers, … }\`) work unchanged.
- Existing dmsg-server configs (top-level \`discovery\` + \`public_address\`) work unchanged via \`NormalizedDeployments()\` fallback.
- Setting \`discovery_dmsg\` alongside legacy \`discovery\` opts into dmsgfirst registration without restructuring.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` no diffs
- [x] \`go test ./pkg/dmsg/dmsg/ ./pkg/dmsgc/ ./pkg/dmsg/dmsgserver/ ./pkg/visor/ ./cmd/skywire-cli/commands/config/\` — all green
- [x] \`go run ./cmd/skywire-cli config gen -n\` produces visor config with \`dmsg\` block (single-deployment object form)
- [x] \`go run ./cmd/skywire-cli config gen -n --dmsgsrv\` produces dmsg-server config with the same per-element shape
- [ ] Production verification: dmsg-server starts on legacy single-deployment config (no edits) and dmsgfirst-upgrades when \`discovery_dmsg\` is set
- [ ] Production verification: dmsg-server multi-deployment config — each \`dmsg[]\` entry's \`advertised_address\` is what gets registered with that discovery