### PR TITLE
fix(skynet/client): accept loop with per-conn remote dial + half-close drain

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -115,8 +115,8 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		return err
 	}
 
-	appCl.Log().Infof("Connecting to %s:%d, forwarding to localhost:%d",
-		remotePK.Hex(), remotePort, localPort)
+	appCl.Log().Infof("Setting up accept loop on localhost:%d → %s:%d",
+		localPort, remotePK.Hex(), remotePort)
 
 	// Set routing port if specified
 	if appPort != 0 {
@@ -125,9 +125,14 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 
 	setAppStatus(appCl, appserver.AppDetailedStatusStarting)
 
-	// Connect to remote skynet server
-	// Use SkyForwardingServerPort (47) which is the built-in visor service
-	// This avoids noise handshake race conditions that occur with app-layer connections
+	// Build a dial factory the client calls per-accept. The factory
+	// captures appCl + remote endpoint so each local connection gets
+	// its own independent remote tunnel — necessary because the
+	// skynet wire is raw bytes with no per-connection framing, so
+	// concurrent (or even tightly-sequenced) local conns sharing a
+	// single remoteConn would interleave their payloads. Using
+	// SkyForwardingServerPort (47, built-in visor service) avoids
+	// the noise-handshake race condition that hits app-layer dials.
 	connApp := appnet.Addr{
 		Net:    netType,
 		PubKey: remotePK,
@@ -135,37 +140,25 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	}
 
 	if routes > 1 {
-		appCl.Log().Infof("Dialing %s on port %d with %d parallel mux routes",
+		appCl.Log().Infof("Per-accept dial shape: %s on port %d with %d parallel mux routes",
 			remotePK.Hex(), skyenv.SkyForwardingServerPort, routes)
 	} else {
-		appCl.Log().Infof("Dialing %s on port %d", remotePK.Hex(), skyenv.SkyForwardingServerPort)
+		appCl.Log().Infof("Per-accept dial shape: %s on port %d",
+			remotePK.Hex(), skyenv.SkyForwardingServerPort)
 	}
 
-	var (
-		conn net.Conn
-		err  error
-	)
-	if routes > 1 {
-		conn, err = appCl.DialWithOptions(connApp, routes)
-	} else {
-		conn, err = appCl.Dial(connApp)
-	}
-	if err != nil {
-		setAppError(appCl, fmt.Errorf("failed to connect to server: %w", err))
-		return fmt.Errorf("failed to connect to server: %w", err)
+	dialRemote := func() (net.Conn, error) {
+		if routes > 1 {
+			return appCl.DialWithOptions(connApp, routes)
+		}
+		return appCl.Dial(connApp)
 	}
 
-	// Create client
-	client := skynet.NewClient(appCl.Log(), remotePK, remotePort, localPort)
+	// Create client with the dial factory; Serve binds the local
+	// listener and runs the accept loop.
+	client := skynet.NewClient(appCl.Log(), remotePK, remotePort, localPort, dialRemote)
 
-	// Connect (send request to server)
-	if err := client.Connect(conn); err != nil {
-		setAppError(appCl, err)
-		appCl.Log().WithError(err).Error("Failed to connect to remote server")
-		return err
-	}
-
-	appCl.Log().Info("Connected to remote skynet server")
+	appCl.Log().Info("Skynet client ready — waiting for local connections")
 	setAppStatus(appCl, appserver.AppDetailedStatusRunning)
 
 	// Handle shutdown

--- a/pkg/skynet/client.go
+++ b/pkg/skynet/client.go
@@ -14,13 +14,35 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-// Client connects to a remote skynet server and forwards traffic to a local port
+// DialRemoteFunc returns a fresh authenticated net.Conn to the remote
+// skynet server. The Client calls it per-accept so each local TCP
+// connection gets its own independent remote tunnel — necessary
+// because the skynet wire is a raw byte stream with no per-connection
+// framing, so concurrent or even tightly-sequenced local conns
+// sharing a single remoteConn would interleave bytes and corrupt
+// payloads.
+//
+// The handshake (ready-signal read + port-request write + reply
+// read) lives inside Client.Connect, which the caller invokes
+// against the returned conn before forwarding. Implementations
+// typically wrap the host visor's appCl.Dial to the
+// SkyForwardingServerPort.
+type DialRemoteFunc func() (net.Conn, error)
+
+// Client connects to a remote skynet server and forwards traffic to a local port.
+// Pre-2026-05-21 this was single-shot: one Connect + one Serve = one
+// local accept + forward + exit. That tore down the cli skynet
+// start app after every curl, leaked the local listener for ~minutes,
+// and made the port-forward operationally useless for any
+// multi-connection workload. The current shape accepts in a loop and
+// dials a fresh remote per accept so sequential local clients each
+// get a clean independent forward.
 type Client struct {
 	log         logrus.FieldLogger
 	remotePK    cipher.PubKey
 	remotePort  int
 	localPort   int
-	remoteConn  net.Conn
+	dialRemote  DialRemoteFunc
 	localLis    net.Listener
 	mu          sync.RWMutex
 	closeCh     chan struct{}
@@ -28,23 +50,25 @@ type Client struct {
 	activeConns sync.WaitGroup
 }
 
-// NewClient creates a new skynet client
-func NewClient(log logrus.FieldLogger, remotePK cipher.PubKey, remotePort, localPort int) *Client {
+// NewClient creates a new skynet client. dialRemote is called once
+// per accepted local connection to produce a fresh remote conn.
+func NewClient(log logrus.FieldLogger, remotePK cipher.PubKey, remotePort, localPort int, dialRemote DialRemoteFunc) *Client {
 	return &Client{
 		log:        log,
 		remotePK:   remotePK,
 		remotePort: remotePort,
 		localPort:  localPort,
+		dialRemote: dialRemote,
 		closeCh:    make(chan struct{}),
 	}
 }
 
-// Connect establishes connection to remote skynet server
+// Connect runs the skynet handshake against a freshly-dialed remote
+// conn: read ready-signal, send port-request, read reply. Returns
+// nil on success — the conn is then ready for raw byte forwarding.
+// Errors close the conn and propagate; caller should drop the
+// local conn that triggered the dial.
 func (c *Client) Connect(remoteConn net.Conn) error {
-	c.mu.Lock()
-	c.remoteConn = remoteConn
-	c.mu.Unlock()
-
 	// Wait for ready signal from server to ensure noise handshake is complete
 	readyBuf := make([]byte, 1)
 	if _, err := remoteConn.Read(readyBuf); err != nil {
@@ -82,11 +106,14 @@ func (c *Client) Connect(remoteConn net.Conn) error {
 		return fmt.Errorf("server error: %s", *reply.Error)
 	}
 
-	c.log.Info("Connected to remote skynet server")
+	c.log.Debug("Skynet handshake complete on fresh remote conn")
 	return nil
 }
 
-// Serve starts accepting local connections and forwarding to remote
+// Serve binds the local listener and runs the accept loop. Each
+// accepted local conn gets its own goroutine + fresh remote dial.
+// Returns when the listener closes (Client.Close) or Accept errors
+// non-recoverably.
 func (c *Client) Serve() error {
 	addr := fmt.Sprintf("127.0.0.1:%d", c.localPort)
 	lis, err := net.Listen("tcp", addr)
@@ -98,53 +125,140 @@ func (c *Client) Serve() error {
 	c.localLis = lis
 	c.mu.Unlock()
 
-	c.log.Infof("Listening on %s, forwarding to remote port %d", addr, c.remotePort)
+	c.log.Infof("Listening on %s, forwarding to remote port %d (accept loop)", addr, c.remotePort)
 
-	return c.forwardRawTCP()
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			select {
+			case <-c.closeCh:
+				return nil
+			default:
+				if errors.Is(err, net.ErrClosed) {
+					return nil
+				}
+				c.log.WithError(err).Error("Accept failed")
+				return err
+			}
+		}
+
+		c.activeConns.Add(1)
+		go func(localConn net.Conn) {
+			defer c.activeConns.Done()
+			c.handleLocalConn(localConn)
+		}(conn)
+	}
 }
 
-func (c *Client) forwardRawTCP() error {
-	c.mu.RLock()
-	remoteConn := c.remoteConn
-	localLis := c.localLis
-	c.mu.RUnlock()
+// handleLocalConn services one accepted local TCP connection: dial a
+// fresh remote conn, do the skynet handshake, forward bytes both
+// ways until either side closes, then tear down both ends.
+//
+// Per-conn remote dial is the right model for this transport — the
+// skynet wire is raw bytes with no per-conn framing, so re-using a
+// single remoteConn across multiple local conns would interleave
+// their payloads.
+func (c *Client) handleLocalConn(localConn net.Conn) {
+	defer func() { _ = localConn.Close() }() //nolint:errcheck
 
-	conn, err := localLis.Accept()
+	remoteConn, err := c.dialRemote()
 	if err != nil {
-		return err
+		c.log.WithError(err).Warn("handleLocalConn: dial remote failed; dropping local conn")
+		return
 	}
-	defer func() { _ = conn.Close() }() //nolint:errcheck
+	defer func() { _ = remoteConn.Close() }() //nolint:errcheck
 
-	done := make(chan struct{}, 2)
+	if err := c.Connect(remoteConn); err != nil {
+		c.log.WithError(err).Warn("handleLocalConn: skynet handshake failed; dropping conn")
+		return
+	}
+
+	c.forwardOnce(localConn, remoteConn)
+}
+
+// forwardOnce wires bytes both ways between one local conn and one
+// remote conn. Half-closes the destination on the side whose Copy
+// finishes first so buffered bytes drain to the peer before the
+// full Close. Pattern mirrors pkg/visor/init_services.go's #2735
+// fix: io.Copy returns when bytes are accepted by the send buffer,
+// not when delivered, so an immediate Close on the OTHER conn drops
+// the in-flight tail. Half-close lets the kernel send buffer drain
+// before the conn fully closes.
+func (c *Client) forwardOnce(localConn, remoteConn net.Conn) {
+	type direction int
+	const (
+		dirLocalToRemote direction = iota
+		dirRemoteToLocal
+	)
+	type doneEvent struct{ d direction }
+
+	done := make(chan doneEvent, 2)
 
 	// local -> remote
 	go func() {
-		_, err := io.Copy(remoteConn, conn)
+		_, err := io.Copy(remoteConn, localConn)
 		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
 			c.log.WithError(err).Debug("local->remote copy ended")
 		}
-		done <- struct{}{}
+		done <- doneEvent{d: dirLocalToRemote}
 	}()
 
 	// remote -> local
 	go func() {
-		_, err := io.Copy(conn, remoteConn)
+		_, err := io.Copy(localConn, remoteConn)
 		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
 			c.log.WithError(err).Debug("remote->local copy ended")
 		}
-		done <- struct{}{}
+		done <- doneEvent{d: dirRemoteToLocal}
 	}()
 
+	// First-done — half-close the OTHER side's write so its send
+	// buffer drains to the peer before we tear down.
+	var first doneEvent
+	select {
+	case first = <-done:
+	case <-c.closeCh:
+		return
+	}
+
+	switch first.d {
+	case dirLocalToRemote:
+		halfCloseWrite(c.log, remoteConn, "remote")
+	case dirRemoteToLocal:
+		halfCloseWrite(c.log, localConn, "local")
+	}
+
+	// Wait for the second direction to drain (bounded by the OS-level
+	// keep-alive / TCP timeout — there's no per-forward drain ticker
+	// here because in practice both copies terminate quickly once one
+	// side half-closes).
 	select {
 	case <-done:
 	case <-c.closeCh:
 	}
 
 	c.log.Debug("Raw TCP forwarding completed")
-	return nil
 }
 
-// Close stops the client
+// halfCloseWrite attempts CloseWrite (TCP half-close) on c so
+// buffered bytes drain to the peer before the conn is fully closed
+// by the surrounding defer. Falls back to full Close when the
+// underlying conn doesn't implement CloseWriter — preserves
+// pre-#2735-style behavior in that path.
+func halfCloseWrite(log logrus.FieldLogger, c net.Conn, side string) {
+	type closeWriter interface{ CloseWrite() error }
+	if cw, ok := c.(closeWriter); ok {
+		if err := cw.CloseWrite(); err != nil {
+			log.WithError(err).WithField("side", side).Debug("CloseWrite failed; falling back to full Close")
+			_ = c.Close() //nolint:errcheck
+		}
+		return
+	}
+	_ = c.Close() //nolint:errcheck
+}
+
+// Close stops the client. Subsequent Accept calls return ErrClosed.
+// Active per-conn forwards drain via the closeCh in forwardOnce.
 func (c *Client) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
@@ -153,11 +267,6 @@ func (c *Client) Close() error {
 		c.mu.Lock()
 		if c.localLis != nil {
 			if cErr := c.localLis.Close(); cErr != nil {
-				err = cErr
-			}
-		}
-		if c.remoteConn != nil {
-			if cErr := c.remoteConn.Close(); cErr != nil && err == nil {
 				err = cErr
 			}
 		}


### PR DESCRIPTION
## Summary
\`pkg/skynet/client.go\`'s forwardRawTCP was **single-shot**: one Accept on the local listener, one io.Copy pair, return on the first \`done\`. The result was that \`cli skynet start\` died after serving a single local connection. Observed live 2026-05-21 during the mux-bw → skynet-port-forwarding pivot:

- \`cli skynet start ... ; curl http://localhost:8091/file\` → curl gets HTTP 200 + **88.8% of body** (931,840 of 1,048,576 bytes), then connection closes mid-stream, app exits, listener leaks for minutes
- Subsequent \`cli skynet start\` fails with \`bind: address already in use\`
- \`cli skynet status\` filters non-running clients so the desync is invisible; \`cli visor app ls\` is the only place \`DetailedStatus=Stopped/Stopped\` is observable

## Root cause
The forwardRawTCP-on-close pattern is the same class as the \`init_services.go\` #2735 fix: \`io.Copy\` returns when bytes are accepted by the destination's send buffer, not delivered to the peer; an immediate \`Close\` on the other side drops the in-flight tail. The single-Accept design also means the app exits after the first local connection regardless.

## Fix
1. **Accept loop**. \`Serve\` binds the listener, then loops on \`Accept\`. Each accepted local conn spawns its own goroutine.
2. **Per-accept fresh remote dial**. \`NewClient\` now takes a \`DialRemoteFunc\` factory; the Connect handshake (ready-signal + port request + reply) moves to per-accept against a freshly-dialed \`remoteConn\`. Necessary because the skynet wire is raw bytes with no per-conn framing — sharing one \`remoteConn\` across concurrent (or even tightly-sequenced) local conns would interleave payloads.
3. **Half-close drain in \`forwardOnce\`**. When the first \`io.Copy\` returns, \`CloseWrite\` the other side's destination so its send buffer drains before the surrounding defer fully closes the conn. Mirrors the #2735 fix shape; same reasoning. Falls back to full Close for conn types without \`CloseWriter\`.

Caller update in \`cmd/apps/skynet-client/commands/skynet-client.go\`: builds a closure capturing \`appCl\` + \`connApp\` and passes it as \`DialRemoteFunc\`. Upfront Dial + Connect removed — both move per-accept.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./pkg/skynet/... ./cmd/apps/skynet-client/...\`
- [x] \`make format\` clean
- [ ] e2e validation: live \`cli skynet start\` + multiple sequential curls against Gamma's fileserver post-deploy

## Operator impact
- \`cli skynet start\` stays running across multiple local connections
- Listener doesn't leak between connections
- Tail bytes of long downloads no longer truncate at random offsets
- Persistent port-forward + reverse-proxy fixtures between visors finally become repeatable

Refs the 2026-05-21 pivot from synthetic mux-bw measurements to real-world skynet port forwarding.