### PR TITLE
fix(cxo/node): handleSub always pushes current Root on duplicate Subscribe

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -728,9 +728,25 @@ func (c *Conn) handleSub(seq uint32, sub *msg.Sub) (_ error) {
 		return errors.New("blank public key") // fatal (invalid request)
 	}
 
-	// check first
+	// Idempotent Subscribe: even when the conn is already registered for
+	// this feed, push the current Root again. Subscribers re-issue
+	// Subscribe on reconnect (via ReconnectPeer → conn.Subscribe), and
+	// the only signal they have that we accepted is Ok. Without a Root
+	// follow-up, a subscriber whose previous fill failed (transient
+	// dmsg blip, partial fetch) has no way to recover — it stays Ok'd
+	// with no backlog and only sees Roots published after its
+	// reconnect lands. Empirically observed: post-restart subscriber
+	// joined a publisher mid-burst, received probebX-19+ live but
+	// missed probeb-01..18 entirely because that initial fill aborted
+	// silently and the publisher never re-pushed.
+	//
+	// sendLastRoot is cheap — one fetch from the local Container plus
+	// one message send. Repeating it on duplicate subscribes is the
+	// minimum-surface fix that doesn't require new message types or
+	// subscriber-side recovery logic.
 	if c.n.fs.hasConnFeed(c, sub.Feed) == true { //nolint:staticcheck
-		c.sendOk(seq) // already subscribed
+		c.sendOk(seq)            // already subscribed
+		c.sendLastRoot(sub.Feed) // push current Root anyway
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
Subscriber reconnects re-issue \`Subscribe\` via \`conn.Subscribe\` → \`msg.Sub\` on the wire. Today the publisher's \`handleSub\` short-circuits \"already subscribed\" duplicates with just \`sendOk(seq)\`, skipping the \`sendLastRoot\` push that fresh Subscribes get.

This silently strands subscribers whose initial fill aborted — transient dmsg blip during the post-Subscribe Filler walk, partial object fetch, etc. The subscriber sees \`Ok\` and proceeds, but the Root from before the abort is now invisible to it: the publisher won't push it again until a new \`Put\` creates a new Root.

## Empirical
Observed today during the T2-sustained 3-agent test: a subscriber that joined a publisher mid-burst received Roots published AFTER its reconnect landed (live updates) but missed every Root the publisher had \`Put\` before subscribe — even though those Roots' message leaves were still in the publisher's tree. Per-peer tallies: Alpha receive 10/30 from Beta + 6/30 from Gamma; Gamma receive 11/30 + 5/30. \`group history\` confirms the messages never reached the application layer.

## Fix
Send the last Root on every Subscribe, including duplicates. \`sendLastRoot\` is one Container lookup + one message; idempotent re-push is the minimum-surface fix that doesn't require new message types or subscriber-side recovery logic.

\`\`\`go
if c.n.fs.hasConnFeed(c, sub.Feed) == true {
    c.sendOk(seq)            // already subscribed
    c.sendLastRoot(sub.Feed) // push current Root anyway
    return nil
}
\`\`\`

## Mechanism
- The subscriber's CXO node fills the Root normally.
- \`handleRootFilled\` → \`walkTree\` → \`applySnapshot\` diffs against the local cache.
- Emits \`UpdateEvent\` for any leaves the subscriber hadn't yet seen.
- Subscribers that already have the data observe a no-op diff; subscribers that missed the prior fill backfill cleanly on the retry.

## Test plan
- [x] \`go test ./pkg/cxo/node/...\` clean
- [x] \`go vet\` + \`gofmt -l\` clean
- [ ] In-prod: with this PR live, restart subscriber visor mid-burst, confirm post-restart \`group history\` shows the full pre-restart message backlog (currently observes only post-restart messages).

## Related
- #2625 — accept-side stale-Conn eviction (publisher side)
- #2643 — dial-side cached-dead-Conn eviction (subscriber side, ConnectPK)
- #2630 — CLI-to-visor replay-on-reconnect (different layer; gRPC streaming, not the CXO subscribe path)
- #2637 — broader history-replay-on-reconnect tracking (this PR is one targeted piece of it)