### PR TITLE
feat(netutil,skyenv): js/wasm build-tag stubs

### DIFF
--- a/pkg/netutil/net_js.go
+++ b/pkg/netutil/net_js.go
@@ -1,0 +1,24 @@
+//go:build js
+
+// Package netutil pkg/netutil/net_js.go
+//
+// js/wasm build of pkg/netutil. The browser has no concept of
+// "default network interface" — the WASM runtime can't enumerate
+// host NICs at all. The functions exist so transitive importers of
+// netutil from packages that DO compile under js (visorconfig and
+// friends, via the in-browser install-page WASM at apt-repo) link
+// successfully; calling them returns an error explaining the
+// situation.
+package netutil
+
+import "errors"
+
+// DefaultNetworkInterface returns an "unsupported on this
+// platform" sentinel error. There's no concept of "the default
+// network interface" inside a browser WASM runtime; this stub
+// exists so packages that transitively depend on netutil for type
+// resolution (struct field references etc.) compile cleanly under
+// GOOS=js without needing per-package WASM-aware build tags.
+func DefaultNetworkInterface() (string, error) {
+	return "", errors.New("netutil: DefaultNetworkInterface unsupported under js/wasm")
+}

--- a/pkg/skyenv/skyenv_js.go
+++ b/pkg/skyenv/skyenv_js.go
@@ -1,0 +1,22 @@
+//go:build js
+
+// Package skyenv pkg/skyenv/skyenv_js.go
+//
+// js/wasm build of pkg/skyenv. Path constants are stubbed to
+// empty/sentinel values — the browser doesn't have filesystem
+// access in the host sense, and the in-browser install-page
+// generator (apt-repo/cmd/wasm) only needs the *type* surface of
+// skyenv to compile; it never reads SkywirePath or ConfigJSON at
+// runtime.
+package skyenv
+
+// SkywirePath is the platform-specific install root. js/wasm:
+// empty string. The install-page WASM doesn't perform host-side
+// filesystem operations.
+const SkywirePath = ""
+
+// ConfigJSON is the platform-specific path component for the
+// visor config file. js/wasm: empty string. The install-page WASM
+// emits the config as a downloadable blob rather than writing it
+// to a host path.
+const ConfigJSON = ""

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -103,29 +103,34 @@ func New(v *Values) *cobra.Command {
 		Long:  longDesc,
 	}
 
+	// Flag descriptions mirror `skywire cli config gen`'s equivalent
+	// flag where one exists, so the autoconfig surface and the
+	// config-gen surface stay in sync. Operators (and the WASM-
+	// rendered install-page form) see what the flag actually DOES,
+	// not just which env var it writes.
 	cmd.Flags().BoolVarP(&v.Verbose, "verbose", "v", false, "show reward address, support links, and other details")
-	cmd.Flags().StringVar(&v.Hvpks, "hvpks", "", "set HYPERVISORPKS in skywire.conf (comma-separated PKs)")
-	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "set ISHYPERVISOR=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "set ISHYPERVISOR=false in skywire.conf")
-	cmd.Flags().StringVar(&v.RewardAddr, "rewardaddr", "", "set REWARDSKYADDR in skywire.conf")
-	cmd.Flags().BoolVar(&v.Public, "public", false, "set VISORISPUBLIC=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoPublic, "no-public", false, "set VISORISPUBLIC=false in skywire.conf")
-	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "set STCPRPORT in skywire.conf (0 = leave unchanged)")
-	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "set SUDPHPORT in skywire.conf (0 = leave unchanged)")
-	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "set LANDMSGPORT in skywire.conf (0 = leave unchanged)")
-	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "set LANDMSGPUBLIC in skywire.conf (host:port)")
-	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "set DMSGPTYPKS in skywire.conf (comma-separated PKs)")
-	cmd.Flags().BoolVar(&v.VpnServer, "vpnserver", false, "set VPNSERVER=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoVpnServer, "no-vpnserver", false, "set VPNSERVER=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.ProxyServer, "proxyserver", false, "set PROXYSERVER=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoProxyServer, "no-proxyserver", false, "set PROXYSERVER=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "set SKYCHAT=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoSkychat, "no-skychat", false, "set SKYCHAT=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.Dmsgweb, "dmsgweb", false, "set DMSGWEB=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoDmsgweb, "no-dmsgweb", false, "set DMSGWEB=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.Skynetweb, "skynetweb", false, "set SKYNETWEB=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoSkynetweb, "no-skynetweb", false, "set SKYNETWEB=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.DisablePubAuto, "disable-public-autoconn", false, "set DISABLEPUBLICAUTOCONN=true in skywire.conf")
+	cmd.Flags().StringVar(&v.Hvpks, "hvpks", "", "comma-separated remote hypervisor PKs to dial — writes HYPERVISORPKS in skywire.conf")
+	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "enable local hypervisor — writes ISHYPERVISOR=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "disable local hypervisor — writes ISHYPERVISOR=false in skywire.conf")
+	cmd.Flags().StringVar(&v.RewardAddr, "rewardaddr", "", "skycoin reward address or xpub key — writes REWARDSKYADDR in skywire.conf")
+	cmd.Flags().BoolVar(&v.Public, "public", false, "publicize visor in service discovery — writes VISORISPUBLIC=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoPublic, "no-public", false, "unpublish visor from service discovery — writes VISORISPUBLIC=false in skywire.conf")
+	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "stcp transport listening port (0 = leave unchanged, random at runtime) — writes STCPRPORT in skywire.conf")
+	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "sudp transport listening port (0 = leave unchanged, random at runtime) — writes SUDPHPORT in skywire.conf")
+	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
+	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "additional dmsgpty-whitelist PKs (hypervisor PKs are already implicit) — writes DMSGPTYPKS in skywire.conf")
+	cmd.Flags().BoolVar(&v.VpnServer, "vpnserver", false, "autostart vpn-server — writes VPNSERVER=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoVpnServer, "no-vpnserver", false, "do not autostart vpn-server — writes VPNSERVER=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.ProxyServer, "proxyserver", false, "autostart skysocks (proxy server) — writes PROXYSERVER=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoProxyServer, "no-proxyserver", false, "do not autostart skysocks — writes PROXYSERVER=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "autostart skychat — writes SKYCHAT=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkychat, "no-skychat", false, "do not autostart skychat — writes SKYCHAT=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.Dmsgweb, "dmsgweb", false, "enable embedded .dmsg resolving SOCKS5 proxy on 127.0.0.1:4445 — writes DMSGWEB=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoDmsgweb, "no-dmsgweb", false, "disable embedded .dmsg resolving SOCKS5 proxy — writes DMSGWEB=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.Skynetweb, "skynetweb", false, "enable embedded .skynet resolving SOCKS5 proxy on 127.0.0.1:4446 — writes SKYNETWEB=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkynetweb, "no-skynetweb", false, "disable embedded .skynet resolving SOCKS5 proxy — writes SKYNETWEB=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.DisablePubAuto, "disable-public-autoconn", false, "disable autoconnect to public visors — writes DISABLEPUBLICAUTOCONN=true in skywire.conf")
 
 	return cmd
 }


### PR DESCRIPTION
Small foundation commit for js/wasm consumers of skywire subpackages.

`pkg/netutil` and `pkg/skyenv` both have platform-gated leaves (`net_{linux,darwin,windows}.go`, `skyenv_{linux,darwin,windows}.go`) that don't cover `GOOS=js` — transitive importers from the WASM side hit `undefined: DefaultNetworkInterface` / `undefined: SkywirePath` / `undefined: ConfigJSON` even though the operational code never needs to run.

This PR adds the missing stubs:

| File | Behavior under js |
|---|---|
| `pkg/netutil/net_js.go` | `DefaultNetworkInterface` returns a sentinel error |
| `pkg/skyenv/skyenv_js.go` | `SkywirePath = ""`, `ConfigJSON = ""` |

Native builds unchanged — `pkg/netutil` tests still pass.

## Context

Follow-up to #2826 (autoconfigcmd + keypair). The apt-repo install-page WASM currently only imports those two lean packages. Future expansion (e.g. a full `pkg/skywireconfig/genvisor` config generator) needs more of skywire's surface to compile under `GOOS=js`. The stubs here aren't strictly needed YET — they're prep for when we want to make more of `pkg/visor/visorconfig` reachable from WASM. Three other vendored 3rd-party deps (`creack/pty`, `go.etcd.io/bbolt`, `james-barrow/golang-ipc`) still block; addressing those is a separate design pass.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/netutil/` passes
- [x] Stub imports compile cleanly under `GOOS=js GOARCH=wasm`