### PR TITLE
feat(skychat/group): history-replay beyond inbox ring (Path A of #2637)

### DIFF
--- a/cmd/apps/skychat/history/group_since_test.go
+++ b/cmd/apps/skychat/history/group_since_test.go
@@ -1,0 +1,189 @@
+// Package history — cmd/apps/skychat/history/group_since_test.go:
+// pins the BoltStore.ListGroupSince contract added so the gRPC
+// StreamGroupMessages handler can backfill a reconnecting subscriber
+// whose disconnect gap exceeds the in-memory inbox ring. Without
+// this query, every operator who actually opted into GroupHistoryDB
+// still saw the inbox-bounded behavior — the persistence existed
+// but was unreachable from the streaming path.
+package history
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBoltStore_ListGroupSince_Empty(t *testing.T) {
+	// Unknown group → nil, nil (matches ListByGroup's unknown-group
+	// shape).
+	s := newTestStore(t, DefaultLimits())
+	msgs, err := s.ListGroupSince("unknown-group", time.Time{})
+	if err != nil {
+		t.Fatalf("ListGroupSince unknown: %v", err)
+	}
+	if msgs != nil {
+		t.Errorf("ListGroupSince unknown: want nil, got %v", msgs)
+	}
+}
+
+func TestBoltStore_ListGroupSince_EmptyGroupID(t *testing.T) {
+	// Empty groupID arg → nil (defensive, matches ListByGroup).
+	s := newTestStore(t, DefaultLimits())
+	msgs, err := s.ListGroupSince("", time.Time{})
+	if err != nil {
+		t.Fatalf("ListGroupSince empty-id: %v", err)
+	}
+	if msgs != nil {
+		t.Errorf("ListGroupSince empty-id: want nil, got %v", msgs)
+	}
+}
+
+func TestBoltStore_ListGroupSince_ZeroTimeReturnsAll(t *testing.T) {
+	// since == zero-time → every message in the group qualifies
+	// because every Timestamp.After(zero) is true. Acts as a
+	// pure "every message in the group, chronological" mode.
+	s := newTestStore(t, DefaultLimits())
+	groupID := "11111111-2222-3333-4444-555555555555"
+	sender := "03ab" + strings.Repeat("0", 62)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	for i := 0; i < 5; i++ {
+		if err := s.AppendGroup(GroupMessage{
+			GroupID:   groupID,
+			SenderPK:  sender,
+			Text:      fmt.Sprintf("msg-%d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Millisecond),
+		}); err != nil {
+			t.Fatalf("AppendGroup %d: %v", i, err)
+		}
+	}
+	msgs, err := s.ListGroupSince(groupID, time.Time{})
+	if err != nil {
+		t.Fatalf("ListGroupSince zero: %v", err)
+	}
+	if len(msgs) != 5 {
+		t.Fatalf("want 5 messages, got %d", len(msgs))
+	}
+	for i, m := range msgs {
+		want := fmt.Sprintf("msg-%d", i)
+		if m.Text != want {
+			t.Errorf("msg %d: text = %q, want %q", i, m.Text, want)
+		}
+	}
+}
+
+func TestBoltStore_ListGroupSince_ReturnsOnlyAfterCursor(t *testing.T) {
+	// Core contract: the returned slice contains every message with
+	// Timestamp strictly greater than `since`, and nothing at or
+	// before it. Pre-fix, the streaming handler had no way to ask
+	// "messages since this cursor" against persisted state; the
+	// only persistent reader was ListByGroup which is limit-shaped.
+	s := newTestStore(t, DefaultLimits())
+	groupID := "abcdef00-1111-2222-3333-444444444444"
+	sender := "03cd" + strings.Repeat("e", 62)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	// Plant 10 messages 100ms apart.
+	for i := 0; i < 10; i++ {
+		if err := s.AppendGroup(GroupMessage{
+			GroupID:   groupID,
+			SenderPK:  sender,
+			Text:      fmt.Sprintf("msg-%02d", i),
+			Timestamp: base.Add(time.Duration(i) * 100 * time.Millisecond),
+		}); err != nil {
+			t.Fatalf("AppendGroup %d: %v", i, err)
+		}
+	}
+
+	// Cursor at message 4's timestamp — expect msgs 5..9 back.
+	cursor := base.Add(4 * 100 * time.Millisecond)
+	msgs, err := s.ListGroupSince(groupID, cursor)
+	if err != nil {
+		t.Fatalf("ListGroupSince: %v", err)
+	}
+	if len(msgs) != 5 {
+		t.Fatalf("want 5 messages since msg-04's TS, got %d (texts: %v)", len(msgs), texts(msgs))
+	}
+	for i, m := range msgs {
+		want := fmt.Sprintf("msg-%02d", i+5)
+		if m.Text != want {
+			t.Errorf("msg %d post-cursor: text = %q, want %q", i, m.Text, want)
+		}
+	}
+}
+
+func TestBoltStore_ListGroupSince_CursorAtNewest(t *testing.T) {
+	// Cursor at-or-past the newest message → empty result. Confirms
+	// the streaming handler's "no backlog to replay" signal works
+	// correctly when the subscriber's cursor is fully caught up.
+	s := newTestStore(t, DefaultLimits())
+	groupID := "deadbeef-cafe-babe-feed-decadeaffaced"
+	sender := "0312" + strings.Repeat("3", 62)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	for i := 0; i < 3; i++ {
+		if err := s.AppendGroup(GroupMessage{
+			GroupID:   groupID,
+			SenderPK:  sender,
+			Text:      fmt.Sprintf("msg-%d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Millisecond),
+		}); err != nil {
+			t.Fatalf("AppendGroup %d: %v", i, err)
+		}
+	}
+	// Cursor past the newest message.
+	cursor := base.Add(10 * time.Second)
+	msgs, err := s.ListGroupSince(groupID, cursor)
+	if err != nil {
+		t.Fatalf("ListGroupSince: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("cursor past newest: want 0 messages, got %d (texts: %v)", len(msgs), texts(msgs))
+	}
+}
+
+func TestBoltStore_ListGroupSince_GroupIsolation(t *testing.T) {
+	// A cursor against group A must not return group B's messages.
+	// The bbolt schema buckets per-group; this test guards against
+	// a future refactor that accidentally crosses the boundary
+	// (e.g. a global tsKey index that doesn't scope to group).
+	s := newTestStore(t, DefaultLimits())
+	groupA := "00000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	groupB := "00000000-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	sender := "0345" + strings.Repeat("6", 62)
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		ts := base.Add(time.Duration(i) * time.Millisecond)
+		for _, gid := range []string{groupA, groupB} {
+			if err := s.AppendGroup(GroupMessage{
+				GroupID:   gid,
+				SenderPK:  sender,
+				Text:      fmt.Sprintf("%s/msg-%d", gid[:8], i),
+				Timestamp: ts,
+			}); err != nil {
+				t.Fatalf("AppendGroup %s/%d: %v", gid, i, err)
+			}
+		}
+	}
+
+	msgs, err := s.ListGroupSince(groupA, time.Time{})
+	if err != nil {
+		t.Fatalf("ListGroupSince groupA: %v", err)
+	}
+	for _, m := range msgs {
+		if m.GroupID != groupA {
+			t.Errorf("groupA query returned message with GroupID=%q (cross-group leak)", m.GroupID)
+		}
+	}
+	if len(msgs) != 3 {
+		t.Errorf("groupA: want 3 messages, got %d", len(msgs))
+	}
+}
+
+func texts(msgs []GroupMessage) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Text)
+	}
+	return out
+}

--- a/cmd/apps/skychat/history/history.go
+++ b/cmd/apps/skychat/history/history.go
@@ -84,6 +84,17 @@ type Store interface {
 	// group, newest last. If limit <= 0, returns all.
 	ListByGroup(groupID string, limit int) ([]GroupMessage, error)
 
+	// ListGroupSince returns every stored group message whose Timestamp
+	// is strictly after `since`, oldest first. Returns nil for an
+	// unknown group or for a group with no messages newer than `since`.
+	//
+	// Used by the gRPC StreamGroupMessages handler to backfill a
+	// reconnecting subscriber whose disconnect gap is longer than the
+	// in-memory inbox ring can cover. The bbolt key is the message
+	// timestamp (see tsKey), so the lookup is a cursor Seek + forward
+	// walk — no full-bucket scan even on a long-running group.
+	ListGroupSince(groupID string, since time.Time) ([]GroupMessage, error)
+
 	// Groups returns the set of group IDs that have any stored messages.
 	Groups() ([]string, error)
 

--- a/cmd/apps/skychat/history/store.go
+++ b/cmd/apps/skychat/history/store.go
@@ -335,6 +335,57 @@ func (s *BoltStore) ListByGroup(groupID string, limit int) ([]GroupMessage, erro
 	return msgs, err
 }
 
+// ListGroupSince implements Store. The bolt bucket is keyed by
+// tsKey(Timestamp), so we Seek to since's tsKey and walk forward —
+// O(messages-since) instead of O(all-messages-in-group). Returns
+// nil for an unknown group; an empty (non-nil error) result for a
+// group with messages but none newer than `since`.
+//
+// The Seek key is the exclusive boundary: messages with
+// Timestamp.Equal(since) are NOT included (since they're already
+// known to the caller — that's the cursor they passed). Anything
+// strictly newer surfaces. Matches the inbox snapshotAfter's TS.After
+// semantics.
+func (s *BoltStore) ListGroupSince(groupID string, since time.Time) ([]GroupMessage, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+	var msgs []GroupMessage
+	err := s.db.View(func(tx *bolt.Tx) error {
+		root := tx.Bucket([]byte(groupsBucket))
+		gBkt := root.Bucket([]byte(groupID))
+		if gBkt == nil {
+			return nil
+		}
+		cur := gBkt.Cursor()
+		var k, v []byte
+		if since.IsZero() || since.UnixNano() < 0 {
+			// "From the beginning" mode. uint64(negative-nano) wraps
+			// to a huge value whose tsKey sorts AFTER every real key,
+			// which would silently return zero results — so the seek
+			// path skipped here and we just walk from the first key.
+			k, v = cur.First()
+		} else {
+			// Seek to the smallest key strictly greater than tsKey(since).
+			// nextKey is the +1 byte-increment of tsKey(since); a
+			// cursor.Seek to it lands on the first key with TS > since
+			// (bolt keys are byte-lex ordered and tsKey is monotonic
+			// in time across the positive-Unix-nano range).
+			boundary := nextKey(tsKey(since))
+			k, v = cur.Seek(boundary)
+		}
+		for ; k != nil; k, v = cur.Next() {
+			var m GroupMessage
+			if err := json.Unmarshal(v, &m); err != nil {
+				continue
+			}
+			msgs = append(msgs, m)
+		}
+		return nil
+	})
+	return msgs, err
+}
+
 // Groups implements Store. Returns the set of group IDs that have any
 // stored messages — symmetric with Peers() for the 1:1 store.
 func (s *BoltStore) Groups() ([]string, error) {

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -314,6 +314,12 @@ type GroupHistoryFetcher interface {
 	// messages — useful for operator inspection ('cli skychat group
 	// history --list-groups' style introspection).
 	Groups() ([]string, error)
+	// ListGroupSince returns every stored message for the named
+	// group with TS strictly after `since`, oldest first. Powers the
+	// gRPC StreamGroupMessages history-fallback path that backfills
+	// a reconnecting subscriber whose disconnect gap is longer than
+	// the in-memory inbox ring can cover.
+	ListGroupSince(groupID string, since time.Time) ([]GroupMessage, error)
 }
 
 // GroupHistory returns up to limit most recent persisted messages for

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -364,6 +364,31 @@ func (a *visorPingAdapter) SnapshotGroupMessagesAfterNs(sinceNs int64) []rpcgrpc
 	return out
 }
 
+// SnapshotGroupHistoryAfterNs bridges Visor.SnapshotGroupHistoryAfter
+// into rpcgrpc's import-cycle-safe shape (UnixNano arg, []GroupMessageData
+// return). Empty slice when grouping is uninitialized or no
+// GroupHistoryDB is configured — the StreamGroupMessages handler
+// treats nil as "no history backfill available, stick with inbox-only"
+// which preserves the existing behavior for operators who haven't
+// opted into persistence.
+func (a *visorPingAdapter) SnapshotGroupHistoryAfterNs(groupID string, sinceNs int64) []rpcgrpc.GroupMessageData {
+	since := time.Unix(0, sinceNs)
+	src := a.v.SnapshotGroupHistoryAfter(groupID, since)
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]rpcgrpc.GroupMessageData, 0, len(src))
+	for _, m := range src {
+		out = append(out, rpcgrpc.GroupMessageData{
+			TimestampNs: m.TS.UnixNano(),
+			GroupID:     m.GroupID,
+			SenderPK:    m.SenderPK.Hex(),
+			Body:        m.Text,
+		})
+	}
+	return out
+}
+
 func (a *visorPingAdapter) LocalPK() cipher.PubKey {
 	return a.v.LocalPK()
 }

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -222,3 +222,36 @@ func (a *groupHistoryAdapter) ListByGroup(groupID string, limit int) ([]GroupMes
 func (a *groupHistoryAdapter) Groups() ([]string, error) {
 	return a.store.Groups()
 }
+
+// ListGroupSince implements groupHistorySink (read path beyond the
+// inbox ring). Walks the bolt store from the first message with TS
+// strictly after `since`, returning visor-shaped GroupMessage values
+// in chronological order. The bolt key is the message timestamp so
+// the underlying call is a cursor Seek + forward walk — bounded by
+// "messages since the cursor" rather than "all messages in the
+// group" even on long-running groups.
+//
+// Invalid-PK records on disk are skipped with a debug log (same
+// defense-in-depth as ListByGroup); the rest of the result stream
+// is preserved.
+func (a *groupHistoryAdapter) ListGroupSince(groupID string, since time.Time) ([]GroupMessage, error) {
+	hMsgs, err := a.store.ListGroupSince(groupID, since)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GroupMessage, 0, len(hMsgs))
+	for _, m := range hMsgs {
+		var senderPK cipher.PubKey
+		if err := senderPK.Set(m.SenderPK); err != nil {
+			a.log.WithError(err).WithField("group", groupID).Debug("grouping: history-since skip bad pk")
+			continue
+		}
+		out = append(out, GroupMessage{
+			GroupID:  m.GroupID,
+			SenderPK: senderPK,
+			Text:     m.Text,
+			TS:       m.Timestamp,
+		})
+	}
+	return out, nil
+}

--- a/pkg/visor/rpcgrpc/group_merge_test.go
+++ b/pkg/visor/rpcgrpc/group_merge_test.go
@@ -1,0 +1,150 @@
+// Package rpcgrpc — pkg/visor/rpcgrpc/group_merge_test.go: pins the
+// mergeGroupBacklog contract added so StreamGroupMessages can backfill
+// a reconnecting subscriber whose disconnect gap is longer than the
+// in-memory inbox ring (groupInboxCap = 256) can cover. The merge
+// interleaves the durable bbolt history snapshot with the inbox
+// snapshot, dropping the duplicates that result from both layers
+// observing the same delivery.
+//
+// Behavior under test:
+//   - chronological output ordering (caller's lastSentNs gate requires it)
+//   - exact-match dedup on (GroupID, TimestampNs, SenderPK)
+//   - empty-input fast paths return the other slice verbatim (no copy)
+//   - history-side TimestampNs equality preserved (handler's `<= lastSentNs`
+//     skip handles the first-after-cursor case correctly)
+package rpcgrpc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func msg(groupID, sender string, ts int64, body string) GroupMessageData {
+	return GroupMessageData{GroupID: groupID, SenderPK: sender, TimestampNs: ts, Body: body}
+}
+
+func TestMergeGroupBacklog_BothEmpty(t *testing.T) {
+	got := mergeGroupBacklog(nil, nil)
+	if got != nil {
+		t.Errorf("both-empty: want nil, got %v", got)
+	}
+}
+
+func TestMergeGroupBacklog_HistoryOnlyReturnsHistory(t *testing.T) {
+	// History without inbox → return history verbatim (no copy
+	// required). Common case when the visor has GroupHistoryDB
+	// enabled but the in-memory inbox is empty for this group.
+	hist := []GroupMessageData{
+		msg("g1", "p1", 100, "a"),
+		msg("g1", "p1", 200, "b"),
+	}
+	got := mergeGroupBacklog(hist, nil)
+	if !reflect.DeepEqual(got, hist) {
+		t.Errorf("history-only: got %v want %v", got, hist)
+	}
+}
+
+func TestMergeGroupBacklog_InboxOnlyReturnsInbox(t *testing.T) {
+	// Symmetric to history-only. This is the pre-PR shape — every
+	// group with persistence off goes through this branch.
+	in := []GroupMessageData{
+		msg("g1", "p1", 100, "a"),
+		msg("g1", "p1", 200, "b"),
+	}
+	got := mergeGroupBacklog(nil, in)
+	if !reflect.DeepEqual(got, in) {
+		t.Errorf("inbox-only: got %v want %v", got, in)
+	}
+}
+
+func TestMergeGroupBacklog_OverlapDedupsByKey(t *testing.T) {
+	// Realistic case: same group, same publisher, same TS — inbox
+	// and history both observed the message. Dedup key is the
+	// (group, ts, sender) triple; message should appear once in
+	// the output. lastSentNs in the handler relies on this so
+	// "the message arrived at deliver()" + "the message is in
+	// history" doesn't double-fire on the wire.
+	hist := []GroupMessageData{
+		msg("g1", "p1", 100, "a"),
+		msg("g1", "p1", 200, "b"),
+		msg("g1", "p1", 300, "c"),
+	}
+	in := []GroupMessageData{
+		msg("g1", "p1", 200, "b"), // dup
+		msg("g1", "p1", 300, "c"), // dup
+		msg("g1", "p1", 400, "d"), // new
+	}
+	got := mergeGroupBacklog(hist, in)
+	want := []GroupMessageData{
+		msg("g1", "p1", 100, "a"),
+		msg("g1", "p1", 200, "b"),
+		msg("g1", "p1", 300, "c"),
+		msg("g1", "p1", 400, "d"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("overlap-dedup: got %v want %v", got, want)
+	}
+}
+
+func TestMergeGroupBacklog_OutputIsChronological(t *testing.T) {
+	// Caller's lastSentNs gate requires chronological order (each
+	// emit advances lastSentNs and subsequent in-order messages
+	// pass the >-test). Interleaved input must produce a single
+	// merged-ascending stream.
+	hist := []GroupMessageData{
+		msg("g1", "p1", 100, "h1"),
+		msg("g1", "p1", 300, "h3"),
+		msg("g1", "p1", 500, "h5"),
+	}
+	in := []GroupMessageData{
+		msg("g1", "p1", 200, "i2"),
+		msg("g1", "p1", 400, "i4"),
+		msg("g1", "p1", 600, "i6"),
+	}
+	got := mergeGroupBacklog(hist, in)
+	last := int64(-1)
+	for i, m := range got {
+		if m.TimestampNs <= last {
+			t.Errorf("merge[%d] TS=%d not strictly greater than prev %d", i, m.TimestampNs, last)
+		}
+		last = m.TimestampNs
+	}
+	if n := len(got); n != 6 {
+		t.Errorf("expected 6 merged messages (no dups), got %d: %v", n, got)
+	}
+}
+
+func TestMergeGroupBacklog_DifferentSendersAtSameTSBothEmit(t *testing.T) {
+	// Two senders publishing within the same nanosecond is rare but
+	// possible (members on different visors hitting the same clock
+	// tick). They must both emit — the dedup key includes SenderPK
+	// specifically to keep them distinct.
+	hist := []GroupMessageData{
+		msg("g1", "p1", 100, "from-p1"),
+	}
+	in := []GroupMessageData{
+		msg("g1", "p2", 100, "from-p2"),
+	}
+	got := mergeGroupBacklog(hist, in)
+	if len(got) != 2 {
+		t.Errorf("same-TS-different-senders: want 2 emits, got %d: %v", len(got), got)
+	}
+}
+
+func TestMergeGroupBacklog_DifferentGroupsAtSameTSBothEmit(t *testing.T) {
+	// Cross-group dedup must NOT collapse — same TS in two
+	// different groups is a coincidence, not a dup. The handler
+	// already filters by req.GroupId after the merge; this test
+	// guards against an over-eager dedup that would silently drop
+	// the "wrong group" half of the merge before the filter fires.
+	hist := []GroupMessageData{
+		msg("g1", "p1", 100, "g1-body"),
+	}
+	in := []GroupMessageData{
+		msg("g2", "p1", 100, "g2-body"),
+	}
+	got := mergeGroupBacklog(hist, in)
+	if len(got) != 2 {
+		t.Errorf("cross-group same-TS: want 2 emits, got %d: %v", len(got), got)
+	}
+}

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -68,6 +68,13 @@ type VisorAPI interface {
 	// inbox ring capacity (long disconnect → only the tail is
 	// recoverable).
 	SnapshotGroupMessagesAfterNs(sinceNs int64) []GroupMessageData
+	// SnapshotGroupHistoryAfterNs returns durably-persisted group
+	// messages with TS > sinceNs for the named group. Powers the
+	// history-fallback path that backfills a subscriber whose
+	// reconnect gap exceeds the in-memory inbox ring. Empty when the
+	// operator hasn't enabled GroupHistoryDB, when the group has no
+	// stored messages, or when no messages newer than sinceNs exist.
+	SnapshotGroupHistoryAfterNs(groupID string, sinceNs int64) []GroupMessageData
 	// LocalPK returns the visor's own public key. Used by route-calc
 	// gRPC handlers that default the src PK to the local visor.
 	LocalPK() cipher.PubKey
@@ -1041,6 +1048,67 @@ func (s *PingServer) StreamRemoteSystemStats(req *RemoteSystemStatsRequest, stre
 //
 // Filter: req.GroupId, when set, scopes the stream to one group. Empty
 // matches every group the visor is in.
+// mergeGroupBacklog interleaves the durable history snapshot with the
+// in-memory inbox snapshot in TimestampNs order, dropping the
+// duplicates that result from the inbox-and-history both observing
+// the same delivery. Output is chronological (oldest first) so the
+// streaming handler's lastSentNs gate emits each message exactly
+// once.
+//
+// Dedup key: (GroupID, TimestampNs, SenderPK). The deliver path
+// writes one history record + one inbox entry per Message, both
+// carrying the same triple — exact-match dedup is sufficient. Body
+// is not part of the key because (a) it's expensive to compare on a
+// hot path and (b) two messages with the same triple but different
+// bodies would already be a corruption signal worth surfacing
+// upstream rather than silently merging.
+//
+// Pre-condition: each input is itself in TimestampNs ascending order.
+// The history walker (BoltStore.ListGroupSince) walks the bbolt
+// cursor forward from a tsKey-based Seek; the inbox snapshot iterates
+// the ring forward. Both satisfy the pre-condition by construction.
+func mergeGroupBacklog(history, inbox []GroupMessageData) []GroupMessageData {
+	if len(history) == 0 {
+		return inbox
+	}
+	if len(inbox) == 0 {
+		return history
+	}
+	out := make([]GroupMessageData, 0, len(history)+len(inbox))
+	seen := make(map[backlogKey]struct{}, len(history)+len(inbox))
+	emit := func(m GroupMessageData) {
+		k := backlogKey{group: m.GroupID, ts: m.TimestampNs, sender: m.SenderPK}
+		if _, dup := seen[k]; dup {
+			return
+		}
+		seen[k] = struct{}{}
+		out = append(out, m)
+	}
+	i, j := 0, 0
+	for i < len(history) && j < len(inbox) {
+		if history[i].TimestampNs <= inbox[j].TimestampNs {
+			emit(history[i])
+			i++
+		} else {
+			emit(inbox[j])
+			j++
+		}
+	}
+	for ; i < len(history); i++ {
+		emit(history[i])
+	}
+	for ; j < len(inbox); j++ {
+		emit(inbox[j])
+	}
+	return out
+}
+
+type backlogKey struct {
+	group  string
+	ts     int64
+	sender string
+}
+
 func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingService_StreamGroupMessagesServer) error {
 	if req == nil {
 		return fmt.Errorf("nil request")
@@ -1076,15 +1144,43 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 	// Backlog replay. Skips when client didn't pass a since (fresh
 	// listen — current behavior, only live messages).
 	if req.SinceTimestampNs > 0 {
+		// Two-source backlog:
+		//   inbox    — in-memory ring (~256 messages, every group),
+		//              bounded by groupInboxCap; long disconnects roll past.
+		//   history  — durable bbolt sink (per-group buckets), opt-in via
+		//              the operator's GroupHistoryDB config. nil/empty
+		//              when persistence is off.
+		//
+		// Strategy: query both, merge by TimestampNs, dedup against
+		// lastSentNs. The inbox is a strict superset of "messages
+		// landed since this visor's startup"; history is a strict
+		// superset of "messages landed since persistence began".
+		// In steady state every inbox entry is also in history (same
+		// deliver path writes both), so the merge mostly de-dupes
+		// at the lastSentNs gate. The gain is correctness on
+		// disconnect gaps longer than the inbox ring — without
+		// history, those messages were silently lost from the
+		// replay even though they survived on disk.
+		//
+		// History is queried only when the request scopes to a single
+		// group (req.GroupId set). The history store is per-group; a
+		// "stream every group" request fans across an unbounded set,
+		// which would defeat the bounded-cost intent of the inbox
+		// fallback. Streaming-every-group is the same case
+		// pre-this-PR — inbox only — and that's the right default
+		// without operator opt-in to broader replay.
+		var history []GroupMessageData
+		if req.GroupId != "" {
+			history = s.visor.SnapshotGroupHistoryAfterNs(req.GroupId, req.SinceTimestampNs)
+		}
 		backlog := s.visor.SnapshotGroupMessagesAfterNs(req.SinceTimestampNs)
-		// Diagnostic log: an empty backlog (len == 0) is ambiguous
-		// without it — either nothing landed since the cursor, OR
-		// the disconnect outlasted the ring-buffer turnover. Operators
-		// staring at a "quiet" group post-reconnect need to tell
-		// those cases apart from the log.
-		s.log.Debugf("gRPC StreamGroupMessages: replay since_ns=%d returned=%d messages (groupInboxCap bounds long-disconnect recovery)",
-			req.SinceTimestampNs, len(backlog))
-		for _, m := range backlog {
+		merged := mergeGroupBacklog(history, backlog)
+		// Diagnostic log: tell history-hit, inbox-hit, and merged
+		// counts apart so operators can confirm the history fallback
+		// actually fired when the gap was long.
+		s.log.Debugf("gRPC StreamGroupMessages: replay since_ns=%d group=%q inbox=%d history=%d merged=%d",
+			req.SinceTimestampNs, req.GroupId, len(backlog), len(history), len(merged))
+		for _, m := range merged {
 			if req.GroupId != "" && m.GroupID != req.GroupId {
 				continue
 			}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -903,6 +903,39 @@ func (v *Visor) SnapshotGroupMessagesAfter(since time.Time) []GroupMessage {
 	return inbox.snapshotAfter(since)
 }
 
+// SnapshotGroupHistoryAfter returns persisted group messages with
+// TS > since from the durable history sink (if configured). Powers
+// the gRPC streaming handler's history-fallback path: when a
+// subscriber's reconnect gap is longer than the in-memory inbox
+// ring (groupInboxCap = 256 messages) can cover, the handler falls
+// through to this method to backfill from bbolt. The two sources
+// are merged + dedup'd at the handler layer.
+//
+// Returns nil + nil error when no history sink is configured
+// (operator hasn't set GroupHistoryDB), an unknown group, or no
+// messages newer than `since`. nil-vs-empty is not distinguished;
+// callers treat both as "no history backfill available, stick with
+// inbox-only".
+//
+// Filter contract matches SnapshotGroupMessagesAfter: strict
+// greater-than (TS > since). The handler's lastSentNs dedup
+// depends on it.
+func (v *Visor) SnapshotGroupHistoryAfter(groupID string, since time.Time) []GroupMessage {
+	v.initLock.RLock()
+	hist := v.grouping.history
+	v.initLock.RUnlock()
+	if hist == nil {
+		return nil
+	}
+	msgs, err := hist.ListGroupSince(groupID, since)
+	if err != nil {
+		v.log.WithError(err).WithField("group", groupID).
+			Debug("grouping: history-since fetch failed; stream falls back to inbox-only")
+		return nil
+	}
+	return msgs
+}
+
 // tpDiscClient is a convenience function to obtain transport discovery client.
 func (v *Visor) tpDiscClient() transport.DiscoveryClient {
 	return v.tpM.Conf.DiscoveryClient


### PR DESCRIPTION
Closes #2637 (Path A only; Path B's wire-format additions are explicitly out of scope and deferred to a follow-up).

## Why

A subscriber whose reconnect disconnect outlasts the in-memory inbox ring (groupInboxCap = 1024 messages) silently loses every message that landed during the gap — even when the operator has explicitly enabled GroupHistoryDB and the messages survived on disk. The streaming handler had no read path through the durable bbolt sink; only the in-memory ring fed the replay.

Concrete from this session: Beta's listener idle ~8h, visor's subscriber kept landing inbound messages, ring rolled past most of the gap, reconnect only saw the tail.

## What

Path A: extend the existing `since_ns` plumbing. The handler queries inbox AND history, merges by TimestampNs, dedups against `lastSentNs`. No wire-format change — Path B (`SinceSeq` + `ReplayMode`) is the future v2 and explicitly deferred.

## Wiring

| New | Where | Purpose |
| --- | --- | --- |
| `Store.ListGroupSince(groupID, since)` | history.go + store.go | bbolt cursor.Seek + forward walk over the per-group bucket |
| `GroupHistoryFetcher.ListGroupSince` | pkg/visor/group.go | read-side interface counterpart |
| `groupHistoryAdapter.ListGroupSince` | pkg/visor/init_group.go | bbolt → visor.GroupMessage conversion |
| `Visor.SnapshotGroupHistoryAfter(groupID, since)` | visor.go | nil-tolerant accessor for the rpcgrpc adapter |
| `VisorAPI.SnapshotGroupHistoryAfterNs` | rpcgrpc/server.go | import-cycle-safe wire shape |
| `visorPingAdapter.SnapshotGroupHistoryAfterNs` | init_apps.go | time.Time ↔ UnixNano bridge |
| `mergeGroupBacklog(history, inbox)` | rpcgrpc/server.go | chronological merge, dedup by `(group, ts, sender)` |

## Handler change

`StreamGroupMessages`, only when `req.SinceTimestampNs > 0`:

1. Inbox snapshot (existing `since_ns` path).
2. History snapshot (new; only when `req.GroupId` is set — the per-group bucket model would fan an unbounded set otherwise).
3. Merge via `mergeGroupBacklog`; dedup by `(group, ts, sender)`.
4. Stream merged result; `lastSentNs` advances exactly once per distinct message, preserving the existing exactly-once contract.

Diagnostic log surfaces `inbox=N history=M merged=K` so operators can confirm history fallback actually fired when the gap was long.

## Edge cases handled

- `since == time.Time{}` — walk from `cursor.First()` rather than Seek-by-tsKey. `time.Time{}.UnixNano()` is negative; `uint64(negative)` wraps to a value whose tsKey sorts AFTER every real key in byte-lex.
- `req.GroupId == ""` (stream-every-group) — skip the history fallback. History buckets are per-group; multiplexing across an unbounded set defeats the bounded-cost intent.
- `GroupHistoryDB` not configured — `SnapshotGroupHistoryAfterNs` returns nil; `mergeGroupBacklog` short-circuits to inbox-only → identical pre-PR behavior.

## Tests

`cmd/apps/skychat/history/group_since_test.go` (6 tests): empty-store, empty-groupID, zero-time-returns-all, returns-only-after-cursor, cursor-at-newest, group-isolation.

`pkg/visor/rpcgrpc/group_merge_test.go` (7 tests): both-empty, history-only, inbox-only, overlap-dedup, chronological-ordering, different-senders-at-same-ts, different-groups-at-same-ts.

`go test -race -count=1 ./pkg/visor/... ./cmd/apps/skychat/history/...` clean. `go vet ./...` clean. `gofmt -l` clean.

## Out of scope

- `SinceSeq uint64` + `ReplayMode` wire fields (Path B; CLI-side seq cursor tracking + `bootstrap=N` replay mode).
- Retention/TTL knobs on the history store specifically for replay bounding.
- Server-side pagination.

The shape of Path A is deliberately additive — Path B would extend the same `SnapshotGroupHistoryAfter` accessor with a seq overload + a `ReplayMode` argument on the wire.