### PR TITLE
fix(visor,cli/dmsg/pty): hard-bound DmsgPtyExec dial + SIGINT honored in cli

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -220,7 +220,19 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 		if len(args) < 2 {
 			return fmt.Errorf("pty exec: <pk> <command> required (or use --via tcp://<pk>@<host:port>)")
 		}
-		_ = ctx // ctx is consumed by the --via branch above; RPC path is synchronous
+		// net/rpc's synchronous Call doesn't honor ctx, so wire SIGINT
+		// to a hard exit. The visor side bounds its own dial budget
+		// (api_services.go DmsgPtyExec) so a leaked goroutine there
+		// drains within ~15s + the user's --timeout; without this
+		// goroutine, an unresponsive dial would leave the CLI process
+		// hung past Ctrl-C with no way for the user to recover except
+		// SIGKILL — combined with `timeout(1)` wrappers that send only
+		// SIGTERM, the process would leak indefinitely.
+		go func() {
+			<-ctx.Done()
+			fmt.Fprintln(cmd.ErrOrStderr(), "exec: interrupted") //nolint:errcheck
+			os.Exit(130)
+		}()
 		addr := internal.ParsePK(cmd.Flags(), "pk", args[0])
 		port, _ := strconv.ParseUint(ptyPort, 10, 16) //nolint:errcheck
 		name := args[1]

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -476,7 +476,18 @@ func (v *Visor) DmsgPtyExec(args DmsgPtyExecArgs) (*dmsgpty.CommandExecResult, e
 		return nil, fmt.Errorf("dmsgpty: remote_pk required")
 	}
 	req := args.Req
-	return v.dmsgPty.ExecRemote(context.Background(), args.RemotePK, args.RemotePort, &req)
+	// Bound the whole call: Req.TimeoutMS covers the remote command's
+	// execution; we add a 15s dial/handshake budget on top so an
+	// unreachable target (stale dmsg discovery, downed peer, etc.)
+	// doesn't hang this RPC goroutine indefinitely. Without the bound,
+	// the dmsg client's dial blocks in a syscall that doesn't unwind
+	// on RPC-side cancellation, leaking a goroutine per attempt and
+	// preventing the caller's `timeout` wrapper from ever returning.
+	const dialBudget = 15 * time.Second
+	callTimeout := time.Duration(req.TimeoutMS)*time.Millisecond + dialBudget
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+	return v.dmsgPty.ExecRemote(ctx, args.RemotePK, args.RemotePort, &req)
 }
 
 // Ports return list of all ports used by visor services and apps


### PR DESCRIPTION
Two related fixes for the 'hung dmsgpty exec process' class.

## Symptom

\`cli dmsg pty exec <pk> -- <cmd>\` against a target whose dmsg discovery entry is stale or whose dmsgpty server isn't reachable hung indefinitely past \`--timeout\`, requiring \`pkill -9\` to recover. Even \`timeout(1)\` wrappers around the CLI failed — SIGTERM was ignored. Two leaked processes (wrapping bash + the exec) accumulated per attempt.

Reproduction from operator host today: probing a recently-restarted visor produced six hung processes (oldest 1h40m, none responding to SIGTERM).

## Root causes

**1. Visor-side `DmsgPtyExec` uses `context.Background()`**

\`pkg/visor/api_services.go:471\`:

\`\`\`go
return v.dmsgPty.ExecRemote(context.Background(), args.RemotePK, args.RemotePort, &req)
\`\`\`

\`Req.TimeoutMS\` is the *remote command's execution budget* — it doesn't bound the dial/handshake. A dmsg dial to an unreachable target hung the RPC goroutine forever, leaking one goroutine per attempt.

**2. CLI-side `ptyExecCmd` discards its signal context**

\`cmd/skywire-cli/commands/dmsg/pty.go:223\`:

\`\`\`go
_ = ctx // ctx is consumed by the --via branch above; RPC path is synchronous
\`\`\`

The comment was wrong — the \`--via tcp://\` branch returns early before this line, so the synchronous \`DmsgPtyExec\` RPC call ran with no signal handling. SIGINT and \`timeout(1)\`'s SIGTERM were ignored.

## Fixes

**Visor side**: bound \`ExecRemote\` with \`Req.TimeoutMS + 15s\` dial budget so stale-discovery / unreachable peers fail fast (~15s) instead of hanging forever.

**CLI side**: spawn a goroutine that \`os.Exit(130)\`'s when the signal context fires, so Ctrl-C and outer \`timeout(1)\` wrappers actually kill the CLI. The visor's now-bounded call cleans up its side within ~15s.

## Test plan

- [x] \`go build .\` clean
- [x] On operator host: \`time timeout 60 ./skywire cli dmsg pty exec --timeout 20s <unreachable-pk> -- echo hi\` returns in 7.8s with \`dmsgpty: new pty client: failed to read response: EOF\` (was: hung indefinitely)
- [x] \`pgrep -f 'dmsg pty exec'\` after the failed call shows 0 leaked processes (was: 2 leaked per attempt)
- [ ] Ctrl-C during a slow exec produces immediate exit with code 130 (manual verify after merge)