### PR TITLE
feat(skychat/group): replay last 100 messages on visor restart

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -286,9 +286,24 @@ func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {
 	return r, nil
 }
 
+// resumeReplayMessageCap is the max number of historical messages
+// per group replayed into the in-memory inbox on Resume. Capped so
+// a long-lived group with thousands of messages doesn't blow the
+// inbox-ring-buffer or the SSE fan-out queues on startup. 100 is
+// enough to give a freshly-restarted operator immediate context
+// without forcing them to scrape the persistent CXO tree directly.
+const resumeReplayMessageCap = 100
+
 // Resume walks the store and reopens every non-terminal session.
 // Records in StatusLeft / StatusRevoked are skipped; the operator
 // can `group join <invite>` again to bring them back.
+//
+// On reopen, the most recent resumeReplayMessageCap messages per
+// group are replayed through the registered handler so consumers
+// (visor inbox → group listen) see immediate context after a visor
+// restart, rather than an empty feed until the next live message
+// arrives. The replay drives the same handler path as live messages,
+// so order and shape match what a steady-state listener would see.
 func (m *Manager) Resume() error {
 	all, err := m.store.List()
 	if err != nil {
@@ -315,8 +330,34 @@ func (m *Manager) Resume() error {
 				_ = m.store.SetStatus(r.ID, StatusPending) //nolint:errcheck
 			}
 		}
+		m.replaySessionHistory(r.ID)
 	}
 	return nil
+}
+
+// replaySessionHistory pumps the last resumeReplayMessageCap messages
+// from a session's persistent tree through the registered handler.
+// Best-effort: errors decoding individual leaves or running the
+// handler are swallowed (debug-logged); a partial replay is better
+// than no replay.
+//
+// For owner-role sessions, the publisher's tree is the source. For
+// member-role sessions, the subscriber's tree (synced from the
+// owner) is the source. Both expose a Walk(prefix, fn) over leaf
+// values keyed by MessagePathPrefix/<ts-nano>/<seq> — sorting by
+// that path string gives us chronological order, and tail-capping
+// at the cap gives us the most recent N.
+func (m *Manager) replaySessionHistory(id string) {
+	m.mu.RLock()
+	sess := m.sessions[id]
+	m.mu.RUnlock()
+	m.onMessageMu.Lock()
+	handler := m.onMessage
+	m.onMessageMu.Unlock()
+	if sess == nil || handler == nil {
+		return
+	}
+	sess.ReplayHistoryThrough(handler, resumeReplayMessageCap)
 }
 
 // Close tears down every live session and returns the first error.

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -40,6 +40,7 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -668,6 +669,81 @@ func writeFrame(c net.Conn, payload []byte) error {
 	}
 	_, err := c.Write(payload)
 	return err
+}
+
+// ReplayHistoryThrough pumps the last `cap` messages from this
+// session's persistent tree through the given handler. Owner-role
+// sessions read from the publisher's local tree; member-role
+// sessions read from the subscriber's synced tree. Empty or
+// uninitialized sessions are no-ops.
+//
+// Best-effort: per-leaf decode / decrypt failures are silently
+// skipped (consistent with onUpdate's policy — a torn leaf
+// shouldn't block the rest of replay).
+//
+// The cap clamps the tail of chronological order: leaves whose
+// path encodes a later timestamp win when more than `cap` exist.
+// Path layout MessagePathPrefix/<ts-nano>/<seq> sorts lexically =
+// chronologically, so a simple sort + tail does the job.
+func (s *Session) ReplayHistoryThrough(handler MessageHandler, cap int) {
+	if handler == nil || cap <= 0 {
+		return
+	}
+	type leaf struct {
+		path  string
+		value []byte
+	}
+	var leaves []leaf
+	walk := func(path string, value []byte) bool {
+		// Defensive copy: tree-store Walk may reuse the value
+		// slice between callback invocations.
+		v := make([]byte, len(value))
+		copy(v, value)
+		leaves = append(leaves, leaf{path: path, value: v})
+		return true
+	}
+	switch s.cfg.Record.Role {
+	case RoleOwner:
+		if s.pub != nil {
+			s.pub.Walk(MessagePathPrefix, walk)
+		}
+	case RoleMember:
+		if s.sub != nil {
+			s.sub.Walk(MessagePathPrefix, walk)
+		}
+	default:
+		return
+	}
+	if len(leaves) == 0 {
+		return
+	}
+	sort.Slice(leaves, func(i, j int) bool {
+		return leaves[i].path < leaves[j].path
+	})
+	start := 0
+	if len(leaves) > cap {
+		start = len(leaves) - cap
+	}
+	for _, l := range leaves[start:] {
+		var msg Message
+		if err := json.Unmarshal(l.value, &msg); err != nil {
+			s.log.WithError(err).WithField("path", l.path).
+				Debug("group: replay: undecodable leaf, skipping")
+			continue
+		}
+		if s.cfg.Record.Mode == ModePrivate && len(msg.Ciphertext) > 0 {
+			plain, dErr := Decrypt(s.cfg.Record.AESKey, msg.Ciphertext, msg.Nonce)
+			if dErr != nil {
+				s.log.WithError(dErr).WithField("path", l.path).
+					Debug("group: replay: decrypt failed, skipping")
+				continue
+			}
+			msg.Text = string(plain)
+			msg.Ciphertext = nil
+			msg.Nonce = nil
+		}
+		handler(s.cfg.Record.ID, msg.SenderPK, msg)
+	}
 }
 
 // onUpdate is the subscriber callback for member-role sessions.


### PR DESCRIPTION
## Summary

Visor halt + rebuild restart wiped the \`group listen\` feed back to empty even though the underlying CXO publisher's bbolt tree still had every message. The visor's group inbox is an in-memory ring buffer populated only by live hooks (subscriber's \`onUpdate\` for inbound peer messages + owner's \`publishAs\` self-echo from #2515); neither replays history.

## Fix

\`Manager.Resume\` now calls \`Session.ReplayHistoryThrough\` on each reopened session, which walks the persistent CXO tree under \`MessagePathPrefix\` and pumps the last 100 messages through the registered handler — same path live messages take. Fresh visor on restart shows immediate context in \`group listen\` rather than an empty feed.

## Source of truth for replay

- owner sessions: \`pub.Walk\` (publisher's own tree on this host)
- member sessions: \`sub.Walk\` (synced tree from owner)

\`ModePrivate\` groups: messages are stored encrypted; replay decodes with the per-group AES key, same as the live \`onUpdate\` path. Torn / corrupt leaves are silently skipped (debug-logged) — partial replay is better than no replay.

## Cap

\`resumeReplayMessageCap = 100\`. Enough for \"what did I miss after a 2-min restart\" context without flooding the inbox ring buffer or SSE fan-out queues. Path encoding (\`MessagePathPrefix/<ts-nano>/<seq>\`) sorts lexically = chronologically, so the cap takes the tail (newest) deterministically.

## No new persistence

Leveraging what the CXO publisher / subscriber already stores. The in-memory inbox ring stays unchanged; this just seeds it on startup.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/group/...\` passes
- [x] \`golangci-lint run\` clean
- [ ] Manual: halt visor with > 0 group messages, restart, run \`group listen\` → see prior messages replayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)