### PR TITLE
fix(help): strip orphan ANSI escapes from --help output

### DIFF
--- a/cmd/dmsg/dial/commands/dial.go
+++ b/cmd/dmsg/dial/commands/dial.go
@@ -32,9 +32,9 @@ var (
 
 func init() {
 	dmsgclient.InitFlags(RootCmd)
-	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
-	RootCmd.Flags().IntVarP(&waitTime, "wait", "w", 0, "wait time in seconds before disconnecting\n\r\033[0m")
-	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r\033[0m")
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "info", "[ debug | warn | error | fatal | panic | trace | info ]")
+	RootCmd.Flags().IntVarP(&waitTime, "wait", "w", 0, "wait time in seconds before disconnecting")
+	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 }
 
 // RootCmd contains the root dmsgcurl command

--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -35,7 +35,7 @@ var (
 func init() {
 	sf.Init(RootCmd, "dmsg_srv", dmsgserver.DefaultConfigPath)
 	RootCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
-	RootCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port\033[0m")
+	RootCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 	RootCmd.Flags().StringVar(&authPassphrase, "auth", "", "auth passphrase as simple auth for official dmsg servers registration")
 }
 

--- a/cmd/dmsg/dmsg-socks5/commands/dmsg-socks5.go
+++ b/cmd/dmsg/dmsg-socks5/commands/dmsg-socks5.go
@@ -50,28 +50,28 @@ func init() {
 		proxyCmd,
 	)
 
-	serveCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to serve socks5\033[0m\n\r")
-	serveCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated\033[0m\n\r")
-	serveCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
-	serveCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
-	serveCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
+	serveCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to serve socks5")
+	serveCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated")
+	serveCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
+	serveCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url")
+	serveCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
 	if os.Getenv("DMSGSK") != "" {
 		sk.Set(os.Getenv("DMSGSK")) //nolint
 	}
-	serveCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
+	serveCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 	serveCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
 	serveCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 
-	proxyCmd.Flags().IntVarP(&proxyPort, "port", "p", 1081, "TCP port to serve SOCKS5 proxy locally\033[0m\n\r")
-	proxyCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to connect to socks5 server\033[0m\n\r")
-	proxyCmd.Flags().StringVarP(&pubk, "pk", "k", "", "dmsg socks5 proxy server public key to connect to\033[0m\n\r")
-	proxyCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
-	proxyCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
-	proxyCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
+	proxyCmd.Flags().IntVarP(&proxyPort, "port", "p", 1081, "TCP port to serve SOCKS5 proxy locally")
+	proxyCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to connect to socks5 server")
+	proxyCmd.Flags().StringVarP(&pubk, "pk", "k", "", "dmsg socks5 proxy server public key to connect to")
+	proxyCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
+	proxyCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url")
+	proxyCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
 	if os.Getenv("DMSGSK") != "" {
 		sk.Set(os.Getenv("DMSGSK")) //nolint
 	}
-	proxyCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
+	proxyCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 	proxyCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
 	proxyCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 

--- a/cmd/dmsg/dmsgcurl/commands/dmsgcurl.go
+++ b/cmd/dmsg/dmsgcurl/commands/dmsgcurl.go
@@ -50,17 +50,17 @@ func init() {
 	RootCmd.Flags().SortFlags = false
 	dmsgclient.InitFlags(RootCmd)
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", proxyAddr, "connect to DMSG via proxy (i.e. '127.0.0.1:1080')")
-	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]")
 	RootCmd.Flags().StringVarP(&dmsgcurlData, "data", "d", "", "dmsghttp POST data")
 	RootCmd.Flags().StringVarP(&dmsgcurlOutput, "out", "o", "", "output filepath")
 	RootCmd.Flags().BoolVarP(&replace, "replace", "r", false, "replace existing file with new downloaded")
-	RootCmd.Flags().IntVarP(&dmsgcurlTries, "try", "t", 1, "download attempts (0 unlimits)\033[0m\n\r")
+	RootCmd.Flags().IntVarP(&dmsgcurlTries, "try", "t", 1, "download attempts (0 unlimits)")
 	RootCmd.Flags().IntVarP(&dmsgcurlWait, "wait", "w", 0, "time to wait between requests")
-	RootCmd.Flags().StringVarP(&dmsgcurlAgent, "agent", "a", "dmsgcurl/"+buildinfo.Version(), "identify as `AGENT`\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&dmsgcurlAgent, "agent", "a", "dmsgcurl/"+buildinfo.Version(), "identify as `AGENT`")
 	if os.Getenv("DMSGCURL_SK") != "" {
 		sk.Set(os.Getenv("DMSGCURL_SK")) //nolint
 	}
-	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
+	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 }
 
 // RootCmd contains the root cli command

--- a/cmd/dmsg/dmsghttp/commands/dmsghttp.go
+++ b/cmd/dmsg/dmsghttp/commands/dmsghttp.go
@@ -43,14 +43,14 @@ func init() {
 	RootCmd.Flags().SortFlags = false
 	dmsgclient.InitFlags(RootCmd)
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", proxyAddr, "connect to DMSG via proxy (i.e. '127.0.0.1:1080')")
-	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&serveDir, "dir", "r", ".", "local dir to serve via dmsghttp\033[0m\n\r")
-	RootCmd.Flags().UintVarP(&dmsgPort, "port", "d", 80, "DMSG port to serve from\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]")
+	RootCmd.Flags().StringVarP(&serveDir, "dir", "r", ".", "local dir to serve via dmsghttp")
+	RootCmd.Flags().UintVarP(&dmsgPort, "port", "d", 80, "DMSG port to serve from")
 	RootCmd.Flags().StringSliceVarP(&wl, "wl", "w", []string{}, "whitelist keys to access server, comma separated")
 	if os.Getenv("DMSGHTTP_SK") != "" {
 		sk.Set(os.Getenv("DMSGHTTP_SK")) //nolint
 	}
-	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
+	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 	RootCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 

--- a/cmd/dmsg/dmsgip/commands/dmsgip.go
+++ b/cmd/dmsg/dmsgip/commands/dmsgip.go
@@ -35,15 +35,15 @@ var (
 func init() {
 	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
 	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
-	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "c", dmsgDisc, "dmsg discovery url\033[0m\n\r")
-	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", 1, "number of dmsg servers to connect to\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "c", dmsgDisc, "dmsg discovery url")
+	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", 1, "number of dmsg servers to connect to")
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
-	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]")
 	if os.Getenv("DMSGIP_SK") != "" {
 		sk.Set(os.Getenv("DMSGIP_SK")) //nolint
 	}
 	RootCmd.Flags().StringSliceVarP(&dmsgServers, "srv", "d", []string{}, "dmsg server public keys")
-	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r\033[0m")
+	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 }
 
 // RootCmd contains the root dmsgcurl command

--- a/cmd/dmsg/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgweb.go
@@ -36,15 +36,15 @@ func init() {
 	pk, _ = sk.PubKey() //nolint
 
 	dmsgclient.InitFlags(RootCmd)
-	RootCmd.Flags().StringVarP(&filterDomainSuffix, "filter", "f", ".dmsg", "domain suffix to filter\033[0m\n\r")
-	RootCmd.Flags().UintVarP(&proxyPort, "socks", "q", proxyPort, "port to serve the socks5 proxy\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&addProxy, "addproxy", "r", addProxy, "configure additional socks5 proxy for dmsgweb (i.e. 127.0.0.1:1080)\033[0m\n\r")
-	RootCmd.Flags().UintSliceVarP(&webPort, "port", "p", webPort, "port(s) to serve the web application\033[0m\n\r")
-	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port as a raw TCP tunnel & disable proxy\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to DMSG via proxy (i.e. '127.0.0.1:1080')\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&filterDomainSuffix, "filter", "f", ".dmsg", "domain suffix to filter")
+	RootCmd.Flags().UintVarP(&proxyPort, "socks", "q", proxyPort, "port to serve the socks5 proxy")
+	RootCmd.Flags().StringVarP(&addProxy, "addproxy", "r", addProxy, "configure additional socks5 proxy for dmsgweb (i.e. 127.0.0.1:1080)")
+	RootCmd.Flags().UintSliceVarP(&webPort, "port", "p", webPort, "port(s) to serve the web application")
+	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port as a raw TCP tunnel & disable proxy")
+	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to DMSG via proxy (i.e. '127.0.0.1:1080')")
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
-	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "E", false, "show example .conf file\033[0m\n\r")
+	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "E", false, "show example .conf file")
 	RootCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 

--- a/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
@@ -39,18 +39,18 @@ func init() {
 
 	RootCmd.AddCommand(srvCmd)
 	dmsgclient.InitFlags(srvCmd)
-	srvCmd.Flags().UintSliceVarP(&localPort, "lport", "p", localPort, "local application interface port(s)\033[0m\n\r")
-	srvCmd.Flags().UintSliceVarP(&dmsgPort, "dport", "d", dmsgPort, "DMSG port(s) to serve\033[0m\n\r")
+	srvCmd.Flags().UintSliceVarP(&localPort, "lport", "p", localPort, "local application interface port(s)")
+	srvCmd.Flags().UintSliceVarP(&dmsgPort, "dport", "d", dmsgPort, "DMSG port(s) to serve")
 	srvCmd.Flags().StringSliceVarP(&wl, "wl", "w", wl, "whitelisted keys for DMSG authenticated routes"+func() string {
 		if len(wl) > 0 {
-			return "\033[0m\n\r"
+			return ""
 		}
 		return ""
 	}())
 	srvCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", proxyAddr, "connect to DMSG via proxy (e.g., '127.0.0.1:1080')")
-	srvCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
+	srvCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]")
 	srvCmd.Flags().BoolVarP(&isEnvs, "envs", "E", false, "show example .conf file")
-	srvCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
+	srvCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified")
 	srvCmd.Flags().StringVar(&pprofMode, "pprofmode", "", "[ cpu | mem | mutex | block | trace | http ]")
 	srvCmd.Flags().StringVar(&pprofAddr, "pprofaddr", "localhost:6060", "pprof http port")
 	srvCmd.CompletionOptions.DisableDefaultCmd = true

--- a/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
@@ -41,12 +41,7 @@ func init() {
 	dmsgclient.InitFlags(srvCmd)
 	srvCmd.Flags().UintSliceVarP(&localPort, "lport", "p", localPort, "local application interface port(s)")
 	srvCmd.Flags().UintSliceVarP(&dmsgPort, "dport", "d", dmsgPort, "DMSG port(s) to serve")
-	srvCmd.Flags().StringSliceVarP(&wl, "wl", "w", wl, "whitelisted keys for DMSG authenticated routes"+func() string {
-		if len(wl) > 0 {
-			return ""
-		}
-		return ""
-	}())
+	srvCmd.Flags().StringSliceVarP(&wl, "wl", "w", wl, "whitelisted keys for DMSG authenticated routes")
 	srvCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", proxyAddr, "connect to DMSG via proxy (e.g., '127.0.0.1:1080')")
 	srvCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]")
 	srvCmd.Flags().BoolVarP(&isEnvs, "envs", "E", false, "show example .conf file")

--- a/cmd/svc/address-resolver/commands/root.go
+++ b/cmd/svc/address-resolver/commands/root.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/address-resolver/api"
@@ -54,7 +53,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 func generateExamples() string {

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -46,7 +45,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/cmd/svc/geoip/commands/root.go
+++ b/cmd/svc/geoip/commands/root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/oschwald/geoip2-golang/v2"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
@@ -47,7 +46,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/cmd/svc/network-monitor/commands/root.go
+++ b/cmd/svc/network-monitor/commands/root.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -65,7 +64,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/cmd/svc/route-finder/commands/root.go
+++ b/cmd/svc/route-finder/commands/root.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -46,7 +45,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 func generateExamples() string {

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -50,7 +49,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/cmd/svc/setup-node/commands/root.go
+++ b/cmd/svc/setup-node/commands/root.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -46,7 +45,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example config

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -84,7 +83,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/cmd/svc/transport-setup/commands/root.go
+++ b/cmd/svc/transport-setup/commands/root.go
@@ -46,7 +46,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/cmd/svc/uptime-tracker/commands/root.go
+++ b/cmd/svc/uptime-tracker/commands/root.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/tidwall/pretty"
 	"gorm.io/gorm"
 
 	"github.com/skycoin/skywire/deployment"
@@ -94,7 +93,7 @@ func exampleJSON(v interface{}) string {
 	if err != nil {
 		return ""
 	}
-	return string(pretty.Color(b, nil))
+	return string(b)
 }
 
 // generateExamples creates example responses from actual struct types

--- a/pkg/dmsg/dmsgclient/flags.go
+++ b/pkg/dmsg/dmsgclient/flags.go
@@ -41,11 +41,11 @@ var (
 func InitFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&UseHTTP, "http", "Z", UseHTTP, "use regular http to connect to DMSG Discovery")
 	cmd.Flags().BoolVarP(&UseDC, "direct", "B", UseDC, "use dmsg-direct client & don't connect to DMSG Discovery")
-	cmd.Flags().StringVarP(&DmsgDiscURL, "disc-url", "U", DmsgDiscURL, "DMSG Discovery URL\033[0m\n\r")
-	cmd.Flags().StringVarP(&DmsgDiscAddr, "disc-addr", "A", DmsgDiscAddr, "DMSG Discovery dmsg address\033[0m\n\r")
+	cmd.Flags().StringVarP(&DmsgDiscURL, "disc-url", "U", DmsgDiscURL, "DMSG Discovery URL")
+	cmd.Flags().StringVarP(&DmsgDiscAddr, "disc-addr", "A", DmsgDiscAddr, "DMSG Discovery dmsg address")
 	cmd.Flags().StringVarP(&DmsgHTTPPath, "dmsgconf", "D", "", "dmsghttp-config path")
-	cmd.Flags().IntVarP(&DmsgSessions, "sess", "e", DmsgSessions, "number of DMSG Servers to connect to\033[0m\n\r")
-	cmd.Flags().StringVarP(&DmsgServerAddr, "srv", "S", "", "connect via specific dmsg server `pk@ip:port`\033[0m\n\r")
+	cmd.Flags().IntVarP(&DmsgSessions, "sess", "e", DmsgSessions, "number of DMSG Servers to connect to")
+	cmd.Flags().StringVarP(&DmsgServerAddr, "srv", "S", "", "connect via specific dmsg server `pk@ip:port`")
 }
 
 // ParseServerAddr parses the --srv flag value into a disc.Entry.


### PR DESCRIPTION
## Summary

Audit of every node in the cobra tree (379 nodes excluding \`skywire skycoin\`) surfaced two ANSI-escape leaks in \`--help\` output that show as garbled \`\\e[0m\\r\` fragments when help is piped or rendered non-TTY:

1. **Orphan \`\\033[0m\\n\\r\` suffix on 49 dmsg flag descriptions.** Pattern \`cmd.Flags().StringVarP(..., \"DMSG Discovery URL\\033[0m\\n\\r\")\` — color-start codes had been removed in a prior refactor but the resets weren't. Affected 11 files across \`cmd/dmsg/\` + \`pkg/dmsg/\` + adjacent.

2. **\`pretty.Color(b, nil)\` unconditional in svc Long descriptions.** The \`exampleJSON()\` helper in every \`cmd/svc/*/commands/root.go\` colorized example JSON snippets that got baked into the cobra Long: text via \`fmt.Sprintf\`. The codes shipped regardless of TTY, so \`skywire svc ar --help | cat\` emitted raw escapes. Removed the colorization — \`json.MarshalIndent\` already produced indented JSON; color was decorative-only. Dropped the now-unused \`tidwall/pretty\` import from 9 files.

## Audit method

Wrote \`skywire-help-audit.sh\` (not committed) that uses \`skywire doc --dry-run\` as the authoritative node list, runs \`--help\` + \`--all\` against each, and flags ANSI leaks / non-zero exits / hidden-flag drift. Pre-fix: 20 nodes leaked ANSI in \`--help\`. Post-fix: 0.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./cmd/dmsg/... ./cmd/svc/... ./pkg/dmsg/...\` passes (only pre-existing Redis-dep tests fail, unrelated)
- [x] \`skywire dmsg curl --help | cat -A | grep -c '\\[0m'\` = 0
- [x] \`skywire svc ar --help | cat -A | grep -c '\\[0m'\` = 0

## Not in scope (deferred)

- \`skywire visor --all\` footer marker \`[0m*\` — separate concern; the visor renders its config-override-flag legend with a printable-but-ugly sequence
- \`skywire cli visor ping --all\` rc=1 — separate concern, likely a missing flag wiring