### PR TITLE
fix(cli/config/gen): SKYCHATPAIR env knob for --pair-enable + conf template entry

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -138,6 +138,10 @@ const envfileLinux = `#
 #--	Skychat local address
 #SKYCHATADDR=':8001'
 
+#--	Skychat pair-RPC channel to visor (required for group chat).
+#--	Default: true. Set to false to disable group-chat plumbing.
+#SKYCHATPAIR=false
+
 #--	Whitelist public keys for the proxy server (empty = allow all)
 #PROXYSERVERWL=('')
 
@@ -391,6 +395,10 @@ const envfileWindows = `#
 
 #--	Skychat local address
 #$SKYCHATADDR=':8001'
+
+#--	Skychat pair-RPC channel to visor (required for group chat).
+#--	Default: true. Set to false to disable group-chat plumbing.
+#$SKYCHATPAIR=$false
 
 #--	Whitelist public keys for the proxy server (empty = allow all)
 #$PROXYSERVERWL=@('')

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -299,6 +299,8 @@ func init() {
 	genConfigCmd.Flags().BoolVar(&isSkychatEnable, "servechat", scriptExecBool("${SKYCHAT:-true}"), "autostart skychat (default: true)")
 	genConfigCmd.Flags().StringVar(&skychatAddr, "chataddr", scriptExecString("${SKYCHATADDR:-"+skyenv.SkychatAddr+"}"), "skychat local address")
 	gHiddenFlags = append(gHiddenFlags, "chataddr")
+	genConfigCmd.Flags().BoolVar(&isSkychatPairEnable, "servechatpair", scriptExecBool("${SKYCHATPAIR:-true}"), "skychat: enable pair-RPC channel to visor (required for group chat)")
+	gHiddenFlags = append(gHiddenFlags, "servechatpair")
 
 	// Skycoin embedded apps. Default-off for both — operator opts in
 	// per-app via these flags or via SKYENV. The wallet's user-drop
@@ -1571,6 +1573,31 @@ func splitDaemonFlags(s string) ([]string, error) {
 	return visorconfig.SplitArgs(s)
 }
 
+// skychatExternalArgs builds the launcher Args slice for the skychat
+// app under external-apps mode (apps run as separate `skywire app`
+// invocations). When pair is true the chat-app gets --pair-enable,
+// which opens its pair-RPC channel to the visor and is required for
+// group chat (#2580 federated send, #2585 admin mirror feeds) to
+// actually propagate messages.
+func skychatExternalArgs(addr string, pair bool) []string {
+	args := []string{"app", "skychat", "--addr", addr}
+	if pair {
+		args = append(args, "--pair-enable")
+	}
+	return args
+}
+
+// skychatInternalArgs mirrors skychatExternalArgs for internal-apps
+// mode (apps run inside the visor process). The external-mode "app"
+// "skychat" prefix is dropped — the launcher routes by app Name.
+func skychatInternalArgs(addr string, pair bool) []string {
+	args := []string{"--addr", addr}
+	if pair {
+		args = append(args, "--pair-enable")
+	}
+	return args
+}
+
 // configureApps sets up launcher app configurations (internal or external),
 // handles app disable/enable flags, and configures VPN/proxy app settings.
 func configureApps(log *logging.Logger) {
@@ -1600,10 +1627,9 @@ func configureApps(log *logging.Logger) {
 				// and for `cli skychat group history` to work. Without
 				// it the chat-app's /status reports
 				// `groups_error: pair-rpc-disabled` and group SSE events
-				// don't reach listeners. Default-on here so a generated
-				// config "just works" for groups; operators who don't
-				// want pair-RPC can edit the args manually.
-				Args: append([]string{"app", "skychat"}, "--addr", chatAddr, "--pair-enable"),
+				// don't reach listeners. Default-on via SKYCHATPAIR
+				// (overridable in /etc/skywire.conf).
+				Args: skychatExternalArgs(chatAddr, isSkychatPairEnable),
 			},
 			{
 				Name:      skyenv.SkysocksName,
@@ -1686,7 +1712,7 @@ func configureApps(log *logging.Logger) {
 				// group chat. See the external-apps branch above for
 				// the rationale; mirrored here so internal-apps
 				// generated configs behave the same.
-				Args: []string{"--addr", chatAddr, "--pair-enable"},
+				Args: skychatInternalArgs(chatAddr, isSkychatPairEnable),
 			},
 			{
 				Name:      skyenv.SkysocksName,

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -110,6 +110,13 @@ var (
 	enableCalculateRoutes      bool
 	isSkychatEnable            bool
 	skychatAddr                string
+	// isSkychatPairEnable adds --pair-enable to the skychat app args
+	// in the generated config. Defaults to true; toggle via SKYCHATPAIR
+	// in /etc/skywire.conf or --servechatpair=false on the CLI. The
+	// pair-RPC channel is required for group chat (#2580 federated send
+	// and #2585 admin mirror) to actually propagate messages, so this
+	// should rarely be off in practice.
+	isSkychatPairEnable bool
 	// Skycoin embedded apps — daemon (full node) + web (thin-client
 	// wallet). Default-off for both. SkycoinWebUser drops the wallet
 	// process to a different UID via the launcher's per-app


### PR DESCRIPTION
Follow-up to #2594.

#2594 hardcoded \`--pair-enable\` in the generated skychat args — fix the symptom but offered no way to disable from \`/etc/skywire.conf\`. Operators wanting to opt out had to edit the generated JSON each time, which the \`skywire-update\` timer clobbers on its next tick.

Switched to a proper SKYENV knob:

\`\`\`
SKYCHATPAIR=true    (default; --pair-enable in generated args)
SKYCHATPAIR=false   (omits --pair-enable; opts out of group chat)
\`\`\`

Same shape as the existing \`SKYCHAT\` / \`SKYCHATADDR\` variables, set in \`/etc/skywire.conf\` and respected by \`skywire-cli config gen\`. Default stays true so a fresh install "just works" for group chat; operators who don't want pair-RPC can flip it in skywire.conf and the change persists across autoconfig regen.

## Wiring

- \`root.go\` — new \`isSkychatPairEnable\` bool with doc-comment
- \`gen.go\` — new \`--servechatpair\` hidden flag, default \`\${SKYCHATPAIR:-true}\`
- \`gen.go\` — \`skychatExternalArgs\` / \`skychatInternalArgs\` helpers used in both \`configureApps\` branches
- \`envfiles.go\` — linux + windows SKYENV templates include \`#SKYCHATPAIR=false\` commented line so operators discover it from \`cli config gen -q\`

## Verified

| Scenario | skychat args |
|---|---|
| Default | \`--addr 127.0.0.1:8001 --pair-enable\` |
| \`SKYENV=conf cli config gen -n --nofetch\` with \`SKYCHATPAIR=false\` | \`--addr 127.0.0.1:8001\` |
| \`cli config gen -q\` template emits \`#SKYCHATPAIR=false\` | ✓ |
| \`golangci-lint run\` on the config package | 0 issues |