### PR TITLE
docs(skychat/status): clarify peers/active_peer_conns are chat-app-layer

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1193,8 +1193,19 @@ func historyPeersHandler(w http.ResponseWriter, _ *http.Request) {
 //
 //	visor_pk             current PK the app is bound under
 //	sse_subscribers      live SSE listener count
-//	active_peer_conns    live peer chat conns
-//	peers                PKs we have conns to
+//	active_peer_conns    live peer chat conns (CHAT-APP LAYER —
+//	                     framed connections the app holds; NOT a
+//	                     dmsg session count. After a visor restart
+//	                     this starts at 0 and only grows when this
+//	                     app initiates an outbound DM or accepts an
+//	                     inbound one. Underlying dmsg may be fully
+//	                     reachable while this reads 0 — that's not
+//	                     a network problem, just a count of how
+//	                     many active chat sessions this app is
+//	                     holding open.)
+//	peers                PKs of the active_peer_conns. Same
+//	                     chat-app-layer caveat — these are NOT the
+//	                     visor's dmsg session list.
 //	persistence_enabled  history store is initialized
 //	pairing_enabled      pair-control sub-protocol is on
 //	frame_proto_version  on-the-wire chat-frame version (diagnose


### PR DESCRIPTION
## Summary

Minimal doc clarification for the \`/status\` \`peers\` and \`active_peer_conns\` fields. These count chat-app framed connections, NOT underlying dmsg sessions, and the gap between the two has bit operators reading the status JSON during degraded-connectivity events.

## Context

Observed: a 10-hour session where chat-app reported \`peers=0\` continuously but a probe DM via \`cli skychat send --wait\` acked in 30ms — confirming the dmsg wire was reachable all along. The chat-app's \`conns\` map only populates when this app initiates outbound or accepts inbound chat frames; visor restart resets it to empty. Operators reading \`peers=0\` reasonably (but wrongly) inferred the visor's dmsg was down.

## Patch

Doc-only change in \`statusHandler\`'s comment block. Notes that:
- \`peers\` / \`active_peer_conns\` are **chat-app layer** (framed conn map this app holds)
- They do NOT reflect dmsg session count
- After visor restart these start at 0 and only grow as the app talks to peers
- Underlying dmsg may be fully reachable while these read 0

## Follow-up

A separate PR can add a \`dmsg_sessions\` field that reads from \`dmsg.Client.AllSessions()\` to surface the gap directly. That needs new RPC plumbing between the visor's app server and the chat-app's \`app.Client\`, so it's not a one-liner; the doc clarification stands on its own as a strict improvement.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- Doc-only — no behavior change.