### PR TITLE
feat(cxo/node): publisher health counters (sendMsg timeouts + dead-conn count)

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -514,6 +514,8 @@ func (c *Conn) sendMsg(seq, rseq uint32, m msg.Msg) error {
 	case <-c.closeq:
 		return ErrClosed
 	case <-time.After(sendMsgQueueTimeout):
+		c.n.sendMsgTimeoutCount.Add(1)
+		c.n.deadConnsClosed.Add(1)
 		c.n.Printf("[WARN] [%s] sendMsg: queue full for %s; declaring conn dead and closing",
 			c.String(), sendMsgQueueTimeout)
 		_ = c.Close() //nolint:errcheck,gosec

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -66,6 +67,23 @@ type Node struct {
 	//
 
 	fillavg *statutil.Duration // filling average
+
+	// sendMsgTimeoutCount counts sendMsg-queue-full-timeout events.
+	// Each increment corresponds to one Conn whose send queue was
+	// blocked for sendMsgQueueTimeout (5s by default) — the conn is
+	// then closed by sendMsg. Surfaced via PublisherStats so operators
+	// can tell whether a publisher fanout is silently shedding peers.
+	// Pre-#2538 this would have manifested as a stalled broadcast loop
+	// with no observable counter; post-#2538 the conn dies but the
+	// fact that it died was only visible in WARN logs.
+	sendMsgTimeoutCount atomic.Uint64
+
+	// deadConnsClosed counts Conn instances that sendMsg closed due to
+	// the timeout path. Always == sendMsgTimeoutCount today (one
+	// timeout = one close), kept separate so a future refactor that
+	// adds other auto-close paths (idle detection, frame-error close,
+	// etc.) can be counted distinctly.
+	deadConnsClosed atomic.Uint64
 
 	//
 	// rpc
@@ -254,6 +272,47 @@ func (n *Node) Connections() (cs []*Conn) {
 	}
 
 	return
+}
+
+// PublisherStats is the snapshot of CXO-publisher-side health counters.
+// Surfaced upward (treestore.Publisher.Stats() → visor RPC →
+// `skywire cli visor doctor`) so operators can spot a publisher
+// fanout that's silently shedding subscribers without parsing WARN
+// logs.
+//
+// Counter semantics:
+//   - SendMsgTimeouts counts sendMsg-queue-full-timeout events.
+//     Each tick is one subscriber whose queue was blocked for the
+//     full sendMsgQueueTimeout window before the conn was force-closed.
+//     A non-zero counter is the smoking gun for the pre-#2538 stuck
+//     publisher pattern, now bounded but worth surfacing.
+//   - DeadConnsClosed counts Conn instances closed by sendMsg's
+//     timeout path. Today this is always equal to SendMsgTimeouts;
+//     kept distinct so future auto-close paths (idle, frame-error,
+//     etc.) can be counted without rebasing this struct.
+//   - ActiveConnections / ActiveFeeds are point-in-time gauges
+//     useful for sanity checking ("did my publisher lose all its
+//     subscribers?").
+type PublisherStats struct {
+	SendMsgTimeouts   uint64 `json:"sendmsg_timeouts"`
+	DeadConnsClosed   uint64 `json:"dead_conns_closed"`
+	ActiveConnections int    `json:"active_connections"`
+	ActiveFeeds       int    `json:"active_feeds"`
+}
+
+// Stats returns a snapshot of the Node's publisher-side health
+// counters + active gauges. Cheap: atomic loads + map-length read
+// under the node mutex.
+func (n *Node) Stats() PublisherStats {
+	n.mx.Lock()
+	conns := len(n.addrToConn)
+	n.mx.Unlock()
+	return PublisherStats{
+		SendMsgTimeouts:   n.sendMsgTimeoutCount.Load(),
+		DeadConnsClosed:   n.deadConnsClosed.Load(),
+		ActiveConnections: conns,
+		ActiveFeeds:       len(n.fs.list()),
+	}
 }
 
 // don't create TCP in background

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -283,6 +283,14 @@ func (p *Publisher) Node() *node.Node {
 	return p.cxoNode
 }
 
+// Stats returns the underlying CXO node's publisher-side health
+// snapshot. Pass-through to node.Node.Stats() for callers that
+// only have a Publisher handle in scope. See node.PublisherStats
+// for counter semantics.
+func (p *Publisher) Stats() node.PublisherStats {
+	return p.cxoNode.Stats()
+}
+
 // SetAllowlist atomically replaces the subscriber allowlist. nil
 // disables the gate (any subscriber accepted). An empty non-nil
 // slice closes the gate to all subscribers — useful for staging a


### PR DESCRIPTION
## Summary

Adds two atomic counters to \`pkg/cxo/node\` that capture the
publisher-fanout health #2538 was meant to bound, plus a snapshot
getter (\`Node.Stats()\` returning \`node.PublisherStats\`) and a
\`treestore.Publisher.Stats()\` pass-through.

## Why

Pre-#2538 a stuck subscriber blocked the publisher's
\`broadcastRoot\` loop indefinitely. #2538 fixed that with a 5s
\`sendMsgQueueTimeout\` that force-closes the dead conn — but the
fact that the bounded path fired was only visible in WARN logs.
Beta's ranked-gaps survey today flagged this as item #10, the
"CXO publisher health metrics in /status" gap that closes a known
prior incident class (the F11b publisher-stuck pattern).

## What

\`pkg/cxo/node/node.go\`:
- \`Node.sendMsgTimeoutCount atomic.Uint64\`: bumped each time
  \`sendMsg\` hits the 5s queue timeout.
- \`Node.deadConnsClosed atomic.Uint64\`: bumped on the same path.
  Tracked separately so future auto-close paths (idle, frame
  error, etc.) can be counted without rebasing.
- \`PublisherStats\` struct: \`SendMsgTimeouts\`, \`DeadConnsClosed\`,
  \`ActiveConnections\`, \`ActiveFeeds\`.
- \`Stats() PublisherStats\` snapshot method: atomic loads + one
  short mutex critical section + one \`nf.list()\` call.

\`pkg/cxo/node/conn.go\`:
- \`sendMsg\` timeout path bumps both counters before logging WARN
  and closing the conn.

\`pkg/cxo/treestore/publisher.go\`:
- \`Publisher.Stats()\`: pass-through to \`Node.Stats()\` for callers
  that have a Publisher handle but don't want to reach for
  \`.Node().\`.

## Scope

Load-bearing primitives only. Visor RPC surface + CLI tool +
\`cli visor doctor\` integration are deferred to a follow-up PR to
keep this diff small and focused. Anyone with a \`*node.Node\` or
\`*treestore.Publisher\` in scope can now query the counters.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/cxo/...\` — green (all packages)
- [ ] Manual: trigger a sendMsg-timeout by half-closing a subscriber
  socket; confirm counter increments.