### PR TITLE
refactor(skychat/group): collapse 4 liveness flags into single lastInboundNs

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -387,33 +387,20 @@ func (m *Manager) Resume() error {
 // isn't dial-hammered.
 const reconnectInterval = 30 * time.Second
 
-// subscriberStaleThreshold is the lag (now - last_message_at) above
-// which an "active" member session is treated as silently stale and
-// demoted to StatusPending so the existing reconnect machinery kicks
-// in. Set well above any plausible owner-publish gap to avoid false
-// positives on genuinely quiet groups: ~10× the reconnect interval.
+// subscriberStaleThreshold is the lag (now - Session.LastInbound())
+// above which a member session is considered stale enough to warrant
+// a reconnect attempt. Set to 3× the owner heartbeat cadence (~30s)
+// plus jitter, so a single missed heartbeat doesn't trigger flap but
+// two consecutive misses do. Used both by
+// Session.IsSubscriberAlive (the operator-visible /status flag) and
+// Manager.detectStaleAndReconnect (the background recovery driver).
 //
-// The trade-off is recovery latency vs. unnecessary reconnects. A
-// truly stuck subscriber stays stuck up to this duration after the
-// CXO conn dies. A quiet group sees an unnecessary reconnect every
-// time the threshold elapses with no traffic — that's OK because
-// (a) reconnect is cheap, (b) ConnectPK is idempotent so the
-// underlying conn is reused when healthy, and (c) the backoff
-// machinery limits churn on persistent failure.
-//
-// A proper fix is owner-side heartbeat publication (PR-C) so
-// subscribers can distinguish "no traffic" from "no pull". This
-// threshold is the bridge until that lands.
-const subscriberStaleThreshold = 5 * time.Minute
-
-// heartbeatStaleThreshold is the lag threshold applied when a session
-// has been observing owner heartbeats. Set to ~3× the recommended
-// emit interval (30s) so a single missed heartbeat doesn't trigger
-// a reconnect — but two consecutive misses do, surfacing real stalls
-// inside ~90s. Tight relative to subscriberStaleThreshold because the
-// heartbeat signal is predictable: a healthy group emits regardless
-// of whether anyone is chatting.
-const heartbeatStaleThreshold = 90 * time.Second
+// Post-#unified-liveness: there is now ONE liveness signal
+// (Session.lastInboundNs, bumped on every onUpdate event including
+// heartbeats), so the previous heartbeat-vs-chat-traffic threshold
+// split is gone — heartbeats are bumps of lastInbound just like
+// chat messages, and the single threshold applies to both.
+const subscriberStaleThreshold = 100 * time.Second
 
 // reconnectAttemptTimeout bounds the per-Connect call so the
 // reconnect loop can't get stuck on a single slow group while other
@@ -445,16 +432,17 @@ func (m *Manager) startReconnectLoop() {
 	go m.runReconnectLoop(m.reconnectCtx)
 }
 
-// runReconnectLoop walks every member-side session in StatusPending
-// on a 30s cadence and re-attempts Connect. Successes promote the
-// record back to StatusActive and reset the per-group failure
-// counter. Failures bump the failure counter and, past the configured
-// thresholds, extend the next-attempt time so the loop skips that
-// group until the backoff window elapses.
+// runReconnectLoop is the background recovery driver. On a 30s
+// cadence it walks every member-role session and triggers a
+// reconnect on any whose Session.LastInbound() is stale (or never
+// recorded). Status is no longer manipulated by this loop — Status
+// is configuration state (Active/Pending/Revoked) set by the
+// operator's join/leave actions and by Connect-result transitions.
+// Health is computed live from LastInbound by IsSubscriberAlive.
 //
 // Logging levels follow the spec:
 //   - debug: every reconnect attempt (success or failure)
-//   - info:  every successful reconnect (StatusPending → StatusActive)
+//   - info:  every successful reconnect
 //   - warn:  every backoff-interval transition
 func (m *Manager) runReconnectLoop(ctx context.Context) {
 	defer m.reconnectWG.Done()
@@ -466,35 +454,28 @@ func (m *Manager) runReconnectLoop(ctx context.Context) {
 			return
 		case <-t.C:
 		}
-		// Two-pass tick: first detect silently-stale active sessions
-		// and demote them to pending; then run the existing pending-
-		// reconnect pass. Order matters — the demotion has to happen
-		// before the pending walk so freshly-demoted records get a
-		// reconnect attempt this same tick.
-		m.detectStaleActive(ctx)
-		m.attemptReconnectPending(ctx)
+		m.detectStaleAndReconnect(ctx)
 	}
 }
 
-// detectStaleActive demotes any active member session whose persisted
-// last_message_at lag exceeds subscriberStaleThreshold. The demotion
-// is the only signal we have today that a "healthy-looking" subscriber
-// has gone silent — Resume's SetStatus(active) and tryReconnect's
-// success path both leave status pinned at active until something
-// flips it back. The CXO Subscriber doesn't surface "my conn died"
-// to us; until owner-side heartbeat publication lands (PR-C) the lag
-// is our best proxy.
+// detectStaleAndReconnect walks every member-role session and
+// triggers a reconnect attempt on any whose Session.LastInbound()
+// is older than subscriberStaleThreshold (or whose session has
+// never observed an inbound, indicated by a zero LastInbound).
 //
-// Demoted records pick up the reconnect loop's normal backoff state,
-// so a session that genuinely cannot reconnect doesn't churn — it
-// retries on the established schedule (30s → 5min after 10 fails →
-// 30min after 30 fails). The wrap-around on success clears the
-// backoff and restores active.
+// This is the recovery driver for the unified liveness signal:
+// IsSubscriberAlive is a pure function of LastInbound, and this
+// pass is what wakes a stuck subscriber back up. Unlike the
+// pre-#unified-liveness version, this does NOT touch
+// Record.Status — Status now reflects configuration state only
+// (joined/left/revoked), not subscriber health. Health is
+// computed live from LastInbound on every /status read.
 //
-// Skips: owner-role sessions (no subscriber), records without a
-// last_message_at (zero value — no traffic ever seen, may be a
-// brand-new join), terminal records.
-func (m *Manager) detectStaleActive(ctx context.Context) {
+// Skips: owner-role sessions (no subscriber), revoked records,
+// sessions without a corresponding live Session in m.sessions.
+// A zero LastInbound on a live session IS treated as stale —
+// we never saw the subscriber attach, so a reconnect is warranted.
+func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -504,81 +485,46 @@ func (m *Manager) detectStaleActive(ctx context.Context) {
 	}
 	now := time.Now().UTC()
 	for _, r := range records {
-		if r.Role != RoleMember || r.Status != StatusActive {
+		if r.Role != RoleMember {
 			continue
 		}
-		// Prefer the heartbeat signal when available — it ticks on a
-		// fixed cadence regardless of chat traffic, so a quiet-but-
-		// healthy group doesn't trip stale-detect. Fall back to
-		// last_message_at lag only when no heartbeat has been seen
-		// (older owner deployments without heartbeat publication, or
-		// a freshly-rejoined member that hasn't observed one yet).
+		// Both Active and Pending records get the stale-check.
+		// Active records that drift stale + Pending records that
+		// never finished the initial Connect both want a kick from
+		// the same reconnect machinery. Terminal states (Left,
+		// Revoked) are skipped — the operator's intent is "not in
+		// the group anymore", not "in the group but unhealthy".
+		if r.Status != StatusActive && r.Status != StatusPending {
+			continue
+		}
 		m.mu.RLock()
 		sess := m.sessions[r.ID]
 		m.mu.RUnlock()
-		var (
-			lag       time.Duration
-			signal    string
-			haveProbe bool
-		)
-		if sess != nil {
-			if lhb := sess.LastHeartbeat(); !lhb.IsZero() {
-				lag = now.Sub(lhb)
-				signal = "heartbeat"
-				haveProbe = true
-			}
+		if sess == nil {
+			continue
 		}
-		if !haveProbe {
-			if r.LastMessageAt.IsZero() {
-				continue
-			}
-			lag = now.Sub(r.LastMessageAt)
-			signal = "last_message_at"
+		last := sess.LastInbound()
+		var lag time.Duration
+		var reason string
+		if last.IsZero() {
+			lag = subscriberStaleThreshold + time.Second // forces the lag > threshold branch
+			reason = "no inbound seen"
+		} else {
+			lag = now.Sub(last)
+			reason = "last_inbound lag"
 		}
-		// Pick the appropriate threshold. Heartbeats are predictable
-		// (~30s cadence) so we can be aggressive — 3× interval ≈ 90s.
-		// Chat-traffic lag is unpredictable; keep the conservative
-		// 5-minute threshold to avoid spurious demotes on quiet groups.
-		threshold := subscriberStaleThreshold
-		if signal == "heartbeat" {
-			threshold = heartbeatStaleThreshold
-		}
-		if lag <= threshold {
+		if lag <= subscriberStaleThreshold {
 			continue
 		}
 		m.log.WithField("id", r.ID).
 			WithField("lag", lag.Round(time.Second).String()).
-			WithField("signal", signal).
-			Warn("group: active session stale; demoting to pending for reconnect")
-		if err := m.store.SetStatus(r.ID, StatusPending); err != nil {
-			m.log.WithError(err).WithField("id", r.ID).
-				Debug("group: stale-detect: SetStatus pending failed")
-		}
-	}
-}
-
-// attemptReconnectPending iterates all member-role sessions currently
-// in StatusPending and tries each one. Single-pass: a session whose
-// Connect succeeds here won't be tried again until its status is
-// reset to pending (e.g. on next visor restart, or a future fault).
-func (m *Manager) attemptReconnectPending(ctx context.Context) {
-	records, err := m.store.List()
-	if err != nil {
-		m.log.WithError(err).Debug("group: reconnect: store list failed")
-		return
-	}
-	now := time.Now().UTC()
-	for _, r := range records {
-		if r.Role != RoleMember || r.Status != StatusPending {
-			continue
-		}
+			WithField("reason", reason).
+			WithField("status", string(r.Status)).
+			Debug("group: session stale; kicking reconnect")
+		// Honor the per-group backoff schedule and don't churn on
+		// permanent failures. reconnectShouldAttempt returns false
+		// while the previous attempt's backoff window is still open.
 		if !m.reconnectShouldAttempt(r.ID, now) {
-			continue
-		}
-		m.mu.RLock()
-		sess, ok := m.sessions[r.ID]
-		m.mu.RUnlock()
-		if !ok || sess == nil {
 			continue
 		}
 		m.tryReconnect(ctx, sess, r.ID)
@@ -586,9 +532,13 @@ func (m *Manager) attemptReconnectPending(ctx context.Context) {
 }
 
 // tryReconnect runs one Connect attempt under reconnectAttemptTimeout.
-// On success: clears per-group failure state, flips Status →
-// StatusActive. On failure: bumps the counter and applies any
-// configured backoff transition.
+// On success: clears per-group failure state and promotes Status →
+// StatusActive (handles the join-Pending → join-Active transition;
+// idempotent on records that were already Active). On failure: bumps
+// the counter and applies any configured backoff transition.
+// Health-reflection from this success now flows automatically:
+// Session.Connect bumps lastInboundNs, so IsSubscriberAlive becomes
+// true on the very next /status read.
 func (m *Manager) tryReconnect(ctx context.Context, sess *Session, id string) {
 	m.log.WithField("id", id).Debug("group: reconnect: attempting subscribe")
 	type result struct{ err error }
@@ -773,24 +723,14 @@ func (m *Manager) MarkMessageDelivered(groupID string, ts time.Time) {
 		m.log.WithError(err).WithField("id", groupID).
 			Debug("group: MarkMessageDelivered: store update failed")
 	}
-	// Re-assert subscriber liveness based on positive delivery
-	// evidence. The session's subAlive flag was set true at Connect
-	// and only cleared at Close, so a CXO conn that silently dies
-	// and reconnects under-the-hood (or a session that was created
-	// via a path that skipped the explicit Connect flag-flip) could
-	// report subscriber_alive=false despite messages flowing.
-	// Observed in production: peer reported subscriber_alive=false
-	// AND last_message_at fresh AND messages visible in listener
-	// log — three contradictory signals that point at subAlive being
-	// out of sync with reality. Any arriving message is proof that
-	// the underlying CXO connection is currently delivering data, so
-	// we re-assert here too.
-	m.mu.RLock()
-	sess := m.sessions[groupID]
-	m.mu.RUnlock()
-	if sess != nil {
-		sess.subAlive.Store(true)
-	}
+	// Post-#unified-liveness: in-memory liveness now flows through
+	// Session.lastInboundNs (set in Session.onUpdate on every event
+	// batch). MarkMessageDelivered no longer touches a separate
+	// flag; the message arrived via onUpdate before the inbox got
+	// it, so lastInboundNs is already fresh by the time we land here.
+	// The only side effect of this method now is the LastMessageAt
+	// store-write above — the persisted projection of the in-memory
+	// signal, used to seed lastInboundNs after a visor restart.
 }
 
 // IsSubscriberAlive reports the live subscriber health for the group

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -98,11 +98,13 @@ type Config struct {
 
 	// HeartbeatInterval, when > 0, makes owner-role sessions emit a
 	// periodic no-op heartbeat probe into the group feed. Members
-	// observe the heartbeats via onUpdate, track lastHeartbeatNs, and
-	// use it as the freshness signal for stale-subscriber detection.
-	// Zero disables heartbeat emission entirely (useful for tests and
-	// for deployments that want to opt out of the ~1KB/min/group
-	// wire cost). Recommended production value: 30s.
+	// observe the heartbeats via onUpdate, which bumps lastInboundNs
+	// (the unified liveness signal) just as a real message would.
+	// Heartbeats are what keep IsSubscriberAlive true on quiet groups
+	// where no chat traffic flows for long stretches. Zero disables
+	// heartbeat emission entirely (useful for tests and for
+	// deployments that want to opt out of the ~1KB/min/group wire
+	// cost). Recommended production value: 30s.
 	HeartbeatInterval time.Duration
 }
 
@@ -153,24 +155,37 @@ type Session struct {
 	handler MessageHandler
 	log     *logging.Logger
 
-	// subAlive tracks whether the most recent Connect() succeeded
-	// and the subscriber has not yet been torn down. Owner-role
-	// sessions are always considered alive (no subscriber to track).
-	// Surfaced through IsSubscriberAlive for the chat-app's /status
-	// per-group health field. Atomic so it can be read without
-	// acquiring any session mutex from the status handler's hot path.
-	subAlive atomic.Bool
+	// lastInboundNs is the unified liveness signal for this session,
+	// in unix-nanoseconds. Set on every observable inbound event —
+	// onUpdate firing on the CXO subscriber (member side) and the
+	// owner-self-echo wrapper observing publishAs (owner side). Both
+	// heartbeats and real chat messages bump it; the distinction
+	// stops mattering here because any leaf arrival is positive
+	// proof the subscriber is currently attached and pulling.
+	//
+	// Pre-refactor (#2530..#2534) this role was split across four
+	// fields — Session.subAlive (Connect/Close), Session.lastHeartbeatNs
+	// (heartbeat-only), Record.LastMessageAt (chat-only persisted),
+	// Record.Status (configuration state pulling double duty as health).
+	// They kept disagreeing in subtle ways and each fix patched ONE
+	// pairwise disagreement; the holistic answer is a single signal
+	// computed not stored, with the persisted LastMessageAt kept as
+	// a coarse-grained crash-recovery seed.
+	//
+	// Initialized from Record.LastMessageAt on session Open so a
+	// freshly-resumed session doesn't appear instantly stale before
+	// the first new inbound arrives. Zero only if no traffic has
+	// ever been seen for this group.
+	//
+	// Atomic so the chat-app's /status hot path can read without any
+	// session-level mutex.
+	lastInboundNs atomic.Int64
 
-	// lastHeartbeatNs holds the unix-nanosecond timestamp at which
-	// this session most recently OBSERVED an owner heartbeat. Set
-	// when the subscriber's onUpdate sees a heartbeat-marker leaf
-	// (member side) OR when the owner-self-echo wrapper sees it
-	// (owner side, kept for symmetry). Zero means no heartbeat seen
-	// yet. Used by the Manager's runReconnectLoop to detect a
-	// silently-stalled subscriber within ~heartbeatStaleThreshold of
-	// the actual stall, rather than waiting for the
-	// no-traffic-implies-stuck fallback.
-	lastHeartbeatNs atomic.Int64
+	// closed is set true on Close so IsSubscriberAlive can short-
+	// circuit to false for torn-down sessions without consulting
+	// lastInbound timing. Owner-role sessions ignore this — they're
+	// always alive while the publisher is running.
+	closed atomic.Bool
 
 	// heartbeatCancel stops the owner-side heartbeat emission loop.
 	// nil for member-role sessions or when HeartbeatInterval=0.
@@ -178,10 +193,16 @@ type Session struct {
 	heartbeatWG     sync.WaitGroup
 }
 
+// subscriberStaleThreshold is defined in manager.go (it's used by
+// both Session.IsSubscriberAlive and Manager.detectStaleAndReconnect
+// so it sits in the package-level const block there).
+
 // HeartbeatMarker is the fixed body of an owner-emitted heartbeat
-// message. Subscribers detect it by exact-match on Message.Text,
-// update lastHeartbeatNs, and DO NOT bubble the message up to the
-// user handler / inbox — heartbeats are wire noise, not chat.
+// message. Subscribers detect it by exact-match on Message.Text and
+// DO NOT bubble the message up to the user handler / inbox —
+// heartbeats are wire noise, not chat. The liveness side effect
+// (bumping lastInboundNs) happens unconditionally at the top of
+// onUpdate, before the heartbeat filter runs.
 //
 // Picked to be (a) unambiguous (operator typing this verbatim into a
 // chat input would be a deliberate spoof, and the sender PK check
@@ -330,8 +351,9 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 //
 // Failures are debug-logged and the loop continues. A persistent
 // publisher problem will show up as both "publishAs heartbeat
-// failed" repeated in the log AND members' lastHeartbeatNs going
-// stale; the latter is the operator-facing signal.
+// failed" repeated in the log AND members' Session.LastInbound()
+// going stale (driving subscriber_alive=false in /status); the
+// latter is the operator-facing signal.
 func (s *Session) runHeartbeatLoop(ctx context.Context, interval time.Duration) {
 	defer s.heartbeatWG.Done()
 	t := time.NewTicker(interval)
@@ -393,6 +415,15 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 	}
 	sub.SetPrefixes([]string{MessagePathPrefix})
 	s := &Session{cfg: cfg, port: cfg.Record.Port, pub: pub, sub: sub, log: log}
+	// Seed lastInboundNs from the persisted LastMessageAt so a
+	// resumed session doesn't look instantly stale before the first
+	// new inbound arrives. Zero LastMessageAt (brand-new join, no
+	// traffic yet) seeds zero — IsSubscriberAlive will report false
+	// until Connect succeeds or the first inbound lands, both of
+	// which bump the timestamp.
+	if !cfg.Record.LastMessageAt.IsZero() {
+		s.lastInboundNs.Store(cfg.Record.LastMessageAt.UnixNano())
+	}
 	sub.OnUpdate(s.onUpdate)
 	return s, nil
 }
@@ -401,10 +432,12 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 // handshake. Owner sessions are a no-op (they don't subscribe to
 // themselves). Idempotent: returns nil if already connected.
 //
-// On success, flips subAlive=true so IsSubscriberAlive starts
-// reporting "true" for operator-visible group health. On error,
-// subAlive stays false and the Manager's background reconnect
-// loop (Manager.runReconnectLoop) keeps retrying.
+// On success, bumps lastInboundNs to now — Connect itself is
+// positive evidence the subscriber side is healthy, so the
+// liveness window starts ticking from here rather than from "no
+// inbound yet". On error, lastInboundNs stays at whatever it was
+// (seeded from Record.LastMessageAt at Open) and the Manager's
+// background reconnect loop keeps retrying.
 func (s *Session) Connect() error {
 	if s.sub == nil {
 		return nil // owner role
@@ -412,8 +445,25 @@ func (s *Session) Connect() error {
 	if err := s.sub.Connect(s.cfg.Record.OwnerPK); err != nil {
 		return fmt.Errorf("group: Connect: %w", err)
 	}
-	s.subAlive.Store(true)
+	s.lastInboundNs.Store(time.Now().UnixNano())
 	return nil
+}
+
+// LastInbound returns the time at which this session most recently
+// observed any inbound CXO event — a chat leaf, an owner heartbeat,
+// or any other update. Zero if no traffic has ever been seen AND
+// Record.LastMessageAt was zero at Open (so the seed yielded zero).
+//
+// Used by Manager.detectStaleAndReconnect to identify subscribers
+// that have silently stopped pulling from the owner, and by
+// IsSubscriberAlive to compute the liveness boolean operators see
+// in /status.
+func (s *Session) LastInbound() time.Time {
+	ns := s.lastInboundNs.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns).UTC()
 }
 
 // IsSubscriberAlive reports whether the subscriber side of this
@@ -422,37 +472,38 @@ func (s *Session) Connect() error {
 // operators can spot a member session whose Connect failed silently
 // or whose subscriber has been torn down.
 //
-// Semantics:
+// Semantics — computed, not stored:
 //   - Owner-role sessions: always true (no subscriber to track; the
 //     publisher side is owned by this visor and there's nothing to
 //     "lose connection" to).
-//   - Member-role sessions: true iff the most recent Connect()
-//     succeeded AND Close has not been called. Does NOT consult the
-//     underlying treestore.Subscriber's live conn state — that would
-//     require a new accessor on Subscriber and the connection there
-//     is best-effort heartbeated by CXO already. The boolean here is
-//     "did we successfully attach + do we believe we're still
-//     attached"; the background reconnect loop is responsible for
-//     re-asserting that belief on its 30s cadence.
+//   - Member-role sessions, after Close: false (the session has been
+//     explicitly torn down; the underlying CXO subscriber is gone).
+//   - Member-role sessions, no inbound ever: false (we never had
+//     evidence the subscriber attached).
+//   - Member-role sessions, any prior inbound: true iff the last
+//     inbound is within subscriberStaleThreshold. Stale beyond that
+//     and the Manager's detectStaleAndReconnect loop will kick a
+//     reconnect; the flag stays false until the next inbound (or a
+//     successful Connect()) refreshes lastInboundNs.
 //
-// LastHeartbeat returns the time at which this session most recently
-// observed an owner heartbeat probe, or the zero time if none seen
-// yet. Used by Manager.runReconnectLoop's stale-detection to demote
-// a silently-stalled subscriber within ~heartbeatStaleThreshold of
-// the stall, regardless of whether chat traffic is flowing.
-func (s *Session) LastHeartbeat() time.Time {
-	ns := s.lastHeartbeatNs.Load()
-	if ns == 0 {
-		return time.Time{}
-	}
-	return time.Unix(0, ns).UTC()
-}
-
+// The unification was previously four-flagged (subAlive bool +
+// lastHeartbeatNs + LastMessageAt + Status's health semantics).
+// Each pair of those could disagree, and we patched the
+// disagreements one by one (#2530, #2532, #2533, #2534). The fix
+// here removes the disagreement class entirely: there is ONE
+// timestamp, and aliveness is a pure function of it.
 func (s *Session) IsSubscriberAlive() bool {
 	if s.sub == nil {
 		return true // owner role
 	}
-	return s.subAlive.Load()
+	if s.closed.Load() {
+		return false
+	}
+	last := s.LastInbound()
+	if last.IsZero() {
+		return false
+	}
+	return time.Since(last) <= subscriberStaleThreshold
 }
 
 // ID returns the group's UUID.
@@ -516,9 +567,12 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 // CXO node, owned by the publisher). Idempotent.
 func (s *Session) Close() error {
 	var firstErr error
-	// Flip subAlive first so any concurrent /status read sees the
+	// Mark closed first so any concurrent /status read sees the
 	// session as dead even if Close races with a long Subscriber.Close.
-	s.subAlive.Store(false)
+	// IsSubscriberAlive short-circuits to false on this flag for
+	// member-role sessions, so we don't have to also rewind
+	// lastInboundNs.
+	s.closed.Store(true)
 	// Stop the owner-side heartbeat emitter (if running). No-op on
 	// member sessions or when HeartbeatInterval=0 at Open time.
 	if s.heartbeatCancel != nil {
@@ -739,20 +793,12 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 	// subscriber path would surface, not the encrypted bytes.
 	// Filter heartbeat self-echoes out of the handler delivery —
 	// they are wire-level liveness probes, not chat content. Still
-	// update lastHeartbeatNs so the owner's own session has a fresh
+	// bump lastInboundNs so the owner's own session has a fresh
 	// liveness timestamp (useful symmetry with member sessions; the
-	// detectStaleActive pass skips owners but other diagnostics may
-	// look at it).
+	// detectStaleAndReconnect pass skips owners but other diagnostics
+	// may look at it).
 	if text == HeartbeatMarker {
-		s.lastHeartbeatNs.Store(time.Now().UnixNano())
-		// Heartbeats are positive evidence of CXO liveness even though
-		// they bypass the MessageHandler / inbox.deliver chain (where
-		// #2532 hooks the subAlive flip). Without this, a heartbeat-
-		// only group — quiet enough that no real messages flow —
-		// would observe heartbeats every 30s, advance lastHeartbeatNs
-		// correctly, but report subscriber_alive=false because the
-		// alive flag was never re-asserted by the delivery chain.
-		s.subAlive.Store(true)
+		s.lastInboundNs.Store(time.Now().UnixNano())
 		return nil
 	}
 	if h := s.handler; h != nil {
@@ -951,7 +997,17 @@ func (s *Session) ReplayHistoryThrough(handler MessageHandler, cap int) {
 // registered handler. Tolerates undecodable leaves (e.g. future
 // metadata under a different prefix, or a tampered ciphertext) by
 // silently dropping them with a debug log.
+//
+// Bumps lastInboundNs once per non-empty events batch — the
+// callback firing is itself proof the subscriber is attached and
+// pulling, regardless of whether the events decode, decrypt, or
+// turn out to be heartbeats. This is the unified liveness signal
+// that replaces the four-flag tangle (subAlive bool +
+// lastHeartbeatNs + LastMessageAt + Status's health semantics).
 func (s *Session) onUpdate(events []treestore.UpdateEvent) {
+	if len(events) > 0 {
+		s.lastInboundNs.Store(time.Now().UnixNano())
+	}
 	h := s.handler
 	if h == nil {
 		return
@@ -979,17 +1035,11 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 			msg.Ciphertext = nil
 			msg.Nonce = nil
 		}
-		// Heartbeat probe from the owner: refresh liveness timestamp
-		// and DO NOT bubble up. Wire-level only — the operator's
-		// listener shouldn't see them.
+		// Heartbeat probe from the owner: lastInboundNs is already
+		// bumped above (event count > 0). Don't bubble heartbeats
+		// up to the user handler — they're wire-level liveness
+		// probes, not chat content.
 		if IsHeartbeat(msg) {
-			s.lastHeartbeatNs.Store(time.Now().UnixNano())
-			// See the same flip in publishAs's heartbeat short-
-			// circuit for why this is necessary: heartbeats bypass
-			// the MessageHandler chain that #2532 hooks subAlive to,
-			// so member sessions in a quiet group would never see
-			// subAlive promoted on heartbeat-only traffic.
-			s.subAlive.Store(true)
 			continue
 		}
 		h(s.cfg.Record.ID, msg.SenderPK, msg)


### PR DESCRIPTION
## Summary

Today's resilience pass landed four incremental fixes (#2530, #2532, #2533, #2534), each patching one pairwise disagreement between four overlapping liveness signals:

| Signal | Driven by |
|---|---|
| `Session.subAlive` (atomic.Bool) | `Connect()`, `Close()` |
| `Session.lastHeartbeatNs` (atomic.Int64) | heartbeat-only path in `onUpdate` |
| `Record.LastMessageAt` (persisted) | `MarkMessage` via `wrapHandler` + `MarkMessageDelivered` |
| `Record.Status` (persisted) | `detectStaleActive` (health), join/leave actions (config) |

Each pair could disagree, and we patched the disagreements one-by-one. This PR removes the disagreement class entirely by collapsing to **one** in-memory signal.

## The new design

```go
type Session struct {
    // ...
    lastInboundNs atomic.Int64 // bumped in onUpdate and Connect; the sole liveness signal
    closed        atomic.Bool  // explicit teardown short-circuit for IsSubscriberAlive
    // ... (subAlive and lastHeartbeatNs removed)
}
```

Bump sites:
- `Session.onUpdate`: once per non-empty events batch at the top of the loop (any CXO callback firing is positive evidence the subscriber is attached and pulling).
- `Session.Connect`: success path (Connect itself is evidence).

Derived signals:
- `IsSubscriberAlive()` = `!closed && time.Since(lastInbound()) <= subscriberStaleThreshold`. Computed, not stored. Owner-role short-circuits to true.
- `Record.LastMessageAt` becomes the **persisted projection** — used to seed `lastInboundNs` at `Open` after a visor restart so a resumed session doesn't look instantly stale.
- `Record.Status` reverts to **pure configuration state** (Active, Pending during join, Revoked, Left). No longer encodes subscriber health.

`detectStaleActive` is rewritten to `detectStaleAndReconnect`: walks member-role sessions (both Active and Pending), checks `sess.LastInbound()` lag, kicks `tryReconnect` when lag exceeds threshold. Does **not** mutate `Record.Status`. `attemptReconnectPending` is folded in and dropped.

`subscriberStaleThreshold` tightens from 5 minutes to 100 seconds (3× heartbeat cadence + jitter). Heartbeats are now part of the unified signal so the threshold can match the predictable heartbeat rhythm rather than the unpredictable chat-traffic rhythm. The old `heartbeatStaleThreshold` (90s) is gone.

`MarkMessageDelivered` drops the `subAlive` flip added in #2532; `lastInboundNs` is already fresh by the time it runs (`onUpdate` bumped it on the same delivery before the inbox handler).

## Behavior change matrix

| Before | After |
|---|---|
| `subAlive=true` + `LastMessageAt` stale | impossible (one signal) |
| `subAlive=false` + messages flowing | impossible (one signal) |
| `Status=Active` + subscriber dead | `Status` pure config; alive computed |
| `detectStaleActive` flips `Status` | gone; just kicks reconnect |
| Quiet group sub demoted after 5min | stays alive (heartbeats are inbound evidence) |
| Stale-sub reconnect via Pending walk | direct from `detectStaleAndReconnect` |

## Tests

- `go build ./cmd/apps/skychat/... ./pkg/visor/...` clean
- `go test -race ./cmd/apps/skychat/... ./pkg/visor/...` clean

## Coordination

Coordinated live with peer `03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c` — we converged on the same shape independently (PEER1's earlier truncated `lastInboundAt` proposal matches the design here). Peer `0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c` authored the four prior incremental fixes that this PR subsumes (#2530, #2532, #2534).

Per the morning's user mandate to stop the whack-a-mole pattern and unify the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)