### PR TITLE
fix(cxo/cxds): memoryCXDS.Del actually removes the map entry

### DIFF
--- a/pkg/cxo/data/cxds/memory.go
+++ b/pkg/cxo/data/cxds/memory.go
@@ -184,7 +184,25 @@ func (m *memoryCXDS) Inc(
 	return
 }
 
-// Del deletes value unconditionally
+// Del deletes value unconditionally.
+//
+// Pre-fix this function decremented the amountAll / volumeAll
+// bookkeeping counters but never executed `delete(m.kvs, key)`, so
+// every Del leaked the entry's value bytes into the map forever.
+// Latent since the file was first vendored; surfaced in production
+// once Publisher.runCleanupLoop started invoking RemoveObjects (which
+// drives Del for every rc=0 orphan after each publish) on long-running
+// services like dmsg-discovery that use the in-memory CXDS as the
+// publisher backing store. Heap pprof on a 16-hour-old dmsg-discovery
+// process showed 1 GB live, 67% in encoder.Serialize and 29% in
+// memoryCXDS.Set with no offsetting Del — the death spiral was 70% of
+// CPU in runtime.scanObject / findObject / sweep, scanning the bloated
+// kvs map every GC cycle.
+//
+// IterateDel on the same struct correctly deletes from the map (see
+// the `delete(m.kvs, k)` call below); only the one-arg Del was missing
+// it. Keep this comment in place so a future refactor that splits
+// bookkeeping out doesn't drop the map delete a second time.
 func (m *memoryCXDS) Del(key cipher.SHA256) (_ error) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
@@ -202,6 +220,8 @@ func (m *memoryCXDS) Del(key cipher.SHA256) (_ error) {
 
 	m.amountAll--
 	m.voluemAll -= len(mo.val)
+
+	delete(m.kvs, key)
 
 	return
 }

--- a/pkg/cxo/data/cxds/memory_del_test.go
+++ b/pkg/cxo/data/cxds/memory_del_test.go
@@ -1,0 +1,100 @@
+// Package cxds pkg/cxo/data/cxds/memory_del_test.go: pins the
+// memoryCXDS.Del invariant that Set+Del returns the underlying map
+// to its original size. Pre-fix Del decremented amountAll/volumeAll
+// but never executed `delete(m.kvs, key)`, leaking the value bytes
+// indefinitely. The leak only surfaced in long-running production
+// processes (dmsg-discovery, ~1 GB / 16 h on a host with active
+// Publisher cleanup) because the bookkeeping counters reported by
+// Amount/Volume *looked* right — only the actual heap was bleeding.
+// This test asserts both the counter contract and the in-memory map
+// contract so a regression that drops either line fails here.
+
+package cxds
+
+import (
+	"crypto/sha256"
+	"strconv"
+	"testing"
+)
+
+func TestMemoryCXDS_Del_FreesMapEntry(t *testing.T) {
+	ds := NewMemoryCXDS().(*memoryCXDS)
+	defer ds.Close() //nolint:errcheck,gosec
+
+	key := sha256.Sum256([]byte("a"))
+	val := []byte("hello")
+
+	if _, err := ds.Set(key, val, 1); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := len(ds.kvs); got != 1 {
+		t.Fatalf("post-Set: map len = %d, want 1", got)
+	}
+
+	if err := ds.Del(key); err != nil {
+		t.Fatalf("Del: %v", err)
+	}
+
+	// The contract the prod leak proved was missing: Del must
+	// actually drop the entry from the backing map. Pre-fix the
+	// counters would report 0 but the map still carried the bytes.
+	if got := len(ds.kvs); got != 0 {
+		t.Errorf("post-Del: map len = %d, want 0 (entry leak — bytes are still pinned in m.kvs)", got)
+	}
+	if all, used := ds.Amount(); all != 0 || used != 0 {
+		t.Errorf("post-Del: Amount = (%d, %d), want (0, 0)", all, used)
+	}
+	if all, used := ds.Volume(); all != 0 || used != 0 {
+		t.Errorf("post-Del: Volume = (%d, %d), want (0, 0)", all, used)
+	}
+}
+
+func TestMemoryCXDS_Del_RepeatedSetDel_DoesNotGrow(t *testing.T) {
+	// Reproduces the prod failure shape: Publisher.runCleanup nudges
+	// per publish, each one walks the orphan set and calls Del for
+	// every rc=0 hash. Pre-fix this loop would leak the bytes of
+	// every orphan into m.kvs while reporting Amount=0. After N
+	// publish cycles the heap holds N * payload bytes despite the
+	// counters claiming the store is empty — exactly the dmsg-disc
+	// pattern.
+	ds := NewMemoryCXDS().(*memoryCXDS)
+	defer ds.Close() //nolint:errcheck,gosec
+
+	const cycles = 1000
+	for i := 0; i < cycles; i++ {
+		key := sha256.Sum256([]byte("k-" + strconv.Itoa(i)))
+		val := []byte("payload-" + strconv.Itoa(i))
+		if _, err := ds.Set(key, val, 1); err != nil {
+			t.Fatalf("Set #%d: %v", i, err)
+		}
+		if err := ds.Del(key); err != nil {
+			t.Fatalf("Del #%d: %v", i, err)
+		}
+	}
+
+	if got := len(ds.kvs); got != 0 {
+		t.Errorf("after %d Set+Del cycles: map len = %d, want 0 (heap leak — every Del leaves the entry behind)", cycles, got)
+	}
+	if all, used := ds.Amount(); all != 0 || used != 0 {
+		t.Errorf("after %d cycles: Amount = (%d, %d), want (0, 0)", cycles, all, used)
+	}
+}
+
+func TestMemoryCXDS_Del_AbsentKey_NoOp(t *testing.T) {
+	// Del of a never-Set key must not mutate state or panic.
+	// Pre-fix this was already correct (early `return` on
+	// `ok == false`); pin it so the fix doesn't drop the guard.
+	ds := NewMemoryCXDS().(*memoryCXDS)
+	defer ds.Close() //nolint:errcheck,gosec
+
+	key := sha256.Sum256([]byte("never-set"))
+	if err := ds.Del(key); err != nil {
+		t.Fatalf("Del of absent key: unexpected error %v", err)
+	}
+	if got := len(ds.kvs); got != 0 {
+		t.Errorf("after Del of absent key: map len = %d, want 0", got)
+	}
+	if all, used := ds.Amount(); all != 0 || used != 0 {
+		t.Errorf("after Del of absent key: Amount = (%d, %d), want (0, 0)", all, used)
+	}
+}


### PR DESCRIPTION
## Summary

\`memoryCXDS.Del\` decremented the \`amountAll\` / \`volumeAll\` bookkeeping counters but never executed \`delete(m.kvs, key)\` — every \`Del\` leaked the entry's value bytes into \`m.kvs\` forever. Latent since the file was vendored; surfaced in production today once \`Publisher.runCleanupLoop\` started invoking \`RemoveObjects\` after every publish on services that use the in-memory CXDS as their publisher backing store.

## Production impact (observed)

\`dmsg-discovery\` on prod-Gamma, 16 h uptime, ~160 req/s sustained, with the always-on CXO clients-by-server publisher (#2456, #2494):

| Symptom | Value |
|---|---|
| RSS | ~1.0 GB |
| Heap \`inuse_space\` | 1034 MB |
| Top heap (67%) | \`cipher/encoder.Serialize\` |
| Next heap (29%) | \`memoryCXDS.Set\` (orphans never freed) |
| Top CPU (70%) | \`runtime.scanObject\` / \`findObject\` / \`sweep\` / \`tryDeferToSpanScan\` |
| Container CPU | 303% |
| Host load avg | 7.61 (8-core box) |

Goroutine count was healthy (118, no leak) — purely a heap leak driving a GC death spiral. Collateral damage on the same host: the systemd visor crashlooped 1700+ times in 16 h because every network deadline expired under CPU starvation.

## Root cause

\`Publisher.runCleanupLoop\` (recent, intentional) walks the orphan set after each publish and calls \`Del\` for every rc=0 key. \`RemoveObjects\` reports success and the counters \`Amount()\`/\`Volume()\` return zero — but the heap holds every byte. \`IterateDel\` on the same struct correctly executes \`delete(m.kvs, k)\` (see pre-existing line in the iterator body); only the one-arg \`Del\` was missing it.

The bug has been latent since the file was first vendored (PR #2277). It only became user-visible once **(a)** the cleanup loop started actively calling \`Del\`, and **(b)** \`dmsg-discovery\` adopted the in-memory CXDS as a publisher backing store (#2456, made always-on in #2494). Today's prod binary roll at 01:25Z was the first long-running production process combining all three at scale.

## Fix

One-line: \`delete(m.kvs, key)\` after the bookkeeping decrements, mirroring \`IterateDel\`'s ordering. The docstring captures the why so a future refactor that splits bookkeeping out doesn't drop it again.

## Tests

\`pkg/cxo/data/cxds/memory_del_test.go\`:

- \`Del_FreesMapEntry\` — single Set+Del returns the map to empty (counters AND \`len(m.kvs)\`). **This is the test that fails without the fix.**
- \`Del_RepeatedSetDel_DoesNotGrow\` — 1000 Set+Del cycles, asserts the map never grows past 0; reproduces the \`runCleanup\` → \`RemoveObjects\` → \`Del\` shape that caused the prod leak.
- \`Del_AbsentKey_NoOp\` — pre-fix early-return on missing key was already correct; pin it so a future refactor doesn't drop the guard.

Verified the failure-mode test fails on the pre-fix state:
\`\`\`
--- FAIL: TestMemoryCXDS_Del_FreesMapEntry (0.00s)
    memory_del_test.go:42: post-Del: map len = 1, want 0
            (entry leak — bytes are still pinned in m.kvs)
\`\`\`

## Test plan

- [x] \`go test -race -count=1 ./pkg/cxo/data/cxds/\` clean
- [x] \`go vet ./pkg/cxo/data/cxds/\` clean
- [x] \`gofmt -l\` clean
- [x] Confirmed test fails without the fix (\`git stash\` → run → \`git stash pop\`)
- [ ] Post-merge prod observation: dmsg-discovery heap should stay flat across a 1 h window instead of growing ~60 MB/h on the prior shape. Restart dmsg-discovery once after the rollout to clear the existing leaked GB.