### PR TITLE
fix(svc): kebab-case --dmsg-port + fix garbled --config + confbs tag

### DIFF
--- a/cmd/svc/address-resolver/commands/root.go
+++ b/cmd/svc/address-resolver/commands/root.go
@@ -108,7 +108,7 @@ GET /security/nonces/{pk}
 }
 
 func init() {
-	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with `skywire cli config gen --ar -o /etc/skywire/address-resolver.json`.\n\r")
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with: skywire cli config gen --ar -o /etc/skywire/address-resolver.json\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9093", "address to bind to\n\r")
 	RootCmd.Flags().StringVar(&udpAddr, "udp-addr", ":30178", "UDP address to bind to for SUDPH\n\r")
 	RootCmd.Flags().StringVar(&publicUDPAddr, "public-udp-address", "", "externally-reachable host:port advertised in /health for SUDPH\n\rrequired for visors that reach this AR over dmsghttp")
@@ -125,7 +125,8 @@ func init() {
 	RootCmd.Flags().BoolVar(&testEnvironment, "test-environment", false, "distinguished between prod and test environment")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
-	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().SetNormalizeFunc(cmdutil.LegacySvcFlagNormalizer)
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
 }

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -93,13 +93,14 @@ GET / - visorconfig.Services
 func init() {
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9082", "address to bind to\n\r")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
-	RootCmd.Flags().StringVar(&tag, "tag", "address_resolver", "logging tag\n\r")
+	RootCmd.Flags().StringVar(&tag, "tag", "config_bootstrapper", "logging tag\n\r")
 	RootCmd.Flags().StringVarP(&stunPath, "config", "c", "./config.json", "stun server list file location\n\r")
 	RootCmd.Flags().StringVarP(&domain, "domain", "d", "skywire.skycoin.com", "the domain of the endpoints\n\r")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsg.DiscURL(false), "url of dmsg-discovery\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
-	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().SetNormalizeFunc(cmdutil.LegacySvcFlagNormalizer)
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
 }

--- a/cmd/svc/route-finder/commands/root.go
+++ b/cmd/svc/route-finder/commands/root.go
@@ -82,7 +82,7 @@ POST /routes
 }
 
 func init() {
-	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with `skywire cli config gen --rf -o /etc/skywire/route-finder.json`.\n\r")
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with: skywire cli config gen --rf -o /etc/skywire/route-finder.json\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9092", "address to bind to\n\r")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
@@ -94,7 +94,8 @@ func init() {
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsg.DiscURL(false), "url of dmsg discovery\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
-	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().SetNormalizeFunc(cmdutil.LegacySvcFlagNormalizer)
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
 }

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -105,7 +105,7 @@ GET /security/nonces/{pk}
 }
 
 func init() {
-	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with `skywire cli config gen --sd -o /etc/skywire/service-discovery.json`.\n\r")
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. Generate with: skywire cli config gen --sd -o /etc/skywire/service-discovery.json\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9098", "address to bind to\n\r")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
@@ -117,7 +117,8 @@ func init() {
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
-	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().SetNormalizeFunc(cmdutil.LegacySvcFlagNormalizer)
 	// 5 min is ~3.3× the 90s client refresh interval
 	// (skyenv.ServiceDiscUpdateInterval), giving safe margin for one
 	// or two dropped refreshes without expiring a live entry.

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -55,7 +55,7 @@ var (
 )
 
 func init() {
-	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. When set, fields below come from the config file. Generate one with `skywire cli config gen --tpd -o /etc/skywire/transport-discovery.json`.\n\r")
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to JSON config file. When set, fields below come from the config file. Generate one with: skywire cli config gen --tpd -o /etc/skywire/transport-discovery.json\n\r")
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9091", "address to bind to\n\r")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
@@ -70,7 +70,8 @@ func init() {
 	RootCmd.Flags().BoolVar(&testEnvironment, "test-environment", false, "distinguished between prod and test environment")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
-	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().SetNormalizeFunc(cmdutil.LegacySvcFlagNormalizer)
 	RootCmd.Flags().StringVar(&dmsgServerType, "dmsg-server-type", "", "type of dmsg server on dmsghttp handler")
 	RootCmd.Flags().StringVar(&storeDataPath, "store-data-path", tpd.DefaultStoreDataPath, "path for bandwidth backup files\n\r")
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")

--- a/cmd/svc/uptime-tracker/commands/root.go
+++ b/cmd/svc/uptime-tracker/commands/root.go
@@ -83,7 +83,8 @@ func init() {
 	RootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", dmsg.DiscURL(false), "url of dmsg discovery\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
-	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
+	RootCmd.Flags().SetNormalizeFunc(cmdutil.LegacySvcFlagNormalizer)
 	RootCmd.Flags().StringVar(&mode, "mode", "", "listener mode: http|dmsg|dual (default dual if --sk, else http; env SKYWIRE_SVC_MODE overrides)")
 }
 

--- a/pkg/cmdutil/legacy_flag_alias.go
+++ b/pkg/cmdutil/legacy_flag_alias.go
@@ -1,0 +1,38 @@
+// Package cmdutil pkg/cmdutil/legacy_flag_alias.go: pflag NormalizeFunc
+// shared by every svc command that has been through a flag-rename. Maps
+// historical flag spellings to their current canonical kebab-case form
+// so any compose.yaml / systemd unit / shell wrapper that still passes
+// the old name keeps working invisibly.
+//
+// The renamed flag is registered ONCE under its current name; this
+// normalizer rewrites the legacy form at parse time, so the legacy form
+// doesn't appear in --help (no surface area pollution) but still
+// resolves to the same target.
+package cmdutil
+
+import "github.com/spf13/pflag"
+
+// legacyFlagAliases maps deprecated flag names → current canonical name.
+// Add an entry here whenever a flag gets renamed in a backward-incompatible
+// way; the corresponding cobra command must SetNormalizeFunc to
+// LegacySvcFlagNormalizer to pick up the alias.
+//
+// Keep entries lowercase on the right side; pflag's NormalizedName is
+// case-sensitive but its lookup uses the normalized form verbatim.
+var legacyFlagAliases = map[string]string{
+	// 2026-05-14: --dmsgPort camelCase outlier across every svc command.
+	// Renamed to --dmsg-port for consistency with --dmsg-disc,
+	// --dmsg-server-type, etc. Old form kept as a silent alias.
+	"dmsgPort": "dmsg-port",
+}
+
+// LegacySvcFlagNormalizer is the NormalizeFunc every svc command's
+// FlagSet should install via Flags().SetNormalizeFunc. Maps legacy flag
+// names from the table above to their current canonical form; falls
+// through unchanged for everything else.
+func LegacySvcFlagNormalizer(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+	if canonical, ok := legacyFlagAliases[name]; ok {
+		return pflag.NormalizedName(canonical)
+	}
+	return pflag.NormalizedName(name)
+}


### PR DESCRIPTION
Three CLI-help inconsistencies across the deployment services:

## 1. \`--dmsgPort\` (camelCase) → \`--dmsg-port\` (kebab-case)

\`--dmsgPort\` was the lone camelCase outlier across every svc command (ar, tpd, rf, sd, confbs, ut). Every other dmsg-related flag uses kebab-case (\`--dmsg-disc\`, \`--dmsg-server-type\`). Renamed to \`--dmsg-port\` for consistency.

**Backward compat:** The legacy \`--dmsgPort\` continues to work as a silent alias via pflag's \`NormalizeFunc\`. Any existing compose.yaml / systemd unit / shell wrapper that still passes the old name continues to function without surface in \`--help\` output.

New shared helper at \`pkg/cmdutil/legacy_flag_alias.go\` centralizes the legacy-name → canonical-name map so future renames can land under the same backward-compat treatment by adding a single entry.

## 2. Garbled \`-c, --config\` rendering

\`ar\`, \`tpd\`, \`rf\`, and \`sd\` wrapped the example command in backticks inside the usage string — pflag interprets backticks as argname-placeholder markers, so the example became the flag's TYPE column instead of the customary \"string\". Result was unreadable help output like:

\`\`\`
-c, --config skywire cli config gen --ar -o /etc/skywire/...   path to JSON config file. Generate with skywire cli config gen --ar -o /etc/skywire/...
\`\`\`

Replaced with plain \"Generate with: skywire cli config gen ...\" in the usage; placeholder now renders as the standard \"string\".

## 3. \`confbs --tag\` default was wrong

Defaulted to \"address_resolver\" — copy-paste from the ar service. Corrected to \"config_bootstrapper\" so its log lines self-identify under the right tag.

## Confirmed safe to rename by deployment grep

Both Beta and Gamma checked their \`compose.yaml\` + \`/etc/systemd/system/skywire*.service\` units for references to \`--dmsgPort\` / \`--testing\` / \`--test-environment\` — none found on either deployment. Backward-compat alias kept anyway for any unknown external operators.

## Out of scope (follow-up candidates)

Other inconsistencies identified during the audit but not in this PR:
- Inconsistent short-form for \`--dmsg-disc\` (-D in rf/confbs, -d in sd, none elsewhere, completely different name \`--dmsgd-url\` in nm)
- Test-mode flag naming chaos (--testing / --test-environment / --test)
- Missing \`--loglvl\` on sd and ut
- \`-l\` shorthand collision risk in ut (\`-l, --log\` boolean vs other services' \`-l, --loglvl\` string)
- \`nm\` uses divergent \`--FOO-url\` naming pattern

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/cmdutil/... ./cmd/svc/...\` passes
- [x] \`make lint\` 0 issues
- [x] Each affected service's \`--help\` rendering verified — \`--dmsg-port\` in canonical form, \`-c, --config string\` placeholder clean, confbs \`--tag\` defaults to \`config_bootstrapper\`
- [x] Legacy \`--dmsgPort\` still parsed as input