### PR TITLE
fix(skychat/group): thread context.Context through Connect / ReconnectPeer

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -219,7 +219,15 @@ func (m *Manager) Join(inv Invite) (Record, error) {
 		_ = m.store.Delete(r.ID) //nolint:errcheck
 		return Record{}, err
 	}
-	if err := sess.Connect(); err != nil {
+	// Join's interactive caller wants a bounded wait: a Connect that
+	// blocks indefinitely on an unreachable owner publisher would
+	// stall the CLI. Use reconnectAttemptTimeout — same per-attempt
+	// budget the background reconnect loop uses, so the failure
+	// mode is identical (and the same backoff machinery picks up
+	// on the next 30s tick).
+	joinCtx, cancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
+	defer cancel()
+	if err := sess.Connect(joinCtx); err != nil {
 		_ = sess.Close()         //nolint:errcheck
 		_ = m.store.Delete(r.ID) //nolint:errcheck
 		return Record{}, fmt.Errorf("group: Join: connect: %w", err)
@@ -483,7 +491,13 @@ func (m *Manager) Resume() error {
 			m.mu.RLock()
 			sess := m.sessions[r.ID]
 			m.mu.RUnlock()
-			if err := sess.Connect(); err != nil {
+			// Resume runs at visor startup — same bounded budget as
+			// the background reconnect tick so one unreachable
+			// owner can't stall the whole Resume loop.
+			resumeCtx, cancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
+			err := sess.Connect(resumeCtx)
+			cancel()
+			if err != nil {
 				m.log.WithError(err).WithField("id", r.ID).
 					Warn("group: Resume: member subscribe connect (will retry in background)")
 				// Mark pending; runReconnectLoop will re-attempt on
@@ -723,20 +737,14 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 // true on the very next /status read.
 func (m *Manager) tryReconnect(ctx context.Context, sess *Session, id string) {
 	m.log.WithField("id", id).Debug("group: reconnect: attempting subscribe")
-	type result struct{ err error }
-	done := make(chan result, 1)
-	go func() {
-		done <- result{err: sess.Connect()}
-	}()
-	var err error
-	select {
-	case <-ctx.Done():
-		return
-	case <-time.After(reconnectAttemptTimeout):
-		err = fmt.Errorf("group: reconnect: timed out after %s", reconnectAttemptTimeout)
-	case r := <-done:
-		err = r.err
-	}
+	// reconnectAttemptTimeout is the per-attempt deadline. Now
+	// threaded as a context all the way through Session.Connect →
+	// per-peer ps.Connect-via-goroutine, so a timeout returns the
+	// caller cleanly instead of orphaning a goroutine and leaving a
+	// per-peer Subscriber.Connect blocked indefinitely.
+	timeoutCtx, cancel := context.WithTimeout(ctx, reconnectAttemptTimeout)
+	defer cancel()
+	err := sess.Connect(timeoutCtx)
 	if err == nil {
 		m.reconnectMu.Lock()
 		delete(m.reconnectState, id)
@@ -768,31 +776,20 @@ func (m *Manager) tryReconnect(ctx context.Context, sess *Session, id string) {
 // N × reconnectAttemptTimeout, which is acceptable for typical
 // group sizes (≤ 10 members).
 func (m *Manager) tryReconnectPeers(ctx context.Context, sess *Session, id string, peers []cipher.PubKey) {
-	type result struct{ err error }
 	successes := 0
 	var lastErr error
 	for _, pk := range peers {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return
-		default:
 		}
 		m.log.WithField("id", id).WithField("peer", pk.String()).
 			Debug("group: reconnect: attempting peer subscribe")
-		done := make(chan result, 1)
-		pkLocal := pk
-		go func() {
-			done <- result{err: sess.ReconnectPeer(pkLocal)}
-		}()
-		var err error
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(reconnectAttemptTimeout):
-			err = fmt.Errorf("group: reconnect-peer %s: timed out after %s", pk.String(), reconnectAttemptTimeout)
-		case r := <-done:
-			err = r.err
-		}
+		// Per-peer deadline threaded as a context — Session.ReconnectPeer
+		// honors it via the same goroutine+select pattern as
+		// Session.Connect. Cancelable, no orphan goroutine pile-up.
+		timeoutCtx, cancel := context.WithTimeout(ctx, reconnectAttemptTimeout)
+		err := sess.ReconnectPeer(timeoutCtx, pk)
+		cancel()
 		if err == nil {
 			successes++
 			m.log.WithField("id", id).WithField("peer", pk.String()).

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -744,15 +744,38 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 // inbound yet". On error, lastInboundNs stays at whatever it was
 // (seeded from Record.LastMessageAt at Open) and the Manager's
 // background reconnect loop keeps retrying.
-func (s *Session) Connect() error {
+func (s *Session) Connect(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Owner-feed subscriber (legacy path) — only set on member sessions.
 	// Failure here is fatal for the member's read path TODAY since
 	// peerSubs may not be enough until every visor migrates. Once D4
 	// retires the relay/owner-feed flow we'll relax this to "any sub
 	// succeeded" semantics.
+	//
+	// pkg/cxo/treestore.Subscriber.Connect is NOT context-aware
+	// internally (it eventually calls dmsg.Client.ConnectPK which
+	// blocks on network IO without a ctx hook). To honor our outer
+	// deadline we wrap each Connect call in a goroutine and select
+	// on ctx — the goroutine's underlying dial may still run to
+	// completion in the background, but it won't block the outer
+	// caller past ctx's deadline. A future refinement plumbs ctx
+	// through Subscriber.Connect → dmsg.ConnectPK for true
+	// cancellation.
 	if s.sub != nil {
-		if err := s.sub.Connect(s.cfg.Record.OwnerPK); err != nil {
-			return fmt.Errorf("group: Connect: %w", err)
+		done := make(chan error, 1)
+		go func() { done <- s.sub.Connect(s.cfg.Record.OwnerPK) }()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("group: Connect: %w", err)
+			}
 		}
 	}
 	// D1 per-PK peer subscribers. Best-effort: if a single peer's
@@ -780,10 +803,27 @@ func (s *Session) Connect() error {
 	peerSuccessCount := 0
 	now := time.Now().UnixNano()
 	for pk, ps := range peers {
-		if err := ps.Connect(pk); err != nil {
-			s.log.WithError(err).WithField("peer", pk.String()).
-				Debug("group: Connect: peer-sub Connect failed; will retry on next reconnect tick")
-			continue
+		// Bail out between peers if the outer deadline expired —
+		// don't pile up more orphan goroutines than necessary.
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		done := make(chan error, 1)
+		pkLocal, psLocal := pk, ps
+		go func() { done <- psLocal.Connect(pkLocal) }()
+		select {
+		case <-ctx.Done():
+			// Outer deadline fired mid-Connect. The goroutine will
+			// eventually return; the buffered channel keeps it from
+			// leaking memory. We stop iterating remaining peers so
+			// the reconnect tick honors the deadline.
+			return ctx.Err()
+		case err := <-done:
+			if err != nil {
+				s.log.WithError(err).WithField("peer", pk.String()).
+					Debug("group: Connect: peer-sub Connect failed; will retry on next reconnect tick")
+				continue
+			}
 		}
 		peerSuccessCount++
 		// Bump per-peer lastInbound on every successful per-peer
@@ -897,7 +937,22 @@ func (s *Session) PeerPKs() []cipher.PubKey {
 // honest.
 //
 // No-op + nil error if pk isn't a known peer of this session.
-func (s *Session) ReconnectPeer(pk cipher.PubKey) error {
+//
+// Honors the provided context: if ctx fires before the underlying
+// Subscriber.Connect returns, ReconnectPeer returns ctx.Err()
+// promptly. The Subscriber.Connect goroutine continues to run in
+// the background (since treestore.Subscriber isn't yet ctx-aware
+// internally — see Session.Connect's comment for the longer-term
+// fix) but the buffered done channel prevents goroutine leakage:
+// the goroutine completes and exits cleanly when the network IO
+// finishes.
+func (s *Session) ReconnectPeer(ctx context.Context, pk cipher.PubKey) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	s.peerSubsMu.RLock()
 	ps := s.peerSubs[pk]
 	a := s.peerLastInboundNs[pk]
@@ -905,8 +960,15 @@ func (s *Session) ReconnectPeer(pk cipher.PubKey) error {
 	if ps == nil {
 		return nil
 	}
-	if err := ps.Connect(pk); err != nil {
-		return err
+	done := make(chan error, 1)
+	go func() { done <- ps.Connect(pk) }()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-done:
+		if err != nil {
+			return err
+		}
 	}
 	if a != nil {
 		a.Store(time.Now().UnixNano())


### PR DESCRIPTION
Follow-up to #2606. Got merged into #2606's branch after #2606 was already squashed; re-opened on a fresh branch off develop.

## Problem

The previous reconnect path used a goroutine+\`time.After\` pattern: an outer 5s select-with-timeout fired and \`tryReconnect\` returned, but the \`Session.Connect\` goroutine kept running. The per-peer \`Subscriber.Connect\` calls inside continued to block on dmsg dial, so a wedged peer left an orphan goroutine on every reconnect tick.

Worse, when the outer caller cleared session-failure state assuming "reconnect returned", those orphan dials sometimes completed seconds later and bumped \`lastInbound\` — creating the appearance of freshness AFTER the manager had already moved on, masking the actual subscriber state from the next tick.

## Fix

Thread \`context.Context\` through \`Session.Connect\` / \`Session.ReconnectPeer\`. Each per-peer \`ps.Connect\` is wrapped in a small goroutine whose result lands on a buffered channel; the outer select waits on either \`ctx.Done()\` or the channel. When ctx fires, the function returns immediately with \`ctx.Err()\`; the goroutine continues to run in the background (cleanly — buffered channel absorbs the eventual result, no leak) but the manager's \`tryReconnect\` / \`tryReconnectPeers\` gets clean control flow.

\`pkg/cxo/treestore.Subscriber.Connect\` itself is NOT context-aware (it eventually calls \`dmsg.Client.ConnectPK\` which blocks without a ctx hook). True cancellation requires plumbing ctx all the way through \`pkg/cxo/treestore\` and \`pkg/dmsg\` — out of scope for this PR. The goroutine+select pattern is the practical interim that makes the outer caller honor the deadline.

## Call-site updates

- \`Manager.tryReconnect\`: drops the goroutine + \`time.After\` pattern; creates \`context.WithTimeout(parent, reconnectAttemptTimeout)\` and passes to \`Session.Connect\`
- \`Manager.tryReconnectPeers\`: per-peer \`WithTimeout\` context (was per-peer \`time.After\` before) — same semantics, cleaner control flow, properly cancelable
- \`Manager.Join\`: bounded with \`reconnectAttemptTimeout\` so an unreachable owner doesn't stall the CLI
- \`Manager.Resume\`: bounded so one unreachable owner doesn't block the whole startup-time resume loop

## Behavior

- Happy path: unchanged.
- Unhappy path: stops piling up orphan goroutines that can wake up later and reset freshness state under the manager's feet.

## Test plan

- [x] \`go build ./cmd/skywire\` clean
- [x] \`golangci-lint run\` on \`cmd/apps/skychat/...\` reports 0 issues