### PR TITLE
feat(dmsgpty/ui): skypty-ui rebrand + drop box overflow + drop DMSGPTYTERM

### DIFF
--- a/pkg/dmsg/dmsgpty/ui.go
+++ b/pkg/dmsg/dmsgpty/ui.go
@@ -70,18 +70,23 @@ func (ui *UI) SetLogger(log logrus.FieldLogger) {
 }
 
 func (ui *UI) writeBanner(w io.Writer, uiAddr string, sID int32) error {
+	// ANSI Shadow font (https://patorjk.com/software/taag/?f=ANSI%20Shadow).
+	// No enclosing box around the header values — the PTY-HOST (66-char
+	// PK) and UI-URL (PK embedded in the URL) overflow any reasonable
+	// fixed-width box. Drop the box; print the header values flush-left
+	// with a blank-line gap above and below.
 	format := `
-██████╗ ███╗   ███╗███████╗ ██████╗ ██████╗ ████████╗██╗   ██╗     ██╗   ██╗██╗
-██╔══██╗████╗ ████║██╔════╝██╔════╝ ██╔══██╗╚══██╔══╝╚██╗ ██╔╝     ██║   ██║██║
-██║  ██║██╔████╔██║███████╗██║  ███╗██████╔╝   ██║    ╚████╔╝█████╗██║   ██║██║
-██║  ██║██║╚██╔╝██║╚════██║██║   ██║██╔═══╝    ██║     ╚██╔╝ ╚════╝██║   ██║██║
-██████╔╝██║ ╚═╝ ██║███████║╚██████╔╝██║        ██║      ██║        ╚██████╔╝██║
-╚═════╝ ╚═╝     ╚═╝╚══════╝ ╚═════╝ ╚═╝        ╚═╝      ╚═╝         ╚═════╝ ╚═╝
-╔═════════════════════════════════════════════════════════════════════════════╗
-║ PTY-HOST : %s
-║   UI-URL : %s
-║   UI-SID : %d
-╚═════════════════════════════════════════════════════════════════════════════╝
+███████╗██╗  ██╗██╗   ██╗██████╗ ████████╗██╗   ██╗     ██╗   ██╗██╗
+██╔════╝██║ ██╔╝╚██╗ ██╔╝██╔══██╗╚══██╔══╝╚██╗ ██╔╝     ██║   ██║██║
+███████╗█████╔╝  ╚████╔╝ ██████╔╝   ██║    ╚████╔╝█████╗██║   ██║██║
+╚════██║██╔═██╗   ╚██╔╝  ██╔═══╝    ██║     ╚██╔╝ ╚════╝██║   ██║██║
+███████║██║  ██╗   ██║   ██║        ██║      ██║        ╚██████╔╝██║
+╚══════╝╚═╝  ╚═╝   ╚═╝   ╚═╝        ╚═╝      ╚═╝         ╚═════╝ ╚═╝
+
+  PTY-HOST  %s
+  UI-URL    %s
+  UI-SID    %d
+
 `
 	var b bytes.Buffer
 	if _, err := fmt.Fprintf(&b, format, ui.dialer.AddrString(), uiAddr, sID); err != nil {
@@ -179,7 +184,7 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 			}
 		}()
 
-		// urlCommands from URL | set DMSGPTYTERM=1 all times
+		// urlCommands joins any ?commands= query into one bash chain.
 		ptyC.Write([]byte(urlCommands(r, customCommands))) //nolint
 
 		// Create WebSocket reader that handles resize messages
@@ -219,14 +224,14 @@ type ErrorJSON struct {
 }
 
 func logWS(conn net.Conn, msg string) {
-	_, _ = fmt.Fprintf(conn, "[dmsgpty-ui] Status: %s\r", msg) //nolint:errcheck
+	_, _ = fmt.Fprintf(conn, "[skypty-ui] Status: %s\r", msg) //nolint:errcheck
 }
 
 func writeWSError(log logrus.FieldLogger, wsConn net.Conn, err error) {
 	log.WithError(err).
 		WithField("remote_addr", wsConn.RemoteAddr()).
 		Error()
-	errB := append([]byte("[dmsgpty-ui] Error: "+err.Error()), '\n', '\r')
+	errB := append([]byte("[skypty-ui] Error: "+err.Error()), '\n', '\r')
 	if _, err := wsConn.Write(errB); err != nil {
 		log.WithError(err).Error("Failed to write error msg to ws conn.")
 	}
@@ -245,7 +250,15 @@ func writeError(log logrus.FieldLogger, w http.ResponseWriter, r *http.Request, 
 }
 
 func urlCommands(r *http.Request, customCommands map[string][]string) string {
-	commands := []string{"export DMSGPTYTERM=1"}
+	// DMSGPTYTERM=1 used to be exported here as a marker the legacy
+	// bash autoconfig checked to skip its own service-restart step
+	// (avoiding a self-interrupt when operators installed skywire from
+	// inside a dmsgpty session). Replaced by NOAUTOCONFIG=true, which
+	// the Go autoconfig honors at the top of its Run handler — set it
+	// before `apt install` / `yay -S` to install without auto-restart,
+	// then run `systemctl start skywire-autoconfig.service` from
+	// outside the pty to configure + restart.
+	var commands []string
 	if commandsQuery, ok := r.URL.Query()["commands"]; ok {
 		if len(commandsQuery[0]) > 0 {
 			commands = append(commands, strings.Split(commandsQuery[0], ",")...)

--- a/pkg/dmsg/dmsgpty/ui.go
+++ b/pkg/dmsg/dmsgpty/ui.go
@@ -185,7 +185,13 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 		}()
 
 		// urlCommands joins any ?commands= query into one bash chain.
-		ptyC.Write([]byte(urlCommands(r, customCommands))) //nolint
+		// Skip the write entirely when there's nothing to send — a
+		// bare "\n" gets interpreted by the pty as Enter and the
+		// shell re-renders the prompt, producing a doubled-prompt
+		// on every fresh session.
+		if cmdStr := urlCommands(r, customCommands); cmdStr != "" {
+			ptyC.Write([]byte(cmdStr)) //nolint
+		}
 
 		// Create WebSocket reader that handles resize messages
 		wsReader := newWSReader(ws, ptyC, log, r)
@@ -270,9 +276,10 @@ func urlCommands(r *http.Request, customCommands map[string][]string) string {
 			commands[i] = strings.Join(val, " && ")
 		}
 	}
-	stringCommands := strings.Join(commands, " && ")
-	stringCommands += "\n"
-	return stringCommands
+	if len(commands) == 0 {
+		return ""
+	}
+	return strings.Join(commands, " && ") + "\n"
 }
 
 // resizeMsg represents a terminal resize message from the client.


### PR DESCRIPTION
## Summary

Three operator-reported cosmetic + workflow gaps in the dmsgpty UI banner shown when opening a pty session.

## Fixes

### 1. Banner rename: dmsgpty-ui → skypty-ui

ASCII art regenerated in ANSI Shadow (https://patorjk.com/software/taag/?f=ANSI%20Shadow) reading \"SKYPTY-UI\". \`[dmsgpty-ui]\` status/error prefixes also flipped to \`[skypty-ui]\`. Logger name kept unchanged (not user-visible).

### 2. Box overflow on header values

The PTY-HOST line contains a 66-char PK plus \`:port\`; the UI-URL line embeds the same PK in a URL. Both overflow the 79-char enclosing box that the previous banner drew:

\`\`\`
║ PTY-HOST : 027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed:22
                                                       (protrudes past the right border ╝)
\`\`\`

No reasonable fixed-width box accommodates a 66-char PK. Drop the box; print the header values flush-left under the ASCII art with a blank-line gap above and below.

### 3. Drop \`DMSGPTYTERM=1\` export

\`urlCommands\` exported \`DMSGPTYTERM=1\` so the legacy bash \`skywire-autoconfig\` script could check it and skip its service-restart step (avoiding a self-interrupt when operators installed skywire from inside the dmsgpty session). The Go-side autoconfig has never read DMSGPTYTERM. \`NOAUTOCONFIG=true\` is the modern equivalent and works through both apt and yay.

Operator workflow for install-without-restart:

\`\`\`sh
# inside dmsgpty session
$ su - myuser  # arch only; deb runs autoconfig as root
$ NOAUTOCONFIG=true yay -S skywire-bin  # or apt install
# postinst sees NOAUTOCONFIG=true → exits 0; no config gen, no restart
$ exit

# from outside the pty
$ systemctl start skywire-autoconfig.service
# runs full autoconfig including the service restart, but it's not
# inside the pty so the operator's session isn't interrupted
\`\`\`

## Companion AUR change

\`skywire-bin/skywire-autoconfig\` (the legacy bash script in skycoin/aur) — drop its DMSGPTYTERM check too, since nothing exports it anymore. Filed as a separate AUR commit, not in this repo.

## Test plan

- [x] \`go build ./...\`
- [x] \`make lint\` clean
- [ ] Live: operator opens dmsgpty UI on a hypervisor and sees the SKYPTY-UI banner + flush-left header values + no \`DMSGPTYTERM=1\` export line