### PR TITLE
fix(skychat): listen --json + --from + outgoing-mirror + network on inbound

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -497,7 +497,16 @@ func handleConn(conn *framedConn) {
 			Timestamp: time.Now().UTC(),
 		})
 
-		clientMsg, err := json.Marshal(map[string]string{"sender": peerPK, "message": text})
+		// Include the network field so listen --net can filter
+		// inbound just as it can filter outbound. Without this, SSE
+		// events for incoming messages carry no transport tag and any
+		// consumer-side --net filter drops them all.
+		clientMsg, err := json.Marshal(map[string]interface{}{
+			"sender":   peerPK,
+			"message":  text,
+			"network":  string(raddr.Net),
+			"outgoing": false,
+		})
 		if err != nil {
 			appLog("Failed to marshal json: %v", err)
 		}
@@ -602,6 +611,27 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			Text:      data["message"],
 			Timestamp: time.Now().UTC(),
 		})
+
+		// Mirror the outgoing message into the SSE stream so headless
+		// listeners (skywire-cli skychat listen) see a complete
+		// transcript without having to scrape send invocations and
+		// merge by timestamp. The TUI's bidirectional view already
+		// renders both directions natively; this brings parity to the
+		// listen-on-the-CLI use case.
+		//
+		// The "sender" field carries the RECIPIENT'S PK here (per-peer
+		// thread routing on the consumer's side stays keyed by the
+		// remote PK regardless of direction), with "outgoing":true so
+		// consumers can distinguish self-sends from peer messages.
+		mirrorMsg, mErr := json.Marshal(map[string]interface{}{
+			"sender":   pk.Hex(),
+			"message":  data["message"],
+			"network":  string(netType),
+			"outgoing": true,
+		})
+		if mErr == nil {
+			hub.broadcast(string(mirrorMsg))
+		}
 	}
 }
 

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -501,11 +501,16 @@ func handleConn(conn *framedConn) {
 		// inbound just as it can filter outbound. Without this, SSE
 		// events for incoming messages carry no transport tag and any
 		// consumer-side --net filter drops them all.
+		//
+		// "dir" is a string ("in"|"out"|... future "relay"|"group-in"|
+		// "group-out") rather than an "outgoing" bool so the schema
+		// stays extensible as group / relay flows land without a
+		// breaking wire-version bump.
 		clientMsg, err := json.Marshal(map[string]interface{}{
-			"sender":   peerPK,
-			"message":  text,
-			"network":  string(raddr.Net),
-			"outgoing": false,
+			"sender":  peerPK,
+			"message": text,
+			"network": string(raddr.Net),
+			"dir":     "in",
 		})
 		if err != nil {
 			appLog("Failed to marshal json: %v", err)
@@ -619,15 +624,25 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		// renders both directions natively; this brings parity to the
 		// listen-on-the-CLI use case.
 		//
+		// IMPORTANT: dir="out" means "WriteFrame returned without
+		// error" — i.e. the framed payload was handed to the
+		// underlying skywire conn. It does NOT mean the peer's
+		// chat-app received or processed the message. Peer-app
+		// receipt-ack is a deferred protocol feature (msg-id +
+		// chat-ack envelope frame type); consumers should not treat
+		// dir:out as delivery confirmation.
+		//
 		// The "sender" field carries the RECIPIENT'S PK here (per-peer
 		// thread routing on the consumer's side stays keyed by the
-		// remote PK regardless of direction), with "outgoing":true so
-		// consumers can distinguish self-sends from peer messages.
+		// remote PK regardless of direction). dir distinguishes
+		// directionality (string, not bool, for extensibility — future
+		// relay/group flows can emit "relay" / "group-in" /
+		// "group-out" without a wire-schema bump).
 		mirrorMsg, mErr := json.Marshal(map[string]interface{}{
-			"sender":   pk.Hex(),
-			"message":  data["message"],
-			"network":  string(netType),
-			"outgoing": true,
+			"sender":  pk.Hex(),
+			"message": data["message"],
+			"network": string(netType),
+			"dir":     "out",
 		})
 		if mErr == nil {
 			hub.broadcast(string(mirrorMsg))

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -147,14 +147,28 @@ restarts). Exit with Ctrl+C.
 
 Output modes:
   text (default): one line per event, format "[sender[/net]] body" for
-    messages; reconnect errors to stderr.
+    inbound messages, "[>sender[/net]] body" for outbound mirrors and
+    other non-inbound directions; reconnect errors to stderr.
   --json: one JSON object per stdout line (NDJSON). Event types:
     {"type":"banner",...}    once at startup (addr + filter context)
-    {"type":"msg",...}       a message from a peer; fields: ts, from, net, body, dir
+    {"type":"msg",...}       a message; fields: ts, from, net, body, dir
     {"type":"reconnect",...} SSE stream is being re-opened; fields: ts, err, delay_ms
     {"type":"error",...}     unparseable / unexpected; fields: ts, err
     Errors do NOT go to stderr in JSON mode — every signal is on stdout
     with a "type" tag so consumers can demux without merging two streams.
+
+Direction field ("dir") on msg events:
+  "in"   — message received from a peer.
+  "out"  — local visor sent the message; mirror surfaced so headless
+           listeners see a complete transcript. NOTE: "out" means the
+           framed payload was handed to the skywire transport (WriteFrame
+           returned without error). It does NOT mean the peer's chat-app
+           has received or processed the message. Peer-app receipt-ack
+           is a deferred protocol feature (msg-id + chat-ack envelope);
+           do not treat "dir":"out" as delivery confirmation.
+  Future values ("relay", "group-in", "group-out") may appear as group
+  and relay flows land; consumers should treat unknown dir values as
+  non-inbound rather than rejecting them.
 
 Filters:
   --net   skynet|dmsg      surface only that transport's messages
@@ -326,10 +340,10 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 		}
 		data := strings.TrimPrefix(line, "data: ")
 		var msg struct {
-			Sender   string `json:"sender"`
-			Message  string `json:"message"`
-			Network  string `json:"network,omitempty"`
-			Outgoing bool   `json:"outgoing,omitempty"`
+			Sender  string `json:"sender"`
+			Message string `json:"message"`
+			Network string `json:"network,omitempty"`
+			Dir     string `json:"dir,omitempty"` // "in" | "out" | future: "relay" | "group-in" | "group-out"
 		}
 		if err := json.Unmarshal([]byte(data), &msg); err != nil {
 			if jsonMode {
@@ -350,11 +364,14 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 			continue
 		}
 
+		// dir defaults to "in" for back-compat with older skychat-app
+		// servers that emit SSE events without a dir field at all.
+		dir := msg.Dir
+		if dir == "" {
+			dir = "in"
+		}
+
 		if jsonMode {
-			dir := "in"
-			if msg.Outgoing {
-				dir = "out"
-			}
 			emitJSON(out, listenEvent{
 				Type: evtMsg,
 				TS:   time.Now().UTC(),
@@ -368,8 +385,12 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 			if msg.Network != "" {
 				netSuffix = "/" + msg.Network
 			}
+			// ">" marks anything that ISN'T a normal inbound event —
+			// outgoing-mirror, future relay/group flows. Keeps text
+			// mode's one-line format readable while distinguishing
+			// the common-case "in" from everything else.
 			dirPrefix := ""
-			if msg.Outgoing {
+			if dir != "in" {
 				dirPrefix = ">"
 			}
 			fmt.Fprintf(out, "[%s%s%s] %s\n", dirPrefix, msg.Sender, netSuffix, msg.Message) //nolint:errcheck

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -31,8 +31,9 @@ var (
 	// — sendCmd's default of "skynet" was clobbered by listenCmd's
 	// default of "", and `skychat send -t X -m hi` (no --net)
 	// surfaced "invalid network type:" because the var was empty.
-	sendNet   string
-	listenNet string
+	sendNet    string
+	listenNet  string
+	listenFrom string
 )
 
 func init() {
@@ -51,6 +52,7 @@ func init() {
 	sendCmd.MarkFlagRequired("msg") //nolint:errcheck,gosec
 
 	listenCmd.Flags().StringVarP(&listenNet, "net", "n", "", "filter by network type (optional; default = all)")
+	listenCmd.Flags().StringVar(&listenFrom, "from", "", "filter by sender public key (optional; full hex PK)")
 
 	chatCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (optional; TUI prompts for it if omitted)")
 	chatCmd.Flags().StringVarP(&sendNet, "net", "n", "skynet", "network type for outgoing messages: skynet or dmsg")
@@ -141,23 +143,65 @@ var listenCmd = &cobra.Command{
 	Long: `Connect to skychat SSE endpoint and display incoming messages.
 
 Reconnects automatically when the connection drops (e.g. the visor
-restarts). Exit with Ctrl+C.`,
+restarts). Exit with Ctrl+C.
+
+Output modes:
+  text (default): one line per event, format "[sender[/net]] body" for
+    messages; reconnect errors to stderr.
+  --json: one JSON object per stdout line (NDJSON). Event types:
+    {"type":"banner",...}    once at startup (addr + filter context)
+    {"type":"msg",...}       a message from a peer; fields: ts, from, net, body, dir
+    {"type":"reconnect",...} SSE stream is being re-opened; fields: ts, err, delay_ms
+    {"type":"error",...}     unparseable / unexpected; fields: ts, err
+    Errors do NOT go to stderr in JSON mode — every signal is on stdout
+    with a "type" tag so consumers can demux without merging two streams.
+
+Filters:
+  --net   skynet|dmsg      surface only that transport's messages
+  --from  <PK hex>         surface only this sender (handy for N-way
+                           channels; filter applies before output)`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Empty listenNet means "all"; if set, only print messages
 		// whose network field matches.
-		filter := listenNet
-		if filter != "" {
-			if err := validateNetwork(filter); err != nil {
+		netFilter := listenNet
+		if netFilter != "" {
+			if err := validateNetwork(netFilter); err != nil {
 				internal.PrintFatalError(cmd.Flags(), err)
 			}
 		}
+		// --from must be a valid full-hex PK if supplied; reject early
+		// rather than silently never matching.
+		var fromFilter cipher.PubKey
+		if listenFrom != "" {
+			if err := fromFilter.Set(listenFrom); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --from public key %q: %w", listenFrom, err))
+			}
+		}
+
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		out := cmd.OutOrStdout()
+		errOut := cmd.ErrOrStderr()
 
 		url := fmt.Sprintf("http://%s/sse", httpAddr)
-		fmt.Printf("Listening for messages from %s", httpAddr)
-		if filter != "" {
-			fmt.Printf(" (filter: %s)", filter)
+
+		if jsonMode {
+			emitJSON(out, listenEvent{
+				Type: evtBanner,
+				TS:   time.Now().UTC(),
+				Addr: httpAddr,
+				Net:  netFilter,
+				From: listenFrom,
+			})
+		} else {
+			fmt.Fprintf(out, "Listening for messages from %s", httpAddr) //nolint:errcheck
+			if netFilter != "" {
+				fmt.Fprintf(out, " (net=%s)", netFilter) //nolint:errcheck
+			}
+			if listenFrom != "" {
+				fmt.Fprintf(out, " (from=%s)", listenFrom) //nolint:errcheck
+			}
+			fmt.Fprint(out, "\nPress Ctrl+C to stop\n\n") //nolint:errcheck
 		}
-		fmt.Print("\nPress Ctrl+C to stop\n\n")
 
 		ctx := cmd.Context()
 		if ctx == nil {
@@ -166,7 +210,7 @@ restarts). Exit with Ctrl+C.`,
 
 		delay := minReconnectDelay
 		for {
-			err := streamSSEOnce(ctx, url, filter)
+			err := streamSSEOnce(ctx, out, url, netFilter, listenFrom, jsonMode)
 			if ctx.Err() != nil {
 				// Caller hit Ctrl+C; exit cleanly.
 				return
@@ -176,8 +220,16 @@ restarts). Exit with Ctrl+C.`,
 				// reconnect prompt rather than an error.
 				delay = minReconnectDelay
 			} else {
-				fmt.Fprintf(cmd.ErrOrStderr(), //nolint:errcheck
-					"skychat listen: %v (reconnecting in %s)\n", err, delay)
+				if jsonMode {
+					emitJSON(out, listenEvent{
+						Type:    evtReconnect,
+						TS:      time.Now().UTC(),
+						Err:     err.Error(),
+						DelayMS: delay.Milliseconds(),
+					})
+				} else {
+					fmt.Fprintf(errOut, "skychat listen: %v (reconnecting in %s)\n", err, delay) //nolint:errcheck
+				}
 			}
 
 			// Sleep before retry, but honor Ctrl+C while sleeping.
@@ -198,11 +250,56 @@ restarts). Exit with Ctrl+C.`,
 	},
 }
 
+// listenEvent is the NDJSON wire-shape emitted by listen --json.
+// One JSON object per stdout line; consumers parse line-at-a-time.
+// Field tagging is stable — adding new fields is backward-compatible
+// (consumers ignore unknown fields); changing or removing a field
+// requires a wire-version bump.
+type listenEvent struct {
+	Type string    `json:"type"`
+	TS   time.Time `json:"ts"`
+
+	// Banner-only.
+	Addr string `json:"addr,omitempty"`
+
+	// Msg-only.
+	From string `json:"from,omitempty"`
+	Net  string `json:"net,omitempty"`
+	Body string `json:"body,omitempty"`
+	Dir  string `json:"dir,omitempty"` // "in" | "out"
+
+	// Reconnect / error.
+	Err     string `json:"err,omitempty"`
+	DelayMS int64  `json:"delay_ms,omitempty"`
+}
+
+const (
+	evtBanner    = "banner"
+	evtMsg       = "msg"
+	evtReconnect = "reconnect"
+	evtError     = "error"
+)
+
+// emitJSON writes one NDJSON line. Errors are intentionally swallowed
+// — the listener is best-effort and we can't do anything useful if
+// stdout is broken.
+func emitJSON(w io.Writer, ev listenEvent) {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	b = append(b, '\n')
+	_, _ = w.Write(b) //nolint:errcheck
+}
+
 // streamSSEOnce opens a single SSE connection and drains it until
 // the stream ends, the context is canceled, or an error occurs.
 // Returns nil on clean end-of-stream so the caller can retry
 // without surfacing it as a failure.
-func streamSSEOnce(ctx context.Context, url, filter string) error {
+//
+// netFilter (""|skynet|dmsg) and fromFilter ("" | full-hex PK)
+// suppress non-matching events before any output.
+func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilter string, jsonMode bool) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("build SSE request: %w", err)
@@ -218,6 +315,10 @@ func streamSSEOnce(ctx context.Context, url, filter string) error {
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	// Default Scanner buffer is 64KB which can split long SSE payloads
+	// (skychat frames cap at 64KB but the SSE wrapping adds the "data: "
+	// prefix + newline). Bump to 256KB to leave headroom.
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data: ") {
@@ -225,22 +326,54 @@ func streamSSEOnce(ctx context.Context, url, filter string) error {
 		}
 		data := strings.TrimPrefix(line, "data: ")
 		var msg struct {
-			Sender  string `json:"sender"`
-			Message string `json:"message"`
-			Network string `json:"network,omitempty"`
+			Sender   string `json:"sender"`
+			Message  string `json:"message"`
+			Network  string `json:"network,omitempty"`
+			Outgoing bool   `json:"outgoing,omitempty"`
 		}
 		if err := json.Unmarshal([]byte(data), &msg); err != nil {
-			fmt.Printf("Raw: %s\n", data)
+			if jsonMode {
+				emitJSON(out, listenEvent{
+					Type: evtError,
+					TS:   time.Now().UTC(),
+					Err:  fmt.Sprintf("unparseable SSE data: %s", data),
+				})
+			} else {
+				fmt.Fprintf(out, "Raw: %s\n", data) //nolint:errcheck
+			}
 			continue
 		}
-		if filter != "" && msg.Network != "" && msg.Network != filter {
+		if netFilter != "" && msg.Network != "" && msg.Network != netFilter {
 			continue
 		}
-		net := ""
-		if msg.Network != "" {
-			net = "/" + msg.Network
+		if fromFilter != "" && msg.Sender != fromFilter {
+			continue
 		}
-		fmt.Printf("[%s%s] %s\n", msg.Sender, net, msg.Message)
+
+		if jsonMode {
+			dir := "in"
+			if msg.Outgoing {
+				dir = "out"
+			}
+			emitJSON(out, listenEvent{
+				Type: evtMsg,
+				TS:   time.Now().UTC(),
+				From: msg.Sender,
+				Net:  msg.Network,
+				Body: msg.Message,
+				Dir:  dir,
+			})
+		} else {
+			netSuffix := ""
+			if msg.Network != "" {
+				netSuffix = "/" + msg.Network
+			}
+			dirPrefix := ""
+			if msg.Outgoing {
+				dirPrefix = ">"
+			}
+			fmt.Fprintf(out, "[%s%s%s] %s\n", dirPrefix, msg.Sender, netSuffix, msg.Message) //nolint:errcheck
+		}
 	}
 	// scanner.Err() returns nil on a clean EOF; io.EOF /
 	// io.ErrUnexpectedEOF / a canceled context all show up here too.


### PR DESCRIPTION
## Summary

Four basic-CLI friction items raised by agent operators driving skychat from headless CLI today. All four address \"works on TUI, fails on scripted listen\" gaps.

1. **\`listen --json\`** — NDJSON output. One JSON object per stdout line. Event types: \`banner\`, \`msg\`, \`reconnect\`, \`error\`. Every signal is on stdout with a \`\"type\"\` tag — scripts demux without merging streams or regex-matching free-form text.
2. **\`listen --from <PK>\`** — server-side filter on sender. Mirrors the existing \`--net\` flag. Required for N-way agent channels where one listener follows many parallel threads.
3. **Outgoing-mirror in SSE** — \`messageHandler\` now broadcasts a hub event with \`\"outgoing\":true\` after each successful send. Headless listeners now see a complete transcript; TUI parity.
4. **Network field on inbound** — \`handleConn\` broadcast now includes \`\"network\": \"skynet\"|\"dmsg\"\` from \`raddr.Net\`. Previously inbound events carried no transport tag and \`--net\` filters dropped them all.

## JSON schema

\`\`\`json
{\"type\":\"banner\",    \"ts\":\"...\", \"addr\":\"127.0.0.1:8001\", \"net\":\"\", \"from\":\"\"}
{\"type\":\"msg\",       \"ts\":\"...\", \"from\":\"<66hex>\", \"net\":\"skynet\", \"body\":\"...\", \"dir\":\"in\"}
{\"type\":\"reconnect\", \"ts\":\"...\", \"err\":\"...\", \"delay_ms\":2000}
{\"type\":\"error\",     \"ts\":\"...\", \"err\":\"unparseable SSE data: ...\"}
\`\`\`

Adding new fields is backward-compatible (consumers ignore unknown fields); changing or removing a field is a wire-version bump.

## Background

Three Claude agent instances driving the visor via skychat today hit the same set of friction items independently. Real bugs (silent on-the-wire truncation) turned out to be display-only in the agent harness notification system — confirmed via self-send: 2600-byte payload arrived 2669 bytes in the listener file. So this PR is scoped to CLI ergonomics, not protocol changes.

Send-side delivery ACK (peer-app acknowledgment, not local-handoff) needs a protocol-level envelope with message-id + chat-ack frame type. Deferred to a follow-up; this PR doesn't change the wire format other than adding two optional fields to existing SSE events.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [x] Manual self-send: 2600-byte payload round-trips intact; --json output parses; --from filter selects.
- [ ] Operator (0pcom) restart of visor onto this branch; agents verify --from + --json + outgoing-mirror in actual N-way listener flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)