### PR TITLE
chore(deps): bump vis-data and vis-network in /pkg/tpviz/ui

### DIFF
--- a/pkg/tpviz/ui/package-lock.json
+++ b/pkg/tpviz/ui/package-lock.json
@@ -11,8 +11,8 @@
         "d3-geo": "^3.1.1",
         "d3-geo-voronoi": "^2.1.0",
         "three": "^0.160.0",
-        "vis-data": "^7.1.9",
-        "vis-network": "^9.1.9"
+        "vis-data": "^8.0.4",
+        "vis-network": "^10.1.0"
       },
       "devDependencies": {
         "@types/three": "^0.160.0",
@@ -778,23 +778,23 @@
       }
     },
     "node_modules/vis-data": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.10.tgz",
-      "integrity": "sha512-23juM9tdCaHTX5vyIQ7XBzsfZU0Hny+gSTwniLrfFcmw9DOm7pi3+h9iEBsoZMp5rX6KNqWwc1MF0fkAmWVuoQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.4.tgz",
+      "integrity": "sha512-TsN0sMHqIRpdfg6TNPtfdINpkgxtnQP6JNWCaiSwvou5seXqKiP5eERkaBg+Y56wyJ4FZTeOEs/dEmWEPrpltQ==",
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/visjs"
       },
       "peerDependencies": {
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "vis-util": "^5.0.1"
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
+        "vis-util": ">=6.0.0"
       }
     },
     "node_modules/vis-network": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.1.13.tgz",
-      "integrity": "sha512-HLeHd5KZS92qzO1kC59qMh1/FWAZxMUEwUWBwDMoj6RKj/Ajkrgy/heEYo0Zc8SZNQ2J+u6omvK2+a28GX1QuQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.1.0.tgz",
+      "integrity": "sha512-D7b5p/C6SwWv1BlH9EDdtP0Tje/PJzSBWKef9qy2DyTC14QB7KBcnAZxIyW2m7mFYyfoeR+k5GF747zDcIhaKA==",
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
         "type": "opencollective",
@@ -804,15 +804,15 @@
         "@egjs/hammerjs": "^2.0.0",
         "component-emitter": "^1.3.0 || ^2.0.0",
         "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
-        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-        "vis-data": "^6.3.0 || ^7.0.0",
-        "vis-util": "^5.0.1"
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0 || ^14.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0"
       }
     },
     "node_modules/vis-util": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.7.tgz",
-      "integrity": "sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-6.0.0.tgz",
+      "integrity": "sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==",
       "license": "(Apache-2.0 OR MIT)",
       "peer": true,
       "engines": {

--- a/pkg/tpviz/ui/package.json
+++ b/pkg/tpviz/ui/package.json
@@ -12,8 +12,8 @@
     "d3-geo": "^3.1.1",
     "d3-geo-voronoi": "^2.1.0",
     "three": "^0.160.0",
-    "vis-data": "^7.1.9",
-    "vis-network": "^9.1.9"
+    "vis-data": "^8.0.4",
+    "vis-network": "^10.1.0"
   },
   "devDependencies": {
     "@types/three": "^0.160.0",


### PR DESCRIPTION
## Summary

Bumps `vis-data` and `vis-network` in `pkg/tpviz/ui` to versions that support the modern `uuid` peer-dep range. Replicates dependabot #2763 without cherry-picking — produced by running `npm install` after editing `package.json`.

- `vis-data`: `7.1.10` → `8.0.4`
- `vis-network`: `9.1.13` → `10.1.0`
- Transitive: `vis-util` `5.0.7` → `6.0.0`, peer `uuid` range extended through v14.

## Test plan

- [x] `npm install` clean
- [x] `npm run build` succeeds against the new versions
- [x] `npm run typecheck` shows the same pre-existing errors as develop (flow-animation.ts canvas-ctx narrowing, missing `@types/d3-geo-voronoi`, local-visor.ts null-checks) — none related to the bumped deps
- [x] Diff byte-identical to #2763 (verified via `diff <(git diff HEAD -- pkg/tpviz/ui/) <(gh pr diff 2763)`)

Closes #2763.