### PR TITLE
feat(tpviz): /api/dmsg/servers/clients backed by DMSG-D clients-by-server CXO snapshot

### DIFF
--- a/pkg/tpviz/cxo_subscriber.go
+++ b/pkg/tpviz/cxo_subscriber.go
@@ -132,9 +132,71 @@ func (s *Server) tryCXOServices() (map[string]ServiceInfo, bool) {
 	return services, true
 }
 
-// (DMSG-D clients-by-server consumer — future PR. The publisher tree
-// lives at clients-by-server/<server>/<client>/{entry,tombstone}; a
-// helper that walks it and produces map[serverPK][]clientPK can be
-// added next to tryCXOServices once a tpviz handler needs it.
-// CXOFeedDMSGDClientsByServer is reserved here for that consumer.)
-var _ = CXOFeedDMSGDClientsByServer // silence unused-const linter
+// tryCXOClientsByServer walks the DMSG-D clients-by-server snapshot
+// and rebuilds a map[server-pk-hex][]disc.Entry — same shape the
+// upstream DMSG-D /dmsg-discovery/servers/clients HTTP endpoint
+// returns. Returns ok=false when the manager isn't installed, the
+// snapshot is empty, or every entry leaf fails to parse — caller
+// falls through to its existing HTTP path.
+//
+// Tombstones are skipped (live entries only). Each leaf carries the
+// full disc.Entry as JSON; the (server, client) PK pair is derivable
+// from the path (clients-by-server/<server>/<client>/entry) but we
+// re-use the server segment for the result map key directly so the
+// shape exactly matches AllClientsByServer's hex-string keys.
+func (s *Server) tryCXOClientsByServer() (map[string][]*discEntry, bool) {
+	mgr := s.cxoMgr()
+	if mgr == nil {
+		return nil, false
+	}
+	out := make(map[string][]*discEntry)
+	any := false
+	mgr.Walk(CXOFeedDMSGDClientsByServer, "clients-by-server/", func(path string, body []byte) bool {
+		if !strings.HasSuffix(path, "/entry") {
+			return true
+		}
+		// path = clients-by-server/<server>/<client>/entry
+		parts := strings.Split(path, "/")
+		if len(parts) != 4 {
+			return true
+		}
+		server := parts[1]
+		var entry discEntry
+		if err := json.Unmarshal(body, &entry); err != nil {
+			return true
+		}
+		out[server] = append(out[server], &entry)
+		any = true
+		return true
+	})
+	if !any {
+		return nil, false
+	}
+	return out, true
+}
+
+// discEntry is a tpviz-local mirror of the disc.Entry JSON shape.
+// Defined here (rather than imported from pkg/dmsg/disc) so tpviz
+// stays decoupled from the dmsg-disc package's full type surface —
+// we only need the JSON-serializable shell for the response body.
+// The fields match the disc.Entry public layout; unknown fields in
+// the wire data are tolerated by encoding/json.
+type discEntry struct {
+	Static    string         `json:"static"`
+	Sequence  uint64         `json:"sequence,omitempty"`
+	Timestamp int64          `json:"timestamp,omitempty"`
+	Client    *discClient    `json:"client,omitempty"`
+	Server    *discServerRec `json:"server,omitempty"`
+	Signature string         `json:"signature,omitempty"`
+	Version   string         `json:"version,omitempty"`
+}
+
+type discClient struct {
+	DelegatedServers []string `json:"delegated_servers,omitempty"`
+}
+
+type discServerRec struct {
+	Address           string `json:"address,omitempty"`
+	AvailableSessions int    `json:"availableSessions,omitempty"`
+	ServerType        string `json:"serverType,omitempty"`
+}

--- a/pkg/tpviz/tpviz.go
+++ b/pkg/tpviz/tpviz.go
@@ -587,6 +587,11 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/api/dmsg/servers", s.handleDMSGServers)
 	s.mux.HandleFunc("/api/dmsg/entries", s.handleDMSGEntries)
 	s.mux.HandleFunc("/api/dmsg/health", s.handleDMSGHealth)
+	// /api/dmsg/servers/clients mirrors upstream DMSG-D's
+	// /dmsg-discovery/servers/clients path shape. CXO-fed when the
+	// manager has a snapshot; falls through to a direct HTTP fetch
+	// of the upstream endpoint otherwise.
+	s.mux.HandleFunc("/api/dmsg/servers/clients", s.handleDMSGServersClients)
 
 	// Network ping endpoint
 	s.mux.HandleFunc("/api/ping", s.handlePing)
@@ -1919,6 +1924,44 @@ func (s *Server) handleDMSGEntries(w http.ResponseWriter, r *http.Request) {
 		"count":   data.EntriesCount,
 		"entries": data.Entries,
 	})
+}
+
+// handleDMSGServersClients returns the same map[server-pk][]Entry
+// shape as upstream DMSG-D's /dmsg-discovery/servers/clients —
+// drives the network visualizer's "who's on each dmsg server" view.
+//
+// CXO-first via the on-demand subscription manager (DMSG-D's
+// clients-by-server tree), falling through to a direct HTTP fetch
+// of the upstream endpoint when the snapshot is empty.
+func (s *Server) handleDMSGServersClients(w http.ResponseWriter, _ *http.Request) {
+	if mgr := s.cxoMgr(); mgr != nil {
+		mgr.AcquireForTab(CXOTabNetworkVisualizer)
+		defer mgr.ReleaseForTab(CXOTabNetworkVisualizer)
+		if grouped, ok := s.tryCXOClientsByServer(); ok {
+			result, mErr := json.Marshal(grouped)
+			if mErr == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+				w.Header().Set("X-Skywire-Source", "cxo")
+				w.Write(result) //nolint:errcheck,gosec
+				return
+			}
+		}
+	}
+
+	// Fall through: pull the same shape from upstream DMSG-D over HTTP.
+	if s.config.DMSGURL == "" {
+		http.Error(w, "DMSG discovery URL not configured", http.StatusServiceUnavailable)
+		return
+	}
+	body, err := fetchURL(s.config.DMSGURL + "/dmsg-discovery/servers/clients")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("upstream fetch failed: %v", err), http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Write([]byte(body)) //nolint:errcheck,gosec
 }
 
 // handleDMSGHealth performs a health check on a remote visor via DMSG


### PR DESCRIPTION
## Summary
- New tpviz route `/api/dmsg/servers/clients` mirrors upstream DMSG-D's `/dmsg-discovery/servers/clients` path shape so the network visualizer's "who's on each dmsg server" view has a direct local endpoint.
- CXO-first: walks the DMSG-D `clients-by-server/<server>/<client>/entry` snapshot from the on-demand subscription manager (publisher landed in #2456, manager in #2457/#2460). Sets `X-Skywire-Source: cxo` so ops can tell which path served.
- Falls through to a direct HTTP fetch of upstream DMSG-D when the snapshot is empty — same JSON shape either way, so the visualizer JS works unchanged.

## Test plan
- [x] `go build ./...`
- [x] `make lint` (0 issues)
- [ ] hit `/api/dmsg/servers/clients` on a live tpviz, confirm `X-Skywire-Source: cxo` once the snapshot warms
- [ ] confirm fallback path returns the same shape as upstream when the CXO manager isn't wired