### PR TITLE
docs(auto-update): GOPROXY=direct for branch-tip resolution

### DIFF
--- a/AUTO_UPDATE.md
+++ b/AUTO_UPDATE.md
@@ -36,16 +36,24 @@ This branch has no shared history with `develop` — it's updated by CI only.
 Using `go run` with isolated cache (no persistent build artifacts):
 
 ```bash
-TMPDIR=$(mktemp -d) && COMMIT=$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
+TMPDIR=$(mktemp -d) && COMMIT=$(GOPROXY=direct GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
 echo $COMMIT
 ```
 
 Or install the helper binary (2MB, reusable):
 
 ```bash
-go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+GOPROXY=direct go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
 COMMIT=$(~/go/bin/skywire-commit)
 ```
+
+**Why `GOPROXY=direct`?** `@skywire-commit` is a branch name. The Go module proxy
+(`proxy.golang.org`) caches branch-tip → SHA resolutions for up to 30 minutes —
+so if you run the update right after a CI merge, the proxy may still return the
+previous SHA and your install no-ops (visible as a suspiciously fast "success"
+in well under a second). Setting `GOPROXY=direct` bypasses the proxy and reads
+the SHA straight from GitHub. The actual module download still proceeds with
+the global default; only the branch-tip resolution is forced direct.
 
 ### Install Skywire at the Tested Commit
 
@@ -53,10 +61,13 @@ COMMIT=$(~/go/bin/skywire-commit)
 go install github.com/skycoin/skywire@$COMMIT
 ```
 
+This step does NOT need `GOPROXY=direct` — once you have the exact commit SHA,
+the proxy lookup is content-addressed and returns the right module regardless.
+
 ### One-Liner (isolated, no persistent build artifacts from the commit check)
 
 ```bash
-TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
+TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOPROXY=direct GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
 ```
 
 ### Check if Update is Needed
@@ -79,8 +90,10 @@ Docker images are pushed to Docker Hub on every merge to `develop`, tagged with 
 
 ```bash
 #!/bin/bash
-# Get the latest tested commit
-go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+# Get the latest tested commit. GOPROXY=direct bypasses proxy.golang.org's
+# branch-tip cache (up to 30min TTL) — without it, the resolver can return
+# the previous SHA and the update silently no-ops in ~250ms with exit 0.
+GOPROXY=direct go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
 LATEST=$(~/go/bin/skywire-commit)
 SHORT=${LATEST:0:12}
 CURRENT=$(cat ~/.skywire-deploy-commit 2>/dev/null || echo "none")


### PR DESCRIPTION
## Summary

Diagnosis from a 3-way coordination session today: a peer's \`skywire-update.timer\` fired every 5 min and reported SUCCESS in ~249ms — far too fast for a real Go build. Visor binary mtime stuck on a stale commit.

**Root cause:** \`go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit\` relies on the Go module proxy (\`proxy.golang.org\`) to resolve the branch tip \`skywire-commit\` to a SHA. The proxy caches branch-tip resolutions for up to 30 minutes. If you hit the update right after a CI merge, the proxy may still return the PREVIOUS SHA. \`go install\` then sees that's the SHA it already has installed and exits in ~250ms — a silent no-op.

CI's \"warming\" step is supposed to force a refresh but isn't 100% reliable in fast-merge windows.

## Fix

\`GOPROXY=direct\` on the branch-tip resolution call only (\`go install ...@skywire-commit\` and the \`go run\` variant). Once the SHA is in hand, the SECOND \`go install\` step (\`go install ...@\$SHA\`) goes through the proxy as before — content-addressed module fetch is fine, only the branch-tip cache was the problem.

Added inline explanation of why \`GOPROXY=direct\` matters so the next operator doesn't drop it during a refactor.

## Test plan

- [x] Doc-only change; no code, no tests
- [ ] Operators of deployment hosts adopt the same pattern in their systemd timer scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)