### PR TITLE
fix(cxo/node): backpressure CXO accept loops to bound pending handshakes

### DIFF
--- a/pkg/cxo/node/transport/dmsg.go
+++ b/pkg/cxo/node/transport/dmsg.go
@@ -32,12 +32,19 @@ const DefaultCXOPort = skyenv.DmsgCXOPort
 type DMSGFactory struct {
 	AcceptedCallback func(conn *Connection)
 
+	// MaxPendingAccepts caps in-flight AcceptedCallback invocations.
+	// Zero (default) leaves accepts unbounded for backwards compatibility;
+	// set it from the Node's MaxPendingConnections to apply backpressure
+	// to the dmsg listener queue when handshake processing falls behind.
+	MaxPendingAccepts int
+
 	dmsgC *dmsg.Client
 	port  uint16
 
 	mu       sync.Mutex
 	listener *dmsg.Listener
 	closed   bool
+	sem      chan struct{} // nil when MaxPendingAccepts == 0
 }
 
 // NewDMSGFactory creates a new DMSGFactory using the given DMSG client.
@@ -58,6 +65,9 @@ func (f *DMSGFactory) Listen() error {
 
 	f.mu.Lock()
 	f.listener = lis
+	if f.MaxPendingAccepts > 0 {
+		f.sem = make(chan struct{}, f.MaxPendingAccepts)
+	}
 	f.mu.Unlock()
 
 	go f.acceptLoop(lis)
@@ -99,14 +109,39 @@ func (f *DMSGFactory) Close() {
 }
 
 func (f *DMSGFactory) acceptLoop(lis net.Listener) {
+	// f.sem is set once in Listen before this goroutine starts, so
+	// reading it without the lock is safe.
+	sem := f.sem
 	for {
+		// Block before Accept when the in-flight callback queue is full,
+		// so the dmsg listener applies backpressure to the remote rather
+		// than the Node piling up handshake goroutines (and their
+		// per-conn buffers + read/write loops) on a contended mutex.
+		if sem != nil {
+			sem <- struct{}{}
+		}
 		conn, err := lis.Accept()
 		if err != nil {
+			if sem != nil {
+				<-sem
+			}
 			return
 		}
 		c := newConnection(conn, false)
-		if cb := f.AcceptedCallback; cb != nil {
-			go cb(c)
+		cb := f.AcceptedCallback
+		if cb == nil {
+			if sem != nil {
+				<-sem
+			}
+			continue
 		}
+		go func() {
+			defer func() {
+				if sem != nil {
+					<-sem
+				}
+			}()
+			cb(c)
+		}()
 	}
 }

--- a/pkg/cxo/node/transport/tcp.go
+++ b/pkg/cxo/node/transport/tcp.go
@@ -9,9 +9,16 @@ import (
 type TCPFactory struct {
 	AcceptedCallback func(conn *Connection)
 
+	// MaxPendingAccepts caps in-flight AcceptedCallback invocations.
+	// Zero (default) leaves accepts unbounded for backwards compatibility;
+	// set it from the Node's MaxPendingConnections to apply backpressure
+	// to the listener queue when handshake processing falls behind.
+	MaxPendingAccepts int
+
 	mu       sync.Mutex
 	listener net.Listener
 	closed   bool
+	sem      chan struct{} // nil when MaxPendingAccepts == 0
 }
 
 // NewTCPFactory creates a new TCPFactory.
@@ -27,6 +34,9 @@ func (f *TCPFactory) Listen(address string) error {
 	}
 	f.mu.Lock()
 	f.listener = ln
+	if f.MaxPendingAccepts > 0 {
+		f.sem = make(chan struct{}, f.MaxPendingAccepts)
+	}
 	f.mu.Unlock()
 
 	go f.acceptLoop(ln)
@@ -68,14 +78,38 @@ func (f *TCPFactory) Close() {
 }
 
 func (f *TCPFactory) acceptLoop(ln net.Listener) {
+	// f.sem is set once in Listen before this goroutine starts, so
+	// reading it without the lock is safe.
+	sem := f.sem
 	for {
+		// Block before Accept when the in-flight callback queue is full,
+		// so the kernel listen backlog absorbs the burst rather than the
+		// Node piling up handshake goroutines on a contended mutex.
+		if sem != nil {
+			sem <- struct{}{}
+		}
 		conn, err := ln.Accept()
 		if err != nil {
+			if sem != nil {
+				<-sem
+			}
 			return
 		}
 		c := newConnection(conn, true)
-		if cb := f.AcceptedCallback; cb != nil {
-			go cb(c)
+		cb := f.AcceptedCallback
+		if cb == nil {
+			if sem != nil {
+				<-sem
+			}
+			continue
 		}
+		go func() {
+			defer func() {
+				if sem != nil {
+					<-sem
+				}
+			}()
+			cb(c)
+		}()
 	}
 }

--- a/pkg/cxo/node/transport/udp.go
+++ b/pkg/cxo/node/transport/udp.go
@@ -11,9 +11,16 @@ import (
 type UDPFactory struct {
 	AcceptedCallback func(conn *Connection)
 
+	// MaxPendingAccepts caps in-flight AcceptedCallback invocations.
+	// Zero (default) leaves accepts unbounded for backwards compatibility;
+	// set it from the Node's MaxPendingConnections to apply backpressure
+	// to the listener queue when handshake processing falls behind.
+	MaxPendingAccepts int
+
 	mu       sync.Mutex
 	listener net.Listener
 	closed   bool
+	sem      chan struct{} // nil when MaxPendingAccepts == 0
 }
 
 // NewUDPFactory creates a new UDPFactory.
@@ -29,6 +36,9 @@ func (f *UDPFactory) Listen(address string) error {
 	}
 	f.mu.Lock()
 	f.listener = ln
+	if f.MaxPendingAccepts > 0 {
+		f.sem = make(chan struct{}, f.MaxPendingAccepts)
+	}
 	f.mu.Unlock()
 
 	go f.acceptLoop(ln)
@@ -59,14 +69,38 @@ func (f *UDPFactory) Close() {
 }
 
 func (f *UDPFactory) acceptLoop(ln net.Listener) {
+	// f.sem is set once in Listen before this goroutine starts, so
+	// reading it without the lock is safe.
+	sem := f.sem
 	for {
+		// Block before Accept when the in-flight callback queue is full,
+		// so the kernel listen backlog absorbs the burst rather than the
+		// Node piling up handshake goroutines on a contended mutex.
+		if sem != nil {
+			sem <- struct{}{}
+		}
 		conn, err := ln.Accept()
 		if err != nil {
+			if sem != nil {
+				<-sem
+			}
 			return
 		}
 		c := newConnection(conn, false)
-		if cb := f.AcceptedCallback; cb != nil {
-			go cb(c)
+		cb := f.AcceptedCallback
+		if cb == nil {
+			if sem != nil {
+				<-sem
+			}
+			continue
 		}
+		go func() {
+			defer func() {
+				if sem != nil {
+					<-sem
+				}
+			}()
+			cb(c)
+		}()
 	}
 }

--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -32,6 +32,12 @@ func newDMSG(n *Node, factory *transport.DMSGFactory) *DMSG {
 		cs:          make(map[cipher.PubKey]*Conn),
 	}
 	d.AcceptedCallback = d.acceptConn
+	// Cap concurrent in-flight accepts at the Node's pending-connection
+	// limit so the dmsg listener applies backpressure when handshake
+	// processing falls behind n.mx, instead of fanning out unbounded
+	// goroutines that pile up on the same mutex (and OOM the process
+	// via per-conn buffers + read/write loops).
+	d.MaxPendingAccepts = n.config.MaxPendingConnections
 	return d
 }
 

--- a/pkg/cxo/node/transports.go
+++ b/pkg/cxo/node/transports.go
@@ -33,6 +33,10 @@ func newTCP(n *Node) (t *TCP) {
 
 	t.n = n
 	t.AcceptedCallback = t.acceptConn
+	// Cap concurrent in-flight accepts at the Node's pending-connection
+	// limit so the listener applies backpressure when handshake processing
+	// falls behind n.mx, instead of fanning out unbounded goroutines.
+	t.MaxPendingAccepts = n.config.MaxPendingConnections
 	t.cs = make(map[string]*Conn)
 
 	return
@@ -203,6 +207,10 @@ func newUDP(n *Node) (u *UDP) {
 
 	u.n = n
 	u.AcceptedCallback = u.acceptConn
+	// Cap concurrent in-flight accepts at the Node's pending-connection
+	// limit so the listener applies backpressure when handshake processing
+	// falls behind n.mx, instead of fanning out unbounded goroutines.
+	u.MaxPendingAccepts = n.config.MaxPendingConnections
 	u.cs = make(map[string]*Conn)
 
 	return


### PR DESCRIPTION
## Summary

The DMSG/TCP/UDP factory `acceptLoop`s in `pkg/cxo/node/transport/` fan out an unbounded `go cb(c)` per accept. Every callback then queues on `Node.mx` to register the connection, and each accepted `Connection` eagerly spawns read/write loops + 256-element in/out channels.

Under sustained inbound load this turns into a runaway feedback loop: more accepts → bigger heap → slower GC → slower handshakes → more accepts.

### Production symptom

Observed on a deployment `transport-discovery`:

| Metric | Value |
|---|---:|
| Goroutines | 115,178 |
| Goroutines blocked on `Node.onNewConn` mutex | 57,332 |
| Goroutines in `transport.(*Connection).writeLoop` | 57,491 |
| Heap (inuse) | 4.6 GB |
| Heap held by `cipher/encoder.Serialize` (CXO) | 2.94 GB |
| Heap held by `cxo/node/transport.newConnection` | 730 MB |
| Heap held by `bufio.NewReaderSize` | 476 MB |
| CPU spent in `runtime.gcBgMarkWorker` | ~76% |
| CPU spent in actual HTTP handlers | ~9.5% |

The container OOM-killed and restarted shortly after.

## Fix

Add an optional `MaxPendingAccepts` cap on each factory. When set, the `acceptLoop` blocks on a buffered-channel semaphore **before** calling `Accept`, so the underlying listener (dmsg or kernel TCP) absorbs the burst instead of the Node piling up goroutines on a contended mutex.

Default of `0` preserves the existing unbounded behavior for callers that don't opt in.

Wire `newDMSG` / `newTCP` / `newUDP` to set the cap to the Node's existing `MaxPendingConnections` (default 1000), matching the limit the Node already enforces inside `onNewConn` — but applied earlier, before the per-conn allocations and before contending for `n.mx`.

This benefits every caller of `EnableDMSG`:
- Deployment side: `transport-discovery/cxoaggregator`, `dmsg/discovery/api/cxo_publisher`, `service-discovery/api/cxo_publisher`
- Visor side: `visor/cxo_subscription_manager`, `tpviz/cxo_subscriber`, `cxo/treestore/{publisher,subscriber}`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/cxo/node/...` clean
- [x] `go test -race ./pkg/cxo/node/...` passes
- [ ] Deploy to a transport-discovery host and verify goroutine count stays bounded under load
- [ ] Confirm `MaxPendingConnections` is still honored end-to-end (the existing in-`onNewConn` check is unchanged; the new cap is just an earlier gate at the same threshold)