### PR TITLE
fix(skychat): auto-reconnect pairRPC client on shutdown error

### DIFF
--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -35,7 +35,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -44,7 +43,6 @@ import (
 
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor"
 )
 
@@ -142,21 +140,18 @@ func notifyInviteSSE(peerPK cipher.PubKey, kind string) {
 }
 
 // connectPairRPC dials the local visor's RPC and stores the client
-// in pairRPC. Best-effort — a failure logs and disables pairing for
-// this run rather than failing skychat startup.
+// in pairRPC. Best-effort — a failure logs and continues without
+// the pair RPC; the watchdog (startPairRPCWatchdog) will retry the
+// dial periodically. All actual mutation of pairRPC goes through
+// connectPairRPCLocked so the package-level pointer is guarded by
+// pairRPCMu.
 func connectPairRPC() {
 	if !pairEnable {
 		return
 	}
-	const dialTimeout = 5 * time.Second
-	conn, err := net.DialTimeout("tcp", pairRPCAddr, dialTimeout)
-	if err != nil {
-		appLog("Pairing: visor RPC dial %s failed: %v — pairing disabled", pairRPCAddr, err)
-		return
+	if connectPairRPCLocked("startup") == nil {
+		appLog("Pairing: initial visor RPC dial failed — watchdog will retry")
 	}
-	log := logging.MustGetLogger(fmt.Sprintf("skychat-pair-rpc://%s", pairRPCAddr))
-	pairRPC = visor.NewRPCClient(log, conn, visor.RPCPrefix, 30*time.Second)
-	appLog("Pairing: connected to visor RPC at %s", pairRPCAddr)
 }
 
 // startPairPoller bridges visor.PairPoll into the existing SSE
@@ -169,7 +164,7 @@ func connectPairRPC() {
 // inbox already protects against unbounded growth of buffered
 // messages.
 func startPairPoller(parent context.Context) {
-	if !pairEnable || pairRPC == nil {
+	if !pairEnable {
 		return
 	}
 	ctx, cancel := context.WithCancel(parent) //nolint:gosec
@@ -185,9 +180,16 @@ func startPairPoller(parent context.Context) {
 				return
 			case <-ticker.C:
 			}
-			msgs, err := pairRPC.PairPoll(since)
+			var msgs []visor.PairMessage
+			err := pairRPCCall("PairPoll", func(c visor.API) error {
+				out, e := c.PairPoll(since)
+				msgs = out
+				return e
+			})
 			if err != nil {
-				appLog("Pairing: PairPoll error: %v", err)
+				if !errors.Is(err, errPairRPCUnavailable) {
+					appLog("Pairing: PairPoll error: %v", err)
+				}
 				continue
 			}
 			for _, m := range msgs {
@@ -241,7 +243,7 @@ func registerPairHTTPHandlers(ctx context.Context, mux *http.ServeMux) {
 // invites.
 func pairInvitesListHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if pairRPC == nil {
+		if !pairRPCAlive() {
 			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
 			return
 		}
@@ -258,7 +260,7 @@ func pairInvitesListHandler() http.HandlerFunc {
 // POST /pair/invites/<pk>/decline.
 func pairInvitesItemHandler(ctx context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if pairRPC == nil {
+		if !pairRPCAlive() {
 			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
 			return
 		}
@@ -288,14 +290,14 @@ func pairInvitesItemHandler(ctx context.Context) http.HandlerFunc {
 			// Create the local pair (status starts at pending; the
 			// initiator's PairMarkActive on receiving our ack will
 			// flip them, but on this side we'd want active too).
-			if err := pairRPC.PairAdd(peer); err != nil {
+			if err := pairRPCCall("PairAdd", func(c visor.API) error { return c.PairAdd(peer) }); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 			// Mark our own side active immediately — the user
 			// just consented, so there's no further confirmation
 			// needed.
-			if err := pairRPC.PairMarkActive(peer); err != nil {
+			if err := pairRPCCall("PairMarkActive", func(c visor.API) error { return c.PairMarkActive(peer) }); err != nil {
 				appLog("Pairing: PairMarkActive after accept failed: %v", err)
 			}
 			pendingDelete(peer)
@@ -323,13 +325,18 @@ func pairInvitesItemHandler(ctx context.Context) http.HandlerFunc {
 // pairRootHandler serves POST /pair (add) and GET /pair (list).
 func pairRootHandler(ctx context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if pairRPC == nil {
+		if !pairRPCAlive() {
 			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
 			return
 		}
 		switch r.Method {
 		case http.MethodGet:
-			pairs, err := pairRPC.PairList()
+			var pairs []visor.PairInfo
+			err := pairRPCCall("PairList", func(c visor.API) error {
+				out, e := c.PairList()
+				pairs = out
+				return e
+			})
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -350,7 +357,7 @@ func pairRootHandler(ctx context.Context) http.HandlerFunc {
 				http.Error(w, "invalid peer_pk: "+err.Error(), http.StatusBadRequest)
 				return
 			}
-			if err := pairRPC.PairAdd(peer); err != nil {
+			if err := pairRPCCall("PairAdd", func(c visor.API) error { return c.PairAdd(peer) }); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -372,7 +379,7 @@ func pairRootHandler(ctx context.Context) http.HandlerFunc {
 // pairItemHandler serves DELETE /pair/{pk} and POST /pair/{pk}/message.
 func pairItemHandler(ctx context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if pairRPC == nil {
+		if !pairRPCAlive() {
 			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
 			return
 		}
@@ -393,7 +400,7 @@ func pairItemHandler(ctx context.Context) http.HandlerFunc {
 
 		switch {
 		case len(segments) == 1 && r.Method == http.MethodDelete:
-			if err := pairRPC.PairRemove(peer); err != nil {
+			if err := pairRPCCall("PairRemove", func(c visor.API) error { return c.PairRemove(peer) }); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -407,7 +414,7 @@ func pairItemHandler(ctx context.Context) http.HandlerFunc {
 				http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
 				return
 			}
-			if err := pairRPC.PairSend(peer, body.Text); err != nil {
+			if err := pairRPCCall("PairSend", func(c visor.API) error { return c.PairSend(peer, body.Text) }); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -427,7 +434,7 @@ func pairItemHandler(ctx context.Context) http.HandlerFunc {
 // malformed JSON, in which case handleConn falls through to the
 // legacy text path.
 func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byte) bool {
-	if !pairEnable || pairRPC == nil {
+	if !pairEnable || !pairRPCAlive() {
 		return false
 	}
 	// Quick reject: pair envelopes are objects, so a non-`{` first
@@ -458,7 +465,7 @@ func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byt
 		// pending pair record to active so the UI shows it as
 		// confirmed.
 		appLog("Pairing: pair-ack from %s — peer accepted", peerPK.Hex())
-		if err := pairRPC.PairMarkActive(peerPK); err != nil {
+		if err := pairRPCCall("PairMarkActive", func(c visor.API) error { return c.PairMarkActive(peerPK) }); err != nil {
 			appLog("Pairing: PairMarkActive after ack failed: %v", err)
 		}
 		notifyInviteSSE(peerPK, "accepted")
@@ -468,7 +475,7 @@ func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byt
 		// Initiator side: the peer declined our invite. Drop the
 		// pending pair record so it doesn't sit in pending forever.
 		appLog("Pairing: pair-decline from %s — peer declined", peerPK.Hex())
-		if err := pairRPC.PairRemove(peerPK); err != nil {
+		if err := pairRPCCall("PairRemove", func(c visor.API) error { return c.PairRemove(peerPK) }); err != nil {
 			appLog("Pairing: PairRemove after decline failed: %v", err)
 		}
 		notifyInviteSSE(peerPK, "declined")

--- a/cmd/apps/skychat/commands/pairing_rpc.go
+++ b/cmd/apps/skychat/commands/pairing_rpc.go
@@ -1,0 +1,211 @@
+// Package commands cmd/apps/skychat/commands/pairing_rpc.go
+//
+// Auto-reconnect wrapper for the visor RPC client used by the pairing
+// subsystem (and group-feed introspection).
+//
+// Background: the chat-app holds a single net/rpc client to the local
+// visor (see connectPairRPC). pkg/visor.(*rpcClient).Call closes the
+// underlying connection on a single timeout — after which every
+// subsequent call returns rpc.ErrShutdown forever. Without the
+// machinery here, that one transient timeout permanently breaks all
+// pair + group operations until the chat-app is restarted.
+//
+// This file adds:
+//   - a mutex guarding the package-level pairRPC pointer
+//   - a redial path that swaps a fresh client in on shutdown
+//   - pairRPCCall, a retry-once-on-shutdown helper used by every call
+//     site so each operation self-heals
+//   - a background watchdog goroutine that periodically pings the RPC
+//     so a long-idle channel doesn't surprise the next operator-facing
+//     call with the reconnect cost.
+
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// pairRPCMu guards pairRPC. All reads/writes of the package-level
+// pairRPC pointer must go through the accessors below.
+var pairRPCMu sync.RWMutex
+
+// pairRPCWatchdogCancel stops the background health-check goroutine.
+var pairRPCWatchdogCancel context.CancelFunc
+
+// errPairRPCUnavailable is returned when no usable client exists —
+// either pairing is disabled or both the initial dial and an in-line
+// redial attempt failed.
+var errPairRPCUnavailable = errors.New("pair-rpc unavailable")
+
+// pairRPCGet returns the current client (may be nil).
+func pairRPCGet() visor.API {
+	pairRPCMu.RLock()
+	defer pairRPCMu.RUnlock()
+	return pairRPC
+}
+
+// pairRPCAlive reports whether a non-nil client is currently set.
+// Mirrors the legacy `if pairRPC == nil` nil-checks but under the
+// mutex.
+func pairRPCAlive() bool { return pairRPCGet() != nil }
+
+// connectPairRPCLocked dials a fresh client and swaps it in under the
+// write lock. Idempotent: any previous client is closed first so the
+// old TCP connection doesn't linger. Safe to call from any goroutine.
+//
+// Returns the new client (may be nil if dialing fails or pairing is
+// disabled). Callers can use the return value to retry immediately
+// without re-reading the global.
+func connectPairRPCLocked(reason string) visor.API {
+	if !pairEnable {
+		return nil
+	}
+	pairRPCMu.Lock()
+	defer pairRPCMu.Unlock()
+
+	// Close any previous client so the old conn doesn't linger.
+	if old := pairRPC; old != nil {
+		if c, ok := old.(io.Closer); ok {
+			_ = c.Close() //nolint:errcheck
+		}
+		pairRPC = nil
+	}
+
+	const dialTimeout = 5 * time.Second
+	conn, err := net.DialTimeout("tcp", pairRPCAddr, dialTimeout)
+	if err != nil {
+		appLog("Pairing: visor RPC redial %s failed (%s): %v", pairRPCAddr, reason, err)
+		return nil
+	}
+	log := logging.MustGetLogger(fmt.Sprintf("skychat-pair-rpc://%s", pairRPCAddr))
+	pairRPC = visor.NewRPCClient(log, conn, visor.RPCPrefix, 30*time.Second)
+	appLog("Pairing: connected to visor RPC at %s (%s)", pairRPCAddr, reason)
+	return pairRPC
+}
+
+// isRPCShutdown reports whether err indicates the RPC client's
+// underlying connection has been closed and will not recover on its
+// own. Covers the canonical rpc.ErrShutdown and the string variant
+// callers see when net.OpError or context.DeadlineExceeded surfaces
+// via pkg/visor.(*rpcClient).Call.
+func isRPCShutdown(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, rpc.ErrShutdown) {
+		return true
+	}
+	// pkg/visor.(*rpcClient).Call closes the conn on context-deadline
+	// (Call returns ctx.Err() in that case). The follow-up call then
+	// surfaces a generic "connection is shut down" or "use of closed
+	// network connection" — both are recovery-by-redial situations.
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "connection is shut down"):
+		return true
+	case strings.Contains(s, "use of closed network connection"):
+		return true
+	case errors.Is(err, context.DeadlineExceeded):
+		// Treat as shutdown: rpcClient.Call has already closed the
+		// conn for us, so the next call would shutdown-error anyway.
+		return true
+	}
+	return false
+}
+
+// pairRPCCall runs fn against the current pairRPC client with
+// reconnect-on-shutdown semantics. If fn returns an error indicating
+// the client is dead, the helper redials once and retries. Returns
+// errPairRPCUnavailable when there is no usable client.
+//
+// The op string is only used for log lines, e.g. "GroupList",
+// "PairAdd". Keep it short.
+func pairRPCCall(op string, fn func(visor.API) error) error {
+	return pairRPCDo(op, pairRPCGet, connectPairRPCLocked, fn)
+}
+
+// pairRPCDo is the inner retry loop. Production callers should use
+// pairRPCCall; this form takes injectable get/redial functions so
+// the retry-on-shutdown behavior can be unit-tested without a real
+// visor RPC server.
+func pairRPCDo(op string,
+	get func() visor.API,
+	redial func(reason string) visor.API,
+	fn func(visor.API) error) error {
+	cli := get()
+	if cli == nil {
+		return errPairRPCUnavailable
+	}
+	err := fn(cli)
+	if err == nil || !isRPCShutdown(err) {
+		return err
+	}
+	appLog("Pairing: %s hit RPC shutdown (%v) — reconnecting", op, err)
+	cli = redial("retry-after-shutdown:" + op)
+	if cli == nil {
+		return errPairRPCUnavailable
+	}
+	return fn(cli)
+}
+
+// startPairRPCWatchdog runs a background loop that periodically
+// verifies the RPC client is alive. On detection of a shut-down
+// connection it redials so the next operator-facing call doesn't
+// have to pay the reconnect cost.
+//
+// The probe is intentionally lightweight: a Health() call. If the
+// visor's API ever loses Health, swap it for another no-arg method.
+//
+// No-op when pairing is disabled.
+func startPairRPCWatchdog(parent context.Context) {
+	if !pairEnable {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent) //nolint:gosec
+	pairRPCWatchdogCancel = cancel
+
+	go func() {
+		// Pick an interval shorter than typical idle-timeout values so
+		// a stale conn is detected before the user notices. 60s is a
+		// reasonable balance against churn for an always-on visor.
+		const probeInterval = 60 * time.Second
+		ticker := time.NewTicker(probeInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			cli := pairRPCGet()
+			if cli == nil {
+				// Try to come up from cold — the original dial may
+				// have failed during startup and never been retried.
+				connectPairRPCLocked("watchdog:cold-start")
+				continue
+			}
+			if _, err := cli.Health(); err != nil && isRPCShutdown(err) {
+				connectPairRPCLocked("watchdog:shutdown-detected")
+			}
+		}
+	}()
+}
+
+// stopPairRPCWatchdog cancels the watchdog goroutine. Idempotent.
+func stopPairRPCWatchdog() {
+	if pairRPCWatchdogCancel != nil {
+		pairRPCWatchdogCancel()
+		pairRPCWatchdogCancel = nil
+	}
+}

--- a/cmd/apps/skychat/commands/pairing_rpc_test.go
+++ b/cmd/apps/skychat/commands/pairing_rpc_test.go
@@ -1,0 +1,198 @@
+// Package commands cmd/apps/skychat/commands/pairing_rpc_test.go
+//
+// Unit tests for the retry-on-shutdown helper. The watchdog and dial
+// paths are integration-shaped (need a real TCP listener + visor RPC
+// server) and are exercised by the e2e tests; this file focuses on
+// the pure error-classification + retry-control logic.
+
+package commands
+
+import (
+	"context"
+	"errors"
+	"net/rpc"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+func init() {
+	// pairRPCDo logs the reconnect transition through appLog, which is
+	// nil until RunSkychat wires it up. Install a no-op so the tests
+	// can drive the retry path without RunSkychat.
+	if appLog == nil {
+		appLog = func(string, ...interface{}) {}
+	}
+}
+
+func TestIsRPCShutdown(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("boom"), false},
+		{"rpc.ErrShutdown direct", rpc.ErrShutdown, true},
+		{"rpc.ErrShutdown wrapped", &wrapErr{rpc.ErrShutdown}, true},
+		{"string form", errors.New("connection is shut down"), true},
+		{"closed conn", errors.New("use of closed network connection"), true},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"non-shutdown timeout", errors.New("i/o timeout"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isRPCShutdown(c.err); got != c.want {
+				t.Fatalf("isRPCShutdown(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// wrapErr is a minimal error wrapper that forwards Unwrap so
+// errors.Is can traverse to the inner sentinel.
+type wrapErr struct{ inner error }
+
+func (w *wrapErr) Error() string { return "wrap: " + w.inner.Error() }
+func (w *wrapErr) Unwrap() error { return w.inner }
+
+// sentinelAPI implements visor.API trivially (via nil embedding) and
+// carries an identifier so the retry test can verify whether fn was
+// called with the original or the post-redial client. Any method
+// invoked through the embedded nil interface will panic — the tests
+// here intentionally don't call any visor API method, only inspect
+// the *sentinelAPI pointer identity.
+type sentinelAPI struct {
+	visorAPIShim
+	id int
+}
+
+// visorAPIShim is a typed shim so embedding it satisfies visor.API.
+// The methods aren't called in tests; the type only exists so
+// sentinelAPI compiles.
+type visorAPIShim struct{ visor.API }
+
+func TestPairRPCDoRetryOnShutdown(t *testing.T) {
+	t.Run("no client returns unavailable", func(t *testing.T) {
+		err := pairRPCDo("Op",
+			func() visor.API { return nil },
+			func(string) visor.API { return nil },
+			func(visor.API) error { t.Fatal("fn must not be called"); return nil },
+		)
+		if !errors.Is(err, errPairRPCUnavailable) {
+			t.Fatalf("want errPairRPCUnavailable, got %v", err)
+		}
+	})
+
+	t.Run("success on first call: no redial", func(t *testing.T) {
+		first := &sentinelAPI{id: 1}
+		calls := 0
+		redials := 0
+		err := pairRPCDo("Op",
+			func() visor.API { return first },
+			func(string) visor.API { redials++; return &sentinelAPI{id: 2} },
+			func(c visor.API) error {
+				calls++
+				if c != first {
+					t.Fatalf("call %d: unexpected client", calls)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if calls != 1 || redials != 0 {
+			t.Fatalf("calls=%d redials=%d, want 1/0", calls, redials)
+		}
+	})
+
+	t.Run("non-shutdown error returns immediately", func(t *testing.T) {
+		first := &sentinelAPI{id: 1}
+		boom := errors.New("transport refused")
+		calls := 0
+		redials := 0
+		err := pairRPCDo("Op",
+			func() visor.API { return first },
+			func(string) visor.API { redials++; return &sentinelAPI{id: 2} },
+			func(visor.API) error { calls++; return boom },
+		)
+		if !errors.Is(err, boom) {
+			t.Fatalf("want boom, got %v", err)
+		}
+		if calls != 1 || redials != 0 {
+			t.Fatalf("calls=%d redials=%d, want 1/0", calls, redials)
+		}
+	})
+
+	t.Run("shutdown triggers exactly one redial+retry", func(t *testing.T) {
+		first := &sentinelAPI{id: 1}
+		second := &sentinelAPI{id: 2}
+		calls := 0
+		redials := 0
+		err := pairRPCDo("Op",
+			func() visor.API { return first },
+			func(string) visor.API { redials++; return second },
+			func(c visor.API) error {
+				calls++
+				switch calls {
+				case 1:
+					if c != first {
+						t.Fatalf("call 1: want first client")
+					}
+					return rpc.ErrShutdown
+				case 2:
+					if c != second {
+						t.Fatalf("call 2: want second client")
+					}
+					return nil
+				default:
+					t.Fatalf("unexpected call %d", calls)
+					return nil
+				}
+			},
+		)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if calls != 2 || redials != 1 {
+			t.Fatalf("calls=%d redials=%d, want 2/1", calls, redials)
+		}
+	})
+
+	t.Run("redial fails: surface unavailable", func(t *testing.T) {
+		first := &sentinelAPI{id: 1}
+		calls := 0
+		redials := 0
+		err := pairRPCDo("Op",
+			func() visor.API { return first },
+			func(string) visor.API { redials++; return nil },
+			func(visor.API) error { calls++; return rpc.ErrShutdown },
+		)
+		if !errors.Is(err, errPairRPCUnavailable) {
+			t.Fatalf("want errPairRPCUnavailable, got %v", err)
+		}
+		if calls != 1 || redials != 1 {
+			t.Fatalf("calls=%d redials=%d, want 1/1", calls, redials)
+		}
+	})
+
+	t.Run("second call also shutdown: surface that err", func(t *testing.T) {
+		first := &sentinelAPI{id: 1}
+		second := &sentinelAPI{id: 2}
+		calls := 0
+		redials := 0
+		err := pairRPCDo("Op",
+			func() visor.API { return first },
+			func(string) visor.API { redials++; return second },
+			func(visor.API) error { calls++; return rpc.ErrShutdown },
+		)
+		if !errors.Is(err, rpc.ErrShutdown) {
+			t.Fatalf("want rpc.ErrShutdown, got %v", err)
+		}
+		// No second retry — only one redial per call.
+		if calls != 2 || redials != 1 {
+			t.Fatalf("calls=%d redials=%d, want 2/1", calls, redials)
+		}
+	})
+}

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -37,6 +37,7 @@ import (
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor"
 )
 
 var r = netutil.NewRetrier(nil, 50*time.Millisecond, netutil.DefaultMaxBackoff, 5, 2)
@@ -613,6 +614,8 @@ func RunSkychat(ctx context.Context, args []string) error {
 	}
 
 	connectPairRPC()
+	startPairRPCWatchdog(ctx)
+	defer stopPairRPCWatchdog()
 	startPairPoller(ctx)
 	defer stopPairPoller()
 
@@ -1486,10 +1489,15 @@ type groupHealth struct {
 //     means group support is disabled in the visor config, OR the
 //     RPC client has a transient connection issue).
 func collectGroupHealth() ([]groupHealth, string) {
-	if pairRPC == nil {
+	if !pairRPCAlive() {
 		return []groupHealth{}, "pair-rpc-disabled"
 	}
-	infos, err := pairRPC.GroupList()
+	var infos []visor.GroupInfo
+	err := pairRPCCall("GroupList", func(c visor.API) error {
+		out, e := c.GroupList()
+		infos = out
+		return e
+	})
 	if err != nil {
 		appCl.Log().Debugf("status: GroupList RPC failed: %v", err)
 		// Truncate the err so a long upstream chain doesn't bloat


### PR DESCRIPTION
## Summary

The chat-app holds a single `net/rpc` client to the local visor in the package-level `pairRPC` variable. `pkg/visor.(*rpcClient).Call` closes the underlying conn on any context-deadline timeout — after which every subsequent call returns `rpc.ErrShutdown` forever.

In production this surfaces as `\"groups_error\": \"rpc-error: connection is shut down\"` in skychat's `/status` output after ~15 hours of uptime; group ops + the 1:1 pair-poll bridge silently break until the app is restarted. Caught in live coordination today — a `skywire cli visor app stop skychat && start skychat` was the only recovery path.

## Fix

- Guard the package-level `pairRPC` pointer with `pairRPCMu` and route all access through `pairRPCGet` / `pairRPCAlive` accessors.
- `connectPairRPCLocked` dials a fresh client and swaps it in under write lock; closes any previous client first so the old conn doesn't linger.
- `pairRPCCall(op, fn)` is a retry-once-on-shutdown helper used at every call site. `isRPCShutdown` matches `rpc.ErrShutdown`, the string variants (\"connection is shut down\", \"use of closed network connection\") and `context.DeadlineExceeded`.
- `startPairRPCWatchdog` runs a 60s health-probe loop (`Health()`) so a long-idle channel is detected before the next operator call has to pay the reconnect cost.
- Every existing `pairRPC.Foo(...)` call site is converted; the legacy `if pairRPC == nil` nil-checks become `pairRPCAlive()` under the mutex.

The retry mechanics live in `pairRPCDo` (inner form with injectable get/redial functions) so the behavior is unit-tested without standing up a real visor RPC server.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/apps/skychat/...` — six new sub-cases in `TestIsRPCShutdown` + six in `TestPairRPCDoRetryOnShutdown` cover all branches
- [x] `golangci-lint run ./cmd/apps/skychat/commands/...` — 0 issues
- [ ] Deploy on the prod host, observe `/status` no longer shows `groups_error` after a forced RPC timeout, watchdog log line `Pairing: connected to visor RPC at ... (watchdog:shutdown-detected)` appears