### PR TITLE
docs(cli/skychat/group): document persistent-wrapper requirement for listen

### DIFF
--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -385,6 +385,25 @@ backs off (1s→30s exponential), re-creates the rpc client, and
 resumes polling. Reduces the burn-the-CLI-Ctrl+C-relaunch
 friction operators hit during a development cycle.
 
+Wrap in a NEVER-TIMEOUT supervisor for agent/automation use:
+the gRPC stream itself self-recovers across visor restarts and
+dmsg blips (#2630), but the OUTER process (this listener
+binary) has no special survival mechanism — it runs until
+killed or its parent times it out. Tools that wrap it in a
+short-lived task (e.g. claude-code's Monitor with a 5-min
+default) WILL silently lose messages once the wrapper expires,
+even though the visor's subscriber is still receiving cleanly.
+
+  * claude-code Monitor: pass ` + "`persistent: true`" + ` (the wrapper runs
+    until session end or explicit TaskStop).
+  * systemd:             omit RuntimeMaxSec; rely on Restart=on-failure.
+  * tmux / shell:        plain ` + "`skywire cli skychat group listen`" + ` runs
+                       indefinitely; no other wrapping needed.
+
+If you observe "subscriber_alive=true on the visor side but
+agent didn't see the message," the outer wrapper is almost
+certainly the culprit. See https://github.com/skycoin/skywire/issues/2654.
+
 Output modes (mutually exclusive — passing both --raw and --json
 errors out):
   text (default): one line per message,


### PR DESCRIPTION
Closes #2654 option (1).

\`cli skychat group listen\` is supposed to be a long-running tail of inbound group messages; the underlying gRPC stream self-recovers across visor restarts and dmsg blips (#2630). But the OUTER process — typically a Monitor task or operator-launched script — has its own timeout, independent of the gRPC layer. Without an explicit persistent-mode setting, the wrapper expires during long idle gaps and the listener silently stops tailing while the visor's subscriber keeps receiving cleanly.

Hit twice in production today during 3-agent coordination:
- listener expired during an 8h+ idle gap between rotation tests
- listener expired mid-T2-redux2 burst at 19:00Z

This PR adds a help-text section documenting the persistent-mode wrapper requirement for agent / automation use, with concrete recipes:

\`\`\`
  * claude-code Monitor: persistent: true
  * systemd:             omit RuntimeMaxSec
  * tmux / shell:        plain invocation suffices
\`\`\`

Also flags the diagnostic signature (\`subscriber_alive=true\` on the visor side but agent didn't see the message) so operators recognize the failure mode and consult the issue.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/skywire-cli/commands/skychat/...\` passes
- [x] \`golangci-lint run ./cmd/skywire-cli/commands/skychat/...\` clean
- [x] \`skywire cli skychat group listen --help\` renders the new section correctly

## Follow-ups (not in this PR)

- Option (2) — periodic \`__listener_alive__\` heartbeat line. Land if (1) doesn't close the surprise factor in practice.
- Option (3) — \`listener_uptime\` in \`cli skychat group info\`. Belongs with the broader per-peer surface from #2628.