### PR TITLE
fix(sd,dmsgd): pre-warm CXO publisher tree from redis at startup

### DIFF
--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -184,6 +184,41 @@ func (a *API) SetClientsByServerCXOPublisher(p *ClientsByServerCXOPublisher) {
 	a.cxoPublisher = p
 }
 
+// WarmCXOFromStore pre-populates the CXO publisher's tree from the
+// current set of client entries in the store. Without this, the
+// publisher only Puts on register / heartbeat events — so right
+// after a dmsg-discovery restart the publisher's tree is empty
+// until the first event lands, and any subscriber that connects in
+// the post-restart gap times out at firstSyncTimeout (10s) with
+// "timeout waiting for Root".
+//
+// Mirrors the existing BackfillDHTMirror pattern: walk AllClientEntries
+// and replay each as a fresh SetEntry (oldEntry=nil so the heartbeat
+// skip in PublishSetEntry doesn't elide the Put). Best-effort —
+// per-entry errors don't abort the warm.
+func (a *API) WarmCXOFromStore(ctx context.Context, log logrus.FieldLogger) {
+	if a == nil || a.cxoPublisher == nil {
+		return
+	}
+	entries, err := a.db.AllClientEntries(ctx)
+	if err != nil {
+		log.WithError(err).Warn("CXO warm: failed to list client entries")
+		return
+	}
+	warmed := 0
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			break
+		}
+		if entry == nil || entry.Client == nil {
+			continue
+		}
+		a.cxoPublisher.PublishSetEntry(nil, entry)
+		warmed++
+	}
+	log.WithField("entries", warmed).Info("CXO warm: pre-populated publisher tree from store")
+}
+
 // BackfillDHTMirror iterates all existing entries in the store and
 // mirrors them to the DHT. This ensures the DHT has the full dataset
 // on startup, not just entries updated since the last restart.

--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -118,6 +118,45 @@ func (a *API) SetServicesCXOPublisher(p *ServicesCXOPublisher) {
 	a.cxoPublisher = p
 }
 
+// WarmCXOFromStore pre-populates the CXO publisher's tree from the
+// current SD store. Without this, the publisher only Puts on
+// register/heartbeat events — so right after an SD restart the
+// publisher's tree is empty until the first event lands, and any
+// subscriber that connects in the gap times out at firstSyncTimeout
+// (10s) with "timeout waiting for Root".
+//
+// Best-effort: per-type listing failures are logged and skipped, but
+// the returned count is the actual number of entries pushed into the
+// publisher's queue. Caller should run this once after
+// SetServicesCXOPublisher and before declaring SD ready to serve.
+func (a *API) WarmCXOFromStore(ctx context.Context) int {
+	if a == nil || a.cxoPublisher == nil {
+		return 0
+	}
+	types := []string{
+		servicedisc.ServiceTypeVisor,
+		servicedisc.ServiceTypeVPN,
+		servicedisc.ServiceTypeProxy,
+		servicedisc.ServiceTypeSkysocks,
+	}
+	var n int
+	for _, sType := range types {
+		services, herr := a.db.Services(ctx, sType, "", "")
+		if herr != nil {
+			a.log.WithField("type", sType).WithError(herr).Warn("CXO warm: failed to list services from store")
+			continue
+		}
+		for i := range services {
+			a.cxoPublisher.PutEntry(&services[i])
+			n++
+		}
+	}
+	if n > 0 {
+		a.log.WithField("entries", n).Info("CXO warm: pre-populated publisher tree from store")
+	}
+	return n
+}
+
 // mirrorVisorServices re-publishes the current full list of services
 // for a visor PK. Called after any service registration or deletion
 // so the DHT target holds the same set as HTTP discovery. An empty

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -267,6 +267,12 @@ func (s *service) runDMSG(
 		log.WithError(perr).Error("Failed to start CXO clients-by-server publisher, continuing without it")
 	} else {
 		a.SetClientsByServerCXOPublisher(pub)
+		// Pre-warm the publisher's tree from existing redis entries so
+		// the first Root carries the live (server, client) map instead
+		// of being empty until the next set/del event — without this a
+		// subscriber connecting in the post-restart gap times out at
+		// firstSyncTimeout (10s).
+		a.WarmCXOFromStore(ctx, log)
 		go func() {
 			<-ctx.Done()
 			pub.Close() //nolint:errcheck,gosec

--- a/pkg/services/sd/sd.go
+++ b/pkg/services/sd/sd.go
@@ -208,6 +208,12 @@ func (s *service) startServicesCXO(
 		return
 	}
 	sdAPI.SetServicesCXOPublisher(pub)
+	// Pre-warm the publisher's tree from the existing redis store so
+	// the publisher's first Root carries the active service list
+	// instead of being empty until the next register/heartbeat event
+	// — without this a subscriber that connects in the post-restart
+	// gap times out at firstSyncTimeout (10s).
+	sdAPI.WarmCXOFromStore(ctx)
 	go func() {
 		<-ctx.Done()
 		pub.Close() //nolint:errcheck,gosec


### PR DESCRIPTION
## Summary

Closes the last two failing CXO feeds on the network. After #2769 (HasPrefix trailing-slash fix) the subscriber side works correctly, but two of the five feeds — `sd-services` and `dmsgd-clients-by-server` — still time out with `timeout waiting for Root after 10s` because their publishers come up empty after restart and only emit a Root when the first register/heartbeat event lands.

This PR pre-warms both publishers from existing redis state at startup, so the first subscriber to connect after restart gets the full snapshot immediately.

## Mechanism

Both publishers only `p.pub.Put` on event-driven calls (`PutEntry` for SD's register/heartbeat HTTP handler, `PublishSetEntry` for dmsg-discovery's POST `/entry/`). On startup the in-memory tree is empty (or `hydrateFromContainer` pulls a previous Root from bbolt if persisted), and the publish loop only fires when `dirty=true`. No Put → no dirty → no Root → subscribers receive nothing on the wire and time out.

Two new methods follow the existing `BackfillDHTMirror` pattern:

**`pkg/service-discovery/api/api.go` — `(a *API) WarmCXOFromStore(ctx)`**

Iterates the 4 known service types (`visor`, `vpn`, `proxy`, `skysocks`), calls `a.db.Services(ctx, sType, "", "")` for each, and enqueues `a.cxoPublisher.PutEntry(&svc)` for every returned service. Best-effort: per-type failures are logged and skipped.

**`pkg/dmsg/discovery/api/api.go` — `(a *API) WarmCXOFromStore(ctx, log)`**

Calls `a.db.AllClientEntries(ctx)` (same method `BackfillDHTMirror` uses) and replays each as a fresh set via `a.cxoPublisher.PublishSetEntry(nil, entry)`. Passing `oldEntry=nil` bypasses the heartbeat-skip short-circuit so every entry produces a Put. Mirrors the DHT-backfill shape that already lives in the same file.

Wired from `pkg/services/sd/sd.go` and `pkg/services/dmsgdisc/dmsgdisc.go` right after `SetXxxCXOPublisher`, before the cleanup goroutine starts.

## Net effect

Before this PR (Alpha's visor, dev tip `1dc0cfc90` with #2769):

```
feed                     paths  cache  last_sync  last_err
tpd-metrics              3      3      32s ago    -                                  ← fixed by #2769
tpd-uptime               3      3      25s ago    -                                  ← fixed by #2769
tpd-all-transports       2      2      0s ago     -                                  ← fixed by #2769
sd-services              0      0      (never)    timeout waiting for Root after 10s ← THIS PR
dmsgd-clients-by-server  0      0      (never)    timeout waiting for Root after 10s ← THIS PR
```

After this PR (post-deploy):

```
sd-services              N      N      <fresh>   -
dmsgd-clients-by-server  M      M      <fresh>   -
```

…where N and M are the live counts in redis (~2500 for SD, thousands for dmsgd per their HTTP endpoints).

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/service-discovery/...` passes
- [x] Pre-existing `pkg/dmsg/discovery/store` test fails identically on stock develop (redis connection-pool reaper hangs without a live redis) — unrelated to this PR
- [ ] Live verification post-deploy: `cli visor cxo refresh sd-services` and `dmsgd-clients-by-server` should return `paths>0 last_err=-` after their deployments roll over

## Related

- #2769 HasPrefix trailing-slash fix (subscriber-side half — needed for paths>0 to actually surface)
- #2491 / #2494 CXO subscriber-gap + publisher-always-on (laid the plumbing this PR completes)
- Task #135