### PR TITLE
fix(visor/cat): half-close listen splice so receive survives empty stdin

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/cat.go
+++ b/cmd/skywire-cli/commands/dmsg/cat.go
@@ -295,7 +295,7 @@ func runVisorCatListen(port uint16, cmd *cobra.Command) error {
 	if catVerbose {
 		fmt.Fprintf(os.Stderr, "stream accepted; splicing stdio\n")
 	}
-	return spliceStdio(conn)
+	return spliceStdioHalfClose(conn)
 }
 
 // splitPKPort parses a `pkhex:port` argument used by `cli dmsg cat`.
@@ -323,6 +323,10 @@ func splitPKPort(s string) (cipher.PubKey, uint16, error) {
 // process's stdio. Returns when either side EOFs or errors. The
 // stdin → conn half drives close-on-eof of conn so the remote sees
 // our stdin close.
+//
+// Used by dial mode (and standalone dmsg dial). For listen mode use
+// spliceStdioHalfClose — that variant doesn't tear down the receive
+// direction when the (often empty) local stdin EOFs.
 func spliceStdio(conn net.Conn) error {
 	var (
 		once    sync.Once
@@ -350,4 +354,45 @@ func spliceStdio(conn net.Conn) error {
 		return nil
 	}
 	return first
+}
+
+// closeWriter is the optional half-close interface satisfied by
+// *net.TCPConn. The CLI's loopback conn to the visor always satisfies
+// this (it's TCP), so we use CloseWrite to signal "no more stdin
+// bytes" instead of full-closing the conn.
+type closeWriter interface {
+	CloseWrite() error
+}
+
+// spliceStdioHalfClose is the asymmetric variant of spliceStdio for
+// the listen-mode CLI. When stdin EOFs (commonly immediately, since
+// `cat listen` is usually invoked with `< /dev/null` or an idle TTY),
+// we CloseWrite on the conn rather than fully closing it. The reverse
+// direction (conn → stdout) keeps reading until the remote sender
+// naturally closes the stream.
+//
+// Hangs only if the remote never closes its side; the listen mode's
+// --timeout flag bounds that on the visor end.
+func spliceStdioHalfClose(conn net.Conn) error {
+	done := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(conn, os.Stdin)
+		if cw, ok := conn.(closeWriter); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- err
+	}()
+	go func() {
+		_, err := io.Copy(os.Stdout, conn)
+		done <- err
+	}()
+	e1 := <-done
+	e2 := <-done
+	_ = conn.Close()
+	for _, e := range []error{e1, e2} {
+		if e != nil && !errors.Is(e, io.EOF) && !errors.Is(e, net.ErrClosed) {
+			return e
+		}
+	}
+	return nil
 }

--- a/pkg/visor/api_visor_cat.go
+++ b/pkg/visor/api_visor_cat.go
@@ -350,7 +350,14 @@ func (v *Visor) visorCatListen(req VisorCatRequest, transport string) (*VisorCat
 				return
 			}
 		}
-		splice(local, remote)
+		// Listen mode uses half-close semantics: the CLI's stdin is
+		// often empty (`< /dev/null` or no piped input), which means
+		// the stdin→remote io.Copy returns EOF immediately. With the
+		// symmetric splice that would tear down the whole pair before
+		// inbound data could arrive. spliceHalfClose keeps the
+		// reverse direction open until the remote sender naturally
+		// closes their stream.
+		spliceHalfClose(local, remote)
 	}()
 
 	return &VisorCatResponse{LocalAddr: loopLis.Addr().String()}, nil
@@ -536,6 +543,11 @@ func acceptOne(ctx context.Context, lis net.Listener) (net.Conn, error) {
 // for any pair of net.Conn — dmsg.Stream, appnet route-group conn,
 // loopback TCP — they all satisfy the interface.
 //
+// Symmetric full-close on first EOF. Use this for the dial side
+// where a stdin EOF means "sender done — tear it all down". The
+// listener side wants asymmetric half-close semantics; see
+// spliceHalfClose.
+//
 // Returns the first non-EOF error seen, or nil on a clean EOF.
 func splice(a, b net.Conn) error {
 	var (
@@ -563,4 +575,68 @@ func splice(a, b net.Conn) error {
 		return nil
 	}
 	return first.err
+}
+
+// closeWriter is the optional half-close interface satisfied by
+// *net.TCPConn (and *net.UnixConn). dmsg.Stream and appnet
+// route-group conns don't implement it — we fall back to "wait for
+// the reverse direction to also EOF before full Close" there.
+type closeWriter interface {
+	CloseWrite() error
+}
+
+// spliceHalfClose is the asymmetric variant of splice used by the
+// listen mode. When one direction of io.Copy returns (its source
+// EOFed), we DO NOT close the whole pair. Instead:
+//
+//   - If the destination supports CloseWrite, we CloseWrite there to
+//     signal "no more bytes from this side" without tearing down the
+//     reverse direction.
+//   - If the destination doesn't (dmsg.Stream / appnet conn), we
+//     do nothing — wait for the reverse direction to also reach EOF
+//     before doing the full pair-Close.
+//
+// Why: the listen-mode CLI's local stdin is often `< /dev/null` or
+// an interactive terminal that never produces bytes; without
+// half-close awareness the immediate stdin-EOF would tear down the
+// whole splice before any inbound data could be received. With this
+// variant the receive direction keeps flowing until the remote sender
+// closes their side naturally.
+//
+// Hazard: if BOTH peers happen to have empty stdin AND no
+// CloseWrite-capable destination (i.e., both pairs are dmsg/dmsg),
+// neither direction will ever EOF and the splice will hang. In
+// practice one half of the pair is always a TCP loopback (the
+// CLI-to-visor bridge) which DOES support CloseWrite, so the cascade
+// completes once one side finishes.
+func spliceHalfClose(a, b net.Conn) error {
+	type copyResult struct{ err error }
+	done := make(chan copyResult, 2)
+	go func() {
+		_, err := io.Copy(a, b)
+		// b is exhausted. Signal a that no more bytes are coming
+		// from b, but keep a's read half open so the reverse
+		// direction can still drain.
+		if cw, ok := a.(closeWriter); ok {
+			_ = cw.CloseWrite() //nolint:errcheck
+		}
+		done <- copyResult{err: err}
+	}()
+	go func() {
+		_, err := io.Copy(b, a)
+		if cw, ok := b.(closeWriter); ok {
+			_ = cw.CloseWrite() //nolint:errcheck
+		}
+		done <- copyResult{err: err}
+	}()
+	r1 := <-done
+	r2 := <-done
+	_ = a.Close() //nolint:errcheck
+	_ = b.Close() //nolint:errcheck
+	for _, r := range []copyResult{r1, r2} {
+		if r.err != nil && !errors.Is(r.err, io.EOF) && !errors.Is(r.err, net.ErrClosed) {
+			return r.err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Second follow-up to #2544. \`cli dmsg cat listen <port>\` is a passive receiver — typically \`cat listen 31337 < /dev/null > out.bin\`. With the symmetric \`splice()\`, the immediate stdin-EOF triggers a full pair-close before any inbound bytes can arrive, killing the receive direction entirely. Alpha hit this running mux-smoke benchmarks piped to \`/dev/null\`.

## Fix

Two new asymmetric variants, used **only** by listen-mode paths:

- \`spliceHalfClose(a, b net.Conn)\` in \`pkg/visor/api_visor_cat.go\` — when one direction EOFs, \`CloseWrite\` on the destination if it satisfies the optional \`closeWriter\` interface (\`*net.TCPConn\` does; \`dmsg.Stream\` / appnet conns don't). For destinations without CloseWrite, wait for the reverse direction to also EOF before full Close. The loopback half of every splice always supports CloseWrite, so the cascade resolves naturally when the remote sender's stream ends.

- \`spliceStdioHalfClose(conn net.Conn)\` in \`cmd/skywire-cli/commands/dmsg/cat.go\` — CLI mirror. When stdin EOFs, \`CloseWrite\` on the loopback conn; \`conn → stdout\` keeps reading until visor closes the loopback.

Dial mode keeps the original symmetric \`splice\` — sender's stdin-EOF *should* tear down the pair (\"I'm done\").

## Why only listen mode

Asymmetric semantics map to role:
- **Dial = sender**: stdin-EOF means \"no more bytes to send\" — propagate as full close so peer's loop terminates.
- **Listen = receiver**: stdin-EOF (which often happens immediately for \`< /dev/null\`) does NOT mean \"abort the receive\"; the receiver is passively waiting on the remote.

## Test plan

- [x] Existing \`TestSpliceBidirectional\` / \`TestSpliceEOFClosesPeer\` still pass (\`splice()\` unchanged)
- [x] \`go build ./...\` / \`go vet ./...\` / \`go test ./pkg/visor/...\` all clean
- [ ] Manual: \`cli dmsg cat listen 31337 < /dev/null > out.bin\` on receiver, \`dd if=/dev/urandom bs=1M count=50 | cli dmsg cat <listener-pk>:31337\` on sender. Pre-fix: \`out.bin\` is empty. Post-fix: \`out.bin\` matches sender's \`dd\` output (sha256 round-trip).

## Hangs

Listener hangs only if the remote sender never closes their stream. The visor's \`acceptCtx\` (5min default, configurable via \`--timeout\`) bounds this. Dial mode unchanged so send-only-without-reply still cascade-closes promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)