### PR TITLE
fix(dmsg): self-deadlock in updateServerEntry under dmsgfirst path

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -285,15 +285,22 @@ func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey) {
 // If 'addr' is an empty string AND no endpoint provides its own
 // advertised address, no update is performed for that endpoint
 // (preserving the legacy "empty addr = skip update" semantics).
-//
-// Caller must hold c.sessionsMx.
 func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSessions int, authPassphrase string) (err error) {
 	endpoints := c.snapshotDiscoveries()
 	if len(endpoints) == 0 {
 		return errors.New("updateServerEntry: no discoveries configured")
 	}
 
+	// Snapshot session count under sessionsMx and release before any IO.
+	// Holding sessionsMx across ep.Client.Entry / PutEntry self-deadlocks
+	// the server: when the disc client is dmsgfirst, the discovery roundtrip
+	// dials over DMSG, and every concurrent stream forward through this
+	// server (server_session.go: serveStream → entity.serverSession →
+	// EntityCommon.session) wants the same mutex. Same shape as the
+	// client-side fix in PR #2443.
+	c.sessionsMx.Lock()
 	availableSessions := maxSessions - len(c.sessions)
+	c.sessionsMx.Unlock()
 	if availableSessions < 0 {
 		availableSessions = 0
 	}
@@ -387,10 +394,7 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, m
 				continue
 			}
 
-			c.sessionsMx.Lock()
 			err := c.updateServerEntry(ctx, addr, maxSessions, authPassphrase)
-			c.sessionsMx.Unlock()
-
 			if err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry.")
 			}
@@ -413,9 +417,7 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, m
 				}
 			}
 		serverUpdate:
-			c.sessionsMx.Lock()
 			err := c.updateServerEntry(ctx, addr, maxSessions, authPassphrase)
-			c.sessionsMx.Unlock()
 			if err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry (nudge).")
 			}

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -233,8 +233,9 @@ func (s *Server) Serve(lis net.Listener, addr string) error {
 
 func (s *Server) startUpdateEntryLoop(ctx context.Context) error {
 	err := netutil.NewDefaultRetrier(s.log).Do(ctx, func() error {
-		s.sessionsMx.Lock()
-		defer s.sessionsMx.Unlock()
+		// updateServerEntry takes sessionsMx internally only for the
+		// session-count snapshot; do NOT hold it across this call —
+		// see the comment in EntityCommon.updateServerEntry.
 		return s.updateServerEntry(ctx, s.AdvertisedAddr(), s.maxSessions, s.authPassphrase)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Same shape as #2443 but on the server side. \`updateServerEntryLoop\` held \`sessionsMx\` across the call to \`updateServerEntry\`, which calls \`ep.Client.Entry\` / \`PutEntry\`. With the disc client wrapped by \`dmsgfirst\`, those calls dial over DMSG — many seconds round-trip. Meanwhile every concurrent stream forward through this server hits \`EntityCommon.session()\` (entity_common.go:194, called from \`server_session.go:serveStream → entity.serverSession\`) and blocks on the same mutex. New clients \`EOF\` / \`i/o deadline reached\` during handshake because \`handleSession\`'s \`setSession\` also takes the lock.

Observed live on dmsg-server-6 right after deploy: ~2k goroutines, 323 stuck on \`c.sessionsMx\` at the session-lookup path, one stuck inside \`updateServerEntryLoop\`, host visor reporting **\"DMSG Servers (0 connected)\"**.

The fix is the same as #2443: move the lock acquisition into \`updateServerEntry\` and hold it only long enough to read \`len(c.sessions)\` for the \`availableSessions\` calculation. The discovery IO runs lock-free, so concurrent session lookups and forwards don't pile up behind it. The two call sites in \`updateServerEntryLoop\` and the one in \`startUpdateEntryLoop\` (server.go) drop their \`sessionsMx.Lock()\` wraps; the docstring is updated accordingly.

## Test plan

- [x] \`go test ./pkg/dmsg/dmsg/\` — passes.
- [ ] Deploy and verify the host visor connects to all dmsg servers in the keyring; goroutine count on dmsg-server pprof drops back to baseline (low hundreds, not thousands); no more \`error=\"i/o deadline reached\"\` storms in dmsg-server logs after a fresh client surge.

