### PR TITLE
fix(skychat): standalone /message guard + CLI --via implicit recipient

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1063,6 +1063,21 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		connsMu.Unlock()
 
 		if !cached {
+			// In --standalone mode appCl is nil — dialAndCache would
+			// panic on appCl.Dial(). Skynet/dmsg listenLoops are off
+			// in standalone (see RunSkychat above), so the only way
+			// /message can reach a peer is through an already-cached
+			// TCP-direct conn (populated by --tcp-peer outbound or
+			// --tcp-listen accept). Surface a clean 503 with the
+			// fix-it-yourself hint instead of a panic.
+			if appCl == nil {
+				http.Error(w,
+					fmt.Sprintf("standalone mode: no cached tcp-direct conn to %s "+
+						"(use --tcp-peer to establish a persistent outbound, "+
+						"or 'skywire cli skychat send --via tcp://<pk>@host:port' to dial directly)", pk),
+					http.StatusServiceUnavailable)
+				return
+			}
 			var err error
 			conn, err = dialAndCache(ctx, pk, addr)
 			if err != nil {

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	"github.com/skycoin/skywire/pkg/cipher"
 )
 
 var (
@@ -57,16 +58,19 @@ func init() {
 		aliasCmd,
 	)
 
-	sendCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (required)")
+	sendCmd.Flags().StringVarP(&recipient, "to", "t", "", "recipient public key (optional when --via tcp://<pk>@host:port is set — the PK in --via is used)")
 	sendCmd.Flags().StringVarP(&message, "msg", "m", "", "message to send (required)")
 	sendCmd.Flags().StringVarP(&sendNet, "net", "n", "skynet", "network type: skynet or dmsg")
 	sendCmd.Flags().DurationVarP(&sendWait, "wait", "w", 5*time.Second, "wait for peer-receipt ack up to this duration (e.g. 5s, 30s); 0 disables wait and returns success on WriteFrame (fire-and-forget). Default 5s gives delivery confirmation.")
 	sendCmd.Flags().IntVarP(&sendRetries, "retries", "r", 1, "extra retry attempts on HTTP/transport failure (default 1). 0 disables retry. Each retry waits 200ms × attempt before retrying. Ack timeouts (peer-side failures with --wait) are NOT retried.")
 	sendCmd.Flags().BoolVar(&sendVerbose, "verbose", false, "surface per-layer detail to stderr: POST request URL+payload, HTTP response status+headers, ack timing, /status counter deltas (outbound_msg_count / fail / retry / fallback). Use to debug send failures.")
-	sendCmd.Flags().StringVar(&sendVia, "via", "", "bypass local chat-app and dial the remote chat-app directly via noise-TCP: tcp://<pk>@host:port. Survives visor / dmsg outages. Use --sk / -c / DMSGCURL_SK for identity.")
+	sendCmd.Flags().StringVar(&sendVia, "via", "", "bypass local chat-app and dial the remote chat-app directly via noise-TCP: tcp://<pk>@host:port. Survives visor / dmsg outages. Use --sk / -c / DMSGCURL_SK for identity. When set, --to becomes optional (the PK in --via is used).")
 	sendCmd.Flags().StringVar(&tcpViaSK, "sk", "", "identity SK for --via tcp (hex). Overrides env + config.")
 	sendCmd.Flags().StringVarP(&tcpViaConfig, "config", "c", "", "skywire.json path — only sk field read, for --via tcp identity")
-	sendCmd.MarkFlagRequired("to")  //nolint:errcheck,gosec
+	// --to is NOT MarkFlagRequired anymore: when --via tcp://<pk>@host:port
+	// is set, the PK comes from --via and -t is redundant. The Run func
+	// below enforces "either --to or --via" at runtime so both can't be
+	// omitted together.
 	sendCmd.MarkFlagRequired("msg") //nolint:errcheck,gosec
 
 	listenCmd.Flags().StringVarP(&listenNet, "net", "n", "", "filter by network type (optional; default = all)")
@@ -127,9 +131,34 @@ Outcomes (--wait > 0):
                          delivered but the peer can't ack. Use
                          --wait=0 against known-old peers.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		pk, err := resolveTarget(recipient)
-		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), err)
+		// Recipient resolution. Two valid inputs:
+		//   1. --to <pk-or-alias> — resolved via alias lookup
+		//   2. --via tcp://<pk>@host:port — PK comes from the URL,
+		//      no --to needed (and if both set, the existing
+		//      sendViaTCP cross-validation enforces they match)
+		// Bail with one clear error when neither is provided.
+		if recipient == "" && sendVia == "" {
+			internal.PrintFatalError(cmd.Flags(),
+				errors.New("either --to <pk> or --via tcp://<pk>@host:port is required"))
+		}
+		var pk cipher.PubKey
+		var err error
+		if recipient != "" {
+			pk, err = resolveTarget(recipient)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+		} else {
+			// --via supplies the PK; parse it here so the verbose
+			// log + post-send "Acked by <pk>" line have a value to
+			// render. parseViaTCPSpec is shared with sendViaTCP, so
+			// any spec error surfaces consistently here.
+			var rpk cipher.PubKey
+			rpk, _, err = parseViaTCPSpec(sendVia)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			pk = rpk
 		}
 		// --via tcp://<pk>@host:port short-circuits the entire HTTP /
 		// chat-app path: dial the remote chat-app's noise-TCP listener


### PR DESCRIPTION
## Summary

Two papercuts on top of #2708/#2709's standalone-mode work, both surfaced by operator + Gamma in live testing today.

### 1. messageHandler nil-deref on un-cached peer in `--standalone`

Pre-fix: a `POST /message` to a peer not in the `conns` cache fell through to `dialAndCache` → `appCl.Dial(addr)`, which nil-panics in standalone (no visor app-net). `net/http` recovers the goroutine so the process stays up, but the handler returns 500-empty and the operator's send is lost.

Post-fix: when `appCl == nil` and `!cached`, return **503** with a self-service hint pointing at the two ways to populate the cache:
- `--tcp-peer tcp://<pk>@host:port` for persistent outbound
- `skywire cli skychat send --via tcp://...` for one-shot direct dial

The cached-conn path (TCP-direct peer already wired in by `--tcp-listen` accept or `--tcp-peer` outbound) keeps working unchanged.

### 2. `cli skychat send -t <pk> --via tcp://<pk>@host:port` redundancy

Pre-fix: the PK had to be repeated in both `-t` and `--via`. Mismatch already errored at runtime but didn't help on first-pass typing.

Post-fix: drop `MarkFlagRequired("to")`. When `--via` is set, the PK in the URL becomes the recipient. When `--via` is unset, `-t` is required as before. Both empty → one clean fatal `either --to <pk> or --via tcp://<pk>@host:port is required`.

## Test plan

- [x] POST /message to uncached random PK in standalone → 503 with hint, no panic, process alive
- [x] POST /message to Beta (cached via `--tcp-peer`) in standalone → acked in 142ms
- [x] `cli skychat send -m "..."` (neither `-t` nor `--via`) → fatal "either --to or --via required"
- [x] `cli skychat send --via tcp://beta@host:port -m "..."` (no `-t`) → acked in 139ms (PK derived from --via)
- [x] `cli skychat send -t beta -m "..."` (no `--via`, normal skynet path) → unchanged
- [x] Verified live in 3-way standalone session: Alpha + Beta + Gamma all running `skywire app skychat --standalone`, reliability floor decouples chat-app from visor restart