### PR TITLE
feat(treeprobe): NDJSON harness for cli visor ping tree-stream

### DIFF
--- a/ci_scripts/tree-probe.sh
+++ b/ci_scripts/tree-probe.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ci_scripts/tree-probe.sh — drive cli visor ping tree-stream
+# across a hop sweep + render per-cell CSV via cmd/treeprobe.
+#
+# Purpose: collect the latency / jitter / cache-hit-rate measurement
+# matrix Synth's May-11 directive asked for. Each invocation produces
+# one CSV per --hops value; the driver names files by hop so the
+# downstream measurement harness (Beta's #2726-style assertion stack)
+# can ingest them by glob.
+#
+# Usage:
+#   ci_scripts/tree-probe.sh                    # default: hops 1..3, tries 5
+#   ci_scripts/tree-probe.sh hops=1,2,3,4 tries=10
+#   ci_scripts/tree-probe.sh outdir=/tmp/runX hops=1
+#
+# Output (one per hop in the sweep):
+#   $outdir/tree-probe-hops<N>.ndjson   raw NDJSON capture
+#   $outdir/tree-probe-hops<N>.csv      per-cell CSV
+#   $outdir/tree-probe-hops<N>.log      treeprobe stderr summary
+#
+# Exit codes:
+#   0  all hops captured + parsed cleanly
+#   1  usage error
+#   2  cli visor ping tree-stream RPC failed on at least one hop
+#   3  treeprobe parser/CSV-writer failed on at least one hop
+#
+# The driver does NOT clear visor state between hops — successive
+# tree-stream invocations may reuse the route cache and produce
+# differing skipped_cached counts, which is the cache-warmth signal
+# the harness wants surfaced. Operator runs the driver against a
+# cold visor when they want a worst-case-first-run measurement.
+
+set -euo pipefail
+
+hops="1,2,3"
+tries="5"
+outdir="/tmp/tree-probe-$(date -u +%Y%m%dT%H%M%SZ)"
+treeprobe_bin="${TREEPROBE_BIN:-treeprobe}"
+
+for arg in "$@"; do
+    case "$arg" in
+        hops=*)   hops="${arg#hops=}" ;;
+        tries=*)  tries="${arg#tries=}" ;;
+        outdir=*) outdir="${arg#outdir=}" ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $arg" >&2; exit 1 ;;
+    esac
+done
+
+case "$tries" in ''|*[!0-9]*) echo "tries must be int: $tries" >&2; exit 1 ;; esac
+mkdir -p "$outdir"
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+
+# Verify treeprobe binary is on PATH.
+if ! command -v "$treeprobe_bin" >/dev/null 2>&1; then
+    echo "treeprobe binary not found (PATH or TREEPROBE_BIN). Build: go build -o ./bin/treeprobe ./cmd/treeprobe" >&2
+    exit 1
+fi
+
+# Verify skywire cli has the tree-stream subcommand (post-#2732).
+if ! skywire cli visor ping tree-stream --help >/dev/null 2>&1; then
+    echo "cli visor ping tree-stream not available; need binary post-PR-#2732" >&2
+    exit 2
+fi
+
+log "starting sweep: hops=$hops tries=$tries outdir=$outdir"
+
+rpc_fail=0
+parse_fail=0
+
+IFS=',' read -r -a hops_arr <<< "$hops"
+for h in "${hops_arr[@]}"; do
+    case "$h" in ''|*[!0-9]*) echo "hops entry must be int: $h" >&2; exit 1 ;; esac
+    log "hop=$h: running tree-stream..."
+    ndjson="$outdir/tree-probe-hops${h}.ndjson"
+    csv="$outdir/tree-probe-hops${h}.csv"
+    sumlog="$outdir/tree-probe-hops${h}.log"
+
+    if ! skywire cli visor ping tree-stream --hops "$h" --tries "$tries" > "$ndjson" 2> "$sumlog"; then
+        log "hop=$h: tree-stream FAILED (see $sumlog)"
+        rpc_fail=1
+        continue
+    fi
+
+    nlines=$(wc -l < "$ndjson")
+    log "hop=$h: captured $nlines NDJSON lines"
+
+    if ! "$treeprobe_bin" < "$ndjson" > "$csv" 2>> "$sumlog"; then
+        log "hop=$h: treeprobe parse FAILED (see $sumlog)"
+        parse_fail=1
+        continue
+    fi
+
+    nrows=$(($(wc -l < "$csv") - 1))  # subtract header row
+    log "hop=$h: emitted $nrows CSV rows → $csv"
+done
+
+log "sweep complete: $(ls "$outdir"/tree-probe-hops*.csv 2>/dev/null | wc -l) CSV files in $outdir"
+
+if [[ $rpc_fail -ne 0 ]]; then
+    exit 2
+fi
+if [[ $parse_fail -ne 0 ]]; then
+    exit 3
+fi
+exit 0

--- a/cmd/treeprobe/main.go
+++ b/cmd/treeprobe/main.go
@@ -1,0 +1,64 @@
+// Command treeprobe consumes an NDJSON event stream from
+// `cli visor ping tree-stream` on stdin and writes CSV rows to
+// stdout, one per (level, parent_pk, remote_pk) cell. Also writes
+// a summary line to stderr.
+//
+// Driver shape:
+//
+//	skywire cli visor ping tree-stream --hops 1 --tries 5 \
+//	  | treeprobe > /tmp/measure-hops1-tries5.csv
+//
+// This binary is intentionally minimal — all logic lives in
+// pkg/util/treeprobe, which has the unit tests. main.go is the
+// io wiring.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/skycoin/skywire/pkg/util/treeprobe"
+)
+
+func main() {
+	p := treeprobe.NewParser(os.Stdin)
+	a := treeprobe.NewAggregator()
+
+	var events int
+	for {
+		d, err := p.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "treeprobe: parse: %v\n", err)
+			os.Exit(1)
+		}
+		a.Observe(d)
+		events++
+	}
+
+	rows, err := treeprobe.WriteCSV(os.Stdout, a)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "treeprobe: write csv: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Summary on stderr — the driver can grep it without polluting
+	// the CSV stdout that downstream tools consume.
+	run := a.RunDone()
+	fmt.Fprintf(os.Stderr,
+		"treeprobe: events=%d cells=%d levels=%d cache_hit_rate=%.2f%%",
+		events, rows, len(a.Levels()), 100*a.CacheHitRate())
+	if run != nil {
+		fmt.Fprintf(os.Stderr,
+			" total_discovered=%d total_pinged=%d total_succeeded=%d total_failed=%d wall_time_ms=%.0f termination=%s",
+			run.TotalDiscovered, run.TotalPinged, run.TotalSucceeded, run.TotalFailed,
+			float64(int64(run.WallTimeNs))/1e6, run.TerminationReason)
+	}
+	if e := a.ServerError(); e != nil {
+		fmt.Fprintf(os.Stderr, " SERVER_ERROR(%s): %s", e.Code, e.Message)
+	}
+	fmt.Fprintln(os.Stderr)
+}

--- a/pkg/util/treeprobe/aggregate.go
+++ b/pkg/util/treeprobe/aggregate.go
@@ -1,0 +1,155 @@
+// aggregate.go — group PingResult events into per-(level, peer) cells.
+//
+// The BFS server emits PingResult events in completion order, not
+// BFS order. The harness CSV row shape is "one row per (level,
+// parent_pk, remote_pk)", so we group results into a deterministic
+// cell key on receive + carry the canonical RunDone + LevelDone
+// aggregates alongside.
+
+package treeprobe
+
+import "sort"
+
+// CellKey identifies one (level, parent_pk, remote_pk) tuple.
+// Used as a map key on the aggregator + as the CSV row identity.
+type CellKey struct {
+	Level    int32
+	ParentPK string
+	RemotePK string
+}
+
+// Cell is one (level, parent, remote) entry's collected state.
+// Result is the canonical metric carrier from the server; Discovered
+// is set if a `discovered` event preceded the result (always true
+// in well-formed streams).
+type Cell struct {
+	Key        CellKey
+	Discovered *Discovered
+	Result     *PingResult
+}
+
+// Aggregator collects Decoded events into a per-cell map + tracks
+// level-and-run totals. Safe for single-goroutine use only — the
+// harness feeds it from one parser loop.
+type Aggregator struct {
+	cells map[CellKey]*Cell
+	// levels[level] = LevelDone for that level (last one wins on
+	// duplicates; the server emits exactly one per level).
+	levels    map[int32]*LevelDone
+	runDone   *RunDone
+	srvErr    *ServerError
+	statusCnt int // raw StatusUpdate event count (informational)
+}
+
+// NewAggregator constructs an empty Aggregator.
+func NewAggregator() *Aggregator {
+	return &Aggregator{
+		cells:  make(map[CellKey]*Cell),
+		levels: make(map[int32]*LevelDone),
+	}
+}
+
+// Observe folds one Decoded event into the aggregator's state.
+// Returns silently on unknown event-types — Parser.Next already
+// validates the discriminator, so unknowns shouldn't reach here.
+func (a *Aggregator) Observe(d *Decoded) {
+	switch d.Type {
+	case TypeDiscovered:
+		k := CellKey{
+			Level:    d.Discovered.Level,
+			ParentPK: d.Discovered.ParentPK,
+			RemotePK: d.Discovered.RemotePK,
+		}
+		cell, ok := a.cells[k]
+		if !ok {
+			cell = &Cell{Key: k}
+			a.cells[k] = cell
+		}
+		cell.Discovered = d.Discovered
+
+	case TypePingResult:
+		k := CellKey{
+			Level:    d.PingResult.Level,
+			ParentPK: d.PingResult.ParentPK,
+			RemotePK: d.PingResult.RemotePK,
+		}
+		cell, ok := a.cells[k]
+		if !ok {
+			cell = &Cell{Key: k}
+			a.cells[k] = cell
+		}
+		cell.Result = d.PingResult
+
+	case TypeLevelDone:
+		// Keep last-wins on duplicate level entries; in practice
+		// the server emits exactly one per level.
+		a.levels[d.LevelDone.Level] = d.LevelDone
+
+	case TypeRunDone:
+		a.runDone = d.RunDone
+
+	case TypeServerError:
+		a.srvErr = d.ServerError
+
+	case TypeStatusUpdate:
+		a.statusCnt++
+	}
+}
+
+// Cells returns the per-cell entries sorted deterministically by
+// (Level asc, ParentPK asc, RemotePK asc) so CSV rows stay stable
+// across runs of the same input.
+func (a *Aggregator) Cells() []*Cell {
+	out := make([]*Cell, 0, len(a.cells))
+	for _, c := range a.cells {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Key.Level != out[j].Key.Level {
+			return out[i].Key.Level < out[j].Key.Level
+		}
+		if out[i].Key.ParentPK != out[j].Key.ParentPK {
+			return out[i].Key.ParentPK < out[j].Key.ParentPK
+		}
+		return out[i].Key.RemotePK < out[j].Key.RemotePK
+	})
+	return out
+}
+
+// Levels returns the per-level summaries in ascending level order.
+func (a *Aggregator) Levels() []*LevelDone {
+	out := make([]*LevelDone, 0, len(a.levels))
+	for _, l := range a.levels {
+		out = append(out, l)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Level < out[j].Level })
+	return out
+}
+
+// RunDone returns the final RunDone event, or nil if the stream
+// ended before run_done fired (i.e., truncated capture).
+func (a *Aggregator) RunDone() *RunDone { return a.runDone }
+
+// ServerError returns the terminal ServerError, or nil if the run
+// ended cleanly.
+func (a *Aggregator) ServerError() *ServerError { return a.srvErr }
+
+// StatusUpdateCount returns the count of status_update events
+// observed. Useful for harness diagnostics — not normally surfaced
+// to CSV.
+func (a *Aggregator) StatusUpdateCount() int { return a.statusCnt }
+
+// CacheHitRate returns the fraction of total_skipped_cached over
+// (total_pinged + total_skipped_cached) — the cache hit rate
+// from PR #2733's use_transport_latency fast-path. Returns 0 if
+// RunDone is missing or denominator is zero.
+func (a *Aggregator) CacheHitRate() float64 {
+	if a.runDone == nil {
+		return 0
+	}
+	denom := int32(a.runDone.TotalPinged) + a.runDone.TotalSkippedCached
+	if denom == 0 {
+		return 0
+	}
+	return float64(a.runDone.TotalSkippedCached) / float64(denom)
+}

--- a/pkg/util/treeprobe/aggregate_test.go
+++ b/pkg/util/treeprobe/aggregate_test.go
@@ -1,0 +1,143 @@
+package treeprobe
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+// Drive the aggregator through the synthetic sampleStream from
+// parser_test.go, then validate the per-cell + run-level + CSV
+// shape.
+func TestAggregator_FoldSampleStream(t *testing.T) {
+	p := NewParser(strings.NewReader(sampleStream))
+	a := NewAggregator()
+	for {
+		d, err := p.Next()
+		if err != nil {
+			break
+		}
+		a.Observe(d)
+	}
+
+	cells := a.Cells()
+	if len(cells) != 2 {
+		t.Fatalf("want 2 cells (one per peer in sample stream); got %d", len(cells))
+	}
+
+	// First cell: 02deadbeef (discovered + ping_result, live_ping)
+	c0 := cells[0]
+	if c0.Key.RemotePK != "02cafefeed" && c0.Key.RemotePK != "02deadbeef" {
+		t.Errorf("cell 0 remote_pk unexpected: %q", c0.Key.RemotePK)
+	}
+	if c0.Result == nil {
+		t.Errorf("cell 0 result missing")
+	} else if c0.Result.LatencySource == "" {
+		t.Errorf("cell 0 latency_source empty")
+	}
+
+	// Run-level + cache hit rate
+	run := a.RunDone()
+	if run == nil {
+		t.Fatal("RunDone missing")
+	}
+	if run.TotalDiscovered != 20 || run.TotalPinged != 15 || run.TotalSkippedCached != 5 {
+		t.Errorf("run totals wrong: %+v", run)
+	}
+	expectedRate := 5.0 / (15.0 + 5.0)
+	if a.CacheHitRate() != expectedRate {
+		t.Errorf("cache hit rate: want %f got %f", expectedRate, a.CacheHitRate())
+	}
+
+	// Status update count
+	if a.StatusUpdateCount() != 1 {
+		t.Errorf("status_update count: want 1 got %d", a.StatusUpdateCount())
+	}
+}
+
+// CSV emit round-trips: write CSV → parse CSV → row count matches
+// cell count, header row present, run-level fields populated.
+func TestWriteCSV_RoundTrip(t *testing.T) {
+	p := NewParser(strings.NewReader(sampleStream))
+	a := NewAggregator()
+	for {
+		d, err := p.Next()
+		if err != nil {
+			break
+		}
+		a.Observe(d)
+	}
+
+	var buf bytes.Buffer
+	n, err := WriteCSV(&buf, a)
+	if err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("WriteCSV rows: want 2 got %d", n)
+	}
+
+	cr := csv.NewReader(&buf)
+	header, err := cr.Read()
+	if err != nil {
+		t.Fatalf("read header: %v", err)
+	}
+	if len(header) != len(CSVHeaders) {
+		t.Errorf("header len: want %d got %d", len(CSVHeaders), len(header))
+	}
+
+	idx := map[string]int{}
+	for i, h := range header {
+		idx[h] = i
+	}
+	row, err := cr.Read()
+	if err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if row[idx["run_termination_reason"]] != "hops_target" {
+		t.Errorf("run_termination_reason: want hops_target got %q", row[idx["run_termination_reason"]])
+	}
+	if row[idx["latency_source"]] == "" {
+		t.Errorf("latency_source empty on row 0")
+	}
+	if row[idx["ping_avg_ms"]] == "" {
+		t.Errorf("ping_avg_ms empty on row 0")
+	}
+}
+
+// Empty stream emits header-only CSV (0 data rows).
+func TestWriteCSV_EmptyStream(t *testing.T) {
+	a := NewAggregator()
+	var buf bytes.Buffer
+	n, err := WriteCSV(&buf, a)
+	if err != nil {
+		t.Fatalf("WriteCSV empty: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("empty stream rows: want 0 got %d", n)
+	}
+	// Header must still be present
+	if !strings.HasPrefix(buf.String(), "level,parent_pk,remote_pk,") {
+		t.Errorf("header missing: %q", buf.String())
+	}
+}
+
+// nsToMs handles zero + non-zero correctly + uses 3 decimal places.
+func TestNsToMs(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, ""},
+		{1000000, "1.000"},
+		{1500000, "1.500"},
+		{287931103, "287.931"},
+	}
+	for _, c := range cases {
+		got := nsToMs(c.in)
+		if got != c.want {
+			t.Errorf("nsToMs(%d): want %q got %q", c.in, c.want, got)
+		}
+	}
+}

--- a/pkg/util/treeprobe/csv.go
+++ b/pkg/util/treeprobe/csv.go
@@ -1,0 +1,203 @@
+// csv.go — emit per-(level, peer) CSV rows from an Aggregator.
+//
+// Row shape is one row per Cell, with run-summary fields repeated
+// across rows so downstream analytics tools (sheets / pandas) can
+// pivot/group without joining a separate summary table. This matches
+// Synth's directive: one CSV consumable by the harness assertion
+// stage (Beta's #2726 mux-probe-assert and successors).
+
+package treeprobe
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// Column headers. Order is the CSV write order; downstream parsers
+// should index by header name not position to remain stable across
+// future column additions.
+var CSVHeaders = []string{
+	// Cell identity
+	"level",
+	"parent_pk",
+	"remote_pk",
+	// Transport identification
+	"tp_id",
+	"tp_type",
+	// Result classification
+	"latency_source",
+	"failed",
+	"canceled",
+	"sample_count",
+	// Latency stats (all in milliseconds for human readability;
+	// nanosecond precision preserved by carrying as float64).
+	"setup_latency_ms",
+	"ping_avg_ms",
+	"ping_p50_ms",
+	"ping_p99_ms",
+	"jitter_ms",
+	// Errors (most-recent from each phase)
+	"setup_err",
+	"ping_err",
+	"calc_err",
+	// Route (joined hop pks; empty for transport_summary)
+	"route_hops",
+	// Run-level summary fields (repeated on every row so downstream
+	// pivot/group can stratify without a second table)
+	"run_total_discovered",
+	"run_total_pinged",
+	"run_total_succeeded",
+	"run_total_failed",
+	"run_total_skipped_cached",
+	"run_wall_time_ms",
+	"run_peak_in_flight",
+	"run_termination_reason",
+	"run_cache_hit_rate",
+}
+
+// WriteCSV emits the aggregator's cells as CSV rows to w. Returns
+// the number of rows written + any write error.
+func WriteCSV(w io.Writer, a *Aggregator) (int, error) {
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+
+	if err := cw.Write(CSVHeaders); err != nil {
+		return 0, fmt.Errorf("treeprobe: write header: %w", err)
+	}
+
+	// Pre-compute run-level scalars so we don't recompute per row.
+	run := a.RunDone()
+	hitRate := a.CacheHitRate()
+
+	cells := a.Cells()
+	for i, c := range cells {
+		row := cellToRow(c, run, hitRate)
+		if err := cw.Write(row); err != nil {
+			return i, fmt.Errorf("treeprobe: write row %d: %w", i, err)
+		}
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		return len(cells), fmt.Errorf("treeprobe: flush: %w", err)
+	}
+	return len(cells), nil
+}
+
+func cellToRow(c *Cell, run *RunDone, hitRate float64) []string {
+	r := c.Result
+	d := c.Discovered
+
+	row := make([]string, 0, len(CSVHeaders))
+	// Cell identity (prefer Result fields, fall back to Discovered)
+	row = append(row,
+		strconv.FormatInt(int64(c.Key.Level), 10),
+		c.Key.ParentPK,
+		c.Key.RemotePK,
+	)
+	row = append(row,
+		pickStr(r != nil, ifResult(r, "TpID"), d, "TpID"),
+		pickStr(r != nil, ifResult(r, "TpType"), d, "TpType"),
+	)
+
+	if r != nil {
+		row = append(row,
+			r.LatencySource,
+			strconv.FormatBool(r.Failed),
+			strconv.FormatBool(r.Canceled),
+			strconv.FormatInt(int64(r.SampleCount), 10),
+			nsToMs(int64(r.SetupLatency)),
+			nsToMs(int64(r.PingAvgNs)),
+			nsToMs(int64(r.PingP50Ns)),
+			nsToMs(int64(r.PingP99Ns)),
+			nsToMs(int64(r.JitterNs)),
+			r.SetupErr,
+			r.PingErr,
+			r.CalcErr,
+			joinRoute(r.Route),
+		)
+	} else {
+		// Cell was discovered but no ping_result arrived (truncated
+		// capture or in-flight at stream end). Emit empty fields
+		// for the result-derived columns.
+		for i := 0; i < 14; i++ {
+			row = append(row, "")
+		}
+	}
+
+	if run != nil {
+		row = append(row,
+			strconv.FormatInt(int64(run.TotalDiscovered), 10),
+			strconv.FormatInt(int64(run.TotalPinged), 10),
+			strconv.FormatInt(int64(run.TotalSucceeded), 10),
+			strconv.FormatInt(int64(run.TotalFailed), 10),
+			strconv.FormatInt(int64(run.TotalSkippedCached), 10),
+			nsToMs(int64(run.WallTimeNs)),
+			strconv.FormatInt(int64(run.PeakInFlight), 10),
+			run.TerminationReason,
+			strconv.FormatFloat(hitRate, 'f', 4, 64),
+		)
+	} else {
+		for i := 0; i < 9; i++ {
+			row = append(row, "")
+		}
+	}
+	return row
+}
+
+// nsToMs formats nanoseconds as milliseconds with microsecond
+// precision (3 decimal places). Returns "" for zero — protobuf
+// omitempty leaves zero values invisible from the run, but the
+// CSV reader benefits from blank rather than 0.000.
+func nsToMs(ns int64) string {
+	if ns == 0 {
+		return ""
+	}
+	return strconv.FormatFloat(float64(ns)/1e6, 'f', 3, 64)
+}
+
+func joinRoute(hops []RouteHop) string {
+	if len(hops) == 0 {
+		return ""
+	}
+	out := ""
+	for i, h := range hops {
+		if i > 0 {
+			out += "|"
+		}
+		out += h.RemotePK
+	}
+	return out
+}
+
+// pickStr returns the value of field 'name' on PingResult when ok,
+// else on Discovered. Avoids reflect — straight switch.
+func pickStr(ok bool, val string, d *Discovered, name string) string {
+	if ok {
+		return val
+	}
+	if d == nil {
+		return ""
+	}
+	switch name {
+	case "TpID":
+		return d.TpID
+	case "TpType":
+		return d.TpType
+	}
+	return ""
+}
+
+func ifResult(r *PingResult, name string) string {
+	if r == nil {
+		return ""
+	}
+	switch name {
+	case "TpID":
+		return r.TpID
+	case "TpType":
+		return r.TpType
+	}
+	return ""
+}

--- a/pkg/util/treeprobe/event.go
+++ b/pkg/util/treeprobe/event.go
@@ -1,0 +1,195 @@
+// Package treeprobe consumes the NDJSON event stream emitted by
+// `cli visor ping tree-stream`, aggregates ping/latency/jitter
+// metrics per (level, parent_pk, remote_pk) tuple, joins against
+// TPD's per-transport bandwidth + latency snapshot, and emits a
+// CSV row per cell of the hop × routes measurement matrix.
+//
+// The package is a thin consumer — it does not invoke `cli ping
+// tree-stream` itself; the driver (ci_scripts/tree-probe.sh) is
+// responsible for spawning the CLI with the right --hops flags
+// and piping the NDJSON into the treeprobe binary on stdin.
+//
+// Wire envelope (locked in PR #2732):
+//
+//	{"ts": "2026-05-20T01:30:00.123Z",
+//	 "type": "ping_result",
+//	 "data": { ...proto-snake_case fields, int64 as string... }}
+//
+// The outer envelope uses RFC3339Nano timestamps and one of 6
+// discriminator strings. The inner data is protojson-marshaled
+// from the corresponding PingTree* proto message with
+// UseProtoNames=true (snake_case fields) and the protobuf int64
+// → JSON string convention. Numeric duration/byte fields in this
+// package's mirror types are typed as Int64String to surface that
+// quirk explicitly to consumers.
+package treeprobe
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// EventType is the discriminator string in the envelope's "type"
+// field. Mirrors the classifyPayload switch in
+// cmd/skywire-cli/commands/visor/ping/tree_stream.go.
+type EventType string
+
+const (
+	TypeDiscovered   EventType = "discovered"
+	TypePingResult   EventType = "ping_result"
+	TypeLevelDone    EventType = "level_done"
+	TypeRunDone      EventType = "run_done"
+	TypeStatusUpdate EventType = "status_update"
+	TypeServerError  EventType = "server_error"
+)
+
+// Envelope is the outer NDJSON line shape. Data is held as
+// json.RawMessage so the consumer can defer decoding to the
+// type-specific struct once it has Type in hand.
+type Envelope struct {
+	TS   string          `json:"ts"`
+	Type EventType       `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// Int64String is the JSON shape protobuf uses for int64 fields:
+// always a JSON string. Wrapping it in a named type lets the
+// parser surface the convention to consumers + lets us add
+// convenience methods for nanosecond → time.Duration conversion
+// without polluting every struct field.
+type Int64String int64
+
+// UnmarshalJSON decodes either a JSON string (protobuf default) OR a
+// JSON number (tolerant for hand-written test fixtures). Returns an
+// error on any non-integer value.
+func (i *Int64String) UnmarshalJSON(b []byte) error {
+	// Strip surrounding quotes if present.
+	if len(b) >= 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		b = b[1 : len(b)-1]
+	}
+	v, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return fmt.Errorf("treeprobe: parse Int64String %q: %w", string(b), err)
+	}
+	*i = Int64String(v)
+	return nil
+}
+
+// MarshalJSON emits the int64-as-string form on the way out — useful
+// for round-tripping in tests + keeps the on-the-wire shape stable.
+func (i Int64String) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(strconv.FormatInt(int64(i), 10))), nil
+}
+
+// Discovered fires when the BFS first observes a new (transport,
+// remote_pk) pair, before any ping is attempted.
+type Discovered struct {
+	TpID     string `json:"tp_id"`
+	TpType   string `json:"tp_type"`
+	RemotePK string `json:"remote_pk"`
+	ParentPK string `json:"parent_pk"`
+	Level    int32  `json:"level"`
+}
+
+// PingResult is the canonical measurement event. One per peer in
+// the tree, regardless of whether the latency was sampled live or
+// pulled from the cached TransportSummary. LatencySource
+// discriminates the provenance.
+//
+// Wire-NOT-deterministic ordering: results arrive interleaved by
+// completion, not in BFS traversal order. The harness sorts/groups
+// by (Level, ParentPK, RemotePK) on receive.
+type PingResult struct {
+	TpID     string `json:"tp_id"`
+	TpType   string `json:"tp_type"`
+	RemotePK string `json:"remote_pk"`
+	ParentPK string `json:"parent_pk"`
+	Level    int32  `json:"level"`
+	// Proto field name is "canceled" (en-US per misspell linter,
+	// renamed from initial "cancelled" during 2026-05-20 design
+	// review).
+	Canceled bool `json:"canceled"`
+
+	SampleCount  int32       `json:"sample_count"`
+	SetupLatency Int64String `json:"setup_latency_ns"`
+	PingAvgNs    Int64String `json:"ping_avg_ns"`
+	PingP50Ns    Int64String `json:"ping_p50_ns"`
+	PingP99Ns    Int64String `json:"ping_p99_ns"`
+	// JitterNs is population stddev of ping samples:
+	// sqrt(sum((x-mean)^2) / N). Spec'd 2026-05-20 00:54Z.
+	JitterNs Int64String `json:"jitter_ns"`
+
+	Failed   bool   `json:"failed"`
+	SetupErr string `json:"setup_err,omitempty"`
+	PingErr  string `json:"ping_err,omitempty"`
+	CalcErr  string `json:"calc_err,omitempty"`
+
+	// LatencySource is one of:
+	//   "live_ping"          — fresh measurement
+	//   "transport_summary"  — smoothed RTT from TransportSummary.LatencyMS
+	//                          (PR #2733, level-1 only)
+	//   "skipped"            — cached fast-path explicitly disabled
+	LatencySource string     `json:"latency_source"`
+	Route         []RouteHop `json:"route,omitempty"`
+}
+
+// RouteHop is one entry in the route taken from probe origin to
+// the target peer. PingResult.Route is empty for level-1 entries.
+type RouteHop struct {
+	TpID     string `json:"tp_id"`
+	TpType   string `json:"tp_type"`
+	RemotePK string `json:"remote_pk"`
+}
+
+// LevelDone fires when the BFS finishes all peers at a given
+// level. SkippedCached is non-zero when transport_summary fast-path
+// short-circuited some peers (Beta's PR #2733). Lets the harness
+// compute use_transport_latency hit-rate per level.
+type LevelDone struct {
+	Level         int32 `json:"level"`
+	Attempted     int32 `json:"attempted"`
+	Succeeded     int32 `json:"succeeded"`
+	Failed        int32 `json:"failed"`
+	SkippedCached int32 `json:"skipped_cached"`
+}
+
+// RunDone fires once at the end of a successful (or canceled) run.
+// Field names match PingTreeRunDone in pkg/visor/rpcgrpc/ping.pb.go;
+// most fields are int32 counters, WallTimeNs is the protobuf int64
+// → JSON string convention.
+//
+// TerminationReason is one of:
+//
+//	"max_level"      — hit cfg.MaxLevel
+//	"no_neighbors"   — BFS exhausted before MaxLevel
+//	"hops_target"    — reached cfg.Hops target level
+//	"context_cancel" — client disconnect / server shutdown
+//	"error"          — see ServerError preceding this event
+type RunDone struct {
+	TotalDiscovered    int32       `json:"total_discovered,omitempty"`
+	TotalPinged        int32       `json:"total_pinged,omitempty"`
+	TotalSucceeded     int32       `json:"total_succeeded,omitempty"`
+	TotalFailed        int32       `json:"total_failed,omitempty"`
+	TotalSkippedCached int32       `json:"total_skipped_cached,omitempty"`
+	WallTimeNs         Int64String `json:"wall_time_ns"`
+	PeakInFlight       int32       `json:"peak_in_flight,omitempty"`
+	TerminationReason  string      `json:"termination_reason,omitempty"`
+}
+
+// StatusUpdate fires periodically (cadence server-chosen) to
+// surface live in-flight + queue state. Dropped first under back-
+// pressure on the bounded event channel.
+type StatusUpdate struct {
+	Phase    string `json:"phase"`
+	InFlight int32  `json:"in_flight"`
+	Pending  int32  `json:"pending"`
+}
+
+// ServerError is emitted when the BFS handler hits a fatal error
+// it can't recover from. Always the last event before the stream
+// terminates.
+type ServerError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/pkg/util/treeprobe/parser.go
+++ b/pkg/util/treeprobe/parser.go
@@ -1,0 +1,131 @@
+// parser.go — NDJSON line decoder.
+//
+// Consumes a stream of envelope lines and emits one strongly-typed
+// payload per call. The parser is buffer-aware (handles partial
+// lines across Read boundaries) and forgiving of trailing whitespace
+// + blank lines between events.
+
+package treeprobe
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Parser wraps a bufio.Scanner over an NDJSON stream from
+// `cli visor ping tree-stream`. Use NewParser to construct, then
+// Next() in a loop until io.EOF.
+type Parser struct {
+	sc *bufio.Scanner
+}
+
+// NewParser constructs a Parser over r. Uses a 1 MiB scan buffer
+// because PingResult events with long route arrays + error
+// messages can run several KiB; default bufio buffer (64 KiB)
+// would suffice today but bumping is cheap insurance against
+// future field bloat.
+func NewParser(r io.Reader) *Parser {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	return &Parser{sc: sc}
+}
+
+// Decoded is the parser's emit shape. Exactly one of the *Payload
+// fields is non-nil per Decoded, matching Envelope.Type. The TS
+// field is the RFC3339Nano timestamp string from the envelope —
+// callers convert to time.Time on demand.
+type Decoded struct {
+	TS   string
+	Type EventType
+
+	Discovered   *Discovered
+	PingResult   *PingResult
+	LevelDone    *LevelDone
+	RunDone      *RunDone
+	StatusUpdate *StatusUpdate
+	ServerError  *ServerError
+}
+
+// Next returns the next decoded event, io.EOF when the stream
+// is exhausted, or a non-nil error on parse failure. Blank lines
+// + trailing whitespace are skipped. Unknown Type values yield
+// an error rather than silent skip — the spec is closed at 6
+// event types and a new one shouldn't sneak past us undetected.
+func (p *Parser) Next() (*Decoded, error) {
+	for p.sc.Scan() {
+		line := p.sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		// Skip lines that are all whitespace.
+		isBlank := true
+		for _, b := range line {
+			if b != ' ' && b != '\t' && b != '\r' {
+				isBlank = false
+				break
+			}
+		}
+		if isBlank {
+			continue
+		}
+
+		var env Envelope
+		if err := json.Unmarshal(line, &env); err != nil {
+			return nil, fmt.Errorf("treeprobe: parse envelope: %w (line: %q)", err, truncate(line, 200))
+		}
+		return p.decodePayload(&env)
+	}
+	if err := p.sc.Err(); err != nil {
+		return nil, fmt.Errorf("treeprobe: scan: %w", err)
+	}
+	return nil, io.EOF
+}
+
+// decodePayload unmarshals env.Data into the type-specific struct
+// according to env.Type. Returns an error if Type is unrecognized
+// or if the inner JSON is malformed for the declared type.
+func (p *Parser) decodePayload(env *Envelope) (*Decoded, error) {
+	d := &Decoded{TS: env.TS, Type: env.Type}
+
+	var inner any
+	switch env.Type {
+	case TypeDiscovered:
+		d.Discovered = &Discovered{}
+		inner = d.Discovered
+	case TypePingResult:
+		d.PingResult = &PingResult{}
+		inner = d.PingResult
+	case TypeLevelDone:
+		d.LevelDone = &LevelDone{}
+		inner = d.LevelDone
+	case TypeRunDone:
+		d.RunDone = &RunDone{}
+		inner = d.RunDone
+	case TypeStatusUpdate:
+		d.StatusUpdate = &StatusUpdate{}
+		inner = d.StatusUpdate
+	case TypeServerError:
+		d.ServerError = &ServerError{}
+		inner = d.ServerError
+	default:
+		return nil, fmt.Errorf("treeprobe: unknown event type %q", env.Type)
+	}
+
+	if err := json.Unmarshal(env.Data, inner); err != nil {
+		return nil, fmt.Errorf("treeprobe: parse %s payload: %w (data: %q)",
+			env.Type, err, truncate(env.Data, 200))
+	}
+	return d, nil
+}
+
+func truncate(b []byte, max int) []byte {
+	if len(b) <= max {
+		return b
+	}
+	out := make([]byte, max+3)
+	copy(out, b[:max])
+	copy(out[max:], "...")
+	return out
+}

--- a/pkg/util/treeprobe/parser_test.go
+++ b/pkg/util/treeprobe/parser_test.go
@@ -1,0 +1,182 @@
+package treeprobe
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// Synthetic fixtures matching the wire shape from PR #2732's
+// emitOne. The Int64String type accepts either JSON string (proto
+// default) or JSON number (test convenience); both forms exercise
+// the same code path.
+const sampleStream = `
+{"ts":"2026-05-20T01:30:00.100Z","type":"discovered","data":{"tp_id":"abc123","tp_type":"stcpr","remote_pk":"02deadbeef","parent_pk":"03self","level":1}}
+{"ts":"2026-05-20T01:30:00.250Z","type":"ping_result","data":{"tp_id":"abc123","tp_type":"stcpr","remote_pk":"02deadbeef","parent_pk":"03self","level":1,"canceled":false,"sample_count":5,"setup_latency_ns":"170710214","ping_avg_ns":"287931103","ping_p50_ns":"290004599","ping_p99_ns":"290004599","jitter_ns":"2073496","failed":false,"latency_source":"live_ping"}}
+{"ts":"2026-05-20T01:30:00.300Z","type":"ping_result","data":{"tp_id":"def456","tp_type":"sudph","remote_pk":"02cafefeed","parent_pk":"03self","level":1,"sample_count":1,"ping_avg_ns":"15000000","ping_p50_ns":"15000000","ping_p99_ns":"15000000","jitter_ns":"0","failed":false,"latency_source":"transport_summary"}}
+{"ts":"2026-05-20T01:30:00.500Z","type":"level_done","data":{"level":1,"attempted":2,"succeeded":2,"failed":0,"skipped_cached":1}}
+{"ts":"2026-05-20T01:30:05.000Z","type":"status_update","data":{"phase":"pinging_level_2","in_flight":4,"pending":12}}
+{"ts":"2026-05-20T01:30:10.000Z","type":"run_done","data":{"total_discovered":20,"total_pinged":15,"total_succeeded":12,"total_failed":3,"total_skipped_cached":5,"wall_time_ns":"10000000000","peak_in_flight":16,"termination_reason":"hops_target"}}
+`
+
+func TestParser_Next_AllEventTypes(t *testing.T) {
+	p := NewParser(strings.NewReader(sampleStream))
+
+	// 1: discovered
+	d, err := p.Next()
+	if err != nil {
+		t.Fatalf("event 1: %v", err)
+	}
+	if d.Type != TypeDiscovered || d.Discovered == nil {
+		t.Fatalf("event 1: wrong type %q or nil payload", d.Type)
+	}
+	if d.Discovered.TpID != "abc123" || d.Discovered.Level != 1 {
+		t.Errorf("event 1: discovered fields wrong: %+v", *d.Discovered)
+	}
+
+	// 2: ping_result (live_ping with all stats)
+	d, err = p.Next()
+	if err != nil {
+		t.Fatalf("event 2: %v", err)
+	}
+	if d.Type != TypePingResult || d.PingResult == nil {
+		t.Fatalf("event 2: wrong type or nil")
+	}
+	pr := d.PingResult
+	if pr.SampleCount != 5 {
+		t.Errorf("event 2: sample_count want 5 got %d", pr.SampleCount)
+	}
+	if int64(pr.PingAvgNs) != 287931103 {
+		t.Errorf("event 2: ping_avg_ns want 287931103 got %d", pr.PingAvgNs)
+	}
+	if int64(pr.JitterNs) != 2073496 {
+		t.Errorf("event 2: jitter_ns want 2073496 got %d", pr.JitterNs)
+	}
+	if pr.LatencySource != "live_ping" {
+		t.Errorf("event 2: latency_source want live_ping got %q", pr.LatencySource)
+	}
+
+	// 3: ping_result with latency_source=transport_summary (fast-path)
+	d, err = p.Next()
+	if err != nil {
+		t.Fatalf("event 3: %v", err)
+	}
+	if d.PingResult.LatencySource != "transport_summary" {
+		t.Errorf("event 3: latency_source want transport_summary got %q", d.PingResult.LatencySource)
+	}
+	if d.PingResult.SampleCount != 1 {
+		t.Errorf("event 3: fast-path sample_count want 1 got %d", d.PingResult.SampleCount)
+	}
+
+	// 4: level_done with skipped_cached
+	d, err = p.Next()
+	if err != nil {
+		t.Fatalf("event 4: %v", err)
+	}
+	if d.Type != TypeLevelDone {
+		t.Fatalf("event 4: wrong type %q", d.Type)
+	}
+	if d.LevelDone.SkippedCached != 1 {
+		t.Errorf("event 4: skipped_cached want 1 got %d", d.LevelDone.SkippedCached)
+	}
+
+	// 5: status_update
+	d, err = p.Next()
+	if err != nil {
+		t.Fatalf("event 5: %v", err)
+	}
+	if d.Type != TypeStatusUpdate || d.StatusUpdate.Phase != "pinging_level_2" {
+		t.Errorf("event 5: status wrong: %+v", d)
+	}
+
+	// 6: run_done
+	d, err = p.Next()
+	if err != nil {
+		t.Fatalf("event 6: %v", err)
+	}
+	if d.Type != TypeRunDone {
+		t.Fatalf("event 6: wrong type %q", d.Type)
+	}
+	if int64(d.RunDone.WallTimeNs) != 10000000000 {
+		t.Errorf("event 6: wall_time_ns want 10000000000 got %d", d.RunDone.WallTimeNs)
+	}
+	if d.RunDone.TerminationReason != "hops_target" {
+		t.Errorf("event 6: termination_reason wrong: %q", d.RunDone.TerminationReason)
+	}
+	if d.RunDone.TotalDiscovered != 20 || d.RunDone.TotalSkippedCached != 5 {
+		t.Errorf("event 6: totals wrong: discovered=%d skipped_cached=%d",
+			d.RunDone.TotalDiscovered, d.RunDone.TotalSkippedCached)
+	}
+
+	// EOF
+	d, err = p.Next()
+	if err != io.EOF {
+		t.Fatalf("want EOF after 6 events; got d=%+v err=%v", d, err)
+	}
+}
+
+func TestParser_TolerantToBlankLines(t *testing.T) {
+	stream := "\n  \n\t\n{\"ts\":\"t\",\"type\":\"server_error\",\"data\":{\"code\":\"X\",\"message\":\"y\"}}\n\n"
+	p := NewParser(strings.NewReader(stream))
+	d, err := p.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if d.Type != TypeServerError || d.ServerError.Code != "X" {
+		t.Errorf("blank-line skip failed: %+v", d)
+	}
+}
+
+func TestParser_RejectsUnknownType(t *testing.T) {
+	stream := `{"ts":"t","type":"weird_new_event","data":{}}` + "\n"
+	p := NewParser(strings.NewReader(stream))
+	_, err := p.Next()
+	if err == nil {
+		t.Fatal("want error on unknown type; got nil")
+	}
+}
+
+func TestParser_RejectsMalformedJSON(t *testing.T) {
+	stream := `{"ts":"t","type":"discovered","data":{`
+	p := NewParser(strings.NewReader(stream))
+	_, err := p.Next()
+	if err == nil {
+		t.Fatal("want error on malformed JSON; got nil")
+	}
+}
+
+func TestInt64String_TolerantOfNumberForm(t *testing.T) {
+	// Hand-written test fixtures may use raw numbers; production
+	// protobuf wire is always string. Both must parse.
+	var i Int64String
+	if err := i.UnmarshalJSON([]byte(`"123"`)); err != nil {
+		t.Fatalf("string form: %v", err)
+	}
+	if i != 123 {
+		t.Errorf("string form: want 123 got %d", i)
+	}
+	if err := i.UnmarshalJSON([]byte(`456`)); err != nil {
+		t.Fatalf("number form: %v", err)
+	}
+	if i != 456 {
+		t.Errorf("number form: want 456 got %d", i)
+	}
+}
+
+func TestInt64String_RoundTrip(t *testing.T) {
+	original := Int64String(42)
+	b, err := original.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `"42"` {
+		t.Errorf("marshal: want %q got %q", `"42"`, string(b))
+	}
+	var back Int64String
+	if err := back.UnmarshalJSON(b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back != original {
+		t.Errorf("round-trip: want %d got %d", original, back)
+	}
+}


### PR DESCRIPTION
## Summary
Synth's May-11 latency/jitter measurement directive's harness slice (per role split locked 2026-05-20 00:59Z pair). Consumes the gRPC streaming output of `cli visor ping tree-stream` (#2732) and renders per-peer latency / jitter / cache-hit-rate stats as CSV.

Builds on top of:
- #2732 (Alpha): server-side gRPC streaming ping-tree RPC
- #2733 (Beta): use_transport_latency fast-path at level 1

## What's here

- `pkg/util/treeprobe/` — Go consumer package
  - `event.go`: typed mirrors of the 6 PingTree* proto payloads + `Int64String` helper for the protobuf int64-as-JSON-string convention
  - `parser.go`: NDJSON envelope decoder (bufio scanner, 1 MiB buffer, blank-line tolerant, unknown-type rejecting)
  - `aggregate.go`: per-(level, parent_pk, remote_pk) cell rollup + run-level totals + cache-hit-rate computation
  - `csv.go`: 28-column flat CSV writer with run-level summary repeated per row
- `cmd/treeprobe/` — thin io-wiring binary (stdin NDJSON → stdout CSV + stderr summary)
- `ci_scripts/tree-probe.sh` — driver script sweeping configurable `--hops` list, emitting one CSV per hop in a timestamped outdir

## Validated end-to-end on real data

Real capture from a public 802-transport visor:

```
$ skywire cli visor ping tree-stream --hops 1 --tries 1 | /tmp/treeprobe > /tmp/real.csv
treeprobe: events=2410 cells=802 levels=1 cache_hit_rate=96.26% \
  total_discovered=802 total_pinged=30 total_succeeded=3 total_failed=27 \
  wall_time_ms=49256 termination=hops_target
```

Sample CSV row (real RTTs from level-1 fast-path):
```
1,03d1d78e...,0201a9ad...,9b5c3d8c...,stcpr,transport_summary,false,false,1,,286.560,...
```

96.26% cache hit rate confirms #2733's `use_transport_latency` fast-path is firing as designed for direct neighbors.

## Wire envelope (locked in #2732)

```json
{"ts": "RFC3339Nano",
 "type": "<discovered|ping_result|level_done|run_done|status_update|server_error>",
 "data": {protojson UseProtoNames=true snake_case + int64-as-string fields}}
```

## CSV row shape (28 columns)

Cell identity:
- `level`, `parent_pk`, `remote_pk`, `tp_id`, `tp_type`

Result fields:
- `latency_source` ∈ {live_ping, transport_summary, skipped}
- `failed`, `canceled`, `sample_count`
- `setup_latency_ms`, `ping_avg_ms`, `ping_p50_ms`, `ping_p99_ms`, `jitter_ms`
- `setup_err`, `ping_err`, `calc_err`, `route_hops`

Run-level summary (repeated per row so downstream pivot/group doesn't need a join):
- `run_total_discovered`, `run_total_pinged`, `run_total_succeeded`, `run_total_failed`
- `run_total_skipped_cached`, `run_wall_time_ms`, `run_peak_in_flight`
- `run_termination_reason`, `run_cache_hit_rate`

## Test plan
- [x] `go vet ./pkg/util/treeprobe/ ./cmd/treeprobe/` clean
- [x] `gofmt -l` clean
- [x] `go test ./pkg/util/treeprobe/` — 10 tests pass
- [x] End-to-end on real 802-cell capture (96.3% cache hit rate)
- [x] `bash -n ci_scripts/tree-probe.sh` clean
- [ ] shellcheck on tree-probe.sh (CI lane)
- [ ] Follow-up PR: TPD-metrics joiner (`cli tp ls --json` → bandwidth column on CSV) for Synth's directive (f) "compare E2E to TPD's per-transport metrics"
- [ ] Follow-up PR: StreamMuxBandwidth consumer once Alpha's separate RPC lands for Synth's directive (e) multiplexed routes