### PR TITLE
feat(tpd): mirror transport register/deregister via CXO publisher

### DIFF
--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -14,10 +14,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
+	"github.com/google/uuid"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
-	"github.com/google/uuid"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -17,6 +17,8 @@ import (
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dht"
@@ -403,7 +405,11 @@ Example:
 		// re-dial — TPD just accepts and re-subscribes on the next
 		// reconcile tick. No visor enumeration needed on TPD's side.
 		if enableCXO && h.DmsgClient != nil {
-			agg, err := cxoaggregator.New(h.DmsgClient, s, cxoaggregator.Config{
+			// Sink wraps the redis store (telemetry methods) plus the
+			// API (register/deregister methods, which need mirrorEdges
+			// in addition to a store write).
+			sink := &tpdAggregatorSink{Store: s, api: tpdAPI}
+			agg, err := cxoaggregator.New(h.DmsgClient, sink, cxoaggregator.Config{
 				Logger: logging.MustGetLogger("tpd-cxo-aggregator"),
 			})
 			if err != nil {
@@ -475,4 +481,29 @@ func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}
+}
+
+// tpdAggregatorSink composes the cxoaggregator.Sink contract from the
+// two collaborators that own the relevant pieces:
+//
+//   - store.Store satisfies the telemetry half (UpdateBandwidth,
+//     UpdateLatency, RecordTransportHeartbeat, IngestTransportTimeline)
+//     directly via the embedded interface.
+//   - The API satisfies the metadata half (RegisterTransportFromCXO,
+//     DeregisterTransportFromCXO) because those need mirrorEdges in
+//     addition to a redis write, and mirrorEdges lives on the API.
+//
+// Defined here so the cxoaggregator package doesn't gain a dependency
+// on the API package; the wiring stays at the deployment layer.
+type tpdAggregatorSink struct {
+	store.Store
+	api *api.API
+}
+
+func (s *tpdAggregatorSink) RegisterTransportFromCXO(ctx context.Context, entry *transport.Entry, reporter cipher.PubKey, version string) error {
+	return s.api.RegisterTransportFromCXO(ctx, entry, reporter, version)
+}
+
+func (s *tpdAggregatorSink) DeregisterTransportFromCXO(ctx context.Context, id uuid.UUID, reporter cipher.PubKey) error {
+	return s.api.DeregisterTransportFromCXO(ctx, id, reporter)
 }

--- a/pkg/transport-discovery/api/cxo_register.go
+++ b/pkg/transport-discovery/api/cxo_register.go
@@ -1,0 +1,98 @@
+// Package api pkg/transport-discovery/api/cxo_register.go
+//
+// CXO-driven register / deregister entry points. The visor publishes
+// transports/<uuid>/entry and transports/<uuid>/tombstone leaves on
+// its TreeStore feed; pkg/transport-discovery/cxoaggregator dispatches
+// those leaves to these methods on the API.
+//
+// The auth check (reporter must be an edge of the entry / existing
+// entry) is duplicated here even though CXO already authenticates the
+// publishing visor by Root signature: the Root sig proves the visor
+// PK that signed it, but the leaf itself can carry any payload, so
+// TPD has to reject entries that name an unrelated PK as an edge.
+// This is the parity check for the SW-Sig httpauth used by the v2/v3
+// HTTP register endpoints, where the "auth PK is an edge" filter is
+// applied during registerTransportV3 (see endpoints.go).
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/transport-discovery/store"
+)
+
+// RegisterTransportFromCXO applies a transport entry published by a
+// visor on its TreeStore feed. Mirrors the work the v3 HTTP register
+// handler does: store write, per-entry heartbeat, mirrorEdges, and
+// per-visor heartbeat. Returns an error on auth failure or store
+// failure; the aggregator logs it at debug.
+func (api *API) RegisterTransportFromCXO(ctx context.Context, entry *transport.Entry, reporter cipher.PubKey, version string) error {
+	if entry == nil {
+		return errors.New("nil entry")
+	}
+	if entry.EdgeIndex(reporter) < 0 {
+		return fmt.Errorf("reporter %s is not an edge of entry %s", reporter, entry.ID)
+	}
+
+	sEntry := &transport.SignedEntry{Entry: entry, Version: version}
+	if err := api.store.RegisterTransportsBatch(ctx, []*transport.SignedEntry{sEntry}); err != nil {
+		return fmt.Errorf("register batch: %w", err)
+	}
+
+	// Heartbeat into the per-transport uptime tables. Pre-uptime
+	// visors won't carry a usable Type and the store's
+	// RecordTransportHeartbeat early-returns on the type filter; we
+	// still call it so a v3-shaped entry from a current visor sets
+	// today's slot bit on register tick (the same behavior the HTTP
+	// v3 handler has at endpoints.go:94).
+	if err := api.store.RecordTransportHeartbeat(ctx, entry.ID, string(entry.Type), time.Time{}); err != nil {
+		// Best-effort — uptime is auxiliary and the store layer logs.
+		_ = err //nolint:errcheck
+	}
+
+	touchedEdges := map[cipher.PubKey]struct{}{
+		entry.Edges[0]: {},
+		entry.Edges[1]: {},
+	}
+	api.mirrorEdges(ctx, touchedEdges)
+
+	if err := api.store.RecordHeartbeat(ctx, reporter, version); err != nil {
+		// Best-effort — visor-level heartbeat is auxiliary.
+		_ = err //nolint:errcheck
+	}
+	return nil
+}
+
+// DeregisterTransportFromCXO applies a tombstone published by a visor
+// on its TreeStore feed. An unknown ID is a no-op (idempotent — a
+// tombstone that arrives after TPD-side eviction is normal).
+func (api *API) DeregisterTransportFromCXO(ctx context.Context, id uuid.UUID, reporter cipher.PubKey) error {
+	existing, err := api.store.GetTransportByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, store.ErrTransportNotFound) {
+			return nil
+		}
+		return fmt.Errorf("lookup existing: %w", err)
+	}
+	if existing.EdgeIndex(reporter) < 0 {
+		return fmt.Errorf("reporter %s is not an edge of existing entry %s", reporter, id)
+	}
+
+	if err := api.store.DeregisterTransport(ctx, id); err != nil {
+		return fmt.Errorf("deregister: %w", err)
+	}
+
+	touchedEdges := map[cipher.PubKey]struct{}{
+		existing.Edges[0]: {},
+		existing.Edges[1]: {},
+	}
+	api.mirrorEdges(ctx, touchedEdges)
+	return nil
+}

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -50,15 +50,17 @@ import (
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
-// Sink receives per-transport telemetry updates from visor TreeStore
-// feeds. The TPD's redis store satisfies this via UpdateBandwidth (per
-// reporter, cumulative counters), UpdateLatency (per transport, RTT
-// min/max/avg in ms), and RecordTransportHeartbeat (per-transport
-// uptime — sets today's 5-min slot bit and the "online today" set
-// member; previously written only via the HTTP /transports/ register
-// path).
+// Sink receives per-transport updates from visor TreeStore feeds. The
+// telemetry methods (UpdateBandwidth / UpdateLatency /
+// RecordTransportHeartbeat / IngestTransportTimeline) are satisfied
+// by the TPD's redis store directly. The metadata methods
+// (RegisterTransportFromCXO / DeregisterTransportFromCXO) require
+// the redis write plus the API-layer DHT mirror update; the wiring
+// in cmd/svc/transport-discovery/commands/root.go composes a sink
+// adapter that delegates each method to the appropriate place.
 type Sink interface {
 	UpdateBandwidth(ctx context.Context, transportID string, reporterPK cipher.PubKey, sent, recv uint64) error
 	UpdateLatency(ctx context.Context, transportID string, minMS, maxMS, avgMS float64) error
@@ -71,6 +73,19 @@ type Sink interface {
 	// (tpID, date). Used by dispatchLeaf to absorb the
 	// transports/<id>/<date>/timeline leaves.
 	IngestTransportTimeline(ctx context.Context, tpID uuid.UUID, date string, bitmap []byte) error
+	// RegisterTransportFromCXO accepts a transport entry published on
+	// a visor's TreeStore feed under transports/<uuid>/entry. The
+	// implementation MUST verify reporter is an edge of the entry
+	// (auth equivalence to the SW-Sig httpauth used by the HTTP
+	// register endpoints). version is the publishing visor's build
+	// version (formerly carried in the SW-Visor-Version header).
+	RegisterTransportFromCXO(ctx context.Context, entry *transport.Entry, reporter cipher.PubKey, version string) error
+	// DeregisterTransportFromCXO accepts a delete signal published on
+	// a visor's TreeStore feed under transports/<uuid>/tombstone. The
+	// implementation MUST verify reporter is an edge of the existing
+	// entry; an unknown ID is treated as a no-op (idempotent) so a
+	// tombstone that arrives after a TPD-side eviction doesn't error.
+	DeregisterTransportFromCXO(ctx context.Context, id uuid.UUID, reporter cipher.PubKey) error
 }
 
 // BandwidthSink is retained as an alias for callers that only need the
@@ -92,6 +107,25 @@ type liveSnapshot struct {
 	LatencyAvgMS float64   `json:"latency_avg_ms,omitempty"`
 	SampledAt    time.Time `json:"sampled_at"`
 	Type         string    `json:"type,omitempty"`
+}
+
+// transportEntryLeaf is the wire shape for transports/<uuid>/entry
+// leaves. Carries the bare transport.Entry plus the publishing
+// visor's build version (parity with the SW-Visor-Version header
+// used on POST /v3/transports/). Re-declared on both sides to keep
+// the dependency direction one-way; the visor publisher in
+// pkg/transport/manager.go publishes the same JSON shape.
+type transportEntryLeaf struct {
+	Version string           `json:"version,omitempty"`
+	Entry   *transport.Entry `json:"entry"`
+}
+
+// tombstoneLeaf is the wire shape for transports/<uuid>/tombstone
+// leaves. The timestamp is informational (the visor's local
+// deletion time); TPD applies the deletion at receive time and does
+// not use the timestamp for ordering.
+type tombstoneLeaf struct {
+	DeletedAt time.Time `json:"deleted_at"`
 }
 
 // Config configures the Aggregator.
@@ -356,6 +390,8 @@ func (a *Aggregator) walkAndDispatch(pack registry.Pack, n *treestore.TreeNode, 
 // dispatchLeaf is the path → action dispatcher. Recognized leaf
 // shapes:
 //
+//	transports/<uuid>/entry               → register (metadata)
+//	transports/<uuid>/tombstone           → deregister
 //	transports/<uuid>/current             → bandwidth + latency + heartbeat
 //	transports/<uuid>/<YYYY-MM-DD>/timeline → per-transport uptime bitmap
 //
@@ -368,6 +404,36 @@ func (a *Aggregator) dispatchLeaf(path string, leaf []byte, reporter cipher.PubK
 		if err := a.sink.IngestTransportTimeline(ctx, tpID, date, leaf); err != nil {
 			a.log.WithError(err).WithField("transport", tpID).WithField("date", date).
 				Debug("CXO aggregator: IngestTransportTimeline failed")
+		}
+		return
+	}
+	if tpID, ok := parseTransportEntryPath(path); ok {
+		var leafEntry transportEntryLeaf
+		if err := json.Unmarshal(leaf, &leafEntry); err != nil {
+			a.log.WithError(err).WithField("path", path).Debug("CXO aggregator: entry leaf decode failed")
+			return
+		}
+		// The leaf carries the entry; the path carries the UUID. They
+		// must agree — a mismatch is either a publisher bug or
+		// tampering and we drop it.
+		if leafEntry.Entry == nil || leafEntry.Entry.ID != tpID {
+			a.log.WithField("path", path).Debug("CXO aggregator: entry leaf id mismatch")
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.sink.RegisterTransportFromCXO(ctx, leafEntry.Entry, reporter, leafEntry.Version); err != nil {
+			a.log.WithError(err).WithField("transport", tpID).
+				Debug("CXO aggregator: RegisterTransportFromCXO failed")
+		}
+		return
+	}
+	if tpID, ok := parseTransportTombstonePath(path); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := a.sink.DeregisterTransportFromCXO(ctx, tpID, reporter); err != nil {
+			a.log.WithError(err).WithField("transport", tpID).
+				Debug("CXO aggregator: DeregisterTransportFromCXO failed")
 		}
 		return
 	}
@@ -445,8 +511,25 @@ func parseTransportTimelinePath(path string) (uuid.UUID, string, bool) {
 // parseCurrentTransportPath returns the transport UUID for paths
 // shaped "transports/<uuid>/current", or false otherwise.
 func parseCurrentTransportPath(path string) (uuid.UUID, bool) {
+	return parseTransportLeafByName(path, "/current")
+}
+
+// parseTransportEntryPath returns the transport UUID for paths shaped
+// "transports/<uuid>/entry", or false otherwise.
+func parseTransportEntryPath(path string) (uuid.UUID, bool) {
+	return parseTransportLeafByName(path, "/entry")
+}
+
+// parseTransportTombstonePath returns the transport UUID for paths
+// shaped "transports/<uuid>/tombstone", or false otherwise.
+func parseTransportTombstonePath(path string) (uuid.UUID, bool) {
+	return parseTransportLeafByName(path, "/tombstone")
+}
+
+// parseTransportLeafByName extracts the transport UUID from any path
+// shaped "transports/<uuid><suffix>" with no extra slashes between.
+func parseTransportLeafByName(path, suffix string) (uuid.UUID, bool) {
 	const prefix = "transports/"
-	const suffix = "/current"
 	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
 		return uuid.UUID{}, false
 	}

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -393,7 +393,10 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 		sink := &recordingSink{}
 		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
 		entry := &transport.Entry{ID: uuid.New(), Edges: [2]cipher.PubKey{pkA, pkB}, Type: "stcpr"}
-		body, _ := json.Marshal(transportEntryLeaf{Entry: entry})
+		body, err := json.Marshal(transportEntryLeaf{Entry: entry})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
 		// path declares `id`, but leaf carries a different UUID — must drop.
 		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA)
 		if len(sink.registers) != 0 {
@@ -404,7 +407,10 @@ func TestDispatchLeafEntryAndTombstone(t *testing.T) {
 	t.Run("tombstone leaf dispatches to DeregisterTransportFromCXO", func(t *testing.T) {
 		sink := &recordingSink{}
 		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
-		body, _ := json.Marshal(tombstoneLeaf{DeletedAt: time.Now().UTC()})
+		body, err := json.Marshal(tombstoneLeaf{DeletedAt: time.Now().UTC()})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
 		a.dispatchLeaf("transports/"+id.String()+"/tombstone", body, pkA)
 		if len(sink.deregisters) != 1 {
 			t.Fatalf("expected 1 deregister call, got %d", len(sink.deregisters))

--- a/pkg/transport-discovery/cxoaggregator/aggregator_test.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
 )
 
 func TestParseCurrentTransportPath(t *testing.T) {
@@ -133,6 +134,8 @@ type recordingSink struct {
 		date   string
 		bitmap []byte
 	}
+	registers   []recordedRegister
+	deregisters []recordedDeregister
 }
 
 func (s *recordingSink) UpdateBandwidth(_ context.Context, _ string, _ cipher.PubKey, _, _ uint64) error {
@@ -166,6 +169,31 @@ func (s *recordingSink) IngestTransportTimeline(_ context.Context, tpID uuid.UUI
 	}{tpID, date, cp})
 	s.mu.Unlock()
 	return nil
+}
+
+func (s *recordingSink) RegisterTransportFromCXO(_ context.Context, e *transport.Entry, reporter cipher.PubKey, version string) error {
+	s.mu.Lock()
+	s.registers = append(s.registers, recordedRegister{entry: e, reporter: reporter, version: version})
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *recordingSink) DeregisterTransportFromCXO(_ context.Context, id uuid.UUID, reporter cipher.PubKey) error {
+	s.mu.Lock()
+	s.deregisters = append(s.deregisters, recordedDeregister{id: id, reporter: reporter})
+	s.mu.Unlock()
+	return nil
+}
+
+type recordedRegister struct {
+	entry    *transport.Entry
+	reporter cipher.PubKey
+	version  string
+}
+
+type recordedDeregister struct {
+	id       uuid.UUID
+	reporter cipher.PubKey
 }
 
 func TestDispatchLeafLatencyGate(t *testing.T) {
@@ -293,4 +321,109 @@ func TestDispatchLeafHeartbeatGate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseTransportEntryAndTombstonePaths(t *testing.T) {
+	id := uuid.New()
+	cases := []struct {
+		path        string
+		wantEntry   bool
+		wantTombsto bool
+	}{
+		{"transports/" + id.String() + "/entry", true, false},
+		{"transports/" + id.String() + "/tombstone", false, true},
+		{"transports/" + id.String() + "/current", false, false},
+		{"transports/" + id.String() + "/2026-04-27/timeline", false, false},
+		{"transports//entry", false, false},
+		{"transports/" + id.String() + "/entry/extra", false, false},
+		{"tiers/" + id.String() + "/entry", false, false},
+	}
+	for _, c := range cases {
+		gotID, ok := parseTransportEntryPath(c.path)
+		if ok != c.wantEntry {
+			t.Errorf("parseTransportEntryPath(%q) ok = %v, want %v", c.path, ok, c.wantEntry)
+		}
+		if c.wantEntry && gotID != id {
+			t.Errorf("parseTransportEntryPath(%q) id = %v, want %v", c.path, gotID, id)
+		}
+		gotID, ok = parseTransportTombstonePath(c.path)
+		if ok != c.wantTombsto {
+			t.Errorf("parseTransportTombstonePath(%q) ok = %v, want %v", c.path, ok, c.wantTombsto)
+		}
+		if c.wantTombsto && gotID != id {
+			t.Errorf("parseTransportTombstonePath(%q) id = %v, want %v", c.path, gotID, id)
+		}
+	}
+}
+
+func TestDispatchLeafEntryAndTombstone(t *testing.T) {
+	id := uuid.New()
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	t.Run("entry leaf dispatches to RegisterTransportFromCXO", func(t *testing.T) {
+		sink := &recordingSink{}
+		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+		entry := &transport.Entry{
+			ID:    id,
+			Edges: [2]cipher.PubKey{pkA, pkB},
+			Type:  "stcpr",
+		}
+		body, err := json.Marshal(transportEntryLeaf{Version: "v1.2.3", Entry: entry})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA)
+		if len(sink.registers) != 1 {
+			t.Fatalf("expected 1 register call, got %d", len(sink.registers))
+		}
+		got := sink.registers[0]
+		if got.entry == nil || got.entry.ID != id {
+			t.Errorf("register entry id mismatch: got %+v", got.entry)
+		}
+		if got.version != "v1.2.3" {
+			t.Errorf("register version = %q, want v1.2.3", got.version)
+		}
+		if got.reporter != pkA {
+			t.Errorf("register reporter mismatch")
+		}
+	})
+
+	t.Run("entry leaf with mismatched id is dropped", func(t *testing.T) {
+		sink := &recordingSink{}
+		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+		entry := &transport.Entry{ID: uuid.New(), Edges: [2]cipher.PubKey{pkA, pkB}, Type: "stcpr"}
+		body, _ := json.Marshal(transportEntryLeaf{Entry: entry})
+		// path declares `id`, but leaf carries a different UUID — must drop.
+		a.dispatchLeaf("transports/"+id.String()+"/entry", body, pkA)
+		if len(sink.registers) != 0 {
+			t.Errorf("expected drop on id mismatch, got %d registers", len(sink.registers))
+		}
+	})
+
+	t.Run("tombstone leaf dispatches to DeregisterTransportFromCXO", func(t *testing.T) {
+		sink := &recordingSink{}
+		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+		body, _ := json.Marshal(tombstoneLeaf{DeletedAt: time.Now().UTC()})
+		a.dispatchLeaf("transports/"+id.String()+"/tombstone", body, pkA)
+		if len(sink.deregisters) != 1 {
+			t.Fatalf("expected 1 deregister call, got %d", len(sink.deregisters))
+		}
+		got := sink.deregisters[0]
+		if got.id != id {
+			t.Errorf("deregister id = %v, want %v", got.id, id)
+		}
+		if got.reporter != pkA {
+			t.Errorf("deregister reporter mismatch")
+		}
+	})
+
+	t.Run("entry leaf with malformed body is dropped", func(t *testing.T) {
+		sink := &recordingSink{}
+		a := &Aggregator{sink: sink, log: logging.MustGetLogger("test")}
+		a.dispatchLeaf("transports/"+id.String()+"/entry", []byte("not json"), pkA)
+		if len(sink.registers) != 0 {
+			t.Errorf("expected drop on bad json, got %d registers", len(sink.registers))
+		}
+	})
 }

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -3,6 +3,7 @@ package transport
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -91,6 +92,14 @@ type Manager struct {
 	// tpdCache stores the cached transport discovery data for local route calculation
 	tpdCache   []*Entry
 	tpdCacheMu sync.RWMutex
+
+	// tpdLeafPub mirrors register / deregister to the visor's CXO
+	// stats publisher tree (the same tree that already carries
+	// transports/<uuid>/current and timeline leaves). Set lazily by
+	// the visor's stats init after the publisher is constructed; nil
+	// means "no CXO publish, HTTP path only." See SetTPDLeafPublisher.
+	tpdLeafPubMu sync.RWMutex
+	tpdLeafPub   TPDLeafPublisher
 
 	// regNudge signals the re-registration loop to run soon (after a short debounce).
 	// Sent after accepting a new transport so it gets batch-registered quickly.
@@ -320,6 +329,11 @@ func (tm *Manager) flushDeletionQueue() {
 	} else {
 		tm.Logger.Debugf("Batch deleted %d/%d transports from TPD", deleted, len(ids))
 	}
+
+	// Mirror to the CXO publisher tree. Dual-write phase: best-effort,
+	// and idempotent on TPD's side (DeregisterTransport on a
+	// not-found ID is a no-op).
+	tm.publishTPDTombstones(ids)
 }
 
 func (tm *Manager) reRegisterTransports(ctx context.Context) {
@@ -358,6 +372,11 @@ func (tm *Manager) reRegisterTransports(ctx context.Context) {
 	} else {
 		tm.Logger.Debugf("Successfully re-registered %d transports", len(bareEntries))
 	}
+
+	// Mirror to the CXO publisher tree. Dual-write phase: HTTP is
+	// authoritative; CXO is best-effort and converges by the next
+	// tick if a publish fails or the publisher isn't yet wired.
+	tm.publishTPDEntries(bareEntries)
 }
 
 func (tm *Manager) getPTpsCache() []PersistentTransports {
@@ -365,6 +384,95 @@ func (tm *Manager) getPTpsCache() []PersistentTransports {
 	defer tm.Conf.PTpsCacheMu.Unlock()
 
 	return tm.Conf.PersistentTransportsCache
+}
+
+// TPDLeafPublisher is the contract the transport manager uses to
+// mirror register / deregister events into a CXO publisher tree
+// consumed by TPD's aggregator. *treestore.Publisher already
+// satisfies this; declaring it as an interface keeps the transport
+// package free of a cxo/treestore dependency. Wired by
+// pkg/visor/init_stats.go after the publisher is built.
+type TPDLeafPublisher interface {
+	Put(path string, value []byte) error
+	Delete(path string) error
+}
+
+// SetTPDLeafPublisher installs (or clears, if nil) the CXO publisher
+// hook used to mirror transport register / deregister leaves to TPD.
+// Safe to call after Serve has started — the next register tick or
+// flushDeletionQueue picks it up. Calling with nil disables CXO
+// mirroring without affecting the HTTP register path.
+func (tm *Manager) SetTPDLeafPublisher(p TPDLeafPublisher) {
+	tm.tpdLeafPubMu.Lock()
+	tm.tpdLeafPub = p
+	tm.tpdLeafPubMu.Unlock()
+}
+
+func (tm *Manager) tpdLeafPublisher() TPDLeafPublisher {
+	tm.tpdLeafPubMu.RLock()
+	defer tm.tpdLeafPubMu.RUnlock()
+	return tm.tpdLeafPub
+}
+
+// publishTPDEntries publishes one transports/<uuid>/entry leaf per
+// entry. Best-effort: failures are logged at debug and the next
+// reRegister tick retries.
+func (tm *Manager) publishTPDEntries(entries []*Entry) {
+	pub := tm.tpdLeafPublisher()
+	if pub == nil || len(entries) == 0 {
+		return
+	}
+	type entryLeaf struct {
+		Version string `json:"version,omitempty"`
+		Entry   *Entry `json:"entry"`
+	}
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		body, err := json.Marshal(entryLeaf{Version: tm.Conf.Version, Entry: e})
+		if err != nil {
+			tm.Logger.WithError(err).WithField("transport", e.ID).
+				Debug("Failed to marshal transport entry leaf")
+			continue
+		}
+		path := fmt.Sprintf("transports/%s/entry", e.ID.String())
+		if err := pub.Put(path, body); err != nil {
+			tm.Logger.WithError(err).WithField("path", path).
+				Debug("Failed to publish transport entry leaf to CXO")
+		}
+	}
+}
+
+// publishTPDTombstones publishes a transports/<uuid>/tombstone leaf
+// per id, and removes the corresponding /entry leaf. Best-effort.
+func (tm *Manager) publishTPDTombstones(ids []uuid.UUID) {
+	pub := tm.tpdLeafPublisher()
+	if pub == nil || len(ids) == 0 {
+		return
+	}
+	body, err := json.Marshal(struct {
+		DeletedAt time.Time `json:"deleted_at"`
+	}{DeletedAt: time.Now().UTC()})
+	if err != nil {
+		tm.Logger.WithError(err).Debug("Failed to marshal tombstone body")
+		return
+	}
+	for _, id := range ids {
+		// Delete the entry leaf so a future tree walk doesn't replay
+		// the now-stale registration; the tombstone leaf is the
+		// positive deletion signal that drives TPD's aggregator.
+		entryPath := fmt.Sprintf("transports/%s/entry", id.String())
+		if err := pub.Delete(entryPath); err != nil {
+			tm.Logger.WithError(err).WithField("path", entryPath).
+				Debug("Failed to delete transport entry leaf from CXO")
+		}
+		tombPath := fmt.Sprintf("transports/%s/tombstone", id.String())
+		if err := pub.Put(tombPath, body); err != nil {
+			tm.Logger.WithError(err).WithField("path", tombPath).
+				Debug("Failed to publish transport tombstone to CXO")
+		}
+	}
 }
 
 // SetPTpsCache sets the PersistentTransportsCache

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -65,6 +65,13 @@ func initStats(_ context.Context, v *Visor, log *logging.Logger) error {
 			log.WithError(err).Warn("Stats: hydrating CXO publisher from bbolt failed")
 		}
 		tracker.SetSink(sink)
+		// Wire the same publisher into the transport manager so its
+		// register / deregister loops mirror the canonical entry +
+		// tombstone leaves to TPD's CXO aggregator (dual-write
+		// alongside the HTTP path during migration).
+		if v.tpM != nil {
+			v.tpM.SetTPDLeafPublisher(pub)
+		}
 	}
 
 	tracker.Run(v.ctx)


### PR DESCRIPTION
## Summary

Visors already publish bandwidth, latency, and uptime telemetry to TPD via their TreeStore feed (the cxoaggregator subscribes per-conn and walks the tree on Root-fill). This extends that pipe to carry the canonical register / deregister operations as new leaf shapes:

- `transports/<uuid>/entry` — JSON `{version, entry}` published on register
- `transports/<uuid>/tombstone` — JSON `{deleted_at}` published on deregister

The aggregator's `dispatchLeaf` gains two branches that route these to new Sink methods (`RegisterTransportFromCXO` / `DeregisterTransportFromCXO`). The deployment wiring in `cmd/svc/transport-discovery/commands/root.go` composes the Sink from the redis store (telemetry methods) plus the API (register/deregister methods, which need `mirrorEdges` in addition to a redis write) without adding a new package dependency from `cxoaggregator` to `api`.

On the visor side, `reRegisterTransports` and `flushDeletionQueue` both gain a CXO mirror call. They run alongside the HTTP `RegisterTransportsV3` / `DeleteTransports` paths — **dual-write, HTTP authoritative** — so older TPD builds keep working and CXO mirroring stays best-effort during migration.

Auth parity with the existing SW-Sig httpauth check: the leaf Root is signed by the publisher's secret key (CXO Root sig), giving us the publishing visor PK; the Sink methods then verify the publisher is an edge of the entry — the same filter `registerTransportV3` applies to `authPK`.

## Why

5-minute prod TPD log sample showed register + deregister + paired auth-nonce traffic at ~12 req/sec (~40 % of TPD's HTTP load). Moving these to the existing CXO data path:

- eliminates the HTTP write churn at TPD ingress (and the matching `/security/nonces/` round-trip that precedes each authenticated write),
- carries less wire data per operation (no signed envelope, version is one header in the leaf body),
- shares connection state with the existing telemetry path (no extra DMSG sessions),
- and lets visors stop reading back their own registrations from `/transports/edge:{ownPK}` once they trust their publisher tree as the source of truth (separate follow-up).

## Migration plan

Three phases, mirroring the rollout of PR #2426:

1. **(this PR) Dual-write.** Visors publish CXO leaves *and* call HTTP. TPD applies both — same redis end-state, idempotent.
2. **CXO-first.** Visors stop HTTP register if the publisher is healthy; HTTP stays as fallback when DMSG isn't ready.
3. **HTTP off.** TPD's `POST /transports/`, `POST /v3/transports/`, `POST /transports/delete-batch`, and `DELETE /transports/id:` are deprecated.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/transport-discovery/cxoaggregator/ ./pkg/transport-discovery/api/ ./pkg/transport/ ./pkg/visor/`
- [x] New unit tests cover path parsing (entry / tombstone vs current / timeline / wrong prefix / extra segment / bad UUID) and dispatcher routing (entry success / id-mismatch drop / tombstone success / malformed body drop).
- [ ] Soak in prod TPD: confirm `CXO aggregator: subscribed to visor feed` lines for visors on this build, and that `transports/<uuid>/entry` leaves arrive at the rate expected (≈ 1/visor/90 s on the re-register tick) without a regression in TPD's mem/CPU profile.
- [ ] Verify dual-write end state: a register that arrives via both HTTP and CXO produces a single redis row with consistent fields (last-writer-wins; both writers carry the same data, so no diff is expected).

## Out of scope

- Transport-setup-node graph crawl as an alternative discovery mechanism — planned as a follow-up branch with default-off wiring.
- Phase 2/3 of the migration (CXO-first / HTTP-off).