### PR TITLE
perf(stats/cxo): batch sample writes into single Publisher mutex acquire

### DIFF
--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -12,6 +12,7 @@ package treestore
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -379,6 +380,80 @@ func (p *Publisher) Get(path string) ([]byte, bool) {
 	out := make([]byte, len(v))
 	copy(out, v)
 	return out, true
+}
+
+// PutOp is a single (path, value) pair for a batched Put. A nil
+// Value means "delete this path" — folded into the batch instead
+// of demanding a separate Delete call (which would re-acquire the
+// mutex on its own). Putting at a path currently held by a sub-tree
+// returns ErrPathConflict on the FIRST conflicting op; ops before
+// the conflict are applied, ops after are skipped.
+type PutOp struct {
+	Path  string
+	Value []byte // nil = delete
+}
+
+// PutBatch applies the given (path, value) pairs in a single
+// mutex-acquire + single markDirty. Mirror of Put / Delete for
+// callers that produce many writes per logical tick — the stats
+// Tracker's sample loop is the motivating case (one write per
+// mirror tier × service, currently each one taking the publisher
+// mutex individually + contending against the publisher's runLoop).
+//
+// On a per-op error (path-segment validation, conflict, etc.) the
+// batch stops at that op; ops already applied stay in the tree and
+// will be flushed by the next publish cycle. Returns the first
+// error encountered, with the index of the failing op in its
+// message.
+//
+// Path validation happens before the mutex is taken so a bad input
+// fails fast without blocking concurrent readers.
+func (p *Publisher) PutBatch(ops []PutOp) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	type prep struct {
+		segs []string
+		val  []byte // nil for delete
+	}
+	prepared := make([]prep, 0, len(ops))
+	for i, op := range ops {
+		segs, err := SplitPath(op.Path)
+		if err != nil {
+			return fmt.Errorf("treestore: PutBatch[%d] %q: %w", i, op.Path, err)
+		}
+		if len(segs) == 0 {
+			return fmt.Errorf("treestore: PutBatch[%d]: cannot Put at empty path (root)", i)
+		}
+		var val []byte
+		if op.Value != nil {
+			val = append([]byte(nil), op.Value...)
+		}
+		prepared = append(prepared, prep{segs: segs, val: val})
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	applied := false
+	for i, pr := range prepared {
+		if pr.val == nil {
+			if deleteAt(p.root, pr.segs) {
+				applied = true
+			}
+			continue
+		}
+		if err := putAt(p.root, pr.segs, pr.val); err != nil {
+			if applied {
+				p.markDirty()
+			}
+			return fmt.Errorf("treestore: PutBatch[%d] %q: %w", i, ops[i].Path, err)
+		}
+		applied = true
+	}
+	if applied {
+		p.markDirty()
+	}
+	return nil
 }
 
 // Delete removes a single leaf. If the path addresses a sub-tree, it

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -230,6 +230,27 @@ func (s *cxoSink) Delete(path string) {
 	}
 }
 
+// PutBatch fans an entire sample's mirror writes into a single
+// treestore.Publisher.PutBatch — one mutex acquire + one markDirty
+// for the lot. Pre-batch each sinkPut took the publisher's mutex
+// independently and contended with transport-manager re-registers
+// + other publishers on the shared mutex; under heavy transport
+// churn that drove ~27% CPU in bbolt-commit and ~47% in
+// gcBgMarkWorker. With the batch, one mutex hop per sample tick
+// regardless of how many tier × service entries fired.
+func (s *cxoSink) PutBatch(ops []stats.SinkOp) {
+	if len(ops) == 0 {
+		return
+	}
+	tsOps := make([]treestore.PutOp, 0, len(ops))
+	for _, op := range ops {
+		tsOps = append(tsOps, treestore.PutOp{Path: op.Path, Value: op.Value})
+	}
+	if err := s.pub.PutBatch(tsOps); err != nil {
+		s.log.WithError(err).WithField("count", len(tsOps)).Debug("Stats: CXO PutBatch failed")
+	}
+}
+
 func statsPath(v *Visor, conf *visorconfig.Stats) string {
 	if conf != nil && conf.Path != "" {
 		return conf.Path

--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -34,23 +34,42 @@ import (
 	"time"
 )
 
+// SinkOp is a single (path, value) pair for a batched Put. A nil
+// Value means "delete this path" — folded into PutBatch so the
+// sampler can hand the sink a single fan-out operation per tick
+// instead of N round-trips.
+type SinkOp struct {
+	Path  string
+	Value []byte // nil = delete
+}
+
 // Sink receives per-path writes mirroring the bbolt store. Methods
 // are called from the Tracker's sampler goroutine; implementations
 // that want to do network I/O should defer it to their own loop.
 //
 // The Sink is best-effort: a returning error is not propagated to
 // the caller. Implementations should log internally if needed.
+//
+// PutBatch collapses a slice of (path, value) ops into one sink
+// call. Sinks that proxy to a contended downstream (the CXO
+// publisher, whose mutex is also taken by transport-manager
+// re-registers and other publishers) MUST implement this in a way
+// that acquires the downstream's lock once for the entire batch —
+// otherwise sampler ticks with many mirrors (e.g. one transport
+// tier × N services) serialize against every other writer.
 type Sink interface {
 	Put(path string, value []byte)
 	Delete(path string)
+	PutBatch(ops []SinkOp)
 }
 
 // noopSink is the default Sink used when none is wired. All
 // operations are dropped silently.
 type noopSink struct{}
 
-func (noopSink) Put(string, []byte) {}
-func (noopSink) Delete(string)      {}
+func (noopSink) Put(string, []byte)   {}
+func (noopSink) Delete(string)        {}
+func (noopSink) PutBatch([]SinkOp)    {}
 
 // SetSink replaces the Tracker's mirror sink. Pass nil to detach
 // (resets to a no-op sink). Safe to call before or after Run.

--- a/pkg/visor/stats/sink_test.go
+++ b/pkg/visor/stats/sink_test.go
@@ -39,6 +39,20 @@ func (s *recordingSink) Delete(path string) {
 	delete(s.puts, path)
 }
 
+// PutBatch fans the ops onto the same recording slots Put/Delete
+// would have hit individually. Lets the existing snapshot-based
+// assertions see batched writes without spotting them as a
+// different shape.
+func (s *recordingSink) PutBatch(ops []SinkOp) {
+	for _, op := range ops {
+		if op.Value == nil {
+			s.Delete(op.Path)
+			continue
+		}
+		s.Put(op.Path, op.Value)
+	}
+}
+
 func (s *recordingSink) snapshot() (map[string][]byte, []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -297,9 +297,30 @@ func (t *Tracker) sample(now time.Time) {
 		return
 	}
 
-	for _, m := range mirrors {
-		t.sinkPut(m.path, m.data)
+	t.sinkPutBatch(mirrors)
+}
+
+// sinkPutBatch fans the sample's mirror writes into a single sink
+// call. The default cxoSink turns this into one Publisher.PutBatch
+// (one mutex acquire, one markDirty) instead of N individual Puts
+// that each contended with transport-manager re-registers and
+// other writers on the publisher's mutex. See pkg/cxo/treestore
+// publisher.go PutBatch for the downstream semantics.
+//
+// Skips when mirrors is empty so an idle sample tick doesn't even
+// take the sink-lookup mutex.
+func (t *Tracker) sinkPutBatch(mirrors []mirrorPair) {
+	if len(mirrors) == 0 {
+		return
 	}
+	t.mu.Lock()
+	sink := t.sink
+	t.mu.Unlock()
+	ops := make([]SinkOp, 0, len(mirrors))
+	for _, m := range mirrors {
+		ops = append(ops, SinkOp{Path: m.path, Value: m.data})
+	}
+	sink.PutBatch(ops)
 }
 
 // mirrorTierBitmap pushes the post-write tier bitmap to the sink.


### PR DESCRIPTION
## Summary

Drops the stats sampler's lock-acquire rate on the contended
\`treestore.Publisher\` mutex from O(tier × service × transport)
per sample interval to O(1). Addresses an observed
100%-on-one-core CPU pattern on long-uptime visors.

## Symptom

A long-uptime visor on an arm64 host: one core pegged at 100%,
rotating across CPUs. CPU profile:

\`\`\`
runtime.gcBgMarkWorker            47%
go.etcd.io/bbolt.(*DB).Update     27%
go.etcd.io/bbolt.(*batch).run     27%
\`\`\`

Goroutine dump showed three writers serialized on the same
\`treestore.(*Publisher)\` mutex:

- \`stats.(*Tracker).sample → cxoSink.Put\`
- \`transport.(*Manager).publishTPDEntries\`
- \`transport.(*Manager).publishTPDTombstones\`

The rotating-CPU pattern is consistent with Go's parallel
\`gcBgMarkWorker\` goroutines bouncing across Ps under sustained GC
pressure driven by the bbolt batch-trigger.

## Root cause

The stats sampler's \`sample()\` loop produces a slice of mirror
writes per tick (one per active tier × service × transport), then
fans them out via individual \`sinkPut\` calls. Each \`sinkPut\` takes
the Publisher's mutex independently. Under heavy transport churn
the combined Put rate keeps the bbolt batch trigger busy enough to
dominate GC.

## Fix

- \`treestore.Publisher.PutBatch(ops []PutOp) error\` — applies an
  arbitrary list of (path, value) ops under a single mutex
  acquire + single markDirty. Nil Value folds into Delete.
- \`stats.Sink.PutBatch(ops []SinkOp)\` — Sink-interface
  counterpart. Sinks that proxy to a contended downstream MUST
  implement this so they take the downstream's lock once per
  batch.
- \`cxoSink.PutBatch\` — wraps \`Publisher.PutBatch\`. One mutex hop
  per tick instead of N.
- \`stats.(*Tracker).sample\` — calls \`sinkPutBatch\` instead of N
  individual \`sinkPut\` calls.

## What's NOT in this PR

- Publisher batch-write-rate counter in \`node.PublisherStats\`
  (proposed observability follow-up; not load-bearing here).
- Transport-manager re-register dedup — separate contributor to
  the contended mutex, but its rate is bursty rather than steady,
  so dropping the steady-state sampler is the bigger win.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/cxo/treestore/... ./pkg/visor/stats/...\` — green
- [ ] Manual: deploy on the affected arm64 host, sample CPU again,
  confirm gcBgMarkWorker drops out of the top.