### PR TITLE
feat(cli/dmsg): route `skywire cli dmsg pty exec` through visor RPC

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -220,7 +220,7 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 		if len(args) < 2 {
 			return fmt.Errorf("pty exec: <pk> <command> required (or use --via tcp://<pk>@<host:port>)")
 		}
-		cli := dmsgpty.DefaultCLI()
+		_ = ctx // ctx is consumed by the --via branch above; RPC path is synchronous
 		addr := internal.ParsePK(cmd.Flags(), "pk", args[0])
 		port, _ := strconv.ParseUint(ptyPort, 10, 16) //nolint:errcheck
 		name := args[1]
@@ -229,7 +229,24 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 			cmdArgs = args[2:]
 		}
 
-		resp, err := cli.ExecRemote(ctx, addr, uint16(port), name, cmdArgs, ptyExecEnv, nil, timeout)
+		// Route through the visor RPC instead of the dmsgpty-host's
+		// own CLI listener. The visor exposes DmsgPtyExec as a
+		// first-class RPC method (see pkg/visor/rpc_visor.go), which
+		// drives Host.ExecRemote directly. This makes the integrated
+		// CLI follow whatever the visor RPC is configured at and
+		// removes the unix-socket-permission gate that the standalone
+		// dmsgpty-cli still hits.
+		rpcCli := ptyRPCClient(cmd.Flags())
+		resp, err := rpcCli.DmsgPtyExec(visor.DmsgPtyExecArgs{
+			RemotePK:   addr,
+			RemotePort: uint16(port),
+			Req: dmsgpty.CommandExecReq{
+				Name:      name,
+				Arg:       cmdArgs,
+				Env:       ptyExecEnv,
+				TimeoutMS: timeout.Milliseconds(),
+			},
+		})
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck
 			os.Exit(1)

--- a/pkg/dmsg/dmsgpty/host.go
+++ b/pkg/dmsg/dmsgpty/host.go
@@ -36,6 +36,32 @@ func NewHost(dmsgC *dmsg.Client, wl Whitelist) *Host {
 	return host
 }
 
+// ExecRemote runs a one-shot command on the remote dmsgpty host at
+// (rPK, rPort) using this host's dmsg client. Equivalent to what a CLI
+// client would obtain via the proxy path, but skips the local CLI
+// socket entirely — callers that already hold a Host (notably the
+// visor's own RPC layer) can drive Exec without the intermediate
+// unix-socket-or-tcp control listener. Same trust model: the remote's
+// whitelist gates the connection on its own PK admission.
+func (h *Host) ExecRemote(ctx context.Context, rPK cipher.PubKey, rPort uint16, req *CommandExecReq) (*CommandExecResult, error) {
+	if rPort == 0 {
+		rPort = DefaultPort
+	}
+	stream, err := h.dmsgC.DialStream(ctx, dmsg.Addr{PK: rPK, Port: rPort})
+	if err != nil {
+		return nil, fmt.Errorf("dmsgpty: dial %s:%d: %w", rPK, rPort, err)
+	}
+	defer stream.Close() //nolint:errcheck
+
+	ptyC, err := NewPtyClient(stream)
+	if err != nil {
+		return nil, fmt.Errorf("dmsgpty: new pty client: %w", err)
+	}
+	defer ptyC.Close() //nolint:errcheck
+
+	return ptyC.Exec(req)
+}
+
 // ServeCLI listens for CLI connections via the provided listener.
 func (h *Host) ServeCLI(ctx context.Context, lis net.Listener) error {
 

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
@@ -53,6 +54,7 @@ type API interface {
 	ClearSkychatPassword(oldPassword string) error
 	SkychatLocalAddr() (string, error)
 	RemoteVisors() ([]string, error)
+	DmsgPtyExec(args DmsgPtyExecArgs) (*dmsgpty.CommandExecResult, error)
 	GetLogRotationInterval() (visorconfig.Duration, error)
 	SetLogRotationInterval(visorconfig.Duration) error
 	IsDMSGClientReady() (bool, error)
@@ -471,6 +473,17 @@ type HealthInfo struct {
 	UptimeTrackerHealth    string `json:"uptime_tracker_health,omitempty"`
 	AutoconnectHealth      string `json:"autoconnect_health,omitempty"`
 	TransportabilityHealth string `json:"transportability_health,omitempty"`
+}
+
+// DmsgPtyExecArgs is the request shape for API.DmsgPtyExec.
+// RemotePK identifies the target visor's dmsgpty host; RemotePort
+// defaults to dmsgpty.DefaultPort (22) when zero. Req carries the
+// command, arguments, optional environment overrides, optional stdin,
+// and per-call timeout — see dmsgpty.CommandExecReq.
+type DmsgPtyExecArgs struct {
+	RemotePK   cipher.PubKey
+	RemotePort uint16
+	Req        dmsgpty.CommandExecReq
 }
 
 // UptimeHistoryArgs is the request shape for API.UptimeHistory. All

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -19,6 +19,7 @@ import (
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -454,6 +455,28 @@ func (v *Visor) RemoteVisors() ([]string, error) {
 		visors = append(visors, conn.Addr.PK.String())
 	}
 	return visors, nil
+}
+
+// DmsgPtyExec runs a one-shot command on the remote visor identified
+// by args.RemotePK using this visor's embedded dmsgpty host. Skips
+// the host's CLI control listener (the unix socket / TCP loopback
+// that the standalone dmsgpty-cli connects to) — the caller already
+// holds an authenticated RPC connection to this visor, so the
+// permission gate is the visor RPC, not the dmsgpty CLI socket.
+//
+// Trust model upstream of this is the visor RPC's auth (whoever can
+// reach :3435). Trust model downstream is unchanged: the remote
+// dmsgpty host enforces its whitelist on the dmsg stream this visor
+// opens; the remote sees this visor's PK as the peer.
+func (v *Visor) DmsgPtyExec(args DmsgPtyExecArgs) (*dmsgpty.CommandExecResult, error) {
+	if v.dmsgPty == nil {
+		return nil, fmt.Errorf("dmsgpty: not initialized on this visor")
+	}
+	if args.RemotePK.Null() {
+		return nil, fmt.Errorf("dmsgpty: remote_pk required")
+	}
+	req := args.Req
+	return v.dmsgPty.ExecRemote(context.Background(), args.RemotePK, args.RemotePort, &req)
 }
 
 // Ports return list of all ports used by visor services and apps

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -717,6 +717,12 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	pty := dmsgpty.NewHost(dmsgC, wl)
+	// Expose the Host on the visor so the RPC layer can drive Exec
+	// directly (see pkg/visor/rpc_visor.go DmsgPtyExec). Without this
+	// the integrated `skywire cli dmsg pty exec` path is forced
+	// through the host's CLI control socket — a separate listener
+	// with separate permissions from the visor's RPC.
+	v.dmsgPty = pty
 
 	if ptyPort := conf.DmsgPort; ptyPort != 0 {
 		serveCtx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is called in pushCloseStack

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
@@ -950,6 +951,15 @@ func (rc *rpcClient) RemoteVisors() ([]string, error) {
 	output := []string{}
 	rc.Call("RemoteVisors", &struct{}{}, &output) // nolint
 	return output, nil
+}
+
+// DmsgPtyExec calls DmsgPtyExec.
+func (rc *rpcClient) DmsgPtyExec(args DmsgPtyExecArgs) (*dmsgpty.CommandExecResult, error) {
+	out := new(dmsgpty.CommandExecResult)
+	if err := rc.Call("DmsgPtyExec", &args, out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // Ports calls Ports.

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/router"
@@ -950,6 +951,11 @@ func (mc *mockRPCClient) DeregisterService(_ []cipher.PubKey, _ string) error {
 // RemoteVisors implements API
 func (mc *mockRPCClient) RemoteVisors() ([]string, error) {
 	return []string{}, nil
+}
+
+// DmsgPtyExec implements API
+func (mc *mockRPCClient) DmsgPtyExec(_ DmsgPtyExecArgs) (*dmsgpty.CommandExecResult, error) {
+	return &dmsgpty.CommandExecResult{}, nil
 }
 
 // Ports implements API

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -3,7 +3,9 @@ package visor
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
 	"github.com/skycoin/skywire/pkg/util/rpcutil"
 )
 
@@ -342,6 +344,23 @@ func (r *RPC) RemoteVisors(_ *struct{}, out *[]string) (err error) {
 		*out = remoteVisors
 	}
 	return err
+}
+
+// DmsgPtyExec runs a one-shot command on a remote visor via the
+// embedded dmsgpty host (see Visor.DmsgPtyExec).
+func (r *RPC) DmsgPtyExec(args *DmsgPtyExecArgs, out *dmsgpty.CommandExecResult) (err error) {
+	defer rpcutil.LogCall(r.log, "DmsgPtyExec", args)(out, &err)
+	if args == nil {
+		return fmt.Errorf("dmsgpty: nil args")
+	}
+	res, err := r.visor.DmsgPtyExec(*args)
+	if err != nil {
+		return err
+	}
+	if res != nil {
+		*out = *res
+	}
+	return nil
 }
 
 // Ports return list of all ports used by visor services and apps

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -111,6 +111,13 @@ type Visor struct {
 	// nil when initDmsgpty was skipped (Dmsgpty config absent).
 	dmsgWL dmsgpty.Whitelist
 
+	// dmsgPty is the live dmsgpty.Host instance, exposed so the visor
+	// RPC layer can drive remote pty operations (Exec, list) without
+	// going back through the host's CLI control listener (the unix
+	// socket / TCP loopback the standalone dmsgpty-cli uses). nil when
+	// initDmsgpty was skipped.
+	dmsgPty *dmsgpty.Host
+
 	// DMSG tracker state
 	dmsgTracker dtmState
 


### PR DESCRIPTION
## Summary

`skywire cli dmsg pty exec` was talking to the dmsgpty-host's own CLI control listener (unix `/tmp/dmsgpty.sock` by default) — a separate listener with its own permissions, distinct from the visor RPC at `:3435` that the rest of the integrated CLI uses. The `--rpc` flag on `exec` was decoration: only `list`/`ui`/`url` actually used it.

This patch makes `exec` go through the visor RPC like the help already promised, using a new first-class RPC method backed by a Host-level helper that skips the proxy-via-local-host hop entirely.

## Changes

- **`pkg/dmsg/dmsgpty/host.go`** — new `(*Host).ExecRemote(ctx, rPK, rPort, req)` dials the remote pty host directly via the host's own dmsg client, runs a `PtyClient` against the resulting stream, returns the captured `CommandExecResult`. Wire-equivalent to the proxy-gateway path, just without the local CLI control listener.
- **`pkg/visor/visor.go` + `init_dmsg.go`** — store the live `*dmsgpty.Host` on `Visor` (as `v.dmsgPty`) right after `dmsgpty.NewHost`.
- **`pkg/visor/api.go` + `api_services.go` + `rpc_visor.go` + `rpc_client.go` + `rpc_client_mock.go`** — new `DmsgPtyExec(args)` RPC, request shape `DmsgPtyExecArgs{ RemotePK, RemotePort, Req }`. Server delegates to `Host.ExecRemote`.
- **`cmd/skywire-cli/commands/dmsg/pty.go`** — refactor the non-`--via` branch of `exec` to call `ptyRPCClient(...).DmsgPtyExec(...)` instead of `dmsgpty.DefaultCLI().ExecRemote(...)`. The `--via tcp://<pk>@<host>:<port>` direct-TCP path is unchanged (it was already independent of the local CLI listener).

## What this fixes operationally

An operator running the CLI as the `skywire` user couldn't reach `/tmp/dmsgpty.sock` (`srwxr-xr-x root:root`, others = `r-x` = no connect perm), even though the same user can talk to the visor RPC at `:3435` fine. With this change the integrated CLI follows the same auth gate as every other integrated subcommand. Standalone `dmsgpty-cli` is untouched.

## Out of scope

- Interactive `start` still uses the CLI control listener; routing it through visor RPC needs a streaming RPC, deferred.
- The dmsgpty-host CLI control listener itself isn't touched — operators using `dmsgpty-cli` standalone keep their current path.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/visor/... ./pkg/dmsg/dmsgpty/...` — pass
- [ ] Live verification (`skywire cli dmsg pty exec <peer-pk> -- whoami`) deferred until the new binary lands through the distribution pipeline — the running visor doesn't know about `DmsgPtyExec` until it's restarted on the post-merge build.