### PR TITLE
feat(skychat/group): stream_send_count to close diagnostic surface

### DIFF
--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -118,6 +118,31 @@ type GroupInfo struct {
 	// Repeated across every GroupInfo for operator convenience.
 	DeliverCount uint64 `json:"deliver_count"`
 
+	// StreamSendCount is the running total of successful stream.Send
+	// calls on rpcgrpc.StreamGroupMessages across both PingServer
+	// instances (local CLI + dmsg-RPC). Counts data events only;
+	// the Subscribed sentinel that the handler emits before entering
+	// the dispatch loop is NOT included.
+	//
+	// Pairs with DeliverCount to localize drops between the inbox
+	// layer and the CLI listener:
+	//   DeliverCount    > StreamSendCount  → drops between inbox and
+	//                                        stream (SubDropCount accounts
+	//                                        for some; rest are adapter
+	//                                        backpressure or stream
+	//                                        flow-control on the gRPC
+	//                                        send buffer).
+	//   DeliverCount   ==  StreamSendCount → everything that landed
+	//                                        in the inbox was sent to
+	//                                        the wire; any operator-
+	//                                        observed loss is downstream
+	//                                        of stream.Send (gRPC client
+	//                                        recv, CLI buffering, or
+	//                                        Monitor task wrapper).
+	//
+	// Visor-wide, not group-scoped. Reset only on visor restart.
+	StreamSendCount uint64 `json:"stream_send_count"`
+
 	// PeerUpdateCount is the per-peer count of treestore subscriber
 	// OnUpdate callbacks observed by Session.makePeerOnUpdate, keyed
 	// by peer-PK hex. Populated alongside PeerLastInbound. Bumped on
@@ -229,6 +254,7 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 	}
 	subDrop := v.groupSubDropCount()
 	deliverCount := v.groupDeliverCount()
+	streamSendCount := v.groupStreamSendCount()
 	out := make([]GroupInfo, 0, len(all))
 	for _, r := range all {
 		info := toInfo(r)
@@ -236,6 +262,7 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 		info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 		info.SubDropCount = subDrop
 		info.DeliverCount = deliverCount
+		info.StreamSendCount = streamSendCount
 		info.PeerUpdateCount = peerUpdateCountHex(mgr.PeerUpdateCount(r.ID))
 		out = append(out, info)
 	}
@@ -260,6 +287,18 @@ func (v *Visor) groupSubDropCount() uint64 {
 		return 0
 	}
 	return inbox.SubDropCount()
+}
+
+// groupStreamSendCount returns the running total of successful
+// stream.Send calls on rpcgrpc.StreamGroupMessages across both
+// PingServer instances (local CLI + dmsg-RPC). Surfaced via
+// GroupInfo.StreamSendCount; visor-wide, not group-scoped (matches
+// the other layer counters' semantics).
+//
+// Subscribed sentinels are NOT counted. The counter is monotonic
+// across the visor's lifetime; reset only on visor restart.
+func (v *Visor) groupStreamSendCount() uint64 {
+	return v.groupStreamSendCounter.Load()
 }
 
 // groupDeliverCount returns the running total of groupInbox.deliver()
@@ -309,6 +348,7 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	info.PeerLastInbound = peerLivenessHex(mgr.PeerLiveness(r.ID))
 	info.SubDropCount = v.groupSubDropCount()
 	info.DeliverCount = v.groupDeliverCount()
+	info.StreamSendCount = v.groupStreamSendCount()
 	info.PeerUpdateCount = peerUpdateCountHex(mgr.PeerUpdateCount(r.ID))
 	return info, nil
 }

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -190,9 +190,21 @@ func (s *cliRPCStats) snapshot() (active int32, total uint64, errors uint64, pea
 	return s.activeConns, s.totalConns, s.totalErrors, s.peakConns, s.lastError, s.lastErrorTime
 }
 
-// visorPingAdapter wraps a Visor to implement rpcgrpc.VisorAPI
+// visorPingAdapter wraps a Visor to implement rpcgrpc.VisorAPI.
+// The adapter is shared across both PingServer instances (local CLI
+// gRPC + dmsg-RPC gRPC) so any counter on the adapter aggregates
+// across both transports.
 type visorPingAdapter struct {
 	v *Visor
+}
+
+// IncGroupStreamSend implements rpcgrpc.VisorAPI. Called once per
+// successful stream.Send by StreamGroupMessages; surfaced back into
+// pkg/visor.GroupInfo.StreamSendCount via Visor.groupStreamSendCount.
+// Subscribed sentinels are NOT counted — operators care about data
+// events.
+func (a *visorPingAdapter) IncGroupStreamSend() {
+	a.v.groupStreamSendCounter.Add(1)
 }
 
 func (a *visorPingAdapter) DialPing(conf rpcgrpc.PingConf) error {

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -75,6 +75,17 @@ type VisorAPI interface {
 	// operator hasn't enabled GroupHistoryDB, when the group has no
 	// stored messages, or when no messages newer than sinceNs exist.
 	SnapshotGroupHistoryAfterNs(groupID string, sinceNs int64) []GroupMessageData
+	// IncGroupStreamSend records one successful stream.Send call from
+	// StreamGroupMessages — i.e. one data event handed to the gRPC
+	// transport. Called by the streaming handler after each successful
+	// Send so the visor can surface a stream_send_count alongside the
+	// inbox-side DeliverCount and SubDropCount in GroupInfo. The two
+	// PingServer instances (local CLI + dmsg-RPC) share a single
+	// adapter, so the counter aggregates across both transports.
+	//
+	// The Subscribed sentinel is NOT counted — operators care about
+	// data delivery throughput, not handshake bookkeeping.
+	IncGroupStreamSend()
 	// LocalPK returns the visor's own public key. Used by route-calc
 	// gRPC handlers that default the src PK to the local visor.
 	LocalPK() cipher.PubKey
@@ -1212,6 +1223,7 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 			}); err != nil {
 				return err
 			}
+			s.visor.IncGroupStreamSend()
 			lastSentNs = m.TimestampNs
 		}
 	}
@@ -1246,6 +1258,7 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 			}); err != nil {
 				return err
 			}
+			s.visor.IncGroupStreamSend()
 			lastSentNs = m.TimestampNs
 		}
 	}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -231,6 +231,15 @@ type Visor struct {
 	// init_group.go. nil when group chat is disabled.
 	grouping groupState
 
+	// groupStreamSendCounter ticks once per successful stream.Send on
+	// any rpcgrpc.StreamGroupMessages stream. Bumped from the gRPC
+	// adapter (visorPingAdapter.IncGroupStreamSend) so the counter
+	// aggregates across both PingServer instances (local CLI + dmsg
+	// remote). Surfaced via GroupInfo.StreamSendCount alongside
+	// DeliverCount + SubDropCount to localize drops between the
+	// inbox layer and the CLI listener pipe.
+	groupStreamSendCounter atomic.Uint64
+
 	// Embedded DMSG Web resolver (nil if dmsg_web.enable is false).
 	// Provides a localhost SOCKS5 proxy that resolves .dmsg hosts.
 	embeddedDmsgWeb *EmbeddedDmsgWeb


### PR DESCRIPTION
Complements #2664 (DeliverCount + PeerUpdateCount). Closes the last 2 of the 9 receive-cascade layers — gRPC adapter + \`stream.Send\`. After this PR, every layer-to-layer drop is locatable from a single \`GroupInfo\` read.

## Adds

- \`rpcgrpc.VisorAPI.IncGroupStreamSend()\` — invoked from \`StreamGroupMessages\` after every successful \`stream.Send\` (data events only — the \`Subscribed\` sentinel is not counted; ops care about data throughput).
- \`visorPingAdapter.IncGroupStreamSend\` implements it by bumping a new \`atomic.Uint64\` on the Visor (\`groupStreamSendCounter\`). The adapter is shared between both PingServer instances (local CLI + dmsg-RPC), so the counter aggregates across both transports.
- \`Visor.groupStreamSendCount()\` accessor + \`GroupInfo.StreamSendCount\` field (uint64, visor-wide). Surfaced in \`GroupList\` + \`GroupGet\`.

## Operator delta table

| Observed | Meaning |
|---|---|
| \`DeliverCount > StreamSendCount\` | drops between inbox and stream (\`SubDropCount\` accounts for some; rest are gRPC adapter backpressure or stream flow-control on the send buffer) |
| \`DeliverCount == StreamSendCount\` | everything that landed in the inbox was sent to the wire; any operator-observed loss is downstream of \`stream.Send\` (gRPC client recv, CLI buffering, or Monitor task wrapper) |

Combined with #2664's \`PeerUpdateCount → DeliverCount\` delta, the full chain is now localizable:

\`\`\`
CXO subscriber callback   →  PeerUpdateCount[peer]
Session → inbox enqueue   →  DeliverCount
inbox → stream sub chan   →  DeliverCount - SubDropCount
stream → wire             →  StreamSendCount
wire → CLI listener       →  (out of process; operator counts lines on stdout)
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/visor/... ./cmd/apps/skychat/group/...\` all green
- [x] \`golangci-lint run\` clean on touched packages (2 pre-existing user_manager gosec warnings unrelated)
- [ ] In-prod: re-run T2-mini with all counters live. Drop-site localization should be one tally read away.