### PR TITLE
fix(cxo/skyobject): replace naked returns in LastRoot with explicit returns

### DIFF
--- a/pkg/cxo/skyobject/index.go
+++ b/pkg/cxo/skyobject/index.go
@@ -556,7 +556,7 @@ func (i *Index) LastRoot(
 
 	var lr *data.Root
 	if lr, err = i.lastRoot(pk, nonce); err != nil {
-		return
+		return nil, err
 	}
 
 	// rootByHash can return (nil, ErrNotFound) when the idx still
@@ -572,16 +572,15 @@ func (i *Index) LastRoot(
 	// (nil, err) — but guard it anyway so a future refactor doesn't
 	// reintroduce the panic shape.
 	if r, err = i.c.rootByHash(lr.Hash); err != nil {
-		return
+		return r, err
 	}
 	if r == nil {
-		err = fmt.Errorf("LastRoot: rootByHash returned nil with no error for hash %s (idx-CXDS inconsistency)", lr.Hash.Hex())
-		return
+		return nil, fmt.Errorf("LastRoot: rootByHash returned nil with no error for hash %s (idx-CXDS inconsistency)", lr.Hash.Hex())
 	}
 
 	r.IsFull = true
 	r.Sig = lr.Sig
-	return
+	return r, nil
 }
 
 // delFeed deletes feed from IdxDB and from the Index


### PR DESCRIPTION
## Summary

Linter flags 3 naked returns in \`Index.LastRoot\` after #2683 grew the function past nakedret's 30-line threshold. CI lint on develop is failing as a result.

\`\`\`
pkg/cxo/skyobject/index.go:559:3: naked return in func \`LastRoot\` with 39 lines of code (nakedret)
pkg/cxo/skyobject/index.go:575:3: naked return in func \`LastRoot\` with 39 lines of code (nakedret)
pkg/cxo/skyobject/index.go:579:3: naked return in func \`LastRoot\` with 39 lines of code (nakedret)
\`\`\`

Replace each \`return\` with the explicit \`return <val>, <err>\` shape. No semantic change — named-return values were already populated correctly at every exit; the new form just makes that visible to a reader.

After: \`golangci-lint run ./...\` clean.

## Test plan
- [x] \`go test ./pkg/cxo/skyobject/...\` passes
- [x] \`make lint\` 0 issues
- [x] Function semantics preserved (every exit returns the same (r, err) pair it did before)