### PR TITLE
feat(skychat-cli): PK alias / addressbook with reverse-resolve on listen + history

### DIFF
--- a/cmd/skywire-cli/commands/skychat/alias.go
+++ b/cmd/skywire-cli/commands/skychat/alias.go
@@ -1,0 +1,266 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/alias.go
+//
+// Local PK addressbook for skychat. 66-hex PKs are brittle to type
+// and to remember; this lets operators alias them by short name and
+// use the alias anywhere a -t / --to / --peer / --from accepts a PK.
+//
+// Storage: $XDG_CONFIG_HOME/skywire/skychat-aliases.json (falls back
+// to ~/.config/skywire/skychat-aliases.json via os.UserConfigDir).
+// Flat JSON {name: pk_hex}. No locking — concurrent writes from two
+// CLI invocations would race; in practice an interactive operator
+// runs one command at a time. File is rewritten atomically (write to
+// temp + rename) on every Set / Del.
+//
+// Resolution rule (resolveTarget): input is a PK if and only if it
+// passes cipher.PubKey.Set. Anything else is treated as an alias
+// lookup. If neither matches, the caller surfaces the error.
+//
+// Names: arbitrary string, but a leading "0" digit is reserved (so
+// a typo on a real PK doesn't get treated as an alias). Empty names
+// are rejected. Names are case-sensitive — "claude2" and "Claude2"
+// are different aliases. The "Other Claude" use case wants this
+// behavior because operators distinguish hosts by case-sensitive
+// hostnames already.
+
+package cliskychat
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+const aliasFileName = "skywire/skychat-aliases.json"
+
+// aliasStore is a tiny on-disk JSON map. Load returns an empty store
+// (not an error) when the file doesn't exist — first-run new install.
+type aliasStore struct {
+	path    string
+	entries map[string]string
+}
+
+func aliasPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("locate user config dir: %w", err)
+	}
+	return filepath.Join(dir, aliasFileName), nil
+}
+
+func loadAliases() (*aliasStore, error) {
+	p, err := aliasPath()
+	if err != nil {
+		return nil, err
+	}
+	s := &aliasStore{path: p, entries: map[string]string{}}
+	raw, err := os.ReadFile(p) //nolint:gosec
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("read aliases: %w", err)
+	}
+	if len(raw) == 0 {
+		return s, nil
+	}
+	if err := json.Unmarshal(raw, &s.entries); err != nil {
+		return nil, fmt.Errorf("parse aliases at %s: %w", p, err)
+	}
+	return s, nil
+}
+
+func (s *aliasStore) save() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("mkdir aliases dir: %w", err)
+	}
+	body, err := json.MarshalIndent(s.entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	// Atomic write: temp in same dir + rename. Same-dir rename is
+	// atomic on POSIX; cross-fs would not be.
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o600); err != nil {
+		return fmt.Errorf("write aliases tmp: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		_ = os.Remove(tmp) //nolint:errcheck
+		return fmt.Errorf("rename aliases: %w", err)
+	}
+	return nil
+}
+
+// lookupAlias returns the alias name registered for the given
+// hex-encoded PK, or "" if none. Best-effort: errors loading the
+// store return "" so display paths never fail on a missing/invalid
+// aliases file.
+func lookupAlias(pkHex string) string {
+	if pkHex == "" {
+		return ""
+	}
+	s, err := loadAliases()
+	if err != nil {
+		return ""
+	}
+	for name, hex := range s.entries {
+		if hex == pkHex {
+			return name
+		}
+	}
+	return ""
+}
+
+// resolveTarget turns a -t / --to / --peer / --from string into a
+// cipher.PubKey. Behavior:
+//
+//   - 66-hex PK accepted directly (and never looked up in the alias
+//     store, even on accidental name collision).
+//   - any other input is treated as an alias name; the store is
+//     loaded and consulted.
+//   - empty input → error.
+//
+// On unknown alias the error names the missing key so the operator
+// can correct it without `alias ls` first.
+func resolveTarget(input string) (cipher.PubKey, error) {
+	if input == "" {
+		return cipher.PubKey{}, errors.New("recipient is empty")
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(input); err == nil {
+		return pk, nil
+	}
+	s, err := loadAliases()
+	if err != nil {
+		return cipher.PubKey{}, fmt.Errorf("looking up %q: %w", input, err)
+	}
+	hex, ok := s.entries[input]
+	if !ok {
+		return cipher.PubKey{}, fmt.Errorf("%q is neither a valid PK nor a known alias (try: skywire cli skychat alias ls)", input)
+	}
+	if err := pk.Set(hex); err != nil {
+		return cipher.PubKey{}, fmt.Errorf("alias %q maps to invalid PK %q: %w", input, hex, err)
+	}
+	return pk, nil
+}
+
+var aliasCmd = &cobra.Command{
+	Use:   "alias",
+	Short: "Manage local PK aliases",
+	Long: `Manage a local addressbook of name → public-key aliases.
+
+Aliases are stored at $XDG_CONFIG_HOME/skywire/skychat-aliases.json
+(falls back to ~/.config/skywire/skychat-aliases.json).
+
+Use a name anywhere a -t / --to / --peer / --from accepts a PK:
+
+  skywire cli skychat alias add claude2 02f9aa588dffa2...
+  skywire cli skychat send -t claude2 -m "hi"
+  skywire cli skychat history --peer claude2
+  skywire cli skychat listen --from claude2
+
+Full hex PKs always resolve directly, regardless of any same-named
+alias (so a typo on a real PK never gets silently rerouted).`,
+}
+
+var aliasAddCmd = &cobra.Command{
+	Use:   "add NAME PK",
+	Short: "Add or replace an alias",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := strings.TrimSpace(args[0])
+		pkStr := strings.TrimSpace(args[1])
+		if name == "" {
+			internal.PrintFatalError(cmd.Flags(), errors.New("alias name is empty"))
+		}
+		// Reserved prefix: a name starting with a hex digit could be
+		// mistaken for a partial PK. Rejecting outright avoids the
+		// "did you mean to type the full PK?" failure mode.
+		if name[0] >= '0' && name[0] <= '9' {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("alias name %q must not start with a digit (looks like a PK fragment)", name))
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(pkStr); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid PK %q: %w", pkStr, err))
+		}
+		s, err := loadAliases()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		prev, existed := s.entries[name]
+		s.entries[name] = pk.Hex()
+		if err := s.save(); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		out := cmd.OutOrStdout()
+		if existed {
+			fmt.Fprintf(out, "alias %s replaced (was %s, now %s)\n", name, prev, pk.Hex()) //nolint:errcheck
+		} else {
+			fmt.Fprintf(out, "alias %s → %s\n", name, pk.Hex()) //nolint:errcheck
+		}
+	},
+}
+
+var aliasLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List all aliases",
+	Run: func(cmd *cobra.Command, _ []string) {
+		s, err := loadAliases()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		out := cmd.OutOrStdout()
+		if jsonMode {
+			b, _ := json.MarshalIndent(s.entries, "", "  ") //nolint:errcheck
+			_, _ = out.Write(append(b, '\n'))               //nolint:errcheck
+			return
+		}
+		if len(s.entries) == 0 {
+			fmt.Fprintln(out, "(no aliases — use `skywire cli skychat alias add NAME PK` to create one)") //nolint:errcheck
+			return
+		}
+		names := make([]string, 0, len(s.entries))
+		for n := range s.entries {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Fprintf(out, "%-20s %s\n", n, s.entries[n]) //nolint:errcheck
+		}
+	},
+}
+
+var aliasRmCmd = &cobra.Command{
+	Use:   "rm NAME",
+	Short: "Remove an alias",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := strings.TrimSpace(args[0])
+		s, err := loadAliases()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if _, ok := s.entries[name]; !ok {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("no such alias %q", name))
+		}
+		delete(s.entries, name)
+		if err := s.save(); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "alias %s removed\n", name) //nolint:errcheck
+	},
+}
+
+func init() {
+	aliasCmd.AddCommand(aliasAddCmd, aliasLsCmd, aliasRmCmd)
+}

--- a/cmd/skywire-cli/commands/skychat/chat.go
+++ b/cmd/skywire-cli/commands/skychat/chat.go
@@ -48,14 +48,15 @@ transitions to chat. Incoming messages from any sender still
 appear in history.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Empty recipient is allowed: the TUI prompts for it.
-		// Anything non-empty must parse as a valid PK up front so
-		// a typo on the command line surfaces immediately rather
-		// than after the TUI takes over the terminal.
+		// Anything non-empty must parse as a valid PK or a known
+		// alias up front so a typo on the command line surfaces
+		// immediately rather than after the TUI takes over the
+		// terminal.
 		recipientPK := ""
 		if recipient != "" {
-			var pk cipher.PubKey
-			if err := pk.Set(recipient); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --to public key %q: %w", recipient, err))
+			pk, err := resolveTarget(recipient)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
 			}
 			recipientPK = pk.String()
 		}

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
-	"github.com/skycoin/skywire/pkg/cipher"
 )
 
 var (
@@ -49,6 +48,7 @@ func init() {
 		chatCmd,
 		historyCmd,
 		statusCmd,
+		aliasCmd,
 	)
 
 	sendCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (required)")
@@ -107,9 +107,9 @@ chat-app to send a chat-ack envelope back. Outcomes:
 Server clamps --wait to [100ms, 60s]. Values outside that range
 are normalized server-side.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		var pk cipher.PubKey
-		if err := pk.Set(recipient); err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid recipient public key %q: %w", recipient, err))
+		pk, err := resolveTarget(recipient)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		if err := validateNetwork(sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
@@ -161,10 +161,11 @@ Returns an error if the chat-app has persistence disabled.`,
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--limit must be 1-1000, got %d", historyLimit))
 		}
 		if historyPeer != "" {
-			var pk cipher.PubKey
-			if err := pk.Set(historyPeer); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --peer public key %q: %w", historyPeer, err))
+			pk, err := resolveTarget(historyPeer)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--peer: %w", err))
 			}
+			historyPeer = pk.Hex()
 		}
 		var sinceCutoff time.Time
 		if historySince != "" {
@@ -235,7 +236,11 @@ Returns an error if the chat-app has persistence disabled.`,
 				if m.Outgoing {
 					dir = "out"
 				}
-				fmt.Fprintf(out, "%s [%s @ %s] %s\n", m.Timestamp.UTC().Format(time.RFC3339), dir, m.Peer, m.Text) //nolint:errcheck
+				peerDisplay := m.Peer
+				if alias := lookupAlias(m.Peer); alias != "" {
+					peerDisplay = alias
+				}
+				fmt.Fprintf(out, "%s [%s @ %s] %s\n", m.Timestamp.UTC().Format(time.RFC3339), dir, peerDisplay, m.Text) //nolint:errcheck
 			}
 		}
 	},
@@ -466,13 +471,14 @@ Filters:
 				internal.PrintFatalError(cmd.Flags(), err)
 			}
 		}
-		// --from must be a valid full-hex PK if supplied; reject early
-		// rather than silently never matching.
-		var fromFilter cipher.PubKey
+		// --from accepts either a 66-hex PK or an alias name. Resolve
+		// up front and convert to the canonical hex form server-side.
 		if listenFrom != "" {
-			if err := fromFilter.Set(listenFrom); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --from public key %q: %w", listenFrom, err))
+			pk, err := resolveTarget(listenFrom)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--from: %w", err))
 			}
+			listenFrom = pk.Hex()
 		}
 
 		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
@@ -562,13 +568,15 @@ type listenEvent struct {
 	Schema string `json:"schema,omitempty"` // listen-output schema version (currently "v1")
 
 	// Msg-only.
-	ID   string `json:"id,omitempty"`   // stable per-event identifier; used by send-ack to correlate
-	From string `json:"from,omitempty"` // local side: own PK on dir:out, peer PK on dir:in
-	To   string `json:"to,omitempty"`   // dir:out only — peer the message was sent to
-	Net  string `json:"net,omitempty"`
-	Body string `json:"body,omitempty"`
-	Dir  string `json:"dir,omitempty"` // "in" | "out" | future: "relay" | "group-in" | "group-out"
-	Len  int    `json:"len,omitempty"` // body byte length, surfaced for size-debug w/o re-parsing
+	ID        string `json:"id,omitempty"`         // stable per-event identifier; used by send-ack to correlate
+	From      string `json:"from,omitempty"`       // local side: own PK on dir:out, peer PK on dir:in
+	FromAlias string `json:"from_alias,omitempty"` // resolved alias for From (consumer-side, best-effort)
+	To        string `json:"to,omitempty"`         // dir:out only — peer the message was sent to
+	ToAlias   string `json:"to_alias,omitempty"`   // resolved alias for To (consumer-side, best-effort)
+	Net       string `json:"net,omitempty"`
+	Body      string `json:"body,omitempty"`
+	Dir       string `json:"dir,omitempty"` // "in" | "out" | future: "relay" | "group-in" | "group-out"
+	Len       int    `json:"len,omitempty"` // body byte length, surfaced for size-debug w/o re-parsing
 
 	// Reconnect / error.
 	Err     string `json:"err,omitempty"`
@@ -667,7 +675,7 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 		}
 
 		if jsonMode {
-			emitJSON(out, listenEvent{
+			ev := listenEvent{
 				Type: evtMsg,
 				TS:   time.Now().UTC(),
 				ID:   msg.ID,
@@ -677,7 +685,18 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 				Body: msg.Message,
 				Dir:  dir,
 				Len:  msg.Len,
-			})
+			}
+			// Best-effort alias resolution: if the local addressbook
+			// has a name for the PK, surface it as a sibling field so
+			// scripted consumers can pretty-print without re-querying.
+			// Empty when unknown — never blocks or errors.
+			if alias := lookupAlias(msg.Sender); alias != "" {
+				ev.FromAlias = alias
+			}
+			if alias := lookupAlias(msg.To); alias != "" {
+				ev.ToAlias = alias
+			}
+			emitJSON(out, ev)
 		} else {
 			netSuffix := ""
 			if msg.Network != "" {
@@ -691,7 +710,13 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 			if dir != "in" {
 				dirPrefix = ">"
 			}
-			fmt.Fprintf(out, "[%s%s%s] %s\n", dirPrefix, msg.Sender, netSuffix, msg.Message) //nolint:errcheck
+			// Reverse-resolve the sender PK to a friendlier alias for
+			// display. Falls back to the hex PK when no alias matches.
+			display := msg.Sender
+			if alias := lookupAlias(msg.Sender); alias != "" {
+				display = alias
+			}
+			fmt.Fprintf(out, "[%s%s%s] %s\n", dirPrefix, display, netSuffix, msg.Message) //nolint:errcheck
 		}
 	}
 	// scanner.Err() returns nil on a clean EOF; io.EOF /


### PR DESCRIPTION
## Summary

The last operator-feedback item: local PK addressbook. 66-hex PKs are brittle to type and remember; this lets operators alias them by short name and use the alias anywhere a \`-t\` / \`--to\` / \`--peer\` / \`--from\` accepts a PK. **And** reverse-resolves on \`listen\` / \`history\` display so threads are readable.

\`\`\`
skywire cli skychat alias add NAME PK
skywire cli skychat alias ls [--json]
skywire cli skychat alias rm NAME

skywire cli skychat alias add other-claude 02f9aa588dffa2...
skywire cli skychat send -t other-claude -m \"hi\"     # forward: alias → PK
skywire cli skychat listen                            # reverse: PK → alias on display
# [other-claude/skynet] hi
\`\`\`

## Storage

\`$XDG_CONFIG_HOME/skywire/skychat-aliases.json\` (falls back to \`~/.config/skywire/skychat-aliases.json\` via \`os.UserConfigDir\`). Flat JSON \`{name: pk_hex}\`. Atomic save: write to temp + rename in the same directory.

## Resolution rules

- **66-hex PK** accepted directly, never looked up in the alias store even on same-named collision (so a typo on a real PK never gets silently rerouted to a different peer).
- **Anything else** treated as an alias name; store loaded and consulted.
- **Unknown alias** error names the missing key + suggests \`alias ls\`.
- **Reverse-resolve** (PK → alias) is best-effort on display only; missing or invalid alias file silently falls back to hex. Never blocks or errors.

## Schema additions (listen --json)

\`\`\`json
{\"type\":\"msg\", ..., \"from\":\"02f9...\", \"from_alias\":\"other-claude\"}
\`\`\`

\`from_alias\` / \`to_alias\` are sibling fields, omitted when unresolved. Consumers can use the raw PK for routing (stable) and the alias for display (friendly).

## Constraints

- Alias name starting with a digit is rejected (could be mistaken for partial PK).
- Empty names rejected.
- Case-sensitive (\"claude2\" ≠ \"Claude2\").

## Wired into

- \`send -t\` (forward)
- \`chat -t\` (forward)
- \`listen --from\` (forward) + display (reverse)
- \`history --peer\` (forward) + display (reverse)

## Closes 8-of-8

This finishes the operator-feedback queue raised during today's coordination session: #2508 (json+from+mirror+net), #2509 (history+status), #2510 (schema v1 id/to/len/counters), #2511 (send --wait peer-ack), #2512 (alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)