### PR TITLE
chore(transport): remove unused tpdCache field + Set/GetTPDCache methods

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -89,10 +89,6 @@ type Manager struct {
 	routeChecker   RouteChecker
 	routeCheckerMu sync.RWMutex
 
-	// tpdCache stores the cached transport discovery data for local route calculation
-	tpdCache   []*Entry
-	tpdCacheMu sync.RWMutex
-
 	// tpdLeafPub mirrors register / deregister to the visor's CXO
 	// stats publisher tree (the same tree that already carries
 	// transports/<uuid>/current and timeline leaves). Set lazily by
@@ -746,21 +742,6 @@ func (tm *Manager) hasActiveRoutes(tpID uuid.UUID) bool {
 		return false
 	}
 	return rc(tpID)
-}
-
-// SetTPDCache updates the cached TPD data for local route calculation.
-func (tm *Manager) SetTPDCache(entries []*Entry) {
-	tm.tpdCacheMu.Lock()
-	defer tm.tpdCacheMu.Unlock()
-	tm.tpdCache = entries
-	tm.Logger.Debugf("TPD cache updated with %d entries", len(entries))
-}
-
-// GetTPDCache returns the cached TPD data.
-func (tm *Manager) GetTPDCache() []*Entry {
-	tm.tpdCacheMu.RLock()
-	defer tm.tpdCacheMu.RUnlock()
-	return tm.tpdCache
 }
 
 // InitClient initilizes a network client


### PR DESCRIPTION
## Summary

`tpdCache` in `pkg/transport/manager.go` was added 2026-03-03 (commit `0ed7e9d38c`) with a stated purpose of "cached transport discovery data for local route calculation", but no caller ever wrote to it or read from it: `SetTPDCache` and `GetTPDCache` are unreferenced across the entire codebase.

The actual local route calculator (`calculateLocalRoutes` in `pkg/router/router_dial.go`) calls `dc.GetAllTransports(ctx)` directly, which hits TPD over HTTP on every dial.

## Net effect

-19 lines. No behavior change.

## Follow-up

The proper improvement is wiring `calculateLocalRoutes` to consult the CXO `tpd-all-transports` snapshot (now populated network-wide post-#2769 + #2771) before falling back to HTTP. Filed separately as a tracker task; intentionally not bundled here because it spans router + visor + transport-manager wiring and merits its own review.

Surfaced during task #126 — the "incompleteness" turned out to be "zero entries, ever" rather than "missing non-adjacent transports".

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] No tests reference the removed methods