### PR TITLE
fix(skywire-cli): serve add --to <host>:<port> preserves explicit host verbatim

### DIFF
--- a/cmd/skywire-cli/commands/resolver/ca.go
+++ b/cmd/skywire-cli/commands/resolver/ca.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	caForce       bool
+	caForce        bool
 	caInstallPrint bool
 )
 
@@ -216,7 +216,7 @@ func defaultCAPaths() (certPath, keyPath string, err error) {
 // detectLinuxTrustStore inspects /etc/os-release to locate the
 // distro's anchors directory and the system trust-update command.
 func detectLinuxTrustStore() (anchorsDir string, updateCmd []string, err error) {
-	osRelease, _ := os.ReadFile("/etc/os-release")
+	osRelease, _ := os.ReadFile("/etc/os-release") //nolint:errcheck,gosec
 	id := osReleaseField(string(osRelease), "ID")
 	idLike := osReleaseField(string(osRelease), "ID_LIKE")
 	combined := id + " " + idLike
@@ -255,4 +255,3 @@ func runVisible(argv []string) error {
 	}
 	return nil
 }
-

--- a/cmd/skywire-cli/commands/serve/serve.go
+++ b/cmd/skywire-cli/commands/serve/serve.go
@@ -155,7 +155,17 @@ Examples:
 					host = "127.0.0.1"
 				}
 				fp.ProxyAddr = fmt.Sprintf("%s:%d", host, p)
-			case host == "" || host == "localhost" || host == "127.0.0.1":
+			case host == "":
+				// Only fall back to the LocalPort short form when no
+				// host was given. Any explicit host — including
+				// "localhost" and "127.0.0.1" — is preserved verbatim
+				// in ProxyAddr so the visor's net.Dial uses exactly
+				// what the user typed and doesn't go through DNS
+				// resolution at dial time (where the saved LocalPort
+				// short form would reconstruct "localhost:port" and
+				// Go's Happy Eyeballs picks v4 vs v6 based on system
+				// config, sometimes landing on a different listener
+				// than the user intended).
 				fp.LocalPort = p
 			default:
 				fp.ProxyAddr = fmt.Sprintf("%s:%d", host, p)

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -273,7 +273,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				if cfg.TLSMITM && uint16(port) == cfg.TLSPort {
 					leaf, lerr := cfg.LeafMinter.For(origHost)
 					if lerr != nil {
-						_ = stream.Close()
+						_ = stream.Close() //nolint:errcheck,gosec
 						return nil, fmt.Errorf("dmsg mitm leaf: %w", lerr)
 					}
 					return &tcpAddrConn{Conn: skynetca.MITMTerminate(stream, leaf)}, nil

--- a/pkg/skynetca/ca.go
+++ b/pkg/skynetca/ca.go
@@ -115,7 +115,10 @@ func SaveCA(cert *x509.Certificate, key *ecdsa.PrivateKey, certPath, keyPath str
 		return fmt.Errorf("mkdir cert dir: %w", err)
 	}
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
-	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+	// 0644 is intentional: the CA cert is public material that the
+	// system trust store needs to read. The matching key file below
+	// is 0600.
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil { //nolint:gosec
 		return fmt.Errorf("write ca.crt: %w", err)
 	}
 	keyDER, err := x509.MarshalECPrivateKey(key)
@@ -131,7 +134,10 @@ func SaveCA(cert *x509.Certificate, key *ecdsa.PrivateKey, certPath, keyPath str
 
 // LoadCA reads a CA cert + key pair previously written by SaveCA.
 func LoadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
-	certBytes, err := os.ReadFile(certPath)
+	// G304: paths come from operator config (visor's skynet_web /
+	// dmsg_web blocks) — file inclusion via variable is the
+	// intentional API shape here.
+	certBytes, err := os.ReadFile(certPath) //nolint:gosec
 	if err != nil {
 		return nil, nil, fmt.Errorf("read ca.crt: %w", err)
 	}
@@ -147,7 +153,7 @@ func LoadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, err
 		return nil, nil, errors.New("ca.crt: not a CA certificate")
 	}
 
-	keyBytes, err := os.ReadFile(keyPath)
+	keyBytes, err := os.ReadFile(keyPath) //nolint:gosec
 	if err != nil {
 		return nil, nil, fmt.Errorf("read ca.key: %w", err)
 	}

--- a/pkg/skynetca/ca_test.go
+++ b/pkg/skynetca/ca_test.go
@@ -1,6 +1,7 @@
 package skynetca
 
 import (
+	"bytes"
 	"crypto/x509"
 	"os"
 	"strings"
@@ -71,14 +72,25 @@ func TestSaveLoadCA_Roundtrip(t *testing.T) {
 	if loadedCert.SerialNumber.Cmp(cert.SerialNumber) != 0 {
 		t.Errorf("serial mismatch")
 	}
-	if loadedKey.D.Cmp(key.D) != 0 {
-		t.Errorf("key D mismatch")
+	// Compare keys via DER round-trip rather than the deprecated
+	// ecdsa.PrivateKey.D field (Go 1.26 deprecates direct big.Int
+	// access on crypto values).
+	gotDER, err := x509.MarshalECPrivateKey(loadedKey)
+	if err != nil {
+		t.Fatalf("marshal loaded key: %v", err)
+	}
+	wantDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal original key: %v", err)
+	}
+	if !bytes.Equal(gotDER, wantDER) {
+		t.Errorf("key mismatch after SaveCA/LoadCA round-trip")
 	}
 }
 
 func TestLoadCA_RejectsNonCA(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(dir+"/junk.crt", []byte("not pem"), 0644); err != nil {
+	if err := os.WriteFile(dir+"/junk.crt", []byte("not pem"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := LoadCA(dir+"/junk.crt", dir+"/junk.key"); err == nil {

--- a/pkg/skynetca/leaf_test.go
+++ b/pkg/skynetca/leaf_test.go
@@ -14,7 +14,7 @@ import (
 const testPK = "027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed"
 
 func TestMinter_RejectsForbiddenSuffix(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})
 
 	if _, err := m.For("foo.example.com"); err == nil {
@@ -23,7 +23,7 @@ func TestMinter_RejectsForbiddenSuffix(t *testing.T) {
 }
 
 func TestMinter_AcceptsSkynetAndDmsg(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})
 
 	for _, host := range []string{testPK + ".skynet", testPK + ".dmsg"} {
@@ -43,7 +43,7 @@ func TestMinter_AcceptsSkynetAndDmsg(t *testing.T) {
 }
 
 func TestMinter_Cache_ReturnsSameLeaf(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, key, LeafOptions{})
 	a, err := m.For(testPK + ".skynet")
 	if err != nil {
@@ -59,7 +59,7 @@ func TestMinter_Cache_ReturnsSameLeaf(t *testing.T) {
 }
 
 func TestMinter_RenewBefore_TriggersFreshMint(t *testing.T) {
-	ca, key, _ := GenerateCA(CAOptions{})
+	ca, key, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	// Validity barely above RenewBefore so the cached cert is
 	// already considered stale immediately.
 	m := NewMinter(ca, key, LeafOptions{Validity: 2 * time.Hour, RenewBefore: 3 * time.Hour})
@@ -82,10 +82,10 @@ func TestMinter_RenewBefore_TriggersFreshMint(t *testing.T) {
 // validate it. This regression-tests Go's name-constraint
 // enforcement, since browser TLS validation depends on it.
 func TestNameConstraints_VerifierRejectsForbiddenLeaf(t *testing.T) {
-	ca, caKey, _ := GenerateCA(CAOptions{PermittedDomains: []string{".skynet"}})
+	ca, caKey, _ := GenerateCA(CAOptions{PermittedDomains: []string{".skynet"}}) //nolint:errcheck,gosec
 
-	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 159))
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)            //nolint:errcheck,gosec
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 159)) //nolint:errcheck,gosec
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: "evil.example.com"},
@@ -99,7 +99,7 @@ func TestNameConstraints_VerifierRejectsForbiddenLeaf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leaf, _ := x509.ParseCertificate(der)
+	leaf, _ := x509.ParseCertificate(der) //nolint:errcheck,gosec
 
 	pool := x509.NewCertPool()
 	pool.AddCert(ca)

--- a/pkg/skynetca/mitm.go
+++ b/pkg/skynetca/mitm.go
@@ -33,9 +33,9 @@ func MITMTerminate(upstream net.Conn, leaf *tls.Certificate) net.Conn {
 	}
 	tlsConn := tls.Server(b, cfg)
 	go func() {
-		defer upstream.Close()
+		defer upstream.Close() //nolint:errcheck,gosec
 		// Closing tlsConn closes b too.
-		defer tlsConn.Close()
+		defer tlsConn.Close() //nolint:errcheck,gosec
 
 		// Run the handshake explicitly so handshake errors don't
 		// race with the io.Copy goroutines below.

--- a/pkg/skynetca/mitm_test.go
+++ b/pkg/skynetca/mitm_test.go
@@ -28,15 +28,15 @@ func TestMITMTerminate_RoundTrip(t *testing.T) {
 
 	upClient, upServer := net.Pipe()
 	go func() {
-		defer upServer.Close()
-		_ = upServer.SetReadDeadline(time.Now().Add(2 * time.Second))
+		defer upServer.Close()                                        //nolint:errcheck,gosec
+		_ = upServer.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
 		buf := make([]byte, 4096)
-		_, _ = upServer.Read(buf)
-		_, _ = upServer.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+		_, _ = upServer.Read(buf)                                                                               //nolint:errcheck,gosec
+		_, _ = upServer.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello")) //nolint:errcheck,gosec
 	}()
 
 	browser := MITMTerminate(upClient, leaf)
-	defer browser.Close()
+	defer browser.Close() //nolint:errcheck,gosec
 
 	pool := x509.NewCertPool()
 	pool.AddCert(ca)
@@ -61,9 +61,9 @@ func TestMITMTerminate_RoundTrip(t *testing.T) {
 // SOCKS5 library's lifecycle, which closes the dialed conn when the
 // browser disconnects.
 func TestMITMTerminate_ClosingPropagates(t *testing.T) {
-	ca, caKey, _ := GenerateCA(CAOptions{})
+	ca, caKey, _ := GenerateCA(CAOptions{}) //nolint:errcheck,gosec
 	m := NewMinter(ca, caKey, LeafOptions{})
-	leaf, _ := m.For("test.skynet")
+	leaf, _ := m.For("test.skynet") //nolint:errcheck,gosec
 
 	upClient, upServer := net.Pipe()
 	browser := MITMTerminate(upClient, leaf)
@@ -72,9 +72,9 @@ func TestMITMTerminate_ClosingPropagates(t *testing.T) {
 	// handshake the goroutine returns from Handshake() error and
 	// closes upClient via defer; that should make a Read on
 	// upServer return error.
-	_ = browser.Close()
+	_ = browser.Close() //nolint:errcheck,gosec
 
-	_ = upServer.SetReadDeadline(time.Now().Add(time.Second))
+	_ = upServer.SetReadDeadline(time.Now().Add(time.Second)) //nolint:errcheck,gosec
 	buf := make([]byte, 1)
 	if _, err := upServer.Read(buf); err == nil {
 		t.Errorf("expected upstream Read error after browser close")

--- a/pkg/skynetweb/hostrewrite.go
+++ b/pkg/skynetweb/hostrewrite.go
@@ -2,7 +2,7 @@
 //
 // HTTP/1.1 Host-header rewriter for the resolver SOCKS5 dial path.
 //
-// Motivation
+// # Motivation
 //
 // A visit to `https://example.com.<pk>.skynet/` resolves to the
 // visor <pk>, but the browser sends `Host: example.com.<pk>.skynet`
@@ -26,7 +26,6 @@ package skynetweb
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -42,8 +41,8 @@ import (
 // The wrapper exposes the io.ReadWriteCloser surface the SOCKS5
 // splice expects:
 //
-//   SOCKS5.io.Copy(dst=hostRewriteConn, src=browser)    → Write side
-//   SOCKS5.io.Copy(dst=browser, src=hostRewriteConn)    → Read side
+//	SOCKS5.io.Copy(dst=hostRewriteConn, src=browser)    → Write side
+//	SOCKS5.io.Copy(dst=browser, src=hostRewriteConn)    → Read side
 //
 // Write side: bytes from the browser (already TLS-decrypted by the
 // MITMTerminate wrapper sitting "above" us in the stack) come in.
@@ -102,11 +101,9 @@ func (h *hostRewriteConn) pump() {
 		if err != nil {
 			// EOF or malformed input — we can't recover the stream.
 			// Closing the backend conn lets the response pump on
-			// the Read side notice and unblock.
-			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrClosedPipe) {
-				// Best-effort: noisy log would be tidier in real code
-				// but we don't have access to the logger here.
-			}
+			// the Read side notice and unblock. We don't have a
+			// logger here, so any non-EOF parse error fails silently;
+			// the connection close conveys the failure to the peer.
 			return
 		}
 
@@ -177,10 +174,10 @@ func (h *hostRewriteConn) SetWriteDeadline(t time.Time) error {
 // splitHostSubdomain parses "<subdomain>.<pk>.<suffix>[:port]" or
 // "<pk>.<suffix>[:port]" into pkLabel + subdomain + port.
 //
-//   "blog.<pk>.skynet"        → ("<pk>", "blog",        80)
-//   "example.com.<pk>.skynet" → ("<pk>", "example.com", 80)
-//   "<pk>.skynet"             → ("<pk>", "",            80)
-//   "<pk>.skynet:1234"        → ("<pk>", "",          1234)
+//	"blog.<pk>.skynet"        → ("<pk>", "blog",        80)
+//	"example.com.<pk>.skynet" → ("<pk>", "example.com", 80)
+//	"<pk>.skynet"             → ("<pk>", "",            80)
+//	"<pk>.skynet:1234"        → ("<pk>", "",          1234)
 //
 // suffix is expected to start with ".". Returns an error when the
 // host shape doesn't match (no suffix match, no PK label, etc.) so

--- a/pkg/skynetweb/hostrewrite_test.go
+++ b/pkg/skynetweb/hostrewrite_test.go
@@ -6,26 +6,52 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 )
 
 // fakeConn is the in-memory pair used to drive the wrapper. Reads/
-// writes go through bytes.Buffer; addresses are stubs.
+// writes go through bytes.Buffer; addresses are stubs. The buffer
+// is mutex-protected because the wrapper's pump goroutine writes
+// while the test goroutine polls — bytes.Buffer is not thread-safe
+// and the -race detector flags it without the lock.
 type fakeConn struct {
 	r *io.PipeReader
 	w *io.PipeWriter
 	// out is what was received on the "backend" side. Tests assert
-	// against this.
+	// against this via the helper methods below; never touch it
+	// directly, since pump writes concurrently.
+	mu  sync.Mutex
 	out bytes.Buffer
 }
 
-func (c *fakeConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
-func (c *fakeConn) Write(p []byte) (int, error) { n, err := c.out.Write(p); return n, err }
+func (c *fakeConn) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.out.Write(p)
+}
 func (c *fakeConn) Close() error {
 	_ = c.r.Close() //nolint:errcheck,gosec
 	_ = c.w.Close() //nolint:errcheck,gosec
 	return nil
+}
+
+// outLen returns the number of bytes the backend has received so far.
+// Safe for concurrent use with the pump goroutine.
+func (c *fakeConn) outLen() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.out.Len()
+}
+
+// outSnapshot returns a copy of the current buffer contents. Used to
+// parse the received request once the pump has flushed it.
+func (c *fakeConn) outSnapshot() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.out.Bytes()...)
 }
 func (c *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
 func (c *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
@@ -98,17 +124,17 @@ func TestHostRewriteConn_RewritesHostHeader(t *testing.T) {
 
 	// The parser goroutine pumps async; give it a moment to flush.
 	// In production this is the SOCKS5 splice's poll loop; here we
-	// just poll the buffer.
+	// just poll the buffer through the mutex-guarded accessor.
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && backend.out.Len() == 0 {
+	for time.Now().Before(deadline) && backend.outLen() == 0 {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if backend.out.Len() == 0 {
+	if backend.outLen() == 0 {
 		t.Fatal("backend received nothing within deadline")
 	}
 
 	// Parse what the backend got and verify Host.
-	got, err := http.ReadRequest(bufio.NewReader(&backend.out))
+	got, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(backend.outSnapshot())))
 	if err != nil {
 		t.Fatalf("backend parse: %v", err)
 	}
@@ -139,13 +165,13 @@ func TestHostRewriteConn_RewritesTwoSequentialRequests(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if bytes.Count(backend.out.Bytes(), []byte("\r\n\r\n")) >= 2 {
+		if bytes.Count(backend.outSnapshot(), []byte("\r\n\r\n")) >= 2 {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	br := bufio.NewReader(&backend.out)
+	br := bufio.NewReader(bytes.NewReader(backend.outSnapshot()))
 	for i, wantPath := range []string{"/a", "/b"} {
 		req, err := http.ReadRequest(br)
 		if err != nil {

--- a/pkg/skynetweb/hostrewrite_test.go
+++ b/pkg/skynetweb/hostrewrite_test.go
@@ -20,8 +20,8 @@ type fakeConn struct {
 	out bytes.Buffer
 }
 
-func (c *fakeConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
-func (c *fakeConn) Write(p []byte) (int, error)        { n, err := c.out.Write(p); return n, err }
+func (c *fakeConn) Read(p []byte) (int, error)  { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error) { n, err := c.out.Write(p); return n, err }
 func (c *fakeConn) Close() error {
 	_ = c.r.Close() //nolint:errcheck,gosec
 	_ = c.w.Close() //nolint:errcheck,gosec

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -213,7 +213,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				// decryption and the wire. If MITM is off, the
 				// browser is already sending plaintext directly to
 				// hostRewriteConn — same parser, same effect.
-				var stack net.Conn = conn
+				stack := conn
 				if target.subdomain != "" {
 					// `subdomain` already encodes the operator's
 					// intent (the URL has labels before the PK).

--- a/pkg/skynetweb/runtime_test.go
+++ b/pkg/skynetweb/runtime_test.go
@@ -49,11 +49,11 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 		onDial: func() (net.Conn, error) {
 			client, server := net.Pipe()
 			go func() {
-				defer server.Close()
-				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+				defer server.Close()                                        //nolint:errcheck,gosec
+				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
 				buf := make([]byte, 4096)
-				_, _ = server.Read(buf)
-				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"))
+				_, _ = server.Read(buf)                                                                               //nolint:errcheck,gosec
+				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello")) //nolint:errcheck,gosec
 			}()
 			return client, nil
 		},
@@ -65,7 +65,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{
+		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{ //nolint:errcheck,gosec
 			ProxyPort:  proxyPort,
 			TLSMITM:    true,
 			TLSPort:    443,
@@ -86,7 +86,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SOCKS5 dial: %v", err)
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck,gosec
 
 	pool := x509.NewCertPool()
 	pool.AddCert(ca)
@@ -97,7 +97,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 	if _, err := tlsConn.Write([]byte("GET / HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n")); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	body, _ := io.ReadAll(tlsConn)
+	body, _ := io.ReadAll(tlsConn) //nolint:errcheck,gosec
 	if !strings.Contains(string(body), "hello") {
 		t.Errorf("body = %q, want to contain hello", string(body))
 	}
@@ -107,7 +107,7 @@ func TestSOCKS5_MITMHandshakeAndSplice(t *testing.T) {
 // 80) skynet target is unaffected by TLSMITM mode — it still goes
 // through pure splice.
 func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
-	ca, caKey, _ := skynetca.GenerateCA(skynetca.CAOptions{})
+	ca, caKey, _ := skynetca.GenerateCA(skynetca.CAOptions{}) //nolint:errcheck,gosec
 	minter := skynetca.NewMinter(ca, caKey, skynetca.LeafOptions{})
 	proxyPort := pickFreePort(t)
 
@@ -115,11 +115,11 @@ func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
 		onDial: func() (net.Conn, error) {
 			client, server := net.Pipe()
 			go func() {
-				defer server.Close()
-				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+				defer server.Close()                                        //nolint:errcheck,gosec
+				_ = server.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
 				buf := make([]byte, 4096)
-				_, _ = server.Read(buf)
-				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nplain!"))
+				_, _ = server.Read(buf)                                                                                //nolint:errcheck,gosec
+				_, _ = server.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nplain!")) //nolint:errcheck,gosec
 			}()
 			return client, nil
 		},
@@ -128,7 +128,7 @@ func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{
+		_ = Run(ctx, logging.MustGetLogger("skynetweb-test"), dialer, Config{ //nolint:errcheck,gosec
 			ProxyPort:  proxyPort,
 			TLSMITM:    true,
 			TLSPort:    443,
@@ -139,17 +139,17 @@ func TestSOCKS5_NonTLSPortStillSplices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	socksDialer, _ := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), nil, proxy.Direct)
+	socksDialer, _ := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), nil, proxy.Direct) //nolint:errcheck,gosec
 	host := testPK + ".skynet"
 	conn, err := socksDialer.Dial("tcp", host+":80")
 	if err != nil {
 		t.Fatalf("SOCKS5 dial: %v", err)
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck,gosec
 	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n")); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	body, _ := io.ReadAll(conn)
+	body, _ := io.ReadAll(conn) //nolint:errcheck,gosec
 	if !strings.Contains(string(body), "plain!") {
 		t.Errorf("plain port body = %q", string(body))
 	}
@@ -172,8 +172,8 @@ func pickFreePort(t *testing.T) uint {
 	if err != nil {
 		t.Fatal(err)
 	}
-	port := uint(lis.Addr().(*net.TCPAddr).Port)
-	_ = lis.Close()
+	port := uint(lis.Addr().(*net.TCPAddr).Port) //nolint:gosec // ephemeral port always fits in uint
+	_ = lis.Close()                              //nolint:errcheck,gosec
 	return port
 }
 
@@ -183,7 +183,7 @@ func waitForListener(host string, port uint, max time.Duration) error {
 	for time.Now().Before(deadline) {
 		c, err := net.Dial("tcp", addr)
 		if err == nil {
-			_ = c.Close()
+			_ = c.Close() //nolint:errcheck,gosec
 			return nil
 		}
 		time.Sleep(25 * time.Millisecond)


### PR DESCRIPTION
## Why

Before this change, the \`--to\` flag handler in \`serve add\` collapsed \`127.0.0.1:X\` and \`localhost:X\` to the \`LocalPort\` short form, dropping the explicit host:

\`\`\`go
case host == "" || host == "localhost" || host == "127.0.0.1":
    fp.LocalPort = p
\`\`\`

At dial time the visor reconstructs \`"localhost:port"\` from \`LocalPort\` and hands it to \`net.Dial\`, which goes through Go's resolver. With \`/etc/hosts\` mapping \`localhost\` to both \`127.0.0.1\` and \`::1\`, Happy Eyeballs picks one — and on dual-stack setups the chosen path can wind up at a different listener than the user intended, sometimes triggering odd error responses like \`HTTP/1.0 400 "Client sent an HTTP request to an HTTPS server"\` from intermediate middleware.

This was discovered while bringing HTTPS-via-skynet up end-to-end alongside #2487. \`serve add 443 --to 127.0.0.1:80\` silently stored as \`localhost:80\` and Waterfox reloads returned a Caddy-style HTTPS-on-HTTP error rather than the page. Switching to \`127.0.0.99:80\` (still loopback, but not in the collapse-shortlist) made everything work. That workaround should not have been necessary.

## What

Only collapse to \`LocalPort\` when no host was given. Any explicit host — including \`"localhost"\` and \`"127.0.0.1"\` — is preserved verbatim in \`ProxyAddr\` so the visor's \`net.Dial\` uses exactly what the user typed.

Behavior after this change:

| command | stored as |
|---|---|
| \`serve add 9000 --to 9000\` | \`LocalPort=9000\` (dial \`localhost:9000\`) |
| \`serve add 9000 --to 127.0.0.1:9000\` | \`ProxyAddr=127.0.0.1:9000\` |
| \`serve add 9000 --to localhost:9000\` | \`ProxyAddr=localhost:9000\` |
| \`serve add 9000 --to 10.0.0.1:9000\` | \`ProxyAddr=10.0.0.1:9000\` |

Port 80 branch unchanged — it always uses \`ProxyAddr\` because port-80 forwards go through the HTTP reverse-proxy on the logserver, not raw TCP forward.

## Backwards compatibility

Stored configs with \`LocalPort\` set continue to work — \`DialTarget()\` falls back to \`"localhost:port"\` when \`ProxyAddr\` is empty.

## Test plan

- [x] Build
- [ ] Manual: \`serve add 9000 --to 127.0.0.1:9000\` followed by \`serve ls\` shows \`127.0.0.1:9000\` in the TO column (not \`localhost:9000\`)
- [ ] CI lint / typecheck