### PR TITLE
fix(visor): skypty + RPC dialer hard-timeout the skynet attempt

### DIFF
--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -39,18 +39,45 @@ func isDone(ctx context.Context) bool {
 // autoUpgradeHypervisorTransport), the skynet path lets RPC traffic
 // flow over the fast p2p path instead of the dmsg relay.
 func dialHypervisorRPC(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Client, rAddr dmsg.Addr) (net.Conn, error) {
-	skyAddr := appnet.Addr{
-		Net:    appnet.TypeSkynet,
-		PubKey: rAddr.PK,
-		Port:   routing.Port(rAddr.Port),
+	// Skynet attempt in a goroutine with a hard outer ceiling.
+	// appnet.DialContext doesn't reliably honor context cancellation
+	// in all code paths (the AppDirectMux direct-dial branch and
+	// parts of route setup do I/O that's not always ctx-bound), so
+	// we wrap with an external timer. The goroutine closes any conn
+	// it gets if the outer dial has already moved on.
+	type skyResult struct {
+		conn net.Conn
+		err  error
 	}
-	skyCtx, skyCancel := context.WithTimeout(ctx, rpcSkynetDialTimeout)
-	conn, err := appnet.DialContext(skyCtx, skyAddr)
-	skyCancel()
-	if err == nil {
-		log.WithField("via", "skynet").Info("Dialed.")
-		return conn, nil
+	skyCh := make(chan skyResult, 1)
+	go func() {
+		skyAddr := appnet.Addr{
+			Net:    appnet.TypeSkynet,
+			PubKey: rAddr.PK,
+			Port:   routing.Port(rAddr.Port),
+		}
+		skyCtx, skyCancel := context.WithTimeout(ctx, rpcSkynetDialTimeout)
+		defer skyCancel()
+		conn, err := appnet.DialContext(skyCtx, skyAddr)
+		select {
+		case skyCh <- skyResult{conn, err}:
+		default:
+			if err == nil && conn != nil {
+				_ = conn.Close() //nolint:errcheck
+			}
+		}
+	}()
+
+	select {
+	case r := <-skyCh:
+		if r.err == nil {
+			log.WithField("via", "skynet").Info("Dialed.")
+			return r.conn, nil
+		}
+	case <-time.After(rpcSkynetDialTimeout):
+		// Skynet attempt exceeded its budget — fall through to dmsg.
 	}
+
 	log.WithField("via", "dmsg").Info("Dialing...")
 	return dmsgC.Dial(ctx, rAddr)
 }

--- a/pkg/visor/skynet_first_dialer.go
+++ b/pkg/visor/skynet_first_dialer.go
@@ -40,6 +40,14 @@ import (
 // long enough for a routed dial to succeed on a healthy network.
 const skynetFirstDialTimeout = 2 * time.Second
 
+// dmsgFallbackDialTimeout caps the dmsg fallback so the dialer
+// can't hang the UI forever if dmsg has trouble reaching the peer
+// (slow dmsg-discovery, dead relay, partitioned network, etc.).
+// The previous behavior — context.Background() with no deadline —
+// stranded the hvui at "Dialing…" indefinitely when both transports
+// were sluggish.
+const dmsgFallbackDialTimeout = 15 * time.Second
+
 // errNilDmsgClient guards against SkynetFirstUIDialer being constructed
 // without the dmsg fallback in place.
 var errNilDmsgClient = errors.New("skynet-first ui dialer: nil dmsg client")
@@ -64,24 +72,56 @@ func (d *skynetFirstUIDialer) Dial() (net.Conn, error) {
 		return nil, errNilDmsgClient
 	}
 
-	// Try skynet first. Bounded by skynetFirstDialTimeout to keep the
-	// fallback responsive — the call site is interactive (operator
-	// clicks "Open terminal" in the hvui and waits).
-	skyAddr := appnet.Addr{
-		Net:    appnet.TypeSkynet,
-		PubKey: d.rAddr.PK,
-		Port:   routing.Port(d.rAddr.Port),
+	// Skynet attempt in a goroutine with a HARD outer ceiling. We
+	// can't count on appnet.DialContext to honor context cancellation
+	// in all code paths — the AppDirectMux direct-dial branch and
+	// parts of the route-setup path do I/O that's not always
+	// ctx-bound. Wrapping the call + a separate timer gives us a
+	// strict upper bound at the cost of a possibly-leaked goroutine
+	// if the skynet dial eventually returns after we've fallen back
+	// to dmsg. The leaked goroutine closes the conn it gets if the
+	// outer dial has already moved on.
+	type skyResult struct {
+		conn net.Conn
+		err  error
 	}
-	skyCtx, skyCancel := context.WithTimeout(context.Background(), skynetFirstDialTimeout)
-	conn, err := appnet.DialContext(skyCtx, skyAddr)
-	skyCancel()
-	if err == nil {
-		return conn, nil
+	skyCh := make(chan skyResult, 1)
+	go func() {
+		skyAddr := appnet.Addr{
+			Net:    appnet.TypeSkynet,
+			PubKey: d.rAddr.PK,
+			Port:   routing.Port(d.rAddr.Port),
+		}
+		skyCtx, skyCancel := context.WithTimeout(context.Background(), skynetFirstDialTimeout)
+		defer skyCancel()
+		conn, err := appnet.DialContext(skyCtx, skyAddr)
+		select {
+		case skyCh <- skyResult{conn, err}:
+		default:
+			// Outer waiter gave up; clean up the conn rather than
+			// leaking it past this goroutine's lifetime.
+			if err == nil && conn != nil {
+				_ = conn.Close() //nolint:errcheck
+			}
+		}
+	}()
+
+	select {
+	case r := <-skyCh:
+		if r.err == nil {
+			return r.conn, nil
+		}
+	case <-time.After(skynetFirstDialTimeout):
+		// Skynet attempt exceeded its budget — fall through to dmsg.
 	}
 
-	// Fall back to dmsg. Errors here are surfaced to the operator
-	// (the original DmsgUIDialer behavior).
-	return d.dmsgC.Dial(context.Background(), d.rAddr)
+	// dmsg fallback. Use a bounded ctx so the UI gets a real error
+	// instead of hanging forever when dmsg-discovery is slow, the
+	// chosen relay is unreachable, or the remote PK simply isn't
+	// online.
+	dmsgCtx, dmsgCancel := context.WithTimeout(context.Background(), dmsgFallbackDialTimeout)
+	defer dmsgCancel()
+	return d.dmsgC.Dial(dmsgCtx, d.rAddr)
 }
 
 func (d *skynetFirstUIDialer) AddrString() string {


### PR DESCRIPTION
## Summary

Operator reports the hvui terminal hangs at \`[skypty-ui] Status: Dialing...\` after PR #2802's \`SkynetFirstUIDialer\` landed. Affects every remote-visor terminal click.

## Root cause

Two interlocking issues in the dialer added in #2802:

1. **\`appnet.DialContext\` doesn't reliably honor ctx cancellation.** The skywire router's \`SkywireNetworker.DialContextWithOptions\` has segments — AppDirectMux \`tryDirectDial\` and parts of route setup — where I/O isn't ctx-bound. Setting a 2s \`skyCtx\` deadline does nothing for those paths.

2. **dmsg fallback used \`context.Background()\`** with no timeout. So even if the skynet ctx eventually unblocked, any hiccup on dmsg (slow dmsg-discovery, dead relay, partitioned network, offline remote PK) stranded the UI indefinitely.

## Fix

Both call sites (\`SkynetFirstUIDialer\` for skypty pty stream; \`dialHypervisorRPC\` for visor → hypervisor RPC reconnect):

- Run skynet attempt in a goroutine with a **hard external timer**. Outer \`select\` waits at most \`skynetFirstDialTimeout\` (2s) / \`rpcSkynetDialTimeout\` (2s) and falls through to dmsg regardless of whether \`appnet.DialContext\` returned. Late-arriving conn from the leaked goroutine is closed cleanly so it doesn't leak past its lifetime.
- \`SkynetFirstUIDialer\` dmsg fallback now uses a **bounded context** (\`dmsgFallbackDialTimeout = 15s\`) so the UI gets a real error instead of hanging forever.

Worst-case dial latency: 2s skynet + 15s dmsg = 17s before an error surfaces. Previously: unbounded.

\`dialHypervisorRPC\`'s dmsg fallback uses the caller's ctx (the visor lifecycle ctx) which is gated by the \`netutil.Retrier\` above it — no extra timeout needed there.

## Test plan

- [x] \`go build ./...\`
- [x] \`make lint\` clean
- [ ] Live: operator clicks Open Terminal on a remote visor in the hvui — banner renders within at most ~2s on a working route, or fails over to dmsg within ~17s on a broken one