### PR TITLE
feat(skychat/group): federated send — members publish to own feed

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -276,24 +276,33 @@ func (m *Manager) SendToGroup(ctx context.Context, id, text string) error {
 	if !ok {
 		return fmt.Errorf("group: SendToGroup: no live session for %s", id)
 	}
-	switch sess.cfg.Record.Role {
-	case RoleOwner:
-		if err := sess.Send(text); err != nil {
-			return err
+	// Federated send: every member — owner OR member — publishes to
+	// their OWN feed. Other members observe directly via peerSubs.
+	// The relay-to-owner path (sess.SubmitToOwner) is retained as a
+	// fallback only when the local visor's publisher isn't healthy
+	// at send time; for steady-state groups every Send is direct.
+	//
+	// Pre-federated v1 routed every member message through the owner
+	// as a single-point-of-failure relay. The session-level
+	// infrastructure (per-member publishers, per-peer subscribers) was
+	// already in place before this change — the only behavioral
+	// difference is the manager's role dispatch here.
+	if err := sess.Send(text); err != nil {
+		// Fallback for the case where this visor's publisher isn't
+		// healthy enough to publish (e.g. CXO node mid-bootstrap).
+		// Only meaningful for member-role sessions — owner role has
+		// nowhere to fall back to.
+		if sess.cfg.Record.Role == RoleMember {
+			if relayErr := sess.SubmitToOwner(ctx, text); relayErr == nil {
+				m.kickReconnect(ctx, id)
+				_ = m.store.MarkMessage(id, time.Now().UTC()) //nolint:errcheck
+				return nil
+			}
 		}
-	case RoleMember:
-		if err := sess.SubmitToOwner(ctx, text); err != nil {
-			return err
-		}
-		// A successful relay submission proves the owner is reachable
-		// over at least one transport. If the subscriber side of this
-		// session is currently down (StatusPending after a transient
-		// Connect failure), now's a good moment to retry — don't wait
-		// up to 30s for the next reconnect tick.
-		m.kickReconnect(ctx, id)
-	default:
-		return fmt.Errorf("group: SendToGroup: unknown role %q", sess.cfg.Record.Role)
+		return err
 	}
+	_ = ctx //nolint:staticcheck // ctx kept in signature for the relay-fallback branch
+
 	_ = m.store.MarkMessage(id, time.Now().UTC()) //nolint:errcheck
 	return nil
 }

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -514,13 +514,13 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		peerSubs: make(map[cipher.PubKey]*treestore.Subscriber),
 	}
 
-	// D1 peer subscribers: every OTHER member (excluding self AND
-	// the owner — the owner's feed is already covered by the legacy
-	// `sub` above for backward-compat with non-migrated owners).
-	// When D4 retires the legacy path, this loop will include the
-	// owner PK too.
+	// Federated mode: subscribe to every OTHER member's feed,
+	// INCLUDING the owner's. The legacy `sub` field above remains
+	// wired as a backward-compat fallback for owners on pre-federated
+	// binaries, but new owners publish to their own feed just like
+	// every other member — so peerSubs covers them too.
 	for _, peerPK := range cfg.Record.Members {
-		if peerPK == cfg.MyPK || peerPK == cfg.Record.OwnerPK {
+		if peerPK == cfg.MyPK {
 			continue
 		}
 		ps, err := treestore.NewSubscriberOnNode(pub.Node(), peerPK, treestore.SubConfig{Logger: log})


### PR DESCRIPTION
## Summary

Removes the single-point-of-failure relay through the group owner on the send path. Every member — owner or member — now publishes to their OWN feed; every member subscribes to every OTHER member's feed (including the owner's). The owner is no longer a SPOF for message delivery.

The session-level infrastructure for federated publish/subscribe was already in place when D1 landed (see the existing comments in \`session.go\` calling out per-member publishers + per-peer subscribers as already-wired). This PR is a small change at the **manager's role-dispatch layer** + a **one-line expansion of the member's peerSubs set**.

## Changes

- **\`cmd/apps/skychat/group/manager.go\`** — \`SendToGroup\` drops the \`RoleOwner\` / \`RoleMember\` switch. Both roles call \`sess.Send\` (which publishes to this visor's own feed). The \`SubmitToOwner\` relay path is retained as a **fallback only** when \`sess.Send\` fails for a member-role session (publisher mid-bootstrap, etc.). Steady-state is federated.
- **\`cmd/apps/skychat/group/session.go\`** — member-side \`openMember\` loop no longer excludes the owner's PK from \`peerSubs\`. Member sessions now subscribe to every other member INCLUDING the owner via the direct per-peer path. The legacy \`sub\` field stays wired as a backward-compat fallback for non-migrated owners (will be removable in a future cleanup once everyone's on the new binary).

## What this changes operationally

- Owner offline ≠ group dead. Members can keep sending; messages reach everyone whose feed is still up.
- No more "owner relay" hop on the hot path — direct member-to-member.
- Roster authority (membership add/remove, invite issuance) still lives with the \`RoleOwner\` — that's a separate axis from message delivery and stays as-is.

## Hard cut

Per the earlier scope discussion: no v1-compat shim. Old clients can still relay-send to an old owner, and old members still see messages from the legacy \`sub\` path; new clients use the federated path. No v1 group needs to be recreated, but the relay path is now best-considered fallback rather than primary.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./cmd/apps/skychat/group/...\` green.
- [x] \`make lint\` clean (also fixes 3 pre-existing chat-app lint findings the new build surfaced; same fixes as in #2578 — only one of these PRs needs to land them).
- [ ] Live: send a message from a non-owner member after the owner halts — verify other members see it.