### PR TITLE
feat(skychat): send --wait peer-receipt ack via chat-msg/chat-ack envelopes

### DIFF
--- a/cmd/apps/skychat/commands/sendack.go
+++ b/cmd/apps/skychat/commands/sendack.go
@@ -1,0 +1,156 @@
+// Package commands cmd/apps/skychat/sendack.go
+//
+// chat-msg / chat-ack envelope: opt-in peer-receipt acknowledgment.
+//
+// Wire format (JSON-encoded payload inside a normal framed frame):
+//
+//	chat-msg: {"type":"chat-msg","id":"<hex>","body":"...","ack":true}
+//	chat-ack: {"type":"chat-ack","id":"<hex>"}
+//
+// Backward compat: when --wait is NOT used, the sender writes the
+// plain-text body as before (no envelope). Old peers + new peers see
+// the same plaintext message. The envelope is OPT-IN at the sender
+// — when --wait is set, the sender wraps in chat-msg and waits for
+// chat-ack with the matching id. An old peer that receives a
+// chat-msg envelope will surface the entire JSON as chat text (ugly,
+// but the agent-coordination use case is all-post-2510 peers anyway).
+//
+// Why not always envelope: it would force every existing human-user
+// chat to look at JSON on old visors during the staggered roll.
+// Opt-in keeps the wire byte-identical for default sends, the same
+// as it has been since #2504.
+//
+// chat-ack is sent back over the same framed conn the chat-msg came
+// in on (writeMu protects the framing). The sender's handleConn
+// recognizes the inbound chat-ack and routes it to a waiter map
+// keyed by id. The /message HTTP handler holds the request open
+// until either: the ack arrives, the deadline fires, or the conn
+// dies.
+
+package commands
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// chatEnvelope is the on-the-wire shape for both chat-msg (carries
+// body) and chat-ack (just id). Fields are encoded omitempty so the
+// two share one Go struct without leaking irrelevant fields.
+type chatEnvelope struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Body string `json:"body,omitempty"`
+	Ack  bool   `json:"ack,omitempty"` // chat-msg only: request ack-on-receipt
+}
+
+const (
+	chatTypeMsg = "chat-msg"
+	chatTypeAck = "chat-ack"
+)
+
+// ackWaiters routes an inbound chat-ack envelope back to the
+// /message HTTP handler that's waiting for it. Keyed by event id;
+// value is a one-shot channel that fires on receipt.
+//
+// Lifetime: the /message handler registers the waiter before writing
+// the chat-msg frame, deregisters it before returning regardless of
+// outcome. A spurious ack (one nobody is waiting for) is silently
+// dropped — that handles late acks after a timeout cleanly.
+var (
+	ackWaitersMu sync.Mutex
+	ackWaiters   = map[string]chan struct{}{}
+)
+
+// registerAckWaiter adds a one-shot channel for the given id. Returns
+// the channel + an unregister func the caller MUST invoke (typically
+// via defer) regardless of whether the wait succeeded or timed out.
+func registerAckWaiter(id string) (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+	ackWaitersMu.Lock()
+	ackWaiters[id] = ch
+	ackWaitersMu.Unlock()
+	return ch, func() {
+		ackWaitersMu.Lock()
+		delete(ackWaiters, id)
+		ackWaitersMu.Unlock()
+	}
+}
+
+// deliverAck signals any waiter registered for id. No-op if no
+// waiter exists (late ack / unsolicited ack). Idempotent.
+func deliverAck(id string) {
+	ackWaitersMu.Lock()
+	ch, ok := ackWaiters[id]
+	ackWaitersMu.Unlock()
+	if !ok {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+		// already signaled
+	}
+}
+
+// tryHandleChatEnvelope attempts to parse payload as a chat-msg or
+// chat-ack envelope. Returns (handled=true, body=...) if it's a
+// chat-msg the caller should surface as a normal chat message after
+// optionally sending an ack back. Returns (handled=true, body="")
+// if it's a chat-ack (consumed internally, no surfacing). Returns
+// (handled=false, _) for anything else — caller falls through to
+// the legacy plain-text path.
+//
+// Envelope recognition is conservative: must start with '{', valid
+// JSON, type field matches a known chat-* value. Anything else is
+// "not an envelope" so plain-text JSON-looking chat (e.g. someone
+// typing literal {} into a chat window) still reaches its peer.
+func tryHandleChatEnvelope(payload []byte, peerPKHex string, sendAck func(id string)) (handled bool, body string, id string) {
+	trimmed := bytesTrimSpace(payload)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false, "", ""
+	}
+	var env chatEnvelope
+	if err := json.Unmarshal(trimmed, &env); err != nil {
+		return false, "", ""
+	}
+	switch env.Type {
+	case chatTypeMsg:
+		if env.Ack && env.ID != "" && sendAck != nil {
+			// Best-effort: a failed ack write is logged by the
+			// caller's sendAck implementation; we still surface the
+			// message so the recipient sees it.
+			sendAck(env.ID)
+		}
+		return true, env.Body, env.ID
+	case chatTypeAck:
+		if env.ID != "" {
+			deliverAck(env.ID)
+		}
+		// Consumed; nothing to surface to the chat UI.
+		return true, "", env.ID
+	}
+	_ = peerPKHex // reserved for future per-peer ack policy / rate-limit
+	return false, "", ""
+}
+
+// chatAckTimeoutFloor / chatAckTimeoutCeiling clamp the wait_ms
+// parameter on /message. Lower bound prevents zero-wait misuse;
+// upper bound bounds resource consumption on a held HTTP request.
+const (
+	chatAckTimeoutFloor   = 100 * time.Millisecond
+	chatAckTimeoutCeiling = 60 * time.Second
+)
+
+// clampAckWait normalizes a caller-supplied wait_ms into the
+// allowed range. Zero / negative / unset → floor; over-ceiling → ceiling.
+func clampAckWait(d time.Duration) time.Duration {
+	if d < chatAckTimeoutFloor {
+		return chatAckTimeoutFloor
+	}
+	if d > chatAckTimeoutCeiling {
+		return chatAckTimeoutCeiling
+	}
+	return d
+}

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -544,8 +544,36 @@ func handleConn(conn *framedConn) {
 			continue
 		}
 
-		text := string(payload)
 		peerPK := raddr.PubKey.Hex()
+
+		// Then try the chat-msg / chat-ack envelope. A chat-msg
+		// envelope (type=chat-msg, ack=true) → unwrap body, send
+		// chat-ack back, surface body as a normal chat message.
+		// A chat-ack envelope (type=chat-ack) → consumed internally
+		// to satisfy a waiting /message --wait request, NOT surfaced
+		// to the SSE stream. Plain-text bodies fall through to the
+		// legacy path unchanged.
+		envHandled, envBody, _ := tryHandleChatEnvelope(payload, peerPK, func(id string) {
+			ackEnv := chatEnvelope{Type: chatTypeAck, ID: id}
+			ackBytes, mErr := json.Marshal(ackEnv)
+			if mErr != nil {
+				appLog("chat-ack marshal failed: %v", mErr)
+				return
+			}
+			if wErr := conn.WriteFrame(ackBytes); wErr != nil {
+				appLog("chat-ack write to %s failed: %v", peerPK, wErr)
+			}
+		})
+		var text string
+		if envHandled {
+			if envBody == "" {
+				// chat-ack consumed — nothing to surface.
+				continue
+			}
+			text = envBody
+		} else {
+			text = string(payload)
+		}
 
 		counterMu.Lock()
 		inboundMsgCount++
@@ -596,22 +624,35 @@ func handleConn(conn *framedConn) {
 func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 
-		data := map[string]string{}
+		var data struct {
+			Recipient string `json:"recipient"`
+			Message   string `json:"message"`
+			Network   string `json:"network,omitempty"`
+			// WaitMS, if positive, requests peer-receipt acknowledgment:
+			// the message is wrapped in a chat-msg envelope with a
+			// unique id, written to the peer, and this handler blocks
+			// up to WaitMS for the peer's chat-ack envelope to come
+			// back over the same conn. On ack: returns 200 + JSON
+			// {acked:true, ms:<elapsed>}. On timeout: 504 + JSON
+			// {acked:false, reason:"timeout"}. Clamped to
+			// [chatAckTimeoutFloor, chatAckTimeoutCeiling] server-side.
+			WaitMS int `json:"wait_ms,omitempty"`
+		}
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		pk := cipher.PubKey{}
-		if err := pk.UnmarshalText([]byte(data["recipient"])); err != nil {
+		if err := pk.UnmarshalText([]byte(data.Recipient)); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		// Determine network type - default to skynet, allow dmsg
 		netType := appnet.TypeSkynet
-		if network, ok := data["network"]; ok {
-			switch network {
+		if data.Network != "" {
+			switch data.Network {
 			case "dmsg":
 				netType = appnet.TypeDmsg
 			case "skynet":
@@ -669,10 +710,40 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			conns[pk] = conn
 			connsMu.Unlock()
 
-			go handleConn(conn)
+			// handleConn's lifetime is the underlying peer connection,
+			// not this HTTP request — req.Context() canceling on
+			// response would tear down a healthy long-lived conn that
+			// future sends + the receive loop rely on. Outliving the
+			// request is the correct shape.
+			go handleConn(conn) //nolint:gosec // G118: long-lived conn, not request-scoped
 		}
 
-		err := conn.WriteFrame([]byte(data["message"]))
+		// Build the on-the-wire payload. Default is plain text (back-
+		// compat with every binary that has shipped to date). When
+		// wait_ms is set, we wrap in a chat-msg envelope with a fresh
+		// id, register an ack-waiter, and after the write blocks the
+		// HTTP request on the ack channel up to wait_ms.
+		wirePayload := []byte(data.Message)
+		var ackID string
+		var ackCh <-chan struct{}
+		var unregisterAck func()
+		var ackWait time.Duration
+		if data.WaitMS > 0 {
+			ackID = newEventID()
+			env := chatEnvelope{Type: chatTypeMsg, ID: ackID, Body: data.Message, Ack: true}
+			eb, mErr := json.Marshal(env)
+			if mErr != nil {
+				http.Error(w, mErr.Error(), http.StatusInternalServerError)
+				return
+			}
+			wirePayload = eb
+			ackWait = clampAckWait(time.Duration(data.WaitMS) * time.Millisecond)
+			ackCh, unregisterAck = registerAckWaiter(ackID)
+			defer unregisterAck()
+		}
+
+		writeStart := time.Now()
+		err := conn.WriteFrame(wirePayload)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 
@@ -687,9 +758,42 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		persistMessage(history.Message{
 			Peer:      pk.Hex(),
 			Outgoing:  true,
-			Text:      data["message"],
+			Text:      data.Message,
 			Timestamp: time.Now().UTC(),
 		})
+
+		// If --wait was requested, block on the ack channel. The
+		// envelope was written above; the peer's chat-app, if it
+		// speaks the chat-msg envelope (i.e. is post-2026-05-12),
+		// recognizes it, persists the body, sends chat-ack back over
+		// the same conn, which our handleConn routes to deliverAck →
+		// our ackCh. Old peers see the JSON-encoded envelope as plain
+		// text and never ack; we time out cleanly.
+		if ackCh != nil {
+			timer := time.NewTimer(ackWait)
+			defer timer.Stop()
+			select {
+			case <-ackCh:
+				elapsed := time.Since(writeStart)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+					"acked": true,
+					"id":    ackID,
+					"ms":    elapsed.Milliseconds(),
+				})
+			case <-timer.C:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusGatewayTimeout)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+					"acked":  false,
+					"id":     ackID,
+					"reason": "timeout",
+					"ms":     ackWait.Milliseconds(),
+				})
+			case <-req.Context().Done():
+				return
+			}
+		}
 
 		// Mirror the outgoing message into the SSE stream so headless
 		// listeners (skywire-cli skychat listen) see a complete
@@ -721,14 +825,20 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		if appCl != nil {
 			myPK = appCl.Config().VisorPK.Hex()
 		}
+		// Use the ack id when --wait was used, so consumers correlate
+		// the outgoing mirror to a specific send by id.
+		mirrorID := ackID
+		if mirrorID == "" {
+			mirrorID = newEventID()
+		}
 		mirrorMsg, mErr := json.Marshal(map[string]interface{}{
 			"sender":  myPK,
 			"to":      pk.Hex(),
-			"message": data["message"],
+			"message": data.Message,
 			"network": string(netType),
 			"dir":     "out",
-			"id":      newEventID(),
-			"len":     len(data["message"]),
+			"id":      mirrorID,
+			"len":     len(data.Message),
 		})
 		if mErr == nil {
 			hub.broadcast(string(mirrorMsg))

--- a/cmd/skywire-cli/commands/skychat/chat.go
+++ b/cmd/skywire-cli/commands/skychat/chat.go
@@ -315,7 +315,7 @@ func (m *chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			toRecipient := m.recipient
 			toNetwork := m.network
 			cmds = append(cmds, func() tea.Msg {
-				err := postMessage(toAddr, toRecipient, text, toNetwork)
+				_, err := postMessage(toAddr, toRecipient, text, toNetwork, 0)
 				return sentMsg{body: text, err: err}
 			})
 		case "pgup":

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -32,6 +32,7 @@ var (
 	// default of "", and `skychat send -t X -m hi` (no --net)
 	// surfaced "invalid network type:" because the var was empty.
 	sendNet      string
+	sendWait     time.Duration
 	listenNet    string
 	listenFrom   string
 	historyPeer  string
@@ -53,6 +54,7 @@ func init() {
 	sendCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (required)")
 	sendCmd.Flags().StringVarP(&message, "msg", "m", "", "message to send (required)")
 	sendCmd.Flags().StringVarP(&sendNet, "net", "n", "skynet", "network type: skynet or dmsg")
+	sendCmd.Flags().DurationVarP(&sendWait, "wait", "w", 0, "wait for peer-receipt ack up to this duration (e.g. 5s, 30s); 0 = no wait (default)")
 	sendCmd.MarkFlagRequired("to")  //nolint:errcheck,gosec
 	sendCmd.MarkFlagRequired("msg") //nolint:errcheck,gosec
 
@@ -81,7 +83,29 @@ var RootCmd = &cobra.Command{
 var sendCmd = &cobra.Command{
 	Use:   "send",
 	Short: "Send a message",
-	Long:  "Send a message to a remote public key via skychat.",
+	Long: `Send a message to a remote public key via skychat.
+
+Default semantics ("--wait" not set): the message is written to the
+peer's framed connection and the command returns 200 as soon as the
+WriteFrame call succeeds. This confirms the message was handed to
+the underlying skywire transport — NOT that the peer's chat-app
+received or processed it.
+
+With --wait DURATION the message is wrapped in a chat-msg envelope
+with a unique id; the command waits up to DURATION for the peer's
+chat-app to send a chat-ack envelope back. Outcomes:
+
+  acked within DURATION: command prints "Acked by <pk> in <ms>ms"
+                         and exits 0.
+  timeout:               command prints "Send to <pk> via <net> not
+                         acked within <DURATION>" and exits 1.
+  peer on old binary:    --wait will time out because the chat-msg
+                         envelope is interpreted as plain JSON text
+                         by pre-2026-05-12 peers. The message was
+                         delivered but the peer can't ack.
+
+Server clamps --wait to [100ms, 60s]. Values outside that range
+are normalized server-side.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		var pk cipher.PubKey
 		if err := pk.Set(recipient); err != nil {
@@ -90,8 +114,21 @@ var sendCmd = &cobra.Command{
 		if err := validateNetwork(sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		if err := postMessage(httpAddr, pk.String(), message, sendNet); err != nil {
+		ack, err := postMessage(httpAddr, pk.String(), message, sendNet, sendWait)
+		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if sendWait > 0 {
+			if ack != nil && ack.Acked {
+				internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("Acked by %s in %dms (id=%s)\n", pk.String(), ack.MS, ack.ID))
+			} else {
+				reason := "no ack"
+				if ack != nil && ack.Reason != "" {
+					reason = ack.Reason
+				}
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("send to %s via %s not acked: %s", pk.String(), sendNet, reason))
+			}
+			return
 		}
 		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("Message sent to %s via %s\n", pk.String(), sendNet))
 	},
@@ -305,31 +342,72 @@ func validateNetwork(n string) error {
 	return fmt.Errorf("invalid network type %q (use 'skynet' or 'dmsg')", n)
 }
 
+// AckResponse is the JSON body the skychat app's /message endpoint
+// returns when wait_ms > 0. Exported so the TUI / scripted callers
+// can consume the same shape.
+type AckResponse struct {
+	Acked  bool   `json:"acked"`
+	ID     string `json:"id,omitempty"`
+	MS     int64  `json:"ms,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
 // postMessage POSTs the message payload to the skychat app's HTTP
-// /message endpoint. Returns nil on 2xx, an error with the response
-// body otherwise. Pulled out of sendCmd so the interactive `chat`
-// TUI can reuse it on every Enter.
-func postMessage(addr, recipientPK, msg, network string) error {
-	body, err := json.Marshal(map[string]string{
+// /message endpoint. Returns nil on 2xx (with no wait) or the ack
+// response when wait > 0. An error means the request failed at the
+// HTTP layer or the chat-app surfaced a 4xx/5xx that's not the
+// 504-on-timeout case (which is returned as a non-nil ack with
+// Acked=false).
+func postMessage(addr, recipientPK, msg, network string, wait time.Duration) (*AckResponse, error) {
+	payload := map[string]interface{}{
 		"recipient": recipientPK,
 		"message":   msg,
 		"network":   network,
-	})
+	}
+	if wait > 0 {
+		payload["wait_ms"] = wait.Milliseconds()
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 	url := fmt.Sprintf("http://%s/message", addr)
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body)) //nolint:gosec
+	// Client timeout: wait + grace. Without this the http.Client's
+	// default no-timeout would let a server-side hang block the CLI
+	// indefinitely; with it, the CLI deadline is always at least
+	// `wait` + 5s so the server's own clamp/timeout fires first.
+	hc := &http.Client{Timeout: wait + 5*time.Second}
+	if wait <= 0 {
+		hc.Timeout = 30 * time.Second
+	}
+	resp, err := hc.Post(url, "application/json", bytes.NewReader(body)) //nolint:gosec
 	if err != nil {
-		return fmt.Errorf("post: %w", err)
+		return nil, fmt.Errorf("post: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
+
+	// 504 carries a non-nil AckResponse{Acked:false, Reason:"timeout"}
+	// — surfaced to the caller, not treated as a server error.
+	if resp.StatusCode == http.StatusGatewayTimeout {
+		var ack AckResponse
+		if err := json.NewDecoder(resp.Body).Decode(&ack); err == nil {
+			return &ack, nil
+		}
+		return &AckResponse{Acked: false, Reason: "timeout"}, nil
+	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return nil
+		if wait > 0 {
+			var ack AckResponse
+			if err := json.NewDecoder(resp.Body).Decode(&ack); err != nil {
+				return nil, fmt.Errorf("decode ack: %w", err)
+			}
+			return &ack, nil
+		}
+		return nil, nil
 	}
 	var errBody bytes.Buffer
 	_, _ = errBody.ReadFrom(resp.Body) //nolint:errcheck
-	return fmt.Errorf("server error %d: %s", resp.StatusCode, strings.TrimSpace(errBody.String()))
+	return nil, fmt.Errorf("server error %d: %s", resp.StatusCode, strings.TrimSpace(errBody.String()))
 }
 
 // Reconnect cadence for the listen loop. Starts at minReconnectDelay


### PR DESCRIPTION
## Summary

The deferred protocol-level work from #2508/#2509/#2510: opt-in peer-receipt acknowledgment on \`skychat send\`. Default sends remain plain-text (back-compat with every binary shipped to date). With \`--wait DURATION\` the sender wraps in a chat-msg envelope and blocks for the peer's chat-ack — populating the \`id\` field reserved in #2510 schema v1.

## Wire format

\`\`\`json
chat-msg:  {\"type\":\"chat-msg\",\"id\":\"<hex>\",\"body\":\"...\",\"ack\":true}
chat-ack:  {\"type\":\"chat-ack\",\"id\":\"<hex>\"}
\`\`\`

Both ride on the existing length-prefixed framed wire (post-#2504). **\`frameProtoVersion\` stays at 1** — the envelopes are application-level on top of the frame format, not a wire-version bump.

## Back-compat

| sender | peer | result |
|---|---|---|
| post-2510 default (no --wait) | any | unchanged — plain-text body, no envelope, no ack |
| post-2510 --wait | post-2510 peer | peer recognizes chat-msg, surfaces body, writes chat-ack back; sender gets 200 + ack timing |
| post-2510 --wait | old peer | old peer renders the JSON envelope as plain chat text; sender times out cleanly with \"not acked\" — message was still delivered, just unconfirmed |

\`--wait\` is opt-in specifically so default sends don't break old-peer UIs.

## CLI

\`\`\`
skywire cli skychat send -t <pk> -m \"hello\" --wait 5s
# Acked by 02f9... in 312ms (id=a1b2c3d4...)

skywire cli skychat send -t <pk> -m \"hello\" --wait 100ms
# (exit 1)
# send to 02f9... via skynet not acked: timeout
\`\`\`

Server clamps \`wait_ms\` to \`[100ms, 60s]\`. CLI HTTP timeout = wait + 5s grace.

## Schema reuse

The mirror SSE event for outgoing messages re-uses the ack \`id\` from #2510 so consumers correlate the \`dir:\"out\"\` event to the originating send by id without further schema bumps. \`/status\` counters from #2510 already track inbound_drop_count etc.; this PR doesn't add new counters.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [x] \`go test ./cmd/apps/skychat/...\` clean
- [ ] Manual: \`send --wait 5s\` between two visors on this branch, verify ack roundtrip
- [ ] Manual: \`send --wait 1s\` from this branch to a peer on develop, verify clean timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)