### PR TITLE
feat(svc): migrate dmsg-discovery onto pkg/services framework

### DIFF
--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
@@ -1,40 +1,28 @@
-// Package commands cmd/dmsg-discovery/commands/root.go
+// Package commands cmd/dmsg-discovery/commands/dmsg-discovery.go
+//
+// Cobra entry point for the standalone `skywire dmsg disc` binary.
+// All the actual run logic lives in pkg/services/dmsgdisc — this file
+// is just the flag set, the optional --config file overlay, and the
+// signal-context wiring.
 package commands
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log"
-	"net"
-	"net/http"
 	"os"
 	"strings"
 	"time"
 
-	proxyproto "github.com/pires/go-proxyproto"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
-	"github.com/skycoin/skywire/pkg/dmsg/direct"
-	"github.com/skycoin/skywire/pkg/dmsg/disc"
-	"github.com/skycoin/skywire/pkg/dmsg/disc/metrics"
-	"github.com/skycoin/skywire/pkg/dmsg/discovery/api"
-	"github.com/skycoin/skywire/pkg/dmsg/discovery/store"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
-	"github.com/skycoin/skywire/pkg/logging"
-	"github.com/skycoin/skywire/pkg/metricsutil"
-	"github.com/skycoin/skywire/pkg/svcmode"
+	"github.com/skycoin/skywire/pkg/services/dmsgdisc"
 )
-
-const redisPasswordEnvName = "REDIS_PASSWORD"
 
 var (
 	sf                cmdutil.ServiceFlags
@@ -46,7 +34,6 @@ var (
 	testMode          bool
 	enableLoadTesting bool
 	testEnvironment   bool
-	pk                cipher.PubKey
 	sk                cipher.SecKey
 	keyFile           string
 	dmsgPort          uint16
@@ -68,7 +55,7 @@ func init() {
 	RootCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 	RootCmd.Flags().StringVar(&authPassphrase, "auth", "", "auth passphrase as simple auth for official dmsg servers registration")
 	RootCmd.Flags().StringVar(&officialServers, "official-servers", "", "list of official dmsg servers keys separated by comma")
-	RootCmd.Flags().StringVar(&redisURL, "redis", store.DefaultURL, "connections string for a redis store\n\r")
+	RootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\n\r")
 	RootCmd.Flags().StringVar(&whitelistKeys, "whitelist-keys", "", "list of whitelisted keys of network monitor used for deregistration")
 	// 60m is 12× the client refresh interval (DefaultUpdateInterval*5 = 5m),
 	// giving ~2-3 missed refreshes of slack before Redis prunes an entry.
@@ -83,9 +70,7 @@ func init() {
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	// dmsg-discovery cannot run in dmsg-only mode because dmsg-servers
-	// themselves register with it over plain HTTP (see
-	// cmd/dmsg-commands/dmsg-server/commands/start/root.go). http and
-	// dual are accepted; dmsg is rejected.
+	// themselves register with it over plain HTTP.
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dual (dmsg-only is rejected — dmsg-servers reach this service over HTTP)")
 	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO clients-by-server publisher feed over DMSG (requires --sk and --mode=dual)")
 }
@@ -129,291 +114,137 @@ Example:
 		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
 			log.Printf("Failed to output build info: %v", err)
 		}
+		logger := sf.Logger()
 
-		log := sf.Logger()
-
-		// configServers, when non-nil, overrides the embedded keyring
-		// preload below. Populated only when --config is set.
-		var configServers []*disc.Entry
-		if configPath != "" {
-			c, cErr := LoadConfig(configPath)
-			if cErr != nil {
-				log.WithError(cErr).Fatal("failed to load config")
-			}
-			applyConfig(c)
-			configServers = c.DmsgServers
-			log.WithField("path", configPath).Info("loaded config")
+		cfg, err := buildConfig()
+		if err != nil {
+			logger.WithError(err).Fatal("failed to build dmsg-discovery config")
 		}
 
-		var err error
-		if keyFile != "" {
-			if err = dmsgcmdutil.LoadOrGenerateKey(keyFile, &sk); err != nil {
-				log.Fatal("Failed to load keyfile: ", err)
-			}
-		}
-		if pk, err = sk.PubKey(); err != nil {
-			log.WithError(err).Warn("No SecKey found. Skipping serving on dmsghttp.")
-		}
-
-		stopPProf := dmsgcmdutil.InitPProf(log, pprofMode, pprofAddr)
-		defer stopPProf()
-
-		metricsutil.ServeHTTPMetrics(log, sf.MetricsAddr)
-
-		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		ctx, cancel := cmdutil.SignalContext(context.Background(), logger)
 		defer cancel()
-		db := prepareDB(ctx, log)
-
-		var m metrics.Metrics
-		if sf.MetricsAddr == "" {
-			m = metrics.NewEmpty()
-		} else {
-			m = metrics.NewVictoriaMetrics()
+		if err := dmsgdisc.New(cfg, logger).Run(ctx); err != nil {
+			logger.WithError(err).Fatal("dmsg-discovery: run failed")
 		}
-
-		var dmsgAddr string
-		if !pk.Null() {
-			dmsgAddr = fmt.Sprintf("%s:%d", pk.Hex(), dmsgPort)
-		}
-
-		// we enable metrics middleware if address is passed
-		enableMetrics := sf.MetricsAddr != ""
-		a := api.New(log, db, m, testMode, enableLoadTesting, enableMetrics, dmsgAddr, authPassphrase, entryTimeout)
-
-		var whitelistPKs []string
-		if whitelistKeys != "" {
-			whitelistPKs = strings.Split(whitelistKeys, ",")
-		}
-
-		for _, v := range whitelistPKs {
-			api.WhitelistPKs.Set(v)
-		}
-
-		a.OfficialServers, err = fetchOfficialDmsgServers(officialServers)
-		if err != nil {
-			log.Info(err)
-		}
-
-		// Resolve --mode. dmsg-discovery intentionally does NOT
-		// accept ModeDmsg because dmsg-servers themselves register
-		// with it over plain HTTP (see dmsg-server's disc.NewHTTP
-		// call). Allow ModeHTTP and ModeDual; reject ModeDmsg.
-		resolvedMode, err := svcmode.ResolveMode(mode, !sk.Null())
-		if err != nil {
-			log.WithError(err).Fatal("invalid --mode")
-		}
-		if resolvedMode == svcmode.ModeDmsg {
-			log.Fatal("dmsg-discovery cannot run in --mode=dmsg: dmsg-servers must reach it over plain HTTP to register. Use --mode=http or --mode=dual.")
-		}
-
-		go a.RunBackgroundTasks(ctx, log)
-		log.WithField("addr", addr).Info("Serving discovery API...")
-		go func() {
-			if listenErr := listenAndServe(addr, a); listenErr != nil {
-				log.Errorf("ListenAndServe: %v", listenErr)
-				cancel()
-			}
-		}()
-		if !pk.Null() && resolvedMode.IncludesDmsg() {
-			// Source priority for the dmsg-server transit set:
-			//   1. config.dmsg_servers from --config (config-file mode)
-			//   2. embedded deployment keyring (deployment.Prod, or
-			//      deployment.Test with --test-environment)
-			//   3. legacy API self-poll (the original bootstrap loop;
-			//      kept as last-resort safety net for binaries built
-			//      with an empty embedded keyring)
-			var servers []*disc.Entry
-			switch {
-			case len(configServers) > 0:
-				servers = configServers
-				log.WithField("count", len(servers)).WithField("source", "config").Info("preloading dmsg-servers from config")
-			default:
-				src := deployment.Prod
-				srcName := "deployment.Prod"
-				if testEnvironment {
-					src = deployment.Test
-					srcName = "deployment.Test"
-				}
-				servers = src.ToDiscEntries()
-				if len(servers) > 0 {
-					log.WithField("count", len(servers)).WithField("source", srcName).Info("preloading dmsg-servers from embedded deployment keyring")
-				} else {
-					log.Warn("no dmsg-servers in embedded deployment keyring; falling back to API self-poll (legacy behavior; will block until at least one server registers over HTTP)")
-					servers = getServers(ctx, a, dmsgServerType, log)
-				}
-			}
-			config := &dmsg.Config{
-				MinSessions:          0, // listen on all available servers
-				UpdateInterval:       dmsg.DefaultUpdateInterval,
-				ConnectedServersType: dmsgServerType,
-			}
-			var keys cipher.PubKeys
-			keys = append(keys, pk)
-			dClient := direct.NewClient(direct.GetAllEntries(keys, servers), log)
-
-			dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx, log, pk, sk, dClient, config)
-			if err != nil {
-				log.WithError(err).Fatal("failed to start direct dmsg client.")
-			}
-
-			defer closeDmsgDC()
-
-			go func() {
-				for {
-					a.DmsgServers = dmsgDC.ConnectedServersPK()
-					time.Sleep(time.Second)
-				}
-			}()
-
-			go updateServers(ctx, a, dClient, dmsgDC, dmsgServerType, log)
-
-			go func() {
-				if dmsgErr := dmsghttp.ListenAndServe(ctx, sk, a, dClient, dmsg.DefaultDmsgHTTPPort, dmsgDC, log); dmsgErr != nil {
-					log.Errorf("dmsghttp.ListenAndServe: %v", dmsgErr)
-					cancel()
-				}
-			}()
-
-			// Serve pprof debug interface over dmsg
-			wl := deployment.Prod.SurveyWhitelist
-			if testEnvironment {
-				wl = deployment.Test.SurveyWhitelist
-			}
-			go func() {
-				if debugErr := dmsghttp.ServeDebug(ctx, dmsgDC, log, wl); debugErr != nil {
-					log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
-				}
-			}()
-
-			// CXO clients-by-server publisher: outbound feed mirroring
-			// the AllClientsByServer / ClientsByServer view. Subscribers
-			// (the hypervisor's network visualizer) connect to DMSG-D's
-			// PK on skyenv.DmsgDMSGDClientsByServerCXOPort and read
-			// JSON-encoded client entries grouped by server PK from
-			// "clients-by-server/<server>/<client>/{entry,tombstone}"
-			// instead of HTTP-polling /dmsg-discovery/servers/clients.
-			if enableCXO {
-				if pub, perr := api.StartClientsByServerCXOPublisher(dmsgDC, sk, log); perr != nil {
-					log.WithError(perr).Error("Failed to start CXO clients-by-server publisher, continuing without it")
-				} else {
-					a.SetClientsByServerCXOPublisher(pub)
-					defer pub.Close() //nolint:errcheck
-				}
-			}
-
-		}
-
-		<-ctx.Done()
 	},
+}
+
+// buildConfig collects the cobra flag values and the optional
+// --config file into a single dmsgdisc.Config. When --config is
+// provided, file values take precedence over flag values for fields
+// the file sets; flag-only fields (or zero-valued file fields) keep
+// the flag default.
+func buildConfig() (*dmsgdisc.Config, error) {
+	cfg := &dmsgdisc.Config{
+		Addr:              addr,
+		Redis:             redisURL,
+		DmsgPort:          dmsgPort,
+		EntryTimeout:      entryTimeout,
+		Mode:              mode,
+		AuthPassphrase:    authPassphrase,
+		OfficialServers:   commaSplit(officialServers),
+		DmsgServerType:    dmsgServerType,
+		TestMode:          testMode,
+		EnableLoadTesting: enableLoadTesting,
+		TestEnvironment:   testEnvironment,
+		Whitelist:         commaSplit(whitelistKeys),
+		MetricsAddr:       sf.MetricsAddr,
+		PProfMode:         pprofMode,
+		PProfAddr:         pprofAddr,
+		EnableCXO:         enableCXO,
+	}
+
+	if keyFile != "" {
+		if err := loadOrGenerateKey(keyFile); err != nil {
+			return nil, err
+		}
+	}
+	if !sk.Null() {
+		cfg.SecKey = sk
+	}
+
+	if configPath != "" {
+		fileCfg, err := dmsgdisc.LoadFile(configPath)
+		if err != nil {
+			return nil, err
+		}
+		// file values win where set
+		mergeFile(cfg, fileCfg)
+	}
+	return cfg, nil
+}
+
+// mergeFile copies non-zero fields from src into dst. Mirrors the
+// previous applyConfig logic so behavior is unchanged: a partial
+// config file can override individual fields without erasing
+// flag-set values for the rest.
+func mergeFile(dst, src *dmsgdisc.Config) {
+	if src.SecKey != (cipher.SecKey{}) {
+		dst.SecKey = src.SecKey
+	}
+	if src.Addr != "" {
+		dst.Addr = src.Addr
+	}
+	if src.Redis != "" {
+		dst.Redis = src.Redis
+	}
+	if src.DmsgPort != 0 {
+		dst.DmsgPort = src.DmsgPort
+	}
+	if src.EntryTimeout != 0 {
+		dst.EntryTimeout = src.EntryTimeout
+	}
+	if src.Mode != "" {
+		dst.Mode = src.Mode
+	}
+	if src.AuthPassphrase != "" {
+		dst.AuthPassphrase = src.AuthPassphrase
+	}
+	if len(src.OfficialServers) > 0 {
+		dst.OfficialServers = src.OfficialServers
+	}
+	if src.DmsgServerType != "" {
+		dst.DmsgServerType = src.DmsgServerType
+	}
+	if src.TestMode {
+		dst.TestMode = true
+	}
+	if src.EnableLoadTesting {
+		dst.EnableLoadTesting = true
+	}
+	if src.TestEnvironment {
+		dst.TestEnvironment = true
+	}
+	if len(src.Whitelist) > 0 {
+		dst.Whitelist = src.Whitelist
+	}
+	if len(src.DmsgServers) > 0 {
+		dst.DmsgServers = src.DmsgServers
+	}
+	if src.EnableCXO {
+		dst.EnableCXO = true
+	}
+}
+
+func commaSplit(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func loadOrGenerateKey(path string) error {
+	return dmsgcmdutil.LoadOrGenerateKey(path, &sk)
 }
 
 // Execute executes root CLI command.
 func Execute() {
 	dmsgclient.Execute(RootCmd)
-}
-
-func prepareDB(ctx context.Context, log *logging.Logger) store.Storer {
-	dbConf := &store.Config{
-		URL:      redisURL,
-		Password: os.Getenv(redisPasswordEnvName),
-		Timeout:  entryTimeout,
-	}
-
-	db, err := store.NewStore(ctx, "redis", dbConf, log)
-	if err != nil {
-		log.Fatal("Failed to initialize redis store: ", err)
-	}
-
-	return db
-}
-
-func getServers(ctx context.Context, a *api.API, dmsgServerType string, log logrus.FieldLogger) (servers []*disc.Entry) {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-	for {
-		servers, err := a.AllServers(ctx, log)
-		if err != nil {
-			log.WithError(err).Fatal("Error getting dmsg-servers.")
-		}
-		// filtered dmsg servers by their type
-		if dmsgServerType != "" {
-			var filteredServers []*disc.Entry
-			for _, server := range servers {
-				if server.Server.ServerType == dmsgServerType {
-					filteredServers = append(filteredServers, server)
-				}
-			}
-			servers = filteredServers
-		}
-		if len(servers) > 0 {
-			return servers
-		}
-		log.Warn("No dmsg-servers found, trying again in 1 minute.")
-		select {
-		case <-ctx.Done():
-			return []*disc.Entry{}
-		case <-ticker.C:
-			return getServers(ctx, a, dmsgServerType, log)
-		}
-	}
-}
-
-func updateServers(ctx context.Context, a *api.API, dClient disc.APIClient, dmsgC *dmsg.Client, dmsgServerType string, log logrus.FieldLogger) {
-	ticker := time.NewTicker(time.Minute * 10)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			servers, err := a.AllServers(ctx, log)
-			if err != nil {
-				log.WithError(err).Error("Error getting dmsg-servers.")
-				break
-			}
-			// filtered dmsg servers by their type
-			if dmsgServerType != "" {
-				var filteredServers []*disc.Entry
-				for _, server := range servers {
-					if server.Server.ServerType == dmsgServerType {
-						filteredServers = append(filteredServers, server)
-					}
-				}
-				servers = filteredServers
-			}
-			for _, server := range servers {
-				dClient.PostEntry(ctx, server) //nolint
-				err := dmsgC.EnsureSession(ctx, server)
-				if err != nil {
-					log.WithField("remote_pk", server.Static).WithError(err).Warn("Failed to establish session.")
-				}
-			}
-		}
-	}
-}
-
-func listenAndServe(addr string, handler http.Handler) error {
-	srv := &http.Server{Addr: addr, Handler: handler, ReadTimeout: 3 * time.Second, WriteTimeout: 3 * time.Second, IdleTimeout: 30 * time.Second, ReadHeaderTimeout: 3 * time.Second}
-	if addr == "" {
-		addr = ":http"
-	}
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
-	}
-	proxyListener := &proxyproto.Listener{Listener: ln}
-	defer proxyListener.Close() // nolint:errcheck
-	return srv.Serve(proxyListener)
-}
-
-func fetchOfficialDmsgServers(officialServers string) (map[string]bool, error) {
-	dmsgServers := make(map[string]bool)
-	if officialServers != "" {
-		dmsgServersList := strings.Split(officialServers, ",")
-		for _, v := range dmsgServersList {
-			dmsgServers[v] = true
-		}
-		return dmsgServers, nil
-	}
-	return dmsgServers, errors.New("no official dmsg server list passed by --official-server flag")
 }

--- a/cmd/svc/skywire-services/commands/root.go
+++ b/cmd/svc/skywire-services/commands/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/skycoin/skywire/pkg/calvin"
 	// Side-effect imports register service factories with
 	// pkg/services so `skywire svc run` can dispatch them.
+	_ "github.com/skycoin/skywire/pkg/services/dmsgdisc"
 	_ "github.com/skycoin/skywire/pkg/services/noop"
 )
 

--- a/pkg/services/dmsgdisc/config.go
+++ b/pkg/services/dmsgdisc/config.go
@@ -1,25 +1,33 @@
-// Package commands cmd/dmsg-discovery/commands/config.go
-package commands
+// Package dmsgdisc pkg/services/dmsgdisc/config.go
+//
+// JSON schema for dmsg-discovery as both a standalone-service config
+// file (cmd/dmsg/dmsg-discovery -c path) AND a service block in a
+// multi-service services.json (skywire svc run --config services.json).
+// Both consumers parse the same struct so there's a single source of
+// truth for the field set.
+package dmsgdisc
 
 import (
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 )
 
-// Config is the JSON configuration for dmsg-discovery. When --config
-// is set, every runtime knob comes from this file; otherwise the
-// service falls back to the legacy per-flag CLI behavior so existing
-// deployments don't break. The schema mirrors the visor / dmsg-server
-// pattern: per-service knobs at the top, dmsg-server transit set in
-// `dmsg_servers` (replaces the runtime read of
-// deployment.Prod.DmsgServers).
+// Config is the JSON configuration for dmsg-discovery. Mirrors the
+// cobra-flag set on cmd/dmsg/dmsg-discovery so a config file or a
+// services.json block can drive the same Run() with no flag-only
+// surprises.
+//
+// In services.json the block also carries `type: "dmsg-discovery"`
+// and an optional `name`; those fields are consumed by the
+// supervisor and are accepted-but-ignored by this struct (json
+// "type" / "name" tags omitted — DisallowUnknownFields is OFF for
+// the block path so the supervisor's framing fields pass through).
 type Config struct {
 	Path string `json:"-"`
 
@@ -61,6 +69,15 @@ type Config struct {
 	Whitelist []string `json:"whitelist_keys,omitempty"`
 	// LogLevel is the minimum log level (debug/info/warn/error).
 	LogLevel string `json:"log_level,omitempty"`
+	// MetricsAddr is the address to expose Prometheus metrics on
+	// (empty disables metrics).
+	MetricsAddr string `json:"metrics_addr,omitempty"`
+	// PProfMode / PProfAddr — pass-through to dmsgcmdutil.InitPProf.
+	PProfMode string `json:"pprof_mode,omitempty"`
+	PProfAddr string `json:"pprof_addr,omitempty"`
+	// EnableCXO turns on the CXO clients-by-server publisher feed
+	// over DMSG. Requires SecKey and a dmsg-capable Mode.
+	EnableCXO bool `json:"cxo,omitempty"`
 
 	// DmsgServers is the static dmsg-server transit set the
 	// discovery preloads at startup. Replaces the runtime read of
@@ -71,57 +88,14 @@ type Config struct {
 	DmsgServers []*disc.Entry `json:"dmsg_servers,omitempty"`
 }
 
-// applyConfig copies values from a parsed Config into the
-// package-level cobra-flag variables that the rest of Run consumes,
-// turning --config into a single source of truth. Empty / zero
-// fields in Config preserve the existing CLI-flag value, so a
-// partial config still leaves the rest at their defaults.
-func applyConfig(c *Config) {
-	if c.SecKey != (cipher.SecKey{}) {
-		sk = c.SecKey
-	}
-	if c.Addr != "" {
-		addr = c.Addr
-	}
-	if c.Redis != "" {
-		redisURL = c.Redis
-	}
-	if c.DmsgPort != 0 {
-		dmsgPort = c.DmsgPort
-	}
-	if c.EntryTimeout != 0 {
-		entryTimeout = c.EntryTimeout
-	}
-	if c.Mode != "" {
-		mode = c.Mode
-	}
-	if c.AuthPassphrase != "" {
-		authPassphrase = c.AuthPassphrase
-	}
-	if len(c.OfficialServers) > 0 {
-		officialServers = strings.Join(c.OfficialServers, ",")
-	}
-	if c.DmsgServerType != "" {
-		dmsgServerType = c.DmsgServerType
-	}
-	if c.TestMode {
-		testMode = true
-	}
-	if c.EnableLoadTesting {
-		enableLoadTesting = true
-	}
-	if c.TestEnvironment {
-		testEnvironment = true
-	}
-	if len(c.Whitelist) > 0 {
-		whitelistKeys = strings.Join(c.Whitelist, ",")
-	}
-}
-
-// LoadConfig reads, parses, and returns a Config from the given path.
+// LoadFile reads, parses, and returns a Config from the given path.
 // Returns an error if the file is missing, malformed, or has fields
 // the JSON decoder doesn't recognize (strict decoding catches typos).
-func LoadConfig(path string) (*Config, error) {
+//
+// Used by the standalone cobra command (`skywire dmsg disc -c path`).
+// The multi-service supervisor goes through ParseBlock instead since
+// it has the bytes already.
+func LoadFile(path string) (*Config, error) {
 	data, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("read config %q: %w", path, err)
@@ -133,5 +107,18 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %q: %w", path, err)
 	}
 	c.Path = path
+	return &c, nil
+}
+
+// ParseBlock decodes a services.json block (the inline JSON object
+// the supervisor passes through Block.Raw) into a Config. Unlike
+// LoadFile, this path tolerates unknown fields — the supervisor's
+// framing keys ("type", "name") arrive in the same object, and any
+// future inline-block extension shouldn't break older binaries.
+func ParseBlock(raw []byte) (*Config, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("dmsg-discovery: parse block: %w", err)
+	}
 	return &c, nil
 }

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -1,0 +1,395 @@
+// Package dmsgdisc pkg/services/dmsgdisc/dmsgdisc.go
+//
+// dmsg-discovery as a pkg/services.Service. Both the standalone
+// cobra command (`skywire dmsg disc`) and the multi-service
+// supervisor (`skywire svc run`) end up calling Run(ctx, cfg, log) —
+// the per-flag CLI path lives in cmd/dmsg/dmsg-discovery and
+// constructs the Config from flags + optional --config file before
+// handing off to Run.
+//
+// dmsg-discovery is a "register-by-HTTP, query-by-HTTP-or-DMSG"
+// service: dmsg-servers reach it over plain HTTP (so --mode=dmsg is
+// rejected), but visors and operators may query it over either
+// transport. The Run loop bootstraps an HTTP listener immediately
+// and, when SecKey is set and the resolved Mode includes DMSG,
+// brings up a dmsg.Client for the dmsghttp / pprof / CXO publisher
+// surfaces.
+package dmsgdisc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	proxyproto "github.com/pires/go-proxyproto"
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/disc/metrics"
+	"github.com/skycoin/skywire/pkg/dmsg/discovery/api"
+	"github.com/skycoin/skywire/pkg/dmsg/discovery/store"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/metricsutil"
+	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/svcmode"
+)
+
+// Type is the registry key used in services.json blocks.
+const Type = "dmsg-discovery"
+
+// RedisPasswordEnvName is the env var the redis store reads its
+// password from. Re-exported so the cobra command's help text and
+// the multi-service runner's docs can reference the same constant.
+const RedisPasswordEnvName = "REDIS_PASSWORD"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// factory parses a services.json block into a Config and returns a
+// Service. The supervisor calls this once per dmsg-discovery block.
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	cfg, err := ParseBlock(raw)
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg, log), nil
+}
+
+// New builds a Service from an already-parsed Config. Used by the
+// cobra command (which builds Config from flags) and by factory
+// (which builds Config from JSON).
+func New(cfg *Config, log *logging.Logger) services.Service {
+	return &service{cfg: cfg, log: log}
+}
+
+// service is the runnable instance. Lowercase: callers go through
+// New / factory so we can change the internal layout freely.
+type service struct {
+	cfg *Config
+	log *logging.Logger
+}
+
+// Run is the long-lived run loop. Returns when ctx cancels or a
+// fatal startup error occurs (bad config, invalid PK pairing,
+// unrecoverable redis init).
+//
+// Lifecycle:
+//  1. Resolve SecKey/PubKey, optional pprof, metrics endpoint
+//  2. Open redis store and build the dmsg-discovery API
+//  3. Resolve --mode (rejects pure DMSG mode for this service)
+//  4. Start HTTP listener; if dmsg-capable, start dmsg client +
+//     dmsghttp + debug/pprof + optional CXO publisher
+//  5. Block on ctx.Done()
+func (s *service) Run(ctx context.Context) error {
+	cfg := s.cfg
+	log := s.log
+
+	pk, sk := cfg.PubKey, cfg.SecKey
+	if pk.Null() && !sk.Null() {
+		var err error
+		if pk, err = sk.PubKey(); err != nil {
+			log.WithError(err).Warn("dmsg-discovery: derive public key from secret key failed; skipping dmsg surfaces")
+		}
+	}
+
+	stopPProf := dmsgcmdutil.InitPProf(log, cfg.PProfMode, cfg.PProfAddr)
+	defer stopPProf()
+
+	metricsutil.ServeHTTPMetrics(log, cfg.MetricsAddr)
+
+	db, err := openStore(ctx, cfg, log)
+	if err != nil {
+		return fmt.Errorf("dmsg-discovery: open store: %w", err)
+	}
+
+	var m metrics.Metrics
+	if cfg.MetricsAddr == "" {
+		m = metrics.NewEmpty()
+	} else {
+		m = metrics.NewVictoriaMetrics()
+	}
+
+	var dmsgAddr string
+	if !pk.Null() {
+		dmsgPort := cfg.DmsgPort
+		if dmsgPort == 0 {
+			dmsgPort = dmsg.DefaultDmsgHTTPPort
+		}
+		dmsgAddr = fmt.Sprintf("%s:%d", pk.Hex(), dmsgPort)
+	}
+	enableMetrics := cfg.MetricsAddr != ""
+	entryTimeout := cfg.EntryTimeout
+	a := api.New(log, db, m, cfg.TestMode, cfg.EnableLoadTesting, enableMetrics, dmsgAddr, cfg.AuthPassphrase, entryTimeout)
+
+	for _, k := range cfg.Whitelist {
+		api.WhitelistPKs.Set(k)
+	}
+
+	a.OfficialServers = officialServersMap(cfg.OfficialServers)
+
+	resolvedMode, err := svcmode.ResolveMode(cfg.Mode, !sk.Null())
+	if err != nil {
+		return fmt.Errorf("dmsg-discovery: invalid mode %q: %w", cfg.Mode, err)
+	}
+	if resolvedMode == svcmode.ModeDmsg {
+		return errors.New("dmsg-discovery: cannot run in mode=dmsg — dmsg-servers must reach this service over plain HTTP to register; use mode=http or mode=dual")
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go a.RunBackgroundTasks(runCtx, log)
+
+	addr := cfg.Addr
+	if addr == "" {
+		addr = ":9090"
+	}
+	log.WithField("addr", addr).Info("Serving discovery API...")
+	go func() {
+		if listenErr := listenAndServe(addr, a); listenErr != nil {
+			log.Errorf("ListenAndServe: %v", listenErr)
+			cancel()
+		}
+	}()
+
+	if !pk.Null() && resolvedMode.IncludesDmsg() {
+		if err := s.runDMSG(runCtx, cancel, cfg, a, pk, sk, log); err != nil {
+			return err
+		}
+	}
+
+	<-runCtx.Done()
+	return nil
+}
+
+func (s *service) runDMSG(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	cfg *Config,
+	a *api.API,
+	pk cipher.PubKey,
+	sk cipher.SecKey,
+	log *logging.Logger,
+) error {
+	// Source priority for the dmsg-server transit set:
+	//   1. config.dmsg_servers (explicit list)
+	//   2. embedded deployment keyring (Prod, or Test when
+	//      TestEnvironment is set)
+	//   3. legacy API self-poll (last-resort: blocks until at least
+	//      one server registers over HTTP)
+	var servers []*disc.Entry
+	switch {
+	case len(cfg.DmsgServers) > 0:
+		servers = cfg.DmsgServers
+		log.WithField("count", len(servers)).WithField("source", "config").
+			Info("preloading dmsg-servers from config")
+	default:
+		src := deployment.Prod
+		srcName := "deployment.Prod"
+		if cfg.TestEnvironment {
+			src = deployment.Test
+			srcName = "deployment.Test"
+		}
+		servers = src.ToDiscEntries()
+		if len(servers) > 0 {
+			log.WithField("count", len(servers)).WithField("source", srcName).
+				Info("preloading dmsg-servers from embedded deployment keyring")
+		} else {
+			log.Warn("no dmsg-servers in embedded deployment keyring; falling back to API self-poll (legacy behavior; blocks until at least one server registers over HTTP)")
+			servers = pollServersUntilFound(ctx, a, cfg.DmsgServerType, log)
+		}
+	}
+
+	dmsgCfg := &dmsg.Config{
+		MinSessions:          0,
+		UpdateInterval:       dmsg.DefaultUpdateInterval,
+		ConnectedServersType: cfg.DmsgServerType,
+	}
+	keys := cipher.PubKeys{pk}
+	dClient := direct.NewClient(direct.GetAllEntries(keys, servers), log)
+
+	dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx, log, pk, sk, dClient, dmsgCfg)
+	if err != nil {
+		return fmt.Errorf("dmsg-discovery: start direct dmsg client: %w", err)
+	}
+	go func() {
+		<-ctx.Done()
+		closeDmsgDC()
+	}()
+
+	go func() {
+		t := time.NewTicker(time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				a.DmsgServers = dmsgDC.ConnectedServersPK()
+			}
+		}
+	}()
+
+	go updateServers(ctx, a, dClient, dmsgDC, cfg.DmsgServerType, log)
+
+	go func() {
+		if dmsgErr := dmsghttp.ListenAndServe(ctx, sk, a, dClient, dmsg.DefaultDmsgHTTPPort, dmsgDC, log); dmsgErr != nil {
+			log.Errorf("dmsghttp.ListenAndServe: %v", dmsgErr)
+			cancel()
+		}
+	}()
+
+	wl := deployment.Prod.SurveyWhitelist
+	if cfg.TestEnvironment {
+		wl = deployment.Test.SurveyWhitelist
+	}
+	go func() {
+		if debugErr := dmsghttp.ServeDebug(ctx, dmsgDC, log, wl); debugErr != nil {
+			log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
+		}
+	}()
+
+	if cfg.EnableCXO {
+		pub, perr := api.StartClientsByServerCXOPublisher(dmsgDC, sk, log)
+		if perr != nil {
+			log.WithError(perr).Error("Failed to start CXO clients-by-server publisher, continuing without it")
+		} else {
+			a.SetClientsByServerCXOPublisher(pub)
+			go func() {
+				<-ctx.Done()
+				pub.Close() //nolint:errcheck,gosec
+			}()
+		}
+	}
+
+	return nil
+}
+
+func openStore(ctx context.Context, cfg *Config, log *logging.Logger) (store.Storer, error) {
+	dbConf := &store.Config{
+		URL:      cfg.Redis,
+		Password: os.Getenv(RedisPasswordEnvName),
+		Timeout:  cfg.EntryTimeout,
+	}
+	if dbConf.URL == "" {
+		dbConf.URL = store.DefaultURL
+	}
+	return store.NewStore(ctx, "redis", dbConf, log)
+}
+
+func officialServersMap(list []string) map[string]bool {
+	if len(list) == 0 {
+		return map[string]bool{}
+	}
+	m := make(map[string]bool, len(list))
+	for _, k := range list {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			m[k] = true
+		}
+	}
+	return m
+}
+
+// pollServersUntilFound is the legacy bootstrap loop kept as a
+// last-resort safety net for binaries built with an empty embedded
+// keyring. Polls the API every minute until a non-empty server set
+// shows up, or ctx cancels (returns empty in that case).
+func pollServersUntilFound(ctx context.Context, a *api.API, dmsgServerType string, log logrus.FieldLogger) []*disc.Entry {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		servers, err := a.AllServers(ctx, log)
+		if err != nil {
+			log.WithError(err).Error("error getting dmsg-servers")
+		}
+		if dmsgServerType != "" {
+			servers = filterServersByType(servers, dmsgServerType)
+		}
+		if len(servers) > 0 {
+			return servers
+		}
+		log.Warn("no dmsg-servers found, retrying in 1 minute")
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// updateServers periodically re-resolves the dmsg-server transit set
+// and re-establishes sessions to anything new. Was the original
+// runtime sync mechanism before the embedded keyring + config-file
+// preload landed; kept for the case where new servers register after
+// startup.
+func updateServers(ctx context.Context, a *api.API, dClient disc.APIClient, dmsgC *dmsg.Client, dmsgServerType string, log logrus.FieldLogger) {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			servers, err := a.AllServers(ctx, log)
+			if err != nil {
+				log.WithError(err).Error("error getting dmsg-servers")
+				continue
+			}
+			if dmsgServerType != "" {
+				servers = filterServersByType(servers, dmsgServerType)
+			}
+			for _, server := range servers {
+				dClient.PostEntry(ctx, server) //nolint:errcheck,gosec
+				if err := dmsgC.EnsureSession(ctx, server); err != nil {
+					log.WithField("remote_pk", server.Static).WithError(err).
+						Warn("failed to establish session")
+				}
+			}
+		}
+	}
+}
+
+func filterServersByType(in []*disc.Entry, dmsgServerType string) []*disc.Entry {
+	out := make([]*disc.Entry, 0, len(in))
+	for _, s := range in {
+		if s.Server != nil && s.Server.ServerType == dmsgServerType {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func listenAndServe(addr string, handler http.Handler) error {
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadTimeout:       3 * time.Second,
+		WriteTimeout:      3 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	if addr == "" {
+		addr = ":http"
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	proxyListener := &proxyproto.Listener{Listener: ln}
+	defer proxyListener.Close() //nolint:errcheck
+	return srv.Serve(proxyListener)
+}


### PR DESCRIPTION
## Summary
- Extracts `cmd/dmsg/dmsg-discovery`'s run loop into `pkg/services/dmsgdisc.Run(ctx)`. Standalone `skywire dmsg disc` cobra command is now a thin wrapper that builds a Config from flags and calls Run.
- Registers the `dmsg-discovery` type with the multi-service supervisor — `skywire svc run --list` now shows it.
- Moves the existing Config struct + LoadFile/ParseBlock into the package so file-driven (cobra `-c`) and block-driven (services.json) startup share one schema.

## Behavioral parity
- Same flag surface; same --mode resolution (ModeDmsg still rejected); same dmsg-server transit-set priority (config > embedded keyring > API self-poll); same redis bootstrap; same EntryTimeout / CXO publisher gates.
- Standalone binary unchanged from an operator's POV.

## Next
dmsg-server migration follows the same shape; then the `cmd/svc/` batch (tpd/sd/ar/rf/sn/tps/stun); then docker-compose collapse.

## Test plan
- [x] `go build ./...`
- [x] `make lint` (0 issues)
- [x] `skywire svc run --list` shows `dmsg-discovery`
- [ ] e2e validation deferred until full set of deployment services migrated and `docker-compose.yml` collapsed