### PR TITLE
fix(skychat): use local ServeMux so RunSkychat is re-entrant

### DIFF
--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -227,14 +227,14 @@ func stopPairPoller() {
 // /pair/invites and /pair/invites/ shadow /pair/ for the invite
 // subtree. This lets the invite handlers be cleanly separate from
 // the per-pair item handler without parsing the path twice.
-func registerPairHTTPHandlers(ctx context.Context) {
+func registerPairHTTPHandlers(ctx context.Context, mux *http.ServeMux) {
 	if !pairEnable {
 		return
 	}
-	http.HandleFunc("/pair", requireAuthFunc(pairRootHandler(ctx)))
-	http.HandleFunc("/pair/invites", requireAuthFunc(pairInvitesListHandler()))
-	http.HandleFunc("/pair/invites/", requireAuthFunc(pairInvitesItemHandler(ctx)))
-	http.HandleFunc("/pair/", requireAuthFunc(pairItemHandler(ctx)))
+	mux.HandleFunc("/pair", requireAuthFunc(pairRootHandler(ctx)))
+	mux.HandleFunc("/pair/invites", requireAuthFunc(pairInvitesListHandler()))
+	mux.HandleFunc("/pair/invites/", requireAuthFunc(pairInvitesItemHandler(ctx)))
+	mux.HandleFunc("/pair/", requireAuthFunc(pairItemHandler(ctx)))
 }
 
 // pairInvitesListHandler serves GET /pair/invites — current pending

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -623,13 +623,21 @@ func RunSkychat(ctx context.Context, args []string) error {
 	}
 	setSkychatInternalToken(internalToken)
 
-	http.Handle("/", requireAuth(http.FileServer(getFileSystem())))
-	http.HandleFunc("/message", requireAuthFunc(messageHandler(ctx)))
-	http.HandleFunc("/sse", requireAuthFunc(sseHandler))
-	http.HandleFunc("/history", requireAuthFunc(historyHandler))
-	http.HandleFunc("/history/peers", requireAuthFunc(historyPeersHandler))
-	http.HandleFunc("/status", requireAuthFunc(statusHandler))
-	registerPairHTTPHandlers(ctx)
+	// Use a fresh local ServeMux so RunSkychat is safe to call more
+	// than once in the same process (in-process launcher re-launch on
+	// app restart, or any caller invoking it twice). The previous
+	// http.DefaultServeMux registrations panicked on duplicate "/"
+	// the second time around — same file, same line, same pattern —
+	// taking the entire chat-app down whenever the launcher tried to
+	// recover from a transient failure or any other re-launch path.
+	mux := http.NewServeMux()
+	mux.Handle("/", requireAuth(http.FileServer(getFileSystem())))
+	mux.HandleFunc("/message", requireAuthFunc(messageHandler(ctx)))
+	mux.HandleFunc("/sse", requireAuthFunc(sseHandler))
+	mux.HandleFunc("/history", requireAuthFunc(historyHandler))
+	mux.HandleFunc("/history/peers", requireAuthFunc(historyPeersHandler))
+	mux.HandleFunc("/status", requireAuthFunc(statusHandler))
+	registerPairHTTPHandlers(ctx, mux)
 
 	url := ""
 	address := addr
@@ -664,6 +672,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 	setAppStatus(appCl, appserver.AppDetailedStatusRunning)
 	srv := &http.Server{
 		Addr:         url,
+		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
\`http.Handle(\"/\")\` on \`http.DefaultServeMux\` panicked the entire chat-app when \`RunSkychat\` was invoked a second time in the same process — \`pattern \"/\" conflicts with pattern \"/\"\`. The default mux is package-level global state; duplicate registration is a hard panic.

## Triggered live

Post-#2598 cascade redeploy on at least one host (build \`v1.3.54-0.20260514213910-71e0902d3bcc\`). The in-process launcher path that calls \`RunSkychat\` appears to re-enter on app restart in some conditions; whatever the trigger, registering on \`DefaultServeMux\` made chat-app non-restartable.

## Fix

Build a local \`http.NewServeMux\` per \`RunSkychat\` invocation and pass it to the \`Server.Handler\` field. Same handler set, same paths, no global state — \`RunSkychat\` is now safe to call any number of times in the same process. \`registerPairHTTPHandlers\` accepts the mux as a parameter to keep its registrations on the same local mux.

## Why this should never have been DefaultServeMux

The previous design wasn't intentional — \`DefaultServeMux\` is a Go stdlib trap that's fine when you ship a binary as a one-shot process (skychat as a subprocess) but breaks the moment you ship it as a library function called twice. \`launcher.RegisterApp(\"skychat\", ...)\` at init time means \`RunSkychat\` IS a library function, and should have always used a local mux.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/...\` passes
- [x] \`make lint\` 0 issues
- [ ] Manual: redeploy, halt+restart visor twice on same host, confirm chat-app survives second restart without panic