### PR TITLE
feat(visor): port-80 reverse-proxy --preserve-host for vhost-based backends

### DIFF
--- a/cmd/skywire-cli/commands/serve/serve.go
+++ b/cmd/skywire-cli/commands/serve/serve.go
@@ -36,14 +36,15 @@ import (
 )
 
 var (
-	serveTo        string
-	serveLabel     string
-	serveDesc      string
-	serveWhitelist string
-	serveSkynet    bool
-	serveDmsg      bool
-	serveLanding   bool
-	serveJSON      bool
+	serveTo           string
+	serveLabel        string
+	serveDesc         string
+	serveWhitelist    string
+	serveSkynet       bool
+	serveDmsg         bool
+	serveLanding      bool
+	servePreserveHost bool
+	serveJSON         bool
 )
 
 func init() {
@@ -53,6 +54,10 @@ func init() {
 	servePortCmd.Flags().BoolVar(&serveSkynet, "skynet", true, "expose over skynet (sky-forwarding server)")
 	servePortCmd.Flags().BoolVar(&serveDmsg, "dmsg", true, "expose over DMSG")
 	servePortCmd.Flags().BoolVar(&serveLanding, "landing", true, "show on the visor landing page")
+	servePortCmd.Flags().BoolVar(&servePreserveHost, "preserve-host", false,
+		"for port-80 HTTP reverse-proxy: keep the original Host header instead of rewriting "+
+			"to --to target. Use when the backend (Caddy / nginx / traefik) dispatches "+
+			"its virtual hosts by Host (e.g. paired with the resolver's subdomain rewrite)")
 	servePortCmd.Flags().StringVar(&serveWhitelist, "whitelist", "", "comma-separated PKs allowed to access this port (empty = allow all)")
 
 	servePortLsCmd.Flags().BoolVar(&serveJSON, "json", false, "emit raw JSON")
@@ -129,6 +134,7 @@ Examples:
 			Skynet:        serveSkynet,
 			DMSG:          serveDmsg,
 			ShowOnLanding: serveLanding,
+			PreserveHost:  servePreserveHost,
 		}
 
 		// Resolve --to into the right field. The visor schema has two

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -29,8 +29,16 @@ import (
 // buildReverseProxy returns a *httputil.ReverseProxy targeting the local
 // app at `target`. Behaviors beyond NewSingleHostReverseProxy:
 //
-//   - Host header is rewritten to the backend's host so apps that
-//     verify the Host header accept the request.
+//   - Host header handling is governed by preserveHost:
+//     preserveHost=false (default): Host is rewritten to target.Host.
+//     Backends that verify Host against their listening address
+//     accept the request — the historical default.
+//     preserveHost=true: the incoming request's Host header passes
+//     through unchanged. Required when the backend (Caddy,
+//     nginx, traefik) dispatches its virtual hosts by Host —
+//     e.g. when an operator forwards port 80 to a Caddy that
+//     serves N domains, paired with the resolver's subdomain
+//     rewrite (skynetweb) on the visitor side.
 //   - Origin header (when present) is rewritten to the backend's URL so
 //     WebSocket upgrades through the visor's port-80 reverse proxy
 //     pass same-origin checks. Without this, audioprism and any other
@@ -38,11 +46,19 @@ import (
 //     audio/data channel even though the WASM/HTML loaded fine.
 //   - ErrorHandler logs reverse-proxy and upgrade failures so the
 //     symptom isn't a silently broken WS connection.
-func buildReverseProxy(log *logging.Logger, target *url.URL) *httputil.ReverseProxy {
+func buildReverseProxy(log *logging.Logger, target *url.URL, preserveHost bool) *httputil.ReverseProxy {
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(target)
-			r.Out.Host = target.Host
+			// SetURL clears Out.Host (see net/http/httputil docs);
+			// we set it explicitly in both branches so the wire
+			// Host header is fully determined by this Rewrite
+			// callback, not by the ServeHTTP default path.
+			if preserveHost {
+				r.Out.Host = r.In.Host
+			} else {
+				r.Out.Host = target.Host
+			}
 			if r.In.Header.Get("Origin") != "" {
 				r.Out.Header.Set("Origin", target.Scheme+"://"+target.Host)
 			}
@@ -110,8 +126,10 @@ func (v *Visor) refreshWebsiteHandler(log *logging.Logger) {
 				lsAPI.SetWebsiteHandler(nil)
 				return
 			}
-			log.WithField("addr", addr).Info("Reverse-proxying custom website (port 80)")
-			lsAPI.SetWebsiteHandler(buildReverseProxy(log, target))
+			log.WithField("addr", addr).
+				WithField("preserve_host", fp.PreserveHost).
+				Info("Reverse-proxying custom website (port 80)")
+			lsAPI.SetWebsiteHandler(buildReverseProxy(log, target, fp.PreserveHost))
 			return
 		}
 	}

--- a/pkg/visor/api_network_test.go
+++ b/pkg/visor/api_network_test.go
@@ -1,0 +1,97 @@
+package visor
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestBuildReverseProxy_HostRewriteDefault checks the historical
+// default — preserveHost=false → backend sees Host = target.Host —
+// because some apps validate Host against their listening address.
+func TestBuildReverseProxy_HostRewriteDefault(t *testing.T) {
+	var gotHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		_, _ = w.Write([]byte("ok")) //nolint:errcheck,gosec
+	}))
+	defer backend.Close()
+
+	target, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	rp := buildReverseProxy(logging.MustGetLogger("test"), target, false)
+	front := httptest.NewServer(rp)
+	defer front.Close()
+
+	req, _ := http.NewRequest("GET", front.URL+"/x", nil) //nolint:errcheck,gosec
+	req.Host = "example.com.0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c.skynet"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()          //nolint:errcheck,gosec
+	body, _ := io.ReadAll(resp.Body) //nolint:errcheck,gosec
+	if string(body) != "ok" {
+		t.Fatalf("body=%q", body)
+	}
+
+	// preserveHost=false → Host on the backend should be target.Host
+	// (the httptest backend's address), NOT the visitor's Host.
+	if gotHost == "" {
+		t.Fatalf("backend got empty Host")
+	}
+	if !strings.HasPrefix(gotHost, "127.0.0.1:") {
+		t.Errorf("preserveHost=false: backend Host=%q, expected target's 127.0.0.1:<port>", gotHost)
+	}
+	if strings.Contains(gotHost, "example.com") {
+		t.Errorf("preserveHost=false: backend Host=%q leaked visitor Host", gotHost)
+	}
+}
+
+// TestBuildReverseProxy_HostPreserved is the new branch. With
+// preserveHost=true the backend sees whatever Host the incoming
+// request carried — Caddy/nginx vhost dispatch path.
+func TestBuildReverseProxy_HostPreserved(t *testing.T) {
+	var gotHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		_, _ = w.Write([]byte("ok")) //nolint:errcheck,gosec
+	}))
+	defer backend.Close()
+
+	target, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	rp := buildReverseProxy(logging.MustGetLogger("test"), target, true)
+	front := httptest.NewServer(rp)
+	defer front.Close()
+
+	const visitorHost = "magnetosphere.net"
+	req, _ := http.NewRequest("GET", front.URL+"/x", nil) //nolint:errcheck,gosec
+	req.Host = visitorHost
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()          //nolint:errcheck,gosec
+	body, _ := io.ReadAll(resp.Body) //nolint:errcheck,gosec
+	if string(body) != "ok" {
+		t.Fatalf("body=%q", body)
+	}
+
+	if gotHost != visitorHost {
+		t.Errorf("preserveHost=true: backend Host=%q, want %q", gotHost, visitorHost)
+	}
+}

--- a/pkg/visor/forwarded_ports.go
+++ b/pkg/visor/forwarded_ports.go
@@ -34,6 +34,22 @@ type ForwardedPort struct {
 	// to reverse-proxy to. For port 80, this replaces the visor's
 	// default landing page with content from the local service.
 	ProxyAddr string `json:"proxy_addr,omitempty"`
+	// PreserveHost controls the Host header on the request the
+	// reverse-proxy emits to the backend. Currently effective on the
+	// port-80 HTTP reverse-proxy (the only forward type that touches
+	// HTTP headers; raw-TCP forwards don't see HTTP at all).
+	//
+	//   false (default): visor rewrites Host to the backend's address
+	//                    (target.Host). Useful when the backend
+	//                    validates Host against its listening address
+	//                    — the historical behavior.
+	//   true:            visor preserves whatever Host the incoming
+	//                    request already carried (e.g. magnetosphere
+	//                    .net after the skynetweb resolver's
+	//                    subdomain rewrite). Required when the
+	//                    backend (Caddy, nginx, traefik) dispatches
+	//                    its virtual hosts by Host header.
+	PreserveHost bool `json:"preserve_host,omitempty"`
 }
 
 // EffectiveLocalPort returns the local TCP port to forward to.


### PR DESCRIPTION
## Summary

The visor's port-80 HTTP reverse-proxy historically rewrites the outgoing `Host:` header to the `--to` backend's address. That helps "paranoid" backends that validate `Host:` against their listening address (the original motivation, kept as the default), but silently breaks the **Caddy-behind-the-visor** pattern: an operator runs Caddy with N virtual hosts, forwards port 80 over skynet, and pairs that with the resolver's subdomain rewrite (#2485) so visitors hit `http(s)://<site>.<pk>.skynet/` URLs. With `Host:` clobbered to `127.0.0.1:80`, every vhost-by-Host dispatcher downstream sees the wrong name and falls through to its default site.

This PR adds an opt-in `PreserveHost` field on `ForwardedPort` and a matching `--preserve-host` flag on `skywire cli serve add`. When set, the port-80 reverse-proxy passes the inbound `Host:` through to the backend untouched.

## Combined flow

```
Browser → https://magnetosphere.net.<pk>.skynet/
       ↓
Resolver (#2484 TLS-MITM) + (#2485 subdomain rewrite)
   → unwraps TLS, sets Host: magnetosphere.net
       ↓
Visor port 80 reverse-proxy (preserveHost=true)
   → forwards request to backend, Host untouched
       ↓
Caddy → Host: magnetosphere.net → vhost dispatch → real content
```

Built-in landing-page routes (rewards survey, runtime logs, `/health`) still win precedence-wise in the visor — enabling `--preserve-host` on the same port doesn't affect rewards eligibility or log collection.

## Why opt-in (default off)

The existing behavior was deliberate and useful for some backends. The new behavior breaks those. Keeping default `false` means existing deployments continue working without operator action; only the operator who knows they want vhost dispatch flips the bit.

## Use it like

```
skywire cli serve add 80 --to 127.0.0.1:80 --preserve-host
```

Or in the visor config under `forwarded_ports`:

```json
{
  "port": 80,
  "proxy_addr": "127.0.0.1:80",
  "preserve_host": true
}
```

## Test plan

- [x] `TestBuildReverseProxy_HostRewriteDefault` — default keeps the existing rewrite-to-target behavior.
- [x] `TestBuildReverseProxy_HostPreserved` — `preserveHost=true` forwards the inbound Host untouched.
- [x] `go build ./...` clean
- [x] `make lint` — net new issues from this PR: zero (only pre-existing in unrelated files).
- [ ] Manual: enable on a real visor, point Caddy at it with N vhosts behind the resolver's subdomain rewrite, confirm `Host:` arrives at Caddy as the visitor's intended hostname.

## Depends on

#2485 (Host-rewrite via subdomain prefix in the resolver) — without it, browsers can't put the right Host into the request in the first place. This PR makes the visor *not erase* that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)