### PR TITLE
fix(transport,dmsg): TCP_NODELAY on all interactive paths

### DIFF
--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -117,6 +117,18 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 			return ClientSession{}, fmt.Errorf("failed to dial: %w", err)
 		}
 	}
+	// TCP_NODELAY on the visor→dmsg-server TCP socket. The dmsg
+	// session carries all dmsg streams (skypty traffic, dmsg-HTTP,
+	// visor-RPC over dmsg, skychat, etc.). Without this, Nagle's
+	// algorithm batches small writes — per-keystroke pty bytes
+	// from the hypervisor UI's skypty hit 40–200ms of delay each,
+	// felt as lag on every key press. dmsg streams demux many
+	// logical flows onto one TCP conn; the demux-side throughput
+	// gains of Nagle aren't material for skywire's mix, and the
+	// interactive-latency loss is severe.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+	}
 
 	dSes, err := makeClientSession(&ce.EntityCommon, ce.porter, conn, entry.Static)
 	if err != nil {

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -218,6 +218,13 @@ func (s *Server) Serve(lis net.Listener, addr string) error {
 			}
 			return err
 		}
+		// TCP_NODELAY on accepted visor sessions — symmetric with the
+		// dial-side fix in client_sessions.go. Without matching it
+		// here, response packets from server to visor would still
+		// Nagle-batch even if the visor's outbound side was clean.
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+		}
 
 		if s.SessionCount() >= s.maxSessions {
 			s.log.
@@ -445,6 +452,13 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer PeerEntry) {
 				bo = time.Duration(float64(bo) * 1.5)
 			}
 			continue
+		}
+		// TCP_NODELAY on the server↔server peer link. Same rationale
+		// as the visor↔server side: small interactive payloads
+		// routed across the dmsg mesh shouldn't pay 40–200ms of
+		// Nagle batching at each hop.
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.SetNoDelay(true) //nolint:errcheck
 		}
 
 		ses := new(SessionCommon)

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -204,6 +204,17 @@ func (c *genericClient) acceptTransport() error {
 	if err != nil {
 		return err
 	}
+	// TCP_NODELAY on inbound TCP transports (stcpr/stcp) so the
+	// accepting end doesn't Nagle-batch responses to small
+	// interactive payloads (per-keystroke skypty bytes, small RPC
+	// replies). The dial side sets the same flag in stcpr.go /
+	// stcp.go; without matching it here, the lag re-appears on the
+	// reverse direction of any interactive stream. UDP-based
+	// sudph isn't affected (no Nagle); the type assertion is a
+	// no-op for non-TCP listeners.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+	}
 	remoteAddr := conn.RemoteAddr()
 	c.log.Debugf("Accepted connection from %v", remoteAddr)
 

--- a/pkg/transport/network/stcp.go
+++ b/pkg/transport/network/stcp.go
@@ -52,6 +52,11 @@ func (c *stcpClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) 
 	if err != nil {
 		return nil, err
 	}
+	// TCP_NODELAY — see stcpr.go's matching comment. Interactive
+	// traffic (skypty, ssh, RPC) bottlenecks on Nagle without this.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+	}
 
 	c.log.Debugf("Dialed %v:%v@%v", rPK, rPort, conn.RemoteAddr())
 	tp, err := c.initTransport(ctx, conn, rPK, rPort)

--- a/pkg/transport/network/stcpr.go
+++ b/pkg/transport/network/stcpr.go
@@ -54,7 +54,23 @@ func (c *stcprClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16)
 func (c *stcprClient) dial(ctx context.Context, addr string) (net.Conn, error) {
 	c.eb.SendTCPDial(context.Background(), string(types.STCPR), addr)
 	dialer := net.Dialer{}
-	return dialer.DialContext(ctx, "tcp", addr)
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	// TCP_NODELAY for interactive traffic. Without this, Nagle's
+	// algorithm batches small writes (e.g., per-keystroke pty bytes
+	// from the hypervisor UI's skypty terminal) with 40–200ms of
+	// delay each, manifesting as per-keystroke lag for operators
+	// using the web pty. Skywire's interactive paths (skypty, ssh
+	// app, remote shells, RPC calls with small request payloads)
+	// all benefit from disabling Nagle; bulk transfers don't lose
+	// anything meaningful (modern TCP segmentation handles
+	// throughput-side packaging at the kernel level).
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+	}
+	return conn, nil
 }
 
 // Start implements Client interface


### PR DESCRIPTION
## Summary

Operator reports per-keystroke lag in the hypervisor UI's skypty terminal — typing feels delayed by ~50-200ms per character.

Root cause: none of skywire's TCP transports set \`TCP_NODELAY\`, so the kernel's Nagle algorithm batches small writes. For interactive traffic like a per-keystroke pty (where each byte is a separate write of 1-2 bytes), Nagle batches with up to 200ms of delay waiting for "more data" that never comes; combined with the remote's delayed-ACK behavior, that's the per-keystroke lag.

## Fix

Set \`TCP_NODELAY\` on both ends of every TCP socket used by skywire's interactive paths. Five sites:

1. \`pkg/transport/network/stcpr.go\` — dial side of stcpr.
2. \`pkg/transport/network/stcp.go\` — dial side of stcp.
3. \`pkg/transport/network/client.go\` — accept side, shared between stcpr/stcp listeners.
4. \`pkg/dmsg/dmsg/client_sessions.go\` — visor's dial to dmsg-server.
5. \`pkg/dmsg/dmsg/server.go\` — dmsg-server's accept of visor sessions + server↔server peer-mesh dials.

Setting it symmetrically on both ends is required; one-sided \`SetNoDelay\` still leaves the unfixed direction Nagle-batching responses, so the round-trip latency stays bad.

## Why disable Nagle network-wide vs. only on pty conns

Nagle helps applications that emit many small writes without intermediate flushes. It hurts applications that emit a single small write and expect it to ship immediately. Skywire's traffic mix:

- **pty/ssh bytes**: single write per keystroke, ship immediately.
- **RPC**: ~KB-scale request/reply, single write each. Nagle is irrelevant — payload already > MSS.
- **dmsg stream packets**: framed, sized payloads — kernel TSO handles throughput-side packaging.
- **Bulk transfer** (dmsg HTTP / skywire-routed apps): same shape; kernel does the right thing without Nagle.

For every payload pattern skywire actually has, TCP_NODELAY is a wash or a clear improvement.

## What operators feel after this lands

- **Interactive pty** (hvui skypty + \`cli dmsg pty start\`) drops from "laggy at every keystroke" to "feels local up to your actual network RTT."
- **Small RPC roundtrips** (CLI commands against remote visors via \`--via\`) lose 50-200ms each.
- **Bulk traffic** unchanged.

## Test plan

- [x] Builds clean.
- [ ] Field test: hvui skypty against a remote visor no longer feels laggy per keystroke.