### PR TITLE
feat(skynetweb): Host-header rewrite via subdomain prefix (depends on #2484)

### DIFF
--- a/pkg/skynetweb/hostrewrite.go
+++ b/pkg/skynetweb/hostrewrite.go
@@ -1,0 +1,262 @@
+// Package skynetweb pkg/skynetweb/hostrewrite.go
+//
+// HTTP/1.1 Host-header rewriter for the resolver SOCKS5 dial path.
+//
+// Motivation
+//
+// A visit to `https://example.com.<pk>.skynet/` resolves to the
+// visor <pk>, but the browser sends `Host: example.com.<pk>.skynet`
+// over the wire. When the backend is a vhost-capable HTTP server
+// (Caddy, nginx, traefik) configured for `example.com`, that Host
+// value doesn't match any of its sites and the request 404s.
+//
+// This wrapper sits between the SOCKS5 splice's plaintext stream
+// (post-TLS-termination if TLS MITM is enabled) and the raw skywire
+// conn to the backend. It parses each HTTP/1.1 request the browser
+// sends, rewrites Host to the configured value (e.g. `example.com`),
+// then re-emits the request to the backend. The response direction
+// is passthrough — Set-Cookie/Location rewriting is left for a
+// future iteration and the limitation is called out in the docs.
+//
+// Boundary: HTTP/1.1 only. h2c (plain HTTP/2) and SSE-with-binary-
+// upgrade scenarios are not handled. Most reverse-proxy deployments
+// terminate browser TLS upstream of the backend's plaintext face
+// anyway, so HTTP/1.1 is the common case.
+package skynetweb
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// hostRewriteConn wraps a net.Conn and rewrites the Host header on
+// every HTTP/1.1 request flowing in the browser→backend direction.
+// Response direction (backend→browser) is a straight passthrough.
+//
+// The wrapper exposes the io.ReadWriteCloser surface the SOCKS5
+// splice expects:
+//
+//   SOCKS5.io.Copy(dst=hostRewriteConn, src=browser)    → Write side
+//   SOCKS5.io.Copy(dst=browser, src=hostRewriteConn)    → Read side
+//
+// Write side: bytes from the browser (already TLS-decrypted by the
+// MITMTerminate wrapper sitting "above" us in the stack) come in.
+// We pipe them into an internal bufio.Reader that an async goroutine
+// parses with http.ReadRequest, modifies, and re-emits to the
+// backend with req.Write.
+//
+// Read side: bytes from the backend pass through unchanged.
+type hostRewriteConn struct {
+	backend    net.Conn
+	targetHost string
+
+	// Write-side pipe: bytes that arrive on Write are written to
+	// pipeW; the parser goroutine reads from pipeR.
+	pipeW *io.PipeWriter
+	pipeR *io.PipeReader
+
+	// Surface for closing the parser goroutine cleanly.
+	closeOnce sync.Once
+	doneCh    chan struct{}
+}
+
+// newHostRewriteConn wraps backend so writes are HTTP-parsed and
+// have their Host header replaced with targetHost. targetHost must
+// be non-empty; the caller (runtime.go) decides whether to apply
+// the wrapper based on the parsed URL.
+func newHostRewriteConn(backend net.Conn, targetHost string) *hostRewriteConn {
+	if targetHost == "" {
+		// Caller bug — guard rather than silently passing through.
+		// A panic is preferable to silent breakage because this
+		// path is only taken when a rewrite was explicitly chosen.
+		panic("skynetweb: newHostRewriteConn called with empty targetHost")
+	}
+	pr, pw := io.Pipe()
+	h := &hostRewriteConn{
+		backend:    backend,
+		targetHost: targetHost,
+		pipeW:      pw,
+		pipeR:      pr,
+		doneCh:     make(chan struct{}),
+	}
+	go h.pump()
+	return h
+}
+
+// pump runs on a dedicated goroutine. Reads HTTP requests from the
+// internal pipe, rewrites Host, re-emits to backend. Exits when
+// Close is called (pipe closure cascades into an EOF on Read).
+func (h *hostRewriteConn) pump() {
+	defer close(h.doneCh)
+	defer h.backend.Close() //nolint:errcheck,gosec
+
+	r := bufio.NewReader(h.pipeR)
+	for {
+		req, err := http.ReadRequest(r)
+		if err != nil {
+			// EOF or malformed input — we can't recover the stream.
+			// Closing the backend conn lets the response pump on
+			// the Read side notice and unblock.
+			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
+				// Best-effort: noisy log would be tidier in real code
+				// but we don't have access to the logger here.
+			}
+			return
+		}
+
+		// Rewrite Host. http.Request.Write uses req.Host (the canonical
+		// field) for the wire-format Host: header; also clear any
+		// stale "Host" entry in the header map so duplicates don't
+		// slip through.
+		req.Host = h.targetHost
+		req.Header.Del("Host")
+
+		// Clear RequestURI: required by req.Write which expects the
+		// request to look "client-side" (URL.RequestURI() is used).
+		req.RequestURI = ""
+
+		// req.URL is parsed with the original Host. Reset Host on
+		// URL too so any %-encoded reconstruction stays consistent.
+		// Path/RawQuery come from RequestURI which we leave on req.URL.
+		if req.URL != nil {
+			req.URL.Host = h.targetHost
+		}
+
+		if err := req.Write(h.backend); err != nil {
+			return
+		}
+	}
+}
+
+// Write accepts browser-side plaintext (post-TLS-MITM) and feeds it
+// into the internal pipe for the parser goroutine.
+func (h *hostRewriteConn) Write(p []byte) (int, error) {
+	return h.pipeW.Write(p)
+}
+
+// Read passes backend bytes through unchanged.
+func (h *hostRewriteConn) Read(p []byte) (int, error) {
+	return h.backend.Read(p)
+}
+
+// Close tears down the pipe (causing the pump to exit) and closes
+// the backend. Idempotent.
+func (h *hostRewriteConn) Close() error {
+	h.closeOnce.Do(func() {
+		_ = h.pipeW.Close() //nolint:errcheck,gosec
+		_ = h.pipeR.Close() //nolint:errcheck,gosec
+	})
+	// Backend close happens inside pump's defer; wait for it so the
+	// caller's Close returns only after the goroutine has actually
+	// released the backend.
+	<-h.doneCh
+	return nil
+}
+
+// net.Conn interface methods — delegate to backend for the address
+// pair (so SOCKS5 sees a coherent local/remote pair) and accept
+// deadlines on both directions.
+func (h *hostRewriteConn) LocalAddr() net.Addr  { return h.backend.LocalAddr() }
+func (h *hostRewriteConn) RemoteAddr() net.Addr { return h.backend.RemoteAddr() }
+func (h *hostRewriteConn) SetDeadline(t time.Time) error {
+	return h.backend.SetDeadline(t)
+}
+func (h *hostRewriteConn) SetReadDeadline(t time.Time) error {
+	return h.backend.SetReadDeadline(t)
+}
+func (h *hostRewriteConn) SetWriteDeadline(t time.Time) error {
+	return h.backend.SetWriteDeadline(t)
+}
+
+// splitHostSubdomain parses "<subdomain>.<pk>.<suffix>[:port]" or
+// "<pk>.<suffix>[:port]" into pkLabel + subdomain + port.
+//
+//   "blog.<pk>.skynet"        → ("<pk>", "blog",        80)
+//   "example.com.<pk>.skynet" → ("<pk>", "example.com", 80)
+//   "<pk>.skynet"             → ("<pk>", "",            80)
+//   "<pk>.skynet:1234"        → ("<pk>", "",          1234)
+//
+// suffix is expected to start with ".". Returns an error when the
+// host shape doesn't match (no suffix match, no PK label, etc.) so
+// the caller can fall back or surface a useful message.
+func splitHostSubdomain(host, suffix string) (pkLabel, subdomain string, port uint16, err error) {
+	// Split off optional port first.
+	hostPart, portStr, hasPort := splitHostPort(host)
+	port = 80
+	if hasPort {
+		p, perr := parseUint16(portStr)
+		if perr != nil {
+			return "", "", 0, fmt.Errorf("invalid port %q: %w", portStr, perr)
+		}
+		port = p
+	}
+
+	// hostPart must end in the suffix.
+	if len(hostPart) <= len(suffix) || hostPart[len(hostPart)-len(suffix):] != suffix {
+		return "", "", 0, fmt.Errorf("host %q has no suffix %q", hostPart, suffix)
+	}
+	stripped := hostPart[:len(hostPart)-len(suffix)]
+
+	// The PK is the last label before the suffix. Anything before
+	// it is the subdomain.
+	lastDot := lastIndexByte(stripped, '.')
+	if lastDot < 0 {
+		// No subdomain — whole thing is the PK.
+		return stripped, "", port, nil
+	}
+	pkLabel = stripped[lastDot+1:]
+	subdomain = stripped[:lastDot]
+	return pkLabel, subdomain, port, nil
+}
+
+// Small helpers kept inline so the parser doesn't pull in extra
+// dependencies (strconv/strings) that the existing runtime.go
+// already imports; using the std lib's equivalents from here would
+// be the same code with import bloat.
+
+func splitHostPort(host string) (h, p string, hasPort bool) {
+	// Walk from the right; first ':' that isn't inside brackets
+	// (IPv6) is the port separator. For our hostnames there are
+	// no brackets.
+	for i := len(host) - 1; i >= 0; i-- {
+		if host[i] == ':' {
+			return host[:i], host[i+1:], true
+		}
+		if host[i] == ']' || host[i] == '/' {
+			break
+		}
+	}
+	return host, "", false
+}
+
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+func parseUint16(s string) (uint16, error) {
+	if len(s) == 0 || len(s) > 5 {
+		return 0, fmt.Errorf("port out of range")
+	}
+	var n uint32
+	for _, ch := range []byte(s) {
+		if ch < '0' || ch > '9' {
+			return 0, fmt.Errorf("non-digit %q", ch)
+		}
+		n = n*10 + uint32(ch-'0')
+		if n > 0xFFFF {
+			return 0, fmt.Errorf("port out of range")
+		}
+	}
+	return uint16(n), nil
+}

--- a/pkg/skynetweb/hostrewrite_test.go
+++ b/pkg/skynetweb/hostrewrite_test.go
@@ -1,0 +1,161 @@
+package skynetweb
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// fakeConn is the in-memory pair used to drive the wrapper. Reads/
+// writes go through bytes.Buffer; addresses are stubs.
+type fakeConn struct {
+	r *io.PipeReader
+	w *io.PipeWriter
+	// out is what was received on the "backend" side. Tests assert
+	// against this.
+	out bytes.Buffer
+}
+
+func (c *fakeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error)        { n, err := c.out.Write(p); return n, err }
+func (c *fakeConn) Close() error {
+	_ = c.r.Close() //nolint:errcheck,gosec
+	_ = c.w.Close() //nolint:errcheck,gosec
+	return nil
+}
+func (c *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (c *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (c *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func newFakeConn() *fakeConn {
+	pr, pw := io.Pipe()
+	return &fakeConn{r: pr, w: pw}
+}
+
+func TestSplitHostSubdomain(t *testing.T) {
+	const suffix = ".skynet"
+	const pk = "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+
+	cases := []struct {
+		host          string
+		wantPK        string
+		wantSubdomain string
+		wantPort      uint16
+		wantErr       bool
+	}{
+		{pk + ".skynet", pk, "", 80, false},
+		{pk + ".skynet:443", pk, "", 443, false},
+		{"blog." + pk + ".skynet", pk, "blog", 80, false},
+		{"example.com." + pk + ".skynet", pk, "example.com", 80, false},
+		{"a.b.c." + pk + ".skynet:8080", pk, "a.b.c", 8080, false},
+		{"no-suffix-here", "", "", 0, true},
+		{pk + ".skynet:notanum", "", "", 0, true},
+	}
+	for _, c := range cases {
+		gotPK, gotSub, gotPort, err := splitHostSubdomain(c.host, suffix)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("splitHostSubdomain(%q): expected err, got nil", c.host)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("splitHostSubdomain(%q): unexpected err %v", c.host, err)
+			continue
+		}
+		if gotPK != c.wantPK || gotSub != c.wantSubdomain || gotPort != c.wantPort {
+			t.Errorf("splitHostSubdomain(%q): got (%q, %q, %d), want (%q, %q, %d)",
+				c.host, gotPK, gotSub, gotPort, c.wantPK, c.wantSubdomain, c.wantPort)
+		}
+	}
+}
+
+// TestHostRewriteConn_RewritesHostHeader feeds a complete HTTP/1.1
+// request into the wrapper's Write side and asserts the backend
+// received the request with Host: rewritten.
+func TestHostRewriteConn_RewritesHostHeader(t *testing.T) {
+	backend := newFakeConn()
+	hr := newHostRewriteConn(backend, "example.com")
+	defer hr.Close() //nolint:errcheck,gosec
+
+	// Browser request. Host header should be the .skynet-flavor URL;
+	// after the wrapper, the backend sees Host: example.com.
+	const browserRequest = "GET /path?q=1 HTTP/1.1\r\n" +
+		"Host: example.com.0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c.skynet\r\n" +
+		"User-Agent: testclient\r\n" +
+		"Accept: */*\r\n" +
+		"\r\n"
+
+	if _, err := hr.Write([]byte(browserRequest)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// The parser goroutine pumps async; give it a moment to flush.
+	// In production this is the SOCKS5 splice's poll loop; here we
+	// just poll the buffer.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && backend.out.Len() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if backend.out.Len() == 0 {
+		t.Fatal("backend received nothing within deadline")
+	}
+
+	// Parse what the backend got and verify Host.
+	got, err := http.ReadRequest(bufio.NewReader(&backend.out))
+	if err != nil {
+		t.Fatalf("backend parse: %v", err)
+	}
+	if got.Host != "example.com" {
+		t.Errorf("Host = %q, want %q", got.Host, "example.com")
+	}
+	if got.URL.Path != "/path" {
+		t.Errorf("Path = %q, want /path", got.URL.Path)
+	}
+	if got.URL.RawQuery != "q=1" {
+		t.Errorf("RawQuery = %q, want q=1", got.URL.RawQuery)
+	}
+}
+
+// TestHostRewriteConn_RewritesTwoSequentialRequests verifies that
+// HTTP/1.1 keep-alive works — multiple requests on one connection
+// each get Host rewritten.
+func TestHostRewriteConn_RewritesTwoSequentialRequests(t *testing.T) {
+	backend := newFakeConn()
+	hr := newHostRewriteConn(backend, "example.com")
+	defer hr.Close() //nolint:errcheck,gosec
+
+	body := "GET /a HTTP/1.1\r\nHost: example.com.<pk>.skynet\r\n\r\n" +
+		"GET /b HTTP/1.1\r\nHost: example.com.<pk>.skynet\r\n\r\n"
+	if _, err := hr.Write([]byte(body)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bytes.Count(backend.out.Bytes(), []byte("\r\n\r\n")) >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	br := bufio.NewReader(&backend.out)
+	for i, wantPath := range []string{"/a", "/b"} {
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			t.Fatalf("req %d parse: %v", i, err)
+		}
+		if req.Host != "example.com" {
+			t.Errorf("req %d Host = %q, want example.com", i, req.Host)
+		}
+		if req.URL.Path != wantPath {
+			t.Errorf("req %d Path = %q, want %q", i, req.URL.Path, wantPath)
+		}
+	}
+}

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"strconv"
-	"strings"
 
 	"github.com/armon/go-socks5"
 	"golang.org/x/net/proxy"
@@ -201,6 +199,31 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				}
 				done(nil)
 
+				// Build the conn stack inside-out. The raw skywire
+				// conn is the innermost layer. Optional host-rewrite
+				// wraps it next (so the rewriter sees plaintext
+				// HTTP). Optional MITM TLS terminator is the outer
+				// layer (so the browser sees a TLS server).
+				//
+				// Order rationale:
+				//
+				//   Browser  ──TLS──► MITMTerminate ──plaintext──► hostRewriteConn ──plaintext──► raw conn ──► backend
+				//
+				// hostRewriteConn parses HTTP/1.1 between MITM
+				// decryption and the wire. If MITM is off, the
+				// browser is already sending plaintext directly to
+				// hostRewriteConn — same parser, same effect.
+				var stack net.Conn = conn
+				if target.subdomain != "" {
+					// `subdomain` already encodes the operator's
+					// intent (the URL has labels before the PK).
+					// Use it verbatim as the rewritten Host.
+					stack = newHostRewriteConn(stack, target.subdomain)
+					log.WithField("pk", target.pk.Hex()).
+						WithField("rewrite_host", target.subdomain).
+						Debug("SOCKS5 → skynet host-rewrite active")
+				}
+
 				// Optional TLS MITM: terminate the browser's TLS
 				// session locally with a leaf cert for the host,
 				// splicing plaintext to the merchant's plain-HTTP
@@ -211,13 +234,13 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				if cfg.TLSMITM && target.port == cfg.TLSPort {
 					leaf, lerr := cfg.LeafMinter.For(origHost)
 					if lerr != nil {
-						_ = conn.Close()
+						_ = stack.Close() //nolint:errcheck,gosec
 						return nil, fmt.Errorf("skynet mitm leaf: %w", lerr)
 					}
-					return &tcpAddrConn{Conn: skynetca.MITMTerminate(conn, leaf)}, nil
+					stack = skynetca.MITMTerminate(stack, leaf)
 				}
 
-				return &tcpAddrConn{Conn: conn}, nil
+				return &tcpAddrConn{Conn: stack}, nil
 			}
 
 			// Not .skynet — forward to upstream or direct.
@@ -290,24 +313,28 @@ func isSkynetHost(host, suffix string) bool {
 type target struct {
 	pk   cipher.PubKey
 	port uint16
+	// subdomain is the label(s) before the PK in the original
+	// hostname, when the visitor used a vhost-style URL like
+	// "<subdomain>.<pk>.skynet". Empty when the URL was just
+	// "<pk>.skynet". Triggers the Host-header rewrite path in the
+	// dial wiring — see newHostRewriteConn in hostrewrite.go.
+	subdomain string
 }
 
-// parseHostHeader turns "<pk>.skynet[:<port>]" into (pk, port). Port
+// parseHostHeader turns "<pk>.skynet[:<port>]" or
+// "<subdomain>.<pk>.skynet[:<port>]" into a target struct. Port
 // defaults to 80 when absent to match conventional HTTP semantics.
+// The subdomain field is non-empty only when there was at least one
+// label before the PK; that signals the runtime to apply the
+// Host-rewrite wrapper.
 func parseHostHeader(host, suffix string) (target, error) {
-	hostParts := strings.SplitN(host, ":", 2)
-	pkHost := strings.TrimSuffix(hostParts[0], suffix)
+	pkLabel, subdomain, port, err := splitHostSubdomain(host, suffix)
+	if err != nil {
+		return target{}, err
+	}
 	var pk cipher.PubKey
-	if err := pk.Set(pkHost); err != nil {
-		return target{}, fmt.Errorf("invalid pk %q: %w", pkHost, err)
+	if err := pk.Set(pkLabel); err != nil {
+		return target{}, fmt.Errorf("invalid pk %q: %w", pkLabel, err)
 	}
-	port := uint16(80)
-	if len(hostParts) == 2 && hostParts[1] != "" {
-		n, err := strconv.ParseUint(hostParts[1], 10, 16)
-		if err != nil {
-			return target{}, fmt.Errorf("invalid port: %w", err)
-		}
-		port = uint16(n)
-	}
-	return target{pk: pk, port: port}, nil
+	return target{pk: pk, port: port, subdomain: subdomain}, nil
 }


### PR DESCRIPTION
## Summary

Adds vhost-style addressing on top of PR #2484's TLS MITM resolver. URLs of the form

```
http(s)://<subdomain>.<pk>.skynet/
```

are translated by the resolver to a dial of `dmsg://<pk>:port` with the HTTP `Host:` header rewritten to `<subdomain>` before the plaintext request reaches the backend. URLs without a subdomain (`<pk>.skynet`) behave exactly as before — no rewrite, no wrapper.

## Motivating use case

An operator runs Caddy on their visor host with N virtual hosts (`example.com`, `blog.example.com`, ...). They forward port 80 over skynet — **one** mapping, not one per site. A visitor types `https://example.com.<pk>.skynet/` and Caddy receives the request with `Host: example.com`, dispatches its vhost normally, serves the right site. With PR #2484 active, the browser also gets a fully valid HTTPS connection (locally-minted leaf cert), so secure-context features like Stripe.js work.

## Implementation

- `splitHostSubdomain` parses optional subdomain labels in the hostname. Anything before the last `.<pk>.skynet[:port]` becomes the rewrite target.
- `target` gains a `subdomain string` field; non-empty triggers the rewrite wrapper.
- `hostRewriteConn` wraps the raw skywire conn, sits inside the MITM TLS terminator. On `Write` (browser → backend), it pipes through `http.ReadRequest`, sets `req.Host = subdomain`, calls `req.Write` to the backend. Response direction is passthrough.
- Wiring is inside-out: `raw conn → hostRewriteConn (if subdomain) → MITMTerminate (if TLS port match) → tcpAddrConn returned to SOCKS5 splice`. Plaintext flows through the rewriter regardless of whether MITM is active.

## Depends on

#2484 — the TLS MITM resolver work this builds on. This PR will only meaningfully merge after that one. Should be rebased onto develop once #2484 lands.

## Limits

- **HTTP/1.1 only.** h2c (plain HTTP/2) and SSE-with-upgrade flows aren't parsed.
- **Response-side rewrites** (`Set-Cookie Domain=`, `Location:` absolute URLs) are out of scope. Cookies with `Domain=` attributes will be rejected by the browser (the actual hostname is `<sub>.<pk>.skynet`, not `<sub>`); operators should either unset `Domain=` or rely on a follow-up flag.
- **Absolute URLs in HTML/JS/CSS** (`<img src="https://example.com/x">`) get fetched by the browser via the resolver's upstream-proxy fallthrough — they go to the real public internet, not back into skynet. For a personal-Caddy-on-the-same-machine deployment where the operator controls DNS, this self-heals.

## Tests

- `TestSplitHostSubdomain` table: no-subdomain, single-label, multi-label, port variants, malformed inputs.
- `TestHostRewriteConn_RewritesHostHeader`: full HTTP/1.1 request round trip, asserts backend received `Host:` rewritten and path/query intact.
- `TestHostRewriteConn_RewritesTwoSequentialRequests`: two sequential keep-alive requests, both get `Host:` rewritten.

All three pass on the existing `pkg/skynetweb` test target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)