### PR TITLE
feat(cli/config): LANDMSG defaults to ISHYPERVISOR + add LANDMSGPORT env knob

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -745,6 +745,14 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 	// look at it).
 	if text == HeartbeatMarker {
 		s.lastHeartbeatNs.Store(time.Now().UnixNano())
+		// Heartbeats are positive evidence of CXO liveness even though
+		// they bypass the MessageHandler / inbox.deliver chain (where
+		// #2532 hooks the subAlive flip). Without this, a heartbeat-
+		// only group — quiet enough that no real messages flow —
+		// would observe heartbeats every 30s, advance lastHeartbeatNs
+		// correctly, but report subscriber_alive=false because the
+		// alive flag was never re-asserted by the delivery chain.
+		s.subAlive.Store(true)
 		return nil
 	}
 	if h := s.handler; h != nil {
@@ -976,6 +984,12 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 		// listener shouldn't see them.
 		if IsHeartbeat(msg) {
 			s.lastHeartbeatNs.Store(time.Now().UnixNano())
+			// See the same flip in publishAs's heartbeat short-
+			// circuit for why this is necessary: heartbeats bypass
+			// the MessageHandler chain that #2532 hooks subAlive to,
+			// so member sessions in a quiet group would never see
+			// subAlive promoted on heartbeat-only traffic.
+			s.subAlive.Store(true)
 			continue
 		}
 		h(s.cfg.Record.ID, msg.SenderPK, msg)

--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -97,6 +97,23 @@ const envfileLinux = `#
 #--	Start the hypervisor interface for this visor
 #ISHYPERVISOR=true
 
+#--	Embedded LAN/WAN DMSG server. Defaults to ON whenever ISHYPERVISOR=true;
+#	managed visors then relay through this hypervisor instead of public
+#	DMSG servers. Set LANDMSG=false to opt out (e.g. HA pair where only
+#	one hypervisor runs the server).
+#LANDMSG=true
+
+#--	Pin the DMSG server's TCP port for stable WAN reachability. Default 0
+#	= OS-assigned at runtime (changes every restart — fine for LAN-only,
+#	bad for remote visors that need a stable address). Set to a chosen
+#	port (e.g. 8082) and port-forward it on your router for WAN access.
+#LANDMSGPORT=8082
+
+#--	Advertise a WAN-reachable address to remote visors (host:port). Empty
+#	= LAN-only. Combine with LANDMSGPORT + a router port-forward for
+#	hypervisors on a NAT.
+#LANDMSGPUBLIC='203.0.113.42:8082'
+
 ### Rewards #############################################################
 
 #--	Skycoin reward address or xpub key

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -388,12 +388,21 @@ func init() {
 	genConfigCmd.Flags().StringVar(&cliAddr, "cliaddr", scriptExecString("${CLIADDR}"), "CLI RPC address (e.g. 0.0.0.0:3435 for Docker)")
 	gHiddenFlags = append(gHiddenFlags, "cliaddr")
 
-	// Embedded DMSG server (LAN/WAN). Disabled by default; pinning the
-	// port + setting public_address makes it WAN-reachable for managed
-	// remote visors (operator must port-forward the chosen TCP port).
-	genConfigCmd.Flags().BoolVar(&lanDmsgEnable, "lan-dmsg", scriptExecBool("${LANDMSG:-false}"), "enable hypervisor's embedded DMSG server (requires --ishv)")
+	// Embedded LAN/WAN DMSG server. Defaults to on whenever the
+	// hypervisor is enabled (ISHYPERVISOR=true) — the embedded server
+	// is the hypervisor's responsibility to managed visors, so the
+	// "I'm a hypervisor" intent implies "I provide DMSG to my
+	// visors". Operator can force-disable with LANDMSG=false even
+	// when ISHYPERVISOR=true, e.g. for an HA pair where only one
+	// hypervisor should run the server.
+	//
+	// Pinning the port + setting public_address makes the server
+	// WAN-reachable for managed remote visors (operator must
+	// port-forward the chosen TCP port; without forwarding the
+	// server stays LAN-only).
+	genConfigCmd.Flags().BoolVar(&lanDmsgEnable, "lan-dmsg", scriptExecBool("${LANDMSG:-${ISHYPERVISOR:-false}}"), "enable hypervisor's embedded DMSG server (defaults to ISHYPERVISOR)")
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg")
-	genConfigCmd.Flags().IntVar(&lanDmsgPort, "lan-dmsg-port", 0, "embedded DMSG server TCP port (0 = OS-assigned at runtime; pin for stable WAN reachability)")
+	genConfigCmd.Flags().IntVar(&lanDmsgPort, "lan-dmsg-port", scriptExecInt("${LANDMSGPORT:-0}"), "embedded DMSG server TCP port (0 = OS-assigned at runtime; pin via LANDMSGPORT for stable WAN reachability)")
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg-port")
 	genConfigCmd.Flags().StringVar(&lanDmsgPublicAddress, "lan-dmsg-public", scriptExecString("${LANDMSGPUBLIC}"), "embedded DMSG server WAN-reachable address (host:port; requires port-forward)")
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg-public")


### PR DESCRIPTION
## Summary

Two operator-feedback items from the v1.3.53+ deployment story:

1. **Implicit LAN DMSG server on hypervisor**. The embedded LAN DMSG server should default to ON whenever `ISHYPERVISOR=true` — the hypervisor's responsibility to its managed visors implies "I provide DMSG to them". Operators were confused that an explicit `LANDMSG=true` was needed even after setting `ISHYPERVISOR=true`.

   Flag default changed from `scriptExecBool("${LANDMSG:-false}")` to `scriptExecBool("${LANDMSG:-${ISHYPERVISOR:-false}}")`. Hypervisors get the embedded server for free; pure visors stay unchanged. Explicit `LANDMSG=false` still wins (e.g. HA pair where only one of two hypervisors should run the server).

2. **`LANDMSGPORT` env knob**. The `--lan-dmsg-port` flag had no env-var counterpart. `skywire autoconfig` reads `/etc/skywire.conf` to drive `config gen`, so a flag-only knob meant operators couldn't pin the port through their canonical config file — they'd have to remember to pass it on every manual autoconfig run.

   Added `LANDMSGPORT` alongside `LANDMSGPUBLIC` via `scriptExecInt("${LANDMSGPORT:-0}")`.

Both env knobs documented in `envfiles.go` templates (bash + pwsh variants under `### Hypervisor UI ###`), with explanatory comments that pair them with `ISHYPERVISOR` and the WAN-reachable use case.

## Test plan
- [x] `go build ./...` clean
- [x] `make lint` 0 issues
- [ ] Live: `ISHYPERVISOR=true` alone produces a `lan_dmsg_server` block in the generated config
- [ ] Live: `LANDMSG=false` + `ISHYPERVISOR=true` produces NO `lan_dmsg_server` block (override works)
- [ ] Live: `LANDMSGPORT=8082` + `LANDMSGPUBLIC='1.2.3.4:8082'` produces a `lan_dmsg_server` block with `port: 8082` + `public_address: '1.2.3.4:8082'`