### PR TITLE
fix(dmsg-discovery): skip CXO republish on heartbeat-only entry updates

### DIFF
--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -207,6 +207,20 @@ func (p *ClientsByServerCXOPublisher) PublishSetEntry(oldEntry, newEntry *disc.E
 		oldServers = pkSet(oldEntry.Client.DelegatedServers)
 	}
 
+	// Heartbeat short-circuit. clients-by-server subscribers consume
+	// (server, client) membership; Sequence/Timestamp/Signature bumps
+	// on otherwise-unchanged entries don't change that view. Under
+	// prod heartbeat load (~160 POST /entry/ per second observed
+	// 2026-05-19) re-publishing every refresh pegged dmsg-discovery
+	// at one full CPU core (13537 cpu-sec over 13309 wall-sec since
+	// startup, with 89% of inuse heap under
+	// Refs.AppendValues -> encoder.Serialize). Skipping when the
+	// materially-visible content is unchanged keeps the leaf set
+	// stable while removing the dominant publish work.
+	if oldEntry != nil && entryContentEqual(oldEntry, newEntry) {
+		return
+	}
+
 	body, err := json.Marshal(newEntry)
 	if err != nil {
 		p.log.WithError(err).Debug("Failed to marshal client entry leaf")
@@ -322,4 +336,36 @@ func pkSet(pks []cipher.PubKey) map[cipher.PubKey]struct{} {
 		out[pk] = struct{}{}
 	}
 	return out
+}
+
+// entryContentEqual reports whether two entries are identical from
+// the clients-by-server view's perspective. Deliberately excludes
+// Sequence, Timestamp, and Signature because those bump on every
+// heartbeat re-signature without changing the delegated-server
+// membership that subscribers consume.
+func entryContentEqual(a, b *disc.Entry) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Version != b.Version || a.ClientType != b.ClientType || a.Protocol != b.Protocol {
+		return false
+	}
+	if a.Static != b.Static {
+		return false
+	}
+	if (a.Client == nil) != (b.Client == nil) {
+		return false
+	}
+	if a.Client != nil {
+		if len(a.Client.DelegatedServers) != len(b.Client.DelegatedServers) {
+			return false
+		}
+		set := pkSet(a.Client.DelegatedServers)
+		for _, pk := range b.Client.DelegatedServers {
+			if _, ok := set[pk]; !ok {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/pkg/dmsg/discovery/api/cxo_publisher_test.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher_test.go
@@ -1,0 +1,164 @@
+// Package api — cxo_publisher_test.go covers the heartbeat
+// short-circuit on PublishSetEntry. Pins the equality semantics so a
+// future field added to disc.Entry has to be explicitly classified
+// as either materially-visible (include in the comparison + skip
+// expected) or heartbeat-only (exclude).
+package api
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+func TestEntryContentEqual(t *testing.T) {
+	pkClient, _ := cipher.GenerateKeyPair()
+	pkS1, _ := cipher.GenerateKeyPair()
+	pkS2, _ := cipher.GenerateKeyPair()
+	pkExtra, _ := cipher.GenerateKeyPair()
+	pkOther, _ := cipher.GenerateKeyPair()
+
+	baseClient := func() *disc.Entry {
+		return &disc.Entry{
+			Version:    "0.0.1",
+			Sequence:   42,
+			Timestamp:  1700000000,
+			Static:     pkClient,
+			Client:     &disc.Client{DelegatedServers: []cipher.PubKey{pkS1, pkS2}},
+			ClientType: "visor",
+			Signature:  "abc",
+		}
+	}
+
+	cases := []struct {
+		name string
+		a, b func() *disc.Entry
+		want bool
+	}{
+		{
+			name: "identical",
+			a:    baseClient,
+			b:    baseClient,
+			want: true,
+		},
+		{
+			name: "heartbeat — only Sequence/Timestamp/Signature differ",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Sequence = 43
+				e.Timestamp = 1700000060
+				e.Signature = "def"
+				return e
+			},
+			want: true,
+		},
+		{
+			name: "DelegatedServers added",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Client.DelegatedServers = append(e.Client.DelegatedServers, pkExtra)
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "DelegatedServers removed",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Client.DelegatedServers = []cipher.PubKey{pkS1}
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "DelegatedServers reordered — same set",
+			// Set semantics, not slice: order shouldn't matter
+			// because the publish fan-out is per-server.
+			a: baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Client.DelegatedServers = []cipher.PubKey{pkS2, pkS1}
+				return e
+			},
+			want: true,
+		},
+		{
+			name: "ClientType changed",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.ClientType = "skysocks"
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "Version changed",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Version = "0.0.2"
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "Protocol changed",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Protocol = "noise"
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "Static PK changed",
+			// Defensive — caller-provided oldEntry/newEntry should
+			// share Static, but the helper must not silently treat
+			// distinct PKs as equal.
+			a: baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Static = pkOther
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "Client absent on one side",
+			a:    baseClient,
+			b: func() *disc.Entry {
+				e := baseClient()
+				e.Client = nil
+				return e
+			},
+			want: false,
+		},
+		{
+			name: "nil a",
+			a:    func() *disc.Entry { return nil },
+			b:    baseClient,
+			want: false,
+		},
+		{
+			name: "nil b",
+			a:    baseClient,
+			b:    func() *disc.Entry { return nil },
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := entryContentEqual(c.a(), c.b())
+			if got != c.want {
+				t.Fatalf("entryContentEqual: got %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- dmsg-discovery was pegged at one full CPU core under prod load (13537 cpu-sec over 13309 wall-sec — sustained 101% since container start), with 89% of inuse heap under `Refs.AppendValues → encoder.Serialize` on the publishRoot path.
- Every `POST /entry/` ran `PublishSetEntry` which `Put` a fresh leaf for every delegated server even when the only diff vs the prior entry was a Sequence/Timestamp/Signature bump. `clients-by-server` subscribers don't consume those fields — they read `(server, client)` membership — so the republish was pure GC/CPU churn at roughly 160 req/sec × `DelegatedServers`.
- Short-circuit `PublishSetEntry` when `oldEntry`'s materially-visible content (Version, ClientType, Protocol, Static, DelegatedServers set) matches `newEntry`. First registrations (`oldEntry == nil`) and real membership / metadata changes publish unchanged.

This builds on #2705 (which fixed the tombstone-bloat side); the heartbeat-skip closes the remaining steady-state hot loop.

### Profile evidence (CPU, post-#2705 binary)
- `runtime.gcBgMarkWorker` 72.4% cum
- `runtime.scanObject` 64.5% cum
- 758k live `encoder.Serialize` objects in heap (85.6% of inuse_objects)
- Path: `treestore.Publisher.publishRoot.func1 → encodeNode → Refs.AppendValues → encoder.Serialize`

### Behavior after the fix
| input | before | after |
|---|---|---|
| New client registration (`oldEntry == nil`) | publish | publish (unchanged) |
| Heartbeat: same DelegatedServers, bumped Seq/Timestamp/Sig | full N-server republish | skip |
| DelegatedServers added/removed | publish (with diff fan-out) | publish (unchanged) |
| ClientType/Version/Protocol change | publish | publish (unchanged) |

## Test plan
- [x] `go build ./pkg/dmsg/discovery/...`
- [x] `go vet ./pkg/dmsg/discovery/...`
- [x] `go test ./pkg/dmsg/discovery/api/` — 12-case `TestEntryContentEqual` pins the comparison semantics (identical / heartbeat / membership add / membership remove / reorder / ClientType / Version / Protocol / Static / nil Client / nil a / nil b)
- [ ] Post-deploy: verify `dmsg-discovery` CPU drops from ~100% to single-digit %, RSS unchanged