### PR TITLE
fix(router): retry with different intermediate on id_reservation dial failure

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -140,6 +140,17 @@ func (r *router) DialRoutes(
 			// intermediate's breaker counter ticks on this failure too,
 			// so repeated failures eventually short-circuit it via
 			// AllowIntermediate.
+			//
+			// We exclude only the SINGLE intermediate identified by the
+			// DialError's PK per attempt — not the entire failed path.
+			// id_reservation hops sequentially and fails fast on the
+			// first unreachable peer, so the DialError's PK pinpoints
+			// the actual blocker. Excluding the rest of the path's
+			// intermediates would over-narrow the route-finder's
+			// candidate set on multi-hop paths where ALL intermediates
+			// except one might be healthy. If the next pick happens to
+			// reuse one of those still-healthy intermediates, that's a
+			// feature: cheap path through a known-good node.
 			if failedPK, ok := extractFailedIntermediatePK(err, lPK, rPK); ok {
 				opts = appendExcludeIntermediate(opts, failedPK)
 				log.WithError(err).Warnf("Route setup failed on intermediate %s (attempt %d/%d); excluding from next route-finder pick",
@@ -1152,6 +1163,13 @@ func extractFailedIntermediatePK(err error, src, dst cipher.PubKey) (cipher.PubK
 // with pk added to ExcludeIntermediatePKs. Returns opts unchanged when
 // pk is already in the slice (idempotent: re-failure of the same
 // intermediate within a single retry cycle won't compound).
+//
+// MUTATES opts when opts is non-nil — ExcludeIntermediatePKs is grown
+// in place via append. Callers that need to preserve the original opts
+// must clone before calling. The current call sites (DialRoutes /
+// PingRoute retry loops) operate on a single opts value across
+// iterations and intentionally want the in-place mutation: carrying
+// excluded PKs forward to the next iteration IS the point.
 //
 // opts is guaranteed non-nil on return so the caller can pass it
 // straight back into fetchBestRoutes without a nil check.

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -131,6 +131,20 @@ func (r *router) DialRoutes(
 
 		rules, connectedNode, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, req)
 		if err != nil {
+			// On dial failure, attribute to the intermediate that broke
+			// id_reservation and exclude it from the NEXT fetchBestRoutes
+			// pick. The router.DialError carries the PK that failed.
+			// Source / destination PKs are excluded from the exclude-set
+			// (the dst can't be subbed out, and src failures are local).
+			// This composes with #2750's per-intermediate breaker: the
+			// intermediate's breaker counter ticks on this failure too,
+			// so repeated failures eventually short-circuit it via
+			// AllowIntermediate.
+			if failedPK, ok := extractFailedIntermediatePK(err, lPK, rPK); ok {
+				opts = appendExcludeIntermediate(opts, failedPK)
+				log.WithError(err).Warnf("Route setup failed on intermediate %s (attempt %d/%d); excluding from next route-finder pick",
+					failedPK, attempt, maxRetries)
+			}
 			if attempt < maxRetries {
 				log.WithError(err).Warnf("Route setup failed (attempt %d/%d), retrying with fresh route...", attempt, maxRetries)
 				continue
@@ -362,6 +376,16 @@ func (r *router) PingRoute(
 		conn, err := r.setupPingRoute(ctx, forwardDesc, forwardPath, reversePath, rPK, opts)
 		if err != nil {
 			lastErr = err
+			// Same retry-with-exclude pattern as DialRoutes — see the
+			// note there for the composition with #2750's per-intermediate
+			// breaker. The intermediate identified here gets added to
+			// opts.ExcludeIntermediatePKs so fetchBestRoutes' next
+			// pickDisjointPath call avoids it.
+			if failedPK, ok := extractFailedIntermediatePK(err, lPK, rPK); ok {
+				opts = appendExcludeIntermediate(opts, failedPK)
+				log.WithError(err).Warnf("Ping route setup failed on intermediate %s (attempt %d/%d); excluding from next route-finder pick",
+					failedPK, attempt, maxRetries)
+			}
 			if attempt < maxRetries {
 				log.WithError(err).Warnf("Ping route setup failed (attempt %d/%d), retrying...", attempt, maxRetries)
 				continue
@@ -1094,4 +1118,52 @@ func intermediatesOfRouteGroup(nrg *NoiseRouteGroup, src, dst cipher.PubKey) []c
 		}
 	}
 	return out
+}
+
+// extractFailedIntermediatePK walks an error chain looking for a
+// router.DialError and returns its PK if and only if the PK is an
+// INTERMEDIATE (i.e., neither the local source nor the remote
+// destination). Returns (PK, true) on a real intermediate failure;
+// (zero, false) otherwise.
+//
+// Used by the DialRoutes / PingRoute retry loops to remember which
+// intermediates have just failed during id_reservation so the next
+// fetchBestRoutes call can route around them via the existing
+// ExcludeIntermediatePKs filter (#2746) without a second route-finder
+// candidate-selection algorithm. Composes with #2750's per-intermediate
+// breaker — that fix tracks repeated failures across calls; this fix
+// handles fast within-call fallback.
+func extractFailedIntermediatePK(err error, src, dst cipher.PubKey) (cipher.PubKey, bool) {
+	if err == nil {
+		return cipher.PubKey{}, false
+	}
+	var de *DialError
+	if !errors.As(err, &de) {
+		return cipher.PubKey{}, false
+	}
+	failed := de.PK
+	if failed == src || failed == dst {
+		return cipher.PubKey{}, false
+	}
+	return failed, true
+}
+
+// appendExcludeIntermediate returns a (potentially new) DialOptions
+// with pk added to ExcludeIntermediatePKs. Returns opts unchanged when
+// pk is already in the slice (idempotent: re-failure of the same
+// intermediate within a single retry cycle won't compound).
+//
+// opts is guaranteed non-nil on return so the caller can pass it
+// straight back into fetchBestRoutes without a nil check.
+func appendExcludeIntermediate(opts *DialOptions, pk cipher.PubKey) *DialOptions {
+	if opts == nil {
+		opts = DefaultDialOptions()
+	}
+	for _, existing := range opts.ExcludeIntermediatePKs {
+		if existing == pk {
+			return opts
+		}
+	}
+	opts.ExcludeIntermediatePKs = append(opts.ExcludeIntermediatePKs, pk)
+	return opts
 }

--- a/pkg/router/router_dial_retry_test.go
+++ b/pkg/router/router_dial_retry_test.go
@@ -73,15 +73,15 @@ func TestExtractFailedIntermediatePK_DialErrorAtSrc(t *testing.T) {
 func TestExtractFailedIntermediatePK_DialErrorAtIntermediate(t *testing.T) {
 	src := mustPK(t)
 	dst := mustPK(t)
-	interm := mustPK(t)
+	intermediate := mustPK(t)
 
-	err := &DialError{PK: interm, Err: errors.New("connection is shut down")}
+	err := &DialError{PK: intermediate, Err: errors.New("connection is shut down")}
 	gotPK, ok := extractFailedIntermediatePK(err, src, dst)
 	if !ok {
 		t.Fatalf("intermediate DialError: ok=false, want true")
 	}
-	if gotPK != interm {
-		t.Errorf("intermediate DialError: pk=%v, want %v", gotPK, interm)
+	if gotPK != intermediate {
+		t.Errorf("intermediate DialError: pk=%v, want %v", gotPK, intermediate)
 	}
 }
 
@@ -91,9 +91,9 @@ func TestExtractFailedIntermediatePK_WrappedDialError(t *testing.T) {
 	// the DialError via errors.As regardless of depth.
 	src := mustPK(t)
 	dst := mustPK(t)
-	interm := mustPK(t)
+	intermediate := mustPK(t)
 
-	dialErr := &DialError{PK: interm, Err: errors.New("connection is shut down")}
+	dialErr := &DialError{PK: intermediate, Err: errors.New("connection is shut down")}
 	wrapped := fmt.Errorf("route setup: failed to reserve route ids: %w", dialErr)
 	wrappedTwice := fmt.Errorf("Dial: %w", wrapped)
 
@@ -101,8 +101,8 @@ func TestExtractFailedIntermediatePK_WrappedDialError(t *testing.T) {
 	if !ok {
 		t.Fatalf("wrapped DialError: ok=false, want true")
 	}
-	if gotPK != interm {
-		t.Errorf("wrapped DialError: pk=%v, want %v", gotPK, interm)
+	if gotPK != intermediate {
+		t.Errorf("wrapped DialError: pk=%v, want %v", gotPK, intermediate)
 	}
 }
 

--- a/pkg/router/router_dial_retry_test.go
+++ b/pkg/router/router_dial_retry_test.go
@@ -1,0 +1,143 @@
+// router_dial_retry_test.go — unit tests for the dial-failure retry
+// helpers added to compose with #2746 (ExcludeIntermediatePKs) and
+// #2750 (per-intermediate breaker). When the setup-node returns a
+// DialError on a multi-hop attempt, DialRoutes / PingRoute extract
+// the failed intermediate's PK and add it to opts.ExcludeIntermediatePKs
+// so the next fetchBestRoutes iteration picks a different candidate
+// from the route-finder's slice. The helpers below are pure, so
+// covering them in isolation lets the integration retry loop stay
+// simple — caller doesn't have to re-derive the "is it src/dst"
+// check or worry about idempotency.
+
+package router
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestExtractFailedIntermediatePK_NoError(t *testing.T) {
+	pk, ok := extractFailedIntermediatePK(nil, cipher.PubKey{}, cipher.PubKey{})
+	if ok {
+		t.Errorf("nil err: ok=true, want false")
+	}
+	if !pk.Null() {
+		t.Errorf("nil err: pk=%v, want zero", pk)
+	}
+}
+
+func TestExtractFailedIntermediatePK_NonDialError(t *testing.T) {
+	// A plain error wrapped without DialError. The walker can't
+	// identify an intermediate to blame, so we get (zero, false).
+	err := fmt.Errorf("some other failure: %w", errors.New("inner"))
+	pk, ok := extractFailedIntermediatePK(err, mustPK(t), mustPK(t))
+	if ok {
+		t.Errorf("non-DialError: ok=true, want false")
+	}
+	if !pk.Null() {
+		t.Errorf("non-DialError: pk=%v, want zero", pk)
+	}
+}
+
+func TestExtractFailedIntermediatePK_DialErrorAtSrc(t *testing.T) {
+	// If the dial failure was the source visor itself (e.g. a local
+	// dmsg-session hiccup), we MUST NOT exclude src from the next
+	// candidate — there's nothing to substitute. Same for dst (the
+	// hypothesis test would be vacuous; the operator demanded the
+	// route TO this specific dst).
+	src := mustPK(t)
+	dst := mustPK(t)
+	for _, who := range []struct {
+		name string
+		pk   cipher.PubKey
+	}{
+		{"src", src},
+		{"dst", dst},
+	} {
+		t.Run(who.name, func(t *testing.T) {
+			err := &DialError{PK: who.pk, Err: errors.New("dmsg error 202")}
+			gotPK, ok := extractFailedIntermediatePK(err, src, dst)
+			if ok {
+				t.Errorf("DialError on %s: ok=true, want false (endpoint)", who.name)
+			}
+			if !gotPK.Null() {
+				t.Errorf("DialError on %s: pk=%v, want zero", who.name, gotPK)
+			}
+		})
+	}
+}
+
+func TestExtractFailedIntermediatePK_DialErrorAtIntermediate(t *testing.T) {
+	src := mustPK(t)
+	dst := mustPK(t)
+	interm := mustPK(t)
+
+	err := &DialError{PK: interm, Err: errors.New("connection is shut down")}
+	gotPK, ok := extractFailedIntermediatePK(err, src, dst)
+	if !ok {
+		t.Fatalf("intermediate DialError: ok=false, want true")
+	}
+	if gotPK != interm {
+		t.Errorf("intermediate DialError: pk=%v, want %v", gotPK, interm)
+	}
+}
+
+func TestExtractFailedIntermediatePK_WrappedDialError(t *testing.T) {
+	// Real error chain from the setup-node: DialError wrapped a few
+	// layers deep inside fmt.Errorf("...: %w", err). Walker must find
+	// the DialError via errors.As regardless of depth.
+	src := mustPK(t)
+	dst := mustPK(t)
+	interm := mustPK(t)
+
+	dialErr := &DialError{PK: interm, Err: errors.New("connection is shut down")}
+	wrapped := fmt.Errorf("route setup: failed to reserve route ids: %w", dialErr)
+	wrappedTwice := fmt.Errorf("Dial: %w", wrapped)
+
+	gotPK, ok := extractFailedIntermediatePK(wrappedTwice, src, dst)
+	if !ok {
+		t.Fatalf("wrapped DialError: ok=false, want true")
+	}
+	if gotPK != interm {
+		t.Errorf("wrapped DialError: pk=%v, want %v", gotPK, interm)
+	}
+}
+
+func TestAppendExcludeIntermediate_NilOpts(t *testing.T) {
+	pk := mustPK(t)
+	opts := appendExcludeIntermediate(nil, pk)
+	if opts == nil {
+		t.Fatal("nil opts: returned nil; want non-nil")
+	}
+	if len(opts.ExcludeIntermediatePKs) != 1 || opts.ExcludeIntermediatePKs[0] != pk {
+		t.Errorf("nil opts: ExcludeIntermediatePKs=%v, want [%v]", opts.ExcludeIntermediatePKs, pk)
+	}
+}
+
+func TestAppendExcludeIntermediate_AppendsNew(t *testing.T) {
+	first := mustPK(t)
+	second := mustPK(t)
+	opts := &DialOptions{ExcludeIntermediatePKs: []cipher.PubKey{first}}
+	opts = appendExcludeIntermediate(opts, second)
+	if len(opts.ExcludeIntermediatePKs) != 2 {
+		t.Fatalf("len=%d, want 2", len(opts.ExcludeIntermediatePKs))
+	}
+	if opts.ExcludeIntermediatePKs[1] != second {
+		t.Errorf("second pk=%v, want %v", opts.ExcludeIntermediatePKs[1], second)
+	}
+}
+
+func TestAppendExcludeIntermediate_Idempotent(t *testing.T) {
+	// Same intermediate failing twice within a retry cycle (transient
+	// flake during the burst): the dedup ensures the exclude list
+	// doesn't grow unbounded across retries.
+	pk := mustPK(t)
+	opts := &DialOptions{ExcludeIntermediatePKs: []cipher.PubKey{pk}}
+	opts = appendExcludeIntermediate(opts, pk)
+	if len(opts.ExcludeIntermediatePKs) != 1 {
+		t.Errorf("after re-add: len=%d, want 1 (dedup)", len(opts.ExcludeIntermediatePKs))
+	}
+}


### PR DESCRIPTION
## Summary

When the route-finder returns a candidate whose intermediate visor's transport conn is dead, `DialRoutes` / `PingRoute` used to fail the entire dial. The next retry attempt's `fetchBestRoutes` would return the same candidate (route-finder cache + `pickDisjointPath`'s deterministic "take paths[0]" behavior), so the operator's `--routes N --min-hops 2` test produced **zero bytes** across every run as soon as the first intermediate the route-finder picked was unhealthy.

This was the dominant blocker for the mux>direct hypothesis test on 2026-05-23 — both Beta's and my empirical sweeps showed 0 bytes for every N≥1 `--min-hops 2` while direct N=1 hit 17-25 MB/s.

## Fix

When the dial returns a `router.DialError` carrying the PK of the intermediate that broke `id_reservation`, add that PK to `opts.ExcludeIntermediatePKs` before the next retry iteration. The existing `fetchBestRoutes → pickDisjointPath` path already honors the exclude set (added in #2746 for disjoint-mux); reusing the same mechanism for the retry case keeps the surface small.

```go
if failedPK, ok := extractFailedIntermediatePK(err, lPK, rPK); ok {
    opts = appendExcludeIntermediate(opts, failedPK)
}
```

Cycle: dial fails on intermediate X → `opts.ExcludeIntermediatePKs` gains X → next `fetchBestRoutes` call has `pickDisjointPath` iterate the route-finder's slice (server returns up to `maxNumberOfRoutes = 3` candidates per direction) and pick the first whose intermediate isn't X. On exhaustion, local route calc is the existing fallback.

## Composition

- **#2746** (ExcludeIntermediatePKs / disjoint-mux): the exclude-set filter mechanism itself
- **#2750** (per-intermediate breaker): handles slow *across-call* attribution so repeated bad picks eventually short-circuit via `AllowIntermediate` without going through the candidate list each time. This PR handles fast *within-call* fallback.

Source/destination PKs are explicitly excluded from the exclude set:
- src failure is a local visor hiccup (no substitute possible)
- dst failure means the operator's specific target visor is unreachable; the dial should surface that, not chase alternatives

## Helpers

- `extractFailedIntermediatePK(err, src, dst)` — `errors.As` the chain to find a `*DialError`, returns the embedded PK if it's neither src nor dst. Pure function; unit-testable without router wiring.
- `appendExcludeIntermediate(opts, pk)` — idempotent append (dedups within a single retry cycle). Returns non-nil opts so the caller can pass it straight back to `fetchBestRoutes`.

## Tests (`pkg/router/router_dial_retry_test.go`)

8 subtests:
- nil err → (zero, false)
- non-DialError chain → (zero, false)
- DialError at src OR dst → (zero, false) — regression guard against substituting the destination
- DialError at intermediate → (pk, true)
- Wrapped DialError 2 layers deep via `fmt.Errorf %w`
- `appendExcludeIntermediate` on nil opts (constructs default)
- `appendExcludeIntermediate` of new PK
- `appendExcludeIntermediate` of duplicate (idempotent)

## Empirical expectation

Post-merge: `cli skynet start --pk peer -r 8090 -l 8091 --routes 4 --min-hops 2` should now successfully establish through whichever of the (up to 3 forward × 3 reverse = 9) route-finder candidate pairs have healthy intermediates, instead of hanging on the first bad pick. Mux>direct hypothesis test becomes empirically runnable.

## Test plan
- [x] `go test ./pkg/router/ -count=1 -short` — pkg/router passes
- [x] `go build ./...` — clean
- [x] `go vet ./pkg/router/...` — clean
- [x] `gofmt -l` — clean
- [ ] CI lanes (linux, darwin, windows, nix)
- [ ] Post-merge: re-fire `cli skynet start --routes 4 --min-hops 2` from Beta to Gamma; verify 4 routes establish (likely via different intermediates) and >0 bytes pump through