### PR TITLE
refactor(dmsgpty): skynet listener + dialer in MultiDialer chain (phase 3)

### DIFF
--- a/pkg/dmsg/dmsgpty/dialer_test.go
+++ b/pkg/dmsg/dmsgpty/dialer_test.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )
@@ -172,4 +174,71 @@ type captureDialer struct {
 func (c *captureDialer) DialStream(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
 	c.count++
 	return c.conn, c.err
+}
+
+// memListener is a minimal net.Listener that yields a single
+// in-memory pipe conn on its first Accept and blocks until ctx
+// expires. Lets us drive ListenAndServeNet through one accept cycle
+// to exercise the extractor branch.
+type memListener struct {
+	conn     net.Conn
+	served   bool
+	done     chan struct{}
+	closeOne sync.Once
+}
+
+func newMemListener(conn net.Conn) *memListener {
+	return &memListener{conn: conn, done: make(chan struct{})}
+}
+
+func (l *memListener) Accept() (net.Conn, error) {
+	if l.served {
+		<-l.done
+		return nil, net.ErrClosed
+	}
+	l.served = true
+	return l.conn, nil
+}
+
+// Close is idempotent — ListenAndServeNet's ctx-done goroutine and
+// the test cleanup both call Close, so double-close must not panic.
+func (l *memListener) Close() error {
+	l.closeOne.Do(func() { close(l.done) })
+	return nil
+}
+
+func (l *memListener) Addr() net.Addr { return &net.TCPAddr{} }
+
+func TestListenAndServeNet_RejectsConnWhenExtractorReturnsFalse(t *testing.T) {
+	// Defense-in-depth: a conn whose extractor returns ok=false is
+	// closed before any pty handshake. Whitelist isn't even
+	// consulted — the conn type itself is foreign and shouldn't
+	// reach the trust gate.
+	server, client := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	h := NewHostWithDialer(nil, NewMemoryWhitelist(), &fakeDialer{})
+	lis := newMemListener(server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Extractor returns false → conn must be closed without
+	// authorize() being reached.
+	done := make(chan error, 1)
+	go func() {
+		done <- h.ListenAndServeNet(ctx, lis, func(net.Conn) (cipher.PubKey, bool) {
+			return cipher.PubKey{}, false
+		})
+	}()
+
+	// Wait for the server-side conn to be closed by the handler.
+	buf := make([]byte, 1)
+	_ = server.SetReadDeadline(time.Now().Add(150 * time.Millisecond)) //nolint:errcheck,gosec
+	_, err := server.Read(buf)
+	if err == nil {
+		t.Error("server conn was not closed; extractor-false should drop the conn")
+	}
+	_ = lis.Close() //nolint:errcheck,gosec
+	<-done
 }

--- a/pkg/dmsg/dmsgpty/host.go
+++ b/pkg/dmsg/dmsgpty/host.go
@@ -207,6 +207,96 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 	}
 }
 
+// PKExtractor pulls the remote public key from an accepted conn so
+// ListenAndServeNet can drive whitelist authorization on transports
+// that aren't dmsg. Returns (pk, true) on success; (zero, false)
+// causes the conn to be rejected before any pty handshake happens
+// — the same defense-in-depth that the dmsg path's whitelist check
+// provides. Callers wrap their listener's conn type (typically
+// appnet.SkywireConn) and read the embedded address.
+type PKExtractor func(conn net.Conn) (cipher.PubKey, bool)
+
+// ListenAndServeNet serves dmsgpty over an arbitrary net.Listener.
+// Generic counterpart of ListenAndServe (which is hard-bound to
+// dmsg.Listener for AcceptStream + dmsg-specific error sentinels);
+// this method handles only the generic surface: accept → extract PK
+// → authorize → fan out to serveConn.
+//
+// Use case: visor wires a parallel listener on appnet.SkywireNetworker
+// so dmsgpty traffic can ride skynet routes in addition to dmsg.
+// Each transport gets its own listener call and they run in
+// parallel — accepted conns are served via the same mux as the
+// dmsg path, so the wire protocol is identical regardless of
+// transport.
+//
+// extractPK must be non-nil; nil short-circuits to a rejected conn
+// because skipping whitelist enforcement would silently weaken the
+// dmsgpty trust model.
+func (h *Host) ListenAndServeNet(ctx context.Context, lis net.Listener, extractPK PKExtractor) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mux := dmsgEndpoints(h)
+
+	log := logging.MustGetLogger("dmsg_pty_net")
+	if h.dmsgC != nil {
+		if ml := h.dmsgC.MasterLogger(); ml != nil {
+			log = ml.PackageLogger("dmsg_pty_net")
+		}
+	}
+
+	go func() {
+		<-ctx.Done()
+		log.WithError(lis.Close()).Debug("ListenAndServeNet() ended.")
+	}()
+
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			log := log.WithError(err)
+			if netErr, ok := err.(net.Error); ok && netErr.Temporary() { //nolint:staticcheck
+				log.Warn("Failed to accept net.Conn with temporary error, continuing...")
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			if err == io.ErrClosedPipe || errors.Is(err, net.ErrClosed) {
+				log.Debug("Cleanly stopped serving.")
+				return nil
+			}
+			log.Error("Failed to accept net.Conn with permanent error.")
+			return err
+		}
+
+		var rPK cipher.PubKey
+		var ok bool
+		if extractPK != nil {
+			rPK, ok = extractPK(conn)
+		}
+		if !ok {
+			log.Warn("Accepted conn rejected: PK extraction failed (nil extractor or non-skywire conn).")
+			_ = conn.Close() //nolint:errcheck,gosec
+			continue
+		}
+
+		logC := log.WithField("remote_pk", rPK.String())
+		if !h.authorize(logC, rPK) {
+			err := writeResponse(conn, errors.New("net stream rejected by whitelist"))
+			logC.WithError(err).Warn()
+			if err := conn.Close(); err != nil {
+				logC.WithError(err).Warn("Conn closed with error.")
+			}
+			continue
+		}
+
+		logC = logC.WithField("conn_id", atomic.AddInt32(&h.connN, 1))
+		logC.Debug("net.Conn accepted.")
+		go func() {
+			h.serveConn(ctx, logC, &mux, conn)
+			atomic.AddInt32(&h.connN, -1)
+		}()
+	}
+}
+
 // serveConn serves a CLI connection or dmsg stream.
 func (h *Host) serveConn(ctx context.Context, log logrus.FieldLogger, mux *hostMux, conn net.Conn) {
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -812,20 +812,15 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 		return err
 	}
 
-	// Route the dmsgpty Host's OUTBOUND proxy dial through a
-	// MultiDialer chain so future strategies (skynet routes /
-	// stcpr) can be plugged in without revisiting this site. Phase
-	// 2 ships a single-strategy chain that only wraps the existing
-	// dmsg path — behavior is bit-for-bit unchanged. Phase 3 will
-	// prepend a transport-aware strategy so `cli dmsg pty start`
-	// rides the visor's already-negotiated transports first and
-	// falls through to dmsg when there's no route. Adding here
-	// rather than at NewHost preserves backward compatibility for
-	// every other NewHost caller (cmd/dmsg/dmsgpty-host, sshd CLI,
-	// tests).
-	pty := dmsgpty.NewHostWithDialer(dmsgC, wl, dmsgpty.MultiDialer{
-		dmsgpty.NewDmsgDialer(dmsgC),
-	})
+	// Route the dmsgpty Host's OUTBOUND proxy dial through the
+	// MultiDialer chain built in init_dmsg_skywire.go. Strategy
+	// order is skywire-first / dmsg-fallback so `cli dmsg pty
+	// start` rides the visor's already-negotiated transports when
+	// a route exists, then falls through to dmsg on miss. Adding
+	// the chain here rather than at NewHost preserves backward
+	// compat for every other NewHost caller (cmd/dmsg/dmsgpty-host,
+	// sshd CLI, tests).
+	pty := dmsgpty.NewHostWithDialer(dmsgC, wl, buildDmsgptyDialer(dmsgC))
 	// Expose the Host on the visor so the RPC layer can drive Exec
 	// directly (see pkg/visor/rpc_visor.go DmsgPtyExec). Without this
 	// the integrated `skywire cli dmsg pty exec` path is forced
@@ -851,6 +846,18 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 			wg.Wait()
 			return nil
 		})
+
+		// Parallel skynet listener — accepts dmsgpty over
+		// appnet.SkywireNetworker so remote peers that have a
+		// negotiated route to us can reach the pty service without
+		// opening a fresh dmsg stream. Returns nil close-func when
+		// the skynet networker isn't wired yet (init ordering) or
+		// when Listen fails; in either case the dmsg listener
+		// above keeps the service functional.
+		runtimeErrors := getErrors(ctx)
+		if closer := startSkywirePtyListener(context.Background(), pty, v.conf.PK, ptyPort, runtimeErrors); closer != nil {
+			v.pushCloseStack("dmsgpty.skywire.serve", closer)
+		}
 
 	}
 

--- a/pkg/visor/init_dmsg_skywire.go
+++ b/pkg/visor/init_dmsg_skywire.go
@@ -1,0 +1,153 @@
+// Package visor pkg/visor/init_dmsg_skywire.go — phase 3 wiring of
+// the dmsgpty Host over skynet routes.
+//
+// Lives in pkg/visor (not pkg/dmsg/dmsgpty) because pkg/app/appnet
+// imports are visor-tier — pushing them down into the dmsgpty
+// package would invert the layering. The dmsgpty package keeps its
+// generic StreamDialer / PKExtractor interfaces (Phase 1/2); this
+// file bridges them to appnet.SkywireNetworker on the visor side.
+//
+// Phase 3 effect: the dmsgpty Host gains a parallel listener on
+// appnet.SkywireNetworker AND its MultiDialer chain prepends a
+// skynet strategy. `cli dmsg pty start` now rides the visor's
+// already-negotiated transports first; on miss (no route, remote
+// not exposing skynet listener) the chain falls through to the
+// existing dmsg strategy. Backward-compat: every dmsg-only deploy
+// keeps working unchanged because dmsg is the chain's last entry.
+package visor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// skywireDialer is a dmsgpty.StreamDialer backed by the visor's
+// SkywireNetworker. Each DialStream opens a fresh skynet conn to
+// the remote's dmsgpty listen-port (DefaultPort by convention).
+//
+// Resolving the networker lazily (per call, not at construction) is
+// intentional: ResolveNetworker reads a global registry that may
+// not yet be populated when initDmsg runs. By the time the first
+// pty.ExecRemote actually fires the resolver is wired, so this
+// adapter just returns a "no skywire networker" error in the
+// pre-init window and the MultiDialer falls through to dmsg —
+// matching the behavior we'd want anyway.
+type skywireDialer struct{}
+
+// DialStream resolves the skynet networker on every call and dials
+// pk:port over it. Failure surfaces a wrapped error so the
+// MultiDialer's joined-error output identifies skynet as the
+// strategy that failed.
+func (skywireDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint16) (net.Conn, error) {
+	n, err := appnet.ResolveNetworker(appnet.TypeSkynet)
+	if err != nil {
+		return nil, fmt.Errorf("skywire: networker unavailable: %w", err)
+	}
+	sn, ok := n.(*appnet.SkywireNetworker)
+	if !ok {
+		return nil, errors.New("skywire: resolved networker is not SkywireNetworker")
+	}
+	return sn.DialContextWithOptions(ctx, appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: pk,
+		Port:   routing.Port(port),
+	}, nil)
+}
+
+// skywireConnPK is the dmsgpty.PKExtractor for conns accepted by
+// the SkywireNetworker listener. Reaches into RemoteAddr() to pull
+// the appnet.Addr that carries the remote PK. Returns (zero, false)
+// for any conn type that doesn't carry an appnet.Addr so foreign
+// listeners can't sneak past the whitelist gate.
+func skywireConnPK(conn net.Conn) (cipher.PubKey, bool) {
+	addr, ok := conn.RemoteAddr().(appnet.Addr)
+	if !ok {
+		return cipher.PubKey{}, false
+	}
+	return addr.PubKey, true
+}
+
+// startSkywirePtyListener opens an appnet listener on (localPK,
+// port) over the skynet networker and serves dmsgpty over it.
+// Mirror of pty.ListenAndServe but on the skynet path; runs in its
+// own goroutine alongside the dmsg listener.
+//
+// Returns a func that cancels + waits for the goroutine. Nil
+// returned cancel means setup failed and the caller can ignore
+// shutdown bookkeeping — typical when the skynet networker isn't
+// available yet at init time.
+func startSkywirePtyListener(ctx context.Context, pty *dmsgpty.Host, localPK cipher.PubKey, port uint16, runtimeErrors chan<- error) func() error {
+	n, err := appnet.ResolveNetworker(appnet.TypeSkynet)
+	if err != nil {
+		// Skynet networker not wired yet — operator will still get
+		// the dmsg listener and the dmsg-only MultiDialer fallback;
+		// pty over skynet routes is then a no-op for this visor run.
+		// Not a fatal init error because the dmsgpty service itself
+		// still functions.
+		return nil
+	}
+	sn, ok := n.(*appnet.SkywireNetworker)
+	if !ok {
+		return nil
+	}
+
+	lis, err := sn.Listen(appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: localPK,
+		Port:   routing.Port(port),
+	})
+	if err != nil {
+		// Listen failure is non-fatal for the same reason the
+		// networker-missing branch is: dmsg path keeps working.
+		// Surface as a runtime warning rather than killing init.
+		select {
+		case runtimeErrors <- fmt.Errorf("skywire dmsgpty Listen: %w", err):
+		default:
+		}
+		return nil
+	}
+
+	serveCtx, cancel := context.WithCancel(ctx)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		if err := pty.ListenAndServeNet(serveCtx, lis, skywireConnPK); err != nil {
+			select {
+			case runtimeErrors <- fmt.Errorf("skywire dmsgpty serve: %w", err):
+			default:
+			}
+		}
+	}()
+
+	return func() error {
+		cancel()
+		wg.Wait()
+		return nil
+	}
+}
+
+// buildDmsgptyDialer returns the MultiDialer used by the visor's
+// dmsgpty Host. Order: skywire first (transport-aware), dmsg last
+// (fallback). Skywire failures fall through to dmsg via
+// MultiDialer's strategy-walk semantics so an operator with no
+// skynet route to the target peer keeps the historical behavior.
+//
+// Future strategies (stcpr, sudpr, direct-TCP) prepend or splice in
+// here without revisiting any other call site.
+func buildDmsgptyDialer(dmsgC *dmsg.Client) dmsgpty.StreamDialer {
+	return dmsgpty.MultiDialer{
+		skywireDialer{},
+		dmsgpty.NewDmsgDialer(dmsgC),
+	}
+}

--- a/pkg/visor/init_dmsg_skywire_test.go
+++ b/pkg/visor/init_dmsg_skywire_test.go
@@ -1,0 +1,97 @@
+// Package visor pkg/visor/init_dmsg_skywire_test.go — pins the
+// Phase 3 wiring contract: PK extractor refuses non-skywire conns
+// (defense-in-depth before the whitelist gate), and the dmsgpty
+// dialer chain is skywire-first / dmsg-fallback.
+package visor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// fakeAppnetConn is a net.Conn whose RemoteAddr returns an
+// appnet.Addr — what SkywireConn would return in production. Only
+// RemoteAddr is exercised; the rest of the surface is unused by the
+// extractor.
+type fakeAppnetConn struct {
+	net.Conn
+	addr appnet.Addr
+}
+
+func (f *fakeAppnetConn) RemoteAddr() net.Addr { return f.addr }
+
+// fakeOtherConn returns a non-appnet.Addr from RemoteAddr — what
+// e.g. a raw TCP conn would do. Used to confirm the extractor
+// REJECTS such conns rather than passing a zero PK through to the
+// whitelist gate.
+type fakeOtherConn struct {
+	net.Conn
+}
+
+func (fakeOtherConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}
+}
+
+func TestSkywireConnPK_ExtractsFromAppnetAddr(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	conn := &fakeAppnetConn{addr: appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: pk,
+		Port:   routing.Port(22),
+	}}
+	got, ok := skywireConnPK(conn)
+	if !ok {
+		t.Fatal("extractor returned ok=false on a valid appnet.Addr conn")
+	}
+	if got != pk {
+		t.Errorf("extractor pk = %s, want %s", got, pk)
+	}
+}
+
+func TestSkywireConnPK_RejectsNonAppnetConn(t *testing.T) {
+	// Defense-in-depth: a foreign conn type (e.g. a raw TCP
+	// hand-off) must NOT pass extraction, because the whitelist
+	// gate downstream would otherwise check a zero PK that
+	// trivially fails closed — but masking this at extraction is
+	// the more honest signal: foreign conns shouldn't reach the
+	// whitelist at all.
+	got, ok := skywireConnPK(fakeOtherConn{})
+	if ok {
+		t.Errorf("extractor accepted non-appnet.Addr conn: got pk=%s", got)
+	}
+}
+
+func TestBuildDmsgptyDialer_SkywireFirstDmsgFallback(t *testing.T) {
+	// Chain order is the load-bearing contract: skywire MUST be
+	// tried before dmsg so operators with a route to the target
+	// peer get the transport-aware path; dmsg is only the
+	// fallback. Swapping the order would silently regress to
+	// dmsg-only behavior for every call where skywire would
+	// succeed.
+	chain, ok := buildDmsgptyDialer(nil).(dmsgpty.MultiDialer)
+	if !ok {
+		t.Fatalf("buildDmsgptyDialer: got %T, want dmsgpty.MultiDialer", chain)
+	}
+	if len(chain) != 2 {
+		t.Fatalf("chain length = %d, want 2 (skywire + dmsg)", len(chain))
+	}
+	if _, isSkywire := chain[0].(skywireDialer); !isSkywire {
+		t.Errorf("chain[0] = %T, want skywireDialer (transport-aware must come first)", chain[0])
+	}
+	// chain[1] is the dmsg adapter (unexported type in dmsgpty);
+	// asserting on type name isn't useful — just confirm it's
+	// non-nil. The presence of 2 entries plus skywire-first is
+	// the meaningful contract.
+	if chain[1] == nil {
+		t.Error("chain[1] is nil; dmsg fallback missing")
+	}
+}
+
+// Compile-time confirmation the extractor matches dmsgpty.PKExtractor.
+// Catches signature drift if either side changes shape.
+var _ dmsgpty.PKExtractor = skywireConnPK


### PR DESCRIPTION
## Summary

Final piece of the StreamDialer refactor stack. \`cli dmsg pty start\` now rides the visor's existing transports first, falling back to dmsg only on miss — the operator-requested behavior that motivated the refactor.

Stack:
- **#2671** (merged) — StreamDialer interface, default dmsg adapter, NewHostWithDialer
- **#2672** (merged) — MultiDialer composition, visor init goes through the chain
- **#2673** (this PR) — skynet listener side + skywireDialer adapter + chain assembly

## Wiring

### \`pkg/dmsg/dmsgpty\`
- \`Host.ListenAndServeNet(ctx, lis, extractPK)\` — generic counterpart of \`ListenAndServe\`. Accept loop is transport-agnostic; the \`PKExtractor\` callback hands the remote PK to the existing whitelist gate. Existing \`ListenAndServe\` stays separate because its loop is bound to \`dmsg.ErrEntityClosed\` + \`dmsg.Stream\` methods that don't generalize cleanly.

### \`pkg/visor/init_dmsg_skywire.go\` (new)
- \`skywireDialer\` — \`StreamDialer\` adapter for \`appnet.SkywireNetworker.DialContextWithOptions\`. Resolves the networker lazily on every call so the pre-init window degrades gracefully (returns an error, MultiDialer falls through to dmsg).
- \`skywireConnPK\` — \`PKExtractor\` that pulls the remote PK from \`RemoteAddr().(appnet.Addr)\`. Rejects foreign conn types (defense-in-depth before the whitelist check).
- \`startSkywirePtyListener\` — mirrors the dmsg listener goroutine on the skynet path. Best-effort: missing networker / Listen failure surfaces a runtime warning but doesn't kill init.
- \`buildDmsgptyDialer\` — canonical \`MultiDialer{skywire, dmsg}\` chain. Single source of strategy ordering.

### \`pkg/visor/init_dmsg.go\`
- \`NewHostWithDialer(dmsgC, wl, buildDmsgptyDialer(dmsgC))\` — full skywire-first chain.
- Parallel \`startSkywirePtyListener\` call alongside the existing dmsg listener. Both share the same Whitelist + mux.

## Backward compat

dmsg-only deploys keep working unchanged because dmsg is always the LAST MultiDialer entry — every skywire failure falls through. Remote peers without a skynet listener stay reachable over dmsg. The skynet listener is opt-in by transport availability: when the networker isn't wired or Listen fails, dmsg-only behavior persists.

## Test plan
- [x] 4 new unit tests:
  - \`TestListenAndServeNet_RejectsConnWhenExtractorReturnsFalse\` — defense-in-depth before whitelist gate.
  - \`TestSkywireConnPK_ExtractsFromAppnetAddr\` — happy path.
  - \`TestSkywireConnPK_RejectsNonAppnetConn\` — foreign conn rejection.
  - \`TestBuildDmsgptyDialer_SkywireFirstDmsgFallback\` — pins the load-bearing chain ordering.
- [x] Compile-time \`PKExtractor\` assertion (\`var _ dmsgpty.PKExtractor = skywireConnPK\`) catches signature drift.
- [x] All existing \`./pkg/dmsg/dmsgpty/... ./pkg/visor/...\` tests pass.
- [x] \`make format && make lint\` clean (0 issues, vet clean).
- [ ] Smoke: visor restart → \`cli dmsg pty start <pk-with-route>\` rides skynet; \`cli dmsg pty start <pk-no-route>\` falls back to dmsg.

## Followups out of scope here
- Per-strategy timeout in MultiDialer (skywire dial that hangs blocks dmsg fallback until ctx fires) — easy to add as a wrapping dialer, deferred until empirical evidence the unbounded skywire dial is a problem.
- Operator-visible counter for which strategy succeeded — would mirror the per-layer counter ladder from #2664/#2665.

## Related
- #2671, #2672 — phases 1 + 2
- Operator request: \`skywire cli dmsg pty start\` should leverage the visor's transports, not just dmsg