### PR TITLE
fix(skychat/group): owner sees own group sends in local inbox

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -541,6 +541,26 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 	if err := s.pub.Put(path, body); err != nil {
 		return fmt.Errorf("group: publishAs: put %q: %w", path, err)
 	}
+
+	// Owner-side local echo: deliver to the local handler so the
+	// owner's own inbox sees their sends. The original design assumed
+	// the owner doesn't need to "hear themselves back" because the
+	// skychat hub fans out locally before publishing — but that's
+	// not how the visor-level group inbox path works. Without a
+	// self-echo, `skywire cli skychat group listen` shows nothing
+	// when the owner is the only participant, which is misleading
+	// during testing (looks like the publish failed silently).
+	//
+	// We deliver the plaintext Message regardless of ModePrivate —
+	// the local handler should see the same content the (decoded)
+	// subscriber path would surface, not the encrypted bytes.
+	if h := s.handler; h != nil {
+		h(s.cfg.Record.ID, senderPK, Message{
+			SenderPK: senderPK,
+			Text:     text,
+			TS:       ts,
+		})
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

#2506 left owner-side sends as \"published but invisible locally\" — the owner has no self-subscriber, and the visor's group inbox is fed only by the subscriber.handleRootFilled path. So \`skywire cli skychat group send\` would succeed (the publish landed in the CXO feed), but \`skywire cli skychat group listen\` showed nothing. The owner couldn't see their own messages even when alone in the group.

The original design comment said *\"owner doesn't need to hear themselves back since Send fans out locally via the skychat hub before publishing\"* — but that's the 1:1-skychat-hub path, not the visor-level group inbox path that the new \`group listen\` CLI uses. The fans-out-locally assumption never applied to groups.

## Fix

\`publishAs\` (the shared owner-direct + member-relayed write path) now invokes the registered \`MessageHandler\` with the plaintext \`Message\` after a successful \`Put\`. The handler is what the visor wires to its group inbox; this gives self-echo for free, no second subscriber, no wire-level self-loop.

For \`ModePrivate\` groups the local echo delivers plaintext (the decoded form). Remote subscribers still see ciphertext on the wire, decoded only after \`Decrypt\` fires on their side.

## Background

Caught live: user testing the just-merged #2513 group-join fix ran \`group listen\` while only one participant (owner) was in the group; sending produced no visible output despite the publish succeeding. Without a self-echo path the only validation of \"did my send work\" was tailing the CXO bbolt dbs.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/group/...\` passes
- [x] \`golangci-lint run\` clean
- [ ] Post-merge + visor restart: \`group send\` followed by \`group listen\` shows the just-sent message in the owner's local inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)