### PR TITLE
feat(visor/hv): runtime management — rm/--all/passwd CLI, hypervisor section on visor info

### DIFF
--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -35,9 +35,20 @@ func init() {
 	hvDisableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
 	hvCmd.AddCommand(hvStatusCmd)
 	hvCmd.AddCommand(hvAddCmd)
+	hvCmd.AddCommand(hvRmCmd)
+	hvRmCmd.Flags().BoolVar(&hvRmAll, "all", false, "remove every runtime-added hypervisor connection")
 	hvCmd.AddCommand(hvLsCmd)
 	hvCmd.AddCommand(hvTreeCmd)
+	hvCmd.AddCommand(hvPasswdCmd)
+	hvPasswdCmd.Flags().StringVar(&hvPasswdOld, "old", "", "current password (prompts if unset)")
+	hvPasswdCmd.Flags().StringVar(&hvPasswdNew, "new", "", "new password (prompts if unset)")
 }
+
+var (
+	hvRmAll     bool
+	hvPasswdOld string
+	hvPasswdNew string
+)
 
 var hvCmd = &cobra.Command{
 	Use:   "hv",
@@ -194,6 +205,78 @@ via DMSG. Not persisted — use SKYENV HYPERVISORPKS for persistence.`,
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		fmt.Printf("Connected to hypervisor %s\n", pk)
+	},
+}
+
+var hvRmCmd = &cobra.Command{
+	Use:   "rm [public-key]",
+	Short: "Disconnect from a remote hypervisor at runtime",
+	Long: `Tear down a runtime-added hypervisor connection. Mirrors hv add
+— only affects connections created via AddHypervisor (this RPC or
+the corresponding CLI). Config-loaded hypervisors aren't affected;
+edit SKYENV HYPERVISORPKS and restart the visor to remove those.
+
+Pass --all to disconnect every runtime-added hypervisor in one
+call. Without --all, exactly one <public-key> argument is
+required.`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if hvRmAll {
+			if len(args) > 0 {
+				return fmt.Errorf("--all takes no positional arguments")
+			}
+			return nil
+		}
+		if len(args) != 1 {
+			return fmt.Errorf("exactly one <public-key> argument required (or pass --all)")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if hvRmAll {
+			n, err := rpcClient.RemoveAllHypervisors()
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			fmt.Printf("Disconnected from %d runtime-added hypervisor(s)\n", n)
+			return
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid public key: %w", err))
+		}
+		if err := rpcClient.RemoveHypervisor(pk); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("Disconnected from hypervisor %s\n", pk)
+	},
+}
+
+var hvPasswdCmd = &cobra.Command{
+	Use:   "passwd",
+	Short: "Change the hypervisor UI admin password",
+	Long: `Change the password for the hypervisor UI's "admin" account.
+Mirrors the /api/change-password endpoint the UI uses, but without
+the HTTP session check (RPC is local-only and already privileged).
+
+Both --old and --new are required. Use the value-only form (avoid
+shell history capturing the password) by sourcing them from an
+env-var or a process-substitution.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if hvPasswdOld == "" || hvPasswdNew == "" {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("both --old and --new are required"))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.SetHypervisorPassword(hvPasswdOld, hvPasswdNew); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println("Hypervisor UI password updated; all existing sessions invalidated.")
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -160,38 +160,54 @@ var summaryCmd = &cobra.Command{
 			internal.PrintFatalRPCError(cmd.Flags(), err)
 		}
 
+		hvPKs := make([]string, 0, len(summary.Overview.Hypervisors))
+		for _, pk := range summary.Overview.Hypervisors {
+			hvPKs = append(hvPKs, pk.String())
+		}
+		connectedHvPKs := make([]string, 0, len(summary.Overview.ConnectedHypervisor))
+		for _, pk := range summary.Overview.ConnectedHypervisor {
+			connectedHvPKs = append(connectedHvPKs, pk.String())
+		}
 		outputJSON := struct {
-			PublicKey      string                    `json:"public_key"`
-			IsSymmetricNAT bool                      `json:"symmetric_nat"`
-			LocalIP        string                    `json:"local_ip"`
-			PublicIP       string                    `json:"public_ip"`
-			CountryCode    string                    `json:"country_code,omitempty"`
-			RegionName     string                    `json:"region_name,omitempty"`
-			CityName       string                    `json:"city_name,omitempty"`
-			DMSGServers    []visor.DMSGServerInfo    `json:"dmsg_servers"`
-			DmsgLatency    string                    `json:"dmsg_latency"`
-			VisorVersion   string                    `json:"visor_version"`
-			ConfigVersion  string                    `json:"config_version"`
-			UptimeTracker  string                    `json:"uptime_tracker"`
-			TimeOnline     float64                   `json:"time_online"`
-			BuildTag       string                    `json:"build_tag"`
-			ARRegistration *visor.ARSelfRegistration `json:"ar_registration,omitempty"`
+			PublicKey            string                    `json:"public_key"`
+			IsSymmetricNAT       bool                      `json:"symmetric_nat"`
+			LocalIP              string                    `json:"local_ip"`
+			PublicIP             string                    `json:"public_ip"`
+			CountryCode          string                    `json:"country_code,omitempty"`
+			RegionName           string                    `json:"region_name,omitempty"`
+			CityName             string                    `json:"city_name,omitempty"`
+			DMSGServers          []visor.DMSGServerInfo    `json:"dmsg_servers"`
+			DmsgLatency          string                    `json:"dmsg_latency"`
+			VisorVersion         string                    `json:"visor_version"`
+			ConfigVersion        string                    `json:"config_version"`
+			UptimeTracker        string                    `json:"uptime_tracker"`
+			TimeOnline           float64                   `json:"time_online"`
+			BuildTag             string                    `json:"build_tag"`
+			ARRegistration       *visor.ARSelfRegistration `json:"ar_registration,omitempty"`
+			IsHypervisor         bool                      `json:"is_hypervisor"`
+			HypervisorAddr       string                    `json:"hypervisor_addr,omitempty"`
+			Hypervisors          []string                  `json:"hypervisors,omitempty"`
+			ConnectedHypervisors []string                  `json:"connected_hypervisors,omitempty"`
 		}{
-			PublicKey:      summary.Overview.PubKey.String(),
-			IsSymmetricNAT: summary.Overview.IsSymmetricNAT,
-			LocalIP:        summary.Overview.LocalIP,
-			PublicIP:       summary.Overview.PublicIP,
-			CountryCode:    summary.Overview.CountryCode,
-			RegionName:     summary.Overview.RegionName,
-			CityName:       summary.Overview.CityName,
-			DMSGServers:    summary.DMSGServers,
-			DmsgLatency:    summary.DmsgStats.RoundTrip.String(),
-			VisorVersion:   summary.Overview.BuildInfo.Version,
-			ConfigVersion:  summary.ConfigVersion,
-			UptimeTracker:  summary.Health.ServicesHealth,
-			TimeOnline:     summary.Uptime,
-			BuildTag:       summary.BuildTag,
-			ARRegistration: arSelf,
+			PublicKey:            summary.Overview.PubKey.String(),
+			IsSymmetricNAT:       summary.Overview.IsSymmetricNAT,
+			LocalIP:              summary.Overview.LocalIP,
+			PublicIP:             summary.Overview.PublicIP,
+			CountryCode:          summary.Overview.CountryCode,
+			RegionName:           summary.Overview.RegionName,
+			CityName:             summary.Overview.CityName,
+			DMSGServers:          summary.DMSGServers,
+			DmsgLatency:          summary.DmsgStats.RoundTrip.String(),
+			VisorVersion:         summary.Overview.BuildInfo.Version,
+			ConfigVersion:        summary.ConfigVersion,
+			UptimeTracker:        summary.Health.ServicesHealth,
+			TimeOnline:           summary.Uptime,
+			BuildTag:             summary.BuildTag,
+			ARRegistration:       arSelf,
+			IsHypervisor:         summary.IsHypervisor,
+			HypervisorAddr:       summary.HypervisorAddr,
+			Hypervisors:          hvPKs,
+			ConnectedHypervisors: connectedHvPKs,
 		}
 		internal.PrintOutput(cmd.Flags(), outputJSON, msg)
 	},
@@ -789,6 +805,33 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 			}
 		} else {
 			msg += "AR Registration: (none)\n"
+		}
+	}
+
+	// Hypervisor section: (a) whether this visor serves the
+	// hypervisor UI and at what bind address, (b) configured remote
+	// hypervisors from the static config, (c) the runtime-connected
+	// subset. Renders all three so the operator can see both the
+	// declared intent and the live state in one place.
+	if summary.IsHypervisor {
+		if summary.HypervisorAddr != "" {
+			msg += fmt.Sprintf("Hypervisor UI: enabled at %s\n", summary.HypervisorAddr)
+		} else {
+			msg += "Hypervisor UI: enabled\n"
+		}
+	} else {
+		msg += "Hypervisor UI: disabled\n"
+	}
+	if len(summary.Overview.Hypervisors) > 0 {
+		msg += fmt.Sprintf("Remote Hypervisors (configured, %d):\n", len(summary.Overview.Hypervisors))
+		for _, pk := range summary.Overview.Hypervisors {
+			msg += "  " + pk.String() + "\n"
+		}
+	}
+	if len(summary.Overview.ConnectedHypervisor) > 0 {
+		msg += fmt.Sprintf("Remote Hypervisors (connected, %d):\n", len(summary.Overview.ConnectedHypervisor))
+		for _, pk := range summary.Overview.ConnectedHypervisor {
+			msg += "  " + pk.String() + "\n"
 		}
 	}
 

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -298,6 +298,9 @@ type API interface {
 	DmsgReconnect() (int, error)
 	DmsgSetMinSessions(n int) error
 	AddHypervisor(pk cipher.PubKey) error
+	RemoveHypervisor(pk cipher.PubKey) error
+	RemoveAllHypervisors() (int, error)
+	SetHypervisorPassword(oldPassword, newPassword string) error
 	CheckAREntry(pk string) ([]string, error)
 	ARSelfInfo() (*ARSelfRegistration, error)
 	TransportRPCCall(remotePK cipher.PubKey, method string, args json.RawMessage) (json.RawMessage, error)
@@ -451,12 +454,17 @@ type Overview struct {
 
 // Summary provides detailed info including overview and health of the visor.
 type Summary struct {
-	Overview             *Overview                      `json:"overview"`
-	Health               *HealthInfo                    `json:"health"`
-	Uptime               float64                        `json:"uptime"`
-	Routes               []routingRuleResp              `json:"routes"`
-	RouteGroups          []RouteGroupInfo               `json:"route_groups,omitempty"`
-	IsHypervisor         bool                           `json:"is_hypervisor,omitempty"`
+	Overview     *Overview         `json:"overview"`
+	Health       *HealthInfo       `json:"health"`
+	Uptime       float64           `json:"uptime"`
+	Routes       []routingRuleResp `json:"routes"`
+	RouteGroups  []RouteGroupInfo  `json:"route_groups,omitempty"`
+	IsHypervisor bool              `json:"is_hypervisor,omitempty"`
+	// HypervisorAddr is the host:port the hypervisor UI is bound to
+	// when IsHypervisor=true. Empty when this visor isn't hosting a
+	// hypervisor (or when v.conf.Hypervisor is nil). Sourced from
+	// v.conf.Hypervisor.HTTPAddr.
+	HypervisorAddr       string                         `json:"hypervisor_addr,omitempty"`
 	DmsgStats            *dmsgtracker.DmsgClientSummary `json:"dmsg_stats"`
 	ConnectedDmsgServers []string                       `json:"connected_dmsg_servers"` // Deprecated: use DMSGServers instead
 	DMSGServers          []DMSGServerInfo               `json:"dmsg_servers"`           // Connected DMSG servers with latencies

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -42,10 +42,12 @@ func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 		defer func() {
 			v.initLock.Lock()
 			delete(v.connectedHypervisors, hvPK)
+			delete(v.hypervisorCancels, hvPK)
 			v.initLock.Unlock()
 		}()
 		v.initLock.Lock()
 		v.connectedHypervisors[hvPK] = true
+		v.hypervisorCancels[hvPK] = cancel
 		v.initLock.Unlock()
 		ServeRPCClient(ctx, log, v.dmsgC, rpcS, addr, hvErrs)
 	}()
@@ -57,4 +59,54 @@ func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 	})
 
 	return nil
+}
+
+// RemoveHypervisor tears down a runtime-added hypervisor connection by
+// PK. Only succeeds for hypervisors that were added via AddHypervisor
+// — config-loaded hypervisors take a different code path and don't
+// enter v.hypervisorCancels. Idempotent: returns nil if the PK isn't
+// currently a runtime-added hypervisor.
+//
+// The connection's goroutine, on cancel, runs its deferred delete of
+// hvPK from both connectedHypervisors and hypervisorCancels — so by
+// the time RemoveHypervisor returns, the visor's view of "connected
+// hypervisors" no longer includes hvPK.
+func (v *Visor) RemoveHypervisor(hvPK cipher.PubKey) error {
+	v.initLock.Lock()
+	cancel, ok := v.hypervisorCancels[hvPK]
+	v.initLock.Unlock()
+	if !ok {
+		// Not a runtime-added hypervisor (or already removed). Don't
+		// error — operator's intent is satisfied either way.
+		return nil
+	}
+	cancel()
+	return nil
+}
+
+// RemoveAllHypervisors tears down every runtime-added hypervisor
+// connection. Returns the count of hypervisors that were
+// disconnected.
+func (v *Visor) RemoveAllHypervisors() (int, error) {
+	v.initLock.Lock()
+	cancels := make([]context.CancelFunc, 0, len(v.hypervisorCancels))
+	for _, c := range v.hypervisorCancels {
+		cancels = append(cancels, c)
+	}
+	v.initLock.Unlock()
+	for _, c := range cancels {
+		c()
+	}
+	return len(cancels), nil
+}
+
+// SetHypervisorPassword changes the hypervisor UI's "admin" account
+// password. Mirrors the /api/change-password endpoint without the
+// HTTP session check — RPC is local-only and already privileged.
+// Returns an error when this visor isn't hosting a hypervisor.
+func (v *Visor) SetHypervisorPassword(oldPassword, newPassword string) error {
+	if v.hvInstance == nil {
+		return fmt.Errorf("hypervisor not running on this visor")
+	}
+	return v.hvInstance.users.ChangeAdminPassword(oldPassword, newPassword)
 }

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -189,6 +189,10 @@ func (v *Visor) Summary() (*Summary, error) {
 		DmsgStats:            dmsgStatValue,
 		ConnectedDmsgServers: connectedDmsgServers,
 		DMSGServers:          dmsgServers,
+		IsHypervisor:         v.IsHypervisorEnabled(),
+	}
+	if v.conf.Hypervisor != nil {
+		summary.HypervisorAddr = v.conf.Hypervisor.HTTPAddr
 	}
 
 	return summary, nil

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -409,6 +409,40 @@ func (r *RPC) AddHypervisor(in *cipher.PubKey, _ *struct{}) (err error) {
 	return r.visor.AddHypervisor(*in)
 }
 
+// RemoveHypervisor tears down a runtime-added hypervisor connection
+// by PK. Idempotent: succeeds with nil if the PK is not currently a
+// runtime-added hypervisor on this visor (covers double-rm, rm of a
+// config-loaded hypervisor, and rm of an already-disconnected PK).
+func (r *RPC) RemoveHypervisor(in *cipher.PubKey, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "RemoveHypervisor", in)(nil, &err)
+	return r.visor.RemoveHypervisor(*in)
+}
+
+// RemoveAllHypervisors tears down every runtime-added hypervisor
+// connection on this visor. Returns the count disconnected.
+func (r *RPC) RemoveAllHypervisors(_ *struct{}, out *int) (err error) {
+	defer rpcutil.LogCall(r.log, "RemoveAllHypervisors", nil)(out, &err)
+	n, err := r.visor.RemoveAllHypervisors()
+	*out = n
+	return err
+}
+
+// HypervisorPasswordChangeIn carries the old + new password for the
+// hypervisor UI "admin" account. Mirrors the shape of
+// usermanager.ChangePassword and SkychatPasswordChangeIn.
+type HypervisorPasswordChangeIn struct {
+	OldPassword string
+	NewPassword string
+}
+
+// SetHypervisorPassword changes the hypervisor UI admin password.
+// Local-only RPC; the HTTP session check that /api/change-password
+// enforces is intentionally absent here.
+func (r *RPC) SetHypervisorPassword(in *HypervisorPasswordChangeIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetHypervisorPassword", nil)(nil, &err)
+	return r.visor.SetHypervisorPassword(in.OldPassword, in.NewPassword)
+}
+
 type DHTSyncRequest struct {
 	RemotePK string `json:"remote_pk"`
 	Salt     string `json:"salt"`

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1565,6 +1565,27 @@ func (rc *rpcClient) AddHypervisor(pk cipher.PubKey) error {
 	return rc.Call("AddHypervisor", &pk, &struct{}{})
 }
 
+// RemoveHypervisor tears down a runtime-added hypervisor connection.
+func (rc *rpcClient) RemoveHypervisor(pk cipher.PubKey) error {
+	return rc.Call("RemoveHypervisor", &pk, &struct{}{})
+}
+
+// RemoveAllHypervisors tears down every runtime-added hypervisor
+// connection. Returns the count disconnected.
+func (rc *rpcClient) RemoveAllHypervisors() (int, error) {
+	var out int
+	err := rc.Call("RemoveAllHypervisors", &struct{}{}, &out)
+	return out, err
+}
+
+// SetHypervisorPassword changes the hypervisor UI admin password.
+func (rc *rpcClient) SetHypervisorPassword(oldPassword, newPassword string) error {
+	return rc.Call("SetHypervisorPassword", &HypervisorPasswordChangeIn{
+		OldPassword: oldPassword,
+		NewPassword: newPassword,
+	}, &struct{}{})
+}
+
 // DmsgSetMinSessions updates the minimum DMSG session count.
 func (rc *rpcClient) DmsgSetMinSessions(n int) error {
 	return rc.Call("DmsgSetMinSessions", &n, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1510,6 +1510,21 @@ func (mc *mockRPCClient) AddHypervisor(_ cipher.PubKey) error {
 	return nil
 }
 
+// RemoveHypervisor implements API.
+func (mc *mockRPCClient) RemoveHypervisor(_ cipher.PubKey) error {
+	return nil
+}
+
+// RemoveAllHypervisors implements API.
+func (mc *mockRPCClient) RemoveAllHypervisors() (int, error) {
+	return 0, nil
+}
+
+// SetHypervisorPassword implements API.
+func (mc *mockRPCClient) SetHypervisorPassword(string, string) error {
+	return nil
+}
+
 // DmsgSetMinSessions implements API.
 func (mc *mockRPCClient) DmsgSetMinSessions(_ int) error {
 	return nil

--- a/pkg/visor/usermanager/user_manager.go
+++ b/pkg/visor/usermanager/user_manager.go
@@ -332,6 +332,31 @@ func (s *UserManager) Close() error {
 	return s.db.Close()
 }
 
+// ChangeAdminPassword updates the password for the "admin" account
+// without requiring an HTTP session — intended for the local RPC
+// path (skywire cli visor hv passwd) which is already privileged.
+// Verifies the old password before writing the new one, enforces
+// the same checkPasswordFormat rules ChangePassword does, and
+// invalidates every active session for the user so old cookies
+// can't be replayed.
+func (s *UserManager) ChangeAdminPassword(oldPassword, newPassword string) error {
+	user, err := s.db.User("admin")
+	if err != nil {
+		return err
+	}
+	if !user.VerifyPassword(oldPassword) {
+		return ErrBadLogin
+	}
+	if err := user.SetPassword(newPassword); err != nil {
+		return err
+	}
+	if err := s.db.SetUser(*user); err != nil {
+		return err
+	}
+	s.delAllSessionsOfUser(user.Name)
+	return nil
+}
+
 func (s *UserManager) delSession(w http.ResponseWriter, r *http.Request) error {
 	cookie, err := r.Cookie(sessionCookieName)
 	if err != nil {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -150,6 +150,14 @@ type Visor struct {
 	isTransportabilityHealthy *internalHealthInfo
 	remoteVisors              map[cipher.PubKey]Conn // remote hypervisors the visor is attempting to connect to
 	connectedHypervisors      map[cipher.PubKey]bool // remote hypervisors the visor is currently connected to
+	// hypervisorCancels holds the per-hypervisor context.CancelFunc
+	// installed by AddHypervisor, keyed by the remote hypervisor PK.
+	// RemoveHypervisor looks up the cancel func and invokes it; the
+	// goroutine's deferred delete from connectedHypervisors completes
+	// the teardown. Populated only for runtime-added hypervisors
+	// (those that came through AddHypervisor / RPC); config-loaded
+	// hypervisors take a different path that doesn't enter this map.
+	hypervisorCancels map[cipher.PubKey]context.CancelFunc
 
 	// Allowed ports for app connections (legacy — being replaced by forwardedPorts)
 	allowed allowedPortsState
@@ -551,6 +559,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 		isAutoconnectHealthy:      newInternalHealthInfo(),
 		isTransportabilityHealthy: newInternalHealthInfo(),
 		connectedHypervisors:      make(map[cipher.PubKey]bool),
+		hypervisorCancels:         make(map[cipher.PubKey]context.CancelFunc),
 		allowed: allowedPortsState{
 			ports: make(map[int]bool),
 			mu:    new(sync.RWMutex),


### PR DESCRIPTION
## Summary

Closes three operator-facing gaps in hypervisor runtime management for v1.3.54.

| Gap | New surface |
|---|---|
| No way to disconnect a runtime-added hypervisor | `cli visor hv rm <pk>` + `--all` |
| Hypervisor UI password change required the web UI | `cli visor hv passwd --old X --new Y` |
| `cli visor info` didn't show any hypervisor state | New hypervisor section in info output + JSON |

## Live verification

```
$ skywire cli visor info | grep -i hyperv
Hypervisor UI: enabled at :8000

$ skywire cli visor hv --help | grep -E '(rm|passwd)'
  passwd                  Change the hypervisor UI admin password
  rm                      Disconnect from a remote hypervisor at runtime
```

## Implementation

- **`RemoveHypervisor` / `RemoveAllHypervisors`** — per-hypervisor `context.CancelFunc` map (`hypervisorCancels`) populated by `AddHypervisor`, looked up + invoked by remove. The hypervisor goroutine's deferred delete from `connectedHypervisors` + `hypervisorCancels` finishes teardown.
- **`SetHypervisorPassword` / `UserManager.ChangeAdminPassword`** — HTTP-session-free password change for the local RPC path. Mirrors the HTTP handler's verify-then-set-then-delAllSessions flow. RPC is local-only and already privileged so the session check would be redundant.
- **Summary** — `IsHypervisor` + `HypervisorAddr` fields populated from `v.conf.Hypervisor` in `api_visor.go`; rendered as the `Hypervisor UI: enabled at <addr>` line in info output.
- **`cli visor info` hypervisor section** — three sub-blocks: hosting status + addr, configured remote hypervisors, connected remote hypervisors. Empty sub-blocks skipped so non-hypervisor-related visors don't get noise.

## Doesn't address

- **Hypervisor TUI parity** — `cli visor hv tui` doesn't surface the new `rm` / `passwd` commands. Tracked as a follow-up; operator mentioned it as a separate concern.

## Behavior notes

- `hv rm <pk>` is **idempotent**: removing a PK that isn't currently a runtime-added hypervisor succeeds with `Disconnected from hypervisor <pk>`. Avoids the operator-confusion of "rm errored, did it work or not?"
- `hv rm` does **NOT** affect config-loaded hypervisors. Edit `HYPERVISORPKS` in `/etc/skywire.conf` + restart visor for those — same intent as `hv add` not persisting to config.
- `hv passwd` **invalidates every active session** for the admin user. Operators with open hvui sessions will need to log in again with the new password.

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/visor/...` passes
- [x] Live: `cli visor info` shows hypervisor section
- [x] Live: `cli visor hv rm` and `cli visor hv passwd` appear under `cli visor hv --help`
- [ ] Cross-visor: have another agent's visor run `hv add <my-pk>` then verify `hv pk` shows on my side; `hv rm <my-pk>` on theirs verifies disconnect

## Related

Pre-requisite for the operator's inter-visor hypervisor-tree test ahead of the next release. v1.3.54 changelog (#2778) already covers the broader release.