### PR TITLE
fix(transport): remove recursive RLock in Manager.GetTransport

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -997,10 +997,28 @@ var ErrNotFound = errors.New("transport not found")
 var ErrUnknownNetwork = errors.New("unknown network type")
 
 // IsKnownNetwork returns true when netName is a known
-// network type that we are able to operate in
+// network type that we are able to operate in.
+//
+// Wrapper around the lockless helper for external callers. Methods
+// that already hold tm.mx (read or write) MUST call
+// isKnownNetworkLocked directly — calling this exported wrapper
+// from inside a held read lock deadlocks against any pending
+// writer (Go's RWMutex prioritizes pending writers to prevent
+// writer starvation, so a recursive RLock attempt blocks when a
+// writer is waiting). Production case that bit us: GetTransport
+// previously called IsKnownNetwork from inside its own RLock; with
+// cleanupTransports or acceptTransport pending the write lock, the
+// recursive read attempt deadlocked, freezing every subsequent
+// transport operation including ServeRPCClient's redial attempts.
 func (tm *Manager) IsKnownNetwork(netName types.Type) bool {
 	tm.mx.RLock()
 	defer tm.mx.RUnlock()
+	return tm.isKnownNetworkLocked(netName)
+}
+
+// isKnownNetworkLocked is the lockless variant of IsKnownNetwork.
+// Caller must hold tm.mx (read or write).
+func (tm *Manager) isKnownNetworkLocked(netName types.Type) bool {
 	_, ok := tm.netClients[netName]
 	return ok
 }
@@ -1009,7 +1027,7 @@ func (tm *Manager) IsKnownNetwork(netName types.Type) bool {
 func (tm *Manager) GetTransport(remote cipher.PubKey, netType types.Type) (*ManagedTransport, error) {
 	tm.mx.RLock()
 	defer tm.mx.RUnlock()
-	if !tm.IsKnownNetwork(netType) {
+	if !tm.isKnownNetworkLocked(netType) {
 		return nil, ErrUnknownNetwork
 	}
 


### PR DESCRIPTION
## Summary

Real deadlock observed in production: every transport operation on the affected visor stuck for 6+ minutes, \`ServeRPCClient\` unable to redial, hypervisor unable to poll, UI showing "last seen X ago" indefinitely. Goroutine dump shows half a dozen goroutines parked on \`Manager.mx\`, including writers (\`cleanupTransports\`, \`acceptTransport\`) waiting for the write lock and readers waiting for the read lock.

## Root cause

Classic Go \`sync.RWMutex\` recursive-RLock deadlock in \`GetTransport\`:

\`\`\`go
func (tm *Manager) GetTransport(...) (...) {
    tm.mx.RLock()
    defer tm.mx.RUnlock()
    if !tm.IsKnownNetwork(netType) { ... }  // ← IsKnownNetwork also calls tm.mx.RLock()
\`\`\`

Go's \`RWMutex\` prioritizes pending writers to prevent writer starvation. When ANY writer is parked waiting for \`Lock()\`, a recursive RLock attempt by an existing reader blocks. Sequence:

1. Reader R takes \`mx.RLock()\` in GetTransport.
2. Writer W (\`cleanupTransports\` / \`acceptTransport\`) calls \`mx.Lock()\`, parks waiting for R.
3. R reaches \`IsKnownNetwork\`, attempts \`mx.RLock()\` again — blocks because writer W is pending.
4. W still waiting for R's first RLock. R waiting for its second. **Deadlock.** Every subsequent transport op piles up behind it.

The recursive call has been in \`GetTransport\` for a long time but was rarely exercised concurrently with writers — until #2810's \`hasFastTransportTo\` (called from \`ServeRPCClient\`'s dialer hook) started invoking \`GetTransport\` on every redial attempt. Combined with the normal \`cleanupTransports\` tick (every 1s) and any \`acceptTransport\` activity, deadlock probability went from "theoretical" to "regularly observed."

## Fix

Factor \`IsKnownNetwork\` into a lockless helper \`isKnownNetworkLocked\` that callers already holding the lock can use. Exported \`IsKnownNetwork\` stays as the lock-acquiring wrapper for external callers. \`GetTransport\` now uses the lockless variant inside its own RLock — no recursion.

## What operators see after this lands

Visors that previously got "stranded" in the hypervisor UI as "last seen X ago" after a temporary network event no longer stay stranded. \`ServeRPCClient\`'s redial path can actually run.

## Notes on the regression

The skywire bug-hunt narrative going back to #2802 (auto-upgrade to skynet for visor↔hypervisor RPC) has been chasing this symptom under different framings — eviction-too-aggressive (#2806), missing init order (#2810), idle-detect too slow (still a real issue but secondary), wire-format issues in TransportRPCCall (separate), etc. **This deadlock is the underlying mechanical bug** that made every other fix attempt only partially effective.

## Test plan

- [x] Builds clean.
- [x] Goroutine dump on the affected visor showed ~6 goroutines parked 6+ min on \`Manager.mx\` lock operations, with the recursive RLock pattern visible in \`GetTransport\` → \`IsKnownNetwork\` lineage.
- [ ] Field test: after auto-update propagates, magneto stops getting stuck in "last seen X ago" state on the operator's hypervisor UI.