### PR TITLE
fix: two nil-derefs on session shutdown — dmsg client smux + vpn server

### DIFF
--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -277,12 +277,30 @@ func (cs *ClientSession) serve() error {
 	for {
 		dStr, err := cs.acceptYamuxStream()
 		if err != nil {
-			// yamux-level failure. Shutdown / closed / EOF are
+			// Stream-mux-level failure. Shutdown / closed / EOF are
 			// terminal — the underlying session is dead. Everything
 			// else is treated as potentially-transient and retried
 			// with a short backoff, mirroring the server-side loop
 			// in ServerSession.Serve (streamErrorBackoff = 50ms).
-			if errors.Is(err, yamux.ErrSessionShutdown) || errors.Is(err, io.EOF) || cs.sm.yamux.IsClosed() {
+			//
+			// `cs.sm` carries either a yamux session or an smux
+			// session — never both. Pre-fix this branch dereferenced
+			// `cs.sm.yamux.IsClosed()` unconditionally, which nil-
+			// deref'd whenever the session was negotiated as smux
+			// (`entry.Protocol == "smux"` in client_sessions.go and
+			// the matching server-side path) and any non-EOF /
+			// non-yamux-shutdown error reached this branch.
+			// Recovered by the goroutine's defer/recover but logged
+			// only as "recovered panic in session serve goroutine: …"
+			// with no clue about the cause.
+			sessionClosed := errors.Is(err, io.EOF)
+			switch {
+			case cs.sm.yamux != nil:
+				sessionClosed = sessionClosed || errors.Is(err, yamux.ErrSessionShutdown) || cs.sm.yamux.IsClosed()
+			case cs.sm.smux != nil:
+				sessionClosed = sessionClosed || cs.sm.smux.IsClosed()
+			}
+			if sessionClosed {
 				cs.log.WithError(err).Debug("Session shut down, stopping accept loop.")
 				return err
 			}

--- a/pkg/vpn/server.go
+++ b/pkg/vpn/server.go
@@ -151,10 +151,32 @@ func (s *Server) Serve(l net.Listener) error {
 		s.lis = l
 		s.lisMx.Unlock()
 		s.setAppStatus(appserver.AppDetailedStatusRunning)
+		// Accept off the local listener parameter, not s.lis.
+		// Close() sets `s.lis = nil` after closing it, and the
+		// previous code dereferenced `s.lis.Accept()` without
+		// holding s.lisMx — so any non-net.ErrClosed accept error
+		// (e.g. a dmsg listener returning "io: read/write on
+		// closed pipe" mid-shutdown) routed to `continue`, and the
+		// next iteration nil-deref'd s.lis. The local `l` always
+		// points at the listener that was passed in; closing it
+		// elsewhere is fine, calling .Accept() on a closed
+		// listener returns an error rather than panicking.
 		for {
-			conn, err := s.lis.Accept()
+			conn, err := l.Accept()
 			if err != nil {
 				if errors.Is(err, net.ErrClosed) {
+					return
+				}
+				// Best-effort match for transport-level shutdowns
+				// that a wrapped listener may surface as a
+				// non-net.ErrClosed error (e.g. dmsg's
+				// "use of closed network connection" /
+				// "io: read/write on closed pipe"). Treat any
+				// accept error after Close() as terminal.
+				s.lisMx.Lock()
+				closed := s.lis == nil
+				s.lisMx.Unlock()
+				if closed {
 					return
 				}
 				fmt.Printf("Failed to accept VPN client connection, continuing: %v\n", err)


### PR DESCRIPTION
Both fired in the wild on a v1.3.50 visor immediately after a session-level shutdown.

## 1. \`pkg/dmsg/dmsg\` — ClientSession.serve() unconditional yamux deref
\`cs.sm\` carries either yamux or smux, never both. The accept-loop's session-closed check unconditionally derefed \`cs.sm.yamux.IsClosed()\`, which nil-deref'd whenever:
- the session was negotiated as smux, AND
- any non-EOF / non-\`yamux.ErrSessionShutdown\` error reached this branch

The goroutine's defer/recover swallowed the panic but logged only \"recovered panic in session serve goroutine: …\" with no indication of where.

**Fix**: branch on which protocol is non-nil, ask that one whether the session is closed.

## 2. \`pkg/vpn/server.go\` — Server.Serve() accept-loop race
\`Server.Close()\` sets \`s.lis = nil\` after closing the listener. The \`Serve()\` goroutine accepted off \`s.lis.Accept()\` without holding the listener mutex; if the accept error didn't match \`net.ErrClosed\` the loop hit \`continue\`, then on the next iteration \`s.lis.Accept()\` derefenced nil — taking down the whole visor process via a panic from inside \`sync.Once.Do\`.

Triggered by a wrapped dmsg listener surfacing \"io: read/write on closed pipe\" rather than the bare \`net.ErrClosed\` during shutdown.

**Fix**: accept off the local listener parameter \`l\` (not the shared \`s.lis\` field), plus a defensive \"is the server already closed?\" check that terminates the loop on any post-Close accept error regardless of how the wrapped listener spelled it.

## Test plan
- [x] \`go build ./...\`
- [x] \`make lint\` (0 issues)
- [ ] On a v1.3.50 visor with the panic reproducing: confirm session shutdown no longer kills the visor