### PR TITLE
feat(sd,tpd,dmsgd): make CXO publishers always-on (drop --cxo flag)

### DIFF
--- a/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg/dmsg-discovery/commands/dmsg-discovery.go
@@ -44,7 +44,6 @@ var (
 	pprofMode         string
 	pprofAddr         string
 	mode              string
-	enableCXO         bool
 )
 
 func init() {
@@ -73,7 +72,6 @@ func init() {
 	// dmsg-discovery cannot run in dmsg-only mode because dmsg-servers
 	// themselves register with it over plain HTTP.
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dual (dmsg-only is rejected — dmsg-servers reach this service over HTTP)")
-	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO clients-by-server publisher feed over DMSG (requires --sk and --mode=dual)")
 }
 
 // RootCmd contains commands for dmsg-discovery
@@ -152,7 +150,6 @@ func buildConfig() (*dmsgdisc.Config, error) {
 		MetricsAddr:       sf.MetricsAddr,
 		PProfMode:         pprofMode,
 		PProfAddr:         pprofAddr,
-		EnableCXO:         enableCXO,
 	}
 
 	if keyFile != "" {
@@ -221,9 +218,6 @@ func mergeFile(dst, src *dmsgdisc.Config) {
 	}
 	if len(src.DmsgServers) > 0 {
 		dst.DmsgServers = src.DmsgServers
-	}
-	if src.EnableCXO {
-		dst.EnableCXO = true
 	}
 }
 

--- a/cmd/skycoin-skywire/README.md
+++ b/cmd/skycoin-skywire/README.md
@@ -8806,7 +8806,6 @@ Usage:
 Flags:
   -a, --addr string               address to bind to
                                    (default ":9091")
-      --cxo                       enable CXO feed for transport data distribution over DMSG
       --dmsg-disc string          url of dmsg-discovery
                                    (default "http://dmsgd.skywire.skycoin.com")
       --dmsg-server-type string   type of dmsg server on dmsghttp handler

--- a/cmd/skywire/README.md
+++ b/cmd/skywire/README.md
@@ -8804,7 +8804,6 @@ Usage:
 Flags:
   -a, --addr string               address to bind to
                                    (default ":9091")
-      --cxo                       enable CXO feed for transport data distribution over DMSG
       --dmsg-disc string          url of dmsg-discovery
                                    (default "http://dmsgd.skywire.skycoin.com")
       --dmsg-server-type string   type of dmsg server on dmsghttp handler

--- a/cmd/svc/README.md
+++ b/cmd/svc/README.md
@@ -1025,7 +1025,6 @@ Usage:
 Flags:
   -a, --addr string               address to bind to
                                    (default ":9091")
-      --cxo                       enable CXO feed for transport data distribution over DMSG
       --dmsg-disc string          url of dmsg-discovery
                                    (default "http://dmsgd.skywire.skycoin.com")
       --dmsg-server-type string   type of dmsg server on dmsghttp handler

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -42,7 +42,6 @@ var (
 	pprofAddr      string
 	entryTimeout   time.Duration
 	mode           string
-	enableCXO      bool
 )
 
 // exampleJSON marshals v to indented JSON with color, returning empty string on error
@@ -124,7 +123,6 @@ func init() {
 	// or two dropped refreshes without expiring a live entry.
 	RootCmd.Flags().DurationVar(&entryTimeout, "entry-timeout", 5*time.Minute, "client service entry TTL (0 to disable)\n\r")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
-	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO services publisher feed over DMSG (requires --sk and --mode that includes dmsg)")
 }
 
 // RootCmd contains the root service-discovery command
@@ -192,7 +190,6 @@ func buildConfig() (*sd.Config, error) {
 		Whitelist:    commaSplit(whitelistKeys),
 		GeoIP:        geoipURL,
 		DmsgPort:     dmsgPort,
-		EnableCXO:    enableCXO,
 		Dmsg: cmdutil.DmsgConfig{
 			Discovery:  dmsgDisc,
 			ServerType: dmsgServerType,
@@ -244,9 +241,6 @@ func mergeFile(dst, src *sd.Config) {
 	}
 	if src.DmsgPort != 0 {
 		dst.DmsgPort = src.DmsgPort
-	}
-	if src.EnableCXO {
-		dst.EnableCXO = true
 	}
 	if src.Dmsg.Discovery != "" {
 		dst.Dmsg.Discovery = src.Dmsg.Discovery

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -50,7 +50,6 @@ var (
 	dmsgDisc        = deployment.Prod.DmsgDiscovery
 	pprofAddr       string
 	storeDataPath   string
-	enableCXO       bool
 	mode            string
 	uptimeDB        string
 )
@@ -74,7 +73,6 @@ func init() {
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&storeDataPath, "store-data-path", tpd.DefaultStoreDataPath, "path for bandwidth backup files\n\r")
-	RootCmd.Flags().BoolVar(&enableCXO, "cxo", false, "enable CXO feed for transport data distribution over DMSG")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
 	RootCmd.Flags().StringVar(&uptimeDB, "uptime-db", tpd.DefaultUptimeDB, "path for the service-self uptime bbolt store (empty disables)")
 }
@@ -253,7 +251,6 @@ func buildConfig() (*tpd.Config, error) {
 		Whitelist:       commaSplit(whitelistKeys),
 		TestEnvironment: testEnvironment,
 		StoreDataPath:   storeDataPath,
-		EnableCXO:       enableCXO,
 		UptimeDB:        uptimeDB,
 		DmsgPort:        dmsgPort,
 		Dmsg: cmdutil.DmsgConfig{
@@ -316,9 +313,6 @@ func mergeFile(dst, src *tpd.Config) {
 	}
 	if src.StoreDataPath != "" {
 		dst.StoreDataPath = src.StoreDataPath
-	}
-	if src.EnableCXO {
-		dst.EnableCXO = true
 	}
 	if src.UptimeDB != "" {
 		dst.UptimeDB = src.UptimeDB

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -86,9 +86,10 @@ type API struct {
 
 	// cxoPublisher mirrors set/del entry events into a CXO TreeStore
 	// feed under clients-by-server/<server>/<client>/{entry,tombstone}.
-	// Set when DMSG-D is started with --cxo. Nil when the flag is off;
-	// calling sites null-check via pub == nil so the HTTP path always
-	// works regardless.
+	// Started automatically whenever DMSG-D runs with a configured
+	// SecKey + dmsg-capable mode. Nil if the publisher failed to bind
+	// or DMSG isn't enabled; calling sites null-check via pub == nil
+	// so the HTTP path always works regardless.
 	cxoPublisher *ClientsByServerCXOPublisher
 }
 
@@ -484,9 +485,10 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 				a.dhtMirror.Mirror(entry.Static, entry, entry.Sequence)
 			}
 
-			// CXO mirror — best-effort, no-op if --cxo wasn't set on
-			// startup. Server entries are ignored at this layer (the
-			// publisher only emits clients-by-server leaves).
+			// CXO mirror — best-effort, no-op if the publisher
+			// failed to start (no DMSG). Server entries are ignored
+			// at this layer (the publisher only emits
+			// clients-by-server leaves).
 			a.cxoPublisher.PublishSetEntry(nil, entry)
 
 			// Record heartbeat for uptime tracking on new client entries.

--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -51,9 +51,9 @@ import (
 var _ = json // referenced from api.go; reuse here
 
 // ClientsByServerCXOPublisher mirrors dmsg-discovery's clients-by-
-// server view into a CXO TreeStore feed. Constructed at DMSG-D
-// startup when --cxo is set; the API calls into it via
-// SetClientsByServerCXOPublisher.
+// server view into a CXO TreeStore feed. Started automatically at
+// DMSG-D startup whenever DMSG is enabled; the API calls into it
+// via SetClientsByServerCXOPublisher.
 type ClientsByServerCXOPublisher struct {
 	pub *treestore.Publisher
 	log *logging.Logger

--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -93,9 +93,11 @@ type API struct {
 	}
 
 	// cxoPublisher mirrors register / deregister events into a CXO
-	// TreeStore feed, set when SD is started with --cxo. Nil when the
-	// flag is off; the calling sites null-check via pub == nil so the
-	// HTTP path always works regardless.
+	// TreeStore feed. Started automatically whenever SD runs with a
+	// configured SecKey + dmsg-capable mode. Nil if the publisher
+	// failed to bind or DMSG isn't enabled; the calling sites
+	// null-check via pub == nil so the HTTP path always works
+	// regardless.
 	cxoPublisher *ServicesCXOPublisher
 }
 
@@ -457,7 +459,8 @@ func (a *API) postEntry(w http.ResponseWriter, r *http.Request) {
 	// Mirror the visor's FULL service list (not just this new entry) so
 	// the DHT target holds the same set as HTTP discovery for this PK.
 	a.mirrorVisorServices(r.Context(), se.Addr.PubKey())
-	// CXO mirror — best-effort, no-op if --cxo wasn't set on startup.
+	// CXO mirror — best-effort, no-op if the publisher failed to
+	// start (no DMSG).
 	a.cxoPublisher.PutEntry(&se)
 
 	httputil.WriteJSON(w, r, http.StatusOK, &se)

--- a/pkg/service-discovery/api/cxo_publisher.go
+++ b/pkg/service-discovery/api/cxo_publisher.go
@@ -39,8 +39,9 @@ import (
 )
 
 // ServicesCXOPublisher mirrors SD's services state into a CXO
-// TreeStore feed. Constructed at SD startup when --cxo is set; the
-// API calls into it via SetServicesCXOPublisher.
+// TreeStore feed. Started automatically at SD startup whenever
+// DMSG is enabled; the API calls into it via
+// SetServicesCXOPublisher.
 type ServicesCXOPublisher struct {
 	pub *treestore.Publisher
 	log *logging.Logger

--- a/pkg/services/dmsgdisc/config.go
+++ b/pkg/services/dmsgdisc/config.go
@@ -75,9 +75,6 @@ type Config struct {
 	// PProfMode / PProfAddr — pass-through to dmsgcmdutil.InitPProf.
 	PProfMode string `json:"pprof_mode,omitempty"`
 	PProfAddr string `json:"pprof_addr,omitempty"`
-	// EnableCXO turns on the CXO clients-by-server publisher feed
-	// over DMSG. Requires SecKey and a dmsg-capable Mode.
-	EnableCXO bool `json:"cxo,omitempty"`
 
 	// DmsgServers is the static dmsg-server transit set the
 	// discovery preloads at startup. Replaces the runtime read of

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -262,17 +262,15 @@ func (s *service) runDMSG(
 		}
 	}()
 
-	if cfg.EnableCXO {
-		pub, perr := api.StartClientsByServerCXOPublisher(dmsgDC, sk, log)
-		if perr != nil {
-			log.WithError(perr).Error("Failed to start CXO clients-by-server publisher, continuing without it")
-		} else {
-			a.SetClientsByServerCXOPublisher(pub)
-			go func() {
-				<-ctx.Done()
-				pub.Close() //nolint:errcheck,gosec
-			}()
-		}
+	pub, perr := api.StartClientsByServerCXOPublisher(dmsgDC, sk, log)
+	if perr != nil {
+		log.WithError(perr).Error("Failed to start CXO clients-by-server publisher, continuing without it")
+	} else {
+		a.SetClientsByServerCXOPublisher(pub)
+		go func() {
+			<-ctx.Done()
+			pub.Close() //nolint:errcheck,gosec
+		}()
 	}
 
 	return nil

--- a/pkg/services/sd/config.go
+++ b/pkg/services/sd/config.go
@@ -40,9 +40,6 @@ type Config struct {
 	// DmsgPort is the dmsghttp listener port (default 80).
 	DmsgPort uint16 `json:"dmsg_port,omitempty"`
 
-	// EnableCXO turns on the CXO services publisher feed over DMSG.
-	EnableCXO bool `json:"enable_cxo,omitempty"`
-
 	// Dmsg is the dmsg-related config block — same shape across
 	// every deployment service that uses it.
 	Dmsg cmdutil.DmsgConfig `json:"dmsg,omitempty"`

--- a/pkg/services/sd/sd.go
+++ b/pkg/services/sd/sd.go
@@ -182,10 +182,8 @@ func (s *service) Run(ctx context.Context) error {
 	}
 	defer h.Close()
 
-	if cfg.EnableCXO && h.DmsgClient != nil {
+	if h.DmsgClient != nil {
 		s.startServicesCXO(runCtx, h.DmsgClient, sdAPI, sk, log)
-	} else if cfg.EnableCXO {
-		log.Warn("CXO requested but dmsg is not enabled (--mode=http); services publisher disabled")
 	}
 
 	select {

--- a/pkg/services/tpd/config.go
+++ b/pkg/services/tpd/config.go
@@ -41,8 +41,6 @@ type Config struct {
 
 	// StoreDataPath is the on-disk path for bandwidth backup files.
 	StoreDataPath string `json:"store_data_path,omitempty"`
-	// EnableCXO turns on the CXO aggregator + metrics publisher.
-	EnableCXO bool `json:"enable_cxo,omitempty"`
 	// UptimeDB is the local self-uptime bbolt store path. Empty
 	// disables service-self uptime recording.
 	UptimeDB string `json:"uptime_db,omitempty"`

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -244,10 +244,8 @@ func (s *service) Run(ctx context.Context) error {
 	}
 	defer h.Close()
 
-	if cfg.EnableCXO && h.DmsgClient != nil {
+	if h.DmsgClient != nil {
 		s.startCXO(runCtx, h, st, tpdAPI, sk, logger)
-	} else if cfg.EnableCXO {
-		logger.Warn("CXO requested but dmsg is not enabled (--mode=http); aggregator/publisher disabled")
 	}
 
 	select {

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -135,10 +135,10 @@ func NewHypervisor(config visorconfig.HypervisorConfig, visor *Visor, dmsgC *dms
 		hv.tpvizServer.SetVisorAPI(adapter, visor.conf.PK.Hex())
 		// Wire the on-demand CXO subscription manager so /api/services
 		// (and future per-feed handlers) can serve from the local SD /
-		// DMSG-D subscriber tree when --cxo is enabled on those
-		// services. cxoSubMgrAdapter forwards int tab/feed identifiers
-		// from tpviz to the typed CXOTab / CXOFeed values used by the
-		// manager — values match across both sides by construction.
+		// DMSG-D subscriber tree. cxoSubMgrAdapter forwards int
+		// tab/feed identifiers from tpviz to the typed CXOTab /
+		// CXOFeed values used by the manager — values match across
+		// both sides by construction.
 		hv.tpvizServer.SetCXOSubMgr(&cxoSubMgrAdapter{v: visor})
 		hv.tpvizServer.Start()
 	}


### PR DESCRIPTION
## Summary

- The CXO publishers in service-discovery, transport-discovery, and dmsg-discovery were gated behind a `--cxo` flag + `EnableCXO` config field. The visor-side subscribers have **no equivalent gate** — they probe every cycle regardless — so when a visor is rolled out before each deployment service has the flag flipped on, operators see persistent `sd-services: cache miss` (and friends) debug noise even though everything is otherwise configured correctly.
- The publishers' real precondition is already a DMSG client + secret key, which is enforced by the existing `h.DmsgClient != nil` / `runDMSG` block. Start them unconditionally inside that block; remove the flag, the config field, and the now-dead "--mode=http; publisher disabled" warnings.
- Stale comments under `pkg/{service-discovery,dmsg/discovery}/api` and `pkg/visor/hypervisor.go` updated to drop the "when `--cxo` is set" phrasing.

## Test plan

- [ ] `go build ./...` (passes)
- [ ] `go vet ./pkg/services/... ./cmd/svc/... ./cmd/dmsg/...` (clean)
- [ ] `go test ./pkg/service-discovery/api/... ./pkg/dmsg/discovery/api/...` (both packages pass; redis-store tests in `pkg/dmsg/discovery/store` fail with `NOAUTH` in this env — unrelated to the change)
- [ ] Deploy SD/TPD/DMSG-D, confirm `CXO ... publisher running` lines in each service's log without any `--cxo` flag on the compose `command:` list
- [ ] Run `skywire cli tp -m` against a visor — first call still misses (cycle hasn't completed), subsequent calls within the 5min cycle hit