### PR TITLE
docs(mkdocs): drop dead apps/ + services/ cards from home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,16 +22,6 @@ extend, or understand a Skywire deployment.
     and live sample output. Generated from the cobra tree on every
     commit to `develop`.
 
-- :material-application-cog: **[Apps](apps/)**
-
-    Visor-hosted applications: skychat, skysocks, skynet, vpn.
-    Per-app behavior and configuration.
-
-- :material-server-network: **[Services](services/)**
-
-    Skywire deployment services: transport-discovery, route-finder,
-    service-discovery, address-resolver, uptime-tracker, etc.
-
 - :material-book-open-page-variant: **[Specs](specs/)**
 
     Protocol-level specifications: transports, packets, routing,
@@ -42,6 +32,17 @@ extend, or understand a Skywire deployment.
     Eligibility rules for the Skywire reward distribution.
 
 </div>
+
+!!! note "Per-app and per-service docs"
+
+    Deep documentation for visor-hosted apps (skychat, skysocks, skynet, vpn)
+    and for the deployment services (transport-discovery, route-finder,
+    service-discovery, address-resolver, uptime-tracker) currently lives
+    alongside the source under
+    [`cmd/apps/`](https://github.com/skycoin/skywire/tree/develop/cmd/apps)
+    and [`cmd/svc/`](https://github.com/skycoin/skywire/tree/develop/cmd/svc).
+    They'll be integrated into this site in a follow-up once their
+    cmd/-relative links are rewritten to live under `docs/`.
 
 ## Other resources
 


### PR DESCRIPTION
The home-page card grid at https://skycoin.github.io/skywire/ pointed at \`/apps/\` and \`/services/\` — paths that 404 because per-app and per-service deep docs were deferred from #2590 along with the rest of the \`cmd/apps/\`, \`cmd/dmsg/\`, and \`cmd/svc/\` READMEs.

Replaced the broken cards with a note pointing readers to the source-adjacent READMEs on GitHub for now and flagging the integration as a follow-up.

The four working sections (Guides, Command Reference, Specs, Rewards) remain in the grid; the top-tab nav was already correct.