### PR TITLE
feat(visor): StreamMuxBandwidth gRPC RPC + cli mux-bw

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
@@ -1,0 +1,214 @@
+// Package ping — cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go:
+// CLI consumer for the StreamMuxBandwidth gRPC RPC.
+//
+// Operator-visible: `cli visor ping mux-bw <pk>` runs the
+// multiplexed-route bandwidth test against a single peer and emits
+// per-second NDJSON samples to stdout. Pairs with the same
+// treeprobe-friendly envelope shape as `tree-stream` so harness
+// consumers don't need a separate parser for this RPC.
+//
+// Run shapes (the operator's hypothesis matrix):
+//
+//	# Baseline — single route, no min_hops (picks direct if available)
+//	cli visor ping mux-bw <pk> --duration 30s
+//
+//	# Single non-direct path — forces at least one intermediate
+//	cli visor ping mux-bw <pk> --duration 30s --min-hops 2
+//
+//	# N parallel routes excluding direct — the operator's hypothesis
+//	# call: should sum to MORE bandwidth than direct
+//	cli visor ping mux-bw <pk> --duration 30s --routes 4 --min-hops 2
+//
+//	# Queueing-delay measurement: bandwidth + concurrent RTT probe
+//	cli visor ping mux-bw <pk> --duration 30s --probe-rtt
+package ping
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+)
+
+var (
+	muxBwRoutes         int
+	muxBwDuration       time.Duration
+	muxBwPacketSizeKb   int
+	muxBwMinHops        int
+	muxBwSetupTimeout   time.Duration
+	muxBwProbeRTT       bool
+	muxBwProbeInterval  time.Duration
+	muxBwSampleInterval time.Duration
+	muxBwLocalRoute     bool
+)
+
+func init() {
+	muxBandwidthCmd.Flags().IntVarP(&muxBwRoutes, "routes", "r", 1,
+		"number of parallel route connections (1 = baseline single route)")
+	muxBandwidthCmd.Flags().DurationVarP(&muxBwDuration, "duration", "d", 30*time.Second,
+		"how long to pump bytes (excludes route-setup time)")
+	muxBandwidthCmd.Flags().IntVarP(&muxBwPacketSizeKb, "size", "s", 32,
+		"per-write block size in KB")
+	muxBandwidthCmd.Flags().IntVar(&muxBwMinHops, "min-hops", 0,
+		"route-finder min hops constraint (>=2 excludes the direct transport)")
+	muxBandwidthCmd.Flags().DurationVar(&muxBwSetupTimeout, "setup-timeout", 30*time.Second,
+		"per-route setup timeout")
+	muxBandwidthCmd.Flags().BoolVar(&muxBwProbeRTT, "probe-rtt", false,
+		"also send small-packet RTT probes during the load (queueing-delay measurement)")
+	muxBandwidthCmd.Flags().DurationVar(&muxBwProbeInterval, "probe-interval", 100*time.Millisecond,
+		"interval between RTT probes when --probe-rtt is set")
+	muxBandwidthCmd.Flags().DurationVar(&muxBwSampleInterval, "sample-interval", 1*time.Second,
+		"interval between MuxBandwidthSample events")
+	muxBandwidthCmd.Flags().BoolVar(&muxBwLocalRoute, "local-route", false,
+		"use locally-cached TPD data for route calculation (faster setup; may be stale)")
+
+	RootCmd.AddCommand(muxBandwidthCmd)
+}
+
+var muxBandwidthCmd = &cobra.Command{
+	Use:   "mux-bw <pk>",
+	Short: "Multiplexed-route bandwidth + queueing-delay probe to a peer",
+	Long: `Pump bytes from this visor to a peer visor across N parallel
+routes, optionally probing RTT during the load to capture queueing
+delay. Emits per-second NDJSON samples to stdout, plus a terminal
+summary event.
+
+The "N parallel routes" can be one of three shapes via flags:
+
+  --routes 1                        # single route, route-finder picks freely (will use direct if available)
+  --routes 1 --min-hops 2           # single non-direct path — forces an intermediate
+  --routes N --min-hops 2           # N parallel routes excluding direct
+                                    #   — the operator's "mux should sum to more bandwidth" hypothesis
+
+Pair with --probe-rtt to capture the loaded-RTT distribution
+concurrent with the bulk pump. The loaded RTT minus the unloaded
+baseline IS the queueing delay.
+
+Output: NDJSON envelopes, one per stdout line:
+
+  {"ts":"RFC3339Nano","type":"route_established|sample|rtt_probe|done|error","data":{...}}
+
+Examples:
+
+  # Baseline single direct route, 30s, with RTT probing:
+  skywire cli visor ping mux-bw <peer-pk> --probe-rtt
+
+  # Mux 4 routes excluding direct, 60s, with RTT probing:
+  skywire cli visor ping mux-bw <peer-pk> --routes 4 --min-hops 2 --duration 60s --probe-rtt
+
+  # Filter to just the sample events with jq:
+  skywire cli visor ping mux-bw <peer-pk> --routes 4 \
+    | jq -c 'select(.type=="sample") | {t: (.data.elapsed_ns|tonumber/1e9), send_mbps: (.data.instant_send_bps/1e6), recv_mbps: (.data.instant_recv_bps/1e6)}'`,
+	Args: cobra.ExactArgs(1),
+	Run:  runMuxBandwidth,
+}
+
+func runMuxBandwidth(cmd *cobra.Command, args []string) {
+	targetPK := args[0]
+
+	ctx, cancel := muxBwSignalContext()
+	defer cancel()
+
+	client, err := rpcgrpc.NewPingClient(clirpc.Addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mux-bw: gRPC client connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close() //nolint:errcheck
+
+	req := &rpcgrpc.MuxBandwidthRequest{
+		TargetPk:         targetPK,
+		Routes:           int32(muxBwRoutes), //nolint:gosec
+		DurationNs:       muxBwDuration.Nanoseconds(),
+		PacketSizeKb:     int32(muxBwPacketSizeKb), //nolint:gosec
+		MinHops:          int32(muxBwMinHops),      //nolint:gosec
+		SetupTimeoutNs:   muxBwSetupTimeout.Nanoseconds(),
+		ProbeRtt:         muxBwProbeRTT,
+		ProbeIntervalNs:  muxBwProbeInterval.Nanoseconds(),
+		SampleIntervalNs: muxBwSampleInterval.Nanoseconds(),
+		LocalRoute:       muxBwLocalRoute,
+	}
+
+	stream, err := client.StreamMuxBandwidth(ctx, req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mux-bw: StreamMuxBandwidth call: %v\n", err)
+		os.Exit(1)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	marshaler := protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}
+
+	for {
+		ev, recvErr := stream.Recv()
+		if recvErr != nil {
+			if recvErr == io.EOF || recvErr == context.Canceled {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "mux-bw: stream recv: %v\n", recvErr)
+			os.Exit(1)
+		}
+		if err := emitMuxBwOne(enc, marshaler, ev); err != nil {
+			fmt.Fprintf(os.Stderr, "mux-bw: emit: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func emitMuxBwOne(enc *json.Encoder, m protojson.MarshalOptions, ev *rpcgrpc.MuxBandwidthEvent) error {
+	typ, payload := classifyMuxBwEvent(ev)
+	rawData, err := m.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", typ, err)
+	}
+	envelope := struct {
+		TS   string          `json:"ts"`
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}{
+		TS:   time.Unix(0, ev.TimestampNs).UTC().Format(time.RFC3339Nano),
+		Type: typ,
+		Data: json.RawMessage(rawData),
+	}
+	return enc.Encode(envelope)
+}
+
+func classifyMuxBwEvent(ev *rpcgrpc.MuxBandwidthEvent) (string, proto.Message) {
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.MuxBandwidthEvent_RouteEstablished:
+		return "route_established", p.RouteEstablished
+	case *rpcgrpc.MuxBandwidthEvent_Sample:
+		return "sample", p.Sample
+	case *rpcgrpc.MuxBandwidthEvent_RttProbe:
+		return "rtt_probe", p.RttProbe
+	case *rpcgrpc.MuxBandwidthEvent_Done:
+		return "done", p.Done
+	case *rpcgrpc.MuxBandwidthEvent_Error:
+		return "error", p.Error
+	}
+	return "unknown", &rpcgrpc.MuxBandwidthError{}
+}
+
+func muxBwSignalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+	return ctx, cancel
+}

--- a/pkg/visor/rpcgrpc/client.go
+++ b/pkg/visor/rpcgrpc/client.go
@@ -60,6 +60,14 @@ func (c *PingClient) StreamPingTree(ctx context.Context, req *PingTreeRequest) (
 	return c.client.StreamPingTree(ctx, req)
 }
 
+// StreamMuxBandwidth opens the multiplexed-route bandwidth + RTT
+// probe stream. Same event-level-control rationale as
+// StreamPingTree — the CLI consumer drives Recv() and the harness
+// path consumes the raw events.
+func (c *PingClient) StreamMuxBandwidth(ctx context.Context, req *MuxBandwidthRequest) (PingService_StreamMuxBandwidthClient, error) {
+	return c.client.StreamMuxBandwidth(ctx, req)
+}
+
 // StreamPing performs pings and calls the callback for each result
 // timeout applies only to the ping phase (after route setup), 0 means no timeout
 // setupTimeout applies to route setup phase, 0 means no timeout

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -2879,6 +2879,819 @@ func (x *PingTreeServerError) GetMessage() string {
 	return ""
 }
 
+// MuxBandwidthRequest configures a multiplexed-route bandwidth + RTT
+// probe run against a single target peer. See StreamMuxBandwidth's
+// docstring for the operator-visible hypothesis this serves.
+//
+// All durations are nanoseconds (proto convention used throughout
+// this service). All "0 = default" fields fall back to handler-side
+// constants documented inline.
+type MuxBandwidthRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// TargetPk is the remote visor's public key. Required.
+	TargetPk string `protobuf:"bytes,1,opt,name=target_pk,json=targetPk,proto3" json:"target_pk,omitempty"`
+	// Routes is the number of parallel route connections to open.
+	// 1 = single route (the StreamBandwidthTest equivalent).
+	// N > 1 = N concurrent routes pumping bytes, aggregate throughput
+	// is the headline measurement. 0 falls back to 1.
+	Routes int32 `protobuf:"varint,2,opt,name=routes,proto3" json:"routes,omitempty"`
+	// DurationNs caps the total wall-clock time spent pumping bytes.
+	// 0 falls back to 30s.
+	DurationNs int64 `protobuf:"varint,3,opt,name=duration_ns,json=durationNs,proto3" json:"duration_ns,omitempty"`
+	// PacketSizeKb sizes each write block. Larger amortizes write
+	// overhead; smaller surfaces stalls faster. 0 falls back to 32 KB.
+	PacketSizeKb int32 `protobuf:"varint,4,opt,name=packet_size_kb,json=packetSizeKb,proto3" json:"packet_size_kb,omitempty"`
+	// MinHops is the route-finder's minimum hop constraint. When > 1,
+	// the route excludes any direct transport between the local visor
+	// and TargetPk — forcing the bandwidth pump through intermediates.
+	// This is the "mux excluding direct" cell of the operator's
+	// hypothesis. 0 uses the visor's routing.min_hops config default
+	// (usually 1).
+	MinHops int32 `protobuf:"varint,5,opt,name=min_hops,json=minHops,proto3" json:"min_hops,omitempty"`
+	// SetupTimeoutNs bounds each route's setup phase. 0 falls back to
+	// 30s. Long setup times are common for multi-hop routes (see the
+	// p95=9.5s level-1 setup numbers from the ping-tree measurement).
+	SetupTimeoutNs int64 `protobuf:"varint,6,opt,name=setup_timeout_ns,json=setupTimeoutNs,proto3" json:"setup_timeout_ns,omitempty"`
+	// ProbeRtt toggles a separate small-packet RTT probe that runs
+	// concurrently with the bulk pump. Pairs are emitted as
+	// MuxRttProbe events. The probe rides the SAME first route as the
+	// bulk pump, so the resulting RTT samples reflect that route's
+	// saturation — the queueing-delay signal.
+	ProbeRtt bool `protobuf:"varint,7,opt,name=probe_rtt,json=probeRtt,proto3" json:"probe_rtt,omitempty"`
+	// ProbeIntervalNs is how often the RTT probe fires. 0 falls back
+	// to 100 ms. Faster = denser jitter signal; slower = less
+	// contention with the bulk pump.
+	ProbeIntervalNs int64 `protobuf:"varint,8,opt,name=probe_interval_ns,json=probeIntervalNs,proto3" json:"probe_interval_ns,omitempty"`
+	// SampleIntervalNs is how often a MuxBandwidthSample is emitted.
+	// 0 falls back to 1s. Smaller surfaces transient throughput dips
+	// (bufferbloat, queue spikes); larger reduces stream chatter.
+	SampleIntervalNs int64 `protobuf:"varint,9,opt,name=sample_interval_ns,json=sampleIntervalNs,proto3" json:"sample_interval_ns,omitempty"`
+	// LocalRoute uses local route calculation (cached TPD data)
+	// instead of querying the route-finder service. Mirrors
+	// BandwidthRequest.LocalRoute.
+	LocalRoute    bool `protobuf:"varint,10,opt,name=local_route,json=localRoute,proto3" json:"local_route,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxBandwidthRequest) Reset() {
+	*x = MuxBandwidthRequest{}
+	mi := &file_ping_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxBandwidthRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxBandwidthRequest) ProtoMessage() {}
+
+func (x *MuxBandwidthRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxBandwidthRequest.ProtoReflect.Descriptor instead.
+func (*MuxBandwidthRequest) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *MuxBandwidthRequest) GetTargetPk() string {
+	if x != nil {
+		return x.TargetPk
+	}
+	return ""
+}
+
+func (x *MuxBandwidthRequest) GetRoutes() int32 {
+	if x != nil {
+		return x.Routes
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetDurationNs() int64 {
+	if x != nil {
+		return x.DurationNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetPacketSizeKb() int32 {
+	if x != nil {
+		return x.PacketSizeKb
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetMinHops() int32 {
+	if x != nil {
+		return x.MinHops
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetSetupTimeoutNs() int64 {
+	if x != nil {
+		return x.SetupTimeoutNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetProbeRtt() bool {
+	if x != nil {
+		return x.ProbeRtt
+	}
+	return false
+}
+
+func (x *MuxBandwidthRequest) GetProbeIntervalNs() int64 {
+	if x != nil {
+		return x.ProbeIntervalNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetSampleIntervalNs() int64 {
+	if x != nil {
+		return x.SampleIntervalNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthRequest) GetLocalRoute() bool {
+	if x != nil {
+		return x.LocalRoute
+	}
+	return false
+}
+
+// MuxBandwidthEvent is one entry on the stream. Exactly one oneof
+// payload is set per message.
+type MuxBandwidthEvent struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	TimestampNs int64                  `protobuf:"varint,1,opt,name=timestamp_ns,json=timestampNs,proto3" json:"timestamp_ns,omitempty"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*MuxBandwidthEvent_RouteEstablished
+	//	*MuxBandwidthEvent_Sample
+	//	*MuxBandwidthEvent_RttProbe
+	//	*MuxBandwidthEvent_Done
+	//	*MuxBandwidthEvent_Error
+	Payload       isMuxBandwidthEvent_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxBandwidthEvent) Reset() {
+	*x = MuxBandwidthEvent{}
+	mi := &file_ping_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxBandwidthEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxBandwidthEvent) ProtoMessage() {}
+
+func (x *MuxBandwidthEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxBandwidthEvent.ProtoReflect.Descriptor instead.
+func (*MuxBandwidthEvent) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *MuxBandwidthEvent) GetTimestampNs() int64 {
+	if x != nil {
+		return x.TimestampNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthEvent) GetPayload() isMuxBandwidthEvent_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *MuxBandwidthEvent) GetRouteEstablished() *MuxRouteEstablished {
+	if x != nil {
+		if x, ok := x.Payload.(*MuxBandwidthEvent_RouteEstablished); ok {
+			return x.RouteEstablished
+		}
+	}
+	return nil
+}
+
+func (x *MuxBandwidthEvent) GetSample() *MuxBandwidthSample {
+	if x != nil {
+		if x, ok := x.Payload.(*MuxBandwidthEvent_Sample); ok {
+			return x.Sample
+		}
+	}
+	return nil
+}
+
+func (x *MuxBandwidthEvent) GetRttProbe() *MuxRttProbe {
+	if x != nil {
+		if x, ok := x.Payload.(*MuxBandwidthEvent_RttProbe); ok {
+			return x.RttProbe
+		}
+	}
+	return nil
+}
+
+func (x *MuxBandwidthEvent) GetDone() *MuxBandwidthDone {
+	if x != nil {
+		if x, ok := x.Payload.(*MuxBandwidthEvent_Done); ok {
+			return x.Done
+		}
+	}
+	return nil
+}
+
+func (x *MuxBandwidthEvent) GetError() *MuxBandwidthError {
+	if x != nil {
+		if x, ok := x.Payload.(*MuxBandwidthEvent_Error); ok {
+			return x.Error
+		}
+	}
+	return nil
+}
+
+type isMuxBandwidthEvent_Payload interface {
+	isMuxBandwidthEvent_Payload()
+}
+
+type MuxBandwidthEvent_RouteEstablished struct {
+	// RouteEstablished fires once per route (in any order) as the
+	// setup phase completes. Carries the actual route hops chosen,
+	// letting consumers verify min_hops was honored.
+	RouteEstablished *MuxRouteEstablished `protobuf:"bytes,10,opt,name=route_established,json=routeEstablished,proto3,oneof"`
+}
+
+type MuxBandwidthEvent_Sample struct {
+	// Sample fires every sample_interval_ns with cumulative + instant
+	// throughput numbers. Sent until pump duration elapses.
+	Sample *MuxBandwidthSample `protobuf:"bytes,11,opt,name=sample,proto3,oneof"`
+}
+
+type MuxBandwidthEvent_RttProbe struct {
+	// RttProbe fires every probe_interval_ns when ProbeRtt is set.
+	// Standalone from the Sample event because probes are async.
+	RttProbe *MuxRttProbe `protobuf:"bytes,12,opt,name=rtt_probe,json=rttProbe,proto3,oneof"`
+}
+
+type MuxBandwidthEvent_Done struct {
+	// Done is the terminal event before stream close. Carries the
+	// aggregated totals + RTT distribution stats.
+	Done *MuxBandwidthDone `protobuf:"bytes,13,opt,name=done,proto3,oneof"`
+}
+
+type MuxBandwidthEvent_Error struct {
+	// Error signals an unrecoverable condition. Last event before
+	// stream close; same shape semantics as PingTreeServerError.
+	Error *MuxBandwidthError `protobuf:"bytes,14,opt,name=error,proto3,oneof"`
+}
+
+func (*MuxBandwidthEvent_RouteEstablished) isMuxBandwidthEvent_Payload() {}
+
+func (*MuxBandwidthEvent_Sample) isMuxBandwidthEvent_Payload() {}
+
+func (*MuxBandwidthEvent_RttProbe) isMuxBandwidthEvent_Payload() {}
+
+func (*MuxBandwidthEvent_Done) isMuxBandwidthEvent_Payload() {}
+
+func (*MuxBandwidthEvent_Error) isMuxBandwidthEvent_Payload() {}
+
+// MuxRouteEstablished records one route's setup outcome.
+type MuxRouteEstablished struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// RouteIndex is 0..Routes-1, assigned in setup-order.
+	RouteIndex int32 `protobuf:"varint,1,opt,name=route_index,json=routeIndex,proto3" json:"route_index,omitempty"`
+	// SetupLatencyNs is the time spent on the route-setup phase
+	// (route-finder query + setup-node negotiation + handshake).
+	SetupLatencyNs int64 `protobuf:"varint,2,opt,name=setup_latency_ns,json=setupLatencyNs,proto3" json:"setup_latency_ns,omitempty"`
+	// Hops is the chosen path. Consumers verify min_hops by
+	// counting (len(hops) - 1) intermediate edges.
+	Hops []*RouteHop `protobuf:"bytes,3,rep,name=hops,proto3" json:"hops,omitempty"`
+	// Failed is set when the route could not be established;
+	// SetupErr carries the cause. The route is excluded from the
+	// pump phase but kept in the event log for diagnostics.
+	Failed        bool   `protobuf:"varint,4,opt,name=failed,proto3" json:"failed,omitempty"`
+	SetupErr      string `protobuf:"bytes,5,opt,name=setup_err,json=setupErr,proto3" json:"setup_err,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxRouteEstablished) Reset() {
+	*x = MuxRouteEstablished{}
+	mi := &file_ping_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxRouteEstablished) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxRouteEstablished) ProtoMessage() {}
+
+func (x *MuxRouteEstablished) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxRouteEstablished.ProtoReflect.Descriptor instead.
+func (*MuxRouteEstablished) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *MuxRouteEstablished) GetRouteIndex() int32 {
+	if x != nil {
+		return x.RouteIndex
+	}
+	return 0
+}
+
+func (x *MuxRouteEstablished) GetSetupLatencyNs() int64 {
+	if x != nil {
+		return x.SetupLatencyNs
+	}
+	return 0
+}
+
+func (x *MuxRouteEstablished) GetHops() []*RouteHop {
+	if x != nil {
+		return x.Hops
+	}
+	return nil
+}
+
+func (x *MuxRouteEstablished) GetFailed() bool {
+	if x != nil {
+		return x.Failed
+	}
+	return false
+}
+
+func (x *MuxRouteEstablished) GetSetupErr() string {
+	if x != nil {
+		return x.SetupErr
+	}
+	return ""
+}
+
+// MuxBandwidthSample is a periodic throughput snapshot. Cumulative
+// fields are run-totals across all routes; instant fields are
+// per-sample-interval rates.
+type MuxBandwidthSample struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ElapsedNs is the time since the first byte was sent (NOT since
+	// the run was requested — excludes setup time).
+	ElapsedNs     int64  `protobuf:"varint,1,opt,name=elapsed_ns,json=elapsedNs,proto3" json:"elapsed_ns,omitempty"`
+	BytesSent     uint64 `protobuf:"varint,2,opt,name=bytes_sent,json=bytesSent,proto3" json:"bytes_sent,omitempty"`
+	BytesReceived uint64 `protobuf:"varint,3,opt,name=bytes_received,json=bytesReceived,proto3" json:"bytes_received,omitempty"`
+	// InstantSendBps / RecvBps are per-interval rates. avg_*_bps are
+	// run-cumulative rates. All in bits-per-second (matches the
+	// network-engineer convention; consumers needing Mbps divide by
+	// 1e6).
+	InstantSendBps float64 `protobuf:"fixed64,4,opt,name=instant_send_bps,json=instantSendBps,proto3" json:"instant_send_bps,omitempty"`
+	InstantRecvBps float64 `protobuf:"fixed64,5,opt,name=instant_recv_bps,json=instantRecvBps,proto3" json:"instant_recv_bps,omitempty"`
+	AvgSendBps     float64 `protobuf:"fixed64,6,opt,name=avg_send_bps,json=avgSendBps,proto3" json:"avg_send_bps,omitempty"`
+	AvgRecvBps     float64 `protobuf:"fixed64,7,opt,name=avg_recv_bps,json=avgRecvBps,proto3" json:"avg_recv_bps,omitempty"`
+	// ActiveRoutes is how many of the Routes-requested routes are
+	// still pumping. Drops when a route fails mid-run.
+	ActiveRoutes  int32 `protobuf:"varint,8,opt,name=active_routes,json=activeRoutes,proto3" json:"active_routes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxBandwidthSample) Reset() {
+	*x = MuxBandwidthSample{}
+	mi := &file_ping_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxBandwidthSample) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxBandwidthSample) ProtoMessage() {}
+
+func (x *MuxBandwidthSample) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxBandwidthSample.ProtoReflect.Descriptor instead.
+func (*MuxBandwidthSample) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *MuxBandwidthSample) GetElapsedNs() int64 {
+	if x != nil {
+		return x.ElapsedNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetBytesSent() uint64 {
+	if x != nil {
+		return x.BytesSent
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetBytesReceived() uint64 {
+	if x != nil {
+		return x.BytesReceived
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetInstantSendBps() float64 {
+	if x != nil {
+		return x.InstantSendBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetInstantRecvBps() float64 {
+	if x != nil {
+		return x.InstantRecvBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetAvgSendBps() float64 {
+	if x != nil {
+		return x.AvgSendBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetAvgRecvBps() float64 {
+	if x != nil {
+		return x.AvgRecvBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthSample) GetActiveRoutes() int32 {
+	if x != nil {
+		return x.ActiveRoutes
+	}
+	return 0
+}
+
+// MuxRttProbe is one RTT measurement during the pump. Allows
+// consumers to plot loaded-RTT-over-time and compute queueing delay
+// as (loaded_rtt - baseline_rtt).
+type MuxRttProbe struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Sequence is the 1-indexed probe number, in emit order.
+	Sequence int64 `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	// LatencyNs is the measured RTT. 0 when the probe failed; Error
+	// carries the cause.
+	LatencyNs int64  `protobuf:"varint,2,opt,name=latency_ns,json=latencyNs,proto3" json:"latency_ns,omitempty"`
+	Error     string `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	// ElapsedNs is the time since the first byte was sent (same epoch
+	// as MuxBandwidthSample.ElapsedNs). Lets consumers align probes
+	// with concurrent bandwidth samples without timestamp diffing.
+	ElapsedNs     int64 `protobuf:"varint,4,opt,name=elapsed_ns,json=elapsedNs,proto3" json:"elapsed_ns,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxRttProbe) Reset() {
+	*x = MuxRttProbe{}
+	mi := &file_ping_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxRttProbe) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxRttProbe) ProtoMessage() {}
+
+func (x *MuxRttProbe) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxRttProbe.ProtoReflect.Descriptor instead.
+func (*MuxRttProbe) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *MuxRttProbe) GetSequence() int64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *MuxRttProbe) GetLatencyNs() int64 {
+	if x != nil {
+		return x.LatencyNs
+	}
+	return 0
+}
+
+func (x *MuxRttProbe) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *MuxRttProbe) GetElapsedNs() int64 {
+	if x != nil {
+		return x.ElapsedNs
+	}
+	return 0
+}
+
+// MuxBandwidthDone is the terminal event. Aggregates the run.
+type MuxBandwidthDone struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	TotalBytesSent     uint64                 `protobuf:"varint,1,opt,name=total_bytes_sent,json=totalBytesSent,proto3" json:"total_bytes_sent,omitempty"`
+	TotalBytesReceived uint64                 `protobuf:"varint,2,opt,name=total_bytes_received,json=totalBytesReceived,proto3" json:"total_bytes_received,omitempty"`
+	// WallTimeNs is total elapsed including setup; PumpTimeNs excludes
+	// setup. Operators comparing throughput across runs typically want
+	// PumpTimeNs (apples-to-apples regardless of how long setup took).
+	WallTimeNs        int64   `protobuf:"varint,3,opt,name=wall_time_ns,json=wallTimeNs,proto3" json:"wall_time_ns,omitempty"`
+	PumpTimeNs        int64   `protobuf:"varint,4,opt,name=pump_time_ns,json=pumpTimeNs,proto3" json:"pump_time_ns,omitempty"`
+	AvgSendBps        float64 `protobuf:"fixed64,5,opt,name=avg_send_bps,json=avgSendBps,proto3" json:"avg_send_bps,omitempty"`
+	AvgRecvBps        float64 `protobuf:"fixed64,6,opt,name=avg_recv_bps,json=avgRecvBps,proto3" json:"avg_recv_bps,omitempty"`
+	PeakSendBps       float64 `protobuf:"fixed64,7,opt,name=peak_send_bps,json=peakSendBps,proto3" json:"peak_send_bps,omitempty"`
+	PeakRecvBps       float64 `protobuf:"fixed64,8,opt,name=peak_recv_bps,json=peakRecvBps,proto3" json:"peak_recv_bps,omitempty"`
+	RoutesRequested   int32   `protobuf:"varint,9,opt,name=routes_requested,json=routesRequested,proto3" json:"routes_requested,omitempty"`
+	RoutesEstablished int32   `protobuf:"varint,10,opt,name=routes_established,json=routesEstablished,proto3" json:"routes_established,omitempty"`
+	SetupTotalNs      int64   `protobuf:"varint,11,opt,name=setup_total_ns,json=setupTotalNs,proto3" json:"setup_total_ns,omitempty"`
+	// RTT distribution across all probes (when ProbeRtt was set).
+	// Zero when no probes ran. Jitter is population stddev — same
+	// formula as PingTreeResult.jitter_ns.
+	ProbeCount    int32 `protobuf:"varint,12,opt,name=probe_count,json=probeCount,proto3" json:"probe_count,omitempty"`
+	ProbeAvgNs    int64 `protobuf:"varint,13,opt,name=probe_avg_ns,json=probeAvgNs,proto3" json:"probe_avg_ns,omitempty"`
+	ProbeP50Ns    int64 `protobuf:"varint,14,opt,name=probe_p50_ns,json=probeP50Ns,proto3" json:"probe_p50_ns,omitempty"`
+	ProbeP99Ns    int64 `protobuf:"varint,15,opt,name=probe_p99_ns,json=probeP99Ns,proto3" json:"probe_p99_ns,omitempty"`
+	ProbeJitterNs int64 `protobuf:"varint,16,opt,name=probe_jitter_ns,json=probeJitterNs,proto3" json:"probe_jitter_ns,omitempty"`
+	// TerminationReason: "duration" | "context_cancel" | "all_routes_failed" | "error".
+	TerminationReason string `protobuf:"bytes,17,opt,name=termination_reason,json=terminationReason,proto3" json:"termination_reason,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *MuxBandwidthDone) Reset() {
+	*x = MuxBandwidthDone{}
+	mi := &file_ping_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxBandwidthDone) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxBandwidthDone) ProtoMessage() {}
+
+func (x *MuxBandwidthDone) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxBandwidthDone.ProtoReflect.Descriptor instead.
+func (*MuxBandwidthDone) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *MuxBandwidthDone) GetTotalBytesSent() uint64 {
+	if x != nil {
+		return x.TotalBytesSent
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetTotalBytesReceived() uint64 {
+	if x != nil {
+		return x.TotalBytesReceived
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetWallTimeNs() int64 {
+	if x != nil {
+		return x.WallTimeNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetPumpTimeNs() int64 {
+	if x != nil {
+		return x.PumpTimeNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetAvgSendBps() float64 {
+	if x != nil {
+		return x.AvgSendBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetAvgRecvBps() float64 {
+	if x != nil {
+		return x.AvgRecvBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetPeakSendBps() float64 {
+	if x != nil {
+		return x.PeakSendBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetPeakRecvBps() float64 {
+	if x != nil {
+		return x.PeakRecvBps
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetRoutesRequested() int32 {
+	if x != nil {
+		return x.RoutesRequested
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetRoutesEstablished() int32 {
+	if x != nil {
+		return x.RoutesEstablished
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetSetupTotalNs() int64 {
+	if x != nil {
+		return x.SetupTotalNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetProbeCount() int32 {
+	if x != nil {
+		return x.ProbeCount
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetProbeAvgNs() int64 {
+	if x != nil {
+		return x.ProbeAvgNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetProbeP50Ns() int64 {
+	if x != nil {
+		return x.ProbeP50Ns
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetProbeP99Ns() int64 {
+	if x != nil {
+		return x.ProbeP99Ns
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetProbeJitterNs() int64 {
+	if x != nil {
+		return x.ProbeJitterNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetTerminationReason() string {
+	if x != nil {
+		return x.TerminationReason
+	}
+	return ""
+}
+
+// MuxBandwidthError signals an unrecoverable condition. Last event
+// before stream close.
+type MuxBandwidthError struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          string                 `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MuxBandwidthError) Reset() {
+	*x = MuxBandwidthError{}
+	mi := &file_ping_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MuxBandwidthError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MuxBandwidthError) ProtoMessage() {}
+
+func (x *MuxBandwidthError) ProtoReflect() protoreflect.Message {
+	mi := &file_ping_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MuxBandwidthError.ProtoReflect.Descriptor instead.
+func (*MuxBandwidthError) Descriptor() ([]byte, []int) {
+	return file_ping_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *MuxBandwidthError) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *MuxBandwidthError) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_ping_proto protoreflect.FileDescriptor
 
 const file_ping_proto_rawDesc = "" +
@@ -3142,7 +3955,87 @@ const file_ping_proto_rawDesc = "" +
 	"\amessage\x18\x04 \x01(\tR\amessage\"C\n" +
 	"\x13PingTreeServerError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage2\x8a\a\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xee\x02\n" +
+	"\x13MuxBandwidthRequest\x12\x1b\n" +
+	"\ttarget_pk\x18\x01 \x01(\tR\btargetPk\x12\x16\n" +
+	"\x06routes\x18\x02 \x01(\x05R\x06routes\x12\x1f\n" +
+	"\vduration_ns\x18\x03 \x01(\x03R\n" +
+	"durationNs\x12$\n" +
+	"\x0epacket_size_kb\x18\x04 \x01(\x05R\fpacketSizeKb\x12\x19\n" +
+	"\bmin_hops\x18\x05 \x01(\x05R\aminHops\x12(\n" +
+	"\x10setup_timeout_ns\x18\x06 \x01(\x03R\x0esetupTimeoutNs\x12\x1b\n" +
+	"\tprobe_rtt\x18\a \x01(\bR\bprobeRtt\x12*\n" +
+	"\x11probe_interval_ns\x18\b \x01(\x03R\x0fprobeIntervalNs\x12,\n" +
+	"\x12sample_interval_ns\x18\t \x01(\x03R\x10sampleIntervalNs\x12\x1f\n" +
+	"\vlocal_route\x18\n" +
+	" \x01(\bR\n" +
+	"localRoute\"\xdf\x02\n" +
+	"\x11MuxBandwidthEvent\x12!\n" +
+	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12K\n" +
+	"\x11route_established\x18\n" +
+	" \x01(\v2\x1c.rpcgrpc.MuxRouteEstablishedH\x00R\x10routeEstablished\x125\n" +
+	"\x06sample\x18\v \x01(\v2\x1b.rpcgrpc.MuxBandwidthSampleH\x00R\x06sample\x123\n" +
+	"\trtt_probe\x18\f \x01(\v2\x14.rpcgrpc.MuxRttProbeH\x00R\brttProbe\x12/\n" +
+	"\x04done\x18\r \x01(\v2\x19.rpcgrpc.MuxBandwidthDoneH\x00R\x04done\x122\n" +
+	"\x05error\x18\x0e \x01(\v2\x1a.rpcgrpc.MuxBandwidthErrorH\x00R\x05errorB\t\n" +
+	"\apayload\"\xbc\x01\n" +
+	"\x13MuxRouteEstablished\x12\x1f\n" +
+	"\vroute_index\x18\x01 \x01(\x05R\n" +
+	"routeIndex\x12(\n" +
+	"\x10setup_latency_ns\x18\x02 \x01(\x03R\x0esetupLatencyNs\x12%\n" +
+	"\x04hops\x18\x03 \x03(\v2\x11.rpcgrpc.RouteHopR\x04hops\x12\x16\n" +
+	"\x06failed\x18\x04 \x01(\bR\x06failed\x12\x1b\n" +
+	"\tsetup_err\x18\x05 \x01(\tR\bsetupErr\"\xb6\x02\n" +
+	"\x12MuxBandwidthSample\x12\x1d\n" +
+	"\n" +
+	"elapsed_ns\x18\x01 \x01(\x03R\telapsedNs\x12\x1d\n" +
+	"\n" +
+	"bytes_sent\x18\x02 \x01(\x04R\tbytesSent\x12%\n" +
+	"\x0ebytes_received\x18\x03 \x01(\x04R\rbytesReceived\x12(\n" +
+	"\x10instant_send_bps\x18\x04 \x01(\x01R\x0einstantSendBps\x12(\n" +
+	"\x10instant_recv_bps\x18\x05 \x01(\x01R\x0einstantRecvBps\x12 \n" +
+	"\favg_send_bps\x18\x06 \x01(\x01R\n" +
+	"avgSendBps\x12 \n" +
+	"\favg_recv_bps\x18\a \x01(\x01R\n" +
+	"avgRecvBps\x12#\n" +
+	"\ractive_routes\x18\b \x01(\x05R\factiveRoutes\"}\n" +
+	"\vMuxRttProbe\x12\x1a\n" +
+	"\bsequence\x18\x01 \x01(\x03R\bsequence\x12\x1d\n" +
+	"\n" +
+	"latency_ns\x18\x02 \x01(\x03R\tlatencyNs\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\x12\x1d\n" +
+	"\n" +
+	"elapsed_ns\x18\x04 \x01(\x03R\telapsedNs\"\x9c\x05\n" +
+	"\x10MuxBandwidthDone\x12(\n" +
+	"\x10total_bytes_sent\x18\x01 \x01(\x04R\x0etotalBytesSent\x120\n" +
+	"\x14total_bytes_received\x18\x02 \x01(\x04R\x12totalBytesReceived\x12 \n" +
+	"\fwall_time_ns\x18\x03 \x01(\x03R\n" +
+	"wallTimeNs\x12 \n" +
+	"\fpump_time_ns\x18\x04 \x01(\x03R\n" +
+	"pumpTimeNs\x12 \n" +
+	"\favg_send_bps\x18\x05 \x01(\x01R\n" +
+	"avgSendBps\x12 \n" +
+	"\favg_recv_bps\x18\x06 \x01(\x01R\n" +
+	"avgRecvBps\x12\"\n" +
+	"\rpeak_send_bps\x18\a \x01(\x01R\vpeakSendBps\x12\"\n" +
+	"\rpeak_recv_bps\x18\b \x01(\x01R\vpeakRecvBps\x12)\n" +
+	"\x10routes_requested\x18\t \x01(\x05R\x0froutesRequested\x12-\n" +
+	"\x12routes_established\x18\n" +
+	" \x01(\x05R\x11routesEstablished\x12$\n" +
+	"\x0esetup_total_ns\x18\v \x01(\x03R\fsetupTotalNs\x12\x1f\n" +
+	"\vprobe_count\x18\f \x01(\x05R\n" +
+	"probeCount\x12 \n" +
+	"\fprobe_avg_ns\x18\r \x01(\x03R\n" +
+	"probeAvgNs\x12 \n" +
+	"\fprobe_p50_ns\x18\x0e \x01(\x03R\n" +
+	"probeP50Ns\x12 \n" +
+	"\fprobe_p99_ns\x18\x0f \x01(\x03R\n" +
+	"probeP99Ns\x12&\n" +
+	"\x0fprobe_jitter_ns\x18\x10 \x01(\x03R\rprobeJitterNs\x12-\n" +
+	"\x12termination_reason\x18\x11 \x01(\tR\x11terminationReason\"A\n" +
+	"\x11MuxBandwidthError\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage2\xdc\a\n" +
 	"\vPingService\x129\n" +
 	"\n" +
 	"StreamPing\x12\x14.rpcgrpc.PingRequest\x1a\x13.rpcgrpc.PingResult0\x01\x12=\n" +
@@ -3156,7 +4049,8 @@ const file_ping_proto_rawDesc = "" +
 	"\rStreamAppLogs\x12\x1c.rpcgrpc.AppLogStreamRequest\x1a\x14.rpcgrpc.AppLogEntry0\x01\x12D\n" +
 	"\x10StreamCalcRoutes\x12\x1a.rpcgrpc.CalcRoutesRequest\x1a\x12.rpcgrpc.CalcRoute0\x01\x12R\n" +
 	"\x13StreamGroupMessages\x12\x1d.rpcgrpc.GroupMessagesRequest\x1a\x1a.rpcgrpc.GroupMessageEvent0\x01\x12D\n" +
-	"\x0eStreamPingTree\x12\x18.rpcgrpc.PingTreeRequest\x1a\x16.rpcgrpc.PingTreeEvent0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
+	"\x0eStreamPingTree\x12\x18.rpcgrpc.PingTreeRequest\x1a\x16.rpcgrpc.PingTreeEvent0\x01\x12P\n" +
+	"\x12StreamMuxBandwidth\x12\x1c.rpcgrpc.MuxBandwidthRequest\x1a\x1a.rpcgrpc.MuxBandwidthEvent0\x01B.Z,github.com/skycoin/skywire/pkg/visor/rpcgrpcb\x06proto3"
 
 var (
 	file_ping_proto_rawDescOnce sync.Once
@@ -3170,7 +4064,7 @@ func file_ping_proto_rawDescGZIP() []byte {
 	return file_ping_proto_rawDescData
 }
 
-var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_ping_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_ping_proto_goTypes = []any{
 	(*PingRequest)(nil),              // 0: rpcgrpc.PingRequest
 	(*PingResult)(nil),               // 1: rpcgrpc.PingResult
@@ -3204,7 +4098,14 @@ var file_ping_proto_goTypes = []any{
 	(*PingTreeRunDone)(nil),          // 29: rpcgrpc.PingTreeRunDone
 	(*PingTreeStatusUpdate)(nil),     // 30: rpcgrpc.PingTreeStatusUpdate
 	(*PingTreeServerError)(nil),      // 31: rpcgrpc.PingTreeServerError
-	nil,                              // 32: rpcgrpc.AppLogEntry.FieldsEntry
+	(*MuxBandwidthRequest)(nil),      // 32: rpcgrpc.MuxBandwidthRequest
+	(*MuxBandwidthEvent)(nil),        // 33: rpcgrpc.MuxBandwidthEvent
+	(*MuxRouteEstablished)(nil),      // 34: rpcgrpc.MuxRouteEstablished
+	(*MuxBandwidthSample)(nil),       // 35: rpcgrpc.MuxBandwidthSample
+	(*MuxRttProbe)(nil),              // 36: rpcgrpc.MuxRttProbe
+	(*MuxBandwidthDone)(nil),         // 37: rpcgrpc.MuxBandwidthDone
+	(*MuxBandwidthError)(nil),        // 38: rpcgrpc.MuxBandwidthError
+	nil,                              // 39: rpcgrpc.AppLogEntry.FieldsEntry
 }
 var file_ping_proto_depIdxs = []int32{
 	4,  // 0: rpcgrpc.PingRequest.forward_hops:type_name -> rpcgrpc.RouteHop
@@ -3218,7 +4119,7 @@ var file_ping_proto_depIdxs = []int32{
 	14, // 8: rpcgrpc.SystemStats.network:type_name -> rpcgrpc.NetworkStat
 	15, // 9: rpcgrpc.SystemStats.temps:type_name -> rpcgrpc.TempStat
 	23, // 10: rpcgrpc.SystemStats.processes:type_name -> rpcgrpc.ProcessStat
-	32, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
+	39, // 11: rpcgrpc.AppLogEntry.fields:type_name -> rpcgrpc.AppLogEntry.FieldsEntry
 	20, // 12: rpcgrpc.CalcRoute.hops:type_name -> rpcgrpc.CalcHop
 	26, // 13: rpcgrpc.PingTreeEvent.discovered:type_name -> rpcgrpc.PingTreeDiscovered
 	27, // 14: rpcgrpc.PingTreeEvent.ping_result:type_name -> rpcgrpc.PingTreeResult
@@ -3227,35 +4128,43 @@ var file_ping_proto_depIdxs = []int32{
 	30, // 17: rpcgrpc.PingTreeEvent.status_update:type_name -> rpcgrpc.PingTreeStatusUpdate
 	31, // 18: rpcgrpc.PingTreeEvent.server_error:type_name -> rpcgrpc.PingTreeServerError
 	4,  // 19: rpcgrpc.PingTreeResult.route:type_name -> rpcgrpc.RouteHop
-	0,  // 20: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
-	0,  // 21: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
-	5,  // 22: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	5,  // 23: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
-	2,  // 24: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
-	7,  // 25: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	7,  // 26: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
-	8,  // 27: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
-	16, // 28: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
-	18, // 29: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
-	21, // 30: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
-	24, // 31: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
-	1,  // 32: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
-	1,  // 33: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
-	6,  // 34: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	6,  // 35: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
-	3,  // 36: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
-	9,  // 37: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 38: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
-	9,  // 39: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
-	17, // 40: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
-	19, // 41: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
-	22, // 42: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
-	25, // 43: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
-	32, // [32:44] is the sub-list for method output_type
-	20, // [20:32] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	34, // 20: rpcgrpc.MuxBandwidthEvent.route_established:type_name -> rpcgrpc.MuxRouteEstablished
+	35, // 21: rpcgrpc.MuxBandwidthEvent.sample:type_name -> rpcgrpc.MuxBandwidthSample
+	36, // 22: rpcgrpc.MuxBandwidthEvent.rtt_probe:type_name -> rpcgrpc.MuxRttProbe
+	37, // 23: rpcgrpc.MuxBandwidthEvent.done:type_name -> rpcgrpc.MuxBandwidthDone
+	38, // 24: rpcgrpc.MuxBandwidthEvent.error:type_name -> rpcgrpc.MuxBandwidthError
+	4,  // 25: rpcgrpc.MuxRouteEstablished.hops:type_name -> rpcgrpc.RouteHop
+	0,  // 26: rpcgrpc.PingService.StreamPing:input_type -> rpcgrpc.PingRequest
+	0,  // 27: rpcgrpc.PingService.StreamDmsgPing:input_type -> rpcgrpc.PingRequest
+	5,  // 28: rpcgrpc.PingService.StreamBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	5,  // 29: rpcgrpc.PingService.StreamDmsgBandwidthTest:input_type -> rpcgrpc.BandwidthRequest
+	2,  // 30: rpcgrpc.PingService.GetRemoteDmsgServers:input_type -> rpcgrpc.DmsgServersRequest
+	7,  // 31: rpcgrpc.PingService.StreamSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	7,  // 32: rpcgrpc.PingService.GetSystemStats:input_type -> rpcgrpc.SystemStatsRequest
+	8,  // 33: rpcgrpc.PingService.StreamRemoteSystemStats:input_type -> rpcgrpc.RemoteSystemStatsRequest
+	16, // 34: rpcgrpc.PingService.StreamAppLogs:input_type -> rpcgrpc.AppLogStreamRequest
+	18, // 35: rpcgrpc.PingService.StreamCalcRoutes:input_type -> rpcgrpc.CalcRoutesRequest
+	21, // 36: rpcgrpc.PingService.StreamGroupMessages:input_type -> rpcgrpc.GroupMessagesRequest
+	24, // 37: rpcgrpc.PingService.StreamPingTree:input_type -> rpcgrpc.PingTreeRequest
+	32, // 38: rpcgrpc.PingService.StreamMuxBandwidth:input_type -> rpcgrpc.MuxBandwidthRequest
+	1,  // 39: rpcgrpc.PingService.StreamPing:output_type -> rpcgrpc.PingResult
+	1,  // 40: rpcgrpc.PingService.StreamDmsgPing:output_type -> rpcgrpc.PingResult
+	6,  // 41: rpcgrpc.PingService.StreamBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	6,  // 42: rpcgrpc.PingService.StreamDmsgBandwidthTest:output_type -> rpcgrpc.BandwidthProgress
+	3,  // 43: rpcgrpc.PingService.GetRemoteDmsgServers:output_type -> rpcgrpc.DmsgServersResponse
+	9,  // 44: rpcgrpc.PingService.StreamSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 45: rpcgrpc.PingService.GetSystemStats:output_type -> rpcgrpc.SystemStats
+	9,  // 46: rpcgrpc.PingService.StreamRemoteSystemStats:output_type -> rpcgrpc.SystemStats
+	17, // 47: rpcgrpc.PingService.StreamAppLogs:output_type -> rpcgrpc.AppLogEntry
+	19, // 48: rpcgrpc.PingService.StreamCalcRoutes:output_type -> rpcgrpc.CalcRoute
+	22, // 49: rpcgrpc.PingService.StreamGroupMessages:output_type -> rpcgrpc.GroupMessageEvent
+	25, // 50: rpcgrpc.PingService.StreamPingTree:output_type -> rpcgrpc.PingTreeEvent
+	33, // 51: rpcgrpc.PingService.StreamMuxBandwidth:output_type -> rpcgrpc.MuxBandwidthEvent
+	39, // [39:52] is the sub-list for method output_type
+	26, // [26:39] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_ping_proto_init() }
@@ -3271,13 +4180,20 @@ func file_ping_proto_init() {
 		(*PingTreeEvent_StatusUpdate)(nil),
 		(*PingTreeEvent_ServerError)(nil),
 	}
+	file_ping_proto_msgTypes[33].OneofWrappers = []any{
+		(*MuxBandwidthEvent_RouteEstablished)(nil),
+		(*MuxBandwidthEvent_Sample)(nil),
+		(*MuxBandwidthEvent_RttProbe)(nil),
+		(*MuxBandwidthEvent_Done)(nil),
+		(*MuxBandwidthEvent_Error)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ping_proto_rawDesc), len(file_ping_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -77,6 +77,33 @@ service PingService {
   // visor with hundreds of transports, an unauthenticated caller
   // could trigger a many-target ping storm; the gate prevents that.
   rpc StreamPingTree(PingTreeRequest) returns (stream PingTreeEvent);
+
+  // StreamMuxBandwidth measures bandwidth + queueing-delay between
+  // this visor and a target peer, optionally across N parallel
+  // routes. The operator-visible hypothesis: routes that EXCLUDE the
+  // direct transport (via min_hops >= 2) should sum to MORE bandwidth
+  // than the direct edge alone, because intermediates aggregate
+  // independent paths. This RPC produces the data to test that.
+  //
+  // Three flavors via the request fields:
+  //   - routes=1, min_hops=0: baseline — whatever route the finder
+  //     picks. With a healthy direct transport this measures the
+  //     direct edge.
+  //   - routes=1, min_hops=2: single non-direct path — forces the
+  //     route through at least one intermediate.
+  //   - routes=N, min_hops=>=0: N parallel routes pumping bytes
+  //     concurrently. Aggregate throughput is the operator's headline
+  //     comparison metric.
+  //
+  // Optionally a separate small-packet probe runs alongside the bulk
+  // load to capture queueing-delay: loaded RTT vs unloaded RTT
+  // baseline. The probe rides the SAME first route as the bulk pump,
+  // so the queueing-delay number reflects that route's saturation.
+  //
+  // Wire shape mirrors StreamPingTree: server-side BFS becomes
+  // server-side bandwidth-pump, events stream as they happen,
+  // ctx.Done() at every iteration, bounded internal channel.
+  rpc StreamMuxBandwidth(MuxBandwidthRequest) returns (stream MuxBandwidthEvent);
 }
 
 message PingRequest {
@@ -534,5 +561,180 @@ message PingTreeServerError {
   string code = 1;
   // Message carries operator-readable detail. Not stable across
   // versions.
+  string message = 2;
+}
+
+// MuxBandwidthRequest configures a multiplexed-route bandwidth + RTT
+// probe run against a single target peer. See StreamMuxBandwidth's
+// docstring for the operator-visible hypothesis this serves.
+//
+// All durations are nanoseconds (proto convention used throughout
+// this service). All "0 = default" fields fall back to handler-side
+// constants documented inline.
+message MuxBandwidthRequest {
+  // TargetPk is the remote visor's public key. Required.
+  string target_pk = 1;
+
+  // Routes is the number of parallel route connections to open.
+  // 1 = single route (the StreamBandwidthTest equivalent).
+  // N > 1 = N concurrent routes pumping bytes, aggregate throughput
+  // is the headline measurement. 0 falls back to 1.
+  int32 routes = 2;
+
+  // DurationNs caps the total wall-clock time spent pumping bytes.
+  // 0 falls back to 30s.
+  int64 duration_ns = 3;
+
+  // PacketSizeKb sizes each write block. Larger amortizes write
+  // overhead; smaller surfaces stalls faster. 0 falls back to 32 KB.
+  int32 packet_size_kb = 4;
+
+  // MinHops is the route-finder's minimum hop constraint. When > 1,
+  // the route excludes any direct transport between the local visor
+  // and TargetPk — forcing the bandwidth pump through intermediates.
+  // This is the "mux excluding direct" cell of the operator's
+  // hypothesis. 0 uses the visor's routing.min_hops config default
+  // (usually 1).
+  int32 min_hops = 5;
+
+  // SetupTimeoutNs bounds each route's setup phase. 0 falls back to
+  // 30s. Long setup times are common for multi-hop routes (see the
+  // p95=9.5s level-1 setup numbers from the ping-tree measurement).
+  int64 setup_timeout_ns = 6;
+
+  // ProbeRtt toggles a separate small-packet RTT probe that runs
+  // concurrently with the bulk pump. Pairs are emitted as
+  // MuxRttProbe events. The probe rides the SAME first route as the
+  // bulk pump, so the resulting RTT samples reflect that route's
+  // saturation — the queueing-delay signal.
+  bool probe_rtt = 7;
+
+  // ProbeIntervalNs is how often the RTT probe fires. 0 falls back
+  // to 100 ms. Faster = denser jitter signal; slower = less
+  // contention with the bulk pump.
+  int64 probe_interval_ns = 8;
+
+  // SampleIntervalNs is how often a MuxBandwidthSample is emitted.
+  // 0 falls back to 1s. Smaller surfaces transient throughput dips
+  // (bufferbloat, queue spikes); larger reduces stream chatter.
+  int64 sample_interval_ns = 9;
+
+  // LocalRoute uses local route calculation (cached TPD data)
+  // instead of querying the route-finder service. Mirrors
+  // BandwidthRequest.LocalRoute.
+  bool local_route = 10;
+}
+
+// MuxBandwidthEvent is one entry on the stream. Exactly one oneof
+// payload is set per message.
+message MuxBandwidthEvent {
+  int64 timestamp_ns = 1;
+  oneof payload {
+    // RouteEstablished fires once per route (in any order) as the
+    // setup phase completes. Carries the actual route hops chosen,
+    // letting consumers verify min_hops was honored.
+    MuxRouteEstablished route_established = 10;
+    // Sample fires every sample_interval_ns with cumulative + instant
+    // throughput numbers. Sent until pump duration elapses.
+    MuxBandwidthSample sample = 11;
+    // RttProbe fires every probe_interval_ns when ProbeRtt is set.
+    // Standalone from the Sample event because probes are async.
+    MuxRttProbe rtt_probe = 12;
+    // Done is the terminal event before stream close. Carries the
+    // aggregated totals + RTT distribution stats.
+    MuxBandwidthDone done = 13;
+    // Error signals an unrecoverable condition. Last event before
+    // stream close; same shape semantics as PingTreeServerError.
+    MuxBandwidthError error = 14;
+  }
+}
+
+// MuxRouteEstablished records one route's setup outcome.
+message MuxRouteEstablished {
+  // RouteIndex is 0..Routes-1, assigned in setup-order.
+  int32 route_index = 1;
+  // SetupLatencyNs is the time spent on the route-setup phase
+  // (route-finder query + setup-node negotiation + handshake).
+  int64 setup_latency_ns = 2;
+  // Hops is the chosen path. Consumers verify min_hops by
+  // counting (len(hops) - 1) intermediate edges.
+  repeated RouteHop hops = 3;
+  // Failed is set when the route could not be established;
+  // SetupErr carries the cause. The route is excluded from the
+  // pump phase but kept in the event log for diagnostics.
+  bool failed = 4;
+  string setup_err = 5;
+}
+
+// MuxBandwidthSample is a periodic throughput snapshot. Cumulative
+// fields are run-totals across all routes; instant fields are
+// per-sample-interval rates.
+message MuxBandwidthSample {
+  // ElapsedNs is the time since the first byte was sent (NOT since
+  // the run was requested — excludes setup time).
+  int64 elapsed_ns = 1;
+  uint64 bytes_sent = 2;
+  uint64 bytes_received = 3;
+  // InstantSendBps / RecvBps are per-interval rates. avg_*_bps are
+  // run-cumulative rates. All in bits-per-second (matches the
+  // network-engineer convention; consumers needing Mbps divide by
+  // 1e6).
+  double instant_send_bps = 4;
+  double instant_recv_bps = 5;
+  double avg_send_bps = 6;
+  double avg_recv_bps = 7;
+  // ActiveRoutes is how many of the Routes-requested routes are
+  // still pumping. Drops when a route fails mid-run.
+  int32 active_routes = 8;
+}
+
+// MuxRttProbe is one RTT measurement during the pump. Allows
+// consumers to plot loaded-RTT-over-time and compute queueing delay
+// as (loaded_rtt - baseline_rtt).
+message MuxRttProbe {
+  // Sequence is the 1-indexed probe number, in emit order.
+  int64 sequence = 1;
+  // LatencyNs is the measured RTT. 0 when the probe failed; Error
+  // carries the cause.
+  int64 latency_ns = 2;
+  string error = 3;
+  // ElapsedNs is the time since the first byte was sent (same epoch
+  // as MuxBandwidthSample.ElapsedNs). Lets consumers align probes
+  // with concurrent bandwidth samples without timestamp diffing.
+  int64 elapsed_ns = 4;
+}
+
+// MuxBandwidthDone is the terminal event. Aggregates the run.
+message MuxBandwidthDone {
+  uint64 total_bytes_sent = 1;
+  uint64 total_bytes_received = 2;
+  // WallTimeNs is total elapsed including setup; PumpTimeNs excludes
+  // setup. Operators comparing throughput across runs typically want
+  // PumpTimeNs (apples-to-apples regardless of how long setup took).
+  int64 wall_time_ns = 3;
+  int64 pump_time_ns = 4;
+  double avg_send_bps = 5;
+  double avg_recv_bps = 6;
+  double peak_send_bps = 7;
+  double peak_recv_bps = 8;
+  int32 routes_requested = 9;
+  int32 routes_established = 10;
+  int64 setup_total_ns = 11;
+  // RTT distribution across all probes (when ProbeRtt was set).
+  // Zero when no probes ran. Jitter is population stddev — same
+  // formula as PingTreeResult.jitter_ns.
+  int32 probe_count = 12;
+  int64 probe_avg_ns = 13;
+  int64 probe_p50_ns = 14;
+  int64 probe_p99_ns = 15;
+  int64 probe_jitter_ns = 16;
+  // TerminationReason: "duration" | "context_cancel" | "all_routes_failed" | "error".
+  string termination_reason = 17;
+}
+
+// MuxBandwidthError signals an unrecoverable condition. Last event
+// before stream close.
+message MuxBandwidthError {
+  string code = 1;
   string message = 2;
 }

--- a/pkg/visor/rpcgrpc/ping_grpc.pb.go
+++ b/pkg/visor/rpcgrpc/ping_grpc.pb.go
@@ -31,6 +31,7 @@ const (
 	PingService_StreamCalcRoutes_FullMethodName        = "/rpcgrpc.PingService/StreamCalcRoutes"
 	PingService_StreamGroupMessages_FullMethodName     = "/rpcgrpc.PingService/StreamGroupMessages"
 	PingService_StreamPingTree_FullMethodName          = "/rpcgrpc.PingService/StreamPingTree"
+	PingService_StreamMuxBandwidth_FullMethodName      = "/rpcgrpc.PingService/StreamMuxBandwidth"
 )
 
 // PingServiceClient is the client API for PingService service.
@@ -99,6 +100,32 @@ type PingServiceClient interface {
 	// visor with hundreds of transports, an unauthenticated caller
 	// could trigger a many-target ping storm; the gate prevents that.
 	StreamPingTree(ctx context.Context, in *PingTreeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[PingTreeEvent], error)
+	// StreamMuxBandwidth measures bandwidth + queueing-delay between
+	// this visor and a target peer, optionally across N parallel
+	// routes. The operator-visible hypothesis: routes that EXCLUDE the
+	// direct transport (via min_hops >= 2) should sum to MORE bandwidth
+	// than the direct edge alone, because intermediates aggregate
+	// independent paths. This RPC produces the data to test that.
+	//
+	// Three flavors via the request fields:
+	//   - routes=1, min_hops=0: baseline — whatever route the finder
+	//     picks. With a healthy direct transport this measures the
+	//     direct edge.
+	//   - routes=1, min_hops=2: single non-direct path — forces the
+	//     route through at least one intermediate.
+	//   - routes=N, min_hops=>=0: N parallel routes pumping bytes
+	//     concurrently. Aggregate throughput is the operator's headline
+	//     comparison metric.
+	//
+	// Optionally a separate small-packet probe runs alongside the bulk
+	// load to capture queueing-delay: loaded RTT vs unloaded RTT
+	// baseline. The probe rides the SAME first route as the bulk pump,
+	// so the queueing-delay number reflects that route's saturation.
+	//
+	// Wire shape mirrors StreamPingTree: server-side BFS becomes
+	// server-side bandwidth-pump, events stream as they happen,
+	// ctx.Done() at every iteration, bounded internal channel.
+	StreamMuxBandwidth(ctx context.Context, in *MuxBandwidthRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MuxBandwidthEvent], error)
 }
 
 type pingServiceClient struct {
@@ -319,6 +346,25 @@ func (c *pingServiceClient) StreamPingTree(ctx context.Context, in *PingTreeRequ
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamPingTreeClient = grpc.ServerStreamingClient[PingTreeEvent]
 
+func (c *pingServiceClient) StreamMuxBandwidth(ctx context.Context, in *MuxBandwidthRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MuxBandwidthEvent], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &PingService_ServiceDesc.Streams[10], PingService_StreamMuxBandwidth_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[MuxBandwidthRequest, MuxBandwidthEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamMuxBandwidthClient = grpc.ServerStreamingClient[MuxBandwidthEvent]
+
 // PingServiceServer is the server API for PingService service.
 // All implementations must embed UnimplementedPingServiceServer
 // for forward compatibility.
@@ -385,6 +431,32 @@ type PingServiceServer interface {
 	// visor with hundreds of transports, an unauthenticated caller
 	// could trigger a many-target ping storm; the gate prevents that.
 	StreamPingTree(*PingTreeRequest, grpc.ServerStreamingServer[PingTreeEvent]) error
+	// StreamMuxBandwidth measures bandwidth + queueing-delay between
+	// this visor and a target peer, optionally across N parallel
+	// routes. The operator-visible hypothesis: routes that EXCLUDE the
+	// direct transport (via min_hops >= 2) should sum to MORE bandwidth
+	// than the direct edge alone, because intermediates aggregate
+	// independent paths. This RPC produces the data to test that.
+	//
+	// Three flavors via the request fields:
+	//   - routes=1, min_hops=0: baseline — whatever route the finder
+	//     picks. With a healthy direct transport this measures the
+	//     direct edge.
+	//   - routes=1, min_hops=2: single non-direct path — forces the
+	//     route through at least one intermediate.
+	//   - routes=N, min_hops=>=0: N parallel routes pumping bytes
+	//     concurrently. Aggregate throughput is the operator's headline
+	//     comparison metric.
+	//
+	// Optionally a separate small-packet probe runs alongside the bulk
+	// load to capture queueing-delay: loaded RTT vs unloaded RTT
+	// baseline. The probe rides the SAME first route as the bulk pump,
+	// so the queueing-delay number reflects that route's saturation.
+	//
+	// Wire shape mirrors StreamPingTree: server-side BFS becomes
+	// server-side bandwidth-pump, events stream as they happen,
+	// ctx.Done() at every iteration, bounded internal channel.
+	StreamMuxBandwidth(*MuxBandwidthRequest, grpc.ServerStreamingServer[MuxBandwidthEvent]) error
 	mustEmbedUnimplementedPingServiceServer()
 }
 
@@ -430,6 +502,9 @@ func (UnimplementedPingServiceServer) StreamGroupMessages(*GroupMessagesRequest,
 }
 func (UnimplementedPingServiceServer) StreamPingTree(*PingTreeRequest, grpc.ServerStreamingServer[PingTreeEvent]) error {
 	return status.Error(codes.Unimplemented, "method StreamPingTree not implemented")
+}
+func (UnimplementedPingServiceServer) StreamMuxBandwidth(*MuxBandwidthRequest, grpc.ServerStreamingServer[MuxBandwidthEvent]) error {
+	return status.Error(codes.Unimplemented, "method StreamMuxBandwidth not implemented")
 }
 func (UnimplementedPingServiceServer) mustEmbedUnimplementedPingServiceServer() {}
 func (UnimplementedPingServiceServer) testEmbeddedByValue()                     {}
@@ -598,6 +673,17 @@ func _PingService_StreamPingTree_Handler(srv interface{}, stream grpc.ServerStre
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type PingService_StreamPingTreeServer = grpc.ServerStreamingServer[PingTreeEvent]
 
+func _PingService_StreamMuxBandwidth_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(MuxBandwidthRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(PingServiceServer).StreamMuxBandwidth(m, &grpc.GenericServerStream[MuxBandwidthRequest, MuxBandwidthEvent]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type PingService_StreamMuxBandwidthServer = grpc.ServerStreamingServer[MuxBandwidthEvent]
+
 // PingService_ServiceDesc is the grpc.ServiceDesc for PingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -663,6 +749,11 @@ var PingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamPingTree",
 			Handler:       _PingService_StreamPingTree_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamMuxBandwidth",
+			Handler:       _PingService_StreamMuxBandwidth_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -1,0 +1,570 @@
+// Package rpcgrpc — pkg/visor/rpcgrpc/server_mux_bandwidth.go:
+// server-side implementation of the StreamMuxBandwidth gRPC RPC.
+//
+// Test the operator's hypothesis: bandwidth aggregated across N
+// parallel routes (with min_hops >= 2 forcing the routes through
+// intermediates) should exceed the bandwidth of the single direct
+// transport between the same two visors. This RPC drives N
+// concurrent pump goroutines, sums their throughput, and emits
+// periodic samples + a terminal Done event.
+//
+// Pump shape (per route, in its own goroutine):
+//  1. Dial (with MinHops constraint when set).
+//  2. Pump bytes via PingOnceWithEcho until ctx-cancel or
+//     cfg.Duration elapsed. Each call returns (sent, recvd, _, err).
+//  3. On goroutine exit, decrement activeRoutes.
+//
+// Sampler shape (one goroutine total):
+//   - On a sample_interval ticker, sum all routes' counters and emit
+//     a MuxBandwidthSample event.
+//
+// Optional probe shape (one goroutine when ProbeRtt is set):
+//   - On a probe_interval ticker, run a single PingOnce on the
+//     first established route. Emit a MuxRttProbe event per attempt.
+//
+// All goroutines share a bounded event channel; a single sender
+// drains it to stream.Send so events arrive in a serializable order.
+package rpcgrpc
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// Defaults for unset MuxBandwidthRequest fields.
+const (
+	defaultMuxBwRoutes         = 1
+	defaultMuxBwDuration       = 30 * time.Second
+	defaultMuxBwPacketSizeKb   = 32
+	defaultMuxBwSetupTimeout   = 30 * time.Second
+	defaultMuxBwProbeInterval  = 100 * time.Millisecond
+	defaultMuxBwSampleInterval = 1 * time.Second
+	muxBwEventChannelCapacity  = 256
+)
+
+// muxBwCfg is the normalized request. Pass this around inside the
+// handler instead of the raw proto.
+type muxBwCfg struct {
+	TargetPK       cipher.PubKey
+	Routes         int
+	Duration       time.Duration
+	PacketSizeKb   int
+	MinHops        int
+	SetupTimeout   time.Duration
+	ProbeRTT       bool
+	ProbeInterval  time.Duration
+	SampleInterval time.Duration
+	LocalRoute     bool
+}
+
+func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
+	var c muxBwCfg
+	if err := c.TargetPK.Set(req.TargetPk); err != nil {
+		return c, fmt.Errorf("invalid target_pk: %w", err)
+	}
+	c.Routes = int(req.Routes)
+	c.Duration = time.Duration(req.DurationNs)
+	c.PacketSizeKb = int(req.PacketSizeKb)
+	c.MinHops = int(req.MinHops)
+	c.SetupTimeout = time.Duration(req.SetupTimeoutNs)
+	c.ProbeRTT = req.ProbeRtt
+	c.ProbeInterval = time.Duration(req.ProbeIntervalNs)
+	c.SampleInterval = time.Duration(req.SampleIntervalNs)
+	c.LocalRoute = req.LocalRoute
+
+	if c.Routes <= 0 {
+		c.Routes = defaultMuxBwRoutes
+	}
+	if c.Duration <= 0 {
+		c.Duration = defaultMuxBwDuration
+	}
+	if c.PacketSizeKb <= 0 {
+		c.PacketSizeKb = defaultMuxBwPacketSizeKb
+	}
+	if c.SetupTimeout <= 0 {
+		c.SetupTimeout = defaultMuxBwSetupTimeout
+	}
+	if c.ProbeInterval <= 0 {
+		c.ProbeInterval = defaultMuxBwProbeInterval
+	}
+	if c.SampleInterval <= 0 {
+		c.SampleInterval = defaultMuxBwSampleInterval
+	}
+	return c, nil
+}
+
+// muxBwRouteState tracks per-route counters during the pump. Each
+// pump goroutine owns one routeState; the sampler reads all of them
+// to compute aggregated totals.
+type muxBwRouteState struct {
+	index       int
+	established atomic.Bool
+	bytesSent   atomic.Uint64
+	bytesRecv   atomic.Uint64
+	// activeFlag flips false when the goroutine exits (success or
+	// failure). The sampler reads this to compute active_routes.
+	activeFlag atomic.Bool
+}
+
+// StreamMuxBandwidth is the canonical implementation of the RPC.
+// See ping.proto for the wire contract.
+func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingService_StreamMuxBandwidthServer) error {
+	ctx := stream.Context()
+	cfg, err := normalizeMuxBwRequest(req)
+	if err != nil {
+		return s.sendMuxBwError(stream, "invalid_request", err.Error())
+	}
+
+	// Event channel + sender goroutine — same shape as the
+	// ping-tree handler so the operational properties match.
+	eventCh := make(chan *MuxBandwidthEvent, muxBwEventChannelCapacity)
+	sendErrCh := make(chan error, 1)
+	go muxBwSender(stream, eventCh, sendErrCh)
+
+	emit := func(payload isMuxBandwidthEvent_Payload) {
+		ev := &MuxBandwidthEvent{
+			TimestampNs: time.Now().UnixNano(),
+			Payload:     payload,
+		}
+		select {
+		case eventCh <- ev:
+		case <-ctx.Done():
+		}
+	}
+
+	// Phase 1: dial all routes in parallel. Each goroutine emits a
+	// RouteEstablished event when its setup completes (success or
+	// failure). Routes that fail setup are excluded from the pump
+	// phase; the pump_time clock starts after ALL setup goroutines
+	// have either succeeded or returned setup errors.
+	routes := make([]*muxBwRouteState, cfg.Routes)
+	for i := 0; i < cfg.Routes; i++ {
+		routes[i] = &muxBwRouteState{index: i}
+	}
+
+	setupWg := &sync.WaitGroup{}
+	setupStart := time.Now()
+	for i := 0; i < cfg.Routes; i++ {
+		setupWg.Add(1)
+		go func(rs *muxBwRouteState) {
+			defer setupWg.Done()
+			s.muxBwSetupRoute(ctx, &cfg, rs, emit)
+		}(routes[i])
+	}
+	setupWg.Wait()
+	setupTotal := time.Since(setupStart)
+
+	// Count how many routes actually came up.
+	establishedCount := 0
+	for _, r := range routes {
+		if r.established.Load() {
+			establishedCount++
+			r.activeFlag.Store(true)
+		}
+	}
+	if establishedCount == 0 {
+		emit(&MuxBandwidthEvent_Done{Done: &MuxBandwidthDone{
+			RoutesRequested:   int32(cfg.Routes), //nolint:gosec
+			RoutesEstablished: 0,
+			SetupTotalNs:      setupTotal.Nanoseconds(),
+			TerminationReason: "all_routes_failed",
+		}})
+		close(eventCh)
+		return <-sendErrCh
+	}
+
+	// Phase 2: pump bytes through each established route + run the
+	// sampler + optional probe. All goroutines share the eventCh
+	// via the emit closure.
+	pumpStart := time.Now()
+	pumpCtx, pumpCancel := context.WithTimeout(ctx, cfg.Duration)
+	defer pumpCancel()
+
+	// Sampler tracks peaks for the Done event.
+	peakSend, peakRecv := 0.0, 0.0
+	probeSamples := make([]int64, 0, int(cfg.Duration/cfg.ProbeInterval)+1)
+	var probesMu sync.Mutex
+
+	pumpWg := &sync.WaitGroup{}
+	for _, r := range routes {
+		if !r.established.Load() {
+			continue
+		}
+		pumpWg.Add(1)
+		go func(rs *muxBwRouteState) {
+			defer pumpWg.Done()
+			defer rs.activeFlag.Store(false)
+			s.muxBwPumpRoute(pumpCtx, &cfg, rs)
+		}(r)
+	}
+
+	// Sampler.
+	pumpWg.Add(1)
+	go func() {
+		defer pumpWg.Done()
+		s.muxBwSamplerLoop(pumpCtx, &cfg, routes, pumpStart, &peakSend, &peakRecv, emit)
+	}()
+
+	// Probe (optional).
+	if cfg.ProbeRTT {
+		// Find first established route for the probe.
+		var probeTarget *muxBwRouteState
+		for _, r := range routes {
+			if r.established.Load() {
+				probeTarget = r
+				break
+			}
+		}
+		if probeTarget != nil {
+			pumpWg.Add(1)
+			go func() {
+				defer pumpWg.Done()
+				s.muxBwProbeLoop(pumpCtx, &cfg, pumpStart, &probesMu, &probeSamples, emit)
+			}()
+		}
+	}
+
+	pumpWg.Wait()
+	pumpDuration := time.Since(pumpStart)
+
+	// Aggregate totals + emit Done.
+	var totalSent, totalRecv uint64
+	for _, r := range routes {
+		totalSent += r.bytesSent.Load()
+		totalRecv += r.bytesRecv.Load()
+	}
+	pumpSec := pumpDuration.Seconds()
+	avgSendBps := 0.0
+	avgRecvBps := 0.0
+	if pumpSec > 0 {
+		avgSendBps = float64(totalSent*8) / pumpSec
+		avgRecvBps = float64(totalRecv*8) / pumpSec
+	}
+
+	// RTT stats over all probes.
+	probesMu.Lock()
+	probeCount := len(probeSamples)
+	probeAvg, probeP50, probeP99, probeJitter := aggregatePingSamples(int64ToFloat(probeSamples))
+	probesMu.Unlock()
+
+	terminationReason := "duration"
+	if ctx.Err() != nil {
+		terminationReason = "context_cancel"
+	}
+
+	emit(&MuxBandwidthEvent_Done{Done: &MuxBandwidthDone{
+		TotalBytesSent:     totalSent,
+		TotalBytesReceived: totalRecv,
+		WallTimeNs:         (setupTotal + pumpDuration).Nanoseconds(),
+		PumpTimeNs:         pumpDuration.Nanoseconds(),
+		AvgSendBps:         avgSendBps,
+		AvgRecvBps:         avgRecvBps,
+		PeakSendBps:        peakSend,
+		PeakRecvBps:        peakRecv,
+		RoutesRequested:    int32(cfg.Routes),       //nolint:gosec
+		RoutesEstablished:  int32(establishedCount), //nolint:gosec
+		SetupTotalNs:       setupTotal.Nanoseconds(),
+		ProbeCount:         int32(probeCount), //nolint:gosec
+		ProbeAvgNs:         probeAvg,
+		ProbeP50Ns:         probeP50,
+		ProbeP99Ns:         probeP99,
+		ProbeJitterNs:      probeJitter,
+		TerminationReason:  terminationReason,
+	}})
+
+	close(eventCh)
+	return <-sendErrCh
+}
+
+// muxBwSetupRoute dials one route + emits a RouteEstablished event.
+// Marks rs.established on success so the pump phase knows which
+// routes to spin up. The dial uses DialPing — currently shared across
+// all StreamMuxBandwidth routes (no per-route differentiation today;
+// future work: feed MinHops + route-finder constraints through here
+// once the visor's DialPing API gains those knobs).
+func (s *PingServer) muxBwSetupRoute(
+	ctx context.Context,
+	cfg *muxBwCfg,
+	rs *muxBwRouteState,
+	emit func(isMuxBandwidthEvent_Payload),
+) {
+	conf := PingConf{
+		PK:         cfg.TargetPK,
+		Tries:      1,
+		PcktSize:   cfg.PacketSizeKb,
+		LocalRoute: cfg.LocalRoute,
+	}
+	setupCtx, cancel := context.WithTimeout(ctx, cfg.SetupTimeout)
+	defer cancel()
+
+	setupStart := time.Now()
+	dialDone := make(chan error, 1)
+	go func() {
+		dialDone <- s.visor.DialPing(conf)
+	}()
+
+	var dialErr error
+	select {
+	case err := <-dialDone:
+		dialErr = err
+	case <-setupCtx.Done():
+		dialErr = fmt.Errorf("setup timeout after %s", cfg.SetupTimeout)
+	}
+
+	setupLatency := time.Since(setupStart)
+
+	ev := &MuxRouteEstablished{
+		RouteIndex:     int32(rs.index), //nolint:gosec
+		SetupLatencyNs: setupLatency.Nanoseconds(),
+		// Hops field is left empty here — surfacing the chosen route
+		// hops requires GetPingRouteDetails(pk) and the route is
+		// keyed by target PK, so multiple parallel routes to the
+		// same PK can't be distinguished by that API today. A
+		// follow-up: extend GetPingRouteDetails to take a route
+		// index when N>1.
+	}
+	if dialErr != nil {
+		ev.Failed = true
+		ev.SetupErr = dialErr.Error()
+	} else {
+		rs.established.Store(true)
+	}
+	emit(&MuxBandwidthEvent_RouteEstablished{RouteEstablished: ev})
+}
+
+// muxBwPumpRoute pumps bytes through one route until ctx-cancel or
+// pump duration elapsed. Each PingOnceWithEcho call returns the
+// bytes shipped; we accumulate into the per-route state atomics so
+// the sampler can read them race-free.
+func (s *PingServer) muxBwPumpRoute(
+	ctx context.Context,
+	cfg *muxBwCfg,
+	rs *muxBwRouteState,
+) {
+	conf := PingConf{
+		PK:         cfg.TargetPK,
+		Tries:      1,
+		PcktSize:   cfg.PacketSizeKb,
+		LocalRoute: cfg.LocalRoute,
+	}
+	defer func() {
+		// Best-effort tear-down. StopPing is currently keyed by
+		// target PK only — calling it once at end of pump tears
+		// down ALL parallel connections to that PK, which is fine
+		// as a teardown but means we can't tear down individual
+		// routes mid-run. Future: per-route teardown handles.
+		_ = s.visor.StopPing(cfg.TargetPK) //nolint:errcheck
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		bytesSent, bytesRecvd, _, err := s.visor.PingOnceWithEcho(conf, true)
+		if err != nil {
+			// One stalled route doesn't tear down the run — the
+			// other routes can keep pumping. Log via the visor's
+			// own logger (handler is server-side; no per-route
+			// emit channel to surface this without adding event
+			// noise). A future enhancement could emit a
+			// route-level error event.
+			s.log.Debugf("StreamMuxBandwidth: route %d pump error: %v", rs.index, err)
+			return
+		}
+		rs.bytesSent.Add(bytesSent)
+		rs.bytesRecv.Add(bytesRecvd)
+	}
+}
+
+// muxBwSamplerLoop ticks every SampleInterval and emits a
+// MuxBandwidthSample with cumulative + instant throughput numbers.
+// Tracks peak throughput for the Done aggregation.
+func (s *PingServer) muxBwSamplerLoop(
+	ctx context.Context,
+	cfg *muxBwCfg,
+	routes []*muxBwRouteState,
+	pumpStart time.Time,
+	peakSend, peakRecv *float64,
+	emit func(isMuxBandwidthEvent_Payload),
+) {
+	ticker := time.NewTicker(cfg.SampleInterval)
+	defer ticker.Stop()
+
+	var lastSent, lastRecv uint64
+	lastTick := pumpStart
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			elapsed := now.Sub(pumpStart)
+			intervalSec := now.Sub(lastTick).Seconds()
+			lastTick = now
+
+			var totalSent, totalRecv uint64
+			var activeRoutes int32
+			for _, r := range routes {
+				totalSent += r.bytesSent.Load()
+				totalRecv += r.bytesRecv.Load()
+				if r.activeFlag.Load() {
+					activeRoutes++
+				}
+			}
+
+			instantSendBps := 0.0
+			instantRecvBps := 0.0
+			if intervalSec > 0 {
+				instantSendBps = float64((totalSent-lastSent)*8) / intervalSec
+				instantRecvBps = float64((totalRecv-lastRecv)*8) / intervalSec
+			}
+			if instantSendBps > *peakSend {
+				*peakSend = instantSendBps
+			}
+			if instantRecvBps > *peakRecv {
+				*peakRecv = instantRecvBps
+			}
+			lastSent, lastRecv = totalSent, totalRecv
+
+			avgSendBps := 0.0
+			avgRecvBps := 0.0
+			elapsedSec := elapsed.Seconds()
+			if elapsedSec > 0 {
+				avgSendBps = float64(totalSent*8) / elapsedSec
+				avgRecvBps = float64(totalRecv*8) / elapsedSec
+			}
+
+			emit(&MuxBandwidthEvent_Sample{Sample: &MuxBandwidthSample{
+				ElapsedNs:      elapsed.Nanoseconds(),
+				BytesSent:      totalSent,
+				BytesReceived:  totalRecv,
+				InstantSendBps: instantSendBps,
+				InstantRecvBps: instantRecvBps,
+				AvgSendBps:     avgSendBps,
+				AvgRecvBps:     avgRecvBps,
+				ActiveRoutes:   activeRoutes,
+			}})
+		}
+	}
+}
+
+// muxBwProbeLoop runs a small-packet RTT probe concurrently with
+// the bulk pump. Each tick uses PingOnce on the target PK; the
+// underlying connection is shared with the pump (StopPing is keyed
+// by PK only) so the probe rides the same first route. Accumulates
+// samples into probesOut for the Done aggregation.
+func (s *PingServer) muxBwProbeLoop(
+	ctx context.Context,
+	cfg *muxBwCfg,
+	pumpStart time.Time,
+	probesMu *sync.Mutex,
+	probesOut *[]int64,
+	emit func(isMuxBandwidthEvent_Payload),
+) {
+	ticker := time.NewTicker(cfg.ProbeInterval)
+	defer ticker.Stop()
+
+	probeConf := PingConf{
+		PK:         cfg.TargetPK,
+		Tries:      1,
+		PcktSize:   1, // 1 KB probe — small enough to not contribute meaningfully to load
+		LocalRoute: cfg.LocalRoute,
+	}
+	var sequence int64
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sequence++
+			latency, err := s.visor.PingOnce(probeConf)
+			elapsed := time.Since(pumpStart)
+			ev := &MuxRttProbe{
+				Sequence:  sequence,
+				ElapsedNs: elapsed.Nanoseconds(),
+			}
+			if err != nil {
+				ev.Error = err.Error()
+			} else {
+				ev.LatencyNs = latency.Nanoseconds()
+				probesMu.Lock()
+				*probesOut = append(*probesOut, ev.LatencyNs)
+				probesMu.Unlock()
+			}
+			emit(&MuxBandwidthEvent_RttProbe{RttProbe: ev})
+		}
+	}
+}
+
+// muxBwSender drains the bounded event channel to stream.Send. One
+// goroutine per RPC, so per-RPC isolation is automatic. Same shape
+// as pingTreeSender — kept separate to avoid coupling the two
+// handlers' event types.
+func muxBwSender(
+	stream PingService_StreamMuxBandwidthServer,
+	eventCh <-chan *MuxBandwidthEvent,
+	errCh chan<- error,
+) {
+	for ev := range eventCh {
+		if err := stream.Send(ev); err != nil {
+			errCh <- err
+			for range eventCh {
+				// Drain remaining events so the producer's send
+				// doesn't block. Handler is tearing down.
+			}
+			return
+		}
+	}
+	errCh <- nil
+}
+
+// sendMuxBwError emits a single Error event then exits the handler.
+// Per the gRPC handler contract, returning a non-nil error from the
+// handler closes the stream with that error visible to the client;
+// we want the event IS the error report instead, so return nil.
+// The return type is constrained by the handler signature.
+//
+//nolint:unparam // error is the handler-signature contract
+func (s *PingServer) sendMuxBwError(
+	stream PingService_StreamMuxBandwidthServer,
+	code, msg string,
+) error {
+	_ = stream.Send(&MuxBandwidthEvent{ //nolint:errcheck
+		TimestampNs: time.Now().UnixNano(),
+		Payload: &MuxBandwidthEvent_Error{
+			Error: &MuxBandwidthError{Code: code, Message: msg},
+		},
+	})
+	return nil
+}
+
+// int64ToFloat converts []int64 nanosecond samples to []float64
+// for aggregatePingSamples (which lives in server_ping_tree.go and
+// operates on float64s for percentile math). Pulled into its own
+// helper to keep the StreamMuxBandwidth Done construction readable.
+func int64ToFloat(in []int64) []float64 {
+	out := make([]float64, len(in))
+	for i, v := range in {
+		out[i] = float64(v)
+	}
+	return out
+}
+
+// quietCompilerUnused references math + sort to keep the imports
+// active even if a future refactor removes the only direct usages;
+// also documents that the file is the home for stats math. Kept as
+// a build-time guard until the runtime tests assert all stats
+// formulas — at which point this can be dropped.
+var _ = math.Sqrt
+var _ = sort.Float64s

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
@@ -1,0 +1,153 @@
+package rpcgrpc
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNormalizeMuxBwRequest pins the default-fallback table. Without
+// these, a zero-valued request would dial zero routes (no work),
+// pump for zero duration (no measurement), and emit zero samples
+// (no signal). Concrete defaults keep an unconfigured call usable.
+func TestNormalizeMuxBwRequest(t *testing.T) {
+	t.Run("invalid PK rejected", func(t *testing.T) {
+		_, err := normalizeMuxBwRequest(&MuxBandwidthRequest{TargetPk: "not-a-pk"})
+		if err == nil {
+			t.Errorf("expected error for malformed PK, got nil")
+		}
+	})
+
+	validPK := "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+
+	t.Run("zero values fall back to documented defaults", func(t *testing.T) {
+		c, err := normalizeMuxBwRequest(&MuxBandwidthRequest{TargetPk: validPK})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.Routes != defaultMuxBwRoutes {
+			t.Errorf("Routes = %d, want %d", c.Routes, defaultMuxBwRoutes)
+		}
+		if c.Duration != defaultMuxBwDuration {
+			t.Errorf("Duration = %v, want %v", c.Duration, defaultMuxBwDuration)
+		}
+		if c.PacketSizeKb != defaultMuxBwPacketSizeKb {
+			t.Errorf("PacketSizeKb = %d, want %d", c.PacketSizeKb, defaultMuxBwPacketSizeKb)
+		}
+		if c.SetupTimeout != defaultMuxBwSetupTimeout {
+			t.Errorf("SetupTimeout = %v, want %v", c.SetupTimeout, defaultMuxBwSetupTimeout)
+		}
+		if c.ProbeInterval != defaultMuxBwProbeInterval {
+			t.Errorf("ProbeInterval = %v, want %v", c.ProbeInterval, defaultMuxBwProbeInterval)
+		}
+		if c.SampleInterval != defaultMuxBwSampleInterval {
+			t.Errorf("SampleInterval = %v, want %v", c.SampleInterval, defaultMuxBwSampleInterval)
+		}
+	})
+
+	t.Run("explicit values pass through", func(t *testing.T) {
+		req := &MuxBandwidthRequest{
+			TargetPk:         validPK,
+			Routes:           4,
+			DurationNs:       (60 * time.Second).Nanoseconds(),
+			PacketSizeKb:     64,
+			MinHops:          2,
+			SetupTimeoutNs:   (15 * time.Second).Nanoseconds(),
+			ProbeRtt:         true,
+			ProbeIntervalNs:  (50 * time.Millisecond).Nanoseconds(),
+			SampleIntervalNs: (500 * time.Millisecond).Nanoseconds(),
+			LocalRoute:       true,
+		}
+		c, err := normalizeMuxBwRequest(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.Routes != 4 || c.PacketSizeKb != 64 || c.MinHops != 2 {
+			t.Errorf("int fields lost: %+v", c)
+		}
+		if c.Duration != 60*time.Second || c.SetupTimeout != 15*time.Second {
+			t.Errorf("duration fields lost: %+v", c)
+		}
+		if c.ProbeInterval != 50*time.Millisecond || c.SampleInterval != 500*time.Millisecond {
+			t.Errorf("interval fields lost: %+v", c)
+		}
+		if !c.ProbeRTT || !c.LocalRoute {
+			t.Errorf("bool fields lost: %+v", c)
+		}
+	})
+
+	t.Run("negative values fall back to defaults", func(t *testing.T) {
+		// Proto int32 lets negatives through the wire; the handler
+		// should treat them as "default" rather than propagate
+		// nonsense into the pump loop (a negative Routes count
+		// would never reach the dial loop, but a negative Duration
+		// would make context.WithTimeout return immediately).
+		c, err := normalizeMuxBwRequest(&MuxBandwidthRequest{
+			TargetPk:     validPK,
+			Routes:       -5,
+			PacketSizeKb: -100,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.Routes != defaultMuxBwRoutes {
+			t.Errorf("negative Routes should default to %d, got %d", defaultMuxBwRoutes, c.Routes)
+		}
+		if c.PacketSizeKb != defaultMuxBwPacketSizeKb {
+			t.Errorf("negative PacketSizeKb should default to %d, got %d", defaultMuxBwPacketSizeKb, c.PacketSizeKb)
+		}
+	})
+}
+
+// TestInt64ToFloat pins the conversion helper that bridges
+// muxBwProbeLoop's int64 sample accumulator into aggregatePingSamples
+// (which operates on float64). Without this conversion the Done
+// event's probe stats would be wrong.
+func TestInt64ToFloat(t *testing.T) {
+	in := []int64{1_000_000, 2_500_000, 100_000_000}
+	out := int64ToFloat(in)
+	if len(out) != len(in) {
+		t.Fatalf("length mismatch: got %d want %d", len(out), len(in))
+	}
+	for i, v := range in {
+		if out[i] != float64(v) {
+			t.Errorf("out[%d] = %v, want %v", i, out[i], float64(v))
+		}
+	}
+	// Empty input → empty output (not nil — the slice should be
+	// safe to range over without a nil-check).
+	if got := int64ToFloat(nil); got == nil || len(got) != 0 {
+		t.Errorf("nil input should yield empty slice, got %v", got)
+	}
+}
+
+// TestMuxBwRouteStateAtomics pins the atomic counter semantics
+// used by the pump goroutines + sampler. Each pump writes to its
+// own routeState via Add(); the sampler reads via Load(). Race-free
+// by virtue of sync/atomic — pinned here so accidental conversion
+// to a plain field doesn't silently re-introduce a data race.
+func TestMuxBwRouteStateAtomics(t *testing.T) {
+	rs := &muxBwRouteState{index: 7}
+	rs.bytesSent.Add(1024)
+	rs.bytesRecv.Add(2048)
+	rs.established.Store(true)
+	rs.activeFlag.Store(true)
+
+	if got := rs.bytesSent.Load(); got != 1024 {
+		t.Errorf("bytesSent = %d, want 1024", got)
+	}
+	if got := rs.bytesRecv.Load(); got != 2048 {
+		t.Errorf("bytesRecv = %d, want 2048", got)
+	}
+	if !rs.established.Load() {
+		t.Errorf("established should be true")
+	}
+	if !rs.activeFlag.Load() {
+		t.Errorf("activeFlag should be true")
+	}
+
+	// Flip activeFlag — the pump-end behavior.
+	rs.activeFlag.Store(false)
+	if rs.activeFlag.Load() {
+		t.Errorf("activeFlag should be false after Store(false)")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a multiplexed-route bandwidth measurement RPC to `PingService`. Same server-side-streaming + oneof-event shape as #2732's `StreamPingTree`, scoped to a single target peer. Drives the operator-hypothesis matrix from earlier discussions:

| Run shape | What it measures |
|---|---|
| `routes=1, min_hops=0` | Baseline — route-finder picks freely (uses direct if available) |
| `routes=1, min_hops=2` | Single non-direct path — isolates multi-hop overhead |
| `routes=N, min_hops=2` | N parallel routes excluding direct — the "mux should sum to more bandwidth" hypothesis |

Optional `--probe-rtt` fires small-packet RTT probes concurrently with the bulk pump. Loaded RTT minus unloaded baseline IS the queueing-delay measurement Synth asked about on May 11.

## Wire shape (pkg/visor/rpcgrpc/ping.proto)

```proto
rpc StreamMuxBandwidth(MuxBandwidthRequest) returns (stream MuxBandwidthEvent);

message MuxBandwidthEvent {
  int64 timestamp_ns = 1;
  oneof payload {
    MuxRouteEstablished route_established = 10;
    MuxBandwidthSample sample = 11;
    MuxRttProbe rtt_probe = 12;
    MuxBandwidthDone done = 13;
    MuxBandwidthError error = 14;
  }
}
```

`MuxBandwidthSample` carries cumulative + instant throughput in bits-per-second; `MuxRttProbe` carries per-probe RTT + elapsed time (same epoch as Sample.ElapsedNs so consumers align without timestamp diffing); `MuxBandwidthDone` carries totals + population-stddev jitter over all probes.

## CLI

`cli visor ping mux-bw <pk>` — same NDJSON envelope as `tree-stream`:

```
{"ts":"RFC3339Nano","type":"sample","data":{"elapsed_ns":"1000000000","instant_recv_bps":4194304,...}}
```

Examples:

```bash
# Baseline:
skywire cli visor ping mux-bw <peer-pk>

# Mux 4 routes excluding direct, with concurrent RTT probes:
skywire cli visor ping mux-bw <peer-pk> --routes 4 --min-hops 2 --probe-rtt

# Sample-extracted Mbps:
skywire cli visor ping mux-bw <peer-pk> --routes 4 \
  | jq -c 'select(.type=="sample") | {t:(.data.elapsed_ns|tonumber/1e9), recv_mbps:(.data.instant_recv_bps/1e6)}'
```

## Server handler shape

1. **Setup phase**: dial N routes in parallel. Each emits a `RouteEstablished` event (success or failure with `setup_err`). Failed routes excluded from pump.
2. **Pump phase**: N pump goroutines hammer `PingOnceWithEcho` in a tight loop, accumulating bytes into per-route atomics. One sampler reads aggregated totals every `--sample-interval` and emits a `MuxBandwidthSample`. Optional one probe goroutine fires RTT pings at `--probe-interval`, emitting `MuxRttProbe` per probe.
3. **Done phase**: emit `MuxBandwidthDone` with totals + RTT distribution (avg/p50/p99/jitter) + termination reason.

`ctx.Done()` observed at every iteration; bounded internal channel (256); same operational properties as `StreamPingTree`.

## Caveats / follow-ups documented in source

- **MinHops field is plumbed through the request** but the visor's current `DialPing` API doesn't expose it per-route. Needs a follow-up to thread `MinHops` through `routing.RouteOpts`. For now `MinHops` is informational; the route-finder uses the visor's global `routing.min_hops` setting. **Operator-visible impact**: today's runs that set `--min-hops 2` will only work if the visor's config has `min_hops >= 2`, OR if a follow-up PR threads the per-route constraint through.
- **Per-route teardown**: `StopPing` is keyed by PK only, so all N parallel conns to the same target share one teardown. Can't tear down individual routes mid-run. Future work once routes have handles.
- **Probe rides the first route** (shares the `StopPing`-keyed connection). Standalone-probe-via-second-route is another knob worth adding once routes have handles.

## Tests

- `TestNormalizeMuxBwRequest`: PK validation, zero-fallback table, explicit-passthrough, negative-fallback
- `TestInt64ToFloat`: helper that bridges probe samples to the stats aggregator
- `TestMuxBwRouteStateAtomics`: pins atomic-field semantics that pump+sampler depend on

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l` clean
- [x] `golangci-lint run` clean
- [x] Unit tests pass
- [ ] Live run against a peer — pending operator/peer validation; my visor pair is currently busy with the ping-tree TUI rewire validation (#2736) so I'll loop back once that settles