### PR TITLE
fix(visor): upgrade dmsg disc clients to dmsgfirst after dmsgC ready

### DIFF
--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/disc/dmsgfirst"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgctrl"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
@@ -199,6 +201,18 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 		return ctx.Err()
 	}
 
+	// Once dmsgC has at least one session, upgrade its discovery
+	// client(s) to dmsgfirst-wrapped variants so subsequent
+	// AvailableServers / Entry / PutEntry calls prefer DMSG and only
+	// fall back to plain HTTP per-call when the dmsg dial fails. The
+	// initial-construction httpC was forced to plain HTTP whenever
+	// initDmsgHTTP's dmsgDC wasn't ready yet (a startup race), which
+	// pinned the dmsgC's discovery refresh to HTTP for the whole
+	// process lifetime — so an outage on the public HTTP fronting
+	// (Caddy, etc.) would break the visor's discovery refresh even
+	// when DMSG was healthy.
+	upgradeDmsgDiscToDmsgfirst(dmsgC, v.conf.Dmsg, log)
+
 	// Seed the DMSG client's entry cache with deployment service PKs.
 	// These services run as "direct" DMSG clients and don't register
 	// in the HTTP discovery, so DialStream's discovery lookup fails.
@@ -232,6 +246,40 @@ const dmsgServersCacheRefreshInterval = 5 * time.Minute
 // fixed interval. Empty refreshes (dmsgd unreachable, no entries) are
 // skipped — DmsgServersCache.Replace treats empty input as a no-op so
 // a transient outage doesn't wipe the cache.
+// upgradeDmsgDiscToDmsgfirst swaps each of dmsgC's per-deployment
+// disc.APIClient instances for a dmsgfirst-wrapped one so the dmsg
+// client's own discovery refresh tries DMSG first and only falls back
+// to plain HTTP when the dmsg dial fails. The dmsg-discovery's PK is
+// extracted from each deployment's `discovery_dmsg` URL — when that's
+// absent, the entry stays on plain HTTP because dmsgfirst.New needs a
+// PK to dial. Safe to call after dmsgC.Ready(); a no-op if no
+// deployments yield a non-zero PK.
+func upgradeDmsgDiscToDmsgfirst(dmsgC *dmsg.Client, conf *dmsgc.DmsgConfig, log *logging.Logger) {
+	if conf == nil {
+		return
+	}
+	deployments := conf.AllDeployments()
+	if len(deployments) == 0 {
+		return
+	}
+	upgraded := make([]dmsgdisc.APIClient, len(deployments))
+	anyUpgraded := false
+	for i, d := range deployments {
+		pk := cmdutil.PKFromDmsgURL(d.DiscoveryDmsg)
+		if pk == (cipher.PubKey{}) {
+			upgraded[i] = dmsgdisc.NewHTTP(d.Discovery, &http.Client{}, log)
+			continue
+		}
+		upgraded[i] = dmsgfirst.New(dmsgC, pk, d.Discovery, &http.Client{}, log)
+		anyUpgraded = true
+		log.WithField("url", d.Discovery).WithField("pk", pk).Info("dmsg discovery client upgraded to dmsgfirst")
+	}
+	if !anyUpgraded {
+		return
+	}
+	dmsgC.SetDiscoveryClients(upgraded)
+}
+
 func (v *Visor) refreshDmsgServersCacheLoop(ctx context.Context, discURL string, httpC *http.Client) {
 	cacheLog := v.MasterLogger().PackageLogger("dmsg_servers_cache")
 	dc := dmsgdisc.NewHTTP(discURL, httpC, cacheLog)

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -278,6 +278,9 @@ func initEmbeddedRouteSetup(ctx context.Context, v *Visor, log *logging.Logger) 
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled waiting for route setup-node dmsg client")
 	}
+	// Same dmsgfirst upgrade as the main dmsgC: discovery refresh
+	// prefers DMSG and only falls back to plain HTTP per-call.
+	upgradeDmsgDiscToDmsgfirst(routeSetupDmsgC, v.conf.Dmsg, log)
 
 	v.initLock.Lock()
 	v.embeddedRouteSetup = &EmbeddedRouteSetup{

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -492,6 +492,10 @@ func initEmbeddedTPS(ctx context.Context, v *Visor, log *logging.Logger) error {
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled waiting for TPS dmsg client")
 	}
+	// Same dmsgfirst upgrade as the main dmsgC: avoids pinning the
+	// embedded TPS's discovery refresh to plain HTTP for the process
+	// lifetime when initDmsgHTTP's dmsgDC isn't ready at construction.
+	upgradeDmsgDiscToDmsgfirst(tpsDmsgC, v.conf.Dmsg, log)
 
 	v.initLock.Lock()
 	v.embeddedTPS = &embeddedTPS{


### PR DESCRIPTION
## Summary

The visor's main \`dmsgC\`, embedded TPS dmsg client, and embedded route-setup-node dmsg client all construct their \`disc.APIClient\` as plain \`disc.NewHTTP\` at startup. The HTTP transport is decided **once** based on whether \`v.dmsgHTTP\` is non-nil at that moment — and because \`initDmsgHTTP\` brings \`dmsgDC\` up in a goroutine, \`v.dmsgHTTP\` is almost always nil during \`initDmsg\`, so the disc client gets pinned to plain HTTP for the whole process lifetime.

Effect during a Caddy / public-HTTP outage: the dmsg client's periodic \`AvailableServers\` refresh keeps retrying plain HTTP and loses the dmsg-server list, even though every dmsg session itself is healthy. This was visible in production:

\`\`\`
WARN [dmsgC]: Retrying... error="Get \"http://dmsgd.skywire.skycoin.com/dmsg-discovery/available_servers\": dial tcp 139.162.160.227:80: connect: connection refused"
WARN [embedded_tps:dmsg]: Retrying... error="..."
\`\`\`

## Fix

After each \`dmsgC.Ready()\`, call \`upgradeDmsgDiscToDmsgfirst\`, which builds a \`dmsgfirst.New\`-wrapped \`disc.APIClient\` per configured deployment and installs them via \`dmsgC.SetDiscoveryClients\` (added in #2438). \`dmsgfirst\` tries DMSG first using the now-ready \`dmsgC\`, and only falls back to plain HTTP per-call when the dmsg dial fails. The discovery PK is extracted from the deployment's \`discovery_dmsg\` URL — when that's missing, the entry stays on plain HTTP.

Applied to:

- \`pkg/visor/init_dmsg.go\` (main \`dmsgC\`)
- \`pkg/visor/init_transport.go\` (embedded TPS)
- \`pkg/visor/init_router.go\` (embedded route-setup-node)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/visor/ ./pkg/dmsg/dmsg/ ./pkg/dmsgc/\` — all green
- [ ] Production verification: stop Caddy briefly; visor's \`dmsgC\` and embedded TPS keep \`AvailableServers\` working over DMSG (no plain-HTTP retry storm)