### PR TITLE
fix(skychat/group): flip subAlive on heartbeat observation too

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -745,6 +745,14 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 	// look at it).
 	if text == HeartbeatMarker {
 		s.lastHeartbeatNs.Store(time.Now().UnixNano())
+		// Heartbeats are positive evidence of CXO liveness even though
+		// they bypass the MessageHandler / inbox.deliver chain (where
+		// #2532 hooks the subAlive flip). Without this, a heartbeat-
+		// only group — quiet enough that no real messages flow —
+		// would observe heartbeats every 30s, advance lastHeartbeatNs
+		// correctly, but report subscriber_alive=false because the
+		// alive flag was never re-asserted by the delivery chain.
+		s.subAlive.Store(true)
 		return nil
 	}
 	if h := s.handler; h != nil {
@@ -976,6 +984,12 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 		// listener shouldn't see them.
 		if IsHeartbeat(msg) {
 			s.lastHeartbeatNs.Store(time.Now().UnixNano())
+			// See the same flip in publishAs's heartbeat short-
+			// circuit for why this is necessary: heartbeats bypass
+			// the MessageHandler chain that #2532 hooks subAlive to,
+			// so member sessions in a quiet group would never see
+			// subAlive promoted on heartbeat-only traffic.
+			s.subAlive.Store(true)
 			continue
 		}
 		h(s.cfg.Record.ID, msg.SenderPK, msg)


### PR DESCRIPTION
## Summary

#2532 hooked `subAlive=true` on `Manager.MarkMessageDelivered`, which fires from the MessageHandler chain. But heartbeats bypass that chain — both the owner-self-echo in `publishAs` and the member-side `onUpdate` short-circuit on `HeartbeatMarker` BEFORE the handler runs, so heartbeat-only traffic never promoted `subAlive`.

Peer `03d1d78e` reproduced this 11 minutes post-#2532: `status=active` + `subscriber_alive=false` on a member whose group had heartbeats arriving every 30s but no chat traffic. Exactly the heartbeat-coverage gap peer `02f9aa58` predicted.

This patch sets `s.subAlive.Store(true)` at both heartbeat short-circuits:
- `publishAs` owner-self-echo (symmetric for diagnostic parity even though `detectStaleActive` skips owners)
- `onUpdate` member-side (the path that actually matters)

3 lines + comment.

## Test plan
- [x] `go build ./...` clean
- [x] `make lint` 0 issues
- [ ] Live: peer in a heartbeat-only group should see `subscriber_alive` flip to `true` within 30s of the next heartbeat (vs staying `false` indefinitely on #2532-alone)