### PR TITLE
chore: cleanup lint issues from UDP-stack admin-merge

### DIFF
--- a/pkg/app/appnet/packet.go
+++ b/pkg/app/appnet/packet.go
@@ -77,7 +77,7 @@ type DatagramPacketConn interface {
 // datagrams stay valid — callers get ErrPacketNetworkerNotSupported
 // when they hit one of those.
 type PacketNetworker interface {
-	// DialPacketContext opens a datagram conn to addr. Cancelling
+	// DialPacketContext opens a datagram conn to addr. Canceling
 	// ctx during the dial returns ctx.Err. The returned conn is
 	// safe for concurrent use by multiple goroutines.
 	DialPacketContext(ctx context.Context, addr Addr) (DatagramPacketConn, error)

--- a/pkg/router/datagram_crypto.go
+++ b/pkg/router/datagram_crypto.go
@@ -432,7 +432,7 @@ func shiftLeft(w *[replayWindowWords]uint64, n uint) {
 	bitShift := n % 64
 	if wordShift > 0 {
 		for i := 0; i < replayWindowWords; i++ {
-			src := i + int(wordShift)
+			src := i + int(wordShift) //nolint:gosec // wordShift bounded by replayWindowWords (32) which fits in int
 			if src < replayWindowWords {
 				w[i] = w[src]
 			} else {

--- a/pkg/visor/forwarded_ports.go
+++ b/pkg/visor/forwarded_ports.go
@@ -38,7 +38,7 @@ type ForwardedPort struct {
 	// reorder, per-datagram AEAD. For DNS / NTP / VoIP / gaming —
 	// anything where a late packet is worse than a lost one.
 	//
-	// Stage 4 of #2607: this field is recognised by the visor's
+	// Stage 4 of #2607: this field is recognized by the visor's
 	// forwarded-port listener loop, which binds a local UDP socket
 	// at EffectiveLocalPort() and pumps datagrams to/from the
 	// peer-side DatagramRouteGroup. The route-setup machinery that

--- a/pkg/visor/udp_bridge.go
+++ b/pkg/visor/udp_bridge.go
@@ -49,7 +49,7 @@ import (
 // closes both conns. Closing either end externally also stops the
 // bridge cleanly — ReadFrom on a closed conn surfaces an error,
 // the corresponding pump goroutine exits, and the second pump is
-// cancelled via the bridge's context.
+// canceled via the bridge's context.
 type UDPBridge struct {
 	local  net.PacketConn // typically *net.UDPConn
 	skynet net.PacketConn // typically *router.DatagramRouteGroup
@@ -102,7 +102,7 @@ func NewUDPBridge(local, skynet net.PacketConn, cfg UDPBridgeConfig) *UDPBridge 
 	if cfg.Logger == nil {
 		cfg.Logger = logging.MustGetLogger("udp-bridge")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118 false positive: cancel stored on struct + invoked in Close()
 	return &UDPBridge{
 		local:      local,
 		skynet:     skynet,

--- a/pkg/visor/udp_bridge_test.go
+++ b/pkg/visor/udp_bridge_test.go
@@ -36,8 +36,6 @@ type pipePacketConn struct {
 
 	localAddr  net.Addr
 	remoteAddr net.Addr
-
-	readDeadline time.Time
 }
 
 func newPipePacketConnPair() (a, b *pipePacketConn) {


### PR DESCRIPTION
Six lint hits from #2610/#2612/#2613/#2614 admin-merges (which skipped CI to keep the stack moving). Started blocking subsequent PRs' CI (Beta's #2617 just hit them). `make lint` 0 issues after this.