### PR TITLE
feat(ipv6): phase 3 — Happy Eyeballs dialer in transport/network

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -401,12 +402,78 @@ func (c *resolvedClient) dialVisor(ctx context.Context, rPK cipher.PubKey, dial 
 		}
 	}
 
-	addr := visorData.RemoteAddr
-	if _, _, err := net.SplitHostPort(addr); err != nil {
-		addr = net.JoinHostPort(addr, visorData.Port)
+	// Happy Eyeballs (#1525 Phase 3): when AR has both a v6 and v4
+	// public address for the peer, try v6 first; fall back to v4 on
+	// any v6 failure (refused, timeout, unreachable). Sequential —
+	// no parallel race, no double-noise-handshake risk. The v6 attempt
+	// gets a bounded window (v6HeadStart) so a black-holed v6 route
+	// doesn't extend the overall dial materially beyond the v4 path's
+	// own connect time.
+	//
+	// Backward-compat: v6-only and v4-only peers are dispatched
+	// directly (no head-start cost). The pre-#1525 single-stack
+	// behavior — "RemoteAddrV6 is empty" — falls through the
+	// addrV6 == "" branch and dials RemoteAddr exactly like before.
+	addrV4 := canonicalAddr(visorData.RemoteAddr, visorData.Port)
+	addrV6 := canonicalAddr(visorData.RemoteAddrV6, visorData.Port)
+	switch {
+	case addrV6 != "" && addrV4 != "":
+		c.log.Debugf("Happy Eyeballs: dual-stack %s (v6) / %s (v4)", addrV6, addrV4)
+		return happyEyeballsDial(ctx, addrV6, addrV4, dial, c.log)
+	case addrV6 != "":
+		c.log.Debugf("Dialing v6-only public address: %s", addrV6)
+		return dial(ctx, addrV6)
+	case addrV4 != "":
+		c.log.Debugf("Dialing v4-only public address: %s", addrV4)
+		return dial(ctx, addrV4)
+	default:
+		return nil, fmt.Errorf("visor data has neither RemoteAddr nor RemoteAddrV6")
 	}
-	c.log.Debugf("Dialing public address: %s", addr)
-	return dial(ctx, addr)
+}
+
+// v6HeadStart bounds the v6 attempt in happyEyeballsDial. Modeled
+// on RFC 8305's 250ms head-start, widened to 1s to give a slow but
+// reachable v6 route a fair chance before falling back to v4. A
+// black-holed v6 route still bounds the extra latency to this much.
+const v6HeadStart = time.Second
+
+// canonicalAddr returns "" when raw is empty (lets the caller branch
+// on "v6 unavailable"), otherwise appends port when raw is bare-host.
+// Mirrors the inline check the pre-#1525 dialer did so the v4/v6
+// branches stay symmetric.
+func canonicalAddr(raw, port string) string {
+	if raw == "" {
+		return ""
+	}
+	if _, _, err := net.SplitHostPort(raw); err != nil {
+		return net.JoinHostPort(raw, port)
+	}
+	return raw
+}
+
+// happyEyeballsDial tries v6 first with a v6HeadStart-bounded sub-ctx,
+// falls back to v4 on any v6 failure. Sequential by design: one
+// socket + one noise handshake in flight at a time. Caller-supplied
+// ctx still bounds the overall dial; the v6 sub-ctx only narrows the
+// v6 attempt's deadline within ctx's window.
+func happyEyeballsDial(ctx context.Context, addrV6, addrV4 string, dial dialFunc, log *logging.Logger) (net.Conn, error) {
+	v6Ctx, cancel := context.WithTimeout(ctx, v6HeadStart)
+	conn, v6Err := dial(v6Ctx, addrV6)
+	cancel()
+	if v6Err == nil {
+		log.Debugf("Happy Eyeballs: v6 connected: %s", addrV6)
+		return conn, nil
+	}
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("happy eyeballs: ctx done during v6 attempt: %w", ctx.Err())
+	}
+	log.WithError(v6Err).Debugf("Happy Eyeballs: v6 %s failed, falling back to v4 %s", addrV6, addrV4)
+	conn, v4Err := dial(ctx, addrV4)
+	if v4Err != nil {
+		return nil, fmt.Errorf("happy eyeballs: v6 (%s) failed: %v; v4 (%s) failed: %w", addrV6, v6Err, addrV4, v4Err)
+	}
+	log.Debugf("Happy Eyeballs: v4 fallback connected: %s", addrV4)
+	return conn, nil
 }
 
 // isPrivateIP checks if an IP address is in a private range

--- a/pkg/transport/network/client_test.go
+++ b/pkg/transport/network/client_test.go
@@ -1,0 +1,168 @@
+// Package network client_test.go: unit tests for the Phase 3 Happy
+// Eyeballs dialer helpers — canonicalAddr port-append behavior and
+// happyEyeballsDial's v6-first / v4-fallback branches.
+package network
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func TestCanonicalAddr(t *testing.T) {
+	const port = "7070"
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"v4 bare host gets port", "192.0.2.1", "192.0.2.1:7070"},
+		{"v4 with port unchanged", "192.0.2.1:9999", "192.0.2.1:9999"},
+		{"v6 bare host gets bracketed port", "2001:db8::1", "[2001:db8::1]:7070"},
+		{"v6 with bracketed port unchanged", "[2001:db8::1]:9999", "[2001:db8::1]:9999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalAddr(tc.raw, port); got != tc.want {
+				t.Fatalf("canonicalAddr(%q, %q) = %q, want %q", tc.raw, port, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeConn satisfies net.Conn just enough for happyEyeballsDial to
+// return a non-nil success value. No bytes are read or written.
+type fakeConn struct{ net.Conn }
+
+func TestHappyEyeballsDial(t *testing.T) {
+	const (
+		v6 = "[2001:db8::1]:7070"
+		v4 = "192.0.2.1:7070"
+	)
+	log := logging.MustGetLogger("client_test")
+
+	t.Run("v6 succeeds, v4 not tried", func(t *testing.T) {
+		var dialed []string
+		dial := func(_ context.Context, addr string) (net.Conn, error) {
+			dialed = append(dialed, addr)
+			return fakeConn{}, nil
+		}
+		conn, err := happyEyeballsDial(context.Background(), v6, v4, dial, log)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conn == nil {
+			t.Fatal("expected non-nil conn")
+		}
+		if len(dialed) != 1 || dialed[0] != v6 {
+			t.Fatalf("expected single v6 dial, got %v", dialed)
+		}
+	})
+
+	t.Run("v6 fails, v4 succeeds", func(t *testing.T) {
+		var dialed []string
+		dial := func(_ context.Context, addr string) (net.Conn, error) {
+			dialed = append(dialed, addr)
+			if addr == v6 {
+				return nil, errors.New("v6 unreachable")
+			}
+			return fakeConn{}, nil
+		}
+		conn, err := happyEyeballsDial(context.Background(), v6, v4, dial, log)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conn == nil {
+			t.Fatal("expected non-nil conn")
+		}
+		if len(dialed) != 2 || dialed[0] != v6 || dialed[1] != v4 {
+			t.Fatalf("expected v6 then v4, got %v", dialed)
+		}
+	})
+
+	t.Run("both fail, error names both", func(t *testing.T) {
+		var dialed []string
+		dial := func(_ context.Context, addr string) (net.Conn, error) {
+			dialed = append(dialed, addr)
+			return nil, errors.New("nope")
+		}
+		_, err := happyEyeballsDial(context.Background(), v6, v4, dial, log)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if len(dialed) != 2 {
+			t.Fatalf("expected both attempts, got %v", dialed)
+		}
+		// Error should reference both endpoints so an operator can
+		// see which v6 and v4 addrs were tried.
+		msg := err.Error()
+		if !containsAll(msg, v6, v4) {
+			t.Fatalf("error %q missing v6 or v4 addr", msg)
+		}
+	})
+
+	t.Run("v6 attempt sub-ctx does not bleed into v4", func(t *testing.T) {
+		var dialed []string
+		var v4Ctx context.Context
+		dial := func(ctx context.Context, addr string) (net.Conn, error) {
+			dialed = append(dialed, addr)
+			if addr == v6 {
+				// Simulate v6 attempt consuming its sub-ctx without
+				// the parent ctx being canceled.
+				return nil, errors.New("v6 failed fast")
+			}
+			v4Ctx = ctx
+			return fakeConn{}, nil
+		}
+		parent, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := happyEyeballsDial(parent, v6, v4, dial, log); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v4Ctx == nil {
+			t.Fatal("v4 dial was not invoked")
+		}
+		// v4 should have inherited the parent ctx — its deadline must
+		// be near the parent's 10s, not v6HeadStart's 1s.
+		dl, ok := v4Ctx.Deadline()
+		if !ok {
+			t.Fatal("v4 ctx missing deadline")
+		}
+		if remaining := time.Until(dl); remaining < 5*time.Second {
+			t.Fatalf("v4 ctx deadline appears narrowed to v6 sub-ctx: %v remaining", remaining)
+		}
+	})
+
+	t.Run("parent ctx canceled during v6 stops short", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		cancel() // already canceled
+		dial := func(ctx context.Context, _ string) (net.Conn, error) {
+			return nil, ctx.Err()
+		}
+		_, err := happyEyeballsDial(parent, v6, v4, dial, log)
+		if err == nil {
+			t.Fatal("expected error from canceled parent ctx")
+		}
+	})
+}
+
+func containsAll(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		found := false
+		for i := 0; i+len(n) <= len(haystack); i++ {
+			if haystack[i:i+len(n)] == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Adds RFC 8305-style **Happy Eyeballs** dialing to `resolvedClient.dialVisor`: when the AddrResolver returns both `RemoteAddr` (v4) and `RemoteAddrV6` for a peer, try v6 first under a 1s sub-ctx; fall back to v4 on any failure
- v6-only and v4-only peers are dispatched directly (no head-start cost); the v4-only path is byte-identical to the pre-#1525 single-stack behavior
- Sequential by design — one socket + one noise handshake in flight at a time, no parallel-race bookkeeping

Composes with already-merged phases:
- #2715 (Phase 1): `RemoteAddrV6` field on AR `VisorData`
- #2716 (Phase 2a): dmsg-server v6 advertisement in discovery entries

Refs #1525.

## Why sequential, not parallel
The pre-existing dialer hands `dial` a single addr and gets back a fully-handshaked `net.Conn`. Racing two handshakes would either need handshake-cancellation plumbing (we don't have it) or risk double-spending noise initiator state. The 1s head-start is wider than RFC 8305's 250ms because we want a slow-but-reachable v6 route to win on uncongested links; a black-holed v6 still bounds the extra latency to 1s before v4 kicks in.

## Behavior matrix
| AR returns | Dialer behavior |
|---|---|
| v4 only | direct dial RemoteAddr — same as before #1525 |
| v6 only | direct dial RemoteAddrV6 |
| both | v6 (1s sub-ctx) → on failure, v4 under caller ctx |
| neither | error (was already an implicit nil-address dial) |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/transport/network/...`
- [x] `go test ./pkg/transport/network/...`
- [x] `make format` clean
- [ ] Integration: confirm dual-stack peers prefer v6 under live AR data (gated on Phase 2a having reached enough peers' AR records)
- [ ] Integration: confirm v4-only peers see no behavior change