### PR TITLE
feat(stats,route-calc): panic-recover sampler + route calc --by-latency

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,15 +30,16 @@ import (
 )
 
 var (
-	calcEnable   bool
-	calcDisable  bool
-	calcTimeout  time.Duration
-	tpdURL       string
-	calcMinHops  uint16
-	calcMaxHops  uint16
-	calcCount    int
-	calcSource   string
-	calcQueueCap int
+	calcEnable    bool
+	calcDisable   bool
+	calcTimeout   time.Duration
+	tpdURL        string
+	calcMinHops   uint16
+	calcMaxHops   uint16
+	calcCount     int
+	calcSource    string
+	calcQueueCap  int
+	calcByLatency bool
 )
 
 func init() {
@@ -50,6 +52,7 @@ func init() {
 	calcCmd.Flags().IntVarP(&calcCount, "count", "c", 1, "max routes to return (0 = all matching)")
 	calcCmd.Flags().StringVar(&calcSource, "source", "tpd", "transport graph source: tpd (HTTP), dht (visor's local DHT store), auto (DHT then TPD)")
 	calcCmd.Flags().IntVar(&calcQueueCap, "queue-cap", 0, "BFS queue cap (0 = server/local default ~200K, negative = unbounded)")
+	calcCmd.Flags().BoolVar(&calcByLatency, "by-latency", false, "rank routes by cumulative transport latency (lowest first); skips the streaming gRPC path since the full set has to be in hand to sort")
 	clirpc.RegisterFetchFlags(calcCmd)
 }
 
@@ -154,7 +157,10 @@ var calcCmd = &cobra.Command{
 		// holding the full result set in memory. This is the only
 		// path that can handle --count 0 (unbounded) on dense graphs
 		// without OOMing the CLI.
-		if rpcClient != nil && strings.ToLower(calcSource) != "dht" {
+		// gRPC streaming path emits routes one-by-one as the BFS
+		// finds them; sorting by latency needs the full set in hand,
+		// so --by-latency forces the local-compute path below.
+		if !calcByLatency && rpcClient != nil && strings.ToLower(calcSource) != "dht" {
 			if err := streamRoutesViaGRPC(ctx, cmd, srcPK, dstPK, minHops, calcMaxHops, calcCount, calcQueueCap, calcSource, tpdURL); err == nil {
 				return
 			} else if !isFallbackEligible(err) {
@@ -202,22 +208,61 @@ var calcCmd = &cobra.Command{
 		}
 
 		type routePair struct {
-			Forward []routing.Hop `json:"forward"`
-			Reverse []routing.Hop `json:"reverse"`
+			Forward        []routing.Hop `json:"forward"`
+			Reverse        []routing.Hop `json:"reverse"`
+			CumLatencyMS   float64       `json:"cum_latency_ms,omitempty"`
+			HasFullLatency bool          `json:"has_full_latency,omitempty"`
 		}
 		pairs := make([]routePair, len(routes))
-		var textBuf strings.Builder
 		for i, r := range routes {
 			fwd := r.Hops
-			rev := reverseHops(fwd)
-			pairs[i] = routePair{Forward: fwd, Reverse: rev}
+			pairs[i] = routePair{Forward: fwd, Reverse: reverseHops(fwd)}
+		}
+
+		// --by-latency: fetch per-visor metrics, build a tp→latency
+		// map, fold into each route, sort. Skipped when the flag is
+		// off so we don't pay the metric-fetch cost for the default
+		// no-sort emit.
+		if calcByLatency {
+			hopsView := make([][]routing.Hop, len(pairs))
+			for i := range pairs {
+				hopsView[i] = pairs[i].Forward
+			}
+			latencyByTpID, lookupErr := fetchTpLatencyMap(cmd, hopsView)
+			if lookupErr != nil {
+				fmt.Fprintf(os.Stderr, "calc: metric fetch partial failure: %v (routes still listed; some routes may sort with +Inf latency)\n", lookupErr)
+			}
+			for i := range pairs {
+				cum, allMeasured := cumulativeLatencyMS(pairs[i].Forward, latencyByTpID)
+				pairs[i].CumLatencyMS = cum
+				pairs[i].HasFullLatency = allMeasured
+			}
+			sort.SliceStable(pairs, func(i, j int) bool {
+				// All-measured wins ties against partially-measured;
+				// inside each class the lower cumulative latency wins.
+				if pairs[i].HasFullLatency != pairs[j].HasFullLatency {
+					return pairs[i].HasFullLatency
+				}
+				return pairs[i].CumLatencyMS < pairs[j].CumLatencyMS
+			})
+		}
+
+		var textBuf strings.Builder
+		for i, p := range pairs {
 			if i > 0 {
 				textBuf.WriteString("\n\n")
 			}
 			if calcCount != 1 {
-				fmt.Fprintf(&textBuf, "[%d/%d]\n", i+1, len(routes))
+				fmt.Fprintf(&textBuf, "[%d/%d]\n", i+1, len(pairs))
 			}
-			fmt.Fprintf(&textBuf, "forward: %v\nreverse: %v", fwd, rev)
+			if calcByLatency {
+				if p.HasFullLatency {
+					fmt.Fprintf(&textBuf, "cumulative latency: %.2f ms\n", p.CumLatencyMS)
+				} else {
+					fmt.Fprintf(&textBuf, "cumulative latency: %.2f ms  (some hops unmeasured)\n", p.CumLatencyMS)
+				}
+			}
+			fmt.Fprintf(&textBuf, "forward: %v\nreverse: %v", p.Forward, p.Reverse)
 		}
 		textBuf.WriteString("\n")
 
@@ -481,3 +526,96 @@ func (s *memoryStore) GetTransportMetricsByVisors(context.Context, []cipher.PubK
 	return nil, nil
 }
 func (s *memoryStore) Close() {}
+
+// transportMetricEntry mirrors the JSON shape that TPD's
+// /metrics/visor/{pks} endpoint emits per transport. Latency values
+// from that endpoint are in microseconds; the cumulative-latency
+// reporter converts to milliseconds for display.
+type transportMetricEntry struct {
+	ID      string `json:"id"`
+	Live    bool   `json:"live"`
+	Latency struct {
+		Min float64 `json:"min"`
+		Max float64 `json:"max"`
+		Avg float64 `json:"avg"`
+	} `json:"latency"`
+}
+
+// fetchTpLatencyMap pulls per-transport latency (in milliseconds)
+// for every unique visor PK appearing in the candidate routes. Uses
+// the standard CLI fetch chain (CXO subscriber → DMSG RPC → HTTP)
+// via clirpc.FetchServiceURL, so the lookup costs are amortized over
+// whichever transport is fastest for the caller's setup.
+//
+// Returns the map and a non-nil error when at least one visor's
+// metrics couldn't be fetched. The map still contains partial data
+// — callers fold any unmeasured transports into the +Inf bucket
+// during sort.
+func fetchTpLatencyMap(cmd *cobra.Command, routesHops [][]routing.Hop) (map[uuid.UUID]float64, error) {
+	uniqPKs := map[cipher.PubKey]struct{}{}
+	for _, hops := range routesHops {
+		for _, h := range hops {
+			uniqPKs[h.From] = struct{}{}
+			uniqPKs[h.To] = struct{}{}
+		}
+	}
+	if len(uniqPKs) == 0 {
+		return map[uuid.UUID]float64{}, nil
+	}
+
+	tpdBase := tpdURL
+	if tpdBase == "" {
+		tpdBase = deployment.Prod.TransportDiscovery
+	}
+	out := make(map[uuid.UUID]float64, 64)
+	var firstErr error
+	for pk := range uniqPKs {
+		url := fmt.Sprintf("%s/metrics/visor/%s", strings.TrimRight(tpdBase, "/"), pk.Hex())
+		body, err := clirpc.FetchServiceURL(cmd.Flags(), url)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %w", pk.Hex(), err)
+			}
+			continue
+		}
+		var entries []transportMetricEntry
+		if jerr := json.Unmarshal(body, &entries); jerr != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: parse metrics: %w", pk.Hex(), jerr)
+			}
+			continue
+		}
+		for _, e := range entries {
+			if !e.Live || e.Latency.Avg <= 0 {
+				continue
+			}
+			tpID, perr := uuid.Parse(e.ID)
+			if perr != nil {
+				continue
+			}
+			// TPD stores latency in microseconds; the displayed unit
+			// is milliseconds. Divide once on ingest so the rest of
+			// the pipeline (sort, sum, print) is in a single unit.
+			out[tpID] = e.Latency.Avg / 1000.0
+		}
+	}
+	return out, firstErr
+}
+
+// cumulativeLatencyMS sums per-hop latency for a route. Returns the
+// sum and a bool that's true only when every hop had a measurement;
+// unmeasured hops contribute +Inf to the sum so they sort to the
+// end and the bool flips false to surface that to the operator.
+func cumulativeLatencyMS(hops []routing.Hop, latByID map[uuid.UUID]float64) (float64, bool) {
+	var sum float64
+	allMeasured := true
+	for _, h := range hops {
+		if lat, ok := latByID[h.TpID]; ok {
+			sum += lat
+		} else {
+			sum = math.Inf(1)
+			allMeasured = false
+		}
+	}
+	return sum, allMeasured
+}

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -14,6 +14,7 @@ package stats
 import (
 	"context"
 	"encoding/json"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -180,16 +181,38 @@ func (t *Tracker) loop(ctx context.Context) {
 
 	// Take an immediate sample so the first observations don't have
 	// to wait an interval — keeps `current` populated at startup.
-	t.sample(time.Now())
+	t.safeSample(time.Now())
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case now := <-tick.C:
-			t.sample(now)
+			t.safeSample(now)
 		}
 	}
+}
+
+// safeSample wraps sample with a panic recover so a single bad
+// observation (corrupt bbolt row, probe returning unexpected nil,
+// per-day rollover edge cases) doesn't silently kill the goroutine
+// and freeze the local uptime/bandwidth view for the rest of the
+// process lifetime. Recovered panics are logged at Error level with
+// the stack so the underlying cause is locatable, then the loop
+// keeps ticking — best effort over correctness on a single
+// observation. Discovered in production where slot fills dropped
+// from ~100% to ~2% across a multi-day window with no log signal;
+// without recover the panic-once / dead-forever behavior was
+// indistinguishable from "everything is fine".
+func (t *Tracker) safeSample(now time.Time) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.log.WithField("panic", r).
+				WithField("stack", string(debug.Stack())).
+				Error("Stats sampler panicked; recovered. Continuing.")
+		}
+	}()
+	t.sample(now)
 }
 
 // sample is the per-tick body. Exposed for tests; callers pass the

--- a/pkg/visor/stats/tracker_test.go
+++ b/pkg/visor/stats/tracker_test.go
@@ -211,3 +211,59 @@ func TestRunDoubleStartIsNoop(t *testing.T) {
 	f.tracker.Run(ctx)
 	<-ctx.Done()
 }
+
+// TestSampler_RecoversFromPanic guards the production-discovered case
+// where a panic inside sample() (corrupt bbolt row, probe returning
+// unexpected nil, day-rollover edge case) silently killed the sampler
+// goroutine — and the visor process kept running for hours/days with
+// stats.db frozen at the last good write. Before the recover() in
+// loop(), this test would deadlock on the second tick assertion
+// because the goroutine would already be dead.
+//
+// The test injects a one-shot panicking probe, ticks once to trigger
+// it, then verifies subsequent ticks still produce bbolt writes.
+func TestSampler_RecoversFromPanic(t *testing.T) {
+	f := newTrackerFixture(t)
+
+	// One-shot panicking TierStates probe: first call panics, then
+	// it switches to returning a normal map so the second tick can
+	// observe a real slot write.
+	callCount := 0
+	tracker := NewTracker(f.store, Probes{
+		TierStates: func() map[string]bool {
+			callCount++
+			if callCount == 1 {
+				panic("synthetic panic in TierStates probe")
+			}
+			return map[string]bool{"process": true}
+		},
+	}, Config{SampleInterval: time.Minute, RetentionDays: 30})
+
+	// First tick — should panic INSIDE sample, recover via safeSample,
+	// and NOT propagate up.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("safeSample let a panic escape: %v", r)
+			}
+		}()
+		tracker.safeSample(time.Now())
+	}()
+
+	if callCount < 1 {
+		t.Fatalf("probe was never called on first tick")
+	}
+
+	// Second tick — probe no longer panics; the slot for "process"
+	// must be set in bbolt afterwards, proving the loop continues.
+	now := time.Now().UTC()
+	tracker.safeSample(now)
+	bm, err := f.store.TierBitmap("process", now)
+	if err != nil {
+		t.Fatalf("TierBitmap: %v", err)
+	}
+	slot := SlotForTime(now)
+	if !GetSlot(bm, slot) {
+		t.Errorf("process tier slot %d not set after recover; sampler is wedged", slot)
+	}
+}


### PR DESCRIPTION
Two unrelated reliability/UX wins bundled per request for this release.

## 1. `pkg/visor/stats`: panic-recover in the sampler loop

### Symptom

A visor was found with `stats.db` frozen at the last write **7+ hours earlier** despite the process being alive. bbolt data showed a clean cliff:

| Date | tier slots set / 288 |
|---|---|
| Apr 27 – May 5 | 100% |
| May 6 | 98.6% |
| May 7 | 90.3% |
| **May 8** | **10.8%** ← onset |
| May 9 | 1.4% |
| May 10 | 1.7% |
| May 11 | 2.4% |

File descriptor 33 still pointed at `stats.db`, no errors in logs, no panic surfaced to the operator. The visor's CLI showed `Local uptime` at 3.8% while TPD's UT reported the same visor at **76.39%** for the same day — proof the heartbeat path worked but the local sampler was wedged.

### Cause

`tracker.loop()` ran `sample()` without `defer recover()`. A panic inside `sample()` (corrupt bbolt row, probe returning unexpected nil, day-rollover edge case) silently killed the sampler goroutine. The visor kept running but the local view stayed stuck for the rest of the session.

### Fix

Wrap `sample()` in `safeSample()` with `defer recover()`. Recovered panics log at `Error` with full stack so the next occurrence locates the actual cause; the loop keeps ticking.

Regression test (`TestSampler_RecoversFromPanic`) injects a one-shot panicking probe and asserts:
- The panic does NOT propagate out of `safeSample`
- The next non-panicking tick still sets its bitmap slot

Before this fix the test would have deadlocked on the second-tick assertion because the goroutine would already be dead.

## 2. `route calc --by-latency`

Rank candidate routes by cumulative per-transport latency, lowest first.

For each route, fetch per-visor metrics via the standard CLI fetch chain (CXO subscriber → DMSG RPC → HTTP) at `/metrics/visor/{pk}`, build a tp→latency map, sum, sort ascending. Unmeasured hops fold into a `+Inf` bucket so partially-measured routes sort to the end — the route is still listed with `(some hops unmeasured)` annotated so the operator sees the caveat rather than silent omission.

### Example output

```
[1/3]
cumulative latency: 87.23 ms
forward: [<hop1> <hop2>]
reverse: [<rev1> <rev2>]

[2/3]
cumulative latency: 142.91 ms
forward: [<hop1> <hop2> <hop3>]
reverse: ...

[3/3]
cumulative latency: +Inf ms  (some hops unmeasured)
forward: [<hop1> <hop2-no-metrics>]
reverse: ...
```

### Design notes

- **Skips the gRPC streaming path.** Sorting needs the full route set in hand, so `--by-latency` forces the local-compute fallback that already collects routes into a slice. Streaming path stays untouched for the default (no-sort) case so `--count 0` performance is preserved.
- **Unit conversion at ingest.** TPD's `/metrics/visor/{pk}` reports latency in **microseconds**; the CLI converts once on ingest so the rest of the pipeline (sort, sum, print) is single-unit (ms). Worth normalizing on the TPD side eventually but out of scope here.
- **Fetch chain.** Uses `clirpc.FetchServiceURL` so the lookup gets the same CXO short-circuit / DMSG-direct / HTTP-fallback ladder every other CLI command uses.

## Test plan

- [x] `go test ./pkg/visor/stats/ -run RecoversFromPanic -v` — passes; panic stack visible in the recovered log
- [x] `go build ./...` clean
- [x] `golangci-lint run ./pkg/visor/stats/ ./cmd/skywire-cli/commands/route/` clean
- [x] `skywire cli route calc --help` shows the new flag
- [ ] In-the-wild: hit `--by-latency` against a 5-hop graph; verify routes sort and the `cumulative latency` line renders
- [ ] In-the-wild: confirm the next stats sampler panic is now Error-logged and the sampler keeps writing slots after