### PR TITLE
feat(svc): collapse 9 deployment containers into 1 for CI e2e

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-  
+
   postgres-db:
     image: "postgres:alpine"
     networks:
@@ -125,160 +125,91 @@ services:
       retries: 15
       start_period: 15s
 
-  transport-discovery:
+  # deployment-services collapses the nine deployment-side containers
+  # (transport-discovery, route-finder, dmsg-discovery, dmsg-server,
+  # setup-node, service-discovery, address-resolver, transport-setup,
+  # stun-server) into a single process driven by `skywire svc run`.
+  # Each service runs as a goroutine inside one binary, sharing a
+  # signal handler and merged log stream. Hostnames are preserved on
+  # the docker bridge via `aliases` so visor configs and the e2e
+  # test's extra_hosts continue to refer to each service by its
+  # original name; only the IPs change.
+  #
+  # IP plan: visors=173.0.0.17 + intra=174.0.0.17 inherits stun's
+  # required pair (RFC 3489 needs two distinct IPs for full NAT type
+  # detection); srv=175.0.0.2 inherits TPD's address.
+  deployment-services:
     privileged: true
     image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: transport-discovery
-    container_name: "transport-discovery"
-    restart: always
+    hostname: deployment-services
+    container_name: "deployment-services"
     networks:
       srv:
         ipv4_address: 175.0.0.2
+        aliases:
+          - transport-discovery
+          - route-finder
+          - dmsg-discovery
+          - dmsg-server
+          - setup-node
+          - service-discovery
+          - address-resolver
+          - transport-setup
       intra:
-        ipv4_address: 174.0.0.2
+        ipv4_address: 174.0.0.17
+        aliases:
+          - transport-discovery
+          - route-finder
+          - dmsg-discovery
+          - dmsg-server
+          - setup-node
+          - service-discovery
+          - address-resolver
+          - transport-setup
+          - stun-server
+      visors:
+        ipv4_address: 173.0.0.17
+        aliases:
+          - stun-server
     depends_on:
       tpd-redis:
         condition: service_healthy
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire svc tpd --addr :9094 --pprof :6094 --redis redis://tpd-redis:6379 --entry-timeout 2m --sk 85789cd7efcdf35340c8f4cb3e15bccdff57efda49af5bcdddaae57374d25ab8 --dmsg-disc http://dmsg-discovery:9090"
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6094/debug/service"]
-      interval: 3s
-      timeout: 3s
-      retries: 15
-      start_period: 5s
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
-  route-finder:
-    privileged: true
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: route-finder
-    container_name: "route-finder"
-    restart: always
-    networks:
-      srv:
-        ipv4_address: 175.0.0.3
-      intra:
-        ipv4_address: 174.0.0.3
-    depends_on:
-      transport-discovery:
+      sd-redis:
         condition: service_healthy
-      tpd-redis:
+      ar-redis:
         condition: service_healthy
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire svc rf --addr :9092 --pprof :6092 --redis redis://tpd-redis:6379 --sk 640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca --dmsg-disc http://dmsg-discovery:9090"
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6092/debug/service"]
-      interval: 3s
-      timeout: 3s
-      retries: 15
-      start_period: 5s
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
-  dmsg-discovery:
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: dmsg-discovery
-    container_name: "dmsg-discovery"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.4
-      intra:
-        ipv4_address: 174.0.0.4
-    restart: always
-    depends_on:
       dmsgd-redis:
         condition: service_healthy
-      transport-discovery:
-        condition: service_healthy
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire dmsg disc --addr :9090 --redis redis://dmsgd-redis:6379 --sk b3f6706cb72215d3873ef92cc0c6037a47fe651112b1685017d6347eed0fb714 -t"
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:9090/health"]
-      interval: 3s
-      timeout: 3s
-      retries: 15
-      start_period: 5s
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
-  dmsg-server:
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: dmsg-server
-    container_name: "dmsg-server"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.5
-      intra:
-        ipv4_address: 174.0.0.5
-    depends_on:
-      dmsg-discovery:
-        condition: service_healthy
     restart: always
     environment:
       - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire dmsg server start /release/dmsg-server.json"
+    entrypoint: "/release/skywire svc run --config /release/services.json"
     volumes:
+      - type: bind
+        source: ../docker/integration/services.json
+        target: /release/services.json
+        read_only: true
       - type: bind
         source: ../docker/integration/dmsg-server.json
         target: /release/dmsg-server.json
         read_only: true
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
-  setup-node:
-    privileged: true
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: setup-node
-    container_name: "setup-node"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.6
-      intra:
-        ipv4_address: 174.0.0.6
-    depends_on:
-      - dmsg-server
-    restart: always
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: /release/skywire svc sn -q http -r :6070 /release/setup-node.json
-    volumes:
       - type: bind
         source: ../docker/integration/setup-node.json
         target: /release/setup-node.json
         read_only: true
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
-  service-discovery:
-    privileged: true
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: service-discovery
-    container_name: "service-discovery"
-    restart: always
-    networks:
-      srv:
-        ipv4_address: 175.0.0.9
-      intra:
-        ipv4_address: 174.0.0.9
-    depends_on:
-      transport-discovery:
-        condition: service_healthy
-      sd-redis:
-        condition: service_healthy
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire svc sd --addr :9091 --pprof :6091 --redis redis://sd-redis:6379 --entry-timeout 2m --sk ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f --dmsg-disc http://dmsg-discovery:9090"
+      - type: bind
+        source: ../docker/integration/transport-setup.json
+        target: /release/transport-setup.json
+        read_only: true
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6091/debug/service"]
+      # All four service /debug/service endpoints (TPD, SD, AR, RF)
+      # share one process — checking any one of them validates the
+      # supervisor is up and at least one HTTP listener is live.
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6094/debug/service"]
       interval: 3s
       timeout: 3s
-      retries: 15
-      start_period: 5s
+      retries: 30
+      start_period: 10s
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
@@ -307,70 +238,6 @@ services:
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
-  address-resolver:
-    privileged: true
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: address-resolver
-    container_name: "address-resolver"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.8
-      intra:
-        ipv4_address: 174.0.0.8
-    depends_on:
-      ar-redis:
-        condition: service_healthy
-    restart: always
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire svc ar --addr :9093 --udp-addr :9093 --pprof :6093 --redis redis://ar-redis:6379 --entry-timeout 2m --sk 1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a --dmsg-disc http://dmsg-discovery:9090"
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:6093/debug/service"]
-      interval: 3s
-      timeout: 3s
-      retries: 15
-      start_period: 5s
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
-  stun-server:
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: stun-server
-    container_name: "stun-server"
-    networks:
-      visors:
-        ipv4_address: 173.0.0.17
-      intra:
-        ipv4_address: 174.0.0.17
-    restart: always
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire svc stun --primary-ip 173.0.0.17 --secondary-ip 174.0.0.17 --port 3478 --alt-port 3479"
-
-  transport-setup:
-    privileged: true
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: transport-setup
-    container_name: "transport-setup"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.16
-      intra:
-        ipv4_address: 174.0.0.16
-    depends_on:
-      - dmsg-server
-    restart: always
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: /release/skywire svc tps -c /release/transport-setup.json
-    volumes:
-      - type: bind
-        source: ../docker/integration/transport-setup.json
-        target: /release/transport-setup.json
-        read_only: true
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-
   # skywire visors, which by being on a different network are to be isolated from the first one
 
   visor-a:
@@ -388,15 +255,16 @@ services:
     extra_hosts:
       - "visor-b:173.0.0.12"
       - "visor-c:173.0.0.13"
-      - "dmsg-discovery:174.0.0.4"
-      - "dmsg-server:174.0.0.5"
-      - "transport-discovery:174.0.0.2"
-      - "route-finder:174.0.0.3"
-      - "address-resolver:174.0.0.8"
-      - "service-discovery:174.0.0.9"
+      - "dmsg-discovery:174.0.0.17"
+      - "dmsg-server:174.0.0.17"
+      - "transport-discovery:174.0.0.17"
+      - "route-finder:174.0.0.17"
+      - "address-resolver:174.0.0.17"
+      - "service-discovery:174.0.0.17"
       - "uptime-tracker:174.0.0.7"
-      - "setup-node:174.0.0.6"
+      - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
+      - "transport-setup:174.0.0.17"
     volumes:
       - type: bind
         source: ../docker/integration/visorA.json
@@ -433,15 +301,16 @@ services:
     extra_hosts:
       - "visor-a:173.0.0.11"
       - "visor-c:173.0.0.13"
-      - "dmsg-discovery:174.0.0.4"
-      - "dmsg-server:174.0.0.5"
-      - "transport-discovery:174.0.0.2"
-      - "route-finder:174.0.0.3"
-      - "address-resolver:174.0.0.8"
-      - "service-discovery:174.0.0.9"
+      - "dmsg-discovery:174.0.0.17"
+      - "dmsg-server:174.0.0.17"
+      - "transport-discovery:174.0.0.17"
+      - "route-finder:174.0.0.17"
+      - "address-resolver:174.0.0.17"
+      - "service-discovery:174.0.0.17"
       - "uptime-tracker:174.0.0.7"
-      - "setup-node:174.0.0.6"
+      - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
+      - "transport-setup:174.0.0.17"
     volumes:
       - type: bind
         source: ../docker/integration/visorB.json
@@ -456,14 +325,8 @@ services:
         target: /opt/integration/hypervisor.key
         read_only: false
     depends_on:
-      setup-node:
-        condition: service_started
-      route-finder:
+      deployment-services:
         condition: service_healthy
-      address-resolver:
-        condition: service_healthy
-      dmsg-server:
-        condition: service_started
     restart: always
     environment:
       - GODEBUG=madvdontneed=1
@@ -493,15 +356,16 @@ services:
     extra_hosts:
       - "visor-a:173.0.0.11"
       - "visor-b:173.0.0.12"
-      - "dmsg-discovery:174.0.0.4"
-      - "dmsg-server:174.0.0.5"
-      - "transport-discovery:174.0.0.2"
-      - "route-finder:174.0.0.3"
-      - "address-resolver:174.0.0.8"
-      - "service-discovery:174.0.0.9"
+      - "dmsg-discovery:174.0.0.17"
+      - "dmsg-server:174.0.0.17"
+      - "transport-discovery:174.0.0.17"
+      - "route-finder:174.0.0.17"
+      - "address-resolver:174.0.0.17"
+      - "service-discovery:174.0.0.17"
       - "uptime-tracker:174.0.0.7"
-      - "setup-node:174.0.0.6"
+      - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
+      - "transport-setup:174.0.0.17"
     volumes:
       - type: bind
         source: ../docker/integration/visorC.json
@@ -523,89 +387,13 @@ services:
       retries: 30
       start_period: 10s
 
-  # visor-a-internal:
-  #   privileged: true
-  #   image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-  #   container_name: "visor-a-internal"
-  #   hostname: visor-a-internal
-  #   cap_add:
-  #     - ALL
-  #   networks:
-  #     visors:
-  #       ipv4_address: 173.0.0.21
-  #     intra:
-  #       ipv4_address: 174.0.0.21
-  #   volumes:
-  #     - type: bind
-  #       source: ../docker/integration/visorA-internal.json
-  #       target: /opt/skywire/skywire-visor.json
-  #       read_only: false
-  #   depends_on:
-  #     - visor-b-internal
-  #   restart: always
-  #   entrypoint: /release/skywire visor -c /opt/skywire/skywire-visor.json -s -l debug -q http
-
-  # visor-b-internal:
-  #   privileged: true
-  #   image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-  #   container_name: "visor-b-internal"
-  #   hostname: visor-b-internal
-  #   cap_add:
-  #     - ALL
-  #   networks:
-  #     visors:
-  #       ipv4_address: 173.0.0.22
-  #     intra:
-  #       ipv4_address: 174.0.0.22
-  #   volumes:
-  #     - type: bind
-  #       source: ../docker/integration/visorB-internal.json
-  #       target: /opt/skywire/skywire-visor.json
-  #       read_only: false
-  #     - type: bind
-  #       source: ../docker/integration/hypervisor.crt
-  #       target: /opt/integration/hypervisor.crt
-  #       read_only: false
-  #     - type: bind
-  #       source: ../docker/integration/hypervisor.key
-  #       target: /opt/integration/hypervisor.key
-  #       read_only: false
-  #   depends_on:
-  #     - setup-node
-  #     - route-finder
-  #     - address-resolver
-  #   restart: always
-  #   entrypoint: /release/skywire visor -c /opt/skywire/skywire-visor.json -s -l debug -q http
-
-  # visor-c-internal:
-  #   privileged: true
-  #   image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-  #   container_name: "visor-c-internal"
-  #   hostname: visor-c-internal
-  #   cap_add:
-  #     - ALL
-  #   networks:
-  #     visors:
-  #       ipv4_address: 173.0.0.23
-  #     intra:
-  #       ipv4_address: 174.0.0.23
-  #   volumes:
-  #     - type: bind
-  #       source: ../docker/integration/visorC-internal.json
-  #       target: /opt/skywire/skywire-visor.json
-  #       read_only: false
-  #   depends_on:
-  #     - visor-a-internal
-  #   restart: always
-  #   entrypoint: /release/skywire visor -c /opt/skywire/skywire-visor.json -s -l debug -q http
-    
   network-monitor:
     image: "${REGISTRY}/skywire:${DOCKER_TAG}"
     hostname: network-monitor
     container_name: "network-monitor"
     networks:
       srv:
-        ipv4_address: 175.0.0.30  
+        ipv4_address: 175.0.0.30
       intra:
         ipv4_address: 174.0.0.30
     environment:
@@ -613,11 +401,10 @@ services:
     entrypoint: "/release/skywire svc nm --addr :9080 --pprof :6080 --ut-url http://uptime-tracker:9095 --tpd-url http://transport-discovery:9094 --sd-url http://service-discovery:9091 --dmsgd-url http://dmsg-discovery:9090 --ar-url http://address-resolver:9093"
     depends_on:
       - visor-c
-      # - visor-c-internal
     restart: always
     stdin_open: true # docker run -i
     tty: true        # docker run -t
-  
+
   e2e-test:
     image: golang:1.26-alpine
     container_name: e2e-test
@@ -627,19 +414,22 @@ services:
       - srv
     extra_hosts:
       # Static host entries bypass Docker embedded DNS (127.0.0.11)
-      # which is flaky on GH Actions ("server misbehaving").
+      # which is flaky on GH Actions ("server misbehaving"). All
+      # collapsed deployment services point at the deployment-services
+      # container's intra IP (174.0.0.17); UT remains separate.
       - "visor-a:173.0.0.11"
       - "visor-b:173.0.0.12"
       - "visor-c:173.0.0.13"
-      - "dmsg-discovery:174.0.0.4"
-      - "dmsg-server:174.0.0.5"
-      - "transport-discovery:174.0.0.2"
-      - "route-finder:174.0.0.3"
-      - "address-resolver:174.0.0.8"
-      - "service-discovery:174.0.0.9"
+      - "dmsg-discovery:174.0.0.17"
+      - "dmsg-server:174.0.0.17"
+      - "transport-discovery:174.0.0.17"
+      - "route-finder:174.0.0.17"
+      - "address-resolver:174.0.0.17"
+      - "service-discovery:174.0.0.17"
       - "uptime-tracker:174.0.0.7"
-      - "setup-node:174.0.0.6"
+      - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
+      - "transport-setup:174.0.0.17"
     volumes:
       - ../:/workspace
       - go-test-cache:/root/.cache/go-build

--- a/docker/integration/dmsg-server.json
+++ b/docker/integration/dmsg-server.json
@@ -2,7 +2,7 @@
   "public_key": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
   "secret_key": "6eddf9399b14f29a60e6a652b321d082f9ed2f0172e02c9d9c1a2a22acf4bee3",
   "discovery": "http://dmsg-discovery:9090",
-  "public_address": "174.0.0.5:8080",
+  "public_address": "174.0.0.17:8080",
   "local_address": ":8080",
   "health_endpoint_address": ":8082",
   "max_sessions": 100,

--- a/docker/integration/services-config.json
+++ b/docker/integration/services-config.json
@@ -21,7 +21,7 @@
       {
         "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
         "server": {
-          "address": "174.0.0.5:8080"
+          "address": "174.0.0.17:8080"
         }
       }
     ],
@@ -54,7 +54,7 @@
       {
         "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
         "server": {
-          "address": "174.0.0.5:8080"
+          "address": "174.0.0.17:8080"
         }
       }
     ],

--- a/docker/integration/services.json
+++ b/docker/integration/services.json
@@ -1,0 +1,87 @@
+{
+  "services": [
+    {
+      "type": "transport-discovery",
+      "name": "tpd",
+      "addr": ":9094",
+      "pprof_addr": ":6094",
+      "redis": "redis://tpd-redis:6379",
+      "entry_timeout": "2m",
+      "secret_key": "85789cd7efcdf35340c8f4cb3e15bccdff57efda49af5bcdddaae57374d25ab8",
+      "uptime_db": "",
+      "store_data_path": "/var/lib/skywire/tpd/bandwidth",
+      "dmsg": {
+        "discovery": "http://dmsg-discovery:9090"
+      }
+    },
+    {
+      "type": "route-finder",
+      "name": "rf",
+      "addr": ":9092",
+      "pprof_addr": ":6092",
+      "redis": "redis://tpd-redis:6379",
+      "secret_key": "640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca",
+      "dmsg": {
+        "discovery": "http://dmsg-discovery:9090"
+      }
+    },
+    {
+      "type": "dmsg-discovery",
+      "name": "dmsgd",
+      "addr": ":9090",
+      "redis": "redis://dmsgd-redis:6379",
+      "secret_key": "b3f6706cb72215d3873ef92cc0c6037a47fe651112b1685017d6347eed0fb714",
+      "test_mode": true
+    },
+    {
+      "type": "dmsg-server",
+      "name": "dmsgs",
+      "config_path": "/release/dmsg-server.json"
+    },
+    {
+      "type": "setup-node",
+      "name": "sn",
+      "config_path": "/release/setup-node.json",
+      "pprof_mode": "http",
+      "pprof_addr": ":6070"
+    },
+    {
+      "type": "service-discovery",
+      "name": "sd",
+      "addr": ":9091",
+      "pprof_addr": ":6091",
+      "redis": "redis://sd-redis:6379",
+      "entry_timeout": "2m",
+      "secret_key": "ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f",
+      "dmsg": {
+        "discovery": "http://dmsg-discovery:9090"
+      }
+    },
+    {
+      "type": "address-resolver",
+      "name": "ar",
+      "addr": ":9093",
+      "udp_addr": ":9093",
+      "pprof_addr": ":6093",
+      "redis": "redis://ar-redis:6379",
+      "entry_timeout": "2m",
+      "secret_key": "1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a",
+      "dmsg": {
+        "discovery": "http://dmsg-discovery:9090"
+      }
+    },
+    {
+      "type": "transport-setup",
+      "name": "tps",
+      "config_path": "/release/transport-setup.json"
+    },
+    {
+      "type": "stun-server",
+      "name": "stun",
+      "primary_ip": "173.0.0.17",
+      "secondary_ip": "174.0.0.17",
+      "port": 3478,
+      "alt_port": 3479
+    }
+  ]
+}

--- a/docker/integration/visorA.json
+++ b/docker/integration/visorA.json
@@ -13,7 +13,7 @@
         "timestamp": 0,
         "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
         "server": {
-          "address": "174.0.0.5:8080",
+          "address": "174.0.0.17:8080",
           "availableSessions": 0
         }
       }

--- a/docker/integration/visorB.json
+++ b/docker/integration/visorB.json
@@ -13,7 +13,7 @@
         "timestamp": 0,
         "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
         "server": {
-          "address": "174.0.0.5:8080",
+          "address": "174.0.0.17:8080",
           "availableSessions": 0
         }
       }

--- a/docker/integration/visorC.json
+++ b/docker/integration/visorC.json
@@ -13,7 +13,7 @@
         "timestamp": 0,
         "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
         "server": {
-          "address": "174.0.0.5:8080",
+          "address": "174.0.0.17:8080",
           "availableSessions": 0
         }
       }

--- a/internal/integration/env_test.go
+++ b/internal/integration/env_test.go
@@ -63,15 +63,13 @@ func NewEnv() *TestEnv {
 		cli:      cli,
 		intraNet: "docker_intra",
 		serviceNames: []string{
-			"/setup-node",
-			"/transport-setup",
-			"/dmsg-server",
-			"/dmsg-discovery",
-			"/route-finder",
-			"/transport-discovery",
-			"/address-resolver",
-			"/service-discovery",
-			// "/network-monitor", // intentionally disabled in production deployment
+			// Nine deployment-side services (tpd, rf, dmsg-disc,
+			// dmsg-server, sn, sd, ar, tps, stun) collapsed into
+			// /deployment-services in compose; uptime-tracker
+			// stays separate pending its replacement by TPD's
+			// uptime tracking. network-monitor is intentionally
+			// disabled in the production deployment.
+			"/deployment-services",
 			"/uptime-tracker",
 		},
 		visorNames: []string{


### PR DESCRIPTION
## Summary
Replaces nine separate docker-compose containers (TPD, RF, DMSG-D, DMSG server, SN, SD, AR, TPS, STUN) with a single `deployment-services` container running \`skywire svc run --config /release/services.json\`. The supervisor brings up all nine services as goroutines sharing one signal handler.

**Container count: 21 → 13.**

## Why this should reduce CI e2e flakes
- Container startup races: nine \`depends_on\` chains reduce to one
- Bridge-DNS hiccups on GH Actions runners: nine fewer per-service hostname lookups per inter-service hop
- Cold-start CPU contention: one Go binary init vs nine concurrently
- Health-check cascades: each service's healthcheck is now a goroutine inside the supervisor's first-error-wins logic

## Network topology
deployment-services container holds three IPs across the existing networks. STUN's binding requirement (RFC 3489 needs two distinct IPs) drove the IP picks for intra/visors.
- \`srv\`: 175.0.0.2 (was TPD's address)
- \`intra\`: 174.0.0.17 (was STUN's secondary; now also used for dmsg-server, the http listeners, etc.)
- \`visors\`: 173.0.0.17 (was STUN's primary)

Hostname aliases on each network preserve every old hostname → resolves to the new container. visor configs and the e2e \`extra_hosts\` referring to each service by its old name continue to work.

## Touch-ups beyond the compose file
- \`docker/integration/dmsg-server.json\`: public_address moved \`174.0.0.5:8080\` → \`174.0.0.17:8080\`.
- \`services-config.json\`, \`visorA/B/C.json\`: dmsg_servers list updated to match.
- \`internal/integration/env_test.go\`: serviceNames list collapses from 8 entries to 2 (deployment-services + uptime-tracker).

## Out of scope
- **uptime-tracker**: being subsumed by TPD's uptime tracking; \`pkg/services/ut\` not migrated. Stays as a separate container.
- **network-monitor**: intentionally disabled in production deployment per env_test.go comment.
- **visor migration**: visor's own collapse into the framework is a separate follow-up.

## Test plan
- [x] \`make lint\` (0 issues)
- [x] \`docker compose config\` validates the compose file
- [x] \`skywire svc run --config docker/integration/services.json\` parses cleanly
- [ ] **Critical: full e2e run before merge** — this is the first PR in the series that actually changes runtime topology, so the gold-path e2e needs to pass.
- [ ] Watch for slow startup if dmsg-server's discovery registration races dmsg-discovery's HTTP listener becoming ready (both in the same process now)
- [ ] Watch for health-endpoint correctness — \`http://transport-discovery:9094/...\` from a visor still reaches TPD's chi router inside the new container

## Not auto-merging
Holding for explicit approval after the e2e run. The previous nine PRs in the series were inert refactors; this one is the one that changes deployment behavior.