### PR TITLE
ci(deploy): serialize Deploy runs per-branch via concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,21 @@ on:
       - develop
       - master
 
+# Serialize Deploy runs per-branch so a rapid burst of merges (e.g.
+# three back-to-back PRs landing on develop within seconds) doesn't
+# race on `docker push :test` — without this the second-to-finish
+# Deploy overwrites the last-to-finish Deploy's image, and the hub
+# tag ends up pointing at whichever build happened to finish last,
+# not at the latest commit. Observed in production on 2026-05-12:
+# PRs #2499 and #2500 merged 4 s apart; both Deploys started, but
+# the #2499 Deploy ran 12 s longer and its `docker push test`
+# overwrote the #2500 build that had pushed seconds earlier.
+# cancel-in-progress is OFF so every commit still gets its own
+# build — they just queue.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

PRs #2499 and #2500 merged ~4 s apart on develop. Both push events fired their own Deploy run; both ran in parallel. The #2499 Deploy took 3m48s, the #2500 Deploy took 3m36s — so the **later-merged** #2500 finished **first** and pushed `docker.io/skycoin/skywire:test`, then the earlier-merged #2499 finished and overwrote it. End result: hub `:test` was built from #2499 even though develop tip was #2500, and the production autopull deployed code that didn't include the perf fix the operator was waiting on. Diagnosis cost an hour of "did #2500 not take?" measurements.

## Why it raced

`docker_build.sh` correctly passes the checked-out commit through to `go install @${commit}` (so each Deploy builds the right binary). The `:test` tag, however, is shared mutable state with no ordering guarantee — whoever runs `docker push` last wins, regardless of which commit triggered the run.

## Fix

Add a concurrency group keyed by branch. New Deploys queue behind in-flight ones. `cancel-in-progress: false` so every commit still gets its own build (we want the SDK / `/health` endpoints to reflect each merge), the queue just preserves push order.

Single-block diff to `.github/workflows/deploy.yml`. No source-tree changes.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm the next two back-to-back develop merges run their Deploys serially (the second shows as "queued — waiting for concurrency group" until the first finishes).
- [ ] After both complete, `docker.io/skycoin/skywire:test` carries the **later** commit's binary.