### PR TITLE
feat(ipv6): phase 4a — ARSelfEntry exposes RemoteAddrV6 + CLI dual-stack render (#1525)

### DIFF
--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -817,6 +817,22 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 }
 
 func formatARAddr(e visor.ARSelfEntry) string {
+	v4 := formatARAddrV4(e)
+	if e.RemoteAddrV6 == "" {
+		return v4
+	}
+	// Dual-stack — surface both addresses with explicit family
+	// labels. The v6 side is rendered verbatim from RemoteAddrV6
+	// (already host:port from splitFamilyAddr in #2715) so the
+	// bracketed form is preserved.
+	return fmt.Sprintf("%s [v4] / %s [v6]", v4, e.RemoteAddrV6)
+}
+
+// formatARAddrV4 renders just the IPv4 portion. Split out from
+// formatARAddr so dual-stack rendering can reuse the existing logic
+// without duplicating it. Pre-#1525 callers see no behavior change
+// (formatARAddr falls through to this when no v6 is set).
+func formatARAddrV4(e visor.ARSelfEntry) string {
 	if e.RemoteAddr == "" && e.Port == "" {
 		return "(unknown)"
 	}

--- a/cmd/skywire-cli/commands/visor/info_format_test.go
+++ b/cmd/skywire-cli/commands/visor/info_format_test.go
@@ -1,0 +1,95 @@
+// Package clivisor — cmd/skywire-cli/commands/visor/info_format_test.go:
+// table-driven tests for the AR self-registration display path. Pins
+// the rendering of dual-stack entries (#1525 Phase 4a) and the
+// pre-existing single-stack semantics that callers relied on before
+// RemoteAddrV6 was added.
+
+package clivisor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+func TestFormatARAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   visor.ARSelfEntry
+		want string
+	}{
+		{
+			name: "v4 only, host:port in RemoteAddr",
+			in:   visor.ARSelfEntry{Type: "stcpr", RemoteAddr: "1.2.3.4:7777", Port: "7777"},
+			want: "1.2.3.4:7777",
+		},
+		{
+			name: "v4 only, bare IP in RemoteAddr + Port",
+			in:   visor.ARSelfEntry{Type: "stcpr", RemoteAddr: "1.2.3.4", Port: "7777"},
+			want: "1.2.3.4:7777",
+		},
+		{
+			name: "v4 only, NAT-mapped port differs from listen port",
+			in:   visor.ARSelfEntry{Type: "sudph", RemoteAddr: "1.2.3.4:55555", Port: "7777"},
+			want: "1.2.3.4:55555 (listen :7777)",
+		},
+		{
+			name: "no v4, no v6 (degenerate)",
+			in:   visor.ARSelfEntry{Type: "stcpr"},
+			want: "(unknown)",
+		},
+		{
+			name: "v4 plus v6 — dual stack with explicit family labels",
+			in: visor.ARSelfEntry{
+				Type:         "stcpr",
+				RemoteAddr:   "1.2.3.4:7777",
+				RemoteAddrV6: "[2001:db8::1]:7777",
+				Port:         "7777",
+			},
+			want: "1.2.3.4:7777 [v4] / [2001:db8::1]:7777 [v6]",
+		},
+		{
+			name: "v6 only with Port set — half-bound startup state",
+			// Dual-stack visor startup race: v6 bind completed before
+			// v4. Existing v4 rendering already falls back to port-
+			// only when RemoteAddr is empty but Port is set. The v6
+			// side is rendered alongside so operators can still see
+			// it IS attached even though v4 hasn't bound yet.
+			in: visor.ARSelfEntry{
+				Type:         "stcpr",
+				RemoteAddrV6: "[2001:db8::1]:7777",
+				Port:         "7777",
+			},
+			want: "7777 [v4] / [2001:db8::1]:7777 [v6]",
+		},
+		{
+			name: "v6 only with no Port — fully half-bound",
+			// Both RemoteAddr and Port empty on the v4 side; the v4
+			// path renders as "(unknown)" so the operator can see the
+			// v4 bind never happened, while v6 is still surfaced.
+			in: visor.ARSelfEntry{
+				Type:         "stcpr",
+				RemoteAddrV6: "[2001:db8::1]:7777",
+			},
+			want: "(unknown) [v4] / [2001:db8::1]:7777 [v6]",
+		},
+		{
+			name: "v4 plus v6, NAT-mapped port on v4",
+			in: visor.ARSelfEntry{
+				Type:         "sudph",
+				RemoteAddr:   "1.2.3.4:55555",
+				RemoteAddrV6: "[2001:db8::1]:7777",
+				Port:         "7777",
+			},
+			want: "1.2.3.4:55555 (listen :7777) [v4] / [2001:db8::1]:7777 [v6]",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatARAddr(c.in)
+			if got != c.want {
+				t.Errorf("formatARAddr(%+v):\n  got:  %q\n  want: %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/visor/api_ar.go
+++ b/pkg/visor/api_ar.go
@@ -47,11 +47,18 @@ func (v *Visor) CheckAREntry(pk string) ([]string, error) {
 
 // ARSelfEntry is one transport-type-row of this visor's own AR registration:
 // the IP:port it is reachable on according to the address-resolver.
+//
+// RemoteAddrV6 is the optional IPv6 counterpart of RemoteAddr, populated
+// when this visor has bound the AR over an IPv6 HTTP client (#2719's
+// secondary bind). Empty for v4-only deployments and on older AR servers
+// that don't capture family — same backward-compat shape as the underlying
+// addrresolver.VisorData (#2715).
 type ARSelfEntry struct {
-	Type       string   `json:"type"`                  // "stcpr" or "sudph"
-	RemoteAddr string   `json:"remote_addr,omitempty"` // public IP as AR sees the visor
-	Port       string   `json:"port,omitempty"`        // listen port
-	Addresses  []string `json:"addresses,omitempty"`   // local interface addresses the visor advertised
+	Type         string   `json:"type"`                     // "stcpr" or "sudph"
+	RemoteAddr   string   `json:"remote_addr,omitempty"`    // public IPv4 as AR sees the visor
+	RemoteAddrV6 string   `json:"remote_addr_v6,omitempty"` // public IPv6 as AR sees the visor (#1525 Phase 4a)
+	Port         string   `json:"port,omitempty"`           // listen port
+	Addresses    []string `json:"addresses,omitempty"`      // local interface addresses the visor advertised
 }
 
 // ARSelfRegistration is the visor's own AR record across transport types.
@@ -124,10 +131,11 @@ func (v *Visor) ARSelfInfo() (*ARSelfRegistration, error) {
 			continue
 		}
 		out.Entries = append(out.Entries, ARSelfEntry{
-			Type:       tpType,
-			RemoteAddr: d.RemoteAddr,
-			Port:       d.Port,
-			Addresses:  append([]string(nil), d.Addresses...),
+			Type:         tpType,
+			RemoteAddr:   d.RemoteAddr,
+			RemoteAddrV6: d.RemoteAddrV6,
+			Port:         d.Port,
+			Addresses:    append([]string(nil), d.Addresses...),
 		})
 	}
 	return out, nil


### PR DESCRIPTION
Phase 4a of the #1525 IPv6 plan. Tight schema + CLI rendering bump per [Alpha's 23:01Z scope-confirm](https://github.com/skycoin/skywire/issues/1525): ~10 LOC plumbing + a focused table-driven test.

## Why

The visor's own AR self-registration is the lowest-level surface that exposes a v6 endpoint to operators (CLI \`cli visor info\` prints it under \"AR Registration\"). \`addrresolver.VisorData.RemoteAddrV6\` landed in #2715 but never reaches that display — \`ARSelfEntry\` doesn't carry it. This PR plumbs the field through and teaches the CLI printer to render dual-stack with explicit family labels.

Doesn't depend on #2719 (visor v6 AR bind) merging first: when the visor hasn't bound v6, \`RemoteAddrV6\` is empty and the CLI falls through to the existing v4-only render — behavior identical to pre-#1525.

## Changes

| file | change |
|---|---|
| \`pkg/visor/api_ar.go\` | \`ARSelfEntry\` gains \`RemoteAddrV6 string\` (\`json:\"remote_addr_v6,omitempty\"\` — backward-compat). \`ARSelfInfo()\` populates it from the cached \`addrresolver.VisorData\`. |
| \`cmd/skywire-cli/commands/visor/info.go\` | \`formatARAddr\` becomes a dual-stack-aware wrapper around \`formatARAddrV4\` (the pre-existing logic, unchanged). Renders \`<v4> [v4] / <v6> [v6]\` when both present. Single-family inputs render exactly as before. |
| \`cmd/skywire-cli/commands/visor/info_format_test.go\` (new) | 7 table-driven cases — including half-bound startup states where one family is attached but not the other. |

## Test cases

| case | wire | render |
|---|---|---|
| host:port v4 | \`1.2.3.4:7777\` | \`1.2.3.4:7777\` |
| bare-IP + Port v4 | \`1.2.3.4\` + Port=7777 | \`1.2.3.4:7777\` |
| NAT-mapped port v4 | RemoteAddr=\`1.2.3.4:55555\`, Port=7777 | \`1.2.3.4:55555 (listen :7777)\` |
| all-empty | — | \`(unknown)\` |
| dual-stack | v4 + \`[2001:db8::1]:7777\` | \`1.2.3.4:7777 [v4] / [2001:db8::1]:7777 [v6]\` |
| half-bound (v6 + Port only) | RemoteAddr=\"\", RemoteAddrV6=set | \`7777 [v4] / [2001:db8::1]:7777 [v6]\` |
| half-bound (v6 only) | only RemoteAddrV6 | \`(unknown) [v4] / [2001:db8::1]:7777 [v6]\` |

```
$ go test ./cmd/skywire-cli/commands/visor/ -run TestFormatARAddr
ok  ./cmd/skywire-cli/commands/visor  0.107s  (7/7)
```

## Out of scope (deferred to 4b)

- Angular transport-details Family column in the hypervisor manager UI
- dmsg-server \`AddressV6\` surfacing (folded into 4b per Alpha's call)

Both pending #2719 merge so live v6 traffic exists to render.