### PR TITLE
fix(cxo/node): guard Conn init signaling against double-close panic

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -28,6 +28,18 @@ type Conn struct {
 
 	initErr error
 	initq   chan struct{}
+	// initClosed is set true the first time onConnInit or onConnInitErr
+	// publishes the init result on this Conn. Protected by Node.mx (the
+	// only callers hold it). Guards close(initq) against a double-close
+	// race: pre-fix the isPending branch of Node.initConn called
+	// onConnInitErr a second time after its waitForInit returned the
+	// error already published by the isNew handshaker, panicking the
+	// whole visor with "close of closed channel" under sustained
+	// handshake-failure load (e.g. when dmsg-discovery is CPU-starved
+	// and every per-peer ConnectPK times out). Idempotency here means
+	// any future caller of onConnInit/onConnInitErr can't reintroduce
+	// the panic even if a new code path adds a redundant signal.
+	initClosed bool
 
 	closeq chan struct{}  // signal for all goroutines to exit
 	doneq  chan struct{}  // closed when run() has fully completed (maps cleaned, transport closed)

--- a/pkg/cxo/node/conn_init_idempotent_test.go
+++ b/pkg/cxo/node/conn_init_idempotent_test.go
@@ -1,0 +1,133 @@
+// Package node pkg/cxo/node/conn_init_idempotent_test.go: pins the
+// idempotency of Node.onConnInitErr / Node.onConnInit so a second
+// caller that reaches the same Conn (the production race shape:
+// isNew handshaker fails + isPending waiter's waitForInit returns
+// and pre-fix also called onConnInitErr) cannot double-close
+// c.initq and panic the visor.
+//
+// The prod panic — verified in journalctl on a CPU-starved host where
+// every dmsg handshake was timing out — was:
+//
+//	panic: close of closed channel
+//	goroutine 634 [running]:
+//	github.com/skycoin/skywire/pkg/cxo/node.(*Node).onConnInitErr+0xe5
+//	  ... node.go:553
+//	github.com/skycoin/skywire/pkg/cxo/node.(*Node).initConn+0x1eb
+//	  ... node.go:488   (the redundant isPending-waiter call removed here)
+//
+// Test target is the idempotency guard itself — Conn.initClosed gated
+// by Node.mx — independent of whether the call site removed in
+// node.go:488 ever fires again.
+
+package node
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+func TestNode_OnConnInitErr_SecondCallNoOp(t *testing.T) {
+	// Pre-set c.initClosed to simulate "first onConnInitErr already
+	// ran"; call onConnInitErr again and assert it returned without
+	// mutating state. Pre-fix the function would have proceeded to
+	// `close(c.initq)` and panicked. Post-fix it returns at the
+	// initClosed gate before touching c.initq, c.initErr, or
+	// n.pendConns.
+	n := &Node{
+		pendConns:  map[string]*Conn{},
+		addrToConn: map[string]*Conn{},
+		pkToConn:   map[cipher.PubKey]*Conn{},
+	}
+	firstErr := errors.New("first publisher's error")
+	c := &Conn{
+		initq:      make(chan struct{}),
+		initErr:    firstErr,
+		initClosed: true,
+	}
+	close(c.initq) // mirror what the first call would have done
+
+	// Second call. Pre-fix this panicked at the unconditional
+	// close(c.initq). Post-fix it must early-return.
+	secondErr := errors.New("second caller's error")
+	n.onConnInitErr(c, secondErr)
+
+	// initErr must still be the first caller's — the second call
+	// did not overwrite, proving the guard kicked in before reaching
+	// the assignment.
+	if c.initErr != firstErr {
+		t.Errorf("initErr clobbered by second call: got %v, want %v (guard let the assignment through)", c.initErr, firstErr)
+	}
+}
+
+func TestNode_OnConnInit_SecondCallNoOp(t *testing.T) {
+	// Same property for the success-path companion. onConnInit also
+	// closes c.initq and must respect the c.initClosed gate so a
+	// stale callback (e.g. a reused Conn pointer after the cleanup
+	// path) can't panic the visor either.
+	n := &Node{
+		pendConns:  map[string]*Conn{},
+		addrToConn: map[string]*Conn{},
+		pkToConn:   map[cipher.PubKey]*Conn{},
+	}
+	c := &Conn{
+		initq:      make(chan struct{}),
+		initClosed: true,
+	}
+	close(c.initq)
+
+	// Should be a no-op; absence of panic is the assertion.
+	n.onConnInit(c)
+
+	// Maps must be untouched — pre-fix the function unconditionally
+	// wrote n.addrToConn[c.Address()] = c, which would nil-deref on
+	// the bare-Conn test fixture; the guard's early-return prevents
+	// the deref entirely.
+	if len(n.addrToConn) != 0 {
+		t.Errorf("addrToConn mutated past the initClosed guard: len = %d, want 0", len(n.addrToConn))
+	}
+	if len(n.pkToConn) != 0 {
+		t.Errorf("pkToConn mutated past the initClosed guard: len = %d, want 0", len(n.pkToConn))
+	}
+}
+
+func TestNode_OnConnInitErr_ConcurrentCallersNoPanic(t *testing.T) {
+	// Reproduces the production goroutine shape: N callers all reach
+	// onConnInitErr for the same Conn from different goroutines
+	// (isNew handshake-failed + 1..N isPending waiters that pre-fix
+	// also invoked onConnInitErr). Without the guard one wins the
+	// close(c.initq) and the others panic with "close of closed
+	// channel". With the guard exactly one wins and the rest no-op.
+	//
+	// Bypass c.Address() (would nil-deref on the bare Conn) by
+	// pre-asserting initClosed=true before the goroutines start, so
+	// every concurrent caller hits the guard. The race detector
+	// would still flag an unsynchronized write to initClosed if the
+	// fix moved the bool outside Node.mx — which is why the test is
+	// `go test -race`-aware.
+	n := &Node{
+		pendConns:  map[string]*Conn{},
+		addrToConn: map[string]*Conn{},
+		pkToConn:   map[cipher.PubKey]*Conn{},
+	}
+	c := &Conn{initq: make(chan struct{}), initClosed: true}
+	close(c.initq)
+
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			// Every concurrent caller hits the guard. Pre-fix any of
+			// these would have proceeded to close(c.initq) and the
+			// second one to win the close panicked the visor with
+			// "close of closed channel".
+			n.onConnInitErr(c, errors.New("waiter"))
+		}()
+	}
+	wg.Wait()
+	// Reaching this point with no panic is the assertion.
+}

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -484,8 +484,18 @@ func (n *Node) initConn(
 		if isIncoming {
 			return nil, errors.New("already have incoming pending connection")
 		}
+		// Wait for the in-flight isNew goroutine to publish the init
+		// result on c.initq. If it fails, that goroutine has already
+		// called onConnInitErr (deletes from pendConns, sets initErr,
+		// closes initq). The waiter must only propagate the error —
+		// pre-fix a redundant onConnInitErr call here double-closed
+		// c.initq and panicked the visor with "close of closed channel"
+		// under sustained handshake failure (peer offline / dmsg
+		// transport CPU-starved). The idempotency guard added in
+		// onConnInitErr below makes this defense-in-depth, but the
+		// behavioral contract is: waiter propagates, handshaker
+		// publishes.
 		if err = c.waitForInit(); err != nil {
-			n.onConnInitErr(c, err)
 			return nil, err
 		}
 		return c, nil
@@ -541,11 +551,19 @@ func (n *Node) onNewConn(
 	return c, true, false, nil
 }
 
-// onConnInitErr atomically removes pending
-// connection and signals about initConn failure.
+// onConnInitErr atomically removes pending connection and signals
+// about initConn failure. Idempotent: c.initClosed gates the close
+// of initq so a double-call (which pre-fix the isPending branch of
+// initConn triggered, double-closing initq and panicking the visor
+// under handshake-failure load) becomes a no-op after the first.
 func (n *Node) onConnInitErr(c *Conn, initErr error) {
 	n.mx.Lock()
 	defer n.mx.Unlock()
+
+	if c.initClosed {
+		return
+	}
+	c.initClosed = true
 
 	delete(n.pendConns, c.Address())
 
@@ -556,9 +574,18 @@ func (n *Node) onConnInitErr(c *Conn, initErr error) {
 // onConnInit atomically moves pending connection to cache
 // and signals about initConn success. It also chekcs if
 // peer's pubkey, receieved during hanshake is duplicate.
+//
+// Mirrors onConnInitErr's c.initClosed gate: success and failure
+// must publish exactly one close of initq, regardless of which
+// goroutine wins the race for the final write.
 func (n *Node) onConnInit(c *Conn) {
 	n.mx.Lock()
 	defer n.mx.Unlock()
+
+	if c.initClosed {
+		return
+	}
+	c.initClosed = true
 
 	delete(n.pendConns, c.Address())
 


### PR DESCRIPTION
## Summary

Production visor crashlooped 1900+ times in one night on:

\`\`\`
panic: close of closed channel
goroutine 634 [running]:
  github.com/skycoin/skywire/pkg/cxo/node.(*Node).onConnInitErr+0xe5
    pkg/cxo/node/node.go:553
  github.com/skycoin/skywire/pkg/cxo/node.(*Node).initConn+0x1eb
    pkg/cxo/node/node.go:488
  github.com/skycoin/skywire/pkg/cxo/node.(*DMSG).ConnectPK
    pkg/cxo/node/transport_dmsg.go:137
  github.com/skycoin/skywire/pkg/cxo/treestore.(*Subscriber).Connect
    pkg/cxo/treestore/subscriber.go:198
  github.com/skycoin/skywire/cmd/apps/skychat/group.(*Session).ReconnectPeer.func1
    cmd/apps/skychat/group/session.go:1041
\`\`\`

Trigger: dmsg-discovery was CPU-starved on the same host (a separate leak fixed in #2676 — \`memoryCXDS.Del\` was missing the actual \`delete(m.kvs, key)\`). Every per-peer \`ConnectPK\` timed out. The \`ReconnectPeer\` storm exposed a latent race in \`Node.initConn\`'s two-caller signaling.

## Race

\`Node.initConn\` has two paths:

| Caller | Branch | Pre-fix behavior on failure |
|---|---|---|
| isNew | line 495 — does the handshake | calls \`onConnInitErr\` → \`close(c.initq)\` |
| isPending | line 487 — \`waitForInit\` on someone else's conn | also called \`onConnInitErr\` → **second close → panic** |

\`waitForInit\` returns once \`initq\` is closed and reads \`initErr\` — meaning the isNew goroutine has already cleaned up (\`delete pendConns\`, set \`initErr\`, close \`initq\`). The isPending caller's second \`onConnInitErr\` is fully redundant AND races on the close. Under sustained handshake-failure load (CPU-starved transport, peer offline, etc.) the race fires every cycle.

## Fix — defense in depth

**(1) Drop the redundant call.** \`node.go:488\`'s isPending branch no longer invokes \`onConnInitErr\`; it just propagates the error from \`waitForInit\`. Contract: handshaker publishes, waiter propagates.

**(2) Make \`onConnInitErr\` / \`onConnInit\` idempotent.** New \`Conn.initClosed bool\`, guarded by the existing \`Node.mx\`. Both functions early-return after the first publish:

\`\`\`go
func (n *Node) onConnInitErr(c *Conn, initErr error) {
    n.mx.Lock()
    defer n.mx.Unlock()

    if c.initClosed {
        return
    }
    c.initClosed = true

    delete(n.pendConns, c.Address())
    c.initErr = initErr
    close(c.initq)
}
\`\`\`

Same gate added to \`onConnInit\` — symmetric coverage so a future code path can't reintroduce the panic from either side.

## Tests

\`pkg/cxo/node/conn_init_idempotent_test.go\`:

- \`SecondCallNoOp\` — pre-set \`initClosed\` + a known \`initErr\`, call \`onConnInitErr\` with a *different* error, assert \`initErr\` unchanged (proves the guard returned before the assignment).
- \`OnConnInit_SecondCallNoOp\` — same property for the success companion; asserts \`addrToConn\` / \`pkToConn\` untouched.
- \`ConcurrentCallersNoPanic\` — 32 goroutines call \`onConnInitErr\` on the same pre-closed Conn. Pre-fix this panicked at \`close(c.initq)\`; post-fix all 32 hit the guard cleanly. \`go test -race\` validates the \`initClosed\` write happens under the lock.

Note: the new tests **don't compile against pre-fix code** (\`initClosed\` is the fix), so they're a strict "requires-the-fix" pin rather than a runtime fail-then-pass.

## Test plan

- [x] \`go test -race -count=1 -timeout=90s ./pkg/cxo/node/\` clean (6.2s)
- [x] \`go vet ./pkg/cxo/node/...\` clean
- [x] \`gofmt -l\` clean
- [ ] Post-merge prod observation: \`systemctl show skywire -p NRestarts\` should stop incrementing on the prod host that produced the stack trace. Currently 1900+ in 18h.

## Pairs with #2676

#2676 (just merged) fixed the upstream trigger — \`memoryCXDS.Del\` leak that CPU-starved dmsg-discovery. Without that fix, handshakes timed out constantly and this race fired every cycle. With that fix, handshakes succeed normally so the race rarely fires — but it's still latent. This PR closes the latent panic so any future cause of dmsg-handshake-stress (peer flap, transport hiccup) doesn't bring down the visor.