### PR TITLE
feat(cli/dmsg/cat): wire --routes flag to router mux for skynet transport

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/cat.go
+++ b/cmd/skywire-cli/commands/dmsg/cat.go
@@ -62,7 +62,7 @@ func init() {
 	catCmd.Flags().DurationVarP(&catTimeout, "timeout", "t", 60*time.Second,
 		"dial / accept timeout")
 	catCmd.Flags().IntVar(&catRoutes, "routes", 1,
-		"number of skynet routes (future-use; skynet transport only)")
+		"number of parallel skynet mux routes (skynet transport only; 0 or 1 = single route)")
 	catCmd.Flags().BoolVarP(&catVerbose, "verbose", "v", false,
 		"print connection info to stderr")
 	catCmd.Flags().VarP(&sk, "sk", "s",
@@ -244,6 +244,7 @@ func runVisorCatDial(transport string, peerPK cipher.PubKey, port uint16, cmd *c
 		Port:      port,
 		Transport: transport,
 		Timeout:   catTimeout,
+		Routes:    catRoutes,
 	}
 	resp, err := rc.VisorCat(req)
 	if err != nil {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -780,6 +780,13 @@ type VisorCatRequest struct {
 	// mode) plus the splice. Zero defaults: 60s for dial, 5m for
 	// listen.
 	Timeout time.Duration `json:"timeout,omitempty"`
+	// Routes requests N parallel mux routes for the skynet transport
+	// in dial mode. The router opens N route-groups in parallel and
+	// stripes writes across them with sequence numbers + resequencing
+	// on reads — bytes remain ordered at the app layer. Ignored for
+	// dmsg transport and for listen mode (listener accepts whatever
+	// the peer dials). 0 or 1 = single route (default).
+	Routes int `json:"routes,omitempty"`
 }
 
 // VisorCatResponse carries the 127.0.0.1 loopback address the CLI

--- a/pkg/visor/api_visor_cat.go
+++ b/pkg/visor/api_visor_cat.go
@@ -37,6 +37,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
@@ -102,7 +103,7 @@ func (v *Visor) visorCatDial(req VisorCatRequest, transport string) (*VisorCatRe
 
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), timeout)
 	defer dialCancel()
-	remote, err := v.dialCatTransport(dialCtx, transport, req.RemotePK, req.Port)
+	remote, err := v.dialCatTransport(dialCtx, transport, req.RemotePK, req.Port, req.Routes)
 	if err != nil {
 		return nil, fmt.Errorf("VisorCat: dial %s %s:%d: %w",
 			transport, req.RemotePK, req.Port, err)
@@ -357,7 +358,11 @@ func (v *Visor) visorCatListen(req VisorCatRequest, transport string) (*VisorCat
 }
 
 // dialCatTransport opens a remote stream over the requested transport.
-func (v *Visor) dialCatTransport(ctx context.Context, transport string, rPK cipher.PubKey, port uint16) (net.Conn, error) {
+// When routes > 1 and the transport is skynet, the router establishes
+// N parallel mux routes via SkywireNetworker.DialContextWithOptions —
+// writes are striped + reads are resequenced inside the route-group's
+// mux layer, so the caller still sees a single ordered net.Conn.
+func (v *Visor) dialCatTransport(ctx context.Context, transport string, rPK cipher.PubKey, port uint16, routes int) (net.Conn, error) {
 	switch transport {
 	case VisorCatTransportDmsg:
 		if err := v.mustWaitDmsgReady(); err != nil {
@@ -365,14 +370,31 @@ func (v *Visor) dialCatTransport(ctx context.Context, transport string, rPK ciph
 		}
 		return v.dmsgC.DialStream(ctx, dmsg.Addr{PK: rPK, Port: port})
 	case VisorCatTransportSkynet:
-		if _, err := appnet.ResolveNetworker(appnet.TypeSkynet); err != nil {
+		nw, err := appnet.ResolveNetworker(appnet.TypeSkynet)
+		if err != nil {
 			return nil, fmt.Errorf("skynet networker not registered: %w", err)
 		}
-		return appnet.DialContext(ctx, appnet.Addr{
+		addr := appnet.Addr{
 			Net:    appnet.TypeSkynet,
 			PubKey: rPK,
 			Port:   routing.Port(port),
-		})
+		}
+		// Routes <= 1 keeps the single-route default; otherwise reach
+		// for SkywireNetworker.DialContextWithOptions to ask the router
+		// for N parallel mux routes. Type-asserting to the concrete
+		// networker is the established pattern for opt-passing — the
+		// abstract appnet.Networker has only the no-opts DialContext.
+		if routes > 1 {
+			if sw, ok := nw.(*appnet.SkywireNetworker); ok {
+				opts := router.DefaultDialOptions()
+				opts.MuxRoutes = routes
+				return sw.DialContextWithOptions(ctx, addr, opts)
+			}
+			// Fallback: networker registered under TypeSkynet isn't the
+			// real SkywireNetworker (unlikely in production; a mock in
+			// tests). Single-route dial preserves correctness.
+		}
+		return appnet.DialContext(ctx, addr)
 	}
 	return nil, fmt.Errorf("unsupported transport %q", transport)
 }


### PR DESCRIPTION
## Summary

The \`--routes=N\` flag on \`cli dmsg cat\` was added in #2544 but documented \"future-use\" and never threaded to the router. Meanwhile the router's multi-route mux machinery (\`establishMuxRoutes\`, \`routeMux\` striping + resequencing, SACK) has been merged and tested via the skysocks \`mux_test\` integration since at least #2552 — just unwired for the dmsg cat consumer.

This 36-line patch unwires it.

## Changes

1. **\`pkg/visor/api.go\`**: \`Routes int\` field added to \`VisorCatRequest\`. RPC clients can now request N parallel mux routes.
2. **\`cmd/skywire-cli/commands/dmsg/cat.go\`**: \`runVisorCatDial\` sets \`req.Routes = catRoutes\`. Flag help drops the \"future-use\" qualifier.
3. **\`pkg/visor/api_visor_cat.go\`**: \`dialCatTransport\` learns to use \`SkywireNetworker.DialContextWithOptions\` when \`routes > 1\` on the skynet transport. Type-asserts the resolved networker to the concrete type — same pattern \`api_transport.go\` uses. Falls back to single-route dial if the asserted type isn't there (test mocks).

dmsg transport remains single-route (mux is a router feature, skynet-only). Listen mode is unaffected (listener accepts whatever the peer's dial requested).

## Why the patch is tiny

The router's \`establishMuxRoutes\` (\`pkg/router/router_dial.go:712\`) opens N parallel route-groups; the \`routeMux\` layer (\`pkg/router/route_group.go:109+\`) stripes payloads with sequence numbers and resequences on read with gap detection + SACK. Callers see a single ordered \`net.Conn\`. All of that was already in place — this PR just hooks the existing dmsg-cat consumer onto the bus.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/visor/...\` clean
- [ ] Manual smoke: \`cli dmsg cat <pk>:<port> --transport=skynet --routes=2\` driving \`cli dmsg iperf\` as the receiver. Compare aggregate Mb/s vs \`--routes=1\`. Tabling until peers are reachable over multiple-transport-pair routes (current testbed has limited route diversity).
- [ ] Cross-host: run between Alpha / Beta / Gamma once Alpha scps a fresh binary.

Existing \`internal/integration/mux_test.go\` already validates the router + mux layer end-to-end for skysocks workloads; this patch extends the same capability surface to streaming consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)