### PR TITLE
feat(svc): JSON config files for the 5 deployment services

### DIFF
--- a/cmd/dmsg/dmsg-discovery/commands/config.go
+++ b/cmd/dmsg/dmsg-discovery/commands/config.go
@@ -1,0 +1,137 @@
+// Package commands cmd/dmsg-discovery/commands/config.go
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// Config is the JSON configuration for dmsg-discovery. When --config
+// is set, every runtime knob comes from this file; otherwise the
+// service falls back to the legacy per-flag CLI behavior so existing
+// deployments don't break. The schema mirrors the visor / dmsg-server
+// pattern: per-service knobs at the top, dmsg-server transit set in
+// `dmsg_servers` (replaces the runtime read of
+// deployment.Prod.DmsgServers).
+type Config struct {
+	Path string `json:"-"`
+
+	PubKey cipher.PubKey `json:"public_key,omitempty"`
+	SecKey cipher.SecKey `json:"secret_key,omitempty"`
+
+	// Addr is the HTTP listen address for the discovery API
+	// (`:9090` by default).
+	Addr string `json:"addr,omitempty"`
+	// Redis is the redis connection URL the discovery uses for the
+	// entry store.
+	Redis string `json:"redis,omitempty"`
+	// DmsgPort is the dmsghttp listener port (default 80).
+	DmsgPort uint16 `json:"dmsg_port,omitempty"`
+	// EntryTimeout is how long client discovery entries live in
+	// redis between refreshes. Zero disables expiry (legacy
+	// behavior; stale entries accumulate forever).
+	EntryTimeout time.Duration `json:"entry_timeout,omitempty"`
+	// Mode is the listener mode: "http" or "dual" (dmsg-only is
+	// rejected because dmsg-servers register over plain HTTP).
+	Mode string `json:"mode,omitempty"`
+	// AuthPassphrase, when non-empty, gates official-server
+	// registration with a shared secret.
+	AuthPassphrase string `json:"auth_passphrase,omitempty"`
+	// OfficialServers is a list of PKs treated as "official" — they
+	// can register without the auth passphrase. Hex-encoded PKs.
+	OfficialServers []string `json:"official_servers,omitempty"`
+	// DmsgServerType filters dmsg-servers by their declared type.
+	DmsgServerType string `json:"dmsg_server_type,omitempty"`
+	// TestMode disables some runtime checks for use in tests.
+	TestMode bool `json:"test_mode,omitempty"`
+	// EnableLoadTesting allows sending fake load to the discovery.
+	EnableLoadTesting bool `json:"enable_load_testing,omitempty"`
+	// TestEnvironment selects deployment.Test over deployment.Prod
+	// for any embedded-keyring fallback at gen time.
+	TestEnvironment bool `json:"test_environment,omitempty"`
+	// Whitelist is the network-monitor PKs allowed to deregister
+	// stale entries. Hex-encoded PKs.
+	Whitelist []string `json:"whitelist_keys,omitempty"`
+	// LogLevel is the minimum log level (debug/info/warn/error).
+	LogLevel string `json:"log_level,omitempty"`
+
+	// DmsgServers is the static dmsg-server transit set the
+	// discovery preloads at startup. Replaces the runtime read of
+	// deployment.Prod.DmsgServers — operators ship a config file
+	// generated from the keyring and edit it as servers rotate, no
+	// rebuild required. Empty list falls back to the embedded
+	// keyring at runtime as a last-resort safety net.
+	DmsgServers []*disc.Entry `json:"dmsg_servers,omitempty"`
+}
+
+// applyConfig copies values from a parsed Config into the
+// package-level cobra-flag variables that the rest of Run consumes,
+// turning --config into a single source of truth. Empty / zero
+// fields in Config preserve the existing CLI-flag value, so a
+// partial config still leaves the rest at their defaults.
+func applyConfig(c *Config) {
+	if c.SecKey != (cipher.SecKey{}) {
+		sk = c.SecKey
+	}
+	if c.Addr != "" {
+		addr = c.Addr
+	}
+	if c.Redis != "" {
+		redisURL = c.Redis
+	}
+	if c.DmsgPort != 0 {
+		dmsgPort = c.DmsgPort
+	}
+	if c.EntryTimeout != 0 {
+		entryTimeout = c.EntryTimeout
+	}
+	if c.Mode != "" {
+		mode = c.Mode
+	}
+	if c.AuthPassphrase != "" {
+		authPassphrase = c.AuthPassphrase
+	}
+	if len(c.OfficialServers) > 0 {
+		officialServers = strings.Join(c.OfficialServers, ",")
+	}
+	if c.DmsgServerType != "" {
+		dmsgServerType = c.DmsgServerType
+	}
+	if c.TestMode {
+		testMode = true
+	}
+	if c.EnableLoadTesting {
+		enableLoadTesting = true
+	}
+	if c.TestEnvironment {
+		testEnvironment = true
+	}
+	if len(c.Whitelist) > 0 {
+		whitelistKeys = strings.Join(c.Whitelist, ",")
+	}
+}
+
+// LoadConfig reads, parses, and returns a Config from the given path.
+// Returns an error if the file is missing, malformed, or has fields
+// the JSON decoder doesn't recognize (strict decoding catches typos).
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", path, err)
+	}
+	var c Config
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	c.Path = path
+	return &c, nil
+}

--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
@@ -39,6 +39,7 @@ const redisPasswordEnvName = "REDIS_PASSWORD"
 
 var (
 	sf                cmdutil.ServiceFlags
+	configPath        string
 	addr              string
 	redisURL          string
 	whitelistKeys     string
@@ -61,6 +62,7 @@ var (
 func init() {
 	sf.Init(RootCmd, "dmsg_disc", "")
 
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. When set, every other CLI flag below is ignored — fields come from the config file. Generate one with `skywire cli config gen --dmsgdisc -o /etc/skywire/dmsg-discovery.json`.\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9090", "address to bind to\n\r")
 	RootCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
@@ -128,6 +130,19 @@ Example:
 		}
 
 		log := sf.Logger()
+
+		// configServers, when non-nil, overrides the embedded keyring
+		// preload below. Populated only when --config is set.
+		var configServers []*disc.Entry
+		if configPath != "" {
+			c, cErr := LoadConfig(configPath)
+			if cErr != nil {
+				log.WithError(cErr).Fatal("failed to load config")
+			}
+			applyConfig(c)
+			configServers = c.DmsgServers
+			log.WithField("path", configPath).Info("loaded config")
+		}
 
 		var err error
 		if keyFile != "" {
@@ -199,27 +214,32 @@ Example:
 			}
 		}()
 		if !pk.Null() && resolvedMode.IncludesDmsg() {
-			// Preload dmsg-servers from the embedded deployment keyring
-			// so the local direct.Client can dial dmsg BEFORE any
-			// HTTP-side registration has happened. Operators that need
-			// a non-default keyring (private network, lab) point
-			// SKYDEPLOY at a custom services-config.json — see
-			// deployment/config.go. Falling back to the legacy API
-			// self-poll only happens when both embedded keyring is
-			// empty AND SKYDEPLOY hasn't supplied one — typically
-			// development with a hand-rolled binary.
-			src := deployment.Prod
-			srcName := "deployment.Prod"
-			if testEnvironment {
-				src = deployment.Test
-				srcName = "deployment.Test"
-			}
-			servers := src.ToDiscEntries()
-			if len(servers) > 0 {
-				log.WithField("count", len(servers)).WithField("source", srcName).Info("preloading dmsg-servers from embedded deployment keyring")
-			} else {
-				log.Warn("no dmsg-servers in embedded deployment keyring; falling back to API self-poll (legacy behavior; will block until at least one server registers over HTTP)")
-				servers = getServers(ctx, a, dmsgServerType, log)
+			// Source priority for the dmsg-server transit set:
+			//   1. config.dmsg_servers from --config (config-file mode)
+			//   2. embedded deployment keyring (deployment.Prod, or
+			//      deployment.Test with --test-environment)
+			//   3. legacy API self-poll (the original bootstrap loop;
+			//      kept as last-resort safety net for binaries built
+			//      with an empty embedded keyring)
+			var servers []*disc.Entry
+			switch {
+			case len(configServers) > 0:
+				servers = configServers
+				log.WithField("count", len(servers)).WithField("source", "config").Info("preloading dmsg-servers from config")
+			default:
+				src := deployment.Prod
+				srcName := "deployment.Prod"
+				if testEnvironment {
+					src = deployment.Test
+					srcName = "deployment.Test"
+				}
+				servers = src.ToDiscEntries()
+				if len(servers) > 0 {
+					log.WithField("count", len(servers)).WithField("source", srcName).Info("preloading dmsg-servers from embedded deployment keyring")
+				} else {
+					log.Warn("no dmsg-servers in embedded deployment keyring; falling back to API self-poll (legacy behavior; will block until at least one server registers over HTTP)")
+					servers = getServers(ctx, a, dmsgServerType, log)
+				}
 			}
 			config := &dmsg.Config{
 				MinSessions:          0, // listen on all available servers

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -207,6 +207,14 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "dmsgdisc")
 	genConfigCmd.Flags().BoolVar(&dmsgSrvConfig, "dmsgsrv", false, "generate config for dmsg-server service")
 	gHiddenFlags = append(gHiddenFlags, "dmsgsrv")
+	genConfigCmd.Flags().BoolVar(&tpdConfig, "tpd", false, "generate config for transport-discovery service")
+	gHiddenFlags = append(gHiddenFlags, "tpd")
+	genConfigCmd.Flags().BoolVar(&sdConfig, "sd", false, "generate config for service-discovery service")
+	gHiddenFlags = append(gHiddenFlags, "sd")
+	genConfigCmd.Flags().BoolVar(&arConfig, "ar", false, "generate config for address-resolver service")
+	gHiddenFlags = append(gHiddenFlags, "ar")
+	genConfigCmd.Flags().BoolVar(&rfConfig, "rf", false, "generate config for route-finder service")
+	gHiddenFlags = append(gHiddenFlags, "rf")
 	genConfigCmd.Flags().BoolVar(&enableCalculateRoutes, "calculate-routes", scriptExecBool("${CALCULATEROUTES:-false}"), "enable local route calculation")
 	gHiddenFlags = append(gHiddenFlags, "calculate-routes")
 
@@ -923,12 +931,25 @@ func serviceProjectionJQ() string {
 		// when the multi-network NAT case requires it.
 		return "{public_key: .pk, secret_key: .sk, dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}, public_address: \"\", local_address: \":8081\", health_endpoint_address: \":8082\", log_level: .log_level, max_sessions: 2048}"
 	case dmsgDiscConfig:
-		// Project to a dmsg-discovery config. dmsg-discovery has no
-		// JSON config file today (CLI flags only), but emitting a
-		// JSON-shaped config makes it scriptable: tooling can read
-		// {public_key, secret_key, addr, dmsg_servers} and pass the
-		// fields to the dmsg-discovery binary as flags.
-		return "{public_key: .pk, secret_key: .sk, addr: \":9090\", dmsg_port: 80, dmsg_servers: .dmsg.servers, log_level: .log_level}"
+		// Project to a dmsg-discovery config. Keys map onto the
+		// Config struct in cmd/dmsg/dmsg-discovery/commands/config.go.
+		// dmsg_servers is the static transit set (replaces the
+		// runtime read of deployment.Prod.DmsgServers).
+		return "{public_key: .pk, secret_key: .sk, addr: \":9090\", redis: \"redis://localhost:6379\", dmsg_port: 80, mode: \"dual\", dmsg_servers: .dmsg.servers, log_level: .log_level}"
+	case tpdConfig:
+		// Project to a transport-discovery config. The `dmsg` block
+		// matches the shape used by every other service in this
+		// family so operators see one schema everywhere.
+		return "{public_key: .pk, secret_key: .sk, addr: \":9091\", redis: \"redis://localhost:6379\", redis_pool_size: 10, entry_timeout: 300000000000, log_level: .log_level, tag: \"transport_discovery\", mode: \"dual\", store_data_path: \"/var/lib/skywire/tpd/bandwidth\", uptime_db: \"/var/lib/skywire/tpd/uptime.db\", dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}}"
+	case sdConfig:
+		// Project to a service-discovery config. Same `dmsg` shape.
+		return "{public_key: .pk, secret_key: .sk, addr: \":9098\", redis: \"redis://localhost:6379\", entry_timeout: 300000000000, log_level: .log_level, mode: \"dual\", dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}}"
+	case arConfig:
+		// Project to an address-resolver config.
+		return "{public_key: .pk, secret_key: .sk, addr: \":9093\", udp_addr: \":30178\", redis: \"redis://localhost:6379\", redis_pool_size: 10, entry_timeout: 300000000000, log_level: .log_level, tag: \"address_resolver\", mode: \"dual\", dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}}"
+	case rfConfig:
+		// Project to a route-finder config.
+		return "{public_key: .pk, secret_key: .sk, addr: \":9092\", redis: \"redis://localhost:6379\", redis_pool_size: 10, log_level: .log_level, tag: \"route_finder\", mode: \"dual\", dmsg: {discovery: .dmsg.discovery, discovery_dmsg: .dmsg.discovery_dmsg, sessions_count: .dmsg.sessions_count, servers: .dmsg.servers}}"
 	}
 	return ""
 }

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -103,6 +103,10 @@ var (
 	snConfig                   bool
 	dmsgDiscConfig             bool
 	dmsgSrvConfig              bool
+	tpdConfig                  bool
+	sdConfig                   bool
+	arConfig                   bool
+	rfConfig                   bool
 	externalApps               bool
 	enableCalculateRoutes      bool
 	isSkychatEnable            bool

--- a/cmd/svc/address-resolver/commands/config.go
+++ b/cmd/svc/address-resolver/commands/config.go
@@ -1,0 +1,132 @@
+// Package commands cmd/svc/address-resolver/commands/config.go
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// Config is the JSON configuration for address-resolver.
+type Config struct {
+	Path string `json:"-"`
+
+	PubKey cipher.PubKey `json:"public_key,omitempty"`
+	SecKey cipher.SecKey `json:"secret_key,omitempty"`
+
+	Addr            string          `json:"addr,omitempty"`
+	UDPAddr         string          `json:"udp_addr,omitempty"`
+	PublicUDPAddr   string          `json:"public_udp_addr,omitempty"`
+	MetricsAddr     string          `json:"metrics_addr,omitempty"`
+	PprofAddr       string          `json:"pprof_addr,omitempty"`
+	Redis           string          `json:"redis,omitempty"`
+	RedisPoolSize   int             `json:"redis_pool_size,omitempty"`
+	EntryTimeout    time.Duration   `json:"entry_timeout,omitempty"`
+	Tag             string          `json:"tag,omitempty"`
+	LogLevel        string          `json:"log_level,omitempty"`
+	Testing         bool            `json:"testing,omitempty"`
+	Mode            string          `json:"mode,omitempty"`
+	Whitelist       []string        `json:"whitelist_keys,omitempty"`
+	SurveyWhitelist []cipher.PubKey `json:"survey_whitelist,omitempty"`
+	TestEnvironment bool            `json:"test_environment,omitempty"`
+
+	// Dmsg is the dmsg-related config block — same shape across
+	// every deployment service that uses it.
+	Dmsg cmdutil.DmsgConfig `json:"dmsg,omitempty"`
+}
+
+// LoadConfig reads, parses, and returns a Config from path.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", path, err)
+	}
+	var c Config
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	c.Path = path
+	return &c, nil
+}
+
+// applyConfig copies values from c into the package-level cobra-flag
+// vars that the rest of Run consumes.
+func applyConfig(c *Config) (servers []*disc.Entry, surveyWL []cipher.PubKey) {
+	if c.SecKey != (cipher.SecKey{}) {
+		sk = c.SecKey
+	}
+	if c.Addr != "" {
+		addr = c.Addr
+	}
+	if c.UDPAddr != "" {
+		udpAddr = c.UDPAddr
+	}
+	if c.PublicUDPAddr != "" {
+		publicUDPAddr = c.PublicUDPAddr
+	}
+	if c.MetricsAddr != "" {
+		metricsAddr = c.MetricsAddr
+	}
+	if c.PprofAddr != "" {
+		pprofAddr = c.PprofAddr
+	}
+	if c.Redis != "" {
+		redisURL = c.Redis
+	}
+	if c.RedisPoolSize > 0 {
+		redisPoolSize = c.RedisPoolSize
+	}
+	if c.EntryTimeout != 0 {
+		entryTimeout = c.EntryTimeout
+	}
+	if c.Tag != "" {
+		tag = c.Tag
+	}
+	if c.LogLevel != "" {
+		logLvl = c.LogLevel
+	}
+	if c.Testing {
+		testing = true
+	}
+	if c.Mode != "" {
+		mode = c.Mode
+	}
+	if c.TestEnvironment {
+		testEnvironment = true
+	}
+	if len(c.Whitelist) > 0 {
+		whitelistKeys = strings.Join(c.Whitelist, ",")
+	}
+	if c.Dmsg.Discovery != "" {
+		dmsgDisc = c.Dmsg.Discovery
+	}
+	if c.Dmsg.ServerType != "" {
+		dmsgServerType = c.Dmsg.ServerType
+	}
+	return c.Dmsg.Servers, c.SurveyWhitelist
+}
+
+// dmsgDiscEntries returns []disc.Entry for svcmode.Start, falling
+// back to the embedded keyring when the config has no servers.
+func dmsgDiscEntries(configServers []*disc.Entry) []disc.Entry {
+	if len(configServers) == 0 {
+		return dmsg.Prod.DmsgServers
+	}
+	out := make([]disc.Entry, 0, len(configServers))
+	for _, e := range configServers {
+		if e != nil {
+			out = append(out, *e)
+		}
+	}
+	return out
+}

--- a/cmd/svc/address-resolver/commands/root.go
+++ b/cmd/svc/address-resolver/commands/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dht"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/httpauth"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -38,6 +39,7 @@ const (
 )
 
 var (
+	configPath      string
 	addr            string
 	udpAddr         string
 	publicUDPAddr   string
@@ -120,6 +122,7 @@ GET /security/nonces/{pk}
 }
 
 func init() {
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with `skywire cli config gen --ar -o /etc/skywire/address-resolver.json`.\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9093", "address to bind to\n\r")
 	RootCmd.Flags().StringVar(&udpAddr, "udp-addr", ":30178", "UDP address to bind to for SUDPH\n\r")
 	RootCmd.Flags().StringVar(&publicUDPAddr, "public-udp-address", "", "externally-reachable host:port advertised in /health for SUDPH (e.g. ar.example.com:30178)\n\rrequired for visors that reach this AR over dmsghttp; without it those visors cannot register SUDPH")
@@ -184,6 +187,16 @@ Example:
 	Run: func(_ *cobra.Command, _ []string) {
 		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
 			log.Printf("Failed to output build info: %v", err)
+		}
+
+		var configServers []*disc.Entry
+		var configSurveyWL []cipher.PubKey
+		if configPath != "" {
+			c, cErr := LoadConfig(configPath)
+			if cErr != nil {
+				log.Fatal(cErr)
+			}
+			configServers, configSurveyWL = applyConfig(c)
 		}
 
 		if !strings.HasPrefix(redisURL, redisScheme) {
@@ -291,6 +304,12 @@ Example:
 			logger.WithError(err).Fatal("invalid --mode")
 		}
 
+		embeddedServers := dmsgDiscEntries(configServers)
+		surveyWL := deployment.Prod.SurveyWhitelist
+		if len(configSurveyWL) > 0 {
+			surveyWL = configSurveyWL
+		}
+
 		h, err := svcmode.Start(ctx, svcmode.Config{
 			Mode:                resolvedMode,
 			HTTPAddr:            addr,
@@ -300,8 +319,8 @@ Example:
 			DmsgPort:            dmsgPort,
 			DmsgDiscovery:       dmsgDisc,
 			DmsgServerType:      dmsgServerType,
-			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
-			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
+			EmbeddedDmsgServers: embeddedServers,
+			SurveyWhitelist:     surveyWL,
 			Log:                 logger,
 			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {

--- a/cmd/svc/route-finder/commands/config.go
+++ b/cmd/svc/route-finder/commands/config.go
@@ -1,0 +1,110 @@
+// Package commands cmd/svc/route-finder/commands/config.go
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// Config is the JSON configuration for route-finder.
+type Config struct {
+	Path string `json:"-"`
+
+	PubKey cipher.PubKey `json:"public_key,omitempty"`
+	SecKey cipher.SecKey `json:"secret_key,omitempty"`
+
+	Addr            string          `json:"addr,omitempty"`
+	MetricsAddr     string          `json:"metrics_addr,omitempty"`
+	PprofAddr       string          `json:"pprof_addr,omitempty"`
+	Redis           string          `json:"redis,omitempty"`
+	RedisPoolSize   int             `json:"redis_pool_size,omitempty"`
+	Tag             string          `json:"tag,omitempty"`
+	LogLevel        string          `json:"log_level,omitempty"`
+	Testing         bool            `json:"testing,omitempty"`
+	Mode            string          `json:"mode,omitempty"`
+	SurveyWhitelist []cipher.PubKey `json:"survey_whitelist,omitempty"`
+
+	// Dmsg is the dmsg-related config block — same shape across
+	// every deployment service that uses it.
+	Dmsg cmdutil.DmsgConfig `json:"dmsg,omitempty"`
+}
+
+// LoadConfig reads, parses, and returns a Config from path.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", path, err)
+	}
+	var c Config
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	c.Path = path
+	return &c, nil
+}
+
+// applyConfig copies values from c into the package-level cobra-flag
+// vars that the rest of Run consumes.
+func applyConfig(c *Config) (servers []*disc.Entry, surveyWL []cipher.PubKey) {
+	if c.SecKey != (cipher.SecKey{}) {
+		sk = c.SecKey
+	}
+	if c.Addr != "" {
+		addr = c.Addr
+	}
+	if c.MetricsAddr != "" {
+		metricsAddr = c.MetricsAddr
+	}
+	if c.PprofAddr != "" {
+		pprofAddr = c.PprofAddr
+	}
+	if c.Redis != "" {
+		redisURL = c.Redis
+	}
+	if c.RedisPoolSize > 0 {
+		redisPoolSize = c.RedisPoolSize
+	}
+	if c.Tag != "" {
+		tag = c.Tag
+	}
+	if c.LogLevel != "" {
+		logLvl = c.LogLevel
+	}
+	if c.Testing {
+		testing = true
+	}
+	if c.Mode != "" {
+		mode = c.Mode
+	}
+	if c.Dmsg.Discovery != "" {
+		dmsgDisc = c.Dmsg.Discovery
+	}
+	if c.Dmsg.ServerType != "" {
+		dmsgServerType = c.Dmsg.ServerType
+	}
+	return c.Dmsg.Servers, c.SurveyWhitelist
+}
+
+// dmsgDiscEntries returns []disc.Entry for svcmode.Start, falling
+// back to the embedded keyring when the config has no servers.
+func dmsgDiscEntries(configServers []*disc.Entry) []disc.Entry {
+	if len(configServers) == 0 {
+		return dmsg.Prod.DmsgServers
+	}
+	out := make([]disc.Entry, 0, len(configServers))
+	for _, e := range configServers {
+		if e != nil {
+			out = append(out, *e)
+		}
+	}
+	return out
+}

--- a/cmd/svc/route-finder/commands/root.go
+++ b/cmd/svc/route-finder/commands/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/skycoin/skywire/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/metricsutil"
@@ -33,6 +34,7 @@ const (
 )
 
 var (
+	configPath     string
 	addr           string
 	metricsAddr    string
 	redisURL       string
@@ -92,6 +94,7 @@ POST /routes
 }
 
 func init() {
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with `skywire cli config gen --rf -o /etc/skywire/route-finder.json`.\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9092", "address to bind to\n\r")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
@@ -140,6 +143,16 @@ Example:
 	Run: func(_ *cobra.Command, _ []string) {
 		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
 			log.Printf("Failed to output build info: %v", err)
+		}
+
+		var configServers []*disc.Entry
+		var configSurveyWL []cipher.PubKey
+		if configPath != "" {
+			c, cErr := LoadConfig(configPath)
+			if cErr != nil {
+				log.Fatal(cErr)
+			}
+			configServers, configSurveyWL = applyConfig(c)
 		}
 
 		if !strings.HasPrefix(redisURL, redisScheme) {
@@ -203,6 +216,12 @@ Example:
 			logger.WithError(err).Fatal("invalid --mode")
 		}
 
+		embeddedServers := dmsgDiscEntries(configServers)
+		surveyWL := deployment.Prod.SurveyWhitelist
+		if len(configSurveyWL) > 0 {
+			surveyWL = configSurveyWL
+		}
+
 		h, err := svcmode.Start(ctx, svcmode.Config{
 			Mode:                resolvedMode,
 			HTTPAddr:            addr,
@@ -212,8 +231,8 @@ Example:
 			DmsgPort:            dmsgPort,
 			DmsgDiscovery:       dmsgDisc,
 			DmsgServerType:      dmsgServerType,
-			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
-			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
+			EmbeddedDmsgServers: embeddedServers,
+			SurveyWhitelist:     surveyWL,
 			Log:                 logger,
 			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {

--- a/cmd/svc/service-discovery/commands/config.go
+++ b/cmd/svc/service-discovery/commands/config.go
@@ -1,0 +1,118 @@
+// Package commands cmd/svc/service-discovery/commands/config.go
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// Config is the JSON configuration for service-discovery.
+type Config struct {
+	Path string `json:"-"`
+
+	PubKey cipher.PubKey `json:"public_key,omitempty"`
+	SecKey cipher.SecKey `json:"secret_key,omitempty"`
+
+	Addr            string          `json:"addr,omitempty"`
+	MetricsAddr     string          `json:"metrics_addr,omitempty"`
+	PprofAddr       string          `json:"pprof_addr,omitempty"`
+	Redis           string          `json:"redis,omitempty"`
+	EntryTimeout    time.Duration   `json:"entry_timeout,omitempty"`
+	LogLevel        string          `json:"log_level,omitempty"`
+	TestMode        bool            `json:"test_mode,omitempty"`
+	Mode            string          `json:"mode,omitempty"`
+	Whitelist       []string        `json:"whitelist_keys,omitempty"`
+	SurveyWhitelist []cipher.PubKey `json:"survey_whitelist,omitempty"`
+
+	// GeoIP is the URL of the geoip service. After PR #2439 visors
+	// populate Geo on their entries directly so this URL is rarely
+	// hit; the field is kept for backward compatibility.
+	GeoIP string `json:"geoip,omitempty"`
+
+	// Dmsg is the dmsg-related config block — same shape across
+	// every deployment service that uses it.
+	Dmsg cmdutil.DmsgConfig `json:"dmsg,omitempty"`
+}
+
+// LoadConfig reads, parses, and returns a Config from path.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", path, err)
+	}
+	var c Config
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	c.Path = path
+	return &c, nil
+}
+
+// applyConfig copies values from c into the package-level cobra-flag
+// vars that the rest of Run consumes. Returns the per-service slices
+// Run consumes directly (embedded dmsg-server transit, survey wl).
+func applyConfig(c *Config) (servers []*disc.Entry, surveyWL []cipher.PubKey) {
+	if c.SecKey != (cipher.SecKey{}) {
+		sk = c.SecKey
+	}
+	if c.Addr != "" {
+		addr = c.Addr
+	}
+	if c.MetricsAddr != "" {
+		metricsAddr = c.MetricsAddr
+	}
+	if c.PprofAddr != "" {
+		pprofAddr = c.PprofAddr
+	}
+	if c.Redis != "" {
+		redisURL = c.Redis
+	}
+	if c.EntryTimeout != 0 {
+		entryTimeout = c.EntryTimeout
+	}
+	if c.TestMode {
+		testMode = true
+	}
+	if c.Mode != "" {
+		mode = c.Mode
+	}
+	if len(c.Whitelist) > 0 {
+		whitelistKeys = strings.Join(c.Whitelist, ",")
+	}
+	if c.GeoIP != "" {
+		geoipURL = c.GeoIP
+	}
+	if c.Dmsg.Discovery != "" {
+		dmsgDisc = c.Dmsg.Discovery
+	}
+	if c.Dmsg.ServerType != "" {
+		dmsgServerType = c.Dmsg.ServerType
+	}
+	return c.Dmsg.Servers, c.SurveyWhitelist
+}
+
+// dmsgDiscEntries returns []disc.Entry for svcmode.Start, falling
+// back to the embedded keyring when the config has no servers.
+func dmsgDiscEntries(configServers []*disc.Entry) []disc.Entry {
+	if len(configServers) == 0 {
+		return dmsg.Prod.DmsgServers
+	}
+	out := make([]disc.Entry, 0, len(configServers))
+	for _, e := range configServers {
+		if e != nil {
+			out = append(out, *e)
+		}
+	}
+	return out
+}

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dht"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/httpauth"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -36,6 +37,7 @@ var log = logging.MustGetLogger("service-discovery")
 const redisPrefix = "service-discovery"
 
 var (
+	configPath     string
 	addr           string
 	metricsAddr    string
 	redisURL       string
@@ -113,6 +115,7 @@ GET /security/nonces/{pk}
 }
 
 func init() {
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with `skywire cli config gen --sd -o /etc/skywire/service-discovery.json`.\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9098", "address to bind to\n\r")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
@@ -162,6 +165,16 @@ Example:
   skywire cli config gen-keys | tee sd-keys.txt
   service-discovery --sk $(tail -n1 sd-keys.txt)`,
 	Run: func(_ *cobra.Command, _ []string) {
+		var configServers []*disc.Entry
+		var configSurveyWL []cipher.PubKey
+		if configPath != "" {
+			c, cErr := LoadConfig(configPath)
+			if cErr != nil {
+				log.Fatal(cErr)
+			}
+			configServers, configSurveyWL = applyConfig(c)
+		}
+
 		if dmsgDisc == "" {
 			dmsgDisc = dmsg.DiscURL(false)
 		}
@@ -249,6 +262,12 @@ Example:
 			log.WithError(err).Fatal("invalid --mode")
 		}
 
+		embeddedServers := dmsgDiscEntries(configServers)
+		surveyWL := deployment.Prod.SurveyWhitelist
+		if len(configSurveyWL) > 0 {
+			surveyWL = configSurveyWL
+		}
+
 		h, err := svcmode.Start(ctx, svcmode.Config{
 			Mode:                resolvedMode,
 			HTTPAddr:            addr,
@@ -258,8 +277,8 @@ Example:
 			DmsgPort:            dmsgPort,
 			DmsgDiscovery:       dmsgDisc,
 			DmsgServerType:      dmsgServerType,
-			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
-			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
+			EmbeddedDmsgServers: embeddedServers,
+			SurveyWhitelist:     surveyWL,
 			Log:                 log,
 			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {

--- a/cmd/svc/transport-discovery/commands/config.go
+++ b/cmd/svc/transport-discovery/commands/config.go
@@ -1,0 +1,152 @@
+// Package commands cmd/svc/transport-discovery/commands/config.go
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// Config is the JSON configuration for transport-discovery. When
+// --config is set, every runtime knob comes from this file; otherwise
+// the service falls back to the legacy per-flag CLI behavior. The
+// `dmsg` block matches dmsg-server's shape so operators see a
+// consistent schema across visor / dmsg-server / every deployment
+// service.
+type Config struct {
+	Path string `json:"-"`
+
+	PubKey cipher.PubKey `json:"public_key,omitempty"`
+	SecKey cipher.SecKey `json:"secret_key,omitempty"`
+
+	Addr            string          `json:"addr,omitempty"`
+	MetricsAddr     string          `json:"metrics_addr,omitempty"`
+	PprofAddr       string          `json:"pprof_addr,omitempty"`
+	Redis           string          `json:"redis,omitempty"`
+	RedisPoolSize   int             `json:"redis_pool_size,omitempty"`
+	EntryTimeout    time.Duration   `json:"entry_timeout,omitempty"`
+	LogLevel        string          `json:"log_level,omitempty"`
+	Tag             string          `json:"tag,omitempty"`
+	Testing         bool            `json:"testing,omitempty"`
+	Mode            string          `json:"mode,omitempty"`
+	Whitelist       []string        `json:"whitelist_keys,omitempty"`
+	SurveyWhitelist []cipher.PubKey `json:"survey_whitelist,omitempty"`
+	TestEnvironment bool            `json:"test_environment,omitempty"`
+
+	// StoreDataPath is the on-disk path for bandwidth backup files.
+	StoreDataPath string `json:"store_data_path,omitempty"`
+	// EnableCXO turns on the CXO aggregator + metrics publisher.
+	EnableCXO bool `json:"enable_cxo,omitempty"`
+	// UptimeDB is the local self-uptime bbolt store path. Empty
+	// disables service-self uptime recording.
+	UptimeDB string `json:"uptime_db,omitempty"`
+
+	// Dmsg is the dmsg-related config block — same shape across
+	// every deployment service that uses it.
+	Dmsg cmdutil.DmsgConfig `json:"dmsg,omitempty"`
+}
+
+// dmsgDiscEntries returns the dmsg-server transit set svcmode.Start
+// expects ([]disc.Entry, value type) from the config's []*disc.Entry
+// when non-empty, otherwise falls back to the embedded
+// dmsg.Prod.DmsgServers keyring.
+func dmsgDiscEntries(configServers []*disc.Entry) []disc.Entry {
+	if len(configServers) == 0 {
+		return dmsg.Prod.DmsgServers
+	}
+	out := make([]disc.Entry, 0, len(configServers))
+	for _, e := range configServers {
+		if e != nil {
+			out = append(out, *e)
+		}
+	}
+	return out
+}
+
+// LoadConfig reads, parses, and returns a Config from path.
+func LoadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("read config %q: %w", path, err)
+	}
+	var c Config
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	c.Path = path
+	return &c, nil
+}
+
+// applyConfig copies values from c into the package-level cobra-flag
+// vars that the rest of Run consumes. Empty / zero fields preserve
+// the existing CLI-flag value, so a partial config is fine.
+// Returns the embedded dmsg-server transit set (if any) and the
+// survey whitelist override the config supplies, both of which Run
+// uses directly rather than going through package-level vars.
+func applyConfig(c *Config) (servers []*disc.Entry, surveyWL []cipher.PubKey) {
+	if c.SecKey != (cipher.SecKey{}) {
+		sk = c.SecKey
+	}
+	if c.Addr != "" {
+		addr = c.Addr
+	}
+	if c.MetricsAddr != "" {
+		metricsAddr = c.MetricsAddr
+	}
+	if c.PprofAddr != "" {
+		pprofAddr = c.PprofAddr
+	}
+	if c.Redis != "" {
+		redisURL = c.Redis
+	}
+	if c.RedisPoolSize > 0 {
+		redisPoolSize = c.RedisPoolSize
+	}
+	if c.EntryTimeout != 0 {
+		entryTimeout = c.EntryTimeout
+	}
+	if c.LogLevel != "" {
+		logLvl = c.LogLevel
+	}
+	if c.Tag != "" {
+		tag = c.Tag
+	}
+	if c.Testing {
+		testing = true
+	}
+	if c.Mode != "" {
+		mode = c.Mode
+	}
+	if c.TestEnvironment {
+		testEnvironment = true
+	}
+	if len(c.Whitelist) > 0 {
+		whitelistKeys = strings.Join(c.Whitelist, ",")
+	}
+	if c.StoreDataPath != "" {
+		storeDataPath = c.StoreDataPath
+	}
+	if c.EnableCXO {
+		enableCXO = true
+	}
+	if c.UptimeDB != "" {
+		uptimeDB = c.UptimeDB
+	}
+	if c.Dmsg.Discovery != "" {
+		dmsgDisc = c.Dmsg.Discovery
+	}
+	if c.Dmsg.ServerType != "" {
+		dmsgServerType = c.Dmsg.ServerType
+	}
+	return c.Dmsg.Servers, c.SurveyWhitelist
+}

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dht"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/httpauth"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -40,6 +41,7 @@ const (
 )
 
 var (
+	configPath      string
 	addr            string
 	metricsAddr     string
 	redisURL        string
@@ -62,6 +64,7 @@ var (
 )
 
 func init() {
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. When set, fields below come from the config file. Generate one with `skywire cli config gen --tpd -o /etc/skywire/transport-discovery.json`.\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9091", "address to bind to\n\r")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
@@ -231,6 +234,16 @@ Example:
 			log.Printf("Failed to output build info: %v", err)
 		}
 
+		var configServers []*disc.Entry
+		var configSurveyWL []cipher.PubKey
+		if configPath != "" {
+			c, cErr := LoadConfig(configPath)
+			if cErr != nil {
+				log.Fatal(cErr)
+			}
+			configServers, configSurveyWL = applyConfig(c)
+		}
+
 		if !strings.HasPrefix(redisURL, redisScheme) {
 			redisURL = redisScheme + redisURL
 		}
@@ -349,6 +362,18 @@ Example:
 			logger.WithError(err).Fatal("invalid --mode")
 		}
 
+		// Source priority for embedded dmsg-server transit and the
+		// survey whitelist:
+		//   1. config (--config)
+		//   2. embedded deployment keyring (deployment.Prod / dmsg.Prod)
+		// Operators ship a config file generated from the keyring so
+		// IP rotations don't require a binary rebuild.
+		embeddedServers := dmsgDiscEntries(configServers)
+		surveyWL := deployment.Prod.SurveyWhitelist
+		if len(configSurveyWL) > 0 {
+			surveyWL = configSurveyWL
+		}
+
 		h, err := svcmode.Start(ctx, svcmode.Config{
 			Mode:                resolvedMode,
 			HTTPAddr:            addr,
@@ -358,8 +383,8 @@ Example:
 			DmsgPort:            dmsgPort,
 			DmsgDiscovery:       dmsgDisc,
 			DmsgServerType:      dmsgServerType,
-			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
-			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
+			EmbeddedDmsgServers: embeddedServers,
+			SurveyWhitelist:     surveyWL,
 			Log:                 logger,
 			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {

--- a/pkg/cmdutil/svcconfig.go
+++ b/pkg/cmdutil/svcconfig.go
@@ -1,0 +1,72 @@
+// Package cmdutil pkg/cmdutil/svcconfig.go
+package cmdutil
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// DmsgConfig is the shared dmsg-related block embedded in each
+// deployment service's config file. Mirrors the visor's
+// `dmsg.discovery` / `dmsg.discovery_dmsg` / `dmsg.servers` shape so
+// operators see a consistent schema across visor + every deployment
+// service. The discovery's PK is encoded inside DiscoveryDmsg
+// (`dmsg://<PK>:<port>`); there is no separate PK field — see
+// PKFromDmsgURL.
+//
+// Polymorphism (object vs array) is intentionally NOT supported here
+// — deployment services don't have a multi-deployment use case the
+// way the visor does. If that ever changes, the visor's
+// pkg/dmsgc.DmsgConfig is the precedent.
+type DmsgConfig struct {
+	// Discovery is the HTTP URL of the dmsg-discovery the service
+	// uses for its own dmsg-client lifecycle (refreshing the server
+	// list, registering a client entry, etc.). Empty for services
+	// that don't talk to a discovery (dmsg-discovery itself).
+	Discovery string `json:"discovery,omitempty"`
+	// DiscoveryDmsg is the dmsg-HTTP URL of the same discovery,
+	// form `dmsg://<PK>:<port>`. Used by dmsgfirst-style clients
+	// to dial the discovery over dmsg before falling back to HTTP.
+	DiscoveryDmsg string `json:"discovery_dmsg,omitempty"`
+	// SessionsCount is the minimum number of dmsg-server sessions
+	// the service should maintain. Zero leaves it to the runtime
+	// default (typically 0 — connect to all available servers).
+	SessionsCount int `json:"sessions_count,omitempty"`
+	// ServerType filters dmsg-servers by their declared type. Empty
+	// matches all. Mirrors the existing --dmsg-server-type flag.
+	ServerType string `json:"server_type,omitempty"`
+	// Servers is the static dmsg-server transit set the service
+	// preloads at startup. Replaces direct reads of
+	// dmsg.Prod.DmsgServers at runtime — operators ship a config
+	// file generated from the embedded keyring once and edit it as
+	// servers rotate, no rebuild required.
+	Servers []*disc.Entry `json:"servers,omitempty"`
+}
+
+// PKFromDmsgURL extracts the dmsg PK from a URL of the form
+// `dmsg://<PK>:<port>[/path]`. Returns the zero PK when the URL is
+// empty, malformed, or doesn't carry a valid PK in the host part.
+// Used by callers that need the discovery's PK for dmsgfirst-style
+// dials without forcing the operator to repeat the PK as a separate
+// field in config.
+func PKFromDmsgURL(s string) cipher.PubKey {
+	if s == "" {
+		return cipher.PubKey{}
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return cipher.PubKey{}
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = strings.SplitN(u.Host, ":", 2)[0]
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(host); err != nil {
+		return cipher.PubKey{}
+	}
+	return pk
+}


### PR DESCRIPTION
## Summary

Adds a \`--config\` flag to **dmsg-discovery**, **transport-discovery**, **service-discovery**, **address-resolver**, and **route-finder**. When set, the Config struct is the source of truth at runtime; when unset, every service falls back to its existing per-flag CLI behavior so existing deployments don't break.

### Why

Embedded \`deployment.Prod\` is consulted *at runtime* today for the dmsg-server bootstrap list and various URLs. That means every IP rotation triggers a binary rebuild. With config files, the embedded keyring becomes purely a build-time seed for \`cli config gen\`; runtime reads from disk.

### Shared dmsg shape

Every service's config has a \`dmsg\` block in the same shape, mirroring the visor and dmsg-server:

\`\`\`jsonc
"dmsg": {
    "discovery": "http://...",
    "discovery_dmsg": "dmsg://<PK>:<port>",
    "sessions_count": 2,
    "servers": [ ... ]
}
\`\`\`

The static \`servers\` list replaces the runtime read of \`dmsg.Prod.DmsgServers\`. dmsg-discovery has \`dmsg_servers\` at the top level (it has no upstream discovery to talk to).

### CLI

\`cli config gen\` grows mutually-exclusive flags mirroring the existing \`--dmsgdisc\` / \`--dmsgsrv\` / \`--sn\`:

- \`--tpd\` → transport-discovery config
- \`--sd\` → service-discovery config
- \`--ar\` → address-resolver config
- \`--rf\` → route-finder config

Each is a JQ projection of the visor config (which already carries the embedded keyring's \`.dmsg.servers\`).

### Skipped

\`uptime-tracker\` — deprecating.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` no diffs
- [x] \`go test ./pkg/cmdutil/ ./cmd/skywire-cli/commands/config/\` — all green
- [x] \`go run ./cmd/skywire-cli config gen -n --tpd|--sd|--ar|--rf|--dmsgdisc|--dmsgsrv\` — each emits a config in the new shape
- [ ] Production verification: each service starts with \`--config /path\` and reads from the file; backward compat — without \`--config\`, all 5 services behave exactly as before