### PR TITLE
feat(skynet-client): plumb --min-hops flag through app dial chain

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -41,6 +41,14 @@ var (
 	// path); N > 1 = router establishes N parallel mux routes and the
 	// app sees a single conn whose payload is striped across them.
 	routes int
+	// minHops, when >= 2, forces the router to find non-direct paths
+	// (rejecting any direct transport between this visor and the
+	// remote). Needed in combination with routes > 1 to actually
+	// exercise the mux>direct hypothesis end-to-end: without
+	// min-hops, the router happily picks the direct transport for
+	// every mux route, so N mux streams ride one TCP socket and
+	// nothing is multiplexed across intermediates.
+	minHops int
 )
 
 func init() {
@@ -50,6 +58,7 @@ func init() {
 	RootCmd.Flags().IntVar(&localPort, "local", 0, "local port to listen on")
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
 	RootCmd.Flags().IntVar(&routes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
+	RootCmd.Flags().IntVar(&minHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
 }
 
 // RootCmd is the root command for skynet-client
@@ -80,6 +89,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		fs.IntVar(&localPort, "local", 0, "local port")
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
 		fs.IntVar(&routes, "routes", 0, "number of parallel skynet mux routes")
+		fs.IntVar(&minHops, "min-hops", 0, "minimum hop count (>=2 rejects direct paths)")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -139,17 +149,24 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		Port:   routing.Port(skyenv.SkyForwardingServerPort),
 	}
 
-	if routes > 1 {
+	switch {
+	case routes > 1 && minHops > 1:
+		appCl.Log().Infof("Per-accept dial shape: %s on port %d with %d parallel mux routes, min-hops=%d",
+			remotePK.Hex(), skyenv.SkyForwardingServerPort, routes, minHops)
+	case routes > 1:
 		appCl.Log().Infof("Per-accept dial shape: %s on port %d with %d parallel mux routes",
 			remotePK.Hex(), skyenv.SkyForwardingServerPort, routes)
-	} else {
+	case minHops > 1:
+		appCl.Log().Infof("Per-accept dial shape: %s on port %d with min-hops=%d",
+			remotePK.Hex(), skyenv.SkyForwardingServerPort, minHops)
+	default:
 		appCl.Log().Infof("Per-accept dial shape: %s on port %d",
 			remotePK.Hex(), skyenv.SkyForwardingServerPort)
 	}
 
 	dialRemote := func() (net.Conn, error) {
-		if routes > 1 {
-			return appCl.DialWithOptions(connApp, routes)
+		if routes > 1 || minHops > 1 {
+			return appCl.DialWithOptions(connApp, routes, minHops)
 		}
 		return appCl.Dial(connApp)
 	}

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -123,9 +123,9 @@ func (_m *MockRPCIngressClient) Dial(remote appnet.Addr) (uint16, routing.Port, 
 	return r0, r1, r2
 }
 
-// DialWithOptions provides a mock function with given fields: remote, muxRoutes
-func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int) (uint16, routing.Port, error) {
-	ret := _m.Called(remote, muxRoutes)
+// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops
+func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int) (uint16, routing.Port, error) {
+	ret := _m.Called(remote, muxRoutes, minHops)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DialWithOptions")
@@ -134,23 +134,23 @@ func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes in
 	var r0 uint16
 	var r1 routing.Port
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int) (uint16, routing.Port, error)); ok {
-		return rf(remote, muxRoutes)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int) (uint16, routing.Port, error)); ok {
+		return rf(remote, muxRoutes, minHops)
 	}
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int) uint16); ok {
-		r0 = rf(remote, muxRoutes)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int) uint16); ok {
+		r0 = rf(remote, muxRoutes, minHops)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(appnet.Addr, int) routing.Port); ok {
-		r1 = rf(remote, muxRoutes)
+	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int) routing.Port); ok {
+		r1 = rf(remote, muxRoutes, minHops)
 	} else {
 		r1 = ret.Get(1).(routing.Port)
 	}
 
-	if rf, ok := ret.Get(2).(func(appnet.Addr, int) error); ok {
-		r2 = rf(remote, muxRoutes)
+	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int) error); ok {
+		r2 = rf(remote, muxRoutes, minHops)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -21,11 +21,13 @@ type RPCIngressClient interface {
 	SetAppPort(appPort routing.Port) error
 	Dial(remote appnet.Addr) (connID uint16, localPort routing.Port, err error)
 	// DialWithOptions asks the server to dial remote with per-call
-	// options. The only currently-honored option is MuxRoutes: when
-	// > 1 and the remote's family routes through SkywireNetworker,
-	// the router establishes N parallel mux routes. MuxRoutes <= 1
-	// is equivalent to plain Dial.
-	DialWithOptions(remote appnet.Addr, muxRoutes int) (connID uint16, localPort routing.Port, err error)
+	// options. Honored fields: muxRoutes (>1 = N parallel mux routes)
+	// and minHops (>=2 = force routes through that many intermediates,
+	// excluding the direct path). Both <= 1 is equivalent to plain Dial.
+	// The two together unblock the operator's mux>direct hypothesis
+	// test via real data-plane apps: muxRoutes alone still picks the
+	// existing direct transport for every route.
+	DialWithOptions(remote appnet.Addr, muxRoutes, minHops int) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
 	Write(connID uint16, b []byte) (int, error)
@@ -91,10 +93,11 @@ func (c *rpcIngressClient) Dial(remote appnet.Addr) (connID uint16, localPort ro
 }
 
 // DialWithOptions sends `DialWithOptions` command to the server.
-// muxRoutes <= 1 falls through to plain Dial semantics on the server
-// side (no extra round-trip cost beyond the slightly larger request).
-func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int) (connID uint16, localPort routing.Port, err error) {
-	req := DialOptionsReq{Addr: remote, MuxRoutes: muxRoutes}
+// muxRoutes <= 1 AND minHops <= 1 falls through to plain Dial
+// semantics on the server side (no extra round-trip cost beyond
+// the slightly larger request).
+func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops int) (connID uint16, localPort routing.Port, err error) {
+	req := DialOptionsReq{Addr: remote, MuxRoutes: muxRoutes, MinHops: minHops}
 	var resp DialResp
 	if err := c.rpc.Call(c.formatMethod("DialWithOptions"), &req, &resp); err != nil {
 		return 0, 0, RPCErr{err.Error()}

--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -129,7 +129,38 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// back to plain DialContext; the round-trip still succeeds and
 		// returns a valid ConnID. We're pinning the wire shape, not the
 		// router-level mux behavior (which is integration-tested).
-		connID, localPort, err := rpcC.DialWithOptions(remote, 4)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0)
+		require.NoError(t, err)
+		require.Equal(t, uint16(1), connID)
+		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)
+	})
+
+	t.Run("ok with minHops", func(t *testing.T) {
+		rpcL, closeL := prepListener(t)
+		defer closeL()
+
+		rpcS := prepRPCServer(t, NewRPCGateway(nil, nil))
+		go rpcS.Accept(rpcL)
+
+		rpcC := prepRPCClient(t, rpcL.Addr().Network(), rpcL.Addr().String())
+
+		dmsgLocal, dmsgRemote, _, remote := prepAddrs()
+
+		dialCtx := context.Background()
+		dialConn := &appcommon.MockConn{}
+		dialConn.On("LocalAddr").Return(dmsgLocal)
+		dialConn.On("RemoteAddr").Return(dmsgRemote)
+
+		n := &appnet.MockNetworker{}
+		n.On("DialContext", dialCtx, remote).Return(dialConn, testhelpers.NoErr)
+
+		appnet.ClearNetworkers()
+		require.NoError(t, appnet.AddNetworker(appnet.TypeDmsg, n))
+
+		// minHops=2 over a non-skynet networker — same fallthrough as
+		// the muxRoutes case. Pins that MinHops is wire-carried through
+		// DialOptionsReq even when the destination family ignores it.
+		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -116,48 +116,53 @@ type DialResp struct {
 
 // DialOptionsReq carries a dial request with extra per-call options.
 // Used by DialWithOptions for app paths that need to request specific
-// router behavior (currently: N parallel mux routes for the skynet
-// transport). Zero / unset MuxRoutes preserves the single-route
-// default — equivalent to plain Dial.
+// router behavior. Zero / unset fields preserve the single-route,
+// router-picks-freely default — equivalent to plain Dial.
 //
 // Added for #1525-adjacent skywire-cli mux-route testing per the
 // operator's 2026-05-19 ask. Generalizes the per-call route count
 // already plumbed through VisorCat (pkg/visor/api_visor_cat.go) into
 // the app-net surface so apps like skynet-client can request N routes
 // at dial time without needing a parallel "cli skynet cat"-style RPC.
+//
+// MinHops mirrors the same field on router.DialOptions and is needed
+// to actually exercise the mux>direct hypothesis end-to-end via real
+// data-plane apps: without it, MuxRoutes > 1 still picks the existing
+// direct transport for every route (N mux streams on one TCP socket),
+// not N routes through N intermediates.
 type DialOptionsReq struct {
 	Addr      appnet.Addr
 	MuxRoutes int
+	MinHops   int
 }
 
 // Dial dials to the remote.
 func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error) {
 	defer rpcutil.LogCall(r.log, "Dial", remote)(resp, &err)
-	return r.dialInternal(*remote, 0, resp)
+	return r.dialInternal(*remote, 0, 0, resp)
 }
 
 // DialWithOptions dials to the remote honoring per-call dial options.
-// Currently the only honored option is MuxRoutes — when > 1 and the
-// destination transport is skynet, the router establishes N parallel
-// mux routes via SkywireNetworker.DialContextWithOptions instead of
-// the single-route DialContext. Mirrors the per-call Routes path
-// already exposed via VisorCat. Falls back to plain Dial semantics
-// (single route) when MuxRoutes <= 1 OR the registered networker for
-// the address family isn't *SkywireNetworker (e.g. dmsg, where mux is
-// inherent to the session and the routes count is a no-op).
+// Honored options: MuxRoutes (N parallel mux routes) + MinHops (require
+// N intermediates between source and destination). Together these
+// exercise the operator's mux>direct hypothesis: MuxRoutes > 1 with
+// MinHops >= 2 forces the router to find N disjoint non-direct paths.
+// Falls back to plain Dial semantics when both are <= 1 OR the
+// registered networker for the address family isn't *SkywireNetworker
+// (e.g. dmsg, where mux is inherent to the session).
 func (r *RPCIngressGateway) DialWithOptions(req *DialOptionsReq, resp *DialResp) (err error) {
 	defer rpcutil.LogCall(r.log, "DialWithOptions", req)(resp, &err)
 	if req == nil {
 		return errors.New("DialWithOptions: nil request")
 	}
-	return r.dialInternal(req.Addr, req.MuxRoutes, resp)
+	return r.dialInternal(req.Addr, req.MuxRoutes, req.MinHops, resp)
 }
 
 // dialInternal is the common dial body shared by Dial + DialWithOptions.
-// muxRoutes <= 1 means "no mux", which is the existing Dial behavior;
-// muxRoutes > 1 triggers the SkywireNetworker.DialContextWithOptions
-// path for skynet destinations.
-func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes int, resp *DialResp) error {
+// muxRoutes <= 1 AND minHops <= 1 means "plain Dial" (existing
+// behavior). Anything else triggers the SkywireNetworker.
+// DialContextWithOptions path so the opts surface is honored.
+func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes, minHops int, resp *DialResp) error {
 	reservedConnID, free, err := r.cm.ReserveNextID()
 	if err != nil {
 		return err
@@ -172,7 +177,7 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes int, resp
 		appName = r.proc.conf.AppName
 	}
 	dialCtx := appnet.WithAppName(context.Background(), appName)
-	conn, err := dialWithMuxRoutes(dialCtx, remote, muxRoutes)
+	conn, err := dialWithMuxRoutes(dialCtx, remote, muxRoutes, minHops)
 	if err != nil {
 		free()
 		return err
@@ -201,14 +206,14 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes int, resp
 }
 
 // dialWithMuxRoutes dials remote either via the single-route default
-// path (appnet.DialContext) or via the SkywireNetworker mux-routes
-// path when muxRoutes > 1 and the registered networker for the addr's
-// family is the real *SkywireNetworker. The type-assertion fallback to
-// the default path matches VisorCat's contract (a test-mock or future
-// alternative networker silently degrades to single-route, preserving
-// correctness with no extra plumbing).
-func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, muxRoutes int) (net.Conn, error) {
-	if muxRoutes <= 1 {
+// path (appnet.DialContext) or via the SkywireNetworker DialOptions
+// path when the caller requested any per-call opts (mux routes OR
+// minimum hops). The type-assertion fallback to the default path
+// matches VisorCat's contract (a test-mock or future alternative
+// networker silently degrades to single-route, preserving correctness
+// with no extra plumbing).
+func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, muxRoutes, minHops int) (net.Conn, error) {
+	if muxRoutes <= 1 && minHops <= 1 {
 		return appnet.DialContext(ctx, remote)
 	}
 	nw, err := appnet.ResolveNetworker(remote.Net)
@@ -217,12 +222,13 @@ func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, muxRoutes int) (
 	}
 	sw, ok := nw.(*appnet.SkywireNetworker)
 	if !ok {
-		// Non-skynet networker (e.g. dmsg) — mux-routes is a no-op
-		// concept at this layer. Fall through to the default dial.
+		// Non-skynet networker (e.g. dmsg) — mux-routes / min-hops are
+		// no-op concepts at this layer. Fall through to the default dial.
 		return appnet.DialContext(ctx, remote)
 	}
 	opts := router.DefaultDialOptions()
 	opts.MuxRoutes = muxRoutes
+	opts.MinHops = minHops
 	return sw.DialContextWithOptions(ctx, remote, opts)
 }
 

--- a/pkg/app/appserver/rpc_ingress_gateway_test.go
+++ b/pkg/app/appserver/rpc_ingress_gateway_test.go
@@ -233,6 +233,33 @@ func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
 		// erroring; the mux-routes hint is dropped.
 		n.AssertExpectations(t)
 	})
+
+	t.Run("minHops N on non-skywire networker falls back to DialContext", func(t *testing.T) {
+		appnet.ClearNetworkers()
+
+		const localPort routing.Port = 202
+
+		dialCtx := context.Background()
+		dialConn := &appcommon.MockConn{}
+		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
+		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
+
+		n := &appnet.MockNetworker{}
+		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+
+		require.NoError(t, appnet.AddNetworker(nType, n))
+
+		rpc := NewRPCGateway(l, nil)
+
+		var resp DialResp
+		req := &DialOptionsReq{Addr: dialAddr, MinHops: 2}
+		require.NoError(t, rpc.DialWithOptions(req, &resp))
+		require.Equal(t, uint16(1), resp.ConnID)
+		require.Equal(t, localPort, resp.LocalPort)
+		// Symmetric to the muxRoutes-fallthrough case: MinHops set alone
+		// on a non-skynet family is silently dropped.
+		n.AssertExpectations(t)
+	})
 }
 
 func TestRPCIngressGateway_Listen(t *testing.T) {

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -106,34 +106,41 @@ func (c *Client) SetAppPort(appPort routing.Port) error {
 
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
-	return c.dial(remote, 0)
+	return c.dial(remote, 0, 0)
 }
 
-// DialWithOptions dials remote with per-call dial options. The only
-// currently-honored option is muxRoutes: when > 1 and the remote's
-// transport family routes through the visor's SkywireNetworker, the
-// underlying router establishes N parallel mux routes. muxRoutes <= 1
-// is semantically equivalent to Dial. Apps requesting multi-route
-// dials (e.g. skynet-client with the --routes flag for #1525-adjacent
-// mux-route testing) call this instead of Dial; non-mux callers keep
-// using Dial unchanged.
-func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes int) (net.Conn, error) {
-	return c.dial(remote, muxRoutes)
+// DialWithOptions dials remote with per-call dial options.
+// Honored options:
+//   - muxRoutes: when > 1 and the remote's transport family routes
+//     through SkywireNetworker, the router establishes N parallel
+//     mux routes.
+//   - minHops: when >= 2, the router rejects the direct path and
+//     finds routes through that many intermediates. Needed in
+//     combination with muxRoutes > 1 to actually exercise the
+//     mux>direct hypothesis, since muxRoutes alone still picks the
+//     existing direct transport for every route.
+//
+// Both <= 1 is semantically equivalent to Dial. Apps requesting these
+// dial shapes (e.g. skynet-client with --routes / --min-hops flags
+// for #1525-adjacent mux-route testing) call this instead of Dial;
+// non-mux callers keep using Dial unchanged.
+func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops int) (net.Conn, error) {
+	return c.dial(remote, muxRoutes, minHops)
 }
 
 // dial is the common body for Dial + DialWithOptions. muxRoutes <= 1
-// invokes the original rpcC.Dial path (preserving the existing wire
-// shape for non-mux callers); muxRoutes > 1 sends the DialWithOptions
-// request so the server-side knows to take the SkywireNetworker
-// mux-routes path.
-func (c *Client) dial(remote appnet.Addr, muxRoutes int) (net.Conn, error) {
+// AND minHops <= 1 invokes the original rpcC.Dial path (preserving the
+// existing wire shape for non-mux callers); otherwise sends the
+// DialWithOptions request so the server-side knows to take the
+// SkywireNetworker per-call-opts path.
+func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops int) (net.Conn, error) {
 	var (
 		connID    uint16
 		localPort routing.Port
 		err       error
 	)
-	if muxRoutes > 1 {
-		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes)
+	if muxRoutes > 1 || minHops > 1 {
+		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops)
 	} else {
 		connID, localPort, err = c.rpcC.Dial(remote)
 	}


### PR DESCRIPTION
## Summary

- Adds `--min-hops` flag to skynet-client and plumbs it through `DialOptionsReq` → `RPCIngressGateway.DialWithOptions` → `SkywireNetworker.DialContextWithOptions` so `opts.MinHops` is set on `router.DialOptions`.
- Companion to #2765 (which gated the appnet `tryDirectDial` shortcut on `MinHops`/`MuxRoutes`). Both are needed to actually exercise the operator's mux>direct hypothesis end-to-end via real skynet apps: #2765 stops the bypass from eating the opts; this PR adds the CLI surface that drives `opts.MinHops`.
- `--routes N` alone (post-#2765) still picks the direct transport for every mux route when one exists; with `--min-hops 2` the router rejects the direct path and finds N disjoint multi-hop routes.

## Motivation

Empirical observation while running the real-data-plane mux>direct test against another visor with #2759 + #2765 in place:

```
cli skynet start --pk <peer> -r 8090 -l 8200 --routes 4
→ visor log:
   Mux route 1/4 established via transport 735f7d73-...
   Mux route 2/4 established via transport 735f7d73-...
   Mux route 3/4 established via transport 735f7d73-...
   Mux route 4/4 established via transport 735f7d73-...
```

All 4 mux routes rode the same `735f7d73-…` direct stcpr transport. `--routes` was honored at the mux-stream level but not the route-finder level. Result: N mux streams over one TCP socket, not N routes via N intermediates.

With this PR:

```
cli skynet start --pk <peer> -r 8090 -l 8200 --routes 4 --min-hops 2
```

forces the router-finder to reject the direct path and find 4 disjoint routes through at least 2 hops each, which is the shape needed to actually compare aggregate-mux throughput against the direct baseline.

## Changes

- `pkg/app/appserver/rpc_ingress_gateway.go` — `DialOptionsReq` gains a `MinHops int` field; `dialInternal` + `dialWithMuxRoutes` thread `minHops` through to `router.DialOptions.MinHops`.
- `pkg/app/appserver/rpc_ingress_client.go` — `RPCIngressClient.DialWithOptions` signature gains `minHops int`.
- `pkg/app/appserver/mock_rpc_ingress_client.go` — mock regenerated to match.
- `pkg/app/client.go` — `Client.DialWithOptions` signature gains `minHops int`; `dial` helper triggers the `DialWithOptions` RPC when either `muxRoutes > 1` or `minHops > 1`.
- `cmd/apps/skynet-client/commands/skynet-client.go` — adds `--min-hops` flag (mirrors `--routes`); cobra side + launcher-args side both parse it; logged on startup; passed to `appCl.DialWithOptions`.
- Tests cover the new `MinHops`-only path (mirrors the existing `MuxRoutes`-only assertions) on both the RPC client and the gateway.

`DialOptionsReq` field addition is wire-compatible: old clients omit `MinHops` → server sees zero-value → legacy behavior preserved.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/app/... ./cmd/apps/skynet-client/...` clean
- [x] `go test -count=1 ./pkg/app/appserver/ ./pkg/app/` all pass
- [ ] Integration: after auto-deploy, fire `cli skynet start --pk <peer> -r 8090 -l 8200 --routes 4 --min-hops 2` and confirm the visor log shows 4 mux routes via DIFFERENT transports (not 4× the same direct transport ID)
- [ ] Confirm `--min-hops 2` alone (without `--routes`) routes single-hop traffic through an intermediate