### PR TITLE
feat(dmsgscp): remove 100MiB cap, add skynet transport via visor RPC

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/scp.go
+++ b/cmd/skywire-cli/commands/dmsg/scp.go
@@ -13,16 +13,19 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgscp"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/visor"
 )
 
 // scpPKPathRe matches a `PK:path` argument. The PK is a 66-char
@@ -32,8 +35,18 @@ import (
 var scpPKPathRe = regexp.MustCompile(`^([a-f0-9]{66}):(.*)$`)
 
 var (
-	scpPort    uint16
-	scpTimeout time.Duration
+	scpPort      uint16
+	scpTimeout   time.Duration
+	scpTransport string
+)
+
+// scpTransportAuto is the default for --transport: try the local
+// visor's VisorSCP RPC first (works for both dmsg and skynet) and
+// fall back to a standalone-dmsg dial when no visor is reachable.
+const (
+	scpTransportAuto   = "auto"
+	scpTransportDmsg   = "dmsg"
+	scpTransportSkynet = "skynet"
 )
 
 func init() {
@@ -42,8 +55,12 @@ func init() {
 		"secret key for the standalone dmsg client (random if unset)")
 	scpCmd.Flags().Uint16VarP(&scpPort, "port", "p", dmsgscp.DefaultPort,
 		"remote dmsg port for the dmsgscp host")
-	scpCmd.Flags().DurationVarP(&scpTimeout, "timeout", "t", 60*time.Second,
-		"transfer timeout (includes dmsg dial + payload)")
+	scpCmd.Flags().DurationVarP(&scpTimeout, "timeout", "t", 5*time.Minute,
+		"transfer timeout (includes dial + payload)")
+	scpCmd.Flags().StringVar(&scpTransport, "transport", scpTransportAuto,
+		"transport: auto (try visor first, fallback dmsg) | dmsg | skynet")
+	scpCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
+		"local visor RPC server address (env: SKYWIRE_RPC). Used for skynet / auto transports.")
 	scpCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal",
 		"[ debug | warn | error | fatal | panic | trace | info ]")
 	if env := os.Getenv("DMSG_SK"); env != "" {
@@ -64,12 +81,26 @@ Examples:
 
 The remote path is interpreted relative to the host's configured
 rootDir — absolute paths and ` + "`..`" + ` are rejected by the wire
-parser. Hard limit on file size: 100 MiB.
+parser. No size cap — large transfers stream through the underlying
+transport without buffering the whole payload in memory.
+
+Transport selection (--transport):
+  - auto    (default) try the local visor's VisorSCP RPC first
+            so the transfer rides whatever transport the visor
+            already has up. Falls back to standalone dmsg when no
+            visor is reachable on --rpc.
+  - dmsg    standalone dmsg path — the CLI bootstraps its own
+            dmsg.Client and dials peer:port directly. Works without
+            a local visor.
+  - skynet  routes the transfer over the skywire router via the
+            visor's VisorSCP RPC. Requires a local visor with
+            appnet TypeSkynet registered.
 
 Identity: --sk gives the standalone dmsg client a stable PK so the
 host's whitelist can authorize it. Without --sk you get a fresh
 random PK each invocation and the host will reject you unless its
-whitelist has been wide-opened.`,
+whitelist has been wide-opened. Identity only matters for the
+standalone dmsg path; the VisorSCP RPC uses the visor's own PK.`,
 	Args:                  cobra.ExactArgs(2),
 	SilenceErrors:         true,
 	SilenceUsage:          true,
@@ -88,20 +119,43 @@ whitelist has been wide-opened.`,
 			return err
 		}
 
-		// Resolve our identity. Mirrors the chat command — a fresh
-		// keypair is fine for ad-hoc use but the operator should
-		// use --sk for a stable PK that can be whitelisted.
+		switch scpTransport {
+		case scpTransportAuto, scpTransportDmsg, scpTransportSkynet:
+		default:
+			return fmt.Errorf("dmsg scp: bad --transport %q (want auto|dmsg|skynet)", scpTransport)
+		}
+
+		// Skynet path requires the visor (CLI has no appnet runtime).
+		if scpTransport == scpTransportSkynet {
+			return runVisorSCP(visor.VisorSCPTransportSkynet, peerPK, direction, localPath, remotePath, cmd)
+		}
+
+		// Auto path: try the visor's RPC first. The visor's own PK is
+		// stable + already on the peer's whitelist, so we save the
+		// operator from threading --sk. Fall back to standalone dmsg
+		// when --rpc is unreachable (typical for an operator running
+		// the CLI on a host without a local visor).
+		if scpTransport == scpTransportAuto {
+			err := runVisorSCP(visor.VisorSCPTransportDmsg, peerPK, direction, localPath, remotePath, cmd)
+			if err == nil {
+				return nil
+			}
+			log.WithError(err).Debug("VisorSCP RPC failed; falling back to standalone dmsg")
+		}
+
+		// Standalone dmsg path — the CLI bootstraps its own
+		// dmsg.Client and dials peer:port directly.
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+		ctx, timeoutCancel := context.WithTimeout(ctx, scpTimeout)
+		defer timeoutCancel()
+
 		myPK, mySK := resolveChatIdentity(sk)
 		if !cmd.Flags().Changed("sk") && os.Getenv("DMSG_SK") == "" {
 			fmt.Fprintf(os.Stderr,
 				"WARN: ephemeral identity. Your PK is %s — the host's whitelist must accept this PK or the transfer will be rejected. Use --sk / DMSG_SK= for a stable identity.\n\n",
 				myPK)
 		}
-
-		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
-		defer cancel()
-		ctx, timeoutCancel := context.WithTimeout(ctx, scpTimeout)
-		defer timeoutCancel()
 
 		dmsgC, closeDmsg, err := startDmsgClient(ctx, log, myPK, mySK)
 		if err != nil {
@@ -129,6 +183,49 @@ whitelist has been wide-opened.`,
 		}
 		return nil
 	},
+}
+
+// runVisorSCP delegates the transfer to the local visor via the
+// VisorSCP RPC. The visor opens the stream over the chosen
+// transport (dmsg or skynet) and runs the dmsgscp protocol entirely
+// inside its own process — bytes never traverse the CLI, only the
+// initial request + completion ack go over the local RPC channel.
+//
+// LocalPath is normalized to an absolute path before sending so the
+// visor (which doesn't share the CLI's cwd) reads/writes the
+// expected file.
+func runVisorSCP(transport string, peerPK cipher.PubKey, direction scpDirection, localPath, remotePath string, cmd *cobra.Command) error {
+	abs, err := filepath.Abs(localPath)
+	if err != nil {
+		return fmt.Errorf("VisorSCP: resolve local path: %w", err)
+	}
+	dir := visor.VisorSCPUpload
+	if direction == scpDirDownload {
+		dir = visor.VisorSCPDownload
+	}
+	req := visor.VisorSCPRequest{
+		RemotePK:   peerPK,
+		Port:       scpPort,
+		Direction:  dir,
+		LocalPath:  abs,
+		RemotePath: remotePath,
+		Transport:  transport,
+		Timeout:    scpTimeout,
+	}
+	rc, err := clirpc.Client(cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("VisorSCP RPC client: %w", err)
+	}
+	if err := rc.VisorSCP(req); err != nil {
+		return fmt.Errorf("VisorSCP (%s): %w", transport, err)
+	}
+	switch direction {
+	case scpDirDownload:
+		fmt.Fprintf(os.Stderr, "downloaded %s:%s -> %s (via visor %s)\n", peerPK, remotePath, abs, transport)
+	case scpDirUpload:
+		fmt.Fprintf(os.Stderr, "uploaded %s -> %s:%s (via visor %s)\n", abs, peerPK, remotePath, transport)
+	}
+	return nil
 }
 
 type scpDirection int

--- a/pkg/dmsg/dmsgscp/client.go
+++ b/pkg/dmsg/dmsgscp/client.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -22,9 +23,16 @@ import (
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 )
 
-// Client is a single-transfer dmsgscp client. Build one via Dial.
+// Client is a single-transfer dmsgscp client. Build one via Dial
+// (dmsg path) or NewClient (any net.Conn, e.g. a skynet stream
+// dialed inside the visor process where appnet is available).
+//
+// The wire protocol is transport-agnostic; the Client holds a
+// `net.Conn` so any stream-shaped transport can plug in. The dmsg
+// Dial helper stays for callers that already have a `*dmsg.Client`
+// in hand and don't need to think about transports.
 type Client struct {
-	conn   *dmsg.Stream
+	conn   net.Conn
 	reader *bufio.Reader
 	remote cipher.PubKey
 }
@@ -42,11 +50,20 @@ func Dial(ctx context.Context, dmsgC *dmsg.Client, rPK cipher.PubKey, port uint1
 	if err != nil {
 		return nil, fmt.Errorf("dmsgscp: dial %s:%d: %w", rPK, port, err)
 	}
+	return NewClient(stream, rPK), nil
+}
+
+// NewClient wraps an already-dialed net.Conn into a dmsgscp Client.
+// Used by callers that opened the stream over a non-dmsg transport
+// (notably skynet via appnet.Dial, from inside the visor process).
+// The remote PK is informational — it appears in error messages but
+// the protocol itself doesn't depend on it.
+func NewClient(conn net.Conn, remote cipher.PubKey) *Client {
 	return &Client{
-		conn:   stream,
-		reader: bufio.NewReader(stream),
-		remote: rPK,
-	}, nil
+		conn:   conn,
+		reader: bufio.NewReader(conn),
+		remote: remote,
+	}
 }
 
 // Close releases the underlying stream.
@@ -155,9 +172,6 @@ func (c *Client) Upload(localPath, remotePath string) error {
 	}
 	if info.IsDir() {
 		return errors.New("dmsgscp: directory upload not supported in v1")
-	}
-	if info.Size() > MaxFileSize {
-		return fmt.Errorf("dmsgscp: local file exceeds %d-byte cap", MaxFileSize)
 	}
 
 	// Step 1: send role line.

--- a/pkg/dmsg/dmsgscp/const.go
+++ b/pkg/dmsg/dmsgscp/const.go
@@ -47,14 +47,12 @@ const (
 	RoleSink = "SINK"
 )
 
-// Safety caps. These are hard limits enforced by both the protocol
-// parser and the Host/Client serve loops. v1 is deliberately
-// conservative — operators wanting larger transfers can fall back
-// to a chunked workflow until v2 lifts the cap.
+// Safety caps. Apply to the header parser only — there is no
+// per-transfer file-size cap. The protocol streams payloads of any
+// length the underlying transport accepts. MaxNameLen / MaxHeaderLen
+// guard against memory exhaustion from a malicious peer sending a
+// multi-megabyte header line; they have no effect on the payload.
 const (
-	// MaxFileSize is the hard cap on a single file transfer (100 MiB).
-	// Sender-claimed sizes above this are rejected by the parser.
-	MaxFileSize int64 = 100 * 1024 * 1024
 	// MaxNameLen caps the basename portion of a `C` or `D` header.
 	// Long enough for any reasonable filename, short enough that a
 	// malicious peer can't exhaust memory with a multi-megabyte

--- a/pkg/dmsg/dmsgscp/host.go
+++ b/pkg/dmsg/dmsgscp/host.go
@@ -267,10 +267,6 @@ func (h *Host) serveSource(_ context.Context, log logrus.FieldLogger, conn net.C
 		_ = WriteFatal(conn, "directory transfers not supported") //nolint:errcheck
 		return
 	}
-	if info.Size() > MaxFileSize {
-		_ = WriteFatal(conn, fmt.Sprintf("file exceeds %d-byte cap", MaxFileSize)) //nolint:errcheck
-		return
-	}
 
 	f, err := os.Open(safePath) //nolint:gosec // path validated by ResolveSafePath
 	if err != nil {

--- a/pkg/dmsg/dmsgscp/protocol.go
+++ b/pkg/dmsg/dmsgscp/protocol.go
@@ -67,8 +67,6 @@ var (
 	ErrBadMode = errors.New("dmsgscp: bad octal mode")
 	// ErrBadSize signals an unparseable or out-of-range size field.
 	ErrBadSize = errors.New("dmsgscp: bad size")
-	// ErrSizeCap signals a size above MaxFileSize.
-	ErrSizeCap = errors.New("dmsgscp: file size exceeds cap")
 	// ErrEmptyName signals a missing or whitespace-only name.
 	ErrEmptyName = errors.New("dmsgscp: empty name")
 	// ErrNameTooLong signals a name above MaxNameLen.
@@ -161,9 +159,6 @@ func parseFileOrDir(typ RecordType, body []byte) (Header, error) {
 	if size < 0 {
 		return Header{}, fmt.Errorf("%w: negative", ErrBadSize)
 	}
-	if size > MaxFileSize {
-		return Header{}, fmt.Errorf("%w: %d > %d", ErrSizeCap, size, MaxFileSize)
-	}
 
 	name := parts[2]
 	if err := validateName(name); err != nil {
@@ -228,9 +223,6 @@ func WriteFileHeader(w io.Writer, mode os.FileMode, size int64, name string) err
 	}
 	if size < 0 {
 		return fmt.Errorf("%w: negative", ErrBadSize)
-	}
-	if size > MaxFileSize {
-		return fmt.Errorf("%w: %d > %d", ErrSizeCap, size, MaxFileSize)
 	}
 	// Mode is masked to the permission bits — same hardening we
 	// apply on the read side.

--- a/pkg/dmsg/dmsgscp/protocol_test.go
+++ b/pkg/dmsg/dmsgscp/protocol_test.go
@@ -24,7 +24,8 @@ func TestWriteAndReadFileHeader(t *testing.T) {
 	}{
 		{"basic", 0644, 1234, "myfile.bin"},
 		{"zero-byte", 0600, 0, "empty.txt"},
-		{"max-size", 0644, MaxFileSize, "huge.dat"},
+		{"hundred-mib", 0644, 100 * 1024 * 1024, "huge.dat"},
+		{"ten-gib", 0644, 10 * 1024 * 1024 * 1024, "very-huge.dat"},
 		{"name-with-spaces", 0755, 42, "file with spaces.txt"},
 		{"long-name", 0644, 1, strings.Repeat("a", MaxNameLen)},
 	}
@@ -106,7 +107,6 @@ func TestReadHeaderMalformed(t *testing.T) {
 		{"bad-mode", "Cabcd 1 x\n", ErrBadMode},
 		{"bad-size", "C0644 nope x\n", ErrBadSize},
 		{"negative-size", "C0644 -1 x\n", ErrBadSize},
-		{"size-over-cap", "C0644 999999999999 x\n", ErrSizeCap},
 		{"empty-name", "C0644 0 \n", ErrEmptyName},
 	}
 	for _, tc := range cases {
@@ -199,10 +199,6 @@ func TestWriteHeaderRejectsBadInput(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteFileHeader(&buf, 0644, -1, "x"); !errors.Is(err, ErrBadSize) {
 		t.Errorf("negative size: err = %v, want ErrBadSize", err)
-	}
-	buf.Reset()
-	if err := WriteFileHeader(&buf, 0644, MaxFileSize+1, "x"); !errors.Is(err, ErrSizeCap) {
-		t.Errorf("oversize: err = %v, want ErrSizeCap", err)
 	}
 	buf.Reset()
 	if err := WriteFileHeader(&buf, 0644, 1, "../x"); !errors.Is(err, ErrPathTraversal) {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -216,6 +216,7 @@ type API interface {
 	DmsgProbe(pk cipher.PubKey, port uint16) (bool, error)
 	DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error)
 	SkynetHTTP(req SkynetHTTPRequest) (*SkynetHTTPResponse, error)
+	VisorSCP(req VisorSCPRequest) error
 	DmsgConnectAll() (*DmsgConnectAllResult, error)
 	SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error)
 	DmsgSessions() (*DmsgClientSessions, error)
@@ -674,6 +675,61 @@ type SkynetHTTPResponse struct {
 	Status     string            `json:"status"`
 	Header     map[string]string `json:"header,omitempty"`
 	Body       []byte            `json:"body,omitempty"`
+}
+
+// VisorSCPDirection enumerates the two scp transfer directions.
+const (
+	// VisorSCPUpload pushes a local file to the remote host's rootDir.
+	VisorSCPUpload = "upload"
+	// VisorSCPDownload pulls a file from the remote host's rootDir
+	// into a local path.
+	VisorSCPDownload = "download"
+)
+
+// VisorSCPTransport enumerates the transports the visor will dial
+// the peer's dmsgscp host over. Both peers expose the host on dmsg
+// AND skynet at the same port; the caller picks per-call.
+const (
+	// VisorSCPTransportDmsg dials peer:port over dmsg.
+	VisorSCPTransportDmsg = "dmsg"
+	// VisorSCPTransportSkynet dials peer:port over the skywire router
+	// (appnet TypeSkynet). Routing through skynet keeps the bytes off
+	// the dmsg overlay and lets the transfer ride whatever transports
+	// the router picks for the route group.
+	VisorSCPTransportSkynet = "skynet"
+)
+
+// VisorSCPRequest describes a peer-to-peer file transfer the visor
+// should perform on the caller's behalf. The visor process opens the
+// stream over the chosen transport (it has both dmsgC + appnet
+// resolvers wired in, where a standalone CLI does not) and drives
+// the dmsgscp wire protocol entirely inside the visor.
+//
+// Local files are read/written on the visor host's filesystem.
+// Operators running the CLI as the same user as the visor process
+// see the obvious "this is my $HOME" behavior.
+type VisorSCPRequest struct {
+	// RemotePK is the peer's visor PK. The peer must have a dmsgscp
+	// host bound and the caller's PK on the host's whitelist.
+	RemotePK cipher.PubKey `json:"remote_pk"`
+	// Port is the peer's dmsgscp port (same for both transports —
+	// dmsgscp.DefaultPort is 23).
+	Port uint16 `json:"port"`
+	// Direction is VisorSCPUpload or VisorSCPDownload.
+	Direction string `json:"direction"`
+	// LocalPath is the path on the visor host's filesystem. For an
+	// upload it's the source; for a download it's the destination.
+	LocalPath string `json:"local_path"`
+	// RemotePath is the path relative to the peer's rootDir. For an
+	// upload it's the destination; for a download it's the source.
+	// Absolute paths and `..` components are rejected by the peer.
+	RemotePath string `json:"remote_path"`
+	// Transport is VisorSCPTransportDmsg or VisorSCPTransportSkynet.
+	// Empty defaults to dmsg.
+	Transport string `json:"transport,omitempty"`
+	// Timeout bounds the whole transfer (dial + scp protocol +
+	// payload). Zero falls back to a 5-minute default.
+	Timeout time.Duration `json:"timeout,omitempty"`
 }
 
 // FetchCXOArgs identifies which CXO feed + path the caller wants the

--- a/pkg/visor/api_visor_scp.go
+++ b/pkg/visor/api_visor_scp.go
@@ -1,0 +1,138 @@
+// Package visor api_visor_scp.go — VisorSCP RPC method.
+//
+// VisorSCP performs a dmsgscp-protocol file transfer from inside
+// the visor process. The visor has both transports plumbed
+// (dmsg.Client + appnet SkywireNetworker), where a standalone CLI
+// has only the dmsg path. Routing the SCP through the visor lets
+// callers pick either transport without bolting an appnet shim
+// onto the CLI.
+//
+// Lives in its own file so the dmsgscp / appnet imports stay
+// scoped to one compilation unit.
+package visor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgscp"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// visorSCPDefaultTimeout bounds the whole transfer (dial + scp
+// protocol + payload) when the caller doesn't supply one. Five
+// minutes is comfortable for a few-hundred-MB binary over a
+// well-routed transport without being so generous that a wedged
+// stream sits forever.
+const visorSCPDefaultTimeout = 5 * time.Minute
+
+// VisorSCP runs a dmsgscp transfer to req.RemotePK:req.Port over
+// req.Transport ("dmsg" or "skynet"), uploading or downloading per
+// req.Direction. The local-filesystem path req.LocalPath is read
+// or written by THIS visor process — operators running the CLI
+// against a different visor see that visor's filesystem, not the
+// caller's.
+//
+// Error categories:
+//   - Validation: bad PK / direction / transport / empty paths →
+//     wrapped errors with stable prefixes the CLI can surface.
+//   - Dial: dmsg session not ready, or skynet networker not yet
+//     registered when initRouter raced this call.
+//   - Protocol: the dmsgscp.Client surface returns the same
+//     fmt.Errorf-wrapped sentinels the standalone client does.
+func (v *Visor) VisorSCP(req VisorSCPRequest) error {
+	if req.RemotePK.Null() {
+		return errors.New("VisorSCP: remote_pk required")
+	}
+	if req.Port == 0 {
+		req.Port = dmsgscp.DefaultPort
+	}
+	if req.LocalPath == "" {
+		return errors.New("VisorSCP: local_path required")
+	}
+	if req.RemotePath == "" {
+		return errors.New("VisorSCP: remote_path required")
+	}
+	switch req.Direction {
+	case VisorSCPUpload, VisorSCPDownload:
+	default:
+		return fmt.Errorf("VisorSCP: bad direction %q (want %q or %q)",
+			req.Direction, VisorSCPUpload, VisorSCPDownload)
+	}
+	transport := req.Transport
+	if transport == "" {
+		transport = VisorSCPTransportDmsg
+	}
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = visorSCPDefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var (
+		conn net.Conn
+		err  error
+	)
+	switch transport {
+	case VisorSCPTransportDmsg:
+		conn, err = v.dialSCPDmsg(ctx, req.RemotePK, req.Port)
+	case VisorSCPTransportSkynet:
+		conn, err = v.dialSCPSkynet(ctx, req.RemotePK, req.Port)
+	default:
+		return fmt.Errorf("VisorSCP: bad transport %q (want %q or %q)",
+			transport, VisorSCPTransportDmsg, VisorSCPTransportSkynet)
+	}
+	if err != nil {
+		return fmt.Errorf("VisorSCP: dial %s %s:%d: %w",
+			transport, req.RemotePK, req.Port, err)
+	}
+	client := dmsgscp.NewClient(conn, req.RemotePK)
+	defer client.Close() //nolint:errcheck,gosec
+
+	switch req.Direction {
+	case VisorSCPUpload:
+		return client.Upload(req.LocalPath, req.RemotePath)
+	case VisorSCPDownload:
+		return client.Download(req.RemotePath, req.LocalPath)
+	}
+	// Unreachable — direction validated above.
+	return nil
+}
+
+// dialSCPDmsg opens a dmsg.Stream to (rPK:port). Reuses the visor's
+// existing dmsg.Client (v.dmsgC) so we share sessions with every
+// other dmsg consumer instead of paying a fresh handshake.
+func (v *Visor) dialSCPDmsg(ctx context.Context, rPK cipher.PubKey, port uint16) (net.Conn, error) {
+	if err := v.mustWaitDmsgReady(); err != nil {
+		return nil, err
+	}
+	return v.dmsgC.DialStream(ctx, dmsg.Addr{PK: rPK, Port: port})
+}
+
+// dialSCPSkynet opens a route-group stream to (rPK:port) via the
+// SkywireNetworker. Goes straight to addr.Port (no
+// SkyForwardingServerPort handshake) because the peer's dmsgscp
+// host binds its appnet listener directly on its visor port via
+// goServeSkynetMirror in init_dmsg.go.
+//
+// The dial blocks until either the route group is established or
+// the caller's deadline fires. Errors propagate verbatim from the
+// router — the wrapping VisorSCP call layers in "skynet PK:port"
+// context for the CLI to surface.
+func (v *Visor) dialSCPSkynet(ctx context.Context, rPK cipher.PubKey, port uint16) (net.Conn, error) {
+	if _, err := appnet.ResolveNetworker(appnet.TypeSkynet); err != nil {
+		return nil, fmt.Errorf("skynet networker not registered: %w", err)
+	}
+	return appnet.DialContext(ctx, appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: rPK,
+		Port:   routing.Port(port),
+	})
+}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1206,6 +1206,14 @@ func (rc *rpcClient) SkynetHTTP(req SkynetHTTPRequest) (*SkynetHTTPResponse, err
 	return &resp, err
 }
 
+// VisorSCP asks the visor to perform a dmsgscp transfer to a peer
+// over the chosen transport (dmsg or skynet). See api_visor_scp.go
+// for the protocol details.
+func (rc *rpcClient) VisorSCP(req VisorSCPRequest) error {
+	var ok bool
+	return rc.Call("VisorSCP", &req, &ok)
+}
+
 // DmsgProbe checks dmsg reachability of a remote PK on a given port.
 func (rc *rpcClient) DmsgProbe(pk cipher.PubKey, port uint16) (bool, error) {
 	var reachable bool

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1147,6 +1147,11 @@ func (mc *mockRPCClient) DmsgHTTP(_ DmsgHTTPRequest) (*DmsgHTTPResponse, error) 
 	return &DmsgHTTPResponse{StatusCode: 200, Status: "OK"}, nil
 }
 
+// VisorSCP implements API.
+func (mc *mockRPCClient) VisorSCP(_ VisorSCPRequest) error {
+	return nil
+}
+
 // DmsgProbe implements API.
 func (mc *mockRPCClient) DmsgProbe(_ cipher.PubKey, _ uint16) (bool, error) {
 	return true, nil

--- a/pkg/visor/rpc_dmsg.go
+++ b/pkg/visor/rpc_dmsg.go
@@ -57,6 +57,18 @@ func (r *RPC) SkynetHTTP(req *SkynetHTTPRequest, out *SkynetHTTPResponse) (err e
 	return nil
 }
 
+// VisorSCP runs a dmsgscp transfer to the peer using the visor's
+// own dmsg.Client / appnet so the caller can pick either transport
+// without an appnet shim on its side. See api_visor_scp.go.
+func (r *RPC) VisorSCP(req *VisorSCPRequest, out *bool) (err error) {
+	defer rpcutil.LogCall(r.log, "VisorSCP", req)(out, &err)
+	if err := r.visor.VisorSCP(*req); err != nil {
+		return err
+	}
+	*out = true
+	return nil
+}
+
 // DmsgConnectAll reaches every dmsg server in discovery and ensures a session to each.
 func (r *RPC) DmsgConnectAll(_ *struct{}, out *DmsgConnectAllResult) (err error) {
 	defer rpcutil.LogCall(r.log, "DmsgConnectAll", nil)(out, &err)


### PR DESCRIPTION
## Summary

Two changes that work together to let \`dmsgscp\` handle realistic
transfer sizes over either transport:

1. **Drop the 100 MiB file-size cap** — was wire-layer-artificial,
   the protocol streams arbitrary sizes.
2. **Add skynet transport** — host already listens on both, dial
   side was dmsg-only because the CLI can't \`ResolveNetworker\`.
   Routed through a new visor RPC so the CLI can pick either
   transport without an appnet shim of its own.

## Why

Trying to push a freshly-built ~196 MiB skywire binary between
peers hits the cap immediately. The comment in
\`pkg/dmsg/dmsgscp/const.go:51-53\` even acknowledged it as
"v1 deliberately conservative — chunked workflow until v2 lifts
the cap." No transport-level reason for the limit. The skynet
side was just unfinished plumbing: the Host already dual-listens
via \`goServeSkynetMirror\` in \`init_dmsg.go\` but the CLI client
only knew how to dial dmsg.

## What changed

### Cap removal

- Removed \`MaxFileSize\` constant, \`ErrSizeCap\` sentinel, and four
  enforcement points (\`ReadHeader\`, \`WriteFileHeader\`,
  \`Host\` SOURCE-role pre-flight, \`Client.Upload\` local-stat
  pre-flight).
- Test cases for cap rejection replaced with 100 MiB and 10 GiB
  header round-trips to prove >cap sizes parse cleanly.
- \`MaxNameLen\` / \`MaxHeaderLen\` kept — those guard against memory
  exhaustion from a malicious peer sending a multi-MB header line,
  unrelated to payload.

### Skynet transport — design A from the discussion

- \`dmsgscp.NewClient(net.Conn, PK)\` — \`Client\` wraps any
  stream-shaped transport; the old \`Dial(...)\` helper stays for
  dmsg-direct callers.
- \`pkg/visor/api_visor_scp.go\`: new \`Visor.VisorSCP\` runs the
  transfer using the visor's own \`dmsgC\` (for dmsg) or
  \`appnet.DialContext\` (for skynet). The protocol bytes never
  traverse the local RPC channel — only the request + completion
  ack do.
- \`API.VisorSCP\` / \`VisorSCPRequest\` + Direction / Transport
  constants in \`pkg/visor/api.go\`; \`rpc_dmsg.go\` RPC handler;
  \`rpcClient.VisorSCP\` wrapper; \`mockRPCClient\` stub.
- \`cli dmsg scp\` gains \`--transport=auto|dmsg|skynet\` (default
  \`auto\`):
  - \`auto\`: try \`VisorSCP\` RPC over dmsg first (visor PK is
    already on most whitelists, saves the operator threading
    \`--sk\`), fall back to standalone-dmsg dial when no visor is
    reachable on \`--rpc\`.
  - \`dmsg\`: existing standalone-dmsg path, unchanged.
  - \`skynet\`: \`VisorSCP\` RPC over skynet, requires the local
    visor.
- \`--timeout\` default bumped \`60s\` → \`5m\` for realistic large-file
  transfers.

LocalPath is resolved to an absolute path on the CLI side before
sending so the visor (which doesn't share the CLI's cwd) reads /
writes the expected file.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` — 0 issues
- [x] \`go test ./pkg/dmsg/dmsgscp/... ./pkg/visor/...\` — green
- [x] Header round-trip tests with 100 MiB and 10 GiB sizes
- [ ] Manual: push the 196 MiB binary to a peer over \`auto\`
  (verifies cap removal + the RPC dmsg path)
- [ ] Manual: same with \`--transport=skynet\` (verifies the appnet
  dial path)