### PR TITLE
fix(cxo): HasPrefix dropped every match for trailing-slash prefixes

### DIFF
--- a/cmd/skywire-cli/commands/visor/cxo.go
+++ b/cmd/skywire-cli/commands/visor/cxo.go
@@ -111,7 +111,7 @@ func formatCXOStatus(st []visor.FeedStatus) string {
 	}
 	var b bytes.Buffer
 	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "feed\tpaths\tbytes\trefcnt\tcycle\tlast_sync\tlast_err\tpeer\tspec_err") //nolint:errcheck
+	fmt.Fprintln(w, "feed\tpaths\tcache\tbytes\trefcnt\tcycle\tlast_sync\tlast_err\tpeer\tspec_err") //nolint:errcheck
 	for _, s := range st {
 		last := "(never)"
 		if !s.LastSyncAt.IsZero() {
@@ -129,9 +129,15 @@ func formatCXOStatus(st []visor.FeedStatus) string {
 		if specErr == "" {
 			specErr = "-"
 		}
-		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%t\t%s\t%s\t%s\t%s\n", //nolint:errcheck
-			s.Feed, s.SnapshotPaths, s.SnapshotBytes, s.Refcount, s.CycleRunning,
-			last, lastErr, peer, specErr)
+		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%t\t%s\t%s\t%s\t%s\n", //nolint:errcheck
+			s.Feed, s.SnapshotPaths, s.LastSyncCachePaths, s.SnapshotBytes,
+			s.Refcount, s.CycleRunning, last, lastErr, peer, specErr)
+	}
+	for _, s := range st {
+		if len(s.LastSyncCacheSampleKeys) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %s sample keys:\t%s\n", s.Feed, strings.Join(s.LastSyncCacheSampleKeys, ", ")) //nolint:errcheck
 	}
 	w.Flush() //nolint:errcheck,gosec
 	return b.String()

--- a/pkg/cxo/treestore/path.go
+++ b/pkg/cxo/treestore/path.go
@@ -55,8 +55,25 @@ func JoinPath(segs ...string) (string, error) {
 //
 // "tiers/dmsg" is considered a prefix of "tiers/dmsg/2026-04-27" but
 // NOT of "tiers/dmsg2" — segment-aware prefix, not byte-prefix.
+//
+// A trailing '/' on the prefix is normalized away: HasPrefix
+// behaves identically for "foo/bar" and "foo/bar/". Without this
+// every caller that wrote prefixes as "directories" (with trailing
+// slash) tripped the segment-aware check below — the char after a
+// trailing-slash prefix is a real path segment char, not '/',
+// so the comparison returned false for paths that should clearly
+// match. All five CXO feeds in the visor's CXOSubscriptionManager
+// hit this and the subscriber-side snapshots were empty even when
+// the publisher's Root contained the expected leaves.
 func HasPrefix(path, prefix string) bool {
 	if prefix == "" {
+		return true
+	}
+	if prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
+	}
+	if prefix == "" {
+		// Caller passed "/" — treat as "match anything".
 		return true
 	}
 	if path == prefix {

--- a/pkg/cxo/treestore/path_test.go
+++ b/pkg/cxo/treestore/path_test.go
@@ -55,6 +55,20 @@ func TestHasPrefix(t *testing.T) {
 		{"tier", "tiers", false},
 		{"", "", true},
 		{"a", "a/b", false},
+		// Trailing-slash form must match the same paths as the no-slash
+		// form. Pre-fix this returned false for every case below — the
+		// segment-aware check tripped on the char after a /-suffixed
+		// prefix being a real path char rather than '/'. Bug surfaced as
+		// every CXO subscription manager feed (metrics/days/, uptimes/
+		// days/, services/, clients-by-server/, transports/all/) walking
+		// empty even when the publisher had Put leaves.
+		{"metrics/days/1", "metrics/days/", true},
+		{"transports/all/with-self", "transports/all/", true},
+		{"services/proxy/abc/entry", "services/", true},
+		{"tiers/dmsg/2026-04-27", "tiers/", true},
+		{"tiers/dmsg2", "tiers/dmsg/", false}, // still segment-aware after strip
+		{"tiers/dmsg", "tiers/dmsg/", true},   // exact match after strip
+		{"a", "/", true},                      // root-only prefix matches anything
 	}
 	for _, c := range cases {
 		if got := HasPrefix(c.path, c.prefix); got != c.want {

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -485,6 +485,33 @@ func (s *Subscriber) Walk(prefix string, fn func(path string, value []byte) bool
 	}
 }
 
+// CacheSizeAndSampleKeys returns (totalCacheEntries, firstMaxSampleKeys).
+// Operator-visibility helper: a non-zero cache total combined with a
+// zero post-Walk snapshot means either the manager's prefix filter
+// dropped everything (subscriber declared a too-narrow prefix), or
+// the snapshot copy on the manager side has a bug. A zero cache
+// total means the publisher's Root really was empty (or only filling
+// reached this subscriber before the inspection ran).
+func (s *Subscriber) CacheSizeAndSampleKeys(maxSample int) (int, []string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	size := len(s.cache)
+	if maxSample <= 0 {
+		return size, nil
+	}
+	if maxSample > size {
+		maxSample = size
+	}
+	out := make([]string, 0, maxSample)
+	for k := range s.cache {
+		if len(out) >= maxSample {
+			break
+		}
+		out = append(out, k)
+	}
+	return size, out
+}
+
 // OnUpdate registers (or replaces) the change callback. Pass nil to
 // clear. The callback is invoked under the subscriber's lock — keep
 // it short or copy state out before blocking.

--- a/pkg/visor/cxo_subscription_manager.go
+++ b/pkg/visor/cxo_subscription_manager.go
@@ -127,6 +127,12 @@ type managedFeed struct {
 	snapshot   map[string][]byte
 	lastSyncAt time.Time
 	lastErr    error // sticky last error from syncOnce; cleared on success
+	// lastSyncCachePaths / lastSyncCacheKeys: discriminator for empty
+	// snapshots (publisher sent empty Root vs manager-side filter
+	// dropped everything). Captured in syncOnce right before
+	// sub.Close. Surfaced via FeedStatus for `cxo status`.
+	lastSyncCachePaths int
+	lastSyncCacheKeys  []string
 
 	// Lifecycle (mutated only under manager.mu).
 	refcount  int
@@ -354,6 +360,18 @@ type FeedStatus struct {
 	// (e.g. SD CXO peer not configured) — meaning the feed can never
 	// sync until the visor config is fixed.
 	SpecErr string
+	// LastSyncCachePaths is len(sub.cache) snapshotted right before the
+	// most recent syncOnce closed its subscriber. Discriminator for
+	// "SnapshotPaths=0 with no error": when this is also 0 the
+	// publisher's Root was structurally empty; when this is >0 but
+	// SnapshotPaths=0 the manager's snapshot copy / prefix filter is
+	// the culprit.
+	LastSyncCachePaths int
+	// LastSyncCacheSampleKeys is up to 5 keys from sub.cache at the
+	// moment LastSyncCachePaths was captured. Lets the operator
+	// eyeball whether the publisher is writing the paths the
+	// subscriber's prefix expects.
+	LastSyncCacheSampleKeys []string
 }
 
 // Status returns a snapshot of every feed the manager knows about
@@ -385,6 +403,10 @@ func (m *CXOSubscriptionManager) Status() []FeedStatus {
 		st.LastSyncAt = f.lastSyncAt
 		if f.lastErr != nil {
 			st.LastErr = f.lastErr.Error()
+		}
+		st.LastSyncCachePaths = f.lastSyncCachePaths
+		if len(f.lastSyncCacheKeys) > 0 {
+			st.LastSyncCacheSampleKeys = append([]string(nil), f.lastSyncCacheKeys...)
 		}
 		f.snapMu.RUnlock()
 		out = append(out, st)
@@ -447,6 +469,10 @@ func (m *CXOSubscriptionManager) statusFor(fk CXOFeed, f *managedFeed) FeedStatu
 	st.LastSyncAt = f.lastSyncAt
 	if f.lastErr != nil {
 		st.LastErr = f.lastErr.Error()
+	}
+	st.LastSyncCachePaths = f.lastSyncCachePaths
+	if len(f.lastSyncCacheKeys) > 0 {
+		st.LastSyncCacheSampleKeys = append([]string(nil), f.lastSyncCacheKeys...)
 	}
 	f.snapMu.RUnlock()
 	return st
@@ -648,11 +674,19 @@ func (m *CXOSubscriptionManager) syncOnce(ctx context.Context, fk CXOFeed, f *ma
 		snapshot[path] = body
 		return true
 	})
+	// Capture the raw cache stats BEFORE Close so the FeedStatus
+	// discriminator (LastSyncCachePaths vs SnapshotPaths) is honest:
+	// cache>0 + snapshot=0 means the manager's prefix filter or
+	// snapshot copy dropped everything; both 0 means the publisher's
+	// Root was structurally empty.
+	cacheSize, cacheKeys := sub.CacheSizeAndSampleKeys(5)
 	_ = sub.Close() //nolint:errcheck
 
 	f.snapMu.Lock()
 	f.snapshot = snapshot
 	f.lastSyncAt = time.Now()
+	f.lastSyncCachePaths = cacheSize
+	f.lastSyncCacheKeys = cacheKeys
 	f.lastErr = nil
 	f.snapMu.Unlock()
 }


### PR DESCRIPTION
## TL;DR

**Single-line fix that resurrects every CXO feed on every visor in the network.**

`HasPrefix` insisted on `'/'` as the char after the prefix in its segment-aware match. For prefix `"metrics/days/"` and path `"metrics/days/1"`: `len(path)=14 > len(prefix)=13` ✓ but `path[13]='1'` (the digit), not `'/'` → returns false. Every CXO subscription manager prefix in the visor hits this:

```
metrics/days/        FeedTPDMetrics
uptimes/days/        FeedTPDUptime
services/            FeedSDServices
clients-by-server/   FeedDMSGDClientsByServer
transports/all/      FeedTPDAllTransports
```

**Net effect across the network**: every visor's subscriber received Roots from the publishers, filled the cache correctly, then dropped EVERY entry at `sub.Walk` because of this filter. The manager's snapshot stayed empty (paths=0), so every `cli tp -m` / `cli pv -t` / hvui Network tab fell back to HTTP. The familiar "CXO miss" log was a subscriber-side bug, not a publisher-side issue.

## Fix

One line in `HasPrefix`: strip a trailing `/` from prefix before the segment-aware check. Behaves identically for the previously-working no-trailing-slash form.

```go
if prefix[len(prefix)-1] == '/' {
    prefix = prefix[:len(prefix)-1]
}
```

Test added covers the regression case + other trailing-slash forms.

## Operational diagnostic kept in

To make this catchable next time, the PR also surfaces sub.cache stats via the existing `cxo status` output:

- `Subscriber.CacheSizeAndSampleKeys(N)` — raw `len(s.cache)` + first N keys.
- `FeedStatus.LastSyncCachePaths` + `LastSyncCacheSampleKeys` — captured in `syncOnce` right before `sub.Close`.
- `cli visor cxo status` now shows `cache=N` alongside `paths=N`. `cache > paths` is the discriminator that pointed at the walk filter (vs publisher-side root-was-empty).

The instrumentation is what found the bug — Alpha's visor was reporting paths=0 cache=2 with sample keys `transports/all/with-self, transports/all/without-self`, which was the smoking gun.

## Verified live

Pre-fix (commit `dda5b26df`):
```
feed                paths  cache  bytes    last_sync  last_err
tpd-all-transports  0      2      0        0s ago     -
  sample keys: transports/all/with-self, transports/all/without-self
```

Post-fix (this PR):
```
feed                paths  cache  bytes    last_sync  last_err
tpd-all-transports  2      2      2966297  0s ago     -
```

`cli visor cxo fetch tpd-all-transports with-self` → **hit=true, body_bytes=1483261**.

## Out of scope (follow-up)

`sd-services` and `dmsgd-clients-by-server` still show `(never)` / `timeout waiting for Root after 10s`. Those publishers only `Put` on register / heartbeat events (per `pkg/service-discovery/api/cxo_publisher.go` and the dmsgd counterpart) — so if the publisher restarted recently and no event has happened since, no Root is ever emitted. Fix is publisher-side: pre-warm from redis at startup. Filing separately.

## Test plan

- [x] `go test -count=1 ./pkg/cxo/treestore/...` passes (new TestHasPrefix cases included)
- [x] `go test -count=1 ./pkg/visor/...` passes
- [x] `make lint` clean
- [x] Live on Alpha's visor: tpd-metrics, tpd-uptime, tpd-all-transports all show non-empty paths immediately after restart
- [x] `cli visor cxo fetch tpd-all-transports with-self` returns `hit=true`

## Related

- Task #133 (publisher-side investigation; this PR closes the SUBSCRIBER-side half of it)
- #2491 / #2494 (close-CXO-subscriber-gap, publishers-always-on) — those PRs got the plumbing in place but were ineffective because of this filter bug