### PR TITLE
feat(cli/log): subcommands for survey-whitelist endpoints

### DIFF
--- a/cmd/skywire-cli/commands/log/dmsghttp_client.go
+++ b/cmd/skywire-cli/commands/log/dmsghttp_client.go
@@ -1,0 +1,177 @@
+// Package clilog cmd/skywire-cli/commands/log/dmsghttp_client.go
+//
+// Shared dmsg-bootstrap + http-client helper for the per-visor
+// survey-whitelist endpoints. Pre-fix, every subcommand that
+// reached out over dmsghttp had to re-implement the SK resolution,
+// dmsg bootstrap, and transport-pool wiring inline. This file
+// centralizes that boilerplate so `cli log info|file|pprof|stats|
+// uptime|reward` share one resolution policy + one dmsg client.
+//
+// Endpoints reached this way are all gated by the remote visor's
+// survey_whitelist (see pkg/visor/logserver/api.go:131-208 — the
+// `authRoute` group). The CLI's local PK is what gets allowlisted;
+// no per-request signing, so SK loading just selects which PK we
+// authenticate AS.
+package clilog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// resolveSurveySK selects the SK used as the CLI's identity for
+// survey-whitelist-gated requests. Resolution order (first hit wins):
+//
+//  1. --sk flag (the existing `sk` cobra var, when non-zero)
+//  2. DMSGCURL_SK env (same env the bulk-collection path honors)
+//  3. survey_client_sk from /opt/skywire/skywire.json (if present)
+//  4. fresh ephemeral keypair — useful for one-off calls against
+//     a wide-open whitelist or for self-targeted requests where the
+//     remote's whitelist includes ephemeral access.
+//
+// Returns the selected SK and a label naming the source — the label
+// is logged at debug so an operator can verify which precedence
+// layer fired without guessing.
+func resolveSurveySK() (cipher.SecKey, string) {
+	var zero cipher.SecKey
+	if sk != zero {
+		return sk, "--sk flag"
+	}
+	if env := os.Getenv("DMSGCURL_SK"); env != "" {
+		var k cipher.SecKey
+		if err := k.Set(env); err == nil {
+			return k, "DMSGCURL_SK env"
+		}
+	}
+	// /opt/skywire/skywire.json is the standard install location; the
+	// same file the visor reads. Reading FAILURES are silent here —
+	// missing file or missing field both fall through to ephemeral.
+	if conf, err := visorconfig.ReadFile(visorconfig.SkywireConfig()); err == nil && conf != nil && conf.SurveyClientSK != "" {
+		var k cipher.SecKey
+		if err := k.Set(conf.SurveyClientSK); err == nil {
+			return k, "skywire.json survey_client_sk"
+		}
+	}
+	_, fresh := cipher.GenerateKeyPair()
+	return fresh, "ephemeral"
+}
+
+// dmsgHTTPClient bootstraps a dmsg client off the resolved SK and
+// returns a pooled http.Client whose transport rides dmsg streams.
+// The returned cleanup func tears down the dmsg client; callers MUST
+// defer it.
+//
+// timeout caps per-request work; pprof CPU profiles can be 30s+ so
+// callers needing slow endpoints pass a longer value (or zero for
+// unbounded — http.Client uses no per-request timeout in that case,
+// only ctx cancellation).
+func dmsgHTTPClient(ctx context.Context, timeout time.Duration) (*http.Client, func(), error) {
+	log := logging.MustGetLogger("log-cli")
+	resolvedSK, source := resolveSurveySK()
+	pk, err := resolvedSK.PubKey()
+	if err != nil {
+		// SecKey.Set already validated the SK shape; PubKey derivation
+		// is deterministic. Treat as ephemeral fallback rather than
+		// fatal — the caller's request will then fail with the
+		// remote's whitelist signal, which is more informative than
+		// dying here.
+		pk, resolvedSK = cipher.GenerateKeyPair()
+		source = "ephemeral (PK derivation failed)"
+	}
+	log.WithField("source", source).WithField("local_pk", pk.String()).Debug("Resolved survey-whitelist identity for CLI request")
+
+	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, resolvedSK, dmsg.Prod.DmsgServers, dmsgDiscURL, "")
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("dmsg bootstrap: %w", err)
+	}
+
+	hc := &http.Client{
+		Transport: dmsghttp.MakeHTTPTransport(ctx, bootstrap.Client),
+		Timeout:   timeout,
+	}
+	cleanup := func() {
+		hc.CloseIdleConnections()
+		bootstrap.Close()
+	}
+	return hc, cleanup, nil
+}
+
+// fetchSurveyEndpoint GETs dmsg://<pk>:80/<path> and writes the body
+// to w. Single helper used by every subcommand that pulls a binary
+// or text response. 200 OK is required; non-200 surfaces as an error
+// with the status code so callers can distinguish whitelist denial
+// (401) from missing-file (404) from server bug (500).
+//
+// Streams (io.Copy) rather than buffering — pprof profiles + visor
+// logs can be megabytes.
+func fetchSurveyEndpoint(ctx context.Context, hc *http.Client, pk cipher.PubKey, path string, w io.Writer) error {
+	target := fmt.Sprintf("dmsg://%s:80%s", pk, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	resp, err := hc.Do(req) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("dmsghttp dial: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("dmsg://%s%s returned status %d (401 = not in survey_whitelist; 404 = endpoint missing on this visor)", pk, path, resp.StatusCode)
+	}
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return fmt.Errorf("copy body: %w", err)
+	}
+	return nil
+}
+
+// fetchSurveyJSON is a typed sibling of fetchSurveyEndpoint for
+// endpoints that return JSON. Decodes into v; v should be a pointer
+// to a struct or map. Same error surface as the byte-stream helper.
+func fetchSurveyJSON(ctx context.Context, hc *http.Client, pk cipher.PubKey, path string, v any) error {
+	target := fmt.Sprintf("dmsg://%s:80%s", pk, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	resp, err := hc.Do(req) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("dmsghttp dial: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("dmsg://%s%s returned status %d", pk, path, resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		return fmt.Errorf("decode JSON: %w", err)
+	}
+	return nil
+}
+
+// parseTargetPK pulls the first positional arg as a public key, with
+// a uniform error message across subcommands. Centralized so the
+// hint text on bad input stays consistent.
+func parseTargetPK(arg string) (cipher.PubKey, error) {
+	var pk cipher.PubKey
+	if err := pk.Set(arg); err != nil {
+		return cipher.PubKey{}, fmt.Errorf("invalid visor PK %q: %w", arg, err)
+	}
+	return pk, nil
+}
+
+// _ keeps deployment imported even if a future trim of the helper
+// happens to drop the only deployment.Prod reference; the bootstrap
+// path needs it.
+var _ = deployment.Prod

--- a/cmd/skywire-cli/commands/log/single_node_info.go
+++ b/cmd/skywire-cli/commands/log/single_node_info.go
@@ -1,0 +1,61 @@
+// Package clilog cmd/skywire-cli/commands/log/single_node_info.go
+//
+// `cli log info <pk>` — fetch a single visor's /node-info JSON over
+// dmsghttp. Distinct from the bulk-collection mode at the `cli log`
+// root (no subcommand), which iterates the entire uptime tracker
+// and writes per-visor folders. This one-shot mode is for ad-hoc
+// inspection: target one visor, dump the survey to stdout.
+package clilog
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func init() {
+	RootCmd.AddCommand(singleInfoCmd)
+}
+
+var singleInfoCmd = &cobra.Command{
+	Use:   "info <pk>",
+	Short: "Fetch a single visor's /node-info survey",
+	Long: `Fetch /node-info from one visor over dmsghttp. JSON written to stdout.
+
+Gated by the remote visor's survey_whitelist — the CLI's local PK
+(derived from --sk / DMSGCURL_SK / survey_client_sk / ephemeral)
+must be allowlisted. Single-target counterpart of bulk ` + "`cli log`" + `
+collection.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log := logging.MustGetLogger("log-cli")
+		pk, err := parseTargetPK(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		hc, cleanup, err := dmsgHTTPClient(ctx, 30*time.Second)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+
+		var survey map[string]any
+		if err := fetchSurveyJSON(ctx, hc, pk, "/node-info", &survey); err != nil {
+			log.Fatal(err)
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(survey); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/log/single_pprof.go
+++ b/cmd/skywire-cli/commands/log/single_pprof.go
@@ -1,0 +1,109 @@
+// Package clilog cmd/skywire-cli/commands/log/single_pprof.go
+//
+// `cli log pprof <pk> <profile>` — fetch one of the remote visor's
+// pprof profiles over dmsghttp and emit the raw bytes to stdout.
+// Direct equivalent of `go tool pprof http://<host>/debug/pprof/<profile>`
+// but routed through the survey_whitelist gate.
+package clilog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// pprofProfiles maps friendly subcommand-arg names to the pprof
+// path segments served by the visor's logserver
+// (pkg/visor/logserver/api.go:193-199). Friendly "cpu" maps to
+// "profile" for the same reason `go tool pprof` accepts both.
+var pprofProfiles = map[string]string{
+	"cpu":          "profile",
+	"profile":      "profile",
+	"heap":         "heap",
+	"goroutine":    "goroutine",
+	"threadcreate": "threadcreate",
+	"block":        "block",
+	"mutex":        "mutex",
+	"allocs":       "allocs",
+	"trace":        "trace",
+	"cmdline":      "cmdline",
+	"symbol":       "symbol",
+}
+
+// pprofProfileNames is the sorted list used in the usage hint. Kept
+// in init() to avoid drift from pprofProfiles.
+var pprofProfileNames []string
+
+var pprofSeconds int
+
+func init() {
+	for k := range pprofProfiles {
+		pprofProfileNames = append(pprofProfileNames, k)
+	}
+	singlePprofCmd.Flags().IntVarP(&pprofSeconds, "seconds", "n", 0, "for cpu/profile/trace: duration in seconds (visor default is 30)")
+	RootCmd.AddCommand(singlePprofCmd)
+}
+
+var singlePprofCmd = &cobra.Command{
+	Use:   "pprof <pk> <profile>",
+	Short: "Fetch a runtime pprof profile from a remote visor",
+	Long: `Fetch /debug/pprof/<profile> from one visor over dmsghttp. Binary
+profile bytes stream to stdout — redirect to a file and feed to
+` + "`go tool pprof`" + `:
+
+  skywire cli log pprof <pk> heap > heap.pprof
+  go tool pprof heap.pprof
+
+Available profiles: cpu (alias for profile), profile, heap, goroutine,
+threadcreate, block, mutex, allocs, trace, cmdline, symbol.
+
+For sampling profiles (cpu / profile / trace), --seconds controls
+the sample duration; the visor caps this at its pprof default (30s).
+Whitelisted via the remote visor's survey_whitelist.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		log := logging.MustGetLogger("log-cli")
+		pk, err := parseTargetPK(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		profile := args[1]
+		realProfile, ok := pprofProfiles[profile]
+		if !ok {
+			log.Fatalf("unknown profile %q (try: %v)", profile, pprofProfileNames)
+		}
+
+		path := "/debug/pprof/" + realProfile
+		// CPU/trace endpoints accept ?seconds=N; non-sampling profiles
+		// ignore it but it's safe to include unconditionally.
+		if pprofSeconds > 0 {
+			path = fmt.Sprintf("%s?seconds=%d", path, pprofSeconds)
+		}
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		// Sampling profiles run for `seconds` server-side; an
+		// http.Client per-request Timeout must outlive that. Pad
+		// generously — 30s default + 60s buffer covers typical use.
+		timeout := time.Duration(pprofSeconds+60) * time.Second
+		if pprofSeconds == 0 {
+			timeout = 90 * time.Second
+		}
+		hc, cleanup, err := dmsgHTTPClient(ctx, timeout)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+
+		if err := fetchSurveyEndpoint(ctx, hc, pk, path, os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/log/single_reward.go
+++ b/cmd/skywire-cli/commands/log/single_reward.go
@@ -1,0 +1,51 @@
+// Package clilog cmd/skywire-cli/commands/log/single_reward.go
+//
+// `cli log reward <pk>` — fetch the remote visor's /reward.txt
+// file over dmsghttp. Only exists when the operator has set a
+// reward address on the visor.
+package clilog
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func init() {
+	RootCmd.AddCommand(singleRewardCmd)
+}
+
+var singleRewardCmd = &cobra.Command{
+	Use:   "reward <pk>",
+	Short: "Fetch /reward.txt from a remote visor",
+	Long: `Fetch /reward.txt from one visor over dmsghttp. The file only
+exists when the operator has set a reward address; absent files
+return 404.
+
+Gated by the remote visor's survey_whitelist.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log := logging.MustGetLogger("log-cli")
+		pk, err := parseTargetPK(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		hc, cleanup, err := dmsgHTTPClient(ctx, 30*time.Second)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+
+		if err := fetchSurveyEndpoint(ctx, hc, pk, "/reward.txt", os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/log/single_stats.go
+++ b/cmd/skywire-cli/commands/log/single_stats.go
@@ -1,0 +1,63 @@
+// Package clilog cmd/skywire-cli/commands/log/single_stats.go
+//
+// `cli log stats <pk> [path]` — fetch the remote visor's
+// /stats[/path] endpoint over dmsghttp. Stats is a typed
+// telemetry store; consult the visor's logserver for the
+// available paths (the bare `stats` call returns the index).
+package clilog
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func init() {
+	RootCmd.AddCommand(singleStatsCmd)
+}
+
+var singleStatsCmd = &cobra.Command{
+	Use:   "stats <pk> [path]",
+	Short: "Fetch /stats[/path] from a remote visor",
+	Long: `Fetch /stats from one visor over dmsghttp. Optional sub-path is
+appended verbatim — e.g. ` + "`cli log stats <pk> uptime/breakdown`" + `
+fetches /stats/uptime/breakdown. Response (JSON or 503 when the
+visor hasn't wired its stats reader) prints to stdout.
+
+Gated by the remote visor's survey_whitelist.`,
+	Args: cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		log := logging.MustGetLogger("log-cli")
+		pk, err := parseTargetPK(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		path := "/stats"
+		if len(args) == 2 {
+			// args[1] is appended verbatim; operators can include
+			// query strings (?since=...) or sub-paths (/uptime/...).
+			if args[1][0] != '/' {
+				path += "/"
+			}
+			path += args[1]
+		}
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		hc, cleanup, err := dmsgHTTPClient(ctx, 30*time.Second)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+
+		if err := fetchSurveyEndpoint(ctx, hc, pk, path, os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/log/single_uptime.go
+++ b/cmd/skywire-cli/commands/log/single_uptime.go
@@ -1,0 +1,59 @@
+// Package clilog cmd/skywire-cli/commands/log/single_uptime.go
+//
+// `cli log uptime <pk> [path]` — fetch the remote visor's
+// /uptime[/path] endpoint over dmsghttp. Like /stats this is a
+// typed telemetry store; bare `uptime` returns the index.
+package clilog
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func init() {
+	RootCmd.AddCommand(singleUptimeCmd)
+}
+
+var singleUptimeCmd = &cobra.Command{
+	Use:   "uptime <pk> [path]",
+	Short: "Fetch /uptime[/path] from a remote visor",
+	Long: `Fetch /uptime from one visor over dmsghttp. Optional sub-path is
+appended verbatim. Response (JSON or 503 when the visor hasn't
+wired its uptime recorder) prints to stdout.
+
+Gated by the remote visor's survey_whitelist.`,
+	Args: cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		log := logging.MustGetLogger("log-cli")
+		pk, err := parseTargetPK(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		path := "/uptime"
+		if len(args) == 2 {
+			if args[1][0] != '/' {
+				path += "/"
+			}
+			path += args[1]
+		}
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		hc, cleanup, err := dmsgHTTPClient(ctx, 30*time.Second)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+
+		if err := fetchSurveyEndpoint(ctx, hc, pk, path, os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/log/single_visor_log.go
+++ b/cmd/skywire-cli/commands/log/single_visor_log.go
@@ -1,0 +1,53 @@
+// Package clilog cmd/skywire-cli/commands/log/single_visor_log.go
+//
+// `cli log file <pk>` — stream a single visor's /visor.log over
+// dmsghttp. Requires the remote visor to have been started with
+// -s/--save-log; without that flag, the endpoint returns 404 and
+// this command surfaces a clear hint.
+package clilog
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func init() {
+	RootCmd.AddCommand(singleFileCmd)
+}
+
+var singleFileCmd = &cobra.Command{
+	Use:   "file <pk>",
+	Short: "Stream a single visor's /visor.log to stdout",
+	Long: `Stream /visor.log from one visor over dmsghttp. Visor must have been
+started with -s/--save-log; without that flag the file doesn't exist
+and the endpoint returns 404.
+
+Gated by the remote visor's survey_whitelist.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		log := logging.MustGetLogger("log-cli")
+		pk, err := parseTargetPK(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+		defer cancel()
+
+		// No per-request timeout — log files can be large and slow.
+		// ctx cancellation (^C) still terminates the stream.
+		hc, cleanup, err := dmsgHTTPClient(ctx, 0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer cleanup()
+
+		if err := fetchSurveyEndpoint(ctx, hc, pk, "/visor.log", os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -60,10 +60,20 @@ type V1 struct {
 	PersistentTransports []transport.PersistentTransports `json:"persistent_transports"`
 	ConfService          string                           `json:"conf_service,omitempty"`      // HTTP URL for config bootstrap service
 	ConfServiceDmsg      string                           `json:"conf_service_dmsg,omitempty"` // DMSG URL for config bootstrap service
-	RewardAddress        string                           `json:"reward_address,omitempty"`
-	RewardSystem         string                           `json:"reward_system,omitempty"`
-	RewardSystemDmsg     string                           `json:"reward_system_dmsg,omitempty"`
-	MemoryLimit          string                           `json:"memory_limit,omitempty"` // Go memory limit (e.g., "256MiB", "auto" for 60% of available RAM)
+	// SurveyClientSK is the CLI-side identity used by
+	// `skywire cli log <subcommand>` to authenticate against remote
+	// visors' survey_whitelist gates (visor logserver port 80 over
+	// dmsg). When non-empty, parses as a hex SecKey; the derived PK
+	// is the identity the remote checks against its survey_whitelist.
+	// Empty (default) falls through to --sk flag → DMSGCURL_SK env →
+	// ephemeral random keypair. Server-side: never read; the visor
+	// ignores this field entirely.
+	SurveyClientSK string `json:"survey_client_sk,omitempty"`
+
+	RewardAddress    string `json:"reward_address,omitempty"`
+	RewardSystem     string `json:"reward_system,omitempty"`
+	RewardSystemDmsg string `json:"reward_system_dmsg,omitempty"`
+	MemoryLimit      string `json:"memory_limit,omitempty"` // Go memory limit (e.g., "256MiB", "auto" for 60% of available RAM)
 
 	Hypervisor *HypervisorConfig `json:"hypervisor,omitempty"`
 }


### PR DESCRIPTION
## Summary

Operator-requested. Today the bulk \`cli log\` collection is the only caller of the visor's survey_whitelist-gated endpoints; ad-hoc single-target access requires manual \`dmsg-curl\`. Add cobra subcommands so the same survey_whitelist SK works for one-shot inspection.

## New subcommands

\`\`\`
skywire cli log info    <pk>           # GET /node-info  (survey JSON)
skywire cli log file    <pk>           # GET /visor.log  (stream to stdout)
skywire cli log pprof   <pk> <prof>    # GET /debug/pprof/<prof>  (binary)
skywire cli log stats   <pk> [path]    # GET /stats[/path]
skywire cli log uptime  <pk> [path]    # GET /uptime[/path]
skywire cli log reward  <pk>           # GET /reward.txt
\`\`\`

All gated by the remote visor's \`survey_whitelist\` (the same allowlist \`cli log\` bulk-collection already uses). Output streams to stdout — operators redirect to files or pipe to \`go tool pprof\`:

\`\`\`bash
skywire cli log pprof <pk> heap > heap.pprof
go tool pprof heap.pprof

skywire cli log file <pk> | grep ERROR

skywire cli log info <pk> | jq '.skywire_version'
\`\`\`

The pprof subcommand handles \`?seconds=N\` for sampling profiles (cpu / profile / trace) and auto-adjusts the http.Client timeout to outlive server-side sample collection.

## Identity resolution

CLI's PK is what the remote checks against its survey_whitelist. Resolution order (first hit wins):

1. \`--sk\` flag (existing)
2. \`DMSGCURL_SK\` env (existing)
3. **NEW**: \`survey_client_sk\` field in \`/opt/skywire/skywire.json\` — CLI-only; visor ignores this field server-side
4. ephemeral random keypair (existing fallback)

Field added at \`pkg/visor/visorconfig/v1.go\` as \`SurveyClientSK string\` with \`omitempty\`. Empty value triggers the existing fallback chain — operators who don't set it see no behavior change.

## Backward compat

No changes to existing bulk-collection behavior: \`cli log\` with no subcommand still iterates the uptime tracker and writes per-visor folders. The new subcommands are additive.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/skywire-cli/... ./pkg/visor/visorconfig/...\` passes
- [x] \`make format && make lint\` 0 issues + vet clean
- [x] \`skywire cli log --help\` shows the new subcommands grouped alongside existing \`tp\` / \`st\`
- [ ] Smoke: \`skywire cli log info <known-pk>\` returns JSON when caller's PK is on the remote's survey_whitelist; returns clear 401 hint otherwise

## Related
- Operator request: surface visor.log + pprof under \`cli log\` with the existing survey_whitelist SK