### PR TITLE
feat(ipv6): phase 2a — dmsg-server v6 advertisement in discovery entry

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -133,7 +133,7 @@ type Client struct {
 // Safe to call before or after Serve. Subsequent updateClientEntry
 // iterations pick up the new endpoint automatically.
 func (c *Client) AddDiscovery(client disc.APIClient, discPK cipher.PubKey) {
-	c.addDiscovery(client, "", discPK)
+	c.addDiscovery(client, "", "", discPK)
 }
 
 // SetDiscoveryClients replaces the underlying disc.APIClient on each

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -26,9 +26,10 @@ import (
 // PK so the entity can recognize an inbound session as originating
 // from that discovery and trigger an immediate registration push.
 type discoveryEndpoint struct {
-	Client         disc.APIClient
-	AdvertisedAddr string
-	PK             cipher.PubKey
+	Client           disc.APIClient
+	AdvertisedAddr   string
+	AdvertisedAddrV6 string
+	PK               cipher.PubKey
 }
 
 // EntityCommon contains the common fields and methods for server and client entities.
@@ -111,21 +112,26 @@ func (c *EntityCommon) init(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClien
 
 // addDiscovery appends an additional dmsg-discovery to register with.
 // advertisedAddr, when non-empty, overrides the entity's default addr
-// for this discovery (servers only — clients should pass empty). pk,
-// when non-zero, identifies the discovery's own dmsg-server PK so the
-// entity can detect inbound sessions from this discovery.
+// for this discovery (servers only — clients should pass empty).
+// advertisedAddrV6, when non-empty, is the optional IPv6 endpoint
+// counterpart to advertisedAddr — stored in disc.Server.AddressV6 on
+// the next updateServerEntry tick. Empty preserves single-stack v4
+// advertisement (the pre-#1525 default). pk, when non-zero, identifies
+// the discovery's own dmsg-server PK so the entity can detect inbound
+// sessions from this discovery.
 //
 // Safe to call after init/Serve has started — subsequent
 // updateServerEntryLoop iterations will pick up the new endpoint.
-func (c *EntityCommon) addDiscovery(client disc.APIClient, advertisedAddr string, pk cipher.PubKey) {
+func (c *EntityCommon) addDiscovery(client disc.APIClient, advertisedAddr, advertisedAddrV6 string, pk cipher.PubKey) {
 	if client == nil {
 		return
 	}
 	c.discoveriesMx.Lock()
 	c.discoveries = append(c.discoveries, &discoveryEndpoint{
-		Client:         client,
-		AdvertisedAddr: advertisedAddr,
-		PK:             pk,
+		Client:           client,
+		AdvertisedAddr:   advertisedAddr,
+		AdvertisedAddrV6: advertisedAddrV6,
+		PK:               pk,
 	})
 	c.discoveriesMx.Unlock()
 }
@@ -285,7 +291,7 @@ func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey) {
 // If 'addr' is an empty string AND no endpoint provides its own
 // advertised address, no update is performed for that endpoint
 // (preserving the legacy "empty addr = skip update" semantics).
-func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSessions int, authPassphrase string) (err error) {
+func (c *EntityCommon) updateServerEntry(ctx context.Context, addr, addrV6 string, maxSessions int, authPassphrase string) (err error) {
 	endpoints := c.snapshotDiscoveries()
 	if len(endpoints) == 0 {
 		return errors.New("updateServerEntry: no discoveries configured")
@@ -319,7 +325,16 @@ func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSe
 		if epAddr == "" {
 			continue
 		}
-		if updateErr := c.updateServerEntryOnEndpoint(ctx, ep, epAddr, availableSessions, authPassphrase); updateErr != nil {
+		// V6 follows the same per-endpoint-override semantics as v4:
+		// a non-empty per-endpoint AdvertisedAddrV6 wins; otherwise
+		// fall back to the entity-level addrV6 (empty when the
+		// server isn't dual-stack-configured). Empty addrV6 → v4-only
+		// entry, preserving backward compat for pre-#1525 servers.
+		epAddrV6 := addrV6
+		if ep.AdvertisedAddrV6 != "" {
+			epAddrV6 = ep.AdvertisedAddrV6
+		}
+		if updateErr := c.updateServerEntryOnEndpoint(ctx, ep, epAddr, epAddrV6, availableSessions, authPassphrase); updateErr != nil {
 			if firstErr == nil {
 				firstErr = updateErr
 			}
@@ -335,11 +350,15 @@ func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSe
 }
 
 // updateServerEntryOnEndpoint runs the read-modify-write registration
-// cycle against a single discovery endpoint.
-func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, addr string, availableSessions int, authPassphrase string) error {
+// cycle against a single discovery endpoint. addrV6 is the optional
+// IPv6 counterpart to addr — empty when the server is v4-only, which
+// keeps the entry's AddressV6 field omitempty-elided exactly as
+// pre-#1525.
+func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, addr, addrV6 string, availableSessions int, authPassphrase string) error {
 	entry, err := ep.Client.Entry(ctx, c.pk)
 	if err != nil {
 		entry = disc.NewServerEntry(c.pk, 0, addr, availableSessions)
+		entry.Server.AddressV6 = addrV6
 		entry.Server.DHTBootstrap = c.dhtBootstrap
 		if err := entry.Sign(c.sk); err != nil {
 			return err
@@ -357,9 +376,10 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 
 	sessionsDelta := entry.Server.AvailableSessions != availableSessions
 	addrDelta := entry.Server.Address != addr
+	addrV6Delta := entry.Server.AddressV6 != addrV6
 
 	// No update needed if entry has no delta AND update is not due.
-	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !due {
+	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !addrV6Delta && !due {
 		return nil
 	}
 
@@ -372,6 +392,10 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 		entry.Server.Address = addr
 		log = log.WithField("addr", entry.Server.Address)
 	}
+	if addrV6Delta {
+		entry.Server.AddressV6 = addrV6
+		log = log.WithField("addr_v6", entry.Server.AddressV6)
+	}
 	// Propagate DHT bootstrap status to discovery entry.
 	entry.Server.DHTBootstrap = c.dhtBootstrap
 	log.Debug("Updating entry.\n")
@@ -379,7 +403,7 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 	return ep.Client.PutEntry(ctx, c.sk, entry)
 }
 
-func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, maxSessions int, authPassphrase string) {
+func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr, addrV6 string, maxSessions int, authPassphrase string) {
 	t := time.NewTimer(c.updateInterval)
 	defer t.Stop()
 
@@ -394,7 +418,7 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, m
 				continue
 			}
 
-			err := c.updateServerEntry(ctx, addr, maxSessions, authPassphrase)
+			err := c.updateServerEntry(ctx, addr, addrV6, maxSessions, authPassphrase)
 			if err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry.")
 			}
@@ -417,7 +441,7 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr string, m
 				}
 			}
 		serverUpdate:
-			err := c.updateServerEntry(ctx, addr, maxSessions, authPassphrase)
+			err := c.updateServerEntry(ctx, addr, addrV6, maxSessions, authPassphrase)
 			if err != nil {
 				c.log.WithError(err).Warn("Failed to update discovery entry (nudge).")
 			}

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -58,7 +58,15 @@ type Server struct {
 
 	// Public TCP address which the dmsg server advertises itself as.
 	// This should only be set once. Once set, addrDone closes.
+	//
+	// addr is the IPv4 endpoint (legacy single-stack contract); addrV6
+	// is the optional IPv6 endpoint, set independently via
+	// SetAdvertisedAddrV6 before Serve when the operator wants the
+	// server discoverable over both families. Empty addrV6 keeps the
+	// pre-#1525 single-stack behavior — disc.Server.AddressV6 stays
+	// empty and v4-only clients see no change.
 	addr     string
+	addrV6   string
 	addrDone chan struct{}
 
 	maxSessions int
@@ -236,13 +244,13 @@ func (s *Server) startUpdateEntryLoop(ctx context.Context) error {
 		// updateServerEntry takes sessionsMx internally only for the
 		// session-count snapshot; do NOT hold it across this call —
 		// see the comment in EntityCommon.updateServerEntry.
-		return s.updateServerEntry(ctx, s.AdvertisedAddr(), s.maxSessions, s.authPassphrase)
+		return s.updateServerEntry(ctx, s.AdvertisedAddr(), s.AdvertisedAddrV6(), s.maxSessions, s.authPassphrase)
 	})
 	if err != nil {
 		return err
 	}
 
-	go s.updateServerEntryLoop(ctx, s.AdvertisedAddr(), s.maxSessions, s.authPassphrase)
+	go s.updateServerEntryLoop(ctx, s.AdvertisedAddr(), s.AdvertisedAddrV6(), s.maxSessions, s.authPassphrase)
 	return nil
 }
 
@@ -251,6 +259,15 @@ func (s *Server) startUpdateEntryLoop(ctx context.Context) error {
 func (s *Server) AdvertisedAddr() string {
 	<-s.addrDone
 	return s.addr
+}
+
+// AdvertisedAddrV6 returns the optional IPv6 TCP address the dmsg server
+// is advertised as. Empty when the server hasn't been configured for
+// IPv6 (the default — preserves the pre-#1525 single-stack contract).
+// Does NOT block on addrDone: v6 advertisement is independent of the
+// primary v4 advertisement and may legitimately remain empty.
+func (s *Server) AdvertisedAddrV6() string {
+	return s.addrV6
 }
 
 // AddDiscovery registers an additional dmsg-discovery this server
@@ -264,7 +281,18 @@ func (s *Server) AdvertisedAddr() string {
 // Safe to call before or after Serve. Subsequent updateServerEntry
 // iterations pick up the new endpoint automatically.
 func (s *Server) AddDiscovery(client disc.APIClient, advertisedAddr string, discPK cipher.PubKey) {
-	s.addDiscovery(client, advertisedAddr, discPK)
+	s.addDiscovery(client, advertisedAddr, "", discPK)
+}
+
+// AddDiscoveryDualStack is the dual-stack variant of AddDiscovery —
+// adds an additional v6 endpoint advertised to this discovery alongside
+// advertisedAddr. Empty advertisedAddrV6 is equivalent to calling
+// AddDiscovery (v4-only for this endpoint). Use this when the same
+// server should expose distinct {v4, v6} addresses to a particular
+// discovery (e.g. LAN-v6 to a local discovery while still v4-public
+// elsewhere).
+func (s *Server) AddDiscoveryDualStack(client disc.APIClient, advertisedAddr, advertisedAddrV6 string, discPK cipher.PubKey) {
+	s.addDiscovery(client, advertisedAddr, advertisedAddrV6, discPK)
 }
 
 // SetDiscoveryClients replaces the underlying disc.APIClient on each
@@ -288,6 +316,16 @@ func (s *Server) SetAdvertisedAddr(lis net.Listener, addr *string) {
 	}
 	s.addr = *addr
 	close(s.addrDone)
+}
+
+// SetAdvertisedAddrV6 sets the optional IPv6 advertised address. Must
+// be called BEFORE Serve so the first updateServerEntry tick already
+// carries the v6 endpoint. Empty addr is a no-op (leaves the server
+// IPv4-only). Independent of SetAdvertisedAddr — they can be called in
+// either order, and the absence of a v6 SetAdvertisedAddrV6 call is
+// the default "no v6 advertisement" behavior for backward compat.
+func (s *Server) SetAdvertisedAddrV6(addr string) {
+	s.addrV6 = addr
 }
 
 // Ready returns a chan which blocks until the server begins serving.

--- a/pkg/dmsg/dmsg/server_ipv6_test.go
+++ b/pkg/dmsg/dmsg/server_ipv6_test.go
@@ -1,0 +1,59 @@
+// Package dmsg — pkg/dmsg/dmsg/server_ipv6_test.go
+//
+// Coverage for the Phase 2a additions: dmsg.Server's optional IPv6
+// advertised-address surface. Verifies SetAdvertisedAddrV6 /
+// AdvertisedAddrV6 round-trip in isolation (no networking) and that
+// the default zero-value behavior preserves single-stack v4 contract
+// for callers that never touch v6.
+package dmsg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg/metrics"
+)
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	dc := disc.NewMock(0)
+	return NewServer(pk, sk, dc, nil, metrics.NewEmpty())
+}
+
+// TestServer_AdvertisedAddrV6_EmptyByDefault verifies a fresh Server
+// reports an empty v6 advertised address — the pre-#1525 single-stack
+// default. The legacy v4 AdvertisedAddr getter blocks on addrDone, so
+// we don't call it here; AdvertisedAddrV6 must NOT block (v6 is
+// optional, see the doc on the getter).
+func TestServer_AdvertisedAddrV6_EmptyByDefault(t *testing.T) {
+	s := newTestServer(t)
+	assert.Empty(t, s.AdvertisedAddrV6(),
+		"Server with no SetAdvertisedAddrV6 call must report empty (v4-only contract)")
+}
+
+// TestServer_SetAdvertisedAddrV6_RoundTrip verifies the setter is
+// captured by the getter and that a non-empty value survives. Mirrors
+// the existing SetAdvertisedAddr contract minus the one-shot constraint
+// (v6 advertisement is independent, so we don't gate it on addrDone).
+func TestServer_SetAdvertisedAddrV6_RoundTrip(t *testing.T) {
+	s := newTestServer(t)
+	s.SetAdvertisedAddrV6("[2001:db8::1]:8081")
+	assert.Equal(t, "[2001:db8::1]:8081", s.AdvertisedAddrV6())
+}
+
+// TestServer_SetAdvertisedAddrV6_OverwriteAllowed verifies that, unlike
+// v4 SetAdvertisedAddr's "set once" contract (enforced by closing
+// addrDone exactly once), SetAdvertisedAddrV6 can be called multiple
+// times. This matters for operator workflows where the v6 endpoint is
+// only known after dmsg-server inspects an external network event
+// (e.g. a router advertisement arriving post-Serve).
+func TestServer_SetAdvertisedAddrV6_OverwriteAllowed(t *testing.T) {
+	s := newTestServer(t)
+	s.SetAdvertisedAddrV6("[2001:db8::1]:8081")
+	s.SetAdvertisedAddrV6("[2001:db8::2]:8081")
+	assert.Equal(t, "[2001:db8::2]:8081", s.AdvertisedAddrV6())
+}

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -110,9 +110,9 @@ type Config struct {
 	// DiscoveryDmsg is set (URL form `dmsg://<PK>:<port>`), the PK is
 	// extracted automatically and used to upgrade registration from
 	// plain HTTP to dmsgfirst.
-	Discovery        string        `json:"discovery,omitempty"`
-	DiscoveryDmsg    string        `json:"discovery_dmsg,omitempty"`
-	PublicAddress    string        `json:"public_address,omitempty"`
+	Discovery     string `json:"discovery,omitempty"`
+	DiscoveryDmsg string `json:"discovery_dmsg,omitempty"`
+	PublicAddress string `json:"public_address,omitempty"`
 	// PublicAddressV6 is the optional IPv6 advertised endpoint. When
 	// non-empty, the server registers AddressV6 alongside Address in
 	// its disc.Entry so dual-stack peers can dial it over IPv6 (the

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -50,11 +50,12 @@ type PeerConfig struct {
 // `dmsg://<PK>:<port>`); there is no separate PK field. Callers
 // extract it on demand for dmsgfirst registration.
 type Deployment struct {
-	Discovery         string        `json:"discovery,omitempty"`
-	DiscoveryDmsg     string        `json:"discovery_dmsg,omitempty"`
-	SessionsCount     int           `json:"sessions_count,omitempty"`
-	Servers           []*disc.Entry `json:"servers,omitempty"`
-	AdvertisedAddress string        `json:"advertised_address,omitempty"`
+	Discovery           string        `json:"discovery,omitempty"`
+	DiscoveryDmsg       string        `json:"discovery_dmsg,omitempty"`
+	SessionsCount       int           `json:"sessions_count,omitempty"`
+	Servers             []*disc.Entry `json:"servers,omitempty"`
+	AdvertisedAddress   string        `json:"advertised_address,omitempty"`
+	AdvertisedAddressV6 string        `json:"advertised_address_v6,omitempty"`
 }
 
 // DmsgConfig is the per-server `dmsg` block. JSON polymorphism
@@ -112,6 +113,14 @@ type Config struct {
 	Discovery        string        `json:"discovery,omitempty"`
 	DiscoveryDmsg    string        `json:"discovery_dmsg,omitempty"`
 	PublicAddress    string        `json:"public_address,omitempty"`
+	// PublicAddressV6 is the optional IPv6 advertised endpoint. When
+	// non-empty, the server registers AddressV6 alongside Address in
+	// its disc.Entry so dual-stack peers can dial it over IPv6 (the
+	// dialer's Happy Eyeballs in Phase 3 picks v6 first when both are
+	// present). The local TCP listener is unchanged — wildcard binds
+	// already accept both families; this field is purely a discovery
+	// advertisement.
+	PublicAddressV6  string        `json:"public_address_v6,omitempty"`
 	LocalAddress     string        `json:"local_address"`
 	HTTPAddress      string        `json:"health_endpoint_address"`
 	LogLevel         string        `json:"log_level"`
@@ -166,6 +175,14 @@ func (c *Config) NormalizedDeployments() []Deployment {
 	for i, d := range src {
 		if d.AdvertisedAddress == "" {
 			d.AdvertisedAddress = c.PublicAddress
+		}
+		// Mirror the v4 fold for the optional v6 endpoint: a non-
+		// empty per-deployment AdvertisedAddressV6 wins; otherwise
+		// the top-level PublicAddressV6 is used. Empty after both
+		// layers leaves the deployment v4-only — disc.Server's
+		// AddressV6 stays omitempty-elided.
+		if d.AdvertisedAddressV6 == "" {
+			d.AdvertisedAddressV6 = c.PublicAddressV6
 		}
 		out[i] = d
 	}

--- a/pkg/dmsg/dmsgserver/ipv6_test.go
+++ b/pkg/dmsg/dmsgserver/ipv6_test.go
@@ -1,0 +1,85 @@
+package dmsgserver_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgserver"
+)
+
+// TestConfig_PublicAddressV6_FoldsToDeployments verifies that a
+// top-level PublicAddressV6 is folded into each NormalizedDeployment's
+// AdvertisedAddressV6 (mirror of the existing v4 fold logic). This is
+// the path the cmd/dmsg/dmsg-server start command relies on to surface
+// a single-config v6 advertisement.
+func TestConfig_PublicAddressV6_FoldsToDeployments(t *testing.T) {
+	c := dmsgserver.Config{
+		Discovery:       "https://disc.example.com",
+		PublicAddress:   "203.0.113.5:8081",
+		PublicAddressV6: "[2001:db8::1]:8081",
+	}
+	ds := c.NormalizedDeployments()
+	require.Len(t, ds, 1)
+	assert.Equal(t, "203.0.113.5:8081", ds[0].AdvertisedAddress)
+	assert.Equal(t, "[2001:db8::1]:8081", ds[0].AdvertisedAddressV6)
+}
+
+// TestConfig_PublicAddressV6_PerDeploymentOverride verifies the same
+// fold semantics as v4: a non-empty per-deployment AdvertisedAddressV6
+// wins over the top-level PublicAddressV6, identical to the existing
+// AdvertisedAddress / PublicAddress relationship.
+func TestConfig_PublicAddressV6_PerDeploymentOverride(t *testing.T) {
+	rawJSON := `{
+        "dmsg": {
+            "discovery": "https://disc-local.example.com",
+            "advertised_address": "10.0.0.5:8081",
+            "advertised_address_v6": "[fd00::5]:8081"
+        },
+        "public_address": "203.0.113.5:8081",
+        "public_address_v6": "[2001:db8::1]:8081"
+    }`
+	var c dmsgserver.Config
+	require.NoError(t, json.Unmarshal([]byte(rawJSON), &c))
+	ds := c.NormalizedDeployments()
+	require.Len(t, ds, 1)
+	// Per-deployment values win on BOTH families — confirms the v6 fold
+	// follows the exact same precedence as v4.
+	assert.Equal(t, "10.0.0.5:8081", ds[0].AdvertisedAddress)
+	assert.Equal(t, "[fd00::5]:8081", ds[0].AdvertisedAddressV6)
+}
+
+// TestConfig_NoPublicAddressV6_BackwardCompat verifies a v4-only Config
+// (no PublicAddressV6) yields v4-only deployments with
+// AdvertisedAddressV6 stays empty. omitempty in JSON means the
+// disc.Server.AddressV6 field ultimately gets elided from the entry,
+// preserving the pre-#1525 single-stack wire format.
+func TestConfig_NoPublicAddressV6_BackwardCompat(t *testing.T) {
+	c := dmsgserver.Config{
+		Discovery:     "https://disc.example.com",
+		PublicAddress: "203.0.113.5:8081",
+	}
+	ds := c.NormalizedDeployments()
+	require.Len(t, ds, 1)
+	assert.Equal(t, "203.0.113.5:8081", ds[0].AdvertisedAddress)
+	assert.Empty(t, ds[0].AdvertisedAddressV6, "v4-only config must leave v6 advertisement empty")
+}
+
+// TestConfig_OnlyV6_FoldsCorrectly is the symmetric edge case to
+// TestConfig_NoPublicAddressV6_BackwardCompat: a config that declares
+// ONLY a v6 endpoint (rare today, more common once v6 deployments
+// become common) still produces a usable Deployment. The v4 side is
+// left empty; the dmsg.Server's updateServerEntryOnEndpoint skips
+// publishing when addr == "" (existing behavior).
+func TestConfig_OnlyV6_FoldsCorrectly(t *testing.T) {
+	c := dmsgserver.Config{
+		Discovery:       "https://disc.example.com",
+		PublicAddressV6: "[2001:db8::1]:8081",
+	}
+	ds := c.NormalizedDeployments()
+	require.Len(t, ds, 1)
+	assert.Empty(t, ds[0].AdvertisedAddress)
+	assert.Equal(t, "[2001:db8::1]:8081", ds[0].AdvertisedAddressV6)
+}

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -224,12 +224,23 @@ func (s *service) Run(ctx context.Context) error {
 
 	for i := 1; i < len(deployments); i++ {
 		extra := deployments[i]
-		srv.AddDiscovery(
+		srv.AddDiscoveryDualStack(
 			disc.NewHTTP(extra.Discovery, &http.Client{}, log),
 			extra.AdvertisedAddress,
+			extra.AdvertisedAddressV6,
 			dmsgserver.PKFromDmsgURL(extra.DiscoveryDmsg),
 		)
 	}
+
+	// Primary deployment's v6 endpoint goes through SetAdvertisedAddrV6
+	// since the existing ListenAndServe contract carries only the v4
+	// pAddr. Empty primaryAdvertisedV6 keeps the pre-#1525 behavior
+	// (server registers AddressV6="" → discovery omits the field).
+	primaryAdvertisedV6 := deployments[0].AdvertisedAddressV6
+	if primaryAdvertisedV6 == "" {
+		primaryAdvertisedV6 = cfg.PublicAddressV6
+	}
+	srv.SetAdvertisedAddrV6(primaryAdvertisedV6)
 
 	srvAPI.SetDmsgServer(srv)
 


### PR DESCRIPTION
## Summary

Second slice of the dual-stack-within-type IPv6 work tracked at **#1525**. Phase 1 ([#2715](https://github.com/skycoin/skywire/pull/2715)) added the optional `RemoteAddrV6` / `AddressV6` fields to the record types; this slice teaches dmsg-server how to populate `Server.AddressV6` in the discovery entry it posts.

## Config surface

```jsonc
{
  "public_address":    "203.0.113.5:8081",
  "public_address_v6": "[2001:db8::1]:8081",    // NEW, optional
  "dmsg": {
    "deployments": [{
      "discovery":              "https://disc-local.example.com",
      "advertised_address":     "10.0.0.5:8081",
      "advertised_address_v6":  "[fd00::5]:8081" // NEW, optional per-deployment
    }]
  }
}
```

`NormalizedDeployments` folds `PublicAddressV6` onto each deployment's `AdvertisedAddressV6` when that per-deployment value is empty — identical fold semantics to the existing v4 path, so the operator's mental model is "one knob, optionally overridden per discovery."

## Surface additions

**Server (`pkg/dmsg/dmsg`)**:
- `Server.SetAdvertisedAddrV6(addr)` + `Server.AdvertisedAddrV6()` — independent of the v4 one-shot `addrDone` gate so v6 stays optional and re-settable.
- `Server.AddDiscoveryDualStack(client, addrV4, addrV6, discPK)` — alongside `AddDiscovery` for multi-discovery callers.

**Internal plumbing**: `discoveryEndpoint.AdvertisedAddrV6` + threaded through `addDiscovery`, `updateServerEntry`, `updateServerEntryLoop`, `updateServerEntryOnEndpoint` with independent v6 delta detection.

**Wiring (`pkg/services/dmsgsrv`)**: primary deployment's v6 goes through `SetAdvertisedAddrV6` so the existing `ListenAndServe` signature stays unchanged (avoids breaking dmsg-socks5, dmsgpty-host, etc.). Extra deployments use `AddDiscoveryDualStack`.

## Backward compat

- Configs without `public_address_v6` / `advertised_address_v6` → no behavior change. `disc.Server.AddressV6` stays omitempty-elided. Pre-#1525 wire format preserved.
- `Server.AddDiscovery` compiles unchanged (passes empty v6 internally).
- `Client.AddDiscovery`'s internal `addDiscovery` call updated to pass empty v6 (clients never advertise endpoints).

## Listener note

**No listener changes in this PR.** The existing `LocalAddress` wildcard bind (`":8081"`) already accepts both families on kernels with `bindv6only=0` (the default). This PR is purely a **discovery advertisement** change. A v6-only operator deployment would also need an `AAAA` DNS record on the discovery service + on whatever hostname maps to the dmsg-server.

## Test plan

- [x] `go build ./...` clean
- [x] **7 new tests pass**:
  - `TestConfig_PublicAddressV6_FoldsToDeployments`
  - `TestConfig_PublicAddressV6_PerDeploymentOverride`
  - `TestConfig_NoPublicAddressV6_BackwardCompat`
  - `TestConfig_OnlyV6_FoldsCorrectly`
  - `TestServer_AdvertisedAddrV6_EmptyByDefault`
  - `TestServer_SetAdvertisedAddrV6_RoundTrip`
  - `TestServer_SetAdvertisedAddrV6_OverwriteAllowed`
- [x] Existing dmsg test suite passes (`go test ./pkg/dmsg/...`) — only `TestRedis*` fails, unrelated, needs live redis

## Phase sequencing

This PR unblocks **Phase 3** (Beta — Happy Eyeballs dialer). The sequence is now:

1. ~~Phase 1: schema add~~ — #2715, merged
2. **Phase 2a: dmsg-server v6 advertisement** — this PR
3. Phase 3: client-side v6 dial (Beta) — has the inputs once 2a merges
4. Phase 2b: visor's v6 AR bind — depends on the visor's dmsg client actually dialing v6 (i.e., Phase 3)
5. Phase 4: hypervisor UI family column (Gamma)
6. Phase 5: CI v6-only lane (Gamma)

Phase 2b was originally part of Phase 2 in the design comment but split out cleanly: it needs LookupIP-over-v6 to actually succeed at the visor, which requires Phase 3's dial-prefers-v6 logic. Splitting keeps each PR reviewable.

Refs #1525