### PR TITLE
fix(cli/proxy): honor ctrl+c during --verbose startup + accept positional <pk>

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -310,7 +310,25 @@ var startCmd = &cobra.Command{
 		startProcess := true
 		appReachedRunning := false
 		for startProcess {
-			time.Sleep(time.Second * 1)
+			// Sleep with ctx awareness — without this, a ctrl+c during
+			// app startup (skysocks-client's dial-retry loop, route
+			// setup, etc.) was ignored by the polling loop in
+			// --verbose mode. The SignalContext goroutine above honors
+			// SIGINT by canceling ctx, but in --verbose mode it just
+			// `return`s; the cleanup is supposed to happen here. If
+			// this loop never observes ctx.Done() it spins forever
+			// until the visor-side app concludes one way or another,
+			// stranding the operator with an unresponsive terminal.
+			select {
+			case <-time.After(time.Second * 1):
+			case <-ctx.Done():
+				startProcess = false
+				// Fall through to one last status snapshot before
+				// exiting the loop so the post-loop --verbose teardown
+				// path (StopApp etc.) has a sane appReachedRunning
+				// reading instead of racing on a half-initialized
+				// state.
+			}
 			if !startVerbose {
 				internal.PrintOutput(cmd.Flags(), nil, ".")
 			}
@@ -376,6 +394,25 @@ var startCmd = &cobra.Command{
 					}
 				}
 			}
+		}
+
+		// SIGINT during the startup polling loop (above) exits the
+		// loop with appReachedRunning=false. In --verbose mode the
+		// SignalContext goroutine intentionally doesn't call KillApp
+		// (it leaves cleanup to the main goroutine so deferred
+		// rpcClient.Close + verboseStream.Close run cleanly). Without
+		// this explicit Stop, the visor-side app keeps running while
+		// the CLI exits — operator pressed ctrl+c expecting to STOP
+		// the proxy, not just detach from it.
+		if startVerbose && !appReachedRunning && ctx.Err() != nil {
+			fmt.Fprintln(os.Stderr, "canceled during startup; stopping app...")
+			if err := rpcClient.StopApp(clientName); err != nil {
+				fmt.Fprintf(os.Stderr, "stop app: %v\n", err)
+			}
+			if verboseStream != nil {
+				verboseStream.Close()
+			}
+			return
 		}
 
 		// --verbose: stay in the foreground, streaming logs until

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -240,6 +240,19 @@ var startCmd = &cobra.Command{
 			}
 		}
 
+		// Accept the server PK from either --pk / -k (named flag) OR
+		// the positional arg documented in `Use: "start [pk]"`.
+		// Pre-fix, an operator running
+		//   skywire cli proxy start <pk> --verbose
+		// (which matches the Use line + is the natural CLI shape)
+		// silently fell into the no-pk branch below: the app started
+		// without --srv, the SOCKS5 listener never bound, and the
+		// "app running" banner lied because the visor only checks the
+		// proc Status flag, not whether the app actually configured
+		// itself.
+		if pk == "" && len(args) > 0 {
+			pk = args[0]
+		}
 		if pk != "" {
 			err := pubkey.Set(pk)
 			if err != nil {


### PR DESCRIPTION
## Two related bugs in \`cli proxy start\`

Both surfaced from the same operator session — first \`--verbose\` was unresponsive to ctrl+c, then once the operator worked around that and tried a different shape, the proxy "ran" but no traffic flowed.

## Bug 1: ctrl+c ignored during --verbose startup

\`\`\`
$ skywire cli proxy start --local-route <pk> --verbose
[DEBUG ...]: No app discovery associated with app. appName="skysocks-client"
^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C^C
(no response, terminal frozen)
\`\`\`

The startup-status polling loop used \`time.Sleep(1s)\` between iterations, with the exit condition gated solely on \`state.Status\`. SIGINT triggers the SignalContext goroutine, which in \`--verbose\` mode intentionally \`return\`s instead of calling KillApp (the contract is that the main goroutine handles cleanup). But the main goroutine was stuck in the polling loop with no ctx awareness.

Fix: replace bare \`time.Sleep\` with a ctx-aware select, exit the loop on cancel, and call \`StopApp\` + close the verbose stream when canceled before \`appReachedRunning\`.

## Bug 2: positional <pk> ignored

The command's \`Use: "start [pk]"\` documents a positional \`<pk>\` argument, but the run-time only honored a positional arg as a fallback when \`--pk\` was set but failed to parse. Operators running the natural shape:

\`\`\`
skywire cli proxy start <pk> --verbose
\`\`\`

silently fell into the no-pk else-branch: the app started without \`--srv\` set, so skysocks-client never connected to a server and never bound its SOCKS5 listener. The visor's bare proc Status flipped to Running anyway, so the banner happily printed "app running; streaming logs" — but \`ss -tlnp\` showed :1080 was never bound, and traffic through the proxy was silently dropped.

Fix: one-liner before the existing \`if pk != ""\` branch:

\`\`\`go
if pk == "" && len(args) > 0 {
    pk = args[0]
}
\`\`\`

Existing \`--pk\` / \`-k\` named flag usage is unchanged; the named-branch positional fallback (for malformed \`--pk\`) is also preserved.

## Test plan

- [x] \`go build ./...\` clean
- [ ] Manual: \`skywire cli proxy start <pk> --verbose\` — confirm :1080 listens + ctrl+c stops cleanly
- [ ] Manual: \`skywire cli proxy start --pk <pk> --verbose\` — confirm named flag still works
- [ ] Manual: ctrl+c during the "Starting." dot-printing phase (before the app reaches Running) — confirm StopApp is called + CLI exits