### PR TITLE
feat(skywireconfig): autoconfigcmd factory + keypair, WASM-clean

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -40,6 +40,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/skywireconfig/autoconfigcmd"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -62,73 +63,20 @@ const (
 // would be clobbered by the next package upgrade.
 const systemdDropIn = "/etc/systemd/system/skywire.service.d/skywire-user.conf"
 
-var autoconfigVerbose bool
-
-// Editable-via-autoconfig knobs. When the operator passes any of
-// these flags, autoconfig rewrites the corresponding line in the
-// resolved SKYENV file BEFORE calling `skywire cli config gen`, so
-// the change is persisted to /etc/skywire.conf and survives
-// re-runs and package reinstalls.
-//
-// Each flag mirrors a `config gen` flag of the same name. We don't
-// pass them through to the subprocess — instead we edit skywire.conf
-// and let the existing `SKYENV=<file> config gen` invocation pick
-// them up. This keeps skywire.conf as the single source of truth.
-var (
-	autoSetHvpks          string
-	autoSetIshv           bool
-	autoSetNoIshv         bool
-	autoSetRewardAddr     string
-	autoSetPublic         bool
-	autoSetNoPublic       bool
-	autoSetStcprPort      int
-	autoSetSudphPort      int
-	autoSetLanDmsgPort    int
-	autoSetLanDmsgPublic  string
-	autoSetDmsgptyPks     string
-	autoSetVpnServer      bool
-	autoSetNoVpnServer    bool
-	autoSetProxyServer    bool
-	autoSetNoProxyServer  bool
-	autoSetSkychat        bool
-	autoSetNoSkychat      bool
-	autoSetDmsgweb        bool
-	autoSetNoDmsgweb      bool
-	autoSetSkynetweb      bool
-	autoSetNoSkynetweb    bool
-	autoSetDisablePubAuto bool
-)
+// autoconfigVals holds the runtime values of the autoconfig flags.
+// Lives at package level so the Run function can read them; the
+// pkg/skywireconfig/autoconfigcmd factory wires the bindings.
+var autoconfigVals autoconfigcmd.Values
 
 func init() {
-	autoconfigCmd.Flags().BoolVarP(&autoconfigVerbose, "verbose", "v", false, "show reward address, support links, and other details")
-
-	// Persistent skywire.conf edits. Each --flag sets the
-	// corresponding env var; --no-flag clears it back to default.
-	// Empty-string / zero-value flags are "leave unchanged" by
-	// virtue of Flags().Changed() lookup at runtime.
-	autoconfigCmd.Flags().StringVar(&autoSetHvpks, "hvpks", "", "set HYPERVISORPKS in skywire.conf (comma-separated PKs)")
-	autoconfigCmd.Flags().BoolVar(&autoSetIshv, "ishv", false, "set ISHYPERVISOR=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoIshv, "no-ishv", false, "set ISHYPERVISOR=false in skywire.conf")
-	autoconfigCmd.Flags().StringVar(&autoSetRewardAddr, "rewardaddr", "", "set REWARDSKYADDR in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetPublic, "public", false, "set VISORISPUBLIC=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoPublic, "no-public", false, "set VISORISPUBLIC=false in skywire.conf")
-	autoconfigCmd.Flags().IntVar(&autoSetStcprPort, "stcpr", 0, "set STCPRPORT in skywire.conf (0 = leave unchanged)")
-	autoconfigCmd.Flags().IntVar(&autoSetSudphPort, "sudph", 0, "set SUDPHPORT in skywire.conf (0 = leave unchanged)")
-	autoconfigCmd.Flags().IntVar(&autoSetLanDmsgPort, "lan-dmsg-port", 0, "set LANDMSGPORT in skywire.conf (0 = leave unchanged)")
-	autoconfigCmd.Flags().StringVar(&autoSetLanDmsgPublic, "lan-dmsg-public", "", "set LANDMSGPUBLIC in skywire.conf (host:port)")
-	autoconfigCmd.Flags().StringVar(&autoSetDmsgptyPks, "dmsgpty-pks", "", "set DMSGPTYPKS in skywire.conf (comma-separated PKs)")
-	autoconfigCmd.Flags().BoolVar(&autoSetVpnServer, "vpnserver", false, "set VPNSERVER=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoVpnServer, "no-vpnserver", false, "set VPNSERVER=false in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetProxyServer, "proxyserver", false, "set PROXYSERVER=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoProxyServer, "no-proxyserver", false, "set PROXYSERVER=false in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetSkychat, "skychat", false, "set SKYCHAT=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoSkychat, "no-skychat", false, "set SKYCHAT=false in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetDmsgweb, "dmsgweb", false, "set DMSGWEB=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoDmsgweb, "no-dmsgweb", false, "set DMSGWEB=false in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetSkynetweb, "skynetweb", false, "set SKYNETWEB=true in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetNoSkynetweb, "no-skynetweb", false, "set SKYNETWEB=false in skywire.conf")
-	autoconfigCmd.Flags().BoolVar(&autoSetDisablePubAuto, "disable-public-autoconn", false, "set DISABLEPUBLICAUTOCONN=true in skywire.conf")
-
+	autoconfigCmd = autoconfigcmd.New(&autoconfigVals)
+	// Preserved from the pre-factory inlined version. The factory
+	// produces a generic, non-hidden command; the binary makes it
+	// hidden so it doesn't pollute the top-level help listing
+	// (operators reach it via the autoconfig package install
+	// step, not via interactive discovery).
+	autoconfigCmd.Hidden = true
+	autoconfigCmd.Run = autoconfigRun
 	RootCmd.AddCommand(autoconfigCmd)
 }
 
@@ -150,35 +98,35 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	}
 
 	if cmd.Flags().Changed("hvpks") {
-		edits = append(edits, skyenvEdit{Key: "HYPERVISORPKS", Value: formatSkyenvBashArray(autoSetHvpks)})
+		edits = append(edits, skyenvEdit{Key: "HYPERVISORPKS", Value: formatSkyenvBashArray(autoconfigVals.Hvpks)})
 	}
-	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoSetIshv, autoSetNoIshv)
+	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoconfigVals.Ishv, autoconfigVals.NoIshv)
 	if cmd.Flags().Changed("rewardaddr") {
-		edits = append(edits, skyenvEdit{Key: "REWARDSKYADDR", Value: formatSkyenvString(autoSetRewardAddr)})
+		edits = append(edits, skyenvEdit{Key: "REWARDSKYADDR", Value: formatSkyenvString(autoconfigVals.RewardAddr)})
 	}
-	addBool("VISORISPUBLIC", "public", "no-public", autoSetPublic, autoSetNoPublic)
+	addBool("VISORISPUBLIC", "public", "no-public", autoconfigVals.Public, autoconfigVals.NoPublic)
 	if cmd.Flags().Changed("stcpr") {
-		edits = append(edits, skyenvEdit{Key: "STCPRPORT", Value: formatSkyenvInt(autoSetStcprPort)})
+		edits = append(edits, skyenvEdit{Key: "STCPRPORT", Value: formatSkyenvInt(autoconfigVals.StcprPort)})
 	}
 	if cmd.Flags().Changed("sudph") {
-		edits = append(edits, skyenvEdit{Key: "SUDPHPORT", Value: formatSkyenvInt(autoSetSudphPort)})
+		edits = append(edits, skyenvEdit{Key: "SUDPHPORT", Value: formatSkyenvInt(autoconfigVals.SudphPort)})
 	}
 	if cmd.Flags().Changed("lan-dmsg-port") {
-		edits = append(edits, skyenvEdit{Key: "LANDMSGPORT", Value: formatSkyenvInt(autoSetLanDmsgPort)})
+		edits = append(edits, skyenvEdit{Key: "LANDMSGPORT", Value: formatSkyenvInt(autoconfigVals.LanDmsgPort)})
 	}
 	if cmd.Flags().Changed("lan-dmsg-public") {
-		edits = append(edits, skyenvEdit{Key: "LANDMSGPUBLIC", Value: formatSkyenvString(autoSetLanDmsgPublic)})
+		edits = append(edits, skyenvEdit{Key: "LANDMSGPUBLIC", Value: formatSkyenvString(autoconfigVals.LanDmsgPublic)})
 	}
 	if cmd.Flags().Changed("dmsgpty-pks") {
-		edits = append(edits, skyenvEdit{Key: "DMSGPTYPKS", Value: formatSkyenvBashArray(autoSetDmsgptyPks)})
+		edits = append(edits, skyenvEdit{Key: "DMSGPTYPKS", Value: formatSkyenvBashArray(autoconfigVals.DmsgptyPks)})
 	}
-	addBool("VPNSERVER", "vpnserver", "no-vpnserver", autoSetVpnServer, autoSetNoVpnServer)
-	addBool("PROXYSERVER", "proxyserver", "no-proxyserver", autoSetProxyServer, autoSetNoProxyServer)
-	addBool("SKYCHAT", "skychat", "no-skychat", autoSetSkychat, autoSetNoSkychat)
-	addBool("DMSGWEB", "dmsgweb", "no-dmsgweb", autoSetDmsgweb, autoSetNoDmsgweb)
-	addBool("SKYNETWEB", "skynetweb", "no-skynetweb", autoSetSkynetweb, autoSetNoSkynetweb)
+	addBool("VPNSERVER", "vpnserver", "no-vpnserver", autoconfigVals.VpnServer, autoconfigVals.NoVpnServer)
+	addBool("PROXYSERVER", "proxyserver", "no-proxyserver", autoconfigVals.ProxyServer, autoconfigVals.NoProxyServer)
+	addBool("SKYCHAT", "skychat", "no-skychat", autoconfigVals.Skychat, autoconfigVals.NoSkychat)
+	addBool("DMSGWEB", "dmsgweb", "no-dmsgweb", autoconfigVals.Dmsgweb, autoconfigVals.NoDmsgweb)
+	addBool("SKYNETWEB", "skynetweb", "no-skynetweb", autoconfigVals.Skynetweb, autoconfigVals.NoSkynetweb)
 	if cmd.Flags().Changed("disable-public-autoconn") {
-		edits = append(edits, skyenvEdit{Key: "DISABLEPUBLICAUTOCONN", Value: formatSkyenvBool(autoSetDisablePubAuto)})
+		edits = append(edits, skyenvEdit{Key: "DISABLEPUBLICAUTOCONN", Value: formatSkyenvBool(autoconfigVals.DisablePubAuto)})
 	}
 	return edits
 }
@@ -195,217 +143,205 @@ type resolvedConfig struct {
 	useUserUnit bool   // true = `systemctl --user`, false = system unit
 }
 
-var autoconfigCmd = &cobra.Command{
-	Use:   "autoconfig",
-	Short: "Automatic visor configuration for packages",
-	Long: `Automatic visor configuration. Reads /etc/skywire.conf (or whatever
-SKYENV points at), generates the visor config, manages the systemd
-drop-in, and restarts (or prompts to start) the service.
+// autoconfigCmd is constructed in init() via the autoconfigcmd factory
+// so the flag set is shared with WASM consumers (apt-repo install
+// page). Use, Short, Long, and flag bindings all come from the
+// factory; this file only contributes Hidden=true and the Run body.
+var autoconfigCmd *cobra.Command
 
-Mode is selected by PKGENV/USRENV in the env file:
+// autoconfigRun is the Run function attached to autoconfigCmd in
+// init(). Extracted from the pre-factory inline closure so the
+// init body stays small.
+func autoconfigRun(cmd *cobra.Command, args []string) {
+	if os.Getenv("NOAUTOCONFIG") == "true" {
+		fmt.Println("autoconfiguration disabled. to configure and start skywire run: skywire autoconfig")
+		os.Exit(0)
+	}
 
-  PKGENV=true            → system install at /opt/skywire,
-                           system-level systemd unit
-  PKGENV=true
-  SKYWIRE_USER=_skywire  → same, but visor runs as _skywire (drop-in
-                           writes User=_skywire, /opt/skywire chowned)
+	msg2("Configuring skywire")
 
-  USRENV=true            → user install at $HOME, systemctl --user
-
-  neither set            → falls back to PKGENV when run as root,
-                           USRENV otherwise.`,
-	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		if os.Getenv("NOAUTOCONFIG") == "true" {
-			fmt.Println("autoconfiguration disabled. to configure and start skywire run: skywire autoconfig")
-			os.Exit(0)
+	// Apply any operator-requested skywire.conf edits before
+	// the rest of autoconfig sources the file. Each `--flag`
+	// rewrites the corresponding env line in place (uncomment +
+	// new value), preserving every other line. The subsequent
+	// `cli config gen` invocation reads the updated file via
+	// SKYENV so the new values take effect on the same run.
+	//
+	// Resolves the skyenv path FIRST so we know which file to
+	// edit — same lookup the downstream stages use, just lifted
+	// up to do the edits first.
+	if edits := collectSkyenvEdits(cmd); len(edits) > 0 {
+		pre := resolveConfig()
+		target := pre.skyenvPath
+		if target == "" {
+			target = defaultSkyenvPath()
 		}
-
-		msg2("Configuring skywire")
-
-		// Apply any operator-requested skywire.conf edits before
-		// the rest of autoconfig sources the file. Each `--flag`
-		// rewrites the corresponding env line in place (uncomment +
-		// new value), preserving every other line. The subsequent
-		// `cli config gen` invocation reads the updated file via
-		// SKYENV so the new values take effect on the same run.
-		//
-		// Resolves the skyenv path FIRST so we know which file to
-		// edit — same lookup the downstream stages use, just lifted
-		// up to do the edits first.
-		if edits := collectSkyenvEdits(cmd); len(edits) > 0 {
-			pre := resolveConfig()
-			target := pre.skyenvPath
-			if target == "" {
-				target = defaultSkyenvPath()
-			}
-			if err := updateSkyenvFile(target, edits); err != nil {
-				fmt.Printf("%s>>> FATAL:%s could not update %s: %v\n", colorRed, colorReset, target, err)
-				os.Exit(1)
-			}
-			editedKeys := make([]string, 0, len(edits))
-			for _, e := range edits {
-				editedKeys = append(editedKeys, e.Key)
-			}
-			msg3(fmt.Sprintf("Updated %s%s%s: %s", colorPurple, target, colorReset, strings.Join(editedKeys, " ")))
-		}
-
-		versionOut, err := exec.Command("skywire", "-v").Output()
-		if err == nil {
-			version := strings.TrimSpace(string(versionOut))
-			if !strings.Contains(version, "unknown") {
-				msg2(fmt.Sprintf("version: %s", strings.Fields(version)[len(strings.Fields(version))-1]))
-			}
-		}
-
-		hvArg := ""
-		if len(args) > 0 {
-			hvArg = args[0]
-		}
-
-		resolved := resolveConfig()
-
-		if err := generateConfig(resolved, hvArg); err != nil {
-			fmt.Printf("%s>>> FATAL:%s %v\n", colorRed, colorReset, err)
+		if err := updateSkyenvFile(target, edits); err != nil {
+			fmt.Printf("%s>>> FATAL:%s could not update %s: %v\n", colorRed, colorReset, target, err)
 			os.Exit(1)
 		}
+		editedKeys := make([]string, 0, len(edits))
+		for _, e := range edits {
+			editedKeys = append(editedKeys, e.Key)
+		}
+		msg3(fmt.Sprintf("Updated %s%s%s: %s", colorPurple, target, colorReset, strings.Join(editedKeys, " ")))
+	}
 
-		if _, err := os.Stat(resolved.configPath); os.IsNotExist(err) {
-			mode := "PKGENV"
-			if resolved.usrEnv {
-				mode = "USRENV"
+	versionOut, err := exec.Command("skywire", "-v").Output()
+	if err == nil {
+		version := strings.TrimSpace(string(versionOut))
+		if !strings.Contains(version, "unknown") {
+			msg2(fmt.Sprintf("version: %s", strings.Fields(version)[len(strings.Fields(version))-1]))
+		}
+	}
+
+	hvArg := ""
+	if len(args) > 0 {
+		hvArg = args[0]
+	}
+
+	resolved := resolveConfig()
+
+	if err := generateConfig(resolved, hvArg); err != nil {
+		fmt.Printf("%s>>> FATAL:%s %v\n", colorRed, colorReset, err)
+		os.Exit(1)
+	}
+
+	if _, err := os.Stat(resolved.configPath); os.IsNotExist(err) {
+		mode := "PKGENV"
+		if resolved.usrEnv {
+			mode = "USRENV"
+		}
+		fmt.Printf("%s>>> FATAL:%s expected config file not found at %s\n", colorRed, colorReset, resolved.configPath)
+		fmt.Printf("            autoconfig resolved mode=%s from %s\n", mode, func() string {
+			if resolved.skyenvPath != "" {
+				return resolved.skyenvPath
 			}
-			fmt.Printf("%s>>> FATAL:%s expected config file not found at %s\n", colorRed, colorReset, resolved.configPath)
-			fmt.Printf("            autoconfig resolved mode=%s from %s\n", mode, func() string {
+			return "implicit fallback (no " + defaultSkyenvPath() + ")"
+		}())
+		fmt.Printf("            if %s is commented out in %s, uncomment it and re-run `skywire autoconfig`\n",
+			mode, func() string {
 				if resolved.skyenvPath != "" {
 					return resolved.skyenvPath
 				}
-				return "implicit fallback (no " + defaultSkyenvPath() + ")"
+				return defaultSkyenvPath()
 			}())
-			fmt.Printf("            if %s is commented out in %s, uncomment it and re-run `skywire autoconfig`\n",
-				mode, func() string {
-					if resolved.skyenvPath != "" {
-						return resolved.skyenvPath
-					}
-					return defaultSkyenvPath()
-				}())
-			os.Exit(100)
-		}
-		msg3(fmt.Sprintf("%sSkywire%s configuration updated\nconfig path: %s%s%s", colorBlue, colorReset, colorPurple, resolved.configPath, colorReset))
+		os.Exit(100)
+	}
+	msg3(fmt.Sprintf("%sSkywire%s configuration updated\nconfig path: %s%s%s", colorBlue, colorReset, colorPurple, resolved.configPath, colorReset))
 
-		// PKGENV mode: keep the systemd drop-in in sync with
-		// SKYWIRE_USER. When SKYWIRE_USER is set, write a drop-in
-		// pinning User= and chown the install to that user. When it's
-		// unset (or the operator switched away from it), tear down a
-		// previously-written drop-in so the unit reverts to running
-		// as root — otherwise the stale `User=<old_user>` would
-		// either fail CHDIR (if that user no longer has access to
-		// the install) or fail the visor's `--pkg requires root`
-		// pre-run check (because the drop-in still pins a non-root
-		// User= even though the operator's policy changed).
-		//
-		// Only meaningful when invoked as root: chowning root-owned
-		// files and writing under /etc/systemd/system/ both need it.
-		// When run as the target user already, we skip both branches
-		// and let the operator manage them out of band.
-		if runtime.GOOS == "linux" && !resolved.usrEnv && os.Geteuid() == 0 {
-			daemonReload := false
-			switch {
-			case resolved.skywireUser != "":
-				if err := writeSystemdDropIn(resolved.skywireUser); err != nil {
-					fmt.Printf("%sWarning:%s could not write systemd drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
+	// PKGENV mode: keep the systemd drop-in in sync with
+	// SKYWIRE_USER. When SKYWIRE_USER is set, write a drop-in
+	// pinning User= and chown the install to that user. When it's
+	// unset (or the operator switched away from it), tear down a
+	// previously-written drop-in so the unit reverts to running
+	// as root — otherwise the stale `User=<old_user>` would
+	// either fail CHDIR (if that user no longer has access to
+	// the install) or fail the visor's `--pkg requires root`
+	// pre-run check (because the drop-in still pins a non-root
+	// User= even though the operator's policy changed).
+	//
+	// Only meaningful when invoked as root: chowning root-owned
+	// files and writing under /etc/systemd/system/ both need it.
+	// When run as the target user already, we skip both branches
+	// and let the operator manage them out of band.
+	if runtime.GOOS == "linux" && !resolved.usrEnv && os.Geteuid() == 0 {
+		daemonReload := false
+		switch {
+		case resolved.skywireUser != "":
+			if err := writeSystemdDropIn(resolved.skywireUser); err != nil {
+				fmt.Printf("%sWarning:%s could not write systemd drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
+			} else {
+				msg3(fmt.Sprintf("Wrote %s (User=%s)", systemdDropIn, resolved.skywireUser))
+				daemonReload = true
+			}
+			if err := chownInstall(resolved.skywireUser); err != nil {
+				fmt.Printf("%sWarning:%s chown %s failed: %v\n", colorYellow, colorReset, skyenv.SkywirePath, err)
+			}
+		default:
+			// SKYWIRE_USER unset → ensure no stale drop-in is
+			// present that would still pin the unit to a
+			// non-root user. Idempotent: silent when there's
+			// nothing to remove.
+			if _, statErr := os.Stat(systemdDropIn); statErr == nil {
+				if err := os.Remove(systemdDropIn); err != nil {
+					fmt.Printf("%sWarning:%s could not remove stale drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
 				} else {
-					msg3(fmt.Sprintf("Wrote %s (User=%s)", systemdDropIn, resolved.skywireUser))
+					msg3(fmt.Sprintf("Removed stale %s (SKYWIRE_USER unset)", systemdDropIn))
+					// Also drop the parent dir if it's now empty.
+					_ = os.Remove(filepath.Dir(systemdDropIn)) //nolint:errcheck
 					daemonReload = true
 				}
-				if err := chownInstall(resolved.skywireUser); err != nil {
-					fmt.Printf("%sWarning:%s chown %s failed: %v\n", colorYellow, colorReset, skyenv.SkywirePath, err)
-				}
-			default:
-				// SKYWIRE_USER unset → ensure no stale drop-in is
-				// present that would still pin the unit to a
-				// non-root user. Idempotent: silent when there's
-				// nothing to remove.
-				if _, statErr := os.Stat(systemdDropIn); statErr == nil {
-					if err := os.Remove(systemdDropIn); err != nil {
-						fmt.Printf("%sWarning:%s could not remove stale drop-in %s: %v\n", colorYellow, colorReset, systemdDropIn, err)
-					} else {
-						msg3(fmt.Sprintf("Removed stale %s (SKYWIRE_USER unset)", systemdDropIn))
-						// Also drop the parent dir if it's now empty.
-						_ = os.Remove(filepath.Dir(systemdDropIn)) //nolint:errcheck
-						daemonReload = true
-					}
-				}
-			}
-			if daemonReload {
-				_ = exec.Command("systemctl", "daemon-reload").Run() //nolint:errcheck,gosec
 			}
 		}
-
-		// SKYBIAN auto-start: legacy appliance bootstrap. Limited to
-		// PKGENV mode; user-mode appliances aren't a thing.
-		// Linux-only — Windows service registration is the Phase 2
-		// piece of the autoconfig parity project (see project memory
-		// project_windows_autoconfig_parity.md). For now Windows
-		// operators run `skywire visor` directly after autoconfig.
-		if runtime.GOOS == "linux" && !resolved.useUserUnit && os.Getenv("SKYBIAN") == "true" {
-			msg3("Enabling skywire service and starting...")
-			_ = exec.Command("systemctl", "enable", "--now", "skywire.service").Run() //nolint:errcheck,gosec
+		if daemonReload {
+			_ = exec.Command("systemctl", "daemon-reload").Run() //nolint:errcheck,gosec
 		}
+	}
 
-		restartOrPrompt(resolved)
+	// SKYBIAN auto-start: legacy appliance bootstrap. Limited to
+	// PKGENV mode; user-mode appliances aren't a thing.
+	// Linux-only — Windows service registration is the Phase 2
+	// piece of the autoconfig parity project (see project memory
+	// project_windows_autoconfig_parity.md). For now Windows
+	// operators run `skywire visor` directly after autoconfig.
+	if runtime.GOOS == "linux" && !resolved.useUserUnit && os.Getenv("SKYBIAN") == "true" {
+		msg3("Enabling skywire service and starting...")
+		_ = exec.Command("systemctl", "enable", "--now", "skywire.service").Run() //nolint:errcheck,gosec
+	}
 
-		// Public key — read from the freshly-generated config rather
-		// than spawning another `skywire cli visor pk` (which would
-		// race against a still-restarting visor RPC port).
-		conf, err := visorconfig.ReadFile(resolved.configPath)
-		pubkey := ""
-		if err == nil && conf != nil {
-			pubkey = conf.PK.Hex()
-		}
+	restartOrPrompt(resolved)
 
+	// Public key — read from the freshly-generated config rather
+	// than spawning another `skywire cli visor pk` (which would
+	// race against a still-restarting visor RPC port).
+	conf, err := visorconfig.ReadFile(resolved.configPath)
+	pubkey := ""
+	if err == nil && conf != nil {
+		pubkey = conf.PK.Hex()
+	}
+
+	if pubkey != "" {
+		msg2(fmt.Sprintf("Visor Public Key:\n%s%s%s", colorGreen, pubkey, colorReset))
+	}
+
+	isHypervisor := conf != nil && conf.Hypervisor != nil && conf.Hypervisor.Enable
+
+	if isHypervisor {
+		msg2(fmt.Sprintf("Hypervisor UI Starting now on:\n%shttp://127.0.0.1:8000%s", colorRed, colorReset))
 		if pubkey != "" {
-			msg2(fmt.Sprintf("Visor Public Key:\n%s%s%s", colorGreen, pubkey, colorReset))
+			vpnURL := fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s", pubkey)
+			msg2(fmt.Sprintf("Use the vpn:\n%s%s%s", colorRed, vpnURL, colorReset))
 		}
 
-		isHypervisor := conf != nil && conf.Hypervisor != nil && conf.Hypervisor.Enable
-
-		if isHypervisor {
-			msg2(fmt.Sprintf("Hypervisor UI Starting now on:\n%shttp://127.0.0.1:8000%s", colorRed, colorReset))
-			if pubkey != "" {
-				vpnURL := fmt.Sprintf("http://127.0.0.1:8000/#/vpn/%s", pubkey)
-				msg2(fmt.Sprintf("Use the vpn:\n%s%s%s", colorRed, vpnURL, colorReset))
+		lanIPs := getLANIPs()
+		if len(lanIPs) > 0 {
+			hvURLs := "Hypervisor UI LAN access:"
+			for _, ip := range lanIPs {
+				hvURLs += fmt.Sprintf("\n%shttp://%s:8000%s", colorYellow, ip, colorReset)
 			}
-
-			lanIPs := getLANIPs()
-			if len(lanIPs) > 0 {
-				hvURLs := "Hypervisor UI LAN access:"
-				for _, ip := range lanIPs {
-					hvURLs += fmt.Sprintf("\n%shttp://%s:8000%s", colorYellow, ip, colorReset)
-				}
-				msg2(hvURLs)
-			}
-		} else {
-			msg2(fmt.Sprintf("%sSkywire%s starting without Hypervisor UI", colorBlue, colorReset))
+			msg2(hvURLs)
 		}
+	} else {
+		msg2(fmt.Sprintf("%sSkywire%s starting without Hypervisor UI", colorBlue, colorReset))
+	}
 
-		if conf != nil && len(conf.Hypervisors) > 0 {
-			hvPKs := ""
-			for _, hvPK := range conf.Hypervisors {
-				hvPKs += hvPK.String() + "\n"
-			}
-			msg2(fmt.Sprintf("Remote Hypervisor Public Key:\n%s%s%s", colorPurple, strings.TrimSpace(hvPKs), colorReset))
+	if conf != nil && len(conf.Hypervisors) > 0 {
+		hvPKs := ""
+		for _, hvPK := range conf.Hypervisors {
+			hvPKs += hvPK.String() + "\n"
 		}
+		msg2(fmt.Sprintf("Remote Hypervisor Public Key:\n%s%s%s", colorPurple, strings.TrimSpace(hvPKs), colorReset))
+	}
 
-		rewardOut, err := exec.Command("skywire", "cli", "reward", "-r").Output() //nolint:gosec
-		if err == nil && len(rewardOut) > 0 {
-			msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
-		}
+	rewardOut, err := exec.Command("skywire", "cli", "reward", "-r").Output() //nolint:gosec
+	if err == nil && len(rewardOut) > 0 {
+		msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
+	}
 
-		if autoconfigVerbose {
-			printWelcome(pubkey, isHypervisor)
-		}
-	},
+if autoconfigVals.Verbose {
+	printWelcome(pubkey, isHypervisor)
+}
 }
 
 // defaultSkyenvPath returns the canonical SKYENV file location for

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -1,0 +1,193 @@
+// Package autoconfigcmd builds the cobra.Command for `skywire
+// autoconfig` as a freestanding factory. The CLI binary in
+// cmd/skywire/commands wires the returned command into the root
+// hierarchy and attaches its RunE; external consumers — TinyGo/Go
+// WASM, doc generators, the apt-repo install-page form — call New()
+// to introspect the flag set and render help text without dragging
+// in the visor's transitive package graph.
+//
+// Why a factory: cobra.Command and its flag bindings hold mutable
+// state (flag values, parse results, Changed bits). A fresh command
+// per call means multiple consumers can coexist without trampling
+// each other's state. The flag *values* are returned alongside the
+// command so the caller can both register a custom Run (for the
+// CLI binary) and read the parsed values (for the .conf edit
+// computation).
+//
+// Why expose env-var metadata: each autoconfig flag corresponds to
+// a SKYENV variable in /etc/skywire.conf. Encoding that mapping in
+// the same place as the flag definition keeps the two from drifting
+// apart, and lets WASM consumers render a form that shows operators
+// exactly which line they're toggling.
+package autoconfigcmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// EnvFormat describes how a flag's runtime value is rendered into
+// its /etc/skywire.conf line.
+type EnvFormat string
+
+const (
+	// EnvFormatBool emits `KEY=true` or `KEY=false`.
+	EnvFormatBool EnvFormat = "bool"
+	// EnvFormatString emits `KEY='value'` with single-quote wrap.
+	EnvFormatString EnvFormat = "string"
+	// EnvFormatInt emits `KEY=N`. Zero values are skipped at the
+	// edit-collection layer (matches the "0 = leave unchanged"
+	// semantic in the autoconfig --help text for port flags).
+	EnvFormatInt EnvFormat = "int"
+	// EnvFormatBashArray emits `KEY=('a' 'b' …)` from a
+	// comma-separated input — the shape HYPERVISORPKS,
+	// DMSGPTYPKS, and similar array-typed env vars use.
+	EnvFormatBashArray EnvFormat = "bashArray"
+)
+
+// EnvMapping ties a CLI flag to the SKYENV variable it writes when
+// the operator passes the flag.
+type EnvMapping struct {
+	// Key is the SKYENV variable name (e.g. "ISHYPERVISOR").
+	Key string
+	// Format is the wire encoding for KEY=… in /etc/skywire.conf.
+	Format EnvFormat
+	// Negate inverts the emit for bool flags. A negation flag like
+	// --no-ishv has Negate=true so passing it (which sets the
+	// bool to true) writes ISHYPERVISOR=false to the .conf file.
+	Negate bool
+}
+
+// Values holds the destination addresses for every flag binding
+// installed by New. Callers pass a Values they own (typically a
+// package-level var in cmd/skywire/commands/autoconfig.go) so that
+// post-parse reads stay simple field access — no double-indirection.
+type Values struct {
+	Verbose         bool
+	Hvpks           string
+	Ishv            bool
+	NoIshv          bool
+	RewardAddr      string
+	Public          bool
+	NoPublic        bool
+	StcprPort       int
+	SudphPort       int
+	LanDmsgPort     int
+	LanDmsgPublic   string
+	DmsgptyPks      string
+	VpnServer       bool
+	NoVpnServer     bool
+	ProxyServer     bool
+	NoProxyServer   bool
+	Skychat         bool
+	NoSkychat       bool
+	Dmsgweb         bool
+	NoDmsgweb       bool
+	Skynetweb       bool
+	NoSkynetweb     bool
+	DisablePubAuto  bool
+}
+
+// New returns a freshly-constructed autoconfig cobra command with
+// flag bindings pointed at v's fields. The command has no RunE /
+// Run — callers (the CLI binary) attach their own; WASM consumers
+// only need cmd.UsageString() and cmd.Flags() and don't run it at
+// all.
+//
+// v must outlive the returned command. Passing nil triggers a
+// panic at flag-registration time (cobra's BoolVar et al. require
+// a non-nil destination).
+func New(v *Values) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "autoconfig",
+		Short: "Automatic visor configuration",
+		Long:  longDesc,
+	}
+
+	cmd.Flags().BoolVarP(&v.Verbose, "verbose", "v", false, "show reward address, support links, and other details")
+	cmd.Flags().StringVar(&v.Hvpks, "hvpks", "", "set HYPERVISORPKS in skywire.conf (comma-separated PKs)")
+	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "set ISHYPERVISOR=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "set ISHYPERVISOR=false in skywire.conf")
+	cmd.Flags().StringVar(&v.RewardAddr, "rewardaddr", "", "set REWARDSKYADDR in skywire.conf")
+	cmd.Flags().BoolVar(&v.Public, "public", false, "set VISORISPUBLIC=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoPublic, "no-public", false, "set VISORISPUBLIC=false in skywire.conf")
+	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "set STCPRPORT in skywire.conf (0 = leave unchanged)")
+	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "set SUDPHPORT in skywire.conf (0 = leave unchanged)")
+	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "set LANDMSGPORT in skywire.conf (0 = leave unchanged)")
+	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "set LANDMSGPUBLIC in skywire.conf (host:port)")
+	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "set DMSGPTYPKS in skywire.conf (comma-separated PKs)")
+	cmd.Flags().BoolVar(&v.VpnServer, "vpnserver", false, "set VPNSERVER=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoVpnServer, "no-vpnserver", false, "set VPNSERVER=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.ProxyServer, "proxyserver", false, "set PROXYSERVER=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoProxyServer, "no-proxyserver", false, "set PROXYSERVER=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "set SKYCHAT=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkychat, "no-skychat", false, "set SKYCHAT=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.Dmsgweb, "dmsgweb", false, "set DMSGWEB=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoDmsgweb, "no-dmsgweb", false, "set DMSGWEB=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.Skynetweb, "skynetweb", false, "set SKYNETWEB=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkynetweb, "no-skynetweb", false, "set SKYNETWEB=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.DisablePubAuto, "disable-public-autoconn", false, "set DISABLEPUBLICAUTOCONN=true in skywire.conf")
+
+	return cmd
+}
+
+// EnvMap returns the flag → SKYENV-var mapping. Keys are CLI flag
+// long names (without leading "--"). Flags absent from the map
+// (currently only --verbose) have no .conf-file effect.
+//
+// A fresh map is returned each call so callers can mutate it
+// without affecting the package-level data.
+func EnvMap() map[string]EnvMapping {
+	out := make(map[string]EnvMapping, len(envMap))
+	for k, v := range envMap {
+		out[k] = v
+	}
+	return out
+}
+
+// envMap is the package-level flag-name → SKYENV-mapping table.
+// Negation flags (--no-X) carry Negate=true so the bool literal
+// passed at the CLI (always true when the flag is present) gets
+// inverted to "false" at .conf-render time.
+var envMap = map[string]EnvMapping{
+	"hvpks":                   {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
+	"ishv":                    {Key: "ISHYPERVISOR", Format: EnvFormatBool},
+	"no-ishv":                 {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
+	"rewardaddr":              {Key: "REWARDSKYADDR", Format: EnvFormatString},
+	"public":                  {Key: "VISORISPUBLIC", Format: EnvFormatBool},
+	"no-public":               {Key: "VISORISPUBLIC", Format: EnvFormatBool, Negate: true},
+	"stcpr":                   {Key: "STCPRPORT", Format: EnvFormatInt},
+	"sudph":                   {Key: "SUDPHPORT", Format: EnvFormatInt},
+	"lan-dmsg-port":           {Key: "LANDMSGPORT", Format: EnvFormatInt},
+	"lan-dmsg-public":         {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
+	"dmsgpty-pks":             {Key: "DMSGPTYPKS", Format: EnvFormatBashArray},
+	"vpnserver":               {Key: "VPNSERVER", Format: EnvFormatBool},
+	"no-vpnserver":            {Key: "VPNSERVER", Format: EnvFormatBool, Negate: true},
+	"proxyserver":             {Key: "PROXYSERVER", Format: EnvFormatBool},
+	"no-proxyserver":          {Key: "PROXYSERVER", Format: EnvFormatBool, Negate: true},
+	"skychat":                 {Key: "SKYCHAT", Format: EnvFormatBool},
+	"no-skychat":              {Key: "SKYCHAT", Format: EnvFormatBool, Negate: true},
+	"dmsgweb":                 {Key: "DMSGWEB", Format: EnvFormatBool},
+	"no-dmsgweb":              {Key: "DMSGWEB", Format: EnvFormatBool, Negate: true},
+	"skynetweb":               {Key: "SKYNETWEB", Format: EnvFormatBool},
+	"no-skynetweb":            {Key: "SKYNETWEB", Format: EnvFormatBool, Negate: true},
+	"disable-public-autoconn": {Key: "DISABLEPUBLICAUTOCONN", Format: EnvFormatBool},
+}
+
+// longDesc matches the pre-factory autoconfig command's Long field
+// verbatim so --help output is unchanged.
+const longDesc = `Automatic visor configuration. Reads /etc/skywire.conf (or whatever
+SKYENV points at), generates the visor config, manages the systemd
+drop-in, and restarts (or prompts to start) the service.
+
+Mode is selected by PKGENV/USRENV in the env file:
+
+  PKGENV=true            → system install at /opt/skywire,
+                           system-level systemd unit
+  PKGENV=true
+  SKYWIRE_USER=_skywire  → same, but visor runs as _skywire (drop-in
+                           writes User=_skywire, /opt/skywire chowned)
+
+  USRENV=true            → user install at $HOME, systemctl --user
+
+  neither set            → falls back to PKGENV when run as root,
+                           USRENV otherwise.`

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -1,0 +1,171 @@
+package autoconfigcmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNew_AllFlagsRegistered asserts every flag the pre-factory
+// autoconfig command exposed is registered by New(). The list is
+// hard-coded — adding a new flag means appending to both the
+// factory and this test, which is the intent: the test guards
+// against accidental flag drops, not against intentional adds.
+func TestNew_AllFlagsRegistered(t *testing.T) {
+	want := []string{
+		"verbose",
+		"hvpks",
+		"ishv", "no-ishv",
+		"rewardaddr",
+		"public", "no-public",
+		"stcpr", "sudph",
+		"lan-dmsg-port", "lan-dmsg-public",
+		"dmsgpty-pks",
+		"vpnserver", "no-vpnserver",
+		"proxyserver", "no-proxyserver",
+		"skychat", "no-skychat",
+		"dmsgweb", "no-dmsgweb",
+		"skynetweb", "no-skynetweb",
+		"disable-public-autoconn",
+	}
+	cmd := New(&Values{})
+	for _, name := range want {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing flag --%s", name)
+		}
+	}
+}
+
+// TestNew_ShortNames asserts the -v short flag for --verbose is
+// preserved. Operators rely on the short form in scripts; renaming
+// or dropping the short would be a backward-incompat surface break.
+func TestNew_ShortNames(t *testing.T) {
+	cmd := New(&Values{})
+	verbose := cmd.Flags().Lookup("verbose")
+	if verbose == nil {
+		t.Fatal("verbose flag missing")
+	}
+	if verbose.Shorthand != "v" {
+		t.Errorf("verbose shorthand = %q; want %q", verbose.Shorthand, "v")
+	}
+}
+
+// TestNew_BindingsTrackValues asserts the returned command's flag
+// bindings actually write into the Values struct fields. Catches
+// the class of bug where the factory wires a flag to a local that
+// gets garbage-collected after New() returns.
+func TestNew_BindingsTrackValues(t *testing.T) {
+	v := &Values{}
+	cmd := New(v)
+	if err := cmd.Flags().Set("hvpks", "0123,4567"); err != nil {
+		t.Fatalf("Set hvpks: %v", err)
+	}
+	if v.Hvpks != "0123,4567" {
+		t.Errorf("Values.Hvpks = %q after Set; want %q", v.Hvpks, "0123,4567")
+	}
+	if err := cmd.Flags().Set("ishv", "true"); err != nil {
+		t.Fatalf("Set ishv: %v", err)
+	}
+	if !v.Ishv {
+		t.Errorf("Values.Ishv = false after Set; want true")
+	}
+	if err := cmd.Flags().Set("stcpr", "7777"); err != nil {
+		t.Fatalf("Set stcpr: %v", err)
+	}
+	if v.StcprPort != 7777 {
+		t.Errorf("Values.StcprPort = %d after Set; want 7777", v.StcprPort)
+	}
+}
+
+// TestEnvMap_Coverage asserts every operator-effective flag has an
+// env-var entry, and that the only flag with NO env mapping is
+// --verbose. Catches the bug where a new flag is added to the
+// factory but its envMap entry is forgotten — the operator passes
+// the flag, autoconfig silently no-ops because envMap doesn't know
+// about it.
+func TestEnvMap_Coverage(t *testing.T) {
+	m := EnvMap()
+	want := []string{
+		"hvpks",
+		"ishv", "no-ishv",
+		"rewardaddr",
+		"public", "no-public",
+		"stcpr", "sudph",
+		"lan-dmsg-port", "lan-dmsg-public",
+		"dmsgpty-pks",
+		"vpnserver", "no-vpnserver",
+		"proxyserver", "no-proxyserver",
+		"skychat", "no-skychat",
+		"dmsgweb", "no-dmsgweb",
+		"skynetweb", "no-skynetweb",
+		"disable-public-autoconn",
+	}
+	for _, name := range want {
+		if _, ok := m[name]; !ok {
+			t.Errorf("envMap missing entry for --%s", name)
+		}
+	}
+	// --verbose must NOT be in envMap (display-only flag).
+	if _, ok := m["verbose"]; ok {
+		t.Errorf("envMap should NOT have --verbose entry; that flag has no .conf effect")
+	}
+}
+
+// TestEnvMap_NegationInversion asserts negation flags (--no-X)
+// carry Negate=true so the literal CLI bool (always true when the
+// flag is present) gets inverted to "false" at render time.
+// Without this, --no-ishv would write ISHYPERVISOR=true — exactly
+// the inverse of the operator's intent.
+func TestEnvMap_NegationInversion(t *testing.T) {
+	m := EnvMap()
+	pairs := []struct {
+		pos, neg string
+	}{
+		{"ishv", "no-ishv"},
+		{"public", "no-public"},
+		{"vpnserver", "no-vpnserver"},
+		{"proxyserver", "no-proxyserver"},
+		{"skychat", "no-skychat"},
+		{"dmsgweb", "no-dmsgweb"},
+		{"skynetweb", "no-skynetweb"},
+	}
+	for _, p := range pairs {
+		pos, ok := m[p.pos]
+		if !ok {
+			t.Errorf("envMap missing positive flag --%s", p.pos)
+			continue
+		}
+		neg, ok := m[p.neg]
+		if !ok {
+			t.Errorf("envMap missing negation flag --%s", p.neg)
+			continue
+		}
+		if pos.Negate {
+			t.Errorf("positive flag --%s should have Negate=false; got true", p.pos)
+		}
+		if !neg.Negate {
+			t.Errorf("negation flag --%s should have Negate=true; got false", p.neg)
+		}
+		if pos.Key != neg.Key {
+			t.Errorf("--%s and --%s should share Key; got %q vs %q", p.pos, p.neg, pos.Key, neg.Key)
+		}
+	}
+}
+
+// TestNew_UsageString_RendersWithoutError asserts cobra's help
+// rendering doesn't panic and produces a non-empty string. The
+// WASM consumer (apt-repo install page) relies on this to render
+// the operator-facing help in the browser.
+func TestNew_UsageString_RendersWithoutError(t *testing.T) {
+	cmd := New(&Values{})
+	usage := cmd.UsageString()
+	if usage == "" {
+		t.Fatal("UsageString returned empty")
+	}
+	// Sanity: every flag should appear in the help text.
+	for _, name := range []string{"hvpks", "ishv", "rewardaddr"} {
+		if !strings.Contains(usage, "--"+name) {
+			t.Errorf("UsageString missing --%s", name)
+		}
+	}
+}
+

--- a/pkg/skywireconfig/keypair/keypair.go
+++ b/pkg/skywireconfig/keypair/keypair.go
@@ -1,0 +1,46 @@
+// Package keypair is a thin, WASM-safe wrapper around
+// pkg/cipher.GenerateKeyPair. It exists so external consumers
+// (TinyGo WASM, doc generators) that need to spin up a fresh visor
+// identity don't have to import the full cipher package surface or
+// understand its hex-formatting conventions.
+//
+// Security note: client-side keygen in a browser WASM is safe ONLY
+// when the secret key never leaves the page. The render layer must
+// not exfiltrate the SK over the network or place it in a clipboard
+// the user might paste publicly. The Generate function returns the
+// SK as a plain string — protecting it is the caller's job.
+package keypair
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// Generate creates a fresh skywire-format keypair and returns
+// (pkHex, skHex) — the same lowercase-hex format every other
+// skywire surface accepts. PK is 66 chars (33-byte compressed
+// secp256k1 point); SK is 64 chars (32-byte scalar).
+//
+// Entropy comes from crypto/rand on standard Go targets and from
+// crypto.getRandomValues via the WASM runtime on js/wasm — both
+// suitable for production identities.
+func Generate() (pkHex, skHex string) {
+	pk, sk := cipher.GenerateKeyPair()
+	return pk.Hex(), sk.Hex()
+}
+
+// FromSecretKey derives the public key for an existing hex secret
+// key. Returns "" + a non-nil error when skHex is malformed (wrong
+// length, non-hex characters, or invalid scalar). Used by config
+// flows where the operator pastes an existing SK and the form needs
+// to display the corresponding PK as a sanity check.
+func FromSecretKey(skHex string) (pkHex string, err error) {
+	var sk cipher.SecKey
+	if err := sk.Set(skHex); err != nil {
+		return "", err
+	}
+	pk, err := sk.PubKey()
+	if err != nil {
+		return "", err
+	}
+	return pk.Hex(), nil
+}

--- a/pkg/skywireconfig/keypair/keypair_test.go
+++ b/pkg/skywireconfig/keypair/keypair_test.go
@@ -1,0 +1,59 @@
+package keypair
+
+import (
+	"regexp"
+	"testing"
+)
+
+// PK is a 33-byte compressed secp256k1 point → 66 hex chars.
+// SK is a 32-byte scalar → 64 hex chars.
+var (
+	pkHexRE = regexp.MustCompile(`^[0-9a-f]{66}$`)
+	skHexRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+func TestGenerate_HexFormat(t *testing.T) {
+	pk, sk := Generate()
+	if !pkHexRE.MatchString(pk) {
+		t.Errorf("pk = %q; want 66 lowercase hex chars", pk)
+	}
+	if !skHexRE.MatchString(sk) {
+		t.Errorf("sk = %q; want 64 lowercase hex chars", sk)
+	}
+}
+
+func TestGenerate_UniquePerCall(t *testing.T) {
+	pk1, sk1 := Generate()
+	pk2, sk2 := Generate()
+	if pk1 == pk2 {
+		t.Error("Generate returned same PK twice — entropy source broken")
+	}
+	if sk1 == sk2 {
+		t.Error("Generate returned same SK twice — entropy source broken")
+	}
+}
+
+func TestFromSecretKey_RoundTrip(t *testing.T) {
+	_, sk := Generate()
+	pkRecovered, err := FromSecretKey(sk)
+	if err != nil {
+		t.Fatalf("FromSecretKey: %v", err)
+	}
+	if !pkHexRE.MatchString(pkRecovered) {
+		t.Errorf("recovered pk = %q; want 66 lowercase hex chars", pkRecovered)
+	}
+}
+
+func TestFromSecretKey_Malformed(t *testing.T) {
+	cases := []string{
+		"",
+		"deadbeef",
+		"not-hex-at-all",
+		"00000000000000000000000000000000000000000000000000000000000000000000", // 68 chars
+	}
+	for _, c := range cases {
+		if _, err := FromSecretKey(c); err == nil {
+			t.Errorf("FromSecretKey(%q) succeeded; want error", c)
+		}
+	}
+}


### PR DESCRIPTION
Foundation for the apt-repo install-page generator (WIP). Two lean packages under `pkg/skywireconfig` that compile cleanly under both `GOOS=js`/`GOARCH=wasm` and TinyGo, so an in-browser form can introspect skywire's real cobra flag set and generate identities offline.

## `pkg/skywireconfig/autoconfigcmd`

```go
func New(*Values) *cobra.Command   // freshly-built autoconfig command
func EnvMap() map[string]EnvMapping // flag-name → SKYENV-var table
```

`cmd/skywire/commands/autoconfig.go`'s 23-flag inline registration block is replaced by one call to `autoconfigcmd.New(&autoconfigVals)`. Single source of truth — the CLI binary and the WASM see the same flag definitions, descriptions, defaults, and short aliases.

EnvMap encodes the per-flag SKYENV mapping with `{Key, Format, Negate}`. Negate=true on negation flags (`--no-ishv` etc.) so the always-true CLI literal gets inverted to `false` at `.conf`-render time.

## `pkg/skywireconfig/keypair`

```go
func Generate() (pkHex, skHex string)
func FromSecretKey(skHex string) (pkHex string, err error)
```

Thin wrapper over `pkg/cipher` for in-browser identity generation. PK is 66 hex chars; SK is 64. WASM-side rendering layer is responsible for keeping the SK in the form and out of the network.

## WASM viability

End-to-end verified with a sample `syscall/js` main calling `cmd.UsageString()`:

| Build | Size |
|---|---|
| Go WASM (`-ldflags='-s -w'`) | 3.8 MB |
| TinyGo WASM (`-no-debug`) | 630 KB |

Both render the same cobra-formatted operator help in the browser.

## Deferred to follow-up

`pkg/skywireconfig/genvisor` (download-the-whole-skywire.json from the form) needs `pkg/visor/visorconfig` first refactored to split pure-data from non-pure-data — currently transitively imports `github.com/creack/pty` and `pkg/netutil`, neither compiling under `js/wasm` (no `syscall.TIOCGWINSZ`, no `DefaultNetworkInterface`) or TinyGo's net/http surface. Its own design pass.

## Test plan

- [x] All existing `cmd/skywire/commands` tests pass with no edits.
- [x] New tests in `pkg/skywireconfig/autoconfigcmd`: every pre-factory flag registered; `-v` short alias preserved; Values bindings track field updates; EnvMap covers every operator-effective flag; negation flags carry `Negate=true`; `UsageString()` renders without error.
- [x] New tests in `pkg/skywireconfig/keypair`: PK 66 hex / SK 64 hex; unique per call; `FromSecretKey` round-trips and rejects malformed input.
- [x] WASM build smoke: `GOOS=js GOARCH=wasm go build` succeeds; `tinygo build -target wasm` succeeds.