### PR TITLE
feat(router): DatagramRouteGroup + Group interface (faithful UDP, stage 2)

### DIFF
--- a/pkg/router/datagram_route_group.go
+++ b/pkg/router/datagram_route_group.go
@@ -89,8 +89,8 @@ var ErrClosed = errors.New("datagram-route-group: closed")
 //   - Close releases the readCh and marks the group dead. Idempotent.
 type DatagramRouteGroup struct {
 	// atomic; first for 64-bit alignment.
-	lastSent     int64
-	closeFlag    int32 // atomic; 1 once Close has run
+	lastSent                 int64
+	closeFlag                int32 // atomic; 1 once Close has run
 	consecutiveWriteFailures int32
 
 	mu sync.Mutex

--- a/pkg/router/datagram_route_group.go
+++ b/pkg/router/datagram_route_group.go
@@ -1,0 +1,381 @@
+// Package router pkg/router/datagram_route_group.go: faithful-UDP-
+// over-skynet sibling to RouteGroup. Stage 2 of #2607.
+//
+// While RouteGroup is net.Conn-shaped (Read/Write, sequenced
+// DataPackets, mux + reorder buffer + SACK retransmit, head-of-line
+// blocking on loss), DatagramRouteGroup is net.PacketConn-shaped
+// (ReadFrom/WriteTo, unsequenced DatagramPackets, loss-tolerant,
+// possibly-unordered delivery). Used by Stage 4's
+// forwarded_ports.udp path to expose UDP datagram semantics over
+// routed skynet hops — for VoIP, gaming, WebRTC media, anything
+// where a late packet is worse than a lost one.
+//
+// Stage 2 scope: type definition, send/receive plumbing,
+// net.PacketConn methods, lifecycle. NO crypto wrapping yet
+// (Stage 3 will add per-datagram ChaCha20-Poly1305-IETF + sliding-
+// window anti-replay). NO router-side dispatch yet (Stage 4 will
+// wire forwarded_ports.udp). At this stage DatagramRouteGroup is
+// self-contained and unit-testable, but no packet in the running
+// system will reach it.
+
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/util/deadline"
+)
+
+// Group is the narrow interface every route-group variant shares.
+// Stream-shaped (RouteGroup, net.Conn) and datagram-shaped
+// (DatagramRouteGroup, net.PacketConn) both satisfy it. Read/Write
+// vs ReadFrom/WriteTo deliberately stay on the concrete types —
+// keeping the shared interface narrow avoids leaking stream vs
+// datagram semantics into call sites that only care about
+// lifecycle.
+type Group interface {
+	Close() error
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	IsAlive() bool
+}
+
+// MaxDatagramPayload is the largest datagram body that fits in a
+// single DatagramPacket on the wire. The packet header carries a
+// uint16 payload-size field, capping the total payload (including
+// any Stage 3 AEAD overhead) at 65535 bytes. Apps consult
+// DatagramRouteGroup.MaxPayload() rather than this constant so the
+// answer accounts for the AEAD tag + nonce overhead Stage 3 will
+// reserve.
+const MaxDatagramPayload = math.MaxUint16
+
+// ErrPayloadTooBig is returned by WriteTo when the caller provides
+// a datagram larger than MaxPayload. Mirrors net.UDPConn's behavior
+// on oversized sends but is surfaced explicitly rather than as an
+// opaque EMSGSIZE — apps that consulted MaxPayload() should never
+// see this in practice.
+var ErrPayloadTooBig = errors.New("datagram-route-group: payload exceeds MaxPayload")
+
+// ErrClosed is returned by ReadFrom / WriteTo after Close.
+var ErrClosed = errors.New("datagram-route-group: closed")
+
+// DatagramRouteGroup carries UDP-shaped datagrams across a route
+// (or set of routes — multiplexing across multiple paths is a
+// future enhancement, not present in Stage 2). Single-peer:
+// WriteTo only accepts the configured remote address; ReadFrom
+// always returns the same remote.
+//
+// Lifecycle:
+//   - Constructed via NewDatagramRouteGroup with rules + transports
+//     (the same setup-node plumbing that builds RouteGroups can
+//     populate either type — Stage 4 wires this).
+//   - Handle(packet) is called by the router whenever a
+//     DatagramPacket arrives whose RouteID matches one of this
+//     group's rules. The packet's payload is queued on readCh and
+//     delivered to the next ReadFrom caller.
+//   - WriteTo wraps the payload in a DatagramPacket (Stage 3 will
+//     also AEAD-seal it), picks a transport, and writes it.
+//   - Close releases the readCh and marks the group dead. Idempotent.
+type DatagramRouteGroup struct {
+	// atomic; first for 64-bit alignment.
+	lastSent     int64
+	closeFlag    int32 // atomic; 1 once Close has run
+	consecutiveWriteFailures int32
+
+	mu sync.Mutex
+
+	cfg    *RouteGroupConfig
+	logger *logging.Logger
+	desc   routing.RouteDescriptor
+	rt     routing.Table
+
+	// tps[i] is the managed transport over which writes to fwd[i]
+	// land. Same shape as RouteGroup.tps — keeping the indexing
+	// invariant identical means the router-side setup code (Stage 4)
+	// can build either group type with the same rule/transport pair.
+	tps []*transport.ManagedTransport
+	fwd []routing.Rule // forward rules (for writing)
+	rvs []routing.Rule // reverse rules (for reading)
+
+	// readCh delivers datagram payloads to ReadFrom. Buffered to
+	// cfg.ReadChBufSize so a brief ReadFrom stall doesn't immediately
+	// drop incoming traffic — but it IS a bounded queue, and once
+	// full further inbound datagrams are dropped (with a logged
+	// counter). This is the right semantics for UDP: an app that
+	// isn't keeping up loses packets, exactly as it would on a
+	// local UDP socket.
+	readCh chan []byte
+
+	readDeadline  deadline.PipeDeadline
+	writeDeadline deadline.PipeDeadline
+
+	networkStats *networkStats
+
+	closed chan struct{}
+	once   sync.Once
+
+	// inboundDropped counts datagrams dropped because readCh was
+	// full when Handle tried to push. Surfaced via Stats() and
+	// useful for diagnosing slow consumers.
+	inboundDropped uint64 // atomic
+}
+
+// NewDatagramRouteGroup constructs a DatagramRouteGroup. The
+// returned group has no rules or transports yet — those are added
+// by the caller (the setup-node-side plumbing, Stage 4) before the
+// group is registered with the router for dispatch.
+//
+// Use cfg=nil for defaults.
+func NewDatagramRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing.RouteDescriptor, mLogger *logging.MasterLogger) *DatagramRouteGroup {
+	if cfg == nil {
+		cfg = DefaultRouteGroupConfig()
+	}
+	logger := logging.MustGetLogger(fmt.Sprintf("DatagramRouteGroup %s", desc.String()))
+	if mLogger != nil {
+		logger = mLogger.PackageLogger(fmt.Sprintf("DatagramRouteGroup %s", desc.String()))
+	}
+	return &DatagramRouteGroup{
+		cfg:           cfg,
+		logger:        logger,
+		desc:          desc,
+		rt:            rt,
+		tps:           make([]*transport.ManagedTransport, 0),
+		fwd:           make([]routing.Rule, 0),
+		rvs:           make([]routing.Rule, 0),
+		readCh:        make(chan []byte, cfg.ReadChBufSize),
+		readDeadline:  deadline.MakePipeDeadline(),
+		writeDeadline: deadline.MakePipeDeadline(),
+		networkStats:  newNetworkStats(),
+		closed:        make(chan struct{}),
+	}
+}
+
+// AddRule registers a (forward rule, transport, reverse rule)
+// triple. Called by the setup-node integration in Stage 4. Index
+// invariant: tps[i] is the transport for fwd[i]; rvs[i] is the
+// matching consume rule on the receive side.
+//
+// In Stage 2 this is the only way to populate the group; the router-
+// side automatic plumbing comes later.
+func (dg *DatagramRouteGroup) AddRule(fwd routing.Rule, tp *transport.ManagedTransport, rv routing.Rule) {
+	dg.mu.Lock()
+	defer dg.mu.Unlock()
+	dg.fwd = append(dg.fwd, fwd)
+	dg.tps = append(dg.tps, tp)
+	dg.rvs = append(dg.rvs, rv)
+}
+
+// MaxPayload returns the largest datagram size that WriteTo will
+// accept. In Stage 2 this is the raw wire cap (65535). Stage 3
+// will reduce it by the per-datagram AEAD overhead (8-byte nonce
+// counter + 16-byte Poly1305 tag = 24 bytes), at which point
+// MaxPayload returns 65511. Apps that consult this before sending
+// avoid the opaque-EMSGSIZE footgun.
+func (dg *DatagramRouteGroup) MaxPayload() int {
+	return MaxDatagramPayload
+}
+
+// WriteTo wraps data in a DatagramPacket and sends it over the
+// first available transport. addr is checked against the group's
+// remote (single-peer model); WriteTo on a wrong addr returns an
+// error rather than silently routing elsewhere — apps that use a
+// DatagramRouteGroup as a single-peer net.PacketConn are unlikely
+// to hit this, but app frameworks that pool PacketConns might.
+func (dg *DatagramRouteGroup) WriteTo(data []byte, addr net.Addr) (int, error) {
+	if dg.isClosed() {
+		return 0, ErrClosed
+	}
+	if len(data) > dg.MaxPayload() {
+		return 0, ErrPayloadTooBig
+	}
+	if addr != nil {
+		if want := dg.RemoteAddr(); want != nil && addr.String() != want.String() {
+			return 0, fmt.Errorf("datagram-route-group: WriteTo addr %s does not match group remote %s", addr, want)
+		}
+	}
+
+	dg.mu.Lock()
+	if len(dg.fwd) == 0 || len(dg.tps) == 0 {
+		dg.mu.Unlock()
+		return 0, errors.New("datagram-route-group: no rules / transports configured")
+	}
+	rule := dg.fwd[0]
+	tp := dg.tps[0]
+	dg.mu.Unlock()
+
+	packet, err := routing.MakeDatagramPacket(rule.NextRouteID(), data)
+	if err != nil {
+		return 0, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	select {
+	case <-dg.writeDeadline.Wait():
+		return 0, timeoutError{}
+	case <-dg.closed:
+		return 0, ErrClosed
+	default:
+	}
+
+	if err := tp.WritePacket(ctx, packet); err != nil {
+		atomic.AddInt32(&dg.consecutiveWriteFailures, 1)
+		return 0, err
+	}
+	atomic.StoreInt32(&dg.consecutiveWriteFailures, 0)
+	atomic.StoreInt64(&dg.lastSent, time.Now().UnixNano())
+	dg.networkStats.AddBandwidthSent(uint64(packet.Size()))
+	return len(data), nil
+}
+
+// ReadFrom delivers the next inbound datagram payload. Blocks until
+// a payload is available, the read deadline fires, or Close runs.
+// The returned addr is always the group's remote (single-peer
+// model). Buffer too small for the datagram is a partial-read
+// situation: copy what fits, drop the rest, return the truncated
+// length and no error — exactly net.UDPConn's behavior on
+// undersized buffers (subject to ENOBUFS-equivalent surfacing at
+// the Stage 5 app-API layer).
+func (dg *DatagramRouteGroup) ReadFrom(p []byte) (int, net.Addr, error) {
+	select {
+	case data, ok := <-dg.readCh:
+		if !ok {
+			return 0, dg.RemoteAddr(), io.EOF
+		}
+		n := copy(p, data)
+		return n, dg.RemoteAddr(), nil
+	case <-dg.readDeadline.Wait():
+		return 0, dg.RemoteAddr(), timeoutError{}
+	case <-dg.closed:
+		return 0, dg.RemoteAddr(), ErrClosed
+	}
+}
+
+// Handle is called by the router (Stage 4) when a DatagramPacket
+// arrives whose RouteID matches one of dg.rvs. The payload is
+// queued on readCh and delivered to the next ReadFrom. If readCh
+// is full, the datagram is dropped (atomic inboundDropped++) —
+// faithful UDP semantics: a slow consumer loses packets.
+//
+// Returns nil on successful queue, io.ErrClosedPipe if the group
+// is closed (router should de-register the route in that case).
+func (dg *DatagramRouteGroup) Handle(packet routing.Packet) error {
+	if dg.isClosed() {
+		return io.ErrClosedPipe
+	}
+	if packet.Type() != routing.DatagramPacket {
+		return fmt.Errorf("datagram-route-group: Handle received non-datagram %s", packet.Type())
+	}
+	dg.networkStats.AddBandwidthReceived(uint64(packet.Size()))
+
+	// Copy out the payload — the underlying packet buffer is owned
+	// by the read loop and may be reused for the next inbound
+	// frame. Without the copy a fast inbound rate would clobber
+	// queued datagrams before the app reads them.
+	payload := packet.Payload()
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+
+	select {
+	case dg.readCh <- cp:
+		return nil
+	case <-dg.closed:
+		return io.ErrClosedPipe
+	default:
+		atomic.AddUint64(&dg.inboundDropped, 1)
+		return nil
+	}
+}
+
+// Close releases the readCh and marks the group dead. Idempotent.
+// In-flight ReadFrom unblocks with ErrClosed; subsequent WriteTo
+// also returns ErrClosed.
+func (dg *DatagramRouteGroup) Close() error {
+	dg.once.Do(func() {
+		atomic.StoreInt32(&dg.closeFlag, 1)
+		close(dg.closed)
+		// Drain readCh non-blockingly so any in-flight Handle that
+		// raced the close doesn't leak.
+		go func() {
+			for range dg.readCh {
+			}
+		}()
+		// Closing readCh lets the drain goroutine exit. Order
+		// matters: close after signaling dg.closed so any select
+		// observers see the closed signal first.
+		close(dg.readCh)
+	})
+	return nil
+}
+
+func (dg *DatagramRouteGroup) isClosed() bool {
+	return atomic.LoadInt32(&dg.closeFlag) == 1
+}
+
+// LocalAddr returns destination address of underlying
+// RouteDescriptor. Mirrors RouteGroup's convention — the descriptor
+// is built from the dialer's perspective so .Dst is "this side."
+func (dg *DatagramRouteGroup) LocalAddr() net.Addr {
+	return dg.desc.Dst()
+}
+
+// RemoteAddr returns source address of underlying RouteDescriptor.
+func (dg *DatagramRouteGroup) RemoteAddr() net.Addr {
+	return dg.desc.Src()
+}
+
+// SetDeadline sets both read and write deadlines.
+func (dg *DatagramRouteGroup) SetDeadline(t time.Time) error {
+	if err := dg.SetReadDeadline(t); err != nil {
+		return err
+	}
+	return dg.SetWriteDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline.
+func (dg *DatagramRouteGroup) SetReadDeadline(t time.Time) error {
+	dg.readDeadline.Set(t)
+	return nil
+}
+
+// SetWriteDeadline sets the write deadline.
+func (dg *DatagramRouteGroup) SetWriteDeadline(t time.Time) error {
+	dg.writeDeadline.Set(t)
+	return nil
+}
+
+// IsAlive returns true if the group is open and recent writes have
+// succeeded. Mirror of RouteGroup.IsAlive's shape so the Group
+// interface stays narrow.
+func (dg *DatagramRouteGroup) IsAlive() bool {
+	if dg.isClosed() {
+		return false
+	}
+	return atomic.LoadInt32(&dg.consecutiveWriteFailures) < maxConsecutiveWriteFailures
+}
+
+// InboundDropped returns the count of inbound datagrams dropped
+// due to a full readCh since group construction. Surfaced for
+// diagnostics; not used in the hot path.
+func (dg *DatagramRouteGroup) InboundDropped() uint64 {
+	return atomic.LoadUint64(&dg.inboundDropped)
+}
+
+// Compile-time assertion that DatagramRouteGroup satisfies the
+// narrow Group interface AND net.PacketConn.
+var (
+	_ Group          = (*DatagramRouteGroup)(nil)
+	_ net.PacketConn = (*DatagramRouteGroup)(nil)
+)

--- a/pkg/router/datagram_route_group_test.go
+++ b/pkg/router/datagram_route_group_test.go
@@ -1,0 +1,217 @@
+// Package router pkg/router/datagram_route_group_test.go: unit
+// tests for the DatagramRouteGroup type. Stage 2 of #2607.
+//
+// These tests exercise the type in isolation — Handle is called
+// directly with crafted DatagramPackets rather than going through
+// a real router dispatch path. That's deliberate: Stage 2's scope
+// is the type itself; Stage 4 wires it into the router and forwarded-
+// ports plumbing where end-to-end integration tests will live.
+
+package router
+
+import (
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// newTestDatagramGroup builds a DatagramRouteGroup with a minimal
+// descriptor and no rules. AddRule + a stub transport are wired by
+// individual tests as needed.
+func newTestDatagramGroup(t *testing.T) *DatagramRouteGroup {
+	t.Helper()
+	srcPK, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	desc := routing.NewRouteDescriptor(srcPK, dstPK, 100, 200)
+	return NewDatagramRouteGroup(nil, nil, desc, nil)
+}
+
+func TestDatagramRouteGroupHandleDeliversToReadFrom(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	// Craft a DatagramPacket with a known payload and feed it via
+	// Handle. ReadFrom should deliver it exactly.
+	payload := []byte("hello-over-udp-skynet")
+	pkt, err := routing.MakeDatagramPacket(routing.RouteID(1), payload)
+	require.NoError(t, err)
+
+	require.NoError(t, dg.Handle(pkt))
+
+	buf := make([]byte, 1500)
+	require.NoError(t, dg.SetReadDeadline(time.Now().Add(time.Second)))
+	n, addr, err := dg.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, buf[:n])
+	assert.Equal(t, dg.RemoteAddr().String(), addr.String())
+}
+
+func TestDatagramRouteGroupHandleRejectsNonDatagramPacket(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	// A DataPacket masquerading as datagram — Handle must reject
+	// rather than silently feed it into readCh. A buggy router-
+	// side dispatch that misroutes a DataPacket to a datagram
+	// group would otherwise corrupt the consumer's view of the
+	// stream.
+	pkt, err := routing.MakeDataPacket(routing.RouteID(1), []byte("not a datagram"))
+	require.NoError(t, err)
+
+	err = dg.Handle(pkt)
+	require.Error(t, err)
+}
+
+func TestDatagramRouteGroupReadFromBlocksUntilDeadline(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	require.NoError(t, dg.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+
+	buf := make([]byte, 1500)
+	start := time.Now()
+	n, _, err := dg.ReadFrom(buf)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, 0, n)
+	require.Error(t, err)
+	var terr net.Error
+	if assert.ErrorAs(t, err, &terr) {
+		assert.True(t, terr.Timeout(), "expected timeout error, got %v", err)
+	}
+	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond, "ReadFrom returned too early")
+}
+
+func TestDatagramRouteGroupCloseUnblocksReadFrom(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1500)
+		_, _, err := dg.ReadFrom(buf)
+		done <- err
+	}()
+
+	// Give the goroutine a moment to enter ReadFrom.
+	time.Sleep(20 * time.Millisecond)
+
+	require.NoError(t, dg.Close())
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrClosed)
+	case <-time.After(time.Second):
+		t.Fatal("Close did not unblock ReadFrom within 1s")
+	}
+}
+
+func TestDatagramRouteGroupCloseIsIdempotent(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	require.NoError(t, dg.Close())
+	require.NoError(t, dg.Close())
+	require.NoError(t, dg.Close())
+}
+
+func TestDatagramRouteGroupWriteToTooBigRejected(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	oversized := make([]byte, dg.MaxPayload()+1)
+	n, err := dg.WriteTo(oversized, dg.RemoteAddr())
+	assert.Equal(t, 0, n)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPayloadTooBig)
+}
+
+func TestDatagramRouteGroupWriteToWithNoRulesFails(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	// No AddRule call — WriteTo has nothing to send through.
+	// Must fail rather than silently succeed.
+	n, err := dg.WriteTo([]byte("hi"), dg.RemoteAddr())
+	assert.Equal(t, 0, n)
+	require.Error(t, err)
+}
+
+func TestDatagramRouteGroupWriteToWrongAddrRejected(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	// A different remote — pooled PacketConn callers that target
+	// the wrong group should be caught rather than silently
+	// routing elsewhere.
+	otherPK, _ := cipher.GenerateKeyPair()
+	wrongDesc := routing.NewRouteDescriptor(otherPK, otherPK, 9, 9)
+	wrongAddr := wrongDesc.Src()
+
+	n, err := dg.WriteTo([]byte("hi"), wrongAddr)
+	assert.Equal(t, 0, n)
+	require.Error(t, err)
+}
+
+func TestDatagramRouteGroupInboundDroppedWhenReadChFull(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	// readCh size = ReadChBufSize from DefaultRouteGroupConfig.
+	// Fill it without ever calling ReadFrom; the next Handle
+	// should atomically bump inboundDropped.
+	capacity := cap(dg.readCh)
+	for i := 0; i < capacity; i++ {
+		pkt, err := routing.MakeDatagramPacket(routing.RouteID(1), []byte("x"))
+		require.NoError(t, err)
+		require.NoError(t, dg.Handle(pkt))
+	}
+	assert.Equal(t, uint64(0), dg.InboundDropped(), "shouldn't drop before queue is full")
+
+	// One more — readCh is full, this one must drop.
+	overflow, err := routing.MakeDatagramPacket(routing.RouteID(1), []byte("dropped"))
+	require.NoError(t, err)
+	require.NoError(t, dg.Handle(overflow))
+	assert.Equal(t, uint64(1), dg.InboundDropped(), "expected one drop after capacity exceeded")
+}
+
+func TestDatagramRouteGroupHandleAfterCloseReturnsClosedPipe(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	require.NoError(t, dg.Close())
+
+	pkt, err := routing.MakeDatagramPacket(routing.RouteID(1), []byte("late"))
+	require.NoError(t, err)
+	err = dg.Handle(pkt)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestDatagramRouteGroupIsAlive(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+
+	assert.True(t, dg.IsAlive(), "fresh group should be alive")
+
+	// Simulate accumulated write failures.
+	atomic.StoreInt32(&dg.consecutiveWriteFailures, maxConsecutiveWriteFailures)
+	assert.False(t, dg.IsAlive(), "group with maxed-out failures should not be alive")
+
+	atomic.StoreInt32(&dg.consecutiveWriteFailures, 0)
+	require.NoError(t, dg.Close())
+	assert.False(t, dg.IsAlive(), "closed group should not be alive")
+}
+
+func TestDatagramRouteGroupSatisfiesPacketConn(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+	// The compile-time assertion in datagram_route_group.go also
+	// enforces this, but the test makes the surface visible in
+	// `go test` output.
+	var _ net.PacketConn = dg
+	var _ Group = dg
+}

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -71,6 +71,8 @@ func (t PacketType) String() string {
 		return "SkynetForward"
 	case AppDirectPacket:
 		return "AppDirect"
+	case DatagramPacket:
+		return "Datagram"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -102,6 +104,7 @@ const (
 	VisorRPCPacket      // visor RPC over transport (route ID = 0), payload: virtual stream data
 	SkynetForwardPacket // skynet port forwarding over direct transport (route ID = 0), virtual stream
 	AppDirectPacket     // skywire-network app direct dial over direct transport (route ID = 0), virtual stream
+	DatagramPacket      // faithful-UDP routed datagram (route ID > 0), payload: opaque bytes (AEAD-sealed at the DatagramRouteGroup layer). No sequence number — counter lives in the AEAD nonce (see RFC #2607).
 )
 
 // Capability bitmap flags for extended handshake negotiation.
@@ -236,6 +239,33 @@ func MakeHandshakePacketRaw(id RouteID, payload []byte) Packet {
 	copy(packet[PacketPayloadOffset:], payload)
 
 	return packet
+}
+
+// MakeDatagramPacket constructs a DatagramPacket. Faithful-UDP path:
+// no sequence number, no reorder buffer, no SACK on the receive side.
+// Loss is loss, ordering is best-effort, head-of-line blocking does
+// not occur on the route group's read path. Payload is opaque to the
+// router — the DatagramRouteGroup wraps it in a per-datagram AEAD
+// (see RFC #2607 Stage 3) before this constructor is called, so what
+// lands on the wire is ciphertext + the 8-byte nonce-counter prefix
+// produced at that layer. This function is wire-format only.
+//
+// Returns ErrPayloadTooBig if the payload (after AEAD wrapping) does
+// not fit in a single skywire frame. Callers should check the
+// DatagramRouteGroup's MaxPayload() before constructing.
+func MakeDatagramPacket(id RouteID, payload []byte) (Packet, error) {
+	if len(payload) > math.MaxUint16 {
+		return Packet{}, ErrPayloadTooBig
+	}
+
+	packet := make([]byte, PacketHeaderSize+len(payload))
+
+	packet[PacketTypeOffset] = byte(DatagramPacket)
+	binary.BigEndian.PutUint32(packet[PacketRouteIDOffset:], uint32(id))
+	binary.BigEndian.PutUint16(packet[PacketPayloadSizeOffset:], uint16(len(payload))) //nolint:gosec
+	copy(packet[PacketPayloadOffset:], payload)
+
+	return packet, nil
 }
 
 // MakeSequencedDataPacket constructs a DataPacket with a 4-byte sequence number

--- a/pkg/routing/packet_test.go
+++ b/pkg/routing/packet_test.go
@@ -67,6 +67,52 @@ func TestMakeSequencedDataPacket(t *testing.T) {
 	assert.Equal(t, data, packet.DataPayloadAfterSeq())
 }
 
+func TestMakeDatagramPacket(t *testing.T) {
+	packet, err := MakeDatagramPacket(2, []byte("foo"))
+	require.NoError(t, err)
+
+	// DatagramPacket is the 18th value of the PacketType iota chain
+	// (index 17 = 0x11). Header layout matches DataPacket: type at
+	// offset 0, routeID big-endian uint32, payloadSize big-endian
+	// uint16, then payload. No prepended sequence number — the
+	// counter that makes datagrams replay-safe lives in the AEAD
+	// nonce constructed at the DatagramRouteGroup layer, not in
+	// the routing-packet body. Wire-byte assertion pins this.
+	expected := []byte{0x11, 0x0, 0x0, 0x0, 0x2, 0x0, 0x3, 0x66, 0x6f, 0x6f}
+
+	assert.Equal(t, expected, []byte(packet))
+	assert.Equal(t, DatagramPacket, packet.Type())
+	assert.Equal(t, uint16(3), packet.Size())
+	assert.Equal(t, RouteID(2), packet.RouteID())
+	assert.Equal(t, []byte("foo"), packet.Payload())
+}
+
+func TestMakeDatagramPacketEmpty(t *testing.T) {
+	// Zero-length payload is valid on the wire — a DatagramRouteGroup
+	// keep-alive datagram or a probe that carries only the AEAD tag.
+	packet, err := MakeDatagramPacket(9, nil)
+	require.NoError(t, err)
+	assert.Equal(t, DatagramPacket, packet.Type())
+	assert.Equal(t, uint16(0), packet.Size())
+	assert.Equal(t, RouteID(9), packet.RouteID())
+	assert.Equal(t, []byte{}, packet.Payload())
+}
+
+func TestMakeDatagramPacketTooBig(t *testing.T) {
+	// Payload size field is uint16 → max 65535. One byte over the
+	// limit must surface as ErrPayloadTooBig so the caller can fall
+	// back (e.g. drop the datagram with EMSGSIZE semantics rather
+	// than silently truncating).
+	oversized := make([]byte, 65536)
+	_, err := MakeDatagramPacket(1, oversized)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPayloadTooBig)
+}
+
+func TestPacketTypeStringDatagram(t *testing.T) {
+	assert.Equal(t, "Datagram", DatagramPacket.String())
+}
+
 func TestMakePingPacket(t *testing.T) {
 	staticTime, _ := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00") //nolint:errcheck
 	timestamp := staticTime.UTC().UnixNano() / int64(time.Millisecond)


### PR DESCRIPTION
Stage 2 of #2607. Builds on #2609 (Stage 1: DatagramPacket wire type).

> [!NOTE]
> Stacked on #2609. If #2609 merges first this PR will auto-rebase; otherwise the commit it depends on is `530293911` (introducing `DatagramPacket` + `MakeDatagramPacket`).

## What this adds

A `PacketConn`-shaped sibling to `RouteGroup` that carries `DatagramPacket`s without sequence numbers, reorder buffering, or SACK retransmit. Loss is loss, ordering is best-effort, head-of-line blocking does not occur on the route group's read path — UDP semantics, not the TCP-shaped delivery `RouteGroup` provides.

### `Group` interface

Narrow shared interface for every route-group variant — `Close` / `LocalAddr` / `RemoteAddr` / `IsAlive`. `Read`/`Write` vs `ReadFrom`/`WriteTo` deliberately stay on the concrete types so call sites that only care about lifecycle don't have to discriminate. Compile-time assertion in `datagram_route_group.go`.

### `DatagramRouteGroup`

- Single-peer (one remote per group, mirroring how `RouteGroup` is single-peer)
- Owns its own `readCh` — **bounded**, and a full queue **drops** the incoming datagram (faithful UDP semantics for a slow consumer; the `InboundDropped()` counter surfaces this for diagnostics)
- `WriteTo` wraps payload in `MakeDatagramPacket` and writes through the first available transport
- `AddRule(fwd, tp, rv)` populates the rule/transport triple. Same indexing invariant as `RouteGroup` so the setup-node plumbing in Stage 4 builds either type from the same code path.
- `MaxPayload()` returns 65535 in Stage 2; Stage 3 reduces it by the per-datagram AEAD overhead (8-byte nonce counter + 16-byte Poly1305 tag = 24 bytes → 65511) once crypto lands.

## What is NOT in this stage

- No **router-side dispatch** yet. `handleDatagramPacket` on the router lands in Stage 4 with `forwarded_ports.udp`; at this stage `Handle` is the unit-test entry point and no packet in the running system actually reaches a `DatagramRouteGroup`.
- No **AEAD wrapping**. Stage 3 adds per-datagram ChaCha20-Poly1305-IETF + sliding-window anti-replay. `MaxPayload()` will be reduced accordingly at that point.
- No **multi-leg / multiplex**. A `DatagramRouteGroup` writes through `tps[0]` only. Path multiplexing is not motivated by Stage 4's `forwarded_ports.udp` use case.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/router/` — pass (12 new tests + existing suite)
- [x] `go test -race ./pkg/router/` — clean, no data races
- [x] Compile-time assertions confirm `Group` + `net.PacketConn` satisfied

Test coverage:

- `HandleDeliversToReadFrom` — happy path: `Handle` → `ReadFrom`
- `HandleRejectsNonDatagramPacket` — defensive: a misrouted `DataPacket` does NOT silently slip into the datagram queue
- `ReadFromBlocksUntilDeadline` — deadline plumbing
- `CloseUnblocksReadFrom` — in-flight reads return `ErrClosed` on `Close`
- `CloseIsIdempotent`
- `WriteToTooBigRejected` — `ErrPayloadTooBig` instead of opaque EMSGSIZE
- `WriteToWithNoRulesFails` — guard against using a half-built group
- `WriteToWrongAddrRejected` — single-peer enforcement
- `InboundDroppedWhenReadChFull` — slow-consumer semantics + atomic counter
- `HandleAfterCloseReturnsClosedPipe`
- `IsAlive` — lifecycle + failure-count thresholding
- `SatisfiesPacketConn` — interface-shape assertion in test output

## Coordination

- Stage 1 (#2609) — wire type, dependency.
- Stage 3 — AEAD layer. Held *softly* for ersonp's eyes per Alpha's review of the RFC; can write it after Stage 2 lands.
- Stage 4 — `forwarded_ports.udp` integration. Mirrors the existing TCP forwarded-port plumbing.
- Stage 5 — `appnet.DialPacket` + `MaxPayload()`-exposing app API.

Closes part of #2607.