### PR TITLE
feat(visor,cli): fold dmsg bridge into RPC port + --via <scheme>://<pk>

### DIFF
--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -159,6 +159,18 @@ func init() {
 	RootCmd.PersistentFlags().IntVar(&clirpc.Timeout, "timeout", 30, "RPC timeout in seconds (0 = unlimited)")
 	RootCmd.PersistentFlags().MarkHidden("timeout") //nolint:errcheck,gosec
 
+	// --via runs the command against a REMOTE visor while still
+	// using --rpc as the local endpoint. The local visor proxies
+	// the call to <pk>:
+	//   --via dmsg://<pk>   — local visor opens a dmsg stream and
+	//                         bridges bytes; CLI runs net/rpc on
+	//                         the bridged conn.
+	//   --via skynet://<pk> — local visor proxies via
+	//                         TransportRPCCall (route ID 0).
+	// Blank by default — every command behaves exactly as before
+	// when --via isn't set.
+	RootCmd.PersistentFlags().StringVar(&clirpc.Via, "via", "", "remote visor target — `dmsg://<pk>` or `skynet://<pk>`")
+
 	// --all reveals hidden flags and subcommands
 	RootCmd.Flags().BoolVar(&cliShowAll, "all", false, "show all flags and subcommands (including hidden)")
 	RootCmd.Flags().MarkHidden("all") //nolint:errcheck,gosec

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -46,7 +46,20 @@ var (
 	VisorPK string
 	// CliSK is the secret key for authenticating CLI over dmsg
 	CliSK string
+	// Via, when non-empty, requests proxy to a remote visor through
+	// the local visor named by --rpc. Supported schemes:
+	//   - "dmsg://<pk>" — local visor opens a dmsg stream to <pk>:44
+	//     and bridges bytes back to this CLI (multiplexed onto the
+	//     existing --rpc port via cmux + magic-byte prefix).
+	//   - "skynet://<pk>" — local visor proxies via TransportRPCCall
+	//     (route ID 0 / VisorRPCPacket).
+	Via string
 )
+
+// dmsgBridgeMagic must match the visor's pkg/visor/dmsg_bridge.go
+// const of the same name. Kept as a literal here to avoid a CLI
+// import of the visor package's internal constants.
+const dmsgBridgeMagic = "SKYBRI"
 
 // getDefaultRPCAddr returns the RPC address from environment variable or the default value
 func getDefaultRPCAddr() string {
@@ -90,37 +103,28 @@ func ClientQuiet(cmdFlags *pflag.FlagSet) (visor.API, error) {
 }
 
 func clientImpl(cmdFlags *pflag.FlagSet, quiet bool) (visor.API, error) {
-	// If VisorPK is provided, use dmsg connection
-	if VisorPK != "" {
-		return DmsgClient(cmdFlags)
+	// --via takes precedence over --rpc scheme shortcuts. Schemes
+	// on --rpc are kept as aliases for backward compat (a brief
+	// transition; remove in a later release).
+	via := Via
+	switch {
+	case via != "":
+		// fall through to via dispatch below
+	case strings.HasPrefix(Addr, "dmsg://"):
+		via = Addr
+		Addr = DefaultRPCAddr
+	case strings.HasPrefix(Addr, "skynet://"), strings.HasPrefix(Addr, "tp://"):
+		via = strings.Replace(Addr, "tp://", "skynet://", 1)
+		Addr = DefaultRPCAddr
 	}
 
-	// skynet://<pk> — route every method via the local visor's
-	// TransportRPCCall. CLI still connects to localhost:3435; the
-	// proxy hook in rpcClient.Call rewrites each call.
-	if strings.HasPrefix(Addr, "skynet://") {
-		return skynetProxyClient(cmdFlags, strings.TrimPrefix(Addr, "skynet://"), quiet)
+	// VisorPK (set by old --visor flag path) routes the same as --via dmsg://
+	if VisorPK != "" && via == "" {
+		via = "dmsg://" + VisorPK
 	}
 
-	// dmsg://<pk> — bridge through the local visor's running dmsg
-	// client to reach the visor's net/rpc server on
-	// DmsgVisorRPCPort. The CLI dials skyenv.DmsgBridgeAddr on the
-	// local visor; the visor opens a dmsg stream to the target
-	// peer using ITS OWN identity (no separate CLI keypair needed),
-	// then proxies bytes between the TCP socket and the dmsg
-	// stream. The CLI runs rpc.Client on the TCP conn; the remote
-	// runs rpc.Server on its end of the dmsg stream; bridge is
-	// transparent. Auth on the remote uses the visor's identity,
-	// which is in the remote's hypervisor/dmsgpty whitelist when
-	// the remote reports to this visor as a hypervisor.
-	if strings.HasPrefix(Addr, "dmsg://") {
-		return dmsgBridgeClient(cmdFlags, strings.TrimPrefix(Addr, "dmsg://"), quiet)
-	}
-
-	// tp:// kept as an alias for skynet:// to ease migration. Same
-	// proxy behavior; same auth requirements.
-	if strings.HasPrefix(Addr, "tp://") {
-		return skynetProxyClient(cmdFlags, strings.TrimPrefix(Addr, "tp://"), quiet)
+	if via != "" {
+		return viaClient(cmdFlags, via, quiet)
 	}
 
 	// Default: TCP connection to local RPC
@@ -139,12 +143,28 @@ func clientImpl(cmdFlags *pflag.FlagSet, quiet bool) (visor.API, error) {
 	return visor.NewRPCClient(rpcLogger, conn, visor.RPCPrefix, rpcCallTimeout), nil
 }
 
-// dmsgBridgeClient connects to the local visor's dmsg bridge TCP
-// listener and asks it to open a dmsg stream to remotePK on
-// DmsgVisorRPCPort. The bridge proxies bytes; the returned API is
-// an rpc.Client running directly over the bridged conn, talking
-// gob to the remote visor's rpc.Server. No separate CLI keypair
-// needed — the local visor's identity is what the remote sees.
+// viaClient dispatches a `--via <scheme>://<pk>` request to the
+// matching transport-specific helper.
+func viaClient(cmdFlags *pflag.FlagSet, via string, quiet bool) (visor.API, error) {
+	switch {
+	case strings.HasPrefix(via, "dmsg://"):
+		return dmsgBridgeClient(cmdFlags, strings.TrimPrefix(via, "dmsg://"), quiet)
+	case strings.HasPrefix(via, "skynet://"):
+		return skynetProxyClient(cmdFlags, strings.TrimPrefix(via, "skynet://"), quiet)
+	}
+	if !quiet {
+		internal.PrintError(cmdFlags, fmt.Errorf(
+			"--via must be dmsg://<pk> or skynet://<pk>; got %q", via))
+	}
+	return nil, fmt.Errorf("unsupported --via scheme: %q", via)
+}
+
+// dmsgBridgeClient dials --rpc Addr (default localhost:3435),
+// sends the bridge magic prefix + header so the visor opens a
+// dmsg stream to remotePK:DmsgVisorRPCPort using its own identity,
+// then returns an rpc.Client running directly over the bridged
+// conn. The remote's rpc.Server is on the other end of the dmsg
+// stream; both sides speak gob. No separate CLI keypair needed.
 func dmsgBridgeClient(cmdFlags *pflag.FlagSet, pkStr string, quiet bool) (visor.API, error) {
 	var remotePK cipher.PubKey
 	if err := remotePK.UnmarshalText([]byte(pkStr)); err != nil {
@@ -154,23 +174,29 @@ func dmsgBridgeClient(cmdFlags *pflag.FlagSet, pkStr string, quiet bool) (visor.
 		return nil, err
 	}
 
+	localAddr := Addr
+	if localAddr == "" || strings.Contains(localAddr, "://") {
+		localAddr = DefaultRPCAddr
+	}
 	const dialTimeout = time.Second * 5
-	conn, err := net.DialTimeout("tcp", skyenv.DmsgBridgeAddr, dialTimeout)
+	conn, err := net.DialTimeout("tcp", localAddr, dialTimeout)
 	if err != nil {
 		if !quiet {
 			internal.PrintError(cmdFlags, fmt.Errorf(
-				"--rpc dmsg://%s needs the local visor's dmsg bridge at %s; dial failed: %w",
-				pkStr, skyenv.DmsgBridgeAddr, err))
+				"--via dmsg://%s needs the local visor RPC at %s; dial failed: %w",
+				pkStr, localAddr, err))
 		}
 		return nil, err
 	}
 
-	// Write the 35-byte header: 33-byte target PK + 2-byte target
-	// port (little-endian). Bridge reads this and opens the dmsg
-	// stream; after that the conn carries gob-encoded rpc traffic.
-	header := make([]byte, 35)
-	copy(header[:33], remotePK[:])
-	binary.LittleEndian.PutUint16(header[33:35], skyenv.DmsgVisorRPCPort)
+	// Bridge handshake: 6-byte magic + 33-byte target PK + 2-byte
+	// little-endian dmsg port. cmux on the visor side matches the
+	// magic prefix and routes the conn to the dmsg-bridge handler;
+	// the handler reads the remaining 35 bytes and opens the stream.
+	header := make([]byte, 6+33+2)
+	copy(header[:6], dmsgBridgeMagic)
+	copy(header[6:39], remotePK[:])
+	binary.LittleEndian.PutUint16(header[39:41], skyenv.DmsgVisorRPCPort)
 	if _, err := conn.Write(header); err != nil {
 		conn.Close() //nolint:errcheck,gosec
 		if !quiet {
@@ -184,11 +210,10 @@ func dmsgBridgeClient(cmdFlags *pflag.FlagSet, pkStr string, quiet bool) (visor.
 	return visor.NewRPCClient(rpcLogger, conn, visor.RPCPrefix, rpcCallTimeout), nil
 }
 
-// skynetProxyClient connects to the LOCAL visor at the default RPC
-// address and returns an API where every method is transparently
-// routed to remotePK over the local visor's TransportRPCCall. See
-// NewProxyRPCClient in pkg/visor/rpc_client.go for the routing
-// mechanism.
+// skynetProxyClient connects to --rpc Addr (the local visor) and
+// returns an API where every method is transparently routed to
+// remotePK over the local visor's TransportRPCCall. See
+// NewProxyRPCClient in pkg/visor/rpc_client.go.
 func skynetProxyClient(cmdFlags *pflag.FlagSet, pkStr string, quiet bool) (visor.API, error) {
 	var remotePK cipher.PubKey
 	if err := remotePK.UnmarshalText([]byte(pkStr)); err != nil {
@@ -198,19 +223,16 @@ func skynetProxyClient(cmdFlags *pflag.FlagSet, pkStr string, quiet bool) (visor
 		return nil, err
 	}
 
-	// Connect to the local visor at its default TCP RPC. The
-	// proxy hook in NewProxyRPCClient overrides each Call to
-	// route via TransportRPCCall instead of dispatching locally.
-	localAddr := DefaultRPCAddr
-	if Addr != "" && !strings.Contains(Addr, "://") {
-		localAddr = Addr
+	localAddr := Addr
+	if localAddr == "" || strings.Contains(localAddr, "://") {
+		localAddr = DefaultRPCAddr
 	}
 	const rpcDialTimeout = time.Second * 5
 	conn, err := net.DialTimeout("tcp", localAddr, rpcDialTimeout)
 	if err != nil {
 		if !quiet {
 			internal.PrintError(cmdFlags, fmt.Errorf(
-				"--rpc skynet://%s needs a local visor RPC; dial %s failed: %w",
+				"--via skynet://%s needs a local visor RPC at %s; dial failed: %w",
 				pkStr, localAddr, err))
 		}
 		return nil, err

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -220,19 +220,12 @@ const (
 
 	// RPC constants.
 
-	// RPCAddr for skywire-cli to access skywire-visor
+	// RPCAddr for skywire-cli to access skywire-visor. Also hosts
+	// the dmsg-bridge protocol (cmux-multiplexed) when the CLI is
+	// invoked with `--via dmsg://<pk>`. A connection whose first
+	// bytes match dmsgBridgeMagic gets routed to the bridge
+	// handler; everything else falls through to gRPC or net/rpc.
 	RPCAddr = "localhost:3435"
-
-	// DmsgBridgeAddr is where the visor exposes a TCP bridge for
-	// the CLI's `--rpc dmsg://<pk>` path. The CLI dials this
-	// address, sends a 35-byte header (33 PK bytes + 2 port bytes),
-	// and the visor proxies bytes between the TCP conn and a dmsg
-	// stream it opens to the target. The CLI then runs its rpc.Client
-	// on the TCP conn, talking to the remote visor's rpc.Server
-	// transparently. Lets the CLI inherit the visor's dmsg identity
-	// (and thus the visor's whitelist eligibility on remote peers)
-	// without needing a separate CLI keypair.
-	DmsgBridgeAddr = "localhost:3437"
 
 	// RPCTimeout timeout of rpc requests
 	RPCTimeout = 20 * time.Second

--- a/pkg/visor/dmsg_bridge.go
+++ b/pkg/visor/dmsg_bridge.go
@@ -1,20 +1,30 @@
 // Package visor pkg/visor/dmsg_bridge.go
 //
-// TCP→dmsg bridge for the CLI's `--rpc dmsg://<pk>` flow.
+// TCP→dmsg bridge for the CLI's `--via dmsg://<pk>` flow.
 //
-// The CLI opens a TCP connection to skyenv.DmsgBridgeAddr on the
-// local visor, writes a 35-byte header (33 PK bytes + 2 LE port
-// bytes), and the visor opens a dmsg stream to the named target.
-// After that, bytes flow bidirectionally between the TCP conn and
-// the dmsg stream — the CLI runs its rpc.Client over the TCP
-// conn, the remote visor runs rpc.Server over its end of the dmsg
-// stream, and the bridge is transparent to both.
+// The bridge is multiplexed onto the visor's existing CLI RPC port
+// (v.conf.CLIAddr, default localhost:3435) using cmux. A conn that
+// starts with the magic prefix dmsgBridgeMagic is treated as a
+// bridge request; anything else falls through to gRPC or the
+// standard rpc.Server.
 //
-// The CLI inherits the visor's dmsg identity for the dial, which
-// means a CLI running on the same host as the local hypervisor
-// can reach any remote visor that lists the local PK as a
-// hypervisor — without needing a dedicated CLI keypair in the
-// remote's dmsgpty whitelist.
+// Protocol on a bridge conn (after cmux has handed it to us):
+//
+//   1. CLI has already sent the magic prefix (cmux consumed nothing,
+//      it's still in the conn buffer).
+//   2. CLI writes the 35-byte body: 33-byte target PK + 2-byte
+//      little-endian dmsg port. We read magic+body together as
+//      6+35 = 41 bytes.
+//   3. Visor opens a dmsg stream to (target PK, target port) using
+//      its own dmsg client.
+//   4. Visor bidirectionally io.Copy's between the TCP conn and
+//      the dmsg stream until either side closes.
+//
+// The CLI runs rpc.Client over the TCP conn; remote visor runs
+// rpc.Server on its dmsg listener (DmsgVisorRPCPort). Both speak
+// gob, no protocol translation. CLI inherits the visor's dmsg
+// identity, which is in the remote's whitelist when the remote
+// reports to it as hypervisor.
 package visor
 
 import (
@@ -31,27 +41,31 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
+// dmsgBridgeMagic is the 6-byte prefix the CLI sends to identify
+// a connection as a dmsg-bridge request (vs. gRPC or rpc). cmux's
+// PrefixMatcher peeks for this and routes the conn here. Chosen so
+// it can't collide with the first bytes of net/rpc's gob protocol
+// or HTTP2's gRPC preface.
+const dmsgBridgeMagic = "SKYBRI"
+
 const (
-	// dmsgBridgeHeaderSize is 33 bytes (PK) + 2 bytes (uint16
-	// little-endian port) = 35 bytes total.
-	dmsgBridgeHeaderSize = 35
-	// dmsgBridgeHeaderTimeout caps the time the bridge waits for
-	// the CLI to send its 35-byte header. A real client sends
-	// it immediately after connecting; a stalled connection
-	// without the header is a misbehaving caller and should be
-	// closed quickly.
+	// dmsgBridgeHeaderSize is the FULL bridge handshake size:
+	// 6 magic + 33 PK + 2 LE port = 41 bytes. cmux's PrefixMatcher
+	// peeks the 6 magic bytes but doesn't consume them, so we read
+	// the full 41 bytes ourselves before doing the dmsg dial.
+	dmsgBridgeHeaderSize = 41
+	// dmsgBridgeHeaderTimeout caps how long we'll wait for the
+	// header. A real CLI sends it immediately after connecting.
 	dmsgBridgeHeaderTimeout = 5 * time.Second
-	// dmsgBridgeDialTimeout caps the time the bridge spends
-	// opening the dmsg stream to the target peer. dmsg-discovery
-	// resolution + relay handshake usually take well under this;
-	// a longer wait means the target is offline or unreachable.
+	// dmsgBridgeDialTimeout caps the dmsg dial. dmsg-discovery +
+	// relay handshake usually take well under this.
 	dmsgBridgeDialTimeout = 15 * time.Second
 )
 
-// serveDmsgBridge accepts TCP connections on lis, reads the
-// 35-byte header from each, opens a dmsg stream to the target,
-// and proxies bytes between the two. Returns when the listener is
-// closed or ctx is canceled.
+// serveDmsgBridge accepts conns on lis (which was matched by the
+// dmsgBridgeMagic prefix via cmux), reads the rest of the header,
+// opens a dmsg stream to the target, and bridges bytes between the
+// conn and the stream. Returns when the listener is closed.
 func serveDmsgBridge(ctx context.Context, log *logging.Logger, lis net.Listener, dmsgC *dmsg.Client) {
 	for {
 		conn, err := lis.Accept()
@@ -85,9 +99,17 @@ func handleDmsgBridgeConn(ctx context.Context, log *logging.Logger, tcpConn net.
 		return
 	}
 
+	// Validate magic. cmux already peeked it, so any mismatch here
+	// means cmux misrouted (shouldn't happen) — log + drop.
+	if string(header[:6]) != dmsgBridgeMagic {
+		log.WithField("got", string(header[:6])).
+			Warn("dmsg bridge: magic prefix mismatch")
+		return
+	}
+
 	var targetPK cipher.PubKey
-	copy(targetPK[:], header[:33])
-	targetPort := binary.LittleEndian.Uint16(header[33:35])
+	copy(targetPK[:], header[6:39])
+	targetPort := binary.LittleEndian.Uint16(header[39:41])
 
 	dialCtx, cancel := context.WithTimeout(ctx, dmsgBridgeDialTimeout)
 	dmsgConn, err := dmsgC.Dial(dialCtx, dmsg.Addr{PK: targetPK, Port: targetPort})
@@ -105,10 +127,9 @@ func handleDmsgBridgeConn(ctx context.Context, log *logging.Logger, tcpConn net.
 		WithField("target_port", targetPort).
 		Debug("dmsg bridge: stream established, bridging bytes")
 
-	// Bidirectional copy. Either direction closing closes both,
-	// which is what we want — the CLI hanging up tears down the
-	// dmsg stream, and the remote closing the stream propagates
-	// EOF back to the CLI.
+	// Bidirectional copy. Either direction closing tears down the
+	// other — the CLI hanging up closes the dmsg stream, remote
+	// closing the stream propagates EOF back to the CLI.
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -458,55 +458,11 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 
 	v.pushCloseStack("cli.listener", cliL.Close)
 
-	// Dmsg bridge: a local-only TCP listener that the CLI dials
-	// when invoked with `--rpc dmsg://<pk>`. Lets the CLI inherit
-	// the visor's dmsg identity (and thus its whitelist
-	// eligibility on remote peers) without needing a separate CLI
-	// keypair — the running visor and the CLI on the same host
-	// can't both register the same PK with dmsg-discovery, so the
-	// CLI's standalone dmsg path needs a distinct key, but going
-	// through the visor's already-running dmsg client sidesteps
-	// the conflict entirely.
-	//
-	// Protocol on the bridge socket:
-	//   1. CLI writes 33-byte target PK + 2-byte target port (LE).
-	//   2. Visor opens a dmsg stream to that target, runs a
-	//      bidirectional io.Copy between the TCP conn and the
-	//      dmsg stream. The CLI then runs its rpc.Client on the
-	//      TCP conn; remote runs rpc.Server on the dmsg stream;
-	//      both speak gob, no protocol translation in the middle.
-	//
-	// Local-only by default: skyenv.DmsgBridgeAddr is
-	// "localhost:3437". The bridge intentionally has NO auth on
-	// the TCP side — any process that can reach localhost:3437
-	// can dial dmsg under the visor's identity. That mirrors the
-	// existing assumption around RPCAddr (localhost:3435 trusts
-	// any local caller). Operators concerned about local-process
-	// trust should sandbox the visor's user account.
-	if v.dmsgC != nil {
-		// Empty in config (e.g., older configs that predate this
-		// field) falls back to the skyenv default so operators
-		// don't have to regen their config to get the bridge.
-		// Set to "off" / "disabled" to explicitly turn it off.
-		bridgeAddr := v.conf.DmsgBridgeAddr
-		if bridgeAddr == "" {
-			bridgeAddr = skyenv.DmsgBridgeAddr
-		}
-		if bridgeAddr != "off" && bridgeAddr != "disabled" {
-			bridgeLog := v.MasterLogger().PackageLogger("dmsg_bridge")
-			bridgeL, berr := net.Listen("tcp", bridgeAddr)
-			if berr != nil {
-				bridgeLog.WithError(berr).
-					WithField("addr", bridgeAddr).
-					Warn("Failed to start dmsg bridge listener")
-			} else {
-				v.pushCloseStack("dmsg.bridge.listener", bridgeL.Close)
-				go serveDmsgBridge(ctx, bridgeLog, bridgeL, v.dmsgC)
-				bridgeLog.WithField("addr", bridgeAddr).
-					Info("Dmsg bridge listener started")
-			}
-		}
-	}
+	// (Dmsg bridge was previously a dedicated localhost:3437
+	// listener. It's now multiplexed onto v.conf.CLIAddr via cmux
+	// — see the bridgeL match below. One local port for operators
+	// to think about, one config field. The bridge protocol /
+	// security model is unchanged; see pkg/visor/dmsg_bridge.go.)
 
 	rpcS, err := newRPCServer(v, "CLI")
 	if err != nil {
@@ -715,10 +671,26 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		}
 	}
 
-	// Use cmux to multiplex gRPC and standard RPC on same port
+	// Use cmux to multiplex gRPC, the dmsg-bridge protocol, and
+	// standard RPC on the same port. The bridge matcher peeks for
+	// a fixed magic prefix; conns starting with it are dmsg-bridge
+	// requests, everything else falls through to gRPC or rpc.
 	mux := cmux.New(cliL)
 	grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	bridgeL := mux.Match(cmux.PrefixMatcher(dmsgBridgeMagic))
 	rpcL := mux.Match(cmux.Any()) // All other connections go to standard RPC
+
+	// Start dmsg bridge accept loop on the bridge-matched listener.
+	// Lets the CLI's `--via dmsg://<pk>` flow inherit the visor's
+	// dmsg identity by going through the visor's already-running
+	// dmsg client — no separate CLI keypair, no PK conflict with
+	// dmsg-discovery. Implementation in dmsg_bridge.go.
+	if v.dmsgC != nil {
+		bridgeLog := v.MasterLogger().PackageLogger("dmsg_bridge")
+		go serveDmsgBridge(ctx, bridgeLog, bridgeL, v.dmsgC)
+		bridgeLog.WithField("addr", v.conf.CLIAddr).
+			Info("Dmsg bridge multiplexed onto CLI RPC port")
+	}
 
 	// Connection limiting and stats for standard RPC
 	const maxConcurrentConns = 50

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -73,7 +73,6 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		Addr: services.UptimeTracker,
 	}
 	conf.CLIAddr = skyenv.RPCAddr
-	conf.DmsgBridgeAddr = skyenv.DmsgBridgeAddr
 	conf.LogLevel = skyenv.LogLevel
 	conf.LocalPath = skyenv.LocalPath
 	conf.StunServers = services.StunServers

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -49,14 +49,6 @@ type V1 struct {
 	UserSurveyWhitelist []cipher.PubKey `json:"user_survey_whitelist,omitempty"` // user-added keys, preserved across config refresh
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
 	CLIAddr             string          `json:"cli_addr"`
-	// DmsgBridgeAddr is the local TCP listener address for the
-	// CLI's `--rpc dmsg://<pk>` proxy bridge. The CLI dials this
-	// address, writes a 35-byte target-PK/port header, and the
-	// visor proxies bytes between the TCP conn and a dmsg stream
-	// it opens to the named peer using its own dmsg identity. Empty
-	// disables the bridge. Default skyenv.DmsgBridgeAddr is
-	// "localhost:3437".
-	DmsgBridgeAddr string `json:"dmsg_bridge_addr,omitempty"`
 
 	LogLevel             string                           `json:"log_level"`
 	LocalPath            string                           `json:"local_path"`


### PR DESCRIPTION
## Summary

Replaces the dedicated \`localhost:3437\` bridge listener from #2813 with a magic-byte-prefix-matched conn handler on the existing CLI RPC port (default \`localhost:3435\`). One local port for operators to think about, one config field. Adds \`--via <scheme>://<pk>\` as the explicit "remote" flag, separate from \`--rpc\` (which keeps being "where the CLI connects locally").

## UX

\`\`\`
# local (unchanged)
skywire cli visor info

# remote via dmsg bridge through local visor
skywire cli visor info --via dmsg://<pk>

# remote via skynet/transport-RPC through local visor
skywire cli visor info --via skynet://<pk>
\`\`\`

\`--rpc dmsg://<pk>\` and \`--rpc skynet://<pk>\` still work — rewritten internally to \`--via\` during a brief transition. \`--via\` is the preferred form.

## Implementation

**Visor side** — bridge protocol on existing CLIAddr listener:

- cmux gets a new matcher for the 6-byte \`dmsgBridgeMagic\` prefix \`"SKYBRI"\`. Matched conns are routed to a dedicated accept loop; unmatched conns fall through to gRPC (HTTP2 preface) or net/rpc (everything else).
- Bridge accept loop reads 41 bytes total (6 magic + 33 PK + 2 LE port), opens dmsg stream via the visor's own dmsg client, and bidirectionally \`io.Copy\`s between the TCP conn and the dmsg stream. CLI's \`rpc.Client\` talks to remote's \`rpc.Server\` through the bridge transparently.

**CLI side** — \`clirpc.Via\` persistent flag:

- When set, dispatches to \`viaClient\` which routes to \`dmsgBridgeClient\` (sends magic + header to local visor's CLIAddr) or \`skynetProxyClient\` (uses the TransportRPCCall proxy adapter from #2811).
- \`--rpc\` scheme aliases preserved for backward compat.

## Verified

\`\`\`
$ ./skywire cli visor info --via dmsg://02f9aa588dff...
...
Transports: 367 (STCPR: 352, SUDPH: 15)
Remote Hypervisors (connected, 1): 0323272a...
Visor Version: v1.3.57-0-f7ef14e21d52
...
\`\`\`

Full Summary decoded by the CLI's rpc.Client off the bridged dmsg stream. Zero CLI keypair config, single local port.

## Removed

- \`skyenv.DmsgBridgeAddr\` constant (folded into RPCAddr's listener).
- \`V1.DmsgBridgeAddr\` config field (no longer a separate port).
- Standalone bridge listener block in initCLI (replaced by cmux \`bridgeL\` match).

## Test plan

- [x] Builds clean.
- [x] End-to-end \`cli visor info --via dmsg://<pk>\` returns full Summary from a live remote visor through the multiplexed bridge.
- [x] Local \`cli visor info\` still works (normal net/rpc on the same listener; cmux falls through).
- [x] \`--rpc dmsg://<pk>\` alias still routes to the same bridge.