### PR TITLE
feat(visor/ping-tree): use_transport_latency fast path at level-1

### DIFF
--- a/pkg/visor/api_transport.go
+++ b/pkg/visor/api_transport.go
@@ -261,6 +261,32 @@ func (v *Visor) RemoveAllTransports() error {
 	return nil
 }
 
+// GetTransportLatencyByRemotePK returns the smoothed average RTT
+// in milliseconds for the local managed transport to remotePK, or
+// 0 if no such transport exists or its latency is not yet sampled.
+//
+// Used by the ping-tree streaming RPC's UseTransportLatency
+// fast-path: at level-1 (direct neighbors) the visor already has
+// continuously-sampled transport-level RTT; re-pinging would
+// duplicate work without adding signal. Returning 0 lets the
+// caller fall back to a live ping when the transport doesn't yet
+// have measurements (e.g. just-established).
+//
+// O(N) over local transports. Stops on first match. Callers should
+// not invoke per-packet — this is intended for the BFS level-1
+// pass where N is the direct-neighbor count.
+func (v *Visor) GetTransportLatencyByRemotePK(remotePK cipher.PubKey) float64 {
+	var latency float64
+	v.tpM.WalkTransports(func(tp *transport.ManagedTransport) bool {
+		if tp.Remote() == remotePK {
+			latency = tp.GetLatency()
+			return false // stop walk
+		}
+		return true
+	})
+	return latency
+}
+
 // DiscoverTransportsByPK implements API.
 func (v *Visor) DiscoverTransportsByPK(pk cipher.PubKey) ([]*transport.Entry, error) {
 	tpD := v.tpDiscClient()

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -409,6 +409,10 @@ func (a *visorPingAdapter) FetchAllTransportEntries(ctx context.Context) ([]*tra
 	return a.v.FetchAllTransportEntries(ctx)
 }
 
+func (a *visorPingAdapter) GetTransportLatencyByRemotePK(remotePK cipher.PubKey) float64 {
+	return a.v.GetTransportLatencyByRemotePK(remotePK)
+}
+
 func (a *visorPingAdapter) DialDmsgRPC(pk cipher.PubKey) (net.Conn, error) {
 	return a.v.DialDmsgRPC(pk)
 }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -93,6 +93,11 @@ type VisorAPI interface {
 	// the visor's existing discovery client. The route-calc gRPC
 	// handler builds the BFS graph from this slice.
 	FetchAllTransportEntries(ctx context.Context) ([]*transport.Entry, error)
+	// GetTransportLatencyByRemotePK returns the smoothed avg RTT (ms)
+	// for the local managed transport to remotePK, or 0 if no such
+	// transport exists or its latency is not yet sampled. Powers the
+	// ping-tree UseTransportLatency fast-path at level-1.
+	GetTransportLatencyByRemotePK(remotePK cipher.PubKey) float64
 }
 
 // GroupMessageData mirrors visor.GroupMessage one-for-one but lives in

--- a/pkg/visor/rpcgrpc/server_ping_tree.go
+++ b/pkg/visor/rpcgrpc/server_ping_tree.go
@@ -379,9 +379,13 @@ func (s *PingServer) sendServerError(stream PingService_StreamPingTreeServer, co
 // complete (success, failure, or ctx-cancel). Updates totals
 // atomically; emits one PingResult per candidate.
 //
-// First cut: live-ping only via DialPing + PingOnce. The
-// use_transport_latency fast path that consults
-// TransportSummary.LatencyMS is a follow-up (Beta's slice).
+// When UseTransportLatency is set and level == 1, candidates whose
+// remote PK has a local managed transport with a non-zero smoothed
+// RTT are short-circuited: a PingResult with
+// LatencySource="transport_summary" is emitted without sending a
+// live ping. Saves a full setup+ping cycle on direct neighbors the
+// visor is already measuring. Candidates without a known transport
+// latency fall through to the live-ping path.
 func (s *PingServer) pingTreePingLevel(
 	ctx context.Context,
 	cfg *pingTreeCfg,
@@ -401,6 +405,25 @@ func (s *PingServer) pingTreePingLevel(
 		if ctx.Err() != nil {
 			break
 		}
+
+		// UseTransportLatency fast-path: only at level-1 (direct
+		// neighbors). Beyond level-1 there's no local transport to
+		// the candidate — must live-ping through intermediates.
+		if level == 1 && cfg.UseTransportLatency {
+			if result, hit := s.tryTransportLatencyFastPath(c); hit {
+				emit(&PingTreeEvent_PingResult{PingResult: result})
+				atomic.AddInt32(&totals.skippedCached, 1)
+				atomic.AddInt32(&pending, -1)
+				emitStatus(
+					"pinging_level_"+itoa(level),
+					atomic.LoadInt32(&totals.currentInFlight),
+					atomic.LoadInt32(&pending),
+					"",
+				)
+				continue
+			}
+		}
+
 		sem <- struct{}{}
 		wg.Add(1)
 		atomic.AddInt32(&pending, -1)
@@ -429,6 +452,47 @@ func (s *PingServer) pingTreePingLevel(
 	}
 
 	wg.Wait()
+}
+
+// tryTransportLatencyFastPath returns (result, true) when the
+// candidate's remote PK has a local managed transport with a
+// non-zero smoothed RTT; the result is a PingTreeResult with
+// LatencySource="transport_summary" suitable for emission. Returns
+// (nil, false) when no such transport exists, the PK is malformed,
+// or the transport's latency has not yet been sampled — caller
+// should fall through to live-ping.
+func (s *PingServer) tryTransportLatencyFastPath(cand pingTreeCandidate) (*PingTreeResult, bool) {
+	var pk cipher.PubKey
+	if err := pk.Set(cand.remotePK); err != nil {
+		return nil, false
+	}
+	latencyMS := s.visor.GetTransportLatencyByRemotePK(pk)
+	return transportLatencyResult(cand, latencyMS)
+}
+
+// transportLatencyResult is the pure-data half of the fast path:
+// given a candidate and a smoothed RTT in milliseconds, return the
+// PingTreeResult to emit, or (nil, false) when the latency value is
+// not usable. Split out from tryTransportLatencyFastPath so the
+// numeric conversion + skip-condition logic is unit-testable
+// without constructing a full VisorAPI mock.
+func transportLatencyResult(cand pingTreeCandidate, latencyMS float64) (*PingTreeResult, bool) {
+	if latencyMS <= 0 {
+		return nil, false
+	}
+	pingNs := int64(latencyMS * float64(time.Millisecond))
+	return &PingTreeResult{
+		TpId:          cand.tpID,
+		TpType:        cand.tpType,
+		RemotePk:      cand.remotePK,
+		ParentPk:      cand.parentPK,
+		Level:         int32(cand.level), //nolint:gosec // BFS level fits int32
+		LatencySource: "transport_summary",
+		PingAvgNs:     pingNs,
+		PingP50Ns:     pingNs,
+		PingP99Ns:     pingNs,
+		SampleCount:   1,
+	}, true
 }
 
 // pingOneTransport runs a single transport's worth of pings (tries

--- a/pkg/visor/rpcgrpc/server_ping_tree_test.go
+++ b/pkg/visor/rpcgrpc/server_ping_tree_test.go
@@ -252,3 +252,68 @@ func TestPingTreeTotalsBumpInFlight(t *testing.T) {
 		t.Errorf("current = %d, want 0 (balanced bumps)", tot.currentInFlight)
 	}
 }
+
+// TestTransportLatencyResult pins the numeric conversion + skip
+// table for the use_transport_latency fast path. Tests the pure
+// half of tryTransportLatencyFastPath so a regression doesn't need
+// a VisorAPI mock to catch.
+func TestTransportLatencyResult(t *testing.T) {
+	cand := pingTreeCandidate{
+		tpID:     uuid.NewString(),
+		tpType:   string(tptypes.STCPR),
+		remotePK: "030c42c98b6bf4a85aa09dbea39872ed94c57c673992810e58ad809d8f586e4444",
+		parentPK: "020e26d9f0da46daec8d3dccff5c100dd03685f7cbe608d93a8e8190892979f2a0",
+		level:    1,
+	}
+
+	t.Run("zero latency falls through to live ping", func(t *testing.T) {
+		r, ok := transportLatencyResult(cand, 0)
+		if ok || r != nil {
+			t.Errorf("zero latency: got (%+v, %v); want (nil, false)", r, ok)
+		}
+	})
+
+	t.Run("negative latency falls through (sentinel for unsampled)", func(t *testing.T) {
+		r, ok := transportLatencyResult(cand, -1.5)
+		if ok || r != nil {
+			t.Errorf("negative latency: got (%+v, %v); want (nil, false)", r, ok)
+		}
+	})
+
+	t.Run("12.5 ms maps to 12_500_000 ns across all three percentiles", func(t *testing.T) {
+		r, ok := transportLatencyResult(cand, 12.5)
+		if !ok || r == nil {
+			t.Fatalf("expected fast-path hit, got (%+v, %v)", r, ok)
+		}
+		const wantNs = 12_500_000
+		if r.PingAvgNs != wantNs || r.PingP50Ns != wantNs || r.PingP99Ns != wantNs {
+			t.Errorf("ns conversion: avg=%d p50=%d p99=%d, want %d each",
+				r.PingAvgNs, r.PingP50Ns, r.PingP99Ns, wantNs)
+		}
+		if r.LatencySource != "transport_summary" {
+			t.Errorf("LatencySource = %q, want %q", r.LatencySource, "transport_summary")
+		}
+		if r.SampleCount != 1 {
+			t.Errorf("SampleCount = %d, want 1 (single smoothed sample)", r.SampleCount)
+		}
+		if r.Level != 1 {
+			t.Errorf("Level = %d, want 1 (fast path is level-1 only)", r.Level)
+		}
+		if r.RemotePk != cand.remotePK || r.TpId != cand.tpID {
+			t.Errorf("candidate fields not preserved: pk=%q tpID=%q", r.RemotePk, r.TpId)
+		}
+	})
+
+	t.Run("sub-millisecond latency rounds to ns floor", func(t *testing.T) {
+		// 0.5 ms = 500_000 ns. The int64 truncation is intentional;
+		// transport-level smoothing already has sub-ms-grained
+		// values clamped by SmoothedRTT's resolution.
+		r, ok := transportLatencyResult(cand, 0.5)
+		if !ok || r == nil {
+			t.Fatalf("expected fast-path hit on 0.5ms")
+		}
+		if r.PingAvgNs != 500_000 {
+			t.Errorf("0.5ms → %d ns, want 500_000", r.PingAvgNs)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Implements the `UseTransportLatency` fast path at level-1 of the streaming ping-tree RPC. #2732 plumbed the proto field + config through but left the actual short-circuit as a follow-up:

> First cut: live-ping only via DialPing + PingOnce. The use_transport_latency fast path that consults TransportSummary.LatencyMS is a follow-up (Beta's slice).

Closes that.

## Behavior
When `UseTransportLatency=true` AND BFS level == 1, each candidate's local managed transport's smoothed RTT is consulted before scheduling a live ping. When non-zero:
- A `PingResult` with `LatencySource="transport_summary"` is emitted immediately
- `totals.skipped_cached` is incremented; `totals.pinged` is not
- `PingP50Ns / PingP99Ns / PingAvgNs` all carry the single smoothed value with `SampleCount=1` (consumers see consistent percentile fields without special-casing the source)
- The live ping is skipped entirely (no setup, no dial, no PingOnce)

Candidates whose transport latency is zero (just-established, not yet sampled) fall through to the live-ping path unchanged. Levels ≥2 never take the fast path — by definition no local transport exists to a peer reached through an intermediate.

## Surface
- **`VisorAPI.GetTransportLatencyByRemotePK(remotePK)`** — new method on the rpcgrpc adapter interface.
- **`Visor.GetTransportLatencyByRemotePK`** — walks transports via the existing `tpM.WalkTransports` primitive (early-exits on first match). O(N) over local transports; called once per level-1 candidate. Lighter than `Transports()` which builds a full `[]*TransportSummary` snapshot.
- **`transportLatencyResult`** — pure-data helper split out of `tryTransportLatencyFastPath` so the numeric conversion + skip semantics are unit-testable without constructing a VisorAPI mock.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/visor/...` — green, including all existing rpcgrpc tests
- [x] New `TestTransportLatencyResult` — 4 subtests pin: zero/negative latency → skip; 12.5ms → 12_500_000ns across all three percentiles; sub-ms rounds to ns floor; candidate fields preserved through the conversion
- [x] `make format` clean

Refs #2732 (server-side ping-tree gRPC streaming).