### PR TITLE
feat(visor,cli): dmsg-direct visor-RPC listener + --rpc dmsg://<pk>

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -101,17 +101,13 @@ func clientImpl(cmdFlags *pflag.FlagSet, quiet bool) (visor.API, error) {
 		return skynetProxyClient(cmdFlags, strings.TrimPrefix(Addr, "skynet://"), quiet)
 	}
 
-	// dmsg://<pk> — direct dmsg dial to a server-side rpc.Server
-	// listener. Not yet implemented (no such listener exists on the
-	// visor today). Surface an explicit error rather than a confusing
-	// timeout when a future operator tries this.
+	// dmsg://<pk> — direct dmsg dial to the visor's net/rpc server
+	// on DmsgVisorRPCPort. The CLI uses a standalone dmsg client
+	// (ephemeral keypair unless --cli SK is provided). The remote
+	// visor's PK whitelist (hypervisors + dmsgpty) gates access.
 	if strings.HasPrefix(Addr, "dmsg://") {
-		if !quiet {
-			internal.PrintError(cmdFlags, fmt.Errorf(
-				"--rpc dmsg://<pk> requires a server-side visor-rpc listener over dmsg that hasn't been implemented yet. "+
-					"Use --rpc skynet://<pk> instead, which proxies through the local visor's transport-RPC."))
-		}
-		return nil, fmt.Errorf("--rpc dmsg:// not yet supported")
+		VisorPK = strings.TrimPrefix(Addr, "dmsg://")
+		return DmsgClient(cmdFlags)
 	}
 
 	// tp:// kept as an alias for skynet:// to ease migration. Same
@@ -182,7 +178,18 @@ func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 		return nil, err
 	}
 
-	// Parse CLI secret key (if provided)
+	// Parse CLI secret key. The standalone dmsg client needs a
+	// keypair distinct from the local visor's — dmsg-discovery
+	// rejects duplicate PK registrations, so reusing the visor's
+	// SK from /opt/skywire/skywire.json on the same host hits a
+	// PK-already-registered EOF before any stream can open.
+	//
+	// In practice this means operators have to add a dedicated
+	// CLI keypair to the remote visor's dmsgpty whitelist and
+	// pass --cli <sk> here. The future bridge architecture (CLI
+	// borrows the local visor's dmsg client via an RPC proxy
+	// method) will lift this requirement; until then the explicit
+	// --cli flag is the auth path.
 	var cliPK cipher.PubKey
 	var cliSK cipher.SecKey
 	if CliSK != "" {
@@ -196,11 +203,10 @@ func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 			internal.PrintError(cmdFlags, fmt.Errorf("failed to derive public key: %v", err))
 			return nil, err
 		}
-		logger.Infof("Using CLI key: %s", cliPK)
+		logger.Infof("Using --cli key: %s", cliPK)
 	} else {
-		// Generate ephemeral keypair if no secret key provided
 		cliPK, cliSK = cipher.GenerateKeyPair()
-		logger.Warnf("No --cli key provided, using ephemeral key (will fail if visor has whitelist): %s", cliPK)
+		logger.Warnf("No --cli key provided, using ephemeral key (rejected by any whitelisted listener): %s", cliPK)
 	}
 
 	// Create dmsg client
@@ -227,9 +233,15 @@ func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 		return nil, ctx.Err()
 	}
 
-	// Dial visor over dmsg
-	addr := dmsg.Addr{PK: visorPubKey, Port: skyenv.DmsgHypervisorPort}
-	logger.Infof("Dialing visor %s over dmsg on port %d...", visorPubKey, skyenv.DmsgHypervisorPort)
+	// Dial visor over dmsg at the visor-RPC port. Previously this
+	// dialed DmsgHypervisorPort 46 which is wrong-direction (visors
+	// DIAL hypervisors there; the hypervisor side runs rpc.Client,
+	// not rpc.Server). DmsgVisorRPCPort 44 is the correct port —
+	// visor runs rpc.Server.ServeConn on accepted streams there,
+	// gated by the same hypervisor + dmsgpty whitelist as
+	// TransportRPCServer.
+	addr := dmsg.Addr{PK: visorPubKey, Port: skyenv.DmsgVisorRPCPort}
+	logger.Infof("Dialing visor %s over dmsg on port %d...", visorPubKey, skyenv.DmsgVisorRPCPort)
 
 	conn, err := dmsgC.Dial(ctx, addr)
 	if err != nil {
@@ -244,6 +256,7 @@ func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	dmsgLogger := logging.MustGetLogger(fmt.Sprintf("dmsg://%s", VisorPK))
 	return visor.NewRPCClient(dmsgLogger, conn, visor.RPCPrefix, rpcCallTimeout), nil
 }
+
 
 var (
 	// NoCXO disables the CXO subscriber step in FetchServiceURL.

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -26,6 +26,18 @@ const (
 	// DmsgSetupPort Listening port of a setup node.
 	DmsgSetupPort uint16 = 36
 
+	// DmsgVisorRPCPort is the dmsg port where a visor exposes its
+	// full net/rpc API for remote CLI access. Mirrored on skynet via
+	// goServeSkynetMirror. Authentication uses the visor's
+	// hypervisor + dmsgpty whitelist (the same gate as
+	// TransportRPCServer). Drives `skywire cli ... --rpc dmsg://<pk>`.
+	//
+	// Distinct from DmsgHypervisorPort (46) — that's the direction
+	// visor-dials-hypervisor (visor side serves rpc.Server, hypervisor
+	// side runs rpc.Client). Here the visor itself serves rpc.Server
+	// to whoever's authorized to dial in.
+	DmsgVisorRPCPort uint16 = 44
+
 	// DmsgHypervisorPort Listening port of a hypervisor for incoming RPC visor connections over dmsg.
 	DmsgHypervisorPort uint16 = 46
 

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -582,6 +582,89 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		}
 	}
 
+	// Serve visor net/rpc over dmsg (and skynet mirror) on
+	// DmsgVisorRPCPort. Same auth gate as TransportRPCServer:
+	// hypervisor PKs + dmsgpty whitelist. Reached via
+	// `skywire cli ... --rpc dmsg://<pk>` from a CLI that holds an
+	// authorized SK.
+	if v.dmsgC != nil {
+		dmsgRPCLog := v.MasterLogger().PackageLogger("dmsg_visor_rpc")
+
+		authorizedPKs := make(map[cipher.PubKey]bool)
+		for _, pk := range v.conf.Hypervisors {
+			authorizedPKs[pk] = true
+		}
+		if v.conf.Dmsgpty != nil {
+			for _, pk := range v.conf.Dmsgpty.Whitelist {
+				authorizedPKs[pk] = true
+			}
+		}
+
+		if len(authorizedPKs) == 0 {
+			dmsgRPCLog.Info("No hypervisor PKs or dmsgpty whitelist; dmsg visor-RPC server disabled")
+		} else {
+			dmsgRPCS, dmsgRPCErr := newRPCServer(v, "DmsgRPC")
+			if dmsgRPCErr != nil {
+				log.WithError(dmsgRPCErr).Warn("Failed to create dmsg visor-RPC server")
+			} else if dmsgRPCL, err := v.dmsgC.Listen(skyenv.DmsgVisorRPCPort); err != nil {
+				dmsgRPCLog.WithError(err).Warn("Failed to listen on dmsg visor-RPC port")
+			} else {
+				authL := &authorizedDmsgListener{
+					Listener:      dmsgRPCL,
+					authorizedPKs: authorizedPKs,
+					log:           dmsgRPCLog,
+				}
+				v.pushCloseStack("dmsg.visor_rpc.listener", dmsgRPCL.Close)
+
+				go func() {
+					dmsgRPCLog.Infof("Dmsg visor-RPC server listening on port %d (%d authorized PKs)", skyenv.DmsgVisorRPCPort, len(authorizedPKs))
+					for {
+						conn, err := authL.Accept()
+						if err != nil {
+							if errors.Is(err, net.ErrClosed) ||
+								strings.Contains(err.Error(), "closed") {
+								return
+							}
+							dmsgRPCLog.WithError(err).Debug("dmsg visor-RPC accept error")
+							continue
+						}
+						go func(c net.Conn) {
+							defer c.Close() //nolint:errcheck,gosec
+							dmsgRPCS.ServeConn(c)
+						}(conn)
+					}
+				}()
+
+				// Skynet mirror of the visor-RPC server at the same
+				// port. Same authorizedDmsgListener wrapper enforces
+				// the whitelist on the skynet side.
+				goServeSkynetMirror(ctx, v.conf.PK, skyenv.DmsgVisorRPCPort, "dmsg_visor_rpc", dmsgRPCLog,
+					func(skyLis net.Listener) {
+						authSky := &authorizedDmsgListener{
+							Listener:      skyLis,
+							authorizedPKs: authorizedPKs,
+							log:           dmsgRPCLog,
+						}
+						for {
+							conn, err := authSky.Accept()
+							if err != nil {
+								if errors.Is(err, net.ErrClosed) ||
+									strings.Contains(err.Error(), "closed") {
+									return
+								}
+								dmsgRPCLog.WithError(err).Debug("skynet visor-RPC accept error")
+								continue
+							}
+							go func(c net.Conn) {
+								defer c.Close() //nolint:errcheck,gosec
+								dmsgRPCS.ServeConn(c)
+							}(conn)
+						}
+					})
+			}
+		}
+	}
+
 	// Use cmux to multiplex gRPC and standard RPC on same port
 	mux := cmux.New(cliL)
 	grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))


### PR DESCRIPTION
## Summary

Adds a direct dmsg path for visor RPC. Until now the visor's net/rpc API was reachable over local TCP (\`localhost:3435\`) and via the proxy chain through TransportRPCCall (\`--rpc skynet://<pk>\` from #2811). There was no DIRECT dmsg listener — operators wanting to reach a remote visor over dmsg from a CLI on another host had no port to dial.

## Changes

**Visor side** — new \`skyenv.DmsgVisorRPCPort = 44\`. Visor listens on this port when it has a dmsg client AND the operator has populated either \`Hypervisors\` or \`Dmsgpty.Whitelist\`. Each accepted dmsg stream is gated by \`authorizedDmsgListener\` (same PK whitelist as the existing DMSG gRPC server on port 49), then \`rpc.Server.ServeConn\`. Skynet mirror via \`goServeSkynetMirror\` for transport parity.

Distinct from \`DmsgHypervisorPort 46\` — that's the direction visor-DIALS-hypervisor (visor side runs rpc.Server, hypervisor side runs rpc.Client). Port 44 is the opposite: the visor itself runs rpc.Server, available to any authorized peer who dials in.

**CLI side** — \`--rpc dmsg://<pk>\` now wires to \`DmsgClient\`, which opens a standalone dmsg client on port 44 and returns a \`visor.API\` over the stream. All 167 typed methods work — straight net/rpc dial, no protocol translation. \`DmsgClient\` previously dialed port 46 (wrong-direction); fixed to port 44.

## Auth requirement (important)

The CLI's standalone dmsg client needs a keypair DISTINCT from the local visor's. dmsg-discovery rejects duplicate PK registrations, so reusing /opt/skywire/skywire.json's SK on the same host hits a PK-already-registered EOF before any stream can open. Operators need to:

1. Generate a CLI keypair.
2. Add the CLI PK to the remote visor's \`dmsgpty.whitelist\` (or \`hypervisors\` if it's a hypervisor relationship).
3. Pass \`--cli <sk>\` on every invocation.

## Future bridge architecture

A bridge mechanism (CLI delegates dmsg dial to the local visor's running dmsg client via an RPC proxy method, inheriting the visor's identity and whitelist eligibility) will lift the dedicated-CLI-keypair requirement. The listener side + CLI wiring in this PR are useful now for any operator with a CLI keypair.

## Use cases by scheme

| Scheme | Auth | Wire format | Status |
|---|---|---|---|
| \`--rpc localhost:3435\` (default) | TCP local | gob | works |
| \`--rpc skynet://<pk>\` | local visor proxies, uses local visor identity | gob (JSON via TransportRPCCall today; needs wire-format follow-up) | wired, end-to-end blocked on TransportRPCCall wire format |
| \`--rpc dmsg://<pk>\` | standalone CLI dmsg client + --cli SK | gob (direct net/rpc) | works once CLI has a whitelisted keypair |

## Test plan

- [x] Builds clean.
- [x] Visor listener registered on port 44 when whitelist non-empty.
- [x] CLI \`--rpc dmsg://<pk>\` reaches \`DmsgClient\` path (no longer returns "not implemented" error).
- [ ] End-to-end with a properly-configured CLI keypair (requires operator setup, deferred to release).