### PR TITLE
fix(cxo/treestore): subscriber.handleRootFilled filters by feedPK

### DIFF
--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -290,11 +290,35 @@ func (s *Subscriber) matchesPrefixLocked(path string) bool {
 // handleRootFilled is the OnRootFilled callback. Walks the tree
 // rooted at r, builds the new path→value snapshot, diffs against
 // the previous cache, and dispatches changes.
+//
+// FeedPK gate: when multiple subscribers share a CXO node (each
+// for a different feed PK — e.g. one peerSub per group member on
+// the owner's node), every subscriber's handleRootFilled fires on
+// every Root regardless of which feed produced it. Without this
+// gate, a Root for feed A causes subscriber B (which targets a
+// different feed) to walk A's tree and apply A's leaves to B's
+// snapshot cache. The next Root for feed B then diffs against the
+// polluted cache and emits spurious deletes for A's leaves plus
+// "new" events for B's leaves. The on-the-wire messages are still
+// correct (sender PK on the leaf JSON drives application routing),
+// but per-peer cache invariants and per-peer-staleness signals
+// are scrambled.
+//
+// Skip non-matching Roots cleanly. Same callback chain remains in
+// place so the next subscriber in the chain still receives the
+// Root (it'll do its own match check).
 func (s *Subscriber) handleRootFilled(r *registry.Root) {
 	if r == nil || len(r.Refs) == 0 {
 		// Root with no payload — could happen on startup before
 		// the publisher has put anything. Treat as empty.
 		s.applySnapshot(nil)
+		return
+	}
+	if r.Pub != skycipher.PubKey(s.feedPK) {
+		// Root is for a different feed than this subscriber tracks.
+		// The chained callback dispatcher fires every subscriber on
+		// every Root; without this check each subscriber would walk
+		// every feed's tree and corrupt its own cache.
 		return
 	}
 


### PR DESCRIPTION
## Summary
The \`OnRootFilled\` callback is set on the shared CXO node — not on the per-feed \`Subscriber\`. \`NewSubscriberOnNode\` chains its handler to the existing \`OnRootFilled\` so multiple Subscribers can coexist on one node (e.g. one peerSub per group member on the owner's node).

But the chained dispatcher fires **every** subscriber's handler on **every** Root, regardless of which feed produced the Root. Without a feedPK filter, a Root for feed A causes subscriber B (which targets a different feed) to walk A's tree and apply A's leaves into B's snapshot cache.

The next Root for feed B then diffs against the polluted cache and emits spurious delete events for A's leaves plus \"new\" events for B's leaves — even though nothing actually changed on either feed.

## Impact
Wire-level message routing is unaffected (the sender PK on the JSON body drives application-layer routing), but **per-peer cache invariants and per-peer-staleness signals get scrambled** — making debugging the receive-side bugs we've been hunting today significantly harder.

## Fix
\`handleRootFilled\` returns early when \`r.Pub != s.feedPK\`. The chained callback dispatcher still passes the Root along to the next subscriber in the chain (each does its own match check).

\`\`\`go
if r.Pub != skycipher.PubKey(s.feedPK) {
    return
}
\`\`\`

## Test plan
- [x] \`go test ./pkg/cxo/...\` clean
- [x] \`go vet\` + \`gofmt -l\` clean

## Related
- #2625 — accept-side stale-Conn eviction
- #2643 — dial-side cached-dead-Conn eviction
- #2647 — handleSub always pushes Root on duplicate Subscribe (sibling fix)
- Same broader receive-side reliability debugging effort