### PR TITLE
feat(skychat/group): sign + verify leaf-level Messages (alpha slice of admin-aggregator)

### DIFF
--- a/cmd/apps/skychat/group/group.go
+++ b/cmd/apps/skychat/group/group.go
@@ -228,4 +228,23 @@ type Message struct {
 	// requires.
 	Ciphertext []byte `json:"ciphertext,omitempty"`
 	Nonce      []byte `json:"nonce,omitempty"`
+
+	// Signature binds (SenderPK, TS, Text|Ciphertext|Nonce) to the
+	// sender's identity via secp256k1 over the canonical-bytes
+	// layout in signing.go. Verified on every inbound leaf so an
+	// admin-aggregator republishing this Message verbatim cannot
+	// tamper with the body or the sender claim — the worst they can
+	// do is omit, which is detectable by cross-admin divergence.
+	//
+	// Zero value (cipher.Sig{}) means "unsigned legacy leaf" — a
+	// publisher predating the admin-aggregator design. VerifyMessage
+	// returns ErrLeafUnsignedLegacy for this case so the inbox path
+	// can downgrade to accept-with-warning during the deprecation
+	// window, then flip to strict-reject once those publishers
+	// have aged out.
+	//
+	// JSON `omitempty` is honored when the field is exactly the
+	// zero value, keeping pre-signing leaves on disk byte-identical
+	// to what they were before this field was introduced.
+	Signature cipher.Sig `json:"signature,omitempty"`
 }

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -1678,6 +1678,27 @@ func (s *Session) publishAs(senderPK cipher.PubKey, text string, ts time.Time) e
 		msg.Ciphertext = ct
 		msg.Nonce = nonce
 	}
+	// Sign with this session's SK. publishAs accepts a parametric
+	// senderPK (the relay path needs to publish as someone else),
+	// but the SIGNATURE is always over (senderPK, msg) with this
+	// session's SK — i.e., the signer asserts "I, this session,
+	// republished this Message and I take responsibility for it".
+	// In the steady-state federated case where senderPK == MyPK, the
+	// signature is the original author's own signature.
+	//
+	// The relay path (handleRelay → owner publishes member's text)
+	// produces a signature where senderPK != MyPK; subscribers
+	// verifying see a signature that DOESN'T bind to the claimed
+	// SenderPK and reject the leaf. This is intentional: post-D1
+	// federated send is the norm, and the legacy relay path is a
+	// pre-D1 fallback. A signed legacy-relay leaf would let the
+	// owner forge messages as any member. Forcing relay leaves to
+	// fail Verify pushes operators toward the federated path; we
+	// can add a separate "owner-asserts-by-relay" envelope type
+	// later if the legacy path needs to survive past TTL.
+	if err := SignMessage(&msg, s.cfg.MySK); err != nil {
+		return fmt.Errorf("group: publishAs: sign: %w", err)
+	}
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("group: publishAs: marshal: %w", err)
@@ -2089,6 +2110,30 @@ func (s *Session) onUpdate(events []treestore.UpdateEvent) {
 			s.log.WithError(err).WithField("path", ev.Path).
 				Debug("group: ignoring undecodable leaf")
 			continue
+		}
+		// Verify the leaf's signature against the claimed SenderPK.
+		// Admin-aggregator republishes are accepted iff the original
+		// author's signature still verifies — admins can omit but not
+		// alter. Backward-compat: pre-signing publishers produce
+		// unsigned leaves (Signature == cipher.Sig{}); these surface
+		// as ErrLeafUnsignedLegacy which we accept-with-warning during
+		// the deprecation window, then flip to strict-reject once
+		// publisher TTL elapses. Any other VerifyMessage error
+		// (forged signature, wrong PK, unknown canonical version) is
+		// a strict reject right now — the leaf is silently dropped
+		// at debug log because an honest admin shouldn't be
+		// republishing leaves that don't verify and we don't want a
+		// noisy log surface for what's effectively an attack signal.
+		if err := VerifyMessage(msg); err != nil {
+			if errors.Is(err, ErrLeafUnsignedLegacy) {
+				s.log.WithField("path", ev.Path).WithField("sender_pk", msg.SenderPK.String()).
+					Debug("group: accepting unsigned legacy leaf (deprecated; publisher predates signing)")
+				// Fall through — accept the leaf.
+			} else {
+				s.log.WithError(err).WithField("path", ev.Path).WithField("sender_pk", msg.SenderPK.String()).
+					Debug("group: rejecting leaf with bad signature")
+				continue
+			}
 		}
 		if s.cfg.Record.Mode == ModePrivate {
 			plain, err := Decrypt(s.cfg.Record.AESKey, msg.Ciphertext, msg.Nonce)

--- a/cmd/apps/skychat/group/signing.go
+++ b/cmd/apps/skychat/group/signing.go
@@ -1,0 +1,168 @@
+// Package group — cmd/apps/skychat/group/signing.go: leaf-level
+// signatures for chat messages. Each Message published to a group
+// feed is signed by the SenderPK so admin-aggregator republishes
+// are tamper-evident: a non-admin subscriber consuming a leaf via
+// an admin's canonical feed verifies the signature against the
+// original SenderPK before delivering to the handler. The admin
+// can only OMIT (which is detectable by cross-admin divergence),
+// never alter.
+//
+// Mirrors the canonical-bytes pattern from gossip.go (#2658) so
+// roster/admin envelopes and message leaves use the same primitive
+// (cipher.SignPayload — secp256k1, same algorithm dmsg discovery
+// entries use). Subscribers built before this change accept
+// signature-bearing leaves transparently because the JSON field
+// is omitempty when zero.
+//
+// Wire format: the Signature field is appended to the existing
+// Message JSON. Backward-compat: legacy leaves on disk (pre-signing
+// publishers) arrive with Signature=zero; VerifyMessage returns
+// ErrLeafUnsignedLegacy which callers can choose to accept with a
+// deprecation warning during the transition window, then flip to
+// strict-reject once publisher TTL elapses.
+package group
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// leafCanonicalVersion is the leading version byte of every
+// signed-leaf canonical-bytes layout. Bumped on incompatible field-
+// set additions so an old verifier fast-rejects (returns
+// ErrLeafUnknownCanonicalVersion) rather than mis-verifying a
+// re-ordered or extended layout.
+const leafCanonicalVersion byte = 1
+
+// Sentinel errors. Callers errors.Is() against these; tests assert
+// directly.
+var (
+	// ErrLeafBadSignature is returned by VerifyMessage when the
+	// signature doesn't bind to (SenderPK, canonicalBytes). The
+	// underlying cipher.VerifyPubKeySignedPayload error is wrapped.
+	ErrLeafBadSignature = errors.New("group: leaf bad signature")
+
+	// ErrLeafMissingSenderPK is returned when SenderPK is the zero
+	// value at sign or verify time. Catches caller mistakes — a
+	// zero PK means we don't know who to verify against.
+	ErrLeafMissingSenderPK = errors.New("group: leaf missing sender_pk")
+
+	// ErrLeafUnknownCanonicalVersion is returned on Verify when the
+	// signed envelope is from a future canonical layout this
+	// binary doesn't understand. Old binaries fast-reject newer
+	// layouts via this rather than computing a digest over a layout
+	// they don't recognize.
+	ErrLeafUnknownCanonicalVersion = errors.New("group: leaf unknown canonical version")
+
+	// ErrLeafUnsignedLegacy is returned by VerifyMessage when the
+	// Signature field is the zero value. Distinct from
+	// ErrLeafBadSignature so the inbox path can downgrade to a
+	// debug log + accept during the deprecation window, then flip
+	// to strict-reject once unsigned publishers have aged out.
+	ErrLeafUnsignedLegacy = errors.New("group: leaf unsigned (legacy publisher)")
+)
+
+// canonicalBytesMessage returns the deterministic byte sequence
+// over a Message's fields that gets signed. Fixed field order,
+// big-endian integers, length-prefixed variable components. Adding
+// new signed fields REQUIRES bumping leafCanonicalVersion so old
+// verifiers reject the new shape rather than silently mis-verifying.
+//
+// Layout (bytes):
+//
+//	1   version (leafCanonicalVersion)
+//	33  SenderPK
+//	8   TS UnixNano BE
+//	4   len(Text) BE
+//	N1  Text bytes
+//	4   len(Ciphertext) BE
+//	N2  Ciphertext bytes
+//	4   len(Nonce) BE
+//	N3  Nonce bytes
+//
+// Returns the SHA-256 digest over the buffer. cipher.SignPayload
+// hashes again internally, but pre-hashing keeps verify cheap (the
+// caller compares a 32-byte digest instead of re-walking the
+// concat) and matches the gossip.go pattern so reviewers see the
+// same shape.
+func canonicalBytesMessage(m Message) []byte {
+	textLen := len(m.Text)
+	cipherLen := len(m.Ciphertext)
+	nonceLen := len(m.Nonce)
+
+	// 1 + 33 + 8 + 4 + 4 + 4 = 54 fixed; pre-size with payload too.
+	buf := make([]byte, 0, 54+textLen+cipherLen+nonceLen)
+	buf = append(buf, leafCanonicalVersion)
+	buf = append(buf, m.SenderPK[:]...)
+
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], uint64(m.TS.UTC().UnixNano())) //nolint:gosec
+	buf = append(buf, ts[:]...)
+
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(textLen)) //nolint:gosec
+	buf = append(buf, l[:]...)
+	buf = append(buf, []byte(m.Text)...)
+
+	binary.BigEndian.PutUint32(l[:], uint32(cipherLen)) //nolint:gosec
+	buf = append(buf, l[:]...)
+	buf = append(buf, m.Ciphertext...)
+
+	binary.BigEndian.PutUint32(l[:], uint32(nonceLen)) //nolint:gosec
+	buf = append(buf, l[:]...)
+	buf = append(buf, m.Nonce...)
+
+	sum := sha256.Sum256(buf)
+	return sum[:]
+}
+
+// SignMessage fills in m.Signature using sec. m.SenderPK MUST
+// already be populated (and must match the PK derived from sec —
+// the function does NOT overwrite SenderPK because publishAs's
+// caller passes both explicitly). m.TS must be set; zero TS hashes
+// to a deterministic-but-meaningless slot so we don't sign it.
+//
+// Returns ErrLeafMissingSenderPK on zero SenderPK; the underlying
+// cipher.SignPayload error otherwise.
+func SignMessage(m *Message, sec cipher.SecKey) error {
+	if m == nil {
+		return ErrLeafMissingSenderPK
+	}
+	if m.SenderPK == (cipher.PubKey{}) {
+		return ErrLeafMissingSenderPK
+	}
+	sig, err := cipher.SignPayload(canonicalBytesMessage(*m), sec)
+	if err != nil {
+		return fmt.Errorf("sign leaf: %w", err)
+	}
+	m.Signature = sig
+	return nil
+}
+
+// VerifyMessage checks m.Signature against m.SenderPK over the
+// canonical-bytes of m's other fields. Returns nil on success;
+// ErrLeafUnsignedLegacy when m.Signature is the zero value (caller
+// decides accept-with-warning vs strict-reject); ErrLeafBadSignature
+// when the signature doesn't bind; ErrLeafMissingSenderPK when
+// SenderPK is zero.
+//
+// Cheap by design — VerifyMessage runs on every inbound leaf in the
+// hot onUpdate path. The canonical bytes are already a 32-byte
+// SHA-256 digest; cipher.VerifyPubKeySignedPayload is a single
+// secp256k1 verify on top.
+func VerifyMessage(m Message) error {
+	if m.SenderPK == (cipher.PubKey{}) {
+		return ErrLeafMissingSenderPK
+	}
+	if m.Signature == (cipher.Sig{}) {
+		return ErrLeafUnsignedLegacy
+	}
+	if err := cipher.VerifyPubKeySignedPayload(m.SenderPK, m.Signature, canonicalBytesMessage(m)); err != nil {
+		return fmt.Errorf("%w: %w", ErrLeafBadSignature, err)
+	}
+	return nil
+}

--- a/cmd/apps/skychat/group/signing_test.go
+++ b/cmd/apps/skychat/group/signing_test.go
@@ -1,0 +1,129 @@
+// Package group — cmd/apps/skychat/group/signing_test.go: pins
+// the contract on leaf signing/verification that admin-aggregator
+// safety relies on. Specifically:
+//
+//   - A signed Message verifies against the SenderPK that signed it.
+//   - Tampering ANY signed field (TS, Text, Ciphertext, Nonce, SenderPK)
+//     invalidates the signature.
+//   - The Signature field itself is NOT covered by canonicalBytes
+//     (a verifier with the same SenderPK can produce a fresh signature
+//     over the same body — that's fine; the body is what matters).
+//   - Unsigned legacy leaves surface as ErrLeafUnsignedLegacy distinctly
+//     from ErrLeafBadSignature, so the inbox path can downgrade legacy
+//     leaves to accept-with-warning without accepting forgeries.
+package group
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	m := Message{
+		SenderPK: pk,
+		TS:       time.Date(2026, 5, 17, 20, 0, 0, 0, time.UTC),
+		Text:     "hello",
+	}
+	if err := SignMessage(&m, sk); err != nil {
+		t.Fatalf("SignMessage: %v", err)
+	}
+	if m.Signature == (cipher.Sig{}) {
+		t.Fatal("SignMessage: signature still zero after sign")
+	}
+	if err := VerifyMessage(m); err != nil {
+		t.Errorf("VerifyMessage on fresh signed message: %v", err)
+	}
+}
+
+func TestVerifyRejectsTampered(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	base := Message{
+		SenderPK: pk,
+		TS:       time.Date(2026, 5, 17, 20, 0, 0, 0, time.UTC),
+		Text:     "original",
+	}
+	if err := SignMessage(&base, sk); err != nil {
+		t.Fatalf("SignMessage: %v", err)
+	}
+	// Every signed-field perturbation must fail Verify; pre-fix we
+	// could let an admin republish-and-edit a leaf because none of
+	// these were covered.
+	cases := []struct {
+		name string
+		mut  func(*Message)
+	}{
+		{"text changed", func(m *Message) { m.Text = "tampered" }},
+		{"ts changed", func(m *Message) { m.TS = m.TS.Add(time.Second) }},
+		{"sender pk changed", func(m *Message) { other, _ := cipher.GenerateKeyPair(); m.SenderPK = other }},
+		{"ciphertext changed", func(m *Message) { m.Ciphertext = []byte{0xff} }},
+		{"nonce changed", func(m *Message) { m.Nonce = []byte{0xff} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tampered := base
+			tc.mut(&tampered)
+			err := VerifyMessage(tampered)
+			if err == nil {
+				t.Fatal("VerifyMessage accepted tampered message")
+			}
+			// sender-pk mutation rejects via ErrLeafBadSignature
+			// (signature no longer binds to the new PK).
+			if !errors.Is(err, ErrLeafBadSignature) {
+				t.Errorf("expected ErrLeafBadSignature, got %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifyUnsignedLegacy(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	m := Message{SenderPK: pk, TS: time.Now().UTC(), Text: "legacy"}
+	// Signature deliberately zero — simulates a pre-signing leaf on disk.
+	err := VerifyMessage(m)
+	if !errors.Is(err, ErrLeafUnsignedLegacy) {
+		t.Fatalf("expected ErrLeafUnsignedLegacy on zero Signature, got %v", err)
+	}
+	// Must NOT also return ErrLeafBadSignature — the two sentinels
+	// are distinct so the inbox path can branch on accept-with-
+	// warning vs strict-reject.
+	if errors.Is(err, ErrLeafBadSignature) {
+		t.Error("ErrLeafUnsignedLegacy must not also satisfy errors.Is(ErrLeafBadSignature)")
+	}
+}
+
+func TestVerifyMissingSenderPK(t *testing.T) {
+	m := Message{TS: time.Now().UTC(), Text: "no sender"}
+	if err := VerifyMessage(m); !errors.Is(err, ErrLeafMissingSenderPK) {
+		t.Errorf("expected ErrLeafMissingSenderPK, got %v", err)
+	}
+}
+
+func TestSignWrongSKBindsToDerivedPK(t *testing.T) {
+	// publishAs is parametric in senderPK — the caller passes
+	// whichever PK should appear as the author. SignMessage uses
+	// the SK passed to it; if those don't match, verify fails. This
+	// is the relay-path protection: a leaf signed by the owner's SK
+	// but claiming a different SenderPK will reject. Documents the
+	// invariant called out in publishAs's comment.
+	authorPK, _ := cipher.GenerateKeyPair()
+	_, relaySK := cipher.GenerateKeyPair()
+	m := Message{
+		SenderPK: authorPK, // claims author identity
+		TS:       time.Now().UTC(),
+		Text:     "relayed",
+	}
+	if err := SignMessage(&m, relaySK); err != nil {
+		t.Fatalf("SignMessage: %v", err)
+	}
+	err := VerifyMessage(m)
+	if err == nil {
+		t.Fatal("VerifyMessage accepted leaf signed by non-matching SK")
+	}
+	if !errors.Is(err, ErrLeafBadSignature) {
+		t.Errorf("expected ErrLeafBadSignature on SK/SenderPK mismatch, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Foundation for the operator-directed admin-aggregator redesign. Today's full-mesh topology (every member subscribes to every other member's per-peer feed) scales quadratically and is the root of today's reliability surface. The replacement design routes messages through admin aggregators that republish observed leaves onto their own canonical group feed — but verbatim republish only works safely if leaves are bound to their sender. **Hence: sign every leaf.**

## What this adds

\`Message.Signature\` (\`cipher.Sig\`, secp256k1) over a deterministic canonical-bytes layout:

\`\`\`
1   version byte (leafCanonicalVersion = 1)
33  SenderPK
8   TS UnixNano BE
4 + N  Text (length-prefixed)
4 + N  Ciphertext (length-prefixed)
4 + N  Nonce (length-prefixed)
\`\`\`

Mirrors the gossip.go pattern from #2658 so roster/admin envelopes and message leaves use the same primitive shape.

- \`publishAs\` signs every leaf with this session's SK before \`pub.Put\`.
- \`onUpdate\` calls \`VerifyMessage\` on every leaf:
  - sig binds to SenderPK → accept normally
  - sig zero (legacy) → accept with debug log (deprecation window)
  - sig present but bad → drop silently at debug

## Backward compat

\`Signature\` is \`json:\",omitempty\"\` — a zero value (legacy publishers pre-this-change) produces byte-identical wire output. New subscribers downgrade unsigned legacy leaves to accept-with-warning. Old subscribers ignore the new field via JSON unknown-field tolerance.

## Security property

Admins can omit (detectable via cross-admin divergence) but cannot alter. \`SignMessage\` uses the SK passed to it; the legacy relay path (owner publishes as member) produces signatures that DON'T bind to the claimed SenderPK and will fail Verify on the subscriber side — intentional, federated-send (#2580) is the supported D1 path.

## Tests

10 cases covering:
- round-trip (sign + verify with matching SK)
- tamper rejection across every signed field (text, ts, sender pk, ciphertext, nonce)
- unsigned-legacy distinguishes from bad-signature (sentinel error contract)
- zero SenderPK rejection
- relay-path SK/SenderPK mismatch rejection

## Work-split context

Operator-directed redesign split between three agents:
- **Alpha (this PR)** — sign+verify foundation
- **Beta** — admin aggregation publisher (NEEDS this PR landed first)
- **Gamma** — non-admin subscription topology (NEEDS this PR)
- **Integration** — flips default behavior, 3-visor #2673 framework

## Dependencies / known CI issue

CI lint on develop is currently red on pre-existing \`nakedret\` issues in \`pkg/cxo/skyobject/index.go\` (from #2683). Filed as #2684 — should land before or alongside this PR.

## Test plan
- [x] \`go test ./cmd/apps/skychat/group/...\` passes (incl 10 new sign/verify tests)
- [x] \`make format && make lint\` on these files clean
- [ ] Integration: 3-visor send/receive with admin-aggregator topology — Beta + Gamma slices required first