### PR TITLE
feat(skychat/group): switch all 6 Connect call sites to ConnectAndWaitForRoot (#2690 followup)

### DIFF
--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -844,7 +844,7 @@ func (s *Session) Connect(ctx context.Context) error {
 	// goroutine that runs to completion before discarding its result.
 	if s.sub != nil {
 		done := make(chan error, 1)
-		go func() { done <- s.sub.Connect(ctx, s.cfg.Record.OwnerPK) }()
+		go func() { done <- s.sub.ConnectAndWaitForRoot(ctx, s.cfg.Record.OwnerPK) }()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -892,7 +892,7 @@ func (s *Session) Connect(ctx context.Context) error {
 		}
 		done := make(chan error, 1)
 		pkLocal, psLocal := pk, ps
-		go func() { done <- psLocal.Connect(ctx, pkLocal) }()
+		go func() { done <- psLocal.ConnectAndWaitForRoot(ctx, pkLocal) }()
 		select {
 		case <-ctx.Done():
 			// Outer deadline fired mid-Connect. The goroutine will
@@ -1076,7 +1076,7 @@ func (s *Session) ReconnectPeer(ctx context.Context, pk cipher.PubKey) error {
 		return nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- ps.Connect(ctx, pk) }()
+	go func() { done <- ps.ConnectAndWaitForRoot(ctx, pk) }()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1125,7 +1125,7 @@ func (s *Session) ReconnectLegacySub(ctx context.Context) error {
 		return nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- s.sub.Connect(ctx, s.cfg.Record.OwnerPK) }()
+	go func() { done <- s.sub.ConnectAndWaitForRoot(ctx, s.cfg.Record.OwnerPK) }()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1364,7 +1364,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 		// in the allowlist doesn't block roster expansion. The retry
 		// loop will pick it up on a later tick with its own deadline.
 		dctx, dcancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
-		err = ps.Connect(dctx, pk)
+		err = ps.ConnectAndWaitForRoot(dctx, pk)
 		dcancel()
 		if err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).
@@ -1499,7 +1499,7 @@ func (s *Session) SetAdminRoster(admins []cipher.PubKey) ([]cipher.PubKey, error
 		// SetAllowlist. A peer that's offline now will be picked up
 		// on the next reconnect tick once the publisher comes back.
 		dctx, dcancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
-		err = ps.Connect(dctx, pk)
+		err = ps.ConnectAndWaitForRoot(dctx, pk)
 		dcancel()
 		if err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).


### PR DESCRIPTION
## Summary

Closes the Phase-C atomicity gap on the skychat-group call sites. Mechanical replacement of every \`Subscriber.Connect\` call in \`session.go\` with \`Subscriber.ConnectAndWaitForRoot\` (added in #2690):

| Line | Site | Context |
|---|---|---|
| 847 | \`s.sub.Connect\` | legacy owner-feed in \`Session.Connect\` |
| 895 | \`psLocal.Connect\` | peerSub at \`openMember\` per-peer add |
| 1079 | \`ps.Connect\` | peerSub at \`AddMember\` runtime add |
| 1128 | \`s.sub.Connect\` | legacy owner-feed in \`Reconnect\` |
| 1367 | \`ps.Connect\` | peerSub at \`detectStaleAndReconnect\` |
| 1502 | \`ps.Connect\` | peerSub at \`peerSubsReattach\` |

## Why

Pre-fix \`Subscriber.Connect\` returns when the subscribe-frame is queued, NOT when the first Root for the feed has been filled. \`session.go\`'s reconnect machinery bumped \`peer_last_inbound\` on Connect-success and treated the subscription as live, masking the half-attached state in production telemetry. Group info would show \`sub_alive=true\` + \`peer_update_count=0\` — exactly the 2026-05-17 21:10Z live-test failure across **all three agents**.

The atomic API waits for \`handleRootFilled\` before returning. After this swap, a successful Connect implies the publisher's current Root has actually landed on this subscriber's CXO node — so the liveness bookkeeping reflects reality and any post-Connect publish is reachable via the same subscribe state machine that just verified.

## Ctx deadlines unchanged

Per #2623, every call site already passes a deadlined context (\`reconnectAttemptTimeout\`). \`ConnectAndWaitForRoot\` honors the same deadline for the root-observation wait — no caller-side change needed beyond the function-name swap.

## Coordination

Pairs with:
- **#2690** (Alpha — \`ConnectAndWaitForRoot\` foundation) — merged
- **#2691** (Beta — repro scaffolding, DRAFT) — Gamma's follow-up assertion-helper commit lands the property assertion that flips from FAIL on pre-swap develop to PASS on this commit

Together the three PRs deliver the operator-mandated CI regression coverage for the peerSub OnUpdate-not-firing class.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./cmd/apps/skychat/group/...\` clean
- [x] \`go test ./cmd/apps/skychat/group/ -count=1\` passes (existing tests still green)
- [ ] Once Gamma's assertions land on #2691, verify the property test flips from FAIL on develop to PASS on this branch
- [ ] Live 3-agent test post-deploy (after Beta+Gamma deploy this commit) — expect \`peer_update_count[peer]\` to advance and \`deliver_count\` to increment by the full burst size