### PR TITLE
fix(cli/config): applyFlagsToConf handles bash-array flags (HYPERVISORPKS et al)

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -2015,6 +2015,25 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 		"reward":  "REWARDSKYADDR",
 	}
 
+	// Array-shaped flags map to bash-array env vars of the form
+	// KEY=('a' 'b' 'c'). Values come in comma-separated form from the
+	// CLI (`--hvpks PK1,PK2`); we split on comma, trim each entry,
+	// drop empties, and emit the canonical single-quoted-space-joined
+	// bash-array form. Mirrors how SkyenvArray decodes the same lines
+	// back out — round-trip safe.
+	arrayFlagToEnv := map[string]string{
+		"hvpks":           "HYPERVISORPKS",
+		"dmsgpty":         "DMSGPTYPKS",
+		"survey":          "SURVEYPKS",
+		"url":             "SVCCONFADDR",
+		"tpsetup":         "TPSETUPPKS",
+		"routesetup":      "ROUTESETUPPKS",
+		"vpnwl":           "VPNSERVERWL",
+		"proxywl":         "PROXYSERVERWL",
+		"skycoinwebnodes": "SKYCOINWEBNODES",
+		"stun":            "STUNSERVERS",
+	}
+
 	lines := strings.Split(conf, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -2035,6 +2054,36 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 					lines[i] = envKey + "='" + val + "'"
 				}
 			}
+		}
+		// Check array flags (bash-array form: KEY=('a' 'b' 'c'))
+		for flagName, envKey := range arrayFlagToEnv {
+			if !cmd.Flags().Changed(flagName) {
+				continue
+			}
+			val, _ := cmd.Flags().GetString(flagName) //nolint:errcheck
+			if val == "" {
+				continue
+			}
+			// Match either the empty template form (#KEY=('')) or a
+			// previously-set non-empty form (#KEY=('foo')) so re-runs
+			// of -q with new flag values overwrite the prior line.
+			commentedKey := "#" + envKey + "="
+			if !strings.HasPrefix(trimmed, commentedKey) {
+				continue
+			}
+			parts := strings.Split(val, ",")
+			out := make([]string, 0, len(parts))
+			for _, p := range parts {
+				p = strings.TrimSpace(p)
+				if p == "" {
+					continue
+				}
+				out = append(out, "'"+p+"'")
+			}
+			if len(out) == 0 {
+				continue
+			}
+			lines[i] = envKey + "=(" + strings.Join(out, " ") + ")"
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/cmd/skywire-cli/commands/config/gen_apply_flags_test.go
+++ b/cmd/skywire-cli/commands/config/gen_apply_flags_test.go
@@ -1,0 +1,226 @@
+// Package cliconfig — applyFlagsToConf unit tests
+//
+// Covers the three flag categories applyFlagsToConf handles:
+//
+//  1. Boolean flags — uncomment lines like `#FLAG=true`.
+//  2. Single-value string flags — uncomment + substitute lines like
+//     `#KEY='oldval'` → `KEY='newval'`.
+//  3. Bash-array flags (the regression this test guards against) —
+//     uncomment + substitute lines of the empty-array template form
+//     into KEY=('a' 'b' 'c'). Pre-fix, only categories 1 and 2 were
+//     handled; an operator running `skywire cli config gen -qpij PK`
+//     got the still-commented HYPERVISORPKS line even though -j was
+//     set, defeating the point of -j.
+package cliconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// makeApplyFlagsCmd builds a minimal *cobra.Command with the same
+// flag bindings applyFlagsToConf inspects. We don't reuse the real
+// genConfigCmd because its PreRun has side effects (filepath resolution,
+// log setup, etc.) we don't want in a unit test.
+func makeApplyFlagsCmd() *cobra.Command {
+	c := &cobra.Command{Use: "fake"}
+	// Booleans
+	for _, name := range []string{"pkg", "ishv", "testenv", "dmsghttp", "public", "servevpn", "autoconn", "publicip"} {
+		c.Flags().Bool(name, false, "")
+	}
+	// Single-value strings
+	for _, name := range []string{"cliaddr", "hvaddr", "timeout", "reward"} {
+		c.Flags().String(name, "", "")
+	}
+	// Array-shaped (comma-separated)
+	for _, name := range []string{"hvpks", "dmsgpty", "survey", "url", "tpsetup", "routesetup", "vpnwl", "proxywl", "skycoinwebnodes", "stun"} {
+		c.Flags().String(name, "", "")
+	}
+	return c
+}
+
+func TestApplyFlagsToConf_ArrayFlag_HypervisorPKs_SinglePK(t *testing.T) {
+	// The bug case the operator reported: `-qpij PK` should
+	// uncomment HYPERVISORPKS in the rendered template.
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("hvpks", "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+
+	in := "#--	Set remote hypervisor public keys\n#HYPERVISORPKS=('')\n"
+	got := applyFlagsToConf(in, cmd)
+
+	want := "HYPERVISORPKS=('0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c')"
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected to contain %q; got:\n%s", want, got)
+	}
+	if strings.Contains(got, "#HYPERVISORPKS=") {
+		t.Fatalf("expected the original commented line to be replaced; got:\n%s", got)
+	}
+}
+
+func TestApplyFlagsToConf_ArrayFlag_HypervisorPKs_MultiplePKs(t *testing.T) {
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("hvpks", "AAA,BBB,CCC"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	in := "#HYPERVISORPKS=('')\n"
+	got := applyFlagsToConf(in, cmd)
+	want := "HYPERVISORPKS=('AAA' 'BBB' 'CCC')"
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected %q; got %q", want, got)
+	}
+}
+
+func TestApplyFlagsToConf_ArrayFlag_TrimsAndDropsEmptyEntries(t *testing.T) {
+	// User typed extra commas or whitespace — should be normalized,
+	// not produce empty array entries.
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("survey", " AAA , , BBB , "); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	in := "#SURVEYPKS=('')\n"
+	got := applyFlagsToConf(in, cmd)
+	want := "SURVEYPKS=('AAA' 'BBB')"
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected %q; got %q", want, got)
+	}
+}
+
+func TestApplyFlagsToConf_ArrayFlag_EmptyValueIsNoOp(t *testing.T) {
+	// Setting to an empty string (or all-whitespace) shouldn't touch
+	// the template — the operator explicitly asked for "no keys".
+	// Leaving the line commented preserves the canonical default.
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("dmsgpty", ""); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	in := "#DMSGPTYPKS=('')\n"
+	got := applyFlagsToConf(in, cmd)
+	if !strings.Contains(got, "#DMSGPTYPKS=('')") {
+		t.Fatalf("expected commented template to be preserved; got:\n%s", got)
+	}
+}
+
+func TestApplyFlagsToConf_ArrayFlag_UnsetFlagIsNoOp(t *testing.T) {
+	// Not calling Flags().Set at all = flag wasn't explicitly set →
+	// must NOT modify the template line. Guards against the
+	// `if val != ""` short-circuit being the only check (which would
+	// trip on flags carrying a default value from scriptExecArray).
+	cmd := makeApplyFlagsCmd()
+	in := "#HYPERVISORPKS=('')\n#DMSGPTYPKS=('')\n"
+	got := applyFlagsToConf(in, cmd)
+	if got != in {
+		t.Fatalf("expected no changes when no array flags set; got:\n%s", got)
+	}
+}
+
+func TestApplyFlagsToConf_ArrayFlag_AllTenFlagsCovered(t *testing.T) {
+	// Sanity check that every array env var present in the canonical
+	// template responds to its flag. If someone adds a new
+	// `#FOO=('')` to envfiles.go but forgets the matching entry in
+	// arrayFlagToEnv, this test won't catch it — but it WILL catch
+	// the inverse (entry added to the map but no template line),
+	// which is the more common refactor mistake.
+	cases := []struct {
+		flag, envKey string
+	}{
+		{"hvpks", "HYPERVISORPKS"},
+		{"dmsgpty", "DMSGPTYPKS"},
+		{"survey", "SURVEYPKS"},
+		{"url", "SVCCONFADDR"},
+		{"tpsetup", "TPSETUPPKS"},
+		{"routesetup", "ROUTESETUPPKS"},
+		{"vpnwl", "VPNSERVERWL"},
+		{"proxywl", "PROXYSERVERWL"},
+		{"skycoinwebnodes", "SKYCOINWEBNODES"},
+		{"stun", "STUNSERVERS"},
+	}
+	for _, c := range cases {
+		t.Run(c.flag, func(t *testing.T) {
+			cmd := makeApplyFlagsCmd()
+			if err := cmd.Flags().Set(c.flag, "X,Y"); err != nil {
+				t.Fatalf("flag set: %v", err)
+			}
+			in := "#" + c.envKey + "=('')\n"
+			got := applyFlagsToConf(in, cmd)
+			want := c.envKey + "=('X' 'Y')"
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected %q; got %q", want, got)
+			}
+		})
+	}
+}
+
+func TestApplyFlagsToConf_BooleanFlag_StillWorks(t *testing.T) {
+	// Regression guard: the array-flag handler runs alongside the
+	// existing boolean handler in the same line loop. Confirm the
+	// boolean path still uncomments correctly.
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("pkg", "true"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	in := "#PKGENV=true\n"
+	got := applyFlagsToConf(in, cmd)
+	if !strings.Contains(got, "\nPKGENV=true") && !strings.HasPrefix(got, "PKGENV=true") {
+		t.Fatalf("expected PKGENV=true uncommented; got %q", got)
+	}
+}
+
+func TestApplyFlagsToConf_ValueFlag_StillWorks(t *testing.T) {
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("cliaddr", "0.0.0.0:3435"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	in := "#CLIADDR=''\n"
+	got := applyFlagsToConf(in, cmd)
+	want := "CLIADDR='0.0.0.0:3435'"
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected %q; got %q", want, got)
+	}
+}
+
+func TestApplyFlagsToConf_MixedFlags(t *testing.T) {
+	// Operator's actual repro: -qpij PK ⇒ -p (pkg, bool),
+	// -i (ishv, bool), -j PK (hvpks, array).
+	cmd := makeApplyFlagsCmd()
+	if err := cmd.Flags().Set("pkg", "true"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	if err := cmd.Flags().Set("ishv", "true"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+	if err := cmd.Flags().Set("hvpks", "PKa,PKb"); err != nil {
+		t.Fatalf("flag set: %v", err)
+	}
+
+	in := strings.Join([]string{
+		"#PKGENV=true",
+		"#ISHYPERVISOR=true",
+		"#HYPERVISORPKS=('')",
+		"",
+	}, "\n")
+	got := applyFlagsToConf(in, cmd)
+
+	for _, want := range []string{
+		"PKGENV=true",
+		"ISHYPERVISOR=true",
+		"HYPERVISORPKS=('PKa' 'PKb')",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output; got:\n%s", want, got)
+		}
+	}
+	// Negative: none of the original commented forms should survive.
+	for _, gone := range []string{
+		"#PKGENV=true",
+		"#ISHYPERVISOR=true",
+		"#HYPERVISORPKS=",
+	} {
+		if strings.Contains(got, gone) {
+			t.Errorf("expected commented form %q to be replaced; got:\n%s", gone, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`skywire cli config gen -qpij <pk>` previously emitted `#HYPERVISORPKS=('')` (still commented, no value) even though `-j` explicitly set the variable. Same gap for every other array-shaped env var in the canonical template — operators using `-q` to generate a template for `/etc/skywire.conf` had to hand-edit every array line after the fact, defeating the point of the flags.

## Repro

```
$ skywire cli config gen -qpij $(skywire cli visor pk) | grep -vE '^$|#'
PKGENV=true
ISHYPERVISOR=true
```

Notice `HYPERVISORPKS=…` is absent. The `-j` value was set on `hypervisorPKs` internally but `applyFlagsToConf` never touched the `#HYPERVISORPKS=('')` template line.

Post-fix:

```
$ skywire cli config gen -qpij $(skywire cli visor pk) | grep -vE '^$|#'
PKGENV=true
HYPERVISORPKS=('0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c')
ISHYPERVISOR=true
```

## Root cause

`applyFlagsToConf` in `cmd/skywire-cli/commands/config/gen.go` had two branches:

1. **Boolean flags** (uncomment `#FLAG=true`): `pkg, ishv, testenv, dmsghttp, public, servevpn, autoconn, publicip`.
2. **Single-value string flags** (uncomment + substitute `#KEY='val'`): `cliaddr, hvaddr, timeout, reward`.

The commented `#KEY=('')` template lines never matched either rule, so array flags silently no-op'd at template-render time.

## Fix

Adds a third branch — `arrayFlagToEnv` covering the 10 array env vars currently in the canonical template:

| flag | env var |
|---|---|
| `-j` / `--hvpks` | `HYPERVISORPKS` |
| `--dmsgpty` | `DMSGPTYPKS` |
| `--survey` | `SURVEYPKS` |
| `-a` / `--url` | `SVCCONFADDR` |
| `--tpsetup` | `TPSETUPPKS` |
| `--routesetup` | `ROUTESETUPPKS` |
| `--vpnwl` | `VPNSERVERWL` |
| `--proxywl` | `PROXYSERVERWL` |
| `--skycoinwebnodes` | `SKYCOINWEBNODES` |
| `--stun` | `STUNSERVERS` |

For each: split the CLI's comma-separated value, trim entries, drop empties, emit `KEY=('a' 'b' 'c')`. Round-trip safe with `pkg/cmdutil.SkyenvArray` (the env-file reader on the other side).

## Test plan

- [x] `go test -count=1 -run TestApplyFlagsToConf ./cmd/skywire-cli/commands/config/...` — 9 subtests covering the operator's exact `-j` repro, multi-PK input, whitespace + empty-entry trimming, unset-flag no-op, empty-value no-op, all 10 array flags reach their template line, regression guard that boolean + value flags still work alongside the new path, and a mixed `-p/-i/-j` scenario.
- [x] `make lint` clean.
- [x] Live verified on a develop visor: `skywire cli config gen -qpij <pk>` now emits the expected `HYPERVISORPKS=(…)` line; multi-PK + other array flags (`--dmsgpty`, `--survey`, `--stun`) all behave the same way.

## Related

Surfaced during a debian-packaging audit. Companion AUR-repo PR will use the env-template generation in postinst (`skywire cli config gen -pqQ /etc/skywire.conf`) instead of shipping `/etc/skywire.conf` directly, removing the dpkg conffile-preservation prompt on `apt upgrade`. That PR depends on this fix landing first so `-j` properly threads HYPERVISORPKS into the generated file.