### PR TITLE
fix(cli/config/gen): default --pair-enable on skychat so groups work out of the box

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1594,7 +1594,16 @@ func configureApps(log *logging.Logger) {
 				Binary:    "skywire",
 				AutoStart: isSkychatEnable,
 				Port:      routing.Port(skyenv.SkychatPort),
-				Args:      append([]string{"app", "skychat"}, "--addr", chatAddr),
+				// --pair-enable opens the chat-app ↔ visor pair-RPC
+				// channel that group chat needs for the per-partner
+				// CXO feeds (#2580 federated send + #2585 admin mirror)
+				// and for `cli skychat group history` to work. Without
+				// it the chat-app's /status reports
+				// `groups_error: pair-rpc-disabled` and group SSE events
+				// don't reach listeners. Default-on here so a generated
+				// config "just works" for groups; operators who don't
+				// want pair-RPC can edit the args manually.
+				Args: append([]string{"app", "skychat"}, "--addr", chatAddr, "--pair-enable"),
 			},
 			{
 				Name:      skyenv.SkysocksName,
@@ -1673,7 +1682,11 @@ func configureApps(log *logging.Logger) {
 				Name:      skyenv.SkychatName,
 				AutoStart: isSkychatEnable,
 				Port:      routing.Port(skyenv.SkychatPort),
-				Args:      []string{"--addr", chatAddr},
+				// --pair-enable opens chat-app ↔ visor pair-RPC for
+				// group chat. See the external-apps branch above for
+				// the rationale; mirrored here so internal-apps
+				// generated configs behave the same.
+				Args: []string{"--addr", chatAddr, "--pair-enable"},
 			},
 			{
 				Name:      skyenv.SkysocksName,


### PR DESCRIPTION
## Problem

Generated configs hardcoded skychat args as just \`--addr <addr>\`. Without \`--pair-enable\` the chat-app never opens its pair-RPC channel to the visor, which means:

- \`/status\` reports \`groups_error: pair-rpc-disabled\`
- \`cli skychat group history\` fails with "history persistence not enabled"
- group SSE events never reach listeners on \`/sse\`
- the pair-message poller (drains group/pair messages onto the SSE stream) never starts

Operators landed in a bad state where group chat appeared to be working from the visor RPC side (\`group list\` / \`group send\` returned success) but no messages actually flowed end-to-end, because federated send (#2580) and admin mirror feeds (#2585) both depend on the pair-RPC plumbing.

Manual edits to \`/opt/skywire/skywire.json\` get clobbered every time \`skywire-autoconfig\` regenerates the config (on the \`skywire-update\` systemd timer), so the only durable fix is default-on in the generator.

## Fix

Add \`--pair-enable\` to the default skychat args in both code paths of \`configureApps\` (\`cmd/skywire-cli/commands/config/gen.go\`):

- external-apps branch — generated when \`--external-apps\` is used
- internal-apps branch — the default path

\`cli config gen -n --nofetch\` now produces skychat args \`--addr 127.0.0.1:8001 --pair-enable\` instead of \`--addr 127.0.0.1:8001\`.

Operators who specifically don't want pair-RPC can edit the args manually (and re-do so after any regen).

\`--persist\` is deliberately left opt-in — operators should control whether chat history hits a local BoltDB.

## Diagnosed during

Live e2e group-chat testing between deployment servers earlier today. Symptoms: my (Beta) and Alpha's group sends both returned 'sent', acks from 1:1 sends worked normally, but group messages never propagated between hosts. Tracking it down: chat-app \`/status\` showed \`pairing_enabled: false\`, \`groups_error: "pair-rpc-disabled"\` — the pair-RPC channel never opened because \`--pair-enable\` wasn't in the launched args.

## Test plan

- [x] \`go build ./cmd/skywire\` clean
- [x] \`golangci-lint run\` on \`cmd/skywire-cli/commands/config/\` reports 0 issues
- [x] \`cli config gen -n --nofetch\` output includes \`--pair-enable\` in skychat args
- [ ] Post-merge: re-run autoconfig on production hosts; verify \`/status\` reports \`pairing_enabled: true\` and \`groups_error\` is absent; verify e2e group send between Alpha + Beta + Gamma