### PR TITLE
fix(hv): only star sub-section row matching the section's hypervisor PK

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -214,7 +214,19 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 			// side, here projected back.
 			visors := make([]Summary, 0, len(sr.entries))
 			for _, e := range sr.entries {
-				visors = append(visors, projectEntryToSummary(e))
+				s := projectEntryToSummary(e)
+				// The sub-section's ★ icon should appear on the
+				// section's own hypervisor row and nowhere else.
+				// Override IsHypervisor (which projectEntryToSummary
+				// sets from e.IsLocal) with strict PK-equality
+				// against this section's HypervisorPK. Defends
+				// against any path that might mistakenly mark a
+				// non-local entry with IsLocal=true on the remote
+				// side, and matches the semantic the hvui's
+				// node-list uses for the local section: "star = this
+				// row is the section's hypervisor."
+				s.IsHypervisor = e.PK == sr.hyperPK
+				visors = append(visors, s)
 			}
 			sections = append(sections, VisorTreeSection{
 				HypervisorPK: sr.hyperPK,


### PR DESCRIPTION
## Summary

Operator post-#2791 reports 192.168.1.102 (a sub-hypervisor connected to the local hypervisor) shows the ★ icon in two sections, not just its own.

The code path that should govern this: \`projectEntryToSummary\` sets \`IsHypervisor: e.IsLocal\`. \`HVListDirectVisors\` marks only the responding sub-hypervisor's own local entry with \`IsLocal=true\`. So star-in-two-places shouldn't be possible by reading the code straight — but the operator is seeing it.

Rather than chase what's leaking, switch to a foolproof rule at the section-build site.

## Fix

In \`getVisorsTreeSummary\`'s sub-section loop, after \`projectEntryToSummary(e)\`, explicitly override:

\`\`\`go
s.IsHypervisor = e.PK == sr.hyperPK
\`\`\`

The star semantic is *\"this row is the section's hypervisor\"*; deriving from PK match against the section's own \`HypervisorPK\` is foolproof and defends against:

- Stale older sub-hypervisor binaries that might mark non-local entries \`IsLocal=true\`.
- Any future projection path that might mistakenly preserve \`IsLocal=true\` across boundaries.

Local section star (driven by \`makeSummaryResp\`'s \`hyper=true\` on \`hv.visor.conf.PK\` only) is unchanged.

\`projectEntryToSummary\` still defaults \`IsHypervisor: e.IsLocal\` — the caller-level override is the source of truth now. Leaving the helper default unchanged keeps it usable from tests / future direct-projection callers without surprises.

## Test plan

- [x] \`go build ./...\`
- [x] \`make lint\` clean
- [x] \`make build-ui\` clean
- [ ] Live: operator confirms 192.168.1.102 has the ★ only in its own section after redeploy

## Related

Sub-hypervisor section visual polish series: #2780 / #2784 / #2786 / #2787 / #2788 / #2789 / #2790 / #2791. This is the final defensive pass on the star.