### PR TITLE
fix(skychat/pairing): Manager.Resume reconnects subscribers (3-agent pair-RX root cause)

### DIFF
--- a/cmd/apps/skychat/pairing/manager.go
+++ b/cmd/apps/skychat/pairing/manager.go
@@ -14,6 +14,7 @@
 package pairing
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -23,6 +24,13 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// resumeConnectTimeout bounds the dmsg dial when Resume re-attaches a
+// pair's subscriber to the peer's CXO publisher feed after a visor
+// restart. Matches pkg/visor's pairConnectTimeout intentionally —
+// resume-on-startup and operator-driven PairAdd have the same "single
+// unreachable peer shouldn't block forever" property.
+const resumeConnectTimeout = 15 * time.Second
 
 // Manager owns the persistent record set and live Pair instances.
 // Safe for concurrent use.
@@ -216,6 +224,32 @@ func (m *Manager) Resume() (resumed int, err error) {
 		}
 		m.pairs[rec.PeerPK] = p
 		resumed++
+
+		// Reconnect the subscriber to the peer's CXO publisher feed.
+		// openPair builds the publisher + subscriber and registers
+		// the onUpdate callback, but does NOT dial peer — that's
+		// Pair.Connect's job, and prior to this fix Resume left
+		// every restored pair with a live publisher and a dead
+		// subscriber. The on-the-wire symptom (verified live with
+		// 3-agent skychat-pair-poll empty across multiple visor
+		// restarts on 2026-05-18): outbound pair-Sends work
+		// (publisher's local Put), inbound onUpdate never fires
+		// (subscriber never subscribed), and pair-poll inbox stays
+		// empty forever.
+		//
+		// Connect-failure here is intentionally non-fatal — it
+		// matches the visor's PairAdd semantics exactly (peer
+		// temporarily unreachable shouldn't block startup; the
+		// reconcile loops + future operator-driven retry will heal).
+		// Pending records still get a Connect attempt so the moment
+		// the peer accepts and starts publishing, we observe it.
+		dctx, dcancel := context.WithTimeout(context.Background(), resumeConnectTimeout)
+		if connErr := p.Connect(dctx); connErr != nil {
+			m.log.WithError(connErr).
+				WithField("peer", rec.PeerPK.Hex()).
+				Debug("pairing: Resume: subscriber Connect failed; pair record kept (will heal on next operator action)")
+		}
+		dcancel()
 	}
 	return resumed, nil
 }


### PR DESCRIPTION
## Summary

Closes the recurring 'pair-poll empty / pair-RX onUpdate not firing' bug class that hit all three agents (Alpha + Beta + Gamma) on 2026-05-18.

## The bug

\`Manager.Add\` → \`openPair\` → \`Pair.Open\` (publisher + subscriber + onUpdate registered) → returns. Then \`PairAdd\` in \`pkg/visor/pairing.go\` wraps this with \`p.Connect(dctx)\` so the subscriber actually dials the peer's CXO node and runs the subscribe-frame exchange.

But \`Manager.Resume\` → \`openPair\` → returns. **No Connect call.**

Every visor restart calls \`init_pairing.go:72\` → \`mgr.Resume()\`, which brought back every persisted pair with a live publisher and a **dead subscriber**:
- Outbound: publisher's local Put → CXO propagation → **works**
- Inbound: peer's Put → my subscriber's onUpdate → **never fires** because the subscribe-frame was never sent

\`pair-poll\` inbox stayed empty forever.

The fix-class is even pre-acknowledged in \`pkg/visor/pairing.go\`'s PairAdd comment:

> Connect-failure is non-fatal — the publisher side is up, and **Resume on a future restart (or a manual retry) will pick up the subscriber side** once the peer is reachable.

But Resume didn't actually do that. Latent bug since pairing was introduced.

## The fix

\`Manager.Resume\` now calls \`p.Connect(ctx)\` with a bounded 15-second deadline per pair (\`resumeConnectTimeout\`, matches PairAdd's \`pairConnectTimeout\`). Failures debug-logged, non-fatal.

## Diagnosis chain leading to this PR (live coordination today)

- **Alpha 19:26Z** baseline rollup: pair-RX broken on their side, pair-poll empty post 19:22Z restart
- **Gamma 19:33Z**: same symptom on their side, SSE bridge captured historic 1c sends but pair-poll empty
- **Beta** surveyed \`pair.go\` / \`manager.go\` / \`init_pairing.go\` — found Resume never calling Connect
- **Alpha 19:44Z** refined: peer's Pair.Send → CXO propagation → subscriber's onUpdate not firing
- This PR closes the loop: Resume now wires the subscriber

## Test plan

- [x] All existing pair tests pass (\`go test ./cmd/apps/skychat/pairing/ -count=1\` — 15.6s, includes baseline + reconnect-cycle + comparison suite from #2694/#2697)
- [x] \`make format\` clean
- [x] \`go vet\` clean
- [ ] 3-agent live test post-deploy: pair-poll should populate with peer-sent messages after either side's visor restart