### PR TITLE
fix(hv): surface sub-section visor transports column

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/httputil"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 	"github.com/skycoin/skywire/rewards"
 )
@@ -271,6 +272,27 @@ func (hv *Hypervisor) collectLocalVisorSummaries() []Summary {
 	return out
 }
 
+// projectEntryTransports returns the per-transport detail the
+// node-list's Transports column iterates. Prefers the full
+// TransportSummaries field populated post-#2789. Falls back to a slice
+// of placeholder TransportSummary entries sized to the count field
+// when the remote sub-hypervisor predates #2789 and only sent the
+// count — the per-type breakdown is unknown but the operator at
+// least sees the right total instead of a "-" dash.
+func projectEntryTransports(e HVVisorEntry) []*TransportSummary {
+	if len(e.TransportSummaries) > 0 {
+		return e.TransportSummaries
+	}
+	if e.Transports <= 0 {
+		return nil
+	}
+	out := make([]*TransportSummary, e.Transports)
+	for i := range out {
+		out[i] = &TransportSummary{Type: types.Type("?")}
+	}
+	return out
+}
+
 // projectEntryToSummary fills the Summary fields the main node list's
 // table consumes from an HVVisorEntry. Fields the table doesn't
 // render (health, dmsg stats, route group info, etc.) stay zero —
@@ -287,6 +309,7 @@ func projectEntryToSummary(e HVVisorEntry) Summary {
 		BuildInfo: &buildinfo.Info{
 			Version: e.Version,
 		},
+		Transports: projectEntryTransports(e),
 	}
 	// Health is partial here — only ServicesHealth carries through
 	// the HVVisorEntry round-trip from the remote hypervisor. That's

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -32,9 +32,16 @@ type HVVisorEntry struct {
 	CountryCode    string        `json:"country_code,omitempty"`
 	IsSymmetricNAT bool          `json:"symmetric_nat,omitempty"`
 	Transports     int           `json:"transports"`
-	Apps           int           `json:"apps"`
-	RewardAddress  string        `json:"reward_address,omitempty"`
-	ConfigVersion  string        `json:"config_version,omitempty"`
+	// TransportSummaries is the full per-transport detail (type,
+	// remote PK, sent/recv counters, etc.) the hvui's node-list
+	// table needs to render its Transports column. Populated by
+	// populateEntryFromSummary from summary.Overview.Transports.
+	// omitempty so older sub-hypervisor binaries that don't fill
+	// this field don't blow the JSON shape.
+	TransportSummaries []*TransportSummary `json:"transport_summaries,omitempty"`
+	Apps               int                 `json:"apps"`
+	RewardAddress      string              `json:"reward_address,omitempty"`
+	ConfigVersion      string              `json:"config_version,omitempty"`
 	// ServicesHealth is the remote visor's most recent
 	// HealthInfo.ServicesHealth ("healthy", "unhealthy",
 	// "connecting", ""). Carried so the hvui's tree-summary
@@ -60,6 +67,7 @@ func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
 	entry.CountryCode = summary.Overview.CountryCode
 	entry.IsSymmetricNAT = summary.Overview.IsSymmetricNAT
 	entry.Transports = len(summary.Overview.Transports)
+	entry.TransportSummaries = summary.Overview.Transports
 	entry.Apps = len(summary.Overview.Apps)
 	entry.ConfigVersion = summary.ConfigVersion
 	entry.RewardAddress = summary.RewardAddress


### PR DESCRIPTION
## Summary

Sub-section node-list rows for proxied visors render \`-\` in the Transports column. \`HVVisorEntry\` only carried the transport *count*, not the per-transport detail the hvui template iterates by type.

## Fix

- Extend \`HVVisorEntry\` with \`TransportSummaries []*TransportSummary\` alongside the existing count.
- Populate it from \`summary.Overview.Transports\` in \`populateEntryFromSummary\`.
- Project it back into \`Summary.Overview.Transports\` in \`projectEntryToSummary\` via a new \`projectEntryTransports\` helper.

## Mixed-version fallback

When the remote sub-hypervisor predates this PR and only sends the count (\`TransportSummaries==nil\` but \`Transports>0\`), \`projectEntryTransports\` synthesizes N placeholder \`*TransportSummary\` entries with \`Type="?"\`. The per-type breakdown is unknown during the upgrade lag, but the operator sees the correct total instead of a dash. Once both ends are on this PR, the real \`TransportSummaries\` flow through.

## Test plan

- [x] \`go build ./...\`
- [x] \`make lint\` clean
- [ ] Live: operator screenshot shows transport counts on sub-section rows after redeploy

## Related

Final mile of the sub-hypervisor section work: #2780 (scrub), #2784 (services_health), #2786 (table styling), #2787 (proxied-visor RPC), #2788 (default-healthy).