### PR TITLE
feat(dmsgpty): TCPListen on standalone dmsgpty-host + --via-visor on cli

### DIFF
--- a/cmd/dmsg/dmsgpty-host/commands/root.go
+++ b/cmd/dmsg/dmsgpty-host/commands/root.go
@@ -46,6 +46,11 @@ var (
 	pk           cipher.PubKey
 	wl           cipher.PubKeys
 
+	// tcpListen, when non-empty, brings up the direct-TCP entry point
+	// (XK noise + dmsgpty whitelist gate) alongside the dmsg-overlay
+	// path. Mirrors the visor-embedded Dmsgpty.TCPListen config.
+	tcpListen string
+
 	// persistent flags
 	envPrefix = defaultEnvPrefix
 
@@ -66,6 +71,8 @@ func init() {
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgport", dmsgPort, "dmsg port for listening for remote hosts")
 	RootCmd.Flags().StringVar(&cliNet, "clinet", cliNet, "network used for listening for cli connections")
 	RootCmd.Flags().StringVar(&cliAddr, "cliaddr", cliAddr, "address used for listening for cli connections")
+	RootCmd.Flags().StringVar(&tcpListen, "tcplisten", "",
+		"optional direct-TCP entry point address (e.g. ':2022'); empty disables. XK-noise + whitelist gated, mirrors the visor-embedded Dmsgpty.TCPListen.")
 	// Prepare flags without associated env/config references.
 	RootCmd.Flags().StringVar(&envPrefix, "envprefix", envPrefix, "env prefix")
 	RootCmd.Flags().BoolVar(&confStdin, "confstdin", confStdin, "config will be read from stdin if set")
@@ -157,6 +164,27 @@ var RootCmd = &cobra.Command{
 				Info("Stopped serving dmsgpty-host.")
 			wg.Done()
 		}()
+
+		// Optional direct-TCP entry point (XK-noise + whitelist
+		// gated). Mirrors the visor-embedded Dmsgpty.TCPListen.
+		// Empty (default) skips it, preserving legacy behavior;
+		// non-empty (e.g. ":2022") brings the listener up alongside
+		// the dmsg-overlay path. The host's NewHost-wired wl is
+		// reused — no separate ACL.
+		tcpAddr := tcpListen
+		if tcpAddr == "" {
+			tcpAddr = conf.TCPListen
+		}
+		if tcpAddr != "" {
+			wg.Add(1)
+			log.WithField("addr", tcpAddr).
+				Info("Listening for direct-TCP streams (XK-noise gated).")
+			go func() {
+				log.WithError(host.ListenAndServeTCP(ctx, tcpAddr, pk, sk)).
+					Info("Stopped serving dmsgpty-host TCP entry point.")
+				wg.Done()
+			}()
+		}
 
 		wg.Wait()
 		return nil

--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -44,6 +44,14 @@ var (
 	// PK, so callers wanting stable authorization should pin --sk
 	// (or set DMSGPTY_SK in the environment). Unset = ephemeral.
 	ptySK cipher.SecKey
+	// ptyViaVisor, when true, borrows the local visor's secret key
+	// from its config file for the --via tcp path's noise handshake.
+	// Convenience for the common case of running the CLI on a host
+	// that also runs a visor: the visor's PK is typically already
+	// on the remote's whitelist, so the operator skips having to
+	// pin --sk or seed DMSGPTY_SK. An explicit --sk / DMSGPTY_SK
+	// always wins.
+	ptyViaVisor bool
 )
 
 // ptyTCPViaRE matches `tcp://<66-hex-pk>@<host:port>` for the --via
@@ -71,6 +79,8 @@ func init() {
 		"bypass local visor + dial remote dmsgpty-host's direct-TCP listener: tcp://<pk>@<host>:<port>")
 	ptyStartCmd.Flags().VarP(&ptySK, "sk", "s",
 		"local secret key for the --via direct-TCP path's noise handshake (random if unset; pin for stable whitelist authorization)")
+	ptyStartCmd.Flags().BoolVar(&ptyViaVisor, "via-visor", false,
+		"borrow local visor's secret key from "+visorconfig.SkywireConfig()+" for the --via noise handshake (--sk wins if set)")
 
 	// Flags for exec command
 	ptyExecCmd.PersistentFlags().StringVarP(&ptyRpcAddr, "rpc", "", "localhost:3435", "RPC server address")
@@ -81,6 +91,8 @@ func init() {
 		"bypass local visor + dial remote dmsgpty-host's direct-TCP listener: tcp://<pk>@<host>:<port>")
 	ptyExecCmd.Flags().VarP(&ptySK, "sk", "s",
 		"local secret key for the --via direct-TCP path's noise handshake (random if unset; pin for stable whitelist authorization)")
+	ptyExecCmd.Flags().BoolVar(&ptyViaVisor, "via-visor", false,
+		"borrow local visor's secret key from "+visorconfig.SkywireConfig()+" for the --via noise handshake (--sk wins if set)")
 
 	// Flags for ui command
 	ptyUICmd.Flags().StringVarP(&ptyPath, "input", "i", "", "read from specified config file")
@@ -273,12 +285,20 @@ func parseTCPVia(via string) (cipher.PubKey, string, error) {
 }
 
 // resolveTCPIdentity returns the (PK, SK) used as the local
-// identity in the --via tcp noise handshake. If skFlag is non-zero,
-// it's used and the matching PK is derived. Otherwise a fresh
-// keypair is generated for the run (operator gets a one-shot
-// identity; whitelist-pinned hosts will reject it). DMSGPTY_SK
-// environment variable is a third source consulted before
-// generation.
+// identity in the --via tcp noise handshake. Resolution order:
+//
+//  1. skFlag (--sk) if non-zero, OR DMSGPTY_SK env if non-empty.
+//     Explicit identity always wins.
+//  2. --via-visor: read skywire.json and use the visor's SK. The
+//     visor's PK is typically already on remote whitelists, so
+//     this is the zero-config convenience path for operators
+//     running CLI alongside a visor.
+//  3. Fresh ephemeral keypair. Whitelist-pinned remotes will
+//     reject it; useful for testing against open-whitelist hosts
+//     or proving connectivity.
+//
+// Fatal-exits with a helpful message on a malformed identity
+// source — the caller can't proceed without a valid keypair.
 func resolveTCPIdentity(skFlag cipher.SecKey) (cipher.PubKey, cipher.SecKey) {
 	var zero cipher.SecKey
 	sk := skFlag
@@ -286,6 +306,19 @@ func resolveTCPIdentity(skFlag cipher.SecKey) (cipher.PubKey, cipher.SecKey) {
 		if env := os.Getenv("DMSGPTY_SK"); env != "" {
 			_ = sk.Set(env) //nolint:errcheck,gosec
 		}
+	}
+	if sk == zero && ptyViaVisor {
+		confPath := visorconfig.SkywireConfig()
+		conf, err := visorconfig.ReadFile(confPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pty --via-visor: read %s: %v\n", confPath, err) //nolint:errcheck
+			os.Exit(1)
+		}
+		if conf.SK == zero {
+			fmt.Fprintf(os.Stderr, "pty --via-visor: visor config %s has empty SK\n", confPath) //nolint:errcheck
+			os.Exit(1)
+		}
+		sk = conf.SK
 	}
 	if sk == zero {
 		pk, fresh := cipher.GenerateKeyPair()

--- a/pkg/dmsg/dmsgpty/conf.go
+++ b/pkg/dmsg/dmsgpty/conf.go
@@ -21,6 +21,23 @@ type Config struct {
 	SK           string   `json:"sk"`
 	PK           string   `json:"pk"`
 	WL           []string `json:"wl"`
+
+	// TCPListen, when non-empty, brings up the direct-TCP entry point
+	// alongside the dmsg-overlay listener — same shape and semantics
+	// as the visor-embedded version (see pkg/visor/visorconfig:
+	// Dmsgpty.TCPListen). net.Listen syntax: ":2022",
+	// "0.0.0.0:2022", "127.0.0.1:2022", IPv6 forms all work. Empty
+	// (default) disables the TCP entry point: only the dmsg-overlay
+	// path is served, matching legacy behavior.
+	//
+	// Auth flow per accepted TCP connection:
+	//   1. XK noise handshake using this host's PK/SK. The client
+	//      pins the server's PK; mismatched pin fails handshake
+	//      (ssh host-key-check equivalent).
+	//   2. The handshake-derived client PK is checked against the
+	//      same whitelist the dmsg-overlay accept loop uses. No
+	//      separate ACL.
+	TCPListen string `json:"tcplisten,omitempty"`
 }
 
 // DefaultConfig is used to populate the config struct with its default values


### PR DESCRIPTION
## Summary

Two convenience extensions of #2559 + #2560 to make the ssh-equivalent surface usable in more shapes.

## Standalone dmsgpty-host: --tcplisten

The visor-embedded path picked up \`Dmsgpty.TCPListen\` via the visor config in #2559. The standalone \`dmsgpty-host\` binary now gets the same optional TCP entry point. Operators can run the host without a visor and still expose the ssh-equivalent surface:

\`\`\`
dmsgpty-host --tcplisten ":2022" -c host-config.json
\`\`\`

Flag-level wiring mirrors the visor side. \`dmsgpty.Config\` also gains a \`"tcplisten"\` field so operators who configure via file (not flags) can set it there. Empty (default) preserves legacy behavior — only the dmsg-overlay path is served.

## CLI: --via-visor

Convenience flag for the common case of running \`cli dmsg pty exec/start --via tcp://...\` on a host that ALSO runs a visor. The visor's PK is typically already on the remote's whitelist, so the operator skips having to pin \`--sk\` or seed \`DMSGPTY_SK\`. With \`--via-visor\` the CLI reads the local visor config (\`visorconfig.SkywireConfig()\` default path) and borrows the visor's SK for the noise handshake.

Resolution priority (unchanged for explicit-identity users):
1. \`--sk\` flag or \`DMSGPTY_SK\` env (explicit wins)
2. \`--via-visor\` → read SK from \`skywire.json\`
3. Fresh ephemeral keypair (random; whitelist-rejected on pinned hosts; useful only for open-whitelist testing)

Both extensions are opt-in. Default behavior of the standalone binary and the CLI is unchanged for operators not setting any of the new flags.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/dmsg/dmsgpty/...\` — green
- [ ] Manual: standalone \`dmsgpty-host --tcplisten :2022\` + \`cli dmsg pty exec --via tcp://<host-pk>@127.0.0.1:2022 --sk <pinned> -- /bin/echo hello\`
- [ ] Manual: visor on box A, CLI on same box: \`cli dmsg pty exec --via tcp://<remote-pk>@<ip>:2022 --via-visor -- /bin/echo hello\`