### PR TITLE
fix(hypervisor): no ghost rows on failed Summary + remove data race

### DIFF
--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -113,27 +113,44 @@ func (v *Visor) HVListDirectVisors() ([]HVVisorEntry, error) {
 
 	log := logging.MustGetLogger("hv_list_direct_visors")
 
+	type sumResult struct {
+		summary *Summary
+		err     error
+	}
 	results := make([]HVVisorEntry, len(remotes))
 	var wg sync.WaitGroup
 	wg.Add(len(remotes))
 	for i, e := range remotes {
 		go func(idx int, pk cipher.PubKey, api API) {
 			defer wg.Done()
-			entry := HVVisorEntry{PK: pk, Online: true}
-			done := make(chan struct{})
+			// Buffered so the Summary goroutine never blocks on
+			// send — if we time out, the late result is just gc'd.
+			// Also avoids the data race the previous shared-entry
+			// pattern had (both the Summary goroutine and the
+			// timeout branch could write the same struct).
+			sumCh := make(chan sumResult, 1)
 			go func() {
-				defer close(done)
 				summary, err := api.Summary()
-				if err != nil {
-					entry.Error = err.Error()
-					return
-				}
-				populateEntryFromSummary(&entry, summary)
+				sumCh <- sumResult{summary, err}
 			}()
+
+			entry := HVVisorEntry{PK: pk}
 			select {
-			case <-done:
+			case r := <-sumCh:
+				if r.err != nil {
+					entry.Error = r.err.Error()
+				} else if r.summary != nil {
+					// Online ONLY when we actually got a Summary
+					// back. Hardcoded Online=true previously left
+					// failed-fetch entries showing as healthy in
+					// the tree-summary table with no other fields
+					// populated — the "ghost row" rendering an
+					// operator reported.
+					entry.Online = true
+					populateEntryFromSummary(&entry, r.summary)
+				}
 			case <-time.After(10 * time.Second):
-				entry.Error = "timeout"
+				entry.Error = "timeout (10s)"
 				log.WithField("pk", pk.String()).Warn("HVListDirectVisors: visor query timed out")
 			}
 			results[idx] = entry
@@ -179,26 +196,35 @@ func (v *Visor) HVListVisors() ([]HVVisorEntry, error) {
 	var wg sync.WaitGroup
 	wg.Add(len(remotes))
 
+	type sumResult struct {
+		summary *Summary
+		err     error
+	}
 	for i, e := range remotes {
 		go func(idx int, pk cipher.PubKey, api API) {
 			defer wg.Done()
-			entry := HVVisorEntry{PK: pk, Online: true}
-
-			done := make(chan struct{})
+			// Same pattern as HVListDirectVisors above: buffered
+			// channel avoids the previous data race where both the
+			// Summary goroutine and the timeout branch could write
+			// the shared entry struct. Online is only set when we
+			// actually got a Summary — fixes ghost-row rendering.
+			sumCh := make(chan sumResult, 1)
 			go func() {
-				defer close(done)
 				summary, err := api.Summary()
-				if err != nil {
-					entry.Error = err.Error()
-					return
-				}
-				populateEntryFromSummary(&entry, summary)
+				sumCh <- sumResult{summary, err}
 			}()
 
+			entry := HVVisorEntry{PK: pk}
 			select {
-			case <-done:
+			case r := <-sumCh:
+				if r.err != nil {
+					entry.Error = r.err.Error()
+				} else if r.summary != nil {
+					entry.Online = true
+					populateEntryFromSummary(&entry, r.summary)
+				}
 			case <-time.After(10 * time.Second):
-				entry.Error = "timeout"
+				entry.Error = "timeout (10s)"
 				log.WithField("pk", pk.String()).Warn("HVListVisors: visor query timed out")
 			}
 			results[idx] = entry


### PR DESCRIPTION
Two bugs in \`HVListDirectVisors\` and \`HVListVisors\` that combined to produce the "ghost row" rendering operators reported in the hypervisor UI's tree summary — rows showing only the visor's PK with everything else empty (no version, no IP, no transports) and marked as \`Online\`.

## Bug 1: hardcoded \`Online: true\`

\`\`\`go
entry := HVVisorEntry{PK: pk, Online: true}
\`\`\`

When the Summary RPC failed (timeout or rpcErr — common for visors in a remoteVisors map whose underlying conn has gone stale), the entry kept \`Online=true\` and only the PK was populated. The projection to \`Summary\` on the consumer side then rendered an "online" row with empty everything. Now \`Online\` is set only when \`api.Summary()\` actually returns a non-nil summary.

## Bug 2: data race on the entry struct

The Summary goroutine and the parent's timeout branch could both write to the same \`entry\` struct. After the timeout fired, the Summary goroutine could still be executing \`populateEntryFromSummary\` or assigning \`entry.Error\` mid-write, while the parent did \`results[idx] = entry\`. Replaced with a buffered-channel pattern where the Summary goroutine owns its result (\`sumResult\` struct) and the parent reads it via \`select\`.

Both fixes applied to \`HVListDirectVisors\` and the parallel logic in \`HVListVisors\`.

## What the operator sees after this lands

Sub-section entries for managed visors whose Summary actually succeeded continue to render normally. Entries whose Summary failed now render with \`Online=false\` — the UI's existing "offline" indicator path applies. PK-only ghost rows masquerading as online are gone.

## Test plan

- [x] Builds clean across the repo.
- [ ] Field test: with a sub-hypervisor that has stale entries in its remoteVisors, the tree summary no longer shows them as Online with empty fields.