### PR TITLE
feat(router): per-direction MuxRoutes for asymmetric route counts

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -56,6 +56,13 @@ var (
 	// lets forward stay direct while reverse is forced multi-hop.
 	fwdMinHops int
 	revMinHops int
+	// fwdMux / revMux are per-direction MuxRoutes overrides. When > 0
+	// they win over --routes for THAT direction's route count.
+	// Canonical download-heavy shape: --forward-mux 1 --reverse-mux 4
+	// yields 1 forward leg (cheap upstream) + 4 reverse legs that
+	// aggregate the bulk payload.
+	fwdMux int
+	revMux int
 )
 
 func init() {
@@ -68,6 +75,8 @@ func init() {
 	RootCmd.Flags().IntVar(&minHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
 	RootCmd.Flags().IntVar(&fwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override (>=2 forces multi-hop on forward direction only)")
 	RootCmd.Flags().IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse direction only)")
+	RootCmd.Flags().IntVar(&fwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override (>0 sets forward leg count independent of --routes)")
+	RootCmd.Flags().IntVar(&revMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override (>0 sets reverse leg count; canonical download-heavy shape: --forward-mux 1 --reverse-mux N)")
 }
 
 // RootCmd is the root command for skynet-client
@@ -101,6 +110,8 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		fs.IntVar(&minHops, "min-hops", 0, "minimum hop count (>=2 rejects direct paths)")
 		fs.IntVar(&fwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override")
 		fs.IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override")
+		fs.IntVar(&fwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override")
+		fs.IntVar(&revMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -176,11 +187,17 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	if revMinHops > 1 {
 		dialShape += fmt.Sprintf(" reverse-min-hops=%d", revMinHops)
 	}
+	if fwdMux > 0 {
+		dialShape += fmt.Sprintf(" forward-mux=%d", fwdMux)
+	}
+	if revMux > 0 {
+		dialShape += fmt.Sprintf(" reverse-mux=%d", revMux)
+	}
 	appCl.Log().Infof("Per-accept dial shape: %s", dialShape)
 
 	dialRemote := func() (net.Conn, error) {
-		if routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 {
-			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops)
+		if routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
+			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 		}
 		return appCl.Dial(connApp)
 	}

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -32,6 +32,8 @@ var (
 	startMinHops    int    // minimum-hop constraint (>=2 rejects direct paths)
 	startFwdMinHops int    // per-direction forward MinHops override
 	startRevMinHops int    // per-direction reverse MinHops override
+	startFwdMux     int    // per-direction forward MuxRoutes override
+	startRevMux     int    // per-direction reverse MuxRoutes override
 )
 
 func init() {
@@ -53,6 +55,8 @@ func init() {
 	startCmd.Flags().IntVar(&startMinHops, "min-hops", 0, "force routes through at least this many intermediates (>=2 rejects direct paths)")
 	startCmd.Flags().IntVar(&startFwdMinHops, "forward-min-hops", 0, "per-direction forward MinHops override (>=2 forces multi-hop on forward only)")
 	startCmd.Flags().IntVar(&startRevMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse only; combine with low/0 --min-hops for direct-upstream + multi-hop-downstream)")
+	startCmd.Flags().IntVar(&startFwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override (>0 sets forward leg count independent of --routes)")
+	startCmd.Flags().IntVar(&startRevMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override (download-heavy: --forward-mux 1 --reverse-mux N)")
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 
 	stopCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of the client instance to stop")
@@ -140,6 +144,14 @@ var startCmd = &cobra.Command{
 
 		if startRevMinHops > 1 {
 			arguments["--reverse-min-hops"] = fmt.Sprintf("%d", startRevMinHops)
+		}
+
+		if startFwdMux > 0 {
+			arguments["--forward-mux"] = fmt.Sprintf("%d", startFwdMux)
+		}
+
+		if startRevMux > 0 {
+			arguments["--reverse-mux"] = fmt.Sprintf("%d", startRevMux)
 		}
 
 		err = rpcClient.DoCustomSetting(appName, arguments)

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -123,9 +123,9 @@ func (_m *MockRPCIngressClient) Dial(remote appnet.Addr) (uint16, routing.Port, 
 	return r0, r1, r2
 }
 
-// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops, fwdMinHops, revMinHops
-func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int) (uint16, routing.Port, error) {
-	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+// DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux
+func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int, fwdMux int, revMux int) (uint16, routing.Port, error) {
+	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DialWithOptions")
@@ -134,23 +134,23 @@ func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes in
 	var r0 uint16
 	var r1 routing.Port
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int) (uint16, routing.Port, error)); ok {
-		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int) (uint16, routing.Port, error)); ok {
+		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 	}
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int) uint16); ok {
-		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int) uint16); ok {
+		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int) routing.Port); ok {
-		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int, int, int) routing.Port); ok {
+		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 	} else {
 		r1 = ret.Get(1).(routing.Port)
 	}
 
-	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int) error); ok {
-		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int, int, int) error); ok {
+		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -21,12 +21,14 @@ type RPCIngressClient interface {
 	SetAppPort(appPort routing.Port) error
 	Dial(remote appnet.Addr) (connID uint16, localPort routing.Port, err error)
 	// DialWithOptions asks the server to dial remote with per-call
-	// options. Honored fields: muxRoutes (>1 = N parallel mux routes),
-	// minHops (>=2 = force routes through N intermediates), fwdMinHops
-	// / revMinHops (per-direction MinHops overrides for bandwidth-
-	// asymmetric workloads — when > 0 they win over minHops for that
-	// direction only). All <= 1 is equivalent to plain Dial.
-	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (connID uint16, localPort routing.Port, err error)
+	// options. Honored fields:
+	//   - muxRoutes (>1 = N parallel mux routes)
+	//   - minHops (>=2 = force routes through N intermediates)
+	//   - fwdMinHops / revMinHops (per-direction MinHops overrides)
+	//   - fwdMux / revMux (per-direction MuxRoutes overrides; setting
+	//     fwdMux=1 + revMux=N yields 1 forward leg + N reverse legs)
+	// All <= 1 is equivalent to plain Dial.
+	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
 	Write(connID uint16, b []byte) (int, error)
@@ -94,13 +96,15 @@ func (c *rpcIngressClient) Dial(remote appnet.Addr) (connID uint16, localPort ro
 // DialWithOptions sends `DialWithOptions` command to the server.
 // All fields <= 1 falls through to plain Dial semantics on the server
 // side (no extra round-trip cost beyond the slightly larger request).
-func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (connID uint16, localPort routing.Port, err error) {
+func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (connID uint16, localPort routing.Port, err error) {
 	req := DialOptionsReq{
-		Addr:           remote,
-		MuxRoutes:      muxRoutes,
-		MinHops:        minHops,
-		ForwardMinHops: fwdMinHops,
-		ReverseMinHops: revMinHops,
+		Addr:             remote,
+		MuxRoutes:        muxRoutes,
+		MinHops:          minHops,
+		ForwardMinHops:   fwdMinHops,
+		ReverseMinHops:   revMinHops,
+		ForwardMuxRoutes: fwdMux,
+		ReverseMuxRoutes: revMux,
 	}
 	var resp DialResp
 	if err := c.rpc.Call(c.formatMethod("DialWithOptions"), &req, &resp); err != nil {

--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -129,7 +129,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// back to plain DialContext; the round-trip still succeeds and
 		// returns a valid ConnID. We're pinning the wire shape, not the
 		// router-level mux behavior (which is integration-tested).
-		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)
@@ -160,7 +160,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// minHops=2 over a non-skynet networker — same fallthrough as
 		// the muxRoutes case. Pins that MinHops is wire-carried through
 		// DialOptionsReq even when the destination family ignores it.
-		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -137,12 +137,20 @@ type DialResp struct {
 // MinHops for that direction only. Zero = inherit MinHops. Setting
 // just ReverseMinHops=2 with MinHops=0 lets forward stay direct while
 // reverse is forced multi-hop — the canonical asymmetric test shape.
+//
+// ForwardMuxRoutes / ReverseMuxRoutes are per-direction overrides for
+// MuxRoutes. Setting ForwardMuxRoutes=1 + ReverseMuxRoutes=4 yields
+// 1 forward leg + 4 reverse legs — the canonical asymmetric-count
+// shape (download-heavy workload aggregating only the reverse
+// direction).
 type DialOptionsReq struct {
-	Addr           appnet.Addr
-	MuxRoutes      int
-	MinHops        int
-	ForwardMinHops int
-	ReverseMinHops int
+	Addr             appnet.Addr
+	MuxRoutes        int
+	MinHops          int
+	ForwardMinHops   int
+	ReverseMinHops   int
+	ForwardMuxRoutes int
+	ReverseMuxRoutes int
 }
 
 // Dial dials to the remote.
@@ -226,7 +234,9 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, req *DialOptionsReq
 // mock or future alternative networker silently degrades to single-
 // route, preserving correctness with no extra plumbing).
 func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptionsReq) (net.Conn, error) {
-	if req == nil || (req.MuxRoutes <= 1 && req.MinHops <= 1 && req.ForwardMinHops <= 1 && req.ReverseMinHops <= 1) {
+	if req == nil || (req.MuxRoutes <= 1 && req.MinHops <= 1 &&
+		req.ForwardMinHops <= 1 && req.ReverseMinHops <= 1 &&
+		req.ForwardMuxRoutes <= 1 && req.ReverseMuxRoutes <= 1) {
 		return appnet.DialContext(ctx, remote)
 	}
 	nw, err := appnet.ResolveNetworker(remote.Net)
@@ -244,6 +254,8 @@ func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptions
 	opts.MinHops = req.MinHops
 	opts.ForwardMinHops = req.ForwardMinHops
 	opts.ReverseMinHops = req.ReverseMinHops
+	opts.ForwardMuxRoutes = req.ForwardMuxRoutes
+	opts.ReverseMuxRoutes = req.ReverseMuxRoutes
 	return sw.DialContextWithOptions(ctx, remote, opts)
 }
 

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -106,7 +106,7 @@ func (c *Client) SetAppPort(appPort routing.Port) error {
 
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
-	return c.dial(remote, 0, 0, 0, 0)
+	return c.dial(remote, 0, 0, 0, 0, 0, 0)
 }
 
 // DialWithOptions dials remote with per-call dial options.
@@ -117,18 +117,21 @@ func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
 //   - minHops: when >= 2, the router rejects the direct path and
 //     finds routes through that many intermediates.
 //   - fwdMinHops / revMinHops: per-direction MinHops overrides for
-//     bandwidth-asymmetric workloads. When > 0 they take precedence
-//     over minHops for THAT direction only. Setting just
-//     revMinHops=2 with minHops=0 lets forward stay direct while
-//     reverse is forced multi-hop — the canonical asymmetric test
-//     shape (HTTP GET: tiny upstream + bulk downstream).
+//     bandwidth-asymmetric path quality (e.g. direct upstream +
+//     multi-hop downstream).
+//   - fwdMux / revMux: per-direction MuxRoutes overrides for
+//     asymmetric route counts. Setting fwdMux=1 + revMux=N yields
+//     1 forward leg + N reverse legs — the canonical download-heavy
+//     workload shape where only the bulk-receive direction is
+//     aggregated.
 //
 // All <= 1 is semantically equivalent to Dial. Apps requesting these
 // dial shapes (e.g. skynet-client with --routes / --min-hops /
-// --forward-min-hops / --reverse-min-hops flags) call this instead
-// of Dial; non-mux callers keep using Dial unchanged.
-func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (net.Conn, error) {
-	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+// --forward-min-hops / --reverse-min-hops / --forward-mux /
+// --reverse-mux flags) call this instead of Dial; non-mux callers
+// keep using Dial unchanged.
+func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (net.Conn, error) {
+	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 }
 
 // dial is the common body for Dial + DialWithOptions. When all opts
@@ -136,14 +139,14 @@ func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinH
 // existing wire shape for non-mux callers); otherwise sends the
 // DialWithOptions request so the server-side knows to take the
 // SkywireNetworker per-call-opts path.
-func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops int) (net.Conn, error) {
+func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (net.Conn, error) {
 	var (
 		connID    uint16
 		localPort routing.Port
 		err       error
 	)
-	if muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 {
-		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops)
+	if muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
+		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 	} else {
 		connID, localPort, err = c.rpcC.Dial(remote)
 	}

--- a/pkg/router/dial_options_test.go
+++ b/pkg/router/dial_options_test.go
@@ -34,6 +34,35 @@ func TestDialOptions_EffectiveMinHops(t *testing.T) {
 	}
 }
 
+func TestDialOptions_EffectiveMuxRoutes(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    *DialOptions
+		forward bool
+		want    int
+	}{
+		{"nil opts forward", nil, true, 0},
+		{"nil opts reverse", nil, false, 0},
+		{"symmetric only forward", &DialOptions{MuxRoutes: 4}, true, 4},
+		{"symmetric only reverse", &DialOptions{MuxRoutes: 4}, false, 4},
+		{"per-direction wins forward", &DialOptions{MuxRoutes: 4, ForwardMuxRoutes: 1}, true, 1},
+		{"per-direction wins reverse", &DialOptions{MuxRoutes: 4, ReverseMuxRoutes: 8}, false, 8},
+		{"per-direction does NOT affect other forward", &DialOptions{MuxRoutes: 4, ReverseMuxRoutes: 8}, true, 4},
+		{"per-direction does NOT affect other reverse", &DialOptions{MuxRoutes: 4, ForwardMuxRoutes: 1}, false, 4},
+		// Canonical asymmetric download shape: fwd=1, rev=N.
+		{"asymmetric: fwd=1 rev=4 fwd", &DialOptions{ForwardMuxRoutes: 1, ReverseMuxRoutes: 4}, true, 1},
+		{"asymmetric: fwd=1 rev=4 rev", &DialOptions{ForwardMuxRoutes: 1, ReverseMuxRoutes: 4}, false, 4},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.opts.EffectiveMuxRoutes(c.forward)
+			if got != c.want {
+				t.Errorf("EffectiveMuxRoutes(%v) = %d, want %d", c.forward, got, c.want)
+			}
+		})
+	}
+}
+
 func TestDialOptions_AnyMinHopsConstraint(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1426,6 +1426,51 @@ func (rg *RouteGroup) appendRules(forward, reverse routing.Rule, tp *transport.M
 	}
 }
 
+// appendForwardLeg adds a forward leg (rule + transport) WITHOUT a
+// matching reverse rule. Used by asymmetric mux setups where the
+// ForwardMuxRoutes count exceeds ReverseMuxRoutes — e.g. a workload
+// with bulk upstream but tiny downstream. The reverse-direction
+// rule from the same setup-node call is discarded by the caller
+// (router.appendRouteAsymmetric) so it doesn't leak in the routing
+// table.
+//
+// Mirrors appendRules' tps[]+fwd[] parallel maintenance but leaves
+// rvs[] untouched. Mux weight + per-leg counter bookkeeping treats
+// this as a new forward leg.
+func (rg *RouteGroup) appendForwardLeg(forward routing.Rule, tp *transport.ManagedTransport) {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+
+	rg.fwd = append(rg.fwd, forward)
+	rg.tps = append(rg.tps, tp)
+
+	if rg.mux != nil && len(rg.tps) > 1 {
+		rg.mux.rebuildWeights(rg.tps)
+	}
+	if rg.mux != nil {
+		rg.mux.growLegs(len(rg.tps))
+	}
+}
+
+// appendReverseLeg adds a reverse rule WITHOUT a paired forward
+// rule + transport. Used by asymmetric mux setups where
+// ReverseMuxRoutes exceeds ForwardMuxRoutes — the operator's
+// canonical bandwidth-asymmetric case (1 forward + N reverse for
+// download-heavy workloads).
+//
+// rvs[] grows independently of tps[]/fwd[]; the read path is by
+// route-id lookup (not slice-indexed) so this works without further
+// data-plane changes. Per-leg counter slots (mux.legs) are NOT
+// extended here — they are parallel to tps[] and the reverse-only
+// leg doesn't add a forward transport. Per-direction recv-byte
+// attribution for reverse-only legs is a separate refinement.
+func (rg *RouteGroup) appendReverseLeg(reverse routing.Rule) {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+
+	rg.rvs = append(rg.rvs, reverse)
+}
+
 func chanClosed(ch chan struct{}) bool {
 	select {
 	case <-ch:

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -177,6 +177,24 @@ type DialOptions struct {
 	// Config.MinHops; else the global default.
 	ForwardMinHops int
 	ReverseMinHops int
+
+	// ForwardMuxRoutes / ReverseMuxRoutes are per-direction overrides
+	// for MuxRoutes. When > 1 they take precedence over the symmetric
+	// MuxRoutes field for THAT direction's route count.
+	//
+	// Use case: the operator's "direct upstream + multi-hop downstream"
+	// test — set ForwardMuxRoutes=1 and ReverseMuxRoutes=4 to open a
+	// single forward leg (the GET request rides one TCP socket) while
+	// the reverse direction aggregates the bulk payload across 4
+	// multi-hop legs. The data plane already supports rg.fwd[] and
+	// rg.rvs[] being different lengths (the read path is by route-id
+	// lookup, not slice index), so this is purely a setup-side change.
+	//
+	// 0 (the default) means "inherit MuxRoutes" for that direction.
+	// When the caller wants strictly N=1 on a side they should set it
+	// to 1 explicitly (not 0) since 0 still falls through to MuxRoutes.
+	ForwardMuxRoutes int
+	ReverseMuxRoutes int
 }
 
 // DefaultDialOptions returns default dial options.
@@ -215,6 +233,31 @@ func (o *DialOptions) EffectiveMinHops(forward bool) int {
 		}
 	}
 	return o.MinHops
+}
+
+// EffectiveMuxRoutes returns the per-direction mux-route count:
+// forward=true → ForwardMuxRoutes if > 0 else MuxRoutes; forward=false →
+// ReverseMuxRoutes if > 0 else MuxRoutes. Callers (establishMuxRoutes,
+// the dial-shape logger) read this once per direction to support
+// asymmetric mux topologies — most commonly 1 forward + N reverse
+// for download-heavy workloads.
+//
+// Returns 0 when opts is nil or all relevant fields are 0; preserves
+// the "single route" default behavior.
+func (o *DialOptions) EffectiveMuxRoutes(forward bool) int {
+	if o == nil {
+		return 0
+	}
+	if forward {
+		if o.ForwardMuxRoutes > 0 {
+			return o.ForwardMuxRoutes
+		}
+	} else {
+		if o.ReverseMuxRoutes > 0 {
+			return o.ReverseMuxRoutes
+		}
+	}
+	return o.MuxRoutes
 }
 
 // AnyMinHopsConstraint reports whether the caller has set any min-hops

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1216,6 +1216,16 @@ func hopPath(path []routing.Hop) string {
 
 // establishMuxRoutes attempts to establish additional parallel routes for a mux-enabled
 // route group. Called after the primary route is established in DialRoutes.
+//
+// Supports asymmetric mux counts: ForwardMuxRoutes / ReverseMuxRoutes
+// override the symmetric MuxRoutes for that direction (see
+// DialOptions.EffectiveMuxRoutes). The loop runs max(fwd, rev) - 1
+// iterations; per iteration, the aux route's forward leg is appended
+// only if i < fwdCount and the reverse leg only if i < revCount. The
+// unused direction's rule is deleted from the routing table to avoid
+// stale-entry leaks. The most useful case is fwd=1 + rev=N for
+// download-heavy workloads (1 forward upstream + N reverse legs that
+// aggregate the bulk payload).
 func (r *router) establishMuxRoutes(
 	ctx context.Context,
 	nrg *NoiseRouteGroup,
@@ -1224,11 +1234,21 @@ func (r *router) establishMuxRoutes(
 	primaryTpID uuid.UUID,
 ) {
 	log := r.scopedLogForOpts(opts, forwardDesc.SrcPort())
-	muxCount := 1
-	if opts != nil && opts.MuxRoutes > 1 {
-		muxCount = opts.MuxRoutes
+	fwdCount := 1
+	revCount := 1
+	if opts != nil {
+		if eff := opts.EffectiveMuxRoutes(true); eff > 1 {
+			fwdCount = eff
+		}
+		if eff := opts.EffectiveMuxRoutes(false); eff > 1 {
+			revCount = eff
+		}
 	}
-	if muxCount <= 1 || nrg.rg.mux == nil {
+	maxCount := fwdCount
+	if revCount > maxCount {
+		maxCount = revCount
+	}
+	if maxCount <= 1 || nrg.rg.mux == nil {
 		return
 	}
 
@@ -1284,7 +1304,19 @@ func (r *router) establishMuxRoutes(
 		parentAppName = opts.AppName
 	}
 
-	for i := 1; i < muxCount; i++ {
+	for i := 1; i < maxCount; i++ {
+		// Per-iteration direction selection: extend forward only when
+		// this leg is needed for fwdCount, reverse only when needed
+		// for revCount. When both are false we skip the entire setup
+		// (rare; only happens if asymmetric counts disagree on which
+		// side is bigger mid-loop, which can't with the current
+		// max() shape — but the guard is cheap).
+		addFwd := i < fwdCount
+		addRev := i < revCount
+		if !addFwd && !addRev {
+			continue
+		}
+
 		muxOpts := &DialOptions{
 			MinForwardRts:          1,
 			MaxForwardRts:          1,
@@ -1313,7 +1345,7 @@ func (r *router) establishMuxRoutes(
 		// caller can decide whether to fail or accept partial mux.
 		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts)
 		if err != nil {
-			log.Debugf("Mux route %d/%d: no additional route found: %v", i+1, muxCount, err)
+			log.Debugf("Mux route %d/%d: no additional route found: %v", i+1, maxCount, err)
 			break
 		}
 
@@ -1330,20 +1362,32 @@ func (r *router) establishMuxRoutes(
 
 		muxRules, _, err := r.conf.RouteGroupDialer.Dial(ctx, log, r.dmsgC, r.conf.SetupNodes, muxReq)
 		if err != nil {
-			log.Debugf("Mux route %d/%d: setup failed: %v", i+1, muxCount, err)
+			log.Debugf("Mux route %d/%d: setup failed: %v", i+1, maxCount, err)
 			break
 		}
 
-		if err := r.appendRouteToGroup(nrg, muxRules); err != nil {
-			log.Debugf("Mux route %d/%d: append failed: %v", i+1, muxCount, err)
+		if err := r.appendRouteAsymmetric(nrg, muxRules, addFwd, addRev); err != nil {
+			log.Debugf("Mux route %d/%d: append failed (addFwd=%v addRev=%v): %v", i+1, maxCount, addFwd, addRev, err)
 			break
 		}
 
-		excludeIDs = append(excludeIDs, muxRules.Forward.NextTransportID())
-		// Accumulate this route's intermediate hops into the
-		// exclude-PK set so subsequent aux routes avoid them.
-		excludePKs = append(excludePKs, intermediatesOfHops(muxFwd, lPK, rPK)...)
-		log.Infof("Mux route %d/%d established via transport %s", i+1, muxCount, muxRules.Forward.NextTransportID())
+		// Track this route's forward TpID + intermediate-PK set ONLY
+		// when we actually appended the forward direction (the
+		// reverse-only case doesn't contribute to forward-side
+		// disjointness exclusion, since no forward transport was
+		// added). For reverse-only legs we still want disjoint reverse
+		// paths but the exclude set is the union of all-direction
+		// intermediates — accumulating the reverse path's
+		// intermediates handles that.
+		if addFwd {
+			excludeIDs = append(excludeIDs, muxRules.Forward.NextTransportID())
+			excludePKs = append(excludePKs, intermediatesOfHops(muxFwd, lPK, rPK)...)
+		}
+		if addRev {
+			excludePKs = append(excludePKs, intermediatesOfHops(muxRev, rPK, lPK)...)
+		}
+		log.Infof("Mux route %d/%d established (fwd=%v rev=%v) via tp %s",
+			i+1, maxCount, addFwd, addRev, muxRules.Forward.NextTransportID())
 	}
 }
 

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -13,6 +13,77 @@ import (
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
+// appendRouteAsymmetric adds an aux mux leg, selectively appending
+// the forward and/or reverse direction. addFwd=true && addRev=true is
+// equivalent to appendRouteToGroup. When either flag is false, the
+// corresponding rule is deleted from the routing table immediately
+// (the setup-node always creates both sides; this is the cleanup for
+// the unused side so it doesn't accumulate stale entries).
+//
+// Used by establishMuxRoutes when ForwardMuxRoutes != ReverseMuxRoutes
+// to construct asymmetric mux topologies (e.g. 1 forward + N reverse
+// for download-heavy workloads).
+func (r *router) appendRouteAsymmetric(nrg *NoiseRouteGroup, rules routing.EdgeRules, addFwd, addRev bool) error {
+	if !addFwd && !addRev {
+		// Neither direction wanted — delete both rules and skip.
+		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+		return nil
+	}
+
+	if err := r.SaveRoutingRules(rules.Forward, rules.Reverse); err != nil {
+		return fmt.Errorf("SaveRoutingRules: %w", err)
+	}
+
+	// Forward leg requires the transport (writes) + DMSG safety check.
+	if addFwd {
+		nextTpID := rules.Forward.NextTransportID()
+		tp := r.tm.Transport(nextTpID)
+		if tp == nil {
+			r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+			return fmt.Errorf("transport %s not found for additional mux route", nextTpID)
+		}
+		if tp.Entry.Type == tptypes.DMSG {
+			r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+			return errors.New("refusing to append DMSG transport to mux route group")
+		}
+		nrg.rg.mu.Lock()
+		for _, existing := range nrg.rg.tps {
+			if existing != nil && existing.Entry.Type == tptypes.DMSG {
+				nrg.rg.mu.Unlock()
+				r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
+				return errors.New("refusing to mux: route group already contains a DMSG transport")
+			}
+		}
+		nrg.rg.mu.Unlock()
+		nrg.rg.appendForwardLeg(rules.Forward, tp)
+
+		// Send handshake on the new forward transport.
+		rg := nrg.rg
+		rg.mu.Lock()
+		lastIdx := len(rg.tps) - 1
+		lastTp := rg.tps[lastIdx]
+		lastRule := rg.fwd[lastIdx]
+		rg.mu.Unlock()
+		packet := routing.MakeHandshakePacket(lastRule.NextRouteID(), rg.encrypt, routing.CapMux|routing.CapSACK)
+		if err := rg.writePacket(context.Background(), lastTp, packet, lastRule.KeyRouteID()); err != nil {
+			r.logger.WithError(err).Warn("Failed to send handshake on additional mux transport")
+		}
+	} else {
+		// Forward not wanted — drop the forward rule from routing table.
+		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID()})
+	}
+
+	if addRev {
+		nrg.rg.appendReverseLeg(rules.Reverse)
+	} else {
+		// Reverse not wanted — drop the reverse rule from routing table.
+		r.rt.DelRules([]routing.RouteID{rules.Reverse.KeyRouteID()})
+	}
+
+	r.logger.Debugf("Appended asymmetric mux route (fwd=%v rev=%v) to RouteGroup %s", addFwd, addRev, &rules.Desc)
+	return nil
+}
+
 // appendRouteToGroup adds an additional transport/rule pair to an existing
 // mux-enabled NoiseRouteGroup. Used for establishing additional parallel routes.
 func (r *router) appendRouteToGroup(nrg *NoiseRouteGroup, rules routing.EdgeRules) error {


### PR DESCRIPTION
## Summary

Slice C of the asymmetric-routing series — completes the operator's canonical bandwidth-asymmetric test shape: **1 forward leg (cheap upstream) + N reverse legs (aggregated downstream payload)**.

The data plane was already capable: \`rg.fwd[]\`+\`rg.tps[]\` and \`rg.rvs[]\` are independent slices (the read path is by route-id lookup, not slice-indexed iteration). \`RemoveMuxRouteByTransport\` even has \`if idx < len(rg.rvs)\` guards that handle different lengths. The symmetric-only constraint was purely a side effect of how \`establishMuxRoutes\`' loop appended fwd+rev paired.

## Canonical use

\`\`\`
cli skynet start --pk <peer> -r 8090 -l 9300 \\
  --forward-mux 1 --reverse-mux 4 --reverse-min-hops 2
\`\`\`

→ 1 forward leg (direct upstream for the GET request) + 4 reverse legs forced multi-hop, aggregating the bulk payload across 4 disjoint intermediates.

## Changes

- \`pkg/router/router.go\`: \`ForwardMuxRoutes\` / \`ReverseMuxRoutes\` on \`DialOptions\`, with \`EffectiveMuxRoutes(forward bool)\` helper matching the per-direction-MinHops pattern from #2792.
- \`pkg/router/route_group.go\`: \`appendForwardLeg\` (fwd+tps only) + \`appendReverseLeg\` (rvs only) — companions to the existing \`appendRules\`. Mux weight rebuild only triggers when \`tps[]\` grows.
- \`pkg/router/router_mux_ops.go\`: \`appendRouteAsymmetric(nrg, rules, addFwd, addRev)\`. When one direction isn't wanted, the rule on that side is deleted from the local routing table to avoid stale-entry leaks (the setup-node always creates both directions of every \`BidirectionalRoute\`; this is the cleanup).
- \`pkg/router/router_dial.go\`: \`establishMuxRoutes\` computes \`fwdCount\` + \`revCount\` via \`EffectiveMuxRoutes\`, loops \`max(fwdCount,revCount)-1\`, and per-iteration sets \`addFwd = (i < fwdCount)\`, \`addRev = (i < revCount)\`. The exclude-set accumulation tracks per-side intermediates independently so disjoint-intermediate routing works correctly in asymmetric topologies too.
- \`pkg/app/appserver/rpc_ingress_gateway.go\`: \`DialOptionsReq\` gains \`ForwardMuxRoutes\` + \`ReverseMuxRoutes\`; \`dialWithMuxRoutes\` plumbs them into \`router.DialOptions\`.
- \`pkg/app/appserver/rpc_ingress_client.go\` (+ mock): \`DialWithOptions\` signature gains \`fwdMux, revMux int\` — now 7 ints total. (A struct-based variant would be cleaner long-term; left as future cleanup.)
- \`pkg/app/client.go\`: same signature extension; non-zero in any of the new fields triggers the \`rpcC.DialWithOptions\` path.
- \`cmd/apps/skynet-client\` + \`cmd/skywire-cli/commands/skynet/root.go\`: \`--forward-mux\` + \`--reverse-mux\` flags. Dial-shape log surfaces the new fields when set.

## Tests

- \`pkg/router/dial_options_test.go\`: 10 subtests for \`EffectiveMuxRoutes\` covering all field combos + canonical asymmetric (fwd=1 rev=N).
- Existing tests updated for 7-arg \`DialWithOptions\` signature.
- Full \`pkg/router/\` + \`pkg/app/\` suites pass (38s).

## Composition

Continues the chain #2751→#2765→#2766→#2770→#2774→#2776→#2782→#2785→#2792. Slice B (per-direction MinHops) + Slice C (per-direction MuxRoutes) together complete the asymmetric-routing surface end-to-end.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`gofmt -l\` clean
- [x] \`go vet ./pkg/router/... ./pkg/app/... ./cmd/...\` clean
- [x] \`go test -count=1 -timeout 90s ./pkg/router/... ./pkg/app/...\` all pass (38s)
- [ ] Post-deploy: \`cli skynet start --pk <peer> -r 8090 -l 9300 --forward-mux 1 --reverse-mux 4 --reverse-min-hops 2\`. Visor log should show 1 forward "Mux route established" + 3 reverse-only aux "Mux route established (fwd=false rev=true)" entries. The Write path picks among 1 forward transport; the Read path accepts on 4 reverse route-ids.