### PR TITLE
refactor(dmsgpty): MultiDialer + visor init via NewHostWithDialer (phase 2)

### DIFF
--- a/pkg/dmsg/dmsgpty/dialer.go
+++ b/pkg/dmsg/dmsgpty/dialer.go
@@ -9,12 +9,13 @@
 // interface around just the outbound dial so a transport-aware
 // adapter can be swapped in without touching the rest of Host.
 //
-// Phase 1 (this PR) is abstraction-only: NewHost wires the default
-// dmsg adapter, behavior is unchanged, every existing caller keeps
-// working. Phase 2 (separate PR) will wire a TransportStreamDialer
-// adapter backed by transport.Manager so `cli dmsg pty start` rides
-// the visor's already-negotiated transports (skynet routes, stcpr,
-// etc.) instead of always opening a fresh dmsg stream.
+// Phase 1 (#2671): NewHost wires the default dmsg adapter, behavior
+// is unchanged. Phase 2 (this PR): MultiDialer composes strategies,
+// visor init goes through NewHostWithDialer with a single-strategy
+// chain (still dmsg-only). Phase 3 (next): a transport-aware adapter
+// backed by SkywireNetworker / transport.Manager prepends to the
+// chain so `cli dmsg pty start` rides the visor's already-negotiated
+// transports first and falls through to dmsg only on miss.
 //
 // The listening side (Host.ListenAndServe → h.dmsgC.Listen) and the
 // logger plumbing stay on *dmsg.Client; only the proxy-out dial is
@@ -24,6 +25,8 @@ package dmsgpty
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -51,9 +54,50 @@ type dmsgDialer struct {
 	c *dmsg.Client
 }
 
+// NewDmsgDialer constructs the dmsg-backed StreamDialer used by
+// NewHost's default wiring and by callers that want to compose it
+// into a MultiDialer alongside non-dmsg strategies. Exposed (vs
+// keeping dmsgDialer private) so the visor's init_dmsg.go can build
+// the same wrapping that NewHost uses internally — both call sites
+// produce identical wire behavior.
+func NewDmsgDialer(c *dmsg.Client) StreamDialer {
+	return dmsgDialer{c: c}
+}
+
 // DialStream forwards to the underlying dmsg.Client. Pre-refactor
 // behavior is preserved exactly: same address shape, same context
 // semantics, same error surface.
 func (d dmsgDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
 	return d.c.DialStream(ctx, dmsg.Addr{PK: pk, Port: port})
+}
+
+// MultiDialer tries each StreamDialer in order and returns the first
+// success. Errors are accumulated; if every strategy fails, the
+// joined error surfaces so operators can see which transports were
+// attempted. Empty list errors immediately rather than panicking.
+//
+// Strategy order is caller-controlled — typically transport-aware
+// adapters first (skynet routes / stcpr) with a dmsg fallback last
+// so working dmsg behavior survives a misconfigured upstream
+// strategy. Each strategy gets the full ctx; a strategy that hangs
+// will block fallback until ctx fires, so callers should bound ctx
+// per overall attempt, not per strategy.
+type MultiDialer []StreamDialer
+
+// DialStream walks the strategies in order. Returns the first conn
+// to succeed; otherwise joins every strategy's error so the caller
+// gets the full attempt list for diagnostics.
+func (m MultiDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
+	if len(m) == 0 {
+		return nil, fmt.Errorf("dmsgpty: MultiDialer has no strategies")
+	}
+	var errs []error
+	for i, d := range m {
+		conn, err := d.DialStream(ctx, pk, port)
+		if err == nil {
+			return conn, nil
+		}
+		errs = append(errs, fmt.Errorf("strategy %d: %w", i, err))
+	}
+	return nil, errors.Join(errs...)
 }

--- a/pkg/dmsg/dmsgpty/dialer_test.go
+++ b/pkg/dmsg/dmsgpty/dialer_test.go
@@ -82,3 +82,94 @@ func TestHost_ExecRemote_DefaultPortFallback(t *testing.T) {
 		t.Errorf("port with rPort=0: got %d, want DefaultPort=%d", got, DefaultPort)
 	}
 }
+
+// stubConn is a minimal net.Conn just to give MultiDialer something
+// non-nil to return on the success path. No I/O is performed.
+type stubConn struct{ net.Conn }
+
+func TestMultiDialer_FirstSuccessWins(t *testing.T) {
+	// First strategy succeeds → later strategies must not be invoked.
+	// Pins the short-circuit: if skynet routes succeed, dmsg fallback
+	// shouldn't open a parallel stream.
+	pk, _ := cipher.GenerateKeyPair()
+	stub := &stubConn{}
+	first := &captureDialer{conn: stub}
+	second := &captureDialer{err: errors.New("must-not-be-called")}
+
+	conn, err := MultiDialer{first, second}.DialStream(context.Background(), pk, 22)
+	if err != nil {
+		t.Fatalf("DialStream: unexpected err %v", err)
+	}
+	if conn != stub {
+		t.Errorf("DialStream returned %v, want stub conn", conn)
+	}
+	if first.count != 1 {
+		t.Errorf("first.count = %d, want 1", first.count)
+	}
+	if second.count != 0 {
+		t.Errorf("second.count = %d, want 0 (later strategy must short-circuit on first success)", second.count)
+	}
+}
+
+func TestMultiDialer_FallsThroughOnError(t *testing.T) {
+	// First strategy errors → next strategy is tried. Pins the
+	// transport-fallback behavior (skynet fails → dmsg succeeds).
+	pk, _ := cipher.GenerateKeyPair()
+	stub := &stubConn{}
+	first := &captureDialer{err: errors.New("skynet unreachable")}
+	second := &captureDialer{conn: stub}
+
+	conn, err := MultiDialer{first, second}.DialStream(context.Background(), pk, 22)
+	if err != nil {
+		t.Fatalf("DialStream: unexpected err %v", err)
+	}
+	if conn != stub {
+		t.Errorf("DialStream returned %v, want stub conn", conn)
+	}
+	if first.count != 1 || second.count != 1 {
+		t.Errorf("call counts: first=%d second=%d, want 1/1", first.count, second.count)
+	}
+}
+
+func TestMultiDialer_AllFailJoinsErrors(t *testing.T) {
+	// Every strategy errors → caller gets every strategy's error
+	// for diagnostics (errors.Join surface). Operators need to see
+	// "skynet timed out AND dmsg refused" not just one.
+	pk, _ := cipher.GenerateKeyPair()
+	errA := errors.New("skynet timeout")
+	errB := errors.New("dmsg refused")
+	a := &captureDialer{err: errA}
+	b := &captureDialer{err: errB}
+
+	_, err := MultiDialer{a, b}.DialStream(context.Background(), pk, 22)
+	if err == nil {
+		t.Fatal("DialStream: want error, got nil")
+	}
+	if !errors.Is(err, errA) || !errors.Is(err, errB) {
+		t.Errorf("joined err missing a sub-error: %v (want both %v and %v)", err, errA, errB)
+	}
+}
+
+func TestMultiDialer_EmptyErrors(t *testing.T) {
+	// An empty MultiDialer is a configuration bug, not a runtime
+	// crash. Errors cleanly so the caller sees the misconfiguration.
+	pk, _ := cipher.GenerateKeyPair()
+	_, err := MultiDialer{}.DialStream(context.Background(), pk, 22)
+	if err == nil {
+		t.Fatal("DialStream: empty MultiDialer should error, got nil")
+	}
+}
+
+// captureDialer counts invocations and returns a fixed (conn, err).
+// Distinct from fakeDialer above: that one captures full call args
+// (pk, port) which the MultiDialer tests don't need.
+type captureDialer struct {
+	conn  net.Conn
+	err   error
+	count int
+}
+
+func (c *captureDialer) DialStream(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	c.count++
+	return c.conn, c.err
+}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -812,7 +812,20 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 		return err
 	}
 
-	pty := dmsgpty.NewHost(dmsgC, wl)
+	// Route the dmsgpty Host's OUTBOUND proxy dial through a
+	// MultiDialer chain so future strategies (skynet routes /
+	// stcpr) can be plugged in without revisiting this site. Phase
+	// 2 ships a single-strategy chain that only wraps the existing
+	// dmsg path — behavior is bit-for-bit unchanged. Phase 3 will
+	// prepend a transport-aware strategy so `cli dmsg pty start`
+	// rides the visor's already-negotiated transports first and
+	// falls through to dmsg when there's no route. Adding here
+	// rather than at NewHost preserves backward compatibility for
+	// every other NewHost caller (cmd/dmsg/dmsgpty-host, sshd CLI,
+	// tests).
+	pty := dmsgpty.NewHostWithDialer(dmsgC, wl, dmsgpty.MultiDialer{
+		dmsgpty.NewDmsgDialer(dmsgC),
+	})
 	// Expose the Host on the visor so the RPC layer can drive Exec
 	// directly (see pkg/visor/rpc_visor.go DmsgPtyExec). Without this
 	// the integrated `skywire cli dmsg pty exec` path is forced


### PR DESCRIPTION
## Summary

Phase 2 of the dmsgpty outbound-transport refactor (#2671 = Phase 1). Adds composable strategy-chaining and forces the visor's production dmsgpty path through the abstraction.

### What's new

- **\`MultiDialer []StreamDialer\`** — walks strategies in order, returns first successful conn, or joins every strategy's error so operators see the full attempt list. Empty chain errors cleanly rather than panicking.
- **\`NewDmsgDialer(c)\`** — exported constructor for the dmsg-backed strategy so the visor and any other caller can build the same dmsg adapter NewHost uses internally.
- **\`pkg/visor/init_dmsg.go\`** — switches \`dmsgpty.NewHost(...)\` → \`dmsgpty.NewHostWithDialer(..., MultiDialer{NewDmsgDialer(dmsgC)})\`. Behavior is bit-for-bit unchanged (single-strategy chain == dmsg-only) but the production path now exercises Phase 1's abstraction end-to-end.

### What's deliberately NOT in scope

- **Skynet listener side**: For dmsgpty over skynet to actually work end-to-end, the remote visor's \`dmsgpty.Host\` would need to also accept incoming \`appnet.SkywireNetworker\` connections on the dmsgpty port. That's a Host method change (parallel \`ListenAndServe\` accepting from a \`net.Listener\` rather than \`dmsg.Client.Listen\`), separate from this dialer refactor. Will be filed as an issue.
- **Skynet outbound strategy**: belongs naturally with the listener-side work since neither is useful without the other.

### Why split Phase 2 / Phase 3

Phase 2 here makes the visor's chain real (\`MultiDialer\` with one entry) so Phase 3 lands as one extra chain entry rather than yet another cross-cutting refactor. The chain-composition contract is what's under test.

### Test plan
- [x] 4 new MultiDialer tests pin first-success-wins, fall-through-on-error, all-fail-joins-errors, and empty-errors contracts
- [x] Phase 1 tests (Host_ExecRemote_RoutesThroughInjectedDialer, Host_ExecRemote_DefaultPortFallback) still pass
- [x] \`go build ./...\` clean
- [x] \`make format && make lint\` clean (0 issues, vet clean)
- [ ] Smoke: visor restart → \`cli dmsg pty start <pk>\` still works over dmsg

### Coordination
- Branched from upstream/develop (post-#2671 + #2670)
- PR-OPEN announcement to skychat-coordination per the 2026-05-16 convention

### Related
- #2671 — Phase 1 (interface + default adapter)
- Operator request: \`skywire cli dmsg pty start\` should use the visor's transports, not just dmsg — the full payoff lands in Phase 3