### PR TITLE
fix(visor): write deadlines on PingOnceWithEcho + probe RouteIndex passthrough

### DIFF
--- a/pkg/visor/api_ping.go
+++ b/pkg/visor/api_ping.go
@@ -298,8 +298,15 @@ func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, byt
 
 	start := time.Now()
 
-	// Send size message
+	// Send size message. Write deadline matches the read deadline
+	// below — without it, a blocked TCP send buffer causes the
+	// call to hang indefinitely. That was the silent-pump-stall
+	// (task #127): mux-bw runs with 0 bytes pumped + 0
+	// MuxRouteFailure events emitted, because PingOnceWithEcho was
+	// stuck inside the Write rather than returning with an error.
+	conn.SetWriteDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck,gosec
 	if _, err = conn.Write(size); err != nil {
+		conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 		return 0, 0, 0, fmt.Errorf("write size: %w", err)
 	}
 	bytesSent += uint64(len(size))
@@ -309,14 +316,17 @@ func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, byt
 	buf := make([]byte, 32*1024)
 	n, err := conn.Read(buf)
 	if err != nil {
-		conn.SetReadDeadline(time.Time{}) //nolint:errcheck,gosec
+		conn.SetReadDeadline(time.Time{})  //nolint:errcheck,gosec
+		conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 		return bytesSent, bytesReceived, 0, fmt.Errorf("read ack: %w", err)
 	}
 	bytesReceived += uint64(n) //nolint:gosec
 
-	// Send ping data
+	// Send ping data. Same write-deadline rationale as above.
+	conn.SetWriteDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck,gosec
 	if _, err = conn.Write(ping); err != nil {
-		conn.SetReadDeadline(time.Time{}) //nolint:errcheck,gosec
+		conn.SetReadDeadline(time.Time{})  //nolint:errcheck,gosec
+		conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 		return bytesSent, bytesReceived, 0, fmt.Errorf("write ping: %w", err)
 	}
 	bytesSent += uint64(len(ping))
@@ -344,7 +354,8 @@ func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, byt
 		}
 		bytesReceived += uint64(n) //nolint:gosec
 	}
-	conn.SetReadDeadline(time.Time{}) //nolint:errcheck,gosec
+	conn.SetReadDeadline(time.Time{})  //nolint:errcheck,gosec
+	conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 
 	return bytesSent, bytesReceived, time.Since(start), nil
 }

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -199,19 +199,32 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 	idleProbeSamples := make([]int64, 0)
 	var idleProbesMu sync.Mutex
 	if cfg.IdleBaselineDuration > 0 && cfg.ProbeRTT {
-		idleCtx, idleCancel := context.WithTimeout(ctx, cfg.IdleBaselineDuration)
-		idleStart := time.Now()
-		idleWg := &sync.WaitGroup{}
-		idleWg.Add(1)
-		go func() {
-			defer idleWg.Done()
-			// Reuse the existing probe loop; it doesn't care whether
-			// a pump is concurrently running — passing only the idle
-			// samples slice means accumulator-direction is correct.
-			s.muxBwProbeLoop(idleCtx, &cfg, idleStart, &idleProbesMu, &idleProbeSamples, emit)
-		}()
-		idleWg.Wait()
-		idleCancel()
+		// Find the first established route for the idle probe.
+		// Same selection as the loaded-phase probe below — we want
+		// both phases riding the same route so the queueing-delay
+		// comparison is apples-to-apples.
+		idleProbeIndex := -1
+		for _, r := range routes {
+			if r.established.Load() {
+				idleProbeIndex = r.index
+				break
+			}
+		}
+		if idleProbeIndex >= 0 {
+			idleCtx, idleCancel := context.WithTimeout(ctx, cfg.IdleBaselineDuration)
+			idleStart := time.Now()
+			idleWg := &sync.WaitGroup{}
+			idleWg.Add(1)
+			go func() {
+				defer idleWg.Done()
+				// Reuse the existing probe loop; it doesn't care whether
+				// a pump is concurrently running — passing only the idle
+				// samples slice means accumulator-direction is correct.
+				s.muxBwProbeLoop(idleCtx, &cfg, idleProbeIndex, idleStart, &idleProbesMu, &idleProbeSamples, emit)
+			}()
+			idleWg.Wait()
+			idleCancel()
+		}
 	}
 
 	// Phase 2: pump bytes through each established route + run the
@@ -248,7 +261,12 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 
 	// Probe (optional).
 	if cfg.ProbeRTT {
-		// Find first established route for the probe.
+		// Find first established route for the probe — pass its
+		// RouteIndex into muxBwProbeLoop so the probe rides the
+		// same conn as the actual established route. Previously the
+		// probe hardcoded RouteIndex 0; when only a non-zero route
+		// established (e.g. Phase D where only R2 came up out of
+		// N=8) every probe failed with "no ping connection".
 		var probeTarget *muxBwRouteState
 		for _, r := range routes {
 			if r.established.Load() {
@@ -258,10 +276,10 @@ func (s *PingServer) StreamMuxBandwidth(req *MuxBandwidthRequest, stream PingSer
 		}
 		if probeTarget != nil {
 			pumpWg.Add(1)
-			go func() {
+			go func(idx int) {
 				defer pumpWg.Done()
-				s.muxBwProbeLoop(pumpCtx, &cfg, pumpStart, &probesMu, &probeSamples, emit)
-			}()
+				s.muxBwProbeLoop(pumpCtx, &cfg, idx, pumpStart, &probesMu, &probeSamples, emit)
+			}(probeTarget.index)
 		}
 	}
 
@@ -560,6 +578,7 @@ func (s *PingServer) muxBwSamplerLoop(
 func (s *PingServer) muxBwProbeLoop(
 	ctx context.Context,
 	cfg *muxBwCfg,
+	routeIndex int,
 	pumpStart time.Time,
 	probesMu *sync.Mutex,
 	probesOut *[]int64,
@@ -573,6 +592,13 @@ func (s *PingServer) muxBwProbeLoop(
 		Tries:      1,
 		PcktSize:   1, // 1 KB probe — small enough to not contribute meaningfully to load
 		LocalRoute: cfg.LocalRoute,
+		// Probe must use the same RouteIndex as the established
+		// route being measured. Hardcoding RouteIndex 0 made every
+		// probe fail with "no ping connection" whenever the first
+		// established route happened to be at a non-zero index
+		// (Phase D's 1-of-8 case where only R2 came up). Caller
+		// passes the route index it picked.
+		RouteIndex: routeIndex,
 	}
 	var sequence int64
 


### PR DESCRIPTION
## Summary

Two related fixes from the post-#2761 measurement work.

### 1. Silent pump stall — \`pkg/visor/api_ping.go\` (#127)

\`PingOnceWithEcho\` set read deadlines (30s) but NO write deadlines. If the underlying TCP send buffer filled (route under load, slow intermediate, etc.) \`conn.Write\` would block indefinitely. Empirical symptom: mux-bw runs with route_established success + 0 bytes pumped + 0 MuxRouteFailure events emitted, because the pump goroutine was stuck inside Write rather than returning with an error.

Phase 6 sweep against Gamma post-#2761: **10 of 12 cells showed exactly this** — idle baseline n=40-46 probes, loaded n=0-2, sent=recv=0B for the full pump duration.

Fix: \`SetWriteDeadline\` mirrors the \`SetReadDeadline\` calls already in place (30s). On deadline, Write returns \`net.ErrDeadlineExceeded\` and the pump's existing error-return path fires a \`MuxRouteFailure\` event (#2756) — making the stall observable instead of silent.

### 2. Probe hardcoded RouteIndex 0 — Gamma's find at 20:20Z (#130)

\`muxBwProbeLoop\`'s \`probeConf\` didn't set \`RouteIndex\`, so every probe used \`PingRouteRef{PK, Index: 0}\`. When N>1 and the first established route was at a non-zero index (Gamma's Phase D: only R2 of N=8 came up), every probe failed with \"no ping connection\". Same class as #2757's adapter bug but in the probe path.

Fix: \`muxBwProbeLoop\` takes a \`routeIndex\` parameter. Both callers (idle baseline + loaded probe) pick the first established route and pass its index. The idle phase needs the same selection logic as the loaded phase — previously it ran blindly, also hitting RouteIndex 0.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`golangci-lint run\` clean
- [ ] Live: \`mux-bw --routes 1 --probe-rtt --duration 30s\` against a peer where TCP buffers fill — pump terminates with MuxRouteFailure within 30s instead of hanging 30s with 0 bytes
- [ ] Live: \`mux-bw --routes 8\` where only a non-zero index establishes — probes work against that index instead of all failing