### PR TITLE
feat(svc): migrate dmsg-server onto pkg/services framework

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -1,45 +1,28 @@
 // Package start cmd/dmsg-server/commands/start/root.go
+//
+// Cobra entry point for `skywire dmsg server start`. Parses flags
+// and the JSON config file into a dmsgsrv.Config, then hands off to
+// pkg/services/dmsgsrv. The actual run loop lives there so the
+// multi-service supervisor (`skywire svc run`) can host the same
+// service from a JSON block.
 package start
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log"
-	"net"
-	"net/http"
-	"net/rpc"
-	"net/url"
 	"os"
-	"strconv"
-	"time"
 
-	chi "github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
 	"github.com/spf13/cobra"
 
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
-	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
-	"github.com/skycoin/skywire/pkg/dmsg/direct"
-	"github.com/skycoin/skywire/pkg/dmsg/disc"
-	"github.com/skycoin/skywire/pkg/dmsg/disc/dmsgfirst"
-	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgserver"
-	"github.com/skycoin/skywire/pkg/geoip"
-	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
-	"github.com/skycoin/skywire/pkg/metricsutil"
-	"github.com/skycoin/skywire/pkg/router"
-	"github.com/skycoin/skywire/pkg/router/setupmetrics"
-	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/services/dmsgsrv"
 )
 
 var (
@@ -66,340 +49,35 @@ var RootCmd = &cobra.Command{
 			log.Printf("Failed to output build info: %v", err)
 		}
 
-		log := sf.Logger()
+		logger := sf.Logger()
 
-		var conf dmsgserver.Config
-		if err := sf.ParseConfig(os.Args, true, &conf, configNotFound); err != nil {
-			log.WithError(err).Fatal("parsing config failed, generating default one...")
+		var inner dmsgserver.Config
+		if err := sf.ParseConfig(os.Args, true, &inner, configNotFound); err != nil {
+			logger.WithError(err).Fatal("parsing config failed, generating default one...")
 		}
 
-		logLvl, _, err := cmdutil.LevelFromString(conf.LogLevel)
+		logLvl, _, err := cmdutil.LevelFromString(inner.LogLevel)
 		if err != nil {
 			log.Printf("Failed to set log level: %v", err)
 		}
 		logging.SetLevel(logLvl)
 
-		stopPProf := dmsgcmdutil.InitPProf(log, pprofMode, pprofAddr)
+		cfg := &dmsgsrv.Config{
+			Config:         inner,
+			AuthPassphrase: authPassphrase,
+			PProfMode:      pprofMode,
+			PProfAddr:      pprofAddr,
+			MetricsAddr:    sf.MetricsAddr,
+		}
+
+		stopPProf := dmsgcmdutil.InitPProf(logger, cfg.PProfMode, cfg.PProfAddr)
 		defer stopPProf()
 
-		if conf.MaxSessions <= 0 {
-			conf.MaxSessions = dmsg.DefaultMaxSessions
-		}
-
-		if conf.HTTPAddress == "" {
-			u, err := url.Parse(conf.LocalAddress)
-			if err != nil {
-				log.Fatal("unable to parse local address url: ", err)
-			}
-			hp, err := strconv.Atoi(u.Port())
-			if err != nil {
-				log.Fatal("unable to parse local address url: ", err)
-			}
-			httpPort := strconv.Itoa(hp + 1)
-			conf.HTTPAddress = ":" + httpPort
-		}
-
-		var m metrics.Metrics
-		if sf.MetricsAddr == "" {
-			m = metrics.NewEmpty()
-		} else {
-			m = metrics.NewVictoriaMetrics()
-		}
-
-		metricsutil.ServeHTTPMetrics(log, sf.MetricsAddr)
-
-		r := chi.NewRouter()
-		r.Use(middleware.RequestID)
-		r.Use(middleware.RealIP)
-		r.Use(middleware.Logger)
-		r.Use(middleware.Recoverer)
-
-		srvAPI := dmsgserver.NewServerAPI(r, log, m)
-
-		// Convert peer config to dmsg.PeerEntry.
-		var peers []dmsg.PeerEntry
-		for _, p := range conf.Peers {
-			peers = append(peers, dmsg.PeerEntry{PK: p.PubKey, Addr: p.Address})
-		}
-
-		srvConf := dmsg.ServerConfig{
-			MaxSessions:    conf.MaxSessions,
-			UpdateInterval: conf.UpdateInterval,
-			AuthPassphrase: authPassphrase,
-			Peers:          peers,
-		}
-
-		// Resolve the configured deployments. NormalizedDeployments
-		// folds the legacy Discovery / DiscoveryDmsg / PublicAddress
-		// fields into a one-element list so existing config files
-		// continue to work unchanged.
-		deployments := conf.NormalizedDeployments()
-		if len(deployments) == 0 {
-			log.Fatal("no dmsg-discoveries configured; set 'discovery' or 'dmsg' in config")
-		}
-
-		// Primary discovery is the first in the list. NewServer takes a
-		// single primary; we attach extras via srv.AddDiscovery once the
-		// server is constructed. Using plain HTTP at construction time;
-		// once the server's outbound dmsg.Client is up later, the
-		// discovery clients are swapped for dmsgfirst-wrapped versions
-		// so registration prefers DMSG when available.
-		primaryHTTP := disc.NewHTTP(deployments[0].Discovery, &http.Client{}, log)
-		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, primaryHTTP, &srvConf, m)
-		srv.SetLogger(log)
-
-		// Wire the geo lookup hook so visors using LookupIPGeo can get
-		// their public IP and its geolocation in a single round-trip
-		// without HTTP-calling the geoip service. The DB is embedded
-		// in pkg/geoip and shared with the standalone geoip service
-		// and the visor's local fallback path. A failure to open the
-		// DB (corrupt embed, etc.) leaves the hook unset; older
-		// LookupIP callers still work, and LookupIPGeo callers see
-		// empty geo fields and fall back to local lookup.
-		if geoDB, err := geoip.OpenEmbedded(); err != nil {
-			log.WithError(err).Warn("failed to open embedded geoip DB; LookupIPGeo will return empty geo fields")
-		} else {
-			srv.SetGeoLookup(func(ip net.IP) (country, region string, lat, lon float64) {
-				res, err := geoip.Lookup(geoDB, ip.String())
-				if err != nil || res == nil {
-					return "", "", 0, 0
-				}
-				if res.Latitude != nil {
-					lat = *res.Latitude
-				}
-				if res.Longitude != nil {
-					lon = *res.Longitude
-				}
-				return res.CountryCode, res.RegionCode, lat, lon
-			})
-		}
-
-		// Attach extras (each with its own per-deployment advertised
-		// address). The primary's advertised address is passed through
-		// the legacy Serve(..., publicAddr) path below.
-		for i := 1; i < len(deployments); i++ {
-			extra := deployments[i]
-			srv.AddDiscovery(
-				disc.NewHTTP(extra.Discovery, &http.Client{}, log),
-				extra.AdvertisedAddress,
-				dmsgserver.PKFromDmsgURL(extra.DiscoveryDmsg),
-			)
-		}
-
-		srvAPI.SetDmsgServer(srv)
-		defer func() { log.WithError(srvAPI.Close()).Info("Closed server.") }()
-
-		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		ctx, cancel := cmdutil.SignalContext(context.Background(), logger)
 		defer cancel()
-
-		// The Server's primary discovery uses the first deployment's
-		// advertised address as the default (passed through Serve).
-		// AdvertisedAddress on extras overrides per-endpoint inside
-		// EntityCommon's update loop.
-		primaryAdvertised := deployments[0].AdvertisedAddress
-		if primaryAdvertised == "" {
-			primaryAdvertised = conf.PublicAddress
+		if err := dmsgsrv.New(cfg, logger).Run(ctx); err != nil {
+			logger.WithError(err).Fatal("dmsg-server: run failed")
 		}
-
-		go srvAPI.RunBackgroundTasks(ctx)
-		log.WithField("addr", conf.HTTPAddress).Info("Serving server API...")
-		go func() {
-			if err := srvAPI.ListenAndServe(conf.LocalAddress, primaryAdvertised, conf.HTTPAddress); err != nil {
-				log.Errorf("Serve: %v", err)
-				cancel()
-			}
-		}()
-
-		// Serve DMSG services using a direct client through ourselves:
-		// - /health on port 80 (DMSG HTTP)
-		// - /debug/pprof on port 81 (DMSG debug)
-		// - Route setup-node on port 36 (DMSG RPC)
-		go func() {
-			<-srv.Ready()
-
-			serverEntry := &disc.Entry{
-				Version: "0.0.1",
-				Static:  conf.PubKey,
-				Server: &disc.Server{
-					Address:           conf.PublicAddress,
-					AvailableSessions: conf.MaxSessions,
-				},
-			}
-
-			// Build the direct client's static view: this server's own
-			// entry plus every peer dmsg-server from the embedded
-			// deployment list (excluding self). Without the peer entries
-			// the direct client could only resolve its own PK, so any
-			// outbound dmsg dial from this process — most importantly
-			// the DHT bootstrap pings and inter-server DHT replication
-			// over the dmsg DHT transport — failed with
-			// "entry of public key is not found", and every bootstrap
-			// peer wound up cached as non-DHT until restart. Mirrors
-			// the BootstrapDmsg helper that every other deployment
-			// service uses (pkg/cmdutil/dmsg_bootstrap.go).
-			// Build the transit set: the union of (a) per-discovery
-			// servers from the config (multi-deployment case where
-			// each discovery has its own disjoint server set), (b) the
-			// embedded deployment keyring (single-deployment fallback),
-			// minus this server itself. Each discovery's `servers` list
-			// expresses which dmsg-servers reach THAT discovery; the
-			// union ensures dmsgC has a session-relayable path to every
-			// configured discovery.
-			servers := []*disc.Entry{serverEntry}
-			seenPK := map[cipher.PubKey]struct{}{conf.PubKey: {}}
-			addServer := func(e *disc.Entry) {
-				if e == nil {
-					return
-				}
-				if _, ok := seenPK[e.Static]; ok {
-					return
-				}
-				seenPK[e.Static] = struct{}{}
-				servers = append(servers, e)
-			}
-			for _, d := range deployments {
-				for _, e := range d.Servers {
-					addServer(e)
-				}
-			}
-			for i := range dmsg.Prod.DmsgServers {
-				addServer(&dmsg.Prod.DmsgServers[i])
-			}
-			entries := direct.GetAllEntries(cipher.PubKeys{conf.PubKey}, servers)
-			dClient := direct.NewClient(entries, log)
-
-			debugConfig := &dmsg.Config{
-				MinSessions: 0,
-			}
-			dmsgC, closeDebug, err := direct.StartDmsg(ctx, log, conf.PubKey, conf.SecKey, dClient, debugConfig)
-			if err != nil {
-				log.WithError(err).Error("failed to start dmsg client for server services")
-				return
-			}
-			defer closeDebug()
-
-			// Upgrade each configured discovery client from plain HTTP
-			// to dmsgfirst — registration then tries DMSG first and
-			// only falls back to HTTP if the dmsg dial fails. The PK
-			// is extracted from the deployment's discovery_dmsg URL;
-			// when discovery_dmsg is unset, dmsgfirst can't dial it
-			// over DMSG, so we leave that entry on plain HTTP and log it.
-			upgraded := make([]disc.APIClient, len(deployments))
-			for i, d := range deployments {
-				pk := dmsgserver.PKFromDmsgURL(d.DiscoveryDmsg)
-				if pk == (cipher.PubKey{}) {
-					upgraded[i] = disc.NewHTTP(d.Discovery, &http.Client{}, log)
-					log.WithField("url", d.Discovery).Debug("discovery_dmsg unset; staying on plain HTTP")
-					continue
-				}
-				upgraded[i] = dmsgfirst.New(dmsgC, pk, d.Discovery, &http.Client{}, log)
-				log.WithField("url", d.Discovery).WithField("pk", pk).Info("discovery upgraded to dmsg-first registration")
-			}
-			srv.SetDiscoveryClients(upgraded)
-
-			// Health endpoint on port 80
-			startedAt := time.Now()
-			dmsgAddr := fmt.Sprintf("%s:%d", conf.PubKey.Hex(), dmsg.DefaultDmsgHTTPPort)
-			healthMux := http.NewServeMux()
-			healthMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-
-				// Collect peer server PKs for the health response.
-				var peerPKs []string
-				for _, p := range conf.Peers {
-					peerPKs = append(peerPKs, p.PubKey.Hex())
-				}
-
-				resp := httputil.HealthCheckResponse{
-					ServiceName:   "dmsg-server",
-					BuildInfo:     buildinfo.Get(),
-					StartedAt:     startedAt,
-					DmsgAddr:      dmsgAddr,
-					DmsgDiscovery: conf.Discovery,
-					PeerServers:   peerPKs,
-				}
-				json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
-			})
-
-			go func() {
-				if err := dmsghttp.ListenAndServe(ctx, conf.SecKey, healthMux, dClient,
-					dmsg.DefaultDmsgHTTPPort, dmsgC, log); err != nil {
-					log.WithError(err).Error("DMSG HTTP health server stopped")
-				}
-			}()
-			log.Infof("DMSG HTTP health endpoint available at %s", dmsgAddr)
-
-			// Debug/pprof endpoint on port 81
-			go func() {
-				if debugErr := dmsghttp.ServeDebug(ctx, dmsgC, log, deployment.Prod.SurveyWhitelist); debugErr != nil {
-					log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
-				}
-			}()
-
-			// Route setup-node on port 36 (optional, enabled via config)
-			if conf.EnableRouteSetup {
-				go func() {
-					snLog := logging.MustGetLogger("dmsg-server:setup-node")
-					snLog.Info("Starting integrated route setup-node")
-
-					lis, lisErr := dmsgC.Listen(skyenv.DmsgSetupPort)
-					if lisErr != nil {
-						snLog.WithError(lisErr).Error("Failed to listen on setup port")
-						return
-					}
-					defer lis.Close() //nolint:errcheck
-
-					snLog.WithField("dmsg_port", skyenv.DmsgSetupPort).Info("Route setup-node listening")
-
-					const maxConcurrent = 20
-					sem := make(chan struct{}, maxConcurrent)
-					setupMetrics := setupmetrics.NewEmpty()
-
-					for {
-						conn, accErr := lis.AcceptStream()
-						if accErr != nil {
-							if ctx.Err() != nil || errors.Is(accErr, dmsg.ErrEntityClosed) {
-								snLog.Debug("Route setup-node listener stopped")
-								return
-							}
-							snLog.WithError(accErr).Warn("Failed to accept setup stream")
-							continue
-						}
-
-						reqPK := conn.RemoteAddr().(dmsg.Addr).PK
-						snLog.WithField("remote_pk", reqPK).Debug("Accepted route setup request")
-
-						gw := &router.SetupRPCGateway{
-							Metrics: setupMetrics,
-							Ctx:     ctx,
-							Conn:    conn,
-							ReqPK:   reqPK,
-							Dialer:  router.WrapDmsgClient(dmsgC),
-							Timeout: 2 * time.Minute,
-						}
-
-						rpcS := rpc.NewServer()
-						if regErr := rpcS.Register(gw); regErr != nil {
-							snLog.WithError(regErr).Error("Failed to register setup RPC")
-							conn.Close() //nolint:errcheck,gosec
-							continue
-						}
-
-						go func() {
-							sem <- struct{}{}
-							defer func() { <-sem }()
-							rpcS.ServeConn(conn)
-						}()
-					}
-				}()
-			} else {
-				log.Info("Route setup-node disabled (enable with enable_route_setup in config)")
-			}
-
-			<-ctx.Done()
-		}()
-
-		<-ctx.Done()
 	},
 }
 

--- a/cmd/svc/skywire-services/commands/root.go
+++ b/cmd/svc/skywire-services/commands/root.go
@@ -29,6 +29,7 @@ import (
 	// Side-effect imports register service factories with
 	// pkg/services so `skywire svc run` can dispatch them.
 	_ "github.com/skycoin/skywire/pkg/services/dmsgdisc"
+	_ "github.com/skycoin/skywire/pkg/services/dmsgsrv"
 	_ "github.com/skycoin/skywire/pkg/services/noop"
 )
 

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -1,0 +1,406 @@
+// Package dmsgsrv pkg/services/dmsgsrv/dmsgsrv.go
+//
+// dmsg-server as a pkg/services.Service. Wraps the existing
+// pkg/dmsg/dmsgserver primitives (Config, ServerAPI) so the
+// multi-service supervisor (`skywire svc run`) can host a dmsg-server
+// alongside dmsg-discovery and the rest of the deployment services
+// in one process.
+//
+// The standalone `skywire dmsg server start` cobra command keeps
+// working — it parses flags + JSON config into a dmsgsrv.Config and
+// hands off to Run. The low-level dmsg-server primitives stay in
+// pkg/dmsg/dmsgserver; this package is purely the run-loop wrapper.
+package dmsgsrv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/rpc"
+	"net/url"
+	"strconv"
+	"time"
+
+	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/disc/dmsgfirst"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgserver"
+	"github.com/skycoin/skywire/pkg/geoip"
+	"github.com/skycoin/skywire/pkg/httputil"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/metricsutil"
+	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/router/setupmetrics"
+	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// Type is the registry key used in services.json blocks.
+const Type = "dmsg-server"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// Config wraps the existing dmsgserver.Config and adds the runtime
+// knobs that previously came from cobra flags rather than the JSON
+// file (auth passphrase, pprof, metrics). When loaded from a JSON
+// services-block, all fields parse from the same flat object.
+type Config struct {
+	dmsgserver.Config
+
+	// AuthPassphrase, when non-empty, is the shared secret a
+	// dmsg-server presents to the discovery for "official" server
+	// registration. Previously a CLI-only flag.
+	AuthPassphrase string `json:"auth_passphrase,omitempty"`
+	// PProfMode / PProfAddr — pass-through to dmsgcmdutil.InitPProf.
+	PProfMode string `json:"pprof_mode,omitempty"`
+	PProfAddr string `json:"pprof_addr,omitempty"`
+	// MetricsAddr is the address to expose Prometheus metrics on
+	// (empty disables metrics).
+	MetricsAddr string `json:"metrics_addr,omitempty"`
+}
+
+// factory parses a services.json block into a Config and returns a
+// Service.
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	cfg, err := ParseBlock(raw)
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg, log), nil
+}
+
+// ParseBlock decodes a services.json block into a Config. Tolerant
+// of unknown fields (the supervisor's framing keys "type" and "name"
+// arrive in the same object).
+func ParseBlock(raw []byte) (*Config, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("dmsg-server: parse block: %w", err)
+	}
+	return &c, nil
+}
+
+// New builds a Service from an already-parsed Config. The cobra
+// command in cmd/dmsg/dmsg-server/commands/start uses this path
+// after mapping flags + --config file into a Config.
+func New(cfg *Config, log *logging.Logger) services.Service {
+	return &service{cfg: cfg, log: log}
+}
+
+type service struct {
+	cfg *Config
+	log *logging.Logger
+}
+
+// Run is the long-lived run loop. Mirrors the previous
+// `skywire dmsg server start` cobra Run callback verbatim — same
+// HTTP API listener, same dmsg client + dmsghttp + pprof + optional
+// route setup-node — but takes its config from the struct rather
+// than package-level variables.
+func (s *service) Run(ctx context.Context) error {
+	cfg := &s.cfg.Config // alias for the embedded dmsgserver.Config
+	log := s.log
+
+	if cfg.MaxSessions <= 0 {
+		cfg.MaxSessions = dmsg.DefaultMaxSessions
+	}
+	if cfg.HTTPAddress == "" {
+		u, err := url.Parse(cfg.LocalAddress)
+		if err != nil {
+			return fmt.Errorf("dmsg-server: parse local_address %q: %w", cfg.LocalAddress, err)
+		}
+		hp, err := strconv.Atoi(u.Port())
+		if err != nil {
+			return fmt.Errorf("dmsg-server: parse local_address port %q: %w", cfg.LocalAddress, err)
+		}
+		cfg.HTTPAddress = ":" + strconv.Itoa(hp+1)
+	}
+
+	var m metrics.Metrics
+	if s.cfg.MetricsAddr == "" {
+		m = metrics.NewEmpty()
+	} else {
+		m = metrics.NewVictoriaMetrics()
+	}
+	metricsutil.ServeHTTPMetrics(log, s.cfg.MetricsAddr)
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	srvAPI := dmsgserver.NewServerAPI(r, log, m)
+
+	// Convert peer config to dmsg.PeerEntry.
+	var peers []dmsg.PeerEntry
+	for _, p := range cfg.Peers {
+		peers = append(peers, dmsg.PeerEntry{PK: p.PubKey, Addr: p.Address})
+	}
+
+	srvConf := dmsg.ServerConfig{
+		MaxSessions:    cfg.MaxSessions,
+		UpdateInterval: cfg.UpdateInterval,
+		AuthPassphrase: s.cfg.AuthPassphrase,
+		Peers:          peers,
+	}
+
+	deployments := cfg.NormalizedDeployments()
+	if len(deployments) == 0 {
+		return errors.New("dmsg-server: no dmsg-discoveries configured; set 'discovery' or 'dmsg' in config")
+	}
+
+	primaryHTTP := disc.NewHTTP(deployments[0].Discovery, &http.Client{}, log)
+	srv := dmsg.NewServer(cfg.PubKey, cfg.SecKey, primaryHTTP, &srvConf, m)
+	srv.SetLogger(log)
+
+	if geoDB, err := geoip.OpenEmbedded(); err != nil {
+		log.WithError(err).Warn("failed to open embedded geoip DB; LookupIPGeo will return empty geo fields")
+	} else {
+		srv.SetGeoLookup(func(ip net.IP) (country, region string, lat, lon float64) {
+			res, err := geoip.Lookup(geoDB, ip.String())
+			if err != nil || res == nil {
+				return "", "", 0, 0
+			}
+			if res.Latitude != nil {
+				lat = *res.Latitude
+			}
+			if res.Longitude != nil {
+				lon = *res.Longitude
+			}
+			return res.CountryCode, res.RegionCode, lat, lon
+		})
+	}
+
+	for i := 1; i < len(deployments); i++ {
+		extra := deployments[i]
+		srv.AddDiscovery(
+			disc.NewHTTP(extra.Discovery, &http.Client{}, log),
+			extra.AdvertisedAddress,
+			dmsgserver.PKFromDmsgURL(extra.DiscoveryDmsg),
+		)
+	}
+
+	srvAPI.SetDmsgServer(srv)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer func() {
+		if err := srvAPI.Close(); err != nil {
+			log.WithError(err).Info("Closed server.")
+		} else {
+			log.Info("Closed server.")
+		}
+	}()
+
+	primaryAdvertised := deployments[0].AdvertisedAddress
+	if primaryAdvertised == "" {
+		primaryAdvertised = cfg.PublicAddress
+	}
+
+	go srvAPI.RunBackgroundTasks(runCtx)
+	log.WithField("addr", cfg.HTTPAddress).Info("Serving server API...")
+	go func() {
+		if err := srvAPI.ListenAndServe(cfg.LocalAddress, primaryAdvertised, cfg.HTTPAddress); err != nil {
+			log.Errorf("Serve: %v", err)
+			cancel()
+		}
+	}()
+
+	go s.serveDmsgSurfaces(runCtx, cancel, srv, deployments)
+
+	<-runCtx.Done()
+	return nil
+}
+
+// serveDmsgSurfaces blocks until the server's outbound dmsg client
+// is ready, then upgrades each configured discovery to dmsgfirst,
+// stands up the DMSG-side health/pprof endpoints, and conditionally
+// hosts the integrated route setup-node.
+func (s *service) serveDmsgSurfaces(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	srv *dmsg.Server,
+	deployments []dmsgserver.Deployment,
+) {
+	cfg := &s.cfg.Config
+	log := s.log
+
+	select {
+	case <-srv.Ready():
+	case <-ctx.Done():
+		return
+	}
+
+	serverEntry := &disc.Entry{
+		Version: "0.0.1",
+		Static:  cfg.PubKey,
+		Server: &disc.Server{
+			Address:           cfg.PublicAddress,
+			AvailableSessions: cfg.MaxSessions,
+		},
+	}
+
+	// Build the transit set: union of (a) per-discovery servers
+	// from the config, (b) embedded deployment keyring, minus self.
+	servers := []*disc.Entry{serverEntry}
+	seenPK := map[cipher.PubKey]struct{}{cfg.PubKey: {}}
+	addServer := func(e *disc.Entry) {
+		if e == nil {
+			return
+		}
+		if _, ok := seenPK[e.Static]; ok {
+			return
+		}
+		seenPK[e.Static] = struct{}{}
+		servers = append(servers, e)
+	}
+	for _, d := range deployments {
+		for _, e := range d.Servers {
+			addServer(e)
+		}
+	}
+	for i := range dmsg.Prod.DmsgServers {
+		addServer(&dmsg.Prod.DmsgServers[i])
+	}
+	entries := direct.GetAllEntries(cipher.PubKeys{cfg.PubKey}, servers)
+	dClient := direct.NewClient(entries, log)
+
+	debugConfig := &dmsg.Config{MinSessions: 0}
+	dmsgC, closeDebug, err := direct.StartDmsg(ctx, log, cfg.PubKey, cfg.SecKey, dClient, debugConfig)
+	if err != nil {
+		log.WithError(err).Error("failed to start dmsg client for server services")
+		return
+	}
+	defer closeDebug()
+
+	// Upgrade each configured discovery client from plain HTTP to
+	// dmsgfirst when DiscoveryDmsg is set; otherwise stay on HTTP.
+	upgraded := make([]disc.APIClient, len(deployments))
+	for i, d := range deployments {
+		pk := dmsgserver.PKFromDmsgURL(d.DiscoveryDmsg)
+		if pk == (cipher.PubKey{}) {
+			upgraded[i] = disc.NewHTTP(d.Discovery, &http.Client{}, log)
+			log.WithField("url", d.Discovery).Debug("discovery_dmsg unset; staying on plain HTTP")
+			continue
+		}
+		upgraded[i] = dmsgfirst.New(dmsgC, pk, d.Discovery, &http.Client{}, log)
+		log.WithField("url", d.Discovery).WithField("pk", pk).Info("discovery upgraded to dmsg-first registration")
+	}
+	srv.SetDiscoveryClients(upgraded)
+
+	startedAt := time.Now()
+	dmsgAddr := fmt.Sprintf("%s:%d", cfg.PubKey.Hex(), dmsg.DefaultDmsgHTTPPort)
+	healthMux := http.NewServeMux()
+	healthMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var peerPKs []string
+		for _, p := range cfg.Peers {
+			peerPKs = append(peerPKs, p.PubKey.Hex())
+		}
+		resp := httputil.HealthCheckResponse{
+			ServiceName:   "dmsg-server",
+			BuildInfo:     buildinfo.Get(),
+			StartedAt:     startedAt,
+			DmsgAddr:      dmsgAddr,
+			DmsgDiscovery: cfg.Discovery,
+			PeerServers:   peerPKs,
+		}
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
+	})
+
+	go func() {
+		if err := dmsghttp.ListenAndServe(ctx, cfg.SecKey, healthMux, dClient,
+			dmsg.DefaultDmsgHTTPPort, dmsgC, log); err != nil {
+			log.WithError(err).Error("DMSG HTTP health server stopped")
+		}
+	}()
+	log.Infof("DMSG HTTP health endpoint available at %s", dmsgAddr)
+
+	go func() {
+		if debugErr := dmsghttp.ServeDebug(ctx, dmsgC, log, deployment.Prod.SurveyWhitelist); debugErr != nil {
+			log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
+		}
+	}()
+
+	if cfg.EnableRouteSetup {
+		go s.serveRouteSetup(ctx, dmsgC)
+	} else {
+		log.Info("Route setup-node disabled (enable with enable_route_setup in config)")
+	}
+
+	<-ctx.Done()
+	_ = cancel
+}
+
+// serveRouteSetup hosts the integrated route setup-node on the
+// dmsg setup port. Each accepted stream gets its own RPC server
+// dispatched to the router.SetupRPCGateway.
+func (s *service) serveRouteSetup(ctx context.Context, dmsgC *dmsg.Client) {
+	snLog := logging.MustGetLogger("dmsg-server:setup-node")
+	snLog.Info("Starting integrated route setup-node")
+
+	lis, lisErr := dmsgC.Listen(skyenv.DmsgSetupPort)
+	if lisErr != nil {
+		snLog.WithError(lisErr).Error("Failed to listen on setup port")
+		return
+	}
+	defer lis.Close() //nolint:errcheck
+
+	snLog.WithField("dmsg_port", skyenv.DmsgSetupPort).Info("Route setup-node listening")
+
+	const maxConcurrent = 20
+	sem := make(chan struct{}, maxConcurrent)
+	setupMetrics := setupmetrics.NewEmpty()
+
+	for {
+		conn, accErr := lis.AcceptStream()
+		if accErr != nil {
+			if ctx.Err() != nil || errors.Is(accErr, dmsg.ErrEntityClosed) {
+				snLog.Debug("Route setup-node listener stopped")
+				return
+			}
+			snLog.WithError(accErr).Warn("Failed to accept setup stream")
+			continue
+		}
+
+		reqPK := conn.RemoteAddr().(dmsg.Addr).PK
+		snLog.WithField("remote_pk", reqPK).Debug("Accepted route setup request")
+
+		gw := &router.SetupRPCGateway{
+			Metrics: setupMetrics,
+			Ctx:     ctx,
+			Conn:    conn,
+			ReqPK:   reqPK,
+			Dialer:  router.WrapDmsgClient(dmsgC),
+			Timeout: 2 * time.Minute,
+		}
+
+		rpcS := rpc.NewServer()
+		if regErr := rpcS.Register(gw); regErr != nil {
+			snLog.WithError(regErr).Error("Failed to register setup RPC")
+			conn.Close() //nolint:errcheck,gosec
+			continue
+		}
+
+		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			rpcS.ServeConn(conn)
+		}()
+	}
+}


### PR DESCRIPTION
## Summary
- Extracts the run loop from `cmd/dmsg/dmsg-server/commands/start` into `pkg/services/dmsgsrv.Run(ctx)`. Standalone `skywire dmsg server start` cobra command becomes a thin wrapper.
- Registers the `dmsg-server` type with the multi-service supervisor — `skywire svc run --list` now shows `{dmsg-discovery, dmsg-server, noop}`.
- New `dmsgsrv.Config` embeds the existing `dmsgserver.Config` and adds the four CLI-only knobs (auth_passphrase, pprof_mode/addr, metrics_addr) so the JSON block carries everything the flags previously did.

## Why dmsgsrv (not dmsgserver)
The lower-level `pkg/dmsg/dmsgserver` already owns `Config`, `ServerAPI`, `NewServer`, `NormalizedDeployments`. The new `pkg/services/dmsgsrv` is purely the run-loop wrapper that turns those primitives into a `pkg/services.Service` — two-package split keeps the service-registration boilerplate out of the low-level package.

## Behavioral parity
Same flag surface on the standalone command. Same NormalizedDeployments resolution, dmsgfirst upgrade, /health endpoint, /debug/pprof, integrated route setup-node, transit-set union semantics.

## Test plan
- [x] `go build ./...`
- [x] `make lint` (0 issues)
- [x] `skywire svc run --list` shows all three
- [ ] e2e validation deferred until full set of deployment services migrated and `docker-compose.yml` collapsed