### PR TITLE
fix(visor): GroupGet populates SubscriberAlive — match GroupList behavior

### DIFF
--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -146,6 +146,17 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 }
 
 // GroupGet returns the info for a specific group, or ErrGroupNotFound.
+//
+// Populates SubscriberAlive the same way GroupList does — without
+// this, single-group queries (`cli skychat group info <id>`) always
+// reported subscriber_alive=false regardless of the live session
+// state, because toInfo doesn't reach into the session map. The
+// list path was already correct; the single-group path silently
+// dropped the field. Surfaced as a misleading symptom during the
+// agent-coordination work today: persisted last_message_at would
+// advance while subscriber_alive stayed false, and we kept chasing
+// that as a session-state divergence when really it was the RPC
+// shape leaving the field unpopulated.
 func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	mgr := v.groupManager()
 	if mgr == nil {
@@ -158,7 +169,9 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	if !ok {
 		return GroupInfo{}, ErrGroupNotFound
 	}
-	return toInfo(r), nil
+	info := toInfo(r)
+	info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
+	return info, nil
 }
 
 // GroupInvite returns a freshly-encoded invite link for an


### PR DESCRIPTION
## Summary

Tiny 1-line fix that makes `Visor.GroupGet` populate `SubscriberAlive` the same way `Visor.GroupList` already does. Without this, `cli skychat group info <id>` always reported `subscriber_alive: false` regardless of the live session state.

## Root cause

```go
func (v *Visor) GroupGet(id string) (GroupInfo, error) {
    ...
    return toInfo(r), nil  // ← toInfo doesn't touch SubscriberAlive
}
```

vs.

```go
func (v *Visor) GroupList() ([]GroupInfo, error) {
    ...
    info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)  // ← does the lookup
    ...
}
```

The bool is left at its zero value (false) by the single-group path.

## Why it matters

Surfaced today during multi-agent coordination work as a misleading debugging symptom:

```
$ skywire cli skychat group info <id>
  last_message_at: 2026-05-13T17:02:15Z   ← fresh
  subscriber_alive: false                  ← lies
```

I spent a meaningful amount of time chasing this as a session-state divergence (Session.lastInboundNs not bumping in lockstep with Record.LastMessageAt) when really it was just the RPC field never getting populated. The session WAS alive; the single-group fetch path just dropped the field.

This is the consumer-side completion of the #2537 unified-liveness refactor — the bool is now consistent across both accessors.

## Tests

- `go build ./pkg/visor/...` clean
- `go test -count=1 ./pkg/visor/` clean
- Live verification on rejoin: needs the merged binary to land on the test hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)