### PR TITLE
fix(cxo/node): bounded sendMsg + fan-out broadcastRoot — closes F11b

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -465,6 +465,28 @@ func (c *Conn) encodeMsg(seq, rseq uint32, m msg.Msg) (raw []byte) {
 
 }
 
+// sendMsgQueueTimeout is the max time sendMsg will wait to enqueue a
+// message into the per-conn sendq. The underlying transport.Connection
+// buffers 256 frames in the `out` channel; if the buffer is full it
+// means the writeLoop is stuck (e.g. the underlying net.Conn is in a
+// silent half-close — the kernel TCP write hasn't surfaced an error
+// yet, but the writer isn't draining either).
+//
+// Pre-fix sendMsg waited indefinitely on `c.sendq <- ...`. A single
+// stuck subscriber would block broadcastRoot's sequential iteration
+// over n.cs, so the publisher's runLoop hung and NO subscriber got
+// the next root push — symptom: peers reported group heartbeats
+// silently stopped arriving and detectStaleActive eventually fired
+// across all subs in lockstep.
+//
+// Bounded with a short timeout: if the buffer can't drain in N
+// seconds the conn is declared dead, Close fires (idempotent), and
+// the conn's run() loop removes it from the nodeFeeds map so future
+// broadcasts skip it. The bounded path means a single dead sub costs
+// at most one timeout's worth of latency on the broadcast — bad but
+// bounded — instead of stopping pushes entirely.
+const sendMsgQueueTimeout = 5 * time.Second
+
 func (c *Conn) sendMsg(seq, rseq uint32, m msg.Msg) error {
 	c.n.Debugf(MsgSendPin, "[%s] send %d %T", c.String(), rseq, m)
 
@@ -474,9 +496,29 @@ func (c *Conn) sendMsg(seq, rseq uint32, m msg.Msg) error {
 	default:
 	}
 
-	c.sendq <- c.encodeMsg(seq, rseq, m)
+	encoded := c.encodeMsg(seq, rseq, m)
 
-	return nil
+	// Fast path: buffer has room, enqueue immediately.
+	select {
+	case c.sendq <- encoded:
+		return nil
+	default:
+	}
+
+	// Slow path: buffer is full. Bound the wait so a stuck subscriber
+	// doesn't stall the publisher's broadcastRoot iteration. closeq
+	// is also selected so a concurrent Close unblocks us cleanly.
+	select {
+	case c.sendq <- encoded:
+		return nil
+	case <-c.closeq:
+		return ErrClosed
+	case <-time.After(sendMsgQueueTimeout):
+		c.n.Printf("[WARN] [%s] sendMsg: queue full for %s; declaring conn dead and closing",
+			c.String(), sendMsgQueueTimeout)
+		_ = c.Close() //nolint:errcheck,gosec
+		return ErrClosed
+	}
 }
 
 func (c *Conn) receiveMsg() error {

--- a/pkg/cxo/node/feed.go
+++ b/pkg/cxo/node/feed.go
@@ -105,13 +105,26 @@ func (n *nodeFeed) close() {
 
 func (n *nodeFeed) broadcastRoot(cr connRoot) {
 
+	// Fan out per-subscriber pushes concurrently so one slow conn's
+	// bounded-but-non-zero queue wait (see sendMsgQueueTimeout in
+	// conn.go) doesn't serialize the broadcast latency. Without this,
+	// even with sendMsg bounded at 5s, three stuck subs would mean a
+	// 15s gap before the third healthy sub gets pushed. With fan-out
+	// the per-sub queue wait is parallelized and the publisher's
+	// runLoop returns to drain wakeup events sooner.
+	//
+	// Goroutines complete (or self-timeout via sendMsgQueueTimeout)
+	// independently; no WaitGroup needed because the caller doesn't
+	// observe individual sub-side completions. sendRoot is fire-and-
+	// forget by design — errors translate to a Close that the
+	// conn's run() loop reaps.
 	for c := range n.cs {
 
 		if c == cr.c {
 			continue
 		}
 
-		c.sendRoot(cr.r)
+		go c.sendRoot(cr.r) //nolint:errcheck
 	}
 
 }


### PR DESCRIPTION
## Root cause of F11b ('owner publishes go silent after first message')

Identified via the publisher-fanout dive promised in the three-agent coordination today.

Pre-fix flow on a publisher with N subscribers, one of which has a silently-half-closed network conn (kernel TCP write hasn't surfaced the error yet, but the writer side isn't draining):

```
publishRoot → cxoNode.Publish(r) → n.fs.broadcastRoot(...)
 → for c in n.cs: c.sendRoot(r)         ← serial iteration
 → sendMsg: c.sendq <- encoded          ← INFINITE WAIT
```

When the stuck conn's underlying `transport.Connection.out` buffer fills (256 frames), `c.sendq <- ...` blocks indefinitely. That blocks broadcastRoot, Publish, and the publisher's runLoop. Every subsequent publish (including heartbeats) silently stalls. ALL OTHER SUBSCRIBERS go quiet too — they're behind the same dead sub in the serial iteration.

Symptom matched exactly: peer reported "rejoin → 1 msg → 16-minute silence" on both peer hosts simultaneously. The "1 msg" was `sendLastRoot` from the freshly-Subscribe'd handshake; subsequent publish-driven pushes all hit the stalled iteration.

## Fix part 1 — bounded `sendMsg` (`conn.go`)

- Fast-path: non-blocking enqueue when buffer has room.
- Slow-path: bounded `select` with `sendMsgQueueTimeout = 5s` + `closeq` cancellation. On timeout, declare the conn dead via `Close()` (idempotent), return `ErrClosed`.

Cost on a healthy slow consumer: 5s of buffering before drop + close. Cost on a dead consumer: same 5s, then auto-recover by reaping the conn so subsequent broadcasts skip it.

## Fix part 2 — fan-out `broadcastRoot` (`feed.go`)

Per-subscriber `sendRoot` calls happen in goroutines now. One bounded-stuck subscriber adds at most its own 5s timeout to that subscriber's send, but doesn't serialize the broadcast. With N subs, the publisher returns control to runLoop in O(1) instead of O(N) on worst-case dead-conn iteration.

`sendRoot` is already fire-and-forget (void return). Errors translate to `Close` which the conn's `run()` loop reaps. No `WaitGroup` required.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/cxo/node/...` pass
- [x] `make lint` 0 issues
- [ ] Live: with one peer's CXO sub artificially stuck (e.g. `iptables -A INPUT -p tcp --sport <pub-port> -j DROP` on the sub side), publisher heartbeats should still reach the OTHER peer
- [ ] Live: stuck sub auto-recovers within ~5s after the timeout fires (visible as a WARN log line: "sendMsg: queue full for X; declaring conn dead and closing")

## Follow-ups (not in this PR)
- Test for the timeout path with a programmable-stall transport.
- Metric / log counter for `sendMsg` timeout firings, surfaced via `/status` so operators can see the dead-conn rate.