### PR TITLE
fix(visor/ping): cap PingOnceWithEcho at 10s + emit failure on bytes=0 exit

### DIFF
--- a/pkg/visor/api_ping.go
+++ b/pkg/visor/api_ping.go
@@ -263,11 +263,20 @@ func (v *Visor) PingOnce(conf PingConfig) (time.Duration, error) {
 // 32 KB payloads), which globally serialized all N parallel pump
 // goroutines through one mutex — bytes-aggregate-across-N didn't
 // scale and per-route avg stayed pinned at ~351 kbps even though
-// peak per-call could hit ~1.7 Mbps. After this PR, the lock is
+// peak per-call could hit ~1.7 Mbps. After PR #2761, the lock is
 // held only for the conns-map lookup; wire I/O on the chosen
 // conn runs unlocked, letting N pump goroutines on DIFFERENT
 // PingRouteRefs run truly in parallel. See Ping doc comment for
 // the conn-lifecycle contract.
+//
+// The entire call is bounded by a single 10s conn.SetDeadline at
+// entry (cleared on return). Previously each of the 4 wire steps
+// (write size, read ack, write ping, read echo) had its own 30s
+// deadline, so a single stuck step could hang up to 30s — racing
+// the mux-bw pumpCtx's default 30s duration and causing the pump
+// to suppress the resulting MuxRouteFailure event (task #131).
+// 10s gives the pump 3+ failed iterations within its window so a
+// stuck-route error reliably reaches the consumer.
 func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, bytesReceived uint64, latency time.Duration, err error) {
 	v.ping.mu.Lock()
 	pingEntry, ok := v.ping.conns[PingRouteRef{PK: conf.PK, Index: conf.RouteIndex}]
@@ -296,66 +305,52 @@ func (v *Visor) PingOnceWithEcho(conf PingConfig, echoFull bool) (bytesSent, byt
 		return 0, 0, 0, err
 	}
 
+	// Cap the entire call at 10s. With separate per-step 30s
+	// deadlines, a stuck Write could hang the full 30s — racing
+	// the mux-bw pumpCtx (default 30s duration) so that the
+	// pump's `if ctx.Err() == nil` guard suppressed the
+	// MuxRouteFailure event (task #131). Capping at 10s gives the
+	// pump 3+ iterations within its 30s budget to surface a real
+	// error before pumpCtx expires.
+	conn.SetDeadline(time.Now().Add(10 * time.Second)) //nolint:errcheck,gosec
+	defer conn.SetDeadline(time.Time{})                //nolint:errcheck,gosec
+
 	start := time.Now()
 
-	// Send size message. Write deadline matches the read deadline
-	// below — without it, a blocked TCP send buffer causes the
-	// call to hang indefinitely. That was the silent-pump-stall
-	// (task #127): mux-bw runs with 0 bytes pumped + 0
-	// MuxRouteFailure events emitted, because PingOnceWithEcho was
-	// stuck inside the Write rather than returning with an error.
-	conn.SetWriteDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck,gosec
 	if _, err = conn.Write(size); err != nil {
-		conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 		return 0, 0, 0, fmt.Errorf("write size: %w", err)
 	}
 	bytesSent += uint64(len(size))
 
-	// Read "ok" ack with timeout
-	conn.SetReadDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck,gosec
 	buf := make([]byte, 32*1024)
 	n, err := conn.Read(buf)
 	if err != nil {
-		conn.SetReadDeadline(time.Time{})  //nolint:errcheck,gosec
-		conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 		return bytesSent, bytesReceived, 0, fmt.Errorf("read ack: %w", err)
 	}
 	bytesReceived += uint64(n) //nolint:gosec
 
-	// Send ping data. Same write-deadline rationale as above.
-	conn.SetWriteDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck,gosec
 	if _, err = conn.Write(ping); err != nil {
-		conn.SetReadDeadline(time.Time{})  //nolint:errcheck,gosec
-		conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 		return bytesSent, bytesReceived, 0, fmt.Errorf("write ping: %w", err)
 	}
 	bytesSent += uint64(len(ping))
 
-	// Read echo response with timeout
-	conn.SetReadDeadline(time.Now().Add(30 * time.Second)) //nolint:errcheck,gosec
 	if echoFull {
-		// Read full payload echo
 		var received int
 		for received < len(ping) {
 			n, err = conn.Read(buf)
 			if err != nil {
-				conn.SetReadDeadline(time.Time{}) //nolint:errcheck,gosec
 				return bytesSent, bytesReceived, 0, fmt.Errorf("read echo: %w", err)
 			}
 			received += n
 			bytesReceived += uint64(n) //nolint:gosec
 		}
 	} else {
-		// Read simple "pong" response
 		n, err = conn.Read(buf)
 		if err != nil {
-			conn.SetReadDeadline(time.Time{}) //nolint:errcheck,gosec
 			return bytesSent, bytesReceived, 0, fmt.Errorf("read echo: %w", err)
 		}
 		bytesReceived += uint64(n) //nolint:gosec
 	}
-	conn.SetReadDeadline(time.Time{})  //nolint:errcheck,gosec
-	conn.SetWriteDeadline(time.Time{}) //nolint:errcheck,gosec
 
 	return bytesSent, bytesReceived, time.Since(start), nil
 }

--- a/pkg/visor/rpcgrpc/server_mux_bandwidth.go
+++ b/pkg/visor/rpcgrpc/server_mux_bandwidth.go
@@ -462,11 +462,16 @@ func (s *PingServer) muxBwPumpRoute(
 			// wire, leaving the operator unable to attribute zero
 			// throughput to a specific cause).
 			//
-			// ctx.Err() != nil indicates the pump's deadline fired
-			// while the call was in-flight — that's not a route
-			// failure, it's a clean shutdown. Skip the event in
-			// that case.
-			if ctx.Err() == nil {
+			// Emit when (a) pumpCtx is still alive (clear in-run
+			// failure), OR (b) we never moved a byte — a clean
+			// shutdown of a healthy pump has bytes > 0, so a
+			// zero-bytes exit is unambiguous "route never worked"
+			// regardless of pumpCtx timing. Pre-task-#131 this
+			// guard suppressed failures when pumpCtx and the
+			// per-call deadline expired in the same instant,
+			// leaving the operator with no MuxRouteFailure event
+			// to explain bytes=0.
+			if ctx.Err() == nil || rs.bytesSent.Load() == 0 {
 				emit(&MuxBandwidthEvent_RouteFailure{
 					RouteFailure: buildRouteFailureEvent(rs, err, pumpStart),
 				})


### PR DESCRIPTION
## Summary

Resolves the deadline-race that suppressed `MuxRouteFailure` events when a mux-bw route never moved a byte. Surfaced clearly in Phase 7 sweeps after #2762: pumps exited cleanly with `bytes=0` but no failure event — operator had no way to attribute zero throughput.

## Root cause

`PingOnceWithEcho` set separate 30s `SetWriteDeadline`/`SetReadDeadline` calls on each of the four wire steps (write size, read ack, write ping, read echo). A single stuck step could hang the full 30s — racing the mux-bw `pumpCtx` (default 30s duration). When both fired in the same instant, the pump's `if ctx.Err() == nil` guard suppressed the failure event:

```go
// muxBwPumpRoute, pre-fix
if ctx.Err() == nil {
    emit(&MuxBandwidthEvent_RouteFailure{ /* ... */ })
}
```

## Fix

**1. `PingOnceWithEcho` — single 10s deadline for the whole call**

Replace four scattered `SetWriteDeadline`/`SetReadDeadline` calls with one `conn.SetDeadline(time.Now().Add(10 * time.Second))` at entry, cleared via `defer`. Caps the entire call at 10s so the pump gets 3+ failed iterations within its 30s budget — a stuck-route error reliably reaches the consumer.

Net -10 lines vs the per-step-deadline version (boilerplate dropped).

**2. `muxBwPumpRoute` — emit on bytes=0 regardless of ctx**

```go
// post-fix
if ctx.Err() == nil || rs.bytesSent.Load() == 0 {
    emit(&MuxBandwidthEvent_RouteFailure{ /* ... */ })
}
```

A clean shutdown of a healthy pump has `bytes > 0`, so a zero-bytes exit is unambiguous "route never worked" regardless of ctx timing. Belt-and-suspenders alongside the deadline shortening.

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/visor/rpcgrpc/...` passes
- [ ] Live re-run of Phase 7 sweep on dev visor: expect that all currently-bytes=0 cells emit a `MuxRouteFailure` event with an underlying error reason

## Related

- #127 silent pump stall — introduced the per-step 30s deadlines this PR consolidates
- #2762 (write/read deadline addition) — this PR refines that approach
- Task #131