### PR TITLE
fix(appnet): gate direct-dial shortcut on MinHops/MuxRoutes opts

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -114,11 +114,20 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 		opts.AppName = AppNameFromContext(ctx)
 	}
 
-	if directConn, ok := r.tryDirectDial(addr); ok {
-		return &SkywireConn{
-			Conn:     directConn,
-			freePort: freePort,
-		}, nil
+	// Only take the direct shortcut when the caller is fine with a
+	// single 0-hop conn. opts.MinHops > 1 means the caller wants
+	// intermediates (direct is 0 hops); opts.MuxRoutes > 1 means the
+	// caller wants N parallel routes (direct returns one conn).
+	// Without this gate, --routes N / --min-hops K on a skynet
+	// client were silently dropped whenever AppDirectMux had a
+	// transport — see ping-path counterpart #2751.
+	if opts.MinHops <= 1 && opts.MuxRoutes <= 1 {
+		if directConn, ok := r.tryDirectDial(addr); ok {
+			return &SkywireConn{
+				Conn:     directConn,
+				freePort: freePort,
+			}, nil
+		}
 	}
 
 	conn, err = r.r.DialRoutes(ctx, addr.PubKey, routing.Port(localPort), addr.Port, opts)


### PR DESCRIPTION
## Summary

`SkywireNetworker.DialContextWithOptions` called `tryDirectDial` unconditionally before consuming `opts.MinHops` / `opts.MuxRoutes`. When `AppDirectMux` has a transport to `addr.PubKey`, the direct shortcut returns immediately and both opts get silently dropped — so `--routes N --min-hops K` on a skynet client becomes `--routes 1 --min-hops 0` whenever a direct transport happens to exist.

Same class as the ping-path counterpart #2751 (`tryDirectPingDial`): the direct shortcut returns a single 0-hop `SkywireConn`, so it's only valid when the caller is fine with both. Wrap it in:

```go
if opts.MinHops <= 1 && opts.MuxRoutes <= 1 {
    if directConn, ok := r.tryDirectDial(addr); ok {
        return &SkywireConn{ /* ... */ }, nil
    }
}
```

## Impact

Blocking real-skynet multi-route measurements (operator's actual ask, vs the `mux-bw` fixture). With this in, `--routes N` and `--min-hops K` on a skynet client behave as expected even when a direct transport happens to be cached.

Discovered by another agent at the appnet layer while running an end-to-end mux>direct test.

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/app/appnet/...` passes
- [ ] Live verification: skynet client with `--routes 4 --min-hops 2` against a peer with a cached direct transport should establish 4 multi-hop routes (not 1 direct conn)

## Related

- #2751 ping-path tryDirectPingDial gate (same fix shape)
- Task #132