### PR TITLE
fix(cxo): auto-recover from bbolt corruption in idxdb + cxds opens

### DIFF
--- a/pkg/cxo/data/cxds/drive.go
+++ b/pkg/cxo/data/cxds/drive.go
@@ -11,6 +11,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/skycoin/skywire/pkg/cxo/data"
+	"github.com/skycoin/skywire/pkg/util/bbolthealth"
 )
 
 var (
@@ -77,6 +78,25 @@ func NewDriveCXDSWithOptions(fileName string, opts DriveOptions) (ds data.CXDS, 
 
 	_, err = os.Stat(fileName)
 	created = os.IsNotExist(err)
+
+	// Probe-and-repair before the real open. RepairIfCorrupt returns
+	// nil when the file is absent, healthy, or successfully renamed
+	// aside as ".corrupt.<unix-ts>" — in the latter case the bolt.Open
+	// below proceeds to create a fresh empty CXDS. This guards against
+	// a commit-time panic later (bbolt's "circular dependency"
+	// assertion fires in an internal batch goroutine and is not
+	// recoverable from caller code). Treating CXDS corruption as
+	// recreate-empty is safe: CXDS is content-addressed and any leaf
+	// lost in a torn write is re-fetched from peers on the next CXO
+	// subscription cycle.
+	if rErr := bbolthealth.RepairIfCorrupt(fileName); rErr != nil {
+		return nil, fmt.Errorf("cxds: integrity-check %s: %w", fileName, rErr)
+	}
+	if !created {
+		if _, statErr := os.Stat(fileName); os.IsNotExist(statErr) {
+			created = true
+		}
+	}
 
 	var b *bolt.DB
 	b, err = bolt.Open(fileName, 0644, &bolt.Options{

--- a/pkg/cxo/data/idxdb/drive.go
+++ b/pkg/cxo/data/idxdb/drive.go
@@ -2,6 +2,7 @@ package idxdb
 
 import (
 	"encoding/binary"
+	"fmt"
 	"os"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/skycoin/skywire/pkg/cxo/data"
+	"github.com/skycoin/skywire/pkg/util/bbolthealth"
 )
 
 var (
@@ -53,6 +55,29 @@ func NewDriveIdxDBWithOptions(fileName string, opts DriveOptions) (idx data.IdxD
 
 	_, err = os.Stat(fileName)
 	created = os.IsNotExist(err) // set the created var
+
+	// Probe-and-repair before the real open. RepairIfCorrupt returns
+	// nil when the file is absent, healthy, or successfully renamed
+	// aside as ".corrupt.<unix-ts>" — in the latter case the bolt.Open
+	// below proceeds to create a fresh empty IdxDB. This guards the
+	// caller against a panic-on-commit later (bbolt's "circular
+	// dependency" assertion fires in an internal batch goroutine and
+	// is not recoverable from caller code). Treating index corruption
+	// as recreate-empty is safe: the IdxDB is a cache of CXO index
+	// metadata that is rebuilt from peer sync / publisher republish
+	// on the next subscription cycle.
+	if rErr := bbolthealth.RepairIfCorrupt(fileName); rErr != nil {
+		return nil, fmt.Errorf("idxdb: integrity-check %s: %w", fileName, rErr)
+	}
+	// If the repair just moved the file aside, the stat above became
+	// stale — re-evaluate so the "created" branch fires for the fresh
+	// open below. (Cheap; bypasses unnecessary work when the file was
+	// actually healthy.)
+	if !created {
+		if _, statErr := os.Stat(fileName); os.IsNotExist(statErr) {
+			created = true
+		}
+	}
 
 	var b *bolt.DB
 

--- a/pkg/cxo/data/idxdb/drive_test.go
+++ b/pkg/cxo/data/idxdb/drive_test.go
@@ -2,29 +2,63 @@ package idxdb
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestNewDriveIdxDB(t *testing.T) {
 
-	t.Run("cant open", func(t *testing.T) {
+	t.Run("garbage file is repaired and recreated", func(t *testing.T) {
+		// Pre-existing behavior: NewDriveIdxDB returned an error on a
+		// file that isn't a valid bbolt store. New behavior (after
+		// integrity-check + auto-repair is wired into the open path):
+		// the garbage file is moved aside as ".corrupt.<unix>" and a
+		// fresh empty IdxDB is created. The trade — losing the bytes
+		// in the garbage file — is acceptable for the IdxDB because
+		// it's a cache rebuilt from CXO peer sync on next subscription
+		// cycle.
 		defer os.Remove(testFileName) //nolint:errcheck,gosec
+		defer cleanupCorruptSiblings(testFileName)
 
 		fl, err := os.Create(testFileName)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		defer fl.Close() //nolint:errcheck,gosec
-
 		if _, err := fl.Write([]byte("Abra-Cadabra")); err != nil {
+			fl.Close() //nolint:errcheck,gosec
+			t.Error(err)
+			return
+		}
+		if err := fl.Close(); err != nil {
 			t.Error(err)
 			return
 		}
 
-		if idx, err := NewDriveIdxDB(testFileName); err == nil {
-			t.Error("missing error")
-			idx.Close() //nolint:errcheck,gosec
+		idx, err := NewDriveIdxDB(testFileName)
+		if err != nil {
+			t.Fatalf("expected auto-repair to recover, got error: %v", err)
+		}
+		idx.Close() //nolint:errcheck,gosec
+
+		// Confirm a .corrupt.<ts> sibling was created from the garbage
+		// content — proves repair fired rather than the open
+		// coincidentally accepting non-bbolt bytes.
+		entries, err := os.ReadDir(filepath.Dir(absDir(testFileName)))
+		if err != nil {
+			t.Fatalf("ReadDir: %v", err)
+		}
+		var foundBak bool
+		base := filepath.Base(testFileName) + ".corrupt."
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), base) {
+				foundBak = true
+				break
+			}
+		}
+		if !foundBak {
+			t.Errorf("expected %s.corrupt.* sibling after auto-repair", filepath.Base(testFileName))
 		}
 	})
 
@@ -33,6 +67,31 @@ func TestNewDriveIdxDB(t *testing.T) {
 	// t.Run("cant create bucket", func(t *testing.T) {
 	// })
 
+}
+
+func absDir(name string) string {
+	if filepath.IsAbs(name) {
+		return name
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return name
+	}
+	return filepath.Join(cwd, name)
+}
+
+func cleanupCorruptSiblings(testFile string) {
+	base := filepath.Base(testFile) + ".corrupt."
+	dir := filepath.Dir(absDir(testFile))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), base) {
+			os.Remove(filepath.Join(dir, e.Name())) //nolint:errcheck,gosec
+		}
+	}
 }
 
 func Test_incSlice(t *testing.T) {

--- a/pkg/util/bbolthealth/repair.go
+++ b/pkg/util/bbolthealth/repair.go
@@ -1,0 +1,112 @@
+// Package bbolthealth — pkg/util/bbolthealth/repair.go: integrity-check
+// helper for bbolt files. Used by visor subsystems whose bbolt stores
+// hold rebuildable data (telemetry, content-addressed CXO leaves, etc.)
+// where automatic recover-by-deletion is preferred over a panic at
+// commit time.
+//
+// Motivation: bbolt's commit path runs in an internal batch goroutine
+// triggered via time.AfterFunc, so an inconsistency assertion (e.g.
+// "circular dependency occurred" from WriteInodeToPage) panics in a
+// goroutine the caller can't recover. Trying to open a known-corrupt
+// file just defers the crash to first write. The cheap defense is to
+// integrity-check the file BEFORE the real open and move it aside if
+// it fails.
+package bbolthealth
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// RepairIfCorrupt opens the bbolt file at path (if it exists), runs
+// bbolt's built-in tx.Check() consistency walk, and — if any problem
+// is found — moves the file aside with a timestamped
+// ".corrupt.<unix>" suffix so the subsequent bolt.Open creates a
+// fresh, empty file.
+//
+// Returns nil when:
+//   - the file doesn't exist (nothing to check)
+//   - the file passes the integrity check
+//   - a corrupt file was successfully moved aside
+//
+// Returns an error only when:
+//   - statting the path failed for a reason other than non-existence
+//   - a corrupt file CANNOT be moved aside (permissions, ENOSPC)
+//
+// In the move-failed case, opening the existing file would just
+// defer a process-killing panic, so callers should propagate.
+//
+// The integrity check uses a WRITABLE open (not ReadOnly): bbolt
+// only initializes the freelist on a writable open, and the freelist
+// is precisely where the kind of inconsistencies that trigger
+// commit-time panics live. The handle is closed immediately so the
+// caller's real open isn't blocked.
+//
+// Callers that want operator visibility into the repair should
+// snapshot the directory's ".corrupt.<unix>" entries before calling
+// and re-scan after to detect a new entry — RepairIfCorrupt itself
+// does no logging (no logger dependency).
+func RepairIfCorrupt(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("bbolthealth: stat %s: %w", path, err)
+	}
+
+	db, openErr := bolt.Open(path, 0600, &bolt.Options{
+		Timeout: 5 * time.Second,
+	})
+	if openErr != nil {
+		// File exists but bbolt won't open it — header corruption,
+		// truncation, or unrelated I/O error. Move aside and let the
+		// caller retry; if the move itself fails, surface so the
+		// caller can fail closed.
+		return moveCorruptAside(path, fmt.Errorf("open: %w", openErr))
+	}
+
+	// Collect up to a few problems for diagnostic context. Don't
+	// keep all of them — bbolt's Check can emit hundreds on a badly
+	// damaged file, and the reason field only carries the first one
+	// to the rename-aside message anyway.
+	var problems []error
+	const maxProblemsKept = 5
+	viewErr := db.View(func(tx *bolt.Tx) error {
+		for e := range tx.Check() {
+			if len(problems) < maxProblemsKept {
+				problems = append(problems, e)
+			}
+		}
+		return nil
+	})
+	closeErr := db.Close()
+	if viewErr != nil {
+		return moveCorruptAside(path, fmt.Errorf("check view: %w", viewErr))
+	}
+	if len(problems) > 0 {
+		return moveCorruptAside(path, fmt.Errorf("bbolt check found %d problems (first: %v)", len(problems), problems[0]))
+	}
+	if closeErr != nil {
+		// Close after a clean Check failing is unusual but not
+		// itself proof of corruption — surface as a soft warning by
+		// returning nil (we already verified contents). The caller's
+		// real open will surface any persistent close-time issue.
+		return nil
+	}
+	return nil
+}
+
+// moveCorruptAside renames the bbolt file at path to
+// "<path>.corrupt.<unix-ts>". Returns an error only when the rename
+// itself fails. The reason argument is preserved in the error message
+// so the operator can see why the file was set aside.
+func moveCorruptAside(path string, reason error) error {
+	bak := fmt.Sprintf("%s.corrupt.%d", path, time.Now().Unix())
+	if err := os.Rename(path, bak); err != nil {
+		return fmt.Errorf("bbolthealth: %s corrupt (%v); also failed to move aside to %s: %w",
+			path, reason, bak, err)
+	}
+	return nil
+}

--- a/pkg/util/bbolthealth/repair_test.go
+++ b/pkg/util/bbolthealth/repair_test.go
@@ -1,0 +1,114 @@
+package bbolthealth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestRepairIfCorrupt_NoFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.db")
+	if err := RepairIfCorrupt(path); err != nil {
+		t.Fatalf("non-existent path should be a no-op, got: %v", err)
+	}
+	// And the file still shouldn't exist after.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("non-existent path should remain absent; stat err=%v", err)
+	}
+}
+
+func TestRepairIfCorrupt_HealthyFilePassesThrough(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "healthy.db")
+	// Create a real bbolt file with a bucket so Check has something
+	// to walk.
+	db, err := bolt.Open(path, 0600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("create healthy bbolt: %v", err)
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, e := tx.CreateBucket([]byte("test"))
+		return e
+	}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := RepairIfCorrupt(path); err != nil {
+		t.Fatalf("healthy file should pass: %v", err)
+	}
+
+	// File still there, no .corrupt.* sibling.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("healthy file should still exist: %v", err)
+	}
+	entries, dirErr := os.ReadDir(filepath.Dir(path))
+	if dirErr != nil {
+		t.Fatalf("ReadDir: %v", dirErr)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".corrupt.") {
+			t.Errorf("unexpected .corrupt. sibling on healthy file: %s", e.Name())
+		}
+	}
+}
+
+func TestRepairIfCorrupt_GarbageFileMovedAside(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "garbage.db")
+	// Plant bytes that aren't a valid bbolt file — bbolt.Open will
+	// reject the header and we'll hit the moveCorruptAside path.
+	if err := os.WriteFile(path, []byte("definitely not a bbolt page"), 0600); err != nil {
+		t.Fatalf("plant garbage: %v", err)
+	}
+
+	if err := RepairIfCorrupt(path); err != nil {
+		t.Fatalf("RepairIfCorrupt on garbage should succeed (move aside), got: %v", err)
+	}
+
+	// Original path should now be absent (moved aside).
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected garbage file to be moved away; stat err=%v", err)
+	}
+
+	// And a .corrupt.<ts> sibling should exist.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var bak string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "garbage.db.corrupt.") {
+			bak = e.Name()
+			break
+		}
+	}
+	if bak == "" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("no garbage.db.corrupt.* sibling found, got %v", names)
+	}
+}
+
+func TestRepairIfCorrupt_IsIdempotentOnRepair(t *testing.T) {
+	// After a successful move-aside, a second call with the same
+	// (now-absent) path should be a clean no-op.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.db")
+	if err := os.WriteFile(path, []byte("nope"), 0600); err != nil {
+		t.Fatalf("plant: %v", err)
+	}
+	if err := RepairIfCorrupt(path); err != nil {
+		t.Fatalf("first repair: %v", err)
+	}
+	if err := RepairIfCorrupt(path); err != nil {
+		t.Fatalf("second repair (path absent now): %v", err)
+	}
+}

--- a/pkg/visor/stats/store.go
+++ b/pkg/visor/stats/store.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"go.etcd.io/bbolt"
+
+	"github.com/skycoin/skywire/pkg/util/bbolthealth"
 )
 
 var (
@@ -53,8 +54,8 @@ type Store struct {
 // the store is local telemetry; everything it holds is regenerated
 // from runtime samples.
 func OpenStore(path string) (*Store, error) {
-	if err := repairIfCorrupt(path); err != nil {
-		// repairIfCorrupt only fails when it cannot move the file
+	if err := bbolthealth.RepairIfCorrupt(path); err != nil {
+		// RepairIfCorrupt only fails when it cannot move the file
 		// aside (permission, ENOSPC). Surface to caller — opening a
 		// known-corrupt file would just defer the panic.
 		return nil, fmt.Errorf("stats: integrity-check %s: %w", path, err)
@@ -458,81 +459,4 @@ func (s *Store) PruneBitmaps(cutoff time.Time) (int, error) {
 		return nil
 	})
 	return removed, err
-}
-
-// repairIfCorrupt opens the bbolt file at path (if it exists), runs
-// bbolt's built-in tx.Check() consistency check, and — if any problem
-// is found — moves the file aside with a timestamped .corrupt.<unix>
-// suffix so the subsequent bbolt.Open creates a fresh, empty file.
-// Returns nil when the file doesn't exist, when it passes the check,
-// or when a corrupt file was successfully moved aside. Returns an
-// error only when the corrupt file CANNOT be moved aside (permission,
-// disk full), since opening a known-bad file would just defer a
-// process-killing panic to first write.
-//
-// The check has to use a writable open: bbolt opens the freelist
-// during init and ReadOnly mode skips that, missing exactly the
-// inconsistencies we're trying to detect. We immediately close the
-// handle, so the writable open is brief and doesn't fight the caller's
-// real open that follows.
-func repairIfCorrupt(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("stat %s: %w", path, err)
-	}
-
-	db, openErr := bbolt.Open(path, 0600, &bbolt.Options{
-		Timeout: 5 * time.Second,
-	})
-	if openErr != nil {
-		// File exists but bbolt won't open it — header corruption,
-		// truncation, or unrelated I/O error. Move aside and try to
-		// recover from scratch; if the move itself fails, surface.
-		return moveCorruptAside(path, fmt.Errorf("open: %w", openErr))
-	}
-
-	// Collect ALL problems Check reports rather than short-circuiting
-	// on the first — useful diagnostic context in the bak-file move
-	// message even if we only fix-by-deletion. Cap at the first few
-	// problems to keep the error message bounded.
-	var problems []error
-	const maxProblemsKept = 5
-	viewErr := db.View(func(tx *bbolt.Tx) error {
-		for e := range tx.Check() {
-			if len(problems) < maxProblemsKept {
-				problems = append(problems, e)
-			}
-		}
-		return nil
-	})
-	closeErr := db.Close()
-	if viewErr != nil {
-		return moveCorruptAside(path, fmt.Errorf("check view: %w", viewErr))
-	}
-	if closeErr != nil {
-		// Not necessarily corruption — but we already saw a clean
-		// Check pass; treat as non-fatal.
-		return nil
-	}
-	if len(problems) > 0 {
-		return moveCorruptAside(path, fmt.Errorf("bbolt check found %d problems (first: %v)", len(problems), problems[0]))
-	}
-	return nil
-}
-
-// moveCorruptAside renames the bbolt file at path to
-// path + .corrupt.<unix-ts> so the caller can proceed to open a fresh
-// file. Returns an error only when the rename itself fails — at that
-// point opening the existing file would just defer the panic, so
-// callers should propagate.
-func moveCorruptAside(path string, reason error) error {
-	bak := fmt.Sprintf("%s.corrupt.%d", path, time.Now().Unix())
-	if err := os.Rename(path, bak); err != nil {
-		return fmt.Errorf("bbolt at %s corrupt (%v); also failed to move aside to %s: %w", path, reason, bak, err)
-	}
-	// Successful repair — caller will recreate. Caller is responsible
-	// for logging the recovery; this package's API doesn't carry a
-	// logger.
-	return nil
 }


### PR DESCRIPTION
## Summary

Follow-up to #2728. That PR added auto-recovery for the `stats.db` bbolt store; this PR extends the same protection to the two remaining visor bbolt open sites — `cxo/data/idxdb` and `cxo/data/cxds`. Without this, only `stats.db` got the recovery, and a parallel cxo corruption on the same visor would still panic.

#2728 was originally intended to ship with this stack but auto-merge fired between my two pushes, so this is just the second commit re-opened as its own PR.

## What's added

**New package `pkg/util/bbolthealth`** — single `RepairIfCorrupt(path)` helper used by all three open sites:
- `pkg/visor/stats.OpenStore` (refactored from inline copy added in #2728)
- `pkg/cxo/data/idxdb.NewDriveIdxDB[WithOptions]`
- `pkg/cxo/data/cxds.NewDriveCXDS[WithOptions]`

The helper probe-opens the file writably (writable open is required: bbolt only initializes the freelist on writable open, and freelist inconsistencies are exactly what trigger the commit-time panic), runs `tx.Check()`, renames to `.corrupt.<unix-ts>` if anything reports bad. Logger-independent.

## Why repair instead of refuse-to-start

| Store | What it holds | Why repair-by-deletion is safe |
| --- | --- | --- |
| `idxdb` | CXO index metadata (feeds, heads) | Rebuilt from peer sync / publisher BatchWindow republish |
| `cxds` | Content-addressed CXO leaves | Re-fetched from peers via next subscription cycle |

Both stores are caches. Losing them costs a sync cycle, not user data.

## Behavior change (cxo data layer)

`NewDriveIdxDB` and `NewDriveCXDS` previously returned an error on a malformed/garbage file. They now move the file aside and proceed to create a fresh empty store. The old "cant open" subtest in `idxdb/drive_test.go` is rewritten to assert the new behavior (file repaired + `.corrupt.<ts>` sibling appears).

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l` clean
- [x] `golangci-lint run` clean on touched packages
- [x] `pkg/util/bbolthealth` unit tests: no-file (no-op), healthy file (pass-through), garbage file (moved aside), idempotent on already-repaired path
- [x] `pkg/visor/stats.TestOpenStoreRepairsCorruptFile` — still passes after refactor to shared helper
- [x] `pkg/cxo/data/idxdb` updated test: garbage file is repaired, sibling appears, new IdxDB usable
- [x] `pkg/cxo/data/cxds` existing test suite green after wiring
- [ ] Manual repro: deliberately corrupt a cxds.db or idx.db on a running visor, halt, observe next-start repaired-and-running outcome.