### PR TITLE
fix(skychat/group): replay backlog on streaming reconnect

### DIFF
--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -341,6 +341,29 @@ func (a *visorPingAdapter) SubscribeGroupMessages(capacity int) (<-chan rpcgrpc.
 	return out, cancel
 }
 
+// SnapshotGroupMessagesAfterNs bridges Visor.SnapshotGroupMessagesAfter
+// (time.Time arg, returns []GroupMessage) into rpcgrpc's import-cycle-
+// safe shape (UnixNano arg, returns []GroupMessageData). Empty slice
+// when grouping isn't initialized — matches the SubscribeGroupMessages
+// (nil channel) convention.
+func (a *visorPingAdapter) SnapshotGroupMessagesAfterNs(sinceNs int64) []rpcgrpc.GroupMessageData {
+	since := time.Unix(0, sinceNs)
+	src := a.v.SnapshotGroupMessagesAfter(since)
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]rpcgrpc.GroupMessageData, 0, len(src))
+	for _, m := range src {
+		out = append(out, rpcgrpc.GroupMessageData{
+			TimestampNs: m.TS.UnixNano(),
+			GroupID:     m.GroupID,
+			SenderPK:    m.SenderPK.Hex(),
+			Body:        m.Text,
+		})
+	}
+	return out
+}
+
 func (a *visorPingAdapter) LocalPK() cipher.PubKey {
 	return a.v.LocalPK()
 }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -60,6 +60,14 @@ type VisorAPI interface {
 	// Returns (nil, no-op) when grouping is not yet initialized on
 	// the visor or running in a test harness.
 	SubscribeGroupMessages(capacity int) (<-chan GroupMessageData, func() uint64)
+	// SnapshotGroupMessagesAfterNs returns inbox-buffered group
+	// messages with TS > sinceNs (UnixNano). Used by
+	// StreamGroupMessages to replay events that landed during a
+	// client's reconnect gap before entering the live dispatch loop.
+	// Empty slice when grouping is uninitialized; bounded by the
+	// inbox ring capacity (long disconnect → only the tail is
+	// recoverable).
+	SnapshotGroupMessagesAfterNs(sinceNs int64) []GroupMessageData
 	// LocalPK returns the visor's own public key. Used by route-calc
 	// gRPC handlers that default the src PK to the local visor.
 	LocalPK() cipher.PubKey
@@ -1014,17 +1022,22 @@ func (s *PingServer) StreamRemoteSystemStats(req *RemoteSystemStatsRequest, stre
 // pattern is exactly what this RPC was added to escape).
 //
 // Sequence:
-//  1. Register the subscription on the inbox (bounded buffer).
+//  1. Register the subscription on the inbox (bounded buffer). This
+//     happens BEFORE the backlog snapshot — any message arriving
+//     during the snapshot read is captured by the live channel and
+//     deduped against the backlog via lastSentNs.
 //  2. Send a Subscribed sentinel so the client can confirm the stream
 //     is live before downstream actions (mirrors the AppLogStream
 //     pattern; lets the CLI gate Ctrl+C handler installation, etc.).
-//  3. If req.SinceTimestampNs > 0, drain backlog from a one-shot
-//     GroupPoll-style call via the existing inbox snapshot — NOT done
-//     here yet; the simplest live-only path is enough for the v1 CLI
-//     replacement. Backlog replay is a follow-up (handler would need
-//     a SnapshotAfter accessor on the adapter).
+//  3. If req.SinceTimestampNs > 0, drain inbox-buffered messages with
+//     TS > since via SnapshotGroupMessagesAfterNs. Each replayed
+//     message bumps lastSentNs so the same message arriving on the
+//     live channel (the subscribe/snapshot race window) is suppressed.
+//     Bounded by the inbox ring size (groupInboxCap) — a client
+//     disconnected longer than the ring turnover gets only the tail.
 //  4. Loop: select on stream.Context().Done() or the subscription
-//     channel; forward each message to the wire.
+//     channel; forward each message to the wire when m.TimestampNs >
+//     lastSentNs.
 //
 // Filter: req.GroupId, when set, scopes the stream to one group. Empty
 // matches every group the visor is in.
@@ -1053,6 +1066,36 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 		return err
 	}
 
+	// lastSentNs deduplicates between the backlog snapshot and the
+	// live channel for messages that landed in the
+	// subscribe-but-not-yet-read window. Initialized to the client's
+	// since cursor so old messages already seen on a prior stream
+	// are never re-emitted.
+	lastSentNs := req.SinceTimestampNs
+
+	// Backlog replay. Skips when client didn't pass a since (fresh
+	// listen — current behavior, only live messages).
+	if req.SinceTimestampNs > 0 {
+		backlog := s.visor.SnapshotGroupMessagesAfterNs(req.SinceTimestampNs)
+		for _, m := range backlog {
+			if req.GroupId != "" && m.GroupID != req.GroupId {
+				continue
+			}
+			if m.TimestampNs <= lastSentNs {
+				continue
+			}
+			if err := stream.Send(&GroupMessageEvent{
+				TimestampNs: m.TimestampNs,
+				GroupId:     m.GroupID,
+				SenderPk:    m.SenderPK,
+				Body:        m.Body,
+			}); err != nil {
+				return err
+			}
+			lastSentNs = m.TimestampNs
+		}
+	}
+
 	for {
 		select {
 		case <-stream.Context().Done():
@@ -1067,6 +1110,14 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 			if req.GroupId != "" && m.GroupID != req.GroupId {
 				continue
 			}
+			// Dedup against the backlog replay above. A message
+			// landing in the inbox during the subscribe-but-not-yet-
+			// snapshot window is delivered on the live channel AND
+			// captured in the snapshot; lastSentNs ensures it goes
+			// out exactly once.
+			if m.TimestampNs <= lastSentNs {
+				continue
+			}
 			if err := stream.Send(&GroupMessageEvent{
 				TimestampNs: m.TimestampNs,
 				GroupId:     m.GroupID,
@@ -1075,6 +1126,7 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 			}); err != nil {
 				return err
 			}
+			lastSentNs = m.TimestampNs
 		}
 	}
 }

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -845,8 +845,9 @@ func (v *Visor) SubscribeLogs(f logging.Filter, capacity int) (<-chan *logrus.En
 // Powers the gRPC StreamGroupMessages handler — the long-lived
 // streaming replacement for the net/rpc GroupPoll loop. Backlog
 // (messages already buffered in the ring at subscribe time) is NOT
-// replayed; callers that want that should call GroupPoll with a
-// since-timestamp before subscribing.
+// replayed by this method; callers that want that should call
+// SnapshotGroupMessagesAfter alongside Subscribe (the streaming
+// handler does exactly that to replay missed events on reconnect).
 //
 // Returns nil channel + a no-op cancel when grouping is disabled on
 // this visor (e.g. early init or tests).
@@ -862,6 +863,27 @@ func (v *Visor) SubscribeGroupMessages(capacity int) (<-chan GroupMessage, func(
 		inbox.unsubscribe(sub)
 		return sub.dropCount.Load()
 	}
+}
+
+// SnapshotGroupMessagesAfter returns the ring-buffered group inbox
+// snapshot of messages with TS > since. Used by the gRPC streaming
+// handler to replay events that landed during a client's reconnect
+// window — the CLI tracks the last-seen timestamp and the server
+// drains anything newer from the buffer before entering the live
+// dispatch loop. Returns nil when grouping is disabled.
+//
+// Buffer size bounds the replay depth; see groupInboxCap. A client
+// that's been disconnected longer than the buffer turnover will see
+// only the most recent groupInboxCap messages, not the full gap.
+// Same limitation as PairPoll/snapshotAfter.
+func (v *Visor) SnapshotGroupMessagesAfter(since time.Time) []GroupMessage {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return nil
+	}
+	return inbox.snapshotAfter(since)
 }
 
 // tpDiscClient is a convenience function to obtain transport discovery client.


### PR DESCRIPTION
## Summary
\`cli skychat group listen\` already tracks last-seen timestamp and passes it as \`since_ns\` on reconnect, but the gRPC server handler ignored it — only the live dispatch loop ran. Messages that landed during the client's reconnect gap were silently dropped.

This PR makes the server-side replay the inbox-buffered backlog before entering the live loop.

## Why
Hit during 3-agent group-chat coordination this week. Peer's listener task timed out during an 8-hour idle gap. Their visor's subscriber kept receiving messages cleanly (\`subscriber_alive=true\`, \`last_message_at\` advancing). But when the CLI consumer reconnected, the new stream resumed live-only — every message that landed during the listener gap was silently dropped. Operator had to manually relay messages between agents to make coordination work.

This is the bug Beta flagged at 03:05Z (\"the cli's reconnect+resume should backfill missed lines\"), and the root cause of \"\`subscriber_alive=true\` but agent didn't see the message until user nudged.\"

## Implementation
- New \`Visor.SnapshotGroupMessagesAfter(since)\` accessor exposes the existing \`inbox.snapshotAfter\` helper.
- \`VisorAPI.SnapshotGroupMessagesAfterNs\` adds the cycle-safe \`rpcgrpc\` bridge; \`visorPingAdapter\` implements the conversion.
- \`StreamGroupMessages\`: register live subscription **first** (so any message arriving during the snapshot read is captured by the live channel), **then** drain the backlog snapshot, **then** enter the live loop. Track \`lastSentNs\` across both phases to dedupe the subscribe-but-not-yet-snapshot race.

## Bounds
Replay is bounded by the inbox ring capacity (\`groupInboxCap\`, currently the same as PairPoll's bound). Long disconnects recover only the tail; full-gap replay (e.g. days offline) would need persisted history with seq-anchored replay (deferred — that's the broader history-replay-on-reconnect architectural item I owe).

## Test plan
- [x] \`go build ./pkg/visor/... ./cmd/skywire-cli/...\` clean
- [x] \`go test ./pkg/visor/...\` all green
- [ ] In-prod: kill+restart a CLI \`group listen\` while peers are sending; confirm post-reconnect output includes the messages that landed during the gap

## Related
- Stacks on develop; not blocked by other PRs
- Beta flagged this gap at 2026-05-16T03:05Z
- This is the \"reliable group chat by morning\" piece that was missing — without it, \`subscriber_alive=true\` doesn't translate to \"agent saw the message\"