### PR TITLE
feat(visor): CXO-aware transport.DiscoveryClient — local route calc reads CXO before HTTP

### DIFF
--- a/pkg/visor/cxo_transport_discovery.go
+++ b/pkg/visor/cxo_transport_discovery.go
@@ -1,0 +1,76 @@
+// Package visor pkg/visor/cxo_transport_discovery.go
+//
+// CXO-aware wrapper around the visor's transport.DiscoveryClient. The
+// only override is GetAllTransports — the network-wide snapshot used
+// by calculateLocalRoutes, autoconnect, the hypervisor's calc tools,
+// and a few RPC paths. Every other DiscoveryClient call (per-edge
+// lookups, registrations, deletes) keeps going to HTTP because the
+// CXO publisher doesn't carry that fan-out and a stale single-edge
+// answer can produce route-setup failures that don't self-correct.
+//
+// The CXO snapshot is refreshed on the manager's 5min cycle while the
+// feed is held; for read-heavy paths (mux-bw probes, hvui Transports
+// tab, route calc on every Dial) that's tighter than the per-call HTTP
+// fetch was. AcquireFor on each call keeps the cycle alive across
+// bursts via cxoTabCloseGrace.
+package visor
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/skycoin/skywire/pkg/transport"
+	tpdapi "github.com/skycoin/skywire/pkg/transport-discovery/api"
+)
+
+// cxoAwareTPD wraps a transport.DiscoveryClient, intercepting
+// GetAllTransports to consult the visor's CXO subscription manager
+// first and falling back to the embedded client (HTTP / DMSG-HTTP) on
+// miss. The embed pattern preserves every other DiscoveryClient
+// method unchanged — only the bulk-fetch path benefits from the
+// cache.
+type cxoAwareTPD struct {
+	transport.DiscoveryClient
+	v *Visor
+}
+
+// GetAllTransports returns the network-wide transport list. Reads the
+// CXO snapshot of tpd-all-transports/without-self when the manager
+// has a non-empty cache; otherwise delegates to the wrapped HTTP
+// client. "without-self" matches the historical HTTP path's omission
+// of self-transports from the bulk listing.
+//
+// AcquireFor + ReleaseFor on every call so a burst of route-calc
+// dials inside the close-grace window reuses one live cycle instead
+// of re-tearing-down between dials. JSON unmarshal of the snapshot
+// is the same code the HTTP path runs; cost is negligible compared
+// to a DMSG-HTTP round-trip.
+func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry, error) {
+	if c.v != nil {
+		if mgr := c.v.CXOSubMgr(); mgr != nil {
+			mgr.AcquireFor(TabCLITransports)
+			defer mgr.ReleaseFor(TabCLITransports)
+			body, _, ok := mgr.Get(FeedTPDAllTransports, tpdapi.AllTransportsPathWithoutSelf)
+			if ok && len(body) > 0 {
+				var entries []*transport.Entry
+				if err := json.Unmarshal(body, &entries); err == nil {
+					return entries, nil
+				}
+				// Unmarshal failure: most likely a schema drift between
+				// publisher and subscriber binaries — let HTTP serve so
+				// the caller still gets a usable answer.
+			}
+		}
+	}
+	return c.DiscoveryClient.GetAllTransports(ctx)
+}
+
+// wrapDiscoveryClientWithCXO returns a CXO-aware wrapper around dc.
+// Returns dc unchanged when v is nil (shouldn't happen in production
+// but keeps the helper safe for tests that pass a bare DC).
+func wrapDiscoveryClientWithCXO(dc transport.DiscoveryClient, v *Visor) transport.DiscoveryClient {
+	if v == nil || dc == nil {
+		return dc
+	}
+	return &cxoAwareTPD{DiscoveryClient: dc, v: v}
+}

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -387,9 +387,14 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		arLimit = v.conf.Transport.ARTransportLimit
 	}
 	tpMConf := transport.ManagerConfig{
-		PubKey:                    v.conf.PK,
-		SecKey:                    v.conf.SK,
-		DiscoveryClient:           tpdC,
+		PubKey: v.conf.PK,
+		SecKey: v.conf.SK,
+		// Wrap the HTTP-backed discovery client so GetAllTransports
+		// reads the CXO tpd-all-transports snapshot first, falling
+		// back to HTTP on miss. The bulk-fetch path is what
+		// calculateLocalRoutes / autoconnect / hvui burn round-trips
+		// on; per-edge lookups keep going to HTTP.
+		DiscoveryClient:           wrapDiscoveryClientWithCXO(tpdC, v),
 		LogStore:                  logS,
 		PersistentTransportsCache: pTps,
 		Version:                   buildinfo.Version(),


### PR DESCRIPTION
## Summary

Completes the CXO cache wiring saga for `tpd-all-transports`. Subscriber-side correctness landed in #2769, publisher-side bootstrap landed in #2771, and the dead in-memory `tpdCache` field was removed in #2772. This PR wires `pkg/router/router_dial.go:calculateLocalRoutes` and the other consumers of `DiscoveryClient.GetAllTransports` to consult the CXO snapshot before falling back to HTTP.

## Why

`calculateLocalRoutes` calls `dc.GetAllTransports(ctx)` on every `DialRoutes`. That's a TPD HTTP (or DMSG-HTTP) round-trip per dial — fine for a CLI invocation, expensive when mux-bw / autoconnect / hvui-route-calc / the gRPC `calcMemStore` are doing it in a tight loop. The CXOSubscriptionManager already holds the full network-state snapshot (~6589 transports / ~3 MB resident, refreshed on the manager's 5min cycle while the feed is held) — and post-#2769+#2771 it's actually populated end-to-end. Consult it before HTTP.

## Mechanism

`pkg/visor/cxo_transport_discovery.go` introduces `cxoAwareTPD`:

```go
type cxoAwareTPD struct {
    transport.DiscoveryClient // embedded — all other methods pass through unchanged
    v *Visor
}

func (c *cxoAwareTPD) GetAllTransports(ctx context.Context) ([]*transport.Entry, error) {
    if mgr := c.v.CXOSubMgr(); mgr != nil {
        mgr.AcquireFor(TabCLITransports)
        defer mgr.ReleaseFor(TabCLITransports)
        body, _, ok := mgr.Get(FeedTPDAllTransports, tpdapi.AllTransportsPathWithoutSelf)
        if ok && len(body) > 0 {
            var entries []*transport.Entry
            if err := json.Unmarshal(body, &entries); err == nil {
                return entries, nil
            }
        }
    }
    return c.DiscoveryClient.GetAllTransports(ctx)
}
```

Embed-and-override means only the bulk-fetch path benefits — per-edge lookups, registers, deletes, stats all keep going to HTTP. A stale per-edge answer can produce route-setup failures that don't self-correct, so deliberately *not* generalized.

`AcquireFor` + `ReleaseFor` per call keeps the cycle alive across bursts via `cxoTabCloseGrace` (10s) — a route-calc storm reuses one live cycle instead of re-tearing-down between dials.

JSON unmarshal failure on the cached body falls through to HTTP so a publisher/subscriber schema drift doesn't blackhole the caller.

## Wired in

`init_transport.go` where `transport.ManagerConfig` is built — `wrapDiscoveryClientWithCXO(tpdC, v)` replaces the bare `tpdC`. The helper returns the input unchanged when `v` is nil so existing test fixtures that pass a bare DC stay untouched.

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/visor/...` passes
- [x] Live verification on Alpha's visor: post-restart `cli visor cxo refresh tpd-all-transports` shows `paths=2 cache=2 bytes=2892354 last_sync=0s ago`. Subsequent `cli tp ls` returns the full network transport list. No new errors in visor log.
- [ ] Operational follow-up: post-deploy, autoconnect log lines for "fetched N transports" should now be near-instant rather than dependent on HTTP latency.

## Related

- #2769 — HasPrefix subscriber-side filter fix
- #2771 — SD + DMSGD publisher pre-warm
- #2772 — remove dead `tpdCache` field this PR effectively supersedes
- Task #136