### PR TITLE
feat(skychat/group): per-layer drop counters in GroupInfo

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -1251,6 +1251,25 @@ func (m *Manager) PeerLiveness(id string) map[cipher.PubKey]time.Time {
 	return out
 }
 
+// PeerUpdateCount returns the per-peer count of OnUpdate-callback
+// invocations observed by Session.makePeerOnUpdate for the given
+// group. Parallel to PeerLiveness — same shape, same lifetime,
+// same nil-on-no-session graceful degradation. Empty map for
+// owner-role sessions that don't follow peer feeds.
+//
+// Used by Visor.GroupGet / GroupList to surface the count alongside
+// PeerLastInbound so operators can localize drops across the
+// receive cascade.
+func (m *Manager) PeerUpdateCount(id string) map[cipher.PubKey]uint64 {
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok || sess == nil {
+		return map[cipher.PubKey]uint64{}
+	}
+	return sess.PeerUpdateCounts()
+}
+
 // List returns every persisted record.
 func (m *Manager) List() ([]Record, error) { return m.store.List() }
 

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -398,6 +398,22 @@ type Session struct {
 	// RLock and access the *atomic.Int64 entries lock-free.
 	peerLastInboundNs map[cipher.PubKey]*atomic.Int64
 
+	// peerUpdateCount is the per-peerSub count of OnUpdate callbacks
+	// observed with events>0 (matches the seam that bumps
+	// peerLastInboundNs). Parallel to peerLastInboundNs in lifetime
+	// and locking: added in SetAllowlist when a peerSub is created,
+	// removed when the peerSub is deleted, guarded by peerSubsMu.
+	//
+	// Operator-facing surface exposed via Manager.PeerUpdateCount and
+	// downstream in pkg/visor.GroupInfo.PeerUpdateCount. The delta
+	// against pkg/visor.GroupInfo.DeliverCount localizes drops: an
+	// individual peer with UpdateCount near zero while DeliverCount
+	// advances is the peerSub-not-firing case (a CXO subscriber
+	// handshake / Conn-level failure); UpdateCount sum approaching
+	// DeliverCount means all peer-subscribers fire but later layers
+	// (sub channel, gRPC stream) drop.
+	peerUpdateCount map[cipher.PubKey]*atomic.Uint64
+
 	// subLastInboundNs is the per-s.sub liveness signal — the legacy
 	// owner-feed subscriber's counterpart to peerLastInboundNs. Bumped
 	// on every inbound UpdateEvent fanout via the legacy subscriber and
@@ -574,6 +590,7 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 		relayCtx: ctx, relayCancel: cancel,
 		peerSubs:          make(map[cipher.PubKey]*treestore.Subscriber),
 		peerLastInboundNs: make(map[cipher.PubKey]*atomic.Int64),
+		peerUpdateCount:   make(map[cipher.PubKey]*atomic.Uint64),
 		dedup:             newRecentSet(inboxDedupCap),
 	}
 
@@ -602,6 +619,7 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 		}
 		ps.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
 		s.peerLastInboundNs[peerPK] = new(atomic.Int64)
+		s.peerUpdateCount[peerPK] = new(atomic.Uint64)
 		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
 		s.peerSubs[peerPK] = ps
 	}
@@ -712,6 +730,7 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		cfg: cfg, port: cfg.Record.Port, pub: pub, sub: sub, log: log,
 		peerSubs:          make(map[cipher.PubKey]*treestore.Subscriber),
 		peerLastInboundNs: make(map[cipher.PubKey]*atomic.Int64),
+		peerUpdateCount:   make(map[cipher.PubKey]*atomic.Uint64),
 		dedup:             newRecentSet(inboxDedupCap),
 	}
 
@@ -734,6 +753,7 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		// (admin-relayed copies of other members' sends) — see the
 		// openOwner equivalent for the full rationale.
 		ps.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
+		s.peerUpdateCount[peerPK] = new(atomic.Uint64)
 		s.peerLastInboundNs[peerPK] = new(atomic.Int64)
 		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
 		s.peerSubs[peerPK] = ps
@@ -1096,13 +1116,39 @@ func (s *Session) makePeerOnUpdate(pk cipher.PubKey) treestore.UpdateCallback {
 		if len(events) > 0 {
 			s.peerSubsMu.RLock()
 			a := s.peerLastInboundNs[pk]
+			c := s.peerUpdateCount[pk]
 			s.peerSubsMu.RUnlock()
 			if a != nil {
 				a.Store(time.Now().UnixNano())
 			}
+			if c != nil {
+				c.Add(1)
+			}
 		}
 		s.onUpdate(events)
 	}
+}
+
+// PeerUpdateCounts returns a snapshot of the per-peer OnUpdate-callback
+// count map. Counts are monotonic across the session's lifetime;
+// readers may compare deltas across two snapshots to measure inbound
+// activity per peer over an interval.
+//
+// Empty map for owner-role sessions (no peerSubs). The returned map
+// is a copy — the caller can read it without holding peerSubsMu.
+func (s *Session) PeerUpdateCounts() map[cipher.PubKey]uint64 {
+	s.peerSubsMu.RLock()
+	defer s.peerSubsMu.RUnlock()
+	if len(s.peerUpdateCount) == 0 {
+		return nil
+	}
+	out := make(map[cipher.PubKey]uint64, len(s.peerUpdateCount))
+	for pk, c := range s.peerUpdateCount {
+		if c != nil {
+			out[pk] = c.Load()
+		}
+	}
+	return out
 }
 
 // makeLegacySubOnUpdate wraps Session.onUpdate with s.sub-specific
@@ -1254,6 +1300,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 			_ = ps.Close() //nolint:errcheck,gosec
 			delete(s.peerSubs, pk)
 			delete(s.peerLastInboundNs, pk)
+			delete(s.peerUpdateCount, pk)
 			evicted = append(evicted, pk)
 		}
 	}
@@ -1270,6 +1317,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 		}
 		ps.SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
 		s.peerLastInboundNs[pk] = new(atomic.Int64)
+		s.peerUpdateCount[pk] = new(atomic.Uint64)
 		ps.OnUpdate(s.makePeerOnUpdate(pk))
 		// Best-effort connect — same semantics as Connect's per-peer
 		// retry: a peer that's offline now will be picked up on the

--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -94,6 +94,44 @@ type GroupInfo struct {
 	// and last_message_at advancing but the CLI listener pipe
 	// missing messages.
 	SubDropCount uint64 `json:"sub_drop_count"`
+
+	// DeliverCount is the running total of groupInbox.deliver()
+	// invocations since visor startup — every message that landed
+	// at the inbox layer, regardless of downstream consumption.
+	//
+	// Combined with PeerUpdateCount (per-peer) and SubDropCount,
+	// localizes drops along the receive path:
+	//   PeerUpdateCount[peer]  =  CXO peerSub → Session callback fired
+	//   DeliverCount           =  Session → inbox.deliver() enqueued
+	//   SubDropCount           =  inbox → gRPC subscriber channel dropped
+	//
+	// Deltas tell where messages are lost:
+	//   peerUpdate_sum < deliverCount  → impossible (deliver is downstream)
+	//   peerUpdate_sum > deliverCount  → drops in Session.makePeerOnUpdate's
+	//                                    deliver call site (per-peer callback fired
+	//                                    but message never reached inbox)
+	//   deliverCount > rcvd_at_client  → drops between inbox and the CLI listener
+	//                                    (subDropCount accounts for some; the rest
+	//                                    are gRPC adapter or stream.Send)
+	//
+	// Visor-wide, not group-scoped (matches SubDropCount semantics).
+	// Repeated across every GroupInfo for operator convenience.
+	DeliverCount uint64 `json:"deliver_count"`
+
+	// PeerUpdateCount is the per-peer count of treestore subscriber
+	// OnUpdate callbacks observed by Session.makePeerOnUpdate, keyed
+	// by peer-PK hex. Populated alongside PeerLastInbound. Bumped on
+	// every events>0 callback (the same seam that bumps the
+	// peerLastInboundNs liveness signal).
+	//
+	// Empty map for owner-role sessions that don't follow peer feeds.
+	// Operator-facing: an idle peer with PeerLastInbound zero AND
+	// PeerUpdateCount zero has never been heard from; an idle peer
+	// with PeerLastInbound stale but PeerUpdateCount > 0 went silent
+	// after a known interaction. Comparing PeerUpdateCount sums to
+	// DeliverCount localizes drops upstream vs downstream of the
+	// inbox enqueue.
+	PeerUpdateCount map[string]uint64 `json:"peer_update_count,omitempty"`
 }
 
 // GroupMessage is one inbound message delivered through the visor's
@@ -190,12 +228,15 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 		return nil, err
 	}
 	subDrop := v.groupSubDropCount()
+	deliverCount := v.groupDeliverCount()
 	out := make([]GroupInfo, 0, len(all))
 	for _, r := range all {
 		info := toInfo(r)
 		info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
 		info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 		info.SubDropCount = subDrop
+		info.DeliverCount = deliverCount
+		info.PeerUpdateCount = peerUpdateCountHex(mgr.PeerUpdateCount(r.ID))
 		out = append(out, info)
 	}
 	return out, nil
@@ -219,6 +260,24 @@ func (v *Visor) groupSubDropCount() uint64 {
 		return 0
 	}
 	return inbox.SubDropCount()
+}
+
+// groupDeliverCount returns the running total of groupInbox.deliver()
+// invocations since the visor started — i.e. every message that
+// landed at the inbox layer, regardless of downstream consumption.
+// Operator-facing: the (deliverCount) − (per-peer update count
+// sum) delta tells you what fraction of messages reached the inbox
+// vs. were lost between the CXO peer-subscriber's OnUpdate and the
+// inbox enqueue. Returns 0 on uninitialized grouping. Visor-wide,
+// not per-group (matches SubDropCount semantics).
+func (v *Visor) groupDeliverCount() uint64 {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return 0
+	}
+	return inbox.deliverCount.Load()
 }
 
 // GroupGet returns the info for a specific group, or ErrGroupNotFound.
@@ -249,6 +308,8 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	info.SubscriberAlive = mgr.IsSubscriberAlive(r.ID)
 	info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 	info.SubDropCount = v.groupSubDropCount()
+	info.DeliverCount = v.groupDeliverCount()
+	info.PeerUpdateCount = peerUpdateCountHex(mgr.PeerUpdateCount(r.ID))
 	return info, nil
 }
 
@@ -264,6 +325,20 @@ func peerLivenessHex(in map[cipher.PubKey]time.Time) map[string]time.Time {
 	out := make(map[string]time.Time, len(in))
 	for pk, ts := range in {
 		out[pk.Hex()] = ts
+	}
+	return out
+}
+
+// peerUpdateCountHex is the parallel converter for the per-peer
+// OnUpdate-callback counts from Manager.PeerUpdateCount. Same
+// empty-input → nil → JSON-omitted convention.
+func peerUpdateCountHex(in map[cipher.PubKey]uint64) map[string]uint64 {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]uint64, len(in))
+	for pk, c := range in {
+		out[pk.Hex()] = c
 	}
 	return out
 }
@@ -477,6 +552,16 @@ type groupInbox struct {
 	// the read path doesn't need the subsMu write lock.
 	subDropTotal atomic.Uint64
 
+	// deliverCount ticks once per groupInbox.deliver() call — i.e. every
+	// time a message lands in this visor's group inbox, regardless of
+	// whether any live subscriber consumed it or any history sink
+	// captured it. Operators use the (deliver_count) − (per-sub
+	// receive_count) delta to localize whether drops are at the
+	// inbox→sub fan-out (subDropCount visible) or further upstream
+	// (peer-subscriber OnUpdate count vs deliver_count). Monotonic
+	// across the inbox's lifetime; reset only on visor restart.
+	deliverCount atomic.Uint64
+
 	// hist, when non-nil, gets a copy of every delivered message for
 	// disk persistence. Best-effort: write errors are logged but never
 	// block the in-memory ring or the live subscriber fan-out. nil
@@ -527,6 +612,7 @@ func (g *groupInbox) deliver(groupID string, senderPK cipher.PubKey, msg skychat
 		Text:     msg.Text,
 		TS:       msg.TS,
 	}
+	g.deliverCount.Add(1)
 	g.mu.Lock()
 	g.buf = append(g.buf, gm)
 	if len(g.buf) > g.cap {

--- a/pkg/visor/group_deliver_count_test.go
+++ b/pkg/visor/group_deliver_count_test.go
@@ -1,0 +1,82 @@
+// Package visor pkg/visor/group_deliver_count_test.go
+//
+// Targeted coverage for the deliverCount counter added to groupInbox
+// for drop-site localization. The full layer-counter surface (also
+// covered by group_sub_dropcount_test.go for the existing sub_drop
+// path) is exercised end-to-end in the 3-agent reliability tests;
+// these unit tests pin the bookkeeping invariants in isolation.
+
+package visor
+
+import (
+	"testing"
+	"time"
+
+	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestDeliverCountIncrementsOncePerDelivery(t *testing.T) {
+	in := newGroupInbox(64)
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	if got := in.deliverCount.Load(); got != 0 {
+		t.Fatalf("fresh inbox deliverCount: want 0 got %d", got)
+	}
+
+	in.deliver("g1", pk1, skychatgroup.Message{Text: "a", TS: time.Now().UTC()})
+	in.deliver("g1", pk1, skychatgroup.Message{Text: "b", TS: time.Now().UTC()})
+	in.deliver("g2", pk2, skychatgroup.Message{Text: "c", TS: time.Now().UTC()})
+
+	if got := in.deliverCount.Load(); got != 3 {
+		t.Fatalf("deliverCount after 3 delivers: want 3 got %d", got)
+	}
+}
+
+func TestDeliverCountSurvivesRingOverflow(t *testing.T) {
+	// Cap=2: the ring drops oldest messages once full, but the
+	// deliverCount counter is monotonic and counts every deliver call
+	// regardless of whether the ring kept the message.
+	in := newGroupInbox(2)
+	pk, _ := cipher.GenerateKeyPair()
+
+	for i := 0; i < 5; i++ {
+		in.deliver("g", pk, skychatgroup.Message{Text: "x", TS: time.Now().UTC()})
+	}
+	if got := in.deliverCount.Load(); got != 5 {
+		t.Fatalf("deliverCount: want 5 (regardless of ring cap=2 drops), got %d", got)
+	}
+	if got := len(in.buf); got != 2 {
+		t.Fatalf("ring buf len: want 2 (capped), got %d", got)
+	}
+}
+
+func TestDeliverCountSurvivesSubDrop(t *testing.T) {
+	// A subscriber with a 1-deep buffer that doesn't drain. Each
+	// delivery enqueues onto the ring AND attempts the fan-out
+	// (which drops via select+default on the second message). The
+	// deliver counter still ticks for every call; sub_drop ticks
+	// for the ones that couldn't enqueue.
+	in := newGroupInbox(64)
+	sub := in.subscribe(1)
+	defer in.unsubscribe(sub)
+
+	pk, _ := cipher.GenerateKeyPair()
+	for i := 0; i < 5; i++ {
+		in.deliver("g", pk, skychatgroup.Message{Text: "x", TS: time.Now().UTC()})
+	}
+
+	if got := in.deliverCount.Load(); got != 5 {
+		t.Fatalf("deliverCount: want 5, got %d", got)
+	}
+	// First message lands in the sub's buffer (capacity 1); the next
+	// 4 select+default away. Drop count should be 4.
+	if got := sub.dropCount.Load(); got != 4 {
+		t.Fatalf("subscriber dropCount: want 4, got %d", got)
+	}
+	// Aggregate visible via the inbox-wide accessor.
+	if got := in.SubDropCount(); got != 4 {
+		t.Fatalf("inbox-wide SubDropCount: want 4, got %d", got)
+	}
+}


### PR DESCRIPTION
After today's reliability cascade landed (19+ PRs), test tallies kept surfacing drops without enough signal to localize WHICH layer of the 9-deep receive cascade actually dropped each message. Every test ended with hypotheses, not measurements. Operator: \"pause new reliability PRs, land per-layer counters first.\"

## Adds

Two new counters surfaced via \`cli skychat group info\`, sitting alongside the existing \`SubDropCount\` (#2628 era) and \`PeerLastInbound\` (#2628 also):

| Counter | Scope | Bumped at |
|---|---|---|
| \`DeliverCount\` | visor-wide \`uint64\` | every \`groupInbox.deliver()\` call |
| \`PeerUpdateCount[pk]\` | per-(group,peer) map | every \`Session.makePeerOnUpdate\` callback with events>0 |

The delta between (sum of \`PeerUpdateCount\` across peers) and \`DeliverCount\` tells the operator whether drops are upstream of the inbox enqueue (per-peer subscriber's OnUpdate not firing — CXO handshake or Conn-level failure) or downstream (\`subDropCount\` and later layers).

## Wiring

- \`pkg/visor/group.go\` — \`deliverCount\` field on groupInbox, bumped in \`deliver()\`; \`groupDeliverCount()\` accessor; \`GroupInfo\` gets \`DeliverCount\` + \`PeerUpdateCount\` fields; \`GroupList\` + \`GroupGet\` populate both.
- \`cmd/apps/skychat/group/session.go\` — \`peerUpdateCount\` parallel to existing \`peerLastInboundNs\`, lifetime-managed alongside, bumped in \`makePeerOnUpdate\`. \`PeerUpdateCounts()\` snapshot accessor.
- \`cmd/apps/skychat/group/manager.go\` — \`PeerUpdateCount(id)\` accessor mirroring \`PeerLiveness\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] 3 new unit tests pass: \`TestDeliverCountIncrementsOncePerDelivery\`, \`TestDeliverCountSurvivesRingOverflow\`, \`TestDeliverCountSurvivesSubDrop\`
- [x] All existing tests in \`./pkg/visor/... ./cmd/apps/skychat/group/...\` pass
- [x] \`golangci-lint run ./pkg/visor/... ./cmd/apps/skychat/group/...\` clean (2 pre-existing user_manager warnings unrelated)
- [ ] In-prod: re-run T2-mini with counters live. Compare \`PeerUpdateCount[alpha]\` against \`DeliverCount\` against listener tally. Drop-site localization should be one tally read away.

## Not in scope (next bite)

- Stream-side counter for \`rpcgrpc.StreamGroupMessages\` \`stream.Send\` invocations. Closes the last 2 of the 9 layers.
- \`cli skychat group info\` rendering of the new counters in human-readable form (currently visible via \`--json\`).