### PR TITLE
fix(dmsg): break dmsgfirst recursion via context guard in HTTPTransport

### DIFF
--- a/pkg/dmsg/disc/dmsgfirst/client.go
+++ b/pkg/dmsg/disc/dmsgfirst/client.go
@@ -155,7 +155,24 @@ func shouldFallback(err error) bool {
 	return false
 }
 
+// insideTransport reports whether the call is happening inside a
+// dmsghttp.HTTPTransport.RoundTrip frame. The DMSG-primary path of
+// every fallbackClient method dials over THIS very transport, so
+// re-entering it here would recurse indefinitely on the same
+// goroutine — every level adds a fresh DialStream → discovery
+// lookup → fallbackClient.X → dmsghttp.RoundTrip frame, blowing
+// the stack within milliseconds. When the guard is set, we skip
+// the primary entirely and use the HTTP fallback for that one call.
+// The outer (non-recursive) caller's normal DMSG-primary flow is
+// unaffected — the guard is scoped to the single nested call.
+func insideTransport(ctx context.Context) bool {
+	return dmsghttp.IsInsideTransport(ctx)
+}
+
 func (c *fallbackClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc.Entry, error) {
+	if insideTransport(ctx) {
+		return c.fallback.Entry(ctx, pk)
+	}
 	if e, err := c.primary.Entry(ctx, pk); !shouldFallback(err) {
 		return e, err
 	} else { //nolint:revive
@@ -165,6 +182,9 @@ func (c *fallbackClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc.Ent
 }
 
 func (c *fallbackClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
+	if insideTransport(ctx) {
+		return c.fallback.PostEntry(ctx, entry)
+	}
 	if err := c.primary.PostEntry(ctx, entry); !shouldFallback(err) {
 		return err
 	} else { //nolint:revive
@@ -174,6 +194,9 @@ func (c *fallbackClient) PostEntry(ctx context.Context, entry *disc.Entry) error
 }
 
 func (c *fallbackClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
+	if insideTransport(ctx) {
+		return c.fallback.PutEntry(ctx, sk, entry)
+	}
 	if err := c.primary.PutEntry(ctx, sk, entry); !shouldFallback(err) {
 		return err
 	} else { //nolint:revive
@@ -183,6 +206,9 @@ func (c *fallbackClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *
 }
 
 func (c *fallbackClient) DelEntry(ctx context.Context, entry *disc.Entry) error {
+	if insideTransport(ctx) {
+		return c.fallback.DelEntry(ctx, entry)
+	}
 	if err := c.primary.DelEntry(ctx, entry); !shouldFallback(err) {
 		return err
 	} else { //nolint:revive
@@ -192,6 +218,9 @@ func (c *fallbackClient) DelEntry(ctx context.Context, entry *disc.Entry) error 
 }
 
 func (c *fallbackClient) AvailableServers(ctx context.Context) ([]*disc.Entry, error) {
+	if insideTransport(ctx) {
+		return c.fallback.AvailableServers(ctx)
+	}
 	if v, err := c.primary.AvailableServers(ctx); !shouldFallback(err) {
 		return v, err
 	} else { //nolint:revive
@@ -201,6 +230,9 @@ func (c *fallbackClient) AvailableServers(ctx context.Context) ([]*disc.Entry, e
 }
 
 func (c *fallbackClient) AllServers(ctx context.Context) ([]*disc.Entry, error) {
+	if insideTransport(ctx) {
+		return c.fallback.AllServers(ctx)
+	}
 	if v, err := c.primary.AllServers(ctx); !shouldFallback(err) {
 		return v, err
 	} else { //nolint:revive
@@ -210,6 +242,9 @@ func (c *fallbackClient) AllServers(ctx context.Context) ([]*disc.Entry, error) 
 }
 
 func (c *fallbackClient) AllEntries(ctx context.Context) ([]string, error) {
+	if insideTransport(ctx) {
+		return c.fallback.AllEntries(ctx)
+	}
 	if v, err := c.primary.AllEntries(ctx); !shouldFallback(err) {
 		return v, err
 	} else { //nolint:revive
@@ -219,6 +254,9 @@ func (c *fallbackClient) AllEntries(ctx context.Context) ([]string, error) {
 }
 
 func (c *fallbackClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
+	if insideTransport(ctx) {
+		return c.fallback.AllClientsByServer(ctx)
+	}
 	if v, err := c.primary.AllClientsByServer(ctx); !shouldFallback(err) {
 		return v, err
 	} else { //nolint:revive
@@ -228,6 +266,9 @@ func (c *fallbackClient) AllClientsByServer(ctx context.Context) (map[string][]*
 }
 
 func (c *fallbackClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	if insideTransport(ctx) {
+		return c.fallback.ClientsByServer(ctx, serverPK)
+	}
 	if v, err := c.primary.ClientsByServer(ctx, serverPK); !shouldFallback(err) {
 		return v, err
 	} else { //nolint:revive

--- a/pkg/dmsg/dmsghttp/http_transport.go
+++ b/pkg/dmsg/dmsghttp/http_transport.go
@@ -90,6 +90,11 @@ func MakeHTTPTransport(_ context.Context, dmsgC *dmsg.Client) *HTTPTransport {
 // the response body is fully read and closed, the stream goes back
 // into the idle pool. On any I/O error the stream is discarded.
 func (t *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Tag the request context so dmsgfirst's fallbackClient knows it's
+	// running inside a dmsghttp dial and must not re-enter this same
+	// transport for its own discovery lookups (would recurse until the
+	// goroutine stack blows). See recursion_guard.go.
+	req = req.WithContext(WithRecursionGuard(req.Context()))
 	if req.URL.Scheme == "dmsg" {
 		req = req.Clone(req.Context())
 		req.URL.Scheme = "http"

--- a/pkg/dmsg/dmsghttp/recursion_guard.go
+++ b/pkg/dmsg/dmsghttp/recursion_guard.go
@@ -1,0 +1,48 @@
+// Package dmsghttp pkg/dmsg/dmsghttp/recursion_guard.go
+//
+// Recursion guard for dmsg-over-HTTP transports.
+//
+// HTTPTransport.RoundTrip dials a fresh dmsg stream via the caller's
+// dmsg.Client whenever there's no idle pooled stream. When the dmsg
+// client's own discovery is itself wrapped with dmsgfirst (DMSG-
+// first, plain-HTTP fallback), the dmsg-side path of dmsgfirst goes
+// over THIS transport. So a discovery lookup triggered from inside
+// RoundTrip — to obtain entries needed for the very dial that's in
+// progress — re-enters RoundTrip on the same goroutine and recurses
+// indefinitely until the stack overflows.
+//
+// The cycle is structural to the dmsgfirst design (using dmsghttp
+// for the primary path is what makes it dmsg-first), so the break
+// has to happen at the inner layer: dmsgfirst notices it's been
+// called from within a RoundTrip frame and routes the lookup through
+// its plain-HTTP fallback for that one call only. The outer caller's
+// flow continues on dmsg as normal.
+//
+// The marker is a context value because contexts already propagate
+// through the entire dmsg DialStream / EnsureAndObtainSession path.
+// No extra threading required at any of the intermediate layers.
+package dmsghttp
+
+import "context"
+
+// recursionGuardKey is the (unexported) context key marking that the
+// current goroutine is executing inside HTTPTransport.RoundTrip.
+type recursionGuardKey struct{}
+
+// WithRecursionGuard returns ctx tagged so dmsg-discovery clients
+// downstream of HTTPTransport.RoundTrip (notably dmsgfirst) can tell
+// they're being called recursively from within a transport dial and
+// avoid re-entering the same transport.
+func WithRecursionGuard(ctx context.Context) context.Context {
+	return context.WithValue(ctx, recursionGuardKey{}, true)
+}
+
+// IsInsideTransport reports whether ctx was tagged by
+// WithRecursionGuard somewhere up the stack. dmsgfirst's
+// fallbackClient checks this in each of its APIClient methods;
+// when true, it short-circuits to the plain-HTTP fallback rather
+// than calling its dmsghttp-backed primary.
+func IsInsideTransport(ctx context.Context) bool {
+	v, _ := ctx.Value(recursionGuardKey{}).(bool)
+	return v
+}


### PR DESCRIPTION
## Summary

Stack overflows kept reproducing on Ctrl+C even after #2451 (pre-seed configured server entries) and #2454 (kind-check the cache). The recursion is structural to dmsgfirst: every method on \`fallbackClient\` — \`Entry\`, \`PostEntry\`, \`AvailableServers\`, \`AllServers\`, \`AllEntries\`, \`AllClientsByServer\`, \`ClientsByServer\` — calls its primary, and the primary is an \`httpClient\` backed by \`dmsghttp.HTTPTransport\` that dials over the SAME \`dmsg.Client\` whose discovery is the fallbackClient. So any of those methods, called from inside \`RoundTrip\` on the same goroutine, re-enters \`RoundTrip\` and recurses until the goroutine stack hits its limit.

#2451 only addressed the recursion path for \`getServerEntry\` (via cached configured servers) — catches the common case but not the general one (peers' delegated server PKs that aren't in our config, or \`AvailableServers\` / \`AllServers\` paths called from \`reconnectMissing\` / \`discoverServers\`). The visor still overflowed during shutdown because late-arriving streams and shutdown-time discovery calls hit those other paths.

## Fix

Context-key recursion guard:

- **\`pkg/dmsg/dmsghttp/recursion_guard.go\`** (new): \`WithRecursionGuard\` / \`IsInsideTransport\` pair, scoped to the dmsghttp package.
- **\`HTTPTransport.RoundTrip\`** wraps its request context with the guard before doing anything. Every \`DialStream\` / \`EnsureAndObtainSession\` call beneath inherits the marked context.
- **\`dmsgfirst.fallbackClient\`** checks the guard at the top of each \`APIClient\` method. When set, it skips the dmsg-primary path and serves the call through its existing HTTP fallback **for that one nested call only**. The outer caller's own DMSG-primary flow is unaffected — the guard is consumed by the inner re-entry, not the outer scope.

## On the project direction

This is consistent with \"DMSG by default, HTTP only as fallback\" — the guard does NOT make HTTP the default; it only routes the recursion-break case through the fallback that already exists. Without it, the recursion has no termination condition that doesn't blow the stack.

## Test plan

- [x] \`make lint\` clean (0 issues)
- [x] \`go build ./...\` clean
- [x] **Manual reproduction**: visor with \`is_public: true\`, GOTRACEBACK=all, captured stderr to file. Run for ~2.5min, SIGINT, wait 25s for shutdown to flush.
  - **Before this PR (develop @ a9a79065d)**: stderr ends at \`fatal error: stack overflow\` (same recursive frames as #2451's repro). Same dmsg server-PKs (\`03717576ada5b1...\`, \`0326978f...\`) churn, same crash.
  - **With this PR**: 12,706 lines of stderr, zero \`fatal error\` / \`stack overflow\` / \`goroutine stack exceeds\` markers, all 31 shutdown modules stop cleanly, last log line: \`[visor:shutdown]: Shutdown complete. Goodbye!\` with the same shutdown-time dmsg dial activity that triggered the previous overflows.
- [ ] Recommended for reviewer: similar repro on a public visor under traffic.

## Family

Continues #2443 / #2448 / #2449 / #2451 family of dmsgfirst self-recursion fixes. The pre-seed from #2451 is still useful (faster server-entry resolution, fewer disc calls in steady state); this guard catches the cases the pre-seed doesn't cover (runtime-discovered server PKs, non-Entry methods on the fallbackClient).