### PR TITLE
fix(cxo): recover from missing seqs in RemoveRootObjects + periodic forced sweep

### DIFF
--- a/pkg/cxo/cxoutils/cxoutils.go
+++ b/pkg/cxo/cxoutils/cxoutils.go
@@ -37,7 +37,6 @@ func RemoveRootObjects(c *skyobject.Container, keepLast int) (err error) {
 			return err
 		}
 
-	HeadLoop:
 		for _, nonce := range heads {
 			var seq uint64
 			if seq, err = c.LastRootSeq(pk, nonce); err != nil {
@@ -51,29 +50,38 @@ func RemoveRootObjects(c *skyobject.Container, keepLast int) (err error) {
 
 			var goDown = seq - uint64(keepLast) //nolint:gosec // positive
 
+			// Walk every seq from goDown down to (and including) 0.
+			// ErrNotFound on an intermediate seq is expected (prior
+			// cleanups already deleted it) — keep going. Previously
+			// the loop did `continue HeadLoop` here, which abandoned
+			// every still-undeleted older seq AND the seq=0 sweep
+			// the instant we hit a gap. A partially-failed prior
+			// DelRoot (idx entry removed but rc-decrement walk
+			// aborted on a missing hash) leaves orphaned objects
+			// with rc>0 forever, since the next cleanup short-
+			// circuits before retrying. Two production-observed
+			// symptoms trace to that: TPD's CXDS bytes climbing to
+			// ~1 GB over days despite RemoveRootObjects firing on
+			// every publish, and the GC-saturation cascade that
+			// starves Node.mu and chokes every dmsg handshake.
 			for ; goDown > 0; goDown-- {
-
 				if err = c.DelRoot(pk, nonce, goDown); err != nil {
 					if err == data.ErrNotFound {
-						err = nil // clear error
-						continue HeadLoop
+						err = nil // already deleted; keep going
+						continue
 					}
-					return err // a failure (CXDS not found error?)
+					return err // a real failure (CXDS not found error?)
 				}
-
 			}
 
 			// seq = 0 (goDown == 0)
 			if err = c.DelRoot(pk, nonce, 0); err != nil {
 				if err == data.ErrNotFound {
 					err = nil // clear error
-					continue HeadLoop
+					continue
 				}
-
 				return err
 			}
-
-			// continue HeadLoop
 
 		} // head loop
 

--- a/pkg/cxo/cxoutils/cxoutils.go
+++ b/pkg/cxo/cxoutils/cxoutils.go
@@ -28,27 +28,26 @@ import (
 //
 // If a feed contains more then one head, then the method
 // keeps last n-th Root objects of every head.
-func RemoveRootObjects(c *skyobject.Container, keepLast int) (err error) {
+func RemoveRootObjects(c *skyobject.Container, keepLast int) error {
 
 	for _, pk := range c.Feeds() {
 
-		var heads []uint64
-		if heads, err = c.Heads(pk); err != nil {
+		heads, err := c.Heads(pk)
+		if err != nil {
 			return err
 		}
 
 		for _, nonce := range heads {
-			var seq uint64
-			if seq, err = c.LastRootSeq(pk, nonce); err != nil {
-				err = nil // clear
-				continue  // not a real error
+			seq, err := c.LastRootSeq(pk, nonce)
+			if err != nil {
+				continue // empty head — not a real error
 			}
 
 			if seq < uint64(keepLast) { //nolint:gosec
 				continue
 			}
 
-			var goDown = seq - uint64(keepLast) //nolint:gosec // positive
+			goDown := seq - uint64(keepLast) //nolint:gosec // positive
 
 			// Walk every seq from goDown down to (and including) 0.
 			// ErrNotFound on an intermediate seq is expected (prior
@@ -65,21 +64,13 @@ func RemoveRootObjects(c *skyobject.Container, keepLast int) (err error) {
 			// every publish, and the GC-saturation cascade that
 			// starves Node.mu and chokes every dmsg handshake.
 			for ; goDown > 0; goDown-- {
-				if err = c.DelRoot(pk, nonce, goDown); err != nil {
-					if err == data.ErrNotFound {
-						err = nil // already deleted; keep going
-						continue
-					}
+				if err := c.DelRoot(pk, nonce, goDown); err != nil && err != data.ErrNotFound {
 					return err // a real failure (CXDS not found error?)
 				}
 			}
 
 			// seq = 0 (goDown == 0)
-			if err = c.DelRoot(pk, nonce, 0); err != nil {
-				if err == data.ErrNotFound {
-					err = nil // clear error
-					continue
-				}
+			if err := c.DelRoot(pk, nonce, 0); err != nil && err != data.ErrNotFound {
 				return err
 			}
 
@@ -87,7 +78,7 @@ func RemoveRootObjects(c *skyobject.Container, keepLast int) (err error) {
 
 	} // feed loop
 
-	return err
+	return nil
 }
 
 // RemoveObjects deletes every CXDS object whose reference count has

--- a/pkg/cxo/cxoutils/cxoutils_test.go
+++ b/pkg/cxo/cxoutils/cxoutils_test.go
@@ -1,0 +1,126 @@
+// Package cxoutils — pkg/cxo/cxoutils/cxoutils_test.go:
+// regression coverage for the partial-walk recovery in
+// RemoveRootObjects.
+package cxoutils
+
+import (
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cxo/data"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+)
+
+type tinyValue struct {
+	N uint32
+}
+
+var tinyRegistry = registry.NewRegistry(func(r *registry.Reg) {
+	r.Register("test.tinyValue", tinyValue{})
+})
+
+func newTestContainer(t *testing.T) *skyobject.Container {
+	t.Helper()
+	cfg := skyobject.NewConfig()
+	cfg.InMemoryDB = true
+	c, err := skyobject.NewContainer(cfg)
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+	return c
+}
+
+// saveRoots publishes n successive Roots into (c, pk, nonce). The
+// payload changes each iteration so every Root references at least
+// one unique object; this gives the cleanup walk something to do
+// when the Root is later deleted.
+func saveRoots(t *testing.T, c *skyobject.Container, pk cipher.PubKey, sk cipher.SecKey, nonce uint64, n int) {
+	t.Helper()
+	if err := c.AddFeed(pk); err != nil {
+		t.Fatalf("AddFeed: %v", err)
+	}
+	if err := c.AddHead(pk, nonce); err != nil {
+		t.Fatalf("AddHead: %v", err)
+	}
+	up, err := c.Unpack(sk, tinyRegistry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	defer up.Close() //nolint:errcheck
+	r := &registry.Root{Pub: pk, Nonce: nonce}
+	for i := 0; i < n; i++ {
+		sch, serr := tinyRegistry.SchemaByName("test.tinyValue")
+		if serr != nil {
+			t.Fatalf("SchemaByName: %v", serr)
+		}
+		var dyn registry.Dynamic
+		if verr := dyn.SetValue(up, &tinyValue{N: uint32(i + 1)}); verr != nil { //nolint:gosec
+			t.Fatalf("SetValue #%d: %v", i, verr)
+		}
+		dyn.Schema = sch.Reference()
+		r.Refs = []registry.Dynamic{dyn}
+		if serr := c.Save(up, r); serr != nil {
+			t.Fatalf("Save #%d: %v", i, serr)
+		}
+	}
+}
+
+// TestRemoveRootObjectsSurvivesMissingMidSeq asserts that
+// RemoveRootObjects keeps deleting older Roots even when one of the
+// intermediate seqs is already gone. The pre-fix loop used
+// `continue HeadLoop` on ErrNotFound, which abandoned the entire
+// goDown walk on the first gap and left every older Root and its
+// orphaned objects behind forever. After the fix, the loop keeps
+// going through every seq below `seq - keepLast`, so we end with
+// exactly `keepLast` Roots regardless of holes.
+func TestRemoveRootObjectsSurvivesMissingMidSeq(t *testing.T) {
+	c := newTestContainer(t)
+	defer c.Close() //nolint:errcheck
+	pk, sk := cipher.GenerateKeyPair()
+	const nonce = uint64(42)
+	const total = 6
+
+	saveRoots(t, c, pk, sk, nonce, total)
+
+	// Sanity: the head's last seq should now be total-1 = 5.
+	last, err := c.LastRootSeq(pk, nonce)
+	if err != nil {
+		t.Fatalf("LastRootSeq before: %v", err)
+	}
+	if last != total-1 {
+		t.Fatalf("last seq: want %d got %d", total-1, last)
+	}
+
+	// Punch a hole at seq 2 to simulate a prior cleanup pass that
+	// got partway through (idx entry removed; rc-decrement walk
+	// aborted). Pre-fix RemoveRootObjects would hit ErrNotFound
+	// here, `continue HeadLoop`, and leave seqs 0/1/3/4 behind.
+	if err = c.DelRoot(pk, nonce, 2); err != nil {
+		t.Fatalf("seed DelRoot(2): %v", err)
+	}
+
+	// keepLast=1: must clear every seq except the last (5).
+	if err = RemoveRootObjects(c, 1); err != nil {
+		t.Fatalf("RemoveRootObjects: %v", err)
+	}
+
+	// Verify by probing — every older seq must come back ErrNotFound
+	// when we try to delete it again. (DelRoot is the only public way
+	// to ask "does seq exist?" without depending on internal API.)
+	for _, seq := range []uint64{0, 1, 3, 4} {
+		err = c.DelRoot(pk, nonce, seq)
+		if err != data.ErrNotFound {
+			t.Errorf("seq %d: expected ErrNotFound after sweep, got %v", seq, err)
+		}
+	}
+	// Seq 5 must survive — LastRootSeq still returns it.
+	last, err = c.LastRootSeq(pk, nonce)
+	if err != nil {
+		t.Fatalf("LastRootSeq after: %v", err)
+	}
+	if last != total-1 {
+		t.Fatalf("last seq after sweep: want %d got %d", total-1, last)
+	}
+}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -699,6 +699,18 @@ func (p *Publisher) Close() error {
 // the LRU cache.
 func (p *Publisher) runCleanupLoop() {
 	defer close(p.cleanupDone)
+	// Periodic forced sweep — catches orphans (rc==0 entries not in
+	// the LRU cache) that the per-publish nudge missed. Per-publish
+	// cleanup can leave residue when DelRoot's rc-decrement walk
+	// aborts mid-tree (a missing hash short-circuits the walk; every
+	// undecremented sibling stays at rc≥1). Those orphans are
+	// invisible to the rc==0 sweep, but a subsequent publish
+	// republishing the same hashes can drive rc to zero, at which
+	// point only an unconditional sweep collects them. The interval
+	// is intentionally long — the per-publish path remains the fast
+	// case; this is the backstop, not the steady-state sweeper.
+	t := time.NewTicker(cleanupForceInterval)
+	defer t.Stop()
 	for {
 		select {
 		case <-p.done:
@@ -707,9 +719,19 @@ func (p *Publisher) runCleanupLoop() {
 			return
 		case <-p.cleanupNudge:
 			p.runCleanup()
+		case <-t.C:
+			p.runCleanup()
 		}
 	}
 }
+
+// cleanupForceInterval is how often the publisher's cleanup loop
+// runs an unconditional sweep even without a publish nudge. 10 min
+// is well below the timescale on which production leaks were
+// observed (~hours-to-days) and well above any sane publish tick
+// (60s for TPD's publishers), so it never piles up on top of a
+// nudge-driven cleanup that just ran.
+const cleanupForceInterval = 10 * time.Minute
 
 func (p *Publisher) runCleanup() {
 	c := p.cxoNode.Container()


### PR DESCRIPTION
## Summary

Two related backstops for the CXDS retention bug that drives TPD's in-process heap to ~1 GB over days.

A pprof of `transport-discovery` taken today showed:

- **heap** — 89.94% of inuse_space (1.08 GB / 1.20 GB) in `cipher/encoder.Serialize`, all called from `registry.(*Refs).AppendValues` via `treestore.encodeNode → publisher.Put`.
- **cpu** — 67% in `runtime.gcBgMarkWorker / scanObjectsSmall / spanClass.sizeclass`; only ~9% in actual HTTP serve work.
- **goroutines** — 2,142 total. 1,341 blocked on `(*Node).onNewConn` mutex lockSlow, 213 in `nodeFeeds.receivedRoot`, 96 in `broadcastRoot`, 116 in `nodeHead.handle`. GC saturation starves Node.mu, which queues every dmsg handshake.

Per-publish cleanup is wired (`runCleanupLoop` fires on every `cleanupNudge`) and in-memory CXDS `IterateDel` does actually `delete(kvs, k)` when rc == 0. So somehow rc isn't reaching zero on objects that should be orphaned.

### (1) `cxoutils.RemoveRootObjects` — survive missing intermediate seqs

`DelRoot` is non-atomic: `delRootLock` removes the Root from IdxDB, then `delRootRelatedValues` walks the tree decrementing rc on every referenced object. If the walk aborts (e.g. `getNoCache` returns `ErrNotFound` on a hash that's been swept) the idx entry is gone but rc stays >0 on every unvisited sibling.

The old `RemoveRootObjects` loop did `continue HeadLoop` when `DelRoot` returned `ErrNotFound` on an intermediate seq, which abandoned the entire remaining `goDown` walk AND the seq=0 sweep — every undeleted older seq stayed behind forever, with their orphaned objects unreachable to the `rc==0` sweep in `RemoveObjects`. Changed to `continue` (inner): a gap no longer poisons the rest of the walk.

Regression test (`cxoutils_test.go`) seeds a hole at seq 2 of a 6-Root head and asserts seqs 0/1/3/4 all clear when `keepLast=1`. **Confirmed to fail against the pre-fix code** (`seq 0: expected ErrNotFound after sweep, got <nil>` × 2 seqs left behind).

### (2) `treestore.Publisher.runCleanupLoop` — periodic forced sweep

Added a 10-minute ticker that runs the cleanup unconditionally on top of the per-publish nudge. Catches the case where rc reaches zero on a later publish cycle without a matching nudge — the `rc==0` sweep then collects them. Long interval (well above any sane 60s publish tick, well below the hours-to-days timescale at which the leak was observed) keeps the fast path nudge-driven.

### What this does NOT fix

- The underlying non-atomicity in `DelRoot` (idx removal vs rc-decrement walk).
- `unpack.go:241`'s explicit `// leave the CXDS broken if an error occurred` path in `Save`.
- The receive-side pressure (213 goroutines backed up in `nodeFeeds.rrq`) when remote visors push Roots faster than the dispatcher consumes.

Those need a controlled reproducer and will land separately. The two changes here are pure backstops — they bound how much per-publish residue can survive in a long-running publisher's CXDS.

## Test plan

- [x] `go test ./pkg/cxo/cxoutils/ -count=1` passes on fix, fails on pre-fix (verified)
- [x] `go test ./pkg/cxo/treestore/ -count=1` passes
- [x] `go test ./pkg/cxo/skyobject/ -count=1` passes
- [x] `go build ./...` passes
- [ ] Operator deploys to a TPD with the existing leak signature, monitors heap over 24-48h