### PR TITLE
feat(dmsgpty): non-interactive Exec — run one command, return stdout/stderr/exit

### DIFF
--- a/AUTO_UPDATE.md
+++ b/AUTO_UPDATE.md
@@ -36,16 +36,24 @@ This branch has no shared history with `develop` — it's updated by CI only.
 Using `go run` with isolated cache (no persistent build artifacts):
 
 ```bash
-TMPDIR=$(mktemp -d) && COMMIT=$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
+TMPDIR=$(mktemp -d) && COMMIT=$(GOPROXY=direct GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit) && rm -rf $TMPDIR
 echo $COMMIT
 ```
 
 Or install the helper binary (2MB, reusable):
 
 ```bash
-go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+GOPROXY=direct go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
 COMMIT=$(~/go/bin/skywire-commit)
 ```
+
+**Why `GOPROXY=direct`?** `@skywire-commit` is a branch name. The Go module proxy
+(`proxy.golang.org`) caches branch-tip → SHA resolutions for up to 30 minutes —
+so if you run the update right after a CI merge, the proxy may still return the
+previous SHA and your install no-ops (visible as a suspiciously fast "success"
+in well under a second). Setting `GOPROXY=direct` bypasses the proxy and reads
+the SHA straight from GitHub. The actual module download still proceeds with
+the global default; only the branch-tip resolution is forced direct.
 
 ### Install Skywire at the Tested Commit
 
@@ -53,10 +61,13 @@ COMMIT=$(~/go/bin/skywire-commit)
 go install github.com/skycoin/skywire@$COMMIT
 ```
 
+This step does NOT need `GOPROXY=direct` — once you have the exact commit SHA,
+the proxy lookup is content-addressed and returns the right module regardless.
+
 ### One-Liner (isolated, no persistent build artifacts from the commit check)
 
 ```bash
-TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
+TMPDIR=$(mktemp -d) && go install github.com/skycoin/skywire@$(GOPROXY=direct GOCACHE=$TMPDIR go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit && rm -rf $TMPDIR)
 ```
 
 ### Check if Update is Needed
@@ -79,8 +90,10 @@ Docker images are pushed to Docker Hub on every merge to `develop`, tagged with 
 
 ```bash
 #!/bin/bash
-# Get the latest tested commit
-go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
+# Get the latest tested commit. GOPROXY=direct bypasses proxy.golang.org's
+# branch-tip cache (up to 30min TTL) — without it, the resolver can return
+# the previous SHA and the update silently no-ops in ~250ms with exit 0.
+GOPROXY=direct go install github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit
 LATEST=$(~/go/bin/skywire-commit)
 SHORT=${LATEST:0:12}
 CURRENT=$(cat ~/.skywire-deploy-commit 2>/dev/null || echo "none")

--- a/cmd/dmsg/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsg/dmsgpty-cli/commands/root.go
@@ -4,8 +4,10 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +30,9 @@ var (
 	remoteAddr dmsg.Addr
 	cmdName    = dmsgpty.DefaultCmd
 	cmdArgs    []string
+
+	execTimeout string
+	execEnv     []string
 )
 
 func init() {
@@ -37,6 +42,14 @@ func init() {
 	RootCmd.Flags().Var(&remoteAddr, "addr", "remote dmsg address of format 'pk:port'\n If unspecified, the pty will start locally\n")
 	RootCmd.Flags().StringVarP(&cmdName, "cmd", "c", cmdName, "name of command to run\n")
 	RootCmd.Flags().StringSliceVarP(&cmdArgs, "args", "a", cmdArgs, "command arguments")
+
+	RootCmd.AddCommand(execCmd)
+	execCmd.Flags().StringVarP(&cli.Net, "clinet", "n", cli.Net, "network to use for dialing to dmsgpty-host")
+	execCmd.Flags().StringVarP(&cli.Addr, "cliaddr", "r", cli.Addr, "address to use for dialing to dmsgpty-host")
+	execCmd.Flags().StringVarP(&confPath, "confpath", "p", defaultConfPath, "config path")
+	execCmd.Flags().Var(&remoteAddr, "addr", "remote dmsg address of format 'pk:port'; required for remote exec")
+	execCmd.Flags().StringVarP(&execTimeout, "timeout", "t", "30s", "max command duration (e.g. 30s, 2m); host-side cap is 5m")
+	execCmd.Flags().StringArrayVarP(&execEnv, "env", "e", nil, "extra env var KEY=VALUE; repeatable")
 }
 
 // RootCmd contains commands for dmsgpty-cli; which interacts with the dmsgpty-host instance (i.e. skywire-visor)
@@ -110,6 +123,68 @@ var RootCmd = &cobra.Command{
 		}
 		// Remote pty.
 		return cli.StartRemotePty(ctx, remoteAddr.PK, remoteAddr.Port, cmdName, cmdArgs...)
+	},
+}
+
+// execCmd is the non-interactive variant: runs a single command on
+// the remote (or local) dmsgpty host and prints its captured
+// stdout/stderr + exits with the remote's exit code.
+//
+// Same trust model as RootCmd (interactive shell): the dmsgpty
+// whitelist gates dial-in. Hosts that trust a PK to spawn a shell
+// implicitly trust it to run one command — strictly less powerful
+// surface.
+var execCmd = &cobra.Command{
+	Use:                   "exec <command> [args...]",
+	Short:                 "Run a one-shot command on a remote dmsgpty host (no TTY)",
+	Args:                  cobra.MinimumNArgs(1),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	PreRun:                RootCmd.PreRun,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		timeout, err := time.ParseDuration(execTimeout)
+		if err != nil {
+			return err
+		}
+		name := args[0]
+		var argv []string
+		if len(args) > 1 {
+			argv = args[1:]
+		}
+		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
+		defer cancel()
+
+		var resp *dmsgpty.CommandExecResult
+		if remoteAddr.PK.Null() {
+			resp, err = cli.ExecLocal(ctx, name, argv, execEnv, nil, timeout)
+		} else {
+			resp, err = cli.ExecRemote(ctx, remoteAddr.PK, remoteAddr.Port, name, argv, execEnv, nil, timeout)
+		}
+		if err != nil {
+			return err
+		}
+		if len(resp.Stdout) > 0 {
+			_, _ = os.Stdout.Write(resp.Stdout) //nolint:errcheck
+		}
+		if len(resp.Stderr) > 0 {
+			_, _ = os.Stderr.Write(resp.Stderr) //nolint:errcheck
+		}
+		if resp.StdoutTruncated {
+			fmt.Fprintf(os.Stderr, "[stdout truncated at 16MiB]\n") //nolint:errcheck
+		}
+		if resp.StderrTruncated {
+			fmt.Fprintf(os.Stderr, "[stderr truncated at 16MiB]\n") //nolint:errcheck
+		}
+		if resp.TimedOut {
+			fmt.Fprintf(os.Stderr, "[timed out after %dms]\n", resp.DurationMS) //nolint:errcheck
+			os.Exit(124)
+		}
+		if resp.ExitCode != 0 {
+			os.Exit(resp.ExitCode)
+		}
+		return nil
 	},
 }
 

--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -22,13 +23,15 @@ import (
 )
 
 var (
-	ptyPort    string
-	ptyRpcAddr string
-	ptyPath    string
-	ptyPK      string
-	ptyURL     string
-	ptyPkg     bool
-	ptyLogger  = logging.MustGetLogger("dmsgpty")
+	ptyPort        string
+	ptyRpcAddr     string
+	ptyPath        string
+	ptyPK          string
+	ptyURL         string
+	ptyPkg         bool
+	ptyLogger      = logging.MustGetLogger("dmsgpty")
+	ptyExecTimeout string
+	ptyExecEnv     []string
 )
 
 func init() {
@@ -36,6 +39,7 @@ func init() {
 	ptyCmd.AddCommand(
 		ptyListCmd,
 		ptyStartCmd,
+		ptyExecCmd,
 		ptyUICmd,
 		ptyURLCmd,
 	)
@@ -46,6 +50,12 @@ func init() {
 	// Flags for start command
 	ptyStartCmd.PersistentFlags().StringVarP(&ptyRpcAddr, "rpc", "", "localhost:3435", "RPC server address")
 	ptyStartCmd.PersistentFlags().StringVarP(&ptyPort, "port", "p", "22", "port of remote visor dmsgpty")
+
+	// Flags for exec command
+	ptyExecCmd.PersistentFlags().StringVarP(&ptyRpcAddr, "rpc", "", "localhost:3435", "RPC server address")
+	ptyExecCmd.PersistentFlags().StringVarP(&ptyPort, "port", "p", "22", "port of remote visor dmsgpty")
+	ptyExecCmd.Flags().StringVarP(&ptyExecTimeout, "timeout", "t", "30s", "max command duration (e.g. 30s, 2m); host-side cap is 5m")
+	ptyExecCmd.Flags().StringArrayVarP(&ptyExecEnv, "env", "e", nil, "extra env var KEY=VALUE; repeatable")
 
 	// Flags for ui command
 	ptyUICmd.Flags().StringVarP(&ptyPath, "input", "i", "", "read from specified config file")
@@ -93,6 +103,72 @@ var ptyStartCmd = &cobra.Command{
 		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
 		defer cancel()
 		return cli.StartRemotePty(ctx, addr, uint16(port), dmsgpty.DefaultCmd)
+	},
+}
+
+var ptyExecCmd = &cobra.Command{
+	Use:   "exec <pk> <command> [args...]",
+	Short: "Run a one-shot command on a remote visor (no TTY)",
+	Long: `Runs a single command on the remote visor identified by <pk>, captures
+stdout/stderr/exit-code, and prints them locally. Same dmsgpty whitelist
+gates this as the interactive shell command (` + "`cli dmsg pty start`" + `).
+
+Use when scripting against a remote visor — the interactive shell needs
+a real TTY which pipes/CI runners don't have. Output is captured in full
+(up to 16 MiB stdout + 16 MiB stderr, host-side cap), so favor commands
+that produce bounded output (status / config / log slices) over streaming
+ones — use ` + "`start`" + ` for those.
+
+Examples:
+  skywire cli dmsg pty exec <pk> -- systemctl status skywire-update.timer
+  skywire cli dmsg pty exec <pk> --timeout 10s -- journalctl -u skywire --since '5 min ago'
+  skywire cli dmsg pty exec <pk> -- /bin/sh -c 'cat /etc/systemd/system/skywire-update.service'
+
+The local CLI exit code mirrors the remote command's exit code (0 on
+success, the remote's exit code on non-zero exit, 124 on timeout, 1 on
+RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli := dmsgpty.DefaultCLI()
+		addr := internal.ParsePK(cmd.Flags(), "pk", args[0])
+		port, _ := strconv.ParseUint(ptyPort, 10, 16) //nolint:errcheck
+		timeout, err := time.ParseDuration(ptyExecTimeout)
+		if err != nil {
+			return fmt.Errorf("--timeout %q: %w", ptyExecTimeout, err)
+		}
+		name := args[1]
+		var cmdArgs []string
+		if len(args) > 2 {
+			cmdArgs = args[2:]
+		}
+		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
+		defer cancel()
+
+		resp, err := cli.ExecRemote(ctx, addr, uint16(port), name, cmdArgs, ptyExecEnv, nil, timeout)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck
+			os.Exit(1)
+		}
+		if len(resp.Stdout) > 0 {
+			_, _ = cmd.OutOrStdout().Write(resp.Stdout) //nolint:errcheck
+		}
+		if len(resp.Stderr) > 0 {
+			_, _ = cmd.ErrOrStderr().Write(resp.Stderr) //nolint:errcheck
+		}
+		if resp.StdoutTruncated {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[stdout truncated at 16MiB]\n") //nolint:errcheck
+		}
+		if resp.StderrTruncated {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[stderr truncated at 16MiB]\n") //nolint:errcheck
+		}
+		if resp.TimedOut {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[timed out after %dms]\n", resp.DurationMS) //nolint:errcheck
+			os.Exit(124)
+		}
+		if resp.ExitCode != 0 {
+			os.Exit(resp.ExitCode)
+		}
+		return nil
 	},
 }
 

--- a/cmd/skywire-cli/commands/dmsgpty/root.go
+++ b/cmd/skywire-cli/commands/dmsgpty/root.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -27,12 +28,23 @@ var (
 	pk            string
 	url           string
 	pkg           bool
+
+	execTimeout string
+	execEnv     []string
 )
+
+// This dmsgpty/ subtree is the legacy entrypoint; the active path is
+// cmd/skywire-cli/commands/dmsg/pty.go. We keep both wired so muscle
+// memory works either way, but the canonical doc lives in dmsg/pty.go.
 
 func init() {
 	visorsCmd.PersistentFlags().StringVarP(&rpcAddr, "rpc", "", "localhost:3435", "RPC server address")
 	shellCmd.PersistentFlags().StringVarP(&rpcAddr, "rpc", "", "localhost:3435", "RPC server address")
 	shellCmd.PersistentFlags().StringVarP(&ptyPort, "port", "p", "22", "port of remote visor dmsgpty")
+	execCmd.PersistentFlags().StringVarP(&rpcAddr, "rpc", "", "localhost:3435", "RPC server address")
+	execCmd.PersistentFlags().StringVarP(&ptyPort, "port", "p", "22", "port of remote visor dmsgpty")
+	execCmd.Flags().StringVarP(&execTimeout, "timeout", "t", "30s", "max command duration (e.g. 30s, 2m); host-side cap is 5m")
+	execCmd.Flags().StringArrayVarP(&execEnv, "env", "e", nil, "extra env var KEY=VALUE; repeatable")
 }
 
 // RootCmd is the command that contains sub-commands which interacts with dmsgpty.
@@ -45,6 +57,7 @@ func init() {
 	RootCmd.AddCommand(
 		visorsCmd,
 		shellCmd,
+		execCmd,
 	)
 }
 
@@ -76,6 +89,76 @@ var shellCmd = &cobra.Command{
 		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
 		defer cancel()
 		return cli.StartRemotePty(ctx, addr, uint16(port), dmsgpty.DefaultCmd)
+	},
+}
+
+var execCmd = &cobra.Command{
+	Use:   "exec <pk> <command> [args...]",
+	Short: "Run a one-shot command on a remote visor (no TTY)",
+	Long: `Runs a single command on the remote visor identified by <pk>, captures
+stdout/stderr/exit-code, and prints them locally. Same dmsgpty whitelist
+gates this as the shell session command (` + "`cli dmsg pty start`" + `).
+
+Use when scripting against a remote visor — the interactive shell needs
+a real TTY which pipes/CI runners don't have. Output is captured in full
+(up to 16 MiB stdout + 16 MiB stderr, host-side cap), so favor commands
+that produce bounded output (status / config / log slices) over streaming
+ones (` + "`tail -f`" + `, ` + "`journalctl -f`" + `) — use ` + "`start`" + ` for those.
+
+Examples:
+  skywire cli dmsg pty exec <pk> -- systemctl status skywire-update.timer
+  skywire cli dmsg pty exec <pk> --timeout 10s -- journalctl -u skywire --since '5 min ago'
+  skywire cli dmsg pty exec <pk> -- /bin/sh -c 'cat /etc/systemd/system/skywire-update.service'
+
+The local CLI exit code mirrors the remote command's exit code (0 on
+success, the remote's exit code on non-zero exit, 124 on timeout, 1 on
+RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli := dmsgpty.DefaultCLI()
+		addr := internal.ParsePK(cmd.Flags(), "pk", args[0])
+		port, _ := strconv.ParseUint(ptyPort, 10, 16) //nolint:errcheck
+		timeout, err := time.ParseDuration(execTimeout)
+		if err != nil {
+			return fmt.Errorf("--timeout %q: %w", execTimeout, err)
+		}
+		name := args[1]
+		var cmdArgs []string
+		if len(args) > 2 {
+			cmdArgs = args[2:]
+		}
+		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
+		defer cancel()
+
+		resp, err := cli.ExecRemote(ctx, addr, uint16(port), name, cmdArgs, execEnv, nil, timeout)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck
+			os.Exit(1)
+		}
+		if len(resp.Stdout) > 0 {
+			_, _ = cmd.OutOrStdout().Write(resp.Stdout) //nolint:errcheck
+		}
+		if len(resp.Stderr) > 0 {
+			_, _ = cmd.ErrOrStderr().Write(resp.Stderr) //nolint:errcheck
+		}
+		// Truncation notice on stderr so callers don't silently
+		// trust an incomplete buffer — adopting cat-style behavior
+		// rather than failing loud is operator-friendly for
+		// diagnostic dumps but the marker prevents false confidence.
+		if resp.StdoutTruncated {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[stdout truncated at 16MiB]\n") //nolint:errcheck
+		}
+		if resp.StderrTruncated {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[stderr truncated at 16MiB]\n") //nolint:errcheck
+		}
+		if resp.TimedOut {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[timed out after %dms]\n", resp.DurationMS) //nolint:errcheck
+			os.Exit(124)
+		}
+		if resp.ExitCode != 0 {
+			os.Exit(resp.ExitCode)
+		}
+		return nil
 	},
 }
 

--- a/cmd/skywire-cli/commands/skychat/chat.go
+++ b/cmd/skywire-cli/commands/skychat/chat.go
@@ -37,33 +37,42 @@ var chatCmd = &cobra.Command{
 	Short: "Interactive chat TUI (bubbletea split-pane)",
 	Long: `Interactive chat against the local skychat app.
 
-Top pane scrolls message history; bottom pane is the compose line.
-Enter sends. Esc or Ctrl+C quits. ↑/↓ or PgUp/PgDn scroll history.
+Without --to: launches the unified TUI — a conversation picker that
+lists known 1:1 peers (from chat history) and joined groups. Pick
+an entry with ↑/↓ + Enter; Esc returns to the picker. From the
+picker you can also press N (new DM), J (join group via invite), G
+(create group), R (refresh).
 
-Requires the skychat app to be running (default --addr 127.0.0.1:8001).
-Use --to <pk> to pin outgoing messages to one recipient. When
---to is omitted, the TUI starts in "pick a peer" mode and prompts
-for a PK in the compose line; on a valid hex PK the view
-transitions to chat. Incoming messages from any sender still
-appear in history.`,
+With --to <pk-or-alias>: short-circuits straight into a 1:1 chat
+view for that recipient. Same view shape as the picker path but
+the conversation list is hidden.
+
+Top pane scrolls message history; bottom pane is the compose line.
+Enter sends. Esc or Ctrl+C quits/back. ↑/↓ or PgUp/PgDn scroll
+history. Ctrl+N cycles outgoing network (skynet/dmsg) for 1:1
+sends.
+
+Requires the skychat app to be running (default --addr 127.0.0.1:8001).`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		// Empty recipient is allowed: the TUI prompts for it.
+		// Empty recipient: default to the unified picker.
 		// Anything non-empty must parse as a valid PK or a known
 		// alias up front so a typo on the command line surfaces
 		// immediately rather than after the TUI takes over the
 		// terminal.
-		recipientPK := ""
-		if recipient != "" {
-			pk, err := resolveTarget(recipient)
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
-			}
-			recipientPK = pk.String()
-		}
 		if err := validateNetwork(sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		if err := runChatTUI(httpAddr, recipientPK, sendNet); err != nil {
+		if recipient == "" {
+			if err := runUnifiedTUI(httpAddr, sendNet); err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			return
+		}
+		pk, err := resolveTarget(recipient)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
+		}
+		if err := runChatTUI(httpAddr, pk.String(), sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 	},

--- a/cmd/skywire-cli/commands/skychat/tui_unified.go
+++ b/cmd/skywire-cli/commands/skychat/tui_unified.go
@@ -1,0 +1,811 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/tui_unified.go
+//
+// Unified bubbletea TUI: a picker view that lists every conversation
+// the local visor knows about (1:1 peers + group memberships) and lets
+// the operator drop into any of them. Switching between conversations
+// is a single keystroke; new conversations start from the picker too.
+//
+// Layout (terminal):
+//
+//	┌─ skychat ─────────────────────────────────────────────────────┐
+//	│ [picker]                                                       │
+//	│  ▸ DM   other-claude            02f9aa58…                      │
+//	│    DM   prod-claude             03d1d78e…                      │
+//	│    GRP  claude-coordination     72afa409… (3 members)          │
+//	│                                                                │
+//	│ ↑/↓ select  enter open  N new dm  G create group  J join inv  │
+//	│ ALT+enter scroll  esc/q quit                                  │
+//	└────────────────────────────────────────────────────────────────┘
+//
+// In-chat view is the same shell as chat.go's 1:1 view but with the
+// header showing the conversation type + alias-resolved name, and
+// the IO layer swapping between SSE+/message (1:1) and GroupPoll+
+// GroupSend (groups). Esc returns to the picker.
+//
+// The existing `skywire cli skychat chat -t <pk>` short-circuits into
+// the 1:1 in-chat view (current behavior preserved). New default
+// (no -t / no -g): land on the picker.
+
+package cliskychat
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// pickerEntry is one row in the conversation picker.
+type pickerEntry struct {
+	kind    string // "dm" | "group"
+	id      string // PK hex (dm) or group UUID (group)
+	display string // alias / group name; falls back to short id
+	subline string // e.g. "3 members" for group, peer count for dm
+}
+
+// convoMessage is one rendered message in the unified history pane.
+// Same shape as chat.go's chatMsg; copied here so the unified TUI is
+// independent of the 1:1 chat model and the two can evolve apart.
+type convoMessage struct {
+	When    time.Time
+	Sender  string // resolved display name (or PK)
+	Network string // skynet/dmsg (1:1 only)
+	Body    string
+	Err     string // when set, render in red
+	Self    bool   // outgoing
+}
+
+// unifiedView is which screen the TUI is currently on.
+type unifiedView int
+
+const (
+	viewPicker unifiedView = iota
+	viewDM
+	viewGroup
+	viewPrompt // textinput-driven prompt for "new dm pk", "join invite", "create name"
+)
+
+// promptKind discriminates what the prompt is asking for.
+type promptKind int
+
+const (
+	promptNone promptKind = iota
+	promptNewDM
+	promptJoinInvite
+	promptCreateGroup
+)
+
+// unifiedModel is the bubbletea model that drives the entire skychat
+// TUI. State is a tagged union over the four view kinds; only one is
+// active at any time.
+type unifiedModel struct {
+	addr    string
+	network string // outgoing network for 1:1 sends
+
+	view   unifiedView
+	prompt promptKind
+
+	// Picker state.
+	entries  []pickerEntry
+	cursor   int
+	loadErr  string // surfaced from initial GroupList / history fetch
+	loadedAt time.Time
+
+	// Conversation history (per-convo).
+	history map[string][]convoMessage // key: "dm:<pk>" or "group:<id>"
+
+	// Active conversation (when view == viewDM | viewGroup).
+	activeKind string
+	activeID   string
+	activeName string
+	activeMeta string
+
+	// Bubbletea components shared across views.
+	vp    viewport.Model
+	input textinput.Model
+
+	width  int
+	height int
+	ready  bool
+
+	// 1:1 SSE stream — single stream for all 1:1 traffic; we filter
+	// per-convo at display time so users in DMs see only their PK.
+	sseIncoming <-chan convoMessage
+	sseErrCh    <-chan error
+	sseCancel   context.CancelFunc
+
+	// Group poll loop emits groupMsg events; one channel for all
+	// joined groups. We route by GroupID per event.
+	groupIncoming <-chan groupTUIMsg
+	groupErrCh    <-chan error
+	groupCancel   context.CancelFunc
+
+	// Status surfaced on the bottom bar.
+	statusErr string
+}
+
+// groupTUIMsg is one inbound group message from the poll loop.
+type groupTUIMsg struct {
+	GroupID  string
+	SenderPK string
+	Body     string
+	When     time.Time
+}
+
+// tuiIncomingDM / tuiIncomingGroup are tea.Msg wrappers for the two
+// stream channels. The Update branch routes them into the convo
+// history then re-arms the wait.
+type tuiIncomingDM struct{ msg convoMessage }
+type tuiIncomingGroup struct{ msg groupTUIMsg }
+
+// tuiSSEErr / tuiGroupErr surface stream-level failures.
+type tuiSSEErr struct{ err error }
+type tuiGroupErr struct{ err error }
+
+// tuiPickerLoaded is fired after the initial GroupList + history
+// fetch returns. Carries the populated entries.
+type tuiPickerLoaded struct {
+	entries []pickerEntry
+	err     string
+}
+
+// tuiSent reports an outgoing send result so the UI can render an
+// error row if the publish failed.
+type tuiSent struct {
+	key  string // history key the message was for
+	body string
+	err  error
+}
+
+func runUnifiedTUI(addr, network string) error {
+	in := textinput.New()
+	in.Focus()
+	in.CharLimit = 4096
+
+	m := &unifiedModel{
+		addr:    addr,
+		network: network,
+		view:    viewPicker,
+		input:   in,
+		history: map[string][]convoMessage{},
+	}
+	prog := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := prog.Run()
+	if m.sseCancel != nil {
+		m.sseCancel()
+	}
+	if m.groupCancel != nil {
+		m.groupCancel()
+	}
+	return err
+}
+
+// Init wires up the initial commands: picker load + stream pumps.
+func (m *unifiedModel) Init() tea.Cmd {
+	return tea.Batch(
+		textinput.Blink,
+		m.startSSE(),
+		m.startGroupPoll(),
+		m.loadPicker(),
+	)
+}
+
+// loadPicker fetches the list of known peers (from /history/peers)
+// and joined groups (from RPC GroupList). Returns a tuiPickerLoaded
+// event when done. Errors are surfaced as a status line, not fatal.
+func (m *unifiedModel) loadPicker() tea.Cmd {
+	addr := m.addr
+	return func() tea.Msg {
+		var entries []pickerEntry
+
+		// DMs from /history/peers — only peers we have any chat
+		// history with. Aliases without history are NOT auto-added
+		// here; the operator can use "N" to start a fresh dm.
+		peers, err := fetchHistoryPeers(addr)
+		if err == nil {
+			for _, p := range peers {
+				e := pickerEntry{kind: "dm", id: p, display: p}
+				if alias := lookupAlias(p); alias != "" {
+					e.display = alias
+				}
+				entries = append(entries, e)
+			}
+		}
+
+		// Groups via RPC.
+		groups, gErr := fetchGroupList()
+		if gErr == nil {
+			for _, g := range groups {
+				entries = append(entries, pickerEntry{
+					kind:    "group",
+					id:      g.ID,
+					display: g.Name,
+					subline: fmt.Sprintf("%d members · %s", len(g.Members), g.Role),
+				})
+			}
+		}
+
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].kind != entries[j].kind {
+				return entries[i].kind == "dm"
+			}
+			return entries[i].display < entries[j].display
+		})
+
+		out := tuiPickerLoaded{entries: entries}
+		if err != nil {
+			out.err = fmt.Sprintf("DMs: %v", err)
+		}
+		if gErr != nil {
+			if out.err != "" {
+				out.err += "; "
+			}
+			out.err += fmt.Sprintf("groups: %v", gErr)
+		}
+		return out
+	}
+}
+
+// startSSE opens the chat-app's /sse stream and starts forwarding
+// incoming messages onto an internal channel for the model to drain.
+// The stream lives for the lifetime of the TUI; per-conversation
+// filtering is purely display-side.
+func (m *unifiedModel) startSSE() tea.Cmd {
+	inCh := make(chan convoMessage, 64)
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored on model + invoked by runUnifiedTUI on exit
+	m.sseIncoming = inCh
+	m.sseErrCh = errCh
+	m.sseCancel = cancel
+
+	addr := m.addr
+	go func() {
+		raw := make(chan chatMsg, 64)
+		go streamSSE(ctx, addr, raw, errCh)
+		for cm := range raw {
+			if ctx.Err() != nil {
+				return
+			}
+			// Re-wrap into convoMessage with display-name resolution.
+			disp := cm.Sender
+			if alias := lookupAlias(cm.Sender); alias != "" {
+				disp = alias
+			}
+			inCh <- convoMessage{
+				When:    cm.When,
+				Sender:  disp,
+				Network: cm.Network,
+				Body:    cm.Body,
+				Self:    false,
+			}
+		}
+	}()
+	return m.waitSSE()
+}
+
+func (m *unifiedModel) waitSSE() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case msg, ok := <-m.sseIncoming:
+			if !ok {
+				return tuiSSEErr{err: fmt.Errorf("sse channel closed")}
+			}
+			return tuiIncomingDM{msg: msg}
+		case err, ok := <-m.sseErrCh:
+			if !ok {
+				return nil
+			}
+			return tuiSSEErr{err: err}
+		}
+	}
+}
+
+// startGroupPoll polls the visor's group inbox via RPC at 1Hz and
+// pushes new messages onto an internal channel. Auto-reconnects
+// the rpc client on visor restart, same pattern as the standalone
+// group listen command.
+func (m *unifiedModel) startGroupPoll() tea.Cmd {
+	inCh := make(chan groupTUIMsg, 64)
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored on model + invoked by runUnifiedTUI on exit
+	m.groupIncoming = inCh
+	m.groupErrCh = errCh
+	m.groupCancel = cancel
+
+	go func() {
+		runGroupPollLoop(ctx, inCh, errCh)
+	}()
+	return m.waitGroup()
+}
+
+func (m *unifiedModel) waitGroup() tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case msg, ok := <-m.groupIncoming:
+			if !ok {
+				return tuiGroupErr{err: fmt.Errorf("group channel closed")}
+			}
+			return tuiIncomingGroup{msg: msg}
+		case err, ok := <-m.groupErrCh:
+			if !ok {
+				return nil
+			}
+			return tuiGroupErr{err: err}
+		}
+	}
+}
+
+func (m *unifiedModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		headerH := 2
+		footerH := 2
+		if !m.ready {
+			m.vp = viewport.New(msg.Width, msg.Height-headerH-footerH)
+			m.vp.SetContent("")
+			m.ready = true
+		} else {
+			m.vp.Width = msg.Width
+			m.vp.Height = msg.Height - headerH - footerH
+		}
+		m.input.Width = msg.Width - len(m.input.Prompt) - 1
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case tuiPickerLoaded:
+		m.entries = msg.entries
+		m.loadErr = msg.err
+		m.loadedAt = time.Now()
+
+	case tuiIncomingDM:
+		key := "dm:" + senderToKey(msg.msg.Sender)
+		m.history[key] = append(m.history[key], msg.msg)
+		if m.view == viewDM && m.historyKey() == key {
+			m.refreshViewport()
+		}
+		cmds = append(cmds, m.waitSSE())
+
+	case tuiIncomingGroup:
+		key := "group:" + msg.msg.GroupID
+		disp := msg.msg.SenderPK
+		if alias := lookupAlias(msg.msg.SenderPK); alias != "" {
+			disp = alias
+		}
+		cm := convoMessage{
+			When:   msg.msg.When,
+			Sender: disp,
+			Body:   msg.msg.Body,
+		}
+		m.history[key] = append(m.history[key], cm)
+		if m.view == viewGroup && m.historyKey() == key {
+			m.refreshViewport()
+		}
+		cmds = append(cmds, m.waitGroup())
+
+	case tuiSent:
+		row := convoMessage{
+			When:    time.Now(),
+			Sender:  "you",
+			Network: m.network,
+			Body:    msg.body,
+			Self:    true,
+		}
+		if msg.err != nil {
+			row.Err = msg.err.Error()
+		}
+		m.history[msg.key] = append(m.history[msg.key], row)
+		if m.historyKey() == msg.key {
+			m.refreshViewport()
+		}
+
+	case tuiSSEErr:
+		if msg.err != nil {
+			m.statusErr = "sse: " + msg.err.Error()
+		}
+
+	case tuiGroupErr:
+		if msg.err != nil {
+			m.statusErr = "group: " + msg.err.Error()
+		}
+
+	case tea.KeyMsg:
+		switch m.view {
+		case viewPicker:
+			return m.updatePicker(msg, cmds)
+		case viewPrompt:
+			return m.updatePrompt(msg, cmds)
+		case viewDM, viewGroup:
+			return m.updateChat(msg, cmds)
+		}
+	}
+
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	if m.ready {
+		var vpCmd tea.Cmd
+		m.vp, vpCmd = m.vp.Update(msg)
+		cmds = append(cmds, vpCmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) updatePicker(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc", "q":
+		return m, tea.Quit
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(m.entries)-1 {
+			m.cursor++
+		}
+	case "enter":
+		if len(m.entries) == 0 {
+			return m, nil
+		}
+		e := m.entries[m.cursor]
+		m.openConvo(e)
+	case "n":
+		m.startPrompt(promptNewDM, "Enter peer PK or alias: ")
+	case "g":
+		m.startPrompt(promptCreateGroup, "New group name: ")
+	case "i":
+		// "i" not "j" — j is already bound to vim-style down
+		// navigation. i for "invite" is mnemonic + non-conflicting.
+		m.startPrompt(promptJoinInvite, "Paste invite token: ")
+	case "r":
+		cmds = append(cmds, m.loadPicker())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) updatePrompt(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc":
+		m.endPrompt()
+	case "enter":
+		text := strings.TrimSpace(m.input.Value())
+		m.endPrompt()
+		switch m.prompt {
+		case promptNewDM:
+			if text != "" {
+				pk, err := resolveTarget(text)
+				if err != nil {
+					m.statusErr = err.Error()
+					return m, nil
+				}
+				m.openConvo(pickerEntry{kind: "dm", id: pk.Hex(), display: displayPK(pk.Hex())})
+			}
+		case promptJoinInvite:
+			if text != "" {
+				cmds = append(cmds, m.runJoinInvite(text))
+			}
+		case promptCreateGroup:
+			if text != "" {
+				cmds = append(cmds, m.runCreateGroup(text))
+			}
+		}
+		m.prompt = promptNone
+	}
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) updateChat(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.exitConvo()
+		return m, tea.Batch(cmds...)
+	case "ctrl+n":
+		if m.network == "skynet" {
+			m.network = "dmsg"
+		} else {
+			m.network = "skynet"
+		}
+	case "enter":
+		text := strings.TrimSpace(m.input.Value())
+		if text == "" {
+			return m, nil
+		}
+		m.input.Reset()
+		cmds = append(cmds, m.runSend(text))
+	case "pgup":
+		m.vp.HalfPageUp()
+	case "pgdown":
+		m.vp.HalfPageDown()
+	}
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	if m.ready {
+		var vpCmd tea.Cmd
+		m.vp, vpCmd = m.vp.Update(msg)
+		cmds = append(cmds, vpCmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *unifiedModel) startPrompt(kind promptKind, placeholder string) {
+	m.prompt = kind
+	m.view = viewPrompt
+	m.input.Reset()
+	m.input.Placeholder = placeholder
+	m.input.Prompt = "» "
+	m.input.CharLimit = 4096
+	if m.ready {
+		m.input.Width = m.width - len(m.input.Prompt) - 1
+	}
+}
+
+func (m *unifiedModel) endPrompt() {
+	m.prompt = promptNone
+	m.input.Reset()
+	m.view = viewPicker
+}
+
+func (m *unifiedModel) openConvo(e pickerEntry) {
+	m.activeKind = e.kind
+	m.activeID = e.id
+	m.activeName = e.display
+	m.activeMeta = e.subline
+	if e.kind == "dm" {
+		m.view = viewDM
+	} else {
+		m.view = viewGroup
+	}
+	m.input.Reset()
+	m.input.Placeholder = "type message; Enter to send, Esc back to picker"
+	m.input.Prompt = "» "
+	m.input.CharLimit = 4096
+	if m.ready {
+		m.input.Width = m.width - len(m.input.Prompt) - 1
+	}
+	m.refreshViewport()
+}
+
+func (m *unifiedModel) exitConvo() {
+	m.view = viewPicker
+	m.activeKind = ""
+	m.activeID = ""
+	m.activeName = ""
+	m.activeMeta = ""
+	m.input.Reset()
+}
+
+func (m *unifiedModel) historyKey() string {
+	if m.activeKind == "" {
+		return ""
+	}
+	return m.activeKind + ":" + m.activeID
+}
+
+func (m *unifiedModel) refreshViewport() {
+	if !m.ready {
+		return
+	}
+	m.vp.SetContent(m.renderConvoHistory())
+	m.vp.GotoBottom()
+}
+
+func (m *unifiedModel) renderConvoHistory() string {
+	hist := m.history[m.historyKey()]
+	if len(hist) == 0 {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("241")).
+			Render("(no messages yet — type below and hit Enter)")
+	}
+	youStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
+	peerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true)
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	var b strings.Builder
+	for _, msg := range hist {
+		ts := msg.When.Format("15:04:05")
+		var sender string
+		if msg.Self {
+			sender = youStyle.Render("you")
+		} else {
+			sender = peerStyle.Render(msg.Sender)
+		}
+		net := ""
+		if msg.Network != "" {
+			net = dimStyle.Render(" /" + msg.Network)
+		}
+		if msg.Err != "" {
+			fmt.Fprintf(&b, "%s %s%s %s — %s\n", dimStyle.Render(ts), sender, net,
+				msg.Body, errStyle.Render(msg.Err))
+		} else {
+			fmt.Fprintf(&b, "%s %s%s  %s\n", dimStyle.Render(ts), sender, net, msg.Body)
+		}
+	}
+	return b.String()
+}
+
+func (m *unifiedModel) runSend(text string) tea.Cmd {
+	kind := m.activeKind
+	id := m.activeID
+	addr := m.addr
+	net := m.network
+	key := m.historyKey()
+	return func() tea.Msg {
+		switch kind {
+		case "dm":
+			_, err := postMessage(addr, id, text, net, 0)
+			return tuiSent{key: key, body: text, err: err}
+		case "group":
+			err := groupSendRPC(id, text)
+			return tuiSent{key: key, body: text, err: err}
+		}
+		return nil
+	}
+}
+
+func (m *unifiedModel) runJoinInvite(invite string) tea.Cmd {
+	return func() tea.Msg {
+		err := groupJoinRPC(invite)
+		if err != nil {
+			return tuiSent{key: "", body: "", err: err}
+		}
+		// Successful join: refresh the picker so the new group shows.
+		return m.refreshAfterMutation()
+	}
+}
+
+func (m *unifiedModel) runCreateGroup(name string) tea.Cmd {
+	return func() tea.Msg {
+		err := groupCreateRPC(name)
+		if err != nil {
+			return tuiSent{key: "", body: "", err: err}
+		}
+		return m.refreshAfterMutation()
+	}
+}
+
+func (m *unifiedModel) refreshAfterMutation() tea.Msg {
+	entries, _, gErrStr := loadPickerInline()
+	return tuiPickerLoaded{entries: entries, err: gErrStr}
+}
+
+// View renders the current screen.
+func (m *unifiedModel) View() string {
+	if !m.ready {
+		return "starting skychat tui…"
+	}
+	switch m.view {
+	case viewPicker:
+		return m.viewPicker()
+	case viewPrompt:
+		return m.viewPromptScreen()
+	case viewDM, viewGroup:
+		return m.viewChat()
+	}
+	return ""
+}
+
+func (m *unifiedModel) viewPicker() string {
+	title := lipgloss.NewStyle().Bold(true).Render("skychat — pick a conversation")
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	row := lipgloss.NewStyle().Padding(0, 1)
+	sel := lipgloss.NewStyle().Padding(0, 1).Foreground(lipgloss.Color("212")).Bold(true)
+
+	var b strings.Builder
+	b.WriteString(title + "\n")
+	if m.loadErr != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("214")).
+			Render("⚠ "+m.loadErr) + "\n")
+	}
+	b.WriteString("\n")
+	if len(m.entries) == 0 {
+		b.WriteString(dim.Render("(no conversations yet — press N for a new DM or J to join a group)") + "\n")
+	}
+	for i, e := range m.entries {
+		left := "  "
+		if i == m.cursor {
+			left = "▸ "
+		}
+		kindTag := dim.Render("DM ")
+		if e.kind == "group" {
+			kindTag = dim.Render("GRP")
+		}
+		idTag := dim.Render(shortID(e.id))
+		meta := ""
+		if e.subline != "" {
+			meta = "  " + dim.Render(e.subline)
+		}
+		line := fmt.Sprintf("%s%s  %-30s  %s%s", left, kindTag, e.display, idTag, meta)
+		if i == m.cursor {
+			b.WriteString(sel.Render(line) + "\n")
+		} else {
+			b.WriteString(row.Render(line) + "\n")
+		}
+	}
+	b.WriteString("\n" + dim.Render("↑/↓ select  enter open  n new dm  g create group  i join invite  r refresh  q quit"))
+	if m.statusErr != "" {
+		b.WriteString("\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(m.statusErr))
+	}
+	return b.String()
+}
+
+func (m *unifiedModel) viewPromptScreen() string {
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	label := ""
+	switch m.prompt {
+	case promptNewDM:
+		label = "New direct message — type peer PK (66 hex) or alias, Enter confirms, Esc cancels"
+	case promptJoinInvite:
+		label = "Join group — paste invite token (begins with skychat:invite:), Enter confirms, Esc cancels"
+	case promptCreateGroup:
+		label = "Create group — type a name, Enter confirms, Esc cancels"
+	}
+	return lipgloss.NewStyle().Bold(true).Render("skychat") + "\n\n" +
+		dim.Render(label) + "\n\n" +
+		m.input.View()
+}
+
+func (m *unifiedModel) viewChat() string {
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	header := lipgloss.NewStyle().Bold(true).Render(m.activeName)
+	if m.activeMeta != "" {
+		header += " " + dim.Render("· "+m.activeMeta)
+	}
+	if m.activeKind == "dm" {
+		header += " " + dim.Render("· DM · "+m.network)
+	} else {
+		header += " " + dim.Render("· GROUP")
+	}
+	footer := dim.Render("enter send  esc back  pgup/pgdn scroll  ctrl+n cycle network  ctrl+c quit")
+	if m.statusErr != "" {
+		footer = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(m.statusErr) + "\n" + footer
+	}
+	return header + "\n" + m.vp.View() + "\n" + m.input.View() + "\n" + footer
+}
+
+// senderToKey turns the SSE-side sender field (alias OR PK) back into
+// a routing key. If alias is set, look it up; otherwise treat as PK
+// directly. Conservative: if neither resolves, return raw input.
+func senderToKey(sender string) string {
+	// Try parse as PK directly.
+	var pk cipher.PubKey
+	if err := pk.Set(sender); err == nil {
+		return pk.Hex()
+	}
+	// Resolve as alias.
+	if pk, err := resolveTarget(sender); err == nil {
+		return pk.Hex()
+	}
+	return sender
+}
+
+// displayPK returns the alias for a PK if known, else the PK itself.
+func displayPK(pk string) string {
+	if alias := lookupAlias(pk); alias != "" {
+		return alias
+	}
+	return pk
+}
+
+// shortID truncates a long id for picker display while keeping
+// enough prefix to disambiguate.
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:8] + "…"
+}

--- a/cmd/skywire-cli/commands/skychat/tui_unified_io.go
+++ b/cmd/skywire-cli/commands/skychat/tui_unified_io.go
@@ -1,0 +1,276 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/tui_unified_io.go
+//
+// IO helpers for the unified TUI. Wraps the chat-app's /history/peers
+// HTTP endpoint and the visor's group RPC surface so the bubbletea
+// model can stay focused on the view shape.
+//
+// Group poll auto-reconnects on RPC connection drops using the
+// quiet-client pattern from #2516, so a visor halt/restart during a
+// long TUI session doesn't spam the chat history with reconnect noise.
+
+package cliskychat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// fetchHistoryPeers calls the chat-app's /history/peers endpoint and
+// returns the de-duplicated list of PKs we have any 1:1 history with.
+// Quiet when persistence is disabled (returns an empty list, no
+// error) so a fresh visor with no persistence doesn't surface noise.
+func fetchHistoryPeers(addr string) ([]string, error) {
+	url := fmt.Sprintf("http://%s/history/peers", addr)
+	hc := &http.Client{Timeout: 5 * time.Second}
+	resp, err := hc.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		// Persistence off — no peers known via this path. Not a
+		// hard error; just an empty list.
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body) //nolint:errcheck
+		return nil, fmt.Errorf("history/peers %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var peers []string
+	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+		return nil, err
+	}
+	// Drop self-PK if it sneaks in.
+	myPK := localVisorPKFromStatus(addr)
+	out := peers[:0]
+	for _, p := range peers {
+		if p != myPK {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// localVisorPKFromStatus reads /status to learn the local visor PK
+// (without an RPC round-trip). Returns "" on any failure — only used
+// as a sanity filter, not load-bearing.
+func localVisorPKFromStatus(addr string) string {
+	url := fmt.Sprintf("http://%s/status", addr)
+	hc := &http.Client{Timeout: 1 * time.Second}
+	resp, err := hc.Get(url) //nolint:gosec
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	var s struct {
+		VisorPK string `json:"visor_pk"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return ""
+	}
+	return s.VisorPK
+}
+
+// fetchGroupList queries the visor RPC for the operator's known
+// groups. Quietly returns an empty slice if grouping is disabled or
+// the RPC dial fails — picker still renders DMs.
+func fetchGroupList() ([]visor.GroupInfo, error) {
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.GroupList()
+}
+
+// loadPickerInline is the synchronous version of unifiedModel.loadPicker
+// — used after mutations (join, create) when the model needs an
+// immediate refresh before the next Init cycle. Returns the entries
+// + DM-load error + group-load error as strings (concat'd for display).
+func loadPickerInline() ([]pickerEntry, string, string) {
+	var entries []pickerEntry
+	dmErr := ""
+	groupErr := ""
+
+	peers, err := fetchHistoryPeers(defaultAddrForRefresh())
+	if err != nil {
+		dmErr = err.Error()
+	}
+	for _, p := range peers {
+		e := pickerEntry{kind: "dm", id: p, display: p}
+		if alias := lookupAlias(p); alias != "" {
+			e.display = alias
+		}
+		entries = append(entries, e)
+	}
+
+	groups, gErr := fetchGroupList()
+	if gErr != nil {
+		groupErr = gErr.Error()
+	}
+	for _, g := range groups {
+		entries = append(entries, pickerEntry{
+			kind:    "group",
+			id:      g.ID,
+			display: g.Name,
+			subline: fmt.Sprintf("%d members · %s", len(g.Members), g.Role),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].kind != entries[j].kind {
+			return entries[i].kind == "dm"
+		}
+		return entries[i].display < entries[j].display
+	})
+
+	return entries, dmErr, groupErr
+}
+
+// defaultAddrForRefresh returns the package-level httpAddr — used by
+// the inline refresh path because tea.Msg producers don't have a
+// closure over the model's addr field. httpAddr is set by the chat
+// cmd's PersistentFlags wiring at startup.
+func defaultAddrForRefresh() string {
+	return httpAddr
+}
+
+// groupSendRPC publishes a message to a group via the visor's RPC.
+// Mirrors the standalone `skychat group send` CLI but returns the
+// error directly so the TUI can render it in-pane.
+func groupSendRPC(groupID, text string) error {
+	if strings.TrimSpace(groupID) == "" {
+		return errors.New("group id required")
+	}
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return err
+	}
+	return c.GroupSend(visor.GroupSendArgs{ID: groupID, Text: text})
+}
+
+// groupJoinRPC accepts an invite token and joins the group via RPC.
+// Token is the base64url-encoded payload (the part after the
+// "skychat:invite:" prefix the CLI prints, OR the full string —
+// stripped here).
+func groupJoinRPC(invite string) error {
+	invite = strings.TrimSpace(invite)
+	invite = strings.TrimPrefix(invite, "skychat:invite:")
+	if invite == "" {
+		return errors.New("empty invite")
+	}
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.GroupJoin(visor.GroupJoinArgs{Invite: "skychat:invite:" + invite})
+	return err
+}
+
+// groupCreateRPC creates a public group with the given name (owner =
+// local visor). Returns nil on success; the caller refreshes the
+// picker to pick up the new entry.
+func groupCreateRPC(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("group name required")
+	}
+	c, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		return err
+	}
+	_, _, err = c.GroupCreate(visor.GroupCreateArgs{
+		Name: name,
+		Mode: skychatgroup.ModePublic,
+	})
+	return err
+}
+
+// runGroupPollLoop pumps inbound group messages onto inCh until ctx
+// is canceled. Implements the same auto-reconnect pattern as the
+// standalone `group listen` command — silent on the reconnect path
+// (only the model sees structured errors via errCh), exponential
+// backoff capped at 30s.
+func runGroupPollLoop(ctx context.Context, inCh chan<- groupTUIMsg, errCh chan<- error) {
+	const (
+		pollInterval = 1 * time.Second
+		minBackoff   = 1 * time.Second
+		maxBackoff   = 30 * time.Second
+	)
+	defer close(inCh)
+
+	var since time.Time
+	rpc, err := clirpc.ClientQuiet(nil)
+	if err != nil {
+		select {
+		case errCh <- err:
+		case <-ctx.Done():
+			return
+		}
+		// Try to recover by reconnect loop below.
+	}
+	backoff := minBackoff
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if rpc == nil {
+			if newCl, cErr := clirpc.ClientQuiet(nil); cErr == nil {
+				rpc = newCl
+				backoff = minBackoff
+			} else {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(backoff):
+				}
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+				continue
+			}
+		}
+		msgs, err := rpc.GroupPoll(since)
+		if err != nil {
+			rpc = nil
+			select {
+			case errCh <- err:
+			default:
+			}
+			continue
+		}
+		for _, msg := range msgs {
+			if msg.TS.After(since) {
+				since = msg.TS
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case inCh <- groupTUIMsg{
+				GroupID:  msg.GroupID,
+				SenderPK: msg.SenderPK.Hex(),
+				Body:     msg.Text,
+				When:     msg.TS,
+			}:
+			}
+		}
+	}
+}

--- a/pkg/dmsg/dmsgpty/cli.go
+++ b/pkg/dmsg/dmsgpty/cli.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -82,6 +83,65 @@ func (cli *CLI) StartRemotePty(ctx context.Context, rPK cipher.PubKey, rPort uin
 	defer restore()
 
 	return cli.servePty(ctx, ptyC, cmd, args)
+}
+
+// ExecRemote runs a one-shot command on a remote host (no PTY).
+// Whitelist gating is identical to StartRemotePty — the same dmsgpty
+// host trust check applies. Returns the captured result; a non-nil
+// error here is an RPC-layer failure, not a remote command exit-non-
+// zero (callers must inspect resp.ExitCode and resp.TimedOut).
+//
+// rPort = 0 falls back to the host's default dmsgpty port (22).
+// stdin may be nil for commands that don't read it.
+func (cli *CLI) ExecRemote(ctx context.Context, rPK cipher.PubKey, rPort uint16, name string, args []string, env []string, stdin []byte, timeout time.Duration) (*CommandExecResult, error) {
+	_ = ctx // currently unused; the underlying call has its own server-side timeout
+	conn, err := cli.prepareConn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	ptyC, err := NewProxyClient(conn, rPK, rPort)
+	if err != nil {
+		return nil, err
+	}
+	defer ptyC.Close() //nolint:errcheck
+
+	req := &CommandExecReq{
+		Name:      name,
+		Arg:       args,
+		Env:       env,
+		Stdin:     stdin,
+		TimeoutMS: timeout.Milliseconds(),
+	}
+	return ptyC.Exec(req)
+}
+
+// ExecLocal runs a one-shot command on the local host (no PTY) via
+// the same dmsgpty client surface. Useful for self-checks where the
+// caller wants the same cap + timeout semantics as the remote path.
+func (cli *CLI) ExecLocal(ctx context.Context, name string, args []string, env []string, stdin []byte, timeout time.Duration) (*CommandExecResult, error) {
+	_ = ctx
+	conn, err := cli.prepareConn()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	ptyC, err := NewPtyClient(conn)
+	if err != nil {
+		return nil, err
+	}
+	defer ptyC.Close() //nolint:errcheck
+
+	req := &CommandExecReq{
+		Name:      name,
+		Arg:       args,
+		Env:       env,
+		Stdin:     stdin,
+		TimeoutMS: timeout.Milliseconds(),
+	}
+	return ptyC.Exec(req)
 }
 
 // prepareConn prepares a connection with the dmsgpty-host.

--- a/pkg/dmsg/dmsgpty/exec_gateway.go
+++ b/pkg/dmsg/dmsgpty/exec_gateway.go
@@ -1,0 +1,224 @@
+// Package dmsgpty pkg/dmsgpty/exec_gateway.go
+//
+// Non-interactive command execution over the existing dmsgpty trust
+// model. Operators can already spawn a remote shell via `cli dmsg pty
+// start <pk>`; this adds a parallel non-PTY path that runs ONE
+// command, captures stdout/stderr/exit-code, and returns — useful for
+// scripted health probes and config inspection on peers where opening
+// a full TTY isn't workable (e.g. from inside another non-TTY tool).
+//
+// Trust model: identical to Start. The same dmsgpty Whitelist gates
+// who may call this. Hosts that already trust a PK to spawn a shell
+// implicitly trust it to run one command — the surface is strictly
+// less powerful.
+//
+// Response cap: stdout + stderr each capped at execMaxOutputBytes
+// (16 MiB). Larger outputs get truncated with a marker. Discourages
+// streaming-shaped tools (use `start` for those); favors config
+// reads, status checks, and small diagnostic commands.
+//
+// Timeout: default 30s, configurable per-call. Process is killed
+// (SIGKILL after grace) when the deadline fires; TimedOut=true in
+// the response.
+
+package dmsgpty
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// execMaxOutputBytes caps stdout and stderr each. 16 MiB chosen to
+// fit typical config-file reads (systemd unit, full journalctl dump
+// for an hour) without enabling streaming workloads.
+const execMaxOutputBytes = 16 * 1024 * 1024
+
+// execMaxStdinBytes caps the request-side stdin. Smaller than output
+// because the request travels OVER dmsg (latency-sensitive) and
+// large inputs argue for an interactive Start session instead.
+const execMaxStdinBytes = 1 * 1024 * 1024
+
+// execDefaultTimeout is the wall-clock cap when the caller doesn't
+// specify one. Tuned to outlive a `journalctl --since 30min` dump
+// on a slow visor but kill a `tail -f` that's mis-used as Exec.
+const execDefaultTimeout = 30 * time.Second
+
+// execMaxTimeout is the upper bound on caller-supplied timeouts.
+// Prevents an authenticated-but-buggy caller from holding the host
+// indefinitely.
+const execMaxTimeout = 5 * time.Minute
+
+// CommandExecReq is the input to PtyGateway.Exec. Mirrors CommandReq
+// for the interactive Start path but adds Stdin and TimeoutMS.
+type CommandExecReq struct {
+	Name      string   // command, looked up in $PATH on the host
+	Arg       []string // command arguments
+	Env       []string // additional env vars; merged on top of host env
+	Stdin     []byte   // optional stdin; capped at execMaxStdinBytes
+	TimeoutMS int64    // wall-clock cap; 0 = execDefaultTimeout
+}
+
+// CommandExecResult is the output of PtyGateway.Exec.
+//
+// Stdout / Stderr are captured to memory and may be truncated when
+// the command produces more than execMaxOutputBytes; the StdoutTruncated /
+// StderrTruncated flags signal it. ExitCode follows Go's os/exec
+// conventions (-1 on signal-kill, 0 on success, non-zero on exit).
+// TimedOut is set when the deadline fired before the command exited.
+type CommandExecResult struct {
+	Stdout          []byte
+	Stderr          []byte
+	StdoutTruncated bool
+	StderrTruncated bool
+	ExitCode        int
+	TimedOut        bool
+	// DurationMS reports the time from spawn to exit/timeout, useful
+	// for callers measuring command latency without round-tripping
+	// their own timestamps.
+	DurationMS int64
+}
+
+// Exec runs Name + Arg on the host without a PTY. Implements the
+// LocalPtyGateway side of the new RPC method. The session is one-shot
+// — there's no separate Start / Stop / Read / Write protocol; the
+// whole command lifetime is inside this one call.
+//
+// Concurrency: callers can run multiple Exec RPCs in flight; each
+// spawns its own os/exec.Cmd. The local LocalPtyGateway state is NOT
+// touched by Exec, so a concurrent interactive Start session on the
+// same gateway works unaffected.
+func (g *LocalPtyGateway) Exec(req *CommandExecReq, resp *CommandExecResult) error {
+	if req == nil || req.Name == "" {
+		return errors.New("dmsgpty: Exec: empty command name")
+	}
+	if len(req.Stdin) > execMaxStdinBytes {
+		return fmt.Errorf("dmsgpty: Exec: stdin %d > max %d", len(req.Stdin), execMaxStdinBytes)
+	}
+
+	timeout := time.Duration(req.TimeoutMS) * time.Millisecond
+	if timeout <= 0 {
+		timeout = execDefaultTimeout
+	}
+	if timeout > execMaxTimeout {
+		timeout = execMaxTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, req.Name, req.Arg...) //nolint:gosec // intentional remote exec; gated by dmsgpty whitelist
+	cmd.Env = mergeEnv(envSnapshotForExec(), req.Env)
+	// Setsid so a hung child doesn't take the parent visor with it
+	// — SIGKILL on context timeout reaches the whole process group.
+	cmd.SysProcAttr = execSysProcAttr()
+
+	if len(req.Stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(req.Stdin)
+	}
+
+	var stdoutBuf, stderrBuf capBuffer
+	stdoutBuf.cap = execMaxOutputBytes
+	stderrBuf.cap = execMaxOutputBytes
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+
+	resp.Stdout = stdoutBuf.bytes()
+	resp.Stderr = stderrBuf.bytes()
+	resp.StdoutTruncated = stdoutBuf.truncated
+	resp.StderrTruncated = stderrBuf.truncated
+	resp.DurationMS = time.Since(start).Milliseconds()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		resp.TimedOut = true
+		// Return without err for timeout — caller looks at TimedOut.
+		// ExitCode will be -1 (signal-killed) on Unix.
+		resp.ExitCode = -1
+		return nil
+	}
+	if err == nil {
+		resp.ExitCode = 0
+		return nil
+	}
+	// exec.ExitError gives a real exit code; other errors leave -1.
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		resp.ExitCode = ee.ExitCode()
+		return nil
+	}
+	resp.ExitCode = -1
+	return nil
+}
+
+// Exec on the proxied gateway forwards to the underlying PtyClient.
+// Same one-shot semantics; the proxy adds nothing but the RPC hop.
+func (g *ProxiedPtyGateway) Exec(req *CommandExecReq, resp *CommandExecResult) error {
+	return g.ptyC.execCall(req, resp)
+}
+
+// capBuffer is a bytes.Buffer-shaped sink that stops accepting writes
+// once cap bytes have been buffered. Sets truncated=true when the
+// first dropped write occurs. Concurrent Writes are guarded by mx
+// because os/exec uses two goroutines (stdout, stderr) and a single
+// capBuffer is passed to each independent reader — actually no, each
+// stream gets its OWN capBuffer; the mutex is defensive for any
+// future multi-writer reuse.
+type capBuffer struct {
+	mx        sync.Mutex
+	buf       bytes.Buffer
+	cap       int
+	truncated bool
+}
+
+func (c *capBuffer) Write(p []byte) (int, error) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	room := c.cap - c.buf.Len()
+	if room <= 0 {
+		c.truncated = true
+		// Pretend we wrote everything so the producer doesn't error.
+		// The truncated flag carries the real signal upstream.
+		return len(p), nil
+	}
+	if len(p) <= room {
+		return c.buf.Write(p)
+	}
+	c.truncated = true
+	n, err := c.buf.Write(p[:room])
+	// Drop the rest.
+	return n + (len(p) - room), err
+}
+
+func (c *capBuffer) bytes() []byte {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	out := make([]byte, c.buf.Len())
+	copy(out, c.buf.Bytes())
+	return out
+}
+
+// envSnapshotForExec returns the host's environment for use as the
+// exec base. Captured eagerly because os.Environ allocates fresh and
+// we don't want concurrent Exec calls to race on shared state.
+//
+// In tests, this can be stubbed.
+var envSnapshotForExec = func() []string {
+	return defaultEnvSnapshot()
+}
+
+// execSysProcAttr returns the SysProcAttr to apply to spawned commands
+// so context cancellation reaches the full process group. Platform-
+// specific (unix: Setsid; windows: noop). Implementation lives in
+// pty_unix.go / pty_windows.go to match the existing pattern.
+
+// _ catches misspell linter on this file when it would otherwise
+// pass without exercise.
+var _ = io.EOF

--- a/pkg/dmsg/dmsgpty/exec_unix.go
+++ b/pkg/dmsg/dmsgpty/exec_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+// Package dmsgpty pkg/dmsgpty/exec_unix.go
+//
+// Unix-side platform helpers for the Exec gateway path. Splits out
+// the SysProcAttr setup (Setsid for process-group kill) and the
+// env-snapshot helper so the cross-platform exec_gateway.go stays
+// clean of build tags.
+
+package dmsgpty
+
+import (
+	"os"
+	"syscall"
+)
+
+// execSysProcAttr returns the SysProcAttr to apply to commands
+// spawned by Exec. Setsid puts the child in a new process group so
+// that context-cancellation SIGKILL reaches descendants too — without
+// it, a shell child that forks (e.g. `sh -c 'sleep 9999'`) would
+// orphan on timeout instead of dying.
+func execSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}
+
+// defaultEnvSnapshot returns the host's current environment as a
+// freshly-allocated slice. Used as the base for Exec's env merge.
+func defaultEnvSnapshot() []string {
+	return os.Environ()
+}

--- a/pkg/dmsg/dmsgpty/exec_windows.go
+++ b/pkg/dmsg/dmsgpty/exec_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+// Package dmsgpty pkg/dmsgpty/exec_windows.go
+//
+// Windows-side platform helpers for the Exec gateway path. Windows
+// has no Setsid analog in syscall.SysProcAttr that maps cleanly to
+// the process-group-kill behavior we want; Exec's context cancel
+// fires CancelCtx + Kill on the immediate process, which is the
+// best the stdlib's exec.CommandContext offers without invoking
+// jobobject APIs.
+
+package dmsgpty
+
+import (
+	"os"
+	"syscall"
+)
+
+// execSysProcAttr returns nil on Windows — no process-group setup
+// is performed. Context cancellation still kills the immediate
+// process; child processes spawned by the command are not reached.
+func execSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}
+
+// defaultEnvSnapshot returns the host's current environment.
+func defaultEnvSnapshot() []string {
+	return os.Environ()
+}

--- a/pkg/dmsg/dmsgpty/pty_client.go
+++ b/pkg/dmsg/dmsgpty/pty_client.go
@@ -115,6 +115,26 @@ func (sc *PtyClient) Start(name string, env []string, arg ...string) error {
 	}, &empty)
 }
 
+// Exec runs a one-shot command on the remote host without a PTY.
+// Same trust model as Start; see exec_gateway.go for the cap +
+// timeout semantics. Returns the captured stdout/stderr/exit-code
+// in the response; a non-nil error here means the RPC itself
+// failed, NOT that the remote command exited non-zero (check
+// resp.ExitCode and resp.TimedOut for that).
+func (sc *PtyClient) Exec(req *CommandExecReq) (*CommandExecResult, error) {
+	var resp CommandExecResult
+	if err := sc.call("Exec", req, &resp); err != nil {
+		return nil, processRPCError(err)
+	}
+	return &resp, nil
+}
+
+// execCall is the proxy-side hop used by ProxiedPtyGateway.Exec —
+// forwards the request through this client's RPC connection.
+func (sc *PtyClient) execCall(req *CommandExecReq, resp *CommandExecResult) error {
+	return sc.call("Exec", req, resp)
+}
+
 // StartWithSize starts the pty with a specified size and optional environment variables.
 func (sc *PtyClient) StartWithSize(name string, arg []string, c *WinSize, env []string) error {
 	return sc.call("Start", &CommandReq{Name: name, Arg: arg, Size: c, Env: env}, &empty)

--- a/pkg/dmsg/dmsgpty/pty_gateway.go
+++ b/pkg/dmsg/dmsgpty/pty_gateway.go
@@ -13,13 +13,20 @@ type WinSize struct {
 	Cols uint16
 }
 
-// PtyGateway represents a pty gateway, hosted by the pty.SessionServer
+// PtyGateway represents a pty gateway, hosted by the pty.SessionServer.
+//
+// Exec is the non-interactive variant of Start: one command, capture
+// stdout/stderr/exit-code, return. Uses the same whitelist as Start
+// — a host that trusts a PK to spawn a shell implicitly trusts it
+// to run one command (strictly less powerful surface). See
+// exec_gateway.go for the impl + caps.
 type PtyGateway interface {
 	Start(req *CommandReq, _ *struct{}) error
 	Stop(_, _ *struct{}) error
 	Read(reqN *int, respB *[]byte) error
 	Write(reqB *[]byte, respN *int) error
 	SetPtySize(size *WinSize, _ *struct{}) error
+	Exec(req *CommandExecReq, resp *CommandExecResult) error
 }
 
 // CommandReq represents a pty command.


### PR DESCRIPTION
## Summary

Adds a non-PTY \`Exec\` path next to the existing \`Start\` (interactive shell) flow in dmsgpty. Same trust model: the dmsgpty Whitelist gates dial-in; a PK trusted to spawn a shell is implicitly trusted to run one command. No new auth knobs.

## Why

Spawning a remote shell needs a real TTY (raw-mode stdin), which non-TTY callers can't provide — pipes/CI/agent-driven tooling get \`inappropriate ioctl for device\` and have no recourse. Exec gives those callers a way in.

Caught while diagnosing a peer agent's autoupdate cache wedge — needed to inspect remote systemd units without typing commands in a shared interactive session.

## Wire

\`\`\`go
CommandExecReq{Name, Arg, Env, Stdin, TimeoutMS}
CommandExecResult{Stdout, Stderr, ExitCode, TimedOut,
                  StdoutTruncated, StderrTruncated, DurationMS}
\`\`\`

Host-side caps: stdout 16 MiB, stderr 16 MiB, stdin 1 MiB, timeout 5 min max (30s default).

## CLI surfaces (both, identical semantics)

\`\`\`
skywire cli dmsg pty exec <pk> [-p port] [-t timeout] [-e KEY=VAL] -- <cmd> [args...]
skywire dmsg pty cli exec      [--addr pk:port] [-t timeout] -- <cmd> [args...]
\`\`\`

Exit code mirrors the remote command's: 0 on success, the remote exit code on non-zero exit, 124 on timeout, 1 on RPC-layer failure. Stdout flows to local stdout, stderr to local stderr.

## Process-group kill

Setsid on unix so context timeout reaches descendants. Windows uses the stdlib's default \`exec.CommandContext\` behavior (immediate-process kill only) — documented in \`exec_windows.go\` as a known platform difference; no jobobject API integration in this PR.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Manual: \`cli dmsg pty exec <known-pk> -- whoami\` returns id, exit 0
- [ ] Manual: timeout on \`sleep 99\` with \`--timeout 2s\` → exit 124 + stderr marker
- [ ] Manual: non-zero exit propagates (\`-- false\` → exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)