### PR TITLE
perf(dmsg): bump AcceptBufferSize 20 → 256 to absorb deployment burst

### DIFF
--- a/pkg/dmsg/dmsg/types.go
+++ b/pkg/dmsg/dmsg/types.go
@@ -39,8 +39,23 @@ var (
 	// in waitRead from holding ephemeral ports indefinitely.
 	StreamIdleTimeout = 2 * time.Minute
 
-	// AcceptBufferSize defines the size of the accepts buffer.
-	AcceptBufferSize = 20
+	// AcceptBufferSize is the buffer depth of each dmsg Listener's
+	// accept channel — how many newly-arrived (but not yet
+	// AcceptStream-drained) streams the listener can hold before it
+	// starts dropping with "Accept buffer full" + ErrAcceptChanMaxed.
+	//
+	// Sized for the largest plausible burst of inbound REQUEST
+	// frames between consumer drains. Production TPD's CXO
+	// subscriber listener (port 50) was empirically hitting steady-
+	// state ~16 drops/sec with a peer count in the few-hundreds
+	// range — small enough that the constant being 20 (the original
+	// value, intended for hobbyist visor accept rates) saturated
+	// within ~1s of a deploy-restart traffic spike and never
+	// recovered. Bumping to 256 absorbs ~16s of burst at that rate
+	// before drops start, and is still tiny in absolute memory
+	// terms (256 pointers ≈ 2 KiB per listener). Listeners that see
+	// less load (visor-side ports, etc.) pay the same trivial cost.
+	AcceptBufferSize = 256
 )
 
 // YamuxConfig returns a tuned yamux configuration for dmsg sessions.


### PR DESCRIPTION
## Summary

Empirically-driven bump of `pkg/dmsg/dmsg/types.go::AcceptBufferSize` from `20` to `256`.

## Observation

Production TPD's CXO subscriber listener on dmsg port 50 (`skyenv.DmsgCXOPort`) was sustaining a ~16 drops/sec rate of `WARN [dmsg_listener]: Accept buffer full, dropping stream` for 1h+ of uptime. Pattern observed in today's deployment-health monitoring:

- container restart at 17:25:xx → 0 drops for ~15 min
- thereafter 950/min steady-state drops
- TPD memory 98MB → 292MB in those 15 min
- re-restart resets the cycle

Visors retry on `ErrAcceptChanMaxed` so the service kept functioning, but at elevated TPD CPU (40-63% vs. quiet 22% baseline) and elevated visor-side retry traffic.

## Root cause

The 20-slot channel saturates within ~1s of a deploy-restart traffic spike (visors reconnecting after the restart) and never recovers — the REQUEST-frame arrival rate stays slightly above the CXO `DMSGFactory.acceptLoop` drain rate (per-conn handshake under the Node's mutex). Permanent backpressure → permanent drops.

## Fix

`AcceptBufferSize = 256` absorbs ~16s of burst at the observed rate before drops start, giving the consumer time to catch up on natural lulls.

## Cost

Negligible: 256 pointer-sized slots ≈ 2 KiB per listener. Lower-traffic listeners (visor-side ports, dmsg-server discovery accept) pay the same trivial cost.

## Scope

This is the **buffer cap**, not the **in-flight callback cap**. The two are complementary:

- `AcceptBufferSize` (this PR): bounds between-accept burst absorption
- `DMSGFactory.MaxPendingAccepts` (already tuned via `MaxPendingConnections=1000` in the CXO Node config): bounds parallel handshake work

## Followups out of scope

- Per-listener override (`AcceptBufferSize` is package-global). If different ports need different buffer depths we can introduce a per-`Listen()` option.
- TPD-side investigation: why does the drain rate cap at ~12/sec? May be Node.mx contention in `initConn`. Separate bug.

## Tests

- `go test -count=1 ./pkg/dmsg/dmsg/` pass.
- `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)