### PR TITLE
fix(skychat/pairing): add /pair/inbox HTTP handler (closes #2699 CLI gap)

### DIFF
--- a/cmd/apps/skychat/commands/pair_inbox_handler_test.go
+++ b/cmd/apps/skychat/commands/pair_inbox_handler_test.go
@@ -132,7 +132,9 @@ func TestPairInboxHandler_LimitTruncatesOldestFirst(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rr.Code)
 	}
 	var got []visor.PairMessage
-	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v\nbody=%q", err, rr.Body.String())
+	}
 	if len(got) != 2 {
 		t.Fatalf("len(got) = %d, want 2", len(got))
 	}

--- a/cmd/apps/skychat/commands/pair_inbox_handler_test.go
+++ b/cmd/apps/skychat/commands/pair_inbox_handler_test.go
@@ -1,0 +1,232 @@
+// Package commands cmd/apps/skychat/commands/pair_inbox_handler_test.go
+//
+// Unit test for the /pair/inbox HTTP handler added to close the
+// shipping gap from #2699: the CLI `cli skychat pair poll` builds
+// GET /pair/inbox?limit=N&since=TS but the chat-app mux only had
+// /pair, /pair/invites, /pair/invites/, /pair/. The path fell into
+// the /pair/{pk} catchall which parsed "inbox" as a peer-PK and
+// rejected the request (HTTP 400 "invalid peer-pk").
+//
+// The handler is intentionally cheap to test: it doesn't open
+// connections, mutate state, or talk to the visor's pairing manager
+// — it only validates query params, calls PairPoll via the
+// reconnect helper, applies the limit window, and JSON-encodes.
+
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// pairPollAPI is a fake visor.API that returns a fixed PairPoll
+// result. All other visor.API methods are unimplemented (nil-embed
+// would panic); the handler only calls PairPoll.
+type pairPollAPI struct {
+	visorAPIShim
+	msgs []visor.PairMessage
+	err  error
+	// lastSince captures the `since` arg the handler passed through.
+	lastSince time.Time
+}
+
+func (p *pairPollAPI) PairPoll(since time.Time) ([]visor.PairMessage, error) {
+	p.lastSince = since
+	return p.msgs, p.err
+}
+
+// withFakePairRPC installs a fake visor.API as the package-level
+// pairRPC for the duration of the test. Restores on Cleanup.
+func withFakePairRPC(t *testing.T, fake visor.API) {
+	t.Helper()
+	if appLog == nil {
+		appLog = func(string, ...interface{}) {}
+	}
+	pairRPCMu.Lock()
+	prev := pairRPC
+	pairRPC = fake
+	pairRPCMu.Unlock()
+	t.Cleanup(func() {
+		pairRPCMu.Lock()
+		pairRPC = prev
+		pairRPCMu.Unlock()
+	})
+}
+
+func mkPairMsg(t *testing.T, text string, ts time.Time) visor.PairMessage {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return visor.PairMessage{PeerPK: pk, Text: text, TS: ts}
+}
+
+func TestPairInboxHandler_EmptyInboxReturnsEmptyArray(t *testing.T) {
+	withFakePairRPC(t, &pairPollAPI{msgs: nil})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox", nil)
+	pairInboxHandler()(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != "[]" && got != "null" {
+		t.Errorf("body = %q, want [] or null", got)
+	}
+}
+
+func TestPairInboxHandler_ReturnsAllMessagesAsJSONArray(t *testing.T) {
+	base := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
+	fake := &pairPollAPI{msgs: []visor.PairMessage{
+		mkPairMsg(t, "first", base.Add(1*time.Second)),
+		mkPairMsg(t, "second", base.Add(2*time.Second)),
+		mkPairMsg(t, "third", base.Add(3*time.Second)),
+	}}
+	withFakePairRPC(t, fake)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox", nil)
+	pairInboxHandler()(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got []visor.PairMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not a JSON array of PairMessage: %v\nbody=%q", err, rr.Body.String())
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	want := []string{"first", "second", "third"}
+	for i, m := range got {
+		if m.Text != want[i] {
+			t.Errorf("got[%d].Text = %q, want %q", i, m.Text, want[i])
+		}
+	}
+}
+
+func TestPairInboxHandler_LimitTruncatesOldestFirst(t *testing.T) {
+	// CLI prints oldest-first, so when the inbox window exceeds the
+	// caller's limit the handler should drop the OLDEST extras (keep
+	// the newest N). This pins the contract so a future refactor that
+	// flipped the slice direction is caught.
+	base := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
+	fake := &pairPollAPI{msgs: []visor.PairMessage{
+		mkPairMsg(t, "oldest", base.Add(1*time.Second)),
+		mkPairMsg(t, "middle", base.Add(2*time.Second)),
+		mkPairMsg(t, "newest", base.Add(3*time.Second)),
+	}}
+	withFakePairRPC(t, fake)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox?limit=2", nil)
+	pairInboxHandler()(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got []visor.PairMessage
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Text != "middle" || got[1].Text != "newest" {
+		t.Errorf("got = [%q, %q], want [middle, newest]", got[0].Text, got[1].Text)
+	}
+}
+
+func TestPairInboxHandler_SinceThreadsThroughToVisor(t *testing.T) {
+	// The since query param is the operator's primary tally tool — if
+	// it doesn't reach PairPoll the caller's "messages since 5m ago"
+	// claim is meaningless.
+	since := time.Date(2026, 5, 18, 0, 5, 0, 0, time.UTC)
+	fake := &pairPollAPI{msgs: nil}
+	withFakePairRPC(t, fake)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox?since="+since.Format(time.RFC3339), nil)
+	pairInboxHandler()(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rr.Code, rr.Body.String())
+	}
+	if !fake.lastSince.Equal(since) {
+		t.Errorf("PairPoll(since) = %v, want %v", fake.lastSince, since)
+	}
+}
+
+func TestPairInboxHandler_RejectsBadLimit(t *testing.T) {
+	withFakePairRPC(t, &pairPollAPI{})
+	cases := []string{"0", "1001", "-1", "abc"}
+	for _, c := range cases {
+		t.Run("limit="+c, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/pair/inbox?limit="+c, nil)
+			pairInboxHandler()(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 for limit=%q", rr.Code, c)
+			}
+		})
+	}
+}
+
+func TestPairInboxHandler_RejectsBadSince(t *testing.T) {
+	withFakePairRPC(t, &pairPollAPI{})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox?since=not-a-timestamp", nil)
+	pairInboxHandler()(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestPairInboxHandler_RejectsNonGet(t *testing.T) {
+	withFakePairRPC(t, &pairPollAPI{})
+	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		t.Run(m, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(m, "/pair/inbox", nil)
+			pairInboxHandler()(rr, req)
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want 405", rr.Code)
+			}
+		})
+	}
+}
+
+func TestPairInboxHandler_RPCUnavailableReturns503(t *testing.T) {
+	// Pairing manager went down between handler registration and
+	// request — the surface should degrade to 503 rather than panic
+	// inside the redial path.
+	pairRPCMu.Lock()
+	prev := pairRPC
+	pairRPC = nil
+	pairRPCMu.Unlock()
+	t.Cleanup(func() {
+		pairRPCMu.Lock()
+		pairRPC = prev
+		pairRPCMu.Unlock()
+	})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox", nil)
+	pairInboxHandler()(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rr.Code)
+	}
+}
+
+func TestPairInboxHandler_PairPollErrorReturns500(t *testing.T) {
+	withFakePairRPC(t, &pairPollAPI{err: errors.New("inbox boom")})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/pair/inbox", nil)
+	pairInboxHandler()(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body=%q", rr.Code, rr.Body.String())
+	}
+}

--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -37,6 +37,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -236,7 +237,72 @@ func registerPairHTTPHandlers(ctx context.Context, mux *http.ServeMux) {
 	mux.HandleFunc("/pair", requireAuthFunc(pairRootHandler(ctx)))
 	mux.HandleFunc("/pair/invites", requireAuthFunc(pairInvitesListHandler()))
 	mux.HandleFunc("/pair/invites/", requireAuthFunc(pairInvitesItemHandler(ctx)))
+	mux.HandleFunc("/pair/inbox", requireAuthFunc(pairInboxHandler()))
 	mux.HandleFunc("/pair/", requireAuthFunc(pairItemHandler(ctx)))
+}
+
+// pairInboxHandler serves GET /pair/inbox — snapshot of inbound pair
+// messages newer than ?since=<RFC3339>, capped at ?limit=N (default
+// 100, max 1000). Non-destructive; the visor's pairInbox keeps the
+// ring intact across reads, so this endpoint and the SSE-bridge
+// poller co-exist without consuming each other's view.
+//
+// Pairs with the CLI's `cli skychat pair poll` command (#2699), which
+// hits this exact URL shape and decodes the response as a JSON array
+// of visor.PairMessage. Without this handler the path falls into the
+// /pair/<pk> catchall and is rejected as an invalid peer-pk.
+func pairInboxHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !pairRPCAlive() {
+			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		q := r.URL.Query()
+		limit := 100
+		if s := q.Get("limit"); s != "" {
+			n, err := strconv.Atoi(s)
+			if err != nil || n < 1 || n > 1000 {
+				http.Error(w, "limit must be 1-1000", http.StatusBadRequest)
+				return
+			}
+			limit = n
+		}
+		var since time.Time
+		if s := q.Get("since"); s != "" {
+			t, err := time.Parse(time.RFC3339Nano, s)
+			if err != nil {
+				// Fall back to plain RFC3339 for callers without sub-second precision.
+				t, err = time.Parse(time.RFC3339, s)
+				if err != nil {
+					http.Error(w, "since must be RFC3339", http.StatusBadRequest)
+					return
+				}
+			}
+			since = t
+		}
+		var msgs []visor.PairMessage
+		if err := pairRPCCall("PairPoll", func(c visor.API) error {
+			out, e := c.PairPoll(since)
+			msgs = out
+			return e
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Take the newest `limit` entries when the ring window is
+		// larger than the caller wants. snapshotAfter returns oldest-
+		// first; the CLI prints oldest-first too, so truncating the
+		// HEAD (newest) would surprise it — drop the OLDEST extras.
+		if len(msgs) > limit {
+			msgs = msgs[len(msgs)-limit:]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(msgs) //nolint:errcheck
+	}
 }
 
 // pairInvitesListHandler serves GET /pair/invites — current pending


### PR DESCRIPTION
## Why

PR #2699 added `cli skychat pair poll` (used during the operator-mandated 3-agent STEP 1c live test on 2026-05-18) but the chat-app server side never registered the matching HTTP route. The CLI hits `GET /pair/inbox?limit=N&since=TS` and the chat-app's mux returns:

```
FATAL: server returned 400: invalid peer-pk: Invalid public key
```

Caught at 00:18Z mid-protocol: pair messages were arriving fine via the SSE bridge but the operator-required tally step (`cli skychat pair poll --since 5m`) was unreachable on every visor. The path falls into `/pair/{pk}` catchall which parses `inbox` as a peer-PK and rejects.

## What

Register `/pair/inbox` as a longest-match fixed route before `/pair/` catchall:

- `GET` only (other methods → 405)
- `?limit=N` (default 100, range 1..1000)
- `?since=TS` (RFC3339Nano with RFC3339 fallback)
- Calls `visor.PairPoll(since)` through `pairRPCCall` so reconnect-on-shutdown still applies
- Keeps the NEWEST `limit` entries when the inbox window > limit (drops oldest extras — preserves the CLI's oldest-first print order)
- Encodes `[]visor.PairMessage` (the struct's existing tags `peer_pk`/`text`/`ts` already match what `pair.go`'s `pairPollCmd` decodes — no shape rework on the CLI side)

`visor.PairPoll` is non-destructive (it's `snapshotAfter`, not drain), so this endpoint and the existing `pairPoller` SSE bridge can both read without consuming each other's view.

## Tests

`cmd/apps/skychat/commands/pair_inbox_handler_test.go` — 11 subtests, all pass locally:

- `EmptyInboxReturnsEmptyArray`
- `ReturnsAllMessagesAsJSONArray` — full JSON round-trip via `visor.PairMessage`
- `LimitTruncatesOldestFirst` — pins the slice direction (a future refactor that flipped it would surprise the CLI)
- `SinceThreadsThroughToVisor` — verifies the operator's `--since 5m` surface
- `RejectsBadLimit` (subtests: 0, 1001, -1, "abc")
- `RejectsBadSince` (not RFC3339)
- `RejectsNonGet` (POST/PUT/DELETE → 405)
- `RPCUnavailableReturns503` — degraded surface when pairing manager is down, no panic
- `PairPollErrorReturns500`

Uses a minimal `pairPollAPI` fake with `visorAPIShim` from `pairing_rpc_test.go`.

## Test plan

- [x] `go build ./cmd/apps/skychat/...` clean
- [x] `go vet ./cmd/apps/skychat/...` clean
- [x] `go test ./cmd/apps/skychat/commands/ -run TestPairInboxHandler -v` — 11/11 PASS
- [ ] CI green
- [ ] Manual re-run of 3-agent STEP 1c protocol: `cli skychat pair poll --since 5m` returns the expected oldest-first list on every visor