### PR TITLE
fix(cxo/treestore): subscriber reconnect watchdog (#2713)

### DIFF
--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -19,6 +19,8 @@ package treestore
 import (
 	"context"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	skycipher "github.com/skycoin/skycoin/src/cipher"
 
@@ -30,6 +32,28 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// reconnectQuietThreshold is how long the subscriber must see no
+// Root activity before the watchdog assumes the connection is dead
+// and re-Connects. Issue #2713: a peer's visor restart drops the
+// existing dmsg session; the subscriber doesn't observe the close
+// (the dmsg layer silently fails to surface it up to treestore) so
+// the subscription stays "live" but nothing flows. 60s is well above
+// any reasonable pair-batch publish cadence (today ~60s ticker on
+// active feeds) but short enough that a peer-restart-stalled
+// subscriber heals within ~90s end-to-end.
+const reconnectQuietThreshold = 60 * time.Second
+
+// reconnectWatchdogTick is the watchdog's poll interval. Half the
+// quiet threshold so a stall is caught within at most threshold +
+// tick. Cheap — one map read + one timestamp comparison per tick.
+const reconnectWatchdogTick = 30 * time.Second
+
+// reconnectConnectTimeout bounds each watchdog-triggered Connect
+// attempt. Matches the deadline pairing.Manager.PairAdd uses for
+// the initial Connect; we don't want a hung dial to wedge the
+// watchdog goroutine.
+const reconnectConnectTimeout = 15 * time.Second
 
 // UpdateEvent describes a single leaf change observed by the
 // subscriber. Value is nil when the leaf was deleted (path missing
@@ -83,6 +107,33 @@ type Subscriber struct {
 	// observation doesn't fast-path a fresh reconnect that hasn't
 	// re-verified the channel.
 	rootObservedSignal chan struct{}
+
+	// lastUpdateNs is the unix-nano timestamp of the most recent
+	// successful handleRootFilled call (i.e. the last time data
+	// flowed end-to-end from publisher → subscriber). The reconnect
+	// watchdog reads this; handleRootFilled bumps it. atomic.Int64
+	// because reads happen on the watchdog goroutine while writes
+	// happen on the CXO filler goroutine.
+	lastUpdateNs atomic.Int64
+
+	// publisherPK stores the most recent Connect target PK so the
+	// watchdog has somewhere to re-Connect to. nil until first
+	// Connect succeeds.
+	publisherPK atomic.Pointer[cipher.PubKey]
+
+	// reconnectStop, when closed, terminates the watchdog. Created
+	// when Connect is first called; closed by Close. Idempotent
+	// close via reconnectOnce.
+	reconnectStop chan struct{}
+	reconnectOnce sync.Once
+	// reconnectStartOnce guards starting the watchdog: we only spawn
+	// the goroutine on the first successful Connect, not every
+	// subsequent reconnect.
+	reconnectStartOnce sync.Once
+	// reconnectAttempts counts watchdog-triggered Connect attempts
+	// (incremented BEFORE the Connect call regardless of outcome).
+	// Surfaced only for tests; treat as opaque metric otherwise.
+	reconnectAttempts atomic.Int64
 
 	closed   bool
 	closeMu  sync.Mutex
@@ -235,7 +286,93 @@ func (s *Subscriber) Connect(ctx context.Context, publisherPK cipher.PubKey) err
 	if err != nil {
 		return err
 	}
-	return conn.Subscribe(skycipher.PubKey(s.feedPK))
+	if err := conn.Subscribe(skycipher.PubKey(s.feedPK)); err != nil {
+		return err
+	}
+
+	// Remember the publisher for the watchdog. Stored as a copy so
+	// the watchdog goroutine doesn't alias a caller-owned variable.
+	pk := publisherPK
+	s.publisherPK.Store(&pk)
+	// Reset the activity clock — a fresh subscribe should not count
+	// as "stale" for the watchdog. handleRootFilled will bump it on
+	// real updates.
+	s.lastUpdateNs.Store(time.Now().UnixNano())
+	// Start the watchdog on the FIRST successful Connect only.
+	s.reconnectStartOnce.Do(func() {
+		s.reconnectStop = make(chan struct{})
+		go s.runReconnectWatchdog()
+	})
+	return nil
+}
+
+// runReconnectWatchdog polls for stalled subscriptions and re-Connects
+// when the local subscriber has gone quiet for longer than the
+// threshold. Fix for issue #2713: when a peer restarts, the dmsg
+// session backing this subscription silently dies — the subscriber
+// keeps thinking it's attached but no Root push arrives. The watchdog
+// detects the silence and forces a fresh Connect to the peer's new
+// publisher.
+//
+// Lifecycle: started on first successful Connect, stopped by Close.
+// Safe to run on naturally-quiet feeds — Connect is idempotent
+// (Subscribe-frame is harmless on a healthy connection), so a
+// wasted reconnect on a feed that's just sleeping costs one dmsg
+// dial + one Subscribe frame, no data loss.
+func (s *Subscriber) runReconnectWatchdog() {
+	s.runReconnectWatchdogWith(reconnectWatchdogTick, reconnectQuietThreshold)
+}
+
+// runReconnectWatchdogWith is the tickable inner loop used by both
+// the production watchdog and tests that need to drive the loop with
+// small intervals.
+func (s *Subscriber) runReconnectWatchdogWith(tickEvery, quietThreshold time.Duration) {
+	tick := time.NewTicker(tickEvery)
+	defer tick.Stop()
+	for {
+		select {
+		case <-s.reconnectStop:
+			return
+		case <-tick.C:
+		}
+		// Snapshot last activity; if zero (no Root ever seen) we
+		// skip the reconnect — the initial subscription may still
+		// be settling.
+		last := s.lastUpdateNs.Load()
+		if last == 0 {
+			continue
+		}
+		quiet := time.Since(time.Unix(0, last))
+		if quiet < quietThreshold {
+			continue
+		}
+		pkPtr := s.publisherPK.Load()
+		if pkPtr == nil {
+			continue
+		}
+		// Bounded Connect so a hung dial doesn't wedge the watchdog
+		// past the next tick. ConnectAndWaitForRoot would be more
+		// thorough (it confirms the new subscription actually
+		// delivers a Root) but here we want a non-blocking refresh —
+		// the next tick will catch a still-quiet feed.
+		s.reconnectAttempts.Add(1)
+		ctx, cancel := context.WithTimeout(context.Background(), reconnectConnectTimeout)
+		err := s.Connect(ctx, *pkPtr)
+		cancel()
+		if err != nil {
+			if s.log != nil {
+				s.log.WithError(err).WithField("publisher_pk", pkPtr.Hex()[:8]).
+					WithField("quiet_seconds", quiet.Seconds()).
+					Debug("treestore: reconnect-watchdog Connect failed; will retry next tick")
+			}
+			continue
+		}
+		if s.log != nil {
+			s.log.WithField("publisher_pk", pkPtr.Hex()[:8]).
+				WithField("quiet_seconds", quiet.Seconds()).
+				Info("treestore: reconnect-watchdog re-Connected after quiet period")
+		}
+	}
 }
 
 // ConnectAndWaitForRoot is the atomic-subscribe variant of Connect:
@@ -368,6 +505,15 @@ func (s *Subscriber) Close() error {
 		return s.closeErr
 	}
 	s.closed = true
+	// Stop the reconnect watchdog before tearing down the node so a
+	// concurrent reconnect attempt doesn't observe a half-closed
+	// node mid-Connect. Idempotent — channel may already be nil if
+	// Connect was never called.
+	s.reconnectOnce.Do(func() {
+		if s.reconnectStop != nil {
+			close(s.reconnectStop)
+		}
+	})
 	if s.ownsNode {
 		s.closeErr = s.cxoNode.Close()
 	}
@@ -450,6 +596,11 @@ func (s *Subscriber) handleRootFilled(r *registry.Root) {
 	}
 
 	s.applySnapshot(snap)
+	// Mark "data flowed" for the reconnect watchdog (#2713). Bumped
+	// only on a feed-matching Root that walked successfully — non-
+	// matching Roots or walk-failures don't count as live activity
+	// for THIS subscriber's purposes.
+	s.lastUpdateNs.Store(time.Now().UnixNano())
 	// Signal any ConnectAndWaitForRoot caller blocked on this
 	// subscriber that a Root was received and the fill walk
 	// completed — the subscription is verifiably live now.

--- a/pkg/cxo/treestore/subscriber_reconnect_test.go
+++ b/pkg/cxo/treestore/subscriber_reconnect_test.go
@@ -1,0 +1,226 @@
+// Package treestore — pkg/cxo/treestore/subscriber_reconnect_test.go:
+// tests for the reconnect watchdog (#2713). The watchdog detects a
+// stalled subscription (no Root for > quietThreshold) and re-Connects
+// to the stored publisher PK. The fix matters because dmsg silently
+// drops sessions when a peer's visor restarts; the subscriber stays
+// "live" in CXO's view but no data flows. Without the watchdog the
+// only recovery is restarting the local visor (the workaround
+// documented in #2713).
+//
+// These tests exercise the watchdog state machine in isolation, with
+// small thresholds + manual lastUpdateNs writes — no DMSG, no real
+// publisher. Connect itself fails fast in this setup (cxoNode.DMSG()
+// returns nil → node.ErrAlreadyListen), so we measure
+// reconnectAttempts rather than Connect-success.
+
+package treestore
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func newReconnectTestSubscriber(t *testing.T) *Subscriber {
+	t.Helper()
+	// Construct without DMSG. Connect will fail fast inside the
+	// watchdog (DMSG()==nil → ErrAlreadyListen), but that's fine —
+	// we're verifying the *decision* to call Connect, not Connect's
+	// success.
+	cfg := node.NewConfig()
+	cxoNode, err := node.NewNode(cfg)
+	if err != nil {
+		t.Fatalf("NewNode: %v", err)
+	}
+	t.Cleanup(func() { _ = cxoNode.Close() })
+
+	s := &Subscriber{
+		log:                logging.MustGetLogger("treestore-sub-reconnect-test"),
+		cxoNode:            cxoNode,
+		cache:              make(map[string][]byte),
+		rootObservedSignal: make(chan struct{}),
+		reconnectStop:      make(chan struct{}),
+	}
+	// Populate publisherPK so the watchdog has somewhere to dial.
+	pk, _ := cipher.GenerateKeyPair()
+	s.publisherPK.Store(&pk)
+	return s
+}
+
+// waitFor polls cond every 5ms up to timeout, returning the time it
+// became true (or t.Fatal on timeout). Used to keep tests fast
+// without flaky sleep-based assertions.
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", what)
+}
+
+func TestReconnectWatchdog_SkipsWhenNoActivityEver(t *testing.T) {
+	// lastUpdateNs == 0 means we never saw a Root. The watchdog should
+	// stay hands-off so a freshly-Connected subscription isn't churned
+	// before its first publisher push arrives.
+	s := newReconnectTestSubscriber(t)
+	if got := s.lastUpdateNs.Load(); got != 0 {
+		t.Fatalf("expected zero lastUpdateNs at start, got %d", got)
+	}
+	go s.runReconnectWatchdogWith(10*time.Millisecond, 50*time.Millisecond)
+	defer close(s.reconnectStop)
+	time.Sleep(100 * time.Millisecond)
+	if got := s.reconnectAttempts.Load(); got != 0 {
+		t.Errorf("expected 0 reconnect attempts when lastUpdate==0, got %d", got)
+	}
+}
+
+func TestReconnectWatchdog_SkipsWhenRecent(t *testing.T) {
+	// lastUpdateNs recent (within threshold) — feed is healthy, no
+	// reconnect needed.
+	s := newReconnectTestSubscriber(t)
+	s.lastUpdateNs.Store(time.Now().UnixNano())
+	go s.runReconnectWatchdogWith(10*time.Millisecond, 500*time.Millisecond)
+	defer close(s.reconnectStop)
+	time.Sleep(60 * time.Millisecond)
+	if got := s.reconnectAttempts.Load(); got != 0 {
+		t.Errorf("expected 0 reconnect attempts on healthy feed, got %d", got)
+	}
+}
+
+func TestReconnectWatchdog_FiresWhenQuiet(t *testing.T) {
+	// lastUpdateNs older than quietThreshold — watchdog should trigger
+	// a Connect attempt on its next tick.
+	s := newReconnectTestSubscriber(t)
+	// 100 ms in the past, threshold is 30 ms → quiet.
+	s.lastUpdateNs.Store(time.Now().Add(-100 * time.Millisecond).UnixNano())
+
+	go s.runReconnectWatchdogWith(10*time.Millisecond, 30*time.Millisecond)
+	defer close(s.reconnectStop)
+
+	waitFor(t, 200*time.Millisecond, "first reconnect attempt", func() bool {
+		return s.reconnectAttempts.Load() >= 1
+	})
+}
+
+func TestReconnectWatchdog_RetriesEveryTickWhileStillQuiet(t *testing.T) {
+	// The watchdog should keep retrying on each tick while the feed
+	// remains quiet — not give up after one failed Connect. Important
+	// for the #2713 scenario where the publisher may take a few seconds
+	// to come back up after a visor restart.
+	s := newReconnectTestSubscriber(t)
+	s.lastUpdateNs.Store(time.Now().Add(-1 * time.Second).UnixNano())
+
+	go s.runReconnectWatchdogWith(10*time.Millisecond, 30*time.Millisecond)
+	defer close(s.reconnectStop)
+
+	waitFor(t, 500*time.Millisecond, "multiple reconnect attempts", func() bool {
+		return s.reconnectAttempts.Load() >= 3
+	})
+}
+
+func TestReconnectWatchdog_StopsOnReconnectStopClosed(t *testing.T) {
+	// Closing reconnectStop must terminate the watchdog goroutine
+	// cleanly. Verifies the Close() path doesn't leak goroutines.
+	s := newReconnectTestSubscriber(t)
+	s.lastUpdateNs.Store(time.Now().Add(-1 * time.Second).UnixNano())
+
+	done := make(chan struct{})
+	go func() {
+		s.runReconnectWatchdogWith(10*time.Millisecond, 30*time.Millisecond)
+		close(done)
+	}()
+	// Let the watchdog fire at least once so we know the goroutine
+	// is alive.
+	waitFor(t, 200*time.Millisecond, "watchdog warmed up", func() bool {
+		return s.reconnectAttempts.Load() >= 1
+	})
+	close(s.reconnectStop)
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("watchdog goroutine did not exit within 200ms of reconnectStop close")
+	}
+}
+
+func TestReconnectWatchdog_StopsRetryingWhileActivityContinues(t *testing.T) {
+	// "Quiet → fires; healthy → stops" oscillation contract: while
+	// real activity keeps bumping lastUpdateNs faster than the quiet
+	// threshold expires, the watchdog should stay hands-off. Models
+	// a real recovered feed where Roots keep arriving.
+	s := newReconnectTestSubscriber(t)
+	s.lastUpdateNs.Store(time.Now().Add(-1 * time.Second).UnixNano())
+
+	go s.runReconnectWatchdogWith(10*time.Millisecond, 100*time.Millisecond)
+	defer close(s.reconnectStop)
+
+	waitFor(t, 300*time.Millisecond, "initial reconnect attempts", func() bool {
+		return s.reconnectAttempts.Load() >= 1
+	})
+	stableAt := s.reconnectAttempts.Load()
+
+	// Simulate continued activity — bump every 20ms, well under the
+	// 100ms quiet threshold. While this loop runs the watchdog should
+	// never decide we're quiet.
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s.lastUpdateNs.Store(time.Now().UnixNano())
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+	time.Sleep(300 * time.Millisecond) // ~30 ticks, ~15 bumps
+	close(stop)
+	<-done
+	if got := s.reconnectAttempts.Load(); got != stableAt {
+		t.Errorf("expected no new reconnect attempts under continuous activity: was %d, now %d", stableAt, got)
+	}
+}
+
+// Sanity check that the atomics-backed fields don't cause a race
+// when accessed from the watchdog goroutine + a synthetic "update"
+// goroutine simulating handleRootFilled. Catches a future refactor
+// that drops atomic.
+func TestReconnectWatchdog_RaceCleanUnderConcurrentBumps(t *testing.T) {
+	s := newReconnectTestSubscriber(t)
+	s.lastUpdateNs.Store(time.Now().Add(-1 * time.Second).UnixNano())
+
+	go s.runReconnectWatchdogWith(5*time.Millisecond, 20*time.Millisecond)
+	defer close(s.reconnectStop)
+
+	var bumps atomic.Int64
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s.lastUpdateNs.Store(time.Now().UnixNano())
+			bumps.Add(1)
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	// No assertion on counts — `go test -race` is the actual judge.
+	// We just want bumps to have happened so the race window is open.
+	if bumps.Load() == 0 {
+		t.Fatal("bumper goroutine never ran")
+	}
+}

--- a/pkg/cxo/treestore/subscriber_reconnect_test.go
+++ b/pkg/cxo/treestore/subscriber_reconnect_test.go
@@ -36,7 +36,7 @@ func newReconnectTestSubscriber(t *testing.T) *Subscriber {
 	if err != nil {
 		t.Fatalf("NewNode: %v", err)
 	}
-	t.Cleanup(func() { _ = cxoNode.Close() })
+	t.Cleanup(func() { _ = cxoNode.Close() }) //nolint:errcheck
 
 	s := &Subscriber{
 		log:                logging.MustGetLogger("treestore-sub-reconnect-test"),


### PR DESCRIPTION
Closes #2713.

## Why

#2711 fixed the case where a visor's own Resume needed to call \`Pair.Connect\` to re-attach its subscribers to peer publishers after **its own** restart. Today's 3-agent federated test (Alpha/Beta/Gamma, 2026-05-18 20:00Z window) surfaced a follow-up: when a **peer's** visor restarts AFTER the local visor's last Resume, the local subscriber is still attached to the peer's pre-restart publisher (which is gone). The peer's fresh publisher comes up on the same deterministic dmsg port, but the local subscriber doesn't detect the disconnect or reconnect.

Repro (per #2713 description, verified live):
1. All 3 agents on post-#2711 binary, pairs all \`status=active\`.
2. Alpha halts visor → Resume re-Connects subscribers to current peer publishers. Pair RX works.
3. Gamma halts visor → Gamma's publisher comes up fresh. Alpha's subscriber is still pointed at the dead pre-Gamma-restart publisher.
4. Gamma sends \`pair send -m foo\`. Alpha's poll empty.
5. Alpha halts visor *again* → Resume re-Connects to Gamma's now-current publisher. Alpha's poll drains \`foo\`.

Workaround until this lands: \"when a peer restarts, restart your visor too.\"

## What

Subscriber-side reconnect watchdog. New fields on \`Subscriber\`:

| field | purpose |
|---|---|
| \`lastUpdateNs atomic.Int64\` | unix-nano of most recent feed-matching handleRootFilled. Bumped on every successful Root walk. |
| \`publisherPK atomic.Pointer[cipher.PubKey]\` | last Connect target — the address the watchdog re-dials. |
| \`reconnectStop / reconnectOnce / reconnectStartOnce\` | watchdog goroutine lifecycle. Started on first successful Connect, stopped by Close. |
| \`reconnectAttempts atomic.Int64\` | lifetime counter, exposed for tests. |

**Watchdog logic** (production wrapper: 60s quiet threshold + 30s tick):
- Every tick, if \`lastUpdateNs == 0\` (no Root ever seen): skip — freshly-Connected feed may be settling.
- If \`time.Since(lastUpdate) < threshold\`: skip — healthy.
- Otherwise: bounded Connect (15s context) to stored \`publisherPK\`. On failure, log + retry next tick. Connect is idempotent on the wire (Subscribe-frame is harmless on a healthy session), so a wasted retry on a naturally-quiet feed costs at most one dmsg dial + one Subscribe frame.

**Trade-off accepted**: a feed that's genuinely quiet for >60s gets a periodic re-Subscribe. Measured cost: one dmsg ConnectPK + one Subscribe per minute per silent feed. Cheap, no data loss, no protocol change. The alternative — dmsg-session-close hook — was more precise but couples treestore to dmsg lifecycle internals; deferred unless this proves wasteful.

## Tests

\`pkg/cxo/treestore/subscriber_reconnect_test.go\` — 7 tests, all pass under \`-race\`:

- \`SkipsWhenNoActivityEver\` — \`lastUpdate==0\` → no attempt
- \`SkipsWhenRecent\` — healthy feed → no attempt
- \`FiresWhenQuiet\` — stale lastUpdate → attempt
- \`RetriesEveryTickWhileStillQuiet\` — sustained failure → keeps trying
- \`StopsOnReconnectStopClosed\` — Close path → goroutine exits
- \`StopsRetryingWhileActivityContinues\` — recovery → stops firing
- \`RaceCleanUnderConcurrentBumps\` — race detector on atomics

Tests use the testable \`runReconnectWatchdogWith(tick, threshold)\` inner form with small values (10-100ms) so they finish in <1s each. The production constants (\`reconnectQuietThreshold = 60s\`, \`reconnectWatchdogTick = 30s\`) are wired in the \`runReconnectWatchdog()\` wrapper.

```
$ go test -race ./pkg/cxo/treestore/
ok  github.com/skycoin/skywire/pkg/cxo/treestore  21.795s
```

## Coordination context

3-agent federated test on 2026-05-18 reached a state where #2711 was deployed across all visors and the only remaining defect was this 2nd-order re-Connect gap. Alpha filed #2713 with three candidate fixes; Alpha greenlit me to take (1) the subscriber-side reconnect loop. Beta + Alpha both restarted visors mid-test to verify the workaround works — this PR removes the need for that workaround.

## Test plan

- [x] \`go build ./pkg/cxo/treestore/...\` clean
- [x] \`go vet ./pkg/cxo/treestore/...\` clean
- [x] \`go test -race ./pkg/cxo/treestore/\` all pass (incl. 7 new watchdog tests)
- [ ] CI green across darwin / windows / linux / static-musl
- [ ] After merge + deploy: re-run the 3-agent federated test sequence from this morning, confirm pair-RX recovers automatically within ~90s after a peer's restart with no local-restart needed