### PR TITLE
fix(autoconfig,cli/config/gen): quiet gen subprocess + clean flag descs

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -142,7 +142,7 @@ func init() {
 		msg += ": " + skyenv.ConfigName
 	}
 	genConfigCmd.Flags().StringVarP(&output, "out", "o", scriptExecString("${OUTPUT}"), msg+"")
-	genConfigCmd.Flags().BoolVarP(&isHide, "hide", "w", false, "dont print the config to the terminal :: show errors with -n flag")
+	genConfigCmd.Flags().BoolVarP(&isHide, "hide", "w", false, "suppress config output to terminal")
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isEnvs, "envs", "q", false, "show the conf template (reflects flags passed)")
 	genConfigCmd.Flags().StringVarP(&envfileOut, "envout", "Q", "", "write conf template to file (reflects flags passed)")
@@ -150,20 +150,20 @@ func init() {
 	// Config generation flags
 	genConfigCmd.Flags().BoolVarP(&isForce, "force", "f", false, "remove pre-existing config")
 	gHiddenFlags = append(gHiddenFlags, "force")
-	genConfigCmd.Flags().BoolVarP(&isRegen, "regen", "r", false, "re-generate existing config & retain keys")
+	genConfigCmd.Flags().BoolVarP(&isRegen, "regen", "r", false, "regenerate existing config and retain keys")
 	genConfigCmd.Flags().BoolVarP(&isRetainHypervisors, "retainhv", "x", false, "retain existing hypervisors with regen")
 	gHiddenFlags = append(gHiddenFlags, "retainhv")
 
 	// Network and deployment flags
 	genConfigCmd.Flags().StringVarP(&serviceConfURL, "url", "a", scriptExecArray(fmt.Sprintf("${SVCCONFADDR[@]-%s}", serviceConfURL)), "services conf url\n\r")
 	gHiddenFlags = append(gHiddenFlags, "url")
-	genConfigCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", scriptExecBool("${TESTENV:-false}"), "use test deployment\n\r(ports are offset +10000 to allow running alongside prod)")
+	genConfigCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", scriptExecBool("${TESTENV:-false}"), "use test deployment (ports offset +10000 from prod)")
 	gHiddenFlags = append(gHiddenFlags, "testenv")
-	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", scriptExecBool("${DMSGHTTP:-false}"), "use only dmsg connection to skywire services (no http fallback)")
-	genConfigCmd.Flags().BoolVar(&isHTTPOnly, "http", false, "use only http connection to skywire services (no dmsg)")
+	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", scriptExecBool("${DMSGHTTP:-false}"), "use only dmsg for skywire services (no http)")
+	genConfigCmd.Flags().BoolVar(&isHTTPOnly, "http", false, "use only http for skywire services (no dmsg)")
 	genConfigCmd.MarkFlagsMutuallyExclusive("dmsghttp", "http")
 	gHiddenFlags = append(gHiddenFlags, "dmsghttp")
-	genConfigCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "D", scriptExecString("${DMSGCONF}"), "dmsghttp-config path")
+	genConfigCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "D", scriptExecString("${DMSGCONF}"), "dmsghttp config path")
 	gHiddenFlags = append(gHiddenFlags, "dmsgconf")
 	// Note: the historical `BESTPROTO=true` knob was a China-only
 	// dmsghttp-fallback path that fired only when ipinfo.io reported
@@ -189,9 +189,9 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "hide")
 	genConfigCmd.Flags().BoolVarP(&isPublic, "public", "z", scriptExecBool("${VISORISPUBLIC:-false}"), "publicize visor in service discovery")
 	gHiddenFlags = append(gHiddenFlags, "public")
-	genConfigCmd.Flags().IntVar(&stcprPort, "stcpr", scriptExecInt("${STCPRPORT:-0}"), "set tcp transport listening port - 0 for random")
+	genConfigCmd.Flags().IntVar(&stcprPort, "stcpr", scriptExecInt("${STCPRPORT:-0}"), "tcp transport listening port (0 = random)")
 	gHiddenFlags = append(gHiddenFlags, "stcpr")
-	genConfigCmd.Flags().IntVar(&sudphPort, "sudph", scriptExecInt("${SUDPHPORT:-0}"), "set udp transport listening port - 0 for random")
+	genConfigCmd.Flags().IntVar(&sudphPort, "sudph", scriptExecInt("${SUDPHPORT:-0}"), "udp transport listening port (0 = random)")
 	gHiddenFlags = append(gHiddenFlags, "sudph")
 
 	// Routing flags
@@ -261,7 +261,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "disableapps")
 	genConfigCmd.Flags().StringVar(&binPath, "binpath", scriptExecString("${BINPATH}"), "set bin_path for visor native apps")
 	gHiddenFlags = append(gHiddenFlags, "binpath")
-	genConfigCmd.Flags().BoolVarP(&isVpnServerEnable, "servevpn", "v", scriptExecBool("${VPNSERVER:-true}"), "autostart vpn server (default: true)")
+	genConfigCmd.Flags().BoolVarP(&isVpnServerEnable, "servevpn", "v", scriptExecBool("${VPNSERVER:-true}"), "autostart vpn server")
 	gHiddenFlags = append(gHiddenFlags, "servevpn")
 
 	// VPN flags
@@ -270,7 +270,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "killsw")
 	genConfigCmd.Flags().StringVar(&addVPNClientSrv, "addvpn", scriptExecString("${ADDVPNPK}"), "set vpn server public key for vpn client")
 	gHiddenFlags = append(gHiddenFlags, "addvpn")
-	genConfigCmd.Flags().StringVar(&addVPNServerWhitelist, "vpnwl", scriptExecArray("${VPNSERVERWL[@]}"), "comma-separated list of public keys allowed to connect to vpn server (empty = allow all)")
+	genConfigCmd.Flags().StringVar(&addVPNServerWhitelist, "vpnwl", scriptExecArray("${VPNSERVERWL[@]}"), "vpn server whitelist (comma separated; empty allows all)")
 	genConfigCmd.Flags().StringVar(&setVPNServerSecure, "secure", scriptExecString("${VPNSEVERSECURE}"), "change secure mode status of vpn server")
 	gHiddenFlags = append(gHiddenFlags, "secure")
 	genConfigCmd.Flags().StringVar(&setVPNServerNetIfc, "netifc", scriptExecString("${VPNSEVERNETIFC}"), "VPN Server network interface (detected: "+getInterfaceNames()+")")
@@ -281,8 +281,8 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "proxyclientpk")
 	genConfigCmd.Flags().BoolVar(&enableProxyClientAutostart, "startproxyclient", scriptExecBool("${STARTPROXYCLIENT:-false}"), "autostart proxy client")
 	gHiddenFlags = append(gHiddenFlags, "startproxyclient")
-	genConfigCmd.Flags().BoolVar(&isProxyServerEnable, "serveproxy", scriptExecBool("${PROXYSERVER:-true}"), "autostart proxy server (default: true)")
-	genConfigCmd.Flags().StringVar(&proxyServerWhitelist, "proxywl", scriptExecArray("${PROXYSERVERWL[@]}"), "comma-separated list of public keys allowed to connect to proxy server (empty = allow all)")
+	genConfigCmd.Flags().BoolVar(&isProxyServerEnable, "serveproxy", scriptExecBool("${PROXYSERVER:-true}"), "autostart proxy server")
+	genConfigCmd.Flags().StringVar(&proxyServerWhitelist, "proxywl", scriptExecArray("${PROXYSERVERWL[@]}"), "proxy server whitelist (comma separated; empty allows all)")
 
 	// Embedded resolving-proxy flags. Browsers point a single SOCKS5
 	// at the dmsgweb listener and `.dmsg` / `.skynet` URLs resolve.
@@ -290,17 +290,17 @@ func init() {
 	// upstream → skynetweb so one entry covers both TLDs.
 	genConfigCmd.Flags().BoolVar(&enableDmsgWeb, "dmsgweb", scriptExecBool("${DMSGWEB:-false}"), "enable embedded .dmsg resolving SOCKS5 proxy on 127.0.0.1:4445")
 	genConfigCmd.Flags().BoolVar(&enableSkynetWeb, "skynetweb", scriptExecBool("${SKYNETWEB:-false}"), "enable embedded .skynet resolving SOCKS5 proxy on 127.0.0.1:4446")
-	genConfigCmd.Flags().BoolVar(&enableSkymailBridge, "skymail-bridge", scriptExecBool("${SKYMAILBRIDGE:-false}"), "enable embedded SMTP→skywire bridge on 127.0.0.1:1025 (relays *.skynet recipients over dmsg)")
-	genConfigCmd.Flags().StringVar(&dmsgWebUpstreamSOCKS, "dmsgweb-upstream", scriptExecString("${DMSGWEBUPSTREAM}"), "upstream SOCKS5 for non-.dmsg traffic (e.g. 127.0.0.1:1080); empty + skynetweb on = auto-chain to skynetweb")
+	genConfigCmd.Flags().BoolVar(&enableSkymailBridge, "skymail-bridge", scriptExecBool("${SKYMAILBRIDGE:-false}"), "enable SMTP to skywire bridge on 127.0.0.1:1025")
+	genConfigCmd.Flags().StringVar(&dmsgWebUpstreamSOCKS, "dmsgweb-upstream", scriptExecString("${DMSGWEBUPSTREAM}"), "upstream SOCKS5 for non .dmsg traffic (empty chains to skynetweb)")
 	gHiddenFlags = append(gHiddenFlags, "dmsgweb-upstream")
-	genConfigCmd.Flags().StringVar(&skynetWebUpstreamSOCKS, "skynetweb-upstream", scriptExecString("${SKYNETWEBUPSTREAM}"), "upstream SOCKS5 for non-.skynet traffic (e.g. 127.0.0.1:1080)")
+	genConfigCmd.Flags().StringVar(&skynetWebUpstreamSOCKS, "skynetweb-upstream", scriptExecString("${SKYNETWEBUPSTREAM}"), "upstream SOCKS5 for non .skynet traffic")
 	gHiddenFlags = append(gHiddenFlags, "skynetweb-upstream")
 
 	// Skychat flags
-	genConfigCmd.Flags().BoolVar(&isSkychatEnable, "servechat", scriptExecBool("${SKYCHAT:-true}"), "autostart skychat (default: true)")
+	genConfigCmd.Flags().BoolVar(&isSkychatEnable, "servechat", scriptExecBool("${SKYCHAT:-true}"), "autostart skychat")
 	genConfigCmd.Flags().StringVar(&skychatAddr, "chataddr", scriptExecString("${SKYCHATADDR:-"+skyenv.SkychatAddr+"}"), "skychat local address")
 	gHiddenFlags = append(gHiddenFlags, "chataddr")
-	genConfigCmd.Flags().BoolVar(&isSkychatPairEnable, "servechatpair", scriptExecBool("${SKYCHATPAIR:-true}"), "skychat: enable pair-RPC channel to visor (required for group chat)")
+	genConfigCmd.Flags().BoolVar(&isSkychatPairEnable, "servechatpair", scriptExecBool("${SKYCHATPAIR:-true}"), "skychat pair RPC channel (required for group chat)")
 	gHiddenFlags = append(gHiddenFlags, "servechatpair")
 
 	// Skycoin embedded apps. Default-off for both — operator opts in
@@ -309,12 +309,12 @@ func init() {
 	// touches the operator's ~/.skycoin/wallets dir, so when the
 	// visor itself runs as _skywire the wallet should be configured
 	// to drop to the operator's UID.
-	genConfigCmd.Flags().BoolVar(&isSkycoinDaemonEnable, "skycoind", scriptExecBool("${SKYCOIND:-false}"), "autostart skycoin daemon (full node) — single-instance legacy path; superseded by --skycoindinstances when set")
-	genConfigCmd.Flags().StringVar(&skycoinDaemonFiber, "skycoindfiber", scriptExecString("${SKYCOIND_FIBER_TOML}"), "legacy single-instance FIBER_TOML; superseded by --skycoindinstances")
+	genConfigCmd.Flags().BoolVar(&isSkycoinDaemonEnable, "skycoind", scriptExecBool("${SKYCOIND:-false}"), "autostart skycoin daemon (legacy single instance)")
+	genConfigCmd.Flags().StringVar(&skycoinDaemonFiber, "skycoindfiber", scriptExecString("${SKYCOIND_FIBER_TOML}"), "legacy FIBER_TOML path (single instance)")
 	gHiddenFlags = append(gHiddenFlags, "skycoindfiber")
-	genConfigCmd.Flags().StringVar(&skycoinDaemonAPISets, "skycoindapi", scriptExecString("${SKYCOIND_API_SETS}"), "legacy single-instance --enable-gui-api-sets; superseded by --skycoindflags")
+	genConfigCmd.Flags().StringVar(&skycoinDaemonAPISets, "skycoindapi", scriptExecString("${SKYCOIND_API_SETS}"), "legacy api sets (single instance)")
 	gHiddenFlags = append(gHiddenFlags, "skycoindapi")
-	genConfigCmd.Flags().StringVar(&skycoinDaemonUser, "skycoindUSER", scriptExecString("${SKYCOIND_USER}"), "drop skycoin daemon to this user via launcher external-mode (applies to every instance)")
+	genConfigCmd.Flags().StringVar(&skycoinDaemonUser, "skycoindUSER", scriptExecString("${SKYCOIND_USER}"), "skycoin daemon UID (applies to every instance)")
 	gHiddenFlags = append(gHiddenFlags, "skycoindUSER")
 	// Multi-instance: SKYCOIND_INSTANCES is a bash array. Entries
 	// are either the literal "skycoin" (built-in defaults, no
@@ -322,27 +322,27 @@ func init() {
 	// expands ${VAR[@]} into a CSV string here; gen splits on commas
 	// at render time and emits one AppConfig per entry with auto-
 	// allocated --port (base 6420 +2N) and --data-dir.
-	genConfigCmd.Flags().StringVar(&skycoinDaemonInstances, "skycoindinstances", scriptExecArray("${SKYCOIND_INSTANCES[@]}"), "comma-separated list of skycoin-daemon instances; entries are either 'skycoin' (built-in defaults) or a fiber.toml path. Empty = use the legacy single-instance path driven by --skycoind / --skycoindfiber.")
+	genConfigCmd.Flags().StringVar(&skycoinDaemonInstances, "skycoindinstances", scriptExecArray("${SKYCOIND_INSTANCES[@]}"), "skycoin daemon instances (comma separated; skycoin or fiber.toml path)")
 	gHiddenFlags = append(gHiddenFlags, "skycoindinstances")
-	genConfigCmd.Flags().StringVar(&skycoinDaemonFlags, "skycoindflags", scriptExecString("${SKYCOIND_FLAGS}"), "extra flags appended to every skycoin-daemon instance (e.g. '--enable-gui-api-sets READ,STATUS'); --port and --data-dir are auto-allocated and must not appear here")
+	genConfigCmd.Flags().StringVar(&skycoinDaemonFlags, "skycoindflags", scriptExecString("${SKYCOIND_FLAGS}"), "extra flags appended to every skycoin daemon (port and data dir auto allocated)")
 	gHiddenFlags = append(gHiddenFlags, "skycoindflags")
-	genConfigCmd.Flags().BoolVar(&isSkycoinWebEnable, "skycoinweb", scriptExecBool("${SKYCOINWEB:-false}"), "autostart skycoin-web thin-client wallet")
+	genConfigCmd.Flags().BoolVar(&isSkycoinWebEnable, "skycoinweb", scriptExecBool("${SKYCOINWEB:-false}"), "autostart skycoin web wallet (thin client)")
 	// 8002 to avoid colliding with skychat's default at 127.0.0.1:8001.
 	// Both apps' upstream defaults happen to be 8001; skychat got there
 	// first in skywire so skycoin-web shifts up by one. Operator can
 	// override via SKYCOINWEBADDR or the universal settings panel.
-	genConfigCmd.Flags().StringVar(&skycoinWebAddr, "skycoinwebaddr", scriptExecString("${SKYCOINWEBADDR:-127.0.0.1:8002}"), "skycoin-web bind address (host:port)")
+	genConfigCmd.Flags().StringVar(&skycoinWebAddr, "skycoinwebaddr", scriptExecString("${SKYCOINWEBADDR:-127.0.0.1:8002}"), "skycoin web bind address (host:port)")
 	gHiddenFlags = append(gHiddenFlags, "skycoinwebaddr")
 	// SKYCOINWEBNODES is a bash array (multiple node URLs supported
 	// — one per fibercoin the wallet is meant to multi-coin-browse).
 	// scriptExecArray expands ${VAR[@]} into a CSV string here; we
 	// re-split on commas at AppConfig render time and emit repeated
 	// --node-url flags as skycoin-web's StringArrayVar expects.
-	genConfigCmd.Flags().StringVar(&skycoinWebNodeURLs, "skycoinwebnodes", scriptExecArray("${SKYCOINWEBNODES[@]}"), "comma-separated node URLs the skycoin-web wallet talks to (empty = upstream default at https://node.skycoin.com)")
+	genConfigCmd.Flags().StringVar(&skycoinWebNodeURLs, "skycoinwebnodes", scriptExecArray("${SKYCOINWEBNODES[@]}"), "node URLs the skycoin web wallet talks to (comma separated)")
 	gHiddenFlags = append(gHiddenFlags, "skycoinwebnodes")
-	genConfigCmd.Flags().StringVar(&skycoinWebWalletDir, "skycoinwebwallet", scriptExecString("${SKYCOINWEBWALLET}"), "skycoin-web --wallet-dir override (empty = upstream default at ~/.skycoin/wallets)")
+	genConfigCmd.Flags().StringVar(&skycoinWebWalletDir, "skycoinwebwallet", scriptExecString("${SKYCOINWEBWALLET}"), "skycoin web wallet dir override")
 	gHiddenFlags = append(gHiddenFlags, "skycoinwebwallet")
-	genConfigCmd.Flags().StringVar(&skycoinWebUser, "skycoinwebuser", scriptExecString("${SKYCOINWEBUSER}"), "drop skycoin-web to this user via launcher external-mode (POSIX setuid; empty = inherit visor UID)")
+	genConfigCmd.Flags().StringVar(&skycoinWebUser, "skycoinwebuser", scriptExecString("${SKYCOINWEBUSER}"), "skycoin web UID (empty inherits visor UID)")
 	gHiddenFlags = append(gHiddenFlags, "skycoinwebuser")
 
 	// Reward address

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -26,6 +26,7 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -463,71 +464,71 @@ func resolveConfig() resolvedConfig {
 	return r
 }
 
-// generateConfig invokes `skywire cli config gen` with the mode
-// flag (-p or -u) matching what resolveConfig already decided. We
-// intentionally do NOT let the subprocess redo the resolution —
-// autoconfig has an implicit "euid==0 → PKGENV" fallback when the
-// env file leaves both PKGENV and USRENV commented out, but
-// `cli config gen` does not, so without explicit -p/-u the
-// subprocess writes the config to gen's own default path (working-
-// directory ./skywire-config.json) instead of the system path
-// autoconfig is expecting at r.configPath. The mismatch surfaces
-// later as the FATAL `expected config file not found` from
-// autoconfig's post-Stat check and aborts the postinst with
-// exit 100. Propagating the resolved mode explicitly closes the gap.
+// generateConfig invokes `skywire cli config gen` with regen +
+// hide flags. -p/-u are NOT passed: cli config gen reads PKGENV /
+// USRENV from the SKYENV file via scriptExecBool, so the env-var
+// path picks up the same resolution autoconfig made — without
+// hard-coding the mode in the args (the operator's intent lives in
+// /etc/skywire.conf, not in this Cmd line).
 func generateConfig(r resolvedConfig, hvArg string) error {
-	// `-w` / `--hide` suppresses the generated config from being
-	// echoed to stdout. autoconfig is meant for unattended
-	// systemd/postinst invocation — dumping the visor's SK + every
-	// service URL through the terminal at every install is both
-	// noisy (the file is the authoritative copy) and a perceived
-	// secret-leak risk on shared terminals / CI logs. The Stdout
-	// pipe we hook up below is still useful for errors; `-w` only
-	// hides the success-path JSON dump.
-	args := []string{"cli", "config", "gen", "-r", "-w"}
+	// printableArgs is what we PRINT for the operator to copy-paste.
+	// Intentionally omits -w (we suppress the noisy fetch logs
+	// ourselves) and -p/-u (resolved via SKYENV vars). If the
+	// install fails, the operator can paste this exact line and see
+	// the full debug logging that we hid.
+	printableArgs := []string{"cli", "config", "gen", "-r"}
 
-	switch {
-	case r.pkgEnv:
-		args = append(args, "-p")
-	case r.usrEnv:
-		args = append(args, "-u")
-	}
+	// args is what we ACTUALLY pass. -w suppresses the success-path
+	// JSON dump (echoing the SK + every service URL on every install
+	// is noisy and a perceived secret-leak risk on shared terminals).
+	args := []string{"cli", "config", "gen", "-r", "-w"}
 
 	switch hvArg {
 	case "0":
 		args = append(args, "-i")
+		printableArgs = append(printableArgs, "-i")
 	case "1":
 		// no hypervisor
 	case "":
 		// New install? Default to enabling the local hypervisor.
 		if _, err := os.Stat(r.configPath); os.IsNotExist(err) {
 			args = append(args, "-i")
+			printableArgs = append(printableArgs, "-i")
 		}
 	default:
 		args = append(args, "-j", hvArg)
+		printableArgs = append(printableArgs, "-j", hvArg)
 	}
 
 	envPrefix := ""
 	if r.skyenvPath != "" {
 		envPrefix = fmt.Sprintf("SKYENV=%s ", r.skyenvPath)
 	}
-	msg3(fmt.Sprintf("Generating skywire config with command:\n  %s%sskywire %s%s", colorCyan, envPrefix, strings.Join(args, " "), colorReset))
+	msg3(fmt.Sprintf("Generating skywire config with command:\n  %s%sskywire %s%s", colorCyan, envPrefix, strings.Join(printableArgs, " "), colorReset))
 
-	// Forward stdout and stderr to the parent so any error from
-	// `cli config gen` (missing service-config.json, bad SK, write
-	// permission denied, etc.) reaches the operator's apt output /
-	// journalctl. Previously these were both /dev/null'd, so a
-	// failing gen exited 0-or-noise and autoconfig only noticed
-	// downstream — by the time the FATAL Stat fired, the actual
-	// cause was lost.
+	// Suppress the subprocess's stdout/stderr by default. The DMSG
+	// fetch chatter ([INFO]/[DEBUG] lines) and -w's hidden JSON dump
+	// both go through here and are noise on the happy path. Buffer
+	// stderr; on failure flush it so the operator can see what
+	// broke (missing service-config.json, bad SK, write permission
+	// denied, etc.). If the operator wants the verbose path, the
+	// printableArgs above show the same command without -w to paste
+	// into a terminal.
+	var stderrBuf bytes.Buffer
 	cmd := exec.Command("skywire", args...) //nolint:gosec
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = &stderrBuf
 	cmd.Env = os.Environ()
 	if r.skyenvPath != "" {
 		cmd.Env = append(cmd.Env, "SKYENV="+r.skyenvPath)
 	}
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		if stderrBuf.Len() > 0 {
+			fmt.Fprint(os.Stderr, stderrBuf.String())
+		}
+		return err
+	}
+	return nil
 }
 
 // writeSystemdDropIn writes a one-section drop-in that pins User=


### PR DESCRIPTION
## Summary

Three operator-reported issues from an armbian \`apt upgrade skywire-bin 1.3.53 → 1.3.54\` install:

1. **Postinst leaks DMSG fetch logs.** The \`skywire autoconfig\` postinst chain ran \`skywire cli config gen -r -w -p\` but the operator still saw \`[INFO]/[DEBUG]\` DMSG-fetch chatter on stderr. \`-w\` only hides the success-path JSON dump, not the stderr noise.

2. **Printed command leaks internal flags.** The same flow printed:
   \`\`\`
    --> Generating skywire config with command:
       SKYENV=/etc/skywire.conf skywire cli config gen -r -w -p
   \`\`\`
   The printed line is meant for operator copy-paste — it should NOT include \`-w\` (so re-running shows the hidden logs) or \`-p\` (which conflicts with the PKGENV/USRENV vars resolved from /etc/skywire.conf).

3. **Cobra flag descriptions break coloredcobra.** Hyphens in description text (\`re-generate\`, \`single-instance\`, \`set tcp transport listening port - 0 for random\`, etc.) trip the flag-name highlighter. Several descriptions also overran a default 80-col terminal.

## Fixes

### \`cmd/skywire/commands/autoconfig.go::generateConfig\`

- Split into two arg slices: \`printableArgs\` (what we show the operator — no \`-w\`, no \`-p\`/\`-u\`) and \`args\` (actual subprocess invocation — \`-w\` kept).
- \`-p\`/\`-u\` removed from actual args. \`cli config gen\` already reads \`PKGENV\` / \`USRENV\` from \`/etc/skywire.conf\` via \`scriptExecBool\` defaults (\`gen.go:363,367\`), so the env-var path picks up the same mode autoconfig resolved — no need to hard-code it in args.
- Subprocess stderr is now buffered. On success → discarded. On failure → flushed so the operator can see what broke. Happy-path postinst output is finally quiet.

### \`cmd/skywire-cli/commands/config/gen.go\`

- Hyphens stripped from description text on every flag where they appeared (replaced with spaces or rephrased). Coloredcobra now colors flag names cleanly.
- Long descriptions shortened: \`--skycoind\`, \`--skycoindinstances\`, \`--skycoindflags\`, \`--skycoinwebnodes\`, \`--skycoinwebwallet\`, \`--skycoinwebuser\`, \`--skymail-bridge\`, \`--dmsgweb-upstream\`, \`--vpnwl\`, \`--proxywl\`.
- Redundant \`(default: true)\` prefixes dropped from \`--servevpn\`, \`--serveproxy\`, \`--servechat\`, \`--servechatpair\` — cobra appends \`(default true)\` automatically.

## Companion change (AUR repo, separate commit)

Restart-on-upgrade for all package-shipped services. Filed as commit \`1fbd870\` in skycoin/aur \`main\` (deb postinst + arch post_upgrade get a \`systemctl try-restart\` loop covering skywire.service + skywire-{autoconfig,sn,ar,rf,tpd,dmsgd,dmsg,sd}.service + dmsgpty-tcp.socket). Deb prerm's upgrade-case stop is dropped — dpkg unlink+rename leaves the old binary inode mapped for running processes until the postinst try-restart picks them up.

## Test plan

- [x] \`go build ./...\`
- [x] \`make lint\` clean
- [x] \`skywire cli config gen --all\` help output has no hyphens in descriptions
- [ ] Live: operator does \`apt upgrade skywire-bin\` on armbian; postinst output shows only the printed (no-\`-w\`/\`-p\`) command line and no DMSG fetch logs