### PR TITLE
fix(visor/router): plumb mux-bw --min-hops through DialPing → router

### DIFF
--- a/pkg/app/appnet/networker.go
+++ b/pkg/app/appnet/networker.go
@@ -116,6 +116,25 @@ func PingContext(ctx context.Context, pk cipher.PubKey, addr Addr) (net.Conn, er
 	return n.PingContext(ctx, pk, addr)
 }
 
+// PingContextWithMinHops dials the remote `addr` constrained to
+// paths of at least `minHops` hops. Used by mux-bw's --min-hops
+// flag to force non-direct routing even when a direct transport
+// exists. Falls back to plain PingContext when the resolved
+// networker isn't a SkywireNetworker (DMSG, etc).
+func PingContextWithMinHops(ctx context.Context, pk cipher.PubKey, addr Addr, minHops int) (net.Conn, error) {
+	n, err := ResolveNetworker(addr.Net)
+	if err != nil {
+		return nil, err
+	}
+	sn, ok := n.(*SkywireNetworker)
+	if !ok || minHops <= 0 {
+		return n.PingContext(ctx, pk, addr)
+	}
+	opts := router.DefaultDialOptions()
+	opts.MinHops = minHops
+	return sn.PingContextWithOpts(ctx, pk, addr, opts)
+}
+
 // PingContextWithTransport dials the remote `addr` using a specific transport.
 // This skips route calculation and uses the provided transport directly.
 // Only works with TypeSkynet networker.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -120,6 +120,21 @@ type DialOptions struct {
 	ReverseHops         []routing.Hop // If set, use these hops for reverse path (skips route calculation)
 	MuxRoutes           int           // Number of parallel routes to establish (0 or 1 = single route, >1 = mux)
 	ExcludeTransportIDs []uuid.UUID   // Transport IDs to exclude from route calculation (for mux)
+	// MinHops, when > 0, is the per-call minimum hop count constraint.
+	// Overrides Config.MinHops for this dial only — needed by callers
+	// that want a non-direct path even when the visor's global
+	// min_hops is 1 (e.g. `cli visor ping mux-bw --min-hops 2`, which
+	// must force every dial through an intermediate to test the
+	// "mux via intermediates > direct" bandwidth hypothesis without
+	// requiring the operator to bump visor-global config).
+	//
+	// Setting MinHops >= 2 also suppresses the direct-transport
+	// fast path inside DialRoutes (the existing
+	// "if r.isTpdExist(rPK) { MinHops = 1 }" downgrade is skipped),
+	// since the caller has explicitly asked NOT to use direct.
+	//
+	// 0 = inherit Config.MinHops (legacy / single-route callers).
+	MinHops int
 	// ExcludeIntermediatePKs lists intermediate-visor PKs that route-
 	// finder paths must NOT contain. Source + destination are never
 	// excluded (they're endpoints, not intermediates). The mux loop

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -52,9 +52,14 @@ func (r *router) DialRoutes(
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, rPK, lPort, rPort)
 
-	// check if transport exist, then skip minhop value and consider it equal 0
+	// check if transport exist, then skip minhop value and consider it equal 0.
+	// Per-call opts.MinHops > 1 suppresses this downgrade: the caller has
+	// explicitly demanded a multi-hop path, and silently routing through the
+	// direct transport when one happens to exist would defeat the constraint
+	// (this was the symptom of `mux-bw --min-hops 2` riding direct stcpr
+	// instead of going via intermediates).
 	defaultMinHops := r.conf.MinHops
-	if r.isTpdExist(rPK) {
+	if r.isTpdExist(rPK) && (opts == nil || opts.MinHops <= 1) {
 		r.conf.MinHops = 1
 	}
 
@@ -457,8 +462,15 @@ fetchRoutesAgain:
 		return nil, nil, fmt.Errorf("context canceled before route fetch: %w", err)
 	}
 
+	// Per-call MinHops override takes precedence over visor-global
+	// Config.MinHops. Set by callers like mux-bw that want to test
+	// a multi-hop path without bumping the visor's static config.
+	rfMinHops := r.conf.MinHops
+	if opts.MinHops > 0 {
+		rfMinHops = uint16(opts.MinHops) //nolint:gosec // bounded by caller; CLI flag values are small
+	}
 	paths, err := r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward, backward},
-		&rfclient.RouteOptions{MinHops: r.conf.MinHops, MaxHops: r.conf.MaxHops})
+		&rfclient.RouteOptions{MinHops: rfMinHops, MaxHops: r.conf.MaxHops})
 
 	if err == rfclient.ErrTransportNotFound {
 		// Try local route calculation - may find a local transport that's not yet in TPD
@@ -640,8 +652,16 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 
 	log.Debugf("Found %d local transports", len(localTps))
 
+	// Skip the direct (1-hop) probe when the caller asked for
+	// MinHops >= 2 — they want a non-direct path. The intermediate
+	// route search below will be the only candidate generator.
+	allowDirect := dialOpts == nil || dialOpts.MinHops <= 1
+
 	// Check for direct (1-hop) route first
 	for _, tp := range localTps {
+		if !allowDirect {
+			break
+		}
 		if tp.remotePK == dst {
 			// Skip DMSG transports for mux (DMSG is a relay, not suitable for multiplexing)
 			if dialOpts != nil && dialOpts.ExcludeDMSG && tp.tpType == "dmsg" {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -606,6 +606,16 @@ type PingConfig struct {
 	// target without their conns trampling each other in the visor's
 	// per-route conn map. See PingRouteRef in pkg/visor/ping.go.
 	RouteIndex int
+	// MinHops, when > 0, forces the route-finder to skip paths with
+	// fewer than this many hops on THIS dial — overrides the visor-
+	// global routing.min_hops config for the duration of the call.
+	// Plumbed straight into router.DialOptions.MinHops. Used by
+	// `cli visor ping mux-bw --min-hops N` to verify the operator's
+	// "mux via intermediates > direct" hypothesis: without it, the
+	// router's direct-transport fast path would short-circuit every
+	// dial to use the direct stcpr whenever one existed. 0 = inherit
+	// visor-global setting.
+	MinHops int
 }
 
 // TestResult type of test result

--- a/pkg/visor/api_ping.go
+++ b/pkg/visor/api_ping.go
@@ -55,7 +55,8 @@ func (v *Visor) DialPing(conf PingConfig) error {
 	defer cancel()
 	var r = netutil.NewRetrier(v.log, 2*time.Second, netutil.DefaultMaxBackoff, 1, 2)
 	err = r.Do(ctx, func() error {
-		if len(conf.ForwardHops) > 0 && len(conf.ReverseHops) > 0 {
+		switch {
+		case len(conf.ForwardHops) > 0 && len(conf.ReverseHops) > 0:
 			// Use explicit route (skips route calculation)
 			fwdHops := make([]appnet.RouteHopInfo, len(conf.ForwardHops))
 			for i, h := range conf.ForwardHops {
@@ -66,10 +67,17 @@ func (v *Visor) DialPing(conf PingConfig) error {
 				revHops[i] = appnet.RouteHopInfo{TpID: h.TpID, From: h.From, To: h.To, TpType: h.TpType}
 			}
 			conn, err = appnet.PingContextWithRoute(ctx, conf.PK, addr, fwdHops, revHops)
-		} else if conf.TransportID != "" {
+		case conf.TransportID != "":
 			// Use specific transport (skips route calculation)
 			conn, err = appnet.PingContextWithTransport(ctx, conf.PK, addr, conf.TransportID)
-		} else {
+		case conf.MinHops > 0:
+			// Constrain the route-finder to multi-hop paths only.
+			// This is what `mux-bw --min-hops N` rides — without
+			// this branch the router would short-circuit to the
+			// direct transport whenever one existed, making the
+			// flag a no-op.
+			conn, err = appnet.PingContextWithMinHops(ctx, conf.PK, addr, conf.MinHops)
+		default:
 			conn, err = appnet.PingContext(ctx, conf.PK, addr)
 		}
 		return err

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -236,6 +236,7 @@ func (a *visorPingAdapter) DialPing(conf rpcgrpc.PingConf) error {
 		ForwardHops: forwardHops,
 		ReverseHops: reverseHops,
 		RouteIndex:  conf.RouteIndex,
+		MinHops:     conf.MinHops,
 	})
 }
 
@@ -246,6 +247,7 @@ func (a *visorPingAdapter) PingOnce(conf rpcgrpc.PingConf) (time.Duration, error
 		PcktSize:   conf.PcktSize,
 		LocalRoute: conf.LocalRoute,
 		RouteIndex: conf.RouteIndex,
+		MinHops:    conf.MinHops,
 	})
 }
 

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -143,6 +143,10 @@ type PingConf struct {
 	// Zero = primary / single-route (legacy behavior). Mirrors
 	// visor.PingConfig.RouteIndex; the adapter passes it through.
 	RouteIndex int
+	// MinHops is the per-call route-finder min-hops constraint.
+	// Mirrors visor.PingConfig.MinHops; adapter passes it through.
+	// 0 = inherit visor-global routing.min_hops.
+	MinHops int
 }
 
 // PingServer implements the gRPC PingService

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -350,6 +350,7 @@ func (s *PingServer) muxBwSetupRoute(
 		PcktSize:   cfg.PacketSizeKb,
 		LocalRoute: cfg.LocalRoute,
 		RouteIndex: rs.index,
+		MinHops:    cfg.MinHops, // enforce --min-hops at the router-finder layer
 	}
 	setupCtx, cancel := context.WithTimeout(ctx, cfg.SetupTimeout)
 	defer cancel()


### PR DESCRIPTION
## Summary

Gamma's diagnostic on 2026-05-20 found that \`cli visor ping mux-bw --min-hops 2\` was a **no-op** — visor journal during a run showed all N parallel routes using the same direct stcpr transport. The +24/42/69% bandwidth gains we measured at N=2/4/8 were **smux-stream parallelism over ONE transport**, not the intermediate-route diversity the operator's hypothesis test intended.

## Root cause

The chain \`visor.PingConfig\` → \`rpcgrpc.PingConf\` → \`appnet.PingContext\` → \`router.DialRoutes\` had no per-call MinHops field. mux-bw set \`req.MinHops\` at the proto layer but it died at the \`rpcgrpc.PingConf\` boundary — there was no corresponding field — and the route layer's only MinHops source was the visor-global \`routing.min_hops\` config (typically 1).

Worse, \`router.DialRoutes\` contained an explicit fast-path downgrade: when a direct transport to the destination exists, \`r.conf.MinHops\` is temporarily set to 1 for the duration of the dial. So even with visor-global min_hops=2, a peer with a direct stcpr would still get routed direct.

## Fix (this PR)

| File | Change |
|---|---|
| \`pkg/router/router.go\` | + \`DialOptions.MinHops int\` — per-call override |
| \`pkg/router/router_dial.go\` | direct-transport fast-path downgrade now only fires when \`opts.MinHops <= 1\`; \`fetchBestRoutes\` uses \`opts.MinHops\` over \`r.conf.MinHops\` when > 0; \`calculateLocalRoutes\` skips the 1-hop probe when \`opts.MinHops > 1\` |
| \`pkg/app/appnet/networker.go\` | + \`PingContextWithMinHops\` helper (mirrors \`PingContextWithTransport\` / \`PingContextWithRoute\` pattern) |
| \`pkg/visor/api.go\` | + \`PingConfig.MinHops int\` |
| \`pkg/visor/api_ping.go\` | \`DialPing\` dial branch picks \`PingContextWithMinHops\` when \`conf.MinHops > 0\` |
| \`pkg/visor/init_apps.go\` | adapter passes \`MinHops\` through |
| \`pkg/visor/rpcgrpc/server.go\` | + \`PingConf.MinHops int\` |
| \`pkg/visor/rpcgrpc/server_mux_bandwidth.go\` | \`muxBwSetupRoute\` populates \`PingConf.MinHops = cfg.MinHops\` |

## Effect post-merge

\`cli visor ping mux-bw <peer> --routes 4 --min-hops 2\` will:
- dial 4 routes, each with \`DialOptions.MinHops=2\`
- route-finder asked for paths with ≥2 hops
- direct-transport downgrade **suppressed**
- visor journal should show each route picking a different intermediate (subject to the separate circuit-breaker issue Gamma is investigating)

## Coordination

- This is **(A) plumbing** in Gamma's split. They're taking **(B) circuit-breaker investigation** — without (B), intermediate route setup still fails with \`"destination circuit breaker open: ... unreachable"\` per their 22:42Z pair. (A) makes the constraint *reach* the router; (B) is needed before intermediate routes actually *complete* setup.
- Independent of #2746's router-layer DisjointMux (Gamma) — they live in adjacent DialOptions fields and don't conflict.
- Beta's smux MaxStreamBuffer work (#1 in the original list) doesn't touch this surface.

## Why no unit test

Verifying end-to-end requires a router fixture (transport manager + setup nodes + route-finder client) that doesn't exist in the test suite. Pragmatic validation: Beta + Gamma run \`mux-bw --routes 4 --min-hops 2\` against each other post-merge and grep the visor journal for distinct stcpr transports per route. Existing test suites still pass.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/visor/...\` pass
- [x] \`golangci-lint run\` clean (0 issues)
- [ ] Live: \`cli visor ping mux-bw <peer> --routes 4 --min-hops 2 --probe-rtt --duration 30s\` → visor journal shows each route on a different transport