### PR TITLE
feat(skychat/group): server-streaming gRPC for group listen

### DIFF
--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -36,6 +36,7 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
 )
 
 var (
@@ -272,68 +273,78 @@ errors out):
 		if jsonMode && groupListenRaw {
 			internal.PrintFatalError(cmd.Flags(), errors.New("--raw and --json are mutually exclusive"))
 		}
-		rpcClient, err := clirpc.Client(cmd.Flags())
-		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), err)
-		}
 		var since time.Time
 		if groupListenSince != "" {
-			since, err = time.Parse(time.RFC3339, groupListenSince)
+			t, err := time.Parse(time.RFC3339, groupListenSince)
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --since: %w", err))
 			}
+			since = t
 		}
 		if !jsonMode {
 			fmt.Println("Listening for group messages. Ctrl+C to exit.")
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		ticker := time.NewTicker(groupListenPoll)
-		defer ticker.Stop()
 
+		// gRPC server-streaming replaces the net/rpc poll loop that
+		// used to live here. The old loop hit the visor's 5-minute
+		// per-conn deadline at init_apps.go:542 every tick window;
+		// gRPC over HTTP/2 keepalives stays connected for the
+		// stream's natural lifetime. The reconnect-on-error wrapper
+		// below still handles visor restarts (visor halt → client's
+		// stream errors → we reopen + resume).
 		const (
 			minBackoff = 1 * time.Second
 			maxBackoff = 30 * time.Second
 		)
 		backoff := minBackoff
-		// reconnected suppresses repeat error spam on the same dead
-		// connection; we log the first failure, then go quiet until
-		// reconnection succeeds.
 		var lastErrLogged bool
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
+		// onMsg renders one message — extracted because the same
+		// rendering path runs against both the gRPC event type and
+		// (when we eventually replay backlog) any seed messages.
+		onMsg := func(tsNs int64, groupID, senderPK, body string) {
+			ts := time.Unix(0, tsNs).UTC()
+			if ts.After(since) {
+				since = ts
 			}
-			msgs, err := rpcClient.GroupPoll(since)
+			if jsonMode {
+				ev := struct {
+					TS       time.Time `json:"ts"`
+					GroupID  string    `json:"group_id"`
+					SenderPK string    `json:"sender_pk"`
+					Body     string    `json:"body"`
+				}{TS: ts, GroupID: groupID, SenderPK: senderPK, Body: body}
+				b, mErr := json.Marshal(ev)
+				if mErr != nil {
+					return
+				}
+				fmt.Println(string(b))
+				return
+			}
+			out := body
+			if !groupListenRaw {
+				out = escapeForOneLine(body)
+			}
+			fmt.Printf("[%s] [%s] %s: %s\n", ts.Format(time.RFC3339), groupID, senderPK, out)
+		}
+
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			grpcClient, err := rpcgrpc.NewPingClient(clirpc.Addr)
 			if err != nil {
 				if !lastErrLogged {
-					fmt.Fprintf(os.Stderr, "group poll: %v (reconnecting in %s)\n", err, backoff) //nolint:errcheck
+					fmt.Fprintf(os.Stderr, "group listen: gRPC dial %v (reconnecting in %s)\n", err, backoff) //nolint:errcheck
 					lastErrLogged = true
 				}
-				// Sleep before re-creating the RPC client so a
-				// visor that's still mid-rebuild has time to
-				// finish. Honor Ctrl+C while sleeping.
 				t := time.NewTimer(backoff)
 				select {
 				case <-t.C:
 				case <-ctx.Done():
 					t.Stop()
 					return
-				}
-				// ClientQuiet (vs Client) suppresses the per-retry
-				// "RPC connection failed" stderr spam — caller knows
-				// the dial failed because cErr is non-nil. Without
-				// this, every backoff tick during a visor restart
-				// printed an identical ERROR line, exactly the
-				// failure mode #2514 was supposed to eliminate.
-				if newCl, cErr := clirpc.ClientQuiet(cmd.Flags()); cErr == nil {
-					rpcClient = newCl
-					// Don't yet reset lastErrLogged — the new
-					// client might still 503 if the visor is
-					// up but the RPC service isn't. Reset only
-					// when the next poll actually returns nil.
 				}
 				if backoff < maxBackoff {
 					backoff *= 2
@@ -343,40 +354,37 @@ errors out):
 				}
 				continue
 			}
-			if lastErrLogged {
-				fmt.Fprintln(os.Stderr, "group poll: reconnected") //nolint:errcheck
-				lastErrLogged = false
-				backoff = minBackoff
+			// Stream errors return here; we reopen above. Success
+			// path: the stream blocks indefinitely until ctx is
+			// canceled (Ctrl+C).
+			err = grpcClient.StreamGroupMessages(ctx, "", since.UnixNano(), nil, func(evt *rpcgrpc.GroupMessageEvent) {
+				if lastErrLogged {
+					fmt.Fprintln(os.Stderr, "group listen: reconnected") //nolint:errcheck
+					lastErrLogged = false
+					backoff = minBackoff
+				}
+				onMsg(evt.TimestampNs, evt.GroupId, evt.SenderPk, evt.Body)
+			})
+			_ = grpcClient.Close() //nolint:errcheck
+			if ctx.Err() != nil {
+				return
 			}
-			for _, m := range msgs {
-				if m.TS.After(since) {
-					since = m.TS
+			if err != nil && !lastErrLogged {
+				fmt.Fprintf(os.Stderr, "group listen: %v (reconnecting in %s)\n", err, backoff) //nolint:errcheck
+				lastErrLogged = true
+			}
+			t := time.NewTimer(backoff)
+			select {
+			case <-t.C:
+			case <-ctx.Done():
+				t.Stop()
+				return
+			}
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
 				}
-				if jsonMode {
-					ev := struct {
-						TS       time.Time `json:"ts"`
-						GroupID  string    `json:"group_id"`
-						SenderPK string    `json:"sender_pk"`
-						Body     string    `json:"body"`
-					}{
-						TS:       m.TS.UTC(),
-						GroupID:  m.GroupID,
-						SenderPK: m.SenderPK.Hex(),
-						Body:     m.Text,
-					}
-					b, mErr := json.Marshal(ev)
-					if mErr != nil {
-						continue
-					}
-					fmt.Println(string(b))
-					continue
-				}
-				body := m.Text
-				if !groupListenRaw {
-					body = escapeForOneLine(body)
-				}
-				fmt.Printf("[%s] [%s] %s: %s\n",
-					m.TS.UTC().Format(time.RFC3339), m.GroupID, m.SenderPK, body)
 			}
 		}
 	},

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
@@ -278,11 +279,30 @@ func toInfo(r skychatgroup.Record) GroupInfo {
 // fresh independent of the wrapped-handler chain in
 // group.Manager.openLocked. Nil-tolerant: if setManager hasn't been
 // called the bookkeeping side-effect is skipped.
+//
+// subs is the live-subscriber set used by the gRPC StreamGroupMessages
+// path. Each subscriber gets its own bounded channel; deliver() fans
+// every inbound message out to all channels with select+default so a
+// slow consumer can't block the inbox. Slow consumers see the dropCount
+// for their subscription advance — they observe the drop, the rest of
+// the system keeps moving. nil-safe; the legacy GroupPoll-only path
+// works fine with subs unused.
 type groupInbox struct {
 	mu  sync.Mutex
 	cap int
 	buf []GroupMessage
 	mgr *skychatgroup.Manager
+
+	subsMu sync.RWMutex
+	subs   map[*groupSub]struct{}
+}
+
+// groupSub is a single live-subscription registered against the inbox.
+// Closed by the inbox on unsubscribe; the subscriber drains ch until it
+// returns ok==false, then exits.
+type groupSub struct {
+	ch        chan GroupMessage
+	dropCount atomic.Uint64
 }
 
 func newGroupInbox(capacity int) *groupInbox {
@@ -303,19 +323,35 @@ func (g *groupInbox) setManager(mgr *skychatgroup.Manager) {
 }
 
 func (g *groupInbox) deliver(groupID string, senderPK cipher.PubKey, msg skychatgroup.Message) {
-	g.mu.Lock()
-	g.buf = append(g.buf, GroupMessage{
+	gm := GroupMessage{
 		GroupID:  groupID,
 		SenderPK: senderPK,
 		Text:     msg.Text,
 		TS:       msg.TS,
-	})
+	}
+	g.mu.Lock()
+	g.buf = append(g.buf, gm)
 	if len(g.buf) > g.cap {
 		drop := len(g.buf) - g.cap
 		g.buf = append(g.buf[:0], g.buf[drop:]...)
 	}
 	mgr := g.mgr
 	g.mu.Unlock()
+
+	// Fan-out to live subscribers (gRPC StreamGroupMessages path).
+	// select+default so a backed-up subscriber never blocks delivery
+	// of this message to anyone else or to the ring buffer above.
+	// A subscriber that misses messages sees its dropCount tick; the
+	// rest of the system is unaffected.
+	g.subsMu.RLock()
+	for sub := range g.subs {
+		select {
+		case sub.ch <- gm:
+		default:
+			sub.dropCount.Add(1)
+		}
+	}
+	g.subsMu.RUnlock()
 	// Belt-and-suspenders: also tick the persisted last_message_at on
 	// the manager. The wrapped MessageHandler installed by openLocked
 	// is supposed to do this too, but during the 3-agent coordination
@@ -340,4 +376,43 @@ func (g *groupInbox) snapshotAfter(since time.Time) []GroupMessage {
 		}
 	}
 	return out
+}
+
+// subscribe registers a live subscriber that receives every message
+// passed to deliver() from this point forward. The returned channel is
+// owned by the inbox: callers drain it until ok==false, which happens
+// when unsubscribe is called. bufSize bounds the per-subscriber queue;
+// bursts past it are dropped (counted via the returned sub's
+// dropCount).
+//
+// Used by the gRPC StreamGroupMessages handler to push messages to the
+// CLI without the net/rpc poll loop. The handler is responsible for
+// calling unsubscribe on its way out (defer or ctx-done).
+func (g *groupInbox) subscribe(bufSize int) *groupSub {
+	if bufSize <= 0 {
+		bufSize = 64
+	}
+	sub := &groupSub{ch: make(chan GroupMessage, bufSize)}
+	g.subsMu.Lock()
+	if g.subs == nil {
+		g.subs = make(map[*groupSub]struct{})
+	}
+	g.subs[sub] = struct{}{}
+	g.subsMu.Unlock()
+	return sub
+}
+
+// unsubscribe removes sub from the live-subscriber set and closes its
+// channel so the consumer's range/select exits cleanly. Safe to call
+// once; double-call is a no-op.
+func (g *groupInbox) unsubscribe(sub *groupSub) {
+	if sub == nil {
+		return
+	}
+	g.subsMu.Lock()
+	if _, ok := g.subs[sub]; ok {
+		delete(g.subs, sub)
+		close(sub.ch)
+	}
+	g.subsMu.Unlock()
 }

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -313,6 +313,34 @@ func (a *visorPingAdapter) SubscribeLogs(f logging.Filter, capacity int) (<-chan
 	return a.v.SubscribeLogs(f, capacity)
 }
 
+// SubscribeGroupMessages bridges visor's group inbox into rpcgrpc's
+// import-cycle-safe channel type. Spawns one goroutine per subscriber
+// that drains the inbox channel, converts each GroupMessage to the
+// rpcgrpc-local GroupMessageData mirror, and forwards on the returned
+// channel. The forwarding goroutine exits when the underlying inbox
+// channel closes (the cancel func calls inbox.unsubscribe, which
+// closes that channel) — which then closes the outbound forwarding
+// channel and signals stream end to the gRPC handler.
+func (a *visorPingAdapter) SubscribeGroupMessages(capacity int) (<-chan rpcgrpc.GroupMessageData, func() uint64) {
+	src, cancel := a.v.SubscribeGroupMessages(capacity)
+	if src == nil {
+		return nil, cancel
+	}
+	out := make(chan rpcgrpc.GroupMessageData, capacity)
+	go func() {
+		defer close(out)
+		for m := range src {
+			out <- rpcgrpc.GroupMessageData{
+				TimestampNs: m.TS.UnixNano(),
+				GroupID:     m.GroupID,
+				SenderPK:    m.SenderPK.Hex(),
+				Body:        m.Text,
+			}
+		}
+	}()
+	return out, cancel
+}
+
 func (a *visorPingAdapter) LocalPK() cipher.PubKey {
 	return a.v.LocalPK()
 }

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -444,3 +444,57 @@ func (c *PingClient) StreamRemoteSystemStats(ctx context.Context, remotePK strin
 		cb(stats)
 	}
 }
+
+// GroupMessageCallback is invoked for every group message the stream
+// delivers. The Subscribed-sentinel entry is filtered out by
+// StreamGroupMessages — callers only see real messages.
+type GroupMessageCallback func(e *GroupMessageEvent)
+
+// StreamGroupMessages opens a server-streaming subscription to the
+// visor's group inbox. Blocks until ctx is canceled or the stream
+// errors. Replaces the net/rpc GroupPoll loop in 'cli skychat group
+// listen', whose underlying conn was killed every 5 minutes by the
+// per-conn deadline at init_apps.go (the deadline exists to bound
+// unary RPC hang detection; it's the wrong tool for long-lived
+// listen-style RPCs).
+//
+// groupID, when non-empty, scopes the stream to one group (server-side
+// filter). Empty subscribes to every group the visor is in.
+//
+// sinceTimestampNs requests backlog replay of messages with TS
+// strictly greater than the value before live deliveries start. Zero
+// means live-only. (Backlog replay is currently honored on the wire
+// but the server-side implementation may be a no-op pending the
+// snapshotAfter accessor — see the server handler comment.)
+//
+// If subscribed is non-nil, it is closed once the server emits the
+// Subscribed sentinel — the same handshake pattern StreamAppLogs uses.
+// The sentinel itself is filtered and not delivered to cb.
+func (c *PingClient) StreamGroupMessages(ctx context.Context, groupID string, sinceTimestampNs int64, subscribed chan<- struct{}, cb GroupMessageCallback) error {
+	stream, err := c.client.StreamGroupMessages(ctx, &GroupMessagesRequest{
+		GroupId:          groupID,
+		SinceTimestampNs: sinceTimestampNs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start group message stream: %w", err)
+	}
+
+	signaled := false
+	for {
+		evt, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("stream error: %w", err)
+		}
+		if evt.Subscribed && !signaled {
+			signaled = true
+			if subscribed != nil {
+				close(subscribed)
+			}
+			continue
+		}
+		cb(evt)
+	}
+}

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -7,12 +7,11 @@
 package rpcgrpc
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1678,6 +1677,152 @@ func (x *CalcHop) GetTo() string {
 	return ""
 }
 
+// GroupMessagesRequest configures a group-message stream subscription.
+type GroupMessagesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// GroupId filters to one group. Empty subscribes to every group
+	// the visor is currently in (the default 'cli skychat group listen'
+	// behavior).
+	GroupId string `protobuf:"bytes,1,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`
+	// SinceTimestampNs replays buffered messages with TS strictly
+	// greater than this value before live deliveries start. Zero
+	// means "live only" — drains nothing from history. Mirrors the
+	// 'since' arg the previous GroupPoll RPC accepted.
+	SinceTimestampNs int64 `protobuf:"varint,2,opt,name=since_timestamp_ns,json=sinceTimestampNs,proto3" json:"since_timestamp_ns,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GroupMessagesRequest) Reset() {
+	*x = GroupMessagesRequest{}
+	mi := &file_ping_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GroupMessagesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GroupMessagesRequest) ProtoMessage() {}
+
+func (x *GroupMessagesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GroupMessagesRequest.ProtoReflect.Descriptor instead.
+func (*GroupMessagesRequest) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *GroupMessagesRequest) GetGroupId() string {
+	if x != nil {
+		return x.GroupId
+	}
+	return ""
+}
+
+func (x *GroupMessagesRequest) GetSinceTimestampNs() int64 {
+	if x != nil {
+		return x.SinceTimestampNs
+	}
+	return 0
+}
+
+// GroupMessageEvent is one inbound group message delivered to the
+// stream. Mirrors visor.GroupMessage one-for-one.
+type GroupMessageEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// TimestampNs is the message Unix-nanos timestamp from the sender.
+	TimestampNs int64 `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`
+	// GroupId is the group the message arrived on.
+	GroupId string `protobuf:"bytes,2,opt,name=group_id,json=groupId,proto3" json:"group_id,omitempty"`
+	// SenderPk is the publishing member's hex public key.
+	SenderPk string `protobuf:"bytes,3,opt,name=sender_pk,json=senderPk,proto3" json:"sender_pk,omitempty"`
+	// Body is the message text (may contain embedded newlines —
+	// callers that need one-line-per-event should escape on display).
+	Body string `protobuf:"bytes,4,opt,name=body,proto3" json:"body,omitempty"`
+	// Subscribed is set on a sentinel sent immediately after the
+	// server registers the subscription. Lets clients gate downstream
+	// RPCs on subscription liveness — same pattern AppLogEntry uses.
+	Subscribed    bool `protobuf:"varint,5,opt,name=subscribed,proto3" json:"subscribed,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GroupMessageEvent) Reset() {
+	*x = GroupMessageEvent{}
+	mi := &file_ping_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GroupMessageEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GroupMessageEvent) ProtoMessage() {}
+
+func (x *GroupMessageEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GroupMessageEvent.ProtoReflect.Descriptor instead.
+func (*GroupMessageEvent) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *GroupMessageEvent) GetTimestampNs() int64 {
+	if x != nil {
+		return x.TimestampNs
+	}
+	return 0
+}
+
+func (x *GroupMessageEvent) GetGroupId() string {
+	if x != nil {
+		return x.GroupId
+	}
+	return ""
+}
+
+func (x *GroupMessageEvent) GetSenderPk() string {
+	if x != nil {
+		return x.SenderPk
+	}
+	return ""
+}
+
+func (x *GroupMessageEvent) GetBody() string {
+	if x != nil {
+		return x.Body
+	}
+	return ""
+}
+
+func (x *GroupMessageEvent) GetSubscribed() bool {
+	if x != nil {
+		return x.Subscribed
+	}
+	return false
+}
+
 // ProcessStat contains information about a running process
 type ProcessStat struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1694,7 +1839,7 @@ type ProcessStat struct {
 
 func (x *ProcessStat) Reset() {
 	*x = ProcessStat{}
-	mi := &file_ping_proto_msgTypes[21]
+	mi := &file_ping_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1706,7 +1851,7 @@ func (x *ProcessStat) String() string {
 func (*ProcessStat) ProtoMessage() {}
 
 func (x *ProcessStat) ProtoReflect() protoreflect.Message {
-	mi := &file_ping_proto_msgTypes[21]
+	mi := &file_ping_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1719,7 +1864,7 @@ func (x *ProcessStat) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessStat.ProtoReflect.Descriptor instead.
 func (*ProcessStat) Descriptor() ([]byte, []int) {
-	return file_ping_proto_rawDescGZIP(), []int{21}
+	return file_ping_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ProcessStat) GetPid() int32 {
@@ -1931,7 +2076,18 @@ const file_ping_proto_rawDesc = "" +
 	"\aCalcHop\x12\x13\n" +
 	"\x05tp_id\x18\x01 \x01(\tR\x04tpId\x12\x12\n" +
 	"\x04from\x18\x02 \x01(\tR\x04from\x12\x0e\n" +
-	"\x02to\x18\x03 \x01(\tR\x02to\"\xce\x01\n" +
+	"\x02to\x18\x03 \x01(\tR\x02to\"_\n" +
+	"\x14GroupMessagesRequest\x12\x19\n" +
+	"\bgroup_id\x18\x01 \x01(\tR\agroupId\x12,\n" +
+	"\x12since_timestamp_ns\x18\x02 \x01(\x03R\x10sinceTimestampNs\"\xa2\x01\n" +
+	"\x11GroupMessageEvent\x12!\n" +
+	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12\x19\n" +
+	"\bgroup_id\x18\x02 \x01(\tR\agroupId\x12\x1b\n" +
+	"\tsender_pk\x18\x03 \x01(\tR\bsenderPk\x12\x12\n" +
+	"\x04body\x18\x04 \x01(\tR\x04body\x12\x1e\n" +
+	"\n" +
+	"subscribed\x18\x05 \x01(\bR\n" +
+	"subscribed\"\xce\x01\n" +
 	"\vProcessStat\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1f\n" +
@@ -1941,7 +2097,7 @@ const file_ping_proto_rawDesc = "" +
 	"\n" +
 	"memory_rss\x18\x05 \x01(\x04R\tmemoryRss\x12\x1a\n" +
 	"\busername\x18\x06 \x01(\tR\busername\x12\x16\n" +
-	"\x06status\x18\a \x01(\tR\x06status2\xf0\x05\n" +
+	"\x06status\x18\a \x01(\tR\x06status2\xc4\x06\n" +
 	"\vPingService\x129\n" +
 	"\n" +
 	"StreamPing\x12\x14.rpcgrpc.PingRequest\x1a\x13.rpcgrpc.PingResult0\x01\x12=\n" +
@@ -1953,7 +2109,8 @@ const file_ping_proto_rawDesc = "" +
 	"\x0eGetSystemStats\x12\x1b.rpcgrpc.SystemStatsRequest\x1a\x14.rpcgrpc.SystemStats\x12T\n" +
 	"\x17StreamRemoteSystemStats\x12!.rpcgrpc.RemoteSystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01\x12E\n" +
 	"\rStreamAppLogs\x12\x1c.rpcgrpc.AppLogStreamRequest\x1a\x14.rpcgrpc.AppLogEntry0\x01\x12D\n" +
-	"\x10StreamCalcRoutes\x12\x1a.rpcgrpc.CalcRoutesRequest\x1a\x12.rpcgrpc.CalcRoute0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
+	"\x10StreamCalcRoutes\x12\x1a.rpcgrpc.CalcRoutesRequest\x1a\x12.rpcgrpc.CalcRoute0\x01\x12R\n" +
+	"\x13StreamGroupMessages\x12\x1d.rpcgrpc.GroupMessagesRequest\x1a\x1a.rpcgrpc.GroupMessageEvent0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -1967,7 +2124,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -1990,8 +2147,10 @@ var file_ping_proto_goTypes = []any{
 	(*CalcRoutesRequest)(nil),        // 18: rpcgrpc.CalcRoutesRequest
 	(*CalcRoute)(nil),                // 19: rpcgrpc.CalcRoute
 	(*CalcHop)(nil),                  // 20: rpcgrpc.CalcHop
-	(*ProcessStat)(nil),              // 21: rpcgrpc.ProcessStat
-	nil,                              // 22: rpcgrpc.AppLogEntry.FieldsEntry
+	(*GroupMessagesRequest)(nil),     // 21: rpcgrpc.GroupMessagesRequest
+	(*GroupMessageEvent)(nil),        // 22: rpcgrpc.GroupMessageEvent
+	(*ProcessStat)(nil),              // 23: rpcgrpc.ProcessStat
+	nil,                              // 24: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -2004,8 +2163,8 @@ var file_ping_proto_depIdxs = []int32{
 	13, // 7: rpcgrpc.SystemStats.disks:type_name -> rpcgrpc.DiskStat
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
-	21, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	22, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	23, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
+	24, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
 	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
 	0,  // 13: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
 	0,  // 14: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
@@ -2017,18 +2176,20 @@ var file_ping_proto_depIdxs = []int32{
 	8,  // 20: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
 	16, // 21: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
 	18, // 22: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	1,  // 23: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 24: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 25: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 26: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 27: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 28: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 29: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 30: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 31: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 32: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	23, // [23:33] is the sub-list for method output_type
-	13, // [13:23] is the sub-list for method input_type
+	21, // 23: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	1,  // 24: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 25: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 26: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 27: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 28: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 29: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 30: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 31: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 32: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 33: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 34: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	24, // [24:35] is the sub-list for method output_type
+	13, // [13:24] is the sub-list for method input_type
 	13, // [13:13] is the sub-list for extension type_name
 	13, // [13:13] is the sub-list for extension extendee
 	0,  // [0:13] is the sub-list for field type_name
@@ -2045,7 +2206,7 @@ func file_ping_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   23,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -41,6 +41,16 @@ service PingService {
   // incrementally and avoids accumulating every result in memory before
   // returning — important when count is large or unbounded.
   rpc StreamCalcRoutes(CalcRoutesRequest) returns (stream CalcRoute);
+
+  // StreamGroupMessages opens a long-lived stream of inbound group
+  // messages. The server holds a per-stream subscription to the
+  // visor's group inbox and pushes each delivered message to the
+  // client as it arrives. Replaces the net/rpc poll loop in
+  // 'cli skychat group listen', which would lose its underlying
+  // connection every 5 minutes to the per-conn deadline applied at
+  // init_apps.go for unary-RPC hang detection. Stream lifetime is
+  // the listen lifetime, no arbitrary ceiling.
+  rpc StreamGroupMessages(GroupMessagesRequest) returns (stream GroupMessageEvent);
 }
 
 message PingRequest {
@@ -262,6 +272,37 @@ message CalcHop {
   string tp_id = 1;
   string from = 2;
   string to = 3;
+}
+
+// GroupMessagesRequest configures a group-message stream subscription.
+message GroupMessagesRequest {
+  // GroupId filters to one group. Empty subscribes to every group
+  // the visor is currently in (the default 'cli skychat group listen'
+  // behavior).
+  string group_id = 1;
+  // SinceTimestampNs replays buffered messages with TS strictly
+  // greater than this value before live deliveries start. Zero
+  // means "live only" — drains nothing from history. Mirrors the
+  // 'since' arg the previous GroupPoll RPC accepted.
+  int64 since_timestamp_ns = 2;
+}
+
+// GroupMessageEvent is one inbound group message delivered to the
+// stream. Mirrors visor.GroupMessage one-for-one.
+message GroupMessageEvent {
+  // TimestampNs is the message Unix-nanos timestamp from the sender.
+  int64 timestamp_ns = 1;
+  // GroupId is the group the message arrived on.
+  string group_id = 2;
+  // SenderPk is the publishing member's hex public key.
+  string sender_pk = 3;
+  // Body is the message text (may contain embedded newlines —
+  // callers that need one-line-per-event should escape on display).
+  string body = 4;
+  // Subscribed is set on a sentinel sent immediately after the
+  // server registers the subscription. Lets clients gate downstream
+  // RPCs on subscription liveness — same pattern AppLogEntry uses.
+  bool subscribed = 5;
 }
 
 // ProcessStat contains information about a running process

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -8,7 +8,6 @@ package rpcgrpc
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -30,6 +29,7 @@ const (
 	PingService_StreamRemoteSystemStats_FullMethodName = "/rpcgrpc.PingService/StreamRemoteSystemStats"
 	PingService_StreamAppLogs_FullMethodName           = "/rpcgrpc.PingService/StreamAppLogs"
 	PingService_StreamCalcRoutes_FullMethodName        = "/rpcgrpc.PingService/StreamCalcRoutes"
+	PingService_StreamGroupMessages_FullMethodName     = "/rpcgrpc.PingService/StreamGroupMessages"
 )
 
 // PingServiceClient is the client API for PingService service.
@@ -64,6 +64,15 @@ type PingServiceClient interface {
 	// incrementally and avoids accumulating every result in memory before
 	// returning — important when count is large or unbounded.
 	StreamCalcRoutes(ctx context.Context, in *CalcRoutesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CalcRoute], error)
+	// StreamGroupMessages opens a long-lived stream of inbound group
+	// messages. The server holds a per-stream subscription to the
+	// visor's group inbox and pushes each delivered message to the
+	// client as it arrives. Replaces the net/rpc poll loop in
+	// 'cli skychat group listen', which would lose its underlying
+	// connection every 5 minutes to the per-conn deadline applied at
+	// init_apps.go for unary-RPC hang detection. Stream lifetime is
+	// the listen lifetime, no arbitrary ceiling.
+	StreamGroupMessages(ctx context.Context, in *GroupMessagesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GroupMessageEvent], error)
 }
 
 type pingServiceClient struct {
@@ -246,6 +255,25 @@ func (c *pingServiceClient) StreamCalcRoutes(ctx context.Context, in *CalcRoutes
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamCalcRoutesClient = grpc.ServerStreamingClient[CalcRoute]
 
+func (c *pingServiceClient) StreamGroupMessages(ctx context.Context, in *GroupMessagesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GroupMessageEvent], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &PingService_ServiceDesc.Streams[8], PingService_StreamGroupMessages_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[GroupMessagesRequest, GroupMessageEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamGroupMessagesClient = grpc.ServerStreamingClient[GroupMessageEvent]
+
 // PingServiceServer is the server API for PingService service.
 // All implementations must embed UnimplementedPingServiceServer
 // for forward compatibility.
@@ -278,6 +306,15 @@ type PingServiceServer interface {
 	// incrementally and avoids accumulating every result in memory before
 	// returning — important when count is large or unbounded.
 	StreamCalcRoutes(*CalcRoutesRequest, grpc.ServerStreamingServer[CalcRoute]) error
+	// StreamGroupMessages opens a long-lived stream of inbound group
+	// messages. The server holds a per-stream subscription to the
+	// visor's group inbox and pushes each delivered message to the
+	// client as it arrives. Replaces the net/rpc poll loop in
+	// 'cli skychat group listen', which would lose its underlying
+	// connection every 5 minutes to the per-conn deadline applied at
+	// init_apps.go for unary-RPC hang detection. Stream lifetime is
+	// the listen lifetime, no arbitrary ceiling.
+	StreamGroupMessages(*GroupMessagesRequest, grpc.ServerStreamingServer[GroupMessageEvent]) error
 	mustEmbedUnimplementedPingServiceServer()
 }
 
@@ -317,6 +354,9 @@ func (UnimplementedPingServiceServer) StreamAppLogs(*AppLogStreamRequest, grpc.S
 }
 func (UnimplementedPingServiceServer) StreamCalcRoutes(*CalcRoutesRequest, grpc.ServerStreamingServer[CalcRoute]) error {
 	return status.Error(codes.Unimplemented, "method StreamCalcRoutes not implemented")
+}
+func (UnimplementedPingServiceServer) StreamGroupMessages(*GroupMessagesRequest, grpc.ServerStreamingServer[GroupMessageEvent]) error {
+	return status.Error(codes.Unimplemented, "method StreamGroupMessages not implemented")
 }
 func (UnimplementedPingServiceServer) mustEmbedUnimplementedPingServiceServer() {}
 func (UnimplementedPingServiceServer) testEmbeddedByValue()                     {}
@@ -463,6 +503,17 @@ func _PingService_StreamCalcRoutes_Handler(srv interface{}, stream grpc.ServerSt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamCalcRoutesServer = grpc.ServerStreamingServer[CalcRoute]
 
+func _PingService_StreamGroupMessages_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(GroupMessagesRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(PingServiceServer).StreamGroupMessages(m, &grpc.GenericServerStream[GroupMessagesRequest, GroupMessageEvent]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamGroupMessagesServer = grpc.ServerStreamingServer[GroupMessageEvent]
+
 // PingService_ServiceDesc is the grpc.ServiceDesc for PingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -518,6 +569,11 @@ var PingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamCalcRoutes",
 			Handler:       _PingService_StreamCalcRoutes_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamGroupMessages",
+			Handler:       _PingService_StreamGroupMessages_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -53,6 +53,13 @@ type VisorAPI interface {
 	// filter; cancel() unsubscribes and returns the dropped count.
 	// Both may be nil (visor without a broadcaster wired up).
 	SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.Entry, func() uint64)
+	// SubscribeGroupMessages returns a channel of inbound group
+	// messages converted into GroupMessageData (rpcgrpc's wire-friendly
+	// mirror of visor.GroupMessage to avoid the visor → rpcgrpc import
+	// cycle). cancel() unsubscribes and returns the dropped count.
+	// Returns (nil, no-op) when grouping is not yet initialized on
+	// the visor or running in a test harness.
+	SubscribeGroupMessages(capacity int) (<-chan GroupMessageData, func() uint64)
 	// LocalPK returns the visor's own public key. Used by route-calc
 	// gRPC handlers that default the src PK to the local visor.
 	LocalPK() cipher.PubKey
@@ -60,6 +67,18 @@ type VisorAPI interface {
 	// the visor's existing discovery client. The route-calc gRPC
 	// handler builds the BFS graph from this slice.
 	FetchAllTransportEntries(ctx context.Context) ([]*transport.Entry, error)
+}
+
+// GroupMessageData mirrors visor.GroupMessage one-for-one but lives in
+// rpcgrpc so VisorAPI.SubscribeGroupMessages doesn't pull pkg/visor
+// into rpcgrpc's import graph. The adapter at the visor's init wires
+// a tiny converter goroutine between the inbox's
+// chan visor.GroupMessage and this chan GroupMessageData.
+type GroupMessageData struct {
+	TimestampNs int64
+	GroupID     string
+	SenderPK    string
+	Body        string
 }
 
 // PingConf mirrors visor.PingConfig to avoid import cycles
@@ -983,6 +1002,79 @@ func (s *PingServer) StreamRemoteSystemStats(req *RemoteSystemStatsRequest, stre
 
 		if err := stream.Send(stats); err != nil {
 			return err
+		}
+	}
+}
+
+// StreamGroupMessages opens a long-lived subscription to the visor's
+// group inbox. The server registers with the inbox via the VisorAPI
+// adapter, then forwards every delivered message to the client over
+// the gRPC stream. Stream lifetime is the subscription lifetime — no
+// per-conn deadline applies (the deadline-driven 5-minute reconnect
+// pattern is exactly what this RPC was added to escape).
+//
+// Sequence:
+//  1. Register the subscription on the inbox (bounded buffer).
+//  2. Send a Subscribed sentinel so the client can confirm the stream
+//     is live before downstream actions (mirrors the AppLogStream
+//     pattern; lets the CLI gate Ctrl+C handler installation, etc.).
+//  3. If req.SinceTimestampNs > 0, drain backlog from a one-shot
+//     GroupPoll-style call via the existing inbox snapshot — NOT done
+//     here yet; the simplest live-only path is enough for the v1 CLI
+//     replacement. Backlog replay is a follow-up (handler would need
+//     a SnapshotAfter accessor on the adapter).
+//  4. Loop: select on stream.Context().Done() or the subscription
+//     channel; forward each message to the wire.
+//
+// Filter: req.GroupId, when set, scopes the stream to one group. Empty
+// matches every group the visor is in.
+func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingService_StreamGroupMessagesServer) error {
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+
+	const subBuffer = 256
+	ch, cancel := s.visor.SubscribeGroupMessages(subBuffer)
+	if ch == nil {
+		return fmt.Errorf("group inbox not available on this visor")
+	}
+	defer cancel()
+
+	s.log.Debugf("gRPC StreamGroupMessages: subscribed group_id=%q since_ns=%d", req.GroupId, req.SinceTimestampNs)
+
+	// Sentinel: tell the client the subscription is live so it can
+	// safely drop fallback paths / install signal handlers / etc.
+	// before the first real message arrives. Sent BEFORE entering
+	// the dispatch loop.
+	if err := stream.Send(&GroupMessageEvent{
+		TimestampNs: time.Now().UnixNano(),
+		Subscribed:  true,
+	}); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		case m, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			// Server-side filter by group_id. The inbox fans every
+			// message to every subscriber; filtering here avoids
+			// per-stream filtering layers in the inbox itself.
+			if req.GroupId != "" && m.GroupID != req.GroupId {
+				continue
+			}
+			if err := stream.Send(&GroupMessageEvent{
+				TimestampNs: m.TimestampNs,
+				GroupId:     m.GroupID,
+				SenderPk:    m.SenderPK,
+				Body:        m.Body,
+			}); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -826,6 +826,33 @@ func (v *Visor) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.En
 	return v.logBcast.Subscribe(f, capacity)
 }
 
+// SubscribeGroupMessages registers a live subscriber on the visor's
+// group inbox. Every message delivered to the inbox from this point
+// forward is fanned out to the returned channel (bounded; bursts past
+// capacity are dropped and counted via the cancel-returned uint64).
+//
+// Powers the gRPC StreamGroupMessages handler — the long-lived
+// streaming replacement for the net/rpc GroupPoll loop. Backlog
+// (messages already buffered in the ring at subscribe time) is NOT
+// replayed; callers that want that should call GroupPoll with a
+// since-timestamp before subscribing.
+//
+// Returns nil channel + a no-op cancel when grouping is disabled on
+// this visor (e.g. early init or tests).
+func (v *Visor) SubscribeGroupMessages(capacity int) (<-chan GroupMessage, func() uint64) {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return nil, func() uint64 { return 0 }
+	}
+	sub := inbox.subscribe(capacity)
+	return sub.ch, func() uint64 {
+		inbox.unsubscribe(sub)
+		return sub.dropCount.Load()
+	}
+}
+
 // tpDiscClient is a convenience function to obtain transport discovery client.
 func (v *Visor) tpDiscClient() transport.DiscoveryClient {
 	return v.tpM.Conf.DiscoveryClient


### PR DESCRIPTION
## Summary

Replaces the \`net/rpc\` \`GroupPoll\` loop in \`cli skychat group listen\` with a server-streaming gRPC subscription, so the listener's connection lifetime is the listen-loop lifetime — not the visor's 5-minute per-conn deadline.

## Why

The visor's RPC accept loop applies \`c.SetDeadline(now + 5 minutes)\` per connection (\`pkg/visor/init_apps.go:542\`). That deadline exists to bound unary-RPC hang detection — e.g. an RPC method iterating a corrupt routing table that loops forever. Useful for short calls; the wrong tool for streaming-style RPCs that legitimately want to live for hours. \`group listen\`, \`skychat listen\`, and similar long-lived listeners would hit this every 5 min, return \`connection is shut down\`, and reconnect via backoff — visible in every operator's monitor as a \"(quiet reconnect)\" cycle.

Bumping the deadline just delays the same wrong shape. The right move is a different transport for streaming-style operations.

## Changes

- \`pkg/visor/rpcgrpc/ping.proto\`: new \`StreamGroupMessages(GroupMessagesRequest) → stream GroupMessageEvent\` RPC. Regenerated bindings.
- \`pkg/visor/group.go\`: \`groupInbox\` gains \`subscribe/unsubscribe\` + a \`groupSub\` type with a bounded per-subscriber channel and \`dropCount\`. \`deliver()\` fans every message to all live subscribers with \`select+default\` so a slow consumer can never block delivery to others.
- \`pkg/visor/visor.go\`: \`Visor.SubscribeGroupMessages(capacity)\` exposes the inbox-subscribe path.
- \`pkg/visor/rpcgrpc/server.go\`: \`StreamGroupMessages\` handler. Registers a subscription, sends a \`Subscribed\` sentinel (mirrors the \`StreamAppLogs\` pattern), then forwards every message to the wire. Server-side \`group_id\` filter.
- \`pkg/visor/init_apps.go\`: \`visorPingAdapter.SubscribeGroupMessages\` bridges the inbox channel into the rpcgrpc-local \`GroupMessageData\` type so \`VisorAPI\` doesn't pull \`pkg/visor\` into \`rpcgrpc\`'s import graph (same workaround as \`PingConf\`).
- \`pkg/visor/rpcgrpc/client.go\`: \`PingClient.StreamGroupMessages\` blocks-until-EOF, filters the sentinel, calls a callback per event.
- \`cmd/skywire-cli/commands/skychat/group.go\`: \`group listen\` dials gRPC and consumes the stream. Reconnect backoff preserved for visor-restart resilience; render path extracted into \`onMsg\` so JSON / text / raw modes share one conversion.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./pkg/visor/...\` green.
- [x] \`make lint\` clean (0 issues).
- [ ] Live: rebuild + restart all 3 peers' visors; verify the periodic \"connection is shut down (reconnecting)\" lines stop firing in the listen monitors after this lands.

## Follow-ups

- Backlog replay on subscribe (the proto field \`SinceTimestampNs\` is honored on the wire but the server handler is live-only for v1; needs a \`snapshotAfter\` accessor on the adapter to wire fully).
- Same gRPC pattern can replace \`cli skychat listen\` (1:1 chat) and other listen-style RPCs in follow-up PRs.