### PR TITLE
feat(ci): mux-route-probe.sh — 3-visor multiplexed-route test runner

### DIFF
--- a/ci_scripts/mux-route-probe.sh
+++ b/ci_scripts/mux-route-probe.sh
@@ -100,8 +100,12 @@ log "pre-flight: self_pk=$self_pk"
 # target, --routes>1 will silently degrade. Check transport types
 # available before dialing.
 
-tp_summary="$("${CLI[@]}" visor transport ls 2>&1 || true)"
-non_dmsg_paths=$(printf '%s\n' "$tp_summary" | grep -cE '\b(stcpr|sudph|stcp)\b' || true)
+# The CLI subcommand is `tp ls`, not `visor transport ls` — fix per
+# Beta's 2026-05-19 #2723 review (the original was always falling
+# through to the abort path because the wrong command emitted help
+# text with no transport-type tokens).
+tp_summary="$("${CLI[@]}" tp ls 2>&1 || true)"
+non_dmsg_paths=$(printf '%s\n' "$tp_summary" | awk '$1 ~ /^(stcpr|sudph|stcp)$/' | wc -l)
 if [[ "$routes" -gt 1 && "$non_dmsg_paths" -eq 0 ]]; then
     cat <<EOF >&2
 ABORT: requested $routes mux legs but no non-DMSG transports exist on
@@ -122,10 +126,18 @@ fi
 # stdout for byte-count integrity.
 
 # Snapshot the route-group state before the dial so we can diff and
-# attribute new groups to this probe.
-pre_rg="$("${CLI[@]}" dmsg cat --help >/dev/null 2>&1 && \
-    "${CLI[@]}" rg ls --json 2>/dev/null || echo '[]')"
-pre_rg_count=$(printf '%s' "$pre_rg" | tr -cd '{' | wc -c)
+# attribute new groups to this probe. Use jq for length — brace-
+# counting is fragile because nested objects (per-app stats inside
+# the route-group records) contain extra braces (Beta's #2723 review).
+require_jq() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "FATAL: jq is required for rg-count assertions" >&2
+        exit 1
+    fi
+}
+require_jq
+pre_rg="$("${CLI[@]}" rg ls --json 2>/dev/null || echo '[]')"
+pre_rg_count=$(printf '%s' "$pre_rg" | jq '. // [] | length')
 
 tmpdir=$(mktemp -d -t muxprobe.XXXXXX)
 trap 'rm -rf "$tmpdir"' EXIT
@@ -134,6 +146,15 @@ trap 'rm -rf "$tmpdir"' EXIT
 # multi-hop byte-pipe with explicit routes control. Replace with a
 # skysocks-client invocation when the runner is wired into an e2e
 # topology that has skysocks-server stood up on target_pk.
+#
+# KNOWN LIMITATION (Beta's #2723 review): this captures bytes coming
+# BACK from target (the dmsg cat process writes its peer's output to
+# throughput.bin). If target_pk has no listener that echoes/streams
+# back, throughput will read 0 even though our stdin was consumed by
+# the route. For an honest one-way send-side throughput measurement
+# the receiving end must be standing up a dmsg-listener that echoes
+# or sinks at a known rate — out-of-scope for this initial runner,
+# tracked for the follow-up Go harness.
 log "starting throughput leg (dmsg cat --routes=$routes)…"
 {
     "${CLI[@]}" dmsg cat "$target_pk:80" --transport=skynet --routes="$routes" \
@@ -147,7 +168,7 @@ sleep 3
 
 # --- assert fanout actually took ---------------------------------------
 post_rg_json="$("${CLI[@]}" rg ls --json 2>/dev/null || echo '[]')"
-post_rg_count=$(printf '%s' "$post_rg_json" | tr -cd '{' | wc -c)
+post_rg_count=$(printf '%s' "$post_rg_json" | jq '. // [] | length')
 delta_rg=$((post_rg_count - pre_rg_count))
 log "rg delta: pre=$pre_rg_count post=$post_rg_count new=$delta_rg (requested=$routes)"
 

--- a/ci_scripts/mux-route-probe.sh
+++ b/ci_scripts/mux-route-probe.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# ci_scripts/mux-route-probe.sh — multiplexed-route end-to-end probe.
+#
+# Drives a multiplexed multi-hop route test across N visors. The
+# methodology specifically guards against the silent --routes=N→1
+# fanout degrade documented in the 2026-05-14 finding: when peers
+# only have DMSG-mediated paths to each other, router.establishMuxRoutes
+# enforces ExcludeDMSG=true on additional legs and silently drops
+# them. `cli rg ls` is the only reliable source of ground truth.
+#
+# Usage:
+#   mux-route-probe.sh <target_pk> [routes=N] [duration=Ns]
+#
+# Required:
+#   target_pk  — destination visor PK (the far end of the route)
+#
+# Optional (env or positional after target_pk):
+#   ROUTES     — requested mux-leg count (default 2)
+#   DURATION   — sustained traffic window in seconds (default 60)
+#   SKYCHAT_RATE — messages per second on skychat low-rate stream
+#                  (default 5)
+#   RPC_ADDR   — visor RPC for `cli` calls (default localhost:3435)
+#
+# Pass/fail per the 2026-05-19 mux-test scope agreement:
+#   (a) cli rg ls after dial MUST show route_count == ROUTES;
+#       otherwise the test ABORTS with a diagnostic — this is the
+#       methodology gap. The probe is not a mux test unless the
+#       fanout actually took.
+#   (b) byte-integrity preserved on skysocks-style payloads.
+#   (c) sustained throughput ≥ 70% of single-leg baseline.
+#   (d) p99 RTT distribution emitted for skychat low-rate stream;
+#       operator decides if the tail is acceptable.
+#   (e) head-of-line check: skychat per-message RTT does NOT
+#       correlate with skysocks throughput beyond |r| > 0.4.
+#
+# Exit codes:
+#   0   success — all checks pass
+#   1   usage error (missing args)
+#   2   topology-degrade abort — fanout didn't take
+#   3   integrity failure
+#   4   throughput regression
+#   5   head-of-line correlation breach
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF' >&2
+Usage: mux-route-probe.sh <target_pk> [routes=N] [duration=Ns]
+
+env: ROUTES, DURATION, SKYCHAT_RATE, RPC_ADDR override defaults.
+See script header for full spec.
+EOF
+    exit 1
+}
+
+# --- parse args / env ---------------------------------------------------
+
+target_pk="${1:-}"
+[[ -z "$target_pk" ]] && usage
+
+routes="${ROUTES:-2}"
+duration="${DURATION:-60}"
+skychat_rate="${SKYCHAT_RATE:-5}"
+rpc_addr="${RPC_ADDR:-localhost:3435}"
+
+# Permit positional overrides too.
+for arg in "${@:2}"; do
+    case "$arg" in
+        routes=*) routes="${arg#routes=}" ;;
+        duration=*) duration="${arg#duration=}" ;;
+        skychat_rate=*) skychat_rate="${arg#skychat_rate=}" ;;
+    esac
+done
+
+case "$routes" in
+    ''|*[!0-9]*) echo "routes must be a positive integer, got: $routes" >&2; usage ;;
+esac
+case "$duration" in
+    ''|*[!0-9]*) echo "duration must be a positive integer, got: $duration" >&2; usage ;;
+esac
+
+CLI=(skywire cli --rpc "$rpc_addr")
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+
+log "probe start: target=$target_pk routes=$routes duration=${duration}s rate=${skychat_rate}/s rpc=$rpc_addr"
+
+# --- pre-flight ---------------------------------------------------------
+# Confirm RPC is reachable + visor identifies itself; abort early on a
+# misconfigured run before we touch network state.
+
+if ! self_pk="$("${CLI[@]}" visor pk 2>/dev/null)"; then
+    echo "pre-flight: visor RPC at $rpc_addr unreachable" >&2
+    exit 1
+fi
+log "pre-flight: self_pk=$self_pk"
+
+# --- topology assertion -------------------------------------------------
+# The methodology gap: if no non-DMSG path exists between us and the
+# target, --routes>1 will silently degrade. Check transport types
+# available before dialing.
+
+tp_summary="$("${CLI[@]}" visor transport ls 2>&1 || true)"
+non_dmsg_paths=$(printf '%s\n' "$tp_summary" | grep -cE '\b(stcpr|sudph|stcp)\b' || true)
+if [[ "$routes" -gt 1 && "$non_dmsg_paths" -eq 0 ]]; then
+    cat <<EOF >&2
+ABORT: requested $routes mux legs but no non-DMSG transports exist on
+this visor. router.establishMuxRoutes will silently degrade to 1 (per
+the 2026-05-14 methodology gap). Establish at least one stcpr/sudph
+transport before re-running:
+
+    skywire cli visor transport add <peer_pk> stcpr
+EOF
+    exit 2
+fi
+
+# --- run the dial -------------------------------------------------------
+# skysocks-style throughput stream: a sustained byte stream over the
+# multi-hop route. Implemented here as a dmsg cat with --routes=N to
+# exercise the multiplexer — same dial path the 2026-05-14 finding
+# documented. The dial blocks for the duration window; we read its
+# stdout for byte-count integrity.
+
+# Snapshot the route-group state before the dial so we can diff and
+# attribute new groups to this probe.
+pre_rg="$("${CLI[@]}" dmsg cat --help >/dev/null 2>&1 && \
+    "${CLI[@]}" rg ls --json 2>/dev/null || echo '[]')"
+pre_rg_count=$(printf '%s' "$pre_rg" | tr -cd '{' | wc -c)
+
+tmpdir=$(mktemp -d -t muxprobe.XXXXXX)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Throughput leg — dmsg cat is the closest existing tool to a
+# multi-hop byte-pipe with explicit routes control. Replace with a
+# skysocks-client invocation when the runner is wired into an e2e
+# topology that has skysocks-server stood up on target_pk.
+log "starting throughput leg (dmsg cat --routes=$routes)…"
+{
+    "${CLI[@]}" dmsg cat "$target_pk:80" --transport=skynet --routes="$routes" \
+        < /dev/urandom \
+        > "$tmpdir/throughput.bin" 2>"$tmpdir/throughput.err" &
+    echo $! > "$tmpdir/throughput.pid"
+} || true
+
+# Give the dial a beat to establish before we assert rg state.
+sleep 3
+
+# --- assert fanout actually took ---------------------------------------
+post_rg_json="$("${CLI[@]}" rg ls --json 2>/dev/null || echo '[]')"
+post_rg_count=$(printf '%s' "$post_rg_json" | tr -cd '{' | wc -c)
+delta_rg=$((post_rg_count - pre_rg_count))
+log "rg delta: pre=$pre_rg_count post=$post_rg_count new=$delta_rg (requested=$routes)"
+
+if [[ "$delta_rg" -lt "$routes" ]]; then
+    kill "$(cat "$tmpdir/throughput.pid" 2>/dev/null)" 2>/dev/null || true
+    cat <<EOF >&2
+ABORT: rg ls reports $delta_rg new route groups; requested $routes.
+This is the silent fanout-degrade documented 2026-05-14 — the test
+is NOT measuring multiplex behavior at the requested fan-out.
+Diagnostic:
+
+  pre  $("${CLI[@]}" rg ls 2>/dev/null | head -3)
+  post $("${CLI[@]}" rg ls 2>/dev/null | head -3)
+
+If your topology has only DMSG paths to $target_pk, add a non-DMSG
+transport first (stcpr/sudph) and re-run.
+EOF
+    exit 2
+fi
+
+log "fanout verified: $delta_rg legs established for requested $routes"
+
+# --- run the low-rate stream + collect RTTs ----------------------------
+log "starting skychat low-rate stream ($skychat_rate msg/s for ${duration}s)…"
+end_ts=$(( $(date +%s) + duration ))
+sent=0
+acks=()
+while (( $(date +%s) < end_ts )); do
+    sent=$((sent + 1))
+    t0=$(date +%s%N)
+    if "${CLI[@]}" skychat send -t "$target_pk" -m "mux-probe-$sent" --wait 5s >/dev/null 2>&1; then
+        t1=$(date +%s%N)
+        acks+=( $((t1 - t0)) )
+    fi
+    # space sends evenly across the second
+    sleep "$(awk "BEGIN{printf \"%.3f\", 1/$skychat_rate}")"
+done
+
+# --- stop throughput + tally ------------------------------------------
+kill "$(cat "$tmpdir/throughput.pid" 2>/dev/null)" 2>/dev/null || true
+wait 2>/dev/null || true
+
+throughput_bytes=$(stat -c %s "$tmpdir/throughput.bin" 2>/dev/null || echo 0)
+throughput_kbps=$((throughput_bytes / duration / 1024))
+
+# Latency distribution from the skychat ACKs.
+if (( ${#acks[@]} > 0 )); then
+    sorted=( $(printf '%s\n' "${acks[@]}" | sort -n) )
+    n=${#sorted[@]}
+    p50_idx=$((n / 2))
+    p99_idx=$((n * 99 / 100))
+    [[ "$p99_idx" -ge "$n" ]] && p99_idx=$((n - 1))
+    p50_ns=${sorted[$p50_idx]}
+    p99_ns=${sorted[$p99_idx]}
+    p50_ms=$((p50_ns / 1000000))
+    p99_ms=$((p99_ns / 1000000))
+else
+    p50_ms="(no acks)"
+    p99_ms="(no acks)"
+    n=0
+fi
+
+# --- emit tally -------------------------------------------------------
+cat <<EOF
+=== mux-route-probe tally ===
+target_pk:      $target_pk
+self_pk:        $self_pk
+routes_req:     $routes
+routes_act:     $delta_rg
+duration:       ${duration}s
+throughput:     ${throughput_kbps} KB/s ($throughput_bytes bytes)
+skychat_sent:   $sent
+skychat_acked:  $n
+rtt_p50:        ${p50_ms} ms
+rtt_p99:        ${p99_ms} ms
+EOF
+
+# Operator-decidable: throughput/RTT-correlation/integrity checks live
+# in a follow-up Go test harness that compares against a recorded
+# single-hop single-leg baseline. The bash runner's job is to GET HERE
+# WITHOUT THE METHODOLOGY-GAP ABORT — the actual pass/fail evaluation
+# is downstream.
+
+exit 0

--- a/ci_scripts/mux-route-probe.sh
+++ b/ci_scripts/mux-route-probe.sh
@@ -195,7 +195,7 @@ throughput_kbps=$((throughput_bytes / duration / 1024))
 
 # Latency distribution from the skychat ACKs.
 if (( ${#acks[@]} > 0 )); then
-    sorted=( $(printf '%s\n' "${acks[@]}" | sort -n) )
+    mapfile -t sorted < <(printf '%s\n' "${acks[@]}" | sort -n)
     n=${#sorted[@]}
     p50_idx=$((n / 2))
     p99_idx=$((n * 99 / 100))


### PR DESCRIPTION
Per Alpha's 00:18Z ACK + assignment, drafting the multiplexed-route probe runner. Pre-aborts on the silent --routes=N→1 fanout degrade documented 2026-05-14 in the methodology-gap memory.

## Why

The 2026-05-14 finding: when a visor has only DMSG-mediated paths to its peer, \`router.establishMuxRoutes\` sets \`ExcludeDMSG=true\` on additional legs, which can't be satisfied, so the dial silently drops to 1 route. \`cli rg ls\` is the only reliable ground truth — without an explicit verify step, a \"--routes=4 ran at 12 MB/s\" measurement is meaningless because all 12 MB/s came from one leg.

This runner builds the verify step in: it snapshots \`rg ls\` pre-dial, snapshots again 3s post-dial, and **aborts with exit code 2 if the delta is less than the requested N**. Any tally past the abort point is a real mux measurement.

## What

\`ci_scripts/mux-route-probe.sh\` — 234 lines, bash-only, drives existing \`skywire cli\` commands. Pre-flight checks RPC + topology (must have stcpr/sudph if routes>1). Dial via \`cli dmsg cat <pk>:80 --routes=N --transport=skynet\` feeding /dev/urandom for sustained throughput. Parallel \`cli skychat send\` at configurable rate for per-message RTT distribution. Tally emits throughput KB/s + p50/p99 RTT + integrity bytecount.

| flag | default | purpose |
|---|---|---|
| \`ROUTES\` | 2 | mux leg count (\`--routes\` arg) |
| \`DURATION\` | 60 | sustained traffic window in seconds |
| \`SKYCHAT_RATE\` | 5 | low-rate stream msg/s |
| \`RPC_ADDR\` | localhost:3435 | visor RPC for \`cli\` |

| exit | meaning |
|---|---|
| 0 | probe completed, tally emitted |
| 1 | usage error |
| 2 | **topology degrade — the methodology gap** |
| 3-5 | reserved for downstream evaluator |

## Out of scope

The actual pass/fail evaluation (throughput vs single-hop baseline, RTT correlation bounds for head-of-line check, byte-integrity verification) is a downstream Go test harness comparing tally outputs across runs. Bash's job is to **get to the tally without the methodology-gap abort** — to give the downstream evaluator a real measurement to compare.

## Test plan

- [x] \`bash -n\` syntax clean
- [ ] dry-run against this visor's own RPC (target=self) to validate pre-flight + tally emit paths
- [ ] coordinated 3-visor run alpha→beta→gamma once Alpha + Beta both have non-DMSG transports up
- [ ] shellcheck via CI shell-lint workflow

## Coordination context

- Alpha 00:13Z pivoted from IPv6 to mux-route testing
- Alpha 00:18Z ACKed my scope (rg add+ls deterministic, 2-hop α→β→γ, skysocks+skychat simultaneous, 70% throughput threshold) + explicit \"Gamma — yes please drive the probe runner\"
- Beta 00:22Z ACKed the scope including the --routes=N→1 abort
- Phase 4b UI continues in parallel (separate branch)