### PR TITLE
fix(router): calculateLocalRoutes must honor MinHops > 2

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -773,6 +773,17 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		}
 	}
 
+	// Skip the 2-hop fallback when the caller demands >2 hops.
+	// calculateLocalRoutes only knows how to build 1-hop and 2-hop
+	// paths; returning a 2-hop path here when min-hops>=3 was asked
+	// would silently violate the constraint (this was task #123 —
+	// the mux-bw --min-hops 3/4 runs that came back with hops_count=2
+	// despite the route-finder service having longer paths available).
+	if dialOpts != nil && dialOpts.MinHops > 2 {
+		return nil, nil, fmt.Errorf("local route calc cannot satisfy min_hops=%d (supports up to 2-hop only)",
+			dialOpts.MinHops)
+	}
+
 	// Try 2-hop routes through intermediate visors
 	for _, tp := range localTps {
 		intermediatePK := tp.remotePK


### PR DESCRIPTION
## Summary

The local route-calc fallback in \`calculateLocalRoutes\` only knows how to build 1-hop and 2-hop routes. When the global route-finder fails to produce a path (transient timeout, stale TPD, \`ErrNoSuitableTransport\`), \`DialRoutes\` falls back to \`calculateLocalRoutes\` — which would silently return a 2-hop route even when the caller demanded \`min-hops >= 3\`.

## Empirical repro (against my visor)

| call | requested | actual hops_count |
|---|---|---|
| \`mux-bw --min-hops 3\` | ≥3 | **2** (wrong) |
| \`mux-bw --min-hops 4\` | ≥4 | **2** (wrong) |
| \`mux-bw --min-hops 5\` | ≥5 | 5 (correct — RF query succeeded, no fallback) |

\`cli route find <peer> -n 3 -x 3\` and \`-n 4 -x 4\` both return proper 3-hop and 4-hop paths, confirming the route-finder service itself honors min-hops. The bug is purely in the local fallback.

## Fix

\`\`\`go
// Skip the 2-hop fallback when the caller demands >2 hops.
// calculateLocalRoutes only knows how to build 1-hop and 2-hop
// paths; returning a 2-hop path when min-hops>=3 was asked
// would silently violate the constraint.
if dialOpts != nil && dialOpts.MinHops > 2 {
    return nil, nil, fmt.Errorf(\"local route calc cannot satisfy min_hops=%d (supports up to 2-hop only)\",
        dialOpts.MinHops)
}
\`\`\`

The router's retry loop above will then either re-attempt the route-finder query or return the error to the caller — both correct behaviors when the local cache genuinely can't satisfy the constraint.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Live: \`mux-bw --min-hops 3 <peer>\` reports hops_count >= 3 OR fails with a clean error message