### PR TITLE
fix(visor/stats): nest daily transport rollup under <date>/rollup, not <date>

### DIFF
--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -12,10 +12,16 @@
 // Path conventions (matching §07 of skywire-specs):
 //
 //	transports/<uuid>/current                 → live snapshot (JSON)
-//	transports/<uuid>/<YYYY-MM-DD>            → that day's rollup (JSON)
+//	transports/<uuid>/<YYYY-MM-DD>/rollup     → that day's rollup (JSON)
 //	transports/<uuid>/<YYYY-MM-DD>/timeline   → 36-byte uptime bitmap
 //	tiers/<tier>/<YYYY-MM-DD>                 → 36-byte bitmap
 //	services/<slug>/<YYYY-MM-DD>              → 36-byte bitmap
+//
+// The rollup and timeline are nested under <YYYY-MM-DD> as siblings.
+// Putting the daily JSON at the bare-date leaf ("transports/<uuid>/<date>")
+// would collide with the timeline write ("transports/<uuid>/<date>/timeline")
+// because the treestore is strictly a tree — a node is leaf XOR sub-tree,
+// never both. The /rollup suffix keeps <date> unambiguously a branch.
 //
 // Sinks are expected to be non-blocking; the Tracker invokes them
 // from the sampler goroutine and does not wait for completion.
@@ -188,7 +194,7 @@ func currentTransportPath(id string) string {
 }
 
 func dailyTransportPath(id, date string) string {
-	return "transports/" + id + "/" + date
+	return "transports/" + id + "/" + date + "/rollup"
 }
 
 func transportTimelinePath(id, date string) string {

--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -100,7 +100,7 @@ func TestSinkReceivesTransportPutsOnSample(t *testing.T) {
 
 	puts, _ := sink.snapshot()
 	wantCurrent := "transports/" + id.String() + "/current"
-	wantDaily := "transports/" + id.String() + "/2026-04-27"
+	wantDaily := "transports/" + id.String() + "/2026-04-27/rollup"
 	if _, ok := puts[wantCurrent]; !ok {
 		t.Errorf("missing %s in sink puts; got %v", wantCurrent, keysOf(puts))
 	}
@@ -224,7 +224,7 @@ func TestSinkDeletedOnBboltRetentionDrop(t *testing.T) {
 		gotPaths[d] = true
 	}
 	for _, want := range wantDates {
-		path := "transports/" + id.String() + "/" + want
+		path := "transports/" + id.String() + "/" + want + "/rollup"
 		if !gotPaths[path] {
 			t.Errorf("expected sink Delete for retention-dropped %s; got dels = %v", path, dels)
 		}

--- a/static/skywire-manager-src/package-lock.json
+++ b/static/skywire-manager-src/package-lock.json
@@ -11819,9 +11819,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- The treestore is strict tree — a node is leaf XOR sub-tree, never both. Writing the daily JSON rollup to `transports/<uuid>/<date>` as a leaf collided with the timeline bitmap write at `transports/<uuid>/<date>/timeline`, which needs `<date>` to be a sub-tree.
- Every sample produced a stream of `CXO Put failed: path X conflicts with existing leaf` log lines and silently dropped the timeline writes for that (transport, date) pair.
- Renamed the rollup leaf to `<date>/rollup` so both writes nest as siblings under `<date>`. The aggregator side already only consumes `current` and `<date>/timeline`, so this is a publish-side rename — invisible downstream.

## Repro

Run a visor with bbolt-backed stats and a CXO sink wired up; debug log shows once per sample per transport per day:

```
DEBUG [stats]: Stats: CXO Put failed error="treestore: path transports/<uuid>/<date> conflicts with existing leaf" path="transports/<uuid>/<date>/timeline"
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/visor/stats/...`
- [x] Updated `sink_test.go` expectations for the new path shape