### PR TITLE
fix(skychat/group): owner-role peerSubs also need reconnect coverage

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -576,10 +576,11 @@ func (m *Manager) runReconnectLoop(ctx context.Context) {
 	}
 }
 
-// detectStaleAndReconnect walks every member-role session and
-// triggers a reconnect attempt on any whose Session.LastInbound()
-// is older than subscriberStaleThreshold (or whose session has
-// never observed an inbound, indicated by a zero LastInbound).
+// detectStaleAndReconnect walks every session (both owner-role AND
+// member-role) and triggers a reconnect attempt on any whose
+// Session.LastInbound() is older than subscriberStaleThreshold (or
+// whose session has never observed an inbound, indicated by a zero
+// LastInbound).
 //
 // This is the recovery driver for the unified liveness signal:
 // IsSubscriberAlive is a pure function of LastInbound, and this
@@ -589,10 +590,27 @@ func (m *Manager) runReconnectLoop(ctx context.Context) {
 // (joined/left/revoked), not subscriber health. Health is
 // computed live from LastInbound on every /status read.
 //
-// Skips: owner-role sessions (no subscriber), revoked records,
-// sessions without a corresponding live Session in m.sessions.
-// A zero LastInbound on a live session IS treated as stale —
-// we never saw the subscriber attach, so a reconnect is warranted.
+// Pre-#2580 only member-role sessions had subscribers needing
+// reconnect (owner just published, didn't subscribe). Post-#2580
+// (federated send) every session — owner included — has a
+// peerSubs map of per-PK subscribers to other members' feeds, and
+// those need the same auto-reconnect coverage. Without it, when a
+// peer restarts its publisher (e.g. operator does group leave +
+// rejoin to refresh a stale subscriber), the owner's peerSub to
+// that peer goes stale and never recovers until the owner halts
+// its own visor.
+//
+// Skips: revoked records, sessions without a corresponding live
+// Session in m.sessions. A zero LastInbound on a live session IS
+// treated as stale — we never saw any peer leaf arrive, so a
+// reconnect is warranted.
+//
+// Granularity note: LastInbound is per-session, not per-peerSub.
+// For owner sessions with multiple peers, a single chatty peer
+// keeps LastInbound fresh and masks the staleness of any silent
+// peer's peerSub. A future refinement would track per-peer
+// liveness; for now the per-session signal is strictly better
+// than the pre-fix "no reconnect coverage for owners at all".
 func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
@@ -603,9 +621,6 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 	}
 	now := time.Now().UTC()
 	for _, r := range records {
-		if r.Role != RoleMember {
-			continue
-		}
 		// Both Active and Pending records get the stale-check.
 		// Active records that drift stale + Pending records that
 		// never finished the initial Connect both want a kick from


### PR DESCRIPTION
## Summary

\`Manager.detectStaleAndReconnect\` gated on \`Role != RoleMember\`
and skipped owner-role sessions entirely. Pre-#2580 that was fine —
owners only had a publisher, no subscribers needing reconnect.
Post-#2580 federated send, every session (owner included) has a
\`peerSubs\` map of per-PK subscribers to other members' feeds, and
those need the same auto-reconnect coverage.

## Symptom

When a peer restarts its publisher (e.g. operator does \`group
leave + rejoin\` to refresh a stale subscriber, or visor restart
that bounces the publisher), the owner's \`peerSub\` to that peer
goes stale and never recovers until the owner halts its own
visor. The symmetric break shows up as one-direction message
loss that the operator can't diagnose without pprof.

Discovered 2026-05-14 during a 3-agent group-chat reliability
test: Beta did \`leave + join\` to refresh their subscriber;
afterwards Alpha (owner)'s peerSub to Beta stayed stuck and
\`last_message_at\` on Alpha's session never advanced past
self-echoes until Alpha halted its visor (forcing fresh peerSubs
at \`openLocked\`).

## Fix

Drop the role-gate in \`detectStaleAndReconnect\`. \`Session.Connect\`
already handles both roles cleanly (the legacy \`s.sub\` is nil-
checked for owner sessions, then the peerSubs Connect loop runs for
both), so no other change is needed.

## Caveat (per-session vs per-peer liveness)

\`LastInbound\` is per-session, not per-peerSub. For owner sessions
with multiple peers, one chatty peer keeps LastInbound fresh and
masks the staleness of any silent peer's peerSub. Per-peer liveness
is a follow-up — the per-session signal here is strictly better
than the pre-fix "no reconnect coverage for owners at all".

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/group/...\` passes
- [x] \`make format check\` passes
- [ ] Manual: three-visor group; peer-side leave+rejoin while owner's visor is running; verify owner's peerSub recovers within the 30s reconnect interval (or backoff window) instead of requiring an owner halt