### PR TITLE
fix(e2e): Makefile e2e-run for collapsed deployment-services container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,16 +455,17 @@ e2e-dock: ## E2E. Build dockers and containers for e2e-tests
 
 e2e-run: ## E2E. Start e2e environment and wait for all health checks to pass
 	@# Start services in stages to avoid overwhelming the CI runner.
-	@# On a dual-core GitHub Actions runner, starting everything at once
-	@# causes healthcheck timeouts because Go services are too slow to
-	@# initialize when competing for CPU.
+	@# On a dual-core GitHub Actions runner, starting everything at
+	@# once causes healthcheck timeouts because Go services are too
+	@# slow to initialize when competing for CPU.
+	@#
+	@# After #2471 the nine deployment-side services (tpd, rf,
+	@# dmsg-disc, dmsg-server, sn, sd, ar, tps, stun) collapse into
+	@# one `deployment-services` container; the previous per-service
+	@# staging is replaced by one wait on the supervisor.
 	bash -c "DOCKER_TAG=e2e docker compose up -d --wait dmsgd-redis ar-redis sd-redis tpd-redis ut-redis postgres-db"
-	bash -c "DOCKER_TAG=e2e docker compose up -d stun-server"
-	bash -c "DOCKER_TAG=e2e docker compose up -d --wait transport-discovery address-resolver uptime-tracker"
-	bash -c "DOCKER_TAG=e2e docker compose up -d --wait dmsg-discovery"
-	bash -c "DOCKER_TAG=e2e docker compose up -d --wait route-finder service-discovery"
-	bash -c "DOCKER_TAG=e2e docker compose up -d --wait dmsg-server"
-	bash -c "DOCKER_TAG=e2e docker compose up -d --wait setup-node transport-setup"
+	bash -c "DOCKER_TAG=e2e docker compose up -d --wait deployment-services"
+	bash -c "DOCKER_TAG=e2e docker compose up -d uptime-tracker"
 	bash -c "DOCKER_TAG=e2e docker compose up -d --wait visor-b"
 	bash -c "DOCKER_TAG=e2e docker compose up -d --wait visor-a visor-c"
 	bash -c "DOCKER_TAG=e2e docker compose ps"


### PR DESCRIPTION
## Summary
Hotfix for #2471. The collapse PR removed the nine individual deployment-service containers from \`docker-compose.yml\` but the Makefile's \`e2e-run\` target still tried to bring them up by name. CI failed at the first reference:

\`\`\`
bash -c "DOCKER_TAG=e2e docker compose up -d stun-server"
no such service: stun-server
make: *** [Makefile:462: e2e-run] Error 1
\`\`\`

This replaces the staged per-service chain with one wait on \`deployment-services\`, followed by \`uptime-tracker\` (still separate pending UT replacement by TPD) and the three visors.

## Test plan
- [x] Compose validates (\`docker compose config --services\`)
- [ ] CI's full e2e run on this PR