### PR TITLE
chore(skychat/group): pin strict-> snapshot contract + add replay debug log

### DIFF
--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -1077,6 +1077,13 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 	// listen — current behavior, only live messages).
 	if req.SinceTimestampNs > 0 {
 		backlog := s.visor.SnapshotGroupMessagesAfterNs(req.SinceTimestampNs)
+		// Diagnostic log: an empty backlog (len == 0) is ambiguous
+		// without it — either nothing landed since the cursor, OR
+		// the disconnect outlasted the ring-buffer turnover. Operators
+		// staring at a "quiet" group post-reconnect need to tell
+		// those cases apart from the log.
+		s.log.Debugf("gRPC StreamGroupMessages: replay since_ns=%d returned=%d messages (groupInboxCap bounds long-disconnect recovery)",
+			req.SinceTimestampNs, len(backlog))
 		for _, m := range backlog {
 			if req.GroupId != "" && m.GroupID != req.GroupId {
 				continue

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -872,6 +872,11 @@ func (v *Visor) SubscribeGroupMessages(capacity int) (<-chan GroupMessage, func(
 // drains anything newer from the buffer before entering the live
 // dispatch loop. Returns nil when grouping is disabled.
 //
+// Filter contract: strict greater-than (TS > since). The streaming
+// handler's lastSentNs dedup assumes this — a >= filter would
+// quietly reintroduce duplicate cursor-message delivery. Do not
+// relax to >= without auditing every caller.
+//
 // Buffer size bounds the replay depth; see groupInboxCap. A client
 // that's been disconnected longer than the buffer turnover will see
 // only the most recent groupInboxCap messages, not the full gap.


### PR DESCRIPTION
## Summary
Two operability follow-ups from @Beta-agent's post-merge review of #2630.

**(1) Pin strict-\`>\` contract on \`SnapshotGroupMessagesAfter\`.** The streaming handler's \`lastSentNs\` dedup assumes the snapshot uses strict greater-than (TS > since), not \`>=\`. A future refactor to \`>=\` would quietly reintroduce duplicate cursor-message delivery on every reconnect. Spell the contract out in the doc comment so the constraint travels with the function.

**(2) Add debug log for replay start.** An empty backlog from \`SnapshotGroupMessagesAfterNs\` is ambiguous without telemetry — either nothing landed since the cursor, or the disconnect outlasted the \`groupInboxCap\` ring-buffer turnover. Operators staring at a quiet group post-reconnect need to tell those cases apart. One debug log line at replay-start fixes it.

\`\`\`
gRPC StreamGroupMessages: replay since_ns=<N> returned=<N> messages (groupInboxCap bounds long-disconnect recovery)
\`\`\`

## Test plan
- [x] \`go build ./pkg/visor/... ./cmd/skywire-cli/...\` clean
- [x] \`go test ./pkg/visor/...\` all green
- Behavior-only change to comments + one debug-level log; no semantic change to delivery logic

## Stacking
- Sits on top of merged #2630
- No conflicts with #2627 follow-ups (different surface)