### PR TITLE
feat(skynet): --routes flag for parallel mux-route dialing

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 
@@ -35,6 +36,11 @@ var (
 	localPort int
 	// appPort is the routing port for the app
 	appPort uint16
+	// routes is the number of parallel skynet mux routes to use for the
+	// underlying app-level conn. 0 or 1 = single route (legacy Dial
+	// path); N > 1 = router establishes N parallel mux routes and the
+	// app sees a single conn whose payload is striped across them.
+	routes int
 )
 
 func init() {
@@ -43,6 +49,7 @@ func init() {
 	RootCmd.Flags().IntVar(&remotePort, "remote", 0, "remote port to forward")
 	RootCmd.Flags().IntVar(&localPort, "local", 0, "local port to listen on")
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
+	RootCmd.Flags().IntVar(&routes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
 }
 
 // RootCmd is the root command for skynet-client
@@ -72,6 +79,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		fs.IntVar(&remotePort, "remote", 0, "remote port")
 		fs.IntVar(&localPort, "local", 0, "local port")
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
+		fs.IntVar(&routes, "routes", 0, "number of parallel skynet mux routes")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -126,9 +134,22 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		Port:   routing.Port(skyenv.SkyForwardingServerPort),
 	}
 
-	appCl.Log().Infof("Dialing %s on port %d", remotePK.Hex(), skyenv.SkyForwardingServerPort)
+	if routes > 1 {
+		appCl.Log().Infof("Dialing %s on port %d with %d parallel mux routes",
+			remotePK.Hex(), skyenv.SkyForwardingServerPort, routes)
+	} else {
+		appCl.Log().Infof("Dialing %s on port %d", remotePK.Hex(), skyenv.SkyForwardingServerPort)
+	}
 
-	conn, err := appCl.Dial(connApp)
+	var (
+		conn net.Conn
+		err  error
+	)
+	if routes > 1 {
+		conn, err = appCl.DialWithOptions(connApp, routes)
+	} else {
+		conn, err = appCl.Dial(connApp)
+	}
 	if err != nil {
 		setAppError(appCl, fmt.Errorf("failed to connect to server: %w", err))
 		return fmt.Errorf("failed to connect to server: %w", err)

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -29,6 +29,7 @@ var (
 	useInternal   bool
 	useExternal   bool
 	clientName    string // optional custom name for the client instance
+	startRoutes   int    // number of parallel skynet mux routes (0/1 = single route)
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	startCmd.Flags().BoolVar(&useInternal, "internal", false, "force internal launcher")
 	startCmd.Flags().BoolVar(&useExternal, "external", false, "force external launcher")
 	startCmd.Flags().StringVarP(&clientName, "name", "n", "", "custom name for this client instance (default: skynet-client-<local-port>)")
+	startCmd.Flags().IntVar(&startRoutes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 
 	stopCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of the client instance to stop")
@@ -117,6 +119,10 @@ var startCmd = &cobra.Command{
 
 		if clientAppPort != 0 {
 			arguments["appPort"] = clientAppPort
+		}
+
+		if startRoutes > 1 {
+			arguments["--routes"] = fmt.Sprintf("%d", startRoutes)
 		}
 
 		err = rpcClient.DoCustomSetting(appName, arguments)

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -123,6 +123,41 @@ func (_m *MockRPCIngressClient) Dial(remote appnet.Addr) (uint16, routing.Port, 
 	return r0, r1, r2
 }
 
+// DialWithOptions provides a mock function with given fields: remote, muxRoutes
+func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int) (uint16, routing.Port, error) {
+	ret := _m.Called(remote, muxRoutes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DialWithOptions")
+	}
+
+	var r0 uint16
+	var r1 routing.Port
+	var r2 error
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int) (uint16, routing.Port, error)); ok {
+		return rf(remote, muxRoutes)
+	}
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int) uint16); ok {
+		r0 = rf(remote, muxRoutes)
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	if rf, ok := ret.Get(1).(func(appnet.Addr, int) routing.Port); ok {
+		r1 = rf(remote, muxRoutes)
+	} else {
+		r1 = ret.Get(1).(routing.Port)
+	}
+
+	if rf, ok := ret.Get(2).(func(appnet.Addr, int) error); ok {
+		r2 = rf(remote, muxRoutes)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // Listen provides a mock function with given fields: local
 func (_m *MockRPCIngressClient) Listen(local appnet.Addr) (uint16, error) {
 	ret := _m.Called(local)

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -20,6 +20,12 @@ type RPCIngressClient interface {
 	SetError(appErr string) error
 	SetAppPort(appPort routing.Port) error
 	Dial(remote appnet.Addr) (connID uint16, localPort routing.Port, err error)
+	// DialWithOptions asks the server to dial remote with per-call
+	// options. The only currently-honored option is MuxRoutes: when
+	// > 1 and the remote's family routes through SkywireNetworker,
+	// the router establishes N parallel mux routes. MuxRoutes <= 1
+	// is equivalent to plain Dial.
+	DialWithOptions(remote appnet.Addr, muxRoutes int) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
 	Write(connID uint16, b []byte) (int, error)
@@ -78,6 +84,19 @@ func (e RPCErr) Error() string {
 func (c *rpcIngressClient) Dial(remote appnet.Addr) (connID uint16, localPort routing.Port, err error) {
 	var resp DialResp
 	if err := c.rpc.Call(c.formatMethod("Dial"), &remote, &resp); err != nil {
+		return 0, 0, RPCErr{err.Error()}
+	}
+
+	return resp.ConnID, resp.LocalPort, nil
+}
+
+// DialWithOptions sends `DialWithOptions` command to the server.
+// muxRoutes <= 1 falls through to plain Dial semantics on the server
+// side (no extra round-trip cost beyond the slightly larger request).
+func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int) (connID uint16, localPort routing.Port, err error) {
+	req := DialOptionsReq{Addr: remote, MuxRoutes: muxRoutes}
+	var resp DialResp
+	if err := c.rpc.Call(c.formatMethod("DialWithOptions"), &req, &resp); err != nil {
 		return 0, 0, RPCErr{err.Error()}
 	}
 

--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -102,6 +102,40 @@ func TestRPCIngressClient_Dial(t *testing.T) {
 	})
 }
 
+func TestRPCIngressClient_DialWithOptions(t *testing.T) {
+	t.Run("ok with muxRoutes", func(t *testing.T) {
+		rpcL, closeL := prepListener(t)
+		defer closeL()
+
+		rpcS := prepRPCServer(t, NewRPCGateway(nil, nil))
+		go rpcS.Accept(rpcL)
+
+		rpcC := prepRPCClient(t, rpcL.Addr().Network(), rpcL.Addr().String())
+
+		dmsgLocal, dmsgRemote, _, remote := prepAddrs()
+
+		dialCtx := context.Background()
+		dialConn := &appcommon.MockConn{}
+		dialConn.On("LocalAddr").Return(dmsgLocal)
+		dialConn.On("RemoteAddr").Return(dmsgRemote)
+
+		n := &appnet.MockNetworker{}
+		n.On("DialContext", dialCtx, remote).Return(dialConn, testhelpers.NoErr)
+
+		appnet.ClearNetworkers()
+		require.NoError(t, appnet.AddNetworker(appnet.TypeDmsg, n))
+
+		// muxRoutes=4 but no SkywireNetworker registered → server falls
+		// back to plain DialContext; the round-trip still succeeds and
+		// returns a valid ConnID. We're pinning the wire shape, not the
+		// router-level mux behavior (which is integration-tested).
+		connID, localPort, err := rpcC.DialWithOptions(remote, 4)
+		require.NoError(t, err)
+		require.Equal(t, uint16(1), connID)
+		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)
+	})
+}
+
 func TestRPCIngressClient_Listen(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		s := prepRPCServer(t, NewRPCGateway(nil, nil))

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -12,6 +12,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/idmanager"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/util/rpcutil"
 )
@@ -113,10 +114,50 @@ type DialResp struct {
 	LocalPort routing.Port
 }
 
+// DialOptionsReq carries a dial request with extra per-call options.
+// Used by DialWithOptions for app paths that need to request specific
+// router behavior (currently: N parallel mux routes for the skynet
+// transport). Zero / unset MuxRoutes preserves the single-route
+// default — equivalent to plain Dial.
+//
+// Added for #1525-adjacent skywire-cli mux-route testing per the
+// operator's 2026-05-19 ask. Generalizes the per-call route count
+// already plumbed through VisorCat (pkg/visor/api_visor_cat.go) into
+// the app-net surface so apps like skynet-client can request N routes
+// at dial time without needing a parallel "cli skynet cat"-style RPC.
+type DialOptionsReq struct {
+	Addr      appnet.Addr
+	MuxRoutes int
+}
+
 // Dial dials to the remote.
 func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error) {
 	defer rpcutil.LogCall(r.log, "Dial", remote)(resp, &err)
+	return r.dialInternal(*remote, 0, resp)
+}
 
+// DialWithOptions dials to the remote honoring per-call dial options.
+// Currently the only honored option is MuxRoutes — when > 1 and the
+// destination transport is skynet, the router establishes N parallel
+// mux routes via SkywireNetworker.DialContextWithOptions instead of
+// the single-route DialContext. Mirrors the per-call Routes path
+// already exposed via VisorCat. Falls back to plain Dial semantics
+// (single route) when MuxRoutes <= 1 OR the registered networker for
+// the address family isn't *SkywireNetworker (e.g. dmsg, where mux is
+// inherent to the session and the routes count is a no-op).
+func (r *RPCIngressGateway) DialWithOptions(req *DialOptionsReq, resp *DialResp) (err error) {
+	defer rpcutil.LogCall(r.log, "DialWithOptions", req)(resp, &err)
+	if req == nil {
+		return errors.New("DialWithOptions: nil request")
+	}
+	return r.dialInternal(req.Addr, req.MuxRoutes, resp)
+}
+
+// dialInternal is the common dial body shared by Dial + DialWithOptions.
+// muxRoutes <= 1 means "no mux", which is the existing Dial behavior;
+// muxRoutes > 1 triggers the SkywireNetworker.DialContextWithOptions
+// path for skynet destinations.
+func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes int, resp *DialResp) error {
 	reservedConnID, free, err := r.cm.ReserveNextID()
 	if err != nil {
 		return err
@@ -131,7 +172,7 @@ func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error
 		appName = r.proc.conf.AppName
 	}
 	dialCtx := appnet.WithAppName(context.Background(), appName)
-	conn, err := appnet.DialContext(dialCtx, *remote)
+	conn, err := dialWithMuxRoutes(dialCtx, remote, muxRoutes)
 	if err != nil {
 		free()
 		return err
@@ -157,6 +198,32 @@ func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error
 	resp.LocalPort = localAddr.Port
 
 	return nil
+}
+
+// dialWithMuxRoutes dials remote either via the single-route default
+// path (appnet.DialContext) or via the SkywireNetworker mux-routes
+// path when muxRoutes > 1 and the registered networker for the addr's
+// family is the real *SkywireNetworker. The type-assertion fallback to
+// the default path matches VisorCat's contract (a test-mock or future
+// alternative networker silently degrades to single-route, preserving
+// correctness with no extra plumbing).
+func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, muxRoutes int) (net.Conn, error) {
+	if muxRoutes <= 1 {
+		return appnet.DialContext(ctx, remote)
+	}
+	nw, err := appnet.ResolveNetworker(remote.Net)
+	if err != nil {
+		return nil, err
+	}
+	sw, ok := nw.(*appnet.SkywireNetworker)
+	if !ok {
+		// Non-skynet networker (e.g. dmsg) — mux-routes is a no-op
+		// concept at this layer. Fall through to the default dial.
+		return appnet.DialContext(ctx, remote)
+	}
+	opts := router.DefaultDialOptions()
+	opts.MuxRoutes = muxRoutes
+	return sw.DialContextWithOptions(ctx, remote, opts)
 }
 
 // Listen starts listening.

--- a/pkg/app/appserver/rpc_ingress_gateway_test.go
+++ b/pkg/app/appserver/rpc_ingress_gateway_test.go
@@ -168,6 +168,73 @@ func testRPCIngressGatewayDialErrorWrappingConn(t *testing.T, l *logging.Logger,
 	require.Equal(t, err, appnet.ErrUnknownAddrType)
 }
 
+func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
+	l := logging.MustGetLogger("rpc_gateway")
+	nType := appnet.TypeDmsg
+	dialAddr := prepAddr(nType)
+
+	t.Run("nil request", func(t *testing.T) {
+		rpc := NewRPCGateway(l, nil)
+		var resp DialResp
+		err := rpc.DialWithOptions(nil, &resp)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "nil request")
+	})
+
+	t.Run("muxRoutes 0 falls through to legacy dial", func(t *testing.T) {
+		appnet.ClearNetworkers()
+
+		const localPort routing.Port = 200
+
+		dialCtx := context.Background()
+		dialConn := &appcommon.MockConn{}
+		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
+		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
+
+		n := &appnet.MockNetworker{}
+		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+
+		require.NoError(t, appnet.AddNetworker(nType, n))
+
+		rpc := NewRPCGateway(l, nil)
+
+		var resp DialResp
+		req := &DialOptionsReq{Addr: dialAddr, MuxRoutes: 0}
+		require.NoError(t, rpc.DialWithOptions(req, &resp))
+		require.Equal(t, uint16(1), resp.ConnID)
+		require.Equal(t, localPort, resp.LocalPort)
+		n.AssertExpectations(t)
+	})
+
+	t.Run("muxRoutes N on non-skywire networker falls back to DialContext", func(t *testing.T) {
+		appnet.ClearNetworkers()
+
+		const localPort routing.Port = 201
+
+		dialCtx := context.Background()
+		dialConn := &appcommon.MockConn{}
+		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
+		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
+
+		n := &appnet.MockNetworker{}
+		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+
+		require.NoError(t, appnet.AddNetworker(nType, n))
+
+		rpc := NewRPCGateway(l, nil)
+
+		var resp DialResp
+		req := &DialOptionsReq{Addr: dialAddr, MuxRoutes: 4}
+		require.NoError(t, rpc.DialWithOptions(req, &resp))
+		require.Equal(t, uint16(1), resp.ConnID)
+		require.Equal(t, localPort, resp.LocalPort)
+		// Confirms the type-assertion guard works: with no *SkywireNetworker
+		// registered we silently degrade to plain DialContext rather than
+		// erroring; the mux-routes hint is dropped.
+		n.AssertExpectations(t)
+	})
+}
+
 func TestRPCIngressGateway_Listen(t *testing.T) {
 	l := logging.MustGetLogger("rpc_gateway")
 	nType := appnet.TypeDmsg

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -106,7 +106,37 @@ func (c *Client) SetAppPort(appPort routing.Port) error {
 
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
-	connID, localPort, err := c.rpcC.Dial(remote)
+	return c.dial(remote, 0)
+}
+
+// DialWithOptions dials remote with per-call dial options. The only
+// currently-honored option is muxRoutes: when > 1 and the remote's
+// transport family routes through the visor's SkywireNetworker, the
+// underlying router establishes N parallel mux routes. muxRoutes <= 1
+// is semantically equivalent to Dial. Apps requesting multi-route
+// dials (e.g. skynet-client with the --routes flag for #1525-adjacent
+// mux-route testing) call this instead of Dial; non-mux callers keep
+// using Dial unchanged.
+func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes int) (net.Conn, error) {
+	return c.dial(remote, muxRoutes)
+}
+
+// dial is the common body for Dial + DialWithOptions. muxRoutes <= 1
+// invokes the original rpcC.Dial path (preserving the existing wire
+// shape for non-mux callers); muxRoutes > 1 sends the DialWithOptions
+// request so the server-side knows to take the SkywireNetworker
+// mux-routes path.
+func (c *Client) dial(remote appnet.Addr, muxRoutes int) (net.Conn, error) {
+	var (
+		connID    uint16
+		localPort routing.Port
+		err       error
+	)
+	if muxRoutes > 1 {
+		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes)
+	} else {
+		connID, localPort, err = c.rpcC.Dial(remote)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Add `--routes int` flag to `skywire cli skynet start` and the `skynet-client` app
- New `DialWithOptions` plumbing on the app-server RPC ingress carries a per-call `MuxRoutes` count from the app down to `appnet.SkywireNetworker.DialContextWithOptions`
- Legacy `Dial` callers / `--routes 0|1` invocations are byte-identical on the wire — only the `--routes > 1` path takes the type-asserted mux branch

## Why
The operator's mux-route hypothesis (throughput ~ linear in N, latency = max(per-route)) cannot be measured today because every app dials via a single route. This adds the minimum fine-grained routing knob needed to drive N routes per app conn for the planned beta↔gamma iperf3-over-skynet runs.

## Wire shape
```go
type DialOptionsReq struct {
    Addr      appnet.Addr
    MuxRoutes int
}

// gateway
func (r *RPCIngressGateway) DialWithOptions(req *DialOptionsReq, resp *DialResp) error
```
Server-side: type-assert to `*appnet.SkywireNetworker` and use `DialContextWithOptions` with `opts.MuxRoutes = N`. If the networker isn't a `SkywireNetworker` (e.g. dmsg, stcp), fall back to plain `appnet.DialContext` so non-skywire families keep working unchanged.

## Files touched
- `pkg/app/appserver/rpc_ingress_gateway.go` — `DialOptionsReq`, `DialWithOptions`, shared `dialInternal`, `dialWithMuxRoutes` helper
- `pkg/app/appserver/rpc_ingress_client.go` — interface + client impl
- `pkg/app/appserver/mock_rpc_ingress_client.go` — regenerated mock entry for `DialWithOptions`
- `pkg/app/client.go` — public `DialWithOptions`, shared private `dial`
- `cmd/apps/skynet-client/commands/skynet-client.go` — `--routes` flag + conditional dial path
- `cmd/skywire-cli/commands/skynet/root.go` — `--routes` flag + args-map threading (`--routes` injected only when `> 1`)

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l` clean
- [x] `go vet` clean
- [x] `golangci-lint run` clean on touched packages
- [x] `TestRPCIngressGateway_DialWithOptions` — nil-request error, `mux=0` legacy fallthrough, `mux=N` on non-skywire networker degrades to `DialContext`
- [x] `TestRPCIngressClient_DialWithOptions` — wire round-trip returns valid ConnID/LocalPort
- [ ] Live mux-test (beta↔gamma via intermediates, iperf3 over `cli skynet start --routes 1|2|4|8`) — runs after merge as part of the planned mux-bandwidth measurement