### PR TITLE
fix(autoconfig): propagate resolved PKGENV/USRENV mode to the gen subprocess

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -128,7 +128,24 @@ Mode is selected by PKGENV/USRENV in the env file:
 		}
 
 		if _, err := os.Stat(resolved.configPath); os.IsNotExist(err) {
+			mode := "PKGENV"
+			if resolved.usrEnv {
+				mode = "USRENV"
+			}
 			fmt.Printf("%s>>> FATAL:%s expected config file not found at %s\n", colorRed, colorReset, resolved.configPath)
+			fmt.Printf("            autoconfig resolved mode=%s from %s\n", mode, func() string {
+				if resolved.skyenvPath != "" {
+					return resolved.skyenvPath
+				}
+				return "implicit fallback (no /etc/skywire.conf)"
+			}())
+			fmt.Printf("            if %s is commented out in %s, uncomment it and re-run `skywire autoconfig`\n",
+				mode, func() string {
+					if resolved.skyenvPath != "" {
+						return resolved.skyenvPath
+					}
+					return "/etc/skywire.conf"
+				}())
 			os.Exit(100)
 		}
 		msg3(fmt.Sprintf("%sSkywire%s configuration updated\nconfig path: %s%s%s", colorBlue, colorReset, colorPurple, resolved.configPath, colorReset))
@@ -282,11 +299,27 @@ func resolveConfig() resolvedConfig {
 	return r
 }
 
-// generateConfig invokes `skywire cli config gen -r`. The mode
-// flags (-p / -u) intentionally aren't passed — the env file's
-// PKGENV/USRENV defaults the gen command already reads do the job.
+// generateConfig invokes `skywire cli config gen` with the mode
+// flag (-p or -u) matching what resolveConfig already decided. We
+// intentionally do NOT let the subprocess redo the resolution —
+// autoconfig has an implicit "euid==0 → PKGENV" fallback when the
+// env file leaves both PKGENV and USRENV commented out, but
+// `cli config gen` does not, so without explicit -p/-u the
+// subprocess writes the config to gen's own default path (working-
+// directory ./skywire-config.json) instead of the system path
+// autoconfig is expecting at r.configPath. The mismatch surfaces
+// later as the FATAL `expected config file not found` from
+// autoconfig's post-Stat check and aborts the postinst with
+// exit 100. Propagating the resolved mode explicitly closes the gap.
 func generateConfig(r resolvedConfig, hvArg string) error {
 	args := []string{"cli", "config", "gen", "-r"}
+
+	switch {
+	case r.pkgEnv:
+		args = append(args, "-p")
+	case r.usrEnv:
+		args = append(args, "-u")
+	}
 
 	switch hvArg {
 	case "0":
@@ -308,9 +341,16 @@ func generateConfig(r resolvedConfig, hvArg string) error {
 	}
 	msg3(fmt.Sprintf("Generating skywire config with command:\n  %s%sskywire %s%s", colorCyan, envPrefix, strings.Join(args, " "), colorReset))
 
+	// Forward stdout and stderr to the parent so any error from
+	// `cli config gen` (missing service-config.json, bad SK, write
+	// permission denied, etc.) reaches the operator's apt output /
+	// journalctl. Previously these were both /dev/null'd, so a
+	// failing gen exited 0-or-noise and autoconfig only noticed
+	// downstream — by the time the FATAL Stat fired, the actual
+	// cause was lost.
 	cmd := exec.Command("skywire", args...) //nolint:gosec
-	cmd.Stdout = nil
-	cmd.Stderr = nil
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 	if r.skyenvPath != "" {
 		cmd.Env = append(cmd.Env, "SKYENV="+r.skyenvPath)

--- a/cmd/skywire/commands/autoconfig_test.go
+++ b/cmd/skywire/commands/autoconfig_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveConfig_ImplicitPkgEnvFallbackUnderRoot is the regression
+// for the v1.3.51 dpkg-100 failure. Sequence that reproduces it:
+//
+//  1. /etc/skywire.conf exists but has PKGENV and USRENV both
+//     commented out (the historical out-of-the-box shape).
+//  2. autoconfig runs as root (via .deb postinst).
+//  3. resolveConfig's implicit "euid==0 → pkg" fallback fires and
+//     sets r.pkgEnv=true with r.configPath=/opt/skywire/skywire.json.
+//  4. Before this fix, generateConfig invoked `cli config gen` with
+//     no -p flag; the subprocess re-read $PKGENV from the env file,
+//     got "false", and wrote the config to its own default path
+//     (./skywire-config.json) instead of /opt/skywire/skywire.json.
+//  5. autoconfig's post-Stat check fired FATAL → postinst exit 100.
+//
+// This test pins down step 3 — confirming resolveConfig still
+// resolves to pkgEnv under root with a silent conf — so the fix in
+// generateConfig (propagating -p explicitly) has a stable contract
+// to lean on.
+func TestResolveConfig_ImplicitPkgEnvFallbackUnderRoot(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to exercise the euid==0 fallback")
+	}
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "skywire.conf")
+	// Both PKGENV and USRENV commented — the historical default.
+	body := "# PKGENV=true\n# USRENV=true\n"
+	if err := os.WriteFile(conf, []byte(body), 0o600); err != nil {
+		t.Fatalf("write conf: %v", err)
+	}
+	t.Setenv("SKYENV", conf)
+
+	r := resolveConfig()
+	if !r.pkgEnv {
+		t.Errorf("pkgEnv = false, want true under root with silent conf")
+	}
+	if r.usrEnv {
+		t.Errorf("usrEnv = true, want false under root with silent conf")
+	}
+	if !strings.Contains(r.configPath, "/opt/skywire") {
+		t.Errorf("configPath = %q, want /opt/skywire/... under pkgEnv", r.configPath)
+	}
+}
+
+// TestResolveConfig_ExplicitUsrEnvHonored verifies the env file
+// still wins when set, so we don't accidentally regress operators
+// who run autoconfig as root but want USRENV behavior.
+func TestResolveConfig_ExplicitUsrEnvHonored(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "skywire.conf")
+	if err := os.WriteFile(conf, []byte("USRENV=true\n"), 0o600); err != nil {
+		t.Fatalf("write conf: %v", err)
+	}
+	t.Setenv("SKYENV", conf)
+
+	r := resolveConfig()
+	if !r.usrEnv {
+		t.Errorf("usrEnv = false, want true when conf has USRENV=true")
+	}
+	if r.pkgEnv {
+		t.Errorf("pkgEnv = true, want false when conf has only USRENV=true")
+	}
+}


### PR DESCRIPTION
## Symptom in the wild

After v1.3.51 .deb upgrades, postinst fails with:

\`\`\`
-> Configuring skywire
 -> version: v1.3.51
 --> Generating skywire config with command:
   SKYENV=/etc/skywire.conf skywire cli config gen -r -i
>>> FATAL: expected config file not found at /opt/skywire/skywire.json
dpkg: error processing package skywire-bin (--configure):
 installed skywire-bin package post-installation script subprocess returned error exit status 100
\`\`\`

Operators report having to manually uncomment \`PKGENV=true\` in \`/etc/skywire.conf\` to recover. That's the workaround; this is the root cause.

## Root cause

Two code paths resolve mode differently:

- **\`resolveConfig()\`** has an implicit \`euid==0 → PKGENV\` fallback when both \`PKGENV\` and \`USRENV\` are commented out in the env file. It sets \`r.pkgEnv=true\` + \`r.configPath=/opt/skywire/skywire.json\`.
- **\`generateConfig()\`** shells out to \`skywire cli config gen -r\` **without -p/-u**. The subprocess re-reads \`${PKGENV:-false}\` via \`scriptExecBool\`, gets \`false\`, has no euid fallback, and writes the config to its own default working-directory path (\`./skywire-config.json\`).

Result: autoconfig's post-Stat at \`r.configPath\` fires FATAL → exit 100 → dpkg aborts.

A 2026-05-09 commit (\`b882037d\`) explicitly documented that the .deb's postinst \`doesn't even invoke autoconfig\` — but the live \`cc.deb.PKGBUILD\` in skycoin/aur DOES invoke \`skywire autoconfig\`, so the path is hot.

## Fix

\`generateConfig\` now passes \`-p\` when \`r.pkgEnv\` is set, \`-u\` when \`r.usrEnv\` is set, so the subprocess gets the parent's already-resolved decision rather than re-deriving it from a possibly-silent env file.

Plus two adjacent quality fixes:

1. Forward stdout/stderr from the subprocess to the parent instead of \`/dev/null\`'ing them — so any actual gen failure (missing service-config.json, write-permission denied, bad SK, etc.) lands in apt output and journalctl. Before this change those errors were silent and the operator only saw the downstream Stat FATAL.
2. The FATAL Stat error now includes the resolved mode and the env-file path it was derived from, so an operator hitting this in the future sees the exact knob to flip rather than just "file not where I expected."

## Test plan

- [x] \`go test ./cmd/skywire/commands/ -run ResolveConfig\` — regression test pins the implicit \`euid==0 → pkgEnv\` fallback (root case skips when not running as root)
- [x] \`go build ./...\`
- [x] \`golangci-lint run ./cmd/skywire/...\` — clean
- [ ] CI on the PR
- [ ] In-the-wild reproduction: comment out \`PKGENV=true\` in \`/etc/skywire.conf\`, \`skywire autoconfig\` — should now succeed and write to \`/opt/skywire/skywire.json\`

## Belt-and-suspenders

\`cc.deb.PKGBUILD\` already ships \`/etc/skywire.conf\` with \`PKGENV=true\` uncommented. That stays as defense in depth — but this PR makes it not strictly necessary anymore.