### PR TITLE
feat(router): per-direction MinHops for asymmetric routing

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -49,6 +49,13 @@ var (
 	// every mux route, so N mux streams ride one TCP socket and
 	// nothing is multiplexed across intermediates.
 	minHops int
+	// fwdMinHops / revMinHops are per-direction MinHops overrides for
+	// bandwidth-asymmetric workloads (HTTP GET = tiny upstream + bulk
+	// downstream). When > 0 they win over min-hops for THAT direction.
+	// Canonical asymmetric test: --forward-min-hops 0 --reverse-min-hops 2
+	// lets forward stay direct while reverse is forced multi-hop.
+	fwdMinHops int
+	revMinHops int
 )
 
 func init() {
@@ -59,6 +66,8 @@ func init() {
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
 	RootCmd.Flags().IntVar(&routes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
 	RootCmd.Flags().IntVar(&minHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
+	RootCmd.Flags().IntVar(&fwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override (>=2 forces multi-hop on forward direction only)")
+	RootCmd.Flags().IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse direction only)")
 }
 
 // RootCmd is the root command for skynet-client
@@ -90,6 +99,8 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
 		fs.IntVar(&routes, "routes", 0, "number of parallel skynet mux routes")
 		fs.IntVar(&minHops, "min-hops", 0, "minimum hop count (>=2 rejects direct paths)")
+		fs.IntVar(&fwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override")
+		fs.IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -149,24 +160,27 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		Port:   routing.Port(skyenv.SkyForwardingServerPort),
 	}
 
-	switch {
-	case routes > 1 && minHops > 1:
-		appCl.Log().Infof("Per-accept dial shape: %s on port %d with %d parallel mux routes, min-hops=%d",
-			remotePK.Hex(), skyenv.SkyForwardingServerPort, routes, minHops)
-	case routes > 1:
-		appCl.Log().Infof("Per-accept dial shape: %s on port %d with %d parallel mux routes",
-			remotePK.Hex(), skyenv.SkyForwardingServerPort, routes)
-	case minHops > 1:
-		appCl.Log().Infof("Per-accept dial shape: %s on port %d with min-hops=%d",
-			remotePK.Hex(), skyenv.SkyForwardingServerPort, minHops)
-	default:
-		appCl.Log().Infof("Per-accept dial shape: %s on port %d",
-			remotePK.Hex(), skyenv.SkyForwardingServerPort)
+	// Build a single log line describing the dial shape (mux + min-hops
+	// + per-direction). Suppress unset fields so the common case stays
+	// short.
+	dialShape := fmt.Sprintf("%s on port %d", remotePK.Hex(), skyenv.SkyForwardingServerPort)
+	if routes > 1 {
+		dialShape += fmt.Sprintf(" with %d parallel mux routes", routes)
 	}
+	if minHops > 1 {
+		dialShape += fmt.Sprintf(" min-hops=%d", minHops)
+	}
+	if fwdMinHops > 1 {
+		dialShape += fmt.Sprintf(" forward-min-hops=%d", fwdMinHops)
+	}
+	if revMinHops > 1 {
+		dialShape += fmt.Sprintf(" reverse-min-hops=%d", revMinHops)
+	}
+	appCl.Log().Infof("Per-accept dial shape: %s", dialShape)
 
 	dialRemote := func() (net.Conn, error) {
-		if routes > 1 || minHops > 1 {
-			return appCl.DialWithOptions(connApp, routes, minHops)
+		if routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 {
+			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops)
 		}
 		return appCl.Dial(connApp)
 	}

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -27,9 +27,11 @@ var (
 	clientAppPort uint16
 	useInternal   bool
 	useExternal   bool
-	clientName    string // optional custom name for the client instance
-	startRoutes   int    // number of parallel skynet mux routes (0/1 = single route)
-	startMinHops  int    // minimum-hop constraint (>=2 rejects direct paths)
+	clientName      string // optional custom name for the client instance
+	startRoutes     int    // number of parallel skynet mux routes (0/1 = single route)
+	startMinHops    int    // minimum-hop constraint (>=2 rejects direct paths)
+	startFwdMinHops int    // per-direction forward MinHops override
+	startRevMinHops int    // per-direction reverse MinHops override
 )
 
 func init() {
@@ -49,6 +51,8 @@ func init() {
 	startCmd.Flags().StringVarP(&clientName, "name", "n", "", "custom name for this client instance (default: skynet-client-<local-port>)")
 	startCmd.Flags().IntVar(&startRoutes, "routes", 0, "number of parallel skynet mux routes (0 or 1 = single route)")
 	startCmd.Flags().IntVar(&startMinHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
+	startCmd.Flags().IntVar(&startFwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override (>=2 forces multi-hop on forward only)")
+	startCmd.Flags().IntVar(&startRevMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse only; combine with low/0 --min-hops for direct-upstream + multi-hop-downstream)")
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 
 	stopCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of the client instance to stop")
@@ -128,6 +132,14 @@ var startCmd = &cobra.Command{
 
 		if startMinHops > 1 {
 			arguments["--min-hops"] = fmt.Sprintf("%d", startMinHops)
+		}
+
+		if startFwdMinHops > 1 {
+			arguments["--forward-min-hops"] = fmt.Sprintf("%d", startFwdMinHops)
+		}
+
+		if startRevMinHops > 1 {
+			arguments["--reverse-min-hops"] = fmt.Sprintf("%d", startRevMinHops)
 		}
 
 		err = rpcClient.DoCustomSetting(appName, arguments)

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -21,12 +21,12 @@ const (
 )
 
 var (
-	remotePort    int
-	remotePk      string
-	localPort     int
-	clientAppPort uint16
-	useInternal   bool
-	useExternal   bool
+	remotePort      int
+	remotePk        string
+	localPort       int
+	clientAppPort   uint16
+	useInternal     bool
+	useExternal     bool
 	clientName      string // optional custom name for the client instance
 	startRoutes     int    // number of parallel skynet mux routes (0/1 = single route)
 	startMinHops    int    // minimum-hop constraint (>=2 rejects direct paths)

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -123,9 +123,9 @@ func (_m *MockRPCIngressClient) Dial(remote appnet.Addr) (uint16, routing.Port, 
 	return r0, r1, r2
 }
 
-// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops
-func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int) (uint16, routing.Port, error) {
-	ret := _m.Called(remote, muxRoutes, minHops)
+// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops, fwdMinHops, revMinHops
+func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int) (uint16, routing.Port, error) {
+	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DialWithOptions")
@@ -134,23 +134,23 @@ func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes in
 	var r0 uint16
 	var r1 routing.Port
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int) (uint16, routing.Port, error)); ok {
-		return rf(remote, muxRoutes, minHops)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int) (uint16, routing.Port, error)); ok {
+		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 	}
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int) uint16); ok {
-		r0 = rf(remote, muxRoutes, minHops)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int) uint16); ok {
+		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int) routing.Port); ok {
-		r1 = rf(remote, muxRoutes, minHops)
+	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int) routing.Port); ok {
+		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 	} else {
 		r1 = ret.Get(1).(routing.Port)
 	}
 
-	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int) error); ok {
-		r2 = rf(remote, muxRoutes, minHops)
+	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int) error); ok {
+		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -21,13 +21,12 @@ type RPCIngressClient interface {
 	SetAppPort(appPort routing.Port) error
 	Dial(remote appnet.Addr) (connID uint16, localPort routing.Port, err error)
 	// DialWithOptions asks the server to dial remote with per-call
-	// options. Honored fields: muxRoutes (>1 = N parallel mux routes)
-	// and minHops (>=2 = force routes through that many intermediates,
-	// excluding the direct path). Both <= 1 is equivalent to plain Dial.
-	// The two together unblock the operator's mux>direct hypothesis
-	// test via real data-plane apps: muxRoutes alone still picks the
-	// existing direct transport for every route.
-	DialWithOptions(remote appnet.Addr, muxRoutes, minHops int) (connID uint16, localPort routing.Port, err error)
+	// options. Honored fields: muxRoutes (>1 = N parallel mux routes),
+	// minHops (>=2 = force routes through N intermediates), fwdMinHops
+	// / revMinHops (per-direction MinHops overrides for bandwidth-
+	// asymmetric workloads — when > 0 they win over minHops for that
+	// direction only). All <= 1 is equivalent to plain Dial.
+	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
 	Write(connID uint16, b []byte) (int, error)
@@ -93,11 +92,16 @@ func (c *rpcIngressClient) Dial(remote appnet.Addr) (connID uint16, localPort ro
 }
 
 // DialWithOptions sends `DialWithOptions` command to the server.
-// muxRoutes <= 1 AND minHops <= 1 falls through to plain Dial
-// semantics on the server side (no extra round-trip cost beyond
-// the slightly larger request).
-func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops int) (connID uint16, localPort routing.Port, err error) {
-	req := DialOptionsReq{Addr: remote, MuxRoutes: muxRoutes, MinHops: minHops}
+// All fields <= 1 falls through to plain Dial semantics on the server
+// side (no extra round-trip cost beyond the slightly larger request).
+func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (connID uint16, localPort routing.Port, err error) {
+	req := DialOptionsReq{
+		Addr:           remote,
+		MuxRoutes:      muxRoutes,
+		MinHops:        minHops,
+		ForwardMinHops: fwdMinHops,
+		ReverseMinHops: revMinHops,
+	}
 	var resp DialResp
 	if err := c.rpc.Call(c.formatMethod("DialWithOptions"), &req, &resp); err != nil {
 		return 0, 0, RPCErr{err.Error()}

--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -129,7 +129,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// back to plain DialContext; the round-trip still succeeds and
 		// returns a valid ConnID. We're pinning the wire shape, not the
 		// router-level mux behavior (which is integration-tested).
-		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)
@@ -160,7 +160,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// minHops=2 over a non-skynet networker — same fallthrough as
 		// the muxRoutes case. Pins that MinHops is wire-carried through
 		// DialOptionsReq even when the destination family ignores it.
-		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -130,39 +130,52 @@ type DialResp struct {
 // data-plane apps: without it, MuxRoutes > 1 still picks the existing
 // direct transport for every route (N mux streams on one TCP socket),
 // not N routes through N intermediates.
+//
+// ForwardMinHops / ReverseMinHops are per-direction overrides for
+// bandwidth-asymmetric workloads (e.g. HTTP GET = small upstream + bulk
+// downstream). When > 0 they take precedence over the symmetric
+// MinHops for that direction only. Zero = inherit MinHops. Setting
+// just ReverseMinHops=2 with MinHops=0 lets forward stay direct while
+// reverse is forced multi-hop — the canonical asymmetric test shape.
 type DialOptionsReq struct {
-	Addr      appnet.Addr
-	MuxRoutes int
-	MinHops   int
+	Addr           appnet.Addr
+	MuxRoutes      int
+	MinHops        int
+	ForwardMinHops int
+	ReverseMinHops int
 }
 
 // Dial dials to the remote.
 func (r *RPCIngressGateway) Dial(remote *appnet.Addr, resp *DialResp) (err error) {
 	defer rpcutil.LogCall(r.log, "Dial", remote)(resp, &err)
-	return r.dialInternal(*remote, 0, 0, resp)
+	return r.dialInternal(*remote, &DialOptionsReq{Addr: *remote}, resp)
 }
 
 // DialWithOptions dials to the remote honoring per-call dial options.
-// Honored options: MuxRoutes (N parallel mux routes) + MinHops (require
-// N intermediates between source and destination). Together these
-// exercise the operator's mux>direct hypothesis: MuxRoutes > 1 with
-// MinHops >= 2 forces the router to find N disjoint non-direct paths.
-// Falls back to plain Dial semantics when both are <= 1 OR the
-// registered networker for the address family isn't *SkywireNetworker
-// (e.g. dmsg, where mux is inherent to the session).
+// Honored options: MuxRoutes (N parallel mux routes), MinHops (require
+// N intermediates), ForwardMinHops / ReverseMinHops (per-direction
+// MinHops overrides for bandwidth-asymmetric workloads). Together
+// these exercise the operator's mux>direct hypothesis and the
+// asymmetric-routing extension: MuxRoutes > 1 with MinHops >= 2 forces
+// N disjoint non-direct paths; per-direction MinHops lets forward and
+// reverse have different constraints (direct upstream + multi-hop
+// downstream). Falls back to plain Dial semantics when no opts demand
+// the router path OR the registered networker for the address family
+// isn't *SkywireNetworker (e.g. dmsg, where mux is inherent).
 func (r *RPCIngressGateway) DialWithOptions(req *DialOptionsReq, resp *DialResp) (err error) {
 	defer rpcutil.LogCall(r.log, "DialWithOptions", req)(resp, &err)
 	if req == nil {
 		return errors.New("DialWithOptions: nil request")
 	}
-	return r.dialInternal(req.Addr, req.MuxRoutes, req.MinHops, resp)
+	return r.dialInternal(req.Addr, req, resp)
 }
 
 // dialInternal is the common dial body shared by Dial + DialWithOptions.
-// muxRoutes <= 1 AND minHops <= 1 means "plain Dial" (existing
-// behavior). Anything else triggers the SkywireNetworker.
-// DialContextWithOptions path so the opts surface is honored.
-func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes, minHops int, resp *DialResp) error {
+// When req carries no per-call opts (all MuxRoutes/MinHops/Forward*/
+// Reverse* <= 1) it falls through to plain DialContext. Otherwise it
+// goes through SkywireNetworker.DialContextWithOptions so the opts
+// surface is honored.
+func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, req *DialOptionsReq, resp *DialResp) error {
 	reservedConnID, free, err := r.cm.ReserveNextID()
 	if err != nil {
 		return err
@@ -177,7 +190,7 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes, minHops 
 		appName = r.proc.conf.AppName
 	}
 	dialCtx := appnet.WithAppName(context.Background(), appName)
-	conn, err := dialWithMuxRoutes(dialCtx, remote, muxRoutes, minHops)
+	conn, err := dialWithMuxRoutes(dialCtx, remote, req)
 	if err != nil {
 		free()
 		return err
@@ -207,13 +220,13 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, muxRoutes, minHops 
 
 // dialWithMuxRoutes dials remote either via the single-route default
 // path (appnet.DialContext) or via the SkywireNetworker DialOptions
-// path when the caller requested any per-call opts (mux routes OR
-// minimum hops). The type-assertion fallback to the default path
-// matches VisorCat's contract (a test-mock or future alternative
-// networker silently degrades to single-route, preserving correctness
-// with no extra plumbing).
-func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, muxRoutes, minHops int) (net.Conn, error) {
-	if muxRoutes <= 1 && minHops <= 1 {
+// path when the caller requested any per-call opts (mux routes,
+// minimum hops, or per-direction MinHops). The type-assertion
+// fallback to the default path matches VisorCat's contract (a test-
+// mock or future alternative networker silently degrades to single-
+// route, preserving correctness with no extra plumbing).
+func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptionsReq) (net.Conn, error) {
+	if req == nil || (req.MuxRoutes <= 1 && req.MinHops <= 1 && req.ForwardMinHops <= 1 && req.ReverseMinHops <= 1) {
 		return appnet.DialContext(ctx, remote)
 	}
 	nw, err := appnet.ResolveNetworker(remote.Net)
@@ -222,13 +235,15 @@ func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, muxRoutes, minHo
 	}
 	sw, ok := nw.(*appnet.SkywireNetworker)
 	if !ok {
-		// Non-skynet networker (e.g. dmsg) — mux-routes / min-hops are
-		// no-op concepts at this layer. Fall through to the default dial.
+		// Non-skynet networker (e.g. dmsg) — per-call opts are no-op
+		// concepts at this layer. Fall through to the default dial.
 		return appnet.DialContext(ctx, remote)
 	}
 	opts := router.DefaultDialOptions()
-	opts.MuxRoutes = muxRoutes
-	opts.MinHops = minHops
+	opts.MuxRoutes = req.MuxRoutes
+	opts.MinHops = req.MinHops
+	opts.ForwardMinHops = req.ForwardMinHops
+	opts.ReverseMinHops = req.ReverseMinHops
 	return sw.DialContextWithOptions(ctx, remote, opts)
 }
 

--- a/pkg/app/appserver/rpc_ingress_gateway_test.go
+++ b/pkg/app/appserver/rpc_ingress_gateway_test.go
@@ -260,6 +260,35 @@ func TestRPCIngressGateway_DialWithOptions(t *testing.T) {
 		// on a non-skynet family is silently dropped.
 		n.AssertExpectations(t)
 	})
+
+	t.Run("ForwardMinHops/ReverseMinHops fall through to default dial on non-skywire networker", func(t *testing.T) {
+		appnet.ClearNetworkers()
+
+		const localPort routing.Port = 203
+
+		dialCtx := context.Background()
+		dialConn := &appcommon.MockConn{}
+		dialConn.On("LocalAddr").Return(dmsg.Addr{Port: uint16(localPort)})
+		dialConn.On("RemoteAddr").Return(dmsg.Addr{})
+
+		n := &appnet.MockNetworker{}
+		n.On("DialContext", dialCtx, dialAddr).Return(dialConn, error(nil))
+
+		require.NoError(t, appnet.AddNetworker(nType, n))
+
+		rpc := NewRPCGateway(l, nil)
+
+		// Asymmetric: only ReverseMinHops set. The non-skywire networker
+		// can't honor per-direction opts; falls through to DialContext.
+		// Pins that the DialWithOptions path accepts the new fields
+		// on the wire and routes them to the right server-side helper.
+		var resp DialResp
+		req := &DialOptionsReq{Addr: dialAddr, ReverseMinHops: 2}
+		require.NoError(t, rpc.DialWithOptions(req, &resp))
+		require.Equal(t, uint16(1), resp.ConnID)
+		require.Equal(t, localPort, resp.LocalPort)
+		n.AssertExpectations(t)
+	})
 }
 
 func TestRPCIngressGateway_Listen(t *testing.T) {

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -106,7 +106,7 @@ func (c *Client) SetAppPort(appPort routing.Port) error {
 
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
-	return c.dial(remote, 0, 0)
+	return c.dial(remote, 0, 0, 0, 0)
 }
 
 // DialWithOptions dials remote with per-call dial options.
@@ -115,32 +115,35 @@ func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
 //     through SkywireNetworker, the router establishes N parallel
 //     mux routes.
 //   - minHops: when >= 2, the router rejects the direct path and
-//     finds routes through that many intermediates. Needed in
-//     combination with muxRoutes > 1 to actually exercise the
-//     mux>direct hypothesis, since muxRoutes alone still picks the
-//     existing direct transport for every route.
+//     finds routes through that many intermediates.
+//   - fwdMinHops / revMinHops: per-direction MinHops overrides for
+//     bandwidth-asymmetric workloads. When > 0 they take precedence
+//     over minHops for THAT direction only. Setting just
+//     revMinHops=2 with minHops=0 lets forward stay direct while
+//     reverse is forced multi-hop — the canonical asymmetric test
+//     shape (HTTP GET: tiny upstream + bulk downstream).
 //
-// Both <= 1 is semantically equivalent to Dial. Apps requesting these
-// dial shapes (e.g. skynet-client with --routes / --min-hops flags
-// for #1525-adjacent mux-route testing) call this instead of Dial;
-// non-mux callers keep using Dial unchanged.
-func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops int) (net.Conn, error) {
-	return c.dial(remote, muxRoutes, minHops)
+// All <= 1 is semantically equivalent to Dial. Apps requesting these
+// dial shapes (e.g. skynet-client with --routes / --min-hops /
+// --forward-min-hops / --reverse-min-hops flags) call this instead
+// of Dial; non-mux callers keep using Dial unchanged.
+func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (net.Conn, error) {
+	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 }
 
-// dial is the common body for Dial + DialWithOptions. muxRoutes <= 1
-// AND minHops <= 1 invokes the original rpcC.Dial path (preserving the
+// dial is the common body for Dial + DialWithOptions. When all opts
+// are <= 1 it invokes the original rpcC.Dial path (preserving the
 // existing wire shape for non-mux callers); otherwise sends the
 // DialWithOptions request so the server-side knows to take the
 // SkywireNetworker per-call-opts path.
-func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops int) (net.Conn, error) {
+func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (net.Conn, error) {
 	var (
 		connID    uint16
 		localPort routing.Port
 		err       error
 	)
-	if muxRoutes > 1 || minHops > 1 {
-		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops)
+	if muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 {
+		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
 	} else {
 		connID, localPort, err = c.rpcC.Dial(remote)
 	}

--- a/pkg/router/dial_options_test.go
+++ b/pkg/router/dial_options_test.go
@@ -1,0 +1,62 @@
+// Package router pkg/router/dial_options_test.go — unit tests for the
+// per-direction resolver helpers on DialOptions added for asymmetric
+// routing (operator framing: bandwidth-asymmetric workloads like HTTP
+// GET should be able to use direct upstream + multi-hop downstream).
+package router
+
+import "testing"
+
+func TestDialOptions_EffectiveMinHops(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    *DialOptions
+		forward bool
+		want    int
+	}{
+		{"nil opts forward", nil, true, 0},
+		{"nil opts reverse", nil, false, 0},
+		{"symmetric only forward", &DialOptions{MinHops: 2}, true, 2},
+		{"symmetric only reverse", &DialOptions{MinHops: 2}, false, 2},
+		{"per-direction wins forward", &DialOptions{MinHops: 2, ForwardMinHops: 4}, true, 4},
+		{"per-direction wins reverse", &DialOptions{MinHops: 2, ReverseMinHops: 4}, false, 4},
+		{"per-direction does NOT affect other direction", &DialOptions{MinHops: 2, ForwardMinHops: 4}, false, 2},
+		{"per-direction does NOT affect other direction rev", &DialOptions{MinHops: 2, ReverseMinHops: 4}, true, 2},
+		{"asymmetric: forward=0 reverse=2", &DialOptions{ForwardMinHops: 0, ReverseMinHops: 2}, true, 0},
+		{"asymmetric: forward=0 reverse=2 rev", &DialOptions{ForwardMinHops: 0, ReverseMinHops: 2}, false, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.opts.EffectiveMinHops(c.forward)
+			if got != c.want {
+				t.Errorf("EffectiveMinHops(%v) = %d, want %d", c.forward, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDialOptions_AnyMinHopsConstraint(t *testing.T) {
+	cases := []struct {
+		name string
+		opts *DialOptions
+		want bool
+	}{
+		{"nil", nil, false},
+		{"all zero", &DialOptions{}, false},
+		{"symmetric 1", &DialOptions{MinHops: 1}, false},
+		{"symmetric 2", &DialOptions{MinHops: 2}, true},
+		{"per-direction fwd 2", &DialOptions{ForwardMinHops: 2}, true},
+		{"per-direction rev 2", &DialOptions{ReverseMinHops: 2}, true},
+		// The asymmetric "1 forward + multi-hop reverse" canonical case:
+		// MinHops untouched, ReverseMinHops bumped above 1. The direct-
+		// transport downgrade in DialRoutes must NOT fire here.
+		{"asymmetric reverse-only", &DialOptions{ReverseMinHops: 2}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.opts.AnyMinHopsConstraint()
+			if got != c.want {
+				t.Errorf("AnyMinHopsConstraint() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -177,7 +177,6 @@ type DialOptions struct {
 	// Config.MinHops; else the global default.
 	ForwardMinHops int
 	ReverseMinHops int
-
 }
 
 // DefaultDialOptions returns default dial options.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -161,6 +161,23 @@ type DialOptions struct {
 	// since DialRoutes is invoked with an ephemeral source port that
 	// isn't the app's registered SetAppPort value.
 	AppName string
+
+	// ForwardMinHops / ReverseMinHops are per-direction overrides for
+	// MinHops. When > 0 they take precedence over the symmetric
+	// MinHops field for THAT direction only. Use case: bandwidth-
+	// asymmetric workloads (HTTP GET = tiny upstream, bulk downstream)
+	// where the user wants e.g. direct stcpr for the forward leg but
+	// multi-hop for the reverse-direction bulk payload.
+	//
+	// 0 (the default) means "inherit MinHops" — back-compat for
+	// callers that only care about symmetric routes.
+	//
+	// Resolution at use site (see resolveDirMinHops): if the per-
+	// direction override is > 0 it wins; else MinHops; else
+	// Config.MinHops; else the global default.
+	ForwardMinHops int
+	ReverseMinHops int
+
 }
 
 // DefaultDialOptions returns default dial options.
@@ -173,6 +190,44 @@ func DefaultDialOptions() *DialOptions {
 		MaxConsumeRts: 1,
 		Retries:       3,
 	}
+}
+
+// EffectiveMinHops returns the per-direction min-hops constraint:
+// forward=true → ForwardMinHops if > 0 else MinHops; forward=false →
+// ReverseMinHops if > 0 else MinHops. Callers (the route-finder query
+// site + the local-BFS fallback) read this once per direction to
+// support bandwidth-asymmetric workloads where forward (small uplink)
+// can use direct/short paths while reverse (bulk downlink) is forced
+// onto multi-hop.
+//
+// Returns 0 when opts is nil or both per-direction + symmetric fields
+// are 0 — preserves the caller's "inherit Config.MinHops" semantic.
+func (o *DialOptions) EffectiveMinHops(forward bool) int {
+	if o == nil {
+		return 0
+	}
+	if forward {
+		if o.ForwardMinHops > 0 {
+			return o.ForwardMinHops
+		}
+	} else {
+		if o.ReverseMinHops > 0 {
+			return o.ReverseMinHops
+		}
+	}
+	return o.MinHops
+}
+
+// AnyMinHopsConstraint reports whether the caller has set any min-hops
+// constraint (symmetric or per-direction). Used at the direct-tp
+// downgrade site in DialRoutes: if either direction wants multi-hop,
+// the "transport-exists → drop MinHops to 1" optimization should be
+// suppressed (mirroring the existing opts.MinHops > 1 check).
+func (o *DialOptions) AnyMinHopsConstraint() bool {
+	if o == nil {
+		return false
+	}
+	return o.MinHops > 1 || o.ForwardMinHops > 1 || o.ReverseMinHops > 1
 }
 
 // Router is responsible for creating and keeping track of routes.

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -59,7 +59,11 @@ func (r *router) DialRoutes(
 	// (this was the symptom of `mux-bw --min-hops 2` riding direct stcpr
 	// instead of going via intermediates).
 	defaultMinHops := r.conf.MinHops
-	if r.isTpdExist(rPK) && (opts == nil || opts.MinHops <= 1) {
+	// Suppress the direct-tp downgrade when ANY min-hops constraint is
+	// set (symmetric or per-direction). Even if only ReverseMinHops > 1,
+	// downgrading globally to 1 would defeat that constraint for the
+	// reverse direction's route-finder query below.
+	if r.isTpdExist(rPK) && !opts.AnyMinHopsConstraint() {
 		r.conf.MinHops = 1
 	}
 
@@ -500,12 +504,48 @@ fetchRoutesAgain:
 	// Per-call MinHops override takes precedence over visor-global
 	// Config.MinHops. Set by callers like mux-bw that want to test
 	// a multi-hop path without bumping the visor's static config.
-	rfMinHops := r.conf.MinHops
-	if opts.MinHops > 0 {
-		rfMinHops = uint16(opts.MinHops) //nolint:gosec // bounded by caller; CLI flag values are small
+	//
+	// Per-direction overrides (ForwardMinHops / ReverseMinHops) win
+	// over the symmetric MinHops when set. When the two directions
+	// differ we split into two route-finder queries — the rfclient
+	// applies one MinHops to all PathEdges in a single call, so
+	// asymmetric constraints can't be expressed in one round-trip.
+	fwdEff := opts.EffectiveMinHops(true)
+	revEff := opts.EffectiveMinHops(false)
+	fwdMinHops := r.conf.MinHops
+	revMinHops := r.conf.MinHops
+	if fwdEff > 0 {
+		fwdMinHops = uint16(fwdEff) //nolint:gosec // bounded by caller; CLI flag values are small
 	}
-	paths, err := r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward, backward},
-		&rfclient.RouteOptions{MinHops: rfMinHops, MaxHops: r.conf.MaxHops})
+	if revEff > 0 {
+		revMinHops = uint16(revEff) //nolint:gosec // bounded by caller; CLI flag values are small
+	}
+
+	var paths map[routing.PathEdges][][]routing.Hop
+	if fwdMinHops == revMinHops {
+		// Common path: single query covers both directions.
+		paths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward, backward},
+			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops})
+	} else {
+		// Asymmetric: two queries with different MinHops per direction.
+		// Merge their results into a single map keyed by PathEdges.
+		var fwdPaths, revPaths map[routing.PathEdges][][]routing.Hop
+		fwdPaths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward},
+			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops})
+		if err == nil {
+			revPaths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{backward},
+				&rfclient.RouteOptions{MinHops: revMinHops, MaxHops: r.conf.MaxHops})
+		}
+		if err == nil {
+			paths = make(map[routing.PathEdges][][]routing.Hop, 2)
+			for k, v := range fwdPaths {
+				paths[k] = v
+			}
+			for k, v := range revPaths {
+				paths[k] = v
+			}
+		}
+	}
 
 	if err == rfclient.ErrTransportNotFound {
 		// Try local route calculation - may find a local transport that's not yet in TPD
@@ -826,9 +866,24 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	log.Debugf("Found %d local transports", len(localTps))
 
 	// Skip the direct (1-hop) probe when the caller asked for
-	// MinHops >= 2 — they want a non-direct path. The intermediate
-	// route search below will be the only candidate generator.
-	allowDirect := dialOpts == nil || dialOpts.MinHops <= 1
+	// MinHops >= 2 — they want a non-direct path. Use the MAX of
+	// per-direction MinHops since local-BFS mirrors forward to reverse
+	// (reverseHops) — both directions share one path here, so we must
+	// satisfy whichever direction has the higher constraint. Callers
+	// that need genuinely asymmetric local paths must use the
+	// route-finder service (fetchBestRoutes path) which queries each
+	// direction independently.
+	bfsMinHops := 0
+	if dialOpts != nil {
+		bfsMinHops = dialOpts.MinHops
+		if fwdEff := dialOpts.EffectiveMinHops(true); fwdEff > bfsMinHops {
+			bfsMinHops = fwdEff
+		}
+		if revEff := dialOpts.EffectiveMinHops(false); revEff > bfsMinHops {
+			bfsMinHops = revEff
+		}
+	}
+	allowDirect := bfsMinHops <= 1
 
 	// Check for direct (1-hop) route first
 	for _, tp := range localTps {
@@ -958,7 +1013,13 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	// same (src, dst, minHops, maxHops, transport graph) tuple
 	// always yields the same path.
 	minHops := 2
-	if dialOpts != nil && dialOpts.MinHops > 0 {
+	// Use bfsMinHops computed above (max across symmetric + per-
+	// direction). Local-BFS mirrors forward→reverse so both directions
+	// share one path; satisfying the higher constraint ensures the
+	// stricter direction is honored.
+	if bfsMinHops > 0 {
+		minHops = bfsMinHops
+	} else if dialOpts != nil && dialOpts.MinHops > 0 {
 		minHops = dialOpts.MinHops
 	}
 	// MaxHops is taken from the router-wide config (DialOptions
@@ -1207,12 +1268,19 @@ func (r *router) establishMuxRoutes(
 	// happily returns the direct transport — so a `--routes N
 	// --min-hops 2` call would establish route 0 multi-hop but routes
 	// 1..N-1 over the direct stcpr, defeating the disjoint-mux intent.
-	// AppName is threaded for log-attribution consistency across the
-	// aux routes (the scoped logger keys on app name).
+	// Per-direction MinHops (Forward/ReverseMinHops) is threaded too
+	// so asymmetric mux dials honor the same per-direction constraints
+	// the parent set. AppName is threaded for log-attribution
+	// consistency across the aux routes (the scoped logger keys on
+	// app name).
 	parentMinHops := 0
+	parentFwdMinHops := 0
+	parentRevMinHops := 0
 	parentAppName := ""
 	if opts != nil {
 		parentMinHops = opts.MinHops
+		parentFwdMinHops = opts.ForwardMinHops
+		parentRevMinHops = opts.ReverseMinHops
 		parentAppName = opts.AppName
 	}
 
@@ -1224,6 +1292,8 @@ func (r *router) establishMuxRoutes(
 			MaxConsumeRts:          1,
 			Retries:                1,
 			MinHops:                parentMinHops,
+			ForwardMinHops:         parentFwdMinHops,
+			ReverseMinHops:         parentRevMinHops,
 			AppName:                parentAppName,
 			ExcludeTransportIDs:    excludeIDs,
 			ExcludeIntermediatePKs: excludePKs,


### PR DESCRIPTION
## Summary

Real workloads are bandwidth-asymmetric — HTTP GET = tiny upstream + bulk downstream; file transfer, video, skynet port-forwarding all follow this shape. Symmetric \`MinHops\` forces forward and reverse paths through the same hop-count constraint, so the user can't say "direct upstream + multi-hop downstream" — the operator's canonical asymmetric test.

This PR adds \`ForwardMinHops\` + \`ReverseMinHops\` to \`router.DialOptions\`. When either is > 0 it overrides the symmetric \`MinHops\` for that direction only. Zero = inherit \`MinHops\`.

**Canonical use** (post-deploy):
```
cli skynet start --pk <peer> --routes 4 --reverse-min-hops 2
```
Forward stays direct (low-latency upstream for the GET), reverse is forced through 2-hop intermediates and aggregated across 4 mux routes (downstream bandwidth aggregation).

## Implementation

- \`pkg/router/router.go\`: new fields on \`DialOptions\` + \`EffectiveMinHops(forward bool)\` + \`AnyMinHopsConstraint()\` helpers.
- \`pkg/router/router_dial.go\`:
  - Direct-tp downgrade in \`DialRoutes\` now suppressed by **any** min-hops constraint (not just symmetric).
  - \`fetchBestRoutes\` does 2 route-finder queries when forward and reverse \`MinHops\` differ (single call otherwise — common path).
  - \`calculateLocalRoutes\` (local BFS fallback) uses \`max(symmetric, fwd, rev)\` since it mirrors forward to reverse via \`reverseHops()\` — must satisfy the stricter direction.
  - \`establishMuxRoutes\` threads per-direction \`MinHops\` to aux routes too.
- \`pkg/app/appserver/rpc_ingress_gateway.go\`: \`DialOptionsReq\` gains \`ForwardMinHops\` + \`ReverseMinHops\`; \`dialInternal\` + \`dialWithMuxRoutes\` plumb them through to \`router.DialOptions\`.
- \`pkg/app/appserver/rpc_ingress_client.go\`: \`DialWithOptions\` signature gains \`fwdMinHops, revMinHops int\` params (mirrored in mock).
- \`pkg/app/client.go\`: same signature extension; non-zero in any of the new fields triggers the \`rpcC.DialWithOptions\` path.
- \`cmd/apps/skynet-client/commands/skynet-client.go\`: new \`--forward-min-hops\` + \`--reverse-min-hops\` flags; threaded to \`appCl.DialWithOptions\`. Dial-shape log collapsed into a single line listing only the set fields.
- \`cmd/skywire-cli/commands/skynet/root.go\`: same flags on the user-facing wrapper, forwarded into the spawned app's args map.

## Tests

- \`pkg/router/dial_options_test.go\`: 2 helper tables covering all field combinations including the asymmetric reverse-only case.
- \`pkg/app/appserver/rpc_ingress_gateway_test.go\`: new subtest pins that \`ForwardMinHops\` / \`ReverseMinHops\` fall through to default dial on non-skywire networkers (mirrors existing MuxRoutes / MinHops fallthrough cases — pins the wire shape of the new fields).
- Existing tests updated for the 5-arg \`DialWithOptions\` signature.
- Full \`pkg/router/\` + \`pkg/app/\` test suites pass.

## What this PR does NOT do (deferred)

- **Per-direction MuxRoutes** (1 forward leg + N reverse legs). Requires data-plane changes since \`route_group\`'s \`fwd[]\` and \`rvs[]\` are populated by paired bidirectional setup. Followup.
- **\`calculateLocalRoutes\` asymmetric BFS.** Currently uses \`max()\` over per-direction MinHops since it mirrors forward to reverse via \`reverseHops()\`. Genuine two-BFS would be larger refactoring.

## Composition

Continues the 8-PR plumbing chain #2751→#2765→#2766→#2770→#2774→#2776→#2782→#2785 that unlocked usable multi-hop on the production deployment today: 1.2-2.5 MB/s on 50 MB pulls, 4/5 reps complete vs 0/N pre-chain. Per-direction \`MinHops\` makes the next class of test (asymmetric workload shape) measurable.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -count=1 -timeout 60s ./pkg/router/... ./pkg/app/...\` all pass (38s)
- [ ] Post-deploy: fire \`cli skynet start --pk <peer> -r 8090 -l 9300 --routes 4 --reverse-min-hops 2\` against Gamma's fileserver. Visor log should show:
  - \`Per-accept dial shape: ... with 4 parallel mux routes reverse-min-hops=2\`
  - Two \`Found routes\` log lines per dial cycle (forward + reverse route-finder queries with different \`MinHops\`)
  - Forward path's hop-count short (1 if direct available), reverse path's hop-count \>= 2