### PR TITLE
feat(visor/cli): mux-bw idle-baseline phase + built-in queueing-delay output

### DIFF
--- a/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
+++ b/cmd/skywire-cli/commands/visor/ping/mux_bandwidth.go
@@ -61,6 +61,7 @@ var (
 	muxBwProbeInterval  time.Duration
 	muxBwSampleInterval time.Duration
 	muxBwLocalRoute     bool
+	muxBwIdleBaseline   time.Duration
 	muxBwJSON           bool
 	muxBwQuiet          bool
 	muxBwOutFile        string
@@ -85,6 +86,8 @@ func init() {
 		"interval between MuxBandwidthSample events")
 	muxBandwidthCmd.Flags().BoolVar(&muxBwLocalRoute, "local-route", false,
 		"use locally-cached TPD data for route calculation (faster setup; may be stale)")
+	muxBandwidthCmd.Flags().DurationVar(&muxBwIdleBaseline, "idle-baseline", 0,
+		"run an idle RTT-probe phase of this duration BEFORE the bulk pump; the summary then prints queueing delay = loaded_pXX - idle_pXX (implies --probe-rtt)")
 	muxBandwidthCmd.Flags().BoolVar(&muxBwJSON, "json", false,
 		"emit NDJSON on stdout (default: human-readable rows + summary)")
 	muxBandwidthCmd.Flags().BoolVarP(&muxBwQuiet, "quiet", "q", false,
@@ -151,16 +154,17 @@ func runMuxBandwidth(_ *cobra.Command, args []string) {
 	defer client.Close() //nolint:errcheck
 
 	req := &rpcgrpc.MuxBandwidthRequest{
-		TargetPk:         targetPK,
-		Routes:           int32(muxBwRoutes), //nolint:gosec
-		DurationNs:       muxBwDuration.Nanoseconds(),
-		PacketSizeKb:     int32(muxBwPacketSizeKb), //nolint:gosec
-		MinHops:          int32(muxBwMinHops),      //nolint:gosec
-		SetupTimeoutNs:   muxBwSetupTimeout.Nanoseconds(),
-		ProbeRtt:         muxBwProbeRTT,
-		ProbeIntervalNs:  muxBwProbeInterval.Nanoseconds(),
-		SampleIntervalNs: muxBwSampleInterval.Nanoseconds(),
-		LocalRoute:       muxBwLocalRoute,
+		TargetPk:               targetPK,
+		Routes:                 int32(muxBwRoutes), //nolint:gosec
+		DurationNs:             muxBwDuration.Nanoseconds(),
+		PacketSizeKb:           int32(muxBwPacketSizeKb), //nolint:gosec
+		MinHops:                int32(muxBwMinHops),      //nolint:gosec
+		SetupTimeoutNs:         muxBwSetupTimeout.Nanoseconds(),
+		ProbeRtt:               muxBwProbeRTT || muxBwIdleBaseline > 0,
+		ProbeIntervalNs:        muxBwProbeInterval.Nanoseconds(),
+		SampleIntervalNs:       muxBwSampleInterval.Nanoseconds(),
+		LocalRoute:             muxBwLocalRoute,
+		IdleBaselineDurationNs: muxBwIdleBaseline.Nanoseconds(),
 	}
 
 	stream, err := client.StreamMuxBandwidth(ctx, req)
@@ -244,6 +248,9 @@ func muxBwHumanHeader(targetPK string, req *rpcgrpc.MuxBandwidthRequest) string 
 	}
 	if req.ProbeRtt {
 		parts = append(parts, "probe-rtt")
+	}
+	if req.IdleBaselineDurationNs > 0 {
+		parts = append(parts, fmt.Sprintf("idle-baseline=%s", time.Duration(req.IdleBaselineDurationNs)))
 	}
 	return fmt.Sprintf("mux-bw → %s  %s", targetPK, strings.Join(parts, " "))
 }
@@ -394,12 +401,31 @@ func (t *muxBwTracker) printSummary(w io.Writer) {
 	//nolint:errcheck // human-mode summary; errors here aren't actionable
 	fmt.Fprintf(w, "recv:      %s  avg=%s  peak=%s\n",
 		fmtBytes(d.TotalBytesReceived), fmtBps(d.AvgRecvBps), fmtBps(d.PeakRecvBps))
+	if d.IdleProbeCount > 0 {
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintf(w, "rtt idle:  n=%d  avg=%s  p50=%s  p99=%s  jitter=%s\n",
+			d.IdleProbeCount,
+			fmtNs(d.IdleProbeAvgNs), fmtNs(d.IdleProbeP50Ns),
+			fmtNs(d.IdleProbeP99Ns), fmtNs(d.IdleProbeJitterNs))
+	}
 	if d.ProbeCount > 0 {
 		//nolint:errcheck // human-mode summary; errors here aren't actionable
 		fmt.Fprintf(w, "rtt load:  n=%d  avg=%s  p50=%s  p99=%s  jitter=%s\n",
 			d.ProbeCount,
 			fmtNs(d.ProbeAvgNs), fmtNs(d.ProbeP50Ns),
 			fmtNs(d.ProbeP99Ns), fmtNs(d.ProbeJitterNs))
+	}
+	// Queueing-delay summary: only valid when BOTH distributions are
+	// non-empty. The headline is the p99 delta (worst-case under
+	// load) but all four percentile deltas are surfaced so the
+	// operator can read whichever matches their SLO.
+	if d.IdleProbeCount > 0 && d.ProbeCount > 0 {
+		//nolint:errcheck // human-mode summary; errors here aren't actionable
+		fmt.Fprintf(w, "queueing:  Δavg=%s  Δp50=%s  Δp99=%s  Δjitter=%s\n",
+			fmtNs(d.ProbeAvgNs-d.IdleProbeAvgNs),
+			fmtNs(d.ProbeP50Ns-d.IdleProbeP50Ns),
+			fmtNs(d.ProbeP99Ns-d.IdleProbeP99Ns),
+			fmtNs(d.ProbeJitterNs-d.IdleProbeJitterNs))
 	}
 	fmt.Fprintf(w, "reason:    %s\n", d.TerminationReason) //nolint:errcheck
 }

--- a/pkg/visor/rpcgrpc/ping.pb.go
+++ b/pkg/visor/rpcgrpc/ping.pb.go
@@ -2929,9 +2929,20 @@ type MuxBandwidthRequest struct {
 	// LocalRoute uses local route calculation (cached TPD data)
 	// instead of querying the route-finder service. Mirrors
 	// BandwidthRequest.LocalRoute.
-	LocalRoute    bool `protobuf:"varint,10,opt,name=local_route,json=localRoute,proto3" json:"local_route,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	LocalRoute bool `protobuf:"varint,10,opt,name=local_route,json=localRoute,proto3" json:"local_route,omitempty"`
+	// IdleBaselineDurationNs, when > 0, inserts a quiescent probe
+	// phase between route setup and the bulk pump. During the phase
+	// the same probe loop fires (rate = probe_interval_ns) but no
+	// pump goroutines run — so the RTT samples reflect the route
+	// with zero contention. The aggregated distribution comes back
+	// in MuxBandwidthDone.idle_probe_* fields, and the queueing
+	// delay computed by callers is (loaded_pXX - idle_pXX). 0 = no
+	// idle phase (skip the baseline measurement). Implies ProbeRtt =
+	// true at the handler — without probes there's nothing to
+	// measure.
+	IdleBaselineDurationNs int64 `protobuf:"varint,11,opt,name=idle_baseline_duration_ns,json=idleBaselineDurationNs,proto3" json:"idle_baseline_duration_ns,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *MuxBandwidthRequest) Reset() {
@@ -3032,6 +3043,13 @@ func (x *MuxBandwidthRequest) GetLocalRoute() bool {
 		return x.LocalRoute
 	}
 	return false
+}
+
+func (x *MuxBandwidthRequest) GetIdleBaselineDurationNs() int64 {
+	if x != nil {
+		return x.IdleBaselineDurationNs
+	}
+	return 0
 }
 
 // MuxBandwidthEvent is one entry on the stream. Exactly one oneof
@@ -3475,8 +3493,9 @@ type MuxBandwidthDone struct {
 	RoutesRequested   int32   `protobuf:"varint,9,opt,name=routes_requested,json=routesRequested,proto3" json:"routes_requested,omitempty"`
 	RoutesEstablished int32   `protobuf:"varint,10,opt,name=routes_established,json=routesEstablished,proto3" json:"routes_established,omitempty"`
 	SetupTotalNs      int64   `protobuf:"varint,11,opt,name=setup_total_ns,json=setupTotalNs,proto3" json:"setup_total_ns,omitempty"`
-	// RTT distribution across all probes (when ProbeRtt was set).
-	// Zero when no probes ran. Jitter is population stddev — same
+	// RTT distribution under load — across all probes that fired
+	// during the bulk pump phase. Zero when no probes ran or
+	// ProbeRtt was false. Jitter is population stddev — same
 	// formula as PingTreeResult.jitter_ns.
 	ProbeCount    int32 `protobuf:"varint,12,opt,name=probe_count,json=probeCount,proto3" json:"probe_count,omitempty"`
 	ProbeAvgNs    int64 `protobuf:"varint,13,opt,name=probe_avg_ns,json=probeAvgNs,proto3" json:"probe_avg_ns,omitempty"`
@@ -3485,6 +3504,17 @@ type MuxBandwidthDone struct {
 	ProbeJitterNs int64 `protobuf:"varint,16,opt,name=probe_jitter_ns,json=probeJitterNs,proto3" json:"probe_jitter_ns,omitempty"`
 	// TerminationReason: "duration" | "context_cancel" | "all_routes_failed" | "error".
 	TerminationReason string `protobuf:"bytes,17,opt,name=termination_reason,json=terminationReason,proto3" json:"termination_reason,omitempty"`
+	// RTT distribution under no contention — across all probes that
+	// fired during the IdleBaselineDuration phase BEFORE the bulk
+	// pump. Zero when idle_baseline_duration_ns was 0 or no probes
+	// landed in the window. Operators compute the queueing delay
+	// as (probe_pXX - idle_probe_pXX); the CLI's summary prints
+	// this delta directly when both distributions are present.
+	IdleProbeCount    int32 `protobuf:"varint,18,opt,name=idle_probe_count,json=idleProbeCount,proto3" json:"idle_probe_count,omitempty"`
+	IdleProbeAvgNs    int64 `protobuf:"varint,19,opt,name=idle_probe_avg_ns,json=idleProbeAvgNs,proto3" json:"idle_probe_avg_ns,omitempty"`
+	IdleProbeP50Ns    int64 `protobuf:"varint,20,opt,name=idle_probe_p50_ns,json=idleProbeP50Ns,proto3" json:"idle_probe_p50_ns,omitempty"`
+	IdleProbeP99Ns    int64 `protobuf:"varint,21,opt,name=idle_probe_p99_ns,json=idleProbeP99Ns,proto3" json:"idle_probe_p99_ns,omitempty"`
+	IdleProbeJitterNs int64 `protobuf:"varint,22,opt,name=idle_probe_jitter_ns,json=idleProbeJitterNs,proto3" json:"idle_probe_jitter_ns,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -3636,6 +3666,41 @@ func (x *MuxBandwidthDone) GetTerminationReason() string {
 		return x.TerminationReason
 	}
 	return ""
+}
+
+func (x *MuxBandwidthDone) GetIdleProbeCount() int32 {
+	if x != nil {
+		return x.IdleProbeCount
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetIdleProbeAvgNs() int64 {
+	if x != nil {
+		return x.IdleProbeAvgNs
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetIdleProbeP50Ns() int64 {
+	if x != nil {
+		return x.IdleProbeP50Ns
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetIdleProbeP99Ns() int64 {
+	if x != nil {
+		return x.IdleProbeP99Ns
+	}
+	return 0
+}
+
+func (x *MuxBandwidthDone) GetIdleProbeJitterNs() int64 {
+	if x != nil {
+		return x.IdleProbeJitterNs
+	}
+	return 0
 }
 
 // MuxBandwidthError signals an unrecoverable condition. Last event
@@ -3955,7 +4020,7 @@ const file_ping_proto_rawDesc = "" +
 	"\amessage\x18\x04 \x01(\tR\amessage\"C\n" +
 	"\x13PingTreeServerError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xee\x02\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xa9\x03\n" +
 	"\x13MuxBandwidthRequest\x12\x1b\n" +
 	"\ttarget_pk\x18\x01 \x01(\tR\btargetPk\x12\x16\n" +
 	"\x06routes\x18\x02 \x01(\x05R\x06routes\x12\x1f\n" +
@@ -3969,7 +4034,8 @@ const file_ping_proto_rawDesc = "" +
 	"\x12sample_interval_ns\x18\t \x01(\x03R\x10sampleIntervalNs\x12\x1f\n" +
 	"\vlocal_route\x18\n" +
 	" \x01(\bR\n" +
-	"localRoute\"\xdf\x02\n" +
+	"localRoute\x129\n" +
+	"\x19idle_baseline_duration_ns\x18\v \x01(\x03R\x16idleBaselineDurationNs\"\xdf\x02\n" +
 	"\x11MuxBandwidthEvent\x12!\n" +
 	"\ftimestamp_ns\x18\x01 \x01(\x03R\vtimestampNs\x12K\n" +
 	"\x11route_established\x18\n" +
@@ -4005,7 +4071,7 @@ const file_ping_proto_rawDesc = "" +
 	"latency_ns\x18\x02 \x01(\x03R\tlatencyNs\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x12\x1d\n" +
 	"\n" +
-	"elapsed_ns\x18\x04 \x01(\x03R\telapsedNs\"\x9c\x05\n" +
+	"elapsed_ns\x18\x04 \x01(\x03R\telapsedNs\"\xf8\x06\n" +
 	"\x10MuxBandwidthDone\x12(\n" +
 	"\x10total_bytes_sent\x18\x01 \x01(\x04R\x0etotalBytesSent\x120\n" +
 	"\x14total_bytes_received\x18\x02 \x01(\x04R\x12totalBytesReceived\x12 \n" +
@@ -4032,7 +4098,12 @@ const file_ping_proto_rawDesc = "" +
 	"\fprobe_p99_ns\x18\x0f \x01(\x03R\n" +
 	"probeP99Ns\x12&\n" +
 	"\x0fprobe_jitter_ns\x18\x10 \x01(\x03R\rprobeJitterNs\x12-\n" +
-	"\x12termination_reason\x18\x11 \x01(\tR\x11terminationReason\"A\n" +
+	"\x12termination_reason\x18\x11 \x01(\tR\x11terminationReason\x12(\n" +
+	"\x10idle_probe_count\x18\x12 \x01(\x05R\x0eidleProbeCount\x12)\n" +
+	"\x11idle_probe_avg_ns\x18\x13 \x01(\x03R\x0eidleProbeAvgNs\x12)\n" +
+	"\x11idle_probe_p50_ns\x18\x14 \x01(\x03R\x0eidleProbeP50Ns\x12)\n" +
+	"\x11idle_probe_p99_ns\x18\x15 \x01(\x03R\x0eidleProbeP99Ns\x12/\n" +
+	"\x14idle_probe_jitter_ns\x18\x16 \x01(\x03R\x11idleProbeJitterNs\"A\n" +
 	"\x11MuxBandwidthError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage2\xdc\a\n" +

--- a/pkg/visor/rpcgrpc/ping.proto
+++ b/pkg/visor/rpcgrpc/ping.proto
@@ -623,6 +623,18 @@ message MuxBandwidthRequest {
   // instead of querying the route-finder service. Mirrors
   // BandwidthRequest.LocalRoute.
   bool local_route = 10;
+
+  // IdleBaselineDurationNs, when > 0, inserts a quiescent probe
+  // phase between route setup and the bulk pump. During the phase
+  // the same probe loop fires (rate = probe_interval_ns) but no
+  // pump goroutines run — so the RTT samples reflect the route
+  // with zero contention. The aggregated distribution comes back
+  // in MuxBandwidthDone.idle_probe_* fields, and the queueing
+  // delay computed by callers is (loaded_pXX - idle_pXX). 0 = no
+  // idle phase (skip the baseline measurement). Implies ProbeRtt =
+  // true at the handler — without probes there's nothing to
+  // measure.
+  int64 idle_baseline_duration_ns = 11;
 }
 
 // MuxBandwidthEvent is one entry on the stream. Exactly one oneof
@@ -720,8 +732,9 @@ message MuxBandwidthDone {
   int32 routes_requested = 9;
   int32 routes_established = 10;
   int64 setup_total_ns = 11;
-  // RTT distribution across all probes (when ProbeRtt was set).
-  // Zero when no probes ran. Jitter is population stddev — same
+  // RTT distribution under load — across all probes that fired
+  // during the bulk pump phase. Zero when no probes ran or
+  // ProbeRtt was false. Jitter is population stddev — same
   // formula as PingTreeResult.jitter_ns.
   int32 probe_count = 12;
   int64 probe_avg_ns = 13;
@@ -730,6 +743,18 @@ message MuxBandwidthDone {
   int64 probe_jitter_ns = 16;
   // TerminationReason: "duration" | "context_cancel" | "all_routes_failed" | "error".
   string termination_reason = 17;
+
+  // RTT distribution under no contention — across all probes that
+  // fired during the IdleBaselineDuration phase BEFORE the bulk
+  // pump. Zero when idle_baseline_duration_ns was 0 or no probes
+  // landed in the window. Operators compute the queueing delay
+  // as (probe_pXX - idle_probe_pXX); the CLI's summary prints
+  // this delta directly when both distributions are present.
+  int32 idle_probe_count = 18;
+  int64 idle_probe_avg_ns = 19;
+  int64 idle_probe_p50_ns = 20;
+  int64 idle_probe_p99_ns = 21;
+  int64 idle_probe_jitter_ns = 22;
 }
 
 // MuxBandwidthError signals an unrecoverable condition. Last event

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -52,16 +52,17 @@ const (
 // muxBwCfg is the normalized request. Pass this around inside the
 // handler instead of the raw proto.
 type muxBwCfg struct {
-	TargetPK       cipher.PubKey
-	Routes         int
-	Duration       time.Duration
-	PacketSizeKb   int
-	MinHops        int
-	SetupTimeout   time.Duration
-	ProbeRTT       bool
-	ProbeInterval  time.Duration
-	SampleInterval time.Duration
-	LocalRoute     bool
+	TargetPK             cipher.PubKey
+	Routes               int
+	Duration             time.Duration
+	PacketSizeKb         int
+	MinHops              int
+	SetupTimeout         time.Duration
+	ProbeRTT             bool
+	ProbeInterval        time.Duration
+	SampleInterval       time.Duration
+	LocalRoute           bool
+	IdleBaselineDuration time.Duration // 0 = no pre-pump idle probe phase
 }
 
 func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
@@ -78,6 +79,14 @@ func normalizeMuxBwRequest(req *MuxBandwidthRequest) (muxBwCfg, error) {
 	c.ProbeInterval = time.Duration(req.ProbeIntervalNs)
 	c.SampleInterval = time.Duration(req.SampleIntervalNs)
 	c.LocalRoute = req.LocalRoute
+	c.IdleBaselineDuration = time.Duration(req.IdleBaselineDurationNs)
+
+	// Idle baseline only makes sense when probes are running — force
+	// ProbeRTT on so the operator gets the queueing-delay comparison
+	// they asked for without remembering to pass both flags.
+	if c.IdleBaselineDuration > 0 {
+		c.ProbeRTT = true
+	}
 
 	if c.Routes <= 0 {
 		c.Routes = defaultMuxBwRoutes
@@ -180,6 +189,31 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 		return <-sendErrCh
 	}
 
+	// Phase 1.5: optional idle-baseline probe. Runs the probe loop
+	// only (no pump goroutines, no sampler) for IdleBaselineDuration.
+	// Captures a clean RTT distribution on the same routes the pump
+	// will load — letting the caller compute queueing delay as
+	// (loaded_pXX - idle_pXX) over identical paths. We bookend it
+	// inside a small WaitGroup so the probe goroutine exits cleanly
+	// before the pump phase starts.
+	idleProbeSamples := make([]int64, 0)
+	var idleProbesMu sync.Mutex
+	if cfg.IdleBaselineDuration > 0 && cfg.ProbeRTT {
+		idleCtx, idleCancel := context.WithTimeout(ctx, cfg.IdleBaselineDuration)
+		idleStart := time.Now()
+		idleWg := &sync.WaitGroup{}
+		idleWg.Add(1)
+		go func() {
+			defer idleWg.Done()
+			// Reuse the existing probe loop; it doesn't care whether
+			// a pump is concurrently running — passing only the idle
+			// samples slice means accumulator-direction is correct.
+			s.muxBwProbeLoop(idleCtx, &cfg, idleStart, &idleProbesMu, &idleProbeSamples, emit)
+		}()
+		idleWg.Wait()
+		idleCancel()
+	}
+
 	// Phase 2: pump bytes through each established route + run the
 	// sampler + optional probe. All goroutines share the eventCh
 	// via the emit closure.
@@ -248,11 +282,18 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 		avgRecvBps = float64(totalRecv*8) / pumpSec
 	}
 
-	// RTT stats over all probes.
+	// RTT stats over loaded probes (during the pump).
 	probesMu.Lock()
 	probeCount := len(probeSamples)
 	probeAvg, probeP50, probeP99, probeJitter := aggregatePingSamples(int64ToFloat(probeSamples))
 	probesMu.Unlock()
+
+	// RTT stats over idle probes (Phase 1.5 baseline). Zero when no
+	// idle-baseline phase ran.
+	idleProbesMu.Lock()
+	idleCount := len(idleProbeSamples)
+	idleAvg, idleP50, idleP99, idleJitter := aggregatePingSamples(int64ToFloat(idleProbeSamples))
+	idleProbesMu.Unlock()
 
 	terminationReason := "duration"
 	if ctx.Err() != nil {
@@ -276,6 +317,11 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 		ProbeP50Ns:         probeP50,
 		ProbeP99Ns:         probeP99,
 		ProbeJitterNs:      probeJitter,
+		IdleProbeCount:     int32(idleCount), //nolint:gosec
+		IdleProbeAvgNs:     idleAvg,
+		IdleProbeP50Ns:     idleP50,
+		IdleProbeP99Ns:     idleP99,
+		IdleProbeJitterNs:  idleJitter,
 		TerminationReason:  terminationReason,
 	}})
 

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth_test.go
@@ -5,6 +5,48 @@ import (
 	"time"
 )
 
+// TestNormalizeMuxBwRequestIdleBaselineImpliesProbeRtt pins the
+// implies-relationship: setting idle_baseline_duration_ns > 0 turns
+// ProbeRTT on at the handler regardless of what the caller passed.
+// Without this, an operator who sets --idle-baseline but forgets
+// --probe-rtt would get zero idle probes — no queueing-delay
+// signal, and the failure mode would be silent (no error, just
+// empty distributions in Done).
+func TestNormalizeMuxBwRequestIdleBaselineImpliesProbeRtt(t *testing.T) {
+	pk := "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+
+	t.Run("idle_baseline > 0 forces ProbeRTT on", func(t *testing.T) {
+		c, err := normalizeMuxBwRequest(&MuxBandwidthRequest{
+			TargetPk:               pk,
+			IdleBaselineDurationNs: (5 * time.Second).Nanoseconds(),
+			ProbeRtt:               false, // operator forgot to set it
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !c.ProbeRTT {
+			t.Errorf("IdleBaselineDuration > 0 should force ProbeRTT = true")
+		}
+		if c.IdleBaselineDuration != 5*time.Second {
+			t.Errorf("IdleBaselineDuration = %v, want 5s", c.IdleBaselineDuration)
+		}
+	})
+
+	t.Run("idle_baseline = 0 leaves ProbeRTT alone", func(t *testing.T) {
+		c, err := normalizeMuxBwRequest(&MuxBandwidthRequest{
+			TargetPk:               pk,
+			IdleBaselineDurationNs: 0,
+			ProbeRtt:               false,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.ProbeRTT {
+			t.Errorf("ProbeRTT should stay false when IdleBaseline=0 and caller didn't set it")
+		}
+	})
+}
+
 // TestNormalizeMuxBwRequest pins the default-fallback table. Without
 // these, a zero-valued request would dial zero routes (no work),
 // pump for zero duration (no measurement), and emit zero samples


### PR DESCRIPTION
## Summary

Operator: "what about the queueing delay?" — previously it was an inferred subtraction the operator had to do themselves (run \`tree-stream\` for idle RTT, then \`mux-bw --probe-rtt\` for loaded RTT, then subtract). The two runs took different routes, so the comparison was confounded.

This PR moves the idle baseline phase server-side into the same \`StreamMuxBandwidth\` flow that runs the loaded measurement, so the idle and loaded distributions are captured over the **same routes** that were just dialed. The CLI summary then prints the queueing-delay deltas directly.

## Operator-visible result

```
$ skywire cli visor ping mux-bw <peer-pk> --routes 4 --min-hops 2 \
    --probe-rtt --idle-baseline 5s --duration 30s

mux-bw → <peer-pk>  routes=4 duration=30s min-hops=2 probe-rtt idle-baseline=5s
[+ 0.12s] R0 ✓ established setup=98.3ms hops=...
...

=== Summary ===
route  state  setup_ms  hops  path
R0     ✓      98.3      3     A→X→Y→B
...

routes:    requested=4 established=4
duration:  wall=35.45s pump=30.0s setup_total=0.41s
sent:      36.5MiB  avg=1.21Mbps  peak=1.41Mbps
recv:      35.8MiB  avg=1.18Mbps  peak=1.40Mbps
rtt idle:  n=42   avg=87ms   p50=82ms   p99=98ms   jitter=4ms
rtt load:  n=147  avg=238ms  p50=196ms  p99=557ms  jitter=101ms
queueing:  Δavg=151ms  Δp50=114ms  Δp99=459ms  Δjitter=97ms
reason:    duration
```

The \`queueing:\` line is the operator-visible answer to Synth's queueing-delay directive. Only printed when both distributions are non-empty (no \`--idle-baseline\` flag → keeps the previous two-line shape).

## Wire changes (proto)

\`MuxBandwidthRequest\` gains:
\`\`\`
int64 idle_baseline_duration_ns = 11;
\`\`\`

\`MuxBandwidthDone\` gains:
\`\`\`
int32 idle_probe_count     = 18;
int64 idle_probe_avg_ns    = 19;
int64 idle_probe_p50_ns    = 20;
int64 idle_probe_p99_ns    = 21;
int64 idle_probe_jitter_ns = 22;
\`\`\`

Existing \`probe_*\` fields now explicitly mean "under load"; docstring updated.

## Server flow

```
Phase 1   : setup (dial N routes, emit RouteEstablished events)
Phase 1.5 : idle baseline (NEW; conditional on idle_baseline_duration_ns > 0)
            — probe loop only, no pump, no sampler
Phase 2   : pump + concurrent probe + sampler (existing)
Done event: both idle_probe_* and probe_* fields populated
```

## CLI

\`cli visor ping mux-bw\` gains \`--idle-baseline DURATION\` (default 0 = skip). Implies \`--probe-rtt\` because the queueing-delay comparison requires both phases.

## Tests

\`TestNormalizeMuxBwRequestIdleBaselineImpliesProbeRtt\` pins the implies-relationship: \`idle > 0\` forces ProbeRTT on; \`idle = 0\` leaves it alone. Without this, an operator who sets \`--idle-baseline\` but forgets \`--probe-rtt\` would get zero idle probes with no error surface — silent failure.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/visor/rpcgrpc/... -run TestNormalizeMuxBw\` pass
- [x] \`golangci-lint run\` clean
- [ ] Live: \`cli visor ping mux-bw <peer> --routes 4 --min-hops 2 --probe-rtt --idle-baseline 5s --duration 30s\` shows both rtt rows + queueing-delta row
- [ ] Backwards compat: same command without \`--idle-baseline\` shows only the loaded rtt row (no idle, no queueing) — previous behavior

## Notes for peers

The wire is backwards-compatible (only adds fields). Gamma's DisjointMux work (#2746, already merged) is orthogonal — idle baseline runs on whichever routes setup produces. Beta's smux MaxStreamBuffer work (#1 in the original list) doesn't touch this surface.