### PR TITLE
perf(cxo): coalesce publisher tree-walk writes into one bbolt tx

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -213,7 +213,8 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 				fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck
 				os.Exit(1)
 			}
-			return reportExecResult(cmd, resp)
+			reportExecResult(cmd, resp)
+			return nil
 		}
 
 		if len(args) < 2 {
@@ -233,7 +234,8 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 			fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck
 			os.Exit(1)
 		}
-		return reportExecResult(cmd, resp)
+		reportExecResult(cmd, resp)
+		return nil
 	},
 }
 
@@ -241,10 +243,10 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 // stdout/stderr and exits with the matching code. Mirrors the
 // inline rendering the dmsg-overlay path used pre-refactor; lifted
 // here so the --via tcp path can share the same surface. Returns
-// nil only on a clean (exit 0, not truncated, not timed out)
-// completion — other shapes call os.Exit directly to surface the
-// right exit code to the caller's shell.
-func reportExecResult(cmd *cobra.Command, resp *dmsgpty.CommandExecResult) error {
+// only on a clean (exit 0, not truncated, not timed out) completion
+// — other shapes call os.Exit directly to surface the right exit
+// code to the caller's shell.
+func reportExecResult(cmd *cobra.Command, resp *dmsgpty.CommandExecResult) {
 	if len(resp.Stdout) > 0 {
 		_, _ = cmd.OutOrStdout().Write(resp.Stdout) //nolint:errcheck
 	}
@@ -264,7 +266,6 @@ func reportExecResult(cmd *cobra.Command, resp *dmsgpty.CommandExecResult) error
 	if resp.ExitCode != 0 {
 		os.Exit(resp.ExitCode)
 	}
-	return nil
 }
 
 // parseTCPVia splits a `tcp://<pk>@<host:port>` URL into the pinned

--- a/pkg/cxo/data/cxds.go
+++ b/pkg/cxo/data/cxds.go
@@ -71,6 +71,18 @@ type CXDS interface {
 	// doesn't exist
 	Del(key cipher.SHA256) (err error)
 
+	// RunBatch invokes fn with a CXDS handle that performs all of its
+	// Set/Get/Inc/Del calls inside a single underlying transaction. On
+	// bbolt-backed stores this collapses N writer transactions (and N
+	// commits) into one, which is the dominant cost on publisher
+	// tree-walks. The scoped handle is only valid for the duration of
+	// fn; using it after fn returns is undefined.
+	//
+	// fn returning nil commits the batch; a non-nil return rolls it
+	// back. RunBatch on stores without transaction semantics (in-memory
+	// CXDS) is a passthrough: fn is invoked with the receiver.
+	RunBatch(fn func(scoped CXDS) error) (err error)
+
 	//
 	// Stat
 	//

--- a/pkg/cxo/data/cxds/cxds.go
+++ b/pkg/cxo/data/cxds/cxds.go
@@ -37,6 +37,12 @@ var (
 	// with "assignment to entry in nil map" — see the fillHead
 	// goroutine path in pkg/cxo/node/head.go that triggered this.
 	ErrClosed = errors.New("CXDS store closed")
+
+	// ErrUnsupportedInBatch is returned by methods on a CXDS handle
+	// scoped to a RunBatch tx when the method can't safely run while
+	// holding an open writer transaction (e.g. Close, Iterate-style
+	// scans that the caller did not opt into via the batch).
+	ErrUnsupportedInBatch = errors.New("operation not supported inside CXDS batch")
 )
 
 func getRefsCount(val []byte) (rc uint32) {

--- a/pkg/cxo/data/cxds/drive.go
+++ b/pkg/cxo/data/cxds/drive.go
@@ -326,6 +326,37 @@ func (d *driveCXDS) incr(
 	return nrc, err
 }
 
+// getInTx is Get's bucket-level work scoped to a caller-provided tx.
+// Returns the value (copy), the (possibly updated) rc, and any error.
+// Used by both the per-op Get (which opens its own tx) and the batch
+// shim (which inherits a parent tx).
+func (d *driveCXDS) getInTx(
+	tx *bolt.Tx,
+	key cipher.SHA256,
+	inc int,
+) (
+	val []byte,
+	rc uint32,
+	err error,
+) {
+
+	var (
+		o   = tx.Bucket(objsBucket)
+		got = o.Get(key[:])
+	)
+
+	if len(got) == 0 {
+		return nil, 0, data.ErrNotFound
+	}
+
+	rc = getRefsCount(got)
+	val = make([]byte, len(got)-4)
+	copy(val, got[4:])
+
+	rc, err = d.incr(o, key[:], val, rc, inc)
+	return val, rc, err
+}
+
 // Get value by key changing or
 // leaving as is references counter.
 //
@@ -349,29 +380,15 @@ func (d *driveCXDS) Get(
 	err error, //         :
 ) {
 
-	var tx = func(tx *bolt.Tx) (err error) {
-
-		var (
-			o   = tx.Bucket(objsBucket)
-			got = o.Get(key[:])
-		)
-
-		if len(got) == 0 {
-			return data.ErrNotFound // pass through
-		}
-
-		rc = getRefsCount(got)
-		val = make([]byte, len(got)-4)
-		copy(val, got[4:])
-
-		rc, err = d.incr(o, key[:], val, rc, inc)
+	fn := func(tx *bolt.Tx) (err error) {
+		val, rc, err = d.getInTx(tx, key, inc)
 		return err
 	}
 
 	if inc == 0 {
-		err = d.b.View(tx) // lookup only — no transaction commit at all
+		err = d.b.View(fn) // lookup only — no transaction commit at all
 	} else {
-		err = d.b.Batch(tx) // refcount bump — coalesces with concurrent calls
+		err = d.b.Batch(fn) // refcount bump — coalesces with concurrent calls
 	}
 
 	return val, rc, err
@@ -387,6 +404,41 @@ func (d *driveCXDS) addAll(vol int) {
 
 	d.amountAll++
 	d.volumeAll += vol
+}
+
+// setInTx is Set's bucket-level work scoped to a caller-provided tx.
+// The tx must be writable (i.e. opened via db.Update or db.Batch).
+// Callers are responsible for the value-length and inc preconditions
+// — setInTx will panic on inc <= 0 mirroring the exported Set.
+func (d *driveCXDS) setInTx(
+	tx *bolt.Tx,
+	key cipher.SHA256,
+	val []byte,
+	inc int,
+) (
+	rc uint32,
+	err error,
+) {
+
+	if inc <= 0 {
+		panicf("invalid inc argument in CXDS.Set: %d", inc)
+	}
+
+	if len(val) == 0 {
+		return 0, ErrEmptyValue
+	}
+
+	var (
+		o   = tx.Bucket(objsBucket)
+		got = o.Get(key[:])
+	)
+
+	if len(got) == 0 {
+		d.addAll(len(val))
+		return d.incr(o, key[:], val, 0, 1)
+	}
+
+	return d.incr(o, key[:], got[4:], getRefsCount(got), inc)
 }
 
 // Set value and its references counter.
@@ -411,15 +463,6 @@ func (d *driveCXDS) Set(
 	err error,
 ) {
 
-	if inc <= 0 {
-		panicf("invalid inc argument in CXDS.Set: %d", inc)
-	}
-
-	if len(val) == 0 {
-		err = ErrEmptyValue
-		return rc, err
-	}
-
 	// Probe whether the key already exists so we can pick Batch
 	// (refcount-only) vs Update (new value) without rolling the
 	// branch decision into a single committed tx.
@@ -432,20 +475,7 @@ func (d *driveCXDS) Set(
 	}
 
 	fn := func(tx *bolt.Tx) (err error) {
-		var (
-			o   = tx.Bucket(objsBucket)
-			got = o.Get(key[:])
-		)
-
-		if len(got) == 0 {
-			// created (the probe could race with a concurrent Del;
-			// fall through to the create path)
-			d.addAll(len(val))
-			rc, err = d.incr(o, key[:], val, 0, 1)
-			return err
-		}
-
-		rc, err = d.incr(o, key[:], got[4:], getRefsCount(got), inc)
+		rc, err = d.setInTx(tx, key, val, inc)
 		return err
 	}
 
@@ -458,6 +488,34 @@ func (d *driveCXDS) Set(
 	return rc, err
 }
 
+// incInTx is Inc's bucket-level work scoped to a caller-provided tx.
+func (d *driveCXDS) incInTx(
+	tx *bolt.Tx,
+	key cipher.SHA256,
+	inc int,
+) (
+	rc uint32,
+	err error,
+) {
+
+	var (
+		o   = tx.Bucket(objsBucket)
+		got = o.Get(key[:])
+	)
+
+	if len(got) == 0 {
+		return 0, data.ErrNotFound
+	}
+
+	rc = getRefsCount(got)
+
+	if inc == 0 {
+		return rc, nil // presence check only
+	}
+
+	return d.incr(o, key[:], got[4:], rc, inc)
+}
+
 // Inc changes references counter
 func (d *driveCXDS) Inc(
 	key cipher.SHA256,
@@ -467,31 +525,15 @@ func (d *driveCXDS) Inc(
 	err error,
 ) {
 
-	var tx = func(tx *bolt.Tx) (_ error) {
-
-		var (
-			o   = tx.Bucket(objsBucket)
-			got = o.Get(key[:])
-		)
-
-		if len(got) == 0 {
-			return data.ErrNotFound
-		}
-
-		rc = getRefsCount(got)
-
-		if inc == 0 {
-			return nil // done
-		}
-
-		rc, err = d.incr(o, key[:], got[4:], rc, inc)
-		return nil
+	fn := func(tx *bolt.Tx) (err error) {
+		rc, err = d.incInTx(tx, key, inc)
+		return err
 	}
 
 	if inc == 0 {
-		err = d.b.View(tx) // lookup only
+		err = d.b.View(fn) // lookup only
 	} else {
-		err = d.b.Batch(tx) // refcount bump — coalesce concurrent calls
+		err = d.b.Batch(fn) // refcount bump — coalesce concurrent calls
 	}
 
 	return rc, err
@@ -511,6 +553,26 @@ func (d *driveCXDS) del(rc uint32, vol int) {
 	d.volumeAll -= vol
 }
 
+// delInTx is Del's bucket-level work scoped to a caller-provided tx.
+func (d *driveCXDS) delInTx(tx *bolt.Tx, key cipher.SHA256) (err error) {
+
+	var (
+		o   = tx.Bucket(objsBucket)
+		got = o.Get(key[:])
+	)
+
+	if len(got) == 0 {
+		return nil // not found
+	}
+
+	if err = o.Delete(key[:]); err != nil {
+		return err
+	}
+
+	d.del(getRefsCount(got), len(got)-4)
+	return nil
+}
+
 // Del deletes value unconditionally
 func (d *driveCXDS) Del(
 	key cipher.SHA256,
@@ -523,22 +585,7 @@ func (d *driveCXDS) Del(
 	// commit) is appropriate. Visibility semantics are preserved —
 	// Batch blocks the caller until the enclosing tx commits.
 	err = d.b.Batch(func(tx *bolt.Tx) (err error) {
-
-		var (
-			o   = tx.Bucket(objsBucket)
-			got = o.Get(key[:])
-		)
-
-		if len(got) == 0 {
-			return // not found
-		}
-
-		if err = o.Delete(key[:]); err != nil {
-			return
-		}
-
-		d.del(getRefsCount(got), len(got)-4)
-		return // nil
+		return d.delInTx(tx, key)
 	})
 
 	return
@@ -655,4 +702,76 @@ func copySlice(in []byte) (got []byte) { //nolint:unused
 	got = make([]byte, len(in))
 	copy(got, in)
 	return
+}
+
+// RunBatch opens one writable bbolt tx and exposes a CXDS view scoped
+// to it. Every Set/Get/Inc/Del invoked on the scoped handle runs
+// inside that single tx, so the cost of opening + committing the tx
+// is amortized across the whole batch. Callers must not retain the
+// scoped handle past fn's return — the tx is committed (or rolled
+// back on error) when fn exits.
+//
+// The dominant workload that drives this path is the publisher
+// tree-walk (skyobject.Container.Save via cxds.Set per encoded leaf),
+// where pre-batch each leaf opened its own db.Update. Coalescing N
+// per-leaf transactions into one removes N-1 meta-page writes,
+// freelist re-allocations, and (when NoSync is off) fdatasyncs.
+//
+// Iterate, IterateDel, and Close are deliberately unavailable on the
+// scoped handle — the publisher path doesn't need them and exposing
+// them inside the writer tx risks deadlocking against bbolt's reader
+// semantics. Callers that need a write-then-iterate cycle should
+// commit the batch first.
+func (d *driveCXDS) RunBatch(fn func(scoped data.CXDS) error) (err error) {
+	return d.b.Update(func(tx *bolt.Tx) error {
+		return fn(&txDriveCXDS{parent: d, tx: tx})
+	})
+}
+
+// txDriveCXDS is a CXDS view bound to a single writable bbolt tx.
+// All Set/Get/Inc/Del operations route through the parent driveCXDS's
+// *InTx helpers using the pinned tx, so they share a single commit at
+// the end of the enclosing RunBatch.
+type txDriveCXDS struct {
+	parent *driveCXDS
+	tx     *bolt.Tx
+}
+
+func (s *txDriveCXDS) Get(key cipher.SHA256, inc int) ([]byte, uint32, error) {
+	return s.parent.getInTx(s.tx, key, inc)
+}
+
+func (s *txDriveCXDS) Set(key cipher.SHA256, val []byte, inc int) (uint32, error) {
+	return s.parent.setInTx(s.tx, key, val, inc)
+}
+
+func (s *txDriveCXDS) Inc(key cipher.SHA256, inc int) (uint32, error) {
+	return s.parent.incInTx(s.tx, key, inc)
+}
+
+func (s *txDriveCXDS) Del(key cipher.SHA256) error {
+	return s.parent.delInTx(s.tx, key)
+}
+
+func (s *txDriveCXDS) Iterate(data.IterateObjectsFunc) error {
+	return ErrUnsupportedInBatch
+}
+
+func (s *txDriveCXDS) IterateDel(data.IterateObjectsDelFunc) error {
+	return ErrUnsupportedInBatch
+}
+
+// Amount/Volume read the parent's atomic counters; safe to call
+// during a batch.
+func (s *txDriveCXDS) Amount() (all, used int) { return s.parent.Amount() }
+func (s *txDriveCXDS) Volume() (all, used int) { return s.parent.Volume() }
+
+func (s *txDriveCXDS) Close() error {
+	return ErrUnsupportedInBatch
+}
+
+// RunBatch on a batch-scoped handle reuses the active tx — nested
+// batch is just a passthrough.
+func (s *txDriveCXDS) RunBatch(fn func(scoped data.CXDS) error) error {
+	return fn(s)
 }

--- a/pkg/cxo/data/cxds/memory.go
+++ b/pkg/cxo/data/cxds/memory.go
@@ -281,3 +281,12 @@ func (m *memoryCXDS) Close() (_ error) {
 	m.kvs = nil // clear
 	return
 }
+
+// RunBatch on the in-memory CXDS has no transaction semantics — the
+// map is already serialized through m.mx and there is no commit cost
+// to amortize. fn is invoked with the receiver, so all CXDS calls
+// inside fn go through the normal per-op locking path. This keeps the
+// interface contract uniform across drive- and memory-backed stores.
+func (m *memoryCXDS) RunBatch(fn func(scoped data.CXDS) error) error {
+	return fn(m)
+}

--- a/pkg/cxo/data/cxds/runbatch_test.go
+++ b/pkg/cxo/data/cxds/runbatch_test.go
@@ -1,0 +1,167 @@
+package cxds
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cxo/data"
+)
+
+// TestRunBatch_DriveSetsArePersistedOnNilReturn confirms that a sequence of
+// Set calls executed inside RunBatch are durable after fn returns nil — i.e.
+// the surrounding tx commits — and that an outside Get from the same store
+// can see them with rc=1.
+func TestRunBatch_DriveSetsArePersistedOnNilReturn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rb.db")
+	ds, err := NewDriveCXDS(path)
+	if err != nil {
+		t.Fatalf("NewDriveCXDS: %v", err)
+	}
+	t.Cleanup(func() { _ = ds.Close() }) //nolint:errcheck
+
+	keys := make([]cipher.SHA256, 8)
+	if err := ds.RunBatch(func(scoped data.CXDS) error {
+		for i := range keys {
+			val := []byte{byte(i), 0xAA}
+			keys[i] = cipher.SumSHA256(val)
+			rc, err := scoped.Set(keys[i], val, 1)
+			if err != nil {
+				return err
+			}
+			if rc != 1 {
+				t.Errorf("batch Set rc = %d; want 1 (fresh insert)", rc)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+
+	for i, k := range keys {
+		val, rc, err := ds.Get(k, 0)
+		if err != nil {
+			t.Errorf("Get[%d]: %v", i, err)
+			continue
+		}
+		if rc != 1 {
+			t.Errorf("Get[%d] rc = %d; want 1", i, rc)
+		}
+		if len(val) != 2 || val[0] != byte(i) || val[1] != 0xAA {
+			t.Errorf("Get[%d] val = %v; want [%d 0xAA]", i, val, i)
+		}
+	}
+}
+
+// TestRunBatch_DriveRollsBackOnError confirms that a non-nil return from fn
+// drops every Set the batch performed — bbolt rolls back the whole tx, so
+// none of the keys end up visible after RunBatch returns.
+func TestRunBatch_DriveRollsBackOnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rb.db")
+	ds, err := NewDriveCXDS(path)
+	if err != nil {
+		t.Fatalf("NewDriveCXDS: %v", err)
+	}
+	t.Cleanup(func() { _ = ds.Close() }) //nolint:errcheck
+
+	sentinel := errors.New("intentional rollback")
+	keys := make([]cipher.SHA256, 4)
+	rbErr := ds.RunBatch(func(scoped data.CXDS) error {
+		for i := range keys {
+			val := []byte{byte(i)}
+			keys[i] = cipher.SumSHA256(val)
+			if _, err := scoped.Set(keys[i], val, 1); err != nil {
+				return err
+			}
+		}
+		return sentinel
+	})
+	if !errors.Is(rbErr, sentinel) {
+		t.Fatalf("RunBatch err = %v; want sentinel", rbErr)
+	}
+
+	for i, k := range keys {
+		if _, _, err := ds.Get(k, 0); !errors.Is(err, data.ErrNotFound) {
+			t.Errorf("after rollback, Get[%d] err = %v; want ErrNotFound", i, err)
+		}
+	}
+}
+
+// TestRunBatch_DriveInteropWithUnbatchedSet confirms that an unbatched
+// Set/Get/Inc executed against the underlying store sees writes a previous
+// RunBatch made — i.e. the batch and per-op paths share the same bucket.
+func TestRunBatch_DriveInteropWithUnbatchedSet(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rb.db")
+	ds, err := NewDriveCXDS(path)
+	if err != nil {
+		t.Fatalf("NewDriveCXDS: %v", err)
+	}
+	t.Cleanup(func() { _ = ds.Close() }) //nolint:errcheck
+
+	val := []byte("hello")
+	key := cipher.SumSHA256(val)
+
+	// Insert via batch.
+	if err := ds.RunBatch(func(scoped data.CXDS) error {
+		_, err := scoped.Set(key, val, 1)
+		return err
+	}); err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+
+	// Bump rc via the unbatched path; should see the batch-inserted row.
+	rc, err := ds.Inc(key, 1)
+	if err != nil {
+		t.Fatalf("unbatched Inc after batch: %v", err)
+	}
+	if rc != 2 {
+		t.Errorf("rc after unbatched Inc = %d; want 2", rc)
+	}
+
+	// Now bump rc inside another batch and confirm the unbatched Get sees it.
+	if err := ds.RunBatch(func(scoped data.CXDS) error {
+		_, err := scoped.Inc(key, 3)
+		return err
+	}); err != nil {
+		t.Fatalf("RunBatch (Inc): %v", err)
+	}
+
+	_, finalRC, err := ds.Get(key, 0)
+	if err != nil {
+		t.Fatalf("final Get: %v", err)
+	}
+	if finalRC != 5 {
+		t.Errorf("final rc = %d; want 5 (1 init + 1 unbatched Inc + 3 batched Inc)", finalRC)
+	}
+}
+
+// TestRunBatch_MemoryIsPassthrough confirms that on the in-memory CXDS,
+// RunBatch invokes fn with the receiver — there's no tx to commit and
+// writes are visible to outside Get without RunBatch having returned.
+func TestRunBatch_MemoryIsPassthrough(t *testing.T) {
+	m := NewMemoryCXDS()
+	t.Cleanup(func() { _ = m.Close() }) //nolint:errcheck
+
+	val := []byte("xyz")
+	key := cipher.SumSHA256(val)
+
+	if err := m.RunBatch(func(scoped data.CXDS) error {
+		if _, err := scoped.Set(key, val, 1); err != nil {
+			t.Fatalf("scoped.Set: %v", err)
+		}
+		// Inside the batch, an outside Get should already see the write —
+		// memory has no tx isolation.
+		if _, rc, err := m.Get(key, 0); err != nil || rc != 1 {
+			t.Errorf("Get during batch: rc=%d err=%v; want rc=1 nil", rc, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+
+	if _, rc, err := m.Get(key, 0); err != nil || rc != 1 {
+		t.Errorf("Get after batch: rc=%d err=%v; want rc=1 nil", rc, err)
+	}
+}

--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/skycoin/skycoin/src/cipher"
@@ -116,6 +117,21 @@ type Cache struct {
 	stat *cxdsStat
 
 	closeo sync.Once //nolint:unused
+
+	// batchTx, when non-nil, redirects c.db()'s view of the underlying
+	// CXDS to a transaction-scoped handle pinned by a WithBatch call.
+	// Every Cache.Set / Cache.Get / Cache.Inc that fires while a batch
+	// is active runs its bbolt work inside that single tx instead of
+	// opening its own — collapsing the publisher tree-walk's per-leaf
+	// commits into one.
+	//
+	// Reads happen under c.mx (every Cache write/read path holds it),
+	// so concurrent Set/Get/Inc callers serialize their tx use through
+	// the mutex; the bbolt tx is never touched by two goroutines at
+	// once. WithBatch tears the pin down only after taking c.mx again
+	// to drain any in-flight CXDS user — see WithBatch for the full
+	// invariant.
+	batchTx atomic.Pointer[data.CXDS]
 }
 
 // initialize the Cache
@@ -157,9 +173,59 @@ func (c *Cache) reset() { //nolint:unused
 	c.stat = nil
 }
 
-// code readablility
+// db returns the CXDS that subsequent Cache operations should target.
+// When a WithBatch call has pinned a transaction-scoped CXDS, db()
+// returns that handle so the operation joins the open batch; otherwise
+// it returns the underlying store.
+//
+// Callers must invoke db() while holding c.mx — the same mutex
+// WithBatch synchronizes against — so the returned pointer remains
+// valid for the duration of the caller's CXDS call.
 func (c *Cache) db() data.CXDS {
+	if tx := c.batchTx.Load(); tx != nil {
+		return *tx
+	}
 	return c.c.db.CXDS()
+}
+
+// WithBatch runs fn with the Cache's underlying CXDS pinned to a
+// single transaction-scoped handle. Every Cache.Set / Cache.Get /
+// Cache.Inc invoked from fn (directly or transitively, including the
+// recursive walks inside Container.Save) runs its bbolt work inside
+// that one tx — replacing N per-leaf commits with a single one. fn
+// returning nil commits the tx; a non-nil return rolls it back.
+//
+// The pin lives in c.batchTx (atomic). Reads happen under c.mx, so
+// concurrent Cache writers/readers from outside fn naturally serialize
+// against fn's tx use through the mutex — the bbolt tx is never
+// touched by two goroutines at once. The tear-down sequence on the
+// way out:
+//
+//  1. Store nil into c.batchTx so any newly-arriving Cache.Set sees
+//     the untwisted CXDS (and will block in bbolt's writer mutex
+//     until our tx commits, as it would have pre-batch).
+//  2. Lock/unlock c.mx once to drain any in-flight Cache.Set that
+//     captured the now-stale tx pointer before step 1 — they finish
+//     their work under our serialization while we wait.
+//  3. Return; the bbolt tx commits at this point.
+//
+// fn must not retain the pinned handle past its return — the tx is
+// gone afterward.
+func (c *Cache) WithBatch(fn func() error) error {
+	return c.c.db.CXDS().RunBatch(func(scoped data.CXDS) (err error) {
+		c.batchTx.Store(&scoped)
+		defer func() {
+			c.batchTx.Store(nil)
+			// Wait for any in-flight Cache operation that may still be
+			// using the scoped CXDS to finish before letting bbolt
+			// commit. Holding the mutex briefly is sufficient: every
+			// Cache CXDS call holds c.mx for its duration, so once we
+			// acquire it nobody else is mid-tx.
+			c.mx.Lock()
+			c.mx.Unlock() //nolint:staticcheck // intentional drain
+		}()
+		return fn()
+	})
 }
 
 // call it under lock

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -666,6 +666,16 @@ func (p *Publisher) publishIfDirty() error {
 
 // publishRoot encodes the in-memory tree as CXO objects and saves
 // the resulting Root under the feed's PK.
+//
+// The encode+save sequence runs inside a single CXDS batch
+// transaction (Cache.WithBatch). Every Set/Inc that fires during the
+// tree walk and the subsequent Container.Save reference-walk shares
+// one bbolt writer tx, collapsing what was previously N per-leaf
+// commits into one — the dominant cost on the publisher's hot path,
+// especially for the stats publisher whose new-leaf rate scales with
+// the sample-interval mirror writes. The IdxDB tx that Container.Save
+// opens for the root metadata write is unrelated (separate bbolt
+// file) and remains its own transaction.
 func (p *Publisher) publishRoot(root *memNode) error {
 	c := p.cxoNode.Container()
 
@@ -684,36 +694,45 @@ func (p *Publisher) publishRoot(root *memNode) error {
 	// can promote them into the per-memNode cache after Save succeeds
 	// — never before, otherwise an aborted publish would leave the
 	// cache pointing at hashes that up.Close has rolled back.
-	var freshSubs []freshSub
-	rootNode, err := encodeNode(up, root, &freshSubs)
+	var (
+		freshSubs []freshSub
+		rootNode  TreeNode
+		r         *registry.Root
+	)
+
+	err = c.Cache.WithBatch(func() error {
+		var err error
+		rootNode, err = encodeNode(up, root, &freshSubs)
+		if err != nil {
+			return err
+		}
+
+		rootSchema, err := Registry.SchemaByName("cxo.treestore.TreeNode")
+		if err != nil {
+			return err
+		}
+
+		var rootDyn registry.Dynamic
+		if err := rootDyn.SetValue(up, &rootNode); err != nil {
+			return err
+		}
+		rootDyn.Schema = rootSchema.Reference()
+
+		nonce := c.ActiveHead(skycipher.PubKey(p.pk))
+		if nonce == 0 {
+			nonce = 1 // CXO requires a non-zero nonce
+		}
+
+		r = &registry.Root{
+			Pub:   skycipher.PubKey(p.pk),
+			Nonce: nonce,
+			Reg:   Registry.Reference(),
+			Refs:  []registry.Dynamic{rootDyn},
+		}
+
+		return c.Save(up, r)
+	})
 	if err != nil {
-		return err
-	}
-
-	rootSchema, err := Registry.SchemaByName("cxo.treestore.TreeNode")
-	if err != nil {
-		return err
-	}
-
-	var rootDyn registry.Dynamic
-	if err := rootDyn.SetValue(up, &rootNode); err != nil {
-		return err
-	}
-	rootDyn.Schema = rootSchema.Reference()
-
-	nonce := c.ActiveHead(skycipher.PubKey(p.pk))
-	if nonce == 0 {
-		nonce = 1 // CXO requires a non-zero nonce
-	}
-
-	r := &registry.Root{
-		Pub:   skycipher.PubKey(p.pk),
-		Nonce: nonce,
-		Reg:   Registry.Reference(),
-		Refs:  []registry.Dynamic{rootDyn},
-	}
-
-	if err := c.Save(up, r); err != nil {
 		return err
 	}
 	p.cxoNode.Publish(r)

--- a/pkg/visor/stats/sink.go
+++ b/pkg/visor/stats/sink.go
@@ -67,9 +67,9 @@ type Sink interface {
 // operations are dropped silently.
 type noopSink struct{}
 
-func (noopSink) Put(string, []byte)   {}
-func (noopSink) Delete(string)        {}
-func (noopSink) PutBatch([]SinkOp)    {}
+func (noopSink) Put(string, []byte) {}
+func (noopSink) Delete(string)      {}
+func (noopSink) PutBatch([]SinkOp)  {}
 
 // SetSink replaces the Tracker's mirror sink. Pass nil to detach
 // (resets to a no-op sink). Safe to call before or after Run.

--- a/pkg/visor/stats/tracker.go
+++ b/pkg/visor/stats/tracker.go
@@ -323,20 +323,11 @@ func (t *Tracker) sinkPutBatch(mirrors []mirrorPair) {
 	sink.PutBatch(ops)
 }
 
-// mirrorTierBitmap pushes the post-write tier bitmap to the sink.
-// Called from sample after MarkTierSlot succeeds. Errors are logged
-// at debug level — sink mirroring is best-effort and must not block
-// the sampler.
-// sinkPut snapshots the sink under the lock and dispatches the put
-// outside it, so a slow sink doesn't pin the sample loop's mutex.
-func (t *Tracker) sinkPut(path string, value []byte) {
-	t.mu.Lock()
-	sink := t.sink
-	t.mu.Unlock()
-	sink.Put(path, value)
-}
-
-// sinkDelete is the per-key delete analog of sinkPut.
+// sinkDelete snapshots the sink under the lock and dispatches the
+// delete outside it, so a slow sink doesn't pin the sample loop's
+// mutex. Called from the retention paths when a row falls outside the
+// publish window (or the retention window) so the publisher's view
+// drops the key in sync with bbolt.
 func (t *Tracker) sinkDelete(path string) {
 	t.mu.Lock()
 	sink := t.sink


### PR DESCRIPTION
## Summary

Adds `CXDS.RunBatch(fn)` and routes `treestore.Publisher.publishRoot` through it so the publisher's tree-walk performs **one bbolt commit per publish** instead of one per encoded leaf. On the stats publisher's hot path this collapses ~50 per-sample writer commits into one.

Identified in pprof on a live visor (post-#2564): `bbolt.(*DB).Update` cum-31%, `Tx.Commit` cum-23%, `batch.run` cum-19%. Most of those samples come from the publisher fanning each `cxds.Set` out into its own writer tx during `Container.Save`.

## Changes

- `data.CXDS`: new `RunBatch(fn func(scoped CXDS) error) error` method. fn returning nil commits; non-nil rolls back.
- `cxds/drive.go`: extracts bucket-level work into `setInTx` / `getInTx` / `incInTx` / `delInTx` helpers (existing `Set`/`Get`/`Inc`/`Del` delegate to them, preserving the View-probe-then-Update/Batch path for new vs existing keys). Adds `txDriveCXDS` — a CXDS view bound to a single writable tx — and `driveCXDS.RunBatch` that opens `db.Update` and hands the shim to fn.
- `cxds/memory.go`: `RunBatch` is a passthrough — in-memory store already serializes via its own mutex and has no commit cost.
- `skyobject/cache.go`: adds `Cache.batchTx atomic.Pointer[data.CXDS]` and `Cache.WithBatch(fn func() error) error`. `c.db()` consults batchTx so every cache CXDS call under fn — including the recursive `Container.Save` reference walk — routes to the scoped handle. Tear-down briefly takes `c.mx` to drain any in-flight cache call that captured the tx pointer before letting bbolt commit.
- `treestore/publisher.go`: `publishRoot` wraps `encodeNode` + `Container.Save` in `Cache.WithBatch`.

## Test plan

- [x] `go test ./pkg/cxo/...` green — including the existing publisher / cache / treestore suites, which now run all of their CXO writes under `Cache.WithBatch` via the new `publishRoot` path.
- [x] New `pkg/cxo/data/cxds/runbatch_test.go` covers: drive-backed batch persists on nil-return, drive-backed batch rolls back on error, drive batch interoperates with unbatched Set/Inc, in-memory passthrough.
- [x] `make lint` (no new findings; only pre-existing project warnings remain).
- [x] Binary builds against `./...`.