### PR TITLE
feat(skyudp-bridge): standalone UDP→dmsg bridge ("sub") — Plan B for UDP-over-skynet

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/sub.go
+++ b/cmd/skywire-cli/commands/dmsg/sub.go
@@ -1,0 +1,17 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/sub.go
+//
+// Registers the standalone UDP→dmsg bridge as the `sub` subcommand
+// of `skywire dmsg`, so a single skywire binary can launch it
+// without requiring a separately-built top-level binary.
+package clidmsg
+
+import (
+	sub "github.com/skycoin/skywire/cmd/sub/commands"
+)
+
+func init() {
+	// Hoist the standalone's RootCmd directly so a single cobra
+	// definition serves both the top-level binary (cmd/sub) and the
+	// integrated subcommand (`skywire dmsg sub`).
+	RootCmd.AddCommand(sub.RootCmd)
+}

--- a/cmd/sub/README.md
+++ b/cmd/sub/README.md
@@ -1,0 +1,102 @@
+# sub — standalone UDP→dmsg bridge (sky UDP bridge)
+
+Standalone, dmsg-only UDP→skywire bridge. Frames UDP datagrams
+with a `uint16` length prefix and ferries them over a dmsg stream;
+the peer end unframes and replays them as UDP onto a local target.
+
+This is **Plan B** for UDP-over-skynet — TCP-shaped reliable +
+in-order transport. Suitable for **non-realtime** UDP:
+
+  - DNS (53)
+  - NTP (123)
+  - SNMP (161/162)
+  - MQTT-SN
+  - WireGuard control-plane handshakes (not bulk data)
+
+For media-class UDP (RTP, VoIP, WebRTC media, real-time game
+protocols) use **Plan A** — true packet-level UDP at the
+route-group layer (RFC #2607). The TCP wrap in this bridge adds
+head-of-line blocking, which is fine for DNS/NTP/SNMP (the app
+retries anyway) and wrong for voice/video (one lost packet stalls
+the whole stream).
+
+Reachable two ways:
+
+  - As a standalone binary built from `cmd/sub/` — invoke `sub …`.
+  - As a subcommand of the unified skywire binary — invoke
+    `skywire dmsg sub …`. Both share the same `cobra.Command`.
+
+## Wire format
+
+A single frame:
+
+```
++--------+----------------+
+| u16 BE | payload (≤64K) |
++--------+----------------+
+```
+
+One frame per UDP datagram. `MaxFrameSize = 65535`. Per-source UDP
+flows get their own stream (per (ip, port) tuple on the client),
+held open until idle (`--idle`, default 60s). Replies flow back
+over the same stream/socket pair so stateful protocols (DNS req +
+reply on the same socket) work.
+
+## Usage
+
+Two subcommands; deploy one of each (one per side of the bridge):
+
+### Client side (host with the UDP app)
+
+```sh
+export SKYUDP_SK=<hex-secret-key>     # persistent identity
+sub client \
+  --listen      127.0.0.1:5353 \
+  --peer        <peer-visor-pk-hex> \
+  --remote-port 53
+```
+
+Then point the local app at `127.0.0.1:5353` (e.g. `dig
+@127.0.0.1 -p 5353 example.com`).
+
+### Server side (host with the UDP target)
+
+```sh
+export SKYUDP_SK=<hex-secret-key>
+sub server \
+  --dmsg-port 53 \
+  --target    127.0.0.1:53
+```
+
+The peer dmsg port (`--dmsg-port` on server, `--remote-port` on
+client) is arbitrary but must match. `--target` is the local UDP
+endpoint the unframed datagrams hit (e.g. a local DNS resolver).
+
+### Keypair sourcing
+
+`SKYUDP_SK` env var, `--sk <hex>`, `--sk-file <path>`, or — if
+nothing is provided — an ephemeral keypair generated per launch.
+Use a persistent key in production so the server's allowlist
+(future work via a wrapping `cli serve whitelist`) remains stable
+across restarts.
+
+## When to reach for `sub` vs the alternatives
+
+| Need | Use |
+| --- | --- |
+| DNS / NTP / SNMP / MQTT-SN over skywire | `sub` (this) |
+| WireGuard control plane over skywire | `sub` |
+| RTP / VoIP / WebRTC media / real-time game | Plan A (RFC #2607) |
+| Plain TCP over skywire | `skywire cli serve` + a TCP forwarder |
+| SMTP over skywire | `smb` / `skywire cli mail` |
+
+## Out of scope
+
+  - DTLS / per-frame auth: dmsg already provides E2E encryption +
+    PK-bound identity. Adding DTLS on top would be redundant.
+  - Path MTU discovery: every frame fits in `[0, 65535]` bytes
+    (UDP payload limit). Apps that fragment at IP layer are
+    re-fragmented by the receiver's UDP stack as usual.
+  - Source-address spoofing across the bridge: per-source flows
+    are keyed by the *local* sender's (ip, port) — the peer end
+    always sees the bridge's UDP source on `--target`.

--- a/cmd/sub/commands/sub.go
+++ b/cmd/sub/commands/sub.go
@@ -1,0 +1,301 @@
+// Package commands cmd/sub/commands/sub.go
+//
+// Standalone (dmsg-only) UDP→dmsg bridge ("sub" — sky UDP bridge).
+// Wraps UDP datagrams in length-prefixed frames, ferries them over
+// a dmsg stream, and replays them as UDP on the peer. Mirrors the
+// smb shape — one binary, no visor dependency, own dmsg.Client.
+//
+// Two subcommands:
+//
+//	sub client   — local UDP listener → peer-dialled dmsg stream
+//	sub server   — accept dmsg streams → forward as UDP to target
+//
+// Plan B for UDP-over-skynet (TCP-over-UDP, reliable + in-order).
+// For media-class UDP (RTP, voice, game) use Plan A — the
+// packet-level UDP at the route-group layer (RFC #2607).
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/calvin"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyudpbridge"
+)
+
+var (
+	// shared
+	skHex    string
+	skFile   string
+	dmsgDisc string
+	logLevel string
+
+	// client
+	clientListen string
+	clientPeer   string
+	clientPort   uint16
+	clientIdle   time.Duration
+	clientDial   time.Duration
+
+	// server
+	serverDmsgPort uint16
+	serverTarget   string
+	serverIdle     time.Duration
+)
+
+// RootCmd is the cobra entry for the standalone UDP→dmsg bridge.
+// Used both as the top-level binary (cmd/sub) and the integrated
+// subcommand `skywire dmsg sub`.
+var RootCmd = &cobra.Command{
+	Use:                   "sub",
+	Short:                 "Standalone UDP→dmsg bridge — ferries length-prefixed UDP datagrams over dmsg streams",
+	Long:                  calvin.AsciiFont("sub"),
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+}
+
+var clientCmd = &cobra.Command{
+	Use:           "client",
+	Short:         "Listen UDP locally, frame + ferry to a peer over dmsg",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx, cancel := signalCtx(cmd.Context())
+		defer cancel()
+		if err := runClient(ctx); err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+var serverCmd = &cobra.Command{
+	Use:           "server",
+	Short:         "Accept dmsg streams, unframe, forward as UDP to a local target",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	Run: func(cmd *cobra.Command, _ []string) {
+		ctx, cancel := signalCtx(cmd.Context())
+		defer cancel()
+		if err := runServer(ctx); err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{clientCmd, serverCmd} {
+		c.Flags().StringVar(&skHex, "sk", "", "secret key hex (env: SKYUDP_SK). Empty + no --sk-file → ephemeral keypair")
+		c.Flags().StringVar(&skFile, "sk-file", "", "path to a file containing the secret key hex (newline-trimmed)")
+		c.Flags().StringVar(&dmsgDisc, "dmsg-disc", "", "dmsg discovery URL (defaults to deployment.Prod.DmsgDiscovery)")
+		c.Flags().StringVar(&logLevel, "log-level", "info", "log level: debug|info|warn|error")
+	}
+
+	clientCmd.Flags().StringVar(&clientListen, "listen", "127.0.0.1:5353", "local UDP listen address")
+	clientCmd.Flags().StringVar(&clientPeer, "peer", "", "peer visor public key hex (required)")
+	clientCmd.Flags().Uint16Var(&clientPort, "remote-port", 0, "dmsg port to dial on the peer (required)")
+	clientCmd.Flags().DurationVar(&clientIdle, "idle", skyudpbridge.DefaultIdleTimeout, "per-source flow idle timeout")
+	clientCmd.Flags().DurationVar(&clientDial, "dial-timeout", skyudpbridge.DefaultDialTimeout, "peer-dial timeout")
+
+	serverCmd.Flags().Uint16Var(&serverDmsgPort, "dmsg-port", 0, "dmsg port to listen on (required)")
+	serverCmd.Flags().StringVar(&serverTarget, "target", "", "local UDP target the unframed datagrams are forwarded to (required, e.g. 127.0.0.1:53)")
+	serverCmd.Flags().DurationVar(&serverIdle, "idle", skyudpbridge.DefaultIdleTimeout, "per-stream UDP-socket idle timeout")
+
+	RootCmd.AddCommand(clientCmd, serverCmd)
+}
+
+// Execute is invoked from the package-main entrypoint.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func signalCtx(parent context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sig
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+func runClient(ctx context.Context) error {
+	if clientPeer == "" {
+		return errors.New("--peer is required")
+	}
+	if clientPort == 0 {
+		return errors.New("--remote-port is required")
+	}
+	var peer cipher.PubKey
+	if err := peer.UnmarshalText([]byte(clientPeer)); err != nil {
+		return fmt.Errorf("parse --peer: %w", err)
+	}
+
+	logger := initLogger("sub-client")
+	pk, sk, err := resolveKeypair()
+	if err != nil {
+		return fmt.Errorf("resolve keypair: %w", err)
+	}
+	logger.WithField("pk", pk.Hex()).Info("dmsg identity")
+
+	dmsgC, stop, err := startDmsgClient(ctx, logger, pk, sk)
+	if err != nil {
+		return fmt.Errorf("start dmsg client: %w", err)
+	}
+	defer stop()
+
+	cfg := skyudpbridge.ClientConfig{
+		ListenUDP:   clientListen,
+		Peer:        peer,
+		PeerPort:    clientPort,
+		IdleTimeout: clientIdle,
+		DialTimeout: clientDial,
+	}
+	logger.Infof("sub client listening UDP %s → dmsg %s:%d", cfg.ListenUDP, peer.Hex()[:8], cfg.PeerPort)
+	if err := skyudpbridge.RunClient(ctx, cfg, &dmsgDialer{c: dmsgC}, logger); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}
+
+func runServer(ctx context.Context) error {
+	if serverDmsgPort == 0 {
+		return errors.New("--dmsg-port is required")
+	}
+	if serverTarget == "" {
+		return errors.New("--target is required")
+	}
+
+	logger := initLogger("sub-server")
+	pk, sk, err := resolveKeypair()
+	if err != nil {
+		return fmt.Errorf("resolve keypair: %w", err)
+	}
+	logger.WithField("pk", pk.Hex()).Info("dmsg identity")
+
+	dmsgC, stop, err := startDmsgClient(ctx, logger, pk, sk)
+	if err != nil {
+		return fmt.Errorf("start dmsg client: %w", err)
+	}
+	defer stop()
+
+	lis, err := dmsgC.Listen(serverDmsgPort)
+	if err != nil {
+		return fmt.Errorf("dmsg listen :%d: %w", serverDmsgPort, err)
+	}
+	go func() {
+		<-ctx.Done()
+		_ = lis.Close() //nolint:errcheck,gosec
+	}()
+
+	cfg := skyudpbridge.ServerConfig{
+		TargetUDP:   serverTarget,
+		IdleTimeout: serverIdle,
+	}
+	logger.Infof("sub server accepting dmsg :%d → UDP %s", serverDmsgPort, cfg.TargetUDP)
+	return skyudpbridge.RunServer(ctx, cfg, lis.Accept, logger)
+}
+
+func initLogger(name string) *logging.Logger {
+	logger := logging.MustGetLogger(name)
+	if lvl, err := logging.LevelFromString(logLevel); err == nil {
+		logging.SetLevel(lvl)
+	}
+	return logger
+}
+
+func resolveKeypair() (cipher.PubKey, cipher.SecKey, error) {
+	candidate := skHex
+	if candidate == "" {
+		candidate = os.Getenv("SKYUDP_SK")
+	}
+	if candidate == "" && skFile != "" {
+		data, err := os.ReadFile(skFile) //nolint:gosec
+		if err != nil {
+			return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("read sk-file: %w", err)
+		}
+		candidate = strings.TrimSpace(string(data))
+	}
+	if candidate == "" {
+		pk, sk := cipher.GenerateKeyPair()
+		return pk, sk, nil
+	}
+
+	var sk cipher.SecKey
+	if err := sk.UnmarshalText([]byte(candidate)); err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("parse sk: %w", err)
+	}
+	pk, err := sk.PubKey()
+	if err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("derive pk: %w", err)
+	}
+	return pk, sk, nil
+}
+
+func startDmsgClient(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey) (*dmsg.Client, func(), error) {
+	discURL := dmsgDisc
+	if discURL == "" {
+		discURL = deployment.Prod.DmsgDiscovery
+	}
+	if discURL == "" {
+		return nil, nil, errors.New("no dmsg discovery URL (set --dmsg-disc)")
+	}
+
+	httpC := &http.Client{Timeout: 30 * time.Second}
+	discClient := disc.NewHTTP(discURL, httpC, log)
+	dmsgCfg := dmsg.DefaultConfig()
+	dmsgCfg.MinSessions = 1
+
+	dmsgC := dmsg.NewClient(pk, sk, discClient, dmsgCfg)
+	go dmsgC.Serve(ctx)
+
+	select {
+	case <-ctx.Done():
+		_ = dmsgC.Close() //nolint:errcheck,gosec
+		return nil, nil, ctx.Err()
+	case <-dmsgC.Ready():
+		log.Debug("dmsg client ready")
+	case <-time.After(30 * time.Second):
+		_ = dmsgC.Close() //nolint:errcheck,gosec
+		return nil, nil, errors.New("timeout waiting for dmsg client")
+	}
+
+	stop := func() {
+		_ = dmsgC.Close() //nolint:errcheck,gosec
+	}
+	return dmsgC, stop, nil
+}
+
+// dmsgDialer satisfies skyudpbridge.Dialer by speaking directly to
+// the peer over dmsg.
+type dmsgDialer struct{ c *dmsg.Client }
+
+func (d *dmsgDialer) Dial(ctx context.Context, peer cipher.PubKey, port uint16) (net.Conn, error) {
+	stream, err := d.c.Dial(ctx, dmsg.Addr{PK: peer, Port: port})
+	if err != nil {
+		return nil, err
+	}
+	return stream, nil
+}

--- a/cmd/sub/sub.go
+++ b/cmd/sub/sub.go
@@ -1,0 +1,51 @@
+// Package main cmd/sub/sub.go
+//
+// Standalone (dmsg-only) UDP→dmsg bridge ("sub"). Length-prefixed
+// UDP datagrams ferried over a dmsg stream. Plan B for
+// UDP-over-skynet — for non-realtime UDP (DNS, NTP, SNMP, MQTT-SN,
+// WireGuard control plane). For media-class UDP use Plan A
+// (packet-level UDP at the route-group layer; RFC #2607).
+//
+// Reachable from a unified skywire binary as `skywire dmsg sub`.
+package main
+
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/sub/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help menu")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint:errcheck,gosec
+}
+
+func main() {
+	cc.Init(&cc.Config{
+		RootCmd:         commands.RootCmd,
+		Headings:        cc.HiBlue + cc.Bold,
+		Commands:        cc.HiBlue + cc.Bold,
+		CmdShortDescr:   cc.HiBlue,
+		Example:         cc.HiBlue + cc.Italic,
+		ExecName:        cc.HiBlue + cc.Bold,
+		Flags:           cc.HiBlue + cc.Bold,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+	commands.Execute()
+}
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/pkg/skyudpbridge/skyudpbridge.go
+++ b/pkg/skyudpbridge/skyudpbridge.go
@@ -1,0 +1,466 @@
+// Package skyudpbridge is the protocol core for the skywire UDP
+// bridge ("sub"): length-prefixed UDP datagrams ferried over a
+// reliable skywire byte-stream (dmsg or skywire-routing). Plan B
+// of the UDP-over-skynet split (Plan A — true packet-level UDP at
+// the route-group layer — lives in pkg/router under RFC #2607).
+//
+// Use shape: a co-located application speaks UDP to a local socket
+// (e.g. DNS resolver hitting :53). The client-side bridge captures
+// each datagram, frames it with a uint16 length prefix, and writes
+// it to a skywire stream. The peer's server-side bridge reads
+// frames off the stream and replays them as UDP to a configured
+// local target (e.g. an upstream resolver on 127.0.0.1:53). The
+// stream stays open for the lifetime of the UDP "flow" (per-source
+// (ip, port) tuple) with an idle timeout.
+//
+// Two ends, mirror-symmetric:
+//
+//	client side:  UDP listener  →  per-source stream  →  framer  →  Stream
+//	server side:  Stream  →  defamer  →  per-stream UDP socket  →  target
+//
+// Replies flow back via the SAME stream/UDP socket pair, so a
+// stateful UDP protocol (DNS reply on same socket) works.
+//
+// Suitable for non-realtime UDP: DNS, NTP, SNMP, MQTT-SN, WireGuard
+// control plane. For media-class UDP (VoIP, RTP, WebRTC media,
+// real-time game protocols) use Plan A (true packet-level UDP at
+// the route-group layer; see RFC #2607).
+//
+// Reliability tradeoff: the skywire stream is TCP-like (reliable,
+// in-order). Wrapping UDP in it gains reliability + ordering but
+// adds head-of-line blocking. For DNS/NTP/SNMP this is fine — the
+// app would retry on packet loss anyway, and replies arriving in
+// order is harmless. For RTP/voice it's wrong — Plan A.
+//
+// The Dialer abstraction lets the standalone (cmd/sub) and any
+// future visor-app variant share this protocol core: standalone
+// backs Dialer with its own dmsg.Client; visor-app would back it
+// with app.Client.Dial. Same pattern as pkg/skymailbridge.
+package skyudpbridge
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// MaxFrameSize is the largest UDP payload the bridge will ferry in
+// a single frame. Set to 65535 (the absolute UDP payload limit) so
+// no realistic datagram is truncated. Frames larger than this are
+// dropped on the client side and never reach the wire.
+const MaxFrameSize = 65535
+
+// DefaultIdleTimeout is how long a per-source flow's stream stays
+// open with no traffic before the bridge closes it. Trades stream
+// reuse (cheaper for chatty flows) against resource bloat (a stuck
+// flow consuming a stream forever). 60s is the same default WireGuard
+// uses for keepalive-driven NAT entries — a sane neighborhood.
+const DefaultIdleTimeout = 60 * time.Second
+
+// DefaultDialTimeout bounds a single peer-dial attempt. Long enough
+// to ride out a skywire route setup, short enough that a UDP app
+// gets a "we tried" failure rather than indefinite blocking.
+const DefaultDialTimeout = 15 * time.Second
+
+// Dialer abstracts the peer-dial step so the same protocol core
+// runs on top of either a direct dmsg.Client (standalone) or
+// app.Client.Dial (visor app). Implementations must return a
+// usable net.Conn or an error; returning (nil, nil) is a contract
+// violation. Mirrors pkg/skymailbridge.Dialer by intent.
+type Dialer interface {
+	Dial(ctx context.Context, peer cipher.PubKey, port uint16) (net.Conn, error)
+}
+
+// ClientConfig configures a client-side bridge instance.
+type ClientConfig struct {
+	// ListenUDP is the local UDP address the bridge listens on for
+	// app traffic. Conventionally "127.0.0.1:<port>". Required.
+	ListenUDP string
+	// Peer is the destination visor's public key. Required.
+	Peer cipher.PubKey
+	// PeerPort is the skywire routing/dmsg port the peer's
+	// server-side bridge listens on. Required (no default —
+	// operators must agree on a port).
+	PeerPort uint16
+	// IdleTimeout is the per-flow idle timer. Zero uses
+	// DefaultIdleTimeout.
+	IdleTimeout time.Duration
+	// DialTimeout caps each peer-dial attempt. Zero uses
+	// DefaultDialTimeout.
+	DialTimeout time.Duration
+}
+
+// ServerConfig configures a server-side bridge instance.
+type ServerConfig struct {
+	// TargetUDP is the local UDP address the server forwards
+	// unframed datagrams to. Conventionally "127.0.0.1:<port>".
+	// Required.
+	TargetUDP string
+	// IdleTimeout is the per-stream UDP-socket idle timer.
+	IdleTimeout time.Duration
+}
+
+// RunClient starts the client-side bridge: UDP listener →
+// per-source stream → framer. Blocks until ctx is cancelled or the
+// underlying listener fails. The Dialer is invoked lazily on the
+// first datagram from each new source.
+func RunClient(ctx context.Context, cfg ClientConfig, dialer Dialer, log logrus.FieldLogger) error {
+	if dialer == nil {
+		return errors.New("skyudpbridge: Dialer is nil")
+	}
+	if cfg.ListenUDP == "" {
+		return errors.New("skyudpbridge: ListenUDP is required")
+	}
+	if cfg.PeerPort == 0 {
+		return errors.New("skyudpbridge: PeerPort is required")
+	}
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = DefaultIdleTimeout
+	}
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = DefaultDialTimeout
+	}
+	if log == nil {
+		log = logrus.NewEntry(logrus.New())
+	}
+
+	udpAddr, err := net.ResolveUDPAddr("udp", cfg.ListenUDP)
+	if err != nil {
+		return fmt.Errorf("resolve listen udp %q: %w", cfg.ListenUDP, err)
+	}
+	udpC, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return fmt.Errorf("listen udp %q: %w", cfg.ListenUDP, err)
+	}
+	defer udpC.Close() //nolint:errcheck,gosec
+
+	c := &clientState{
+		cfg:    cfg,
+		dialer: dialer,
+		log:    log,
+		udpC:   udpC,
+		flows:  make(map[string]*clientFlow),
+	}
+	go func() {
+		<-ctx.Done()
+		_ = udpC.Close() //nolint:errcheck,gosec
+		// Close active flows too — serveUDP may be blocked in
+		// WriteFrame on a stream whose peer stopped reading,
+		// and closing the udpC alone wouldn't unblock it.
+		c.closeAllFlows()
+	}()
+
+	err = c.serveUDP(ctx)
+	c.closeAllFlows()
+	return err
+}
+
+// RunServer starts the server-side bridge: accept skywire streams,
+// read framed datagrams, forward via UDP. Blocks until ctx is
+// cancelled or the listener fails. accept is the inbound-stream
+// accept function — provided by the caller because dmsg and
+// skywire-routing have different listen primitives.
+func RunServer(ctx context.Context, cfg ServerConfig, accept func() (net.Conn, error), log logrus.FieldLogger) error {
+	if accept == nil {
+		return errors.New("skyudpbridge: accept fn is nil")
+	}
+	if cfg.TargetUDP == "" {
+		return errors.New("skyudpbridge: TargetUDP is required")
+	}
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = DefaultIdleTimeout
+	}
+	if log == nil {
+		log = logrus.NewEntry(logrus.New())
+	}
+
+	target, err := net.ResolveUDPAddr("udp", cfg.TargetUDP)
+	if err != nil {
+		return fmt.Errorf("resolve target udp %q: %w", cfg.TargetUDP, err)
+	}
+
+	for {
+		conn, err := accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		go handleServerStream(ctx, conn, target, cfg.IdleTimeout, log)
+	}
+}
+
+// WriteFrame writes one length-prefixed datagram to w. Returns an
+// error if the payload is over MaxFrameSize or the write partially
+// completes. Exported so tests + the future visor-app variant share
+// the same wire format guarantees.
+func WriteFrame(w io.Writer, payload []byte) error {
+	if len(payload) > MaxFrameSize {
+		return fmt.Errorf("skyudpbridge: frame %d > max %d", len(payload), MaxFrameSize)
+	}
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(payload))) //nolint:gosec // bounded above
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("write frame header: %w", err)
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("write frame body: %w", err)
+	}
+	return nil
+}
+
+// ReadFrame reads one length-prefixed datagram from r into buf.
+// Returns the number of bytes read into buf. If the incoming frame
+// is larger than len(buf), returns an error (caller should size
+// buf to MaxFrameSize for guaranteed acceptance).
+func ReadFrame(r io.Reader, buf []byte) (int, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return 0, err
+	}
+	n := int(binary.BigEndian.Uint16(hdr[:]))
+	if n == 0 {
+		return 0, nil
+	}
+	if n > len(buf) {
+		return 0, fmt.Errorf("skyudpbridge: frame %d > buf %d", n, len(buf))
+	}
+	if _, err := io.ReadFull(r, buf[:n]); err != nil {
+		return 0, fmt.Errorf("read frame body: %w", err)
+	}
+	return n, nil
+}
+
+// --- client side internals ---
+
+type clientFlow struct {
+	conn     net.Conn
+	mu       sync.Mutex
+	idleStop chan struct{}
+	addr     *net.UDPAddr
+}
+
+type clientState struct {
+	cfg    ClientConfig
+	dialer Dialer
+	log    logrus.FieldLogger
+	udpC   *net.UDPConn
+
+	mu    sync.Mutex
+	flows map[string]*clientFlow // keyed by source addr.String()
+}
+
+func (c *clientState) serveUDP(ctx context.Context) error {
+	buf := make([]byte, MaxFrameSize)
+	for {
+		n, src, err := c.udpC.ReadFromUDP(buf)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("udp read: %w", err)
+		}
+		payload := make([]byte, n)
+		copy(payload, buf[:n])
+
+		flow, err := c.getOrDialFlow(ctx, src)
+		if err != nil {
+			c.log.WithError(err).WithField("src", src.String()).
+				Debug("skyudpbridge: dial flow failed; dropping datagram")
+			continue
+		}
+		flow.mu.Lock()
+		writeErr := WriteFrame(flow.conn, payload)
+		flow.mu.Unlock()
+		if writeErr != nil {
+			c.log.WithError(writeErr).WithField("src", src.String()).
+				Debug("skyudpbridge: frame write failed; tearing down flow")
+			c.removeFlow(src)
+		}
+	}
+}
+
+func (c *clientState) getOrDialFlow(ctx context.Context, src *net.UDPAddr) (*clientFlow, error) {
+	key := src.String()
+	c.mu.Lock()
+	if f, ok := c.flows[key]; ok {
+		c.mu.Unlock()
+		return f, nil
+	}
+	c.mu.Unlock()
+
+	dialCtx, cancel := context.WithTimeout(ctx, c.cfg.DialTimeout)
+	defer cancel()
+	conn, err := c.dialer.Dial(dialCtx, c.cfg.Peer, c.cfg.PeerPort)
+	if err != nil {
+		return nil, err
+	}
+	flow := &clientFlow{
+		conn:     conn,
+		idleStop: make(chan struct{}),
+		addr:     src,
+	}
+
+	c.mu.Lock()
+	// Double-check in case a concurrent datagram from the same source
+	// raced us. If so, close the redundant conn and reuse the existing.
+	if existing, ok := c.flows[key]; ok {
+		c.mu.Unlock()
+		_ = conn.Close() //nolint:errcheck,gosec
+		return existing, nil
+	}
+	c.flows[key] = flow
+	c.mu.Unlock()
+
+	// Stream→UDP reply pump.
+	go c.pumpReplies(flow, src)
+	// Idle reaper.
+	go c.idleReaper(flow, src)
+	return flow, nil
+}
+
+func (c *clientState) pumpReplies(flow *clientFlow, src *net.UDPAddr) {
+	buf := make([]byte, MaxFrameSize)
+	for {
+		n, err := ReadFrame(flow.conn, buf)
+		if err != nil {
+			c.log.WithError(err).WithField("src", src.String()).
+				Debug("skyudpbridge: reply pump stopped")
+			c.removeFlow(src)
+			return
+		}
+		if n == 0 {
+			continue
+		}
+		if _, werr := c.udpC.WriteToUDP(buf[:n], src); werr != nil {
+			c.log.WithError(werr).WithField("src", src.String()).
+				Debug("skyudpbridge: udp reply write failed")
+			c.removeFlow(src)
+			return
+		}
+	}
+}
+
+func (c *clientState) idleReaper(flow *clientFlow, src *net.UDPAddr) {
+	t := time.NewTimer(c.cfg.IdleTimeout)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		c.log.WithField("src", src.String()).Debug("skyudpbridge: idle timeout, closing flow")
+		c.removeFlow(src)
+	case <-flow.idleStop:
+		return
+	}
+}
+
+func (c *clientState) closeAllFlows() {
+	c.mu.Lock()
+	flows := c.flows
+	c.flows = make(map[string]*clientFlow)
+	c.mu.Unlock()
+	for _, f := range flows {
+		close(f.idleStop)
+		_ = f.conn.Close() //nolint:errcheck,gosec
+	}
+}
+
+func (c *clientState) removeFlow(src *net.UDPAddr) {
+	key := src.String()
+	c.mu.Lock()
+	flow, ok := c.flows[key]
+	if ok {
+		delete(c.flows, key)
+	}
+	c.mu.Unlock()
+	if ok {
+		close(flow.idleStop)
+		_ = flow.conn.Close() //nolint:errcheck,gosec
+	}
+}
+
+// --- server side internals ---
+
+func handleServerStream(ctx context.Context, stream net.Conn, target *net.UDPAddr, idleTimeout time.Duration, log logrus.FieldLogger) {
+	defer stream.Close() //nolint:errcheck,gosec
+
+	// Per-stream UDP socket. Source-port replies from target land
+	// on this socket and route back over this stream — keeping a
+	// stateful UDP protocol (DNS req/reply on same socket) working.
+	udp, err := net.DialUDP("udp", nil, target)
+	if err != nil {
+		log.WithError(err).Debug("skyudpbridge: server dial target udp failed")
+		return
+	}
+	defer udp.Close() //nolint:errcheck,gosec
+
+	idleCh := make(chan struct{}, 1)
+	// stream→UDP
+	go func() {
+		buf := make([]byte, MaxFrameSize)
+		for {
+			n, err := ReadFrame(stream, buf)
+			if err != nil {
+				select {
+				case idleCh <- struct{}{}:
+				default:
+				}
+				return
+			}
+			if n == 0 {
+				continue
+			}
+			if _, werr := udp.Write(buf[:n]); werr != nil {
+				log.WithError(werr).Debug("skyudpbridge: server udp write failed")
+				select {
+				case idleCh <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}()
+	// UDP→stream
+	go func() {
+		buf := make([]byte, MaxFrameSize)
+		for {
+			_ = udp.SetReadDeadline(time.Now().Add(idleTimeout)) //nolint:errcheck,gosec
+			n, _, err := udp.ReadFromUDP(buf)
+			if err != nil {
+				select {
+				case idleCh <- struct{}{}:
+				default:
+				}
+				return
+			}
+			if err := WriteFrame(stream, buf[:n]); err != nil {
+				log.WithError(err).Debug("skyudpbridge: server stream write failed")
+				select {
+				case idleCh <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-idleCh:
+	}
+}

--- a/pkg/skyudpbridge/skyudpbridge_test.go
+++ b/pkg/skyudpbridge/skyudpbridge_test.go
@@ -1,0 +1,171 @@
+package skyudpbridge
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{},
+		[]byte("a"),
+		bytes.Repeat([]byte{0xAB}, 1500),
+		bytes.Repeat([]byte{0xCD}, MaxFrameSize),
+	}
+	for _, payload := range cases {
+		var buf bytes.Buffer
+		if err := WriteFrame(&buf, payload); err != nil {
+			t.Fatalf("WriteFrame(len=%d): %v", len(payload), err)
+		}
+		out := make([]byte, MaxFrameSize)
+		n, err := ReadFrame(&buf, out)
+		if err != nil {
+			t.Fatalf("ReadFrame(len=%d): %v", len(payload), err)
+		}
+		if n != len(payload) {
+			t.Fatalf("ReadFrame returned n=%d, want %d", n, len(payload))
+		}
+		if !bytes.Equal(out[:n], payload) {
+			t.Fatalf("ReadFrame body mismatch (len=%d)", len(payload))
+		}
+	}
+}
+
+func TestWriteFrameRejectsOversized(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, make([]byte, MaxFrameSize+1)); err == nil {
+		t.Fatal("expected error for oversized frame, got nil")
+	}
+}
+
+func TestReadFrameRejectsBufTooSmall(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, bytes.Repeat([]byte{1}, 100)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFrame(&buf, make([]byte, 50)); err == nil {
+		t.Fatal("expected error when buf < frame, got nil")
+	}
+}
+
+func TestReadFrameEOF(t *testing.T) {
+	if _, err := ReadFrame(bytes.NewReader(nil), make([]byte, 10)); err != io.EOF {
+		t.Fatalf("ReadFrame on empty: got %v, want EOF", err)
+	}
+}
+
+// pipeDialer implements Dialer by handing out one end of an in-memory
+// net.Pipe per Dial. The other end is published on accepted so the
+// test can pump it through a server.
+type pipeDialer struct {
+	mu       sync.Mutex
+	accepted []net.Conn
+}
+
+func (p *pipeDialer) Dial(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	a, b := net.Pipe()
+	p.mu.Lock()
+	p.accepted = append(p.accepted, b)
+	p.mu.Unlock()
+	return a, nil
+}
+
+// TestClientFramesDatagramsOntoStream brings up the client side
+// against a pipe-backed Dialer and verifies that a single UDP
+// datagram surfaces on the peer end as exactly one length-prefixed
+// frame with the original payload.
+func TestClientFramesDatagramsOntoStream(t *testing.T) {
+	pd := &pipeDialer{}
+	cfg := ClientConfig{
+		ListenUDP:   "127.0.0.1:0",
+		Peer:        cipher.PubKey{},
+		PeerPort:    9999,
+		IdleTimeout: 5 * time.Second,
+		DialTimeout: time.Second,
+	}
+
+	// Bind a UDP listener up front so we know the port for the test.
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	probe, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound := probe.LocalAddr().(*net.UDPAddr)
+	_ = probe.Close() //nolint:errcheck,gosec
+	cfg.ListenUDP = bound.String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	done := make(chan error, 1)
+	go func() { done <- RunClient(ctx, cfg, pd, logger) }()
+
+	// Wait briefly for the UDP listen to land.
+	deadline := time.Now().Add(2 * time.Second)
+	var sender *net.UDPConn
+	for time.Now().Before(deadline) {
+		sender, err = net.DialUDP("udp", nil, bound)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("dial UDP %s: %v", bound, err)
+	}
+	defer sender.Close() //nolint:errcheck,gosec
+
+	payload := []byte("hello-skyudp")
+
+	// Resend until the client side has bound + dialled the pipe.
+	// RunClient opens the UDP socket asynchronously, so the first
+	// few datagrams may be dropped before the listener is up.
+	var peerConn net.Conn
+	for time.Now().Before(deadline) {
+		_, _ = sender.Write(payload) //nolint:errcheck,gosec
+		pd.mu.Lock()
+		if len(pd.accepted) > 0 {
+			peerConn = pd.accepted[0]
+		}
+		pd.mu.Unlock()
+		if peerConn != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if peerConn == nil {
+		t.Fatal("Dial was never called within deadline")
+	}
+	defer peerConn.Close() //nolint:errcheck,gosec
+
+	_ = peerConn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck,gosec
+	got := make([]byte, MaxFrameSize)
+	n, err := ReadFrame(peerConn, got)
+	if err != nil {
+		t.Fatalf("ReadFrame on peer side: %v", err)
+	}
+	if !bytes.Equal(got[:n], payload) {
+		t.Fatalf("peer frame = %q, want %q", got[:n], payload)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunClient did not exit after cancel")
+	}
+}


### PR DESCRIPTION
## Summary

Adds **`sub`** — a standalone (dmsg-only) UDP→dmsg bridge that wraps UDP datagrams in length-prefixed frames and ferries them over a dmsg stream. Sibling to `smb` (cmd/smb, PR #2598/#2605).

**Plan B for UDP-over-skynet.** Suitable for non-realtime UDP — DNS, NTP, SNMP, MQTT-SN, WireGuard control plane. For media-class UDP (RTP, VoIP, WebRTC media, real-time game protocols) use **Plan A** — packet-level UDP at the route-group layer (RFC #2607 / PR #2609).

## Wire format

```
+--------+----------------+
| u16 BE | payload (≤64K) |
+--------+----------------+
```

One frame per UDP datagram. Per-source UDP flow (keyed by sender's `(ip, port)`) gets its own dmsg stream, held until idle (default 60s). Replies flow back over the same stream/socket pair so stateful UDP protocols (DNS req + reply on same socket) work natively.

## Components

- **`pkg/skyudpbridge`** — protocol core. Frame codec, client + server pumps, per-source flow map with idle reaper, `Dialer` interface mirroring `pkg/skymailbridge.Dialer` so a future visor-app variant can swap in `app.Client.Dial`.
- **`cmd/sub`** — standalone binary with own `dmsg.Client`. Two subcommands:
  - `sub client --listen 127.0.0.1:5353 --peer <pk> --remote-port <p>`
  - `sub server --dmsg-port <p> --target 127.0.0.1:53`
- **`cmd/skywire-cli/commands/dmsg/sub.go`** — hoists `cmd/sub`'s `RootCmd` so the unified skywire binary exposes it as `skywire dmsg sub`. Same trick the `smb` integration uses.

## Tests

`pkg/skyudpbridge` ships with:
- Frame round-trip across edge sizes (0, 1, 1500, MaxFrameSize).
- Oversized-frame rejection.
- Pipe-backed end-to-end test: real UDP listener, in-memory `Dialer`, verifies a sent datagram surfaces on the peer side as exactly one framed payload.

Passes with `-race`.

## Out of scope

- DTLS / per-frame auth (dmsg already provides E2E encryption + PK-bound identity).
- Path MTU discovery (every frame fits in the UDP payload limit).
- Visor-embedded variant (will follow once the standalone is validated; same staged approach as smb → embedded_skymail_bridge).

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race ./pkg/skyudpbridge/...`
- [ ] End-to-end DNS over `sub` between two visors (manual, separate machines)
- [ ] End-to-end NTP over `sub` (manual)