### PR TITLE
fix(skychat/group): member CXO node dial-port off-by-one breaks join

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -257,12 +257,26 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 	// throwaway publisher with an empty allowlist (no one subscribes
 	// to a member's per-group feed in D1) just to get a node. Phase
 	// 2 turns this into a real per-member outbox feed.
+	// Member's throwaway local CXO node uses Record.Port — the SAME
+	// port number the owner's publisher binds on the owner's visor.
+	// Two visors can both bind the same DMSG port number; the port is
+	// per-PK. The DMSGFactory in CXO uses one port for both Listen
+	// AND outbound Dial (see cxo/node/transport/dmsg.go:89), so the
+	// subscriber's ConnectPK to the owner dials at the same port —
+	// which MUST be Record.Port to hit the owner's CXO publisher, not
+	// the relay listener (which is at Record.Port+1).
+	//
+	// Local collision risk: theoretical only — happens if the same
+	// visor is also publisher of a different group on the SAME
+	// Record.Port (~1/65535 birthday collision per-pair across
+	// groups). When it does happen, bind fails with a clear "address
+	// in use" error; not silent corruption.
 	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
 		BatchWindow:         cfg.BatchWindow,
 		Logger:              log,
 		DataDir:             filepath.Join(cfg.DataDir, "group", cfg.Record.ID, "member"),
-		DmsgPort:            cfg.Record.Port + 1, // separate port; owner owns Record.Port
-		SubscriberAllowlist: []cipher.PubKey{},   // empty = nobody allowed
+		DmsgPort:            cfg.Record.Port,
+		SubscriberAllowlist: []cipher.PubKey{}, // empty = nobody allowed
 		// Member-side throwaway node — pure cache, no durability
 		// requirement at all.
 		NoSyncCXDS: true,


### PR DESCRIPTION
## Summary

Members were unable to join any group created on #2506+. Every \`skywire cli skychat group join <invite>\` returned \`group: Connect: handshake failed: factory.Connection closed\`. Owner-side logs showed the giveaway: \`group: relay unmarshal error invalid character '\\x01'\` — CXO handshake bytes (frame magic \`0x01\`) hitting the relay listener at \`Record.Port+1\` instead of the CXO publisher at \`Record.Port\`.

## Root cause

\`cmd/apps/skychat/group/session.go:264\` configured the member's throwaway CXO node with \`DmsgPort: Record.Port + 1\`. The comment said \"owner owns Record.Port\" — but DMSG ports are namespaced per-PK, so \`owner-PK:Record.Port\` and \`member-PK:Record.Port\` are completely unrelated bindings. The +1 was defending against a non-existent same-visor collision.

The real bug surfaces because \`pkg/cxo/node/transport/dmsg.go\`'s \`DMSGFactory\` uses **one** port for both local \`Listen()\` AND outbound \`Connect()\`:

\`\`\`go
func (f *DMSGFactory) Connect(remotePK cipher.PubKey) (*Connection, error) {
    addr := dmsg.Addr{PK: remotePK, Port: f.port}
    ...
}
\`\`\`

Member's local node was configured with \`Record.Port+1\` → subscriber's \`ConnectPK\` dialed \`owner-PK:Record.Port+1\` → owner's **relay** listener accepted (which expects framed JSON RelayMessage) → CXO handshake bytes → unmarshal error → connection closed → join fails.

## Fix

One-line: member's \`DmsgPort\` becomes \`Record.Port\` (same number as owner's, but bound on a different PK = different visor — no local collision). Subscriber dial then correctly hits the CXO publisher.

## Corner case

The same visor being publisher of one group AND member of another at the **same** \`Record.Port\` (~1/65535 per-pair birthday probability across groups). Bind fails with \"address in use\", which is a clear error, not silent corruption. Acceptable.

## Independent confirmation

Peer agent (02f9aa58…) reached the same one-line diagnosis during live testing of a 3-way coordination group. Two independent agents converged on \"line 264: drop +1\".

## Long-term option

\`DMSGFactory\` could grow a separate \`dialPort\` field so listen and dial don't share \`f.port\`. Not necessary for the fix; filing as a follow-up if it's wanted.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Post-merge: 0pcom restarts dev visor, peers retry \`group join <invite>\`, handshake completes, 3-way coordination feed works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)