### PR TITLE
feat(visor): honor caller SetupTimeout in DialPing

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -616,6 +616,13 @@ type PingConfig struct {
 	// dial to use the direct stcpr whenever one existed. 0 = inherit
 	// visor-global setting.
 	MinHops int
+	// SetupTimeout, when > 0, overrides DialPing's hardcoded 30s
+	// dial timeout. Multi-hop route setup through 4+ intermediates
+	// can take 30-120s (route-finder + setup-node round trips +
+	// saveRouteGroupRules retries), exceeding the legacy 30s
+	// ceiling. mux-bw passes its cfg.SetupTimeout here. 0 falls
+	// back to the existing 30s default.
+	SetupTimeout time.Duration
 }
 
 // TestResult type of test result

--- a/pkg/visor/api_ping.go
+++ b/pkg/visor/api_ping.go
@@ -51,7 +51,16 @@ func (v *Visor) DialPing(conf PingConfig) error {
 	var err error
 	var conn net.Conn
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Caller-supplied setup timeout — falls back to the legacy 30s
+	// ceiling when conf.SetupTimeout is zero. mux-bw passes its
+	// per-route setup-timeout flag here so multi-hop routes (4+
+	// intermediates) can complete the saveRouteGroupRules retries
+	// that routinely exceed 30s.
+	setupTimeout := 30 * time.Second
+	if conf.SetupTimeout > 0 {
+		setupTimeout = conf.SetupTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 	defer cancel()
 	var r = netutil.NewRetrier(v.log, 2*time.Second, netutil.DefaultMaxBackoff, 1, 2)
 	err = r.Do(ctx, func() error {

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -228,15 +228,16 @@ func (a *visorPingAdapter) DialPing(conf rpcgrpc.PingConf) error {
 		})
 	}
 	return a.v.DialPing(PingConfig{
-		PK:          conf.PK,
-		Tries:       conf.Tries,
-		PcktSize:    conf.PcktSize,
-		LocalRoute:  conf.LocalRoute,
-		TransportID: conf.TransportID,
-		ForwardHops: forwardHops,
-		ReverseHops: reverseHops,
-		RouteIndex:  conf.RouteIndex,
-		MinHops:     conf.MinHops,
+		PK:           conf.PK,
+		Tries:        conf.Tries,
+		PcktSize:     conf.PcktSize,
+		LocalRoute:   conf.LocalRoute,
+		TransportID:  conf.TransportID,
+		ForwardHops:  forwardHops,
+		ReverseHops:  reverseHops,
+		RouteIndex:   conf.RouteIndex,
+		MinHops:      conf.MinHops,
+		SetupTimeout: time.Duration(conf.SetupTimeoutNs),
 	})
 }
 

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -147,6 +147,10 @@ type PingConf struct {
 	// Mirrors visor.PingConfig.MinHops; adapter passes it through.
 	// 0 = inherit visor-global routing.min_hops.
 	MinHops int
+	// SetupTimeoutNs is the dial-setup ceiling in nanoseconds.
+	// Mirrors visor.PingConfig.SetupTimeout; adapter converts to
+	// time.Duration. 0 falls back to DialPing's 30s default.
+	SetupTimeoutNs int64
 }
 
 // PingServer implements the gRPC PingService

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -345,12 +345,13 @@ func (s *PingServer) muxBwSetupRoute(
 	emit func(isMuxBandwidthEvent_Payload),
 ) {
 	conf := PingConf{
-		PK:         cfg.TargetPK,
-		Tries:      1,
-		PcktSize:   cfg.PacketSizeKb,
-		LocalRoute: cfg.LocalRoute,
-		RouteIndex: rs.index,
-		MinHops:    cfg.MinHops, // enforce --min-hops at the router-finder layer
+		PK:             cfg.TargetPK,
+		Tries:          1,
+		PcktSize:       cfg.PacketSizeKb,
+		LocalRoute:     cfg.LocalRoute,
+		RouteIndex:     rs.index,
+		MinHops:        cfg.MinHops, // enforce --min-hops at the router-finder layer
+		SetupTimeoutNs: cfg.SetupTimeout.Nanoseconds(),
 	}
 	setupCtx, cancel := context.WithTimeout(ctx, cfg.SetupTimeout)
 	defer cancel()


### PR DESCRIPTION
## Summary

\`DialPing\` had a hardcoded \`context.WithTimeout(..., 30*time.Second)\` that silently capped any caller-supplied setup window. mux-bw's \`--setup-timeout\` flag and the per-route setupCtx wrapped around it were both masked.

Multi-hop route setup through 4+ intermediates routinely needs 30-120s (route-finder query + setup-node round trips + saveRouteGroupRules retries on stale TPD data). Above the 30s ceiling these routes fail with \"context deadline exceeded\" before ever reaching the pump phase — so \`h=4\` and \`h=5\` measurements for the operator's latency/jitter/queueing-delay sweep simply can't run.

## Fix

| File | Change |
|---|---|
| \`pkg/visor/api.go\` | + \`PingConfig.SetupTimeout time.Duration\` (0 = inherit 30s legacy default) |
| \`pkg/visor/api_ping.go\` | DialPing ctx timeout derived from \`conf.SetupTimeout\` |
| \`pkg/visor/rpcgrpc/server.go\` | + \`PingConf.SetupTimeoutNs int64\` (cross-pkg mirror) |
| \`pkg/visor/init_apps.go\` | adapter converts \`SetupTimeoutNs\` → \`time.Duration\` |
| \`pkg/visor/rpcgrpc/server_mux_bandwidth.go\` | muxBwSetupRoute populates the new field from \`cfg.SetupTimeout\` |

## Effect

\`cli visor ping mux-bw --setup-timeout 90s --min-hops 4 <peer>\` now actually waits 90s for route setup. h=4/h=5 measurements feasible against peers where the route-finder finds longer paths than the local visor's BFS reaches (the global RF service has 4/5/6-hop paths — empirically verified via \`cli route find -n 4/5/6\`).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Live: \`mux-bw --min-hops 4 --setup-timeout 90s <peer>\` now succeeds where prior 30s ceiling failed