### PR TITLE
feat(cxo/treestore): subscriber consumes OnFillingBreaks (visibility)

### DIFF
--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -131,6 +131,9 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
 		s.handleRootFilled(r)
 	}
+	cxoNode.Config().OnFillingBreaks = func(_ *node.Node, r *registry.Root, err error) {
+		s.handleFillingBreaks(r, err)
+	}
 	return s, nil
 }
 
@@ -164,6 +167,13 @@ func NewSubscriberOnNode(cxoNode *node.Node, feedPK cipher.PubKey, conf SubConfi
 		s.handleRootFilled(r)
 		if prev != nil {
 			prev(n, r)
+		}
+	}
+	prevFB := cxoNode.Config().OnFillingBreaks
+	cxoNode.Config().OnFillingBreaks = func(n *node.Node, r *registry.Root, err error) {
+		s.handleFillingBreaks(r, err)
+		if prevFB != nil {
+			prevFB(n, r, err)
 		}
 	}
 	return s, nil
@@ -342,6 +352,37 @@ func (s *Subscriber) handleRootFilled(r *registry.Root) {
 	}
 
 	s.applySnapshot(snap)
+}
+
+// handleFillingBreaks is the OnFillingBreaks callback. Fires when a
+// Root the subscriber received fails to fill — typically because a
+// transient dmsg blip during the post-Subscribe fetch interrupted the
+// recursive walk that resolves child objects. Before this hook was
+// wired, the failure was completely silent: the subscriber's filler
+// dropped the Root, no UpdateEvents fired, and the subscriber stayed
+// empty (or out-of-date) until the publisher pushed a new Root.
+//
+// FeedPK gate matches handleRootFilled — when multiple subscribers
+// share a CXO node, only the one tracking this Root's feed should
+// take the failure as its own.
+//
+// Today's behavior is log-only. Pairing this with #2647 (publisher
+// always pushes Root on duplicate Subscribe) covers the common
+// recovery path: subscriber's next reconnect-driven Subscribe gets
+// the Root pushed again. A more proactive recovery (subscriber
+// requests an immediate re-push from its CXO node here) is a future
+// follow-up.
+func (s *Subscriber) handleFillingBreaks(r *registry.Root, err error) {
+	if r == nil {
+		return
+	}
+	if r.Pub != skycipher.PubKey(s.feedPK) {
+		return
+	}
+	s.log.WithError(err).
+		WithField("feed", s.feedPK.Hex()).
+		WithField("seq", r.Seq).
+		Warn("treestore-sub: Root filling aborted; subscriber will miss this Root until publisher re-pushes")
 }
 
 // applySnapshot replaces the cache with snap and fires the change


### PR DESCRIPTION
## Summary
\`OnFillingBreaks\` is the CXO node's notification when a Root fails to fill — typically a transient dmsg blip interrupting the recursive fetch that resolves the Root's child objects. Before this PR **no consumer was wired**, so fill failures were completely silent: filler dropped the Root, no \`UpdateEvent\` fired, no log, subscriber stayed empty (or out-of-date) until the publisher pushed a fresh Root.

## What this PR does
- Wires \`Subscriber.handleFillingBreaks\` on both constructors (\`NewSubscriber\` owns-node, \`NewSubscriberOnNode\` shared-node + chain).
- Logs at \`Warn\` level: feed pk, root seq, error. So fill failures become diagnosable.
- FeedPK gate matches \`handleRootFilled\`'s behavior — only the subscriber tracking this Root's feed reports the abort.

## What this PR doesn't do
Proactive recovery (subscriber requests a re-push from its CXO node when fill aborts). That's a future follow-up when we have data on how often fills fail in practice. The combination with #2647 (publisher always pushes Root on duplicate Subscribe) covers the common recovery path: subscriber's next reconnect-driven Subscribe gets the Root re-pushed.

## Test plan
- [x] \`go test ./pkg/cxo/...\` clean
- [x] \`go vet\` + \`gofmt -l\` clean
- [ ] In-prod: induce a fill failure (kill a dmsg session mid-fetch) and confirm the new Warn log surfaces in the visor's runtime buffer.

## Related
- #2647 — handleSub always pushes Root on duplicate Subscribe (the recovery side)
- #2648 — feedPK filter on handleRootFilled (sibling correctness fix)
- Broader receive-side debugging effort.