### PR TITLE
fix(visor/cat): sniffer must not treat CLI half-close as give-up

### DIFF
--- a/pkg/visor/api_visor_cat.go
+++ b/pkg/visor/api_visor_cat.go
@@ -210,13 +210,24 @@ func (v *Visor) visorCatListen(req VisorCatRequest, transport string) (*VisorCat
 		}
 
 		// Sniffer: read 1 byte from local. Cases:
-		//   - local closes before remote arrives: err signals close,
-		//     cancel acceptCtx so remote-wait gives up promptly.
 		//   - local sends a byte before remote arrives (CLI piped
 		//     stdin early): hold the byte and prepend it to the
 		//     splice once remote is ready.
-		//   - remote arrives first: signal sniffer to stop; if it
-		//     read a byte before stopping, splice prepends.
+		//   - local returns io.EOF: CLI did either a CloseWrite
+		//     (post-#2549 half-close on stdin EOF — CLI still alive
+		//     reading the conn) OR a full Close (CLI gave up). The
+		//     kernel doesn't surface the distinction without a
+		//     syscall probe, so we conservatively treat EOF as "CLI
+		//     half-closed, still alive" and wait for stopSniff
+		//     (remote arrival) without canceling acceptCtx. The
+		//     acceptCtx --timeout (5min default) still bounds the
+		//     listen-resource hold if CLI genuinely gave up.
+		//   - local returns a hard error (RST / EPIPE / net.ErrClosed):
+		//     CLI is genuinely gone — cancel acceptCtx so the
+		//     deferred listener-close fires immediately.
+		//   - remote arrives first: signal sniffer to stop via
+		//     stopSniff; if it read a byte before stopping, splice
+		//     prepends.
 		type sniffResult struct {
 			b   byte
 			has bool
@@ -243,6 +254,15 @@ func (v *Visor) visorCatListen(req VisorCatRequest, transport string) (*VisorCat
 							continue
 						}
 					}
+					// io.EOF = CLI sent FIN. Could be alive (CloseWrite
+					// from spliceStdioHalfClose) or gone (full Close).
+					// Conservatively assume alive — wait for remote.
+					if errors.Is(rerr, io.EOF) {
+						<-stopSniff
+						sniffCh <- sniffResult{}
+						return
+					}
+					// Hard error (RST, EPIPE, ErrClosed): CLI gone.
 					sniffCh <- sniffResult{err: rerr}
 					return
 				}


### PR DESCRIPTION
## Summary

Third dmsgcat follow-up. Interaction bug between #2547 (visor sniffer cancels on local read error) and #2549 (CLI does CloseWrite on stdin-EOF instead of full Close): visor's sniffer sees the CloseWrite as \`io.EOF\` and fires the cancel-acceptCtx path, killing the listener before any remote can dial.

Effect for users: \`cli dmsg cat listen <port>\` with stdin not held open (the default shell invocation) exits within milliseconds. The workaround in chat coordination has been \`sleep infinity | cli dmsg cat listen <port>\`, but that's not in \`--help\`.

## Fix

In the sniffer's read-error branch, distinguish:
- \`io.EOF\` (FIN — could be CloseWrite from an alive CLI, or full Close from a gone CLI). Can't tell at the Go net layer without a syscall probe, so conservatively treat as **half-close**: stop sniffing, wait for remote arrival via \`stopSniff\`, do not cancel \`acceptCtx\`.
- Hard errors (\`RST\`, \`EPIPE\`, \`net.ErrClosed\`) — CLI genuinely gone. Retain the original cancel-fast behavior.

The acceptCtx \`--timeout\` (5min default) still bounds listener resources if the CLI silently gave up — same cleanup window the pre-#2547 code had.

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` + \`go test ./pkg/visor/...\` clean
- [x] Smoke: \`cli dmsg cat listen 6010\` invoked without piping stdin
  - Pre-fix: exits ~1s after \`stream accepted; splicing stdio\`
  - Post-fix: stays alive until \`--timeout\` fires (verified with \`timeout 4\` killing at 4s)
- [ ] Cross-host: re-run Phase 2 mux smoke test without \`sleep infinity\` workaround on listener side

## Trade-off

Loses the fast-cancel behavior introduced by #2547 for the \"CLI Ctrl-C\" scenario when CloseWrite-on-stdin-EOF is the trigger. The Ctrl-C / full-process-exit case still triggers a hard error (RST/EPIPE), which is correctly detected. So fast-cancel only degrades for users who explicitly half-close stdin via shell (rare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)