### PR TITLE
feat(svc): migrate setup-node, transport-setup, stun-server (final batch)

### DIFF
--- a/cmd/svc/setup-node/commands/root.go
+++ b/cmd/svc/setup-node/commands/root.go
@@ -15,32 +15,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
-	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/dmsgc"
-	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
-	"github.com/skycoin/skywire/pkg/metricsutil"
 	"github.com/skycoin/skywire/pkg/router"
-	"github.com/skycoin/skywire/pkg/router/setupmetrics"
+	"github.com/skycoin/skywire/pkg/services/sn"
 	"github.com/skycoin/skywire/pkg/skyenv"
-	"github.com/skycoin/skywire/pkg/transport"
-	"github.com/skycoin/skywire/pkg/transport/network"
-	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
-	"github.com/skycoin/skywire/pkg/transport/tpdclient"
-	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 var (
@@ -110,214 +99,50 @@ Usage:
   skywire cli config gen --sn | skywire svc sn -i`,
 	Run: func(_ *cobra.Command, args []string) {
 		mLog := logging.NewMasterLogger()
-		log := logging.MustGetLogger(tag)
+		logger := logging.MustGetLogger(tag)
 
 		if _, err := buildinfo.Get().WriteTo(mLog.Out); err != nil {
 			mLog.Printf("Failed to output build info: %v", err)
 		}
 
-		if pprofMode == "http" {
-			metricsutil.ServePProf(log, pprofAddr, "setup-node")
-		}
-
 		var rdr io.Reader
-		var err error
-
 		if !cfgFromStdin {
 			configFile := "config.json"
-
 			if len(args) > 0 {
 				configFile = args[0]
 			}
-			rdr, err = os.Open(configFile)
+			f, err := os.Open(configFile) //nolint:gosec
 			if err != nil {
-				log.Fatalf("Failed to open config: %v", err)
+				logger.Fatalf("Failed to open config: %v", err)
 			}
+			rdr = f
 		} else {
-			log.Info("Reading config from STDIN")
+			logger.Info("Reading config from STDIN")
 			rdr = bufio.NewReader(os.Stdin)
 		}
-
-		conf := &router.SetupConfig{}
-
 		raw, err := io.ReadAll(rdr)
 		if err != nil {
-			log.Fatalf("Failed to read config: %v", err)
+			logger.Fatalf("Failed to read config: %v", err)
+		}
+		var setupConf router.SetupConfig
+		if err := json.Unmarshal(raw, &setupConf); err != nil {
+			logger.WithField("raw", string(raw)).Fatalf("Failed to decode config: %s", err)
 		}
 
-		if err := json.Unmarshal(raw, &conf); err != nil {
-			log.WithField("raw", string(raw)).Fatalf("Failed to decode config: %s", err)
+		cfg := &sn.Config{
+			SetupConfig: setupConf,
+			MetricsAddr: metricsAddr,
+			PProfMode:   pprofMode,
+			PProfAddr:   pprofAddr,
+			Tag:         tag,
 		}
 
-		log.Infof("Config: %#v", conf)
-
-		sn, err := router.NewNode(conf)
-		if err != nil {
-			log.Fatal("Failed to create a setup node: ", err)
-		}
-
-		collector := prepareMetrics(log)
-
-		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		ctx, cancel := cmdutil.SignalContext(context.Background(), logger)
 		defer cancel()
-
-		// Initialize transport manager for cascade route setup.
-		// The RSN uses STCPR transports with label "setup" to reach
-		// visors directly, enabling route setup without DMSG.
-		if conf.Transport != nil && conf.Cascade != nil {
-			tpLabel := transport.LabelSetup
-			if conf.Transport.DefaultLabel != "" {
-				tpLabel = transport.Label(conf.Transport.DefaultLabel)
-			}
-
-			// The setup-node's DMSG client is brought up inside
-			// router.NewNode (which already waits for ready before
-			// returning), so it's safe to use here for outbound
-			// dmsg-http requests to the discovery services.
-			snDmsgC := sn.DmsgClient()
-
-			var tpdC transport.DiscoveryClient
-			if conf.TransportDiscovery != "" {
-				httpC, hcErr := getHTTPClient(ctx, snDmsgC, conf.TransportDiscovery)
-				if hcErr != nil {
-					log.WithError(hcErr).Warn("Failed to build TPD HTTP client — using mock")
-					tpdC = transport.NewDiscoveryMock()
-				} else {
-					var tpdErr error
-					tpdC, tpdErr = tpdclient.NewHTTP(
-						conf.TransportDiscovery,
-						conf.PK, conf.SK,
-						httpC, "",
-						mLog,
-					)
-					if tpdErr != nil {
-						log.WithError(tpdErr).Warn("Failed to create TPD client — using mock")
-						tpdC = transport.NewDiscoveryMock()
-					}
-				}
-			} else {
-				tpdC = transport.NewDiscoveryMock()
-			}
-
-			logS := transport.InMemoryTransportLogStore()
-			tpMConf := transport.ManagerConfig{
-				PubKey:           conf.PK,
-				SecKey:           conf.SK,
-				DiscoveryClient:  tpdC,
-				LogStore:         logS,
-				Version:          buildinfo.Version(),
-				ARTransportLimit: -1, // RSN never registers with AR
-			}
-
-			var arC addrresolver.APIClient
-			if conf.Transport.AddressResolver != "" {
-				httpC, hcErr := getHTTPClient(ctx, snDmsgC, conf.Transport.AddressResolver)
-				if hcErr != nil {
-					log.WithError(hcErr).Warn("Failed to build AR HTTP client — AR disabled")
-				} else {
-					arC, _ = addrresolver.NewHTTP( //nolint:errcheck
-						conf.Transport.AddressResolver,
-						conf.PK, conf.SK,
-						httpC, "",
-						log, mLog,
-					)
-				}
-			}
-
-			factory := network.ClientFactory{
-				PK:         conf.PK,
-				SK:         conf.SK,
-				ListenAddr: conf.Transport.STCPRAddr,
-				ARClient:   arC,
-				EB:         appevent.NewBroadcaster(log, 0),
-				MLogger:    mLog,
-			}
-
-			tpM, tpErr := transport.NewManager(log, arC, factory.EB, &tpMConf, factory)
-			if tpErr != nil {
-				log.WithError(tpErr).Warn("Failed to create transport manager — cascade disabled")
-			} else {
-				tpM.InitClient(ctx, types.STCPR, 0)
-				log.WithField("stcpr_addr", conf.Transport.STCPRAddr).
-					WithField("label", tpLabel).
-					Info("RSN transport manager started (STCPR)")
-
-				sn.InitCascade(conf, tpM)
-				_ = tpLabel // label is set per-transport at dial time
-			}
+		if err := sn.New(cfg, logger).Run(ctx); err != nil {
+			logger.WithError(err).Fatal("setup-node: run failed")
 		}
-
-		// Start DMSG HTTP health server using the setup-node's own DMSG client.
-		// This avoids creating a second DMSG client with the same PK, which
-		// causes "error 306 - no associated listener" when the DMSG server
-		// routes streams to the wrong client.
-		{
-			startedAt := time.Now()
-			dmsgAddr := fmt.Sprintf("%s:%d", conf.PK.Hex(), dmsg.DefaultDmsgHTTPPort)
-
-			healthMux := http.NewServeMux()
-			healthMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				resp := httputil.HealthCheckResponse{
-					ServiceName: "setup-node",
-					BuildInfo:   buildinfo.Get(),
-					StartedAt:   startedAt,
-					DmsgAddr:    dmsgAddr,
-					DmsgServers: sn.DmsgClient().ConnectedServersPK(),
-				}
-				json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
-			})
-
-			// Public stats endpoint — aggregate counters, latency percentiles,
-			// failure breakdown. Recent failures are sanitized (no src/dst PKs).
-			healthMux.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				snap := collector.Snapshot()
-				// Sanitize: strip src/dst PKs from recent failures and top destinations
-				// to avoid leaking which visors are communicating with each other.
-				for i := range snap.RecentFailures {
-					snap.RecentFailures[i].SrcPK = ""
-					snap.RecentFailures[i].DstPK = ""
-				}
-				for i := range snap.TopDestinations {
-					snap.TopDestinations[i].PK = ""
-				}
-				for i := range snap.TopFailedDestinations {
-					snap.TopFailedDestinations[i].PK = ""
-				}
-				json.NewEncoder(w).Encode(snap) //nolint:errcheck,gosec
-			})
-
-			// Use the setup-node's own DMSG client for health/debug endpoints
-			snClient := sn.DmsgClient()
-			go func() {
-				if err := dmsghttp.ListenAndServe(ctx, conf.SK, healthMux, nil,
-					dmsg.DefaultDmsgHTTPPort, snClient, log); err != nil {
-					log.WithError(err).Error("DMSG HTTP health server stopped")
-				}
-			}()
-			go func() {
-				if err := dmsghttp.ServeDebug(ctx, snClient, log, deployment.Prod.SurveyWhitelist); err != nil {
-					log.WithError(err).Error("DMSG HTTP debug server stopped")
-				}
-			}()
-			log.Infof("DMSG HTTP health endpoint available at %s", dmsgAddr)
-		}
-
-		log.Fatal(sn.Serve(ctx, collector))
 	},
-}
-
-func prepareMetrics(log logrus.FieldLogger) *setupmetrics.Collector {
-	collector := setupmetrics.NewCollector(setupmetrics.CollectorConfig{})
-
-	if metricsAddr != "" {
-		// Victoria Metrics publishes Prometheus gauges alongside the Collector.
-		_ = setupmetrics.NewVictoriaMetrics()
-		metricsutil.ServeHTTPMetrics(log, metricsAddr)
-	}
-
-	return collector
 }
 
 // checkHealthCmd does health check on running route setup node
@@ -394,54 +219,5 @@ var checkHealthCmd = &cobra.Command{
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
-	}
-}
-
-// getHTTPClient returns an *http.Client for the given service URL,
-// dispatching on URL scheme: dmsg:// URLs get a client backed by a
-// dmsghttp.HTTPTransport routed through snDmsgC, http(s):// URLs get
-// a plain http.Client.
-//
-// Mirrors the pattern in pkg/visor/init.go's getHTTPClient — same
-// scheme-aware handling so the setup-node can talk to TPD/AR over
-// either transport just like the visor does. The visor path also
-// PostEntry-warms the dmsg discovery; we skip that here because the
-// setup-node is a one-direction client (no inbound dmsg traffic the
-// service needs to route to it through delegated servers).
-func getHTTPClient(_ context.Context, snDmsgC *dmsg.Client, service string) (*http.Client, error) {
-	if service == "" {
-		return nil, fmt.Errorf("service URL is empty")
-	}
-
-	var serviceURL dmsgcurl.URL
-	if err := serviceURL.Fill(service); err != nil {
-		// Fill rejects malformed inputs but tolerates plain http(s)
-		// URLs without scheme — bare host:port paths fall through here.
-		// Treat any parse failure as "not a dmsg URL, use plain HTTP".
-		return plainHTTPClient(), nil
-	}
-
-	if serviceURL.Scheme != "dmsg" {
-		return plainHTTPClient(), nil
-	}
-
-	if snDmsgC == nil {
-		return nil, fmt.Errorf("dmsg URL %q requires a DMSG client; none available", service)
-	}
-
-	return &http.Client{
-		Transport: dmsghttp.MakeHTTPTransport(context.Background(), snDmsgC),
-	}, nil
-}
-
-// plainHTTPClient returns the http.Client previously hard-coded
-// in-line — kept as a small helper so the dmsg path can share the
-// same call site shape.
-func plainHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			DisableKeepAlives: true,
-			IdleConnTimeout:   5 * time.Second,
-		},
 	}
 }

--- a/cmd/svc/skywire-services/commands/root.go
+++ b/cmd/svc/skywire-services/commands/root.go
@@ -34,7 +34,10 @@ import (
 	_ "github.com/skycoin/skywire/pkg/services/noop"
 	_ "github.com/skycoin/skywire/pkg/services/rf"
 	_ "github.com/skycoin/skywire/pkg/services/sd"
+	_ "github.com/skycoin/skywire/pkg/services/sn"
+	_ "github.com/skycoin/skywire/pkg/services/stun"
 	_ "github.com/skycoin/skywire/pkg/services/tpd"
+	_ "github.com/skycoin/skywire/pkg/services/tps"
 )
 
 func init() {

--- a/cmd/svc/stun-server/commands/root.go
+++ b/cmd/svc/stun-server/commands/root.go
@@ -6,17 +6,16 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
-	"syscall"
 
-	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
-	"github.com/skycoin/skywire/pkg/stunserver"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services/stun"
 )
 
 var (
@@ -57,38 +56,18 @@ Requires two distinct IPs for full NAT type detection.
 	Version:               buildinfo.Version(),
 	Run: func(_ *cobra.Command, _ []string) {
 		logger := logging.MustGetLogger(tag)
-		lvl, err := logging.LevelFromString(logLvl)
-		if err != nil {
-			logger.Fatal("Invalid loglvl detected")
-		}
-		logging.SetLevel(lvl)
-
-		if primaryIP == "" || secondaryIP == "" {
-			logger.Fatal("Both --primary-ip and --secondary-ip are required")
-		}
-
-		srv := &stunserver.Server{
+		cfg := &stun.Config{
 			PrimaryIP:   primaryIP,
 			SecondaryIP: secondaryIP,
-			PrimaryPort: port,
+			Port:        port,
 			AltPort:     altPort,
-			Software:    "skywire-stun",
-			Log:         logger,
+			LogLevel:    logLvl,
+			Tag:         tag,
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := cmdutil.SignalContext(context.Background(), logger)
 		defer cancel()
-
-		stop := make(chan os.Signal, 1)
-		signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-
-		go func() {
-			<-stop
-			cancel()
-		}()
-
-		if err := srv.Start(ctx); err != nil {
-			logger.Fatalf("STUN server failed: %v", err)
+		if err := stun.New(cfg, logger).Run(ctx); err != nil {
+			logger.WithError(err).Fatal("stun-server: run failed")
 		}
 	},
 }

--- a/cmd/svc/transport-setup/commands/root.go
+++ b/cmd/svc/transport-setup/commands/root.go
@@ -6,13 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
-	"syscall"
-	"time"
 
 	"github.com/bitfield/script"
 	"github.com/google/uuid"
@@ -23,8 +19,10 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsgc"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services/tps"
 	"github.com/skycoin/skywire/pkg/transport-setup/api"
 	"github.com/skycoin/skywire/pkg/transport-setup/config"
 )
@@ -140,59 +138,17 @@ Generate Keys:
 		}
 		const loggerTag = "transport_setup"
 		logger := logging.MustGetLogger(loggerTag)
-		lvl, err := logging.LevelFromString(logLvl)
-		if err != nil {
-			logger.Fatal("Invalid loglvl detected")
-		}
-		logging.SetLevel(lvl)
 
 		conf := config.MustReadConfig(configFile, logger)
-		tpsAPI := api.New(logger, conf)
-
-		// Setup context with signal handling
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		go func() {
-			<-sigCh
-			logger.Info("Received shutdown signal")
-			cancel()
-		}()
-
-		// Start dmsg listener in goroutine
-		go func() {
-			logger.Info("Starting dmsg RPC listener")
-			if err := tpsAPI.ServeDmsg(ctx); err != nil {
-				if ctx.Err() == nil {
-					logger.WithError(err).Error("Dmsg server error")
-				}
-			}
-		}()
-
-		// Start HTTP server
-		srv := &http.Server{
-			Addr:              fmt.Sprintf(":%d", conf.Port),
-			ReadHeaderTimeout: 2 * time.Second,
-			IdleTimeout:       30 * time.Second,
-			Handler:           tpsAPI,
+		cfg := &tps.Config{
+			Config:   conf,
+			LogLevel: logLvl,
+			Tag:      loggerTag,
 		}
-
-		logger.WithField("addr", srv.Addr).Info("Starting HTTP server")
-
-		// Graceful shutdown
-		go func() {
-			<-ctx.Done()
-			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer shutdownCancel()
-			if err := srv.Shutdown(shutdownCtx); err != nil {
-				logger.WithError(err).Error("HTTP server shutdown error")
-			}
-		}()
-
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Errorf("ListenAndServe: %v", err)
+		ctx, cancel := cmdutil.SignalContext(context.Background(), logger)
+		defer cancel()
+		if err := tps.New(cfg, logger).Run(ctx); err != nil {
+			logger.WithError(err).Fatal("transport-setup: run failed")
 		}
 	},
 }

--- a/pkg/services/sn/sn.go
+++ b/pkg/services/sn/sn.go
@@ -1,0 +1,335 @@
+// Package sn pkg/services/sn/sn.go
+//
+// setup-node as a pkg/services.Service. Listens on dmsg port 36 for
+// route-setup RPC requests; optionally builds a transport manager
+// for the cascade-route-setup path that reaches visors over STCPR.
+//
+// Block shape supports either inline router.SetupConfig fields or a
+// `config_path` indirection (the existing per-service JSON file).
+// E2E uses the file path; tighter "all-in-one" deployments can
+// embed the config inline.
+package sn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/app/appevent"
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/httputil"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/metricsutil"
+	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/router/setupmetrics"
+	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/transport/network"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	"github.com/skycoin/skywire/pkg/transport/tpdclient"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// Type is the registry key used in services.json blocks.
+const Type = "setup-node"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// Config is the JSON configuration for setup-node. Embeds
+// router.SetupConfig so callers can either set those fields inline
+// in the block (small all-in-one deployments) or point at a file
+// via ConfigPath (production / CI e2e — the file wins when set).
+type Config struct {
+	router.SetupConfig
+
+	// ConfigPath, when non-empty, is the path to a JSON file
+	// containing a router.SetupConfig. Read at Run() time; values
+	// from the file overwrite any inline equivalents. Mutually
+	// exclusive in spirit (inline config is the alternative).
+	ConfigPath string `json:"config_path,omitempty"`
+
+	MetricsAddr string `json:"metrics_addr,omitempty"`
+	PProfMode   string `json:"pprof_mode,omitempty"`
+	PProfAddr   string `json:"pprof_addr,omitempty"`
+	Tag         string `json:"tag,omitempty"`
+}
+
+// LoadFile reads a setup-node config file. Returns the inner
+// SetupConfig directly because the file-based path doesn't carry
+// the supervisor-only fields (MetricsAddr, PProfMode, etc.).
+func LoadFile(path string) (*router.SetupConfig, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("setup-node: read config %q: %w", path, err)
+	}
+	var sc router.SetupConfig
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return nil, fmt.Errorf("setup-node: parse config %q: %w", path, err)
+	}
+	return &sc, nil
+}
+
+// ParseBlock decodes a services.json block into a Config.
+func ParseBlock(raw []byte) (*Config, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("setup-node: parse block: %w", err)
+	}
+	return &c, nil
+}
+
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	cfg, err := ParseBlock(raw)
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg, log), nil
+}
+
+// New builds a Service from an already-parsed Config.
+func New(cfg *Config, log *logging.Logger) services.Service {
+	return &service{cfg: cfg, log: log}
+}
+
+type service struct {
+	cfg *Config
+	log *logging.Logger
+}
+
+func (s *service) Run(ctx context.Context) error {
+	cfg := s.cfg
+	tag := cfg.Tag
+	if tag == "" {
+		tag = "setup_node"
+	}
+	log := logging.MustGetLogger(tag)
+	mLog := logging.NewMasterLogger()
+	_ = s.log // logger replaced
+
+	if cfg.PProfMode == "http" {
+		metricsutil.ServePProf(log, cfg.PProfAddr, "setup-node")
+	}
+
+	// Resolve the SetupConfig: file wins over inline.
+	conf := &cfg.SetupConfig
+	if cfg.ConfigPath != "" {
+		fileSetup, err := LoadFile(cfg.ConfigPath)
+		if err != nil {
+			return err
+		}
+		conf = fileSetup
+	}
+	if conf.PK.Null() || conf.SK.Null() {
+		return errors.New("setup-node: public_key and secret_key required (inline or via config_path)")
+	}
+
+	log.Infof("Config: %#v", conf)
+	sn, err := router.NewNode(conf)
+	if err != nil {
+		return fmt.Errorf("setup-node: create node: %w", err)
+	}
+
+	collector := setupmetrics.NewCollector(setupmetrics.CollectorConfig{})
+	if cfg.MetricsAddr != "" {
+		_ = setupmetrics.NewVictoriaMetrics()
+		metricsutil.ServeHTTPMetrics(log, cfg.MetricsAddr)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Cascade route-setup transport manager: STCPR transports labeled
+	// "setup" reach visors directly, enabling route setup without DMSG.
+	if conf.Transport != nil && conf.Cascade != nil {
+		s.startCascade(runCtx, conf, sn, log, mLog)
+	}
+
+	// DMSG HTTP /health and /stats served via the setup-node's own
+	// DMSG client (avoids "no associated listener" from a duplicate
+	// client with the same PK).
+	s.startDMSGHealth(runCtx, conf, sn, collector, log)
+
+	if err := sn.Serve(runCtx, collector); err != nil {
+		return fmt.Errorf("setup-node: serve: %w", err)
+	}
+	return nil
+}
+
+func (s *service) startCascade(
+	ctx context.Context,
+	conf *router.SetupConfig,
+	sn *router.Node,
+	log *logging.Logger,
+	mLog *logging.MasterLogger,
+) {
+	tpLabel := transport.LabelSetup
+	if conf.Transport.DefaultLabel != "" {
+		tpLabel = transport.Label(conf.Transport.DefaultLabel)
+	}
+
+	snDmsgC := sn.DmsgClient()
+
+	var tpdC transport.DiscoveryClient
+	if conf.TransportDiscovery != "" {
+		httpC, hcErr := getHTTPClient(snDmsgC, conf.TransportDiscovery)
+		if hcErr != nil {
+			log.WithError(hcErr).Warn("Failed to build TPD HTTP client — using mock")
+			tpdC = transport.NewDiscoveryMock()
+		} else {
+			var tpdErr error
+			tpdC, tpdErr = tpdclient.NewHTTP(
+				conf.TransportDiscovery,
+				conf.PK, conf.SK,
+				httpC, "",
+				mLog,
+			)
+			if tpdErr != nil {
+				log.WithError(tpdErr).Warn("Failed to create TPD client — using mock")
+				tpdC = transport.NewDiscoveryMock()
+			}
+		}
+	} else {
+		tpdC = transport.NewDiscoveryMock()
+	}
+
+	tpMConf := transport.ManagerConfig{
+		PubKey:           conf.PK,
+		SecKey:           conf.SK,
+		DiscoveryClient:  tpdC,
+		LogStore:         transport.InMemoryTransportLogStore(),
+		Version:          buildinfo.Version(),
+		ARTransportLimit: -1, // RSN never registers with AR
+	}
+
+	var arC addrresolver.APIClient
+	if conf.Transport.AddressResolver != "" {
+		httpC, hcErr := getHTTPClient(snDmsgC, conf.Transport.AddressResolver)
+		if hcErr != nil {
+			log.WithError(hcErr).Warn("Failed to build AR HTTP client — AR disabled")
+		} else {
+			arC, _ = addrresolver.NewHTTP( //nolint:errcheck
+				conf.Transport.AddressResolver,
+				conf.PK, conf.SK,
+				httpC, "",
+				log, mLog,
+			)
+		}
+	}
+
+	factory := network.ClientFactory{
+		PK:         conf.PK,
+		SK:         conf.SK,
+		ListenAddr: conf.Transport.STCPRAddr,
+		ARClient:   arC,
+		EB:         appevent.NewBroadcaster(log, 0),
+		MLogger:    mLog,
+	}
+
+	tpM, tpErr := transport.NewManager(log, arC, factory.EB, &tpMConf, factory)
+	if tpErr != nil {
+		log.WithError(tpErr).Warn("Failed to create transport manager — cascade disabled")
+		return
+	}
+	tpM.InitClient(ctx, types.STCPR, 0)
+	log.WithField("stcpr_addr", conf.Transport.STCPRAddr).
+		WithField("label", tpLabel).
+		Info("RSN transport manager started (STCPR)")
+	sn.InitCascade(conf, tpM)
+	_ = tpLabel
+}
+
+func (s *service) startDMSGHealth(
+	ctx context.Context,
+	conf *router.SetupConfig,
+	sn *router.Node,
+	collector *setupmetrics.Collector,
+	log *logging.Logger,
+) {
+	startedAt := time.Now()
+	dmsgAddr := fmt.Sprintf("%s:%d", conf.PK.Hex(), dmsg.DefaultDmsgHTTPPort)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := httputil.HealthCheckResponse{
+			ServiceName: "setup-node",
+			BuildInfo:   buildinfo.Get(),
+			StartedAt:   startedAt,
+			DmsgAddr:    dmsgAddr,
+			DmsgServers: sn.DmsgClient().ConnectedServersPK(),
+		}
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
+	})
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		snap := collector.Snapshot()
+		// Sanitize: strip src/dst PKs to avoid leaking visor topology.
+		for i := range snap.RecentFailures {
+			snap.RecentFailures[i].SrcPK = ""
+			snap.RecentFailures[i].DstPK = ""
+		}
+		for i := range snap.TopDestinations {
+			snap.TopDestinations[i].PK = ""
+		}
+		for i := range snap.TopFailedDestinations {
+			snap.TopFailedDestinations[i].PK = ""
+		}
+		json.NewEncoder(w).Encode(snap) //nolint:errcheck,gosec
+	})
+
+	snClient := sn.DmsgClient()
+	go func() {
+		if err := dmsghttp.ListenAndServe(ctx, conf.SK, mux, nil,
+			dmsg.DefaultDmsgHTTPPort, snClient, log); err != nil {
+			log.WithError(err).Error("DMSG HTTP health server stopped")
+		}
+	}()
+	go func() {
+		if err := dmsghttp.ServeDebug(ctx, snClient, log, deployment.Prod.SurveyWhitelist); err != nil {
+			log.WithError(err).Error("DMSG HTTP debug server stopped")
+		}
+	}()
+	log.Infof("DMSG HTTP health endpoint available at %s", dmsgAddr)
+}
+
+// getHTTPClient returns an *http.Client for the given service URL,
+// dispatching on URL scheme: dmsg:// URLs get a client backed by a
+// dmsghttp.HTTPTransport routed through snDmsgC, http(s):// URLs
+// get a plain http.Client.
+func getHTTPClient(snDmsgC *dmsg.Client, service string) (*http.Client, error) {
+	if service == "" {
+		return nil, fmt.Errorf("service URL is empty")
+	}
+	var serviceURL dmsgcurl.URL
+	if err := serviceURL.Fill(service); err != nil {
+		return plainHTTPClient(), nil
+	}
+	if serviceURL.Scheme != "dmsg" {
+		return plainHTTPClient(), nil
+	}
+	if snDmsgC == nil {
+		return nil, fmt.Errorf("dmsg URL %q requires a DMSG client; none available", service)
+	}
+	return &http.Client{
+		Transport: dmsghttp.MakeHTTPTransport(context.Background(), snDmsgC),
+	}, nil
+}
+
+func plainHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			IdleConnTimeout:   5 * time.Second,
+		},
+	}
+}

--- a/pkg/services/stun/stun.go
+++ b/pkg/services/stun/stun.go
@@ -1,0 +1,108 @@
+// Package stun pkg/services/stun/stun.go
+//
+// stun-server as a pkg/services.Service. Implements RFC 3489 NAT
+// discovery; requires two distinct IPs for full NAT-type detection
+// (the `change-address` STUN attribute path needs the secondary).
+package stun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	skycoinlogging "github.com/skycoin/skycoin/src/util/logging"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/stunserver"
+)
+
+// Type is the registry key used in services.json blocks.
+const Type = "stun-server"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// Config is the JSON configuration for the STUN server. Tiny —
+// stun-server has no redis, no dmsg, no svcmode listener.
+type Config struct {
+	PrimaryIP   string `json:"primary_ip"`
+	SecondaryIP string `json:"secondary_ip"`
+	Port        int    `json:"port,omitempty"`     // default 3478
+	AltPort     int    `json:"alt_port,omitempty"` // default 3479
+	LogLevel    string `json:"log_level,omitempty"`
+	Tag         string `json:"tag,omitempty"`
+}
+
+// ParseBlock decodes a services.json block into a Config.
+func ParseBlock(raw []byte) (*Config, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("stun-server: parse block: %w", err)
+	}
+	return &c, nil
+}
+
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	cfg, err := ParseBlock(raw)
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg, log), nil
+}
+
+// New builds a Service from an already-parsed Config.
+func New(cfg *Config, log *logging.Logger) services.Service {
+	return &service{cfg: cfg, log: log}
+}
+
+type service struct {
+	cfg *Config
+	log *logging.Logger
+}
+
+func (s *service) Run(ctx context.Context) error {
+	cfg := s.cfg
+	if cfg.PrimaryIP == "" || cfg.SecondaryIP == "" {
+		return errors.New("stun-server: both primary_ip and secondary_ip are required")
+	}
+	port := cfg.Port
+	if port == 0 {
+		port = 3478
+	}
+	altPort := cfg.AltPort
+	if altPort == 0 {
+		altPort = 3479
+	}
+
+	tag := cfg.Tag
+	if tag == "" {
+		tag = "stun"
+	}
+	// stunserver.Server.Log uses skycoin's logging package, not
+	// pkg/logging — supply a separate logger instance for it.
+	skyLogger := skycoinlogging.MustGetLogger(tag)
+	logger := logging.MustGetLogger(tag)
+	if cfg.LogLevel != "" {
+		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
+			logging.SetLevel(lvl)
+		}
+	}
+	_ = s.log // logger is replaced with a tag-scoped one
+	_ = logger
+
+	srv := &stunserver.Server{
+		PrimaryIP:   cfg.PrimaryIP,
+		SecondaryIP: cfg.SecondaryIP,
+		PrimaryPort: port,
+		AltPort:     altPort,
+		Software:    "skywire-stun",
+		Log:         skyLogger,
+	}
+	if err := srv.Start(ctx); err != nil {
+		return fmt.Errorf("stun-server: start: %w", err)
+	}
+	return nil
+}

--- a/pkg/services/tps/tps.go
+++ b/pkg/services/tps/tps.go
@@ -1,0 +1,150 @@
+// Package tps pkg/services/tps/tps.go
+//
+// transport-setup as a pkg/services.Service. Listens on dmsg RPC
+// for visors and exposes an HTTP API to manage transports remotely.
+//
+// Like setup-node, the block can either embed config.Config inline
+// or point at a file via ConfigPath. E2E uses the file path; small
+// all-in-one deployments can embed inline.
+package tps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/transport-setup/api"
+	"github.com/skycoin/skywire/pkg/transport-setup/config"
+)
+
+// Type is the registry key used in services.json blocks.
+const Type = "transport-setup"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// Config is the JSON configuration for transport-setup.
+type Config struct {
+	config.Config
+
+	// ConfigPath, when non-empty, is the path to a JSON file
+	// containing a config.Config. File wins over inline.
+	ConfigPath string `json:"config_path,omitempty"`
+	LogLevel   string `json:"log_level,omitempty"`
+	Tag        string `json:"tag,omitempty"`
+}
+
+// LoadFile reads a transport-setup config file.
+func LoadFile(path string) (*config.Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("transport-setup: read config %q: %w", path, err)
+	}
+	var c config.Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("transport-setup: parse config %q: %w", path, err)
+	}
+	return &c, nil
+}
+
+// ParseBlock decodes a services.json block into a Config.
+func ParseBlock(raw []byte) (*Config, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("transport-setup: parse block: %w", err)
+	}
+	return &c, nil
+}
+
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	cfg, err := ParseBlock(raw)
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg, log), nil
+}
+
+// New builds a Service from an already-parsed Config.
+func New(cfg *Config, log *logging.Logger) services.Service {
+	return &service{cfg: cfg, log: log}
+}
+
+type service struct {
+	cfg *Config
+	log *logging.Logger
+}
+
+func (s *service) Run(ctx context.Context) error {
+	cfg := s.cfg
+	tag := cfg.Tag
+	if tag == "" {
+		tag = "transport_setup"
+	}
+	logger := logging.MustGetLogger(tag)
+	if cfg.LogLevel != "" {
+		if lvl, err := logging.LevelFromString(cfg.LogLevel); err == nil {
+			logging.SetLevel(lvl)
+		}
+	}
+	_ = s.log
+
+	conf := &cfg.Config
+	if cfg.ConfigPath != "" {
+		fileConf, err := LoadFile(cfg.ConfigPath)
+		if err != nil {
+			return err
+		}
+		conf = fileConf
+	}
+	if conf.PK.Null() || conf.SK.Null() {
+		return errors.New("transport-setup: public_key and secret_key required (inline or via config_path)")
+	}
+
+	tpsAPI := api.New(logger, *conf)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		logger.Info("Starting dmsg RPC listener")
+		if err := tpsAPI.ServeDmsg(runCtx); err != nil {
+			if runCtx.Err() == nil {
+				logger.WithError(err).Error("Dmsg server error")
+			}
+		}
+	}()
+
+	srv := &http.Server{
+		Addr:              fmt.Sprintf(":%d", conf.Port),
+		ReadHeaderTimeout: 2 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		Handler:           tpsAPI,
+	}
+	logger.WithField("addr", srv.Addr).Info("Starting HTTP server")
+
+	go func() { //nolint:gosec
+		<-runCtx.Done()
+		// Shutdown uses a fresh ctx because the parent is already
+		// canceled — the timeout governs how long to wait for
+		// in-flight requests to drain before forcing the listener
+		// closed.
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			logger.WithError(err).Error("HTTP server shutdown error")
+		}
+	}()
+
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Errorf("ListenAndServe: %v", err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
Final batch of deployment-service migrations onto `pkg/services`. After this lands all nine CI-e2e deployment services are runnable through `skywire svc run --config services.json`.

- `pkg/services/sn` — setup-node (router.SetupConfig inline + config_path indirection)
- `pkg/services/tps` — transport-setup (config.Config inline + config_path indirection)
- `pkg/services/stun` — stun-server (smallest of the lot, no redis/dmsg/svcmode)

## Status
- ✅ dmsg-discovery, dmsg-server, transport-discovery, service-discovery, address-resolver, route-finder, setup-node, transport-setup, stun-server
- ⏭ docker-compose.yml collapse to one deployment container
- ⏭ visor migration (separate follow-up)

`uptime-tracker` and `network-monitor` are out of scope (UT being subsumed by TPD's uptime tracking, NM intentionally disabled in production deployment).

## Test plan
- [x] `go build ./...`
- [x] `make lint` (0 issues)
- [x] `skywire svc run --list` shows all 10 (9 services + noop)
- [ ] e2e validation comes with the docker-compose collapse PR