### PR TITLE
fix(cxo/treestore): hydrate Publisher in-memory tree from container on restart

### DIFF
--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -286,10 +286,12 @@ func New(cxoNode *node.Node, sk cipher.SecKey, conf Config) (*Publisher, error) 
 	// walking it back into the memNode keeps publish continuity across
 	// process boundaries. Errors here degrade to the empty-tree fallback
 	// (the existing behavior) so a corrupted on-disk state can't block
-	// the publisher from coming up.
+	// the publisher from coming up — but log at Warn so the operator-
+	// visible signal is loud enough to investigate: silent fallback
+	// looks exactly like the pre-fix bug from a subscriber's perspective.
 	if err := p.hydrateFromContainer(); err != nil {
 		conf.Logger.WithError(err).
-			Debug("treestore-pub: hydrate from container skipped; starting with empty tree")
+			Warn("treestore-pub: hydrate from container failed; starting with empty tree (any previously-published leaves will not be in the next published Root)")
 	}
 	go p.runLoop()
 	go p.runCleanupLoop()

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -275,9 +275,108 @@ func New(cxoNode *node.Node, sk cipher.SecKey, conf Config) (*Publisher, error) 
 		cleanupNudge: make(chan struct{}, 1),
 		cleanupDone:  make(chan struct{}),
 	}
+	// Hydrate the in-memory tree from the previously-published Root on
+	// the underlying CXO node, if one exists. Without this, every
+	// process restart starts from an empty memNode — the next Put
+	// publishes a Root whose Refs point to a TreeNode containing only
+	// that one new leaf, and subscribers' applySnapshot replaces their
+	// cache with the truncated tree (every historical leaf gets emitted
+	// as a delete event). The bbolt-persisted CXO objects survive the
+	// restart, so the previous Root is reachable via Container.LastRoot;
+	// walking it back into the memNode keeps publish continuity across
+	// process boundaries. Errors here degrade to the empty-tree fallback
+	// (the existing behavior) so a corrupted on-disk state can't block
+	// the publisher from coming up.
+	if err := p.hydrateFromContainer(); err != nil {
+		conf.Logger.WithError(err).
+			Debug("treestore-pub: hydrate from container skipped; starting with empty tree")
+	}
 	go p.runLoop()
 	go p.runCleanupLoop()
 	return p, nil
+}
+
+// hydrateFromContainer walks the previously-published Root for this
+// publisher's feed (if any) and rebuilds p.root from it. Returns nil
+// when the feed has no prior state (fresh publisher); a non-nil error
+// is logged but doesn't block publisher startup (caller falls back to
+// the empty-tree default).
+//
+// Idempotent — safe to call before goroutines start (Publisher.New
+// pattern) and serves as the recovery path for any future "wipe the
+// in-memory tree and rebuild" use case. Locking is intentionally
+// absent: callers hold the only reference to p.root at this point.
+func (p *Publisher) hydrateFromContainer() error {
+	c := p.cxoNode.Container()
+	skyPK := skycipher.PubKey(p.pk)
+	nonce := c.ActiveHead(skyPK)
+	if nonce == 0 {
+		// No active head for this feed — fresh publisher state, no
+		// hydration needed. Not an error.
+		return nil
+	}
+	r, err := c.LastRoot(skyPK, nonce)
+	if err != nil {
+		return fmt.Errorf("LastRoot: %w", err)
+	}
+	if r == nil || len(r.Refs) == 0 {
+		return nil
+	}
+	skyfromCipher := skycipher.SecKey(p.sk)
+	up, err := c.Unpack(skyfromCipher, Registry)
+	if err != nil {
+		return fmt.Errorf("Unpack: %w", err)
+	}
+	defer up.Close() //nolint:errcheck
+
+	var rootNode TreeNode
+	if err := r.Refs[0].Value(up, &rootNode); err != nil {
+		return fmt.Errorf("decode root TreeNode: %w", err)
+	}
+	hydrated := newMemNode()
+	if err := hydrateMemNode(up, &rootNode, hydrated); err != nil {
+		return fmt.Errorf("walk: %w", err)
+	}
+	p.root = hydrated
+	return nil
+}
+
+// hydrateMemNode is the publisher-side counterpart to subscriber.go's
+// walkTree: same TreeNode decode loop, but builds a memNode tree
+// (with sub-nodes nested by name) instead of a flat path→value map.
+// The shape matches what encodeNode produces, so a subsequent publish
+// against the hydrated tree round-trips through publishRoot and
+// produces a Root identical to the one we just read — until a Put
+// mutates a path, after which the dirty-path-only re-encode keeps
+// the unchanged subtrees stable.
+func hydrateMemNode(up registry.Pack, node *TreeNode, dest *memNode) error {
+	n, err := node.Children.Len(up)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < n; i++ {
+		var entry TreeEntry
+		if _, err := node.Children.ValueByIndex(up, i, &entry); err != nil {
+			return err
+		}
+		if len(entry.Leaf) > 0 {
+			dest.leaves[entry.Name] = append([]byte(nil), entry.Leaf...)
+			continue
+		}
+		if entry.Sub.Hash == (skycipher.SHA256{}) {
+			continue
+		}
+		var sub TreeNode
+		if err := entry.Sub.Value(up, &sub); err != nil {
+			return err
+		}
+		child := newMemNode()
+		if err := hydrateMemNode(up, &sub, child); err != nil {
+			return err
+		}
+		dest.subs[entry.Name] = child
+	}
+	return nil
 }
 
 // Feed returns the public key of the feed. Subscribers connect using

--- a/pkg/cxo/treestore/publisher_rehydrate_test.go
+++ b/pkg/cxo/treestore/publisher_rehydrate_test.go
@@ -1,0 +1,317 @@
+// Package treestore — pkg/cxo/treestore/publisher_rehydrate_test.go:
+// pins the publisher-restart hydration contract added so that
+// subscribers' applySnapshot doesn't observe a truncated tree after
+// the publisher process restarts. Without this contract, the first
+// Put after restart publishes a Root whose Refs point at a TreeNode
+// containing only that single new leaf, every historical leaf gets
+// dropped from subscribers' caches, and the application layer sees a
+// silent catastrophic data loss across the receive-side feed.
+//
+// The integration story rides the existing manual E2E plan for the
+// full subscriber↔publisher loop; this file pins the publisher-side
+// invariant in isolation: Close + reopen on the same DataDir
+// reproduces the in-memory tree from the previously-published Root.
+package treestore
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+)
+
+// fileBackedNode constructs a CXO Node whose container persists to
+// disk under dataDir. Used by the rehydrate tests because the
+// in-memory backend the rest of the suite uses doesn't survive a
+// Close + reopen cycle.
+func fileBackedNode(t *testing.T, dataDir string, sk cipher.SecKey) *node.Node {
+	t.Helper()
+	cfg := node.NewConfig()
+	cfg.SecKey = skycipher.SecKey(sk)
+	cfg.Config = skyobject.NewConfig()
+	cfg.Config.DataDir = dataDir
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
+	n, err := node.NewNode(cfg)
+	if err != nil {
+		t.Fatalf("NewNode(%q): %v", dataDir, err)
+	}
+	return n
+}
+
+// closePublisher tears down a publisher in the test's preferred order
+// (publisher Close → node Close), surfacing the first error and
+// failing the test if either step errors.
+func closePublisher(t *testing.T, p *Publisher) {
+	t.Helper()
+	if err := p.Close(); err != nil {
+		t.Fatalf("publisher.Close: %v", err)
+	}
+}
+
+func TestPublisherHydrateFreshNodeNoOp(t *testing.T) {
+	// A freshly-constructed Publisher on a brand-new DataDir has no
+	// previously-published Root. hydrateFromContainer must short-
+	// circuit with no error and leave p.root as the default empty
+	// memNode. Pre-fix, the early-return for nonce=0 wasn't there
+	// and LastRoot returned data.ErrNoSuchFeed — accepting that as
+	// "fresh, skip" is the contract.
+	dir := t.TempDir()
+	_, sk := cipher.GenerateKeyPair()
+
+	n := fileBackedNode(t, filepath.Join(dir, "node"), sk)
+	defer func() { _ = n.Close() }()
+
+	p, err := New(n, sk, Config{BatchWindow: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer closePublisher(t, p)
+
+	// Empty tree → root has no leaves and no sub-trees.
+	if got := len(p.root.leaves); got != 0 {
+		t.Errorf("fresh publisher: expected zero leaves, got %d", got)
+	}
+	if got := len(p.root.subs); got != 0 {
+		t.Errorf("fresh publisher: expected zero sub-trees, got %d", got)
+	}
+}
+
+func TestPublisherHydrateRebuildsTreeAcrossRestart(t *testing.T) {
+	// End-to-end of the bug + fix: publish a few leaves through one
+	// publisher instance, Close it, reopen on the same DataDir, and
+	// confirm the new publisher's in-memory tree mirrors the
+	// pre-Close state. Without hydration the second publisher's
+	// p.root is empty; with hydration it carries the historical
+	// leaves so the next Put publishes a Root with both old + new.
+	dataDir := t.TempDir()
+	nodeDir := filepath.Join(dataDir, "node")
+	_, sk := cipher.GenerateKeyPair()
+
+	// First publisher instance: write three leaves at distinct
+	// paths (root-level + a nested path) so the test exercises both
+	// leaf and sub-tree hydration branches.
+	n1 := fileBackedNode(t, nodeDir, sk)
+	p1, err := New(n1, sk, Config{BatchWindow: 10 * time.Millisecond})
+	if err != nil {
+		_ = n1.Close()
+		t.Fatalf("New (instance 1): %v", err)
+	}
+	puts := []struct {
+		path  string
+		value []byte
+	}{
+		{"alpha", []byte("alpha-value")},
+		{"beta/one", []byte("beta-one-value")},
+		{"beta/two", []byte("beta-two-value")},
+	}
+	for _, put := range puts {
+		if err := p1.Put(put.path, put.value); err != nil {
+			_ = p1.Close()
+			_ = n1.Close()
+			t.Fatalf("Put(%q): %v", put.path, err)
+		}
+	}
+	if err := p1.Flush(); err != nil {
+		_ = p1.Close()
+		_ = n1.Close()
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := p1.Close(); err != nil {
+		_ = n1.Close()
+		t.Fatalf("publisher.Close: %v", err)
+	}
+	if err := n1.Close(); err != nil {
+		t.Fatalf("node.Close: %v", err)
+	}
+
+	// Second publisher instance: same SecKey, same DataDir. The
+	// in-memory tree should be rebuilt from the previously-published
+	// Root before runLoop starts.
+	n2 := fileBackedNode(t, nodeDir, sk)
+	defer func() { _ = n2.Close() }()
+	p2, err := New(n2, sk, Config{BatchWindow: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("New (instance 2): %v", err)
+	}
+	defer closePublisher(t, p2)
+
+	// Verify leaf reachable at root and via the nested sub-tree.
+	if got, ok := p2.Get("alpha"); !ok || !bytes.Equal(got, []byte("alpha-value")) {
+		t.Errorf("Get(alpha): ok=%v got=%q want=%q", ok, got, "alpha-value")
+	}
+	if got, ok := p2.Get("beta/one"); !ok || !bytes.Equal(got, []byte("beta-one-value")) {
+		t.Errorf("Get(beta/one): ok=%v got=%q want=%q", ok, got, "beta-one-value")
+	}
+	if got, ok := p2.Get("beta/two"); !ok || !bytes.Equal(got, []byte("beta-two-value")) {
+		t.Errorf("Get(beta/two): ok=%v got=%q want=%q", ok, got, "beta-two-value")
+	}
+}
+
+func TestPublisherHydrateNextPublishContainsHistoricalLeaves(t *testing.T) {
+	// The end-to-end consequence the receive-side stall hinged on:
+	// after Close + reopen, the FIRST publish has to include
+	// historical leaves alongside the newly-added one. Without
+	// hydration, the first publishRoot encoded a 1-leaf TreeNode
+	// and subscribers' applySnapshot replaced their cache with the
+	// truncated tree (emitting delete events for everything
+	// historical). With hydration the new Root's TreeNode contains
+	// both, and a subscriber-side applySnapshot diff would be a
+	// pure insert for the new leaf with no deletes.
+	dataDir := t.TempDir()
+	nodeDir := filepath.Join(dataDir, "node")
+	pk, sk := cipher.GenerateKeyPair()
+
+	n1 := fileBackedNode(t, nodeDir, sk)
+	p1, err := New(n1, sk, Config{BatchWindow: 10 * time.Millisecond})
+	if err != nil {
+		_ = n1.Close()
+		t.Fatalf("New (instance 1): %v", err)
+	}
+	for _, path := range []string{"msgs/one", "msgs/two"} {
+		if err := p1.Put(path, []byte(path+"-body")); err != nil {
+			_ = p1.Close()
+			_ = n1.Close()
+			t.Fatalf("Put(%q): %v", path, err)
+		}
+	}
+	if err := p1.Flush(); err != nil {
+		_ = p1.Close()
+		_ = n1.Close()
+		t.Fatalf("Flush: %v", err)
+	}
+	_ = p1.Close()
+	_ = n1.Close()
+
+	n2 := fileBackedNode(t, nodeDir, sk)
+	defer func() { _ = n2.Close() }()
+	p2, err := New(n2, sk, Config{BatchWindow: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("New (instance 2): %v", err)
+	}
+	defer closePublisher(t, p2)
+
+	// Add a new leaf and publish. Walk the resulting Root's TreeNode
+	// to confirm it contains all three paths (msgs/one, msgs/two
+	// from instance 1 + msgs/three from instance 2).
+	if err := p2.Put("msgs/three", []byte("msgs/three-body")); err != nil {
+		t.Fatalf("Put(msgs/three): %v", err)
+	}
+	if err := p2.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Read the latest Root and walk its tree to compare against the
+	// expected leaf set.
+	c := p2.cxoNode.Container()
+	skyPK := skycipher.PubKey(pk)
+	nonce := c.ActiveHead(skyPK)
+	if nonce == 0 {
+		t.Fatalf("ActiveHead returned zero after publish — root not persisted")
+	}
+	r, err := c.LastRoot(skyPK, nonce)
+	if err != nil {
+		t.Fatalf("LastRoot: %v", err)
+	}
+	if r == nil || len(r.Refs) == 0 {
+		t.Fatalf("LastRoot returned empty root")
+	}
+	up, err := c.Unpack(skycipher.SecKey(sk), Registry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	defer func() { _ = up.Close() }()
+
+	var rootNode TreeNode
+	if err := r.Refs[0].Value(up, &rootNode); err != nil {
+		t.Fatalf("decode rootNode: %v", err)
+	}
+	walked := make(map[string][]byte)
+	if err := walkTree(up, &rootNode, "", walked); err != nil {
+		t.Fatalf("walkTree: %v", err)
+	}
+
+	want := map[string][]byte{
+		"msgs/one":   []byte("msgs/one-body"),
+		"msgs/two":   []byte("msgs/two-body"),
+		"msgs/three": []byte("msgs/three-body"),
+	}
+	for path, wantVal := range want {
+		got, ok := walked[path]
+		if !ok {
+			t.Errorf("post-restart Root missing %q (this is the pre-fix bug)", path)
+			continue
+		}
+		if !bytes.Equal(got, wantVal) {
+			t.Errorf("post-restart Root %q: got %q want %q", path, got, wantVal)
+		}
+	}
+	for path := range walked {
+		if _, ok := want[path]; !ok {
+			t.Errorf("post-restart Root has unexpected path %q", path)
+		}
+	}
+}
+
+func TestHydrateMemNodeWalksLeavesAndSubTrees(t *testing.T) {
+	// Direct exercise of the hydration walker. Build a TreeNode with
+	// one leaf + one sub-tree (which itself contains a leaf), save
+	// it through a Pack, then walk it via hydrateMemNode and confirm
+	// the resulting memNode mirror has both shapes. Avoids the
+	// publisher-restart machinery so the test fails fast on a regression
+	// in the walker itself.
+	dir := t.TempDir()
+	_, sk := cipher.GenerateKeyPair()
+
+	n := fileBackedNode(t, dir, sk)
+	defer func() { _ = n.Close() }()
+
+	c := n.Container()
+	up, err := c.Unpack(skycipher.SecKey(sk), Registry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	defer func() { _ = up.Close() }()
+
+	// Build inner TreeNode (one leaf), then outer TreeNode (one leaf
+	// at the root + an entry whose Sub points at inner).
+	innerLeaf := TreeEntry{Name: "deep", Leaf: []byte("deep-value")}
+	innerNode := TreeNode{}
+	if err := innerNode.Children.AppendValues(up, innerLeaf); err != nil {
+		t.Fatalf("inner.AppendValues: %v", err)
+	}
+	var innerRef registry.Ref
+	if err := innerRef.SetValue(up, &innerNode); err != nil {
+		t.Fatalf("inner.SetValue: %v", err)
+	}
+
+	outerLeaf := TreeEntry{Name: "alpha", Leaf: []byte("alpha-value")}
+	outerSub := TreeEntry{Name: "beta", Sub: innerRef}
+	outerNode := TreeNode{}
+	if err := outerNode.Children.AppendValues(up, outerLeaf, outerSub); err != nil {
+		t.Fatalf("outer.AppendValues: %v", err)
+	}
+
+	dest := newMemNode()
+	if err := hydrateMemNode(up, &outerNode, dest); err != nil {
+		t.Fatalf("hydrateMemNode: %v", err)
+	}
+	if got, want := string(dest.leaves["alpha"]), "alpha-value"; got != want {
+		t.Errorf("dest.leaves[alpha]: got %q want %q", got, want)
+	}
+	beta, ok := dest.subs["beta"]
+	if !ok {
+		t.Fatalf("dest.subs[beta]: missing")
+	}
+	if got, want := string(beta.leaves["deep"]), "deep-value"; got != want {
+		t.Errorf("dest.subs[beta].leaves[deep]: got %q want %q", got, want)
+	}
+}

--- a/pkg/cxo/treestore/publisher_rehydrate_test.go
+++ b/pkg/cxo/treestore/publisher_rehydrate_test.go
@@ -68,7 +68,9 @@ func TestPublisherHydrateFreshNodeNoOp(t *testing.T) {
 	_, sk := cipher.GenerateKeyPair()
 
 	n := fileBackedNode(t, filepath.Join(dir, "node"), sk)
-	defer func() { _ = n.Close() }()
+	defer func() {
+		_ = n.Close() //nolint:errcheck
+	}()
 
 	p, err := New(n, sk, Config{BatchWindow: 10 * time.Millisecond})
 	if err != nil {
@@ -102,7 +104,7 @@ func TestPublisherHydrateRebuildsTreeAcrossRestart(t *testing.T) {
 	n1 := fileBackedNode(t, nodeDir, sk)
 	p1, err := New(n1, sk, Config{BatchWindow: 10 * time.Millisecond})
 	if err != nil {
-		_ = n1.Close()
+		_ = n1.Close() //nolint:errcheck
 		t.Fatalf("New (instance 1): %v", err)
 	}
 	puts := []struct {
@@ -115,18 +117,18 @@ func TestPublisherHydrateRebuildsTreeAcrossRestart(t *testing.T) {
 	}
 	for _, put := range puts {
 		if err := p1.Put(put.path, put.value); err != nil {
-			_ = p1.Close()
-			_ = n1.Close()
+			_ = p1.Close() //nolint:errcheck
+			_ = n1.Close() //nolint:errcheck
 			t.Fatalf("Put(%q): %v", put.path, err)
 		}
 	}
 	if err := p1.Flush(); err != nil {
-		_ = p1.Close()
-		_ = n1.Close()
+		_ = p1.Close() //nolint:errcheck
+		_ = n1.Close() //nolint:errcheck
 		t.Fatalf("Flush: %v", err)
 	}
 	if err := p1.Close(); err != nil {
-		_ = n1.Close()
+		_ = n1.Close() //nolint:errcheck
 		t.Fatalf("publisher.Close: %v", err)
 	}
 	if err := n1.Close(); err != nil {
@@ -137,7 +139,9 @@ func TestPublisherHydrateRebuildsTreeAcrossRestart(t *testing.T) {
 	// in-memory tree should be rebuilt from the previously-published
 	// Root before runLoop starts.
 	n2 := fileBackedNode(t, nodeDir, sk)
-	defer func() { _ = n2.Close() }()
+	defer func() {
+		_ = n2.Close() //nolint:errcheck
+	}()
 	p2, err := New(n2, sk, Config{BatchWindow: 10 * time.Millisecond})
 	if err != nil {
 		t.Fatalf("New (instance 2): %v", err)
@@ -173,26 +177,28 @@ func TestPublisherHydrateNextPublishContainsHistoricalLeaves(t *testing.T) {
 	n1 := fileBackedNode(t, nodeDir, sk)
 	p1, err := New(n1, sk, Config{BatchWindow: 10 * time.Millisecond})
 	if err != nil {
-		_ = n1.Close()
+		_ = n1.Close() //nolint:errcheck
 		t.Fatalf("New (instance 1): %v", err)
 	}
 	for _, path := range []string{"msgs/one", "msgs/two"} {
 		if err := p1.Put(path, []byte(path+"-body")); err != nil {
-			_ = p1.Close()
-			_ = n1.Close()
+			_ = p1.Close() //nolint:errcheck
+			_ = n1.Close() //nolint:errcheck
 			t.Fatalf("Put(%q): %v", path, err)
 		}
 	}
 	if err := p1.Flush(); err != nil {
-		_ = p1.Close()
-		_ = n1.Close()
+		_ = p1.Close() //nolint:errcheck
+		_ = n1.Close() //nolint:errcheck
 		t.Fatalf("Flush: %v", err)
 	}
-	_ = p1.Close()
-	_ = n1.Close()
+	_ = p1.Close() //nolint:errcheck
+	_ = n1.Close() //nolint:errcheck
 
 	n2 := fileBackedNode(t, nodeDir, sk)
-	defer func() { _ = n2.Close() }()
+	defer func() {
+		_ = n2.Close() //nolint:errcheck
+	}()
 	p2, err := New(n2, sk, Config{BatchWindow: 10 * time.Millisecond})
 	if err != nil {
 		t.Fatalf("New (instance 2): %v", err)
@@ -228,7 +234,9 @@ func TestPublisherHydrateNextPublishContainsHistoricalLeaves(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unpack: %v", err)
 	}
-	defer func() { _ = up.Close() }()
+	defer func() {
+		_ = up.Close() //nolint:errcheck
+	}()
 
 	var rootNode TreeNode
 	if err := r.Refs[0].Value(up, &rootNode); err != nil {
@@ -272,14 +280,18 @@ func TestHydrateMemNodeWalksLeavesAndSubTrees(t *testing.T) {
 	_, sk := cipher.GenerateKeyPair()
 
 	n := fileBackedNode(t, dir, sk)
-	defer func() { _ = n.Close() }()
+	defer func() {
+		_ = n.Close() //nolint:errcheck
+	}()
 
 	c := n.Container()
 	up, err := c.Unpack(skycipher.SecKey(sk), Registry)
 	if err != nil {
 		t.Fatalf("Unpack: %v", err)
 	}
-	defer func() { _ = up.Close() }()
+	defer func() {
+		_ = up.Close() //nolint:errcheck
+	}()
 
 	// Build inner TreeNode (one leaf), then outer TreeNode (one leaf
 	// at the root + an entry whose Sub points at inner).


### PR DESCRIPTION
Complementary to #2647. Where #2647 fixes \"subscriber's initial fill aborted; reconnect re-Subscribes; publisher acks-ok without re-pushing the current Root\" (subscriber-side recovery against a healthy publisher), this PR fixes \"publisher restarts; its in-memory memNode starts empty; the FIRST Put after restart publishes a Root whose Refs point at a TreeNode containing only that one new leaf; subscribers' applySnapshot replaces their cache with the truncated tree and emits delete events for every historical leaf.\"

The bbolt-persisted CXO objects survive the restart, so the previous Root is reachable via `Container.LastRoot(pk, ActiveHead)`. Walking it back into the memNode keeps publish continuity across process boundaries: the next Put encodes a Root that contains both the historical leaves and the new one, and subscribers' applySnapshot diff stays a pure insert for the new leaf with no spurious deletes.

## Empirical

Observed in today's T2-sustained 3-agent reliability test. With the full cascade (#2606 + #2608 + #2620 + #2622 + #2623 + #2625 + #2627 + #2643) in place, sustained 30 min × 1/min × 3 senders still showed ~50–83% receive drop in tallies:

| Receiver | a (Alpha sends) | b (Beta sends) | g (Gamma sends) |
| --- | --- | --- | --- |
| Gamma | 11/30 | 5/30 | 26/30 (self) |
| Alpha | (self) | 10/30 | 6/30 |

The receive timestamp pattern: Gamma got probea-01, 09, then 19..30 (after Alpha's 14:47Z restart on commit `b2b1541797a3`). Probes 14:18..14:46 were lost — exactly the window where Alpha had restarted its publisher and the in-memory tree was empty, so each new send re-published a single-leaf root. Combined with the subscriber-side gap #2647 closes, this fully explains the T2 data.

## Wiring

- **`Publisher.hydrateFromContainer()`** — new method on Publisher. Calls `c.LastRoot(pk, c.ActiveHead(pk))`; on first construction with a brand-new feed, `ActiveHead` returns 0 and the method short-circuits with nil error (fresh state, no hydration needed). On a previously-active feed, it Unpacks the Root, decodes `r.Refs[0]` as a TreeNode, and walks the tree via the new helper.

- **`hydrateMemNode(up, node, dest)`** — publisher-side counterpart to subscriber.go's `walkTree`. Same TreeNode decode loop, but builds the nested memNode shape (leaves and subs by name) instead of the subscriber's flat path→value map.

- **`Publisher.New()`** calls `hydrateFromContainer` immediately after the struct is initialized and before `runLoop` starts. Errors from hydration are logged at debug level and degrade to the existing empty-tree fallback — a corrupted on-disk state can't block the publisher from coming up.

## Tests

`publisher_rehydrate_test.go` (4 tests):

1. `TestPublisherHydrateFreshNodeNoOp` — brand-new DataDir → no prior Root → hydrate is a no-op, p.root stays empty.
2. `TestPublisherHydrateRebuildsTreeAcrossRestart` — publish three leaves (one at root, two in a nested sub-tree), Close + reopen, confirm `Get(...)` returns each leaf with its original value on the new publisher instance.
3. `TestPublisherHydrateNextPublishContainsHistoricalLeaves` — the end-to-end consequence. Publish two leaves, Close + reopen, publish one new leaf, walk the freshly-published Root via `walkTree`, confirm the new Root contains ALL three leaves.
4. `TestHydrateMemNodeWalksLeavesAndSubTrees` — direct exercise of the walker on a hand-constructed TreeNode + sub-tree.

`go test -race -count=1 ./pkg/cxo/treestore/...` clean. `go vet` clean. `gofmt -l` clean.

## Related

- #2647 — handleSub always pushes current Root on duplicate Subscribe. Complementary; this PR fixes the orthogonal publisher-restart case.
- #2630 — replay-on-reconnect at the gRPC streaming layer. Different layer (chat-app→CLI); doesn't reach the CXO subscriber↔publisher loop this PR addresses.
- #2625 / #2643 — stale-Conn eviction on accept / dial paths. Different mechanism.