### PR TITLE
feat(skychat/group): surface per-peer last-inbound in GroupInfo

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -1081,6 +1081,32 @@ func (m *Manager) IsSubscriberAlive(id string) bool {
 	return sess.IsSubscriberAlive()
 }
 
+// PeerLiveness returns the per-peer last-inbound timestamps for the
+// given group, keyed by peer PK. Empty map if no live session, or for
+// owner-role sessions that don't follow peer feeds. Zero time for a
+// peer indicates the peerSub has never observed an inbound (either
+// peerSub is connecting, the peer is silent, or — until #2620 — the
+// legacy s.sub subscriber hasn't covered this peer's traffic).
+//
+// Used by Visor.GroupGet/GroupList to surface per-peer telemetry so
+// operators can identify a single silent peer in an otherwise healthy
+// group, rather than chasing the session-level SubscriberAlive=true
+// while one member's messages quietly never arrive.
+func (m *Manager) PeerLiveness(id string) map[cipher.PubKey]time.Time {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok || sess == nil {
+		return map[cipher.PubKey]time.Time{}
+	}
+	peers := sess.PeerPKs()
+	out := make(map[cipher.PubKey]time.Time, len(peers))
+	for _, pk := range peers {
+		out[pk] = sess.PeerLastInbound(pk)
+	}
+	return out
+}
+
 // List returns every persisted record.
 func (m *Manager) List() ([]Record, error) { return m.store.List() }
 

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -53,6 +53,16 @@ type GroupInfo struct {
 	// side. Populated by GroupList; left zero by other accessors that
 	// don't need it. See group.Manager.IsSubscriberAlive for semantics.
 	SubscriberAlive bool `json:"subscriber_alive"`
+
+	// PeerLastInbound is the per-peer last-inbound time, keyed by
+	// peer-PK hex. Populated by GroupList and GroupGet alongside
+	// SubscriberAlive. A zero time means the peerSub for that peer
+	// is connecting, silent since startup, or (legacy s.sub path)
+	// not individually tracked. Empty map for owner-role sessions
+	// that don't follow peer feeds. Operator-facing: lets `cli
+	// skychat group info` show which specific peer is stale in a
+	// group whose session-level SubscriberAlive is otherwise true.
+	PeerLastInbound map[string]time.Time `json:"peer_last_inbound,omitempty"`
 }
 
 // GroupMessage is one inbound message delivered through the visor's
@@ -152,6 +162,7 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 	for _, r := range all {
 		info := toInfo(r)
 		info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
+		info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 		out = append(out, info)
 	}
 	return out, nil
@@ -183,7 +194,24 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	}
 	info := toInfo(r)
 	info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
+	info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 	return info, nil
+}
+
+// peerLivenessHex converts the cipher-keyed Manager.PeerLiveness map
+// into a hex-keyed JSON-friendly map. Returns nil when the input map
+// is empty so the JSON omitempty tag drops the field entirely for
+// records with no peer-level telemetry (e.g. owner-role sessions, or
+// when no live session exists).
+func peerLivenessHex(in map[cipher.PubKey]time.Time) map[string]time.Time {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]time.Time, len(in))
+	for pk, ts := range in {
+		out[pk.Hex()] = ts
+	}
+	return out
 }
 
 // GroupInvite returns a freshly-encoded invite link for an


### PR DESCRIPTION
## Summary
- Adds \`GroupInfo.PeerLastInbound\` (peer-PK-hex → last-inbound time) so operators can identify a single silent peer in an otherwise healthy group.
- Previously \`SubscriberAlive\` was the only liveness signal at the GroupInfo surface — session-level true/false, no breakdown for which peerSub is actually receiving traffic.
- The data already existed on \`Session\` (\`peerLastInboundNs\`, \`Session.PeerLastInbound\`, \`Session.PeerPKs\` from #2606). This PR plumbs it through \`Manager.PeerLiveness\` (new) and into the visor RPC \`GroupGet\`/\`GroupList\` responses.

## Why
When one peer's feed silently fails while others stay chatty, the session-level signal stays green and the failure was only detectable by waiting for the missing peer's chat-acks to time out. Per-peer telemetry surfaces it immediately. Demonstrated useful this session: after fixing #2625's join blocker, one member rejoined but their roster was incomplete (separate cross-visor gossip gap). Per-peer telemetry lets us distinguish \"their subscriber works but the roster is stale\" from \"their subscriber is silently failing on one peer's feed.\"

## Wire-format change
- \`GroupInfo\` gains optional \`peer_last_inbound\` map field. \`omitempty\` keeps backwards-compatible responses for records with no peer telemetry (owner-role, or no live session).

## Test plan
- [x] \`go test ./pkg/visor/... ./cmd/apps/skychat/group/... -count=1\` passes
- [x] \`go vet ./pkg/visor/... ./cmd/apps/skychat/group/...\` clean
- [ ] In-production verification: run \`cli skychat group info <id> --json\` and confirm \`peer_last_inbound\` populated with per-peer timestamps

## Related
- Stacks naturally on top of #2625 (factory.Connection-closed eviction fix)
- Part of the open architectural-gaps roadmap from tonight's coordination work — this is the small/scoped first piece
- Larger items still open: cross-visor admin/roster gossip RFC, history replay on reconnect, multi-transport publisher