### PR TITLE
fix(cli/skychat): drop redundant \n in listen banner Println (vet)

### DIFF
--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -137,7 +137,7 @@ var listenCmd = &cobra.Command{
 		if filter != "" {
 			fmt.Printf(" (filter: %s)", filter)
 		}
-		fmt.Println("\nPress Ctrl+C to stop\n")
+		fmt.Print("\nPress Ctrl+C to stop\n\n")
 
 		resp, err := http.Get(url) //nolint:gosec
 		if err != nil {


### PR DESCRIPTION
## Summary
- `cmd/skywire-cli/commands/skychat/root.go:140` had `fmt.Println("\nPress Ctrl+C to stop\n")`. The literal carried its own trailing `\n` *and* `Println` appends one, which `go vet` flags as `fmt.Println arg list ends with redundant newline`.
- Switched to `fmt.Print("\nPress Ctrl+C to stop\n\n")` so the intended blank-line gap before the SSE stream starts is preserved.

## Test plan
- [x] `CGO_ENABLED=0 GO111MODULE=on go vet -mod=vendor -tags 'withoutsystray withoutgotop' ./...` → exit 0
- [x] `make check` (local) → 0 issues
- [x] Manual `./skywire cli skychat listen` formatting unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)