### PR TITLE
feat(sd,dmsgd): add CXO publishers for services + clients-by-server

### DIFF
--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
@@ -57,6 +57,7 @@ var (
 	pprofMode         string
 	pprofAddr         string
 	mode              string
+	enableCXO         bool
 )
 
 func init() {
@@ -87,6 +88,7 @@ func init() {
 	// cmd/dmsg-commands/dmsg-server/commands/start/root.go). http and
 	// dual are accepted; dmsg is rejected.
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dual (dmsg-only is rejected — dmsg-servers reach this service over HTTP)")
+	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO clients-by-server publisher feed over DMSG (requires --sk and --mode=dual)")
 }
 
 // RootCmd contains commands for dmsg-discovery
@@ -283,6 +285,22 @@ Example:
 					log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
 				}
 			}()
+
+			// CXO clients-by-server publisher: outbound feed mirroring
+			// the AllClientsByServer / ClientsByServer view. Subscribers
+			// (the hypervisor's network visualizer) connect to DMSG-D's
+			// PK on skyenv.DmsgDMSGDClientsByServerCXOPort and read
+			// JSON-encoded client entries grouped by server PK from
+			// "clients-by-server/<server>/<client>/{entry,tombstone}"
+			// instead of HTTP-polling /dmsg-discovery/servers/clients.
+			if enableCXO {
+				if pub, perr := api.StartClientsByServerCXOPublisher(dmsgDC, sk, log); perr != nil {
+					log.WithError(perr).Error("Failed to start CXO clients-by-server publisher, continuing without it")
+				} else {
+					a.SetClientsByServerCXOPublisher(pub)
+					defer pub.Close() //nolint:errcheck
+				}
+			}
 
 			// Mirror DMSG entries to Redis in DHT format. The DMSG servers'
 			// DHT nodes read from the same Redis and serve the data via

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -52,6 +52,7 @@ var (
 	pprofAddr      string
 	entryTimeout   time.Duration
 	mode           string
+	enableCXO      bool
 )
 
 // exampleJSON marshals v to indented JSON with color, returning empty string on error
@@ -133,6 +134,7 @@ func init() {
 	// or two dropped refreshes without expiring a live entry.
 	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 5*time.Minute, "client service entry TTL (0 to disable)\n\r")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
+	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO services publisher feed over DMSG (requires --sk and --mode that includes dmsg)")
 }
 
 // RootCmd contains the root service-discovery command
@@ -291,6 +293,23 @@ Example:
 		defer h.Close()
 
 		// (Visor reachability probe gate removed — see api.go.)
+
+		// CXO services publisher: outbound feed mirroring the live
+		// services state. Subscribers (the hypervisor's network
+		// visualizer + tab-specific consumers) connect to SD's PK on
+		// skyenv.DmsgSDServicesCXOPort and read the JSON-encoded
+		// service entries from "services/<type>/<pk>/{entry,tombstone}"
+		// instead of HTTP-polling /api/services?type=...
+		if enableCXO && h.DmsgClient != nil {
+			if pub, perr := api.StartServicesCXOPublisher(ctx, h.DmsgClient, sk, log); perr != nil {
+				log.WithError(perr).Error("Failed to start CXO services publisher, continuing without it")
+			} else {
+				sdAPI.SetServicesCXOPublisher(pub)
+				defer pub.Close() //nolint:errcheck
+			}
+		} else if enableCXO {
+			log.Warn("CXO requested but dmsg is not enabled (--mode=http); services publisher disabled")
+		}
 
 		// Wire DHT entry mirroring: every service registration is
 		// also published to the DHT under the visor's PK.

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -83,6 +83,13 @@ type API struct {
 	allClientsAt     time.Time
 	allClientsErr    error
 	allClientsSingle singleflight // dedupes concurrent refreshes
+
+	// cxoPublisher mirrors set/del entry events into a CXO TreeStore
+	// feed under clients-by-server/<server>/<client>/{entry,tombstone}.
+	// Set when DMSG-D is started with --cxo. Nil when the flag is off;
+	// calling sites null-check via pub == nil so the HTTP path always
+	// works regardless.
+	cxoPublisher *ClientsByServerCXOPublisher
 }
 
 // singleflight is a tiny in-place dedupe primitive. When a refresh is
@@ -165,6 +172,15 @@ func (a *API) SetDHTMirror(m interface {
 	Delete(subjectPK cipher.PubKey)
 }) {
 	a.dhtMirror = m
+}
+
+// SetClientsByServerCXOPublisher installs the CXO publisher that
+// mirrors set/del entry events into a TreeStore feed at
+// clients-by-server/<server>/<client>/{entry,tombstone}. Pass nil to
+// disable. Wired by cmd/dmsg/dmsg-discovery after the publisher is
+// built; no-op until then.
+func (a *API) SetClientsByServerCXOPublisher(p *ClientsByServerCXOPublisher) {
+	a.cxoPublisher = p
 }
 
 // BackfillDHTMirror iterates all existing entries in the store and
@@ -468,6 +484,11 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 				a.dhtMirror.Mirror(entry.Static, entry, entry.Sequence)
 			}
 
+			// CXO mirror — best-effort, no-op if --cxo wasn't set on
+			// startup. Server entries are ignored at this layer (the
+			// publisher only emits clients-by-server leaves).
+			a.cxoPublisher.PublishSetEntry(nil, entry)
+
 			// Record heartbeat for uptime tracking on new client entries.
 			if entry.Client != nil {
 				_ = a.db.RecordHeartbeat(r.Context(), entry.Static, entry.ClientType) //nolint:errcheck
@@ -497,6 +518,10 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 		if a.dhtMirror != nil {
 			a.dhtMirror.Mirror(entry.Static, entry, entry.Sequence)
 		}
+
+		// CXO mirror — diff old vs new DelegatedServers so subscribers
+		// see clean adds/removes for the (server, client) pairs.
+		a.cxoPublisher.PublishSetEntry(oldEntry, entry)
 
 		// Record heartbeat for uptime tracking on client entry updates.
 		if entry.Client != nil {
@@ -540,6 +565,17 @@ func (a *API) delEntry() func(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Capture the existing entry BEFORE deleting it so the CXO
+		// publisher knows which (server, client) pairs to tombstone.
+		// Best-effort: a fetch failure here just means we publish no
+		// CXO tombstones; the HTTP delete still proceeds.
+		var preDelEntry *disc.Entry
+		if a.cxoPublisher != nil {
+			if existing, ferr := a.db.Entry(r.Context(), entry.Static); ferr == nil {
+				preDelEntry = existing
+			}
+		}
+
 		err := a.db.DelEntry(r.Context(), entry.Static)
 
 		// If we make sure that every error is handled then we can
@@ -552,6 +588,10 @@ func (a *API) delEntry() func(w http.ResponseWriter, r *http.Request) {
 		if a.dhtMirror != nil {
 			a.dhtMirror.Delete(entry.Static)
 		}
+
+		// CXO mirror: tombstone every (server, client) pair the
+		// deleted client entry was previously delegated to.
+		a.cxoPublisher.PublishDelEntry(preDelEntry)
 
 		a.writeJSON(w, r, http.StatusOK, disc.MsgEntryDeleted)
 	}

--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -1,0 +1,240 @@
+// Package api pkg/dmsg/discovery/api/cxo_publisher.go
+//
+// CXO publisher for dmsg-discovery's "clients by server" view.
+//
+// The hypervisor's network visualizer needs to know "which clients
+// are currently delegated to each dmsg server" — the same view
+// AllClientsByServer / ClientsByServer expose over HTTP. This
+// publisher mirrors that as a TreeStore feed:
+//
+//	clients-by-server/<server-pk>/<client-pk>/entry        // JSON disc.Entry
+//	clients-by-server/<server-pk>/<client-pk>/tombstone    // JSON {"deleted_at": "..."}
+//
+// We deliberately do NOT publish a separate entries/<pk> tree (the
+// non-denormalized form) because no consumer we know of subscribes
+// to per-PK lookups; the network-visualizer pattern is always
+// server-grouped, and AllClientsByServer / ClientsByServer is what
+// the existing http path serves.
+//
+// On a client SetEntry, the publisher diffs the new DelegatedServers
+// list against the old (if any) and emits:
+//   - Put on clients-by-server/<server>/<client>/entry for every
+//     server in the new list.
+//   - Tombstone on clients-by-server/<server>/<client>/tombstone for
+//     every server that was in the old list but not the new (the
+//     client moved off that server).
+//
+// Server entries are ignored by this publisher — a server PK is the
+// path-prefix bucket, not a member of the view.
+package api
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// json is the package-scope jsoniter.ConfigFastest value declared
+// in api.go. We reuse it here to avoid pulling in encoding/json
+// (which collides with the package-scope name) and to match the
+// performance characteristics of the rest of dmsg-discovery's
+// hot path.
+var _ = json // referenced from api.go; reuse here
+
+// ClientsByServerCXOPublisher mirrors dmsg-discovery's clients-by-
+// server view into a CXO TreeStore feed. Constructed at DMSG-D
+// startup when --cxo is set; the API calls into it via
+// SetClientsByServerCXOPublisher.
+type ClientsByServerCXOPublisher struct {
+	pub *treestore.Publisher
+	log *logging.Logger
+
+	mu        sync.Mutex
+	lastError error
+}
+
+// StartClientsByServerCXOPublisher constructs the publisher backed by
+// the given dmsg client and DMSG-D secret key. The publisher's
+// allowlist is open — the underlying HTTP routes are public reads,
+// so the CXO mirror inherits that. Returns nil + error if the
+// publisher can't be created (no dmsg client, listener bind failure,
+// etc.); callers log and continue without it (HTTP path stays the
+// source of truth).
+func StartClientsByServerCXOPublisher(dmsgC *dmsg.Client, sk cipher.SecKey, logger logrus.FieldLogger) (*ClientsByServerCXOPublisher, error) {
+	log := logging.MustGetLogger("dmsgd-cxo-clients-pub")
+
+	pub, err := treestore.NewWithDMSG(dmsgC, sk, treestore.PubConfig{
+		Logger:     log,
+		InMemoryDB: true, // recomputed from redis on every mutation
+		DmsgPort:   skyenv.DmsgDMSGDClientsByServerCXOPort,
+	})
+	if err != nil {
+		return nil, err
+	}
+	pub.SetAllowlist(nil)
+
+	p := &ClientsByServerCXOPublisher{pub: pub, log: log}
+	if logger != nil {
+		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgDMSGDClientsByServerCXOPort).
+			Info("CXO clients-by-server publisher running")
+	}
+	return p, nil
+}
+
+// FeedPK returns the publisher's feed PK (DMSG-D's own PK).
+func (p *ClientsByServerCXOPublisher) FeedPK() cipher.PubKey { return p.pub.Feed() }
+
+// Close stops the publisher. Safe to call multiple times.
+func (p *ClientsByServerCXOPublisher) Close() error {
+	if p == nil || p.pub == nil {
+		return nil
+	}
+	return p.pub.Close()
+}
+
+// PublishSetEntry mirrors a set/update of a client entry. Emits Puts
+// for every server in the new DelegatedServers list and tombstones
+// for any server that dropped out (compared to old). Does nothing
+// for server entries (they're path buckets here, not members) or
+// for client entries with empty DelegatedServers (nothing to publish).
+func (p *ClientsByServerCXOPublisher) PublishSetEntry(oldEntry, newEntry *disc.Entry) {
+	if p == nil || p.pub == nil || newEntry == nil || newEntry.Client == nil {
+		return
+	}
+	clientPK := newEntry.Static
+	newServers := pkSet(newEntry.Client.DelegatedServers)
+	oldServers := map[cipher.PubKey]struct{}{}
+	if oldEntry != nil && oldEntry.Client != nil {
+		oldServers = pkSet(oldEntry.Client.DelegatedServers)
+	}
+
+	body, err := json.Marshal(newEntry)
+	if err != nil {
+		p.log.WithError(err).Debug("Failed to marshal client entry leaf")
+		p.recordError(err)
+		return
+	}
+
+	// Put / re-Put for every server in the new list. CXO is content-
+	// addressed so unchanged bytes are wire-no-ops.
+	for srv := range newServers {
+		path := entryLeafPath(srv, clientPK)
+		if err := p.pub.Put(path, body); err != nil {
+			p.log.WithError(err).WithField("path", path).Debug("Failed to publish clients-by-server entry leaf")
+			p.recordError(err)
+			continue
+		}
+		// Clear any prior tombstone for this (server, client) pair —
+		// re-delegation should leave only the live leaf.
+		if err := p.pub.Delete(tombstoneLeafPath(srv, clientPK)); err != nil {
+			p.log.WithError(err).Debug("Failed to clear prior clients-by-server tombstone")
+		}
+	}
+
+	// Tombstone every server that was in the old list but not the new.
+	now := time.Now().UTC()
+	tomb, err := json.Marshal(struct {
+		DeletedAt time.Time `json:"deleted_at"`
+	}{DeletedAt: now})
+	if err != nil {
+		p.log.WithError(err).Debug("Failed to marshal clients-by-server tombstone")
+		return
+	}
+	for srv := range oldServers {
+		if _, kept := newServers[srv]; kept {
+			continue
+		}
+		entryPath := entryLeafPath(srv, clientPK)
+		if err := p.pub.Delete(entryPath); err != nil {
+			p.log.WithError(err).WithField("path", entryPath).
+				Debug("Failed to delete dropped clients-by-server entry leaf")
+		}
+		tombPath := tombstoneLeafPath(srv, clientPK)
+		if err := p.pub.Put(tombPath, tomb); err != nil {
+			p.log.WithError(err).WithField("path", tombPath).
+				Debug("Failed to publish clients-by-server tombstone")
+			p.recordError(err)
+		}
+	}
+}
+
+// PublishDelEntry mirrors a full client-entry delete: tombstones for
+// every server the client was previously delegated to. oldEntry is
+// the entry being deleted (caller fetches it from store before the
+// DelEntry call).
+func (p *ClientsByServerCXOPublisher) PublishDelEntry(oldEntry *disc.Entry) {
+	if p == nil || p.pub == nil || oldEntry == nil || oldEntry.Client == nil {
+		return
+	}
+	clientPK := oldEntry.Static
+	servers := pkSet(oldEntry.Client.DelegatedServers)
+	if len(servers) == 0 {
+		return
+	}
+	tomb, err := json.Marshal(struct {
+		DeletedAt time.Time `json:"deleted_at"`
+	}{DeletedAt: time.Now().UTC()})
+	if err != nil {
+		p.log.WithError(err).Debug("Failed to marshal clients-by-server tombstone")
+		return
+	}
+	for srv := range servers {
+		entryPath := entryLeafPath(srv, clientPK)
+		if err := p.pub.Delete(entryPath); err != nil {
+			p.log.WithError(err).Debug("Failed to delete clients-by-server entry leaf on full delete")
+		}
+		tombPath := tombstoneLeafPath(srv, clientPK)
+		if err := p.pub.Put(tombPath, tomb); err != nil {
+			p.log.WithError(err).Debug("Failed to publish clients-by-server tombstone on full delete")
+			p.recordError(err)
+		}
+	}
+}
+
+func (p *ClientsByServerCXOPublisher) recordError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastError = err
+}
+
+// LastError returns the most recent publish error, or nil.
+func (p *ClientsByServerCXOPublisher) LastError() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastError
+}
+
+// EntryLeafPath / TombstoneLeafPath are exported so subscribers can
+// reconstruct paths without duplicating the format string.
+func EntryLeafPath(serverPK, clientPK cipher.PubKey) string {
+	return entryLeafPath(serverPK, clientPK)
+}
+func TombstoneLeafPath(serverPK, clientPK cipher.PubKey) string {
+	return tombstoneLeafPath(serverPK, clientPK)
+}
+
+func entryLeafPath(serverPK, clientPK cipher.PubKey) string {
+	return fmt.Sprintf("clients-by-server/%s/%s/entry", serverPK.Hex(), clientPK.Hex())
+}
+func tombstoneLeafPath(serverPK, clientPK cipher.PubKey) string {
+	return fmt.Sprintf("clients-by-server/%s/%s/tombstone", serverPK.Hex(), clientPK.Hex())
+}
+
+// pkSet builds a set-of-PK from a slice; small helper to avoid
+// repeated O(N²) membership tests in the diff loops above.
+func pkSet(pks []cipher.PubKey) map[cipher.PubKey]struct{} {
+	out := make(map[cipher.PubKey]struct{}, len(pks))
+	for _, pk := range pks {
+		out[pk] = struct{}{}
+	}
+	return out
+}

--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -91,6 +91,12 @@ type API struct {
 		Mirror(subjectPK cipher.PubKey, entry interface{}, seq uint64)
 		Delete(subjectPK cipher.PubKey)
 	}
+
+	// cxoPublisher mirrors register / deregister events into a CXO
+	// TreeStore feed, set when SD is started with --cxo. Nil when the
+	// flag is off; the calling sites null-check via pub == nil so the
+	// HTTP path always works regardless.
+	cxoPublisher *ServicesCXOPublisher
 }
 
 // SetDHTMirror sets a mirror that publishes per-visor service lists to
@@ -100,6 +106,14 @@ func (a *API) SetDHTMirror(m interface {
 	Delete(subjectPK cipher.PubKey)
 }) {
 	a.dhtMirror = m
+}
+
+// SetServicesCXOPublisher installs the CXO publisher that mirrors
+// register / deregister events into a TreeStore feed. Pass nil to
+// disable. Wired by cmd/svc/service-discovery/commands/root.go after
+// the publisher is built; no-op until then.
+func (a *API) SetServicesCXOPublisher(p *ServicesCXOPublisher) {
+	a.cxoPublisher = p
 }
 
 // mirrorVisorServices re-publishes the current full list of services
@@ -443,6 +457,8 @@ func (a *API) postEntry(w http.ResponseWriter, r *http.Request) {
 	// Mirror the visor's FULL service list (not just this new entry) so
 	// the DHT target holds the same set as HTTP discovery for this PK.
 	a.mirrorVisorServices(r.Context(), se.Addr.PubKey())
+	// CXO mirror — best-effort, no-op if --cxo wasn't set on startup.
+	a.cxoPublisher.PutEntry(&se)
 
 	httputil.WriteJSON(w, r, http.StatusOK, &se)
 }
@@ -476,6 +492,7 @@ func (a *API) delEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	a.mirrorVisorServices(r.Context(), serviceAddr.PubKey())
+	a.cxoPublisher.DelEntry(sType, serviceAddr.PubKey())
 	httputil.WriteJSON(w, r, http.StatusOK, true)
 }
 
@@ -552,6 +569,7 @@ func (a *API) deregisterEntry(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		a.mirrorVisorServices(r.Context(), key)
+		a.cxoPublisher.DelEntry(sType, key)
 	}
 	a.log.WithFields(logrus.Fields{"Number of Keys": len(keys), "Keys": keys, "Type": sType}).Info("Deregistration process completed.")
 	a.writeJSON(w, r, http.StatusOK, true)

--- a/pkg/service-discovery/api/cxo_publisher.go
+++ b/pkg/service-discovery/api/cxo_publisher.go
@@ -1,0 +1,172 @@
+// Package api pkg/service-discovery/api/cxo_publisher.go
+//
+// CXO publisher for service-discovery's services tree.
+//
+// Subscribers (the hypervisor's network visualizer + tab-specific
+// consumers) read the live set of registered services from a single
+// TreeStore feed instead of polling /api/services?type=... over HTTP.
+// Tree shape:
+//
+//	services/<type>/<pk>/entry        // JSON-encoded servicedisc.Service
+//	services/<type>/<pk>/tombstone    // JSON {"deleted_at": "..."}
+//
+// Type-as-prefix lets a consumer that only cares about one service
+// kind (e.g. just VPN) subscribe to services/vpn/ and skip the rest.
+//
+// Event-driven: register/update calls Put on success; explicit
+// deregister calls Delete (and Put on the tombstone leaf); expiry
+// sweep emits tombstones for entries the redis cleanup found stale.
+// CXO content-addresses, so re-publishing an unchanged entry is a
+// no-op at the wire layer — heartbeats from a still-alive service
+// don't burn bandwidth.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/servicedisc"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// ServicesCXOPublisher mirrors SD's services state into a CXO
+// TreeStore feed. Constructed at SD startup when --cxo is set; the
+// API calls into it via SetServicesCXOPublisher.
+type ServicesCXOPublisher struct {
+	pub *treestore.Publisher
+	log *logging.Logger
+
+	mu        sync.Mutex
+	lastError error
+}
+
+// StartServicesCXOPublisher constructs a publisher backed by the
+// given DMSG client and SD secret key. The publisher's allowlist is
+// open — the underlying SD HTTP routes are public reads, so the CXO
+// mirror inherits that. Returns nil + error if the publisher can't be
+// created (no dmsg client, listener bind failure, etc.); callers log
+// and continue without it (the HTTP path remains the source of truth).
+func StartServicesCXOPublisher(_ context.Context, dmsgC *dmsg.Client, sk cipher.SecKey, logger logrus.FieldLogger) (*ServicesCXOPublisher, error) {
+	log := logging.MustGetLogger("sd-cxo-services-pub")
+
+	pub, err := treestore.NewWithDMSG(dmsgC, sk, treestore.PubConfig{
+		Logger:     log,
+		InMemoryDB: true, // services are always recomputed from redis on next mutation/sweep
+		DmsgPort:   skyenv.DmsgSDServicesCXOPort,
+	})
+	if err != nil {
+		return nil, err
+	}
+	pub.SetAllowlist(nil)
+
+	p := &ServicesCXOPublisher{pub: pub, log: log}
+	if logger != nil {
+		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgSDServicesCXOPort).
+			Info("CXO services publisher running")
+	}
+	return p, nil
+}
+
+// FeedPK returns the publisher's feed PK (SD's own PK, since the
+// publisher was constructed with SD's secret key). Subscribers
+// connect to this PK on skyenv.DmsgSDServicesCXOPort.
+func (p *ServicesCXOPublisher) FeedPK() cipher.PubKey { return p.pub.Feed() }
+
+// Close stops the publisher. Safe to call multiple times.
+func (p *ServicesCXOPublisher) Close() error {
+	if p == nil || p.pub == nil {
+		return nil
+	}
+	return p.pub.Close()
+}
+
+// PutEntry mirrors a service register/update. Idempotent: identical
+// bytes are a no-op at the wire layer. Best-effort; logs at debug
+// on failure (HTTP path is authoritative).
+func (p *ServicesCXOPublisher) PutEntry(svc *servicedisc.Service) {
+	if p == nil || p.pub == nil || svc == nil {
+		return
+	}
+	if svc.Type == "" {
+		return
+	}
+	body, err := json.Marshal(svc)
+	if err != nil {
+		p.log.WithError(err).Debug("Failed to marshal service entry leaf")
+		p.recordError(err)
+		return
+	}
+	path := entryPath(svc.Type, svc.Addr.PubKey())
+	if err := p.pub.Put(path, body); err != nil {
+		p.log.WithError(err).WithField("path", path).Debug("Failed to publish service entry leaf")
+		p.recordError(err)
+		// Also clear any stale tombstone so subscribers don't see
+		// a dead-then-alive flap. Best-effort.
+		_ = p.pub.Delete(tombstonePath(svc.Type, svc.Addr.PubKey())) //nolint:errcheck
+		return
+	}
+	// Drop any existing tombstone for the same key — re-registration
+	// after expiry should leave only the live entry leaf.
+	if err := p.pub.Delete(tombstonePath(svc.Type, svc.Addr.PubKey())); err != nil {
+		p.log.WithError(err).Debug("Failed to clear stale services tombstone")
+	}
+}
+
+// DelEntry mirrors a service deregister or expiry. Removes the entry
+// leaf and writes a tombstone leaf so subscribers see the deletion.
+// Best-effort.
+func (p *ServicesCXOPublisher) DelEntry(svcType string, pk cipher.PubKey) {
+	if p == nil || p.pub == nil || svcType == "" {
+		return
+	}
+	if err := p.pub.Delete(entryPath(svcType, pk)); err != nil {
+		p.log.WithError(err).WithField("type", svcType).Debug("Failed to delete service entry leaf")
+		p.recordError(err)
+	}
+	body, err := json.Marshal(struct {
+		DeletedAt time.Time `json:"deleted_at"`
+	}{DeletedAt: time.Now().UTC()})
+	if err != nil {
+		p.log.WithError(err).Debug("Failed to marshal services tombstone")
+		return
+	}
+	if err := p.pub.Put(tombstonePath(svcType, pk), body); err != nil {
+		p.log.WithError(err).WithField("type", svcType).Debug("Failed to publish services tombstone")
+		p.recordError(err)
+	}
+}
+
+func (p *ServicesCXOPublisher) recordError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastError = err
+}
+
+// LastError returns the most recent publish error, or nil. Exposed
+// for /health-style introspection.
+func (p *ServicesCXOPublisher) LastError() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastError
+}
+
+// EntryPath / TombstonePath are exported so subscribers can construct
+// the same leaf paths without duplicating the format string.
+func EntryPath(svcType string, pk cipher.PubKey) string     { return entryPath(svcType, pk) }
+func TombstonePath(svcType string, pk cipher.PubKey) string { return tombstonePath(svcType, pk) }
+
+func entryPath(svcType string, pk cipher.PubKey) string {
+	return fmt.Sprintf("services/%s/%s/entry", svcType, pk.Hex())
+}
+func tombstonePath(svcType string, pk cipher.PubKey) string {
+	return fmt.Sprintf("services/%s/%s/tombstone", svcType, pk.Hex())
+}

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -60,6 +60,22 @@ const (
 	// can pick exactly the feed it wants without dragging in metrics.
 	DmsgTPDUptimeCXOPort uint16 = 52
 
+	// DmsgSDServicesCXOPort is the DMSG port the service-discovery's
+	// CXO services publisher listens on. Subscribers (the hypervisor's
+	// network visualizer + tab-specific consumers) dial this port to
+	// receive incremental service register/deregister events at
+	// services/<type>/<pk>/{entry,tombstone}.
+	DmsgSDServicesCXOPort uint16 = 53
+
+	// DmsgDMSGDClientsByServerCXOPort is the DMSG port the
+	// dmsg-discovery's CXO clients-by-server publisher listens on.
+	// Subscribers dial it to receive the denormalized clients-by-server
+	// index at clients-by-server/<server-pk>/<client-pk>/{entry,tombstone}
+	// — the shape the network visualizer's "who's on each dmsg server"
+	// view consumes. Distinct port from DmsgSDServicesCXOPort so
+	// consumers can subscribe to one feed without the other.
+	DmsgDMSGDClientsByServerCXOPort uint16 = 54
+
 	// DmsgDHTPort Listening port for the Kademlia DHT protocol.
 	DmsgDHTPort uint16 = 100
 


### PR DESCRIPTION
## Summary

Two new outbound CXO TreeStore feeds, both gated behind a new \`--cxo\` flag. Off by default. Behavior-preserving: services run identically when the flag isn't set; consumers (the hypervisor's network visualizer + metrics-tab CXO subscriber) will land as a follow-up PR. The publishers are inert until then — they listen on their dmsg port, nobody connects, and the existing HTTP paths remain authoritative.

## Service discovery: \`services/\`

New file: \`pkg/service-discovery/api/cxo_publisher.go\`. Tree shape:

\`\`\`
services/<type>/<pk>/entry         # JSON servicedisc.Service
services/<type>/<pk>/tombstone     # JSON {\"deleted_at\": \"...\"}
\`\`\`

Type-as-prefix lets a consumer that only cares about one service kind (VPN-only, proxy-only) subscribe to \`services/vpn/\` and skip the rest. The network visualizer subscribes to all of \`services/\`.

Hooked into the existing register / deregister mutation paths in \`api.go\`:
- \`UpdateServiceAndHeartbeat\` success → \`PutEntry\`
- \`DeleteService\` success in \`delEntry\` and \`deregisterEntry\` → \`DelEntry\`

CXO is content-addressed, so heartbeat re-registers of an unchanged service are a wire no-op.

## DMSG discovery: \`clients-by-server/\`

New file: \`pkg/dmsg/discovery/api/cxo_publisher.go\`. Tree shape:

\`\`\`
clients-by-server/<server-pk>/<client-pk>/entry         # JSON disc.Entry
clients-by-server/<server-pk>/<client-pk>/tombstone     # JSON {\"deleted_at\": \"...\"}
\`\`\`

Denormalized index of \"which clients are delegated to each dmsg server\" — same shape \`AllClientsByServer\` / \`ClientsByServer\` expose over HTTP, which is what the network visualizer consumes. Deliberately no separate \`entries/<pk>/\` tree (the non-denormalized form) because no consumer needs per-PK lookups; the visualizer pattern is always server-grouped.

Hooked into \`setEntry\` / \`delEntry\`:
- On \`SetEntry\`: diff old vs new \`DelegatedServers\` → \`Put\`s for new servers + tombstones for servers the client moved off of.
- On \`DelEntry\`: tombstone every server the client was previously delegated to.

Server entries are ignored at this layer (a server PK is a path bucket here, not a member).

## CLI flags + ports

- New \`--cxo\` on both \`skywire svc service-discovery\` and \`skywire dmsg-discovery\`. Off by default. Requires \`--sk\` and a dmsg-capable \`--mode\`.
- New constants in \`pkg/skyenv/skyenv.go\`:
  - \`DmsgSDServicesCXOPort = 53\`
  - \`DmsgDMSGDClientsByServerCXOPort = 54\`
  Distinct from \`DmsgTPDMetricsCXOPort\` / \`DmsgTPDUptimeCXOPort\` so consumers can subscribe to one feed without dragging in others.

## What's NOT in this PR

The hypervisor-side on-demand subscription manager and the tpviz cutover that consumes these feeds. Both come in a follow-up PR (\`feat/tpviz-cxo-on-demand\` continues). That PR will also add the \`hypervisor.cxo_subscribe_interval\` config knob (default 5m), the 10s tab-close grace period, and remove the auto-refresh ticker in \`pkg/tpviz\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [ ] Run SD with \`--cxo --sk <key> --mode dual\`: verify \`CXO services publisher running\` log line; verify register / deregister mutation paths trigger publish (visible in cxo treestore log).
- [ ] Run DMSG-D with \`--cxo --sk <key> --mode dual\`: verify \`CXO clients-by-server publisher running\` log line; verify a visor's \`SetEntry\` triggers \`PutEntry\` for each delegated server.
- [ ] Existing HTTP routes unaffected with or without \`--cxo\` — same payload, same status codes.