### PR TITLE
fix(skychat): /status groups visibility + stale-active demotion + inbox MarkMessage

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1218,8 +1218,18 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	if visorPKErr != "" {
 		status["error"] = visorPKErr
 	}
-	if groups := collectGroupHealth(); groups != nil {
-		status["groups"] = groups
+	// Always surface a result for the groups[] introspection path
+	// even when it fails. Previously a nil pairRPC or a GroupList RPC
+	// failure was returned as a silent nil and the 'groups' key was
+	// suppressed entirely — making it impossible for an operator to
+	// distinguish "this visor has no groups" from "the introspection
+	// path is broken". Now we always set 'groups' (an array, possibly
+	// empty) AND, on the failure paths, set 'groups_error' with a
+	// short reason string so the failure mode is greppable.
+	groups, groupsErr := collectGroupHealth()
+	status["groups"] = groups
+	if groupsErr != "" {
+		status["groups_error"] = groupsErr
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1255,14 +1265,36 @@ type groupHealth struct {
 // pair-RPC channel (when --pair-enable is set, which is the default
 // for any setup that has grouping enabled at all). This reuses that
 // channel rather than introducing a new IPC dependency.
-func collectGroupHealth() []groupHealth {
+// collectGroupHealth returns the per-group health summary for every
+// joined group on this visor, plus a short error-reason string when
+// the introspection path failed. The caller always renders a 'groups'
+// array (possibly empty) so an operator never sees the field silently
+// missing; the 'groups_error' field appears alongside whenever the
+// returned reason is non-empty, making the failure mode visible.
+//
+// Two failure paths surface as distinct reason strings:
+//
+//   - pairRPC == nil  → "pair-rpc-disabled" (operator turned off
+//     pair mode, so the chat-app can't reach the visor for group
+//     introspection; not necessarily a bug).
+//   - GroupList RPC errored → "rpc-error: <truncated err>" (the
+//     visor's group manager rejected or failed the call — usually
+//     means group support is disabled in the visor config, OR the
+//     RPC client has a transient connection issue).
+func collectGroupHealth() ([]groupHealth, string) {
 	if pairRPC == nil {
-		return nil
+		return []groupHealth{}, "pair-rpc-disabled"
 	}
 	infos, err := pairRPC.GroupList()
 	if err != nil {
 		appCl.Log().Debugf("status: GroupList RPC failed: %v", err)
-		return nil
+		// Truncate the err so a long upstream chain doesn't bloat
+		// /status responses or wrap unprintable bytes through HTTP.
+		es := err.Error()
+		if len(es) > 200 {
+			es = es[:200] + "…"
+		}
+		return []groupHealth{}, "rpc-error: " + es
 	}
 	out := make([]groupHealth, 0, len(infos))
 	now := time.Now().UTC()
@@ -1285,7 +1317,7 @@ func collectGroupHealth() []groupHealth {
 		}
 		out = append(out, gh)
 	}
-	return out
+	return out, ""
 }
 
 // persistMessage stores a message in the history backend if persistence is

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -369,6 +369,25 @@ func (m *Manager) Resume() error {
 // isn't dial-hammered.
 const reconnectInterval = 30 * time.Second
 
+// subscriberStaleThreshold is the lag (now - last_message_at) above
+// which an "active" member session is treated as silently stale and
+// demoted to StatusPending so the existing reconnect machinery kicks
+// in. Set well above any plausible owner-publish gap to avoid false
+// positives on genuinely quiet groups: ~10× the reconnect interval.
+//
+// The trade-off is recovery latency vs. unnecessary reconnects. A
+// truly stuck subscriber stays stuck up to this duration after the
+// CXO conn dies. A quiet group sees an unnecessary reconnect every
+// time the threshold elapses with no traffic — that's OK because
+// (a) reconnect is cheap, (b) ConnectPK is idempotent so the
+// underlying conn is reused when healthy, and (c) the backoff
+// machinery limits churn on persistent failure.
+//
+// A proper fix is owner-side heartbeat publication (PR-C) so
+// subscribers can distinguish "no traffic" from "no pull". This
+// threshold is the bridge until that lands.
+const subscriberStaleThreshold = 5 * time.Minute
+
 // reconnectAttemptTimeout bounds the per-Connect call so the
 // reconnect loop can't get stuck on a single slow group while other
 // pending groups starve.
@@ -420,7 +439,60 @@ func (m *Manager) runReconnectLoop(ctx context.Context) {
 			return
 		case <-t.C:
 		}
+		// Two-pass tick: first detect silently-stale active sessions
+		// and demote them to pending; then run the existing pending-
+		// reconnect pass. Order matters — the demotion has to happen
+		// before the pending walk so freshly-demoted records get a
+		// reconnect attempt this same tick.
+		m.detectStaleActive(ctx)
 		m.attemptReconnectPending(ctx)
+	}
+}
+
+// detectStaleActive demotes any active member session whose persisted
+// last_message_at lag exceeds subscriberStaleThreshold. The demotion
+// is the only signal we have today that a "healthy-looking" subscriber
+// has gone silent — Resume's SetStatus(active) and tryReconnect's
+// success path both leave status pinned at active until something
+// flips it back. The CXO Subscriber doesn't surface "my conn died"
+// to us; until owner-side heartbeat publication lands (PR-C) the lag
+// is our best proxy.
+//
+// Demoted records pick up the reconnect loop's normal backoff state,
+// so a session that genuinely cannot reconnect doesn't churn — it
+// retries on the established schedule (30s → 5min after 10 fails →
+// 30min after 30 fails). The wrap-around on success clears the
+// backoff and restores active.
+//
+// Skips: owner-role sessions (no subscriber), records without a
+// last_message_at (zero value — no traffic ever seen, may be a
+// brand-new join), terminal records.
+func (m *Manager) detectStaleActive(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	records, err := m.store.List()
+	if err != nil {
+		return
+	}
+	now := time.Now().UTC()
+	for _, r := range records {
+		if r.Role != RoleMember || r.Status != StatusActive {
+			continue
+		}
+		if r.LastMessageAt.IsZero() {
+			continue
+		}
+		if now.Sub(r.LastMessageAt) <= subscriberStaleThreshold {
+			continue
+		}
+		m.log.WithField("id", r.ID).
+			WithField("lag", now.Sub(r.LastMessageAt).Round(time.Second).String()).
+			Warn("group: active session stale; demoting to pending for reconnect")
+		if err := m.store.SetStatus(r.ID, StatusPending); err != nil {
+			m.log.WithError(err).WithField("id", r.ID).
+				Debug("group: stale-detect: SetStatus pending failed")
+		}
 	}
 }
 
@@ -622,6 +694,25 @@ func (m *Manager) Close() error {
 
 // Get returns the persisted record for an ID.
 func (m *Manager) Get(id string) (Record, bool, error) { return m.store.Get(id) }
+
+// MarkMessageDelivered records that a message with the given timestamp
+// reached the inbox for the named group. Belt-and-suspenders to keep
+// LastMessageAt fresh independent of the wrapped-handler chain in
+// openLocked: any subsystem with a Manager reference can call this
+// after delivering a message externally (e.g. the visor's groupInbox
+// when it drains a SSE push) so the persisted last_message_at stays
+// consistent with what's actually flowing into the inbox.
+//
+// Idempotent and best-effort: errors are swallowed at debug level
+// because a failure here is purely cosmetic — the message still
+// reached its consumer; only the operator-visible lag indicator is
+// affected.
+func (m *Manager) MarkMessageDelivered(groupID string, ts time.Time) {
+	if err := m.store.MarkMessage(groupID, ts); err != nil {
+		m.log.WithError(err).WithField("id", groupID).
+			Debug("group: MarkMessageDelivered: store update failed")
+	}
+}
 
 // IsSubscriberAlive reports the live subscriber health for the group
 // id, surfaced by the chat-app's /status endpoint as the per-group

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -259,10 +259,17 @@ func toInfo(r skychatgroup.Record) GroupInfo {
 
 // groupInbox is a bounded ring buffer of inbound group messages,
 // drained by GroupPoll. Mirrors pairInbox exactly.
+//
+// mgr is set after construction via setManager; deliver() uses it to
+// tick last_message_at on the persisted record so the indicator stays
+// fresh independent of the wrapped-handler chain in
+// group.Manager.openLocked. Nil-tolerant: if setManager hasn't been
+// called the bookkeeping side-effect is skipped.
 type groupInbox struct {
 	mu  sync.Mutex
 	cap int
 	buf []GroupMessage
+	mgr *skychatgroup.Manager
 }
 
 func newGroupInbox(capacity int) *groupInbox {
@@ -272,9 +279,18 @@ func newGroupInbox(capacity int) *groupInbox {
 	return &groupInbox{cap: capacity, buf: make([]GroupMessage, 0, capacity)}
 }
 
+// setManager wires the group Manager so deliver() can refresh
+// last_message_at on the persisted record after a successful push.
+// Set once during init_group.go after both the Manager and inbox
+// exist; subsequent calls overwrite atomically under the inbox mutex.
+func (g *groupInbox) setManager(mgr *skychatgroup.Manager) {
+	g.mu.Lock()
+	g.mgr = mgr
+	g.mu.Unlock()
+}
+
 func (g *groupInbox) deliver(groupID string, senderPK cipher.PubKey, msg skychatgroup.Message) {
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	g.buf = append(g.buf, GroupMessage{
 		GroupID:  groupID,
 		SenderPK: senderPK,
@@ -284,6 +300,20 @@ func (g *groupInbox) deliver(groupID string, senderPK cipher.PubKey, msg skychat
 	if len(g.buf) > g.cap {
 		drop := len(g.buf) - g.cap
 		g.buf = append(g.buf[:0], g.buf[drop:]...)
+	}
+	mgr := g.mgr
+	g.mu.Unlock()
+	// Belt-and-suspenders: also tick the persisted last_message_at on
+	// the manager. The wrapped MessageHandler installed by openLocked
+	// is supposed to do this too, but during the 3-agent coordination
+	// session some peers observed last_message_at not advancing even
+	// while messages were arriving in their group-listen output —
+	// suggesting at least one delivery path bypasses the wrapper.
+	// Updating from inbox.deliver guarantees the indicator tracks
+	// whatever actually lands in the inbox, regardless of which
+	// upstream code path put it there.
+	if mgr != nil {
+		mgr.MarkMessageDelivered(groupID, msg.TS)
 	}
 }
 

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -62,6 +62,7 @@ func initGrouping(_ context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	inbox := newGroupInbox(groupInboxCap)
+	inbox.setManager(mgr)
 	mgr.SetMessageHandler(inbox.deliver)
 
 	v.initLock.Lock()


### PR DESCRIPTION
## Summary

Three small fixes around the per-group health surface from the 11-hour stall observed in the live 3-agent coordination session. Peer `02f9aa58` owns an orthogonal owner-side heartbeat watchdog PR; this PR closes the visibility / bookkeeping gaps that the watchdog will rely on.

### 1. `/status.groups` suppression → explicit error surface

`collectGroupHealth` returned `nil` silently when `pairRPC == nil` OR when `GroupList` RPC failed, and the `groups` key was omitted from `/status`. An operator couldn't tell "no joined groups" from "introspection broken."

Now `/status` always carries a `groups` array (possibly empty) plus, on the failure paths, a `groups_error` string: `pair-rpc-disabled` or `rpc-error: <err-truncated-to-200>`.

### 2. Active-but-stale subscriber → demote to pending

`runReconnectLoop` only acted on `StatusPending`. A member whose CXO subscriber silently halted (no error, no Close) stayed pinned at `StatusActive` forever; peers spent 11h with `last_message_at` frozen at pre-stall and needed manual `leave + join` via dmsgpty to recover.

New `detectStaleActive` first-pass on each tick: any active member record with `last_message_at` lag > `subscriberStaleThreshold` (5min) gets demoted to `StatusPending`, then `attemptReconnectPending` on the same tick picks it up via the existing backoff machinery (10 fails → 5min, 30 fails → 30min).

Threshold is ~10× the reconnect interval so quiet-but-healthy groups don't trip spurious reconnects. This is the bridge until owner-side heartbeat publication (PR-C, peer's draft) lands.

### 3. `inbox.deliver` belt-and-suspenders `MarkMessage`

Peer `03d1d78e` observed: messages flowing through SSE listener but `Record.LastMessageAt` frozen. The wrapped `MessageHandler` from `openLocked` is supposed to update `LastMessageAt` on inbound, but at least one delivery path appears to bypass it.

`groupInbox` now holds a `*skychatgroup.Manager` (wired via `setManager` in `init_group.go`), and `inbox.deliver` calls `manager.MarkMessageDelivered(groupID, msg.TS)` after appending to the ring. Best-effort: errors are debug-logged — a missed bookkeeping update is cosmetic; the message still reached the operator's listener.

`Manager.MarkMessageDelivered` is the new public entry point so the visor wrapper doesn't leak the store.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./cmd/apps/skychat/group/...` pass
- [x] `make lint` — 0 issues
- [ ] Live: peer with stuck subscriber gets auto-recovered within one 30s tick after lag exceeds 5min (vs needing manual leave+rejoin)
- [ ] Live: `/status` always shows `groups` field; `groups_error` appears with a useful reason when pairRPC is off or GroupList fails
- [ ] Live: peer's `last_message_at` advances on every inbound group message (no more frozen indicators)

## Related
- Original auto-reconnect path landed in #2523
- Peer 02f9aa58's owner-heartbeat watchdog PR (in flight) complements this — heartbeats give a positive "I should be seeing traffic" signal so stale-detection can fire faster + with fewer false positives.