### PR TITLE
docs(readme): tighten Skynet bullet to the routing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,12 @@ else follows.
   connectivity. NAT-indifferent, always-available baseline that
   works for endpoints which cannot reach each other directly.
 
-* **Skynet: peer-to-peer, multi-hop, and multiplexed routing that
-  bootstraps from DMSG.** Skynet auto-creates direct transports
-  between visors — STCPR (TCP relay) and SUDPH (UDP hole-punching)
-  — and builds single-hop or multi-hop routes across them with
-  Noise-encrypted packets end-to-end; intermediate visors see only
-  the previous and next hop. Multi-route mux groups parallel routes
-  between the same endpoints for higher bandwidth. The control-plane
-  services that make this possible — transport discovery, route
-  finder, service discovery, address resolver — are themselves
-  reached over DMSG, which is why DMSG bootstraps the routed
-  network.
+* **Skynet: peer-to-peer, multi-hop, and multiplexed routing.**
+  Routes carry Noise-encrypted packets end-to-end across one or
+  more direct transports between visors; intermediate visors see
+  only the previous and next hop. Multi-route mux groups parallel
+  routes between the same endpoints for higher aggregate
+  bandwidth.
 
 * **Remote monitoring and remote management over the overlay.**
   `skywire cli` reaches any visor over DMSG or Skynet for one-shot


### PR DESCRIPTION
## Summary

- Drops "that bootstraps from DMSG" from the Skynet bullet headline.
- Drops the STCPR/SUDPH autoconnect sentence and the control-plane / DMSG-bootstrap closing — both are about how transports got there, not about the routing properties the bullet claims.
- Keeps the substantive routing properties: Noise-encrypted end-to-end, intermediate visors see only previous/next hop, multi-route mux for higher aggregate bandwidth.

Transport types and the auto-transport mechanism already live in the "Skywire Network and Transports" section below; control-plane discovery already lives in the deeper sections too.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the Skynet bullet reads as a single clean claim about routing properties.