### PR TITLE
feat(skychat-cli): history + status subcommands

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -198,6 +198,14 @@ func (h *sseHub) subscribe() (<-chan string, func()) {
 	}
 }
 
+// clientCount returns how many SSE subscribers are currently
+// connected. Used by /status for operator health probes.
+func (h *sseHub) clientCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients)
+}
+
 // broadcast sends msg to every connected client. Drops to clients
 // whose buffer is full — bounded fan-out keeps a single stalled
 // client from holding back the whole stream.
@@ -373,6 +381,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 	http.HandleFunc("/sse", requireAuthFunc(sseHandler))
 	http.HandleFunc("/history", requireAuthFunc(historyHandler))
 	http.HandleFunc("/history/peers", requireAuthFunc(historyPeersHandler))
+	http.HandleFunc("/status", requireAuthFunc(statusHandler))
 	registerPairHTTPHandlers(ctx)
 
 	url := ""
@@ -805,6 +814,48 @@ func historyPeersHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(peers) //nolint:errcheck,gosec
+}
+
+// statusHandler returns a snapshot of the chat-app's runtime health
+// for operator probes. Replaces the chain of `docker exec + ss -tlnp
+// + curl /sse` an operator would otherwise need to verify the app
+// is up. JSON shape is stable — added fields are backward-compatible.
+func statusHandler(w http.ResponseWriter, _ *http.Request) {
+	connsMu.Lock()
+	connCount := len(conns)
+	peers := make([]string, 0, connCount)
+	for pk := range conns {
+		peers = append(peers, pk.Hex())
+	}
+	connsMu.Unlock()
+
+	var subscriberCount int
+	if hub != nil {
+		subscriberCount = hub.clientCount()
+	}
+
+	var visorPK string
+	var visorPKErr string
+	if appCl != nil {
+		visorPK = appCl.Config().VisorPK.Hex()
+	} else {
+		visorPKErr = "app client not initialized"
+	}
+
+	status := map[string]interface{}{
+		"visor_pk":            visorPK,
+		"sse_subscribers":     subscriberCount,
+		"active_peer_conns":   connCount,
+		"peers":               peers,
+		"persistence_enabled": historyStore != nil,
+		"pairing_enabled":     pairEnable,
+	}
+	if visorPKErr != "" {
+		status["error"] = visorPKErr
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status) //nolint:errcheck,gosec
 }
 
 // persistMessage stores a message in the history backend if persistence is

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -47,6 +47,7 @@ func init() {
 		listenCmd,
 		chatCmd,
 		historyCmd,
+		statusCmd,
 	)
 
 	sendCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (required)")
@@ -199,6 +200,76 @@ Returns an error if the chat-app has persistence disabled.`,
 				}
 				fmt.Fprintf(out, "%s [%s @ %s] %s\n", m.Timestamp.UTC().Format(time.RFC3339), dir, m.Peer, m.Text) //nolint:errcheck
 			}
+		}
+	},
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Probe the skychat app's health",
+	Long: `Print a snapshot of the skychat app's runtime health: visor PK,
+SSE subscriber count, active peer conns and their PKs, whether
+persistence + pairing are enabled.
+
+Operator use: "is my chat app working" without docker exec / ss /
+curl gymnastics. Returns 1 + a clear error if the chat-app's HTTP
+endpoint isn't reachable.
+
+Default output is human-readable lines; --json emits the raw status
+object suitable for scripts.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		url := fmt.Sprintf("http://%s/status", httpAddr)
+		resp, err := http.Get(url) //nolint:gosec
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("chat app unreachable at %s: %w", httpAddr, err))
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("status fetch: server %d: %s", resp.StatusCode, strings.TrimSpace(string(body))))
+		}
+
+		raw, err := io.ReadAll(resp.Body)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("status read: %w", err))
+		}
+
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		out := cmd.OutOrStdout()
+
+		if jsonMode {
+			_, _ = out.Write(raw) //nolint:errcheck
+			if len(raw) > 0 && raw[len(raw)-1] != '\n' {
+				_, _ = out.Write([]byte{'\n'}) //nolint:errcheck
+			}
+			return
+		}
+
+		var status struct {
+			VisorPK            string   `json:"visor_pk"`
+			SSESubscribers     int      `json:"sse_subscribers"`
+			ActivePeerConns    int      `json:"active_peer_conns"`
+			Peers              []string `json:"peers"`
+			PersistenceEnabled bool     `json:"persistence_enabled"`
+			PairingEnabled     bool     `json:"pairing_enabled"`
+			Error              string   `json:"error,omitempty"`
+		}
+		if err := json.Unmarshal(raw, &status); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("decode status: %w", err))
+		}
+		fmt.Fprintf(out, "Chat app at %s\n", httpAddr)                         //nolint:errcheck
+		fmt.Fprintf(out, "  visor PK:           %s\n", status.VisorPK)         //nolint:errcheck
+		fmt.Fprintf(out, "  SSE subscribers:    %d\n", status.SSESubscribers)  //nolint:errcheck
+		fmt.Fprintf(out, "  active peer conns:  %d\n", status.ActivePeerConns) //nolint:errcheck
+		if len(status.Peers) > 0 {
+			for _, p := range status.Peers {
+				fmt.Fprintf(out, "    - %s\n", p) //nolint:errcheck
+			}
+		}
+		fmt.Fprintf(out, "  persistence:        %v\n", status.PersistenceEnabled) //nolint:errcheck
+		fmt.Fprintf(out, "  pairing:            %v\n", status.PairingEnabled)     //nolint:errcheck
+		if status.Error != "" {
+			fmt.Fprintf(out, "  error:              %s\n", status.Error) //nolint:errcheck
 		}
 	},
 }

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -31,9 +31,12 @@ var (
 	// — sendCmd's default of "skynet" was clobbered by listenCmd's
 	// default of "", and `skychat send -t X -m hi` (no --net)
 	// surfaced "invalid network type:" because the var was empty.
-	sendNet    string
-	listenNet  string
-	listenFrom string
+	sendNet      string
+	listenNet    string
+	listenFrom   string
+	historyPeer  string
+	historyLimit int
+	historySince string
 )
 
 func init() {
@@ -43,6 +46,7 @@ func init() {
 		sendCmd,
 		listenCmd,
 		chatCmd,
+		historyCmd,
 	)
 
 	sendCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (required)")
@@ -53,6 +57,10 @@ func init() {
 
 	listenCmd.Flags().StringVarP(&listenNet, "net", "n", "", "filter by network type (optional; default = all)")
 	listenCmd.Flags().StringVar(&listenFrom, "from", "", "filter by sender public key (optional; full hex PK)")
+
+	historyCmd.Flags().StringVar(&historyPeer, "peer", "", "filter by peer public key (optional; full hex PK)")
+	historyCmd.Flags().IntVar(&historyLimit, "limit", 100, "max messages to return (1-1000)")
+	historyCmd.Flags().StringVar(&historySince, "since", "", "only return messages newer than this duration (e.g. 1h, 30m, 24h)")
 
 	chatCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (optional; TUI prompts for it if omitted)")
 	chatCmd.Flags().StringVarP(&sendNet, "net", "n", "skynet", "network type for outgoing messages: skynet or dmsg")
@@ -85,6 +93,113 @@ var sendCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("Message sent to %s via %s\n", pk.String(), sendNet))
+	},
+}
+
+var historyCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Print persisted message history",
+	Long: `Print the locally persisted message history.
+
+Recovery path for missed messages: when the listener is down (visor
+restart, shell filter ate the events, the agent driver missed a
+notification), the history store still has them. This command reads
+straight from the chat-app's /history HTTP endpoint and prints the
+result.
+
+Filters:
+  --peer  <PK>     only this peer's messages (full hex PK)
+  --limit N        max messages to return (default 100, max 1000)
+  --since DURATION client-side filter: drop messages older than this
+                   (e.g. 1h, 30m, 24h, 168h for a week)
+
+With --json: prints {ts, peer, from, outgoing, text} per line (NDJSON,
+matches the listen schema as closely as possible). Without --json:
+prints "<ISO ts> [in|out @ peer] body" one per line.
+
+Returns an error if the chat-app has persistence disabled.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if historyLimit <= 0 || historyLimit > 1000 {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--limit must be 1-1000, got %d", historyLimit))
+		}
+		if historyPeer != "" {
+			var pk cipher.PubKey
+			if err := pk.Set(historyPeer); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --peer public key %q: %w", historyPeer, err))
+			}
+		}
+		var sinceCutoff time.Time
+		if historySince != "" {
+			d, err := time.ParseDuration(historySince)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --since duration %q: %w", historySince, err))
+			}
+			if d < 0 {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--since duration must be positive, got %s", d))
+			}
+			sinceCutoff = time.Now().Add(-d)
+		}
+
+		url := fmt.Sprintf("http://%s/history?limit=%d", httpAddr, historyLimit)
+		if historyPeer != "" {
+			url += "&peer=" + historyPeer
+		}
+		resp, err := http.Get(url) //nolint:gosec
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("history fetch: %w", err))
+		}
+		defer resp.Body.Close() //nolint:errcheck
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			internal.PrintFatalError(cmd.Flags(), errors.New("chat-app persistence not enabled (start visor with --persist-skychat-history)"))
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("history fetch: server %d: %s", resp.StatusCode, strings.TrimSpace(string(body))))
+		}
+
+		// /history returns a JSON array of history.Message records.
+		var msgs []struct {
+			Peer      string    `json:"peer"`
+			From      string    `json:"from"`
+			Outgoing  bool      `json:"outgoing"`
+			Text      string    `json:"text"`
+			Timestamp time.Time `json:"timestamp"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&msgs); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("decode history: %w", err))
+		}
+
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		out := cmd.OutOrStdout()
+
+		for _, m := range msgs {
+			if !sinceCutoff.IsZero() && m.Timestamp.Before(sinceCutoff) {
+				continue
+			}
+			if jsonMode {
+				ev := struct {
+					TS       time.Time `json:"ts"`
+					Peer     string    `json:"peer"`
+					From     string    `json:"from,omitempty"`
+					Outgoing bool      `json:"outgoing"`
+					Text     string    `json:"text"`
+				}{
+					TS:       m.Timestamp,
+					Peer:     m.Peer,
+					From:     m.From,
+					Outgoing: m.Outgoing,
+					Text:     m.Text,
+				}
+				b, _ := json.Marshal(ev)          //nolint:errcheck
+				_, _ = out.Write(append(b, '\n')) //nolint:errcheck
+			} else {
+				dir := "in"
+				if m.Outgoing {
+					dir = "out"
+				}
+				fmt.Fprintf(out, "%s [%s @ %s] %s\n", m.Timestamp.UTC().Format(time.RFC3339), dir, m.Peer, m.Text) //nolint:errcheck
+			}
+		}
 	},
 }
 


### PR DESCRIPTION
## Summary

Two more skychat-CLI gaps after #2508. Both unblock agent operators driving the chat headless without docker exec / curl / grep gymnastics.

### \`skywire cli skychat history\`

Reads the chat-app's existing \`/history\` HTTP endpoint and prints the result. Recovery path for missed messages: visor restart, listener filter ate events, agent driver missed a notification — the persistence store has them; this gives the CLI a way to pull them out.

\`\`\`
skywire cli skychat history [--peer PK] [--limit N] [--since DUR] [--json]
\`\`\`

- \`--peer  PK\`      server-side filter (full hex PK)
- \`--limit N\`       server-side, 1-1000, default 100
- \`--since DUR\`     client-side time filter (e.g. \`1h\`, \`30m\`, \`24h\`)
- \`--json\`          NDJSON; matches the listen schema as closely as possible
- default: \`<RFC3339 ts> [in|out @ peer] body\` one per line

Clear error \"chat-app persistence not enabled (start visor with --persist-skychat-history)\" instead of the opaque 503 the HTTP endpoint returns.

### \`skywire cli skychat status\` + chat-app \`/status\`

Operator health probe. Replaces the \`docker exec + ss -tlnp + curl /sse\` chain. New chat-app endpoint:

\`\`\`json
{
  \"visor_pk\": \"<66hex>\",
  \"sse_subscribers\": 2,
  \"active_peer_conns\": 4,
  \"peers\": [\"<pk>\", \"<pk>\", ...],
  \"persistence_enabled\": true,
  \"pairing_enabled\": true
}
\`\`\`

CLI default: human-readable lines. \`--json\` passes through the server object. Returns 1 + clear error if the chat-app HTTP endpoint isn't reachable.

\`sseHub.clientCount()\` added as the underlying primitive (single mutex-guarded counter; same lock the broadcast path uses).

## Background

Continuation of agent-operator feedback that drove #2508. Originally a single batch but I split history + status out for cleaner review (and to leave room for the bigger send --ack work as a separate proto-level change).

Remaining items from operator feedback (deferred):
- \`send --ack\` (P0) — requires envelope + msg-id + chat-ack frame type; protocol change
- PK aliases (P3) — local addressbook for \`-t alias\` instead of 66-hex

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [x] \`skywire cli skychat history --help\`, \`status --help\` render
- [x] \`skychat history\` against running visor surfaces persistence-disabled error correctly
- [ ] Post-merge: operator runs both against a chat-app with persistence on and confirms output

🤖 Generated with [Claude Code](https://claude.com/claude-code)