### PR TITLE
feat(visor): auto-upgrade visor↔hypervisor to skynet for RPC + skypty

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -873,7 +873,13 @@ type dmsgPtyUI struct {
 }
 
 func setupDmsgPtyUI(dmsgC *dmsg.Client, visorPK cipher.PubKey) *dmsgPtyUI {
-	ptyDialer := dmsgpty.DmsgUIDialer(dmsgC, dmsg.Addr{PK: visorPK, Port: skyenv.DmsgPtyPort})
+	// SkynetFirstUIDialer tries appnet.Dial(skynet) before falling
+	// back to dmsg. The remote visor dual-listens for dmsgpty on
+	// dmsg + skynet at the same port (init_dmsg_skywire.go's
+	// startSkywirePtyListener), so the skynet path lets the pty
+	// stream ride a stcpr / sudph transport when one exists between
+	// us and the visor.
+	ptyDialer := SkynetFirstUIDialer(dmsgC, dmsg.Addr{PK: visorPK, Port: skyenv.DmsgPtyPort})
 	return &dmsgPtyUI{
 		PtyUI: dmsgpty.NewUI(ptyDialer, dmsgpty.DefaultUIConfig()),
 	}

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -714,6 +714,16 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 
 		}(hvErrs)
 
+		// Background goroutine: probe the hypervisor via dmsg, then
+		// attempt stcpr / sudph transport creation so subsequent RPC
+		// and skypty dials ride a fast p2p path instead of the dmsg
+		// relay. See init_hypervisor_transport.go for the policy +
+		// reconciliation cadence.
+		go v.autoUpgradeHypervisorTransport(ctx,
+			hvPK,
+			v.MasterLogger().PackageLogger("hypervisor_transport").WithField("hypervisor_pk", hvPK),
+		)
+
 		v.pushCloseStack("hypervisor."+hvPK.String()[:shortHashLen], func() error {
 			cancel()
 			wg.Wait()

--- a/pkg/visor/init_hypervisor_transport.go
+++ b/pkg/visor/init_hypervisor_transport.go
@@ -1,0 +1,170 @@
+// Package visor pkg/visor/init_hypervisor_transport.go
+//
+// Visor → hypervisor transport auto-upgrade.
+//
+// The visor's `Hypervisors` config field lists hypervisor PKs the
+// visor reports to. ServeRPCClient establishes a dmsg session to
+// each as the bootstrap RPC channel — that's the "is the hypervisor
+// reachable" signal. Once that session is up, the goroutine started
+// here attempts to establish a stcpr / sudph transport between the
+// visor and the hypervisor too, so subsequent RPC + skypty dials
+// can ride the fast p2p path instead of the dmsg relay.
+//
+// Ordering rationale:
+//
+//  1. dmsg session up  → hypervisor is alive + reachable through the
+//     network.
+//  2. Attempt stcpr (no dmsg needed) — direct TCP via address
+//     resolver bind. Falls through quickly when the visor or
+//     hypervisor lacks a public stcpr endpoint.
+//  3. Attempt sudph (uses dmsg for signaling) — direct UDP via
+//     address resolver, hole-punched through NAT.
+//
+// Both transports persist past first creation; the goroutine
+// reconciles every 5 minutes (or after a failed attempt's backoff
+// expires) by re-checking whether the fast transport is still
+// present and re-trying if not.
+//
+// Stops cleanly when the visor's lifecycle ctx is canceled.
+package visor
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+const (
+	// hypervisorTransportInitialBackoff is the first retry delay
+	// after the goroutine starts; gives ServeRPCClient time to
+	// complete its initial dmsg dial.
+	hypervisorTransportInitialBackoff = 5 * time.Second
+	// hypervisorTransportMaxBackoff caps the failure-path backoff.
+	hypervisorTransportMaxBackoff = 5 * time.Minute
+	// hypervisorTransportReconcileInterval is the steady-state
+	// poll cadence once a fast transport is established.
+	hypervisorTransportReconcileInterval = 5 * time.Minute
+	// hypervisorTransportProbeTimeout caps the dmsg reachability
+	// probe; on slower paths a longer timeout would just delay the
+	// next reconciliation pass.
+	hypervisorTransportProbeTimeout = 10 * time.Second
+)
+
+// autoUpgradeHypervisorTransport runs in a goroutine per configured
+// hypervisor PK. See the package doc for the gating + ordering.
+func (v *Visor) autoUpgradeHypervisorTransport(ctx context.Context, hvPK cipher.PubKey, log logrus.FieldLogger) {
+	backoff := hypervisorTransportInitialBackoff
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		// Transport manager may not be wired yet at very-early init —
+		// in practice it always is by the time initHypervisors runs,
+		// but defend anyway since we can't recover from a nil panic.
+		if v.tpM == nil {
+			backoff = hypervisorTransportInitialBackoff
+			continue
+		}
+
+		// Skip the work if neither fast transport type is available
+		// locally — common on visors that disable stcpr/sudph or that
+		// run pure-dmsg builds. Re-check every cycle in case config
+		// changes at runtime (RPC API can flip these).
+		localSTCPR := v.tpM.IsKnownNetwork(tptypes.STCPR)
+		localSUDPH := v.tpM.IsKnownNetwork(tptypes.SUDPH)
+		if !localSTCPR && !localSUDPH {
+			backoff = hypervisorTransportReconcileInterval
+			continue
+		}
+
+		// Probe via dmsg first. Without a dmsg session to the
+		// hypervisor, the transport-create attempt would just spin
+		// against an unresponsive peer; gating on a successful probe
+		// keeps the failure-path cheap.
+		if v.dmsgC != nil {
+			probeCtx, probeCancel := context.WithTimeout(ctx, hypervisorTransportProbeTimeout)
+			reachable := v.dmsgC.Probe(probeCtx, hvPK, skyenv.DmsgAwaitSetupPort)
+			probeCancel()
+			if !reachable {
+				if backoff < hypervisorTransportMaxBackoff {
+					backoff *= 2
+				}
+				continue
+			}
+		}
+
+		// Already have a fast transport to this hypervisor? Then
+		// nothing to do this cycle.
+		if v.hasFastTransportTo(hvPK) {
+			backoff = hypervisorTransportReconcileInterval
+			continue
+		}
+
+		// Try stcpr first — direct TCP, no dmsg signaling needed.
+		if localSTCPR {
+			if _, err := v.tpM.SaveTransport(ctx, hvPK, tptypes.STCPR, transport.LabelAutomatic); err == nil {
+				log.WithField("type", string(tptypes.STCPR)).
+					WithField("hypervisor_pk", hvPK).
+					Info("Upgraded hypervisor transport")
+				backoff = hypervisorTransportReconcileInterval
+				continue
+			} else if isContextError(err) {
+				return
+			} else {
+				log.WithField("type", string(tptypes.STCPR)).WithError(err).
+					Debug("stcpr transport to hypervisor failed; trying sudph")
+			}
+		}
+
+		// stcpr unavailable or failed — try sudph (UDP, NAT-hole-punch
+		// via address resolver signaling).
+		if localSUDPH {
+			if _, err := v.tpM.SaveTransport(ctx, hvPK, tptypes.SUDPH, transport.LabelAutomatic); err == nil {
+				log.WithField("type", string(tptypes.SUDPH)).
+					WithField("hypervisor_pk", hvPK).
+					Info("Upgraded hypervisor transport")
+				backoff = hypervisorTransportReconcileInterval
+				continue
+			} else if isContextError(err) {
+				return
+			} else {
+				log.WithField("type", string(tptypes.SUDPH)).WithError(err).
+					Debug("sudph transport to hypervisor failed")
+			}
+		}
+
+		// Both attempts failed — back off and try again later. dmsg
+		// session remains the working channel.
+		if backoff < hypervisorTransportMaxBackoff {
+			backoff *= 2
+		}
+	}
+}
+
+// hasFastTransportTo returns true when the transport manager has a
+// stcpr or sudph automatic-label transport to the given peer.
+func (v *Visor) hasFastTransportTo(remotePK cipher.PubKey) bool {
+	if v.tpM == nil {
+		return false
+	}
+	for _, tp := range v.tpM.GetTransportsByLabel(transport.LabelAutomatic) {
+		if tp.Remote() != remotePK {
+			continue
+		}
+		switch tp.Type() {
+		case tptypes.STCPR, tptypes.SUDPH:
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -9,9 +9,17 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/netutil"
+	"github.com/skycoin/skywire/pkg/routing"
 )
+
+// rpcSkynetDialTimeout bounds the skynet dial attempt before
+// falling back to dmsg. Short enough that a missing route doesn't
+// stall the visor's reconnect loop; long enough for a routed dial
+// to succeed on a healthy network.
+const rpcSkynetDialTimeout = 2 * time.Second
 
 func isDone(ctx context.Context) bool {
 	select {
@@ -22,16 +30,43 @@ func isDone(ctx context.Context) bool {
 	}
 }
 
-// ServeRPCClient repetitively dials to a remote dmsg address and serves a RPC server to that address.
+// dialHypervisorRPC tries to open a connection to the hypervisor's
+// RPC port over the skywire router first, falling back to dmsg.
+//
+// The hypervisor's ServeRPC (hypervisor.go) dual-listens for RPC on
+// dmsg AND skynet at the same port via goServeSkynetMirror. Once
+// the visor has a stcpr / sudph transport to the hypervisor (via
+// autoUpgradeHypervisorTransport), the skynet path lets RPC traffic
+// flow over the fast p2p path instead of the dmsg relay.
+func dialHypervisorRPC(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Client, rAddr dmsg.Addr) (net.Conn, error) {
+	skyAddr := appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: rAddr.PK,
+		Port:   routing.Port(rAddr.Port),
+	}
+	skyCtx, skyCancel := context.WithTimeout(ctx, rpcSkynetDialTimeout)
+	conn, err := appnet.DialContext(skyCtx, skyAddr)
+	skyCancel()
+	if err == nil {
+		log.WithField("via", "skynet").Info("Dialed.")
+		return conn, nil
+	}
+	log.WithField("via", "dmsg").Info("Dialing...")
+	return dmsgC.Dial(ctx, rAddr)
+}
+
+// ServeRPCClient repetitively dials to a remote hypervisor and serves a
+// RPC server to that address.
+//
+// The dial path tries skynet first (via the skywire router) and falls
+// back to dmsg. See dialHypervisorRPC.
 func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Client, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
 	const maxBackoff = time.Second * 5
 	retry := netutil.NewRetrier(log, netutil.DefaultInitBackoff, maxBackoff, netutil.DefaultTries, netutil.DefaultFactor)
 	for {
 		var conn net.Conn
 		err := retry.Do(ctx, func() (rErr error) {
-			log.Info("Dialing...")
-			addr := dmsg.Addr{PK: rAddr.PK, Port: rAddr.Port}
-			conn, rErr = dmsgC.Dial(ctx, addr)
+			conn, rErr = dialHypervisorRPC(ctx, log, dmsgC, rAddr)
 			return rErr
 		})
 		if err != nil {

--- a/pkg/visor/skynet_first_dialer.go
+++ b/pkg/visor/skynet_first_dialer.go
@@ -1,0 +1,89 @@
+// Package visor pkg/visor/skynet_first_dialer.go
+//
+// SkynetFirstUIDialer wraps a dmsg-based dmsgpty UIDialer and tries
+// to reach the peer over the skywire router first. The visor's
+// dmsgpty host already dual-listens on dmsg and skynet at the same
+// port (see init_dmsg_skywire.go's startSkywirePtyListener), so the
+// peer-side accept loops are symmetric — the only thing missing was
+// the hypervisor's dial-side preference for the fast path.
+//
+// Behavior:
+//   - Try appnet.DialContext(skynet, peer:port) with a short timeout.
+//     Success returns that conn; the pty stream flows over whatever
+//     transport the router selected (stcpr / sudph / dmsg).
+//   - On any error from the skynet dial (no route, networker not
+//     registered, timeout), fall back to dmsg.Client.Dial which has
+//     been the original behavior.
+//
+// The skynet path needs a route to the peer, which means the visor
+// has to be sharing a transport with the hypervisor (or vice versa).
+// pkg/visor/init_hypervisor_transport.go's auto-upgrade goroutine
+// establishes that route from the visor side; the hypervisor uses
+// any transport the visor advertised in the address resolver.
+package visor
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// skynetFirstDialTimeout caps the skynet dial attempt before falling
+// back to dmsg. Short enough to keep the user-visible "Dialing..."
+// message responsive on hosts that don't have a route to the peer;
+// long enough for a routed dial to succeed on a healthy network.
+const skynetFirstDialTimeout = 2 * time.Second
+
+// errNilDmsgClient guards against SkynetFirstUIDialer being constructed
+// without the dmsg fallback in place.
+var errNilDmsgClient = errors.New("skynet-first ui dialer: nil dmsg client")
+
+type skynetFirstUIDialer struct {
+	dmsgC *dmsg.Client
+	rAddr dmsg.Addr
+}
+
+// SkynetFirstUIDialer returns a dmsgpty UIDialer that prefers the
+// skywire router for the pty stream and falls back to dmsg. The
+// dmsg client is required as the fallback transport.
+func SkynetFirstUIDialer(dmsgC *dmsg.Client, rAddr dmsg.Addr) dmsgpty.UIDialer {
+	return &skynetFirstUIDialer{
+		dmsgC: dmsgC,
+		rAddr: rAddr,
+	}
+}
+
+func (d *skynetFirstUIDialer) Dial() (net.Conn, error) {
+	if d.dmsgC == nil {
+		return nil, errNilDmsgClient
+	}
+
+	// Try skynet first. Bounded by skynetFirstDialTimeout to keep the
+	// fallback responsive — the call site is interactive (operator
+	// clicks "Open terminal" in the hvui and waits).
+	skyAddr := appnet.Addr{
+		Net:    appnet.TypeSkynet,
+		PubKey: d.rAddr.PK,
+		Port:   routing.Port(d.rAddr.Port),
+	}
+	skyCtx, skyCancel := context.WithTimeout(context.Background(), skynetFirstDialTimeout)
+	conn, err := appnet.DialContext(skyCtx, skyAddr)
+	skyCancel()
+	if err == nil {
+		return conn, nil
+	}
+
+	// Fall back to dmsg. Errors here are surfaced to the operator
+	// (the original DmsgUIDialer behavior).
+	return d.dmsgC.Dial(context.Background(), d.rAddr)
+}
+
+func (d *skynetFirstUIDialer) AddrString() string {
+	return d.rAddr.String()
+}


### PR DESCRIPTION
## Summary

Wires the visor↔hypervisor data plane to prefer the fast p2p transport (stcpr / sudph) over the dmsg relay while keeping dmsg as the bootstrap + fallback path.

Operator's symptoms motivating this: skypty disconnect/reconnect loops, and RPC traffic that goes through dmsg relays even when both ends are on the same LAN with a direct route available.

## Background

The accept sides were already dual-transport:

- Visor's dmsgpty host dual-listens for ssh on dmsg + skynet at the same port (`pkg/visor/init_dmsg_skywire.go`'s `startSkywirePtyListener`).
- Hypervisor's RPC accept dual-listens on dmsg + skynet at the same port (`pkg/visor/hypervisor.go`'s `ServeRPC` + `goServeSkynetMirror`).

But the dial sides were dmsg-only, and nothing tried to establish a fast transport between visor and hypervisor in the first place. So even though the servers could speak skynet, the clients never tried to.

## Changes

### 1. `pkg/visor/init_hypervisor_transport.go` (new)

Per-hypervisor goroutine spawned from `initHypervisors` that:

- Probes the hypervisor via dmsg (`skyenv.DmsgAwaitSetupPort`) as the reachability gate.
- On a successful probe, attempts `stcpr` then `sudph` via `tpM.SaveTransport(LabelAutomatic)`.
- Reconciles every 5 minutes (or on failure backoff, capped at 5 min). Stops cleanly when the visor's lifecycle ctx is canceled.

Once the transport is up, the skywire router has a route to the hypervisor PK, so `appnet.Dial(skynet, hvPK:port)` can succeed.

### 2. `pkg/visor/rpc_client_serve.go`

`ServeRPCClient`'s dial helper (new `dialHypervisorRPC`) tries `appnet.DialContext(skynet, peer:port)` with a 2s timeout, falls back to `dmsg.Client.Dial`. Match the pattern the autoconnect path uses for its dmsg probe.

### 3. `pkg/visor/skynet_first_dialer.go` (new) + `pkg/visor/hypervisor.go`

`SkynetFirstUIDialer` implements `dmsgpty.UIDialer` — tries skynet first, falls back to dmsg. `setupDmsgPtyUI` now uses it instead of `dmsgpty.DmsgUIDialer`. The pty UI in the hvui upgrades onto skynet whenever a route exists.

## Ordering

1. **Bootstrap**: visor connects to hypervisor over dmsg (existing).
2. **Reachability gate**: dmsg session up → hypervisor is alive.
3. **Auto-upgrade**: (1) attempts stcpr / sudph, establishes a fast transport.
4. **Steady-state**: (2) RPC dials and (3) pty dials prefer skynet. dmsg stays as the fallback.
5. **Fault tolerance**: if the fast transport tears down, the next RPC/pty dial falls through to dmsg automatically; (1) keeps trying to re-establish in the background.

## Test plan

- [x] \`go build ./...\`
- [x] \`make lint\` clean
- [ ] Live: operator runs against the three-visor + sub-hypervisor setup. Open hvui terminal on a remote visor — observe that the dial uses skynet once auto-upgrade has had a few seconds to land. Visor RPC sessions log "Dialed via skynet" in the visor log instead of "Dialing..." (dmsg).