### PR TITLE
fix(skychat/group): re-assert subAlive on every delivered message

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -773,6 +773,24 @@ func (m *Manager) MarkMessageDelivered(groupID string, ts time.Time) {
 		m.log.WithError(err).WithField("id", groupID).
 			Debug("group: MarkMessageDelivered: store update failed")
 	}
+	// Re-assert subscriber liveness based on positive delivery
+	// evidence. The session's subAlive flag was set true at Connect
+	// and only cleared at Close, so a CXO conn that silently dies
+	// and reconnects under-the-hood (or a session that was created
+	// via a path that skipped the explicit Connect flag-flip) could
+	// report subscriber_alive=false despite messages flowing.
+	// Observed in production: peer reported subscriber_alive=false
+	// AND last_message_at fresh AND messages visible in listener
+	// log — three contradictory signals that point at subAlive being
+	// out of sync with reality. Any arriving message is proof that
+	// the underlying CXO connection is currently delivering data, so
+	// we re-assert here too.
+	m.mu.RLock()
+	sess := m.sessions[groupID]
+	m.mu.RUnlock()
+	if sess != nil {
+		sess.subAlive.Store(true)
+	}
 }
 
 // IsSubscriberAlive reports the live subscriber health for the group


### PR DESCRIPTION
## Summary

After #2530 + #2531, peer `03d1d78e` reported a residual contradiction: a member's group listener was receiving messages (own publishes from owner AND heartbeats every 30s, so `last_message_at` advanced correctly) but `subscriber_alive` stayed `false`. Three signals — listener log content, `last_message_at`, and `subscriber_alive` — all derive from the same delivery event but disagreed.

Root cause: `subAlive` lived on a separate code path from `MarkMessage`. It was only flipped `true` by `sess.Connect()` and `false` by `sess.Close()`. The CXO subscriber's internal reconnect (or any path that delivered messages without an explicit Connect cycle) left `subAlive` stale.

Fix (3 lines): `MarkMessageDelivered` now also flips `sess.subAlive = true`. Any arriving message is positive proof of liveness; the alive-flag should reflect that.

## Test plan
- [x] `go build ./...` clean
- [x] `make lint` 0 issues
- [ ] Live: peer with `subscriber_alive=false` despite traffic flowing should flip to `true` after next inbound message