### PR TITLE
fix(cxo/node): synchronize OnRootFilled/OnFillingBreaks callback access (unblocks CI)

### DIFF
--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -62,6 +62,14 @@ type Node struct {
 	maxFillingParallel int     // copy of c.Config().MaxFillingParallel
 	rollAvgSamples     int     //nolint:unused // copy of c.Config().RollAvgSamples
 
+	// callbackMu guards the mutable callback fields on config that
+	// pkg/cxo/treestore's Subscriber chains onto post-construction
+	// (OnRootFilled, OnFillingBreaks). Without it, the close-and-
+	// reopen pattern (subscriber.Close + NewSubscriberOnNode again)
+	// races with the head goroutine's onRootFilled read — surfaced
+	// by treestore TestPeerSubMissesAfterReattach under -race.
+	callbackMu sync.RWMutex
+
 	//
 	// stat
 	//
@@ -706,18 +714,46 @@ func (n *Node) onRootReceived(c *Conn, r *registry.Root) (err error) {
 
 func (n *Node) onRootFilled(r *registry.Root) {
 
-	if orf := n.config.OnRootFilled; orf != nil {
+	n.callbackMu.RLock()
+	orf := n.config.OnRootFilled
+	n.callbackMu.RUnlock()
+	if orf != nil {
 		orf(n, r)
 	}
 
 }
 
+// SwapOnRootFilled atomically replaces the OnRootFilled callback and
+// returns the previous value. Used by pkg/cxo/treestore's Subscriber
+// to chain its handler in front of any pre-existing one without
+// racing the head goroutine's read at onRootFilled.
+func (n *Node) SwapOnRootFilled(next func(*Node, *registry.Root)) (prev func(*Node, *registry.Root)) {
+	n.callbackMu.Lock()
+	defer n.callbackMu.Unlock()
+	prev = n.config.OnRootFilled
+	n.config.OnRootFilled = next
+	return prev
+}
+
 func (n *Node) onFillingBreaks(r *registry.Root, reason error) {
 
-	if brk := n.config.OnFillingBreaks; brk != nil {
+	n.callbackMu.RLock()
+	brk := n.config.OnFillingBreaks
+	n.callbackMu.RUnlock()
+	if brk != nil {
 		brk(n, r, reason)
 	}
 
+}
+
+// SwapOnFillingBreaks atomically replaces the OnFillingBreaks callback
+// and returns the previous value. Mirror of SwapOnRootFilled.
+func (n *Node) SwapOnFillingBreaks(next func(*Node, *registry.Root, error)) (prev func(*Node, *registry.Root, error)) {
+	n.callbackMu.Lock()
+	defer n.callbackMu.Unlock()
+	prev = n.config.OnFillingBreaks
+	n.config.OnFillingBreaks = next
+	return prev
 }
 
 // has connection to peer with given id (pk)

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -154,12 +154,16 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 		rootObservedSignal: make(chan struct{}),
 	}
 
-	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
+	// Use Swap helpers (synchronized) instead of direct Config()
+	// mutation. The single-subscriber-per-node case still races with
+	// the head goroutine's onRootFilled reader without sync — exposed
+	// by treestore TestPeerSubMissesAfterReattach.
+	cxoNode.SwapOnRootFilled(func(_ *node.Node, r *registry.Root) {
 		s.handleRootFilled(r)
-	}
-	cxoNode.Config().OnFillingBreaks = func(_ *node.Node, r *registry.Root, err error) {
+	})
+	cxoNode.SwapOnFillingBreaks(func(_ *node.Node, r *registry.Root, err error) {
 		s.handleFillingBreaks(r, err)
-	}
+	})
 	return s, nil
 }
 
@@ -189,20 +193,26 @@ func NewSubscriberOnNode(cxoNode *node.Node, feedPK cipher.PubKey, conf SubConfi
 		cache:              make(map[string][]byte),
 		rootObservedSignal: make(chan struct{}),
 	}
-	prev := cxoNode.Config().OnRootFilled
-	cxoNode.Config().OnRootFilled = func(n *node.Node, r *registry.Root) {
+	// SwapOnRootFilled / SwapOnFillingBreaks are atomic under
+	// callbackMu, so a re-attach (Close then NewSubscriberOnNode)
+	// doesn't race with the head goroutine's read at onRootFilled.
+	// Pre-fix: TestPeerSubMissesAfterReattach surfaced the race
+	// (treestore/peersub_reattach_test.go:337 re-attach call vs
+	// node.go onRootFilled at the same instant).
+	var prev func(*node.Node, *registry.Root)
+	prev = cxoNode.SwapOnRootFilled(func(n *node.Node, r *registry.Root) {
 		s.handleRootFilled(r)
 		if prev != nil {
 			prev(n, r)
 		}
-	}
-	prevFB := cxoNode.Config().OnFillingBreaks
-	cxoNode.Config().OnFillingBreaks = func(n *node.Node, r *registry.Root, err error) {
+	})
+	var prevFB func(*node.Node, *registry.Root, error)
+	prevFB = cxoNode.SwapOnFillingBreaks(func(n *node.Node, r *registry.Root, err error) {
 		s.handleFillingBreaks(r, err)
 		if prevFB != nil {
 			prevFB(n, r, err)
 		}
-	}
+	})
 	return s, nil
 }
 


### PR DESCRIPTION
## Why — blocking every PR

`TestPeerSubMissesAfterReattach` (merged via #2691) fails on linux + windows under `-race`:

```
WARNING: DATA RACE
Write at subscriber.go:193  (NewSubscriberOnNode → cxoNode.Config().OnRootFilled = ...)
Read  at node.go:709        (background head goroutine onRootFilled)
```

The race lives in `pkg/cxo/treestore/subscriber.go`, not the test scaffold — `Subscriber` chains onto `Node.config` callbacks post-construction without synchronization. First-attach is racy only in theory (node just constructed); **re-attach** surfaces it in practice because close→reopen overlaps in-flight head goroutines reading `Config().OnRootFilled`.

CI on every PR now runs with `-race`, so this **blocks all merges** until landed.

## What

- `pkg/cxo/node`: add `Node.callbackMu sync.RWMutex`. Wrap `onRootFilled` / `onFillingBreaks` read accessors with `RLock`. Expose `SwapOnRootFilled` / `SwapOnFillingBreaks` helpers that take `Lock`, swap, and return the previous handler in one atomic step.
- `pkg/cxo/treestore/subscriber.go`: `NewSubscriber` + `NewSubscriberOnNode` use `Swap*` helpers instead of direct `Config().OnXxx = ...` writes.

Scope is **just the two callbacks the Subscriber re-attach path mutates**. `OnRootReceived` / `OnSubscribeRemote` / `OnUnsubscribeRemote` / `OnConnect` / `OnDisconnect` are also mutable but currently only the aggregator sets them once at startup; if a future caller wires them post-construction the same Swap pattern can be extended.

## Verification

```
$ go test -race -run TestPeerSubMissesAfterReattach ./pkg/cxo/treestore/
ok  github.com/skycoin/skywire/pkg/cxo/treestore  4.726s

$ go test -race ./pkg/cxo/treestore/
ok  github.com/skycoin/skywire/pkg/cxo/treestore 21.268s

$ go test -race ./pkg/cxo/node/
ok  github.com/skycoin/skywire/pkg/cxo/node       5.920s
```

## Test plan

- [x] Race detector clean on the formerly-failing test
- [x] Full `pkg/cxo/treestore/` + `pkg/cxo/node/` test suites pass with `-race`
- [ ] CI green
- [ ] After merge: my #2702 (independent, pair/inbox handler) can finally pass its CI

## Discovery context

Caught at 00:55Z while reviewing why CI on #2702 (an unrelated chat-app HTTP handler PR) failed on linux + windows. The static-musl + darwin jobs (no `-race`) were green; only the `-race` runners surfaced it.