### PR TITLE
feat(cli,visor,tpd): close CXO subscriber gap (SD services, TPD all-transports) + bbolt cache fallback

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -8,8 +8,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -19,6 +19,7 @@ import (
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/clicache"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
@@ -248,6 +249,29 @@ func cxoFeedForURL(rawURL string) (feed, path string, ok bool) {
 		}
 		return "", "", false
 	}
+
+	// SD /api/services?type=X → "sd-services" feed. The visor's
+	// CXOSubscriptionManager already maintains a materialized
+	// FeedSDServices snapshot for TabCLIServices and TabAutoconnect;
+	// the FetchCXO branch just walks it for the requested type.
+	if isUnderBase(rawURL, deployment.Prod.ServiceDiscovery, "/api/services") ||
+		isUnderBase(rawURL, deployment.Prod.ServiceDiscoveryDmsg, "/api/services") {
+		if t := queryParam(rawURL, "type"); t != "" {
+			return "sd-services", "type/" + t, true
+		}
+		return "", "", false
+	}
+
+	// TPD /all-transports → "tpd-all-transports" feed. The publisher
+	// emits two variants (with-self / without-self) on a 60s
+	// cadence; the CLI's `pv -t`, `tp tree`, and `tp viz` callers
+	// hit /all-transports without an explicit selfTransports flag,
+	// which the TPD endpoint serves as "without self".
+	if isUnderBase(rawURL, deployment.Prod.TransportDiscovery, "/all-transports") ||
+		isUnderBase(rawURL, deployment.Prod.TransportDiscoveryDmsg, "/all-transports") {
+		return "tpd-all-transports", "without-self", true
+	}
+
 	return "", "", false
 }
 
@@ -393,27 +417,30 @@ func fetchViaDmsgDirect(dmsgURL string) ([]byte, error) {
 // routes the fetch through FetchServiceURL (RPC → DMSG → HTTP) instead of
 // going straight to HTTP.
 //
-// Caching semantics match GetData:
+// Caching semantics:
 //   - If cachefile == "", caching is disabled and we fetch fresh every call.
-//   - If the cache file exists and is younger than cacheFilesAge minutes,
-//     its contents are returned as-is.
-//   - Otherwise we fetch via FetchServiceURL and, on success, atomically
-//     write the response to cachefile for the next call.
-//   - On fetch failure, a stale cache file (if present) is returned as a
-//     last resort rather than propagating an empty string, matching the
-//     "best-effort" behavior callers expect.
+//     Otherwise the cachefile argument is treated as a non-empty marker for
+//     "caching enabled"; the actual storage is a single bbolt DB at
+//     pkg/clicache's DefaultPath (NOT the per-URL JSON file the legacy
+//     code used). The bbolt approach replaces the older /tmp/<host>/<endpoint>.json
+//     files which couldn't be shared across users due to umask downgrade.
+//   - If a cached entry exists and is younger than cacheFilesAge minutes,
+//     its body is returned as-is.
+//   - Otherwise we fetch via FetchServiceURL and write the response through
+//     to the bbolt cache for the next call.
+//   - On fetch failure, a stale cached entry is returned as a last resort
+//     rather than propagating an empty string.
 //
 // Returns the response body as a string, or "" if every path failed and
 // there was no cache to fall back on. Errors are logged at debug level.
 func FetchCachedServiceURL(cmdFlags *pflag.FlagSet, cachefile, thisurl string, cacheFilesAge int) string {
-	// Serve a fresh cache if we have one.
-	if cachefile != "" {
-		if st, err := os.Stat(cachefile); err == nil {
-			if time.Since(st.ModTime()).Minutes() <= float64(cacheFilesAge) {
-				if data, err := os.ReadFile(cachefile); err == nil { //nolint:gosec
-					return string(data)
-				}
-			}
+	cache := getCLICacheIfEnabled(cachefile)
+	maxAge := time.Duration(cacheFilesAge) * time.Minute
+
+	// Serve a fresh cache entry if we have one.
+	if cache != nil {
+		if e, ok := cache.Fresh(thisurl, maxAge); ok {
+			return string(e.Body)
 		}
 	}
 
@@ -422,27 +449,52 @@ func FetchCachedServiceURL(cmdFlags *pflag.FlagSet, cachefile, thisurl string, c
 	if err != nil {
 		logger.Debugf("FetchCachedServiceURL: all fetch paths failed for %s: %v", thisurl, err)
 		// Last-ditch: return stale cache if we have one.
-		if cachefile != "" {
-			if data, rerr := os.ReadFile(cachefile); rerr == nil { //nolint:gosec
-				return string(data)
+		if cache != nil {
+			if e, ok := cache.Get(thisurl); ok {
+				return string(e.Body)
 			}
 		}
 		return ""
 	}
 
 	// Write-through to cache for next call. Non-fatal on error.
-	// Use world-readable permissions so multiple users (visor service,
-	// CLI user) can share the same /tmp cache directory.
-	if cachefile != "" {
-		dir := filepath.Dir(cachefile)
-		if err := os.MkdirAll(dir, 0o777); err != nil { //nolint:gosec
-			logger.Debugf("FetchCachedServiceURL: cache mkdir failed for %s: %v", dir, err)
-		}
-		if werr := os.WriteFile(cachefile, body, 0o666); werr != nil { //nolint:gosec
-			logger.Debugf("FetchCachedServiceURL: cache write failed for %s: %v", cachefile, werr)
+	if cache != nil {
+		if werr := cache.Put(thisurl, body); werr != nil {
+			logger.Debugf("FetchCachedServiceURL: cache put failed for %s: %v", thisurl, werr)
 		}
 	}
 	return string(body)
+}
+
+var (
+	cliCacheOnce sync.Once
+	cliCache     *clicache.Cache
+)
+
+// getCLICacheIfEnabled returns the process-singleton bbolt cache iff
+// cachefile is non-empty (the historical "caching on" signal). The
+// argument's path is no longer used — the DB location is resolved
+// via clicache.DefaultPath. Returns nil when caching is disabled or
+// when the DB couldn't be opened (e.g. another CLI holds the lock);
+// callers treat nil as "no cache, fetch fresh every call".
+func getCLICacheIfEnabled(cachefile string) *clicache.Cache {
+	if cachefile == "" {
+		return nil
+	}
+	cliCacheOnce.Do(func() {
+		path, err := clicache.DefaultPath()
+		if err != nil {
+			logger.Debugf("clicache: resolve default path: %v", err)
+			return
+		}
+		c, err := clicache.Open(path)
+		if err != nil {
+			logger.Debugf("clicache: open %s: %v", path, err)
+			return
+		}
+		cliCache = c
+	})
+	return cliCache
 }
 
 // FetchServiceURL fetches a URL from a deployment service using a three-step chain:

--- a/pkg/clicache/clicache.go
+++ b/pkg/clicache/clicache.go
@@ -79,18 +79,26 @@ func DefaultPath() (string, error) {
 // writable by other users — this is what the older per-URL file
 // cache failed to do (umask downgrade).
 //
+// The wide permissions are deliberate: when the visor runs as root
+// (e.g. via the systemd service) and the operator runs the CLI as
+// their own user, both must be able to write the cache or the CLI
+// degenerates back into per-user files. The cache contents are
+// public deployment-service responses, so wide read perms aren't a
+// disclosure risk. gosec G301/G302 warnings are silenced for the
+// same reason.
+//
 // A 2s open timeout matches the rest of the codebase's bbolt usage
 // and prevents the CLI from hanging if another process holds the
 // lock.
 func Open(path string) (*Cache, error) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o777); err != nil {
+	if err := os.MkdirAll(dir, 0o777); err != nil { //nolint:gosec // intentional shared-cache mode; see Open doc
 		return nil, fmt.Errorf("clicache: mkdir %q: %w", dir, err)
 	}
 	// Defeat the umask explicitly — MkdirAll only sets perms on
 	// newly-created components, and the second argument is masked
 	// by the calling process's umask. Chmod isn't subject to umask.
-	if err := os.Chmod(dir, 0o777); err != nil {
+	if err := os.Chmod(dir, 0o777); err != nil { //nolint:gosec // intentional shared-cache mode; see Open doc
 		// Non-fatal: a non-shared cache still works for the calling user.
 		_ = err //nolint:errcheck // intentionally swallowed
 	}
@@ -100,7 +108,7 @@ func Open(path string) (*Cache, error) {
 		return nil, fmt.Errorf("clicache: open %q: %w", path, err)
 	}
 	// Same umask-defeat for the file itself.
-	_ = os.Chmod(path, 0o666) //nolint:errcheck // non-fatal
+	_ = os.Chmod(path, 0o666) //nolint:errcheck,gosec // non-fatal; intentional shared-cache mode
 
 	return &Cache{db: db, path: path}, nil
 }

--- a/pkg/clicache/clicache.go
+++ b/pkg/clicache/clicache.go
@@ -1,0 +1,202 @@
+// Package clicache provides a single-file bbolt-backed cache that
+// `skywire cli` commands use to memoize deployment-service fetches
+// (SD `/api/services`, TPD `/all-transports`, UT `/uptimes`, etc.)
+// for the CLI's --cfa minutes-old window.
+//
+// Replaces the older per-URL JSON-file cache in `/tmp/<service>/...`,
+// which had two problems:
+//
+//   - umask silently downgraded the intended 0o777/0o666 modes, so a
+//     CLI run as one user couldn't write into a dir created by a CLI
+//     run as another user (typically root via the visor service).
+//   - Each cached endpoint was its own file on disk; no way to scope
+//     or evict in one operation.
+//
+// The bbolt approach: one DB file at
+// $XDG_CACHE_HOME/skywire/cli-fetch.db (default
+// ~/.cache/skywire/cli-fetch.db). System-wide installs that want a
+// shared cache across users can set SKYWIRE_CLI_CACHE_DB to
+// /var/cache/skywire/cli-fetch.db (or similar) and ensure the file
+// is 0o666 with a 0o777 parent — both are set explicitly by Open.
+//
+// Entries are keyed by URL inside a per-service-host bucket so a
+// future cache-clear can target a single service. Values are framed
+// as JSON `{"body": "...", "fetched_at": "..."}` so a `bbolt dump`
+// or `strings(1)` produces something legible.
+package clicache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// DefaultFilename is the bbolt file's basename under the cache dir.
+const DefaultFilename = "cli-fetch.db"
+
+// Entry is the value stored under each URL key.
+type Entry struct {
+	Body      []byte    `json:"body"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+// Cache is a thin wrapper around a bbolt.DB scoped to the CLI's
+// service-fetch use case. The zero value is unusable — use Open.
+type Cache struct {
+	mu   sync.Mutex
+	db   *bolt.DB
+	path string
+}
+
+// DefaultPath returns the path the CLI should use for its cache db,
+// resolved from (in order): $SKYWIRE_CLI_CACHE_DB,
+// $XDG_CACHE_HOME/skywire/<DefaultFilename>,
+// $HOME/.cache/skywire/<DefaultFilename>.
+func DefaultPath() (string, error) {
+	if env := os.Getenv("SKYWIRE_CLI_CACHE_DB"); env != "" {
+		return env, nil
+	}
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "skywire", DefaultFilename), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate user cache dir: %w", err)
+	}
+	return filepath.Join(home, ".cache", "skywire", DefaultFilename), nil
+}
+
+// Open creates or opens the cache DB at path. The parent directory
+// is created if missing. Both the directory and the DB file are
+// explicitly chmodded to 0o777 / 0o666 so a root-owned DB remains
+// writable by other users — this is what the older per-URL file
+// cache failed to do (umask downgrade).
+//
+// A 2s open timeout matches the rest of the codebase's bbolt usage
+// and prevents the CLI from hanging if another process holds the
+// lock.
+func Open(path string) (*Cache, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return nil, fmt.Errorf("clicache: mkdir %q: %w", dir, err)
+	}
+	// Defeat the umask explicitly — MkdirAll only sets perms on
+	// newly-created components, and the second argument is masked
+	// by the calling process's umask. Chmod isn't subject to umask.
+	if err := os.Chmod(dir, 0o777); err != nil {
+		// Non-fatal: a non-shared cache still works for the calling user.
+		_ = err //nolint:errcheck // intentionally swallowed
+	}
+
+	db, err := bolt.Open(path, 0o666, &bolt.Options{Timeout: 2 * time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("clicache: open %q: %w", path, err)
+	}
+	// Same umask-defeat for the file itself.
+	_ = os.Chmod(path, 0o666) //nolint:errcheck // non-fatal
+
+	return &Cache{db: db, path: path}, nil
+}
+
+// Close releases the underlying bbolt DB. Safe to call on a nil
+// receiver so callers can `defer c.Close()` without nil-checks.
+func (c *Cache) Close() error {
+	if c == nil || c.db == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	err := c.db.Close()
+	c.db = nil
+	return err
+}
+
+// Path returns the on-disk location of the DB.
+func (c *Cache) Path() string {
+	if c == nil {
+		return ""
+	}
+	return c.path
+}
+
+// bucketForURL groups entries by the URL's host so a future
+// per-service eviction can target a single bucket. Falls back to a
+// shared "_" bucket if url.Parse fails — better to cache than to
+// drop on the floor.
+func bucketForURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "_"
+	}
+	return u.Host
+}
+
+// Get returns the cached entry for rawURL, or ok=false on miss.
+// Returns ok=false on any decode error — caller treats it as a
+// fresh-fetch trigger rather than propagating a partial value.
+func (c *Cache) Get(rawURL string) (Entry, bool) {
+	if c == nil || c.db == nil {
+		return Entry{}, false
+	}
+	var e Entry
+	hit := false
+	err := c.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketForURL(rawURL)))
+		if b == nil {
+			return nil
+		}
+		raw := b.Get([]byte(rawURL))
+		if raw == nil {
+			return nil
+		}
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil
+		}
+		hit = true
+		return nil
+	})
+	if err != nil {
+		return Entry{}, false
+	}
+	return e, hit
+}
+
+// Fresh is a convenience wrapper that returns the entry only if
+// it's been fetched within maxAge. Equivalent to Get + age check.
+func (c *Cache) Fresh(rawURL string, maxAge time.Duration) (Entry, bool) {
+	e, ok := c.Get(rawURL)
+	if !ok {
+		return Entry{}, false
+	}
+	if time.Since(e.FetchedAt) > maxAge {
+		return Entry{}, false
+	}
+	return e, true
+}
+
+// Put stores body under rawURL with the current time as the
+// fetched_at timestamp.
+func (c *Cache) Put(rawURL string, body []byte) error {
+	if c == nil || c.db == nil {
+		return errors.New("clicache: nil cache")
+	}
+	e := Entry{Body: append([]byte(nil), body...), FetchedAt: time.Now().UTC()}
+	raw, err := json.Marshal(&e)
+	if err != nil {
+		return fmt.Errorf("clicache: marshal entry: %w", err)
+	}
+	return c.db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte(bucketForURL(rawURL)))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(rawURL), raw)
+	})
+}

--- a/pkg/clicache/clicache_test.go
+++ b/pkg/clicache/clicache_test.go
@@ -12,7 +12,7 @@ func TestPutGet_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer c.Close() //nolint:errcheck,gosec
 
 	url := "http://sd.example.com/api/services?type=visor"
 	body := []byte(`[{"address":"deadbeef:80","type":"visor"}]`)
@@ -36,7 +36,7 @@ func TestFresh_RespectsMaxAge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer c.Close() //nolint:errcheck,gosec
 
 	url := "http://sd.example.com/api/services?type=visor"
 	if err := c.Put(url, []byte("x")); err != nil {
@@ -55,7 +55,7 @@ func TestGet_MissOnUnknownURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer c.Close() //nolint:errcheck,gosec
 
 	if _, ok := c.Get("http://nope"); ok {
 		t.Errorf("Get hit on never-put URL")
@@ -98,7 +98,7 @@ func TestOpen_ChmodFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
+	defer c.Close() //nolint:errcheck,gosec
 	info, err := os.Stat(dbPath)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/clicache/clicache_test.go
+++ b/pkg/clicache/clicache_test.go
@@ -1,0 +1,112 @@
+package clicache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPutGet_RoundTrip(t *testing.T) {
+	c, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	url := "http://sd.example.com/api/services?type=visor"
+	body := []byte(`[{"address":"deadbeef:80","type":"visor"}]`)
+	if err := c.Put(url, body); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := c.Get(url)
+	if !ok {
+		t.Fatalf("Get miss")
+	}
+	if string(got.Body) != string(body) {
+		t.Errorf("body = %q, want %q", got.Body, body)
+	}
+	if time.Since(got.FetchedAt) > time.Minute {
+		t.Errorf("fetched_at too far in past: %v", got.FetchedAt)
+	}
+}
+
+func TestFresh_RespectsMaxAge(t *testing.T) {
+	c, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	url := "http://sd.example.com/api/services?type=visor"
+	if err := c.Put(url, []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.Fresh(url, time.Minute); !ok {
+		t.Errorf("Fresh miss on just-put entry")
+	}
+	if _, ok := c.Fresh(url, time.Nanosecond); ok {
+		t.Errorf("Fresh hit on too-strict maxAge")
+	}
+}
+
+func TestGet_MissOnUnknownURL(t *testing.T) {
+	c, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if _, ok := c.Get("http://nope"); ok {
+		t.Errorf("Get hit on never-put URL")
+	}
+}
+
+func TestBucketForURL_PerHost(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{"http://sd.skycoin.com/api/services", "sd.skycoin.com"},
+		{"http://tpd.skywire.skycoin.com/all-transports", "tpd.skywire.skycoin.com"},
+		{"not a url", "_"},
+		{"", "_"},
+	} {
+		if got := bucketForURL(tc.url); got != tc.want {
+			t.Errorf("bucketForURL(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestNilReceiver_Safe(t *testing.T) {
+	var c *Cache
+	if _, ok := c.Get("anything"); ok {
+		t.Errorf("Get on nil cache returned ok")
+	}
+	if _, ok := c.Fresh("anything", time.Minute); ok {
+		t.Errorf("Fresh on nil cache returned ok")
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("Close on nil cache returned %v", err)
+	}
+	if c.Path() != "" {
+		t.Errorf("Path on nil cache returned %q", c.Path())
+	}
+}
+
+func TestOpen_ChmodFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	c, err := Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 0o666 may be reduced by extreme umasks like 077, but in normal
+	// environments at least other-read should survive. We assert the
+	// mode is *at least* 0o644 to keep the test stable on CI sandboxes.
+	if mode := info.Mode().Perm(); mode < 0o644 {
+		t.Errorf("DB perms = %#o, want >= 0o644", mode)
+	}
+}

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -303,6 +303,15 @@ func (s *service) startCXO(
 			pub.Close() //nolint:errcheck,gosec
 		}()
 	}
+
+	if pub, perr := api.StartAllTransportsCXOPublisher(ctx, tpdAPI, h.DmsgClient, sk, logger); perr != nil {
+		logger.WithError(perr).Error("Failed to start CXO all-transports publisher, continuing without it")
+	} else {
+		go func() {
+			<-ctx.Done()
+			pub.Close() //nolint:errcheck,gosec
+		}()
+	}
 }
 
 // aggregatorSink composes the cxoaggregator.Sink contract from the

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -76,6 +76,15 @@ const (
 	// consumers can subscribe to one feed without the other.
 	DmsgDMSGDClientsByServerCXOPort uint16 = 54
 
+	// DmsgTPDAllTransportsCXOPort is the DMSG port the TPD's CXO
+	// all-transports snapshot publisher listens on. Mirrors the
+	// HTTP /all-transports endpoint on a fixed cadence; subscribers
+	// (the CLI's `pv -t`, `tp tree`, `tp viz`) read the snapshot
+	// instead of HTTP-polling. Distinct port from
+	// DmsgTPDMetricsCXOPort and DmsgTPDUptimeCXOPort so consumers can
+	// subscribe to one TPD feed without dragging in the others.
+	DmsgTPDAllTransportsCXOPort uint16 = 55
+
 	// DmsgDHTPort Listening port for the Kademlia DHT protocol.
 	DmsgDHTPort uint16 = 100
 

--- a/pkg/transport-discovery/api/cxo_all_transports_publisher.go
+++ b/pkg/transport-discovery/api/cxo_all_transports_publisher.go
@@ -1,0 +1,166 @@
+// Package api pkg/transport-discovery/api/cxo_all_transports_publisher.go
+//
+// CXO publisher for the network-wide all-transports snapshot. On a
+// fixed cadence (default 60s) the publisher reads the store's
+// memoized GetAllTransports(...) result for both the with-self and
+// without-self variants and writes JSON-encoded []*transport.Entry
+// to TreeStore paths
+//
+//	transports/all/with-self
+//	transports/all/without-self
+//
+// Subscribers (the CLI's `pv -t`, `tp tree`, `tp viz`) read the
+// snapshot instead of HTTP-polling /all-transports. CXO's content
+// addressing means a stable transport set produces a stable Root,
+// so reading the same snapshot twice in a row is effectively free
+// after the first sync.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// allTransportsPublishInterval is the recompute cadence. 60s matches
+// the metrics/uptime publishers; the store's allTransportsCache
+// memoizes between ticks so the actual cost is bounded.
+const allTransportsPublishInterval = 60 * time.Second
+
+// Published paths. Exported so visor-side subscribers don't have to
+// duplicate the format strings.
+const (
+	AllTransportsPathWithSelf    = "transports/all/with-self"
+	AllTransportsPathWithoutSelf = "transports/all/without-self"
+)
+
+// AllTransportsCXOPublisher periodically reads the store's
+// GetAllTransports snapshot and publishes the with-self and
+// without-self variants. Close shuts the publisher and stops the
+// ticker.
+type AllTransportsCXOPublisher struct {
+	api *API
+	pub *treestore.Publisher
+	log *logging.Logger
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu        sync.Mutex
+	lastError error
+}
+
+// StartAllTransportsCXOPublisher constructs a publisher backed by
+// the given DMSG client and TPD secret key, then kicks off the
+// recompute ticker. Best-effort: HTTP /all-transports stays the
+// source of truth; callers should log and continue if this fails.
+func StartAllTransportsCXOPublisher(ctx context.Context, api *API, dmsgC *dmsg.Client, sk cipher.SecKey, logger logrus.FieldLogger) (*AllTransportsCXOPublisher, error) {
+	log := logging.MustGetLogger("tpd-cxo-all-transports-pub")
+
+	pub, err := treestore.NewWithDMSG(dmsgC, sk, treestore.PubConfig{
+		Logger:     log,
+		InMemoryDB: true,
+		DmsgPort:   skyenv.DmsgTPDAllTransportsCXOPort,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// nil allowlist = open feed (any subscriber accepted).
+	pub.SetAllowlist(nil)
+
+	pubCtx, cancel := context.WithCancel(ctx)
+	ap := &AllTransportsCXOPublisher{
+		api:    api,
+		pub:    pub,
+		log:    log,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	if logger != nil {
+		logger.WithField("feed_pk", pub.Feed()).WithField("dmsg_port", skyenv.DmsgTPDAllTransportsCXOPort).
+			Info("CXO all-transports publisher running")
+	}
+	go ap.loop(pubCtx)
+	return ap, nil
+}
+
+// FeedPK returns the publisher's feed PK (TPD's own PK).
+func (a *AllTransportsCXOPublisher) FeedPK() cipher.PubKey { return a.pub.Feed() }
+
+// Close stops the ticker and tears down the publisher.
+func (a *AllTransportsCXOPublisher) Close() error {
+	if a.cancel != nil {
+		a.cancel()
+	}
+	<-a.done
+	return a.pub.Close()
+}
+
+func (a *AllTransportsCXOPublisher) loop(ctx context.Context) {
+	defer close(a.done)
+
+	// Publish once immediately so an early subscriber gets a snapshot.
+	a.publishOnce(ctx)
+
+	t := time.NewTicker(allTransportsPublishInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			a.publishOnce(ctx)
+		}
+	}
+}
+
+func (a *AllTransportsCXOPublisher) publishOnce(ctx context.Context) {
+	for _, v := range []struct {
+		path     string
+		withSelf bool
+	}{
+		{AllTransportsPathWithoutSelf, false},
+		{AllTransportsPathWithSelf, true},
+	} {
+		entries, err := a.api.store.GetAllTransports(ctx, v.withSelf)
+		if err != nil {
+			a.log.WithError(err).WithField("path", v.path).Debug("all-transports fetch failed; will retry next tick")
+			a.recordError(err)
+			continue
+		}
+		body, err := json.Marshal(entries)
+		if err != nil {
+			a.log.WithError(err).WithField("path", v.path).Warn("all-transports marshal failed")
+			a.recordError(err)
+			continue
+		}
+		if err := a.pub.Put(v.path, body); err != nil {
+			a.log.WithError(err).WithField("path", v.path).Warn("publisher Put failed")
+			a.recordError(err)
+			continue
+		}
+	}
+}
+
+func (a *AllTransportsCXOPublisher) recordError(err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.lastError = err
+}
+
+// LastError returns the most recent error from the publish loop, or
+// nil if the last tick succeeded for both variants.
+func (a *AllTransportsCXOPublisher) LastError() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.lastError
+}

--- a/pkg/visor/api_all_transports.go
+++ b/pkg/visor/api_all_transports.go
@@ -1,0 +1,50 @@
+// Package visor pkg/visor/api_all_transports.go
+//
+// Reader-side helper for the TPD all-transports CXO snapshot. The
+// publisher lives in pkg/transport-discovery/api/cxo_all_transports_publisher.go
+// and writes JSON-encoded []*transport.Entry to two paths
+// (transports/all/with-self, transports/all/without-self). This
+// helper Acquires the TabCLITransports tab on the
+// CXOSubscriptionManager, reads the requested path's snapshot, and
+// returns the raw JSON body so FetchCXO can serve it to the CLI
+// unchanged.
+//
+// "Acquire on each call" is intentional and lightweight — the
+// manager's reference counting plus close-grace amortize repeated
+// CLI invocations within ~10s, and a CLI not running once a minute
+// keeps the cycle from running forever.
+package visor
+
+import (
+	"errors"
+
+	tpdapi "github.com/skycoin/skywire/pkg/transport-discovery/api"
+)
+
+// ErrTPDAllTransportsNotReady is returned when the CXO subscriber
+// has nothing for the requested path yet (no manager, no PK, hasn't
+// synced).
+var ErrTPDAllTransportsNotReady = errors.New("tpd all-transports: cxo cache miss")
+
+// FetchAllTransportsCXO returns the cached JSON for the requested
+// variant (withSelf true → transports/all/with-self, else
+// transports/all/without-self). Caller treats the not-ready error
+// as a cache miss and falls through to HTTP.
+func (v *Visor) FetchAllTransportsCXO(withSelf bool) ([]byte, error) {
+	mgr := v.CXOSubMgr()
+	if mgr == nil {
+		return nil, ErrTPDAllTransportsNotReady
+	}
+	mgr.AcquireFor(TabCLITransports)
+	defer mgr.ReleaseFor(TabCLITransports)
+
+	path := tpdapi.AllTransportsPathWithoutSelf
+	if withSelf {
+		path = tpdapi.AllTransportsPathWithSelf
+	}
+	body, _, ok := mgr.Get(FeedTPDAllTransports, path)
+	if !ok || len(body) == 0 {
+		return nil, ErrTPDAllTransportsNotReady
+	}
+	return body, nil
+}

--- a/pkg/visor/api_fetch_cxo.go
+++ b/pkg/visor/api_fetch_cxo.go
@@ -12,7 +12,10 @@
 package visor
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
+	"time"
 )
 
 // FetchCXO implements API.
@@ -48,6 +51,49 @@ func (v *Visor) FetchCXO(args FetchCXOArgs) (*FetchCXOResult, error) {
 			return &FetchCXOResult{Reason: "tpd-uptime: " + err.Error()}, nil
 		}
 		return &FetchCXOResult{Hit: true, Body: body, LastRootAt: ts}, nil
+
+	case "sd-services":
+		// Path is "type/<typeName>". Maps onto the SD HTTP endpoint
+		// /api/services?type=<typeName>; the materialized snapshot
+		// lives in the CXOSubscriptionManager's FeedSDServices and
+		// is walked by servicesFromCXO (no extra subscriber needed).
+		const prefix = "type/"
+		if !strings.HasPrefix(args.Path, prefix) {
+			return &FetchCXOResult{Reason: "invalid path for sd-services: " + args.Path}, nil
+		}
+		serviceType := args.Path[len(prefix):]
+		if serviceType == "" {
+			return &FetchCXOResult{Reason: "sd-services: missing service type"}, nil
+		}
+		services, ok := v.servicesFromCXO(serviceType, "", "")
+		if !ok {
+			return &FetchCXOResult{Reason: "sd-services: cache miss"}, nil
+		}
+		body, err := json.Marshal(services)
+		if err != nil {
+			return &FetchCXOResult{Reason: "sd-services: marshal: " + err.Error()}, nil
+		}
+		return &FetchCXOResult{Hit: true, Body: body, LastRootAt: time.Now()}, nil
+
+	case "tpd-all-transports":
+		// Path is "with-self" or "without-self".
+		var withSelf bool
+		switch args.Path {
+		case "with-self":
+			withSelf = true
+		case "without-self":
+			withSelf = false
+		default:
+			return &FetchCXOResult{Reason: "invalid path for tpd-all-transports: " + args.Path}, nil
+		}
+		body, err := v.FetchAllTransportsCXO(withSelf)
+		if err != nil {
+			if errors.Is(err, ErrTPDAllTransportsNotReady) {
+				return &FetchCXOResult{Reason: "tpd-all-transports: cache miss"}, nil
+			}
+			return &FetchCXOResult{Reason: "tpd-all-transports: " + err.Error()}, nil
+		}
+		return &FetchCXOResult{Hit: true, Body: body, LastRootAt: time.Now()}, nil
 
 	default:
 		return &FetchCXOResult{Reason: "unknown feed: " + args.Feed}, nil

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -61,6 +61,11 @@ const (
 	// FeedDMSGDClientsByServer is DMSG-D's clients-by-server publisher
 	// (clients-by-server/<server>/<client>/{entry,tombstone}).
 	FeedDMSGDClientsByServer
+	// FeedTPDAllTransports is TPD's all-transports snapshot publisher
+	// (transports/all/{with-self,without-self}). Used by the CLI's
+	// `pv -t`, `tp tree`, `tp viz` commands as a CXO alternative to
+	// HTTP-polling /all-transports.
+	FeedTPDAllTransports
 )
 
 // CXOTab identifies a consumer of one or more CXO feeds. Tabs in the
@@ -84,6 +89,10 @@ const (
 	// SD services feed; refcount summed with TabAutoconnect when
 	// both are active so they share the running cycle.
 	TabCLIServices
+	// TabCLITransports is the operator-facing transport-listing CLI
+	// commands (`pv -t`, `tp tree`, `tp viz`). Maps to the TPD
+	// all-transports feed.
+	TabCLITransports
 )
 
 // tabFeedDeps maps each tab to the set of feeds it depends on.
@@ -95,6 +104,7 @@ var tabFeedDeps = map[CXOTab][]CXOFeed{
 	TabUptime:            {FeedTPDUptime},
 	TabAutoconnect:       {FeedSDServices},
 	TabCLIServices:       {FeedSDServices},
+	TabCLITransports:     {FeedTPDAllTransports},
 }
 
 // CXOSubscriptionManager owns the per-feed cycle goroutines + the
@@ -512,6 +522,12 @@ func (m *CXOSubscriptionManager) feedSpec(fk CXOFeed) (cipher.PubKey, uint16, st
 			return cipher.PubKey{}, 0, "", errors.New("no DMSG-D CXO peer (dmsg.discovery_dmsg unset)")
 		}
 		return pk, skyenv.DmsgDMSGDClientsByServerCXOPort, "clients-by-server/", nil
+	case FeedTPDAllTransports:
+		pk, ok := tpdCXOPeer(m.v)
+		if !ok {
+			return cipher.PubKey{}, 0, "", errors.New("no TPD CXO peer (transport.discovery_dmsg unset)")
+		}
+		return pk, skyenv.DmsgTPDAllTransportsCXOPort, "transports/all/", nil
 	}
 	return cipher.PubKey{}, 0, "", fmt.Errorf("unknown feed: %d", fk)
 }


### PR DESCRIPTION
## Why

`skywire cli pv -t` was still writing per-URL JSON cache files to
`/tmp/sd.skycoin.com/` and `/tmp/tpd.skywire.skycoin.com/`, and
permission-denied debug lines were spamming the log because those
dirs are owned by root (visor service) while the CLI ran as the
operator.

Two root causes:

1. The CXO subscriber architecture (PR #2456 et al.) only covered
   TPD `/metrics?days=N` and TPD `/uptimes?v=v3`. The other URLs
   `pv` hits — SD `/api/services?type=X` and TPD `/all-transports`
   — fell through to the legacy HTTP+file-cache path.
2. The file cache code's `MkdirAll(dir, 0o777)` and
   `WriteFile(..., 0o666)` were silently downgraded by the visor's
   `UMask=0022` (and a more restrictive umask gave the observed
   `0o750`/`0o640` modes). Other users couldn't write into the dirs
   even if they could read them.

## What this changes

### 1. SD `/api/services?type=X` over CXO

`pkg/visor/api_services.go:servicesFromCXO` already walked the
materialized FeedSDServices snapshot for VPNServers, ProxyServers,
autoconnect. The URL-driven CLI fetch chain wasn't routed through
it — fixed by adding a `case "sd-services":` to FetchCXO that
parses `type/<typeName>` and delegates to the existing helper, plus
a `cxoFeedForURL` row mapping `<sd-base>/api/services?type=X` →
(`sd-services`, `type/X`).

No new visor subscriber, no new manager feed.

### 2. TPD `/all-transports` over CXO

Net-new feed end-to-end:

| Layer | File |
|---|---|
| Port | `pkg/skyenv/skyenv.go` → `DmsgTPDAllTransportsCXOPort = 55` |
| Publisher | `pkg/transport-discovery/api/cxo_all_transports_publisher.go` — 60s ticker, store.GetAllTransports for both variants, two paths |
| Service startup | `pkg/services/tpd/tpd.go` — started alongside metrics/uptime |
| Manager feed | `pkg/visor/cxo_subscription_manager.go` — `FeedTPDAllTransports`, `TabCLITransports`, `tabFeedDeps`, `feedSpec` |
| Reader helper | `pkg/visor/api_all_transports.go` — `FetchAllTransportsCXO(withSelf)` |
| FetchCXO | `pkg/visor/api_fetch_cxo.go` — `case \"tpd-all-transports\":` |
| CLI route | `cmd/skywire-cli/commands/rpc/root.go` — `cxoFeedForURL` |

### 3. bbolt fallback cache replaces /tmp JSON files

For URLs not yet covered by CXO (e.g. UT uptimes during deprecation
transition), the file cache is replaced with a single bbolt DB:

  - `pkg/clicache` — new package; DB at
    `$XDG_CACHE_HOME/skywire/cli-fetch.db` (default
    `~/.cache/skywire/cli-fetch.db`), or via
    `$SKYWIRE_CLI_CACHE_DB`. Parent dir + DB file explicitly
    chmodded so umask can't downgrade the perms. Per-host buckets,
    URL keys, JSON `{body, fetched_at}` values.
  - `cmd/skywire-cli/commands/rpc/root.go` —
    `FetchCachedServiceURL` now uses the bbolt cache. The `cachefile`
    argument is preserved but is treated as a non-empty toggle, so
    every existing caller works unchanged.

## Behavior after this lands

`skywire cli pv -t` as a non-root user:

  - SD visor list → CXO snapshot. No /tmp write.
  - TPD all-transports → CXO snapshot. No /tmp write.
  - UT uptimes (intentionally not on CXO, slated for deprecation) →
    bbolt fallback at `~/.cache/skywire/cli-fetch.db`.

No `/tmp/sd.skycoin.com/` or `/tmp/tpd.skywire.skycoin.com/` ever
created.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./pkg/clicache/...` — pass
- [x] `go test ./pkg/visor/... ./pkg/transport-discovery/...` — pass (no existing-test regression)
- [ ] CI: full repo test suite
- [ ] Manual smoke on a deployment that has run #2456 publishers:
  - `pv -t` on a deployment-connected visor → no /tmp write, output matches HTTP.
  - SIGTERM the SD service briefly → CLI falls through to HTTP without errors.
  - Run as root then as a non-root user → no permission warnings.
  - Inspect `~/.cache/skywire/cli-fetch.db` with `bbolt buckets` — only the URLs not on CXO appear (UT etc.).

## Compatibility

  - Net-new ports, new package, all `omitempty`-equivalent additions to existing structs.
  - `FetchCachedServiceURL` signature unchanged.
  - Visor configs unaffected.
  - `/tmp/sd.skycoin.com/` and `/tmp/tpd.skywire.skycoin.com/` from older builds remain but go untouched; safe to delete manually.