### PR TITLE
feat(skychat-cli): unified TUI — picker + DM + group chat

### DIFF
--- a/AUTO_UPDATE.md
+++ b/AUTO_UPDATE.md
@@ -36,16 +36,24 @@ This branch has no shared history with `develop` — it's updated by CI only.
 Using `go run` with isolated cache (no persistent build artifacts):
 
 ```bash
-TMPDIR=$(mktemp -d) && COMMIT=$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
+TMPDIR=$(mktemp -d) && COMMIT=$(GOPROXY=direct GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
 echo $COMMIT
 ```
 
 Or install the helper binary (2MB, reusable):
 
 ```bash
-go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+GOPROXY=direct go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
 COMMIT=$(~/go/bin/skywire-commit)
 ```
+
+**Why `GOPROXY=direct`?** `@skywire-commit` is a branch name. The Go module proxy
+(`proxy.golang.org`) caches branch-tip → SHA resolutions for up to 30 minutes —
+so if you run the update right after a CI merge, the proxy may still return the
+previous SHA and your install no-ops (visible as a suspiciously fast "success"
+in well under a second). Setting `GOPROXY=direct` bypasses the proxy and reads
+the SHA straight from GitHub. The actual module download still proceeds with
+the global default; only the branch-tip resolution is forced direct.
 
 ### Install Skywire at the Tested Commit
 
@@ -53,10 +61,13 @@ COMMIT=$(~/go/bin/skywire-commit)
 go install github.com/skycoin/skywire@$COMMIT
 ```
 
+This step does NOT need `GOPROXY=direct` — once you have the exact commit SHA,
+the proxy lookup is content-addressed and returns the right module regardless.
+
 ### One-Liner (isolated, no persistent build artifacts from the commit check)
 
 ```bash
-TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
+TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOPROXY=direct GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
 ```
 
 ### Check if Update is Needed
@@ -79,8 +90,10 @@ Docker images are pushed to Docker Hub on every merge to `develop`, tagged with 
 
 ```bash
 #!/bin/bash
-# Get the latest tested commit
-go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+# Get the latest tested commit. GOPROXY=direct bypasses proxy.golang.org's
+# branch-tip cache (up to 30min TTL) — without it, the resolver can return
+# the previous SHA and the update silently no-ops in ~250ms with exit 0.
+GOPROXY=direct go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
 LATEST=$(~/go/bin/skywire-commit)
 SHORT=${LATEST:0:12}
 CURRENT=$(cat ~/.skywire-deploy-commit 2>/dev/null || echo "none")

--- a/cmd/skywire-cli/commands/skychat/chat.go
+++ b/cmd/skywire-cli/commands/skychat/chat.go
@@ -37,33 +37,42 @@ var chatCmd = &cobra.Command{
 	Short: "Interactive chat TUI (bubbletea split-pane)",
 	Long: `Interactive chat against the local skychat app.
 
-Top pane scrolls message history; bottom pane is the compose line.
-Enter sends. Esc or Ctrl+C quits. ↑/↓ or PgUp/PgDn scroll history.
+Without --to: launches the unified TUI — a conversation picker that
+lists known 1:1 peers (from chat history) and joined groups. Pick
+an entry with ↑/↓ + Enter; Esc returns to the picker. From the
+picker you can also press N (new DM), J (join group via invite), G
+(create group), R (refresh).
 
-Requires the skychat app to be running (default --addr 127.0.0.1:8001).
-Use --to <pk> to pin outgoing messages to one recipient. When
---to is omitted, the TUI starts in "pick a peer" mode and prompts
-for a PK in the compose line; on a valid hex PK the view
-transitions to chat. Incoming messages from any sender still
-appear in history.`,
+With --to <pk-or-alias>: short-circuits straight into a 1:1 chat
+view for that recipient. Same view shape as the picker path but
+the conversation list is hidden.
+
+Top pane scrolls message history; bottom pane is the compose line.
+Enter sends. Esc or Ctrl+C quits/back. ↑/↓ or PgUp/PgDn scroll
+history. Ctrl+N cycles outgoing network (skynet/dmsg) for 1:1
+sends.
+
+Requires the skychat app to be running (default --addr 127.0.0.1:8001).`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		// Empty recipient is allowed: the TUI prompts for it.
+		// Empty recipient: default to the unified picker.
 		// Anything non-empty must parse as a valid PK or a known
 		// alias up front so a typo on the command line surfaces
 		// immediately rather than after the TUI takes over the
 		// terminal.
-		recipientPK := ""
-		if recipient != "" {
-			pk, err := resolveTarget(recipient)
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
-			}
-			recipientPK = pk.String()
-		}
 		if err := validateNetwork(sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		if err := runChatTUI(httpAddr, recipientPK, sendNet); err != nil {
+		if recipient == "" {
+			if err := runUnifiedTUI(httpAddr, sendNet); err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			return
+		}
+		pk, err := resolveTarget(recipient)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
+		}
+		if err := runChatTUI(httpAddr, pk.String(), sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 	},

--- a/cmd/skywire-cli/commands/skychat/tui_unified.go
+++ b/cmd/skywire-cli/commands/skychat/tui_unified.go
@@ -1,0 +1,811 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/tui_unified.go
+//
+// Unified bubbletea TUI: a picker view that lists every conversation
+// the local visor knows about (1:1 peers + group memberships) and lets
+// the operator drop into any of them. Switching between conversations
+// is a single keystroke; new conversations start from the picker too.
+//
+// Layout (terminal):
+//
+//	┌─ skychat ─────────────────────────────────────────────────────┐
+//	│ [picker]                                                       │
+//	│  ▸ DM   other-claude            02f9aa58…                      │
+//	│    DM   prod-claude             03d1d78e…                      │
+//	│    GRP  claude-coordination     72afa409… (3 members)          │
+//	│                                                                │
+//	│ ↑/↓ select  enter open  N new dm  G create group  J join inv  │
+//	│ ALT+enter scroll  esc/q quit                                  │
+//	└────────────────────────────────────────────────────────────────┘
+//
+// In-chat view is the same shell as chat.go's 1:1 view but with the
+// header showing the conversation type + alias-resolved name, and
+// the IO layer swapping between SSE+/message (1:1) and GroupPoll+
+// GroupSend (groups). Esc returns to the picker.
+//
+// The existing `skywire cli skychat chat -t <pk>` short-circuits into
+// the 1:1 in-chat view (current behavior preserved). New default
+// (no -t / no -g): land on the picker.
+
+package cliskychat
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// pickerEntry is one row in the conversation picker.
+type pickerEntry struct {
+	kind    string // "dm" | "group"
+	id      string // PK hex (dm) or group UUID (group)
+	display string // alias / group name; falls back to short id
+	subline string // e.g. "3 members" for group, peer count for dm
+}
+
+// convoMessage is one rendered message in the unified history pane.
+// Same shape as chat.go's chatMsg; copied here so the unified TUI is
+// independent of the 1:1 chat model and the two can evolve apart.
+type convoMessage struct {
+	When    time.Time
+	Sender  string // resolved display name (or PK)
+	Network string // skynet/dmsg (1:1 only)
+	Body    string
+	Err     string // when set, render in red
+	Self    bool   // outgoing
+}
+
+// unifiedView is which screen the TUI is currently on.
+type unifiedView int
+
+const (
+	viewPicker unifiedView = iota
+	viewDM
+	viewGroup
+	viewPrompt // textinput-driven prompt for "new dm pk", "join invite", "create name"
+)
+
+// promptKind discriminates what the prompt is asking for.
+type promptKind int
+
+const (
+	promptNone promptKind = iota
+	promptNewDM
+	promptJoinInvite
+	promptCreateGroup
+)
+
+// unifiedModel is the bubbletea model that drives the entire skychat
+// TUI. State is a tagged union over the four view kinds; only one is
+// active at any time.
+type unifiedModel struct {
+	addr    string
+	network string // outgoing network for 1:1 sends
+
+	view   unifiedView
+	prompt promptKind
+
+	// Picker state.
+	entries  []pickerEntry
+	cursor   int
+	loadErr  string // surfaced from initial GroupList / history fetch
+	loadedAt time.Time
+
+	// Conversation history (per-convo).
+	history map[string][]convoMessage // key: "dm:<pk>" or "group:<id>"
+
+	// Active conversation (when view == viewDM | viewGroup).
+	activeKind string
+	activeID   string
+	activeName string
+	activeMeta string
+
+	// Bubbletea components shared across views.
+	vp    viewport.Model
+	input textinput.Model
+
+	width  int
+	height int
+	ready  bool
+
+	// 1:1 SSE stream — single stream for all 1:1 traffic; we filter
+	// per-convo at display time so users in DMs see only their PK.
+	sseIncoming <-chan convoMessage
+	sseErrCh    <-chan error
+	sseCancel   context.CancelFunc
+
+	// Group poll loop emits groupMsg events; one channel for all
+	// joined groups. We route by GroupID per event.
+	groupIncoming <-chan groupTUIMsg
+	groupErrCh    <-chan error
+	groupCancel   context.CancelFunc
+
+	// Status surfaced on the bottom bar.
+	statusErr string
+}
+
+// groupTUIMsg is one inbound group message from the poll loop.
+type groupTUIMsg struct {
+	GroupID  string
+	SenderPK string
+	Body     string
+	When     time.Time
+}
+
+// tuiIncomingDM / tuiIncomingGroup are tea.Msg wrappers for the two
+// stream channels. The Update branch routes them into the convo
+// history then re-arms the wait.
+type tuiIncomingDM struct{ msg convoMessage }
+type tuiIncomingGroup struct{ msg groupTUIMsg }
+
+// tuiSSEErr / tuiGroupErr surface stream-level failures.
+type tuiSSEErr struct{ err error }
+type tuiGroupErr struct{ err error }
+
+// tuiPickerLoaded is fired after the initial GroupList + history
+// fetch returns. Carries the populated entries.
+type tuiPickerLoaded struct {
+	entries []pickerEntry
+	err     string
+}
+
+// tuiSent reports an outgoing send result so the UI can render an
+// error row if the publish failed.
+type tuiSent struct {
+	key  string // history key the message was for
+	body string
+	err  error
+}
+
+func runUnifiedTUI(addr, network string) error {
+	in := textinput.New()
+	in.Focus()
+	in.CharLimit = 4096
+
+	m := &unifiedModel{
+		addr:    addr,
+		network: network,
+		view:    viewPicker,
+		input:   in,
+		history: map[string][]convoMessage{},
+	}
+	prog := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := prog.Run()
+	if m.sseCancel != nil {
+		m.sseCancel()
+	}
+	if m.groupCancel != nil {
+		m.groupCancel()
+	}
+	return err
+}
+
+// Init wires up the initial commands: picker load + stream pumps.
+func (m *unifiedModel) Init() tea.Cmd {
+	return tea.Batch(
+		textinput.Blink,
+		m.startSSE(),
+		m.startGroupPoll(),
+		m.loadPicker(),
+	)
+}
+
+// loadPicker fetches the list of known peers (from /history/peers)
+// and joined groups (from RPC GroupList). Returns a tuiPickerLoaded
+// event when done. Errors are surfaced as a status line, not fatal.
+func (m *unifiedModel) loadPicker() tea.Cmd {
+	addr := m.addr
+	return func() tea.Msg {
+		var entries []pickerEntry
+
+		// DMs from /history/peers — only peers we have any chat
+		// history with. Aliases without history are NOT auto-added
+		// here; the operator can use "N" to start a fresh dm.
+		peers, err := fetchHistoryPeers(addr)
+		if err == nil {
+			for _, p := range peers {
+				e := pickerEntry{kind: "dm", id: p, display: p}
+				if alias := lookupAlias(p); alias != "" {
+					e.display = alias
+				}
+				entries = append(entries, e)
+			}
+		}
+
+		// Groups via RPC.
+		groups, gErr := fetchGroupList()
+		if gErr == nil {
+			for _, g := range groups {
+				entries = append(entries, pickerEntry{
+					kind:    "group",
+					id:      g.ID,
+					display: g.Name,
+					subline: fmt.Sprintf("%d members · %s", len(g.Members), g.Role),
+				})
+			}
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].kind != entries[j].kind {
+				return entries[i].kind == "dm"
+			}
+			return entries[i].display < entries[j].display
+		})
+
+		out := tuiPickerLoaded{entries: entries}
+		if err != nil {
+			out.err = fmt.Sprintf("DMs: %v", err)
+		}
+		if gErr != nil {
+			if out.err != "" {
+				out.err += "; "
+			}
+			out.err += fmt.Sprintf("groups: %v", gErr)
+		}
+		return out
+	}
+}
+
+// startSSE opens the chat-app's /sse stream and starts forwarding
+// incoming messages onto an internal channel for the model to drain.
+// The stream lives for the lifetime of the TUI; per-conversation
+// filtering is purely display-side.
+func (m *unifiedModel) startSSE() tea.Cmd {
+	inCh := make(chan convoMessage, 64)
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored on model + invoked by runUnifiedTUI on exit
+	m.sseIncoming = inCh
+	m.sseErrCh = errCh
+	m.sseCancel = cancel
+
+	addr := m.addr
+	go func() {
+		raw := make(chan chatMsg, 64)
+		go streamSSE(ctx, addr, raw, errCh)
+		for cm := range raw {
+			if ctx.Err() != nil {
+				return
+			}
+			// Re-wrap into convoMessage with display-name resolution.
+			disp := cm.Sender
+			if alias := lookupAlias(cm.Sender); alias != "" {
+				disp = alias
+			}
+			inCh <- convoMessage{
+				When:    cm.When,
+				Sender:  disp,
+				Network: cm.Network,
+				Body:    cm.Body,
+				Self:    false,
+			}
+		}
+	}()
+	return m.waitSSE()
+}
+
+func (m *unifiedModel) waitSSE() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case msg, ok := <-m.sseIncoming:
+			if !ok {
+				return tuiSSEErr{err: fmt.Errorf("sse channel closed")}
+			}
+			return tuiIncomingDM{msg: msg}
+		case err, ok := <-m.sseErrCh:
+			if !ok {
+				return nil
+			}
+			return tuiSSEErr{err: err}
+		}
+	}
+}
+
+// startGroupPoll polls the visor's group inbox via RPC at 1Hz and
+// pushes new messages onto an internal channel. Auto-reconnects
+// the rpc client on visor restart, same pattern as the standalone
+// group listen command.
+func (m *unifiedModel) startGroupPoll() tea.Cmd {
+	inCh := make(chan groupTUIMsg, 64)
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored on model + invoked by runUnifiedTUI on exit
+	m.groupIncoming = inCh
+	m.groupErrCh = errCh
+	m.groupCancel = cancel
+
+	go func() {
+		runGroupPollLoop(ctx, inCh, errCh)
+	}()
+	return m.waitGroup()
+}
+
+func (m *unifiedModel) waitGroup() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case msg, ok := <-m.groupIncoming:
+			if !ok {
+				return tuiGroupErr{err: fmt.Errorf("group channel closed")}
+			}
+			return tuiIncomingGroup{msg: msg}
+		case err, ok := <-m.groupErrCh:
+			if !ok {
+				return nil
+			}
+			return tuiGroupErr{err: err}
+		}
+	}
+}
+
+func (m *unifiedModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		headerH := 2
+		footerH := 2
+		if !m.ready {
+			m.vp = viewport.New(msg.Width, msg.Height-headerH-footerH)
+			m.vp.SetContent("")
+			m.ready = true
+		} else {
+			m.vp.Width = msg.Width
+			m.vp.Height = msg.Height - headerH - footerH
+		}
+		m.input.Width = msg.Width - len(m.input.Prompt) - 1
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case tuiPickerLoaded:
+		m.entries = msg.entries
+		m.loadErr = msg.err
+		m.loadedAt = time.Now()
+
+	case tuiIncomingDM:
+		key := "dm:" + senderToKey(msg.msg.Sender)
+		m.history[key] = append(m.history[key], msg.msg)
+		if m.view == viewDM && m.historyKey() == key {
+			m.refreshViewport()
+		}
+		cmds = append(cmds, m.waitSSE())
+
+	case tuiIncomingGroup:
+		key := "group:" + msg.msg.GroupID
+		disp := msg.msg.SenderPK
+		if alias := lookupAlias(msg.msg.SenderPK); alias != "" {
+			disp = alias
+		}
+		cm := convoMessage{
+			When:   msg.msg.When,
+			Sender: disp,
+			Body:   msg.msg.Body,
+		}
+		m.history[key] = append(m.history[key], cm)
+		if m.view == viewGroup && m.historyKey() == key {
+			m.refreshViewport()
+		}
+		cmds = append(cmds, m.waitGroup())
+
+	case tuiSent:
+		row := convoMessage{
+			When:    time.Now(),
+			Sender:  "you",
+			Network: m.network,
+			Body:    msg.body,
+			Self:    true,
+		}
+		if msg.err != nil {
+			row.Err = msg.err.Error()
+		}
+		m.history[msg.key] = append(m.history[msg.key], row)
+		if m.historyKey() == msg.key {
+			m.refreshViewport()
+		}
+
+	case tuiSSEErr:
+		if msg.err != nil {
+			m.statusErr = "sse: " + msg.err.Error()
+		}
+
+	case tuiGroupErr:
+		if msg.err != nil {
+			m.statusErr = "group: " + msg.err.Error()
+		}
+
+	case tea.KeyMsg:
+		switch m.view {
+		case viewPicker:
+			return m.updatePicker(msg, cmds)
+		case viewPrompt:
+			return m.updatePrompt(msg, cmds)
+		case viewDM, viewGroup:
+			return m.updateChat(msg, cmds)
+		}
+	}
+
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	if m.ready {
+		var vpCmd tea.Cmd
+		m.vp, vpCmd = m.vp.Update(msg)
+		cmds = append(cmds, vpCmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) updatePicker(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc", "q":
+		return m, tea.Quit
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(m.entries)-1 {
+			m.cursor++
+		}
+	case "enter":
+		if len(m.entries) == 0 {
+			return m, nil
+		}
+		e := m.entries[m.cursor]
+		m.openConvo(e)
+	case "n":
+		m.startPrompt(promptNewDM, "Enter peer PK or alias: ")
+	case "g":
+		m.startPrompt(promptCreateGroup, "New group name: ")
+	case "i":
+		// "i" not "j" — j is already bound to vim-style down
+		// navigation. i for "invite" is mnemonic + non-conflicting.
+		m.startPrompt(promptJoinInvite, "Paste invite token: ")
+	case "r":
+		cmds = append(cmds, m.loadPicker())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) updatePrompt(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc":
+		m.endPrompt()
+	case "enter":
+		text := strings.TrimSpace(m.input.Value())
+		m.endPrompt()
+		switch m.prompt {
+		case promptNewDM:
+			if text != "" {
+				pk, err := resolveTarget(text)
+				if err != nil {
+					m.statusErr = err.Error()
+					return m, nil
+				}
+				m.openConvo(pickerEntry{kind: "dm", id: pk.Hex(), display: displayPK(pk.Hex())})
+			}
+		case promptJoinInvite:
+			if text != "" {
+				cmds = append(cmds, m.runJoinInvite(text))
+			}
+		case promptCreateGroup:
+			if text != "" {
+				cmds = append(cmds, m.runCreateGroup(text))
+			}
+		}
+		m.prompt = promptNone
+	}
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) updateChat(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.exitConvo()
+		return m, tea.Batch(cmds...)
+	case "ctrl+n":
+		if m.network == "skynet" {
+			m.network = "dmsg"
+		} else {
+			m.network = "skynet"
+		}
+	case "enter":
+		text := strings.TrimSpace(m.input.Value())
+		if text == "" {
+			return m, nil
+		}
+		m.input.Reset()
+		cmds = append(cmds, m.runSend(text))
+	case "pgup":
+		m.vp.HalfPageUp()
+	case "pgdown":
+		m.vp.HalfPageDown()
+	}
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	if m.ready {
+		var vpCmd tea.Cmd
+		m.vp, vpCmd = m.vp.Update(msg)
+		cmds = append(cmds, vpCmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) startPrompt(kind promptKind, placeholder string) {
+	m.prompt = kind
+	m.view = viewPrompt
+	m.input.Reset()
+	m.input.Placeholder = placeholder
+	m.input.Prompt = "» "
+	m.input.CharLimit = 4096
+	if m.ready {
+		m.input.Width = m.width - len(m.input.Prompt) - 1
+	}
+}
+
+func (m *unifiedModel) endPrompt() {
+	m.prompt = promptNone
+	m.input.Reset()
+	m.view = viewPicker
+}
+
+func (m *unifiedModel) openConvo(e pickerEntry) {
+	m.activeKind = e.kind
+	m.activeID = e.id
+	m.activeName = e.display
+	m.activeMeta = e.subline
+	if e.kind == "dm" {
+		m.view = viewDM
+	} else {
+		m.view = viewGroup
+	}
+	m.input.Reset()
+	m.input.Placeholder = "type message; Enter to send, Esc back to picker"
+	m.input.Prompt = "» "
+	m.input.CharLimit = 4096
+	if m.ready {
+		m.input.Width = m.width - len(m.input.Prompt) - 1
+	}
+	m.refreshViewport()
+}
+
+func (m *unifiedModel) exitConvo() {
+	m.view = viewPicker
+	m.activeKind = ""
+	m.activeID = ""
+	m.activeName = ""
+	m.activeMeta = ""
+	m.input.Reset()
+}
+
+func (m *unifiedModel) historyKey() string {
+	if m.activeKind == "" {
+		return ""
+	}
+	return m.activeKind + ":" + m.activeID
+}
+
+func (m *unifiedModel) refreshViewport() {
+	if !m.ready {
+		return
+	}
+	m.vp.SetContent(m.renderConvoHistory())
+	m.vp.GotoBottom()
+}
+
+func (m *unifiedModel) renderConvoHistory() string {
+	hist := m.history[m.historyKey()]
+	if len(hist) == 0 {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("241")).
+			Render("(no messages yet — type below and hit Enter)")
+	}
+	youStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
+	peerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true)
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	var b strings.Builder
+	for _, msg := range hist {
+		ts := msg.When.Format("15:04:05")
+		var sender string
+		if msg.Self {
+			sender = youStyle.Render("you")
+		} else {
+			sender = peerStyle.Render(msg.Sender)
+		}
+		net := ""
+		if msg.Network != "" {
+			net = dimStyle.Render(" /" + msg.Network)
+		}
+		if msg.Err != "" {
+			fmt.Fprintf(&b, "%s %s%s %s — %s\n", dimStyle.Render(ts), sender, net,
+				msg.Body, errStyle.Render(msg.Err))
+		} else {
+			fmt.Fprintf(&b, "%s %s%s  %s\n", dimStyle.Render(ts), sender, net, msg.Body)
+		}
+	}
+	return b.String()
+}
+
+func (m *unifiedModel) runSend(text string) tea.Cmd {
+	kind := m.activeKind
+	id := m.activeID
+	addr := m.addr
+	net := m.network
+	key := m.historyKey()
+	return func() tea.Msg {
+		switch kind {
+		case "dm":
+			_, err := postMessage(addr, id, text, net, 0)
+			return tuiSent{key: key, body: text, err: err}
+		case "group":
+			err := groupSendRPC(id, text)
+			return tuiSent{key: key, body: text, err: err}
+		}
+		return nil
+	}
+}
+
+func (m *unifiedModel) runJoinInvite(invite string) tea.Cmd {
+	return func() tea.Msg {
+		err := groupJoinRPC(invite)
+		if err != nil {
+			return tuiSent{key: "", body: "", err: err}
+		}
+		// Successful join: refresh the picker so the new group shows.
+		return m.refreshAfterMutation()
+	}
+}
+
+func (m *unifiedModel) runCreateGroup(name string) tea.Cmd {
+	return func() tea.Msg {
+		err := groupCreateRPC(name)
+		if err != nil {
+			return tuiSent{key: "", body: "", err: err}
+		}
+		return m.refreshAfterMutation()
+	}
+}
+
+func (m *unifiedModel) refreshAfterMutation() tea.Msg {
+	entries, _, gErrStr := loadPickerInline()
+	return tuiPickerLoaded{entries: entries, err: gErrStr}
+}
+
+// View renders the current screen.
+func (m *unifiedModel) View() string {
+	if !m.ready {
+		return "starting skychat tui…"
+	}
+	switch m.view {
+	case viewPicker:
+		return m.viewPicker()
+	case viewPrompt:
+		return m.viewPromptScreen()
+	case viewDM, viewGroup:
+		return m.viewChat()
+	}
+	return ""
+}
+
+func (m *unifiedModel) viewPicker() string {
+	title := lipgloss.NewStyle().Bold(true).Render("skychat — pick a conversation")
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	row := lipgloss.NewStyle().Padding(0, 1)
+	sel := lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("212")).Bold(true)
+
+	var b strings.Builder
+	b.WriteString(title + "\n")
+	if m.loadErr != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("214")).
+			Render("⚠ "+m.loadErr) + "\n")
+	}
+	b.WriteString("\n")
+	if len(m.entries) == 0 {
+		b.WriteString(dim.Render("(no conversations yet — press N for a new DM or J to join a group)") + "\n")
+	}
+	for i, e := range m.entries {
+		left := "  "
+		if i == m.cursor {
+			left = "▸ "
+		}
+		kindTag := dim.Render("DM ")
+		if e.kind == "group" {
+			kindTag = dim.Render("GRP")
+		}
+		idTag := dim.Render(shortID(e.id))
+		meta := ""
+		if e.subline != "" {
+			meta = "  " + dim.Render(e.subline)
+		}
+		line := fmt.Sprintf("%s%s  %-30s  %s%s", left, kindTag, e.display, idTag, meta)
+		if i == m.cursor {
+			b.WriteString(sel.Render(line) + "\n")
+		} else {
+			b.WriteString(row.Render(line) + "\n")
+		}
+	}
+	b.WriteString("\n" + dim.Render("↑/↓ select  enter open  n new dm  g create group  i join invite  r refresh  q quit"))
+	if m.statusErr != "" {
+		b.WriteString("\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(m.statusErr))
+	}
+	return b.String()
+}
+
+func (m *unifiedModel) viewPromptScreen() string {
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	label := ""
+	switch m.prompt {
+	case promptNewDM:
+		label = "New direct message — type peer PK (66 hex) or alias, Enter confirms, Esc cancels"
+	case promptJoinInvite:
+		label = "Join group — paste invite token (begins with skychat:invite:), Enter confirms, Esc cancels"
+	case promptCreateGroup:
+		label = "Create group — type a name, Enter confirms, Esc cancels"
+	}
+	return lipgloss.NewStyle().Bold(true).Render("skychat") + "\n\n" +
+		dim.Render(label) + "\n\n" +
+		m.input.View()
+}
+
+func (m *unifiedModel) viewChat() string {
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	header := lipgloss.NewStyle().Bold(true).Render(m.activeName)
+	if m.activeMeta != "" {
+		header += " " + dim.Render("· "+m.activeMeta)
+	}
+	if m.activeKind == "dm" {
+		header += " " + dim.Render("· DM · "+m.network)
+	} else {
+		header += " " + dim.Render("· GROUP")
+	}
+	footer := dim.Render("enter send  esc back  pgup/pgdn scroll  ctrl+n cycle network  ctrl+c quit")
+	if m.statusErr != "" {
+		footer = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(m.statusErr) + "\n" + footer
+	}
+	return header + "\n" + m.vp.View() + "\n" + m.input.View() + "\n" + footer
+}
+
+// senderToKey turns the SSE-side sender field (alias OR PK) back into
+// a routing key. If alias is set, look it up; otherwise treat as PK
+// directly. Conservative: if neither resolves, return raw input.
+func senderToKey(sender string) string {
+	// Try parse as PK directly.
+	var pk cipher.PubKey
+	if err := pk.Set(sender); err == nil {
+		return pk.Hex()
+	}
+	// Resolve as alias.
+	if pk, err := resolveTarget(sender); err == nil {
+		return pk.Hex()
+	}
+	return sender
+}
+
+// displayPK returns the alias for a PK if known, else the PK itself.
+func displayPK(pk string) string {
+	if alias := lookupAlias(pk); alias != "" {
+		return alias
+	}
+	return pk
+}
+
+// shortID truncates a long id for picker display while keeping
+// enough prefix to disambiguate.
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:8] + "…"
+}

--- a/cmd/skywire-cli/commands/skychat/tui_unified_io.go
+++ b/cmd/skywire-cli/commands/skychat/tui_unified_io.go
@@ -1,0 +1,276 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/tui_unified_io.go
+//
+// IO helpers for the unified TUI. Wraps the chat-app's /history/peers
+// HTTP endpoint and the visor's group RPC surface so the bubbletea
+// model can stay focused on the view shape.
+//
+// Group poll auto-reconnects on RPC connection drops using the
+// quiet-client pattern from #2516, so a visor halt/restart during a
+// long TUI session doesn't spam the chat history with reconnect noise.
+
+package cliskychat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// fetchHistoryPeers calls the chat-app's /history/peers endpoint and
+// returns the de-duplicated list of PKs we have any 1:1 history with.
+// Quiet when persistence is disabled (returns an empty list, no
+// error) so a fresh visor with no persistence doesn't surface noise.
+func fetchHistoryPeers(addr string) ([]string, error) {
+	url := fmt.Sprintf("http://%s/history/peers", addr)
+	hc := &http.Client{Timeout: 5 * time.Second}
+	resp, err := hc.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		// Persistence off — no peers known via this path. Not a
+		// hard error; just an empty list.
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+		return nil, fmt.Errorf("history/peers %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var peers []string
+	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+		return nil, err
+	}
+	// Drop self-PK if it sneaks in.
+	myPK := localVisorPKFromStatus(addr)
+	out := peers[:0]
+	for _, p := range peers {
+		if p != myPK {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// localVisorPKFromStatus reads /status to learn the local visor PK
+// (without an RPC round-trip). Returns "" on any failure — only used
+// as a sanity filter, not load-bearing.
+func localVisorPKFromStatus(addr string) string {
+	url := fmt.Sprintf("http://%s/status", addr)
+	hc := &http.Client{Timeout: 1 * time.Second}
+	resp, err := hc.Get(url) //nolint:gosec
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	var s struct {
+		VisorPK string `json:"visor_pk"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return ""
+	}
+	return s.VisorPK
+}
+
+// fetchGroupList queries the visor RPC for the operator's known
+// groups. Quietly returns an empty slice if grouping is disabled or
+// the RPC dial fails — picker still renders DMs.
+func fetchGroupList() ([]visor.GroupInfo, error) {
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.GroupList()
+}
+
+// loadPickerInline is the synchronous version of unifiedModel.loadPicker
+// — used after mutations (join, create) when the model needs an
+// immediate refresh before the next Init cycle. Returns the entries
+// + DM-load error + group-load error as strings (concat'd for display).
+func loadPickerInline() ([]pickerEntry, string, string) {
+	var entries []pickerEntry
+	dmErr := ""
+	groupErr := ""
+
+	peers, err := fetchHistoryPeers(defaultAddrForRefresh())
+	if err != nil {
+		dmErr = err.Error()
+	}
+	for _, p := range peers {
+		e := pickerEntry{kind: "dm", id: p, display: p}
+		if alias := lookupAlias(p); alias != "" {
+			e.display = alias
+		}
+		entries = append(entries, e)
+	}
+
+	groups, gErr := fetchGroupList()
+	if gErr != nil {
+		groupErr = gErr.Error()
+	}
+	for _, g := range groups {
+		entries = append(entries, pickerEntry{
+			kind:    "group",
+			id:      g.ID,
+			display: g.Name,
+			subline: fmt.Sprintf("%d members · %s", len(g.Members), g.Role),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].kind != entries[j].kind {
+			return entries[i].kind == "dm"
+		}
+		return entries[i].display < entries[j].display
+	})
+
+	return entries, dmErr, groupErr
+}
+
+// defaultAddrForRefresh returns the package-level httpAddr — used by
+// the inline refresh path because tea.Msg producers don't have a
+// closure over the model's addr field. httpAddr is set by the chat
+// cmd's PersistentFlags wiring at startup.
+func defaultAddrForRefresh() string {
+	return httpAddr
+}
+
+// groupSendRPC publishes a message to a group via the visor's RPC.
+// Mirrors the standalone `skychat group send` CLI but returns the
+// error directly so the TUI can render it in-pane.
+func groupSendRPC(groupID, text string) error {
+	if strings.TrimSpace(groupID) == "" {
+		return errors.New("group id required")
+	}
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return err
+	}
+	return c.GroupSend(visor.GroupSendArgs{ID: groupID, Text: text})
+}
+
+// groupJoinRPC accepts an invite token and joins the group via RPC.
+// Token is the base64url-encoded payload (the part after the
+// "skychat:invite:" prefix the CLI prints, OR the full string —
+// stripped here).
+func groupJoinRPC(invite string) error {
+	invite = strings.TrimSpace(invite)
+	invite = strings.TrimPrefix(invite, "skychat:invite:")
+	if invite == "" {
+		return errors.New("empty invite")
+	}
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.GroupJoin(visor.GroupJoinArgs{Invite: "skychat:invite:" + invite})
+	return err
+}
+
+// groupCreateRPC creates a public group with the given name (owner =
+// local visor). Returns nil on success; the caller refreshes the
+// picker to pick up the new entry.
+func groupCreateRPC(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("group name required")
+	}
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return err
+	}
+	_, _, err = c.GroupCreate(visor.GroupCreateArgs{
+		Name: name,
+		Mode: skychatgroup.ModePublic,
+	})
+	return err
+}
+
+// runGroupPollLoop pumps inbound group messages onto inCh until ctx
+// is canceled. Implements the same auto-reconnect pattern as the
+// standalone `group listen` command — silent on the reconnect path
+// (only the model sees structured errors via errCh), exponential
+// backoff capped at 30s.
+func runGroupPollLoop(ctx context.Context, inCh chan<- groupTUIMsg, errCh chan<- error) {
+	const (
+		pollInterval = 1 * time.Second
+		minBackoff   = 1 * time.Second
+		maxBackoff   = 30 * time.Second
+	)
+	defer close(inCh)
+
+	var since time.Time
+	rpc, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		select {
+		case errCh <- err:
+		case <-ctx.Done():
+			return
+		}
+		// Try to recover by reconnect loop below.
+	}
+	backoff := minBackoff
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if rpc == nil {
+			if newCl, cErr := clirpc.ClientQuiet(nil); cErr == nil {
+				rpc = newCl
+				backoff = minBackoff
+			} else {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(backoff):
+				}
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+				continue
+			}
+		}
+		msgs, err := rpc.GroupPoll(since)
+		if err != nil {
+			rpc = nil
+			select {
+			case errCh <- err:
+			default:
+			}
+			continue
+		}
+		for _, msg := range msgs {
+			if msg.TS.After(since) {
+				since = msg.TS
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case inCh <- groupTUIMsg{
+				GroupID:  msg.GroupID,
+				SenderPK: msg.SenderPK.Hex(),
+				Body:     msg.Text,
+				When:     msg.TS,
+			}:
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Default \`skywire cli skychat chat\` (no \`-t\`) now lands on a unified conversation picker. Lists known DMs (from /history/peers) and joined groups (from RPC GroupList) in one view with alias reverse-resolve. Pick a row to drop into the chat view; Esc returns to the picker.

## Picker

\`\`\`
skychat — pick a conversation

▸ DM   other-claude            02f9aa58…
  DM   prod-claude             03d1d78e…
  GRP  claude-coordination     72afa409…  3 members · owner

↑/↓ select  enter open  n new dm  g create group  i join invite  r refresh  q quit
\`\`\`

Keybindings: arrows or vim hjkl, Enter opens, N starts a new DM (prompts for PK or alias), G creates a new group, I joins via invite token, R refreshes.

## Chat view

Same shape as the existing 1:1 chat TUI (viewport + textinput). Esc returns to the picker, Ctrl+C quits. Ctrl+N cycles skynet/dmsg for 1:1 outgoing sends.

IO layer swaps by conversation type:
- DM: HTTP /sse stream + POST /message (existing path)
- Group: RPC GroupPoll + RPC GroupSend, with the auto-reconnect + quiet-client pattern from #2514/#2516

## Back-compat

\`skywire cli skychat chat -t <pk-or-alias>\` short-circuits into the 1:1 chat view, picker skipped. Same behavior as before; scripted callers + muscle memory keep working.

## Files

- New: \`tui_unified.go\` — bubbletea model, view dispatching, render
- New: \`tui_unified_io.go\` — HTTP /history/peers + group RPC wrappers
- \`chat.go\`: chat command Run() branches on whether -t was supplied

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Manual: \`skywire cli skychat chat\` (no flags) → picker shows current DMs + joined groups
- [ ] Manual: pick a DM, send a message, verify roundtrip
- [ ] Manual: pick a group, send a message, verify owner-self-echo and remote-peer-broadcast both work
- [ ] Manual: N → new DM prompt; type alias; opens that DM
- [ ] Manual: G → group create prompt
- [ ] Manual: I → join invite prompt
- [ ] Manual: visor halt during chat — auto-reconnect kicks in without spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)