### PR TITLE
feat(skychat/group): non-admin sub topology — admin-aggregator slice

### DIFF
--- a/cmd/apps/skychat/group/manager.go
+++ b/cmd/apps/skychat/group/manager.go
@@ -447,6 +447,17 @@ func (m *Manager) PromoteAdmin(id string, pk cipher.PubKey) (Record, error) {
 	sess, live := m.sessions[id]
 	m.mu.RUnlock()
 	if live {
+		// Admin-aggregator topology hook (#2685 admin-aggregator
+		// design): the live session's peerSubs depend on the admin
+		// set. A promote means a non-admin member that previously
+		// skipped this peer must now subscribe; an admin member's
+		// set is unchanged but the call is cheap and idempotent.
+		// SetAdminRoster is best-effort — errors are logged at
+		// Debug, the next call will reconcile.
+		if _, sarErr := sess.SetAdminRoster(append([]cipher.PubKey(nil), r.Admins...)); sarErr != nil {
+			m.log.WithError(sarErr).WithField("id", id).WithField("peer", pk.String()).
+				Debug("group: PromoteAdmin: SetAdminRoster failed; live session may be slow to pick up the new admin's feed until next reconnect tick")
+		}
 		if _, err := sess.PublishAdminMutation(AdminOpPromote, pk, 0); err != nil {
 			m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
 				Debug("group: PromoteAdmin: gossip emit failed; local state still consistent")
@@ -506,6 +517,15 @@ func (m *Manager) DemoteAdmin(id string, pk cipher.PubKey) (Record, error) {
 	sess, live := m.sessions[id]
 	m.mu.RUnlock()
 	if live {
+		// Admin-aggregator topology hook (#2685 admin-aggregator
+		// design): a demote means non-admin members must drop the
+		// peerSub to the demoted PK (their leaves no longer reach
+		// non-admins directly — only via the still-admins' republish).
+		// See SetAdminRoster docstring.
+		if _, sarErr := sess.SetAdminRoster(append([]cipher.PubKey(nil), r.Admins...)); sarErr != nil {
+			m.log.WithError(sarErr).WithField("id", id).WithField("peer", pk.String()).
+				Debug("group: DemoteAdmin: SetAdminRoster failed; live session may continue subscribing to the demoted PK until next admin-roster change")
+		}
 		if _, err := sess.PublishAdminMutation(AdminOpDemote, pk, 0); err != nil {
 			m.log.WithError(err).WithField("id", id).WithField("peer", pk.String()).
 				Debug("group: DemoteAdmin: gossip emit failed; local state still consistent")

--- a/cmd/apps/skychat/group/nonadmin_sub_topology_test.go
+++ b/cmd/apps/skychat/group/nonadmin_sub_topology_test.go
@@ -1,0 +1,226 @@
+// Package group — cmd/apps/skychat/group/nonadmin_sub_topology_test.go:
+// pins the admin-aggregator subscription rule (#2685 design) on the
+// pure-function helper that drives openMember + SetAdminRoster. The
+// full Session/CXO integration rides the manual E2E plan (same
+// convention as the rest of the package's tests); these tests cover
+// the role-conditional subscription set in isolation so a refactor
+// can't drift the contract Beta's admin-aggregator publisher depends
+// on.
+//
+// Rule under test:
+//
+//	desired = { pk in Members : pk != myPK AND (r.IsAdmin(myPK) OR r.IsAdmin(pk)) }
+//
+// Admins follow every member; non-admins follow only admins.
+
+package group
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func sortedPKHexes(set map[cipher.PubKey]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for pk := range set {
+		out = append(out, pk.Hex())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedHexList(pks ...cipher.PubKey) []string {
+	out := make([]string, 0, len(pks))
+	for _, pk := range pks {
+		out = append(out, pk.Hex())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestDesiredPeerSubsForRole_AdminFollowsEveryMember(t *testing.T) {
+	// Admin path: when this visor is admin (owner OR in Admins),
+	// the desired set is every non-self member regardless of admin
+	// status. This is the "input pipe" side of the topology — admins
+	// observe every leaf so they can republish for non-admins.
+	owner, _ := cipher.GenerateKeyPair()
+	adminB, _ := cipher.GenerateKeyPair()
+	memberA, _ := cipher.GenerateKeyPair()
+	memberB, _ := cipher.GenerateKeyPair()
+	r := Record{
+		OwnerPK: owner,
+		Admins:  []cipher.PubKey{owner, adminB},
+		Members: []cipher.PubKey{owner, adminB, memberA, memberB},
+	}
+
+	t.Run("owner_sees_all_non_self", func(t *testing.T) {
+		got := desiredPeerSubsForRole(r, owner)
+		want := sortedHexList(adminB, memberA, memberB)
+		if !reflect.DeepEqual(sortedPKHexes(got), want) {
+			t.Errorf("owner desired set: got %v, want %v", sortedPKHexes(got), want)
+		}
+	})
+
+	t.Run("non_owner_admin_sees_all_non_self", func(t *testing.T) {
+		got := desiredPeerSubsForRole(r, adminB)
+		want := sortedHexList(owner, memberA, memberB)
+		if !reflect.DeepEqual(sortedPKHexes(got), want) {
+			t.Errorf("admin-but-not-owner desired set: got %v, want %v", sortedPKHexes(got), want)
+		}
+	})
+}
+
+func TestDesiredPeerSubsForRole_NonAdminFollowsOnlyAdmins(t *testing.T) {
+	// Core admin-aggregator rule: non-admin's desired set is just
+	// the admins. The non-admin's leaves still propagate through
+	// the admin-republish path; the non-admin sees other non-admins'
+	// leaves transitively via any admin's canonical feed.
+	owner, _ := cipher.GenerateKeyPair()
+	adminB, _ := cipher.GenerateKeyPair()
+	memberA, _ := cipher.GenerateKeyPair()
+	memberB, _ := cipher.GenerateKeyPair()
+	r := Record{
+		OwnerPK: owner,
+		Admins:  []cipher.PubKey{owner, adminB},
+		Members: []cipher.PubKey{owner, adminB, memberA, memberB},
+	}
+	got := desiredPeerSubsForRole(r, memberA)
+	want := sortedHexList(owner, adminB)
+	if !reflect.DeepEqual(sortedPKHexes(got), want) {
+		t.Errorf("non-admin desired set: got %v, want %v (admin-aggregator: should be admins only)", sortedPKHexes(got), want)
+	}
+	// Pin the inverse: memberB (the other non-admin) is explicitly
+	// NOT in the set — that's the linear-scaling win.
+	if _, present := got[memberB]; present {
+		t.Errorf("non-admin desired set: includes memberB (another non-admin) — should be admin-only")
+	}
+}
+
+func TestDesiredPeerSubsForRole_OwnerOnly_NoAdmins_BootstrapCase(t *testing.T) {
+	// Group with just an owner + one non-admin member (the
+	// founder-only-admin bootstrap case). Non-admin still gets the
+	// owner since the owner is implicitly admin via IsAdmin's
+	// founder rule, regardless of the explicit Admins slice.
+	owner, _ := cipher.GenerateKeyPair()
+	member, _ := cipher.GenerateKeyPair()
+	r := Record{
+		OwnerPK: owner,
+		Admins:  nil, // EnsureFounderInAdmins not called; founder is implicit
+		Members: []cipher.PubKey{owner, member},
+	}
+	t.Run("owner_desired_set", func(t *testing.T) {
+		got := desiredPeerSubsForRole(r, owner)
+		want := sortedHexList(member)
+		if !reflect.DeepEqual(sortedPKHexes(got), want) {
+			t.Errorf("owner: got %v, want %v", sortedPKHexes(got), want)
+		}
+	})
+	t.Run("member_sees_owner", func(t *testing.T) {
+		got := desiredPeerSubsForRole(r, member)
+		want := sortedHexList(owner)
+		if !reflect.DeepEqual(sortedPKHexes(got), want) {
+			t.Errorf("member: got %v, want %v (non-admin must always see owner via founder-as-implicit-admin)", sortedPKHexes(got), want)
+		}
+	})
+}
+
+func TestDesiredPeerSubsForRole_NeverIncludesSelf(t *testing.T) {
+	// Self is always skipped. Holds across admin/non-admin roles
+	// and across founder-vs-explicit-admin paths.
+	owner, _ := cipher.GenerateKeyPair()
+	adminB, _ := cipher.GenerateKeyPair()
+	memberA, _ := cipher.GenerateKeyPair()
+	r := Record{
+		OwnerPK: owner,
+		Admins:  []cipher.PubKey{owner, adminB},
+		Members: []cipher.PubKey{owner, adminB, memberA},
+	}
+	for _, self := range []cipher.PubKey{owner, adminB, memberA} {
+		got := desiredPeerSubsForRole(r, self)
+		if _, present := got[self]; present {
+			t.Errorf("self (%s) appeared in desired set: %v", self.Hex()[:8], sortedPKHexes(got))
+		}
+	}
+}
+
+func TestDesiredPeerSubsForRole_PromoteFlipsNonAdminToFullMesh(t *testing.T) {
+	// Promote semantic: a non-admin sees only admins; after they're
+	// promoted, they see every non-self member. This is exactly the
+	// case Manager.PromoteAdmin → Session.SetAdminRoster covers at
+	// the live-session layer.
+	owner, _ := cipher.GenerateKeyPair()
+	adminB, _ := cipher.GenerateKeyPair()
+	memberA, _ := cipher.GenerateKeyPair()
+	memberB, _ := cipher.GenerateKeyPair()
+
+	before := Record{
+		OwnerPK: owner,
+		Admins:  []cipher.PubKey{owner, adminB},
+		Members: []cipher.PubKey{owner, adminB, memberA, memberB},
+	}
+	preSet := desiredPeerSubsForRole(before, memberA)
+	if len(preSet) != 2 {
+		t.Fatalf("pre-promote: non-admin desired len = %d, want 2 (admins only)", len(preSet))
+	}
+
+	// Promote memberA.
+	after := before
+	after.Admins = append([]cipher.PubKey(nil), before.Admins...)
+	after.Admins = append(after.Admins, memberA)
+	postSet := desiredPeerSubsForRole(after, memberA)
+	if len(postSet) != 3 {
+		t.Errorf("post-promote: now-admin desired len = %d, want 3 (full mesh non-self)", len(postSet))
+	}
+	if _, present := postSet[memberB]; !present {
+		t.Errorf("post-promote: now-admin should subscribe to memberB (the remaining non-admin) — full-mesh input pipe expected")
+	}
+}
+
+func TestDesiredPeerSubsForRole_DemoteShrinksToAdminsOnly(t *testing.T) {
+	// Demote semantic: an admin sees full mesh; after demotion they
+	// see only the remaining admins. Mirror of the promote test.
+	owner, _ := cipher.GenerateKeyPair()
+	adminB, _ := cipher.GenerateKeyPair()
+	adminC, _ := cipher.GenerateKeyPair()
+	memberA, _ := cipher.GenerateKeyPair()
+
+	before := Record{
+		OwnerPK: owner,
+		Admins:  []cipher.PubKey{owner, adminB, adminC},
+		Members: []cipher.PubKey{owner, adminB, adminC, memberA},
+	}
+	preSet := desiredPeerSubsForRole(before, adminC)
+	if len(preSet) != 3 {
+		t.Fatalf("pre-demote: admin desired len = %d, want 3 (full mesh non-self)", len(preSet))
+	}
+
+	// Demote adminC (the self).
+	after := before
+	after.Admins = []cipher.PubKey{owner, adminB} // adminC dropped
+	postSet := desiredPeerSubsForRole(after, adminC)
+	if len(postSet) != 2 {
+		t.Errorf("post-demote: now-non-admin desired len = %d, want 2 (admins only)", len(postSet))
+	}
+	if _, present := postSet[memberA]; present {
+		t.Errorf("post-demote: now-non-admin should NOT subscribe to memberA (also non-admin) — admin-only expected")
+	}
+}
+
+func TestDesiredPeerSubsForRole_EmptyMembers_EmptyDesired(t *testing.T) {
+	// Degenerate: no members → empty desired set. Guards a
+	// future refactor that might add a default-self-include or
+	// founder-fallback there.
+	owner, _ := cipher.GenerateKeyPair()
+	r := Record{
+		OwnerPK: owner,
+		Admins:  []cipher.PubKey{owner},
+		Members: nil,
+	}
+	got := desiredPeerSubsForRole(r, owner)
+	if len(got) != 0 {
+		t.Errorf("empty-members desired set: got %d entries, want 0 (%v)", len(got), sortedPKHexes(got))
+	}
+}

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -618,6 +618,14 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 	// of the offline member's leaves keeps the message reachable.
 	// onUpdate's dedup set collapses the (primary + N mirror copies)
 	// fan-in to a single delivery per source leaf.
+	//
+	// Admin-aggregator note (#2685 signed leaves): owners are
+	// always admins by the IsAdmin contract, so they always sit on
+	// the "subscribe to every member" side of the new topology.
+	// The non-admin filtering applied in openMember does not apply
+	// here — see openMember for the role-conditional rule, and
+	// SetAdminRoster for the dynamic re-evaluation on PromoteAdmin
+	// / DemoteAdmin.
 	for _, peerPK := range cfg.Record.Members {
 		if peerPK == cfg.MyPK {
 			continue
@@ -745,15 +753,34 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 		dedup:             newRecentSet(inboxDedupCap),
 	}
 
-	// Federated mode: subscribe to every OTHER member's feed,
-	// INCLUDING the owner's. The legacy `sub` field above remains
-	// wired as a backward-compat fallback for owners on pre-federated
-	// binaries, but new owners publish to their own feed just like
-	// every other member — so peerSubs covers them too.
-	for _, peerPK := range cfg.Record.Members {
-		if peerPK == cfg.MyPK {
-			continue
-		}
+	// Admin-aggregator topology (post-#2685 signed leaves):
+	//
+	//   - If THIS visor is an admin (owner OR in Record.Admins), it is
+	//     an input-pipe + republisher: subscribe to every OTHER
+	//     member's feed so we observe every signed leaf and can
+	//     republish it onto our own canonical feed for the
+	//     non-admin members that follow us.
+	//
+	//   - If THIS visor is NOT an admin, subscribe ONLY to admin
+	//     members' canonical feeds. The admins republish every
+	//     signed leaf verbatim, so following them is sufficient to
+	//     see all messages — without paying the quadratic N×N
+	//     subscription cost. Verification is unchanged: Session
+	//     onUpdate runs the leaf-signature check on every leaf
+	//     regardless of which feed it came from, so an admin
+	//     republishing a tampered leaf would be rejected with the
+	//     same error path as a direct peer leaf.
+	//
+	// The legacy `sub` field above stays wired for the owner-relay
+	// fallback path; it subscribes to OwnerPK specifically (the
+	// founder is always an admin by IsAdmin contract), so non-admin
+	// members are always covered for the owner's republished view
+	// even before peerSubs to other admins finish Connect.
+	// desiredPeerSubsForRole encodes the admin-aggregator rule;
+	// see its docstring. Iterating the pure-function output keeps
+	// the openMember vs SetAdminRoster behavior in lockstep.
+	desired := desiredPeerSubsForRole(cfg.Record, cfg.MyPK)
+	for peerPK := range desired {
 		ps, err := treestore.NewSubscriberOnNode(pub.Node(), peerPK, treestore.SubConfig{Logger: log})
 		if err != nil {
 			log.WithError(err).WithField("peer", peerPK.String()).
@@ -1342,6 +1369,141 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 		if err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).
 				Debug("group: SetAllowlist: peer-sub Connect failed; will retry on next reconnect tick")
+		} else if a := s.peerLastInboundNs[pk]; a != nil {
+			a.Store(time.Now().UnixNano())
+		}
+		s.peerSubs[pk] = ps
+	}
+	s.peerSubsMu.Unlock()
+	return evicted, nil
+}
+
+// desiredPeerSubsForRole computes the set of peer PKs this visor
+// should hold per-peer CXO subscriptions for, under the admin-
+// aggregator topology (#2685):
+//
+//	desired = { pk in r.Members : pk != myPK AND (r.IsAdmin(myPK) OR r.IsAdmin(pk)) }
+//
+// Admins follow every member (input pipe + republish). Non-admins
+// follow only admins (the admin canonical feed receives every
+// signed leaf verbatim). The legacy s.sub subscription to OwnerPK
+// is independent of this set; non-admins always have the owner
+// covered via legacy s.sub plus (transitively) via owner-as-admin
+// membership in this set.
+//
+// Pure function: no Session state, no CXO. Used at openMember and
+// SetAdminRoster so the rule has one source of truth.
+func desiredPeerSubsForRole(r Record, myPK cipher.PubKey) map[cipher.PubKey]struct{} {
+	iAmAdmin := r.IsAdmin(myPK)
+	out := make(map[cipher.PubKey]struct{}, len(r.Members))
+	for _, pk := range r.Members {
+		if pk == myPK {
+			continue
+		}
+		if !iAmAdmin && !r.IsAdmin(pk) {
+			continue
+		}
+		out[pk] = struct{}{}
+	}
+	return out
+}
+
+// SetAdminRoster re-evaluates this session's peerSubs against a new
+// admin set under the admin-aggregator topology (#2685). Idempotent
+// add/remove of per-peer subscriptions to match the rule:
+//
+//	desired_set = { pk in Members : pk != MyPK AND (iAmAdmin OR pk in Admins) }
+//
+// Hooks Manager.PromoteAdmin / Manager.DemoteAdmin: when a peer's
+// admin status flips, the live session's input topology must follow
+// or the peer's leaves stop reaching non-admin members. Mirrors
+// SetAllowlist's structure (compute desired, drop removed, add new)
+// and returns the evicted peers so the caller can clean
+// (groupID, peerPK)-keyed state (per-peer reconnect backoff, etc.).
+//
+// admins is the new admin set; cfg.Record.Members is read live so the
+// member-set side of the desired computation reflects whatever the
+// most recent SetAllowlist landed. Founder admin status is implicit
+// — the IsAdmin check uses the union of the founder PK and Admins.
+//
+// Owner-role sessions: this is a no-op because openOwner already
+// subscribes to every non-self member (owners are always admins by
+// IsAdmin contract, so the rule degenerates to "subscribe to all").
+// Member-role admin status can change at runtime; that's the case
+// this function handles.
+//
+// Errors: returns (evicted, error). Connect failures on newly-added
+// peers are logged at Debug and the entry stays in peerSubs — the
+// background reconnect loop picks them up on the next tick. Returns
+// an error only if the session has no node to attach subs to (a
+// torn-down session) or the receiver is nil; per-peer subscriber
+// creation errors are logged + skipped, matching SetAllowlist's
+// best-effort contract.
+func (s *Session) SetAdminRoster(admins []cipher.PubKey) ([]cipher.PubKey, error) {
+	if s == nil || s.pub == nil {
+		return nil, errors.New("group: SetAdminRoster: nil session or no publisher attached")
+	}
+	// Cache the snapshot under cfg.Record.Admins so iAmAdmin /
+	// IsAdmin checks elsewhere (publish path, openOwner doc, etc.)
+	// see the new view too. Founder PK stays where it is on
+	// cfg.Record.OwnerPK; IsAdmin's union semantics handle it.
+	adminSnap := append([]cipher.PubKey(nil), admins...)
+	s.cfg.Record.Admins = adminSnap
+
+	// members snapshot read under membersMu where one exists (owner
+	// role); on member-role sessions the field is nil and we fall
+	// back to cfg.Record.Members which never mutates after Open.
+	// Splice the live snapshot into a temporary Record for the pure
+	// helper — we already mutated cfg.Record.Admins above so the
+	// IsAdmin contract reads the new view.
+	r := s.cfg.Record
+	s.membersMu.RLock()
+	if s.members != nil {
+		r.Members = append([]cipher.PubKey(nil), s.members...)
+	} else {
+		r.Members = append([]cipher.PubKey(nil), s.cfg.Record.Members...)
+	}
+	s.membersMu.RUnlock()
+	desired := desiredPeerSubsForRole(r, s.cfg.MyPK)
+
+	var evicted []cipher.PubKey
+	s.peerSubsMu.Lock()
+	// Drop peers no longer desired — close their subs while still
+	// holding the lock so a racing Connect doesn't pick up a
+	// half-torn sub (same pattern as SetAllowlist).
+	for pk, ps := range s.peerSubs {
+		if _, keep := desired[pk]; !keep {
+			_ = ps.Close() //nolint:errcheck,gosec
+			delete(s.peerSubs, pk)
+			delete(s.peerLastInboundNs, pk)
+			delete(s.peerUpdateCount, pk)
+			evicted = append(evicted, pk)
+		}
+	}
+	// Add newly-desired peers.
+	for pk := range desired {
+		if _, exists := s.peerSubs[pk]; exists {
+			continue
+		}
+		ps, err := treestore.NewSubscriberOnNode(s.pub.Node(), pk, treestore.SubConfig{Logger: s.log})
+		if err != nil {
+			s.log.WithError(err).WithField("peer", pk.String()).
+				Warn("group: SetAdminRoster: peer-sub create failed; will retry on next admin-roster change")
+			continue
+		}
+		ps.SetPrefixes([]string{MessagePathPrefix})
+		s.peerLastInboundNs[pk] = new(atomic.Int64)
+		s.peerUpdateCount[pk] = new(atomic.Uint64)
+		ps.OnUpdate(s.makePeerOnUpdate(pk))
+		// Best-effort connect — same per-peer retry contract as
+		// SetAllowlist. A peer that's offline now will be picked up
+		// on the next reconnect tick once the publisher comes back.
+		dctx, dcancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
+		err = ps.Connect(dctx, pk)
+		dcancel()
+		if err != nil {
+			s.log.WithError(err).WithField("peer", pk.String()).
+				Debug("group: SetAdminRoster: peer-sub Connect failed; will retry on next reconnect tick")
 		} else if a := s.peerLastInboundNs[pk]; a != nil {
 			a.Store(time.Now().UnixNano())
 		}


### PR DESCRIPTION
## Summary

Gamma's slice of the **admin-aggregator** design (operator-approved, post-#2685 signed leaves). Cuts peerSub subscription cost from **quadratic N×N to linear** by having non-admin members subscribe ONLY to admin canonical feeds — admins (who already subscribe to every member as input pipe) republish each signed leaf verbatim onto their own feed for non-admins to consume.

## The rule

\`\`\`
desired = { pk in r.Members : pk != myPK AND (r.IsAdmin(myPK) OR r.IsAdmin(pk)) }
\`\`\`

- Admins follow every non-self member (input pipe + republish).
- Non-admins follow only admin members.
- Self always excluded.

Encoded in a single pure helper \`desiredPeerSubsForRole(r, myPK)\` used by both \`openMember\` and \`SetAdminRoster\` so the rule has one source of truth.

## Files

- \`cmd/apps/skychat/group/session.go\`:
  - \`desiredPeerSubsForRole(r, myPK)\` — pure helper.
  - \`openMember\` — builds initial peerSubs via the helper (replaces inline iteration).
  - \`openOwner\` — unchanged behavior (owners are always admin by \`IsAdmin\` contract); docstring updated to note the symmetry.
  - \`Session.SetAdminRoster(admins)\` — new method, mirrors \`SetAllowlist\`'s shape (compute desired, drop removed, add new, return evicted PKs). Best-effort \`Connect\` on adds; close on removes. Hook for runtime admin-set changes.
- \`cmd/apps/skychat/group/manager.go\`:
  - \`Manager.PromoteAdmin\` / \`Manager.DemoteAdmin\` — call \`SetAdminRoster\` on the live session after \`store.Put\` and before \`PublishAdminMutation\`, so live peerSubs follow the new admin roster without waiting for a reconnect tick.

## Why this is safe

- Verification path unchanged: \`Session.onUpdate\` runs the leaf-signature check on every leaf regardless of which feed it arrived from (#2685). An admin republishing a tampered leaf is rejected by the same code path as a direct peer leaf.
- Legacy \`s.sub\` (subscribed to \`OwnerPK\` specifically) is untouched. Non-admins remain covered for the owner's canonical feed via that path regardless of peerSubs state, so the bootstrap (founder-only-admin) case has no regression.
- \`SetAdminRoster\` is best-effort and idempotent — duplicate calls, races against a closing session, or sub-create failures degrade gracefully (logged at Debug/Warn) without taking the session down.

## Tests

\`cmd/apps/skychat/group/nonadmin_sub_topology_test.go\` — pure-function coverage of \`desiredPeerSubsForRole\`; full CXO/Session integration rides the manual E2E plan (per the package's existing convention — see \`per_peer_backoff_test.go\`'s package doc):

- \`AdminFollowsEveryMember\` — both founder-admin and explicit-admin paths see every non-self member.
- \`NonAdminFollowsOnlyAdmins\` — explicit non-admin only sees admins; other non-admins absent (the linear-scaling win).
- \`OwnerOnly_NoAdmins_BootstrapCase\` — founder-as-implicit-admin: non-admin still sees owner even when \`Record.Admins\` is nil.
- \`NeverIncludesSelf\` — across owner / explicit-admin / non-admin roles.
- \`PromoteFlipsNonAdminToFullMesh\` — simulates \`PromoteAdmin\`'s end-state on the rule.
- \`DemoteShrinksToAdminsOnly\` — simulates \`DemoteAdmin\`'s end-state.
- \`EmptyMembers_EmptyDesired\` — degenerate guard.

Verified the tests fail to compile against pre-fix code (\`desiredPeerSubsForRole\` is the new helper, so the dependency is strict).

## Test plan

- [x] \`go test -race -count=1 -timeout=120s ./cmd/apps/skychat/group/\` clean (existing tests still pass alongside the new ones)
- [x] \`go vet ./cmd/apps/skychat/group/...\` clean
- [x] \`gofmt -l cmd/apps/skychat/group/\` clean
- [ ] Multi-visor 3-agent E2E (rides the planned integration PR after this + Beta's admin-aggregation-publisher slice land)

## Coordination

Pairs with Alpha's #2685 (leaf signatures, merged 20:49Z) and Beta's admin-aggregation-publisher PR (per-peer-feed → own-canonical-feed republish, in flight). All three converge on \`Session.onUpdate\` + \`Session.publishAs\`; line-range conflicts have been kept minimal. The integration PR (Alpha or whoever picks it up) flips defaults + adds the multi-visor test after this + Beta's slice land.