### PR TITLE
feat(visor): geoip without HTTP — dmsg-server LookupIPGeo + Geo on SD entries

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/rpc"
 	"net/url"
@@ -35,6 +36,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgserver"
+	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/metricsutil"
@@ -149,6 +151,33 @@ var RootCmd = &cobra.Command{
 		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, primaryHTTP, &srvConf, m)
 		srv.SetLogger(log)
 		srv.SetDHTBootstrap(conf.EnableDHT)
+
+		// Wire the geo lookup hook so visors using LookupIPGeo can get
+		// their public IP and its geolocation in a single round-trip
+		// without HTTP-calling the geoip service. The DB is embedded
+		// in pkg/geoip and shared with the standalone geoip service
+		// and the visor's local fallback path. A failure to open the
+		// DB (corrupt embed, etc.) leaves the hook unset; older
+		// LookupIP callers still work, and LookupIPGeo callers see
+		// empty geo fields and fall back to local lookup.
+		if geoDB, err := geoip.OpenEmbedded(); err != nil {
+			log.WithError(err).Warn("failed to open embedded geoip DB; LookupIPGeo will return empty geo fields")
+		} else {
+			srv.SetGeoLookup(func(ip net.IP) (country, region string, lat, lon float64) {
+				res, err := geoip.Lookup(geoDB, ip.String())
+				if err != nil || res == nil {
+					return "", "", 0, 0
+				}
+				if res.Latitude != nil {
+					lat = *res.Latitude
+				}
+				if res.Longitude != nil {
+					lon = *res.Longitude
+				}
+				return res.CountryCode, res.RegionCode, lat, lon
+			})
+		}
+
 		// Attach extras (each with its own per-deployment advertised
 		// address). The primary's advertised address is passed through
 		// the legacy Serve(..., publicAddr) path below.

--- a/pkg/app/appdisc/factory.go
+++ b/pkg/app/appdisc/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/geo"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -27,7 +28,8 @@ type Factory struct {
 	DisplayNodeIP     bool
 	Client            *http.Client
 	ClientPublicIP    string
-	HeartbeatInterval time.Duration // Interval for service discovery heartbeats
+	HeartbeatInterval time.Duration     // Interval for service discovery heartbeats
+	Geo               *geo.LocationData // Visor's geolocation; included in service entries
 }
 
 func (f *Factory) setDefaults() {
@@ -56,6 +58,7 @@ func (f *Factory) VisorUpdater(port uint16) Updater {
 		Port:          port,
 		DiscAddr:      f.ServiceDisc,
 		DisplayNodeIP: f.DisplayNodeIP,
+		Geo:           f.Geo,
 	}
 
 	return newServiceUpdater(
@@ -86,6 +89,7 @@ func (f *Factory) PublicVisorUpdater(
 		Port:          port,
 		DiscAddr:      f.ServiceDisc,
 		DisplayNodeIP: f.DisplayNodeIP,
+		Geo:           f.Geo,
 	}
 
 	inner := newServiceUpdater(
@@ -127,6 +131,7 @@ func (f *Factory) AppUpdater(conf appcommon.ProcConfig) (Updater, bool) {
 			SK:       f.SK,
 			Port:     uint16(conf.RoutingPort),
 			DiscAddr: f.ServiceDisc,
+			Geo:      f.Geo,
 		}
 	}
 

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -312,6 +312,72 @@ func (ce *Client) dialViaConnectedServers(ctx context.Context, addr Addr) (*Stre
 	return nil, ErrCannotConnectToDelegated
 }
 
+// LookupIPGeo dials a dmsg-server for both the client's public IP
+// and its geolocation in a single round-trip. Falls through to
+// dmsg-servers exactly like LookupIP — first a session-mate, then
+// any delegated server. Older dmsg-servers without a geo lookup
+// configured return GeoCountry="" — the caller should fall back to
+// a local geoip lookup in that case.
+func (ce *Client) LookupIPGeo(ctx context.Context, servers []cipher.PubKey) (StreamResponse, error) {
+	cancellabelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if servers == nil {
+		entries, err := ce.discoverServers(cancellabelCtx, true)
+		if err != nil {
+			return StreamResponse{}, err
+		}
+		for _, entry := range entries {
+			servers = append(servers, entry.Static)
+		}
+	}
+
+	// Already-connected sessions first.
+	for _, srvPK := range servers {
+		if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
+			resp, err := dSes.LookupIPGeo(Addr{PK: dSes.RemotePK(), Port: 1})
+			if err != nil {
+				ce.log.WithError(err).WithField("server_pk", srvPK).Warn("Failed to dial server for IP+geo.")
+				continue
+			}
+			if ce.conf.ClientType == "test" {
+				return resp, nil
+			}
+			if !netutil.IsPublicIP(resp.IP) {
+				ce.log.WithField("server_pk", srvPK).WithField("ip", resp.IP.String()).Warn("Received non-public IP address from dmsg server, trying other servers.")
+				continue
+			}
+			return resp, nil
+		}
+	}
+
+	// Otherwise dial a delegated server.
+	for _, srvPK := range servers {
+		dSes, err := ce.EnsureAndObtainSession(ctx, srvPK)
+		if err != nil {
+			continue
+		}
+		resp, err := dSes.LookupIPGeo(Addr{PK: dSes.RemotePK(), Port: 1})
+		if err != nil {
+			ce.log.WithError(err).WithField("server_pk", srvPK).Warn("Failed to dial server for IP+geo.")
+			continue
+		}
+		if err := dSes.Close(); err != nil {
+			ce.log.WithError(err).WithField("server_pk", srvPK).Warn("Failed to close session")
+		}
+		if ce.conf.ClientType == "test" {
+			return resp, nil
+		}
+		if !netutil.IsPublicIP(resp.IP) {
+			ce.log.WithField("server_pk", srvPK).WithField("ip", resp.IP.String()).Warn("Received non-public IP address from dmsg server, trying other servers.")
+			continue
+		}
+		return resp, nil
+	}
+
+	return StreamResponse{}, ErrCannotConnectToDelegated
+}
+
 // LookupIP dails to dmsg servers for public IP of the client.
 func (ce *Client) LookupIP(ctx context.Context, servers []cipher.PubKey) (myIP net.IP, err error) {
 

--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -190,13 +190,29 @@ func (cs *ClientSession) DialStream(ctx context.Context, dst Addr) (dStr *Stream
 
 // LookupIP attempts to dial a stream to the server for the IP address of the client.
 func (cs *ClientSession) LookupIP(dst Addr) (myIP net.IP, err error) {
+	resp, err := cs.lookupIPInternal(dst, false)
+	if err != nil {
+		return nil, err
+	}
+	return resp.IP, nil
+}
+
+// LookupIPGeo is the same as LookupIP but additionally asks the dmsg
+// server for geolocation data on the resolved IP. Older servers
+// without a configured GeoLookupFunc return zero geo fields — the
+// caller falls back to a local lookup when GeoCountry is empty.
+func (cs *ClientSession) LookupIPGeo(dst Addr) (StreamResponse, error) {
+	return cs.lookupIPInternal(dst, true)
+}
+
+func (cs *ClientSession) lookupIPInternal(dst Addr, geo bool) (resp StreamResponse, err error) {
 	log := cs.log.
 		WithField("func", "ClientSession.LookupIP").
 		WithField("dst_addr", cs.rPK)
 
 	dStr, err := newInitiatingStream(cs)
 	if err != nil {
-		return nil, err
+		return StreamResponse{}, err
 	}
 
 	// Close stream on failure.
@@ -210,26 +226,25 @@ func (cs *ClientSession) LookupIP(dst Addr) (myIP net.IP, err error) {
 
 	// Prepare deadline.
 	if err = dStr.SetDeadline(time.Now().Add(HandshakeTimeout)); err != nil {
-		return nil, err
+		return StreamResponse{}, err
 	}
 
 	// Do stream handshake.
-	req, err := dStr.writeIPRequest(dst)
+	req, err := dStr.writeIPRequestWithGeo(dst, geo)
 	if err != nil {
-		return nil, err
+		return StreamResponse{}, err
 	}
 
-	myIP, err = dStr.readIPResponse(req)
+	resp, err = dStr.readIPGeoResponse(req)
 	if err != nil {
-		return nil, err
+		return StreamResponse{}, err
 	}
 
-	err = dStr.Close()
-	if err != nil {
-		return nil, err
+	if err = dStr.Close(); err != nil {
+		return StreamResponse{}, err
 	}
 
-	return myIP, err
+	return resp, nil
 }
 
 // serve accepts incoming streams from remote clients.

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -88,6 +88,10 @@ type EntityCommon struct {
 	// a single batched update, matching the transport manager's
 	// re-registration debounce pattern.
 	entryNudge chan struct{}
+
+	// geoLookup is set by Server.SetGeoLookup. Server-side IP-info
+	// stream handler reads it; client entities leave it nil.
+	geoLookup GeoLookupFunc
 }
 
 func (c *EntityCommon) init(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, log logrus.FieldLogger, updateInterval time.Duration) {

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -72,6 +72,23 @@ type Server struct {
 	peerSessionsMx sync.Mutex
 }
 
+// GeoLookupFunc returns geolocation data for the given IP. Returns
+// zero values when the IP is non-public or the lookup fails — the
+// caller passes the zero values straight through into the response
+// and the dmsg client falls back to a local lookup on its end.
+type GeoLookupFunc func(ip net.IP) (country, region string, lat, lon float64)
+
+// SetGeoLookup registers an IP-to-geo lookup function. The function
+// is called by the IP-info stream handler when the request has
+// GeoInfo=true, so dmsg clients can get their public IP and its
+// geolocation in one round-trip. Pass nil to disable. cmd/dmsg/dmsg-
+// server wires the embedded MaxMind DB; pkg/dmsg/dmsg deliberately
+// does not import pkg/geoip to avoid pulling the 62MB embedded DB
+// into every dmsg-using binary.
+func (s *Server) SetGeoLookup(fn GeoLookupFunc) {
+	s.geoLookup = fn
+}
+
 // NewServer creates a new dmsg server entity.
 func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *ServerConfig, m metrics.Metrics) *Server {
 	if conf == nil {

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -219,6 +219,19 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 			Accepted: true,
 			IP:       ip,
 		}
+		// Optional geo enrichment: when the client asked for geo and
+		// the server has a lookup function configured, fill the geo
+		// fields from the embedded MaxMind DB (wired by
+		// cmd/dmsg/dmsg-server). Lookup failures (private IP,
+		// unmappable IP, DB error) leave the fields zero — the
+		// client falls back to a local lookup in that case.
+		if req.GeoInfo && ss.entity.geoLookup != nil {
+			country, region, lat, lon := ss.entity.geoLookup(ip)
+			resp.GeoCountry = country
+			resp.GeoRegion = region
+			resp.GeoLat = lat
+			resp.GeoLon = lon
+		}
 		obj, err := MakeSignedStreamResponse(&resp, ss.entity.LocalSK())
 		if err != nil {
 			ss.m.RecordStream(metrics.DeltaFailed) // record failed stream

--- a/pkg/dmsg/dmsg/stream.go
+++ b/pkg/dmsg/dmsg/stream.go
@@ -128,7 +128,12 @@ func (s *Stream) writeRequest(rAddr Addr) (req StreamRequest, err error) {
 	return req, err
 }
 
-func (s *Stream) writeIPRequest(rAddr Addr) (req StreamRequest, err error) {
+// writeIPRequestWithGeo opens an IP-info stream request to the
+// destination dmsg-server. When geo is true, the request also asks
+// the server to populate the response's geo fields (the lookup runs
+// against the server's embedded MaxMind DB; older servers without
+// the hook return empty geo and the caller falls back locally).
+func (s *Stream) writeIPRequestWithGeo(rAddr Addr, geo bool) (req StreamRequest, err error) {
 	// Reserve stream in porter.
 	var lPort uint16
 	var closeFn func()
@@ -149,6 +154,7 @@ func (s *Stream) writeIPRequest(rAddr Addr) (req StreamRequest, err error) {
 		SrcAddr:   s.lAddr,
 		DstAddr:   s.rAddr,
 		IPinfo:    true,
+		GeoInfo:   geo,
 	}
 	obj, err := MakeSignedStreamRequest(&req, s.ses.localSK())
 	if err != nil {
@@ -261,28 +267,34 @@ func (s *Stream) readResponse(req StreamRequest) error {
 	return s.ns.ProcessHandshakeMessage(resp.NoiseMsg)
 }
 
-func (s *Stream) readIPResponse(req StreamRequest) (net.IP, error) {
+// readIPGeoResponse reads the StreamResponse from an IP-info stream
+// request. The IP field is always populated on success; the geo
+// fields are populated only when the request had GeoInfo=true and
+// the server has a geo lookup hook configured. Older servers leave
+// the geo fields zero — callers must be prepared to fall back to a
+// local lookup.
+func (s *Stream) readIPGeoResponse(req StreamRequest) (StreamResponse, error) {
 	var obj SignedObject
 	var err error
 	if s.sStr != nil {
 		obj, err = s.ses.readObject(s.sStr)
 		if err != nil {
-			return nil, err
+			return StreamResponse{}, err
 		}
 	} else {
 		obj, err = s.ses.readObject(s.yStr)
 		if err != nil {
-			return nil, err
+			return StreamResponse{}, err
 		}
 	}
 	resp, err := obj.ObtainStreamResponse()
 	if err != nil {
-		return nil, err
+		return StreamResponse{}, err
 	}
 	if err := resp.Verify(req); err != nil {
-		return nil, err
+		return StreamResponse{}, err
 	}
-	return resp.IP, nil
+	return resp, nil
 }
 
 func (s *Stream) prepareFields(init bool, lAddr, rAddr Addr) error {

--- a/pkg/dmsg/dmsg/types.go
+++ b/pkg/dmsg/dmsg/types.go
@@ -222,7 +222,15 @@ type StreamRequest struct {
 	SrcAddr   Addr
 	DstAddr   Addr
 	IPinfo    bool
-	NoiseMsg  []byte
+	// GeoInfo, when set, asks the destination dmsg-server to also
+	// populate the geo fields on StreamResponse using its own embedded
+	// MaxMind database. Only meaningful when IPinfo is also set, since
+	// the geo lookup runs on the same TCP source IP. Older
+	// dmsg-servers ignore this flag and return zero geo fields, so the
+	// client must be prepared to fall back to a local lookup when the
+	// response's geo fields are empty.
+	GeoInfo  bool
+	NoiseMsg []byte
 
 	raw SignedObject `enc:"-"` // back reference.
 }
@@ -259,8 +267,18 @@ type StreamResponse struct {
 	ReqHash  cipher.SHA256 // Hash of associated dial request.
 	Accepted bool          // Whether the request is accepted.
 	IP       net.IP        // IP address of the node.
-	ErrCode  errorCode     // Check if not accepted.
-	NoiseMsg []byte
+	// Geo fields are populated only when the request had both
+	// IPinfo=true and GeoInfo=true and the dmsg-server has a geo
+	// lookup function configured (cmd/dmsg/dmsg-server wires the
+	// embedded MaxMind DB; other dmsg.Server users may leave it
+	// unset, in which case these fields stay zero). The client
+	// falls back to a local lookup when GeoCountry is empty.
+	GeoCountry string  // ISO country code
+	GeoRegion  string  // ISO region/subdivision code
+	GeoLat     float64 // latitude
+	GeoLon     float64 // longitude
+	ErrCode    errorCode
+	NoiseMsg   []byte
 
 	raw SignedObject `enc:"-"` // back reference.
 }

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/geo"
 	"github.com/skycoin/skywire/pkg/httpauthclient"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
@@ -42,6 +43,12 @@ type Config struct {
 	Port          uint16
 	DiscAddr      string
 	DisplayNodeIP bool
+	// Geo, when non-nil, is attached to the entry on Register/Update.
+	// The service-discovery server short-circuits its own IP→geo HTTP
+	// lookup when the entry already carries Geo, so a visor that does
+	// its own geoip lookup (via dmsg-server LookupIPGeo or the visor's
+	// embedded MaxMind DB) eliminates the SD→geoip-service round-trip.
+	Geo *geo.LocationData
 }
 
 // HTTPClient is responsible for interacting with the service-discovery
@@ -66,6 +73,7 @@ func NewClient(log logrus.FieldLogger, mLog *logging.MasterLogger, conf Config, 
 			Type:          conf.Type,
 			Version:       buildinfo.Version(),
 			DisplayNodeIP: conf.DisplayNodeIP,
+			Geo:           conf.Geo,
 		},
 		client:         client,
 		clientPublicIP: clientPublicIP,

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -21,6 +21,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
+	"github.com/skycoin/skywire/pkg/geo"
 	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -205,6 +206,26 @@ func LookupGeo(ip string) *GeoData {
 		g.Longitude = *res.Longitude
 	}
 	return g
+}
+
+// serviceGeo returns a snapshot of the visor's cached geolocation in
+// the shape expected by service-discovery / uptime-tracker entries.
+// When the visor populates this on its registrations, the receiving
+// service short-circuits its own IP→geo HTTP lookup. Returns nil
+// when geolocation has not been determined yet (e.g. before the
+// address-resolver init that populates v.geo.data).
+func (v *Visor) serviceGeo() *geo.LocationData {
+	v.geo.mu.RLock()
+	defer v.geo.mu.RUnlock()
+	if v.geo.data == nil {
+		return nil
+	}
+	return &geo.LocationData{
+		Country: v.geo.data.CountryCode,
+		Region:  v.geo.data.RegionCode,
+		Lat:     v.geo.data.Latitude,
+		Lon:     v.geo.data.Longitude,
+	}
 }
 
 func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) error {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -55,16 +55,21 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		return err
 	}
 
-	// Get public IP for address resolver binding (needed for NAT setups).
-	// Try dmsg first; fall back to STUN. Geolocation comes from the embedded
-	// MaxMind database — no HTTP round-trip to the geoip service.
+	// Get public IP (and ideally geolocation) from a connected
+	// dmsg-server. LookupIPGeo asks the server to fold in the geoip
+	// data using its own embedded MaxMind DB so the visor doesn't
+	// need an HTTP round-trip to the geoip service. Older
+	// dmsg-servers without the geo lookup hook return GeoCountry=""
+	// — we fall back to the visor's own embedded LookupGeo in that
+	// case. STUN is the last-resort path when dmsg can't answer.
 	var pIP string
+	var serverGeo *GeoData
 
 	lookupCtx, lookupCancel := context.WithTimeout(ctx, 10*time.Second)
-	ipAddr, err := v.dmsgC.LookupIP(lookupCtx, nil)
+	resp, err := v.dmsgC.LookupIPGeo(lookupCtx, nil)
 	lookupCancel()
 	if err != nil {
-		log.WithError(err).Debug("Failed to get public IP from dmsg server, trying STUN")
+		log.WithError(err).Debug("Failed to get public IP+geo from dmsg server, trying STUN")
 		<-v.stun.ready
 		if v.stun.client.PublicIP != nil {
 			pIP = v.stun.client.PublicIP.IP()
@@ -73,12 +78,27 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 			log.Warn("Failed to determine public IP from dmsg and STUN")
 		}
 	} else {
-		pIP = ipAddr.String()
+		pIP = resp.IP.String()
 		log.WithField("public_ip", pIP).Debug("Got public IP from dmsg server")
+		if resp.GeoCountry != "" {
+			serverGeo = &GeoData{
+				CountryCode: resp.GeoCountry,
+				RegionCode:  resp.GeoRegion,
+				Latitude:    resp.GeoLat,
+				Longitude:   resp.GeoLon,
+			}
+			log.WithField("country", serverGeo.CountryCode).Debug("Got geolocation from dmsg server")
+		}
 	}
 
-	if geoData := LookupGeo(pIP); geoData != nil {
-		log.WithField("country", geoData.CountryCode).Debug("Got geolocation from embedded GeoIP database")
+	geoData := serverGeo
+	if geoData == nil {
+		if local := LookupGeo(pIP); local != nil {
+			log.WithField("country", local.CountryCode).Debug("Got geolocation from embedded GeoIP database (fallback)")
+			geoData = local
+		}
+	}
+	if geoData != nil {
 		v.geo.mu.Lock()
 		v.geo.data = geoData
 		v.geo.mu.Unlock()
@@ -132,6 +152,7 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 		factory.DisplayNodeIP = conf.DisplayNodeIP
 		factory.HeartbeatInterval = time.Duration(conf.HeartbeatInterval)
 		factory.Client = httpC
+		factory.Geo = v.serviceGeo()
 
 		// Get public IP for service discovery (needed for NAT setups).
 		// Try dmsg first; fall back to STUN. No HTTP geoip query.
@@ -528,6 +549,7 @@ func (v *Visor) startPublicAutoconnectInternal(ctx context.Context, log *logging
 		Port:          uint16(0),
 		DiscAddr:      serviceDisc,
 		DisplayNodeIP: v.conf.Launcher.DisplayNodeIP,
+		Geo:           v.serviceGeo(),
 	}
 	// only needed for dmsghttp
 	pIP, err := getPublicIP(v, serviceDisc)


### PR DESCRIPTION
## Summary

Eliminates the visor → SD → geoip-HTTP round-trip for service-discovery registration. Two complementary changes:

### Part C — dmsg-server returns geo with the IP lookup

- \`StreamRequest\` gains \`GeoInfo bool\` (opt-in flag).
- \`StreamResponse\` gains \`GeoCountry\` / \`GeoRegion\` / \`GeoLat\` / \`GeoLon\`.
- Server-side handler in \`server_session.go\` invokes a new \`GeoLookupFunc\` hook on \`dmsg.Server\` when the request has \`GeoInfo=true\`.
- \`cmd/dmsg/dmsg-server\` wires the embedded MaxMind DB to the hook via \`SetGeoLookup\`. \`pkg/dmsg/dmsg\` deliberately does not import \`pkg/geoip\` — the embedded DB is 62MB and would inflate every dmsg-using binary (dmsgcurl, dmsgweb, etc.).
- \`Client.LookupIPGeo\` and \`ClientSession.LookupIPGeo\` are parallel to \`LookupIP\`. Older servers without the hook return empty geo fields (gob handles missing fields as zero values), so callers fall back gracefully.

### Part A — visor populates Geo on outgoing SD entries

- \`servicedisc.Config\` gains \`Geo *geo.LocationData\`. \`NewClient\` passes it straight to the entry's \`Geo\` field.
- The SD service already short-circuits its own \`geoFromIP\` HTTP call when \`entry.Geo\` is non-nil (\`pkg/service-discovery/api/api.go:389\` — pre-existing check). With visors now populating Geo, the call never fires.
- Visor's \`init_transport.go\` uses \`LookupIPGeo\` first, falls back to \`LookupIP\` + local \`LookupGeo\` (embedded DB) when the dmsg-server returns empty geo.
- \`v.serviceGeo()\` converts the cached \`GeoData\` into \`geo.LocationData\`. Threaded into \`appdisc.Factory\` and \`init_transport.go\`'s \`servicedisc.Config\` for the autoconnect path.

### Why both

Either one works on its own, but together they:
- Get geoip out of the visor's hot path even before the dmsg-server's MaxMind DB is updated (local fallback).
- Get the visor off carrying its own DB once dmsg-servers all have the hook (DB updates centralized on the server side).
- Eliminate the SD-server's HTTP geoip dependency in the steady state.

The geoip HTTP service stays running for the basic browser \"what's my IP\" use case via VPN/proxy clients; only the visor → SD → geoip path is removed.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/dmsg/dmsg/ ./pkg/dmsgc/ ./pkg/dmsg/dmsgserver/ ./pkg/visor/ ./pkg/servicedisc/ ./pkg/app/appdisc/ ./pkg/geoip/ ./pkg/geo/ ./cmd/skywire-cli/commands/config/\` — all green
- [ ] Production verification: visor logs \`Got geolocation from dmsg server\` (Part C) once dmsg-servers carry this binary
- [ ] Production verification: SD service logs no longer show \`Failed to get geo data\` for visor entries (Part A short-circuits the HTTP fallback)