### PR TITLE
chore(skyudp-bridge): fix misspell-lint hits from #2611

### DIFF
--- a/cmd/sub/commands/sub.go
+++ b/cmd/sub/commands/sub.go
@@ -7,7 +7,7 @@
 //
 // Two subcommands:
 //
-//	sub client   — local UDP listener → peer-dialled dmsg stream
+//	sub client   — local UDP listener → peer-dialed dmsg stream
 //	sub server   — accept dmsg streams → forward as UDP to target
 //
 // Plan B for UDP-over-skynet (TCP-over-UDP, reliable + in-order).

--- a/pkg/skyudpbridge/skyudpbridge.go
+++ b/pkg/skyudpbridge/skyudpbridge.go
@@ -110,7 +110,7 @@ type ServerConfig struct {
 }
 
 // RunClient starts the client-side bridge: UDP listener →
-// per-source stream → framer. Blocks until ctx is cancelled or the
+// per-source stream → framer. Blocks until ctx is canceled or the
 // underlying listener fails. The Dialer is invoked lazily on the
 // first datagram from each new source.
 func RunClient(ctx context.Context, cfg ClientConfig, dialer Dialer, log logrus.FieldLogger) error {
@@ -166,7 +166,7 @@ func RunClient(ctx context.Context, cfg ClientConfig, dialer Dialer, log logrus.
 
 // RunServer starts the server-side bridge: accept skywire streams,
 // read framed datagrams, forward via UDP. Blocks until ctx is
-// cancelled or the listener fails. accept is the inbound-stream
+// canceled or the listener fails. accept is the inbound-stream
 // accept function — provided by the caller because dmsg and
 // skywire-routing have different listen primitives.
 func RunServer(ctx context.Context, cfg ServerConfig, accept func() (net.Conn, error), log logrus.FieldLogger) error {

--- a/pkg/skyudpbridge/skyudpbridge_test.go
+++ b/pkg/skyudpbridge/skyudpbridge_test.go
@@ -131,7 +131,7 @@ func TestClientFramesDatagramsOntoStream(t *testing.T) {
 
 	payload := []byte("hello-skyudp")
 
-	// Resend until the client side has bound + dialled the pipe.
+	// Resend until the client side has bound + dialed the pipe.
 	// RunClient opens the UDP socket asynchronously, so the first
 	// few datagrams may be dropped before the listener is up.
 	var peerConn net.Conn


### PR DESCRIPTION
#2611 was admin-merged with misspell-lint CI failures still on linux/darwin/windows. Four trivial cleanups so develop's lint stays green for in-flight PRs that would otherwise inherit the failures.

- `dialled → dialed` in cmd/sub/commands/sub.go, pkg/skyudpbridge/skyudpbridge_test.go
- `cancelled → canceled` in pkg/skyudpbridge/skyudpbridge.go (×2 sites)

`make lint` 0 issues locally. `go build ./...` clean.