### PR TITLE
fix(visor): bound --dmsg-server startup + support pk@host:port form

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -25,7 +26,10 @@ var (
 	// ErrPortAlreadyBound is being returned when the desired port is already bound to.
 	ErrPortAlreadyBound = errors.New("port already bound")
 	// ErrClosedConn is being returned when we are listening on a closed connection.
-	ErrClosedConn = errors.New("listening on closed connection")
+	// Wraps net.ErrClosed so generic accept loops that check the standard
+	// sentinel (e.g. dmsgctrl.ServeListener) recognize this as terminal
+	// instead of spin-logging on shutdown.
+	ErrClosedConn = fmt.Errorf("listening on closed connection: %w", net.ErrClosed)
 )
 
 // SkywireNetworker implements `Networker` for skynet.

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -111,6 +111,12 @@ type Client struct {
 	LookupHTTPHits   atomic.Int64 // resolved from HTTP discovery
 	LookupHTTPMisses atomic.Int64 // HTTP discovery returned not found
 
+	// pinnedFailures counts consecutive failed Serve-loop passes
+	// while in pinned mode (--dmsg-server / ctx.Value("dmsgServer")
+	// set). The visor polls PinnedFailureCount() during startup to
+	// decide when to abort. Resets to zero on successful session.
+	pinnedFailures atomic.Int64
+
 	errCh chan error
 	done  chan struct{}
 	once  sync.Once
@@ -237,22 +243,60 @@ func (ce *Client) Serve(ctx context.Context) {
 		var entries []*disc.Entry
 		var err error
 		ce.log.Debug("Discovering dmsg servers...")
-		if ctx.Value("dmsgServer") != nil {
+		pinned := ctx.Value("dmsgServer") != nil
+		pinnedAddr, _ := ctx.Value("dmsgServerAddr").(string)
+		if pinned && pinnedAddr != "" {
+			// pk@host:port form: skip discovery entirely. We have
+			// everything dialSession needs (PK + TCP address) right
+			// here, so don't burn an HTTP round-trip on dmsg-discovery
+			// — that may be unreachable in the bootstrap scenarios
+			// this mode exists for. A bad PK falls through to "No
+			// entries found" and gets counted as a pinned failure.
+			if dmsgServer, ok := ctx.Value("dmsgServer").(string); ok {
+				var pk cipher.PubKey
+				if err := pk.Set(dmsgServer); err != nil {
+					ce.log.WithError(err).
+						WithField("dmsg_server", dmsgServer).
+						Warn("Pinned dmsg server PK invalid; will retry.")
+					entries = nil
+				} else {
+					entries = []*disc.Entry{{
+						Static: pk,
+						Server: &disc.Server{Address: pinnedAddr},
+					}}
+				}
+			}
+		} else if pinned {
 			entries, err = ce.discoverServers(cancellabelCtx, true)
 			if err != nil {
 				ce.log.WithError(err).Warn("Failed to discover dmsg servers.")
 				if err == context.Canceled || err == context.DeadlineExceeded {
 					return
 				}
+				ce.pinnedFailures.Add(1)
 				ce.serveWait()
 				continue
 			}
 
-			for ind, entry := range entries {
-				if dmsgServer, ok := ctx.Value("dmsgServer").(string); ok && entry.Static.Hex() == dmsgServer {
-					entries = entries[ind : ind+1]
-					break
+			// Strict pinning: keep only the requested server. If it's
+			// not in discovery (typo, not registered, etc.), drop to
+			// empty entries so the outer loop hits the "No entries
+			// found" retry path instead of silently connecting to a
+			// different server.
+			matched := false
+			if dmsgServer, ok := ctx.Value("dmsgServer").(string); ok {
+				for ind, entry := range entries {
+					if entry.Static.Hex() == dmsgServer {
+						entries = entries[ind : ind+1]
+						matched = true
+						break
+					}
 				}
+			}
+			if !matched {
+				ce.log.WithField("dmsg_server", ctx.Value("dmsgServer")).
+					Warn("Pinned dmsg server not in discovery; will retry.")
+				entries = nil
 			}
 		} else if ctx.Value("setupNode") != nil {
 			entries, err = ce.discoverServers(cancellabelCtx, true)
@@ -277,6 +321,9 @@ func (ce *Client) Serve(ctx context.Context) {
 		}
 		if len(entries) == 0 {
 			ce.log.Warnf("No entries found. Retrying after %s...", ce.bo.String())
+			if pinned {
+				ce.pinnedFailures.Add(1)
+			}
 			ce.serveWait()
 			continue
 		}
@@ -352,6 +399,9 @@ func (ce *Client) Serve(ctx context.Context) {
 					// Only backoff after all servers have been tried
 					ce.log.WithField("current_backoff", ce.bo.String()).
 						Warn("All servers failed, backing off.")
+					if pinned {
+						ce.pinnedFailures.Add(1)
+					}
 					ce.serveWait()
 				}
 				ce.log.WithField("remote_pk", entry.Static).WithError(err).
@@ -359,6 +409,9 @@ func (ce *Client) Serve(ctx context.Context) {
 			} else {
 				// Reset backoff on successful session establishment.
 				ce.bo = ce.initBO
+				if pinned {
+					ce.pinnedFailures.Store(0)
+				}
 			}
 		}
 
@@ -391,6 +444,16 @@ func (ce *Client) Serve(ctx context.Context) {
 // dmsg discovery.
 func (ce *Client) Ready() <-chan struct{} {
 	return ce.ready
+}
+
+// PinnedFailureCount returns the number of consecutive failed
+// Serve-loop passes while the client is pinned to a single dmsg
+// server via the "dmsgServer" context value. Reset to 0 whenever a
+// session is successfully established. Callers (the visor's startup
+// path) use this to bound how long the visor waits for a pinned
+// server before aborting startup.
+func (ce *Client) PinnedFailureCount() int64 {
+	return ce.pinnedFailures.Load()
 }
 
 func (ce *Client) discoverServers(ctx context.Context, all bool) (entries []*disc.Entry, err error) {

--- a/pkg/visor/cmd.go
+++ b/pkg/visor/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -45,11 +46,13 @@ var (
 	// root indicates process is run with root permissions
 	root bool // nolint:unused
 	// visorBuildInfo holds information about the build
-	visorBuildInfo *buildinfo.Info
-	dmsgServer     string
-	isStoreLog     bool
-	isForceColor   bool
-	useRouteFinder bool // override local route calculation to use route finder
+	visorBuildInfo        *buildinfo.Info
+	dmsgServer            string
+	dmsgServerAddr        string // populated from --dmsg-server when given as pk@host:port; empty means "use discovery"
+	dmsgServerMaxAttempts int
+	isStoreLog            bool
+	isForceColor          bool
+	useRouteFinder        bool // override local route calculation to use route finder
 )
 
 // nolint: gocyclo
@@ -70,6 +73,9 @@ func init() {
 	}
 	RootCmd.Flags().StringVar(&dmsgServer, "dmsg-server", "", "use specified dmsg server public key")
 	hiddenflags = append(hiddenflags, "dmsg-server")
+	RootCmd.Flags().IntVar(&dmsgServerMaxAttempts, "dmsg-server-max-attempts", 5,
+		"max failed connect attempts before shutdown (only with --dmsg-server)")
+	hiddenflags = append(hiddenflags, "dmsg-server-max-attempts")
 	//only show flags for configs which exist
 
 	if _, err := os.Stat(skyenv.SkywirePath + "/" + skyenv.ConfigJSON); err == nil {
@@ -219,6 +225,35 @@ var RootCmd = &cobra.Command{
 				if _, err := os.Stat(confPath); err != nil {
 					//fail here on no config
 					log.WithError(err).Fatal("config file not found")
+				}
+			}
+		}
+		// Parse --dmsg-server. Two accepted forms:
+		//   <pk>               — let dmsg discovery resolve the address (existing behavior)
+		//   <pk>@<host:port>   — skip discovery entirely and dial host:port directly
+		// The "@" form is for bootstrapping a visor that can't reach
+		// dmsg-discovery yet (fresh install, sealed network, etc.) and
+		// for pinning a specific server address regardless of what
+		// discovery says. The pinned-failure cap from
+		// --dmsg-server-max-attempts still applies — TCP dial failures
+		// count as attempts.
+		if dmsgServer != "" {
+			if i := strings.Index(dmsgServer, "@"); i >= 0 {
+				pkPart := dmsgServer[:i]
+				addrPart := dmsgServer[i+1:]
+				if pkPart == "" || addrPart == "" {
+					log.Fatalf("--dmsg-server: invalid pk@host:port form (need both pk and address): %q", dmsgServer)
+				}
+				var pk cipher.PubKey
+				if err := pk.Set(pkPart); err != nil {
+					log.WithError(err).Fatalf("--dmsg-server: invalid public key %q", pkPart)
+				}
+				dmsgServer = pkPart
+				dmsgServerAddr = addrPart
+			} else {
+				var pk cipher.PubKey
+				if err := pk.Set(dmsgServer); err != nil {
+					log.WithError(err).Fatalf("--dmsg-server: invalid public key %q", dmsgServer)
 				}
 			}
 		}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -54,13 +54,49 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	if v.dmsgServersCache != nil {
 		configured = v.dmsgServersCache.MergePreferringCache(configured)
 	}
+	log := v.MasterLogger().PackageLogger("dmsg_http")
+	// --dmsg-server pins the direct dmsg client (dmsgDC) to a single
+	// server. The discovery-driven dmsgC is pinned separately by
+	// dmsg.Client.serve() via the "dmsgServer" context value.
+	if dmsgServer != "" {
+		var pinned []*dmsgdisc.Entry
+		if dmsgServerAddr != "" {
+			// pk@host:port form: synthesize the entry from the flag so
+			// dmsg-http works on a bootstrap visor that has no cached
+			// servers and possibly no working discovery.
+			var pk cipher.PubKey
+			if err := pk.Set(dmsgServer); err != nil {
+				log.WithError(err).WithField("dmsg_server", dmsgServer).
+					Error("--dmsg-server: invalid public key; dmsg-http will be unavailable")
+			} else {
+				pinned = []*dmsgdisc.Entry{{
+					Static: pk,
+					Server: &dmsgdisc.Server{Address: dmsgServerAddr},
+				}}
+				log.WithField("dmsg_server", dmsgServer).
+					WithField("addr", dmsgServerAddr).
+					Info("--dmsg-server pk@host:port: skipping discovery for dmsg-http")
+			}
+		} else {
+			for _, e := range configured {
+				if e != nil && e.Static.Hex() == dmsgServer {
+					pinned = []*dmsgdisc.Entry{e}
+					break
+				}
+			}
+			if len(pinned) == 0 {
+				log.WithField("dmsg_server", dmsgServer).
+					Warn("--dmsg-server PK not in configured/cached servers; dmsg-http will be unavailable")
+			}
+		}
+		configured = pinned
+	}
 	servers := shuffleServers(configured)
 
 	if len(servers) == 0 {
 		return nil
 	}
 
-	log := v.MasterLogger().PackageLogger("dmsg_http")
 	keys = append(keys, v.conf.PK)
 	// Add deployment service PKs so the direct client can look them up
 	// without querying the HTTP discovery (services run as direct clients
@@ -168,6 +204,23 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// Override the discovery URL used by the DMSG client
 	dmsgConf := *v.conf.Dmsg
 	dmsgConf.Discovery = discURL
+	// --dmsg-server pins the client to one server (discovery filter in
+	// dmsg.Client.serve). Force sessions_count=1 so the client doesn't
+	// burn retries trying to open additional sessions when only one
+	// server is reachable. Deep-copy Deployments so the override stays
+	// local to this dmsgConf and doesn't leak into v.conf.Dmsg via the
+	// shared slice header.
+	if dmsgServer != "" {
+		if len(dmsgConf.Deployments) > 0 {
+			deps := make([]dmsgc.Deployment, len(dmsgConf.Deployments))
+			copy(deps, dmsgConf.Deployments)
+			deps[0].SessionsCount = 1
+			dmsgConf.Deployments = deps
+		}
+		dmsgConf.SessionsCount = 1
+		log.WithField("dmsg_server", dmsgServer).
+			Info("--dmsg-server set: forcing dmsg.sessions_count=1")
+	}
 	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.MasterLogger())
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
@@ -189,17 +242,60 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	v.initLock.Unlock()
 
 	// Wait for DMSG to connect before returning. All modules that depend on
-	// dmsgC will only start after this, ensuring DMSG is ready before any
+	// dmsg will only start after this, ensuring DMSG is ready before any
 	// service tries to use it. Without this, services start dialing over DMSG
 	// before sessions are established, causing unnecessary HTTP fallbacks.
+	//
+	// Two readiness regimes:
+	//   - Unpinned (default): wait up to dmsgInitTimeout and continue
+	//     either way; services fall back to HTTP if dmsg is slow.
+	//   - Pinned (--dmsg-server): there's exactly one server we can
+	//     reach, so a timeout doesn't mean "be patient" — it means
+	//     "give up." Poll the dmsg client's pinned-failure counter
+	//     instead and abort startup once it exceeds the configured
+	//     attempt cap. Each failed pass already costs at least one
+	//     backoff (5s → 60s), so 5 attempts is on the order of
+	//     2–3 minutes before shutdown.
 	const dmsgInitTimeout = 30 * time.Second
-	select {
-	case <-dmsgC.Ready():
-		log.Info("DMSG client connected and ready.")
-	case <-time.After(dmsgInitTimeout):
-		log.Warn("DMSG client not ready after timeout, continuing (services may fall back to HTTP)")
-	case <-ctx.Done():
-		return ctx.Err()
+	if dmsgServer != "" {
+		maxAttempts := dmsgServerMaxAttempts
+		if maxAttempts <= 0 {
+			maxAttempts = 5
+		}
+		log.WithField("dmsg_server", dmsgServer).
+			WithField("max_attempts", maxAttempts).
+			Info("--dmsg-server set: waiting for pinned server (will abort after max attempts)")
+		ticker := time.NewTicker(1 * time.Second)
+	pinnedWait:
+		for {
+			select {
+			case <-dmsgC.Ready():
+				log.Info("DMSG client connected and ready.")
+				break pinnedWait
+			case <-ctx.Done():
+				ticker.Stop()
+				return ctx.Err()
+			case <-ticker.C:
+				if attempts := dmsgC.PinnedFailureCount(); attempts >= int64(maxAttempts) {
+					ticker.Stop()
+					log.WithField("dmsg_server", dmsgServer).
+						WithField("attempts", attempts).
+						WithField("max_attempts", maxAttempts).
+						Error("--dmsg-server pinned but unreachable; aborting startup")
+					return fmt.Errorf("dmsg server %s (from --dmsg-server) unreachable after %d attempts", dmsgServer, attempts)
+				}
+			}
+		}
+		ticker.Stop()
+	} else {
+		select {
+		case <-dmsgC.Ready():
+			log.Info("DMSG client connected and ready.")
+		case <-time.After(dmsgInitTimeout):
+			log.Warn("DMSG client not ready after timeout, continuing (services may fall back to HTTP)")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	// Seed the DMSG client's entry cache with deployment service PKs

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -619,8 +619,16 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	v.runtimeErrors = make(chan error)
 	ctx = context.WithValue(ctx, runtimeErrsKey, v.runtimeErrors)
 	if dmsgServer != "" {
-		type dmsgServerKey struct{}
-		ctx = context.WithValue(ctx, dmsgServerKey{}, dmsgServer)
+		// dmsg.Client.serve() reads ctx.Value("dmsgServer") (string key)
+		// to pin discovery to a single server PK. Match that key exactly
+		// — a private struct type here would silently disable pinning.
+		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer) //nolint:staticcheck // SA1029: matches dmsg.Client's existing string key
+		if dmsgServerAddr != "" {
+			// --dmsg-server pk@host:port form. dmsg.Client.serve() reads
+			// "dmsgServerAddr" alongside "dmsgServer" and skips discovery
+			// when both are set, dialing host:port directly.
+			ctx = context.WithValue(ctx, "dmsgServerAddr", dmsgServerAddr) //nolint:staticcheck // SA1029: matches dmsg.Client's existing string key
+		}
 	}
 	registerModules(v.MasterLogger())
 	var mainModule visorinit.Module
@@ -637,22 +645,26 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	if err := mainModule.Wait(ctx); err != nil {
 		select {
 		case <-ctx.Done():
-			if err := v.Close(); err != nil {
-				log.WithError(err).Error("Visor closed with error.")
-			}
 		default:
-			log.Error(err)
+			log.WithError(err).Error("Module init failed; shutting down.")
+		}
+		// Always run the close stack so handlers registered before the
+		// failure (dmsg client Serve goroutine, listeners, etc.) get a
+		// chance to exit cleanly — otherwise partial init leaks them
+		// until the process dies.
+		if cerr := v.Close(); cerr != nil {
+			log.WithError(cerr).Error("Visor closed with error.")
 		}
 		return nil, false
 	}
 	if err := tm.Wait(ctx); err != nil {
 		select {
 		case <-ctx.Done():
-			if err := v.Close(); err != nil {
-				log.WithError(err).Error("Visor closed with error.")
-			}
 		default:
-			log.Error(err)
+			log.WithError(err).Error("Transport module init failed; shutting down.")
+		}
+		if cerr := v.Close(); cerr != nil {
+			log.WithError(cerr).Error("Visor closed with error.")
 		}
 		return nil, false
 	}


### PR DESCRIPTION
## Summary
Carries forward @mrpalide's #2529 on top of the current develop tip. Closes #2528 (both parts: spinning "listening on closed connection" log loop on Ctrl+C, and \`--dmsg-server\` flag silently ignored).

Five changes that together make \`--dmsg-server\` actually pin the dmsg client and let Ctrl+C cleanly shut down:

1. **\`pkg/visor/visor.go\` context-key fix (load-bearing)** — \`--dmsg-server\` was silently ignored because \`NewVisor\` stored the PK under a private \`struct{}\` context key, but \`dmsg.Client.serve()\` reads it via the **string** key \`\"dmsgServer\"\`. The private key was unreachable to the consumer, so pinning never happened. Switched to the string key the consumer expects, with a \`//nolint:staticcheck SA1029\` — matching the existing wire key is required.

2. **\`pkg/visor/visor.go\` always-Close on init failure** — without this, a failed init left the dmsg \`Serve\` goroutine and listeners running until process exit, surfacing as the \"tons of same line\" spin-log on Ctrl+C (#2528 part 1).

3. **\`pkg/app/appnet/skywire_networker.go\` ErrClosedConn wraps net.ErrClosed** — \`dmsgctrl.ServeListener\`'s accept loop checks the standard sentinel via \`errors.Is\` to know when to stop; the custom string-only error never matched, so the loop kept spin-logging on listener close.

4. **\`pkg/dmsg/dmsg/client.go\` pinned-failure counter + strict matching + pk@host:port shortcut** — old code matched the requested PK in discovery results and **silently used the wrong server** when the match wasn't found; now drops to empty entries on no-match so the outer loop retries instead of mis-connecting. Adds the \`pk@host:port\` shortcut: if the visor passes \"dmsgServerAddr\" in context alongside \"dmsgServer\", skip discovery entirely and dial host:port directly — useful for bootstrapping a visor that can't reach dmsg-discovery (fresh install, sealed network). \`PinnedFailureCount()\` exposes the counter for the visor's startup gate.

5. **\`pkg/visor/init_dmsg.go\` bounded wait + sessions_count=1 force** — when pinned, force \`dmsg.SessionsCount=1\` (single-server topology) and switch the dmsg-ready wait from a 30s warn-and-continue timeout to a poll loop bounded by \`--dmsg-server-max-attempts\` (default 5). Each failed pass costs at least one dmsg-client backoff (5s → 60s), so 5 attempts ≈ 2–3 minutes before shutdown — short enough to fail visibly, long enough to ride out a transient blip. \`initDmsgHTTP\` also honors the pk@host:port form.

\`cmd.go\` adds \`--dmsg-server-max-attempts\` (hidden, default 5) and extends \`--dmsg-server\`'s parser to accept \`pk@host:port\`, validating the PK at flag-parse time.

## Why
Picking up @mrpalide's #2529 — that PR's CI failures on \`TestConfigGenHypervisor\` / \`TestConfigGenEnvFile\` were stale-base (unrelated to this work). Fresh rebase against develop tip + local re-run of the failing tests confirms they pass. The actual code in #2529 is sound and addresses real bugs in the \`--dmsg-server\` path.

## Test plan (from #2529, verified)
- [x] Local: \`go test ./pkg/visor/... ./pkg/dmsg/dmsg/... ./pkg/app/appnet/... ./cmd/skywire-cli/commands/config/...\` all green
- [x] Local: \`go vet\` clean, \`gofmt -l\` clean
- [ ] \`--dmsg-server <unreachable-pk>\` — confirm ~5 retries then abort with \"--dmsg-server pinned but unreachable\"
- [ ] \`--dmsg-server <reachable-pk>\` — confirm normal startup + pinning
- [ ] no \`--dmsg-server\` — confirm 30s warn-and-continue path unchanged
- [ ] \`--dmsg-server-max-attempts=2\` — confirm shutdown ~2× faster
- [ ] \`--dmsg-server <pk>@<reachable-host:port>\` — confirm no discovery call (\"skipping discovery for dmsg-http\")
- [ ] \`--dmsg-server <pk>@<unreachable-host:port>\` — confirm TCP dial failures count, shutdown at cap
- [ ] \`--dmsg-server pk@\` or \`@host:port\` — confirm fatal at startup with clear message
- [ ] Ctrl+C while visor running — confirm no spinning \"listening on closed connection\" log loop

## Credit
- @mrpalide for #2529 design + most of the implementation
- Rebased on develop and re-verified by 0pcom

Closes #2528. Closes #2529.