### PR TITLE
feat(visor): server-side gRPC streaming ping-tree RPC

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/tree_stream.go
+++ b/cmd/skywire-cli/commands/visor/ping/tree_stream.go
@@ -1,0 +1,255 @@
+// Package ping — cmd/skywire-cli/commands/visor/ping/tree_stream.go:
+// thin gRPC client for the StreamPingTree RPC. The visor does the
+// BFS server-side and pushes PingTreeEvents over the stream; this
+// command renders each event as one NDJSON line on stdout.
+//
+// Why separate from tree.go: the Bubble Tea TUI in tree.go has its
+// own model + render loop that the next iteration will rewire onto
+// this same stream. Until that lands, the new server-side gRPC path
+// gets its own subcommand so the existing TUI keeps working
+// unchanged for interactive users while harness consumers + coding
+// agents drive the new RPC.
+//
+// Output: one JSON object per stdout line. Top-level fields:
+//
+//	{"ts":"<RFC3339Nano>", "type":"discovered|ping_result|level_done|run_done|status_update|server_error", "data":{...}}
+//
+// `data` is the marshaled oneof payload with proto's snake_case
+// field names preserved. NDJSON consumers can `jq -c .` to filter,
+// or stream-decode into the wire types via protojson.
+package ping
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+)
+
+var (
+	streamMaxLevel    int
+	streamHops        int
+	streamTries       int
+	streamSize        int
+	streamConcurrency int
+	streamOnlineOnly  bool
+	streamMinVersion  string
+	streamUseTpLat    bool
+	streamDmsgOnly    bool
+	streamDmsgPreChk  bool
+	streamRetries     int
+	streamDryRun      bool
+	streamTimeout     time.Duration
+	streamSetupTO     time.Duration
+)
+
+func init() {
+	pingTreeStreamCmd.Flags().IntVarP(&streamMaxLevel, "max-level", "l", 0,
+		"maximum BFS depth (0 = unlimited until expansion exhausts)")
+	pingTreeStreamCmd.Flags().IntVar(&streamHops, "hops", 0,
+		"ping ONLY entries at exactly N hops; other levels are discovered but not pinged")
+	pingTreeStreamCmd.Flags().IntVarP(&streamTries, "tries", "t", 1,
+		"per-transport ping count; PingResult carries aggregated stats")
+	pingTreeStreamCmd.Flags().IntVarP(&streamSize, "size", "s", 2,
+		"packet size in KB")
+	pingTreeStreamCmd.Flags().IntVarP(&streamConcurrency, "concurrency", "c", 16,
+		"max in-flight pings per BFS level")
+	pingTreeStreamCmd.Flags().BoolVarP(&streamOnlineOnly, "online", "g", false,
+		"only ping visors marked online in the uptime tracker")
+	pingTreeStreamCmd.Flags().StringVarP(&streamMinVersion, "version", "v", "",
+		"filter by minimum visor version (semver)")
+	pingTreeStreamCmd.Flags().BoolVar(&streamUseTpLat, "use-transport-latency", true,
+		"at level 1: skip the live ping when the transport already has a smoothed RTT in TransportSummary.LatencyMS")
+	pingTreeStreamCmd.Flags().BoolVar(&streamDmsgOnly, "dmsg-only", false,
+		"force the ping path to ride DMSG instead of the skywire router")
+	pingTreeStreamCmd.Flags().BoolVar(&streamDmsgPreChk, "dmsg-precheck", false,
+		"probe DMSG reachability before each route ping; discards unreachable visors early")
+	pingTreeStreamCmd.Flags().IntVar(&streamRetries, "retries", 0,
+		"retry attempts on failed pings")
+	pingTreeStreamCmd.Flags().BoolVar(&streamDryRun, "dry-run", false,
+		"discovery only; no PingResult events fire (every entry marked latency_source=skipped)")
+	pingTreeStreamCmd.Flags().DurationVarP(&streamTimeout, "timeout", "o", 30*time.Second,
+		"per-ping timeout (after route setup)")
+	pingTreeStreamCmd.Flags().DurationVar(&streamSetupTO, "setup-timeout", 30*time.Second,
+		"per-transport route-setup timeout")
+
+	RootCmd.AddCommand(pingTreeStreamCmd)
+}
+
+var pingTreeStreamCmd = &cobra.Command{
+	Use:   "tree-stream",
+	Short: "Stream a server-side BFS ping-tree as NDJSON (for harness consumers + coding agents)",
+	Long: `Stream a server-side BFS ping-tree as NDJSON to stdout.
+
+The visor walks its own neighborhood breadth-first and streams one
+event per discovered transport, per ping result, per level boundary,
+and a final run summary. Each event is one JSON object per stdout
+line (NDJSON).
+
+Wire format (top-level fields per line):
+  {"ts":"<RFC3339Nano>","type":"<event>","data":{...}}
+
+Event types:
+  discovered     — BFS added (transport, peer) to the level-N candidate set
+  ping_result    — ping (or transport_summary cache hit) completed
+  level_done     — every transport at level N has resolved
+  run_done       — terminal event; carries totals + termination_reason
+  status_update  — informational progress (in-flight count, phase)
+  server_error   — unrecoverable condition; stream closes after this
+
+Examples:
+
+  # Hop-level latency measurement (synth's directive):
+  skywire cli visor ping tree-stream --hops 1 --tries 5 | jq -c 'select(.type=="ping_result")'
+  skywire cli visor ping tree-stream --hops 2 --tries 5 -l 2 | tee hops-2.ndjson
+  skywire cli visor ping tree-stream --hops 3 --tries 5 -l 3 | tee hops-3.ndjson
+
+  # Discovery only, no pings (visualize the reachable graph):
+  skywire cli visor ping tree-stream --dry-run --max-level 2
+
+  # Aggregate latency across all reachable levels:
+  skywire cli visor ping tree-stream --tries 3 | jq -c 'select(.type=="ping_result") | {level:.data.level, avg_ms:(.data.ping_avg_ns/1e6)}'
+
+The TUI variant of this command is still 'cli visor ping tree' —
+that one keeps the Bubble Tea interactive surface and will be
+rewired onto this same stream in a follow-up.`,
+	Run: runPingTreeStream,
+}
+
+// runPingTreeStream connects to the local visor's gRPC server,
+// invokes StreamPingTree with the flag-derived request, and writes
+// one NDJSON line per event to stdout until the stream closes
+// (RunDone, ServerError, or ctx-cancel from Ctrl+C).
+func runPingTreeStream(cmd *cobra.Command, _ []string) {
+	ctx, cancel := signalContext()
+	defer cancel()
+
+	client, err := rpcgrpc.NewPingClient(clirpc.Addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: gRPC client connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close() //nolint:errcheck
+
+	// CLI flag inputs are int; proto fields are int32. None of these
+	// values realistically exceed int32 max (max-level ~10, hops ~10,
+	// tries ~100, packet size in KB ~64, concurrency ~256) — nolint
+	// is the right call rather than runtime clamping.
+	req := &rpcgrpc.PingTreeRequest{
+		MaxLevel:            int32(streamMaxLevel), //nolint:gosec
+		Hops:                int32(streamHops),     //nolint:gosec
+		Tries:               int32(streamTries),    //nolint:gosec
+		PacketSizeKb:        int32(streamSize),     //nolint:gosec
+		PingTimeoutNs:       streamTimeout.Nanoseconds(),
+		SetupTimeoutNs:      streamSetupTO.Nanoseconds(),
+		Concurrency:         int32(streamConcurrency), //nolint:gosec
+		OnlineOnly:          streamOnlineOnly,
+		MinVersion:          streamMinVersion,
+		UseTransportLatency: streamUseTpLat,
+		DmsgOnly:            streamDmsgOnly,
+		DmsgPreCheck:        streamDmsgPreChk,
+		Retries:             int32(streamRetries), //nolint:gosec
+		DryRun:              streamDryRun,
+	}
+
+	stream, err := client.StreamPingTree(ctx, req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: StreamPingTree call: %v\n", err)
+		os.Exit(1)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	// protojson preserves snake_case field names; conversion from
+	// proto-Message to encoding/json marshaler goes through
+	// protojson.Marshal → []byte → json.RawMessage so the outer
+	// envelope can carry the data unmolested.
+	marshaler := protojson.MarshalOptions{
+		UseProtoNames:   true, // snake_case fields, matches proto declarations
+		EmitUnpopulated: false,
+	}
+
+	for {
+		ev, recvErr := stream.Recv()
+		if recvErr != nil {
+			// EOF is normal stream-end; everything else is a problem.
+			if recvErr.Error() == "EOF" || recvErr == context.Canceled {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "error: stream recv: %v\n", recvErr)
+			os.Exit(1)
+		}
+		if err := emitOne(enc, marshaler, ev); err != nil {
+			fmt.Fprintf(os.Stderr, "error: emit: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+// emitOne writes one NDJSON line: envelope with type+ts+data.
+func emitOne(enc *json.Encoder, m protojson.MarshalOptions, ev *rpcgrpc.PingTreeEvent) error {
+	typ, payload := classifyPayload(ev)
+	rawData, err := m.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", typ, err)
+	}
+	envelope := struct {
+		TS   string          `json:"ts"`
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}{
+		TS:   time.Unix(0, ev.TimestampNs).UTC().Format(time.RFC3339Nano),
+		Type: typ,
+		Data: json.RawMessage(rawData),
+	}
+	return enc.Encode(envelope)
+}
+
+// classifyPayload returns the event-type discriminator string and
+// the proto-Message contents for the marshaler. Centralized here so
+// the wire format stays consistent — adding a new oneof variant
+// means updating exactly this function.
+func classifyPayload(ev *rpcgrpc.PingTreeEvent) (string, proto.Message) {
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.PingTreeEvent_Discovered:
+		return "discovered", p.Discovered
+	case *rpcgrpc.PingTreeEvent_PingResult:
+		return "ping_result", p.PingResult
+	case *rpcgrpc.PingTreeEvent_LevelDone:
+		return "level_done", p.LevelDone
+	case *rpcgrpc.PingTreeEvent_RunDone:
+		return "run_done", p.RunDone
+	case *rpcgrpc.PingTreeEvent_StatusUpdate:
+		return "status_update", p.StatusUpdate
+	case *rpcgrpc.PingTreeEvent_ServerError:
+		return "server_error", p.ServerError
+	default:
+		// Unknown payload — emit an empty data block under a stable
+		// type so consumers don't crash on unexpected events.
+		return "unknown", &rpcgrpc.PingTreeStatusUpdate{}
+	}
+}
+
+// signalContext returns a context that cancels on SIGINT/SIGTERM.
+// Mirrors the helper from other CLI commands in this directory
+// (kept inline rather than reaching into another file's private
+// helper).
+func signalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+	return ctx, cancel
+}

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -47,6 +47,19 @@ func (c *PingClient) Close() error {
 	return c.conn.Close()
 }
 
+// StreamPingTree opens the server-side BFS ping-tree stream. The
+// caller drives the returned stream via Recv() and is responsible
+// for handling the io.EOF terminus + any wire errors. Unlike the
+// other PingClient methods this returns the raw protoc-generated
+// stream type because callers want event-level control (e.g. the
+// 'cli visor ping tree-stream' command emits NDJSON envelopes, the
+// upcoming Bubble Tea TUI rewire will drive its own update loop).
+// Wrapping in a callback pattern here would force every consumer to
+// re-marshal back to the event type.
+func (c *PingClient) StreamPingTree(ctx context.Context, req *PingTreeRequest) (PingService_StreamPingTreeClient, error) {
+	return c.client.StreamPingTree(ctx, req)
+}
+
 // StreamPing performs pings and calls the callback for each result
 // timeout applies only to the ping phase (after route setup), 0 means no timeout
 // setupTimeout applies to route setup phase, 0 means no timeout

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -7,12 +7,11 @@
 package rpcgrpc
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1917,6 +1916,969 @@ func (x *ProcessStat) GetStatus() string {
 	return ""
 }
 
+// PingTreeRequest configures a server-side BFS ping-tree walk.
+// All durations are in nanoseconds (proto convention used throughout
+// this service). All "0 = default" fields fall back to handler-side
+// constants documented inline.
+type PingTreeRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// MaxLevel caps BFS depth. 0 = unlimited until expansion exhausts.
+	MaxLevel int32 `protobuf:"varint,1,opt,name=max_level,json=maxLevel,proto3" json:"max_level,omitempty"`
+	// Hops, when > 0, pings ONLY entries at exactly N hops. The BFS
+	// still discovers intermediate levels (so it can reach the target),
+	// but no PingResult fires for non-target levels. Synth's "latency
+	// as a function of hop count" measurement uses this.
+	Hops int32 `protobuf:"varint,2,opt,name=hops,proto3" json:"hops,omitempty"`
+	// Tries is the per-transport ping count. The PingResult carries
+	// the aggregated stats (avg, p50, p99, jitter) over all tries.
+	// 0 falls back to 1.
+	Tries int32 `protobuf:"varint,3,opt,name=tries,proto3" json:"tries,omitempty"`
+	// PacketSizeKb is the per-ping packet size. 0 falls back to 2 KB.
+	PacketSizeKb int32 `protobuf:"varint,4,opt,name=packet_size_kb,json=packetSizeKb,proto3" json:"packet_size_kb,omitempty"`
+	// PingTimeoutNs bounds each individual ping (after route setup).
+	// 0 falls back to 30s.
+	PingTimeoutNs int64 `protobuf:"varint,5,opt,name=ping_timeout_ns,json=pingTimeoutNs,proto3" json:"ping_timeout_ns,omitempty"`
+	// SetupTimeoutNs bounds the route-setup phase per transport.
+	// 0 falls back to 30s.
+	SetupTimeoutNs int64 `protobuf:"varint,6,opt,name=setup_timeout_ns,json=setupTimeoutNs,proto3" json:"setup_timeout_ns,omitempty"`
+	// Concurrency limits in-flight pings per level. The cap resets
+	// between levels (level 2 starts with a fresh budget after level 1
+	// drains) — predictable LevelDone semantics + bounded fan-out at
+	// deep levels. 0 falls back to 16.
+	Concurrency int32 `protobuf:"varint,7,opt,name=concurrency,proto3" json:"concurrency,omitempty"`
+	// OnlineOnly filters discovered visors via the uptime tracker.
+	OnlineOnly bool `protobuf:"varint,8,opt,name=online_only,json=onlineOnly,proto3" json:"online_only,omitempty"`
+	// MinVersion filters by minimum visor version (semver). Empty = no
+	// filter.
+	MinVersion string `protobuf:"bytes,9,opt,name=min_version,json=minVersion,proto3" json:"min_version,omitempty"`
+	// UseTransportLatency turns on the level-1 fast path: when a
+	// direct transport already has a non-zero smoothed
+	// TransportSummary.LatencyMS, the handler emits a PingResult with
+	// latency_source="transport_summary" and skips the live ping.
+	// Saves traffic + makes level 1 instant for warm transports.
+	// Deeper levels always live-ping (no transport-level latency for
+	// multi-hop routes).
+	UseTransportLatency bool `protobuf:"varint,10,opt,name=use_transport_latency,json=useTransportLatency,proto3" json:"use_transport_latency,omitempty"`
+	// DmsgOnly forces the ping to ride the DMSG path instead of the
+	// skywire router. Mirrors `cli visor ping --dmsg`.
+	DmsgOnly bool `protobuf:"varint,11,opt,name=dmsg_only,json=dmsgOnly,proto3" json:"dmsg_only,omitempty"`
+	// DmsgPreCheck probes DMSG reachability before attempting a
+	// route ping. Discards unreachable visors early.
+	DmsgPreCheck bool `protobuf:"varint,12,opt,name=dmsg_pre_check,json=dmsgPreCheck,proto3" json:"dmsg_pre_check,omitempty"`
+	// Retries adds N retry attempts on failed pings. 0 = no retry.
+	Retries int32 `protobuf:"varint,13,opt,name=retries,proto3" json:"retries,omitempty"`
+	// DryRun runs the BFS discovery but emits no PingResult events;
+	// useful for visualizing the reachable graph without traffic.
+	DryRun        bool `protobuf:"varint,14,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeRequest) Reset() {
+	*x = PingTreeRequest{}
+	mi := &file_ping_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeRequest) ProtoMessage() {}
+
+func (x *PingTreeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeRequest.ProtoReflect.Descriptor instead.
+func (*PingTreeRequest) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *PingTreeRequest) GetMaxLevel() int32 {
+	if x != nil {
+		return x.MaxLevel
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetHops() int32 {
+	if x != nil {
+		return x.Hops
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetTries() int32 {
+	if x != nil {
+		return x.Tries
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetPacketSizeKb() int32 {
+	if x != nil {
+		return x.PacketSizeKb
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetPingTimeoutNs() int64 {
+	if x != nil {
+		return x.PingTimeoutNs
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetSetupTimeoutNs() int64 {
+	if x != nil {
+		return x.SetupTimeoutNs
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetConcurrency() int32 {
+	if x != nil {
+		return x.Concurrency
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetOnlineOnly() bool {
+	if x != nil {
+		return x.OnlineOnly
+	}
+	return false
+}
+
+func (x *PingTreeRequest) GetMinVersion() string {
+	if x != nil {
+		return x.MinVersion
+	}
+	return ""
+}
+
+func (x *PingTreeRequest) GetUseTransportLatency() bool {
+	if x != nil {
+		return x.UseTransportLatency
+	}
+	return false
+}
+
+func (x *PingTreeRequest) GetDmsgOnly() bool {
+	if x != nil {
+		return x.DmsgOnly
+	}
+	return false
+}
+
+func (x *PingTreeRequest) GetDmsgPreCheck() bool {
+	if x != nil {
+		return x.DmsgPreCheck
+	}
+	return false
+}
+
+func (x *PingTreeRequest) GetRetries() int32 {
+	if x != nil {
+		return x.Retries
+	}
+	return 0
+}
+
+func (x *PingTreeRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+// PingTreeEvent is one entry on the stream. Exactly one oneof
+// payload is set per message. Consumers switch on the payload type;
+// the top-level timestamp_ns is server-side wall time at emit.
+type PingTreeEvent struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	TimestampNs int64                  `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*PingTreeEvent_Discovered
+	//	*PingTreeEvent_PingResult
+	//	*PingTreeEvent_LevelDone
+	//	*PingTreeEvent_RunDone
+	//	*PingTreeEvent_StatusUpdate
+	//	*PingTreeEvent_ServerError
+	Payload       isPingTreeEvent_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeEvent) Reset() {
+	*x = PingTreeEvent{}
+	mi := &file_ping_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeEvent) ProtoMessage() {}
+
+func (x *PingTreeEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeEvent.ProtoReflect.Descriptor instead.
+func (*PingTreeEvent) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *PingTreeEvent) GetTimestampNs() int64 {
+	if x != nil {
+		return x.TimestampNs
+	}
+	return 0
+}
+
+func (x *PingTreeEvent) GetPayload() isPingTreeEvent_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *PingTreeEvent) GetDiscovered() *PingTreeDiscovered {
+	if x != nil {
+		if x, ok := x.Payload.(*PingTreeEvent_Discovered); ok {
+			return x.Discovered
+		}
+	}
+	return nil
+}
+
+func (x *PingTreeEvent) GetPingResult() *PingTreeResult {
+	if x != nil {
+		if x, ok := x.Payload.(*PingTreeEvent_PingResult); ok {
+			return x.PingResult
+		}
+	}
+	return nil
+}
+
+func (x *PingTreeEvent) GetLevelDone() *PingTreeLevelDone {
+	if x != nil {
+		if x, ok := x.Payload.(*PingTreeEvent_LevelDone); ok {
+			return x.LevelDone
+		}
+	}
+	return nil
+}
+
+func (x *PingTreeEvent) GetRunDone() *PingTreeRunDone {
+	if x != nil {
+		if x, ok := x.Payload.(*PingTreeEvent_RunDone); ok {
+			return x.RunDone
+		}
+	}
+	return nil
+}
+
+func (x *PingTreeEvent) GetStatusUpdate() *PingTreeStatusUpdate {
+	if x != nil {
+		if x, ok := x.Payload.(*PingTreeEvent_StatusUpdate); ok {
+			return x.StatusUpdate
+		}
+	}
+	return nil
+}
+
+func (x *PingTreeEvent) GetServerError() *PingTreeServerError {
+	if x != nil {
+		if x, ok := x.Payload.(*PingTreeEvent_ServerError); ok {
+			return x.ServerError
+		}
+	}
+	return nil
+}
+
+type isPingTreeEvent_Payload interface {
+	isPingTreeEvent_Payload()
+}
+
+type PingTreeEvent_Discovered struct {
+	Discovered *PingTreeDiscovered `protobuf:"bytes,10,opt,name=discovered,proto3,oneof"`
+}
+
+type PingTreeEvent_PingResult struct {
+	PingResult *PingTreeResult `protobuf:"bytes,11,opt,name=ping_result,json=pingResult,proto3,oneof"`
+}
+
+type PingTreeEvent_LevelDone struct {
+	LevelDone *PingTreeLevelDone `protobuf:"bytes,12,opt,name=level_done,json=levelDone,proto3,oneof"`
+}
+
+type PingTreeEvent_RunDone struct {
+	RunDone *PingTreeRunDone `protobuf:"bytes,13,opt,name=run_done,json=runDone,proto3,oneof"`
+}
+
+type PingTreeEvent_StatusUpdate struct {
+	StatusUpdate *PingTreeStatusUpdate `protobuf:"bytes,14,opt,name=status_update,json=statusUpdate,proto3,oneof"`
+}
+
+type PingTreeEvent_ServerError struct {
+	// ServerError is a terminal event: the handler is about to
+	// close the stream because of an unrecoverable condition
+	// (e.g. proto break, internal panic recovered). Clients should
+	// treat receipt as equivalent to stream-EOF with a known cause.
+	ServerError *PingTreeServerError `protobuf:"bytes,15,opt,name=server_error,json=serverError,proto3,oneof"`
+}
+
+func (*PingTreeEvent_Discovered) isPingTreeEvent_Payload() {}
+
+func (*PingTreeEvent_PingResult) isPingTreeEvent_Payload() {}
+
+func (*PingTreeEvent_LevelDone) isPingTreeEvent_Payload() {}
+
+func (*PingTreeEvent_RunDone) isPingTreeEvent_Payload() {}
+
+func (*PingTreeEvent_StatusUpdate) isPingTreeEvent_Payload() {}
+
+func (*PingTreeEvent_ServerError) isPingTreeEvent_Payload() {}
+
+// Discovered fires when the BFS adds a (transport, peer) pair to the
+// candidate set at level N. Fires BEFORE the corresponding PingResult.
+type PingTreeDiscovered struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TpId          string                 `protobuf:"bytes,1,opt,name=tp_id,json=tpId,proto3" json:"tp_id,omitempty"`
+	TpType        string                 `protobuf:"bytes,2,opt,name=tp_type,json=tpType,proto3" json:"tp_type,omitempty"`
+	RemotePk      string                 `protobuf:"bytes,3,opt,name=remote_pk,json=remotePk,proto3" json:"remote_pk,omitempty"`
+	ParentPk      string                 `protobuf:"bytes,4,opt,name=parent_pk,json=parentPk,proto3" json:"parent_pk,omitempty"`
+	Level         int32                  `protobuf:"varint,5,opt,name=level,proto3" json:"level,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeDiscovered) Reset() {
+	*x = PingTreeDiscovered{}
+	mi := &file_ping_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeDiscovered) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeDiscovered) ProtoMessage() {}
+
+func (x *PingTreeDiscovered) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeDiscovered.ProtoReflect.Descriptor instead.
+func (*PingTreeDiscovered) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *PingTreeDiscovered) GetTpId() string {
+	if x != nil {
+		return x.TpId
+	}
+	return ""
+}
+
+func (x *PingTreeDiscovered) GetTpType() string {
+	if x != nil {
+		return x.TpType
+	}
+	return ""
+}
+
+func (x *PingTreeDiscovered) GetRemotePk() string {
+	if x != nil {
+		return x.RemotePk
+	}
+	return ""
+}
+
+func (x *PingTreeDiscovered) GetParentPk() string {
+	if x != nil {
+		return x.ParentPk
+	}
+	return ""
+}
+
+func (x *PingTreeDiscovered) GetLevel() int32 {
+	if x != nil {
+		return x.Level
+	}
+	return 0
+}
+
+// PingResult fires when a transport's ping (or the cache fast-path)
+// completes. Both success and failure produce a PingResult; consumers
+// switch on the failed bool. Latency stats are aggregated across the
+// per-tries sample series.
+type PingTreeResult struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	TpId     string                 `protobuf:"bytes,1,opt,name=tp_id,json=tpId,proto3" json:"tp_id,omitempty"`
+	TpType   string                 `protobuf:"bytes,2,opt,name=tp_type,json=tpType,proto3" json:"tp_type,omitempty"`
+	RemotePk string                 `protobuf:"bytes,3,opt,name=remote_pk,json=remotePk,proto3" json:"remote_pk,omitempty"`
+	ParentPk string                 `protobuf:"bytes,4,opt,name=parent_pk,json=parentPk,proto3" json:"parent_pk,omitempty"`
+	Level    int32                  `protobuf:"varint,5,opt,name=level,proto3" json:"level,omitempty"`
+	Failed   bool                   `protobuf:"varint,6,opt,name=failed,proto3" json:"failed,omitempty"`
+	// Canceled distinguishes ctx-canceled-mid-flight from genuine
+	// failure. Set when ctx.Err() != nil at the time the result was
+	// finalized. Different operator action: retry vs investigate.
+	Canceled bool `protobuf:"varint,7,opt,name=canceled,proto3" json:"canceled,omitempty"`
+	// SetupLatencyNs is the route-setup phase time. Excluded from the
+	// ping_*_ns aggregations below — those are per-ping post-setup.
+	SetupLatencyNs int64 `protobuf:"varint,8,opt,name=setup_latency_ns,json=setupLatencyNs,proto3" json:"setup_latency_ns,omitempty"`
+	// SampleCount is the number of successful pings (out of Tries).
+	// Zero when failed.
+	SampleCount int32 `protobuf:"varint,9,opt,name=sample_count,json=sampleCount,proto3" json:"sample_count,omitempty"`
+	// PingAvgNs / PingP50Ns / PingP99Ns / JitterNs are aggregations
+	// over the sample series. Jitter is the population stddev:
+	// sqrt(sum((x - mean)^2) / N). Zero when sample_count < 2 (no
+	// stddev defined for a single sample).
+	PingAvgNs int64 `protobuf:"varint,10,opt,name=ping_avg_ns,json=pingAvgNs,proto3" json:"ping_avg_ns,omitempty"`
+	PingP50Ns int64 `protobuf:"varint,11,opt,name=ping_p50_ns,json=pingP50Ns,proto3" json:"ping_p50_ns,omitempty"`
+	PingP99Ns int64 `protobuf:"varint,12,opt,name=ping_p99_ns,json=pingP99Ns,proto3" json:"ping_p99_ns,omitempty"`
+	JitterNs  int64 `protobuf:"varint,13,opt,name=jitter_ns,json=jitterNs,proto3" json:"jitter_ns,omitempty"`
+	// SetupErr / PingErr / CalcErr surface the most-recent error from
+	// each phase. Multiple may be set when multiple phases failed.
+	SetupErr string `protobuf:"bytes,14,opt,name=setup_err,json=setupErr,proto3" json:"setup_err,omitempty"`
+	PingErr  string `protobuf:"bytes,15,opt,name=ping_err,json=pingErr,proto3" json:"ping_err,omitempty"`
+	CalcErr  string `protobuf:"bytes,16,opt,name=calc_err,json=calcErr,proto3" json:"calc_err,omitempty"`
+	// LatencySource carries the provenance of the latency stats:
+	//
+	//	"live_ping"          — measured by an actual ping just now
+	//	"transport_summary"  — pulled from TransportSummary.LatencyMS
+	//	                       (smoothed cache, level-1 fast path)
+	//	"skipped"            — entry was --hops mismatch or --dry-run
+	//
+	// Consumers use this to weight stale-cache values vs fresh probes.
+	LatencySource string `protobuf:"bytes,17,opt,name=latency_source,json=latencySource,proto3" json:"latency_source,omitempty"`
+	// Route is the hop sequence used for this ping. Empty for the
+	// transport_summary fast-path (no route was constructed).
+	Route         []*RouteHop `protobuf:"bytes,18,rep,name=route,proto3" json:"route,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeResult) Reset() {
+	*x = PingTreeResult{}
+	mi := &file_ping_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeResult) ProtoMessage() {}
+
+func (x *PingTreeResult) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeResult.ProtoReflect.Descriptor instead.
+func (*PingTreeResult) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *PingTreeResult) GetTpId() string {
+	if x != nil {
+		return x.TpId
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetTpType() string {
+	if x != nil {
+		return x.TpType
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetRemotePk() string {
+	if x != nil {
+		return x.RemotePk
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetParentPk() string {
+	if x != nil {
+		return x.ParentPk
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetLevel() int32 {
+	if x != nil {
+		return x.Level
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetFailed() bool {
+	if x != nil {
+		return x.Failed
+	}
+	return false
+}
+
+func (x *PingTreeResult) GetCanceled() bool {
+	if x != nil {
+		return x.Canceled
+	}
+	return false
+}
+
+func (x *PingTreeResult) GetSetupLatencyNs() int64 {
+	if x != nil {
+		return x.SetupLatencyNs
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetSampleCount() int32 {
+	if x != nil {
+		return x.SampleCount
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetPingAvgNs() int64 {
+	if x != nil {
+		return x.PingAvgNs
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetPingP50Ns() int64 {
+	if x != nil {
+		return x.PingP50Ns
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetPingP99Ns() int64 {
+	if x != nil {
+		return x.PingP99Ns
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetJitterNs() int64 {
+	if x != nil {
+		return x.JitterNs
+	}
+	return 0
+}
+
+func (x *PingTreeResult) GetSetupErr() string {
+	if x != nil {
+		return x.SetupErr
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetPingErr() string {
+	if x != nil {
+		return x.PingErr
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetCalcErr() string {
+	if x != nil {
+		return x.CalcErr
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetLatencySource() string {
+	if x != nil {
+		return x.LatencySource
+	}
+	return ""
+}
+
+func (x *PingTreeResult) GetRoute() []*RouteHop {
+	if x != nil {
+		return x.Route
+	}
+	return nil
+}
+
+// LevelDone fires after every transport at level N has either
+// completed its ping or been skipped. Always fires before the next
+// level's Discovered events. Counts are authoritative for the harness.
+type PingTreeLevelDone struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Level int32                  `protobuf:"varint,1,opt,name=level,proto3" json:"level,omitempty"`
+	// Attempted = sum of (succeeded + failed + skipped_cached + skipped_dry).
+	Attempted int32 `protobuf:"varint,2,opt,name=attempted,proto3" json:"attempted,omitempty"`
+	Succeeded int32 `protobuf:"varint,3,opt,name=succeeded,proto3" json:"succeeded,omitempty"`
+	Failed    int32 `protobuf:"varint,4,opt,name=failed,proto3" json:"failed,omitempty"`
+	// SkippedCached is the count of entries where the
+	// use_transport_latency fast-path fired. Lets harnesses compute
+	// cache hit rate.
+	SkippedCached int32 `protobuf:"varint,5,opt,name=skipped_cached,json=skippedCached,proto3" json:"skipped_cached,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeLevelDone) Reset() {
+	*x = PingTreeLevelDone{}
+	mi := &file_ping_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeLevelDone) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeLevelDone) ProtoMessage() {}
+
+func (x *PingTreeLevelDone) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeLevelDone.ProtoReflect.Descriptor instead.
+func (*PingTreeLevelDone) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *PingTreeLevelDone) GetLevel() int32 {
+	if x != nil {
+		return x.Level
+	}
+	return 0
+}
+
+func (x *PingTreeLevelDone) GetAttempted() int32 {
+	if x != nil {
+		return x.Attempted
+	}
+	return 0
+}
+
+func (x *PingTreeLevelDone) GetSucceeded() int32 {
+	if x != nil {
+		return x.Succeeded
+	}
+	return 0
+}
+
+func (x *PingTreeLevelDone) GetFailed() int32 {
+	if x != nil {
+		return x.Failed
+	}
+	return 0
+}
+
+func (x *PingTreeLevelDone) GetSkippedCached() int32 {
+	if x != nil {
+		return x.SkippedCached
+	}
+	return 0
+}
+
+// RunDone is the terminal event before stream close. Fires exactly
+// once per StreamPingTree call.
+type PingTreeRunDone struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	TotalDiscovered    int32                  `protobuf:"varint,1,opt,name=total_discovered,json=totalDiscovered,proto3" json:"total_discovered,omitempty"`
+	TotalPinged        int32                  `protobuf:"varint,2,opt,name=total_pinged,json=totalPinged,proto3" json:"total_pinged,omitempty"`
+	TotalSucceeded     int32                  `protobuf:"varint,3,opt,name=total_succeeded,json=totalSucceeded,proto3" json:"total_succeeded,omitempty"`
+	TotalFailed        int32                  `protobuf:"varint,4,opt,name=total_failed,json=totalFailed,proto3" json:"total_failed,omitempty"`
+	TotalSkippedCached int32                  `protobuf:"varint,5,opt,name=total_skipped_cached,json=totalSkippedCached,proto3" json:"total_skipped_cached,omitempty"`
+	WallTimeNs         int64                  `protobuf:"varint,6,opt,name=wall_time_ns,json=wallTimeNs,proto3" json:"wall_time_ns,omitempty"`
+	// PeakInFlight is the highest concurrent ping count observed
+	// during the run. Useful for tuning concurrency.
+	PeakInFlight int32 `protobuf:"varint,7,opt,name=peak_in_flight,json=peakInFlight,proto3" json:"peak_in_flight,omitempty"`
+	// TerminationReason is one of:
+	//
+	//	"max_level"          — hit cfg.MaxLevel
+	//	"no_neighbors"       — BFS exhausted before MaxLevel
+	//	"hops_target"        — reached cfg.Hops target level
+	//	"context_cancel"     — client disconnect / server shutdown
+	//	"error"              — see ServerError preceding this event
+	TerminationReason string `protobuf:"bytes,8,opt,name=termination_reason,json=terminationReason,proto3" json:"termination_reason,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PingTreeRunDone) Reset() {
+	*x = PingTreeRunDone{}
+	mi := &file_ping_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeRunDone) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeRunDone) ProtoMessage() {}
+
+func (x *PingTreeRunDone) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeRunDone.ProtoReflect.Descriptor instead.
+func (*PingTreeRunDone) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *PingTreeRunDone) GetTotalDiscovered() int32 {
+	if x != nil {
+		return x.TotalDiscovered
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetTotalPinged() int32 {
+	if x != nil {
+		return x.TotalPinged
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetTotalSucceeded() int32 {
+	if x != nil {
+		return x.TotalSucceeded
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetTotalFailed() int32 {
+	if x != nil {
+		return x.TotalFailed
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetTotalSkippedCached() int32 {
+	if x != nil {
+		return x.TotalSkippedCached
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetWallTimeNs() int64 {
+	if x != nil {
+		return x.WallTimeNs
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetPeakInFlight() int32 {
+	if x != nil {
+		return x.PeakInFlight
+	}
+	return 0
+}
+
+func (x *PingTreeRunDone) GetTerminationReason() string {
+	if x != nil {
+		return x.TerminationReason
+	}
+	return ""
+}
+
+// StatusUpdate is a low-priority informational event (e.g. "expanding
+// level 3", "draining in-flight"). The handler MUST prefer dropping
+// StatusUpdate over PingResult under backpressure — never trade
+// measurement data for status text.
+type PingTreeStatusUpdate struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Phase is one of: "discovering" | "pinging_level_N" | "finalizing".
+	Phase string `protobuf:"bytes,1,opt,name=phase,proto3" json:"phase,omitempty"`
+	// InFlight is the count of currently-active ping goroutines.
+	InFlight int32 `protobuf:"varint,2,opt,name=in_flight,json=inFlight,proto3" json:"in_flight,omitempty"`
+	// Pending is the count of queued-but-not-started pings.
+	Pending int32 `protobuf:"varint,3,opt,name=pending,proto3" json:"pending,omitempty"`
+	// Message is an optional human-readable hint (e.g. "waiting on 3
+	// slow pings at level 2"). Empty for routine progress.
+	Message       string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeStatusUpdate) Reset() {
+	*x = PingTreeStatusUpdate{}
+	mi := &file_ping_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeStatusUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeStatusUpdate) ProtoMessage() {}
+
+func (x *PingTreeStatusUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeStatusUpdate.ProtoReflect.Descriptor instead.
+func (*PingTreeStatusUpdate) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *PingTreeStatusUpdate) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *PingTreeStatusUpdate) GetInFlight() int32 {
+	if x != nil {
+		return x.InFlight
+	}
+	return 0
+}
+
+func (x *PingTreeStatusUpdate) GetPending() int32 {
+	if x != nil {
+		return x.Pending
+	}
+	return 0
+}
+
+func (x *PingTreeStatusUpdate) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// ServerError signals an unrecoverable condition that's about to
+// close the stream. Clients receive it as the last event before
+// stream-EOF; preserves a known cause vs an opaque transport error.
+type PingTreeServerError struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Code is a short stable identifier (e.g. "auth_denied",
+	// "internal_panic", "tpm_unavailable"). Suitable for grep / metric
+	// labeling.
+	Code string `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
+	// Message carries operator-readable detail. Not stable across
+	// versions.
+	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PingTreeServerError) Reset() {
+	*x = PingTreeServerError{}
+	mi := &file_ping_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PingTreeServerError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PingTreeServerError) ProtoMessage() {}
+
+func (x *PingTreeServerError) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PingTreeServerError.ProtoReflect.Descriptor instead.
+func (*PingTreeServerError) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *PingTreeServerError) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *PingTreeServerError) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_ping_proto protoreflect.FileDescriptor
 
 const file_ping_proto_rawDesc = "" +
@@ -2098,7 +3060,89 @@ const file_ping_proto_rawDesc = "" +
 	"\n" +
 	"memory_rss\x18\x05 \x01(\x04R\tmemoryRss\x12\x1a\n" +
 	"\busername\x18\x06 \x01(\tR\busername\x12\x16\n" +
-	"\x06status\x18\a \x01(\tR\x06status2\xc4\x06\n" +
+	"\x06status\x18\a \x01(\tR\x06status\"\xde\x03\n" +
+	"\x0fPingTreeRequest\x12\x1b\n" +
+	"\tmax_level\x18\x01 \x01(\x05R\bmaxLevel\x12\x12\n" +
+	"\x04hops\x18\x02 \x01(\x05R\x04hops\x12\x14\n" +
+	"\x05tries\x18\x03 \x01(\x05R\x05tries\x12$\n" +
+	"\x0epacket_size_kb\x18\x04 \x01(\x05R\fpacketSizeKb\x12&\n" +
+	"\x0fping_timeout_ns\x18\x05 \x01(\x03R\rpingTimeoutNs\x12(\n" +
+	"\x10setup_timeout_ns\x18\x06 \x01(\x03R\x0esetupTimeoutNs\x12 \n" +
+	"\vconcurrency\x18\a \x01(\x05R\vconcurrency\x12\x1f\n" +
+	"\vonline_only\x18\b \x01(\bR\n" +
+	"onlineOnly\x12\x1f\n" +
+	"\vmin_version\x18\t \x01(\tR\n" +
+	"minVersion\x122\n" +
+	"\x15use_transport_latency\x18\n" +
+	" \x01(\bR\x13useTransportLatency\x12\x1b\n" +
+	"\tdmsg_only\x18\v \x01(\bR\bdmsgOnly\x12$\n" +
+	"\x0edmsg_pre_check\x18\f \x01(\bR\fdmsgPreCheck\x12\x18\n" +
+	"\aretries\x18\r \x01(\x05R\aretries\x12\x17\n" +
+	"\adry_run\x18\x0e \x01(\bR\x06dryRun\"\xb5\x03\n" +
+	"\rPingTreeEvent\x12!\n" +
+	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12=\n" +
+	"\n" +
+	"discovered\x18\n" +
+	" \x01(\v2\x1b.rpcgrpc.PingTreeDiscoveredH\x00R\n" +
+	"discovered\x12:\n" +
+	"\vping_result\x18\v \x01(\v2\x17.rpcgrpc.PingTreeResultH\x00R\n" +
+	"pingResult\x12;\n" +
+	"\n" +
+	"level_done\x18\f \x01(\v2\x1a.rpcgrpc.PingTreeLevelDoneH\x00R\tlevelDone\x125\n" +
+	"\brun_done\x18\r \x01(\v2\x18.rpcgrpc.PingTreeRunDoneH\x00R\arunDone\x12D\n" +
+	"\rstatus_update\x18\x0e \x01(\v2\x1d.rpcgrpc.PingTreeStatusUpdateH\x00R\fstatusUpdate\x12A\n" +
+	"\fserver_error\x18\x0f \x01(\v2\x1c.rpcgrpc.PingTreeServerErrorH\x00R\vserverErrorB\t\n" +
+	"\apayload\"\x92\x01\n" +
+	"\x12PingTreeDiscovered\x12\x13\n" +
+	"\x05tp_id\x18\x01 \x01(\tR\x04tpId\x12\x17\n" +
+	"\atp_type\x18\x02 \x01(\tR\x06tpType\x12\x1b\n" +
+	"\tremote_pk\x18\x03 \x01(\tR\bremotePk\x12\x1b\n" +
+	"\tparent_pk\x18\x04 \x01(\tR\bparentPk\x12\x14\n" +
+	"\x05level\x18\x05 \x01(\x05R\x05level\"\xaf\x04\n" +
+	"\x0ePingTreeResult\x12\x13\n" +
+	"\x05tp_id\x18\x01 \x01(\tR\x04tpId\x12\x17\n" +
+	"\atp_type\x18\x02 \x01(\tR\x06tpType\x12\x1b\n" +
+	"\tremote_pk\x18\x03 \x01(\tR\bremotePk\x12\x1b\n" +
+	"\tparent_pk\x18\x04 \x01(\tR\bparentPk\x12\x14\n" +
+	"\x05level\x18\x05 \x01(\x05R\x05level\x12\x16\n" +
+	"\x06failed\x18\x06 \x01(\bR\x06failed\x12\x1a\n" +
+	"\bcanceled\x18\a \x01(\bR\bcanceled\x12(\n" +
+	"\x10setup_latency_ns\x18\b \x01(\x03R\x0esetupLatencyNs\x12!\n" +
+	"\fsample_count\x18\t \x01(\x05R\vsampleCount\x12\x1e\n" +
+	"\vping_avg_ns\x18\n" +
+	" \x01(\x03R\tpingAvgNs\x12\x1e\n" +
+	"\vping_p50_ns\x18\v \x01(\x03R\tpingP50Ns\x12\x1e\n" +
+	"\vping_p99_ns\x18\f \x01(\x03R\tpingP99Ns\x12\x1b\n" +
+	"\tjitter_ns\x18\r \x01(\x03R\bjitterNs\x12\x1b\n" +
+	"\tsetup_err\x18\x0e \x01(\tR\bsetupErr\x12\x19\n" +
+	"\bping_err\x18\x0f \x01(\tR\apingErr\x12\x19\n" +
+	"\bcalc_err\x18\x10 \x01(\tR\acalcErr\x12%\n" +
+	"\x0elatency_source\x18\x11 \x01(\tR\rlatencySource\x12'\n" +
+	"\x05route\x18\x12 \x03(\v2\x11.rpcgrpc.RouteHopR\x05route\"\xa4\x01\n" +
+	"\x11PingTreeLevelDone\x12\x14\n" +
+	"\x05level\x18\x01 \x01(\x05R\x05level\x12\x1c\n" +
+	"\tattempted\x18\x02 \x01(\x05R\tattempted\x12\x1c\n" +
+	"\tsucceeded\x18\x03 \x01(\x05R\tsucceeded\x12\x16\n" +
+	"\x06failed\x18\x04 \x01(\x05R\x06failed\x12%\n" +
+	"\x0eskipped_cached\x18\x05 \x01(\x05R\rskippedCached\"\xd4\x02\n" +
+	"\x0fPingTreeRunDone\x12)\n" +
+	"\x10total_discovered\x18\x01 \x01(\x05R\x0ftotalDiscovered\x12!\n" +
+	"\ftotal_pinged\x18\x02 \x01(\x05R\vtotalPinged\x12'\n" +
+	"\x0ftotal_succeeded\x18\x03 \x01(\x05R\x0etotalSucceeded\x12!\n" +
+	"\ftotal_failed\x18\x04 \x01(\x05R\vtotalFailed\x120\n" +
+	"\x14total_skipped_cached\x18\x05 \x01(\x05R\x12totalSkippedCached\x12 \n" +
+	"\fwall_time_ns\x18\x06 \x01(\x03R\n" +
+	"wallTimeNs\x12$\n" +
+	"\x0epeak_in_flight\x18\a \x01(\x05R\fpeakInFlight\x12-\n" +
+	"\x12termination_reason\x18\b \x01(\tR\x11terminationReason\"}\n" +
+	"\x14PingTreeStatusUpdate\x12\x14\n" +
+	"\x05phase\x18\x01 \x01(\tR\x05phase\x12\x1b\n" +
+	"\tin_flight\x18\x02 \x01(\x05R\binFlight\x12\x18\n" +
+	"\apending\x18\x03 \x01(\x05R\apending\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\"C\n" +
+	"\x13PingTreeServerError\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage2\x8a\a\n" +
 	"\vPingService\x129\n" +
 	"\n" +
 	"StreamPing\x12\x14.rpcgrpc.PingRequest\x1a\x13.rpcgrpc.PingResult0\x01\x12=\n" +
@@ -2111,7 +3155,8 @@ const file_ping_proto_rawDesc = "" +
 	"\x17StreamRemoteSystemStats\x12!.rpcgrpc.RemoteSystemStatsRequest\x1a\x14.rpcgrpc.SystemStats0\x01\x12E\n" +
 	"\rStreamAppLogs\x12\x1c.rpcgrpc.AppLogStreamRequest\x1a\x14.rpcgrpc.AppLogEntry0\x01\x12D\n" +
 	"\x10StreamCalcRoutes\x12\x1a.rpcgrpc.CalcRoutesRequest\x1a\x12.rpcgrpc.CalcRoute0\x01\x12R\n" +
-	"\x13StreamGroupMessages\x12\x1d.rpcgrpc.GroupMessagesRequest\x1a\x1a.rpcgrpc.GroupMessageEvent0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
+	"\x13StreamGroupMessages\x12\x1d.rpcgrpc.GroupMessagesRequest\x1a\x1a.rpcgrpc.GroupMessageEvent0\x01\x12D\n" +
+	"\x0eStreamPingTree\x12\x18.rpcgrpc.PingTreeRequest\x1a\x16.rpcgrpc.PingTreeEvent0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -2125,7 +3170,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -2151,7 +3196,15 @@ var file_ping_proto_goTypes = []any{
 	(*GroupMessagesRequest)(nil),     // 21: rpcgrpc.GroupMessagesRequest
 	(*GroupMessageEvent)(nil),        // 22: rpcgrpc.GroupMessageEvent
 	(*ProcessStat)(nil),              // 23: rpcgrpc.ProcessStat
-	nil,                              // 24: rpcgrpc.AppLogEntry.FieldsEntry
+	(*PingTreeRequest)(nil),          // 24: rpcgrpc.PingTreeRequest
+	(*PingTreeEvent)(nil),            // 25: rpcgrpc.PingTreeEvent
+	(*PingTreeDiscovered)(nil),       // 26: rpcgrpc.PingTreeDiscovered
+	(*PingTreeResult)(nil),           // 27: rpcgrpc.PingTreeResult
+	(*PingTreeLevelDone)(nil),        // 28: rpcgrpc.PingTreeLevelDone
+	(*PingTreeRunDone)(nil),          // 29: rpcgrpc.PingTreeRunDone
+	(*PingTreeStatusUpdate)(nil),     // 30: rpcgrpc.PingTreeStatusUpdate
+	(*PingTreeServerError)(nil),      // 31: rpcgrpc.PingTreeServerError
+	nil,                              // 32: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -2165,35 +3218,44 @@ var file_ping_proto_depIdxs = []int32{
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
 	23, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	24, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	32, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
 	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
-	0,  // 13: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 14: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 15: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 16: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 17: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 18: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 19: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 20: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 21: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	18, // 22: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	21, // 23: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
-	1,  // 24: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 25: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 26: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 27: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 28: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 29: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 30: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 31: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 32: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 33: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	22, // 34: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
-	24, // [24:35] is the sub-list for method output_type
-	13, // [13:24] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	26, // 13: rpcgrpc.PingTreeEvent.discovered:type_name -> rpcgrpc.PingTreeDiscovered
+	27, // 14: rpcgrpc.PingTreeEvent.ping_result:type_name -> rpcgrpc.PingTreeResult
+	28, // 15: rpcgrpc.PingTreeEvent.level_done:type_name -> rpcgrpc.PingTreeLevelDone
+	29, // 16: rpcgrpc.PingTreeEvent.run_done:type_name -> rpcgrpc.PingTreeRunDone
+	30, // 17: rpcgrpc.PingTreeEvent.status_update:type_name -> rpcgrpc.PingTreeStatusUpdate
+	31, // 18: rpcgrpc.PingTreeEvent.server_error:type_name -> rpcgrpc.PingTreeServerError
+	4,  // 19: rpcgrpc.PingTreeResult.route:type_name -> rpcgrpc.RouteHop
+	0,  // 20: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 21: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 22: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 23: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 24: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 25: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 26: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 27: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 28: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 29: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	21, // 30: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	24, // 31: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
+	1,  // 32: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 33: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 34: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 35: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 36: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 37: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 38: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 39: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 40: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 41: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 42: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	25, // 43: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
+	32, // [32:44] is the sub-list for method output_type
+	20, // [20:32] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -2201,13 +3263,21 @@ func file_ping_proto_init() {
 	if File_ping_proto != nil {
 		return
 	}
+	file_ping_proto_msgTypes[25].OneofWrappers = []any{
+		(*PingTreeEvent_Discovered)(nil),
+		(*PingTreeEvent_PingResult)(nil),
+		(*PingTreeEvent_LevelDone)(nil),
+		(*PingTreeEvent_RunDone)(nil),
+		(*PingTreeEvent_StatusUpdate)(nil),
+		(*PingTreeEvent_ServerError)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   25,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -51,6 +51,32 @@ service PingService {
   // init_apps.go for unary-RPC hang detection. Stream lifetime is
   // the listen lifetime, no arbitrary ceiling.
   rpc StreamGroupMessages(GroupMessagesRequest) returns (stream GroupMessageEvent);
+
+  // StreamPingTree walks the visor's neighborhood breadth-first and
+  // streams discovery + ping events as they happen. Replaces the
+  // client-side BFS in 'cli visor ping tree' — server-side has
+  // direct access to TransportSummary.LatencyMS (the smoothed per-
+  // transport RTT measured continuously by the transport layer),
+  // the route-finder, and the local tpM, so it can:
+  //   - Skip live pings at level 1 when the transport already has a
+  //     warmed latency cache (use_transport_latency flag);
+  //   - Walk tpM.WalkTransports directly without the snapshot
+  //     allocation cost that the unary Transports() RPC imposes
+  //     on visors with hundreds of transports;
+  //   - Observe cancellation at every BFS iteration so a client
+  //     disconnect tears down the walk within one in-flight ping.
+  //
+  // Result events arrive in chunk-complete-by-completion order, NOT
+  // deterministically grouped per peer — consumers that want
+  // (level, parent_pk, remote_pk) grouping must sort/bucket on
+  // receive. Server-side per-level concurrency means events for
+  // level N+1 never appear before level N's LevelDone.
+  //
+  // Authorization: the handler gates on the same whitelist used by
+  // dmsgscp (hypervisors + own PK + Dmsgpty.Whitelist). On a public
+  // visor with hundreds of transports, an unauthenticated caller
+  // could trigger a many-target ping storm; the gate prevents that.
+  rpc StreamPingTree(PingTreeRequest) returns (stream PingTreeEvent);
 }
 
 message PingRequest {
@@ -314,4 +340,199 @@ message ProcessStat {
   uint64 memory_rss = 5;      // Resident set size in bytes
   string username = 6;        // Username running the process
   string status = 7;          // Process status (running, sleeping, etc.)
+}
+
+// PingTreeRequest configures a server-side BFS ping-tree walk.
+// All durations are in nanoseconds (proto convention used throughout
+// this service). All "0 = default" fields fall back to handler-side
+// constants documented inline.
+message PingTreeRequest {
+  // MaxLevel caps BFS depth. 0 = unlimited until expansion exhausts.
+  int32 max_level = 1;
+  // Hops, when > 0, pings ONLY entries at exactly N hops. The BFS
+  // still discovers intermediate levels (so it can reach the target),
+  // but no PingResult fires for non-target levels. Synth's "latency
+  // as a function of hop count" measurement uses this.
+  int32 hops = 2;
+  // Tries is the per-transport ping count. The PingResult carries
+  // the aggregated stats (avg, p50, p99, jitter) over all tries.
+  // 0 falls back to 1.
+  int32 tries = 3;
+  // PacketSizeKb is the per-ping packet size. 0 falls back to 2 KB.
+  int32 packet_size_kb = 4;
+  // PingTimeoutNs bounds each individual ping (after route setup).
+  // 0 falls back to 30s.
+  int64 ping_timeout_ns = 5;
+  // SetupTimeoutNs bounds the route-setup phase per transport.
+  // 0 falls back to 30s.
+  int64 setup_timeout_ns = 6;
+  // Concurrency limits in-flight pings per level. The cap resets
+  // between levels (level 2 starts with a fresh budget after level 1
+  // drains) — predictable LevelDone semantics + bounded fan-out at
+  // deep levels. 0 falls back to 16.
+  int32 concurrency = 7;
+  // OnlineOnly filters discovered visors via the uptime tracker.
+  bool online_only = 8;
+  // MinVersion filters by minimum visor version (semver). Empty = no
+  // filter.
+  string min_version = 9;
+  // UseTransportLatency turns on the level-1 fast path: when a
+  // direct transport already has a non-zero smoothed
+  // TransportSummary.LatencyMS, the handler emits a PingResult with
+  // latency_source="transport_summary" and skips the live ping.
+  // Saves traffic + makes level 1 instant for warm transports.
+  // Deeper levels always live-ping (no transport-level latency for
+  // multi-hop routes).
+  bool use_transport_latency = 10;
+  // DmsgOnly forces the ping to ride the DMSG path instead of the
+  // skywire router. Mirrors `cli visor ping --dmsg`.
+  bool dmsg_only = 11;
+  // DmsgPreCheck probes DMSG reachability before attempting a
+  // route ping. Discards unreachable visors early.
+  bool dmsg_pre_check = 12;
+  // Retries adds N retry attempts on failed pings. 0 = no retry.
+  int32 retries = 13;
+  // DryRun runs the BFS discovery but emits no PingResult events;
+  // useful for visualizing the reachable graph without traffic.
+  bool dry_run = 14;
+}
+
+// PingTreeEvent is one entry on the stream. Exactly one oneof
+// payload is set per message. Consumers switch on the payload type;
+// the top-level timestamp_ns is server-side wall time at emit.
+message PingTreeEvent {
+  int64 timestamp_ns = 1;
+  oneof payload {
+    PingTreeDiscovered discovered = 10;
+    PingTreeResult ping_result = 11;
+    PingTreeLevelDone level_done = 12;
+    PingTreeRunDone run_done = 13;
+    PingTreeStatusUpdate status_update = 14;
+    // ServerError is a terminal event: the handler is about to
+    // close the stream because of an unrecoverable condition
+    // (e.g. proto break, internal panic recovered). Clients should
+    // treat receipt as equivalent to stream-EOF with a known cause.
+    PingTreeServerError server_error = 15;
+  }
+}
+
+// Discovered fires when the BFS adds a (transport, peer) pair to the
+// candidate set at level N. Fires BEFORE the corresponding PingResult.
+message PingTreeDiscovered {
+  string tp_id = 1;
+  string tp_type = 2;
+  string remote_pk = 3;
+  string parent_pk = 4;
+  int32 level = 5;
+}
+
+// PingResult fires when a transport's ping (or the cache fast-path)
+// completes. Both success and failure produce a PingResult; consumers
+// switch on the failed bool. Latency stats are aggregated across the
+// per-tries sample series.
+message PingTreeResult {
+  string tp_id = 1;
+  string tp_type = 2;
+  string remote_pk = 3;
+  string parent_pk = 4;
+  int32 level = 5;
+  bool failed = 6;
+  // Canceled distinguishes ctx-canceled-mid-flight from genuine
+  // failure. Set when ctx.Err() != nil at the time the result was
+  // finalized. Different operator action: retry vs investigate.
+  bool canceled = 7;
+  // SetupLatencyNs is the route-setup phase time. Excluded from the
+  // ping_*_ns aggregations below — those are per-ping post-setup.
+  int64 setup_latency_ns = 8;
+  // SampleCount is the number of successful pings (out of Tries).
+  // Zero when failed.
+  int32 sample_count = 9;
+  // PingAvgNs / PingP50Ns / PingP99Ns / JitterNs are aggregations
+  // over the sample series. Jitter is the population stddev:
+  // sqrt(sum((x - mean)^2) / N). Zero when sample_count < 2 (no
+  // stddev defined for a single sample).
+  int64 ping_avg_ns = 10;
+  int64 ping_p50_ns = 11;
+  int64 ping_p99_ns = 12;
+  int64 jitter_ns = 13;
+  // SetupErr / PingErr / CalcErr surface the most-recent error from
+  // each phase. Multiple may be set when multiple phases failed.
+  string setup_err = 14;
+  string ping_err = 15;
+  string calc_err = 16;
+  // LatencySource carries the provenance of the latency stats:
+  //   "live_ping"          — measured by an actual ping just now
+  //   "transport_summary"  — pulled from TransportSummary.LatencyMS
+  //                          (smoothed cache, level-1 fast path)
+  //   "skipped"            — entry was --hops mismatch or --dry-run
+  // Consumers use this to weight stale-cache values vs fresh probes.
+  string latency_source = 17;
+  // Route is the hop sequence used for this ping. Empty for the
+  // transport_summary fast-path (no route was constructed).
+  repeated RouteHop route = 18;
+}
+
+// LevelDone fires after every transport at level N has either
+// completed its ping or been skipped. Always fires before the next
+// level's Discovered events. Counts are authoritative for the harness.
+message PingTreeLevelDone {
+  int32 level = 1;
+  // Attempted = sum of (succeeded + failed + skipped_cached + skipped_dry).
+  int32 attempted = 2;
+  int32 succeeded = 3;
+  int32 failed = 4;
+  // SkippedCached is the count of entries where the
+  // use_transport_latency fast-path fired. Lets harnesses compute
+  // cache hit rate.
+  int32 skipped_cached = 5;
+}
+
+// RunDone is the terminal event before stream close. Fires exactly
+// once per StreamPingTree call.
+message PingTreeRunDone {
+  int32 total_discovered = 1;
+  int32 total_pinged = 2;
+  int32 total_succeeded = 3;
+  int32 total_failed = 4;
+  int32 total_skipped_cached = 5;
+  int64 wall_time_ns = 6;
+  // PeakInFlight is the highest concurrent ping count observed
+  // during the run. Useful for tuning concurrency.
+  int32 peak_in_flight = 7;
+  // TerminationReason is one of:
+  //   "max_level"          — hit cfg.MaxLevel
+  //   "no_neighbors"       — BFS exhausted before MaxLevel
+  //   "hops_target"        — reached cfg.Hops target level
+  //   "context_cancel"     — client disconnect / server shutdown
+  //   "error"              — see ServerError preceding this event
+  string termination_reason = 8;
+}
+
+// StatusUpdate is a low-priority informational event (e.g. "expanding
+// level 3", "draining in-flight"). The handler MUST prefer dropping
+// StatusUpdate over PingResult under backpressure — never trade
+// measurement data for status text.
+message PingTreeStatusUpdate {
+  // Phase is one of: "discovering" | "pinging_level_N" | "finalizing".
+  string phase = 1;
+  // InFlight is the count of currently-active ping goroutines.
+  int32 in_flight = 2;
+  // Pending is the count of queued-but-not-started pings.
+  int32 pending = 3;
+  // Message is an optional human-readable hint (e.g. "waiting on 3
+  // slow pings at level 2"). Empty for routine progress.
+  string message = 4;
+}
+
+// ServerError signals an unrecoverable condition that's about to
+// close the stream. Clients receive it as the last event before
+// stream-EOF; preserves a known cause vs an opaque transport error.
+message PingTreeServerError {
+  // Code is a short stable identifier (e.g. "auth_denied",
+  // "internal_panic", "tpm_unavailable"). Suitable for grep / metric
+  // labeling.
+  string code = 1;
+  // Message carries operator-readable detail. Not stable across
+  // versions.
+  string message = 2;
 }

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -8,7 +8,6 @@ package rpcgrpc
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -31,6 +30,7 @@ const (
 	PingService_StreamAppLogs_FullMethodName           = "/rpcgrpc.PingService/StreamAppLogs"
 	PingService_StreamCalcRoutes_FullMethodName        = "/rpcgrpc.PingService/StreamCalcRoutes"
 	PingService_StreamGroupMessages_FullMethodName     = "/rpcgrpc.PingService/StreamGroupMessages"
+	PingService_StreamPingTree_FullMethodName          = "/rpcgrpc.PingService/StreamPingTree"
 )
 
 // PingServiceClient is the client API for PingService service.
@@ -74,6 +74,31 @@ type PingServiceClient interface {
 	// init_apps.go for unary-RPC hang detection. Stream lifetime is
 	// the listen lifetime, no arbitrary ceiling.
 	StreamGroupMessages(ctx context.Context, in *GroupMessagesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GroupMessageEvent], error)
+	// StreamPingTree walks the visor's neighborhood breadth-first and
+	// streams discovery + ping events as they happen. Replaces the
+	// client-side BFS in 'cli visor ping tree' — server-side has
+	// direct access to TransportSummary.LatencyMS (the smoothed per-
+	// transport RTT measured continuously by the transport layer),
+	// the route-finder, and the local tpM, so it can:
+	//   - Skip live pings at level 1 when the transport already has a
+	//     warmed latency cache (use_transport_latency flag);
+	//   - Walk tpM.WalkTransports directly without the snapshot
+	//     allocation cost that the unary Transports() RPC imposes
+	//     on visors with hundreds of transports;
+	//   - Observe cancellation at every BFS iteration so a client
+	//     disconnect tears down the walk within one in-flight ping.
+	//
+	// Result events arrive in chunk-complete-by-completion order, NOT
+	// deterministically grouped per peer — consumers that want
+	// (level, parent_pk, remote_pk) grouping must sort/bucket on
+	// receive. Server-side per-level concurrency means events for
+	// level N+1 never appear before level N's LevelDone.
+	//
+	// Authorization: the handler gates on the same whitelist used by
+	// dmsgscp (hypervisors + own PK + Dmsgpty.Whitelist). On a public
+	// visor with hundreds of transports, an unauthenticated caller
+	// could trigger a many-target ping storm; the gate prevents that.
+	StreamPingTree(ctx context.Context, in *PingTreeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[PingTreeEvent], error)
 }
 
 type pingServiceClient struct {
@@ -275,6 +300,25 @@ func (c *pingServiceClient) StreamGroupMessages(ctx context.Context, in *GroupMe
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamGroupMessagesClient = grpc.ServerStreamingClient[GroupMessageEvent]
 
+func (c *pingServiceClient) StreamPingTree(ctx context.Context, in *PingTreeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[PingTreeEvent], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &PingService_ServiceDesc.Streams[9], PingService_StreamPingTree_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[PingTreeRequest, PingTreeEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamPingTreeClient = grpc.ServerStreamingClient[PingTreeEvent]
+
 // PingServiceServer is the server API for PingService service.
 // All implementations must embed UnimplementedPingServiceServer
 // for forward compatibility.
@@ -316,6 +360,31 @@ type PingServiceServer interface {
 	// init_apps.go for unary-RPC hang detection. Stream lifetime is
 	// the listen lifetime, no arbitrary ceiling.
 	StreamGroupMessages(*GroupMessagesRequest, grpc.ServerStreamingServer[GroupMessageEvent]) error
+	// StreamPingTree walks the visor's neighborhood breadth-first and
+	// streams discovery + ping events as they happen. Replaces the
+	// client-side BFS in 'cli visor ping tree' — server-side has
+	// direct access to TransportSummary.LatencyMS (the smoothed per-
+	// transport RTT measured continuously by the transport layer),
+	// the route-finder, and the local tpM, so it can:
+	//   - Skip live pings at level 1 when the transport already has a
+	//     warmed latency cache (use_transport_latency flag);
+	//   - Walk tpM.WalkTransports directly without the snapshot
+	//     allocation cost that the unary Transports() RPC imposes
+	//     on visors with hundreds of transports;
+	//   - Observe cancellation at every BFS iteration so a client
+	//     disconnect tears down the walk within one in-flight ping.
+	//
+	// Result events arrive in chunk-complete-by-completion order, NOT
+	// deterministically grouped per peer — consumers that want
+	// (level, parent_pk, remote_pk) grouping must sort/bucket on
+	// receive. Server-side per-level concurrency means events for
+	// level N+1 never appear before level N's LevelDone.
+	//
+	// Authorization: the handler gates on the same whitelist used by
+	// dmsgscp (hypervisors + own PK + Dmsgpty.Whitelist). On a public
+	// visor with hundreds of transports, an unauthenticated caller
+	// could trigger a many-target ping storm; the gate prevents that.
+	StreamPingTree(*PingTreeRequest, grpc.ServerStreamingServer[PingTreeEvent]) error
 	mustEmbedUnimplementedPingServiceServer()
 }
 
@@ -358,6 +427,9 @@ func (UnimplementedPingServiceServer) StreamCalcRoutes(*CalcRoutesRequest, grpc.
 }
 func (UnimplementedPingServiceServer) StreamGroupMessages(*GroupMessagesRequest, grpc.ServerStreamingServer[GroupMessageEvent]) error {
 	return status.Error(codes.Unimplemented, "method StreamGroupMessages not implemented")
+}
+func (UnimplementedPingServiceServer) StreamPingTree(*PingTreeRequest, grpc.ServerStreamingServer[PingTreeEvent]) error {
+	return status.Error(codes.Unimplemented, "method StreamPingTree not implemented")
 }
 func (UnimplementedPingServiceServer) mustEmbedUnimplementedPingServiceServer() {}
 func (UnimplementedPingServiceServer) testEmbeddedByValue()                     {}
@@ -515,6 +587,17 @@ func _PingService_StreamGroupMessages_Handler(srv interface{}, stream grpc.Serve
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamGroupMessagesServer = grpc.ServerStreamingServer[GroupMessageEvent]
 
+func _PingService_StreamPingTree_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(PingTreeRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(PingServiceServer).StreamPingTree(m, &grpc.GenericServerStream[PingTreeRequest, PingTreeEvent]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamPingTreeServer = grpc.ServerStreamingServer[PingTreeEvent]
+
 // PingService_ServiceDesc is the grpc.ServiceDesc for PingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -575,6 +658,11 @@ var PingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamGroupMessages",
 			Handler:       _PingService_StreamGroupMessages_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamPingTree",
+			Handler:       _PingService_StreamPingTree_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/visor/rpcgrpc/server_ping_tree.go
+++ b/pkg/visor/rpcgrpc/server_ping_tree.go
@@ -1,0 +1,725 @@
+// Package rpcgrpc — pkg/visor/rpcgrpc/server_ping_tree.go: server-side
+// implementation of the StreamPingTree gRPC RPC. Replaces the
+// client-side BFS in cmd/skywire-cli/commands/visor/ping/tree.go,
+// giving the visor direct access to per-transport latency data and
+// the route-finder graph without paying for RPC roundtrips per BFS
+// step.
+//
+// Wire shape: per ping.proto, one PingTreeEvent per discovered entry
+// / ping result / level boundary / run terminus. Per-level
+// concurrency, ctx.Done() observed at every BFS iteration, bounded
+// event channel with drop-StatusUpdate-before-PingResult policy.
+//
+// Authorization: TODO — first cut runs unauthenticated for
+// development; follow-up PR gates on the dmsgWL whitelist
+// (hypervisors + own PK + Dmsgpty.Whitelist) before opening to the
+// network. Local CLI use over the unix-socket RPC is implicitly
+// trusted via filesystem permissions; the gate matters for the
+// dmsg-port gRPC entry point.
+package rpcgrpc
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// Defaults for unset PingTreeRequest fields. Kept in one place so
+// changing a default doesn't require chasing magic numbers through
+// the handler.
+const (
+	defaultPingTreeTries         = 1
+	defaultPingTreePacketSizeKb  = 2
+	defaultPingTreePingTimeout   = 30 * time.Second
+	defaultPingTreeSetupTimeout  = 30 * time.Second
+	defaultPingTreeConcurrency   = 16
+	pingTreeEventChannelCapacity = 256
+)
+
+// pingTreeCfg is the normalized request — every "0 = default" field
+// resolved, every duration in time.Duration, every PK as cipher.PubKey.
+// Pass this around inside the handler instead of the raw proto.
+type pingTreeCfg struct {
+	MaxLevel            int
+	Hops                int
+	Tries               int
+	PacketSizeKb        int
+	PingTimeout         time.Duration
+	SetupTimeout        time.Duration
+	Concurrency         int
+	OnlineOnly          bool
+	MinVersion          string
+	UseTransportLatency bool
+	DmsgOnly            bool
+	DmsgPreCheck        bool
+	Retries             int
+	DryRun              bool
+}
+
+func normalizePingTreeRequest(req *PingTreeRequest) pingTreeCfg {
+	c := pingTreeCfg{
+		MaxLevel:            int(req.MaxLevel),
+		Hops:                int(req.Hops),
+		Tries:               int(req.Tries),
+		PacketSizeKb:        int(req.PacketSizeKb),
+		PingTimeout:         time.Duration(req.PingTimeoutNs),
+		SetupTimeout:        time.Duration(req.SetupTimeoutNs),
+		Concurrency:         int(req.Concurrency),
+		OnlineOnly:          req.OnlineOnly,
+		MinVersion:          req.MinVersion,
+		UseTransportLatency: req.UseTransportLatency,
+		DmsgOnly:            req.DmsgOnly,
+		DmsgPreCheck:        req.DmsgPreCheck,
+		Retries:             int(req.Retries),
+		DryRun:              req.DryRun,
+	}
+	if c.Tries <= 0 {
+		c.Tries = defaultPingTreeTries
+	}
+	if c.PacketSizeKb <= 0 {
+		c.PacketSizeKb = defaultPingTreePacketSizeKb
+	}
+	if c.PingTimeout <= 0 {
+		c.PingTimeout = defaultPingTreePingTimeout
+	}
+	if c.SetupTimeout <= 0 {
+		c.SetupTimeout = defaultPingTreeSetupTimeout
+	}
+	if c.Concurrency <= 0 {
+		c.Concurrency = defaultPingTreeConcurrency
+	}
+	return c
+}
+
+// pingTreeCandidate is one (transport, peer) pair the BFS has
+// discovered and may try to ping. Keyed in the visited set by
+// remote PK (we don't try to ping the same peer twice via different
+// transports — the route-finder chooses one).
+type pingTreeCandidate struct {
+	tpID     string
+	tpType   string
+	remotePK string
+	parentPK string
+	level    int
+}
+
+// pingTreeTotals accumulates run-wide counters. Read by the final
+// RunDone emission. All fields are int32 for direct proto field copy.
+type pingTreeTotals struct {
+	mu              sync.Mutex
+	discovered      int32
+	pinged          int32
+	succeeded       int32
+	failed          int32
+	skippedCached   int32
+	peakInFlight    int32
+	currentInFlight int32 // tracked via atomic, snapshot to peak under mu
+}
+
+func (t *pingTreeTotals) bumpInFlight(delta int32) {
+	cur := atomic.AddInt32(&t.currentInFlight, delta)
+	if delta > 0 {
+		t.mu.Lock()
+		if cur > t.peakInFlight {
+			t.peakInFlight = cur
+		}
+		t.mu.Unlock()
+	}
+}
+
+// StreamPingTree walks the visor's neighborhood breadth-first and
+// streams discovery + ping events. See ping.proto for the wire
+// shape; this function is the canonical implementation.
+//
+// Implementation outline:
+//  1. Fetch the global transport-discovery adjacency once
+//     (FetchAllTransportEntries returns every entry in the system).
+//  2. Spawn a sender goroutine that drains a bounded event channel
+//     to stream.Send. The bounded channel + non-blocking send for
+//     StatusUpdate gives backpressure visibility without dropping
+//     measurement data.
+//  3. BFS:
+//     - Level 1: enumerate candidates from adjacency[localPK].
+//     - For each level, emit Discovered, then ping with bounded
+//     concurrency, then emit LevelDone.
+//     - At each iteration check ctx.Done() so a client disconnect
+//     tears the walk down within one in-flight ping.
+//  4. Emit RunDone with termination_reason.
+//
+// Level-1 fast path via TransportSummary.LatencyMS is left as a
+// TODO with the explicit hook so the follow-up PR can land it
+// without restructuring (Beta's slice per role split).
+func (s *PingServer) StreamPingTree(req *PingTreeRequest, stream PingService_StreamPingTreeServer) error {
+	ctx := stream.Context()
+	cfg := normalizePingTreeRequest(req)
+
+	localPK := s.visor.LocalPK()
+	localPKHex := localPK.String()
+
+	// 1. Build adjacency from TPD's full transport entry set.
+	entries, err := s.visor.FetchAllTransportEntries(ctx)
+	if err != nil {
+		return s.sendServerError(stream, "tpd_fetch_failed", err.Error())
+	}
+	adjacency := buildPingTreeAdjacency(entries)
+
+	// 2. Set up sender goroutine + bounded event channel.
+	eventCh := make(chan *PingTreeEvent, pingTreeEventChannelCapacity)
+	sendErrCh := make(chan error, 1)
+	go pingTreeSender(stream, eventCh, sendErrCh)
+
+	// 3. BFS state.
+	visited := map[string]bool{localPKHex: true}
+	totals := &pingTreeTotals{}
+	runStart := time.Now()
+	terminationReason := "no_neighbors" // overwritten below as appropriate
+
+	emit := func(payload isPingTreeEvent_Payload) {
+		ev := &PingTreeEvent{
+			TimestampNs: time.Now().UnixNano(),
+			Payload:     payload,
+		}
+		// Discovered / PingResult / LevelDone / RunDone / ServerError
+		// must NOT drop — they carry measurement data. StatusUpdate
+		// may drop under pressure. The sender goroutine handles the
+		// actual send to stream; this channel is purely an
+		// ordering + buffering vehicle.
+		select {
+		case eventCh <- ev:
+		case <-ctx.Done():
+		}
+	}
+	emitStatus := func(phase string, inFlight, pending int32, msg string) {
+		ev := &PingTreeEvent{
+			TimestampNs: time.Now().UnixNano(),
+			Payload: &PingTreeEvent_StatusUpdate{
+				StatusUpdate: &PingTreeStatusUpdate{
+					Phase:    phase,
+					InFlight: inFlight,
+					Pending:  pending,
+					Message:  msg,
+				},
+			},
+		}
+		// Non-blocking: StatusUpdate is the drop-eligible event type.
+		// If the channel is full, the consumer is already getting
+		// data events; status text isn't worth blocking on.
+		select {
+		case eventCh <- ev:
+		default:
+		}
+	}
+
+	// Level 1: direct neighbors of localPK in the adjacency.
+	emitStatus("discovering_level_1", 0, 0, "")
+	level1 := candidatesFromAdjacency(adjacency, localPKHex, localPKHex, 1, visited)
+	for _, c := range level1 {
+		atomic.AddInt32(&totals.discovered, 1)
+		emit(&PingTreeEvent_Discovered{
+			Discovered: candidateToDiscovered(c),
+		})
+	}
+
+	// Ping level 1.
+	if !cfg.DryRun {
+		s.pingTreePingLevel(ctx, &cfg, 1, level1, totals, emit, emitStatus)
+	} else {
+		// Dry-run: mark every level-1 entry as "skipped" so the
+		// totals still tally.
+		for _, c := range level1 {
+			emit(&PingTreeEvent_PingResult{
+				PingResult: &PingTreeResult{
+					TpId:          c.tpID,
+					TpType:        c.tpType,
+					RemotePk:      c.remotePK,
+					ParentPk:      c.parentPK,
+					Level:         int32(c.level), //nolint:gosec // BFS level fits int32
+					LatencySource: "skipped",
+				},
+			})
+			atomic.AddInt32(&totals.skippedCached, 1)
+		}
+	}
+	level1Done := levelDoneFor(level1, 1)
+	emit(&PingTreeEvent_LevelDone{LevelDone: level1Done})
+
+	// Check ctx between levels — client-disconnect tear-down.
+	if ctx.Err() != nil {
+		terminationReason = "context_cancel"
+		goto FINALIZE
+	}
+
+	// Levels 2..N: expand from previously-discovered visors. We use
+	// the adjacency we already have (no re-fetch — the snapshot is
+	// per-call). Walk parents from visited set, but only those that
+	// belong to the previous level.
+	if cfg.MaxLevel == 0 || cfg.MaxLevel > 1 {
+		parentsByLevel := map[int]map[string]bool{1: pksFromCandidates(level1)}
+		for level := 2; ; level++ {
+			if cfg.MaxLevel > 0 && level > cfg.MaxLevel {
+				terminationReason = "max_level"
+				break
+			}
+			if cfg.Hops > 0 && level > cfg.Hops {
+				terminationReason = "hops_target"
+				break
+			}
+			if ctx.Err() != nil {
+				terminationReason = "context_cancel"
+				break
+			}
+
+			parents := parentsByLevel[level-1]
+			if len(parents) == 0 {
+				terminationReason = "no_neighbors"
+				break
+			}
+
+			emitStatus("discovering_level_"+itoa(level), 0, 0, "")
+			var levelN []pingTreeCandidate
+			for parentPK := range parents {
+				for _, c := range candidatesFromAdjacency(adjacency, parentPK, parentPK, level, visited) {
+					atomic.AddInt32(&totals.discovered, 1)
+					levelN = append(levelN, c)
+					emit(&PingTreeEvent_Discovered{Discovered: candidateToDiscovered(c)})
+				}
+			}
+			if len(levelN) == 0 {
+				terminationReason = "no_neighbors"
+				break
+			}
+
+			// Decide whether THIS level pings: --hops means only ping
+			// the target level; everything in between is discovered
+			// for BFS continuation but not pinged.
+			shouldPing := !cfg.DryRun && (cfg.Hops == 0 || cfg.Hops == level)
+			if shouldPing {
+				s.pingTreePingLevel(ctx, &cfg, level, levelN, totals, emit, emitStatus)
+			} else {
+				for _, c := range levelN {
+					emit(&PingTreeEvent_PingResult{
+						PingResult: &PingTreeResult{
+							TpId:          c.tpID,
+							TpType:        c.tpType,
+							RemotePk:      c.remotePK,
+							ParentPk:      c.parentPK,
+							Level:         int32(c.level), //nolint:gosec // BFS level fits int32
+							LatencySource: "skipped",
+						},
+					})
+					atomic.AddInt32(&totals.skippedCached, 1)
+				}
+			}
+			emit(&PingTreeEvent_LevelDone{LevelDone: levelDoneFor(levelN, level)})
+
+			parentsByLevel[level] = pksFromCandidates(levelN)
+			// Free the previous level's parent set; not needed again.
+			delete(parentsByLevel, level-1)
+		}
+	} else {
+		terminationReason = "max_level"
+	}
+
+FINALIZE:
+	emit(&PingTreeEvent_RunDone{
+		RunDone: &PingTreeRunDone{
+			TotalDiscovered:    atomic.LoadInt32(&totals.discovered),
+			TotalPinged:        atomic.LoadInt32(&totals.pinged),
+			TotalSucceeded:     atomic.LoadInt32(&totals.succeeded),
+			TotalFailed:        atomic.LoadInt32(&totals.failed),
+			TotalSkippedCached: atomic.LoadInt32(&totals.skippedCached),
+			WallTimeNs:         time.Since(runStart).Nanoseconds(),
+			PeakInFlight:       totals.peakInFlight,
+			TerminationReason:  terminationReason,
+		},
+	})
+
+	close(eventCh)
+	return <-sendErrCh
+}
+
+// pingTreeSender drains eventCh to stream.Send. Runs until the
+// channel closes; any Send error closes the run with that error.
+// One goroutine per RPC, so per-RPC isolation is automatic.
+func pingTreeSender(stream PingService_StreamPingTreeServer, eventCh <-chan *PingTreeEvent, errCh chan<- error) {
+	for ev := range eventCh {
+		if err := stream.Send(ev); err != nil {
+			errCh <- err
+			// Drain remaining events so the producer's send-to-channel
+			// doesn't block forever. The handler is in tear-down at
+			// this point — events are best-effort.
+			for range eventCh {
+			}
+			return
+		}
+	}
+	errCh <- nil
+}
+
+// sendServerError emits a ServerError event and closes the stream.
+// Used for unrecoverable conditions detected before the BFS starts.
+func (s *PingServer) sendServerError(stream PingService_StreamPingTreeServer, code, msg string) error {
+	_ = stream.Send(&PingTreeEvent{ //nolint:errcheck // best-effort terminal event; we're closing anyway
+		TimestampNs: time.Now().UnixNano(),
+		Payload: &PingTreeEvent_ServerError{
+			ServerError: &PingTreeServerError{Code: code, Message: msg},
+		},
+	})
+	return nil
+}
+
+// pingTreePingLevel pings every candidate at one BFS level with
+// bounded per-level concurrency. Blocks until all candidates
+// complete (success, failure, or ctx-cancel). Updates totals
+// atomically; emits one PingResult per candidate.
+//
+// First cut: live-ping only via DialPing + PingOnce. The
+// use_transport_latency fast path that consults
+// TransportSummary.LatencyMS is a follow-up (Beta's slice).
+func (s *PingServer) pingTreePingLevel(
+	ctx context.Context,
+	cfg *pingTreeCfg,
+	level int,
+	candidates []pingTreeCandidate,
+	totals *pingTreeTotals,
+	emit func(isPingTreeEvent_Payload),
+	emitStatus func(string, int32, int32, string),
+) {
+	sem := make(chan struct{}, cfg.Concurrency)
+	var wg sync.WaitGroup
+
+	var pending = int32(len(candidates)) //nolint:gosec // candidate count is bounded by BFS frontier, fits int32
+	emitStatus("pinging_level_"+itoa(level), 0, pending, "")
+
+	for _, c := range candidates {
+		if ctx.Err() != nil {
+			break
+		}
+		sem <- struct{}{}
+		wg.Add(1)
+		atomic.AddInt32(&pending, -1)
+		totals.bumpInFlight(1)
+		go func(cand pingTreeCandidate) {
+			defer func() {
+				<-sem
+				totals.bumpInFlight(-1)
+				wg.Done()
+				emitStatus(
+					"pinging_level_"+itoa(level),
+					atomic.LoadInt32(&totals.currentInFlight),
+					atomic.LoadInt32(&pending),
+					"",
+				)
+			}()
+			result := s.pingOneTransport(ctx, cfg, cand)
+			emit(&PingTreeEvent_PingResult{PingResult: result})
+			atomic.AddInt32(&totals.pinged, 1)
+			if result.Failed {
+				atomic.AddInt32(&totals.failed, 1)
+			} else {
+				atomic.AddInt32(&totals.succeeded, 1)
+			}
+		}(c)
+	}
+
+	wg.Wait()
+}
+
+// pingOneTransport runs a single transport's worth of pings (tries
+// many, computes p50/p99/jitter) and returns the proto PingTreeResult.
+// On ctx-cancel mid-flight the result carries Canceled=true so
+// consumers can distinguish from genuine failures.
+func (s *PingServer) pingOneTransport(
+	ctx context.Context,
+	cfg *pingTreeCfg,
+	cand pingTreeCandidate,
+) *PingTreeResult {
+	result := &PingTreeResult{
+		TpId:          cand.tpID,
+		TpType:        cand.tpType,
+		RemotePk:      cand.remotePK,
+		ParentPk:      cand.parentPK,
+		Level:         int32(cand.level), //nolint:gosec // BFS level fits int32
+		LatencySource: "live_ping",
+	}
+
+	var pk cipher.PubKey
+	if err := pk.Set(cand.remotePK); err != nil {
+		result.Failed = true
+		result.SetupErr = "invalid remote pk: " + err.Error()
+		return result
+	}
+
+	pingConf := PingConf{
+		PK:       pk,
+		Tries:    cfg.Tries,
+		PcktSize: cfg.PacketSizeKb,
+	}
+
+	// Setup phase: route setup OR dmsg dial. Timeout per setup.
+	setupCtx, setupCancel := context.WithTimeout(ctx, cfg.SetupTimeout)
+	defer setupCancel()
+	setupStart := time.Now()
+
+	dialDone := make(chan error, 1)
+	go func() {
+		if cfg.DmsgOnly {
+			dialDone <- s.visor.DialDmsgPing(pk)
+		} else {
+			dialDone <- s.visor.DialPing(pingConf)
+		}
+	}()
+
+	select {
+	case err := <-dialDone:
+		result.SetupLatencyNs = time.Since(setupStart).Nanoseconds()
+		if err != nil {
+			result.Failed = true
+			result.SetupErr = err.Error()
+			if ctx.Err() != nil {
+				result.Canceled = true
+			}
+			return result
+		}
+	case <-setupCtx.Done():
+		result.SetupLatencyNs = time.Since(setupStart).Nanoseconds()
+		result.Failed = true
+		if ctx.Err() != nil {
+			result.SetupErr = "context canceled during setup"
+			result.Canceled = true
+		} else {
+			result.SetupErr = "setup timeout after " + cfg.SetupTimeout.String()
+		}
+		return result
+	}
+
+	// Ping phase: run cfg.Tries pings; aggregate stats.
+	samples := make([]float64, 0, cfg.Tries)
+	for i := 0; i < cfg.Tries; i++ {
+		if ctx.Err() != nil {
+			result.Canceled = true
+			break
+		}
+		pingCtx, pingCancel := context.WithTimeout(ctx, cfg.PingTimeout)
+		latencyCh := make(chan time.Duration, 1)
+		errPingCh := make(chan error, 1)
+		go func() {
+			var (
+				latency time.Duration
+				err     error
+			)
+			if cfg.DmsgOnly {
+				latency, err = s.visor.DmsgPingOnce(pingConf)
+			} else {
+				latency, err = s.visor.PingOnce(pingConf)
+			}
+			if err != nil {
+				errPingCh <- err
+				return
+			}
+			latencyCh <- latency
+		}()
+		select {
+		case latency := <-latencyCh:
+			samples = append(samples, float64(latency.Nanoseconds()))
+		case err := <-errPingCh:
+			if result.PingErr == "" {
+				result.PingErr = err.Error()
+			}
+		case <-pingCtx.Done():
+			if result.PingErr == "" {
+				result.PingErr = "ping timeout after " + cfg.PingTimeout.String()
+			}
+		}
+		pingCancel()
+	}
+
+	// Tear down the persistent route/dmsg connection used by this run.
+	// Tear-down errors are non-actionable at the BFS level — the
+	// underlying conn is going to be GC'd either way, and surfacing
+	// them would split the result emission across success+stop-error
+	// paths.
+	if cfg.DmsgOnly {
+		_ = s.visor.StopDmsgPing(pk) //nolint:errcheck
+	} else {
+		_ = s.visor.StopPing(pk) //nolint:errcheck
+	}
+
+	result.SampleCount = int32(len(samples)) //nolint:gosec // sample count <= cfg.Tries (int32 input field)
+	if len(samples) == 0 {
+		result.Failed = true
+		if result.PingErr == "" {
+			result.PingErr = "no successful pings"
+		}
+		return result
+	}
+	result.PingAvgNs, result.PingP50Ns, result.PingP99Ns, result.JitterNs = aggregatePingSamples(samples)
+	return result
+}
+
+// aggregatePingSamples computes avg / p50 / p99 / population stddev
+// (jitter) over the sample series. All inputs and outputs are in
+// nanoseconds. Returns zeros when len(samples) == 0; only the
+// stddev is zero when len < 2 (no variance defined).
+func aggregatePingSamples(samples []float64) (avg, p50, p99, jitter int64) {
+	if len(samples) == 0 {
+		return 0, 0, 0, 0
+	}
+	sum := 0.0
+	for _, s := range samples {
+		sum += s
+	}
+	avgF := sum / float64(len(samples))
+	avg = int64(avgF)
+
+	// Percentiles via sorted copy. cfg.Tries is small (1-100 typical),
+	// so the alloc + sort is negligible compared to the network I/O
+	// the ping itself did.
+	sorted := make([]float64, len(samples))
+	copy(sorted, samples)
+	sort.Float64s(sorted)
+	p50 = int64(sorted[len(sorted)/2])
+	// p99 over a tiny sample is effectively max; that's the right
+	// behavior — synth's directive cares about tail latency.
+	p99idx := (len(sorted) * 99) / 100
+	if p99idx >= len(sorted) {
+		p99idx = len(sorted) - 1
+	}
+	p99 = int64(sorted[p99idx])
+
+	if len(samples) < 2 {
+		return avg, p50, p99, 0
+	}
+	var sq float64
+	for _, s := range samples {
+		d := s - avgF
+		sq += d * d
+	}
+	jitter = int64(math.Sqrt(sq / float64(len(samples))))
+	return avg, p50, p99, jitter
+}
+
+// buildPingTreeAdjacency is the same shape as the client-side BFS
+// used: PK -> [neighbor info]. Each transport produces two edges
+// (one per direction) so the BFS can walk in either direction.
+type pingTreeAdjacencyEntry struct {
+	tpID     string
+	tpType   string
+	remotePK string
+}
+
+func buildPingTreeAdjacency(entries []*transport.Entry) map[string][]pingTreeAdjacencyEntry {
+	adj := make(map[string][]pingTreeAdjacencyEntry, len(entries)/2)
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		a, b := e.Edges[0].String(), e.Edges[1].String()
+		adj[a] = append(adj[a], pingTreeAdjacencyEntry{
+			tpID:     e.ID.String(),
+			tpType:   string(e.Type),
+			remotePK: b,
+		})
+		if a != b {
+			adj[b] = append(adj[b], pingTreeAdjacencyEntry{
+				tpID:     e.ID.String(),
+				tpType:   string(e.Type),
+				remotePK: a,
+			})
+		}
+	}
+	return adj
+}
+
+// candidatesFromAdjacency emits the next-level candidates for one
+// parent PK, marking each emitted remote PK as visited so siblings
+// at the same level don't re-emit it. parentPK and parentLevel are
+// recorded on each candidate for tree-rendering on the consumer.
+func candidatesFromAdjacency(
+	adj map[string][]pingTreeAdjacencyEntry,
+	pivotPK, parentPK string,
+	level int,
+	visited map[string]bool,
+) []pingTreeCandidate {
+	neighbors := adj[pivotPK]
+	out := make([]pingTreeCandidate, 0, len(neighbors))
+	for _, n := range neighbors {
+		if visited[n.remotePK] {
+			continue
+		}
+		visited[n.remotePK] = true
+		out = append(out, pingTreeCandidate{
+			tpID:     n.tpID,
+			tpType:   n.tpType,
+			remotePK: n.remotePK,
+			parentPK: parentPK,
+			level:    level,
+		})
+	}
+	return out
+}
+
+func candidateToDiscovered(c pingTreeCandidate) *PingTreeDiscovered {
+	return &PingTreeDiscovered{
+		TpId:     c.tpID,
+		TpType:   c.tpType,
+		RemotePk: c.remotePK,
+		ParentPk: c.parentPK,
+		Level:    int32(c.level), //nolint:gosec // BFS level fits int32
+	}
+}
+
+func pksFromCandidates(cs []pingTreeCandidate) map[string]bool {
+	out := make(map[string]bool, len(cs))
+	for _, c := range cs {
+		out[c.remotePK] = true
+	}
+	return out
+}
+
+func levelDoneFor(candidates []pingTreeCandidate, level int) *PingTreeLevelDone {
+	// Note: at the moment we don't track per-level success/failure on
+	// totals (only run-wide). For LevelDone we compute the
+	// per-candidate-count as proxy for "attempted" — the per-level
+	// success/failed breakout would require an additional
+	// per-level totals struct. Acceptable initial fidelity; harness
+	// consumers can derive the same values by counting PingResult
+	// events between LevelDone boundaries.
+	return &PingTreeLevelDone{
+		Level:     int32(level),           //nolint:gosec // BFS level int fits int32
+		Attempted: int32(len(candidates)), //nolint:gosec // candidate count fits int32
+		// TODO: tally per-level Succeeded/Failed/SkippedCached when
+		// the use_transport_latency fast-path lands and the
+		// per-level distinction matters for that PR's tests.
+	}
+}
+
+// itoa is a 1-allocation int-to-string used in StatusUpdate phase
+// strings. Avoids pulling strconv just for this.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/visor/rpcgrpc/server_ping_tree_test.go
+++ b/pkg/visor/rpcgrpc/server_ping_tree_test.go
@@ -1,0 +1,254 @@
+package rpcgrpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// TestNormalizePingTreeRequest pins the "0 = default" fallback
+// table. Without these, a zero-valued request would either run
+// forever (zero timeout) or hammer the visor with zero-concurrency
+// (no parallelism) or zero-tries (no measurements). Concrete defaults
+// keep an unconfigured call usable.
+func TestNormalizePingTreeRequest(t *testing.T) {
+	t.Run("zero request falls back to all defaults", func(t *testing.T) {
+		req := &PingTreeRequest{}
+		c := normalizePingTreeRequest(req)
+		if c.Tries != defaultPingTreeTries {
+			t.Errorf("Tries default = %d, want %d", c.Tries, defaultPingTreeTries)
+		}
+		if c.PacketSizeKb != defaultPingTreePacketSizeKb {
+			t.Errorf("PacketSizeKb default = %d, want %d", c.PacketSizeKb, defaultPingTreePacketSizeKb)
+		}
+		if c.PingTimeout != defaultPingTreePingTimeout {
+			t.Errorf("PingTimeout default = %v, want %v", c.PingTimeout, defaultPingTreePingTimeout)
+		}
+		if c.SetupTimeout != defaultPingTreeSetupTimeout {
+			t.Errorf("SetupTimeout default = %v, want %v", c.SetupTimeout, defaultPingTreeSetupTimeout)
+		}
+		if c.Concurrency != defaultPingTreeConcurrency {
+			t.Errorf("Concurrency default = %d, want %d", c.Concurrency, defaultPingTreeConcurrency)
+		}
+	})
+
+	t.Run("explicit values pass through", func(t *testing.T) {
+		req := &PingTreeRequest{
+			MaxLevel:            5,
+			Hops:                3,
+			Tries:               10,
+			PacketSizeKb:        64,
+			PingTimeoutNs:       (5 * time.Second).Nanoseconds(),
+			SetupTimeoutNs:      (15 * time.Second).Nanoseconds(),
+			Concurrency:         32,
+			OnlineOnly:          true,
+			MinVersion:          "v1.3.0",
+			UseTransportLatency: true,
+			DmsgOnly:            true,
+			DmsgPreCheck:        true,
+			Retries:             2,
+			DryRun:              true,
+		}
+		c := normalizePingTreeRequest(req)
+		if c.MaxLevel != 5 || c.Hops != 3 || c.Tries != 10 || c.PacketSizeKb != 64 {
+			t.Errorf("explicit values lost: %+v", c)
+		}
+		if c.PingTimeout != 5*time.Second || c.SetupTimeout != 15*time.Second {
+			t.Errorf("timeout values lost: ping=%v setup=%v", c.PingTimeout, c.SetupTimeout)
+		}
+		if c.Concurrency != 32 {
+			t.Errorf("Concurrency = %d, want 32", c.Concurrency)
+		}
+		if !c.OnlineOnly || c.MinVersion != "v1.3.0" || !c.UseTransportLatency ||
+			!c.DmsgOnly || !c.DmsgPreCheck || c.Retries != 2 || !c.DryRun {
+			t.Errorf("bool/string passthrough lost: %+v", c)
+		}
+	})
+
+	t.Run("negative values fall back to defaults", func(t *testing.T) {
+		// Proto fields are int32 so negative-encoded values are
+		// theoretically possible; treat them as "default" rather than
+		// propagate nonsense into the run loop.
+		req := &PingTreeRequest{
+			Tries:        -5,
+			PacketSizeKb: -100,
+			Concurrency:  -1,
+		}
+		c := normalizePingTreeRequest(req)
+		if c.Tries != defaultPingTreeTries {
+			t.Errorf("negative Tries should default, got %d", c.Tries)
+		}
+		if c.PacketSizeKb != defaultPingTreePacketSizeKb {
+			t.Errorf("negative PacketSizeKb should default, got %d", c.PacketSizeKb)
+		}
+		if c.Concurrency != defaultPingTreeConcurrency {
+			t.Errorf("negative Concurrency should default, got %d", c.Concurrency)
+		}
+	})
+}
+
+// TestAggregatePingSamples pins the stats math (avg/p50/p99/jitter).
+// Synth's directive specifically calls out jitter as a measurement
+// target, so the formula choice (population stddev) is locked in
+// here against accidental changes.
+func TestAggregatePingSamples(t *testing.T) {
+	t.Run("empty samples yields zeros", func(t *testing.T) {
+		avg, p50, p99, jitter := aggregatePingSamples(nil)
+		if avg != 0 || p50 != 0 || p99 != 0 || jitter != 0 {
+			t.Errorf("empty: got avg=%d p50=%d p99=%d jitter=%d, want all 0",
+				avg, p50, p99, jitter)
+		}
+	})
+
+	t.Run("single sample: avg=p50=p99, jitter=0", func(t *testing.T) {
+		// stddev undefined for n<2; the handler returns 0 by
+		// definition (documented on PingTreeResult.jitter_ns).
+		avg, p50, p99, jitter := aggregatePingSamples([]float64{500})
+		if avg != 500 || p50 != 500 || p99 != 500 {
+			t.Errorf("single: got avg=%d p50=%d p99=%d, want all 500", avg, p50, p99)
+		}
+		if jitter != 0 {
+			t.Errorf("single: jitter = %d, want 0 (undefined for n<2)", jitter)
+		}
+	})
+
+	t.Run("uniform samples have zero jitter", func(t *testing.T) {
+		// Population stddev of an all-same series is 0.
+		_, _, _, jitter := aggregatePingSamples([]float64{100, 100, 100, 100, 100})
+		if jitter != 0 {
+			t.Errorf("uniform: jitter = %d, want 0", jitter)
+		}
+	})
+
+	t.Run("five-sample series exercises percentile + stddev", func(t *testing.T) {
+		// Series: 100, 200, 300, 400, 500
+		// avg = 300
+		// sorted [100,200,300,400,500] → p50 = idx 2 (300), p99 = idx 4 (500)
+		// Population stddev: sqrt(sum((x - mean)^2) / N)
+		//   sum of squares = 40000 + 10000 + 0 + 10000 + 40000 = 100000
+		//   stddev = sqrt(100000 / 5) = sqrt(20000) ≈ 141.42
+		avg, p50, p99, jitter := aggregatePingSamples([]float64{100, 200, 300, 400, 500})
+		if avg != 300 {
+			t.Errorf("avg = %d, want 300", avg)
+		}
+		if p50 != 300 {
+			t.Errorf("p50 = %d, want 300", p50)
+		}
+		if p99 != 500 {
+			t.Errorf("p99 = %d, want 500", p99)
+		}
+		// Jitter as int64 nanoseconds: sqrt(20000) ≈ 141, give it
+		// ±2 slack for the int conversion.
+		if jitter < 139 || jitter > 143 {
+			t.Errorf("jitter = %d, want ~141 (population stddev of the series)", jitter)
+		}
+	})
+
+	t.Run("unsorted input produces same result as sorted", func(t *testing.T) {
+		a1, p501, p991, j1 := aggregatePingSamples([]float64{300, 100, 500, 200, 400})
+		a2, p502, p992, j2 := aggregatePingSamples([]float64{100, 200, 300, 400, 500})
+		if a1 != a2 || p501 != p502 || p991 != p992 || j1 != j2 {
+			t.Errorf("unsorted gave different result: (%d,%d,%d,%d) vs (%d,%d,%d,%d)",
+				a1, p501, p991, j1, a2, p502, p992, j2)
+		}
+	})
+}
+
+// TestBuildPingTreeAdjacency pins the adjacency-map structure.
+// Operator-visible behavior: every transport produces TWO edges
+// (one per direction) so BFS can walk in either direction. Self-
+// loops (edge a == edge b) only contribute one edge to avoid
+// double-counting in the BFS frontier.
+func TestBuildPingTreeAdjacency(t *testing.T) {
+	pk := func(b byte) cipher.PubKey {
+		var p cipher.PubKey
+		p[0] = 0x02
+		p[1] = b
+		return p
+	}
+	pkA, pkB, pkC := pk(0xa1), pk(0xb1), pk(0xc1)
+	t1 := uuid.New()
+	t2 := uuid.New()
+
+	entries := []*transport.Entry{
+		{ID: t1, Edges: [2]cipher.PubKey{pkA, pkB}, Type: tptypes.STCPR},
+		{ID: t2, Edges: [2]cipher.PubKey{pkB, pkC}, Type: tptypes.SUDPH},
+	}
+	adj := buildPingTreeAdjacency(entries)
+
+	a, b, c := pkA.String(), pkB.String(), pkC.String()
+
+	if len(adj[a]) != 1 || adj[a][0].remotePK != b {
+		t.Errorf("a's neighbors = %+v, want [%s]", adj[a], b)
+	}
+	if len(adj[b]) != 2 {
+		t.Errorf("b's neighbors = %+v, want 2 entries", adj[b])
+	}
+	if len(adj[c]) != 1 || adj[c][0].remotePK != b {
+		t.Errorf("c's neighbors = %+v, want [%s]", adj[c], b)
+	}
+}
+
+// TestCandidatesFromAdjacency pins the dedup-by-remote-PK behavior.
+// If a peer is reachable via multiple transports we only emit one
+// candidate (the BFS pings the peer, not the transport — the
+// route-finder chooses transport).
+func TestCandidatesFromAdjacency(t *testing.T) {
+	pkLocal := "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+	pkPeer1 := "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36"
+	pkPeer2 := "03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c"
+
+	// Local has 3 transports: stcpr+sudph to peer1, stcpr to peer2.
+	adj := map[string][]pingTreeAdjacencyEntry{
+		pkLocal: {
+			{tpID: "tp-stcpr-1", tpType: "stcpr", remotePK: pkPeer1},
+			{tpID: "tp-sudph-1", tpType: "sudph", remotePK: pkPeer1},
+			{tpID: "tp-stcpr-2", tpType: "stcpr", remotePK: pkPeer2},
+		},
+	}
+	visited := map[string]bool{pkLocal: true}
+	out := candidatesFromAdjacency(adj, pkLocal, pkLocal, 1, visited)
+	if len(out) != 2 {
+		t.Fatalf("got %d candidates, want 2 (dedup by remote PK)", len(out))
+	}
+	// Verify both peers are present.
+	got := map[string]bool{}
+	for _, c := range out {
+		got[c.remotePK] = true
+	}
+	if !got[pkPeer1] || !got[pkPeer2] {
+		t.Errorf("missing peer: got %v", got)
+	}
+	// Verify visited is updated so subsequent calls skip them.
+	out2 := candidatesFromAdjacency(adj, pkLocal, pkLocal, 1, visited)
+	if len(out2) != 0 {
+		t.Errorf("second call should produce 0 candidates (all visited), got %d", len(out2))
+	}
+}
+
+// TestPingTreeTotalsBumpInFlight pins peak-tracking. Operator can't
+// tune concurrency without knowing what peak was actually hit, so the
+// RunDone.PeakInFlight metric needs to be correct under contention.
+func TestPingTreeTotalsBumpInFlight(t *testing.T) {
+	tot := &pingTreeTotals{}
+	tot.bumpInFlight(1)
+	tot.bumpInFlight(1)
+	tot.bumpInFlight(1)
+	tot.bumpInFlight(-1)
+	tot.bumpInFlight(1)
+	tot.bumpInFlight(-1)
+	tot.bumpInFlight(-1)
+	tot.bumpInFlight(-1)
+
+	if tot.peakInFlight != 3 {
+		t.Errorf("peak = %d, want 3 (max of 1,2,3,2,3,2,1,0)", tot.peakInFlight)
+	}
+	if tot.currentInFlight != 0 {
+		t.Errorf("current = %d, want 0 (balanced bumps)", tot.currentInFlight)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new RPC `StreamPingTree` to `pkg/visor/rpcgrpc.PingService` that runs the BFS server-side. Re-implements the latency-by-hop-count measurement tool (synth's directive from May 11) properly so it can drive the kind of measurements that have been deferred for two weeks.

Replaces the structural-problem path in the current `cli visor ping tree`:

| Old `cli visor ping tree` | New `cli visor ping tree-stream` |
|---|---|
| Client-side BFS, RPC per ping | Server-side BFS, one stream per run |
| Default concurrency=2 (visor with 500+ tps never finishes level 1) | Default concurrency=16, configurable |
| Renderer hides pending entries — masks progress | Discovered + ping_result events fire as they happen |
| Bubble Tea TUI; can't run without /dev/tty | NDJSON to stdout — CI/coding-agent friendly |
| No `ctx.Done()` observation between levels | Observed at every BFS iteration |

## Wire shape (pkg/visor/rpcgrpc/ping.proto)

```proto
rpc StreamPingTree(PingTreeRequest) returns (stream PingTreeEvent);

message PingTreeEvent {
  int64 timestamp_ns = 1;
  oneof payload {
    PingTreeDiscovered discovered = 10;
    PingTreeResult ping_result = 11;
    PingTreeLevelDone level_done = 12;
    PingTreeRunDone run_done = 13;
    PingTreeStatusUpdate status_update = 14;
    PingTreeServerError server_error = 15;
  }
}
```

`PingTreeResult` carries the full per-peer stats: `sample_count`, `ping_avg_ns`, `ping_p50_ns`, `ping_p99_ns`, `jitter_ns` (population stddev), `setup_latency_ns`, `latency_source` (`"live_ping"` | `"transport_summary"` | `"skipped"`), and the route hops.

## CLI

New subcommand `cli visor ping tree-stream` is a thin gRPC consumer that emits one NDJSON line per event to stdout. Existing `cli visor ping tree` (Bubble Tea TUI) is untouched — a follow-up will rewire it onto the same stream.

```bash
# Synth's latency-by-hop-count measurement:
skywire cli visor ping tree-stream --hops 1 --tries 5 \
  | jq -c 'select(.type=="ping_result" and .data.failed != true) | {
      pk: .data.remote_pk,
      avg_ms: (.data.ping_avg_ns | tonumber / 1e6),
      jitter_ms: (.data.jitter_ns | tonumber / 1e6)
    }'
```

## Design choices (reviewed with Beta + Gamma)

The shape reflects pair-channel design review with both peer agents:

- **Per-level concurrency** (not total) — predictable LevelDone semantics, bounded fan-out at deep levels
- **Same `PingResult` event for cached vs live**, with `latency_source` discriminator — better consumer ergonomics than branching on event type
- **Separate `StreamMuxBandwidth` RPC** (deferred, not in this PR) for the multiplexed-route bandwidth measurement — different sampling shape from probe RTT
- **Bounded internal event channel (256)** with drop-StatusUpdate-before-PingResult policy — backpressure visible, measurement data never dropped
- **ctx.Done() observed at every BFS iteration** — client disconnect tears down within one in-flight ping
- **`tpM.WalkTransports`** directly rather than the snapshot-allocating `Transports()` unary RPC

## Verified end-to-end

Tested on a 426-transport visor:

- 65+ `discovered` events emit immediately on bind
- `ping_result` events flow live as each ping completes
- Successful pings carry real RTT + jitter stats:
  ```
  {"setup_latency_ns":"170710214","sample_count":2,"ping_avg_ns":"287931103",
   "ping_p50_ns":"290004599","ping_p99_ns":"290004599","jitter_ns":"2073496",
   "latency_source":"live_ping"}
  ```
- Failed pings surface the visor's internal error string verbatim
- `RunDone` carries `total_*` + `wall_time_ns` + `peak_in_flight` + `termination_reason`

## Tests

- `TestNormalizePingTreeRequest`: zero/explicit/negative passthrough
- `TestAggregatePingSamples`: empty/single/uniform/5-sample series, pinned to population-stddev formula
- `TestBuildPingTreeAdjacency`: bidirectional edge construction
- `TestCandidatesFromAdjacency`: dedup by remote PK
- `TestPingTreeTotalsBumpInFlight`: peak-tracking under contention

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l` clean
- [x] `golangci-lint run` clean (zero issues)
- [x] All new unit tests pass
- [x] Manual smoke test on local visor (426 transports): events stream as designed
- [ ] Operator runs the synth latency-by-hop measurement and confirms output usability

## Follow-ups (stack-friendly, called out for peer agents)

1. **`use_transport_latency` fast-path** — at level 1, consult `TransportSummary.LatencyMS` (already populated from `tp.GetLatency()`) and skip the live ping when non-zero. Beta's slice per design-review role split. ~30-50 line patch with the hook already in place in `pingOneTransport`.
2. **`pkg/util/treeprobe` harness consumer** — Go consumer of `PingTreeEvent` that builds (level, peer) → metrics rollup, joins with TPD bandwidth metrics, emits CSV for the synth/operator measurement matrix. Gamma's slice.
3. **Rewire the Bubble Tea TUI** in `cmd/skywire-cli/commands/visor/ping/tree.go` to consume the same `StreamPingTree` stream. Removes the 2000+ lines of client-side BFS state machinery.
4. **Authorization gate** on the dmsg-port entry point (this PR runs unauthenticated for development; local unix-socket use is filesystem-permission-trusted, but the dmsg-port gRPC needs a whitelist check before opening to the network).
5. **`StreamMuxBandwidth` RPC** for the multiplexed-route bandwidth measurement — separate RPC because the sampling shape is continuous-throughput rather than N-probes-per-peer.