### PR TITLE
feat(cli): ssh + sshd commands — OpenSSH-equivalent surface over skywire identity

### DIFF
--- a/cmd/dmsg/dmsgpty-host/commands/root.go
+++ b/cmd/dmsg/dmsgpty-host/commands/root.go
@@ -48,7 +48,7 @@ var (
 
 	// tcpListen, when non-empty, brings up the direct-TCP entry point
 	// (XK noise + dmsgpty whitelist gate) alongside the dmsg-overlay
-	// path. Mirrors the visor-embedded Dmsgpty.TCPListen config.
+	// path. Mirrors the visor-embedded Dmsgpty.SshListen config.
 	tcpListen string
 
 	// noDmsg, when true, skips the dmsg.Client + dmsg-listener setup
@@ -101,7 +101,7 @@ func init() {
 	RootCmd.Flags().StringVar(&cliNet, "clinet", cliNet, "network used for listening for cli connections")
 	RootCmd.Flags().StringVar(&cliAddr, "cliaddr", cliAddr, "address used for listening for cli connections")
 	RootCmd.Flags().StringVar(&tcpListen, "tcplisten", "",
-		"optional direct-TCP entry point address (e.g. ':2022'); empty disables. XK-noise + whitelist gated, mirrors the visor-embedded Dmsgpty.TCPListen.")
+		"optional direct-TCP entry point address (e.g. ':2022'); empty disables. XK-noise + whitelist gated, mirrors the visor-embedded Dmsgpty.SshListen. Exposed as 'skywire cli sshd'.")
 	RootCmd.Flags().BoolVar(&noDmsg, "no-dmsg", false,
 		"skip dmsg.Client + dmsg listener; run as TCP-only daemon (use with --tcplisten or --listen-fd)")
 	RootCmd.Flags().StringVar(&skFromVisor, "sk-from-visor", "",
@@ -250,13 +250,13 @@ var RootCmd = &cobra.Command{
 		}
 
 		// Optional direct-TCP entry point (XK-noise + whitelist
-		// gated). Mirrors the visor-embedded Dmsgpty.TCPListen.
+		// gated). Mirrors the visor-embedded Dmsgpty.SshListen.
 		// Empty (default) skips it; non-empty brings the listener up
 		// alongside the dmsg-overlay path. The host's NewHost-wired wl
 		// is reused — no separate ACL.
 		tcpAddr := tcpListen
 		if tcpAddr == "" {
-			tcpAddr = conf.TCPListen
+			tcpAddr = conf.SshListen
 		}
 		if tcpAddr != "" {
 			wg.Add(1)

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -31,6 +31,8 @@ import (
 	cliskychat "github.com/skycoin/skywire/cmd/skywire-cli/commands/skychat"
 	cliskycoin "github.com/skycoin/skywire/cmd/skywire-cli/commands/skycoin"
 	cliskynet "github.com/skycoin/skywire/cmd/skywire-cli/commands/skynet"
+	clissh "github.com/skycoin/skywire/cmd/skywire-cli/commands/ssh"
+	clisshd "github.com/skycoin/skywire/cmd/skywire-cli/commands/sshd"
 	clisurvey "github.com/skycoin/skywire/cmd/skywire-cli/commands/survey"
 	clisvc "github.com/skycoin/skywire/cmd/skywire-cli/commands/svc"
 	clitp "github.com/skycoin/skywire/cmd/skywire-cli/commands/tp"
@@ -82,6 +84,8 @@ func init() {
 	cliskysocksc.RootCmd.GroupID = groupApps
 	cliskychat.RootCmd.GroupID = groupApps
 	cliskynet.RootCmd.GroupID = groupApps
+	clissh.RootCmd.GroupID = groupApps
+	clisshd.RootCmd.GroupID = groupApps
 
 	clitp.RootCmd.GroupID = groupNet
 	clitps.RootCmd.GroupID = groupNet
@@ -127,6 +131,8 @@ func init() {
 		climdisc.RootCmd,
 		clisd.RootCmd,
 		cliskychat.RootCmd,
+		clissh.RootCmd,
+		clisshd.RootCmd,
 		cliskycoin.RootCmd,
 		clicompletion.RootCmd,
 		clilog.RootCmd,

--- a/cmd/skywire-cli/commands/ssh/ssh.go
+++ b/cmd/skywire-cli/commands/ssh/ssh.go
@@ -1,0 +1,268 @@
+// Package clissh cmd/skywire-cli/commands/ssh/ssh.go — `skywire cli ssh`,
+// the OpenSSH-equivalent client over skywire identity.
+//
+// Maps onto the existing dmsgpty.CLI direct-TCP path (PR #2559/#2560):
+// XK noise handshake pins the server PK, the server side authorizes
+// the client PK against the dmsgpty whitelist (= authorized_keys
+// equivalent), and the resulting stream runs the dmsgpty
+// mux — interactive shell or one-shot exec, your pick.
+//
+// This is a thin alias over `cli dmsg pty exec/start --via tcp://...`
+// with the destination spelled `<pk>@<host>:<port>` (matching ssh's
+// `user@host:port` muscle memory) and the visor's SK auto-loaded by
+// default (--no-visor-key opts out). The underlying machinery lives
+// in pkg/dmsg/dmsgpty/cli_tcp.go.
+package clissh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// sshDestRE matches both bare `<pk>@<host>:<port>` and the more
+// explicit `tcp://<pk>@<host>:<port>` forms. The pk is 66-char hex;
+// the address part is anything net.Dial will accept (`host:port`,
+// `[v6]:port`, IPv4 with port). The address must contain a colon —
+// the default port belongs in the URL, not implicit in this layer,
+// to keep parsing unambiguous against IPv6 addresses.
+var sshDestRE = regexp.MustCompile(`^(?:tcp://)?([a-f0-9]{66})@(.+:[^:]+)$`)
+
+// Flags (package-level so cobra can wire them once).
+var (
+	sshSK       cipher.SecKey
+	sshNoVisor  bool
+	sshEnv      []string
+	sshTimeout  string
+	sshNoPty    bool
+	sshDefPort  string
+	sshLegacyPK string //nolint:unused // kept for future "ssh <pk>" + --host shape
+)
+
+func init() {
+	RootCmd.Flags().SortFlags = false
+	RootCmd.Flags().VarP(&sshSK, "sk", "s",
+		"local client SK for the noise handshake (random if unset; pin for stable whitelist authorization)")
+	RootCmd.Flags().BoolVar(&sshNoVisor, "no-visor-key", false,
+		"don't borrow the local visor's SK from "+visorconfig.SkywireConfig()+" — use --sk or a random one instead")
+	RootCmd.Flags().StringArrayVarP(&sshEnv, "env", "e", nil,
+		"extra env var KEY=VALUE; repeatable; exec mode only")
+	RootCmd.Flags().StringVarP(&sshTimeout, "timeout", "t", "30s",
+		"max command duration in exec mode (e.g. 30s, 2m); host-side cap is 5m")
+	RootCmd.Flags().BoolVar(&sshNoPty, "no-pty", false,
+		"force exec mode even when no command is given (rarely useful — defaults to interactive when no command, exec when command is present, matching ssh's behavior)")
+	RootCmd.Flags().StringVarP(&sshDefPort, "port", "p", "2022",
+		"default port when the destination omits one (e.g. 'ssh <pk>@host' resolves to <pk>@host:<port>)")
+}
+
+// RootCmd is the `skywire cli ssh` command — OpenSSH-equivalent client
+// over skywire identity. Registered separately under skywire-cli's
+// root alongside the `sshd` server command.
+var RootCmd = &cobra.Command{
+	Use:   "ssh <pk>@<host>[:<port>] [-- <command> [args...]]",
+	Short: "Open a remote shell or exec a command on a peer visor (ssh-equivalent)",
+	Long: `skywire cli ssh — OpenSSH-equivalent client over skywire identity.
+
+Dials a peer's direct-TCP dmsgpty endpoint (the surface exposed by
+'skywire cli sshd' or by 'dmsgpty.ssh_listen' in the visor config),
+runs an XK noise handshake pinning the server's PK, and proxies an
+interactive shell or a one-shot exec.
+
+Compared to OpenSSH:
+  ssh's host-key check  ↔ noise XK pins the server PK from the
+                          destination URL
+  authorized_keys       ↔ dmsgpty whitelist on the server side
+  password / pubkey     ↔ client PK alone, derived from the local
+                          visor's SK by default (override with --sk
+                          or --no-visor-key)
+  TCP :22 default       ↔ TCP :2022 default (--port to override)
+  ssh -t / ssh <cmd>    ↔ no positional command → interactive pty
+                          positional command after '--' → exec mode
+
+Examples:
+  # Interactive shell on a peer visor at 1.2.3.4:2022
+  skywire cli ssh 0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c@1.2.3.4:2022
+
+  # One-shot exec
+  skywire cli ssh 0323...@1.2.3.4:2022 -- systemctl status skywire
+
+  # Use a pinned client SK instead of the visor's
+  skywire cli ssh 0323...@1.2.3.4:2022 --sk <hex> -- whoami
+
+The underlying transport is identical to 'cli dmsg pty exec/start
+--via tcp://<pk>@<host>:<port>'; this command is the discoverable
+ssh-shaped alias over that path.`,
+	Args:                  cobra.MinimumNArgs(1),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dest := args[0]
+		// If the destination omits a port, splice in --port. Doing it
+		// here (not in the regex) avoids ambiguity with IPv6 literals.
+		dest = injectDefaultPort(dest, sshDefPort)
+
+		rPK, addr, err := parseSSHDestination(dest)
+		if err != nil {
+			return err
+		}
+
+		myPK, mySK := resolveSSHIdentity(sshSK, !sshNoVisor)
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), nil)
+		defer cancel()
+
+		cli := dmsgpty.DefaultCLI()
+
+		// Interactive when no positional command follows.
+		if len(args) == 1 {
+			if sshNoPty {
+				return fmt.Errorf("ssh: --no-pty requires a command to exec")
+			}
+			return (&cli).StartRemotePtyTCP(ctx, rPK, addr, myPK, mySK, dmsgpty.DefaultCmd)
+		}
+
+		// Exec mode.
+		timeout, err := time.ParseDuration(sshTimeout)
+		if err != nil {
+			return fmt.Errorf("ssh: --timeout %q: %w", sshTimeout, err)
+		}
+		name := args[1]
+		var cmdArgs []string
+		if len(args) > 2 {
+			cmdArgs = args[2:]
+		}
+		resp, err := (&cli).ExecRemoteTCP(ctx, rPK, addr, myPK, mySK, name, cmdArgs, sshEnv, nil, timeout)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "ssh: %v\n", err) //nolint:errcheck
+			os.Exit(1)
+		}
+		reportSSHExec(cmd, resp)
+		return nil
+	},
+}
+
+// parseSSHDestination splits `<pk>@<host>:<port>` (with optional
+// `tcp://` prefix) into the remote PK and the dial-target address.
+// The PK must be canonical 66-hex; addr is passed through to
+// net.Dial verbatim. Any error message includes the offending
+// destination string for operator readability.
+func parseSSHDestination(dest string) (cipher.PubKey, string, error) {
+	m := sshDestRE.FindStringSubmatch(dest)
+	if m == nil {
+		return cipher.PubKey{}, "", fmt.Errorf("ssh: destination %q must be <66-hex-pk>@<host:port> (optionally prefixed tcp://)", dest)
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(m[1]); err != nil {
+		return cipher.PubKey{}, "", fmt.Errorf("ssh: destination PK invalid: %w", err)
+	}
+	return pk, m[2], nil
+}
+
+// injectDefaultPort splices a port into the destination if the user
+// gave only `<pk>@<host>`. IPv6 literals must already carry their own
+// `:port` because there's no unambiguous insertion point — we only
+// inject when there's no `:` after the `@` boundary at all.
+func injectDefaultPort(dest, defPort string) string {
+	// Match the @-boundary; everything after must contain a colon to be
+	// considered well-formed. If it does not, append :defPort.
+	at := -1
+	for i := 0; i < len(dest); i++ {
+		if dest[i] == '@' {
+			at = i
+			break
+		}
+	}
+	if at < 0 || at == len(dest)-1 {
+		return dest // let parseSSHDestination produce the real error
+	}
+	host := dest[at+1:]
+	for i := 0; i < len(host); i++ {
+		if host[i] == ':' {
+			return dest // already has a port (or IPv6 with port)
+		}
+	}
+	return dest + ":" + defPort
+}
+
+// resolveSSHIdentity loads the client SK with this precedence:
+//  1. --sk flag, when explicitly set (non-zero).
+//  2. DMSGPTY_SK env var, when --sk is unset.
+//  3. The local visor's SK from skywire-config.json, when
+//     useVisorKey is true (the default — matches the user-friendly
+//     "no separate identity to manage" feel of ssh + key agent).
+//  4. A fresh random keypair, when none of the above resolved.
+//
+// Mirrors resolveTCPIdentity in cmd/skywire-cli/commands/dmsg/pty.go
+// but defaults useVisorKey true (the existing --via-visor flag was
+// opt-in; for the ssh-shaped command the visor-borrow default is the
+// right discoverability choice).
+func resolveSSHIdentity(skFlag cipher.SecKey, useVisorKey bool) (cipher.PubKey, cipher.SecKey) {
+	var zero cipher.SecKey
+	sk := skFlag
+	if sk == zero {
+		if env := os.Getenv("DMSGPTY_SK"); env != "" {
+			_ = sk.Set(env) //nolint:errcheck,gosec
+		}
+	}
+	if sk == zero && useVisorKey {
+		confPath := visorconfig.SkywireConfig()
+		conf, err := visorconfig.ReadFile(confPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ssh: --visor-key read %s: %v\n", confPath, err) //nolint:errcheck
+			os.Exit(1)
+		}
+		if conf.SK == zero {
+			fmt.Fprintf(os.Stderr, "ssh: --visor-key: visor config %s has empty SK\n", confPath) //nolint:errcheck
+			os.Exit(1)
+		}
+		sk = conf.SK
+	}
+	if sk == zero {
+		pk, fresh := cipher.GenerateKeyPair()
+		return pk, fresh
+	}
+	pk, err := sk.PubKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ssh: failed to derive PK from --sk: %v\n", err) //nolint:errcheck
+		os.Exit(1)
+	}
+	return pk, sk
+}
+
+// reportSSHExec is the exec-mode result-renderer. Mirrors
+// reportExecResult in cmd/skywire-cli/commands/dmsg/pty.go but lives
+// here so this command can stand alone if dmsg/pty.go is ever split
+// into a separate binary. Local exit code mirrors the remote
+// command's exit code (0 / N / 124 timeout / 1 RPC error).
+func reportSSHExec(cmd *cobra.Command, resp *dmsgpty.CommandExecResult) {
+	if len(resp.Stdout) > 0 {
+		_, _ = cmd.OutOrStdout().Write(resp.Stdout) //nolint:errcheck
+	}
+	if len(resp.Stderr) > 0 {
+		_, _ = cmd.ErrOrStderr().Write(resp.Stderr) //nolint:errcheck
+	}
+	if resp.StdoutTruncated {
+		fmt.Fprintf(cmd.ErrOrStderr(), "[stdout truncated at 16MiB]\n") //nolint:errcheck
+	}
+	if resp.StderrTruncated {
+		fmt.Fprintf(cmd.ErrOrStderr(), "[stderr truncated at 16MiB]\n") //nolint:errcheck
+	}
+	if resp.TimedOut {
+		fmt.Fprintf(cmd.ErrOrStderr(), "[timed out after %dms]\n", resp.DurationMS) //nolint:errcheck
+		os.Exit(124)
+	}
+	if resp.ExitCode != 0 {
+		os.Exit(resp.ExitCode)
+	}
+}

--- a/cmd/skywire-cli/commands/sshd/sshd.go
+++ b/cmd/skywire-cli/commands/sshd/sshd.go
@@ -1,0 +1,284 @@
+// Package clisshd cmd/skywire-cli/commands/sshd/sshd.go — `skywire cli
+// sshd`, the OpenSSH-equivalent server over skywire identity. Thin
+// wrapper around dmsgpty.Host's direct-TCP entry point (PR #2559)
+// with sensible defaults for the standalone-daemon shape:
+//
+//   - TCP-only: no dmsg.Client, no dmsg listener (the visor or the
+//     standalone dmsgpty-host already handle the overlay path; sshd
+//     is for the direct-TCP case operators reach for ssh-style).
+//   - Identity defaulted to the local visor's SK so operators don't
+//     manage a separate keypair; --sk-from-visor accepts an explicit
+//     path, otherwise the default skywire-config.json is read.
+//   - Whitelist read from the dmsgpty config or supplied inline with
+//     --allow <pk>,<pk>; same data shape as authorized_keys.
+//
+// For dual-mode (dmsg + TCP) operators, use the visor's embedded
+// Dmsgpty.SshListen or the lower-level `dmsgpty-host` binary directly.
+// This command is intentionally narrow.
+package clisshd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// jsonDecode is a tiny wrapper over encoding/json that doesn't
+// require importing dmsgpty's jsoniter alias just for this one call.
+func jsonDecode(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}
+
+// Flags.
+var (
+	sshdListen     string
+	sshdSKFromConf string
+	sshdAllow      []string
+	sshdConfPath   string
+	sshdLog        string
+)
+
+func init() {
+	RootCmd.Flags().SortFlags = false
+	RootCmd.Flags().StringVarP(&sshdListen, "listen", "l", ":2022",
+		"TCP listen address (e.g. :2022, 0.0.0.0:2022, 127.0.0.1:2022)")
+	RootCmd.Flags().StringVar(&sshdSKFromConf, "sk-from-visor", "",
+		"path to a skywire-config.json whose .sk we use as the server identity; empty means try the default "+visorconfig.SkywireConfig())
+	RootCmd.Flags().StringSliceVar(&sshdAllow, "allow", nil,
+		"comma-separated client PKs that may connect (authorized_keys equivalent); merged with --conf's whitelist if both are set")
+	RootCmd.Flags().StringVarP(&sshdConfPath, "conf", "c", "",
+		"optional dmsgpty config.json with whitelist + identity; --allow + --sk-from-visor override matching fields")
+	RootCmd.Flags().StringVar(&sshdLog, "log-level", "info",
+		"log level: trace|debug|info|warn|error")
+}
+
+// RootCmd is `skywire cli sshd` — OpenSSH-equivalent server.
+//
+// Registered under skywire-cli's root alongside `cli ssh` (client).
+// Compared to OpenSSH's sshd:
+//
+//	sshd_config Port      ↔ --listen
+//	authorized_keys       ↔ --allow / --conf's whitelist
+//	host key              ↔ --sk-from-visor (or the default visor SK)
+//	HostbasedAuthentication ↔ noise XK pins both sides via PK
+var RootCmd = &cobra.Command{
+	Use:   "sshd",
+	Short: "Run a direct-TCP dmsgpty server (ssh-equivalent daemon)",
+	Long: `skywire cli sshd — OpenSSH-equivalent server over skywire identity.
+
+Binds a TCP port and serves the dmsgpty protocol over it, gated by an
+XK noise handshake against this server's PK + a whitelist of client
+PKs. The protocol underneath is identical to the dmsg-overlay
+dmsgpty-host; sshd is the discoverable, ssh-shaped surface over the
+direct-TCP entry point.
+
+Use this when:
+  - You want a peer-to-peer remote shell that doesn't require running
+    a full skywire visor on the server (or that runs ALONGSIDE one,
+    sharing the visor's PK without contending for the dmsg-disc entry).
+  - You have direct IP reachability to the server and want lower
+    latency than the dmsg overlay path.
+  - You're scripting ssh-like access into your skywire fleet.
+
+Use the visor's embedded dmsgpty.ssh_listen field instead when:
+  - You want the same port served by your already-running visor.
+  - You want the dmsg-overlay path AND the TCP path on the same
+    process (sshd is TCP-only by design).
+
+Examples:
+  # Run on :2022 with two PKs allowed, identity from default visor config:
+  skywire cli sshd --listen :2022 --allow 02f9...,03d1...
+
+  # Use a non-default visor config for the server identity:
+  skywire cli sshd --listen :2022 --sk-from-visor /etc/skywire/skywire.json --allow 02f9...
+
+  # Use a standalone dmsgpty config.json for both identity AND whitelist:
+  skywire cli sshd --listen :2022 --conf /etc/skywire/dmsgpty.json`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if sshdListen == "" {
+			return fmt.Errorf("sshd: --listen is required")
+		}
+
+		log := logging.MustGetLogger("sshd")
+		if lvl, err := logging.LevelFromString(sshdLog); err == nil {
+			logging.SetLevel(lvl)
+		}
+
+		// Resolve server identity (the "host key"). Precedence:
+		// 1. --conf <path>'s .sk if present.
+		// 2. --sk-from-visor <path>'s .sk if set, else the default
+		//    visor config's .sk.
+		sk, err := resolveServerSK(sshdConfPath, sshdSKFromConf)
+		if err != nil {
+			return err
+		}
+		pk, err := sk.PubKey()
+		if err != nil {
+			return fmt.Errorf("sshd: derive PK from SK: %w", err)
+		}
+
+		// Build the whitelist. --allow is the inline form; --conf
+		// supplies the file-based form; both are unioned.
+		wl, err := buildSshdWhitelist(sshdConfPath, sshdAllow)
+		if err != nil {
+			return err
+		}
+
+		// Standalone-TCP host: nil dmsg.Client. The TCP entry point
+		// in pkg/dmsg/dmsgpty/host_tcp.go nil-guards the dmsgC
+		// access at #2569, so this is supported.
+		host := dmsgpty.NewHost(nil, wl)
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		log.WithField("addr", sshdListen).
+			WithField("pk", pk.String()).
+			WithField("whitelist_size", len(sshdAllow)).
+			Info("sshd: listening")
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		errCh := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			errCh <- host.ListenAndServeTCP(ctx, sshdListen, pk, sk)
+		}()
+
+		select {
+		case <-ctx.Done():
+			log.Info("sshd: shutting down on signal")
+		case err := <-errCh:
+			if err != nil {
+				return fmt.Errorf("sshd: listen %s: %w", sshdListen, err)
+			}
+		}
+		wg.Wait()
+		return nil
+	},
+}
+
+// resolveServerSK loads the server's SK with this precedence:
+//  1. If confPath is set and its .sk is non-empty, use that (a
+//     standalone dmsgpty config.json).
+//  2. Otherwise, if skFromConfPath is set, read .sk from that path
+//     (a skywire-config.json).
+//  3. Otherwise, fall back to the default skywire-config.json
+//     (visorconfig.SkywireConfig()). This is the friendly default —
+//     operators with a visor installed don't need extra flags.
+func resolveServerSK(confPath, skFromConfPath string) (cipher.SecKey, error) {
+	var zero cipher.SecKey
+	if confPath != "" {
+		c, err := readDmsgptyConf(confPath)
+		if err == nil && c.SK != "" {
+			var sk cipher.SecKey
+			if err := sk.Set(c.SK); err != nil {
+				return zero, fmt.Errorf("sshd: --conf %s sk invalid: %w", confPath, err)
+			}
+			return sk, nil
+		}
+	}
+	path := skFromConfPath
+	if path == "" {
+		path = visorconfig.SkywireConfig()
+	}
+	conf, err := visorconfig.ReadFile(path)
+	if err != nil {
+		return zero, fmt.Errorf("sshd: read visor config %s: %w (use --sk-from-visor or --conf)", path, err)
+	}
+	if conf.SK == zero {
+		return zero, fmt.Errorf("sshd: visor config %s has empty SK", path)
+	}
+	return conf.SK, nil
+}
+
+// buildSshdWhitelist merges --allow (inline) and --conf's WL (file).
+// Returns an in-memory whitelist (dmsgpty.NewMemoryWhitelist) so
+// the host doesn't write back to the conf file on the
+// allow/disallow RPCs the CLI exposes for the dmsg-overlay path.
+//
+// Returns an error rather than an empty whitelist when nothing is
+// specified — refusing to start an open server is the safer default
+// (anyone with the server's address + a fresh keypair could otherwise
+// connect, since noise alone doesn't authorize, only the wl does).
+func buildSshdWhitelist(confPath string, inline []string) (dmsgpty.Whitelist, error) {
+	keys := make(map[cipher.PubKey]struct{})
+
+	if confPath != "" {
+		c, err := readDmsgptyConf(confPath)
+		if err != nil {
+			return nil, fmt.Errorf("sshd: --conf %s: %w", confPath, err)
+		}
+		for _, s := range c.WL {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			var pk cipher.PubKey
+			if err := pk.Set(s); err != nil {
+				return nil, fmt.Errorf("sshd: --conf %s: invalid pk %q: %w", confPath, s, err)
+			}
+			keys[pk] = struct{}{}
+		}
+	}
+
+	for _, raw := range inline {
+		for _, s := range strings.Split(raw, ",") {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			var pk cipher.PubKey
+			if err := pk.Set(s); err != nil {
+				return nil, fmt.Errorf("sshd: --allow %q invalid: %w", s, err)
+			}
+			keys[pk] = struct{}{}
+		}
+	}
+
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("sshd: refusing to start with an empty whitelist (use --allow <pk>,... or --conf <path>)")
+	}
+
+	// Materialize into an in-memory whitelist.
+	pks := make([]cipher.PubKey, 0, len(keys))
+	for pk := range keys {
+		pks = append(pks, pk)
+	}
+	wl := dmsgpty.NewMemoryWhitelist()
+	if err := wl.Add(pks...); err != nil {
+		return nil, fmt.Errorf("sshd: build whitelist: %w", err)
+	}
+	return wl, nil
+}
+
+// readDmsgptyConf reads a standalone dmsgpty config.json. Wraps
+// the public DefaultConfig to avoid duplicating the JSON shape.
+func readDmsgptyConf(path string) (dmsgpty.Config, error) {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		return dmsgpty.Config{}, err
+	}
+	defer f.Close() //nolint:errcheck
+	conf := dmsgpty.DefaultConfig()
+	if err := jsonDecode(f, &conf); err != nil {
+		return dmsgpty.Config{}, err
+	}
+	return conf, nil
+}

--- a/pkg/dmsg/dmsgpty/cli_tcp.go
+++ b/pkg/dmsg/dmsgpty/cli_tcp.go
@@ -28,7 +28,7 @@ import (
 const tcpDialTimeout = 10 * time.Second
 
 // ExecRemoteTCP runs a one-shot command on a remote visor via the
-// dmsgpty-host's direct-TCP entry point (Dmsgpty.TCPListen).
+// dmsgpty-host's direct-TCP entry point (Dmsgpty.SshListen).
 // rPK is pinned during the noise handshake — equivalent to ssh's
 // host-key check. addr is `host:port` (any net.Dial-acceptable form).
 // localPK/localSK is the caller's identity; the remote's whitelist

--- a/pkg/dmsg/dmsgpty/conf.go
+++ b/pkg/dmsg/dmsgpty/conf.go
@@ -22,13 +22,17 @@ type Config struct {
 	PK           string   `json:"pk"`
 	WL           []string `json:"wl"`
 
-	// TCPListen, when non-empty, brings up the direct-TCP entry point
+	// SshListen, when non-empty, brings up the direct-TCP entry point
 	// alongside the dmsg-overlay listener — same shape and semantics
 	// as the visor-embedded version (see pkg/visor/visorconfig:
-	// Dmsgpty.TCPListen). net.Listen syntax: ":2022",
+	// Dmsgpty.SshListen). net.Listen syntax: ":2022",
 	// "0.0.0.0:2022", "127.0.0.1:2022", IPv6 forms all work. Empty
 	// (default) disables the TCP entry point: only the dmsg-overlay
 	// path is served, matching legacy behavior.
+	//
+	// This is the surface that `skywire cli ssh` (client) and
+	// `skywire cli sshd` (server) expose as the OpenSSH-equivalent
+	// shell over skywire.
 	//
 	// Auth flow per accepted TCP connection:
 	//   1. XK noise handshake using this host's PK/SK. The client
@@ -37,7 +41,7 @@ type Config struct {
 	//   2. The handshake-derived client PK is checked against the
 	//      same whitelist the dmsg-overlay accept loop uses. No
 	//      separate ACL.
-	TCPListen string `json:"tcplisten,omitempty"`
+	SshListen string `json:"ssh_listen,omitempty"`
 }
 
 // DefaultConfig is used to populate the config struct with its default values

--- a/pkg/dmsg/dmsgpty/host_tcp.go
+++ b/pkg/dmsg/dmsgpty/host_tcp.go
@@ -4,7 +4,7 @@
 //
 // The dmsg-overlay path (ListenAndServe on a dmsg port) is the
 // primary entry. This file adds a parallel listener that operators
-// can enable via Dmsgpty.TCPListen in the visor config. The
+// can enable via Dmsgpty.SshListen in the visor config. The
 // handshake model intentionally mirrors ssh's:
 //
 //   - The CLIENT pins the SERVER's PK (passed as RemotePK on the
@@ -187,10 +187,17 @@ func (h *Host) serveTCPConn(
 		log.WithError(err).Debug("dmsgpty-tcp: noise handshake failed.")
 		return
 	}
-	if rw.Buffered() > 0 {
-		log.Warn("dmsgpty-tcp: noise handshake left buffered bytes — abort.")
-		return
-	}
+	// rw.Buffered() may be non-zero here when the client (whose
+	// writeRequest immediately follows the handshake) has already
+	// shipped its first application frame and rawInput's bufio reader
+	// has prefetched it during the handshake's final read. Those
+	// bytes are encrypted noise frames waiting to be decrypted by
+	// the next rw.Read — letting them through is correct; aborting
+	// here was the source of the intermittent
+	// "NewPtyClient: failed to read response: EOF" the client saw
+	// on fast/local TCP paths. The original defensive check assumed
+	// post-handshake buffered bytes were stale or attacker-injected,
+	// but ReadRawFrame would fail-closed on any garbage anyway.
 	rPK := rw.RemoteStatic()
 	log = log.WithField("remote_pk", rPK.String())
 

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -740,11 +740,12 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	// Direct-TCP dmsgpty entry point — operator opts in via
-	// Dmsgpty.TCPListen ("" disables). Same whitelist as the
+	// Dmsgpty.SshListen ("" disables). Same whitelist as the
 	// dmsg-overlay path; XK-noise handshake gates the accepted PK
 	// before the stream reaches the dmsgpty mux. See
-	// dmsgpty/host_tcp.go for the per-connection flow.
-	if tcpAddr := conf.TCPListen; tcpAddr != "" {
+	// dmsgpty/host_tcp.go for the per-connection flow. Exposed at
+	// CLI as `skywire cli ssh` / `skywire cli sshd`.
+	if tcpAddr := conf.SshListen; tcpAddr != "" {
 		tcpCtx, tcpCancel := context.WithCancel(context.Background()) //nolint:gosec // cancel called in pushCloseStack
 		tcpWg := new(sync.WaitGroup)
 		tcpWg.Add(1)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -69,11 +69,15 @@ type Dmsgpty struct {
 	CLIAddr   string          `json:"cli_address"`
 	Whitelist []cipher.PubKey `json:"whitelist"`
 
-	// TCPListen, when non-empty, brings up a direct-TCP entry point
+	// SshListen, when non-empty, brings up a direct-TCP entry point
 	// for the dmsgpty / dmsgscp / dmsgcat protocols, separate from the
 	// dmsg-overlay path. Listening address in net.Listen format —
 	// `:2022`, `0.0.0.0:2022`, `127.0.0.1:2022`, etc. Empty (default)
 	// disables it: only the dmsg-overlay entry point is served.
+	//
+	// This is the surface that `skywire cli ssh` (client) and
+	// `skywire cli sshd` (server) expose as the OpenSSH-equivalent
+	// shell over skywire identity.
 	//
 	// Auth flow per accepted TCP connection:
 	//   1. Noise XK handshake using the visor's identity keypair —
@@ -86,11 +90,10 @@ type Dmsgpty struct {
 	//      mux so dmsgpty / dmsgscp / dmsgcat clients work uniformly
 	//      over either transport.
 	//
-	// Motivation: ssh-equivalent over skywire identity. Operators who
-	// have direct IP reachability to a peer can `cli dmsg pty exec`
-	// (and friends) over TCP — no dmsg-discovery dependency, lower
-	// latency for known endpoints, same PK-based auth model.
-	TCPListen string `json:"tcp_listen,omitempty"`
+	// Motivation: operators who have direct IP reachability to a peer
+	// can `cli ssh <pk>@<host>:<port>` — no dmsg-discovery dependency,
+	// lower latency for known endpoints, same PK-based auth model.
+	SshListen string `json:"ssh_listen,omitempty"`
 }
 
 // Dmsgscp configures the dmsgscp-host (scp-over-dmsg daemon).


### PR DESCRIPTION
## Summary

Two new commands inside the existing \`skywire cli\` surface that expose the OpenSSH-equivalent shell over skywire identity:

\`\`\`
skywire cli ssh  <pk>@<host>:<port> [-- <command>]   # client
skywire cli sshd --listen :2022 --allow <pk>,...     # server
\`\`\`

These are thin discoverable aliases over the existing direct-TCP dmsgpty entry point (#2559 / #2560). No new protocol, no new daemon — just the right command surface so operators looking for "ssh over skywire" find it instead of \`cli dmsg pty exec --via tcp://...\`.

## OpenSSH equivalence (documented in --help)

| OpenSSH | skywire |
|---|---|
| ssh's host-key check | Noise XK pins server PK from the destination URL |
| authorized_keys | dmsgpty whitelist on the server side |
| password / pubkey | client PK alone, defaulted from local visor's SK |
| TCP :22 default | TCP :2022 default (--port to override) |
| \`ssh -t\` / \`ssh <cmd>\` | no positional command → interactive pty; positional command → exec |

## Config rename — hard cut

The opt-in field was never enabled in production, so renaming is free:

- \`pkg/visor/visorconfig\`: \`Dmsgpty.TCPListen\` → \`Dmsgpty.SshListen\` (json \`tcp_listen\` → \`ssh_listen\`)
- \`pkg/dmsg/dmsgpty\`: \`Config.TCPListen\` → \`Config.SshListen\` (json \`tcplisten\` → \`ssh_listen\`)
- All callers (\`pkg/visor/init_dmsg\`, \`cmd/dmsg/dmsgpty-host\`) updated.

Operators with existing configs need to rename the field in their JSON.

## Design choices

- **Two sibling commands**, not \`cli ssh\` with a daemon subcommand. Mirrors OpenSSH's \`ssh\` / \`sshd\` split exactly, keeps each command's help focused on one role.
- **\`--visor-key\` defaults ON** on the client. Matches the "no separate identity to manage" ssh + key-agent feel. \`--no-visor-key\` opts out for explicit \`--sk\` use.
- **\`cli sshd\` refuses to start with an empty whitelist** — safer default than serving an open shell.
- **\`cli sshd\` is TCP-only** by design (\`--no-dmsg\` baked in). Operators who want dual dmsg+TCP serve the same protocol from a visor (with \`dmsgpty.ssh_listen\` set) or run \`dmsgpty-host\` directly.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./pkg/dmsg/dmsgpty/... ./cmd/skywire-cli/...\` green.
- [x] \`make lint\` clean (0 issues).
- [x] Live smoke test: \`skywire cli ssh <pk>@<host>:2022 -- whoami\` against a peer visor returned the expected output.
- [ ] Live: rebuild + restart peers' visors so they pick up the renamed \`dmsgpty.ssh_listen\` field; verify the TCP entry point binds.