### PR TITLE
feat(skywire-autoconfig): persistent skywire.conf edits + cleanup vestigial knobs

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -38,15 +38,11 @@ const envfileLinux = `#
 #--	Use test deployment
 #TESTENV=true
 
-#--	Use dmsghttp to connect to the production deployment ; overrides BESTPROTO=true
+#--	Use dmsghttp to connect to the production deployment
 #DMSGHTTP=true
 
 #--	Number of dmsg serverts to connect to (0 unlimits)
 #MINDMSGSESS=8
-
-#--	Automatically determine the best protocol (dmsg or http)
-#	based on location to connect to the deployment servers
-#BESTPROTO=true
 
 ### Transports ##########################################################
 
@@ -97,11 +93,10 @@ const envfileLinux = `#
 #--	Start the hypervisor interface for this visor
 #ISHYPERVISOR=true
 
-#--	Embedded LAN/WAN DMSG server. Defaults to ON whenever ISHYPERVISOR=true;
-#	managed visors then relay through this hypervisor instead of public
-#	DMSG servers. Set LANDMSG=false to opt out (e.g. HA pair where only
-#	one hypervisor runs the server).
-#LANDMSG=true
+#--	Embedded LAN/WAN DMSG server is always on whenever ISHYPERVISOR=true.
+#	Managed visors relay through this hypervisor instead of public DMSG
+#	servers. The two knobs below control the WAN-reachability path; see
+#	the comments for when to set them.
 
 #--	Pin the DMSG server's TCP port for stable WAN reachability. Default 0
 #	= OS-assigned at runtime (changes every restart — fine for LAN-only,
@@ -316,15 +311,11 @@ const envfileWindows = `#
 #--	Use test deployment
 #$TESTENV=$true
 
-#--	Use dmsghttp to connect to the production deployment ; overrides BESTPROTO=$true
+#--	Use dmsghttp to connect to the production deployment
 #$DMSGHTTP=$true
 
 #--	Number of dmsg servers to connect to (0 unlimits)
 #$MINDMSGSESS=8
-
-#--	Automatically determine the best protocol (dmsg or http)
-#	based on location to connect to the deployment servers
-#$BESTPROTO=$true
 
 ### Transports ##########################################################
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -165,7 +165,13 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "dmsghttp")
 	genConfigCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "D", scriptExecString("${DMSGCONF}"), "dmsghttp-config path")
 	gHiddenFlags = append(gHiddenFlags, "dmsgconf")
-	genConfigCmd.Flags().BoolVarP(&isBestProtocol, "bestproto", "b", scriptExecBool("${BESTPROTO:-false}"), "best protocol (dmsg | direct) based on location") //this will also disable public autoconnect based on location
+	// Note: the historical `BESTPROTO=true` knob was a China-only
+	// dmsghttp-fallback path that fired only when ipinfo.io reported
+	// country=CN. The default dmsghttp+http fallback in service
+	// resolution covers that case everywhere now, so the knob is
+	// vestigial and removed in this revision. Operators who actually
+	// need the China-only behavior should set DMSGHTTP=true +
+	// DISABLEPUBLICAUTOCONN=true directly.
 	genConfigCmd.Flags().BoolVar(&noFetch, "nofetch", false, "do not fetch the services from the service conf url")
 	gHiddenFlags = append(gHiddenFlags, "nofetch")
 	// SvcConfName integration not wired in.
@@ -388,20 +394,18 @@ func init() {
 	genConfigCmd.Flags().StringVar(&cliAddr, "cliaddr", scriptExecString("${CLIADDR}"), "CLI RPC address (e.g. 0.0.0.0:3435 for Docker)")
 	gHiddenFlags = append(gHiddenFlags, "cliaddr")
 
-	// Embedded LAN/WAN DMSG server. Defaults to on whenever the
-	// hypervisor is enabled (ISHYPERVISOR=true) — the embedded server
-	// is the hypervisor's responsibility to managed visors, so the
-	// "I'm a hypervisor" intent implies "I provide DMSG to my
-	// visors". Operator can force-disable with LANDMSG=false even
-	// when ISHYPERVISOR=true, e.g. for an HA pair where only one
-	// hypervisor should run the server.
+	// Embedded LAN/WAN DMSG server. Always on whenever ISHYPERVISOR=true
+	// — "I'm a hypervisor" implies "I provide DMSG to my managed
+	// visors". The previous LANDMSG=true toggle was redundant in the
+	// 99% case (operators set it precisely because they had also set
+	// ISHYPERVISOR=true) and confusing in the 1% case (HA pair where
+	// the use case for one-but-not-the-other turned out to be
+	// imaginary — running two LAN-DMSG servers across two hypervisors
+	// is fine, managed visors just see two relay options).
 	//
-	// Pinning the port + setting public_address makes the server
-	// WAN-reachable for managed remote visors (operator must
-	// port-forward the chosen TCP port; without forwarding the
-	// server stays LAN-only).
-	genConfigCmd.Flags().BoolVar(&lanDmsgEnable, "lan-dmsg", scriptExecBool("${LANDMSG:-${ISHYPERVISOR:-false}}"), "enable hypervisor's embedded DMSG server (defaults to ISHYPERVISOR)")
-	gHiddenFlags = append(gHiddenFlags, "lan-dmsg")
+	// Operators who actually want hypervisor-without-LAN-DMSG can
+	// hand-edit /opt/skywire/skywire.json to drop the
+	// hypervisor.lan_dmsg_server.enable boolean.
 	genConfigCmd.Flags().IntVar(&lanDmsgPort, "lan-dmsg-port", scriptExecInt("${LANDMSGPORT:-0}"), "embedded DMSG server TCP port (0 = OS-assigned at runtime; pin via LANDMSGPORT for stable WAN reachability)")
 	gHiddenFlags = append(gHiddenFlags, "lan-dmsg-port")
 	genConfigCmd.Flags().StringVar(&lanDmsgPublicAddress, "lan-dmsg-public", scriptExecString("${LANDMSGPUBLIC}"), "embedded DMSG server WAN-reachable address (host:port; requires port-forward)")
@@ -601,12 +605,6 @@ var genConfigCmd = &cobra.Command{
 		// enable errors from service conf fetch from the combination of these flags
 		if isStdout && isHide {
 			isStdout = false
-		}
-
-		//determine best protocol
-		if isBestProtocol && netutil.LocalProtocol() {
-			disablePublicAutoConn = true
-			isDmsgHTTP = true
 		}
 
 		fetchServiceConfig(log)
@@ -1303,12 +1301,18 @@ func configureHypervisor(log *logging.Logger) {
 		} else {
 			config.HTTPAddr = offsetAddr(config.HTTPAddr)
 		}
-		// Embedded DMSG server. Only emit the block when the operator
-		// asked for it (or supplied port/public-address knobs); leaving
-		// it nil keeps existing configs unchanged.
-		if lanDmsgEnable || lanDmsgPort != 0 || lanDmsgPublicAddress != "" {
+		// Embedded LAN/WAN DMSG server. Implicit-on whenever this
+		// visor is also a hypervisor — the hypervisor's
+		// responsibility to its managed visors implies it provides
+		// the DMSG relay. Operators who want a hypervisor WITHOUT
+		// the embedded server can drop the
+		// `hypervisor.lan_dmsg_server.enable` boolean in
+		// /opt/skywire/skywire.json post-gen; that path is
+		// expected to be vanishingly rare so it's not exposed via
+		// a config-gen flag.
+		if isHypervisor {
 			config.LANDmsgServer = &visorconfig.LANDmsgServerConf{
-				Enable:        lanDmsgEnable,
+				Enable:        true,
 				Port:          lanDmsgPort,
 				PublicAddress: lanDmsgPublicAddress,
 			}
@@ -1908,15 +1912,14 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 	// Map of flag names to the SKYENV variable they control.
 	// When a flag is explicitly set, uncomment the corresponding line.
 	flagToEnv := map[string]string{
-		"pkg":       "PKGENV=true",
-		"bestproto": "BESTPROTO=true",
-		"ishv":      "ISHYPERVISOR=true",
-		"testenv":   "TESTENV=true",
-		"dmsghttp":  "DMSGHTTP=true",
-		"public":    "VISORISPUBLIC=true",
-		"servevpn":  "VPNSERVER=true",
-		"autoconn":  "DISABLEPUBLICAUTOCONN=true",
-		"publicip":  "DISPLAYNODEIP=true",
+		"pkg":      "PKGENV=true",
+		"ishv":     "ISHYPERVISOR=true",
+		"testenv":  "TESTENV=true",
+		"dmsghttp": "DMSGHTTP=true",
+		"public":   "VISORISPUBLIC=true",
+		"servevpn": "VPNSERVER=true",
+		"autoconn": "DISABLEPUBLICAUTOCONN=true",
+		"publicip": "DISPLAYNODEIP=true",
 	}
 
 	// Also handle string/value flags

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -51,7 +51,6 @@ var (
 	isEnableAuth               bool
 	selectedOS                 string
 	disableApps                string
-	isBestProtocol             bool
 	serviceConfURL             = deployment.ProdConf.Conf
 	testServiceConfURL         = deployment.TestConf.Conf
 	dnsServer                  = "1.1.1.1"
@@ -146,10 +145,11 @@ var (
 	muxRoutes                int
 	cliAddr                  string
 	// Hypervisor-embedded DMSG server (LAN/WAN). Operator-set knobs:
-	// enable, port, and an optional public address advertised to remote
+	// port and an optional public address advertised to remote
 	// visors. Port should be pinned for stable WAN reachability since
-	// the OS-assigned port (when 0) changes on every restart.
-	lanDmsgEnable        bool
+	// the OS-assigned port (when 0) changes on every restart. The
+	// "enable" boolean is implicit — the LAN-DMSG server is always
+	// on whenever ISHYPERVISOR=true.
 	lanDmsgPort          int
 	lanDmsgPublicAddress string
 )

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -63,9 +63,123 @@ const systemdDropIn = "/etc/systemd/system/skywire.service.d/skywire-user.conf"
 
 var autoconfigVerbose bool
 
+// Editable-via-autoconfig knobs. When the operator passes any of
+// these flags, autoconfig rewrites the corresponding line in the
+// resolved SKYENV file BEFORE calling `skywire cli config gen`, so
+// the change is persisted to /etc/skywire.conf and survives
+// re-runs and package reinstalls.
+//
+// Each flag mirrors a `config gen` flag of the same name. We don't
+// pass them through to the subprocess — instead we edit skywire.conf
+// and let the existing `SKYENV=<file> config gen` invocation pick
+// them up. This keeps skywire.conf as the single source of truth.
+var (
+	autoSetHvpks          string
+	autoSetIshv           bool
+	autoSetNoIshv         bool
+	autoSetRewardAddr     string
+	autoSetPublic         bool
+	autoSetNoPublic       bool
+	autoSetStcprPort      int
+	autoSetSudphPort      int
+	autoSetLanDmsgPort    int
+	autoSetLanDmsgPublic  string
+	autoSetDmsgptyPks     string
+	autoSetVpnServer      bool
+	autoSetNoVpnServer    bool
+	autoSetProxyServer    bool
+	autoSetNoProxyServer  bool
+	autoSetSkychat        bool
+	autoSetNoSkychat      bool
+	autoSetDmsgweb        bool
+	autoSetNoDmsgweb      bool
+	autoSetSkynetweb      bool
+	autoSetNoSkynetweb    bool
+	autoSetDisablePubAuto bool
+)
+
 func init() {
 	autoconfigCmd.Flags().BoolVarP(&autoconfigVerbose, "verbose", "v", false, "show reward address, support links, and other details")
+
+	// Persistent skywire.conf edits. Each --flag sets the
+	// corresponding env var; --no-flag clears it back to default.
+	// Empty-string / zero-value flags are "leave unchanged" by
+	// virtue of Flags().Changed() lookup at runtime.
+	autoconfigCmd.Flags().StringVar(&autoSetHvpks, "hvpks", "", "set HYPERVISORPKS in skywire.conf (comma-separated PKs)")
+	autoconfigCmd.Flags().BoolVar(&autoSetIshv, "ishv", false, "set ISHYPERVISOR=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoIshv, "no-ishv", false, "set ISHYPERVISOR=false in skywire.conf")
+	autoconfigCmd.Flags().StringVar(&autoSetRewardAddr, "rewardaddr", "", "set REWARDSKYADDR in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetPublic, "public", false, "set VISORISPUBLIC=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoPublic, "no-public", false, "set VISORISPUBLIC=false in skywire.conf")
+	autoconfigCmd.Flags().IntVar(&autoSetStcprPort, "stcpr", 0, "set STCPRPORT in skywire.conf (0 = leave unchanged)")
+	autoconfigCmd.Flags().IntVar(&autoSetSudphPort, "sudph", 0, "set SUDPHPORT in skywire.conf (0 = leave unchanged)")
+	autoconfigCmd.Flags().IntVar(&autoSetLanDmsgPort, "lan-dmsg-port", 0, "set LANDMSGPORT in skywire.conf (0 = leave unchanged)")
+	autoconfigCmd.Flags().StringVar(&autoSetLanDmsgPublic, "lan-dmsg-public", "", "set LANDMSGPUBLIC in skywire.conf (host:port)")
+	autoconfigCmd.Flags().StringVar(&autoSetDmsgptyPks, "dmsgpty-pks", "", "set DMSGPTYPKS in skywire.conf (comma-separated PKs)")
+	autoconfigCmd.Flags().BoolVar(&autoSetVpnServer, "vpnserver", false, "set VPNSERVER=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoVpnServer, "no-vpnserver", false, "set VPNSERVER=false in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetProxyServer, "proxyserver", false, "set PROXYSERVER=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoProxyServer, "no-proxyserver", false, "set PROXYSERVER=false in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetSkychat, "skychat", false, "set SKYCHAT=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoSkychat, "no-skychat", false, "set SKYCHAT=false in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetDmsgweb, "dmsgweb", false, "set DMSGWEB=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoDmsgweb, "no-dmsgweb", false, "set DMSGWEB=false in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetSkynetweb, "skynetweb", false, "set SKYNETWEB=true in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetNoSkynetweb, "no-skynetweb", false, "set SKYNETWEB=false in skywire.conf")
+	autoconfigCmd.Flags().BoolVar(&autoSetDisablePubAuto, "disable-public-autoconn", false, "set DISABLEPUBLICAUTOCONN=true in skywire.conf")
+
 	RootCmd.AddCommand(autoconfigCmd)
+}
+
+// collectSkyenvEdits walks the autoSet* flags and assembles the list
+// of edits to apply to /etc/skywire.conf. Only flags the operator
+// actually passed are included — un-passed flags leave the
+// corresponding lines untouched.
+func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
+	var edits []skyenvEdit
+	// Bool-pair helper: --flag wins over --no-flag if both somehow set,
+	// but cobra normally only sees one per invocation.
+	addBool := func(key string, onName, offName string, on, off bool) {
+		switch {
+		case cmd.Flags().Changed(onName) && on:
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(true)})
+		case cmd.Flags().Changed(offName) && off:
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(false)})
+		}
+	}
+
+	if cmd.Flags().Changed("hvpks") {
+		edits = append(edits, skyenvEdit{Key: "HYPERVISORPKS", Value: formatSkyenvBashArray(autoSetHvpks)})
+	}
+	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoSetIshv, autoSetNoIshv)
+	if cmd.Flags().Changed("rewardaddr") {
+		edits = append(edits, skyenvEdit{Key: "REWARDSKYADDR", Value: formatSkyenvString(autoSetRewardAddr)})
+	}
+	addBool("VISORISPUBLIC", "public", "no-public", autoSetPublic, autoSetNoPublic)
+	if cmd.Flags().Changed("stcpr") {
+		edits = append(edits, skyenvEdit{Key: "STCPRPORT", Value: formatSkyenvInt(autoSetStcprPort)})
+	}
+	if cmd.Flags().Changed("sudph") {
+		edits = append(edits, skyenvEdit{Key: "SUDPHPORT", Value: formatSkyenvInt(autoSetSudphPort)})
+	}
+	if cmd.Flags().Changed("lan-dmsg-port") {
+		edits = append(edits, skyenvEdit{Key: "LANDMSGPORT", Value: formatSkyenvInt(autoSetLanDmsgPort)})
+	}
+	if cmd.Flags().Changed("lan-dmsg-public") {
+		edits = append(edits, skyenvEdit{Key: "LANDMSGPUBLIC", Value: formatSkyenvString(autoSetLanDmsgPublic)})
+	}
+	if cmd.Flags().Changed("dmsgpty-pks") {
+		edits = append(edits, skyenvEdit{Key: "DMSGPTYPKS", Value: formatSkyenvBashArray(autoSetDmsgptyPks)})
+	}
+	addBool("VPNSERVER", "vpnserver", "no-vpnserver", autoSetVpnServer, autoSetNoVpnServer)
+	addBool("PROXYSERVER", "proxyserver", "no-proxyserver", autoSetProxyServer, autoSetNoProxyServer)
+	addBool("SKYCHAT", "skychat", "no-skychat", autoSetSkychat, autoSetNoSkychat)
+	addBool("DMSGWEB", "dmsgweb", "no-dmsgweb", autoSetDmsgweb, autoSetNoDmsgweb)
+	addBool("SKYNETWEB", "skynetweb", "no-skynetweb", autoSetSkynetweb, autoSetNoSkynetweb)
+	if cmd.Flags().Changed("disable-public-autoconn") {
+		edits = append(edits, skyenvEdit{Key: "DISABLEPUBLICAUTOCONN", Value: formatSkyenvBool(autoSetDisablePubAuto)})
+	}
+	return edits
 }
 
 // resolvedConfig captures the answers autoconfig derives from the
@@ -100,13 +214,40 @@ Mode is selected by PKGENV/USRENV in the env file:
   neither set            → falls back to PKGENV when run as root,
                            USRENV otherwise.`,
 	Hidden: true,
-	Run: func(_ *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) {
 		if os.Getenv("NOAUTOCONFIG") == "true" {
 			fmt.Println("autoconfiguration disabled. to configure and start skywire run: skywire autoconfig")
 			os.Exit(0)
 		}
 
 		msg2("Configuring skywire")
+
+		// Apply any operator-requested skywire.conf edits before
+		// the rest of autoconfig sources the file. Each `--flag`
+		// rewrites the corresponding env line in place (uncomment +
+		// new value), preserving every other line. The subsequent
+		// `cli config gen` invocation reads the updated file via
+		// SKYENV so the new values take effect on the same run.
+		//
+		// Resolves the skyenv path FIRST so we know which file to
+		// edit — same lookup the downstream stages use, just lifted
+		// up to do the edits first.
+		if edits := collectSkyenvEdits(cmd); len(edits) > 0 {
+			pre := resolveConfig()
+			target := pre.skyenvPath
+			if target == "" {
+				target = defaultSkyenvPath()
+			}
+			if err := updateSkyenvFile(target, edits); err != nil {
+				fmt.Printf("%s>>> FATAL:%s could not update %s: %v\n", colorRed, colorReset, target, err)
+				os.Exit(1)
+			}
+			editedKeys := make([]string, 0, len(edits))
+			for _, e := range edits {
+				editedKeys = append(editedKeys, e.Key)
+			}
+			msg3(fmt.Sprintf("Updated %s%s%s: %s", colorPurple, target, colorReset, strings.Join(editedKeys, " ")))
+		}
 
 		versionOut, err := exec.Command("skywire", "-v").Output()
 		if err == nil {

--- a/cmd/skywire/commands/autoconfig_skyenv.go
+++ b/cmd/skywire/commands/autoconfig_skyenv.go
@@ -1,0 +1,228 @@
+// Package commands cmd/skywire/commands/autoconfig_skyenv.go
+//
+// updateSkyenvFile applies a list of key/value edits to a bash-style
+// env file (e.g. /etc/skywire.conf). For each edit:
+//
+//   - If a line `KEY=...` exists (commented `#KEY=...` or not), it is
+//     replaced with the new `KEY=value` form, uncommented.
+//   - If no such line exists, the edit is appended at the end of the
+//     file under a "set by skywire autoconfig" header.
+//
+// Other lines (comments, unrelated settings, formatting) are preserved
+// verbatim. Write is atomic: temp file + fsync + rename.
+//
+// This is the implementation behind the `skywire autoconfig --hvpks ...`
+// family of flags that bypass having operators hand-edit the config
+// file for the common knobs while still keeping that file as the
+// single source of truth for `skywire cli config gen`.
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// skyenvEdit is one key/value update applied to a skyenv file.
+// Value should already be formatted in the bash syntax expected for
+// that key — single-quoted strings, bare booleans/ints, or
+// '(...)'-wrapped arrays. See formatSkyenvBool / formatSkyenvString /
+// formatSkyenvBashArray helpers below.
+type skyenvEdit struct {
+	Key   string // bash variable name (e.g. "HYPERVISORPKS")
+	Value string // RHS, including quoting / array parens / value
+}
+
+// updateSkyenvFile applies the edits to the file at path. The file
+// must already exist — `skywire autoconfig` always installs the
+// template via the package, so this is a safe assumption for the
+// operator-facing flow. Returns an error if the file is missing or
+// the atomic rename fails.
+//
+// If two edits target the same key, the LATER one wins (mirrors the
+// bash semantics of sequential assignment).
+func updateSkyenvFile(path string, edits []skyenvEdit) error {
+	if len(edits) == 0 {
+		return nil
+	}
+	if path == "" {
+		return fmt.Errorf("updateSkyenvFile: empty path")
+	}
+
+	// De-dupe + last-write-wins, preserving insertion order for the
+	// append-tail case. Map provides constant-time lookup during the
+	// scan; slice holds order for the eventual append.
+	desired := make(map[string]string, len(edits))
+	ordered := make([]string, 0, len(edits))
+	for _, e := range edits {
+		if _, ok := desired[e.Key]; !ok {
+			ordered = append(ordered, e.Key)
+		}
+		desired[e.Key] = e.Value
+	}
+
+	src, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("updateSkyenvFile: open %s: %w", path, err)
+	}
+	defer src.Close() //nolint:errcheck
+
+	matched := make(map[string]bool, len(desired))
+	out := make([]string, 0, 256)
+
+	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20) // tolerate long lines
+	for scanner.Scan() {
+		line := scanner.Text()
+		if k := skyenvLineKey(line); k != "" {
+			if v, ok := desired[k]; ok {
+				out = append(out, k+"="+v)
+				matched[k] = true
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("updateSkyenvFile: scan %s: %w", path, err)
+	}
+
+	// Append any keys we never matched. Tag the block so operators
+	// scanning the file later can tell autoconfig wrote it.
+	var appended []string
+	for _, k := range ordered {
+		if !matched[k] {
+			appended = append(appended, k+"="+desired[k])
+		}
+	}
+	if len(appended) > 0 {
+		// Trim a trailing empty line on the existing file so the
+		// header block stays visually attached without a double blank.
+		for len(out) > 0 && out[len(out)-1] == "" {
+			out = out[:len(out)-1]
+		}
+		out = append(out,
+			"",
+			"### Added by `skywire autoconfig` ######################################",
+		)
+		out = append(out, appended...)
+	}
+
+	// Atomic write: temp file in the same dir, fsync, rename. Same-dir
+	// is required so the rename is on the same filesystem.
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".skywire.conf.tmp-")
+	if err != nil {
+		return fmt.Errorf("updateSkyenvFile: tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) } //nolint:errcheck
+	w := bufio.NewWriter(tmp)
+	for _, line := range out {
+		if _, err := w.WriteString(line); err != nil {
+			_ = tmp.Close() //nolint:errcheck,gosec
+			cleanup()
+			return fmt.Errorf("updateSkyenvFile: write: %w", err)
+		}
+		if _, err := w.WriteString("\n"); err != nil {
+			_ = tmp.Close() //nolint:errcheck,gosec
+			cleanup()
+			return fmt.Errorf("updateSkyenvFile: write: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = tmp.Close() //nolint:errcheck,gosec
+		cleanup()
+		return fmt.Errorf("updateSkyenvFile: flush: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close() //nolint:errcheck,gosec
+		cleanup()
+		return fmt.Errorf("updateSkyenvFile: sync: %w", err)
+	}
+	// Preserve original mode if possible; otherwise default to 0644
+	// (autoconfig usually runs as root via systemd, and the file is
+	// world-readable by design — operators view it without sudo).
+	mode := os.FileMode(0644)
+	if st, err := os.Stat(path); err == nil {
+		mode = st.Mode().Perm()
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close() //nolint:errcheck,gosec
+		cleanup()
+		return fmt.Errorf("updateSkyenvFile: chmod: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("updateSkyenvFile: close: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("updateSkyenvFile: rename: %w", err)
+	}
+	return nil
+}
+
+// skyenvKeyRE matches `KEY=` or `#KEY=` (with optional leading
+// whitespace and optional space between `#` and the key). Captures the
+// key name. Anchored at line start.
+//
+// Conservative on the LHS: only matches the bash-conventional shape
+// (UPPER_CASE plus underscore + digits). Mixed-case `key=value` lines,
+// rare in skywire.conf, are left untouched — autoconfig will append
+// them as new lines instead of trying to replace.
+var skyenvKeyRE = regexp.MustCompile(`^\s*#?\s*([A-Z_][A-Z0-9_]*)=`)
+
+// skyenvLineKey returns the bash variable name from a line that looks
+// like `KEY=value` or `#KEY=value`, or empty if the line isn't a
+// recognizable variable assignment.
+func skyenvLineKey(line string) string {
+	m := skyenvKeyRE.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// formatSkyenvBool returns the bash-literal form for a boolean knob:
+// "true" or "false". Bash treats both as bare words; the visor's
+// scriptExecBool unwraps either to a Go bool.
+func formatSkyenvBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// formatSkyenvString returns the bash-literal form for a string knob.
+// Single-quoted with `'` escaped via `'\”`. Operators read these
+// values verbatim; we don't try to be clever about it.
+func formatSkyenvString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// formatSkyenvBashArray returns the `('a' 'b' 'c')` form expected by
+// HYPERVISORPKS / DMSGPTYPKS / etc. Input is split on commas; each
+// element is trimmed and single-quoted. Empty input produces `(”)`
+// to match the template's default-empty representation.
+func formatSkyenvBashArray(csv string) string {
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, "'"+strings.ReplaceAll(p, "'", `'\''`)+"'")
+	}
+	if len(out) == 0 {
+		return "('')"
+	}
+	return "(" + strings.Join(out, " ") + ")"
+}
+
+// formatSkyenvInt returns the bash-literal form for an int knob.
+func formatSkyenvInt(i int) string { return fmt.Sprintf("%d", i) }


### PR DESCRIPTION
## Summary

Three operator-feedback items from the v1.3.53+ deployment story, bundled.

### 1. `skywire autoconfig` learns persistent skywire.conf edits

A focused set of flags mirror the operator-facing `config gen` knobs. When passed, autoconfig rewrites the corresponding line in the resolved SKYENV file BEFORE calling `config gen`. Other lines (comments, unrelated settings, operator edits) are preserved verbatim; missing keys get appended under a "Added by skywire autoconfig" header. Atomic write.

Flags: `--hvpks`, `--ishv`/`--no-ishv`, `--rewardaddr`, `--public`/`--no-public`, `--stcpr`, `--sudph`, `--lan-dmsg-port`, `--lan-dmsg-public`, `--dmsgpty-pks`, `--vpnserver`/`--no-vpnserver`, `--proxyserver`/`--no-proxyserver`, `--skychat`/`--no-skychat`, `--dmsgweb`/`--no-dmsgweb`, `--skynetweb`/`--no-skynetweb`, `--disable-public-autoconn`.

Net effect: `sudo skywire autoconfig --hvpks 02abc,03def --rewardaddr 2skyaddr` becomes a one-liner that persists across re-runs and package reinstalls.

### 2. BESTPROTO removed (vestigial)

`BESTPROTO=true` only did anything when ipinfo.io country lookup returned "CN" — a China-specific dmsghttp-fallback path. The default dmsghttp+http fallback covers that everywhere now.

Drops the flag, env knob, the `if isBestProtocol && netutil.LocalProtocol()` branch in gen.go, and the template entries (bash + pwsh).

### 3. LANDMSG toggle collapsed into ISHYPERVISOR

Embedded LAN/WAN DMSG server is now ALWAYS on when `ISHYPERVISOR=true`. The previous toggle was redundant in the 99% case and the imagined HA-pair use case turned out not to be a real problem.

`LANDMSGPORT` + `LANDMSGPUBLIC` knobs remain — they control WAN-reachability of the always-on server.

## Test plan
- [x] `go build ./...` clean
- [x] `make lint` 0 issues
- [ ] Live: `sudo skywire autoconfig --hvpks 02abc --rewardaddr 2sky` mutates /etc/skywire.conf with the two values and `config gen` picks them up on the same run
- [ ] Live: `ISHYPERVISOR=true` alone produces `lan_dmsg_server.enable: true` in the generated config (no `LANDMSG=true` needed)
- [ ] Live: removing `BESTPROTO=true` from an existing skywire.conf is a no-op (line ignored by config gen)