### PR TITLE
fix(skychat/pairing): connect resumed pair subscribers on visor restart

### DIFF
--- a/cmd/apps/skychat/pairing/manager.go
+++ b/cmd/apps/skychat/pairing/manager.go
@@ -14,6 +14,7 @@
 package pairing
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -23,6 +24,13 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// resumeConnectTimeout bounds each Pair.Connect dial during Resume.
+// Picked to match pkg/visor's pairConnectTimeout so the resume path
+// has the same per-peer dial budget the operator-initiated PairAdd
+// path uses; deviating here would surprise debug sessions that
+// expect identical behavior across the two entry points.
+const resumeConnectTimeout = 15 * time.Second
 
 // Manager owns the persistent record set and live Pair instances.
 // Safe for concurrent use.
@@ -199,7 +207,11 @@ func (m *Manager) Resume() (resumed int, err error) {
 		return 0, fmt.Errorf("pairing: Resume: list: %w", err)
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	// Collect resumed pairs so we can Connect them after releasing
+	// m.mu. Holding the lock across Connect would serialize dmsg
+	// dials behind it and turn a flaky peer into a startup stall;
+	// release first and dial concurrently per pair.
+	var toConnect []*Pair
 	for _, rec := range records {
 		if rec.Status == StatusRevoked {
 			continue
@@ -216,6 +228,34 @@ func (m *Manager) Resume() (resumed int, err error) {
 		}
 		m.pairs[rec.PeerPK] = p
 		resumed++
+		toConnect = append(toConnect, p)
+	}
+	m.mu.Unlock()
+
+	// Connect each resumed pair's subscriber to the peer's publisher.
+	// WITHOUT this, the subscriber sits idle — its OnUpdate callback
+	// never fires for peer-published messages, so the visor's pair
+	// inbox stays empty and PairPoll returns nothing. Pre-fix, the
+	// only working path was PairAdd (initial pairing) which already
+	// calls Connect; every subsequent visor restart silently broke
+	// inbound pair messages until the operator re-added the pair.
+	//
+	// Done off the main resume path so a slow / unreachable peer
+	// doesn't block visor startup — Connect failures are non-fatal
+	// (same as PairAdd's best-effort dial); the pair record stays
+	// in m.pairs and the next manual retry or peer reachability will
+	// pick it up via a fresh PairAdd-style flow at the operator
+	// layer. Per-dial bound by resumeConnectTimeout.
+	for _, p := range toConnect {
+		go func(p *Pair) {
+			ctx, cancel := context.WithTimeout(context.Background(), resumeConnectTimeout)
+			defer cancel()
+			if cerr := p.Connect(ctx); cerr != nil {
+				m.log.WithError(cerr).
+					WithField("peer", p.cfg.PeerPK.Hex()).
+					Debug("pairing: Resume: subscriber Connect failed; pair record kept")
+			}
+		}(p)
 	}
 	return resumed, nil
 }


### PR DESCRIPTION
## Summary

Pair messaging silently broke after every visor restart — `pair list` showed both peers as `active`, the publisher was up, the subscriber was registered with an `OnUpdate` callback, but no peer-published messages ever arrived. CLI `pair poll` stayed empty indefinitely; the visor's pair inbox never grew; chat-app's SSE-bridge pair poller saw nothing to broadcast.

## Root cause

`Manager.Resume()`'s `openPair()` built each pair's publisher + subscriber + wired `OnUpdate`, but never called `Pair.Connect` — the call that actually dials the peer's CXO node to start receiving `Put` events. Without that, the subscriber sits idle waiting for a dial that never comes.

`PairAdd` (initial pairing) already calls `Connect` explicitly via `pkg/visor/pairing.go:83`; the visor.go:84-86 comment even claims *"Resume on a future restart will pick up the subscriber side"* — but the code didn't match the comment.

## Fix

In `Resume`, after each pair is opened + stored in `m.pairs`, spawn a goroutine that calls `p.Connect` with a 15s timeout (`resumeConnectTimeout` matches `pkg/visor.pairConnectTimeout` for behavior parity with `PairAdd`). Done concurrently per pair to avoid serializing N peer dials behind a flaky one; failures log at `Debug` and the pair record stays kept — same best-effort contract `PairAdd` has.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/apps/skychat/pairing/...` (15.5s) passes
- [x] `go test ./pkg/visor/... -run Pair` passes
- [x] Live verification:
  - Pre-fix on patched visor: my `pair poll` empty across 8+ polls even with peers confirming fresh pair sends with CLI `Pair message sent in 2ms` acks
  - Post-fix on this branch: halted visor → restart-loop rebuilt with fix → `pair poll` immediately drained **12 backlog messages** (Beta's `1c-pair-beta-echo-1..3` from 19:19:39Z + `1c-beta-fresh` + `1c-beta-retry-19:32:48Z`; Gamma's `1c-pair-alpha-1..5` + `1c-gamma-fresh-19:23Z` + the 19:20Z text echo); SSE bridge captured all of them with the `[peerPK]` pair-channel prefix (no `/skynet` suffix)
- [x] Reproducible cross-agent — both Alpha and Gamma hit this exact bug after their respective post-#2710 visor restarts; Gamma's parallel diagnosis ("F11 pattern: subscriber active but not actually receiving") aligned on the same `Connect`-after-`Resume` gap before this fix landed