### PR TITLE
fix(gotop): capture stray log output instead of corrupting the TUI

### DIFF
--- a/cmd/skywire-cli/commands/gotop/root.go
+++ b/cmd/skywire-cli/commands/gotop/root.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -200,6 +201,28 @@ func runDirectGotop() error {
 	lstream := getLayout(conf)
 	ly := layout.ParseLayout(lstream)
 
+	// Silence the default logger BEFORE ui.Init: upstream gotop emits
+	// log.Println on transient gopsutil glitches (e.g. the "negative
+	// value for recently received network data" line in
+	// vendor/.../widgets/net.go:118 when an interface counter rolls
+	// back across an interface reset / quick sample window). Those go
+	// to stderr by default — on a termui-backed TUI that writes straight
+	// onto the live screen, garbling the CPU graph + process list
+	// permanently (no render cycle repairs it). Capture to an in-memory
+	// buffer here so the messages aren't lost; flush them to stderr
+	// after ui.Close in the deferred restore, where the terminal is
+	// back in line-mode and a plain text dump is fine.
+	var logBuf logCapture
+	prevLogOut := log.Default().Writer()
+	log.SetOutput(&logBuf)
+	defer func() {
+		log.SetOutput(prevLogOut)
+		if captured := logBuf.String(); captured != "" {
+			fmt.Fprintln(os.Stderr, "--- gotop runtime messages ---")
+			fmt.Fprint(os.Stderr, captured)
+		}
+	}()
+
 	// Initialize UI
 	if err = ui.Init(); err != nil {
 		return err
@@ -381,6 +404,21 @@ func runGotopWithConfig(updateInterval time.Duration, remoteMode bool) error {
 	// Get layout
 	lstream := getLayout(conf)
 	ly := layout.ParseLayout(lstream)
+
+	// Same log-capture treatment as runDirectGotop — keep upstream
+	// log.Println output from the gopsutil-counter-rollback handlers
+	// off the live TUI screen. See the comment on the direct path
+	// for the full rationale.
+	var logBuf logCapture
+	prevLogOut := log.Default().Writer()
+	log.SetOutput(&logBuf)
+	defer func() {
+		log.SetOutput(prevLogOut)
+		if captured := logBuf.String(); captured != "" {
+			fmt.Fprintln(os.Stderr, "--- gotop runtime messages ---")
+			fmt.Fprint(os.Stderr, captured)
+		}
+	}()
 
 	// Initialize UI
 	if err = ui.Init(); err != nil {
@@ -745,4 +783,49 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-1] + "."
+}
+
+// logCapture is an io.Writer the runDirectGotop / runVisorGotop
+// paths swap in as log.Default()'s Writer for the duration of the
+// TUI. Captures upstream gotop's transient log output (gopsutil
+// counter rollbacks, etc.) in memory rather than letting them
+// write straight onto the live termui screen. Flushed to stderr
+// on TUI exit so the messages aren't lost.
+//
+// Bounded to avoid runaway memory on a long-running session
+// with a misbehaving gopsutil source: writes past
+// logCaptureMaxBytes drop and set truncated=true.
+type logCapture struct {
+	mu        sync.Mutex
+	buf       []byte
+	truncated bool
+}
+
+const logCaptureMaxBytes = 256 * 1024 // 256 KiB plenty for an interactive session
+
+func (c *logCapture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	room := logCaptureMaxBytes - len(c.buf)
+	if room <= 0 {
+		c.truncated = true
+		return len(p), nil
+	}
+	if len(p) <= room {
+		c.buf = append(c.buf, p...)
+		return len(p), nil
+	}
+	c.truncated = true
+	c.buf = append(c.buf, p[:room]...)
+	return len(p), nil
+}
+
+func (c *logCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := string(c.buf)
+	if c.truncated {
+		s += "[gotop log buffer truncated at 256KiB]\n"
+	}
+	return s
 }


### PR DESCRIPTION
## Summary

Operator screenshotted a garbled \`cli gotop --local\` session: the CPU graph and process-list panes had lines of plain text bleeding through (\`error: negative value for recently received network data from gopsutil. recentBytesRecv: ...\` among others). Once written those bytes stay on screen — termui's next render cycle redraws its OWN cells but doesn't touch cells it never owned, so the graffiti persists for the rest of the session.

**Source**: upstream gotop's \`widgets/net.go:118\` calls \`log.Println\` on gopsutil counter rollbacks (interface reset / fast-sample window / container restart on the host). \`log.Default()\`'s output is stderr, which on a termui-backed TUI is the same fd as the live screen. Same handler exists for sent bytes at \`net.go:124\`. **Vendor dep**, so we can't change those calls without forking.

## Fix without forking

Swap \`log.Default()\`'s Writer to an in-memory buffer (\`logCapture\`) for the duration of the TUI session — applied in both \`runDirectGotop\` and \`runVisorGotop\`, before \`ui.Init()\`. The deferred restore (after \`ui.Close()\`) prints the captured messages to real stderr where they're harmless plain text. Operators still see what went wrong on exit; they just don't see it overlaid on a live render.

\`logCapture\` is bounded to 256 KiB to keep a long-running misbehaving gopsutil source from leaking memory; overflow drops with a truncation marker.

## Background

Caught live during the 3-way coordination session — peer agent was running gotop in a separate ssh and the deployment update cycle triggered the network-rollback path repeatedly.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Manual: run \`cli gotop --local\` on a host where gopsutil net counter rollback fires (or wait for natural occurrence) → screen stays clean during session, captured messages appear on stderr after Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)