### PR TITLE
fix(skychat/group): legacy s.sub liveness coverage in detectStaleAndReconnect

### DIFF
--- a/cmd/apps/skychat/group/legacy_sub_liveness_test.go
+++ b/cmd/apps/skychat/group/legacy_sub_liveness_test.go
@@ -1,0 +1,110 @@
+// Package group — cmd/apps/skychat/group/legacy_sub_liveness_test.go:
+// targeted coverage for the legacy s.sub liveness accessor +
+// reconnect wrapper added to extend the per-peerSub liveness machinery
+// (#2606) to cover the D1 owner-feed subscriber. The full reconnect
+// wiring rides Session.Open / treestore CXO infra and is exercised by
+// the manual E2E plan; this file pins the accessor contracts the
+// stale-check branch in detectStaleAndReconnect now depends on.
+package group
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+)
+
+// nonNilSubSentinel returns a *treestore.Subscriber whose only
+// purpose is to satisfy s.sub != nil for HasLegacySub /
+// LegacySubLastInbound. Never call Connect on the returned value —
+// the zero-value Subscriber has no node attached and will panic.
+func nonNilSubSentinel() *treestore.Subscriber {
+	return &treestore.Subscriber{}
+}
+
+func TestLegacySubLastInboundZeroOnOwnerSession(t *testing.T) {
+	// Owner-role sessions never carry a legacy owner-feed subscriber
+	// (s.sub is nil by construction in openOwner). Accessor must
+	// short-circuit to zero time so the detectStaleAndReconnect
+	// branch never enrolls owner sessions in the legacy-sub stale
+	// loop. HasLegacySub mirrors this so callers can fast-skip
+	// without dereferencing the time.
+	s := &Session{}
+	if !s.LegacySubLastInbound().IsZero() {
+		t.Errorf("owner session: LegacySubLastInbound should be zero, got %v", s.LegacySubLastInbound())
+	}
+	if s.HasLegacySub() {
+		t.Errorf("owner session: HasLegacySub should be false, got true")
+	}
+}
+
+func TestLegacySubLastInboundReturnsStoredTime(t *testing.T) {
+	// On member sessions where s.sub is non-nil and subLastInboundNs
+	// has been bumped (via the makeLegacySubOnUpdate wrapper firing
+	// or via a successful Connect / ReconnectLegacySub), the
+	// accessor must reflect the stored timestamp so the stale-check
+	// branch computes lag correctly. Uses a zero-value Subscriber
+	// sentinel — neither accessor dereferences it, so the lack of
+	// a real CXO node attached is fine.
+	s := &Session{}
+	s.sub = nonNilSubSentinel()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	s.subLastInboundNs.Store(now.UnixNano())
+	got := s.LegacySubLastInbound()
+	if got.IsZero() {
+		t.Fatalf("LegacySubLastInbound returned zero with subLastInboundNs=%d", now.UnixNano())
+	}
+	if !got.Equal(now) {
+		t.Errorf("LegacySubLastInbound got %v want %v", got, now)
+	}
+	if !s.HasLegacySub() {
+		t.Errorf("HasLegacySub: expected true with s.sub set")
+	}
+}
+
+func TestLegacySubLastInboundZeroWhenSubNilEvenIfNsSet(t *testing.T) {
+	// Defensive: if a future refactor leaves subLastInboundNs bumped
+	// after tearing s.sub down (e.g. SetAllowlist drops the legacy
+	// subscriber), the accessor must still report zero — operators
+	// reading IsSubscriberAlive should see "no legacy sub" rather
+	// than a stale-but-non-zero timestamp that maps to "alive".
+	s := &Session{}
+	s.subLastInboundNs.Store(time.Now().UnixNano())
+	if !s.LegacySubLastInbound().IsZero() {
+		t.Errorf("nil-sub session: LegacySubLastInbound should be zero, got %v", s.LegacySubLastInbound())
+	}
+}
+
+func TestReconnectLegacySubNoopOnOwnerSession(t *testing.T) {
+	// Manager.tryReconnectLegacySub is gated by HasLegacySub, but
+	// Session.ReconnectLegacySub also has to be safe for direct
+	// callers that haven't checked. Confirms the no-op + nil-error
+	// contract for the s.sub == nil branch.
+	s := &Session{}
+	if err := s.ReconnectLegacySub(context.Background()); err != nil {
+		t.Errorf("ReconnectLegacySub on owner session: want nil err, got %v", err)
+	}
+	if !s.LegacySubLastInbound().IsZero() {
+		t.Errorf("ReconnectLegacySub on owner session: must not bump subLastInboundNs")
+	}
+}
+
+func TestReconnectLegacySubHonorsCanceledContext(t *testing.T) {
+	// A canceled context must return ctx.Err() without dialing —
+	// mirrors ReconnectPeer's pre-check. We can't exercise the
+	// actual Connect path without CXO infra, but the early-return
+	// branch is deterministic and worth pinning so a refactor
+	// doesn't accidentally drop the ctx.Err() check.
+	s := &Session{}
+	s.sub = nonNilSubSentinel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := s.ReconnectLegacySub(ctx)
+	if err == nil {
+		t.Fatalf("ReconnectLegacySub: want ctx.Err() on canceled context, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("ReconnectLegacySub: want context.Canceled, got %v", err)
+	}
+}

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -710,7 +710,27 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 				stalePeers = append(stalePeers, pk)
 			}
 		}
-		if len(stalePeers) == 0 {
+		// Legacy s.sub staleness check — separate field, separate
+		// liveness signal. Member sessions where openMember attached
+		// the legacy owner-feed subscriber can have every peerSub
+		// alive (so the per-peer loop above produces an empty
+		// stalePeers list) while s.sub is silently wedged. The
+		// per-peerSub liveness map from #2606 doesn't cover s.sub
+		// because it lives outside peerSubs (deferred D4 cleanup),
+		// so without this branch a wedged s.sub stays dead until the
+		// operator does leave + rejoin.
+		legacySubStale := false
+		if sess.HasLegacySub() {
+			last := sess.LegacySubLastInbound()
+			var lag time.Duration
+			if last.IsZero() {
+				lag = subscriberStaleThreshold + time.Second
+			} else {
+				lag = now.Sub(last)
+			}
+			legacySubStale = lag > subscriberStaleThreshold
+		}
+		if len(stalePeers) == 0 && !legacySubStale {
 			continue
 		}
 		// Honor the per-group backoff so a wedged group doesn't
@@ -718,12 +738,20 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 		if !m.reconnectShouldAttempt(r.ID, now) {
 			continue
 		}
-		m.log.WithField("id", r.ID).
-			WithField("stale_peers", len(stalePeers)).
-			WithField("total_peers", len(peers)).
-			WithField("status", string(r.Status)).
-			Debug("group: per-peer stale; kicking per-peer reconnects")
-		m.tryReconnectPeers(ctx, sess, r.ID, stalePeers)
+		if len(stalePeers) > 0 {
+			m.log.WithField("id", r.ID).
+				WithField("stale_peers", len(stalePeers)).
+				WithField("total_peers", len(peers)).
+				WithField("status", string(r.Status)).
+				Debug("group: per-peer stale; kicking per-peer reconnects")
+			m.tryReconnectPeers(ctx, sess, r.ID, stalePeers)
+		}
+		if legacySubStale {
+			m.log.WithField("id", r.ID).
+				WithField("status", string(r.Status)).
+				Debug("group: legacy s.sub stale; kicking owner-feed reconnect")
+			m.tryReconnectLegacySub(ctx, sess, r.ID)
+		}
 	}
 }
 
@@ -813,6 +841,48 @@ func (m *Manager) tryReconnectPeers(ctx context.Context, sess *Session, id strin
 	if lastErr != nil {
 		m.reconnectRecordFailure(id, lastErr)
 	}
+}
+
+// tryReconnectLegacySub runs one ReconnectLegacySub attempt for the
+// session's legacy s.sub owner-feed subscriber. Counterpart to
+// tryReconnectPeers but for the single legacy subscriber that lives
+// outside the peerSubs map (deferred D4 cleanup). No-op on owner
+// sessions and on member sessions where s.sub is nil.
+//
+// On success: clears per-group failure state and promotes Status →
+// StatusActive (same shape as tryReconnect / tryReconnectPeers).
+// Session.ReconnectLegacySub bumps subLastInboundNs internally so the
+// next detectStaleAndReconnect tick correctly sees the session as
+// fresh. On failure: records via reconnectRecordFailure so the
+// per-group backoff engages.
+//
+// Deliberately separate from tryReconnectPeers — they target
+// different subscribers (s.sub vs. peerSubs[ownerPK]) which can
+// independently go stale, and routing through a single helper would
+// blur which one a given log line refers to.
+func (m *Manager) tryReconnectLegacySub(ctx context.Context, sess *Session, id string) {
+	if !sess.HasLegacySub() {
+		return
+	}
+	m.log.WithField("id", id).
+		Debug("group: reconnect: attempting legacy owner-feed subscribe")
+	timeoutCtx, cancel := context.WithTimeout(ctx, reconnectAttemptTimeout)
+	defer cancel()
+	if err := sess.ReconnectLegacySub(timeoutCtx); err != nil {
+		m.log.WithError(err).WithField("id", id).
+			Debug("group: reconnect: legacy owner-feed subscribe failed")
+		m.reconnectRecordFailure(id, err)
+		return
+	}
+	m.reconnectMu.Lock()
+	delete(m.reconnectState, id)
+	m.reconnectMu.Unlock()
+	if sErr := m.store.SetStatus(id, StatusActive); sErr != nil {
+		m.log.WithError(sErr).WithField("id", id).
+			Warn("group: reconnect: SetStatus active failed")
+	}
+	m.log.WithField("id", id).
+		Info("group: reconnect: legacy owner-feed subscribe restored")
 }
 
 // reconnectShouldAttempt returns false when the per-group nextAttempt

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -397,6 +397,23 @@ type Session struct {
 	// same lock that protects peerSubs) — readers grab a snapshot under
 	// RLock and access the *atomic.Int64 entries lock-free.
 	peerLastInboundNs map[cipher.PubKey]*atomic.Int64
+
+	// subLastInboundNs is the per-s.sub liveness signal — the legacy
+	// owner-feed subscriber's counterpart to peerLastInboundNs. Bumped
+	// on every inbound UpdateEvent fanout via the legacy subscriber and
+	// on every successful s.sub.Connect. Member-role only; stays zero
+	// on owner sessions where s.sub is nil.
+	//
+	// Why separate from peerLastInboundNs: s.sub is the D1 single-
+	// subscriber legacy field tracked outside the peerSubs map (its
+	// merge into peerSubs is the deferred D4 cleanup). The per-peerSub
+	// liveness machinery from #2606 only covers peerSubs entries, so
+	// without this signal a wedged s.sub goes silently dead and
+	// detectStaleAndReconnect has nothing to fire on. After a chat-app
+	// or visor restart that doesn't re-run Open, the per-peerSub
+	// reconnects fire for everything in peerSubs but s.sub stays in
+	// whatever attached/dead state it landed in.
+	subLastInboundNs atomic.Int64
 }
 
 // subscriberStaleThreshold is defined in manager.go (it's used by
@@ -730,7 +747,7 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 	if !cfg.Record.LastMessageAt.IsZero() {
 		s.lastInboundNs.Store(cfg.Record.LastMessageAt.UnixNano())
 	}
-	sub.OnUpdate(s.onUpdate)
+	sub.OnUpdate(s.makeLegacySubOnUpdate())
 	return s, nil
 }
 
@@ -777,6 +794,12 @@ func (s *Session) Connect(ctx context.Context) error {
 				return fmt.Errorf("group: Connect: %w", err)
 			}
 		}
+		// Bump per-s.sub liveness: a successful Connect is positive
+		// evidence the legacy owner-feed subscriber is attached, even
+		// before the first inbound leaf arrives. Lets the staleness
+		// window for s.sub start ticking from here, mirroring the
+		// per-peerSub Connect-bump behaviour below.
+		s.subLastInboundNs.Store(time.Now().UnixNano())
 	}
 	// D1 per-PK peer subscribers. Best-effort: if a single peer's
 	// publisher isn't reachable yet (e.g. they restarted), that one
@@ -874,6 +897,39 @@ func (s *Session) LastInbound() time.Time {
 		return time.Time{}
 	}
 	return time.Unix(0, ns).UTC()
+}
+
+// LegacySubLastInbound returns the time the legacy s.sub owner-feed
+// subscriber most recently observed an inbound CXO event (or a
+// successful Connect). Zero time on owner sessions (s.sub is nil),
+// freshly-opened member sessions that haven't yet had their first
+// Connect succeed, and torn-down sessions.
+//
+// Used by Manager.detectStaleAndReconnect to spot a wedged owner-feed
+// subscriber independently of the per-peerSub liveness map (#2606).
+// s.sub lives outside that map by design (deferred D4 cleanup), so it
+// needs its own staleness signal.
+func (s *Session) LegacySubLastInbound() time.Time {
+	if s.sub == nil {
+		return time.Time{}
+	}
+	ns := s.subLastInboundNs.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns).UTC()
+}
+
+// HasLegacySub reports whether this session carries an attached
+// legacy s.sub owner-feed subscriber. True only for member-role
+// sessions where openMember successfully created the legacy
+// subscriber; false on owner sessions and on member sessions whose
+// s.sub was torn down by Close.
+//
+// Used by detectStaleAndReconnect to skip the legacy-sub stale check
+// on sessions that have no legacy subscriber to begin with.
+func (s *Session) HasLegacySub() bool {
+	return s.sub != nil
 }
 
 // PeerLastInbound returns the per-peerSub last-inbound timestamp for
@@ -976,6 +1032,47 @@ func (s *Session) ReconnectPeer(ctx context.Context, pk cipher.PubKey) error {
 	return nil
 }
 
+// ReconnectLegacySub re-runs Connect on the legacy s.sub owner-feed
+// subscriber. Mirrors ReconnectPeer's shape but targets the s.sub
+// field rather than a peerSubs entry. No-op + nil error on owner-
+// role sessions and on sessions where s.sub is nil.
+//
+// On success: bumps subLastInboundNs to time.Now. Connect itself is
+// positive evidence the legacy subscriber is attached even before
+// the first inbound leaf arrives.
+//
+// On failure: returns Subscriber.Connect's error verbatim;
+// subLastInboundNs stays unchanged so the next detectStaleAndReconnect
+// tick still sees the session as stale and tries again.
+//
+// Honors the provided context: ctx cancellation returns ctx.Err()
+// promptly, with the same goroutine-leak protection used by Connect
+// + ReconnectPeer (buffered done channel, treestore.Subscriber is
+// not yet ctx-aware internally).
+func (s *Session) ReconnectLegacySub(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.sub == nil {
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- s.sub.Connect(s.cfg.Record.OwnerPK) }()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-done:
+		if err != nil {
+			return err
+		}
+	}
+	s.subLastInboundNs.Store(time.Now().UnixNano())
+	return nil
+}
+
 // makePeerOnUpdate wraps Session.onUpdate with per-peer lastInbound
 // bookkeeping. Each peerSub gets its own wrapper at registration time
 // (in newSession/openOwner/openMember/SetAllowlist) so onUpdate-firing
@@ -994,6 +1091,25 @@ func (s *Session) makePeerOnUpdate(pk cipher.PubKey) treestore.UpdateCallback {
 			if a != nil {
 				a.Store(time.Now().UnixNano())
 			}
+		}
+		s.onUpdate(events)
+	}
+}
+
+// makeLegacySubOnUpdate wraps Session.onUpdate with s.sub-specific
+// lastInbound bookkeeping. Mirrors makePeerOnUpdate's shape for the
+// legacy D1 owner-feed subscriber that lives outside the peerSubs map.
+//
+// Registered in place of the raw s.onUpdate on s.sub in openMember so
+// the per-s.sub staleness signal (subLastInboundNs) is bumped exactly
+// when an inbound CXO event arrives via the legacy path. Without this
+// wrapper, detectStaleAndReconnect has no way to tell s.sub apart from
+// the peerSubs and a wedged s.sub stays dead until the operator does
+// leave + rejoin.
+func (s *Session) makeLegacySubOnUpdate() treestore.UpdateCallback {
+	return func(events []treestore.UpdateEvent) {
+		if len(events) > 0 {
+			s.subLastInboundNs.Store(time.Now().UnixNano())
 		}
 		s.onUpdate(events)
 	}


### PR DESCRIPTION
Closes #2619.

## What

#2606 extended `detectStaleAndReconnect` from session-wide to per-peerSub granularity, but coverage stopped at `Session.peerSubs`. The legacy `Session.sub` field — D1 single-subscriber to the owner's feed on member sessions — still has no per-subscriber staleness signal. Its merge into `peerSubs` is the deferred D4 cleanup; until that lands, every chat-app or visor restart that doesn't re-run `Open` can leave a wedged `s.sub` silently dead while every `peerSubs` entry reconnects fine.

Observed live 2026-05-15: Gamma's member session to `claude-coordination` reported `subscriber_alive=false` for >25 min while Alpha's owner-side peerSub-TO-Gamma reconnected reliably. The fix path was `group leave` + rejoin via invite — works because Open constructs a fresh `s.sub`. Without this PR operators have to monitor `subscriber_alive` and manually rejoin.

## Wiring (mirrors #2606's shape)

| New | Where | Purpose |
| --- | --- | --- |
| `Session.subLastInboundNs atomic.Int64` | session.go | per-`s.sub` liveness signal, parallel to `peerLastInboundNs` |
| `Session.makeLegacySubOnUpdate()` | session.go | wraps `s.onUpdate` with `subLastInboundNs` bookkeeping; registered on `s.sub` in `openMember` in place of raw `s.onUpdate` |
| `Session.Connect` (modified) | session.go | bumps `subLastInboundNs` after successful `s.sub.Connect`, mirroring the per-peer Connect-bump bookkeeping already in place |
| `Session.LegacySubLastInbound()` | session.go | accessor used by `detectStaleAndReconnect` |
| `Session.HasLegacySub()` | session.go | fast-skip predicate |
| `Session.ReconnectLegacySub(ctx)` | session.go | targeted reconnect; ctx-aware, mirrors `ReconnectPeer` |
| `Manager.detectStaleAndReconnect` (modified) | manager.go | computes `legacySubStale` alongside the per-peer loop; either non-empty `stalePeers` OR a stale legacy sub triggers per-group backoff + reconnect attempts |
| `Manager.tryReconnectLegacySub` | manager.go | one `ReconnectLegacySub` under `reconnectAttemptTimeout`; clears failure state on success, records failure (engaging per-group backoff) on error |

## Why option (b) — separate signal — vs. (a) merge into peerSubs

(a) would be the D4 cleanup itself: drop `s.sub`, fold into `peerSubs[ownerPK]`, let existing per-peer machinery handle it. Right long-term shape but a substantially larger surface change touching Open / Connect / SetAllowlist / Send / relay paths — and the relay flow on the legacy sub interacts with members on pre-federated binaries. (b) adds three fields + three methods and stays narrowly focused on the staleness gap, so it can ride a stable release while D4 is planned separately.

## Tests

`legacy_sub_liveness_test.go` pins the new accessor contracts (zero-value, nil-sub, sub-set bump, owner-session short-circuit) and the early-return branches of `ReconnectLegacySub` (no-op on nil sub, ctx.Err() on canceled context). The reconnect integration itself rides the existing manual E2E plan since unit-level CXO bring-up doesn't yet exist for this package — same convention as the rest of `group/`'s tests.

`go test -race -count=1 ./cmd/apps/skychat/group/...` clean.

## Operator validation

Post-merge, this PR + binary roll should let `subscriber_alive=false` self-recover within `subscriberStaleThreshold` instead of requiring manual `group leave` + rejoin. The diagnostic loop:

1. `cli skychat group info <id> | jq .subscriber_alive` — confirm fresh true after Connect / observable inbound
2. Force staleness (peer publisher restart, hostile network, or manual reset)
3. Wait `subscriberStaleThreshold` + reconnect window
4. Re-read `subscriber_alive`; should be back to true without operator intervention

## Out-of-scope

- D4 cleanup proper. Tracked on #2619.
- Per-peer / per-legacy-sub backoff schedule independent of per-group backoff.