### PR TITLE
feat(cli/skychat/group): render sub_drop_count on group info

### DIFF
--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -206,8 +206,15 @@ func renderGroupInfo(info visor.GroupInfo) string {
 	fmt.Fprintf(&buf, "created_at:        %s\n", info.CreatedAt.UTC().Format(time.RFC3339)) //nolint:errcheck
 	fmt.Fprintf(&buf, "joined_at:         %s\n", info.JoinedAt.UTC().Format(time.RFC3339))  //nolint:errcheck
 	fmt.Fprintf(&buf, "last_message_at:   %s\n", last)                                      //nolint:errcheck
-	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive)                      //nolint:errcheck
-	fmt.Fprintf(&buf, "members (%d):\n", len(info.Members))                                 //nolint:errcheck
+	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive) //nolint:errcheck
+	// SubDropCount is inbox-wide (same value on every group); show it
+	// here so operators querying `group info` for chat-health don't
+	// need a separate /status call. Only when non-zero to keep healthy
+	// output unchanged. See visor.GroupInfo.SubDropCount for semantics.
+	if info.SubDropCount > 0 {
+		fmt.Fprintf(&buf, "sub_drop_count:    %d (visor-wide gRPC fan-out)\n", info.SubDropCount) //nolint:errcheck
+	}
+	fmt.Fprintf(&buf, "members (%d):\n", len(info.Members)) //nolint:errcheck
 	for _, pk := range info.Members {
 		fmt.Fprintf(&buf, "  %s\n", pk) //nolint:errcheck
 	}

--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -206,7 +206,7 @@ func renderGroupInfo(info visor.GroupInfo) string {
 	fmt.Fprintf(&buf, "created_at:        %s\n", info.CreatedAt.UTC().Format(time.RFC3339)) //nolint:errcheck
 	fmt.Fprintf(&buf, "joined_at:         %s\n", info.JoinedAt.UTC().Format(time.RFC3339))  //nolint:errcheck
 	fmt.Fprintf(&buf, "last_message_at:   %s\n", last)                                      //nolint:errcheck
-	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive) //nolint:errcheck
+	fmt.Fprintf(&buf, "subscriber_alive:  %t\n", info.SubscriberAlive)                      //nolint:errcheck
 	// SubDropCount is inbox-wide (same value on every group); show it
 	// here so operators querying `group info` for chat-health don't
 	// need a separate /status call. Only when non-zero to keep healthy


### PR DESCRIPTION
## Summary
Rebased onto post-#2662 develop. #2662 already added \`GroupInfo.SubDropCount\` + the inbox accumulator + surfaced it on chat-app /status (HTTP). This PR adds the missing CLI render so \`cli skychat group info\` shows the same number on its human-readable path — operators querying chat health from the CLI shouldn't have to flip to /status or --json to see drops.

9-line delta in \`cmd/skywire-cli/commands/skychat/group.go\`. Hidden when zero, labelled "visor-wide gRPC fan-out" so the same number appearing across multiple groups doesn't read as per-group noise.

## Why this is small now
Original draft of #2663 added a duplicate \`InboxDrops\` field + a parallel accumulator implementation. #2662 landed first with the same field under a different name (\`SubDropCount\`) and a slightly more elegant accumulator approach (snapshot-at-unsubscribe rather than eager-increment-in-deliver). Reset onto upstream/develop and kept only the CLI-render delta that #2662 left out.

## Test plan
- [x] \`go build ./cmd/skywire-cli/...\` clean
- [x] No new tests — render path is a one-liner; #2662 already pinned the counter semantics in \`group_sub_dropcount_test.go\`
- [ ] Visual: \`cli skychat group info <id>\` shows nothing extra when drops=0, shows the labelled line when drops>0