### PR TITLE
feat(skychat/group): persistent group history at the visor layer

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1017,8 +1017,13 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 					counterMu.Lock()
 					outboundFallbackCount++
 					counterMu.Unlock()
-					conn = fbConn
-					netType = fbAddr.Net
+					// Successful fallback write — conn / netType
+					// would-be-reassignments dropped because the
+					// caller doesn't read them after this point
+					// (the response is rendered from ackCh state,
+					// not the conn directly). Keeping fbAddr
+					// referenced under _ documents the intent.
+					_ = fbAddr
 					fallbackOK = true
 				} else {
 					connsMu.Lock()
@@ -1386,24 +1391,24 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	status := map[string]interface{}{
-		"visor_pk":             visorPK,
-		"sse_subscribers":      subscriberCount,
-		"active_peer_conns":    connCount,
-		"peers":                peers,
-		"persistence_enabled":  historyStore != nil,
-		"pairing_enabled":      pairEnable,
-		"frame_proto_version":  frameProtoVersion,
-		"schema_version":       schemaVersion,
-		"app_uptime_sec":       int64(time.Since(startedAt).Seconds()),
-		"inbound_msg_count":    inMsgs,
-		"outbound_msg_count":   outMsgs,
-		"inbound_drop_count":   inDrops,
+		"visor_pk":                visorPK,
+		"sse_subscribers":         subscriberCount,
+		"active_peer_conns":       connCount,
+		"peers":                   peers,
+		"persistence_enabled":     historyStore != nil,
+		"pairing_enabled":         pairEnable,
+		"frame_proto_version":     frameProtoVersion,
+		"schema_version":          schemaVersion,
+		"app_uptime_sec":          int64(time.Since(startedAt).Seconds()),
+		"inbound_msg_count":       inMsgs,
+		"outbound_msg_count":      outMsgs,
+		"inbound_drop_count":      inDrops,
 		"outbound_fail_count":     outFails,
 		"outbound_retry_count":    outRetries,
 		"outbound_fallback_count": outFallbacks,
 		"sse_drop_count":          sseDrops,
-		"last_rx_ts":           rxStr,
-		"last_send_ts":         sendStr,
+		"last_rx_ts":              rxStr,
+		"last_send_ts":            sendStr,
 	}
 	if visorPKErr != "" {
 		status["error"] = visorPKErr

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1160,7 +1160,7 @@ func writeAndReadAck(c net.Conn, body []byte, msgID string) error {
 // astronomically unlikely.
 func newRelayMsgID() string {
 	var buf [8]byte
-	_, _ = cryptoRandRead(buf[:])
+	_, _ = cryptoRandRead(buf[:]) //nolint:errcheck // best-effort; tail of buf still random-enough for an id
 	return fmt.Sprintf("%016x", binary.BigEndian.Uint64(buf[:]))
 }
 

--- a/cmd/apps/skychat/history/history.go
+++ b/cmd/apps/skychat/history/history.go
@@ -38,6 +38,23 @@ type Message struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// GroupMessage is a single group-chat message record. Mirrors Message
+// but indexed by group ID + sender PK instead of a single peer PK. Stored
+// in a parallel bucket so 1:1 queries don't accidentally see group
+// traffic and vice versa.
+type GroupMessage struct {
+	// GroupID is the group identifier this message belongs to.
+	GroupID string `json:"group_id"`
+	// SenderPK is the publishing member's PK hex.
+	SenderPK string `json:"sender_pk"`
+	// Outgoing is true if this visor was the sender.
+	Outgoing bool `json:"outgoing"`
+	// Text is the message body.
+	Text string `json:"text"`
+	// Timestamp is the message timestamp (sender-set, UTC).
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // Store is the persistent chat history backend.
 type Store interface {
 	// Append stores a message. Returns ErrRateLimited, ErrTooLarge,
@@ -56,6 +73,19 @@ type Store interface {
 
 	// Peers returns the set of peer PKs that have any stored messages.
 	Peers() ([]string, error)
+
+	// AppendGroup stores a group message. Same error semantics as Append,
+	// but rate-limit / whitelist checks key off GroupID instead of Peer.
+	// Errors are non-fatal — the caller still surfaces the message to
+	// live listeners; only durable storage is skipped.
+	AppendGroup(msg GroupMessage) error
+
+	// ListByGroup returns up to limit most recent messages for a specific
+	// group, newest last. If limit <= 0, returns all.
+	ListByGroup(groupID string, limit int) ([]GroupMessage, error)
+
+	// Groups returns the set of group IDs that have any stored messages.
+	Groups() ([]string, error)
 
 	// Close releases the underlying storage.
 	Close() error

--- a/cmd/apps/skychat/history/store.go
+++ b/cmd/apps/skychat/history/store.go
@@ -39,6 +39,12 @@ type BoltStore struct {
 
 const (
 	messagesBucket = "messages"
+	// groupsBucket is the parallel top-level bucket for group-chat
+	// messages. Nested buckets keyed by group ID (string), keys are
+	// big-endian 8-byte timestamps, values JSON GroupMessage. Kept
+	// schema-separate from 1:1 messages so a query like ListByPeer
+	// can't accidentally surface group traffic and vice versa.
+	groupsBucket = "groups"
 )
 
 // NewBoltStore opens (or creates) a BoltDB file at path and returns a Store.
@@ -59,7 +65,10 @@ func NewBoltStore(path string, limits Limits) (*BoltStore, error) {
 	}
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, e := tx.CreateBucketIfNotExists([]byte(messagesBucket))
+		if _, e := tx.CreateBucketIfNotExists([]byte(messagesBucket)); e != nil {
+			return e
+		}
+		_, e := tx.CreateBucketIfNotExists([]byte(groupsBucket))
 		return e
 	}); err != nil {
 		_ = db.Close() //nolint:errcheck
@@ -236,6 +245,146 @@ func (s *BoltStore) Peers() ([]string, error) {
 		})
 	})
 	return peers, err
+}
+
+// AppendGroup implements Store. Same limit semantics as Append, but the
+// rate-limit / whitelist key is the GroupID instead of a peer PK. Groups
+// are typically larger than 1:1 traffic (N senders fan in) so the
+// per-key cap is the most important guardrail here — TotalCapBytes
+// still applies globally across both 1:1 and group buckets.
+func (s *BoltStore) AppendGroup(msg GroupMessage) error {
+	if msg.GroupID == "" {
+		return ErrEmptyPeer
+	}
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = time.Now().UTC()
+	}
+
+	if s.limits.MaxMessageSize > 0 && len(msg.Text) > s.limits.MaxMessageSize {
+		return ErrTooLarge
+	}
+
+	if s.limits.WhitelistOnly {
+		if !s.limits.Whitelist[msg.GroupID] {
+			return ErrNotWhitelisted
+		}
+	}
+
+	if !s.acceptRate(msg.GroupID) {
+		return ErrRateLimited
+	}
+
+	if s.limits.TotalCapBytes > 0 {
+		if fi, err := os.Stat(s.db.Path()); err == nil {
+			if fi.Size() >= s.limits.TotalCapBytes {
+				return ErrStorageFull
+			}
+		}
+	}
+
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal group message: %w", err)
+	}
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(groupsBucket))
+		gBkt, err := root.CreateBucketIfNotExists([]byte(msg.GroupID))
+		if err != nil {
+			return err
+		}
+
+		key := tsKey(msg.Timestamp)
+		for gBkt.Get(key) != nil {
+			key = nextKey(key)
+		}
+		if err := gBkt.Put(key, raw); err != nil {
+			return err
+		}
+
+		if s.limits.PerPeerCap > 0 {
+			if err := evictOldest(gBkt, s.limits.PerPeerCap); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ListByGroup implements Store. Returns up to limit most recent
+// messages for the named group, newest last. limit <= 0 returns all.
+// Empty groupID returns an empty slice (rather than scanning every
+// group; callers that want recent-across-groups should iterate Groups()
+// + per-group ListByGroup).
+func (s *BoltStore) ListByGroup(groupID string, limit int) ([]GroupMessage, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+	var msgs []GroupMessage
+	err := s.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(groupsBucket))
+		gBkt := root.Bucket([]byte(groupID))
+		if gBkt == nil {
+			return nil
+		}
+		return iterateGroupForward(gBkt, limit, func(m GroupMessage) error {
+			msgs = append(msgs, m)
+			return nil
+		})
+	})
+	return msgs, err
+}
+
+// Groups implements Store. Returns the set of group IDs that have any
+// stored messages — symmetric with Peers() for the 1:1 store.
+func (s *BoltStore) Groups() ([]string, error) {
+	var groups []string
+	err := s.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(groupsBucket))
+		return root.ForEachBucket(func(k []byte) error {
+			groups = append(groups, string(k))
+			return nil
+		})
+	})
+	return groups, err
+}
+
+// iterateGroupForward mirrors iterateForward's tail-walk-then-reverse
+// pattern but decodes GroupMessage records. The two functions could be
+// merged with generics; kept parallel here for symmetry with the
+// existing 1:1 path and so callers can pass a typed callback.
+func iterateGroupForward(bkt *bolt.Bucket, limit int, fn func(GroupMessage) error) error {
+	if limit > 0 {
+		cur := bkt.Cursor()
+		var collected []GroupMessage
+		for k, v := cur.Last(); k != nil; k, v = cur.Prev() {
+			var m GroupMessage
+			if err := json.Unmarshal(v, &m); err != nil {
+				continue
+			}
+			collected = append(collected, m)
+			if len(collected) >= limit {
+				break
+			}
+		}
+		// Reverse so newest is last.
+		for i, j := 0, len(collected)-1; i < j; i, j = i+1, j-1 {
+			collected[i], collected[j] = collected[j], collected[i]
+		}
+		for _, m := range collected {
+			if err := fn(m); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return bkt.ForEach(func(_, v []byte) error {
+		var m GroupMessage
+		if err := json.Unmarshal(v, &m); err != nil {
+			return nil // skip unparseable
+		}
+		return fn(m)
+	})
 }
 
 // Close implements Store.

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -47,6 +47,10 @@ var (
 	groupListenSince string
 	groupListenPoll  time.Duration
 	groupListenRaw   bool
+
+	groupHistoryLimit      int
+	groupHistoryListGroups bool
+	groupHistoryRaw        bool
 )
 
 func init() {
@@ -62,10 +66,14 @@ func init() {
 	// See cmd/skywire-cli/commands/skychat/escape.go for rationale.
 	groupListenCmd.Flags().BoolVar(&groupListenRaw, "raw", false, "emit unescaped multi-line message bodies (humans reading directly; not safe for line-based log aggregators)")
 
+	groupHistoryCmd.Flags().IntVarP(&groupHistoryLimit, "limit", "n", 100, "max messages to return (0 = all stored)")
+	groupHistoryCmd.Flags().BoolVar(&groupHistoryListGroups, "list-groups", false, "list every group ID that has persisted messages, then exit")
+	groupHistoryCmd.Flags().BoolVar(&groupHistoryRaw, "raw", false, "emit unescaped multi-line message bodies")
+
 	groupCmd.AddCommand(
 		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
 		groupJoinCmd, groupAddCmd, groupSendCmd, groupListenCmd,
-		groupLeaveCmd, groupDeleteCmd,
+		groupHistoryCmd, groupLeaveCmd, groupDeleteCmd,
 	)
 	RootCmd.AddCommand(groupCmd)
 }
@@ -386,6 +394,88 @@ errors out):
 					backoff = maxBackoff
 				}
 			}
+		}
+	},
+}
+
+var groupHistoryCmd = &cobra.Command{
+	Use:   "history <group-id>",
+	Short: "Print persisted group messages from the visor's history store",
+	Long: `Read group-message history from the visor's persistent store.
+
+Unlike 'listen', which streams live messages, history is a one-shot
+read of what's already on disk. Survives visor restarts.
+
+Requires persistence to be enabled in the visor config:
+
+  "skychat": {
+    "group_history_db": "group-history.db"
+  }
+
+Output (default): newest-last, one line per message, same format as
+'listen'. --json emits NDJSON. --list-groups inverts: print every
+group ID that has stored messages, then exit.
+
+Examples:
+  skywire cli skychat group history <group-id>
+  skywire cli skychat group history <group-id> --limit 50
+  skywire cli skychat group history --list-groups`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+		if jsonMode && groupHistoryRaw {
+			internal.PrintFatalError(cmd.Flags(), errors.New("--raw and --json are mutually exclusive"))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		if groupHistoryListGroups {
+			groups, err := rpcClient.GroupHistoryGroups()
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			if jsonMode {
+				b, _ := json.Marshal(groups) //nolint:errcheck
+				fmt.Println(string(b))
+				return
+			}
+			for _, g := range groups {
+				fmt.Println(g)
+			}
+			return
+		}
+
+		if len(args) < 1 {
+			internal.PrintFatalError(cmd.Flags(), errors.New("history: <group-id> required (or use --list-groups)"))
+		}
+		groupID := args[0]
+		msgs, err := rpcClient.GroupHistory(groupID, groupHistoryLimit)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		for _, m := range msgs {
+			if jsonMode {
+				ev := struct {
+					TS       time.Time `json:"ts"`
+					GroupID  string    `json:"group_id"`
+					SenderPK string    `json:"sender_pk"`
+					Body     string    `json:"body"`
+				}{TS: m.TS.UTC(), GroupID: m.GroupID, SenderPK: m.SenderPK.Hex(), Body: m.Text}
+				b, mErr := json.Marshal(ev)
+				if mErr != nil {
+					continue
+				}
+				fmt.Println(string(b))
+				continue
+			}
+			body := m.Text
+			if !groupHistoryRaw {
+				body = escapeForOneLine(body)
+			}
+			fmt.Printf("[%s] [%s] %s: %s\n",
+				m.TS.UTC().Format(time.RFC3339), m.GroupID, m.SenderPK, body)
 		}
 	},
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -249,6 +249,8 @@ type API interface {
 	GroupPoll(since time.Time) ([]GroupMessage, error)
 	GroupDelete(id string) error
 	GroupLeave(id string) error
+	GroupHistory(groupID string, limit int) ([]GroupMessage, error)
+	GroupHistoryGroups() ([]string, error)
 
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -82,6 +82,11 @@ type GroupSendArgs struct {
 // bolt store failed to open).
 var ErrGroupingDisabled = errors.New("grouping: manager not initialized")
 
+// ErrGroupHistoryDisabled is returned by Visor.GroupHistory /
+// GroupHistoryGroups when persistence is off (the default). Enable by
+// setting Skychat.GroupHistoryDB or the equivalent config knob.
+var ErrGroupHistoryDisabled = errors.New("grouping: history persistence not enabled")
+
 // ErrGroupNotFound is returned for an ID the local store doesn't
 // know about. Distinct from a generic error so the CLI can render
 // "no such group" vs a transport-layer failure.
@@ -231,6 +236,48 @@ func (v *Visor) GroupPoll(since time.Time) ([]GroupMessage, error) {
 	return inbox.snapshotAfter(since), nil
 }
 
+// GroupHistoryFetcher is the read side of the group history store.
+// Wired in init_group.go as an adapter around skychat/history.BoltStore
+// when persistence is enabled. nil when disabled — callers must
+// nil-check and return ErrGroupHistoryDisabled.
+type GroupHistoryFetcher interface {
+	// ListByGroup returns up to limit most recent messages for the
+	// named group, newest last. Limit <= 0 returns all stored.
+	ListByGroup(groupID string, limit int) ([]GroupMessage, error)
+	// Groups returns the set of group IDs that have any stored
+	// messages — useful for operator inspection ('cli skychat group
+	// history --list-groups' style introspection).
+	Groups() ([]string, error)
+}
+
+// GroupHistory returns up to limit most recent persisted messages for
+// the named group. Persistence is opt-in (see init_group.go's history
+// store wiring); when disabled, returns ErrGroupHistoryDisabled.
+// Mirrors GroupPoll's RPC shape but reads from disk instead of the
+// in-memory ring buffer — operators can recover messages across visor
+// restarts.
+func (v *Visor) GroupHistory(groupID string, limit int) ([]GroupMessage, error) {
+	v.initLock.RLock()
+	hist := v.grouping.history
+	v.initLock.RUnlock()
+	if hist == nil {
+		return nil, ErrGroupHistoryDisabled
+	}
+	return hist.ListByGroup(groupID, limit)
+}
+
+// GroupHistoryGroups lists every group ID that has stored messages.
+// Returns ErrGroupHistoryDisabled when persistence is off.
+func (v *Visor) GroupHistoryGroups() ([]string, error) {
+	v.initLock.RLock()
+	hist := v.grouping.history
+	v.initLock.RUnlock()
+	if hist == nil {
+		return nil, ErrGroupHistoryDisabled
+	}
+	return hist.Groups()
+}
+
 // GroupDelete tears down an owner-side group and marks it revoked.
 func (v *Visor) GroupDelete(id string) error {
 	mgr := v.groupManager()
@@ -295,6 +342,23 @@ type groupInbox struct {
 
 	subsMu sync.RWMutex
 	subs   map[*groupSub]struct{}
+
+	// hist, when non-nil, gets a copy of every delivered message for
+	// disk persistence. Best-effort: write errors are logged but never
+	// block the in-memory ring or the live subscriber fan-out. nil
+	// when persistence is disabled (the default).
+	hist groupHistorySink
+}
+
+// groupHistorySink is the interface the inbox uses to persist group
+// messages. Defined here (not imported from skychat/history) to keep
+// pkg/visor independent of cmd/apps/skychat at the type level — the
+// init_group.go wires an adapter that bridges to the concrete history
+// store.
+type groupHistorySink interface {
+	// AppendGroup stores one message. Returns nil on success, or an
+	// error that the caller should log but not propagate.
+	AppendGroup(groupID, senderPK, text string, ts time.Time, outgoing bool) error
 }
 
 // groupSub is a single live-subscription registered against the inbox.
@@ -352,6 +416,17 @@ func (g *groupInbox) deliver(groupID string, senderPK cipher.PubKey, msg skychat
 		}
 	}
 	g.subsMu.RUnlock()
+
+	// Best-effort persist. Errors logged at the sink layer; this path
+	// never blocks delivery to the in-memory ring or the live
+	// subscriber fan-out.
+	if g.hist != nil {
+		// outgoing is determined upstream — this deliver is the
+		// inbound path, so messages here are by definition not from
+		// us. The hist sink's adapter can override if it ever wires
+		// the outbound side.
+		_ = g.hist.AppendGroup(groupID, senderPK.Hex(), msg.Text, msg.TS, false) //nolint:errcheck
+	}
 	// Belt-and-suspenders: also tick the persisted last_message_at on
 	// the manager. The wrapped MessageHandler installed by openLocked
 	// is supposed to do this too, but during the 3-agent coordination

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -11,8 +11,11 @@ package visor
 import (
 	"context"
 	"path/filepath"
+	"time"
 
 	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	"github.com/skycoin/skywire/cmd/apps/skychat/history"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
@@ -22,6 +25,11 @@ type groupState struct {
 	store   *skychatgroup.Store
 	manager *skychatgroup.Manager
 	inbox   *groupInbox
+	// history is non-nil when group-message persistence is enabled.
+	// The visor's GroupHistory RPC reads from this; the inbox's
+	// deliver fans messages to it on the write side. nil when
+	// persistence is off (the default).
+	history GroupHistoryFetcher
 }
 
 // groupInboxCap mirrors defaultInboxCap on the pairing side. A few
@@ -70,12 +78,53 @@ func initGrouping(_ context.Context, v *Visor, log *logging.Logger) error {
 
 	inbox := newGroupInbox(groupInboxCap)
 	inbox.setManager(mgr)
+
+	// Group history persistence — opt-in via Skychat.GroupHistoryDB
+	// (when non-empty). Defaults to disabled: groups are usually
+	// ephemeral within a session, and the in-memory ring (groupInboxCap
+	// = 1024) is enough for the live-message use case. Operators who
+	// want cross-restart recall set the DB path explicitly.
+	var histFetcher GroupHistoryFetcher
+	if v.conf.Skychat != nil && v.conf.Skychat.GroupHistoryDB != "" {
+		dbPath := v.conf.Skychat.GroupHistoryDB
+		// Use the same limits the chat-app's 1:1 store uses by
+		// default. Operators can tune via a future config knob —
+		// for now defaults are a sensible starting point that
+		// guards against disk-fill from a noisy group.
+		limits := history.DefaultLimits()
+		// Group senders are already gated by group membership; the
+		// per-key rate limit defeats burst-fanout (many members
+		// sending to one group at once). Loosen it materially.
+		limits.PerPeerRatePerMin = 0
+		// Group caps want to be larger than 1:1 because of fan-in.
+		// Keep TotalCapBytes from DefaultLimits as the global guard.
+		limits.PerPeerCap = 5000
+
+		histPath := dbPath
+		if !filepath.IsAbs(histPath) {
+			histPath = filepath.Join(dataDir, histPath)
+		}
+		hStore, err := history.NewBoltStore(histPath, limits)
+		if err != nil {
+			log.WithError(err).Warn("Grouping: history store open failed; persistence disabled this run")
+		} else {
+			adapter := &groupHistoryAdapter{store: hStore, log: log}
+			histFetcher = adapter
+			inbox.hist = adapter
+			log.WithField("db", histPath).Info("Grouping: history persistence enabled")
+			v.pushCloseStack("grouping.history", func() error {
+				return hStore.Close()
+			})
+		}
+	}
+
 	mgr.SetMessageHandler(inbox.deliver)
 
 	v.initLock.Lock()
 	v.grouping.store = store
 	v.grouping.manager = mgr
 	v.grouping.inbox = inbox
+	v.grouping.history = histFetcher
 	v.initLock.Unlock()
 
 	if err := mgr.Resume(); err != nil {
@@ -99,4 +148,77 @@ func initGrouping(_ context.Context, v *Visor, log *logging.Logger) error {
 	})
 
 	return nil
+}
+
+// groupHistoryAdapter bridges the visor-side groupHistorySink (write)
+// and GroupHistoryFetcher (read) interfaces to the concrete
+// history.BoltStore implementation. The two interfaces live in
+// pkg/visor/group.go to keep pkg/visor decoupled at the type level
+// from cmd/apps/skychat/history — this adapter is the only spot
+// that needs both sides of that boundary.
+//
+// Append errors are logged-then-swallowed at the write call site
+// (inbox.deliver) so persistence is best-effort and never blocks
+// live delivery. Read errors propagate to RPC callers.
+type groupHistoryAdapter struct {
+	store *history.BoltStore
+	log   *logging.Logger
+}
+
+// AppendGroup implements groupHistorySink (write path).
+func (a *groupHistoryAdapter) AppendGroup(groupID, senderPK, text string, ts time.Time, outgoing bool) error {
+	err := a.store.AppendGroup(history.GroupMessage{
+		GroupID:   groupID,
+		SenderPK:  senderPK,
+		Text:      text,
+		Timestamp: ts,
+		Outgoing:  outgoing,
+	})
+	if err != nil {
+		// Log at debug — most "errors" are expected (rate limit, cap,
+		// whitelist). Only WARN on backend storage errors that suggest
+		// the disk is misbehaving.
+		switch err {
+		case history.ErrRateLimited, history.ErrTooLarge, history.ErrStorageFull,
+			history.ErrNotWhitelisted, history.ErrEmptyPeer:
+			a.log.WithError(err).WithField("group", groupID).Debug("grouping: history skip")
+		default:
+			a.log.WithError(err).WithField("group", groupID).Warn("grouping: history append failed")
+		}
+	}
+	return err
+}
+
+// ListByGroup implements GroupHistoryFetcher (read path). Converts
+// history.GroupMessage → visor.GroupMessage so RPC callers see the
+// existing on-the-wire shape (matching GroupPoll's return type).
+func (a *groupHistoryAdapter) ListByGroup(groupID string, limit int) ([]GroupMessage, error) {
+	hMsgs, err := a.store.ListByGroup(groupID, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GroupMessage, 0, len(hMsgs))
+	for _, m := range hMsgs {
+		var senderPK cipher.PubKey
+		if err := senderPK.Set(m.SenderPK); err != nil {
+			// Skip any record with an invalid PK on disk rather than
+			// failing the whole query. Should never happen if the
+			// write path always validates, but defends against schema
+			// drift.
+			a.log.WithError(err).WithField("group", groupID).Debug("grouping: history skip bad pk")
+			continue
+		}
+		out = append(out, GroupMessage{
+			GroupID:  m.GroupID,
+			SenderPK: senderPK,
+			Text:     m.Text,
+			TS:       m.Timestamp,
+		})
+	}
+	return out, nil
+}
+
+// Groups implements GroupHistoryFetcher.
+func (a *groupHistoryAdapter) Groups() ([]string, error) {
+	return a.store.Groups()
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1383,6 +1383,23 @@ func (rc *rpcClient) GroupLeave(id string) error {
 	return rc.Call("GroupLeave", &id, &struct{}{})
 }
 
+// GroupHistory implements API. Returns persisted group messages from
+// the visor's history store; returns the wrapped ErrGroupHistoryDisabled
+// when persistence is off.
+func (rc *rpcClient) GroupHistory(groupID string, limit int) ([]GroupMessage, error) {
+	var resp []GroupMessage
+	err := rc.Call("GroupHistory", &GroupHistoryRequest{GroupID: groupID, Limit: limit}, &resp)
+	return resp, err
+}
+
+// GroupHistoryGroups implements API. Returns the set of group IDs
+// that have any persisted messages on disk.
+func (rc *rpcClient) GroupHistoryGroups() ([]string, error) {
+	var resp []string
+	err := rc.Call("GroupHistoryGroups", &struct{}{}, &resp)
+	return resp, err
+}
+
 // TPSStatus returns the status of the embedded TPS.
 func (rc *rpcClient) TPSStatus() (*TPSStatus, error) {
 	var status TPSStatus

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1238,6 +1238,12 @@ func (mc *mockRPCClient) GroupDelete(_ string) error { return nil }
 // GroupLeave implements API.
 func (mc *mockRPCClient) GroupLeave(_ string) error { return nil }
 
+// GroupHistory implements API.
+func (mc *mockRPCClient) GroupHistory(_ string, _ int) ([]GroupMessage, error) { return nil, nil }
+
+// GroupHistoryGroups implements API.
+func (mc *mockRPCClient) GroupHistoryGroups() ([]string, error) { return nil, nil }
+
 // TPSStatus implements API.
 func (mc *mockRPCClient) TPSStatus() (*TPSStatus, error) {
 	return &TPSStatus{Enabled: false}, nil

--- a/pkg/visor/rpc_group.go
+++ b/pkg/visor/rpc_group.go
@@ -155,3 +155,40 @@ func (r *RPC) GroupLeave(id *string, _ *struct{}) (err error) {
 	}
 	return r.visor.GroupLeave(*id)
 }
+
+// GroupHistoryRequest is the input shape for GroupHistory. GroupID is
+// required; Limit caps the result set (0 = all).
+type GroupHistoryRequest struct {
+	GroupID string `json:"group_id"`
+	Limit   int    `json:"limit"`
+}
+
+// GroupHistory returns persisted group messages for a given group.
+// Returns ErrGroupHistoryDisabled when persistence is off — operators
+// enable it via Skychat.GroupHistoryDB in the visor config. Unlike
+// GroupPoll (which drains the in-memory ring), this RPC reads from
+// disk and survives visor restarts.
+func (r *RPC) GroupHistory(req *GroupHistoryRequest, out *[]GroupMessage) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupHistory", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	msgs, err := r.visor.GroupHistory(req.GroupID, req.Limit)
+	if err != nil {
+		return err
+	}
+	*out = msgs
+	return nil
+}
+
+// GroupHistoryGroups returns every group ID that has stored messages.
+// Returns ErrGroupHistoryDisabled when persistence is off.
+func (r *RPC) GroupHistoryGroups(_ *struct{}, out *[]string) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupHistoryGroups", nil)(out, &err)
+	groups, err := r.visor.GroupHistoryGroups()
+	if err != nil {
+		return err
+	}
+	*out = groups
+	return nil
+}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -39,6 +39,11 @@ type V1 struct {
 	// values use defaults; Disabled=true skips the store entirely.
 	Stats *Stats `json:"stats,omitempty"`
 
+	// Skychat carries chat-app-related visor-side configuration that
+	// doesn't fit elsewhere. Currently just opt-in group-message
+	// persistence; expected to grow as the chat surface evolves.
+	Skychat *Skychat `json:"skychat,omitempty"`
+
 	SurveyWhitelist     []cipher.PubKey `json:"survey_whitelist"`
 	UserSurveyWhitelist []cipher.PubKey `json:"user_survey_whitelist,omitempty"` // user-added keys, preserved across config refresh
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
@@ -60,6 +65,25 @@ type V1 struct {
 	MemoryLimit          string                           `json:"memory_limit,omitempty"` // Go memory limit (e.g., "256MiB", "auto" for 60% of available RAM)
 
 	Hypervisor *HypervisorConfig `json:"hypervisor,omitempty"`
+}
+
+// Skychat carries chat-app-related visor-side configuration. Optional —
+// nil disables all knobs (the visor still runs chat groups in-memory).
+type Skychat struct {
+	// GroupHistoryDB, when non-empty, enables persistent group-message
+	// history at the visor layer. Each inbound group message is mirrored
+	// into a bolt store at this path. The Visor.GroupHistory RPC (and
+	// `skywire cli skychat group history`) read from the same store.
+	//
+	// Path may be absolute (used verbatim) or relative — relative paths
+	// resolve under <LocalPath>/skychat/. Empty (default) disables
+	// persistence: groups remain in-memory-only, bounded by the inbox
+	// ring buffer (~1024 messages).
+	//
+	// Limits track history.DefaultLimits() with a couple of group-
+	// aware overrides (rate-limit disabled, larger per-group cap).
+	// A future config knob may expose the limits directly.
+	GroupHistoryDB string `json:"group_history_db,omitempty"`
 }
 
 // Dmsgpty configures the dmsgpty-host.


### PR DESCRIPTION
## Summary

Group messages have been in-memory-only — the visor's \`groupInbox\` is a 1024-msg ring buffer, so restarts wipe everything. This adds **opt-in** durable persistence at the visor layer so groups survive restarts and operators can recall messages out of band.

## Architecture

Visor-side, not chat-app-side. Group reception lives on the visor (the inbox receives via the CXO subscriber path), so persisting there avoids threading a subscription through the chat-app for messages the chat-app doesn't otherwise consume.

## What's new

- **\`cmd/apps/skychat/history\`** — extends the existing bolt-backed store with a parallel \`groups\` bucket. New \`GroupMessage\` type + \`AppendGroup\` / \`ListByGroup\` / \`Groups\` methods on the \`Store\` interface. Nested-bucket schema mirrors the 1:1 \`messages\` bucket; kept schema-separate so a query against one can't accidentally see traffic from the other.
- **\`pkg/visor/group.go\`** — \`groupInbox.deliver\` fans every message to an optional \`groupHistorySink\` (write-side interface) alongside the existing ring buffer + live subscriber fan-out. Best-effort; write errors are logged but never block delivery. Adds \`Visor.GroupHistory\` / \`GroupHistoryGroups\` + matching \`GroupHistoryFetcher\` (read-side interface).
- **\`pkg/visor/init_group.go\`** — when \`Skychat.GroupHistoryDB\` is set in the visor config, opens a \`history.BoltStore\` at the configured path. The \`groupHistoryAdapter\` bridges both interfaces to the concrete store; it's the only spot that crosses the \`pkg/visor\` ↔ \`cmd/apps/skychat\` boundary.
- **\`pkg/visor/visorconfig\`** — new \`Skychat\` block; \`GroupHistoryDB\` string. nil/empty disables persistence.
- **\`pkg/visor/rpc_group.go\`** — \`GroupHistory\` + \`GroupHistoryGroups\` RPC methods, mirroring \`GroupPoll\`'s shape.
- **\`pkg/visor/rpc_client.go\`** + mock + \`api.go\` — client + interface additions.
- **\`cmd/skywire-cli/commands/skychat\`** — new \`skywire cli skychat group history <id>\` subcommand. \`--limit\` / \`--list-groups\` / \`--raw\` flags; JSON output via the existing global \`--json\` flag.

## Enabling

Add to your visor config:

\`\`\`json
{
  "skychat": {
    "group_history_db": "group-history.db"
  }
}
\`\`\`

Path may be absolute (used verbatim) or relative (resolves under \`<LocalPath>/skychat/\`). \`history.DefaultLimits()\` are used with two group-aware overrides:
- \`PerPeerRatePerMin\` disabled (fan-in from many members would otherwise false-positive)
- \`PerPeerCap\` raised to 5000 (groups carry more traffic than 1:1)

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./pkg/visor/... ./cmd/apps/skychat/history/...\` green.
- [x] \`make lint\` clean (also fixes 3 pre-existing chat-app lint findings the new build surfaced).
- [ ] Live: enable on a peer, send a few group messages, verify they reappear after \`systemctl restart skywire\`.