### PR TITLE
chore: apply make format

### DIFF
--- a/pkg/cmdutil/legacy_flag_alias.go
+++ b/pkg/cmdutil/legacy_flag_alias.go
@@ -10,7 +10,9 @@
 // resolves to the same target.
 package cmdutil
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+)
 
 // legacyFlagAliases maps deprecated flag names → current canonical name.
 // Add an entry here whenever a flag gets renamed in a backward-incompatible

--- a/pkg/dmsg/disc/dmsgfirst/client_test.go
+++ b/pkg/dmsg/disc/dmsgfirst/client_test.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"net"
 	"net/url"
-	"testing"
-
 	"slices"
+	"testing"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"


### PR DESCRIPTION
## Summary

\`make format\` on develop produces two import-block adjustments that haven't been committed. Without them, any subsequent PR that touches the repo fails the CI format check before reaching test/lint phases.

Pure formatting — no semantic change. Splits one-line \`import \"x\"\` into the parenthesized form (cmdutil) and reorders stdlib imports into a single contiguous block (dmsgfirst).

## Test plan
- [x] \`make format\` produces an empty diff after this PR
- [x] \`make lint\` clean
- [x] No semantic change (formatter-only edits)