### PR TITLE
fix(skychat/group): clear per-peer reconnect state on roster eviction

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -379,7 +379,16 @@ func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {
 	sess, live := m.sessions[id]
 	m.mu.RUnlock()
 	if live {
-		_ = sess.SetAllowlist(r.Members) //nolint:errcheck
+		// AddMember is additive so evicted is typically empty here,
+		// but route the result through peerReconnectClear anyway so
+		// the cleanup invariant holds uniformly for every code path
+		// that calls SetAllowlist — a future RemoveMember (or any
+		// caller that shrinks the allowlist) gets the per-peer
+		// backoff state dropped automatically.
+		evicted, _ := sess.SetAllowlist(r.Members) //nolint:errcheck
+		for _, pk := range evicted {
+			m.peerReconnectClear(id, pk)
+		}
 	}
 	return r, nil
 }

--- a/cmd/apps/skychat/group/roster_evict_clear_test.go
+++ b/cmd/apps/skychat/group/roster_evict_clear_test.go
@@ -1,0 +1,75 @@
+// Package group — cmd/apps/skychat/group/roster_evict_clear_test.go:
+// targeted coverage for the per-peer reconnect state cleanup on
+// roster eviction added as a follow-up to PR #2627. Pre-fix,
+// Session.SetAllowlist tore down evicted peerSubs but the parallel
+// Manager.peerReconnectState entry for that (id, peer) lingered
+// until session close — a subsequent re-add picked up a stale
+// backoff window that suppressed reconnects to the freshly-created
+// peerSub. The new SetAllowlist signature returns evicted PKs so
+// the Manager can clear those entries in lockstep.
+//
+// Full CXO/Session integration tests live in the manual E2E plan
+// (same convention as the rest of this package's tests); these
+// exercise the Manager-side cleanup contract in isolation.
+package group
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestPeerReconnectClearOnRosterEvictionLetsReAddReconnect(t *testing.T) {
+	// Force per-peer backoff state for a peer, then clear via the
+	// eviction hook. The next shouldAttempt must return true — a
+	// freshly re-added peerSub should not inherit the old backoff
+	// window. This is the regression that pre-PR could happen if a
+	// member was removed-then-re-added: the old per-peer state would
+	// keep suppressing reconnect attempts to the fresh peerSub for
+	// up to reconnectBackoffInterval2 (30min).
+	m := newPeerBackoffTestManager(t)
+	pk, _ := cipher.GenerateKeyPair()
+	id := "group-evict-test"
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.peerReconnectRecordFailure(id, pk, errors.New("force-state"))
+	}
+	now := time.Now().UTC()
+	if m.peerReconnectShouldAttempt(id, pk, now) {
+		t.Fatalf("test setup: expected backoff engaged for evict-test peer")
+	}
+	// Eviction path — what Manager.AddMember (and any future
+	// RemoveMember) does after SetAllowlist returns a non-empty
+	// evicted slice.
+	m.peerReconnectClear(id, pk)
+	if !m.peerReconnectShouldAttempt(id, pk, now) {
+		t.Errorf("after eviction clear, expected shouldAttempt=true (fresh backoff state)")
+	}
+}
+
+func TestPeerReconnectClearOneOfManyKeepsOthers(t *testing.T) {
+	// Eviction of one peer must not collateral-clear another peer's
+	// backoff state in the same group. The outer-map cleanup only
+	// fires when the inner map is empty (covered by
+	// TestPeerReconnectClearDropsState in per_peer_backoff_test.go).
+	m := newPeerBackoffTestManager(t)
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	id := "group-evict-test"
+	for i := uint32(0); i < reconnectBackoffFailures1; i++ {
+		m.peerReconnectRecordFailure(id, a, errors.New("force-state"))
+		m.peerReconnectRecordFailure(id, b, errors.New("force-state"))
+	}
+	m.peerReconnectClear(id, a)
+	now := time.Now().UTC()
+	if !m.peerReconnectShouldAttempt(id, a, now) {
+		t.Errorf("after evicting a, expected a-state cleared (shouldAttempt=true)")
+	}
+	if m.peerReconnectShouldAttempt(id, b, now) {
+		t.Errorf("after evicting a, expected b-state preserved (shouldAttempt=false in backoff)")
+	}
+	if _, ok := m.peerReconnectState[id]; !ok {
+		t.Errorf("outer-map should still contain id while other peers remain")
+	}
+}

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1196,6 +1196,9 @@ func (s *Session) Send(text string) error {
 // SetAllowlist updates the publisher's subscriber allowlist AND the
 // owner-side relay-gate's view of the member set, both live. Owner-
 // side only. Used when an invite is issued or a member is removed.
+// Returns the list of peers whose peerSubs were torn down — the
+// caller (Manager) is responsible for clearing any state keyed by
+// (group ID, peer PK), e.g. the per-peer reconnect backoff map.
 //
 // Two gates that both need refreshing:
 //
@@ -1212,9 +1215,9 @@ func (s *Session) Send(text string) error {
 // Visible symptom: member sends silently dropped on the owner; the
 // member's local Record.Members showing the original allowlist while
 // the owner had since added more peers.
-func (s *Session) SetAllowlist(members []cipher.PubKey) error {
+func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error) {
 	if s.pub == nil || s.cfg.Record.Role != RoleOwner {
-		return errors.New("group: SetAllowlist: only owner-role sessions have an allowlist")
+		return nil, errors.New("group: SetAllowlist: only owner-role sessions have an allowlist")
 	}
 	snap := append([]cipher.PubKey(nil), members...)
 	s.pub.SetAllowlist(append([]cipher.PubKey(nil), members...))
@@ -1232,6 +1235,16 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 		}
 		desired[pk] = struct{}{}
 	}
+	// evicted tracks peers whose peerSubs we just tore down; returned
+	// to the caller so Manager state keyed by (id, peerPK) — the
+	// per-peer reconnect backoff map in particular — can be cleaned
+	// up alongside the session-side eviction. Without this, evicted
+	// peers' backoff state could outlive its peerSub: harmless if
+	// the peer is never re-added (the entry just consumes a few bytes
+	// until session close), confusing if the same peer is later
+	// re-added because the stale backoff window suppresses reconnect
+	// attempts to a fresh peerSub.
+	var evicted []cipher.PubKey
 	s.peerSubsMu.Lock()
 	// Drop removed peers — close their subs while still holding the
 	// lock so a racing Connect doesn't pick up a half-torn sub.
@@ -1240,6 +1253,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 			_ = ps.Close() //nolint:errcheck,gosec
 			delete(s.peerSubs, pk)
 			delete(s.peerLastInboundNs, pk)
+			evicted = append(evicted, pk)
 		}
 	}
 	// Add new peers.
@@ -1268,7 +1282,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) error {
 		s.peerSubs[pk] = ps
 	}
 	s.peerSubsMu.Unlock()
-	return nil
+	return evicted, nil
 }
 
 // Close tears down the subscriber + publisher (and the underlying


### PR DESCRIPTION
Follow-up to #2627 (Beta's review nit).

## Why

#2627 added per-(group, peer) reconnect backoff. `Session.SetAllowlist` tears down evicted peerSubs but the parallel `Manager.peerReconnectState[id][peer]` entry lingered until session close. Harmless if the evicted peer is never re-added; on remove-then-re-add the fresh peerSub inherits the previous backoff window — up to 30min of suppressed reconnect attempts to a brand-new subscriber. Visible symptom would be _\"I just re-added this peer and their messages aren't reaching me for ages.\"_

## Wiring

- `Session.SetAllowlist(members) error` → `(evicted []cipher.PubKey, error)`. Behavior unchanged otherwise; the slice is the set of PKs whose peerSubs were closed in the eviction loop.

- `Manager.AddMember` (the only existing caller) routes the returned evicted list through `m.peerReconnectClear(id, pk)`. AddMember is additive today so the slice is empty in steady state, but the invariant holds for any future caller that shrinks the allowlist (RemoveMember, owner-side member-set re-sync from gossip, etc.).

## Re-add side handled implicitly

The \"roster-re-add\" nit Beta also flagged is covered by this same cleanup: once eviction clears the per-peer state, a subsequent SetAllowlist that re-adds the same PK creates a fresh peerSub (with a fresh `peerLastInboundNs` entry) and the next reconnect attempt sees `shouldAttempt=true` with zero failures recorded.

## Tests

`roster_evict_clear_test.go`:
- `TestPeerReconnectClearOnRosterEvictionLetsReAddReconnect` — forces backoff state for a peer, calls `peerReconnectClear` (what AddMember's eviction loop does), confirms next `shouldAttempt` is true.
- `TestPeerReconnectClearOneOfManyKeepsOthers` — eviction of one peer must not collateral-clear another peer's backoff state in the same group; outer-map entry stays present while other peers remain.

`go test -race -count=1 ./cmd/apps/skychat/group/...` clean. `go vet` clean. `gofmt -l` clean.

## Out of scope

- A `Manager.RemoveMember` API. Not added because nothing's calling for it yet.
- E2E test for the actual `SetAllowlist` eviction in a live CXO session — same convention as the rest of `group/`'s tests.