### PR TITLE
chore: fix behaviour→behavior misspell from #2620

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -798,7 +798,7 @@ func (s *Session) Connect(ctx context.Context) error {
 		// evidence the legacy owner-feed subscriber is attached, even
 		// before the first inbound leaf arrives. Lets the staleness
 		// window for s.sub start ticking from here, mirroring the
-		// per-peerSub Connect-bump behaviour below.
+		// per-peerSub Connect-bump behavior below.
 		s.subLastInboundNs.Store(time.Now().UnixNano())
 	}
 	// D1 per-PK peer subscribers. Best-effort: if a single peer's


### PR DESCRIPTION
One misspell hit from #2620 admin-merge. make lint 0 issues after.