### PR TITLE
feat(svc): pkg/services framework + skywire svc run multi-service supervisor

### DIFF
--- a/cmd/svc/skywire-services/commands/root.go
+++ b/cmd/svc/skywire-services/commands/root.go
@@ -18,6 +18,7 @@ import (
 	rf "github.com/skycoin/skywire/cmd/svc/route-finder/commands"
 	sd "github.com/skycoin/skywire/cmd/svc/service-discovery/commands"
 	sn "github.com/skycoin/skywire/cmd/svc/setup-node/commands"
+	run "github.com/skycoin/skywire/cmd/svc/skywire-services/commands/run"
 	stunsvr "github.com/skycoin/skywire/cmd/svc/stun-server/commands"
 	se "github.com/skycoin/skywire/cmd/svc/sw-env/commands"
 	tpd "github.com/skycoin/skywire/cmd/svc/transport-discovery/commands"
@@ -25,6 +26,9 @@ import (
 	ut "github.com/skycoin/skywire/cmd/svc/uptime-tracker/commands"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
+	// Side-effect imports register service factories with
+	// pkg/services so `skywire svc run` can dispatch them.
+	_ "github.com/skycoin/skywire/pkg/services/noop"
 )
 
 func init() {
@@ -46,6 +50,7 @@ func init() {
 		nm.RootCmd,
 		geoip.RootCmd,
 		stunsvr.RootCmd,
+		run.RootCmd,
 	)
 	tpd.RootCmd.Use = "tpd"
 	tps.RootCmd.Use = "tps"

--- a/cmd/svc/skywire-services/commands/run/run.go
+++ b/cmd/svc/skywire-services/commands/run/run.go
@@ -1,0 +1,107 @@
+// Package run cmd/svc/skywire-services/commands/run/run.go
+//
+// Implements `skywire svc run --config services.json` — the
+// multi-service-in-one-process supervisor. Each service block in the
+// JSON file maps to a Factory previously installed by per-service
+// package init() (see pkg/services/dmsgdisc, pkg/services/tpd, ...).
+//
+// This subcommand is the ONLY entry point that runs more than one
+// service in a single process. The existing per-service subcommands
+// (`skywire svc tpd`, `skywire dmsg dmsg-discovery start`, ...)
+// continue to work unchanged for production deployments — they each
+// build their own pkg/services.Service and run it directly without
+// going through the registry.
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services"
+)
+
+var (
+	configPath string
+	listOnly   bool
+)
+
+func init() {
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "",
+		"path to services.json (required unless --list)")
+	RootCmd.Flags().BoolVar(&listOnly, "list", false,
+		"print the registered service types and exit")
+}
+
+// RootCmd implements `skywire svc run`.
+var RootCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run multiple deployment services in one process",
+	Long: `Run multiple deployment services in one process.
+
+Reads a JSON config file describing which services to host and starts
+each one. Used to collapse the per-service docker containers in CI
+e2e and small all-in-one deployments down to a single binary.
+
+Example services.json:
+
+  {
+    "services": [
+      { "type": "dmsg-discovery",     "addr": ":9090", ... },
+      { "type": "dmsg-server",        ... },
+      { "type": "transport-discovery", ... }
+    ]
+  }
+
+Use --list to see which service types are registered.`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if listOnly {
+			types := services.RegisteredTypes()
+			if len(types) == 0 {
+				fmt.Fprintln(os.Stdout, "no service types registered") //nolint:errcheck
+				return nil
+			}
+			fmt.Fprintln(os.Stdout, "registered service types:") //nolint:errcheck
+			for _, t := range types {
+				fmt.Fprintf(os.Stdout, "  %s\n", t) //nolint:errcheck
+			}
+			return nil
+		}
+		if configPath == "" {
+			return fmt.Errorf("--config is required (or pass --list)")
+		}
+		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to print build info: %v\n", err)
+		}
+		master := logging.NewMasterLogger()
+		log := master.PackageLogger("skywire-svc-run")
+
+		file, err := services.LoadFile(configPath)
+		if err != nil {
+			return err
+		}
+		log.WithField("count", len(file.Services)).
+			WithField("config", configPath).
+			Info("loaded services config")
+
+		// Sanity-check every block's type up front so the error
+		// message points at the bad block rather than going silent
+		// until the supervisor tries to build it.
+		for i, b := range file.Services {
+			if _, ok := services.Lookup(b.Type); !ok {
+				return fmt.Errorf("services.json[%d]: unknown type %q (registered: %v)",
+					i, b.Type, services.RegisteredTypes())
+			}
+		}
+
+		return services.Run(context.Background(), file, master)
+	},
+}

--- a/pkg/services/noop/noop.go
+++ b/pkg/services/noop/noop.go
@@ -1,0 +1,82 @@
+// Package noop pkg/services/noop/noop.go
+//
+// "noop" service — validates the pkg/services framework end-to-end
+// without bringing in any real service's dependencies. Used by
+// `skywire svc run --config services.json` smoke tests and as the
+// minimal example of how a service plugs into the registry.
+//
+// Block shape:
+//
+//	{ "type": "noop", "name": "demo", "tick_seconds": 5 }
+//
+// Behavior: logs "tick" every tick_seconds (default 30) until ctx
+// cancels. tick_seconds <= 0 disables ticking — service still runs
+// to completion when ctx cancels but produces no output.
+package noop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services"
+)
+
+// Type is the registry key used in services.json.
+const Type = "noop"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// Config is the JSON shape of a noop block. Fields are deliberately
+// minimal — this exists to validate the pipeline, not as a real
+// service.
+type Config struct {
+	Type        string `json:"type"`
+	Name        string `json:"name,omitempty"`
+	TickSeconds int    `json:"tick_seconds,omitempty"`
+}
+
+// service is the runnable instance built from a block. Lowercase
+// because operators interact with the type via the Factory + raw
+// JSON, not by constructing it directly.
+type service struct {
+	cfg Config
+	log *logging.Logger
+}
+
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("noop: parse config: %w", err)
+	}
+	return &service{cfg: c, log: log}, nil
+}
+
+func (s *service) Run(ctx context.Context) error {
+	tick := s.cfg.TickSeconds
+	if tick == 0 {
+		tick = 30
+	}
+	if tick < 0 {
+		// Negative disables ticking entirely — useful as a
+		// "this service exists but does nothing" placeholder.
+		s.log.Info("noop service running (no tick)")
+		<-ctx.Done()
+		return nil
+	}
+	t := time.NewTicker(time.Duration(tick) * time.Second)
+	defer t.Stop()
+	s.log.WithField("interval_seconds", tick).Info("noop service ticking")
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			s.log.Info("tick")
+		}
+	}
+}

--- a/pkg/services/run.go
+++ b/pkg/services/run.go
@@ -1,0 +1,139 @@
+// Package services pkg/services/run.go
+//
+// errgroup-style supervisor for a parsed services.File. Brought into
+// its own file so the registry primitives in services.go stay small
+// and easy to read.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// LoadFile reads a services.json from disk and returns the parsed
+// File. Validates only that every block has a "type" — type-specific
+// validation happens later when the Factory decodes the block.
+func LoadFile(path string) (File, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return File{}, fmt.Errorf("services: read %s: %w", path, err)
+	}
+	return ParseFile(data)
+}
+
+// ParseFile parses the JSON bytes into a File. Exposed alongside
+// LoadFile so callers (tests, embedded configs) can pass bytes
+// directly without going through the filesystem.
+func ParseFile(data []byte) (File, error) {
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return File{}, fmt.Errorf("services: parse: %w", err)
+	}
+	if len(f.Services) == 0 {
+		return File{}, errors.New("services: config has no services")
+	}
+	return f, nil
+}
+
+// Run dispatches every block in file to its registered Factory and
+// supervises the resulting Services. Returns when:
+//   - ctx is canceled (returns nil)
+//   - SIGINT/SIGTERM is received (returns nil; ctx is canceled
+//     internally so all services unwind cleanly)
+//   - any service's Run returns an error (returns the first error;
+//     other services are then canceled and joined)
+//
+// Each service runs in its own goroutine and shares the same ctx.
+// Services log under their Block.Label() so an operator looking at
+// merged stdout can tell two instances of the same service type
+// apart.
+func Run(ctx context.Context, file File, master *logging.MasterLogger) error {
+	log := master.PackageLogger("services-supervisor")
+	// Build all services up front before starting any. A factory
+	// failure (bad config, bad PK, bad URL) is fatal — abort
+	// without partial startup. Cheaper than discovering it 30s in
+	// when the third service fails to bind.
+	type built struct {
+		block Block
+		svc   Service
+	}
+	svcs := make([]built, 0, len(file.Services))
+	for i, b := range file.Services {
+		factory, ok := Lookup(b.Type)
+		if !ok {
+			return fmt.Errorf("services: block #%d (%s): unknown type %q (registered: %v)",
+				i, b.Label(), b.Type, RegisteredTypes())
+		}
+		s, err := factory(b.Raw, master.PackageLogger(b.Label()))
+		if err != nil {
+			return fmt.Errorf("services: block #%d (%s): build: %w", i, b.Label(), err)
+		}
+		svcs = append(svcs, built{block: b, svc: s})
+	}
+
+	// Shared context: any service erroring cancels everyone, and
+	// SIGINT/SIGTERM also cancel everyone. The signal goroutine is
+	// joined via the wait group below so the process doesn't exit
+	// before signal handling unwinds.
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case s := <-sigCh:
+			log.WithField("signal", s).Info("received shutdown signal; canceling all services")
+			cancel()
+		case <-runCtx.Done():
+		}
+	}()
+
+	// First-error wins. Subsequent errors are logged but don't
+	// overwrite — gives the operator the clearest signal of what
+	// actually broke first vs. cascading collateral damage.
+	var (
+		firstErrMu sync.Mutex
+		firstErr   error
+		wg         sync.WaitGroup
+	)
+	recordErr := func(label string, err error) {
+		if err == nil || errors.Is(err, context.Canceled) {
+			return
+		}
+		firstErrMu.Lock()
+		defer firstErrMu.Unlock()
+		if firstErr == nil {
+			firstErr = fmt.Errorf("%s: %w", label, err)
+			cancel()
+			return
+		}
+		log.WithError(err).WithField("service", label).
+			Warn("service errored after first fatal; ignoring")
+	}
+
+	for _, s := range svcs {
+		wg.Add(1)
+		go func(s built) {
+			defer wg.Done()
+			label := s.block.Label()
+			log.WithField("service", label).WithField("type", s.block.Type).
+				Info("starting service")
+			err := s.svc.Run(runCtx)
+			log.WithField("service", label).
+				WithError(err).Info("service exited")
+			recordErr(label, err)
+		}(s)
+	}
+	wg.Wait()
+	return firstErr
+}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -1,0 +1,155 @@
+// Package services pkg/services/services.go
+//
+// Multi-service-in-one-process runner for Skywire deployment services.
+// Each service registers a Factory that decodes its block from a
+// JSON services.json and returns a Service that runs until ctx
+// cancels or a fatal error.
+//
+// Goal: collapse the nine deployment-side containers exercised by
+// CI e2e (dmsg-discovery, dmsg-server, transport-discovery,
+// service-discovery, address-resolver, route-finder, transport-setup,
+// stun-server, setup-node) down to a single binary invocation
+// (`skywire svc run --config services.json`) so CI e2e doesn't have
+// to wrangle nine Dockerfiles. uptime-tracker and network-monitor
+// are out of scope — UT is being subsumed by TPD, NM is intentionally
+// disabled in the production deployment. Production deployments
+// unchanged — the existing per-service cobra subcommands stay and
+// build their own Service via the same Factory.
+//
+// Topology choice: each service gets its own HTTP listener (no path
+// multiplexing). In-process topology stays identical to the
+// multi-container topology, so the e2e suite exercises the same code
+// paths whether it runs collapsed or not.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Service is what each per-service package returns from its Factory.
+// Run blocks until ctx is canceled or a fatal error occurs. The
+// registry shuts services down by canceling the shared ctx — there's
+// no separate Stop method.
+type Service interface {
+	Run(ctx context.Context) error
+}
+
+// Factory builds a Service from a raw block in services.json. The
+// block is the full JSON object the operator wrote (including the
+// "type" field, which factories typically ignore — the registry has
+// already used it to dispatch).
+type Factory func(raw json.RawMessage, log *logging.Logger) (Service, error)
+
+// File is the on-disk shape of services.json.
+//
+//	{
+//	  "services": [
+//	    { "type": "dmsg-discovery", ... },
+//	    { "type": "dmsg-server",    ... }
+//	  ]
+//	}
+//
+// Each Block carries its full original JSON so the per-service
+// factory can decode into its own typed config struct without losing
+// fields the framework doesn't know about.
+type File struct {
+	Services []Block `json:"services"`
+}
+
+// Block is one service entry. UnmarshalJSON pulls the type marker
+// out and stashes the full block bytes on Raw for the factory.
+type Block struct {
+	Type string
+	Name string
+	Raw  json.RawMessage
+}
+
+// UnmarshalJSON captures both the typed fields ("type", optional
+// "name") and the full block bytes, so factories can re-decode the
+// block into their own config struct. Forward-compatible: extra
+// service-specific fields live alongside "type" / "name" in the same
+// object and reach the factory via Raw.
+func (b *Block) UnmarshalJSON(data []byte) error {
+	var probe struct {
+		Type string `json:"type"`
+		Name string `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("services: parse block header: %w", err)
+	}
+	if probe.Type == "" {
+		return fmt.Errorf("services: block missing required \"type\" field")
+	}
+	b.Type = probe.Type
+	b.Name = probe.Name
+	b.Raw = make(json.RawMessage, len(data))
+	copy(b.Raw, data)
+	return nil
+}
+
+// Label returns the operator-visible name for this block, falling
+// back to the type when no explicit name was set. Used in log
+// prefixes so an operator running multiple instances of the same
+// service type can tell them apart.
+func (b *Block) Label() string {
+	if b.Name != "" {
+		return b.Name
+	}
+	return b.Type
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]Factory{}
+)
+
+// Register installs a Factory for the given service type. Called
+// from each service package's init(); duplicate registrations panic
+// (programmer error, caught at process startup).
+func Register(svcType string, f Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, dup := registry[svcType]; dup {
+		panic(fmt.Sprintf("services: duplicate registration for type %q", svcType))
+	}
+	registry[svcType] = f
+}
+
+// Lookup returns the Factory registered for svcType, or false when
+// none is registered. Exported so the cobra subcommand can produce a
+// helpful "available types: ..." error before attempting a build.
+func Lookup(svcType string) (Factory, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	f, ok := registry[svcType]
+	return f, ok
+}
+
+// RegisteredTypes returns the sorted list of currently-registered
+// service types. Used by the cobra subcommand's error messages and
+// `skywire svc run --list` output.
+func RegisteredTypes() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	out := make([]string, 0, len(registry))
+	for t := range registry {
+		out = append(out, t)
+	}
+	sortStrings(out)
+	return out
+}
+
+// sortStrings is a small dependency-free sort to avoid pulling in
+// "sort" just for one call site.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `pkg/services` framework: Service interface, Factory type, registry, JSON schema (typed service blocks with full-block passthrough), errgroup-style supervisor with SIGINT/SIGTERM handling and first-error-wins semantics.
- Adds `skywire svc run --config services.json` cobra subcommand mounted alongside the existing per-service subcommands (`tpd`, `sd`, `ar`, etc.) — purely additive, no existing entry point changes.
- Includes `pkg/services/noop` as the validation service for the framework. Smoke-tested with two simultaneous noop blocks against `skywire svc run`; clean SIGINT shutdown of all services.

## Why
CI e2e currently runs eleven deployment containers. Many of the e2e flakes come from `depends_on` ordering races, container-DNS hiccups on GH Actions, and resource contention across concurrent container starts. Per-service migrations onto this framework collapse those down to one container running `skywire svc run`.

## Scope of this PR
Framework only — no real services migrated yet. Per-service migration PRs land each `cmd/<svc>/.../RunE` body into `pkg/services/<svc>.Run(ctx, cfg)` and a registered Factory, then `docker/docker-compose.yml` collapses to one container.

uptime-tracker and network-monitor are intentionally out of scope — UT is being subsumed by TPD's uptime tracking, NM is already disabled in the production deployment.

## Test plan
- [x] `go build ./...`
- [x] `make lint` (0 issues)
- [x] `skywire svc run --list` prints registered types
- [x] `skywire svc run --config two-noop.json` runs both, ticks, SIGINT triggers clean shutdown of both
- [x] Unknown type produces helpful error pointing at the offending block
- [ ] Per-service migrations follow as separate PRs