### PR TITLE
fix(skynetca,resolver): base32 PK DNS-label so HTTPS-via-skynet leaf certs are RFC-compliant

### DIFF
--- a/cmd/skywire-cli/commands/resolver/ca.go
+++ b/cmd/skywire-cli/commands/resolver/ca.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	caForce       bool
+	caForce        bool
 	caInstallPrint bool
 )
 
@@ -216,7 +216,7 @@ func defaultCAPaths() (certPath, keyPath string, err error) {
 // detectLinuxTrustStore inspects /etc/os-release to locate the
 // distro's anchors directory and the system trust-update command.
 func detectLinuxTrustStore() (anchorsDir string, updateCmd []string, err error) {
-	osRelease, _ := os.ReadFile("/etc/os-release")
+	osRelease, _ := os.ReadFile("/etc/os-release") //nolint:errcheck,gosec
 	id := osReleaseField(string(osRelease), "ID")
 	idLike := osReleaseField(string(osRelease), "ID_LIKE")
 	combined := id + " " + idLike
@@ -255,4 +255,3 @@ func runVisible(argv []string) error {
 	}
 	return nil
 }
-

--- a/cmd/skywire-cli/commands/shortcuts.go
+++ b/cmd/skywire-cli/commands/shortcuts.go
@@ -26,6 +26,11 @@ func init() {
 	statusCmd.GroupID = groupVisor
 	pkCmd.GroupID = groupVisor
 	haltCmd.GroupID = groupVisor
+	// Re-mount the dnslabel subcommand under the shortcut so
+	// `cli pk dnslabel` works as well as `cli visor pk dnslabel`.
+	// The shortcut's pkCmd is a separate *cobra.Command — its
+	// children aren't inherited from the underlying visor pkCmd.
+	pkCmd.AddCommand(clivisor.PKDNSLabelCmd)
 }
 
 // statusCmd is `skywire cli status` — equivalent to `cli visor info`.

--- a/cmd/skywire-cli/commands/visor/exports.go
+++ b/cmd/skywire-cli/commands/visor/exports.go
@@ -11,6 +11,10 @@ package clivisor
 // PKCmd is the `cli visor pk` command. Top-level `cli pk` reuses its Run.
 var PKCmd = pkCmd
 
+// PKDNSLabelCmd is the `cli visor pk dnslabel` subcommand. Top-level
+// `cli pk dnslabel` re-mounts the same Command so both paths reach it.
+var PKDNSLabelCmd = pkDNSLabelCmd
+
 // SummaryCmd is the `cli visor info` command. Top-level `cli status`
 // reuses its Run; the leaf name differs only at the root.
 var SummaryCmd = summaryCmd

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -18,6 +18,7 @@ import (
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -29,6 +30,7 @@ func init() {
 	RootCmd.AddCommand(pkCmd)
 	pkCmd.Flags().StringVarP(&path, "input", "i", "", "path of input config file.")
 	pkCmd.Flags().BoolVarP(&pkg, "pkg", "p", false, "read from "+fmt.Sprintf("%v", visorconfig.PackageConfig()))
+	pkCmd.AddCommand(pkDNSLabelCmd)
 	RootCmd.AddCommand(summaryCmd)
 	RootCmd.AddCommand(readyCmd)
 	RootCmd.AddCommand(buildInfoCmd)
@@ -65,6 +67,59 @@ var pkCmd = &cobra.Command{
 			outputPK = overview.PubKey.Hex() + "\n"
 		}
 		internal.PrintOutput(cmd.Flags(), strings.TrimSuffix(outputPK, "\n"), outputPK)
+	},
+}
+
+// pkDNSLabelCmd converts a PK between its hex (66 chars) and base32
+// DNS-label (53 chars) forms. The base32 form is what skynet URLs
+// must use — hex overflows DNS-label and X.509 CN limits and breaks
+// HTTPS via the resolver's TLS-MITM mode.
+var pkDNSLabelCmd = &cobra.Command{
+	Use:   "dnslabel [hex-or-base32-pk]",
+	Short: "Convert a PK to/from its skynet-URL DNS-label form (base32)",
+	Long: `Convert a public key between its hex and base32 DNS-label forms.
+
+With no argument: prints the local visor's PK as a base32 DNS label.
+With one argument: detects the form and prints the other.
+
+  hex (66 chars)   →  base32 (53 chars, DNS-label-safe, used in URLs)
+  base32 (53)      →  hex (66, used everywhere else in skywire)`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var pk cipher.PubKey
+		if len(args) == 1 {
+			in := args[0]
+			switch len(in) {
+			case 66:
+				if err := pk.Set(in); err != nil {
+					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid hex PK: %w", err))
+				}
+				out := pk.DNSLabel()
+				internal.PrintOutput(cmd.Flags(), out, out+"\n")
+			case cipher.PubKeyDNSLabelLen:
+				decoded, err := cipher.ParseDNSLabel(in)
+				if err != nil {
+					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid base32 PK: %w", err))
+				}
+				out := decoded.Hex()
+				internal.PrintOutput(cmd.Flags(), out, out+"\n")
+			default:
+				internal.PrintFatalError(cmd.Flags(),
+					fmt.Errorf("input %q has length %d; expected 66 (hex) or 53 (base32)", in, len(in)))
+			}
+			return
+		}
+		// No arg — query the running visor.
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		overview, err := rpcClient.Overview()
+		if err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+		out := overview.PubKey.DNSLabel()
+		internal.PrintOutput(cmd.Flags(), out, out+"\n")
 	},
 }
 

--- a/docs/skynet-tls.md
+++ b/docs/skynet-tls.md
@@ -151,10 +151,35 @@ manually if you want to revoke completely.
 
 After install + visor restart, point a browser at the resolver
 SOCKS5 (default `127.0.0.1:4446` for skynet, `4445` for dmsg) and
-visit `https://<visor-pk>.skynet/`. You should see the merchant's
-content with no certificate warning. Browser dev-tools should
-report `isSecureContext = true` and the cert issuer as the local
-"Skynet Resolver Local CA".
+visit `https://<visor-pk-dns-label>.skynet/`. You should see the
+merchant's content with no certificate warning. Browser dev-tools
+should report `isSecureContext = true` and the cert issuer as the
+local "Skynet Resolver Local CA".
+
+### Why `<visor-pk-dns-label>` and not hex
+
+A 33-byte PubKey is 66 hex chars, which overflows two strict
+limits enforced by NSS (Firefox / Waterfox / Chrome):
+
+  - RFC 1035 caps each DNS label at 63 octets.
+  - X.520 caps an X.509 Subject `CN` attribute at 64 chars
+    (ub-common-name).
+
+A leaf cert minted for `<66-hex>.skynet` is rejected as
+"improperly encoded" before any trust check runs. The base32 form
+produced by `<pk>.DNSLabel()` is 53 chars — fits both limits.
+
+The hex form is still accepted by the resolver for backwards
+compatibility with plain-HTTP URLs already in circulation, but
+HTTPS will not work with it regardless of CA install state.
+
+To get a visor's PK in the URL form, use:
+
+```
+skywire cli pk dnslabel                       # local visor
+skywire cli pk dnslabel <hex-pk>              # arbitrary PK (hex → base32)
+skywire cli pk dnslabel <base32-pk>           # round-trip back to hex
+```
 
 ## Trust scope
 

--- a/pkg/cipher/dnslabel.go
+++ b/pkg/cipher/dnslabel.go
@@ -1,0 +1,59 @@
+// Package cipher — DNS-label encoding for PubKey.
+//
+// Skynet URLs of the form `<subdomain>.<pk>.skynet` need to fit each
+// component into a DNS label. The hex form is 66 chars (33 bytes × 2),
+// which exceeds two limits:
+//
+//   - RFC 1035 caps each DNS label at 63 octets.
+//   - X.520 ub-common-name caps the X.509 Subject.CommonName at 64.
+//
+// Either limit causes strict TLS stacks (NSS / Firefox / Chrome) to
+// reject the leaf cert minted by the resolver's TLS-MITM mode as
+// "improperly encoded," so HTTPS over skynet doesn't work at all
+// with the hex form regardless of how the URL is dialled.
+//
+// RFC 4648 base32 of 33 bytes is 53 chars unpadded (ceil(33*8/5)),
+// well under 63. Lowercase is canonical for DNS (case-insensitive
+// but lowercase is the convention) and decodes case-insensitively
+// regardless. Padding is stripped because DNS labels can't contain
+// '='. We use base32 rather than base64url because DNS labels are
+// case-insensitive: base64's A/a / B/b / + / / would collide or be
+// rewritten by intermediaries.
+package cipher
+
+import (
+	"encoding/base32"
+	"fmt"
+	"strings"
+)
+
+// dnsLabelEnc is RFC 4648 base32 without padding, decoded
+// case-insensitively. 33-byte PubKey → 53 chars.
+var dnsLabelEnc = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// PubKeyDNSLabelLen is the number of base32 chars produced by DNSLabel
+// for a 33-byte PubKey. Exposed so callers can branch between the new
+// base32 form and the legacy 66-char hex form when parsing skynet URLs.
+const PubKeyDNSLabelLen = 53
+
+// DNSLabel returns the PubKey as a lowercase, unpadded base32 string
+// suitable for use as a single DNS label inside a skynet hostname.
+func (pk PubKey) DNSLabel() string {
+	return strings.ToLower(dnsLabelEnc.EncodeToString(pk[:]))
+}
+
+// ParseDNSLabel decodes a base32 PubKey label produced by DNSLabel
+// back into a PubKey. Input is treated case-insensitively. Returns
+// an error when the input is not a valid 33-byte base32 encoding.
+func ParseDNSLabel(label string) (PubKey, error) {
+	raw, err := dnsLabelEnc.DecodeString(strings.ToUpper(label))
+	if err != nil {
+		return PubKey{}, fmt.Errorf("cipher: decode dns label: %w", err)
+	}
+	if len(raw) != 33 {
+		return PubKey{}, fmt.Errorf("cipher: dns label decoded to %d bytes, want 33", len(raw))
+	}
+	var pk PubKey
+	copy(pk[:], raw)
+	return pk, nil
+}

--- a/pkg/cipher/dnslabel.go
+++ b/pkg/cipher/dnslabel.go
@@ -10,7 +10,7 @@
 // Either limit causes strict TLS stacks (NSS / Firefox / Chrome) to
 // reject the leaf cert minted by the resolver's TLS-MITM mode as
 // "improperly encoded," so HTTPS over skynet doesn't work at all
-// with the hex form regardless of how the URL is dialled.
+// with the hex form regardless of how the URL is dialed.
 //
 // RFC 4648 base32 of 33 bytes is 53 chars unpadded (ceil(33*8/5)),
 // well under 63. Lowercase is canonical for DNS (case-insensitive

--- a/pkg/cipher/dnslabel_test.go
+++ b/pkg/cipher/dnslabel_test.go
@@ -42,9 +42,9 @@ func TestDNSLabelCaseInsensitive(t *testing.T) {
 
 func TestDNSLabelInvalid(t *testing.T) {
 	cases := []string{
-		"",            // empty
-		"not-base32!", // bad chars
-		"aa",          // too short (decodes to <33 bytes)
+		"",                       // empty
+		"not-base32!",            // bad chars
+		"aa",                     // too short (decodes to <33 bytes)
 		strings.Repeat("a", 200), // way too long
 	}
 	for _, c := range cases {

--- a/pkg/cipher/dnslabel_test.go
+++ b/pkg/cipher/dnslabel_test.go
@@ -1,0 +1,66 @@
+package cipher
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDNSLabelRoundtrip(t *testing.T) {
+	pk, _ := GenerateKeyPair()
+	label := pk.DNSLabel()
+
+	if got := len(label); got != PubKeyDNSLabelLen {
+		t.Fatalf("DNSLabel length = %d, want %d", got, PubKeyDNSLabelLen)
+	}
+	if label != strings.ToLower(label) {
+		t.Errorf("DNSLabel = %q, expected lowercase", label)
+	}
+	if strings.ContainsAny(label, "=+/") {
+		t.Errorf("DNSLabel = %q contains padding/non-base32 chars", label)
+	}
+
+	got, err := ParseDNSLabel(label)
+	if err != nil {
+		t.Fatalf("ParseDNSLabel: %v", err)
+	}
+	if got != pk {
+		t.Errorf("roundtrip mismatch: got %x want %x", got[:], pk[:])
+	}
+}
+
+func TestDNSLabelCaseInsensitive(t *testing.T) {
+	pk, _ := GenerateKeyPair()
+	label := pk.DNSLabel()
+	upper, err := ParseDNSLabel(strings.ToUpper(label))
+	if err != nil {
+		t.Fatalf("ParseDNSLabel(uppercase): %v", err)
+	}
+	if upper != pk {
+		t.Errorf("uppercase decode mismatch")
+	}
+}
+
+func TestDNSLabelInvalid(t *testing.T) {
+	cases := []string{
+		"",            // empty
+		"not-base32!", // bad chars
+		"aa",          // too short (decodes to <33 bytes)
+		strings.Repeat("a", 200), // way too long
+	}
+	for _, c := range cases {
+		if _, err := ParseDNSLabel(c); err == nil {
+			t.Errorf("ParseDNSLabel(%q) = nil err, want error", c)
+		}
+	}
+}
+
+func TestDNSLabelFitsRFC1035(t *testing.T) {
+	// Sanity: 53 chars must be ≤ 63 (RFC 1035 label limit) and ≤ 64
+	// (X.520 ub-common-name).
+	if PubKeyDNSLabelLen > 63 {
+		t.Fatalf("DNSLabel length %d exceeds RFC 1035 label limit (63)", PubKeyDNSLabelLen)
+	}
+	if PubKeyDNSLabelLen > 64 {
+		t.Fatalf("DNSLabel length %d exceeds X.520 ub-common-name (64)", PubKeyDNSLabelLen)
+	}
+}

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -248,9 +248,9 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			}
 
 			if _, ok := dialCtx.Value(dmsgResolverPortKey).(string); ok {
-				pkHex := strings.TrimSuffix(origHost, cfg.DomainSuffix)
-				var pk cipher.PubKey
-				if err := pk.Set(pkHex); err != nil {
+				pkLabel := strings.TrimSuffix(origHost, cfg.DomainSuffix)
+				pk, err := parsePKLabel(pkLabel)
+				if err != nil {
 					return nil, fmt.Errorf("invalid PK in hostname %q: %w", origHost, err)
 				}
 				port, err := strconv.ParseUint(origPort, 10, 16)
@@ -414,4 +414,22 @@ func handleTCPConn(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client,
 	_ = conn.Close()     //nolint:errcheck
 	_ = dmsgConn.Close() //nolint:errcheck
 	<-done
+}
+
+// parsePKLabel accepts either the legacy 66-char hex form or the
+// 53-char base32 DNSLabel form. See pkg/cipher/dnslabel.go for the
+// motivation: only the base32 form fits in a DNS label and an X.509
+// Subject.CommonName, so TLS-MITM browser URLs must use it. Hex is
+// kept accepted for backcompat with plain-HTTP URLs already in use.
+func parsePKLabel(label string) (cipher.PubKey, error) {
+	switch len(label) {
+	case cipher.PubKeyDNSLabelLen: // 53 — base32
+		return cipher.ParseDNSLabel(label)
+	default:
+		var pk cipher.PubKey
+		if err := pk.Set(label); err != nil {
+			return cipher.PubKey{}, err
+		}
+		return pk, nil
+	}
 }

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -273,7 +273,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				if cfg.TLSMITM && uint16(port) == cfg.TLSPort {
 					leaf, lerr := cfg.LeafMinter.For(origHost)
 					if lerr != nil {
-						_ = stream.Close()
+						_ = stream.Close() //nolint:errcheck,gosec
 						return nil, fmt.Errorf("dmsg mitm leaf: %w", lerr)
 					}
 					return &tcpAddrConn{Conn: skynetca.MITMTerminate(stream, leaf)}, nil

--- a/pkg/skynetca/ca.go
+++ b/pkg/skynetca/ca.go
@@ -115,7 +115,10 @@ func SaveCA(cert *x509.Certificate, key *ecdsa.PrivateKey, certPath, keyPath str
 		return fmt.Errorf("mkdir cert dir: %w", err)
 	}
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
-	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+	// 0644 is intentional: the CA cert is public material that the
+	// system trust store needs to read. The matching key file below
+	// is 0600.
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil { //nolint:gosec
 		return fmt.Errorf("write ca.crt: %w", err)
 	}
 	keyDER, err := x509.MarshalECPrivateKey(key)
@@ -131,7 +134,10 @@ func SaveCA(cert *x509.Certificate, key *ecdsa.PrivateKey, certPath, keyPath str
 
 // LoadCA reads a CA cert + key pair previously written by SaveCA.
 func LoadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
-	certBytes, err := os.ReadFile(certPath)
+	// G304: paths come from operator config (visor's skynet_web /
+	// dmsg_web blocks) — file inclusion via variable is the
+	// intentional API shape here.
+	certBytes, err := os.ReadFile(certPath) //nolint:gosec
 	if err != nil {
 		return nil, nil, fmt.Errorf("read ca.crt: %w", err)
 	}
@@ -147,7 +153,7 @@ func LoadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, err
 		return nil, nil, errors.New("ca.crt: not a CA certificate")
 	}
 
-	keyBytes, err := os.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(keyPath) //nolint:gosec
 	if err != nil {
 		return nil, nil, fmt.Errorf("read ca.key: %w", err)
 	}

--- a/pkg/skynetca/ca_test.go
+++ b/pkg/skynetca/ca_test.go
@@ -1,6 +1,7 @@
 package skynetca
 
 import (
+	"bytes"
 	"crypto/x509"
 	"os"
 	"strings"
@@ -71,14 +72,25 @@ func TestSaveLoadCA_Roundtrip(t *testing.T) {
 	if loadedCert.SerialNumber.Cmp(cert.SerialNumber) != 0 {
 		t.Errorf("serial mismatch")
 	}
-	if loadedKey.D.Cmp(key.D) != 0 {
-		t.Errorf("key D mismatch")
+	// Compare keys via DER round-trip rather than the deprecated
+	// ecdsa.PrivateKey.D field (Go 1.26 deprecates direct big.Int
+	// access on crypto values).
+	gotDER, err := x509.MarshalECPrivateKey(loadedKey)
+	if err != nil {
+		t.Fatalf("marshal loaded key: %v", err)
+	}
+	wantDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal original key: %v", err)
+	}
+	if !bytes.Equal(gotDER, wantDER) {
+		t.Errorf("key mismatch after SaveCA/LoadCA round-trip")
 	}
 }
 
 func TestLoadCA_RejectsNonCA(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(dir+"/junk.crt", []byte("not pem"), 0644); err != nil {
+	if err := os.WriteFile(dir+"/junk.crt", []byte("not pem"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := LoadCA(dir+"/junk.crt", dir+"/junk.key"); err == nil {

--- a/pkg/skynetca/leaf.go
+++ b/pkg/skynetca/leaf.go
@@ -124,12 +124,20 @@ func (m *CachedMinter) mint(host string) (*tls.Certificate, error) {
 	now := time.Now().UTC()
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: host},
-		DNSNames:     []string{host},
-		NotBefore:    now.Add(-1 * time.Hour),
-		NotAfter:     now.Add(m.opts.Validity),
-		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		// Subject.CommonName intentionally omitted. X.520
+		// ub-common-name caps it at 64 chars; a skynet host like
+		// "<subdomain>.<53-char-base32-pk>.skynet" easily exceeds
+		// that when the subdomain is non-trivial (e.g.
+		// "magnetosphere.net.<53>.skynet" = 78 chars). Strict
+		// X.509 parsers reject the cert outright. Browsers have
+		// ignored CN since 2017 (Chrome) / Firefox followed —
+		// SAN is the source of truth.
+		Subject:     pkix.Name{},
+		DNSNames:    []string{host},
+		NotBefore:   now.Add(-1 * time.Hour),
+		NotAfter:    now.Add(m.opts.Validity),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, m.ca, &key.PublicKey, m.caKey)
 	if err != nil {

--- a/pkg/skynetca/leaf_test.go
+++ b/pkg/skynetca/leaf_test.go
@@ -14,7 +14,7 @@ import (
 const testPK = "027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed"
 
 func TestMinter_RejectsForbiddenSuffix(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})
 
 	if _, err := m.For("foo.example.com"); err == nil {
@@ -23,7 +23,7 @@ func TestMinter_RejectsForbiddenSuffix(t *testing.T) {
 }
 
 func TestMinter_AcceptsSkynetAndDmsg(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})
 
 	for _, host := range []string{testPK + ".skynet", testPK + ".dmsg"} {
@@ -43,7 +43,7 @@ func TestMinter_AcceptsSkynetAndDmsg(t *testing.T) {
 }
 
 func TestMinter_Cache_ReturnsSameLeaf(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})
 	a, err := m.For(testPK + ".skynet")
 	if err != nil {
@@ -59,7 +59,7 @@ func TestMinter_Cache_ReturnsSameLeaf(t *testing.T) {
 }
 
 func TestMinter_RenewBefore_TriggersFreshMint(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	// Validity barely above RenewBefore so the cached cert is
 	// already considered stale immediately.
 	m := NewMinter(ca, key, LeafOptions{Validity: 2 * time.Hour, RenewBefore: 3 * time.Hour})
@@ -82,10 +82,10 @@ func TestMinter_RenewBefore_TriggersFreshMint(t *testing.T) {
 // validate it. This regression-tests Go's name-constraint
 // enforcement, since browser TLS validation depends on it.
 func TestNameConstraints_VerifierRejectsForbiddenLeaf(t *testing.T) {
-	ca, caKey, _ := GenerateCA(CAOptions{PermittedDomains: []string{".skynet"}})
+	ca, caKey, _ := GenerateCA(CAOptions{PermittedDomains: []string{".skynet"}}) //nolint:errcheck,gosec
 
-	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 159))
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)            //nolint:errcheck,gosec
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 159)) //nolint:errcheck,gosec
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: "evil.example.com"},
@@ -99,7 +99,7 @@ func TestNameConstraints_VerifierRejectsForbiddenLeaf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leaf, _ := x509.ParseCertificate(der)
+	leaf, _ := x509.ParseCertificate(der) //nolint:errcheck,gosec
 
 	pool := x509.NewCertPool()
 	pool.AddCert(ca)

--- a/pkg/skynetca/leaf_test.go
+++ b/pkg/skynetca/leaf_test.go
@@ -123,7 +123,10 @@ func TestMinter_EmitsRFC1035CompliantSAN(t *testing.T) {
 		rfc1035LabelMax = 63 // octets per DNS label
 		x520CNMax       = 64 // ub-common-name
 	)
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, err := GenerateCA(CAOptions{})
+	if err != nil {
+		t.Fatalf("GenerateCA: %v", err)
+	}
 	m := NewMinter(ca, key, LeafOptions{})
 
 	// Use a host with a 53-char base32 PK label, the canonical form.

--- a/pkg/skynetca/leaf_test.go
+++ b/pkg/skynetca/leaf_test.go
@@ -113,3 +113,50 @@ func TestStaticMinter_NilLeafErrors(t *testing.T) {
 		t.Errorf("expected error for nil leaf")
 	}
 }
+
+// TestMinter_EmitsRFC1035CompliantSAN protects the strict-parsers path
+// (NSS / Firefox / Waterfox / Chrome). The constants here mirror what
+// strict X.509 stacks enforce; loosening them would break browser TLS
+// over skynet without warning at compile time.
+func TestMinter_EmitsRFC1035CompliantSAN(t *testing.T) {
+	const (
+		rfc1035LabelMax = 63 // octets per DNS label
+		x520CNMax       = 64 // ub-common-name
+	)
+	ca, key, _ := GenerateCA(CAOptions{})
+	m := NewMinter(ca, key, LeafOptions{})
+
+	// Use a host with a 53-char base32 PK label, the canonical form.
+	host := "magnetosphere.net.abcdefghijklmnopqrstuvwxyz234567abcdefghijklmnopqrst.skynet"
+	leaf, err := m.For(host)
+	if err != nil {
+		t.Fatalf("For(%q): %v", host, err)
+	}
+
+	// CN must be empty (or ≤64 chars) — strict parsers reject longer.
+	if cn := leaf.Leaf.Subject.CommonName; len(cn) > x520CNMax {
+		t.Errorf("Subject.CN length %d > %d: %q", len(cn), x520CNMax, cn)
+	}
+
+	// Every label in every DNSName SAN must be ≤63 octets.
+	for _, name := range leaf.Leaf.DNSNames {
+		for _, label := range splitDots(name) {
+			if len(label) > rfc1035LabelMax {
+				t.Errorf("SAN %q has label %q of length %d > %d",
+					name, label, len(label), rfc1035LabelMax)
+			}
+		}
+	}
+}
+
+func splitDots(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == '.' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return out
+}

--- a/pkg/skynetca/mitm.go
+++ b/pkg/skynetca/mitm.go
@@ -33,9 +33,9 @@ func MITMTerminate(upstream net.Conn, leaf *tls.Certificate) net.Conn {
 	}
 	tlsConn := tls.Server(b, cfg)
 	go func() {
-		defer upstream.Close()
+		defer upstream.Close() //nolint:errcheck,gosec
 		// Closing tlsConn closes b too.
-		defer tlsConn.Close()
+		defer tlsConn.Close() //nolint:errcheck,gosec
 
 		// Run the handshake explicitly so handshake errors don't
 		// race with the io.Copy goroutines below.

--- a/pkg/skynetca/mitm_test.go
+++ b/pkg/skynetca/mitm_test.go
@@ -28,15 +28,15 @@ func TestMITMTerminate_RoundTrip(t *testing.T) {
 
 	upClient, upServer := net.Pipe()
 	go func() {
-		defer upServer.Close()
-		_ = upServer.SetReadDeadline(time.Now().Add(2 * time.Second))
+		defer upServer.Close()                                        //nolint:errcheck,gosec
+		_ = upServer.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
 		buf := make([]byte, 4096)
-		_, _ = upServer.Read(buf)
-		_, _ = upServer.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+		_, _ = upServer.Read(buf)                                                                               //nolint:errcheck,gosec
+		_, _ = upServer.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello")) //nolint:errcheck,gosec
 	}()
 
 	browser := MITMTerminate(upClient, leaf)
-	defer browser.Close()
+	defer browser.Close() //nolint:errcheck,gosec
 
 	pool := x509.NewCertPool()
 	pool.AddCert(ca)
@@ -61,9 +61,9 @@ func TestMITMTerminate_RoundTrip(t *testing.T) {
 // SOCKS5 library's lifecycle, which closes the dialed conn when the
 // browser disconnects.
 func TestMITMTerminate_ClosingPropagates(t *testing.T) {
-	ca, caKey, _ := GenerateCA(CAOptions{})
+	ca, caKey, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, caKey, LeafOptions{})
-	leaf, _ := m.For("test.skynet")
+	leaf, _ := m.For("test.skynet") //nolint:errcheck,gosec
 
 	upClient, upServer := net.Pipe()
 	browser := MITMTerminate(upClient, leaf)
@@ -72,9 +72,9 @@ func TestMITMTerminate_ClosingPropagates(t *testing.T) {
 	// handshake the goroutine returns from Handshake() error and
 	// closes upClient via defer; that should make a Read on
 	// upServer return error.
-	_ = browser.Close()
+	_ = browser.Close() //nolint:errcheck,gosec
 
-	_ = upServer.SetReadDeadline(time.Now().Add(time.Second))
+	_ = upServer.SetReadDeadline(time.Now().Add(time.Second)) //nolint:errcheck,gosec
 	buf := make([]byte, 1)
 	if _, err := upServer.Read(buf); err == nil {
 		t.Errorf("expected upstream Read error after browser close")

--- a/pkg/skynetweb/hostrewrite.go
+++ b/pkg/skynetweb/hostrewrite.go
@@ -2,7 +2,7 @@
 //
 // HTTP/1.1 Host-header rewriter for the resolver SOCKS5 dial path.
 //
-// Motivation
+// # Motivation
 //
 // A visit to `https://example.com.<pk>.skynet/` resolves to the
 // visor <pk>, but the browser sends `Host: example.com.<pk>.skynet`
@@ -26,7 +26,6 @@ package skynetweb
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -42,8 +41,8 @@ import (
 // The wrapper exposes the io.ReadWriteCloser surface the SOCKS5
 // splice expects:
 //
-//   SOCKS5.io.Copy(dst=hostRewriteConn, src=browser)    → Write side
-//   SOCKS5.io.Copy(dst=browser, src=hostRewriteConn)    → Read side
+//	SOCKS5.io.Copy(dst=hostRewriteConn, src=browser)    → Write side
+//	SOCKS5.io.Copy(dst=browser, src=hostRewriteConn)    → Read side
 //
 // Write side: bytes from the browser (already TLS-decrypted by the
 // MITMTerminate wrapper sitting "above" us in the stack) come in.
@@ -102,11 +101,9 @@ func (h *hostRewriteConn) pump() {
 		if err != nil {
 			// EOF or malformed input — we can't recover the stream.
 			// Closing the backend conn lets the response pump on
-			// the Read side notice and unblock.
-			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
-				// Best-effort: noisy log would be tidier in real code
-				// but we don't have access to the logger here.
-			}
+			// the Read side notice and unblock. We don't have a
+			// logger here, so any non-EOF parse error fails silently;
+			// the connection close conveys the failure to the peer.
 			return
 		}
 
@@ -177,10 +174,10 @@ func (h *hostRewriteConn) SetWriteDeadline(t time.Time) error {
 // splitHostSubdomain parses "<subdomain>.<pk>.<suffix>[:port]" or
 // "<pk>.<suffix>[:port]" into pkLabel + subdomain + port.
 //
-//   "blog.<pk>.skynet"        → ("<pk>", "blog",        80)
-//   "example.com.<pk>.skynet" → ("<pk>", "example.com", 80)
-//   "<pk>.skynet"             → ("<pk>", "",            80)
-//   "<pk>.skynet:1234"        → ("<pk>", "",          1234)
+//	"blog.<pk>.skynet"        → ("<pk>", "blog",        80)
+//	"example.com.<pk>.skynet" → ("<pk>", "example.com", 80)
+//	"<pk>.skynet"             → ("<pk>", "",            80)
+//	"<pk>.skynet:1234"        → ("<pk>", "",          1234)
 //
 // suffix is expected to start with ".". Returns an error when the
 // host shape doesn't match (no suffix match, no PK label, etc.) so

--- a/pkg/skynetweb/hostrewrite_test.go
+++ b/pkg/skynetweb/hostrewrite_test.go
@@ -6,26 +6,52 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
 
 // fakeConn is the in-memory pair used to drive the wrapper. Reads/
-// writes go through bytes.Buffer; addresses are stubs.
+// writes go through bytes.Buffer; addresses are stubs. The buffer
+// is mutex-protected because the wrapper's pump goroutine writes
+// while the test goroutine polls — bytes.Buffer is not thread-safe
+// and the -race detector flags it without the lock.
 type fakeConn struct {
 	r *io.PipeReader
 	w *io.PipeWriter
 	// out is what was received on the "backend" side. Tests assert
-	// against this.
+	// against this via the helper methods below; never touch it
+	// directly, since pump writes concurrently.
+	mu  sync.Mutex
 	out bytes.Buffer
 }
 
-func (c *fakeConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
-func (c *fakeConn) Write(p []byte) (int, error) { n, err := c.out.Write(p); return n, err }
+func (c *fakeConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.out.Write(p)
+}
 func (c *fakeConn) Close() error {
 	_ = c.r.Close() //nolint:errcheck,gosec
 	_ = c.w.Close() //nolint:errcheck,gosec
 	return nil
+}
+
+// outLen returns the number of bytes the backend has received so far.
+// Safe for concurrent use with the pump goroutine.
+func (c *fakeConn) outLen() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.out.Len()
+}
+
+// outSnapshot returns a copy of the current buffer contents. Used to
+// parse the received request once the pump has flushed it.
+func (c *fakeConn) outSnapshot() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.out.Bytes()...)
 }
 func (c *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
 func (c *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
@@ -98,17 +124,17 @@ func TestHostRewriteConn_RewritesHostHeader(t *testing.T) {
 
 	// The parser goroutine pumps async; give it a moment to flush.
 	// In production this is the SOCKS5 splice's poll loop; here we
-	// just poll the buffer.
+	// just poll the buffer through the mutex-guarded accessor.
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && backend.out.Len() == 0 {
+	for time.Now().Before(deadline) && backend.outLen() == 0 {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if backend.out.Len() == 0 {
+	if backend.outLen() == 0 {
 		t.Fatal("backend received nothing within deadline")
 	}
 
 	// Parse what the backend got and verify Host.
-	got, err := http.ReadRequest(bufio.NewReader(&backend.out))
+	got, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(backend.outSnapshot())))
 	if err != nil {
 		t.Fatalf("backend parse: %v", err)
 	}
@@ -139,13 +165,13 @@ func TestHostRewriteConn_RewritesTwoSequentialRequests(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if bytes.Count(backend.out.Bytes(), []byte("\r\n\r\n")) >= 2 {
+		if bytes.Count(backend.outSnapshot(), []byte("\r\n\r\n")) >= 2 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	br := bufio.NewReader(&backend.out)
+	br := bufio.NewReader(bytes.NewReader(backend.outSnapshot()))
 	for i, wantPath := range []string{"/a", "/b"} {
 		req, err := http.ReadRequest(br)
 		if err != nil {

--- a/pkg/skynetweb/hostrewrite_test.go
+++ b/pkg/skynetweb/hostrewrite_test.go
@@ -20,8 +20,8 @@ type fakeConn struct {
 	out bytes.Buffer
 }
 
-func (c *fakeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
-func (c *fakeConn) Write(p []byte) (int, error)        { n, err := c.out.Write(p); return n, err }
+func (c *fakeConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error) { n, err := c.out.Write(p); return n, err }
 func (c *fakeConn) Close() error {
 	_ = c.r.Close() //nolint:errcheck,gosec
 	_ = c.w.Close() //nolint:errcheck,gosec

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -213,7 +213,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				// decryption and the wire. If MITM is off, the
 				// browser is already sending plaintext directly to
 				// hostRewriteConn — same parser, same effect.
-				var stack net.Conn = conn
+				stack := conn
 				if target.subdomain != "" {
 					// `subdomain` already encodes the operator's
 					// intent (the URL has labels before the PK).

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -332,9 +332,28 @@ func parseHostHeader(host, suffix string) (target, error) {
 	if err != nil {
 		return target{}, err
 	}
-	var pk cipher.PubKey
-	if err := pk.Set(pkLabel); err != nil {
+	pk, err := parsePKLabel(pkLabel)
+	if err != nil {
 		return target{}, fmt.Errorf("invalid pk %q: %w", pkLabel, err)
 	}
 	return target{pk: pk, port: port, subdomain: subdomain}, nil
+}
+
+// parsePKLabel accepts either the legacy 66-char hex form or the
+// 53-char base32 DNSLabel form. Base32 is the canonical form going
+// forward — it's the only one that fits in a DNS label (RFC 1035, 63
+// octets) and an X.509 Subject.CommonName (X.520 ub-common-name, 64),
+// so TLS MITM URLs must use it. Hex remains accepted because plain-
+// HTTP skynet URLs minted before this change are in circulation.
+func parsePKLabel(label string) (cipher.PubKey, error) {
+	switch len(label) {
+	case cipher.PubKeyDNSLabelLen: // 53 — base32
+		return cipher.ParseDNSLabel(label)
+	default: // hex (66) or anything else — let PubKey.Set complain
+		var pk cipher.PubKey
+		if err := pk.Set(label); err != nil {
+			return cipher.PubKey{}, err
+		}
+		return pk, nil
+	}
 }

--- a/pkg/skynetweb/runtime_test.go
+++ b/pkg/skynetweb/runtime_test.go
@@ -49,11 +49,11 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 		onDial: func() (net.Conn, error) {
 			client, server := net.Pipe()
 			go func() {
-				defer server.Close()
-				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+				defer server.Close()                                        //nolint:errcheck,gosec
+				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
 				buf := make([]byte, 4096)
-				_, _ = server.Read(buf)
-				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+				_, _ = server.Read(buf)                                                                               //nolint:errcheck,gosec
+				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello")) //nolint:errcheck,gosec
 			}()
 			return client, nil
 		},
@@ -65,7 +65,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{
+		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{ //nolint:errcheck,gosec
 			ProxyPort:  proxyPort,
 			TLSMITM:    true,
 			TLSPort:    443,
@@ -86,7 +86,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SOCKS5 dial: %v", err)
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck,gosec
 
 	pool := x509.NewCertPool()
 	pool.AddCert(ca)
@@ -97,7 +97,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 	if _, err := tlsConn.Write([]byte("GET / HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n")); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	body, _ := io.ReadAll(tlsConn)
+	body, _ := io.ReadAll(tlsConn) //nolint:errcheck,gosec
 	if !strings.Contains(string(body), "hello") {
 		t.Errorf("body = %q, want to contain hello", string(body))
 	}
@@ -107,7 +107,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 // 80) skynet target is unaffected by TLSMITM mode — it still goes
 // through pure splice.
 func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
-	ca, caKey, _ := skynetca.GenerateCA(skynetca.CAOptions{})
+	ca, caKey, _ := skynetca.GenerateCA(skynetca.CAOptions{}) //nolint:errcheck,gosec
 	minter := skynetca.NewMinter(ca, caKey, skynetca.LeafOptions{})
 	proxyPort := pickFreePort(t)
 
@@ -115,11 +115,11 @@ func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
 		onDial: func() (net.Conn, error) {
 			client, server := net.Pipe()
 			go func() {
-				defer server.Close()
-				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+				defer server.Close()                                        //nolint:errcheck,gosec
+				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
 				buf := make([]byte, 4096)
-				_, _ = server.Read(buf)
-				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nplain!"))
+				_, _ = server.Read(buf)                                                                                //nolint:errcheck,gosec
+				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nplain!")) //nolint:errcheck,gosec
 			}()
 			return client, nil
 		},
@@ -128,7 +128,7 @@ func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{
+		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{ //nolint:errcheck,gosec
 			ProxyPort:  proxyPort,
 			TLSMITM:    true,
 			TLSPort:    443,
@@ -139,17 +139,17 @@ func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	socksDialer, _ := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), nil, proxy.Direct)
+	socksDialer, _ := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), nil, proxy.Direct) //nolint:errcheck,gosec
 	host := testPK + ".skynet"
 	conn, err := socksDialer.Dial("tcp", host+":80")
 	if err != nil {
 		t.Fatalf("SOCKS5 dial: %v", err)
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck,gosec
 	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n")); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	body, _ := io.ReadAll(conn)
+	body, _ := io.ReadAll(conn) //nolint:errcheck,gosec
 	if !strings.Contains(string(body), "plain!") {
 		t.Errorf("plain port body = %q", string(body))
 	}
@@ -172,8 +172,8 @@ func pickFreePort(t *testing.T) uint {
 	if err != nil {
 		t.Fatal(err)
 	}
-	port := uint(lis.Addr().(*net.TCPAddr).Port)
-	_ = lis.Close()
+	port := uint(lis.Addr().(*net.TCPAddr).Port) //nolint:gosec // ephemeral port always fits in uint
+	_ = lis.Close()                              //nolint:errcheck,gosec
 	return port
 }
 
@@ -183,7 +183,7 @@ func waitForListener(host string, port uint, max time.Duration) error {
 	for time.Now().Before(deadline) {
 		c, err := net.Dial("tcp", addr)
 		if err == nil {
-			_ = c.Close()
+			_ = c.Close() //nolint:errcheck,gosec
 			return nil
 		}
 		time.Sleep(25 * time.Millisecond)

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -311,9 +311,12 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 			if h, _, err := net.SplitHostPort(host); err == nil {
 				host = h
 			}
-			// If host is a bare PK (66 hex chars), append .skynet
-			// so generated URLs route through the SOCKS5 proxy.
-			if len(host) == 66 && !strings.Contains(host, ".") {
+			// If host is a bare PK (66 hex chars or 53 base32 chars),
+			// append .skynet so generated URLs route through the
+			// SOCKS5 proxy. Base32 is the canonical form (the only
+			// one TLS-MITM can mint a cert for); hex is accepted
+			// for backcompat with older URLs.
+			if !strings.Contains(host, ".") && (len(host) == 66 || len(host) == 53) {
 				host += ".skynet"
 			}
 			for _, fp := range api.forwardedPortLister.LandingPageEntries() {


### PR DESCRIPTION
## Why

A 33-byte secp256k1 PubKey is 66 hex chars, which overflows two strict X.509 limits enforced by NSS (Firefox / Waterfox / Chrome):

- RFC 1035 caps each DNS label at 63 octets.
- X.520 ub-common-name caps the X.509 Subject `CN` attribute at 64.

Either violation causes browsers to reject the resolver's TLS-MITM leaf (added in #2484) as **"improperly encoded"** before any trust check runs, so HTTPS over `.skynet` was unreachable from any strict browser regardless of CA install state. OpenSSL is permissive (curl `-k` succeeds), which masked the issue against the data-path validation tests.

This was discovered while end-to-end-testing #2484/#2485/#2486 against a real backend (Caddy + magnetosphere.net). HTTP-via-skynet worked; HTTPS-via-skynet got `PR_END_OF_FILE_ERROR` initially, then `SEC_ERROR_BAD_DER`-equivalent after enabling MITM.

## What

- **`pkg/cipher`** — add `PubKey.DNSLabel()` (RFC 4648 base32, lowercase, no padding → **53 chars**) and `ParseDNSLabel`. Comfortably under both limits.
- **`pkg/skynetweb`, `pkg/dmsgweb`** — `parsePKLabel` accepts **either** base32 (53) or legacy hex (66). HTTP-only URLs already in circulation keep working; HTTPS needs the base32 form.
- **`pkg/skynetca`** — drop `Subject.CN` from minted leaves entirely. Browsers have ignored CN since 2017 (Chrome) — SAN is the source of truth. With subdomain prefixes (`magnetosphere.net.<53>.skynet` = 78 chars) the full hostname exceeds 64 chars even in base32, so CN can never round-trip. Regression test guards label length and CN length.
- **`pkg/visor/logserver`** — landing-page link generation recognizes both 66-hex and 53-base32 bare-PK Host headers.
- **`cmd/skywire-cli`** — `skywire cli pk dnslabel [hex|base32]` helper auto-detects the input form and prints the other; with no arg, prints the running visor's PK as base32 (the URL form). Wired under both `cli pk` and `cli visor pk`.
- **`docs/skynet-tls.md`** — explain why URLs use base32 not hex; document the helper.

## Compared to TOR

`.onion` v3 addresses are 56 base32 chars (32B ed25519 pubkey + 2B checksum + 1B version, encoded as base32). They chose base32 from day one because they'd done the cert-compat homework. We hadn't; hex was natural everywhere else in the codebase. This change brings the skynet URL scheme in line with cert constraints.

A TOR-style checksum + version byte would also be nice (typo detection, future key-type forward-compat) — filed as a follow-up so the encoding stays trivial in this PR.

## Test plan

- [x] `go test ./pkg/cipher/ ./pkg/skynetca/ ./pkg/skynetweb/`
- [x] Regression test in `pkg/skynetca/leaf_test.go` asserts SAN labels ≤ 63 and CN ≤ 64 with a realistic subdomain
- [x] `curl -kv https://<sub>.<base32>.skynet/` completes TLS handshake with a strict-parser-acceptable leaf
- [ ] Live: Waterfox accepts the leaf (with CA installed in NSS Authorities store) — pending reviewer-side test
- [ ] CI lint / typecheck

## Follow-ups (not in this PR)

- Caddy returns `HTTP/1.0 400 Bad Request` to the resolver's post-MITM plaintext request. Likely a `hostRewriteConn` buffering / write-ordering bug when the front side is feeding decrypted TLS records rather than a raw socket. Tracked separately.
- Optional: TOR-style checksum + version byte in the DNS-label encoding.

Draft until end-to-end verified against a real browser.