### PR TITLE
fix(skychat/group): subscriber_alive promotes on inbound leaf, not only Connect()

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -943,7 +943,19 @@ func (s *Session) ReplayHistoryThrough(handler MessageHandler, cap int) {
 // registered handler. Tolerates undecodable leaves (e.g. future
 // metadata under a different prefix, or a tampered ciphertext) by
 // silently dropping them with a debug log.
+//
+// The CXO subscriber invoking this callback is itself proof the
+// subscriber is currently attached and pulling — so flip
+// subAlive=true on every onUpdate firing. This rescues the case
+// where Manager.detectStaleActive (or any other code path) demoted
+// the flag while leaves are still actually flowing: the next leaf
+// promotes the session back to alive, so /status's
+// subscriber_alive matches observable reality without waiting for
+// the reconnect loop's next tick.
 func (s *Session) onUpdate(events []treestore.UpdateEvent) {
+	if len(events) > 0 {
+		s.subAlive.Store(true)
+	}
 	h := s.handler
 	if h == nil {
 		return


### PR DESCRIPTION
## Summary

Pre-#2530 wiring set `s.subAlive=true` only on `Connect()` success and `false` only on `Close()`. #2530 added `Manager.detectStaleActive` which demotes `subAlive` to `false` when `LastMessageAt` lag exceeds a threshold — but the only path *back* to `true` after a demote was the next `Manager.tryReconnect` tick (up to 30s away, escalating to 5min or 30min under sustained failure). Meanwhile, if leaves were actually flowing from the publisher, `last_message_at` would advance through the `wrapHandler` MarkMessage path even while `subscriber_alive` stayed `false` — operator-visible internal inconsistency.

Observed in production today:
```
$ skywire cli skychat group info <id>
"status": "active",
"last_message_at": "2026-05-13T12:12:24.198Z",   ← fresh
"subscriber_alive": false                         ← lies
```

## Fix

3-line change in `Session.onUpdate` (the CXO callback for leaf arrivals): set `s.subAlive.Store(true)` at the top of the function. The callback firing is itself proof the subscriber is attached and pulling, so `subscriber_alive` should reflect that immediately rather than wait for the reconnect loop's next tick.

```go
func (s *Session) onUpdate(events []treestore.UpdateEvent) {
+   if len(events) > 0 {
+       s.subAlive.Store(true)
+   }
    h := s.handler
    ...
}
```

The `len(events) > 0` guard is defensive: an empty events slice is not proof of liveness (and shouldn't normally happen, but CXO is free to evolve).

## Behavior change

| State | Before | After |
|---|---|---|
| Connect() succeeds | subAlive=true | unchanged |
| detectStaleActive demotes a still-active sub | subAlive=false until next reconnect tick | next leaf restores subAlive=true immediately |
| Heartbeat leaf arrives at a demoted sub | subAlive stays false until reconnect | subAlive=true on the heartbeat callback |
| Close() called | subAlive=false | unchanged |

## Tests

- `go build ./cmd/apps/skychat/...` clean
- `go test ./cmd/apps/skychat/group/...` clean

## Context

Coordinated live with peer `03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c` (same `0pcom` GitHub identity — can't formally approve). The "3-line fix" was identified jointly as the residual gap after #2530 (groups visibility + stale-active demote + inbox.deliver MarkMessage) and #2531 (owner heartbeat watchdog) landed. This is the matching promote-on-evidence half of the demote-on-lag fix in #2530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)