### PR TITLE
fix(visor): PingOnceWithEcho adapter must forward RouteIndex + MinHops

### DIFF
--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -319,6 +319,8 @@ func (a *visorPingAdapter) PingOnceWithEcho(conf rpcgrpc.PingConf, echoFull bool
 		Tries:      conf.Tries,
 		PcktSize:   conf.PcktSize,
 		LocalRoute: conf.LocalRoute,
+		RouteIndex: conf.RouteIndex,
+		MinHops:    conf.MinHops,
 	}, echoFull)
 }
 

--- a/pkg/visor/ping_adapter_route_index_test.go
+++ b/pkg/visor/ping_adapter_route_index_test.go
@@ -1,0 +1,58 @@
+// Package visor pkg/visor/ping_adapter_route_index_test.go
+//
+// Pins the visorPingAdapter contract that conf.RouteIndex (and
+// conf.MinHops) cross the rpcgrpc.PingConf → visor.PingConfig
+// boundary intact. Pre-fix, the PingOnceWithEcho adapter silently
+// dropped both fields — every PingOnceWithEcho call from the
+// mux-bw pump goroutine looked up the ping connection at
+// PingRouteRef{PK, Index: 0} regardless of the goroutine's own
+// RouteIndex, so aux routes (Index >= 1) registered via DialPing
+// were unreachable. The observable failure was "no ping connection
+// for <pk>#0, call DialPing first" emitted via MuxRouteFailure
+// even when the route was successfully established at the matching
+// index — surfaced by #2756 (Beta's pump-phase failure event),
+// which is how this bug became diagnosable from the wire.
+//
+// Strategy: with no ping connection registered, PingOnceWithEcho
+// returns an error whose message contains "%s#%d" with conf.PK
+// and conf.RouteIndex. If the adapter forwards RouteIndex
+// correctly, the error mentions the requested index (e.g. "#3");
+// if it doesn't, the error mentions "#0". So the error-message
+// content IS the regression signal — no fixture / mock needed.
+
+package visor
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+)
+
+func TestPingAdapter_PingOnceWithEcho_ForwardsRouteIndex(t *testing.T) {
+	v := &Visor{ping: pingState{conns: make(map[PingRouteRef]ping), mu: &sync.Mutex{}}}
+	a := &visorPingAdapter{v: v}
+
+	// No ping connection registered for the requested (PK, Index).
+	// The adapter should pass RouteIndex through, so the resulting
+	// error message names the same index we asked for.
+	for _, idx := range []int{0, 1, 2, 7} {
+		_, _, _, err := a.PingOnceWithEcho(rpcgrpc.PingConf{
+			RouteIndex: idx,
+			PcktSize:   1,
+		}, false)
+		if err == nil {
+			t.Fatalf("idx=%d: expected error for unregistered conn, got nil", idx)
+		}
+		// Error format: "no ping connection for %s#%d, call DialPing first"
+		// We assert the index portion verbatim so a regression that drops
+		// RouteIndex to zero surfaces immediately.
+		want := "#" + strconv.Itoa(idx) + ","
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("idx=%d: error %q does not contain %q — adapter dropped RouteIndex?",
+				idx, err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Beta's MuxRouteFailure event (#2756) surfaced the smoking gun on `mux-bw --routes N --min-hops 2`: one route would establish at index 2 but its pump loop immediately failed with `no ping connection for <pk>#0, call DialPing first`. The lookup `PingRouteRef.Index` was 0 even though the pump goroutine carried `RouteIndex = 2`.

## Root cause

The `rpcgrpc.PingConf → visor.PingConfig` adapter in `pkg/visor/init_apps.go`'s `visorPingAdapter` forwards `RouteIndex` for `DialPing` (line 238) and `PingOnce` (line 249), but `PingOnceWithEcho` was missing it — same for `MinHops`. Every aux-route pump call therefore looked up `PingRouteRef{PK, Index: 0}` regardless of the goroutine's own index, finding nothing because `DialPing` had registered the conn at the matching aux index.

## Fix

Three-line adapter parity fix:

```go
func (a *visorPingAdapter) PingOnceWithEcho(conf rpcgrpc.PingConf, echoFull bool) ... {
    return a.v.PingOnceWithEcho(PingConfig{
        PK:         conf.PK,
        Tries:      conf.Tries,
        PcktSize:   conf.PcktSize,
        LocalRoute: conf.LocalRoute,
+       RouteIndex: conf.RouteIndex,
+       MinHops:    conf.MinHops,
    }, echoFull)
}
```

The DMSG adapter (`DmsgPingOnceWithEcho`) is intentionally untouched — `v.dmsgPing.conns` is keyed by PK alone, not `PingRouteRef`, so no DMSG path consumes `RouteIndex`.

## Test

`TestPingAdapter_PingOnceWithEcho_ForwardsRouteIndex` pins the adapter contract by exploiting the error message format. With no ping connection registered, `v.PingOnceWithEcho` returns:

```
no ping connection for %s#%d, call DialPing first
```

where `%d` is `conf.RouteIndex` *post-adapter*. The test calls the adapter with `RouteIndex` in `{0, 1, 2, 7}` and asserts the error string contains the matching `#<idx>,`. A regression that drops `RouteIndex` (or stuffs in `MinHops` by accident) surfaces in the error string directly — no mock VisorAPI, no fixtures.

## Empirical chain

This is the third bug in the `mux-bw --min-hops` measurement path to surface via the wire-event observability landed in #2746 → #2749 → #2751 → #2752 → #2750 → #2753 → #2754 → #2756. The pattern holds: each event-surface fix lights up the next bug downstream. The operator's "mux > direct" hypothesis test should finally be measurable end-to-end once #2756's `route_failure` event + this PR auto-deploy.

## Test plan
- [x] `go test ./pkg/visor/... -count=1 -short` — clean.
- [x] `go vet ./pkg/visor/...` — clean.
- [x] `gofmt -l pkg/visor/init_apps.go pkg/visor/ping_adapter_route_index_test.go` — clean.
- [ ] CI lanes (linux, darwin, windows, nix).
- [ ] Post-merge: re-run `mux-bw --routes 4 --min-hops 2` and verify aux routes pump bytes instead of failing with `#0` lookup error.