### PR TITLE
feat(router): unpair forward/reverse candidate selection

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -582,32 +582,40 @@ fetchRoutesAgain:
 	return fwdPath, revPath, nil
 }
 
-// pickDisjointPath walks the parallel forward/reverse-path slices the
-// route-finder returned (paired by index) and returns the
-// forward/reverse pair whose intermediate hops do not contain any PK
-// in exclude AND whose total measured latency is lowest.
+// pickDisjointPath returns the forward/reverse path pair whose
+// intermediate hops do not contain any PK in exclude AND whose
+// per-direction latency is lowest. Forward and reverse are RANKED
+// INDEPENDENTLY — the route-finder returns each direction as its own
+// candidate slice (PathEdges{forward, backward} at the FindRoutes call
+// site) and the data plane stores fwd / rvs as separate rule chains
+// (route_group.fwd / route_group.rvs), so there's no requirement that
+// the two paths share the same intermediates.
 //
-// latencyFor is a per-TpID latency lookup (avg-ms; 0 = unknown). Pairs
-// containing any unknown-latency hop are still considered, but unknown
-// hops are treated as a high cost so KNOWN-good paths are preferred
-// when available. Pass nil to disable latency ranking (legacy
-// first-acceptable behavior).
+// Pre-#2782 this function paired by index (forward[i], reverse[i]),
+// which threw away the independent-direction signal: if forward had
+// a great candidate at index 2 but the best reverse was at index 0,
+// pairing-by-index would force forward[0] + reverse[0] (or whatever
+// matching pair scored lowest combined). Unpairing closes that gap.
+//
+// latencyFor is a per-TpID latency lookup (avg-ms; 0 = unknown). Hops
+// with unknown latency are treated as a high cost so paths with
+// measured signal outrank paths with no signal at all. Pass nil to
+// disable latency ranking (legacy first-acceptable behavior).
 //
 // When exclude is empty AND latencyFor is nil: returns paths[0] (the
-// pre-existing hot-path single-route behavior — back-compat).
+// pre-existing hot-path single-route behavior — back-compat for tests
+// and any caller that doesn't opt in to ranking).
 //
-// ok=false means every candidate touched the exclude set — the caller
-// should fall back to local route calc or surface ErrNoRouteFound.
+// ok=false means every candidate in at least one direction touched
+// the exclude set — caller should fall back to local route calc or
+// surface ErrNoRouteFound.
 //
-// Rationale for ranking by latency: prior to this, the route-finder's
-// first-returned candidate was selected even when alternative
-// candidates had measurably better RTT. The empirical 2026-05-23
-// bilateral ss-tinp capture showed a route-finder pick going through a
-// geo-distant Indonesia intermediate (cwnd:2 ssthresh:2 10-18% retx)
-// while a much healthier candidate was available in the same response
-// — TPD already carries that latency signal end-to-end via the CXO
-// telemetry feed and aggregator (pkg/transport-discovery/cxoaggregator).
-// Visor-side ranking on top of the existing data closes the loop.
+// Rationale for asymmetric ranking (operator framing 2026-05-23):
+// most real workloads are bandwidth-asymmetric (HTTP GET = tiny
+// upstream + bulk downstream). Allowing forward and reverse to use
+// different intermediates means each direction can pick its best
+// available wire, not the best PAIR — which is strictly weaker when
+// the per-direction optimums sit at different indices.
 func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey, latencyFor func(uuid.UUID) float64) ([]routing.Hop, []routing.Hop, bool) {
 	if len(forward) == 0 || len(reverse) == 0 {
 		return nil, nil, false
@@ -622,40 +630,39 @@ func pickDisjointPath(forward, reverse [][]routing.Hop, exclude []cipher.PubKey,
 	for _, pk := range exclude {
 		excludeSet[pk] = struct{}{}
 	}
-	// Iterate paired indices. Empirically the route-finder returns
-	// equal-length slices; defensively cap by min(len).
-	n := len(forward)
-	if len(reverse) < n {
-		n = len(reverse)
+	fwdPath, fwdOK := pickBestDirection(forward, excludeSet, latencyFor)
+	revPath, revOK := pickBestDirection(reverse, excludeSet, latencyFor)
+	if !fwdOK || !revOK {
+		return nil, nil, false
 	}
-	// Collect acceptable candidates (passing the disjointness check),
-	// then pick the lowest-latency pair. When latencyFor is nil OR
-	// every candidate has fully-unknown latency, ties resolve to the
-	// first-encountered candidate — the legacy behavior.
+	return fwdPath, revPath, true
+}
+
+// pickBestDirection returns the lowest-latency-scoring candidate from
+// a single direction's path slice that doesn't touch the exclude set.
+// When latencyFor is nil, returns the first acceptable candidate (the
+// legacy first-after-exclude behavior — preserved for callers that
+// don't opt into ranking, e.g. the existing tests).
+func pickBestDirection(paths [][]routing.Hop, excludeSet map[cipher.PubKey]struct{}, latencyFor func(uuid.UUID) float64) ([]routing.Hop, bool) {
 	bestIdx := -1
 	bestScore := 0.0
-	for i := 0; i < n; i++ {
-		if pathTouchesIntermediate(forward[i], excludeSet) ||
-			pathTouchesIntermediate(reverse[i], excludeSet) {
+	for i, p := range paths {
+		if pathTouchesIntermediate(p, excludeSet) {
 			continue
 		}
 		if latencyFor == nil {
-			// No ranker — first acceptable wins.
-			return forward[i], reverse[i], true
+			return p, true
 		}
-		score := pathLatencyScore(forward[i], latencyFor) + pathLatencyScore(reverse[i], latencyFor)
+		score := pathLatencyScore(p, latencyFor)
 		if bestIdx < 0 || score < bestScore {
 			bestIdx = i
 			bestScore = score
 		}
 	}
 	if bestIdx < 0 {
-		return nil, nil, false
+		return nil, false
 	}
-	// bestIdx is set only by the loop above where 0 <= i < n =
-	// min(len(forward), len(reverse)), so both indexes are in-bounds.
-	// gosec can't track the cross-slice min, hence the explicit nolint.
-	return forward[bestIdx], reverse[bestIdx], true //nolint:gosec
+	return paths[bestIdx], true
 }
 
 // pathLatencyScore returns the sum of per-hop avg-latency-ms across a

--- a/pkg/router/router_dial_disjoint_test.go
+++ b/pkg/router/router_dial_disjoint_test.go
@@ -357,3 +357,81 @@ func TestPickDisjointPath_NoLatencyRankerLegacyBehavior(t *testing.T) {
 		t.Errorf("nil-ranker + non-empty exclude: want first acceptable (mid1), got %v", f[0].To)
 	}
 }
+
+func TestPickDisjointPath_AsymmetricForwardReverse(t *testing.T) {
+	// Forward and reverse should be ranked INDEPENDENTLY. Constructed
+	// case: fwd[0] is slow, fwd[1] is fast; rev[0] is fast, rev[1] is
+	// slow. Pre-unpair behavior would have paired (fwd[i], rev[i]) and
+	// picked whichever index minimized the SUM — here either pair has
+	// the same sum (slow+fast), so paired-by-index would have returned
+	// the first one. Post-unpair: picks fwd[1] AND rev[0], which is
+	// the strictly-better choice (fast in both directions).
+	src := mustPK(t)
+	midFastFwd := mustPK(t)
+	midSlowFwd := mustPK(t)
+	midFastRev := mustPK(t)
+	midSlowRev := mustPK(t)
+	dst := mustPK(t)
+
+	hSlowFwd0 := hop(src, midSlowFwd)
+	hSlowFwd1 := hop(midSlowFwd, dst)
+	hFastFwd0 := hop(src, midFastFwd)
+	hFastFwd1 := hop(midFastFwd, dst)
+	hFastRev0 := hop(dst, midFastRev)
+	hFastRev1 := hop(midFastRev, src)
+	hSlowRev0 := hop(dst, midSlowRev)
+	hSlowRev1 := hop(midSlowRev, src)
+
+	fwd := [][]routing.Hop{
+		{hSlowFwd0, hSlowFwd1}, // index 0 slow
+		{hFastFwd0, hFastFwd1}, // index 1 fast
+	}
+	rev := [][]routing.Hop{
+		{hFastRev0, hFastRev1}, // index 0 fast
+		{hSlowRev0, hSlowRev1}, // index 1 slow
+	}
+
+	latency := map[uuid.UUID]float64{
+		hSlowFwd0.TpID: 300, hSlowFwd1.TpID: 300, // 600ms total
+		hFastFwd0.TpID: 30, hFastFwd1.TpID: 30, // 60ms total
+		hFastRev0.TpID: 30, hFastRev1.TpID: 30, // 60ms total
+		hSlowRev0.TpID: 300, hSlowRev1.TpID: 300, // 600ms total
+	}
+
+	f, r, ok := pickDisjointPath(fwd, rev, nil, func(id uuid.UUID) float64 { return latency[id] })
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if f[0].To != midFastFwd {
+		t.Errorf("forward: expected midFastFwd (%v), got %v", midFastFwd, f[0].To)
+	}
+	if r[0].To != midFastRev {
+		t.Errorf("reverse: expected midFastRev (%v), got %v", midFastRev, r[0].To)
+	}
+}
+
+func TestPickDisjointPath_AsymmetricExcludeIntersection(t *testing.T) {
+	// Exclude check applies per-direction. If midX is excluded:
+	//   - any forward path passing through midX is rejected
+	//   - any reverse path passing through midX is rejected independently
+	// So a path pair where forward[i] is acceptable but every reverse[j]
+	// touches the exclude set should yield ok=false.
+	src := mustPK(t)
+	mid := mustPK(t)
+	dst := mustPK(t)
+
+	// Forward has one good option (no excluded intermediate).
+	fwd := [][]routing.Hop{
+		{hop(src, mustPK(t)), hop(mustPK(t), dst)},
+	}
+	// Reverse: every candidate touches `mid` (which is excluded).
+	rev := [][]routing.Hop{
+		{hop(dst, mid), hop(mid, src)},
+		{hop(dst, mid), hop(mid, src)},
+	}
+
+	_, _, ok := pickDisjointPath(fwd, rev, []cipher.PubKey{mid}, nil)
+	if ok {
+		t.Error("expected ok=false when every reverse candidate touches exclude set")
+	}
+}


### PR DESCRIPTION
## Summary

The route-finder returns forward and reverse candidates **independently** (`pkg/router/router_dial.go:507` queries `[]routing.PathEdges{forward, backward}`); the data plane stores them as independent rule chains (`route_group.fwd` + `route_group.rvs`); there's no architectural requirement that the two share the same intermediates. The dial layer was the only place enforcing symmetry, and only implicitly — `pickDisjointPath` paired candidates by index.

Pre-#2782 + the index-pairing in #2782's `pickDisjointPath` threw that independence away — when the latency ranker picked `(forward[i], reverse[i])` by paired index, it ignored the case where forward's best candidate sat at one index and reverse's best sat at another.

Now: each direction is ranked separately via `pickBestDirection`. Best forward + best reverse (each by sum-of-per-hop-latency) regardless of which slice index they came from. Disjointness check applies per-direction.

## Why this matters

Real workloads are **bandwidth-asymmetric**:
- HTTP GET: tiny upstream, bulk downstream
- File transfer: same shape
- Video streaming: same
- skynet port-forwarding: same (the operator's actual product surface)

Letting each direction find its best wire — possibly a different intermediate — turns "best paired" into "best per direction" with no extra round-trip cost and no protocol change.

## Tests

- `TestPickDisjointPath_AsymmetricForwardReverse` — fwd[1] is fast, rev[0] is fast, paired-by-index would tie-break on first; unpaired returns (fwd[1], rev[0]) which is strictly better.
- `TestPickDisjointPath_AsymmetricExcludeIntersection` — exclude check applies per-direction; if every reverse candidate touches the exclude set, `ok=false`.

Existing `Pick*` and `PathLatencyScore*` tests pass unchanged. Full `pkg/router/` suite (37s) green.

## Composition

Companion to #2782 (latency-rank). Together with the chain #2751→#2765→#2766→#2770→#2774→#2776→#2782, multi-hop went from 0-15 KB/s pre-deploy → 1.2-2.5 MB/s in empirical testing 2026-05-23 (3 of 5 N=1 --min-hops 2 reps completed full 50MB transfer on first attempt). Unpairing is the next refinement.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./pkg/router/...` passes (37s)
- [ ] Post-deploy: rerun N=1 --min-hops 2 sweep. Visor log should show that selected forward + reverse transport IDs no longer come from the same route-finder candidate index when independent ranking finds a better split.