### PR TITLE
fix(cli/scp): disable CLI RPC call timeout for VisorSCP path

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/scp.go
+++ b/cmd/skywire-cli/commands/dmsg/scp.go
@@ -212,6 +212,14 @@ func runVisorSCP(transport string, peerPK cipher.PubKey, direction scpDirection,
 		Transport:  transport,
 		Timeout:    scpTimeout,
 	}
+	// Drop the default 30s RPC call timeout — the scp transfer's
+	// own --timeout (req.Timeout above) bounds the visor-side work,
+	// and a multi-hundred-MB transfer routinely exceeds 30s.
+	// clirpc.Timeout is a package-global; saving + restoring keeps
+	// other CLI subcommands using the default in the same process.
+	prevTimeout := clirpc.Timeout
+	clirpc.Timeout = 0
+	defer func() { clirpc.Timeout = prevTimeout }()
 	rc, err := clirpc.Client(cmd.Flags())
 	if err != nil {
 		return fmt.Errorf("VisorSCP RPC client: %w", err)


### PR DESCRIPTION
## Summary

Follow-up to #2542. The default \`clirpc.Timeout\` is 30s; that cap
fires inside the VisorSCP RPC call for any non-trivial transfer.

## Why

Caught on the first end-to-end push of a 75 MiB compressed binary
to a peer using the new \`--transport=auto\` path:

\`\`\`
DEBUG [dmsg-scp]: VisorSCP RPC failed; falling back to standalone dmsg error="VisorSCP (dmsg): context deadline exceeded"
WARN: ephemeral identity. Your PK is ... — the host's whitelist must accept this PK or the transfer will be rejected.
2026/05/13 09:50:15 Failed to execute command: dmsgscp: peer error: dmsg stream rejected by whitelist
\`\`\`

VisorSCP doesn't return from the RPC until the transfer finishes
(streaming protocol, host-side blocking call). 30s is right for
request/reply RPCs like \`DmsgHTTP\` / \`SkynetHTTP\`; it's wrong for
long-streaming SCP.

The transfer itself is already bounded by \`--timeout\` (default 5m
in #2542), so dropping the RPC-call cap to unlimited just removes
a second, smaller deadline that was strictly more restrictive than
the one the operator picked.

## Fix

Save + restore \`clirpc.Timeout\` around the \`Client()\` construction
in \`runVisorSCP\`. The save+restore is defensive — the CLI is
usually one-shot — but keeps other subcommands invoked in the same
process on the default 30s.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` — 0 issues
- [x] End-to-end: pushed 75 MiB to two peers over \`--transport=auto\`
  (one of them through the new RPC, the other validating the same
  path) — both completed.