### PR TITLE
fix(skychat): bound /message inner Write with a per-call deadline

### DIFF
--- a/cmd/apps/skychat/commands/framedconn_writedeadline_test.go
+++ b/cmd/apps/skychat/commands/framedconn_writedeadline_test.go
@@ -1,0 +1,221 @@
+// Package commands cmd/apps/skychat/commands/framedconn_writedeadline_test.go:
+// pins the bounded-write behavior of framedConn.WriteFrameDeadline so a
+// slow / hung peer transport can't pin the /message HTTP handler
+// goroutine indefinitely.
+//
+// Pre-fix the chat-app's messageHandler called conn.WriteFrame, which
+// blocks inside the inner c.Conn.Write call with no deadline. A peer
+// whose visor was crashlooping (so its dmsg listener side absorbed but
+// never drained writes) wedged the handler's goroutine. Worse,
+// c.writeMu was held the whole time, so EVERY subsequent /message to
+// the same peer queued behind the hung write. Observed cross-peer
+// cascade on 2026-05-17 around 20:20Z: a single Beta-send hang
+// preceded every subsequent /message — to Alpha, Beta, anyone — timing
+// out at the outer HTTP context deadline (~30 s) for hours after.
+// Bounding the inner Write lets the handler return cleanly, the
+// writeMu releases, and the next caller is freed.
+
+package commands
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestFramedConn_WriteFrameDeadline_TimesOutOnStalledPeer(t *testing.T) {
+	// Build a real TCP pair via net.Pipe so the underlying conn
+	// honors SetWriteDeadline. Receiver never reads, so once the
+	// kernel send buffer fills (or in net.Pipe's case, the first
+	// write blocks immediately since pipes are unbuffered) the
+	// write blocks. Without a deadline the WriteFrame call would
+	// pin the goroutine; with one it returns net.Error{Timeout: true}.
+	srvSide, cliSide := net.Pipe()
+	defer cliSide.Close() //nolint:errcheck,gosec
+	defer srvSide.Close() //nolint:errcheck,gosec
+	// Don't drain srvSide — that's the whole point.
+
+	c := newFramedConn(cliSide)
+
+	const timeout = 100 * time.Millisecond
+	start := time.Now()
+	err := c.WriteFrameDeadline([]byte("hello"), timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("WriteFrameDeadline against an undrained peer: want timeout error, got nil")
+	}
+	var ne net.Error
+	if !errors.As(err, &ne) || !ne.Timeout() {
+		t.Errorf("WriteFrameDeadline err = %v (Timeout()=%v); want net.Error with Timeout()==true", err, ne != nil && ne.Timeout())
+	}
+	if elapsed < timeout {
+		t.Errorf("WriteFrameDeadline returned in %v (before %v deadline) — deadline did not bound the write", elapsed, timeout)
+	}
+	if elapsed > timeout+500*time.Millisecond {
+		// Allow scheduler slop but flag a really late return so the
+		// deadline machinery isn't silently broken.
+		t.Errorf("WriteFrameDeadline returned %v after the %v deadline — net.Conn.SetWriteDeadline appears not to bound this transport", elapsed-timeout, timeout)
+	}
+}
+
+func TestFramedConn_WriteFrameDeadline_DeadlineResetForNextCaller(t *testing.T) {
+	// After a deadline-bounded write times out, the next call must
+	// not inherit the expired deadline — pre-fix a lingering
+	// SetWriteDeadline could pre-expire subsequent writes on the
+	// same conn. Verify by stalling-then-draining: first call hits
+	// the deadline; reader starts draining; second call must
+	// succeed (with a non-expired deadline) instead of returning
+	// instant-timeout because of leftover state.
+	//
+	// Skipped on net.Pipe because pipes don't honor concurrent
+	// drain semantics the way TCP does. Build a localhost TCP
+	// pair instead.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer lis.Close() //nolint:errcheck,gosec
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, aErr := lis.Accept()
+		if aErr != nil {
+			return
+		}
+		accepted <- conn
+	}()
+
+	cli, err := net.Dial("tcp", lis.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer cli.Close() //nolint:errcheck,gosec
+	srv := <-accepted
+	defer srv.Close() //nolint:errcheck,gosec
+
+	c := newFramedConn(cli)
+
+	// First call: timeout immediately by setting the deadline to a
+	// past instant. Pre-fix the deadline would not get reset after
+	// this call and a subsequent SetWriteDeadline call in
+	// WriteFrameDeadline would re-establish a deadline — but if a
+	// hypothetical buggy fix skipped the reset, the next plain
+	// WriteFrame (no deadline arg) would inherit the past deadline
+	// and instant-fail. Cover both paths.
+
+	// Fill the buffer by writing a large payload until it blocks,
+	// then trigger a short-timeout call. To keep the test bounded
+	// and portable, just use a short timeout on a small payload —
+	// TCP send buffer isn't reliably exhausted by one frame, but
+	// the deadline expires the SECOND write call (payload) when
+	// the kernel buffer fills.
+	largePayload := make([]byte, 64*1024)
+	for i := range largePayload {
+		largePayload[i] = 'x'
+	}
+
+	// Repeated writes against an unread srv: eventually one blocks.
+	// Cap the loop so a kernel with a large buffer doesn't spin
+	// forever.
+	const maxWrites = 64
+	var lastErr error
+	var lastWasTimeout bool
+	for i := 0; i < maxWrites; i++ {
+		err := c.WriteFrameDeadline(largePayload, 50*time.Millisecond)
+		if err != nil {
+			lastErr = err
+			var ne net.Error
+			lastWasTimeout = errors.As(err, &ne) && ne.Timeout()
+			break
+		}
+	}
+	if lastErr == nil {
+		t.Skip("Could not stall the TCP send buffer within bounded write loop; this kernel/buffer combination doesn't reproduce the deadline path")
+	}
+	if !lastWasTimeout {
+		// Non-timeout error (e.g. broken pipe) — still proves the
+		// deadline didn't wedge the goroutine; skip the
+		// reset-verification half.
+		t.Logf("first-blocking-write returned non-timeout: %v — deadline still bounded the call, but skipping reset check on this kernel", lastErr)
+		return
+	}
+
+	// Now drain srv to free the buffer.
+	go func() {
+		buf := make([]byte, 16*1024)
+		for {
+			if _, err := srv.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	// Give the drainer a moment to release pressure.
+	time.Sleep(50 * time.Millisecond)
+
+	// Plain WriteFrame (no explicit deadline). Pre-buggy-fix this
+	// could have inherited the now-expired deadline from
+	// WriteFrameDeadline's stale SetWriteDeadline call. Post-fix
+	// the deadline was reset to zero-time on the defer, so this
+	// call uses no deadline and succeeds.
+	if err := c.WriteFrame([]byte("after-reset")); err != nil {
+		t.Errorf("plain WriteFrame after deadline-bounded timeout: got %v, want nil (deadline reset should leave the conn unbounded for subsequent calls)", err)
+	}
+}
+
+// recordingConn wraps a net.Conn and records every SetWriteDeadline
+// argument in order. Propagates the call to the embedded conn so
+// the underlying transport's deadline machinery still fires —
+// without this propagation the inner Write would block forever
+// while the test only watched the recorder.
+type recordingConn struct {
+	net.Conn
+	mu        sync.Mutex
+	deadlines []time.Time
+}
+
+func (r *recordingConn) SetWriteDeadline(t time.Time) error {
+	r.mu.Lock()
+	r.deadlines = append(r.deadlines, t)
+	r.mu.Unlock()
+	return r.Conn.SetWriteDeadline(t)
+}
+
+// TestFramedConn_WriteFrameDeadline_SetsAndResets verifies the
+// envelope contract directly: SetWriteDeadline is called twice per
+// WriteFrameDeadline invocation — once with a non-zero deadline on
+// entry, once with time.Time{} (the "no deadline" sentinel) on
+// exit — regardless of whether the Write itself succeeded or
+// timed out. This is the portable contract test that doesn't
+// depend on kernel buffer behavior or net.Conn flavor.
+func TestFramedConn_WriteFrameDeadline_SetsAndResets(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer srv.Close() //nolint:errcheck,gosec
+	defer cli.Close() //nolint:errcheck,gosec
+
+	rc := &recordingConn{Conn: cli}
+	c := newFramedConn(rc)
+
+	// Short timeout — the Write will time out (net.Pipe honors
+	// deadlines via pipeDeadline) since srv isn't being drained.
+	// We don't care about the timeout outcome here; we care about
+	// the deadline-setting envelope.
+	_ = c.WriteFrameDeadline([]byte("ping"), 50*time.Millisecond) //nolint:errcheck
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if len(rc.deadlines) < 2 {
+		t.Fatalf("WriteFrameDeadline made %d SetWriteDeadline calls; want >=2 (set + reset)", len(rc.deadlines))
+	}
+	// First call: non-zero deadline ~50ms in the future.
+	if rc.deadlines[0].IsZero() {
+		t.Errorf("first SetWriteDeadline arg was zero-time; want a future deadline ~now+timeout")
+	}
+	// Last call: time.Time{} reset.
+	last := rc.deadlines[len(rc.deadlines)-1]
+	if !last.IsZero() {
+		t.Errorf("last SetWriteDeadline arg was %v; want time.Time{} (the 'no deadline' sentinel) so subsequent calls don't inherit an expired deadline", last)
+	}
+}

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -80,6 +80,12 @@ func newFramedConn(c net.Conn) *framedConn { return &framedConn{Conn: c} }
 
 // WriteFrame writes a length-prefixed message. Returns an error
 // if the payload is empty or exceeds skychatMaxFrameSize.
+//
+// Unbounded — if the underlying net.Conn's Write blocks (peer not
+// draining, transport stuck), the call blocks indefinitely and the
+// caller's request goroutine is wedged. messageHandler uses
+// WriteFrameDeadline below instead so a slow peer can't pin the
+// /message handler forever.
 func (c *framedConn) WriteFrame(payload []byte) error {
 	if len(payload) == 0 {
 		return errors.New("skychat: empty payload")
@@ -89,6 +95,77 @@ func (c *framedConn) WriteFrame(payload []byte) error {
 	}
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) //nolint:gosec
+	if _, err := c.Conn.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := c.Conn.Write(payload)
+	return err
+}
+
+// messageWriteTimeout bounds a single WriteFrame call from the
+// /message HTTP handler. Picked above the typical successful-send
+// latency (low-ms) and below the operator-facing default ack budget
+// (5–10 s), so a slow peer hits the deadline well before the caller
+// gives up on the HTTP request entirely.
+//
+// Pre-fix the chat-app had no per-write deadline anywhere — a peer
+// whose underlying transport stalled (e.g. dmsg session half-dead
+// because the peer's visor was crashlooping) would pin the
+// /message handler's goroutine indefinitely on the inner
+// c.Conn.Write(). The hung handler held c.writeMu, so every
+// subsequent send on the SAME conn queued behind it. Worse,
+// observed cross-peer wedge: a single Beta-send hang at 20:20Z
+// preceded every subsequent /message request — to Alpha, Beta,
+// any peer — timing out at the HTTP context-deadline (~30 s) for
+// hours afterward. Bounding the inner Write lets the handler
+// surface a clean timeout, the writeMu releases, and the next
+// caller's send is freed.
+const messageWriteTimeout = 5 * time.Second
+
+// WriteFrameDeadline is the bounded variant used from
+// messageHandler. Sets a write deadline on the underlying net.Conn
+// for the duration of this Write call, then resets it on the way
+// out — so the deadline scope is exactly the framed write and
+// future calls aren't accidentally pre-expired by a lingering
+// deadline. A net.Conn-level timeout surfaces as an error from
+// Write whose Timeout() method returns true, which the caller can
+// distinguish from a connection-reset or peer-close.
+//
+// timeout must be > 0; pass 0 to fall back to plain WriteFrame
+// (no deadline). The reset uses time.Time{} which net.Conn
+// documents as "no deadline".
+func (c *framedConn) WriteFrameDeadline(payload []byte, timeout time.Duration) error {
+	if timeout <= 0 {
+		return c.WriteFrame(payload)
+	}
+	// Acquire writeMu BEFORE setting the deadline so the deadline
+	// scope tracks the actual on-wire write rather than including
+	// time spent waiting behind a concurrent same-peer writer. If
+	// the wait itself wedges, the caller's HTTP context-deadline
+	// is the outer ceiling.
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	if err := c.Conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+		// SetWriteDeadline failure is rare on a healthy net.Conn;
+		// fall through to a best-effort unbounded write rather
+		// than blocking the message entirely on a metadata error.
+		// Subsequent SetWriteDeadline(time.Time{}) reset on the
+		// way out is also best-effort.
+		_ = err //nolint:errcheck
+	}
+	defer func() {
+		_ = c.Conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
+	}()
+
+	if len(payload) == 0 {
+		return errors.New("skychat: empty payload")
+	}
+	if len(payload) > skychatMaxFrameSize {
+		return fmt.Errorf("skychat: payload %d > max %d", len(payload), skychatMaxFrameSize)
+	}
 	var hdr [4]byte
 	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) //nolint:gosec
 	if _, err := c.Conn.Write(hdr[:]); err != nil {
@@ -950,7 +1027,7 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		// A fresh-dial write failure isn't retried (a second dial
 		// of the same network in the same handler tick won't help).
 		writeStart := time.Now()
-		err := conn.WriteFrame(wirePayload)
+		err := conn.WriteFrameDeadline(wirePayload, messageWriteTimeout)
 		if err != nil && cached {
 			// Stale-conn auto-retry: a cached conn whose underlying
 			// transport has gone stale (peer chat-app restart,
@@ -979,7 +1056,7 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 				http.Error(w, fmt.Sprintf("redial after write %v: %v", err, derr), http.StatusBadRequest)
 				return
 			}
-			if werr := newConn.WriteFrame(wirePayload); werr != nil {
+			if werr := newConn.WriteFrameDeadline(wirePayload, messageWriteTimeout); werr != nil {
 				connsMu.Lock()
 				if conns[pk] == newConn {
 					delete(conns, pk)
@@ -1025,7 +1102,7 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			// the transport / route to the peer on that network.
 			fallbackOK := false
 			if fbConn, fbAddr := tryNetworkFallback(ctx, pk, netType); fbConn != nil {
-				if werr := fbConn.WriteFrame(wirePayload); werr == nil {
+				if werr := fbConn.WriteFrameDeadline(wirePayload, messageWriteTimeout); werr == nil {
 					counterMu.Lock()
 					outboundFallbackCount++
 					counterMu.Unlock()


### PR DESCRIPTION
## Summary

\`messageHandler\` called \`conn.WriteFrame\`, which blocks inside the inner \`c.Conn.Write\` call with no deadline. A peer whose underlying transport stalled — dmsg session half-dead because the peer's visor was crashlooping, slow remote drain, anything — wedged the handler's goroutine. \`c.writeMu\` was held the whole time, so every subsequent send on the same conn queued behind it; observed on 2026-05-17 ~20:20Z, a single Beta-send hang preceded every subsequent \`/message\` (to Alpha, Beta, any peer) timing out at the outer HTTP context deadline (~30 s) for hours.

That symptom directly blocks the operator-stated DM-reliability requirement, so this PR caps the failure mode.

## Fix

New \`framedConn.WriteFrameDeadline(payload, timeout)\`:

1. Acquires \`c.writeMu\` first so the deadline scope tracks the on-wire write, not queue time behind a concurrent same-peer writer.
2. \`SetWriteDeadline(time.Now().Add(timeout))\` on the underlying \`net.Conn\`.
3. Performs the framed write (4-byte BE length + payload).
4. Defers \`SetWriteDeadline(time.Time{})\` reset on the way out so subsequent calls don't inherit an expired deadline.

A timed-out write surfaces as a \`net.Error\` with \`Timeout() == true\`, which the caller can distinguish from a connection reset.

\`messageHandler\` calls \`WriteFrameDeadline\` at all three send sites (cached, redial-after-stale, network-fallback) with \`messageWriteTimeout = 5 s\` — picked above typical successful-send latency (low-ms) and below the operator-facing default ack budget (5–10 s), so a slow peer hits the deadline well before the HTTP caller gives up on the request entirely.

The original \`WriteFrame\` stays in place for internal callers (the ack-write in \`handleConn\`'s read-loop, and the pairing flow) where the unbounded form is correct — those run inside the conn's own read-loop / pairing path, not behind an operator's HTTP request.

## What this does NOT yet diagnose

Why a Beta-send timeout *cascades* into Alpha-send hangs (different cached conn, different read-loop). Likely deeper in the visor's appserver \`Write\` RPC path — needs a goroutine dump from a wedged chat-app to confirm, which I couldn't grab without sudo today. This PR is a defensive ceiling so any future slow-peer event sheds requests cleanly. The next investigation should be a separate issue/PR on the visor appserver Write semantics.

## Tests

\`cmd/apps/skychat/commands/framedconn_writedeadline_test.go\`:

- \`TimesOutOnStalledPeer\` — \`net.Pipe\` to an undrained receiver; \`WriteFrameDeadline\` must return a \`net.Error\` with \`Timeout()==true\` within the bounded window (elapsed >= timeout, elapsed < timeout+500ms).
- \`DeadlineResetForNextCaller\` — TCP loopback; after a deadline-bounded timeout, a follow-up plain \`WriteFrame\` succeeds, proving the \`SetWriteDeadline(zero)\` reset cleared the expired deadline. Skipped gracefully when the loop can't stall the local kernel send buffer (best-effort across kernels).
- \`SetsAndResets\` — portable contract test using a \`recordingConn\` wrapper that records every \`SetWriteDeadline\` argument AND propagates the call to the embedded conn (so the underlying transport's deadline machinery still fires). Asserts \`WriteFrameDeadline\` made \`>=2\` \`SetWriteDeadline\` calls, the first non-zero, the last \`time.Time{}\` (the "no deadline" sentinel).

Verified the tests fail to compile against pre-fix code — the new method is the fix, so the tests are a strict "requires-the-fix" pin.

## Test plan

- [x] \`go test -race -count=1 ./cmd/apps/skychat/...\` clean (commands + group + history + pairing all green)
- [x] \`go vet ./cmd/apps/skychat/...\` clean
- [x] \`gofmt -l\` clean
- [ ] Post-merge: monitor chat-app behavior on prod-Gamma — confirm \`/message\` returns a clean timeout/error rather than hanging the request goroutine when a peer transport stalls.