### PR TITLE
fix(dmsg): break getServerEntry recursion under dmsgfirst path

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -665,6 +665,25 @@ func (ce *Client) SetDHTLookup(fn func(pk cipher.PubKey) (*disc.Entry, error)) {
 	ce.DHTLookup = fn
 }
 
+// resolveServerEntry returns the discovery entry for the given dmsg
+// server PK, consulting the local entryCache first and only falling
+// through to the disc.APIClient (potentially a dmsgfirst-wrapped client
+// whose primary path dials over DMSG and would land back here) on a
+// cache miss. Configured bootstrap servers are pre-seeded by
+// dmsgc.New, so the common dial-session path never reaches the fall-
+// through and the dmsgfirst recursion never has a chance to run.
+//
+// The returned entry is validated to be a server entry — a client
+// entry would mean someone passed a non-server PK as srvPK, which is
+// a programming error in the caller and we want to surface it the
+// same way the bare disc lookup did.
+func (ce *Client) resolveServerEntry(ctx context.Context, srvPK cipher.PubKey) (*disc.Entry, error) {
+	if entry, ok := ce.getCachedEntry(srvPK); ok && entry != nil && entry.Server != nil {
+		return entry, nil
+	}
+	return getServerEntry(ctx, ce.dc, srvPK)
+}
+
 // SeedEntryCache injects a client entry into the discovery cache so that
 // DialStream can find the destination without querying the HTTP discovery.
 // This is used for deployment services that run as direct DMSG clients

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -26,6 +26,19 @@ import (
 // non-reentrant mutex. Holding the lock only during the cache check and
 // the dialSession step still serializes concurrent dials to the same
 // server, preserving the invariant the lock was protecting.
+//
+// We also resolve the server entry from the local entryCache first when
+// possible. If we go to ce.dc here, the dmsgfirst wrapper's primary
+// path is dmsghttp — which is itself a DialStream that lands back in
+// EnsureAndObtainSession to set up its session, calls getServerEntry,
+// and recurses into the same disc.Entry call until the goroutine stack
+// blows up. The cache short-circuit removes that loop entirely for any
+// server PK we already know about (configured servers are pre-seeded by
+// dmsgc.New, so the common case never makes a network lookup; runtime-
+// learned servers fall through to the slower disc-client path which
+// only recurses if we genuinely don't have the entry yet — and even
+// then, the recursion bottoms out as soon as one configured server's
+// session is dialed and seeds itself).
 func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKey) (ClientSession, error) {
 	ce.sesMx.Lock()
 	if dSes, ok := ce.clientSession(ce.porter, srvPK); ok {
@@ -34,7 +47,7 @@ func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKe
 	}
 	ce.sesMx.Unlock()
 
-	srvEntry, err := getServerEntry(ctx, ce.dc, srvPK)
+	srvEntry, err := ce.resolveServerEntry(ctx, srvPK)
 	if err != nil {
 		return ClientSession{}, err
 	}

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -296,6 +297,39 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 	dmsgC := dmsg.NewClient(pk, sk, primaryC, dmsgConf)
 	dmsgC.SetLogger(masterLogger.PackageLogger("dmsgC"))
 	dmsgC.SetMasterLogger(masterLogger)
+
+	// Pre-seed the entry cache with every configured server (across
+	// all deployments + LAN servers). EnsureAndObtainSession resolves
+	// server entries from this cache before falling through to the
+	// disc client, which prevents a recursion that otherwise blows the
+	// goroutine stack on shutdown / disrupted-network paths: when
+	// ce.dc is the dmsgfirst wrapper, its primary is dmsghttp, and
+	// dmsghttp.RoundTrip → DialStream → EnsureAndObtainSession →
+	// getServerEntry → ce.dc.Entry → dmsghttp.RoundTrip … with
+	// nothing to break the loop. With these entries pre-seeded, any
+	// dial against a configured server short-circuits before the disc
+	// client is even consulted, so the loop never starts.
+	seenSeeds := make(map[cipher.PubKey]struct{})
+	seedFn := func(srcLabel string, entries []*disc.Entry) {
+		for _, srv := range entries {
+			if srv == nil || srv.Static.Null() || srv.Server == nil {
+				continue
+			}
+			if _, dup := seenSeeds[srv.Static]; dup {
+				continue
+			}
+			seenSeeds[srv.Static] = struct{}{}
+			dmsgC.SeedEntryCache(srv.Static, srv)
+			masterLogger.PackageLogger("dmsgC").
+				WithField("server_pk", srv.Static.String()).
+				WithField("source", srcLabel).
+				Debug("Pre-seeded dmsg server entry into cache")
+		}
+	}
+	for i, dep := range deployments {
+		seedFn(fmt.Sprintf("deployments[%d].servers", i), dep.Servers)
+	}
+	seedFn("primary.lan_servers", primary.LANServers)
 	// Attach extra deployments so the visor publishes its client entry
 	// to every configured discovery. Plain HTTP at construction time;
 	// the visor's init_dmsg path can swap these for dmsgfirst-wrapped


### PR DESCRIPTION
## Summary

Fixes a 2900-frame stack overflow (\`runtime: goroutine stack exceeds 1000000000-byte limit\`) hit when shutting down an \`is_public: true\` visor with the dmsgfirst-wrapped discovery client.

The cycle:

\`\`\`
dmsgfirst.fallbackClient.Entry          (primary path)
  → disc.httpClient.Entry               (primary is dmsghttp-backed)
    → http.Client.Do
      → dmsghttp.HTTPTransport.RoundTrip
        → dmsg.Client.DialStream
          → dmsg.Client.EnsureAndObtainSession
            → dmsg.getServerEntry
              → ce.dc.Entry             (same fallbackClient again)
                → … LOOP
\`\`\`

The dmsgfirst wrapper's primary is \`dmsghttp\` — entry lookups travel over DMSG by design. But that means \`RoundTrip\` needs a session, the session needs a server entry, and the server-entry lookup goes through the same wrapper that's already in flight on the stack. Nothing to break the cycle.

## Fix

Two coordinated changes that together remove the recursion at its root, without introducing a plain-HTTP detour:

1. **\`EnsureAndObtainSession\` consults \`Client.entryCache\` first** (\`pkg/dmsg/dmsg/client.go\`, \`pkg/dmsg/dmsg/client_sessions.go\`). The cache lookup is read-only (\`getCachedEntry\` — no disc client involvement), so it cannot itself recurse. On a hit, return the cached server entry. On a miss, fall through to \`getServerEntry\` exactly as before.
2. **\`dmsgc.New\` pre-seeds the cache** with every configured bootstrap server, across all deployments + LAN servers (\`pkg/dmsgc/dmsgc.go\`). Uses the existing \`SeedEntryCache\` primitive — the same mechanism already used to seed deployment-service PKs (route finder, address resolver, etc.). With those entries in place, the common dial-session path against any configured server short-circuits before the disc client is touched.

A runtime-learned server PK that isn't in any deployment's \`servers\` list still goes through the disc client path. That path can technically recurse — but only one level: by the time it does, *some* configured server is already cached (or we couldn't have reached the new server in the first place), and \`dialSession\` against the cached server completes without further lookups.

## Why not switch to plain HTTP for transport-internal lookups?

The repo's direction is to eliminate plain-HTTP requests by default — all HTTP must go over dmsg. Forcing transport-internal lookups onto plain HTTP would regress that posture even as a recursion break. Pre-seeding the cache resolves the loop without that compromise: the configured-server case is satisfied entirely from in-memory state, no HTTP transport involved.

## Relation to prior dmsgfirst fixes

This continues the family of dmsgfirst self-recursion fixes:
- #2443 — \`updateClientEntry\` self-deadlock
- #2448 — \`updateServerEntry\` self-deadlock  
- #2449 — \`EnsureAndObtainSession\` self-deadlock (mutex re-entry)

Shutdown-time \`getServerEntry\` was the unaddressed survivor — the underlying mechanism (dmsgfirst primary calls back into itself for transport setup) is the same; the lock-deadlock variants are fixed but the entry-lookup variant blew the stack instead.

## Test plan

- [ ] \`make lint\` clean (verified: 0 issues)
- [ ] \`go test ./pkg/dmsg/dmsg/... ./pkg/dmsgc/...\` passes (verified)
- [ ] Run a public visor with \`is_public: true\`, exercise traffic for a few minutes, then \`Ctrl+C\` — should shut down cleanly without the 2900-frame stack dump
- [ ] Existing dmsg flows (DialStream, session establishment, transport creation) still work in the common case (cache pre-seed should be transparent — same disc lookup happens, just cache-served)
- [ ] Visor logs show \`Pre-seeded dmsg server entry into cache\` (debug level) for each configured server at startup