### PR TITLE
fix(hv): dedup hypervisor visor rows in tree-summary local section + surface Hostname

### DIFF
--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -170,6 +170,7 @@ var summaryCmd = &cobra.Command{
 		}
 		outputJSON := struct {
 			PublicKey            string                    `json:"public_key"`
+			Hostname             string                    `json:"hostname,omitempty"`
 			IsSymmetricNAT       bool                      `json:"symmetric_nat"`
 			LocalIP              string                    `json:"local_ip"`
 			PublicIP             string                    `json:"public_ip"`
@@ -190,6 +191,7 @@ var summaryCmd = &cobra.Command{
 			ConnectedHypervisors []string                  `json:"connected_hypervisors,omitempty"`
 		}{
 			PublicKey:            summary.Overview.PubKey.String(),
+			Hostname:             summary.Overview.Hostname,
 			IsSymmetricNAT:       summary.Overview.IsSymmetricNAT,
 			LocalIP:              summary.Overview.LocalIP,
 			PublicIP:             summary.Overview.PublicIP,
@@ -760,8 +762,12 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 		geoStr = strings.Join(parts, ", ")
 	}
 
-	msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\nSymmetric NAT: %t\nLocal IP: %s\nPublic IP: %s\n",
-		summary.Overview.PubKey, summary.Overview.IsSymmetricNAT, summary.Overview.LocalIP, summary.Overview.PublicIP)
+	msg := fmt.Sprintf(".:: Visor Summary ::.\nPublic key: %q\n", summary.Overview.PubKey)
+	if summary.Overview.Hostname != "" {
+		msg += fmt.Sprintf("Hostname: %s\n", summary.Overview.Hostname)
+	}
+	msg += fmt.Sprintf("Symmetric NAT: %t\nLocal IP: %s\nPublic IP: %s\n",
+		summary.Overview.IsSymmetricNAT, summary.Overview.LocalIP, summary.Overview.PublicIP)
 
 	if geoStr != "" {
 		msg += fmt.Sprintf("Location: %s\n", geoStr)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -450,6 +450,14 @@ type Overview struct {
 	Longitude           float64               `json:"longitude,omitempty"`
 	Hypervisors         []cipher.PubKey       `json:"hypervisors"`
 	ConnectedHypervisor []cipher.PubKey       `json:"connected_hypervisor"`
+	// Hostname is the operating-system hostname the visor process
+	// sees at the time of the Overview call. Best-effort:
+	// os.Hostname() failures (sandbox / containerized environments
+	// missing the syscall) yield an empty string rather than
+	// erroring out the whole Overview. Surfaced to operators in the
+	// hypervisor UI as the default label fallback when no explicit
+	// label is set, and shown in `cli visor info`.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // Summary provides detailed info including overview and health of the visor.

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -103,6 +103,16 @@ func (v *Visor) Overview() (*Overview, error) {
 		overview.ConnectedHypervisor = append(overview.ConnectedHypervisor, connectedHV)
 	}
 
+	// Hostname — best-effort. os.Hostname rarely fails, but when it
+	// does (sandbox / containerized envs missing the syscall) we
+	// fall through with Hostname="" rather than failing the whole
+	// Overview. The hvui consumes this for the operator-friendly
+	// label default + per-node info row; CLI surfaces it in the
+	// `cli visor info` Hypervisor section.
+	if h, err := os.Hostname(); err == nil {
+		overview.Hostname = h
+	}
+
 	return overview, nil
 }
 

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -170,6 +170,14 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 		wg.Wait()
 
 		rendered := map[cipher.PubKey]bool{localPK: true}
+		// subHyperPKs collects every hypervisor PK that gets its own
+		// section below the local one. Used to scrub the local
+		// section's visor list — a hypervisor that has its own
+		// section shouldn't ALSO appear as a row in the local
+		// section's table, because the UI tabs render each section
+		// independently and the operator perceives the duplicate
+		// hypervisor row as a bug ("the visor shows twice").
+		subHyperPKs := make(map[cipher.PubKey]struct{}, len(results))
 		for _, sr := range results {
 			if rendered[sr.hyperPK] {
 				continue
@@ -185,6 +193,7 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				}
 				es := sr.err.Error()
 				rendered[sr.hyperPK] = true
+				subHyperPKs[sr.hyperPK] = struct{}{}
 				sections = append(sections, VisorTreeSection{
 					HypervisorPK: sr.hyperPK,
 					ViaChain:     []cipher.PubKey{localPK},
@@ -193,6 +202,7 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				continue
 			}
 			rendered[sr.hyperPK] = true
+			subHyperPKs[sr.hyperPK] = struct{}{}
 			// Project HVVisorEntry → Summary so the UI's existing
 			// table renderer works identically across all sections.
 			// Sub-hypervisor visors don't carry the full Summary
@@ -210,6 +220,29 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				ViaChain:     []cipher.PubKey{localPK},
 				Visors:       visors,
 			})
+		}
+
+		// Scrub the local section: drop any visor row whose PK has
+		// its own subsequent sub-hypervisor section. Without this,
+		// a hypervisor that's both connected to AND served by this
+		// visor shows up in both the local section (as a plain
+		// connected visor) and its own section (as the section's
+		// hypervisor) — duplicate rows from the operator's POV.
+		// Doesn't touch the local hypervisor's own row at index 0
+		// (it's hv.visor.conf.PK, never in subHyperPKs).
+		if len(subHyperPKs) > 0 && len(sections) > 0 {
+			scrubbed := make([]Summary, 0, len(sections[0].Visors))
+			for _, v := range sections[0].Visors {
+				if v.Overview == nil {
+					scrubbed = append(scrubbed, v)
+					continue
+				}
+				if _, isSub := subHyperPKs[v.Overview.PubKey]; isSub {
+					continue
+				}
+				scrubbed = append(scrubbed, v)
+			}
+			sections[0].Visors = scrubbed
 		}
 
 		httputil.WriteJSON(w, r, http.StatusOK, VisorTreeResponse{Sections: sections})


### PR DESCRIPTION
## Summary

Two operator-observed gaps in v1.3.54 hypervisor-UI prep.

### Tree-summary duplicate

`/api/visors-tree-summary` builds one section per hypervisor. Sections dedup by hypervisor PK, but a hypervisor that's both (a) connected to this visor AND (b) running its own hypervisor UI shows up **twice** in the rendered UI: once as a plain row in the local section's visor list, once as the header of its own sub-section. Operator screenshot showed this directly.

Existing intentional "visors replicate across sections" comment is about inner visor lists per section — not about hypervisor rows appearing as plain visors in the OUTER local section.

**Fix:** collect `subHyperPKs` (every `hyperPK` that gets its own sub-section), then scrub `sections[0].Visors` (the local section) of any PK in that set. Doesn't touch the local hypervisor's own row at index 0 — that's `hv.visor.conf.PK`, which is in `rendered` (seeded with `localPK`) and never enters `subHyperPKs`.

### Hostname surfacing

`Overview` gains a `Hostname` field, populated from `os.Hostname()` in `Visor.Overview()`. Best-effort: `os.Hostname()` failures yield `""` rather than erroring the whole Overview. Surfaced in `cli visor info` as a new `Hostname: <name>` line and in the JSON output as `hostname`.

The hypervisor UI consumes this for the operator-friendly **default label** (when no explicit label is set) and the **per-node info row** — that frontend work is a separate PR since it needs `make build-ui` + Angular template changes.

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/visor/...` passes
- [x] Live: `cli visor info` shows `Hostname: node` between PubKey and NAT
- [ ] Cross-visor: another agent runs `hv add <my-pk>`, then their `/api/visors-tree-summary` returns sections without my PK appearing in their local section

## Related

- Companion to #2779 (hv runtime management — rm/--all/passwd/info section).
- Operator's screenshot at 11:18 surfaced both bugs together; hostname surfacing builds toward frontend label-default work.