### PR TITLE
fix(skychat/group): bump session lastInboundNs on ReconnectLegacySub success

### DIFF
--- a/cmd/apps/skychat/group/legacy_sub_liveness_test.go
+++ b/cmd/apps/skychat/group/legacy_sub_liveness_test.go
@@ -90,6 +90,21 @@ func TestReconnectLegacySubNoopOnOwnerSession(t *testing.T) {
 	}
 }
 
+func TestReconnectLegacySubNoopDoesNotBumpSessionLastInbound(t *testing.T) {
+	// The no-op branch (s.sub == nil) must NOT bump lastInboundNs.
+	// Bumping it would phantom-mark an owner session as fresh on
+	// every reconnect tick and mask actual session-wide staleness
+	// from the legacy session-wide fallback path in
+	// detectStaleAndReconnect.
+	s := &Session{}
+	if err := s.ReconnectLegacySub(context.Background()); err != nil {
+		t.Errorf("ReconnectLegacySub on owner session: want nil err, got %v", err)
+	}
+	if !s.LastInbound().IsZero() {
+		t.Errorf("ReconnectLegacySub on owner session: must not bump lastInboundNs")
+	}
+}
+
 func TestReconnectLegacySubHonorsCanceledContext(t *testing.T) {
 	// A canceled context must return ctx.Err() without dialing —
 	// mirrors ReconnectPeer's pre-check. We can't exercise the

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1037,12 +1037,18 @@ func (s *Session) ReconnectPeer(ctx context.Context, pk cipher.PubKey) error {
 // field rather than a peerSubs entry. No-op + nil error on owner-
 // role sessions and on sessions where s.sub is nil.
 //
-// On success: bumps subLastInboundNs to time.Now. Connect itself is
-// positive evidence the legacy subscriber is attached even before
-// the first inbound leaf arrives.
+// On success: bumps both subLastInboundNs and the session-wide
+// lastInboundNs. Connect itself is positive evidence the legacy
+// subscriber is attached even before the first inbound leaf arrives,
+// and on member sessions s.sub being healthy is sufficient to
+// declare the session as a whole healthy — same rationale as
+// Session.Connect's bump-on-success path. Skipping the session-wide
+// bump would leave subscriber_alive=false after a successful
+// reconnect until the next heartbeat or chat message arrives, which
+// is the symptom this fix is meant to remove.
 //
 // On failure: returns Subscriber.Connect's error verbatim;
-// subLastInboundNs stays unchanged so the next detectStaleAndReconnect
+// neither timestamp is bumped so the next detectStaleAndReconnect
 // tick still sees the session as stale and tries again.
 //
 // Honors the provided context: ctx cancellation returns ctx.Err()
@@ -1069,7 +1075,9 @@ func (s *Session) ReconnectLegacySub(ctx context.Context) error {
 			return err
 		}
 	}
-	s.subLastInboundNs.Store(time.Now().UnixNano())
+	now := time.Now().UnixNano()
+	s.subLastInboundNs.Store(now)
+	s.lastInboundNs.Store(now)
 	return nil
 }
 


### PR DESCRIPTION
Follow-up to #2620.

## Observed

Live on-host validation after the autoupdater rolled the develop tip with #2620 confirmed the autonomous recovery works end-to-end — but with a ~2min gap between Record.Status flipping \"active\" and IsSubscriberAlive returning true:

| t | event | status | subscriber_alive |
|---|---|---|---|
| 00:27:28 | autoupdater installs #2620 binary | — | — |
| ~00:28:22 | chat-app cold-start | pending | false |
| 00:30:31 | detectStaleAndReconnect tick fires tryReconnectLegacySub; Connect succeeds | active | false |
| 00:32:31 | first heartbeat arrives via wrapper; lastInboundNs bumped | active | true |

Operationally that ~2min window leaves operators staring at `subscriber_alive=false` after a successful reconnect, when /status is supposed to be the canonical health probe. Easy to mistake for \"the reconnect didn't take.\"

## Fix

One-line behavior change in `Session.ReconnectLegacySub`: bump the session-wide `lastInboundNs` alongside `subLastInboundNs` on a successful s.sub.Connect. Matches the rationale already documented on Session.Connect's bump-on-success path:

> Member-role sessions also have the legacy s.sub path, which was already required to succeed above; reaching this point means s.sub is healthy if it exists, so member sessions bump unconditionally.

## Why this doesn't extend to ReconnectPeer

ReconnectPeer deliberately does NOT bump the session-wide signal — one chatty peer's per-peer reconnect succeeding is not proof of session-wide health, and the existing rationale carefully argues against masking a wedged session as fresh via a single-peer signal. The legacy `s.sub` is different: on member sessions it's the primary subscriber to the OWNER's feed, so its health does correspond to session-wide health under the existing IsSubscriberAlive semantics (`s.sub == nil || lastInboundNs fresh`).

## Test

Adds `TestReconnectLegacySubNoopDoesNotBumpSessionLastInbound` pinning the s.sub == nil branch: owner sessions (and torn-down member sessions) must NOT bump lastInboundNs from ReconnectLegacySub, since that would phantom-mark them as fresh and mask actual staleness from the session-wide fallback path in detectStaleAndReconnect.

`go test -race -count=1 ./cmd/apps/skychat/group/...` clean.

## Net effect post-merge

The 00:30:31 reconnect-success moment ALSO bumps lastInboundNs, so subscriber_alive flips true at status-flip time rather than at heartbeat-arrival time. Wall-clock recovery window shrinks by one heartbeat interval (typically 30s) — operationally a meaningful chunk on cold-restart cascades where operators are watching /status flip live.

## Out-of-scope

Alpha flagged a separate cold-start cascade observation: post-#2608 the 5s `reconnectAttemptTimeout` is biting on first-attempt dmsg dials when there's no warmed-up dmsg session yet, with all peerSubs surfacing \"context deadline exceeded\" every reconnect tick. That's a different surface (the timeout constant + possibly a slow-start mode for the first N attempts post-Open) and deserves its own PR — not rolled into this one.