### PR TITLE
refactor(dmsgpty): StreamDialer interface for outbound proxy dial (phase 1)

### DIFF
--- a/pkg/dmsg/dmsgpty/dialer.go
+++ b/pkg/dmsg/dmsgpty/dialer.go
@@ -1,0 +1,59 @@
+// Package dmsgpty pkg/dmsg/dmsgpty/dialer.go
+//
+// StreamDialer abstracts the outbound dial that Host uses to proxy
+// CLI requests to a remote dmsgpty endpoint. Pre-refactor, Host
+// reached into its bound *dmsg.Client directly (h.dmsgC.DialStream)
+// at every call site — pinning the entire dmsgpty stack to dmsg as
+// the only outbound transport, even though the wire-level PtyClient
+// only needs an io.ReadWriteCloser. This file introduces a small
+// interface around just the outbound dial so a transport-aware
+// adapter can be swapped in without touching the rest of Host.
+//
+// Phase 1 (this PR) is abstraction-only: NewHost wires the default
+// dmsg adapter, behavior is unchanged, every existing caller keeps
+// working. Phase 2 (separate PR) will wire a TransportStreamDialer
+// adapter backed by transport.Manager so `cli dmsg pty start` rides
+// the visor's already-negotiated transports (skynet routes, stcpr,
+// etc.) instead of always opening a fresh dmsg stream.
+//
+// The listening side (Host.ListenAndServe → h.dmsgC.Listen) and the
+// logger plumbing stay on *dmsg.Client; only the proxy-out dial is
+// pluggable. dmsgpty-hosts are still reached over dmsg by remote
+// peers — only this host's outgoing proxy gets the transport choice.
+package dmsgpty
+
+import (
+	"context"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// StreamDialer is the outbound-dial side of dmsgpty.Host. Implementations
+// open a bidirectional stream to (pk, port) on whatever transport they're
+// backed by. The returned conn carries the dmsgpty wire protocol that
+// NewPtyClient consumes, so any net.Conn-shaped transport (dmsg.Stream,
+// skynet RouteGroup, raw TCP, …) is a valid backing.
+type StreamDialer interface {
+	// DialStream opens an outbound stream to pk:port. The returned conn
+	// is owned by the caller — close on cleanup. ctx bounds dial-side
+	// work only; in-flight reads/writes on the returned conn are
+	// independent of ctx cancellation.
+	DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error)
+}
+
+// dmsgDialer is the default StreamDialer used when NewHost wires a
+// host without an explicit dialer override. Bridges to dmsg.Client.
+// DialStream so existing call sites keep the exact wire+timing
+// behavior they had before the refactor.
+type dmsgDialer struct {
+	c *dmsg.Client
+}
+
+// DialStream forwards to the underlying dmsg.Client. Pre-refactor
+// behavior is preserved exactly: same address shape, same context
+// semantics, same error surface.
+func (d dmsgDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
+	return d.c.DialStream(ctx, dmsg.Addr{PK: pk, Port: port})
+}

--- a/pkg/dmsg/dmsgpty/dialer_test.go
+++ b/pkg/dmsg/dmsgpty/dialer_test.go
@@ -1,0 +1,84 @@
+// Package dmsgpty pkg/dmsg/dmsgpty/dialer_test.go — pins the StreamDialer
+// abstraction added so the outbound proxy-dial side of Host is
+// pluggable. Phase 1 contract: the dialer field is what gets invoked
+// on ExecRemote / handleProxy paths, not the bound *dmsg.Client.
+package dmsgpty
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// fakeDialer captures the (pk, port) of each DialStream call and
+// returns a fixed err. The err short-circuits the rest of ExecRemote
+// before it touches the conn — the test only needs to prove the
+// dialer field is what gets reached, not that an actual PtyClient
+// boots over the returned conn.
+type fakeDialer struct {
+	calls   []fakeDialCall
+	dialErr error
+}
+
+type fakeDialCall struct {
+	pk   cipher.PubKey
+	port uint16
+}
+
+func (f *fakeDialer) DialStream(_ context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
+	f.calls = append(f.calls, fakeDialCall{pk: pk, port: port})
+	return nil, f.dialErr
+}
+
+func TestHost_ExecRemote_RoutesThroughInjectedDialer(t *testing.T) {
+	// Custom dialer fed via NewHostWithDialer is what ExecRemote
+	// invokes — proves the Host doesn't reach past the abstraction
+	// to its bound dmsg.Client for the outbound side.
+	pk, _ := cipher.GenerateKeyPair()
+	want := errors.New("fake dial failed")
+	fake := &fakeDialer{dialErr: want}
+
+	// dmsgC stays nil because the listening side isn't exercised;
+	// only the outbound path is under test. If anything reached for
+	// h.dmsgC.DialStream pre-refactor, this test would NPE — the
+	// existence of a non-NPE failure surface is the contract.
+	h := NewHostWithDialer(nil, nil, fake)
+
+	_, err := h.ExecRemote(context.Background(), pk, 22, &CommandExecReq{Name: "true"})
+	if err == nil {
+		t.Fatal("ExecRemote: want error from injected dialer, got nil")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("ExecRemote err = %v, want it to wrap %v", err, want)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("dialer calls: got %d, want 1", len(fake.calls))
+	}
+	got := fake.calls[0]
+	if got.pk != pk {
+		t.Errorf("dialer call pk = %s, want %s", got.pk, pk)
+	}
+	if got.port != 22 {
+		t.Errorf("dialer call port = %d, want 22", got.port)
+	}
+}
+
+func TestHost_ExecRemote_DefaultPortFallback(t *testing.T) {
+	// rPort=0 falls back to DefaultPort (matches pre-refactor
+	// ExecRemote behavior). The fallback happens BEFORE the dialer
+	// is invoked, so the dialer sees the resolved port.
+	pk, _ := cipher.GenerateKeyPair()
+	fake := &fakeDialer{dialErr: errors.New("stop early")}
+	h := NewHostWithDialer(nil, nil, fake)
+
+	_, _ = h.ExecRemote(context.Background(), pk, 0, &CommandExecReq{Name: "true"}) //nolint:errcheck
+	if len(fake.calls) != 1 {
+		t.Fatalf("dialer calls: got %d, want 1", len(fake.calls))
+	}
+	if got := fake.calls[0].port; got != DefaultPort {
+		t.Errorf("port with rPort=0: got %d, want DefaultPort=%d", got, DefaultPort)
+	}
+}

--- a/pkg/dmsg/dmsgpty/host.go
+++ b/pkg/dmsg/dmsgpty/host.go
@@ -20,18 +20,43 @@ import (
 )
 
 // Host represents the main instance of dmsgpty.
+//
+// dmsgC is kept for the listening side (ListenAndServe) and logger
+// access; the outbound proxy-dial side now goes through `dialer` so
+// callers can plug in a transport-aware StreamDialer. NewHost wires
+// the default dmsg adapter so behavior is unchanged when callers
+// don't opt in.
 type Host struct {
-	dmsgC *dmsg.Client
-	wl    Whitelist
+	dmsgC  *dmsg.Client
+	dialer StreamDialer
+	wl     Whitelist
 
 	cliN  int32
 	connN int32
 }
 
-// NewHost creates a new dmsgpty.Host with a given dmsg.Client and whitelist.
+// NewHost creates a new dmsgpty.Host with a given dmsg.Client and
+// whitelist. Outbound proxy dials go over dmsg via the default
+// adapter (pre-refactor behavior). Callers that want the outbound
+// side to use a different transport — typically the visor with its
+// transport.Manager — should use NewHostWithDialer instead.
 func NewHost(dmsgC *dmsg.Client, wl Whitelist) *Host {
+	return NewHostWithDialer(dmsgC, wl, dmsgDialer{c: dmsgC})
+}
+
+// NewHostWithDialer constructs a Host with an explicit outbound
+// StreamDialer. dmsgC is still required for the listening side
+// (ListenAndServe binds the dmsg port for incoming proxy requests)
+// and for logger plumbing — only the OUTBOUND proxy dial flows
+// through the supplied dialer.
+//
+// Pass dmsgDialer{c: dmsgC} to keep dmsg-only outbound (equivalent
+// to NewHost). Pass a transport-aware adapter (Phase 2) to let
+// `cli dmsg pty start` ride the visor's existing transports.
+func NewHostWithDialer(dmsgC *dmsg.Client, wl Whitelist, dialer StreamDialer) *Host {
 	host := new(Host)
 	host.dmsgC = dmsgC
+	host.dialer = dialer
 	host.wl = wl
 	return host
 }
@@ -47,7 +72,7 @@ func (h *Host) ExecRemote(ctx context.Context, rPK cipher.PubKey, rPort uint16, 
 	if rPort == 0 {
 		rPort = DefaultPort
 	}
-	stream, err := h.dmsgC.DialStream(ctx, dmsg.Addr{PK: rPK, Port: rPort})
+	stream, err := h.dialer.DialStream(ctx, rPK, rPort)
 	if err != nil {
 		return nil, fmt.Errorf("dmsgpty: dial %s:%d: %w", rPK, rPort, err)
 	}
@@ -273,7 +298,7 @@ func handleProxy(h *Host) handleFunc {
 		}
 
 		// Proxy request.
-		stream, err := h.dmsgC.DialStream(ctx, dmsg.Addr{PK: pk, Port: port})
+		stream, err := h.dialer.DialStream(ctx, pk, port)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

\`dmsgpty.Host\` reached past its abstraction boundary at two outbound call sites (\`ExecRemote\` line 50, \`handleProxy\` line 276), invoking \`h.dmsgC.DialStream\` directly. That pinned dmsgpty's outbound side to dmsg as the only transport — even though the wire-level \`PtyClient\` only requires an \`io.ReadWriteCloser\`.

This PR adds a \`StreamDialer\` interface around just that outbound dial:

\`\`\`go
type StreamDialer interface {
    DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error)
}
\`\`\`

Both outbound call sites now route through \`Host.dialer\`. The default \`dmsgDialer\` wraps \`*dmsg.Client\` so \`NewHost\` behavior is **unchanged** — every existing caller keeps working bit-for-bit.

A new \`NewHostWithDialer\` constructor lets callers (notably the visor in a follow-up PR) inject a transport-aware dialer that walks \`transport.Manager\` to pick skynet routes / stcpr / etc.

## What's NOT changed
- **Listening side** (\`Host.ListenAndServe\` → \`h.dmsgC.Listen\`) stays on dmsg. Remote peers still reach dmsgpty hosts over dmsg.
- **Logger plumbing** (\`MasterLogger\`, \`Logger\`) stays on \`*dmsg.Client\`.
- **Wire protocol** unchanged — \`PtyClient\` over any \`net.Conn\` already works.

Only OUR outbound proxy dial gets the transport choice.

## Why two phases
- **Phase 1 (this PR)**: pure abstraction, zero behavior change, easy to review. Default behavior preserved.
- **Phase 2 (next PR)**: add \`TransportStreamDialer\` adapter backed by \`transport.Manager\`. Wire it into visor init so \`cli dmsg pty start\` rides existing transports (the operator's stated intent — \`skywire cli dmsg pty start\` should leverage the visor's already-negotiated sessions, including skynet routes, not just dmsg).

Splitting keeps Phase 1's surface tight (~170 lines, all in \`pkg/dmsg/dmsgpty/\`) and lets the transport-adapter design get its own review.

## Test plan
- [x] Two new unit tests:
  - \`TestHost_ExecRemote_RoutesThroughInjectedDialer\` — proves \`NewHostWithDialer(nil, nil, fake)\` doesn't reach for \`h.dmsgC\` and uses the injected dialer (the \`dmsgC=nil\` argument is the contract anchor — pre-refactor this would have NPEd).
  - \`TestHost_ExecRemote_DefaultPortFallback\` — pins \`rPort=0 → DefaultPort\` resolution happens before the dialer is invoked.
- [x] All existing \`./pkg/dmsg/dmsgpty/...\` tests pass (\`ok 5.143s\`)
- [x] \`make format && make lint\` clean (0 issues, vet clean)
- [x] Branch from \`upstream/develop\` per coordination convention; PR-OPEN announcement posted to skychat-coordination

## Related
- Operator request: \`skywire cli dmsg pty start\` should use the visor's existing transports, not just dmsg.
- The standalone \`skywire dmsg pty\` keeps dmsg-only by design (no transport.Manager).