### PR TITLE
feat(cli/skychat/group): render stream_send_count on group info

### DIFF
--- a/cmd/skywire-cli/commands/skychat/group.go
+++ b/cmd/skywire-cli/commands/skychat/group.go
@@ -221,6 +221,12 @@ func renderGroupInfo(info visor.GroupInfo) string {
 	// zero". See visor.GroupInfo.DeliverCount for the delta calculus
 	// against PeerUpdateCount and SubDropCount.
 	fmt.Fprintf(&buf, "deliver_count:     %d (visor-wide inbox enqueues)\n", info.DeliverCount) //nolint:errcheck
+	// StreamSendCount closes the diagnostic ladder (per #2665): per
+	// visor.GroupInfo doc, DeliverCount == StreamSendCount means every
+	// inbox enqueue made it to the gRPC wire; DeliverCount >
+	// StreamSendCount localizes drops to the inbox→stream seam.
+	// Visor-wide; rendered as a labeled line on every group's info.
+	fmt.Fprintf(&buf, "stream_send_count: %d (visor-wide stream.Send)\n", info.StreamSendCount) //nolint:errcheck
 	fmt.Fprintf(&buf, "members (%d):\n", len(info.Members))                                     //nolint:errcheck
 	for _, pk := range info.Members {
 		fmt.Fprintf(&buf, "  %s\n", pk) //nolint:errcheck


### PR DESCRIPTION
## Summary
Close the CLI-render gap left by #2665 (just merged). That PR surfaced \`StreamSendCount\` on \`GroupInfo\` but didn't render it on the human-readable \`cli skychat group info\` output. Add one labeled line so the full diagnostic ladder is operator-visible without \`--json\`.

After this, \`cli skychat group info\` carries the complete ladder shipped today:

\`\`\`
sub_drop_count:    3 (visor-wide gRPC fan-out)
deliver_count:     142 (visor-wide inbox enqueues)
stream_send_count: 139 (visor-wide stream.Send)
peer_last_inbound (2):
  PEER       LAST_INBOUND          AGE   UPDATES
  02f9aa...  2026-05-17T00:50:00Z  5s    63
  03d1d7...  2026-05-17T00:49:30Z  35s   12
\`\`\`

Operator reads \`deliver_count − stream_send_count\` to localize drops between the inbox and the gRPC send seam.

## Test plan
- [x] \`make format && go build ./cmd/skywire-cli/... ./pkg/visor/...\` clean
- [x] \`make lint\` 0 issues + vet clean
- [ ] Visual: \`cli skychat group info <id>\` shows the new \`stream_send_count\` line beneath \`deliver_count\`

## Related
- #2665 — added \`StreamSendCount\` field this renders
- #2666 — sibling rendering PR for \`deliver_count\` + per-peer UPDATES column
- #2663 — sibling rendering PR for \`sub_drop_count\`