### PR TITLE
fix(hv): propagate ServicesHealth through HVVisorEntry → sub-section status dots

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -288,8 +288,20 @@ func projectEntryToSummary(e HVVisorEntry) Summary {
 			Version: e.Version,
 		},
 	}
+	// Health is partial here — only ServicesHealth carries through
+	// the HVVisorEntry round-trip from the remote hypervisor. That's
+	// enough for nodeStatusClass to choose between dot-green
+	// (healthy), dot-yellow (unhealthy), and dot-outline-gray
+	// (unknown). The other Health fields stay zero — the UI's
+	// per-row template guards on field presence (see node-list's
+	// nodeStatusClass).
+	var health *HealthInfo
+	if e.ServicesHealth != "" {
+		health = &HealthInfo{ServicesHealth: e.ServicesHealth}
+	}
 	return Summary{
 		Overview:      overview,
+		Health:        health,
 		BuildTag:      e.BuildTag,
 		Uptime:        e.Uptime,
 		Online:        e.Online,

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -35,7 +35,16 @@ type HVVisorEntry struct {
 	Apps           int           `json:"apps"`
 	RewardAddress  string        `json:"reward_address,omitempty"`
 	ConfigVersion  string        `json:"config_version,omitempty"`
-	Error          string        `json:"error,omitempty"`
+	// ServicesHealth is the remote visor's most recent
+	// HealthInfo.ServicesHealth ("healthy", "unhealthy",
+	// "connecting", ""). Carried so the hvui's tree-summary
+	// sub-section can render the same green / yellow / gray status
+	// dot that the local section's main table does — without this,
+	// every sub-section row falls through to nodeStatusClass's
+	// "online but health unknown" branch and renders as a gray
+	// outline circle even when the visor is fully healthy.
+	ServicesHealth string `json:"services_health,omitempty"`
+	Error          string `json:"error,omitempty"`
 	// ProxiedVia is set when this entry was discovered through a connected
 	// sub-hypervisor rather than a direct connection. The value is the PK
 	// of the sub-hypervisor that proxies operations on this visor.
@@ -54,6 +63,9 @@ func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
 	entry.Apps = len(summary.Overview.Apps)
 	entry.ConfigVersion = summary.ConfigVersion
 	entry.RewardAddress = summary.RewardAddress
+	if summary.Health != nil {
+		entry.ServicesHealth = summary.Health.ServicesHealth
+	}
 }
 
 // HVListDirectVisors returns summaries of visors DIRECTLY connected to


### PR DESCRIPTION
## Summary

Operator observed: visors in the per-sub-hypervisor sections (#2783) render with no green status dot even when the same visor in the main local-section table shows as online. **Root cause:** `projectEntryToSummary` filled in `Online` from `HVVisorEntry` but not `Health`, so the frontend's `nodeStatusClass` fell through to its "online-but-health-unknown" branch (`dot-outline-gray`) instead of the local table's `dot-green` (online + healthy).

To the operator's question — "does it need an update on the remote hypervisor end?" — yes, the remote hypervisor's `HVListDirectVisors` response needs to carry one more field. This PR adds it.

## Mechanism

Carries `ServicesHealth` through the existing chain:

```
HealthInfo.ServicesHealth      (source on the remote visor's Summary,
                                set by Health())
      ↓ populateEntryFromSummary
HVVisorEntry.ServicesHealth    (new JSON field, omitempty)
      ↓ projectEntryToSummary
Summary.Health.ServicesHealth  (rebuilt as a minimal HealthInfo)
      ↓ /api/visors-tree-summary JSON
response.health.services_health  (already parsed by the frontend's
                                  parseVisorsResponse — same shape as
                                  the local-section path; no Angular
                                  change needed)
```

Other `HealthInfo` fields stay zero on the projected side. That's enough for `nodeStatusClass` to choose between `dot-green` (healthy), `dot-yellow` (unhealthy), and `dot-outline-gray` (unknown — empty `ServicesHealth`, e.g. older sub-hypervisor binary without this field).

## Net effect post-deploy

Visors in sub-hypervisor sections render with the same status colors as their counterparts in the main table — closing the visual asymmetry the operator flagged at 12:30.

## Test plan

- [x] `go build ./...`
- [x] `make lint` clean
- [x] `go test -count=1 ./pkg/visor/...` passes
- [ ] Cross-visor live verification: another agent restarts with this PR deployed, then this visor's `/#/nodes/list/0` shows green dots on sub-section rows for healthy visors

## Companion PRs

- #2780 — server-side tree-summary dedup + `Overview.Hostname`
- #2781 — frontend label default = hostname
- #2783 — frontend per-sub-hypervisor sections rendered