### PR TITLE
fix(dmsg): reject cached server entries in getClientEntryCached

### DIFF
--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -147,8 +147,20 @@ func (ce *Client) DialStream(ctx context.Context, addr Addr) (*Stream, error) {
 //  1. Entry cache (instant, in-memory)
 //  2. DHT lookup (instant if entry is in local store, no network)
 //  3. HTTP discovery (network round-trip)
+//
+// The entryCache is shared with the server-entry resolution path
+// (Client.resolveServerEntry, populated by SeedEntryCache for
+// configured dmsg servers — see dmsgc.New). A cached entry's kind
+// (Client vs Server) is determined by which fields are populated, so
+// when callers expect a client entry but the cache happens to hold a
+// server entry for that PK (e.g. DHT bootstrap dialing a dmsg server
+// PK as if it were a peer), we must treat it as a miss and fall
+// through to the discovery path — getClientEntry will return
+// ErrDiscEntryIsNotClient, matching the pre-cache behavior. Without
+// this guard, DialStream returns a nil-Client entry and segfaults
+// dereferencing entry.Client.DelegatedServers at line 110.
 func (ce *Client) getClientEntryCached(ctx context.Context, clientPK cipher.PubKey) (*disc.Entry, error) {
-	if entry, ok := ce.getCachedEntry(clientPK); ok {
+	if entry, ok := ce.getCachedEntry(clientPK); ok && entry != nil && entry.Client != nil {
 		ce.LookupCacheHits.Add(1)
 		return entry, nil
 	}


### PR DESCRIPTION
## Summary

Regression from #2451. The recursion fix pre-seeds configured dmsg server entries into \`Client.entryCache\` so \`EnsureAndObtainSession\` can resolve server PKs without going to the disc client (breaking the dmsgfirst recursion). Problem: that same cache is also read by \`getClientEntryCached\`, the lookup path \`DialStream\` uses for arbitrary peer PKs.

When something dials a server PK as if it were a client peer — **DHT bootstrap is the immediate trigger** (its \`bootstrap_peers\` list happens to include dmsg server PKs) — the cache returns the seeded server entry (\`Client == nil\`), and \`DialStream\` segfaults at \`client_dial.go:110\`:

\`\`\`go
delegatedSessions := ce.sortedDelegatedSessions(entry.Client.DelegatedServers)
                                                ^^^ nil dereference
\`\`\`

Reproduces deterministically on startup:

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11ef981]

goroutine 578 [running]:
github.com/skycoin/skywire/pkg/dmsg/dmsg.(*Client).DialStream
    /pkg/dmsg/dmsg/client_dial.go:110 +0x601
github.com/skycoin/skywire/pkg/dht.(*DMSGTransport).Dial
    /pkg/dht/dmsg_transport.go:35 +0xa5
github.com/skycoin/skywire/pkg/dht.(*Node).rpcPing
    /pkg/dht/dht.go:644 +0xbf
github.com/skycoin/skywire/pkg/dht.(*Node).bootstrapOnce
    /pkg/dht/dht.go:834 +0x1e9
\`\`\`

## Fix

\`getClientEntryCached\` now validates the cached entry is actually a client entry (\`entry.Client != nil\`); cached server entries are treated as misses and the lookup falls through to \`getClientEntry\`, which already returns \`ErrDiscEntryIsNotClient\` and lets \`DialStream\`'s \`discErr\` path handle it cleanly.

This mirrors the filter \`getClientEntry\` already applies on the disc-fetched path. The cache layer was the only place where the kind-check was missing — pre-#2451 it didn't matter because nothing was seeding server entries.

The server-side path (\`Client.resolveServerEntry\`) already filters with \`entry.Server != nil\`, so the symmetric problem doesn't exist there. Cache stays mixed; each caller filters to its expected kind.

## Test plan

- [x] \`go test ./pkg/dmsg/dmsg/...\` passes (existing tests cover client-entry resolution paths)
- [x] \`make lint\` clean
- [x] \`go build ./...\` clean
- [ ] Visor with \`is_public: true\` + DHT enabled starts cleanly without the SEGV
- [ ] Recursion fix from #2451 still effective: configured dmsg servers resolved from cache, no \`getServerEntry → fallbackClient.Entry\` recursion

Should be merged ASAP — this breaks visor startup for anyone who synced develop after #2451 landed and has DHT bootstrap peers configured.