### PR TITLE
feat(skychat): admin role + admin-set management (1/3)

### DIFF
--- a/cmd/apps/skychat/group/group.go
+++ b/cmd/apps/skychat/group/group.go
@@ -109,8 +109,28 @@ type Record struct {
 	// — just for display.
 	Name string `json:"name"`
 
-	// OwnerPK is the visor that publishes the message feed.
+	// OwnerPK is the founding-creator visor's public key. Historically
+	// this was the single PK with roster authority + the only PK that
+	// could publish to the feed. As of the federated send change,
+	// roster authority is on Admins (which always includes OwnerPK
+	// implicitly), and every member publishes to their own feed. The
+	// field name stays for backward compatibility with persisted
+	// records + the invite-link schema; semantically it's now the
+	// "founder" PK — immutable, used as the recovery anchor.
 	OwnerPK cipher.PubKey `json:"owner_pk"`
+
+	// Admins are the PKs with roster authority: add/remove members,
+	// issue invites, change AES key, promote/demote other admins.
+	// OwnerPK is always treated as an admin (the founder is immutable
+	// admin); on-disk this slice may or may not include it explicitly
+	// — IsAdmin handles either case.
+	//
+	// Empty/nil on legacy records — the migration path in store.Get
+	// fills it with [OwnerPK] on first read so older groups inherit
+	// founder-only admin authority. Operator-driven changes flow
+	// through Manager.PromoteAdmin / DemoteAdmin which never permit
+	// removing the founder (OwnerPK) from this list.
+	Admins []cipher.PubKey `json:"admins,omitempty"`
 
 	// Port is the DMSG port the owner's publisher listens on.
 	// Chosen by the owner at create time (not deterministic from
@@ -142,6 +162,49 @@ type Record struct {
 	CreatedAt     time.Time `json:"created_at"`
 	JoinedAt      time.Time `json:"joined_at"`
 	LastMessageAt time.Time `json:"last_message_at,omitempty"`
+}
+
+// IsFounder reports whether pk is the group's founder (the original
+// creator). The founder is implicitly always an admin and cannot be
+// demoted. Equality with OwnerPK is the source of truth.
+func (r Record) IsFounder(pk cipher.PubKey) bool {
+	return r.OwnerPK == pk
+}
+
+// IsAdmin reports whether pk has roster authority on this group —
+// i.e. is the founder OR is explicitly listed in Admins. Used to gate
+// AddMember / BuildInvite / promote-demote / delete operations.
+//
+// The founder check is OR'd in unconditionally so a legacy record
+// whose Admins slice is nil (pre-migration on-disk shape) still
+// treats the founder as an admin without needing the migration to
+// have run first.
+func (r Record) IsAdmin(pk cipher.PubKey) bool {
+	if r.IsFounder(pk) {
+		return true
+	}
+	for _, a := range r.Admins {
+		if a == pk {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureFounderInAdmins normalizes the on-disk Admins slice so the
+// founder is always explicitly present. Called by the store on read
+// for legacy records (Admins == nil) and by manager ops that mutate
+// Admins so the invariant holds post-mutation. Idempotent.
+func (r *Record) EnsureFounderInAdmins() {
+	if r.OwnerPK == (cipher.PubKey{}) {
+		return
+	}
+	for _, a := range r.Admins {
+		if a == r.OwnerPK {
+			return
+		}
+	}
+	r.Admins = append([]cipher.PubKey{r.OwnerPK}, r.Admins...)
 }
 
 // Message is the on-the-wire (well, on-the-feed) form of a group

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -234,8 +234,24 @@ func (m *Manager) Join(inv Invite) (Record, error) {
 // already-terminal record.
 func (m *Manager) Leave(id string) error { return m.terminate(id, StatusLeft) }
 
-// Delete tears down an owner-side group and marks it revoked.
-func (m *Manager) Delete(id string) error { return m.terminate(id, StatusRevoked) }
+// Delete tears down an admin-side group and marks it revoked. Only
+// visors that IsAdmin on the record may delete; non-admin members
+// should call Leave instead. Returns an error for the wrong-role
+// case so a typo doesn't silently revoke a group that another
+// admin still owns.
+func (m *Manager) Delete(id string) error {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return fmt.Errorf("group: Delete: get: %w", err)
+	}
+	if !ok {
+		return nil // already gone — idempotent, matches terminate's contract
+	}
+	if !r.IsAdmin(m.myPK) {
+		return errors.New("group: Delete: only admins can revoke a group; use Leave to depart")
+	}
+	return m.terminate(id, StatusRevoked)
+}
 
 func (m *Manager) terminate(id string, status Status) error {
 	r, ok, err := m.store.Get(id)
@@ -317,8 +333,14 @@ func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {
 	if !ok {
 		return Record{}, fmt.Errorf("group: AddMember: no record for %s", id)
 	}
-	if r.Role != RoleOwner {
-		return Record{}, errors.New("group: AddMember: only owner-role can edit")
+	// Post-#admin-roles: roster authority lives on the Admins set, not
+	// on Role. Role still distinguishes publisher (owner) from
+	// subscriber (member) infrastructure at session-open time, but
+	// "who can add members" is now any visor whose PK is in
+	// r.IsAdmin(). The founder check inside IsAdmin keeps the legacy
+	// owner-only behavior on records whose Admins slice is empty.
+	if !r.IsAdmin(m.myPK) {
+		return Record{}, errors.New("group: AddMember: only admins can edit roster")
 	}
 	for _, existing := range r.Members {
 		if existing == pk {
@@ -334,6 +356,93 @@ func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {
 	m.mu.RUnlock()
 	if live {
 		_ = sess.SetAllowlist(r.Members) //nolint:errcheck
+	}
+	return r, nil
+}
+
+// PromoteAdmin adds pk to the group's Admins set. Callable by any
+// existing admin. Idempotent — promoting an already-admin returns the
+// current record without mutating storage. The promoted PK gains
+// roster authority (AddMember / BuildInvite / Delete / promote+demote)
+// from the moment this call returns successfully on this visor; other
+// visors learn of the change through the next out-of-band roster
+// gossip (admin-mirror PR adds the on-feed channel).
+//
+// Note: in the federated send architecture, the promoted PK does not
+// need to already be a Member — promotion is a roster-authority grant,
+// not a membership change. Practically, an admin who isn't also a
+// member is unusual; callers should treat that as a separate AddMember
+// step where they want it.
+func (m *Manager) PromoteAdmin(id string, pk cipher.PubKey) (Record, error) {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return Record{}, fmt.Errorf("group: PromoteAdmin: get: %w", err)
+	}
+	if !ok {
+		return Record{}, fmt.Errorf("group: PromoteAdmin: no record for %s", id)
+	}
+	if !r.IsAdmin(m.myPK) {
+		return Record{}, errors.New("group: PromoteAdmin: only admins can promote")
+	}
+	if pk == (cipher.PubKey{}) {
+		return Record{}, errors.New("group: PromoteAdmin: pk required")
+	}
+	if r.IsAdmin(pk) {
+		return r, nil // already admin (founder OR explicit) — idempotent
+	}
+	r.Admins = append(r.Admins, pk)
+	r.EnsureFounderInAdmins()
+	if err := m.store.Put(r); err != nil {
+		return Record{}, fmt.Errorf("group: PromoteAdmin: store: %w", err)
+	}
+	return r, nil
+}
+
+// DemoteAdmin removes pk from the group's Admins set. Refuses to
+// demote the founder (r.OwnerPK) — the founder is the immutable
+// recovery anchor and demoting them would lock the group out of
+// roster recovery if every other admin's visor went offline. Other
+// admins MAY demote each other (no protection beyond the founder
+// rule); the assumption is that admins trust each other by virtue of
+// having been promoted.
+//
+// Idempotent on a PK that wasn't an admin to begin with — returns the
+// current record without mutating storage. Errors only on store
+// failure, the founder-demote attempt, and the only-admins-can-demote
+// gate.
+func (m *Manager) DemoteAdmin(id string, pk cipher.PubKey) (Record, error) {
+	r, ok, err := m.store.Get(id)
+	if err != nil {
+		return Record{}, fmt.Errorf("group: DemoteAdmin: get: %w", err)
+	}
+	if !ok {
+		return Record{}, fmt.Errorf("group: DemoteAdmin: no record for %s", id)
+	}
+	if !r.IsAdmin(m.myPK) {
+		return Record{}, errors.New("group: DemoteAdmin: only admins can demote")
+	}
+	if pk == (cipher.PubKey{}) {
+		return Record{}, errors.New("group: DemoteAdmin: pk required")
+	}
+	if r.IsFounder(pk) {
+		return Record{}, errors.New("group: DemoteAdmin: cannot demote the founder")
+	}
+	out := r.Admins[:0]
+	mutated := false
+	for _, a := range r.Admins {
+		if a == pk {
+			mutated = true
+			continue
+		}
+		out = append(out, a)
+	}
+	if !mutated {
+		return r, nil // nothing to do — pk wasn't in the explicit Admins slice
+	}
+	r.Admins = out
+	r.EnsureFounderInAdmins()
+	if err := m.store.Put(r); err != nil {
+		return Record{}, fmt.Errorf("group: DemoteAdmin: store: %w", err)
 	}
 	return r, nil
 }
@@ -761,9 +870,11 @@ func (m *Manager) IsSubscriberAlive(id string) bool {
 // List returns every persisted record.
 func (m *Manager) List() ([]Record, error) { return m.store.List() }
 
-// BuildInvite encodes an invite link for an owner-side group. Returns
-// an error for member-side records (members can't invite in D1; only
-// the owner controls the allowlist).
+// BuildInvite encodes an invite link for an admin-side group. Any
+// visor that IsAdmin on the record can issue invites — the founder
+// implicitly, and explicit Admins entries (set via PromoteAdmin).
+// Non-admin members get an error so the legacy owner-only invariant
+// is preserved on records whose Admins slice is still founder-only.
 func (m *Manager) BuildInvite(id string) (string, error) {
 	r, ok, err := m.store.Get(id)
 	if err != nil {
@@ -772,8 +883,8 @@ func (m *Manager) BuildInvite(id string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("group: BuildInvite: no record for %s", id)
 	}
-	if r.Role != RoleOwner {
-		return "", errors.New("group: BuildInvite: only owners can issue invites")
+	if !r.IsAdmin(m.myPK) {
+		return "", errors.New("group: BuildInvite: only admins can issue invites")
 	}
 	return EncodeInvite(Invite{
 		ID:      r.ID,

--- a/cmd/apps/skychat/group/store.go
+++ b/cmd/apps/skychat/group/store.go
@@ -89,6 +89,11 @@ func (s *Store) Get(id string) (Record, bool, error) {
 		found = true
 		return json.Unmarshal(raw, &r)
 	})
+	// Legacy records persisted before the Admins field existed have
+	// Admins == nil. Normalize on every read so IsAdmin and admin-
+	// gated manager ops see a consistent shape. Idempotent for new
+	// records that already have the founder explicit.
+	r.EnsureFounderInAdmins()
 	return r, found, err
 }
 
@@ -105,6 +110,10 @@ func (s *Store) List() ([]Record, error) {
 			if err := json.Unmarshal(v, &r); err != nil {
 				return err
 			}
+			// Mirror Get's legacy-record normalization so any
+			// caller iterating List sees the same admin-shape
+			// invariant Get returns.
+			r.EnsureFounderInAdmins()
 			out = append(out, r)
 			return nil
 		})

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -9,7 +9,9 @@
 //	skywire cli skychat group info    <group-id>
 //	skywire cli skychat group invite  <group-id>           # re-emits the invite link
 //	skywire cli skychat group join    <invite-link>
-//	skywire cli skychat group add     <group-id> <pk>      # owner: extend allowlist
+//	skywire cli skychat group add     <group-id> <pk>      # admin: extend allowlist
+//	skywire cli skychat group promote <group-id> <pk>      # admin: grant roster authority
+//	skywire cli skychat group demote  <group-id> <pk>      # admin: revoke roster authority (founder is immutable)
 //	skywire cli skychat group send    <group-id> <text>    # owner only in v1
 //	skywire cli skychat group listen  [--since RFC3339]    # poll inbox, stream
 //	skywire cli skychat group leave   <group-id>           # member side
@@ -72,8 +74,9 @@ func init() {
 
 	groupCmd.AddCommand(
 		groupCreateCmd, groupListCmd, groupInfoCmd, groupInviteCmd,
-		groupJoinCmd, groupAddCmd, groupSendCmd, groupListenCmd,
-		groupHistoryCmd, groupLeaveCmd, groupDeleteCmd,
+		groupJoinCmd, groupAddCmd, groupPromoteCmd, groupDemoteCmd,
+		groupSendCmd, groupListenCmd, groupHistoryCmd,
+		groupLeaveCmd, groupDeleteCmd,
 	)
 	RootCmd.AddCommand(groupCmd)
 }
@@ -228,6 +231,65 @@ var groupAddCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		human := fmt.Sprintf("group %s now has %d members\n", args[0], len(info.Members))
+		internal.PrintOutput(cmd.Flags(), info, human)
+	},
+}
+
+var groupPromoteCmd = &cobra.Command{
+	Use:   "promote <group-id> <pk>",
+	Short: "Admin: grant roster authority (add/remove members, issue invites) to PK",
+	Long: `Promote PK to admin on the named group.
+
+Any existing admin (founder, or any visor previously promoted) can run
+this. Idempotent: promoting an already-admin returns the current
+record without writing. The promoted PK gains roster authority from
+the moment this call returns on this visor; other visors learn of the
+change through subsequent roster gossip (admin-mirror feeds; follow-up
+PR).`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var pk cipher.PubKey
+		if err := pk.Set(args[1]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid pk %q: %w", args[1], err))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, err := rpcClient.GroupPromoteAdmin(args[0], pk)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		human := fmt.Sprintf("group %s now has %d admin(s)\n", args[0], len(info.Admins))
+		internal.PrintOutput(cmd.Flags(), info, human)
+	},
+}
+
+var groupDemoteCmd = &cobra.Command{
+	Use:   "demote <group-id> <pk>",
+	Short: "Admin: revoke roster authority from PK (founder cannot be demoted)",
+	Long: `Demote PK on the named group.
+
+Any existing admin can run this. The founder (the original group
+creator, immutable per Record.OwnerPK) cannot be demoted — that's
+the recovery anchor that keeps a group reachable even if every other
+admin's visor is offline. Demoting a non-admin PK is a no-op
+(idempotent).`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var pk cipher.PubKey
+		if err := pk.Set(args[1]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid pk %q: %w", args[1], err))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		info, err := rpcClient.GroupDemoteAdmin(args[0], pk)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		human := fmt.Sprintf("group %s now has %d admin(s)\n", args[0], len(info.Admins))
 		internal.PrintOutput(cmd.Flags(), info, human)
 	},
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -245,6 +245,8 @@ type API interface {
 	GroupGet(id string) (GroupInfo, error)
 	GroupInvite(id string) (string, error)
 	GroupAddMember(id string, pk cipher.PubKey) (GroupInfo, error)
+	GroupPromoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error)
+	GroupDemoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error)
 	GroupSend(args GroupSendArgs) error
 	GroupPoll(since time.Time) ([]GroupMessage, error)
 	GroupDelete(id string) error

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -32,11 +32,17 @@ import (
 // GroupInfo is the public summary of a chat group, returned by
 // GroupList and GroupGet.
 type GroupInfo struct {
-	ID            string              `json:"id"`
-	Name          string              `json:"name"`
-	OwnerPK       cipher.PubKey       `json:"owner_pk"`
-	Port          uint16              `json:"port"`
-	Mode          skychatgroup.Mode   `json:"mode"`
+	ID      string            `json:"id"`
+	Name    string            `json:"name"`
+	OwnerPK cipher.PubKey     `json:"owner_pk"`
+	Port    uint16            `json:"port"`
+	Mode    skychatgroup.Mode `json:"mode"`
+	// Admins is the per-record roster-authority set. Mirrors
+	// Record.Admins exactly — founder is implicitly admin and is
+	// surfaced explicitly here after EnsureFounderInAdmins runs on
+	// the store read path, so RPC clients can render the admin list
+	// without having to OR in OwnerPK themselves.
+	Admins        []cipher.PubKey     `json:"admins,omitempty"`
 	Members       []cipher.PubKey     `json:"members"`
 	Role          skychatgroup.Role   `json:"role"`
 	Status        skychatgroup.Status `json:"status"`
@@ -205,6 +211,38 @@ func (v *Visor) GroupAddMember(id string, pk cipher.PubKey) (GroupInfo, error) {
 	return toInfo(r), nil
 }
 
+// GroupPromoteAdmin adds pk to the group's Admins set. Callable by
+// any existing admin (founder implicitly, or any explicit Admins
+// entry). Returns the updated info — surfacing Admins so the caller
+// can confirm the grant landed.
+func (v *Visor) GroupPromoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupInfo{}, ErrGroupingDisabled
+	}
+	r, err := mgr.PromoteAdmin(id, pk)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	return toInfo(r), nil
+}
+
+// GroupDemoteAdmin removes pk from the group's explicit Admins set.
+// Refuses to demote the founder (immutable recovery anchor). Other
+// admins can demote each other freely — the assumption is that admins
+// trust each other by virtue of having been promoted.
+func (v *Visor) GroupDemoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error) {
+	mgr := v.groupManager()
+	if mgr == nil {
+		return GroupInfo{}, ErrGroupingDisabled
+	}
+	r, err := mgr.DemoteAdmin(id, pk)
+	if err != nil {
+		return GroupInfo{}, err
+	}
+	return toInfo(r), nil
+}
+
 // GroupSend publishes a message into the named group's feed.
 // Owners write directly; members open a dmsg stream to the owner's
 // relay listener and submit, the owner re-publishes with sender
@@ -309,6 +347,7 @@ func toInfo(r skychatgroup.Record) GroupInfo {
 		OwnerPK:       r.OwnerPK,
 		Port:          r.Port,
 		Mode:          r.Mode,
+		Admins:        append([]cipher.PubKey(nil), r.Admins...),
 		Members:       append([]cipher.PubKey(nil), r.Members...),
 		Role:          r.Role,
 		Status:        r.Status,

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1361,6 +1361,20 @@ func (rc *rpcClient) GroupAddMember(id string, pk cipher.PubKey) (GroupInfo, err
 	return resp, err
 }
 
+// GroupPromoteAdmin implements API.
+func (rc *rpcClient) GroupPromoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error) {
+	var resp GroupInfo
+	err := rc.Call("GroupPromoteAdmin", &GroupPromoteAdminRequest{ID: id, PK: pk}, &resp)
+	return resp, err
+}
+
+// GroupDemoteAdmin implements API.
+func (rc *rpcClient) GroupDemoteAdmin(id string, pk cipher.PubKey) (GroupInfo, error) {
+	var resp GroupInfo
+	err := rc.Call("GroupDemoteAdmin", &GroupPromoteAdminRequest{ID: id, PK: pk}, &resp)
+	return resp, err
+}
+
 // GroupSend implements API.
 func (rc *rpcClient) GroupSend(args GroupSendArgs) error {
 	return rc.Call("GroupSend", &args, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1226,6 +1226,16 @@ func (mc *mockRPCClient) GroupAddMember(_ string, _ cipher.PubKey) (GroupInfo, e
 	return GroupInfo{}, nil
 }
 
+// GroupPromoteAdmin implements API.
+func (mc *mockRPCClient) GroupPromoteAdmin(_ string, _ cipher.PubKey) (GroupInfo, error) {
+	return GroupInfo{}, nil
+}
+
+// GroupDemoteAdmin implements API.
+func (mc *mockRPCClient) GroupDemoteAdmin(_ string, _ cipher.PubKey) (GroupInfo, error) {
+	return GroupInfo{}, nil
+}
+
 // GroupSend implements API.
 func (mc *mockRPCClient) GroupSend(_ GroupSendArgs) error { return nil }
 

--- a/pkg/visor/rpc_group.go
+++ b/pkg/visor/rpc_group.go
@@ -114,6 +114,43 @@ func (r *RPC) GroupAddMember(req *GroupAddMemberRequest, out *GroupInfo) (err er
 	return nil
 }
 
+// GroupPromoteAdminRequest is the input to RPC.GroupPromoteAdmin /
+// GroupDemoteAdmin. Shape mirrors GroupAddMemberRequest.
+type GroupPromoteAdminRequest struct {
+	ID string        `json:"id"`
+	PK cipher.PubKey `json:"pk"`
+}
+
+// GroupPromoteAdmin grants roster authority to PK on the named group.
+// Callable by any existing admin on this visor.
+func (r *RPC) GroupPromoteAdmin(req *GroupPromoteAdminRequest, out *GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupPromoteAdmin", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, err := r.visor.GroupPromoteAdmin(req.ID, req.PK)
+	if err != nil {
+		return err
+	}
+	*out = info
+	return nil
+}
+
+// GroupDemoteAdmin revokes roster authority from PK on the named
+// group. Refuses to demote the founder (immutable recovery anchor).
+func (r *RPC) GroupDemoteAdmin(req *GroupPromoteAdminRequest, out *GroupInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "GroupDemoteAdmin", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	info, err := r.visor.GroupDemoteAdmin(req.ID, req.PK)
+	if err != nil {
+		return err
+	}
+	*out = info
+	return nil
+}
+
 // GroupSend publishes one message into the named group's feed.
 // Owner-side only in v1.
 func (r *RPC) GroupSend(req *GroupSendArgs, _ *struct{}) (err error) {

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -7,11 +7,12 @@
 package rpcgrpc
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -8,6 +8,7 @@ package rpcgrpc
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
## Summary

Adds an explicit `Admins []cipher.PubKey` field to `group.Record`
alongside `OwnerPK`. `OwnerPK` becomes the immutable **founder** —
the recovery anchor that can never be demoted. `Admins` is the
per-record roster-authority set: any visor whose PK appears there
can add members, issue invites, delete the group, and promote /
demote other admins. Founder is implicit-admin via the
`IsFounder` OR-check inside `Record.IsAdmin`; the store
normalizes the on-disk slice on read (`EnsureFounderInAdmins`)
so legacy records without the field inherit founder-only admin
authority cleanly.

Replaces the prior `Role != RoleOwner` gates in
`Manager.AddMember`, `BuildInvite`, and `Delete` with
`!IsAdmin(myPK)` so any admin (not just the founder) can mutate
the roster. `Role` still drives publisher vs subscriber session
infrastructure — only the authority surface moves.

New API surface:
- `Manager.PromoteAdmin(id, pk) (Record, error)` — idempotent grant
- `Manager.DemoteAdmin(id, pk) (Record, error)` — idempotent revoke; refuses to demote the founder
- `Visor.GroupPromoteAdmin` / `GroupDemoteAdmin` RPC methods + client + mock
- `skywire cli skychat group promote <gid> <pk>` / `demote <gid> <pk>` CLI subcommands
- `GroupInfo.Admins` field so callers render the admin set without re-deriving the founder OR

## PR series context

This is **PR 1 of 3** in the admin-mirror series proposed in the
earlier design conversation:

1. (this PR) admin role + admin-set management
2. admin **mirror feed** wiring — per-admin secondary publisher
   that mirrors every member feed, so the group stays reachable
   whenever any admin's visor is online (not just the founder's)
3. member-side **subscribe-to-admin-mirror** + cross-mirror dedup

The mirror infrastructure isn't wired in this PR — promotions are
local roster-authority grants only; cross-visor admin propagation
rides on the PR-2 mirror feeds. Skipping the mirror in PR-1 keeps
the surface small enough to review and ship without depending on
the larger change.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/apps/skychat/group/... ./pkg/visor/...` passes
- [x] `make format check` passes
- [ ] Manual: founder promotes a peer → peer can `cli skychat group add` a new member on their visor
- [ ] Manual: non-founder admin promotes a third visor → third visor gains admin authority
- [ ] Manual: admin attempts to demote the founder → rejected with clear error
- [ ] Manual: admin demotes another admin → revoked; demoted visor's subsequent `add`/`invite` is rejected