### PR TITLE
fix(cli/skynet): forward --min-hops flag through start command

### DIFF
--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -29,6 +29,7 @@ var (
 	useExternal   bool
 	clientName    string // optional custom name for the client instance
 	startRoutes   int    // number of parallel skynet mux routes (0/1 = single route)
+	startMinHops  int    // minimum-hop constraint (>=2 rejects direct paths)
 )
 
 func init() {
@@ -47,6 +48,7 @@ func init() {
 	startCmd.Flags().BoolVar(&useExternal, "external", false, "force external launcher")
 	startCmd.Flags().StringVarP(&clientName, "name", "n", "", "custom name for this client instance (default: skynet-client-<local-port>)")
 	startCmd.Flags().IntVar(&startRoutes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
+	startCmd.Flags().IntVar(&startMinHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 
 	stopCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of the client instance to stop")
@@ -122,6 +124,10 @@ var startCmd = &cobra.Command{
 
 		if startRoutes > 1 {
 			arguments["--routes"] = fmt.Sprintf("%d", startRoutes)
+		}
+
+		if startMinHops > 1 {
+			arguments["--min-hops"] = fmt.Sprintf("%d", startMinHops)
 		}
 
 		err = rpcClient.DoCustomSetting(appName, arguments)


### PR DESCRIPTION
## Summary

- Completes the gap in #2766: the skynet-client **app binary** got the new \`--min-hops\` flag, but the user-facing \`cli skynet start\` wrapper never registered the flag, so every invocation of \`cli skynet start ... --min-hops 2\` died with \`unknown flag: --min-hops\` before the arg could reach the app.
- This PR mirrors the existing \`--routes\` wiring: declare \`startMinHops int\`, register with \`Flags().IntVar\`, append \`--min-hops <N>\` to the arguments map when \`> 1\`.

## Repro before this fix (against post-#2766 binary)

\`\`\`
$ skywire cli skynet start --pk <peer> -r 8090 -l 8410 --name b-mh --min-hops 2
2026/05/23 10:25:31 Failed to execute command: unknown flag: --min-hops
\`\`\`

The flag IS in the binary (visible via \`strings\` on the embedded skynet-client section), but only the app binary's RootCmd registered it. The CLI wrapper is a separate program that takes its own \`cobra\` flag set, builds an arg map, then calls the visor's StartApp RPC which spawns the skynet-client binary with those args.

## After this fix

\`\`\`
$ skywire cli skynet start --pk <peer> -r 8090 -l 8410 --name b-mh --routes 4 --min-hops 2
Starting b-mh -> <peer>:8090 -> localhost:8410 .
Running!
\`\`\`

Together with #2765 (operator's appnet bypass gate) + #2766 (app-side flag + RPC plumbing), this PR finally surfaces the full \`--min-hops\` knob end-to-end via the user-facing CLI, so the operator's mux>direct hypothesis test on the real skynet data plane can actually be run.

## Test plan

- [x] \`go build ./cmd/skywire-cli/...\` clean
- [x] \`go vet ./cmd/skywire-cli/commands/skynet/...\` clean
- [ ] After auto-deploy: \`cli skynet start --pk <peer> -r 8090 -l 8410 --routes 4 --min-hops 2\` succeeds and \`cli visor app ls\` shows the new client running
- [ ] Confirm the spawned skynet-client logs the dial shape with min-hops=2