### PR TITLE
feat(visor): cut VPNServers / ProxyServers / PublicVisors over to CXO snapshot

### DIFF
--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -312,18 +312,70 @@ func (v *Visor) servicesFromHTTP(serviceType, version, country string) ([]servic
 	return sdClient.Services(context.Background(), 0, version, country)
 }
 
-// VPNServers gets available public VPN servers from service discovery.
+// servicesFromCXO walks the SD services snapshot under
+// services/<serviceType>/<pk>/entry and rebuilds a []Service
+// honoring optional version + country filters. Returns ok=false when
+// the manager isn't installed, the snapshot is empty, or every leaf
+// failed to parse — caller falls through to servicesFromHTTP.
+func (v *Visor) servicesFromCXO(serviceType, version, country string) ([]servicedisc.Service, bool) {
+	mgr := v.CXOSubMgr()
+	if mgr == nil {
+		return nil, false
+	}
+	mgr.AcquireFor(TabCLIServices)
+	defer mgr.ReleaseFor(TabCLIServices)
+
+	prefix := "services/" + serviceType + "/"
+	var services []servicedisc.Service
+	mgr.Walk(FeedSDServices, prefix, func(path string, body []byte) bool {
+		if !strings.HasSuffix(path, "/entry") {
+			return true
+		}
+		var svc servicedisc.Service
+		if err := json.Unmarshal(body, &svc); err != nil {
+			return true
+		}
+		if version != "" && svc.Version != version {
+			return true
+		}
+		if country != "" {
+			if svc.Geo == nil || svc.Geo.Country != country {
+				return true
+			}
+		}
+		services = append(services, svc)
+		return true
+	})
+	if len(services) == 0 {
+		return nil, false
+	}
+	return services, true
+}
+
+// VPNServers gets available public VPN servers — CXO snapshot first,
+// HTTP service-discovery fallback.
 func (v *Visor) VPNServers(version, country string) ([]servicedisc.Service, error) {
+	if services, ok := v.servicesFromCXO(servicedisc.ServiceTypeVPN, version, country); ok {
+		return services, nil
+	}
 	return v.servicesFromHTTP(servicedisc.ServiceTypeVPN, version, country)
 }
 
-// ProxyServers gets available proxy servers from service discovery.
+// ProxyServers gets available proxy servers — CXO snapshot first,
+// HTTP service-discovery fallback.
 func (v *Visor) ProxyServers(version, country string) ([]servicedisc.Service, error) {
+	if services, ok := v.servicesFromCXO(servicedisc.ServiceTypeProxy, version, country); ok {
+		return services, nil
+	}
 	return v.servicesFromHTTP(servicedisc.ServiceTypeProxy, version, country)
 }
 
-// PublicVisors gets available public visors from service discovery.
+// PublicVisors gets available public visors — CXO snapshot first,
+// HTTP service-discovery fallback.
 func (v *Visor) PublicVisors(version, country string) ([]servicedisc.Service, error) {
+	if services, ok := v.servicesFromCXO(servicedisc.ServiceTypeVisor, version, country); ok {
+		return services, nil
+	}
 	return v.servicesFromHTTP(servicedisc.ServiceTypeVisor, version, country)
 }
 

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -79,6 +79,11 @@ const (
 	// TabAutoconnect is the visor's public-visor autoconnect cycle —
 	// SD services only (filters down to the visor type at walk time).
 	TabAutoconnect
+	// TabCLIServices is the operator-facing service-listing CLI
+	// commands (`skywire cli proxy list`, `vpn list`, `pv`). Same
+	// SD services feed; refcount summed with TabAutoconnect when
+	// both are active so they share the running cycle.
+	TabCLIServices
 )
 
 // tabFeedDeps maps each tab to the set of feeds it depends on.
@@ -89,6 +94,7 @@ var tabFeedDeps = map[CXOTab][]CXOFeed{
 	TabMetrics:           {FeedTPDMetrics, FeedTPDUptime},
 	TabUptime:            {FeedTPDUptime},
 	TabAutoconnect:       {FeedSDServices},
+	TabCLIServices:       {FeedSDServices},
 }
 
 // CXOSubscriptionManager owns the per-feed cycle goroutines + the


### PR DESCRIPTION
## Summary

The three RPC methods backing \`skywire cli vpn list\`, \`proxy list\`, and \`pv\` (and the matching hvui dropdowns) now consult the SD services CXO snapshot before falling through to HTTP discovery.

## Shape

- New tab \`TabCLIServices\` mapped to \`FeedSDServices\`. Same feed \`TabAutoconnect\` uses, so they share the running cycle when both are active — operator running CLI commands while autoconnect is in a cycle window adds to the refcount, no extra dial.
- New helper \`Visor.servicesFromCXO(svcType, version, country)\` walks \`services/<svcType>/<pk>/entry\` leaves under the snapshot, parses each as a \`servicedisc.Service\`, applies the \`version\` / \`country\` filters client-side, returns the result. Tombstones skipped.
- \`VPNServers\` / \`ProxyServers\` / \`PublicVisors\` try the CXO path first; on \`ok=false\` (no manager, snapshot empty, or all leaves filtered out) they fall through to the existing \`servicesFromHTTP\` path. Operator-visible behavior is identical when CXO is unavailable — same data, same shape, same filter semantics.

## Why this is reasonable for short-lived CLI calls

The manager's grace period (10s) keeps the cycle alive across back-to-back invocations — a typical interactive session running \`proxy list\` then \`vpn list\` reuses the same snapshot without re-dialing. A first-ever invocation after a long idle pays one \`syncOnce\` roundtrip (bounded by \`firstSyncTimeout = 10s\`); everything within \`cxo_subscribe_interval\` after that is a memory read.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [x] \`go test ./pkg/visor/...\` passes
- [ ] \`skywire cli proxy list\` / \`vpn list\` / \`pv\` against a deployment with SD's \`--cxo\` enabled — first call after restart pays the dial, subsequent calls within 5min serve from snapshot. Output identical to HTTP path.
- [ ] Same commands against a deployment WITHOUT \`--cxo\` — fall through to HTTP cleanly, same output as before.

## Sequence

- ✅ #2456 / #2457 / #2458 / #2459 / #2460 / #2461
- ⬅ This PR
- ⏭ \`/api/dmsg/servers/clients\` tpviz handler (mirrors the upstream DMSG-D \`/dmsg-discovery/servers/clients\` path shape)
- ⏭ Then: declarative deploy config (multi-service-per-process binary)