### PR TITLE
fix(dmsg): self-deadlock in updateClientEntry under dmsgfirst path

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -177,11 +177,10 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 			c.nudgeEntryUpdate()
 			return nil
 		default:
-			// First session — update immediately.
-			c.sessionsMx.Lock()
-			err := c.EntityCommon.updateClientEntry(ctx, c.done, c.conf.ClientType)
-			c.sessionsMx.Unlock()
-			if err != nil {
+			// First session — update immediately. updateClientEntry
+			// takes sessionsMx itself for its snapshot; holding it
+			// here would self-deadlock via the dmsgfirst path.
+			if err := c.EntityCommon.updateClientEntry(ctx, c.done, c.conf.ClientType); err != nil {
 				return err
 			}
 			c.readyOnce.Do(func() { close(c.ready) })

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -477,10 +477,17 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 		return errors.New("updateClientEntry: no discoveries configured")
 	}
 
+	// Snapshot the connected-server PK set under sessionsMx and release
+	// before any IO. Holding sessionsMx across ep.Client.Entry() / PutEntry()
+	// self-deadlocks now that the disc client (dmsgfirst) dials over DMSG —
+	// HTTPTransport.RoundTrip → DialStream → sortedDelegatedSessions →
+	// session() also wants sessionsMx, on this same goroutine.
+	c.sessionsMx.Lock()
 	srvPKs := make([]cipher.PubKey, 0, len(c.sessions))
 	for pk := range c.sessions {
 		srvPKs = append(srvPKs, pk)
 	}
+	c.sessionsMx.Unlock()
 
 	// Short-circuit: if the delegated server set we're about to publish
 	// is identical to what we last successfully pushed AND an update
@@ -590,11 +597,9 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 				continue
 			}
 
-			c.sessionsMx.Lock()
-			err := c.updateClientEntry(ctx, done, clientType)
-			c.sessionsMx.Unlock()
-
-			if err != nil {
+			// updateClientEntry takes sessionsMx itself for its snapshot;
+			// holding it here would self-deadlock via the dmsgfirst path.
+			if err := c.updateClientEntry(ctx, done, clientType); err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry.")
 			}
 
@@ -616,10 +621,8 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 				}
 			}
 		clientUpdate:
-			c.sessionsMx.Lock()
-			err := c.updateClientEntry(ctx, done, clientType)
-			c.sessionsMx.Unlock()
-			if err != nil {
+			// See timer-tick comment above re: sessionsMx.
+			if err := c.updateClientEntry(ctx, done, clientType); err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry (nudge).")
 			}
 			t.Reset(c.updateInterval)

--- a/static/skywire-manager-src/package-lock.json
+++ b/static/skywire-manager-src/package-lock.json
@@ -11067,13 +11067,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -12216,9 +12216,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- `updateClientEntryLoop` and `setSessionCallback` held `sessionsMx` across the call to `updateClientEntry`, which calls `ep.Client.Entry`. With the disc client wrapped by dmsgfirst (#2441), that `Entry` call dials over DMSG — `HTTPTransport.RoundTrip` → `DialStream` → `sortedDelegatedSessions` → `clientSession` → `session()` — and `session()` tries to lock the same `sessionsMx` on the same goroutine. Self-deadlock on a non-reentrant mutex.
- Move the `sessionsMx` acquisition into `updateClientEntry` itself, just long enough to snapshot the connected-server PK set, and release before any IO. Drop the surrounding lock at the three callers (timer tick + nudge in `updateClientEntryLoop`, first-session callback in `NewClient`).

Pre-dmsgfirst this was safe because `ep.Client` was plain HTTP and never re-entered dmsg. The lock guarding the snapshot had been conflated with a lock effectively serializing the IO; splitting them is the fix.

## Repro / observed pathology

On a long-running visor:
- pprof showed 4179 goroutines blocked at `entity_common.go:194` (`session()`) for ~13h, behind one goroutine in `updateClientEntryLoop` that held `sessionsMx` and was itself stuck waiting to re-acquire it via the dmsgfirst → DialStream → session() chain.
- Every API handler that touched dmsg piled up behind the deadlock, leaving the hypervisor UI stuck on its loading spinner.
- After the patch: 0 goroutines blocked at `session()`; API handlers respond in <1ms.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/dmsg/dmsg/...`
- [x] Verified live on a deadlocked visor — replaced the binary, restarted, confirmed no goroutines blocked at `entity_common.go:194` and the hypervisor UI loads normally.