### PR TITLE
chore(hv-tree): filter "method not found" the same as not-a-hypervisor

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -178,11 +178,12 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				// Skip remotes that simply aren't hypervisors (the
 				// most common case — every plain visor in the
 				// deployment would otherwise show as a no-op error
-				// row in the tree).
-				es := sr.err.Error()
-				if es == "hypervisor not running" || es == "hypervisor not enabled" {
+				// row in the tree). Mirrors isNotHypervisorErr() in
+				// rpc_hypervisor_proxy.go — kept in sync there.
+				if isNotHypervisorErr(sr.err) {
 					continue
 				}
+				es := sr.err.Error()
 				rendered[sr.hyperPK] = true
 				sections = append(sections, VisorTreeSection{
 					HypervisorPK: sr.hyperPK,

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -7,6 +7,7 @@ package visor
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -410,12 +411,32 @@ func (v *Visor) HVListVisorsTree() (*HVVisorTree, error) {
 // as a hypervisor" errors from HVListDirectVisors, so we can quietly
 // skip those remotes from the tree (every visor in a deployment that
 // ISN'T also a hypervisor would otherwise show up as a SubError row).
+//
+// Three distinct cases collapse into "not a hypervisor":
+//  1. "hypervisor not running" — remote is fully running but its
+//     hypervisor module never initialized (no config section).
+//  2. "hypervisor not enabled" — module initialized but the runtime
+//     toggle is off (operator disabled via `cli visor hv disable`).
+//  3. "rpc: can't find method app-visor.HVListDirectVisors" — remote
+//     is on a pre-#2633 binary that predates the new RPC method.
+//     Functionally indistinguishable from "not a hypervisor" until
+//     they update. Without this match, every plain visor in a
+//     deployment running an older binary noisily appears as a
+//     SubError row in `hv tree` output until everyone updates.
 func isNotHypervisorErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	s := err.Error()
-	return s == "hypervisor not running" || s == "hypervisor not enabled"
+	if s == "hypervisor not running" || s == "hypervisor not enabled" {
+		return true
+	}
+	// "rpc: can't find method app-visor.HVListDirectVisors" — pre-#2633
+	// binary. The net/rpc layer formats unknown methods this way; match
+	// the suffix so any service-name prefix change in the future stays
+	// covered.
+	return strings.Contains(s, "can't find method HVListDirectVisors") ||
+		strings.HasSuffix(s, ".HVListDirectVisors")
 }
 
 // HVVisorSummary returns detailed info about a specific remote visor.


### PR DESCRIPTION
## Summary
Small UX cleanup on the \`cli visor hv tree\` output. When a peer remote runs a pre-#2633 binary, its net/rpc layer rejects \`HVListDirectVisors\` with \`rpc: can't find method app-visor.HVListDirectVisors\`. Functionally that peer is \"not a hypervisor\" from the tree builder's perspective, so it should be silently skipped — not surfaced as a noisy \`SubError\` row.

## Why
Observed in production this morning after restarting Alpha to cascade-tip: \`cli visor hv tree\` had a long tail of identical sub-error sections (one per peer remote still on the older binary) that will auto-clear as those remotes update — but until then the noise was hiding the actually-interesting case (a real sub-hypervisor with visors).

Extends \`isNotHypervisorErr()\` to match the method-not-found shape via \`strings.Contains\` / \`strings.HasSuffix\` so a future service-name prefix change in the rpc layer stays covered. Mirrors the check in the HTTP handler so both code paths agree.

## Test plan
- [x] \`go build ./pkg/visor/...\` clean
- [x] \`go test ./pkg/visor/...\` all green
- [x] \`go vet\` + \`gofmt -l\` clean
- [ ] In-prod: \`cli visor hv tree\` post-merge should no longer show the \"method not found\" sub-error sections; real sub-hypervisors still render normally.

## Behavior change
- Pre-#2633 remote peers: previously rendered as \`SubError\` row; now silently skipped.
- Real sub-hypervisors: no change.
- No-config remotes (\"hypervisor not running\" / \"not enabled\"): no change.