### PR TITLE
fix(cxo/node): evict stale Conn on peer rejoin instead of rejecting

### DIFF
--- a/pkg/cxo/node/handshake.go
+++ b/pkg/cxo/node/handshake.go
@@ -68,9 +68,14 @@ func (c *Conn) performHandshake() error {
 
 		switch x := m.(type) {
 		case *msg.Ack:
-			// Check if node already has connection with peer.
-			if _, ok := c.n.hasPeer(x.NodeID); ok {
-				return ErrAlreadyHaveConnection
+			// A stale Conn for this peer (whose run() loop wedged or whose
+			// receiveMsg is blocked on a half-dead transport) silently
+			// rejects every rejoin attempt with ErrAlreadyHaveConnection.
+			// On a fresh SYN from the same peer, evict the prior record:
+			// the new conn is the source of truth and the old will tear
+			// itself down via Close → receiveMsg unblock → removeConn.
+			if existing, ok := c.n.hasPeer(x.NodeID); ok {
+				c.n.evictStalePeer(existing, x.NodeID)
 			}
 			c.peerID = x.NodeID
 
@@ -144,20 +149,14 @@ func (c *Conn) acceptHandshake() (err error) {
 			return err
 		}
 
-		// Check if node already has connection with peer.
-		if _, ok := c.n.hasPeer(syn.NodeID); ok {
-			var (
-				err = ErrAlreadyHaveConnection
-
-				errMsg = &msg.Err{
-					Err: err.Error(),
-				}
-			)
-			if sendErr := c.sendMsg(c.nextSeq(), seq, errMsg); sendErr != nil { //nolint:errcheck,gosec
-				c.n.Error(sendErr, "faield to send err message")
-			}
-
-			return err
+		// A stale Conn for this peer (whose run() loop wedged or whose
+		// receiveMsg is blocked on a half-dead transport) silently
+		// rejects every rejoin attempt with ErrAlreadyHaveConnection.
+		// On a fresh SYN from the same peer, evict the prior record:
+		// the new conn is the source of truth and the old will tear
+		// itself down via Close → receiveMsg unblock → removeConn.
+		if existing, ok := c.n.hasPeer(syn.NodeID); ok {
+			c.n.evictStalePeer(existing, syn.NodeID)
 		}
 
 		// Send Ack message.

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -687,6 +687,35 @@ func (n *Node) hasPeer(id cipher.PubKey) (c *Conn, yep bool) { //nolint:unparam
 	return
 }
 
+// evictStalePeer closes the existing Conn for `id` and waits up to
+// the response timeout for run() to clean up (removeConn clears the
+// pkToConn slot). Used by handshake when a peer's fresh SYN/Ack
+// names the same NodeID as a Conn we already track — that record
+// is, by construction, stale (the peer wouldn't be redialing if
+// the old session were healthy on their side). The wait bounds
+// the race window before the caller registers the new Conn via
+// onConnInit; if cleanup overruns the timeout we proceed anyway
+// and accept the pkToConn slot being overwritten by onConnInit.
+func (n *Node) evictStalePeer(existing *Conn, id cipher.PubKey) {
+	if existing == nil {
+		return
+	}
+	n.Debugf(ConnHskPin, "[%s] evicting stale Conn for peer %s on rejoin",
+		existing.String(), id.Hex())
+	existing.Close() //nolint:errcheck,gosec
+	rt := n.config.TCP.ResponseTimeout
+	if existing.IsTCP() == false { //nolint:staticcheck
+		rt = n.config.UDP.ResponseTimeout
+	}
+	if rt <= 0 {
+		rt = 5 * time.Second
+	}
+	select {
+	case <-existing.Done():
+	case <-time.After(rt):
+	}
+}
+
 // A Stat represents Node stat
 type Stat struct {
 	*skyobject.Stat

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -569,12 +569,27 @@ func (n *Node) onConnInit(c *Conn) {
 }
 
 // removeConn reomoves connection from cache.
+//
+// Identity-checks the slot before deleting: when evictStalePeer
+// closes a stale Conn AND its run() drains past evictStalePeer's
+// timeout AND the handshake completes AND onConnInit overwrites
+// pkToConn[id] with a NEW Conn — all before the old run() finally
+// calls removeConn(old) — the old removeConn must NOT wipe the
+// slot now pointing at the live new Conn. Same shape for
+// addrToConn. Without the identity check, the late removeConn of
+// the evicted Conn silently strands the live one (hasPeer returns
+// false, feed routing skips the peer) until something else
+// re-registers.
 func (n *Node) removeConn(c *Conn) {
 	n.mx.Lock()
 	defer n.mx.Unlock()
 
-	delete(n.addrToConn, c.Address())
-	delete(n.pkToConn, c.peerID)
+	if existing, ok := n.addrToConn[c.Address()]; ok && existing == c {
+		delete(n.addrToConn, c.Address())
+	}
+	if existing, ok := n.pkToConn[c.peerID]; ok && existing == c {
+		delete(n.pkToConn, c.peerID)
+	}
 
 	// Remove from feed tracking
 	n.fs.delConn(c)


### PR DESCRIPTION
## Summary
- `acceptHandshake` rejected every incoming SYN whose `NodeID` matched a `pkToConn` entry with `ErrAlreadyHaveConnection` — including SYNs from peers whose prior session is in fact gone. On their side this surfaces as `factory.Connection closed` and they retry forever with the same outcome, never recover.
- Same shape on the outgoing side (`performHandshake`'s `Ack` path).
- On duplicate-peer detection, we now evict the existing `Conn` via `Close`, wait briefly for `run()` to drain (`removeConn` clears the slot), then proceed. The new connection is authoritative — the old record only persisted because `run()` never observed the disconnect (half-dead transport, wedged `receiveMsg`, or the peer's network/visor reset without TCP RST reaching us).

## Why
Hit in production tonight on a skychat group: peer's `subscriber_alive` went `false` ~17min after a transport blip, then 5 sequential `cli skychat group leave` + `join` cycles all failed identically with `'group: Join: connect: group: Connect: handshake failed: factory.Connection closed'`. 1:1 chat round-trips kept working (visor + chat-app healthy), publisher dmsg port was probe-reachable, owner's runtime log had no `received` events from that peer — pinpointing the failure to the CXO factory accept side rejecting the fresh `SYN`.

## Test plan
- [x] `go test ./pkg/cxo/node/... -count=1` passes
- [x] `go vet ./pkg/cxo/node/...` clean
- [ ] In-production verification: install built binary on owner host, observe that the previously-stuck peer's next group rejoin succeeds (group `subscriber_alive=true` on their side, fresh probe round-trip)

## Follow-ups (not in this PR)
- Cross-visor admin/roster gossip RFC (owner-SPOF for state mutations)
- History replay on reconnect (subscriber backfill from publisher's TreeStore)
- Liveness telemetry surface (`subscriber_alive` per-peer in `group info`)
- Multi-transport publisher (skynet fallback when dmsg congests)
- Mixed-binary-version detection / CI integration test