### PR TITLE
fix(autoconfig): clear stale systemd drop-in when SKYWIRE_USER unsets

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -133,20 +133,52 @@ Mode is selected by PKGENV/USRENV in the env file:
 		}
 		msg3(fmt.Sprintf("%sSkywire%s configuration updated\nconfig path: %s%s%s", colorBlue, colorReset, colorPurple, resolved.configPath, colorReset))
 
-		// PKGENV + SKYWIRE_USER → write drop-in + chown the install.
-		// Only meaningful when running as root (chown of root-owned
-		// files needs root); when run as the target user already, the
-		// drop-in still needs root, so we skip both branches and let
-		// the operator manage them out of band if they wish.
-		if !resolved.usrEnv && resolved.skywireUser != "" && os.Geteuid() == 0 {
-			if err := writeSystemdDropIn(resolved.skywireUser); err != nil {
-				fmt.Printf("%sWarning:%s could not write systemd drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
-			} else {
-				msg3(fmt.Sprintf("Wrote %s (User=%s)", systemdDropIn, resolved.skywireUser))
-				_ = exec.Command("systemctl", "daemon-reload").Run() //nolint:errcheck,gosec
+		// PKGENV mode: keep the systemd drop-in in sync with
+		// SKYWIRE_USER. When SKYWIRE_USER is set, write a drop-in
+		// pinning User= and chown the install to that user. When it's
+		// unset (or the operator switched away from it), tear down a
+		// previously-written drop-in so the unit reverts to running
+		// as root — otherwise the stale `User=<old_user>` would
+		// either fail CHDIR (if that user no longer has access to
+		// the install) or fail the visor's `--pkg requires root`
+		// pre-run check (because the drop-in still pins a non-root
+		// User= even though the operator's policy changed).
+		//
+		// Only meaningful when invoked as root: chowning root-owned
+		// files and writing under /etc/systemd/system/ both need it.
+		// When run as the target user already, we skip both branches
+		// and let the operator manage them out of band.
+		if !resolved.usrEnv && os.Geteuid() == 0 {
+			daemonReload := false
+			switch {
+			case resolved.skywireUser != "":
+				if err := writeSystemdDropIn(resolved.skywireUser); err != nil {
+					fmt.Printf("%sWarning:%s could not write systemd drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
+				} else {
+					msg3(fmt.Sprintf("Wrote %s (User=%s)", systemdDropIn, resolved.skywireUser))
+					daemonReload = true
+				}
+				if err := chownInstall(resolved.skywireUser); err != nil {
+					fmt.Printf("%sWarning:%s chown %s failed: %v\n", colorYellow, colorReset, skyenv.SkywirePath, err)
+				}
+			default:
+				// SKYWIRE_USER unset → ensure no stale drop-in is
+				// present that would still pin the unit to a
+				// non-root user. Idempotent: silent when there's
+				// nothing to remove.
+				if _, statErr := os.Stat(systemdDropIn); statErr == nil {
+					if err := os.Remove(systemdDropIn); err != nil {
+						fmt.Printf("%sWarning:%s could not remove stale drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
+					} else {
+						msg3(fmt.Sprintf("Removed stale %s (SKYWIRE_USER unset)", systemdDropIn))
+						// Also drop the parent dir if it's now empty.
+						_ = os.Remove(filepath.Dir(systemdDropIn)) //nolint:errcheck
+						daemonReload = true
+					}
+				}
 			}
-			if err := chownInstall(resolved.skywireUser); err != nil {
-				fmt.Printf("%sWarning:%s chown %s failed: %v\n", colorYellow, colorReset, skyenv.SkywirePath, err)
+			if daemonReload {
+				_ = exec.Command("systemctl", "daemon-reload").Run() //nolint:errcheck,gosec
 			}
 		}
 

--- a/scripts/deb_installer/deb.postinst
+++ b/scripts/deb_installer/deb.postinst
@@ -10,6 +10,25 @@ fi
 
 setcap 'cap_net_admin+p' /opt/skywire/apps/vpn-client
 
+# Defensive cleanup of a stale `skywire autoconfig`-managed systemd
+# drop-in. autoconfig writes `/etc/systemd/system/skywire.service.d/
+# skywire-user.conf` (User=_skywire) when /etc/skywire.conf has
+# SKYWIRE_USER=<name> set, but doesn't remove that drop-in when the
+# operator later unsets SKYWIRE_USER — leaving the unit pinned to a
+# user that the operator no longer intends to run as. This .deb
+# never asks for that drop-in (the shipped service runs as root
+# unconditionally), so any drop-in still sitting there is
+# definitionally stale: drop it. Idempotent — silent when there's
+# nothing to remove.
+if [ -f /etc/skywire.conf ] && \
+   ! grep -qE '^[[:space:]]*SKYWIRE_USER=' /etc/skywire.conf 2>/dev/null ; then
+	if [ -f /etc/systemd/system/skywire.service.d/skywire-user.conf ] ; then
+		rm -f /etc/systemd/system/skywire.service.d/skywire-user.conf
+		rmdir --ignore-fail-on-non-empty /etc/systemd/system/skywire.service.d 2>/dev/null || true
+		echo "removed stale skywire-user.conf drop-in (SKYWIRE_USER unset in /etc/skywire.conf)"
+	fi
+fi
+
 # Automatically added by dh_systemd_enable/12.1.1
 if [ \"\$1\" = \"configure\" ] || [ \"\$1\" = \"abort-upgrade\" ] || [ \"\$1\" = \"abort-deconfigure\" ] || [ \"\$1\" = \"abort-remove\" ] ; then
 	# This will only remove masks created by d-s-h on package removal.


### PR DESCRIPTION
## Problem
\`skywire autoconfig\` writes \`/etc/systemd/system/skywire.service.d/skywire-user.conf\` (\`User=<name>\`) when \`/etc/skywire.conf\` has \`SKYWIRE_USER=<name>\` set, pinning the unit to that user. But it never removed that drop-in when the operator later unset SKYWIRE_USER — leaving the unit pinned to a user the operator no longer intends.

Two failure modes that follow from the stale drop-in:
- **CHDIR failure** if \`/opt/skywire\` is no longer accessible to the pinned user
- **\"root permissions required to use the specified config\"** — the default unit's \`ExecStart\` includes \`--pkg\`, which the visor's pre-run check rejects under non-root, so the drop-in's \`User=_skywire\` makes startup fail every time

Discovered in the wild on a v1.3.50 AUR upgrade where the operator previously had \`SKYWIRE_USER=_skywire\` set, then commented it out expecting the unit to revert to root. The drop-in stayed; the visor failed both errors above on every restart.

## Fix
Track the policy: under PKGENV mode running as root, when \`SKYWIRE_USER\` is set we write+chown as before; when it's unset we remove the drop-in (idempotent) and drop the parent dir if empty. \`systemctl daemon-reload\` fires in both branches when state changed.

Same defensive cleanup added to \`scripts/deb_installer/deb.postinst\`: the .deb's own \`skywire.service\` runs as root unconditionally, so any drop-in at install time is definitionally stale.

## Note on v1.3.50 packages
v1.3.50 was already cut and packaged at AUR / .deb time, so this lands for v1.3.51+. The package-level workarounds (in \`skywire.install\` for AUR + the matching \`deb.postinst\` snippet) handle v1.3.50 in the field — operators who upgrade to a v1.3.50 build with the package fix will have the drop-in cleaned up automatically.

## Test plan
- [x] \`go build ./...\`
- [x] \`make lint\` (0 issues)
- [ ] On a v1.3.50 box with stale \`skywire-user.conf\`: install v1.3.51, run \`skywire autoconfig\`, confirm the drop-in is gone and the unit starts as root
- [ ] On a v1.3.50 box with active \`SKYWIRE_USER=_skywire\`: install v1.3.51, run \`skywire autoconfig\`, confirm the drop-in is preserved and unit runs as \`_skywire\`