### PR TITLE
fix(skychat/group): per-(group, peer) reconnect backoff

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -130,12 +130,12 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 		log = logging.MustGetLogger("skychat-group-manager")
 	}
 	return &Manager{
-		store:             cfg.Store,
-		dmsgC:             cfg.DmsgC,
-		myPK:              cfg.MyPK,
-		mySK:              cfg.MySK,
-		dataDir:           cfg.DataDir,
-		log:               log,
+		store:              cfg.Store,
+		dmsgC:              cfg.DmsgC,
+		myPK:               cfg.MyPK,
+		mySK:               cfg.MySK,
+		dataDir:            cfg.DataDir,
+		log:                log,
 		portAlloc:          defaultPortAlloc,
 		sessions:           make(map[string]*Session),
 		heartbeatInterval:  cfg.HeartbeatInterval,

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -70,6 +70,13 @@ type Manager struct {
 	reconnectWG     sync.WaitGroup
 	reconnectMu     sync.Mutex
 	reconnectState  map[string]*reconnectState // keyed by group ID
+	// peerReconnectState tracks per-(group, peer) backoff for the
+	// tryReconnectPeers path so one wedged peer's failures don't
+	// engage a session-level backoff that locks out healthy peers'
+	// reconnect attempts. Parallel to reconnectState; the session-
+	// level map still backs tryReconnect (full Connect) and
+	// tryReconnectLegacySub. Outer key = group ID, inner key = peer PK.
+	peerReconnectState map[string]map[cipher.PubKey]*reconnectState
 }
 
 // reconnectState tracks per-group consecutive-failure backoff so a
@@ -129,10 +136,11 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 		mySK:              cfg.MySK,
 		dataDir:           cfg.DataDir,
 		log:               log,
-		portAlloc:         defaultPortAlloc,
-		sessions:          make(map[string]*Session),
-		heartbeatInterval: cfg.HeartbeatInterval,
-		reconnectState:    make(map[string]*reconnectState),
+		portAlloc:          defaultPortAlloc,
+		sessions:           make(map[string]*Session),
+		heartbeatInterval:  cfg.HeartbeatInterval,
+		reconnectState:     make(map[string]*reconnectState),
+		peerReconnectState: make(map[string]map[cipher.PubKey]*reconnectState),
 	}, nil
 }
 
@@ -278,6 +286,14 @@ func (m *Manager) terminate(id string, status Status) error {
 	if live {
 		_ = sess.Close() //nolint:errcheck
 	}
+	// Drop all per-peer reconnect state for this group — the session
+	// (and its peerSubs) are gone, so any remaining (id, peer) entries
+	// in peerReconnectState would be unreachable memory until next
+	// process restart.
+	m.reconnectMu.Lock()
+	delete(m.reconnectState, id)
+	delete(m.peerReconnectState, id)
+	m.reconnectMu.Unlock()
 	_ = m.store.SetStatus(r.ID, status) //nolint:errcheck
 	return nil
 }
@@ -749,11 +765,13 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 		if len(stalePeers) == 0 && !legacySubStale {
 			continue
 		}
-		// Honor the per-group backoff so a wedged group doesn't
-		// churn the reconnect machinery once per tick per peer.
-		if !m.reconnectShouldAttempt(r.ID, now) {
-			continue
-		}
+		// Per-peer path: tryReconnectPeers consults peerReconnectShouldAttempt
+		// internally for each peer individually, so the per-peer
+		// branch deliberately bypasses the session-level
+		// reconnectShouldAttempt gate. Pre-T2b that gate sat HERE
+		// and a single wedged peer's session-level backoff would
+		// suppress every peer's reconnect attempts for the entire
+		// 5min/30min window.
 		if len(stalePeers) > 0 {
 			m.log.WithField("id", r.ID).
 				WithField("stale_peers", len(stalePeers)).
@@ -762,7 +780,14 @@ func (m *Manager) detectStaleAndReconnect(ctx context.Context) {
 				Debug("group: per-peer stale; kicking per-peer reconnects")
 			m.tryReconnectPeers(ctx, sess, r.ID, stalePeers)
 		}
+		// Legacy s.sub path: still gated by the session-level
+		// reconnectShouldAttempt, since s.sub failures feed into
+		// reconnectRecordFailure(id, ...) which is the session-level
+		// backoff. Per-peer state lives in a separate map.
 		if legacySubStale {
+			if !m.reconnectShouldAttempt(r.ID, now) {
+				continue
+			}
 			m.log.WithField("id", r.ID).
 				WithField("status", string(r.Status)).
 				Debug("group: legacy s.sub stale; kicking owner-feed reconnect")
@@ -820,11 +845,25 @@ func (m *Manager) tryReconnect(ctx context.Context, sess *Session, id string) {
 // N × reconnectAttemptTimeout, which is acceptable for typical
 // group sizes (≤ 10 members).
 func (m *Manager) tryReconnectPeers(ctx context.Context, sess *Session, id string, peers []cipher.PubKey) {
+	now := time.Now().UTC()
 	successes := 0
-	var lastErr error
+	skipped := 0
 	for _, pk := range peers {
 		if ctx.Err() != nil {
 			return
+		}
+		// Per-peer backoff gate: a single wedged peer in 5min/30min
+		// backoff doesn't lock out the other stale peers' attempts.
+		// Pre-T2b this gate lived at the session level above the
+		// whole tryReconnectPeers call, so any one peer accumulating
+		// reconnectBackoffFailures1 failures suppressed reconnects
+		// for every peer in the session for the entire backoff
+		// window. Per-peer state fixes that.
+		if !m.peerReconnectShouldAttempt(id, pk, now) {
+			skipped++
+			m.log.WithField("id", id).WithField("peer", pk.String()).
+				Debug("group: reconnect: peer in backoff window, skipping this tick")
+			continue
 		}
 		m.log.WithField("id", id).WithField("peer", pk.String()).
 			Debug("group: reconnect: attempting peer subscribe")
@@ -836,14 +875,20 @@ func (m *Manager) tryReconnectPeers(ctx context.Context, sess *Session, id strin
 		cancel()
 		if err == nil {
 			successes++
+			m.peerReconnectClear(id, pk)
 			m.log.WithField("id", id).WithField("peer", pk.String()).
 				Info("group: reconnect: peer subscribe restored")
 			continue
 		}
-		lastErr = err
-		m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
-			Debug("group: reconnect: peer subscribe failed")
+		m.peerReconnectRecordFailure(id, pk, err)
 	}
+	// Session-level state still tracks "at least one peer reconnect
+	// succeeded this tick" so the SetStatus(Active) promotion fires
+	// when the session as a whole is recovering. We clear the
+	// session-level reconnectState entry on any success to keep
+	// parity with the legacy session-level backoff path used by
+	// tryReconnect (full Connect) — that entry continues to gate
+	// THAT path even if all per-peer attempts are skipped.
 	if successes > 0 {
 		m.reconnectMu.Lock()
 		delete(m.reconnectState, id)
@@ -852,11 +897,12 @@ func (m *Manager) tryReconnectPeers(ctx context.Context, sess *Session, id strin
 			m.log.WithError(sErr).WithField("id", id).
 				Warn("group: reconnect: SetStatus active failed")
 		}
-		return
 	}
-	if lastErr != nil {
-		m.reconnectRecordFailure(id, lastErr)
-	}
+	// No session-level reconnectRecordFailure on the per-peer path:
+	// per-peer failures are recorded against their own entries
+	// inside the loop. The session-level backoff schedule is reserved
+	// for tryReconnect (full Connect failure) and tryReconnectLegacySub.
+	_ = skipped // tracked in log lines, no further bookkeeping
 }
 
 // tryReconnectLegacySub runs one ReconnectLegacySub attempt for the
@@ -904,10 +950,36 @@ func (m *Manager) tryReconnectLegacySub(ctx context.Context, sess *Session, id s
 // reconnectShouldAttempt returns false when the per-group nextAttempt
 // is still in the future (i.e. we're in a backoff window). True when
 // there's no state (first attempt) or when the backoff has elapsed.
+//
+// Gates tryReconnect (full Session.Connect) and tryReconnectLegacySub;
+// the per-peer path (tryReconnectPeers) uses peerReconnectShouldAttempt
+// instead so a wedged session-wide backoff doesn't lock out healthy
+// peers' independent reconnect attempts.
 func (m *Manager) reconnectShouldAttempt(id string, now time.Time) bool {
 	m.reconnectMu.Lock()
 	defer m.reconnectMu.Unlock()
 	st, ok := m.reconnectState[id]
+	if !ok {
+		return true
+	}
+	return !st.nextAttempt.After(now)
+}
+
+// peerReconnectShouldAttempt is the per-peer counterpart to
+// reconnectShouldAttempt. Returns true when (id, peer) has no
+// recorded failures or when the per-peer backoff window has elapsed.
+// Lets tryReconnectPeers skip just the wedged peer rather than the
+// whole session, so a single permanently-unreachable peer cannot
+// engage a session-level backoff that locks out healthy peers'
+// reconnect attempts.
+func (m *Manager) peerReconnectShouldAttempt(id string, pk cipher.PubKey, now time.Time) bool {
+	m.reconnectMu.Lock()
+	defer m.reconnectMu.Unlock()
+	peers, ok := m.peerReconnectState[id]
+	if !ok {
+		return true
+	}
+	st, ok := peers[pk]
 	if !ok {
 		return true
 	}
@@ -927,21 +999,7 @@ func (m *Manager) reconnectRecordFailure(id string, attemptErr error) {
 		m.reconnectState[id] = st
 	}
 	st.failures++
-	var transition string
-	switch {
-	case st.failures == reconnectBackoffFailures2:
-		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval2)
-		transition = reconnectBackoffInterval2.String()
-	case st.failures == reconnectBackoffFailures1:
-		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval1)
-		transition = reconnectBackoffInterval1.String()
-	case st.failures > reconnectBackoffFailures2:
-		// Stay at the 30min cadence for any subsequent failures.
-		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval2)
-	case st.failures > reconnectBackoffFailures1:
-		// Stay at the 5min cadence between the two thresholds.
-		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval1)
-	}
+	transition := applyBackoffTransition(st)
 	failures := st.failures
 	m.reconnectMu.Unlock()
 	if transition != "" {
@@ -954,6 +1012,83 @@ func (m *Manager) reconnectRecordFailure(id string, attemptErr error) {
 			WithField("failures", failures).
 			Debug("group: reconnect: attempt failed")
 	}
+}
+
+// peerReconnectRecordFailure is the per-peer counterpart to
+// reconnectRecordFailure. Increments the (id, peer) counter and
+// applies the same backoff threshold transitions independently of
+// any other peer's failure history. Lets one wedged peer accumulate
+// its own backoff schedule (5min, 30min) without dragging the rest
+// of the session into the same schedule.
+func (m *Manager) peerReconnectRecordFailure(id string, pk cipher.PubKey, attemptErr error) {
+	m.reconnectMu.Lock()
+	peers, ok := m.peerReconnectState[id]
+	if !ok {
+		peers = make(map[cipher.PubKey]*reconnectState)
+		m.peerReconnectState[id] = peers
+	}
+	st, ok := peers[pk]
+	if !ok {
+		st = &reconnectState{}
+		peers[pk] = st
+	}
+	st.failures++
+	transition := applyBackoffTransition(st)
+	failures := st.failures
+	m.reconnectMu.Unlock()
+	if transition != "" {
+		m.log.WithError(attemptErr).WithField("id", id).
+			WithField("peer", pk.String()).
+			WithField("failures", failures).
+			WithField("next_interval", transition).
+			Warn("group: reconnect: extending per-peer backoff")
+	} else {
+		m.log.WithError(attemptErr).WithField("id", id).
+			WithField("peer", pk.String()).
+			WithField("failures", failures).
+			Debug("group: reconnect: per-peer attempt failed")
+	}
+}
+
+// peerReconnectClear drops the per-peer backoff state for (id, peer).
+// Called on per-peer reconnect success and on peer eviction
+// (SetAllowlist removing a member) so the entry doesn't outlive its
+// peerSub.
+func (m *Manager) peerReconnectClear(id string, pk cipher.PubKey) {
+	m.reconnectMu.Lock()
+	defer m.reconnectMu.Unlock()
+	peers, ok := m.peerReconnectState[id]
+	if !ok {
+		return
+	}
+	delete(peers, pk)
+	if len(peers) == 0 {
+		delete(m.peerReconnectState, id)
+	}
+}
+
+// applyBackoffTransition extends st.nextAttempt according to the same
+// failure-count thresholds reconnectRecordFailure and
+// peerReconnectRecordFailure both use. Caller holds reconnectMu.
+// Returns the human-readable transition interval if a threshold was
+// crossed in this call, or "" otherwise. Extracted so the per-group
+// and per-peer paths share one backoff schedule.
+func applyBackoffTransition(st *reconnectState) string {
+	switch {
+	case st.failures == reconnectBackoffFailures2:
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval2)
+		return reconnectBackoffInterval2.String()
+	case st.failures == reconnectBackoffFailures1:
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval1)
+		return reconnectBackoffInterval1.String()
+	case st.failures > reconnectBackoffFailures2:
+		// Stay at the 30min cadence for any subsequent failures.
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval2)
+	case st.failures > reconnectBackoffFailures1:
+		// Stay at the 5min cadence between the two thresholds.
+		st.nextAttempt = time.Now().UTC().Add(reconnectBackoffInterval1)
+	}
+	return ""
 }
 
 // kickReconnect is the opportunistic-retry hook: when a member-side

--- a/cmd/apps/skychat/group/per_peer_backoff_test.go
+++ b/cmd/apps/skychat/group/per_peer_backoff_test.go
@@ -1,0 +1,164 @@
+// Package group — cmd/apps/skychat/group/per_peer_backoff_test.go:
+// targeted coverage for the per-(group, peer) reconnect backoff
+// added in T2b. The full reconnect loop wiring rides the manual E2E
+// plan (same convention as the rest of the manager.go tests in this
+// package); these tests pin the manager's per-peer state helpers in
+// isolation so a refactor doesn't regress the contract
+// detectStaleAndReconnect + tryReconnectPeers depend on.
+package group
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// newPeerBackoffTestManager returns a *Manager seeded with the
+// minimum state the per-peer backoff helpers need — the maps —
+// without any session / store / dmsg infra. The new helpers don't
+// touch any other fields, so a partially-initialized Manager is
+// safe for these tests.
+func newPeerBackoffTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return &Manager{
+		log:                logging.MustGetLogger("skychat-group-manager-test"),
+		reconnectState:     make(map[string]*reconnectState),
+		peerReconnectState: make(map[string]map[cipher.PubKey]*reconnectState),
+	}
+}
+
+func TestPeerReconnectShouldAttemptDefaultsTrue(t *testing.T) {
+	// No prior failure recorded → should attempt. Mirrors
+	// reconnectShouldAttempt's contract for the session-level path.
+	m := newPeerBackoffTestManager(t)
+	pk, _ := cipher.GenerateKeyPair()
+	if !m.peerReconnectShouldAttempt("group-1", pk, time.Now().UTC()) {
+		t.Errorf("expected true when no peer state exists, got false")
+	}
+}
+
+func TestPeerReconnectRecordFailureExtendsBackoff(t *testing.T) {
+	// First failure: bumps counter, no transition until
+	// reconnectBackoffFailures1 threshold. At that exact failure
+	// count the per-peer nextAttempt extends by
+	// reconnectBackoffInterval1 (so shouldAttempt returns false
+	// until that window elapses). Mirrors reconnectRecordFailure's
+	// schedule — they share applyBackoffTransition.
+	m := newPeerBackoffTestManager(t)
+	pk, _ := cipher.GenerateKeyPair()
+	id := "group-1"
+	now := time.Now().UTC()
+	err := errors.New("synthetic peer reconnect failure")
+	for i := uint32(1); i < reconnectBackoffFailures1; i++ {
+		m.peerReconnectRecordFailure(id, pk, err)
+		if !m.peerReconnectShouldAttempt(id, pk, now) {
+			t.Errorf("at failure=%d (below threshold), expected shouldAttempt=true", i)
+		}
+	}
+	// Threshold cross — extends by reconnectBackoffInterval1.
+	m.peerReconnectRecordFailure(id, pk, err)
+	if m.peerReconnectShouldAttempt(id, pk, now) {
+		t.Errorf("at failure=%d (threshold), expected shouldAttempt=false within backoff window", reconnectBackoffFailures1)
+	}
+	// And shouldAttempt flips back to true once the backoff window
+	// passes — the underlying nextAttempt is a wall-clock time.
+	future := now.Add(reconnectBackoffInterval1 + time.Second)
+	if !m.peerReconnectShouldAttempt(id, pk, future) {
+		t.Errorf("after backoff window elapsed, expected shouldAttempt=true")
+	}
+}
+
+func TestPeerReconnectClearDropsState(t *testing.T) {
+	// On per-peer reconnect SUCCESS, tryReconnectPeers calls
+	// peerReconnectClear to drop the (id, peer) entry so the next
+	// failure starts the schedule from zero. Confirms the entry
+	// goes away AND the outer (group-keyed) map cleans up when
+	// empty.
+	m := newPeerBackoffTestManager(t)
+	pk, _ := cipher.GenerateKeyPair()
+	id := "group-1"
+	// Force a known backoff state.
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.peerReconnectRecordFailure(id, pk, errors.New("force-state"))
+	}
+	if m.peerReconnectShouldAttempt(id, pk, time.Now().UTC()) {
+		t.Fatalf("test setup: expected backoff engaged after %d failures", reconnectBackoffFailures1)
+	}
+	m.peerReconnectClear(id, pk)
+	if !m.peerReconnectShouldAttempt(id, pk, time.Now().UTC()) {
+		t.Errorf("after clear, expected shouldAttempt=true (fresh state)")
+	}
+	if _, ok := m.peerReconnectState[id]; ok {
+		t.Errorf("after clearing the only peer for group, expected outer map[id] to be deleted")
+	}
+}
+
+func TestPeerReconnectIndependentBetweenPeers(t *testing.T) {
+	// One wedged peer's backoff must not gate a healthy peer's
+	// next-tick attempt. This is the core T2b property: pre-fix
+	// the session-level backoff schedule engaged on any one peer's
+	// repeated failures and locked out reconnect attempts for the
+	// rest of the session.
+	m := newPeerBackoffTestManager(t)
+	wedged, _ := cipher.GenerateKeyPair()
+	healthy, _ := cipher.GenerateKeyPair()
+	id := "group-1"
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.peerReconnectRecordFailure(id, wedged, errors.New("force-state"))
+	}
+	now := time.Now().UTC()
+	if m.peerReconnectShouldAttempt(id, wedged, now) {
+		t.Errorf("wedged peer: expected shouldAttempt=false in backoff window")
+	}
+	if !m.peerReconnectShouldAttempt(id, healthy, now) {
+		t.Errorf("healthy peer: expected shouldAttempt=true (independent of wedged peer's backoff)")
+	}
+}
+
+func TestPeerReconnectIndependentBetweenGroups(t *testing.T) {
+	// Same peer PK in two different groups gets independent
+	// backoff state. Otherwise a peer wedged in group A would
+	// silently lock out reconnects in group B sharing that peer.
+	m := newPeerBackoffTestManager(t)
+	pk, _ := cipher.GenerateKeyPair()
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.peerReconnectRecordFailure("group-a", pk, errors.New("force-state"))
+	}
+	now := time.Now().UTC()
+	if m.peerReconnectShouldAttempt("group-a", pk, now) {
+		t.Errorf("group-a state should be in backoff after %d failures", reconnectBackoffFailures1)
+	}
+	if !m.peerReconnectShouldAttempt("group-b", pk, now) {
+		t.Errorf("group-b state should be fresh: per-(group, peer) keying")
+	}
+}
+
+func TestPeerReconnectSecondThresholdExtendsLonger(t *testing.T) {
+	// At reconnectBackoffFailures2 the nextAttempt extends by
+	// reconnectBackoffInterval2 (the longer 30min cadence in
+	// production). Pins the second threshold transition so the
+	// per-peer schedule matches the session-level one.
+	m := newPeerBackoffTestManager(t)
+	pk, _ := cipher.GenerateKeyPair()
+	for i := uint32(0); i < reconnectBackoffFailures2; i++ {
+		m.peerReconnectRecordFailure("group-1", pk, errors.New("force-state"))
+	}
+	now := time.Now().UTC()
+	if m.peerReconnectShouldAttempt("group-1", pk, now) {
+		t.Errorf("at failures=%d, expected shouldAttempt=false in long-backoff window", reconnectBackoffFailures2)
+	}
+	// Just past the first threshold's window — should still be in
+	// backoff because the second threshold extended further.
+	pastShort := now.Add(reconnectBackoffInterval1 + time.Second)
+	if m.peerReconnectShouldAttempt("group-1", pk, pastShort) {
+		t.Errorf("after short-interval elapsed, second-threshold backoff should still be engaged")
+	}
+	// Past the long window — should be true again.
+	pastLong := now.Add(reconnectBackoffInterval2 + time.Second)
+	if !m.peerReconnectShouldAttempt("group-1", pk, pastLong) {
+		t.Errorf("after long-interval elapsed, expected shouldAttempt=true")
+	}
+}


### PR DESCRIPTION
Closes #2626. Tier-2b of the post-cascade reliability synthesis (#2606 was per-peer **liveness**; this is per-peer **backoff**).

## Why

#2606 made staleness detection per-peerSub, but `reconnectShouldAttempt` + `reconnectRecordFailure` still key on group ID alone. One wedged peer's failures bump `reconnectState[id].nextAttempt` and `detectStaleAndReconnect` skips the entire `tryReconnectPeers` call for the next 5-30min — locking out reconnect attempts for every other stale peer in the session.

T1 reliability test pass on 2026-05-16 surfaced this: 9/10 receive drop from Alpha + 10/10 from Beta on a fully-cascaded receiver. The cascade #2606+#2608+#2620+#2622+#2623 closes the auto-recover loop, but per-peer reconnects don't actually fire when session-level backoff is engaged.

## Wiring

| New | Where | Purpose |
| --- | --- | --- |
| `Manager.peerReconnectState map[string]map[cipher.PubKey]*reconnectState` | manager.go | per-(group, peer) failure + nextAttempt; parallel to `reconnectState` |
| `peerReconnectShouldAttempt(id, pk, now)` | manager.go | per-peer counterpart to `reconnectShouldAttempt` |
| `peerReconnectRecordFailure(id, pk, err)` | manager.go | per-peer counterpart to `reconnectRecordFailure` |
| `peerReconnectClear(id, pk)` | manager.go | drop entry on success; outer-map cleanup when empty |
| `applyBackoffTransition(st)` | manager.go | extracted threshold/extension helper shared by both record-failure paths |

## Behavior

| Path | Backoff scope (pre) | Backoff scope (post) |
| --- | --- | --- |
| `tryReconnect` (full Session.Connect) | session | session (unchanged) |
| `tryReconnectLegacySub` (member s.sub) | session | session (unchanged) |
| `tryReconnectPeers` (per peerSub) | session | **per (group, peer)** |

`detectStaleAndReconnect`'s per-peer branch removes the session-level `reconnectShouldAttempt` gate — that's the one that was suppressing healthy-peer reconnects. Per-peer gating now happens inside `tryReconnectPeers`'s loop, per peer, immediately before each `ReconnectPeer` call.

`reconnectRecordFailure` now delegates threshold handling to `applyBackoffTransition` so per-group and per-peer paths share one source of truth.

`Manager.terminate` (Leave + Delete) drops the outer `peerReconnectState[id]` alongside `reconnectState[id]` so per-peer state can't outlive its session.

## Tests

`per_peer_backoff_test.go` (5 tests): default-true on fresh state, threshold transition extends nextAttempt by interval-1, clear drops state with outer-map cleanup, per-peer independence within one group (wedged peer doesn't gate healthy peer), per-group independence for the same peer PK, second-threshold transition extends by interval-2.

`go test -race -count=1 ./cmd/apps/skychat/group/...` clean. `go vet` clean.

## Out of scope

- Tier-2a: ctx-cancellation through `dmsg.Client.ConnectPK` (Beta's PR).
- Tier-3: roster/admin-set gossip RFC (Alpha).
- The `factory.Connection closed` mystery on owner-side CXO accept — separate ticket; needs Alpha's visor log during a failed join.