### PR TITLE
fix(cli/config): seed conf-service PK in dmsg entry cache before fetch

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -803,6 +803,30 @@ func fetchServiceConfigDmsg(log *logging.Logger) bool {
 	}
 	defer dmsgBoot.Close()
 
+	// Pre-seed the conf service's PK in the dmsg client's entry cache.
+	// The conf service runs as a direct client (it doesn't register in
+	// the HTTP discovery), so dmsgC.DialStream's default disc lookup
+	// fails with "entry is not found in discovery" — which is harmless
+	// (the FallbackRoundTripper below recovers via plain HTTP) but
+	// loud during a fresh apt install where every postinst log line
+	// is operator-visible. Seeding the entry tells DialStream the conf
+	// service is reachable via every embedded DMSG server as a
+	// delegated relay, mirroring the visor-side
+	// `seedDmsgServiceEntries` pattern in pkg/visor/init_dmsg.go.
+	if confPK := dmsg.ExtractPKFromDmsgAddr(embeddedConf.ConfDmsg); confPK != "" {
+		var pkObj cipher.PubKey
+		if err := pkObj.UnmarshalText([]byte(confPK)); err == nil {
+			serverPKs := make([]cipher.PubKey, 0, len(dmsg.Prod.DmsgServers))
+			for i := range dmsg.Prod.DmsgServers {
+				serverPKs = append(serverPKs, dmsg.Prod.DmsgServers[i].Static)
+			}
+			dmsgBoot.Client.SeedEntryCache(pkObj, &disc.Entry{
+				Static: pkObj,
+				Client: &disc.Client{DelegatedServers: serverPKs},
+			})
+		}
+	}
+
 	// Make HTTP request through DMSG transport using FallbackRoundTripper.
 	// This tries each connected DMSG server directly, bypassing discovery
 	// lookup (conf service uses a direct client, not registered in discovery).
@@ -984,7 +1008,7 @@ func configureServices(log *logging.Logger) {
 // invent new schema, only rearrange the visor config's keys.
 //
 // Mutually-exclusive flags: only the FIRST set flag wins, in
-// precedence order sn → dmsgsrv → dmsgdisc. The CLI rejects multiple
+// precedence order sn → dmsgsrv → disc. The CLI rejects multiple
 // flags upstream of this helper, but the precedence here keeps
 // behavior deterministic if that check is ever bypassed.
 func serviceProjectionJQ() string {


### PR DESCRIPTION
## Summary

Postinst on a fresh \`apt install skywire-bin\` prints a loud DMSG
failure path before silently succeeding via HTTP fallback. Fix: pre-seed
the conf-service's PK so the DMSG path actually succeeds.

## Symptom

\`\`\`
[skywire-cli]: Fetching service endpoints via DMSG from dmsg://<conf-pk>:80
DEBUG [skywire-cli]: Discovery lookup failed, trying connected servers
  error="dmsg error 100 - entry is not found in discovery: entry of public key is not found"
DEBUG ClientSession.DialStream: Stream closed on failure. error="EOF"
DEBUG [skywire-cli]: DialStream failed via connected server, trying next
  error="EOF"
ERROR [skywire-cli]: Failed to fetch config via DMSG
  error="all DMSG transports failed: last error: dmsg error 100..."
[skywire-cli]: Fetching service endpoints from http://conf.skywire.skycoin.com
[skywire-cli]: Fetched service endpoints from 'http://conf.skywire.skycoin.com'
[skywire-cli]: Updated file '/opt/skywire/skywire.json'
\`\`\`

End result: success. But a fresh-install operator's terminal looks like it failed.

## Cause

The conf service runs as a **direct DMSG client** — it doesn't register an entry in the HTTP discovery. So when \`cmdutil.BootstrapDmsg\` returns and we call \`dmsgHTTPClient.Get(embeddedConf.ConfDmsg)\`, the underlying \`dmsgC.DialStream(<conf-pk>:80)\` first does a disc lookup, which returns \`ErrKeyNotFound\`. Then the dmsg client falls through to its connected-server retry path, but those sessions have no route for the conf-service PK either, so they EOF. Then \`fetchServiceConfigDmsg\` returns false, and \`loadServiceConfig\` falls back to plain HTTP, which works.

The visor doesn't hit this because of \`seedDmsgServiceEntries\` in \`pkg/visor/init_dmsg.go\` — it explicitly seeds the conf-service PK with all embedded DMSG server PKs as delegated relays, so \`DialStream\` skips the disc lookup entirely. The CLI's standalone bootstrap path was missing this seed step.

## Fix

After \`cmdutil.BootstrapDmsg\` returns in \`fetchServiceConfigDmsg\`, extract the conf-service PK from \`deployment.{Prod,Test}.ConfDmsg\` and call:

\`\`\`go
dmsgBoot.Client.SeedEntryCache(confPK, &disc.Entry{
  Static: confPK,
  Client: &disc.Client{DelegatedServers: serverPKs},
})
\`\`\`

with \`serverPKs\` = the embedded \`dmsg.Prod.DmsgServers\` PKs. Mirrors the visor pattern.

## Test plan

- [x] \`go build ./...\` clean
- [x] No new lint issues (pre-existing develop issues unchanged)
- [ ] Manual: \`SKYENV=/etc/skywire.conf skywire cli config gen -r -w -p\` on a fresh host with no \`/opt/skywire/skywire.json\` — confirm logs show \`Fetched service endpoints via DMSG\` instead of falling back to HTTP after a "Failed to fetch config via DMSG" error.