### PR TITLE
feat(cli/ping-mux-bw): bubbletea TUI dashboard for StreamMuxBandwidth

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth_tui.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth_tui.go
@@ -1,0 +1,774 @@
+// Package ping — cmd/skywire-cli/commands/visor/ping/mux_bandwidth_tui.go:
+// Bubble Tea TUI consumer of the StreamMuxBandwidth gRPC RPC.
+//
+// Operator-visible: `cli visor ping mux-bw-tui <pk>` runs the same
+// multiplexed-route bandwidth test as `mux-bw` but presents it as a
+// live dashboard instead of NDJSON: per-route status row,
+// throughput sparkline, RTT-probe sparkline (when --probe-rtt is
+// set), and a scrollable events log.
+//
+// Identical flags to `mux-bw`; the only difference is rendering.
+// Both subcommands ride the same server-side RPC handler, so a
+// change at the server lands in both.
+package ping
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+)
+
+func init() {
+	// All flags mirror `mux-bw` exactly — the variables are
+	// shared across files in this package so the TUI command picks
+	// up the same defaults / parser as the NDJSON command.
+	muxBandwidthTUICmd.Flags().IntVarP(&muxBwRoutes, "routes", "r", 1,
+		"number of parallel route connections (1 = baseline single route)")
+	muxBandwidthTUICmd.Flags().DurationVarP(&muxBwDuration, "duration", "d", 30*time.Second,
+		"how long to pump bytes (excludes route-setup time)")
+	muxBandwidthTUICmd.Flags().IntVarP(&muxBwPacketSizeKb, "size", "s", 32,
+		"per-write block size in KB")
+	muxBandwidthTUICmd.Flags().IntVar(&muxBwMinHops, "min-hops", 0,
+		"route-finder min hops constraint (>=2 excludes the direct transport)")
+	muxBandwidthTUICmd.Flags().DurationVar(&muxBwSetupTimeout, "setup-timeout", 30*time.Second,
+		"per-route setup timeout")
+	muxBandwidthTUICmd.Flags().BoolVar(&muxBwProbeRTT, "probe-rtt", false,
+		"also send small-packet RTT probes during the load (queueing-delay measurement)")
+	muxBandwidthTUICmd.Flags().DurationVar(&muxBwProbeInterval, "probe-interval", 100*time.Millisecond,
+		"interval between RTT probes when --probe-rtt is set")
+	muxBandwidthTUICmd.Flags().DurationVar(&muxBwSampleInterval, "sample-interval", 1*time.Second,
+		"interval between MuxBandwidthSample events")
+	muxBandwidthTUICmd.Flags().BoolVar(&muxBwLocalRoute, "local-route", false,
+		"use locally-cached TPD data for route calculation (faster setup; may be stale)")
+
+	RootCmd.AddCommand(muxBandwidthTUICmd)
+}
+
+var muxBandwidthTUICmd = &cobra.Command{
+	Use:   "mux-bw-tui <pk>",
+	Short: "Interactive Bubble Tea TUI for the multiplexed-route bandwidth probe",
+	Long: `Live dashboard for StreamMuxBandwidth — same RPC as
+'cli visor ping mux-bw', different rendering.
+
+The screen shows:
+  * Per-route status row — one tile per route with state, hop count, setup time
+  * Live stats line — instant + avg + peak throughput, bytes pumped, active routes
+  * Throughput sparkline — last 60 sample-interval ticks
+  * RTT sparkline (when --probe-rtt) — last 60 probes
+  * Events log — scrollable viewport
+
+For automation / harness consumption use the NDJSON sibling
+'cli visor ping mux-bw' instead.
+
+Controls inside the TUI:
+  ↑/k, ↓/j     scroll events one line
+  PgUp/PgDn    page up/down
+  Home/End     top/bottom
+  a            toggle auto-scroll
+  q/Ctrl+C     quit (results print to stdout on exit)`,
+	Args: cobra.ExactArgs(1),
+	Run:  runMuxBandwidthTUI,
+}
+
+func runMuxBandwidthTUI(_ *cobra.Command, args []string) {
+	targetPK := args[0]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := rpcgrpc.NewPingClient(clirpc.Addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mux-bw-tui: gRPC client connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close() //nolint:errcheck
+
+	req := &rpcgrpc.MuxBandwidthRequest{
+		TargetPk:         targetPK,
+		Routes:           int32(muxBwRoutes), //nolint:gosec
+		DurationNs:       muxBwDuration.Nanoseconds(),
+		PacketSizeKb:     int32(muxBwPacketSizeKb), //nolint:gosec
+		MinHops:          int32(muxBwMinHops),      //nolint:gosec
+		SetupTimeoutNs:   muxBwSetupTimeout.Nanoseconds(),
+		ProbeRtt:         muxBwProbeRTT,
+		ProbeIntervalNs:  muxBwProbeInterval.Nanoseconds(),
+		SampleIntervalNs: muxBwSampleInterval.Nanoseconds(),
+		LocalRoute:       muxBwLocalRoute,
+	}
+
+	stream, err := client.StreamMuxBandwidth(ctx, req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mux-bw-tui: StreamMuxBandwidth call: %v\n", err)
+		os.Exit(1)
+	}
+
+	model := newMuxBwTUIModel(ctx, cancel, targetPK, *req)
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithContext(ctx))
+	go muxBwConsumeStream(stream, p)
+
+	if _, err := p.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "mux-bw-tui: TUI: %v\n", err)
+		os.Exit(1)
+	}
+
+	// tea.WithAltScreen wipes the screen on exit; reprint the final
+	// dashboard to stdout so the run lands in terminal scrollback
+	// regardless of how it terminated. Same pattern as ping tree.
+	fmt.Print(model.renderHeader() + "\n")
+	fmt.Print(model.renderRoutes() + "\n")
+	fmt.Print(model.renderStats() + "\n")
+	fmt.Print(model.renderThroughputBlock() + "\n")
+	if muxBwProbeRTT {
+		fmt.Print(model.renderRttBlock() + "\n")
+	}
+	fmt.Print(model.renderDone() + "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Stream consumer
+// ---------------------------------------------------------------------------
+
+type muxBwEventMsg struct{ ev *rpcgrpc.MuxBandwidthEvent }
+type muxBwStreamDoneMsg struct{}
+type muxBwStreamErrMsg struct{ err error }
+
+func muxBwConsumeStream(stream rpcgrpc.PingService_StreamMuxBandwidthClient, p *tea.Program) {
+	for {
+		ev, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				p.Send(muxBwStreamDoneMsg{})
+				return
+			}
+			p.Send(muxBwStreamErrMsg{err: err})
+			return
+		}
+		p.Send(muxBwEventMsg{ev: ev})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model
+// ---------------------------------------------------------------------------
+
+const (
+	muxBwSparkWidth   = 60
+	muxBwEventBufSize = 500
+)
+
+type muxBwRoute struct {
+	established bool
+	failed      bool
+	setupErr    string
+	setupNs     int64
+	hopCount    int
+}
+
+type muxBwTimePoint struct {
+	elapsedNs int64
+	value     float64
+}
+
+type muxBwEvent struct {
+	elapsedNs int64
+	text      string
+}
+
+type muxBwTUIModel struct {
+	viewport viewport.Model
+	spinner  spinner.Model
+
+	ready      bool
+	quitting   bool
+	width      int
+	height     int
+	autoScroll bool
+
+	targetPK string
+	req      rpcgrpc.MuxBandwidthRequest
+
+	mu sync.RWMutex
+
+	routes []muxBwRoute // index = route index
+
+	// Throughput history (instant recv bps per sample-interval tick).
+	throughput []muxBwTimePoint
+	rttProbes  []muxBwTimePoint
+
+	// Latest stats (from most recent Sample event).
+	cumSent        uint64
+	cumRecv        uint64
+	avgSendBps     float64
+	avgRecvBps     float64
+	instantSendBps float64
+	instantRecvBps float64
+	peakRecvBps    float64
+	peakSendBps    float64
+	activeRoutes   int32
+
+	probeCount int64
+	probeSum   int64
+
+	events []muxBwEvent
+
+	runStart    time.Time
+	streamEnded bool
+	streamErr   error
+	serverError string
+	done        *rpcgrpc.MuxBandwidthDone
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func newMuxBwTUIModel(ctx context.Context, cancel context.CancelFunc, targetPK string, req rpcgrpc.MuxBandwidthRequest) *muxBwTUIModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Line
+	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("86"))
+
+	return &muxBwTUIModel{
+		spinner:    sp,
+		autoScroll: true,
+		ctx:        ctx,
+		cancel:     cancel,
+		runStart:   time.Now(),
+		targetPK:   targetPK,
+		req:        req,
+		routes:     make([]muxBwRoute, req.Routes),
+	}
+}
+
+func (m *muxBwTUIModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, muxBwTickCmd())
+}
+
+type muxBwTickMsg struct{}
+
+func muxBwTickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg { return muxBwTickMsg{} })
+}
+
+func (m *muxBwTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch v := msg.(type) {
+	case tea.KeyMsg:
+		switch v.String() {
+		case "q", "ctrl+c", "esc":
+			m.quitting = true
+			m.cancel()
+			return m, tea.Quit
+		case "a":
+			m.autoScroll = !m.autoScroll
+		case "up", "k":
+			m.viewport.ScrollUp(1)
+			m.autoScroll = false
+		case "down", "j":
+			m.viewport.ScrollDown(1)
+			m.autoScroll = false
+		case "pgup":
+			m.viewport.HalfPageUp()
+			m.autoScroll = false
+		case "pgdown":
+			m.viewport.HalfPageDown()
+			m.autoScroll = false
+		case "home", "g":
+			m.viewport.GotoTop()
+			m.autoScroll = false
+		case "end", "G":
+			m.viewport.GotoBottom()
+			m.autoScroll = true
+		}
+
+	case tea.WindowSizeMsg:
+		fixedRows := m.fixedRows()
+		if !m.ready {
+			m.viewport = viewport.New(v.Width, v.Height-fixedRows)
+			m.viewport.SetContent(m.renderEventsBody())
+			m.ready = true
+		} else {
+			m.viewport.Width = v.Width
+			m.viewport.Height = v.Height - fixedRows
+		}
+		m.width, m.height = v.Width, v.Height
+
+	case spinner.TickMsg:
+		var spinnerCmd tea.Cmd
+		m.spinner, spinnerCmd = m.spinner.Update(msg)
+		cmds = append(cmds, spinnerCmd)
+
+	case muxBwTickMsg:
+		m.viewport.SetContent(m.renderEventsBody())
+		if m.autoScroll {
+			m.viewport.GotoBottom()
+		}
+		if !m.streamEnded {
+			cmds = append(cmds, muxBwTickCmd())
+		}
+
+	case muxBwEventMsg:
+		m.applyEvent(v.ev)
+		m.viewport.SetContent(m.renderEventsBody())
+		if m.autoScroll {
+			m.viewport.GotoBottom()
+		}
+
+	case muxBwStreamDoneMsg:
+		m.streamEnded = true
+		m.viewport.SetContent(m.renderEventsBody())
+
+	case muxBwStreamErrMsg:
+		m.streamErr = v.err
+		m.streamEnded = true
+		m.viewport.SetContent(m.renderEventsBody())
+	}
+
+	var vpCmd tea.Cmd
+	m.viewport, vpCmd = m.viewport.Update(msg)
+	cmds = append(cmds, vpCmd)
+	return m, tea.Batch(cmds...)
+}
+
+// fixedRows is the number of non-viewport lines we render around
+// the events viewport: header(1) + routes(1) + stats(1) + sep(1) +
+// throughput-section(3) + (rtt-section(3) if probe-rtt) + sep(1) +
+// events-header(1) + footer(1) = 12 or 9.
+func (m *muxBwTUIModel) fixedRows() int {
+	base := 9
+	if muxBwProbeRTT {
+		base += 3
+	}
+	return base
+}
+
+// ---------------------------------------------------------------------------
+// Event application
+// ---------------------------------------------------------------------------
+
+func (m *muxBwTUIModel) applyEvent(ev *rpcgrpc.MuxBandwidthEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.MuxBandwidthEvent_RouteEstablished:
+		r := p.RouteEstablished
+		if int(r.RouteIndex) >= 0 && int(r.RouteIndex) < len(m.routes) {
+			m.routes[r.RouteIndex] = muxBwRoute{
+				established: !r.Failed,
+				failed:      r.Failed,
+				setupErr:    r.SetupErr,
+				setupNs:     r.SetupLatencyNs,
+				hopCount:    len(r.Hops),
+			}
+		}
+		txt := ""
+		if r.Failed {
+			txt = fmt.Sprintf("R%d FAILED %s (setup=%s)", r.RouteIndex, r.SetupErr, formatDuration(r.SetupLatencyNs))
+		} else {
+			txt = fmt.Sprintf("R%d established (hops=%d setup=%s)", r.RouteIndex, len(r.Hops), formatDuration(r.SetupLatencyNs))
+		}
+		m.appendEvent(0, "route_established", txt)
+
+	case *rpcgrpc.MuxBandwidthEvent_Sample:
+		s := p.Sample
+		m.cumSent = s.BytesSent
+		m.cumRecv = s.BytesReceived
+		m.instantSendBps = s.InstantSendBps
+		m.instantRecvBps = s.InstantRecvBps
+		m.avgSendBps = s.AvgSendBps
+		m.avgRecvBps = s.AvgRecvBps
+		if s.InstantRecvBps > m.peakRecvBps {
+			m.peakRecvBps = s.InstantRecvBps
+		}
+		if s.InstantSendBps > m.peakSendBps {
+			m.peakSendBps = s.InstantSendBps
+		}
+		m.activeRoutes = s.ActiveRoutes
+		m.throughput = appendCapped(m.throughput, muxBwTimePoint{
+			elapsedNs: s.ElapsedNs,
+			value:     s.InstantRecvBps,
+		}, muxBwSparkWidth*2)
+		m.appendEvent(s.ElapsedNs, "sample",
+			fmt.Sprintf("recv=%s active=%d/%d", formatBps(s.InstantRecvBps), s.ActiveRoutes, m.req.Routes))
+
+	case *rpcgrpc.MuxBandwidthEvent_RttProbe:
+		r := p.RttProbe
+		if r.LatencyNs > 0 {
+			m.probeCount++
+			m.probeSum += r.LatencyNs
+			m.rttProbes = appendCapped(m.rttProbes, muxBwTimePoint{
+				elapsedNs: r.ElapsedNs,
+				value:     float64(r.LatencyNs),
+			}, muxBwSparkWidth*2)
+			m.appendEvent(r.ElapsedNs, "rtt_probe",
+				fmt.Sprintf("seq=%d rtt=%s", r.Sequence, formatDuration(r.LatencyNs)))
+		} else {
+			m.appendEvent(r.ElapsedNs, "rtt_probe",
+				fmt.Sprintf("seq=%d FAILED %s", r.Sequence, r.Error))
+		}
+
+	case *rpcgrpc.MuxBandwidthEvent_Done:
+		m.done = p.Done
+		m.appendEvent(p.Done.WallTimeNs, "done",
+			fmt.Sprintf("avg_recv=%s peak_recv=%s pumped=%s reason=%s",
+				formatBps(p.Done.AvgRecvBps),
+				formatBps(p.Done.PeakRecvBps),
+				formatBytes(p.Done.TotalBytesReceived),
+				p.Done.TerminationReason))
+
+	case *rpcgrpc.MuxBandwidthEvent_Error:
+		e := p.Error
+		m.serverError = fmt.Sprintf("%s: %s", e.Code, e.Message)
+		m.appendEvent(0, "error", e.Message)
+	}
+}
+
+func (m *muxBwTUIModel) appendEvent(elapsedNs int64, typ, body string) {
+	m.events = append(m.events, muxBwEvent{
+		elapsedNs: elapsedNs,
+		text:      fmt.Sprintf("%-18s %s", typ, body),
+	})
+	if len(m.events) > muxBwEventBufSize {
+		m.events = m.events[len(m.events)-muxBwEventBufSize:]
+	}
+}
+
+func appendCapped[T any](s []T, v T, max int) []T {
+	s = append(s, v)
+	if len(s) > max {
+		s = s[len(s)-max:]
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+func (m *muxBwTUIModel) View() string {
+	if m.quitting {
+		return "Shutting down...\n"
+	}
+	if !m.ready {
+		return "Initializing...\n"
+	}
+
+	footerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	hint := "↑/↓ scroll | a auto-scroll | q quit"
+	if m.streamEnded {
+		hint = "Run complete — q to exit"
+	}
+	scrollPct := m.viewport.ScrollPercent() * 100
+	scrollTag := fmt.Sprintf("%.0f%%", scrollPct)
+	if m.autoScroll {
+		scrollTag += " [auto]"
+	}
+	footer := footerStyle.Render(fmt.Sprintf("%s | %s", hint, scrollTag))
+
+	parts := []string{
+		m.renderHeader(),
+		m.renderRoutes(),
+		m.renderStats(),
+		m.renderThroughputBlock(),
+	}
+	if muxBwProbeRTT {
+		parts = append(parts, m.renderRttBlock())
+	}
+	parts = append(parts,
+		lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true).Render("Events:"),
+		m.viewport.View(),
+		footer,
+	)
+	return strings.Join(parts, "\n")
+}
+
+func (m *muxBwTUIModel) renderHeader() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+
+	elapsed := time.Since(m.runStart).Truncate(time.Second)
+	dur := time.Duration(m.req.DurationNs)
+	right := fmt.Sprintf("elapsed: %s / %s", elapsed, dur)
+	if m.serverError != "" {
+		right = "server error: " + m.serverError
+	} else if m.streamErr != nil {
+		right = "stream error: " + m.streamErr.Error()
+	}
+	title := fmt.Sprintf("Mux Bandwidth → %s", m.targetPK)
+	return titleStyle.Render(title) + "  " + dimStyle.Render(right)
+}
+
+func (m *muxBwTUIModel) renderRoutes() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	okStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+	failStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	pendStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	tiles := make([]string, 0, len(m.routes))
+	for i, r := range m.routes {
+		switch {
+		case r.failed:
+			tiles = append(tiles, failStyle.Render(fmt.Sprintf("[R%d ✗ %s]", i, truncate(r.setupErr, 24))))
+		case r.established:
+			tiles = append(tiles, okStyle.Render(fmt.Sprintf("[R%d ✓ hops=%d setup=%s]", i, r.hopCount, formatDuration(r.setupNs))))
+		default:
+			tiles = append(tiles, pendStyle.Render(fmt.Sprintf("[R%d · pending]", i)))
+		}
+	}
+	label := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).Render("Routes:  ")
+	return label + strings.Join(tiles, " ")
+}
+
+func (m *muxBwTUIModel) renderStats() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	label := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).Render("Stats:   ")
+	body := fmt.Sprintf("send=%s recv=%s   peak=%s   pumped: %s sent / %s recv   active=%d/%d",
+		formatBps(m.instantSendBps),
+		formatBps(m.instantRecvBps),
+		formatBps(m.peakRecvBps),
+		formatBytes(m.cumSent),
+		formatBytes(m.cumRecv),
+		m.activeRoutes, m.req.Routes,
+	)
+	return label + body
+}
+
+func (m *muxBwTUIModel) renderThroughputBlock() string {
+	m.mu.RLock()
+	values := make([]float64, len(m.throughput))
+	for i, t := range m.throughput {
+		values[i] = t.value
+	}
+	cur := m.instantRecvBps
+	avg := m.avgRecvBps
+	peak := m.peakRecvBps
+	m.mu.RUnlock()
+
+	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).
+		Render(fmt.Sprintf("Throughput (recv, last %d samples):", muxBwSparkWidth))
+	chart := sparkline(values, muxBwSparkWidth)
+	stats := fmt.Sprintf("  cur=%s  avg=%s  peak=%s",
+		formatBps(cur), formatBps(avg), formatBps(peak))
+	return header + "\n" + chart + stats
+}
+
+func (m *muxBwTUIModel) renderRttBlock() string {
+	m.mu.RLock()
+	values := make([]float64, len(m.rttProbes))
+	for i, t := range m.rttProbes {
+		values[i] = t.value
+	}
+	var avg, p50, p99, jit float64
+	n := len(values)
+	if m.done != nil {
+		avg = float64(m.done.ProbeAvgNs)
+		p50 = float64(m.done.ProbeP50Ns)
+		p99 = float64(m.done.ProbeP99Ns)
+		jit = float64(m.done.ProbeJitterNs)
+		n = int(m.done.ProbeCount)
+	} else if len(values) > 0 {
+		// Running approximation; Done will replace with the
+		// authoritative server-computed distribution.
+		sorted := append([]float64(nil), values...)
+		sort.Float64s(sorted)
+		p50 = sorted[len(sorted)/2]
+		p99 = sorted[(len(sorted)*99)/100]
+		var sum float64
+		for _, v := range sorted {
+			sum += v
+		}
+		avg = sum / float64(len(sorted))
+		var sq float64
+		for _, v := range sorted {
+			sq += (v - avg) * (v - avg)
+		}
+		jit = math.Sqrt(sq / float64(len(sorted)))
+	}
+	m.mu.RUnlock()
+
+	header := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("39")).
+		Render(fmt.Sprintf("RTT probes (loaded, last %d):", muxBwSparkWidth))
+	chart := sparkline(values, muxBwSparkWidth)
+	stats := fmt.Sprintf("  avg=%s  p50=%s  p99=%s  jit=%s  n=%d",
+		formatDuration(int64(avg)),
+		formatDuration(int64(p50)),
+		formatDuration(int64(p99)),
+		formatDuration(int64(jit)),
+		n,
+	)
+	return header + "\n" + chart + stats
+}
+
+func (m *muxBwTUIModel) renderEventsBody() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var sb strings.Builder
+	for _, e := range m.events {
+		secs := float64(e.elapsedNs) / 1e9
+		sb.WriteString(fmt.Sprintf("[+%6.3fs] %s\n", secs, e.text))
+	}
+	return sb.String()
+}
+
+func (m *muxBwTUIModel) renderDone() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.done == nil {
+		return ""
+	}
+	headStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	out := headStyle.Render("=== Run Summary ===") + "\n"
+	out += fmt.Sprintf(
+		"routes:   requested=%d established=%d\n"+
+			"timings:  wall=%s pump=%s setup_total=%s\n"+
+			"sent:     %s avg=%s peak=%s\n"+
+			"recv:     %s avg=%s peak=%s\n",
+		m.done.RoutesRequested, m.done.RoutesEstablished,
+		formatDuration(m.done.WallTimeNs),
+		formatDuration(m.done.PumpTimeNs),
+		formatDuration(m.done.SetupTotalNs),
+		formatBytes(m.done.TotalBytesSent),
+		formatBps(m.done.AvgSendBps),
+		formatBps(m.done.PeakSendBps),
+		formatBytes(m.done.TotalBytesReceived),
+		formatBps(m.done.AvgRecvBps),
+		formatBps(m.done.PeakRecvBps),
+	)
+	if m.done.ProbeCount > 0 {
+		out += fmt.Sprintf("rtt:      n=%d avg=%s p50=%s p99=%s jit=%s\n",
+			m.done.ProbeCount,
+			formatDuration(m.done.ProbeAvgNs),
+			formatDuration(m.done.ProbeP50Ns),
+			formatDuration(m.done.ProbeP99Ns),
+			formatDuration(m.done.ProbeJitterNs),
+		)
+	}
+	out += fmt.Sprintf("reason:   %s\n", m.done.TerminationReason)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+var sparkRunes = []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+
+// sparkline maps the last `width` values to single-row Unicode block
+// glyphs scaled to the max value in the window. Returns a fixed-width
+// string; pads with spaces when fewer than `width` samples exist.
+func sparkline(values []float64, width int) string {
+	if len(values) == 0 {
+		return strings.Repeat(" ", width)
+	}
+
+	start := 0
+	if len(values) > width {
+		start = len(values) - width
+	}
+	window := values[start:]
+
+	var maxV float64
+	for _, v := range window {
+		if v > maxV {
+			maxV = v
+		}
+	}
+	if maxV == 0 {
+		// All zeros — render the lowest glyph for the window width
+		// so the operator sees the sparkline exists.
+		return strings.Repeat(string(sparkRunes[0]), len(window)) +
+			strings.Repeat(" ", width-len(window))
+	}
+
+	var sb strings.Builder
+	for _, v := range window {
+		idx := int(v / maxV * float64(len(sparkRunes)-1))
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(sparkRunes) {
+			idx = len(sparkRunes) - 1
+		}
+		sb.WriteRune(sparkRunes[idx])
+	}
+	for i := len(window); i < width; i++ {
+		sb.WriteRune(' ')
+	}
+	return sb.String()
+}
+
+// formatBps renders a bits-per-second value in the largest sensible
+// unit (Kbps / Mbps / Gbps). Three-sig-fig fixed-width output.
+func formatBps(v float64) string {
+	switch {
+	case v >= 1e9:
+		return fmt.Sprintf("%6.2fGbps", v/1e9)
+	case v >= 1e6:
+		return fmt.Sprintf("%6.2fMbps", v/1e6)
+	case v >= 1e3:
+		return fmt.Sprintf("%6.2fKbps", v/1e3)
+	default:
+		return fmt.Sprintf("%6.2f bps", v)
+	}
+}
+
+// formatBytes renders a byte count in the largest sensible unit.
+func formatBytes(v uint64) string {
+	f := float64(v)
+	switch {
+	case f >= 1<<30:
+		return fmt.Sprintf("%6.2fGiB", f/(1<<30))
+	case f >= 1<<20:
+		return fmt.Sprintf("%6.2fMiB", f/(1<<20))
+	case f >= 1<<10:
+		return fmt.Sprintf("%6.2fKiB", f/(1<<10))
+	default:
+		return fmt.Sprintf("%6.0f B", f)
+	}
+}
+
+// formatDuration renders a nanosecond duration in human form.
+func formatDuration(ns int64) string {
+	switch {
+	case ns >= int64(time.Second):
+		return fmt.Sprintf("%6.2fs", float64(ns)/float64(time.Second))
+	case ns >= int64(time.Millisecond):
+		return fmt.Sprintf("%6.1fms", float64(ns)/float64(time.Millisecond))
+	case ns >= int64(time.Microsecond):
+		return fmt.Sprintf("%6.1fµs", float64(ns)/float64(time.Microsecond))
+	default:
+		return fmt.Sprintf("%dns", ns)
+	}
+}
+
+// truncate trims s to maxLen runes with a trailing ellipsis. Used
+// for error messages in tight tile rendering.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-1] + "…"
+}

--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth_tui_test.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth_tui_test.go
@@ -1,0 +1,159 @@
+package ping
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSparkline pins the sparkline rendering contract:
+//   - empty input → fixed-width blank string
+//   - all-zero input → low-glyph filled (so the operator sees the
+//     sparkline exists even before data flows)
+//   - mixed values scale to the max in the window
+//   - shorter-than-width input pads with trailing spaces
+//   - longer-than-width input uses the trailing `width` values
+func TestSparkline(t *testing.T) {
+	width := 10
+
+	if got := sparkline(nil, width); got != strings.Repeat(" ", width) {
+		t.Errorf("nil input: got %q, want %d spaces", got, width)
+	}
+
+	zeros := []float64{0, 0, 0, 0, 0}
+	got := sparkline(zeros, width)
+	// 5 of the lowest-glyph rune + 5 spaces. Width counted in runes.
+	if runeCount(got) != width {
+		t.Errorf("zeros: width = %d, want %d (got %q)", runeCount(got), width, got)
+	}
+
+	mixed := []float64{1, 2, 4, 8, 0}
+	got = sparkline(mixed, width)
+	if runeCount(got) != width {
+		t.Errorf("mixed: width = %d, want %d", runeCount(got), width)
+	}
+	// Largest value should produce the largest glyph (last index).
+	largestIdx := strings.IndexRune(got, '█')
+	if largestIdx < 0 {
+		t.Errorf("mixed: expected highest glyph for max value, got %q", got)
+	}
+
+	// Longer than width — last `width` only.
+	long := make([]float64, 30)
+	for i := range long {
+		long[i] = float64(i)
+	}
+	got = sparkline(long, width)
+	if runeCount(got) != width {
+		t.Errorf("long: width = %d, want %d", runeCount(got), width)
+	}
+	// Last value (29) is the max — the rightmost glyph must be the
+	// highest, since the window is values[20..30) and 29 is highest.
+	rs := []rune(got)
+	if rs[len(rs)-1] != '█' {
+		t.Errorf("long: last glyph = %q, want █ (got line %q)", rs[len(rs)-1], got)
+	}
+}
+
+func runeCount(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}
+
+// TestFormatBps pins the unit selection. fixed-width output is a
+// hard contract — the dashboard layout relies on the column staying
+// the same width across orders of magnitude.
+func TestFormatBps(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "  0.00 bps"},
+		{500, "500.00 bps"},
+		{1500, "  1.50Kbps"},
+		{1_500_000, "  1.50Mbps"},
+		{1_500_000_000, "  1.50Gbps"},
+	}
+	for _, c := range cases {
+		got := formatBps(c.in)
+		if got != c.want {
+			t.Errorf("formatBps(%v) = %q, want %q", c.in, got, c.want)
+		}
+		if len(got) != 10 {
+			t.Errorf("formatBps(%v) = %q (len=%d), want fixed width 10", c.in, got, len(got))
+		}
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "     0 B"},
+		{500, "   500 B"},
+		{2048, "  2.00KiB"},
+		{2 * 1024 * 1024, "  2.00MiB"},
+		{2 * 1024 * 1024 * 1024, "  2.00GiB"},
+	}
+	for _, c := range cases {
+		got := formatBytes(c.in)
+		if got != c.want {
+			t.Errorf("formatBytes(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0ns"},
+		{500, "500ns"},
+		{int64(2 * time.Microsecond), "   2.0µs"},
+		{int64(2 * time.Millisecond), "   2.0ms"},
+		{int64(2 * time.Second), "  2.00s"},
+	}
+	for _, c := range cases {
+		got := formatDuration(c.in)
+		if got != c.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTruncate pins the ellipsis-on-overflow behavior used in tight
+// route-tile rendering. Inputs shorter than maxLen pass through
+// unchanged.
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 10); got != "short" {
+		t.Errorf("short: got %q, want %q", got, "short")
+	}
+	if got := truncate("0123456789", 10); got != "0123456789" {
+		t.Errorf("at-limit: got %q, want unchanged", got)
+	}
+	got := truncate("0123456789abcdef", 10)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("overflow: got %q, want trailing ellipsis", got)
+	}
+}
+
+// TestAppendCapped pins the ring-buffer behavior used for both
+// throughput and rttProbes slices.
+func TestAppendCapped(t *testing.T) {
+	s := []int{}
+	for i := 0; i < 5; i++ {
+		s = appendCapped(s, i, 3)
+	}
+	if len(s) != 3 {
+		t.Errorf("len = %d, want 3", len(s))
+	}
+	// Should retain the LAST three values: [2, 3, 4]
+	if s[0] != 2 || s[1] != 3 || s[2] != 4 {
+		t.Errorf("contents = %v, want [2 3 4]", s)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `cli visor ping mux-bw-tui <pk>` — a live Bubble Tea dashboard that consumes the same `StreamMuxBandwidth` RPC as the NDJSON sibling `cli visor ping mux-bw` (#2737) but renders it as a dashboard instead of newline-delimited JSON.

Use `mux-bw-tui` for interactive exploration; keep using `mux-bw` for automation / harness consumption.

## Layout

```
Mux Bandwidth → 03d1d78e7323e1dc63a6cbbf79e52974791e3cd7b5aaab77f045d72a21b066ee8c   elapsed: 22.4s / 30.0s
Routes:  [R0 ✓ hops=4 setup=0.10s] [R1 ✓ hops=4 setup=0.10s] [R2 ✓ hops=4 setup=0.10s] [R3 ✓ hops=4 setup=0.10s]
Stats:   send=1.23Mbps recv=1.21Mbps   peak=1.41Mbps   pumped: 12.4MiB / 12.2MiB   active=4/4

Throughput (recv, last 60 samples):
▁▂▃▄▅▆▇█▇▇█████████████████████████████  cur=1.23Mbps  avg=0.95Mbps  peak=1.41Mbps

RTT probes (loaded, last 60):
▆██▇█████████████████████ ▂▁▃▆▂▁▁█▂▁▂▃   avg=238ms p50=196ms p99=557ms jit=101ms  n=147

Events:
[+22.412] sample             recv=1.23Mbps active=4/4
[+22.512] rtt_probe          seq=147 rtt=224ms
[+22.612] rtt_probe          seq=148 rtt=199ms
...

↑/↓ scroll | a auto-scroll | q quit | 100% [auto]
```

## Design points

- **Identical RPC + identical request shape.** Only the consumer differs — server-side fixes land in both subcommands.
- **Flags shared at package scope** with the NDJSON sibling, so defaults stay aligned.
- **Per-route status row**: one tile per `RouteEstablished` event in setup-time order. Failed routes show the truncated error and stay visible for diagnostic value.
- **Sparklines** are single-row Unicode-block glyphs (▁▂▃▄▅▆▇█) scaled to the max value in a 60-sample window. Dense enough for trend visibility, cheap enough to redraw every event.
- **Running RTT approximation** while the pump is in flight; replaced by the authoritative server-computed distribution when the `Done` event arrives.
- **Post-quit print**: `tea.WithAltScreen` wipes the screen on exit, so the final dashboard re-renders to stdout after `p.Run()` returns — same pattern adopted in the ping tree TUI fix (#2738).

## Tests

Pin the pure helpers:
- `TestSparkline` — width contract for empty/zero/mixed/long inputs, max-value glyph correctness
- `TestFormatBps` / `TestFormatBytes` / `TestFormatDuration` — fixed-width output across magnitudes
- `TestTruncate` — ellipsis-on-overflow + at-limit passthrough
- `TestAppendCapped` — ring-buffer retains last N values

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./cmd/skywire-cli/commands/visor/ping/...` pass
- [x] `golangci-lint run` clean (0 issues)
- [ ] Live run: `cli visor ping mux-bw-tui <peer-pk> --routes 4 --min-hops 2 --probe-rtt --duration 30s`
- [ ] Ctrl+C mid-run → final dashboard prints to stdout