### PR TITLE
fix(cxo/skyobject): LastRoot + rootByHash nil-deref on missing CXDS bytes

### DIFF
--- a/pkg/cxo/skyobject/container.go
+++ b/pkg/cxo/skyobject/container.go
@@ -317,7 +317,17 @@ func (c *Container) rootByHash(
 		return
 	}
 
-	r, err = registry.DecodeRoot(val)
+	// Latent nil-deref companion to Index.LastRoot's panic site:
+	// DecodeRoot returns (nil, err) on a malformed payload, and the
+	// pre-fix `r.Hash = hash` on the next line panicked with
+	// "invalid memory address or nil pointer dereference". Couldn't
+	// fire when CXDS retention was broken (every byte ever Set was
+	// still resolvable, so DecodeRoot was being fed valid input);
+	// post-#2676 the bytes can actually be missing, and any path
+	// that lands on a stale-but-truncated payload would crash here.
+	if r, err = registry.DecodeRoot(val); err != nil {
+		return
+	}
 	r.Hash = hash
 	return
 }

--- a/pkg/cxo/skyobject/index.go
+++ b/pkg/cxo/skyobject/index.go
@@ -2,6 +2,7 @@ package skyobject
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -558,7 +559,25 @@ func (i *Index) LastRoot(
 		return
 	}
 
-	r, err = i.c.rootByHash(lr.Hash)
+	// rootByHash can return (nil, ErrNotFound) when the idx still
+	// references a hash whose CXDS bytes have been swept — a real
+	// inconsistency post-#2676 / #2677 now that the cleanup paths
+	// actually remove entries. Pre-fix the immediate r.IsFull / r.Sig
+	// assignments below nil-derefed the moment cleanup outran the
+	// idx-update, panicking every Publisher.hydrateFromContainer on
+	// startup and crashlooping the visor. Returning the err lets the
+	// caller fall back (Publisher.New logs Warn and starts with empty
+	// tree) instead of taking down the process. r==nil + err==nil
+	// shouldn't happen — DecodeRoot returns either (val, nil) or
+	// (nil, err) — but guard it anyway so a future refactor doesn't
+	// reintroduce the panic shape.
+	if r, err = i.c.rootByHash(lr.Hash); err != nil {
+		return
+	}
+	if r == nil {
+		err = fmt.Errorf("LastRoot: rootByHash returned nil with no error for hash %s (idx-CXDS inconsistency)", lr.Hash.Hex())
+		return
+	}
 
 	r.IsFull = true
 	r.Sig = lr.Sig

--- a/pkg/cxo/skyobject/lastroot_missing_cxds_test.go
+++ b/pkg/cxo/skyobject/lastroot_missing_cxds_test.go
@@ -1,0 +1,133 @@
+// Package skyobject pkg/cxo/skyobject/lastroot_missing_cxds_test.go:
+// pins the behavior of Index.LastRoot and Container.rootByHash when
+// CXDS no longer holds the bytes for a hash the index still
+// references — the exact prod failure mode after #2676 + #2677 made
+// the cleanup paths actually delete entries.
+//
+// Pre-fix Index.LastRoot crashed the entire visor on Publisher
+// startup:
+//
+//	panic: runtime error: invalid memory address or nil pointer dereference
+//	  pkg/cxo/skyobject/index.go:563
+//	  pkg/cxo/treestore/(*Publisher).hydrateFromContainer  publisher.go:321
+//	  pkg/cxo/treestore.New                                publisher.go:293
+//	  pkg/cxo/treestore.NewWithDMSG                        publisher.go:219
+//	  pkg/visor/visorinit.(*Module).InitConcurrent
+//
+// because the panic site `r.IsFull = true` dereferenced a nil r
+// returned from rootByHash. Caller (Publisher.New) already had
+// graceful error fallback to an empty in-memory tree — the panic
+// was the only thing that turned the inconsistency into a crashloop.
+
+package skyobject
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+)
+
+func TestIndex_LastRoot_MissingCXDSBytes_ReturnsError(t *testing.T) {
+	// Reproduce the prod crash shape: idx has a row pointing at a
+	// root hash whose bytes are no longer in CXDS. Verify LastRoot
+	// returns an error rather than panicking on nil dereference.
+	c := getTestContainer()
+	defer c.Close() //nolint:errcheck,gosec
+
+	pk, sk := cipher.GenerateKeyPair() //nolint:errcheck,gosec
+	if err := c.AddFeed(pk); err != nil {
+		t.Fatalf("AddFeed: %v", err)
+	}
+	up, err := c.Unpack(sk, testRegistry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	r := &registry.Root{Pub: pk, Nonce: 7}
+	if err := c.Save(up, r); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Sanity-check: LastRoot succeeds while CXDS still holds the bytes.
+	if got, err := c.LastRoot(pk, r.Nonce); err != nil {
+		t.Fatalf("pre-Del LastRoot: unexpected error %v", err)
+	} else if got == nil {
+		t.Fatalf("pre-Del LastRoot: returned nil with no error")
+	} else if got.Hash != r.Hash {
+		t.Fatalf("pre-Del LastRoot: got hash %s, want %s", got.Hash.Hex(), r.Hash.Hex())
+	}
+
+	// Simulate cleanup outrunning the idx update: yank the root's
+	// bytes out of both the in-process Cache and the underlying CXDS
+	// while leaving the idx row untouched. Touching only one layer
+	// is invisible because Cache.Get short-circuits on its own map
+	// before consulting the DB — but the production failure mode
+	// reaches the DB layer (cleanup paths evict from both via Set/Inc
+	// down to rc=0 + sweep), so the test mimics the same end-state.
+	c.Cache.mx.Lock()
+	delete(c.is, r.Hash)
+	c.Cache.mx.Unlock()
+	if err := c.DB().CXDS().Del(r.Hash); err != nil {
+		t.Fatalf("CXDS.Del: %v", err)
+	}
+
+	// Post-fix: LastRoot returns an error (the data.ErrNotFound the
+	// underlying Get surfaces). Pre-fix this panicked with nil deref.
+	got, err := c.LastRoot(pk, r.Nonce)
+	if err == nil {
+		t.Errorf("LastRoot after CXDS.Del: want non-nil error, got nil")
+	}
+	if got != nil {
+		t.Errorf("LastRoot after CXDS.Del: want nil root, got %+v", got)
+	}
+}
+
+func TestContainer_RootByHash_MissingCXDSBytes_ReturnsError(t *testing.T) {
+	// Companion test for the exported RootByHash → unexported
+	// rootByHash path. Pre-fix the missing-bytes case would have
+	// nil-derefed on `r.Hash = hash` after a failed DecodeRoot or
+	// on Get-error after the assignment-before-return reorder. Post-
+	// fix returns the error cleanly.
+	c := getTestContainer()
+	defer c.Close() //nolint:errcheck,gosec
+
+	pk, sk := cipher.GenerateKeyPair() //nolint:errcheck,gosec
+	if err := c.AddFeed(pk); err != nil {
+		t.Fatalf("AddFeed: %v", err)
+	}
+	up, err := c.Unpack(sk, testRegistry)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	r := &registry.Root{Pub: pk, Nonce: 11}
+	if err := c.Save(up, r); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	c.Cache.mx.Lock()
+	delete(c.is, r.Hash)
+	c.Cache.mx.Unlock()
+	if err := c.DB().CXDS().Del(r.Hash); err != nil {
+		t.Fatalf("CXDS.Del: %v", err)
+	}
+
+	got, err := c.RootByHash(r.Hash)
+	if err == nil {
+		t.Errorf("RootByHash after CXDS.Del: want non-nil error, got nil")
+	}
+	if got != nil {
+		t.Errorf("RootByHash after CXDS.Del: want nil root, got %+v", got)
+	}
+
+	// Sanity: error message is informative — the operator-facing
+	// "what went wrong" should mention the missing hash so a future
+	// log line is greppable. Loosely matched so the wording can
+	// evolve without breaking the test.
+	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "not found") {
+		// data.ErrNotFound's text is "not found" — relying on the
+		// canonical error from the layer below.
+		t.Logf("note: RootByHash err = %q (loose check for substring 'not found')", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Production visor crashlooped on every startup, immediately after the binary built off \`d3de13e80\` (which includes #2676 + #2677 + #2681) rolled. Stack trace:

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 139 [running]:
  pkg/cxo/skyobject.(*Index).LastRoot               index.go:563 +0x1f1
  pkg/cxo/treestore.(*Publisher).hydrateFromContainer  publisher.go:321 +0xe5
  pkg/cxo/treestore.New                             publisher.go:293 +0x605
  pkg/cxo/treestore.NewWithDMSG                     publisher.go:219 +0x2dc
  pkg/visor/visorinit.(*Module).InitConcurrent
\`\`\`

Every \`Publisher.hydrateFromContainer\` call (one per CXO-publishing visor or app) hits this on startup → \`exited, status=2\` → \`Restart=always\` → infinite crashloop.

## Root cause

Two co-located latent bugs:

### Index.LastRoot (index.go:561)

\`\`\`go
r, err = i.c.rootByHash(lr.Hash)

r.IsFull = true       // ← nil-deref when rootByHash returned (nil, ErrNotFound)
r.Sig = lr.Sig
\`\`\`

The \`err\` from rootByHash was silently ignored. The two sibling \`rootByHash\` callers in the same file (\`delRootRelatedValues\`, line 935; \`Root\` by-seq, line 1138) already check err — only \`LastRoot\` didn't.

### Container.rootByHash (container.go:320)

\`\`\`go
r, err = registry.DecodeRoot(val)
r.Hash = hash         // ← nil-deref when DecodeRoot returned (nil, err)
\`\`\`

Same shape, latent companion.

## Why now

Pre-#2676 / #2677 the in-memory CXDS held every byte ever Set (memoryCXDS.Del missed the actual map delete, and DelRoot's non-atomic walk left rc>0 on orphans). \`rootByHash\` always resolved, so neither nil-deref could fire. Once those two fixes landed and the cleanup paths started actually evicting entries, the (idx, CXDS) inconsistency window that DelRoot opens — idx-update before tree-walk decrement-and-sweep, called out as \`What this does NOT fix\` in #2677's body — became observable on every startup, and every \`hydrateFromContainer\` panicked.

## Fix

Defensive err check in both sites; LastRoot also guards \`(nil, nil)\` for defense-in-depth. Caller chain already has graceful fallback — \`Publisher.New\` logs a Warn and falls back to the empty-tree default when hydrate returns err — so the visor recovers instead of crashlooping.

## Tests

\`pkg/cxo/skyobject/lastroot_missing_cxds_test.go\`:

- \`Index_LastRoot_MissingCXDSBytes_ReturnsError\` — Save a Root, evict it from both the Cache and the underlying CXDS (matches the cleanup end-state without driving the full DelRoot walk), call LastRoot, assert (nil root, non-nil err).
- \`Container_RootByHash_MissingCXDSBytes_ReturnsError\` — same shape for the exported RootByHash → unexported rootByHash path.

Verified both tests fail on pre-fix code with the exact prod panic:

\`\`\`
pkg/cxo/skyobject.(*Index).LastRoot
  pkg/cxo/skyobject/index.go:563 +0x1f1
TestIndex_LastRoot_MissingCXDSBytes_ReturnsError
  pkg/cxo/skyobject/lastroot_missing_cxds_test.go:78 +0x57b
\`\`\`

## Test plan

- [x] \`go test -race -count=1 -timeout=120s ./pkg/cxo/skyobject/ ./pkg/cxo/treestore/ ./pkg/cxo/data/cxds/\` clean
- [x] \`go vet ./pkg/cxo/skyobject/...\` clean
- [x] \`gofmt -l\` clean
- [ ] Post-merge prod observation: \`systemctl show skywire -p NRestarts\` should stop incrementing on the host that produced the trace. Currently 2164+ in 18h on the host that's running the d3de13e80 build.

## Pairs with #2676, #2677, #2681

This PR completes today's "CXDS retention now works correctly" arc:

- #2676 — memoryCXDS.Del actually removes map entries
- #2677 — RemoveRootObjects survives missing intermediate seqs + periodic forced sweep
- #2681 — Conn init signaling no longer double-closes initq
- **#2683 (this) — readers handle the idx-CXDS inconsistency without panicking**

Without all four, the visor either leaks memory unbounded (pre-#2676) or crashloops on startup (post-#2676 alone, the situation we landed in for ~30 min until #2681 + this PR were ready).