### PR TITLE
feat(visor): per-route teardown — decouple StopPing from PK-only

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -598,6 +598,14 @@ type PingConfig struct {
 	TransportID string         // Optional: use specific transport (skips route calculation)
 	ForwardHops []RouteHopInfo // Optional: explicit forward route (skips route calculation)
 	ReverseHops []RouteHopInfo // Optional: explicit reverse route (skips route calculation)
+	// RouteIndex identifies which of multiple parallel routes to the
+	// same peer this PingConfig refers to. Zero (the default) means
+	// "primary / single route" and preserves all legacy single-route
+	// behavior. Non-zero values are used by mux-aware callers
+	// (`cli visor ping mux-bw`) to dial multiple routes to the same
+	// target without their conns trampling each other in the visor's
+	// per-route conn map. See PingRouteRef in pkg/visor/ping.go.
+	RouteIndex int
 }
 
 // TestResult type of test result

--- a/pkg/visor/api_ping.go
+++ b/pkg/visor/api_ping.go
@@ -87,7 +87,7 @@ func (v *Visor) DialPing(conf PingConfig) error {
 	}
 
 	v.ping.mu.Lock()
-	v.ping.conns[conf.PK] = ping{
+	v.ping.conns[PingRouteRef{PK: conf.PK, Index: conf.RouteIndex}] = ping{
 		conn:     conn,
 		hops:     hops,
 		hopInfos: hopInfos,
@@ -102,9 +102,9 @@ func (v *Visor) Ping(conf PingConfig) ([]time.Duration, error) {
 	v.ping.mu.Lock()
 	defer v.ping.mu.Unlock()
 
-	pingEntry, ok := v.ping.conns[conf.PK]
+	pingEntry, ok := v.ping.conns[PingRouteRef{PK: conf.PK, Index: conf.RouteIndex}]
 	if !ok {
-		return nil, fmt.Errorf("no ping connection for %s, call DialPing first", conf.PK)
+		return nil, fmt.Errorf("no ping connection for %s#%d, call DialPing first", conf.PK, conf.RouteIndex)
 	}
 
 	return doPingRoundTrips(pingEntry.conn, conf)
@@ -168,9 +168,9 @@ func (v *Visor) PingOnce(conf PingConfig) (time.Duration, error) {
 	v.ping.mu.Lock()
 	defer v.ping.mu.Unlock()
 
-	pingEntry, ok := v.ping.conns[conf.PK]
+	pingEntry, ok := v.ping.conns[PingRouteRef{PK: conf.PK, Index: conf.RouteIndex}]
 	if !ok {
-		return 0, fmt.Errorf("no ping connection for %s, call DialPing first", conf.PK)
+		return 0, fmt.Errorf("no ping connection for %s#%d, call DialPing first", conf.PK, conf.RouteIndex)
 	}
 
 	data := make([]byte, conf.PcktSize*1024)
@@ -231,9 +231,9 @@ func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, byt
 	v.ping.mu.Lock()
 	defer v.ping.mu.Unlock()
 
-	pingEntry, ok := v.ping.conns[conf.PK]
+	pingEntry, ok := v.ping.conns[PingRouteRef{PK: conf.PK, Index: conf.RouteIndex}]
 	if !ok {
-		return 0, 0, 0, fmt.Errorf("no ping connection for %s, call DialPing first", conf.PK)
+		return 0, 0, 0, fmt.Errorf("no ping connection for %s#%d, call DialPing first", conf.PK, conf.RouteIndex)
 	}
 
 	data := make([]byte, conf.PcktSize*1024)
@@ -310,24 +310,53 @@ func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, byt
 }
 
 // StopPing implements API.
+//
+// Tears down ALL routes to the given peer (every PingRouteRef whose
+// PK matches). Callers that want to tear down a single route in a
+// mux-set must use StopPingRoute(ref) instead. The legacy semantics
+// (single PK = single connection) are preserved for the common
+// case where no aux routes exist.
 func (v *Visor) StopPing(pk cipher.PubKey) error {
 	v.ping.mu.Lock()
 	defer v.ping.mu.Unlock()
 
-	pingEntry, ok := v.ping.conns[pk]
-	if !ok || pingEntry.conn == nil {
-		// Already stopped or never started
-		delete(v.ping.conns, pk)
+	var firstErr error
+	for ref, entry := range v.ping.conns {
+		if ref.PK != pk {
+			continue
+		}
+		if entry.conn != nil {
+			if err := entry.conn.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		delete(v.ping.conns, ref)
+	}
+	return firstErr
+}
+
+// StopPingRoute closes a single route in a mux-set without
+// touching the other parallel routes to the same peer. Used by
+// `cli visor ping mux-bw` when one of N parallel routes fails
+// mid-pump and we want to keep the others alive, and by future
+// mux-aware proxies that want to drop one leg of a multi-route
+// session.
+//
+// Returns nil if the ref doesn't match any known conn (idempotent —
+// safe to call from cleanup paths that aren't sure whether the route
+// was ever established).
+func (v *Visor) StopPingRoute(ref PingRouteRef) error {
+	v.ping.mu.Lock()
+	defer v.ping.mu.Unlock()
+
+	entry, ok := v.ping.conns[ref]
+	if !ok || entry.conn == nil {
+		delete(v.ping.conns, ref)
 		return nil
 	}
-	err := pingEntry.conn.Close()
-	if err != nil {
-		// Still delete the entry even if close fails
-		delete(v.ping.conns, pk)
-		return err
-	}
-	delete(v.ping.conns, pk)
-	return nil
+	err := entry.conn.Close()
+	delete(v.ping.conns, ref)
+	return err
 }
 
 // StopAllPings stops all active ping connections and cleans up their routes.
@@ -339,38 +368,54 @@ func (v *Visor) StopAllPings() (int, []string, error) {
 	var errs []string
 	count := 0
 
-	for pk, pingEntry := range v.ping.conns {
+	for ref, pingEntry := range v.ping.conns {
 		if pingEntry.conn != nil {
 			if err := pingEntry.conn.Close(); err != nil {
-				errs = append(errs, fmt.Sprintf("failed to close ping to %s: %v", pk, err))
+				errs = append(errs, fmt.Sprintf("failed to close ping to %s: %v", ref, err))
 			}
 		}
-		delete(v.ping.conns, pk)
+		delete(v.ping.conns, ref)
 		count++
 	}
 
 	return count, errs, nil
 }
 
-// GetPingRoute returns the route hops for an established ping connection.
-// Returns nil if no ping connection exists for the given public key.
+// GetPingRoute returns the route hops for the primary ping
+// connection to a peer (RouteIndex 0). For aux routes in a mux-set
+// use GetPingRouteAt(ref).
 func (v *Visor) GetPingRoute(pk cipher.PubKey) []cipher.PubKey {
+	return v.GetPingRouteAt(PingRoutePrimary(pk))
+}
+
+// GetPingRouteAt returns the route hops for a specific ping route.
+func (v *Visor) GetPingRouteAt(ref PingRouteRef) []cipher.PubKey {
 	v.ping.mu.Lock()
 	defer v.ping.mu.Unlock()
 
-	if pingEntry, ok := v.ping.conns[pk]; ok {
+	if pingEntry, ok := v.ping.conns[ref]; ok {
 		return pingEntry.hops
 	}
 	return nil
 }
 
-// GetPingRouteDetails returns detailed route information for a ping connection,
-// including transport IDs and types for each hop.
+// GetPingRouteDetails returns detailed route information for the
+// PRIMARY ping connection to a peer (RouteIndex 0), including
+// transport IDs and types for each hop. For aux routes use
+// GetPingRouteDetailsAt(ref).
 func (v *Visor) GetPingRouteDetails(pk cipher.PubKey) []router.RouteHopInfo {
+	return v.GetPingRouteDetailsAt(PingRoutePrimary(pk))
+}
+
+// GetPingRouteDetailsAt returns detailed route information for a
+// specific ping route. Used by mux-aware callers (mux-bw) to surface
+// the hops of each parallel route — the primary-keyed accessor
+// can't distinguish among them.
+func (v *Visor) GetPingRouteDetailsAt(ref PingRouteRef) []router.RouteHopInfo {
 	v.ping.mu.Lock()
 	defer v.ping.mu.Unlock()
 
-	if pingEntry, ok := v.ping.conns[pk]; ok {
+	if pingEntry, ok := v.ping.conns[ref]; ok {
 		return pingEntry.hopInfos
 	}
 	return nil
@@ -395,8 +440,11 @@ func (v *Visor) BandwidthTest(conf BandwidthTestConfig) (BandwidthResult, error)
 		LocalRoute: conf.LocalRoute,
 	}
 
+	// BandwidthTest is a single-route caller; use the primary slot.
+	primary := PingRoutePrimary(conf.PK)
+
 	v.ping.mu.Lock()
-	_, exists := v.ping.conns[conf.PK]
+	_, exists := v.ping.conns[primary]
 	v.ping.mu.Unlock()
 
 	if !exists {
@@ -406,7 +454,7 @@ func (v *Visor) BandwidthTest(conf BandwidthTestConfig) (BandwidthResult, error)
 	}
 
 	v.ping.mu.Lock()
-	pingEntry, ok := v.ping.conns[conf.PK]
+	pingEntry, ok := v.ping.conns[primary]
 	if !ok {
 		v.ping.mu.Unlock()
 		return BandwidthResult{}, fmt.Errorf("no ping connection for %s", conf.PK)

--- a/pkg/visor/api_ping_test.go
+++ b/pkg/visor/api_ping_test.go
@@ -1,0 +1,225 @@
+// Package visor — pkg/visor/api_ping_test.go: unit tests for the
+// per-route teardown surface added when PingRouteRef became the
+// pingState.conns map key.
+package visor
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/router"
+)
+
+// fakeConn satisfies net.Conn and records Close() calls for tests.
+// Avoids dragging in netpipe / real sockets just to verify the
+// teardown bookkeeping in the visor's pingState map.
+type fakeConn struct {
+	closed bool
+	err    error
+}
+
+func (c *fakeConn) Read(_ []byte) (int, error)         { return 0, nil }
+func (c *fakeConn) Write(_ []byte) (int, error)        { return 0, nil }
+func (c *fakeConn) Close() error                       { c.closed = true; return c.err }
+func (c *fakeConn) LocalAddr() net.Addr                { return nil }
+func (c *fakeConn) RemoteAddr() net.Addr               { return nil }
+func (c *fakeConn) SetDeadline(_ time.Time) error      { return nil } //nolint:unused
+func (c *fakeConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// helperPK constructs a deterministic 33-byte PubKey from an int.
+// Avoids running the curve to generate real keys — we only need
+// distinct values for map-key tests.
+func helperPK(b byte) cipher.PubKey {
+	var pk cipher.PubKey
+	pk[0] = 2 // compressed-Y marker — any constant works for map equality
+	pk[1] = b
+	return pk
+}
+
+// newPingStateVisor builds the smallest Visor that the ping
+// teardown methods touch. They only read v.ping.conns + v.ping.mu;
+// nothing else. Keeps the test free of init plumbing.
+func newPingStateVisor() *Visor {
+	return &Visor{
+		ping: pingState{
+			conns: make(map[PingRouteRef]ping),
+			mu:    new(sync.Mutex),
+		},
+	}
+}
+
+// TestPingRouteRefMapIsolation pins the central invariant: two
+// PingRouteRef values that share PK but differ in Index are
+// distinct map keys. If this regresses (e.g. someone redefines
+// PingRouteRef to ignore Index), mux-bw's N parallel routes
+// silently collapse back to a single shared conn.
+func TestPingRouteRefMapIsolation(t *testing.T) {
+	pk := helperPK(1)
+	r0 := PingRouteRef{PK: pk, Index: 0}
+	r1 := PingRouteRef{PK: pk, Index: 1}
+
+	m := make(map[PingRouteRef]ping)
+	m[r0] = ping{conn: &fakeConn{}}
+	m[r1] = ping{conn: &fakeConn{}}
+
+	if len(m) != 2 {
+		t.Fatalf("two distinct refs should produce 2 map entries, got %d", len(m))
+	}
+	if m[r0].conn == m[r1].conn {
+		t.Errorf("entries at different RouteIndex share a conn — map key is collapsing")
+	}
+}
+
+// TestPingRoutePrimary pins the legacy-caller convenience: callers
+// passing a bare PK keep working because PingRoutePrimary(pk) maps
+// to Index 0.
+func TestPingRoutePrimary(t *testing.T) {
+	pk := helperPK(2)
+	ref := PingRoutePrimary(pk)
+	if ref.PK != pk {
+		t.Errorf("PK mismatch: got %v want %v", ref.PK, pk)
+	}
+	if ref.Index != 0 {
+		t.Errorf("Index should be 0 (primary), got %d", ref.Index)
+	}
+}
+
+// TestStopPingClosesAllRoutesForPeer pins the legacy-semantics
+// preservation: StopPing(pk) closes every route for that peer, not
+// just the primary. This matters because existing callers
+// (init_services teardown, hypervisor_handlers_reachability) call
+// StopPing expecting "tear it all down for this PK".
+func TestStopPingClosesAllRoutesForPeer(t *testing.T) {
+	v := newPingStateVisor()
+	pk := helperPK(3)
+
+	c0, c1, c2 := &fakeConn{}, &fakeConn{}, &fakeConn{}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 0}] = ping{conn: c0}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 1}] = ping{conn: c1}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 2}] = ping{conn: c2}
+
+	// Add a conn for an unrelated peer — it must NOT be touched.
+	otherPK := helperPK(4)
+	otherConn := &fakeConn{}
+	v.ping.conns[PingRouteRef{PK: otherPK, Index: 0}] = ping{conn: otherConn}
+
+	if err := v.StopPing(pk); err != nil {
+		t.Fatalf("StopPing returned error: %v", err)
+	}
+
+	if !c0.closed || !c1.closed || !c2.closed {
+		t.Errorf("expected all three routes for pk closed: got %v %v %v",
+			c0.closed, c1.closed, c2.closed)
+	}
+	if otherConn.closed {
+		t.Errorf("StopPing(pk) closed an unrelated peer's conn — bleed-over")
+	}
+	// All pk entries must be deleted; the other peer's entry stays.
+	if _, ok := v.ping.conns[PingRouteRef{PK: pk, Index: 0}]; ok {
+		t.Errorf("pk Index 0 still in map after StopPing")
+	}
+	if _, ok := v.ping.conns[PingRouteRef{PK: otherPK, Index: 0}]; !ok {
+		t.Errorf("unrelated peer's entry was deleted")
+	}
+}
+
+// TestStopPingRouteOnlyClosesOneRoute pins the new affordance: the
+// caller can drop a single route without touching the parallel
+// routes. mux-bw relies on this when one of N pump goroutines
+// finishes / errors out.
+func TestStopPingRouteOnlyClosesOneRoute(t *testing.T) {
+	v := newPingStateVisor()
+	pk := helperPK(5)
+
+	c0, c1 := &fakeConn{}, &fakeConn{}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 0}] = ping{conn: c0}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 1}] = ping{conn: c1}
+
+	if err := v.StopPingRoute(PingRouteRef{PK: pk, Index: 1}); err != nil {
+		t.Fatalf("StopPingRoute returned error: %v", err)
+	}
+
+	if c0.closed {
+		t.Errorf("Index 0 conn closed by StopPingRoute(Index 1)")
+	}
+	if !c1.closed {
+		t.Errorf("Index 1 conn not closed by StopPingRoute(Index 1)")
+	}
+	if _, ok := v.ping.conns[PingRouteRef{PK: pk, Index: 0}]; !ok {
+		t.Errorf("Index 0 removed from map by StopPingRoute(Index 1)")
+	}
+	if _, ok := v.ping.conns[PingRouteRef{PK: pk, Index: 1}]; ok {
+		t.Errorf("Index 1 still in map after StopPingRoute(Index 1)")
+	}
+}
+
+// TestStopPingRouteIdempotent pins idempotency: cleanup paths that
+// aren't sure whether a route was ever established should be safe
+// to call StopPingRoute on a missing ref. Returns nil, no panic.
+func TestStopPingRouteIdempotent(t *testing.T) {
+	v := newPingStateVisor()
+	pk := helperPK(6)
+
+	// No conn ever stored.
+	if err := v.StopPingRoute(PingRouteRef{PK: pk, Index: 7}); err != nil {
+		t.Errorf("StopPingRoute on unknown ref should be nil error, got %v", err)
+	}
+
+	// Map entry exists but conn is nil (the close path tolerates this).
+	v.ping.conns[PingRouteRef{PK: pk, Index: 0}] = ping{conn: nil}
+	if err := v.StopPingRoute(PingRouteRef{PK: pk, Index: 0}); err != nil {
+		t.Errorf("StopPingRoute on nil-conn entry should be nil error, got %v", err)
+	}
+}
+
+// TestStopPingRoutePropagatesCloseError pins that conn-close errors
+// surface to the caller — mux-bw's defer chain logs them, so
+// swallowing would mask real issues.
+func TestStopPingRoutePropagatesCloseError(t *testing.T) {
+	v := newPingStateVisor()
+	pk := helperPK(7)
+	closeErr := errors.New("simulated close failure")
+	v.ping.conns[PingRouteRef{PK: pk, Index: 0}] = ping{conn: &fakeConn{err: closeErr}}
+
+	err := v.StopPingRoute(PingRouteRef{PK: pk, Index: 0})
+	if !errors.Is(err, closeErr) {
+		t.Errorf("StopPingRoute should return the conn.Close() error, got %v", err)
+	}
+	if _, ok := v.ping.conns[PingRouteRef{PK: pk, Index: 0}]; ok {
+		t.Errorf("entry must still be deleted on close error")
+	}
+}
+
+// TestGetPingRouteDetailsAtPerRoute pins per-route hop lookup —
+// the consumer for MuxRouteEstablished.hops. Without this the
+// peer-keyed GetPingRouteDetails(pk) returns whichever route was
+// stored last, which is non-deterministic in the mux setup phase.
+func TestGetPingRouteDetailsAtPerRoute(t *testing.T) {
+	v := newPingStateVisor()
+	pk := helperPK(8)
+
+	hops0 := []router.RouteHopInfo{{TpID: "tp-a", From: "A", To: "B", TpType: "stcpr"}}
+	hops1 := []router.RouteHopInfo{
+		{TpID: "tp-b", From: "A", To: "X", TpType: "stcpr"},
+		{TpID: "tp-c", From: "X", To: "B", TpType: "stcpr"},
+	}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 0}] = ping{hopInfos: hops0}
+	v.ping.conns[PingRouteRef{PK: pk, Index: 1}] = ping{hopInfos: hops1}
+
+	got0 := v.GetPingRouteDetailsAt(PingRouteRef{PK: pk, Index: 0})
+	if len(got0) != 1 || got0[0].TpID != "tp-a" {
+		t.Errorf("route 0 hops mismatch: %+v", got0)
+	}
+	got1 := v.GetPingRouteDetailsAt(PingRouteRef{PK: pk, Index: 1})
+	if len(got1) != 2 || got1[0].TpID != "tp-b" || got1[1].TpID != "tp-c" {
+		t.Errorf("route 1 hops mismatch: %+v", got1)
+	}
+	if got := v.GetPingRouteDetailsAt(PingRouteRef{PK: pk, Index: 99}); got != nil {
+		t.Errorf("unknown route should yield nil, got %+v", got)
+	}
+}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
+	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
@@ -234,6 +235,7 @@ func (a *visorPingAdapter) DialPing(conf rpcgrpc.PingConf) error {
 		TransportID: conf.TransportID,
 		ForwardHops: forwardHops,
 		ReverseHops: reverseHops,
+		RouteIndex:  conf.RouteIndex,
 	})
 }
 
@@ -243,6 +245,7 @@ func (a *visorPingAdapter) PingOnce(conf rpcgrpc.PingConf) (time.Duration, error
 		Tries:      conf.Tries,
 		PcktSize:   conf.PcktSize,
 		LocalRoute: conf.LocalRoute,
+		RouteIndex: conf.RouteIndex,
 	})
 }
 
@@ -250,26 +253,45 @@ func (a *visorPingAdapter) StopPing(pk cipher.PubKey) error {
 	return a.v.StopPing(pk)
 }
 
+// StopPingRoute crosses the rpcgrpc → visor boundary by converting
+// the rpcgrpc-local PingRouteRef into the visor-package PingRouteRef.
+// The rpcgrpc-side struct exists only to keep that package free of
+// pkg/visor imports.
+func (a *visorPingAdapter) StopPingRoute(ref rpcgrpc.PingRouteRef) error {
+	return a.v.StopPingRoute(PingRouteRef{PK: ref.PK, Index: ref.Index})
+}
+
 func (a *visorPingAdapter) GetPingRoute(pk cipher.PubKey) []cipher.PubKey {
 	return a.v.GetPingRoute(pk)
 }
 
 func (a *visorPingAdapter) GetPingRouteDetails(pk cipher.PubKey) []rpcgrpc.RouteHopInfo {
-	details := a.v.GetPingRouteDetails(pk)
+	return convertHopInfos(a.v.GetPingRouteDetails(pk))
+}
+
+// GetPingRouteDetailsAt — per-route variant used by mux-bw to fill
+// MuxRouteEstablished.hops at setup time. See StopPingRoute for the
+// boundary-cross note.
+func (a *visorPingAdapter) GetPingRouteDetailsAt(ref rpcgrpc.PingRouteRef) []rpcgrpc.RouteHopInfo {
+	return convertHopInfos(a.v.GetPingRouteDetailsAt(PingRouteRef{PK: ref.PK, Index: ref.Index}))
+}
+
+// convertHopInfos is the router.RouteHopInfo → rpcgrpc.RouteHopInfo
+// projection shared by the two GetPingRouteDetails* paths.
+func convertHopInfos(details []router.RouteHopInfo) []rpcgrpc.RouteHopInfo {
 	if details == nil {
 		return nil
 	}
-	// Convert router.RouteHopInfo to rpcgrpc.RouteHopInfo
-	result := make([]rpcgrpc.RouteHopInfo, len(details))
+	out := make([]rpcgrpc.RouteHopInfo, len(details))
 	for i, d := range details {
-		result[i] = rpcgrpc.RouteHopInfo{
+		out[i] = rpcgrpc.RouteHopInfo{
 			TpID:   d.TpID,
 			From:   d.From,
 			To:     d.To,
 			TpType: d.TpType,
 		}
 	}
-	return result
+	return out
 }
 
 func (a *visorPingAdapter) GetLastRouteCalcTime() time.Duration {

--- a/pkg/visor/ping.go
+++ b/pkg/visor/ping.go
@@ -2,12 +2,42 @@
 package visor
 
 import (
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/router"
 )
+
+// PingRouteRef identifies a specific route to a peer. Index 0 is
+// the primary/legacy route used by single-route callers; aux routes
+// (1..N-1) are added by callers that establish multiple parallel
+// routes to the same target — currently only `cli visor ping mux-bw`,
+// future mux-aware proxies will join.
+//
+// The route map is keyed by this struct rather than by bare PK so
+// that N parallel DialPing calls to the same peer can coexist
+// without overwriting each other's conn / route hops. Legacy
+// single-route callers stay PK-only via PingRoutePrimary(pk) or by
+// leaving PingConfig.RouteIndex at its zero value.
+type PingRouteRef struct {
+	PK    cipher.PubKey
+	Index int
+}
+
+// PingRoutePrimary returns the PingRouteRef for the primary route
+// to a peer. Call sites that don't care about multi-route semantics
+// pass this — keeps the existing single-route fast path unambiguous.
+func PingRoutePrimary(pk cipher.PubKey) PingRouteRef {
+	return PingRouteRef{PK: pk, Index: 0}
+}
+
+// String renders as "<pk>#<index>" — useful for logs and the
+// rpc-grpc dmsg-port handler's per-route debug output.
+func (r PingRouteRef) String() string {
+	return fmt.Sprintf("%s#%d", r.PK, r.Index)
+}
 
 type ping struct {
 	conn     net.Conn

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -31,14 +31,32 @@ type RouteHopInfo struct {
 	TpType string
 }
 
+// PingRouteRef identifies a specific route in a mux-set. Mirrors
+// visor.PingRouteRef across the package boundary to avoid the
+// rpcgrpc → visor import cycle. The visorPingAdapter converts at
+// the boundary.
+type PingRouteRef struct {
+	PK    cipher.PubKey
+	Index int
+}
+
 // VisorAPI defines the interface for visor ping operations
 type VisorAPI interface {
 	DialPing(conf PingConf) error
 	PingOnce(conf PingConf) (time.Duration, error)
 	PingOnceWithEcho(conf PingConf, echoFull bool) (bytesSent, bytesReceived uint64, latency time.Duration, err error)
 	StopPing(pk cipher.PubKey) error
+	// StopPingRoute tears down a single route in a mux-set without
+	// touching the peer's other parallel routes. Used by
+	// StreamMuxBandwidth to drop a failed aux route mid-pump.
+	StopPingRoute(ref PingRouteRef) error
 	GetPingRoute(pk cipher.PubKey) []cipher.PubKey
 	GetPingRouteDetails(pk cipher.PubKey) []RouteHopInfo
+	// GetPingRouteDetailsAt returns the hops for a specific route in
+	// a mux-set. The peer-keyed accessor (GetPingRouteDetails) can't
+	// distinguish among N parallel routes to the same target, so
+	// per-route emit paths (MuxRouteEstablished.hops) ride this.
+	GetPingRouteDetailsAt(ref PingRouteRef) []RouteHopInfo
 	GetLastRouteCalcTime() time.Duration
 	DialDmsgPing(pk cipher.PubKey) error
 	DialDmsgPingViaServer(pk cipher.PubKey, serverPK cipher.PubKey) error
@@ -121,6 +139,10 @@ type PingConf struct {
 	TransportID string         // Optional: use specific transport (skips route calculation)
 	ForwardHops []RouteHopInfo // Optional: explicit forward route (skips route calculation)
 	ReverseHops []RouteHopInfo // Optional: explicit reverse route (skips route calculation)
+	// RouteIndex selects among N parallel routes to the same peer.
+	// Zero = primary / single-route (legacy behavior). Mirrors
+	// visor.PingConfig.RouteIndex; the adapter passes it through.
+	RouteIndex int
 }
 
 // PingServer implements the gRPC PingService

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -285,10 +285,13 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 
 // muxBwSetupRoute dials one route + emits a RouteEstablished event.
 // Marks rs.established on success so the pump phase knows which
-// routes to spin up. The dial uses DialPing — currently shared across
-// all StreamMuxBandwidth routes (no per-route differentiation today;
-// future work: feed MinHops + route-finder constraints through here
-// once the visor's DialPing API gains those knobs).
+// routes to spin up.
+//
+// Each route uses a distinct RouteIndex (0..N-1) — the visor's
+// per-route conn map (keyed by PingRouteRef) keeps the N parallel
+// conns separate. Previously the conn map was keyed by PK alone, so
+// concurrent DialPing calls to the same target overwrote each other
+// and "N parallel routes" was N parallel uses of one conn.
 func (s *PingServer) muxBwSetupRoute(
 	ctx context.Context,
 	cfg *muxBwCfg,
@@ -300,6 +303,7 @@ func (s *PingServer) muxBwSetupRoute(
 		Tries:      1,
 		PcktSize:   cfg.PacketSizeKb,
 		LocalRoute: cfg.LocalRoute,
+		RouteIndex: rs.index,
 	}
 	setupCtx, cancel := context.WithTimeout(ctx, cfg.SetupTimeout)
 	defer cancel()
@@ -323,18 +327,26 @@ func (s *PingServer) muxBwSetupRoute(
 	ev := &MuxRouteEstablished{
 		RouteIndex:     int32(rs.index), //nolint:gosec
 		SetupLatencyNs: setupLatency.Nanoseconds(),
-		// Hops field is left empty here — surfacing the chosen route
-		// hops requires GetPingRouteDetails(pk) and the route is
-		// keyed by target PK, so multiple parallel routes to the
-		// same PK can't be distinguished by that API today. A
-		// follow-up: extend GetPingRouteDetails to take a route
-		// index when N>1.
 	}
 	if dialErr != nil {
 		ev.Failed = true
 		ev.SetupErr = dialErr.Error()
 	} else {
 		rs.established.Store(true)
+		// Surface the chosen hops for this specific route. Now that
+		// the conn map is keyed by PingRouteRef, GetPingRouteDetailsAt
+		// can pick out this route's hops without ambiguity. Consumers
+		// (mux-bw NDJSON, mux-bw-tui dashboard, treeprobe harness)
+		// can verify route diversity from this field.
+		ref := PingRouteRef{PK: cfg.TargetPK, Index: rs.index}
+		for _, h := range s.visor.GetPingRouteDetailsAt(ref) {
+			ev.Hops = append(ev.Hops, &RouteHop{
+				TpId:   h.TpID,
+				From:   h.From,
+				To:     h.To,
+				TpType: h.TpType,
+			})
+		}
 	}
 	emit(&MuxBandwidthEvent_RouteEstablished{RouteEstablished: ev})
 }
@@ -353,14 +365,15 @@ func (s *PingServer) muxBwPumpRoute(
 		Tries:      1,
 		PcktSize:   cfg.PacketSizeKb,
 		LocalRoute: cfg.LocalRoute,
+		RouteIndex: rs.index,
 	}
 	defer func() {
-		// Best-effort tear-down. StopPing is currently keyed by
-		// target PK only — calling it once at end of pump tears
-		// down ALL parallel connections to that PK, which is fine
-		// as a teardown but means we can't tear down individual
-		// routes mid-run. Future: per-route teardown handles.
-		_ = s.visor.StopPing(cfg.TargetPK) //nolint:errcheck
+		// Per-route teardown — closes JUST this route's conn, not
+		// the other parallel routes to the same target. Without
+		// this, the first pump goroutine to finish would tear down
+		// every aux route's conn, leaving the other pump goroutines
+		// chasing closed conns.
+		_ = s.visor.StopPingRoute(PingRouteRef{PK: cfg.TargetPK, Index: rs.index}) //nolint:errcheck
 	}()
 
 	for {
@@ -459,10 +472,12 @@ func (s *PingServer) muxBwSamplerLoop(
 }
 
 // muxBwProbeLoop runs a small-packet RTT probe concurrently with
-// the bulk pump. Each tick uses PingOnce on the target PK; the
-// underlying connection is shared with the pump (StopPing is keyed
-// by PK only) so the probe rides the same first route. Accumulates
-// samples into probesOut for the Done aggregation.
+// the bulk pump. The probe rides RouteIndex 0 (the primary pump's
+// route) — they serialize via the visor's ping mutex so protocol
+// framing stays well-formed even though they share the conn.
+// Adding a dedicated probe-only route (e.g. RouteIndex = N) is a
+// future optimization. Accumulates samples into probesOut for the
+// Done aggregation.
 func (s *PingServer) muxBwProbeLoop(
 	ctx context.Context,
 	cfg *muxBwCfg,

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -311,9 +311,12 @@ type Visor struct {
 	tpdUptimeLastFail atomic.Int64
 }
 
-// pingState manages Skywire transport ping connections.
+// pingState manages Skywire transport ping connections. Keyed by
+// PingRouteRef (PK + RouteIndex) so multiple parallel routes to the
+// same peer can coexist without overwriting each other — single-route
+// callers use PingRoutePrimary(pk) (RouteIndex=0) and see no change.
 type pingState struct {
-	conns    map[cipher.PubKey]ping
+	conns    map[PingRouteRef]ping
 	mu       *sync.Mutex
 	pcktSize int
 }
@@ -582,7 +585,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 		},
 		arSelf: newARSelfState(),
 		ping: pingState{
-			conns: make(map[cipher.PubKey]ping),
+			conns: make(map[PingRouteRef]ping),
 			mu:    new(sync.Mutex),
 		},
 		dmsgPing: dmsgPingState{


### PR DESCRIPTION
## Summary

The visor's ping connection map (`pingState.conns`) was keyed by `cipher.PubKey` alone. N parallel `DialPing` calls to the same peer — exactly what `cli visor ping mux-bw` does for `--routes N` — overwrote each other; only the last call's conn survived. The "N parallel routes" running through `PingOnceWithEcho` were actually N parallel uses of *one* conn.

Same root cause prevented:
- `StopPing` per-route (you'd kill all of them — first pump goroutine's `defer` tore down the others)
- `GetPingRouteDetails` per-route (which route's hops?)
- `MuxRouteEstablished.hops` being populated server-side

## Changes

1. **New type `PingRouteRef{PK, Index}`** (`pkg/visor/ping.go`) — composite key. Index 0 = primary / single-route (legacy). Aux routes use 1..N-1. `PingRoutePrimary(pk)` helper for the common case.

2. **`PingConfig` gains `RouteIndex int`** (`pkg/visor/api.go`). Zero value preserves all legacy behavior.

3. **`pingState.conns` changes** from `map[PubKey]ping` to `map[PingRouteRef]ping`. All Dial/Ping/PingOnce/PingOnceWithEcho callers key by `PingRouteRef{conf.PK, conf.RouteIndex}`.

4. **New methods on `Visor`**:
   - `StopPingRoute(ref PingRouteRef) error` — close one route, leave the others alive. Idempotent.
   - `GetPingRouteDetailsAt(ref) []router.RouteHopInfo` — per-route hops.

5. **`StopPing(pk)` semantics**: now iterates the conns map and closes *every* `PingRouteRef` whose PK matches. Existing single-route callers (`init_services`, `hypervisor_handlers_reachability`, rpcgrpc reachability) keep working unchanged.

6. **`VisorAPI` interface** (`pkg/visor/rpcgrpc/server.go`) gains the new methods. `PingConf` mirror gains `RouteIndex`. `visorPingAdapter` (`pkg/visor/init_apps.go`) crosses the rpcgrpc↔visor boundary.

7. **`server_mux_bandwidth.go` wires it up**:
   - `muxBwSetupRoute` passes `rs.index` as `RouteIndex` on DialPing
   - `muxBwPumpRoute` defers `StopPingRoute` (was `StopPing` on PK only, which on the first pump's defer-fire tore down every aux route's conn)
   - After successful dial, hops pulled via `GetPingRouteDetailsAt` and emitted in `MuxRouteEstablished.Hops` — consumers (mux-bw NDJSON, mux-bw-tui, treeprobe) can verify route diversity from the wire

## Tests — `pkg/visor/api_ping_test.go`

- `TestPingRouteRefMapIsolation` — central invariant: distinct indexes are distinct map keys (the bug this PR fixes)
- `TestPingRoutePrimary` — back-compat helper
- `TestStopPingClosesAllRoutesForPeer` — legacy `StopPing(pk)` semantics preserved; no bleed-over to unrelated peers
- `TestStopPingRouteOnlyClosesOneRoute` — new per-route teardown doesn't touch parallel routes
- `TestStopPingRouteIdempotent` — safe on missing / nil-conn entries
- `TestStopPingRoutePropagatesCloseError` — conn.Close errors surface to caller
- `TestGetPingRouteDetailsAtPerRoute` — distinct hops per route

## Coordination

This PR is the foundation for Gamma's (2) DisjointMux + (4) per-route visibility work (their pair-thread proposed `PingRouteRef` from the same scope). Beta's (1) smux MaxStreamBuffer is orthogonal — ships in parallel.

## Known limitations (separate PRs)

- The visor's `v.ping.mu` mutex serializes the entire echo I/O — even with per-route conns, only one pump goroutine actually progresses at a time. Real concurrency requires per-route mutexes or dropping the lock around I/O. Called out in source comments; not blocking this PR's correctness fix.
- Probe loop in mux-bw still rides RouteIndex 0 (primary). Future: dedicated probe-only RouteIndex = N.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/visor/... -run 'TestPing|TestStop|TestGetPing'` pass
- [x] `golangci-lint run` clean
- [ ] Live mux-bw run against a peer with `--routes 4`: each MuxRouteEstablished event carries a non-empty Hops list with distinct paths
- [ ] Bandwidth scaling pattern Gamma measured (+24% N=2, +42% N=4, +69% N=8) persists or improves — true N parallel conns instead of N pumps fighting for one conn