### PR TITLE
feat(ipv6): phase 1 schema — RemoteAddrV6 + AddressV6, per-family bind merge

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -282,6 +282,36 @@ func (a *API) logger(r *http.Request) logrus.FieldLogger {
 	return httputil.GetLogger(r)
 }
 
+// splitFamilyAddr returns the IPv4 and IPv6 RemoteAddr values for an
+// observed bind source address. Exactly one of the return values is
+// non-empty; family is inferred by parsing the host portion of addr.
+// addr may be either a bare host ("1.2.3.4" / "::1" — STCPR style)
+// or host:port ("1.2.3.4:5060" / "[::1]:5060" — SUDPH style); both
+// are accepted. An unparseable input (host that isn't a valid IP)
+// falls through to v4 to match historical behavior where any
+// non-empty observed RemoteAddr went into the single RemoteAddr
+// field unchanged.
+//
+// Paired with the per-family merge in store.Bind: a dual-stack
+// visor's two binds (one over IPv4 HTTP, one over IPv6 HTTP) each
+// populate one of v4/v6 here, and the store merges them into a
+// single record. See pkg/transport/network/addrresolver.VisorData
+// and #1525 for the full design.
+func splitFamilyAddr(addr string) (v4, v6 string) {
+	if addr == "" {
+		return "", ""
+	}
+	host := addr
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		host = h
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || ip.To4() != nil {
+		return addr, ""
+	}
+	return "", addr
+}
+
 func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 	remoteAddr := httpauth.GetRemoteAddr(r)
 	a.logger(r).Infof("New POST /bind/stcpr request from %v", remoteAddr)
@@ -340,8 +370,10 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	v4Addr, v6Addr := splitFamilyAddr(remoteAddr)
 	visorData := addrresolver.VisorData{
-		RemoteAddr:     remoteAddr,
+		RemoteAddr:     v4Addr,
+		RemoteAddrV6:   v6Addr,
 		LocalAddresses: localAddresses,
 	}
 
@@ -813,8 +845,10 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 		}
 	}
 
+	v4SUDPH, v6SUDPH := splitFamilyAddr(effectiveRemoteAddr)
 	visorData := addrresolver.VisorData{
-		RemoteAddr:     effectiveRemoteAddr,
+		RemoteAddr:     v4SUDPH,
+		RemoteAddrV6:   v6SUDPH,
 		LocalAddresses: localAddresses,
 	}
 
@@ -864,8 +898,10 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 			// Handle re-registration: try to unmarshal as LocalAddresses
 			var localAddresses addrresolver.LocalAddresses
 			if err := json.Unmarshal(data, &localAddresses); err == nil && localAddresses.Port != "" {
+				v4Re, v6Re := splitFamilyAddr(fromAddr)
 				newVisorData := addrresolver.VisorData{
-					RemoteAddr:     fromAddr,
+					RemoteAddr:     v4Re,
+					RemoteAddrV6:   v6Re,
 					LocalAddresses: localAddresses,
 				}
 				if err := a.store.Bind(context.Background(), types.SUDPH, pk, newVisorData); err != nil {

--- a/pkg/address-resolver/api/ipv6_split_test.go
+++ b/pkg/address-resolver/api/ipv6_split_test.go
@@ -1,0 +1,52 @@
+// Package api — pkg/address-resolver/api/ipv6_split_test.go
+//
+// Verifies splitFamilyAddr family detection over the input shapes
+// the AR bind handlers actually feed it: bare host (STCPR style),
+// host:port (SUDPH style), and edge cases (empty, unparseable,
+// IPv4-mapped IPv6). Paired with the per-family merge in
+// store.Bind, this is the round-trip that lets a dual-stack visor
+// register both families in one AR record. See #1525 Phase 1.
+package api
+
+import (
+	"testing"
+)
+
+func TestSplitFamilyAddr(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantV4    string
+		wantV6    string
+	}{
+		// STCPR-style bare host inputs.
+		{"v4 bare host", "203.0.113.5", "203.0.113.5", ""},
+		{"v6 bare host", "2001:db8::1", "", "2001:db8::1"},
+		{"v6 loopback", "::1", "", "::1"},
+
+		// SUDPH-style host:port inputs.
+		{"v4 host:port", "203.0.113.5:5060", "203.0.113.5:5060", ""},
+		{"v6 host:port bracketed", "[2001:db8::1]:5060", "", "[2001:db8::1]:5060"},
+
+		// Backward-compat fallbacks: unparseable or empty inputs.
+		// Historically these would have gone into the single
+		// RemoteAddr field unchanged; preserve that contract so we
+		// don't regress on a hostname-style PublicIP declaration.
+		{"non-IP hostname", "visor.example.com", "visor.example.com", ""},
+		{"empty", "", "", ""},
+
+		// IPv4-mapped IPv6 (::ffff:1.2.3.4) is semantically v4
+		// traffic — must classify as v4 so dialers don't try a
+		// useless v6 route. net.ParseIP().To4() does this for us.
+		{"v4-mapped v6", "::ffff:203.0.113.5", "::ffff:203.0.113.5", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v4, v6 := splitFamilyAddr(tc.in)
+			if v4 != tc.wantV4 || v6 != tc.wantV6 {
+				t.Errorf("splitFamilyAddr(%q) = (%q, %q); want (%q, %q)",
+					tc.in, v4, v6, tc.wantV4, tc.wantV6)
+			}
+		})
+	}
+}

--- a/pkg/address-resolver/api/ipv6_split_test.go
+++ b/pkg/address-resolver/api/ipv6_split_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestSplitFamilyAddr(t *testing.T) {
 	cases := []struct {
-		name      string
-		in        string
-		wantV4    string
-		wantV6    string
+		name   string
+		in     string
+		wantV4 string
+		wantV6 string
 	}{
 		// STCPR-style bare host inputs.
 		{"v4 bare host", "203.0.113.5", "203.0.113.5", ""},

--- a/pkg/address-resolver/store/ipv6_merge_test.go
+++ b/pkg/address-resolver/store/ipv6_merge_test.go
@@ -1,0 +1,81 @@
+//go:build !no_ci
+// +build !no_ci
+
+// Package store — pkg/address-resolver/store/ipv6_merge_test.go
+//
+// Verifies the per-family merge semantics added in #1525 Phase 1:
+// a dual-stack visor binds twice (once over IPv4 HTTP, once over
+// IPv6 HTTP). Each Bind carries exactly one of RemoteAddr /
+// RemoteAddrV6 (the family the AR server captured from the
+// connecting socket). After the second Bind, Resolve must return
+// BOTH addrs — naive overwrite would clobber the first family.
+//
+// Backward-compat: a v4-only visor (RemoteAddrV6 stays empty)
+// continues to behave exactly as today.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func TestMemoryStore_BindMergesFamilyAddrs(t *testing.T) {
+	ctx := context.Background()
+	s := newMemoryStore()
+	pk, _ := cipher.GenerateKeyPair()
+
+	// Bind 1: IPv4 only (simulates visor's v4 HTTP bind).
+	require.NoError(t, s.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+		RemoteAddr: "203.0.113.5",
+	}))
+	got, err := s.Resolve(ctx, types.STCPR, pk)
+	require.NoError(t, err)
+	require.Equal(t, "203.0.113.5", got.RemoteAddr)
+	require.Empty(t, got.RemoteAddrV6)
+
+	// Bind 2: IPv6 only (simulates visor's v6 HTTP bind). Merge
+	// must preserve the prior v4 addr.
+	require.NoError(t, s.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+		RemoteAddrV6: "2001:db8::1",
+	}))
+	got, err = s.Resolve(ctx, types.STCPR, pk)
+	require.NoError(t, err)
+	require.Equal(t, "203.0.113.5", got.RemoteAddr, "v4 addr must survive subsequent v6-only bind")
+	require.Equal(t, "2001:db8::1", got.RemoteAddrV6)
+
+	// Bind 3: refresh v4 with a NEW address. Merge must replace
+	// the v4 addr but keep the v6 from the prior bind.
+	require.NoError(t, s.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+		RemoteAddr: "203.0.113.99",
+	}))
+	got, err = s.Resolve(ctx, types.STCPR, pk)
+	require.NoError(t, err)
+	require.Equal(t, "203.0.113.99", got.RemoteAddr, "fresh v4 bind replaces prior v4")
+	require.Equal(t, "2001:db8::1", got.RemoteAddrV6, "v6 addr must survive v4-only re-bind")
+}
+
+func TestMemoryStore_BindV4OnlyBackwardCompat(t *testing.T) {
+	// Pre-#1525 callers populate only RemoteAddr and expect Resolve
+	// to round-trip unchanged. The merge logic must not introduce
+	// any v6 ghost into a never-v6 record.
+	ctx := context.Background()
+	s := newMemoryStore()
+	pk, _ := cipher.GenerateKeyPair()
+
+	require.NoError(t, s.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+		RemoteAddr: "203.0.113.5",
+	}))
+	require.NoError(t, s.Bind(ctx, types.STCPR, pk, addrresolver.VisorData{
+		RemoteAddr: "203.0.113.5", // 90s refresh, same addr
+	}))
+	got, err := s.Resolve(ctx, types.STCPR, pk)
+	require.NoError(t, err)
+	require.Equal(t, "203.0.113.5", got.RemoteAddr)
+	require.Empty(t, got.RemoteAddrV6)
+}

--- a/pkg/address-resolver/store/memory_store.go
+++ b/pkg/address-resolver/store/memory_store.go
@@ -28,6 +28,22 @@ func (s *memStore) Bind(_ context.Context, netType types.Type, pk cipher.PubKey,
 		s.visorData[netType] = make(map[string]addrresolver.VisorData)
 	}
 
+	// Preserve the other-family RemoteAddr when this bind only carries
+	// one of the two. A dual-stack visor calls Bind twice — once over
+	// IPv4 HTTP (sets RemoteAddr only) and once over IPv6 HTTP (sets
+	// RemoteAddrV6 only). Naive overwrite would clobber the prior
+	// family's record and force-back to single-stack until the next
+	// 90s refresh cycle. Merge preserves whichever family addr the
+	// new payload didn't touch.
+	if existing, ok := s.visorData[netType][pk.String()]; ok {
+		if visorData.RemoteAddr == "" && existing.RemoteAddr != "" {
+			visorData.RemoteAddr = existing.RemoteAddr
+		}
+		if visorData.RemoteAddrV6 == "" && existing.RemoteAddrV6 != "" {
+			visorData.RemoteAddrV6 = existing.RemoteAddrV6
+		}
+	}
+
 	s.visorData[netType][pk.String()] = visorData
 
 	return nil

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -130,13 +130,36 @@ func (s *redisStore) resolve(ctx context.Context, key string) (addrresolver.Viso
 // bindWithIndex pipelines the per-PK Set with an SAdd to the per-netType
 // index set. The SAdd is idempotent on re-bind (90 s refresh cadence), so
 // the index converges to the live set without explicit dedup.
+//
+// Family merge: a dual-stack visor binds twice (once per IPv4 / IPv6
+// HTTP socket). Each call sets exactly one of RemoteAddr / RemoteAddrV6
+// (the family the AR server observed). We Get the existing record first
+// and preserve whichever family addr the new payload didn't touch, so
+// the dual-stack record converges to {v4, v6} both populated. Naive
+// overwrite would clobber the prior family for ~90s until the next
+// refresh — operators dialing during that window would see only one
+// family even though the visor offers both.
+//
+// The Get + Set is NOT atomic; two concurrent binds for the same PK
+// over different families can race and lose one update. The 90 s
+// refresh cycle naturally heals such a race within one period, so we
+// accept the simpler implementation rather than a WATCH/MULTI loop.
 func (s *redisStore) bindWithIndex(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
+	key := getKey(string(netType), pk)
+	if existing, err := s.resolve(ctx, key); err == nil {
+		if visorData.RemoteAddr == "" && existing.RemoteAddr != "" {
+			visorData.RemoteAddr = existing.RemoteAddr
+		}
+		if visorData.RemoteAddrV6 == "" && existing.RemoteAddrV6 != "" {
+			visorData.RemoteAddrV6 = existing.RemoteAddrV6
+		}
+	}
 	raw, err := json.Marshal(visorData)
 	if err != nil {
 		return err
 	}
 	pipe := s.client.Pipeline()
-	pipe.Set(ctx, getKey(string(netType), pk), string(raw), s.ttl)
+	pipe.Set(ctx, key, string(raw), s.ttl)
 	pipe.SAdd(ctx, indexKey(string(netType)), pk.String())
 	_, err = pipe.Exec(ctx)
 	return err

--- a/pkg/dmsg/disc/entry.go
+++ b/pkg/dmsg/disc/entry.go
@@ -168,8 +168,22 @@ func (c *Client) String() string {
 
 // Server contains parameters for Server instances.
 type Server struct {
-	// IPv4 or IPv6 public address of the DMSG Server.
+	// Address is the DMSG Server's reachable endpoint ("host:port").
+	// Historically an IPv4 or IPv6 address could go in this field
+	// either-or; with the dual-stack-within-record design (see #1525)
+	// Address now canonically carries the IPv4 endpoint and
+	// AddressV6 carries the IPv6 counterpart. Servers listening on
+	// only one family leave the other blank; servers listening on
+	// both populate both. Dialers prefer v6 with v4 fallback per
+	// RFC 8305.
 	Address string `json:"address"`
+
+	// AddressV6 is the optional IPv6 ("[host]:port") endpoint for
+	// dual-stack DMSG servers. Empty when the server is v4-only.
+	// Backward-compat: older servers omit this field; older clients
+	// ignore it; either side absent the field falls through to
+	// Address as today.
+	AddressV6 string `json:"address_v6,omitempty"`
 
 	// AvailableSessions is the number of available sessions that the server can currently accept.
 	AvailableSessions int `json:"availableSessions"`

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -76,9 +76,21 @@ type APIClient interface {
 }
 
 // VisorData stores visor data.
+//
+// RemoteAddr is the visor's reachable IPv4 endpoint ("host:port"),
+// observed by the AR server from the bind request's source socket
+// (or carried via the visor's declared PublicIP). RemoteAddrV6 is
+// the optional IPv6 counterpart, populated when the visor binds
+// over an IPv6 HTTP client. A dual-stack visor calls bind twice
+// (once per family) and the AR server merges into a single record;
+// peers Resolve once and the dialer picks a family (v6 first per
+// RFC 8305 with v4 fallback). Backward-compat: v4-only visors and
+// older AR servers emit/store an empty RemoteAddrV6 and the rest
+// of the pipeline behaves exactly as today.
 type VisorData struct {
-	RemoteAddr string `json:"remote_addr"`
-	IsLocal    bool   `json:"is_local,omitempty"`
+	RemoteAddr   string `json:"remote_addr"`
+	RemoteAddrV6 string `json:"remote_addr_v6,omitempty"`
+	IsLocal      bool   `json:"is_local,omitempty"`
 	LocalAddresses
 }
 


### PR DESCRIPTION
## Summary

First slice of the dual-stack-within-type IPv6 design tracked at **#1525** (see [updated design comment](https://github.com/skycoin/skywire/issues/1525#issuecomment-4482164950)). Adds optional v6 address fields to the two records that carry peer endpoints + teaches the AR to capture address family from the connecting socket + merges per-family Binds so a dual-stack visor's two binds converge into one `{v4, v6}` record.

## Schema

```go
// pkg/transport/network/addrresolver.VisorData
RemoteAddrV6 string `json:"remote_addr_v6,omitempty"`

// pkg/dmsg/disc.Server
AddressV6 string `json:"address_v6,omitempty"`
```

Both `omitempty` — v4-only visors and pre-#1525 AR servers are fully compatible.

## Behavior

| Visor → AR | Server captures | Stored record |
|------------|-----------------|---------------|
| v4 HTTP bind | `RemoteAddr` (v4) | `{v4, ""}` |
| then v6 HTTP bind | `RemoteAddrV6` (v6) | `{v4, v6}` (merged) |
| v4 refresh (new addr) | `RemoteAddr` (v4') | `{v4', v6}` (v6 preserved) |

`splitFamilyAddr` infers family by parsing the host portion of the observed remote address (accepts bare host for STCPR + `host:port` for SUDPH; v4-mapped v6 classifies as v4; unparseable hostnames fall through to v4 to preserve the historical contract for declared-PublicIP strings).

## Test plan

- [x] `go build ./...` clean
- [x] **10 new tests pass**:
  - `TestSplitFamilyAddr` × 8 subtests (v4/v6 bare hosts, v4/v6 host:port, v4-mapped v6, non-IP hostname fallback, empty)
  - `TestMemoryStore_BindMergesFamilyAddrs` (v4 → v6 → v4-refresh sequence; each step verifies the un-touched family's addr survived)
  - `TestMemoryStore_BindV4OnlyBackwardCompat` (single-family records never grow a v6 ghost)
- [x] Existing AR + dmsg-disc test suites still pass (only `TestRedis` fails because no local redis server, unrelated)

## Unblocks

- **Phase 2** (visor v6 bind + dmsg-server v6 host) — Alpha will follow up
- **Phase 3** (Happy Eyeballs dialer) — Beta scoped
- **Phase 4** (hypervisor UI family column) — Gamma scoped
- **Phase 5** (CI v6-only lane) — Gamma scoped

## Operator deploy note

Even after the full IPv6 stack lands, **v6 won't actually be exercised until AAAA DNS records are added for `ip.skycoin.com`, `ar.skywire…`, and dmsg-disc**. Visors learn their public IP from `ip.skycoin.com` (currently A-only at `139.162.160.227`), and AR/dmsg-disc are reached by name. Code without DNS is silent — operator action required before v6 traffic flows.

Refs #1525