### PR TITLE
fix(cli): operator-UX bundle — config template + WARN, router/proxy clarity

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -58,7 +58,7 @@ const envfileLinux = `#
 #DISABLEPUBLICAUTOCONN=true
 
 #-- Add transport setup public keys
-#TPSETUPPKS('')
+#TPSETUPPKS=('')
 
 ### Ports ###############################################################
 #	Note: when generating a test deployment config (-t / TESTENV=true),
@@ -74,7 +74,7 @@ const envfileLinux = `#
 ### Routing #############################################################
 
 #-- Add route setup-node public keys
-#ROUTESETUPPKS('')
+#ROUTESETUPPKS=('')
 
 #--	Enable local route calculation (instead of using route finder)
 #CALCULATEROUTES=true
@@ -85,12 +85,12 @@ const envfileLinux = `#
 #HYPERVISORPKS=('')
 
 #--	Grant access to pseudoterminal (pty) for public keys
-#DMSGPTYPKS('')
+#DMSGPTYPKS=('')
 
 ### Survey Access #######################################################
 
 #--	Grant access for survey collection to these public keys
-#SURVEYPKS('')
+#SURVEYPKS=('')
 
 ### Hypervisor UI #######################################################
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -557,8 +557,22 @@ var genConfigCmd = &cobra.Command{
 					if err != nil {
 						log.Error("cannot stat: /root")
 					}
-					if (owner != rootOwner) && isRoot {
-						log.Warn("writing config as root to directory not owned by root")
+					owner = strings.TrimSpace(owner)
+					rootOwner = strings.TrimSpace(rootOwner)
+					// The package case (-p, /opt/skywire owned by the
+					// 'skywire' sysusers user) intentionally has root
+					// writing into a non-root-owned directory — the
+					// daemon either runs as root or `skywire autoconfig`
+					// chowns the install to SKYWIRE_USER afterwards.
+					// The old unconditional warn fired on every
+					// `sudo skywire autoconfig`, masquerading
+					// expected behavior as a problem. Suppress it for
+					// the explicit -p case and add the actual path to
+					// the message for the cases where it really is a
+					// surprise (e.g. `sudo config gen` defaulting to
+					// /home/$user/skywire-config.json).
+					if (owner != rootOwner) && isRoot && !isPkgEnv {
+						log.Warnf("writing config as root to %s (owned by %q, not root); pass -p for the package path or -o to choose explicitly", confPath, owner)
 					}
 					if !isRoot && (owner == rootOwner) {
 						log.Fatal("Insufficient permissions to write to the specified path")

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -133,18 +133,21 @@ var startCmd = &cobra.Command{
 			rpcClient.StopApp("skysocks-client") //nolint:errcheck,gosec
 		}
 
-		// If --existing-tp flag is set, configure router to only use existing transports
-		if existingTpOnly {
-			if err := rpcClient.SetExistingTPOnly(true); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set existing transport only mode: %w", err))
-			}
+		// Both --existing-tp and --local-route map onto persistent
+		// visor state via RPC: a previous `proxy start --local-route`
+		// leaves the router permanently in forceLocal mode until the
+		// visor restarts. The flags were never "auto-rolled-back" on
+		// the next invocation, which means a subsequent
+		// `proxy start <pk>` (no flags) silently inherits the old
+		// state and fails when the new target isn't reachable under
+		// that constraint. Always SetExistingTPOnly / SetForceLocalRoutes
+		// to exactly the current flag value so the visor mirrors what
+		// the operator just typed.
+		if err := rpcClient.SetExistingTPOnly(existingTpOnly); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set existing transport only mode: %w", err))
 		}
-
-		// If --local-route flag is set, skip route finder and use local route calculation
-		if forceLocalRoutes {
-			if err := rpcClient.SetForceLocalRoutes(true); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set force local routes mode: %w", err))
-			}
+		if err := rpcClient.SetForceLocalRoutes(forceLocalRoutes); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set force local routes mode: %w", err))
 		}
 
 		// If --mux flag is set, enable route multiplexing.

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -320,7 +320,19 @@ var startCmd = &cobra.Command{
 
 			for _, state := range states {
 				if state.Name == stateName {
-					if state.Status == appserver.AppStatusRunning {
+					// Bare Status flips to Running as soon as the OS
+					// process is alive — well before the app has
+					// dialed its remote. Skysocks-client (and friends)
+					// set DetailedStatus = "Starting" while inside
+					// their dial-retry loop, then flip to "Running"
+					// once the conn is established. To make
+					// `proxy start --verbose`'s "app running" banner
+					// honest, treat "Starting" as not-yet-ready and
+					// keep polling. Apps that never emit a detailed
+					// status leave it empty, so we still graduate on
+					// bare Status for those.
+					detailedStarting := state.DetailedStatus == appserver.AppDetailedStatusStarting
+					if state.Status == appserver.AppStatusRunning && !detailedStarting {
 						startProcess = false
 						appReachedRunning = true
 						if !startVerbose {

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -173,7 +173,7 @@ restarts). Exit with Ctrl+C.`,
 				// reconnect prompt rather than an error.
 				delay = minReconnectDelay
 			} else {
-				fmt.Fprintf(cmd.ErrOrStderr(),
+				fmt.Fprintf(cmd.ErrOrStderr(), //nolint:errcheck
 					"skychat listen: %v (reconnecting in %s)\n", err, delay)
 			}
 

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -312,7 +312,15 @@ func resolveConfig() resolvedConfig {
 // autoconfig's post-Stat check and aborts the postinst with
 // exit 100. Propagating the resolved mode explicitly closes the gap.
 func generateConfig(r resolvedConfig, hvArg string) error {
-	args := []string{"cli", "config", "gen", "-r"}
+	// `-w` / `--hide` suppresses the generated config from being
+	// echoed to stdout. autoconfig is meant for unattended
+	// systemd/postinst invocation — dumping the visor's SK + every
+	// service URL through the terminal at every install is both
+	// noisy (the file is the authoritative copy) and a perceived
+	// secret-leak risk on shared terminals / CI logs. The Stdout
+	// pipe we hook up below is still useful for errors; `-w` only
+	// hides the success-path JSON dump.
+	args := []string{"cli", "config", "gen", "-r", "-w"}
 
 	switch {
 	case r.pkgEnv:

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -82,15 +82,33 @@ func (r *router) DialRoutes(
 	}
 
 	// Retry route setup with fresh routes if it fails due to stale TPD data.
-	// Route-finder may return routes with non-existent transports (TPD sync issues),
-	// so we query for fresh routes on each retry instead of retrying the same bad route.
+	// Route-finder may return routes with non-existent transports (TPD sync
+	// issues), so we query for fresh routes on each retry instead of retrying
+	// the same bad route.
+	//
+	// With --local-route enabled, fetchBestRoutes runs calculateLocalRoutes
+	// instead — that's deterministic over the local transport graph, so a
+	// retry against the same graph state would just burn CPU rebuilding the
+	// transport cache (~1s, 1.5k entries) for the same answer. Fail fast in
+	// that mode, and don't emit the "Route finder failed" wording either,
+	// since no route-finder query was ever made.
+	r.forceLocalRoutesMu.Lock()
+	forceLocal := r.forceLocalRoutes
+	r.forceLocalRoutesMu.Unlock()
 	const maxRetries = 3
+	maxFetchAttempts := maxRetries
+	if forceLocal {
+		maxFetchAttempts = 1
+	}
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
 		if err != nil {
-			if attempt < maxRetries {
+			if attempt < maxFetchAttempts {
 				log.WithError(err).Warnf("Route finder failed (attempt %d/%d), retrying with fresh query...", attempt, maxRetries)
 				continue
+			}
+			if forceLocal {
+				return nil, fmt.Errorf("local route calc: %w", err)
 			}
 			return nil, fmt.Errorf("route finder: %w", err)
 		}
@@ -308,13 +326,28 @@ func (r *router) PingRoute(
 		return r.setupPingRoute(ctx, forwardDesc, forwardPath, reversePath, rPK, opts)
 	}
 
+	// Same fail-fast logic for ping: with --local-route on, the
+	// fetch is deterministic so 3× the same calc just wastes ~3s
+	// of cache rebuilds. The "Ping route finder failed" wording is
+	// equally misleading when no route finder was queried.
+	r.forceLocalRoutesMu.Lock()
+	pingForceLocal := r.forceLocalRoutes
+	r.forceLocalRoutesMu.Unlock()
 	const maxRetries = 3
+	pingMaxFetch := maxRetries
+	if pingForceLocal {
+		pingMaxFetch = 1
+	}
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
 		if err != nil {
-			lastErr = fmt.Errorf("route finder: %w", err)
-			if attempt < maxRetries {
+			if pingForceLocal {
+				lastErr = fmt.Errorf("local route calc: %w", err)
+			} else {
+				lastErr = fmt.Errorf("route finder: %w", err)
+			}
+			if attempt < pingMaxFetch {
 				log.WithError(err).Warnf("Ping route finder failed (attempt %d/%d), retrying...", attempt, maxRetries)
 				continue
 			}


### PR DESCRIPTION
Five small CLI/operator-UX fixes that surfaced together while debugging a node operator's `skywire autoconfig` SK-mismatch. None bundled because the diff is large — bundled because they're all triggered by the same `skywire autoconfig` / `proxy start` invocation chain and ship better as one set.

## Config template + gen warn

- **`cli config gen -q` template**: 4 bash array lines missed the `=` (`TPSETUPPKS('')` → `TPSETUPPKS=('')`, plus `ROUTESETUPPKS`, `DMSGPTYPKS`, `SURVEYPKS`). Operators uncommenting any of them got "command not found" instead of an empty array, silently breaking the autoconfig sourcing. PowerShell variant of the same template had `=@('')` correctly throughout; bash side only.
- **`config gen` ownership WARN**: previously emitted `writing config as root to directory not owned by root` on every `sudo skywire autoconfig` (because `-p` resolves to /opt/skywire, which is intentionally owned by the `skywire` sysusers user). Operators chased imagined breakage. Suppress under `-p`/PKGENV; for the genuine-surprise case, include the actual path + owner + hint:

      writing config as root to /home/node/skywire-config.json
      (owned by "node", not root); pass -p for the package path
      or -o to choose explicitly

## Router / proxy clarity

- **`fix(router): honest log + fail-fast when --local-route fails`** — the retry loop logged "Route finder failed (attempt N/3)" even though `fetchBestRoutes` had run `calculateLocalRoutes` (no RF query). Each retry rebuilt the ~1.5k-entry transport cache (~1s) for the same deterministic answer. Now: fail fast under `--local-route`, and wrap the final error as `local route calc:` not `route finder:`.
- **`fix(cli/proxy): "app running" banner waits for DetailedStatus`** — `--verbose` declared the app running as soon as the OS process was alive, while it was still inside skysocks-client's `dialServer` retry loop. Wait for `DetailedStatus != "Starting"` so the banner reflects the connected state.
- **`fix(cli/proxy): always reflect --local-route / --existing-tp state`** — `SetForceLocalRoutes` / `SetExistingTPOnly` are persistent visor-side RPC state; a previous `--local-route` run left the router in that mode until visor restart, and a subsequent `proxy start <pk>` silently inherited it. Always pass the current flag value, even when false.

## Test plan

- [x] `./skywire cli config gen -q | grep -E '#?[A-Z_]+\\('` → 0 bare-paren lines
- [x] `sudo SKYENV=/etc/skywire.conf ./skywire cli config gen -r -p` → no WARN
- [x] `./skywire cli config gen -r` (non-root, root-owned dir) → still log.Fatal as before
- [x] `./skywire cli proxy start --local-route --existing-tp <unreachable-pk>` → 1 "local route calc" error instead of 3 "Route finder failed" retries
- [x] `./skywire cli proxy start --pk <pk> --verbose` against a real visor → "app running" only after dial succeeds
- [x] `./skywire cli proxy start --local-route` then `./skywire cli proxy start <pk>` → second run isn't stuck in forceLocal mode
- [x] `go vet -tags 'withoutsystray withoutgotop' ./...` → exit 0
- [x] `golangci-lint run` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)