### PR TITLE
fix+resilience(skychat): MarkMessage + TUI/GUI polish + cli single-line listen + stale-conn retry + group auto-reconnect + /status health

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -745,13 +745,52 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		writeStart := time.Now()
 		err := conn.WriteFrame(wirePayload)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-
+			// Stale-conn auto-retry: a conn that's still in the
+			// `conns` map but whose underlying transport has gone
+			// away (peer chat-app restart, transient transport
+			// fault, etc) used to lose the caller's CURRENT message
+			// — the handler returned 400, the operator had to retry
+			// from the CLI / UI. Now we delete the stale entry, dial
+			// a fresh conn to the same peer, and retry the WriteFrame
+			// ONCE. Only on a second failure do we surface the error
+			// to the caller. The retry is one-shot to keep this
+			// codepath bounded; chronic peer-unreachability still
+			// surfaces as 400 within bounded time.
 			connsMu.Lock()
 			delete(conns, pk)
 			connsMu.Unlock()
 
-			return
+			appCl.Log().WithError(err).Warnf("Stale conn to %s: retrying with fresh dial", pk)
+
+			var raw net.Conn
+			dialErr := r.Do(ctx, func() error {
+				c, dErr := appCl.Dial(addr)
+				if dErr != nil {
+					return dErr
+				}
+				raw = c
+				return nil
+			})
+			if dialErr != nil {
+				http.Error(w, fmt.Sprintf("send retry failed: %s; fresh dial: %s", err, dialErr), http.StatusBadRequest)
+				return
+			}
+			conn = newFramedConn(raw)
+			connsMu.Lock()
+			conns[pk] = conn
+			connsMu.Unlock()
+			// Same long-lived-conn semantics as the initial-dial
+			// path — handleConn owns the lifetime of this conn, not
+			// the HTTP request.
+			go handleConn(conn) //nolint:gosec // G118: long-lived conn, not request-scoped
+
+			if retryErr := conn.WriteFrame(wirePayload); retryErr != nil {
+				connsMu.Lock()
+				delete(conns, pk)
+				connsMu.Unlock()
+				http.Error(w, fmt.Sprintf("send retry failed: %s; fresh dial: %s", err, retryErr), http.StatusBadRequest)
+				return
+			}
 		}
 
 		// Persist outgoing message (best-effort).
@@ -1091,9 +1130,74 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	if visorPKErr != "" {
 		status["error"] = visorPKErr
 	}
+	if groups := collectGroupHealth(); groups != nil {
+		status["groups"] = groups
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(status) //nolint:errcheck,gosec
+}
+
+// groupHealth is the per-group health summary surfaced by /status.
+// lag_seconds is a pointer so JSON encoding emits explicit null when
+// the group has never seen a message (last_message_at is the zero
+// time). Operators can then treat "lag_seconds > 600" as a stale-feed
+// alarm without false-positive on brand-new empty groups.
+type groupHealth struct {
+	ID              string    `json:"id"`
+	Name            string    `json:"name"`
+	Role            string    `json:"role"`
+	Status          string    `json:"status"`
+	MembersCount    int       `json:"members_count"`
+	LastMessageAt   time.Time `json:"last_message_at,omitempty"`
+	LagSeconds      *int64    `json:"lag_seconds"`
+	SubscriberAlive bool      `json:"subscriber_alive"`
+}
+
+// collectGroupHealth queries the visor's GroupList RPC and renders
+// the per-group health entries for /status. Returns nil if the
+// pair-RPC channel isn't wired (grouping then can't be inspected
+// from the chat-app process). Returns an empty slice if the visor
+// has no groups (vs. nil = "unknown / not introspectable") so
+// consumers can distinguish "no groups configured" from "grouping
+// unreachable".
+//
+// Why route through the visor RPC: the chat-app process doesn't own
+// the group.Manager — the visor does. The chat-app already opens a
+// pair-RPC channel (when --pair-enable is set, which is the default
+// for any setup that has grouping enabled at all). This reuses that
+// channel rather than introducing a new IPC dependency.
+func collectGroupHealth() []groupHealth {
+	if pairRPC == nil {
+		return nil
+	}
+	infos, err := pairRPC.GroupList()
+	if err != nil {
+		appCl.Log().Debugf("status: GroupList RPC failed: %v", err)
+		return nil
+	}
+	out := make([]groupHealth, 0, len(infos))
+	now := time.Now().UTC()
+	for _, g := range infos {
+		gh := groupHealth{
+			ID:              g.ID,
+			Name:            g.Name,
+			Role:            string(g.Role),
+			Status:          string(g.Status),
+			MembersCount:    len(g.Members),
+			LastMessageAt:   g.LastMessageAt,
+			SubscriberAlive: g.SubscriberAlive,
+		}
+		if !g.LastMessageAt.IsZero() {
+			lag := int64(now.Sub(g.LastMessageAt).Seconds())
+			if lag < 0 {
+				lag = 0
+			}
+			gh.LagSeconds = &lag
+		}
+		out = append(out, gh)
+	}
+	return out
 }
 
 // persistMessage stores a message in the history backend if persistence is

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -834,6 +834,7 @@
         this.recipients.forEach(r => this._addRecipient(r));
         this._sseSubscribe();
         this.syncPairedFromVisor();
+        this.syncHistoryPeers();
       }
 
       showToast(message, type = 'success') {
@@ -982,10 +983,81 @@
         this.showToast('Contact added successfully.');
       }
 
+      // syncHistoryPeers seeds the sidebar with peers the visor has
+      // stored history for but localStorage doesn't know about (fresh
+      // browser, new device, cleared cache). 404/503 means the visor
+      // has persistence disabled — silently fall back to the
+      // localStorage-only flow.
+      syncHistoryPeers() {
+        fetch('/history/peers')
+          .then(res => (res.status === 404 || res.status === 503) ? null : (res.ok ? res.json() : null))
+          .then(peers => {
+            if (!peers) return;
+            peers.forEach(p => {
+              if (p && !this.recipients.includes(p)) {
+                this._addRecipient(p);
+              }
+            });
+          })
+          .catch(e => console.debug('skychat /history/peers sync skipped:', e.message));
+      }
+
+      // loadHistoryFor preloads the server-side DM history for a peer
+      // when the local message buffer is empty. Idempotent: returns
+      // early if local already has messages, so it doesn't clobber
+      // in-memory sends made before the fetch resolves. 404/503 means
+      // persistence is off; fall back silently.
+      loadHistoryFor(pk) {
+        if (!this.messages[pk] || this.messages[pk].length > 0) return;
+        fetch(`/history?peer=${encodeURIComponent(pk)}&limit=100`)
+          .then(res => (res.status === 404 || res.status === 503) ? null : (res.ok ? res.json() : null))
+          .then(msgs => {
+            if (!msgs || msgs.length === 0) return;
+            if (this.messages[pk].length > 0) return; // a live message arrived; defer to it
+            const withDates = [];
+            let lastDay = null;
+            msgs.forEach(m => {
+              const ts = new Date(m.timestamp);
+              const day = ts.toDateString();
+              if (day !== lastDay) {
+                withDates.push({ date: ts });
+                lastDay = day;
+              }
+              withDates.push({
+                ts: ts,
+                from: m.outgoing ? 'me' : (m.from || m.peer),
+                text: m.text,
+              });
+            });
+            this.messages[pk] = withDates;
+            this.messagesQuantity[pk] = msgs.length;
+            this.saveChat(pk);
+            // Re-render if the user is already looking at this convo.
+            if (this.recipient === pk) {
+              const msgEl = document.getElementById('messages');
+              msgEl.innerHTML = '';
+              this.messages[pk].forEach(m => this._showMessage(m));
+              msgEl.scrollTop = msgEl.scrollHeight;
+              this.messagesSeen[pk] = this.messagesQuantity[pk];
+              this.saveSeenList();
+              this.updateUnreadBadges();
+            }
+            // Update sidebar preview from newest non-date entry.
+            for (let i = this.messages[pk].length - 1; i >= 0; i--) {
+              if (!this.messages[pk][i].date) {
+                this.updatePreview(pk, this.messages[pk][i]);
+                break;
+              }
+            }
+          })
+          .catch(e => console.debug(`skychat /history?peer=${pk} skipped:`, e.message));
+      }
+
       selectRecipient(pk) {
         if (this.recipient === pk) return;
 
         this.recipient = pk;
+        this.loadHistoryFor(pk);
 
         document.querySelectorAll('.recipient-item').forEach(item => {
           item.classList.toggle('active', item.dataset.pk === pk);
@@ -1233,6 +1305,11 @@
           this.refreshPairControls();
           this.showToast(`Pair declined by ${peer.substring(0,8)}...`, 'error');
         }
+        // Authoritative server-side reconciliation — the SSE branches
+        // above mutate local state only, so a stale received-list can
+        // hang around if the SSE envelope is malformed or arrives
+        // out-of-order. Refetch keeps the sidebar in sync with truth.
+        this.syncPendingInvites();
       }
 
       updateUnreadBadges() {
@@ -1274,7 +1351,7 @@
           url = `/pair/${destination}/message`;
           body = JSON.stringify({ text: msg });
         } else {
-          url = 'message';
+          url = '/message';
           body = JSON.stringify({ recipient: destination, message: msg, network: network });
         }
 

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -59,6 +59,24 @@ type Manager struct {
 
 	mu       sync.RWMutex
 	sessions map[string]*Session
+
+	// reconnect loop state — see runReconnectLoop.
+	reconnectCtx    context.Context
+	reconnectCancel context.CancelFunc
+	reconnectWG     sync.WaitGroup
+	reconnectMu     sync.Mutex
+	reconnectState  map[string]*reconnectState // keyed by group ID
+}
+
+// reconnectState tracks per-group consecutive-failure backoff so a
+// permanently-unreachable owner doesn't get hammered every cycle.
+// See runReconnectLoop for the state machine.
+type reconnectState struct {
+	failures uint32
+	// nextAttempt is set when a backoff transition extends the
+	// per-group interval beyond the base 30s tick. The reconnect
+	// loop skips groups whose nextAttempt is still in the future.
+	nextAttempt time.Time
 }
 
 // ManagerConfig wires a Manager.
@@ -88,14 +106,15 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 		log = logging.MustGetLogger("skychat-group-manager")
 	}
 	return &Manager{
-		store:     cfg.Store,
-		dmsgC:     cfg.DmsgC,
-		myPK:      cfg.MyPK,
-		mySK:      cfg.MySK,
-		dataDir:   cfg.DataDir,
-		log:       log,
-		portAlloc: defaultPortAlloc,
-		sessions:  make(map[string]*Session),
+		store:          cfg.Store,
+		dmsgC:          cfg.DmsgC,
+		myPK:           cfg.MyPK,
+		mySK:           cfg.MySK,
+		dataDir:        cfg.DataDir,
+		log:            log,
+		portAlloc:      defaultPortAlloc,
+		sessions:       make(map[string]*Session),
+		reconnectState: make(map[string]*reconnectState),
 	}, nil
 }
 
@@ -248,6 +267,12 @@ func (m *Manager) SendToGroup(ctx context.Context, id, text string) error {
 		if err := sess.SubmitToOwner(ctx, text); err != nil {
 			return err
 		}
+		// A successful relay submission proves the owner is reachable
+		// over at least one transport. If the subscriber side of this
+		// session is currently down (StatusPending after a transient
+		// Connect failure), now's a good moment to retry — don't wait
+		// up to 30s for the next reconnect tick.
+		m.kickReconnect(ctx, id)
 	default:
 		return fmt.Errorf("group: SendToGroup: unknown role %q", sess.cfg.Record.Role)
 	}
@@ -324,15 +349,222 @@ func (m *Manager) Resume() error {
 			m.mu.RUnlock()
 			if err := sess.Connect(); err != nil {
 				m.log.WithError(err).WithField("id", r.ID).
-					Warn("group: Resume: member subscribe connect")
-				// Keep the record but mark pending for now; a future
-				// Reconnect step (not in v1) can retry.
+					Warn("group: Resume: member subscribe connect (will retry in background)")
+				// Mark pending; runReconnectLoop will re-attempt on
+				// its 30s cadence (with backoff on repeated failures)
+				// until the owner becomes reachable.
 				_ = m.store.SetStatus(r.ID, StatusPending) //nolint:errcheck
 			}
 		}
 		m.replaySessionHistory(r.ID)
 	}
+	m.startReconnectLoop()
 	return nil
+}
+
+// reconnectInterval is the base cadence the reconnect loop walks
+// pending sessions on. Short enough that a peer's chat-app restart
+// (which usually completes inside 30s) auto-heals without operator
+// intervention; long enough that a permanently-unreachable owner
+// isn't dial-hammered.
+const reconnectInterval = 30 * time.Second
+
+// reconnectAttemptTimeout bounds the per-Connect call so the
+// reconnect loop can't get stuck on a single slow group while other
+// pending groups starve.
+const reconnectAttemptTimeout = 5 * time.Second
+
+// Backoff transition thresholds. After this many consecutive
+// failures on a given group, the per-group nextAttempt is bumped
+// out so the loop skips it until enough wall time has passed.
+const (
+	reconnectBackoffFailures1 = 10
+	reconnectBackoffInterval1 = 5 * time.Minute
+	reconnectBackoffFailures2 = 30
+	reconnectBackoffInterval2 = 30 * time.Minute
+)
+
+// startReconnectLoop launches the background goroutine that retries
+// failed member-side Connects. Safe to call multiple times — the
+// second call is a no-op while the loop is already running.
+func (m *Manager) startReconnectLoop() {
+	m.reconnectMu.Lock()
+	if m.reconnectCtx != nil {
+		m.reconnectMu.Unlock()
+		return
+	}
+	m.reconnectCtx, m.reconnectCancel = context.WithCancel(context.Background())
+	m.reconnectMu.Unlock()
+	m.reconnectWG.Add(1)
+	go m.runReconnectLoop(m.reconnectCtx)
+}
+
+// runReconnectLoop walks every member-side session in StatusPending
+// on a 30s cadence and re-attempts Connect. Successes promote the
+// record back to StatusActive and reset the per-group failure
+// counter. Failures bump the failure counter and, past the configured
+// thresholds, extend the next-attempt time so the loop skips that
+// group until the backoff window elapses.
+//
+// Logging levels follow the spec:
+//   - debug: every reconnect attempt (success or failure)
+//   - info:  every successful reconnect (StatusPending → StatusActive)
+//   - warn:  every backoff-interval transition
+func (m *Manager) runReconnectLoop(ctx context.Context) {
+	defer m.reconnectWG.Done()
+	t := time.NewTicker(reconnectInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		m.attemptReconnectPending(ctx)
+	}
+}
+
+// attemptReconnectPending iterates all member-role sessions currently
+// in StatusPending and tries each one. Single-pass: a session whose
+// Connect succeeds here won't be tried again until its status is
+// reset to pending (e.g. on next visor restart, or a future fault).
+func (m *Manager) attemptReconnectPending(ctx context.Context) {
+	records, err := m.store.List()
+	if err != nil {
+		m.log.WithError(err).Debug("group: reconnect: store list failed")
+		return
+	}
+	now := time.Now().UTC()
+	for _, r := range records {
+		if r.Role != RoleMember || r.Status != StatusPending {
+			continue
+		}
+		if !m.reconnectShouldAttempt(r.ID, now) {
+			continue
+		}
+		m.mu.RLock()
+		sess, ok := m.sessions[r.ID]
+		m.mu.RUnlock()
+		if !ok || sess == nil {
+			continue
+		}
+		m.tryReconnect(ctx, sess, r.ID)
+	}
+}
+
+// tryReconnect runs one Connect attempt under reconnectAttemptTimeout.
+// On success: clears per-group failure state, flips Status →
+// StatusActive. On failure: bumps the counter and applies any
+// configured backoff transition.
+func (m *Manager) tryReconnect(ctx context.Context, sess *Session, id string) {
+	m.log.WithField("id", id).Debug("group: reconnect: attempting subscribe")
+	type result struct{ err error }
+	done := make(chan result, 1)
+	go func() {
+		done <- result{err: sess.Connect()}
+	}()
+	var err error
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(reconnectAttemptTimeout):
+		err = fmt.Errorf("group: reconnect: timed out after %s", reconnectAttemptTimeout)
+	case r := <-done:
+		err = r.err
+	}
+	if err == nil {
+		m.reconnectMu.Lock()
+		delete(m.reconnectState, id)
+		m.reconnectMu.Unlock()
+		if sErr := m.store.SetStatus(id, StatusActive); sErr != nil {
+			m.log.WithError(sErr).WithField("id", id).
+				Warn("group: reconnect: SetStatus active failed")
+		}
+		m.log.WithField("id", id).Info("group: reconnect: subscribe restored")
+		return
+	}
+	m.reconnectRecordFailure(id, err)
+}
+
+// reconnectShouldAttempt returns false when the per-group nextAttempt
+// is still in the future (i.e. we're in a backoff window). True when
+// there's no state (first attempt) or when the backoff has elapsed.
+func (m *Manager) reconnectShouldAttempt(id string, now time.Time) bool {
+	m.reconnectMu.Lock()
+	defer m.reconnectMu.Unlock()
+	st, ok := m.reconnectState[id]
+	if !ok {
+		return true
+	}
+	return !st.nextAttempt.After(now)
+}
+
+// reconnectRecordFailure increments the per-group counter and emits
+// a warn-level transition log when crossing one of the configured
+// failure thresholds. The backoff intervals are absolute next-attempt
+// times so the reconnect loop's cheap RLock-and-skip path doesn't
+// have to do any arithmetic per tick.
+func (m *Manager) reconnectRecordFailure(id string, attemptErr error) {
+	m.reconnectMu.Lock()
+	st, ok := m.reconnectState[id]
+	if !ok {
+		st = &reconnectState{}
+		m.reconnectState[id] = st
+	}
+	st.failures++
+	var transition string
+	switch {
+	case st.failures == reconnectBackoffFailures2:
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval2)
+		transition = reconnectBackoffInterval2.String()
+	case st.failures == reconnectBackoffFailures1:
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval1)
+		transition = reconnectBackoffInterval1.String()
+	case st.failures > reconnectBackoffFailures2:
+		// Stay at the 30min cadence for any subsequent failures.
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval2)
+	case st.failures > reconnectBackoffFailures1:
+		// Stay at the 5min cadence between the two thresholds.
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval1)
+	}
+	failures := st.failures
+	m.reconnectMu.Unlock()
+	if transition != "" {
+		m.log.WithError(attemptErr).WithField("id", id).
+			WithField("failures", failures).
+			WithField("next_interval", transition).
+			Warn("group: reconnect: extending backoff")
+	} else {
+		m.log.WithError(attemptErr).WithField("id", id).
+			WithField("failures", failures).
+			Debug("group: reconnect: attempt failed")
+	}
+}
+
+// kickReconnect is the opportunistic-retry hook: when a member-side
+// SendToGroup succeeds via the relay listener, that proves the owner
+// is reachable — so it's likely a good moment to retry the failed
+// subscriber Connect too. Called outside of any session lock to avoid
+// contending with the regular reconnect tick.
+//
+// Distinct from runReconnectLoop's 30s cadence: this fires
+// immediately on a successful send, often before the next tick would,
+// shortening the typical recovery from <30s to <1s when the failure
+// was a transient transport hiccup.
+func (m *Manager) kickReconnect(ctx context.Context, id string) {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok || sess == nil || sess.sub == nil {
+		return
+	}
+	if sess.IsSubscriberAlive() {
+		return
+	}
+	// Best-effort: don't block the SendToGroup caller. The retry
+	// runs in its own goroutine and surfaces results through the
+	// usual reconnect logs.
+	go m.tryReconnect(ctx, sess, id)
 }
 
 // replaySessionHistory pumps the last resumeReplayMessageCap messages
@@ -362,7 +594,19 @@ func (m *Manager) replaySessionHistory(id string) {
 
 // Close tears down every live session and returns the first error.
 // Does NOT close the Store — caller still owns that.
+//
+// Also stops the background reconnect loop (if it was started via
+// Resume). Idempotent: a second Close is a no-op.
 func (m *Manager) Close() error {
+	m.reconnectMu.Lock()
+	cancel := m.reconnectCancel
+	m.reconnectCancel = nil
+	m.reconnectCtx = nil
+	m.reconnectMu.Unlock()
+	if cancel != nil {
+		cancel()
+		m.reconnectWG.Wait()
+	}
 	m.mu.Lock()
 	sessions := m.sessions
 	m.sessions = make(map[string]*Session)
@@ -378,6 +622,23 @@ func (m *Manager) Close() error {
 
 // Get returns the persisted record for an ID.
 func (m *Manager) Get(id string) (Record, bool, error) { return m.store.Get(id) }
+
+// IsSubscriberAlive reports the live subscriber health for the group
+// id, surfaced by the chat-app's /status endpoint as the per-group
+// `subscriber_alive` field. Returns true for owner-role sessions
+// (no subscriber) and for member-role sessions whose most recent
+// Connect() succeeded. Returns false for member-role sessions sitting
+// at StatusPending or when no live session exists for the id (e.g.
+// the record was left/revoked).
+func (m *Manager) IsSubscriberAlive(id string) bool {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok || sess == nil {
+		return false
+	}
+	return sess.IsSubscriberAlive()
+}
 
 // List returns every persisted record.
 func (m *Manager) List() ([]Record, error) { return m.store.List() }

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -424,12 +424,25 @@ func (m *Manager) openLocked(r Record) (*Session, error) {
 		return nil, fmt.Errorf("group: open %s: %w", r.ID, err)
 	}
 	if h != nil {
-		sess.SetMessageHandler(h)
+		sess.SetMessageHandler(m.wrapHandler(r.ID, h))
 	}
 	m.mu.Lock()
 	m.sessions[r.ID] = sess
 	m.mu.Unlock()
 	return sess, nil
+}
+
+// wrapHandler decorates the user handler so every observed message
+// (inbound from the feed AND owner self-echo of own sends) updates
+// the record's LastMessageAt. Without this, last_message_at only
+// reflected outbound SendToGroup calls — member-side records showed
+// "0001-01-01" forever even with healthy inbound, and group list's
+// LAST_MESSAGE column was a misleading sender-only counter.
+func (m *Manager) wrapHandler(id string, h MessageHandler) MessageHandler {
+	return func(groupID string, senderPK cipher.PubKey, msg Message) {
+		_ = m.store.MarkMessage(id, msg.TS) //nolint:errcheck
+		h(groupID, senderPK, msg)
+	}
 }
 
 // defaultPortAlloc picks a random DMSG port in the range

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -143,6 +143,14 @@ type Session struct {
 
 	handler MessageHandler
 	log     *logging.Logger
+
+	// subAlive tracks whether the most recent Connect() succeeded
+	// and the subscriber has not yet been torn down. Owner-role
+	// sessions are always considered alive (no subscriber to track).
+	// Surfaced through IsSubscriberAlive for the chat-app's /status
+	// per-group health field. Atomic so it can be read without
+	// acquiring any session mutex from the status handler's hot path.
+	subAlive atomic.Bool
 }
 
 // relayPortOffset is the dmsg-port delta from the group's CXO
@@ -311,6 +319,11 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 // Connect dials the owner's CXO node and starts the subscribe
 // handshake. Owner sessions are a no-op (they don't subscribe to
 // themselves). Idempotent: returns nil if already connected.
+//
+// On success, flips subAlive=true so IsSubscriberAlive starts
+// reporting "true" for operator-visible group health. On error,
+// subAlive stays false and the Manager's background reconnect
+// loop (Manager.runReconnectLoop) keeps retrying.
 func (s *Session) Connect() error {
 	if s.sub == nil {
 		return nil // owner role
@@ -318,7 +331,33 @@ func (s *Session) Connect() error {
 	if err := s.sub.Connect(s.cfg.Record.OwnerPK); err != nil {
 		return fmt.Errorf("group: Connect: %w", err)
 	}
+	s.subAlive.Store(true)
 	return nil
+}
+
+// IsSubscriberAlive reports whether the subscriber side of this
+// session is currently live. Surfaced through the chat-app's
+// /status endpoint as the per-group `subscriber_alive` field so
+// operators can spot a member session whose Connect failed silently
+// or whose subscriber has been torn down.
+//
+// Semantics:
+//   - Owner-role sessions: always true (no subscriber to track; the
+//     publisher side is owned by this visor and there's nothing to
+//     "lose connection" to).
+//   - Member-role sessions: true iff the most recent Connect()
+//     succeeded AND Close has not been called. Does NOT consult the
+//     underlying treestore.Subscriber's live conn state — that would
+//     require a new accessor on Subscriber and the connection there
+//     is best-effort heartbeated by CXO already. The boolean here is
+//     "did we successfully attach + do we believe we're still
+//     attached"; the background reconnect loop is responsible for
+//     re-asserting that belief on its 30s cadence.
+func (s *Session) IsSubscriberAlive() bool {
+	if s.sub == nil {
+		return true // owner role
+	}
+	return s.subAlive.Load()
 }
 
 // ID returns the group's UUID.
@@ -382,6 +421,9 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 // CXO node, owned by the publisher). Idempotent.
 func (s *Session) Close() error {
 	var firstErr error
+	// Flip subAlive first so any concurrent /status read sees the
+	// session as dead even if Close races with a long Subscriber.Close.
+	s.subAlive.Store(false)
 	if s.relayCancel != nil {
 		s.relayCancel()
 	}

--- a/cmd/skywire-cli/commands/skychat/escape.go
+++ b/cmd/skywire-cli/commands/skychat/escape.go
@@ -1,0 +1,58 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/escape.go:
+// helpers for keeping `skychat listen` and `skychat group listen`
+// output strictly one-line-per-message.
+//
+// Why this exists: agent monitor harnesses and most log aggregators
+// treat each stdout line as a separate event. When a chat body
+// contains embedded newlines, the default fmt.Fprintf(out, "... %s\n",
+// body) emits multiple lines for one logical message — the harness
+// either fragments them into N events (losing per-message correlation)
+// or clips at line N due to per-event size limits. The wire is fine
+// (/status.inbound_msg_count and chat-app logs still see the full
+// body); the issue is purely the CLI's stdout shape.
+//
+// escapeForOneLine renders a body so each chat message renders as
+// exactly ONE line of stdout. We pick literal `\n` / `\r` / `\\`
+// escapes (visible to humans, machine-detectable) rather than dropping
+// the characters: an operator reading the log can still tell the
+// message contained newlines, and any consumer that wants the raw
+// content can pass --raw (or --json, which handles multi-line bodies
+// natively via JSON string encoding).
+package cliskychat
+
+import "strings"
+
+// escapeForOneLine turns embedded newlines and carriage returns into
+// the literal two-character sequences `\n` and `\r`, so the returned
+// string contains no actual line terminators. Backslashes are also
+// escaped so the transformation is reversible — `\\n` always decodes
+// to "\n" (escape) rather than "\<newline>" (raw control char).
+//
+// Order matters: backslashes must be escaped FIRST so that a "\n" in
+// the input doesn't survive the subsequent newline-escape only to be
+// undone by an external decoder. Without that, an input of `a\nb`
+// (the two chars: backslash + 'n', no real newline) and an input of
+// `a<LF>b` would both render to the same output `a\nb`.
+func escapeForOneLine(s string) string {
+	if s == "" {
+		return s
+	}
+	if !strings.ContainsAny(s, "\\\n\r") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/cmd/skywire-cli/commands/skychat/escape_test.go
+++ b/cmd/skywire-cli/commands/skychat/escape_test.go
@@ -1,0 +1,64 @@
+// Package cliskychat cmd/skywire-cli/commands/skychat/escape_test.go
+package cliskychat
+
+import "testing"
+
+func TestEscapeForOneLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "plain ascii", in: "hello world", want: "hello world"},
+		{name: "lf only", in: "line1\nline2", want: `line1\nline2`},
+		{name: "cr only", in: "line1\rline2", want: `line1\rline2`},
+		{name: "crlf", in: "line1\r\nline2", want: `line1\r\nline2`},
+		{name: "multi lf", in: "a\nb\nc", want: `a\nb\nc`},
+		{
+			// Backslashes must round-trip. Without the backslash escape,
+			// an input of `a\nb` (literal: a, backslash, n, b) and an
+			// input of "a<LF>b" would both collapse to the same output.
+			name: "backslash preserved",
+			in:   `a\nb`,
+			want: `a\\nb`,
+		},
+		{
+			name: "newline plus backslash",
+			in:   "a\\\nb",
+			want: `a\\\nb`,
+		},
+		{
+			name: "unicode passthrough",
+			in:   "skywire — 🚀\nnext",
+			want: `skywire — 🚀\nnext`,
+		},
+		{
+			name: "trailing newline",
+			in:   "done\n",
+			want: `done\n`,
+		},
+		{
+			// Verify the early-return fast path keeps non-special
+			// input identical (no Builder allocation, byte-for-byte
+			// same string).
+			name: "tab and control chars left alone",
+			in:   "col1\tcol2",
+			want: "col1\tcol2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := escapeForOneLine(tc.in)
+			if got != tc.want {
+				t.Fatalf("escapeForOneLine(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			// Hard invariant: the output never contains a raw CR or LF.
+			for _, r := range got {
+				if r == '\n' || r == '\r' {
+					t.Fatalf("escapeForOneLine(%q) emitted a raw line terminator %q", tc.in, got)
+				}
+			}
+		})
+	}
+}

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -22,6 +22,7 @@ package cliskychat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -44,6 +45,7 @@ var (
 
 	groupListenSince string
 	groupListenPoll  time.Duration
+	groupListenRaw   bool
 )
 
 func init() {
@@ -54,6 +56,10 @@ func init() {
 
 	groupListenCmd.Flags().StringVar(&groupListenSince, "since", "", "RFC3339 lower bound for the first poll; empty = drain current inbox window then follow")
 	groupListenCmd.Flags().DurationVar(&groupListenPoll, "interval", time.Second, "poll interval")
+	// --raw and --json (persistent) are mutually exclusive; default
+	// escapes \n and \r so each event is exactly one stdout line.
+	// See cmd/skywire-cli/commands/skychat/escape.go for rationale.
+	groupListenCmd.Flags().BoolVar(&groupListenRaw, "raw", false, "emit unescaped multi-line message bodies (humans reading directly; not safe for line-based log aggregators)")
 
 	groupCmd.AddCommand(
 		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
@@ -247,8 +253,25 @@ dies when the visor halts (rebuild-restart loop). The poller
 catches "connection is shut down" / EOF / similar errors,
 backs off (1s→30s exponential), re-creates the rpc client, and
 resumes polling. Reduces the burn-the-CLI-Ctrl+C-relaunch
-friction operators hit during a development cycle.`,
+friction operators hit during a development cycle.
+
+Output modes (mutually exclusive — passing both --raw and --json
+errors out):
+  text (default): one line per message,
+    "[<ts>] [<group-id>] <sender-pk>: <body>". Embedded newlines and
+    carriage returns in the body are escaped to literal \n / \r so
+    each message is exactly ONE line of stdout. This is the mode
+    agents and log-line aggregators should use.
+  --raw: same format, body NOT escaped. For humans reading directly.
+  --json: NDJSON, one object per line:
+    {"ts":..., "group_id":..., "sender_pk":..., "body":...}
+    JSON's native string encoding handles multi-line bodies; this
+    mode is also one-line-per-event.`,
 	Run: func(cmd *cobra.Command, _ []string) {
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		if jsonMode && groupListenRaw {
+			internal.PrintFatalError(cmd.Flags(), errors.New("--raw and --json are mutually exclusive"))
+		}
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
@@ -260,7 +283,9 @@ friction operators hit during a development cycle.`,
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --since: %w", err))
 			}
 		}
-		fmt.Println("Listening for group messages. Ctrl+C to exit.")
+		if !jsonMode {
+			fmt.Println("Listening for group messages. Ctrl+C to exit.")
+		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		ticker := time.NewTicker(groupListenPoll)
@@ -327,8 +352,31 @@ friction operators hit during a development cycle.`,
 				if m.TS.After(since) {
 					since = m.TS
 				}
+				if jsonMode {
+					ev := struct {
+						TS       time.Time `json:"ts"`
+						GroupID  string    `json:"group_id"`
+						SenderPK string    `json:"sender_pk"`
+						Body     string    `json:"body"`
+					}{
+						TS:       m.TS.UTC(),
+						GroupID:  m.GroupID,
+						SenderPK: m.SenderPK.Hex(),
+						Body:     m.Text,
+					}
+					b, mErr := json.Marshal(ev)
+					if mErr != nil {
+						continue
+					}
+					fmt.Println(string(b))
+					continue
+				}
+				body := m.Text
+				if !groupListenRaw {
+					body = escapeForOneLine(body)
+				}
 				fmt.Printf("[%s] [%s] %s: %s\n",
-					m.TS.UTC().Format(time.RFC3339), m.GroupID, m.SenderPK, m.Text)
+					m.TS.UTC().Format(time.RFC3339), m.GroupID, m.SenderPK, body)
 			}
 		}
 	},

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -34,6 +34,7 @@ var (
 	sendWait     time.Duration
 	listenNet    string
 	listenFrom   string
+	listenRaw    bool
 	historyPeer  string
 	historyLimit int
 	historySince string
@@ -60,6 +61,11 @@ func init() {
 
 	listenCmd.Flags().StringVarP(&listenNet, "net", "n", "", "filter by network type (optional; default = all)")
 	listenCmd.Flags().StringVar(&listenFrom, "from", "", "filter by sender public key (optional; full hex PK)")
+	// --raw and --json are mutually exclusive; default (neither set)
+	// escapes \n and \r so each event is exactly one line of stdout
+	// for agent / log-aggregator consumption. See escape.go for the
+	// rationale and exact transformation.
+	listenCmd.Flags().BoolVar(&listenRaw, "raw", false, "emit unescaped multi-line message bodies (humans reading directly; not safe for line-based log aggregators)")
 
 	historyCmd.Flags().StringVar(&historyPeer, "peer", "", "filter by peer public key (optional; full hex PK)")
 	historyCmd.Flags().IntVar(&historyLimit, "limit", 100, "max messages to return (1-1000)")
@@ -433,11 +439,23 @@ var listenCmd = &cobra.Command{
 Reconnects automatically when the connection drops (e.g. the visor
 restarts). Exit with Ctrl+C.
 
-Output modes:
+Output modes (mutually exclusive — passing both --raw and --json
+errors out):
   text (default): one line per event, format "[sender[/net]] body" for
     inbound messages, "[>sender[/net]] body" for outbound mirrors and
     other non-inbound directions; reconnect errors to stderr.
-  --json: one JSON object per stdout line (NDJSON). Event types:
+    Embedded newlines and carriage returns in the body are escaped to
+    the literal two-character sequences \n / \r so every event is
+    exactly ONE line of stdout. This is the mode agents and log-line
+    aggregators should use — otherwise a multi-line chat body would
+    fragment into N stdout events.
+  --raw: same text format, but the body is NOT escaped. Use this when
+    a human is reading the output directly and wants the original
+    multi-line layout. Not safe for monitor harnesses that treat each
+    line as a separate event.
+  --json: one JSON object per stdout line (NDJSON). Bodies pass through
+    JSON's native string encoding (\n, \r, etc are escaped by the JSON
+    encoder), so this mode is also one-line-per-event. Event types:
     {"type":"banner",...}    once at startup (addr + filter context)
     {"type":"msg",...}       a message; fields: ts, from, net, body, dir
     {"type":"reconnect",...} SSE stream is being re-opened; fields: ts, err, delay_ms
@@ -482,6 +500,9 @@ Filters:
 		}
 
 		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		if jsonMode && listenRaw {
+			internal.PrintFatalError(cmd.Flags(), errors.New("--raw and --json are mutually exclusive"))
+		}
 		out := cmd.OutOrStdout()
 		errOut := cmd.ErrOrStderr()
 
@@ -514,7 +535,7 @@ Filters:
 
 		delay := minReconnectDelay
 		for {
-			err := streamSSEOnce(ctx, out, url, netFilter, listenFrom, jsonMode)
+			err := streamSSEOnce(ctx, out, url, netFilter, listenFrom, jsonMode, listenRaw)
 			if ctx.Err() != nil {
 				// Caller hit Ctrl+C; exit cleanly.
 				return
@@ -613,7 +634,12 @@ func emitJSON(w io.Writer, ev listenEvent) {
 //
 // netFilter (""|skynet|dmsg) and fromFilter ("" | full-hex PK)
 // suppress non-matching events before any output.
-func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilter string, jsonMode bool) error {
+//
+// raw=false (default) escapes \n / \r in the message body so every
+// text-mode event is exactly one line of stdout; raw=true preserves
+// the original body verbatim. jsonMode supersedes both (the JSON
+// encoder handles escaping natively).
+func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilter string, jsonMode, raw bool) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("build SSE request: %w", err)
@@ -716,7 +742,11 @@ func streamSSEOnce(ctx context.Context, out io.Writer, url, netFilter, fromFilte
 			if alias := lookupAlias(msg.Sender); alias != "" {
 				display = alias
 			}
-			fmt.Fprintf(out, "[%s%s%s] %s\n", dirPrefix, display, netSuffix, msg.Message) //nolint:errcheck
+			body := msg.Message
+			if !raw {
+				body = escapeForOneLine(body)
+			}
+			fmt.Fprintf(out, "[%s%s%s] %s\n", dirPrefix, display, netSuffix, body) //nolint:errcheck
 		}
 	}
 	// scanner.Err() returns nil on a clean EOF; io.EOF /

--- a/cmd/skywire-cli/commands/skychat/tui_unified.go
+++ b/cmd/skywire-cli/commands/skychat/tui_unified.go
@@ -55,12 +55,13 @@ type pickerEntry struct {
 // Same shape as chat.go's chatMsg; copied here so the unified TUI is
 // independent of the 1:1 chat model and the two can evolve apart.
 type convoMessage struct {
-	When    time.Time
-	Sender  string // resolved display name (or PK)
-	Network string // skynet/dmsg (1:1 only)
-	Body    string
-	Err     string // when set, render in red
-	Self    bool   // outgoing
+	When     time.Time
+	Sender   string // resolved display name (or PK) — for rendering
+	SenderPK string // raw PK hex from wire — for routing keys; empty for outgoing
+	Network  string // skynet/dmsg (1:1 only)
+	Body     string
+	Err      string // when set, render in red
+	Self     bool   // outgoing
 }
 
 // unifiedView is which screen the TUI is currently on.
@@ -149,6 +150,11 @@ type tuiIncomingGroup struct{ msg groupTUIMsg }
 // tuiSSEErr / tuiGroupErr surface stream-level failures.
 type tuiSSEErr struct{ err error }
 type tuiGroupErr struct{ err error }
+
+// tuiMutationErr surfaces an error from a picker-level mutation
+// (group join / create) that has no associated history bucket to
+// render into. The handler renders it as a status banner.
+type tuiMutationErr struct{ err error }
 
 // tuiPickerLoaded is fired after the initial GroupList + history
 // fetch returns. Carries the populated entries.
@@ -280,11 +286,12 @@ func (m *unifiedModel) startSSE() tea.Cmd {
 				disp = alias
 			}
 			inCh <- convoMessage{
-				When:    cm.When,
-				Sender:  disp,
-				Network: cm.Network,
-				Body:    cm.Body,
-				Self:    false,
+				When:     cm.When,
+				Sender:   disp,
+				SenderPK: cm.Sender,
+				Network:  cm.Network,
+				Body:     cm.Body,
+				Self:     false,
 			}
 		}
 	}()
@@ -368,7 +375,16 @@ func (m *unifiedModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadedAt = time.Now()
 
 	case tuiIncomingDM:
-		key := "dm:" + senderToKey(msg.msg.Sender)
+		// Route off the raw PK from the wire, not the resolved display
+		// name. If the alias was removed mid-session, the display would
+		// no longer round-trip to the PK and the inbound would split
+		// from the outbound (keyed by activeID/PK) into a separate
+		// "dm:<alias>" history bucket.
+		routePK := msg.msg.SenderPK
+		if routePK == "" {
+			routePK = senderToKey(msg.msg.Sender) // fallback for any caller still on the old path
+		}
+		key := "dm:" + routePK
 		m.history[key] = append(m.history[key], msg.msg)
 		if m.view == viewDM && m.historyKey() == key {
 			m.refreshViewport()
@@ -416,6 +432,11 @@ func (m *unifiedModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tuiGroupErr:
 		if msg.err != nil {
 			m.statusErr = "group: " + msg.err.Error()
+		}
+
+	case tuiMutationErr:
+		if msg.err != nil {
+			m.statusErr = msg.err.Error()
 		}
 
 	case tea.KeyMsg:
@@ -661,7 +682,7 @@ func (m *unifiedModel) runJoinInvite(invite string) tea.Cmd {
 	return func() tea.Msg {
 		err := groupJoinRPC(invite)
 		if err != nil {
-			return tuiSent{key: "", body: "", err: err}
+			return tuiMutationErr{err: fmt.Errorf("group join: %w", err)}
 		}
 		// Successful join: refresh the picker so the new group shows.
 		return m.refreshAfterMutation()
@@ -672,7 +693,7 @@ func (m *unifiedModel) runCreateGroup(name string) tea.Cmd {
 	return func() tea.Msg {
 		err := groupCreateRPC(name)
 		if err != nil {
-			return tuiSent{key: "", body: "", err: err}
+			return tuiMutationErr{err: fmt.Errorf("group create: %w", err)}
 		}
 		return m.refreshAfterMutation()
 	}

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -42,6 +42,10 @@ type GroupInfo struct {
 	CreatedAt     time.Time           `json:"created_at"`
 	JoinedAt      time.Time           `json:"joined_at"`
 	LastMessageAt time.Time           `json:"last_message_at,omitempty"`
+	// SubscriberAlive is the live health of this visor's subscriber
+	// side. Populated by GroupList; left zero by other accessors that
+	// don't need it. See group.Manager.IsSubscriberAlive for semantics.
+	SubscriberAlive bool `json:"subscriber_alive"`
 }
 
 // GroupMessage is one inbound message delivered through the visor's
@@ -119,7 +123,10 @@ func (v *Visor) GroupJoin(args GroupJoinArgs) (GroupInfo, error) {
 	return toInfo(r), nil
 }
 
-// GroupList returns every persisted group on this visor.
+// GroupList returns every persisted group on this visor. The
+// SubscriberAlive field is populated from the live session map —
+// the only API surface where that's needed (the chat-app's /status
+// renders per-group health from this).
 func (v *Visor) GroupList() ([]GroupInfo, error) {
 	mgr := v.groupManager()
 	if mgr == nil {
@@ -131,7 +138,9 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 	}
 	out := make([]GroupInfo, 0, len(all))
 	for _, r := range all {
-		out = append(out, toInfo(r))
+		info := toInfo(r)
+		info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
+		out = append(out, info)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Four scopes, all surfaced during today's 3-agent live coordination session. Bundled on one branch per the "no divergent branches" rule.

### Commit 1 — `fix(skychat/group)`: MarkMessage on inbound (originally PR title)

`group.Manager.MarkMessage` was only called from `SendToGroup`. Inbound paths passed the handler through unchanged so `Record.LastMessageAt` only reflected own sends. `openLocked` now wraps the handler to update LastMessageAt with the message's own `TS`.

### Commit 2 — `polish(skychat)`: TUI + GUI bundle

- TUI: `tuiMutationErr` for picker errors; `convoMessage.SenderPK` for alias-rename-safe routing
- GUI: `/message` absolute URL; `syncHistoryPeers()` + `loadHistoryFor()` server-side history preload; `syncPendingInvites()` post-SSE reconciliation

### Commit 3 — `fix(skychat/cli)`: single-line stdout per message + --raw + --json

Self-test 4439-char 60-line DM confirmed wire is fine; cli text-mode emitted multi-line stdout which agent monitors clipped per-event-display. New default escapes `\n` / `\r` so each chat message = exactly one stdout line. `--raw` for humans, `--json` for NDJSON (mutually exclusive). escape_test.go has 11 sub-cases including a hard invariant that the escaped output never contains a raw line terminator.

### Commit 4 — `fix(skychat)`: stale-conn retry + group auto-reconnect + /status health

Three resilience holes surfaced today:

- **Stale-conn-send loses current message** (`cmd/apps/skychat/commands/skychat.go`): cached `framedConn` dies silently; first WriteFrame fails and operator's message is lost. Now: dial fresh, retry once before reporting failure.
- **Group subscriber stuck at `StatusPending` no auto-retry** (`group/manager.go`): manager.go:328 explicitly punted to "future Reconnect step (not in v1)". We hit this twice today (peers `02f9aa58` + `03d1d78e`), each requiring manual `dmsgpty exec` leave+rejoin to unstick. New: `runReconnectLoop` background goroutine, per-group backoff (10 fails → 5min, 30 fails → 30min), opportunistic retry kicked from `SendToGroup` when relay succeeds. `Session.IsSubscriberAlive()` atomic accessor for the /status hot path.
- **Silent group fanout failures** (statusHandler): no visibility when a subscriber stalls. New: `/status.groups[]` with `{id, name, role, status, members_count, last_message_at, lag_seconds, subscriber_alive}`. `lag_seconds` lets operators alarm on `lag > 600`.

## Test plan
- [x] `go build ./...` clean
- [x] `make lint` — 0 issues
- [x] `go test ./cmd/apps/skychat/... ./cmd/skywire-cli/commands/skychat/...` pass
- [x] Live: peer 02f9aa58 leave+rejoin via dmsgpty unstuck at 23:12Z (matches the failure mode the auto-reconnect addresses)
- [x] Live: peer 03d1d78e leave+rejoin via dmsgpty unstuck at 23:19Z (second instance of same failure mode)
- [ ] Live after rebuild: peer chat-app restarts should auto-recover within one 30s reconnect tick instead of staying stuck indefinitely
- [ ] Live: stale conn after long idle should auto-retry on next send, no manual operator retry

## Out of scope (peer-agreed follow-ups)

- P1 — end-to-end ACK by msg.id (extending #2510/#2511 schema). Eliminates F1+F3+F5+F10 collapses into a single 'undelivered' surface. Peer `02f9aa58` to own in a fresh PR after this lands.
- P3 — unified `listen --all` combining DM + group SSE channels.
- P4 — per-peer `/status.peers[]` detail (analogous to the new `/status.groups[]`).
- P6 — explicit frame-size error + max advertised in `/status`.