### PR TITLE
fix(cli/config): generate lan-dmsg-server keypair at gen time (unblocks CI)

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1311,10 +1311,24 @@ func configureHypervisor(log *logging.Logger) {
 		// expected to be vanishingly rare so it's not exposed via
 		// a config-gen flag.
 		if isHypervisor {
+			// Generate the LAN DMSG server keypair eagerly. The struct's
+			// `pk`/`sk` json tags use `omitempty` but encoding/json does
+			// NOT treat a zero-valued fixed-size byte array as empty, so
+			// without explicit keys here the marshaled config emits
+			// `"sk": "0000...0000"`. Re-reading that config back fails
+			// because cipher.SecKey.UnmarshalText calls SecKeyFromHex →
+			// NewSecKey → secp256k1.VerifySeckey which rejects all-zero
+			// keys with ErrInvalidSecKey. The lan-dmsg server needs a
+			// stable keypair anyway (the type's docstring even says it's
+			// persisted across restarts), so generating it at gen time
+			// is the cleanest path.
+			lanPK, lanSK := cipher.GenerateKeyPair()
 			config.LANDmsgServer = &visorconfig.LANDmsgServerConf{
 				Enable:        true,
 				Port:          lanDmsgPort,
 				PublicAddress: lanDmsgPublicAddress,
+				PK:            lanPK,
+				SK:            lanSK,
 			}
 		}
 		conf.Hypervisor = &config


### PR DESCRIPTION
## Summary

\`cli config gen --ishv\` (post #2535) emits zero-valued
\`hypervisor.lan_dmsg_server.{pk,sk}\` because encoding/json does NOT
treat a zero-valued fixed-size byte array (\`cipher.PubKey\` /
\`cipher.SecKey\`) as empty even with the \`omitempty\` json tag.
Re-reading that config back fails: \`cipher.SecKey.UnmarshalText\` →
\`SecKeyFromHex\` → \`NewSecKey\` → \`secp256k1.VerifySeckey\` rejects
all-zero keys with \`ErrInvalidSecKey\`.

## Impact

Every PR's \`darwin\` and \`linux\` CI jobs fail with three broken tests
in \`cmd/skywire-cli/commands/config/gen_test.go\`:

  - \`TestConfigGenHypervisor\`
  - \`TestConfigGenHypervisorAddr\`
  - \`TestConfigGenEnvFile\`

all reporting \`failed to parse config JSON: Invalid secret key\`.
Visible on the head of develop (#2538) and every open PR (e.g.
#2539, #2540).

## Fix

Generate the keypair at gen time. The lan-dmsg server needs a stable
keypair anyway — the type's docstring already says it's persisted
across restarts — so this is the cleanest path. Mirrors what
\`HypervisorConfig.FillDefaults\` already does for the hypervisor's
own keypair.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` — 0 issues
- [x] \`go test ./cmd/skywire-cli/commands/config/... -run 'TestConfigGenHypervisor|TestConfigGenHypervisorAddr|TestConfigGenEnvFile'\` — green