### PR TITLE
fix(skychat/group): owner's own heartbeat must not bump lastInboundNs

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1263,13 +1263,29 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 	// the local handler should see the same content the (decoded)
 	// subscriber path would surface, not the encrypted bytes.
 	// Filter heartbeat self-echoes out of the handler delivery —
-	// they are wire-level liveness probes, not chat content. Still
-	// bump lastInboundNs so the owner's own session has a fresh
-	// liveness timestamp (useful symmetry with member sessions; the
-	// detectStaleAndReconnect pass skips owners but other diagnostics
-	// may look at it).
+	// they are wire-level liveness probes, not chat content.
+	//
+	// Critically: do NOT bump lastInboundNs here. Pre-#2595 this
+	// bump was harmless because detectStaleAndReconnect skipped
+	// owner-role sessions entirely (the "useful symmetry" the prior
+	// comment claimed didn't actually drive any behavior). Post-
+	// #2595 the reconnect loop covers owner-role peerSubs too, and
+	// the owner's OWN heartbeat (every 30s by default) bumping
+	// lastInboundNs keeps every owner session permanently
+	// "fresh" — staleness threshold (100s) is never crossed,
+	// reconnect never fires, peer-publisher restarts are never
+	// recovered from. The bump made reconnect a no-op for owners
+	// since #2595 landed.
+	//
+	// lastInboundNs is the **inbound** liveness signal — it should
+	// only advance on observable inbound events from PEERS. Local
+	// heartbeat emission is an outbound write; it proves the
+	// publisher is healthy enough to publish but says nothing about
+	// whether peer subscribers are attached or peer publishers are
+	// reachable. Conflating the two masked the peerSub reachability
+	// problem that #2600's Connect-error-on-zero-success aimed to
+	// surface.
 	if text == HeartbeatMarker {
-		s.lastInboundNs.Store(time.Now().UnixNano())
 		return nil
 	}
 	if h := s.handler; h != nil {


### PR DESCRIPTION
publishAs's heartbeat-filter branch was bumping `lastInboundNs` every time the owner emitted a heartbeat (every 30s by default).

Pre-#2595 `detectStaleAndReconnect` skipped owner-role sessions, so the bump was harmless. Post-#2595 the reconnect loop covers owner-role peerSubs too — and the owner's OWN heartbeat now keeps `lastInboundNs` **permanently fresh**: staleness threshold (100s) is never crossed, reconnect never fires, peer-publisher restarts are never recovered from.

## Net effect

An owner-role session's peerSubs go silently dead after ANY peer restarts their publisher, with no recovery until the owner halts their own visor. Pairs poorly with #2600's Connect-error-on-zero-success — that fix surfaces failures to the backoff counter, but the reconnect loop never even ENTERS the failing Connect path because `lastInboundNs` looks fresh thanks to the heartbeat bump.

## The fix

Don't bump `lastInboundNs` on heartbeat emission. `lastInboundNs` is the **inbound** liveness signal — should advance only on observable inbound events FROM PEERS. Local heartbeat is outbound; proves the publisher is healthy but says nothing about subscribers.

## Series context (third fix in this code path today)

1. #2595 — drop role-gate so reconnect loop covers owner-role
2. #2600 — Connect returns error when 0 peerSubs attached, so backoff engages
3. **this PR** — heartbeat doesn't bump lastInboundNs, so reconnect loop actually enters the failing Connect path

Each prior fix unmasked the next bug in the chain. Together they make owner-role peerSub recovery actually function.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/apps/skychat/group/...` passes
- [x] `make lint` 0 issues
- [ ] Manual: 3-visor group, owner restarts, peers restart, peers send — verify owner's last_message_at advances within ~130s (staleThreshold + reconnect tick) instead of staying stuck on self-echoes