### PR TITLE
chore(changelog): v1.3.55 — patch release on top of v1.3.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 updates may be generated with `scripts/changelog.sh <PR#lowest> <PR#highest>`
 
+## 1.3.55
+
+Patch release. Two PRs on top of v1.3.54.
+
+### Multihop + multiplexed routing
+
+-   `feat(router)`: per-direction MuxRoutes for asymmetric route counts  [#2797](https://github.com/skycoin/skywire/pull/2797)
+
+### Packaging + config UX
+
+-   `fix(autoconfig,cli/config/gen)`: quiet gen subprocess + clean flag descs  [#2798](https://github.com/skycoin/skywire/pull/2798)
+
+Companion AUR change (skycoin/aur, not in this repo): try-restart loop in deb postinst + arch post_upgrade so every package-shipped service that's currently active picks up the new binary on `apt upgrade` / `pacman -Syu` without operator intervention.
+
 ## 1.3.54
 
 Multihop + multiplexed routing is operator-facing now. A new


### PR DESCRIPTION
## Summary

Two PRs since v1.3.54. Patch release.

- #2797 feat(router): per-direction MuxRoutes for asymmetric route counts
- #2798 fix(autoconfig,cli/config/gen): quiet gen subprocess + clean flag descs

Plus a companion AUR-repo change (try-restart loop on upgrade for every package-shipped systemd unit). Tagging v1.3.55 after this merges.