### PR TITLE
fix(installers): preserve SK + add skywire.conf env file on win + mac

### DIFF
--- a/scripts/mac_installer/install_scripts/postinstall
+++ b/scripts/mac_installer/install_scripts/postinstall
@@ -13,9 +13,28 @@ mkdir -p "${skywire_dir}"
 
 chown -R "${USER}" "$skywire_dir"
 
+# Operator-editable env file. macOS analog of /etc/skywire.conf
+# (Linux) and %ProgramData%\Skywire\skywire.conf (Windows). Lives
+# next to the JSON config so it survives `Remove Skywire` — the
+# uninstaller's remove_scripts/postinstall only nukes
+# ${skywire_dir}/local, not the whole dir. Generate the template
+# here on first install only; the update_scripts/postinstall
+# doesn't recreate it, so operator edits persist across upgrades.
+export SKYENV="${skywire_dir}/skywire.conf"
+if [[ ! -f "${SKYENV}" ]]; then
+  /Applications/Skywire.app/Contents/MacOS/skywire cli config gen -pqQ "${SKYENV}"
+  chown "${USER}" "${SKYENV}"
+fi
+
 echo "generating skywire config if it doesn't exist"
+# `-b` used to map to BESTPROTO; removed in #2536. Passing it to
+# current binaries makes cobra reject the whole command line — the
+# gen never ran, and the visor's own bootstrap then generated a
+# fresh SK on every schema change between releases. Dropped here so
+# the gen actually runs. Also picks up operator-edited values from
+# ${SKYENV} via cli's scriptExecBool / scriptExecString.
 if [[ ! -f "${skywire_dir}"/skywire-config.json ]]; then
-  /Applications/Skywire.app/Contents/MacOS/skywire cli config gen --loglvl info -bpio "${skywire_dir}"/skywire-config.json
+  /Applications/Skywire.app/Contents/MacOS/skywire cli config gen --loglvl info -pio "${skywire_dir}"/skywire-config.json
 fi
 chown "${USER}" "${skywire_dir}"/skywire-config.json
 

--- a/scripts/mac_installer/update_scripts/postinstall
+++ b/scripts/mac_installer/update_scripts/postinstall
@@ -21,6 +21,23 @@ if [[ -L /usr/local/bin/skywire-cli ]]; then
   unlink /usr/local/bin/skywire-cli
 fi
 
-/Applications/Skywire.app/Contents/MacOS/skywire cli config gen --loglvl info -bprio "${skywire_dir}"/skywire-config.json
+# `-b` used to map to BESTPROTO; removed in #2536. Passing it to
+# current binaries makes cobra reject the whole command line, the
+# gen never ran, and `-r` (regenerate-with-key-retention) was
+# never applied — operators report their visor SK changing on
+# every macOS update. Dropping `-b` lets gen actually run; `-r`
+# then reads the existing skywire-config.json, extracts the SK,
+# and writes a new config carrying that same SK. (Mirrors the
+# Linux deb / arch post_install fix from #2796 and the Windows
+# MSI fix in this PR.)
+#
+# Point SKYENV at the operator's env file so cli picks up
+# PKGENV / ISHYPERVISOR / HYPERVISORPKS / DISABLEPUBLICAUTOCONN /
+# etc. from it. The file was created by install_scripts on first
+# install; this script doesn't touch it, so operator edits
+# persist across every macOS update.
+export SKYENV="${skywire_dir}/skywire.conf"
+
+/Applications/Skywire.app/Contents/MacOS/skywire cli config gen --loglvl info -prio "${skywire_dir}"/skywire-config.json
 chown "${USER}" "${skywire_dir}"/skywire-config.json
 

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -42,6 +42,28 @@ if exist "%HOMEPATH%\skywire-config.json" (
 	move /Y "%HOMEPATH%\skywire-config.json" . >nul 2>&1
 )
 
+:: Windows-side equivalent of Linux's /etc/skywire.conf. Lives under
+:: %ProgramData% (typically C:\ProgramData\Skywire\) so operator
+:: edits survive MSI upgrades — the MSI installs into Program Files
+:: but doesn't touch ProgramData. `defaultSkyenvPath` in
+:: cmd/skywire/commands/autoconfig.go points at the same path; the
+:: SKYENV env var here makes cli + autoconfig pick the file up
+:: regardless of CWD.
+set "SKYENV=%ProgramData%\Skywire\skywire.conf"
+if not exist "%ProgramData%\Skywire\" (
+    mkdir "%ProgramData%\Skywire" >nul 2>&1
+)
+
+:: Generate the env-file template ONLY if missing. -p forces the
+:: package-mode defaults (paths under C:\Program Files\Skywire), -q
+:: prints the template, -Q writes to the file. Mirrors the deb/arch
+:: `[[ ! -f /etc/skywire.conf ]] && skywire cli config gen -pqQ ...`
+:: pattern from PR #2796 — once the file exists, every subsequent
+:: install / upgrade leaves operator edits intact.
+if not exist "%SKYENV%" (
+    skywire cli config gen -pqQ "%SKYENV%" >nul 2>&1
+)
+
 :: Config generation. The `-b` flag used to map to a removed
 :: BESTPROTO knob; passing it to current binaries makes cobra reject
 :: the entire command line ("unknown shorthand flag: 'b'") and the
@@ -53,6 +75,8 @@ if exist "%HOMEPATH%\skywire-config.json" (
 :: post_install logic).
 ::
 :: First install (no skywire-config.json yet) — generate fresh.
+:: cli reads %SKYENV% via the SKYENV env var; its PKGENV / HYPERVISORPKS
+:: / DISABLEPUBLICAUTOCONN / etc. settings are picked up here.
 if not exist "skywire-config.json" (
     skywire cli config gen -irpw --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
 )
@@ -61,7 +85,8 @@ if not exist "skywire-config.json" (
 :: The regen path reads the existing skywire-config.json, extracts
 :: the SK, then writes a fresh config carrying that same SK. `-x`
 :: also preserves the existing hypervisor PK list. SK preserved
-:: across every MSI update.
+:: across every MSI update. cli still reads %SKYENV% for any
+:: operator-edited knobs in skywire.conf.
 if exist "new.update" (
     skywire cli config gen -irpwx --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
     del new.update >nul 2>&1

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -42,14 +42,28 @@ if exist "%HOMEPATH%\skywire-config.json" (
 	move /Y "%HOMEPATH%\skywire-config.json" . >nul 2>&1
 )
 
-:: Generating new config file if not exist
+:: Config generation. The `-b` flag used to map to a removed
+:: BESTPROTO knob; passing it to current binaries makes cobra reject
+:: the entire command line ("unknown shorthand flag: 'b'") and the
+:: gen never ran. With the gen short-circuited, the visor's own
+:: bootstrap fell through to fresh-key generation on every schema
+:: change, which is what operators were reporting as "my SK changed
+:: on update". Dropping `-b` lets gen actually run; `-r` then
+:: preserves the SK from the existing config (mirrors the deb/arch
+:: post_install logic).
+::
+:: First install (no skywire-config.json yet) — generate fresh.
 if not exist "skywire-config.json" (
-    skywire cli config gen -birpw --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
+    skywire cli config gen -irpw --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
 )
 
-:: Regenerating config file after update and install new version of Skywire
+:: Upgrade marker (new.update shipped in MSI) — regenerate with `-r`.
+:: The regen path reads the existing skywire-config.json, extracts
+:: the SK, then writes a fresh config carrying that same SK. `-x`
+:: also preserves the existing hypervisor PK list. SK preserved
+:: across every MSI update.
 if exist "new.update" (
-    skywire cli config gen -birpwx >nul 2>&1
+    skywire cli config gen -irpwx --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
     del new.update >nul 2>&1
 )
 


### PR DESCRIPTION
## Summary

Operator-knob env file + SK preservation parity across the deb / arch / Windows MSI / macOS .pkg installers. Three of the four already had it after PR #2796; this PR closes the gap on Windows and macOS.

Same shape applied everywhere now:

| | Linux deb / arch | Windows MSI | macOS .pkg |
|---|---|---|---|
| Env file path | \`/etc/skywire.conf\` | \`%ProgramData%\\Skywire\\skywire.conf\` | \`~/Library/Application Support/Skywire/skywire.conf\` |
| Generated on | first install only (postinst guards on missing) | first launch only (bat guards on missing) | first install only (install_scripts guards on missing) |
| Survives uninstall | yes — postrm doesn't touch \`/etc/\` | yes — \`%ProgramData%\` outside MSI install root | yes — remove_scripts only nukes \`${skywire_dir}/local\` |
| SK preserved on upgrade | yes — postinst runs \`cli config gen -r\` | yes (after this PR — \`-b\` was breaking the gen) | yes (after this PR — same bug) |

## Bugs fixed

### 1. \`-b\` flag is dead but still passed everywhere

\`-b\` mapped to BESTPROTO. Removed in #2536's vestigial-knob cleanup. Current binaries reject the whole command line:

\`\`\`
$ skywire cli config gen -birpwx
Failed to execute command: unknown shorthand flag: 'b' in -birpwx
\`\`\`

Windows \`skywire.bat\` redirected \`>/dev/null 2>&1\`, swallowing the error. macOS install_scripts / update_scripts didn't redirect but the installer UI doesn't show the error either. In both cases the gen never ran → \`-r\` (regenerate-with-key-retention) never applied → visor's own bootstrap regenerated SK on any schema change between releases.

**Fix**: drop \`-b\` from every \`cli config gen\` call in both installers.

### 2. No persistent operator-knobs file on Windows or macOS

The Linux side ships \`/etc/skywire.conf\` semantics via \`defaultSkyenvPath()\` in \`cmd/skywire/commands/autoconfig.go:418\` — and that function already returned \`%ProgramData%\\Skywire\\skywire.conf\` on Windows. The plumbing existed; the installer just didn't use it. macOS had no env file at all.

**Fix**:

- **Windows \`skywire.bat\`**: \`set SKYENV=%ProgramData%\\Skywire\\skywire.conf\` early, \`mkdir\` the directory, generate the env-file template via \`cli config gen -pqQ\` only when the file is missing. Subsequent upgrades leave operator edits intact.

- **macOS install_scripts/postinstall**: \`export SKYENV=\"${skywire_dir}/skywire.conf\"\`, generate via \`cli config gen -pqQ\` only when missing, chown to operator. Lives next to skywire-config.json in \`~/Library/Application Support/Skywire/\`.

- **macOS update_scripts/postinstall**: \`export SKYENV\` only (doesn't recreate the file). \`cli config gen\` subprocess picks up operator-edited \`PKGENV\` / \`ISHYPERVISOR\` / \`HYPERVISORPKS\` / etc. from the env file via \`scriptExecBool\` / \`scriptExecString\`.

## Verified locally

- \`cli config gen -irpwx\` (Windows path) preserves SK across runs
- \`cli config gen -pio\` then \`cli config gen -prio\` (macOS path) preserves SK across runs
- \`cli config gen -pqQ\` produces a complete 276-line env-file template covering every knob

## Test plan

- [x] Local: SK preservation across \`-r\` regens
- [x] Local: env-file template generation
- [ ] Live: Windows operator builds the next MSI, upgrades, confirms (a) SK survives, (b) \`%ProgramData%\\Skywire\\skywire.conf\` exists after first install with sensible defaults, (c) edits to that file survive the next upgrade and reflect in the regenerated \`skywire-config.json\`
- [ ] Live: macOS operator builds the next .pkg, runs Update, confirms (a) SK survives, (b) \`~/Library/Application Support/Skywire/skywire.conf\` exists after first install, (c) edits survive across Update