### PR TITLE
feat(router): per-datagram AEAD for DatagramRouteGroup (faithful UDP, stage 3)

### DIFF
--- a/pkg/router/datagram_crypto.go
+++ b/pkg/router/datagram_crypto.go
@@ -156,10 +156,10 @@ const (
 //
 // Single-direction; thread-safe.
 type DatagramCipher struct {
-	role     Role
-	destPK   cipher.PubKey // for AAD binding on outbound; sender's PK on inbound
-	aead     atomic.Pointer[cipherEpoch]
-	rekeyMu  sync.Mutex // serializes Rekey calls
+	role    Role
+	destPK  cipher.PubKey // for AAD binding on outbound; sender's PK on inbound
+	aead    atomic.Pointer[cipherEpoch]
+	rekeyMu sync.Mutex // serializes Rekey calls
 
 	// Outbound-only state. The atomic counter is the sender's
 	// next nonce; rekey resets it. Tracked separately from inbound
@@ -179,13 +179,13 @@ type DatagramCipher struct {
 // count thresholds for the current rekey epoch. Replaced atomically
 // on Rekey so in-flight Seal/Open calls observe a consistent epoch.
 type cipherEpoch struct {
-	aead         interface { // chacha20poly1305.New returns this shape
+	aead interface { // chacha20poly1305.New returns this shape
 		Seal(dst, nonce, plaintext, additionalData []byte) []byte
 		Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error)
 	}
-	openedAt     time.Time
-	timeLimit    time.Duration
-	packetLimit  uint64
+	openedAt    time.Time
+	timeLimit   time.Duration
+	packetLimit uint64
 }
 
 // NewDatagramCipher constructs an outbound-or-inbound cipher from a

--- a/pkg/router/datagram_crypto.go
+++ b/pkg/router/datagram_crypto.go
@@ -1,0 +1,459 @@
+// Package router pkg/router/datagram_crypto.go: per-datagram AEAD
+// for DatagramRouteGroup. Stage 3 of #2607.
+//
+// Stream Noise (what RouteGroup uses) generates a continuous
+// keystream that desyncs on lost frames — every subsequent
+// decryption fails. UDP drops packets by design, so the datagram
+// path needs a cipher that survives loss: each datagram independently
+// encrypted, authenticated, replay-protected, AEAD-bound to its
+// route + receiver.
+//
+// Per-datagram AEAD model (matches WireGuard / IPsec ESP / DTLS 1.3
+// data-plane):
+//
+//   - Cipher: ChaCha20-Poly1305-IETF (RFC 7539). Same primitive the
+//     existing skywire crypto stack uses for Noise; reusing keeps
+//     the dependency surface flat. 256-bit key, 96-bit nonce,
+//     128-bit auth tag.
+//
+//   - Master key: derived from the Noise session master via HKDF-SHA256.
+//     One subkey per direction (initiator→responder vs the reverse)
+//     and per route within the session.
+//
+//   - Nonce: 96 bits, constructed as zero-padding(32) || counter(64).
+//     Counter is 64-bit, monotonic per-sender, starts at 0 at
+//     handshake. On the wire only the 8-byte counter portion is
+//     transmitted; the receiver reconstructs the full nonce from
+//     the implicit zero-padding. Saves 4 bytes/datagram vs sending
+//     the full 12-byte nonce. WireGuard precedent.
+//
+//   - AAD: routeID (4 bytes, big-endian) || destPK (33 bytes,
+//     compressed secp256k1). Binds the sealed datagram to (a) this
+//     route within the session and (b) this specific receiver.
+//     Cross-route substitution and cross-receiver replay both
+//     blocked even if an attacker captures ciphertext from a
+//     parallel route and tries to inject it elsewhere.
+//
+//   - Anti-replay: RFC 6479 sliding window, 2048-bit (32 × uint64
+//     bitmap). The counter IS the sequence — no redundant `seq` on
+//     the wire. The window's "have I seen this counter" check IS
+//     the replay-protection sequence check.
+//
+//   - Rekey: triggered on time (default 2 min since last rekey) or
+//     packet count (default 2^32 packets sent on this direction).
+//     Below the 2^60 ChaCha bound by many orders of magnitude;
+//     comfortable safety margin. Rekey resets the counter to 0
+//     on both sides under the new master.
+//
+// Wire format of one sealed datagram body (what goes inside a
+// DatagramPacket's payload):
+//
+//   [counter (8 bytes, big-endian uint64)] [ciphertext + 16-byte tag]
+//
+// Plaintext max = MaxDatagramPayload - 8 (counter) - 16 (tag) = 65511.
+// Exported via DatagramCipher.MaxPlaintext() so DatagramRouteGroup.MaxPayload
+// can return the right number to callers.
+
+package router
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/hkdf"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// Datagram AEAD wire constants. Public so Stage 4's MaxPayload
+// computation can subtract the correct overhead.
+const (
+	// DatagramCounterSize is the on-wire counter prefix length.
+	DatagramCounterSize = 8
+
+	// DatagramTagSize is the Poly1305 authentication tag length.
+	DatagramTagSize = chacha20poly1305.Overhead
+
+	// DatagramOverhead is the total per-datagram wire overhead
+	// (counter prefix + auth tag). Plaintext + DatagramOverhead is
+	// what lands in a DatagramPacket's payload.
+	DatagramOverhead = DatagramCounterSize + DatagramTagSize
+
+	// MaxDatagramPlaintext is the largest plaintext datagram body
+	// that fits in a single DatagramPacket after AEAD wrapping.
+	// Computed from MaxDatagramPayload (the routing-packet payload
+	// cap) minus DatagramOverhead.
+	MaxDatagramPlaintext = MaxDatagramPayload - DatagramOverhead
+
+	// DefaultRekeyTimeInterval is the time-based rekey trigger.
+	// WireGuard uses 2 minutes; matching that for operational
+	// familiarity.
+	DefaultRekeyTimeInterval = 2 * time.Minute
+
+	// DefaultRekeyPacketLimit is the packet-count rekey trigger.
+	// 2^32 = ~4.3B packets, well below the ChaCha 2^60 bound but
+	// generous compared to realistic workloads (a 100 Kpps stream
+	// for ~12 hours).
+	DefaultRekeyPacketLimit uint64 = 1 << 32
+
+	// replayWindowSize is the sliding-window length in bits. RFC
+	// 6479 recommends 1024+; WireGuard uses 2048. We match
+	// WireGuard.
+	replayWindowSize = 2048
+
+	// replayWindowWords is the underlying bitmap length in uint64s.
+	replayWindowWords = replayWindowSize / 64
+)
+
+// Errors surfaced by DatagramCipher operations.
+var (
+	// ErrCounterExhausted is returned by Seal when the per-direction
+	// counter has reached its rekey limit and no rekey has happened
+	// yet. The caller should trigger a rekey and retry.
+	ErrCounterExhausted = errors.New("datagram-crypto: counter exhausted, rekey required")
+
+	// ErrAEADAuth is returned by Open when the auth tag does not
+	// verify, the counter falls outside the replay window, or the
+	// counter was already seen. Indistinguishable to the caller by
+	// design — leaking which failure occurred would expose timing
+	// signal to an attacker probing the window.
+	ErrAEADAuth = errors.New("datagram-crypto: auth failure")
+
+	// ErrCiphertextTooShort is returned when the input to Open is
+	// shorter than the minimum (counter prefix + tag).
+	ErrCiphertextTooShort = errors.New("datagram-crypto: ciphertext shorter than overhead")
+
+	// ErrPlaintextTooLong is returned when Seal's input exceeds
+	// MaxDatagramPlaintext.
+	ErrPlaintextTooLong = errors.New("datagram-crypto: plaintext exceeds MaxDatagramPlaintext")
+)
+
+// Role identifies which direction's subkey this cipher serves.
+// A DatagramRouteGroup holds two ciphers: one for outbound (seal
+// with the direction matching the local end's role at handshake)
+// and one for inbound (open with the peer's direction).
+type Role uint8
+
+const (
+	// RoleInitiator is the side that dialed the route.
+	RoleInitiator Role = iota
+	// RoleResponder is the side that accepted the route.
+	RoleResponder
+)
+
+// DatagramCipher is the per-direction AEAD state. Two instances
+// per DatagramRouteGroup: one for sealing outbound, one for opening
+// inbound. They share the same Noise-derived master (Wire-level
+// rekey moves both ciphers atomically) but each tracks its own
+// counter (outbound) or replay window (inbound).
+//
+// Single-direction; thread-safe.
+type DatagramCipher struct {
+	role     Role
+	destPK   cipher.PubKey // for AAD binding on outbound; sender's PK on inbound
+	aead     atomic.Pointer[cipherEpoch]
+	rekeyMu  sync.Mutex // serializes Rekey calls
+
+	// Outbound-only state. The atomic counter is the sender's
+	// next nonce; rekey resets it. Tracked separately from inbound
+	// so two-direction ciphers can share the cipherEpoch without
+	// stomping on each other.
+	outCounter uint64 // atomic
+
+	// Inbound-only state. The sliding-window bitmap tracks which
+	// counters have been observed in the trailing replayWindowSize
+	// values up to top. Protected by inMu.
+	inMu     sync.Mutex
+	inWindow [replayWindowWords]uint64
+	inTop    uint64
+}
+
+// cipherEpoch bundles the AEAD instance with the time and packet-
+// count thresholds for the current rekey epoch. Replaced atomically
+// on Rekey so in-flight Seal/Open calls observe a consistent epoch.
+type cipherEpoch struct {
+	aead         interface { // chacha20poly1305.New returns this shape
+		Seal(dst, nonce, plaintext, additionalData []byte) []byte
+		Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error)
+	}
+	openedAt     time.Time
+	timeLimit    time.Duration
+	packetLimit  uint64
+}
+
+// NewDatagramCipher constructs an outbound-or-inbound cipher from a
+// 32-byte Noise master key, the route's role, the binding PK (the
+// destination PK on outbound; the sender's PK on inbound — both go
+// into AAD identically). Optional config overrides time/packet
+// rekey limits; zero values fall back to defaults.
+func NewDatagramCipher(masterKey [32]byte, role Role, bindPK cipher.PubKey, cfg *DatagramCipherConfig) (*DatagramCipher, error) {
+	dc := &DatagramCipher{role: role, destPK: bindPK}
+	if err := dc.installEpoch(masterKey, cfg); err != nil {
+		return nil, err
+	}
+	return dc, nil
+}
+
+// DatagramCipherConfig tunes the rekey thresholds. Zero values use
+// the package defaults (2 min / 2^32 packets).
+type DatagramCipherConfig struct {
+	TimeLimit   time.Duration
+	PacketLimit uint64
+}
+
+func (dc *DatagramCipher) installEpoch(masterKey [32]byte, cfg *DatagramCipherConfig) error {
+	// HKDF-SHA256 expansion: one direction-tagged subkey per role
+	// so initiator's outbound key ≠ responder's outbound key even
+	// from the same master.
+	info := []byte("skywire-datagram-v1-init")
+	if dc.role == RoleResponder {
+		info = []byte("skywire-datagram-v1-resp")
+	}
+	h := hkdf.New(sha256.New, masterKey[:], nil, info)
+	subkey := make([]byte, chacha20poly1305.KeySize)
+	if _, err := io.ReadFull(h, subkey); err != nil {
+		return fmt.Errorf("datagram-crypto: hkdf: %w", err)
+	}
+	aead, err := chacha20poly1305.New(subkey)
+	if err != nil {
+		return fmt.Errorf("datagram-crypto: new chacha: %w", err)
+	}
+
+	tl := DefaultRekeyTimeInterval
+	pl := DefaultRekeyPacketLimit
+	if cfg != nil {
+		if cfg.TimeLimit > 0 {
+			tl = cfg.TimeLimit
+		}
+		if cfg.PacketLimit > 0 {
+			pl = cfg.PacketLimit
+		}
+	}
+
+	dc.aead.Store(&cipherEpoch{
+		aead:        aead,
+		openedAt:    time.Now(),
+		timeLimit:   tl,
+		packetLimit: pl,
+	})
+	atomic.StoreUint64(&dc.outCounter, 0)
+	dc.inMu.Lock()
+	for i := range dc.inWindow {
+		dc.inWindow[i] = 0
+	}
+	dc.inTop = 0
+	dc.inMu.Unlock()
+	return nil
+}
+
+// Rekey replaces the AEAD epoch with one derived from a fresh
+// master key. The counter resets to 0; the replay window clears.
+// Both sides must perform the swap in lockstep (driven by the
+// outer route-setup machinery, not by this type).
+func (dc *DatagramCipher) Rekey(masterKey [32]byte, cfg *DatagramCipherConfig) error {
+	dc.rekeyMu.Lock()
+	defer dc.rekeyMu.Unlock()
+	return dc.installEpoch(masterKey, cfg)
+}
+
+// NeedsRekey reports whether the current epoch has exceeded the
+// time-based or packet-count-based rekey trigger. The outer
+// scheduling layer polls this and initiates a Noise rekey when it
+// fires. Idempotent — calling does not change state.
+func (dc *DatagramCipher) NeedsRekey() bool {
+	ep := dc.aead.Load()
+	if ep == nil {
+		return false
+	}
+	if time.Since(ep.openedAt) >= ep.timeLimit {
+		return true
+	}
+	if atomic.LoadUint64(&dc.outCounter) >= ep.packetLimit {
+		return true
+	}
+	return false
+}
+
+// MaxPlaintext returns the largest plaintext datagram body that
+// Seal will accept. Surfaced via DatagramRouteGroup.MaxPayload to
+// callers.
+func (dc *DatagramCipher) MaxPlaintext() int {
+	return MaxDatagramPlaintext
+}
+
+// Seal AEAD-encrypts plaintext and prepends the 8-byte counter.
+// Output: [counter (8)] [ciphertext + 16-byte tag]. AAD is
+// constructed from routeID + dc.destPK. Returns ErrCounterExhausted
+// if the counter has reached the rekey limit — the caller should
+// trigger Rekey and retry.
+func (dc *DatagramCipher) Seal(routeID uint32, plaintext []byte) ([]byte, error) {
+	if len(plaintext) > MaxDatagramPlaintext {
+		return nil, ErrPlaintextTooLong
+	}
+	ep := dc.aead.Load()
+	if ep == nil {
+		return nil, errors.New("datagram-crypto: cipher uninitialised")
+	}
+	counter := atomic.AddUint64(&dc.outCounter, 1) - 1 // first nonce = 0
+	if counter >= ep.packetLimit {
+		// Roll back — we didn't consume a counter the receiver
+		// could ever observe.
+		atomic.AddUint64(&dc.outCounter, ^uint64(0))
+		return nil, ErrCounterExhausted
+	}
+
+	var nonce [chacha20poly1305.NonceSize]byte
+	binary.BigEndian.PutUint64(nonce[4:], counter)
+
+	aad := makeAAD(routeID, dc.destPK)
+
+	out := make([]byte, DatagramCounterSize, DatagramCounterSize+len(plaintext)+DatagramTagSize)
+	binary.BigEndian.PutUint64(out, counter)
+	out = ep.aead.Seal(out, nonce[:], plaintext, aad)
+	return out, nil
+}
+
+// Open verifies and decrypts a sealed datagram body. Input format
+// matches Seal's output. Returns ErrAEADAuth on any of: tag mismatch,
+// counter outside the replay window, counter already observed.
+// Indistinguishable failure modes are intentional — leaking which
+// failed would expose timing signal to an attacker.
+//
+// On success the counter is recorded in the replay window so the
+// same datagram cannot be replayed within the window.
+func (dc *DatagramCipher) Open(routeID uint32, sealed []byte) ([]byte, error) {
+	if len(sealed) < DatagramOverhead {
+		return nil, ErrCiphertextTooShort
+	}
+	ep := dc.aead.Load()
+	if ep == nil {
+		return nil, errors.New("datagram-crypto: cipher uninitialised")
+	}
+
+	counter := binary.BigEndian.Uint64(sealed[:DatagramCounterSize])
+	ct := sealed[DatagramCounterSize:]
+
+	// Pre-AEAD replay check: cheap reject for counters well outside
+	// the window. AEAD check follows; only commit the window
+	// update if auth succeeds (otherwise a forged packet could
+	// poison the window).
+	if !dc.replayPrecheck(counter) {
+		return nil, ErrAEADAuth
+	}
+
+	var nonce [chacha20poly1305.NonceSize]byte
+	binary.BigEndian.PutUint64(nonce[4:], counter)
+	aad := makeAAD(routeID, dc.destPK)
+
+	pt, err := ep.aead.Open(nil, nonce[:], ct, aad)
+	if err != nil {
+		return nil, ErrAEADAuth
+	}
+	if !dc.replayCommit(counter) {
+		// Lost a race with another goroutine that committed the
+		// same counter first — treat as replay.
+		return nil, ErrAEADAuth
+	}
+	return pt, nil
+}
+
+// replayPrecheck returns false if the counter is definitely
+// outside the window (too old) or already observed. A true return
+// means the counter passes the cheap check; final commit happens
+// only after AEAD authentication succeeds.
+func (dc *DatagramCipher) replayPrecheck(counter uint64) bool {
+	dc.inMu.Lock()
+	defer dc.inMu.Unlock()
+	if counter+replayWindowSize <= dc.inTop {
+		return false // beyond the trailing edge
+	}
+	if counter <= dc.inTop {
+		// Inside the window — check the bit.
+		offset := dc.inTop - counter
+		word := (replayWindowSize - 1 - offset) / 64
+		bit := uint64(1) << ((replayWindowSize - 1 - offset) % 64)
+		return dc.inWindow[word]&bit == 0
+	}
+	return true // ahead of inTop — always fresh
+}
+
+// replayCommit marks the counter as observed. Returns false if a
+// concurrent goroutine committed the same counter between
+// precheck and commit (effectively treats the race-loser as a
+// replay so we don't deliver the same datagram twice).
+func (dc *DatagramCipher) replayCommit(counter uint64) bool {
+	dc.inMu.Lock()
+	defer dc.inMu.Unlock()
+	if counter > dc.inTop {
+		shift := counter - dc.inTop
+		if shift >= replayWindowSize {
+			// Slide reset — far ahead of previous top.
+			for i := range dc.inWindow {
+				dc.inWindow[i] = 0
+			}
+		} else {
+			// Shift the bitmap left by `shift` bits.
+			shiftLeft(&dc.inWindow, uint(shift))
+		}
+		dc.inTop = counter
+		// Mark the newly-arrived top bit.
+		bit := uint64(1) << ((replayWindowSize - 1) % 64)
+		dc.inWindow[(replayWindowSize-1)/64] &^= bit // clear any stale
+		// Actually we want to set the bit at the position of the
+		// new top, which after shift is at the most-significant
+		// edge.
+		dc.inWindow[replayWindowWords-1] |= 1
+		return true
+	}
+	// counter <= dc.inTop and within window per precheck.
+	offset := dc.inTop - counter
+	word := (replayWindowSize - 1 - offset) / 64
+	bit := uint64(1) << ((replayWindowSize - 1 - offset) % 64)
+	if dc.inWindow[word]&bit != 0 {
+		return false // raced
+	}
+	dc.inWindow[word] |= bit
+	return true
+}
+
+// shiftLeft shifts the bitmap left by n bits (n < replayWindowSize).
+// "Left" here means toward the most-significant bit, which is the
+// most-recent end of the window — older counters fall off the
+// least-significant end.
+func shiftLeft(w *[replayWindowWords]uint64, n uint) {
+	wordShift := n / 64
+	bitShift := n % 64
+	if wordShift > 0 {
+		for i := 0; i < replayWindowWords; i++ {
+			src := i + int(wordShift)
+			if src < replayWindowWords {
+				w[i] = w[src]
+			} else {
+				w[i] = 0
+			}
+		}
+	}
+	if bitShift > 0 {
+		for i := 0; i < replayWindowWords-1; i++ {
+			w[i] = (w[i] << bitShift) | (w[i+1] >> (64 - bitShift))
+		}
+		w[replayWindowWords-1] <<= bitShift
+	}
+}
+
+// makeAAD constructs the AEAD associated-data block for a sealed
+// datagram. routeID is big-endian uint32; destPK is the 33-byte
+// compressed secp256k1 PK exactly as it appears on the wire.
+func makeAAD(routeID uint32, destPK cipher.PubKey) []byte {
+	out := make([]byte, 4+len(destPK))
+	binary.BigEndian.PutUint32(out, routeID)
+	copy(out[4:], destPK[:])
+	return out
+}

--- a/pkg/router/datagram_crypto_test.go
+++ b/pkg/router/datagram_crypto_test.go
@@ -1,0 +1,293 @@
+// Package router pkg/router/datagram_crypto_test.go: unit tests
+// for the per-datagram AEAD layer. Stage 3 of #2607.
+
+package router
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// newTestPair builds an initiator+responder cipher pair sharing the
+// same master key + bind PK. The two ciphers each play one role on
+// each side: initiator's "outbound" matches responder's "inbound"
+// (same subkey via HKDF info "skywire-datagram-v1-init") and vice
+// versa.
+func newTestPair(t *testing.T, cfg *DatagramCipherConfig) (initiatorOut, responderIn, responderOut, initiatorIn *DatagramCipher) {
+	t.Helper()
+	var master [32]byte
+	_, err := rand.Read(master[:])
+	require.NoError(t, err)
+	bindPK, _ := cipher.GenerateKeyPair()
+
+	initiatorOut, err = NewDatagramCipher(master, RoleInitiator, bindPK, cfg)
+	require.NoError(t, err)
+	responderIn, err = NewDatagramCipher(master, RoleInitiator, bindPK, cfg) // peer's inbound mirrors my outbound
+	require.NoError(t, err)
+	responderOut, err = NewDatagramCipher(master, RoleResponder, bindPK, cfg)
+	require.NoError(t, err)
+	initiatorIn, err = NewDatagramCipher(master, RoleResponder, bindPK, cfg)
+	require.NoError(t, err)
+	return
+}
+
+func TestDatagramCipherRoundTrip(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	plaintext := []byte("over-skynet-as-datagram")
+	sealed, err := out.Seal(42, plaintext)
+	require.NoError(t, err)
+
+	// Wire-format checks: first 8 bytes = counter (0 on first send);
+	// total length = counter(8) + ciphertext(plaintext) + tag(16).
+	assert.Equal(t, uint64(0), binary.BigEndian.Uint64(sealed[:8]))
+	assert.Equal(t, DatagramOverhead+len(plaintext), len(sealed))
+
+	pt, err := in.Open(42, sealed)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, pt)
+}
+
+func TestDatagramCipherWrongRouteIDRejected(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	sealed, err := out.Seal(42, []byte("for route 42"))
+	require.NoError(t, err)
+
+	// Wrong route ID at Open → AAD mismatch → auth failure.
+	_, err = in.Open(43, sealed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAEADAuth)
+}
+
+func TestDatagramCipherWrongBindPKRejected(t *testing.T) {
+	var master [32]byte
+	_, _ = rand.Read(master[:])
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	out, err := NewDatagramCipher(master, RoleInitiator, pk1, nil)
+	require.NoError(t, err)
+	in, err := NewDatagramCipher(master, RoleInitiator, pk2, nil) // different bindPK
+	require.NoError(t, err)
+
+	sealed, err := out.Seal(42, []byte("test"))
+	require.NoError(t, err)
+
+	// AAD mismatch on destPK → auth failure.
+	_, err = in.Open(42, sealed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAEADAuth)
+}
+
+func TestDatagramCipherReplayRejected(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	sealed, err := out.Seal(1, []byte("once"))
+	require.NoError(t, err)
+
+	// First Open succeeds.
+	_, err = in.Open(1, sealed)
+	require.NoError(t, err)
+
+	// Replay of the same ciphertext → auth failure (already in
+	// the window).
+	_, err = in.Open(1, sealed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAEADAuth)
+}
+
+func TestDatagramCipherOutOfWindowRejected(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	// Send + receive enough datagrams to advance the window past
+	// where counter=0 was. replayWindowSize is 2048, so 3000 sends
+	// puts counter=0 well outside the trailing edge.
+	for i := 0; i < 3000; i++ {
+		sealed, err := out.Seal(1, []byte("x"))
+		require.NoError(t, err)
+		_, err = in.Open(1, sealed)
+		require.NoError(t, err)
+	}
+
+	// Now craft a sealed datagram with counter=0 (replay the very
+	// first message we sent). The replay window has long since
+	// slid past 0; even if we had its ciphertext it would fall
+	// outside the window and be rejected on precheck.
+	//
+	// We don't have the original ciphertext, but we can prove the
+	// rejection by hand-constructing a counter=0 prefix and showing
+	// it gets rejected without even attempting AEAD verify. We
+	// detect "outside window" indirectly: the function returns
+	// ErrAEADAuth (same opaque error as forge / auth fail), so we
+	// just confirm the negative.
+	var sealed [DatagramOverhead + 5]byte
+	// counter prefix all zeros (already is).
+	// ciphertext + tag is junk; precheck rejects before AEAD runs.
+	_, err := in.Open(1, sealed[:])
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAEADAuth)
+}
+
+func TestDatagramCipherCounterMonotonic(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	// Two seals back to back — second must use counter=1.
+	s0, err := out.Seal(7, []byte("a"))
+	require.NoError(t, err)
+	s1, err := out.Seal(7, []byte("b"))
+	require.NoError(t, err)
+
+	assert.Equal(t, uint64(0), binary.BigEndian.Uint64(s0[:8]))
+	assert.Equal(t, uint64(1), binary.BigEndian.Uint64(s1[:8]))
+	assert.NotEqual(t, s0, s1, "different counters must produce different ciphertexts")
+
+	pt0, err := in.Open(7, s0)
+	require.NoError(t, err)
+	pt1, err := in.Open(7, s1)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("a"), pt0)
+	assert.Equal(t, []byte("b"), pt1)
+}
+
+func TestDatagramCipherReorderedDeliveryAccepted(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	// Seal 10 datagrams in order.
+	sealed := make([][]byte, 10)
+	for i := 0; i < 10; i++ {
+		s, err := out.Seal(1, []byte{byte(i)})
+		require.NoError(t, err)
+		sealed[i] = s
+	}
+
+	// Open in reverse — sliding window must accept each as fresh
+	// the first time. Faithful-UDP-over-skynet apps will see
+	// reordering and must not have their messages rejected for it.
+	for i := 9; i >= 0; i-- {
+		pt, err := in.Open(1, sealed[i])
+		require.NoError(t, err, "datagram %d failed", i)
+		assert.Equal(t, []byte{byte(i)}, pt)
+	}
+}
+
+func TestDatagramCipherCounterExhaustedTriggersRekey(t *testing.T) {
+	cfg := &DatagramCipherConfig{
+		PacketLimit: 3, // exhaust quickly
+	}
+	out, _, _, _ := newTestPair(t, cfg)
+
+	// Three seals succeed; fourth must fail with ErrCounterExhausted
+	// AND not consume a counter the receiver would have observed.
+	_, err := out.Seal(1, []byte("1"))
+	require.NoError(t, err)
+	_, err = out.Seal(1, []byte("2"))
+	require.NoError(t, err)
+	_, err = out.Seal(1, []byte("3"))
+	require.NoError(t, err)
+
+	assert.True(t, out.NeedsRekey(), "after PacketLimit reached, NeedsRekey should fire")
+
+	_, err = out.Seal(1, []byte("4"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCounterExhausted)
+}
+
+func TestDatagramCipherNeedsRekeyOnTime(t *testing.T) {
+	cfg := &DatagramCipherConfig{
+		TimeLimit: 20 * time.Millisecond,
+	}
+	out, _, _, _ := newTestPair(t, cfg)
+
+	assert.False(t, out.NeedsRekey(), "fresh cipher should not need rekey")
+	time.Sleep(30 * time.Millisecond)
+	assert.True(t, out.NeedsRekey(), "time-based trigger should fire after TimeLimit")
+}
+
+func TestDatagramCipherRekeyResetsState(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	// Send a few; advance counter to 3.
+	for i := 0; i < 3; i++ {
+		s, err := out.Seal(1, []byte("pre"))
+		require.NoError(t, err)
+		_, err = in.Open(1, s)
+		require.NoError(t, err)
+	}
+
+	// Rekey both with a fresh master.
+	var newMaster [32]byte
+	_, _ = rand.Read(newMaster[:])
+	require.NoError(t, out.Rekey(newMaster, nil))
+	require.NoError(t, in.Rekey(newMaster, nil))
+
+	// First seal post-rekey: counter should reset to 0.
+	s0, err := out.Seal(1, []byte("post"))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), binary.BigEndian.Uint64(s0[:8]))
+
+	pt, err := in.Open(1, s0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("post"), pt)
+}
+
+func TestDatagramCipherShortCiphertextRejected(t *testing.T) {
+	_, in, _, _ := newTestPair(t, nil)
+	_, err := in.Open(1, []byte{0x01, 0x02}) // way under DatagramOverhead
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCiphertextTooShort)
+}
+
+func TestDatagramCipherPlaintextTooLongRejected(t *testing.T) {
+	out, _, _, _ := newTestPair(t, nil)
+	tooBig := bytes.Repeat([]byte{0x42}, MaxDatagramPlaintext+1)
+	_, err := out.Seal(1, tooBig)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPlaintextTooLong)
+}
+
+func TestDatagramCipherConcurrentSealOpenSafe(t *testing.T) {
+	out, in, _, _ := newTestPair(t, nil)
+
+	const N = 200
+	sealed := make(chan []byte, N)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < N; i++ {
+			s, err := out.Seal(1, []byte{byte(i)})
+			if err != nil {
+				t.Errorf("seal: %v", err)
+				return
+			}
+			sealed <- s
+		}
+		close(sealed)
+	}()
+
+	var opened uint64
+	go func() {
+		defer wg.Done()
+		for s := range sealed {
+			_, err := in.Open(1, s)
+			if err == nil {
+				atomic.AddUint64(&opened, 1)
+			}
+		}
+	}()
+
+	wg.Wait()
+	assert.Equal(t, uint64(N), atomic.LoadUint64(&opened), "all N seals should round-trip")
+}

--- a/pkg/router/datagram_route_group.go
+++ b/pkg/router/datagram_route_group.go
@@ -129,6 +129,24 @@ type DatagramRouteGroup struct {
 	// full when Handle tried to push. Surfaced via Stats() and
 	// useful for diagnosing slow consumers.
 	inboundDropped uint64 // atomic
+
+	// AEAD layer. outCipher seals outbound datagrams (called by
+	// WriteTo); inCipher opens inbound (called by Handle). Nil
+	// means the AEAD layer is bypassed — used by the existing
+	// Stage 2 unit tests that wire the type without crypto. Stage 4
+	// will require non-nil ciphers at construction time so production
+	// paths can't accidentally bypass the AEAD; the bypass mode is
+	// strictly for test convenience.
+	outCipher *DatagramCipher
+	inCipher  *DatagramCipher
+
+	// aeadAuthFailures counts inbound datagrams that failed to
+	// authenticate (forgery attempts, replay attempts, corrupted
+	// packets in flight). Surfaced via AEADAuthFailures() for
+	// diagnostics. Forged datagrams under load would otherwise be
+	// invisible to operators — this lets a monitor pick up an
+	// in-progress attack.
+	aeadAuthFailures uint64 // atomic
 }
 
 // NewDatagramRouteGroup constructs a DatagramRouteGroup. The
@@ -161,6 +179,20 @@ func NewDatagramRouteGroup(cfg *RouteGroupConfig, rt routing.Table, desc routing
 	}
 }
 
+// SetCiphers installs the per-direction AEAD ciphers. Called by the
+// setup-node integration in Stage 4 after the Noise handshake
+// produces the master key.
+//
+// Nil ciphers leave the AEAD layer bypassed (raw plaintext on the
+// wire) — only used by Stage 2 unit tests; the production path
+// MUST install ciphers before any traffic flows.
+func (dg *DatagramRouteGroup) SetCiphers(out, in *DatagramCipher) {
+	dg.mu.Lock()
+	defer dg.mu.Unlock()
+	dg.outCipher = out
+	dg.inCipher = in
+}
+
 // AddRule registers a (forward rule, transport, reverse rule)
 // triple. Called by the setup-node integration in Stage 4. Index
 // invariant: tps[i] is the transport for fwd[i]; rvs[i] is the
@@ -176,13 +208,21 @@ func (dg *DatagramRouteGroup) AddRule(fwd routing.Rule, tp *transport.ManagedTra
 	dg.rvs = append(dg.rvs, rv)
 }
 
-// MaxPayload returns the largest datagram size that WriteTo will
-// accept. In Stage 2 this is the raw wire cap (65535). Stage 3
-// will reduce it by the per-datagram AEAD overhead (8-byte nonce
-// counter + 16-byte Poly1305 tag = 24 bytes), at which point
-// MaxPayload returns 65511. Apps that consult this before sending
-// avoid the opaque-EMSGSIZE footgun.
+// MaxPayload returns the largest plaintext datagram that WriteTo
+// will accept. When AEAD is enabled (Stage 3 cipher installed via
+// SetCiphers) the cap is MaxDatagramPayload minus the 24-byte
+// per-datagram overhead (8-byte counter prefix + 16-byte Poly1305
+// tag) = 65511. When the cipher is unset the bypass mode returns
+// the raw wire cap.
+//
+// Apps consult this before sending to avoid the opaque-EMSGSIZE
+// footgun.
 func (dg *DatagramRouteGroup) MaxPayload() int {
+	dg.mu.Lock()
+	defer dg.mu.Unlock()
+	if dg.outCipher != nil {
+		return dg.outCipher.MaxPlaintext()
+	}
 	return MaxDatagramPayload
 }
 
@@ -212,9 +252,21 @@ func (dg *DatagramRouteGroup) WriteTo(data []byte, addr net.Addr) (int, error) {
 	}
 	rule := dg.fwd[0]
 	tp := dg.tps[0]
+	cipher := dg.outCipher
 	dg.mu.Unlock()
 
-	packet, err := routing.MakeDatagramPacket(rule.NextRouteID(), data)
+	// Wrap in AEAD if configured. Stage 4 will require this; Stage 2
+	// unit tests use the bypass path.
+	body := data
+	if cipher != nil {
+		sealed, err := cipher.Seal(uint32(rule.NextRouteID()), data)
+		if err != nil {
+			return 0, fmt.Errorf("datagram-route-group: seal: %w", err)
+		}
+		body = sealed
+	}
+
+	packet, err := routing.MakeDatagramPacket(rule.NextRouteID(), body)
 	if err != nil {
 		return 0, err
 	}
@@ -280,13 +332,32 @@ func (dg *DatagramRouteGroup) Handle(packet routing.Packet) error {
 	}
 	dg.networkStats.AddBandwidthReceived(uint64(packet.Size()))
 
-	// Copy out the payload — the underlying packet buffer is owned
-	// by the read loop and may be reused for the next inbound
-	// frame. Without the copy a fast inbound rate would clobber
-	// queued datagrams before the app reads them.
-	payload := packet.Payload()
-	cp := make([]byte, len(payload))
-	copy(cp, payload)
+	// Resolve the inbound cipher under the mutex — Stage 4 may swap
+	// it on rekey concurrent with Handle.
+	dg.mu.Lock()
+	cipher := dg.inCipher
+	dg.mu.Unlock()
+
+	// Decrypt + verify under the AEAD layer if configured. Bypass
+	// mode is the Stage-2 unit-test path. Auth failures bump a
+	// counter and drop silently — surfacing the failure to the
+	// sender would expose timing signal to a forger.
+	var cp []byte
+	if cipher != nil {
+		pt, err := cipher.Open(uint32(packet.RouteID()), packet.Payload())
+		if err != nil {
+			atomic.AddUint64(&dg.aeadAuthFailures, 1)
+			return nil // drop silently
+		}
+		cp = pt
+	} else {
+		// Copy out the payload — the underlying packet buffer is
+		// owned by the read loop and may be reused for the next
+		// inbound frame.
+		payload := packet.Payload()
+		cp = make([]byte, len(payload))
+		copy(cp, payload)
+	}
 
 	select {
 	case dg.readCh <- cp:
@@ -371,6 +442,17 @@ func (dg *DatagramRouteGroup) IsAlive() bool {
 // diagnostics; not used in the hot path.
 func (dg *DatagramRouteGroup) InboundDropped() uint64 {
 	return atomic.LoadUint64(&dg.inboundDropped)
+}
+
+// AEADAuthFailures returns the count of inbound datagrams dropped
+// due to AEAD authentication failure since group construction.
+// Includes both forged datagrams and replay attempts; intentionally
+// not differentiated to avoid leaking timing signal to an attacker.
+// A rising counter under normal operation indicates either a
+// forgery attempt in progress or a peer-side cipher desync (often
+// a missed rekey).
+func (dg *DatagramRouteGroup) AEADAuthFailures() uint64 {
+	return atomic.LoadUint64(&dg.aeadAuthFailures)
 }
 
 // Compile-time assertion that DatagramRouteGroup satisfies the

--- a/pkg/router/datagram_route_group_test.go
+++ b/pkg/router/datagram_route_group_test.go
@@ -215,3 +215,81 @@ func TestDatagramRouteGroupSatisfiesPacketConn(t *testing.T) {
 	var _ net.PacketConn = dg
 	var _ Group = dg
 }
+
+func TestDatagramRouteGroupWithCiphersRoundTrip(t *testing.T) {
+	// End-to-end test for the Stage 3 integration: install ciphers,
+	// craft a "sealed" inbound datagram with the correct counter +
+	// AEAD wrapping (matching what a peer would have sent), feed
+	// through Handle, and assert the plaintext lands on ReadFrom.
+	//
+	// Doesn't go through a real router/transport — that's Stage 4's
+	// scope. The point here is to prove the seal/open plumbing on
+	// DatagramRouteGroup is wired correctly.
+
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	// Build a pair of ciphers — peer-side (sealer) and local-side
+	// (opener). Same master + bindPK; the bindPK is the local end's
+	// PK since Open will look it up in AAD.
+	out, in, _, _ := newTestPair(t, nil)
+	dg.SetCiphers(out, in)
+
+	// MaxPayload must now reflect the AEAD overhead.
+	assert.Equal(t, MaxDatagramPlaintext, dg.MaxPayload(),
+		"with cipher installed, MaxPayload should subtract AEAD overhead")
+
+	// Simulate an inbound datagram: peer sealed plaintext over
+	// route 1 with the matching out-cipher. We replay the seal here
+	// because the bindPK in our test ciphers happens to be the
+	// same; in production the peer's outbound matches our inbound
+	// via the role pairing in newTestPair.
+	plaintext := []byte("inbound-datagram-via-cipher")
+	sealed, err := out.Seal(1, plaintext)
+	require.NoError(t, err)
+
+	pkt, err := routing.MakeDatagramPacket(routing.RouteID(1), sealed)
+	require.NoError(t, err)
+
+	require.NoError(t, dg.Handle(pkt))
+
+	buf := make([]byte, 1500)
+	require.NoError(t, dg.SetReadDeadline(time.Now().Add(time.Second)))
+	n, _, err := dg.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, buf[:n])
+}
+
+func TestDatagramRouteGroupHandleAEADFailureDropsSilently(t *testing.T) {
+	dg := newTestDatagramGroup(t)
+	defer dg.Close() //nolint:errcheck
+
+	out, in, _, _ := newTestPair(t, nil)
+	dg.SetCiphers(out, in)
+
+	// Build a forged "sealed" payload — random bytes of the correct
+	// length. Auth tag will not verify.
+	forged := make([]byte, DatagramOverhead+16)
+	for i := range forged {
+		forged[i] = byte(i)
+	}
+	pkt, err := routing.MakeDatagramPacket(routing.RouteID(1), forged)
+	require.NoError(t, err)
+
+	// Handle must return nil (no error surfaced — leaking the
+	// failure to the sender would expose timing signal). The
+	// AEADAuthFailures counter must increment.
+	require.NoError(t, dg.Handle(pkt))
+	assert.Equal(t, uint64(1), dg.AEADAuthFailures(),
+		"forged datagram should bump aeadAuthFailures")
+
+	// And the readCh must remain empty — the forged datagram must
+	// NOT have been delivered.
+	require.NoError(t, dg.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+	buf := make([]byte, 1500)
+	_, _, err = dg.ReadFrom(buf)
+	require.Error(t, err)
+	var terr net.Error
+	require.ErrorAs(t, err, &terr)
+	assert.True(t, terr.Timeout())
+}


### PR DESCRIPTION
Stage 3 of #2607. Stacked on #2610 (Stage 2: DatagramRouteGroup + Group interface).

> [!NOTE]
> Stacked on #2610 which is stacked on #2609. The full chain merges as 1 → 2 → 3.

## What this adds

Each datagram is independently encrypted, authenticated, and replay-protected — the cipher survives the loss / reorder / HoL-free delivery semantics that faithful-UDP-over-skynet requires. Stream Noise (what `RouteGroup` uses today) won't work here: its continuous keystream desyncs on a lost frame, after which every subsequent decrypt fails.

## Cryptographic shape (per #2607 + Alpha's review)

- **Cipher**: ChaCha20-Poly1305-IETF (RFC 7539). Same primitive Noise uses; reusing keeps the dependency surface flat. 256-bit key, 96-bit nonce, 128-bit Poly1305 tag.
- **Master key**: HKDF-SHA256 from the Noise session master with role-tagged info (`skywire-datagram-v1-init` vs `-resp`).
- **Nonce**: 96 bits = zero-padding(32) || counter(64). 64-bit monotonic per-sender counter; on the wire only the 8-byte counter is transmitted (saves 4 bytes/pkt vs full nonce). Matches WireGuard.
- **AAD**: `routeID(4) || destPK(33)`. Cross-route substitution and cross-receiver replay both blocked.
- **Anti-replay**: RFC 6479 sliding window, 2048-bit. Counter IS the sequence — no redundant `seq` on the wire. Window commit happens **after** AEAD verify (a forged datagram cannot poison the window).
- **Rekey**: time-based (default 2 min) or packet-count-based (default 2^32). Well below the 2^60 ChaCha bound. `NeedsRekey()` is polled; `Rekey(newMaster)` swaps the AEAD epoch atomically.

## Wire format of one sealed datagram body

```
[counter (8 bytes BE uint64)] [ciphertext + 16-byte Poly1305 tag]
```

`MaxDatagramPlaintext = 65511` (MaxDatagramPayload - DatagramOverhead). `DatagramRouteGroup.MaxPayload()` now reflects this when a cipher is installed.

## Integration

`DatagramRouteGroup.SetCiphers(out, in)` installs the per-direction ciphers. `WriteTo` seals before `MakeDatagramPacket`; `Handle` opens after unwrap. **Auth failures drop silently** (returning to the sender leaks timing signal) but bump `AEADAuthFailures()` for operator diagnostics — a rising counter indicates either a forgery attempt in progress or a peer-side cipher desync.

Bypass mode (nil ciphers) is retained for Stage 2 unit tests; **production paths in Stage 4 will require non-nil ciphers** before any traffic flows.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/router/` — all green (13 new crypto tests + 2 new integration tests + Stage 2's 12 + existing suite)
- [x] `go test -race ./pkg/router/` — clean, no data races

Crypto layer tests (13):
- `RoundTrip`, `WrongRouteIDRejected`, `WrongBindPKRejected`, `ReplayRejected`, `OutOfWindowRejected`, `CounterMonotonic`, `ReorderedDeliveryAccepted`, `CounterExhaustedTriggersRekey`, `NeedsRekeyOnTime`, `RekeyResetsState`, `ShortCiphertextRejected`, `PlaintextTooLongRejected`, `ConcurrentSealOpenSafe`

Integration tests (2 new on top of Stage 2):
- `WithCiphersRoundTrip` — install ciphers, assert `MaxPayload` reflects AEAD overhead, round-trip a sealed packet
- `HandleAEADFailureDropsSilently` — forged sealed payload bumps `AEADAuthFailures` and does NOT deliver to `ReadFrom`; no error surfaced

## Coordination

- Stage 1 (#2609) and Stage 2 (#2610) are the prerequisite stack.
- Stage 4 will wire `forwarded_ports.udp` — uses `SetCiphers` to install ciphers from the Noise handshake.
- Stage 5 — app API.

@ersonp — the crypto stage was held softly for your eyes per Alpha's review of the RFC. If you have feedback, fire away. Otherwise the choices are: ChaCha20-Poly1305-IETF cipher, HKDF-SHA256 key derivation, 64-bit counter on-wire, AAD = routeID||destPK, 2048-bit sliding-window anti-replay, rekey on time-or-packet-count.

Closes part of #2607.