### PR TITLE
docs(specs): strip non-normative content from specifications

### DIFF
--- a/skywire-specs/specifications/02-HTTP_Authorization_Middleware.md
+++ b/skywire-specs/specifications/02-HTTP_Authorization_Middleware.md
@@ -1,98 +1,93 @@
 # HTTP Authorization Middleware
 
-Skywire is made up of multiple services and nodes. Some of these services/nodes communicate via restful interfaces, and some of the endpoints require authentication and authorization.
+Skywire is composed of multiple services and nodes. Some of these
+communicate via RESTful interfaces; some endpoints require
+authentication and authorization.
 
-As nodes in the Skywire network are identified via public keys, an appropriate approach to authentication and authorization is via public/private key cryptography. The curve to use is `secp256k1`, and when referenced by the RESTFUL endpoints, it is to be represented as a hexadecimal string format.
+Nodes are identified by public keys, so the authentication scheme
+is based on public/private key cryptography. The curve used for
+node identity is `secp256k1`; public keys are represented in RESTful
+endpoints as lowercase hexadecimal strings.
 
-These HTTP security middleware features should be implemented within the `/pkg/utils/httpauth` module of the `skywire` repository. This module not only provides server-side logic, but also client-side logic to make interaction with the server-side more streamlined.
+## Authorization protocol
 
-## Authorization Procedures
+To prevent replay attacks and unauthorized access, each remote
+entity (identified by its public key) is associated with a
+monotonically increasing *Security Nonce*. The remote entity SHALL
+sign the *Security Nonce* concatenated with the request body on
+every authenticated request.
 
-To avoid replay attacks and unauthorized access, each remote entity (represented by it's public key) is assigned an *Security Nonce* by the `httpauth` module. The remote entity is required to sign the *Security Nonce* alongside the request body on every request.
+The next expected *Security Nonce* SHALL increment by one for each
+request that the server processes successfully (HTTP 2xx response).
+On any non-2xx response, the next expected nonce SHALL NOT change.
 
-For each successful request, the next expected *Security Nonce* is to increment. The `httpauth` module is to provide an interface named `NonceStorer` to keep an record of "remote entity public key" to "next expected nonce" associations. The following is a proposed structure for `NonceStorer`;
+The initial next expected *Security Nonce* for a remote entity is
+zero. Servers MAY omit storage entries for remotes whose
+next-expected nonce is still zero.
 
-```golang
-// NonceStorer stores Incrementing Security Nonces.
-type NonceStorer interface {
+## Request headers
 
-    // IncrementNonce increments the nonce associated with the specified remote entity.
-    // It returns the next expected nonce after it has been incremented and returns error on failure.
-    IncrementNonce(ctx context.Context, remotePK cipher.PubKey) (nonce uint64, err error)
+An authenticated request SHALL carry the following headers (`SW`
+denotes Skywire):
 
-    // Nonce obtains the next expected nonce for a given remote entity (represented by public key).
-    // It returns error on failure.
-    Nonce(ctx context.Context, remotePK cipher.PubKey) (nonce uint64, err error)
+| Header      | Value |
+|-------------|-------|
+| `SW-Public` | The remote's public key, hexadecimal-encoded. |
+| `SW-Nonce`  | The current Security Nonce for this request, decimal-encoded. |
+| `SW-Sig`    | The signature, hexadecimal-encoded, over `SHA256(nonce_bytes \|\| body)`, where `nonce_bytes` is the 8-byte big-endian encoding of the nonce and `body` is the verbatim request body. |
 
-    // Count obtains the number of entries stored in the underlying database.
-    Count(ctx context.Context) (n int, err error)
-}
-```
+The server SHALL reject a request with HTTP 401 if any of the
+following hold:
 
-Take note that the only times the next-expected *Security Nonce* (for a given remote entity) is to increment, is when a successful request happens.
+- The public key in `SW-Public` is not whitelisted (when a
+  whitelist is configured).
+- The nonce in `SW-Nonce` does not match the server's next-expected
+  nonce for the entity.
+- The signature in `SW-Sig` does not verify against the
+  reconstructed `SHA256(nonce_bytes || body)` digest using the
+  declared public key.
+- The request body length exceeds the server's configured maximum
+  (when set).
 
-Initially (when no successful requests has been processed for a given remote entity), the next expected *Security Nonce* should always be zero. When it is this value, the underlying database for the `NonceStorer` implementation should not need an entry for it.
+## Nonce-recovery endpoint
 
-For every request that requires authentication and authorization in this manner, the structure `httpauth.Server` is to handle it. Specifically, it is to "wrap" the original `http.HandlerFunc` to add additional logic for checking the request. Consequently, the `httpauth.Client` appends the needed additional headers to the request.
-
-The following extra header values are required (`SW` stands for Skywire);
-
-- `SW-Public` - Specifies the public key (hexadecimal string representation) of the Skywire Node performing this operation.
-- `SW-Nonce` - Specifies the incrementing nonce provided by this operation.
-- `SW-Sig` - Specifies the of the signature (hexadecimal string representation) of the hash result of the concatenation of the Security Nonce + Body of the request.
-
-The `httpauth.Server` should also provide the `http.HandlerFunc` which obtains the next expected incrementing nonce for a given public key. This is required when a remote entity looses sync. A successful response of this call should look something of the following;
+The server SHALL expose an endpoint that returns the
+next-expected Security Nonce for a given public key, so a remote
+that has lost sync can recover without an out-of-band channel.
+The endpoint response body SHALL be:
 
 ```json
 {
-    "edge": "<public-key>",
-    "next_nonce": 0
+    "edge": "<public-key-hex>",
+    "next_nonce": <uint64>
 }
 ```
 
-The following is a proposed implementation of `httpauth.Server`;
+The nonce-recovery endpoint itself is not authenticated.
 
-```golang
-package httpauth
+## Storage contract
 
-// Server provides server-side logic for Skywire-related RESTFUL authorization and authentication.
-type Server struct {
-    // implementation ...
-}
+The server-side storage layer SHALL provide:
 
-// NewServer creates a new authentication server with the provided NonceStorer.
-func NewServer(store NonceStorer) *Server {
-    // implementation ...
-}
+- An operation to retrieve the next-expected nonce for a given
+  public key. The result SHALL be zero when no entry exists.
+- An atomic operation to retrieve-and-increment the next-expected
+  nonce for a public key in a single step, returning the
+  post-increment value. The atomicity guarantee is required to
+  prevent two concurrent requests from racing past the same nonce.
+- An operation to enumerate the number of stored entries (for
+  operational visibility).
 
-// WrapConfig configures the '(*Server).Wrap' function.
-type WrapConfig struct {
-    // MaxHTTPBodyLen specifies the max body length that is acceptable.
-    // No limit is set if the value is 0.
-    MaxHTTPBodyLen  int
+## Client contract
 
-    // PubKeyWhitelist specifies the whitelisted public keys.
-    // If value is nil, no whitelist rules are set.
-    PubKeyWhitelist []cipher.PubKey
-}
+A client implementation SHALL:
 
-// Wrap wraps a http.HandlerFunc and adds authentication logic.
-// The original http.HandlerFunc is responsible for setting the status code.
-// The middleware logic should only increment the security nonce if the status code
-// from the original http.HandlerFunc is of 2xx value (representing success).
-func (as *Server) Wrap(config *WrapConfig, original http.HandlerFunc) http.HandlerFunc {
-    // implementation ...
-}
-
-// HandleNextNonce returns a http handler that 
-func (as *Server) NextNonceHandler(remotePK cipher.PubKey) http.HandlerFunc {
-    // implementation ...
-}
-```
-
-Take note that for the `(*Server).Wrap` function, we will need to define a custom `http.ResponseWriter` to obtain the status code (https://www.reddit.com/r/golang/comments/7p35s4/how_do_i_get_the_response_status_for_my_middleware/).
-
-The `httpauth.Client` implementation is responsible for providing logic for the following actions;
-
-- Keep a local record of the next expected *Security Nonce*.
-- Adding security header values to a given request (`http.Request`).
+- Track the next-expected Security Nonce locally per server it
+  talks to.
+- On every authenticated request, set the three `SW-*` headers as
+  described above using the locally tracked nonce.
+- On a successful (2xx) response, increment its local nonce by one.
+- On HTTP 401 with a `next_nonce` mismatch, re-sync by calling the
+  nonce-recovery endpoint and retrying once. A second 401 indicates
+  a real authorization failure (key not whitelisted, signature
+  invalid) and SHALL NOT be retried automatically.

--- a/skywire-specs/specifications/05-Messaging_System.md
+++ b/skywire-specs/specifications/05-Messaging_System.md
@@ -247,33 +247,6 @@ func (*HTTPClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 
 The module also provides public functions to instantiate valid `Entry` objects.
 
-### Messaging Discovery Integration Tests
-
-> **TODO:** Fix wording.
-
-This package does not uses another `messenger` package, so integration tests are defined for the external services that `discovery` is using. In this case, the external store and `discovery` itself for testing the `client` library.
-
-The cases for the store integration testing:
-
- 1. Its able to set an entry on the database without error by calling the `storer.SetEntry` method.
- 2. Its able to retrieve the previously set entry by calling the `storer.Entry` method.
- 3. Creates multiple service entries and store them by calling `storer.SetEntry`, then it should be able to retrieve them with `store.AvailableServers`.
- 4. `store.AvailableServers` receives a `maxCount int` argument. We also test it passing an integer which value is less than the amount of server entries we have set in the database, it should return this exact amount of server entries.
- 5. Same as in number 4, but we set `maxCount` to number bigger than the number of server entries we have set, now we should get an slice of the size of the server entries we have set.
-
-In order to run the test we preferably create a clean new instance of the store database using Docker, and the test code should connect to it. We remove it after we have tested.
-
-In order to test the client library we do integration test with an instance of the discovery server.
-The test cases for the client integration testing:
-
-1. By using the method SetEntry the client can set a new entry on the discovery server.
-2. By using the method SetEntry the client can update a previously set entry on the discovery server.
-3. If using SetEntry to update a previously set Entry, but the new sequence is not the previous sequence + 1 it should return an error with status code 500, Something unexpected happened.
-4. If using SetEntry to update a previously set Entry, but the signature of the new entry has been made by a different secret key it should return an error with status code 401, Invalid signature.
-5. By calling the method Entry with the public key of a previously set Entry it should return that entry.
-6. By calling the method Entry with the public key of a previously non-set Entry it should return an error with code 404, Entry of public key is not found.
-7. By calling the method AvailableServers when there are previously set server entries it should return them.
-
 ## Messaging Link
 
 The `link` provides two *Messaging Instances* a means to establish a connection with one another, and also handle a pool of connections.
@@ -413,19 +386,6 @@ Only the `KK` [interactive handshake pattern (fundamental)](http://noiseprotocol
 ```
 
 The `-> e, es, ss` message is the `NoiseMessage1` of a `OpenChannel` frame, while the `<- e, ee, se` message is the `NoiseMessage2` of a `ChannelOpened` frame.
-
-### Implementation in Code
-
-Within the `messaging` module:
-
-- `Link` structure should represent a link between two instances.
-- `Pool` structure should handle multiple `Links` (with different instances).
-- `Client` which implements a *Client Instance*.
-- `Server` which implements a *Server Instance*.
-
-*Client Instances* communicate with each other via a *Server Instance* (which acts as a relay).
-
-Both structs will use `link.Pool` to handle links, but *Frames* are handled differently. *Client Instances* are to implement `TransportFactory` while a *Server Instance* is not required to. A *Client Instance* should also represent an established *Channel* as a `Transport` implementation.
 
 ### Configuring an Instance
 

--- a/skywire-specs/specifications/17-App2 module.md
+++ b/skywire-specs/specifications/17-App2 module.md
@@ -1,5 +1,11 @@
 # `app2`
 
+> **STATUS: Draft proposal — non-normative.** This document is a
+> design proposal for a future refactor of the `app` module. It is
+> kept in the specifications directory for historical reference;
+> none of its requirements are binding on current implementations.
+> See `12-App_Server.md` for the normative app-server contract.
+
 The current `app` module of Skywire is a mess. It is hard to test and it's actual communication logic is split across multiple packages. This proposal details how I would envision an *ideal* `app` package, and also how we can migrate and eventually scrap the old `app` module.
 
 ## Overview

--- a/skywire-specs/specifications/18-Router2 module.md
+++ b/skywire-specs/specifications/18-Router2 module.md
@@ -1,5 +1,11 @@
 # `router2`
 
+> **STATUS: Draft proposal — non-normative.** This document is a
+> design proposal for a future refactor of the `router` module. It
+> is kept in the specifications directory for historical reference;
+> none of its requirements are binding on current implementations.
+> See `11-Router.md` for the normative router contract.
+
 The goal of this proposal is to split out and define the responsiblities within `router` to allow for easier integration of future features, as well as make the codebase easier to understand.
 
 The current implementation of `routing.Rule` has fields that have different meanings, based on the rule type. A clearer definition of rule types are addressed in this proposal.

--- a/skywire-specs/specifications/24-Public_Visors.md
+++ b/skywire-specs/specifications/24-Public_Visors.md
@@ -14,15 +14,6 @@ Unlike regular visors, public visors must be externally reachable, either via:
 - A public IP address with no NAT
 - Port forwarding configured on the router (forwarding the STCPR port, default 7777)
 
-## Code Structure
-
-The public visor logic is distributed across several packages:
-
-- `/pkg/visor/init.go` - `initPublicVisor()` initializes public visor registration
-- `/pkg/app/appdisc/discovery_manager.go` - `PublicVisorUpdater` handles registration lifecycle
-- `/pkg/transport/network/client.go` - External STCPR detection logic
-- `/pkg/visor/visorconfig/v1.go` - `PublicVisorConfig` configuration structure
-
 ## Configuration
 
 Public visor behavior is configured in the visor's JSON configuration:

--- a/skywire-specs/specifications/25-Public_Autoconnect.md
+++ b/skywire-specs/specifications/25-Public_Autoconnect.md
@@ -11,15 +11,6 @@ The autoconnect system ensures network connectivity by:
 - **Fallback discovery**: Finding well-connected visors via *Transport Discovery* when no public visors are available
 - **Connection maintenance**: Periodically checking and re-establishing connections
 
-## Code Structure
-
-The autoconnect logic is implemented in:
-
-- `/pkg/visor/autoconnect.go` - Main autoconnect implementation
-- `/pkg/visor/init.go` - Autoconnect initialization (`initPublicAutoconnect`)
-- `/pkg/servicedisc/` - Service discovery client for fetching public visors
-- `/pkg/skyenv/skyenv.go` - Configuration constants
-
 ## Configuration
 
 Autoconnect behavior is configured in the visor's JSON configuration:

--- a/skywire-specs/specifications/29-Address_Resolver_Privacy.md
+++ b/skywire-specs/specifications/29-Address_Resolver_Privacy.md
@@ -77,60 +77,16 @@ Once deregistered, the visor does NOT automatically re-register if transports ar
 
 To re-register, the visor must be restarted (or the config changed and reinitialize triggered).
 
-## CLI Support
+## Address Resolver Client Contract
 
-```
-skywire cli config show .transport.ar_transport_limit
-```
+The AR client SHALL provide a deregister operation that:
 
-Runtime changes (future):
-```
-skywire cli visor ar-limit <N>
-```
+- Issues a DELETE to the AR's deregistration endpoint for the
+  visor's public key.
+- Clears the local registration state so subsequent transport
+  changes do not re-register the visor.
+- Stops the periodic re-registration heartbeat.
 
-This would update the limit at runtime without restart. Setting it to 0 would re-register with AR. Setting it to -1 would deregister immediately.
-
-## Implementation
-
-### Config
-
-Add `ARTransportLimit` to the transport config struct:
-
-```go
-type Transport struct {
-    // ... existing fields ...
-    ARTransportLimit int `json:"ar_transport_limit,omitempty"`
-}
-```
-
-### Transport Manager
-
-After each transport is established, check the count against the limit:
-
-```go
-func (tm *Manager) checkARLimit() {
-    if tm.conf.ARTransportLimit <= 0 {
-        return // 0 = no limit, negative = never registered
-    }
-    if tm.TransportCount() >= tm.conf.ARTransportLimit {
-        tm.deregisterFromAR()
-    }
-}
-```
-
-### Initialization
-
-During visor startup, if `ARTransportLimit < 0`:
-- Skip AR registration entirely
-- Log: "Address resolver registration disabled (ar_transport_limit < 0)"
-
-If `ARTransportLimit > 0`:
-- Register normally
-- Start monitoring transport count
-
-### Address Resolver Client
-
-Add a `Deregister()` method to the AR client that removes the visor's entry:
-- DELETE request to the AR's deregistration endpoint
-- Clear the local registration state
-- Stop the periodic re-registration heartbeat
+After a successful deregistration, the AR SHALL no longer serve the
+visor's record to lookups; the visor MAY still maintain transports
+established prior to deregistration.


### PR DESCRIPTION
## Summary

Audit pass over `skywire-specs/specifications/`. That directory is for **normative** protocol/contract documents — what implementations SHALL/MUST/SHOULD do — not tutorials, code walkthroughs, test plans, or implementation guides. Several files had drifted; this PR brings them back to spec style.

Net diff: 7 files, +101/-196 (mostly removals).

## Changes

### Banners on draft proposals

- `17-App2 module.md`, `18-Router2 module.md` — both are explicit design proposals for future refactors. Added a **"STATUS: Draft proposal — non-normative"** banner at the top of each pointing readers to the normative counterpart (`12-App_Server.md`, `11-Router.md`).

### Rewrites

- `02-HTTP_Authorization_Middleware.md` — the previous version was a Go-pseudo-code walkthrough of the proposed `httpauth.Server` / `NonceStorer` interface (`"implementation ..."`). Rewritten as a normative protocol description: `SW-*` header semantics, signature scheme (SHA256 over `nonce_bytes \|\| body`), nonce-increment-on-success rule, storage contract (atomic retrieve-and-increment), client contract (401-then-recover flow). Implementations pick their own struct shape.

### Trim non-spec content

- `05-Messaging_System.md` — removed "Messaging Discovery Integration Tests" (enumerated test cases belong in a test plan, not protocol spec) and "Implementation in Code" subsection (Go module struct list).
- `24-Public_Visors.md`, `25-Public_Autoconnect.md` — removed "Code Structure" sections that bullet-listed implementation file paths. File paths rot.
- `29-Address_Resolver_Privacy.md` — removed "CLI Support" examples and replaced the "Implementation" section (Go struct field, Go method body, log-line strings) with a normative AR client contract.

## What's untouched

Audit also flagged MEDIUM-severity items in `04-Transport_Discovery.md` (bbolt/CSV impl detail) and `07-Transport_Management.md` (telemetry-store schema). Those contain a mix of normative protocol claims and implementation detail that needs more careful surgery; deferred to keep this PR's review scope tight.

## Test plan

Doc-only; renders as standard markdown.