### PR TITLE
fix(skychat-cli): suppress reconnect-spam on group listen retries

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -60,7 +60,25 @@ func getDefaultRPCAddr() string {
 //   - "localhost:3435" (default) — direct TCP to local visor
 //   - "tp://<pk>" via --rpc flag — proxy through local visor's transport to remote visor
 //   - VisorPK via --visor flag — connect over DMSG
+//
+// On dial failure, prints the error to stderr via internal.PrintError
+// so one-shot callers see the cause. Long-running reconnect loops
+// (group listen, skychat listen) should use ClientQuiet to suppress
+// per-retry spam.
 func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
+	return clientImpl(cmdFlags, false)
+}
+
+// ClientQuiet is the silent variant of Client. On dial failure it
+// returns the error WITHOUT printing to stderr. Use this from any
+// callsite that retries on failure (a noisy loop spamming the same
+// "RPC connection failed" line is worse than no message at all —
+// the caller knows the dial failed because err is non-nil).
+func ClientQuiet(cmdFlags *pflag.FlagSet) (visor.API, error) {
+	return clientImpl(cmdFlags, true)
+}
+
+func clientImpl(cmdFlags *pflag.FlagSet, quiet bool) (visor.API, error) {
 	// If VisorPK is provided, use dmsg connection
 	if VisorPK != "" {
 		return DmsgClient(cmdFlags)
@@ -68,10 +86,12 @@ func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
 
 	// Check for tp:// scheme — transport proxy through local visor
 	if strings.HasPrefix(Addr, "tp://") {
-		internal.PrintError(cmdFlags, fmt.Errorf(
-			"tp:// scheme detected. Use 'skywire cli visor tp-rpc %s <method>' instead.\n"+
-				"Example: skywire cli visor tp-rpc %s Overview",
-			Addr[5:], Addr[5:]))
+		if !quiet {
+			internal.PrintError(cmdFlags, fmt.Errorf(
+				"tp:// scheme detected. Use 'skywire cli visor tp-rpc %s <method>' instead.\n"+
+					"Example: skywire cli visor tp-rpc %s Overview",
+				Addr[5:], Addr[5:]))
+		}
 		return nil, fmt.Errorf("tp:// not supported as --rpc address; use 'visor tp-rpc' command")
 	}
 
@@ -79,7 +99,9 @@ func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	const rpcDialTimeout = time.Second * 5
 	conn, err := net.DialTimeout("tcp", Addr, rpcDialTimeout)
 	if err != nil {
-		internal.PrintError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
+		if !quiet {
+			internal.PrintError(cmdFlags, fmt.Errorf("RPC connection failed; is skywire running?: %v", err))
+		}
 		return nil, err
 	}
 	// Timeout of 0 means unlimited

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -297,7 +297,13 @@ friction operators hit during a development cycle.`,
 					t.Stop()
 					return
 				}
-				if newCl, cErr := clirpc.Client(cmd.Flags()); cErr == nil {
+				// ClientQuiet (vs Client) suppresses the per-retry
+				// "RPC connection failed" stderr spam — caller knows
+				// the dial failed because cErr is non-nil. Without
+				// this, every backoff tick during a visor restart
+				// printed an identical ERROR line, exactly the
+				// failure mode #2514 was supposed to eliminate.
+				if newCl, cErr := clirpc.ClientQuiet(cmd.Flags()); cErr == nil {
 					rpcClient = newCl
 					// Don't yet reset lastErrLogged — the new
 					// client might still 503 if the visor is


### PR DESCRIPTION
## Summary

#2514 added auto-reconnect to \`group listen\` but the reconnect loop called \`clirpc.Client\`, which itself prints \"RPC connection failed\" to stderr on every dial failure. Result: a visor restart that takes 10s produced ~5 ERROR lines per second from inside the CLI — exactly the failure mode #2514 was supposed to eliminate.

## Fix

\`clirpc.ClientQuiet\` — same code path as \`Client\`, returns the error WITHOUT printing to stderr on dial failure. Caller (the reconnect loop) already knows the dial failed because \`cErr != nil\`. \`group listen\`'s reconnect path switches to it. Loop's own logging (\"first error + reconnecting in <backoff>\" once, \"reconnected\" on success) is now the only output during a restart cycle.

One-shot callers (and all other RPC users in the cli tree) still call \`Client\` and still get the original error message on the one failure they care about. The split is purely opt-in for retry loops.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Post-merge + visor restart: \`group listen\` should print one line during the down window, not 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)