### PR TITLE
feat(routing): add DatagramPacket wire type (faithful UDP, stage 1)

### DIFF
--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -71,6 +71,8 @@ func (t PacketType) String() string {
 		return "SkynetForward"
 	case AppDirectPacket:
 		return "AppDirect"
+	case DatagramPacket:
+		return "Datagram"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -102,6 +104,7 @@ const (
 	VisorRPCPacket      // visor RPC over transport (route ID = 0), payload: virtual stream data
 	SkynetForwardPacket // skynet port forwarding over direct transport (route ID = 0), virtual stream
 	AppDirectPacket     // skywire-network app direct dial over direct transport (route ID = 0), virtual stream
+	DatagramPacket      // faithful-UDP routed datagram (route ID > 0), payload: opaque bytes (AEAD-sealed at the DatagramRouteGroup layer). No sequence number — counter lives in the AEAD nonce (see RFC #2607).
 )
 
 // Capability bitmap flags for extended handshake negotiation.
@@ -236,6 +239,33 @@ func MakeHandshakePacketRaw(id RouteID, payload []byte) Packet {
 	copy(packet[PacketPayloadOffset:], payload)
 
 	return packet
+}
+
+// MakeDatagramPacket constructs a DatagramPacket. Faithful-UDP path:
+// no sequence number, no reorder buffer, no SACK on the receive side.
+// Loss is loss, ordering is best-effort, head-of-line blocking does
+// not occur on the route group's read path. Payload is opaque to the
+// router — the DatagramRouteGroup wraps it in a per-datagram AEAD
+// (see RFC #2607 Stage 3) before this constructor is called, so what
+// lands on the wire is ciphertext + the 8-byte nonce-counter prefix
+// produced at that layer. This function is wire-format only.
+//
+// Returns ErrPayloadTooBig if the payload (after AEAD wrapping) does
+// not fit in a single skywire frame. Callers should check the
+// DatagramRouteGroup's MaxPayload() before constructing.
+func MakeDatagramPacket(id RouteID, payload []byte) (Packet, error) {
+	if len(payload) > math.MaxUint16 {
+		return Packet{}, ErrPayloadTooBig
+	}
+
+	packet := make([]byte, PacketHeaderSize+len(payload))
+
+	packet[PacketTypeOffset] = byte(DatagramPacket)
+	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(len(payload))) //nolint:gosec
+	copy(packet[PacketPayloadOffset:], payload)
+
+	return packet, nil
 }
 
 // MakeSequencedDataPacket constructs a DataPacket with a 4-byte sequence number

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -67,6 +67,52 @@ func TestMakeSequencedDataPacket(t *testing.T) {
 	assert.Equal(t, data, packet.DataPayloadAfterSeq())
 }
 
+func TestMakeDatagramPacket(t *testing.T) {
+	packet, err := MakeDatagramPacket(2, []byte("foo"))
+	require.NoError(t, err)
+
+	// DatagramPacket is the 18th value of the PacketType iota chain
+	// (index 17 = 0x11). Header layout matches DataPacket: type at
+	// offset 0, routeID big-endian uint32, payloadSize big-endian
+	// uint16, then payload. No prepended sequence number — the
+	// counter that makes datagrams replay-safe lives in the AEAD
+	// nonce constructed at the DatagramRouteGroup layer, not in
+	// the routing-packet body. Wire-byte assertion pins this.
+	expected := []byte{0x11, 0x0, 0x0, 0x0, 0x2, 0x0, 0x3, 0x66, 0x6f, 0x6f}
+
+	assert.Equal(t, expected, []byte(packet))
+	assert.Equal(t, DatagramPacket, packet.Type())
+	assert.Equal(t, uint16(3), packet.Size())
+	assert.Equal(t, RouteID(2), packet.RouteID())
+	assert.Equal(t, []byte("foo"), packet.Payload())
+}
+
+func TestMakeDatagramPacketEmpty(t *testing.T) {
+	// Zero-length payload is valid on the wire — a DatagramRouteGroup
+	// keep-alive datagram or a probe that carries only the AEAD tag.
+	packet, err := MakeDatagramPacket(9, nil)
+	require.NoError(t, err)
+	assert.Equal(t, DatagramPacket, packet.Type())
+	assert.Equal(t, uint16(0), packet.Size())
+	assert.Equal(t, RouteID(9), packet.RouteID())
+	assert.Equal(t, []byte{}, packet.Payload())
+}
+
+func TestMakeDatagramPacketTooBig(t *testing.T) {
+	// Payload size field is uint16 → max 65535. One byte over the
+	// limit must surface as ErrPayloadTooBig so the caller can fall
+	// back (e.g. drop the datagram with EMSGSIZE semantics rather
+	// than silently truncating).
+	oversized := make([]byte, 65536)
+	_, err := MakeDatagramPacket(1, oversized)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPayloadTooBig)
+}
+
+func TestPacketTypeStringDatagram(t *testing.T) {
+	assert.Equal(t, "Datagram", DatagramPacket.String())
+}
+
 func TestMakePingPacket(t *testing.T) {
 	staticTime, _ := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00") //nolint:errcheck
 	timestamp := staticTime.UTC().UnixNano() / int64(time.Millisecond)


### PR DESCRIPTION
Stage 1 of #2607 — faithful UDP-over-skynet.

## What this adds

A new `PacketType`, `DatagramPacket`, used in subsequent stages by `DatagramRouteGroup` to carry UDP datagrams across routes without sequence numbers, reorder buffering, or SACK retransmit. The receiver gets loss-tolerant, possibly-unordered delivery — semantics that match real UDP, not the TCP-shaped delivery the existing `DataPacket` provides.

## Wire layout

Same header as `DataPacket`: type byte (`0x11`), 4-byte big-endian route ID, 2-byte big-endian payload size, then payload. **No prepended sequence number.** The counter that makes datagrams replay-safe lives in the AEAD nonce constructed at the `DatagramRouteGroup` layer (stage 3, see RFC #2607 §Stage-3); it does not live in the routing packet body.

Payload size cap is `uint16` (65535), same as `DataPacket`. Stage 5 will expose `MaxPayload()` on the `PacketConn` returned to apps so they avoid the opaque-EMSGSIZE footgun.

## What this does NOT do

- No `DatagramRouteGroup` yet (stage 2).
- No AEAD wrapping yet (stage 3).
- No `forwarded_ports.udp` mode yet (stage 4).
- No `DialPacket` app API yet (stage 5).
- DatagramPackets are never **produced or consumed** anywhere in the codebase as of this PR — the type is dead-letter until stage 2.

## Why ship as a separate stage

Mechanical change, no behavior impact, no risk to existing routes. Lets later stages build on a wire format that's already on develop. Smaller PRs review faster.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/routing/...` — pass (3 new tests pin the wire bytes, empty payload, oversize rejection, plus the `String()` case)
- [x] `go test ./pkg/router/...` — pass (no router changes; nothing the existing tests touch should care about a new PacketType iota value)
- [x] Full build of every package — clean

## Coordination

- Stage 2 (`DatagramRouteGroup`) will be the next PR. Held until this lands so stages stay reviewable independently.
- 027087fe40's `cmd/skyudp-bridge` (shape B, query-response UDP) is the sibling workstream. No dependency.

Closes part of #2607.