### PR TITLE
fix(skychat/group): per-peerSub liveness signal so silent peers get reconnected

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -605,12 +605,27 @@ func (m *Manager) runReconnectLoop(ctx context.Context) {
 // treated as stale — we never saw any peer leaf arrive, so a
 // reconnect is warranted.
 //
-// Granularity note: LastInbound is per-session, not per-peerSub.
-// For owner sessions with multiple peers, a single chatty peer
-// keeps LastInbound fresh and masks the staleness of any silent
-// peer's peerSub. A future refinement would track per-peer
-// liveness; for now the per-session signal is strictly better
-// than the pre-fix "no reconnect coverage for owners at all".
+// Granularity: staleness is checked PER-PEER. Session.PeerPKs() is
+// the canonical list of peerSubs; for each, Session.PeerLastInbound()
+// returns the per-peer liveness signal. Any peer whose individual
+// peerSub is stale triggers a reconnect attempt, independent of how
+// active the other peers are. This closes the gap where one chatty
+// peer's bumps to the session-wide LastInbound() masked a silent
+// peer's failed peerSub from the reconnect machinery.
+//
+// Reconnect path: per-stale-peer, ReconnectPeer(pk) runs one peerSub
+// Connect under reconnectAttemptTimeout. The session-level
+// reconnectShouldAttempt backoff still gates the whole session (we
+// don't churn on a wedged group), so a peer that fails repeatedly
+// inherits the session's backoff schedule rather than getting its
+// own. Per-peer backoff would be a follow-up refinement if we see
+// e.g. one bad peer perpetually triggering retries.
+//
+// Fallback: if a session has no peerSubs (legacy owner-only members
+// where federated send hasn't kicked in, or owner sessions on
+// pre-federated binaries), fall back to the session-wide
+// LastInbound + Session.Connect path so those visors keep the
+// reconnect coverage they had pre-this-change.
 func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
@@ -636,31 +651,65 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 		if sess == nil {
 			continue
 		}
-		last := sess.LastInbound()
-		var lag time.Duration
-		var reason string
-		if last.IsZero() {
-			lag = subscriberStaleThreshold + time.Second // forces the lag > threshold branch
-			reason = "no inbound seen"
-		} else {
-			lag = now.Sub(last)
-			reason = "last_inbound lag"
-		}
-		if lag <= subscriberStaleThreshold {
+		peers := sess.PeerPKs()
+		if len(peers) == 0 {
+			// Fallback to session-wide signal when this session
+			// doesn't have peerSubs (legacy code paths). Same
+			// semantics as before this change.
+			last := sess.LastInbound()
+			var lag time.Duration
+			var reason string
+			if last.IsZero() {
+				lag = subscriberStaleThreshold + time.Second
+				reason = "no inbound seen"
+			} else {
+				lag = now.Sub(last)
+				reason = "last_inbound lag"
+			}
+			if lag <= subscriberStaleThreshold {
+				continue
+			}
+			m.log.WithField("id", r.ID).
+				WithField("lag", lag.Round(time.Second).String()).
+				WithField("reason", reason).
+				WithField("status", string(r.Status)).
+				Debug("group: session stale; kicking reconnect (legacy session-wide path)")
+			if !m.reconnectShouldAttempt(r.ID, now) {
+				continue
+			}
+			m.tryReconnect(ctx, sess, r.ID)
 			continue
 		}
-		m.log.WithField("id", r.ID).
-			WithField("lag", lag.Round(time.Second).String()).
-			WithField("reason", reason).
-			WithField("status", string(r.Status)).
-			Debug("group: session stale; kicking reconnect")
-		// Honor the per-group backoff schedule and don't churn on
-		// permanent failures. reconnectShouldAttempt returns false
-		// while the previous attempt's backoff window is still open.
+		// Per-peer staleness check. Collect the stale peers under
+		// one read of the clock so the iteration sees a consistent
+		// "now". One reconnect attempt per stale peer per tick.
+		var stalePeers []cipher.PubKey
+		for _, pk := range peers {
+			last := sess.PeerLastInbound(pk)
+			var lag time.Duration
+			if last.IsZero() {
+				lag = subscriberStaleThreshold + time.Second
+			} else {
+				lag = now.Sub(last)
+			}
+			if lag > subscriberStaleThreshold {
+				stalePeers = append(stalePeers, pk)
+			}
+		}
+		if len(stalePeers) == 0 {
+			continue
+		}
+		// Honor the per-group backoff so a wedged group doesn't
+		// churn the reconnect machinery once per tick per peer.
 		if !m.reconnectShouldAttempt(r.ID, now) {
 			continue
 		}
-		m.tryReconnect(ctx, sess, r.ID)
+		m.log.WithField("id", r.ID).
+			WithField("stale_peers", len(stalePeers)).
+			WithField("total_peers", len(peers)).
+			WithField("status", string(r.Status)).
+			Debug("group: per-peer stale; kicking per-peer reconnects")
+		m.tryReconnectPeers(ctx, sess, r.ID, stalePeers)
 	}
 }
 
@@ -700,6 +749,73 @@ func (m *Manager) tryReconnect(ctx context.Context, sess *Session, id string) {
 		return
 	}
 	m.reconnectRecordFailure(id, err)
+}
+
+// tryReconnectPeers runs one ReconnectPeer attempt per stale peer
+// in sequence. Each attempt is bounded by reconnectAttemptTimeout so
+// a single wedged peer can't block the others. Treats per-peer
+// success and failure independently: clears session-wide failure
+// state only when at least one peer reconnected successfully,
+// because that's positive evidence the session as a whole is
+// recovering; records a failure otherwise so the per-group backoff
+// schedule engages and we don't churn on a wedged group.
+//
+// Why sequential rather than parallel: each peer Connect can pull a
+// CXO node mutex (#2599 fixed the publisher-side mutex; the
+// subscriber side still serializes per node), and parallel attempts
+// would just queue up behind each other anyway. Sequential keeps
+// the log output readable and the worst-case wall time at
+// N × reconnectAttemptTimeout, which is acceptable for typical
+// group sizes (≤ 10 members).
+func (m *Manager) tryReconnectPeers(ctx context.Context, sess *Session, id string, peers []cipher.PubKey) {
+	type result struct{ err error }
+	successes := 0
+	var lastErr error
+	for _, pk := range peers {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		m.log.WithField("id", id).WithField("peer", pk.String()).
+			Debug("group: reconnect: attempting peer subscribe")
+		done := make(chan result, 1)
+		pkLocal := pk
+		go func() {
+			done <- result{err: sess.ReconnectPeer(pkLocal)}
+		}()
+		var err error
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(reconnectAttemptTimeout):
+			err = fmt.Errorf("group: reconnect-peer %s: timed out after %s", pk.String(), reconnectAttemptTimeout)
+		case r := <-done:
+			err = r.err
+		}
+		if err == nil {
+			successes++
+			m.log.WithField("id", id).WithField("peer", pk.String()).
+				Info("group: reconnect: peer subscribe restored")
+			continue
+		}
+		lastErr = err
+		m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
+			Debug("group: reconnect: peer subscribe failed")
+	}
+	if successes > 0 {
+		m.reconnectMu.Lock()
+		delete(m.reconnectState, id)
+		m.reconnectMu.Unlock()
+		if sErr := m.store.SetStatus(id, StatusActive); sErr != nil {
+			m.log.WithError(sErr).WithField("id", id).
+				Warn("group: reconnect: SetStatus active failed")
+		}
+		return
+	}
+	if lastErr != nil {
+		m.reconnectRecordFailure(id, lastErr)
+	}
 }
 
 // reconnectShouldAttempt returns false when the per-group nextAttempt

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -374,6 +374,29 @@ type Session struct {
 	// (inboxDedupCap) so a pathological input can't grow the map.
 	// Initialized to a non-nil empty set at Open; never replaced.
 	dedup *recentSet
+
+	// peerLastInboundNs is the per-peerSub liveness signal. Each entry
+	// is bumped (to time.Now().UnixNano()) on every observable inbound
+	// event from THAT specific peer's onUpdate fan-out, including a
+	// successful per-peer Connect (which is positive evidence the
+	// peerSub is attached).
+	//
+	// Why per-peer in addition to the session-level lastInboundNs:
+	// detectStaleAndReconnect uses peer-granular liveness to decide
+	// which peerSubs to reconnect. The session-level signal aggregates
+	// across all peers, so one chatty peer keeps the session "fresh"
+	// indefinitely and masks a silent peer's failed peerSub from the
+	// reconnect machinery. The per-peer map closes that gap — staleness
+	// is detected and a reconnect is kicked per peerSub, independent of
+	// how active the others are.
+	//
+	// Key set is populated alongside Session.peerSubs: every time a
+	// peerSub is created (newSession/openMember/openOwner/SetAllowlist),
+	// a parallel atomic.Int64 is added here. Removed in SetAllowlist
+	// when peerSubs[pk] is deleted. Guarded by Session.peerSubsMu (the
+	// same lock that protects peerSubs) — readers grab a snapshot under
+	// RLock and access the *atomic.Int64 entries lock-free.
+	peerLastInboundNs map[cipher.PubKey]*atomic.Int64
 }
 
 // subscriberStaleThreshold is defined in manager.go (it's used by
@@ -532,8 +555,9 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 		cfg: cfg, port: cfg.Record.Port, pub: pub, log: log,
 		members:  append([]cipher.PubKey(nil), cfg.Record.Members...),
 		relayCtx: ctx, relayCancel: cancel,
-		peerSubs: make(map[cipher.PubKey]*treestore.Subscriber),
-		dedup:    newRecentSet(inboxDedupCap),
+		peerSubs:          make(map[cipher.PubKey]*treestore.Subscriber),
+		peerLastInboundNs: make(map[cipher.PubKey]*atomic.Int64),
+		dedup:             newRecentSet(inboxDedupCap),
 	}
 
 	// Per-member subscribers: each non-owner-self member publishes
@@ -560,7 +584,8 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 			continue
 		}
 		ps.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
-		ps.OnUpdate(s.onUpdate)
+		s.peerLastInboundNs[peerPK] = new(atomic.Int64)
+		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
 		s.peerSubs[peerPK] = ps
 	}
 	if dmsgLis, err := cfg.DmsgC.Listen(relayPort); err != nil {
@@ -668,8 +693,9 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 	sub.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
 	s := &Session{
 		cfg: cfg, port: cfg.Record.Port, pub: pub, sub: sub, log: log,
-		peerSubs: make(map[cipher.PubKey]*treestore.Subscriber),
-		dedup:    newRecentSet(inboxDedupCap),
+		peerSubs:          make(map[cipher.PubKey]*treestore.Subscriber),
+		peerLastInboundNs: make(map[cipher.PubKey]*atomic.Int64),
+		dedup:             newRecentSet(inboxDedupCap),
 	}
 
 	// Federated mode: subscribe to every OTHER member's feed,
@@ -691,7 +717,8 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		// (admin-relayed copies of other members' sends) — see the
 		// openOwner equivalent for the full rationale.
 		ps.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
-		ps.OnUpdate(s.onUpdate)
+		s.peerLastInboundNs[peerPK] = new(atomic.Int64)
+		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
 		s.peerSubs[peerPK] = ps
 	}
 	// Seed lastInboundNs from the persisted LastMessageAt so a
@@ -751,6 +778,7 @@ func (s *Session) Connect() error {
 	}
 	s.peerSubsMu.RUnlock()
 	peerSuccessCount := 0
+	now := time.Now().UnixNano()
 	for pk, ps := range peers {
 		if err := ps.Connect(pk); err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).
@@ -758,6 +786,16 @@ func (s *Session) Connect() error {
 			continue
 		}
 		peerSuccessCount++
+		// Bump per-peer lastInbound on every successful per-peer
+		// Connect. detectStaleAndReconnect uses this peer-granular
+		// signal so a silent peer's failed peerSub gets retried even
+		// when other peers keep the session-wide lastInbound fresh.
+		s.peerSubsMu.RLock()
+		a := s.peerLastInboundNs[pk]
+		s.peerSubsMu.RUnlock()
+		if a != nil {
+			a.Store(now)
+		}
 	}
 	// Only declare the session "fresh" (bump lastInboundNs) if SOME
 	// subscriber side actually connected. Member-role sessions also
@@ -796,6 +834,107 @@ func (s *Session) LastInbound() time.Time {
 		return time.Time{}
 	}
 	return time.Unix(0, ns).UTC()
+}
+
+// PeerLastInbound returns the per-peerSub last-inbound timestamp for
+// the given peer PK. Zero time = no inbound ever observed from that
+// peer (peerSub is either never-connected or silent since startup).
+// Returns zero time if pk isn't a known peer of this session.
+//
+// Used by Manager.detectStaleAndReconnect to detect a silent peer's
+// failed peerSub even when other peers in the session are chatty
+// enough to keep the session-level LastInbound() fresh. Pre-this-
+// method the reconnect machinery only saw the session aggregate and
+// silently-failing peerSubs stayed in that state indefinitely.
+func (s *Session) PeerLastInbound(pk cipher.PubKey) time.Time {
+	s.peerSubsMu.RLock()
+	a, ok := s.peerLastInboundNs[pk]
+	s.peerSubsMu.RUnlock()
+	if !ok {
+		return time.Time{}
+	}
+	ns := a.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns).UTC()
+}
+
+// PeerPKs returns the set of peer PKs this session has a peerSub for
+// (i.e., every group member other than self that this visor follows).
+// The slice is a snapshot — safe to iterate after the function returns
+// without holding the session's internal lock. Sorted for determinism
+// so callers iterating the slice produce stable behavior (mostly
+// helpful in tests and structured-log output).
+func (s *Session) PeerPKs() []cipher.PubKey {
+	s.peerSubsMu.RLock()
+	defer s.peerSubsMu.RUnlock()
+	out := make([]cipher.PubKey, 0, len(s.peerSubs))
+	for k := range s.peerSubs {
+		out = append(out, k)
+	}
+	// Sort by hex form for determinism; cipher.PubKey doesn't have a
+	// natural ordering otherwise. The ~5 byte allocations per call are
+	// trivial vs. the reconnect machinery's work.
+	sort.Slice(out, func(i, j int) bool { return out[i].Hex() < out[j].Hex() })
+	return out
+}
+
+// ReconnectPeer re-runs Connect on a single peerSub. Counterpart to
+// Session.Connect which retries every peer in one shot. The
+// detectStaleAndReconnect loop uses this for per-peer recovery so a
+// stale silent peer doesn't trigger redundant Connect retries on
+// already-healthy peers (and the per-peer success/failure attribution
+// keeps the manager's backoff state cleaner).
+//
+// On success: bumps the peer's per-peer lastInbound timestamp.
+// Connect is positive evidence the peerSub is attached, so the
+// liveness window for THIS peer restarts here.
+//
+// On failure: returns the underlying Subscriber.Connect error
+// verbatim; caller decides whether to log, retry, or apply backoff.
+// peerLastInboundNs is NOT bumped, so the staleness signal stays
+// honest.
+//
+// No-op + nil error if pk isn't a known peer of this session.
+func (s *Session) ReconnectPeer(pk cipher.PubKey) error {
+	s.peerSubsMu.RLock()
+	ps := s.peerSubs[pk]
+	a := s.peerLastInboundNs[pk]
+	s.peerSubsMu.RUnlock()
+	if ps == nil {
+		return nil
+	}
+	if err := ps.Connect(pk); err != nil {
+		return err
+	}
+	if a != nil {
+		a.Store(time.Now().UnixNano())
+	}
+	return nil
+}
+
+// makePeerOnUpdate wraps Session.onUpdate with per-peer lastInbound
+// bookkeeping. Each peerSub gets its own wrapper at registration time
+// (in newSession/openOwner/openMember/SetAllowlist) so onUpdate-firing
+// preserves per-peer attribution that the treestore.UpdateCallback
+// signature otherwise discards.
+//
+// The peer's atomic.Int64 is captured by closure; the wrapper is
+// safe-for-concurrent-use because atomic.Int64.Store handles
+// concurrency itself.
+func (s *Session) makePeerOnUpdate(pk cipher.PubKey) treestore.UpdateCallback {
+	return func(events []treestore.UpdateEvent) {
+		if len(events) > 0 {
+			s.peerSubsMu.RLock()
+			a := s.peerLastInboundNs[pk]
+			s.peerSubsMu.RUnlock()
+			if a != nil {
+				a.Store(time.Now().UnixNano())
+			}
+		}
+		s.onUpdate(events)
+	}
 }
 
 // IsSubscriberAlive reports whether the subscriber side of this
@@ -914,6 +1053,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 		if _, keep := desired[pk]; !keep {
 			_ = ps.Close() //nolint:errcheck,gosec
 			delete(s.peerSubs, pk)
+			delete(s.peerLastInboundNs, pk)
 		}
 	}
 	// Add new peers.
@@ -928,13 +1068,16 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 			continue
 		}
 		ps.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
-		ps.OnUpdate(s.onUpdate)
+		s.peerLastInboundNs[pk] = new(atomic.Int64)
+		ps.OnUpdate(s.makePeerOnUpdate(pk))
 		// Best-effort connect — same semantics as Connect's per-peer
 		// retry: a peer that's offline now will be picked up on the
 		// next reconnect tick once the publisher comes back.
 		if err := ps.Connect(pk); err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).
 				Debug("group: SetAllowlist: peer-sub Connect failed; will retry on next reconnect tick")
+		} else if a := s.peerLastInboundNs[pk]; a != nil {
+			a.Store(time.Now().UnixNano())
 		}
 		s.peerSubs[pk] = ps
 	}


### PR DESCRIPTION
#2595, #2600, #2601 fixed three layered bugs in the group reconnect loop, but a granularity gap remained: \`Session.lastInboundNs\` is a SESSION-level signal — bumped on every observed inbound from any peer — while reconnect decisions are inherently PER-PEER. One chatty peer in the group kept the session-wide signal fresh, and \`detectStaleAndReconnect\` saw the session as healthy and never retried the silent peer's failed peerSub.

Surfaced live on the cascade-deploy test today: Beta's CXO peerSub-to-Beta-feed on Alpha's side stayed in handshake-fail backoff indefinitely as long as Gamma kept sending probes — Gamma's bumps were keeping Alpha's session-wide \`lastInboundNs\` fresh, so the reconnect loop never tried again for Beta.

## Fix

Move staleness detection to per-peerSub granularity. Session-level \`lastInboundNs\` stays for \`IsSubscriberAlive\`'s "session has at least one alive peer" semantics; a new per-peer map fills the liveness-detection role.

### Wiring

- \`Session.peerLastInboundNs map[cipher.PubKey]*atomic.Int64\` parallel to \`Session.peerSubs\`
- \`Session.makePeerOnUpdate(pk)\` wraps each peerSub's onUpdate so the per-peer entry is bumped on observed inbound from THAT peer
- \`Session.PeerPKs()\`, \`Session.PeerLastInbound(pk)\`, \`Session.ReconnectPeer(pk)\` — public surface used by Manager
- \`Manager.detectStaleAndReconnect\` iterates \`PeerPKs()\`, builds per-tick \`stalePeers\`, runs \`tryReconnectPeers\` instead of the session-wide \`tryReconnect\` when peerSubs exist. Falls back to the session-wide path for legacy pre-#2580 paths.
- \`Manager.tryReconnectPeers\` — sequential per-peer Connect, each bounded by \`reconnectAttemptTimeout\`; clears session failure state when ≥1 peer reconnects, otherwise records failure so per-group backoff engages.

### Why sequential per-peer reconnect

Each peer Connect can serialize on a per-CXO-node mutex; parallel attempts queue behind each other anyway. Sequential keeps logs readable and worst-case wall time at \`N × reconnectAttemptTimeout\`, acceptable for typical group sizes.

### Per-peer success bookkeeping

Successful per-peer Connect via either \`ReconnectPeer\` OR the all-peers \`Session.Connect\` bumps the peer's \`peerLastInboundNs\` — positive evidence the peerSub attached. SetAllowlist's add path also bumps on initial-Connect success.

### Backoff scope

Per-group backoff still gates the session, so a wedged group can't churn once-per-tick-per-peer. Per-peer backoff would be a follow-up if a single bad peer routinely triggers retries.

## Test plan

- [x] \`go build ./cmd/skywire\` clean
- [x] \`golangci-lint run\` on \`cmd/apps/skychat/...\` reports 0 issues
- [ ] Live retest of Alpha↔Beta peerSub recovery after redeploy: with the fix, Alpha's peerSub-to-Beta should reconnect on the next 30s tick after Beta rejoins; without the fix, Gamma's chatty probes mask the staleness and Alpha never retries