### PR TITLE
fix(cli/log): bootstrap dmsg from embedded servers, fetch UT over dmsghttp

### DIFF
--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"math/rand"
@@ -25,8 +24,8 @@ import (
 
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/cmdutil" //nolint:errcheck
-	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 )
@@ -93,19 +92,59 @@ var logCmd = &cobra.Command{
 			return
 		}
 
-		// Create dmsgcurl instance
-		dg := dmsgcurl.New(flag.CommandLine)
-		flag.Parse()
+		// Bootstrap DMSG using embedded prod server entries before anything
+		// else — the previous code path opened dmsgC via `dmsgcurl.StartDmsg`
+		// which hits the dmsg-discovery over plain HTTP, AND fetched the UT
+		// over plain HTTP before dmsgC existed. Pre-seeding from the
+		// embedded keyring lets us reach UT + every per-visor endpoint
+		// purely over dmsghttp from here on. Falls back to HTTP discovery
+		// only if the binary has no embedded server entries (out-of-prod
+		// builds). Server-type empty = no filtering (production default).
+		pk, err := sk.PubKey()
+		if err != nil {
+			pk, sk = cipher.GenerateKeyPair()
+		}
+		bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers, dmsgDisc, "")
+		if err != nil {
+			log.WithError(err).Error("Failed to bootstrap dmsg client.")
+			return
+		}
+		defer bootstrap.Close()
+		dmsgC := bootstrap.Client
 
-		// Set the uptime tracker to fetch data from
+		// One pooled dmsghttp client reused for both the UT fetch and the
+		// per-visor download loop below. The transport pools per-host
+		// streams internally so concurrent visor fetches share dmsg
+		// sessions instead of paying a fresh noise handshake each.
+		dmsgHTTPC := &http.Client{
+			Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC),
+			Timeout:   60 * time.Second,
+		}
+
+		// Connect dmsgC to any additional servers the dmsg-disc knows
+		// about beyond the embedded prod set. BootstrapDmsg already
+		// dials every embedded entry; this loop catches custom / test
+		// servers that operators may have configured but that aren't
+		// baked into the binary. Fetches over dmsghttp using dmsgHTTPC,
+		// not plain HTTP.
+		allServer := getAllDMSGServers(cmd.Flags())
+		for _, server := range allServer {
+			dmsgC.EnsureAndObtainSession(ctx, server.PK) //nolint:errcheck,gosec
+		}
+
+		// Set the uptime tracker to fetch data from. We rewrite the
+		// HTTP base to its dmsg counterpart from the deployment map so
+		// the request rides over dmsghttp on dmsgC; if the operator
+		// passed a custom utAddr that has no known dmsg twin, the
+		// original HTTP URL is used as-is (the dmsghttp transport would
+		// reject it for being non-PK-host, so getUptimes falls back to
+		// a plain http.Client in that case).
 		endpoint := utAddr + "/uptimes?v=v2"
-
 		if fetchFrom != "" {
 			endpoint = utAddr + "&visors=" + fetchFrom
 		}
 
-		//Fetch the uptime data over http
-		uptimes, err := getUptimes(endpoint, log)
+		uptimes, err := getUptimes(ctx, endpoint, dmsgHTTPC, log)
 		if err != nil {
 			log.WithError(err).Error("Unable to get data from uptime tracker.")
 			return
@@ -114,24 +153,6 @@ var logCmd = &cobra.Command{
 		rand.Shuffle(len(uptimes), func(i, j int) {
 			uptimes[i], uptimes[j] = uptimes[j], uptimes[i]
 		})
-		// Create dmsg http client
-		pk, err := sk.PubKey()
-		if err != nil {
-			pk, sk = cipher.GenerateKeyPair()
-		}
-
-		dmsgC, closeDmsg, err := dg.StartDmsg(ctx, log, pk, sk)
-		if err != nil {
-			log.Error(err) //nolint:errcheck
-			return
-		}
-		defer closeDmsg()
-
-		// Connect dmsgC to all servers
-		allServer := getAllDMSGServers(cmd.Flags())
-		for _, server := range allServer {
-			dmsgC.EnsureAndObtainSession(ctx, server.PK) //nolint:errcheck,gosec
-		}
 
 		minimumVersion, _ := version.NewVersion(minv) //nolint:errcheck
 		incVerList := strings.Split(incVer, ",")
@@ -393,12 +414,32 @@ func (pw *ProgressWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func getUptimes(endpoint string, log *logging.Logger) ([]VisorUptimeResponse, error) {
+// getUptimes fetches the visor list from the uptime tracker. Prefers
+// the dmsg form (http://<UT-PK>:<port>/...) over the passed dmsgHTTPC,
+// since dmsgHTTPC is a pooled dmsghttp transport that already shares
+// the caller's dmsg sessions. Falls back to plain HTTP iff the UT URL
+// has no known dmsg twin in the deployment map (operator-overridden
+// utAddr against a non-deployment UT).
+//
+// Pre-fix, this function spun up its own plain http.Client and never
+// went over dmsg, even when a perfectly good dmsg.Client was already
+// up in the same process.
+func getUptimes(ctx context.Context, endpoint string, dmsgHTTPC *http.Client, log *logging.Logger) ([]VisorUptimeResponse, error) {
 	var results []VisorUptimeResponse
-	client := http.Client{
-		Timeout: 60 * time.Second,
+	fetchURL := endpoint
+	client := dmsgHTTPC
+	if dmsgEquiv := clirpc.DmsgURLForHTTP(endpoint); dmsgEquiv != "" {
+		fetchURL = dmsgEquiv
+	} else {
+		log.Debugf("No dmsg twin for %s; falling back to plain HTTP for UT fetch", endpoint)
+		client = &http.Client{Timeout: 60 * time.Second}
 	}
-	response, err := client.Get(endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		log.Error("Error while building UT request. Error: ", err)
+		return results, errors.New("Cannot get Uptime data")
+	}
+	response, err := client.Do(req)
 	if err != nil {
 		log.Error("Error while fetching data from uptime service. Error: ", err)
 		return results, errors.New("Cannot get Uptime data")
@@ -409,12 +450,12 @@ func getUptimes(endpoint string, log *logging.Logger) ([]VisorUptimeResponse, er
 		log.Error("Error while reading data from uptime service. Error: ", err)
 		return results, errors.New("Cannot get Uptime data")
 	}
-	log.Debugf("Successfully  called uptime service and received answer %+v", results)
 	err = json.Unmarshal(body, &results)
 	if err != nil {
 		log.Errorf("Error while unmarshalling data from uptime service.\nBody:\n%v\nError:\n%v ", string(body), err)
 		return results, errors.New("Cannot get Uptime data")
 	}
+	log.Debugf("Successfully called uptime service via %s and received %d entries", fetchURL, len(results))
 	return results, nil
 }
 

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -210,9 +210,14 @@ func isDmsgURL(u string) bool {
 	return len(u) >= 7 && u[:7] == "dmsg://"
 }
 
-// dmsgURLForHTTP looks up the DMSG equivalent URL for an HTTP service URL.
+// DmsgURLForHTTP looks up the DMSG equivalent URL for an HTTP service URL.
 // Returns empty string if no DMSG address is known for the service.
-func dmsgURLForHTTP(httpURL string) string {
+//
+// Exported so callers outside cmd/skywire-cli/commands/rpc (notably
+// cli log) can rewrite a service URL to its dmsg-form before fetching
+// over a caller-owned dmsg.Client, avoiding a plain-HTTP hop through
+// the deployment-services HTTP edge.
+func DmsgURLForHTTP(httpURL string) string {
 	// Map HTTP base URLs to their DMSG counterparts from the deployment config
 	mappings := map[string]string{
 		deployment.Prod.TransportDiscovery: deployment.Prod.TransportDiscoveryDmsg,
@@ -566,7 +571,7 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 	// map before calling RPC; if no mapping exists we skip step 1 and
 	// rely on step 2/3.
 	rpcURL := url
-	if dmsgEquiv := dmsgURLForHTTP(url); dmsgEquiv != "" {
+	if dmsgEquiv := DmsgURLForHTTP(url); dmsgEquiv != "" {
 		rpcURL = dmsgEquiv
 	}
 
@@ -602,7 +607,7 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 	// existing sessions. Step 2 creates an ephemeral DMSG client which
 	// does discovery lookups that hang for services with server entries.
 	if !NoDmsg && NoRPC {
-		dmsgURL := dmsgURLForHTTP(url)
+		dmsgURL := DmsgURLForHTTP(url)
 		if dmsgURL != "" {
 			logger.Debugf("Trying direct DMSG fetch: %s", dmsgURL)
 			body, err := fetchViaDmsgDirect(dmsgURL)


### PR DESCRIPTION
## Summary

Removes the last two plain-HTTP calls to deployment services from
\`skywire cli log\` (the reward log-collector). Both can ride dmsg
already; the code just hadn't been wired through.

## Why

Pre-fix, the command hit deployment services over plain HTTP twice:

1. **UT fetch** — \`getUptimes\` opened its own \`http.Client\` and went
   straight to \`http://ut.skywire.skycoin.com\` BEFORE the local
   \`dmsg.Client\` was even built, so it had no choice but to use HTTP.
2. **dmsg-disc bootstrap** — \`dmsgcurl.StartDmsg\` constructed its
   \`disc.APIClient\` via \`disc.NewHTTP(dmsgDisc, ...)\` and queried the
   dmsg-discovery over plain HTTP before any dmsg session existed.

Visible as:
\`\`\`
DEBUG [log-collecting]: Successfully called uptime service and received answer []
DEBUG disc.NewHTTP [log-collecting]: Created HTTP client. addr="http://dmsgd.skywire.skycoin.com"
INFO  [log-collecting]: Connecting to dmsg network... dmsg_disc="http://dmsgd.skywire.skycoin.com" ...
\`\`\`

## What changed

\`cmd/skywire-cli/commands/log/log.go\`:

- Replaced \`dmsgcurl.New + dg.StartDmsg\` with
  \`cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers, dmsgDisc, \"\")\`.
  The embedded prod server keyring (same set \`skywire dmsg curl -B\`
  uses) lets the client dial every dmsg server directly without a
  single \`disc.NewHTTP\` call. The bootstrap helper also arms the
  background dmsg-first refresh loop that picks up operator-defined
  custom servers within ~10 min.
- Reordered: bootstrap now happens BEFORE the UT fetch. The UT call
  uses a pooled \`dmsghttp.MakeHTTPTransport\` on the same dmsg.Client
  the per-visor download loop uses.
- \`getUptimes\` rewrites the UT URL via \`clirpc.DmsgURLForHTTP\` so
  http://ut.skywire.skycoin.com becomes dmsg://&lt;UT-PK&gt;:80 before
  the request goes out. Plain HTTP remains the fallback only for
  operator-overridden UT URLs that have no dmsg twin in the
  deployment map.

\`cmd/skywire-cli/commands/rpc/root.go\`:

- Exported \`dmsgURLForHTTP\` → \`DmsgURLForHTTP\` so cli/log can use the
  same HTTP→DMSG resolver that \`FetchServiceURL\` already used
  internally.

## Side effects

- \`dmsgcurl.StartDmsg\` is no longer called from cli/log; removed
  the \`dmsgcurl\` + \`flag\` imports from this command.
- The per-visor download loop is unchanged — it already uses
  dmsghttp transports correctly. (Pool fragmentation across the
  per-goroutine transports is a separate optimization, out of scope.)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` — 0 issues
- [x] \`go test ./cmd/skywire-cli/...\` — unrelated pre-existing config
  test failures on develop are unaffected
- [ ] Operator manual: run \`skywire cli log -k &lt;pk&gt;\` against the
  prod deployment, confirm no \`disc.NewHTTP\` HTTP fetch in the
  output and the UT call goes over dmsghttp