### PR TITLE
fix(skychat/pairing): clear lint issues from #2694 + #2697 baseline tests

### DIFF
--- a/cmd/apps/skychat/pairing/baseline_test.go
+++ b/cmd/apps/skychat/pairing/baseline_test.go
@@ -299,7 +299,9 @@ func TestPairCloseIsIdempotent(t *testing.T) {
 	require.NoError(t, rig.pairA.Close())
 }
 
-// errPairClosedSatisfiesErrorsIs is a compile-time check that the
-// sentinel is reachable from this test package — guards against a
-// future rename moving ErrPairClosed out of the public surface.
-var errPairClosedSatisfiesErrorsIs = errors.Is(ErrPairClosed, ErrPairClosed)
+// Compile-time check that the sentinel is reachable from this test
+// package — guards against a future rename moving ErrPairClosed
+// out of the public surface. Anonymous to avoid an unused-var
+// flag from the linter while still failing the build if the
+// symbol disappears.
+var _ = errors.Is(ErrPairClosed, ErrPairClosed)

--- a/cmd/apps/skychat/pairing/integration_test.go
+++ b/cmd/apps/skychat/pairing/integration_test.go
@@ -159,7 +159,11 @@ func TestPairRoundTripOverDmsg(t *testing.T) {
 	}))
 }
 
-func waitDmsgReady(t *testing.T, c *dmsg.Client, timeout time.Duration) {
+// waitDmsgReady blocks until c.Ready() fires or the supplied
+// timeout elapses (then t.Fatal). All current callers pass 10s;
+// the parameter is retained so an outlier slower-network case can
+// override without adding a second helper.
+func waitDmsgReady(t *testing.T, c *dmsg.Client, timeout time.Duration) { //nolint:unparam
 	t.Helper()
 	select {
 	case <-c.Ready():


### PR DESCRIPTION
## Summary

CI lint on develop fails on two pre-existing issues introduced by today's baseline-test PRs:

\`\`\`
cmd/apps/skychat/pairing/baseline_test.go:305    unused: var errPairClosedSatisfiesErrorsIs
cmd/apps/skychat/pairing/integration_test.go:162 unparam: waitDmsgReady - timeout always 10s
\`\`\`

Fixes:
- Anonymize the compile-time \`errors.Is\` check (\`var _ = …\`) — keeps the "symbol reachable from this package" guard while letting the linter see the call site
- Add \`//nolint:unparam\` on \`waitDmsgReady\` with a one-line rationale so the helper doesn't have to be split for callers that need a longer wait later

Caught when my #2699 PR's CI failed on these pre-existing issues after rebasing. Both fixes are pure hygiene — no semantic change.

## Test plan
- [x] \`go test ./cmd/apps/skychat/pairing/...\` passes
- [x] \`golangci-lint run ./cmd/apps/skychat/pairing/...\` 0 issues