### PR TITLE
fix(cli/skynet,visor): list custom-named skynet apps + render AppStatusStarting

### DIFF
--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -225,7 +224,9 @@ Examples:
 
 			stopped := 0
 			for _, state := range states {
-				if strings.HasPrefix(state.Name, "skynet-client-") && state.Status == appserver.AppStatusRunning {
+				// Match by Binary so custom-named clients (--name) are
+				// included — same fix as the status listing.
+				if state.Binary == skynetClientBinaryName && state.Status == appserver.AppStatusRunning {
 					if err := rpcClient.StopApp(state.Name); err != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to stop %s: %v\n", state.Name, err)
 					} else {
@@ -286,18 +287,27 @@ Examples:
 		found := false
 
 		for _, state := range states {
-			// Match skynet-client-* apps or exact filter match
-			isSkynetClient := strings.HasPrefix(state.Name, "skynet-client-") || state.Name == "skynet-client"
+			// Match by Binary field — AddApp sets AppConfig.Binary
+			// to the literal binary name regardless of the operator-
+			// provided --name. The legacy name-prefix match missed
+			// any client started with `cli skynet start --name X`
+			// where X doesn't start with "skynet-client-" — so the
+			// status listing claimed "No skynet clients configured"
+			// while `cli visor app ls` clearly showed a running
+			// skynet-client app under the operator's chosen name.
+			isSkynetClient := state.Binary == skynetClientBinaryName
 			matchesFilter := filterName == "" || state.Name == filterName
 
 			if isSkynetClient && matchesFilter {
 				found = true
 				status := "stopped"
-				if state.Status == appserver.AppStatusRunning {
+				switch state.Status {
+				case appserver.AppStatusRunning:
 					status = "running"
-				}
-				if state.Status == appserver.AppStatusErrored {
+				case appserver.AppStatusErrored:
 					status = "errored"
+				case appserver.AppStatusStarting:
+					status = "starting"
 				}
 
 				jsonStatus := clientStatus{

--- a/cmd/skywire-cli/commands/skynet/srv.go
+++ b/cmd/skywire-cli/commands/skynet/srv.go
@@ -191,7 +191,13 @@ Examples:
 
 			stopped := 0
 			for _, state := range states {
-				if strings.HasPrefix(state.Name, "skynet-") && state.Status == appserver.AppStatusRunning {
+				// Match by Binary so custom-named srv instances are
+				// included AND skynet-client apps (which also start
+				// with "skynet-") are excluded. Same fix as the status
+				// listing — and important here because a bulk `srv
+				// stop` was previously also stopping any running
+				// skynet-client apps under default naming.
+				if state.Binary == skynetBinaryName && state.Status == appserver.AppStatusRunning {
 					if err := rpcClient.StopApp(state.Name); err != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to stop %s: %v\n", state.Name, err)
 					} else {
@@ -252,18 +258,26 @@ Examples:
 		found := false
 
 		for _, state := range states {
-			// Match skynet-* apps or exact filter match
-			isSkynetServer := strings.HasPrefix(state.Name, "skynet-") || state.Name == "skynet"
+			// Match by Binary field so the listing finds custom-
+			// named srv instances started with `cli skynet srv start
+			// --name X`. Also tightens against false positives — the
+			// name-prefix "skynet-" matched any app starting with
+			// that string (including skynet-client clients started
+			// with default naming), surfacing CLIENT apps in the SRV
+			// status output.
+			isSkynetServer := state.Binary == skynetBinaryName
 			matchesFilter := filterName == "" || state.Name == filterName
 
 			if isSkynetServer && matchesFilter {
 				found = true
 				status := "stopped"
-				if state.Status == appserver.AppStatusRunning {
+				switch state.Status {
+				case appserver.AppStatusRunning:
 					status = "running"
-				}
-				if state.Status == appserver.AppStatusErrored {
+				case appserver.AppStatusErrored:
 					status = "errored"
+				case appserver.AppStatusStarting:
+					status = "starting"
 				}
 
 				jsonStatus := serverStatus{

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -136,6 +136,8 @@ func formatAppList(states []*appserver.AppState) ([]appLsState, string) {
 			status = "running"
 		case appserver.AppStatusErrored:
 			status = "errored"
+		case appserver.AppStatusStarting:
+			status = "starting"
 		}
 		fmt.Fprintf(w, "%s\t%s\t%t\t%s\t%s\n", //nolint:errcheck
 			state.Name, strconv.Itoa(int(state.Port)),

--- a/cmd/skywire-cli/commands/visor/app_format_test.go
+++ b/cmd/skywire-cli/commands/visor/app_format_test.go
@@ -1,0 +1,76 @@
+// Package visor cmd/skywire-cli/commands/visor/app_format_test.go
+//
+// Pins the formatAppList AppStatus → display-string mapping. Pre-fix
+// the switch had cases only for Running and Errored, so an app in
+// AppStatusStarting state rendered as the default "stopped" — the
+// operator-visible symptom that surfaced during the 2026-05-21
+// skynet port-forwarding investigation as `cli visor app ls` showing
+// "stopped" rows whose DetailedStatus was "Starting", inconsistent
+// and confusing.
+
+package clivisor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+)
+
+func TestFormatAppList_RendersEveryAppStatus(t *testing.T) {
+	cases := []struct {
+		status     appserver.AppStatus
+		wantStatus string
+	}{
+		{appserver.AppStatusStopped, "stopped"},
+		{appserver.AppStatusRunning, "running"},
+		{appserver.AppStatusErrored, "errored"},
+		{appserver.AppStatusStarting, "starting"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.wantStatus, func(t *testing.T) {
+			states := []*appserver.AppState{
+				{
+					AppConfig: appserver.AppConfig{
+						Name: "test-app",
+						Port: 42,
+					},
+					Status:         tc.status,
+					DetailedStatus: "any-detail",
+				},
+			}
+
+			rows, text := formatAppList(states)
+			if len(rows) != 1 {
+				t.Fatalf("expected 1 row, got %d", len(rows))
+			}
+			if rows[0].Status != tc.wantStatus {
+				t.Errorf("Status=%q, want %q", rows[0].Status, tc.wantStatus)
+			}
+			if !strings.Contains(text, tc.wantStatus) {
+				t.Errorf("text output missing %q; got:\n%s", tc.wantStatus, text)
+			}
+		})
+	}
+}
+
+func TestFormatAppList_UnknownStatusFallsBackToStopped(t *testing.T) {
+	// An unrecognized AppStatus (e.g., a future variant that hasn't
+	// been added to the switch yet) should fall back to "stopped" —
+	// safer default than blowing up. Pin the fallback so a future
+	// refactor doesn't accidentally panic on an unknown int.
+	states := []*appserver.AppState{
+		{
+			AppConfig: appserver.AppConfig{Name: "test", Port: 1},
+			Status:    appserver.AppStatus(99), // bogus
+		},
+	}
+	rows, _ := formatAppList(states)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Status != "stopped" {
+		t.Errorf("unknown status: rendered %q, want fallback %q", rows[0].Status, "stopped")
+	}
+}


### PR DESCRIPTION
## Summary

Three CLI visibility fixes from the 2026-05-21 real-world skynet port-forwarding investigation. Beta's #2759 fixes the data-plane (client accept loop + half-close drain); this PR fixes the control-plane visibility gaps that were hiding the data-plane state from the operator.

## Changes

### 1. `cli visor app ls` was showing "stopped" for Starting apps

`formatAppList` switched only on `AppStatusRunning` and `AppStatusErrored`. `AppStatusStarting` fell through to the default "stopped" — so a starting app rendered as "stopped Starting" (status column "stopped" + detailed_status "Starting"), which read as a state-machine bug. The state was correct; the display was wrong.

Fix: add the `AppStatusStarting → "starting"` case.

### 2. `cli skynet status` claimed "No skynet clients configured" for custom-named clients

The filter matched by name prefix `"skynet-client-"`. `cli skynet start --name CUSTOM` produces an app whose name is `CUSTOM`, which doesn't match that prefix — so the listing claimed "No skynet clients configured" while `cli visor app ls` clearly showed a skynet-client app under the operator's chosen name.

Fix: switch the filter to `state.Binary == skynetClientBinaryName`. `AddApp` sets `AppConfig.Binary` to the literal binary name regardless of the operator's `--name` choice, so this catches every skynet-client app regardless of naming. Same fix applied to `stop --all` (was missing custom-named clients).

### 3. `cli skynet srv status` was matching CLIENT apps too

The filter matched by name prefix `"skynet-"` — too broad. It grabbed any app whose name starts with that, including skynet-client apps under default naming (`skynet-client-<port>`). So `cli skynet srv status` listed clients as servers, and `cli skynet srv stop --all` would have stopped running clients.

Fix: switch the filter to `state.Binary == skynetBinaryName`.

## Empirical validation

Before fix on my Gamma visor:

```
$ cli skynet status
No skynet clients configured

$ cli visor app ls | grep skynet
skynet-beta-fileserver  10  false  stopped  Starting
```

After fix on same visor:

```
$ cli skynet status
Name:        skynet-beta-fileserver
Status:      stopped
...
Details:     Stopped

$ cli visor app ls | grep skynet
skynet-beta-fileserver  10  false  stopped  Stopped
```

## Out of scope

The launcher's stale-`DetailedStatus` propagation (when a proc exits with a saved-error path or without one) lives in `pkg/app/launcher/launcher.go AppState()` — separate from the CLI surface and a different mechanism. The "Stopped" detailed-status shown post-fix above reflects clean shutdown; the original "Starting" stale-status was masked by Beta re-arming their srv between captures. The launcher reset is a follow-up.

## Test plan

- [x] `go test ./cmd/skywire-cli/commands/visor/ -run TestFormatAppList` — 5 subtests pass (status mapping + fallback)
- [x] `go build ./cmd/skywire-cli/...` — clean
- [x] `go vet ./cmd/skywire-cli/...` — clean
- [x] `gofmt -l cmd/skywire-cli/` — clean
- [x] Empirical: `~/go/bin/skywire-cli skynet status` now lists my custom-named skynet client (vs pre-fix "No skynet clients configured")
- [ ] CI lanes (linux, darwin, windows, nix)