### PR TITLE
feat(hv): nested-visor tree API + cli hv tree command (backend half)

### DIFF
--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -36,6 +36,7 @@ func init() {
 	hvCmd.AddCommand(hvStatusCmd)
 	hvCmd.AddCommand(hvAddCmd)
 	hvCmd.AddCommand(hvLsCmd)
+	hvCmd.AddCommand(hvTreeCmd)
 }
 
 var hvCmd = &cobra.Command{
@@ -255,5 +256,92 @@ transport count, and other details. The local visor is shown first.`,
 		}
 		tw.Flush() //nolint:errcheck,gosec
 		internal.PrintOutput(cmd.Flags(), entries, buf.String())
+	},
+}
+
+var hvTreeCmd = &cobra.Command{
+	Use:   "tree",
+	Short: "Tree view of visors per hypervisor (local + direct sub-hypervisors)",
+	Long: `Render the hypervisor structure as one section per hypervisor.
+
+The local hypervisor appears first with its directly-connected visors.
+Each sub-hypervisor connected to the local one appears as its own
+section with a chain breadcrumb and that hypervisor's directly-
+connected visors. A visor connected to multiple hypervisors will
+appear in every relevant section by design.
+
+Walks one level (local + direct sub-hypervisors). Sections dedup by
+hypervisor PK; a sub-hypervisor reachable via two paths renders once.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		tree, err := rpcClient.HVListVisorsTree()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to list visors tree: %w", err))
+		}
+
+		var buf strings.Builder
+		for sectionIdx, section := range tree.Sections {
+			if sectionIdx > 0 {
+				// Print breadcrumb chain for sub-hypervisors —
+				// ascii-tree style so the structure is obvious in
+				// plain terminals without needing UTF-8 box chars.
+				buf.WriteString("\n")
+				for chainIdx, chainPK := range section.ViaChain {
+					prefix := strings.Repeat("    ", chainIdx)
+					buf.WriteString(prefix + chainPK.String() + "\n")
+				}
+				prefix := strings.Repeat("    ", len(section.ViaChain)-1) + "└── "
+				buf.WriteString(prefix + section.HypervisorPK.String() + "\n")
+			} else {
+				buf.WriteString(section.HypervisorPK.String() + "\n")
+			}
+			if section.SubError != "" {
+				buf.WriteString("  (sub-hypervisor query error: " + section.SubError + ")\n")
+				continue
+			}
+			if len(section.Visors) == 0 {
+				buf.WriteString("  (no visors)\n")
+				continue
+			}
+			tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "  PK\tVERSION\tUPTIME\tTP\tAPPS\tIP\tCC\tSTATUS") //nolint:errcheck
+			for _, e := range section.Visors {
+				pk := e.PK.String()
+				status := "ok"
+				if e.IsLocal {
+					status = "local"
+				}
+				if e.Error != "" {
+					status = e.Error
+					if len(status) > 25 {
+						status = status[:25] + "..."
+					}
+				}
+				ver := e.Version
+				if ver == "" {
+					ver = "-"
+				}
+				uptime := "-"
+				if e.Uptime > 0 {
+					uptime = (time.Duration(e.Uptime) * time.Second).Truncate(time.Second).String()
+				}
+				ip := e.PublicIP
+				if ip == "" {
+					ip = "-"
+				}
+				cc := e.CountryCode
+				if cc == "" {
+					cc = "-"
+				}
+				fmt.Fprintf(tw, "  %s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\n", //nolint:errcheck
+					pk, ver, uptime, e.Transports, e.Apps, ip, cc, status)
+			}
+			tw.Flush() //nolint:errcheck,gosec
+		}
+		internal.PrintOutput(cmd.Flags(), tree, buf.String())
 	},
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -302,6 +302,8 @@ type API interface {
 	ARSelfInfo() (*ARSelfRegistration, error)
 	TransportRPCCall(remotePK cipher.PubKey, method string, args json.RawMessage) (json.RawMessage, error)
 	HVListVisors() ([]HVVisorEntry, error)
+	HVListDirectVisors() ([]HVVisorEntry, error)
+	HVListVisorsTree() (*HVVisorTree, error)
 	HVVisorSummary(pk cipher.PubKey) (*Summary, error)
 	HVStartApp(pk cipher.PubKey, appName string) error
 	HVStopApp(pk cipher.PubKey, appName string) error

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -519,6 +519,7 @@ func (hv *Hypervisor) makeMux() chi.Router {
 				r.Get("/lan-dmsg-server", hv.getLANDmsgServer())
 				r.Get("/visors", hv.getVisors())
 				r.Get("/visors-summary", hv.getAllVisorsSummary())
+				r.Get("/visors-tree-summary", hv.getVisorsTreeSummary())
 				r.Get("/network-view", hv.getNetworkView())
 				r.Get("/reward-rules", hv.getRewardRules())
 				r.Get("/visors/{pk}", hv.getVisor())

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -2,10 +2,13 @@
 package visor
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
@@ -73,6 +76,219 @@ func (hv *Hypervisor) getVisors() http.HandlerFunc {
 
 		httputil.WriteJSON(w, r, http.StatusOK, overviews)
 	}
+}
+
+// VisorTreeSection is one hypervisor's section in the tree response.
+// Same shape as HVVisorTreeNode in the visor RPC, but rehydrates each
+// HVVisorEntry into the richer Summary the UI's table already knows
+// how to render. Visor entries replicate across sections by design;
+// sections themselves dedup.
+type VisorTreeSection struct {
+	HypervisorPK cipher.PubKey   `json:"hypervisor_pk"`
+	ViaChain     []cipher.PubKey `json:"via_chain,omitempty"`
+	Visors       []Summary       `json:"visors"`
+	SubError     string          `json:"sub_error,omitempty"`
+}
+
+// VisorTreeResponse wraps the tree sections for the UI's main node
+// list endpoint.
+type VisorTreeResponse struct {
+	Sections []VisorTreeSection `json:"sections"`
+}
+
+// getVisorsTreeSummary returns the structured tree of hypervisor
+// sections for the UI's main node list. The local hypervisor's
+// section is built using the existing getAllVisorsSummary path (with
+// the summary cache + dead-visor cleanup) so the local table renders
+// identically to today. Sub-hypervisor sections query each direct
+// remote hypervisor for its own direct visors via RPC.
+//
+// Visor entries replicate across sections when a visor is connected
+// to multiple hypervisors (intentional — every table shows every
+// visor directly connected to that hypervisor). Sections themselves
+// dedup by hypervisor PK.
+func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		localPK := hv.visor.conf.PK
+
+		// Build the local section by reusing the same Summary
+		// machinery as /visors-summary — same fields, same cache,
+		// same offline-row semantics.
+		localVisors := hv.collectLocalVisorSummaries()
+		sections := []VisorTreeSection{{
+			HypervisorPK: localPK,
+			ViaChain:     nil,
+			Visors:       localVisors,
+		}}
+
+		// Snapshot direct remotes for the sub-hypervisor walk. Each
+		// remote that's itself a hypervisor contributes a section;
+		// non-hypervisors are silently skipped (every visor in a
+		// deployment would otherwise show as a "this isn't a
+		// hypervisor" placeholder).
+		hv.mu.RLock()
+		type remote struct {
+			pk   cipher.PubKey
+			conn Conn
+		}
+		remotes := make([]remote, 0, len(hv.remoteVisors))
+		for pk, c := range hv.remoteVisors {
+			remotes = append(remotes, remote{pk, c})
+		}
+		hv.mu.RUnlock()
+
+		type subResult struct {
+			hyperPK cipher.PubKey
+			entries []HVVisorEntry
+			err     error
+		}
+		results := make([]subResult, len(remotes))
+		var wg sync.WaitGroup
+		wg.Add(len(remotes))
+		for i, e := range remotes {
+			go func(idx int, pk cipher.PubKey, api API) {
+				defer wg.Done()
+				done := make(chan struct {
+					vs  []HVVisorEntry
+					err error
+				}, 1)
+				go func() {
+					vs, err := api.HVListDirectVisors()
+					done <- struct {
+						vs  []HVVisorEntry
+						err error
+					}{vs, err}
+				}()
+				select {
+				case r := <-done:
+					results[idx] = subResult{pk, r.vs, r.err}
+				case <-time.After(10 * time.Second):
+					results[idx] = subResult{pk, nil, fmt.Errorf("timeout")}
+				}
+			}(i, e.pk, e.conn.API)
+		}
+		wg.Wait()
+
+		rendered := map[cipher.PubKey]bool{localPK: true}
+		for _, sr := range results {
+			if rendered[sr.hyperPK] {
+				continue
+			}
+			if sr.err != nil {
+				// Skip remotes that simply aren't hypervisors (the
+				// most common case — every plain visor in the
+				// deployment would otherwise show as a no-op error
+				// row in the tree).
+				es := sr.err.Error()
+				if es == "hypervisor not running" || es == "hypervisor not enabled" {
+					continue
+				}
+				rendered[sr.hyperPK] = true
+				sections = append(sections, VisorTreeSection{
+					HypervisorPK: sr.hyperPK,
+					ViaChain:     []cipher.PubKey{localPK},
+					SubError:     es,
+				})
+				continue
+			}
+			rendered[sr.hyperPK] = true
+			// Project HVVisorEntry → Summary so the UI's existing
+			// table renderer works identically across all sections.
+			// Sub-hypervisor visors don't carry the full Summary
+			// shape (health, dmsg stats, etc.) — those fields stay
+			// zero/empty. The basic fields the table cares about
+			// (PK, version, uptime, transports, apps, IP, country)
+			// come through populateEntryFromSummary on the remote
+			// side, here projected back.
+			visors := make([]Summary, 0, len(sr.entries))
+			for _, e := range sr.entries {
+				visors = append(visors, projectEntryToSummary(e))
+			}
+			sections = append(sections, VisorTreeSection{
+				HypervisorPK: sr.hyperPK,
+				ViaChain:     []cipher.PubKey{localPK},
+				Visors:       visors,
+			})
+		}
+
+		httputil.WriteJSON(w, r, http.StatusOK, VisorTreeResponse{Sections: sections})
+	}
+}
+
+// collectLocalVisorSummaries returns the Summary slice this
+// hypervisor's main node list shows, reusing the existing fetch /
+// cache / dead-visor cleanup logic. Extracted from
+// getAllVisorsSummary so the tree endpoint can build the local
+// section without duplicating that wiring.
+func (hv *Hypervisor) collectLocalVisorSummaries() []Summary {
+	// Reuse the existing handler's wire by serving it to a discard
+	// writer — keeps the cleanup + caching invariants intact. The
+	// summary set is small enough that the extra encode/decode is
+	// not a concern; alternative is a bigger refactor pulling the
+	// fetch logic into a shared helper.
+	rec := newBufferingResponseRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/visors-summary", nil) //nolint:errcheck
+	hv.getAllVisorsSummary()(rec, req)
+	var out []Summary
+	if err := rec.decode(&out); err != nil {
+		hv.logger.WithError(err).Warn("getVisorsTreeSummary: failed to decode local section")
+		return nil
+	}
+	return out
+}
+
+// projectEntryToSummary fills the Summary fields the main node list's
+// table consumes from an HVVisorEntry. Fields the table doesn't
+// render (health, dmsg stats, route group info, etc.) stay zero —
+// the UI's per-row code already guards on field presence (see
+// node.service.ts comments around "Offline rows from the hypervisor
+// cache still carry the visor's last-known fields").
+func projectEntryToSummary(e HVVisorEntry) Summary {
+	overview := &Overview{
+		PubKey:         e.PK,
+		LocalIP:        e.LocalIP,
+		PublicIP:       e.PublicIP,
+		CountryCode:    e.CountryCode,
+		IsSymmetricNAT: e.IsSymmetricNAT,
+		BuildInfo: &buildinfo.Info{
+			Version: e.Version,
+		},
+	}
+	return Summary{
+		Overview:      overview,
+		BuildTag:      e.BuildTag,
+		Uptime:        e.Uptime,
+		Online:        e.Online,
+		IsHypervisor:  false,
+		RewardAddress: e.RewardAddress,
+		ConfigVersion: e.ConfigVersion,
+	}
+}
+
+// bufferingResponseRecorder is a minimal http.ResponseWriter that
+// captures the body so collectLocalVisorSummaries can decode it.
+// Avoids pulling in net/http/httptest just for one internal call.
+type bufferingResponseRecorder struct {
+	hdr  http.Header
+	code int
+	body []byte
+}
+
+func newBufferingResponseRecorder() *bufferingResponseRecorder {
+	return &bufferingResponseRecorder{hdr: http.Header{}}
+}
+
+func (r *bufferingResponseRecorder) Header() http.Header        { return r.hdr }
+func (r *bufferingResponseRecorder) WriteHeader(code int)       { r.code = code }
+func (r *bufferingResponseRecorder) Write(b []byte) (int, error) {
+	r.body = append(r.body, b...)
+	return len(b), nil
+}
+func (r *bufferingResponseRecorder) decode(v interface{}) error {
+	if len(r.body) == 0 {
+		return fmt.Errorf("empty body")
+	}
+	return json.Unmarshal(r.body, v)
 }
 
 // provides overview of single visor.

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -278,8 +278,8 @@ func newBufferingResponseRecorder() *bufferingResponseRecorder {
 	return &bufferingResponseRecorder{hdr: http.Header{}}
 }
 
-func (r *bufferingResponseRecorder) Header() http.Header        { return r.hdr }
-func (r *bufferingResponseRecorder) WriteHeader(code int)       { r.code = code }
+func (r *bufferingResponseRecorder) Header() http.Header  { return r.hdr }
+func (r *bufferingResponseRecorder) WriteHeader(code int) { r.code = code }
 func (r *bufferingResponseRecorder) Write(b []byte) (int, error) {
 	r.body = append(r.body, b...)
 	return len(b), nil

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1597,6 +1597,26 @@ func (rc *rpcClient) HVListVisors() ([]HVVisorEntry, error) {
 	return out, nil
 }
 
+// HVListDirectVisors returns summaries of visors DIRECTLY connected
+// to this hypervisor (no sub-hypervisor merging).
+func (rc *rpcClient) HVListDirectVisors() ([]HVVisorEntry, error) {
+	var out []HVVisorEntry
+	if err := rc.Call("HVListDirectVisors", &struct{}{}, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// HVListVisorsTree returns the structured tree of hypervisor sections
+// (local + direct sub-hypervisors, depth 2).
+func (rc *rpcClient) HVListVisorsTree() (*HVVisorTree, error) {
+	var out HVVisorTree
+	if err := rc.Call("HVListVisorsTree", &struct{}{}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // HVVisorSummary returns a detailed summary of a specific remote visor.
 func (rc *rpcClient) HVVisorSummary(pk cipher.PubKey) (*Summary, error) {
 	var out Summary

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1350,6 +1350,16 @@ func (mc *mockRPCClient) HVListVisors() ([]HVVisorEntry, error) {
 	return nil, fmt.Errorf("not supported in mock")
 }
 
+// HVListDirectVisors implements API.
+func (mc *mockRPCClient) HVListDirectVisors() ([]HVVisorEntry, error) {
+	return nil, fmt.Errorf("not supported in mock")
+}
+
+// HVListVisorsTree implements API.
+func (mc *mockRPCClient) HVListVisorsTree() (*HVVisorTree, error) {
+	return nil, fmt.Errorf("not supported in mock")
+}
+
 // HVVisorSummary implements API.
 func (mc *mockRPCClient) HVVisorSummary(_ cipher.PubKey) (*Summary, error) {
 	return nil, fmt.Errorf("not supported in mock")

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -55,6 +55,73 @@ func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
 	entry.RewardAddress = summary.RewardAddress
 }
 
+// HVListDirectVisors returns summaries of visors DIRECTLY connected to
+// this hypervisor — does NOT walk sub-hypervisors. Used by the tree
+// builder to query each sub-hypervisor's own direct visors without
+// pulling its already-flattened sub-merge.
+//
+// Local visor is included first (with IsLocal=true) when this visor
+// has the hypervisor flag enabled, matching HVListVisors's shape.
+func (v *Visor) HVListDirectVisors() ([]HVVisorEntry, error) {
+	if v.hvInstance == nil {
+		return nil, fmt.Errorf("hypervisor not running")
+	}
+	if !v.hvInstance.IsEnabled() {
+		return nil, fmt.Errorf("hypervisor not enabled")
+	}
+
+	hv := v.hvInstance
+	hv.mu.RLock()
+	type remote struct {
+		pk   cipher.PubKey
+		conn Conn
+	}
+	remotes := make([]remote, 0, len(hv.remoteVisors))
+	for pk, c := range hv.remoteVisors {
+		remotes = append(remotes, remote{pk, c})
+	}
+	hv.mu.RUnlock()
+
+	log := logging.MustGetLogger("hv_list_direct_visors")
+
+	results := make([]HVVisorEntry, len(remotes))
+	var wg sync.WaitGroup
+	wg.Add(len(remotes))
+	for i, e := range remotes {
+		go func(idx int, pk cipher.PubKey, api API) {
+			defer wg.Done()
+			entry := HVVisorEntry{PK: pk, Online: true}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				summary, err := api.Summary()
+				if err != nil {
+					entry.Error = err.Error()
+					return
+				}
+				populateEntryFromSummary(&entry, summary)
+			}()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				entry.Error = "timeout"
+				log.WithField("pk", pk.String()).Warn("HVListDirectVisors: visor query timed out")
+			}
+			results[idx] = entry
+		}(i, e.pk, e.conn.API)
+	}
+	wg.Wait()
+
+	if hv.visor != nil {
+		localEntry := HVVisorEntry{PK: v.conf.PK, Online: true, IsLocal: true}
+		if localSummary, err := v.Summary(); err == nil {
+			populateEntryFromSummary(&localEntry, localSummary)
+		}
+		results = append([]HVVisorEntry{localEntry}, results...)
+	}
+	return results, nil
+}
+
 // HVListVisors returns summaries of all visors connected to this hypervisor.
 func (v *Visor) HVListVisors() ([]HVVisorEntry, error) {
 	if v.hvInstance == nil {
@@ -140,6 +207,15 @@ func (v *Visor) HVListVisors() ([]HVVisorEntry, error) {
 			go func() {
 				sub, err := api.HVListVisors()
 				if err != nil {
+					// Errors swallowed silently here previously made
+					// "the feature didn't work" un-diagnosable from the
+					// caller's side. Most common reason: the remote
+					// isn't running as a hypervisor (`hv status:
+					// disabled`) and HVListVisors returns "hypervisor
+					// not enabled". Log so operators can see why a
+					// sub-hypervisor merge yielded nothing.
+					log.WithError(err).WithField("pk", hyperPK.String()).
+						Debug("HVListVisors: sub-hypervisor query failed (likely not a hypervisor)")
 					done <- nil
 					return
 				}
@@ -169,6 +245,177 @@ func (v *Visor) HVListVisors() ([]HVVisorEntry, error) {
 	}
 
 	return results, nil
+}
+
+// HVVisorTreeNode is one hypervisor's section in the tree response:
+// the hypervisor's PK, the chain of hypervisors from the local one
+// down to this one (empty for the local hypervisor itself), and the
+// visors directly connected to this hypervisor (NOT transitively
+// merged from any sub-hypervisors below it).
+//
+// Sub-hypervisors that fail to respond surface their error via the
+// SubError field instead of being silently dropped — the UI can
+// render a placeholder row with the error text, and operators can
+// tell "no sub-visors" from "query failed."
+type HVVisorTreeNode struct {
+	HypervisorPK cipher.PubKey   `json:"hypervisor_pk"`
+	ViaChain     []cipher.PubKey `json:"via_chain,omitempty"`
+	Visors       []HVVisorEntry  `json:"visors"`
+	SubError     string          `json:"sub_error,omitempty"`
+}
+
+// HVVisorTree is the structured response of HVListVisorsTree — a
+// flat list of hypervisor sections. The first entry is the local
+// hypervisor; subsequent entries are sub-hypervisors reachable from
+// it. Each section's `via_chain` documents the path from the local
+// hypervisor down to that sub-hypervisor, so the UI can render a
+// breadcrumb without recomputing.
+//
+// Visor entries replicate across sections: a visor V that's connected
+// to both the local hypervisor and a sub-hypervisor will appear in
+// BOTH sections — the semantics are "every table shows every visor
+// directly connected to that hypervisor," intentionally. Tables
+// themselves dedup: two paths to the same sub-hypervisor render once.
+type HVVisorTree struct {
+	Sections []HVVisorTreeNode `json:"sections"`
+}
+
+// HVListVisorsTree builds a tree-shaped response of every hypervisor
+// reachable from this one (local + direct sub-hypervisors only, depth
+// 2). Each section reports the visors DIRECTLY connected to that
+// hypervisor; cross-section dedup is the UI's job (visors with two
+// hypervisors appear in two sections by design).
+//
+// Cycle protection: tables dedup by hypervisor PK — if a sub-
+// hypervisor is reachable via two paths (e.g. via mutual hypervisor
+// pairs), its table renders once. Per-section query timeout (10s)
+// bounds wall time regardless of depth.
+//
+// Currently 1 level deep (local + direct sub-hypervisors). Walking
+// transitively to depth N would need a request-scoped visited-set
+// on the wire so each hop knows what NOT to recurse into;
+// out-of-scope for v1.
+func (v *Visor) HVListVisorsTree() (*HVVisorTree, error) {
+	if v.hvInstance == nil {
+		return nil, fmt.Errorf("hypervisor not running")
+	}
+	if !v.hvInstance.IsEnabled() {
+		return nil, fmt.Errorf("hypervisor not enabled")
+	}
+
+	localPK := v.conf.PK
+	localVisors, err := v.HVListDirectVisors()
+	if err != nil {
+		return nil, err
+	}
+
+	sections := []HVVisorTreeNode{
+		{
+			HypervisorPK: localPK,
+			ViaChain:     nil,
+			Visors:       localVisors,
+		},
+	}
+
+	hv := v.hvInstance
+	hv.mu.RLock()
+	type remote struct {
+		pk   cipher.PubKey
+		conn Conn
+	}
+	remotes := make([]remote, 0, len(hv.remoteVisors))
+	for pk, c := range hv.remoteVisors {
+		remotes = append(remotes, remote{pk, c})
+	}
+	hv.mu.RUnlock()
+
+	log := logging.MustGetLogger("hv_list_visors_tree")
+
+	// Query each direct remote's HVListDirectVisors in parallel; only
+	// remotes that respond successfully are themselves hypervisors and
+	// contribute a section. Remotes that error (not a hypervisor / not
+	// reachable) are skipped; the error gets logged for operators.
+	type subResult struct {
+		hyperPK cipher.PubKey
+		visors  []HVVisorEntry
+		err     error
+	}
+	results := make([]subResult, len(remotes))
+	var wg sync.WaitGroup
+	wg.Add(len(remotes))
+	for i, e := range remotes {
+		go func(idx int, hyperPK cipher.PubKey, api API) {
+			defer wg.Done()
+			done := make(chan struct {
+				vs  []HVVisorEntry
+				err error
+			}, 1)
+			go func() {
+				vs, err := api.HVListDirectVisors()
+				done <- struct {
+					vs  []HVVisorEntry
+					err error
+				}{vs, err}
+			}()
+			select {
+			case r := <-done:
+				results[idx] = subResult{hyperPK, r.vs, r.err}
+			case <-time.After(10 * time.Second):
+				log.WithField("pk", hyperPK.String()).Warn("HVListVisorsTree: sub-hypervisor query timed out")
+				results[idx] = subResult{hyperPK, nil, fmt.Errorf("timeout")}
+			}
+		}(i, e.pk, e.conn.API)
+	}
+	wg.Wait()
+
+	// Dedup sub-hypervisors by PK. The local hypervisor is already in
+	// `sections[0]`; sub-hypervisor PKs that match the local PK (the
+	// mutual-hypervisor case) are skipped — they'd render the same
+	// table the local section already has.
+	rendered := map[cipher.PubKey]bool{localPK: true}
+	for _, r := range results {
+		if rendered[r.hyperPK] {
+			continue
+		}
+		if r.err != nil {
+			// Sub query failed but we still want to render a section
+			// so operators see WHICH sub-hypervisor failed and how.
+			// Skip if the remote simply isn't a hypervisor (the most
+			// common case — "hypervisor not enabled") to avoid noise.
+			if isNotHypervisorErr(r.err) {
+				log.WithError(r.err).WithField("pk", r.hyperPK.String()).
+					Debug("HVListVisorsTree: skipping non-hypervisor remote")
+				continue
+			}
+			rendered[r.hyperPK] = true
+			sections = append(sections, HVVisorTreeNode{
+				HypervisorPK: r.hyperPK,
+				ViaChain:     []cipher.PubKey{localPK},
+				SubError:     r.err.Error(),
+			})
+			continue
+		}
+		rendered[r.hyperPK] = true
+		sections = append(sections, HVVisorTreeNode{
+			HypervisorPK: r.hyperPK,
+			ViaChain:     []cipher.PubKey{localPK},
+			Visors:       r.visors,
+		})
+	}
+
+	return &HVVisorTree{Sections: sections}, nil
+}
+
+// isNotHypervisorErr identifies the well-known "remote isn't running
+// as a hypervisor" errors from HVListDirectVisors, so we can quietly
+// skip those remotes from the tree (every visor in a deployment that
+// ISN'T also a hypervisor would otherwise show up as a SubError row).
+func isNotHypervisorErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return s == "hypervisor not running" || s == "hypervisor not enabled"
 }
 
 // HVVisorSummary returns detailed info about a specific remote visor.

--- a/pkg/visor/rpc_hypervisors.go
+++ b/pkg/visor/rpc_hypervisors.go
@@ -23,6 +23,39 @@ func (r *RPC) HVListVisors(_ *struct{}, out *[]HVVisorEntry) (err error) {
 	return nil
 }
 
+// HVListDirectVisors returns summaries of visors DIRECTLY connected
+// to this hypervisor (no sub-hypervisor merging). Powers the tree
+// builder's per-sub-hypervisor section.
+func (r *RPC) HVListDirectVisors(_ *struct{}, out *[]HVVisorEntry) (err error) {
+	defer rpcutil.LogCall(r.log, "HVListDirectVisors", nil)(out, &err)
+	v, ok := r.visor.(*Visor)
+	if !ok {
+		return fmt.Errorf("not a visor instance")
+	}
+	entries, lErr := v.HVListDirectVisors()
+	if lErr != nil {
+		return lErr
+	}
+	*out = entries
+	return nil
+}
+
+// HVListVisorsTree returns the structured tree of hypervisor sections
+// for the UI's main node list.
+func (r *RPC) HVListVisorsTree(_ *struct{}, out *HVVisorTree) (err error) {
+	defer rpcutil.LogCall(r.log, "HVListVisorsTree", nil)(out, &err)
+	v, ok := r.visor.(*Visor)
+	if !ok {
+		return fmt.Errorf("not a visor instance")
+	}
+	tree, tErr := v.HVListVisorsTree()
+	if tErr != nil {
+		return tErr
+	}
+	*out = *tree
+	return nil
+}
+
 // HVVisorSummary returns a detailed summary of a specific remote visor.
 func (r *RPC) HVVisorSummary(pk *cipher.PubKey, out *Summary) (err error) {
 	defer rpcutil.LogCall(r.log, "HVVisorSummary", pk)(out, &err)


### PR DESCRIPTION
## Summary
Backend half of the nested-hypervisor visibility feature. Operator running a chained-hypervisor setup (visor A is local hypervisor, visor B has A set as its remote-hypervisor AND B is itself a hypervisor for visors B1/B2) wants to see B1/B2 surface in A's UI labeled as "reachable via B." The existing \`HVListVisors\` flattens with dedup which loses the grouping; this adds a tree-shaped API that preserves it.

## API surface

- \`Visor.HVListDirectVisors() ([]HVVisorEntry, error)\` — like \`HVListVisors\` but skips the sub-hypervisor merge. Used by the tree builder to ask each sub-hypervisor for ONLY its direct visors.
- \`Visor.HVListVisorsTree() (*HVVisorTree, error)\` — structured response:

\`\`\`json
{
  "sections": [
    { "hypervisor_pk": "0323...", "visors": [...local + direct visors...] },
    { "hypervisor_pk": "0314...", "via_chain": ["0323..."], "visors": [...visors connected to 0314...] }
  ]
}
\`\`\`

- HTTP endpoint \`GET /api/visors-tree-summary\` returns the same shape projected into the \`Summary\` type the UI already renders. The frontend's existing per-row rendering keeps working unchanged.
- \`skywire cli visor hv tree\` CLI command for end-to-end verification:

\`\`\`
0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
  PK                        VERSION                                UPTIME    TP  APPS  IP            CC  STATUS
  0323272a...               v1.3.54-0.20260516010757-bb6126a8b5e7  1h28m     2   1     -             -   local
  ...

0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c
└── 031405306f8511d0227a198e7c9b32ad4885404ec6274ca0da05f88c52bbea86c4
  PK                        VERSION  UPTIME     TP  APPS  IP            CC  STATUS
  031405306f8511d0...       v1.3.53  32h58m48s  34  5     123.50.137.0  AU  local
\`\`\`

## Design decisions

- **Visor entries replicate across sections.** A visor connected to multiple hypervisors appears in every relevant section. Semantically each table shows every visor directly connected to that hypervisor — including the visor's "home" if dual-homed.
- **Sections dedup by hypervisor PK.** Mutual hypervisor pairs (A↔B) render the shared sub-hypervisor once.
- **Depth 1 only for v1.** Walking deeper would need a request-scoped visited-set parameter on the wire so each hop knows what NOT to recurse into. Data shape accommodates it; defer the impl.
- **Silent-error fix.** \`HVListVisors\` previously swallowed every sub-hypervisor query error (\`done <- nil\`), making "the merge yielded nothing" impossible to diagnose without strace. Now logged at Debug. ("not a hypervisor" is the most common cause — every plain visor would otherwise spam Warn.)
- **Sub-hypervisor Summary projection.** Sub-section visors carry \`HVVisorEntry\` fields projected into \`Summary\` (overview pk, build info, country, ip). The deeper \`Summary\` fields (health, dmsg stats, route group) stay zero — the UI already guards on field presence for offline cached rows; same code path covers it.

## Why
Operator added a remote visor (031405..., Australia) and set it up to have the local hypervisor as ITS remote hypervisor, expecting the Australia visor's visors to surface here. Didn't work — turned out the Australia visor IS hypervisor-enabled but had no visors connected to it (nothing to transit). Discovering THAT required adding logging; the existing path swallowed errors so even the diagnostic was invisible. This PR makes the structure visible and the error path debuggable.

## Test plan
- [x] \`go build ./pkg/visor/... ./cmd/skywire-cli/...\` clean
- [x] \`go test ./pkg/visor/...\` all green
- [x] Manual \`skywire cli visor hv tree\` — single-section output verified against current hypervisor
- [ ] In-prod verification after restart: add a sub-hypervisor with its own connected visors, confirm they surface in the second section

## Follow-up
- Frontend (Angular) PR — modify \`pages/node-list\` to render per-section tables with breadcrumbs. Title bar shows local hypervisor PK. Coming in a separate PR for review focus.
- Deeper recursion (depth >= 2) — defer; the wire shape accommodates a future visited-set param.