### PR TITLE
  fix(visor): bound --dmsg-server startup + support pk@host:port form

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -25,7 +26,10 @@ var (
 	// ErrPortAlreadyBound is being returned when the desired port is already bound to.
 	ErrPortAlreadyBound = errors.New("port already bound")
 	// ErrClosedConn is being returned when we are listening on a closed connection.
-	ErrClosedConn = errors.New("listening on closed connection")
+	// Wraps net.ErrClosed so generic accept loops that check the standard
+	// sentinel (e.g. dmsgctrl.ServeListener) recognize this as terminal
+	// instead of spin-logging on shutdown.
+	ErrClosedConn = fmt.Errorf("listening on closed connection: %w", net.ErrClosed)
 )
 
 // SkywireNetworker implements `Networker` for skynet.

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -244,7 +244,29 @@ func (ce *Client) Serve(ctx context.Context) {
 		var err error
 		ce.log.Debug("Discovering dmsg servers...")
 		pinned := ctx.Value("dmsgServer") != nil
-		if pinned {
+		pinnedAddr, _ := ctx.Value("dmsgServerAddr").(string)
+		if pinned && pinnedAddr != "" {
+			// pk@host:port form: skip discovery entirely. We have
+			// everything dialSession needs (PK + TCP address) right
+			// here, so don't burn an HTTP round-trip on dmsg-discovery
+			// — that may be unreachable in the bootstrap scenarios
+			// this mode exists for. A bad PK falls through to "No
+			// entries found" and gets counted as a pinned failure.
+			if dmsgServer, ok := ctx.Value("dmsgServer").(string); ok {
+				var pk cipher.PubKey
+				if err := pk.Set(dmsgServer); err != nil {
+					ce.log.WithError(err).
+						WithField("dmsg_server", dmsgServer).
+						Warn("Pinned dmsg server PK invalid; will retry.")
+					entries = nil
+				} else {
+					entries = []*disc.Entry{{
+						Static: pk,
+						Server: &disc.Server{Address: pinnedAddr},
+					}}
+				}
+			}
+		} else if pinned {
 			entries, err = ce.discoverServers(cancellabelCtx, true)
 			if err != nil {
 				ce.log.WithError(err).Warn("Failed to discover dmsg servers.")

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -111,6 +111,12 @@ type Client struct {
 	LookupHTTPHits   atomic.Int64 // resolved from HTTP discovery
 	LookupHTTPMisses atomic.Int64 // HTTP discovery returned not found
 
+	// pinnedFailures counts consecutive failed Serve-loop passes
+	// while in pinned mode (--dmsg-server / ctx.Value("dmsgServer")
+	// set). The visor polls PinnedFailureCount() during startup to
+	// decide when to abort. Resets to zero on successful session.
+	pinnedFailures atomic.Int64
+
 	errCh chan error
 	done  chan struct{}
 	once  sync.Once
@@ -237,22 +243,38 @@ func (ce *Client) Serve(ctx context.Context) {
 		var entries []*disc.Entry
 		var err error
 		ce.log.Debug("Discovering dmsg servers...")
-		if ctx.Value("dmsgServer") != nil {
+		pinned := ctx.Value("dmsgServer") != nil
+		if pinned {
 			entries, err = ce.discoverServers(cancellabelCtx, true)
 			if err != nil {
 				ce.log.WithError(err).Warn("Failed to discover dmsg servers.")
 				if err == context.Canceled || err == context.DeadlineExceeded {
 					return
 				}
+				ce.pinnedFailures.Add(1)
 				ce.serveWait()
 				continue
 			}
 
-			for ind, entry := range entries {
-				if dmsgServer, ok := ctx.Value("dmsgServer").(string); ok && entry.Static.Hex() == dmsgServer {
-					entries = entries[ind : ind+1]
-					break
+			// Strict pinning: keep only the requested server. If it's
+			// not in discovery (typo, not registered, etc.), drop to
+			// empty entries so the outer loop hits the "No entries
+			// found" retry path instead of silently connecting to a
+			// different server.
+			matched := false
+			if dmsgServer, ok := ctx.Value("dmsgServer").(string); ok {
+				for ind, entry := range entries {
+					if entry.Static.Hex() == dmsgServer {
+						entries = entries[ind : ind+1]
+						matched = true
+						break
+					}
 				}
+			}
+			if !matched {
+				ce.log.WithField("dmsg_server", ctx.Value("dmsgServer")).
+					Warn("Pinned dmsg server not in discovery; will retry.")
+				entries = nil
 			}
 		} else if ctx.Value("setupNode") != nil {
 			entries, err = ce.discoverServers(cancellabelCtx, true)
@@ -277,6 +299,9 @@ func (ce *Client) Serve(ctx context.Context) {
 		}
 		if len(entries) == 0 {
 			ce.log.Warnf("No entries found. Retrying after %s...", ce.bo.String())
+			if pinned {
+				ce.pinnedFailures.Add(1)
+			}
 			ce.serveWait()
 			continue
 		}
@@ -352,6 +377,9 @@ func (ce *Client) Serve(ctx context.Context) {
 					// Only backoff after all servers have been tried
 					ce.log.WithField("current_backoff", ce.bo.String()).
 						Warn("All servers failed, backing off.")
+					if pinned {
+						ce.pinnedFailures.Add(1)
+					}
 					ce.serveWait()
 				}
 				ce.log.WithField("remote_pk", entry.Static).WithError(err).
@@ -359,6 +387,9 @@ func (ce *Client) Serve(ctx context.Context) {
 			} else {
 				// Reset backoff on successful session establishment.
 				ce.bo = ce.initBO
+				if pinned {
+					ce.pinnedFailures.Store(0)
+				}
 			}
 		}
 
@@ -391,6 +422,16 @@ func (ce *Client) Serve(ctx context.Context) {
 // dmsg discovery.
 func (ce *Client) Ready() <-chan struct{} {
 	return ce.ready
+}
+
+// PinnedFailureCount returns the number of consecutive failed
+// Serve-loop passes while the client is pinned to a single dmsg
+// server via the "dmsgServer" context value. Reset to 0 whenever a
+// session is successfully established. Callers (the visor's startup
+// path) use this to bound how long the visor waits for a pinned
+// server before aborting startup.
+func (ce *Client) PinnedFailureCount() int64 {
+	return ce.pinnedFailures.Load()
 }
 
 func (ce *Client) discoverServers(ctx context.Context, all bool) (entries []*disc.Entry, err error) {

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -47,6 +48,7 @@ var (
 	// visorBuildInfo holds information about the build
 	visorBuildInfo        *buildinfo.Info
 	dmsgServer            string
+	dmsgServerAddr        string // populated from --dmsg-server when given as pk@host:port; empty means "use discovery"
 	dmsgServerMaxAttempts int
 	isStoreLog            bool
 	isForceColor          bool
@@ -223,6 +225,35 @@ var RootCmd = &cobra.Command{
 				if _, err := os.Stat(confPath); err != nil {
 					//fail here on no config
 					log.WithError(err).Fatal("config file not found")
+				}
+			}
+		}
+		// Parse --dmsg-server. Two accepted forms:
+		//   <pk>               — let dmsg discovery resolve the address (existing behavior)
+		//   <pk>@<host:port>   — skip discovery entirely and dial host:port directly
+		// The "@" form is for bootstrapping a visor that can't reach
+		// dmsg-discovery yet (fresh install, sealed network, etc.) and
+		// for pinning a specific server address regardless of what
+		// discovery says. The pinned-failure cap from
+		// --dmsg-server-max-attempts still applies — TCP dial failures
+		// count as attempts.
+		if dmsgServer != "" {
+			if i := strings.Index(dmsgServer, "@"); i >= 0 {
+				pkPart := dmsgServer[:i]
+				addrPart := dmsgServer[i+1:]
+				if pkPart == "" || addrPart == "" {
+					log.Fatalf("--dmsg-server: invalid pk@host:port form (need both pk and address): %q", dmsgServer)
+				}
+				var pk cipher.PubKey
+				if err := pk.Set(pkPart); err != nil {
+					log.WithError(err).Fatalf("--dmsg-server: invalid public key %q", pkPart)
+				}
+				dmsgServer = pkPart
+				dmsgServerAddr = addrPart
+			} else {
+				var pk cipher.PubKey
+				if err := pk.Set(dmsgServer); err != nil {
+					log.WithError(err).Fatalf("--dmsg-server: invalid public key %q", dmsgServer)
 				}
 			}
 		}

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -45,12 +45,12 @@ var (
 	// root indicates process is run with root permissions
 	root bool // nolint:unused
 	// visorBuildInfo holds information about the build
-	visorBuildInfo *buildinfo.Info
+	visorBuildInfo        *buildinfo.Info
 	dmsgServer            string
 	dmsgServerMaxAttempts int
 	isStoreLog            bool
-	isForceColor   bool
-	useRouteFinder bool // override local route calculation to use route finder
+	isForceColor          bool
+	useRouteFinder        bool // override local route calculation to use route finder
 )
 
 // nolint: gocyclo

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -46,8 +46,9 @@ var (
 	root bool // nolint:unused
 	// visorBuildInfo holds information about the build
 	visorBuildInfo *buildinfo.Info
-	dmsgServer     string
-	isStoreLog     bool
+	dmsgServer            string
+	dmsgServerMaxAttempts int
+	isStoreLog            bool
 	isForceColor   bool
 	useRouteFinder bool // override local route calculation to use route finder
 )
@@ -70,6 +71,9 @@ func init() {
 	}
 	RootCmd.Flags().StringVar(&dmsgServer, "dmsg-server", "", "use specified dmsg server public key")
 	hiddenflags = append(hiddenflags, "dmsg-server")
+	RootCmd.Flags().IntVar(&dmsgServerMaxAttempts, "dmsg-server-max-attempts", 5,
+		"max failed connect attempts before shutdown (only with --dmsg-server)")
+	hiddenflags = append(hiddenflags, "dmsg-server-max-attempts")
 	//only show flags for configs which exist
 
 	if _, err := os.Stat(skyenv.SkywirePath + "/" + skyenv.ConfigJSON); err == nil {

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -54,13 +54,30 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	if v.dmsgServersCache != nil {
 		configured = v.dmsgServersCache.MergePreferringCache(configured)
 	}
+	log := v.MasterLogger().PackageLogger("dmsg_http")
+	// --dmsg-server pins the direct dmsg client (dmsgDC) to a single
+	// server. The discovery-driven dmsgC is pinned separately by
+	// dmsg.Client.serve() via the "dmsgServer" context value.
+	if dmsgServer != "" {
+		var pinned []*dmsgdisc.Entry
+		for _, e := range configured {
+			if e != nil && e.Static.Hex() == dmsgServer {
+				pinned = []*dmsgdisc.Entry{e}
+				break
+			}
+		}
+		if len(pinned) == 0 {
+			log.WithField("dmsg_server", dmsgServer).
+				Warn("--dmsg-server PK not in configured/cached servers; dmsg-http will be unavailable")
+		}
+		configured = pinned
+	}
 	servers := shuffleServers(configured)
 
 	if len(servers) == 0 {
 		return nil
 	}
 
-	log := v.MasterLogger().PackageLogger("dmsg_http")
 	keys = append(keys, v.conf.PK)
 	// Add deployment service PKs so the direct client can look them up
 	// without querying the HTTP discovery (services run as direct clients
@@ -168,6 +185,23 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// Override the discovery URL used by the DMSG client
 	dmsgConf := *v.conf.Dmsg
 	dmsgConf.Discovery = discURL
+	// --dmsg-server pins the client to one server (discovery filter in
+	// dmsg.Client.serve). Force sessions_count=1 so the client doesn't
+	// burn retries trying to open additional sessions when only one
+	// server is reachable. Deep-copy Deployments so the override stays
+	// local to this dmsgConf and doesn't leak into v.conf.Dmsg via the
+	// shared slice header.
+	if dmsgServer != "" {
+		if len(dmsgConf.Deployments) > 0 {
+			deps := make([]dmsgc.Deployment, len(dmsgConf.Deployments))
+			copy(deps, dmsgConf.Deployments)
+			deps[0].SessionsCount = 1
+			dmsgConf.Deployments = deps
+		}
+		dmsgConf.SessionsCount = 1
+		log.WithField("dmsg_server", dmsgServer).
+			Info("--dmsg-server set: forcing dmsg.sessions_count=1")
+	}
 	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.MasterLogger())
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
@@ -189,17 +223,60 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	v.initLock.Unlock()
 
 	// Wait for DMSG to connect before returning. All modules that depend on
-	// dmsgC will only start after this, ensuring DMSG is ready before any
+	// dmsg will only start after this, ensuring DMSG is ready before any
 	// service tries to use it. Without this, services start dialing over DMSG
 	// before sessions are established, causing unnecessary HTTP fallbacks.
+	//
+	// Two readiness regimes:
+	//   - Unpinned (default): wait up to dmsgInitTimeout and continue
+	//     either way; services fall back to HTTP if dmsg is slow.
+	//   - Pinned (--dmsg-server): there's exactly one server we can
+	//     reach, so a timeout doesn't mean "be patient" — it means
+	//     "give up." Poll the dmsg client's pinned-failure counter
+	//     instead and abort startup once it exceeds the configured
+	//     attempt cap. Each failed pass already costs at least one
+	//     backoff (5s → 60s), so 5 attempts is on the order of
+	//     2–3 minutes before shutdown.
 	const dmsgInitTimeout = 30 * time.Second
-	select {
-	case <-dmsgC.Ready():
-		log.Info("DMSG client connected and ready.")
-	case <-time.After(dmsgInitTimeout):
-		log.Warn("DMSG client not ready after timeout, continuing (services may fall back to HTTP)")
-	case <-ctx.Done():
-		return ctx.Err()
+	if dmsgServer != "" {
+		maxAttempts := dmsgServerMaxAttempts
+		if maxAttempts <= 0 {
+			maxAttempts = 5
+		}
+		log.WithField("dmsg_server", dmsgServer).
+			WithField("max_attempts", maxAttempts).
+			Info("--dmsg-server set: waiting for pinned server (will abort after max attempts)")
+		ticker := time.NewTicker(1 * time.Second)
+	pinnedWait:
+		for {
+			select {
+			case <-dmsgC.Ready():
+				log.Info("DMSG client connected and ready.")
+				break pinnedWait
+			case <-ctx.Done():
+				ticker.Stop()
+				return ctx.Err()
+			case <-ticker.C:
+				if attempts := dmsgC.PinnedFailureCount(); attempts >= int64(maxAttempts) {
+					ticker.Stop()
+					log.WithField("dmsg_server", dmsgServer).
+						WithField("attempts", attempts).
+						WithField("max_attempts", maxAttempts).
+						Error("--dmsg-server pinned but unreachable; aborting startup")
+					return fmt.Errorf("dmsg server %s (from --dmsg-server) unreachable after %d attempts", dmsgServer, attempts)
+				}
+			}
+		}
+		ticker.Stop()
+	} else {
+		select {
+		case <-dmsgC.Ready():
+			log.Info("DMSG client connected and ready.")
+		case <-time.After(dmsgInitTimeout):
+			log.Warn("DMSG client not ready after timeout, continuing (services may fall back to HTTP)")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	// Seed the DMSG client's entry cache with deployment service PKs

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -60,15 +60,34 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	// dmsg.Client.serve() via the "dmsgServer" context value.
 	if dmsgServer != "" {
 		var pinned []*dmsgdisc.Entry
-		for _, e := range configured {
-			if e != nil && e.Static.Hex() == dmsgServer {
-				pinned = []*dmsgdisc.Entry{e}
-				break
+		if dmsgServerAddr != "" {
+			// pk@host:port form: synthesize the entry from the flag so
+			// dmsg-http works on a bootstrap visor that has no cached
+			// servers and possibly no working discovery.
+			var pk cipher.PubKey
+			if err := pk.Set(dmsgServer); err != nil {
+				log.WithError(err).WithField("dmsg_server", dmsgServer).
+					Error("--dmsg-server: invalid public key; dmsg-http will be unavailable")
+			} else {
+				pinned = []*dmsgdisc.Entry{{
+					Static: pk,
+					Server: &dmsgdisc.Server{Address: dmsgServerAddr},
+				}}
+				log.WithField("dmsg_server", dmsgServer).
+					WithField("addr", dmsgServerAddr).
+					Info("--dmsg-server pk@host:port: skipping discovery for dmsg-http")
 			}
-		}
-		if len(pinned) == 0 {
-			log.WithField("dmsg_server", dmsgServer).
-				Warn("--dmsg-server PK not in configured/cached servers; dmsg-http will be unavailable")
+		} else {
+			for _, e := range configured {
+				if e != nil && e.Static.Hex() == dmsgServer {
+					pinned = []*dmsgdisc.Entry{e}
+					break
+				}
+			}
+			if len(pinned) == 0 {
+				log.WithField("dmsg_server", dmsgServer).
+					Warn("--dmsg-server PK not in configured/cached servers; dmsg-http will be unavailable")
+			}
 		}
 		configured = pinned
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -597,8 +597,10 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	v.runtimeErrors = make(chan error)
 	ctx = context.WithValue(ctx, runtimeErrsKey, v.runtimeErrors)
 	if dmsgServer != "" {
-		type dmsgServerKey struct{}
-		ctx = context.WithValue(ctx, dmsgServerKey{}, dmsgServer)
+		// dmsg.Client.serve() reads ctx.Value("dmsgServer") (string key)
+		// to pin discovery to a single server PK. Match that key exactly
+		// — a private struct type here would silently disable pinning.
+		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer) //nolint:staticcheck // SA1029: matches dmsg.Client's existing string key
 	}
 	registerModules(v.MasterLogger())
 	var mainModule visorinit.Module
@@ -615,22 +617,26 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	if err := mainModule.Wait(ctx); err != nil {
 		select {
 		case <-ctx.Done():
-			if err := v.Close(); err != nil {
-				log.WithError(err).Error("Visor closed with error.")
-			}
 		default:
-			log.Error(err)
+			log.WithError(err).Error("Module init failed; shutting down.")
+		}
+		// Always run the close stack so handlers registered before the
+		// failure (dmsg client Serve goroutine, listeners, etc.) get a
+		// chance to exit cleanly — otherwise partial init leaks them
+		// until the process dies.
+		if cerr := v.Close(); cerr != nil {
+			log.WithError(cerr).Error("Visor closed with error.")
 		}
 		return nil, false
 	}
 	if err := tm.Wait(ctx); err != nil {
 		select {
 		case <-ctx.Done():
-			if err := v.Close(); err != nil {
-				log.WithError(err).Error("Visor closed with error.")
-			}
 		default:
-			log.Error(err)
+			log.WithError(err).Error("Transport module init failed; shutting down.")
+		}
+		if cerr := v.Close(); cerr != nil {
+			log.WithError(cerr).Error("Visor closed with error.")
 		}
 		return nil, false
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -601,6 +601,12 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 		// to pin discovery to a single server PK. Match that key exactly
 		// — a private struct type here would silently disable pinning.
 		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer) //nolint:staticcheck // SA1029: matches dmsg.Client's existing string key
+		if dmsgServerAddr != "" {
+			// --dmsg-server pk@host:port form. dmsg.Client.serve() reads
+			// "dmsgServerAddr" alongside "dmsgServer" and skips discovery
+			// when both are set, dialing host:port directly.
+			ctx = context.WithValue(ctx, "dmsgServerAddr", dmsgServerAddr) //nolint:staticcheck // SA1029: matches dmsg.Client's existing string key
+		}
 	}
 	registerModules(v.MasterLogger())
 	var mainModule visorinit.Module


### PR DESCRIPTION
  Did you run `make format && make check`? Yes

  Fixes #2528

  Changes:
  - Add `--dmsg-server-max-attempts` flag (default 5, hidden); only honored with `--dmsg-server`.
  - Track consecutive failed `Serve`-loop passes in `dmsg.Client` via atomic counter, exposed as `PinnedFailureCount()`. Increments on discovery error, pinned PK not in discovery, or
  `EnsureSession` failure. Resets on successful session.
  keeps the 30s warn-and-continue behavior.
  - With the dmsg client's 5s→60s backoff between passes, 5 attempts ≈ 2–3 min before shutdown — short enough to fail visibly, long enough to ride out transient blips.
  - Extend `--dmsg-server` to accept `pk@host:port` in addition to plain `pk`. With the `@` form, skip dmsg-discovery entirely and dial `host:port` directly. Useful for bootstrapping a
  visor that can't reach discovery yet, or for pinning a specific server address regardless of what discovery says. The PK is validated at flag parse; bad/empty form → fatal with a
  clear message. The failed-attempts cap still applies — TCP dial failures count as attempts.
  - `initDmsgHTTP` also honors the `@` form: synthesizes the pinned entry from the flag so dmsg-HTTP works on a fresh cache-less visor.
  - Includes earlier dirty-log + graceful-shutdown fix: run `Visor.Close()` on both init-failure paths in `NewVisor` so the dmsg `Serve` goroutine and listeners exit cleanly instead of
  leaking until the process dies.
  
  How to test this PR:
  - Start visor with `--dmsg-server <unreachable-pk>`; confirm it retries ~5 times and exits with `--dmsg-server pinned but unreachable; aborting startup`.
  - Start visor with `--dmsg-server <reachable-pk>`; confirm normal startup and `DMSG client connected and ready.` log.
  - Start visor without `--dmsg-server`; confirm the 30s warn-and-continue path still fires when dmsg is slow.
  - Tune `--dmsg-server-max-attempts=2` and confirm shutdown happens ~2× faster.
  - Start visor with `--dmsg-server <pk>@<reachable-host:port>`; confirm no discovery call is made for session setup (`--dmsg-server pk@host:port: skipping discovery for dmsg-http` in
  logs) and dmsg connects.
  - Start visor with `--dmsg-server <pk>@<unreachable-host:port>`; confirm TCP dial failures count as attempts and the visor shuts down after the cap is reached.
  - Start visor with `--dmsg-server pk@` or `--dmsg-server @host:port`; confirm fatal error at startup with a clear message.