### PR TITLE
feat(ci): mux-probe-assert — Go harness for mux-route-probe.sh tally

### DIFF
--- a/ci_scripts/mux-baseline.example.json
+++ b/ci_scripts/mux-baseline.example.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Reference baseline for mux-probe-assert. Record this from a SINGLE-LEG (routes=1) probe run before exercising mux fanout, so the throughput-ratio assertion has a real reference point. The .example.json suffix is intentional — keep the live baseline (mux-baseline.json) gitignored so per-environment numbers don't drift into the repo.",
+  "throughput_kbps": 1000,
+  "throughput_threshold_pct": 70,
+  "rtt_p99_ceiling_ms": 500,
+  "skychat_ack_rate_min_pct": 90
+}

--- a/cmd/mux-probe-assert/main.go
+++ b/cmd/mux-probe-assert/main.go
@@ -251,44 +251,56 @@ func scanInt64(out *int64, s string) error {
 	return nil
 }
 
+// emitf/emitln wrap fmt.Fprintf/Fprintln on an io.Writer and discard
+// the return so callers don't have to litter _, _ = on every trace
+// line. The Writer here is stderr (or a test buffer); a write error
+// is not actionable from the harness's perspective.
+func emitf(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...) //nolint:errcheck
+}
+
+func emitln(w io.Writer, s string) {
+	_, _ = fmt.Fprintln(w, s) //nolint:errcheck
+}
+
 // assertTally applies the scope-agreement thresholds and returns the
 // exit code. Writes a one-line summary per assertion to w so a CI
 // lane log shows the full pass/fail trace, not just the exit code.
 func assertTally(t Tally, b Baseline, w io.Writer) int {
-	fmt.Fprintf(w, "mux-probe-assert: target=%s routes_req=%d routes_act=%d throughput=%dKB/s p50=%dms p99=%dms\n",
+	emitf(w, "mux-probe-assert: target=%s routes_req=%d routes_act=%d throughput=%dKB/s p50=%dms p99=%dms\n",
 		t.TargetPK, t.RoutesReq, t.RoutesAct, t.ThroughputKBPS, t.RTTp50ms, t.RTTp99ms)
 
 	// (a) routes_act ≥ routes_req — the methodology gap.
 	if t.RoutesAct < t.RoutesReq {
-		fmt.Fprintf(w, "FAIL: topology degrade — routes_act %d < routes_req %d\n", t.RoutesAct, t.RoutesReq)
+		emitf(w, "FAIL: topology degrade — routes_act %d < routes_req %d\n", t.RoutesAct, t.RoutesReq)
 		return exitTopologyDegrade
 	}
-	fmt.Fprintf(w, "PASS: fanout took (routes_act %d ≥ routes_req %d)\n", t.RoutesAct, t.RoutesReq)
+	emitf(w, "PASS: fanout took (routes_act %d ≥ routes_req %d)\n", t.RoutesAct, t.RoutesReq)
 
 	// (c) throughput ≥ threshold% of baseline.
 	if b.ThroughputKBPS > 0 {
 		floor := b.ThroughputKBPS * b.ThroughputThresholdPct / 100
 		if t.ThroughputKBPS < floor {
-			fmt.Fprintf(w, "FAIL: throughput regression — %d KB/s < %d KB/s (%d%% of baseline %d KB/s)\n",
+			emitf(w, "FAIL: throughput regression — %d KB/s < %d KB/s (%d%% of baseline %d KB/s)\n",
 				t.ThroughputKBPS, floor, b.ThroughputThresholdPct, b.ThroughputKBPS)
 			return exitThroughputRegress
 		}
-		fmt.Fprintf(w, "PASS: throughput %d KB/s ≥ floor %d KB/s (baseline %d KB/s @ %d%%)\n",
+		emitf(w, "PASS: throughput %d KB/s ≥ floor %d KB/s (baseline %d KB/s @ %d%%)\n",
 			t.ThroughputKBPS, floor, b.ThroughputKBPS, b.ThroughputThresholdPct)
 	} else {
-		fmt.Fprintln(w, "SKIP: throughput check disabled (baseline.throughput_kbps == 0)")
+		emitln(w, "SKIP: throughput check disabled (baseline.throughput_kbps == 0)")
 	}
 
 	// (d) p99 ≤ ceiling. Operator-picked absolute bound, not
 	// baseline-relative — a mux run shouldn't bloat the tail.
 	if b.RTTp99CeilingMs > 0 {
 		if t.RTTp99ms > b.RTTp99CeilingMs {
-			fmt.Fprintf(w, "FAIL: p99 RTT %d ms > ceiling %d ms\n", t.RTTp99ms, b.RTTp99CeilingMs)
+			emitf(w, "FAIL: p99 RTT %d ms > ceiling %d ms\n", t.RTTp99ms, b.RTTp99CeilingMs)
 			return exitThroughputRegress // grouped with throughput-class regressions
 		}
-		fmt.Fprintf(w, "PASS: p99 RTT %d ms ≤ ceiling %d ms\n", t.RTTp99ms, b.RTTp99CeilingMs)
+		emitf(w, "PASS: p99 RTT %d ms ≤ ceiling %d ms\n", t.RTTp99ms, b.RTTp99CeilingMs)
 	} else {
-		fmt.Fprintln(w, "SKIP: p99 ceiling check disabled (baseline.rtt_p99_ceiling_ms == 0)")
+		emitln(w, "SKIP: p99 ceiling check disabled (baseline.rtt_p99_ceiling_ms == 0)")
 	}
 
 	// Skychat ack-rate floor. Independent of routes/throughput —
@@ -297,11 +309,11 @@ func assertTally(t Tally, b Baseline, w io.Writer) int {
 	if b.SkychatAckRateMinPct > 0 && t.SkychatSent > 0 {
 		ackPct := t.SkychatAcked * 100 / t.SkychatSent
 		if ackPct < b.SkychatAckRateMinPct {
-			fmt.Fprintf(w, "FAIL: skychat ack rate %d%% < min %d%% (%d/%d)\n",
+			emitf(w, "FAIL: skychat ack rate %d%% < min %d%% (%d/%d)\n",
 				ackPct, b.SkychatAckRateMinPct, t.SkychatAcked, t.SkychatSent)
 			return exitThroughputRegress
 		}
-		fmt.Fprintf(w, "PASS: skychat ack rate %d%% ≥ min %d%% (%d/%d)\n",
+		emitf(w, "PASS: skychat ack rate %d%% ≥ min %d%% (%d/%d)\n",
 			ackPct, b.SkychatAckRateMinPct, t.SkychatAcked, t.SkychatSent)
 	}
 
@@ -310,7 +322,7 @@ func assertTally(t Tally, b Baseline, w io.Writer) int {
 	// correlation between skychat-RTT and skysocks-throughput can't
 	// be computed here. Pairs with a future runner enhancement that
 	// emits a CSV of (send_ts, ack_ts, concurrent_throughput).
-	fmt.Fprintln(w, "SKIP: head-of-line correlation check (runner doesn't emit per-message data yet)")
+	emitln(w, "SKIP: head-of-line correlation check (runner doesn't emit per-message data yet)")
 
 	return exitOK
 }

--- a/cmd/mux-probe-assert/main.go
+++ b/cmd/mux-probe-assert/main.go
@@ -1,0 +1,316 @@
+// Command mux-probe-assert consumes the tally emitted by
+// ci_scripts/mux-route-probe.sh and enforces pass/fail thresholds
+// against a recorded baseline. Designed to be piped:
+//
+//	mux-route-probe.sh <target_pk> | mux-probe-assert -baseline=ci_scripts/mux-baseline.json
+//
+// Or with the tally captured to a file:
+//
+//	mux-route-probe.sh <target_pk> > tally.txt
+//	mux-probe-assert -baseline=... < tally.txt
+//
+// Exit codes intentionally match the runner's (per the 2026-05-19
+// mux-test scope agreement) so a CI lane can use either tool's exit
+// code without ambiguity:
+//
+//	0  success — all checks pass
+//	1  usage / parse error
+//	2  topology-degrade abort (routes_act < routes_req)
+//	3  integrity failure (reserved; runner doesn't emit a checksum yet)
+//	4  throughput regression (< 70% of baseline)
+//	5  head-of-line correlation breach (reserved; needs per-msg data
+//	   the bash runner doesn't emit yet)
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Tally holds the parsed fields from mux-route-probe.sh's stdout
+// tally block. Field order matches the runner's emit order so the
+// json shape is stable across versions of the tool.
+type Tally struct {
+	TargetPK       string `json:"target_pk"`
+	SelfPK         string `json:"self_pk"`
+	RoutesReq      int    `json:"routes_req"`
+	RoutesAct      int    `json:"routes_act"`
+	DurationSec    int    `json:"duration_sec"`
+	ThroughputKBPS int    `json:"throughput_kbps"`
+	ThroughputB    int64  `json:"throughput_bytes"`
+	SkychatSent    int    `json:"skychat_sent"`
+	SkychatAcked   int    `json:"skychat_acked"`
+	RTTp50ms       int    `json:"rtt_p50_ms"`
+	RTTp99ms       int    `json:"rtt_p99_ms"`
+}
+
+// Baseline holds the recorded reference numbers for the assertions.
+// Throughput is the only baseline-relative threshold today; RTT is
+// an absolute sanity bound the operator picks. Routes is enforced
+// against the tally's own RoutesReq, not the baseline.
+type Baseline struct {
+	// ThroughputKBPS is the single-leg / single-route reference for
+	// the throughput ratio assertion. The mux run is expected to
+	// hit ≥ ThroughputThresholdPct of this number.
+	ThroughputKBPS int `json:"throughput_kbps"`
+
+	// ThroughputThresholdPct is the floor (out of 100) the mux run
+	// must clear vs ThroughputKBPS. Defaults to 70 per the
+	// 2026-05-19 scope agreement.
+	ThroughputThresholdPct int `json:"throughput_threshold_pct"`
+
+	// RTTp99CeilingMs is the absolute upper bound on the p99 ack
+	// latency the operator considers acceptable. Zero disables the
+	// check (useful when only throughput is being measured).
+	RTTp99CeilingMs int `json:"rtt_p99_ceiling_ms"`
+
+	// SkychatAckRateMinPct is the minimum percentage (out of 100)
+	// of skychat sends that must ack within the runner's wait
+	// window. Zero disables.
+	SkychatAckRateMinPct int `json:"skychat_ack_rate_min_pct"`
+}
+
+const (
+	exitOK                = 0
+	exitUsage             = 1
+	exitTopologyDegrade   = 2
+	exitIntegrity         = 3 //nolint:unused,deadcode // reserved
+	exitThroughputRegress = 4
+	exitHOLBreach         = 5 //nolint:unused,deadcode // reserved
+)
+
+func main() {
+	var baselinePath string
+	flag.StringVar(&baselinePath, "baseline", "", "path to baseline JSON (required)")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: %s -baseline=<path> < tally.txt\n\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if baselinePath == "" {
+		flag.Usage()
+		os.Exit(exitUsage)
+	}
+
+	baseline, err := loadBaseline(baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load baseline %q: %v\n", baselinePath, err)
+		os.Exit(exitUsage)
+	}
+
+	tally, err := parseTally(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse tally: %v\n", err)
+		os.Exit(exitUsage)
+	}
+
+	code := assertTally(tally, baseline, os.Stderr)
+	os.Exit(code)
+}
+
+func loadBaseline(path string) (Baseline, error) {
+	var b Baseline
+	f, err := os.Open(path) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return b, err
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck
+	if err := json.NewDecoder(f).Decode(&b); err != nil {
+		return b, fmt.Errorf("decode: %w", err)
+	}
+	if b.ThroughputThresholdPct == 0 {
+		b.ThroughputThresholdPct = 70 // scope-agreement default
+	}
+	return b, nil
+}
+
+// parseTally reads the runner's stdout block. Tolerant of leading
+// log lines (the bash runner emits "[HH:MM:SSZ] …" log lines before
+// the tally) — only lines after "=== mux-route-probe tally ===" are
+// consumed.
+func parseTally(r io.Reader) (Tally, error) {
+	var t Tally
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	inTally := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "=== mux-route-probe tally ===") {
+			inTally = true
+			continue
+		}
+		if !inTally || line == "" {
+			continue
+		}
+		key, val, ok := splitKV(line)
+		if !ok {
+			continue
+		}
+		if err := assignField(&t, key, val); err != nil {
+			return t, fmt.Errorf("field %q: %w", key, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return t, err
+	}
+	if !inTally {
+		return t, errors.New("no tally block found (expected '=== mux-route-probe tally ===' marker)")
+	}
+	if t.RoutesReq == 0 {
+		return t, errors.New("tally missing required field routes_req")
+	}
+	return t, nil
+}
+
+// splitKV pulls "key: value" out of one tally line. Returns ok=false
+// for lines that don't match (e.g. blank, marker, stray log noise
+// mixed in).
+func splitKV(line string) (key, val string, ok bool) {
+	idx := strings.Index(line, ":")
+	if idx <= 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(line[:idx]), strings.TrimSpace(line[idx+1:]), true
+}
+
+// assignField populates t from one key/value pair. Unknown keys are
+// silently ignored so future runner additions don't break older
+// harness builds. Numeric fields tolerate the runner's trailing unit
+// suffix ("60s", "1234 KB/s (5678 bytes)", "12 ms").
+func assignField(t *Tally, key, val string) error {
+	switch key {
+	case "target_pk":
+		t.TargetPK = val
+	case "self_pk":
+		t.SelfPK = val
+	case "routes_req":
+		return scanInt(&t.RoutesReq, val)
+	case "routes_act":
+		return scanInt(&t.RoutesAct, val)
+	case "duration":
+		return scanInt(&t.DurationSec, strings.TrimSuffix(val, "s"))
+	case "throughput":
+		// "1234 KB/s (5678 bytes)"
+		fields := strings.Fields(val)
+		if len(fields) >= 1 {
+			if err := scanInt(&t.ThroughputKBPS, fields[0]); err != nil {
+				return err
+			}
+		}
+		// Pull "(5678 bytes)" if present — purely informational.
+		if i := strings.Index(val, "("); i >= 0 {
+			rest := strings.TrimSuffix(strings.TrimPrefix(val[i+1:], ""), ")")
+			restFields := strings.Fields(rest)
+			if len(restFields) >= 1 {
+				_ = scanInt64(&t.ThroughputB, restFields[0]) //nolint:errcheck
+			}
+		}
+	case "skychat_sent":
+		return scanInt(&t.SkychatSent, val)
+	case "skychat_acked":
+		return scanInt(&t.SkychatAcked, val)
+	case "rtt_p50":
+		return scanInt(&t.RTTp50ms, strings.TrimSuffix(val, " ms"))
+	case "rtt_p99":
+		return scanInt(&t.RTTp99ms, strings.TrimSuffix(val, " ms"))
+	}
+	return nil
+}
+
+func scanInt(out *int, s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "(no acks)" {
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+	*out = n
+	return nil
+}
+
+func scanInt64(out *int64, s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*out = n
+	return nil
+}
+
+// assertTally applies the scope-agreement thresholds and returns the
+// exit code. Writes a one-line summary per assertion to w so a CI
+// lane log shows the full pass/fail trace, not just the exit code.
+func assertTally(t Tally, b Baseline, w io.Writer) int {
+	fmt.Fprintf(w, "mux-probe-assert: target=%s routes_req=%d routes_act=%d throughput=%dKB/s p50=%dms p99=%dms\n",
+		t.TargetPK, t.RoutesReq, t.RoutesAct, t.ThroughputKBPS, t.RTTp50ms, t.RTTp99ms)
+
+	// (a) routes_act ≥ routes_req — the methodology gap.
+	if t.RoutesAct < t.RoutesReq {
+		fmt.Fprintf(w, "FAIL: topology degrade — routes_act %d < routes_req %d\n", t.RoutesAct, t.RoutesReq)
+		return exitTopologyDegrade
+	}
+	fmt.Fprintf(w, "PASS: fanout took (routes_act %d ≥ routes_req %d)\n", t.RoutesAct, t.RoutesReq)
+
+	// (c) throughput ≥ threshold% of baseline.
+	if b.ThroughputKBPS > 0 {
+		floor := b.ThroughputKBPS * b.ThroughputThresholdPct / 100
+		if t.ThroughputKBPS < floor {
+			fmt.Fprintf(w, "FAIL: throughput regression — %d KB/s < %d KB/s (%d%% of baseline %d KB/s)\n",
+				t.ThroughputKBPS, floor, b.ThroughputThresholdPct, b.ThroughputKBPS)
+			return exitThroughputRegress
+		}
+		fmt.Fprintf(w, "PASS: throughput %d KB/s ≥ floor %d KB/s (baseline %d KB/s @ %d%%)\n",
+			t.ThroughputKBPS, floor, b.ThroughputKBPS, b.ThroughputThresholdPct)
+	} else {
+		fmt.Fprintln(w, "SKIP: throughput check disabled (baseline.throughput_kbps == 0)")
+	}
+
+	// (d) p99 ≤ ceiling. Operator-picked absolute bound, not
+	// baseline-relative — a mux run shouldn't bloat the tail.
+	if b.RTTp99CeilingMs > 0 {
+		if t.RTTp99ms > b.RTTp99CeilingMs {
+			fmt.Fprintf(w, "FAIL: p99 RTT %d ms > ceiling %d ms\n", t.RTTp99ms, b.RTTp99CeilingMs)
+			return exitThroughputRegress // grouped with throughput-class regressions
+		}
+		fmt.Fprintf(w, "PASS: p99 RTT %d ms ≤ ceiling %d ms\n", t.RTTp99ms, b.RTTp99CeilingMs)
+	} else {
+		fmt.Fprintln(w, "SKIP: p99 ceiling check disabled (baseline.rtt_p99_ceiling_ms == 0)")
+	}
+
+	// Skychat ack-rate floor. Independent of routes/throughput —
+	// catches the case where the route exists but the chat-app
+	// is dropping messages on the receive side.
+	if b.SkychatAckRateMinPct > 0 && t.SkychatSent > 0 {
+		ackPct := t.SkychatAcked * 100 / t.SkychatSent
+		if ackPct < b.SkychatAckRateMinPct {
+			fmt.Fprintf(w, "FAIL: skychat ack rate %d%% < min %d%% (%d/%d)\n",
+				ackPct, b.SkychatAckRateMinPct, t.SkychatAcked, t.SkychatSent)
+			return exitThroughputRegress
+		}
+		fmt.Fprintf(w, "PASS: skychat ack rate %d%% ≥ min %d%% (%d/%d)\n",
+			ackPct, b.SkychatAckRateMinPct, t.SkychatAcked, t.SkychatSent)
+	}
+
+	// (e) head-of-line correlation: reserved. The bash runner only
+	// emits aggregate p50/p99, not per-message timestamps, so the
+	// correlation between skychat-RTT and skysocks-throughput can't
+	// be computed here. Pairs with a future runner enhancement that
+	// emits a CSV of (send_ts, ack_ts, concurrent_throughput).
+	fmt.Fprintln(w, "SKIP: head-of-line correlation check (runner doesn't emit per-message data yet)")
+
+	return exitOK
+}

--- a/cmd/mux-probe-assert/main_test.go
+++ b/cmd/mux-probe-assert/main_test.go
@@ -1,0 +1,207 @@
+// Package main main_test.go — table-driven tests for the tally
+// parser + assertion engine. The contract this pins:
+//
+//   - Tally parsing tolerates leading log lines from the bash runner.
+//   - Numeric fields tolerate the runner's unit suffixes.
+//   - Each scope-agreement assertion has both a pass and fail path.
+//
+// Pre-conditions are spelled out in each subtest to avoid the
+// shared-fixture coupling that bit us on prior CLI parse tests.
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+const sampleTally = `[16:42:07Z] probe start: target=03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c routes=2 duration=60s rate=5/s rpc=localhost:3435
+[16:42:07Z] pre-flight: self_pk=02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36
+[16:42:10Z] starting throughput leg (dmsg cat --routes=2)…
+[16:42:13Z] rg delta: pre=0 post=2 new=2 (requested=2)
+[16:42:13Z] fanout verified: 2 legs established for requested 2
+[16:42:13Z] starting skychat low-rate stream (5 msg/s for 60s)…
+=== mux-route-probe tally ===
+target_pk:      03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c
+self_pk:        02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36
+routes_req:     2
+routes_act:     2
+duration:       60s
+throughput:     312 KB/s (19169280 bytes)
+skychat_sent:   300
+skychat_acked:  298
+rtt_p50:        45 ms
+rtt_p99:        180 ms
+`
+
+func TestParseTally_Success(t *testing.T) {
+	tally, err := parseTally(strings.NewReader(sampleTally))
+	if err != nil {
+		t.Fatalf("parseTally: %v", err)
+	}
+	if tally.TargetPK != "03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c" {
+		t.Errorf("TargetPK: %q", tally.TargetPK)
+	}
+	if tally.RoutesReq != 2 {
+		t.Errorf("RoutesReq: %d", tally.RoutesReq)
+	}
+	if tally.RoutesAct != 2 {
+		t.Errorf("RoutesAct: %d", tally.RoutesAct)
+	}
+	if tally.DurationSec != 60 {
+		t.Errorf("DurationSec: %d", tally.DurationSec)
+	}
+	if tally.ThroughputKBPS != 312 {
+		t.Errorf("ThroughputKBPS: %d", tally.ThroughputKBPS)
+	}
+	if tally.ThroughputB != 19169280 {
+		t.Errorf("ThroughputB: %d", tally.ThroughputB)
+	}
+	if tally.SkychatSent != 300 || tally.SkychatAcked != 298 {
+		t.Errorf("skychat sent=%d acked=%d", tally.SkychatSent, tally.SkychatAcked)
+	}
+	if tally.RTTp50ms != 45 || tally.RTTp99ms != 180 {
+		t.Errorf("rtt p50=%d p99=%d", tally.RTTp50ms, tally.RTTp99ms)
+	}
+}
+
+func TestParseTally_NoTallyMarker(t *testing.T) {
+	// Just log lines, no tally block — should error so a CI lane
+	// doesn't silently zero out and report success on a runner that
+	// crashed before emitting its tally.
+	in := "[16:42:07Z] probe start: target=…\n[16:42:08Z] ABORT: pre-flight failed\n"
+	if _, err := parseTally(strings.NewReader(in)); err == nil {
+		t.Fatal("expected error on tally-missing input")
+	}
+}
+
+func TestParseTally_NoAcksTolerated(t *testing.T) {
+	// Bash runner emits "(no acks)" sentinel when the skychat
+	// stream got zero ack-backs. Parser must not error on the
+	// string — assignField returns nil and the int stays zero.
+	in := `=== mux-route-probe tally ===
+target_pk:      a
+self_pk:        b
+routes_req:     1
+routes_act:     1
+duration:       10s
+throughput:     0 KB/s (0 bytes)
+skychat_sent:   0
+skychat_acked:  0
+rtt_p50:        (no acks)
+rtt_p99:        (no acks)
+`
+	tally, err := parseTally(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseTally: %v", err)
+	}
+	if tally.RTTp50ms != 0 || tally.RTTp99ms != 0 {
+		t.Errorf("expected zero rtt on no-acks, got p50=%d p99=%d", tally.RTTp50ms, tally.RTTp99ms)
+	}
+}
+
+func TestAssertTally_TopologyDegrade(t *testing.T) {
+	tally := Tally{RoutesReq: 2, RoutesAct: 1, ThroughputKBPS: 1000}
+	baseline := Baseline{ThroughputKBPS: 1000, ThroughputThresholdPct: 70}
+	var buf bytes.Buffer
+	if got := assertTally(tally, baseline, &buf); got != exitTopologyDegrade {
+		t.Fatalf("expected exitTopologyDegrade (%d), got %d. log=%s", exitTopologyDegrade, got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "topology degrade") {
+		t.Errorf("missing 'topology degrade' in log: %s", buf.String())
+	}
+}
+
+func TestAssertTally_ThroughputRegression(t *testing.T) {
+	// 70% of 1000 KB/s = 700 KB/s floor. 600 < 700 → fail.
+	tally := Tally{RoutesReq: 2, RoutesAct: 2, ThroughputKBPS: 600}
+	baseline := Baseline{ThroughputKBPS: 1000, ThroughputThresholdPct: 70}
+	var buf bytes.Buffer
+	if got := assertTally(tally, baseline, &buf); got != exitThroughputRegress {
+		t.Fatalf("expected exitThroughputRegress (%d), got %d. log=%s", exitThroughputRegress, got, buf.String())
+	}
+}
+
+func TestAssertTally_RTTp99CeilingBreach(t *testing.T) {
+	tally := Tally{RoutesReq: 1, RoutesAct: 1, ThroughputKBPS: 1000, RTTp99ms: 5000}
+	baseline := Baseline{
+		ThroughputKBPS:         1000,
+		ThroughputThresholdPct: 70,
+		RTTp99CeilingMs:        1000,
+	}
+	var buf bytes.Buffer
+	got := assertTally(tally, baseline, &buf)
+	if got != exitThroughputRegress {
+		t.Fatalf("expected exitThroughputRegress (%d) on p99 breach, got %d. log=%s", exitThroughputRegress, got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "p99 RTT") {
+		t.Errorf("missing 'p99 RTT' in log: %s", buf.String())
+	}
+}
+
+func TestAssertTally_SkychatAckRateBreach(t *testing.T) {
+	// 50/100 = 50% acked, min is 90% → fail.
+	tally := Tally{
+		RoutesReq:      1,
+		RoutesAct:      1,
+		ThroughputKBPS: 1000,
+		SkychatSent:    100,
+		SkychatAcked:   50,
+	}
+	baseline := Baseline{
+		ThroughputKBPS:         1000,
+		ThroughputThresholdPct: 70,
+		SkychatAckRateMinPct:   90,
+	}
+	var buf bytes.Buffer
+	got := assertTally(tally, baseline, &buf)
+	if got != exitThroughputRegress {
+		t.Fatalf("expected exitThroughputRegress (%d) on ack-rate breach, got %d. log=%s", exitThroughputRegress, got, buf.String())
+	}
+}
+
+func TestAssertTally_AllPass(t *testing.T) {
+	tally := Tally{
+		RoutesReq:      2,
+		RoutesAct:      2,
+		ThroughputKBPS: 850,
+		RTTp99ms:       180,
+		SkychatSent:    100,
+		SkychatAcked:   95,
+	}
+	baseline := Baseline{
+		ThroughputKBPS:         1000,
+		ThroughputThresholdPct: 70,
+		RTTp99CeilingMs:        500,
+		SkychatAckRateMinPct:   90,
+	}
+	var buf bytes.Buffer
+	if got := assertTally(tally, baseline, &buf); got != exitOK {
+		t.Fatalf("expected exitOK, got %d. log=%s", got, buf.String())
+	}
+	// All four PASS lines should be present.
+	for _, want := range []string{"PASS: fanout took", "PASS: throughput", "PASS: p99 RTT", "PASS: skychat ack rate"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("missing %q in log: %s", want, buf.String())
+		}
+	}
+}
+
+func TestAssertTally_DisabledChecksSkip(t *testing.T) {
+	// Zero-valued baseline thresholds → SKIP rather than FAIL.
+	// Useful when only one assertion is being measured (e.g. early
+	// runs without a recorded throughput baseline yet).
+	tally := Tally{RoutesReq: 1, RoutesAct: 1, ThroughputKBPS: 100}
+	baseline := Baseline{} // all-zero
+	var buf bytes.Buffer
+	if got := assertTally(tally, baseline, &buf); got != exitOK {
+		t.Fatalf("expected exitOK with all-zero baseline, got %d. log=%s", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "SKIP: throughput check disabled") {
+		t.Errorf("missing throughput SKIP: %s", buf.String())
+	}
+}
+
+// Sanity: parseTally accepts io.Reader, not just strings.Reader.
+var _ io.Reader = (*bytes.Reader)(nil)


### PR DESCRIPTION
## Summary
Beta's slice of the mux-test work (per the 2026-05-19 scope agreement) — a Go assertion harness that consumes the stdout tally from \`ci_scripts/mux-route-probe.sh\` (#2723) and enforces pass/fail thresholds against a recorded baseline.

## What's in
- **\`cmd/mux-probe-assert/main.go\`** — parser tolerant of the runner's leading log lines + unit-suffixed values (\`60s\`, \`312 KB/s (19169280 bytes)\`, \`(no acks)\`); assertion engine emits a one-line PASS/FAIL/SKIP trace per check so a CI lane log shows the full evaluation path, not just the exit code.
- **\`cmd/mux-probe-assert/main_test.go\`** — 9 table-driven cases covering parse tolerance and each assertion's pass/fail/skip paths.
- **\`ci_scripts/mux-baseline.example.json\`** — schema reference with operator-tunable thresholds.

## Pipeline
\`\`\`bash
ci_scripts/mux-route-probe.sh <target_pk> routes=2 | mux-probe-assert -baseline=ci_scripts/mux-baseline.json
\`\`\`

## Exit codes
Aligned with the runner's so a CI lane can union them without ambiguity:
| code | meaning |
|---|---|
| 0 | all checks pass |
| 1 | usage / parse error |
| 2 | topology degrade (\`routes_act < routes_req\` — the 2026-05-14 methodology gap) |
| 4 | throughput regression OR p99 ceiling breach OR skychat ack-rate breach |

Codes **3** (integrity) and **5** (head-of-line correlation) are reserved — both need runner-side data the bash script doesn't emit yet (a payload checksum + per-message timestamps). Documented in the source.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./cmd/mux-probe-assert/...\`
- [x] \`go test ./cmd/mux-probe-assert/...\` — 9/9 pass
- [x] \`make format\` clean
- [ ] End-to-end with the live runner once intermediate-pool topology is in place (\`alpha→beta→intermediate→gamma\` via #2725)

Refs #2723, #1525 mux-test scope agreement 2026-05-19.