### PR TITLE
test(skychat/pairing): pair-level CXO replay-on-reconnect baseline (operator reset, phase A)

### DIFF
--- a/cmd/apps/skychat/pairing/baseline_test.go
+++ b/cmd/apps/skychat/pairing/baseline_test.go
@@ -1,0 +1,235 @@
+// Package pairing — cmd/apps/skychat/pairing/baseline_test.go:
+// baseline tests for 1:1 pair DMs (operator reset directive
+// 2026-05-17T22:53Z, Phase A).
+//
+// TestPairRoundTripOverDmsg (integration_test.go) already proves the
+// happy path: publisher + subscriber on dmsgtest, send-then-receive
+// in both directions, ciphertext-at-rest, allowlist enforcement.
+// This file adds the COVERAGE GAPS the operator's reset surfaced:
+//
+//   1. Reconnect after close. The production failure mode all three
+//      agents hit on 2026-05-17 21:10Z: a subscriber closes (visor
+//      restart, session reopen, network blip), reattaches via fresh
+//      Connect, and silently misses messages published in the gap.
+//      Pair-level test should be the first place this regression
+//      shows up — pairs are 1:1, no admin/topology in the way.
+//
+//   2. CXO replay value-prop. The operator's "what does CXO solve
+//      vs. what does it cost" question. CXO's claim is that a
+//      re-subscribing peer catches up on the publisher's history
+//      that landed during the gap, without needing per-message
+//      retry logic in the chat-app. The test below proves that
+//      claim or falsifies it.
+//
+// Built on integration_test.go's helpers (testInbox, waitDmsgReady,
+// connectWithRetry pattern) — keeps this file focused on the new
+// scenarios.
+package pairing
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// pairTestRig collects the per-side state two-pair tests need. The
+// methods on this type isolate the dmsgtest + Manager + Pair wiring
+// so the actual test bodies stay focused on the scenario under test.
+type pairTestRig struct {
+	env *dmsgtest.Env
+
+	mgrA, mgrB     *Manager
+	pairA, pairB   *Pair
+	inboxA, inboxB *testInbox
+	pkA, pkB       cipher.PubKey
+}
+
+// newPairTestRig spins up a 1-server / 2-client dmsg env, brings up
+// a pairing.Manager on each side with shared PK/SK pairs (mirroring
+// the visor wiring), and registers handlers BEFORE Add so the very
+// first Root the subscribers see gets surfaced. Returns a rig ready
+// for the test to drive Connect / Send / Close lifecycle.
+func newPairTestRig(t *testing.T) *pairTestRig {
+	t.Helper()
+
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, skB := cipher.GenerateKeyPair()
+
+	env := dmsgtest.NewEnv(t, dmsgtest.DefaultTimeout)
+	env.Discovery()
+	require.NoError(t, env.Startup(dmsgtest.DefaultTimeout, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+
+	dmsgA, err := env.NewClientWithKeys(pkA, skA, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	dmsgB, err := env.NewClientWithKeys(pkB, skB, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	waitDmsgReady(t, dmsgA, 10*time.Second)
+	waitDmsgReady(t, dmsgB, 10*time.Second)
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	storeA, err := OpenStore(filepath.Join(dirA, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeA.Close() }) //nolint:errcheck
+	storeB, err := OpenStore(filepath.Join(dirB, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeB.Close() }) //nolint:errcheck
+
+	mgrA, err := NewManager(ManagerConfig{
+		Store:   storeA,
+		DmsgC:   dmsgA,
+		MyPK:    pkA,
+		MySK:    skA,
+		DataDir: filepath.Join(dirA, "cxo"),
+		Logger:  logging.MustGetLogger("pair-A"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgrA.Close() }) //nolint:errcheck
+	mgrB, err := NewManager(ManagerConfig{
+		Store:   storeB,
+		DmsgC:   dmsgB,
+		MyPK:    pkB,
+		MySK:    skB,
+		DataDir: filepath.Join(dirB, "cxo"),
+		Logger:  logging.MustGetLogger("pair-B"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgrB.Close() }) //nolint:errcheck
+
+	inboxA := newTestInbox()
+	inboxB := newTestInbox()
+	mgrA.SetMessageHandler(inboxA.deliver)
+	mgrB.SetMessageHandler(inboxB.deliver)
+
+	pairA, err := mgrA.Add(pkB)
+	require.NoError(t, err)
+	pairB, err := mgrB.Add(pkA)
+	require.NoError(t, err)
+
+	connectWithRetry(t, pairA)
+	connectWithRetry(t, pairB)
+
+	return &pairTestRig{
+		env:    env,
+		mgrA:   mgrA,
+		mgrB:   mgrB,
+		pairA:  pairA,
+		pairB:  pairB,
+		inboxA: inboxA,
+		inboxB: inboxB,
+		pkA:    pkA,
+		pkB:    pkB,
+	}
+}
+
+// connectWithRetry mirrors integration_test.go's local helper: dmsg
+// dials on a fresh server can transiently fail under CI load when
+// the session table is briefly saturated. 10 attempts with linear
+// backoff is plenty for the in-process env.
+func connectWithRetry(t *testing.T, p *Pair) {
+	t.Helper()
+	var lastErr error
+	for attempt := 0; attempt < 10; attempt++ {
+		if err := p.Connect(context.Background()); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+		time.Sleep(time.Duration(200+attempt*100) * time.Millisecond)
+	}
+	t.Fatalf("pairing connect retries exhausted: %v", lastErr)
+}
+
+// TestPairReceivesMessagesPublishedDuringSubscriberGap is the
+// pair-level analog of the bug all three agents hit on 2026-05-17:
+// a subscriber drops (visor restart / session reopen / dmsg blip),
+// the publisher continues publishing while subscriber-less, then
+// the subscriber comes back. The question this test answers: does
+// CXO's publisher-side state plus re-subscribe handshake actually
+// deliver the gap-window messages, or does the receive cascade
+// silently lose them?
+//
+// If the test PASSES, the pair-level CXO replay is sound — any
+// production loss must be at a higher layer (multi-publisher
+// federation, reconnect bookkeeping, etc.). If the test FAILS,
+// even the simplest CXO use case is unreliable on reconnect and
+// every higher-layer fix is building on sand.
+func TestPairReceivesMessagesPublishedDuringSubscriberGap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; skipped under -short")
+	}
+	rig := newPairTestRig(t)
+
+	// Phase 1: prove the connected baseline. A sends, B receives.
+	const helloAB = "phase-1-baseline"
+	require.NoError(t, rig.pairA.Send(helloAB))
+	require.NoError(t, rig.inboxB.waitFor(20*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == rig.pkA && m.text == helloAB {
+				return true
+			}
+		}
+		return false
+	}), "baseline send before gap must arrive")
+
+	// Phase 2: B drops its pair entirely (the closest analog to a
+	// visor restart at the pair level). Manager.Remove tears down
+	// the subscriber + publisher and clears the persistent record;
+	// the test then re-Adds. Anything A publishes between Remove
+	// and the second Add lands in A's CXDS but has no subscriber to
+	// fan out to.
+	require.NoError(t, rig.mgrB.Remove(rig.pkA))
+
+	const duringGapAB = "phase-2-during-gap"
+	require.NoError(t, rig.pairA.Send(duringGapAB))
+
+	// Brief grace so A's publisher actually commits the leaf to its
+	// CXDS before B reconnects. Without this the test would
+	// accidentally exercise the publish-and-subscribe-arrive
+	// concurrently path, which is a different scenario.
+	time.Sleep(500 * time.Millisecond)
+
+	// Phase 3: B re-creates the pair from scratch. The new pair
+	// holds a fresh subscriber to A's feed; CXO's claim is that the
+	// initial sync delivers A's existing leaves (including the
+	// during-gap one) to B's onUpdate.
+	pairB2, err := rig.mgrB.Add(rig.pkA)
+	require.NoError(t, err)
+	connectWithRetry(t, pairB2)
+
+	// The pre-restart message must arrive. If this assertion fails,
+	// CXO replay-on-reconnect at the pair level is broken — a
+	// foundational regression worth a stop-the-world fix before any
+	// other comms work.
+	require.NoError(t, rig.inboxB.waitFor(20*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == rig.pkA && m.text == duringGapAB {
+				return true
+			}
+		}
+		return false
+	}), "after re-Add, B must receive the during-gap message via CXO replay")
+
+	// Phase 4: a fresh post-reconnect send still works. Distinguishes
+	// "replay delivered the old message but the new subscriber is
+	// dead going forward" from a healthy reconnect.
+	const postReconnectAB = "phase-4-post-reconnect"
+	require.NoError(t, rig.pairA.Send(postReconnectAB))
+	require.NoError(t, rig.inboxB.waitFor(20*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == rig.pkA && m.text == postReconnectAB {
+				return true
+			}
+		}
+		return false
+	}), "post-reconnect live send must arrive on the re-Added pair")
+}

--- a/cmd/apps/skychat/pairing/baseline_test.go
+++ b/cmd/apps/skychat/pairing/baseline_test.go
@@ -28,6 +28,7 @@ package pairing
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -233,3 +234,72 @@ func TestPairReceivesMessagesPublishedDuringSubscriberGap(t *testing.T) {
 		return false
 	}), "post-reconnect live send must arrive on the re-Added pair")
 }
+
+// TestPairSendAfterCloseReturnsClosedError exercises an error
+// surface gap surfaced by the operator's reset: pre-fix, calling
+// Send after Close nil-deref'd on p.pub.Put because Close set p.pub
+// = nil without guarding subsequent operations. The fix lifts the
+// failure into a clean sentinel error (ErrPairClosed) callers can
+// branch on via errors.Is — matches every other "this resource is
+// gone" error pattern in skywire and gives a meaningful surface to
+// the --verbose flag Alpha's #2693 wires up.
+func TestPairSendAfterCloseReturnsClosedError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; skipped under -short")
+	}
+	rig := newPairTestRig(t)
+
+	// Sanity: a healthy Send works before Close.
+	require.NoError(t, rig.pairA.Send("pre-close"))
+
+	// Close the pair. mgrA.Remove tears down both publisher and
+	// subscriber and nils them out internally.
+	require.NoError(t, rig.mgrA.Remove(rig.pkB))
+
+	// The Pair pointer the test still holds is now closed. Send
+	// MUST return ErrPairClosed, not panic.
+	err := rig.pairA.Send("post-close")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPairClosed,
+		"Send after Close must return ErrPairClosed, got: %v", err)
+}
+
+// TestPairConnectAfterCloseReturnsClosedError mirrors the Send case
+// for the Connect side: Close nils p.sub; a later Connect would
+// nil-deref. Same fix shape: explicit guard + ErrPairClosed.
+func TestPairConnectAfterCloseReturnsClosedError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; skipped under -short")
+	}
+	rig := newPairTestRig(t)
+
+	// Close pairA's underlying pair via the manager. The cached
+	// rig.pairA pointer now references a closed Pair.
+	require.NoError(t, rig.mgrA.Remove(rig.pkB))
+
+	err := rig.pairA.Connect(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPairClosed,
+		"Connect after Close must return ErrPairClosed, got: %v", err)
+}
+
+// TestPairCloseIsIdempotent confirms the documented "Close may be
+// called multiple times safely" contract still holds after the
+// nil-guard additions. Defensive: a future refactor that adds state
+// to the close path could break this without a test.
+func TestPairCloseIsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; skipped under -short")
+	}
+	rig := newPairTestRig(t)
+
+	require.NoError(t, rig.pairA.Close())
+	// Second Close must not panic and must return nil — there's
+	// nothing left to tear down.
+	require.NoError(t, rig.pairA.Close())
+}
+
+// errPairClosedSatisfiesErrorsIs is a compile-time check that the
+// sentinel is reachable from this test package — guards against a
+// future rename moving ErrPairClosed out of the public surface.
+var errPairClosedSatisfiesErrorsIs = errors.Is(ErrPairClosed, ErrPairClosed)

--- a/cmd/apps/skychat/pairing/baseline_test.go
+++ b/cmd/apps/skychat/pairing/baseline_test.go
@@ -7,19 +7,19 @@
 // in both directions, ciphertext-at-rest, allowlist enforcement.
 // This file adds the COVERAGE GAPS the operator's reset surfaced:
 //
-//   1. Reconnect after close. The production failure mode all three
-//      agents hit on 2026-05-17 21:10Z: a subscriber closes (visor
-//      restart, session reopen, network blip), reattaches via fresh
-//      Connect, and silently misses messages published in the gap.
-//      Pair-level test should be the first place this regression
-//      shows up — pairs are 1:1, no admin/topology in the way.
+//  1. Reconnect after close. The production failure mode all three
+//     agents hit on 2026-05-17 21:10Z: a subscriber closes (visor
+//     restart, session reopen, network blip), reattaches via fresh
+//     Connect, and silently misses messages published in the gap.
+//     Pair-level test should be the first place this regression
+//     shows up — pairs are 1:1, no admin/topology in the way.
 //
-//   2. CXO replay value-prop. The operator's "what does CXO solve
-//      vs. what does it cost" question. CXO's claim is that a
-//      re-subscribing peer catches up on the publisher's history
-//      that landed during the gap, without needing per-message
-//      retry logic in the chat-app. The test below proves that
-//      claim or falsifies it.
+//  2. CXO replay value-prop. The operator's "what does CXO solve
+//     vs. what does it cost" question. CXO's claim is that a
+//     re-subscribing peer catches up on the publisher's history
+//     that landed during the gap, without needing per-message
+//     retry logic in the chat-app. The test below proves that
+//     claim or falsifies it.
 //
 // Built on integration_test.go's helpers (testInbox, waitDmsgReady,
 // connectWithRetry pattern) — keeps this file focused on the new

--- a/cmd/apps/skychat/pairing/pair.go
+++ b/cmd/apps/skychat/pairing/pair.go
@@ -179,7 +179,13 @@ func Open(cfg Config) (*Pair, error) {
 // Open + Connect are split so the pairing handshake can stage the
 // publisher before the peer is known to be ready, then activate the
 // inbound side once the peer's pair-ack arrives.
+//
+// Returns ErrPairClosed if Close has already torn down the
+// subscriber. Pre-fix this nil-deref'd on p.sub.Connect.
 func (p *Pair) Connect(ctx context.Context) error {
+	if p.sub == nil {
+		return ErrPairClosed
+	}
 	if err := p.sub.Connect(ctx, p.cfg.PeerPK); err != nil {
 		return fmt.Errorf("pairing: Connect: %w", err)
 	}
@@ -202,6 +208,13 @@ func (p *Pair) SetMessageHandler(h MessageHandler) {
 	p.handler = h
 }
 
+// ErrPairClosed is returned by Send / Connect when the pair has
+// already been Closed. Surfaces the post-close state as a clean
+// error instead of a nil-pointer panic on p.pub / p.sub. Sentinel
+// so callers can distinguish closed-pair from transient publisher
+// errors via errors.Is(err, ErrPairClosed).
+var ErrPairClosed = errors.New("pairing: pair is closed")
+
 // Send publishes a message to this side's outbox feed. The peer's
 // subscriber will see it on the next CXO publish-batch cycle.
 //
@@ -209,7 +222,13 @@ func (p *Pair) SetMessageHandler(h MessageHandler) {
 // before being stored as the leaf value, so anyone who breaches
 // the publisher allowlist still cannot read message content.
 // The path itself (timestamp + seq) stays plaintext.
+//
+// Returns ErrPairClosed if Close has already torn down the
+// publisher. Pre-fix this nil-deref'd on p.pub.Put.
 func (p *Pair) Send(text string) error {
+	if p.pub == nil {
+		return ErrPairClosed
+	}
 	now := time.Now().UTC()
 	msg := Message{Text: text, TS: now}
 	body, err := json.Marshal(msg)


### PR DESCRIPTION
## Summary

Operator reset directive 2026-05-17T22:53Z: stop building federated CXO group features until baseline behavior at simpler layers is verified. This PR is **Phase A** of the reset plan — the 1:1 pair (simplest CXO use): one publisher, one subscriber, no admin layer, no multi-writer fan-in.

Two scopes packaged together (separate commits):

### Commit 1 — baseline replay-on-reconnect test

`TestPairRoundTripOverDmsg` (already in `integration_test.go`) proves the happy path. This PR adds the coverage gap the reset surfaced — the production failure mode all three agents observed on 2026-05-17 21:10Z (peerSub re-attach silently losing messages):

`TestPairReceivesMessagesPublishedDuringSubscriberGap` — four-phase reconnect cycle in-process via `dmsgtest`:
1. **Connected baseline** — A sends, B receives.
2. **Gap** — B drops its pair entirely (Manager.Remove). A continues publishing while subscriber-less.
3. **Reconnect + replay** — B re-Adds. CXO's claim: initial sync delivers the during-gap leaf. **Load-bearing assertion.**
4. **Post-reconnect live send** — A sends again, B receives.

**PASSES on develop** (3/3 stable under `-count=3`). The pair-level CXO replay is sound. Any production loss observed today must be at a higher layer (multi-publisher federation, reconnect bookkeeping mismatch) — not in the foundational publish/subscribe pipeline.

### Commit 2 — ErrPairClosed sentinel + nil-guards

Two real bugs surfaced by the Phase A exploration:
- `Send` after `Close` → nil-panic (Close sets `p.pub = nil`; Send didn't guard)
- `Connect` after `Close` → same shape

Adds `ErrPairClosed` sentinel + nil-guards on both. Matches every other "this resource is gone" pattern in skywire. Gives Alpha's `--verbose` CLI surface (#2693) a meaningful symbol for operator-facing diagnostics.

Three regression tests added:
- `TestPairSendAfterCloseReturnsClosedError`
- `TestPairConnectAfterCloseReturnsClosedError`
- `TestPairCloseIsIdempotent`

## Reusable rig

Helpers extracted to a `pairTestRig` type so Phase C (Gamma's mesh-group baseline) and Phase 1 (Gamma's CXO-backed DM comparison) can build on the same dmsgtest + Manager wiring without re-copying.

## Out-of-scope here

- Pair-level `Connect → ConnectAndWaitForRoot` swap — surfaced a deadlock when tried, filed as issue #2696 (atomic-API needs an empty-Root-on-Open fix to work at the pair layer).
- `--verbose` CLI surface — Alpha's #2693.
- Phase 1 CXO comparison — Gamma's upcoming PR.

## Test plan

- [x] `go test ./cmd/apps/skychat/pairing/ -count=3 -timeout 240s` — all tests pass
- [x] `go vet`, `ineffassign` clean
- [x] No new dependencies
- [x] ErrPairClosed reachable via `errors.Is` from external callers
- [ ] Operator: run `go test ./cmd/apps/skychat/pairing/ -count=1 -v` locally to verify the baseline + error-path coverage before Phase B/C/D scoping