### PR TITLE
feat(skychat/group): stream-send counter — closes layer 9 of 9

### DIFF
--- a/pkg/visor/group.go
+++ b/pkg/visor/group.go
@@ -132,6 +132,24 @@ type GroupInfo struct {
 	// DeliverCount localizes drops upstream vs downstream of the
 	// inbox enqueue.
 	PeerUpdateCount map[string]uint64 `json:"peer_update_count,omitempty"`
+
+	// StreamSendCount is the running total of successful gRPC
+	// rpcgrpc.StreamGroupMessages stream.Send invocations to live CLI
+	// subscribers since visor startup. Closes the last layer in the
+	// per-layer ladder begun by PeerUpdateCount / DeliverCount /
+	// SubDropCount: a message that reaches inbox.deliver and isn't
+	// dropped at sub.ch must be Send'd exactly once per subscriber.
+	//
+	// Includes one Send per subscription startup (the Subscribed
+	// sentinel) plus one Send per message dispatched. Operators
+	// localizing a drop walk the delta:
+	//   DeliverCount − SubDropCount  =  expected per-subscriber Sends
+	//   actual StreamSendCount        =  observed Sends
+	// A gap (DeliverCount − SubDropCount > StreamSendCount, modulo
+	// active-subscription sentinels) localizes the drop to the gRPC
+	// Send seam itself — slow transport, EOF mid-Send, context
+	// cancellation before flush. Visor-wide, not group-scoped.
+	StreamSendCount uint64 `json:"stream_send_count"`
 }
 
 // GroupMessage is one inbound message delivered through the visor's
@@ -229,6 +247,7 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 	}
 	subDrop := v.groupSubDropCount()
 	deliverCount := v.groupDeliverCount()
+	streamSend := v.groupStreamSendCount()
 	out := make([]GroupInfo, 0, len(all))
 	for _, r := range all {
 		info := toInfo(r)
@@ -237,6 +256,7 @@ func (v *Visor) GroupList() ([]GroupInfo, error) {
 		info.SubDropCount = subDrop
 		info.DeliverCount = deliverCount
 		info.PeerUpdateCount = peerUpdateCountHex(mgr.PeerUpdateCount(r.ID))
+		info.StreamSendCount = streamSend
 		out = append(out, info)
 	}
 	return out, nil
@@ -280,6 +300,37 @@ func (v *Visor) groupDeliverCount() uint64 {
 	return inbox.deliverCount.Load()
 }
 
+// groupStreamSendCount returns the inbox-wide rolling total of
+// successful gRPC stream.Send invocations from
+// rpcgrpc.StreamGroupMessages. Returns 0 when grouping is
+// uninitialized. Visor-wide; see GroupInfo.StreamSendCount docstring
+// for the layer-9 role in the per-layer counter ladder.
+func (v *Visor) groupStreamSendCount() uint64 {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return 0
+	}
+	return inbox.StreamSendCount()
+}
+
+// recordGroupStreamSend bumps the inbox-wide stream.Send counter.
+// Wired into the rpcgrpc.VisorAPI adapter so the gRPC handler can
+// increment without importing pkg/visor; matches the indirection
+// pattern used by SubscribeGroupMessages. No-op when grouping is
+// uninitialized so test harnesses without a fully-wired visor don't
+// have to mock the counter side too.
+func (v *Visor) recordGroupStreamSend() {
+	v.initLock.RLock()
+	inbox := v.grouping.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return
+	}
+	inbox.RecordStreamSend()
+}
+
 // GroupGet returns the info for a specific group, or ErrGroupNotFound.
 //
 // Populates SubscriberAlive the same way GroupList does — without
@@ -310,6 +361,7 @@ func (v *Visor) GroupGet(id string) (GroupInfo, error) {
 	info.SubDropCount = v.groupSubDropCount()
 	info.DeliverCount = v.groupDeliverCount()
 	info.PeerUpdateCount = peerUpdateCountHex(mgr.PeerUpdateCount(r.ID))
+	info.StreamSendCount = v.groupStreamSendCount()
 	return info, nil
 }
 
@@ -562,6 +614,20 @@ type groupInbox struct {
 	// across the inbox's lifetime; reset only on visor restart.
 	deliverCount atomic.Uint64
 
+	// streamSendCount ticks once per successful gRPC
+	// rpcgrpc.StreamGroupMessages stream.Send to a CLI subscriber.
+	// Incremented from the rpcgrpc handler (not from inside the inbox)
+	// via RecordStreamSend — counter lives here for proximity to
+	// deliverCount and subDropTotal so the per-layer delta calculus
+	// (DeliverCount − SubDropCount ≈ StreamSendCount for the
+	// single-subscriber steady state) reads from a single struct.
+	// Closes the last hop in the 9-layer counter ladder: peer-update
+	// → inbox.deliver → sub.ch fan-out → stream.Send to CLI. Includes
+	// the per-subscription "Subscribed" sentinel send so the count
+	// reflects every successful Send invocation (one per subscription
+	// startup, plus one per message dispatched).
+	streamSendCount atomic.Uint64
+
 	// hist, when non-nil, gets a copy of every delivered message for
 	// disk persistence. Best-effort: write errors are logged but never
 	// block the in-memory ring or the live subscriber fan-out. nil
@@ -738,4 +804,26 @@ func (g *groupInbox) SubDropCount() uint64 {
 	}
 	g.subsMu.RUnlock()
 	return total
+}
+
+// RecordStreamSend bumps the inbox-wide successful-stream.Send counter.
+// Called by rpcgrpc.StreamGroupMessages after every successful Send to
+// a CLI subscriber (including the per-subscription Subscribed sentinel).
+// The counter is the layer-9 end of the per-layer ladder: peer-update
+// → inbox.deliver → sub.ch fan-out → stream.Send, surfaced as
+// GroupInfo.StreamSendCount so an operator can localize whether a
+// missing message dropped at the bounded sub.ch (subDropCount) or
+// somewhere downstream of the inbox→stream handoff.
+func (g *groupInbox) RecordStreamSend() {
+	g.streamSendCount.Add(1)
+}
+
+// StreamSendCount returns the rolling total of successful gRPC
+// stream.Send invocations to live CLI subscribers since this inbox
+// (and therefore this visor's grouping subsystem) initialized.
+// Includes the per-subscription Subscribed sentinel; subtract one
+// per active subscription if the operator needs the message-only
+// count. Visor-wide, not per-group.
+func (g *groupInbox) StreamSendCount() uint64 {
+	return g.streamSendCount.Load()
 }

--- a/pkg/visor/group_stream_send_count_test.go
+++ b/pkg/visor/group_stream_send_count_test.go
@@ -1,0 +1,98 @@
+// Package visor pkg/visor/group_stream_send_count_test.go
+//
+// Pins the streamSendCount counter added to groupInbox so the
+// rpcgrpc.StreamGroupMessages handler's per-Send bump (via the
+// visorPingAdapter.RecordGroupStreamSend bridge) lands on a single
+// monotonic atomic.Uint64 reachable from GroupList / GroupGet.
+// Closes the layer-9 hop in the per-layer counter ladder:
+//
+//	peerUpdate → inbox.deliver → sub.ch fan-out → stream.Send → CLI
+//
+// The full handler is exercised end-to-end by the 3-agent
+// reliability tests; this file pins the counter contract in
+// isolation so a future refactor of the rpcgrpc handler can't
+// silently re-route Sends past the counter.
+
+package visor
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGroupInbox_StreamSendCount_DefaultsZero(t *testing.T) {
+	// Fresh inbox with no Sends recorded → 0. The counter must not
+	// depend on the subscriber map or any deliver activity; it's a
+	// pure accumulator bumped from the gRPC handler.
+	g := newGroupInbox(0)
+	if got := g.StreamSendCount(); got != 0 {
+		t.Errorf("fresh inbox: StreamSendCount = %d, want 0", got)
+	}
+}
+
+func TestGroupInbox_StreamSendCount_IncrementsOnRecord(t *testing.T) {
+	// Each RecordStreamSend call bumps the counter by exactly one.
+	// Pins the contract the rpcgrpc handler relies on: "one Send →
+	// one bump" so DeliverCount − SubDropCount ≈ StreamSendCount
+	// (modulo active-subscription sentinels) holds for the operator-
+	// facing delta calculus.
+	g := newGroupInbox(0)
+	for i := 0; i < 7; i++ {
+		g.RecordStreamSend()
+	}
+	if got := g.StreamSendCount(); got != 7 {
+		t.Errorf("after 7 RecordStreamSend calls: got %d, want 7", got)
+	}
+}
+
+func TestGroupInbox_StreamSendCount_IsAtomicUnderConcurrency(t *testing.T) {
+	// The counter is read from GroupList / GroupGet while
+	// concurrent gRPC handlers bump it from N parallel
+	// StreamGroupMessages stream.Send loops. Bursty parallel bumps
+	// must add up to the expected total — a non-atomic counter
+	// would lose increments here under `go test -race`.
+	g := newGroupInbox(0)
+
+	const goroutines = 16
+	const perG = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perG; j++ {
+				g.RecordStreamSend()
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := uint64(goroutines * perG)
+	if got := g.StreamSendCount(); got != want {
+		t.Errorf("after %d concurrent bumps: got %d, want %d", want, got, want)
+	}
+}
+
+func TestGroupInbox_StreamSendCount_IndependentOfDeliverAndSubDrop(t *testing.T) {
+	// The three counters address different layers; bumping one must
+	// never bleed into another. Deliveries don't move
+	// StreamSendCount (the bump lives in the rpcgrpc handler, not
+	// in deliver), and sub-drop bookkeeping doesn't touch it either.
+	g := newGroupInbox(0)
+	sub := g.subscribe(1)
+	defer g.unsubscribe(sub)
+
+	// Stage 1: only RecordStreamSend.
+	g.RecordStreamSend()
+	g.RecordStreamSend()
+	if got := g.StreamSendCount(); got != 2 {
+		t.Fatalf("post-Record: StreamSendCount = %d, want 2", got)
+	}
+	if got := g.deliverCount.Load(); got != 0 {
+		t.Errorf("post-Record: deliverCount = %d, want 0 (Record must not touch deliver)", got)
+	}
+	if got := g.SubDropCount(); got != 0 {
+		t.Errorf("post-Record: SubDropCount = %d, want 0 (Record must not touch sub-drop)", got)
+	}
+}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -389,6 +389,14 @@ func (a *visorPingAdapter) SnapshotGroupHistoryAfterNs(groupID string, sinceNs i
 	return out
 }
 
+// RecordGroupStreamSend bridges the rpcgrpc handler's per-Send
+// counter bump into the visor's groupInbox.streamSendCount. No-op
+// when grouping is uninitialized (matches the rest of the adapter's
+// graceful-degradation pattern).
+func (a *visorPingAdapter) RecordGroupStreamSend() {
+	a.v.recordGroupStreamSend()
+}
+
 func (a *visorPingAdapter) LocalPK() cipher.PubKey {
 	return a.v.LocalPK()
 }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -75,6 +75,15 @@ type VisorAPI interface {
 	// operator hasn't enabled GroupHistoryDB, when the group has no
 	// stored messages, or when no messages newer than sinceNs exist.
 	SnapshotGroupHistoryAfterNs(groupID string, sinceNs int64) []GroupMessageData
+	// RecordGroupStreamSend bumps the visor's inbox-wide successful-
+	// gRPC-stream.Send counter. StreamGroupMessages calls this after
+	// every successful stream.Send to a CLI subscriber (including the
+	// Subscribed sentinel). Surfaced as GroupInfo.StreamSendCount;
+	// closes the layer-9 hop in the per-layer counter ladder so an
+	// operator can localize a drop to the stream.Send seam vs the
+	// upstream inbox→sub.ch fan-out (SubDropCount) or the inbox layer
+	// itself (DeliverCount). No-op when grouping is uninitialized.
+	RecordGroupStreamSend()
 	// LocalPK returns the visor's own public key. Used by route-calc
 	// gRPC handlers that default the src PK to the local visor.
 	LocalPK() cipher.PubKey
@@ -1150,6 +1159,7 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 	}); err != nil {
 		return err
 	}
+	s.visor.RecordGroupStreamSend()
 
 	// lastSentNs deduplicates between the backlog snapshot and the
 	// live channel for messages that landed in the
@@ -1212,6 +1222,7 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 			}); err != nil {
 				return err
 			}
+			s.visor.RecordGroupStreamSend()
 			lastSentNs = m.TimestampNs
 		}
 	}
@@ -1246,6 +1257,7 @@ func (s *PingServer) StreamGroupMessages(req *GroupMessagesRequest, stream PingS
 			}); err != nil {
 				return err
 			}
+			s.visor.RecordGroupStreamSend()
 			lastSentNs = m.TimestampNs
 		}
 	}


### PR DESCRIPTION
## Summary

#2662 surfaced inbox→sub.ch drops (`SubDropCount`); #2664 added `DeliverCount` + `PeerUpdateCount` for the upstream layers. The `StreamGroupMessages` handler's `stream.Send` seam — the last hop between the visor and a connected CLI subscriber — was still unobserved, so a slow or torn gRPC transport that lost messages **post-fan-out** left no operator-visible trace.

This wires an `atomic.Uint64` on `groupInbox` (sits alongside `deliverCount` and `subDropTotal`), bumped from the rpcgrpc handler after every successful `stream.Send` (including the per-subscription `Subscribed` sentinel). Surfaced as `GroupInfo.StreamSendCount`, populated in `GroupList` + `GroupGet`. The bump is bridged through the existing `VisorAPI` adapter so rpcgrpc doesn't import `pkg/visor`.

## Counter ladder, complete

| Layer | Counter | Meaning |
| --- | --- | --- |
| 1 | `PeerUpdateCount[peer]` | CXO peerSub → Session callback fired |
| 2 | `DeliverCount` | Session → `inbox.deliver()` enqueued |
| 3 | `SubDropCount` | inbox → `sub.ch` dropped (bounded fan-out) |
| 4 | `StreamSendCount` *(new)* | `sub.ch` → gRPC `stream.Send` to CLI |

Operator delta to localize a missing message:

```
expected per-subscriber Sends  =  DeliverCount − SubDropCount
observed Sends                  =  StreamSendCount
gap (modulo active-sub sentinels) → drop at the gRPC Send seam
                                    (slow transport, EOF mid-Send,
                                     context cancel before flush)
```

Without this counter, every post-sub-fan-out drop manifests as silent: `subscriber_alive=true`, `sub_drop_count=0`, `deliver_count` advancing, and yet the CLI listener pipe never sees the message. That's the exact pathology that surfaced this afternoon when `deliver_count=0` on a post-restart visor while `peer_last_inbound` advanced — diagnostic visibility was the gap.

## Tests

`pkg/visor/group_stream_send_count_test.go`:
- `DefaultsZero` — fresh inbox returns 0.
- `IncrementsOnRecord` — one bump per `RecordStreamSend` call (the contract the rpcgrpc handler relies on).
- `IsAtomicUnderConcurrency` — 16 goroutines × 1000 bumps, race-clean under `go test -race`.
- `IndependentOfDeliverAndSubDrop` — bumping the new counter must not bleed into `deliverCount` or `SubDropCount`.

The full handler is exercised end-to-end by the 3-agent reliability drivers; this file pins the counter contract in isolation so a future refactor of the rpcgrpc handler can't silently re-route Sends past the counter.

## Test plan

- [x] `go test -race -count=1 ./pkg/visor/... ./pkg/visor/rpcgrpc/...`
- [x] `go vet ./pkg/visor/... ./pkg/visor/rpcgrpc/...`
- [x] `gofmt -l` clean on changed files
- [ ] Live workload after rollout: confirm `cli skychat group info <id>` surfaces `stream_send_count` and that under a burst on a buf=1 stream the `DeliverCount − SubDropCount = StreamSendCount` invariant holds (modulo `+1` per active subscription's `Subscribed` sentinel)

## Files

- `pkg/visor/group.go` — `streamSendCount atomic.Uint64` on `groupInbox`, `RecordStreamSend()` + `StreamSendCount()` methods, `GroupInfo.StreamSendCount` field, `groupStreamSendCount()` + `recordGroupStreamSend()` visor accessors, populate in `GroupList` + `GroupGet`.
- `pkg/visor/rpcgrpc/server.go` — `VisorAPI.RecordGroupStreamSend()` interface method, three `s.visor.RecordGroupStreamSend()` call sites in `StreamGroupMessages` (sentinel, backlog-replay, live).
- `pkg/visor/init_apps.go` — `visorPingAdapter.RecordGroupStreamSend()` bridge.
- `pkg/visor/group_stream_send_count_test.go` *(new)* — 4 tests.

Sits cleanly atop #2664 (just merged); no overlap with the in-flight #2666 (CLI render of `DeliverCount` + `PeerUpdateCount`).