### PR TITLE
fix(dmsg): self-deadlock in EnsureAndObtainSession across dmsgfirst path

### DIFF
--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -18,17 +18,35 @@ import (
 // EnsureAndObtainSession attempts to obtain a session.
 // If the session does not exist, we will attempt to establish one.
 // It returns an error if the session does not exist AND cannot be established.
+//
+// sesMx is released across the discovery lookup (getServerEntry) because
+// ce.dc may be a dmsgfirst-wrapped client whose primary path dials over
+// DMSG itself — DialStream → phase 3 → EnsureAndObtainSession on the
+// same goroutine, which would re-acquire sesMx and self-deadlock on a
+// non-reentrant mutex. Holding the lock only during the cache check and
+// the dialSession step still serializes concurrent dials to the same
+// server, preserving the invariant the lock was protecting.
 func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKey) (ClientSession, error) {
 	ce.sesMx.Lock()
-	defer ce.sesMx.Unlock()
-
 	if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
+		ce.sesMx.Unlock()
 		return dSes, nil
 	}
+	ce.sesMx.Unlock()
 
 	srvEntry, err := getServerEntry(ctx, ce.dc, srvPK)
 	if err != nil {
 		return ClientSession{}, err
+	}
+
+	ce.sesMx.Lock()
+	defer ce.sesMx.Unlock()
+	// Re-check after re-locking — another goroutine may have raced
+	// us to establish a session for the same server PK while we
+	// were doing the discovery lookup. Use it instead of dialing
+	// a duplicate.
+	if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
+		return dSes, nil
 	}
 	return ce.dialSession(ctx, srvEntry)
 }


### PR DESCRIPTION
## Summary

`EnsureAndObtainSession` held `sesMx` across the call to `getServerEntry`. With `ce.dc` wrapped by dmsgfirst, `getServerEntry` dials over DMSG — `HTTPTransport.RoundTrip` → `DialStream` → phase 3 (line 129 of `client_dial.go`) → `EnsureAndObtainSession` on the same goroutine, which tries to re-acquire `sesMx`. Self-deadlock on a non-reentrant mutex.

Same recursion shape as the prior `sessionsMx` deadlock fix in #2443 — different mutex, different file, same root cause: a lock guarding cache state was being held across IO that re-entered the same lock through dmsgfirst.

## Repro / observed pathology

On a visor with marginal dmsg connectivity (single session, network flap):

- `initAddressResolver` calls `dmsgC.LookupIPGeo` (10s timeout via `WithTimeout`).
- `LookupIPGeo` iterates delegated servers, calls `EnsureAndObtainSession(srvPK)`.
- `EnsureAndObtainSession` locks `sesMx`, then `getServerEntry(ce.dc, srvPK)` runs over the dmsgfirst-wrapped disc client.
- dmsgfirst's primary path calls `DialStream(dmsgdiscPK)`. With seeded delegated-server entries, phases 1/2 fail (we have only the one connected session) and phase 3 calls `EnsureAndObtainSession(otherSrvPK)` on the same goroutine.
- That re-locks `sesMx` → deadlock.

The visor's pprof showed `initAddressResolver` and `NodeHealthTracker.doTPSHealthCheck` goroutines blocked at `sesMx.Lock()` for 30+ minutes; the hypervisor HTTP server never bound `:8000` because the entire transport-init tree depends on the deadlocked dmsgC.

## Fix

Release `sesMx` across the discovery lookup. Re-acquire afterwards and double-check `ce.clientSession` before dialing — so two callers racing on the same server PK still won't create duplicate sessions.

```go
ce.sesMx.Lock()
if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
    ce.sesMx.Unlock()
    return dSes, nil
}
ce.sesMx.Unlock()

srvEntry, err := getServerEntry(ctx, ce.dc, srvPK)
if err != nil {
    return ClientSession{}, err
}

ce.sesMx.Lock()
defer ce.sesMx.Unlock()
if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
    return dSes, nil // raced; another goroutine got there first
}
return ce.dialSession(ctx, srvEntry)
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/dmsg/dmsg/...`
- [x] Live: deployed on a visor that had been deadlocked for 30+ minutes, init unblocked and the hypervisor module bound `:8000` within seconds of the rebuild.