### PR TITLE
feat(router): rank route candidates by measured per-hop latency

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -652,7 +652,10 @@ func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey,
 	if bestIdx < 0 {
 		return nil, nil, false
 	}
-	return forward[bestIdx], reverse[bestIdx], true
+	// bestIdx is set only by the loop above where 0 <= i < n =
+	// min(len(forward), len(reverse)), so both indexes are in-bounds.
+	// gosec can't track the cross-slice min, hence the explicit nolint.
+	return forward[bestIdx], reverse[bestIdx], true //nolint:gosec
 }
 
 // pathLatencyScore returns the sum of per-hop avg-latency-ms across a

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -555,15 +555,22 @@ fetchRoutesAgain:
 
 	log.Debugf("Found routes Forward: %s. Reverse %s", paths[forward], paths[backward])
 
-	// DisjointMux post-filter: if the caller populated
-	// ExcludeIntermediatePKs (typically the mux loop tracking
-	// intermediates of already-established routes), iterate the
-	// route-finder's response and return the first path whose
-	// intermediates don't overlap with the exclude set. The
-	// route-finder doesn't natively know about this constraint, so
-	// we filter client-side. Source + destination are NOT considered
-	// "intermediates" (they're endpoints).
-	fwdPath, revPath, ok := pickDisjointPath(paths[forward], paths[backward], opts.ExcludeIntermediatePKs)
+	// DisjointMux post-filter + latency ranking: iterate the route-
+	// finder's response and return the path whose intermediates don't
+	// overlap with opts.ExcludeIntermediatePKs AND whose total per-hop
+	// avg latency is lowest among acceptable candidates. The route-
+	// finder service doesn't sort by latency at query time today; the
+	// visor has the same TPD latency data available in-memory (own
+	// transports via tm.GetLatencyStats) + via TPD entries (already
+	// aggregated by pkg/transport-discovery/cxoaggregator from the
+	// CXO telemetry feed). Building the lookup here puts the ranking
+	// in the dial hot path with no extra round-trip cost — local-
+	// transport latency is a constant-time map read; non-local hops
+	// fall back to GetTransport's cached entry. Pass-through when
+	// the route-finder returned a single candidate (lookup is built
+	// but never iterated).
+	latencyFor := r.buildLatencyLookup(ctx, paths[forward], paths[backward])
+	fwdPath, revPath, ok := pickDisjointPath(paths[forward], paths[backward], opts.ExcludeIntermediatePKs, latencyFor)
 	if !ok {
 		log.Debugf("No route-finder path avoids the %d excluded intermediates; trying local route calc fallback", len(opts.ExcludeIntermediatePKs))
 		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, src, dst, opts)
@@ -576,19 +583,39 @@ fetchRoutesAgain:
 }
 
 // pickDisjointPath walks the parallel forward/reverse-path slices the
-// route-finder returned (paired by index) and returns the first
+// route-finder returned (paired by index) and returns the
 // forward/reverse pair whose intermediate hops do not contain any PK
-// in exclude. When exclude is empty (the common single-route case),
-// returns paths[0]. ok=false means every candidate touched the
-// exclude set — the caller should fall back to local route calc or
-// surface ErrNoRouteFound.
-func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey) ([]routing.Hop, []routing.Hop, bool) {
+// in exclude AND whose total measured latency is lowest.
+//
+// latencyFor is a per-TpID latency lookup (avg-ms; 0 = unknown). Pairs
+// containing any unknown-latency hop are still considered, but unknown
+// hops are treated as a high cost so KNOWN-good paths are preferred
+// when available. Pass nil to disable latency ranking (legacy
+// first-acceptable behavior).
+//
+// When exclude is empty AND latencyFor is nil: returns paths[0] (the
+// pre-existing hot-path single-route behavior — back-compat).
+//
+// ok=false means every candidate touched the exclude set — the caller
+// should fall back to local route calc or surface ErrNoRouteFound.
+//
+// Rationale for ranking by latency: prior to this, the route-finder's
+// first-returned candidate was selected even when alternative
+// candidates had measurably better RTT. The empirical 2026-05-23
+// bilateral ss-tinp capture showed a route-finder pick going through a
+// geo-distant Indonesia intermediate (cwnd:2 ssthresh:2 10-18% retx)
+// while a much healthier candidate was available in the same response
+// — TPD already carries that latency signal end-to-end via the CXO
+// telemetry feed and aggregator (pkg/transport-discovery/cxoaggregator).
+// Visor-side ranking on top of the existing data closes the loop.
+func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey, latencyFor func(uuid.UUID) float64) ([]routing.Hop, []routing.Hop, bool) {
 	if len(forward) == 0 || len(reverse) == 0 {
 		return nil, nil, false
 	}
-	if len(exclude) == 0 {
-		// Hot path: no constraint, keep the existing first-element
-		// behavior so back-compat single-route callers are unaffected.
+	if len(exclude) == 0 && latencyFor == nil {
+		// Hot path: no constraint, no ranker. Preserve the original
+		// first-element behavior so back-compat single-route callers
+		// are unaffected (tests that don't pass a latencyFor).
 		return forward[0], reverse[0], true
 	}
 	excludeSet := make(map[cipher.PubKey]struct{}, len(exclude))
@@ -601,13 +628,110 @@ func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey)
 	if len(reverse) < n {
 		n = len(reverse)
 	}
+	// Collect acceptable candidates (passing the disjointness check),
+	// then pick the lowest-latency pair. When latencyFor is nil OR
+	// every candidate has fully-unknown latency, ties resolve to the
+	// first-encountered candidate — the legacy behavior.
+	bestIdx := -1
+	bestScore := 0.0
 	for i := 0; i < n; i++ {
-		if !pathTouchesIntermediate(forward[i], excludeSet) &&
-			!pathTouchesIntermediate(reverse[i], excludeSet) {
+		if pathTouchesIntermediate(forward[i], excludeSet) ||
+			pathTouchesIntermediate(reverse[i], excludeSet) {
+			continue
+		}
+		if latencyFor == nil {
+			// No ranker — first acceptable wins.
 			return forward[i], reverse[i], true
 		}
+		score := pathLatencyScore(forward[i], latencyFor) + pathLatencyScore(reverse[i], latencyFor)
+		if bestIdx < 0 || score < bestScore {
+			bestIdx = i
+			bestScore = score
+		}
 	}
-	return nil, nil, false
+	if bestIdx < 0 {
+		return nil, nil, false
+	}
+	return forward[bestIdx], reverse[bestIdx], true
+}
+
+// pathLatencyScore returns the sum of per-hop avg-latency-ms across a
+// path, treating unknown latencies (latencyFor returning 0) as a high
+// cost so paths with measured latency outrank paths with no signal at
+// all. The penalty (unknownLatencyCostMs) is set above the practical
+// upper bound of healthy single-hop latency — currently 1000ms — so a
+// single unknown hop already loses to a known 500ms hop, but a path
+// composed entirely of unknown hops is still preferred over no path.
+func pathLatencyScore(path []routing.Hop, latencyFor func(uuid.UUID) float64) float64 {
+	const unknownLatencyCostMs = 1000.0
+	var total float64
+	for _, h := range path {
+		ms := latencyFor(h.TpID)
+		if ms <= 0 {
+			total += unknownLatencyCostMs
+			continue
+		}
+		total += ms
+	}
+	return total
+}
+
+// buildLatencyLookup constructs a TpID → avg-latency-ms lookup over
+// the union of TpIDs appearing in fwd and rev path candidates.
+// Sources, in preference order:
+//
+//  1. Local transport manager — `tm.GetLatencyStats().Avg` for any
+//     transport this visor holds. Constant-time map read; reflects the
+//     freshest measured RSN-ping value, including transports that
+//     haven't yet propagated to TPD.
+//  2. TPD `GetTransport(tpID)` — entries the local visor doesn't own
+//     (the intermediate-to-intermediate hops). Latency hydrated by
+//     pkg/transport-discovery/cxoaggregator from the per-visor CXO
+//     telemetry feed.
+//
+// Returns a closure rather than a map so the caller pays for lookups
+// only for hops actually visited during ranking; the candidate slice
+// is typically 2-3 paths × ≤6 hops = small.
+func (r *router) buildLatencyLookup(ctx context.Context, fwd, rev [][]routing.Hop) func(uuid.UUID) float64 {
+	// Single dial's candidate set is small — collect unique TpIDs first
+	// so we don't double-fetch when an intermediate appears in both
+	// forward and reverse paths.
+	unique := make(map[uuid.UUID]struct{})
+	for _, paths := range [][][]routing.Hop{fwd, rev} {
+		for _, p := range paths {
+			for _, h := range p {
+				unique[h.TpID] = struct{}{}
+			}
+		}
+	}
+	cache := make(map[uuid.UUID]float64, len(unique))
+	for id := range unique {
+		// Local transport first — freshest signal, no TPD round-trip.
+		if r.tm != nil {
+			if tp := r.tm.Transport(id); tp != nil {
+				if stats := tp.GetLatencyStats(); stats.Avg > 0 {
+					cache[id] = stats.Avg
+					continue
+				}
+			}
+		}
+		// Fall through to TPD: hydrated latency from the CXO aggregator.
+		// Errors are logged at debug and treated as unknown — ranker's
+		// unknownLatencyCostMs penalty handles missing data.
+		if r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil {
+			entry, err := r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, id)
+			if err != nil {
+				r.logger.WithError(err).Debugf("buildLatencyLookup: GetTransportByID failed for %s — treating as unknown latency", id)
+				continue
+			}
+			if entry != nil && entry.Latency > 0 {
+				cache[id] = entry.Latency
+			}
+		}
+	}
+	return func(id uuid.UUID) float64 {
+		return cache[id]
+	}
 }
 
 // pathTouchesIntermediate reports whether route hops contain any PK
@@ -885,14 +1009,34 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	// once and the BFS stays linear in graph size.
 	expandedAtDepth := make(map[cipher.PubKey]map[int]bool)
 
+	// Per-TpID latency lookup over the entries we just fetched —
+	// hydrated by the CXO telemetry aggregator on TPD's side. Used to
+	// rank multiple same-level dst-hits below.
+	tpLatencyMs := make(map[uuid.UUID]float64)
+	for _, entry := range allEntries {
+		if entry == nil {
+			continue
+		}
+		if entry.Latency > 0 {
+			tpLatencyMs[entry.ID] = entry.Latency
+		}
+	}
+	localLatencyFor := func(id uuid.UUID) float64 { return tpLatencyMs[id] }
+
 	queue := seed
 	for level := 1; level <= maxHops && len(queue) > 0; level++ {
 		nextQueue := make([]bfsNode, 0)
+		// Collect ALL dst-hits at this level, then pick the lowest-
+		// latency among them. Pre-fix this loop returned on the first
+		// hit, leaving the BFS's deterministic-by-PK ordering as the
+		// only tiebreaker — which empirically picked geo-distant
+		// intermediates over healthier same-hop-count alternatives.
+		var dstCandidates [][]routing.Hop
 		for _, node := range queue {
 			// Did we reach the destination at an acceptable depth?
 			if node.pk == dst && level >= minHops {
-				log.Debugf("Local BFS found %d-hop route via %v", level, hopPath(node.path))
-				return node.path, reverseHops(node.path), nil
+				dstCandidates = append(dstCandidates, node.path)
+				continue
 			}
 			// Stop expanding nodes already at maxHops — children would
 			// exceed the cap.
@@ -945,6 +1089,24 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 				return children[i].pk.String() < children[j].pk.String()
 			})
 			nextQueue = append(nextQueue, children...)
+		}
+		// If any dst-candidates were collected at this level, pick the
+		// lowest-latency one and return. BFS continues to higher levels
+		// only when no dst-hit happened — shorter paths still beat
+		// longer ones, as before; the change is purely a tiebreaker
+		// among same-hop-count candidates.
+		if len(dstCandidates) > 0 {
+			best := dstCandidates[0]
+			bestScore := pathLatencyScore(best, localLatencyFor)
+			for _, p := range dstCandidates[1:] {
+				if s := pathLatencyScore(p, localLatencyFor); s < bestScore {
+					best = p
+					bestScore = s
+				}
+			}
+			log.Debugf("Local BFS found %d-hop route via %v (best of %d same-level candidates, score=%.1fms)",
+				level, hopPath(best), len(dstCandidates), bestScore)
+			return best, reverseHops(best), nil
 		}
 		queue = nextQueue
 	}

--- a/pkg/router/router_dial_disjoint_test.go
+++ b/pkg/router/router_dial_disjoint_test.go
@@ -88,7 +88,7 @@ func TestPickDisjointPath_NoExcludeReturnsFirst(t *testing.T) {
 		{hop(dst, mid2), hop(mid2, src)},
 	}
 
-	f, r, ok := pickDisjointPath(fwd, rev, nil)
+	f, r, ok := pickDisjointPath(fwd, rev, nil, nil)
 	if !ok {
 		t.Fatal("no-exclude: expected ok=true")
 	}
@@ -118,7 +118,7 @@ func TestPickDisjointPath_SkipsExcludedIntermediate(t *testing.T) {
 		{hop(dst, mid3), hop(mid3, src)},
 	}
 
-	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2})
+	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2}, nil)
 	if !ok {
 		t.Fatal("exclude mid1+mid2 with mid3 available: expected ok=true")
 	}
@@ -142,7 +142,7 @@ func TestPickDisjointPath_AllExcluded(t *testing.T) {
 		{hop(dst, mid2), hop(mid2, src)},
 	}
 
-	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2})
+	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid1, mid2}, nil)
 	if ok {
 		t.Error("all paths excluded: expected ok=false")
 	}
@@ -164,7 +164,7 @@ func TestPickDisjointPath_ReverseAlsoFiltered(t *testing.T) {
 		{hop(dst, midR), hop(midR, src)},
 	}
 
-	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midR})
+	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midR}, nil)
 	if ok {
 		t.Error("midR excluded but in reverse path: expected ok=false")
 	}
@@ -215,5 +215,145 @@ func TestIntermediatesOfHops(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPathLatencyScore_KnownAndUnknown(t *testing.T) {
+	src := mustPK(t)
+	mid := mustPK(t)
+	dst := mustPK(t)
+
+	h1 := hop(src, mid)
+	h2 := hop(mid, dst)
+
+	// All hops known: score is the simple sum.
+	lat := map[uuid.UUID]float64{h1.TpID: 50, h2.TpID: 30}
+	score := pathLatencyScore([]routing.Hop{h1, h2}, func(id uuid.UUID) float64 { return lat[id] })
+	if score != 80.0 {
+		t.Errorf("known-only: want 80.0, got %.1f", score)
+	}
+
+	// One hop unknown (latency 0): unknown penalty applied.
+	// Penalty constant (1000ms) ensures known-good paths outrank
+	// any path with an unknown hop unless the known path is also slow.
+	lat2 := map[uuid.UUID]float64{h1.TpID: 50}
+	score2 := pathLatencyScore([]routing.Hop{h1, h2}, func(id uuid.UUID) float64 { return lat2[id] })
+	if score2 != 1050.0 {
+		t.Errorf("one-unknown: want 1050.0 (50 known + 1000 unknown penalty), got %.1f", score2)
+	}
+}
+
+func TestPickDisjointPath_LatencyRanking(t *testing.T) {
+	src := mustPK(t)
+	midFast := mustPK(t)
+	midSlow := mustPK(t)
+	dst := mustPK(t)
+
+	// Two acceptable candidates (no exclude). First is via the slow
+	// intermediate, second is via the fast one. Pre-latency-rank
+	// behavior would return the first. New behavior should return
+	// the SECOND (lower total latency).
+	hSlow := hop(src, midSlow)
+	hSlowToDst := hop(midSlow, dst)
+	hFast := hop(src, midFast)
+	hFastToDst := hop(midFast, dst)
+
+	fwd := [][]routing.Hop{
+		{hSlow, hSlowToDst},
+		{hFast, hFastToDst},
+	}
+	rev := [][]routing.Hop{
+		{hop(dst, midSlow), hop(midSlow, src)},
+		{hop(dst, midFast), hop(midFast, src)},
+	}
+
+	latency := map[uuid.UUID]float64{
+		hSlow.TpID: 300, hSlowToDst.TpID: 250, // 550ms via slow
+		hFast.TpID: 40, hFastToDst.TpID: 30, // 70ms via fast
+	}
+	// Reverse legs get the same per-tp latency lookup; the slow
+	// intermediate path scores worse regardless.
+	for _, p := range rev[0] {
+		latency[p.TpID] = 300
+	}
+	for _, p := range rev[1] {
+		latency[p.TpID] = 40
+	}
+
+	f, _, ok := pickDisjointPath(fwd, rev, nil, func(id uuid.UUID) float64 { return latency[id] })
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if f[0].To != midFast {
+		t.Errorf("expected ranker to pick fast intermediate (%v), got %v", midFast, f[0].To)
+	}
+}
+
+func TestPickDisjointPath_LatencyRankingWithExclude(t *testing.T) {
+	// Three candidates: [excluded, slow-but-acceptable, fast-but-acceptable].
+	// Ranker must skip the excluded one AND prefer fast over slow
+	// among the remaining acceptable candidates.
+	src := mustPK(t)
+	midBad := mustPK(t)
+	midSlow := mustPK(t)
+	midFast := mustPK(t)
+	dst := mustPK(t)
+
+	fwd := [][]routing.Hop{
+		{hop(src, midBad), hop(midBad, dst)},
+		{hop(src, midSlow), hop(midSlow, dst)},
+		{hop(src, midFast), hop(midFast, dst)},
+	}
+	rev := [][]routing.Hop{
+		{hop(dst, midBad), hop(midBad, src)},
+		{hop(dst, midSlow), hop(midSlow, src)},
+		{hop(dst, midFast), hop(midFast, src)},
+	}
+
+	// Assign latencies: bad (excluded, irrelevant), slow, fast.
+	latency := map[uuid.UUID]float64{}
+	for _, p := range append(fwd[1], rev[1]...) {
+		latency[p.TpID] = 250
+	}
+	for _, p := range append(fwd[2], rev[2]...) {
+		latency[p.TpID] = 40
+	}
+
+	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{midBad}, func(id uuid.UUID) float64 { return latency[id] })
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if f[0].To != midFast {
+		t.Errorf("expected fast (%v) post-exclude, got %v", midFast, f[0].To)
+	}
+}
+
+func TestPickDisjointPath_NoLatencyRankerLegacyBehavior(t *testing.T) {
+	// When latencyFor is nil AND exclude is non-empty, the function
+	// should return the first acceptable candidate — preserving the
+	// pre-latency-rank semantics for callers that don't opt in.
+	src := mustPK(t)
+	mid1 := mustPK(t)
+	mid2 := mustPK(t)
+	dst := mustPK(t)
+
+	fwd := [][]routing.Hop{
+		{hop(src, mid1), hop(mid1, dst)},
+		{hop(src, mid2), hop(mid2, dst)},
+	}
+	rev := [][]routing.Hop{
+		{hop(dst, mid1), hop(mid1, src)},
+		{hop(dst, mid2), hop(mid2, src)},
+	}
+
+	// Non-empty exclude (just to make the function iterate), but no
+	// ranker. Result should be the first-after-exclude — here, mid1
+	// is not excluded so [0] passes.
+	f, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mustPK(t)}, nil)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if f[0].To != mid1 {
+		t.Errorf("nil-ranker + non-empty exclude: want first acceptable (mid1), got %v", f[0].To)
 	}
 }


### PR DESCRIPTION
## Summary

The route-finder service + local-BFS fallback return up to N candidate paths per direction, ordered by hop count + topological discovery only. Among equal-hop candidates the visor was picking the first — which on the 2026-05-23 bilateral \`ss -tinp\` capture meant a geo-distant Indonesia intermediate (cwnd:2 ssthresh:2, 10-18% retransmits, 317ms minRTT) was being selected over a same-hop-count alternative that would have been an order of magnitude faster.

TPD already carries the latency signal end-to-end (visor RSN ping → CXO telemetry feed → `cxoaggregator.UpdateLatency` → Redis → `GetAllTransports` / `GetTransportByID` includes `Entry.Latency`). The router was the only layer not consuming it at pick time. This PR closes the loop.

## Changes

- **`pickDisjointPath`** (`pkg/router/router_dial.go`) gains a `latencyFor func(uuid.UUID) float64` parameter. Among acceptable (non-excluded) candidates, returns the pair with the lowest sum of per-hop avg latencies. nil `latencyFor` preserves the legacy first-acceptable behavior.
- **`pathLatencyScore`** — pure helper, sums per-hop avg ms with an unknown-latency penalty (1000ms) so paths with measured signal outrank fully-unknown ones, while a fully-unknown path is still preferred over no path.
- **`router.buildLatencyLookup`** constructs a `TpID → ms` cache:
  1. `r.tm.Transport(tpID).GetLatencyStats()` for transports the local visor holds (freshest signal, no round-trip)
  2. `r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, tpID)` for intermediate-to-intermediate hops the visor doesn't own — `Entry.Latency` hydrated by the CXO aggregator
- **`fetchBestRoutes`** wires the lookup into the `pickDisjointPath` call site. Candidate set is small (typically 2-3 paths × ≤6 hops); lookup overhead is constant per dial.
- **`calculateLocalRoutes` BFS** no longer returns the first-discovered dst-hit at a given level — it collects all same-level dst-hits and picks the lowest-latency one. Shorter paths still beat longer ones (BFS level-by-level preserved); change is purely a tiebreaker among same-hop-count candidates.

## Tests

4 new subtests in `router_dial_disjoint_test.go`:
- `TestPathLatencyScore_KnownAndUnknown` — pure helper, both branches
- `TestPickDisjointPath_LatencyRanking` — two candidates, ranker picks fast over slow
- `TestPickDisjointPath_LatencyRankingWithExclude` — excluded + ranker compose
- `TestPickDisjointPath_NoLatencyRankerLegacyBehavior` — nil ranker = first-acceptable preserved

Full `pkg/router/` test suite passes (37s).

## Empirical motivation

From the bilateral ss capture with Gamma (16:15Z 2026-05-23):

```
fwd intermediate (114.73.232.8, Indonesia):
  minRTT 317-388ms, cwnd:2-3, ssthresh:2-7, retx 10-18%
rev intermediate (104.136.22.124):
  minRTT 17-43ms, cwnd:10+, retx 0%
```

Both intermediates were returned by the route-finder as same-hop-count candidates. The first one was picked; throughput collapsed to ~10 KB/s. A ranker over the latency data already in TPD would have picked the second.

## Composition with prior PRs

This is the immediate next slice after the 7-PR mux-route plumbing chain (#2751 → #2765 → #2766 → #2770 → #2774 → #2776). The plumbing finally lets visors dial multi-hop reliably; this PR makes the multi-hop pick less adversarial.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/router/...` clean
- [x] `go test -count=1 ./pkg/router/...` passes (37s)
- [ ] Post-deploy: rerun `cli skynet start --pk gamma -r 8090 -l 9001 --routes 1 --min-hops 2` against Gamma's fileserver. Expect visor log to show the chosen intermediate is the lower-latency candidate per `Entry.Latency`. Throughput should improve unless the latency-signal hydration is stale across the chosen tps (separate issue).