### PR TITLE
refactor(visor): cycle-based CXO sync — subscribe → snapshot → unsubscribe

### DIFF
--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -1,38 +1,36 @@
 // Package visor pkg/visor/cxo_subscription_manager.go
 //
-// On-demand CXO subscription manager for hypervisor UI tabs.
+// Cycle-based on-demand CXO sync manager.
 //
-// The hypervisor's network visualizer and metrics tabs source their
-// data from CXO publisher feeds (TPD's transport metrics + uptime,
-// SD's services tree, DMSG-D's clients-by-server tree). Keeping
-// long-lived subscriptions to all four feeds when nobody is looking
-// at the UI is wasteful — DMSG sessions stay open, the publishers
-// keep pushing Root updates, the visor keeps receiving and ignoring
-// them. Operators reasonably expect "no UI open == no traffic."
+// The hypervisor's network visualizer / metrics tabs and the visor's
+// own autoconnect / CLI listing commands all want a recent snapshot
+// of network-wide state from one of the deployment-side CXO
+// publishers (TPD's metrics + uptime aggregates, SD's services tree,
+// DMSG-D's clients-by-server tree). Keeping a long-lived subscription
+// alive is wasteful — most of those updates are noise to a UI that
+// might be open for a few seconds at a time, and a subscription that
+// was open across a publisher restart goes silently stale because
+// `treestore.Subscriber.Connect` is one-shot with no built-in
+// reconnect.
 //
-// This manager wraps a per-feed CXO subscriber with refcount +
-// grace-period semantics:
+// This manager runs each feed as a periodic *cycle*:
 //
-//   - AcquireFor(tab) — UI tab is opening; bumps refcount on every
-//     feed that tab depends on. Subscribes to feeds that aren't yet
-//     active.
-//   - ReleaseFor(tab) — UI tab is closing; drops refcount. When a
-//     feed's refcount falls to zero, the subscription is scheduled
-//     for close after a short grace period (default 10s) — long
-//     enough that a navigation flicker doesn't tear-down + re-dial.
-//   - Get(feed, path) — handler reads the latest cached value from
-//     the active subscriber, or "not ready" if no acquire is live.
+//	subscribe → wait for first Root → walk into local snapshot
+//	→ unsubscribe → sleep `interval` → repeat
 //
-// `hypervisor.cxo_subscribe_interval` (default 5m) is the re-sync
-// minimum: subscriptions stay open while a tab is acquired, and the
-// publisher's own tick rate (~60s for metrics/uptime) drives the
-// data freshness inside that window. The interval matters when tabs
-// open/close repeatedly: we won't tear down a feed sooner than that
-// after its last release, so a fast re-acquire reuses the live
-// subscription.
+// Cycles only run while at least one consumer holds the feed via
+// AcquireFor. When the last release happens the cycle stops on the
+// next interval boundary (with a small grace), so a fast acquire-
+// release-acquire reuses the running cycle without re-dialing.
+//
+// Get / Walk read the *snapshot*, not a live subscriber — so the
+// data they see is always at most `interval`-old, never tied to a
+// dmsg session that may have died. A publisher restart self-heals
+// on the next sync because each cycle dials fresh.
 package visor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -45,93 +43,103 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
-// CXOFeed identifies one upstream CXO publisher feed the manager
-// can subscribe to. Adding a new feed means: add a const here, a
-// case in feedSpec, and a tab → feeds dependency entry below.
+// CXOFeed identifies one upstream CXO publisher feed the manager can
+// sync from. Adding a new feed means: add a const here, a case in
+// feedSpec, and a tab → feeds dependency entry below.
 type CXOFeed int
 
 const (
-	// FeedTPDMetrics is TPD's metrics-aggregate publisher, paths
-	// metrics/days/<n>. Drives the network-wide transport view.
+	// FeedTPDMetrics is TPD's metrics-aggregate publisher
+	// (metrics/days/<n>).
 	FeedTPDMetrics CXOFeed = iota
-	// FeedTPDUptime is TPD's uptime-aggregate publisher, paths
-	// uptimes/days/<n>. Drives the network-wide visor-uptime view.
+	// FeedTPDUptime is TPD's uptime-aggregate publisher
+	// (uptimes/days/<n>).
 	FeedTPDUptime
-	// FeedSDServices is SD's services publisher, paths
-	// services/<type>/<pk>/{entry,tombstone}. Drives the network
-	// visualizer's "which visors run which services" overlay.
+	// FeedSDServices is SD's services publisher
+	// (services/<type>/<pk>/{entry,tombstone}).
 	FeedSDServices
-	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server
-	// publisher, paths clients-by-server/<server>/<client>/...
-	// Drives the network visualizer's "who's on each dmsg server"
-	// overlay.
+	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server publisher
+	// (clients-by-server/<server>/<client>/{entry,tombstone}).
 	FeedDMSGDClientsByServer
 )
 
-// CXOTab identifies a hypervisor UI tab whose data sourcing is
-// managed by this manager.
+// CXOTab identifies a consumer of one or more CXO feeds. Tabs in the
+// hypervisor UI map onto tabs here directly; non-UI consumers
+// (autoconnect, CLI commands) get their own tab kinds.
 type CXOTab int
 
 const (
-	// TabNetworkVisualizer is the network visualizer tab — needs
-	// SD services + DMSG-D clients-by-server + TPD metrics for
-	// the transport graph.
+	// TabNetworkVisualizer is the network visualizer tab — needs SD
+	// services + DMSG-D clients-by-server + TPD metrics.
 	TabNetworkVisualizer CXOTab = iota
-	// TabMetrics is the network metrics tab — needs TPD metrics +
-	// TPD uptime aggregates.
+	// TabMetrics is the metrics tab — TPD metrics + TPD uptime.
 	TabMetrics
-	// TabUptime is the network uptime tab — needs TPD uptime only.
+	// TabUptime is the network uptime tab — TPD uptime only.
 	TabUptime
+	// TabAutoconnect is the visor's public-visor autoconnect cycle —
+	// SD services only (filters down to the visor type at walk time).
+	TabAutoconnect
 )
 
 // tabFeedDeps maps each tab to the set of feeds it depends on.
-// AcquireFor / ReleaseFor walks this list; a feed shared between
-// tabs has its refcount summed across them.
+// Acquire / Release walks this list; a feed shared between tabs has
+// its refcount summed across them.
 var tabFeedDeps = map[CXOTab][]CXOFeed{
 	TabNetworkVisualizer: {FeedSDServices, FeedDMSGDClientsByServer, FeedTPDMetrics},
 	TabMetrics:           {FeedTPDMetrics, FeedTPDUptime},
 	TabUptime:            {FeedTPDUptime},
+	TabAutoconnect:       {FeedSDServices},
 }
 
-// CXOSubscriptionManager owns the lifecycle of per-feed CXO
-// subscribers and the refcount/grace logic that decides when to
-// open / close them. Constructed by initCXOSubscriptionManager()
-// and stored on the Visor.
+// CXOSubscriptionManager owns the per-feed cycle goroutines + the
+// in-memory snapshots they populate. Constructed lazily by
+// Visor.CXOSubMgr() on first use.
 type CXOSubscriptionManager struct {
 	v        *Visor
 	log      *logging.Logger
-	interval time.Duration // hypervisor.cxo_subscribe_interval (resync floor)
-	grace    time.Duration // tab-close grace before actual close
+	interval time.Duration // cycle period (cxo_subscribe_interval)
+	grace    time.Duration // delay after last release before stopping the cycle
 
 	mu    sync.Mutex
 	feeds map[CXOFeed]*managedFeed
-	tabs  map[CXOTab]int // outstanding AcquireFor refcount per tab
 }
 
-// managedFeed holds the per-feed runtime state.
+// managedFeed holds a single feed's runtime state.
 type managedFeed struct {
-	sub        *treestore.Subscriber
-	refcount   int         // total tabs requiring this feed
-	closeTimer *time.Timer // scheduled close (nil = none pending)
-	lastRootAt time.Time   // most recent OnUpdate timestamp
-	openErr    error       // last subscriber-open error (sticky for diagnostics)
+	// Snapshot data — populated by syncOnce, read by Get / Walk.
+	snapMu     sync.RWMutex
+	snapshot   map[string][]byte
+	lastSyncAt time.Time
+	lastErr    error // sticky last error from syncOnce; cleared on success
+
+	// Lifecycle (mutated only under manager.mu).
+	refcount  int
+	cancel    context.CancelFunc // stops the cycle goroutine
+	done      chan struct{}      // closed when the cycle goroutine exits
+	stopTimer *time.Timer        // pending grace-expiry stop
 }
 
-// defaultCXOSubscribeInterval is the resync floor when the operator
+// defaultCXOSubscribeInterval is the cycle period when the operator
 // hasn't set hypervisor.cxo_subscribe_interval. 5min matches the
-// user-facing intent: refresh per-feed data at most that often.
+// "no more than once every 5 min" intent.
 const defaultCXOSubscribeInterval = 5 * time.Minute
 
-// cxoTabCloseGrace is the delay between a feed's refcount dropping
-// to zero and the subscriber actually closing. 10s smooths over UI
-// navigation flicker (close-then-immediate-reopen) so we don't pay
-// a fresh DMSG handshake for a 1s tab switch.
+// cxoTabCloseGrace is how long after the refcount falls to zero we
+// keep running the cycle. 10s smooths over UI tab navigation flicker
+// without leaking a long idle subscription.
 const cxoTabCloseGrace = 10 * time.Second
 
-// NewCXOSubscriptionManager constructs a manager but doesn't open
-// any subscriptions until AcquireFor is called. interval comes
-// from hypervisor.cxo_subscribe_interval; <= 0 falls back to the
-// default.
+// firstSyncTimeout bounds how long syncOnce waits for the first Root
+// after Connect. After this the subscriber is closed and the cycle
+// records an error; the next cycle (or an explicit AcquireFor that
+// triggers a sync) retries from scratch. Long enough to ride out a
+// dmsg-session reconnect, short enough that a UI Acquire on a dead
+// publisher returns its cache-miss within ~10s.
+const firstSyncTimeout = 10 * time.Second
+
+// NewCXOSubscriptionManager constructs an idle manager. interval
+// comes from hypervisor.cxo_subscribe_interval; <= 0 falls back to
+// defaultCXOSubscribeInterval.
 func NewCXOSubscriptionManager(v *Visor, interval time.Duration, log *logging.Logger) *CXOSubscriptionManager {
 	if interval <= 0 {
 		interval = defaultCXOSubscribeInterval
@@ -145,15 +153,14 @@ func NewCXOSubscriptionManager(v *Visor, interval time.Duration, log *logging.Lo
 		interval: interval,
 		grace:    cxoTabCloseGrace,
 		feeds:    make(map[CXOFeed]*managedFeed),
-		tabs:     make(map[CXOTab]int),
 	}
 }
 
-// CXOSubMgr returns the visor's on-demand CXO subscription manager,
-// constructing it lazily on first use. Returns nil when the visor
-// has no DMSG client (e.g. early in startup, or DMSG disabled).
-// Caller treats nil as "subscription unavailable" — every Acquire/
-// Release/Get on a nil receiver is a no-op.
+// CXOSubMgr returns the visor's manager, constructing it lazily on
+// first use. Returns nil when the visor has no DMSG client (early
+// startup, or DMSG disabled). Callers treat nil as "no manager;
+// fall through to whatever non-CXO source you'd otherwise use" —
+// every method on a nil receiver is a safe no-op.
 func (v *Visor) CXOSubMgr() *CXOSubscriptionManager {
 	v.initLock.Lock()
 	defer v.initLock.Unlock()
@@ -173,110 +180,143 @@ func (v *Visor) CXOSubMgr() *CXOSubscriptionManager {
 	return v.cxoSubMgr
 }
 
-// AcquireFor signals that a UI tab is opening and pulls the feeds
-// it depends on into "active" state. Idempotent across multiple
-// open tabs of the same kind — the refcount sums across them. Feeds
-// that fail to subscribe (no DMSG, no peer PK, dial timeout) are
-// logged and skipped; later Get calls return ok=false until the
-// next acquire retry.
+// AcquireFor signals that a consumer is about to read from the
+// feeds a tab depends on. Idempotent across multiple holders;
+// refcount sums. On the first acquire of a feed, the cycle goroutine
+// starts and a sync is kicked off immediately so the snapshot has a
+// chance to populate before the caller's first Get / Walk. (Whether
+// it actually does depends on dmsg session readiness; callers handle
+// the cache-miss case by falling through to HTTP.)
 func (m *CXOSubscriptionManager) AcquireFor(tab CXOTab) {
 	if m == nil {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.tabs[tab]++
 	for _, fk := range tabFeedDeps[tab] {
 		m.acquireFeedLocked(fk)
 	}
 }
 
-// ReleaseFor signals that a UI tab is closing. Drops the refcount
-// on each of the tab's feeds; feeds that hit zero are scheduled for
-// close after the grace period.
+// ReleaseFor signals that a consumer is done. Drops the refcount on
+// each feed the tab depends on. Feeds whose refcount falls to zero
+// schedule their cycle goroutine to stop after the grace period —
+// during which a fresh AcquireFor cancels the stop and reuses the
+// running cycle.
 func (m *CXOSubscriptionManager) ReleaseFor(tab CXOTab) {
 	if m == nil {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.tabs[tab] <= 0 {
-		return
-	}
-	m.tabs[tab]--
 	for _, fk := range tabFeedDeps[tab] {
 		m.releaseFeedLocked(fk)
 	}
 }
 
-// Get returns the current cached body for (feed, path) and the
-// timestamp of the last Root update for that feed. ok=false when no
-// AcquireFor is currently holding the feed open or the subscriber
-// hasn't received a value for that path yet — handlers should treat
-// that as a cache miss and fall through to whatever HTTP path
-// served before the cutover.
+// Get returns the cached body for (feed, path) plus the timestamp of
+// the most recent successful sync, or ok=false if the feed has no
+// snapshot yet (no acquire ever happened, the first cycle hasn't
+// completed, or every cycle failed). Callers handle ok=false by
+// falling through to HTTP.
 func (m *CXOSubscriptionManager) Get(feed CXOFeed, path string) ([]byte, time.Time, bool) {
 	if m == nil {
 		return nil, time.Time{}, false
 	}
 	m.mu.Lock()
 	f, ok := m.feeds[feed]
-	if !ok || f == nil || f.sub == nil {
-		m.mu.Unlock()
+	m.mu.Unlock()
+	if !ok || f == nil {
 		return nil, time.Time{}, false
 	}
-	sub := f.sub
-	ts := f.lastRootAt
-	m.mu.Unlock()
-	body, ok := sub.Get(path)
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	if f.snapshot == nil {
+		return nil, time.Time{}, false
+	}
+	body, ok := f.snapshot[path]
 	if !ok || len(body) == 0 {
 		return nil, time.Time{}, false
 	}
-	return body, ts, true
+	out := make([]byte, len(body))
+	copy(out, body)
+	return out, f.lastSyncAt, true
 }
 
-// Walk iterates every (path, body) pair under the given prefix on
-// the named feed's active subscriber, calling fn for each leaf.
-// Returns ok=false when the feed isn't currently subscribed (no
-// AcquireFor live, or the dial failed). Walk does NOT block waiting
-// for the first Root — use it after a Get of any specific path
-// returns ok or when handlers are happy with "best effort, fall
-// through to HTTP on empty."
+// Walk invokes fn for every (path, body) in the feed's cached
+// snapshot whose path begins with prefix. Returns ok=false (with fn
+// never called) if the feed has no snapshot. Bodies passed to fn
+// are owned by the snapshot — callers must copy if they need to
+// retain bytes after fn returns.
 func (m *CXOSubscriptionManager) Walk(feed CXOFeed, prefix string, fn func(path string, body []byte) bool) bool {
 	if m == nil {
 		return false
 	}
 	m.mu.Lock()
 	f, ok := m.feeds[feed]
-	if !ok || f == nil || f.sub == nil {
-		m.mu.Unlock()
+	m.mu.Unlock()
+	if !ok || f == nil {
 		return false
 	}
-	sub := f.sub
-	m.mu.Unlock()
-	sub.Walk(prefix, fn)
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	if len(f.snapshot) == 0 {
+		return false
+	}
+	for path, body := range f.snapshot {
+		if prefix != "" && !hasPathPrefix(path, prefix) {
+			continue
+		}
+		if !fn(path, body) {
+			return true
+		}
+	}
 	return true
 }
 
-// Close tears down every active subscription. Called from the
-// visor's shutdown sequence.
+// Close stops every active cycle and drops every snapshot. Called
+// from the visor's shutdown sequence.
 func (m *CXOSubscriptionManager) Close() {
 	if m == nil {
 		return
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	for fk, f := range m.feeds {
-		if f.closeTimer != nil {
-			f.closeTimer.Stop()
-			f.closeTimer = nil
+	feeds := make([]*managedFeed, 0, len(m.feeds))
+	for _, f := range m.feeds {
+		if f.stopTimer != nil {
+			f.stopTimer.Stop()
+			f.stopTimer = nil
 		}
-		if f.sub != nil {
-			_ = f.sub.Close() //nolint:errcheck
-			f.sub = nil
-		}
-		delete(m.feeds, fk)
+		feeds = append(feeds, f)
 	}
+	m.feeds = make(map[CXOFeed]*managedFeed)
+	m.mu.Unlock()
+	for _, f := range feeds {
+		if f.cancel != nil {
+			f.cancel()
+		}
+		if f.done != nil {
+			<-f.done
+		}
+	}
+}
+
+// LastError returns the sticky last error seen by syncOnce on a
+// feed, or nil if the most recent cycle succeeded (or no cycle has
+// ever run). Exposed for /health-style introspection.
+func (m *CXOSubscriptionManager) LastError(feed CXOFeed) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	f, ok := m.feeds[feed]
+	m.mu.Unlock()
+	if !ok || f == nil {
+		return nil
+	}
+	f.snapMu.RLock()
+	defer f.snapMu.RUnlock()
+	return f.lastErr
 }
 
 // acquireFeedLocked must be called under m.mu.
@@ -287,24 +327,20 @@ func (m *CXOSubscriptionManager) acquireFeedLocked(fk CXOFeed) {
 		m.feeds[fk] = f
 	}
 	f.refcount++
-	// Cancel any pending close — caller still wants this feed.
-	if f.closeTimer != nil {
-		f.closeTimer.Stop()
-		f.closeTimer = nil
+	if f.stopTimer != nil {
+		f.stopTimer.Stop()
+		f.stopTimer = nil
 	}
-	if f.sub != nil {
-		// Already subscribed; nothing else to do.
-		return
+	if f.cancel == nil {
+		// First reference: start the cycle goroutine. cancel is
+		// stashed on the feed and called from releaseFeedLocked
+		// (via the grace timer) or Close — gosec's "context cancel
+		// not called" check can't see across the timer hop.
+		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec
+		f.cancel = cancel
+		f.done = make(chan struct{})
+		go m.cycleLoop(ctx, fk, f)
 	}
-	sub, err := m.openSubscriberLocked(fk)
-	if err != nil {
-		f.openErr = err
-		m.log.WithError(err).WithField("feed", fk).
-			Debug("Failed to open CXO subscriber; serving stale / cache-miss until next acquire")
-		return
-	}
-	f.sub = sub
-	f.openErr = nil
 }
 
 // releaseFeedLocked must be called under m.mu.
@@ -316,37 +352,134 @@ func (m *CXOSubscriptionManager) releaseFeedLocked(fk CXOFeed) {
 	if f.refcount > 0 {
 		f.refcount--
 	}
-	if f.refcount > 0 || f.sub == nil {
+	if f.refcount > 0 {
 		return
 	}
-	// refcount hit zero. Schedule close after grace; if a re-acquire
-	// arrives before the timer fires, acquireFeedLocked cancels it.
-	closeAt := m.grace
-	// Honor the resync-floor as a minimum: never tear down a feed
-	// sooner than `interval` after the last sync. Keeps a fast
-	// reopen-after-close path subscription-stable.
-	if since := time.Since(f.lastRootAt); since < m.interval {
-		if remaining := m.interval - since; remaining > closeAt {
-			closeAt = remaining
-		}
+	// refcount hit zero — schedule cycle stop after grace. A fresh
+	// acquire before the timer fires cancels it.
+	if f.stopTimer != nil {
+		return
 	}
 	feed := fk
-	f.closeTimer = time.AfterFunc(closeAt, func() {
+	f.stopTimer = time.AfterFunc(m.grace, func() {
 		m.mu.Lock()
-		defer m.mu.Unlock()
 		ff, ok := m.feeds[feed]
-		if !ok || ff.refcount > 0 || ff.sub == nil {
+		if !ok || ff.refcount > 0 {
+			if ff != nil {
+				ff.stopTimer = nil
+			}
+			m.mu.Unlock()
 			return
 		}
-		_ = ff.sub.Close() //nolint:errcheck
-		ff.sub = nil
-		ff.closeTimer = nil
+		cancel := ff.cancel
+		done := ff.done
+		ff.cancel = nil
+		ff.done = nil
+		ff.stopTimer = nil
+		m.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		if done != nil {
+			<-done
+		}
 	})
+}
+
+// cycleLoop is the per-feed goroutine. Runs syncOnce immediately,
+// then on every `interval` tick, until ctx is canceled.
+func (m *CXOSubscriptionManager) cycleLoop(ctx context.Context, fk CXOFeed, f *managedFeed) {
+	defer close(f.done)
+	m.syncOnce(ctx, fk, f)
+	t := time.NewTicker(m.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			m.syncOnce(ctx, fk, f)
+		}
+	}
+}
+
+// syncOnce performs a single subscribe → wait-for-first-Root →
+// snapshot → unsubscribe cycle. On any error the previous snapshot
+// is left in place; callers continue serving stale data until the
+// next cycle succeeds.
+func (m *CXOSubscriptionManager) syncOnce(ctx context.Context, fk CXOFeed, f *managedFeed) {
+	if m.v.dmsgC == nil {
+		f.recordErr(errors.New("dmsg client not ready"))
+		return
+	}
+	peerPK, port, prefix, err := m.feedSpec(fk)
+	if err != nil {
+		f.recordErr(err)
+		return
+	}
+
+	sub, err := treestore.NewSubscriber(m.v.dmsgC, peerPK, treestore.SubConfig{
+		InMemoryDB: true,
+		DmsgPort:   port,
+	})
+	if err != nil {
+		f.recordErr(fmt.Errorf("create subscriber: %w", err))
+		return
+	}
+	sub.SetPrefixes([]string{prefix})
+
+	rootCh := make(chan struct{}, 1)
+	sub.OnUpdate(func(_ []treestore.UpdateEvent) {
+		select {
+		case rootCh <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := sub.Connect(peerPK); err != nil {
+		_ = sub.Close() //nolint:errcheck
+		f.recordErr(fmt.Errorf("dial publisher: %w", err))
+		return
+	}
+
+	select {
+	case <-rootCh:
+		// First Root arrived — proceed to snapshot.
+	case <-time.After(firstSyncTimeout):
+		_ = sub.Close() //nolint:errcheck
+		f.recordErr(fmt.Errorf("timeout waiting for Root after %s", firstSyncTimeout))
+		return
+	case <-ctx.Done():
+		_ = sub.Close() //nolint:errcheck
+		return
+	}
+
+	snapshot := make(map[string][]byte)
+	sub.Walk(prefix, func(path string, body []byte) bool {
+		// Walk passes a copy of body, so storing it is safe.
+		snapshot[path] = body
+		return true
+	})
+	_ = sub.Close() //nolint:errcheck
+
+	f.snapMu.Lock()
+	f.snapshot = snapshot
+	f.lastSyncAt = time.Now()
+	f.lastErr = nil
+	f.snapMu.Unlock()
+}
+
+// recordErr stores the error on the feed for LastError to surface.
+// Does not touch the snapshot — the previous one stays in place.
+func (f *managedFeed) recordErr(err error) {
+	f.snapMu.Lock()
+	f.lastErr = err
+	f.snapMu.Unlock()
 }
 
 // feedSpec returns the (peerPK, dmsgPort, pathPrefix) tuple for a
 // feed. Returns an error if the visor doesn't have the peer's PK
-// configured (e.g. transport.discovery_dmsg empty for TPD feeds).
+// configured.
 func (m *CXOSubscriptionManager) feedSpec(fk CXOFeed) (cipher.PubKey, uint16, string, error) {
 	switch fk {
 	case FeedTPDMetrics:
@@ -377,49 +510,14 @@ func (m *CXOSubscriptionManager) feedSpec(fk CXOFeed) (cipher.PubKey, uint16, st
 	return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed: %d", fk)
 }
 
-// openSubscriberLocked dials the peer's TreeStore publisher and
-// returns a connected Subscriber filtered to the feed's path
-// prefix. Must be called under m.mu.
-func (m *CXOSubscriptionManager) openSubscriberLocked(fk CXOFeed) (*treestore.Subscriber, error) {
-	if m.v.dmsgC == nil {
-		return nil, errors.New("dmsg client not ready")
-	}
-	peerPK, port, prefix, err := m.feedSpec(fk)
-	if err != nil {
-		return nil, err
-	}
-	sub, err := treestore.NewSubscriber(m.v.dmsgC, peerPK, treestore.SubConfig{
-		InMemoryDB: true,
-		DmsgPort:   port,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create subscriber: %w", err)
-	}
-	sub.SetPrefixes([]string{prefix})
-	feed := fk
-	sub.OnUpdate(func(_ []treestore.UpdateEvent) {
-		m.mu.Lock()
-		if f, ok := m.feeds[feed]; ok {
-			f.lastRootAt = time.Now()
-		}
-		m.mu.Unlock()
-	})
-	if err := sub.Connect(peerPK); err != nil {
-		_ = sub.Close() //nolint:errcheck
-		return nil, fmt.Errorf("dial publisher: %w", err)
-	}
-	return sub, nil
-}
-
-// sdCXOPeer / dmsgdCXOPeer mirror tpdCXOPeer (init_stats.go) for
-// the new SD-services and DMSG-D-clients-by-server feeds. Returns
-// ok=false if the visor's config doesn't carry a parseable
-// service_discovery_dmsg / dmsg.discovery_dmsg URL.
+// sdCXOPeer extracts the SD publisher PK from the visor's
+// launcher.service_discovery_dmsg URL.
 func sdCXOPeer(v *Visor) (cipher.PubKey, bool) {
-	raw := v.conf.Launcher.ServiceDiscDmsg
-	return parseDmsgPeer(raw)
+	return parseDmsgPeer(v.conf.Launcher.ServiceDiscDmsg)
 }
 
+// dmsgdCXOPeer extracts the DMSG-D publisher PK from the visor's
+// dmsg.discovery_dmsg URL.
 func dmsgdCXOPeer(v *Visor) (cipher.PubKey, bool) {
 	if v.conf.Dmsg == nil {
 		return cipher.PubKey{}, false
@@ -439,4 +537,30 @@ func parseDmsgPeer(raw string) (cipher.PubKey, bool) {
 		return cipher.PubKey{}, false
 	}
 	return u.Addr.PK, true
+}
+
+// hasPathPrefix matches the semantics of the upstream
+// treestore.HasPrefix without the package import: empty prefix
+// matches everything, and the prefix must end at a path-segment
+// boundary (or the path must equal the prefix).
+func hasPathPrefix(path, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	if path == prefix {
+		return true
+	}
+	if len(path) <= len(prefix) {
+		return false
+	}
+	if path[:len(prefix)] != prefix {
+		return false
+	}
+	// Allow either the prefix already includes a trailing '/', or the
+	// next char in path is '/'.
+	last := prefix[len(prefix)-1]
+	if last == '/' {
+		return true
+	}
+	return path[len(prefix)] == '/'
 }


### PR DESCRIPTION
## Summary

Replaces the long-lived subscriber-while-acquired model from #2457 with a periodic *subscribe → wait for first Root → walk into local snapshot → unsubscribe* cycle that runs only while at least one consumer holds the feed via \`AcquireFor\`.

## Why

- **Publisher-restart staleness was unhandled.** \`treestore.Subscriber.Connect\` is one-shot with no built-in reconnect. A discovery service restarting (TPD, SD, DMSG-D) left existing visor subscribers reading stale snapshots forever, and the manager's \`f.sub != nil\` check on \`AcquireFor\` couldn't tell the difference between healthy and dead.
- **The bandwidth bound is wrong direction.** A network-visualizer tab open for a few seconds doesn't need every Root the publisher pushes — most updates are noise to the consumer. The right cap is \"one full sync per cycle interval,\" not \"every update for the entire tab lifetime.\"
- **Cycle model sidesteps reconnect management entirely.** Each cycle dials fresh, so a publisher restart self-heals on the next interval. Nothing to listen on, no liveness probes, no resubscription state.

## Shape

- Each \`managedFeed\` carries a \`snapshot map[string][]byte\` + \`lastSyncAt\` + \`lastErr\`.
- \`AcquireFor\` bumps the refcount and (on first reference) starts a per-feed cycle goroutine that runs \`syncOnce\` immediately, then on every \`interval\` tick.
- \`syncOnce\` does \`Connect\` → wait for first \`OnUpdate\` (bounded by \`firstSyncTimeout = 10s\`) → \`Walk\` to copy leaves into the snapshot map → \`Close\`. On any error the previous snapshot stays in place; consumers continue serving stale data until the next cycle succeeds.
- \`Get\` / \`Walk\` read the snapshot directly — no live subscriber to consult, so a dead dmsg session can't leak into a consumer's view.
- \`ReleaseFor\` drops the refcount; on hit-zero the cycle goroutine is scheduled to stop after \`cxoTabCloseGrace = 10s\`. A fresh \`AcquireFor\` before the timer fires cancels the stop and reuses the running cycle.

## New tab

\`TabAutoconnect\` mapped to \`FeedSDServices\` — the visor's public-visor autoconnect cycle will use this in the next PR (it walks \`services/visor/\` under the snapshot).

## Compatibility

The public API (\`AcquireFor\` / \`ReleaseFor\` / \`Get\` / \`Walk\` / \`Close\`) is unchanged. The tpviz \`/api/services\` consumer from #2458 keeps working — it sees a fresh snapshot (per cycle) instead of a live subscriber, but the call sites (\`mgr.AcquireForTab\` + \`mgr.Walk\` + \`mgr.ReleaseForTab\`) are identical.

## Testing

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [x] \`go test ./pkg/visor/...\` passes
- [ ] Behavioral verification deferred to the autoconnect/CLI consumer cutovers — those PRs will exercise the cycle path with real publisher data.

## Sequence

- ✅ #2456 — SD + DMSG-D CXO publishers
- ✅ #2457 — subscription manager + config field
- ✅ #2458 — \`/api/services\` cutover via the manager
- ✅ #2459 — DHT removal
- ⬅ This PR — manager cycle-based refactor
- ⏭ Next: autoconnect cutover (\`TabAutoconnect\` consumer)
- ⏭ Then: CLI cutover (\`proxy list\` / \`vpn list\` / \`pv\`)
- ⏭ Then: \`/api/dmsg/servers/clients\` tpviz handler (mirrors the upstream DMSG-D \`/dmsg-discovery/servers/clients\` path shape)