### PR TITLE
feat(visor/autoconnect): pull public visors from CXO snapshot when available

### DIFF
--- a/pkg/visor/autoconnect.go
+++ b/pkg/visor/autoconnect.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -193,7 +194,7 @@ func (a *autoconnector) Run(ctx context.Context, v *Visor) (err error) {
 
 			// fetch public visors
 			var addrs []cipher.PubKey
-			addrs, err = a.fetchPubAddresses(ctx)
+			addrs, err = a.fetchPubAddresses(ctx, v)
 			if err != nil {
 				a.log.Errorf("Cannot fetch public visors from service discovery: %s", err)
 				v.isServicesHealthy.unset()
@@ -411,10 +412,25 @@ func (a *autoconnector) tryEstablishTransport(ctx context.Context, pk cipher.Pub
 	return nil
 }
 
-func (a *autoconnector) fetchPubAddresses(ctx context.Context) ([]cipher.PubKey, error) {
-	var services []servicedisc.Service
+func (a *autoconnector) fetchPubAddresses(ctx context.Context, v *Visor) ([]cipher.PubKey, error) {
+	// CXO-first: when the on-demand subscription manager has a fresh
+	// snapshot of SD's services tree, use it. The manager's cycle
+	// runs at most once per `hypervisor.cxo_subscribe_interval`
+	// (default 5min), and a fresh AcquireFor here kicks off that
+	// cycle if no other consumer has already done so. Release on
+	// return; the manager's grace period handles the next
+	// autoconnect tick reusing the running cycle.
+	if mgr := v.CXOSubMgr(); mgr != nil {
+		mgr.AcquireFor(TabAutoconnect)
+		defer mgr.ReleaseFor(TabAutoconnect)
+		if pks := pubVisorsFromCXOSnapshot(mgr); len(pks) > 0 {
+			a.log.WithField("count", len(pks)).Debug("Autoconnect: resolved public visors from CXO snapshot")
+			return pks, nil
+		}
+	}
 
-	// Resolve public visors from service discovery over HTTP.
+	// Fall back to HTTP service discovery.
+	var services []servicedisc.Service
 	retrier := netutil.NewDefaultRetrier(a.log)
 	fetch := func() (err error) {
 		services, err = a.client.Services(ctx, a.maxConns, "", "")
@@ -428,6 +444,34 @@ func (a *autoconnector) fetchPubAddresses(ctx context.Context) ([]cipher.PubKey,
 		pks[i] = service.Addr.PubKey()
 	}
 	return pks, nil
+}
+
+// pubVisorsFromCXOSnapshot walks the SD services tree under
+// services/visor/<pk>/entry and returns the PKs as a slice. Empty
+// slice (rather than nil) when the snapshot exists but has no visor
+// entries; nil when the snapshot is missing entirely (caller falls
+// through to HTTP).
+func pubVisorsFromCXOSnapshot(mgr *CXOSubscriptionManager) []cipher.PubKey {
+	var pks []cipher.PubKey
+	mgr.Walk(FeedSDServices, "services/visor/", func(path string, _ []byte) bool {
+		// path = services/visor/<pk>/{entry,tombstone}.
+		// Skip tombstones; live entries only.
+		if !strings.HasSuffix(path, "/entry") {
+			return true
+		}
+		// Strip the prefix and trailing "/entry" to recover the PK.
+		core := strings.TrimSuffix(strings.TrimPrefix(path, "services/visor/"), "/entry")
+		if core == "" {
+			return true
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(core); err != nil {
+			return true
+		}
+		pks = append(pks, pk)
+		return true
+	})
+	return pks
 }
 
 // return public keys from pks that are absent in given list of transports


### PR DESCRIPTION
## Summary

\`autoconnector.fetchPubAddresses\` is the every-\`PublicServiceDelay\` tick that asks SD for the public-visor list and feeds it into the autoconnect dial pipeline. Previously HTTP-only after the DHT removal in #2459; now CXO-first via the cycle-based subscription manager from #2460.

## Shape

- \`AcquireFor(TabAutoconnect)\` at function entry; deferred \`ReleaseFor\` on return. The manager's grace period keeps the cycle alive across consecutive autoconnect ticks (\`PublicServiceDelay\` defaults to 30s, cycle \`interval\` defaults to 5min — so several ticks in a row reuse the same snapshot without re-dialing).
- \`pubVisorsFromCXOSnapshot\` walks \`services/visor/<pk>/entry\` leaves, recovers the PK from the path, returns the list. Tombstones are skipped.
- Empty walk result (snapshot missing because the manager just started, or genuinely no public visors in the snapshot) falls through to the existing HTTP retrier path — the operator-visible behavior is identical when CXO is unavailable.

## Why this is safe across SD restarts

The cycle model means each sync is a fresh dial; a publisher restart self-heals on the next interval (#2460). Autoconnect's own 30s tick rate handles the case where the snapshot is briefly empty between cycles by retrying — which falls through to HTTP if CXO is still empty.

The tab map already had \`TabAutoconnect → FeedSDServices\` from #2460; this is just the consumer that exercises that mapping.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [x] \`go test ./pkg/visor/...\` passes
- [ ] Run a visor with SD's \`--cxo\` enabled in the deployment; confirm autoconnect log lines show \`Autoconnect: resolved public visors from CXO snapshot\` after the first manager cycle completes (~5min after first acquire, or sooner if the first \`syncOnce\` succeeds promptly).
- [ ] Run a visor against an SD without \`--cxo\` (or while SD is down); confirm autoconnect still works via the HTTP fallback — same behavior as today.

## Sequence

- ✅ #2456 / #2457 / #2458 / #2459 / #2460
- ⬅ This PR — autoconnect cutover
- ⏭ CLI cutover (\`proxy list\` / \`vpn list\` / \`pv\`)
- ⏭ \`/api/dmsg/servers/clients\` tpviz handler