### PR TITLE
feat(cli/ping): human-readable defaults + built-in aggregation for tree-stream + mux-bw

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
@@ -2,10 +2,17 @@
 // CLI consumer for the StreamMuxBandwidth gRPC RPC.
 //
 // Operator-visible: `cli visor ping mux-bw <pk>` runs the
-// multiplexed-route bandwidth test against a single peer and emits
-// per-second NDJSON samples to stdout. Pairs with the same
-// treeprobe-friendly envelope shape as `tree-stream` so harness
-// consumers don't need a separate parser for this RPC.
+// multiplexed-route bandwidth test against a single peer.
+//
+// Default stdout: human-readable rows + a final summary with avg /
+// peak throughput, RTT distribution stats (when --probe-rtt is
+// set), and the termination reason — the queueing-delay
+// measurement reads off the summary table directly, no jq needed.
+//
+// --json: emit NDJSON instead. Same envelope shape as ping
+// tree-stream, so treeprobe-style harnesses can consume either.
+//
+// --output FILE: NDJSON tee independent of stdout mode.
 //
 // Run shapes (the operator's hypothesis matrix):
 //
@@ -30,7 +37,10 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"sort"
+	"strings"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -51,6 +61,9 @@ var (
 	muxBwProbeInterval  time.Duration
 	muxBwSampleInterval time.Duration
 	muxBwLocalRoute     bool
+	muxBwJSON           bool
+	muxBwQuiet          bool
+	muxBwOutFile        string
 )
 
 func init() {
@@ -72,32 +85,43 @@ func init() {
 		"interval between MuxBandwidthSample events")
 	muxBandwidthCmd.Flags().BoolVar(&muxBwLocalRoute, "local-route", false,
 		"use locally-cached TPD data for route calculation (faster setup; may be stale)")
+	muxBandwidthCmd.Flags().BoolVar(&muxBwJSON, "json", false,
+		"emit NDJSON on stdout (default: human-readable rows + summary)")
+	muxBandwidthCmd.Flags().BoolVarP(&muxBwQuiet, "quiet", "q", false,
+		"in human mode: suppress per-event rows; print only setup + summary")
+	muxBandwidthCmd.Flags().StringVarP(&muxBwOutFile, "output", "O", "",
+		"append NDJSON of every event to FILE (independent of stdout mode)")
 
 	RootCmd.AddCommand(muxBandwidthCmd)
 }
 
 var muxBandwidthCmd = &cobra.Command{
 	Use:   "mux-bw <pk>",
-	Short: "Multiplexed-route bandwidth + queueing-delay probe to a peer",
+	Short: "Multiplexed-route bandwidth + queueing-delay probe (human output by default; --json for NDJSON)",
 	Long: `Pump bytes from this visor to a peer visor across N parallel
 routes, optionally probing RTT during the load to capture queueing
-delay. Emits per-second NDJSON samples to stdout, plus a terminal
-summary event.
+delay.
 
-The "N parallel routes" can be one of three shapes via flags:
+Default output: human-readable per-second sample rows + a final
+summary with per-route setup times, totals, peak rates, the loaded
+RTT distribution (when --probe-rtt is set), and the termination
+reason. The queueing-delay measurement reads off that summary
+without piping through jq.
 
-  --routes 1                        # single route, route-finder picks freely (will use direct if available)
-  --routes 1 --min-hops 2           # single non-direct path — forces an intermediate
+--json: NDJSON envelope per event, same shape as tree-stream:
+  {"ts":"<RFC3339Nano>","type":"route_established|sample|rtt_probe|done|error","data":{...}}
+
+--output FILE: tee NDJSON to FILE regardless of stdout mode.
+
+Run shapes:
+
+  --routes 1                        # single route, route-finder picks freely
+  --routes 1 --min-hops 2           # single non-direct path
   --routes N --min-hops 2           # N parallel routes excluding direct
-                                    #   — the operator's "mux should sum to more bandwidth" hypothesis
 
-Pair with --probe-rtt to capture the loaded-RTT distribution
-concurrent with the bulk pump. The loaded RTT minus the unloaded
-baseline IS the queueing delay.
-
-Output: NDJSON envelopes, one per stdout line:
-
-  {"ts":"RFC3339Nano","type":"route_established|sample|rtt_probe|done|error","data":{...}}
+Pair with --probe-rtt to capture loaded-RTT samples concurrent
+with the bulk pump. The loaded RTT minus the unloaded baseline IS
+the queueing delay.
 
 Examples:
 
@@ -107,14 +131,13 @@ Examples:
   # Mux 4 routes excluding direct, 60s, with RTT probing:
   skywire cli visor ping mux-bw <peer-pk> --routes 4 --min-hops 2 --duration 60s --probe-rtt
 
-  # Filter to just the sample events with jq:
-  skywire cli visor ping mux-bw <peer-pk> --routes 4 \
-    | jq -c 'select(.type=="sample") | {t: (.data.elapsed_ns|tonumber/1e9), send_mbps: (.data.instant_send_bps/1e6), recv_mbps: (.data.instant_recv_bps/1e6)}'`,
+  # Same run but capture NDJSON for offline analysis:
+  skywire cli visor ping mux-bw <peer-pk> --routes 4 --output /tmp/mux.ndjson`,
 	Args: cobra.ExactArgs(1),
 	Run:  runMuxBandwidth,
 }
 
-func runMuxBandwidth(cmd *cobra.Command, args []string) {
+func runMuxBandwidth(_ *cobra.Command, args []string) {
 	targetPK := args[0]
 
 	ctx, cancel := muxBwSignalContext()
@@ -146,27 +169,294 @@ func runMuxBandwidth(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
+	stdoutEnc := json.NewEncoder(os.Stdout)
 	marshaler := protojson.MarshalOptions{
 		UseProtoNames:   true,
 		EmitUnpopulated: false,
+	}
+
+	var fileEnc *json.Encoder
+	if muxBwOutFile != "" {
+		f, fErr := os.OpenFile(muxBwOutFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644) //nolint:gosec
+		if fErr != nil {
+			fmt.Fprintf(os.Stderr, "mux-bw: open --output file: %v\n", fErr)
+			os.Exit(1)
+		}
+		defer f.Close() //nolint:errcheck
+		fileEnc = json.NewEncoder(f)
+	}
+
+	tracker := newMuxBwTracker()
+	startedAt := time.Now()
+
+	if !muxBwJSON && !muxBwQuiet {
+		fmt.Fprintln(os.Stderr, muxBwHumanHeader(targetPK, req))
 	}
 
 	for {
 		ev, recvErr := stream.Recv()
 		if recvErr != nil {
 			if recvErr == io.EOF || recvErr == context.Canceled {
-				return
+				break
 			}
 			fmt.Fprintf(os.Stderr, "mux-bw: stream recv: %v\n", recvErr)
 			os.Exit(1)
 		}
-		if err := emitMuxBwOne(enc, marshaler, ev); err != nil {
-			fmt.Fprintf(os.Stderr, "mux-bw: emit: %v\n", err)
-			os.Exit(1)
+
+		tracker.record(ev)
+
+		if fileEnc != nil {
+			if err := emitMuxBwOne(fileEnc, marshaler, ev); err != nil {
+				fmt.Fprintf(os.Stderr, "mux-bw: emit to file: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		switch {
+		case muxBwJSON:
+			if err := emitMuxBwOne(stdoutEnc, marshaler, ev); err != nil {
+				fmt.Fprintf(os.Stderr, "mux-bw: emit: %v\n", err)
+				os.Exit(1)
+			}
+		case muxBwQuiet:
+			// Suppress per-event rows.
+		default:
+			muxBwEmitHumanRow(os.Stdout, ev, startedAt)
 		}
 	}
+
+	if !muxBwJSON {
+		tracker.printSummary(os.Stdout)
+	}
 }
+
+// ---------------------------------------------------------------------------
+// Human output
+// ---------------------------------------------------------------------------
+
+func muxBwHumanHeader(targetPK string, req *rpcgrpc.MuxBandwidthRequest) string {
+	parts := []string{
+		fmt.Sprintf("routes=%d", req.Routes),
+		fmt.Sprintf("duration=%s", time.Duration(req.DurationNs)),
+	}
+	if req.MinHops > 0 {
+		parts = append(parts, fmt.Sprintf("min-hops=%d", req.MinHops))
+	}
+	if req.ProbeRtt {
+		parts = append(parts, "probe-rtt")
+	}
+	return fmt.Sprintf("mux-bw → %s  %s", targetPK, strings.Join(parts, " "))
+}
+
+func muxBwEmitHumanRow(w io.Writer, ev *rpcgrpc.MuxBandwidthEvent, start time.Time) {
+	elapsed := time.Since(start).Seconds()
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.MuxBandwidthEvent_RouteEstablished:
+		r := p.RouteEstablished
+		if r.Failed {
+			//nolint:errcheck // human-mode log write; errors here aren't actionable
+			fmt.Fprintf(w, "[+%6.2fs] R%d ✗ FAILED %s (setup=%s)\n",
+				elapsed, r.RouteIndex, r.SetupErr, fmtNs(r.SetupLatencyNs))
+			return
+		}
+		// Compact hops summary: just count + final destination so
+		// the row stays one line wide.
+		path := ""
+		if len(r.Hops) > 0 {
+			path = " hops=" + muxBwRenderHopPath(r.Hops)
+		}
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] R%d ✓ established setup=%s%s\n",
+			elapsed, r.RouteIndex, fmtNs(r.SetupLatencyNs), path)
+	case *rpcgrpc.MuxBandwidthEvent_Sample:
+		s := p.Sample
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] sample  send=%s recv=%s  cum=%s/%s  active=%d\n",
+			elapsed, fmtBps(s.InstantSendBps), fmtBps(s.InstantRecvBps),
+			fmtBytes(s.BytesSent), fmtBytes(s.BytesReceived), s.ActiveRoutes)
+	case *rpcgrpc.MuxBandwidthEvent_RttProbe:
+		r := p.RttProbe
+		if r.LatencyNs == 0 && r.Error != "" {
+			fmt.Fprintf(w, "[+%6.2fs] probe   seq=%d FAILED %s\n", elapsed, r.Sequence, r.Error) //nolint:errcheck
+		}
+		// Successful probes are quiet on stdout to avoid drowning out
+		// sample rows; they still show up in the final RTT
+		// distribution + NDJSON file. Use --json or --output to see
+		// every probe.
+	case *rpcgrpc.MuxBandwidthEvent_Done:
+		d := p.Done
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] done    sent=%s recv=%s  avg=%s/%s  peak=%s/%s  (%s)\n",
+			elapsed,
+			fmtBytes(d.TotalBytesSent), fmtBytes(d.TotalBytesReceived),
+			fmtBps(d.AvgSendBps), fmtBps(d.AvgRecvBps),
+			fmtBps(d.PeakSendBps), fmtBps(d.PeakRecvBps),
+			d.TerminationReason)
+	case *rpcgrpc.MuxBandwidthEvent_Error:
+		e := p.Error
+		fmt.Fprintf(w, "[+%6.2fs] !!! error: %s: %s\n", elapsed, e.Code, e.Message) //nolint:errcheck
+	}
+}
+
+// muxBwRenderHopPath returns "A→B→C" given a Hops slice. The hop's
+// `From` is the previous node, `To` is the next — chaining them
+// produces the full path. Used in the streaming row + the summary
+// table so the operator sees which intermediates were chosen.
+func muxBwRenderHopPath(hops []*rpcgrpc.RouteHop) string {
+	if len(hops) == 0 {
+		return ""
+	}
+	pieces := make([]string, 0, len(hops)+1)
+	pieces = append(pieces, hops[0].From)
+	for _, h := range hops {
+		pieces = append(pieces, h.To)
+	}
+	return strings.Join(pieces, "→")
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+type muxBwTracker struct {
+	routeSet []*rpcgrpc.MuxRouteEstablished
+	done     *rpcgrpc.MuxBandwidthDone
+	srvErr   string
+}
+
+func newMuxBwTracker() *muxBwTracker {
+	return &muxBwTracker{}
+}
+
+func (t *muxBwTracker) record(ev *rpcgrpc.MuxBandwidthEvent) {
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.MuxBandwidthEvent_RouteEstablished:
+		t.routeSet = append(t.routeSet, p.RouteEstablished)
+	case *rpcgrpc.MuxBandwidthEvent_Done:
+		t.done = p.Done
+	case *rpcgrpc.MuxBandwidthEvent_Error:
+		t.srvErr = p.Error.Message
+	}
+}
+
+func (t *muxBwTracker) printSummary(w io.Writer) {
+	//nolint:errcheck // human-mode summary; errors here aren't actionable
+	fmt.Fprintln(w, "\n=== Summary ===")
+
+	if len(t.routeSet) > 0 {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintln(tw, "route\tstate\tsetup_ms\thops\tpath")
+		sort.Slice(t.routeSet, func(i, j int) bool {
+			return t.routeSet[i].RouteIndex < t.routeSet[j].RouteIndex
+		})
+		for _, r := range t.routeSet {
+			state := "✓"
+			if r.Failed {
+				state = "✗"
+			}
+			path := "-"
+			if len(r.Hops) > 0 {
+				path = muxBwRenderHopPath(r.Hops)
+			}
+			extra := ""
+			if r.Failed {
+				extra = " " + r.SetupErr
+			}
+			//nolint:errcheck // human-mode summary; errors here aren't actionable
+			fmt.Fprintf(tw, "R%d\t%s\t%.1f\t%d\t%s%s\n",
+				r.RouteIndex, state,
+				float64(r.SetupLatencyNs)/1e6, len(r.Hops), path, extra)
+		}
+		tw.Flush() //nolint:errcheck,gosec
+	}
+
+	if t.done == nil {
+		if t.srvErr != "" {
+			fmt.Fprintf(w, "\nrun ended with server error: %s\n", t.srvErr) //nolint:errcheck
+			return
+		}
+		fmt.Fprintln(w, "\n(no Done event — run interrupted)") //nolint:errcheck
+		return
+	}
+
+	d := t.done
+	fmt.Fprintln(w, "") //nolint:errcheck
+	//nolint:errcheck // human-mode summary; errors here aren't actionable
+	fmt.Fprintf(w, "routes:    requested=%d established=%d\n",
+		d.RoutesRequested, d.RoutesEstablished)
+	//nolint:errcheck // human-mode summary; errors here aren't actionable
+	fmt.Fprintf(w, "duration:  wall=%s pump=%s setup_total=%s\n",
+		fmtNs(d.WallTimeNs), fmtNs(d.PumpTimeNs), fmtNs(d.SetupTotalNs))
+	//nolint:errcheck // human-mode summary; errors here aren't actionable
+	fmt.Fprintf(w, "sent:      %s  avg=%s  peak=%s\n",
+		fmtBytes(d.TotalBytesSent), fmtBps(d.AvgSendBps), fmtBps(d.PeakSendBps))
+	//nolint:errcheck // human-mode summary; errors here aren't actionable
+	fmt.Fprintf(w, "recv:      %s  avg=%s  peak=%s\n",
+		fmtBytes(d.TotalBytesReceived), fmtBps(d.AvgRecvBps), fmtBps(d.PeakRecvBps))
+	if d.ProbeCount > 0 {
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintf(w, "rtt load:  n=%d  avg=%s  p50=%s  p99=%s  jitter=%s\n",
+			d.ProbeCount,
+			fmtNs(d.ProbeAvgNs), fmtNs(d.ProbeP50Ns),
+			fmtNs(d.ProbeP99Ns), fmtNs(d.ProbeJitterNs))
+	}
+	fmt.Fprintf(w, "reason:    %s\n", d.TerminationReason) //nolint:errcheck
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+// fmtBps / fmtBytes / fmtNs are non-conflicting with the formatBps /
+// formatBytes / formatDuration helpers in mux_bandwidth_tui.go;
+// distinct names prevent confusion since the TUI version emits
+// fixed-width strings for column alignment, while these emit
+// compact natural-width strings for line-flowing log output.
+
+func fmtBps(v float64) string {
+	switch {
+	case v >= 1e9:
+		return fmt.Sprintf("%.2fGbps", v/1e9)
+	case v >= 1e6:
+		return fmt.Sprintf("%.2fMbps", v/1e6)
+	case v >= 1e3:
+		return fmt.Sprintf("%.2fKbps", v/1e3)
+	default:
+		return fmt.Sprintf("%.0fbps", v)
+	}
+}
+
+func fmtBytes(v uint64) string {
+	f := float64(v)
+	switch {
+	case f >= 1<<30:
+		return fmt.Sprintf("%.2fGiB", f/(1<<30))
+	case f >= 1<<20:
+		return fmt.Sprintf("%.2fMiB", f/(1<<20))
+	case f >= 1<<10:
+		return fmt.Sprintf("%.2fKiB", f/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", v)
+	}
+}
+
+func fmtNs(ns int64) string {
+	switch {
+	case ns >= int64(time.Second):
+		return fmt.Sprintf("%.2fs", float64(ns)/float64(time.Second))
+	case ns >= int64(time.Millisecond):
+		return fmt.Sprintf("%.1fms", float64(ns)/float64(time.Millisecond))
+	case ns >= int64(time.Microsecond):
+		return fmt.Sprintf("%.1fµs", float64(ns)/float64(time.Microsecond))
+	default:
+		return fmt.Sprintf("%dns", ns)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NDJSON wire (--json + --output)
+// ---------------------------------------------------------------------------
 
 func emitMuxBwOne(enc *json.Encoder, m protojson.MarshalOptions, ev *rpcgrpc.MuxBandwidthEvent) error {
 	typ, payload := classifyMuxBwEvent(ev)

--- a/cmd/skywire-cli/commands/visor/ping/tree_stream.go
+++ b/cmd/skywire-cli/commands/visor/ping/tree_stream.go
@@ -1,21 +1,21 @@
 // Package ping — cmd/skywire-cli/commands/visor/ping/tree_stream.go:
 // thin gRPC client for the StreamPingTree RPC. The visor does the
 // BFS server-side and pushes PingTreeEvents over the stream; this
-// command renders each event as one NDJSON line on stdout.
+// command renders each event either as a human-readable row
+// (default) or as one NDJSON object per stdout line (--json).
 //
-// Why separate from tree.go: the Bubble Tea TUI in tree.go has its
-// own model + render loop that the next iteration will rewire onto
-// this same stream. Until that lands, the new server-side gRPC path
-// gets its own subcommand so the existing TUI keeps working
-// unchanged for interactive users while harness consumers + coding
-// agents drive the new RPC.
+// Default output is built for direct human consumption — including
+// a final aggregation table (avg/p50/p99/jitter grouped by hop
+// count) so the latency-vs-hops measurement Synth asked about
+// doesn't need a follow-up jq pipeline.
 //
-// Output: one JSON object per stdout line. Top-level fields:
+// --json switches to the NDJSON wire format consumed by external
+// harnesses + coding agents:
 //
-//	{"ts":"<RFC3339Nano>", "type":"discovered|ping_result|level_done|run_done|status_update|server_error", "data":{...}}
+//	{"ts":"<RFC3339Nano>","type":"<event>","data":{...}}
 //
 // `data` is the marshaled oneof payload with proto's snake_case
-// field names preserved. NDJSON consumers can `jq -c .` to filter,
+// field names preserved. NDJSON consumers can `jq -c .` to filter
 // or stream-decode into the wire types via protojson.
 package ping
 
@@ -23,9 +23,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"sort"
+	"strings"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -51,6 +55,9 @@ var (
 	streamDryRun      bool
 	streamTimeout     time.Duration
 	streamSetupTO     time.Duration
+	streamJSON        bool
+	streamQuiet       bool
+	streamOutFile     string
 )
 
 func init() {
@@ -82,24 +89,38 @@ func init() {
 		"per-ping timeout (after route setup)")
 	pingTreeStreamCmd.Flags().DurationVar(&streamSetupTO, "setup-timeout", 30*time.Second,
 		"per-transport route-setup timeout")
+	pingTreeStreamCmd.Flags().BoolVar(&streamJSON, "json", false,
+		"emit NDJSON on stdout (default: human-readable rows + per-hop summary)")
+	pingTreeStreamCmd.Flags().BoolVarP(&streamQuiet, "quiet", "q", false,
+		"in human mode: suppress per-event rows and print only the final summary")
+	pingTreeStreamCmd.Flags().StringVarP(&streamOutFile, "output", "O", "",
+		"append NDJSON of every event to FILE (independent of stdout mode)")
 
 	RootCmd.AddCommand(pingTreeStreamCmd)
 }
 
 var pingTreeStreamCmd = &cobra.Command{
 	Use:   "tree-stream",
-	Short: "Stream a server-side BFS ping-tree as NDJSON (for harness consumers + coding agents)",
-	Long: `Stream a server-side BFS ping-tree as NDJSON to stdout.
+	Short: "Stream a server-side BFS ping-tree as human-readable rows + summary (or NDJSON with --json)",
+	Long: `Stream a server-side BFS ping-tree.
 
 The visor walks its own neighborhood breadth-first and streams one
 event per discovered transport, per ping result, per level boundary,
-and a final run summary. Each event is one JSON object per stdout
-line (NDJSON).
+plus a final run summary.
 
-Wire format (top-level fields per line):
+Default stdout: human-readable rows + a final aggregation table
+showing succeeded / failed counts and avg/p50/p99/jitter grouped by
+hop count. The Synth-directive latency-vs-hops measurement reads
+directly from this table — no jq pipeline required.
+
+--json: emit NDJSON instead. One JSON object per stdout line:
   {"ts":"<RFC3339Nano>","type":"<event>","data":{...}}
 
-Event types:
+--output FILE: write the NDJSON to FILE regardless of stdout mode,
+so harness consumers can capture machine-readable data while the
+operator watches the human stream.
+
+Event types (visible in --json or in --output FILE):
   discovered     — BFS added (transport, peer) to the level-N candidate set
   ping_result    — ping (or transport_summary cache hit) completed
   level_done     — every transport at level N has resolved
@@ -109,28 +130,30 @@ Event types:
 
 Examples:
 
-  # Hop-level latency measurement (synth's directive):
-  skywire cli visor ping tree-stream --hops 1 --tries 5 | jq -c 'select(.type=="ping_result")'
-  skywire cli visor ping tree-stream --hops 2 --tries 5 -l 2 | tee hops-2.ndjson
-  skywire cli visor ping tree-stream --hops 3 --tries 5 -l 3 | tee hops-3.ndjson
+  # Latency + jitter as a function of hops (Synth's directive):
+  skywire cli visor ping tree-stream --hops 1 --tries 5
+  skywire cli visor ping tree-stream --hops 2 --tries 5 -l 2
+  skywire cli visor ping tree-stream --hops 3 --tries 5 -l 3
+
+  # Same as above but keep only the summary table:
+  skywire cli visor ping tree-stream --hops 2 --tries 5 -l 2 --quiet
+
+  # Capture NDJSON for offline analysis while watching live rows:
+  skywire cli visor ping tree-stream --tries 5 --output /tmp/tree.ndjson
 
   # Discovery only, no pings (visualize the reachable graph):
   skywire cli visor ping tree-stream --dry-run --max-level 2
 
-  # Aggregate latency across all reachable levels:
-  skywire cli visor ping tree-stream --tries 3 | jq -c 'select(.type=="ping_result") | {level:.data.level, avg_ms:(.data.ping_avg_ns/1e6)}'
-
-The TUI variant of this command is still 'cli visor ping tree' —
-that one keeps the Bubble Tea interactive surface and will be
-rewired onto this same stream in a follow-up.`,
+The TUI variant is 'cli visor ping tree' for interactive use.`,
 	Run: runPingTreeStream,
 }
 
 // runPingTreeStream connects to the local visor's gRPC server,
-// invokes StreamPingTree with the flag-derived request, and writes
-// one NDJSON line per event to stdout until the stream closes
-// (RunDone, ServerError, or ctx-cancel from Ctrl+C).
-func runPingTreeStream(cmd *cobra.Command, _ []string) {
+// invokes StreamPingTree with the flag-derived request, and dispatches
+// each event to (a) human rows on stdout, (b) NDJSON on stdout, and
+// (c) NDJSON to --output FILE — modes (a)/(b) are mutually exclusive
+// via --json; (c) is always-on when --output is set.
+func runPingTreeStream(_ *cobra.Command, _ []string) {
 	ctx, cancel := signalContext()
 	defer cancel()
 
@@ -168,32 +191,282 @@ func runPingTreeStream(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
-	// protojson preserves snake_case field names; conversion from
-	// proto-Message to encoding/json marshaler goes through
-	// protojson.Marshal → []byte → json.RawMessage so the outer
-	// envelope can carry the data unmolested.
+	// File tee (always NDJSON when --output is set).
+	var fileEnc *json.Encoder
+	if streamOutFile != "" {
+		f, fErr := os.OpenFile(streamOutFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644) //nolint:gosec
+		if fErr != nil {
+			fmt.Fprintf(os.Stderr, "error: open --output file: %v\n", fErr)
+			os.Exit(1)
+		}
+		defer f.Close() //nolint:errcheck
+		fileEnc = json.NewEncoder(f)
+	}
+
+	stdoutEnc := json.NewEncoder(os.Stdout)
 	marshaler := protojson.MarshalOptions{
 		UseProtoNames:   true, // snake_case fields, matches proto declarations
 		EmitUnpopulated: false,
+	}
+
+	stats := newPingTreeStats()
+	startedAt := time.Now()
+
+	if !streamJSON && !streamQuiet {
+		fmt.Fprintln(os.Stderr, treeStreamHumanHeader(req))
 	}
 
 	for {
 		ev, recvErr := stream.Recv()
 		if recvErr != nil {
 			// EOF is normal stream-end; everything else is a problem.
-			if recvErr.Error() == "EOF" || recvErr == context.Canceled {
-				return
+			if recvErr == io.EOF || recvErr == context.Canceled {
+				break
 			}
 			fmt.Fprintf(os.Stderr, "error: stream recv: %v\n", recvErr)
 			os.Exit(1)
 		}
-		if err := emitOne(enc, marshaler, ev); err != nil {
-			fmt.Fprintf(os.Stderr, "error: emit: %v\n", err)
-			os.Exit(1)
+
+		// Always update stats so the summary is correct regardless of
+		// stdout mode.
+		stats.record(ev)
+
+		// File tee always emits NDJSON.
+		if fileEnc != nil {
+			if err := emitOne(fileEnc, marshaler, ev); err != nil {
+				fmt.Fprintf(os.Stderr, "error: emit to file: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		// Stdout mode dispatch.
+		switch {
+		case streamJSON:
+			if err := emitOne(stdoutEnc, marshaler, ev); err != nil {
+				fmt.Fprintf(os.Stderr, "error: emit: %v\n", err)
+				os.Exit(1)
+			}
+		case streamQuiet:
+			// Suppress per-event rows; summary still prints at end.
+		default:
+			emitHumanRow(os.Stdout, ev, startedAt)
 		}
 	}
+
+	// Final summary in human modes (default + --quiet). In --json
+	// mode the consumer parses run_done out of the NDJSON stream.
+	if !streamJSON {
+		stats.printSummary(os.Stdout)
+	}
 }
+
+// ---------------------------------------------------------------------------
+// Human output
+// ---------------------------------------------------------------------------
+
+// treeStreamHumanHeader is the one-line banner printed to stderr at
+// the start of a human-mode run. Goes to stderr so it doesn't leak
+// into the summary table when stdout is redirected to a file.
+func treeStreamHumanHeader(req *rpcgrpc.PingTreeRequest) string {
+	var parts []string
+	if req.Hops > 0 {
+		parts = append(parts, fmt.Sprintf("hops=%d", req.Hops))
+	}
+	if req.MaxLevel > 0 {
+		parts = append(parts, fmt.Sprintf("max-level=%d", req.MaxLevel))
+	}
+	if req.Tries > 0 {
+		parts = append(parts, fmt.Sprintf("tries=%d", req.Tries))
+	}
+	if req.DryRun {
+		parts = append(parts, "dry-run")
+	}
+	return fmt.Sprintf("ping tree-stream → %s", strings.Join(parts, " "))
+}
+
+// emitHumanRow prints one event as a single line on the given writer.
+// Discovered events are intentionally skipped — they fire in bulk at
+// BFS-expansion time and would drown out the ping_result rows the
+// operator actually wants to see. They're still in the --output file
+// for offline analysis.
+func emitHumanRow(w io.Writer, ev *rpcgrpc.PingTreeEvent, start time.Time) {
+	elapsed := time.Since(start).Seconds()
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.PingTreeEvent_PingResult:
+		r := p.PingResult
+		glyph := "✓"
+		if r.Canceled {
+			glyph = "⊘"
+		} else if r.Failed {
+			glyph = "✗"
+		}
+		srcTag := "[live ]"
+		if r.LatencySource == "transport_summary" {
+			srcTag = "[cache]"
+		} else if r.LatencySource == "skipped" {
+			srcTag = "[skip ]"
+		}
+		statsBlock := ""
+		if r.Failed {
+			msg := r.PingErr
+			if msg == "" {
+				msg = r.SetupErr
+			}
+			if msg == "" {
+				msg = r.CalcErr
+			}
+			statsBlock = msg
+		} else if r.SampleCount > 1 {
+			statsBlock = fmt.Sprintf("avg=%.1fms p50=%.1fms p99=%.1fms jit=%.1fms n=%d",
+				float64(r.PingAvgNs)/1e6,
+				float64(r.PingP50Ns)/1e6,
+				float64(r.PingP99Ns)/1e6,
+				float64(r.JitterNs)/1e6,
+				r.SampleCount)
+		} else {
+			statsBlock = fmt.Sprintf("avg=%.1fms n=%d",
+				float64(r.PingAvgNs)/1e6, r.SampleCount)
+		}
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] %s L%d hops=%d %s  %s  %s  %s\n",
+			elapsed, glyph, r.Level, hopsFromLevel(r.Level), r.RemotePk, r.TpType, srcTag, statsBlock)
+	case *rpcgrpc.PingTreeEvent_LevelDone:
+		l := p.LevelDone
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] --- level %d done: attempted=%d succeeded=%d failed=%d skipped_cached=%d ---\n",
+			elapsed, l.Level, l.Attempted, l.Succeeded, l.Failed, l.SkippedCached)
+	case *rpcgrpc.PingTreeEvent_RunDone:
+		r := p.RunDone
+		//nolint:errcheck // human-mode log write; errors here aren't actionable
+		fmt.Fprintf(w, "[+%6.2fs] === run done: discovered=%d pinged=%d succ=%d fail=%d wall=%dms (%s) ===\n",
+			elapsed, r.TotalDiscovered, r.TotalPinged, r.TotalSucceeded, r.TotalFailed,
+			r.WallTimeNs/1e6, r.TerminationReason)
+	case *rpcgrpc.PingTreeEvent_ServerError:
+		e := p.ServerError
+		fmt.Fprintf(w, "[+%6.2fs] !!! server error: %s: %s\n", elapsed, e.Code, e.Message) //nolint:errcheck
+	}
+}
+
+// hopsFromLevel converts a BFS level (1-indexed) into a hop count.
+// BFS level 1 is "direct neighbor" — one transport edge between
+// local and remote, which is 1 hop.
+func hopsFromLevel(level int32) int32 {
+	return level
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation (per-hops summary)
+// ---------------------------------------------------------------------------
+
+// hopAgg accumulates the per-hop-count stats the run-end summary
+// table reports. Only successful pings (not failed / not canceled /
+// not skipped) contribute to the latency-distribution averages —
+// failures only count toward attempted / failed.
+type hopAgg struct {
+	attempted     int
+	succeeded     int
+	failed        int
+	skippedCached int
+	avgSum        float64
+	p50Sum        float64
+	p99Sum        float64
+	jitterSum     float64
+	avgN          int
+}
+
+type pingTreeStats struct {
+	perHops map[int32]*hopAgg
+	runDone *rpcgrpc.PingTreeRunDone
+}
+
+func newPingTreeStats() *pingTreeStats {
+	return &pingTreeStats{perHops: make(map[int32]*hopAgg)}
+}
+
+func (s *pingTreeStats) record(ev *rpcgrpc.PingTreeEvent) {
+	switch p := ev.Payload.(type) {
+	case *rpcgrpc.PingTreeEvent_PingResult:
+		r := p.PingResult
+		h := s.bucket(r.Level)
+		h.attempted++
+		switch {
+		case r.Failed || r.Canceled:
+			h.failed++
+		case r.LatencySource == "skipped":
+			h.skippedCached++
+		default:
+			h.succeeded++
+			if r.LatencySource == "transport_summary" {
+				h.skippedCached++
+			}
+			h.avgSum += float64(r.PingAvgNs) / 1e6
+			h.p50Sum += float64(r.PingP50Ns) / 1e6
+			h.p99Sum += float64(r.PingP99Ns) / 1e6
+			h.jitterSum += float64(r.JitterNs) / 1e6
+			h.avgN++
+		}
+	case *rpcgrpc.PingTreeEvent_RunDone:
+		s.runDone = p.RunDone
+	}
+}
+
+func (s *pingTreeStats) bucket(level int32) *hopAgg {
+	if h, ok := s.perHops[level]; ok {
+		return h
+	}
+	h := &hopAgg{}
+	s.perHops[level] = h
+	return h
+}
+
+// printSummary writes the per-hop-count aggregation table — the
+// data Synth's directive asked for. Columns are right-aligned via
+// text/tabwriter for clean alignment across viewport widths.
+func (s *pingTreeStats) printSummary(w io.Writer) {
+	if len(s.perHops) == 0 {
+		fmt.Fprintln(w, "\n(no ping results)") //nolint:errcheck
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "\n=== Per-hop summary (avg across entries) ===")                                 //nolint:errcheck
+	fmt.Fprintln(tw, "hops\tattempted\tsucceeded\tfailed\tcached\tavg_ms\tp50_ms\tp99_ms\tjitter_ms") //nolint:errcheck
+
+	keys := make([]int32, 0, len(s.perHops))
+	for k := range s.perHops {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	for _, k := range keys {
+		h := s.perHops[k]
+		var avgStr, p50Str, p99Str, jitStr string
+		if h.avgN > 0 {
+			avgStr = fmt.Sprintf("%.2f", h.avgSum/float64(h.avgN))
+			p50Str = fmt.Sprintf("%.2f", h.p50Sum/float64(h.avgN))
+			p99Str = fmt.Sprintf("%.2f", h.p99Sum/float64(h.avgN))
+			jitStr = fmt.Sprintf("%.2f", h.jitterSum/float64(h.avgN))
+		} else {
+			avgStr, p50Str, p99Str, jitStr = "-", "-", "-", "-"
+		}
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintf(tw, "%d\t%d\t%d\t%d\t%d\t%s\t%s\t%s\t%s\n",
+			hopsFromLevel(k), h.attempted, h.succeeded, h.failed, h.skippedCached,
+			avgStr, p50Str, p99Str, jitStr)
+	}
+	tw.Flush() //nolint:errcheck,gosec
+
+	if s.runDone != nil {
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintf(w, "\ntotals: discovered=%d pinged=%d succeeded=%d failed=%d wall=%dms reason=%s\n",
+			s.runDone.TotalDiscovered, s.runDone.TotalPinged,
+			s.runDone.TotalSucceeded, s.runDone.TotalFailed,
+			s.runDone.WallTimeNs/1e6, s.runDone.TerminationReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NDJSON wire (--json + --output)
+// ---------------------------------------------------------------------------
 
 // emitOne writes one NDJSON line: envelope with type+ts+data.
 func emitOne(enc *json.Encoder, m protojson.MarshalOptions, ev *rpcgrpc.PingTreeEvent) error {


### PR DESCRIPTION
## Summary

Previously \`cli visor ping tree-stream\` and \`cli visor ping mux-bw\` always emitted NDJSON on stdout, forcing operators to pipe through jq just to read the numbers Synth's latency/jitter/queueing-delay directive asked for. Switch the default to human-readable rows + a built-in aggregation summary; NDJSON is opt-in via \`--json\`.

## New flags (both commands)

| Flag | Effect |
|---|---|
| \`--json\` | emit NDJSON on stdout (previous default) |
| \`-q, --quiet\` | in human mode, suppress per-event rows; only the summary prints |
| \`-O, --output FILE\` | tee NDJSON to FILE regardless of stdout mode |

## tree-stream — per-hop summary

```
[+ 5.32s] ✓ L1 hops=1 03d1d78e...  stcpr  [cache] avg=18.2ms n=5
[+12.41s] --- level 1 done: attempted=12 succeeded=11 failed=1 ---
...

=== Per-hop summary (avg across entries) ===
hops  attempted  succeeded  failed  cached  avg_ms  p50_ms  p99_ms  jitter_ms
1     12         11         1       3       18.40   17.10   42.30   2.10
2     34         32         2       0       104.20  98.40   245.10  9.80
3     8          7          1       0       198.50  195.40  301.20  14.20

totals: discovered=54 pinged=54 succeeded=50 failed=4 wall=18234ms reason=completed
```

The Synth-directive measurement (latency + jitter as a function of hops) reads off the table directly — no jq pipeline.

## mux-bw — per-route + RTT-distribution summary

```
mux-bw → <pk>  routes=4 duration=30s min-hops=2 probe-rtt
[+ 0.12s] R0 ✓ established setup=98.3ms hops=A→X→Y→B
[+ 0.13s] R1 ✓ established setup=102.1ms hops=A→X→Z→B
...
[+ 1.13s] sample  send=720Kbps recv=712Kbps  cum=89.4KiB/87.8KiB  active=4

=== Summary ===
route  state  setup_ms  hops  path
R0     ✓      98.3      3     A→X→Y→B
R1     ✓      102.1     3     A→X→Z→B
R2     ✗      30000.0   0     -  setup timeout
R3     ✓      105.7     3     A→W→Y→B

routes:    requested=4 established=3
duration:  wall=30.45s pump=30.0s setup_total=0.41s
sent:      36.5MiB  avg=1.21Mbps  peak=1.41Mbps
recv:      35.8MiB  avg=1.18Mbps  peak=1.40Mbps
rtt load:  n=147  avg=238ms  p50=196ms  p99=557ms  jitter=101ms
reason:    completed
```

The queueing-delay measurement Synth asked about is the last \`rtt load\` line; the operator subtracts the idle baseline (captured via \`ping tree-stream --hops 0 --tries 200\`) from the loaded p99 here.

## Why not treeprobe?

The \`pkg/util/treeprobe\` library landed as an external aggregator because the CLI commands were emitting raw NDJSON. With the aggregation built in, treeprobe-as-library is still useful for external harnesses consuming the \`--output FILE\` NDJSON, but operators don't need a separate command for the common case.

## Notes

- Human-mode rows print to stdout; the one-line banner ("ping tree-stream → hops=2 tries=5") prints to stderr so stdout-redirect workflows (\`$cmd > file\`) capture only the data.
- Successful RTT probes in mux-bw are quiet on stdout to avoid drowning out sample rows; their stats roll into the final rtt distribution. Use \`--json\` or \`--output\` to see every probe.
- For TPD metrics, \`cli tp metrics\` already exists and supports \`--by-transport\`, \`--tree\`, \`--pk\` filtering, and \`--json\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/skywire-cli/commands/visor/ping/...\` pass
- [x] \`golangci-lint run\` clean (0 issues)
- [ ] Live: \`cli visor ping tree-stream --hops 1 --tries 5\` shows rows + summary table
- [ ] Live: \`cli visor ping tree-stream --json --hops 1 --tries 5\` shows previous NDJSON behavior
- [ ] Live: \`cli visor ping mux-bw <pk> --routes 4 --min-hops 2 --probe-rtt --duration 30s\` shows per-route table + rtt distribution

## Coordination

Harness consumers (treeprobe, external scripts) that relied on NDJSON-by-default need to pass \`--json\` or use \`--output FILE\`. Will pair-announce.