### PR TITLE
fix(cxo/skyobject): DelRoot walk best-effort on ErrNotFound (#2678 root cause, TPD leak fix)

### DIFF
--- a/pkg/cxo/skyobject/index.go
+++ b/pkg/cxo/skyobject/index.go
@@ -924,6 +924,25 @@ func (i *Index) delPackWalkFunc(
 		// if it will be deleted by the -1
 
 		if val, rc, err = i.c.getNoCache(hash, -1); err != nil {
+			// Best-effort decrement (#2678 root-cause fix). The
+			// previous shape returned the error here, which made
+			// walkRoot abort the entire tree-walk on the first
+			// missing hash. In practice that's a sibling/sub-tree
+			// already swept by an earlier RemoveObjects pass — the
+			// orphaned-bytes signature the production TPD leak
+			// reported: every undecremented sibling stays at
+			// rc>=1 forever, and no later cleanup retries because
+			// the parent seq has been removed from idx.
+			//
+			// Swallow ErrNotFound: the missing hash has nothing
+			// for us to decrement, but the rest of the tree still
+			// does. Any non-NotFound error (real DB failure)
+			// continues to bubble up — those are bugs we want
+			// loud.
+			if errors.Is(err, data.ErrNotFound) {
+				err = nil
+				return deepper, err
+			}
 			return deepper, err
 		}
 


### PR DESCRIPTION
## Summary

Closes the root cause behind issue #2678 — the TPD CXDS-bytes-keep-climbing leak that hit production twice (this morning's snapshot shows ~896 MB resident, 85% in \`cipher/encoder.Serialize\` from \`registry.(*Refs).AppendValues\` — same signature as the 2026-05-17 incident at 1.08 GB, dampened only by PR #2677's backstop).

## The bug

\`Index.DelRoot\` is non-atomic by design: \`delRootLock\` removes the seq from IdxDB first, then \`delRootRelatedValues\` walks the tree decrementing rc on every referenced object. The walk uses \`getNoCache(hash, -1)\` per object.

Pre-fix: when \`getNoCache\` reported a hash was missing (already swept by an earlier RemoveObjects pass — entirely possible since cleanup runs continuously), the walkFunc returned \`data.ErrNotFound\` up to \`walkRoot\`. walkRoot's only error-swallow is \`registry.ErrStopIteration\`; anything else aborts the entire tree-walk.

Net effect: every sibling and descendant of the missing-hash node stayed un-decremented. Their rc never reached zero, so the \`rc==0\` sweep in RemoveObjects couldn't collect them. Combined with the IdxDB removal that already happened in step 1, the parent seq was gone from idx — \`RemoveRootObjects\` on the next cleanup tick saw ErrNotFound for that seq and skipped it. **The orphaned bytes lived forever.**

This is exactly what the production heap signature reported: 762 MB of \`encoder.Serialize\` allocations, all reachable through \`Refs.AppendValues\` from earlier feed publishes, with no live root referencing them.

## The fix

Swallow \`data.ErrNotFound\` in the walkFunc. The hash being missing means there's nothing for us to decrement at that key — but the rest of the tree still has live references that need their rc dropped. Continue the walk.

\`\`\`go
if val, rc, err = i.c.getNoCache(hash, -1); err != nil {
    if errors.Is(err, data.ErrNotFound) {
        err = nil
        return deepper, err
    }
    return deepper, err  // real DB failure — still bubble up loud
}
\`\`\`

19 lines added (most are the explanatory comment). Pure semantic narrowing: pre-fix every error aborted the walk; post-fix only real DB failures abort, the expected-NotFound case is recovered.

## Why this won't make things worse

The "best-effort" framing isn't a loosening — it's a correctness fix. The walk's goal is "decrement every referenced object's rc by 1." A missing object can't be decremented (it has nothing to decrement), but that's the desired terminal state, not an error condition for THAT particular hash. The error was incidental to the missing-hash case; this PR distinguishes the two.

## Relationship to other PRs / issues

- #2677 — cxoutils-layer backstop (RemoveRootObjects partial-walk recovery + 10-min forced sweep). Dampened leak rate, didn't fix the source. Stays in place; complementary.
- #2678 — issue this closes. The "Proposed fix" section there describes exactly this change.
- #2446 — earlier blank-hash guard in the same walkFunc (kept). Different sub-case (Ref.Sub zero-value), same shape of "don't let a non-error condition look like an error to walkRoot."

## Test plan

- [x] \`go test ./pkg/cxo/skyobject/... -count=1\` passes
- [x] \`go test ./pkg/cxo/cxoutils/... -count=1\` passes (the existing partial-walk regression test from #2677 still green; this PR strengthens that guarantee at a lower layer)
- [x] \`make format\` clean
- [x] \`go vet\` clean
- [ ] Operator-side validation: re-pull TPD heap pprof 24h after deploy; expect \`Refs.AppendValues\` retention to drop substantially (steady-state should be O(transports × snapshot-size) ~tens of MB, not hundreds)

Closes #2678.