### PR TITLE
feat(skychat/group): surface gRPC subscriber drop count in /status

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1457,6 +1457,15 @@ type groupHealth struct {
 	LastMessageAt   time.Time `json:"last_message_at,omitempty"`
 	LagSeconds      *int64    `json:"lag_seconds"`
 	SubscriberAlive bool      `json:"subscriber_alive"`
+	// SubDropCount is the inbox→stream fan-out drop tally surfaced
+	// from the visor's group inbox. See visor.GroupInfo.SubDropCount
+	// for the full semantics. Repeated across every group entry in
+	// this list because the underlying counter is inbox-wide, not
+	// per-group — a busy stream that backpressures up to the
+	// channel-full default branch drops messages destined for every
+	// group, but operators looking at one group's /status entry
+	// shouldn't have to know that to find the number.
+	SubDropCount uint64 `json:"sub_drop_count"`
 }
 
 // collectGroupHealth queries the visor's GroupList RPC and renders
@@ -1519,6 +1528,7 @@ func collectGroupHealth() ([]groupHealth, string) {
 			MembersCount:    len(g.Members),
 			LastMessageAt:   g.LastMessageAt,
 			SubscriberAlive: g.SubscriberAlive,
+			SubDropCount:    g.SubDropCount,
 		}
 		if !g.LastMessageAt.IsZero() {
 			lag := int64(now.Sub(g.LastMessageAt).Seconds())

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -63,6 +63,37 @@ type GroupInfo struct {
 	// skychat group info` show which specific peer is stale in a
 	// group whose session-level SubscriberAlive is otherwise true.
 	PeerLastInbound map[string]time.Time `json:"peer_last_inbound,omitempty"`
+
+	// SubDropCount is the running total of inbox-to-stream drops
+	// across every live + torn-down gRPC StreamGroupMessages
+	// subscriber on THIS VISOR. Bumped in groupInbox.deliver's
+	// select+default branch when a subscriber's bounded channel is
+	// full (per-subscriber 256-message buffer set by the gRPC
+	// handler); persisted across unsubscribe so a single rolling
+	// total survives stream restarts.
+	//
+	// Inbox-wide, not group-scoped — the inbox fans every message
+	// to every live subscriber regardless of group, so a drop is
+	// "this subscriber couldn't keep up" rather than "this group is
+	// noisy". Repeated across every GroupInfo here for operator
+	// convenience; cross-checking the value between two groups in
+	// the same /status response always returns the same number.
+	//
+	// Distinct from the inbox ring's overflow drop semantics — the
+	// ring keeps the most-recent groupInboxCap (1024) messages
+	// regardless of subscriber draining. SubDropCount only counts
+	// messages that reached deliver's fan-out but failed to enqueue
+	// onto a particular subscriber's channel; the ring still has
+	// them and the next StreamGroupMessages reconnect's backlog
+	// replay picks them up via SinceTimestampNs (#2630/#2659).
+	//
+	// Surfaced live so the chat-app's /status can flag a busy group
+	// whose subscriber side is silently dropping under burst — pre-
+	// fix the count was only readable at unsubscribe time, leaving a
+	// gap where an operator watching /status saw subscriber_alive=true
+	// and last_message_at advancing but the CLI listener pipe
+	// missing messages.
+	SubDropCount uint64 `json:"sub_drop_count"`
 }
 
 // GroupMessage is one inbound message delivered through the visor's
@@ -158,14 +189,36 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	subDrop := v.groupSubDropCount()
 	out := make([]GroupInfo, 0, len(all))
 	for _, r := range all {
 		info := toInfo(r)
 		info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
 		info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
+		info.SubDropCount = subDrop
 		out = append(out, info)
 	}
 	return out, nil
+}
+
+// groupSubDropCount returns the inbox-wide running total of drops on
+// the gRPC StreamGroupMessages fan-out path. Returns 0 when the
+// grouping subsystem is uninitialized or has no inbox attached
+// (matches the existing pattern for nil-state graceful degradation).
+//
+// Repeated across every GroupInfo in GroupList / GroupGet rather
+// than living in its own RPC because operators viewing per-group
+// /status entries shouldn't have to make a separate call to find
+// the drop count. The value is the same across all groups on this
+// visor — see GroupInfo.SubDropCount docstring.
+func (v *Visor) groupSubDropCount() uint64 {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return 0
+	}
+	return inbox.SubDropCount()
 }
 
 // GroupGet returns the info for a specific group, or ErrGroupNotFound.
@@ -195,6 +248,7 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	info := toInfo(r)
 	info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
 	info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
+	info.SubDropCount = v.groupSubDropCount()
 	return info, nil
 }
 
@@ -416,6 +470,13 @@ type groupInbox struct {
 	subsMu sync.RWMutex
 	subs   map[*groupSub]struct{}
 
+	// subDropTotal is the running accumulator of drop counts harvested
+	// from torn-down subscribers at unsubscribe time. The live-counter
+	// reads in SubDropCount sum this with each live sub's atomic.Uint64,
+	// keeping the total monotonic across stream restarts. Atomic so
+	// the read path doesn't need the subsMu write lock.
+	subDropTotal atomic.Uint64
+
 	// hist, when non-nil, gets a copy of every delivered message for
 	// disk persistence. Best-effort: write errors are logged but never
 	// block the in-memory ring or the live subscriber fan-out. nil
@@ -560,7 +621,35 @@ func (g *groupInbox) unsubscribe(sub *groupSub) {
 	g.subsMu.Lock()
 	if _, ok := g.subs[sub]; ok {
 		delete(g.subs, sub)
+		// Accumulate the departing subscriber's drop count into the
+		// inbox-wide total so SubDropCount stays monotonic across
+		// stream restarts. Doing it under subsMu keeps the live-sum
+		// + accumulator from racing: a fresh subscribe is also
+		// behind the mutex, so the read-then-accumulate sequence on
+		// the same sub-instance is serialized.
+		g.subDropTotal.Add(sub.dropCount.Load())
 		close(sub.ch)
 	}
 	g.subsMu.Unlock()
+}
+
+// SubDropCount returns the rolling total of inbox-to-stream drops
+// across every live + torn-down subscriber on this inbox. Drops
+// happen in deliver's select+default when a subscriber's bounded
+// channel is full; this method sums the live subscribers' running
+// counters with the accumulator that carries the count forward
+// across unsubscribe events. Inbox-wide (not per-group).
+//
+// Surfaced via GroupInfo.SubDropCount on every GroupList /
+// GroupGet result; the chat-app's /status renders it alongside
+// subscriber_alive + last_message_at so an operator can spot a
+// silently-dropping stream under burst without reading visor logs.
+func (g *groupInbox) SubDropCount() uint64 {
+	total := g.subDropTotal.Load()
+	g.subsMu.RLock()
+	for sub := range g.subs {
+		total += sub.dropCount.Load()
+	}
+	g.subsMu.RUnlock()
+	return total
 }

--- a/pkg/visor/group_sub_dropcount_test.go
+++ b/pkg/visor/group_sub_dropcount_test.go
@@ -1,0 +1,130 @@
+// Package visor — pkg/visor/group_sub_dropcount_test.go: pins the
+// groupInbox.SubDropCount accumulator semantics added so the chat-app
+// /status response surfaces a live signal when the gRPC
+// StreamGroupMessages fan-out is silently dropping messages between
+// inbox.deliver and a bounded subscriber channel. Pre-fix, the
+// per-subscriber dropCount was only readable at unsubscribe time and
+// went nowhere operator-visible — leaving a diagnostic gap where a
+// busy group looked healthy by subscriber_alive + last_message_at
+// but the listener pipe was silently shedding messages.
+//
+// Integration coverage (a full gRPC handler reading a slow stream)
+// rides the existing E2E plan; this file pins the inbox-side
+// counter contract in isolation.
+package visor
+
+import (
+	"testing"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestGroupInbox_SubDropCount_DefaultsZero(t *testing.T) {
+	// Fresh inbox with no subscribers + no deliveries → 0. Both the
+	// live-sum and the accumulator paths must initialize empty.
+	g := newGroupInbox(0)
+	if got := g.SubDropCount(); got != 0 {
+		t.Errorf("fresh inbox: SubDropCount = %d, want 0", got)
+	}
+}
+
+func TestGroupInbox_SubDropCount_LiveSumWhenChannelFull(t *testing.T) {
+	// Subscribe with a buf=1 channel, deliver 5 messages without
+	// draining. deliver's select+default fires on every overflow
+	// and bumps sub.dropCount → SubDropCount returns the running
+	// live sum.
+	g := newGroupInbox(0)
+	sub := g.subscribe(1)
+	defer g.unsubscribe(sub)
+
+	pk, _ := cipher.GenerateKeyPair()
+	for i := 0; i < 5; i++ {
+		g.deliver("group-a", pk, skychatgroup.Message{Text: "x"})
+	}
+	// One message fits in the buf=1 channel, the other four drop.
+	if got := g.SubDropCount(); got != 4 {
+		t.Errorf("after 5 deliveries on buf=1 sub: SubDropCount = %d, want 4", got)
+	}
+}
+
+func TestGroupInbox_SubDropCount_AccumulatesAcrossUnsubscribe(t *testing.T) {
+	// Drop count harvested at unsubscribe must persist into the
+	// inbox-wide total so a fresh subscriber doesn't reset the
+	// operator-visible /status counter. This is the property that
+	// makes the rolling total monotonic across stream restarts.
+	g := newGroupInbox(0)
+
+	// Stream 1: 3 drops, then teardown.
+	sub1 := g.subscribe(1)
+	pk, _ := cipher.GenerateKeyPair()
+	for i := 0; i < 4; i++ {
+		g.deliver("group-a", pk, skychatgroup.Message{Text: "x"})
+	}
+	if got := g.SubDropCount(); got != 3 {
+		t.Fatalf("pre-unsubscribe: SubDropCount = %d, want 3", got)
+	}
+	g.unsubscribe(sub1)
+	if got := g.SubDropCount(); got != 3 {
+		t.Errorf("post-unsubscribe: SubDropCount = %d, want 3 (accumulator should carry forward)", got)
+	}
+
+	// Stream 2: subscribe afresh, no new drops yet → total unchanged.
+	sub2 := g.subscribe(1)
+	defer g.unsubscribe(sub2)
+	if got := g.SubDropCount(); got != 3 {
+		t.Errorf("fresh subscribe after teardown: SubDropCount = %d, want 3", got)
+	}
+
+	// Stream 2 drops 2 more.
+	for i := 0; i < 3; i++ {
+		g.deliver("group-a", pk, skychatgroup.Message{Text: "y"})
+	}
+	if got := g.SubDropCount(); got != 5 {
+		t.Errorf("post-second-stream drops: SubDropCount = %d, want 5 (3 accumulated + 2 live)", got)
+	}
+}
+
+func TestGroupInbox_SubDropCount_AggregatesMultipleLiveSubs(t *testing.T) {
+	// Two concurrent subscribers, both with buf=1, both observe
+	// overflows. SubDropCount sums across both — operators tracking
+	// the visor-wide total should see both contributions.
+	g := newGroupInbox(0)
+	sub1 := g.subscribe(1)
+	sub2 := g.subscribe(1)
+	defer g.unsubscribe(sub1)
+	defer g.unsubscribe(sub2)
+
+	pk, _ := cipher.GenerateKeyPair()
+	for i := 0; i < 4; i++ {
+		g.deliver("group-a", pk, skychatgroup.Message{Text: "x"})
+	}
+	// Each sub takes 1, drops 3 → total 6.
+	if got := g.SubDropCount(); got != 6 {
+		t.Errorf("2 live subs each buf=1, 4 deliveries: SubDropCount = %d, want 6", got)
+	}
+}
+
+func TestGroupInbox_SubDropCount_RoomyChannelDoesNotDrop(t *testing.T) {
+	// Sanity-check the inverse: when the subscriber's channel buffer
+	// is large enough to hold every delivery, no drops accrue.
+	// Sizing the buffer past the deliver count makes the test
+	// deterministic — a goroutine-drain variant raced with the
+	// deliver tight-loop on slower machines because the scheduler
+	// can't always interleave them fast enough.
+	//
+	// Prevents a regression where the counter would tick on every
+	// deliver regardless of channel pressure.
+	g := newGroupInbox(0)
+	const N = 50
+	sub := g.subscribe(N * 2) // headroom; no select+default firings expected
+	t.Cleanup(func() { g.unsubscribe(sub) })
+
+	pk, _ := cipher.GenerateKeyPair()
+	for i := 0; i < N; i++ {
+		g.deliver("group-a", pk, skychatgroup.Message{Text: "x"})
+	}
+	if got := g.SubDropCount(); got != 0 {
+		t.Errorf("buf=2N, N deliveries: SubDropCount = %d, want 0", got)
+	}
+}

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -1119,7 +1119,24 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 	if ch == nil {
 		return fmt.Errorf("group inbox not available on this visor")
 	}
-	defer cancel()
+	// On tear-down, log the subscriber's final dropCount at WARN if
+	// non-zero. Pre-fix this number was silently discarded, leaving a
+	// gap where an operator watching subscriber_alive=true could
+	// reasonably believe the receive path was healthy while the CLI
+	// listener was actually missing messages dropped between
+	// inbox.deliver and the gRPC stream's bounded channel. Inbox-
+	// wide rolling total is also surfaced live via GroupInfo
+	// .SubDropCount (#groupInbox.SubDropCount); the per-subscriber
+	// number from cancel() is the just-departing stream's
+	// contribution, useful for correlating a specific reconnect's
+	// shape with the rolling visor-wide total.
+	defer func() {
+		dropped := cancel()
+		if dropped > 0 {
+			s.log.Warnf("gRPC StreamGroupMessages: subscriber teardown drop_count=%d group_id=%q (inbox→stream channel was full during fan-out; messages survive in the inbox ring + history sink, reconnect with SinceTimestampNs replays them)",
+				dropped, req.GroupId)
+		}
+	}()
 
 	s.log.Debugf("gRPC StreamGroupMessages: subscribed group_id=%q since_ns=%d", req.GroupId, req.SinceTimestampNs)
 


### PR DESCRIPTION
## Why

T2-mini reliability run at 23:30Z surfaced a class of message loss the cascade (#2606..#2659) doesn't address: the inbox→stream fan-out at `groupInbox.deliver`. When a subscriber's bounded channel is full, deliver's `select+default` branch fires and the per-subscriber `dropCount` ticks. Pre-fix that count was only readable via the `cancel()` return value at unsubscribe time, which never surfaced anywhere operator-visible.

Concrete from today's run: my CXO subscriber's `last_message_at` advanced past Beta's `probeb-07` timing — confirming \"the messages reached the visor\" — while the CLI listener displayed only 2 of Beta's 10 probes. `last_message_at` + `subscriber_alive` looked healthy; the diagnostic was unreachable.

This PR closes the visibility gap. It does **NOT** fix the drop — just makes it observable so the next PR can target the right layer.

## Wiring

| New | Where | Purpose |
| --- | --- | --- |
| `groupInbox.subDropTotal atomic.Uint64` | pkg/visor/group.go | accumulator for drop counts harvested at unsubscribe |
| `groupInbox.SubDropCount() uint64` | pkg/visor/group.go | sums accumulator + every live sub's per-instance count under `subsMu.RLock` |
| `unsubscribe` change | pkg/visor/group.go | harvests departing sub's final dropCount into the accumulator under the same lock as the sub-set delete |
| `GroupInfo.SubDropCount uint64` | pkg/visor/group.go | new JSON field; populated by `GroupList` + `GroupGet` |
| `Visor.groupSubDropCount()` | pkg/visor/group.go | nil-tolerant accessor used by both populators |
| `groupHealth.SubDropCount` | cmd/apps/skychat/commands/skychat.go | chat-app `/status` renders the value alongside `subscriber_alive` / `last_message_at` / `lag_seconds` |
| `StreamGroupMessages` defer WARN | pkg/visor/rpcgrpc/server.go | per-stream WARN log at teardown when the just-departing stream's dropCount > 0 |

## What this is NOT

- **Not** a fix for the drops themselves. `select+default` stays — bounded buffers are the right shape (one wedged subscriber can't block the inbox's whole fan-out). The eventual fix is bigger `subBuffer`, smarter backpressure, or per-message Send timeout in the handler loop — pick after we have operator-visible numbers from real workloads.
- **Not** retroactive. Counts start from zero on every visor restart.
- **Not** per-group. The counter is per-subscriber, and a gRPC `StreamGroupMessages` subscriber sees every group on the visor. Repeating the same number on each `GroupInfo` is operator convenience, not per-group semantics — docstring is explicit.

## Tests

`pkg/visor/group_sub_dropcount_test.go` (5 tests):

- `_DefaultsZero` — fresh inbox, no subs / no deliveries → 0
- `_LiveSumWhenChannelFull` — `subscribe(buf=1)` + 5 deliveries → 4 drops surfaced via live `SubDropCount`
- `_AccumulatesAcrossUnsubscribe` — monotonicity property: drop, unsubscribe, fresh sub, drop again → total carries forward
- `_AggregatesMultipleLiveSubs` — 2 `buf=1` subs + 4 deliveries → count sums across all live subs
- `_RoomyChannelDoesNotDrop` — `buf=2N`, N deliveries → 0 (regression guard against the counter ticking regardless of channel state)

`go test -race -count=1 ./pkg/visor/... ./cmd/apps/skychat/...` clean. `go vet ./...` clean. `gofmt -l` clean.

## Related

- #2630 (replay-on-streaming-reconnect) — different layer (CLI↔visor stream replay); addresses the gap *after* the subscriber disconnects.
- #2659 (history-replay beyond inbox ring) — fills in the bbolt fallback for long-gap reconnects. Both #2630 and #2659 are recovery paths; SubDropCount surfaces the steady-state shedding those recoveries don't see.
- The follow-up that actually changes drop behavior is the next PR. This one is diagnostic only.