### PR TITLE
fix(cxo/node): plug Connection read/write-loop goroutine leak

### DIFF
--- a/pkg/cxo/node/transport/connection.go
+++ b/pkg/cxo/node/transport/connection.go
@@ -76,6 +76,14 @@ func (c *Connection) GetChanIn() <-chan []byte {
 }
 
 func (c *Connection) readLoop() {
+	// On any exit (read error, peer drop, size violation) tear down
+	// the whole Connection so the paired writeLoop's `<-c.done`
+	// select unblocks. Without this, a passive remote-side drop
+	// leaves writeLoop parked in the select forever — Close is
+	// only called from upper layers, and not every code path that
+	// loses a peer reaches one. Close is idempotent so the paired
+	// defer in writeLoop is safe.
+	defer c.Close()
 	defer close(c.in)
 
 	header := make([]byte, 4)
@@ -101,6 +109,11 @@ func (c *Connection) readLoop() {
 }
 
 func (c *Connection) writeLoop() {
+	// Mirrors readLoop's defer: tear down the Connection on any
+	// exit so the paired readLoop's io.ReadFull unblocks (via the
+	// underlying conn.Close inside Close). Close is idempotent.
+	defer c.Close()
+
 	header := make([]byte, 4)
 	for {
 		select {

--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -122,18 +122,27 @@ func (d *DMSG) acceptConn(fc *transport.Connection) {
 	}
 }
 
-// closeConn removes the cached entry that matches the given conn.
-// Called from Conn.run() cleanup so a dead DMSG conn does not persist
-// in d.cs and short-circuit subsequent ConnectPK calls.
+// closeConn closes the underlying transport.Connection and removes
+// the cached entry that matches the given conn. Called from
+// Conn.run() cleanup so a dead DMSG conn does not persist in d.cs
+// (which would short-circuit subsequent ConnectPK calls) and so the
+// read/write loops attached to the transport.Connection actually
+// exit (closing c.Connection signals their `<-c.done` selects).
 //
-// Without this, when the *remote* CXO node restarts (and its old
-// per-conn state goes away) the local side's dmsg session survives
-// — but the cxo Conn on top is dead. ConnectPK's existing-conn
-// cache hit then returns the dead conn, the publisher's AnnounceTo
-// never re-handshakes, and from the remote aggregator's point of
-// view that publisher is silent forever (until the publisher itself
-// restarts). closeConn is the symmetric undo for addConn so the
-// cache stays consistent with the live conn set.
+// Without the cache delete, when the *remote* CXO node restarts
+// (and its old per-conn state goes away) the local side's dmsg
+// session survives — but the cxo Conn on top is dead. ConnectPK's
+// existing-conn cache hit then returns the dead conn, the
+// publisher's AnnounceTo never re-handshakes, and from the remote
+// aggregator's point of view that publisher is silent forever
+// (until the publisher itself restarts).
+//
+// Without the Close, every dropped peer leaks the transport-level
+// readLoop and writeLoop goroutines. Observed in production after
+// ~7h uptime: 36,609 Connection.writeLoop goroutines parked in the
+// `<-c.done` select forever (one per peer ever connected),
+// dragging GC scanstack to 25% of CPU. TCP.closeConn and
+// UDP.closeConn already do this; DMSG was missing it.
 //
 // Iterating to find c is fine: d.cs is bounded by peer count, and
 // this fires only on conn teardown — not in the hot path.
@@ -143,8 +152,11 @@ func (d *DMSG) closeConn(c *Conn) {
 	for pk, cached := range d.cs {
 		if cached == c {
 			delete(d.cs, pk)
-			return
+			break
 		}
+	}
+	if !c.Connection.IsClosed() {
+		c.Connection.Close()
 	}
 }
 


### PR DESCRIPTION
## Summary

Production SD on the deployment host after ~7h uptime: **37,073 goroutines, 36,609 of them parked in `cxo/node/transport.(*Connection).writeLoop` ↓** waiting on `<-c.done`. Leak rate ~5,200 writeLoops/hour, growing strictly monotonically since process start. GC `scanstack` at 25% of CPU; total CPU 169% with 85.55% inside `runtime.systemstack → gcBgMarkWorker → gcDrain` chewing the bloated heap.

Root cause: a passive remote drop trips `readLoop`'s `io.ReadFull` → it returns (closing `c.in` via its defer) but **never closes `c.done`**. The paired `writeLoop` is parked in `select { case <-c.out: …; case <-c.done: return }` and only unblocks if someone calls `Connection.Close()`. `Connection.Close` was being called from upper layers inconsistently — and specifically `DMSG.closeConn(c *Conn)` in `pkg/cxo/node/transport_dmsg.go:140` was removing the cached `*Conn` entry but never closing the `transport.Connection`, while the matching `TCP.closeConn` / `UDP.closeConn` already do.

## Fix

Two changes, defense at two layers:

1. **`pkg/cxo/node/transport/connection.go`** — `defer c.Close()` at the top of both `readLoop` and `writeLoop`. Whichever loop notices the failure first tears the whole Connection down: the deferred `Close` shuts the underlying `net.Conn` (unblocking the paired loop's I/O) and closes `c.done` (unblocking the paired loop's select). `Close` already short-circuits via its `closed` flag, so a paired double-call is a no-op. Protects any future transport that forgets to call `Connection.Close` on the upper layer.

2. **`pkg/cxo/node/transport_dmsg.go`** — `DMSG.closeConn` now does `IsClosed` check + `Connection.Close()` after the cache delete, mirroring `TCP.closeConn` / `UDP.closeConn`. The proximate leak site even before adding the defer.

Either change alone plugs the leak. Both together hold the invariant *"if the Connection is no longer in use, its goroutines are gone"* at two layers, so the next person who adds a transport doesn't have to know to call Close.

## Test plan

- [x] `go build ./...` (passes)
- [x] `go vet ./pkg/cxo/...` (clean)
- [ ] Deploy SD/DMSG-D; watch `/debug/pprof/goroutine?debug=1` — success = total goroutine count stays under ~1k and `writeLoop` count tracks current connection count (not climbing across peer churn)
- [ ] Verify CPU drops from 169% as the GC scanstack pressure clears

Pprof artifacts that motivated this fix: `/home/skywire/skywire_test/pprof-20260512-0949/` on the prod-deployment host.