### PR TITLE
feat(hvui): node-list consumes tree sections + header shows local hypervisor PK

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.html
@@ -34,6 +34,17 @@
       <!-- Header. -->
       <div class="generic-title-container mt-4.5 d-flex" [ngClass]="{'paginator-icons-fixer': numberOfPages > 1}">
         <div class="title">
+          @if (localHypervisorPk) {
+            <!-- Local hypervisor PK label. Populated from the tree
+                 response's local section (sections[0]). The next-step
+                 PR adds per-sub-hypervisor table sections below the
+                 main table; this is the title bar piece per #2640's
+                 design. -->
+            <div class="hypervisor-pk-label transparent-50" [matTooltip]="localHypervisorPk">
+              <mat-icon class="small-icon" [inline]="true">star_outline</mat-icon>
+              <span class="ml-1">{{ localHypervisorPk }}</span>
+            </div>
+          }
           @if (dataFilterer.currentFiltersTexts && dataFilterer.currentFiltersTexts.length > 0) {
             <div class="filter-label subtle-transparent-button cursor-pointer" (click)="dataFilterer.removeFilters()">
               @for (filterTexts of dataFilterer.currentFiltersTexts; track filterTexts) {

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.scss
@@ -1,5 +1,20 @@
 @import "variables";
 
+// Local hypervisor PK label shown in the main node list title bar.
+// Renders as small monospace text with a star icon. The full PK is
+// only legible at larger viewports; on narrow screens it truncates
+// with ellipsis but stays expandable via the matTooltip on hover.
+.hypervisor-pk-label {
+  display: inline-flex;
+  align-items: center;
+  font-family: monospace;
+  font-size: 12px;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .labels {
   width: 15%;
 }

--- a/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node-list/node-list.component.ts
@@ -4,7 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Router, ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 
-import { NodeService, KnownHealthStatuses } from '../../../services/node.service';
+import { NodeService, NodeSection, KnownHealthStatuses } from '../../../services/node.service';
 import { Node } from '../../../app.datatypes';
 import { AuthService, AuthStates } from '../../../services/auth.service';
 import { EditLabelComponent } from '../../layout/edit-label/edit-label.component';
@@ -83,6 +83,15 @@ export class NodeListComponent extends PageBaseComponent implements OnInit, OnDe
   currentPage = 1;
   // Used as a helper var, as the URL is read asynchronously.
   currentPageInUrl = 1;
+
+  // Per-hypervisor sections from the tree endpoint (#2633). The
+  // template currently renders the flat `allNodes` table; sections
+  // is consumed by the header (to show local hypervisor PK) and is
+  // available for the per-section table refactor (#2640).
+  sections: NodeSection[] = [];
+  // Local hypervisor PK — convenience accessor for the title bar
+  // (derived from sections[0]). Empty until first data arrives.
+  localHypervisorPk = '';
 
   // Array with the properties of the columns that can be used for filtering the data.
   filterProperties: FilterProperties[] = [
@@ -427,6 +436,19 @@ export class NodeListComponent extends PageBaseComponent implements OnInit, OnDe
         if (result.data && !result.error) {
           this.allNodes = result.data as Node[];
           this.dataFilterer.setData(this.allNodes);
+
+          // Tree shape from #2633's /api/visors-tree-summary. Populates
+          // `sections` for the next-step multi-table render. Header
+          // shows the local hypervisor PK; if the response is empty
+          // (older backend, or pre-init), fall back to whatever the
+          // first node's PK is so the header isn't blank.
+          if (result.sections && result.sections.length > 0) {
+            this.sections = result.sections;
+            this.localHypervisorPk = result.sections[0].hypervisorPk;
+          } else {
+            this.sections = [];
+            this.localHypervisorPk = '';
+          }
 
           // Fetch reward data if on the rewards tab and not yet loaded
           if (this.showRewardsInfo && !this.rewardDataLoaded && !this.rewardDataLoading) {

--- a/static/skywire-manager-src/src/app/services/multiple-node-data.service.ts
+++ b/static/skywire-manager-src/src/app/services/multiple-node-data.service.ts
@@ -6,18 +6,28 @@ import { Node } from '../app.datatypes';
 import { processServiceError } from '../utils/errors';
 import { OperationError } from '../utils/operation-error';
 import { AppConfig } from '../app.config';
-import { NodeService } from './node.service';
+import { NodeService, NodeSection } from './node.service';
 
 /**
  * Data about the node list, returned by MultipleNodeDataService.
  */
 export class MultipleNodesBackendData {
   /**
-   * Node list. If the last operation for getting the data ended in an error, this property
-   * may still have a previously obtained value. If no data has already been obtained, it
-   * is null
+   * Flat node list, derived from sections by concatenating each
+   * section's nodes (with cross-section visor de-duplication kept by
+   * the consumer if needed — same visor PK can appear in multiple
+   * sections by design). Existing components that consume the flat
+   * list keep working unchanged.
    */
   data: Node[];
+  /**
+   * Per-hypervisor sections in tree form. First entry is the local
+   * hypervisor; subsequent entries are sub-hypervisors. Consumed by
+   * the main node list UI to render per-section tables with the
+   * breadcrumb between them. See NodeService.getNodesTree() for the
+   * source-of-truth contract.
+   */
+  sections: NodeSection[];
   /**
    * Error found while trying to get the data. It will only have a value if the last
    * try ended in an error.
@@ -110,12 +120,23 @@ export class MultipleNodeDataService {
         this.dataSubject.next(this.lastEmitedData);
       }),
       delay(120),
-      // Load the data.
-      mergeMap(() => this.nodeService.getNodes()))
-    .subscribe(result => {
+      // Load the data. Use the tree endpoint as the primary source —
+      // it carries the per-sub-hypervisor structure the UI needs to
+      // render multi-table layout. The flat `data` field is derived
+      // from sections by concatenating each section's nodes; consumers
+      // that don't care about sections keep working unchanged.
+      mergeMap(() => this.nodeService.getNodesTree()))
+    .subscribe((sections: NodeSection[]) => {
+      const flat: Node[] = [];
+      for (const s of sections) {
+        for (const n of s.nodes) {
+          flat.push(n);
+        }
+      }
       // Send the event.
       this.lastEmitedData = {
-        data: result,
+        data: flat,
+        sections: sections,
         error: null,
         momentOfLastCorrectUpdate: Date.now(),
         updating: false
@@ -130,6 +151,7 @@ export class MultipleNodeDataService {
       // Send the event.
       this.lastEmitedData = {
         data: this.lastEmitedData.data,
+        sections: this.lastEmitedData.sections,
         error: err,
         momentOfLastCorrectUpdate: this.lastEmitedData.momentOfLastCorrectUpdate,
         updating: false


### PR DESCRIPTION
## Summary
Second-half of the hypervisor-tree UI feature (after #2641's service layer). Wires \`getNodesTree()\` through \`MultipleNodeDataService\` and the main node-list component, plus adds the title-bar PK label per the operator's design.

The actual per-sub-hypervisor multi-table render is the **next-step PR** (#2640) — kept separate so this one stays reviewable without the table-structure changes mixed in.

## Changes
- \`MultipleNodeDataService\` backs the periodic refresh with \`getNodesTree()\` instead of \`getNodes()\`. The flat \`data\` field is derived by concatenating each section's nodes — existing consumers that ignore sections keep working unchanged. New \`sections\` field on \`MultipleNodesBackendData\` carries the per-hypervisor tree.
- \`node-list.component.ts\`: tracks \`sections\` and \`localHypervisorPk\` from the tree response. \`localHypervisorPk\` falls to \`''\` when the backend response doesn't include sections (older backend that hasn't shipped #2633 yet).
- \`node-list.component.html\`: title bar renders the local hypervisor PK above the existing filter chips. \`matTooltip\` surfaces the full PK on narrow viewports where the label truncates to ellipsis.
- \`node-list.component.scss\`: new \`.hypervisor-pk-label\` class — monospace, small, ellipsis-truncated to fit the existing title bar width.

## Test plan
- [x] \`npx tsc --noEmit -p static/skywire-manager-src\` clean
- [ ] In-prod: open hypervisor UI, confirm local hypervisor PK appears in the title bar above the node list. Section data is fetched but not yet rendered as separate tables (next PR).

## What still needs work
- Multi-table render: wrap existing \`<table>\` blocks in \`*ngFor=\"let section of sections\"\` so each sub-hypervisor section renders its own table. Add the breadcrumb header between sections. Tracking in #2640.

## Related
- #2633 (backend) — merged
- #2641 (service half) — merged
- #2640 (multi-table render — next-step PR)