### PR TITLE
fix(dmsgscp): default-on, listen on dmsg + skynet

### DIFF
--- a/pkg/dmsg/dmsgscp/host.go
+++ b/pkg/dmsg/dmsgscp/host.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
@@ -85,17 +86,33 @@ func (h *Host) RootDir() string { return h.rootDir }
 // dmsgpty.Host.ListenAndServe — see that function's comments for
 // the rationale on the temporary-error sleep and the close-pipe
 // classification.
+//
+// The accept loop body is shared with ServeListener so the same Host
+// can also accept on a skynet listener for dual-transport parity.
 func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	lis, err := h.dmsgC.Listen(port)
 	if err != nil {
 		return fmt.Errorf("dmsgscp: listen on dmsg port %d: %w", port, err)
 	}
+	h.logger().WithField("port", port).WithField("root", h.rootDir).
+		Debug("dmsgscp listening on dmsg.")
+	return h.ServeListener(ctx, lis)
+}
+
+// ServeListener runs the accept loop against a caller-provided
+// listener. Used directly by the skynet-mirror goroutine in
+// initDmsgpty so the dmsgscp Host serves over BOTH dmsg and the
+// skywire router at the same port number. The listener is closed
+// when ctx is canceled.
+//
+// Authorization (whitelist check) happens per-stream and works
+// uniformly across listener types because remoteAddrToPK handles
+// both dmsg.Addr and appnet.Addr shapes.
+func (h *Host) ServeListener(ctx context.Context, lis net.Listener) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	log := h.logger()
-	log.WithField("port", port).WithField("root", h.rootDir).Debug("dmsgscp listening.")
 
 	go func() {
 		<-ctx.Done()
@@ -103,7 +120,7 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 	}()
 
 	for {
-		stream, err := lis.AcceptStream()
+		conn, err := lis.Accept()
 		if err != nil {
 			log := log.WithError(err)
 			// Same temporary-error treatment as dmsgpty.
@@ -122,16 +139,22 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 			return err
 		}
 
-		rPK := stream.RawRemoteAddr().PK
+		rPK, ok := remoteAddrToPK(conn.RemoteAddr())
+		if !ok {
+			log.WithField("addr_type", fmt.Sprintf("%T", conn.RemoteAddr())).
+				Warn("dmsgscp: cannot extract peer PK from accepted conn; closing.")
+			_ = conn.Close() //nolint:errcheck
+			continue
+		}
 		slog := log.WithField("remote_pk", rPK.String())
 
 		if !h.authorize(slog, rPK) {
 			// Tell the peer why we're hanging up so the client
 			// surface gets a useful error rather than a bare EOF.
-			if werr := WriteFatal(stream, "dmsg stream rejected by whitelist"); werr != nil {
+			if werr := WriteFatal(conn, "dmsg stream rejected by whitelist"); werr != nil {
 				slog.WithError(werr).Debug("dmsgscp: failed to write rejection.")
 			}
-			if cerr := stream.Close(); cerr != nil {
+			if cerr := conn.Close(); cerr != nil {
 				slog.WithError(cerr).Debug("dmsgscp: error closing rejected stream.")
 			}
 			continue
@@ -142,8 +165,22 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 		go func(s net.Conn, l logrus.FieldLogger) {
 			h.serve(ctx, l, s)
 			atomic.AddInt32(&h.connN, -1)
-		}(stream, slog)
+		}(conn, slog)
 	}
+}
+
+// remoteAddrToPK extracts a cipher.PubKey from an accepted conn's
+// RemoteAddr. Supports dmsg.Addr (dmsg listener) and appnet.Addr
+// (skynet listener via the skywire router). Unrecognized address
+// types return ok=false; the caller logs + closes the connection.
+func remoteAddrToPK(addr net.Addr) (cipher.PubKey, bool) {
+	switch a := addr.(type) {
+	case dmsg.Addr:
+		return a.PK, true
+	case appnet.Addr:
+		return a.PubKey, true
+	}
+	return cipher.PubKey{}, false
 }
 
 // authorize mirrors the dmsgpty implementation byte-for-byte so the

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -739,18 +739,24 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	}
 
-	// dmsgscp Host (scp-over-dmsg). Reuses the dmsgpty whitelist by
-	// default — operators who trust a peer for pty also trust them
-	// for file transfer in v1. Disabled by default; only starts the
-	// listener when the operator opts in via config.
-	if scpConf := v.conf.Dmsgscp; scpConf != nil && scpConf.Enabled {
+	// dmsgscp Host (scp-over-dmsg). On by default — access is gated
+	// by the same whitelist that dmsgpty uses. Operators opt OUT
+	// via Dmsgscp.Disabled. When Dmsgscp.Whitelist is non-empty it
+	// overrides the dmsgpty whitelist; otherwise the dmsgpty
+	// whitelist (already constructed above with hypervisors + own
+	// PK) is reused so trusting a peer for pty also trusts them
+	// for file transfer.
+	//
+	// Listens on BOTH dmsg and the skywire router at the same port.
+	// dmsg covers the bootstrap path; skynet covers steady-state
+	// operation over arbitrary transports.
+	scpConf := v.conf.Dmsgscp
+	if scpConf == nil {
+		scpConf = &visorconfig.Dmsgscp{} // all-defaults: enabled, port 23, default rootDir, dmsgpty whitelist
+	}
+	if !scpConf.Disabled {
 		scpWL := wl
 		if len(scpConf.Whitelist) > 0 {
-			// Operator opted into a separate whitelist for scp.
-			// Build a fresh memory-whitelist seeded with those keys
-			// + the visor's own PK + the hypervisors (mirrors the
-			// dmsgpty whitelist construction above so loopback +
-			// hypervisor access stay consistent across services).
 			ownWL := dmsgpty.NewMemoryWhitelist()
 			if err := ownWL.Add(scpConf.Whitelist...); err != nil {
 				return fmt.Errorf("dmsgscp: seed whitelist: %w", err)
@@ -785,12 +791,23 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 				runtimeErrors <- fmt.Errorf("dmsgscp listen-and-serve stopped: %w", err)
 			}
 		}()
+		// Skynet mirror — same port, same Host. Polls until the
+		// router's skynet networker is registered (initRouter may
+		// run after this), then binds and serves. Same accept loop
+		// as the dmsg side; per-stream whitelist gate is uniform
+		// across both transports.
+		goServeSkynetMirror(serveCtx, v.conf.PK, scpPort, "dmsgscp", v.log,
+			func(skyLis net.Listener) {
+				if err := scpHost.ServeListener(serveCtx, skyLis); err != nil {
+					getErrors(ctx) <- fmt.Errorf("dmsgscp skynet mirror stopped: %w", err)
+				}
+			})
 		v.pushCloseStack("dmsgscp.serve", func() error {
 			cancel()
 			wg.Wait()
 			return nil
 		})
-		log.WithField("port", scpPort).WithField("root", rootDir).Info("dmsgscp host started.")
+		log.WithField("port", scpPort).WithField("root", rootDir).Info("dmsgscp host started (dmsg + skynet).")
 	}
 
 	if conf.CLINet != "" {

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -71,17 +71,25 @@ type Dmsgpty struct {
 }
 
 // Dmsgscp configures the dmsgscp-host (scp-over-dmsg daemon).
-// Disabled by default — operators must opt in by setting Enabled to
-// true. When Whitelist is empty the host reuses Dmsgpty.Whitelist
-// (handled at initialisation time, not in this struct) so trusting
+// The host is on by default — access is gated by the same whitelist
+// that dmsgpty uses (a peer's PK must be on the list to be served).
+// Operators who want to disable it entirely set Disabled=true. When
+// Whitelist is empty the host reuses Dmsgpty.Whitelist so trusting
 // a peer for pty implicitly trusts them for file transfer too.
+//
+// The host listens on BOTH dmsg and the skywire router (skynet) at
+// the same port number — same dual-listen pattern dmsg_http and
+// others use. dmsg covers the bootstrap path (works before any
+// router transport is up); skynet covers steady-state operation
+// over arbitrary transports.
 type Dmsgscp struct {
-	// Enabled toggles whether initDmsgpty starts the dmsgscp Host.
-	// Default false to keep existing visors quiet on first restart
-	// after upgrade.
-	Enabled bool `json:"enabled"`
+	// Disabled, when true, suppresses both the dmsg and skynet
+	// listeners. Default false (== on). Inverted from the original
+	// `Enabled` field so the zero value matches the default.
+	Disabled bool `json:"disabled,omitempty"`
 	// DmsgPort is the dmsg port to listen on; zero means use
-	// dmsgscp.DefaultPort (23).
+	// dmsgscp.DefaultPort (23). The skynet mirror binds the same
+	// port number on the router for parity.
 	DmsgPort uint16 `json:"dmsg_port,omitempty"`
 	// RootDir is the filesystem directory the host serves files
 	// from (its effective chroot). Empty means


### PR DESCRIPTION
## Summary

Two follow-up fixes to #2524 surfaced by the user immediately after merge:

### 1. Default-on (whitelist is the gate)

`Dmsgscp.Enabled bool` defaulting to false meant operators had to opt in to a feature whose security gate (the whitelist) was already in place. dmsgpty itself defaults on with the same gate; there's no security reason to make dmsgscp behave differently.

Flipped: new `Dmsgscp.Disabled bool` (omitempty so the zero value matches the new default — daemon on). Opt-OUT for operators who want the daemon completely off. Nil `Dmsgscp{}` block is now treated as all-defaults (enabled, port 23, default rootDir, dmsgpty whitelist) so a visor never even seeing the section in its config still serves.

### 2. Dual listen (dmsg + skynet, same port)

The original `ListenAndServe` bound only on dmsg. The visor's pattern (already used by `dmsg_http`, `tps`, the UI server, etc., via `pkg/visor/dual_listen.go`'s `goServeSkynetMirror`) is to bind every dmsg port on the skywire router at the same port number too. dmsg covers the bootstrap path; skynet covers steady-state operation over arbitrary transports.

Refactored `Host`: extracted the accept loop into `ServeListener(ctx, net.Listener)`. `ListenAndServe` is now a thin wrapper that does the `dmsg.Listen` then calls `ServeListener`. `init_dmsg.go` adds a parallel `goServeSkynetMirror` call that hands the skynet listener to the same `Host.ServeListener`.

Per-stream remote-PK extraction handles both `dmsg.Addr` and `appnet.Addr` via a local `remoteAddrToPK` helper (the visor-local `remotePK` is package-private so we keep a small dedicated copy in `pkg/dmsg/dmsgscp/host.go`).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/dmsg/dmsgscp/...` pass
- [x] `make lint` — 0 issues
- [ ] Live: after merge + redeploy, a peer's `dmsg scp` from a whitelisted PK should succeed against my visor without any config edit
- [ ] Live: same `dmsg scp` succeeds via the skynet path once router transports are up (manual: temporarily block dmsg port 23 on iptables, confirm the operation still succeeds — proves skynet mirror handled it)

## Out of scope
- Surfacing the dmsgscp port + listener state in `/status` for operator visibility — small follow-up if useful.