### PR TITLE
chore(release): auto-publish draft when all artifacts upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,3 +482,21 @@ jobs:
           gh release upload "${{ github.ref_name }}" checksums.txt \
             --repo ${{ github.repository }} \
             --clobber
+
+  publish-release:
+    # Flips the draft release to published once every build artifact is
+    # uploaded and the combined checksums file is in place. The
+    # two-phase create-as-draft / publish-when-complete pattern means
+    # users never see a partial release (downloading the tarball before
+    # the checksum file lands, etc.). create-release sets --draft;
+    # this job clears it after every dependent job has succeeded.
+    needs: [linux, darwin-amd64, darwin-arm64, windows, docker, create-checksums]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ github.ref_name }}" \
+            --repo ${{ github.repository }} \
+            --draft=false


### PR DESCRIPTION
Every tagged release currently lands on GitHub as a draft and stays that way until manually flipped to published. Useful as a safety net during the workflow's build-and-upload phase (users never see a partial release where the binary archive exists but the checksum file doesn't, etc.) — but the manual final step is busywork and adds latency between "CI is done" and "users can download."

Adds a \`publish-release\` job that runs \`gh release edit --draft=false\` after every other job completes successfully (linux, darwin-amd64, darwin-arm64, windows, docker, create-checksums). The two-phase pattern is preserved: create-as-draft → upload everything → flip to published. If anything fails in between, the release stays a draft, which is the desired safety behavior.