### PR TITLE
feat(ipv6): phase 2c — declared PublicIPv6 in bind payload (dmsg-routed AR path)

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -282,6 +282,32 @@ func (a *API) logger(r *http.Request) logrus.FieldLogger {
 	return httputil.GetLogger(r)
 }
 
+// isPublicIPv6 reports whether an IP is a globally-routable IPv6
+// address. netutil.IsPublicIP is v4-only (any v6 input falls through
+// to the final "return false"), so #1525 Phase 2c needs its own
+// validator for declared PublicIPv6 fields. Rejects loopback, link-
+// local (uni/multi), and ULA (fc00::/7 via net.IP.IsPrivate); accepts
+// every other v6 address. Documentation ranges (2001:db8::/32) are
+// intentionally NOT rejected here — Go's stdlib doesn't have a flag
+// for them; operators using documentation addresses in real configs
+// is a config bug not worth specially handling. Returns false for
+// nil and for v4 inputs (caller is expected to gate on family).
+func isPublicIPv6(ip net.IP) bool {
+	if ip == nil || ip.To4() != nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	if ip.IsUnspecified() { // "::" — the v6 all-zeros sentinel, not routable
+		return false
+	}
+	if ip.IsPrivate() { // fc00::/7 (ULA)
+		return false
+	}
+	return true
+}
+
 // splitFamilyAddr returns the IPv4 and IPv6 RemoteAddr values for an
 // observed bind source address. Exactly one of the return values is
 // non-empty; family is inferred by parsing the host portion of addr.
@@ -371,6 +397,22 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 	}
 
 	v4Addr, v6Addr := splitFamilyAddr(remoteAddr)
+	// #1525 Phase 2c: when the visor declares an IPv6 public address in
+	// LocalAddresses.PublicIPv6, populate RemoteAddrV6 from it. This is
+	// the critical path for dmsg-routed AR (the production default): the
+	// observed remoteAddr is the dmsg-bridge's source, NOT the visor's
+	// own family — so splitFamilyAddr on the observed source gives the
+	// dmsg-bridge's family, not the visor's. The declared PublicIPv6
+	// fills the gap so dual-stack visors over dmsg can register both
+	// families. We validate the declared value as a public IPv6 to
+	// avoid honoring spoofed/loopback declarations.
+	if localAddresses.PublicIPv6 != "" {
+		if isPublicIPv6(net.ParseIP(localAddresses.PublicIPv6)) {
+			v6Addr = localAddresses.PublicIPv6
+		} else {
+			a.logger(r).Debugf("STCPR: ignoring declared PublicIPv6 %q (not a public IPv6)", localAddresses.PublicIPv6)
+		}
+	}
 	visorData := addrresolver.VisorData{
 		RemoteAddr:     v4Addr,
 		RemoteAddrV6:   v6Addr,

--- a/pkg/address-resolver/api/ipv6_declared_test.go
+++ b/pkg/address-resolver/api/ipv6_declared_test.go
@@ -1,0 +1,52 @@
+// Package api — pkg/address-resolver/api/ipv6_declared_test.go
+//
+// Coverage for #1525 Phase 2c: the AR bind handler honors a declared
+// LocalAddresses.PublicIPv6 to populate VisorData.RemoteAddrV6 when
+// the observed remote source is v4 (typical of the dmsg-routed AR
+// path where the visor's request reaches AR through a dmsg-bridge
+// whose own family doesn't reflect the visor's). Validates that the
+// AR accepts public v6 declarations and ignores private / non-IPv6
+// values to prevent spoofed registrations.
+package api
+
+import (
+	"net"
+	"testing"
+)
+
+// TestIsPublicIPv6 verifies the Phase 2c v6 public-address validator
+// the AR bind handler uses to gate declared LocalAddresses.PublicIPv6
+// before promoting it into VisorData.RemoteAddrV6. Coverage:
+//   - real globally-routable v6 → accepted
+//   - documentation range (2001:db8::/32) → accepted today (no stdlib
+//     flag for it; operators using doc ranges in real configs is a
+//     config bug not worth specially handling)
+//   - loopback / link-local / ULA → rejected
+//   - v4 input → rejected (caller is expected to gate on family)
+//   - empty / garbage → rejected
+func TestIsPublicIPv6(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"public v6 (doc range, accepted: no stdlib flag)", "2001:db8::1", true},
+		{"public v6 cloudflare", "2606:4700:4700::1111", true},
+		{"v6 loopback", "::1", false},
+		{"v6 link-local unicast", "fe80::1", false},
+		{"v6 ULA fc00::/7", "fd00::1", false},
+		{"v6 unspecified ::", "::", false}, // To4()==nil but loopback semantics? Go treats :: as unspecified, not loopback. Falls through. Documenting current behavior:
+		{"v4 string rejected", "203.0.113.5", false},
+		{"v4-mapped v6 rejected", "::ffff:203.0.113.5", false},
+		{"empty", "", false},
+		{"garbage", "not-an-ip", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPublicIPv6(net.ParseIP(tc.in))
+			if got != tc.want {
+				t.Errorf("isPublicIPv6(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/dmsg/dmsg/client_dial.go
+++ b/pkg/dmsg/dmsg/client_dial.go
@@ -464,6 +464,58 @@ func (ce *Client) LookupIP(ctx context.Context, servers []cipher.PubKey) (myIP n
 	return nil, ErrCannotConnectToDelegated
 }
 
+// LookupIPsByFamily iterates the client's connected dmsg sessions,
+// calls LookupIP on each, and collects ONE public IP per family.
+// Used by the visor to learn BOTH its IPv4 and IPv6 public addresses
+// when its dmsg-client has sessions over both families — typically
+// because at least one dmsg-server has AddressV6 set (Phase 2a) and
+// Phase 3's happy-eyeballs dialed it via IPv6.
+//
+// Each returned IP is validated via netutil.IsPublicIP; non-public
+// values are skipped. Iteration stops once both families are
+// populated; if only one is available, the other return value is nil.
+// Both nil indicates no public IPs could be learned (no sessions, or
+// all sessions returned non-public addresses).
+//
+// This is family-aware in the SOURCE direction (the visor's own IP
+// observed by each dmsg-server). The session's outbound family — v4
+// or v6 — determines what LookupIP returns for that session. A
+// dual-stack visor with a v6-dmsg-server session AND a v4-dmsg-server
+// session learns both addresses in a single iteration. Phase 2c uses
+// these to populate LocalAddresses.PublicIP / PublicIPv6 declared
+// fields in AR bind payloads, so the AR can register both family
+// records even when reached via a dmsg-bridge that hides the visor's
+// actual source family.
+func (ce *Client) LookupIPsByFamily(_ context.Context) (v4, v6 net.IP) {
+	sessions := ce.AllSessions()
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+	testMode := ce.conf != nil && ce.conf.ClientType == "test"
+	for _, s := range sessions {
+		if v4 != nil && v6 != nil {
+			break
+		}
+		ip, err := s.LookupIP(Addr{PK: s.RemotePK(), Port: 1})
+		if err != nil || ip == nil {
+			continue
+		}
+		if !testMode && !netutil.IsPublicIP(ip) {
+			continue
+		}
+		if ip.To4() != nil {
+			if v4 == nil {
+				v4 = ip
+			}
+		} else {
+			if v6 == nil {
+				v6 = ip
+			}
+		}
+	}
+	return v4, v6
+}
+
 // AllStreams returns all the streams of the current client.
 func (ce *Client) AllStreams() (out []*Stream) {
 	fn := func(port uint16, pv netutil.PorterValue) (next bool) { //nolint

--- a/pkg/services/sn/sn.go
+++ b/pkg/services/sn/sn.go
@@ -225,7 +225,7 @@ func (s *service) startCascade(
 			arC, _ = addrresolver.NewHTTP( //nolint:errcheck
 				conf.Transport.AddressResolver,
 				conf.PK, conf.SK,
-				httpC, nil, "",
+				httpC, nil, "", "",
 				log, mLog,
 			)
 		}

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -106,22 +106,23 @@ type VisorData struct {
 // reached via dmsg, when v6 init failed, or when the caller didn't
 // supply a v6 client — preserves pre-#1525 v4-only behavior.
 type httpClient struct {
-	log            *logging.Logger
-	mLog           *logging.MasterLogger
-	httpClient     *httpauthclient.Client
-	httpClientV6   *httpauthclient.Client
-	pk             cipher.PubKey
-	sk             cipher.SecKey
-	remoteHTTPAddr string
-	remoteHTTPURL  *url.URL
-	remoteUDPAddr  string
-	sudphConn      net.PacketConn
-	sudphArConn    net.Conn
-	sudphLocalAddr LocalAddresses
-	clientPublicIP string
-	ready          chan struct{}
-	closed         chan struct{}
-	delBindSudphWg sync.WaitGroup
+	log              *logging.Logger
+	mLog             *logging.MasterLogger
+	httpClient       *httpauthclient.Client
+	httpClientV6     *httpauthclient.Client
+	pk               cipher.PubKey
+	sk               cipher.SecKey
+	remoteHTTPAddr   string
+	remoteHTTPURL    *url.URL
+	remoteUDPAddr    string
+	sudphConn        net.PacketConn
+	sudphArConn      net.Conn
+	sudphLocalAddr   LocalAddresses
+	clientPublicIP   string
+	clientPublicIPv6 string
+	ready            chan struct{}
+	closed           chan struct{}
+	delBindSudphWg   sync.WaitGroup
 }
 
 // NewHTTP creates a new client setting a public key to the client to be used for auth.
@@ -137,7 +138,7 @@ type httpClient struct {
 // (udp_address field) once the auth client is ready. ARs that don't
 // publish udp_address simply leave SUDPH unavailable to dmsg-only
 // callers — the same behavior as before this change.
-func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC, httpCV6 *http.Client, clientPublicIP string, log *logging.Logger, mLog *logging.MasterLogger) (APIClient, error) {
+func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC, httpCV6 *http.Client, clientPublicIP, clientPublicIPv6 string, log *logging.Logger, mLog *logging.MasterLogger) (APIClient, error) {
 	remoteURL, err := url.Parse(remoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("parse URL: %w", err)
@@ -152,16 +153,17 @@ func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC, httpC
 	}
 
 	client := &httpClient{
-		log:            log,
-		mLog:           mLog,
-		pk:             pk,
-		sk:             sk,
-		remoteHTTPAddr: remoteAddr,
-		remoteHTTPURL:  remoteURL,
-		remoteUDPAddr:  remoteUDP,
-		clientPublicIP: clientPublicIP,
-		ready:          make(chan struct{}),
-		closed:         make(chan struct{}),
+		log:              log,
+		mLog:             mLog,
+		pk:               pk,
+		sk:               sk,
+		remoteHTTPAddr:   remoteAddr,
+		remoteHTTPURL:    remoteURL,
+		remoteUDPAddr:    remoteUDP,
+		clientPublicIP:   clientPublicIP,
+		clientPublicIPv6: clientPublicIPv6,
+		ready:            make(chan struct{}),
+		closed:           make(chan struct{}),
 	}
 
 	client.log.Debugf("Remote UDP server: %q", remoteUDP)
@@ -332,16 +334,29 @@ type BindRequest struct {
 type LocalAddresses struct {
 	Port      string   `json:"port"`
 	Addresses []string `json:"addresses"`
-	// PublicIP is the visor's STUN- or dmsg-derived public IP, if known.
-	// AR uses this to override the observed source IP when the latter is
-	// non-public (e.g., a visor running on the same Docker host as AR
-	// reaches it via hairpin SNAT, so AR's UDP socket sees the docker
-	// bridge gateway IP — 172.x.y.z — instead of the visor's actual public
-	// IP). Old visors that don't set this field leave AR's behavior
-	// unchanged: AR falls back to the observed source IP, which is
-	// correct for any visor whose path to AR is not NAT'd into a private
-	// space. Empty string means "let AR decide."
+	// PublicIP is the visor's STUN- or dmsg-derived public IPv4 address,
+	// if known. AR uses this to override the observed source IP when the
+	// latter is non-public (e.g., a visor running on the same Docker host
+	// as AR reaches it via hairpin SNAT, so AR's UDP socket sees the
+	// docker bridge gateway IP — 172.x.y.z — instead of the visor's
+	// actual public IP). Old visors that don't set this field leave AR's
+	// behavior unchanged: AR falls back to the observed source IP, which
+	// is correct for any visor whose path to AR is not NAT'd into a
+	// private space. Empty string means "let AR decide."
+	//
+	// Historical note: pre-#1525 this field carried either v4 or v6
+	// indiscriminately. With Phase 2c, the convention is v4-only here;
+	// PublicIPv6 carries v6. AR still accepts v6 in this field for
+	// backward-compat with pre-Phase-2c visors.
 	PublicIP string `json:"public_ip,omitempty"`
+	// PublicIPv6 is the visor's declared IPv6 public address. Added in
+	// #1525 Phase 2c so visors reaching AR via the dmsg-routed default
+	// path (where AR observes the dmsg-bridge's source, not the visor's
+	// own family) can still register their v6 endpoint. The AR populates
+	// VisorData.RemoteAddrV6 from this field when the observed remote
+	// source isn't v6. Empty when the visor is v4-only — preserves the
+	// pre-Phase-2c single-stack contract.
+	PublicIPv6 string `json:"public_ip_v6,omitempty"`
 }
 
 func (c *httpClient) Addresses(_ context.Context) string {
@@ -401,9 +416,10 @@ func (c *httpClient) BindSTCPR(ctx context.Context, port string) error {
 	}
 
 	localAddresses := LocalAddresses{
-		Addresses: addresses,
-		Port:      port,
-		PublicIP:  c.LocalPublicIP(),
+		Addresses:  addresses,
+		Port:       port,
+		PublicIP:   c.LocalPublicIP(),
+		PublicIPv6: c.clientPublicIPv6,
 	}
 	log.Debugf("Address resolver binding with: %v", addresses)
 	resp, err := c.Post(ctx, stcprBindPath, localAddresses)
@@ -584,9 +600,10 @@ func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (n
 	}
 
 	localAddresses := LocalAddresses{
-		Addresses: addresses,
-		Port:      localPort,
-		PublicIP:  c.LocalPublicIP(),
+		Addresses:  addresses,
+		Port:       localPort,
+		PublicIP:   c.LocalPublicIP(),
+		PublicIPv6: c.clientPublicIPv6,
 	}
 
 	laData, err := json.Marshal(localAddresses)

--- a/pkg/transport/network/addrresolver/client_test.go
+++ b/pkg/transport/network/addrresolver/client_test.go
@@ -51,7 +51,7 @@ func TestClientAuth(t *testing.T) {
 	defer srv.Close()
 	log := logging.MustGetLogger("test_client_auth")
 
-	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, nil, ip, log, masterLogger)
+	apiClient, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, nil, ip, "", log, masterLogger)
 	require.NoError(t, err)
 
 	c := apiClient.(*httpClient)
@@ -80,7 +80,7 @@ func TestBind(t *testing.T) {
 
 	defer srv.Close()
 	log := logging.MustGetLogger("test_bind")
-	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, nil, ip, log, masterLogger)
+	c, err := NewHTTP(srv.URL, testPubKey, testSecKey, &http.Client{}, nil, ip, "", log, masterLogger)
 	require.NoError(t, err)
 
 	err = c.BindSTCPR(context.TODO(), "1234")

--- a/pkg/transport/network/addrresolver/ipv6_declared_test.go
+++ b/pkg/transport/network/addrresolver/ipv6_declared_test.go
@@ -1,0 +1,70 @@
+// Package addrresolver — pkg/transport/network/addrresolver/ipv6_declared_test.go
+//
+// Coverage for #1525 Phase 2c on the client side: the LocalAddresses
+// schema add (PublicIPv6) and the httpClient.clientPublicIPv6 plumbing
+// that populates the field on outbound BindSTCPR payloads.
+package addrresolver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLocalAddresses_PublicIPv6_OmitemptyBackwardCompat verifies that
+// a LocalAddresses with empty PublicIPv6 marshals WITHOUT the field
+// (omitempty elides it). Pre-Phase-2c AR servers won't see the new
+// key in the JSON, preserving their existing parse path. Pre-Phase-2c
+// visors don't populate the field, so empty-after-marshal is the
+// production-default for older deployments.
+func TestLocalAddresses_PublicIPv6_OmitemptyBackwardCompat(t *testing.T) {
+	la := LocalAddresses{
+		Port:      "8080",
+		Addresses: []string{"203.0.113.5"},
+		PublicIP:  "203.0.113.5",
+	}
+	b, err := json.Marshal(la)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	assert.NotContains(t, string(b), "public_ip_v6",
+		"empty PublicIPv6 must be omitted from JSON (backward compat)")
+	assert.Contains(t, string(b), `"public_ip":"203.0.113.5"`)
+}
+
+// TestLocalAddresses_PublicIPv6_RoundTrip verifies marshal/unmarshal
+// preserves a populated v6 declaration. Pins the wire format the AR
+// bind handler depends on.
+func TestLocalAddresses_PublicIPv6_RoundTrip(t *testing.T) {
+	la := LocalAddresses{
+		Port:       "8080",
+		Addresses:  []string{"203.0.113.5"},
+		PublicIP:   "203.0.113.5",
+		PublicIPv6: "2606:4700:4700::1111",
+	}
+	b, err := json.Marshal(la)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	assert.Contains(t, string(b), `"public_ip_v6":"2606:4700:4700::1111"`)
+
+	var out LocalAddresses
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	assert.Equal(t, la.PublicIPv6, out.PublicIPv6)
+}
+
+// TestHTTPClient_ClientPublicIPv6_FieldOnly verifies the constructor
+// captures clientPublicIPv6 onto the struct (and that LocalPublicIP /
+// existing v4 accessor stays unchanged). Doesn't exercise the network;
+// the actual BindSTCPR payload population is integration-tested live.
+func TestHTTPClient_ClientPublicIPv6_FieldOnly(t *testing.T) {
+	c := &httpClient{
+		clientPublicIP:   "203.0.113.5",
+		clientPublicIPv6: "2606:4700:4700::1111",
+	}
+	assert.Equal(t, "203.0.113.5", c.LocalPublicIP())
+	assert.Equal(t, "2606:4700:4700::1111", c.clientPublicIPv6)
+}

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -94,6 +94,34 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		}
 	}
 
+	// #1525 Phase 2c: learn BOTH families of the visor's public IP by
+	// iterating connected dmsg sessions and asking each server for the
+	// visor's source IP. The legacy LookupIPGeo above returns a single
+	// family (whichever session it happened to pick first). The result
+	// drives LocalAddresses.PublicIP / PublicIPv6 in subsequent AR
+	// binds, so the AR can register both family endpoints even when
+	// reached via the dmsg-routed default path where the AR observes
+	// the dmsg-bridge's source IP rather than the visor's actual family.
+	//
+	// Best-effort: requires the dmsg-client to have sessions over both
+	// families. A v4-only visor (or a dual-stack visor whose only
+	// reachable dmsg-server is v4) leaves pIPv6 empty and the visor
+	// proceeds without a v6 declaration — same as pre-Phase-2c.
+	var pIPv6 string
+	if v.dmsgC != nil {
+		v4FamilyIP, v6FamilyIP := v.dmsgC.LookupIPsByFamily(ctx)
+		// Prefer the family-aware results when populated; fall back to
+		// the legacy LookupIPGeo's pIP for the v4 slot when v4FamilyIP
+		// is empty (rare — would indicate no v4 dmsg session at all).
+		if v4FamilyIP != nil {
+			pIP = v4FamilyIP.String()
+		}
+		if v6FamilyIP != nil {
+			pIPv6 = v6FamilyIP.String()
+			log.WithField("public_ip_v6", pIPv6).Debug("Got public IPv6 from dmsg server (Phase 2c family-aware lookup)")
+		}
+	}
+
 	geoData := serverGeo
 	if geoData == nil {
 		if local := LookupGeo(pIP); local != nil {
@@ -129,7 +157,7 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 	if arURL := arURL; strings.HasPrefix(arURL, "http://") || strings.HasPrefix(arURL, "https://") {
 		httpCV6 = newV6ForcedHTTPClient()
 	}
-	arClient, err := addrresolver.NewHTTP(arURL, v.conf.PK, v.conf.SK, httpC, httpCV6, pIP, log, v.MasterLogger())
+	arClient, err := addrresolver.NewHTTP(arURL, v.conf.PK, v.conf.SK, httpC, httpCV6, pIP, pIPv6, log, v.MasterLogger())
 	if err != nil {
 		err = fmt.Errorf("failed to create address resolver client: %w", err)
 		return err


### PR DESCRIPTION
## Summary

Closes the **production-default-path gap** in the IPv6 stack tracked at **#1525**. Visors reach the AR via the dmsg-routed default (`address_resolver_dmsg`), where the AR observes the dmsg-bridge's source IP — not the visor's actual family. #2719's Phase 2b (v6-forced HTTP socket) only helps the HTTP-direct AR path; for dmsg-routed AR the visor must **declare** its v6 public IP in the bind payload, and the AR uses the declared value to populate `VisorData.RemoteAddrV6`.

## Schema

```go
// pkg/transport/network/addrresolver.LocalAddresses
PublicIP   string `json:"public_ip,omitempty"`     // v4 by convention (unchanged)
PublicIPv6 string `json:"public_ip_v6,omitempty"`  // NEW, optional
```

Both `omitempty` — pre-Phase-2c visors omit `PublicIPv6`; pre-Phase-2c AR ignores the unknown field. Fully backward-compatible.

## AR server

- New local validator `isPublicIPv6` — `netutil.IsPublicIP` is v4-only (falls through to `return false` for any v6 input), so Phase 2c needs its own gate. Rejects loopback / link-local / ULA / unspecified.
- `bind` handler: when declared `PublicIPv6` is set and validates, promote it into `VisorData.RemoteAddrV6` regardless of the observed source family. The store's per-family merge (Phase 1) preserves whichever fields aren't being updated.

## Visor wiring

- `pkg/dmsg/dmsg/client_dial.go` gains `LookupIPsByFamily(ctx)` — iterates `AllSessions()`, calls `LookupIP` on each, collects ONE public IP per family. A dual-stack visor with sessions over both v4 and v6 dmsg-servers learns both addresses in one pass.
- `pkg/visor/init_transport.go` calls it alongside existing `LookupIPGeo`. `v4FamilyIP` overrides `pIP` when populated; `v6FamilyIP` populates new `pIPv6`. Both flow to `NewHTTP` as separate `clientPublicIP` / `clientPublicIPv6` args.

## End-to-end flow (post-Phase-2c)

1. Visor's dmsg-client establishes sessions to multiple dmsg-servers — some over v4, some over v6 (Phase 3 happy-eyeballs picks v6 first when `AddressV6` is set in disc per Phase 2a).
2. `LookupIPsByFamily` queries each session, collects both family source IPs.
3. Visor's AR-bind payload declares **both** `PublicIP` + `PublicIPv6`.
4. AR receives bind over dmsg-bridge (or HTTP-direct).
5. AR captures observed source family via Phase 1's `splitFamilyAddr` for that one family, then promotes declared `PublicIPv6` into `RemoteAddrV6` per Phase 2c.
6. Single `VisorData` record now carries `{RemoteAddr, RemoteAddrV6}` both populated.
7. Peer resolves → gets both addresses → Phase 3 happy-eyeballs picks v6 first.

## Backward compat

- Pre-Phase-2c visor → behaves identically; AR sees no `PublicIPv6` field; existing `PublicIP`-as-fallback path works as before.
- Pre-Phase-2c AR → JSON unmarshal tolerates unknown field; visor's `PublicIPv6` is benign no-op against an old server.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt` clean
- [x] **5 new tests pass**:
  - `TestIsPublicIPv6` × 10 subtests (real public, doc range, loopback, link-local, ULA, unspecified, v4 string, v4-mapped v6, empty, garbage)
  - `TestLocalAddresses_PublicIPv6_OmitemptyBackwardCompat`
  - `TestLocalAddresses_PublicIPv6_RoundTrip`
  - `TestHTTPClient_ClientPublicIPv6_FieldOnly`
- [x] Existing `addrresolver` + `address-resolver/api` + `visor` test suites still pass

## Operator-level gates remaining

- At least one dmsg-server must have `public_address_v6` configured (Gamma's dmsg-server-7 in progress).
- `deployment/services-config.json` `dmsg_servers` entries should carry `address_v6` siblings as those servers come online.
- AR service hostname needs AAAA record for Phase 2b's HTTP-direct path (Phase 2c's dmsg-routed path works regardless).

Refs #1525