### PR TITLE
fix(visor+hypervisor): self-heal orphan RPC conns on degraded dmsg

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -594,10 +594,23 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 						live = true
 					}
 				case <-time.After(5 * time.Second):
-					hv.logger.WithField("pk", pk).Warn("Remote visor summary RPC timed out (5s)")
-					mu.Lock()
-					deadVisors = append(deadVisors, pk)
-					mu.Unlock()
+					// Outer timeout: render the UI snappy by falling
+					// through to the cache fallback below, but DON'T
+					// evict the visor on a single slow round. The
+					// Summary goroutine continues running with its
+					// 20s inner ctx (skyenv.RPCTimeout); if the conn
+					// is genuinely broken, that ctx fires, closes the
+					// conn from rpc_client.go:104, and the NEXT poll
+					// round sees rpcErr != nil (write-to-closed-conn)
+					// and properly evicts. Eviction on outer timeout
+					// alone was over-aggressive — it dropped visors
+					// that were merely slow (dmsg jitter, route flap,
+					// transient load) and stranded them in stale-row
+					// state because most visors don't yet have the
+					// idle-detect fix in ServeRPCClient that would
+					// otherwise let them recover by redialing.
+					hv.logger.WithField("pk", pk).
+						Warn("Remote visor summary RPC slow (>5s); using cache, will re-poll next round")
 				}
 
 				if live {

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"net"
 	"net/rpc"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -20,6 +22,27 @@ import (
 // stall the visor's reconnect loop; long enough for a routed dial
 // to succeed on a healthy network.
 const rpcSkynetDialTimeout = 2 * time.Second
+
+// hypervisorRPCIdleTimeout is the maximum time the visor will hold
+// an idle (no traffic in either direction) served RPC conn to its
+// hypervisor before closing it and redialing. The hypervisor polls
+// us with Summary RPC calls on its UI refresh cadence; under normal
+// operation those polls happen well within this window and the
+// idle timer never fires.
+//
+// This timeout exists for the case where the dmsg session (or the
+// skywire route) underneath the conn dies silently — the hypervisor's
+// next poll fails, its rpc.Client.Close() runs but can't deliver a
+// close frame over the broken session, and our blocking Read on the
+// served end of the conn stays parked indefinitely. Without this
+// timer the visor sits with an orphaned conn for the rest of the
+// process lifetime; the hypervisor sees it as "last seen N minutes
+// ago" with no recovery short of a visor restart.
+//
+// 10 min is a tradeoff: long enough that normal UI-idle periods
+// don't cause reconnect churn, short enough that operators don't
+// stare at stale "last seen" rows for hours.
+const hypervisorRPCIdleTimeout = 10 * time.Minute
 
 func isDone(ctx context.Context) bool {
 	select {
@@ -110,15 +133,96 @@ func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Cli
 		}
 
 		log.Info("Serving RPC client...")
+		// Wrap the conn so an extended idle period (no read or write
+		// activity for hypervisorRPCIdleTimeout) forces the conn closed
+		// and triggers a redial. Guards against silently-dead dmsg /
+		// route sessions where the hypervisor's close on a failed poll
+		// can't reach us. See the const doc for the full rationale.
+		idleConn := newIdleConn(conn, hypervisorRPCIdleTimeout, log)
 		connCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is called when ServeConn returns
 		go func() {
-			rpcS.ServeConn(conn)
+			rpcS.ServeConn(idleConn)
 			cancel()
 		}()
 		<-connCtx.Done()
+		idleConn.stop()
 
 		log.WithError(conn.Close()).
 			WithField("context_done", isDone(ctx)).
 			Debug("Conn closed. Redialing...")
+	}
+}
+
+// idleConn wraps a net.Conn and closes it if no Read or Write
+// activity occurs within idleTimeout. The wrapped Read / Write
+// stamp lastActivity on every successful byte transfer; a watcher
+// goroutine ticks every idleTimeout/4 and closes the conn when the
+// stamp is older than idleTimeout.
+//
+// Close on idle is the safe action — the consumer (rpcS.ServeConn)
+// sees the close as a Read error, returns, and the outer
+// ServeRPCClient loop redials. There's no false-positive harm:
+// reconnect to the hypervisor is cheap relative to staying
+// stranded.
+type idleConn struct {
+	net.Conn
+	lastActivity atomic.Int64 // unix nanos
+	idleTimeout  time.Duration
+	stopOnce     sync.Once
+	stopped      chan struct{}
+	log          logrus.FieldLogger
+}
+
+func newIdleConn(c net.Conn, idleTimeout time.Duration, log logrus.FieldLogger) *idleConn {
+	ic := &idleConn{
+		Conn:        c,
+		idleTimeout: idleTimeout,
+		stopped:     make(chan struct{}),
+		log:         log,
+	}
+	ic.lastActivity.Store(time.Now().UnixNano())
+	go ic.watch()
+	return ic
+}
+
+func (c *idleConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.lastActivity.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+func (c *idleConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n > 0 {
+		c.lastActivity.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+// stop tells the watcher to exit. Called from ServeRPCClient after
+// the ServeConn goroutine returns, so we don't leak the watcher
+// past the conn's lifetime.
+func (c *idleConn) stop() {
+	c.stopOnce.Do(func() { close(c.stopped) })
+}
+
+func (c *idleConn) watch() {
+	t := time.NewTicker(c.idleTimeout / 4)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.stopped:
+			return
+		case now := <-t.C:
+			last := time.Unix(0, c.lastActivity.Load())
+			if now.Sub(last) >= c.idleTimeout {
+				c.log.WithField("idle_for", now.Sub(last)).
+					Info("Hypervisor RPC conn idle past threshold; closing to force redial.")
+				_ = c.Conn.Close() //nolint:errcheck
+				return
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Two complementary fixes to stop visors from getting stuck in the hypervisor UI as \"last seen N minutes ago\" forever after a degraded dmsg session.

**Symptom (operator-reported).** Visors connect, get polled successfully for a while, then drop off the hypervisor UI with a stale-row \"last seen\" timestamp. The only recovery is a visor process restart. Multiple visors at once is common during dmsg relay churn.

**Root cause.** When a dmsg session degrades (relay restart, NAT timeout, route flap, transient load) so that bidirectional streams stall but the session isn't formally torn down:
- The hypervisor's `Summary` RPC times out → hypervisor evicts the visor from `remoteVisors` → stops polling it.
- The hypervisor's `rpc_client.go:104` calls `rc.conn.Close()` to surface the close to the visor — but `Close` on a degraded session can't deliver a close frame; the close completes locally and the visor never knows.
- The visor's served end of the stream sits parked in `VStream.Read` for the rest of the process lifetime. `rpcS.ServeConn` never returns. The retrier never gets a redial cycle.

Confirmed via dmsg-curl'd goroutine dumps on three stuck visors (`/debug/pprof/goroutine?debug=2`): all three had `ServeRPCClient` parked in `chan receive` for nearly their full process uptime, the inner `ServeConn` deep in `VStream.Read` for the same duration.

## Fixes

### 1. `pkg/visor/rpc_client_serve.go` — idle-detect the served conn

Wraps the served RPC conn in `ServeRPCClient` so 10 minutes of zero read/write activity force a local `conn.Close()`. `VStream.Close()` signals its `closed` chan, the parked Read returns `io.EOF`, `ServeConn` returns, `connCtx` cancels, the existing retrier redials. Hypervisor re-Accepts on the new conn and polling resumes.

10 min threshold balances reconnect-churn (hypervisor only polls on UI-triggered HTTP) against time-stuck-stale.

### 2. `pkg/visor/hypervisor_handlers_visors.go` — decouple UI snappiness from eviction

Old code: 5s outer timeout in the Summary fan-out both surfaced cached data AND added the visor to `deadVisors` for map eviction. One slow round and the visor was gone.

New code: 5s timeout still surfaces cached data, but the visor stays in `remoteVisors`; next poll round tries again. The in-flight Summary goroutine continues against `skyenv.RPCTimeout` (20s) — if the conn is genuinely broken, that inner ctx fires, closes the conn, and the next poll round sees `rpcErr != nil` for the proper eviction path. Healthy-but-slow visors no longer get stranded.

## Together

Combined, the two fixes self-heal across the four common dmsg failure modes:
- **Slow round** → hypervisor doesn't evict, retries next round.
- **Broken session, close frame delivered** → existing hypervisor close-on-timeout works; visor sees EOF.
- **Broken session, close frame lost** → visor's idle-detect catches it within 10 min.
- **Half-dead stream** → idle-detect catches it within 10 min.

## Test plan

- [x] Confirmed unfix'd behavior via pprof goroutine dumps on three stuck visors (`v1.3.57-0-95a4670c05f3`): all three parked in `chan receive` / `VStream.Read` for full uptime.
- [x] Local hypervisor restart triggered clean dmsg-stream-close cascade; visors with healthy sessions reconnected immediately. Visors with degraded sessions stayed stuck — exactly the case the visor-side fix targets.
- [x] Built clean against the working tree (`go build ./pkg/visor`).
- [ ] Field test: deploy via auto-update channel, monitor for reduction in stuck-visor reports across the network.