### PR TITLE
feat(skychat,dmsg): D1 group chat + standalone `skywire dmsg chat`

### DIFF
--- a/cmd/apps/skychat/group/crypto.go
+++ b/cmd/apps/skychat/group/crypto.go
@@ -1,0 +1,74 @@
+// Package group — cmd/apps/skychat/group/crypto.go: AES-256-GCM
+// envelope helpers for ModePrivate groups.
+//
+// Why GCM (not ChaCha20-Poly1305 or noise): every visor binary
+// already pulls in crypto/aes + crypto/cipher for other code paths,
+// keeping the surface area unchanged. GCM also gives us AEAD with
+// 16-byte tag which is exactly what we want for per-message
+// authentication on the feed.
+//
+// Nonce policy: 12-byte random per message. With a single AES key
+// shared across an arbitrary number of senders, that's the
+// "single-write key" failure mode AEADs warn about — but each
+// message's nonce is independently random, so the probability of
+// nonce reuse across the group is 1 - exp(-N²/2¹⁹⁷), i.e.
+// negligible at any realistic message volume.
+package group
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+)
+
+// Encrypt produces (ciphertext, nonce) for a ModePrivate group.
+// Caller is responsible for tagging the resulting Message body with
+// Ciphertext + Nonce. Returns an error iff the key length is wrong
+// or the underlying RNG fails.
+func Encrypt(key, plaintext []byte) (ciphertext, nonce []byte, err error) {
+	if len(key) != 32 {
+		return nil, nil, fmt.Errorf("group crypto: AES key must be 32 bytes, got %d", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("group crypto: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, fmt.Errorf("group crypto: cipher.NewGCM: %w", err)
+	}
+	nonce = make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, nil, fmt.Errorf("group crypto: nonce rand: %w", err)
+	}
+	ciphertext = gcm.Seal(nil, nonce, plaintext, nil)
+	return ciphertext, nonce, nil
+}
+
+// Decrypt is the inverse of Encrypt. Failures (wrong key, mangled
+// ciphertext, mangled nonce, tag check) all surface as errors —
+// callers should display "[decryption failed]" or similar on the
+// feed line rather than the raw error to avoid leaking which kind
+// of failure occurred to a passive observer.
+func Decrypt(key, ciphertext, nonce []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("group crypto: AES key must be 32 bytes, got %d", len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("group crypto: aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("group crypto: cipher.NewGCM: %w", err)
+	}
+	if len(nonce) != gcm.NonceSize() {
+		return nil, fmt.Errorf("group crypto: nonce length: got %d want %d", len(nonce), gcm.NonceSize())
+	}
+	pt, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("group crypto: gcm.Open: %w", err)
+	}
+	return pt, nil
+}

--- a/cmd/apps/skychat/group/group.go
+++ b/cmd/apps/skychat/group/group.go
@@ -1,0 +1,168 @@
+// Package group — cmd/apps/skychat/group: D1 owner-centric group chat
+// built on top of skywire's existing CXO TreeStore feeds.
+//
+// Architecture (D1, "owner-centric single feed"):
+//
+//   - One member ("owner") publishes the group's single CXO feed.
+//     The feed's SubscriberAllowlist enumerates every group member so
+//     only they can subscribe.
+//   - Other members subscribe to that feed. They receive messages but
+//     don't publish; outgoing messages are POSTed to the owner over
+//     the existing 1:1 skychat /message endpoint with a group_id tag,
+//     and the owner relays them into the feed.
+//   - Owner offline → group is read-only until owner comes back.
+//     Acceptable v1 limit. Phase 2 (project memo) shifts to
+//     distributed publishers so this isn't a SPOF.
+//
+// Coexistence of public + private groups: the Mode field on Record
+// drives whether message bodies are AES-GCM-encrypted on the feed.
+//
+//   - Public: body is plaintext JSON on the feed. Anyone with the
+//     groupID and an allowlist seat can read.
+//   - Private: owner generates a random 32-byte AES-256-GCM key at
+//     create time. The key travels in the invite link, so any
+//     possessor of the link can join AND decrypt history. Removing
+//     a member from a private group requires re-keying — for v1
+//     that means creating a fresh group. Acceptable tradeoff.
+//
+// Why not per-recipient ECIES of the key (so we can revoke):
+// adds a real crypto surface (DH-derive + key-wrap layer) that
+// belongs in a Phase 2 spec, not in v1. The "create a new group to
+// revoke" workflow is bad UX but correct security and concrete.
+package group
+
+import (
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// Mode selects whether messages are encrypted on the feed.
+type Mode string
+
+const (
+	// ModePublic — plaintext JSON message bodies on the feed.
+	// Anyone the owner allowlists can read. Suited for semi-public
+	// rooms (e.g. "operator support").
+	ModePublic Mode = "public"
+
+	// ModePrivate — AES-256-GCM-encrypted message bodies. Key in
+	// the invite link; without the key, even an allowlisted
+	// subscriber sees only ciphertext.
+	ModePrivate Mode = "private"
+)
+
+// IsValid returns true for the two recognised modes.
+func (m Mode) IsValid() bool {
+	return m == ModePublic || m == ModePrivate
+}
+
+// Status enumerates a Record's lifecycle, mirroring pairing.Status
+// where it makes sense.
+type Status string
+
+const (
+	// StatusPending — we've registered the group locally but the
+	// CXO publisher / subscriber haven't completed their handshake
+	// yet (owner just created it, or member just joined and is
+	// dialing). Treated as "almost active" by the UI.
+	StatusPending Status = "pending"
+
+	// StatusActive — owner's publisher is up, member's subscriber
+	// is connected. Messages flow.
+	StatusActive Status = "active"
+
+	// StatusLeft — member side: the operator left this group. The
+	// record stays for audit / re-join via the same invite. The
+	// publisher / subscriber are torn down on transition.
+	StatusLeft Status = "left"
+
+	// StatusRevoked — owner side: the owner deleted the group. The
+	// publisher is torn down; subscribers will see a stream end.
+	// Kept in the local store so an operator can grep "what groups
+	// did I run last quarter".
+	StatusRevoked Status = "revoked"
+)
+
+// Role distinguishes the operator's relationship to this group.
+type Role string
+
+const (
+	// RoleOwner — this visor publishes the feed. Outgoing messages
+	// go straight to Publisher.Put.
+	RoleOwner Role = "owner"
+
+	// RoleMember — this visor subscribes to the owner's feed.
+	// Outgoing messages are POSTed to the owner via the existing
+	// 1:1 skychat /message with a group_id tag.
+	RoleMember Role = "member"
+)
+
+// Record is the persisted form of a group as this visor knows it.
+// Member visors and the owner visor store the same shape; only
+// Role differs.
+type Record struct {
+	// ID is the group's UUID. Used as the bbolt bucket key.
+	ID string `json:"id"`
+
+	// Name is operator-supplied free-form. Not used as an identity
+	// — just for display.
+	Name string `json:"name"`
+
+	// OwnerPK is the visor that publishes the message feed.
+	OwnerPK cipher.PubKey `json:"owner_pk"`
+
+	// Port is the DMSG port the owner's publisher listens on.
+	// Chosen by the owner at create time (not deterministic from
+	// the groupID — pair-allocator-style determinism doesn't help
+	// when the owner is one fixed PK; an opaque port works fine
+	// because the invite link distributes it).
+	Port uint16 `json:"port"`
+
+	// Mode is public vs private. Drives whether AESKey is present
+	// + whether the body is encrypted on the feed.
+	Mode Mode `json:"mode"`
+
+	// AESKey is the 32-byte AES-256-GCM key. Set iff Mode ==
+	// ModePrivate. Travels in the invite link; storing locally
+	// avoids having to re-decode the invite every send.
+	AESKey []byte `json:"aes_key,omitempty"`
+
+	// Members enumerates every PK the owner has allowlisted. On
+	// the owner side this drives Publisher.SetAllowlist; on the
+	// member side it's display-only (the operator wants to know
+	// who else is in the room).
+	Members []cipher.PubKey `json:"members"`
+
+	// Role tells lifecycle code whether to manage a Publisher
+	// (owner) or a Subscriber (member).
+	Role Role `json:"role"`
+
+	Status        Status    `json:"status"`
+	CreatedAt     time.Time `json:"created_at"`
+	JoinedAt      time.Time `json:"joined_at"`
+	LastMessageAt time.Time `json:"last_message_at,omitempty"`
+}
+
+// Message is the on-the-wire (well, on-the-feed) form of a group
+// chat entry. For ModePrivate groups, the body lands in Ciphertext
+// + Nonce instead of Text; the renderer plugs in AESKey to decrypt.
+type Message struct {
+	// SenderPK identifies which member sent this. Required.
+	SenderPK cipher.PubKey `json:"sender_pk"`
+
+	// TS is the sender's wall-clock. Used for ordering display and
+	// for the per-feed last-50 history seed.
+	TS time.Time `json:"ts"`
+
+	// Text is the plaintext body for ModePublic groups. Empty for
+	// ModePrivate (use Ciphertext+Nonce instead).
+	Text string `json:"text,omitempty"`
+
+	// Ciphertext + Nonce carry AES-GCM-encrypted bodies for
+	// ModePrivate groups. Nonce is a fresh 12-byte value per message
+	// — never reused for the same key, which is what AES-GCM
+	// requires.
+	Ciphertext []byte `json:"ciphertext,omitempty"`
+	Nonce      []byte `json:"nonce,omitempty"`
+}

--- a/cmd/apps/skychat/group/group.go
+++ b/cmd/apps/skychat/group/group.go
@@ -52,7 +52,7 @@ const (
 	ModePrivate Mode = "private"
 )
 
-// IsValid returns true for the two recognised modes.
+// IsValid returns true for the two recognized modes.
 func (m Mode) IsValid() bool {
 	return m == ModePublic || m == ModePrivate
 }

--- a/cmd/apps/skychat/group/group_test.go
+++ b/cmd/apps/skychat/group/group_test.go
@@ -1,0 +1,227 @@
+// Package group — cmd/apps/skychat/group/group_test.go: round-trip
+// coverage for the invite + crypto + store code paths. The fan-out
+// CXO wiring lives in the manager and is exercised separately by
+// the manual E2E test plan (project memo).
+package group
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// pkN returns a fresh real PK. Tests use real keys (not raw byte
+// synthesis) because cipher.PubKey.UnmarshalText validates the
+// curve-point via cipher.PubKeyFromHex; a synthetic non-point would
+// silently round-trip to the zero PK and mask the actual SetMembers /
+// allowlist behavior being tested. The `n` parameter is just for
+// readability when an assertion fails — it doesn't influence the key.
+func pkN(_ byte) cipher.PubKey {
+	pk, _ := cipher.GenerateKeyPair()
+	return pk
+}
+
+func TestInviteRoundTripPublic(t *testing.T) {
+	in := Invite{
+		ID:      "11111111-2222-3333-4444-555555555555",
+		Name:    "operator support",
+		OwnerPK: pkN(0x01),
+		Port:    20001,
+		Mode:    ModePublic,
+	}
+	link, err := EncodeInvite(in)
+	if err != nil {
+		t.Fatalf("EncodeInvite: %v", err)
+	}
+	if got := link; len(got) == 0 || got[:len(inviteURIScheme)] != inviteURIScheme {
+		t.Errorf("link missing scheme prefix: %q", got)
+	}
+	out, err := DecodeInvite(link)
+	if err != nil {
+		t.Fatalf("DecodeInvite: %v", err)
+	}
+	if out.ID != in.ID || out.Name != in.Name || out.Port != in.Port || out.Mode != in.Mode || out.OwnerPK != in.OwnerPK {
+		t.Errorf("round trip mismatch: %+v vs %+v", in, out)
+	}
+	if len(out.AESKey) != 0 {
+		t.Errorf("public invite should not carry AES key, got %d bytes", len(out.AESKey))
+	}
+}
+
+func TestInviteRoundTripPrivate(t *testing.T) {
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("GenerateAESKey: %v", err)
+	}
+	in := Invite{
+		ID:      "abcdef01-2345-6789-abcd-ef0123456789",
+		Name:    "private ops",
+		OwnerPK: pkN(0x02),
+		Port:    20002,
+		Mode:    ModePrivate,
+		AESKey:  key,
+	}
+	link, err := EncodeInvite(in)
+	if err != nil {
+		t.Fatalf("EncodeInvite: %v", err)
+	}
+	out, err := DecodeInvite(link)
+	if err != nil {
+		t.Fatalf("DecodeInvite: %v", err)
+	}
+	if !bytes.Equal(out.AESKey, in.AESKey) {
+		t.Errorf("AES key did not survive round trip")
+	}
+}
+
+func TestInviteRejectsModeKeyMismatch(t *testing.T) {
+	// Public must NOT have a key.
+	if _, err := EncodeInvite(Invite{
+		ID: "x", Name: "x", OwnerPK: pkN(1), Port: 1, Mode: ModePublic,
+		AESKey: make([]byte, 32),
+	}); err == nil {
+		t.Error("encode: public with AES key should error")
+	}
+	// Private must have a 32-byte key.
+	if _, err := EncodeInvite(Invite{
+		ID: "x", Name: "x", OwnerPK: pkN(1), Port: 1, Mode: ModePrivate,
+		AESKey: make([]byte, 16), // wrong length
+	}); err == nil {
+		t.Error("encode: private with short key should error")
+	}
+	// Decoder also rejects malformed.
+	if _, err := DecodeInvite("skychat:invite:!!!!"); err == nil {
+		t.Error("decode: garbage payload should error")
+	}
+	if _, err := DecodeInvite("not-an-invite"); err == nil {
+		t.Error("decode: missing scheme should error")
+	}
+}
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("GenerateAESKey: %v", err)
+	}
+	plain := []byte("hello group, this is a chat message with utf-8: 你好")
+	ct, nonce, err := Encrypt(key, plain)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if len(nonce) != 12 {
+		t.Errorf("nonce should be 12 bytes (GCM standard), got %d", len(nonce))
+	}
+	if bytes.Equal(ct, plain) {
+		t.Error("ciphertext should not equal plaintext")
+	}
+	pt, err := Decrypt(key, ct, nonce)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(pt, plain) {
+		t.Errorf("decrypt mismatch: %q vs %q", pt, plain)
+	}
+}
+
+func TestDecryptRejectsTampered(t *testing.T) {
+	key, _ := GenerateAESKey() //nolint:errcheck
+	ct, nonce, _ := Encrypt(key, []byte("secret message")) //nolint:errcheck
+	// Flip one byte in the ciphertext. GCM's MAC should detect it.
+	ct[0] ^= 0xff
+	if _, err := Decrypt(key, ct, nonce); err == nil {
+		t.Error("Decrypt should reject tampered ciphertext")
+	}
+}
+
+func TestDecryptRejectsWrongKey(t *testing.T) {
+	k1, _ := GenerateAESKey() //nolint:errcheck
+	k2, _ := GenerateAESKey() //nolint:errcheck
+	ct, nonce, _ := Encrypt(k1, []byte("for k1 only")) //nolint:errcheck
+	if _, err := Decrypt(k2, ct, nonce); err == nil {
+		t.Error("Decrypt should reject wrong key")
+	}
+}
+
+// Two random nonces from independent calls must not collide in a
+// reasonable number of iterations. A regression that fixes the
+// nonce (e.g. someone hard-codes it for "convenience") would fail
+// this immediately.
+func TestEncryptNonceUnique(t *testing.T) {
+	key, _ := GenerateAESKey() //nolint:errcheck
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		_, n, err := Encrypt(key, []byte("x"))
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+		s := string(n)
+		if _, dup := seen[s]; dup {
+			t.Fatalf("nonce collision at iteration %d", i)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+func TestStoreCRUD(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "groups.db")
+	s, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer s.Close() //nolint:errcheck
+
+	id := "abcdef01-0000-0000-0000-000000000000"
+	r := Record{
+		ID:        id,
+		Name:      "test",
+		OwnerPK:   pkN(1),
+		Port:      30001,
+		Mode:      ModePublic,
+		Members:   []cipher.PubKey{pkN(1), pkN(2), pkN(3)},
+		Role:      RoleOwner,
+		Status:    StatusPending,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.Put(r); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok, err := s.Get(id)
+	if err != nil || !ok {
+		t.Fatalf("Get: err=%v ok=%v", err, ok)
+	}
+	if got.Name != r.Name || got.Port != r.Port || got.Mode != r.Mode {
+		t.Errorf("Get mismatch: %+v", got)
+	}
+	// SetStatus + List.
+	if err := s.SetStatus(id, StatusActive); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+	all, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 || all[0].Status != StatusActive {
+		t.Errorf("List/SetStatus: %+v", all)
+	}
+	// SetMembers replaces.
+	m1, m2 := pkN(10), pkN(20)
+	newMembers := []cipher.PubKey{m1, m2}
+	if err := s.SetMembers(id, newMembers); err != nil {
+		t.Fatalf("SetMembers: %v", err)
+	}
+	got, _, _ = s.Get(id) //nolint:errcheck
+	if len(got.Members) != 2 || got.Members[0] != m1 || got.Members[1] != m2 {
+		t.Errorf("SetMembers: %+v", got.Members)
+	}
+	// Delete.
+	if err := s.Delete(id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok, _ := s.Get(id); ok { //nolint:errcheck
+		t.Error("Delete: record still present")
+	}
+}

--- a/cmd/apps/skychat/group/group_test.go
+++ b/cmd/apps/skychat/group/group_test.go
@@ -127,7 +127,7 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 }
 
 func TestDecryptRejectsTampered(t *testing.T) {
-	key, _ := GenerateAESKey() //nolint:errcheck
+	key, _ := GenerateAESKey()                             //nolint:errcheck
 	ct, nonce, _ := Encrypt(key, []byte("secret message")) //nolint:errcheck
 	// Flip one byte in the ciphertext. GCM's MAC should detect it.
 	ct[0] ^= 0xff
@@ -137,8 +137,8 @@ func TestDecryptRejectsTampered(t *testing.T) {
 }
 
 func TestDecryptRejectsWrongKey(t *testing.T) {
-	k1, _ := GenerateAESKey() //nolint:errcheck
-	k2, _ := GenerateAESKey() //nolint:errcheck
+	k1, _ := GenerateAESKey()                          //nolint:errcheck
+	k2, _ := GenerateAESKey()                          //nolint:errcheck
 	ct, nonce, _ := Encrypt(k1, []byte("for k1 only")) //nolint:errcheck
 	if _, err := Decrypt(k2, ct, nonce); err == nil {
 		t.Error("Decrypt should reject wrong key")

--- a/cmd/apps/skychat/group/invite.go
+++ b/cmd/apps/skychat/group/invite.go
@@ -1,0 +1,118 @@
+// Package group — cmd/apps/skychat/group/invite.go: encode + decode
+// the invite payload an owner hands to a prospective member.
+//
+// Invite-link grammar:
+//
+//	skychat:invite:<base64url(json(Invite))>
+//
+// base64url so a single-token paste through a terminal / chat tab /
+// shell variable doesn't get mangled. URL queries would have worked
+// for ModePublic but the AES key in ModePrivate doesn't urlencode
+// cleanly across every shell.
+//
+// The whole payload is plaintext on the wire — there's no signature
+// over it. The trust model is "whoever you handed the invite to is
+// trusted to be in the group"; the visor-level allowlist enforces
+// that on the CXO subscribe side, and AES key possession + allowlist
+// together gate access to private group bodies.
+//
+// AES key generation lives here too because the only callers that
+// need to generate a key are the create + parse paths.
+package group
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// inviteURIScheme is the prefix every invite link starts with. The
+// `://` form would also have worked but `:` keeps the link short
+// enough to read in a one-line chat message.
+const inviteURIScheme = "skychat:invite:"
+
+// Invite is the on-the-wire content of an invite link. Mirrors the
+// subset of group.Record an invitee needs to (a) bootstrap a local
+// Record and (b) start the CXO subscribe.
+type Invite struct {
+	ID      string        `json:"id"`
+	Name    string        `json:"name"`
+	OwnerPK cipher.PubKey `json:"owner_pk"`
+	Port    uint16        `json:"port"`
+	Mode    Mode          `json:"mode"`
+
+	// AESKey is set iff Mode == ModePrivate. Anybody with this link
+	// can decrypt the feed; the invite IS the key. Owner-side key
+	// rotation = create a fresh group with a fresh invite.
+	AESKey []byte `json:"aes_key,omitempty"`
+}
+
+// EncodeInvite returns the printable invite-link form.
+func EncodeInvite(inv Invite) (string, error) {
+	if !inv.Mode.IsValid() {
+		return "", fmt.Errorf("group invite: invalid mode %q", inv.Mode)
+	}
+	if inv.Mode == ModePrivate && len(inv.AESKey) != 32 {
+		return "", fmt.Errorf("group invite: private mode needs 32-byte AES key, got %d", len(inv.AESKey))
+	}
+	if inv.Mode == ModePublic && len(inv.AESKey) > 0 {
+		return "", fmt.Errorf("group invite: public mode must not carry an AES key")
+	}
+	body, err := json.Marshal(inv)
+	if err != nil {
+		return "", fmt.Errorf("group invite: marshal: %w", err)
+	}
+	return inviteURIScheme + base64.RawURLEncoding.EncodeToString(body), nil
+}
+
+// DecodeInvite parses an invite-link string back into an Invite.
+// Tolerates leading/trailing whitespace because operators paste
+// these from terminals.
+func DecodeInvite(s string) (Invite, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, inviteURIScheme) {
+		return Invite{}, fmt.Errorf("group invite: missing %q prefix", inviteURIScheme)
+	}
+	payload := strings.TrimPrefix(s, inviteURIScheme)
+	body, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return Invite{}, fmt.Errorf("group invite: base64 decode: %w", err)
+	}
+	var inv Invite
+	if err := json.Unmarshal(body, &inv); err != nil {
+		return Invite{}, fmt.Errorf("group invite: json unmarshal: %w", err)
+	}
+	if !inv.Mode.IsValid() {
+		return Invite{}, fmt.Errorf("group invite: invalid mode %q", inv.Mode)
+	}
+	if inv.Mode == ModePrivate && len(inv.AESKey) != 32 {
+		return Invite{}, fmt.Errorf("group invite: private mode requires 32-byte AES key, got %d", len(inv.AESKey))
+	}
+	if inv.Mode == ModePublic && len(inv.AESKey) > 0 {
+		return Invite{}, fmt.Errorf("group invite: public mode must not carry an AES key")
+	}
+	if inv.ID == "" {
+		return Invite{}, fmt.Errorf("group invite: empty ID")
+	}
+	if inv.OwnerPK == (cipher.PubKey{}) {
+		return Invite{}, fmt.Errorf("group invite: empty OwnerPK")
+	}
+	if inv.Port == 0 {
+		return Invite{}, fmt.Errorf("group invite: zero Port")
+	}
+	return inv, nil
+}
+
+// GenerateAESKey returns a fresh 32-byte key sourced from
+// crypto/rand. Used at create time for ModePrivate groups.
+func GenerateAESKey() ([]byte, error) {
+	k := make([]byte, 32)
+	if _, err := rand.Read(k); err != nil {
+		return nil, fmt.Errorf("group invite: gen AES key: %w", err)
+	}
+	return k, nil
+}

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -1,0 +1,412 @@
+// Package group — cmd/apps/skychat/group/manager.go: orchestrates
+// this visor's collection of group sessions, parallel to pairing.Manager.
+//
+// The Manager owns the bbolt Store and a map[groupID]*Session of
+// live runtime state. It glues persistence to lifecycle:
+//
+//   - Create: owner-side; allocates port + AES key (private mode),
+//     persists the record, opens the publisher.
+//   - Join: member-side; takes an invite, persists the record,
+//     opens the subscriber + Connect.
+//   - Leave: member-side; transitions to StatusLeft and tears the
+//     session down.
+//   - Delete: owner-side; revokes the record, tears down.
+//   - Resume: on startup, walk the store and reopen everything
+//     that's still active.
+//   - SendToGroup: owner-side relay path. Member-side outgoing is
+//     handled by skychat's existing 1:1 wire with a group_id tag;
+//     the skychat app calls this on the owner side after receiving
+//     such a message.
+//
+// Message fan-out: a single MessageHandler is installed at Manager
+// init and propagated to every Session, so skychat's hub just
+// receives a (groupID, senderPK, msg) tuple and turns it into an
+// SSE event.
+package group
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Manager owns the persistent record set and live Session instances.
+// Safe for concurrent use.
+type Manager struct {
+	store   *Store
+	dmsgC   *dmsg.Client
+	myPK    cipher.PubKey
+	mySK    cipher.SecKey
+	dataDir string
+	log     *logging.Logger
+
+	// portAlloc decides which DMSG port to assign to a brand-new
+	// owner-side group. Defaults to a random pick from a reserved
+	// range; tests override it.
+	portAlloc func() (uint16, error)
+
+	onMessageMu sync.RWMutex
+	onMessage   MessageHandler
+
+	mu       sync.RWMutex
+	sessions map[string]*Session
+}
+
+// ManagerConfig wires a Manager.
+type ManagerConfig struct {
+	Store   *Store
+	DmsgC   *dmsg.Client
+	MyPK    cipher.PubKey
+	MySK    cipher.SecKey
+	DataDir string
+	Logger  *logging.Logger
+}
+
+// NewManager constructs a manager. Does not open any sessions; call
+// Resume to bring up everything in the store.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	if cfg.Store == nil {
+		return nil, errors.New("group: NewManager: Store required")
+	}
+	if cfg.DmsgC == nil {
+		return nil, errors.New("group: NewManager: DmsgC required")
+	}
+	if cfg.DataDir == "" {
+		return nil, errors.New("group: NewManager: DataDir required")
+	}
+	log := cfg.Logger
+	if log == nil {
+		log = logging.MustGetLogger("skychat-group-manager")
+	}
+	return &Manager{
+		store:     cfg.Store,
+		dmsgC:     cfg.DmsgC,
+		myPK:      cfg.MyPK,
+		mySK:      cfg.MySK,
+		dataDir:   cfg.DataDir,
+		log:       log,
+		portAlloc: defaultPortAlloc,
+		sessions:  make(map[string]*Session),
+	}, nil
+}
+
+// SetMessageHandler installs the inbound callback. Propagated to
+// every live Session.
+func (m *Manager) SetMessageHandler(h MessageHandler) {
+	m.onMessageMu.Lock()
+	m.onMessage = h
+	m.onMessageMu.Unlock()
+	m.mu.RLock()
+	for _, s := range m.sessions {
+		s.SetMessageHandler(h)
+	}
+	m.mu.RUnlock()
+}
+
+// Create constructs a new owner-side group, persists it, and opens
+// the publisher. Returns the persisted Record (with ID + Port + key
+// populated) so the caller can build the invite link.
+func (m *Manager) Create(name string, mode Mode, initialMembers []cipher.PubKey) (Record, error) {
+	if name == "" {
+		return Record{}, errors.New("group: Create: name required")
+	}
+	if !mode.IsValid() {
+		return Record{}, fmt.Errorf("group: Create: invalid mode %q", mode)
+	}
+	port, err := m.portAlloc()
+	if err != nil {
+		return Record{}, fmt.Errorf("group: Create: port: %w", err)
+	}
+	r := Record{
+		ID:        uuid.NewString(),
+		Name:      name,
+		OwnerPK:   m.myPK,
+		Port:      port,
+		Mode:      mode,
+		Members:   uniqueWithSelf(m.myPK, initialMembers),
+		Role:      RoleOwner,
+		Status:    StatusActive,
+		CreatedAt: time.Now().UTC(),
+		JoinedAt:  time.Now().UTC(),
+	}
+	if mode == ModePrivate {
+		key, err := GenerateAESKey()
+		if err != nil {
+			return Record{}, err
+		}
+		r.AESKey = key
+	}
+	if err := m.store.Put(r); err != nil {
+		return Record{}, fmt.Errorf("group: Create: store: %w", err)
+	}
+	if _, err := m.openLocked(r); err != nil {
+		_ = m.store.Delete(r.ID) //nolint:errcheck
+		return Record{}, err
+	}
+	return r, nil
+}
+
+// Join accepts an invite link, persists a member-side record, and
+// opens a subscriber connected to the owner. Returns the record.
+func (m *Manager) Join(inv Invite) (Record, error) {
+	if inv.OwnerPK == m.myPK {
+		return Record{}, errors.New("group: Join: refusing to subscribe to own group")
+	}
+	r := Record{
+		ID:        inv.ID,
+		Name:      inv.Name,
+		OwnerPK:   inv.OwnerPK,
+		Port:      inv.Port,
+		Mode:      inv.Mode,
+		AESKey:    inv.AESKey,
+		Members:   []cipher.PubKey{inv.OwnerPK, m.myPK},
+		Role:      RoleMember,
+		Status:    StatusPending,
+		CreatedAt: time.Now().UTC(),
+		JoinedAt:  time.Now().UTC(),
+	}
+	if err := m.store.Put(r); err != nil {
+		return Record{}, fmt.Errorf("group: Join: store: %w", err)
+	}
+	sess, err := m.openLocked(r)
+	if err != nil {
+		_ = m.store.Delete(r.ID) //nolint:errcheck
+		return Record{}, err
+	}
+	if err := sess.Connect(); err != nil {
+		_ = sess.Close()         //nolint:errcheck
+		_ = m.store.Delete(r.ID) //nolint:errcheck
+		return Record{}, fmt.Errorf("group: Join: connect: %w", err)
+	}
+	_ = m.store.SetStatus(r.ID, StatusActive) //nolint:errcheck
+	r.Status = StatusActive
+	return r, nil
+}
+
+// Leave (member) or Delete (owner): both tear down the session and
+// move the record to a terminal status. Idempotent on a missing or
+// already-terminal record.
+func (m *Manager) Leave(id string) error { return m.terminate(id, StatusLeft) }
+
+// Delete tears down an owner-side group and marks it revoked.
+func (m *Manager) Delete(id string) error { return m.terminate(id, StatusRevoked) }
+
+func (m *Manager) terminate(id string, status Status) error {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return fmt.Errorf("group: terminate: get %s: %w", id, err)
+	}
+	if !ok {
+		return nil // already gone
+	}
+	m.mu.Lock()
+	sess, live := m.sessions[id]
+	if live {
+		delete(m.sessions, id)
+	}
+	m.mu.Unlock()
+	if live {
+		_ = sess.Close() //nolint:errcheck
+	}
+	_ = m.store.SetStatus(r.ID, status) //nolint:errcheck
+	return nil
+}
+
+// SendToGroup publishes a message into the named group's CXO feed.
+// Caller must be the owner of the group (member-side outgoing messages
+// flow through the skychat 1:1 wire to the owner, which then calls
+// SendToGroup as the relay step). Returns ErrNotOwner if invoked for
+// a member-role record.
+func (m *Manager) SendToGroup(id, text string) error {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("group: SendToGroup: no live session for %s", id)
+	}
+	if err := sess.Send(text); err != nil {
+		return err
+	}
+	_ = m.store.MarkMessage(id, time.Now().UTC()) //nolint:errcheck
+	return nil
+}
+
+// AddMember (owner) extends the allowlist + persisted member list.
+// Returns the updated record so the caller can re-issue the invite.
+func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return Record{}, fmt.Errorf("group: AddMember: get: %w", err)
+	}
+	if !ok {
+		return Record{}, fmt.Errorf("group: AddMember: no record for %s", id)
+	}
+	if r.Role != RoleOwner {
+		return Record{}, errors.New("group: AddMember: only owner-role can edit")
+	}
+	for _, existing := range r.Members {
+		if existing == pk {
+			return r, nil // already present, idempotent
+		}
+	}
+	r.Members = append(r.Members, pk)
+	if err := m.store.Put(r); err != nil {
+		return Record{}, fmt.Errorf("group: AddMember: store: %w", err)
+	}
+	m.mu.RLock()
+	sess, live := m.sessions[id]
+	m.mu.RUnlock()
+	if live {
+		_ = sess.SetAllowlist(r.Members) //nolint:errcheck
+	}
+	return r, nil
+}
+
+// Resume walks the store and reopens every non-terminal session.
+// Records in StatusLeft / StatusRevoked are skipped; the operator
+// can `group join <invite>` again to bring them back.
+func (m *Manager) Resume() error {
+	all, err := m.store.List()
+	if err != nil {
+		return fmt.Errorf("group: Resume: list: %w", err)
+	}
+	for _, r := range all {
+		if r.Status == StatusLeft || r.Status == StatusRevoked {
+			continue
+		}
+		if _, err := m.openLocked(r); err != nil {
+			m.log.WithError(err).WithField("id", r.ID).
+				Warn("group: Resume: skipping session")
+			continue
+		}
+		if r.Role == RoleMember {
+			m.mu.RLock()
+			sess := m.sessions[r.ID]
+			m.mu.RUnlock()
+			if err := sess.Connect(); err != nil {
+				m.log.WithError(err).WithField("id", r.ID).
+					Warn("group: Resume: member subscribe connect")
+				// Keep the record but mark pending for now; a future
+				// Reconnect step (not in v1) can retry.
+				_ = m.store.SetStatus(r.ID, StatusPending) //nolint:errcheck
+			}
+		}
+	}
+	return nil
+}
+
+// Close tears down every live session and returns the first error.
+// Does NOT close the Store — caller still owns that.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	sessions := m.sessions
+	m.sessions = make(map[string]*Session)
+	m.mu.Unlock()
+	var firstErr error
+	for _, s := range sessions {
+		if err := s.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// Get returns the persisted record for an ID.
+func (m *Manager) Get(id string) (Record, bool, error) { return m.store.Get(id) }
+
+// List returns every persisted record.
+func (m *Manager) List() ([]Record, error) { return m.store.List() }
+
+// BuildInvite encodes an invite link for an owner-side group. Returns
+// an error for member-side records (members can't invite in D1; only
+// the owner controls the allowlist).
+func (m *Manager) BuildInvite(id string) (string, error) {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("group: BuildInvite: no record for %s", id)
+	}
+	if r.Role != RoleOwner {
+		return "", errors.New("group: BuildInvite: only owners can issue invites")
+	}
+	return EncodeInvite(Invite{
+		ID:      r.ID,
+		Name:    r.Name,
+		OwnerPK: r.OwnerPK,
+		Port:    r.Port,
+		Mode:    r.Mode,
+		AESKey:  r.AESKey,
+	})
+}
+
+// openLocked is the shared "open and remember" helper. Caller does
+// not need to hold m.mu — this method acquires it.
+func (m *Manager) openLocked(r Record) (*Session, error) {
+	m.onMessageMu.RLock()
+	h := m.onMessage
+	m.onMessageMu.RUnlock()
+	sess, err := Open(Config{
+		MyPK:    m.myPK,
+		MySK:    m.mySK,
+		Record:  r,
+		DmsgC:   m.dmsgC,
+		DataDir: m.dataDir,
+		Logger:  m.log,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("group: open %s: %w", r.ID, err)
+	}
+	if h != nil {
+		sess.SetMessageHandler(h)
+	}
+	m.mu.Lock()
+	m.sessions[r.ID] = sess
+	m.mu.Unlock()
+	return sess, nil
+}
+
+// defaultPortAlloc picks a random DMSG port in the range
+// [GroupPortBase, GroupPortBase+GroupPortSpan). Mirrors pairing's
+// deterministic allocator in spirit but uses randomness because a
+// group has no canonical "(a, b)" pair to hash from — only one
+// owner, and the same owner might run many groups. Tests override
+// via portAlloc.
+func defaultPortAlloc() (uint16, error) {
+	const (
+		base = uint16(60000)
+		span = uint16(5000) // [60000, 65000), well clear of the pair range
+	)
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0, err
+	}
+	raw := uint16(b[0])<<8 | uint16(b[1])
+	return base + raw%span, nil
+}
+
+// uniqueWithSelf de-duplicates `extras` and ensures self is included.
+// Owner-side semantics: the owner is always in their own allowlist
+// so resuming after an unclean shutdown doesn't accidentally lock
+// the owner out (`SetAllowlist([]pk{member1, member2})` minus self).
+func uniqueWithSelf(self cipher.PubKey, extras []cipher.PubKey) []cipher.PubKey {
+	seen := map[cipher.PubKey]struct{}{self: {}}
+	out := []cipher.PubKey{self}
+	for _, pk := range extras {
+		if _, dup := seen[pk]; dup {
+			continue
+		}
+		seen[pk] = struct{}{}
+		out = append(out, pk)
+	}
+	return out
+}

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -47,7 +47,7 @@ import (
 )
 
 // MessagePathPrefix is the prefix used for message leaves within a
-// group feed. Matches the pairing analogue so an operator who
+// group feed. Matches the pairing analog so an operator who
 // understands one understands both.
 const MessagePathPrefix = "msgs"
 

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1,0 +1,335 @@
+// Package group — cmd/apps/skychat/group/session.go: runtime
+// lifecycle for one live group, parallel to pairing.Pair.
+//
+// One Session per (group, role) pair on each visor:
+//
+//   - Owner role: hosts a treestore.Publisher with
+//     SubscriberAllowlist set to every member's PK. Send writes
+//     leaves under "msgs/<ts-nano>/<seq>" which subscribers pick up.
+//     No subscriber on this side — owner doesn't need to "hear
+//     themselves back" since Send fans out locally via the skychat
+//     hub before publishing.
+//
+//   - Member role: hosts a treestore.Subscriber connected to the
+//     owner's group feed on the deterministic port from Record.Port.
+//     No publisher in D1. Outgoing messages (when wired into
+//     skychat) go to the owner via the existing 1:1 pair-control
+//     wire with a group_id tag; owner relays into the feed.
+//
+// Encryption: if the record's Mode is ModePrivate, AES-256-GCM
+// envelope wraps the message body before Put and unwraps on
+// receive. If ModePublic, the body is plaintext JSON. This is the
+// only divergence from pairing.Pair — pairing always encrypts via
+// the ECDH-derived per-pair key.
+//
+// Phase 2 (project memo project_windows_autoconfig_parity refers
+// only to the Windows track; this is the group-chat track) shifts
+// to distributed publishers so the owner is no longer a SPOF: each
+// member publishes their own message feed, subscribers follow the
+// owner's membership feed and every member's message feed. The
+// Session type as written here is forward-compatible — Phase 2
+// just spins up multiple Sessions per group, one per remote member.
+package group
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// MessagePathPrefix is the prefix used for message leaves within a
+// group feed. Matches the pairing analogue so an operator who
+// understands one understands both.
+const MessagePathPrefix = "msgs"
+
+// MessageHandler is invoked on every newly-arrived group message
+// after decryption (for private groups). Called from the
+// subscriber's update goroutine; implementations must not block.
+//
+// The senderPK is the member who published the message (extracted
+// from the decoded Message.SenderPK field, not from the CXO leaf
+// path, so a malicious owner who relays from another member can't
+// spoof attribution beyond what the sender's signature already
+// gates).
+type MessageHandler func(groupID string, senderPK cipher.PubKey, msg Message)
+
+// Config bundles the inputs Session.Open needs. Mirrors
+// pairing.Config where it makes sense; Record + Role replace the
+// PeerPK-shaped fields.
+type Config struct {
+	// MyPK / MySK identify this visor.
+	MyPK cipher.PubKey
+	MySK cipher.SecKey
+
+	// Record is the persisted group state. The session inherits ID,
+	// OwnerPK, Port, Mode, AESKey, Members, and Role from it. The
+	// caller must have already loaded this from group.Store.
+	Record Record
+
+	// DmsgC is the shared DMSG client.
+	DmsgC *dmsg.Client
+
+	// DataDir is the per-visor parent directory for CXO state. Each
+	// Session carves its own group/<id>/ subtree inside it.
+	DataDir string
+
+	// Logger is optional; nil falls back to a tag-based default.
+	Logger *logging.Logger
+
+	// BatchWindow forwards to the publisher (see treestore.PubConfig).
+	BatchWindow time.Duration
+}
+
+// Session is one live group as this visor knows it — either as the
+// owner (publisher) or as a member (subscriber). Safe for concurrent
+// use after Open returns; Send / Close may be called from any
+// goroutine.
+type Session struct {
+	cfg  Config
+	port uint16
+
+	// Exactly one of pub or sub is non-nil, decided by cfg.Record.Role.
+	pub *treestore.Publisher
+	sub *treestore.Subscriber
+
+	// seq disambiguates messages with the same nanosecond timestamp.
+	// Owner-scoped (members don't publish in D1), but lives on the
+	// Session so the Phase-2-future where every member is a publisher
+	// just works.
+	seq atomic.Uint64
+
+	handler MessageHandler
+	log     *logging.Logger
+}
+
+// Open constructs the session's CXO node and brings up the role-
+// appropriate publisher OR subscriber. For owner role, the
+// publisher's SubscriberAllowlist is set to every member PK in the
+// record. For member role, the subscriber is created attached to a
+// fresh CXO node and waits for Connect to dial the owner.
+func Open(cfg Config) (*Session, error) {
+	if cfg.DmsgC == nil {
+		return nil, errors.New("group: Open: DmsgC required")
+	}
+	if cfg.Record.ID == "" {
+		return nil, errors.New("group: Open: Record.ID required")
+	}
+	if cfg.Record.OwnerPK == (cipher.PubKey{}) {
+		return nil, errors.New("group: Open: Record.OwnerPK required")
+	}
+	if cfg.Record.Port == 0 {
+		return nil, errors.New("group: Open: Record.Port required")
+	}
+	if !cfg.Record.Mode.IsValid() {
+		return nil, fmt.Errorf("group: Open: invalid Mode %q", cfg.Record.Mode)
+	}
+	if cfg.Record.Mode == ModePrivate && len(cfg.Record.AESKey) != 32 {
+		return nil, fmt.Errorf("group: Open: private mode requires 32-byte AESKey, got %d", len(cfg.Record.AESKey))
+	}
+	if cfg.DataDir == "" {
+		return nil, errors.New("group: Open: DataDir required")
+	}
+
+	log := cfg.Logger
+	if log == nil {
+		log = logging.MustGetLogger("skychat-group")
+	}
+
+	switch cfg.Record.Role {
+	case RoleOwner:
+		return openOwner(cfg, log)
+	case RoleMember:
+		return openMember(cfg, log)
+	default:
+		return nil, fmt.Errorf("group: Open: invalid Role %q", cfg.Record.Role)
+	}
+}
+
+// openOwner brings up a publisher with the member allowlist.
+func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
+	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
+		BatchWindow:         cfg.BatchWindow,
+		Logger:              log,
+		DataDir:             filepath.Join(cfg.DataDir, "group", cfg.Record.ID),
+		DmsgPort:            cfg.Record.Port,
+		SubscriberAllowlist: append([]cipher.PubKey(nil), cfg.Record.Members...),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("group: Open owner: build publisher: %w", err)
+	}
+	return &Session{cfg: cfg, port: cfg.Record.Port, pub: pub, log: log}, nil
+}
+
+// openMember creates a subscriber. The connect-to-owner step is
+// deferred to Connect so the caller controls ordering (e.g. after
+// the local Record is persisted, before announcing membership to
+// other apps).
+func openMember(cfg Config, log *logging.Logger) (*Session, error) {
+	// Member needs a CXO node to host the subscriber on. We build a
+	// throwaway publisher with an empty allowlist (no one subscribes
+	// to a member's per-group feed in D1) just to get a node. Phase
+	// 2 turns this into a real per-member outbox feed.
+	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
+		BatchWindow:         cfg.BatchWindow,
+		Logger:              log,
+		DataDir:             filepath.Join(cfg.DataDir, "group", cfg.Record.ID, "member"),
+		DmsgPort:            cfg.Record.Port + 1, // separate port; owner owns Record.Port
+		SubscriberAllowlist: []cipher.PubKey{},   // empty = nobody allowed
+	})
+	if err != nil {
+		return nil, fmt.Errorf("group: Open member: build local node: %w", err)
+	}
+	sub, err := treestore.NewSubscriberOnNode(pub.Node(), cfg.Record.OwnerPK, treestore.SubConfig{
+		Logger: log,
+	})
+	if err != nil {
+		_ = pub.Close() //nolint:errcheck
+		return nil, fmt.Errorf("group: Open member: attach subscriber: %w", err)
+	}
+	sub.SetPrefixes([]string{MessagePathPrefix})
+	s := &Session{cfg: cfg, port: cfg.Record.Port, pub: pub, sub: sub, log: log}
+	sub.OnUpdate(s.onUpdate)
+	return s, nil
+}
+
+// Connect dials the owner's CXO node and starts the subscribe
+// handshake. Owner sessions are a no-op (they don't subscribe to
+// themselves). Idempotent: returns nil if already connected.
+func (s *Session) Connect() error {
+	if s.sub == nil {
+		return nil // owner role
+	}
+	if err := s.sub.Connect(s.cfg.Record.OwnerPK); err != nil {
+		return fmt.Errorf("group: Connect: %w", err)
+	}
+	return nil
+}
+
+// ID returns the group's UUID.
+func (s *Session) ID() string { return s.cfg.Record.ID }
+
+// Port returns the DMSG port this session uses.
+func (s *Session) Port() uint16 { return s.port }
+
+// SetMessageHandler registers (or replaces) the inbound-message
+// callback. Pass nil to unregister.
+func (s *Session) SetMessageHandler(h MessageHandler) {
+	s.handler = h
+}
+
+// Send publishes a chat message. Owner-side only in D1: members
+// must POST to the owner via the existing 1:1 pair-control wire
+// with a group_id tag, and the owner's skychat app calls Send to
+// relay into the feed. Returns an error if invoked on a member-role
+// session.
+//
+// For ModePrivate groups, the body is AES-256-GCM-sealed before
+// being stored as the leaf value. The path itself (timestamp +
+// seq) stays plaintext.
+func (s *Session) Send(text string) error {
+	if s.pub == nil || s.cfg.Record.Role != RoleOwner {
+		return errors.New("group: Send: only owner-role sessions can publish in D1")
+	}
+	now := time.Now().UTC()
+	msg := Message{
+		SenderPK: s.cfg.MyPK,
+		TS:       now,
+	}
+	switch s.cfg.Record.Mode {
+	case ModePublic:
+		msg.Text = text
+	case ModePrivate:
+		ct, nonce, err := Encrypt(s.cfg.Record.AESKey, []byte(text))
+		if err != nil {
+			return fmt.Errorf("group: Send: %w", err)
+		}
+		msg.Ciphertext = ct
+		msg.Nonce = nonce
+	}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("group: Send: marshal: %w", err)
+	}
+	seq := s.seq.Add(1)
+	path := MessagePathPrefix + "/" + strconv.FormatInt(now.UnixNano(), 10) + "/" + strconv.FormatUint(seq, 10)
+	if err := s.pub.Put(path, body); err != nil {
+		return fmt.Errorf("group: Send: put %q: %w", path, err)
+	}
+	return nil
+}
+
+// SetAllowlist updates the publisher's subscriber allowlist to the
+// given member set. Owner-side only. Used when an invite is issued
+// or a member is removed.
+func (s *Session) SetAllowlist(members []cipher.PubKey) error {
+	if s.pub == nil || s.cfg.Record.Role != RoleOwner {
+		return errors.New("group: SetAllowlist: only owner-role sessions have an allowlist")
+	}
+	s.pub.SetAllowlist(append([]cipher.PubKey(nil), members...))
+	return nil
+}
+
+// Close tears down the subscriber + publisher (and the underlying
+// CXO node, owned by the publisher). Idempotent.
+func (s *Session) Close() error {
+	var firstErr error
+	if s.sub != nil {
+		if err := s.sub.Close(); err != nil {
+			firstErr = err
+		}
+		s.sub = nil
+	}
+	if s.pub != nil {
+		if err := s.pub.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		s.pub = nil
+	}
+	return firstErr
+}
+
+// onUpdate is the subscriber callback for member-role sessions.
+// Decodes each leaf, decrypts if private, and dispatches via the
+// registered handler. Tolerates undecodable leaves (e.g. future
+// metadata under a different prefix, or a tampered ciphertext) by
+// silently dropping them with a debug log.
+func (s *Session) onUpdate(events []treestore.UpdateEvent) {
+	h := s.handler
+	if h == nil {
+		return
+	}
+	for _, ev := range events {
+		if ev.Value == nil {
+			continue
+		}
+		var msg Message
+		if err := json.Unmarshal(ev.Value, &msg); err != nil {
+			s.log.WithError(err).WithField("path", ev.Path).
+				Debug("group: ignoring undecodable leaf")
+			continue
+		}
+		if s.cfg.Record.Mode == ModePrivate {
+			plain, err := Decrypt(s.cfg.Record.AESKey, msg.Ciphertext, msg.Nonce)
+			if err != nil {
+				s.log.WithError(err).WithField("path", ev.Path).
+					Debug("group: ignoring leaf failing decrypt")
+				continue
+			}
+			msg.Text = string(plain)
+			// Don't expose the ciphertext to handlers; they should
+			// only see plaintext from this point.
+			msg.Ciphertext = nil
+			msg.Nonce = nil
+		}
+		h(s.cfg.Record.ID, msg.SenderPK, msg)
+	}
+}

--- a/cmd/apps/skychat/group/store.go
+++ b/cmd/apps/skychat/group/store.go
@@ -1,0 +1,172 @@
+// Package group — cmd/apps/skychat/group/store.go: bbolt-backed
+// persistence for chat groups.
+//
+// One bucket "groups" with key = group UUID, value = JSON Record.
+// Layout parallels pairing.Store deliberately so an operator who
+// understands one understands both.
+package group
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+const groupsBucket = "groups"
+
+// Store is a bolt-backed group record store. Safe for concurrent use.
+type Store struct {
+	db *bolt.DB
+	mu sync.RWMutex
+}
+
+// OpenStore opens (or creates) the bolt file at path. The parent dir
+// is created if missing.
+func OpenStore(path string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("group: mkdir parent: %w", err)
+	}
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 2 * time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("group: open bolt: %w", err)
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, e := tx.CreateBucketIfNotExists([]byte(groupsBucket))
+		return e
+	}); err != nil {
+		_ = db.Close() //nolint:errcheck
+		return nil, fmt.Errorf("group: init bucket: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
+// Close releases the bolt file handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Put writes (or replaces) the record for r.ID.
+func (s *Store) Put(r Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r.ID == "" {
+		return fmt.Errorf("group: Put: empty ID")
+	}
+	body, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("group: marshal record: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(groupsBucket))
+		return b.Put([]byte(r.ID), body)
+	})
+}
+
+// Get returns the record for id and a boolean indicating presence.
+func (s *Store) Get(id string) (Record, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var (
+		r     Record
+		found bool
+	)
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(groupsBucket))
+		raw := b.Get([]byte(id))
+		if raw == nil {
+			return nil
+		}
+		found = true
+		return json.Unmarshal(raw, &r)
+	})
+	return r, found, err
+}
+
+// List returns every persisted record. Order is bolt's bucket-sorted
+// order (lexicographic on the UUID string).
+func (s *Store) List() ([]Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []Record
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(groupsBucket))
+		return b.ForEach(func(_, v []byte) error {
+			var r Record
+			if err := json.Unmarshal(v, &r); err != nil {
+				return err
+			}
+			out = append(out, r)
+			return nil
+		})
+	})
+	return out, err
+}
+
+// Delete removes the record for id. No-op if absent.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(groupsBucket))
+		return b.Delete([]byte(id))
+	})
+}
+
+// SetStatus updates only the Status field of an existing record.
+// Returns an error if no record exists for id.
+func (s *Store) SetStatus(id string, status Status) error {
+	return s.update(id, func(r *Record) {
+		r.Status = status
+	})
+}
+
+// MarkMessage updates LastMessageAt to the given timestamp.
+func (s *Store) MarkMessage(id string, ts time.Time) error {
+	return s.update(id, func(r *Record) {
+		r.LastMessageAt = ts
+	})
+}
+
+// SetMembers replaces the Members slice. Owner-side: drives
+// Publisher.SetAllowlist on the next push. Member-side: updates the
+// "who's in this room" display.
+func (s *Store) SetMembers(id string, members []cipher.PubKey) error {
+	return s.update(id, func(r *Record) {
+		r.Members = members
+	})
+}
+
+// update is the shared read-modify-write helper. Acquires the write
+// lock, loads the record, applies fn, and saves. Returns an error
+// if no record exists for id.
+func (s *Store) update(id string, fn func(*Record)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(groupsBucket))
+		raw := b.Get([]byte(id))
+		if raw == nil {
+			return fmt.Errorf("group: no record for %s", id)
+		}
+		var r Record
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return err
+		}
+		fn(&r)
+		body, err := json.Marshal(&r)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(id), body)
+	})
+}

--- a/cmd/skywire-cli/commands/dmsg/chat.go
+++ b/cmd/skywire-cli/commands/dmsg/chat.go
@@ -1,0 +1,641 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/chat.go: standalone
+// dmsg-only chat. Run when the local visor is down (or absent) so
+// operators can still reach a support channel.
+//
+// The visor-app skychat (cmd/apps/skychat) uses the visor's identity
+// and the visor's dmsg.Client — its main strength is sharing the same
+// PK operators publish in service-discovery, but the cost is "if the
+// visor is broken, skychat is broken too." This command sidesteps
+// that: it stands up its OWN dmsg.Client with a separate secret key,
+// listens on a dmsg port for inbound chat, and dials peers directly
+// over dmsg for outbound. No visor RPC, no route-finder, no skynet.
+//
+// Wire format mirrors the visor-app skychat post PR #2504:
+//
+//	[4-byte BE length][JSON envelope]
+//
+// where the JSON shape is {"sender","message","ts","network"}. Two
+// skywire dmsg chat instances can talk to each other; cross-talk
+// with visor-app skychat works if the visor-app side is also on the
+// post-#2504 framed protocol.
+//
+// Why a TUI rather than send/listen subcommands like dmsgcurl: the
+// expected use is interactive — an operator opens it, types a few
+// messages back and forth with support, closes it. send/listen
+// would force the operator to manage two terminal windows. Same
+// reasoning as `skywire cli skychat chat`.
+package clidmsg
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+const (
+	// chatDmsgPort is the dmsg port `skywire dmsg chat` listens on
+	// by default. 9001 sits well clear of the visor's reserved
+	// system ports (everything <300 plus the 80/100/136 cluster)
+	// AND outside the visor app routing-port range, so two
+	// standalone instances and a visor with skychat can coexist
+	// on the same dmsg-discovery without port collisions. Operator
+	// can override with --port.
+	chatDmsgPort = uint16(9001)
+	// chatMaxFrameSize bounds claimed-length sanity on the read
+	// side. 64 KiB matches the visor-app skychat ceiling so a
+	// peer running either implementation can write the largest
+	// frame the other accepts.
+	chatMaxFrameSize = 64 * 1024
+)
+
+var (
+	chatTo   string
+	chatPort uint16
+)
+
+func init() {
+	chatCmd.Flags().SortFlags = false
+	chatCmd.Flags().VarP(&sk, "sk", "s",
+		"secret key for the standalone dmsg client (a random one is generated if unset; required for stable identity across sessions)")
+	chatCmd.Flags().StringVarP(&chatTo, "to", "t", "",
+		"recipient public key (optional; TUI prompts if omitted)")
+	chatCmd.Flags().Uint16VarP(&chatPort, "port", "p", chatDmsgPort,
+		"local dmsg port to listen on for inbound chat")
+	chatCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal",
+		"[ debug | warn | error | fatal | panic | trace | info ]")
+	if env := os.Getenv("DMSG_SK"); env != "" {
+		sk.Set(env) //nolint:errcheck,gosec
+	}
+}
+
+var chatCmd = &cobra.Command{
+	Use:   "chat",
+	Short: "Interactive chat over dmsg (standalone, no visor required)",
+	Long: `DMSG chat — interactive 1:1 messaging directly over the dmsg network.
+
+Standalone tool: stands up its own dmsg.Client using --sk (or a
+randomly-generated key if --sk is omitted), listens on --port for
+inbound, dials peers over dmsg for outbound. Use this when the local
+visor is down or absent and you still need to reach a peer.
+
+Identity note: --sk gives the standalone client a stable public key.
+Without --sk, every invocation gets a fresh PK and any peer trying to
+reach you needs to be re-told the new PK. Set DMSG_SK env or pass
+--sk to keep an identity across sessions.
+
+Recipient: pass --to <pk> to pin the conversation, or run without
+--to to drop into pick-a-peer mode (the TUI prompts).
+
+Ctrl+C / Esc to quit.`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		log := logging.MustGetLogger("dmsg-chat")
+		if logLvl != "" {
+			if lvl, err := logging.LevelFromString(logLvl); err == nil {
+				logging.SetLevel(lvl)
+			}
+		}
+
+		// Resolve identity. If --sk wasn't passed, generate a fresh
+		// keypair — gives the operator a working session but a
+		// rolling PK. Stable PK requires --sk on every call.
+		myPK, mySK := resolveChatIdentity(sk)
+		if !cmd.Flags().Changed("sk") && os.Getenv("DMSG_SK") == "" {
+			fmt.Fprintf(os.Stderr,
+				"WARN: ephemeral identity. Your PK is %s — peers can't reach you across sessions. Use --sk or DMSG_SK= for a stable identity.\n\n",
+				myPK)
+		}
+
+		// Validate --to up front if provided. Empty value drops the
+		// TUI into pick-a-peer mode.
+		recipient := ""
+		if chatTo != "" {
+			var rpk cipher.PubKey
+			if err := rpk.Set(chatTo); err != nil {
+				return fmt.Errorf("invalid --to public key %q: %w", chatTo, err)
+			}
+			recipient = rpk.String()
+		}
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		// Start dmsg client. startDmsgClient (curl.go) returns a
+		// usable client + close hook; ConnectMultiple is implicit
+		// inside the Serve / Ready dance.
+		dmsgC, closeDmsg, err := startDmsgClient(ctx, log, myPK, mySK)
+		if err != nil {
+			return fmt.Errorf("dmsg client: %w", err)
+		}
+		defer closeDmsg()
+
+		// Listen for inbound chat. Each accepted stream gets its own
+		// reader goroutine; messages funnel into the shared inCh
+		// which the TUI drains via tea.Cmd.
+		listener, err := dmsgC.Listen(chatPort)
+		if err != nil {
+			return fmt.Errorf("dmsg listen :%d: %w", chatPort, err)
+		}
+		defer listener.Close() //nolint:errcheck
+		log.WithField("port", chatPort).Info("dmsg chat listening")
+
+		inCh := make(chan incomingChatMsg, 64)
+		errCh := make(chan error, 1)
+		go acceptInbound(ctx, listener, log, inCh, errCh)
+
+		fmt.Fprintf(os.Stderr, "Your PK: %s\nListening on :%d\n\n", myPK, chatPort)
+
+		return runChatTUI(ctx, log, dmsgC, myPK, recipient, inCh, errCh)
+	},
+}
+
+// resolveChatIdentity returns the (PK, SK) the standalone client
+// runs as. If skFlag derives a valid PK, that pair is used;
+// otherwise a fresh keypair is generated. The signature returns an
+// error slot deliberately empty — kept on the API in case a future
+// SK-from-file path needs to surface I/O failures.
+func resolveChatIdentity(skFlag cipher.SecKey) (cipher.PubKey, cipher.SecKey) {
+	pk, err := skFlag.PubKey()
+	if err == nil {
+		return pk, skFlag
+	}
+	gpk, gsk := cipher.GenerateKeyPair()
+	return gpk, gsk
+}
+
+// incomingChatMsg is one inbound message after framing + JSON decode.
+type incomingChatMsg struct {
+	SenderPK string    `json:"sender"`
+	Message  string    `json:"message"`
+	TS       time.Time `json:"ts"`
+	Network  string    `json:"network"`
+}
+
+// outgoingChatMsg is what we marshal + send on the wire.
+type outgoingChatMsg = incomingChatMsg
+
+func acceptInbound(ctx context.Context, l net.Listener, log *logging.Logger,
+	out chan<- incomingChatMsg, errs chan<- error) {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			if ctx.Err() == nil {
+				select {
+				case errs <- err:
+				default:
+				}
+			}
+			return
+		}
+		go readInbound(ctx, c, log, out)
+	}
+}
+
+func readInbound(ctx context.Context, c net.Conn, log *logging.Logger, out chan<- incomingChatMsg) {
+	defer c.Close() //nolint:errcheck
+	for {
+		payload, err := readFrame(c)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.WithError(err).Debug("inbound read")
+			}
+			return
+		}
+		var msg incomingChatMsg
+		if err := json.Unmarshal(payload, &msg); err != nil {
+			log.WithError(err).Debug("inbound unmarshal")
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case out <- msg:
+		}
+	}
+}
+
+// readFrame reads one length-prefixed message. Mirrors the visor-app
+// skychat framed wire (#2504) so peers from either implementation
+// interop.
+func readFrame(c net.Conn) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(c, hdr[:]); err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint32(hdr[:])
+	if length == 0 {
+		return nil, errors.New("chat: zero-length frame")
+	}
+	if length > chatMaxFrameSize {
+		return nil, fmt.Errorf("chat: frame %d > max %d (peer running old unframed skychat?)", length, chatMaxFrameSize)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(c, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func writeFrame(c net.Conn, payload []byte) error {
+	if len(payload) == 0 {
+		return errors.New("chat: empty payload")
+	}
+	if len(payload) > chatMaxFrameSize {
+		return fmt.Errorf("chat: payload %d > max %d", len(payload), chatMaxFrameSize)
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) //nolint:gosec
+	if _, err := c.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := c.Write(payload)
+	return err
+}
+
+// ============================== TUI ==============================
+//
+// Bubbletea split-pane: viewport history on top, textinput compose
+// at the bottom. Parallel to cmd/skywire-cli/commands/skychat/chat.go
+// but talks dmsg.Client.DialStream directly instead of POSTing to a
+// local skychat HTTP server.
+
+type chatRow struct {
+	When   time.Time
+	Sender string
+	Body   string
+	Err    string // when set, this is a send-failure row (red)
+	Self   bool   // true for messages we sent
+}
+
+type chatModel struct {
+	ctx       context.Context
+	dmsgC     *dmsg.Client
+	myPK      string
+	recipient string
+	port      uint16
+
+	awaitingRecipient bool
+	recipientErr      string
+
+	history []chatRow
+	vp      viewport.Model
+	input   textinput.Model
+
+	width  int
+	height int
+	ready  bool
+
+	listenErr string
+
+	incoming <-chan incomingChatMsg
+	errs     <-chan error
+
+	// peerConnMu guards reuse of an open outbound stream to the
+	// pinned recipient. Re-dialing per message is correct but
+	// burns dmsg session capacity unnecessarily for a conversation
+	// of any length.
+	peerConnMu sync.Mutex
+	peerConn   net.Conn
+}
+
+type incomingTeaMsg struct{ msg incomingChatMsg }
+type listenErrTeaMsg struct{ err error }
+type sentTeaMsg struct {
+	body string
+	err  error
+}
+
+func runChatTUI(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client,
+	myPK cipher.PubKey, recipient string, incoming <-chan incomingChatMsg, errs <-chan error) error {
+
+	in := textinput.New()
+	in.Focus()
+	in.CharLimit = 4096
+	if recipient == "" {
+		in.Placeholder = "paste recipient PK (66 hex chars); Enter to confirm, Esc to quit"
+		in.Prompt = "to: "
+		in.CharLimit = 128
+	} else {
+		in.Placeholder = "type message; Enter to send, Esc to quit"
+		in.Prompt = "» "
+	}
+
+	m := &chatModel{
+		ctx:               ctx,
+		dmsgC:             dmsgC,
+		myPK:              myPK.String(),
+		recipient:         recipient,
+		port:              chatPort,
+		awaitingRecipient: recipient == "",
+		input:             in,
+		incoming:          incoming,
+		errs:              errs,
+	}
+	prog := tea.NewProgram(m, tea.WithAltScreen())
+	if _, err := prog.Run(); err != nil {
+		log.WithError(err).Debug("tui run")
+		return err
+	}
+	m.closePeerConn()
+	return nil
+}
+
+func (m *chatModel) Init() tea.Cmd {
+	return tea.Batch(textinput.Blink, m.waitIncoming(), m.waitListenErr())
+}
+
+func (m *chatModel) waitIncoming() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case <-m.ctx.Done():
+			return nil
+		case msg, ok := <-m.incoming:
+			if !ok {
+				return listenErrTeaMsg{err: errors.New("inbound channel closed")}
+			}
+			return incomingTeaMsg{msg: msg}
+		}
+	}
+}
+
+func (m *chatModel) waitListenErr() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case <-m.ctx.Done():
+			return nil
+		case err, ok := <-m.errs:
+			if !ok {
+				return nil
+			}
+			return listenErrTeaMsg{err: err}
+		}
+	}
+}
+
+func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		headerH := 2 // header + my-pk line
+		footerH := 2
+		if !m.ready {
+			m.vp = viewport.New(msg.Width, msg.Height-headerH-footerH)
+			m.vp.SetContent(m.renderHistory())
+			m.ready = true
+		} else {
+			m.vp.Width = msg.Width
+			m.vp.Height = msg.Height - headerH - footerH
+		}
+		m.input.Width = msg.Width - len(m.input.Prompt) - 1
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			return m, tea.Quit
+		case "enter":
+			text := m.input.Value()
+			if text == "" {
+				return m, nil
+			}
+			if m.awaitingRecipient {
+				var pk cipher.PubKey
+				if err := pk.Set(text); err != nil {
+					m.recipientErr = fmt.Sprintf("invalid PK: %v", err)
+					m.input.Reset()
+					return m, nil
+				}
+				m.recipient = pk.String()
+				m.awaitingRecipient = false
+				m.recipientErr = ""
+				m.input.Reset()
+				m.input.Placeholder = "type message; Enter to send, Esc to quit"
+				m.input.Prompt = "» "
+				m.input.CharLimit = 4096
+				if m.ready {
+					m.input.Width = m.width - len(m.input.Prompt) - 1
+				}
+				return m, nil
+			}
+			m.input.Reset()
+			body := text
+			cmds = append(cmds, func() tea.Msg {
+				err := m.sendOne(body)
+				return sentTeaMsg{body: body, err: err}
+			})
+		case "pgup":
+			m.vp.HalfPageUp()
+		case "pgdown":
+			m.vp.HalfPageDown()
+		}
+
+	case incomingTeaMsg:
+		m.append(chatRow{
+			When:   nonZeroTS(msg.msg.TS),
+			Sender: msg.msg.SenderPK,
+			Body:   msg.msg.Message,
+		})
+		cmds = append(cmds, m.waitIncoming())
+
+	case sentTeaMsg:
+		row := chatRow{
+			When:   time.Now().UTC(),
+			Sender: m.myPK,
+			Body:   msg.body,
+			Self:   true,
+		}
+		if msg.err != nil {
+			row.Err = msg.err.Error()
+		}
+		m.append(row)
+
+	case listenErrTeaMsg:
+		if msg.err != nil {
+			m.listenErr = msg.err.Error()
+		}
+	}
+
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	cmds = append(cmds, cmd)
+	if m.ready {
+		m.vp, cmd = m.vp.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *chatModel) append(row chatRow) {
+	m.history = append(m.history, row)
+	if !m.ready {
+		return
+	}
+	wasAtBottom := m.vp.AtBottom()
+	m.vp.SetContent(m.renderHistory())
+	if wasAtBottom {
+		m.vp.GotoBottom()
+	}
+}
+
+func (m *chatModel) sendOne(body string) error {
+	if m.recipient == "" {
+		return errors.New("no recipient")
+	}
+	var rpk cipher.PubKey
+	if err := rpk.Set(m.recipient); err != nil {
+		return err
+	}
+	c, err := m.ensurePeerConn(rpk)
+	if err != nil {
+		return err
+	}
+	env := outgoingChatMsg{
+		SenderPK: m.myPK,
+		Message:  body,
+		TS:       time.Now().UTC(),
+		Network:  "dmsg",
+	}
+	payload, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := writeFrame(c, payload); err != nil {
+		// Stream may have died; drop the cached conn so the next
+		// send re-dials. Don't bury the error; surface it on the
+		// failure row.
+		m.closePeerConn()
+		return fmt.Errorf("write: %w", err)
+	}
+	return nil
+}
+
+// ensurePeerConn returns an open framed stream to the pinned
+// recipient, dialing one if needed. Cached between calls — closed
+// when sendOne sees a write error so a half-dead conn doesn't
+// persist.
+func (m *chatModel) ensurePeerConn(rpk cipher.PubKey) (net.Conn, error) {
+	m.peerConnMu.Lock()
+	defer m.peerConnMu.Unlock()
+	if m.peerConn != nil {
+		return m.peerConn, nil
+	}
+	ctx, cancel := context.WithTimeout(m.ctx, 15*time.Second)
+	defer cancel()
+	stream, err := m.dmsgC.DialStream(ctx, dmsg.Addr{PK: rpk, Port: chatDmsgPort})
+	if err != nil {
+		return nil, fmt.Errorf("dial: %w", err)
+	}
+	m.peerConn = stream
+	return stream, nil
+}
+
+func (m *chatModel) closePeerConn() {
+	m.peerConnMu.Lock()
+	defer m.peerConnMu.Unlock()
+	if m.peerConn != nil {
+		_ = m.peerConn.Close() //nolint:errcheck
+		m.peerConn = nil
+	}
+}
+
+func nonZeroTS(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now().UTC()
+	}
+	return t
+}
+
+func (m *chatModel) renderHistory() string {
+	if len(m.history) == 0 {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("241")).
+			Render("(no messages yet — type below and hit Enter)")
+	}
+	youStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
+	peerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true)
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	var b lipgloss.Style
+	_ = b
+	out := ""
+	for _, row := range m.history {
+		ts := row.When.Format("15:04:05")
+		var sender string
+		if row.Self {
+			sender = youStyle.Render("you")
+		} else {
+			sender = peerStyle.Render(shortPK(row.Sender))
+		}
+		body := row.Body
+		if row.Err != "" {
+			body = errStyle.Render(fmt.Sprintf("✗ send failed: %s — %q", row.Err, row.Body))
+		}
+		out += fmt.Sprintf("%s %s  %s\n", dimStyle.Render(ts), sender, body)
+	}
+	return out
+}
+
+func shortPK(pk string) string {
+	if len(pk) <= 12 {
+		return pk
+	}
+	return pk[:12] + "…"
+}
+
+func (m *chatModel) View() string {
+	if !m.ready {
+		return "Initializing…\n"
+	}
+	hdrStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+
+	var header string
+	if m.awaitingRecipient {
+		hint := dimStyle.Render("pick a recipient PK below")
+		if m.recipientErr != "" {
+			hint = errStyle.Render(m.recipientErr)
+		}
+		header = fmt.Sprintf("%s  %s  port=:%d",
+			hdrStyle.Render("dmsg chat"), hint, m.port)
+	} else {
+		header = fmt.Sprintf("%s  %s  port=:%d",
+			hdrStyle.Render("dmsg chat"),
+			dimStyle.Render("to "+shortPK(m.recipient)), m.port)
+	}
+	if m.listenErr != "" {
+		header += "  " + errStyle.Render("[listen err: "+m.listenErr+"]")
+	}
+	myLine := dimStyle.Render("you = " + shortPK(m.myPK))
+
+	var footer string
+	if m.awaitingRecipient {
+		footer = dimStyle.Render("Enter confirm recipient | Esc/Ctrl+C quit")
+	} else {
+		footer = dimStyle.Render("Enter send | ↑/↓ PgUp/PgDn scroll | Esc/Ctrl+C quit")
+	}
+
+	return header + "\n" + myLine + "\n" + m.vp.View() + "\n" + m.input.View() + "\n" + footer
+}

--- a/cmd/skywire-cli/commands/dmsg/root.go
+++ b/cmd/skywire-cli/commands/dmsg/root.go
@@ -24,5 +24,6 @@ func init() {
 	RootCmd.AddCommand(
 		curlCmd,
 		ptyCmd,
+		chatCmd,
 	)
 }

--- a/cmd/skywire-cli/commands/skychat/chat.go
+++ b/cmd/skywire-cli/commands/skychat/chat.go
@@ -41,17 +41,28 @@ Top pane scrolls message history; bottom pane is the compose line.
 Enter sends. Esc or Ctrl+C quits. ↑/↓ or PgUp/PgDn scroll history.
 
 Requires the skychat app to be running (default --addr 127.0.0.1:8001).
-Use --to <pk> to pin outgoing messages to one recipient; incoming
-messages from other senders still appear in history.`,
+Use --to <pk> to pin outgoing messages to one recipient. When
+--to is omitted, the TUI starts in "pick a peer" mode and prompts
+for a PK in the compose line; on a valid hex PK the view
+transitions to chat. Incoming messages from any sender still
+appear in history.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		var pk cipher.PubKey
-		if err := pk.Set(recipient); err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --to public key %q: %w", recipient, err))
+		// Empty recipient is allowed: the TUI prompts for it.
+		// Anything non-empty must parse as a valid PK up front so
+		// a typo on the command line surfaces immediately rather
+		// than after the TUI takes over the terminal.
+		recipientPK := ""
+		if recipient != "" {
+			var pk cipher.PubKey
+			if err := pk.Set(recipient); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --to public key %q: %w", recipient, err))
+			}
+			recipientPK = pk.String()
 		}
 		if err := validateNetwork(sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		if err := runChatTUI(httpAddr, pk.String(), sendNet); err != nil {
+		if err := runChatTUI(httpAddr, recipientPK, sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 	},
@@ -90,6 +101,17 @@ type chatModel struct {
 	recipient string
 	network   string
 
+	// awaitingRecipient is true when the operator launched the
+	// TUI without --to <pk>. The textinput is repurposed as a
+	// "paste the recipient PK here" prompt; Enter validates and
+	// flips the model into chat mode. Mirrors the GUI's "enter
+	// recipient PK in the header" flow.
+	awaitingRecipient bool
+	// recipientErr surfaces the last PK-parse failure inline so
+	// the operator sees why their paste didn't take, instead of
+	// staring at an unchanged prompt.
+	recipientErr string
+
 	history []chatMsg
 	vp      viewport.Model
 	input   textinput.Model
@@ -107,10 +129,19 @@ type chatModel struct {
 
 func runChatTUI(addr, recipient, network string) error {
 	in := textinput.New()
-	in.Placeholder = "type message; Enter to send, Esc to quit"
 	in.Focus()
 	in.CharLimit = 4096
-	in.Prompt = "» "
+	if recipient == "" {
+		// Pick-a-peer mode: textinput accepts a 66-char hex PK.
+		// CharLimit bumped to fit a PK + small slack for paste
+		// noise. Prompt shape borrowed from the GUI's PK input.
+		in.Placeholder = "paste recipient PK (66 hex chars); Enter to confirm, Esc to quit"
+		in.Prompt = "to: "
+		in.CharLimit = 128
+	} else {
+		in.Placeholder = "type message; Enter to send, Esc to quit"
+		in.Prompt = "» "
+	}
 
 	inCh := make(chan chatMsg, 64)
 	errCh := make(chan error, 1)
@@ -118,13 +149,14 @@ func runChatTUI(addr, recipient, network string) error {
 	go streamSSE(ctx, addr, inCh, errCh)
 
 	m := &chatModel{
-		addr:      addr,
-		recipient: recipient,
-		network:   network,
-		input:     in,
-		sseLive:   true,
-		incoming:  inCh,
-		sseErrCh:  errCh,
+		addr:              addr,
+		recipient:         recipient,
+		network:           network,
+		input:             in,
+		sseLive:           true,
+		incoming:          inCh,
+		sseErrCh:          errCh,
+		awaitingRecipient: recipient == "",
 	}
 	prog := tea.NewProgram(m, tea.WithAltScreen())
 	_, err := prog.Run()
@@ -238,6 +270,31 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			text := strings.TrimSpace(m.input.Value())
 			if text == "" {
+				return m, nil
+			}
+			// In pick-a-peer mode, Enter parses the PK and
+			// transitions into chat mode. The textinput is
+			// then reset with the chat-mode prompt + placeholder
+			// for the actual messaging flow.
+			if m.awaitingRecipient {
+				var pk cipher.PubKey
+				if err := pk.Set(text); err != nil {
+					m.recipientErr = fmt.Sprintf("invalid PK: %v", err)
+					m.input.Reset()
+					return m, nil
+				}
+				m.recipient = pk.String()
+				m.awaitingRecipient = false
+				m.recipientErr = ""
+				m.input.Reset()
+				m.input.Placeholder = "type message; Enter to send, Esc to quit"
+				m.input.Prompt = "» "
+				m.input.CharLimit = 4096
+				if m.ready {
+					// Header now shows the recipient, so the
+					// "to <prompt>" line widens; refit input.
+					m.input.Width = m.width - len(m.input.Prompt) - 1
+				}
 				return m, nil
 			}
 			m.input.Reset()
@@ -357,17 +414,34 @@ func (m *chatModel) View() string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
 
-	header := fmt.Sprintf("%s  %s  network=%s  addr=%s",
-		hdrStyle.Render("skychat"),
-		dimStyle.Render("to "+shortPK(m.recipient)),
-		m.network,
-		m.addr,
-	)
+	// Header differs between pick-a-peer and chat modes. In
+	// pick-a-peer the "to <pk>" slot is replaced with a prompt
+	// hint and (if applicable) the last parse error.
+	var header string
+	if m.awaitingRecipient {
+		hint := dimStyle.Render("pick a recipient PK below")
+		if m.recipientErr != "" {
+			hint = errStyle.Render(m.recipientErr)
+		}
+		header = fmt.Sprintf("%s  %s  network=%s  addr=%s",
+			hdrStyle.Render("skychat"), hint, m.network, m.addr)
+	} else {
+		header = fmt.Sprintf("%s  %s  network=%s  addr=%s",
+			hdrStyle.Render("skychat"),
+			dimStyle.Render("to "+shortPK(m.recipient)),
+			m.network, m.addr,
+		)
+	}
 	if !m.sseLive {
 		header += "  " + errStyle.Render("[SSE down: "+m.sseErr+"]")
 	}
 
-	footer := dimStyle.Render("Enter send | ↑/↓ PgUp/PgDn scroll | Esc/Ctrl+C quit")
+	var footer string
+	if m.awaitingRecipient {
+		footer = dimStyle.Render("Enter to confirm recipient | Esc/Ctrl+C quit")
+	} else {
+		footer = dimStyle.Render("Enter send | ↑/↓ PgUp/PgDn scroll | Esc/Ctrl+C quit")
+	}
 
 	var b strings.Builder
 	b.WriteString(header)

--- a/cmd/skywire-cli/commands/skychat/chat.go
+++ b/cmd/skywire-cli/commands/skychat/chat.go
@@ -267,6 +267,19 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "esc":
 			return m, tea.Quit
+		case "ctrl+n":
+			// Cycle outgoing network type. Affects subsequent
+			// Sends only — already-delivered messages keep their
+			// per-message network tag. Header reflects the new
+			// value immediately. Pick-a-peer mode also honors
+			// this (operator can decide skynet vs dmsg before
+			// they even type the recipient PK).
+			if m.network == "skynet" {
+				m.network = "dmsg"
+			} else {
+				m.network = "skynet"
+			}
+			return m, nil
 		case "enter":
 			text := strings.TrimSpace(m.input.Value())
 			if text == "" {
@@ -438,9 +451,9 @@ func (m *chatModel) View() string {
 
 	var footer string
 	if m.awaitingRecipient {
-		footer = dimStyle.Render("Enter to confirm recipient | Esc/Ctrl+C quit")
+		footer = dimStyle.Render("Enter to confirm recipient | Ctrl+N toggle network | Esc/Ctrl+C quit")
 	} else {
-		footer = dimStyle.Render("Enter send | ↑/↓ PgUp/PgDn scroll | Esc/Ctrl+C quit")
+		footer = dimStyle.Render("Enter send | ↑/↓ PgUp/PgDn scroll | Ctrl+N toggle network | Esc/Ctrl+C quit")
 	}
 
 	var b strings.Builder

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -1,0 +1,332 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/group.go:
+// operator-facing CLI for D1 group chat. Thin wrappers over the
+// visor's GroupX RPC methods.
+//
+// Subcommands:
+//
+//	skywire cli skychat group create  --name <name> [--mode public|private] [--member <pk> ...]
+//	skywire cli skychat group list
+//	skywire cli skychat group info    <group-id>
+//	skywire cli skychat group invite  <group-id>           # re-emits the invite link
+//	skywire cli skychat group join    <invite-link>
+//	skywire cli skychat group add     <group-id> <pk>      # owner: extend allowlist
+//	skywire cli skychat group send    <group-id> <text>    # owner only in v1
+//	skywire cli skychat group listen  [--since RFC3339]    # poll inbox, stream
+//	skywire cli skychat group leave   <group-id>           # member side
+//	skywire cli skychat group delete  <group-id>           # owner side
+//
+// All commands talk to the LOCAL visor via clirpc.Client; the visor
+// owns the group.Manager. No DMSG dial happens in the CLI itself.
+package cliskychat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+var (
+	groupCreateName    string
+	groupCreateMode    string
+	groupCreateMembers []string
+
+	groupListenSince string
+	groupListenPoll  time.Duration
+)
+
+func init() {
+	groupCreateCmd.Flags().StringVarP(&groupCreateName, "name", "n", "", "human-readable group name (required)")
+	groupCreateCmd.Flags().StringVarP(&groupCreateMode, "mode", "m", "public", "public | private — private encrypts feed messages with an AES key shipped in the invite link")
+	groupCreateCmd.Flags().StringSliceVar(&groupCreateMembers, "member", nil, "initial member PK; repeat for many (the owner is implicit)")
+	groupCreateCmd.MarkFlagRequired("name") //nolint:errcheck,gosec
+
+	groupListenCmd.Flags().StringVar(&groupListenSince, "since", "", "RFC3339 lower bound for the first poll; empty = drain current inbox window then follow")
+	groupListenCmd.Flags().DurationVar(&groupListenPoll, "interval", time.Second, "poll interval")
+
+	groupCmd.AddCommand(
+		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
+		groupJoinCmd, groupAddCmd, groupSendCmd, groupListenCmd,
+		groupLeaveCmd, groupDeleteCmd,
+	)
+	RootCmd.AddCommand(groupCmd)
+}
+
+var groupCmd = &cobra.Command{
+	Use:   "group",
+	Short: "D1 owner-centric group chat over CXO feeds",
+	Long: `Group chat over CXO TreeStore feeds.
+
+Architecture (v1, D1): one member owns the group's CXO feed and
+publishes messages; other members subscribe (read-only in v1; a
+follow-up adds member-side relay). Owner generates an invite link
+that carries the group ID, owner PK, port, and (for private groups)
+the AES-GCM key.`,
+}
+
+var groupCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new group (this visor becomes the owner)",
+	Run: func(cmd *cobra.Command, _ []string) {
+		mode := skychatgroup.Mode(groupCreateMode)
+		if !mode.IsValid() {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --mode %q (use public or private)", groupCreateMode))
+		}
+		members, err := parsePKs(groupCreateMembers)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, link, err := rpcClient.GroupCreate(visor.GroupCreateArgs{
+			Name:           groupCreateName,
+			Mode:           mode,
+			InitialMembers: members,
+		})
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		printGroupCreated(cmd, info, link)
+	},
+}
+
+func printGroupCreated(cmd *cobra.Command, info visor.GroupInfo, link string) {
+	out := struct {
+		Info   visor.GroupInfo `json:"info"`
+		Invite string          `json:"invite"`
+	}{Info: info, Invite: link}
+	human := fmt.Sprintf("group created\n  id:     %s\n  name:   %s\n  mode:   %s\n  port:   %d\n  members: %d\n\ninvite link (share with members):\n  %s\n",
+		info.ID, info.Name, info.Mode, info.Port, len(info.Members), link)
+	internal.PrintOutput(cmd.Flags(), out, human)
+}
+
+var groupListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all groups this visor knows about",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		all, err := rpcClient.GroupList()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		var buf strings.Builder
+		w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tNAME\tMODE\tROLE\tSTATUS\tMEMBERS\tLAST_MESSAGE") //nolint:errcheck
+		for _, g := range all {
+			last := "-"
+			if !g.LastMessageAt.IsZero() {
+				last = g.LastMessageAt.UTC().Format(time.RFC3339)
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n", //nolint:errcheck
+				g.ID, g.Name, g.Mode, g.Role, g.Status, len(g.Members), last)
+		}
+		_ = w.Flush() //nolint:errcheck
+		internal.PrintOutput(cmd.Flags(), all, buf.String())
+	},
+}
+
+var groupInfoCmd = &cobra.Command{
+	Use:   "info <group-id>",
+	Short: "Show one group's full record",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, err := rpcClient.GroupGet(args[0])
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		body, _ := json.MarshalIndent(info, "", "  ") //nolint:errcheck
+		internal.PrintOutput(cmd.Flags(), info, string(body)+"\n")
+	},
+}
+
+var groupInviteCmd = &cobra.Command{
+	Use:   "invite <group-id>",
+	Short: "Re-emit the invite link for an owner-side group",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		link, err := rpcClient.GroupInvite(args[0])
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), link, link+"\n")
+	},
+}
+
+var groupJoinCmd = &cobra.Command{
+	Use:   "join <invite-link>",
+	Short: "Join a group by invite link",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, err := rpcClient.GroupJoin(visor.GroupJoinArgs{Invite: args[0]})
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		human := fmt.Sprintf("joined group %q\n  id:    %s\n  owner: %s\n  mode:  %s\n",
+			info.Name, info.ID, info.OwnerPK, info.Mode)
+		internal.PrintOutput(cmd.Flags(), info, human)
+	},
+}
+
+var groupAddCmd = &cobra.Command{
+	Use:   "add <group-id> <pk>",
+	Short: "Owner: extend the group allowlist by one member PK",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var pk cipher.PubKey
+		if err := pk.Set(args[1]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid pk %q: %w", args[1], err))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, err := rpcClient.GroupAddMember(args[0], pk)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		human := fmt.Sprintf("group %s now has %d members\n", args[0], len(info.Members))
+		internal.PrintOutput(cmd.Flags(), info, human)
+	},
+}
+
+var groupSendCmd = &cobra.Command{
+	Use:   "send <group-id> <text>",
+	Short: "Publish a message to a group (owner-only in v1)",
+	Args:  cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		text := strings.Join(args[1:], " ")
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.GroupSend(visor.GroupSendArgs{ID: id, Text: text}); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("sent to %s\n", id))
+	},
+}
+
+var groupListenCmd = &cobra.Command{
+	Use:   "listen",
+	Short: "Stream inbound group messages (across every joined group)",
+	Long: `Poll the visor's group inbox and print messages as they
+arrive. Mirrors ` + "`skywire cli skychat listen`" + ` for 1:1 chat but for
+group feeds. Ctrl+C exits.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		var since time.Time
+		if groupListenSince != "" {
+			since, err = time.Parse(time.RFC3339, groupListenSince)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --since: %w", err))
+			}
+		}
+		fmt.Println("Listening for group messages. Ctrl+C to exit.")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ticker := time.NewTicker(groupListenPoll)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			msgs, err := rpcClient.GroupPoll(since)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "group poll: %v\n", err) //nolint:errcheck
+				continue
+			}
+			for _, m := range msgs {
+				if m.TS.After(since) {
+					since = m.TS
+				}
+				fmt.Printf("[%s] [%s] %s: %s\n",
+					m.TS.UTC().Format(time.RFC3339), m.GroupID, m.SenderPK, m.Text)
+			}
+		}
+	},
+}
+
+var groupLeaveCmd = &cobra.Command{
+	Use:   "leave <group-id>",
+	Short: "Member: leave a group (tears down the subscriber)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.GroupLeave(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("left %s\n", args[0]))
+	},
+}
+
+var groupDeleteCmd = &cobra.Command{
+	Use:   "delete <group-id>",
+	Short: "Owner: delete a group (tears down the publisher)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.GroupDelete(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("deleted %s\n", args[0]))
+	},
+}
+
+// parsePKs converts a comma/repeated-flag list of hex strings to
+// cipher.PubKey slice. Empty input returns nil (no members beyond
+// owner). cobra's StringSliceVar honors comma-split + repeat-flag.
+func parsePKs(raw []string) ([]cipher.PubKey, error) {
+	out := make([]cipher.PubKey, 0, len(raw))
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(s); err != nil {
+			return nil, fmt.Errorf("invalid PK %q: %w", s, err)
+		}
+		out = append(out, pk)
+	}
+	return out, nil
+}

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -52,9 +52,12 @@ func init() {
 
 	listenCmd.Flags().StringVarP(&listenNet, "net", "n", "", "filter by network type (optional; default = all)")
 
-	chatCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (required)")
+	chatCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (optional; TUI prompts for it if omitted)")
 	chatCmd.Flags().StringVarP(&sendNet, "net", "n", "skynet", "network type for outgoing messages: skynet or dmsg")
-	chatCmd.MarkFlagRequired("to") //nolint:errcheck,gosec
+	// --to deliberately NOT MarkFlagRequired: an empty recipient
+	// drops the TUI into "pick a peer" mode where the textinput
+	// gates entry to chat view on a valid PK. Matches the GUI's
+	// flow where you type the PK into the header before sending.
 }
 
 // RootCmd contains skychat commands

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -235,6 +235,19 @@ type API interface {
 	PairSend(peerPK cipher.PubKey, text string) error
 	PairPoll(since time.Time) ([]PairMessage, error)
 
+	// Chat-group feeds — D1 owner-centric CXO feeds with multi-PK
+	// allowlists. See pkg/visor/group.go.
+	GroupCreate(args GroupCreateArgs) (GroupInfo, string, error)
+	GroupJoin(args GroupJoinArgs) (GroupInfo, error)
+	GroupList() ([]GroupInfo, error)
+	GroupGet(id string) (GroupInfo, error)
+	GroupInvite(id string) (string, error)
+	GroupAddMember(id string, pk cipher.PubKey) (GroupInfo, error)
+	GroupSend(args GroupSendArgs) error
+	GroupPoll(since time.Time) ([]GroupMessage, error)
+	GroupDelete(id string) error
+	GroupLeave(id string) error
+
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)
 	TPSAddTransport(targetPK, remotePK cipher.PubKey, tpType string) (*TPSTransportResponse, error)

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -1,0 +1,281 @@
+// Package visor pkg/visor/group.go
+//
+// Visor-level wrapper around the cmd/apps/skychat/group package.
+// Mirrors pkg/visor/pairing.go in shape: owns one group.Manager
+// (initialized in init_group.go) plus an in-memory ring of recently
+// received messages. RPC clients call GroupCreate / GroupJoin /
+// GroupList / GroupSend / GroupPoll / GroupDelete / GroupLeave; the
+// poll model is the same as PairPoll, so apps that already drain a
+// pair-poll loop can layer on a group-poll loop with the same shape.
+//
+// Scope (v1, D1 owner-centric):
+//
+//   - Owners can create groups, invite via link, broadcast messages.
+//   - Members can join via invite, read messages, leave.
+//   - Member-side "send" is NOT in v1. Members read only; the owner
+//     drives the conversation. Phase-2 (project memo group-chat
+//     plan) adds member-side relay via the existing pair-message
+//     wire with a group_id tag.
+package visor
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// GroupInfo is the public summary of a chat group, returned by
+// GroupList and GroupGet.
+type GroupInfo struct {
+	ID            string              `json:"id"`
+	Name          string              `json:"name"`
+	OwnerPK       cipher.PubKey       `json:"owner_pk"`
+	Port          uint16              `json:"port"`
+	Mode          skychatgroup.Mode   `json:"mode"`
+	Members       []cipher.PubKey     `json:"members"`
+	Role          skychatgroup.Role   `json:"role"`
+	Status        skychatgroup.Status `json:"status"`
+	CreatedAt     time.Time           `json:"created_at"`
+	JoinedAt      time.Time           `json:"joined_at"`
+	LastMessageAt time.Time           `json:"last_message_at,omitempty"`
+}
+
+// GroupMessage is one inbound message delivered through the visor's
+// group inbox. Outbound (owner-only Sends) are NOT echoed here; the
+// caller already knows what it sent.
+type GroupMessage struct {
+	GroupID  string        `json:"group_id"`
+	SenderPK cipher.PubKey `json:"sender_pk"`
+	Text     string        `json:"text"`
+	TS       time.Time     `json:"ts"`
+}
+
+// GroupCreateArgs is the RPC input for GroupCreate.
+type GroupCreateArgs struct {
+	Name           string            `json:"name"`
+	Mode           skychatgroup.Mode `json:"mode"`
+	InitialMembers []cipher.PubKey   `json:"initial_members,omitempty"`
+}
+
+// GroupJoinArgs is the RPC input for GroupJoin.
+type GroupJoinArgs struct {
+	Invite string `json:"invite"`
+}
+
+// GroupSendArgs is the RPC input for GroupSend.
+type GroupSendArgs struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+}
+
+// ErrGroupingDisabled is returned by Visor group methods when the
+// manager isn't initialized (dmsg unavailable at startup, or the
+// bolt store failed to open).
+var ErrGroupingDisabled = errors.New("grouping: manager not initialized")
+
+// ErrGroupNotFound is returned for an ID the local store doesn't
+// know about. Distinct from a generic error so the CLI can render
+// "no such group" vs a transport-layer failure.
+var ErrGroupNotFound = errors.New("grouping: group not found")
+
+// GroupCreate constructs a new owner-side group on this visor.
+// Returns the persisted info and the invite link so the operator
+// can hand the link out.
+func (v *Visor) GroupCreate(args GroupCreateArgs) (GroupInfo, string, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupInfo{}, "", ErrGroupingDisabled
+	}
+	r, err := mgr.Create(args.Name, args.Mode, args.InitialMembers)
+	if err != nil {
+		return GroupInfo{}, "", err
+	}
+	link, err := mgr.BuildInvite(r.ID)
+	if err != nil {
+		return GroupInfo{}, "", err
+	}
+	return toInfo(r), link, nil
+}
+
+// GroupJoin accepts an invite link, registers a member-side record,
+// and opens the subscriber. Returns the info on the joined group.
+func (v *Visor) GroupJoin(args GroupJoinArgs) (GroupInfo, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupInfo{}, ErrGroupingDisabled
+	}
+	inv, err := skychatgroup.DecodeInvite(args.Invite)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	r, err := mgr.Join(inv)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	return toInfo(r), nil
+}
+
+// GroupList returns every persisted group on this visor.
+func (v *Visor) GroupList() ([]GroupInfo, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return nil, ErrGroupingDisabled
+	}
+	all, err := mgr.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GroupInfo, 0, len(all))
+	for _, r := range all {
+		out = append(out, toInfo(r))
+	}
+	return out, nil
+}
+
+// GroupGet returns the info for a specific group, or ErrGroupNotFound.
+func (v *Visor) GroupGet(id string) (GroupInfo, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupInfo{}, ErrGroupingDisabled
+	}
+	r, ok, err := mgr.Get(id)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	if !ok {
+		return GroupInfo{}, ErrGroupNotFound
+	}
+	return toInfo(r), nil
+}
+
+// GroupInvite returns a freshly-encoded invite link for an
+// owner-side group. Members get an error (only owners can issue
+// invites in D1).
+func (v *Visor) GroupInvite(id string) (string, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return "", ErrGroupingDisabled
+	}
+	return mgr.BuildInvite(id)
+}
+
+// GroupAddMember extends the allowlist + persisted member list.
+// Owner-side only.
+func (v *Visor) GroupAddMember(id string, pk cipher.PubKey) (GroupInfo, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupInfo{}, ErrGroupingDisabled
+	}
+	r, err := mgr.AddMember(id, pk)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	return toInfo(r), nil
+}
+
+// GroupSend publishes a message into the named group's feed.
+// Owner-side only in v1. Members get "only owner can send" — the
+// member-side relay path lands in a follow-up commit.
+func (v *Visor) GroupSend(args GroupSendArgs) error {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return ErrGroupingDisabled
+	}
+	return mgr.SendToGroup(args.ID, args.Text)
+}
+
+// GroupPoll drains messages with TS > since. Mirrors PairPoll.
+func (v *Visor) GroupPoll(since time.Time) ([]GroupMessage, error) {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return nil, ErrGroupingDisabled
+	}
+	return inbox.snapshotAfter(since), nil
+}
+
+// GroupDelete tears down an owner-side group and marks it revoked.
+func (v *Visor) GroupDelete(id string) error {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return ErrGroupingDisabled
+	}
+	return mgr.Delete(id)
+}
+
+// GroupLeave is the member-side counterpart of Delete.
+func (v *Visor) GroupLeave(id string) error {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return ErrGroupingDisabled
+	}
+	return mgr.Leave(id)
+}
+
+func (v *Visor) groupManager() *skychatgroup.Manager {
+	v.initLock.RLock()
+	defer v.initLock.RUnlock()
+	return v.grouping.manager
+}
+
+func toInfo(r skychatgroup.Record) GroupInfo {
+	return GroupInfo{
+		ID:            r.ID,
+		Name:          r.Name,
+		OwnerPK:       r.OwnerPK,
+		Port:          r.Port,
+		Mode:          r.Mode,
+		Members:       append([]cipher.PubKey(nil), r.Members...),
+		Role:          r.Role,
+		Status:        r.Status,
+		CreatedAt:     r.CreatedAt,
+		JoinedAt:      r.JoinedAt,
+		LastMessageAt: r.LastMessageAt,
+	}
+}
+
+// groupInbox is a bounded ring buffer of inbound group messages,
+// drained by GroupPoll. Mirrors pairInbox exactly.
+type groupInbox struct {
+	mu  sync.Mutex
+	cap int
+	buf []GroupMessage
+}
+
+func newGroupInbox(capacity int) *groupInbox {
+	if capacity <= 0 {
+		capacity = groupInboxCap
+	}
+	return &groupInbox{cap: capacity, buf: make([]GroupMessage, 0, capacity)}
+}
+
+func (g *groupInbox) deliver(groupID string, senderPK cipher.PubKey, msg skychatgroup.Message) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.buf = append(g.buf, GroupMessage{
+		GroupID:  groupID,
+		SenderPK: senderPK,
+		Text:     msg.Text,
+		TS:       msg.TS,
+	})
+	if len(g.buf) > g.cap {
+		drop := len(g.buf) - g.cap
+		g.buf = append(g.buf[:0], g.buf[drop:]...)
+	}
+}
+
+func (g *groupInbox) snapshotAfter(since time.Time) []GroupMessage {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]GroupMessage, 0, len(g.buf))
+	for _, m := range g.buf {
+		if m.TS.After(since) {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -130,6 +130,9 @@ var (
 	cxoUserFeedsMod vinit.Module
 	// Chat-pair feed manager (opt-in per-partner CXO feeds).
 	pairingMod vinit.Module
+	// Chat-group feed manager (D1 owner-centric CXO feeds with
+	// multi-PK allowlist).
+	groupingMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 	// config initialization
@@ -209,8 +212,12 @@ func registerModules(logger *logging.MasterLogger) {
 	// Chat-pair manager: opt-in per-partner CXO feeds with allowlist.
 	// Depends only on dmsgC.
 	pairingMod = maker("pairing", initPairing, &dmsgC)
+	// Chat-group manager: D1 owner-centric group CXO feeds. Same
+	// shape as pairingMod, same dmsgC dependency, separate bbolt
+	// store. See init_group.go.
+	groupingMod = maker("grouping", initGrouping, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &pty,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -1,0 +1,94 @@
+// Package visor pkg/visor/init_group.go
+//
+// Init wiring for the chat-group feed manager. Parallel to
+// init_pairing.go — same shape, same best-effort failure
+// semantics, same close-stack registration. Depends on dmsgC, opens
+// its own bbolt store under v.conf.LocalPath/skychat/groups.db, and
+// resumes any non-terminal group records persisted from a previous
+// run.
+package visor
+
+import (
+	"context"
+	"path/filepath"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// groupState holds the visor-side runtime state for chat groups.
+// Lives on the Visor struct so RPC handlers can reach it.
+type groupState struct {
+	store   *skychatgroup.Store
+	manager *skychatgroup.Manager
+	inbox   *groupInbox
+}
+
+// groupInboxCap mirrors defaultInboxCap on the pairing side. A few
+// hundred messages a minute under burst, hard cap before unbounded
+// growth if the consumer is slow or absent.
+const groupInboxCap = 1024
+
+// initGrouping brings up the per-visor chat-group feed manager. Best
+// effort: a failure here logs and disables group chat for this run
+// rather than failing visor startup. Group RPC handlers return
+// ErrGroupingDisabled when the manager is absent.
+func initGrouping(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.dmsgC == nil {
+		log.Debug("Grouping: dmsg client absent; manager not started")
+		return nil
+	}
+	dataDir := filepath.Join(v.conf.LocalPath, "skychat")
+	storePath := filepath.Join(dataDir, "groups.db")
+
+	store, err := skychatgroup.OpenStore(storePath)
+	if err != nil {
+		log.WithError(err).Warn("Grouping: open store failed; group chat disabled this run")
+		return nil
+	}
+
+	mgr, err := skychatgroup.NewManager(skychatgroup.ManagerConfig{
+		Store:   store,
+		DmsgC:   v.dmsgC,
+		MyPK:    v.conf.PK,
+		MySK:    v.conf.SK,
+		DataDir: filepath.Join(dataDir, "cxo-groups"),
+		Logger:  log,
+	})
+	if err != nil {
+		_ = store.Close() //nolint:errcheck
+		log.WithError(err).Warn("Grouping: NewManager failed; group chat disabled this run")
+		return nil
+	}
+
+	inbox := newGroupInbox(groupInboxCap)
+	mgr.SetMessageHandler(inbox.deliver)
+
+	v.initLock.Lock()
+	v.grouping.store = store
+	v.grouping.manager = mgr
+	v.grouping.inbox = inbox
+	v.initLock.Unlock()
+
+	if err := mgr.Resume(); err != nil {
+		log.WithError(err).Warn("Grouping: Resume returned error; partial recovery only")
+	}
+	log.Info("Grouping: manager ready")
+
+	v.pushCloseStack("grouping", func() error {
+		var firstErr error
+		if mgr != nil {
+			if err := mgr.Close(); err != nil {
+				firstErr = err
+			}
+		}
+		if store != nil {
+			if err := store.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	})
+
+	return nil
+}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1298,6 +1298,72 @@ func (rc *rpcClient) PairPoll(since time.Time) ([]PairMessage, error) {
 	return resp, err
 }
 
+// GroupCreate implements API.
+func (rc *rpcClient) GroupCreate(args GroupCreateArgs) (GroupInfo, string, error) {
+	var resp GroupCreateResponse
+	if err := rc.Call("GroupCreate", &args, &resp); err != nil {
+		return GroupInfo{}, "", err
+	}
+	return resp.Info, resp.Invite, nil
+}
+
+// GroupJoin implements API.
+func (rc *rpcClient) GroupJoin(args GroupJoinArgs) (GroupInfo, error) {
+	var resp GroupInfo
+	err := rc.Call("GroupJoin", &args, &resp)
+	return resp, err
+}
+
+// GroupList implements API.
+func (rc *rpcClient) GroupList() ([]GroupInfo, error) {
+	var resp []GroupInfo
+	err := rc.Call("GroupList", &struct{}{}, &resp)
+	return resp, err
+}
+
+// GroupGet implements API.
+func (rc *rpcClient) GroupGet(id string) (GroupInfo, error) {
+	var resp GroupInfo
+	err := rc.Call("GroupGet", &id, &resp)
+	return resp, err
+}
+
+// GroupInvite implements API.
+func (rc *rpcClient) GroupInvite(id string) (string, error) {
+	var resp string
+	err := rc.Call("GroupInvite", &id, &resp)
+	return resp, err
+}
+
+// GroupAddMember implements API.
+func (rc *rpcClient) GroupAddMember(id string, pk cipher.PubKey) (GroupInfo, error) {
+	var resp GroupInfo
+	err := rc.Call("GroupAddMember", &GroupAddMemberRequest{ID: id, NewPK: pk}, &resp)
+	return resp, err
+}
+
+// GroupSend implements API.
+func (rc *rpcClient) GroupSend(args GroupSendArgs) error {
+	return rc.Call("GroupSend", &args, &struct{}{})
+}
+
+// GroupPoll implements API.
+func (rc *rpcClient) GroupPoll(since time.Time) ([]GroupMessage, error) {
+	var resp []GroupMessage
+	err := rc.Call("GroupPoll", &GroupPollRequest{Since: since}, &resp)
+	return resp, err
+}
+
+// GroupDelete implements API.
+func (rc *rpcClient) GroupDelete(id string) error {
+	return rc.Call("GroupDelete", &id, &struct{}{})
+}
+
+// GroupLeave implements API.
+func (rc *rpcClient) GroupLeave(id string) error {
+	return rc.Call("GroupLeave", &id, &struct{}{})
+}
+
 // TPSStatus returns the status of the embedded TPS.
 func (rc *rpcClient) TPSStatus() (*TPSStatus, error) {
 	var status TPSStatus

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1194,6 +1194,40 @@ func (mc *mockRPCClient) PairSend(_ cipher.PubKey, _ string) error { return nil 
 // PairPoll implements API.
 func (mc *mockRPCClient) PairPoll(_ time.Time) ([]PairMessage, error) { return nil, nil }
 
+// GroupCreate implements API.
+func (mc *mockRPCClient) GroupCreate(_ GroupCreateArgs) (GroupInfo, string, error) {
+	return GroupInfo{}, "", nil
+}
+
+// GroupJoin implements API.
+func (mc *mockRPCClient) GroupJoin(_ GroupJoinArgs) (GroupInfo, error) { return GroupInfo{}, nil }
+
+// GroupList implements API.
+func (mc *mockRPCClient) GroupList() ([]GroupInfo, error) { return nil, nil }
+
+// GroupGet implements API.
+func (mc *mockRPCClient) GroupGet(_ string) (GroupInfo, error) { return GroupInfo{}, nil }
+
+// GroupInvite implements API.
+func (mc *mockRPCClient) GroupInvite(_ string) (string, error) { return "", nil }
+
+// GroupAddMember implements API.
+func (mc *mockRPCClient) GroupAddMember(_ string, _ cipher.PubKey) (GroupInfo, error) {
+	return GroupInfo{}, nil
+}
+
+// GroupSend implements API.
+func (mc *mockRPCClient) GroupSend(_ GroupSendArgs) error { return nil }
+
+// GroupPoll implements API.
+func (mc *mockRPCClient) GroupPoll(_ time.Time) ([]GroupMessage, error) { return nil, nil }
+
+// GroupDelete implements API.
+func (mc *mockRPCClient) GroupDelete(_ string) error { return nil }
+
+// GroupLeave implements API.
+func (mc *mockRPCClient) GroupLeave(_ string) error { return nil }
+
 // TPSStatus implements API.
 func (mc *mockRPCClient) TPSStatus() (*TPSStatus, error) {
 	return &TPSStatus{Enabled: false}, nil

--- a/pkg/visor/rpc_group.go
+++ b/pkg/visor/rpc_group.go
@@ -1,0 +1,157 @@
+// Package visor pkg/visor/rpc_group.go
+//
+// RPC adapter for the chat-group feed manager. Thin wrappers over
+// the Visor methods in group.go. Mirrors rpc_pairing.go shape.
+package visor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/util/rpcutil"
+)
+
+// GroupCreateResponse pairs the persisted GroupInfo with the
+// freshly-encoded invite link the operator should distribute.
+type GroupCreateResponse struct {
+	Info   GroupInfo `json:"info"`
+	Invite string    `json:"invite"`
+}
+
+// GroupAddMemberRequest is the input to RPC.GroupAddMember.
+type GroupAddMemberRequest struct {
+	ID    string        `json:"id"`
+	NewPK cipher.PubKey `json:"new_pk"`
+}
+
+// GroupPollRequest is the input to RPC.GroupPoll.
+type GroupPollRequest struct {
+	Since time.Time `json:"since"`
+}
+
+// GroupCreate constructs a new owner-side group on this visor and
+// returns the persisted info + the invite link.
+func (r *RPC) GroupCreate(req *GroupCreateArgs, out *GroupCreateResponse) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupCreate", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, link, err := r.visor.GroupCreate(*req)
+	if err != nil {
+		return err
+	}
+	*out = GroupCreateResponse{Info: info, Invite: link}
+	return nil
+}
+
+// GroupJoin accepts an invite link and registers a member-side
+// record.
+func (r *RPC) GroupJoin(req *GroupJoinArgs, out *GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupJoin", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, err := r.visor.GroupJoin(*req)
+	if err != nil {
+		return err
+	}
+	*out = info
+	return nil
+}
+
+// GroupList returns every persisted group on this visor.
+func (r *RPC) GroupList(_ *struct{}, out *[]GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupList", nil)(out, &err)
+	all, err := r.visor.GroupList()
+	if err != nil {
+		return err
+	}
+	*out = all
+	return nil
+}
+
+// GroupGet returns one group's info by ID.
+func (r *RPC) GroupGet(id *string, out *GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupGet", id)(out, &err)
+	if id == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, err := r.visor.GroupGet(*id)
+	if err != nil {
+		return err
+	}
+	*out = info
+	return nil
+}
+
+// GroupInvite returns a freshly-encoded invite link for an
+// owner-side group.
+func (r *RPC) GroupInvite(id *string, out *string) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupInvite", id)(out, &err)
+	if id == nil {
+		return fmt.Errorf("nil request")
+	}
+	link, err := r.visor.GroupInvite(*id)
+	if err != nil {
+		return err
+	}
+	*out = link
+	return nil
+}
+
+// GroupAddMember extends the allowlist + persisted member list.
+func (r *RPC) GroupAddMember(req *GroupAddMemberRequest, out *GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupAddMember", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, err := r.visor.GroupAddMember(req.ID, req.NewPK)
+	if err != nil {
+		return err
+	}
+	*out = info
+	return nil
+}
+
+// GroupSend publishes one message into the named group's feed.
+// Owner-side only in v1.
+func (r *RPC) GroupSend(req *GroupSendArgs, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupSend", req)(nil, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.GroupSend(*req)
+}
+
+// GroupPoll drains inbound group messages with TS strictly after Since.
+func (r *RPC) GroupPoll(req *GroupPollRequest, out *[]GroupMessage) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupPoll", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	msgs, err := r.visor.GroupPoll(req.Since)
+	if err != nil {
+		return err
+	}
+	*out = msgs
+	return nil
+}
+
+// GroupDelete tears down an owner-side group.
+func (r *RPC) GroupDelete(id *string, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupDelete", id)(nil, &err)
+	if id == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.GroupDelete(*id)
+}
+
+// GroupLeave is the member-side counterpart of GroupDelete.
+func (r *RPC) GroupLeave(id *string, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupLeave", id)(nil, &err)
+	if id == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.GroupLeave(*id)
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -208,6 +208,11 @@ type Visor struct {
 	// init failed); RPC handlers surface ErrPairingDisabled.
 	pairing pairingState
 
+	// grouping holds the chat-group feed manager + bbolt store +
+	// inbound message ring. Same shape as pairing, brought up by
+	// init_group.go. nil when group chat is disabled.
+	grouping groupState
+
 	// Embedded DMSG Web resolver (nil if dmsg_web.enable is false).
 	// Provides a localhost SOCKS5 proxy that resolves .dmsg hosts.
 	embeddedDmsgWeb *EmbeddedDmsgWeb


### PR DESCRIPTION
## Summary

Two related operator-UX features:

### 1. D1 group chat over CXO feeds (`skywire cli skychat group …`)

Owner-centric group chat built on the existing CXO TreeStore + skychat infrastructure. Parallel to the 1:1 `pairing/` package, with a multi-PK allowlist instead of pair-of-two.

**Scope (v1, owner-broadcast)**:
- Owners create groups, invite via link, broadcast messages
- Members join via invite, read messages, leave
- Public AND private modes coexist — private uses AES-256-GCM, key shipped in invite link
- Last-50 history seeds new joiners (CXO feed's natural history)
- Member-side relay (send through owner) is **not** in v1 — files as follow-up. Members read; owners send.

### 2. `skywire dmsg chat` — standalone dmsg-only chat

Run when the local visor is down (or absent) so operators can still reach a support channel. Mirrors `skywire dmsg curl`'s standalone shape: own dmsg client, own identity, no visor RPC, no skynet. Wire format matches the visor-app skychat post #2504 so cross-talk with `skywire cli skychat chat` works.

### 3. TUI niceties

- `skywire cli skychat chat` no longer requires `--to`; the TUI starts in pick-a-peer mode and prompts for a PK
- `Ctrl+N` in the skychat TUI toggles outgoing network (skynet ↔ dmsg) without re-launching

## Code map

- `cmd/apps/skychat/group/` — new package: `Record`, `Store` (bbolt), `Invite` (base64url-encoded link), `crypto.go` (AES-256-GCM helpers), `Session` (per-group runtime, mirrors `pairing.Pair`), `Manager` (orchestrator, mirrors `pairing.Manager`).
- `pkg/visor/init_group.go` + `group.go` + `rpc_group.go` — visor-level wrapper + RPC adapter. New module wired into init chain after `pairingMod` with the same dmsgC dependency.
- `pkg/visor/api.go` — 10 new methods (`GroupCreate`, `GroupJoin`, `GroupList`, `GroupGet`, `GroupInvite`, `GroupAddMember`, `GroupSend`, `GroupPoll`, `GroupDelete`, `GroupLeave`).
- `cmd/skywire-cli/commands/skychat/group.go` — operator CLI: `skywire cli skychat group {create,list,info,invite,join,add,send,listen,leave,delete}`.
- `cmd/skywire-cli/commands/skychat/chat.go` + `root.go` — pick-a-peer mode; Ctrl+N network toggle.
- `cmd/skywire-cli/commands/dmsg/chat.go` — standalone dmsg chat as `skywire dmsg chat`.

## Invite link format

```
skychat:invite:<base64url(json({id, name, owner_pk, port, mode, aes_key?}))>
```

## Test plan

- [x] `go build ./...` — clean (Linux + Windows cross-compile)
- [x] `go test ./cmd/apps/skychat/group/... ./pkg/visor/...` — passes
- [x] `golangci-lint run …` — 0 issues
- [x] Unit coverage on group package: invite round-trip (public + private), encode/decode mode-key mismatch rejection, AES-GCM round-trip + tamper-detection + nonce-uniqueness, store CRUD
- [x] `skywire cli skychat group --help` and `skywire cli dmsg chat --help` render the new subtrees
- [x] `skywire cli skychat chat` (no --to) reaches the TUI without "required flag" abort
- [ ] Manual E2E across two real visors — skipped per release schedule; validate post-merge with the release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)