### PR TITLE
fix(visor/public): re-register in service discovery once transport count drains below max

### DIFF
--- a/pkg/app/appdisc/discovery_manager.go
+++ b/pkg/app/appdisc/discovery_manager.go
@@ -4,6 +4,7 @@ package appdisc
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -36,6 +37,14 @@ type serviceUpdater struct {
 	cancel            context.CancelFunc
 	wg                sync.WaitGroup
 	stopOnce          sync.Once
+	// paused, when true, makes the heartbeat loop skip its Register
+	// call. Pause() additionally calls DeleteEntry once so the SD
+	// entry goes away promptly; Resume() flips the flag back and
+	// kicks an immediate re-registration. The loop itself stays
+	// alive across pause cycles — operators using PublicVisorUpdater
+	// expect transient drain (e.g. max_transports) to be reversible
+	// when the situation clears, not a permanent removal.
+	paused atomic.Bool
 }
 
 // newServiceUpdater creates a new serviceUpdater with heartbeat support.
@@ -81,12 +90,49 @@ func (u *serviceUpdater) heartbeatLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			if u.paused.Load() {
+				// Drained state — caller (e.g. PublicVisorUpdater
+				// after hitting max_transports) wants no SD entry
+				// for now. Stay alive so Resume can flip us back.
+				continue
+			}
 			if err := u.client.Register(ctx); err != nil {
 				u.log.WithError(err).Warn("Failed to send heartbeat to service discovery")
 			} else {
 				u.log.Debug("Service discovery heartbeat sent successfully")
 			}
 		}
+	}
+}
+
+// Pause flags the heartbeat loop to stop publishing the SD entry and
+// removes any currently-published entry. The loop itself keeps running
+// so Resume can flip the flag back without a fresh goroutine. Idempotent.
+func (u *serviceUpdater) Pause() {
+	if !u.paused.CompareAndSwap(false, true) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := u.client.DeleteEntry(ctx); err != nil {
+		u.log.WithError(err).Warn("Failed to delete service entry on pause")
+	}
+}
+
+// Resume flips paused off and immediately re-registers so the SD
+// entry reappears without waiting for the next heartbeat tick.
+// Idempotent. No-op if Stop has already been called (cancel is nil).
+func (u *serviceUpdater) Resume() {
+	if !u.paused.CompareAndSwap(true, false) {
+		return
+	}
+	if u.cancel == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := u.client.Register(ctx); err != nil {
+		u.log.WithError(err).Warn("Re-registration on resume failed; will retry via heartbeat")
 	}
 }
 
@@ -123,6 +169,16 @@ type PublicVisorUpdater struct {
 	wg              sync.WaitGroup
 	stopOnce        sync.Once
 	deregisteredFor string // reason for deregistration (empty if still registered)
+	// drained tracks whether we've called inner.Pause() because the
+	// transport count crossed maxTransports. While drained the SD
+	// entry is gone; the monitor loop watches for the count to drop
+	// back below the resume threshold (90% of maxTransports — small
+	// hysteresis to prevent flapping right at the boundary) and then
+	// calls inner.Resume(). Without this, hitting the cap once was a
+	// permanent removal until visor restart, and the visor's other
+	// public siblings frequently disappeared from service discovery
+	// after a single transient spike.
+	drained bool
 }
 
 // NewPublicVisorUpdater creates a new public visor updater with validation logic.
@@ -214,13 +270,21 @@ func (u *PublicVisorUpdater) monitorLoop(ctx context.Context) {
 			// Continue monitoring for max transports
 
 		case <-transportTicker.C:
-			// Check transport count
+			// Check transport count, manage drained <-> active state.
 			if u.maxTransports > 0 && u.getTransportCount != nil {
 				count := u.getTransportCount()
-				if count >= u.maxTransports {
-					u.log.Infof("Public visor reached max transports (%d/%d). Deregistering from service discovery.", count, u.maxTransports)
-					u.deregister("max_transports")
-					return
+				switch {
+				case !u.drained && count >= u.maxTransports:
+					u.log.Infof("Public visor reached max transports (%d/%d). Pausing service-discovery registration.", count, u.maxTransports)
+					u.inner.Pause()
+					u.drained = true
+				case u.drained && count < (u.maxTransports*9)/10:
+					// Hysteresis: only resume once we're meaningfully
+					// under the cap (90%). Prevents flapping when the
+					// count oscillates around maxTransports.
+					u.log.Infof("Public visor transport count fell to %d/%d. Resuming service-discovery registration.", count, u.maxTransports)
+					u.inner.Resume()
+					u.drained = false
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes a real-world disappearance of public visors from service discovery.

\`PublicVisorUpdater.monitorLoop\` (\`pkg/app/appdisc/discovery_manager.go\`) was calling \`deregister(\"max_transports\")\` and \`return\`-ing from the goroutine the moment transport count crossed \`MaxTransports\` (default 1000). The exit was fatal: nothing watched for the count to drop again, and the inner \`serviceUpdater\` was \`Stop\`'d permanently. So a single transient spike past the cap removed the visor from service discovery **for the rest of its uptime** — peers stopped autoconnecting, transport counts fell back down, and the visor was orphaned despite still being perfectly reachable.

This was the original intent of the code (the \"max_transports\" deregistration was meant to be transient drainage, not permanent removal); the resume side never got wired up.

## Fix

Two coordinated changes:

1. **\`serviceUpdater\` gains \`Pause\`/\`Resume\`.** \`Pause\` flips an \`atomic.Bool\` that makes the heartbeat loop skip its \`Register\` call, and issues a one-shot \`DeleteEntry\` so the SD entry goes away promptly. \`Resume\` flips the flag off and immediately re-registers. The heartbeat goroutine itself stays alive across pause cycles — no restart, no re-construction.

2. **\`PublicVisorUpdater.monitorLoop\` uses \`inner.Pause\` / \`inner.Resume\` instead of \`deregister + return\`.** When count >= maxTransports, pause. When count drops back below 90% of maxTransports, resume. The 10% hysteresis prevents flapping when the transport count oscillates around the cap.

The \`no_external_stcpr\` deregistration path (still permanent, since the only honest signal for \"is this visor actually reachable from WAN\" is the initial external-STCPR validation) is untouched.

## Why hysteresis at 90%

\`(maxTransports * 9) / 10\` integer division — for default 1000, resumes at 900. Wide enough to absorb normal transport-count noise; tight enough that operators who set a low cap (say 50) still see meaningful drainage before re-registration. No config knob exposed for this — internal heuristic, can become one if anyone needs it.

## What's unchanged

- The \`no_external_stcpr\` validation path — first-boot probe still happens, still permanent if it fails. The visor self-probe problem (a visor can't reach its own port forward from inside the LAN) makes ongoing WAN validation infeasible without external help, so we don't try.
- The \`OnExternalSTCPR\` / \`validated\` semantics — once validated, stays validated. (\"validation decay\" is a known edge case but adds noise without high-confidence signal; deferred.)
- The \`MaxTransports\` config field and default value (1000).

## Test plan

- [x] \`make lint\` — 0 issues
- [x] \`go build ./...\` clean
- [x] \`go vet ./pkg/app/appdisc/...\` clean
- [ ] Public visor with low \`max_transports\` (say 5) hits cap: SD entry disappears within 5 seconds (Pause's DeleteEntry is synchronous), heartbeat keeps running but skips Register. Drop a few transports; once count < 4 (90% of 5 rounded down via integer div = 4), entry reappears within 10 seconds (Resume's immediate Register). Confirm via \`curl https://sd.skycoin.com/api/services?type=visor\`.
- [ ] Visor with default \`max_transports: 1000\` runs continuously past 1000 then back to ~600: appears in service discovery throughout.
- [ ] Hysteresis: count flapping between 999 and 1001 should not flap registration (only triggers Pause once at >=1000, only resumes once count falls below 900).

Continues the public-visor / service-discovery cleanup from the recent autoconnect work.