### PR TITLE
feat(cli/group): human-readable info + peer_last_inbound table

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -1081,6 +1081,32 @@ func (m *Manager) IsSubscriberAlive(id string) bool {
 	return sess.IsSubscriberAlive()
 }
 
+// PeerLiveness returns the per-peer last-inbound timestamps for the
+// given group, keyed by peer PK. Empty map if no live session, or for
+// owner-role sessions that don't follow peer feeds. Zero time for a
+// peer indicates the peerSub has never observed an inbound (either
+// peerSub is connecting, the peer is silent, or — until #2620 — the
+// legacy s.sub subscriber hasn't covered this peer's traffic).
+//
+// Used by Visor.GroupGet/GroupList to surface per-peer telemetry so
+// operators can identify a single silent peer in an otherwise healthy
+// group, rather than chasing the session-level SubscriberAlive=true
+// while one member's messages quietly never arrive.
+func (m *Manager) PeerLiveness(id string) map[cipher.PubKey]time.Time {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok || sess == nil {
+		return map[cipher.PubKey]time.Time{}
+	}
+	peers := sess.PeerPKs()
+	out := make(map[cipher.PubKey]time.Time, len(peers))
+	for _, pk := range peers {
+		out[pk] = sess.PeerLastInbound(pk)
+	}
+	return out
+}
+
 // List returns every persisted record.
 func (m *Manager) List() ([]Record, error) { return m.store.List() }
 

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -196,18 +196,18 @@ func renderGroupInfo(info visor.GroupInfo) string {
 	if !info.LastMessageAt.IsZero() {
 		last = info.LastMessageAt.UTC().Format(time.RFC3339)
 	}
-	fmt.Fprintf(&buf, "id:                %s\n", info.ID)            //nolint:errcheck
-	fmt.Fprintf(&buf, "name:              %s\n", info.Name)          //nolint:errcheck
-	fmt.Fprintf(&buf, "owner:             %s\n", info.OwnerPK)       //nolint:errcheck
-	fmt.Fprintf(&buf, "port:              %d\n", info.Port)          //nolint:errcheck
-	fmt.Fprintf(&buf, "mode:              %s\n", info.Mode)          //nolint:errcheck
-	fmt.Fprintf(&buf, "role:              %s\n", info.Role)          //nolint:errcheck
-	fmt.Fprintf(&buf, "status:            %s\n", info.Status)        //nolint:errcheck
-	fmt.Fprintf(&buf, "created_at:        %s\n", info.CreatedAt.UTC().Format(time.RFC3339))  //nolint:errcheck
-	fmt.Fprintf(&buf, "joined_at:         %s\n", info.JoinedAt.UTC().Format(time.RFC3339))   //nolint:errcheck
-	fmt.Fprintf(&buf, "last_message_at:   %s\n", last)               //nolint:errcheck
-	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive) //nolint:errcheck
-	fmt.Fprintf(&buf, "members (%d):\n", len(info.Members))          //nolint:errcheck
+	fmt.Fprintf(&buf, "id:                %s\n", info.ID)                                   //nolint:errcheck
+	fmt.Fprintf(&buf, "name:              %s\n", info.Name)                                 //nolint:errcheck
+	fmt.Fprintf(&buf, "owner:             %s\n", info.OwnerPK)                              //nolint:errcheck
+	fmt.Fprintf(&buf, "port:              %d\n", info.Port)                                 //nolint:errcheck
+	fmt.Fprintf(&buf, "mode:              %s\n", info.Mode)                                 //nolint:errcheck
+	fmt.Fprintf(&buf, "role:              %s\n", info.Role)                                 //nolint:errcheck
+	fmt.Fprintf(&buf, "status:            %s\n", info.Status)                               //nolint:errcheck
+	fmt.Fprintf(&buf, "created_at:        %s\n", info.CreatedAt.UTC().Format(time.RFC3339)) //nolint:errcheck
+	fmt.Fprintf(&buf, "joined_at:         %s\n", info.JoinedAt.UTC().Format(time.RFC3339))  //nolint:errcheck
+	fmt.Fprintf(&buf, "last_message_at:   %s\n", last)                                      //nolint:errcheck
+	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive)                      //nolint:errcheck
+	fmt.Fprintf(&buf, "members (%d):\n", len(info.Members))                                 //nolint:errcheck
 	for _, pk := range info.Members {
 		fmt.Fprintf(&buf, "  %s\n", pk) //nolint:errcheck
 	}

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -172,9 +172,68 @@ var groupInfoCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		body, _ := json.MarshalIndent(info, "", "  ") //nolint:errcheck
-		internal.PrintOutput(cmd.Flags(), info, string(body)+"\n")
+		// JSON path stays unchanged: tooling and the prior
+		// human-readable-was-JSON behavior are preserved when --json
+		// is set. The default human path renders a labeled summary
+		// plus a per-peer liveness table when peer_last_inbound has
+		// entries — the operator-facing surface for the telemetry
+		// added in #2628.
+		human := renderGroupInfo(info)
+		internal.PrintOutput(cmd.Flags(), info, human)
 	},
+}
+
+// renderGroupInfo formats a GroupInfo for the operator-facing
+// `cli skychat group info` default (non-JSON) output. The shape
+// mirrors `group list` columns for the header fields, then adds
+// a per-peer last-inbound table when the visor populated
+// peer_last_inbound (group is a live member-side session with one
+// or more peerSubs). A zero time is rendered as "never" to make
+// "subscriber up, this peer is silent" obvious vs an absent row.
+func renderGroupInfo(info visor.GroupInfo) string {
+	var buf strings.Builder
+	last := "-"
+	if !info.LastMessageAt.IsZero() {
+		last = info.LastMessageAt.UTC().Format(time.RFC3339)
+	}
+	fmt.Fprintf(&buf, "id:                %s\n", info.ID)            //nolint:errcheck
+	fmt.Fprintf(&buf, "name:              %s\n", info.Name)          //nolint:errcheck
+	fmt.Fprintf(&buf, "owner:             %s\n", info.OwnerPK)       //nolint:errcheck
+	fmt.Fprintf(&buf, "port:              %d\n", info.Port)          //nolint:errcheck
+	fmt.Fprintf(&buf, "mode:              %s\n", info.Mode)          //nolint:errcheck
+	fmt.Fprintf(&buf, "role:              %s\n", info.Role)          //nolint:errcheck
+	fmt.Fprintf(&buf, "status:            %s\n", info.Status)        //nolint:errcheck
+	fmt.Fprintf(&buf, "created_at:        %s\n", info.CreatedAt.UTC().Format(time.RFC3339))  //nolint:errcheck
+	fmt.Fprintf(&buf, "joined_at:         %s\n", info.JoinedAt.UTC().Format(time.RFC3339))   //nolint:errcheck
+	fmt.Fprintf(&buf, "last_message_at:   %s\n", last)               //nolint:errcheck
+	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive) //nolint:errcheck
+	fmt.Fprintf(&buf, "members (%d):\n", len(info.Members))          //nolint:errcheck
+	for _, pk := range info.Members {
+		fmt.Fprintf(&buf, "  %s\n", pk) //nolint:errcheck
+	}
+	if len(info.Admins) > 0 {
+		fmt.Fprintf(&buf, "admins (%d):\n", len(info.Admins)) //nolint:errcheck
+		for _, pk := range info.Admins {
+			fmt.Fprintf(&buf, "  %s\n", pk) //nolint:errcheck
+		}
+	}
+	if len(info.PeerLastInbound) > 0 {
+		fmt.Fprintf(&buf, "peer_last_inbound (%d):\n", len(info.PeerLastInbound)) //nolint:errcheck
+		w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "  PEER\tLAST_INBOUND\tAGE") //nolint:errcheck
+		now := time.Now().UTC()
+		for pk, ts := range info.PeerLastInbound {
+			when := "never"
+			age := "-"
+			if !ts.IsZero() {
+				when = ts.UTC().Format(time.RFC3339)
+				age = now.Sub(ts.UTC()).Truncate(time.Second).String()
+			}
+			fmt.Fprintf(w, "  %s\t%s\t%s\n", pk, when, age) //nolint:errcheck
+		}
+		_ = w.Flush() //nolint:errcheck
+	}
+	return buf.String()
 }
 
 var groupInviteCmd = &cobra.Command{

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -53,6 +53,16 @@ type GroupInfo struct {
 	// side. Populated by GroupList; left zero by other accessors that
 	// don't need it. See group.Manager.IsSubscriberAlive for semantics.
 	SubscriberAlive bool `json:"subscriber_alive"`
+
+	// PeerLastInbound is the per-peer last-inbound time, keyed by
+	// peer-PK hex. Populated by GroupList and GroupGet alongside
+	// SubscriberAlive. A zero time means the peerSub for that peer
+	// is connecting, silent since startup, or (legacy s.sub path)
+	// not individually tracked. Empty map for owner-role sessions
+	// that don't follow peer feeds. Operator-facing: lets `cli
+	// skychat group info` show which specific peer is stale in a
+	// group whose session-level SubscriberAlive is otherwise true.
+	PeerLastInbound map[string]time.Time `json:"peer_last_inbound,omitempty"`
 }
 
 // GroupMessage is one inbound message delivered through the visor's
@@ -152,6 +162,7 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 	for _, r := range all {
 		info := toInfo(r)
 		info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
+		info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 		out = append(out, info)
 	}
 	return out, nil
@@ -183,7 +194,24 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	}
 	info := toInfo(r)
 	info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
+	info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 	return info, nil
+}
+
+// peerLivenessHex converts the cipher-keyed Manager.PeerLiveness map
+// into a hex-keyed JSON-friendly map. Returns nil when the input map
+// is empty so the JSON omitempty tag drops the field entirely for
+// records with no peer-level telemetry (e.g. owner-role sessions, or
+// when no live session exists).
+func peerLivenessHex(in map[cipher.PubKey]time.Time) map[string]time.Time {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]time.Time, len(in))
+	for pk, ts := range in {
+		out[pk.Hex()] = ts
+	}
+	return out
 }
 
 // GroupInvite returns a freshly-encoded invite link for an


### PR DESCRIPTION
## Summary
Per @Beta-agent's review on #2628 — \`cli skychat group info\` previously dumped raw JSON regardless of \`--json\` flag. This renders a labeled summary by default with a per-peer last-inbound table when \`peer_last_inbound\` has entries.

\`\`\`
id:                72afa409-8b2e-4323-aa1e-8be57f30ebd5
name:              claude-coordination
owner:             0323272a...
port:              63225
mode:              public
role:              owner
status:            active
created_at:        2026-05-12T19:56:12Z
joined_at:         2026-05-12T19:56:12Z
last_message_at:   2026-05-16T02:57:16Z
subscriber_alive:  true
members (4):
  0323272a...
  02f9aa58...
  03d1d78e...
  027087fe40...
admins (3):
  0323272a...
  02f9aa58...
  03d1d78e...
peer_last_inbound (3):
  PEER          LAST_INBOUND          AGE
  02f9aa58...   2026-05-16T02:56:26Z  3m12s
  03d1d78e...   2026-05-16T02:52:48Z  6m50s
  027087fe40... never                 -
\`\`\`

A zero time renders as \"never\" rather than the Go epoch — important for the \"subscriber up, this specific peer is silent\" diagnostic that motivated #2628, where the absent-row-vs-zero-row distinction makes the difference between \"peer never tracked\" and \"peer tracked but never received.\"

JSON path stays unchanged: \`--json\` flag still dumps the structured object.

## Test plan
- [x] \`go build ./cmd/skywire-cli/...\` clean
- [x] \`go vet ./cmd/skywire-cli/...\` clean
- [ ] In-prod: \`skywire cli skychat group info <id>\` shows the table when at least one peer has a peerSub tracked

## Stacking
- Depends on #2628 (which adds the GroupInfo.PeerLastInbound field)
- No behavior change when peer_last_inbound is empty (owner sessions, or sessions with no peerSubs at all)