### PR TITLE
feat(svc): migrate skywire-visor onto pkg/services framework

### DIFF
--- a/cmd/svc/skywire-services/commands/root.go
+++ b/cmd/svc/skywire-services/commands/root.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/skycoin/skywire/pkg/services/stun"
 	_ "github.com/skycoin/skywire/pkg/services/tpd"
 	_ "github.com/skycoin/skywire/pkg/services/tps"
+	_ "github.com/skycoin/skywire/pkg/services/visor"
 )
 
 func init() {

--- a/pkg/services/visor/visor.go
+++ b/pkg/services/visor/visor.go
@@ -1,0 +1,95 @@
+// Package visor pkg/services/visor/visor.go
+//
+// skywire-visor as a pkg/services.Service. Lets `skywire svc run`
+// host a visor alongside the deployment services (or alongside
+// other visors) in one process. Useful for:
+//   - laptop / single-host all-in-one demos
+//   - CI e2e collapses where one visor can co-locate with the
+//     services container
+//   - embedded / hackathon deployments where running multiple
+//     binaries is awkward
+//
+// Block schema is `{ "type": "visor", "config_path": "..." }`. The
+// visor's own JSON config is too large to comfortably embed inline
+// in services.json (~200 lines of nested fields), so this wrapper
+// only supports the file-path indirection. The standalone
+// `skywire-visor` and `skywire visor` commands are unchanged.
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// Type is the registry key used in services.json blocks.
+const Type = "visor"
+
+func init() {
+	services.Register(Type, factory)
+}
+
+// Config is the JSON shape of a visor block in services.json.
+type Config struct {
+	// ConfigPath is the path to the visor's own JSON config file.
+	// Required — the visor config is too large to embed inline.
+	ConfigPath string `json:"config_path"`
+}
+
+// ParseBlock decodes a services.json block into a Config.
+func ParseBlock(raw []byte) (*Config, error) {
+	var c Config
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("visor: parse block: %w", err)
+	}
+	if c.ConfigPath == "" {
+		return nil, errors.New("visor: config_path is required")
+	}
+	return &c, nil
+}
+
+func factory(raw json.RawMessage, log *logging.Logger) (services.Service, error) {
+	cfg, err := ParseBlock(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &service{cfg: cfg, log: log}, nil
+}
+
+type service struct {
+	cfg *Config
+	log *logging.Logger
+}
+
+// Run loads the visor's config file and hands off to the visor's
+// main run loop with the supervisor's ctx as the parent. When the
+// supervisor cancels its ctx (SIGINT, sibling-service error), the
+// visor unwinds via the same SignalContext path the standalone
+// binary uses.
+func (s *service) Run(ctx context.Context) error {
+	path := filepath.Clean(s.cfg.ConfigPath)
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("visor: open config %q: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	bi := buildinfo.Get()
+	conf, compat, err := visorconfig.Parse(s.log, f, path, bi)
+	if err != nil {
+		return fmt.Errorf("visor: parse config %q: %w", path, err)
+	}
+	if !compat {
+		return fmt.Errorf("visor: config %q version is incompatible with this binary", path)
+	}
+	return visor.Run(ctx, conf)
+}

--- a/pkg/visor/systray.go
+++ b/pkg/visor/systray.go
@@ -5,6 +5,8 @@
 package visor
 
 import (
+	"context"
+
 	"fyne.io/systray"
 )
 
@@ -17,7 +19,7 @@ func runAppSystray() {
 	conf := initConfig()
 
 	go func() {
-		err := run(conf)
+		err := run(context.Background(), conf)
 		if err != nil {
 			mLog.WithError(err).Fatal("a fatal error occurred")
 		}
@@ -29,7 +31,7 @@ func runAppSystray() {
 }
 
 func runApp() {
-	err := run(nil)
+	err := run(context.Background(), nil)
 	if err != nil {
 		mLog.WithError(err).Fatal("a fatal error occurred")
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -383,11 +383,24 @@ func reload(v *Visor) error {
 		return err
 	}
 	v = nil
-	return run(nil)
+	return run(context.Background(), nil)
 }
 
-// RunVisor runs the visor
-func run(conf *visorconfig.V1) error {
+// Run is the exported entry point used by pkg/services/visor. parentCtx
+// becomes the parent of the SignalContext run() builds internally —
+// when the multi-service supervisor cancels its ctx, the visor's
+// signal-derived ctx cancels too and the visor unwinds cleanly.
+//
+// Behaves identically to the standalone cobra path when parentCtx is
+// context.Background(), which is what runApp / runAppSystray pass.
+func Run(parentCtx context.Context, conf *visorconfig.V1) error {
+	return run(parentCtx, conf)
+}
+
+// run is the implementation for both the standalone cobra entry point
+// and the multi-service supervisor. parentCtx is the parent of the
+// SignalContext built around it.
+func run(parentCtx context.Context, conf *visorconfig.V1) error {
 	store, hook := logstore.MakeStore(runtimeLogMaxEntries)
 	mLog.AddHook(hook)
 
@@ -458,7 +471,7 @@ func run(conf *visorconfig.V1) error {
 		defer func() { _ = uptimeRec.Close() }() //nolint:errcheck
 	}
 
-	ctx, cancel := cmdutil.SignalContext(context.Background(), mLog)
+	ctx, cancel := cmdutil.SignalContext(parentCtx, mLog)
 	vis, ok := NewVisor(ctx, conf)
 	if !ok {
 		select {

--- a/pkg/visor/withoutsystray.go
+++ b/pkg/visor/withoutsystray.go
@@ -5,6 +5,7 @@
 package visor
 
 import (
+	"context"
 	"sync"
 )
 
@@ -18,7 +19,7 @@ func runAppSystray() {
 }
 
 func runApp() {
-	err := run(nil)
+	err := run(context.Background(), nil)
 	if err != nil {
 		mLog.WithError(err).Fatal("a fatal error occurred")
 	}


### PR DESCRIPTION
## Summary
Lets \`skywire svc run\` host a visor alongside the deployment services (or alongside other visors) in one process. Standalone \`skywire-visor\` and \`skywire visor\` commands unchanged.

- **pkg/visor**: extracted \`run()\` to take a \`parentCtx\` parameter so its internal SignalContext is derived from the supervisor's ctx. New exported \`visor.Run(parentCtx, conf)\` is the entry point.
- **pkg/services/visor**: registers \`Type="visor"\`, parses block, loads + validates config from \`config_path\`, hands off to \`visor.Run\`.

## Block schema
\`\`\`json
{ "type": "visor", "config_path": "/etc/skywire/skywire-visor.json" }
\`\`\`

Inline visor config intentionally not supported — the visor config is ~200 lines of nested fields, awkward to embed in services.json. The file-path indirection matches the existing per-visor config workflow.

## Use cases
1. **All-in-one demo deployments** — one binary with the deployment services + a visor
2. **CI e2e collapse follow-up** — visor-c could co-locate with deployment-services (drops e2e to 12 containers from 13)
3. **Embedded multi-tenant** — multiple visors in one process, each with its own \`config_path\`

## Lifecycle
The supervisor's first-error-wins logic applies. SIGINT cancels everyone simultaneously. Visor's internal SignalContext is parented on the supervisor's ctx so the cascade works.

## Test plan
- [x] \`go build ./...\`
- [x] \`make lint\` (0 issues)
- [x] \`skywire svc run --list\` shows visor alongside the 9 deployment services + noop
- [ ] e2e validation deferred until visor-c migration in a follow-up