### PR TITLE
feat(dmsgscp): scp-over-dmsg utility, port 23, whitelist-gated

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/root.go
+++ b/cmd/skywire-cli/commands/dmsg/root.go
@@ -25,5 +25,6 @@ func init() {
 		curlCmd,
 		ptyCmd,
 		chatCmd,
+		scpCmd,
 	)
 }

--- a/cmd/skywire-cli/commands/dmsg/scp.go
+++ b/cmd/skywire-cli/commands/dmsg/scp.go
@@ -1,0 +1,184 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/scp.go: the
+// `skywire cli dmsg scp` subcommand. Drives the dmsgscp client
+// against either a peer's dmsgscp Host or the local visor's
+// (loopback over its own dmsg PK).
+//
+// Direction is inferred from which argument carries a `PK:`
+// prefix. The PK is 66 hex chars — long enough that the regex
+// can't false-match a normal filename.
+package clidmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgscp"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// scpPKPathRe matches a `PK:path` argument. The PK is a 66-char
+// lowercase-hex string (33 bytes encoded). The path captures
+// everything after the colon (may be empty if the caller intends
+// the rootDir itself, though our Host won't currently accept that).
+var scpPKPathRe = regexp.MustCompile(`^([a-f0-9]{66}):(.*)$`)
+
+var (
+	scpPort    uint16
+	scpTimeout time.Duration
+)
+
+func init() {
+	scpCmd.Flags().SortFlags = false
+	scpCmd.Flags().VarP(&sk, "sk", "s",
+		"secret key for the standalone dmsg client (random if unset)")
+	scpCmd.Flags().Uint16VarP(&scpPort, "port", "p", dmsgscp.DefaultPort,
+		"remote dmsg port for the dmsgscp host")
+	scpCmd.Flags().DurationVarP(&scpTimeout, "timeout", "t", 60*time.Second,
+		"transfer timeout (includes dmsg dial + payload)")
+	scpCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal",
+		"[ debug | warn | error | fatal | panic | trace | info ]")
+	if env := os.Getenv("DMSG_SK"); env != "" {
+		sk.Set(env) //nolint:errcheck,gosec
+	}
+}
+
+var scpCmd = &cobra.Command{
+	Use:   "scp <src> <dst>",
+	Short: "Copy a file between this host and a remote visor over dmsg",
+	Long: `DMSG scp — copy a single file between this machine and a remote
+visor's dmsgscp Host. Exactly one of <src>/<dst> must carry a
+` + "`PK:path`" + ` prefix (66-char hex public key + colon + path).
+
+Examples:
+  skywire cli dmsg scp ./local.bin <pk>:remote.bin       (upload)
+  skywire cli dmsg scp <pk>:remote.bin ./local.bin       (download)
+
+The remote path is interpreted relative to the host's configured
+rootDir — absolute paths and ` + "`..`" + ` are rejected by the wire
+parser. Hard limit on file size: 100 MiB.
+
+Identity: --sk gives the standalone dmsg client a stable PK so the
+host's whitelist can authorize it. Without --sk you get a fresh
+random PK each invocation and the host will reject you unless its
+whitelist has been wide-opened.`,
+	Args:                  cobra.ExactArgs(2),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log := logging.MustGetLogger("dmsg-scp")
+		if logLvl != "" {
+			if lvl, err := logging.LevelFromString(logLvl); err == nil {
+				logging.SetLevel(lvl)
+			}
+		}
+
+		direction, peerPK, remotePath, localPath, err := classifyArgs(args[0], args[1])
+		if err != nil {
+			return err
+		}
+
+		// Resolve our identity. Mirrors the chat command — a fresh
+		// keypair is fine for ad-hoc use but the operator should
+		// use --sk for a stable PK that can be whitelisted.
+		myPK, mySK := resolveChatIdentity(sk)
+		if !cmd.Flags().Changed("sk") && os.Getenv("DMSG_SK") == "" {
+			fmt.Fprintf(os.Stderr,
+				"WARN: ephemeral identity. Your PK is %s — the host's whitelist must accept this PK or the transfer will be rejected. Use --sk / DMSG_SK= for a stable identity.\n\n",
+				myPK)
+		}
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+		ctx, timeoutCancel := context.WithTimeout(ctx, scpTimeout)
+		defer timeoutCancel()
+
+		dmsgC, closeDmsg, err := startDmsgClient(ctx, log, myPK, mySK)
+		if err != nil {
+			return fmt.Errorf("dmsg client: %w", err)
+		}
+		defer closeDmsg()
+
+		c, err := dmsgscp.Dial(ctx, dmsgC, peerPK, scpPort)
+		if err != nil {
+			return err
+		}
+		defer c.Close() //nolint:errcheck
+
+		switch direction {
+		case scpDirDownload:
+			if err := c.Download(remotePath, localPath); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "downloaded %s:%s -> %s\n", peerPK, remotePath, localPath)
+		case scpDirUpload:
+			if err := c.Upload(localPath, remotePath); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "uploaded %s -> %s:%s\n", localPath, peerPK, remotePath)
+		}
+		return nil
+	},
+}
+
+type scpDirection int
+
+const (
+	scpDirDownload scpDirection = iota
+	scpDirUpload
+)
+
+// classifyArgs returns (direction, peerPK, remotePath, localPath).
+// Exactly one of src/dst must carry a `PK:` prefix — both or
+// neither is rejected.
+func classifyArgs(src, dst string) (scpDirection, cipher.PubKey, string, string, error) {
+	srcPK, srcPath, srcHasPK := splitPKPath(src)
+	dstPK, dstPath, dstHasPK := splitPKPath(dst)
+
+	switch {
+	case srcHasPK && dstHasPK:
+		return 0, cipher.PubKey{}, "", "",
+			errors.New("dmsg scp: only one of <src>/<dst> may carry a PK: prefix")
+	case !srcHasPK && !dstHasPK:
+		return 0, cipher.PubKey{}, "", "",
+			errors.New("dmsg scp: exactly one of <src>/<dst> must carry a PK: prefix")
+	case srcHasPK:
+		// PK on src = download.
+		return scpDirDownload, srcPK, srcPath, dst, nil
+	default:
+		// PK on dst = upload.
+		return scpDirUpload, dstPK, dstPath, src, nil
+	}
+}
+
+// splitPKPath splits a `pkhex:path` argument. Returns (pk, path, true)
+// on a match, or (_, _, false) if the argument is a plain local path.
+// A leading `PK:` with the right shape is required — we don't fall
+// back to "looks like a hex string" heuristics.
+func splitPKPath(s string) (cipher.PubKey, string, bool) {
+	m := scpPKPathRe.FindStringSubmatch(s)
+	if m == nil {
+		return cipher.PubKey{}, "", false
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(m[1]); err != nil {
+		// PK validation failed — surface as "no match" rather than
+		// erroring here; the regex should have caught any bad shape
+		// but the underlying cipher.PubKey.Set may add e.g. tweak
+		// checks that the regex doesn't.
+		return cipher.PubKey{}, "", false
+	}
+	// Strip any leading "./" the user might have typed defensively.
+	path := strings.TrimPrefix(m[2], "./")
+	return pk, path, true
+}

--- a/pkg/dmsg/dmsgscp/client.go
+++ b/pkg/dmsg/dmsgscp/client.go
@@ -1,0 +1,216 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/client.go: the dialing side of
+// scp-over-dmsg. A Client wraps a single dmsg.Stream and exposes
+// Download / Upload methods that drive the same wire framing the
+// Host serves.
+//
+// A Client is single-use by design: each transfer establishes a
+// fresh dmsg stream, runs the framing end-to-end, and closes. This
+// keeps the failure model simple — half-finished transfers can't
+// pollute a long-lived stream — and matches how the CLI invokes it.
+package dmsgscp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// Client is a single-transfer dmsgscp client. Build one via Dial.
+type Client struct {
+	conn   *dmsg.Stream
+	reader *bufio.Reader
+	remote cipher.PubKey
+}
+
+// Dial opens a dmsg.Stream to (rPK:port) and returns a Client
+// ready to drive Upload/Download. The caller must Close the
+// Client when done — Upload/Download don't close on success so the
+// caller can chain (in practice, every CLI path closes immediately).
+func Dial(ctx context.Context, dmsgC *dmsg.Client, rPK cipher.PubKey, port uint16) (*Client, error) {
+	if dmsgC == nil {
+		return nil, errors.New("dmsgscp: nil dmsg client")
+	}
+	addr := dmsg.Addr{PK: rPK, Port: port}
+	stream, err := dmsgC.DialStream(ctx, addr)
+	if err != nil {
+		return nil, fmt.Errorf("dmsgscp: dial %s:%d: %w", rPK, port, err)
+	}
+	return &Client{
+		conn:   stream,
+		reader: bufio.NewReader(stream),
+		remote: rPK,
+	}, nil
+}
+
+// Close releases the underlying stream.
+func (c *Client) Close() error {
+	if c.conn == nil {
+		return nil
+	}
+	err := c.conn.Close()
+	c.conn = nil
+	return err
+}
+
+// Download pulls a file from the remote host's rootDir at
+// remotePath and writes it to localPath. Existing files at
+// localPath are overwritten.
+func (c *Client) Download(remotePath, localPath string) error {
+	if c.conn == nil {
+		return errors.New("dmsgscp: client closed")
+	}
+
+	// Step 1: send role line.
+	if _, err := fmt.Fprintf(c.conn, "%s %s\n", RoleSource, remotePath); err != nil {
+		return fmt.Errorf("dmsgscp: write role line: %w", err)
+	}
+
+	// Step 2: read the C-record from the host.
+	hdr, err := ReadHeader(c.reader)
+	if err != nil {
+		return fmt.Errorf("dmsgscp: read header: %w", err)
+	}
+	if hdr.Type == RecordDirStart || hdr.Type == RecordDirEnd {
+		return ErrDirNotSupported
+	}
+	if hdr.Type != RecordFile {
+		return fmt.Errorf("dmsgscp: unexpected record type %c", hdr.Type)
+	}
+
+	// Step 3: ack the header.
+	if err := WriteAck(c.conn); err != nil {
+		return fmt.Errorf("dmsgscp: ack header: %w", err)
+	}
+
+	// Step 4: open destination, then read exactly Size bytes.
+	// Mode comes from the wire, masked to 0700 (umask-style) — same
+	// hardening as the host's SINK path.
+	mode := hdr.Mode & 0700
+	if mode == 0 {
+		mode = 0600
+	}
+	// Ensure the parent directory exists so callers can drop into
+	// an arbitrary path without pre-creating.
+	if dir := filepath.Dir(localPath); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return fmt.Errorf("dmsgscp: mkdir parent: %w", err)
+		}
+	}
+	f, err := os.OpenFile(localPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("dmsgscp: open local file: %w", err)
+	}
+
+	cleanup := func(success bool) error {
+		closeErr := f.Close()
+		if !success {
+			if rerr := os.Remove(localPath); rerr != nil && !os.IsNotExist(rerr) {
+				return fmt.Errorf("close=%v, remove=%w", closeErr, rerr)
+			}
+		}
+		return closeErr
+	}
+
+	if _, err := io.CopyN(f, c.reader, hdr.Size); err != nil {
+		_ = cleanup(false) //nolint:errcheck
+		return fmt.Errorf("dmsgscp: read payload: %w", err)
+	}
+
+	// Step 5: read the host's trailing ack on the payload.
+	if msg, err := ReadAck(c.reader); err != nil {
+		_ = cleanup(false) //nolint:errcheck
+		if len(msg) > 0 {
+			return fmt.Errorf("dmsgscp: peer error: %s: %w", msg, err)
+		}
+		return fmt.Errorf("dmsgscp: read trailing ack: %w", err)
+	}
+
+	// Step 6: send our final ack.
+	if err := WriteAck(c.conn); err != nil {
+		_ = cleanup(false) //nolint:errcheck
+		return fmt.Errorf("dmsgscp: final ack: %w", err)
+	}
+
+	return cleanup(true)
+}
+
+// Upload pushes localPath to the remote host at remotePath.
+// remotePath is interpreted relative to the host's rootDir; the
+// basename of remotePath becomes the C-record's name.
+func (c *Client) Upload(localPath, remotePath string) error {
+	if c.conn == nil {
+		return errors.New("dmsgscp: client closed")
+	}
+
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return fmt.Errorf("dmsgscp: stat local: %w", err)
+	}
+	if info.IsDir() {
+		return errors.New("dmsgscp: directory upload not supported in v1")
+	}
+	if info.Size() > MaxFileSize {
+		return fmt.Errorf("dmsgscp: local file exceeds %d-byte cap", MaxFileSize)
+	}
+
+	// Step 1: send role line.
+	if _, err := fmt.Fprintf(c.conn, "%s %s\n", RoleSink, remotePath); err != nil {
+		return fmt.Errorf("dmsgscp: write role line: %w", err)
+	}
+
+	// Step 2: wait for the host's ready ack.
+	if msg, err := ReadAck(c.reader); err != nil {
+		if len(msg) > 0 {
+			return fmt.Errorf("dmsgscp: peer error: %s: %w", msg, err)
+		}
+		return fmt.Errorf("dmsgscp: ready ack: %w", err)
+	}
+
+	// Step 3: send C-record. Basename only — the destination
+	// directory came from the role line.
+	base := filepath.Base(remotePath)
+	if err := WriteFileHeader(c.conn, info.Mode(), info.Size(), base); err != nil {
+		return fmt.Errorf("dmsgscp: write header: %w", err)
+	}
+
+	// Step 4: wait for header ack.
+	if msg, err := ReadAck(c.reader); err != nil {
+		if len(msg) > 0 {
+			return fmt.Errorf("dmsgscp: peer error: %s: %w", msg, err)
+		}
+		return fmt.Errorf("dmsgscp: header ack: %w", err)
+	}
+
+	// Step 5: stream the payload.
+	f, err := os.Open(localPath) //nolint:gosec // path supplied by local caller
+	if err != nil {
+		return fmt.Errorf("dmsgscp: open local file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	if _, err := io.CopyN(c.conn, f, info.Size()); err != nil {
+		return fmt.Errorf("dmsgscp: write payload: %w", err)
+	}
+
+	// Step 6: send trailing ack.
+	if err := WriteAck(c.conn); err != nil {
+		return fmt.Errorf("dmsgscp: write trailing ack: %w", err)
+	}
+
+	// Step 7: wait for the host's final ack.
+	if msg, err := ReadAck(c.reader); err != nil {
+		if len(msg) > 0 {
+			return fmt.Errorf("dmsgscp: peer error: %s: %w", msg, err)
+		}
+		return fmt.Errorf("dmsgscp: final ack: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/dmsg/dmsgscp/const.go
+++ b/pkg/dmsg/dmsgscp/const.go
@@ -1,0 +1,66 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/const.go: shared constants for the
+// scp-over-dmsg utility — wire-protocol framing bytes, default
+// dmsg port, and the configurable safety caps the host enforces on
+// every transfer.
+package dmsgscp
+
+// Dmsg-port constants. We pick port 23 deliberately — adjacent to
+// dmsgpty's port 22 — so the two services occupy a contiguous,
+// easily-recognized pair on every visor that runs them.
+const (
+	// DefaultPort is the default dmsg port the dmsgscp Host listens
+	// on. Operators may override via config.
+	DefaultPort = uint16(23)
+)
+
+// Wire-protocol framing bytes. The protocol is a stripped-down
+// re-implementation of OpenSSH's scp wire format (the "rcp" subset)
+// — a single ack byte after every header and every payload, and an
+// error prefix for warnings vs fatal aborts.
+const (
+	// AckByte is the single-byte acknowledgement the receiver sends
+	// after a valid header or completed payload. Zero by design so a
+	// raw read of \x00 from the peer means "go ahead".
+	AckByte byte = 0x00
+	// WarnPrefix marks a non-fatal warning line — sender or receiver
+	// may continue after consuming the line.
+	WarnPrefix byte = 0x01
+	// FatalPrefix marks a fatal error line — the recipient must abort
+	// the transfer once it consumes the line.
+	FatalPrefix byte = 0x02
+)
+
+// Role markers — the first line written on a freshly-dialed stream
+// tells the Host whether the caller wants to pull (SOURCE) or push
+// (SINK). SSH's classic role flag (`-f` / `-t` on the remote scp
+// binary) doesn't map cleanly to a non-shell daemon, so we use an
+// explicit line. The format is `<ROLE> <path>\n` with ROLE in
+// `SOURCE` or `SINK` and `path` a relative path under the host's
+// rootDir.
+const (
+	// RoleSource is sent by a client requesting a download — the
+	// host plays the "source" role (reads file from disk, writes
+	// to wire).
+	RoleSource = "SOURCE"
+	// RoleSink is sent by a client requesting an upload — the host
+	// plays the "sink" role (reads payload from wire, writes to disk).
+	RoleSink = "SINK"
+)
+
+// Safety caps. These are hard limits enforced by both the protocol
+// parser and the Host/Client serve loops. v1 is deliberately
+// conservative — operators wanting larger transfers can fall back
+// to a chunked workflow until v2 lifts the cap.
+const (
+	// MaxFileSize is the hard cap on a single file transfer (100 MiB).
+	// Sender-claimed sizes above this are rejected by the parser.
+	MaxFileSize int64 = 100 * 1024 * 1024
+	// MaxNameLen caps the basename portion of a `C` or `D` header.
+	// Long enough for any reasonable filename, short enough that a
+	// malicious peer can't exhaust memory with a multi-megabyte
+	// header line.
+	MaxNameLen = 255
+	// MaxHeaderLen caps the entire header line (`C<mode> <size> <name>\n`).
+	// 1 KiB is well above MaxNameLen + the fixed fields.
+	MaxHeaderLen = 1024
+)

--- a/pkg/dmsg/dmsgscp/host.go
+++ b/pkg/dmsg/dmsgscp/host.go
@@ -1,0 +1,425 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/host.go: the listening side of
+// scp-over-dmsg. Host accepts dmsg streams on its configured port,
+// authorizes the remote PK against an injected Whitelist, reads the
+// first line to discover the role the caller wants the host to play
+// (SOURCE = caller downloads, SINK = caller uploads), then drives
+// the framing accordingly.
+//
+// The structure deliberately mirrors pkg/dmsg/dmsgpty/host.go — same
+// accept loop, same temporary-error retry, same close hooks. The
+// big difference is the dispatch: dmsgpty multiplexes RPC endpoints
+// over a single yamux-ish mux on each stream; dmsgscp uses each
+// stream for a single file transfer end-to-end.
+package dmsgscp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Whitelist is an alias for dmsgpty.Whitelist so operators can pass
+// the same whitelist instance to both daemons without re-importing.
+// We deliberately don't define a new interface here — the contract
+// is identical and the indirection would just confuse callers.
+type Whitelist = dmsgpty.Whitelist
+
+// Host is the listening side of dmsgscp.
+type Host struct {
+	dmsgC   *dmsg.Client
+	wl      Whitelist
+	rootDir string
+
+	connN int32
+}
+
+// NewHost creates a new dmsgscp Host with the given dmsg client,
+// whitelist, and filesystem root. rootDir is created with 0700
+// permissions if it does not already exist — the directory is the
+// effective chroot for every served transfer.
+func NewHost(dmsgC *dmsg.Client, wl Whitelist, rootDir string) (*Host, error) {
+	if dmsgC == nil {
+		return nil, errors.New("dmsgscp: nil dmsg client")
+	}
+	if wl == nil {
+		return nil, errors.New("dmsgscp: nil whitelist")
+	}
+	if rootDir == "" {
+		return nil, errors.New("dmsgscp: empty root directory")
+	}
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("dmsgscp: resolve root dir: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0700); err != nil {
+		return nil, fmt.Errorf("dmsgscp: create root dir: %w", err)
+	}
+	return &Host{
+		dmsgC:   dmsgC,
+		wl:      wl,
+		rootDir: absRoot,
+	}, nil
+}
+
+// RootDir returns the filesystem root the host serves from.
+func (h *Host) RootDir() string { return h.rootDir }
+
+// ListenAndServe binds the configured dmsg port and serves transfers
+// until ctx is canceled or the listener fails permanently. The
+// signature and accept-loop pattern intentionally mirror
+// dmsgpty.Host.ListenAndServe — see that function's comments for
+// the rationale on the temporary-error sleep and the close-pipe
+// classification.
+func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	lis, err := h.dmsgC.Listen(port)
+	if err != nil {
+		return fmt.Errorf("dmsgscp: listen on dmsg port %d: %w", port, err)
+	}
+
+	log := h.logger()
+	log.WithField("port", port).WithField("root", h.rootDir).Debug("dmsgscp listening.")
+
+	go func() {
+		<-ctx.Done()
+		log.WithError(lis.Close()).Debug("dmsgscp listener closed.")
+	}()
+
+	for {
+		stream, err := lis.AcceptStream()
+		if err != nil {
+			log := log.WithError(err)
+			// Same temporary-error treatment as dmsgpty.
+			if err, ok := err.(net.Error); ok && err.Temporary() { //nolint
+				log.Warn("dmsgscp: temporary accept error, continuing...")
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			if errors.Is(err, io.ErrClosedPipe) ||
+				errors.Is(err, dmsg.ErrEntityClosed) ||
+				errors.Is(err, net.ErrClosed) {
+				log.Debug("dmsgscp: cleanly stopped serving.")
+				return nil
+			}
+			log.Error("dmsgscp: permanent accept error.")
+			return err
+		}
+
+		rPK := stream.RawRemoteAddr().PK
+		slog := log.WithField("remote_pk", rPK.String())
+
+		if !h.authorize(slog, rPK) {
+			// Tell the peer why we're hanging up so the client
+			// surface gets a useful error rather than a bare EOF.
+			if werr := WriteFatal(stream, "dmsg stream rejected by whitelist"); werr != nil {
+				slog.WithError(werr).Debug("dmsgscp: failed to write rejection.")
+			}
+			if cerr := stream.Close(); cerr != nil {
+				slog.WithError(cerr).Debug("dmsgscp: error closing rejected stream.")
+			}
+			continue
+		}
+
+		slog = slog.WithField("conn_id", atomic.AddInt32(&h.connN, 1))
+		slog.Debug("dmsgscp: stream accepted.")
+		go func(s net.Conn, l logrus.FieldLogger) {
+			h.serve(ctx, l, s)
+			atomic.AddInt32(&h.connN, -1)
+		}(stream, slog)
+	}
+}
+
+// authorize mirrors the dmsgpty implementation byte-for-byte so the
+// audit story stays identical between the two daemons.
+func (h *Host) authorize(log logrus.FieldLogger, rPK cipher.PubKey) bool {
+	ok, err := h.wl.Get(rPK)
+	if err != nil {
+		log.WithError(err).Error("dmsgscp: whitelist error.")
+		return false
+	}
+	if !ok {
+		log.Warn("dmsgscp: public key rejected by whitelist.")
+		return false
+	}
+	return true
+}
+
+// serve handles one accepted stream end-to-end. It reads the role
+// line, dispatches to serveSource (host reads file, sends to client)
+// or serveSink (host receives file from client), and tears the
+// stream down on exit. Any unexpected I/O failure is logged at debug
+// — the client side will surface its own error.
+func (h *Host) serve(ctx context.Context, log logrus.FieldLogger, conn net.Conn) {
+	defer func() {
+		if err := conn.Close(); err != nil {
+			log.WithError(err).Debug("dmsgscp: stream close error.")
+		}
+	}()
+
+	r := bufio.NewReader(conn)
+	line, err := readRoleLine(r)
+	if err != nil {
+		log.WithError(err).Debug("dmsgscp: failed to read role line.")
+		_ = WriteFatal(conn, "malformed role line") //nolint:errcheck
+		return
+	}
+
+	role, rawPath, err := parseRoleLine(line)
+	if err != nil {
+		log.WithError(err).WithField("line", line).Warn("dmsgscp: bad role line.")
+		_ = WriteFatal(conn, err.Error()) //nolint:errcheck
+		return
+	}
+
+	switch role {
+	case RoleSource:
+		h.serveSource(ctx, log, conn, r, rawPath)
+	case RoleSink:
+		h.serveSink(ctx, log, conn, r, rawPath)
+	default:
+		// Already filtered by parseRoleLine, but keep the switch
+		// total so a future addition gets caught.
+		_ = WriteFatal(conn, "unknown role") //nolint:errcheck
+	}
+}
+
+// serveSource handles a SOURCE request — the host plays the role of
+// the file sender. The wire flow is:
+//
+//  1. peer dialed and sent  `SOURCE <path>\n`
+//  2. host writes `C<mode> <size> <name>\n`
+//  3. host reads ack \x00
+//  4. host writes <size> bytes
+//  5. host writes ack \x00
+//  6. host reads ack \x00
+//
+// Any failure path writes a fatal-prefix line so the client gets a
+// human-readable reason, then returns.
+func (h *Host) serveSource(_ context.Context, log logrus.FieldLogger, conn net.Conn, r *bufio.Reader, name string) {
+	safePath, err := ResolveSafePath(h.rootDir, name)
+	if err != nil {
+		log.WithError(err).WithField("name", name).Warn("dmsgscp: path resolution failed.")
+		_ = WriteFatal(conn, "bad path: "+err.Error()) //nolint:errcheck
+		return
+	}
+
+	info, err := os.Stat(safePath)
+	if err != nil {
+		log.WithError(err).Debug("dmsgscp: stat failed.")
+		_ = WriteFatal(conn, "stat: "+err.Error()) //nolint:errcheck
+		return
+	}
+	if info.IsDir() {
+		_ = WriteFatal(conn, "directory transfers not supported") //nolint:errcheck
+		return
+	}
+	if info.Size() > MaxFileSize {
+		_ = WriteFatal(conn, fmt.Sprintf("file exceeds %d-byte cap", MaxFileSize)) //nolint:errcheck
+		return
+	}
+
+	f, err := os.Open(safePath) //nolint:gosec // path validated by ResolveSafePath
+	if err != nil {
+		_ = WriteFatal(conn, "open: "+err.Error()) //nolint:errcheck
+		return
+	}
+	defer f.Close() //nolint:errcheck
+
+	if err := WriteFileHeader(conn, info.Mode(), info.Size(), filepath.Base(name)); err != nil {
+		log.WithError(err).Debug("dmsgscp: WriteFileHeader failed.")
+		return
+	}
+
+	if msg, err := ReadAck(r); err != nil {
+		log.WithError(err).WithField("msg", string(msg)).Debug("dmsgscp: peer did not ack header.")
+		return
+	}
+
+	// io.CopyN exactly the claimed size — guards against runaway
+	// writes if Stat lied between the header write and the read.
+	if _, err := io.CopyN(conn, f, info.Size()); err != nil {
+		log.WithError(err).Debug("dmsgscp: payload copy failed.")
+		return
+	}
+
+	if err := WriteAck(conn); err != nil {
+		log.WithError(err).Debug("dmsgscp: final ack write failed.")
+		return
+	}
+
+	if msg, err := ReadAck(r); err != nil {
+		log.WithError(err).WithField("msg", string(msg)).Debug("dmsgscp: peer did not ack payload.")
+		return
+	}
+
+	log.WithField("path", safePath).WithField("bytes", info.Size()).Info("dmsgscp: SOURCE complete.")
+}
+
+// serveSink handles a SINK request — the host plays the role of the
+// file receiver. The wire flow is:
+//
+//  1. peer dialed and sent  `SINK <path>\n`
+//  2. host writes ack \x00 (ready)
+//  3. peer writes `C<mode> <size> <name>\n`
+//  4. host writes ack \x00
+//  5. peer writes <size> bytes
+//  6. peer writes ack \x00
+//  7. host writes ack \x00
+//
+// The `<name>` in the C-record is treated as the basename only — the
+// destination directory comes from the SINK path. This matches the
+// rcp/scp convention: the caller specifies the destination on dial.
+func (h *Host) serveSink(_ context.Context, log logrus.FieldLogger, conn net.Conn, r *bufio.Reader, name string) {
+	safePath, err := ResolveSafePath(h.rootDir, name)
+	if err != nil {
+		log.WithError(err).WithField("name", name).Warn("dmsgscp: path resolution failed.")
+		_ = WriteFatal(conn, "bad path: "+err.Error()) //nolint:errcheck
+		return
+	}
+
+	// Ensure the parent dir exists so a SINK request can place files
+	// in arbitrary depth under rootDir without the operator having
+	// to pre-create the tree.
+	if err := os.MkdirAll(filepath.Dir(safePath), 0700); err != nil {
+		_ = WriteFatal(conn, "mkdir: "+err.Error()) //nolint:errcheck
+		return
+	}
+
+	// Tell the peer we're ready to read the C-record.
+	if err := WriteAck(conn); err != nil {
+		log.WithError(err).Debug("dmsgscp: ready-ack write failed.")
+		return
+	}
+
+	hdr, err := ReadHeader(r)
+	if err != nil {
+		log.WithError(err).Debug("dmsgscp: ReadHeader failed.")
+		_ = WriteFatal(conn, "bad header: "+err.Error()) //nolint:errcheck
+		return
+	}
+	if hdr.Type == RecordDirStart || hdr.Type == RecordDirEnd {
+		_ = WriteFatal(conn, ErrDirNotSupported.Error()) //nolint:errcheck
+		return
+	}
+	if hdr.Type != RecordFile {
+		_ = WriteFatal(conn, "unexpected record type") //nolint:errcheck
+		return
+	}
+
+	if err := WriteAck(conn); err != nil {
+		log.WithError(err).Debug("dmsgscp: header-ack write failed.")
+		return
+	}
+
+	// Open the destination O_TRUNC so a repeat upload overwrites
+	// cleanly. Permissions come from the wire-supplied mode masked
+	// by 0700 (umask-style) so we never grant world access via a
+	// malicious upload.
+	mode := hdr.Mode & 0700
+	if mode == 0 {
+		mode = 0600
+	}
+	f, err := os.OpenFile(safePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode) //nolint:gosec // path validated
+	if err != nil {
+		_ = WriteFatal(conn, "open: "+err.Error()) //nolint:errcheck
+		return
+	}
+	// Close hooks here matter — io.CopyN below can fail mid-write
+	// and we want the partial file to be removed rather than left
+	// as a confusing artifact.
+	cleanup := func(success bool) {
+		if cerr := f.Close(); cerr != nil {
+			log.WithError(cerr).Debug("dmsgscp: file close error.")
+		}
+		if !success {
+			if rerr := os.Remove(safePath); rerr != nil && !os.IsNotExist(rerr) {
+				log.WithError(rerr).Debug("dmsgscp: failed to remove partial upload.")
+			}
+		}
+	}
+
+	if _, err := io.CopyN(f, r, hdr.Size); err != nil {
+		log.WithError(err).Debug("dmsgscp: payload copy failed.")
+		cleanup(false)
+		return
+	}
+
+	// Read the sender's trailing payload ack.
+	if msg, err := ReadAck(r); err != nil {
+		log.WithError(err).WithField("msg", string(msg)).Debug("dmsgscp: peer did not send trailing ack.")
+		cleanup(false)
+		return
+	}
+
+	if err := WriteAck(conn); err != nil {
+		log.WithError(err).Debug("dmsgscp: final ack write failed.")
+		cleanup(false)
+		return
+	}
+
+	cleanup(true)
+	log.WithField("path", safePath).WithField("bytes", hdr.Size).Info("dmsgscp: SINK complete.")
+}
+
+// readRoleLine reads the first line from a freshly-dialed stream.
+// We use a bounded line length: a malicious peer could otherwise
+// stall the accept loop by trickling header bytes forever. The
+// 4 KiB default bufio buffer is more than enough — a role line is
+// `SOURCE ` plus a path bounded by MaxNameLen.
+func readRoleLine(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	if len(line) > MaxHeaderLen {
+		return "", ErrHeaderTooLong
+	}
+	// Strip trailing \r\n / \n robustly.
+	line = strings.TrimRight(line, "\r\n")
+	return line, nil
+}
+
+// parseRoleLine splits `<ROLE> <path>` and returns the canonical
+// role + raw path. Returns a descriptive error suitable for sending
+// back over the wire on failure.
+func parseRoleLine(line string) (role, path string, err error) {
+	// SplitN(2) so a path containing spaces survives.
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) != 2 {
+		return "", "", errors.New("expected `SOURCE <path>` or `SINK <path>`")
+	}
+	role = parts[0]
+	path = parts[1]
+	if role != RoleSource && role != RoleSink {
+		return "", "", fmt.Errorf("unknown role %q", role)
+	}
+	if path == "" {
+		return "", "", errors.New("empty path")
+	}
+	return role, path, nil
+}
+
+// logger returns the field-logger used for all server-side log lines.
+func (h *Host) logger() logrus.FieldLogger {
+	if ml := h.dmsgC.MasterLogger(); ml != nil {
+		return ml.PackageLogger("dmsg_scp")
+	}
+	return logging.MustGetLogger("dmsg_scp")
+}

--- a/pkg/dmsg/dmsgscp/protocol.go
+++ b/pkg/dmsg/dmsgscp/protocol.go
@@ -1,0 +1,359 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/protocol.go: wire-protocol
+// header parsing + serialization, plus the tiny ack helpers that
+// drive the framing. The protocol mirrors OpenSSH's scp on-wire
+// format — a single header line per record, a single ack byte after
+// every header and every payload, and an in-band error prefix
+// (\x01 warning, \x02 fatal) for human-readable failures.
+//
+// We only implement records the dmsgscp Host/Client actually use:
+//
+//	C<octal-mode> <size> <name>\n  - file record (followed by `size`
+//	                                 bytes of payload + ack)
+//	D<octal-mode> 0 <dirname>\n    - start of recursion (v1 rejects)
+//	E\n                            - end of recursion (v1 rejects)
+//
+// Path safety: the parser rejects any `..` component, absolute
+// paths, embedded NUL/newline, and names beyond MaxNameLen — these
+// are all explicit traversal/DoS guards rather than passive checks.
+// Callers still resolve the final path against the host's rootDir
+// via ResolveSafePath before touching the filesystem.
+package dmsgscp
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// RecordType identifies a parsed protocol record.
+type RecordType byte
+
+// Supported record types.
+const (
+	// RecordFile is a `C` (file) record.
+	RecordFile RecordType = 'C'
+	// RecordDirStart is a `D` (start-of-directory) record. v1 rejects.
+	RecordDirStart RecordType = 'D'
+	// RecordDirEnd is an `E` (end-of-directory) record. v1 rejects.
+	RecordDirEnd RecordType = 'E'
+)
+
+// Header is one parsed protocol record. For RecordDirEnd, only Type
+// is meaningful; Mode/Size/Name are zero.
+type Header struct {
+	Type RecordType
+	Mode os.FileMode // permission bits parsed from the octal field
+	Size int64       // payload size in bytes (0 for D/E)
+	Name string      // basename, validated against traversal
+}
+
+// Sentinel parser errors. Callers can use errors.Is to react to a
+// specific failure mode (e.g. send a fatal-prefix line on the wire
+// after ErrPathTraversal).
+var (
+	// ErrShortHeader signals a header line shorter than the minimum
+	// valid form (`C0 0 x`).
+	ErrShortHeader = errors.New("dmsgscp: header too short")
+	// ErrHeaderTooLong signals a header line above MaxHeaderLen.
+	ErrHeaderTooLong = errors.New("dmsgscp: header line exceeds max length")
+	// ErrUnknownRecord signals a leading byte we don't recognize.
+	ErrUnknownRecord = errors.New("dmsgscp: unknown record type")
+	// ErrBadMode signals an unparseable octal mode field.
+	ErrBadMode = errors.New("dmsgscp: bad octal mode")
+	// ErrBadSize signals an unparseable or out-of-range size field.
+	ErrBadSize = errors.New("dmsgscp: bad size")
+	// ErrSizeCap signals a size above MaxFileSize.
+	ErrSizeCap = errors.New("dmsgscp: file size exceeds cap")
+	// ErrEmptyName signals a missing or whitespace-only name.
+	ErrEmptyName = errors.New("dmsgscp: empty name")
+	// ErrNameTooLong signals a name above MaxNameLen.
+	ErrNameTooLong = errors.New("dmsgscp: name exceeds max length")
+	// ErrPathTraversal signals a name containing `..` or absolute paths.
+	ErrPathTraversal = errors.New("dmsgscp: name contains path traversal")
+	// ErrInvalidName signals a name with NUL or newline bytes.
+	ErrInvalidName = errors.New("dmsgscp: name contains invalid characters")
+	// ErrDirNotSupported is returned when a D/E record arrives — v1
+	// is files-only.
+	ErrDirNotSupported = errors.New("dmsgscp: directory transfer not implemented in v1")
+)
+
+// ReadHeader reads one header record from r. It consumes up to (and
+// including) the trailing newline. ErrHeaderTooLong is returned if
+// the line would exceed MaxHeaderLen — the caller should treat that
+// as fatal and abort the stream.
+//
+// io.EOF is returned verbatim when the peer cleanly closes before
+// sending a header — callers distinguish "no more records" from a
+// malformed record by checking for io.EOF.
+func ReadHeader(r *bufio.Reader) (Header, error) {
+	// ReadSlice rather than ReadString so we can enforce the cap
+	// before allocating a string. bufio.Reader.ReadSlice returns
+	// bufio.ErrBufferFull if the line exceeds the buffer; we size
+	// the buffer at the call site (NewReader uses 4 KiB default,
+	// well above MaxHeaderLen) so the cap path triggers via our
+	// own length check first.
+	line, err := r.ReadSlice('\n')
+	if err != nil {
+		// A line longer than the buffer surfaces as
+		// bufio.ErrBufferFull — translate to our cap error so
+		// callers get a consistent classification.
+		if errors.Is(err, bufio.ErrBufferFull) {
+			return Header{}, ErrHeaderTooLong
+		}
+		// EOF / unexpected EOF / closed pipe propagate verbatim.
+		return Header{}, err
+	}
+	if len(line) > MaxHeaderLen {
+		return Header{}, ErrHeaderTooLong
+	}
+	// Strip trailing \n (and optional \r for robustness against
+	// peers that CRLF their wire).
+	line = trimTrailingNewline(line)
+	if len(line) == 0 {
+		return Header{}, ErrShortHeader
+	}
+
+	switch RecordType(line[0]) {
+	case RecordDirEnd:
+		// `E` is the entire line; anything after is malformed.
+		if len(line) != 1 {
+			return Header{}, ErrUnknownRecord
+		}
+		return Header{Type: RecordDirEnd}, nil
+
+	case RecordFile, RecordDirStart:
+		return parseFileOrDir(RecordType(line[0]), line[1:])
+
+	default:
+		return Header{}, fmt.Errorf("%w: %q", ErrUnknownRecord, string(line[0]))
+	}
+}
+
+// parseFileOrDir parses the body of a C or D record — the part
+// AFTER the leading type byte. Format: `<octal-mode> <size> <name>`.
+func parseFileOrDir(typ RecordType, body []byte) (Header, error) {
+	// SplitN(3) so a name containing spaces — which scp wire format
+	// does allow — survives intact. Real scp uses a single space
+	// between the fixed fields and the name; the name itself can
+	// contain spaces.
+	parts := strings.SplitN(string(body), " ", 3)
+	if len(parts) != 3 {
+		return Header{}, ErrShortHeader
+	}
+
+	// Mode: octal, leading zero by convention. ParseUint handles
+	// both "0644" and "644" interchangeably with base 8.
+	mode64, err := strconv.ParseUint(parts[0], 8, 32)
+	if err != nil {
+		return Header{}, fmt.Errorf("%w: %q", ErrBadMode, parts[0])
+	}
+
+	// Size: decimal, non-negative.
+	size, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return Header{}, fmt.Errorf("%w: %q", ErrBadSize, parts[1])
+	}
+	if size < 0 {
+		return Header{}, fmt.Errorf("%w: negative", ErrBadSize)
+	}
+	if size > MaxFileSize {
+		return Header{}, fmt.Errorf("%w: %d > %d", ErrSizeCap, size, MaxFileSize)
+	}
+
+	name := parts[2]
+	if err := validateName(name); err != nil {
+		return Header{}, err
+	}
+
+	// `D` records always carry size 0 in real scp — enforce that so
+	// a malicious peer can't smuggle a non-zero size field through.
+	if typ == RecordDirStart && size != 0 {
+		return Header{}, fmt.Errorf("%w: D-record size must be 0", ErrBadSize)
+	}
+
+	return Header{
+		Type: typ,
+		// FileMode masks to the permission bits — we deliberately
+		// drop setuid/setgid/sticky from incoming records; the host
+		// applies an additional umask when creating the file.
+		Mode: os.FileMode(mode64) & os.ModePerm,
+		Size: size,
+		Name: name,
+	}, nil
+}
+
+// validateName enforces the path-safety rules on a header name.
+// Returns one of the sentinel errors so callers can switch on the
+// failure mode if needed.
+func validateName(name string) error {
+	if name == "" {
+		return ErrEmptyName
+	}
+	if len(name) > MaxNameLen {
+		return ErrNameTooLong
+	}
+	// NUL and newline aren't legal in unix filenames anyway and
+	// would let a peer smuggle extra header lines or terminate
+	// strings early in C-string-based downstream code.
+	if strings.ContainsAny(name, "\x00\n\r") {
+		return ErrInvalidName
+	}
+	// Absolute paths and any `..` component must be rejected
+	// regardless of OS — the host serves a chroot-style rootDir
+	// and the wire format never describes paths above it.
+	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, `\`) {
+		return ErrPathTraversal
+	}
+	// Split on both separators so a Windows-style backslash path
+	// is caught even when running on Linux.
+	for _, sep := range []string{"/", `\`} {
+		for _, p := range strings.Split(name, sep) {
+			if p == ".." {
+				return ErrPathTraversal
+			}
+		}
+	}
+	return nil
+}
+
+// WriteFileHeader emits a `C<mode> <size> <name>\n` line.
+func WriteFileHeader(w io.Writer, mode os.FileMode, size int64, name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	if size < 0 {
+		return fmt.Errorf("%w: negative", ErrBadSize)
+	}
+	if size > MaxFileSize {
+		return fmt.Errorf("%w: %d > %d", ErrSizeCap, size, MaxFileSize)
+	}
+	// Mode is masked to the permission bits — same hardening we
+	// apply on the read side.
+	line := fmt.Sprintf("C%04o %d %s\n", uint32(mode&os.ModePerm), size, name)
+	if len(line) > MaxHeaderLen {
+		return ErrHeaderTooLong
+	}
+	_, err := io.WriteString(w, line)
+	return err
+}
+
+// WriteAck writes a single ack byte (\x00) to the peer.
+func WriteAck(w io.Writer) error {
+	_, err := w.Write([]byte{AckByte})
+	return err
+}
+
+// ReadAck reads a single byte from the peer and returns:
+//
+//	(nil, nil)              on a clean ack (\x00)
+//	(warnMsg, nil)          on a warning line (\x01 + msg + \n) — the
+//	                        caller may continue but should surface
+//	                        the message
+//	(fatalMsg, errFatal)    on a fatal line (\x02 + msg + \n) — the
+//	                        caller must abort
+//
+// On I/O error it returns (nil, err).
+func ReadAck(r *bufio.Reader) ([]byte, error) {
+	b, err := r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	switch b {
+	case AckByte:
+		return nil, nil
+	case WarnPrefix, FatalPrefix:
+		// Read the rest of the line (up to and including \n).
+		// ReadSlice is bounded by the buffer size; we accept any
+		// length here because the peer is reporting an error and
+		// truncating its message would obscure debugging.
+		line, lerr := r.ReadBytes('\n')
+		// Strip trailing newline for cleaner display.
+		line = trimTrailingNewline(line)
+		if b == FatalPrefix {
+			return line, &FatalError{Msg: string(line)}
+		}
+		// Warning: not an error, just a message.
+		return line, lerr
+	default:
+		return nil, fmt.Errorf("dmsgscp: unexpected byte 0x%02x from peer", b)
+	}
+}
+
+// FatalError wraps a fatal-prefix message from the peer. ReadAck
+// returns one as its error so callers using errors.As can extract
+// the original text.
+type FatalError struct {
+	Msg string
+}
+
+// Error implements the error interface.
+func (e *FatalError) Error() string { return "dmsgscp: peer reported fatal: " + e.Msg }
+
+// WriteFatal writes a fatal-prefix error line to the peer and
+// returns any I/O error. Format: \x02<msg>\n.
+func WriteFatal(w io.Writer, msg string) error {
+	// Replace any newlines in the message — they'd let a malicious
+	// caller inject extra framing on the wire.
+	clean := strings.ReplaceAll(msg, "\n", " ")
+	clean = strings.ReplaceAll(clean, "\r", " ")
+	_, err := fmt.Fprintf(w, "%c%s\n", FatalPrefix, clean)
+	return err
+}
+
+// WriteWarn writes a warning-prefix error line to the peer.
+// Format: \x01<msg>\n. The peer is expected to surface this but
+// continue.
+func WriteWarn(w io.Writer, msg string) error {
+	clean := strings.ReplaceAll(msg, "\n", " ")
+	clean = strings.ReplaceAll(clean, "\r", " ")
+	_, err := fmt.Fprintf(w, "%c%s\n", WarnPrefix, clean)
+	return err
+}
+
+// ResolveSafePath joins rootDir with a wire-provided name and
+// verifies the result stays under rootDir after symlink-unaware
+// cleaning. Callers must NOT pass the result to filepath.EvalSymlinks
+// before using it for I/O — the guard is purely structural.
+//
+// Returns the cleaned absolute path or ErrPathTraversal.
+func ResolveSafePath(rootDir, name string) (string, error) {
+	if err := validateName(name); err != nil {
+		return "", err
+	}
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return "", err
+	}
+	joined := filepath.Join(absRoot, name)
+	cleaned := filepath.Clean(joined)
+	// On case-insensitive filesystems this prefix check is still
+	// correct because filepath.Clean preserves the original case
+	// and absRoot derives from the same source. The trailing
+	// separator on absRoot prevents a "/root-evil" path from
+	// passing the HasPrefix("/root") check.
+	rootWithSep := absRoot
+	if !strings.HasSuffix(rootWithSep, string(filepath.Separator)) {
+		rootWithSep += string(filepath.Separator)
+	}
+	if cleaned != absRoot && !strings.HasPrefix(cleaned, rootWithSep) {
+		return "", ErrPathTraversal
+	}
+	return cleaned, nil
+}
+
+// trimTrailingNewline strips a single trailing \n and an optional
+// preceding \r. Returns a slice into the input (no allocation).
+func trimTrailingNewline(b []byte) []byte {
+	if len(b) > 0 && b[len(b)-1] == '\n' {
+		b = b[:len(b)-1]
+	}
+	if len(b) > 0 && b[len(b)-1] == '\r' {
+		b = b[:len(b)-1]
+	}
+	return b
+}

--- a/pkg/dmsg/dmsgscp/protocol_test.go
+++ b/pkg/dmsg/dmsgscp/protocol_test.go
@@ -1,0 +1,326 @@
+// Package dmsgscp pkg/dmsg/dmsgscp/protocol_test.go: unit coverage
+// for the wire-protocol parser/writer + path-traversal guard.
+// Integration tests (real dmsg.Client end-to-end) are intentionally
+// skipped — those run live against peer visors.
+package dmsgscp
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteAndReadFileHeader(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     os.FileMode
+		size     int64
+		fileName string
+	}{
+		{"basic", 0644, 1234, "myfile.bin"},
+		{"zero-byte", 0600, 0, "empty.txt"},
+		{"max-size", 0644, MaxFileSize, "huge.dat"},
+		{"name-with-spaces", 0755, 42, "file with spaces.txt"},
+		{"long-name", 0644, 1, strings.Repeat("a", MaxNameLen)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteFileHeader(&buf, tc.mode, tc.size, tc.fileName); err != nil {
+				t.Fatalf("WriteFileHeader: %v", err)
+			}
+			got, err := ReadHeader(bufio.NewReader(&buf))
+			if err != nil {
+				t.Fatalf("ReadHeader: %v", err)
+			}
+			if got.Type != RecordFile {
+				t.Errorf("Type = %c, want C", got.Type)
+			}
+			if got.Mode != tc.mode&os.ModePerm {
+				t.Errorf("Mode = %o, want %o", got.Mode, tc.mode&os.ModePerm)
+			}
+			if got.Size != tc.size {
+				t.Errorf("Size = %d, want %d", got.Size, tc.size)
+			}
+			if got.Name != tc.fileName {
+				t.Errorf("Name = %q, want %q", got.Name, tc.fileName)
+			}
+		})
+	}
+}
+
+func TestReadHeaderDirRecords(t *testing.T) {
+	t.Run("D-start", func(t *testing.T) {
+		buf := bytes.NewBufferString("D0755 0 mydir\n")
+		got, err := ReadHeader(bufio.NewReader(buf))
+		if err != nil {
+			t.Fatalf("ReadHeader(D): %v", err)
+		}
+		if got.Type != RecordDirStart {
+			t.Errorf("Type = %c, want D", got.Type)
+		}
+		if got.Name != "mydir" {
+			t.Errorf("Name = %q, want mydir", got.Name)
+		}
+	})
+	t.Run("D-with-nonzero-size", func(t *testing.T) {
+		buf := bytes.NewBufferString("D0755 5 mydir\n")
+		_, err := ReadHeader(bufio.NewReader(buf))
+		if !errors.Is(err, ErrBadSize) {
+			t.Errorf("err = %v, want ErrBadSize", err)
+		}
+	})
+	t.Run("E-end", func(t *testing.T) {
+		buf := bytes.NewBufferString("E\n")
+		got, err := ReadHeader(bufio.NewReader(buf))
+		if err != nil {
+			t.Fatalf("ReadHeader(E): %v", err)
+		}
+		if got.Type != RecordDirEnd {
+			t.Errorf("Type = %c, want E", got.Type)
+		}
+	})
+	t.Run("E-with-trailing-junk", func(t *testing.T) {
+		buf := bytes.NewBufferString("Etrailing\n")
+		_, err := ReadHeader(bufio.NewReader(buf))
+		if !errors.Is(err, ErrUnknownRecord) {
+			t.Errorf("err = %v, want ErrUnknownRecord", err)
+		}
+	})
+}
+
+func TestReadHeaderMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want error
+	}{
+		{"empty-line", "\n", ErrShortHeader},
+		{"unknown-prefix", "Q0644 1 x\n", ErrUnknownRecord},
+		{"missing-fields", "C0644 1234\n", ErrShortHeader},
+		{"bad-mode", "Cabcd 1 x\n", ErrBadMode},
+		{"bad-size", "C0644 nope x\n", ErrBadSize},
+		{"negative-size", "C0644 -1 x\n", ErrBadSize},
+		{"size-over-cap", "C0644 999999999999 x\n", ErrSizeCap},
+		{"empty-name", "C0644 0 \n", ErrEmptyName},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ReadHeader(bufio.NewReader(strings.NewReader(tc.in)))
+			if !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadHeaderTooLong(t *testing.T) {
+	// Construct a header line longer than MaxHeaderLen so the cap
+	// check fires before allocation. The default bufio.Reader
+	// buffer is 4096 — we want a single line that's longer than
+	// MaxHeaderLen but still fits in the buffer so ReadSlice
+	// returns it successfully and our length check rejects it.
+	name := strings.Repeat("x", MaxHeaderLen) // way over MaxNameLen but exercises the line-length check
+	in := "C0644 1 " + name + "\n"
+	_, err := ReadHeader(bufio.NewReader(strings.NewReader(in)))
+	// Either the name-length check or the header-length check fires.
+	// Both are valid rejections — the important thing is that we
+	// don't silently accept an overlong line.
+	if err == nil {
+		t.Fatal("expected error for overlong header, got nil")
+	}
+	if !errors.Is(err, ErrNameTooLong) && !errors.Is(err, ErrHeaderTooLong) {
+		t.Errorf("err = %v, want ErrNameTooLong or ErrHeaderTooLong", err)
+	}
+}
+
+func TestReadHeaderEOF(t *testing.T) {
+	_, err := ReadHeader(bufio.NewReader(strings.NewReader("")))
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("err = %v, want io.EOF", err)
+	}
+}
+
+func TestPathTraversalRejection(t *testing.T) {
+	cases := []string{
+		"../etc/passwd",
+		"/etc/passwd",
+		"foo/../bar",
+		"foo/../../bar",
+		`..\windows`,
+		`\absolute`,
+		"a/b/../../../c",
+		"..",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			in := "C0644 1 " + name + "\n"
+			_, err := ReadHeader(bufio.NewReader(strings.NewReader(in)))
+			if !errors.Is(err, ErrPathTraversal) {
+				t.Errorf("err = %v, want ErrPathTraversal", err)
+			}
+		})
+	}
+}
+
+func TestInvalidNameChars(t *testing.T) {
+	cases := []string{
+		"file\x00name",
+		"file\nname",
+		"file\rname",
+	}
+	for _, name := range cases {
+		// Drop newline cases that would prematurely terminate the
+		// header line on the parser side — those manifest as
+		// ErrShortHeader via the split. Test validateName directly
+		// for those.
+		if strings.ContainsAny(name, "\n\r") {
+			if err := validateName(name); !errors.Is(err, ErrInvalidName) {
+				t.Errorf("validateName(%q) = %v, want ErrInvalidName", name, err)
+			}
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			in := "C0644 1 " + name + "\n"
+			_, err := ReadHeader(bufio.NewReader(strings.NewReader(in)))
+			if !errors.Is(err, ErrInvalidName) {
+				t.Errorf("err = %v, want ErrInvalidName", err)
+			}
+		})
+	}
+}
+
+func TestWriteHeaderRejectsBadInput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteFileHeader(&buf, 0644, -1, "x"); !errors.Is(err, ErrBadSize) {
+		t.Errorf("negative size: err = %v, want ErrBadSize", err)
+	}
+	buf.Reset()
+	if err := WriteFileHeader(&buf, 0644, MaxFileSize+1, "x"); !errors.Is(err, ErrSizeCap) {
+		t.Errorf("oversize: err = %v, want ErrSizeCap", err)
+	}
+	buf.Reset()
+	if err := WriteFileHeader(&buf, 0644, 1, "../x"); !errors.Is(err, ErrPathTraversal) {
+		t.Errorf("traversal: err = %v, want ErrPathTraversal", err)
+	}
+	buf.Reset()
+	if err := WriteFileHeader(&buf, 0644, 1, ""); !errors.Is(err, ErrEmptyName) {
+		t.Errorf("empty: err = %v, want ErrEmptyName", err)
+	}
+}
+
+func TestAckRoundTrip(t *testing.T) {
+	t.Run("clean-ack", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := WriteAck(&buf); err != nil {
+			t.Fatalf("WriteAck: %v", err)
+		}
+		line, err := ReadAck(bufio.NewReader(&buf))
+		if err != nil {
+			t.Errorf("ReadAck: %v", err)
+		}
+		if line != nil {
+			t.Errorf("line = %q, want nil", line)
+		}
+	})
+	t.Run("fatal", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := WriteFatal(&buf, "no such file"); err != nil {
+			t.Fatalf("WriteFatal: %v", err)
+		}
+		line, err := ReadAck(bufio.NewReader(&buf))
+		if err == nil {
+			t.Fatal("expected error from ReadAck, got nil")
+		}
+		var fe *FatalError
+		if !errors.As(err, &fe) {
+			t.Errorf("err = %v, want *FatalError", err)
+		}
+		if string(line) != "no such file" {
+			t.Errorf("line = %q, want %q", line, "no such file")
+		}
+	})
+	t.Run("warn", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := WriteWarn(&buf, "stale stat"); err != nil {
+			t.Fatalf("WriteWarn: %v", err)
+		}
+		line, err := ReadAck(bufio.NewReader(&buf))
+		// EOF after the line is fine for a fresh buffer; the
+		// important thing is no fatal-style error.
+		if err != nil && !errors.Is(err, io.EOF) {
+			t.Errorf("unexpected err: %v", err)
+		}
+		if string(line) != "stale stat" {
+			t.Errorf("line = %q, want %q", line, "stale stat")
+		}
+	})
+	t.Run("fatal-strips-newlines-in-msg", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := WriteFatal(&buf, "line1\nline2"); err != nil {
+			t.Fatalf("WriteFatal: %v", err)
+		}
+		if strings.Count(buf.String(), "\n") != 1 {
+			t.Errorf("expected exactly one newline in framed output, got %q", buf.String())
+		}
+	})
+}
+
+func TestResolveSafePath(t *testing.T) {
+	root := t.TempDir()
+	t.Run("simple-file", func(t *testing.T) {
+		got, err := ResolveSafePath(root, "foo.txt")
+		if err != nil {
+			t.Fatalf("ResolveSafePath: %v", err)
+		}
+		want := filepath.Join(root, "foo.txt")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("nested-file", func(t *testing.T) {
+		got, err := ResolveSafePath(root, "sub/dir/file")
+		if err != nil {
+			t.Fatalf("ResolveSafePath: %v", err)
+		}
+		want := filepath.Join(root, "sub", "dir", "file")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+	t.Run("traversal-rejected", func(t *testing.T) {
+		_, err := ResolveSafePath(root, "../escape")
+		if !errors.Is(err, ErrPathTraversal) {
+			t.Errorf("err = %v, want ErrPathTraversal", err)
+		}
+	})
+	t.Run("absolute-rejected", func(t *testing.T) {
+		_, err := ResolveSafePath(root, "/etc/passwd")
+		if !errors.Is(err, ErrPathTraversal) {
+			t.Errorf("err = %v, want ErrPathTraversal", err)
+		}
+	})
+	t.Run("sibling-prefix-rejected", func(t *testing.T) {
+		// Build a sibling directory that shares the rootDir prefix
+		// as a string but is NOT under rootDir on the filesystem.
+		// /tmp/rootXXX  vs  /tmp/rootXXX-evil.
+		sibling := root + "-evil"
+		// We don't need to create it — ResolveSafePath is
+		// purely path-string-based. But we should ensure that
+		// constructing a name that would land in "sibling" via
+		// joining is rejected. With our validator, that's
+		// impossible (no `..` allowed), so this test is a
+		// belt-and-suspenders check that joining a normal name
+		// can't escape via clever string manipulation.
+		_, err := ResolveSafePath(root, "foo")
+		if err != nil {
+			t.Errorf("unexpected error for normal name: %v", err)
+		}
+		_ = sibling
+	})
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -30,6 +30,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgctrl"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgscp"
 	"github.com/skycoin/skywire/pkg/dmsgc"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -736,6 +737,60 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 			return nil
 		})
 
+	}
+
+	// dmsgscp Host (scp-over-dmsg). Reuses the dmsgpty whitelist by
+	// default — operators who trust a peer for pty also trust them
+	// for file transfer in v1. Disabled by default; only starts the
+	// listener when the operator opts in via config.
+	if scpConf := v.conf.Dmsgscp; scpConf != nil && scpConf.Enabled {
+		scpWL := wl
+		if len(scpConf.Whitelist) > 0 {
+			// Operator opted into a separate whitelist for scp.
+			// Build a fresh memory-whitelist seeded with those keys
+			// + the visor's own PK + the hypervisors (mirrors the
+			// dmsgpty whitelist construction above so loopback +
+			// hypervisor access stay consistent across services).
+			ownWL := dmsgpty.NewMemoryWhitelist()
+			if err := ownWL.Add(scpConf.Whitelist...); err != nil {
+				return fmt.Errorf("dmsgscp: seed whitelist: %w", err)
+			}
+			if err := ownWL.Add(v.conf.Hypervisors...); err != nil {
+				return fmt.Errorf("dmsgscp: seed hypervisors: %w", err)
+			}
+			if err := ownWL.Add(v.conf.PK); err != nil {
+				v.log.Errorf("Cannot add itself to the scp whitelist: %s", err)
+			}
+			scpWL = ownWL
+		}
+		rootDir := scpConf.RootDir
+		if rootDir == "" {
+			rootDir = filepath.Join(v.conf.LocalPath, "scp-root")
+		}
+		scpHost, err := dmsgscp.NewHost(dmsgC, scpWL, rootDir)
+		if err != nil {
+			return fmt.Errorf("dmsgscp: build host: %w", err)
+		}
+		scpPort := scpConf.DmsgPort
+		if scpPort == 0 {
+			scpPort = dmsgscp.DefaultPort
+		}
+		serveCtx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel called in pushCloseStack
+		wg := new(sync.WaitGroup)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runtimeErrors := getErrors(ctx)
+			if err := scpHost.ListenAndServe(serveCtx, scpPort); err != nil {
+				runtimeErrors <- fmt.Errorf("dmsgscp listen-and-serve stopped: %w", err)
+			}
+		}()
+		v.pushCloseStack("dmsgscp.serve", func() error {
+			cancel()
+			wg.Wait()
+			return nil
+		})
+		log.WithField("port", scpPort).WithField("root", rootDir).Info("dmsgscp host started.")
 	}
 
 	if conf.CLINet != "" {

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -23,6 +23,7 @@ type V1 struct {
 
 	Dmsg          *dmsgc.DmsgConfig   `json:"dmsg"`
 	Dmsgpty       *Dmsgpty            `json:"dmsgpty,omitempty"`
+	Dmsgscp       *Dmsgscp            `json:"dmsgscp,omitempty"`
 	UIServer      *UIServer           `json:"ui_server,omitempty"`
 	LogServer     *LogServer          `json:"log_server,omitempty"`
 	DmsgWeb       *DmsgWebConfig      `json:"dmsg_web,omitempty"`
@@ -67,6 +68,28 @@ type Dmsgpty struct {
 	CLINet    string          `json:"cli_network"`
 	CLIAddr   string          `json:"cli_address"`
 	Whitelist []cipher.PubKey `json:"whitelist"`
+}
+
+// Dmsgscp configures the dmsgscp-host (scp-over-dmsg daemon).
+// Disabled by default — operators must opt in by setting Enabled to
+// true. When Whitelist is empty the host reuses Dmsgpty.Whitelist
+// (handled at initialisation time, not in this struct) so trusting
+// a peer for pty implicitly trusts them for file transfer too.
+type Dmsgscp struct {
+	// Enabled toggles whether initDmsgpty starts the dmsgscp Host.
+	// Default false to keep existing visors quiet on first restart
+	// after upgrade.
+	Enabled bool `json:"enabled"`
+	// DmsgPort is the dmsg port to listen on; zero means use
+	// dmsgscp.DefaultPort (23).
+	DmsgPort uint16 `json:"dmsg_port,omitempty"`
+	// RootDir is the filesystem directory the host serves files
+	// from (its effective chroot). Empty means
+	// <local_path>/scp-root is used.
+	RootDir string `json:"root_dir,omitempty"`
+	// Whitelist optionally overrides the dmsgpty whitelist. When
+	// nil or empty, init reuses Dmsgpty.Whitelist.
+	Whitelist []cipher.PubKey `json:"whitelist,omitempty"`
 }
 
 // UIServer configures the visor UI server (serves tp-viz and other UIs).


### PR DESCRIPTION
## Summary

Peer-to-peer file transfer between skywire hosts via dmsg streams, adjacent to dmsgpty's port 22 on port 23. Operator-requested feature surfaced during today's coordination session — peers ended up routing config patches and pprof artifacts through sshfs because nothing existed at the skywire layer.

Wire is a stripped-down OpenSSH SCP framing (decades-tested for file-mode/size/name edge cases): `C<mode> <size> <name>\n` header → ack → payload bytes → ack. `\x01`/`\x02` prefixes for warn/fatal error lines. Dmsg streams are already noise-authenticated; we layer a whitelist on top (reusing dmsgpty's trust model by default).

## What's in v1

- `pkg/dmsg/dmsgscp/` — new package: `const.go` / `protocol.go` / `host.go` / `client.go` + `protocol_test.go`
- `cmd/skywire-cli/commands/dmsg/scp.go` — `skywire cli dmsg scp <src> <dst>` with regex-based direction inference (66-hex PK prefix determines remote)
- `pkg/visor/visorconfig/v1.go` — new sibling `Dmsgscp` config struct with `Enabled` / `DmsgPort` / `RootDir` / `Whitelist`
- `pkg/visor/init_dmsg.go` — opt-in startup block; reuses dmsgpty's whitelist when `Dmsgscp.Whitelist` is empty
- 10 top-level tests / 36 sub-cases including all 8 path-traversal variants and the `/root-evil → /root` sibling-prefix attack

## Security posture

- `validateName` rejects `..`, absolute paths, NUL, CR/LF, Windows-style `\`-prefix
- `ResolveSafePath` does `filepath.Abs + Join + Clean`, then prefix-check with trailing separator
- Mode-bit masking to `0700` on receive (umask-style — peer can't grant world-write via wire mode)
- Hard 100 MiB file cap, 255-char name cap, 1 KiB header cap
- Partial-write cleanup on mid-transfer failure (no half-files in rootDir)
- Opt-in: `Dmsgscp.Enabled` defaults to `false`; existing visors aren't surprised on upgrade

## Out of scope for v1

Explicit rejections, not "we forgot": recursion (`D`/`E` records get a fatal-prefix line + closed stream), resume, byte-range, content-hash verify. Those are rsync territory and a separate tool. v2 lifts the file-size cap once we have operational data.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` — 0 issues
- [x] `go test ./pkg/dmsg/dmsgscp/...` — pass
- [ ] Live: enable `dmsgscp` on a visor with whitelist=[peer-pk]; from peer host run `skywire cli dmsg scp 02f9aa...:test.bin /tmp/test.bin` and confirm transfer + hash match
- [ ] Live: attempt traversal — `skywire cli dmsg scp 02f9aa...:../../etc/passwd /tmp/x` should fail at header validation, not silently read
- [ ] Live: attempt 200 MiB upload — should reject at the `C`-header size field, not after partial transfer

## Follow-ups (not this PR)

- `--rpc` tunneling so non-`--sk` invocations route through the visor RPC (mirror how `dmsg curl` falls through). Needs a new RPC method on `visor.API`.
- Recursion via `D`/`E` records (only if operational use surfaces a real need; small individual files have been the actual pattern).