### PR TITLE
fix(hypervisor): bridge Hostname from summaryCache for cross-version sub-sections

### DIFF
--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -49,7 +49,7 @@ func (v *Visor) AddHypervisor(hvPK cipher.PubKey) error {
 		v.connectedHypervisors[hvPK] = true
 		v.hypervisorCancels[hvPK] = cancel
 		v.initLock.Unlock()
-		ServeRPCClient(ctx, log, v.dmsgC, rpcS, addr, hvErrs)
+		ServeRPCClient(ctx, log, v.tpM, v.dmsgC, rpcS, addr, hvErrs)
 	}()
 
 	v.pushCloseStack("hypervisor.runtime."+hvPK.String()[:shortHashLen], func() error {

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -273,6 +273,29 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				}
 				fwg.Wait()
 			}
+
+			// Enrich Hostname from the local summaryCache when the
+			// sub-hypervisor's HVVisorEntry round-trip didn't carry it
+			// — happens when the sub-hypervisor predates the
+			// Hostname-on-HVVisorEntry change (PR #2808). The local
+			// section already polls Summary for any PK we have a
+			// direct conn to, and that Summary's Overview.Hostname is
+			// the source of truth. Without this bridge, sub-section
+			// rows show LAN IP as the default label until the
+			// sub-hypervisor itself updates.
+			hv.summaryCacheMx.RLock()
+			for i := range visors {
+				if visors[i].Overview == nil || visors[i].Overview.Hostname != "" {
+					continue
+				}
+				cached, ok := hv.summaryCache[visors[i].Overview.PubKey]
+				if !ok || cached.sum == nil || cached.sum.Overview == nil {
+					continue
+				}
+				visors[i].Overview.Hostname = cached.sum.Overview.Hostname
+			}
+			hv.summaryCacheMx.RUnlock()
+
 			sections = append(sections, VisorTreeSection{
 				HypervisorPK: sr.hyperPK,
 				ViaChain:     []cipher.PubKey{localPK},

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -171,14 +171,6 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 		wg.Wait()
 
 		rendered := map[cipher.PubKey]bool{localPK: true}
-		// subHyperPKs collects every hypervisor PK that gets its own
-		// section below the local one. Used to scrub the local
-		// section's visor list — a hypervisor that has its own
-		// section shouldn't ALSO appear as a row in the local
-		// section's table, because the UI tabs render each section
-		// independently and the operator perceives the duplicate
-		// hypervisor row as a bug ("the visor shows twice").
-		subHyperPKs := make(map[cipher.PubKey]struct{}, len(results))
 		for _, sr := range results {
 			if rendered[sr.hyperPK] {
 				continue
@@ -194,7 +186,6 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				}
 				es := sr.err.Error()
 				rendered[sr.hyperPK] = true
-				subHyperPKs[sr.hyperPK] = struct{}{}
 				sections = append(sections, VisorTreeSection{
 					HypervisorPK: sr.hyperPK,
 					ViaChain:     []cipher.PubKey{localPK},
@@ -203,7 +194,6 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 				continue
 			}
 			rendered[sr.hyperPK] = true
-			subHyperPKs[sr.hyperPK] = struct{}{}
 			// Project HVVisorEntry → Summary so the UI's existing
 			// table renderer works identically across all sections.
 			// Sub-hypervisor visors don't carry the full Summary
@@ -290,28 +280,23 @@ func (hv *Hypervisor) getVisorsTreeSummary() http.HandlerFunc {
 			})
 		}
 
-		// Scrub the local section: drop any visor row whose PK has
-		// its own subsequent sub-hypervisor section. Without this,
-		// a hypervisor that's both connected to AND served by this
-		// visor shows up in both the local section (as a plain
-		// connected visor) and its own section (as the section's
-		// hypervisor) — duplicate rows from the operator's POV.
-		// Doesn't touch the local hypervisor's own row at index 0
-		// (it's hv.visor.conf.PK, never in subHyperPKs).
-		if len(subHyperPKs) > 0 && len(sections) > 0 {
-			scrubbed := make([]Summary, 0, len(sections[0].Visors))
-			for _, v := range sections[0].Visors {
-				if v.Overview == nil {
-					scrubbed = append(scrubbed, v)
-					continue
-				}
-				if _, isSub := subHyperPKs[v.Overview.PubKey]; isSub {
-					continue
-				}
-				scrubbed = append(scrubbed, v)
-			}
-			sections[0].Visors = scrubbed
-		}
+		// Intentionally NOT scrubbing the local section. A visor that
+		// is both (a) directly connected to this hypervisor and (b)
+		// itself a hypervisor with its own section represents two
+		// distinct relationships, and both should be visible. The
+		// local section's row reflects "this visor is one of my
+		// managed visors"; the sub-section's IsLocal row reflects
+		// "this visor runs its own hypervisor too." Operators rely on
+		// the local-section row to manage the visor as a peer — pty
+		// access, transport admin, etc. — independent of its
+		// hypervisor role. Filtering it out hid managed visors that
+		// happened to also run a hypervisor.
+		//
+		// Sections still dedup by hypervisor PK (line 173 onward), so
+		// no section ever appears twice; only visor *rows* replicate
+		// across sections, which matches the doc comment at the top
+		// of this function ("Visor entries replicate across sections
+		// when a visor is connected to multiple hypervisors").
 
 		httputil.WriteJSON(w, r, http.StatusOK, VisorTreeResponse{Sections: sections})
 	}
@@ -373,6 +358,10 @@ func projectEntryToSummary(e HVVisorEntry) Summary {
 		PublicIP:       e.PublicIP,
 		CountryCode:    e.CountryCode,
 		IsSymmetricNAT: e.IsSymmetricNAT,
+		// Hostname is the hvui's default label fallback. Carrying
+		// it through HVVisorEntry → Summary lets sub-section rows
+		// render the same label the visor's own overview would show.
+		Hostname: e.Hostname,
 		BuildInfo: &buildinfo.Info{
 			Version: e.Version,
 		},

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -709,7 +709,7 @@ func initHypervisors(_ context.Context, v *Visor, _ *logging.Logger) error {
 			//			}
 			defer delete(v.connectedHypervisors, hvPK)
 			v.connectedHypervisors[hvPK] = true
-			ServeRPCClient(ctx, log, v.dmsgC, rpcS, addr, hvErrs)
+			ServeRPCClient(ctx, log, v.tpM, v.dmsgC, rpcS, addr, hvErrs)
 			//			ServeRPCClient(ctx, log, autoPeerIP, v.dmsgC, rpcS, addr, hvErrs)
 
 		}(hvErrs)

--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -12,37 +12,57 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
 )
 
-// rpcSkynetDialTimeout bounds the skynet dial attempt before
-// falling back to dmsg. Short enough that a missing route doesn't
-// stall the visor's reconnect loop; long enough for a routed dial
-// to succeed on a healthy network.
+// rpcSkynetDialTimeout bounds the skynet dial attempt before falling
+// back to dmsg. Skynet only gets attempted at all when a stcpr or
+// sudph transport to the hypervisor already exists, so this timeout
+// is just for the route-setup leg above that existing transport.
 const rpcSkynetDialTimeout = 2 * time.Second
+
+// rpcSkynetCooldown is how long we stop trying skynet for the
+// hypervisor RPC conn after a failure on that path.
+//
+// A "failure" here means either the dial failed, or a previously-
+// established skynet conn ended unexpectedly (caught either by ServeConn
+// returning a read error or by the idleConn watcher). Either signal
+// indicates the skynet route is unhealthy enough that we shouldn't
+// keep cycling onto it on every redial — dmsg is the reliable
+// baseline and we should sit on it for a bit before retrying skynet.
+//
+// 5 min lines up with autoUpgradeHypervisorTransport's reconcile
+// cadence: after that interval, the auto-upgrade pass would have
+// re-checked / re-established the transport, so a fresh skynet try
+// makes sense.
+const rpcSkynetCooldown = 5 * time.Minute
 
 // hypervisorRPCIdleTimeout is the maximum time the visor will hold
 // an idle (no traffic in either direction) served RPC conn to its
-// hypervisor before closing it and redialing. The hypervisor polls
-// us with Summary RPC calls on its UI refresh cadence; under normal
-// operation those polls happen well within this window and the
-// idle timer never fires.
+// hypervisor before closing it and redialing.
 //
-// This timeout exists for the case where the dmsg session (or the
-// skywire route) underneath the conn dies silently — the hypervisor's
-// next poll fails, its rpc.Client.Close() runs but can't deliver a
-// close frame over the broken session, and our blocking Read on the
-// served end of the conn stays parked indefinitely. Without this
-// timer the visor sits with an orphaned conn for the rest of the
-// process lifetime; the hypervisor sees it as "last seen N minutes
-// ago" with no recovery short of a visor restart.
-//
-// 10 min is a tradeoff: long enough that normal UI-idle periods
-// don't cause reconnect churn, short enough that operators don't
-// stare at stale "last seen" rows for hours.
+// Under normal operation the hypervisor's Summary polling cadence
+// (driven by UI refresh) keeps the conn active. The idle-detect
+// catches the case where the underlying skynet route or dmsg session
+// dies silently: the hypervisor's next poll times out, its close
+// can't deliver a close frame over the broken session, and our
+// blocking Read on the served end of the conn sits parked forever.
 const hypervisorRPCIdleTimeout = 10 * time.Minute
+
+// rpcTransport names the transport carrying a given served RPC conn,
+// recorded by dialHypervisorRPC so ServeRPCClient can apply the
+// skynet cooldown when an unexpectedly-closed conn was on skynet.
+type rpcTransport string
+
+const (
+	transportSkynet rpcTransport = "skynet"
+	transportDmsg   rpcTransport = "dmsg"
+)
 
 func isDone(ctx context.Context) bool {
 	select {
@@ -53,70 +73,108 @@ func isDone(ctx context.Context) bool {
 	}
 }
 
-// dialHypervisorRPC tries to open a connection to the hypervisor's
-// RPC port over the skywire router first, falling back to dmsg.
-//
-// The hypervisor's ServeRPC (hypervisor.go) dual-listens for RPC on
-// dmsg AND skynet at the same port via goServeSkynetMirror. Once
-// the visor has a stcpr / sudph transport to the hypervisor (via
-// autoUpgradeHypervisorTransport), the skynet path lets RPC traffic
-// flow over the fast p2p path instead of the dmsg relay.
-func dialHypervisorRPC(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Client, rAddr dmsg.Addr) (net.Conn, error) {
-	// Skynet attempt in a goroutine with a hard outer ceiling.
-	// appnet.DialContext doesn't reliably honor context cancellation
-	// in all code paths (the AppDirectMux direct-dial branch and
-	// parts of route setup do I/O that's not always ctx-bound), so
-	// we wrap with an external timer. The goroutine closes any conn
-	// it gets if the outer dial has already moved on.
-	type skyResult struct {
-		conn net.Conn
-		err  error
+// hasFastTransportTo reports whether the visor has an established
+// stcpr or sudph transport to the given peer. This is the gate for
+// trying skynet — without an underlying transport, a skynet dial
+// would go out to the router for a route that can't be built and
+// either fail or hang up to its 2s budget.
+func hasFastTransportTo(tpM *transport.Manager, pk cipher.PubKey) bool {
+	if tpM == nil {
+		return false
 	}
-	skyCh := make(chan skyResult, 1)
-	go func() {
+	if tp, err := tpM.GetTransport(pk, tptypes.STCPR); err == nil && tp != nil {
+		return true
+	}
+	if tp, err := tpM.GetTransport(pk, tptypes.SUDPH); err == nil && tp != nil {
+		return true
+	}
+	return false
+}
+
+// dialHypervisorRPC opens the visor's persistent RPC connection to
+// the hypervisor. It prefers skynet (the fast direct path) whenever:
+//
+//  1. A stcpr or sudph transport to the hypervisor exists — i.e.,
+//     autoUpgradeHypervisorTransport has already done its job. Without
+//     this, a skynet dial would either fail or wait out the 2s budget
+//     while the router tries (and fails) to build a route.
+//  2. There has been no recent skynet failure (rpcSkynetCooldown). A
+//     failure here means a previous skynet conn either failed to dial
+//     or died on us silently — there's no point cycling back onto
+//     skynet on every redial when the path is flaky.
+//
+// In all other cases it dials over dmsg. dmsg is the reliable
+// baseline: relay disconnects propagate failure cleanly up the
+// stack as EOF, so the retrier above can redial without operator
+// intervention.
+//
+// The returned rpcTransport identifies which path served the
+// returned conn, so ServeRPCClient can record a skynet failure if
+// the conn ends unexpectedly.
+func dialHypervisorRPC(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	tpM *transport.Manager,
+	dmsgC *dmsg.Client,
+	rAddr dmsg.Addr,
+	lastSkyFail *atomic.Int64,
+) (net.Conn, rpcTransport, error) {
+	if hasFastTransportTo(tpM, rAddr.PK) && !inSkynetCooldown(lastSkyFail) {
 		skyAddr := appnet.Addr{
 			Net:    appnet.TypeSkynet,
 			PubKey: rAddr.PK,
 			Port:   routing.Port(rAddr.Port),
 		}
-		skyCtx, skyCancel := context.WithTimeout(ctx, rpcSkynetDialTimeout)
-		defer skyCancel()
+		skyCtx, cancel := context.WithTimeout(ctx, rpcSkynetDialTimeout)
 		conn, err := appnet.DialContext(skyCtx, skyAddr)
-		select {
-		case skyCh <- skyResult{conn, err}:
-		default:
-			if err == nil && conn != nil {
-				_ = conn.Close() //nolint:errcheck
-			}
-		}
-	}()
-
-	select {
-	case r := <-skyCh:
-		if r.err == nil {
+		cancel()
+		if err == nil {
 			log.WithField("via", "skynet").Info("Dialed.")
-			return r.conn, nil
+			return conn, transportSkynet, nil
 		}
-	case <-time.After(rpcSkynetDialTimeout):
-		// Skynet attempt exceeded its budget — fall through to dmsg.
+		// Eligible for skynet but the dial failed. Record the failure
+		// so the next redial cycle defers to dmsg until the cooldown
+		// elapses, then fall through to dmsg for this attempt.
+		lastSkyFail.Store(time.Now().UnixNano())
+		log.WithError(err).Debug("Skynet dial to hypervisor failed; falling back to dmsg.")
 	}
 
 	log.WithField("via", "dmsg").Info("Dialing...")
-	return dmsgC.Dial(ctx, rAddr)
+	conn, err := dmsgC.Dial(ctx, rAddr)
+	if err != nil {
+		return nil, "", err
+	}
+	return conn, transportDmsg, nil
 }
 
-// ServeRPCClient repetitively dials to a remote hypervisor and serves a
-// RPC server to that address.
-//
-// The dial path tries skynet first (via the skywire router) and falls
-// back to dmsg. See dialHypervisorRPC.
-func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Client, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
+// inSkynetCooldown reports whether the most recent recorded skynet
+// failure is recent enough to skip skynet on this dial cycle.
+func inSkynetCooldown(lastFail *atomic.Int64) bool {
+	last := lastFail.Load()
+	if last == 0 {
+		return false
+	}
+	return time.Since(time.Unix(0, last)) < rpcSkynetCooldown
+}
+
+// ServeRPCClient repetitively dials to a remote hypervisor and serves
+// a RPC server to that address. The dial uses dmsg by default, switching
+// to skynet when an underlying fast transport exists and isn't in
+// cooldown — see dialHypervisorRPC.
+func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, tpM *transport.Manager, dmsgC *dmsg.Client, rpcS *rpc.Server, rAddr dmsg.Addr, errCh chan<- error) {
 	const maxBackoff = time.Second * 5
 	retry := netutil.NewRetrier(log, netutil.DefaultInitBackoff, maxBackoff, netutil.DefaultTries, netutil.DefaultFactor)
+
+	// lastSkyFail is per-hypervisor (this function is one goroutine
+	// per hypervisor PK). Records the most recent skynet failure so
+	// dialHypervisorRPC can apply the cooldown.
+	var lastSkyFail atomic.Int64
+
 	for {
 		var conn net.Conn
+		var via rpcTransport
 		err := retry.Do(ctx, func() (rErr error) {
-			conn, rErr = dialHypervisorRPC(ctx, log, dmsgC, rAddr)
+			conn, via, rErr = dialHypervisorRPC(ctx, log, tpM, dmsgC, rAddr, &lastSkyFail)
 			return rErr
 		})
 		if err != nil {
@@ -132,12 +190,11 @@ func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Cli
 			continue
 		}
 
-		log.Info("Serving RPC client...")
-		// Wrap the conn so an extended idle period (no read or write
-		// activity for hypervisorRPCIdleTimeout) forces the conn closed
-		// and triggers a redial. Guards against silently-dead dmsg /
-		// route sessions where the hypervisor's close on a failed poll
-		// can't reach us. See the const doc for the full rationale.
+		log.WithField("via", string(via)).Info("Serving RPC client...")
+		// Idle-detect wraps the conn so we don't sit parked in Read
+		// forever if the underlying session (skynet route OR dmsg)
+		// dies silently. Defense in depth on top of dmsg's own
+		// session-level close detection.
 		idleConn := newIdleConn(conn, hypervisorRPCIdleTimeout, log)
 		connCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is called when ServeConn returns
 		go func() {
@@ -147,8 +204,17 @@ func ServeRPCClient(ctx context.Context, log logrus.FieldLogger, dmsgC *dmsg.Cli
 		<-connCtx.Done()
 		idleConn.stop()
 
+		// If a skynet conn ended for any reason other than the
+		// visor shutting down, treat that as a skynet-path failure
+		// and start the cooldown — keeps us from immediately cycling
+		// back onto the same flaky path on the next dial.
+		if via == transportSkynet && !isDone(ctx) {
+			lastSkyFail.Store(time.Now().UnixNano())
+		}
+
 		log.WithError(conn.Close()).
 			WithField("context_done", isDone(ctx)).
+			WithField("via", string(via)).
 			Debug("Conn closed. Redialing...")
 	}
 }

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -51,7 +51,14 @@ type HVVisorEntry struct {
 	// "online but health unknown" branch and renders as a gray
 	// outline circle even when the visor is fully healthy.
 	ServicesHealth string `json:"services_health,omitempty"`
-	Error          string `json:"error,omitempty"`
+	// Hostname is the visor's os.Hostname(). The hvui's main node
+	// list uses this as the default Label when no explicit label is
+	// set; without it, sub-section rows render with an empty Label
+	// column even though the visor itself reports a valid hostname.
+	// Carried separately from PK because Overview.Hostname doesn't
+	// survive the HVVisorEntry round-trip otherwise.
+	Hostname string `json:"hostname,omitempty"`
+	Error    string `json:"error,omitempty"`
 	// ProxiedVia is set when this entry was discovered through a connected
 	// sub-hypervisor rather than a direct connection. The value is the PK
 	// of the sub-hypervisor that proxies operations on this visor.
@@ -71,6 +78,7 @@ func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
 	entry.Apps = len(summary.Overview.Apps)
 	entry.ConfigVersion = summary.ConfigVersion
 	entry.RewardAddress = summary.RewardAddress
+	entry.Hostname = summary.Overview.Hostname
 	if summary.Health != nil {
 		entry.ServicesHealth = summary.Health.ServicesHealth
 	}


### PR DESCRIPTION
## Summary

Follow-up to #2808. The Hostname propagation through HVVisorEntry only works when *both* the local hypervisor and the sub-hypervisor are on new code. A sub-hypervisor running an older binary doesn't populate Hostname → sub-section row falls through to LAN IP as the default label until that sub-hypervisor updates.

Bridge the gap: when projecting a sub-section visor whose HVVisorEntry has an empty Hostname, fall back to the local hypervisor's own summaryCache. If we have a direct conn to that PK (we polled it for the local section), the cached Summary has the hostname.

## Behavior matrix

- **Sub-hypervisor on new code**: Hostname carries through HVVisorEntry. Bridge is a no-op (`!= ""` guard).
- **Sub-hypervisor on old code + is a managed visor of mine**: bridge populates from cache. Fixed immediately.
- **Sub-hypervisor on old code + NOT a managed visor of mine**: no cache hit, falls back to LAN IP as before. Only the sub-hypervisor updating fixes this case.

## Test plan

- [x] Builds clean.
- [ ] Field test: magnetosphere (on `7aca74e42b7a`, pre-#2808) appears in its own sub-section with hostname as label, drawn from local summaryCache.