### PR TITLE
feat(autoconfig,skyenv): native-Go env-file parser; Windows-aware autoconfig (phase 1)

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -32,6 +32,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -137,14 +138,14 @@ Mode is selected by PKGENV/USRENV in the env file:
 				if resolved.skyenvPath != "" {
 					return resolved.skyenvPath
 				}
-				return "implicit fallback (no /etc/skywire.conf)"
+				return "implicit fallback (no " + defaultSkyenvPath() + ")"
 			}())
 			fmt.Printf("            if %s is commented out in %s, uncomment it and re-run `skywire autoconfig`\n",
 				mode, func() string {
 					if resolved.skyenvPath != "" {
 						return resolved.skyenvPath
 					}
-					return "/etc/skywire.conf"
+					return defaultSkyenvPath()
 				}())
 			os.Exit(100)
 		}
@@ -165,7 +166,7 @@ Mode is selected by PKGENV/USRENV in the env file:
 		// files and writing under /etc/systemd/system/ both need it.
 		// When run as the target user already, we skip both branches
 		// and let the operator manage them out of band.
-		if !resolved.usrEnv && os.Geteuid() == 0 {
+		if runtime.GOOS == "linux" && !resolved.usrEnv && os.Geteuid() == 0 {
 			daemonReload := false
 			switch {
 			case resolved.skywireUser != "":
@@ -201,7 +202,11 @@ Mode is selected by PKGENV/USRENV in the env file:
 
 		// SKYBIAN auto-start: legacy appliance bootstrap. Limited to
 		// PKGENV mode; user-mode appliances aren't a thing.
-		if !resolved.useUserUnit && os.Getenv("SKYBIAN") == "true" {
+		// Linux-only — Windows service registration is the Phase 2
+		// piece of the autoconfig parity project (see project memory
+		// project_windows_autoconfig_parity.md). For now Windows
+		// operators run `skywire visor` directly after autoconfig.
+		if runtime.GOOS == "linux" && !resolved.useUserUnit && os.Getenv("SKYBIAN") == "true" {
 			msg3("Enabling skywire service and starting...")
 			_ = exec.Command("systemctl", "enable", "--now", "skywire.service").Run() //nolint:errcheck,gosec
 		}
@@ -261,6 +266,23 @@ Mode is selected by PKGENV/USRENV in the env file:
 	},
 }
 
+// defaultSkyenvPath returns the canonical SKYENV file location for
+// the host OS. Linux uses /etc/skywire.conf (FHS); Windows uses
+// %ProgramData%\Skywire\skywire.conf (the equivalent system-wide
+// configuration path — picked up by an elevated Notepad or the
+// %ProgramData% environment variable). Anything else falls back to
+// the Linux path so darwin / freebsd builds keep their previous
+// behavior; they're not formally supported here but shouldn't regress.
+func defaultSkyenvPath() string {
+	if runtime.GOOS == "windows" {
+		if pd := os.Getenv("ProgramData"); pd != "" {
+			return filepath.Join(pd, "Skywire", "skywire.conf")
+		}
+		return `C:\ProgramData\Skywire\skywire.conf`
+	}
+	return "/etc/skywire.conf"
+}
+
 // resolveConfig reads the skyenv file and translates it to the
 // concrete answers downstream code needs. Falls back gracefully to
 // the legacy PKGENV-on-root behavior when the file is silent.
@@ -268,8 +290,9 @@ func resolveConfig() resolvedConfig {
 	r := resolvedConfig{}
 	r.skyenvPath = os.Getenv("SKYENV")
 	if r.skyenvPath == "" {
-		if _, err := os.Stat("/etc/skywire.conf"); err == nil {
-			r.skyenvPath = "/etc/skywire.conf"
+		candidate := defaultSkyenvPath()
+		if _, err := os.Stat(candidate); err == nil {
+			r.skyenvPath = candidate
 		}
 	}
 
@@ -385,7 +408,17 @@ func writeSystemdDropIn(username string) error {
 // configured user. Skipped silently if the user doesn't exist
 // (common during a partial install where postinstall hasn't created
 // the user yet); the operator sees a warning instead.
+//
+// Windows: POSIX uid/gid don't translate. SKYWIRE_USER on Windows is
+// resolved at Service install time by setting the service's run-as
+// account, not by chmodding files — see project memory
+// project_windows_autoconfig_parity.md Phase 2 for the ServiceInstall
+// integration. Returns nil here so the caller's "Warning: chown
+// failed" branch doesn't fire for a no-op.
 func chownInstall(username string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	u, err := user.Lookup(username)
 	if err != nil {
 		return fmt.Errorf("user %q not found: %w", username, err)
@@ -405,10 +438,20 @@ func chownInstall(username string) error {
 }
 
 // restartOrPrompt branches on the resolved mode to pick the right
-// systemctl invocation. Active unit → restart; inactive → print the
-// command the operator should run to enable+start it. Never tries to
-// auto-enable: respects operator intent.
+// service-manager invocation. Linux: systemctl. Windows: defer to
+// Phase 2 — for now we just tell the operator the manual command
+// they need (`skywire visor -c <path>`) until the Windows Service
+// registration ships.
+//
+// Active unit → restart; inactive → print the start instructions.
+// Never tries to auto-enable: respects operator intent.
 func restartOrPrompt(r resolvedConfig) {
+	if runtime.GOOS == "windows" {
+		msg2(fmt.Sprintf("Start skywire on Windows with (admin PowerShell):\n\t%sskywire visor -c %q%s",
+			colorRed, r.configPath, colorReset))
+		return
+	}
+
 	systemctlArgs := []string{}
 	if r.useUserUnit {
 		systemctlArgs = append(systemctlArgs, "--user")

--- a/pkg/cmdutil/skyenv.go
+++ b/pkg/cmdutil/skyenv.go
@@ -1,92 +1,65 @@
 // Package cmdutil pkg/cmdutil/skyenv.go
-// Shared SKYENV config file evaluation helpers.
-// Used by skywire cli config gen and dmsg commands.
+//
+// Shared SKYENV config file evaluation helpers. Used by
+// `skywire cli config gen` and the dmsg commands.
+//
+// Pre-refactor this file shelled out per-call to bash (Linux) or
+// powershell (Windows) to expand `${VAR:-default}` and `${VAR[@]}`
+// bash-isms against the sourced env file. The fork-per-call overhead
+// was meaningful (a single `cli config gen` triggers ~50 of these),
+// the bash dependency made it fragile under non-default shells, and
+// the parallel powershell path silently differed on edge cases.
+//
+// Now backed by a native Go parser in skyenv_parse.go — see that file
+// for the exact subset of bash syntax supported.
 package cmdutil
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/bitfield/script"
-
-	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
-// SkyenvValue sources a SKYENV file and evaluates a bash variable expression,
-// returning the raw string result. This is the common core for all typed helpers.
-//
-// One level of SKYENV= redirect is honored: if the sourced envfile sets
-// SKYENV to a different existing path (e.g. /etc/skywire.conf saying
-// SKYENV=/home/operator/.config/skywire.conf), that file is sourced
-// after the original so its values win. Recursion stops there — a
-// chain `/etc/skywire.conf` → `~/.config/skywire.conf` →
-// `~/.config/skywire-test.conf` would only follow the first hop.
-func SkyenvValue(expr, envfile string) (string, error) {
-	if skyenv.OS == "windows" {
-		variable := expr
-		if strings.Contains(variable, ":-") {
-			parts := strings.SplitN(variable, ":-", 2)
-			variable = parts[0] + "}"
-		}
-		out, err := script.Exec(fmt.Sprintf(
-			`powershell -c "$SKYENV = '%s'; if ($SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; if ($SKYENV -ne '%s' -and $SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; echo %s"`,
-			envfile, envfile, variable,
-		)).String()
-		if err != nil {
-			return "", err
-		}
-		out = strings.TrimSpace(out)
-		if out == "" || out == variable {
-			return "", nil
-		}
-		return out, nil
-	}
-	// First source — pulls in the original envfile's variables. If
-	// the file reassigned SKYENV to a different existing path, source
-	// that path next so its assignments override the originals.
-	out, err := script.Exec(fmt.Sprintf(
-		`bash -c 'SKYENV=%s ; ORIGINAL_SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; if [[ $SKYENV != "" ]] && [[ $SKYENV != "$ORIGINAL_SKYENV" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`,
-		envfile, envfile, expr,
-	)).String()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(out), nil
-}
-
-// SkyenvSlice sources a SKYENV file and expands a bash array expression
-// into a string slice, one element per line. Honors the same
-// one-level SKYENV= redirect as SkyenvValue.
-func SkyenvSlice(expr, envfile string) ([]string, error) {
-	if skyenv.OS == "windows" {
-		variable := expr
-		if idx := strings.Index(variable, "[@]}"); idx != -1 {
-			variable = strings.TrimSuffix(variable, "[@]}")
-			variable = strings.TrimSuffix(variable, "{")
-		}
-		return script.Exec(fmt.Sprintf(
-			`powershell -c "$SKYENV = '%s'; if ($SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; if ($SKYENV -ne '%s' -and $SKYENV -ne '' -and (Test-Path $SKYENV)) { . $SKYENV }; foreach ($item in %s) { Write-Host $item }"`,
-			envfile, envfile, variable,
-		)).Slice()
-	}
-	return script.Exec(fmt.Sprintf(
-		`bash -c 'SKYENV=%s ; ORIGINAL_SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; if [[ $SKYENV != "" ]] && [[ $SKYENV != "$ORIGINAL_SKYENV" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; for _i in %s ; do echo "$_i" ; done'`,
-		envfile, envfile, expr,
-	)).Slice()
-}
-
-// SkyenvDefault extracts the default value from a bash ${VAR:-default} expression.
+// SkyenvDefault extracts the default value from a `${VAR:-default}`
+// expression body. Public because some callers want to know "what
+// would the fallback be" without actually sourcing the env file
+// (e.g. constructing help text). The :- / - forms are handled the
+// same way the parser handles them.
 func SkyenvDefault(s string) string {
-	if strings.Contains(s, ":-") {
-		parts := strings.SplitN(s, ":-", 2)
-		return strings.TrimRight(parts[1], "}")
+	body, ok := stripExprBrackets(s)
+	if !ok {
+		return ""
+	}
+	_, def, useDefault, _ := splitExprBody(body)
+	if useDefault {
+		return def
 	}
 	return ""
 }
 
-// SkyenvString evaluates a bash variable expression and returns the string value,
-// falling back to the default from the expression if unset.
+// SkyenvValue sources `envfile` and evaluates the bash expression
+// `expr`, returning the raw string result. Errors are not used —
+// the function is best-effort: a missing file, an unrecognized
+// expression, etc. all return "".
+func SkyenvValue(expr, envfile string) (string, error) {
+	f, err := ParseSkyenvFile(envfile)
+	if err != nil {
+		return "", err
+	}
+	return f.Eval(expr), nil
+}
+
+// SkyenvSlice sources `envfile` and expands an array expression into
+// a string slice, one element per array entry.
+func SkyenvSlice(expr, envfile string) ([]string, error) {
+	f, err := ParseSkyenvFile(envfile)
+	if err != nil {
+		return nil, err
+	}
+	return f.EvalSlice(expr), nil
+}
+
+// SkyenvString evaluates expr and returns the string value, falling
+// back to the expression's `:-default` (if any) on empty / unset.
 func SkyenvString(s, envfile string) string {
 	out, err := SkyenvValue(s, envfile)
 	if err != nil || out == "" {
@@ -95,7 +68,8 @@ func SkyenvString(s, envfile string) string {
 	return out
 }
 
-// SkyenvBool evaluates a bash variable expression and returns a bool.
+// SkyenvBool evaluates expr and parses it as a Go bool. Unset / empty
+// → fall back to `:-default`; unparseable → false.
 func SkyenvBool(s, envfile string) bool {
 	out, err := SkyenvValue(s, envfile)
 	if err != nil || out == "" {
@@ -108,7 +82,9 @@ func SkyenvBool(s, envfile string) bool {
 	return b
 }
 
-// SkyenvArray evaluates a bash array expression and returns a comma-separated string.
+// SkyenvArray evaluates an array expression and returns its elements
+// joined by commas. Used by callers that feed the result to flags
+// expecting a comma-separated list (StringVar shaped).
 func SkyenvArray(s, envfile string) string {
 	items, err := SkyenvSlice(s, envfile)
 	if err != nil || len(items) == 0 {
@@ -117,7 +93,7 @@ func SkyenvArray(s, envfile string) string {
 	return strings.Join(items, ",")
 }
 
-// SkyenvInt evaluates a bash variable expression and returns an int.
+// SkyenvInt evaluates expr as a base-10 int.
 func SkyenvInt(s, envfile string) int {
 	out, err := SkyenvValue(s, envfile)
 	if err != nil || out == "" {
@@ -130,7 +106,7 @@ func SkyenvInt(s, envfile string) int {
 	return i
 }
 
-// SkyenvUint evaluates a bash variable expression and returns a uint.
+// SkyenvUint evaluates expr as a base-10 unsigned int.
 func SkyenvUint(s, envfile string) uint {
 	out, err := SkyenvValue(s, envfile)
 	if err != nil || out == "" {
@@ -143,7 +119,8 @@ func SkyenvUint(s, envfile string) uint {
 	return uint(i)
 }
 
-// SkyenvStringSlice evaluates a bash array expression and returns a string slice.
+// SkyenvStringSlice evaluates an array expression and returns the
+// raw elements.
 func SkyenvStringSlice(s, envfile string) []string {
 	items, err := SkyenvSlice(s, envfile)
 	if err != nil || len(items) == 0 {
@@ -152,7 +129,10 @@ func SkyenvStringSlice(s, envfile string) []string {
 	return items
 }
 
-// SkyenvBoolSlice evaluates a bash array expression and returns a bool slice.
+// SkyenvBoolSlice evaluates an array expression of "true"/"false"
+// tokens and returns a bool slice. Any non-"true" element parses as
+// false. An empty / unset variable returns [false] so callers that
+// index `result[0]` don't panic.
 func SkyenvBoolSlice(s, envfile string) []bool {
 	items, err := SkyenvSlice(s, envfile)
 	if err != nil {
@@ -173,7 +153,9 @@ func SkyenvBoolSlice(s, envfile string) []bool {
 	return result
 }
 
-// SkyenvUintSlice evaluates a bash array expression and returns a uint slice.
+// SkyenvUintSlice evaluates an array expression of base-10 unsigned
+// integers and returns a uint slice. Unparseable elements are
+// silently dropped.
 func SkyenvUintSlice(s, envfile string) []uint {
 	items, err := SkyenvSlice(s, envfile)
 	if err != nil {

--- a/pkg/cmdutil/skyenv_parse.go
+++ b/pkg/cmdutil/skyenv_parse.go
@@ -1,0 +1,360 @@
+// Package cmdutil pkg/cmdutil/skyenv_parse.go
+//
+// Native-Go parser for the SKYENV config file (/etc/skywire.conf on
+// Linux, %ProgramData%\Skywire\skywire.conf on Windows). Replaces the
+// previous bash-subprocess approach that called `script.Exec("bash
+// -c 'source ${SKYENV}; printf %s')`. The bash path worked but
+// (1) added a subshell per Skyenv* call (many called during a single
+// `config gen`), (2) required bash on every host (Windows-side had a
+// powershell fallback with subtly different expansion semantics),
+// and (3) leaked the env file's secrets through ps(1) / /proc.
+//
+// Scope: enough of bash variable expansion to handle what skywire's
+// own conf template emits. Specifically:
+//
+//   - KEY=value                 plain assignment
+//   - KEY='value' / KEY="value" single- or double-quoted
+//   - KEY=('a' 'b' 'c')         bash array literal (each element
+//     optionally quoted, whitespace-separated)
+//   - # comment                 line comment (also trailing on values
+//     where the comment isn't quoted in)
+//   - ${VAR}                    simple substitution
+//   - ${VAR:-default}           default-if-unset-or-empty
+//   - ${VAR-default}            default-if-unset
+//   - ${VAR[@]}                 array elements (whitespace-joined for
+//     compatibility with the callers that
+//     feed the result to fmt.Sprintf %s)
+//   - ${VAR[@]-default}         array-or-default
+//
+// Intentionally NOT supported (nothing in our templates uses these):
+// command substitution `$(…)`, nested expansions, multi-line
+// continuations, `${VAR:offset:length}`, `${VAR/pat/repl}`. Adding
+// any of those means we're papering over a template that's drifting
+// into bash territory — prefer fixing the template.
+package cmdutil
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// SkyenvFile is the parsed contents of a SKYENV config file. The map
+// values carry the source-level "shape" of the assignment: scalar
+// assignments become a single-element slice; bash array literals stay
+// as multi-element slices so ${VAR[@]} expansion preserves element
+// boundaries.
+type SkyenvFile struct {
+	Vars map[string][]string
+}
+
+// ParseSkyenvFile reads `path` and returns a SkyenvFile. A missing
+// path is NOT an error — callers (the cli config gen flag defaults)
+// invoke this on every flag binding, well before any operator has
+// edited /etc/skywire.conf. Empty result + nil err mirrors the old
+// bash path's behavior on a missing file.
+//
+// One level of SKYENV= redirect is honored: if the parsed file
+// reassigns SKYENV to a different existing path, that file's
+// contents are parsed second and overlay the first. Mirrors the
+// "source twice" pattern the previous bash implementation used so
+// operators with `/etc/skywire.conf → ~/.config/skywire.conf`
+// redirects keep the same behavior.
+func ParseSkyenvFile(path string) (*SkyenvFile, error) {
+	f := &SkyenvFile{Vars: make(map[string][]string)}
+	if path == "" {
+		return f, nil
+	}
+	if err := f.merge(path); err != nil {
+		return f, err
+	}
+	if redirect, ok := f.Vars["SKYENV"]; ok && len(redirect) > 0 {
+		if redirect[0] != "" && redirect[0] != path {
+			if _, err := os.Stat(redirect[0]); err == nil {
+				_ = f.merge(redirect[0]) //nolint:errcheck
+			}
+		}
+	}
+	return f, nil
+}
+
+// merge parses one env file and overlays its assignments onto f.
+// Returns nil for "file doesn't exist" — see ParseSkyenvFile.
+func (f *SkyenvFile) merge(path string) error {
+	fh, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer fh.Close() //nolint:errcheck
+	scanner := bufio.NewScanner(fh)
+	// Some operators paste long PK lists into HYPERVISORPKS=(). Bump
+	// the line buffer past bufio.Scanner's 64KiB default so a
+	// 200-element array doesn't get silently truncated.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		key, vals, ok := parseAssign(scanner.Text())
+		if !ok {
+			continue
+		}
+		f.Vars[key] = vals
+	}
+	return scanner.Err()
+}
+
+// parseAssign extracts (key, values, ok) from one source line.
+// Returns ok=false for comments, blank lines, and anything that
+// doesn't match `KEY=...`. Quoting and the array-literal form are
+// resolved here so the caller's map carries already-unquoted values.
+func parseAssign(line string) (string, []string, bool) {
+	// Strip leading whitespace; leave trailing for the value side
+	// (we'll trim there too, but a line that's pure whitespace is
+	// not an assignment).
+	trimmed := strings.TrimLeft(line, " \t")
+	if trimmed == "" {
+		return "", nil, false
+	}
+	if trimmed[0] == '#' {
+		return "", nil, false
+	}
+	eq := strings.IndexByte(trimmed, '=')
+	if eq <= 0 {
+		return "", nil, false
+	}
+	key := trimmed[:eq]
+	rhs := strings.TrimSpace(trimmed[eq+1:])
+	// Validate key shape — bash allows [a-zA-Z_][a-zA-Z0-9_]*.
+	// Reject anything else so we don't misinterpret URL-ish lines
+	// with `=` in them (e.g. a comment that contains "http://x?k=v").
+	if !isShellIdent(key) {
+		return "", nil, false
+	}
+	// Array literal: `(a b c)` — bash whitespace-split each element,
+	// optionally each quoted.
+	if strings.HasPrefix(rhs, "(") {
+		end := strings.LastIndexByte(rhs, ')')
+		if end < 0 {
+			// Unterminated — treat as scalar so the operator sees
+			// the raw form when they grep their conf, not a silent
+			// drop.
+			return key, []string{stripTrailingComment(rhs)}, true
+		}
+		inner := rhs[1:end]
+		return key, tokenizeArray(inner), true
+	}
+	// Scalar — strip outer quotes and trailing inline comment.
+	return key, []string{dequote(stripTrailingComment(rhs))}, true
+}
+
+// isShellIdent returns whether s is a valid bash identifier.
+func isShellIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, c := range s {
+		switch {
+		case c == '_':
+		case c >= 'A' && c <= 'Z':
+		case c >= 'a' && c <= 'z':
+		case i > 0 && c >= '0' && c <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// stripTrailingComment removes a "# …" suffix that isn't inside
+// quotes. Bash strips on whitespace-` #`; we use the same rule so an
+// embedded `#` inside a value (rare but legal) isn't treated as a
+// comment start.
+func stripTrailingComment(s string) string {
+	inSingle, inDouble := false, false
+	for i, c := range s {
+		switch c {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble && (i == 0 || s[i-1] == ' ' || s[i-1] == '\t') {
+				return strings.TrimRight(s[:i], " \t")
+			}
+		}
+	}
+	return s
+}
+
+// dequote strips a single pair of matching outer quotes. Bash also
+// understands backslash escapes inside double quotes; our templates
+// don't use them, so we leave the body verbatim.
+func dequote(s string) string {
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// tokenizeArray splits a bash array body `'a' 'b c' 'd'` into its
+// individual elements. Whitespace outside quotes is the delimiter;
+// each element is dequoted before being stored.
+func tokenizeArray(s string) []string {
+	var out []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	flush := func() {
+		if cur.Len() > 0 {
+			out = append(out, dequote(cur.String()))
+			cur.Reset()
+		}
+	}
+	for _, c := range s {
+		switch c {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+			cur.WriteRune(c)
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+			cur.WriteRune(c)
+		case ' ', '\t':
+			if inSingle || inDouble {
+				cur.WriteRune(c)
+			} else {
+				flush()
+			}
+		default:
+			cur.WriteRune(c)
+		}
+	}
+	flush()
+	return out
+}
+
+// Eval evaluates a single ${...} expression against f. Returns the
+// expanded string. Mirrors the subset of bash expansion the old
+// `script.Exec("bash -c 'printf %s' ${expr}")` path produced.
+//
+// Recognized expressions:
+//
+//	${VAR}                  → value of VAR (empty if unset)
+//	${VAR:-default}         → value of VAR if set+non-empty, else default
+//	${VAR-default}          → value of VAR if set, else default
+//	${VAR[@]}               → array elements joined with space
+//	${VAR[@]-default}       → array elements if set, else default
+//
+// Anything that doesn't start with `${` and end with `}` is returned
+// verbatim — same forgiving behavior as the bash path.
+func (f *SkyenvFile) Eval(expr string) string {
+	body, ok := stripExprBrackets(expr)
+	if !ok {
+		return expr
+	}
+	name, defaultVal, useDefault, arrayMode := splitExprBody(body)
+
+	vals, set := f.Vars[name]
+	if !set || (len(vals) == 1 && vals[0] == "") {
+		if useDefault {
+			return defaultVal
+		}
+		return ""
+	}
+	if arrayMode {
+		return strings.Join(vals, " ")
+	}
+	return vals[0]
+}
+
+// EvalSlice returns the array form. Unlike Eval which joins, this
+// preserves element boundaries — used by SkyenvSlice / SkyenvStringSlice
+// callers that need to range over the result.
+func (f *SkyenvFile) EvalSlice(expr string) []string {
+	body, ok := stripExprBrackets(expr)
+	if !ok {
+		return []string{expr}
+	}
+	name, defaultVal, useDefault, _ := splitExprBody(body)
+	vals, set := f.Vars[name]
+	if !set || (len(vals) == 1 && vals[0] == "") {
+		if useDefault {
+			if defaultVal == "" {
+				return nil
+			}
+			return strings.Fields(defaultVal)
+		}
+		return nil
+	}
+	return vals
+}
+
+func stripExprBrackets(expr string) (string, bool) {
+	if !strings.HasPrefix(expr, "${") {
+		return "", false
+	}
+	if !strings.HasSuffix(expr, "}") {
+		return "", false
+	}
+	return expr[2 : len(expr)-1], true
+}
+
+// splitExprBody parses the body of `${...}` into (name, default,
+// useDefault, arrayMode). Order of operations is "consume name, then
+// optional [@], then optional default" so the bash-style operators
+// `${VAR:-d}` and `${VAR[@]-d}` round-trip cleanly.
+//
+// Examples:
+//
+//	"PKGENV"             → ("PKGENV",  "",        false, false)
+//	"PKGENV:-false"      → ("PKGENV",  "false",   true,  false)
+//	"PKGENV-false"       → ("PKGENV",  "false",   true,  false)
+//	"HYPERVISORPKS[@]"   → ("HYPERVISORPKS", "",  false, true)
+//	"HYPERVISORPKS[@]-x" → ("HYPERVISORPKS", "x", true,  true)
+func splitExprBody(body string) (name, defaultVal string, useDefault, arrayMode bool) {
+	// 1. Consume identifier chars to extract the variable name.
+	// Bash identifiers: [A-Za-z_][A-Za-z0-9_]*.
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		if c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			i++
+			continue
+		}
+		if i > 0 && c >= '0' && c <= '9' {
+			i++
+			continue
+		}
+		break
+	}
+	name = body[:i]
+	rest := body[i:]
+	// 2. Optional [@] array marker — only meaningful immediately
+	// after the name in our template grammar.
+	if strings.HasPrefix(rest, "[@]") {
+		arrayMode = true
+		rest = rest[len("[@]"):]
+	}
+	// 3. Optional default operator. `:-` and `-` differ in bash
+	// (empty-vs-unset trigger), but our templates don't depend on
+	// that distinction; both map to useDefault=true.
+	switch {
+	case strings.HasPrefix(rest, ":-"):
+		useDefault = true
+		defaultVal = rest[2:]
+	case strings.HasPrefix(rest, "-"):
+		useDefault = true
+		defaultVal = rest[1:]
+	}
+	return name, defaultVal, useDefault, arrayMode
+}

--- a/pkg/cmdutil/skyenv_test.go
+++ b/pkg/cmdutil/skyenv_test.go
@@ -1,0 +1,227 @@
+// Package cmdutil pkg/cmdutil/skyenv_test.go
+//
+// Coverage for the SKYENV native-Go parser. The expressions exercised
+// here are exactly those that `cli config gen` issues at flag-binding
+// time — see cmd/skywire-cli/commands/config/gen.go for the live
+// callsites. Adding a new expression shape to a template should land
+// alongside a new case in these tests.
+package cmdutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// envWith writes a temporary env file containing the given body and
+// returns its path. Caller-side cleanup happens via t.TempDir().
+func envWith(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skywire.conf")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestSkyenvParseAssignments(t *testing.T) {
+	body := `# comment line
+PKGENV=true
+USRENV=false
+OUTPUT='./skywire-config.json'
+SKYCHATADDR=":8001"
+SVCCONFADDR=('http://a' 'http://b')
+HYPERVISORPKS=('pk1' 'pk2' 'pk3')
+SVCCONF=services-config.json   # trailing comment
+EMPTY=
+QUOTED_SPACE='hello world'
+NUM=42
+`
+	path := envWith(t, body)
+	f, err := ParseSkyenvFile(path)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	check := func(key string, want []string) {
+		t.Helper()
+		got, ok := f.Vars[key]
+		if !ok {
+			t.Errorf("%s: missing", key)
+			return
+		}
+		if len(got) != len(want) {
+			t.Errorf("%s: len got=%d want=%d (%v)", key, len(got), len(want), got)
+			return
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("%s[%d]: got %q want %q", key, i, got[i], want[i])
+			}
+		}
+	}
+	check("PKGENV", []string{"true"})
+	check("USRENV", []string{"false"})
+	check("OUTPUT", []string{"./skywire-config.json"})
+	check("SKYCHATADDR", []string{":8001"})
+	check("SVCCONFADDR", []string{"http://a", "http://b"})
+	check("HYPERVISORPKS", []string{"pk1", "pk2", "pk3"})
+	check("SVCCONF", []string{"services-config.json"})
+	check("EMPTY", []string{""})
+	check("QUOTED_SPACE", []string{"hello world"})
+	check("NUM", []string{"42"})
+}
+
+func TestSkyenvEvalScalar(t *testing.T) {
+	path := envWith(t, "PKGENV=true\nUSRENV=false\nEMPTY=\n")
+	cases := []struct {
+		expr string
+		want string
+	}{
+		{"${PKGENV}", "true"},
+		{"${PKGENV:-false}", "true"},
+		{"${USRENV:-true}", "false"}, // set, even though value differs from default
+		{"${MISSING}", ""},           // unset, no default
+		{"${MISSING:-fallback}", "fallback"},
+		{"${MISSING-fallback}", "fallback"},
+		{"${EMPTY:-fallback}", "fallback"}, // empty → :- triggers default
+		{"plain text", "plain text"},       // non-${…} pass-through
+	}
+	for _, c := range cases {
+		got := SkyenvString(c.expr, path)
+		if got != c.want {
+			t.Errorf("SkyenvString(%q) = %q, want %q", c.expr, got, c.want)
+		}
+	}
+}
+
+func TestSkyenvEvalBool(t *testing.T) {
+	path := envWith(t, "PKGENV=true\nUSRENV=false\n")
+	if !SkyenvBool("${PKGENV:-false}", path) {
+		t.Error("PKGENV=true should resolve to true")
+	}
+	if SkyenvBool("${USRENV:-true}", path) {
+		t.Error("USRENV=false should resolve to false")
+	}
+	if SkyenvBool("${MISSING:-false}", path) {
+		t.Error("missing var w/ default false should be false")
+	}
+	if !SkyenvBool("${MISSING:-true}", path) {
+		t.Error("missing var w/ default true should be true")
+	}
+}
+
+func TestSkyenvEvalArray(t *testing.T) {
+	path := envWith(t, `HYPERVISORPKS=('a' 'b' 'c')
+EMPTY_ARR=('')
+SVCCONFADDR=('http://x')
+`)
+	if got := SkyenvArray("${HYPERVISORPKS[@]}", path); got != "a,b,c" {
+		t.Errorf("HYPERVISORPKS array got %q want a,b,c", got)
+	}
+	if got := SkyenvStringSlice("${HYPERVISORPKS[@]}", path); len(got) != 3 || got[1] != "b" {
+		t.Errorf("HYPERVISORPKS slice got %v want [a b c]", got)
+	}
+	// `EMPTY_ARR=('')` parses as a single-element array containing
+	// an empty string. Eval treats single-empty-element as "use
+	// default" so a template that ships `KEY=('')` (the canonical
+	// "placeholder, fill me in" form in skywire.conf) still gets
+	// the operator's `:-default` when nothing's been filled in.
+	if got := SkyenvArray("${EMPTY_ARR[@]-defx}", path); got != "defx" {
+		t.Errorf("EMPTY_ARR[@]-default got %q want defx", got)
+	}
+	if got := SkyenvArray("${MISSING_ARR[@]-fallback}", path); got != "fallback" {
+		t.Errorf("MISSING_ARR[@]-fallback got %q want fallback", got)
+	}
+	if got := SkyenvArray("${SVCCONFADDR[@]-https://default}", path); got != "http://x" {
+		t.Errorf("SVCCONFADDR[@]-default got %q want http://x", got)
+	}
+}
+
+func TestSkyenvEvalInt(t *testing.T) {
+	path := envWith(t, "MINDMSGSESS=8\n")
+	if got := SkyenvInt("${MINDMSGSESS:-2}", path); got != 8 {
+		t.Errorf("MINDMSGSESS got %d want 8", got)
+	}
+	if got := SkyenvInt("${MISSING:-2}", path); got != 2 {
+		t.Errorf("missing w/ default 2 got %d want 2", got)
+	}
+	if got := SkyenvInt("${NONNUMERIC:-bogus}", path); got != 0 {
+		t.Errorf("unparseable default got %d want 0", got)
+	}
+}
+
+func TestSkyenvCommentAndQuoteHandling(t *testing.T) {
+	path := envWith(t, `# this is a comment
+   # indented comment
+KEY1=value1
+KEY2='quoted value'
+KEY3="dq value"
+KEY4=trailing # this is comment, not value
+KEY5='value with # not a comment'
+KEY6=
+not an assignment
+=alsoNot
+123BadName=ignored
+`)
+	f, _ := ParseSkyenvFile(path) //nolint:errcheck
+	cases := map[string]string{
+		"KEY1": "value1",
+		"KEY2": "quoted value",
+		"KEY3": "dq value",
+		"KEY4": "trailing",
+		"KEY5": "value with # not a comment",
+		"KEY6": "",
+	}
+	for k, want := range cases {
+		got := f.Vars[k]
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("%s: got %v want [%q]", k, got, want)
+		}
+	}
+	if _, ok := f.Vars["123BadName"]; ok {
+		t.Error("identifier starting with digit should be rejected")
+	}
+	if _, ok := f.Vars[""]; ok {
+		t.Error("`=alsoNot` should not produce an empty-name entry")
+	}
+}
+
+func TestSkyenvMissingFile(t *testing.T) {
+	// Missing file is not an error — mirrors the old bash path
+	// where a non-existent SKYENV just produced empty expansions.
+	f, err := ParseSkyenvFile("/no/such/path/skywire.conf")
+	if err != nil {
+		t.Errorf("missing file should return nil err, got %v", err)
+	}
+	if len(f.Vars) != 0 {
+		t.Errorf("missing file should yield empty vars, got %v", f.Vars)
+	}
+	if got := SkyenvBool("${PKGENV:-true}", ""); !got {
+		t.Errorf("empty envfile + default true should be true, got %v", got)
+	}
+}
+
+func TestSkyenvRedirect(t *testing.T) {
+	// One level of SKYENV= redirect honored: the original file is
+	// parsed first, then if it sets SKYENV to a different existing
+	// file, that file's assignments overlay the original.
+	dir := t.TempDir()
+	pri := filepath.Join(dir, "primary.conf")
+	sec := filepath.Join(dir, "override.conf")
+	_ = os.WriteFile(pri, []byte("PKGENV=true\nSK=primary_sk\nSKYENV="+sec+"\n"), 0o600) //nolint:errcheck,gosec
+	_ = os.WriteFile(sec, []byte("SK=override_sk\nUSRENV=true\n"), 0o600)                //nolint:errcheck,gosec
+
+	if got := SkyenvString("${SK}", pri); got != "override_sk" {
+		t.Errorf("SK after redirect got %q want override_sk", got)
+	}
+	// PKGENV not overridden in `sec`, so it should still be `true`
+	// from the primary file.
+	if got := SkyenvBool("${PKGENV:-false}", pri); !got {
+		t.Errorf("PKGENV after redirect got %v want true", got)
+	}
+	if got := SkyenvBool("${USRENV:-false}", pri); !got {
+		t.Errorf("USRENV (set only in override) got %v want true", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of a 4-phase Windows-autoconfig-parity project. Goal: get `skywire autoconfig` on Windows to behave like its Linux counterpart (same env-file shape, same orchestrator command, same upgrade semantics). This PR is the foundation.

## What changes

**`pkg/cmdutil/skyenv`** — replace bash/powershell subprocess with a native Go parser:
- Old code shelled out to `bash -c 'source ${SKYENV}; printf %s'` (Linux) or a powershell equivalent (Windows) per call. A single `cli config gen` triggers ~50 of those. New code parses once, evaluates in-process.
- Handles the exact subset of bash our templates emit: `KEY=v`, `KEY='v'`, `KEY="v"`, `KEY=('a' 'b' 'c')`, line + trailing `#` comments, `${VAR}`, `${VAR:-d}`, `${VAR-d}`, `${VAR[@]}`, `${VAR[@]-d}`.
- Intentionally **not** supported: command substitution, nested expansions, `${VAR:offset:length}`, `${VAR/pat/repl}`. Anything that needs those is a template-drift signal, not a parser bug.

**`cmd/skywire/commands/autoconfig.go`** — Windows-runtime correct:
- `defaultSkyenvPath()` returns `%ProgramData%\Skywire\skywire.conf` on Windows, `/etc/skywire.conf` everywhere else.
- systemd-drop-in management and `chownInstall` gated on `runtime.GOOS == "linux"`. Phase 2 will replace those with `golang.org/x/sys/windows/svc/mgr` Windows-service registration.
- `restartOrPrompt` prints the manual `skywire visor -c <path>` command on Windows until Phase 2 lands the Service wrapper.

**`pkg/cmdutil/skyenv_test.go`** — coverage for every expression shape `cli config gen` issues at flag-binding time, plus comment handling, identifier validation, missing-file behavior, and one-level SKYENV redirect.

## What's NOT in this PR

Phases 2–4 (saved in project memory `project_windows_autoconfig_parity.md`):
- **Phase 2**: Windows Service registration via `golang.org/x/sys/windows/svc/mgr` — `skywire visor service install/start/stop/uninstall` subcommands, autoconfig wires the service the way it currently wires systemctl on Linux.
- **Phase 3**: MSI integration — WiX CustomAction + ServiceInstall/Control + MajorUpgrade replacing the current `skywire.bat`-driven install lifecycle.
- **Phase 4**: Tray + headless polish — conditional browser open, `HEADLESS=true` env-file flag, MSI Shortcut for `skywire-tray.exe` on logon.

Each phase ships as its own PR once the prior one lands and runtime-testing on Windows is available.

## Test plan

- [x] `go build ./...` — clean
- [x] `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags 'withoutsystray withoutgotop' ./...` — clean
- [x] `go test ./pkg/cmdutil/...` — passes (new parser tests included)
- [x] `golangci-lint run ./pkg/cmdutil/... ./cmd/skywire/...` — 0 issues
- [x] Manual sanity: `SKYENV=/etc/skywire.conf skywire cli config gen -q` still emits the same template; `${VAR:-default}` and `${VAR[@]}` still resolve correctly through the new parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)