### PR TITLE
feat(skychat/group): publish signed roster/admin mutations on roster change

### DIFF
--- a/cmd/apps/skychat/group/gossip_emit_test.go
+++ b/cmd/apps/skychat/group/gossip_emit_test.go
@@ -1,0 +1,250 @@
+// Package group — cmd/apps/skychat/group/gossip_emit_test.go:
+// targeted coverage for Session.PublishRosterMutation /
+// PublishAdminMutation (step 2 of #2636 RFC).
+//
+// Scope: the publish helpers' contract — seq monotonicity, signed
+// envelope reachable via the publisher's local view, the
+// session-without-publisher error path. Cross-visor convergence is
+// the reconciler's responsibility (step 3) and lives in its own
+// test file.
+package group
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// nilPublisherSession is the smallest Session that exercises the
+// nil-publisher guard in the Publish helpers. Mirrors the shape of
+// a sessions-but-degraded-state Session (no DMSG, no publisher) —
+// we don't run treestore.NewWithDMSG here because the helpers'
+// no-publisher branch is the only thing under test.
+func nilPublisherSession(t *testing.T) *Session {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	return &Session{
+		cfg: Config{
+			MyPK: pk,
+			MySK: sk,
+			Record: Record{
+				ID:      "00000000-0000-0000-0000-000000000001",
+				OwnerPK: pk,
+			},
+		},
+	}
+}
+
+func TestPublishRosterMutationRejectsNilPublisher(t *testing.T) {
+	s := nilPublisherSession(t)
+	peer, _ := cipher.GenerateKeyPair()
+	_, err := s.PublishRosterMutation(RosterOpAdd, peer, 0)
+	if err == nil {
+		t.Fatal("expected error when publisher is nil")
+	}
+}
+
+func TestPublishAdminMutationRejectsNilPublisher(t *testing.T) {
+	s := nilPublisherSession(t)
+	peer, _ := cipher.GenerateKeyPair()
+	_, err := s.PublishAdminMutation(AdminOpPromote, peer, 0)
+	if err == nil {
+		t.Fatal("expected error when publisher is nil")
+	}
+}
+
+// testPublisherSession builds an in-memory Publisher (no DMSG —
+// pkg/cxo/treestore.New plus a no-op CXO node) wrapped in a minimal
+// Session whose cfg carries the publisher's PK/SK and a valid group
+// ID. Enough to exercise PublishRosterMutation / PublishAdminMutation
+// end-to-end including the publisher's Put round-trip.
+func testPublisherSession(t *testing.T) *Session {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	pub := newInProcessPublisher(t, sk)
+	return &Session{
+		cfg: Config{
+			MyPK: pk,
+			MySK: sk,
+			Record: Record{
+				ID:      uuid.NewString(),
+				OwnerPK: pk,
+			},
+		},
+		pub: pub,
+		log: logging.MustGetLogger("group.gossip-emit-test"),
+	}
+}
+
+// newInProcessPublisher builds a Publisher backed by an in-memory CXO
+// node with no network listeners. Mirrors publisher_test.go's nopNode
+// pattern. Suitable for emit unit-tests: the publisher accepts Puts
+// and stores them in the in-memory container; the broadcast side is
+// a no-op because no peers are connected.
+func newInProcessPublisher(t *testing.T, sk cipher.SecKey) *treestore.Publisher {
+	t.Helper()
+	cfg := node.NewConfig()
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
+	cfg.Config.InMemoryDB = true
+	n, err := node.NewNode(cfg)
+	if err != nil {
+		t.Fatalf("node.NewNode: %v", err)
+	}
+	t.Cleanup(func() { _ = n.Close() }) //nolint:errcheck
+	pub, err := treestore.New(n, sk, treestore.Config{BatchWindow: 5 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("treestore.New: %v", err)
+	}
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+	return pub
+}
+
+// pubReadable polls the publisher's in-memory view until path is
+// readable, then returns its body. Bounded poll guards against the
+// (very unlikely in this in-memory path) async-publish race.
+func pubReadable(t *testing.T, pub *treestore.Publisher, path string) []byte {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		body, ok := pub.Get(path)
+		if ok {
+			return body
+		}
+		// no-op — Get is in-process, no delay needed beyond the
+		// loop's natural retry cadence.
+	}
+	t.Fatalf("pubReadable: %s not present after retries", path)
+	return nil
+}
+
+func TestPublishRosterMutationLandsOnFeed(t *testing.T) {
+	s := testPublisherSession(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	seq1, err := s.PublishRosterMutation(RosterOpAdd, peer, 0)
+	if err != nil {
+		t.Fatalf("PublishRosterMutation #1: %v", err)
+	}
+	if seq1 != 1 {
+		t.Fatalf("first publish seq: want 1 got %d", seq1)
+	}
+
+	seq2, err := s.PublishRosterMutation(RosterOpRemove, peer, seq1)
+	if err != nil {
+		t.Fatalf("PublishRosterMutation #2: %v", err)
+	}
+	if seq2 != 2 {
+		t.Fatalf("second publish seq: want 2 got %d", seq2)
+	}
+
+	// Read back leaf #1 and verify the envelope decodes + verifies.
+	body := pubReadable(t, s.pub, fmt.Sprintf("%s/%05d", RosterPathPrefix, seq1))
+	m, err := UnmarshalRoster(body)
+	if err != nil {
+		t.Fatalf("UnmarshalRoster: %v", err)
+	}
+	if m.Op != RosterOpAdd {
+		t.Errorf("Op: want RosterOpAdd got %v", m.Op)
+	}
+	if m.PeerPK != peer {
+		t.Errorf("PeerPK mismatch")
+	}
+	if m.IssuerPK != s.cfg.MyPK {
+		t.Errorf("IssuerPK: want %s got %s", s.cfg.MyPK, m.IssuerPK)
+	}
+	if m.ParentSeq != 0 {
+		t.Errorf("ParentSeq: want 0 got %d", m.ParentSeq)
+	}
+
+	// And #2 carries the chained ParentSeq.
+	body2 := pubReadable(t, s.pub, fmt.Sprintf("%s/%05d", RosterPathPrefix, seq2))
+	m2, err := UnmarshalRoster(body2)
+	if err != nil {
+		t.Fatalf("UnmarshalRoster #2: %v", err)
+	}
+	if m2.ParentSeq != seq1 {
+		t.Errorf("ParentSeq chain: want %d got %d", seq1, m2.ParentSeq)
+	}
+}
+
+func TestPublishAdminMutationLandsOnFeed(t *testing.T) {
+	s := testPublisherSession(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	seq, err := s.PublishAdminMutation(AdminOpPromote, peer, 0)
+	if err != nil {
+		t.Fatalf("PublishAdminMutation: %v", err)
+	}
+	if seq != 1 {
+		t.Fatalf("first admin publish seq: want 1 got %d", seq)
+	}
+
+	body := pubReadable(t, s.pub, fmt.Sprintf("%s/%05d", AdminPathPrefix, seq))
+	m, err := UnmarshalAdmin(body)
+	if err != nil {
+		t.Fatalf("UnmarshalAdmin: %v", err)
+	}
+	if m.Op != AdminOpPromote {
+		t.Errorf("Op: want AdminOpPromote got %v", m.Op)
+	}
+	if m.PeerPK != peer {
+		t.Errorf("PeerPK mismatch")
+	}
+	if m.IssuerPK != s.cfg.MyPK {
+		t.Errorf("IssuerPK: want %s got %s", s.cfg.MyPK, m.IssuerPK)
+	}
+}
+
+func TestPublishSequenceIsAtomic(t *testing.T) {
+	// Concurrent publishes must each get a distinct seq with no
+	// gaps. Two goroutines hammer the helper; the seq counter
+	// (atomic.Uint64.Add) is the single source of monotonicity.
+	s := testPublisherSession(t)
+	peer, _ := cipher.GenerateKeyPair()
+
+	const N = 50
+	var (
+		seen [N + 1]atomic.Bool
+		errs atomic.Uint64
+	)
+	done := make(chan struct{}, 2)
+	for w := 0; w < 2; w++ {
+		go func() {
+			for i := 0; i < N/2; i++ {
+				seq, err := s.PublishRosterMutation(RosterOpAdd, peer, 0)
+				if err != nil {
+					errs.Add(1)
+					continue
+				}
+				if seq < 1 || seq > uint64(N) {
+					errs.Add(1)
+					continue
+				}
+				if seen[seq].Swap(true) {
+					errs.Add(1) // duplicate seq — would be a bug in atomic.Add
+				}
+			}
+			done <- struct{}{}
+		}()
+	}
+	<-done
+	<-done
+	if errs.Load() != 0 {
+		t.Fatalf("concurrent publish: %d errors / collisions observed", errs.Load())
+	}
+	// Every seq 1..N must have been observed exactly once.
+	for i := 1; i <= N; i++ {
+		if !seen[i].Load() {
+			t.Errorf("seq %d not observed", i)
+		}
+	}
+}

--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -389,6 +389,17 @@ func (m *Manager) AddMember(id string, pk cipher.PubKey) (Record, error) {
 		for _, pk := range evicted {
 			m.peerReconnectClear(id, pk)
 		}
+		// Federated gossip emit (step 2 of #2636 RFC): publish a
+		// signed RosterMutation onto THIS visor's publisher feed so
+		// other visors' subscribers learn of the roster change
+		// without an explicit invite re-issuance. Best-effort — a
+		// failure here doesn't roll back the local store change;
+		// the operator can re-trigger emission by re-calling
+		// AddMember (idempotent) once the publisher is healthy.
+		if _, err := sess.PublishRosterMutation(RosterOpAdd, pk, 0); err != nil {
+			m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
+				Debug("group: AddMember: gossip emit failed; local state still consistent")
+		}
 	}
 	return r, nil
 }
@@ -427,6 +438,19 @@ func (m *Manager) PromoteAdmin(id string, pk cipher.PubKey) (Record, error) {
 	r.EnsureFounderInAdmins()
 	if err := m.store.Put(r); err != nil {
 		return Record{}, fmt.Errorf("group: PromoteAdmin: store: %w", err)
+	}
+	// Federated gossip emit (step 2 of #2636 RFC). See AddMember
+	// for rationale. Member-side roster derivation needs to know
+	// the promoted PK is an admin so its mutations are accepted by
+	// the reconciler downstream.
+	m.mu.RLock()
+	sess, live := m.sessions[id]
+	m.mu.RUnlock()
+	if live {
+		if _, err := sess.PublishAdminMutation(AdminOpPromote, pk, 0); err != nil {
+			m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
+				Debug("group: PromoteAdmin: gossip emit failed; local state still consistent")
+		}
 	}
 	return r, nil
 }
@@ -476,6 +500,16 @@ func (m *Manager) DemoteAdmin(id string, pk cipher.PubKey) (Record, error) {
 	r.EnsureFounderInAdmins()
 	if err := m.store.Put(r); err != nil {
 		return Record{}, fmt.Errorf("group: DemoteAdmin: store: %w", err)
+	}
+	// Federated gossip emit (step 2 of #2636 RFC). See PromoteAdmin.
+	m.mu.RLock()
+	sess, live := m.sessions[id]
+	m.mu.RUnlock()
+	if live {
+		if _, err := sess.PublishAdminMutation(AdminOpDemote, pk, 0); err != nil {
+			m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
+				Debug("group: DemoteAdmin: gossip emit failed; local state still consistent")
+		}
 	}
 	return r, nil
 }

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -48,6 +48,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
@@ -86,6 +88,20 @@ const MessagePathPrefix = "msgs"
 // can SetPrefixes([]string{MessagePathPrefix, MirrorPathPrefix})
 // to consume both kinds of leaves from the same feed.
 const MirrorPathPrefix = "mirror"
+
+// RosterPathPrefix is the prefix used for signed roster-mutation
+// envelopes within a group feed (cross-visor admin/roster gossip —
+// RFC at docs/skychat_group_gossip_rfc.md, types in gossip.go).
+// Every roster mutation issued by an admin lands at
+// "<RosterPathPrefix>/<seq>" on that admin's own publisher feed;
+// other members' subscribers pick it up and apply through the
+// reconciler (PR-3 of the gossip impl).
+const RosterPathPrefix = "roster"
+
+// AdminPathPrefix is the parallel prefix for signed admin-mutation
+// envelopes (promote / demote). Same per-feed seq scheme as
+// RosterPathPrefix.
+const AdminPathPrefix = "admin"
 
 // dedupKey reduces a leaf path to its content-identity suffix —
 // the canonical "<senderPK>/<ts>/<seq>" tail that both the primary
@@ -430,6 +446,24 @@ type Session struct {
 	// reconnects fire for everything in peerSubs but s.sub stays in
 	// whatever attached/dead state it landed in.
 	subLastInboundNs atomic.Int64
+
+	// rosterSeq and adminSeq are the per-feed monotonic sequence
+	// counters appended to gossip-mutation leaf paths
+	// (RosterPathPrefix/<seq>, AdminPathPrefix/<seq>). Initialized
+	// to zero; first mutation publishes at seq=1. Atomic.Add()
+	// returns the post-increment value, so each PublishRoster /
+	// PublishAdmin call gets a fresh seq via a single CAS. The
+	// counter is per-Session because it's per-publisher-feed; cross-
+	// visor convergence happens in the reconciler via ParentSeq.
+	//
+	// Not persisted: on restart the counter resets to zero, which
+	// is fine — the publisher rehydrates its tree (#2651) and the
+	// next mutation lands at roster/00001 (or wherever the highest
+	// existing seq + 1 is, once the rehydrate path observes it).
+	// Subscribers dedup via the canonical-bytes signature, so a
+	// post-restart seq collision is at worst a no-op replay.
+	rosterSeq atomic.Uint64
+	adminSeq  atomic.Uint64
 }
 
 // subscriberStaleThreshold is defined in manager.go (it's used by
@@ -1338,6 +1372,85 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 	}
 	s.peerSubsMu.Unlock()
 	return evicted, nil
+}
+
+// PublishRosterMutation signs op+peerPK as a RosterMutation envelope
+// (per docs/skychat_group_gossip_rfc.md) and writes it to this
+// session's publisher under RosterPathPrefix/<seq>. Subscribers on
+// other visors observe the leaf via their normal OnUpdate path; the
+// reconciler (step 3 of the gossip impl) decodes, verifies, and
+// applies.
+//
+// Caller is responsible for ensuring this visor has roster authority
+// to issue the mutation (Manager.AddMember already gates on
+// r.IsAdmin(myPK) before calling this). The envelope's IssuerPK is
+// always this session's MyPK; signature uses MySK.
+//
+// parentSeq is the highest roster-mutation seq THIS issuer has
+// observed before issuing — used by the reconciler to void mutations
+// from a since-demoted admin. Callers that don't track parent_seq
+// can pass 0; the reconciler treats parent_seq=0 as "no causal
+// constraint" and applies the mutation if signature + admin-set
+// gate pass.
+//
+// Returns the seq the mutation was published at (>=1), or an error
+// if signing or Put fails. The session must have a live publisher
+// (s.pub != nil) — sessions opened in a degenerate state (no DMSG)
+// have nil publishers and return an error here.
+func (s *Session) PublishRosterMutation(op RosterOp, peerPK cipher.PubKey, parentSeq uint64) (uint64, error) {
+	if s == nil || s.pub == nil {
+		return 0, errors.New("group: PublishRosterMutation: no live publisher")
+	}
+	seq := s.rosterSeq.Add(1)
+	m := RosterMutation{
+		GroupID:   uuid.MustParse(s.cfg.Record.ID),
+		Op:        op,
+		PeerPK:    peerPK,
+		ParentSeq: parentSeq,
+		IssuedAt:  time.Now().UTC(),
+	}
+	if err := SignRoster(&m, s.cfg.MySK); err != nil {
+		return 0, fmt.Errorf("group: PublishRosterMutation: sign: %w", err)
+	}
+	body, err := MarshalRoster(m)
+	if err != nil {
+		return 0, fmt.Errorf("group: PublishRosterMutation: marshal: %w", err)
+	}
+	path := fmt.Sprintf("%s/%05d", RosterPathPrefix, seq)
+	if err := s.pub.Put(path, body); err != nil {
+		return 0, fmt.Errorf("group: PublishRosterMutation: Put %s: %w", path, err)
+	}
+	return seq, nil
+}
+
+// PublishAdminMutation is the parallel emitter for AdminMutation —
+// promote / demote of a peer's admin authority. Same envelope shape
+// and semantics as PublishRosterMutation, scoped to the admin-feed
+// path (AdminPathPrefix/<seq>) and using s.adminSeq.
+func (s *Session) PublishAdminMutation(op AdminOp, peerPK cipher.PubKey, parentSeq uint64) (uint64, error) {
+	if s == nil || s.pub == nil {
+		return 0, errors.New("group: PublishAdminMutation: no live publisher")
+	}
+	seq := s.adminSeq.Add(1)
+	m := AdminMutation{
+		GroupID:   uuid.MustParse(s.cfg.Record.ID),
+		Op:        op,
+		PeerPK:    peerPK,
+		ParentSeq: parentSeq,
+		IssuedAt:  time.Now().UTC(),
+	}
+	if err := SignAdmin(&m, s.cfg.MySK); err != nil {
+		return 0, fmt.Errorf("group: PublishAdminMutation: sign: %w", err)
+	}
+	body, err := MarshalAdmin(m)
+	if err != nil {
+		return 0, fmt.Errorf("group: PublishAdminMutation: marshal: %w", err)
+	}
+	path := fmt.Sprintf("%s/%05d", AdminPathPrefix, seq)
+	if err := s.pub.Put(path, body); err != nil {
+		return 0, fmt.Errorf("group: PublishAdminMutation: Put %s: %w", path, err)
+	}
+	return seq, nil
 }
 
 // Close tears down the subscriber + publisher (and the underlying


### PR DESCRIPTION
Step 2 of the gossip impl outlined in PR #2656 (RFC at \`docs/skychat_group_gossip_rfc.md\`, closes issue #2636). Builds on the mutation types + signing from #2658.

## What this does

- **\`Session.PublishRosterMutation\` and \`PublishAdminMutation\`** — build an envelope (typed Op + PeerPK + monotonic ParentSeq + IssuedAt + IssuerPK), sign with the session's MySK via the existing \`SignRoster\` / \`SignAdmin\` helpers, and \`Put()\` the JSON encoding under \`RosterPathPrefix/<seq>\` or \`AdminPathPrefix/<seq>\` on the session's own publisher feed.

- **Per-feed atomic.Uint64 seq counters** (\`rosterSeq\`, \`adminSeq\`) on Session. Each Publish call increments-and-returns via a single CAS so concurrent issuers see monotonically distinct seqs.

- **Wires the manager mutators**: \`AddMember\`, \`PromoteAdmin\`, \`DemoteAdmin\` invoke the emit helpers AFTER the local store mutation lands. Best-effort: a publish failure logs at debug and doesn't roll back the local state change (matches the federated-send error handling convention elsewhere in the package).

- **\`RosterPathPrefix = \"roster\"\` and \`AdminPathPrefix = \"admin\"\`** so the wire-format paths are referenced symbolically. Mirrors \`MessagePathPrefix\` / \`MirrorPathPrefix\` in shape.

## What this doesn't do

- **Subscribers don't yet apply the mutations** to their local Record. That's step 3 of the impl (separate PR): the reconciler decodes, verifies the issuer is currently in the admin-set, and walks \`ParentSeq\` for retroactive voids.

- **\`RemoveMember\` isn't a Manager method yet**; this PR only emits on \`AddMember\` / \`PromoteAdmin\` / \`DemoteAdmin\`. \`RemoveMember\` + its corresponding \`RosterOpRemove\` emit are a follow-up.

- **No \"seq resumes from highest-on-disk\" logic on publisher restart.** Per the RFC note, sequence collisions across restarts are at worst no-op replays for the subscriber (the canonical-bytes signature gates dedup). A future PR can plumb the rehydrate path to read the highest existing seq and seed the counter.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./cmd/apps/skychat/group/... -race -count=3\` passes (5 new tests + all existing)
- [x] \`golangci-lint run ./cmd/apps/skychat/group/...\` clean

## New tests

| Test | What |
|---|---|
| \`TestPublishRosterMutationRejectsNilPublisher\` | Degenerate session (no publisher) returns error rather than panicking |
| \`TestPublishAdminMutationRejectsNilPublisher\` | Same for the admin emit path |
| \`TestPublishRosterMutationLandsOnFeed\` | Full round-trip: publish two mutations, read back the leaves, decode and verify envelope matches what was published (Op, PeerPK, IssuerPK, ParentSeq chain) |
| \`TestPublishAdminMutationLandsOnFeed\` | Same for admin emit path |
| \`TestPublishSequenceIsAtomic\` | Two goroutines hammer \`PublishRosterMutation\` in parallel; every seq 1..N must appear exactly once, no duplicates, no gaps |

## Tracks

- #2636 (gossip RFC) step 2 of 7
- #2639 (owner-SPOF) — emit-side unblocks; reconciler-side still needed for full convergence
- Builds on #2658 (mutation types + signing) and #2656 (RFC)