### PR TITLE
feat(skychat/group): mutation types + signing for roster/admin gossip

### DIFF
--- a/cmd/apps/skychat/group/gossip.go
+++ b/cmd/apps/skychat/group/gossip.go
@@ -1,0 +1,312 @@
+// Package group — cmd/apps/skychat/group/gossip.go: typed mutation
+// envelopes for cross-visor admin/roster gossip per the RFC at
+// docs/skychat_group_gossip_rfc.md (#2636 issue, #2656 PR).
+//
+// This file is intentionally pure types + sign/verify + JSON wire —
+// no CXO interaction yet. The publisher emit (step 2) and subscriber
+// apply (step 3) will live in adjacent files in the same package.
+// Keeping the cryptographic core isolated here means the sign/verify
+// path is exercised by deterministic unit tests without standing up
+// a DMSG fixture.
+//
+// Signing primitive: skywire's existing cipher.SignPayload /
+// VerifyPubKeySignedPayload (secp256k1, the same primitive used by
+// every visor PK). The RFC's "ed25519" wording was a holdover from
+// the design sketch — secp256k1 is what's in the binary and what's
+// already in operators' fingertips. Sig size: 65 bytes (64 sig +
+// 1 recovery byte), exposed as cipher.Sig.
+//
+// Canonical bytes: signing operates on a deterministic byte layout
+// (fixed field order, fixed-width integers, no JSON whitespace
+// dependency) so the same envelope always produces the same
+// signature regardless of how it's serialized over the wire. The
+// JSON encoding is the wire format; canonicalBytes is the signing
+// format.
+
+package group
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// RosterOp is the kind of roster mutation. Stored as a small
+// integer for canonical-bytes compactness and JSON round-trips as
+// the same integer (intentionally not a string so a future op type
+// never overlaps an old binary's parse).
+type RosterOp uint8
+
+const (
+	// RosterOpAdd records a peer being added to the member set.
+	// Idempotent: applying twice is a no-op.
+	RosterOpAdd RosterOp = 1
+	// RosterOpRemove records a peer being removed from the member
+	// set. Idempotent: applying to a peer already absent is a no-op.
+	RosterOpRemove RosterOp = 2
+)
+
+// AdminOp is the kind of admin-set mutation. Parallel to RosterOp.
+type AdminOp uint8
+
+const (
+	// AdminOpPromote grants admin authority to PeerPK.
+	// Idempotent: applying twice is a no-op.
+	AdminOpPromote AdminOp = 1
+	// AdminOpDemote revokes admin authority from PeerPK.
+	// Idempotent: applying to a non-admin is a no-op. The founder
+	// PK (Record.OwnerPK) cannot be demoted — Apply rejects the
+	// mutation per the reconciliation rule.
+	AdminOpDemote AdminOp = 2
+)
+
+// RosterMutation is one signed instruction to add or remove a
+// peer from the group's member set. Issued by an admin and applied
+// independently on every subscribing visor per the reconciliation
+// rule documented in the RFC.
+//
+// The signature covers the canonical-bytes encoding of GroupID +
+// Op + PeerPK + ParentSeq + IssuedAt + IssuerPK. Wire format is
+// JSON (this struct's MarshalJSON tags).
+type RosterMutation struct {
+	GroupID   uuid.UUID     `json:"group_id"`
+	Op        RosterOp      `json:"op"`
+	PeerPK    cipher.PubKey `json:"peer_pk"`
+	ParentSeq uint64        `json:"parent_seq"`
+	IssuedAt  time.Time     `json:"issued_at"`
+	IssuerPK  cipher.PubKey `json:"issuer_pk"`
+	Signature cipher.Sig    `json:"signature"`
+}
+
+// AdminMutation is one signed instruction to promote or demote a
+// peer in the admin set. Same envelope shape as RosterMutation
+// minus the Op type. Two structs (not one with a polymorphic Op)
+// keeps each mutation's path-on-the-feed scope obvious to the
+// subscriber's pattern-match.
+type AdminMutation struct {
+	GroupID   uuid.UUID     `json:"group_id"`
+	Op        AdminOp       `json:"op"`
+	PeerPK    cipher.PubKey `json:"peer_pk"`
+	ParentSeq uint64        `json:"parent_seq"`
+	IssuedAt  time.Time     `json:"issued_at"`
+	IssuerPK  cipher.PubKey `json:"issuer_pk"`
+	Signature cipher.Sig    `json:"signature"`
+}
+
+// canonicalBytesRoster returns the deterministic byte sequence
+// over a roster mutation's fields that gets signed. Fixed field
+// order, big-endian integers, fixed-width components. Adding new
+// fields to RosterMutation in the future REQUIRES bumping the
+// leading version byte so old verifiers can fast-reject the new
+// shape rather than silently mis-verifying a re-ordered layout.
+func canonicalBytesRoster(m RosterMutation) []byte {
+	// Pre-size: 1 (version) + 16 (uuid) + 1 (op) + 33 (pk) + 8 (seq) + 8 (ts) + 33 (issuer)
+	buf := make([]byte, 0, 1+16+1+33+8+8+33)
+	buf = append(buf, gossipCanonicalVersion)
+	buf = append(buf, m.GroupID[:]...)
+	buf = append(buf, byte(m.Op))
+	buf = append(buf, m.PeerPK[:]...)
+	var seq [8]byte
+	binary.BigEndian.PutUint64(seq[:], m.ParentSeq)
+	buf = append(buf, seq[:]...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], uint64(m.IssuedAt.UTC().UnixNano())) //nolint:gosec
+	buf = append(buf, ts[:]...)
+	buf = append(buf, m.IssuerPK[:]...)
+	// Hash once here so verifiers can compare a fixed-size digest
+	// instead of re-walking the byte concat. This is just a
+	// convenience for the verify path; cipher.SignPayload itself
+	// does its own SHA256 inside.
+	sum := sha256.Sum256(buf)
+	return sum[:]
+}
+
+// canonicalBytesAdmin is the parallel canonicalizer for
+// AdminMutation. Identical layout aside from the Op type tag.
+func canonicalBytesAdmin(m AdminMutation) []byte {
+	buf := make([]byte, 0, 1+16+1+33+8+8+33)
+	buf = append(buf, gossipCanonicalVersion)
+	buf = append(buf, m.GroupID[:]...)
+	buf = append(buf, byte(m.Op))
+	buf = append(buf, m.PeerPK[:]...)
+	var seq [8]byte
+	binary.BigEndian.PutUint64(seq[:], m.ParentSeq)
+	buf = append(buf, seq[:]...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], uint64(m.IssuedAt.UTC().UnixNano())) //nolint:gosec
+	buf = append(buf, ts[:]...)
+	buf = append(buf, m.IssuerPK[:]...)
+	sum := sha256.Sum256(buf)
+	return sum[:]
+}
+
+// gossipCanonicalVersion is the leading version byte of every
+// canonical-bytes layout. Bumped only on incompatible additions to
+// the signed field set; a verifier that doesn't recognize the
+// version returns ErrUnknownCanonicalVersion so an old binary
+// gracefully rejects a newer envelope instead of mis-verifying.
+const gossipCanonicalVersion byte = 1
+
+// Sentinel errors. Tests assert these directly; callers can
+// errors.Is them off the returned err.
+var (
+	// ErrGossipBadSignature is returned by Verify when the signature
+	// doesn't bind to (IssuerPK, canonicalBytes). Includes the case
+	// where the IssuerPK is the zero value.
+	ErrGossipBadSignature = errors.New("gossip: bad signature")
+
+	// ErrGossipMissingFields is returned when a required field is
+	// the zero value at sign or verify time (GroupID zero, IssuerPK
+	// zero, IssuedAt zero, Signature zero on verify). Catches
+	// constructor mistakes before the bad envelope hits the wire.
+	ErrGossipMissingFields = errors.New("gossip: missing required field")
+
+	// ErrGossipUnknownOp is returned when Op is outside the defined
+	// constant range. A subscriber that receives a future op type
+	// drops with this error rather than apply unknown semantics.
+	ErrGossipUnknownOp = errors.New("gossip: unknown op")
+
+	// ErrGossipDemoteFounder is returned when an AdminMutation
+	// would demote a group's founder. The reconciler rejects on
+	// this before applying the local admin-set change. Tested at
+	// the unit level by passing the founder PK as PeerPK; the
+	// integration with Record.OwnerPK happens in the apply path.
+	ErrGossipDemoteFounder = errors.New("gossip: cannot demote founder")
+)
+
+// SignRoster fills in IssuerPK + Signature on m using sec. m must
+// have GroupID, Op, PeerPK, IssuedAt, and (if non-zero) ParentSeq
+// already populated. The function does NOT mutate Op / GroupID /
+// PeerPK / ParentSeq / IssuedAt — caller owns those.
+//
+// Returns ErrGossipMissingFields when required inputs are zero,
+// ErrGossipUnknownOp when Op is out of range, or the underlying
+// cipher.SignPayload error.
+func SignRoster(m *RosterMutation, sec cipher.SecKey) error {
+	if m == nil {
+		return ErrGossipMissingFields
+	}
+	if m.GroupID == (uuid.UUID{}) || m.PeerPK == (cipher.PubKey{}) || m.IssuedAt.IsZero() {
+		return ErrGossipMissingFields
+	}
+	if m.Op != RosterOpAdd && m.Op != RosterOpRemove {
+		return ErrGossipUnknownOp
+	}
+	pk, err := sec.PubKey()
+	if err != nil {
+		return fmt.Errorf("derive issuer pubkey: %w", err)
+	}
+	m.IssuerPK = pk
+	sig, err := cipher.SignPayload(canonicalBytesRoster(*m), sec)
+	if err != nil {
+		return fmt.Errorf("sign roster mutation: %w", err)
+	}
+	m.Signature = sig
+	return nil
+}
+
+// SignAdmin is the parallel signer for AdminMutation.
+func SignAdmin(m *AdminMutation, sec cipher.SecKey) error {
+	if m == nil {
+		return ErrGossipMissingFields
+	}
+	if m.GroupID == (uuid.UUID{}) || m.PeerPK == (cipher.PubKey{}) || m.IssuedAt.IsZero() {
+		return ErrGossipMissingFields
+	}
+	if m.Op != AdminOpPromote && m.Op != AdminOpDemote {
+		return ErrGossipUnknownOp
+	}
+	pk, err := sec.PubKey()
+	if err != nil {
+		return fmt.Errorf("derive issuer pubkey: %w", err)
+	}
+	m.IssuerPK = pk
+	sig, err := cipher.SignPayload(canonicalBytesAdmin(*m), sec)
+	if err != nil {
+		return fmt.Errorf("sign admin mutation: %w", err)
+	}
+	m.Signature = sig
+	return nil
+}
+
+// VerifyRoster checks that m.Signature binds m.IssuerPK to the
+// canonical bytes. Returns nil on success, ErrGossipBadSignature
+// on mismatch, ErrGossipMissingFields when the envelope is
+// incomplete, ErrGossipUnknownOp on out-of-range Op.
+//
+// Verification is stateless: it does NOT check that IssuerPK is
+// in the local admin set (the reconciler does that), nor that
+// ParentSeq is sensible (also the reconciler's job). Those are
+// data-plane checks against current local state; this function
+// is the cryptographic-only check.
+func VerifyRoster(m RosterMutation) error {
+	if m.GroupID == (uuid.UUID{}) || m.PeerPK == (cipher.PubKey{}) ||
+		m.IssuerPK == (cipher.PubKey{}) || m.IssuedAt.IsZero() ||
+		m.Signature == (cipher.Sig{}) {
+		return ErrGossipMissingFields
+	}
+	if m.Op != RosterOpAdd && m.Op != RosterOpRemove {
+		return ErrGossipUnknownOp
+	}
+	if err := cipher.VerifyPubKeySignedPayload(m.IssuerPK, m.Signature, canonicalBytesRoster(m)); err != nil {
+		return fmt.Errorf("%w: %v", ErrGossipBadSignature, err)
+	}
+	return nil
+}
+
+// VerifyAdmin is the parallel verifier for AdminMutation.
+func VerifyAdmin(m AdminMutation) error {
+	if m.GroupID == (uuid.UUID{}) || m.PeerPK == (cipher.PubKey{}) ||
+		m.IssuerPK == (cipher.PubKey{}) || m.IssuedAt.IsZero() ||
+		m.Signature == (cipher.Sig{}) {
+		return ErrGossipMissingFields
+	}
+	if m.Op != AdminOpPromote && m.Op != AdminOpDemote {
+		return ErrGossipUnknownOp
+	}
+	if err := cipher.VerifyPubKeySignedPayload(m.IssuerPK, m.Signature, canonicalBytesAdmin(m)); err != nil {
+		return fmt.Errorf("%w: %v", ErrGossipBadSignature, err)
+	}
+	return nil
+}
+
+// MarshalRoster returns the JSON wire encoding of m. Trivial
+// wrapper around encoding/json — present so callers don't reach
+// past the package boundary for the encoder.
+func MarshalRoster(m RosterMutation) ([]byte, error) { return json.Marshal(m) }
+
+// MarshalAdmin returns the JSON wire encoding of m.
+func MarshalAdmin(m AdminMutation) ([]byte, error) { return json.Marshal(m) }
+
+// UnmarshalRoster decodes a JSON wire envelope into a RosterMutation
+// and verifies the signature. Convenience for the subscriber path
+// where every received leaf is decode-and-verify in lockstep.
+func UnmarshalRoster(data []byte) (RosterMutation, error) {
+	var m RosterMutation
+	if err := json.Unmarshal(data, &m); err != nil {
+		return RosterMutation{}, fmt.Errorf("decode roster mutation: %w", err)
+	}
+	if err := VerifyRoster(m); err != nil {
+		return RosterMutation{}, err
+	}
+	return m, nil
+}
+
+// UnmarshalAdmin is the parallel decoder for AdminMutation.
+func UnmarshalAdmin(data []byte) (AdminMutation, error) {
+	var m AdminMutation
+	if err := json.Unmarshal(data, &m); err != nil {
+		return AdminMutation{}, fmt.Errorf("decode admin mutation: %w", err)
+	}
+	if err := VerifyAdmin(m); err != nil {
+		return AdminMutation{}, err
+	}
+	return m, nil
+}

--- a/cmd/apps/skychat/group/gossip_test.go
+++ b/cmd/apps/skychat/group/gossip_test.go
@@ -1,0 +1,288 @@
+// Package group — cmd/apps/skychat/group/gossip_test.go: unit
+// coverage for the signed-mutation envelopes added by gossip.go.
+//
+// Scope is pure types + sign + verify + JSON round-trip; the
+// reconciler that applies mutations to a local Record lives in a
+// separate file (subsequent PR) and gets its own integration-shape
+// tests against the Manager surface.
+package group
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// gossipKeys produces a deterministic-feeling but fresh PK/SK pair
+// for each test. Pulled out so individual tests don't repeat the
+// boilerplate.
+func gossipKeys(t *testing.T) (cipher.PubKey, cipher.SecKey) {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	return pk, sk
+}
+
+// gossipBaseRoster builds a populated-but-unsigned RosterMutation
+// for the test's own arrangement. PeerPK / IssuedAt / GroupID are
+// fixed so test failures point at semantic mismatches, not
+// nondeterminism.
+func gossipBaseRoster(peer cipher.PubKey) RosterMutation {
+	return RosterMutation{
+		GroupID:   uuid.MustParse("72afa409-8b2e-4323-aa1e-8be57f30ebd5"),
+		Op:        RosterOpAdd,
+		PeerPK:    peer,
+		ParentSeq: 42,
+		IssuedAt:  time.Date(2026, 5, 16, 22, 50, 0, 0, time.UTC),
+	}
+}
+
+func gossipBaseAdmin(peer cipher.PubKey) AdminMutation {
+	return AdminMutation{
+		GroupID:   uuid.MustParse("72afa409-8b2e-4323-aa1e-8be57f30ebd5"),
+		Op:        AdminOpPromote,
+		PeerPK:    peer,
+		ParentSeq: 7,
+		IssuedAt:  time.Date(2026, 5, 16, 22, 50, 0, 0, time.UTC),
+	}
+}
+
+func TestSignVerifyRosterRoundTrip(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	if err := SignRoster(&m, sk); err != nil {
+		t.Fatalf("SignRoster: %v", err)
+	}
+	if m.IssuerPK == (cipher.PubKey{}) {
+		t.Fatal("issuer pk should be populated after sign")
+	}
+	if m.Signature == (cipher.Sig{}) {
+		t.Fatal("signature should be populated after sign")
+	}
+	if err := VerifyRoster(m); err != nil {
+		t.Fatalf("VerifyRoster on fresh sign: %v", err)
+	}
+}
+
+func TestSignVerifyAdminRoundTrip(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseAdmin(peer)
+	if err := SignAdmin(&m, sk); err != nil {
+		t.Fatalf("SignAdmin: %v", err)
+	}
+	if err := VerifyAdmin(m); err != nil {
+		t.Fatalf("VerifyAdmin on fresh sign: %v", err)
+	}
+}
+
+func TestVerifyDetectsTamperedField(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	if err := SignRoster(&m, sk); err != nil {
+		t.Fatalf("SignRoster: %v", err)
+	}
+	// Flip Op — same canonical-bytes prefix until the Op byte, so
+	// the signature should clearly not bind to the new payload.
+	tampered := m
+	tampered.Op = RosterOpRemove
+	if err := VerifyRoster(tampered); !errors.Is(err, ErrGossipBadSignature) {
+		t.Fatalf("expected ErrGossipBadSignature on tampered Op, got %v", err)
+	}
+	// Flip PeerPK.
+	tampered = m
+	tampered.PeerPK[0] ^= 0xFF
+	if err := VerifyRoster(tampered); !errors.Is(err, ErrGossipBadSignature) {
+		t.Fatalf("expected ErrGossipBadSignature on tampered PeerPK, got %v", err)
+	}
+	// Bump ParentSeq.
+	tampered = m
+	tampered.ParentSeq++
+	if err := VerifyRoster(tampered); !errors.Is(err, ErrGossipBadSignature) {
+		t.Fatalf("expected ErrGossipBadSignature on tampered ParentSeq, got %v", err)
+	}
+	// Bump IssuedAt by 1ns.
+	tampered = m
+	tampered.IssuedAt = tampered.IssuedAt.Add(time.Nanosecond)
+	if err := VerifyRoster(tampered); !errors.Is(err, ErrGossipBadSignature) {
+		t.Fatalf("expected ErrGossipBadSignature on tampered IssuedAt, got %v", err)
+	}
+}
+
+func TestVerifyDetectsWrongIssuer(t *testing.T) {
+	// Sign with sk1, swap IssuerPK to pk2 — the verifier should
+	// reject because the signature still recovers to pk1 but the
+	// envelope claims pk2.
+	_, sk1 := gossipKeys(t)
+	pk2, _ := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	if err := SignRoster(&m, sk1); err != nil {
+		t.Fatalf("SignRoster: %v", err)
+	}
+	m.IssuerPK = pk2
+	if err := VerifyRoster(m); !errors.Is(err, ErrGossipBadSignature) {
+		t.Fatalf("expected ErrGossipBadSignature on swapped IssuerPK, got %v", err)
+	}
+}
+
+func TestSignRejectsZeroFields(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+
+	// Zero GroupID.
+	m := gossipBaseRoster(peer)
+	m.GroupID = uuid.UUID{}
+	if err := SignRoster(&m, sk); !errors.Is(err, ErrGossipMissingFields) {
+		t.Errorf("expected ErrGossipMissingFields on zero GroupID, got %v", err)
+	}
+
+	// Zero PeerPK.
+	m = gossipBaseRoster(peer)
+	m.PeerPK = cipher.PubKey{}
+	if err := SignRoster(&m, sk); !errors.Is(err, ErrGossipMissingFields) {
+		t.Errorf("expected ErrGossipMissingFields on zero PeerPK, got %v", err)
+	}
+
+	// Zero IssuedAt.
+	m = gossipBaseRoster(peer)
+	m.IssuedAt = time.Time{}
+	if err := SignRoster(&m, sk); !errors.Is(err, ErrGossipMissingFields) {
+		t.Errorf("expected ErrGossipMissingFields on zero IssuedAt, got %v", err)
+	}
+
+	// Nil receiver.
+	if err := SignRoster(nil, sk); !errors.Is(err, ErrGossipMissingFields) {
+		t.Errorf("expected ErrGossipMissingFields on nil receiver, got %v", err)
+	}
+}
+
+func TestSignRejectsUnknownOp(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	m.Op = 99
+	if err := SignRoster(&m, sk); !errors.Is(err, ErrGossipUnknownOp) {
+		t.Fatalf("expected ErrGossipUnknownOp on Op=99, got %v", err)
+	}
+
+	a := gossipBaseAdmin(peer)
+	a.Op = 99
+	if err := SignAdmin(&a, sk); !errors.Is(err, ErrGossipUnknownOp) {
+		t.Fatalf("expected ErrGossipUnknownOp on AdminOp=99, got %v", err)
+	}
+}
+
+func TestVerifyRejectsUnknownOp(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	// Sign at a valid Op, then mutate to an invalid Op AFTER
+	// signing — verifier should reject on the op-range check
+	// before reaching the signature path.
+	if err := SignRoster(&m, sk); err != nil {
+		t.Fatalf("SignRoster: %v", err)
+	}
+	m.Op = 99
+	if err := VerifyRoster(m); !errors.Is(err, ErrGossipUnknownOp) {
+		t.Fatalf("expected ErrGossipUnknownOp on Op=99, got %v", err)
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	if err := SignRoster(&m, sk); err != nil {
+		t.Fatalf("SignRoster: %v", err)
+	}
+
+	wire, err := MarshalRoster(m)
+	if err != nil {
+		t.Fatalf("MarshalRoster: %v", err)
+	}
+	got, err := UnmarshalRoster(wire)
+	if err != nil {
+		t.Fatalf("UnmarshalRoster: %v", err)
+	}
+	if got != m {
+		t.Fatalf("round-trip mismatch:\n  want %+v\n  got  %+v", m, got)
+	}
+
+	a := gossipBaseAdmin(peer)
+	if err := SignAdmin(&a, sk); err != nil {
+		t.Fatalf("SignAdmin: %v", err)
+	}
+	wire, err = MarshalAdmin(a)
+	if err != nil {
+		t.Fatalf("MarshalAdmin: %v", err)
+	}
+	gota, err := UnmarshalAdmin(wire)
+	if err != nil {
+		t.Fatalf("UnmarshalAdmin: %v", err)
+	}
+	if gota != a {
+		t.Fatalf("admin round-trip mismatch:\n  want %+v\n  got  %+v", a, gota)
+	}
+}
+
+func TestUnmarshalRejectsTamperedWire(t *testing.T) {
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	m := gossipBaseRoster(peer)
+	if err := SignRoster(&m, sk); err != nil {
+		t.Fatalf("SignRoster: %v", err)
+	}
+
+	wire, err := MarshalRoster(m)
+	if err != nil {
+		t.Fatalf("MarshalRoster: %v", err)
+	}
+
+	// Decode → mutate → re-encode → confirm rejection.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(wire, &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	raw["op"] = json.RawMessage([]byte("2")) // RosterOpRemove instead of Add
+	tampered, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if _, err := UnmarshalRoster(tampered); !errors.Is(err, ErrGossipBadSignature) {
+		t.Fatalf("expected ErrGossipBadSignature on tampered wire, got %v", err)
+	}
+}
+
+func TestCanonicalBytesIsStableAcrossRuns(t *testing.T) {
+	// Two identical envelopes (same fields) must hash to the same
+	// canonical bytes so a re-signed mutation produces a verifying
+	// signature for any party reconstructing the canonical form.
+	_, sk := gossipKeys(t)
+	peer, _ := gossipKeys(t)
+	a := gossipBaseRoster(peer)
+	b := gossipBaseRoster(peer)
+	if err := SignRoster(&a, sk); err != nil {
+		t.Fatalf("SignRoster a: %v", err)
+	}
+	if err := SignRoster(&b, sk); err != nil {
+		t.Fatalf("SignRoster b: %v", err)
+	}
+	// Secp256k1 signatures are randomized via the nonce k, so the
+	// signatures themselves differ — but both must verify against
+	// the same envelope.
+	if err := VerifyRoster(a); err != nil {
+		t.Fatalf("VerifyRoster a: %v", err)
+	}
+	bWithASig := b
+	bWithASig.Signature = a.Signature
+	if err := VerifyRoster(bWithASig); err != nil {
+		t.Fatalf("cross-sig verify (same canonical bytes): %v", err)
+	}
+}


### PR DESCRIPTION
Step 1 of the gossip implementation outlined in PR #2656's RFC. Pure types + sign/verify + JSON wire — no CXO interaction yet (publisher emit lands in step 2, subscriber apply in step 3).

## Adds

- \`RosterMutation\` and \`AdminMutation\` envelopes carrying the fields the reconciler needs: \`GroupID\`, \`Op\`, \`PeerPK\`, \`ParentSeq\`, \`IssuedAt\`, \`IssuerPK\`, \`Signature\`.
- Typed \`RosterOp\` / \`AdminOp\` uint8 — \`RosterOpAdd\` / \`RosterOpRemove\` and \`AdminOpPromote\` / \`AdminOpDemote\` — so a future op type never overlaps an old binary's parse.
- \`SignRoster\` / \`SignAdmin\` / \`VerifyRoster\` / \`VerifyAdmin\` / \`MarshalRoster\` / \`MarshalAdmin\` / \`UnmarshalRoster\` / \`UnmarshalAdmin\`.

## Crypto

Skywire's existing secp256k1 primitive (\`cipher.SignPayload\` / \`cipher.VerifyPubKeySignedPayload\`). The RFC's \"ed25519\" wording was a holdover from design; secp256k1 is what's already in the binary and what every visor's PK already is. Sig stays as \`cipher.Sig\` (65 bytes including the recovery byte).

## Canonical bytes

Deterministic field layout with a leading version byte for forward compatibility. Sign and Verify operate on this canonical form so JSON whitespace / key-ordering can't cause verification drift. A future field addition bumps \`gossipCanonicalVersion\` so old verifiers fast-reject instead of mis-verifying.

## Sentinel errors

- \`ErrGossipBadSignature\` — signature doesn't bind to (IssuerPK, canonicalBytes)
- \`ErrGossipMissingFields\` — required field is zero at sign or verify
- \`ErrGossipUnknownOp\` — op out of defined range
- \`ErrGossipDemoteFounder\` — reserved for the reconciler (step 3), unused here

## Test plan

10 unit tests, all pass:

- [x] Sign/verify round-trip for both mutation types
- [x] Tamper-detection on Op / PeerPK / ParentSeq / IssuedAt / IssuerPK
- [x] JSON round-trip
- [x] Wire-tamper rejection via decode→mutate→re-encode
- [x] Canonical-bytes stability across runs (two signatures of the same envelope have different secp256k1 nonces but both verify against the same canonical bytes)
- [x] Zero-field rejection at sign
- [x] Unknown-op rejection at sign + verify
- [x] Wrong-issuer rejection at verify
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./cmd/apps/skychat/group/...\` clean

## Tracks

- #2636 (gossip RFC) step 1 of 7
- #2639 (owner-SPOF) unblocks at step 3 of the impl outline
- Hard prereq for the subscriber bootstrap step: Gamma's #2637 (seq-anchored replay)