### PR TITLE
fix(router): blame intermediate not dst when id_reservation fails on a hop

### DIFF
--- a/pkg/router/setupmetrics/stats.go
+++ b/pkg/router/setupmetrics/stats.go
@@ -30,17 +30,18 @@ type FailureReason string
 // through to ReasonUnknown and the raw error message is still captured
 // in the RecentFailures ring buffer for investigation.
 const (
-	ReasonInvalidRoute      FailureReason = "invalid_route"      // BidirectionalRoute.Check failed
-	ReasonRuleGeneration    FailureReason = "rule_generation"    // GenerateRules returned ErrNoKey etc.
-	ReasonIDReservation     FailureReason = "id_reservation"     // ReserveRouteIDs failed dialing the destination / an intermediary
-	ReasonSourceUnreachable FailureReason = "source_unreachable" // ReserveRouteIDs could not reach the SOURCE visor (not the dst's fault)
-	ReasonIntermediaryRules FailureReason = "intermediary_rules" // BroadcastIntermediaryRules failed
-	ReasonDestinationRules  FailureReason = "destination_rules"  // AddEdgeRules on destination router failed
-	ReasonContextDeadline   FailureReason = "context_deadline"   // overall request timed out
-	ReasonContextCanceled   FailureReason = "context_canceled"   // caller canceled before completion
-	ReasonConcurrencyLimit  FailureReason = "concurrency_limit"  // dropped at the accept loop backpressure check
-	ReasonCircuitOpen       FailureReason = "circuit_open"       // per-destination breaker short-circuited the setup
-	ReasonUnknown           FailureReason = "unknown"            // failure classifier could not decide
+	ReasonInvalidRoute            FailureReason = "invalid_route"            // BidirectionalRoute.Check failed
+	ReasonRuleGeneration          FailureReason = "rule_generation"          // GenerateRules returned ErrNoKey etc.
+	ReasonIDReservation           FailureReason = "id_reservation"           // ReserveRouteIDs failed dialing the destination
+	ReasonSourceUnreachable       FailureReason = "source_unreachable"       // ReserveRouteIDs could not reach the SOURCE visor (not the dst's fault)
+	ReasonIntermediateUnreachable FailureReason = "intermediate_unreachable" // ReserveRouteIDs could not reach an INTERMEDIATE visor (not the dst's fault)
+	ReasonIntermediaryRules       FailureReason = "intermediary_rules"       // BroadcastIntermediaryRules failed
+	ReasonDestinationRules        FailureReason = "destination_rules"        // AddEdgeRules on destination router failed
+	ReasonContextDeadline         FailureReason = "context_deadline"         // overall request timed out
+	ReasonContextCanceled         FailureReason = "context_canceled"         // caller canceled before completion
+	ReasonConcurrencyLimit        FailureReason = "concurrency_limit"        // dropped at the accept loop backpressure check
+	ReasonCircuitOpen             FailureReason = "circuit_open"             // per-destination breaker short-circuited the setup
+	ReasonUnknown                 FailureReason = "unknown"                  // failure classifier could not decide
 )
 
 // FailureEvent captures a single failed setup attempt with enough
@@ -257,8 +258,33 @@ func NewCollector(cfg CollectorConfig) *Collector {
 // half-open and allow the current probe through. A subsequent success
 // will close the breaker (via finish); a failure re-opens it and
 // resets the 60-second timer.
+//
+// AllowIntermediate is the per-intermediate sibling — see below.
 func (c *Collector) AllowDestination(dstPK cipher.PubKey) (bool, string) {
-	pk := dstPK.String()
+	return c.allowPK(dstPK)
+}
+
+// AllowIntermediate reports whether a route candidate whose path
+// traverses interPK should be allowed to proceed. Intermediate
+// breakers are populated by id_reservation failures attributed to
+// the intermediate (see the default branch in finish()). Callers
+// that have already computed a candidate route's intermediates
+// (typically the route-setup-node, or a router that wants to
+// pre-filter route-finder output) can call this for each hop and
+// reject the route early if any intermediate's breaker is open —
+// avoiding a ~10s id-reservation timeout per known-bad hop.
+//
+// Uses the same allowPK helper as AllowDestination; intermediate
+// breakers live in the same map as destination breakers (keyed by
+// PK string), which keeps the bookkeeping uniform.
+func (c *Collector) AllowIntermediate(interPK cipher.PubKey) (bool, string) {
+	return c.allowPK(interPK)
+}
+
+// allowPK is the shared half-open transition machinery for
+// destinations and intermediates.
+func (c *Collector) allowPK(pubKey cipher.PubKey) (bool, string) {
+	pk := pubKey.String()
 	if pk == "" {
 		return true, ""
 	}
@@ -395,17 +421,29 @@ func (c *Collector) finish(ctx context.Context, srcPK, dstPK cipher.PubKey, hopC
 	// modes like rule_generation reflect local config problems that
 	// won't self-heal by waiting, so they shouldn't trip the breaker.
 	//
-	// Critically: id_reservation can fail because the SOURCE visor is
-	// unreachable (MakeMap dials every hop — src, dst, intermediaries).
-	// A flaky source visor would otherwise poison the destination's
-	// breaker, blocking all requests to a healthy destination just
-	// because a few source visors were unreachable. We extract the PK
-	// that actually failed to dial (from router.DialError) and only
-	// trip the destination's breaker when it matches the destination.
-	// Source-side failures are reclassified as source_unreachable so
-	// the ring buffer and reason counts tell the real story, and the
-	// destination's Failed counter is NOT incremented for them so the
-	// Top-Failed-Destinations table stops fingering innocent dsts.
+	// Critically: id_reservation can fail because the SOURCE visor or
+	// an INTERMEDIATE visor is unreachable (MakeMap dials every hop —
+	// src, dst, intermediaries). A flaky source/intermediate visor
+	// would otherwise poison the destination's breaker, blocking all
+	// requests to a healthy destination just because some other visor
+	// in the path was unreachable. We extract the PK that actually
+	// failed to dial (from router.DialError) and only trip the
+	// destination's breaker when it matches the destination.
+	//
+	// Source-side failures are reclassified as source_unreachable.
+	// Intermediate-side failures are reclassified as
+	// intermediate_unreachable; the intermediate's own breaker is
+	// tripped so the next route-finder pick that traverses this
+	// intermediate can be short-circuited via AllowIntermediate.
+	// In both cases the destination's Failed counter is NOT
+	// incremented so the Top-Failed-Destinations table stops
+	// fingering innocent dsts.
+	//
+	// The mux-disjoint case (N routes through N different
+	// intermediates) is the motivating scenario: under the old
+	// behavior, even one bad intermediate per route would accumulate
+	// circuitFailureThreshold hits on the dst and lock all parallel
+	// attempts out — including ones through healthy intermediates.
 	reason := classifyError(ctx, err)
 	blameDst := true
 	if reason == ReasonIDReservation {
@@ -425,10 +463,17 @@ func (c *Collector) finish(ctx context.Context, srcPK, dstPK cipher.PubKey, hopC
 			reason = ReasonSourceUnreachable
 			blameDst = false
 		default:
-			// Intermediary hop failed; treat it like a dst failure for
-			// breaker purposes — the destination can't be reached via
-			// this intermediary regardless.
-			c.recordCircuitFailureLocked(dstStr)
+			// Intermediate hop failed. Do NOT blame the dst — a
+			// disjoint-mux scenario can have N parallel routes through
+			// N different intermediates, and one bad intermediate
+			// shouldn't lock the dst out for the other (N-1) good
+			// ones. Track failures against the intermediate's own
+			// breaker so future setups can short-circuit on a known-
+			// bad intermediate.
+			reason = ReasonIntermediateUnreachable
+			blameDst = false
+			c.touchDest(failedPK.String()) // ensure breaker entry exists
+			c.recordCircuitFailureLocked(failedPK.String())
 		}
 	}
 	if blameDst && destStat != nil {

--- a/pkg/router/setupmetrics/stats_test.go
+++ b/pkg/router/setupmetrics/stats_test.go
@@ -290,6 +290,81 @@ func TestCollector_CircuitBreaker_DestinationUnreachable(t *testing.T) {
 	}
 }
 
+// TestCollector_CircuitBreaker_IntermediateUnreachable verifies that
+// when the failed dial PK was an intermediate hop (neither src nor
+// dst), the destination's breaker stays closed and the
+// intermediate's own breaker accumulates instead. Regression test
+// for the disjoint-mux pathology: N parallel routes through N
+// different intermediates would accumulate dst breaker hits per bad
+// intermediate, locking out all attempts even via healthy
+// intermediates.
+func TestCollector_CircuitBreaker_IntermediateUnreachable(t *testing.T) {
+	c := NewCollector(CollectorConfig{})
+	srcPK, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	interPK, _ := cipher.GenerateKeyPair()
+
+	// Fail circuitFailureThreshold+2 times, each time with the
+	// INTERMEDIATE as the failed dial target.
+	for i := 0; i < circuitFailureThreshold+2; i++ {
+		e := fmt.Errorf("failed to instantiate route id reserver: a dial attempt failed with: %w",
+			&dialErrStub{pk: interPK, msg: "dial " + interPK.String() + "@136: dmsg error 202"})
+		c.RecordRouteContext(context.Background(), srcPK, dstPK, 2)(&e)
+	}
+
+	if ok, reason := c.AllowDestination(dstPK); !ok {
+		t.Fatalf("intermediate-side failures should NOT trip dst breaker, got denied: %q", reason)
+	}
+	if ok, _ := c.AllowIntermediate(interPK); ok {
+		t.Fatal("intermediate-side failures should trip the intermediate's breaker")
+	}
+
+	snap := c.Snapshot()
+	if got := snap.FailuresByReason[ReasonIntermediateUnreachable]; got != circuitFailureThreshold+2 {
+		t.Errorf("intermediate_unreachable count=%d, want %d", got, circuitFailureThreshold+2)
+	}
+	if got := snap.FailuresByReason[ReasonIDReservation]; got != 0 {
+		t.Errorf("id_reservation count=%d, want 0 (all should reclass to intermediate_unreachable)", got)
+	}
+	// Destination's Failed counter should not have been incremented.
+	for _, d := range snap.TopDestinations {
+		if d.PK == dstPK.String() && d.Failed != 0 {
+			t.Errorf("dst Failed=%d, want 0 (intermediate failures shouldn't blame the dst)", d.Failed)
+		}
+	}
+}
+
+// TestCollector_CircuitBreaker_IntermediateBreakerNotPoisoningDst
+// asserts the asymmetry: an intermediate breaker tripping leaves the
+// dst breaker closed, so routes through OTHER intermediates can
+// still set up. Without this property the disjoint-mux fanout would
+// be useless under any rate of intermediate flakiness.
+func TestCollector_CircuitBreaker_IntermediateBreakerNotPoisoningDst(t *testing.T) {
+	c := NewCollector(CollectorConfig{})
+	srcPK, _ := cipher.GenerateKeyPair()
+	dstPK, _ := cipher.GenerateKeyPair()
+	badInter, _ := cipher.GenerateKeyPair()
+	goodInter, _ := cipher.GenerateKeyPair()
+
+	// Trip the bad intermediate's breaker.
+	for i := 0; i < circuitFailureThreshold; i++ {
+		e := fmt.Errorf("failed to instantiate route id reserver: a dial attempt failed with: %w",
+			&dialErrStub{pk: badInter, msg: "dial " + badInter.String() + "@136: timeout"})
+		c.RecordRouteContext(context.Background(), srcPK, dstPK, 2)(&e)
+	}
+
+	// Bad intermediate denied; good intermediate + dst still allowed.
+	if ok, _ := c.AllowIntermediate(badInter); ok {
+		t.Fatal("bad intermediate breaker should be open")
+	}
+	if ok, _ := c.AllowIntermediate(goodInter); !ok {
+		t.Fatal("good intermediate breaker should be closed")
+	}
+	if ok, _ := c.AllowDestination(dstPK); !ok {
+		t.Fatal("dst breaker should be closed (intermediate failures must not poison it)")
+	}
+}
+
 // TestCollector_CircuitBreakerOnlyIDReservation verifies that other
 // failure reasons do not trip the breaker — only dial-path failures
 // should, because the others are local config / rule problems that

--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -444,6 +444,20 @@ func CreateRouteGroup(ctx context.Context, dialer network.Dialer, pool *ClientPo
 			log.Debugf("circuit breaker: %s", reason)
 			return routing.EdgeRules{}, fmt.Errorf("%w: %s", ErrCircuitOpen, reason)
 		}
+		// Also short-circuit if any intermediate on the forward path
+		// has an open breaker. Skipping the last Forward hop's .To
+		// (that's the destination, already checked above). The
+		// pre-check saves the ~10s id_reservation timeout per known-
+		// bad intermediate, which is the whole point of breakers.
+		for i, h := range biRt.Forward {
+			if i == len(biRt.Forward)-1 {
+				break
+			}
+			if ok, reason := collector.AllowIntermediate(h.To); !ok {
+				log.Debugf("circuit breaker (intermediate): %s", reason)
+				return routing.EdgeRules{}, fmt.Errorf("%w: intermediate %s", ErrCircuitOpen, reason)
+			}
+		}
 	}
 
 	// Ensure bi routes input is valid.


### PR DESCRIPTION
## Summary

Disjoint-mux scenario (N parallel routes through N different intermediates) exposed a circuit-breaker attribution bug: when an intermediate hop failed to dial during `id_reservation`, the **destination's** breaker accumulated the hit. Five bad intermediates tripped the destination's breaker even though the destination was reachable via the other N-5 healthy intermediates. All subsequent setup attempts to the dst then fast-failed for `circuitOpenDuration` (~60s).

Symmetric to the source-side fix already in place: source-side dial failures don't poison the dst breaker either. Intermediates needed the same treatment.

## Changes

- `pkg/router/setupmetrics/stats.go`:
  - `finish()` default branch (intermediate hop failed): set `reason = ReasonIntermediateUnreachable`, `blameDst = false`, and record the breaker hit against the **intermediate's** PK (not the dst's).
  - New `AllowIntermediate` accessor mirrors `AllowDestination`; both share an `allowPK` helper.
  - Adds `ReasonIntermediateUnreachable` `FailureReason`.

- `pkg/router/setupnode.go`: `CreateRouteGroup` also consults `AllowIntermediate` for each hop on the forward path. A known-bad intermediate now short-circuits the setup with the same `ErrCircuitOpen` sentinel + the intermediate's PK in the reason string, saving the ~10s id_reservation timeout per known-bad hop.

- `pkg/router/setupmetrics/stats_test.go`: 2 new tests.
  - `TestCollector_CircuitBreaker_IntermediateUnreachable` — 5+ intermediate-fails do NOT trip the dst breaker, DO trip the intermediate's breaker, are reclassified to `intermediate_unreachable`, and don't blame the dst `Failed` counter.
  - `TestCollector_CircuitBreaker_IntermediateBreakerNotPoisoningDst` — asserts the asymmetry that makes disjoint-mux work: bad intermediate denied, good intermediate + dst still allowed.

## Empirical motivation

Captured during #2746 followup. `mux-bw --routes 8 --min-hops 2` against a peer failed all 8 routes with `destination circuit breaker open` despite the route-finder returning 7+ valid candidates through different intermediates. Each route's intermediate-dial failure ticked the dst breaker; once 5 in a 5-minute window had hit, the dst was locked out and the remaining ~3 healthy candidates were never even tried.

## Why this matters now

Pairs with #2746 (disjoint mux) and #2749 (`--min-hops` plumbing). Once `mux-bw` actually routes through intermediates, intermediate flakiness no longer destroys the dst breaker semantics — disjoint-mux is now actually viable against deployment intermediates that may individually be flaky.

## Test plan
- [x] `go test ./pkg/router/setupmetrics/ -count=1 -v` — all 13 subtests pass (11 pre-existing + 2 new).
- [x] `go test ./pkg/router/ -count=1 -short` — passes.
- [x] `go build ./...` — clean.
- [x] `gofmt` — clean.
- [ ] CI lanes (linux, darwin, windows, nix).
- [ ] Post-merge: re-run `mux-bw --routes 8 --min-hops 2` against a peer with known-flaky intermediates and confirm routes through healthy intermediates succeed instead of all-fail.