### PR TITLE
feat(skychat): noise-TCP direct transport — listener, peer dialer, CLI --via

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -574,6 +574,13 @@ func init() {
 	RootCmd.Flags().BoolVar(&pairEnable, "pair-enable", false, "enable per-partner CXO pair feeds (HTTP /pair endpoints + handshake)")
 	RootCmd.Flags().StringVar(&pairRPCAddr, "pair-rpc", "localhost:3435", "visor RPC address used by the pair manager")
 	RootCmd.Flags().DurationVar(&pairPollInterval, "pair-poll-interval", time.Second, "how often skychat drains the visor's pair-message inbox onto the SSE stream")
+
+	// TCP-direct entry points — see tcp_direct.go. Defaults disabled.
+	RootCmd.Flags().StringVar(&tcpListen, "tcp-listen", "", "accept noise-XK on TCP (e.g. ':8800'); requires --tcp-whitelist + an identity (--sk/-c/env). Bidirectional once established.")
+	RootCmd.Flags().StringSliceVar(&tcpPeers, "tcp-peer", nil, "persistent outbound TCP-direct peer: tcp://<pk>@host:port (repeat for many). For NAT-side hosts that dial out to public-IP peers.")
+	RootCmd.Flags().StringVar(&tcpWhitelist, "tcp-whitelist", "", "comma-separated peer PKs allowed to connect via --tcp-listen (empty rejects all)")
+	RootCmd.Flags().StringVar(&tcpSKFlag, "sk", "", "identity SK for TCP-direct (hex). Overrides env + config.")
+	RootCmd.Flags().StringVarP(&tcpConfigPath, "config", "c", "", "path to skywire.json — only the sk field is read, for TCP-direct identity")
 }
 
 // RootCmd is the root command for skywire-cli
@@ -626,6 +633,13 @@ func RunSkychat(ctx context.Context, args []string) error {
 		fs.BoolVar(&pairEnable, "pair-enable", false, "enable per-partner CXO pair feeds")
 		fs.StringVar(&pairRPCAddr, "pair-rpc", "localhost:3435", "visor RPC address for pair manager")
 		fs.DurationVar(&pairPollInterval, "pair-poll-interval", time.Second, "pair inbox poll interval")
+		// TCP-direct flags must be parseable in the visor-launched
+		// path too — visor passes args verbatim from skywire.json.
+		fs.StringVar(&tcpListen, "tcp-listen", "", "TCP-direct listen addr")
+		fs.StringSliceVar(&tcpPeers, "tcp-peer", nil, "tcp://<pk>@host:port (repeatable)")
+		fs.StringVar(&tcpWhitelist, "tcp-whitelist", "", "comma-separated allowed peer PKs")
+		fs.StringVar(&tcpSKFlag, "sk", "", "TCP-direct identity SK (hex)")
+		fs.StringVarP(&tcpConfigPath, "config", "c", "", "skywire.json path for SK")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -676,7 +690,14 @@ func RunSkychat(ctx context.Context, args []string) error {
 	if useDmsg {
 		go listenLoop(appnet.TypeDmsg, port)
 	}
-	if !useSkynet && !useDmsg {
+	// TCP-direct entry point — independent of useSkynet/useDmsg.
+	// Operator opts in via --tcp-listen / --tcp-peer; nil-effect
+	// when both are empty so existing visor-managed setups are
+	// unaffected. See tcp_direct.go for the accept/dial loops.
+	if err := startTCPDirect(ctx); err != nil {
+		appLog("skychat: tcp-direct startup failed: %v — continuing with dmsg/skynet only", err)
+	}
+	if !useSkynet && !useDmsg && tcpListen == "" && len(tcpPeers) == 0 {
 		appLog("Warning: no network types enabled, skychat will not accept connections")
 	}
 

--- a/cmd/apps/skychat/commands/tcp_direct.go
+++ b/cmd/apps/skychat/commands/tcp_direct.go
@@ -1,0 +1,411 @@
+// Package commands — cmd/apps/skychat/commands/tcp_direct.go:
+// chat-app's noise-TCP entry points, the reliability-floor transport
+// described in #2706. Same noise-XK primitive dmsgpty uses, applied
+// to chat frames so agents can reach each other when dmsg-disc /
+// skynet / visor itself is misbehaving.
+//
+// Two halves:
+//
+//  1. --tcp-listen :PORT — accept noise-XK on TCP, wrap the
+//     resulting conn so chat-app's existing handleConn loop (which
+//     expects appnet.Addr on RemoteAddr) can consume it unchanged.
+//
+//  2. --tcp-peer tcp://<pk>@host:port (repeatable) — maintain a
+//     persistent outbound dial per listed peer. Reconnect with
+//     exponential backoff. Lets agents behind NAT reach
+//     public-IP peers and HAVE A BIDIRECTIONAL channel: once the
+//     handshake completes, the listener side can write back over
+//     the same socket. Operator only port-forwards on the public
+//     side; NAT side runs --tcp-peer only.
+//
+// Identity comes from the chat-app's --sk / -c / DMSGCURL_SK
+// resolution chain (skychat.go owns those flags). Whitelist (the
+// chat-app's existing --tcp-whitelist set) gates incoming peers
+// the same way dmsgpty's whitelist does — empty list rejects all,
+// which is fail-safe.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire/tcpnoise"
+)
+
+// osGetenv exists only to make the resolveTCPIdentity test path
+// hookable later without pulling in os everywhere. Today it's a
+// pass-through to os.Getenv.
+func osGetenv(k string) string { return os.Getenv(k) }
+
+// readSKFromConfig reads the "sk" field from a JSON file in
+// skywire.json's shape. The visor's config has many other fields;
+// we tolerate them and only consume sk. Returns a clear error if
+// the file is missing, isn't JSON, or has no sk field.
+func readSKFromConfig(path string) (cipher.SecKey, error) {
+	var zero cipher.SecKey
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return zero, fmt.Errorf("read %s: %w", path, err)
+	}
+	var conf struct {
+		SK string `json:"sk"`
+	}
+	if err := json.Unmarshal(data, &conf); err != nil {
+		return zero, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if conf.SK == "" {
+		return zero, fmt.Errorf("%s has no sk field", path)
+	}
+	var sk cipher.SecKey
+	if err := sk.Set(conf.SK); err != nil {
+		return zero, fmt.Errorf("%s sk: %w", path, err)
+	}
+	return sk, nil
+}
+
+// tcpReconnectMin / tcpReconnectMax bound the outbound-dial backoff.
+// Mirrors the reconnect cadence the SSE listener uses; long enough
+// that a permanently-unreachable peer doesn't burn CPU.
+const (
+	tcpReconnectMin = 1 * time.Second
+	tcpReconnectMax = 60 * time.Second
+)
+
+// Flag-backed vars owned by the chat-app's flag registration in
+// skychat.go. Default zero values mean "TCP-direct disabled" —
+// the chat-app only spawns the TCP loops when an operator opts
+// in. Keeping these here (rather than in skychat.go's catch-all
+// var block) keeps the tcp-direct surface visibly separable so
+// future #2706 work that promotes the pattern across other apps
+// can lift this file into a shared package wholesale.
+var (
+	tcpListen     string   // --tcp-listen :PORT  (empty disables)
+	tcpPeers      []string // --tcp-peer  tcp://<pk>@host:port  (repeatable)
+	tcpWhitelist  string   // --tcp-whitelist <pk>,<pk>  (REQUIRED if --tcp-listen)
+	tcpSKFlag     string   // --sk <hex>  (overrides config / env / ephemeral)
+	tcpConfigPath string   // -c / --config <path>  (reads SK from skywire.json)
+)
+
+// tcpDirectConn wraps a tcpnoise.Conn so RemoteAddr() returns an
+// appnet.Addr — chat-app's existing handleConn does a type assertion
+// to appnet.Addr on the addr; satisfying that contract here lets us
+// reuse the entire frame-handler + counter + persistence path
+// without per-transport branches.
+type tcpDirectConn struct {
+	net.Conn // tcpnoise.Conn — passes through LocalAddr/Close/etc
+	rPK      cipher.PubKey
+}
+
+// RemoteAddr returns the noise-learned PK wrapped in appnet.Addr
+// shape so handleConn's `conn.RemoteAddr().(appnet.Addr)` succeeds.
+// Net=TypeTCPDirect surfaces in SSE events as the network field so
+// operators can see which transport carried each inbound message.
+func (c *tcpDirectConn) RemoteAddr() net.Addr {
+	return appnet.Addr{Net: appnet.TypeTCPDirect, PubKey: c.rPK}
+}
+
+// parseTCPPeerSpec turns "tcp://<66-hex-pk>@host:port" into its
+// components. Same shape as dmsgpty's --via tcp://; centralized so
+// errors are consistent. Returns ErrTCPPeerBadShape on any
+// formatting failure with the offending input echoed back.
+func parseTCPPeerSpec(spec string) (cipher.PubKey, string, error) {
+	const prefix = "tcp://"
+	if !strings.HasPrefix(spec, prefix) {
+		return cipher.PubKey{}, "", fmt.Errorf("tcp-peer: must start with %q: %s", prefix, spec)
+	}
+	rest := strings.TrimPrefix(spec, prefix)
+	at := strings.IndexByte(rest, '@')
+	if at <= 0 || at == len(rest)-1 {
+		return cipher.PubKey{}, "", fmt.Errorf("tcp-peer: missing @ separator in %q", spec)
+	}
+	pkHex := rest[:at]
+	addr := rest[at+1:]
+	var pk cipher.PubKey
+	if err := pk.Set(pkHex); err != nil {
+		return cipher.PubKey{}, "", fmt.Errorf("tcp-peer: invalid pk %q: %w", pkHex, err)
+	}
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		return cipher.PubKey{}, "", fmt.Errorf("tcp-peer: invalid host:port %q: %w", addr, err)
+	}
+	return pk, addr, nil
+}
+
+// runTCPListen spawns the accept loop on tcpListenAddr. Each
+// accepted conn runs the noise XK handshake (responder side),
+// gets its peer-PK authorized against the chat-app's whitelist
+// (when set), and then enters the standard handleConn path —
+// identical to the dmsg / skynet accept paths in skychat.go.
+//
+// localPK / localSK is the chat-app's identity; tcpWhitelist (set
+// when len > 0) is the per-PK accept list. Empty whitelist rejects
+// all incoming peers — fail-safe for misconfiguration.
+//
+// Returns when the listener errors or ctx is canceled.
+func runTCPListen(
+	ctx context.Context,
+	listenAddr string,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+	whitelist map[cipher.PubKey]struct{},
+) error {
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("tcp-listen %s: %w", listenAddr, err)
+	}
+	appLog("skychat: tcp-direct listening on %s", listenAddr)
+	go func() {
+		<-ctx.Done()
+		_ = lis.Close() //nolint:errcheck
+	}()
+
+	for {
+		raw, err := lis.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+				return nil
+			}
+			appLog("skychat: tcp-direct Accept: %v", err)
+			return err
+		}
+		go acceptTCPConn(raw, localPK, localSK, whitelist)
+	}
+}
+
+// acceptTCPConn runs the noise handshake on a single accepted TCP
+// conn, authorizes the learned PK against the whitelist, registers
+// the conn in the chat-app's conns map keyed by PK, and kicks off
+// handleConn. Mirrors the dmsg-accept flow in skychat.go's listen
+// loop — kept here so the tcp-specific bookkeeping (raw close on
+// reject, the wrapper for appnet.Addr-style RemoteAddr) doesn't
+// pollute the dmsg path.
+func acceptTCPConn(
+	raw net.Conn,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+	whitelist map[cipher.PubKey]struct{},
+) {
+	wrapped, rPK, err := tcpnoise.Accept(raw, localPK, localSK)
+	if err != nil {
+		appLog("skychat: tcp-direct handshake failed from %s: %v", raw.RemoteAddr(), err)
+		return
+	}
+	// Whitelist gate. Empty whitelist = reject all (the chat-app
+	// must be explicitly configured to accept). This matches
+	// dmsgpty's host_tcp.go behavior.
+	if len(whitelist) == 0 {
+		appLog("skychat: tcp-direct rejecting %s: no whitelist configured", rPK)
+		_ = wrapped.Close() //nolint:errcheck
+		return
+	}
+	if _, ok := whitelist[rPK]; !ok {
+		appLog("skychat: tcp-direct rejecting %s: not on whitelist", rPK)
+		_ = wrapped.Close() //nolint:errcheck
+		return
+	}
+
+	tdc := &tcpDirectConn{Conn: wrapped, rPK: rPK}
+	fc := newFramedConn(tdc)
+	connsMu.Lock()
+	conns[rPK] = fc
+	connsMu.Unlock()
+	appLog("skychat: tcp-direct conn accepted from %s", rPK)
+	handleConn(fc)
+}
+
+// runTCPPeerDialers spawns one persistent-dial goroutine per
+// --tcp-peer spec. Each goroutine maintains a single outbound
+// conn, redials on disconnect with exponential backoff. Existing
+// conn slot in the conns map is left to the natural handleConn
+// teardown path — we don't pre-evict because a slow peer might
+// still be live just slow.
+//
+// Returns immediately; goroutines run for the chat-app's lifetime.
+func runTCPPeerDialers(
+	ctx context.Context,
+	peers []string,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+) {
+	for _, spec := range peers {
+		pk, addr, err := parseTCPPeerSpec(spec)
+		if err != nil {
+			appLog("skychat: tcp-peer skipping bad spec %q: %v", spec, err)
+			continue
+		}
+		go peerDialLoop(ctx, pk, addr, localPK, localSK)
+	}
+}
+
+// peerDialLoop is the persistent-outbound state machine for a single
+// --tcp-peer. Dial → handshake → register → handleConn (blocks
+// until peer disconnect) → backoff → repeat. Backoff resets on
+// successful handshake so a flapping peer can recover quickly once
+// it stabilizes; long-down peers ride the cap.
+func peerDialLoop(
+	ctx context.Context,
+	rPK cipher.PubKey,
+	addr string,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+) {
+	backoff := tcpReconnectMin
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		dialCtx, cancel := context.WithTimeout(ctx, tcpnoise.DialTimeout+tcpnoise.HandshakeTimeout)
+		conn, err := tcpnoise.Dial(dialCtx, addr, localPK, localSK, rPK)
+		cancel()
+		if err != nil {
+			appLog("skychat: tcp-peer dial %s@%s failed: %v (backoff %s)", rPK, addr, err, backoff)
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return
+			}
+			backoff *= 2
+			if backoff > tcpReconnectMax {
+				backoff = tcpReconnectMax
+			}
+			continue
+		}
+		// Successful dial — reset backoff so any subsequent disconnect
+		// retries quickly before extending the gap.
+		backoff = tcpReconnectMin
+
+		tdc := &tcpDirectConn{Conn: conn, rPK: rPK}
+		fc := newFramedConn(tdc)
+		connsMu.Lock()
+		// If a prior conn (from accept side OR a previous loop iter)
+		// is still registered, supersede it. The old framedConn's
+		// handleConn will exit naturally on its next ReadFrame.
+		conns[rPK] = fc
+		connsMu.Unlock()
+		appLog("skychat: tcp-peer connected to %s@%s", rPK, addr)
+		// handleConn blocks until the peer disconnects (ReadFrame
+		// error). On return we'll loop and redial.
+		handleConn(fc)
+		appLog("skychat: tcp-peer disconnected from %s@%s", rPK, addr)
+	}
+}
+
+// resolveTCPIdentity returns the SK + derived PK used as this
+// chat-app's identity for noise XK. Resolution order, first hit
+// wins:
+//
+//  1. --sk SECKEY                     (explicit override)
+//  2. DMSGCURL_SK env                 (operator convention)
+//  3. -c / --config PATH              (read SK field from skywire.json)
+//  4. fail loudly                     (TCP-direct REQUIRES a stable
+//     identity; ephemeral noise PKs
+//     defeat the trust model)
+//
+// Called once at chat-app startup from startTCPDirect; SK material
+// is not held beyond what tcpnoise.Dial / Accept need on the call
+// stack.
+func resolveTCPIdentity() (cipher.PubKey, cipher.SecKey, string, error) {
+	var zero cipher.SecKey
+	if tcpSKFlag != "" {
+		var sk cipher.SecKey
+		if err := sk.Set(tcpSKFlag); err != nil {
+			return cipher.PubKey{}, zero, "", fmt.Errorf("--sk: %w", err)
+		}
+		pk, err := sk.PubKey()
+		if err != nil {
+			return cipher.PubKey{}, zero, "", fmt.Errorf("--sk: derive pk: %w", err)
+		}
+		return pk, sk, "flag", nil
+	}
+	if env := osGetenv("DMSGCURL_SK"); env != "" {
+		var sk cipher.SecKey
+		if err := sk.Set(env); err == nil {
+			pk, err := sk.PubKey()
+			if err == nil {
+				return pk, sk, "env", nil
+			}
+		}
+	}
+	if tcpConfigPath != "" {
+		sk, err := readSKFromConfig(tcpConfigPath)
+		if err != nil {
+			return cipher.PubKey{}, zero, "", fmt.Errorf("-c %s: %w", tcpConfigPath, err)
+		}
+		pk, err := sk.PubKey()
+		if err != nil {
+			return cipher.PubKey{}, zero, "", fmt.Errorf("-c %s: derive pk: %w", tcpConfigPath, err)
+		}
+		return pk, sk, "config", nil
+	}
+	return cipher.PubKey{}, zero, "", errors.New(
+		"TCP-direct enabled but no identity configured " +
+			"(set --sk, DMSGCURL_SK env, or -c /path/to/skywire.json)")
+}
+
+// startTCPDirect is the chat-app's TCP-direct entry point. Wired
+// from RunSkychat AFTER the dmsg/skynet listenLoops are spawned, so
+// the conns map is initialized. Spawns the accept loop (when
+// --tcp-listen set) and the per-peer dial loops (when --tcp-peer set)
+// using the resolved identity. Returns early with nil when neither
+// flag is set — TCP-direct is fully opt-in.
+func startTCPDirect(ctx context.Context) error {
+	if tcpListen == "" && len(tcpPeers) == 0 {
+		return nil
+	}
+	pk, sk, source, err := resolveTCPIdentity()
+	if err != nil {
+		return fmt.Errorf("tcp-direct: %w", err)
+	}
+	appLog("skychat: tcp-direct identity pk=%s (source: %s)", pk, source)
+
+	whitelist := tcpWhitelistSet(tcpWhitelist)
+	if tcpListen != "" {
+		if len(whitelist) == 0 {
+			appLog("skychat: tcp-direct WARNING --tcp-listen set without --tcp-whitelist; will reject all incoming peers")
+		}
+		go func() {
+			if err := runTCPListen(ctx, tcpListen, pk, sk, whitelist); err != nil {
+				appLog("skychat: tcp-direct listener exited: %v", err)
+			}
+		}()
+	}
+	if len(tcpPeers) > 0 {
+		runTCPPeerDialers(ctx, tcpPeers, pk, sk)
+	}
+	return nil
+}
+
+// tcpWhitelistSet builds a PK-set from a comma-separated string of
+// hex PKs. Whitespace-tolerant; bad entries logged and skipped.
+// Public so the chat-app's flag wiring can construct the set once
+// and pass it to runTCPListen.
+func tcpWhitelistSet(commaSep string) map[cipher.PubKey]struct{} {
+	out := make(map[cipher.PubKey]struct{})
+	if commaSep == "" {
+		return out
+	}
+	mu := sync.Mutex{}
+	for _, raw := range strings.Split(commaSep, ",") {
+		hex := strings.TrimSpace(raw)
+		if hex == "" {
+			continue
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(hex); err != nil {
+			appLog("skychat: tcp-whitelist skipping invalid pk %q: %v", hex, err)
+			continue
+		}
+		mu.Lock()
+		out[pk] = struct{}{}
+		mu.Unlock()
+	}
+	return out
+}

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -34,6 +34,9 @@ var (
 	sendWait     time.Duration
 	sendRetries  int
 	sendVerbose  bool
+	sendVia      string // --via tcp://<pk>@host:port (bypasses local chat-app)
+	tcpViaSK     string // --sk for --via tcp identity
+	tcpViaConfig string // -c / --config for --via tcp identity
 	listenNet    string
 	listenFrom   string
 	listenRaw    bool
@@ -60,6 +63,9 @@ func init() {
 	sendCmd.Flags().DurationVarP(&sendWait, "wait", "w", 5*time.Second, "wait for peer-receipt ack up to this duration (e.g. 5s, 30s); 0 disables wait and returns success on WriteFrame (fire-and-forget). Default 5s gives delivery confirmation.")
 	sendCmd.Flags().IntVarP(&sendRetries, "retries", "r", 1, "extra retry attempts on HTTP/transport failure (default 1). 0 disables retry. Each retry waits 200ms × attempt before retrying. Ack timeouts (peer-side failures with --wait) are NOT retried.")
 	sendCmd.Flags().BoolVar(&sendVerbose, "verbose", false, "surface per-layer detail to stderr: POST request URL+payload, HTTP response status+headers, ack timing, /status counter deltas (outbound_msg_count / fail / retry / fallback). Use to debug send failures.")
+	sendCmd.Flags().StringVar(&sendVia, "via", "", "bypass local chat-app and dial the remote chat-app directly via noise-TCP: tcp://<pk>@host:port. Survives visor / dmsg outages. Use --sk / -c / DMSGCURL_SK for identity.")
+	sendCmd.Flags().StringVar(&tcpViaSK, "sk", "", "identity SK for --via tcp (hex). Overrides env + config.")
+	sendCmd.Flags().StringVarP(&tcpViaConfig, "config", "c", "", "skywire.json path — only sk field read, for --via tcp identity")
 	sendCmd.MarkFlagRequired("to")  //nolint:errcheck,gosec
 	sendCmd.MarkFlagRequired("msg") //nolint:errcheck,gosec
 
@@ -124,6 +130,42 @@ Outcomes (--wait > 0):
 		pk, err := resolveTarget(recipient)
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		// --via tcp://<pk>@host:port short-circuits the entire HTTP /
+		// chat-app path: dial the remote chat-app's noise-TCP listener
+		// directly, write a chat-msg envelope, optionally wait for ack.
+		// Bypasses the local chat-app entirely — useful when the local
+		// visor is down OR when dmsg-disc / skynet are misbehaving.
+		// --net is ignored in this path; the noise XK handshake pins
+		// the PK from --via, not from --to.
+		if sendVia != "" {
+			errOut := cmd.ErrOrStderr()
+			if sendVerbose {
+				fmt.Fprintf(errOut, "[verbose] via: %s\n", sendVia)                           //nolint:errcheck
+				fmt.Fprintf(errOut, "[verbose] msg bytes: %d\n", len(message))                //nolint:errcheck
+				fmt.Fprintf(errOut, "[verbose] wait timeout: %s\n", sendWait)                 //nolint:errcheck
+				fmt.Fprintf(errOut, "[verbose] mode: noise-TCP direct (no local chat-app)\n") //nolint:errcheck
+			}
+			ack, err := sendViaTCP(sendVia, recipient, message, sendWait)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			if sendWait > 0 {
+				if ack != nil && ack.Acked {
+					internal.PrintOutput(cmd.Flags(), nil,
+						fmt.Sprintf("Acked by %s in %dms (id=%s, via tcp)\n", pk.String(), ack.MS, ack.ID))
+					return
+				}
+				reason := "no ack"
+				if ack != nil && ack.Reason != "" {
+					reason = ack.Reason
+				}
+				internal.PrintFatalError(cmd.Flags(),
+					fmt.Errorf("send to %s via tcp not acked: %s", pk.String(), reason))
+			}
+			internal.PrintOutput(cmd.Flags(), nil,
+				fmt.Sprintf("Message sent to %s via tcp\n", pk.String()))
+			return
 		}
 		if err := validateNetwork(sendNet); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)

--- a/cmd/skywire-cli/commands/skychat/tcp_via.go
+++ b/cmd/skywire-cli/commands/skychat/tcp_via.go
@@ -1,0 +1,276 @@
+// Package cliskychat — tcp_via.go: noise-TCP direct send path for
+// `cli skychat send --via tcp://<pk>@host:port`. Mirrors the
+// dmsgpty `--via tcp://` pattern: dial the remote chat-app's
+// --tcp-listen port, run noise XK with the remote's PK pinned,
+// write a chat-msg envelope, optionally wait for chat-ack, close.
+//
+// Distinct from the default send path (which POSTs to the local
+// chat-app's /message HTTP endpoint and lets the chat-app pick a
+// transport). --via tcp:// bypasses the local chat-app entirely —
+// the CLI process IS the dialer. This is the reliability-floor
+// transport: works when the local visor is down, when dmsg-disc
+// is unreachable, when the chat-app itself is wedged.
+//
+// Identity resolution (--sk → DMSGCURL_SK → -c skywire.json →
+// ephemeral) matches the chat-app's tcp-direct path so operators
+// have one mental model for "what identity goes on the wire".
+package cliskychat
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire/tcpnoise"
+)
+
+const (
+	tcpFrameMaxBytes  = 1 << 20 // 1 MiB upper bound on inbound frame size
+	tcpAckPollTimeout = 60 * time.Second
+)
+
+// chatEnvelope mirrors cmd/apps/skychat/commands/sendack.go's
+// shape. Duplicated here rather than imported to keep the CLI
+// binary independent of the chat-app's full dependency graph.
+// Field tags MUST stay in sync with the chat-app — every shipping
+// peer parses this struct on the wire.
+type chatEnvelope struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Body string `json:"body,omitempty"`
+	Ack  bool   `json:"ack,omitempty"`
+}
+
+// sendViaTCP runs the full --via tcp:// path: parse the spec,
+// resolve identity, dial, frame-write the chat-msg envelope,
+// optionally wait for ack. Returns an AckResponse on success
+// (Acked=true with timing); a non-nil error indicates a transport-
+// or handshake-layer failure rather than a peer-side ack timeout
+// (which is returned as Acked=false).
+func sendViaTCP(viaSpec, recipientPKHex, message string, wait time.Duration) (*AckResponse, error) {
+	rPK, addr, err := parseViaTCPSpec(viaSpec)
+	if err != nil {
+		return nil, err
+	}
+	// Sanity check: --via PK should match --to PK. Confusing if they
+	// disagree — the noise handshake pins --via's PK so --to would
+	// be ignored anyway. Reject explicitly to spare operators the
+	// debug session.
+	if recipientPKHex != "" {
+		var want cipher.PubKey
+		if err := want.Set(recipientPKHex); err == nil && want != rPK {
+			return nil, fmt.Errorf("--to %s != --via tcp:// pk %s (the pinned PK in --via wins; use one or the other)", recipientPKHex, rPK)
+		}
+	}
+
+	localPK, localSK, err := resolveTCPIdentityCLI()
+	if err != nil {
+		return nil, err
+	}
+
+	dialCtx, cancel := context.WithTimeout(context.Background(), tcpnoise.DialTimeout+tcpnoise.HandshakeTimeout)
+	defer cancel()
+	conn, err := tcpnoise.Dial(dialCtx, addr, localPK, localSK, rPK)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	id := newCLIEventID()
+	env := chatEnvelope{Type: chatTypeMsg, ID: id, Body: message, Ack: wait > 0}
+	payload, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("marshal envelope: %w", err)
+	}
+	start := time.Now()
+	if err := writeFrame(conn, payload); err != nil {
+		return nil, fmt.Errorf("write frame: %w", err)
+	}
+	if wait <= 0 {
+		// Fire-and-forget — frame is queued, return immediately.
+		return nil, nil
+	}
+
+	// Wait for matching chat-ack. Read frames until we see one with
+	// our id, or the wait deadline elapses, or the conn errors.
+	deadline := time.Now().Add(wait)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return &AckResponse{Acked: false, ID: id, Reason: "timeout"}, nil
+		}
+		if err := conn.SetReadDeadline(time.Now().Add(remaining)); err != nil {
+			return nil, fmt.Errorf("set read deadline: %w", err)
+		}
+		frame, err := readFrame(conn)
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) || isTimeout(err) {
+				return &AckResponse{Acked: false, ID: id, Reason: "timeout"}, nil
+			}
+			return nil, fmt.Errorf("read frame: %w", err)
+		}
+		var inEnv chatEnvelope
+		if err := json.Unmarshal(frame, &inEnv); err != nil {
+			// Non-envelope frame — could be a normal chat message
+			// arriving while we wait. Ignore and keep reading for the
+			// ack.
+			continue
+		}
+		if inEnv.Type == chatTypeAck && inEnv.ID == id {
+			return &AckResponse{Acked: true, ID: id, MS: time.Since(start).Milliseconds()}, nil
+		}
+		// Other envelope type or wrong id — keep waiting.
+	}
+}
+
+// chatTypeMsg / chatTypeAck mirror the chat-app's constants;
+// duplicated for the same reason chatEnvelope is duplicated.
+const (
+	chatTypeMsg = "chat-msg"
+	chatTypeAck = "chat-ack"
+)
+
+// parseViaTCPSpec turns "tcp://<66-hex-pk>@host:port" into
+// (pk, "host:port"). Same shape as dmsgpty --via tcp.
+func parseViaTCPSpec(spec string) (cipher.PubKey, string, error) {
+	const prefix = "tcp://"
+	if len(spec) < len(prefix) || spec[:len(prefix)] != prefix {
+		return cipher.PubKey{}, "", fmt.Errorf("--via tcp: must start with %q", prefix)
+	}
+	rest := spec[len(prefix):]
+	at := -1
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == '@' {
+			at = i
+			break
+		}
+	}
+	if at <= 0 || at >= len(rest)-1 {
+		return cipher.PubKey{}, "", fmt.Errorf("--via tcp: missing @ separator in %q", spec)
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(rest[:at]); err != nil {
+		return cipher.PubKey{}, "", fmt.Errorf("--via tcp: invalid pk: %w", err)
+	}
+	return pk, rest[at+1:], nil
+}
+
+// resolveTCPIdentityCLI mirrors the chat-app's resolveTCPIdentity
+// chain (tcp_direct.go): --sk → DMSGCURL_SK → -c config → error.
+// CLI binary doesn't have access to the chat-app's globals so we
+// duplicate the logic; the resolution ORDER is shared by convention
+// and documented in #2706.
+func resolveTCPIdentityCLI() (cipher.PubKey, cipher.SecKey, error) {
+	var zero cipher.SecKey
+	if tcpViaSK != "" {
+		var sk cipher.SecKey
+		if err := sk.Set(tcpViaSK); err != nil {
+			return cipher.PubKey{}, zero, fmt.Errorf("--sk: %w", err)
+		}
+		pk, err := sk.PubKey()
+		if err != nil {
+			return cipher.PubKey{}, zero, fmt.Errorf("--sk: derive pk: %w", err)
+		}
+		return pk, sk, nil
+	}
+	if env := os.Getenv("DMSGCURL_SK"); env != "" {
+		var sk cipher.SecKey
+		if err := sk.Set(env); err == nil {
+			pk, err := sk.PubKey()
+			if err == nil {
+				return pk, sk, nil
+			}
+		}
+	}
+	if tcpViaConfig != "" {
+		data, err := os.ReadFile(tcpViaConfig) //nolint:gosec
+		if err != nil {
+			return cipher.PubKey{}, zero, fmt.Errorf("-c %s: %w", tcpViaConfig, err)
+		}
+		var conf struct {
+			SK string `json:"sk"`
+		}
+		if err := json.Unmarshal(data, &conf); err != nil {
+			return cipher.PubKey{}, zero, fmt.Errorf("-c %s parse: %w", tcpViaConfig, err)
+		}
+		if conf.SK == "" {
+			return cipher.PubKey{}, zero, fmt.Errorf("-c %s: no sk field", tcpViaConfig)
+		}
+		var sk cipher.SecKey
+		if err := sk.Set(conf.SK); err != nil {
+			return cipher.PubKey{}, zero, fmt.Errorf("-c %s sk: %w", tcpViaConfig, err)
+		}
+		pk, err := sk.PubKey()
+		if err != nil {
+			return cipher.PubKey{}, zero, fmt.Errorf("-c %s derive pk: %w", tcpViaConfig, err)
+		}
+		return pk, sk, nil
+	}
+	return cipher.PubKey{}, zero, errors.New(
+		"--via tcp requires identity: set --sk, DMSGCURL_SK env, or -c skywire.json")
+}
+
+// writeFrame writes a length-prefixed payload — same wire format
+// the chat-app's framedConn uses (4-byte big-endian length + bytes).
+func writeFrame(w io.Writer, payload []byte) error {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) //nolint:gosec
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	if _, err := w.Write(payload); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readFrame reads one length-prefixed payload. Caps frame size to
+// tcpFrameMaxBytes so a malicious or buggy peer can't OOM the CLI
+// with a giant length header.
+func readFrame(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n > tcpFrameMaxBytes {
+		return nil, fmt.Errorf("frame size %d exceeds %d", n, tcpFrameMaxBytes)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// isTimeout matches the os.ErrDeadlineExceeded shape that
+// net.Conn.SetReadDeadline produces on expiry — used to map the
+// timeout case onto AckResponse{Acked: false} rather than a hard
+// transport error.
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	type timeouter interface{ Timeout() bool }
+	if t, ok := err.(timeouter); ok {
+		return t.Timeout()
+	}
+	return false
+}
+
+// newCLIEventID generates an ack-id for chat-msg envelopes. The
+// chat-app uses a 16-hex-char id; this matches that shape so the
+// debug surfaces (id in --verbose output, id in receiver SSE)
+// look uniform regardless of which side sourced the message.
+func newCLIEventID() string {
+	var buf [8]byte
+	now := time.Now().UnixNano()
+	binary.BigEndian.PutUint64(buf[:], uint64(now)) //nolint:gosec
+	return fmt.Sprintf("%016x", buf)
+}

--- a/pkg/app/appnet/type.go
+++ b/pkg/app/appnet/type.go
@@ -9,6 +9,12 @@ const (
 	TypeDmsg Type = "dmsg"
 	// TypeSkynet is a network type for skywire communication.
 	TypeSkynet Type = "skynet"
+	// TypeTCPDirect is a network type for noise-XK over raw TCP —
+	// point-to-point with known endpoints, no dmsg-disc, no visor
+	// routing. Apps use this as a reliability floor for
+	// agent-to-agent comms that survives visor restarts and dmsg
+	// infrastructure blips. See pkg/skywire/tcpnoise + #2706.
+	TypeTCPDirect Type = "tcp-direct"
 )
 
 // IsValid checks whether the network contains valid value for the type.
@@ -20,7 +26,8 @@ func (n Type) IsValid() bool {
 // nolint: gochecknoglobals
 var (
 	validNetworks = map[Type]struct{}{
-		TypeDmsg:   {},
-		TypeSkynet: {},
+		TypeDmsg:      {},
+		TypeSkynet:    {},
+		TypeTCPDirect: {},
 	}
 )

--- a/pkg/skywire/tcpnoise/tcpnoise.go
+++ b/pkg/skywire/tcpnoise/tcpnoise.go
@@ -1,0 +1,130 @@
+// Package tcpnoise — noise-XK over raw TCP, factored out of
+// pkg/dmsg/dmsgpty so apps other than dmsgpty (skychat first, then
+// app skynet / app skysocks etc. per #2706) can build TCP-direct
+// transports on the same primitive without dragging in a dmsgpty
+// dependency.
+//
+// The handshake is XK (one-side static, mutual auth via static
+// public keys). Initiator pins the responder's PK before dial;
+// responder learns the initiator's PK from the handshake. The
+// resulting net.Conn surfaces decrypted bytes via Read/Write —
+// callers see plaintext frames and don't touch the noise layer.
+//
+// Threat model: same as dmsgpty's --via tcp path. Endpoint
+// confidentiality + integrity rely on the operator's PK pinning
+// (--whitelist on accept side, explicit PK in the dial URL on
+// initiator side). No discovery; both sides agree out-of-band on
+// host:port and the remote PK.
+package tcpnoise
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+)
+
+// DialTimeout bounds the underlying TCP dial.
+const DialTimeout = 10 * time.Second
+
+// HandshakeTimeout bounds the noise XK handshake. Generous because
+// the first noise round-trip can stall on TCP fast-open quirks +
+// app-cold-start latency; once the handshake completes per-stream
+// timeouts at the application layer take over.
+const HandshakeTimeout = 10 * time.Second
+
+// Dial opens a TCP connection to addr, runs an XK noise handshake
+// pinning rPK as the responder, and returns the noise-wrapped
+// net.Conn ready for application framing.
+//
+// localPK / localSK is the initiator's identity. Standard skywire
+// convention: use the visor's SK so the PK matches what peers see
+// over dmsg / skynet (allowlists keep working). Ephemeral keypairs
+// also work for one-off use but will fail PK-pinned remotes.
+func Dial(
+	ctx context.Context,
+	addr string,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+	rPK cipher.PubKey,
+) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: DialTimeout}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("tcpnoise: dial %s: %w", addr, err)
+	}
+
+	ns, err := noise.New(noise.HandshakeXK, noise.Config{
+		LocalPK:   localPK,
+		LocalSK:   localSK,
+		RemotePK:  rPK,
+		Initiator: true,
+	})
+	if err != nil {
+		_ = conn.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("tcpnoise: noise init: %w", err)
+	}
+	rw := noise.NewReadWriter(conn, ns)
+	if err := rw.Handshake(HandshakeTimeout); err != nil {
+		_ = conn.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("tcpnoise: handshake (server pinned to %s): %w", rPK, err)
+	}
+	return &Conn{Conn: conn, rw: rw, rPK: rPK}, nil
+}
+
+// Accept runs the responder side of the XK handshake on raw — a
+// connection already accepted from a net.Listener. Returns the
+// noise-wrapped conn AND the remote PK learned during the
+// handshake. The caller is expected to consult a whitelist on the
+// returned PK before serving any application traffic over the conn.
+//
+// On handshake failure, the raw conn is closed and an error is
+// returned. The caller should NOT use raw afterwards.
+func Accept(
+	raw net.Conn,
+	localPK cipher.PubKey,
+	localSK cipher.SecKey,
+) (net.Conn, cipher.PubKey, error) {
+	ns, err := noise.New(noise.HandshakeXK, noise.Config{
+		LocalPK:   localPK,
+		LocalSK:   localSK,
+		Initiator: false,
+	})
+	if err != nil {
+		_ = raw.Close() //nolint:errcheck,gosec
+		return nil, cipher.PubKey{}, fmt.Errorf("tcpnoise: noise init: %w", err)
+	}
+	rw := noise.NewReadWriter(raw, ns)
+	if err := rw.Handshake(HandshakeTimeout); err != nil {
+		_ = raw.Close() //nolint:errcheck,gosec
+		return nil, cipher.PubKey{}, fmt.Errorf("tcpnoise: handshake: %w", err)
+	}
+	rPK := rw.RemoteStatic()
+	return &Conn{Conn: raw, rw: rw, rPK: rPK}, rPK, nil
+}
+
+// Conn is a net.Conn adapter over a noise.ReadWriter. The embedded
+// net.Conn supplies LocalAddr / Close / Set*Deadline; Read / Write
+// override to go through the noise framing for confidentiality +
+// integrity. rPK is the peer's static PK pinned during the
+// handshake — exposed via RemotePK for app-side whitelist / logging.
+type Conn struct {
+	net.Conn // for LocalAddr / Close / Set*Deadline
+	rw       *noise.ReadWriter
+	rPK      cipher.PubKey
+}
+
+// Read pulls plaintext bytes from the noise layer.
+func (c *Conn) Read(p []byte) (int, error) { return c.rw.Read(p) }
+
+// Write seals plaintext bytes via the noise layer.
+func (c *Conn) Write(p []byte) (int, error) { return c.rw.Write(p) }
+
+// RemotePK is the peer's static public key learned via the
+// handshake (responder side) or pinned at dial time (initiator
+// side). Callers use this to authorize the peer against a
+// whitelist before serving application traffic.
+func (c *Conn) RemotePK() cipher.PubKey { return c.rPK }


### PR DESCRIPTION
## Summary

Operator-directed reliability-floor transport per #2706. The chat-app and CLI gain a noise-XK-over-raw-TCP path that survives visor restarts, dmsg-disc / skynet outages, and visor-internal wedging — the exact failure modes that bit agent-agent comms across the 2026-05-16/17 reliability runs.

Pattern is structurally identical to dmsgpty's \`--via tcp://\` shipped in #2675; this PR extracts the noise-TCP helpers into a shared package and applies them to skychat.

## What lands

### `pkg/skywire/tcpnoise/` (new)
- `Dial(ctx, addr, localPK, localSK, rPK) → net.Conn` (initiator)
- `Accept(rawConn, localPK, localSK) → (net.Conn, learned PK)` (responder)
- `Conn` (net.Conn adapter exposing the noise layer's plaintext)

Factored from `pkg/dmsg/dmsgpty/{cli_tcp,host_tcp}.go` shapes. **dmsgpty itself is not migrated yet** — kept untouched to bound this PR's blast radius. dmsgpty migration is a mechanical #2706 follow-up.

### `pkg/app/appnet`
- `TypeTCPDirect = "tcp-direct"` so inbound TCP-direct frames surface with that network in SSE events / `--verbose` output

### `cmd/apps/skychat/commands/tcp_direct.go` (new)

| Flag | Purpose |
|---|---|
| `--tcp-listen :PORT` | accept noise-XK on TCP (server side) |
| `--tcp-peer tcp://<pk>@host:port` | persistent outbound dialer with exponential backoff (repeatable for many peers; NAT side) |
| `--tcp-whitelist <pk>,<pk>` | REQUIRED when listening; empty rejects all (fail-safe) |
| `--sk <hex>` | identity SK |
| `-c, --config <path>` | read sk field from skywire.json |

Resolution chain: `--sk` → `DMSGCURL_SK` env → `-c` config → **fail**. No ephemeral fallback — PK pinning is the trust model; ephemeral PKs defeat whitelists.

All flags opt-in; zero-effect when unset, so existing visor-managed setups are untouched.

### `cmd/skywire-cli/commands/skychat/tcp_via.go` (new)
- `cli skychat send --via tcp://<pk>@host:port` bypasses the local chat-app entirely. CLI process IS the dialer. Builds the same chat-msg envelope the `/message` path builds; writes via length-prefixed frame; reads chat-ack on `--wait > 0`.
- Identity chain (`--sk` / `-c` / env) mirrors the chat-app's tcp-direct path — one mental model.

## Behavior on a 4-member group

```
Beta + Gamma (public IPs):
  chat-app --tcp-listen :8800 --tcp-whitelist <alpha-pk>,<gamma-pk>... -c /opt/skywire/skywire.json

Alpha (NAT):
  chat-app --tcp-peer tcp://<beta-pk>@beta-host:8800 \
           --tcp-peer tcp://<gamma-pk>@gamma-host:8800 \
           -c /opt/skywire/skywire.json
```

Once handshakes complete, TCP's full-duplex semantics carry frames in **both directions** over each socket. Alpha port-forwards nothing; Beta/Gamma port-forward only their respective TCP-listen ports.

## Operator UX

```
cli skychat send -t <pk> -m "hi"                                # existing default path
cli skychat send -t <pk> -m "hi" --net dmsg --verbose           # existing
cli skychat send -t <pk> -m "hi" --via tcp://<pk>@host:8800 -c /opt/skywire/skywire.json  # NEW
```

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./cmd/apps/skychat/commands/... ./cmd/skywire-cli/commands/skychat/... ./pkg/skywire/tcpnoise/... ./pkg/app/appnet/...` passes
- [x] `make format && make lint` 0 issues + vet clean
- [ ] Live: 3-agent run with Beta/Gamma listening + Alpha dialing peer-list

## Out of scope (deferred to #2706 follow-ups)
- dmsgpty migration off its private noise-TCP helpers onto the shared `pkg/skywire/tcpnoise` (functional duplicate exists; merge is mechanical)
- `app pty` / `app skynet` renames + namespace consolidation
- Visor config schema changes (TCP-direct flags pass through the existing launcher app-args mechanism unchanged)
- Conditional flag visibility gated on `APP_PROC_KEY`

## Related
- #2706 — tracking issue for the full app-namespace consolidation
- #2675 — dmsgpty `--via tcp://` (proof-of-concept; same noise-XK primitive)