### PR TITLE
feat(tpviz): cut /api/services over to CXO subscriber with HTTP fallback

### DIFF
--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -1,0 +1,140 @@
+// Package tpviz pkg/tpviz/cxo_subscriber.go
+//
+// Optional integration with the visor's on-demand CXO subscription
+// manager. When the hypervisor wires one in via SetCXOSubMgr,
+// /api/services and /api/dmsg/entries try the manager's local
+// snapshot first and fall through to the existing HTTP fetcher on
+// cache miss. AcquireFor / ReleaseFor on each request scopes the
+// underlying CXO subscription to active UI traffic (with the
+// manager's own 10s grace handling multi-fetch tab loads).
+//
+// Tab and feed identifiers are int constants here that mirror the
+// values defined on the visor side (CXOTab / CXOFeed). The
+// hypervisor's wiring is responsible for matching them; this is a
+// minimal compromise to keep tpviz independent of pkg/visor (which
+// would create an import cycle).
+package tpviz
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/servicedisc"
+)
+
+// Tab identifiers used in calls to CXOSubMgr.AcquireForTab /
+// ReleaseForTab. Values match pkg/visor.CXOTab; the hypervisor
+// adapter passes them through unchanged.
+const (
+	CXOTabNetworkVisualizer = 0
+)
+
+// Feed identifiers used in calls to CXOSubMgr.Walk. Values match
+// pkg/visor.CXOFeed; the hypervisor adapter passes them through.
+const (
+	CXOFeedSDServices           = 2 // services/<type>/<pk>/{entry,tombstone}
+	CXOFeedDMSGDClientsByServer = 3 // clients-by-server/<server>/<client>/{entry,tombstone}
+)
+
+// CXOSubMgr is the minimal slice of pkg/visor.CXOSubscriptionManager
+// tpviz needs. Defined as an interface so tpviz can be built and
+// tested without importing pkg/visor (which would close an import
+// cycle: visor → tpviz → visor). The hypervisor wires a thin
+// adapter in pkg/visor/hypervisor.go.
+type CXOSubMgr interface {
+	AcquireForTab(tab int)
+	ReleaseForTab(tab int)
+	Walk(feed int, prefix string, fn func(path string, body []byte) bool) bool
+}
+
+// SetCXOSubMgr installs (or replaces, with nil to clear) the CXO
+// subscription manager. Idempotent. Safe to call before or after
+// the server is serving.
+func (s *Server) SetCXOSubMgr(m CXOSubMgr) {
+	s.cxoSubMu.Lock()
+	defer s.cxoSubMu.Unlock()
+	s.cxoSubMgr = m
+}
+
+// cxoMgr returns the currently installed manager, or nil when none.
+// Hot-path read; takes the read lock so concurrent SetCXOSubMgr
+// (rare — only at startup) doesn't race.
+func (s *Server) cxoMgr() CXOSubMgr {
+	s.cxoSubMu.RLock()
+	defer s.cxoSubMu.RUnlock()
+	return s.cxoSubMgr
+}
+
+// tryCXOServices walks the SD services subscriber tree and builds
+// the same map[pk]ServiceInfo that handleServices' HTTP path
+// constructs. Returns ok=false when the manager isn't installed,
+// the feed isn't subscribed (no AcquireFor live, or dial failed),
+// or the subscriber hasn't received any leaves yet — in any of
+// those cases the caller falls through to its existing HTTP
+// fetcher.
+//
+// The walk reconstructs the per-type service grouping that the
+// HTTP path gets from servicedisc's per-type query: the leaf path
+// is services/<type>/<pk>/entry, the body is the JSON-encoded
+// servicedisc.Service. We pluck <type> off the path (cheap) so we
+// don't have to re-parse it from the body.
+func (s *Server) tryCXOServices() (map[string]ServiceInfo, bool) {
+	mgr := s.cxoMgr()
+	if mgr == nil {
+		return nil, false
+	}
+	services := make(map[string]ServiceInfo)
+	any := false
+	ok := mgr.Walk(CXOFeedSDServices, "services/", func(path string, body []byte) bool {
+		// Skip tombstones; we only want live entries.
+		if !strings.HasSuffix(path, "/entry") {
+			return true
+		}
+		// path = services/<type>/<pk>/entry
+		parts := strings.Split(path, "/")
+		if len(parts) != 4 {
+			return true
+		}
+		svcType := parts[1]
+		pk := parts[2]
+
+		// Body is a servicedisc.Service. We want the geo country
+		// for the IP-grouping overlay; the address we already
+		// have from the path.
+		var svc servicedisc.Service
+		if err := json.Unmarshal(body, &svc); err != nil {
+			return true
+		}
+
+		any = true
+		if info, exists := services[pk]; exists {
+			info.Services = append(info.Services, svcType)
+			if info.Country == "" && svc.Geo != nil && svc.Geo.Country != "" {
+				info.Country = svc.Geo.Country
+			}
+			services[pk] = info
+			return true
+		}
+		country := ""
+		if svc.Geo != nil {
+			country = svc.Geo.Country
+		}
+		services[pk] = ServiceInfo{
+			PK:       pk,
+			Services: []string{svcType},
+			Country:  country,
+		}
+		return true
+	})
+	if !ok || !any {
+		return nil, false
+	}
+	return services, true
+}
+
+// (DMSG-D clients-by-server consumer — future PR. The publisher tree
+// lives at clients-by-server/<server>/<client>/{entry,tombstone}; a
+// helper that walks it and produces map[serverPK][]clientPK can be
+// added next to tryCXOServices once a tpviz handler needs it.
+// CXOFeedDMSGDClientsByServer is reserved here for that consumer.)
+var _ = CXOFeedDMSGDClientsByServer // silence unused-const linter

--- a/pkg/tpviz/tpviz.go
+++ b/pkg/tpviz/tpviz.go
@@ -266,6 +266,16 @@ type Server struct {
 	tpsMu  sync.RWMutex
 	tpsAPI TPSAPI
 
+	// On-demand CXO subscription manager (optional). When set, the
+	// /api/services and /api/dmsg/entries handlers try the CXO
+	// subscriber tree first and fall through to the HTTP path on
+	// cache miss. AcquireFor / ReleaseFor on every request scopes
+	// the subscription to actual UI activity — its 10s grace
+	// smooths over multi-fetch tab opens. Wired from the hypervisor
+	// via SetCXOSubMgr.
+	cxoSubMu  sync.RWMutex
+	cxoSubMgr CXOSubMgr
+
 	// DMSG discovery cache
 	dmsgMu    sync.RWMutex
 	dmsgCache *DMSGData
@@ -618,6 +628,26 @@ func (s *Server) handleUptimes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
+	// CXO-first: when a subscription manager is wired in, acquire the
+	// network-visualizer feed bundle for the duration of this request
+	// (the manager's grace period batches multi-fetch tab loads). If
+	// the SD feed has any leaves cached, serve from there. Otherwise
+	// fall through to the SD-cache file path / live HTTP fetch below.
+	if mgr := s.cxoMgr(); mgr != nil {
+		mgr.AcquireForTab(CXOTabNetworkVisualizer)
+		defer mgr.ReleaseForTab(CXOTabNetworkVisualizer)
+		if services, ok := s.tryCXOServices(); ok {
+			result, mErr := json.Marshal(services)
+			if mErr == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+				w.Header().Set("X-Skywire-Source", "cxo")
+				w.Write(result) //nolint:errcheck,gosec
+				return
+			}
+		}
+	}
+
 	// Try to use cached SD data first
 	if s.config.CacheDirSD != "" && !s.config.NoCache {
 		data, err := s.getSDData()

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -235,6 +235,29 @@ func (m *CXOSubscriptionManager) Get(feed CXOFeed, path string) ([]byte, time.Ti
 	return body, ts, true
 }
 
+// Walk iterates every (path, body) pair under the given prefix on
+// the named feed's active subscriber, calling fn for each leaf.
+// Returns ok=false when the feed isn't currently subscribed (no
+// AcquireFor live, or the dial failed). Walk does NOT block waiting
+// for the first Root — use it after a Get of any specific path
+// returns ok or when handlers are happy with "best effort, fall
+// through to HTTP on empty."
+func (m *CXOSubscriptionManager) Walk(feed CXOFeed, prefix string, fn func(path string, body []byte) bool) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	if !ok || f == nil || f.sub == nil {
+		m.mu.Unlock()
+		return false
+	}
+	sub := f.sub
+	m.mu.Unlock()
+	sub.Walk(prefix, fn)
+	return true
+}
+
 // Close tears down every active subscription. Called from the
 // visor's shutdown sequence.
 func (m *CXOSubscriptionManager) Close() {

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -127,6 +127,13 @@ func NewHypervisor(config visorconfig.HypervisorConfig, visor *Visor, dmsgC *dms
 		hv.tpvizServer = tpviz.NewServer(tpvizCfg)
 		adapter := &visorAPIAdapter{v: visor}
 		hv.tpvizServer.SetVisorAPI(adapter, visor.conf.PK.Hex())
+		// Wire the on-demand CXO subscription manager so /api/services
+		// (and future per-feed handlers) can serve from the local SD /
+		// DMSG-D subscriber tree when --cxo is enabled on those
+		// services. cxoSubMgrAdapter forwards int tab/feed identifiers
+		// from tpviz to the typed CXOTab / CXOFeed values used by the
+		// manager — values match across both sides by construction.
+		hv.tpvizServer.SetCXOSubMgr(&cxoSubMgrAdapter{v: visor})
 		hv.tpvizServer.Start()
 	}
 

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -1154,6 +1154,31 @@ func (a *tpsAPIAdapter) PK() string {
 	return tps.pk.String()
 }
 
+// cxoSubMgrAdapter wires the visor's on-demand CXO subscription
+// manager into tpviz's narrow CXOSubMgr interface. Tpviz uses int
+// for tab/feed identifiers to keep its API decoupled from
+// pkg/visor (which would close an import cycle). The values match
+// CXOTab / CXOFeed by construction; the cast is safe.
+type cxoSubMgrAdapter struct{ v *Visor }
+
+// AcquireForTab forwards to the visor's lazily-constructed manager.
+// A nil manager (visor has no DMSG client yet) is a no-op — the
+// caller's CXO-first path naturally falls through to its HTTP
+// fallback on a subsequent Walk that returns ok=false.
+func (a *cxoSubMgrAdapter) AcquireForTab(tab int) {
+	a.v.CXOSubMgr().AcquireFor(CXOTab(tab))
+}
+
+// ReleaseForTab forwards to the manager. No-op on nil.
+func (a *cxoSubMgrAdapter) ReleaseForTab(tab int) {
+	a.v.CXOSubMgr().ReleaseFor(CXOTab(tab))
+}
+
+// Walk forwards to the manager.
+func (a *cxoSubMgrAdapter) Walk(feed int, prefix string, fn func(path string, body []byte) bool) bool {
+	return a.v.CXOSubMgr().Walk(CXOFeed(feed), prefix, fn)
+}
+
 func initUIServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// Check if UI server is configured and enabled
 	if v.conf.UIServer == nil || !v.conf.UIServer.Enable {


### PR DESCRIPTION
## Summary

Wires tpviz to the on-demand CXO subscription manager from #2457. \`/api/services\` now serves from the SD services subscriber tree (populated by SD running with \`--cxo\`, #2456) when one's available; existing http/dmsghttp + cache-file paths remain as the fallback when the manager is absent or the subscriber's local snapshot is empty.

## Tpviz changes

- **New file \`pkg/tpviz/cxo_subscriber.go\`**:
  - \`CXOSubMgr\` interface (minimal: \`AcquireForTab\`, \`ReleaseForTab\`, \`Walk\`) so tpviz can be built independent of \`pkg/visor\` (which would create an import cycle).
  - \`SetCXOSubMgr\` setter + \`cxoMgr()\` hot-path read.
  - \`tryCXOServices()\` walks \`services/<type>/<pk>/entry\` leaves and rebuilds the \`map[pk]ServiceInfo\` shape \`handleServices\` used to construct from three SD HTTP fetches.
  - Tab/feed identifier constants (int) that match pkg/visor's \`CXOTab\` / \`CXOFeed\` by construction; the hypervisor adapter forwards them through unchanged.
- **\`handleServices\`**: when a manager is wired in, \`AcquireForTab\` on enter, \`ReleaseForTab\` on exit (defer), and try CXO first. The Walk + reconstruct path emits an \`X-Skywire-Source: cxo\` header so ops can tell which path served. Cache-miss / no-manager falls through to the existing SD-cache file → HTTP fetch chain.

## Visor changes

- New \`CXOSubscriptionManager.Walk(feed, prefix, fn)\` — exposes \`treestore.Subscriber.Walk\` through the manager so consumers can enumerate leaves under a prefix without direct subscriber access.
- New \`cxoSubMgrAdapter\` in \`pkg/visor/init_services.go\` wires the manager into tpviz via the int-typed \`CXOSubMgr\` interface; cast is safe because the consts are aligned. Adapter's \`Acquire\` / \`Release\` / \`Walk\` all forward to \`v.CXOSubMgr()\` (lazily-constructed), which is nil-safe so a not-yet-ready visor is a no-op.
- \`pkg/visor/hypervisor.go\`'s tpviz construction now calls \`SetCXOSubMgr\` alongside the existing \`SetVisorAPI\`.

## What's NOT in this PR

- \`/api/dmsg/entries\` (DMSG-D \`/servers/clients\`) — the publisher tree is in place from #2456 but the helper / handler hookup is the next chunk. \`CXOFeedDMSGDClientsByServer\` is reserved with a placeholder so the constant doesn't bit-rot.
- The auto-refresh ticker in \`pkg/tpviz\` is unchanged. With only \`/api/services\` on the CXO path it'd still poll for the other data sources, so no traffic is saved by removing it yet. The remaining \`/api/transports\` (TPD \`/all-transports\`) and \`/api/uptimes\` (UT v2) need their own publishers before the ticker can be retired entirely.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [ ] Run a deployment with #2456 + #2457 plus \`--cxo\` on SD; open the network visualizer; \`curl http://127.0.0.1:8000/tp-viz/api/services -i\` should return \`X-Skywire-Source: cxo\` after the manager has subscribed and received the first Root.
- [ ] Without SD's \`--cxo\` set (or with the manager not wired): \`/api/services\` falls through to its existing path and serves identical JSON shape (no header).
- [ ] AcquireFor / ReleaseFor scoping: a single GET fires Acquire then Release immediately on response. Burst of GETs over a few seconds reuses the open subscription thanks to the manager's 10s grace; idle visualizer (tab closed) tears down the subscription after grace.

## Sequence

- ✅ #2456 — SD + DMSG-D CXO publishers (merged)
- ✅ #2457 — On-demand CXO subscription manager + config field (merged)
- ⬅ This PR — \`/api/services\` cutover via the manager
- ⏭ Future — \`/api/dmsg/entries\` cutover, then publishers for TPD \`/all-transports\` + UT v2 + remaining DMSG-D feeds, then ticker removal