### PR TITLE
feat(dmsgpty): direct-TCP entry point with XK-noise handshake (server-side)

### DIFF
--- a/pkg/dmsg/dmsgpty/host_tcp.go
+++ b/pkg/dmsg/dmsgpty/host_tcp.go
@@ -1,0 +1,203 @@
+// Package dmsgpty pkg/dmsg/dmsgpty/host_tcp.go — direct-TCP entry
+// point for the dmsgpty / dmsgscp / dmsgcat protocols, with an XK
+// noise handshake gating the dmsgpty whitelist.
+//
+// The dmsg-overlay path (ListenAndServe on a dmsg port) is the
+// primary entry. This file adds a parallel listener that operators
+// can enable via Dmsgpty.TCPListen in the visor config. The
+// handshake model intentionally mirrors ssh's:
+//
+//   - The CLIENT pins the SERVER's PK (passed as RemotePK on the
+//     XK-Initiator side). A wrong PK fails the handshake — the
+//     equivalent of "host key check failed".
+//   - The SERVER learns the CLIENT's PK from the completed
+//     handshake (noise.RemoteStatic()). That PK is then checked
+//     against the dmsgpty Whitelist — the equivalent of
+//     authorized_keys but indexed by visor PK instead of an SSH
+//     pubkey.
+//
+// The Stream that comes out of the noise wrapper satisfies net.Conn
+// and is fed to the same serveConn path that the dmsg-overlay
+// listener uses, so dmsgpty / dmsgscp / dmsgcat handlers are
+// transport-agnostic at the protocol layer.
+package dmsgpty
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// tcpHandshakeTimeout bounds the XK noise handshake on each accepted
+// TCP connection. Operator-facing dial latency is bounded; a stuck
+// handshake (client never speaks, or attacker probes the port) costs
+// at most one timeout's worth of accept-loop pacing.
+const tcpHandshakeTimeout = 10 * time.Second
+
+// ListenAndServeTCP brings up a raw-TCP entry point for the dmsgpty
+// protocol on addr (net.Listen format — `:2022`, `0.0.0.0:2022`,
+// etc.). Each accepted connection runs an XK noise handshake with
+// the visor's identity keypair before being authorized against the
+// dmsgpty whitelist and handed to the standard dmsgpty mux.
+//
+// Blocks until ctx is canceled or the listener fails permanently.
+// Returns the underlying listen error in the latter case; ctx-driven
+// shutdown returns nil.
+//
+// Whitelist sharing: the wl injected at NewHost time is the same wl
+// the dmsg-overlay path uses. There is no separate TCP ACL by design
+// — trusting a peer for dmsg-pty implicitly trusts them over the
+// TCP entry point, since the protocol semantics are identical.
+func (h *Host) ListenAndServeTCP(ctx context.Context, addr string, localPK cipher.PubKey, localSK cipher.SecKey) error {
+	if addr == "" {
+		return errors.New("dmsgpty: ListenAndServeTCP: empty addr")
+	}
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("dmsgpty: tcp listen %s: %w", addr, err)
+	}
+
+	log := logging.MustGetLogger("dmsg_pty_tcp")
+	masterLogger := h.dmsgC.MasterLogger()
+	if masterLogger != nil {
+		log = masterLogger.PackageLogger("dmsg_pty_tcp")
+	}
+	log.WithField("addr", lis.Addr().String()).Info("Direct-TCP dmsgpty listener bound.")
+
+	go func() {
+		<-ctx.Done()
+		_ = lis.Close() //nolint:errcheck
+	}()
+
+	mux := dmsgEndpoints(h)
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			if errors.Is(err, io.ErrClosedPipe) || errors.Is(err, net.ErrClosed) {
+				log.Debug("dmsgpty-tcp: cleanly stopped serving.")
+				return nil
+			}
+			if ne, ok := err.(net.Error); ok && ne.Temporary() { //nolint:staticcheck // Temporary is the canonical accept-error pattern
+				log.WithError(err).Warn("dmsgpty-tcp: temporary accept error, continuing...")
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			log.WithError(err).Error("dmsgpty-tcp: permanent accept error.")
+			return err
+		}
+		go h.handleTCPConn(ctx, log, &mux, conn, localPK, localSK)
+	}
+}
+
+// handleTCPConn runs the per-connection noise + authorize + serve
+// pipeline. Each accepted conn becomes its own goroutine so a stuck
+// handshake (slow client, attacker probing the port) doesn't block
+// the accept loop.
+func (h *Host) handleTCPConn(
+	ctx context.Context,
+	parentLog logrus.FieldLogger,
+	mux *hostMux,
+	conn net.Conn,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+) {
+	defer func() { _ = conn.Close() }() //nolint:errcheck
+
+	log := parentLog.WithField("remote_addr", conn.RemoteAddr().String())
+
+	// XK with Initiator=false: we (server) know our own static, and
+	// learn the client's static via the handshake. Pre-handshake
+	// deadlines bound the cost of an attacker holding a TCP slot open
+	// without speaking; once the handshake completes the per-stream
+	// timeouts of the dmsgpty handlers take over.
+	ns, err := noise.New(noise.HandshakeXK, noise.Config{
+		LocalPK:   localPK,
+		LocalSK:   localSK,
+		Initiator: false,
+	})
+	if err != nil {
+		log.WithError(err).Warn("dmsgpty-tcp: noise init failed.")
+		return
+	}
+	rw := noise.NewReadWriter(conn, ns)
+	if err := rw.Handshake(tcpHandshakeTimeout); err != nil {
+		log.WithError(err).Debug("dmsgpty-tcp: noise handshake failed.")
+		return
+	}
+	if rw.Buffered() > 0 {
+		log.Warn("dmsgpty-tcp: noise handshake left buffered bytes — abort.")
+		return
+	}
+	rPK := rw.RemoteStatic()
+	log = log.WithField("remote_pk", rPK.String())
+
+	if !h.authorize(log, rPK) {
+		// authorize logs the rejection itself; close the wrapped
+		// conn so the client gets a read EOF.
+		return
+	}
+
+	log = log.WithField("conn_id", atomic.AddInt32(&h.connN, 1))
+	defer atomic.AddInt32(&h.connN, -1)
+	log.Debug("dmsgpty-tcp: stream accepted.")
+
+	nc := &noiseNetConn{Conn: conn, rw: rw, rPK: rPK}
+	h.serveConn(ctx, log, mux, nc)
+}
+
+// noiseNetConn adapts a noise.ReadWriter back to net.Conn so the
+// existing dmsgpty mux can consume it identically to a dmsg.Stream.
+// Read / Write go through the noise layer for encryption + framing;
+// LocalAddr / RemoteAddr / Close / SetDeadline pass through to the
+// underlying TCP conn unchanged. RemoteAddr returns a synthetic
+// dmsg-shaped address so any downstream code that pattern-matches
+// on `dmsg.Addr` / `appnet.Addr` for PK extraction can keep its
+// existing extraction path.
+type noiseNetConn struct {
+	net.Conn // for LocalAddr / Close / Set*Deadline. Read/Write below override.
+	rw       *noise.ReadWriter
+	rPK      cipher.PubKey
+}
+
+// Read pulls plaintext bytes from the noise layer.
+func (c *noiseNetConn) Read(p []byte) (int, error) { return c.rw.Read(p) }
+
+// Write pushes plaintext bytes through the noise layer.
+func (c *noiseNetConn) Write(p []byte) (int, error) { return c.rw.Write(p) }
+
+// RemoteAddr returns a TCPNoiseAddr carrying the handshake-derived
+// peer PK alongside the underlying TCP address. Callers that need
+// the PK can type-assert; callers that just want a net.Addr get the
+// usual ip:port string.
+func (c *noiseNetConn) RemoteAddr() net.Addr {
+	return TCPNoiseAddr{TCP: c.Conn.RemoteAddr(), PK: c.rPK}
+}
+
+// TCPNoiseAddr is the RemoteAddr type returned from a dmsgpty-tcp
+// accepted connection. The underlying TCP address is preserved so
+// log lines + audit trails look familiar; PK is the peer's
+// noise-handshake-verified static key.
+type TCPNoiseAddr struct {
+	TCP net.Addr
+	PK  cipher.PubKey
+}
+
+// Network returns the underlying TCP network ("tcp" / "tcp4" / "tcp6").
+func (a TCPNoiseAddr) Network() string { return a.TCP.Network() }
+
+// String returns a `<pk>@<ip:port>` form so log lines uniquely
+// identify the peer without the reader having to cross-reference the
+// dmsg discovery.
+func (a TCPNoiseAddr) String() string {
+	return fmt.Sprintf("%s@%s", a.PK.String(), a.TCP.String())
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -739,6 +739,30 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	}
 
+	// Direct-TCP dmsgpty entry point — operator opts in via
+	// Dmsgpty.TCPListen ("" disables). Same whitelist as the
+	// dmsg-overlay path; XK-noise handshake gates the accepted PK
+	// before the stream reaches the dmsgpty mux. See
+	// dmsgpty/host_tcp.go for the per-connection flow.
+	if tcpAddr := conf.TCPListen; tcpAddr != "" {
+		tcpCtx, tcpCancel := context.WithCancel(context.Background()) //nolint:gosec // cancel called in pushCloseStack
+		tcpWg := new(sync.WaitGroup)
+		tcpWg.Add(1)
+		go func() {
+			defer tcpWg.Done()
+			runtimeErrors := getErrors(ctx)
+			if err := pty.ListenAndServeTCP(tcpCtx, tcpAddr, v.conf.PK, v.conf.SK); err != nil {
+				runtimeErrors <- fmt.Errorf("dmsgpty tcp listen %s stopped: %w", tcpAddr, err)
+			}
+		}()
+		v.pushCloseStack("dmsgpty.tcp.serve", func() error {
+			tcpCancel()
+			tcpWg.Wait()
+			return nil
+		})
+		log.WithField("addr", tcpAddr).Info("Mounted dmsgpty direct-TCP entry point")
+	}
+
 	// dmsgscp Host (scp-over-dmsg). On by default — access is gated
 	// by the same whitelist that dmsgpty uses. Operators opt OUT
 	// via Dmsgscp.Disabled. When Dmsgscp.Whitelist is non-empty it

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -68,6 +68,29 @@ type Dmsgpty struct {
 	CLINet    string          `json:"cli_network"`
 	CLIAddr   string          `json:"cli_address"`
 	Whitelist []cipher.PubKey `json:"whitelist"`
+
+	// TCPListen, when non-empty, brings up a direct-TCP entry point
+	// for the dmsgpty / dmsgscp / dmsgcat protocols, separate from the
+	// dmsg-overlay path. Listening address in net.Listen format —
+	// `:2022`, `0.0.0.0:2022`, `127.0.0.1:2022`, etc. Empty (default)
+	// disables it: only the dmsg-overlay entry point is served.
+	//
+	// Auth flow per accepted TCP connection:
+	//   1. Noise XK handshake using the visor's identity keypair —
+	//      the client side pins the server's PK (same trust model as
+	//      ssh's host key check) and the server learns the client's PK
+	//      from the handshake.
+	//   2. The learned client PK is checked against the SAME whitelist
+	//      that gates the dmsg-overlay accept loop. No separate ACL.
+	//   3. On accept, the stream is handed to the existing dmsgpty
+	//      mux so dmsgpty / dmsgscp / dmsgcat clients work uniformly
+	//      over either transport.
+	//
+	// Motivation: ssh-equivalent over skywire identity. Operators who
+	// have direct IP reachability to a peer can `cli dmsg pty exec`
+	// (and friends) over TCP — no dmsg-discovery dependency, lower
+	// latency for known endpoints, same PK-based auth model.
+	TCPListen string `json:"tcp_listen,omitempty"`
 }
 
 // Dmsgscp configures the dmsgscp-host (scp-over-dmsg daemon).


### PR DESCRIPTION
## Summary

Adds an **opt-in TCP listener** to the dmsgpty Host that serves the
dmsgpty / dmsgscp / dmsgcat protocols outside the dmsg overlay.
ssh-equivalent on skywire: with a peer's PK and an IP:port,
operators can \`cli dmsg pty exec\` / \`scp\` / \`cat\` without depending
on dmsg-discovery, dmsg-servers, or the dmsg overlay being healthy.

## Wire model

Server side, per accepted TCP connection:

1. **XK noise handshake** with the visor's identity keypair
   (\`Initiator=false\`). The client side passes the server's PK on
   dial; the noise handshake fails if that pin is wrong — ssh
   host-key-check equivalent.
2. **Whitelist gate**: the handshake-derived client PK
   (\`noise.ReadWriter.RemoteStatic\`) is checked against the SAME
   \`dmsgpty.Whitelist\` the dmsg-overlay accept loop uses. No
   separate ACL — trusting a peer for dmsgpty over dmsg implicitly
   trusts them over the TCP entry point too. Protocol semantics
   are identical.
3. **Handoff**: the noise-wrapped stream is handed to the existing
   \`serveConn\` path with \`dmsgEndpoints\` mux. dmsgpty / scp / cat
   handlers see \`net.Conn\` just like a \`dmsg.Stream\` and need no
   changes.

## Config

New \`Dmsgpty.TCPListen string\` field.

- Empty (default) keeps the dmsg-overlay path as the only entry
  point — no behavior change for existing operators.
- Non-empty (e.g. \`":2022"\`) brings the TCP listener up.
  \`net.Listen\` semantics — \`0.0.0.0:N\`, \`:N\`, \`127.0.0.1:N\`, IPv6
  forms all work.

## Visor wiring

\`init_dmsg.go\` reads \`conf.TCPListen\` after the existing
dmsg-overlay \`ListenAndServe\` spawn. On non-empty, launches a
parallel goroutine calling \`pty.ListenAndServeTCP\`, pushing a
matching close-stack entry so shutdown is clean. The visor's own
PK/SK feed the noise XK handshake.

## What's NOT in this PR

CLI client support — \`cli dmsg pty exec --via tcp://<pk>@<ip>:<port>\`
sugar comes as a follow-up. With this PR alone, the listener is up
and reachable by any speaker of the noise+dmsgpty wire protocol;
operator-facing CLI ergonomics arrive next.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/dmsg/dmsgpty/... ./pkg/visor/...\` — green
- [x] Linter — no new issues introduced (pre-existing develop lint
  issues remain; this PR doesn't add any)
- [ ] Manual: enable \`tcp_listen: ":2022"\` on a test visor, dial
  with a Noise+dmsgpty client speaker, confirm whitelist gate +
  pty exec work as on the dmsg path
- [ ] Follow-up PR: CLI \`--via tcp://\` flag