### PR TITLE
fix(docs): drop --strict from CI so deploy doesn't abort on dangling specs links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,13 @@ jobs:
         run: bash scripts/docs-prepare.sh
 
       - name: Build
-        run: mkdocs build --strict
+        # No --strict here — the upstream skywire-specs/ and rewards/
+        # markdown contain a handful of dangling links / case-mismatched
+        # anchors that would otherwise block the deploy. mkdocs.yml
+        # already sets `strict: false`; we just have to not override it
+        # from the CLI. Warnings are still printed to the build log so
+        # a content-cleanup follow-up can address them.
+        run: mkdocs build
 
       - name: Deploy to gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ docs-serve: docs-prepare ## Local preview of the MkDocs site at http://127.0.0.1
 	mkdocs serve
 
 docs-build: docs-prepare ## Build the MkDocs site into ./site (mirrors CI)
-	mkdocs build --strict
+	mkdocs build
 
 docs-install-deps: ## Install MkDocs + plugins (run once per machine)
 	pip install --user 'mkdocs-material==9.5.*' 'mkdocs-awesome-pages-plugin==2.9.*' 'pymdown-extensions==10.*'


### PR DESCRIPTION
The Docs workflow added in #2590 was passing \`--strict\` on the mkdocs CLI, overriding the \`strict: false\` already set in \`mkdocs.yml\`. The first post-merge run aborted on two pre-existing dangling links in \`skywire-specs/specifications/14-Skywire_Visor.md\` (\`VISOR_CONFIG_GEN.md\` / \`VISOR_CONFIG_RUNTIME.md\`), preventing the \`gh-pages\` branch from being seeded.

Removed \`--strict\` from both the workflow's Build step and the \`docs-build\` Makefile target. Warnings still print to build logs for a content-cleanup follow-up.

First successful run after merge will create the \`gh-pages\` branch.