### PR TITLE
perf(cipher,dmsgd): halve hex-encode allocs on MarshalText + dedupe in hot map

### DIFF
--- a/pkg/cipher/cipher.go
+++ b/pkg/cipher/cipher.go
@@ -4,6 +4,7 @@ package cipher
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strings"
@@ -131,9 +132,15 @@ func (pk PubKey) Type() string {
 	return "cipher.PubKey"
 }
 
-// MarshalText implements encoding.TextMarshaler.
+// MarshalText implements encoding.TextMarshaler. Writes hex bytes
+// directly into a freshly-allocated buffer instead of going through
+// `[]byte(pk.Hex())`, which would round-trip through an intermediate
+// string allocation. Halves the per-marshal allocation in the
+// jsoniter / dmsg-discovery hot path that serializes lots of PKs.
 func (pk PubKey) MarshalText() ([]byte, error) {
-	return []byte(pk.Hex()), nil
+	out := make([]byte, hex.EncodedLen(len(pk)))
+	hex.Encode(out, pk[:])
+	return out, nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
@@ -227,9 +234,12 @@ func (sk *SecKey) Type() string {
 	return "cipher.SecKey"
 }
 
-// MarshalText implements encoding.TextMarshaler.
+// MarshalText implements encoding.TextMarshaler. See PubKey.MarshalText
+// for the rationale on skipping the intermediate string allocation.
 func (sk SecKey) MarshalText() ([]byte, error) {
-	return []byte(sk.Hex()), nil
+	out := make([]byte, hex.EncodedLen(len(sk)))
+	hex.Encode(out, sk[:])
+	return out, nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
@@ -279,9 +289,12 @@ func (sig Sig) Null() bool {
 	return sig == Sig{}
 }
 
-// MarshalText implements encoding.TextMarshaler.
+// MarshalText implements encoding.TextMarshaler. See PubKey.MarshalText
+// for the rationale on skipping the intermediate string allocation.
 func (sig Sig) MarshalText() ([]byte, error) {
-	return []byte(sig.Hex()), nil
+	out := make([]byte, hex.EncodedLen(len(sig)))
+	hex.Encode(out, sig[:])
+	return out, nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.

--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -724,7 +724,12 @@ func (a *API) allClientsByServer() http.HandlerFunc {
 			}
 			clientPK := entry.Static.Hex()
 			for _, serverPK := range entry.Client.DelegatedServers {
-				result[serverPK.Hex()] = append(result[serverPK.Hex()], clientPK)
+				// Hex once per (entry, server) pair — previously
+				// called twice per inner iter (map key + value
+				// lookup), doubling the hex-encode load on every
+				// invocation of this endpoint.
+				sHex := serverPK.Hex()
+				result[sHex] = append(result[sHex], clientPK)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Production dmsg-discovery alloc_space (30s capture on a fresh container, ~405 MB allocated, 13.5 MB/s sustained) was dominated by hex encoding:

| % | Site |
|---|---|
| 16.26 % | `encoding/hex.EncodeToString` (66 MB flat) |
| 4.94 / 11.55 % | `json-iterator.Marshal` (calls `TextMarshaler` on every `cipher.PubKey` field) |
| 4.27 % | `json-iterator.Stream.WriteString` |

Two cheap wins, no behavioral change:

1. **`pkg/cipher/cipher.go`** — `PubKey` / `SecKey` / `Sig` `MarshalText` used to be `[]byte(pk.Hex())`, which round-trips through an intermediate string (`hex.EncodeToString` allocs 66 B for the string, then `[]byte(s)` copies it into a 66 B slice). Replace with a direct `hex.Encode` into a single freshly-allocated slice — halves the per-marshal allocation and matches what every other stdlib `TextMarshaler` does (`uuid`, `big.Int`, etc.).

2. **`pkg/dmsg/discovery/api/api.go`** — `allClientsByServer` was calling `serverPK.Hex()` **twice** per inner iter (once for the map key lookup, once for the append target). Hoist into a local. For the production ~700-client × ~3-server population that's a 4× reduction in hex calls on the hot endpoint feeding the network visualizer.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/cipher/... ./pkg/dmsg/discovery/...`
- [x] `go test ./pkg/cipher/...` (passes)
- [x] `go test ./pkg/dmsg/discovery/api/...` (passes)
- [ ] After deploy, capture another alloc_space pprof on dmsgd — expect the `encoding/hex` row to drop materially (theoretically by ~50% from change 1, plus the `clientsByAllServers` contribution which depends on call frequency).

## Not addressed

This doesn't touch the broader json-iterator path (custom encoder hooks would let us write hex directly into the stream's buffer and skip the per-PK 66 B alloc entirely — a more invasive change for a follow-up if the dmsgd alloc rate still bites after this lands).