### PR TITLE
feat(skychat/group): owner heartbeat watchdog for fast stale-sub detection

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -60,6 +60,10 @@ type Manager struct {
 	mu       sync.RWMutex
 	sessions map[string]*Session
 
+	// heartbeatInterval is the owner-emit cadence forwarded to every
+	// new owner-role Session via openLocked. Zero disables.
+	heartbeatInterval time.Duration
+
 	// reconnect loop state — see runReconnectLoop.
 	reconnectCtx    context.Context
 	reconnectCancel context.CancelFunc
@@ -87,7 +91,20 @@ type ManagerConfig struct {
 	MySK    cipher.SecKey
 	DataDir string
 	Logger  *logging.Logger
+
+	// HeartbeatInterval, when > 0, makes every owner-role session
+	// opened by this Manager emit a periodic no-op heartbeat probe.
+	// Members observe these to detect a silently-stalled CXO
+	// subscriber inside ~3×interval. Zero disables (default for
+	// callers that don't set it; for visor production set to 30s).
+	HeartbeatInterval time.Duration
 }
+
+// DefaultHeartbeatInterval is the recommended interval an owner
+// session emits its heartbeat probe. 30s gives a stall-detection
+// window of ~90s without measurable wire overhead on a typical
+// group.
+const DefaultHeartbeatInterval = 30 * time.Second
 
 // NewManager constructs a manager. Does not open any sessions; call
 // Resume to bring up everything in the store.
@@ -106,15 +123,16 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 		log = logging.MustGetLogger("skychat-group-manager")
 	}
 	return &Manager{
-		store:          cfg.Store,
-		dmsgC:          cfg.DmsgC,
-		myPK:           cfg.MyPK,
-		mySK:           cfg.MySK,
-		dataDir:        cfg.DataDir,
-		log:            log,
-		portAlloc:      defaultPortAlloc,
-		sessions:       make(map[string]*Session),
-		reconnectState: make(map[string]*reconnectState),
+		store:             cfg.Store,
+		dmsgC:             cfg.DmsgC,
+		myPK:              cfg.MyPK,
+		mySK:              cfg.MySK,
+		dataDir:           cfg.DataDir,
+		log:               log,
+		portAlloc:         defaultPortAlloc,
+		sessions:          make(map[string]*Session),
+		heartbeatInterval: cfg.HeartbeatInterval,
+		reconnectState:    make(map[string]*reconnectState),
 	}, nil
 }
 
@@ -388,6 +406,15 @@ const reconnectInterval = 30 * time.Second
 // threshold is the bridge until that lands.
 const subscriberStaleThreshold = 5 * time.Minute
 
+// heartbeatStaleThreshold is the lag threshold applied when a session
+// has been observing owner heartbeats. Set to ~3× the recommended
+// emit interval (30s) so a single missed heartbeat doesn't trigger
+// a reconnect — but two consecutive misses do, surfacing real stalls
+// inside ~90s. Tight relative to subscriberStaleThreshold because the
+// heartbeat signal is predictable: a healthy group emits regardless
+// of whether anyone is chatting.
+const heartbeatStaleThreshold = 90 * time.Second
+
 // reconnectAttemptTimeout bounds the per-Connect call so the
 // reconnect loop can't get stuck on a single slow group while other
 // pending groups starve.
@@ -480,14 +507,48 @@ func (m *Manager) detectStaleActive(ctx context.Context) {
 		if r.Role != RoleMember || r.Status != StatusActive {
 			continue
 		}
-		if r.LastMessageAt.IsZero() {
-			continue
+		// Prefer the heartbeat signal when available — it ticks on a
+		// fixed cadence regardless of chat traffic, so a quiet-but-
+		// healthy group doesn't trip stale-detect. Fall back to
+		// last_message_at lag only when no heartbeat has been seen
+		// (older owner deployments without heartbeat publication, or
+		// a freshly-rejoined member that hasn't observed one yet).
+		m.mu.RLock()
+		sess := m.sessions[r.ID]
+		m.mu.RUnlock()
+		var (
+			lag       time.Duration
+			signal    string
+			haveProbe bool
+		)
+		if sess != nil {
+			if lhb := sess.LastHeartbeat(); !lhb.IsZero() {
+				lag = now.Sub(lhb)
+				signal = "heartbeat"
+				haveProbe = true
+			}
 		}
-		if now.Sub(r.LastMessageAt) <= subscriberStaleThreshold {
+		if !haveProbe {
+			if r.LastMessageAt.IsZero() {
+				continue
+			}
+			lag = now.Sub(r.LastMessageAt)
+			signal = "last_message_at"
+		}
+		// Pick the appropriate threshold. Heartbeats are predictable
+		// (~30s cadence) so we can be aggressive — 3× interval ≈ 90s.
+		// Chat-traffic lag is unpredictable; keep the conservative
+		// 5-minute threshold to avoid spurious demotes on quiet groups.
+		threshold := subscriberStaleThreshold
+		if signal == "heartbeat" {
+			threshold = heartbeatStaleThreshold
+		}
+		if lag <= threshold {
 			continue
 		}
 		m.log.WithField("id", r.ID).
-			WithField("lag", now.Sub(r.LastMessageAt).Round(time.Second).String()).
+			WithField("lag", lag.Round(time.Second).String()).
+			WithField("signal", signal).
 			Warn("group: active session stale; demoting to pending for reconnect")
 		if err := m.store.SetStatus(r.ID, StatusPending); err != nil {
 			m.log.WithError(err).WithField("id", r.ID).
@@ -765,12 +826,13 @@ func (m *Manager) openLocked(r Record) (*Session, error) {
 	h := m.onMessage
 	m.onMessageMu.RUnlock()
 	sess, err := Open(Config{
-		MyPK:    m.myPK,
-		MySK:    m.mySK,
-		Record:  r,
-		DmsgC:   m.dmsgC,
-		DataDir: m.dataDir,
-		Logger:  m.log,
+		MyPK:              m.myPK,
+		MySK:              m.mySK,
+		Record:            r,
+		DmsgC:             m.dmsgC,
+		DataDir:           m.dataDir,
+		Logger:            m.log,
+		HeartbeatInterval: m.heartbeatInterval,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("group: open %s: %w", r.ID, err)

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -95,6 +95,15 @@ type Config struct {
 
 	// BatchWindow forwards to the publisher (see treestore.PubConfig).
 	BatchWindow time.Duration
+
+	// HeartbeatInterval, when > 0, makes owner-role sessions emit a
+	// periodic no-op heartbeat probe into the group feed. Members
+	// observe the heartbeats via onUpdate, track lastHeartbeatNs, and
+	// use it as the freshness signal for stale-subscriber detection.
+	// Zero disables heartbeat emission entirely (useful for tests and
+	// for deployments that want to opt out of the ~1KB/min/group
+	// wire cost). Recommended production value: 30s.
+	HeartbeatInterval time.Duration
 }
 
 // Session is one live group as this visor knows it — either as the
@@ -151,7 +160,40 @@ type Session struct {
 	// per-group health field. Atomic so it can be read without
 	// acquiring any session mutex from the status handler's hot path.
 	subAlive atomic.Bool
+
+	// lastHeartbeatNs holds the unix-nanosecond timestamp at which
+	// this session most recently OBSERVED an owner heartbeat. Set
+	// when the subscriber's onUpdate sees a heartbeat-marker leaf
+	// (member side) OR when the owner-self-echo wrapper sees it
+	// (owner side, kept for symmetry). Zero means no heartbeat seen
+	// yet. Used by the Manager's runReconnectLoop to detect a
+	// silently-stalled subscriber within ~heartbeatStaleThreshold of
+	// the actual stall, rather than waiting for the
+	// no-traffic-implies-stuck fallback.
+	lastHeartbeatNs atomic.Int64
+
+	// heartbeatCancel stops the owner-side heartbeat emission loop.
+	// nil for member-role sessions or when HeartbeatInterval=0.
+	heartbeatCancel context.CancelFunc
+	heartbeatWG     sync.WaitGroup
 }
+
+// HeartbeatMarker is the fixed body of an owner-emitted heartbeat
+// message. Subscribers detect it by exact-match on Message.Text,
+// update lastHeartbeatNs, and DO NOT bubble the message up to the
+// user handler / inbox — heartbeats are wire noise, not chat.
+//
+// Picked to be (a) unambiguous (operator typing this verbatim into a
+// chat input would be a deliberate spoof, and the sender PK check
+// still requires it to come from the owner) and (b) recognizable in
+// logs / pcap dumps without decoding the JSON envelope around it.
+const HeartbeatMarker = "__skychat_group_heartbeat__"
+
+// IsHeartbeat returns true for messages that are owner-emitted
+// heartbeat probes rather than chat content. Exposed so the visor's
+// inbox layer (pkg/visor/group.go) can filter heartbeats from the
+// poll ring without re-importing the constant in two places.
+func IsHeartbeat(msg Message) bool { return msg.Text == HeartbeatMarker }
 
 // relayPortOffset is the dmsg-port delta from the group's CXO
 // publish port to the relay-submission listener. Members dial
@@ -264,7 +306,46 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 	}
 	s.relayWG.Add(1)
 	go s.bindRelaySkynet(relayPort)
+
+	// Heartbeat emission. Publishes a tiny no-op message to the feed
+	// every HeartbeatInterval so members can detect a silently-stalled
+	// CXO subscriber as "haven't seen a heartbeat in N intervals"
+	// independent of whether real chat traffic is flowing. Zero
+	// interval disables (useful for tests + low-overhead deployments).
+	if cfg.HeartbeatInterval > 0 {
+		hbCtx, hbCancel := context.WithCancel(context.Background())
+		s.heartbeatCancel = hbCancel
+		s.heartbeatWG.Add(1)
+		go s.runHeartbeatLoop(hbCtx, cfg.HeartbeatInterval)
+	}
 	return s, nil
+}
+
+// runHeartbeatLoop is the owner-side periodic heartbeat publisher.
+// Emits a HeartbeatMarker message every interval until ctx is
+// canceled (Close path). The publishAs call goes through the normal
+// owner write path, which means heartbeats also exercise the
+// publisher's batch + CXO save machinery — a healthy probe that
+// implicitly catches publisher-side wedges too.
+//
+// Failures are debug-logged and the loop continues. A persistent
+// publisher problem will show up as both "publishAs heartbeat
+// failed" repeated in the log AND members' lastHeartbeatNs going
+// stale; the latter is the operator-facing signal.
+func (s *Session) runHeartbeatLoop(ctx context.Context, interval time.Duration) {
+	defer s.heartbeatWG.Done()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := s.publishAs(s.cfg.MyPK, HeartbeatMarker, time.Now().UTC()); err != nil {
+				s.log.WithError(err).Debug("group: heartbeat publish failed")
+			}
+		}
+	}
 }
 
 // openMember creates a subscriber. The connect-to-owner step is
@@ -353,6 +434,20 @@ func (s *Session) Connect() error {
 //     "did we successfully attach + do we believe we're still
 //     attached"; the background reconnect loop is responsible for
 //     re-asserting that belief on its 30s cadence.
+//
+// LastHeartbeat returns the time at which this session most recently
+// observed an owner heartbeat probe, or the zero time if none seen
+// yet. Used by Manager.runReconnectLoop's stale-detection to demote
+// a silently-stalled subscriber within ~heartbeatStaleThreshold of
+// the stall, regardless of whether chat traffic is flowing.
+func (s *Session) LastHeartbeat() time.Time {
+	ns := s.lastHeartbeatNs.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns).UTC()
+}
+
 func (s *Session) IsSubscriberAlive() bool {
 	if s.sub == nil {
 		return true // owner role
@@ -424,6 +519,12 @@ func (s *Session) Close() error {
 	// Flip subAlive first so any concurrent /status read sees the
 	// session as dead even if Close races with a long Subscriber.Close.
 	s.subAlive.Store(false)
+	// Stop the owner-side heartbeat emitter (if running). No-op on
+	// member sessions or when HeartbeatInterval=0 at Open time.
+	if s.heartbeatCancel != nil {
+		s.heartbeatCancel()
+		s.heartbeatWG.Wait()
+	}
 	if s.relayCancel != nil {
 		s.relayCancel()
 	}
@@ -636,6 +737,16 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 	// We deliver the plaintext Message regardless of ModePrivate —
 	// the local handler should see the same content the (decoded)
 	// subscriber path would surface, not the encrypted bytes.
+	// Filter heartbeat self-echoes out of the handler delivery —
+	// they are wire-level liveness probes, not chat content. Still
+	// update lastHeartbeatNs so the owner's own session has a fresh
+	// liveness timestamp (useful symmetry with member sessions; the
+	// detectStaleActive pass skips owners but other diagnostics may
+	// look at it).
+	if text == HeartbeatMarker {
+		s.lastHeartbeatNs.Store(time.Now().UnixNano())
+		return nil
+	}
 	if h := s.handler; h != nil {
 		h(s.cfg.Record.ID, senderPK, Message{
 			SenderPK: senderPK,
@@ -859,6 +970,13 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 			// only see plaintext from this point.
 			msg.Ciphertext = nil
 			msg.Nonce = nil
+		}
+		// Heartbeat probe from the owner: refresh liveness timestamp
+		// and DO NOT bubble up. Wire-level only — the operator's
+		// listener shouldn't see them.
+		if IsHeartbeat(msg) {
+			s.lastHeartbeatNs.Store(time.Now().UnixNano())
+			continue
 		}
 		h(s.cfg.Record.ID, msg.SenderPK, msg)
 	}

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -54,6 +54,13 @@ func initGrouping(_ context.Context, v *Visor, log *logging.Logger) error {
 		MySK:    v.conf.SK,
 		DataDir: filepath.Join(dataDir, "cxo-groups"),
 		Logger:  log,
+		// Owner-side heartbeat emission. Every group this visor owns
+		// publishes a no-op probe every interval so members can detect
+		// a silently-stalled CXO subscriber via "no heartbeat in N
+		// seconds" rather than "no traffic in 5min". The recommended
+		// 30s cadence pairs with the member-side 90s stale threshold
+		// for a 2-misses-then-reconnect policy.
+		HeartbeatInterval: skychatgroup.DefaultHeartbeatInterval,
 	})
 	if err != nil {
 		_ = store.Close() //nolint:errcheck


### PR DESCRIPTION
## Summary

Closes F11b from the 3-agent coordination session: a CXO subscriber that silently halted left `status` pinned at `active` until the `subscriberStaleThreshold` fallback (5min in #2530) caught up — but only when chat traffic was expected. Quiet groups stayed undiagnosed indefinitely.

This PR adds owner-side periodic heartbeat publication so members can detect stalls via "no heartbeat in N seconds" rather than "no traffic in 5min".

### Mechanism

- **Owner side**: every `RoleOwner` session whose Manager has `HeartbeatInterval > 0` runs `runHeartbeatLoop`, publishing a `HeartbeatMarker` leaf every interval (default 30s) through the normal `publishAs` path. This exercises the publisher's full machinery; a publisher wedge surfaces as both `publishAs heartbeat failed` warns AND members' stale-detect firing.
- **Member side**: `onUpdate` exact-matches `HeartbeatMarker`, bumps `Session.lastHeartbeatNs` (`atomic.Int64`), and filters the message from the user handler / inbox. Wire noise stays off the operator's listener.
- **Stale detection** (extends `detectStaleActive` from #2530): when a member session has observed at least one heartbeat, uses heartbeat freshness with a 90s threshold (~3× emit interval, two-misses policy). Falls back to `last_message_at` with the 5min threshold for older owner deployments and freshly-rejoined members. The signal source is logged.
- **Owner-self-echo filter**: `publishAs` also short-circuits on `HeartbeatMarker` so owner doesn't deliver heartbeats to its own handler, and bumps its own `lastHeartbeatNs` for diagnostic parity.

### Wire cost

~80 bytes/heartbeat × 30s × N groups → ~8KB/hr/group. Negligible.

### Config

- `skychatgroup.ManagerConfig.HeartbeatInterval` (zero disables) — wired through `openLocked` → `Session.Open` → owner goroutine.
- `DefaultHeartbeatInterval = 30s` exported for the visor; `pkg/visor/init_group.go` passes it. Tests + tools that want quiet behavior pass zero.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./cmd/apps/skychat/group/...` pass
- [x] `make lint` — 0 issues
- [ ] Live: with both peers on this binary, kill the owner's CXO publisher (`pkill -STOP`-style or block port 63225) and confirm member-side stale-detect fires within ~90s (vs 5min on #2530-only)
- [ ] Live: `cli skychat group info` `subscriber_alive` updates correctly across heartbeat-induced reconnect cycles

## Related
- Builds on #2530 (stale-detect + `/status.groups_error`). Without that, this PR's stale-detection would still be there but without the visibility surfaces for operators.
- The owner-side `IsHeartbeat` helper is exported so the visor inbox layer can also filter heartbeats from `GroupPoll` ring buffers if a future revision wants to (not done here; current path filters at session level which is sufficient).