### PR TITLE
fix(cxo): thread context.Context through Subscriber.Connect → dmsg ConnectPK

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -780,12 +780,13 @@ func (s *Session) Connect(ctx context.Context) error {
 	// deadline we wrap each Connect call in a goroutine and select
 	// on ctx — the goroutine's underlying dial may still run to
 	// completion in the background, but it won't block the outer
-	// caller past ctx's deadline. A future refinement plumbs ctx
-	// through Subscriber.Connect → dmsg.ConnectPK for true
-	// cancellation.
+	// caller past ctx's deadline. Post-T2a (ctx-through-ConnectPK)
+	// the underlying dmsg dial also honors ctx, so a canceled
+	// Connect actually aborts the dial rather than leaking a
+	// goroutine that runs to completion before discarding its result.
 	if s.sub != nil {
 		done := make(chan error, 1)
-		go func() { done <- s.sub.Connect(s.cfg.Record.OwnerPK) }()
+		go func() { done <- s.sub.Connect(ctx, s.cfg.Record.OwnerPK) }()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -833,7 +834,7 @@ func (s *Session) Connect(ctx context.Context) error {
 		}
 		done := make(chan error, 1)
 		pkLocal, psLocal := pk, ps
-		go func() { done <- psLocal.Connect(pkLocal) }()
+		go func() { done <- psLocal.Connect(ctx, pkLocal) }()
 		select {
 		case <-ctx.Done():
 			// Outer deadline fired mid-Connect. The goroutine will
@@ -1017,7 +1018,7 @@ func (s *Session) ReconnectPeer(ctx context.Context, pk cipher.PubKey) error {
 		return nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- ps.Connect(pk) }()
+	go func() { done <- ps.Connect(ctx, pk) }()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1066,7 +1067,7 @@ func (s *Session) ReconnectLegacySub(ctx context.Context) error {
 		return nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- s.sub.Connect(s.cfg.Record.OwnerPK) }()
+	go func() { done <- s.sub.Connect(ctx, s.cfg.Record.OwnerPK) }()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1272,8 +1273,14 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 		ps.OnUpdate(s.makePeerOnUpdate(pk))
 		// Best-effort connect — same semantics as Connect's per-peer
 		// retry: a peer that's offline now will be picked up on the
-		// next reconnect tick once the publisher comes back.
-		if err := ps.Connect(pk); err != nil {
+		// next reconnect tick once the publisher comes back. Bound
+		// the dial with a short timeout so a single unreachable peer
+		// in the allowlist doesn't block roster expansion. The retry
+		// loop will pick it up on a later tick with its own deadline.
+		dctx, dcancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
+		err = ps.Connect(dctx, pk)
+		dcancel()
+		if err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).
 				Debug("group: SetAllowlist: peer-sub Connect failed; will retry on next reconnect tick")
 		} else if a := s.peerLastInboundNs[pk]; a != nil {

--- a/cmd/apps/skychat/pairing/integration_test.go
+++ b/cmd/apps/skychat/pairing/integration_test.go
@@ -16,6 +16,7 @@
 package pairing
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"sync"
@@ -111,7 +112,7 @@ func TestPairRoundTripOverDmsg(t *testing.T) {
 	connectWithRetry := func(p *Pair) error {
 		var lastErr error
 		for attempt := 0; attempt < 10; attempt++ {
-			if err := p.Connect(); err == nil {
+			if err := p.Connect(context.Background()); err == nil {
 				return nil
 			} else {
 				lastErr = err

--- a/cmd/apps/skychat/pairing/pair.go
+++ b/cmd/apps/skychat/pairing/pair.go
@@ -22,6 +22,7 @@
 package pairing
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -171,11 +172,15 @@ func Open(cfg Config) (*Pair, error) {
 // Connect dials the peer's CXO node and starts the subscribe
 // handshake. Idempotent: returns nil if already connected.
 //
+// ctx bounds the dmsg dial — see Subscriber.Connect. Callers without
+// a natural ctx can pass context.Background(); the dial will then
+// rely on dmsg's own timeouts to escape a hung peer.
+//
 // Open + Connect are split so the pairing handshake can stage the
 // publisher before the peer is known to be ready, then activate the
 // inbound side once the peer's pair-ack arrives.
-func (p *Pair) Connect() error {
-	if err := p.sub.Connect(p.cfg.PeerPK); err != nil {
+func (p *Pair) Connect(ctx context.Context) error {
+	if err := p.sub.Connect(ctx, p.cfg.PeerPK); err != nil {
 		return fmt.Errorf("pairing: Connect: %w", err)
 	}
 	return nil

--- a/pkg/cxo/node/rpc.go
+++ b/pkg/cxo/node/rpc.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/rpc"
@@ -364,7 +365,10 @@ type DMSGRPC struct {
 	n *Node
 }
 
-// Connect to a remote CXO node over DMSG by public key.
+// Connect to a remote CXO node over DMSG by public key. net/rpc's
+// method signature doesn't carry a ctx, so the dial is bounded only
+// by the dmsg client's own timeouts. Callers that need cancellation
+// must reach (*DMSG).ConnectPK directly with their own context.
 func (d *DMSGRPC) Connect(pk cipher.PubKey, _ *struct{}) error {
 	dmsgT := d.n.DMSG()
 	if dmsgT == nil {
@@ -373,7 +377,7 @@ func (d *DMSGRPC) Connect(pk cipher.PubKey, _ *struct{}) error {
 	// Convert skycoin cipher.PubKey to skywire cipher.PubKey
 	var swPK swcipher.PubKey
 	copy(swPK[:], pk[:])
-	_, err := dmsgT.ConnectPK(swPK)
+	_, err := dmsgT.ConnectPK(context.Background(), swPK)
 	return err
 }
 

--- a/pkg/cxo/node/transport/dmsg.go
+++ b/pkg/cxo/node/transport/dmsg.go
@@ -84,10 +84,14 @@ func (f *DMSGFactory) Address() string {
 	return ""
 }
 
-// Connect dials a remote CXO node over DMSG by public key.
-func (f *DMSGFactory) Connect(remotePK cipher.PubKey) (*Connection, error) {
+// Connect dials a remote CXO node over DMSG by public key. ctx is
+// passed straight to dmsg.Client.Dial — a canceled or expired ctx
+// aborts the dial and returns ctx.Err() (wrapped). Callers that
+// don't need cancellation can pass context.Background(); the
+// (*DMSG).ConnectPK wrapper threads its caller's ctx through here.
+func (f *DMSGFactory) Connect(ctx context.Context, remotePK cipher.PubKey) (*Connection, error) {
 	addr := dmsg.Addr{PK: remotePK, Port: f.port}
-	conn, err := f.dmsgC.Dial(context.Background(), addr)
+	conn, err := f.dmsgC.Dial(ctx, addr)
 	if err != nil {
 		return nil, fmt.Errorf("dmsg dial %v: %w", addr, err)
 	}

--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -4,6 +4,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -73,6 +74,14 @@ func (d *DMSG) Listen() error {
 // ConnectPK connects to a remote CXO node over DMSG by public key.
 // If a healthy connection already exists, returns the existing one.
 //
+// ctx bounds the underlying dmsg.Client.Dial — when ctx is canceled
+// or its deadline elapses before the dial completes, ConnectPK
+// returns ctx.Err() rather than blocking on a half-dead transport.
+// Pre-this-change the dmsg dial used context.Background(), so a
+// peer hung at the dmsg layer would survive the caller's deadline
+// (Manager.tryReconnectPeers, Session.ReconnectPeer, …) and pin a
+// goroutine in the dial until OS-level keepalive fired.
+//
 // Cached-Conn liveness gate: a cached Conn whose closeq is signaled
 // (run loop has observed the underlying transport going away, but
 // removeConn hasn't yet completed) OR whose underlying transport
@@ -102,7 +111,7 @@ func (d *DMSG) Listen() error {
 // network with no FIN/RST) — that path needs a separate liveness
 // pulse, deferred. For typical "peer's dmsg server flipped /
 // transport reset cleanly" failures this is sufficient.
-func (d *DMSG) ConnectPK(remotePK cipher.PubKey) (*Conn, error) {
+func (d *DMSG) ConnectPK(ctx context.Context, remotePK cipher.PubKey) (*Conn, error) {
 	d.n.Debugf(NewOutConnPin, "[dmsg:%s] connecting", remotePK.String())
 
 	// Check if connection already exists AND is alive.
@@ -119,7 +128,7 @@ func (d *DMSG) ConnectPK(remotePK cipher.PubKey) (*Conn, error) {
 	}
 
 	// Dial over DMSG
-	fc, err := d.DMSGFactory.Connect(remotePK)
+	fc, err := d.DMSGFactory.Connect(ctx, remotePK)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -11,6 +11,7 @@
 package treestore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -341,7 +342,7 @@ func (p *Publisher) AllowsSubscriber(pk cipher.PubKey) bool {
 // then sees the inbound conn and subscribes to the visor's feed
 // (PK = visor PK = the publisher feed). Idempotent: returns nil for
 // an existing live conn, redials if the previous conn has dropped.
-func (p *Publisher) AnnounceTo(peerPK cipher.PubKey) error {
+func (p *Publisher) AnnounceTo(ctx context.Context, peerPK cipher.PubKey) error {
 	if p.cxoNode == nil {
 		return errors.New("treestore: publisher has no cxo node")
 	}
@@ -349,7 +350,7 @@ func (p *Publisher) AnnounceTo(peerPK cipher.PubKey) error {
 	if dmsgT == nil {
 		return errors.New("treestore: publisher has no dmsg transport")
 	}
-	_, err := dmsgT.ConnectPK(peerPK)
+	_, err := dmsgT.ConnectPK(ctx, peerPK)
 	return err
 }
 

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -17,6 +17,7 @@
 package treestore
 
 import (
+	"context"
 	"sync"
 
 	skycipher "github.com/skycoin/skycoin/src/cipher"
@@ -172,13 +173,19 @@ func NewSubscriberOnNode(cxoNode *node.Node, feedPK cipher.PubKey, conf SubConfi
 // Connect dials the publisher over DMSG and subscribes to the feed
 // PK provided at construction. Updates begin flowing on the next
 // publish.
-func (s *Subscriber) Connect(publisherPK cipher.PubKey) error {
+//
+// ctx bounds the dial — when ctx is canceled or its deadline elapses
+// before the underlying DMSG handshake completes, Connect returns
+// ctx.Err() promptly instead of blocking on a half-dead transport.
+// Cancellation is plumbed all the way to dmsg.Client.Dial via the
+// (*DMSG).ConnectPK → (*DMSGFactory).Connect chain.
+func (s *Subscriber) Connect(ctx context.Context, publisherPK cipher.PubKey) error {
 	dmsgT := s.cxoNode.DMSG()
 	if dmsgT == nil {
 		return node.ErrAlreadyListen
 	}
 
-	conn, err := dmsgT.ConnectPK(publisherPK)
+	conn, err := dmsgT.ConnectPK(ctx, publisherPK)
 	if err != nil {
 		return err
 	}

--- a/pkg/visor/api_tpd_metrics_subscriber.go
+++ b/pkg/visor/api_tpd_metrics_subscriber.go
@@ -20,6 +20,7 @@
 package visor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -114,7 +115,12 @@ func (v *Visor) ensureTPDMetricsSubscriber() (*tpdMetricsSubscriber, error) {
 		}
 		v.tpdMetricsSubMu.Unlock()
 	})
-	if err := sub.Connect(tpdPK); err != nil {
+	// Per-attempt deadline on the dmsg dial — Subscriber.Connect's ctx
+	// is plumbed all the way to dmsg.Client.Dial post-T2a.
+	dctx, dcancel := context.WithTimeout(context.Background(), pairConnectTimeout)
+	err = sub.Connect(dctx, tpdPK)
+	dcancel()
+	if err != nil {
 		_ = sub.Close() //nolint:errcheck
 		return nil, fmt.Errorf("dial tpd metrics publisher: %w", err)
 	}

--- a/pkg/visor/api_tpd_uptime_subscriber.go
+++ b/pkg/visor/api_tpd_uptime_subscriber.go
@@ -21,6 +21,7 @@
 package visor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -144,11 +145,15 @@ func (v *Visor) ensureTPDUptimeSubscriber() (*tpdUptimeSubscriber, error) {
 	})
 
 	// Connect can hang indefinitely when the publisher's listener is
-	// down (e.g. TPD is panicking). Run it in a goroutine and bound
-	// the wait — anything past connectTimeout is treated as a cache
-	// miss so the handler chain falls through to DMSG-HTTP / HTTP.
+	// down (e.g. TPD is panicking). Bound the dial via the ctx that
+	// Subscriber.Connect now threads to dmsg.Client.Dial (post-T2a),
+	// and keep the goroutine+select wrapper as belt-and-suspenders
+	// so the outer time.After fires reliably even if a future
+	// regression removes the ctx-honoring in the dmsg layer.
+	dctx, dcancel := context.WithTimeout(context.Background(), connectTimeout)
+	defer dcancel()
 	done := make(chan error, 1)
-	go func() { done <- sub.Connect(tpdPK) }()
+	go func() { done <- sub.Connect(dctx, tpdPK) }()
 	select {
 	case err := <-done:
 		if err != nil {

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -624,7 +624,7 @@ func (m *CXOSubscriptionManager) syncOnce(ctx context.Context, fk CXOFeed, f *ma
 		}
 	})
 
-	if err := sub.Connect(peerPK); err != nil {
+	if err := sub.Connect(ctx, peerPK); err != nil {
 		_ = sub.Close() //nolint:errcheck
 		f.recordErr(fmt.Errorf("dial publisher: %w", err))
 		return

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -125,19 +125,25 @@ const announceInterval = 30 * time.Second
 func runAnnounceLoop(ctx context.Context, pub *treestore.Publisher, tpdPK cipher.PubKey, log *logging.Logger) {
 	t := time.NewTicker(announceInterval)
 	defer t.Stop()
-	announceOnce(pub, tpdPK, log)
+	announceOnce(ctx, pub, tpdPK, log)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			announceOnce(pub, tpdPK, log)
+			announceOnce(ctx, pub, tpdPK, log)
 		}
 	}
 }
 
-func announceOnce(pub *treestore.Publisher, tpdPK cipher.PubKey, log *logging.Logger) {
-	if err := pub.AnnounceTo(tpdPK); err != nil {
+func announceOnce(ctx context.Context, pub *treestore.Publisher, tpdPK cipher.PubKey, log *logging.Logger) {
+	// Per-attempt deadline bounds the dmsg dial: announceInterval is
+	// 30s, but the publisher's CXO ConnectPK can block on a half-dead
+	// transport much longer than that. Cap each attempt at half the
+	// interval so a stuck dial doesn't starve the next tick.
+	dctx, cancel := context.WithTimeout(ctx, announceInterval/2)
+	defer cancel()
+	if err := pub.AnnounceTo(dctx, tpdPK); err != nil {
 		// Trace-level: this races with TPD start-up and DMSG
 		// readiness; transient failures are normal.
 		log.WithError(err).WithField("tpd_pk", tpdPK).Trace("Stats: CXO announce to TPD failed")

--- a/pkg/visor/pairing.go
+++ b/pkg/visor/pairing.go
@@ -12,6 +12,7 @@
 package visor
 
 import (
+	"context"
 	"errors"
 	"sort"
 	"sync"
@@ -20,6 +21,13 @@ import (
 	"github.com/skycoin/skywire/cmd/apps/skychat/pairing"
 	"github.com/skycoin/skywire/pkg/cipher"
 )
+
+// pairConnectTimeout bounds the dmsg dial in PairAdd. PairAdd is
+// operator-initiated (HTTP from the chat-app), so a single
+// unreachable peer shouldn't block the HTTP request beyond this
+// window. The publisher side is up regardless; the subscriber side
+// reconnects on next Resume.
+const pairConnectTimeout = 15 * time.Second
 
 // PairInfo is the public summary of a chat pair, returned by PairList
 // and used as the poll cursor for PairPoll.
@@ -66,7 +74,13 @@ func (v *Visor) PairAdd(peerPK cipher.PubKey) error {
 	if err != nil {
 		return err
 	}
-	if err := p.Connect(); err != nil {
+	// Bound the dial: PairAdd is operator-initiated (HTTP from the
+	// chat-app), so a single unreachable peer shouldn't block the
+	// HTTP request beyond the per-attempt window. Subscriber.Connect's
+	// ctx is plumbed all the way to dmsg.Client.Dial post-T2a.
+	dctx, dcancel := context.WithTimeout(context.Background(), pairConnectTimeout)
+	defer dcancel()
+	if err := p.Connect(dctx); err != nil {
 		// Connect-failure is non-fatal — the publisher side is up,
 		// and Resume on a future restart (or a manual retry) will
 		// pick up the subscriber side once the peer is reachable.


### PR DESCRIPTION
## Summary

The CXO subscriber's dial chain hardcoded \`context.Background()\` at the bottom:

\`\`\`
Subscriber.Connect → (*DMSG).ConnectPK → (*DMSGFactory).Connect
                   → dmsg.Client.Dial(context.Background(), addr)
\`\`\`

A caller's deadline never reached the actual dmsg dial. A peer hung at the dmsg layer would survive ctx-canceled callers (Manager.tryReconnectPeers, Session.ReconnectPeer, lazy TPD metrics/uptime subscribers, …) and pin a goroutine in the dial until OS-level keepalive eventually fired.

This is the Tier-2a follow-up noted at \`cmd/apps/skychat/group/session.go:780-785\`:

> A future refinement plumbs ctx through Subscriber.Connect → dmsg.ConnectPK for true cancellation.

This PR is that refinement.

## Plumbed

\`ctx context.Context\` added as first parameter to:

- \`Subscriber.Connect(ctx, pk)\`
- \`(*DMSG).ConnectPK(ctx, pk)\`
- \`(*DMSGFactory).Connect(ctx, pk)\` → \`dmsg.Client.Dial(ctx, addr)\`
- \`Pair.Connect(ctx)\`
- \`Publisher.AnnounceTo(ctx, pk)\`

## Call sites

Where the caller had a natural ctx (the goroutine+select-on-ctx wrappers in session.go, \`syncOnce\` ctx in cxo_subscription_manager.go, \`runAnnounceLoop\` ctx in init_stats.go) — threaded straight through.

Where the caller didn't have a natural ctx (\`Visor.PairAdd\` HTTP handler, \`Session.SetAllowlist\` member-add loop, lazy TPD metrics/uptime subscriber init) — a bounded \`context.WithTimeout\` is created at the dial site. Durations match existing per-attempt windows (\`pairConnectTimeout = 15s\`, \`reconnectAttemptTimeout = 15s\`, existing \`connectTimeout\`).

\`net/rpc.DMSGRPC.Connect\` has a fixed signature and can't carry ctx — it passes \`context.Background()\` with a comment pointing callers needing cancellation to \`(*DMSG).ConnectPK\` directly.

## Why the goroutine wrappers stay

The \`go func() { done <- ps.Connect(ctx, pk) }()\` + \`select { case <-ctx.Done(): … case err := <-done: … }\` patterns in session.go are kept as belt-and-suspenders so the outer timeout still fires if a future regression removes ctx-honoring in the dmsg layer. With this change the dial actually aborts on cancel, the goroutine returns promptly, and no work is wasted finishing a dial whose result will be discarded.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/cxo/... ./cmd/apps/skychat/... ./pkg/visor/...\` all green
- [ ] Live verify post-deploy: kill an Alpha-side dial mid-flight (e.g. block 30082 with iptables), observe Beta's tryReconnectPeers logs \"context deadline exceeded\" within 15s instead of stalling for 60s+