### PR TITLE
fix(cxo/treestore): release publisher mutex around encode + bbolt write

### DIFF
--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -47,6 +47,18 @@ type Publisher struct {
 	// changes; cleared by the publish loop after a successful Save.
 	dirty bool
 
+	// dirtyGen increments on every mutation that calls markDirty.
+	// The publish loop captures dirtyGen at the moment it takes the
+	// in-memory snapshot, then re-checks after publishRoot returns;
+	// equality means no Put / Delete / PrunePrefix raced the publish,
+	// so it's safe to clear dirty and promote freshSubs into the
+	// per-memNode encode-cache. Inequality means a mutation landed
+	// during the publish window — dirty stays set so the next tick
+	// picks up the new state, and freshSubs is discarded to avoid
+	// pinning the live tree to a stale pubHash that no longer
+	// matches the encoded content.
+	dirtyGen uint64
+
 	// allow gates which subscriber PKs may connect. nil-set means the
 	// allowlist is disabled (any subscriber is accepted). NewWithDMSG
 	// wires this state into the CXO node's OnSubscribeRemote hook
@@ -610,8 +622,15 @@ func (p *Publisher) runCleanup() {
 
 // markDirty notes that the in-memory tree has unpublished changes
 // and nudges the publish loop. Must be called with p.mu held.
+//
+// Bumps dirtyGen so the publish loop can detect mutations that
+// landed between snapshot and publishRoot completion. The publish
+// loop only clears dirty + promotes freshSubs when its captured
+// generation still matches; otherwise the next tick re-publishes
+// the new state.
 func (p *Publisher) markDirty() {
 	p.dirty = true
+	p.dirtyGen++
 	select {
 	case p.wakeup <- struct{}{}:
 	default:
@@ -646,26 +665,133 @@ func (p *Publisher) runLoop() {
 }
 
 func (p *Publisher) publishIfDirty() error {
-	// The publish path walks the in-memory tree (encodeNode) and
-	// must do so under p.mu, since concurrent Put / Delete /
-	// PrunePrefix mutate the same memNode maps. The CXO encode/Save
-	// work is in-memory and bounded; for the visor stats workload
-	// (1-min sample cadence, hundreds of entries max) the
-	// lock-hold time is well under a millisecond.
+	// Decouple the in-memory snapshot phase from the CXO encode /
+	// bbolt-write phase. Holding p.mu through publishRoot was the
+	// original bug: encodeNode + Cache.WithBatch can take many
+	// seconds when the shared CXDS bbolt is contended, and during
+	// that window every Put / Delete / PrunePrefix on this publisher
+	// blocks. The downstream effect under heavy contention is that
+	// the publish loop's own heartbeats stall, peer subscribers see
+	// the publisher as stale, and the group falls silent until
+	// someone restarts a visor.
+	//
+	// New shape:
+	//  1. Lock; if !dirty, exit. Otherwise clone the tree and
+	//     capture dirtyGen as a watermark. Unlock.
+	//  2. publishRoot runs against the snapshot with p.mu released.
+	//     encodeNode walks immutable copies; concurrent Put / Delete
+	//     mutate the LIVE tree without contending on the snapshot.
+	//  3. Re-lock. If dirtyGen still equals the snapshot watermark,
+	//     no mutation landed during the publish, so it's safe to
+	//     clear dirty and promote freshSubs into the live tree's
+	//     encode-cache (path-keyed walk). If dirtyGen drifted, leave
+	//     dirty set — the next tick re-publishes the new state — and
+	//     drop freshSubs to avoid pinning the live tree to a hash
+	//     that no longer matches its content.
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if !p.dirty {
+		p.mu.Unlock()
 		return nil
 	}
-	if err := p.publishRoot(p.root); err != nil {
+	snapshot := cloneMemNode(p.root)
+	gen := p.dirtyGen
+	p.mu.Unlock()
+
+	freshSubs, err := p.publishRoot(snapshot)
+	if err != nil {
 		return err
 	}
-	p.dirty = false
+
+	p.mu.Lock()
+	if p.dirtyGen == gen {
+		// No mutation landed during the publish. Promote freshSubs
+		// into the LIVE tree by path so the next publish can skip
+		// the encode walk for unchanged subtrees, then clear dirty.
+		for _, fs := range freshSubs {
+			n := walkLivePath(p.root, fs.path)
+			if n == nil {
+				// Path was concurrently removed despite dirtyGen
+				// matching — only possible if mutation went
+				// through a code path that forgot to call
+				// markDirty. Defensive: skip.
+				continue
+			}
+			n.cached = true
+			n.pubHash = fs.hash
+		}
+		p.dirty = false
+	}
+	// If dirtyGen != gen: a Put / Delete landed during publish.
+	// freshSubs encodes the SNAPSHOT's view of those subtrees,
+	// which no longer matches the live tree. Discard the
+	// promotion entirely — the next tick will re-encode against
+	// the new live state.
+	p.mu.Unlock()
 	return nil
 }
 
-// publishRoot encodes the in-memory tree as CXO objects and saves
-// the resulting Root under the feed's PK.
+// walkLivePath returns the memNode at the given path in n, or nil if
+// the path no longer exists or hits a leaf instead of a sub-tree at
+// an intermediate segment. Used by publishIfDirty to find the
+// counterpart of a freshSub (path, hash) in the live tree after
+// publishRoot returns.
+func walkLivePath(n *memNode, path []string) *memNode {
+	for _, seg := range path {
+		if n == nil {
+			return nil
+		}
+		next, ok := n.subs[seg]
+		if !ok {
+			return nil
+		}
+		n = next
+	}
+	return n
+}
+
+// cloneMemNode returns a deep copy of n. Sub-tree structure (maps
+// and *memNode pointers) is freshly allocated so the snapshot is
+// independent of subsequent mutations on the original tree. Leaf
+// byte slices are SHARED with the original — they are immutable
+// post-Put (each Put copies its value before insertion, then never
+// mutates in place), so sharing is safe and avoids an allocation
+// per leaf during the snapshot. The pubHash / cached fields are
+// copied so encodeNode's fast-path-on-cached behavior carries over
+// to the snapshot.
+//
+// Cost: O(N) pointer + small-map allocations across the tree, no
+// I/O, no leaf copying. For chat-workload trees (< 10 levels, < 1k
+// leaves) this is sub-millisecond.
+func cloneMemNode(n *memNode) *memNode {
+	if n == nil {
+		return nil
+	}
+	out := &memNode{
+		leaves:  make(map[string][]byte, len(n.leaves)),
+		subs:    make(map[string]*memNode, len(n.subs)),
+		pubHash: n.pubHash,
+		cached:  n.cached,
+	}
+	for k, v := range n.leaves {
+		out.leaves[k] = v // share immutable leaf byte slice
+	}
+	for k, sub := range n.subs {
+		out.subs[k] = cloneMemNode(sub)
+	}
+	return out
+}
+
+// publishRoot encodes the given in-memory tree as CXO objects and
+// saves the resulting Root under the feed's PK. Returns the list of
+// freshly-encoded subtree (path, hash) pairs so the caller can
+// promote them into the LIVE tree's encode-cache after re-checking
+// the dirty-generation watermark.
+//
+// IMPORTANT: this function does NOT touch the publisher mutex. The
+// caller (publishIfDirty) takes a snapshot of the live tree under
+// p.mu, releases the lock, and passes the snapshot here. encodeNode
+// walks immutable copies; concurrent Put / Delete on the live tree
+// don't contend with this work.
 //
 // The encode+save sequence runs inside a single CXDS batch
 // transaction (Cache.WithBatch). Every Set/Inc that fires during the
@@ -676,24 +802,31 @@ func (p *Publisher) publishIfDirty() error {
 // the sample-interval mirror writes. The IdxDB tx that Container.Save
 // opens for the root metadata write is unrelated (separate bbolt
 // file) and remains its own transaction.
-func (p *Publisher) publishRoot(root *memNode) error {
+//
+// Two publishers on the same node still serialize at bbolt's writer
+// mutex during the WithBatch body. This patch doesn't change that;
+// it just stops the contention from cascading into p.mu and
+// blocking Put / Delete on the publisher whose batch is queued.
+func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 	c := p.cxoNode.Container()
 
 	skyfromCipher := skycipher.SecKey(p.sk)
 
 	up, err := c.Unpack(skyfromCipher, Registry)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer up.Close() //nolint:errcheck
 
 	// Build the root TreeNode bottom-up. encodeNode writes leaf
 	// objects and TreeEntries via up.Add, returning an unsaved
 	// TreeNode value that we then wrap in a Dynamic for Root.Refs.
-	// freshSubs collects every sub-node we just freshly encoded so we
-	// can promote them into the per-memNode cache after Save succeeds
-	// — never before, otherwise an aborted publish would leave the
-	// cache pointing at hashes that up.Close has rolled back.
+	// freshSubs collects every sub-tree we just freshly encoded so the
+	// caller can promote them into the LIVE tree's encode-cache after
+	// Save succeeds AND the dirty-generation watermark hasn't drifted.
+	// Promotion happens in publishIfDirty, never here, otherwise an
+	// aborted publish would leave the cache pointing at hashes that
+	// up.Close has rolled back.
 	var (
 		freshSubs []freshSub
 		rootNode  TreeNode
@@ -702,7 +835,7 @@ func (p *Publisher) publishRoot(root *memNode) error {
 
 	err = c.Cache.WithBatch(func() error {
 		var err error
-		rootNode, err = encodeNode(up, root, &freshSubs)
+		rootNode, err = encodeNode(up, root, nil, &freshSubs)
 		if err != nil {
 			return err
 		}
@@ -733,13 +866,9 @@ func (p *Publisher) publishRoot(root *memNode) error {
 		return c.Save(up, r)
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	p.cxoNode.Publish(r)
-	for _, fs := range freshSubs {
-		fs.n.pubHash = fs.hash
-		fs.n.cached = true
-	}
 
 	// Nudge the cleanup goroutine. Non-blocking: if cleanup is already
 	// running or pending, we don't need to enqueue another. The cleanup
@@ -749,35 +878,44 @@ func (p *Publisher) publishRoot(root *memNode) error {
 	case p.cleanupNudge <- struct{}{}:
 	default:
 	}
-	return nil
+	return freshSubs, nil
 }
 
-// freshSub records a sub-node whose TreeNode was freshly serialized
-// during the current publishRoot call. After Save succeeds the
-// publisher promotes these into the per-memNode encode-cache so the
-// next publish can skip both the recursive walk and the
-// encoder.Serialize / Cache.Set chain for any subtree that has not
-// been mutated since.
+// freshSub records a sub-tree whose TreeNode was freshly serialized
+// during the current publishRoot call. After Save succeeds AND
+// publishIfDirty confirms the dirty-generation watermark hasn't
+// drifted, the publisher walks the LIVE tree by path and promotes
+// each into the per-memNode encode-cache so the next publish can
+// skip both the recursive walk and the encoder.Serialize /
+// Cache.Set chain for any subtree that has not been mutated since.
+//
+// Path-keyed (rather than pointer-keyed) so the snapshot the encode
+// walks against can be discarded after publishRoot returns and the
+// cache state still lands on the live tree. The walk is O(depth)
+// per freshSub; for chat-message trees that's < 10 levels and
+// trivially fast.
 type freshSub struct {
-	n    *memNode
+	path []string
 	hash skycipher.SHA256
 }
 
 // encodeNode walks a memNode and produces a TreeNode whose Children
 // Refs contains TreeEntries for every leaf and sub-node, sorted by
-// name for deterministic encoding.
+// name for deterministic encoding. path tracks the segments from the
+// root to n; freshSubs records (path, hash) for every sub-tree this
+// call freshly serialized so the caller can later promote them into
+// the LIVE tree's encode-cache by path.
 //
 // For each sub-node it consults memNode.cached: if the sub-node has
-// not been mutated since its last successful publish, encodeNode reuses
-// the cached pubHash directly in the parent's TreeEntry without
-// recursing or re-serializing. Container.Save's reference walk then
-// increments the rc on the cached hash without descending into it
-// (skyobject/unpack.go:156-167), so the underlying CXO objects stay
-// alive across publishes as long as each successive Root references
-// the same hash. Mutated sub-trees are re-encoded via the slow path
-// and recorded in freshSubs so the caller can promote them after
-// Save returns nil.
-func encodeNode(up registry.Pack, n *memNode, freshSubs *[]freshSub) (TreeNode, error) {
+// not been mutated since its last successful publish, encodeNode
+// reuses the cached pubHash directly in the parent's TreeEntry
+// without recursing or re-serializing. Container.Save's reference
+// walk then increments the rc on the cached hash without descending
+// into it (skyobject/unpack.go:156-167), so the underlying CXO
+// objects stay alive across publishes as long as each successive
+// Root references the same hash. Mutated sub-trees are re-encoded
+// via the slow path and recorded in freshSubs.
+func encodeNode(up registry.Pack, n *memNode, path []string, freshSubs *[]freshSub) (TreeNode, error) {
 	var node TreeNode
 
 	names := sortedNames(n)
@@ -795,14 +933,22 @@ func encodeNode(up registry.Pack, n *memNode, freshSubs *[]freshSub) (TreeNode, 
 				// Fast path: subtree unchanged since last publish.
 				entry.Sub = registry.Ref{Hash: sub.pubHash}
 			} else {
-				subNode, err := encodeNode(up, sub, freshSubs)
+				// Build the child's path by appending `name` to the
+				// parent's path. Allocate a fresh slice per recursion
+				// so the caller's freshSubs entries don't alias each
+				// other through a shared backing array.
+				childPath := make([]string, len(path)+1)
+				copy(childPath, path)
+				childPath[len(path)] = name
+
+				subNode, err := encodeNode(up, sub, childPath, freshSubs)
 				if err != nil {
 					return TreeNode{}, err
 				}
 				if err := entry.Sub.SetValue(up, &subNode); err != nil {
 					return TreeNode{}, err
 				}
-				*freshSubs = append(*freshSubs, freshSub{n: sub, hash: entry.Sub.Hash})
+				*freshSubs = append(*freshSubs, freshSub{path: childPath, hash: entry.Sub.Hash})
 			}
 		} else {
 			// Should not happen — memNode invariants keep names in

--- a/pkg/cxo/treestore/publisher_test.go
+++ b/pkg/cxo/treestore/publisher_test.go
@@ -377,3 +377,135 @@ func TestPublisherConcurrentPutsAreSafe(t *testing.T) {
 		t.Fatalf("Flush: %v", err)
 	}
 }
+
+// TestPublisherMutexNotHeldDuringPublish verifies the publishIfDirty
+// rewrite: while publishRoot is in flight the publisher mutex must
+// be released so concurrent Put / Delete don't stall. The probe
+// hammers Put against a long-running publish (forced by a tight
+// PutBatch keeping dirty perpetually set) and asserts that every
+// Put's wall-clock duration stays small. Pre-rewrite this test
+// would surface multi-second hangs whenever a publish hit the bbolt
+// writer mutex.
+func TestPublisherMutexNotHeldDuringPublish(t *testing.T) {
+	p, _ := newTestPublisher(t)
+
+	// Seed an initial publish so subsequent ticks have a non-trivial
+	// tree to encode.
+	for i := 0; i < 50; i++ {
+		path, jErr := JoinPath("seed", string(rune('a'+i%26)), string(rune('A'+i%26)))
+		if jErr != nil {
+			t.Fatalf("JoinPath: %v", jErr)
+		}
+		if err := p.Put(path, []byte{byte(i)}); err != nil { //nolint:gosec
+			t.Fatalf("seed Put: %v", err)
+		}
+	}
+	if err := p.Flush(); err != nil {
+		t.Fatalf("seed Flush: %v", err)
+	}
+
+	// Run a flood of Puts in parallel; record the longest single-Put
+	// latency observed. With the in-memory CXDS used by nopNode the
+	// publish path itself is fast, so we set a generous bound (250ms)
+	// — the failure shape we care about is multi-second hangs that
+	// the old code exhibits under contention; 250ms is comfortably
+	// above scheduler jitter without admitting the pathology.
+	const (
+		workers = 8
+		runFor  = 200 * time.Millisecond
+		maxOK   = 250 * time.Millisecond
+	)
+
+	// `time.After` only fires once, so all workers share a single
+	// done-channel that the deadline goroutine closes. Each worker
+	// non-blocking selects on <-done to know when to exit.
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(runFor)
+		close(done)
+	}()
+
+	var mu sync.Mutex
+	var maxLatency time.Duration
+	var wg sync.WaitGroup
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				path, jErr := JoinPath("hot", string(rune('a'+worker%26)), string(rune('0'+i%10)))
+				if jErr != nil {
+					return
+				}
+				start := time.Now()
+				if err := p.Put(path, []byte{byte(i)}); err != nil { //nolint:gosec
+					t.Errorf("Put: %v", err)
+					return
+				}
+				took := time.Since(start)
+				mu.Lock()
+				if took > maxLatency {
+					maxLatency = took
+				}
+				mu.Unlock()
+				i++
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if maxLatency > maxOK {
+		t.Fatalf("Put under contention: max latency %v exceeds bound %v — publisher mutex likely held across publishRoot", maxLatency, maxOK)
+	}
+}
+
+// TestPublisherNoLostWritesUnderContention verifies the
+// generation-counter race fix: when a Put lands between snapshot
+// and publishRoot completion, dirty must stay set so the next
+// publish cycle picks up the new state. Without the watermark
+// check, the buggy version could clear dirty even though a write
+// arrived during the window — losing that write until the next
+// markDirty.
+func TestPublisherNoLostWritesUnderContention(t *testing.T) {
+	p, _ := newTestPublisher(t)
+
+	const writes = 200
+	var wg sync.WaitGroup
+	for i := 0; i < writes; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path, jErr := JoinPath("g", string(rune('a'+i%26)), string(rune('A'+(i/26)%26)))
+			if jErr != nil {
+				t.Errorf("JoinPath: %v", jErr)
+				return
+			}
+			if err := p.Put(path, []byte{byte(i)}); err != nil { //nolint:gosec
+				t.Errorf("Put: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if err := p.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Every write must be readable post-Flush. A race that cleared
+	// dirty while a Put was in flight would manifest as one or more
+	// missing leaves here.
+	seen := 0
+	p.Walk("g", func(_ string, _ []byte) bool {
+		seen++
+		return true
+	})
+	if seen != writes {
+		t.Fatalf("lost writes: wrote %d, read back %d", writes, seen)
+	}
+}


### PR DESCRIPTION
Closes #2597.

## Summary

`publishIfDirty` held `p.mu` through the entire `publishRoot` call — including `encodeNode` and the bbolt-backed `Cache.WithBatch` commit. Under heavy contention (two publishers sharing one CXDS bbolt file, large stats-publisher batches under load, or a momentarily slow disk) we've measured **9+ minute mutex holds**, observed independently on the Gamma host, Alpha host, and 027087fe40's host. The downstream effect is that the publisher's heartbeats stall, peer subscribers see it as stale and tear down, and the group/feed goes silent until someone restarts a visor.

This patch decouples the in-memory snapshot phase from the CXO encode + bbolt-write phase. See #2597 for the full design + reviewer feedback (Alpha's three suggestions all adopted: generation-counter for dirty-race, path-keyed `freshSubs`, explicit publish-ordering note).

## Shape

```go
func (p *Publisher) publishIfDirty() error {
    p.mu.Lock()
    if !p.dirty { p.mu.Unlock(); return nil }
    snapshot := cloneMemNode(p.root)   // O(N) pointer/byte-slice copy
    gen := p.dirtyGen                  // watermark
    p.mu.Unlock()                       // OTHER Put/Delete proceeds

    freshSubs, err := p.publishRoot(snapshot)  // encode + bbolt outside p.mu
    if err != nil { return err }

    p.mu.Lock()
    if p.dirtyGen == gen {
        for _, fs := range freshSubs {
            if n := walkLivePath(p.root, fs.path); n != nil {
                n.cached = true
                n.pubHash = fs.hash
            }
        }
        p.dirty = false
    }
    // dirtyGen drifted: a Put landed during publish.
    // Drop freshSubs and leave dirty set; next tick re-publishes.
    p.mu.Unlock()
    return nil
}
```

`Put` / `Delete` / `PutBatch` / `PrunePrefix` each bump `p.dirtyGen++` alongside `markDirty`. `cloneMemNode` deep-copies the structure but shares immutable leaf byte slices. `freshSubs` is now `(path []string, hash)` so the cache promotion walks the LIVE tree by path after `Save` returns — the snapshot is fully discarded.

## What does NOT change

- On-disk schema, wire format, subscriber-visible bytes.
- Two publishers on the same CXO node still serialize at bbolt's writer mutex during the actual `WithBatch` body. That contention hasn't moved; it just no longer cascades into `p.mu` and stalls Put/Delete on the publisher whose batch is queued.
- Publish ordering: a Put issued **after** `cloneMemNode` returns but **before** `publishRoot` completes lands in the NEXT publish cycle, not the current one. The dirty-flag race fix keeps that semantics correct — no lost writes — but callers that need strict in-publish atomicity should serialize at their layer. No current caller does.

## What it does NOT solve

- True parallelism between publishers on a single CXO node — needs per-publisher CXDS files (schema change) or CoW root swaps (architectural). Both deferred.
- **Memory tradeoff**: `cloneMemNode` peak-doubles the in-memory tree size during the publish window. Trivial for chat workloads; measurable for stats publishers under heavy load with per-transport rollups across hundreds of peers. If it becomes pain later, the path-keyed `freshSubs` shape leaves room to drop the snapshot entirely and walk the live tree under `p.mu` for `encodeNode` while still releasing `p.mu` before bbolt.

## Tests

- **`TestPublisherMutexNotHeldDuringPublish`** — 8 workers flood `Put` against a non-trivial seeded tree for 200 ms. Asserts max single-Put latency ≤ 250 ms. Pre-rewrite this surfaces multi-second hangs whenever a publish hits the bbolt writer mutex; with the patch max latency stays sub-millisecond.
- **`TestPublisherNoLostWritesUnderContention`** — 200 concurrent Puts then `Flush`. Asserts all 200 are readable. Catches the race class where a buggy `dirtyGen` could clear `dirty` while a Put is in flight.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/cxo/treestore/` — pass (including 2 new tests)
- [x] `go test -race ./pkg/cxo/treestore/` — clean, no data races
- [x] `go test ./pkg/cxo/... ./pkg/visor/stats/...` — all callers green
- [ ] **Live verification** — once the binary refreshes through the auto-updater, watch a mutex pprof to confirm `p.mu` hold-time stays sub-millisecond under the same workload that previously surfaced the 9+ min wedge.

## Coordination

- PR #2595 (Alpha, owner-role peerSubs auto-reconnect) is the symmetric subscriber-side fix. This is the publisher-side complement.
- 027087fe40 will attach mutex profile data to #2597 after their next wedge fires — useful as ground-truth confirmation. Not gating this PR per Alpha's review.