### PR TITLE
feat(visorconfig): schema/operational split — V1 now WASM-clean

### DIFF
--- a/pkg/app/appserver/app_state.go
+++ b/pkg/app/appserver/app_state.go
@@ -1,7 +1,9 @@
 // Package appserver pkg/app/appserver/app_state.go
 package appserver
 
-import "github.com/skycoin/skywire/pkg/routing"
+import (
+	"github.com/skycoin/skywire/pkg/app/appserver/spec"
+)
 
 // AppStatus defines running status of an App.
 type AppStatus int
@@ -44,34 +46,11 @@ func (s AppStatus) String() string {
 // definition — credentials can't be dropped per-goroutine without
 // breaking the runtime's thread-pinning assumptions, and the visor
 // logs a warning if any of these fields are set on an internal app.
-type AppConfig struct {
-	Name      string       `json:"name"`
-	Binary    string       `json:"binary,omitempty"`
-	Args      []string     `json:"args,omitempty"`
-	AutoStart bool         `json:"auto_start"`
-	Port      routing.Port `json:"port"`
-	// User overrides the UID the spawned process runs as (POSIX
-	// setuid before exec). Requires the visor to have the
-	// privileges to switch users (i.e. running as root, or with
-	// CAP_SETUID). Empty = inherit visor UID.
-	User string `json:"user,omitempty"`
-	// Group overrides the GID. Empty = inherit visor GID, or the
-	// primary group of User when User is set.
-	Group string `json:"group,omitempty"`
-	// WorkDir overrides the proc's working directory. Empty =
-	// launcher's per-app default (lc.LocalPath/<app-name>).
-	WorkDir string `json:"work_dir,omitempty"`
-	// Env adds key=value pairs to the spawned process's
-	// environment. Useful for HOME=/home/<user> when User is set.
-	Env []string `json:"env,omitempty"`
-	// LauncherMode persists the operator's launcher-mode preference
-	// for this app: "internal" runs the app inside the visor process,
-	// "external" spawns it as a child with optional User/Group/etc.
-	// Empty = use whatever the visor's StartApp default chooses
-	// (today: external when Binary is set, internal otherwise).
-	// Honored by StartApp; StartAppWithMode still wins per-call.
-	LauncherMode string `json:"launcher_mode,omitempty"`
-}
+// AppConfig is the wire-format type for an app's launcher entry.
+// Aliased from pkg/app/appserver/spec so existing callers writing
+// `appserver.AppConfig{...}` keep compiling, while the canonical
+// (WASM-clean) definition lives in the spec leaf package.
+type AppConfig = spec.AppConfig
 
 // AppState defines state parameters for a registered App.
 type AppState struct {

--- a/pkg/app/appserver/spec/spec.go
+++ b/pkg/app/appserver/spec/spec.go
@@ -1,0 +1,52 @@
+// Package spec is the WASM-clean schema half of pkg/app/appserver.
+// Holds the AppConfig wire-format type that pkg/visor/visorconfig.V1's
+// Launcher.Apps field embeds. Splitting it out of pkg/app/appserver
+// keeps V1 importable from GOOS=js consumers without dragging in
+// appserver's operational graph (which transitively pulls
+// github.com/james-barrow/golang-ipc — the per-app IPC channel —
+// and go.etcd.io/bbolt — the app-state store).
+//
+// pkg/app/appserver re-exports `AppConfig = spec.AppConfig` so
+// existing callers compile unchanged.
+package spec
+
+import (
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// AppConfig defines app startup parameters.
+//
+// User/Group/WorkDir/Env are POSIX-only knobs that only take effect
+// when the app runs as an external process (Binary set, no internal
+// RunFunc registered). In-process apps share the visor's UID/GID by
+// definition — credentials can't be dropped per-goroutine without
+// breaking the runtime's thread-pinning assumptions, and the visor
+// logs a warning if any of these fields are set on an internal app.
+type AppConfig struct {
+	Name      string       `json:"name"`
+	Binary    string       `json:"binary,omitempty"`
+	Args      []string     `json:"args,omitempty"`
+	AutoStart bool         `json:"auto_start"`
+	Port      routing.Port `json:"port"`
+	// User overrides the UID the spawned process runs as (POSIX
+	// setuid before exec). Requires the visor to have the
+	// privileges to switch users (i.e. running as root, or with
+	// CAP_SETUID). Empty = inherit visor UID.
+	User string `json:"user,omitempty"`
+	// Group overrides the GID. Empty = inherit visor GID, or the
+	// primary group of User when User is set.
+	Group string `json:"group,omitempty"`
+	// WorkDir overrides the proc's working directory. Empty =
+	// launcher's per-app default (lc.LocalPath/<app-name>).
+	WorkDir string `json:"work_dir,omitempty"`
+	// Env adds key=value pairs to the spawned process's
+	// environment. Useful for HOME=/home/<user> when User is set.
+	Env []string `json:"env,omitempty"`
+	// LauncherMode persists the operator's launcher-mode preference
+	// for this app: "internal" runs the app inside the visor process,
+	// "external" spawns it as a child with optional User/Group/etc.
+	// Empty = use whatever the visor's StartApp default chooses
+	// (today: external when Binary is set, internal otherwise).
+	// Honored by StartApp; StartAppWithMode still wins per-call.
+	LauncherMode string `json:"launcher_mode,omitempty"`
+}

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -1,219 +1,34 @@
-// Package dmsgc dmsg config and client
+// Package dmsgc dmsg config and client. Operational half of the
+// dmsg configuration surface: the wire-format types and their JSON
+// methods live in pkg/dmsgc/spec (WASM-clean), and pkg/dmsgc here
+// aliases them so existing callers keep working unchanged while
+// composing the dmsg.Client constructor and the LAN-priority
+// discovery wrapper that need the heavier transitive deps.
 package dmsgc
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/skycoin/skywire/pkg/app/appevent"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// Deployment is one (dmsg-discovery, transit-servers) pair. Each
-// Deployment is independent — different deployments may use different
-// servers, sessions counts, protocols, or LAN preferences.
-//
-// The discovery's PK is encoded in DiscoveryDmsg (form
-// `dmsg://<PK>:<port>`) and is extracted on demand by callers that
-// need it for dmsgfirst registration; there is no separate PK field.
-type Deployment struct {
-	Discovery            string        `json:"discovery,omitempty"`
-	DiscoveryDmsg        string        `json:"discovery_dmsg,omitempty"`
-	SessionsCount        int           `json:"sessions_count,omitempty"`
-	Servers              []*disc.Entry `json:"servers,omitempty"`
-	ConnectedServersType string        `json:"servers_type,omitempty"`
-	Protocol             string        `json:"protocol,omitempty"`
-	LANServers           []*disc.Entry `json:"lan_servers,omitempty"`
-	// HypervisorDiscovery is an optional override URL pointing at a
-	// hypervisor-hosted dmsg-discovery proxy. When set, the dmsg client
-	// queries this URL first and falls back to Discovery (the canonical
-	// public dmsg-discovery) on error. Pushed automatically by
-	// hypervisors with their embedded dmsg server enabled — see
-	// LANDmsgServerInfo.DiscoveryURL.
-	HypervisorDiscovery string `json:"hypervisor_discovery,omitempty"`
-}
+// Deployment is the wire-format type for one (dmsg-discovery,
+// transit-servers) pair. Aliased from pkg/dmsgc/spec so existing
+// callers writing `dmsgc.Deployment{...}` keep compiling, while the
+// canonical definition lives in the WASM-clean spec package.
+type Deployment = spec.Deployment
 
-// DmsgConfig is the visor-side dmsg subsystem configuration.
-//
-// JSON polymorphism: a single Deployment object is the single-
-// deployment shape that visor configs have always used; an array of
-// Deployments is the multi-deployment shape, where each entry pairs
-// a dmsg-discovery with the dmsg-servers that reach it. Internally
-// the type stores a slice; the single-object shape unmarshals into
-// a one-element slice and marshals back to an object.
-//
-// For backward compatibility with code that reads
-// `v.conf.Dmsg.Discovery` etc. directly, the legacy top-level fields
-// are kept as a mirror of Deployments[0]. Writers that build a
-// DmsgConfig by setting top-level fields directly still work — the
-// MarshalJSON synthesizes a one-element Deployments from the
-// top-level fields when Deployments is empty.
-type DmsgConfig struct {
-	// Deployments is the canonical list, populated by UnmarshalJSON.
-	Deployments []Deployment `json:"-"`
-
-	// Top-level mirror fields. Read-only after UnmarshalJSON; the
-	// canonical state lives in Deployments. Kept to avoid churning
-	// the many existing call sites that read Dmsg.Discovery /
-	// Dmsg.DiscoveryDmsg / Dmsg.Servers / etc. directly.
-	Discovery            string        `json:"-"`
-	DiscoveryDmsg        string        `json:"-"`
-	SessionsCount        int           `json:"-"`
-	Servers              []*disc.Entry `json:"-"`
-	ConnectedServersType string        `json:"-"`
-	Protocol             string        `json:"-"`
-	LANServers           []*disc.Entry `json:"-"`
-	HypervisorDiscovery  string        `json:"-"`
-}
-
-// UnmarshalJSON accepts either a single Deployment object or an array
-// of Deployments and populates Deployments + the legacy top-level
-// mirror fields accordingly.
-func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
-	trimmed := bytes.TrimLeft(data, " \t\n\r")
-	if len(trimmed) > 0 && trimmed[0] == '[' {
-		if err := json.Unmarshal(data, &c.Deployments); err != nil {
-			return err
-		}
-	} else {
-		var single Deployment
-		if err := json.Unmarshal(data, &single); err != nil {
-			return err
-		}
-		c.Deployments = []Deployment{single}
-	}
-	c.mirrorPrimary()
-	return nil
-}
-
-// MarshalJSON emits the single-deployment object shape when there is
-// exactly one deployment, otherwise the array shape. When Deployments
-// is empty but the top-level fields are populated (e.g. a writer that
-// only set Discovery + Servers directly), a one-element Deployments
-// is synthesized from the mirror fields so the JSON output is correct.
-func (c DmsgConfig) MarshalJSON() ([]byte, error) {
-	deployments := c.Deployments
-	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "") {
-		deployments = []Deployment{c.toDeployment()}
-	}
-	if len(deployments) == 1 {
-		return json.Marshal(deployments[0])
-	}
-	return json.Marshal(deployments)
-}
-
-// mirrorPrimary copies Deployments[0] into the legacy top-level fields
-// so existing readers keep working in the single-deployment case. For
-// multi-deployment configs the mirror reflects the first entry — code
-// that needs to iterate uses Deployments directly.
-func (c *DmsgConfig) mirrorPrimary() {
-	if len(c.Deployments) == 0 {
-		return
-	}
-	d := c.Deployments[0]
-	c.Discovery = d.Discovery
-	c.DiscoveryDmsg = d.DiscoveryDmsg
-	c.SessionsCount = d.SessionsCount
-	c.Servers = d.Servers
-	c.ConnectedServersType = d.ConnectedServersType
-	c.Protocol = d.Protocol
-	c.LANServers = d.LANServers
-	c.HypervisorDiscovery = d.HypervisorDiscovery
-}
-
-// toDeployment snapshots the legacy top-level fields into a Deployment.
-func (c *DmsgConfig) toDeployment() Deployment {
-	return Deployment{
-		Discovery:            c.Discovery,
-		DiscoveryDmsg:        c.DiscoveryDmsg,
-		SessionsCount:        c.SessionsCount,
-		Servers:              c.Servers,
-		ConnectedServersType: c.ConnectedServersType,
-		Protocol:             c.Protocol,
-		LANServers:           c.LANServers,
-		HypervisorDiscovery:  c.HypervisorDiscovery,
-	}
-}
-
-// Primary returns the first deployment, synthesizing one from the
-// legacy top-level fields when Deployments is empty. Callers can rely
-// on Primary always returning a non-nil pointer for any non-empty
-// DmsgConfig.
-func (c *DmsgConfig) Primary() *Deployment {
-	if len(c.Deployments) > 0 {
-		return &c.Deployments[0]
-	}
-	d := c.toDeployment()
-	return &d
-}
-
-// AllDeployments returns the list of deployments, synthesizing a
-// one-element list from the legacy top-level fields when Deployments
-// is empty. Returns nil only when the config is fully zero.
-func (c *DmsgConfig) AllDeployments() []Deployment {
-	if len(c.Deployments) > 0 {
-		return c.Deployments
-	}
-	if c.Discovery == "" && c.DiscoveryDmsg == "" && len(c.Servers) == 0 && c.HypervisorDiscovery == "" {
-		return nil
-	}
-	return []Deployment{c.toDeployment()}
-}
-
-// ResolvedServers unions servers from all deployments, deduping by PK.
-// The result is what the direct.Client should be preloaded with so the
-// client can dmsg-dial every configured discovery — whether
-// deployments share a server set or have disjoint per-deployment sets.
-func (c *DmsgConfig) ResolvedServers() []*disc.Entry {
-	seen := make(map[cipher.PubKey]struct{})
-	var out []*disc.Entry
-	add := func(e *disc.Entry) {
-		if e == nil {
-			return
-		}
-		if _, ok := seen[e.Static]; ok {
-			return
-		}
-		seen[e.Static] = struct{}{}
-		out = append(out, e)
-	}
-	for _, d := range c.AllDeployments() {
-		for _, e := range d.Servers {
-			add(e)
-		}
-	}
-	return out
-}
-
-// pkFromDmsgURL extracts the dmsg PK from a URL of the form
-// `dmsg://<PK>:<port>[/path]`. Returns the zero PK when the URL is
-// empty, malformed, or doesn't contain a valid PK in the host part.
-func pkFromDmsgURL(s string) cipher.PubKey {
-	if s == "" {
-		return cipher.PubKey{}
-	}
-	u, err := url.Parse(s)
-	if err != nil || u.Host == "" {
-		return cipher.PubKey{}
-	}
-	host := u.Hostname()
-	if host == "" {
-		host = strings.SplitN(u.Host, ":", 2)[0]
-	}
-	var pk cipher.PubKey
-	if err := pk.Set(host); err != nil {
-		return cipher.PubKey{}
-	}
-	return pk
-}
+// DmsgConfig is the wire-format type for the visor-side dmsg
+// subsystem configuration. Aliased from pkg/dmsgc/spec; see
+// spec.DmsgConfig for the type doc and the JSON-polymorphism notes.
+type DmsgConfig = spec.DmsgConfig
 
 // lanPriorityDisc wraps a disc.APIClient to prepend LAN server entries
 // to discovery results. LAN servers are tried first, with automatic
@@ -337,7 +152,7 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 	for i := 1; i < len(deployments); i++ {
 		dmsgC.AddDiscovery(
 			disc.NewHTTP(deployments[i].Discovery, httpC, masterLogger.PackageLogger("dmsgC:disc")),
-			pkFromDmsgURL(deployments[i].DiscoveryDmsg),
+			spec.PKFromDmsgURL(deployments[i].DiscoveryDmsg),
 		)
 	}
 	return dmsgC

--- a/pkg/dmsgc/spec/spec.go
+++ b/pkg/dmsgc/spec/spec.go
@@ -1,0 +1,236 @@
+// Package spec is the WASM-clean schema half of pkg/dmsgc. The types
+// and methods here describe the visor's dmsg-subsystem configuration
+// at the wire (JSON) layer only — no dmsg client construction, no
+// network I/O, no transitive pull on operational packages.
+//
+// Why split: pkg/dmsgc itself imports pkg/dmsg/dmsg (the dmsg client
+// implementation) which transitively brings in pty / ipc / bbolt
+// vendor packages that don't compile under GOOS=js. That made
+// pkg/visor/visorconfig.V1, which has a *dmsgc.DmsgConfig field,
+// uncompilable from any WASM consumer (apt-repo install page, doc
+// generators, schema validators).
+//
+// Moving the wire types out into this leaf package lets V1 reference
+// dmsgcspec.DmsgConfig instead — V1 compiles under WASM, the
+// install-page can render and emit live visor configs, and the
+// operational pkg/dmsgc keeps doing its job for the visor binary
+// via a `type DmsgConfig = spec.DmsgConfig` alias.
+//
+// All methods on DmsgConfig are pure: JSON marshalers and getters
+// over the in-memory slice. None of them touch network, filesystem,
+// or transitive operational packages. Adding an operational method
+// (one that dials, fetches, etc.) belongs in pkg/dmsgc, not here.
+package spec
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// Deployment is one (dmsg-discovery, transit-servers) pair. Each
+// Deployment is independent — different deployments may use different
+// servers, sessions counts, protocols, or LAN preferences.
+//
+// The discovery's PK is encoded in DiscoveryDmsg (form
+// `dmsg://<PK>:<port>`) and is extracted on demand by callers that
+// need it for dmsgfirst registration; there is no separate PK field.
+type Deployment struct {
+	Discovery            string        `json:"discovery,omitempty"`
+	DiscoveryDmsg        string        `json:"discovery_dmsg,omitempty"`
+	SessionsCount        int           `json:"sessions_count,omitempty"`
+	Servers              []*disc.Entry `json:"servers,omitempty"`
+	ConnectedServersType string        `json:"servers_type,omitempty"`
+	Protocol             string        `json:"protocol,omitempty"`
+	LANServers           []*disc.Entry `json:"lan_servers,omitempty"`
+	// HypervisorDiscovery is an optional override URL pointing at a
+	// hypervisor-hosted dmsg-discovery proxy. When set, the dmsg client
+	// queries this URL first and falls back to Discovery (the canonical
+	// public dmsg-discovery) on error. Pushed automatically by
+	// hypervisors with their embedded dmsg server enabled — see
+	// LANDmsgServerInfo.DiscoveryURL.
+	HypervisorDiscovery string `json:"hypervisor_discovery,omitempty"`
+}
+
+// DmsgConfig is the visor-side dmsg subsystem configuration.
+//
+// JSON polymorphism: a single Deployment object is the single-
+// deployment shape that visor configs have always used; an array of
+// Deployments is the multi-deployment shape, where each entry pairs
+// a dmsg-discovery with the dmsg-servers that reach it. Internally
+// the type stores a slice; the single-object shape unmarshals into
+// a one-element slice and marshals back to an object.
+//
+// For backward compatibility with code that reads
+// `v.conf.Dmsg.Discovery` etc. directly, the legacy top-level fields
+// are kept as a mirror of Deployments[0]. Writers that build a
+// DmsgConfig by setting top-level fields directly still work — the
+// MarshalJSON synthesizes a one-element Deployments from the
+// top-level fields when Deployments is empty.
+type DmsgConfig struct {
+	// Deployments is the canonical list, populated by UnmarshalJSON.
+	Deployments []Deployment `json:"-"`
+
+	// Top-level mirror fields. Read-only after UnmarshalJSON; the
+	// canonical state lives in Deployments. Kept to avoid churning
+	// the many existing call sites that read Dmsg.Discovery /
+	// Dmsg.DiscoveryDmsg / Dmsg.Servers / etc. directly.
+	Discovery            string        `json:"-"`
+	DiscoveryDmsg        string        `json:"-"`
+	SessionsCount        int           `json:"-"`
+	Servers              []*disc.Entry `json:"-"`
+	ConnectedServersType string        `json:"-"`
+	Protocol             string        `json:"-"`
+	LANServers           []*disc.Entry `json:"-"`
+	HypervisorDiscovery  string        `json:"-"`
+}
+
+// UnmarshalJSON accepts either a single Deployment object or an array
+// of Deployments and populates Deployments + the legacy top-level
+// mirror fields accordingly.
+func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimLeft(data, " \t\n\r")
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		if err := json.Unmarshal(data, &c.Deployments); err != nil {
+			return err
+		}
+	} else {
+		var single Deployment
+		if err := json.Unmarshal(data, &single); err != nil {
+			return err
+		}
+		c.Deployments = []Deployment{single}
+	}
+	c.mirrorPrimary()
+	return nil
+}
+
+// MarshalJSON emits the single-deployment object shape when there is
+// exactly one deployment, otherwise the array shape. When Deployments
+// is empty but the top-level fields are populated (e.g. a writer that
+// only set Discovery + Servers directly), a one-element Deployments
+// is synthesized from the mirror fields so the JSON output is correct.
+func (c DmsgConfig) MarshalJSON() ([]byte, error) {
+	deployments := c.Deployments
+	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "") {
+		deployments = []Deployment{c.toDeployment()}
+	}
+	if len(deployments) == 1 {
+		return json.Marshal(deployments[0])
+	}
+	return json.Marshal(deployments)
+}
+
+// mirrorPrimary copies Deployments[0] into the legacy top-level fields
+// so existing readers keep working in the single-deployment case. For
+// multi-deployment configs the mirror reflects the first entry — code
+// that needs to iterate uses Deployments directly.
+func (c *DmsgConfig) mirrorPrimary() {
+	if len(c.Deployments) == 0 {
+		return
+	}
+	d := c.Deployments[0]
+	c.Discovery = d.Discovery
+	c.DiscoveryDmsg = d.DiscoveryDmsg
+	c.SessionsCount = d.SessionsCount
+	c.Servers = d.Servers
+	c.ConnectedServersType = d.ConnectedServersType
+	c.Protocol = d.Protocol
+	c.LANServers = d.LANServers
+	c.HypervisorDiscovery = d.HypervisorDiscovery
+}
+
+// toDeployment snapshots the legacy top-level fields into a Deployment.
+func (c *DmsgConfig) toDeployment() Deployment {
+	return Deployment{
+		Discovery:            c.Discovery,
+		DiscoveryDmsg:        c.DiscoveryDmsg,
+		SessionsCount:        c.SessionsCount,
+		Servers:              c.Servers,
+		ConnectedServersType: c.ConnectedServersType,
+		Protocol:             c.Protocol,
+		LANServers:           c.LANServers,
+		HypervisorDiscovery:  c.HypervisorDiscovery,
+	}
+}
+
+// Primary returns the first deployment, synthesizing one from the
+// legacy top-level fields when Deployments is empty. Callers can rely
+// on Primary always returning a non-nil pointer for any non-empty
+// DmsgConfig.
+func (c *DmsgConfig) Primary() *Deployment {
+	if len(c.Deployments) > 0 {
+		return &c.Deployments[0]
+	}
+	d := c.toDeployment()
+	return &d
+}
+
+// AllDeployments returns the list of deployments, synthesizing a
+// one-element list from the legacy top-level fields when Deployments
+// is empty. Returns nil only when the config is fully zero.
+func (c *DmsgConfig) AllDeployments() []Deployment {
+	if len(c.Deployments) > 0 {
+		return c.Deployments
+	}
+	if c.Discovery == "" && c.DiscoveryDmsg == "" && len(c.Servers) == 0 && c.HypervisorDiscovery == "" {
+		return nil
+	}
+	return []Deployment{c.toDeployment()}
+}
+
+// ResolvedServers unions servers from all deployments, deduping by PK.
+// The result is what the direct.Client should be preloaded with so the
+// client can dmsg-dial every configured discovery — whether
+// deployments share a server set or have disjoint per-deployment sets.
+func (c *DmsgConfig) ResolvedServers() []*disc.Entry {
+	seen := make(map[cipher.PubKey]struct{})
+	var out []*disc.Entry
+	add := func(e *disc.Entry) {
+		if e == nil {
+			return
+		}
+		if _, ok := seen[e.Static]; ok {
+			return
+		}
+		seen[e.Static] = struct{}{}
+		out = append(out, e)
+	}
+	for _, d := range c.AllDeployments() {
+		for _, e := range d.Servers {
+			add(e)
+		}
+	}
+	return out
+}
+
+// PKFromDmsgURL extracts the dmsg PK from a URL of the form
+// `dmsg://<PK>:<port>[/path]`. Returns the zero PK when the URL is
+// empty, malformed, or doesn't contain a valid PK in the host part.
+//
+// Exported (vs the pre-split lowercase pkFromDmsgURL) because the
+// spec package is the natural home for parse helpers that depend
+// only on stdlib + cipher. Internal callers in pkg/dmsgc now use
+// spec.PKFromDmsgURL.
+func PKFromDmsgURL(s string) cipher.PubKey {
+	if s == "" {
+		return cipher.PubKey{}
+	}
+	u, err := url.Parse(s)
+	if err != nil || u.Host == "" {
+		return cipher.PubKey{}
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = strings.SplitN(u.Host, ":", 2)[0]
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(host); err != nil {
+		return cipher.PubKey{}
+	}
+	return pk
+}

--- a/pkg/skyenv/skyenv_js.go
+++ b/pkg/skyenv/skyenv_js.go
@@ -20,3 +20,11 @@ const SkywirePath = ""
 // emits the config as a downloadable blob rather than writing it
 // to a host path.
 const ConfigJSON = ""
+
+// PackageConfig returns an empty PkgConfig under js/wasm. There's
+// no host install root in a browser, so all PkgConfig fields are
+// just zero values. Operational callers should never invoke this
+// from WASM — it exists for type compilation only.
+func PackageConfig() PkgConfig {
+	return PkgConfig{}
+}

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport/network"
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
+	tspec "github.com/skycoin/skywire/pkg/transport/spec"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
@@ -27,11 +28,11 @@ const reconnectPhaseDelay = 10 * time.Second
 const reconnectRemoteTimeout = 3 * time.Second
 const transportReRegisterInterval = 90 * time.Second
 
-// PersistentTransports is a persistent transports description
-type PersistentTransports struct {
-	PK      cipher.PubKey `json:"pk"`
-	NetType types.Type    `json:"type"`
-}
+// PersistentTransports is the wire-format pinning entry. Aliased
+// from pkg/transport/spec so existing callers writing
+// `transport.PersistentTransports{...}` keep compiling, while the
+// canonical (WASM-clean) definition lives in the spec leaf package.
+type PersistentTransports = tspec.PersistentTransports
 
 // ManagerConfig configures a Manager.
 type ManagerConfig struct {

--- a/pkg/transport/network/spec/spec.go
+++ b/pkg/transport/network/spec/spec.go
@@ -1,0 +1,24 @@
+// Package spec is the WASM-clean schema half of pkg/transport/network.
+// Currently holds STCPConfig (the visor-side Skywire-TCP configuration
+// stanza) — a pure-data type that pkg/visor/visorconfig.V1 embeds.
+//
+// Splitting it out of pkg/transport/network lets V1 reference the
+// schema directly without transitively pulling in the package's
+// operational dependencies (netutil's DefaultNetworkInterface,
+// bbolt's transport log store, etc.) which don't compile under
+// GOOS=js. pkg/transport/network keeps a `type STCPConfig =
+// spec.STCPConfig` alias so existing callers don't need to change
+// imports.
+package spec
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// STCPConfig defines config for Skywire-TCP network. Pure data —
+// the actual stcp client / listener / dialer live in
+// pkg/transport/network and operate on this type.
+type STCPConfig struct {
+	PKTable          map[cipher.PubKey]string `json:"pk_table"`
+	ListeningAddress string                   `json:"listening_address"`
+}

--- a/pkg/transport/network/stcp.go
+++ b/pkg/transport/network/stcp.go
@@ -8,15 +8,16 @@ import (
 	"net"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport/network/spec"
 	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
-// STCPConfig defines config for Skywire-TCP network.
-type STCPConfig struct {
-	PKTable          map[cipher.PubKey]string `json:"pk_table"`
-	ListeningAddress string                   `json:"listening_address"`
-}
+// STCPConfig is the wire-format type for Skywire-TCP configuration.
+// Aliased from pkg/transport/network/spec so existing callers
+// writing `network.STCPConfig{...}` keep compiling, while the
+// canonical (WASM-clean) definition lives in the spec leaf package.
+type STCPConfig = spec.STCPConfig
 
 type stcpClient struct {
 	*genericClient

--- a/pkg/transport/spec/spec.go
+++ b/pkg/transport/spec/spec.go
@@ -1,0 +1,26 @@
+// Package spec is the WASM-clean schema half of pkg/transport.
+// Currently holds PersistentTransports — the wire-format entry the
+// visor stores per pinned transport peer. pkg/visor/visorconfig.V1
+// embeds a `[]PersistentTransports`, so this type living in a leaf
+// package keeps V1 importable from GOOS=js consumers without
+// pulling in pkg/transport's operational graph (bbolt log store,
+// manager goroutines, etc.).
+//
+// pkg/transport re-exports `PersistentTransports = spec.PersistentTransports`
+// so existing callers compile unchanged.
+package spec
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// PersistentTransports is a persistent-transport description: the
+// pinning entry that tells the visor "always keep a transport open
+// to peer PK over network type NetType". Pure data; pkg/transport's
+// manager reads these at init and on-config-reload to drive its
+// reconciliation loop.
+type PersistentTransports struct {
+	PK      cipher.PubKey `json:"pk"`
+	NetType types.Type    `json:"type"`
+}

--- a/pkg/visor/visorconfig/args.go
+++ b/pkg/visor/visorconfig/args.go
@@ -16,14 +16,17 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/skycoin/skywire/pkg/app/appserver"
+	appspec "github.com/skycoin/skywire/pkg/app/appserver/spec"
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
-// appsList wraps []appserver.AppConfig so the JSON I/O layer can
+// appsList wraps []appspec.AppConfig so the JSON I/O layer can
 // rewrite Args between string and []string without touching the
-// shared appserver type.
-type appsList []appserver.AppConfig
+// shared appserver type. Uses the WASM-clean spec subpackage so
+// pkg/visor/visorconfig stays compilable under GOOS=js — the type
+// is identical to appspec.AppConfig (alias) so callers that read
+// the on-disk config through this package keep working unchanged.
+type appsList []appspec.AppConfig
 
 // MarshalJSON emits each AppConfig's Args as a shell-quoted string.
 func (a appsList) MarshalJSON() ([]byte, error) {
@@ -41,7 +44,7 @@ func (a *appsList) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	out := make([]appserver.AppConfig, len(raw))
+	out := make([]appspec.AppConfig, len(raw))
 	for i, r := range raw {
 		cfg, err := unmarshalAppConfig(r)
 		if err != nil {
@@ -53,7 +56,7 @@ func (a *appsList) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// appConfigOnDisk mirrors appserver.AppConfig with Args as a string.
+// appConfigOnDisk mirrors appspec.AppConfig with Args as a string.
 // Only used at the JSON boundary.
 type appConfigOnDisk struct {
 	Name         string       `json:"name"`
@@ -68,7 +71,7 @@ type appConfigOnDisk struct {
 	LauncherMode string       `json:"launcher_mode,omitempty"`
 }
 
-func toOnDisk(c appserver.AppConfig) appConfigOnDisk {
+func toOnDisk(c appspec.AppConfig) appConfigOnDisk {
 	return appConfigOnDisk{
 		Name:         c.Name,
 		Binary:       c.Binary,
@@ -83,15 +86,15 @@ func toOnDisk(c appserver.AppConfig) appConfigOnDisk {
 	}
 }
 
-func unmarshalAppConfig(raw json.RawMessage) (appserver.AppConfig, error) {
+func unmarshalAppConfig(raw json.RawMessage) (appspec.AppConfig, error) {
 	// Shadow AppConfig.Args with a RawMessage at the outer scope so
 	// we can dispatch on its JSON shape (string vs array).
 	var pre struct {
-		appserver.AppConfig
+		appspec.AppConfig
 		Args json.RawMessage `json:"args,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &pre); err != nil {
-		return appserver.AppConfig{}, err
+		return appspec.AppConfig{}, err
 	}
 	cfg := pre.AppConfig
 	if len(pre.Args) == 0 {
@@ -104,13 +107,13 @@ func unmarshalAppConfig(raw json.RawMessage) (appserver.AppConfig, error) {
 	if err := json.Unmarshal(pre.Args, &s); err == nil {
 		parsed, perr := splitArgs(s)
 		if perr != nil {
-			return appserver.AppConfig{}, fmt.Errorf("parsing args string: %w", perr)
+			return appspec.AppConfig{}, fmt.Errorf("parsing args string: %w", perr)
 		}
 		cfg.Args = parsed
 		return cfg, nil
 	}
 	if err := json.Unmarshal(pre.Args, &cfg.Args); err != nil {
-		return appserver.AppConfig{}, fmt.Errorf("args must be string or array: %w", err)
+		return appspec.AppConfig{}, fmt.Errorf("args must be string or array: %w", err)
 	}
 	return cfg, nil
 }

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
-	"github.com/skycoin/skywire/pkg/dmsgc"
+	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/skyenv"
-	"github.com/skycoin/skywire/pkg/transport/network"
+	tnspec "github.com/skycoin/skywire/pkg/transport/network/spec"
 )
 
 // MakeBaseConfig returns a visor config with 'enforced' fields only.
@@ -37,7 +36,7 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 	if common != nil {
 		conf.Common = common
 	}
-	conf.Dmsg = &dmsgc.DmsgConfig{
+	conf.Dmsg = &dmsgspec.DmsgConfig{
 		Discovery:            services.DmsgDiscovery,
 		SessionsCount:        1,
 		Servers:              []*disc.Entry{},
@@ -90,10 +89,10 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 	conf.Dmsgpty = &Dmsgpty{
 		DmsgPort: skyenv.DmsgPtyPort,
 		CLINet:   skyenv.DmsgPtyCLINet,
-		CLIAddr:  dmsgpty.DefaultCLIAddr(),
+		CLIAddr:  defaultDmsgPtyCLIAddr(),
 	}
 
-	conf.STCP = &network.STCPConfig{
+	conf.STCP = &tnspec.STCPConfig{
 		ListeningAddress: skyenv.STCPAddr,
 		PKTable:          nil,
 	}
@@ -133,6 +132,17 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		conf.GeoIP = deployment.Prod.GeoIP
 	}
 	return conf
+}
+
+// defaultDmsgPtyCLIAddr is the conventional unix-style temp-socket
+// path the visor's dmsgpty Host listens on. Hardcoded here rather
+// than calling pkg/dmsg/dmsgpty.DefaultCLIAddr so config.go stays
+// WASM-clean (dmsgpty's pty.go pulls in syscall.TIOCGWINSZ + friends
+// that don't exist under GOOS=js). Operators on Windows get the
+// right path written by cmd/skywire-cli/commands/config/gen.go,
+// which still calls dmsgpty.DefaultCLIAddr() in its native build.
+func defaultDmsgPtyCLIAddr() string {
+	return "/tmp/dmsgpty.sock"
 }
 
 // DmsgHTTPServers struct use to unmarshal dmsghttp file

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -2,18 +2,12 @@
 package visorconfig
 
 import (
-	"fmt"
-	"math/rand"
-	"strings"
 	"sync"
 
-	"github.com/skycoin/skywire/pkg/app/appserver"
-	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/dmsgc"
-	"github.com/skycoin/skywire/pkg/routing"
-	"github.com/skycoin/skywire/pkg/transport"
-	"github.com/skycoin/skywire/pkg/transport/network"
+	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
+	tnspec "github.com/skycoin/skywire/pkg/transport/network/spec"
+	tspec "github.com/skycoin/skywire/pkg/transport/spec"
 )
 
 // V1 is visor config
@@ -21,7 +15,7 @@ type V1 struct {
 	*Common
 	mu sync.RWMutex
 
-	Dmsg          *dmsgc.DmsgConfig    `json:"dmsg"`
+	Dmsg          *dmsgspec.DmsgConfig `json:"dmsg"`
 	Dmsgpty       *Dmsgpty             `json:"dmsgpty,omitempty"`
 	Dmsgscp       *Dmsgscp             `json:"dmsgscp,omitempty"`
 	UIServer      *UIServer            `json:"ui_server,omitempty"`
@@ -30,7 +24,7 @@ type V1 struct {
 	SkynetWeb     *SkynetWebConfig     `json:"skynet_web,omitempty"`
 	SkymailBridge *SkymailBridgeConfig `json:"skymail_bridge,omitempty"`
 	Rewards       *RewardsConfig       `json:"rewards,omitempty"`
-	STCP          *network.STCPConfig  `json:"skywire-tcp,omitempty"`
+	STCP          *tnspec.STCPConfig   `json:"skywire-tcp,omitempty"`
 	Transport     *Transport           `json:"transport"`
 	Routing       *Routing             `json:"routing"`
 	UptimeTracker *UptimeTracker       `json:"uptime_tracker,omitempty"`
@@ -57,7 +51,7 @@ type V1 struct {
 	IsPublic             bool                             `json:"is_public"`
 	PublicVisorConfig    *PublicVisorConfig               `json:"public_visor,omitempty"`
 	GeoIP                string                           `json:"geoip"`
-	PersistentTransports []transport.PersistentTransports `json:"persistent_transports"`
+	PersistentTransports []tspec.PersistentTransports `json:"persistent_transports"`
 	ConfService          string                           `json:"conf_service,omitempty"`      // HTTP URL for config bootstrap service
 	ConfServiceDmsg      string                           `json:"conf_service_dmsg,omitempty"` // DMSG URL for config bootstrap service
 	// SurveyClientSK is the CLI-side identity used by
@@ -449,246 +443,6 @@ func (v1 *V1) Flush() error {
 	return v1.Common.flush(v1)
 }
 
-// UpdateAppAutostart modifies a single app's autostart value within the config and also the given
-//
-// The updated config gets flushed to file if there are any changes.
-// func (v1 *V1) UpdateAppAutostart(appName string, autoStart bool) error {
-func (v1 *V1) UpdateAppAutostart(launch *launcher.AppLauncher, appName string, autoStart bool) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-	conf := v1.Launcher
-	changed := false
-	for i := range conf.Apps {
-		if conf.Apps[i].Name == appName {
-			conf.Apps[i].AutoStart = autoStart
-			changed = true
-			break
-		}
-	}
-	if !changed {
-		return nil
-	}
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// UpdateAppArg updates the cli flag of the specified app config and also within the
-// The updated config gets flushed to file if there are any changes.
-// func (v1 *V1) UpdateAppArg(appName, argName string, value interface{}) error {
-func (v1 *V1) UpdateAppArg(launch *launcher.AppLauncher, appName, argName string, value interface{}) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-
-	var configChanged bool
-	switch val := value.(type) {
-	case string:
-		configChanged = updateStringArg(conf, appName, argName, val)
-	case bool:
-		configChanged = updateBoolArg(conf, appName, argName, val)
-	default:
-		return fmt.Errorf("invalid arg type %T", value)
-	}
-
-	if !configChanged {
-		return nil
-	}
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// UpdateAppArgBatch updates the cli flag of the specified app config and also within the
-// The updated config gets flushed to file if there are any changes.
-// func (v1 *V1) UpdateAppArg(appName, argName string, value interface{}) error {
-func (v1 *V1) UpdateAppArgBatch(launch *launcher.AppLauncher, appName string, args map[string]any) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-
-	var configChanged bool
-
-	for arg, value := range args {
-		switch val := value.(type) {
-		case string:
-			configChanged = updateStringArg(conf, appName, arg, val)
-		case bool:
-			configChanged = updateBoolArg(conf, appName, arg, val)
-		default:
-			return fmt.Errorf("invalid arg type %T", value)
-		}
-	}
-
-	if !configChanged {
-		return nil
-	}
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// UpdateAppEnv sets, replaces, or deletes a KEY=value entry on the
-// named app's Env list. An empty value deletes the entry. The
-// updated config gets flushed to file if anything changed and the
-// launcher is reset so the new env takes effect on the next start.
-func (v1 *V1) UpdateAppEnv(launch *launcher.AppLauncher, appName, key, value string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	if key == "" {
-		return fmt.Errorf("env key must not be empty")
-	}
-
-	conf := v1.Launcher
-	configChanged := updateEnvEntry(conf, appName, key, value)
-	if !configChanged {
-		return nil
-	}
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// UpdateAppEnvBatch is the multi-key counterpart to UpdateAppEnv.
-// One config flush + one launcher reset for the whole batch. An
-// empty map value deletes that key.
-func (v1 *V1) UpdateAppEnvBatch(launch *launcher.AppLauncher, appName string, env map[string]string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-	configChanged := false
-	for key, value := range env {
-		if key == "" {
-			return fmt.Errorf("env key must not be empty")
-		}
-		if updateEnvEntry(conf, appName, key, value) {
-			configChanged = true
-		}
-	}
-	if !configChanged {
-		return nil
-	}
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// updateEnvEntry mutates conf.Apps[i].Env in place: replaces the
-// entry whose KEY= prefix matches `key`, deletes it if value is
-// empty, or appends a new KEY=value entry. Returns true iff the
-// app's Env actually changed (so the caller knows whether to flush).
-func updateEnvEntry(conf *Launcher, appName, key, value string) bool {
-	prefix := key + "="
-	desired := key + "=" + value
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-		// Look for an existing entry with this key.
-		for j := range conf.Apps[i].Env {
-			if !strings.HasPrefix(conf.Apps[i].Env[j], prefix) {
-				continue
-			}
-			if value == "" {
-				conf.Apps[i].Env = append(conf.Apps[i].Env[:j], conf.Apps[i].Env[j+1:]...)
-				return true
-			}
-			if conf.Apps[i].Env[j] == desired {
-				return false
-			}
-			conf.Apps[i].Env[j] = desired
-			return true
-		}
-		// No existing entry; nothing to delete.
-		if value == "" {
-			return false
-		}
-		conf.Apps[i].Env = append(conf.Apps[i].Env, desired)
-		return true
-	}
-	// App not found — silently no-op, mirrors UpdateAppArg's behavior
-	// (it iterates and just doesn't match).
-	return false
-}
-
-// UpdateAppPort update app port for communicat with visor
-func (v1 *V1) UpdateAppPort(launch *launcher.AppLauncher, appName string, port uint16) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-	requestPort := routing.Port(port)
-	conf := v1.Launcher
-	busyPorts := map[routing.Port]bool{}
-	appExist := false
-	for ind, app := range conf.Apps {
-		busyPorts[app.Port] = true
-		if app.Name == appName {
-			appExist = true
-			if requestPort == app.Port {
-				break
-			}
-			if _, ok := busyPorts[requestPort]; ok && requestPort != app.Port {
-				return fmt.Errorf("requested port is busy")
-			}
-			conf.Apps[ind].Port = requestPort
-		}
-	}
-	if !appExist {
-		return fmt.Errorf("app not available")
-	}
-
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// DeleteAppArg Delete entire of args of a custom app
-func (v1 *V1) DeleteAppArg(launch *launcher.AppLauncher, appName string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-
-	configChanged := deleteAppArg(conf, appName)
-
-	if !configChanged {
-		return nil
-	}
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
 
 // UpdateMinHops updates min_hops config
 func (v1 *V1) UpdateMinHops(hops uint16) error {
@@ -700,7 +454,7 @@ func (v1 *V1) UpdateMinHops(hops uint16) error {
 }
 
 // UpdatePersistentTransports updates persistent_transports in config
-func (v1 *V1) UpdatePersistentTransports(pTps []transport.PersistentTransports) error {
+func (v1 *V1) UpdatePersistentTransports(pTps []tspec.PersistentTransports) error {
 	v1.mu.Lock()
 	v1.PersistentTransports = pTps
 	v1.mu.Unlock()
@@ -709,7 +463,7 @@ func (v1 *V1) UpdatePersistentTransports(pTps []transport.PersistentTransports) 
 }
 
 // GetPersistentTransports gets persistent_transports from config
-func (v1 *V1) GetPersistentTransports() ([]transport.PersistentTransports, error) {
+func (v1 *V1) GetPersistentTransports() ([]tspec.PersistentTransports, error) {
 	v1.mu.Lock()
 	defer v1.mu.Unlock()
 	return v1.PersistentTransports, nil
@@ -755,280 +509,6 @@ func (v1 *V1) GetCalculateRoutes() bool {
 	defer v1.mu.RUnlock()
 	return v1.Routing.CalculateRoutes
 }
-
-// AddAppConfig add new config to apps if name was not same
-func (v1 *V1) AddAppConfig(launch *launcher.AppLauncher, appName, binaryName string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-	busyPorts := map[routing.Port]bool{}
-	for _, app := range conf.Apps {
-		busyPorts[app.Port] = true
-		if app.Name == appName {
-			return fmt.Errorf("the app exist")
-		}
-	}
-	var randomNumber int
-	for {
-		minn := 10
-		maxx := 99
-		randomNumber = rand.Intn(maxx-minn+1) + minn             //nolint: gosec
-		if _, ok := busyPorts[routing.Port(randomNumber)]; !ok { //nolint: gosec
-			break
-		}
-	}
-
-	conf.Apps = append(conf.Apps, appserver.AppConfig{Name: appName, Binary: binaryName, Port: routing.Port(randomNumber)}) //nolint: gosec
-
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// UpdateAppArgsFull replaces the entire Args slice on the named app.
-// Used by the universal app-settings panel where the operator edits
-// the args as a shell-string and we parse + replace; per-flag
-// UpdateAppArg is for targeted CLI surface, not whole-form save.
-func (v1 *V1) UpdateAppArgsFull(launch *launcher.AppLauncher, appName string, args []string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-		conf.Apps[i].Args = args
-		launch.ResetConfig(launcher.AppLauncherConfig{
-			VisorPK:       v1.PK,
-			Apps:          conf.Apps,
-			ServerAddr:    conf.ServerAddr,
-			DisplayNodeIP: conf.DisplayNodeIP,
-		})
-		return v1.flush(v1)
-	}
-	return fmt.Errorf("app %q not found in launcher config", appName)
-}
-
-// UpdateAppEnvFull replaces the entire Env slice on the named app.
-// Counterpart to UpdateAppArgsFull for the env list. Per-key
-// UpdateAppEnv is still available for targeted mutation; this
-// method is for whole-form save where deletion of keys not in the
-// new list is the intended semantics.
-func (v1 *V1) UpdateAppEnvFull(launch *launcher.AppLauncher, appName string, env []string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-		conf.Apps[i].Env = env
-		launch.ResetConfig(launcher.AppLauncherConfig{
-			VisorPK:       v1.PK,
-			Apps:          conf.Apps,
-			ServerAddr:    conf.ServerAddr,
-			DisplayNodeIP: conf.DisplayNodeIP,
-		})
-		return v1.flush(v1)
-	}
-	return fmt.Errorf("app %q not found in launcher config", appName)
-}
-
-// UpdateAppLauncherMode persists the launcher-mode preference for
-// an app entry. Empty string clears the override (visor default).
-// Validated values: "", "internal", "external".
-func (v1 *V1) UpdateAppLauncherMode(launch *launcher.AppLauncher, appName, mode string) error {
-	switch mode {
-	case "", "internal", "external":
-	default:
-		return fmt.Errorf("invalid launcher mode %q (must be empty, 'internal', or 'external')", mode)
-	}
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-		conf.Apps[i].LauncherMode = mode
-		launch.ResetConfig(launcher.AppLauncherConfig{
-			VisorPK:       v1.PK,
-			Apps:          conf.Apps,
-			ServerAddr:    conf.ServerAddr,
-			DisplayNodeIP: conf.DisplayNodeIP,
-		})
-		return v1.flush(v1)
-	}
-	return fmt.Errorf("app %q not found in launcher config", appName)
-}
-
-// DeleteAppConfig removes an app entry from the launcher config and
-// flushes the change. The caller is responsible for stopping the
-// running proc (if any) before calling this — V1 doesn't own the
-// procmanager. Returns an error if the named app isn't in the
-// config so accidental no-ops surface to the operator.
-func (v1 *V1) DeleteAppConfig(launch *launcher.AppLauncher, appName string) error {
-	v1.mu.Lock()
-	defer v1.mu.Unlock()
-
-	conf := v1.Launcher
-	idx := -1
-	for i, app := range conf.Apps {
-		if app.Name == appName {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
-		return fmt.Errorf("app %q not found in launcher config", appName)
-	}
-	conf.Apps = append(conf.Apps[:idx], conf.Apps[idx+1:]...)
-
-	launch.ResetConfig(launcher.AppLauncherConfig{
-		VisorPK:       v1.PK,
-		Apps:          conf.Apps,
-		ServerAddr:    conf.ServerAddr,
-		DisplayNodeIP: conf.DisplayNodeIP,
-	})
-	return v1.flush(v1)
-}
-
-// updateStringArg updates the cli non-boolean flag of the specified app config and also within the
-// It removes argName from app args if value is an empty string.
-// The updated config gets flushed to file if there are any changes.
-func updateStringArg(conf *Launcher, appName, argName, value string) bool {
-	configChanged := false
-
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-
-		configChanged = true
-
-		argChanged := false
-		l := len(conf.Apps[i].Args)
-		for j := 0; j < l; j++ {
-			equalArgName := conf.Apps[i].Args[j] == argName && j+1 < len(conf.Apps[i].Args)
-			if !equalArgName {
-				continue
-			}
-
-			if value == "" {
-				conf.Apps[i].Args = append(conf.Apps[i].Args[:j], conf.Apps[i].Args[j+2:]...)
-				j-- //nolint:ineffassign
-			} else {
-				conf.Apps[i].Args[j+1] = value
-			}
-
-			argChanged = true
-			break
-		}
-
-		if !argChanged && value != "" {
-			conf.Apps[i].Args = append(conf.Apps[i].Args, argName, value)
-		}
-
-		break
-	}
-
-	return configChanged
-}
-
-// updateBoolArg updates the cli boolean flag of the specified app config and also within the
-// All flag names and values are formatted as "-name=value" to allow arbitrary values with respect to different
-// possible default values.
-// The updated config gets flushed to file if there are any changes.
-func updateBoolArg(conf *Launcher, appName, argName string, value bool) bool {
-	const argFmt = "%s=%v"
-
-	configChanged := false
-
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-
-		// we format it to have a single dash, just to unify representation
-		fmtedArgName := argName
-		if argName[1] == '-' {
-			fmtedArgName = fmtedArgName[1:]
-		}
-
-		arg := fmt.Sprintf(argFmt, fmtedArgName, value)
-
-		configChanged = true
-
-		argChanged := false
-		for j := 0; j < len(conf.Apps[i].Args); j++ {
-			// there shouldn't be such values if config is modified automatically,
-			// but might happen if done manually, so we avoid further panic with this check
-			if len(conf.Apps[i].Args[j]) < 2 {
-				continue
-			}
-
-			equalArgName := conf.Apps[i].Args[j][1] != '-' && strings.HasPrefix(conf.Apps[i].Args[j], fmtedArgName)
-			if conf.Apps[i].Args[j][1] == '-' {
-				equalArgName = strings.HasPrefix(conf.Apps[i].Args[j], "-"+fmtedArgName)
-			}
-
-			if !equalArgName {
-				continue
-			}
-
-			// check next value. currently we store value along with the flag name in a single string,
-			// but there're may be some broken configs because of the previous functionality, so we
-			// make our best effort to fix this on the go
-			if (j + 1) < len(conf.Apps[i].Args) {
-				// bool value shouldn't be present there, so we remove it, if it is
-				if conf.Apps[i].Args[j+1] == "true" || conf.Apps[i].Args[j+1] == "false" {
-					if (j + 2) < len(conf.Apps[i].Args) {
-						conf.Apps[i].Args = append(conf.Apps[i].Args[:j+1], conf.Apps[i].Args[j+2:]...)
-					} else {
-						conf.Apps[i].Args = conf.Apps[i].Args[:j+1]
-					}
-				}
-			}
-
-			conf.Apps[i].Args[j] = arg
-			argChanged = true
-
-			break
-		}
-
-		if !argChanged {
-			conf.Apps[i].Args = append(conf.Apps[i].Args, arg)
-		}
-
-		break
-	}
-
-	return configChanged
-}
-
-// deleteAppArg delete all args of an app by its name
-func deleteAppArg(conf *Launcher, appName string) bool {
-	var configChanged bool
-	for i := range conf.Apps {
-		if conf.Apps[i].Name != appName {
-			continue
-		}
-
-		conf.Apps[i].Args = []string{}
-		configChanged = true
-		break
-	}
-	return configChanged
-}
-
 // mergePubKeys returns the union of the given public key slices, preserving
 // the order of the first slice and appending any unique keys from the second.
 // nil slices are handled transparently.

--- a/pkg/visor/visorconfig/v1_runtime.go
+++ b/pkg/visor/visorconfig/v1_runtime.go
@@ -1,0 +1,542 @@
+// Package visorconfig pkg/visor/visorconfig/v1_runtime.go
+//
+// Non-WASM half of V1's mutator surface. Every method here takes a
+// *launcher.AppLauncher (the running app launcher whose ResetConfig
+// gets called after each mutation), which would drag in
+// pkg/app/launcher's operational deps (process management, bbolt
+// app-state store, james-barrow/golang-ipc) — none of which compile
+// under GOOS=js.
+//
+// This file is build-tag-gated to !js so v1.go (the type
+// definitions + pure mutators that callers compose into a V1) can
+// compile under WASM for in-browser config-generation tooling (the
+// apt-repo install page). The visor binary builds native and
+// includes both files; the WASM build sees only v1.go.
+
+//go:build !js
+
+package visorconfig
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/app/launcher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// UpdateAppAutostart modifies a single app's autostart value within the config and also the given
+//
+// The updated config gets flushed to file if there are any changes.
+// func (v1 *V1) UpdateAppAutostart(appName string, autoStart bool) error {
+func (v1 *V1) UpdateAppAutostart(launch *launcher.AppLauncher, appName string, autoStart bool) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+	conf := v1.Launcher
+	changed := false
+	for i := range conf.Apps {
+		if conf.Apps[i].Name == appName {
+			conf.Apps[i].AutoStart = autoStart
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return nil
+	}
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// UpdateAppArg updates the cli flag of the specified app config and also within the
+// The updated config gets flushed to file if there are any changes.
+// func (v1 *V1) UpdateAppArg(appName, argName string, value interface{}) error {
+func (v1 *V1) UpdateAppArg(launch *launcher.AppLauncher, appName, argName string, value interface{}) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+
+	var configChanged bool
+	switch val := value.(type) {
+	case string:
+		configChanged = updateStringArg(conf, appName, argName, val)
+	case bool:
+		configChanged = updateBoolArg(conf, appName, argName, val)
+	default:
+		return fmt.Errorf("invalid arg type %T", value)
+	}
+
+	if !configChanged {
+		return nil
+	}
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// UpdateAppArgBatch updates the cli flag of the specified app config and also within the
+// The updated config gets flushed to file if there are any changes.
+// func (v1 *V1) UpdateAppArg(appName, argName string, value interface{}) error {
+func (v1 *V1) UpdateAppArgBatch(launch *launcher.AppLauncher, appName string, args map[string]any) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+
+	var configChanged bool
+
+	for arg, value := range args {
+		switch val := value.(type) {
+		case string:
+			configChanged = updateStringArg(conf, appName, arg, val)
+		case bool:
+			configChanged = updateBoolArg(conf, appName, arg, val)
+		default:
+			return fmt.Errorf("invalid arg type %T", value)
+		}
+	}
+
+	if !configChanged {
+		return nil
+	}
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// UpdateAppEnv sets, replaces, or deletes a KEY=value entry on the
+// named app's Env list. An empty value deletes the entry. The
+// updated config gets flushed to file if anything changed and the
+// launcher is reset so the new env takes effect on the next start.
+func (v1 *V1) UpdateAppEnv(launch *launcher.AppLauncher, appName, key, value string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	if key == "" {
+		return fmt.Errorf("env key must not be empty")
+	}
+
+	conf := v1.Launcher
+	configChanged := updateEnvEntry(conf, appName, key, value)
+	if !configChanged {
+		return nil
+	}
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// UpdateAppEnvBatch is the multi-key counterpart to UpdateAppEnv.
+// One config flush + one launcher reset for the whole batch. An
+// empty map value deletes that key.
+func (v1 *V1) UpdateAppEnvBatch(launch *launcher.AppLauncher, appName string, env map[string]string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	configChanged := false
+	for key, value := range env {
+		if key == "" {
+			return fmt.Errorf("env key must not be empty")
+		}
+		if updateEnvEntry(conf, appName, key, value) {
+			configChanged = true
+		}
+	}
+	if !configChanged {
+		return nil
+	}
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// updateEnvEntry mutates conf.Apps[i].Env in place: replaces the
+// entry whose KEY= prefix matches `key`, deletes it if value is
+// empty, or appends a new KEY=value entry. Returns true iff the
+// app's Env actually changed (so the caller knows whether to flush).
+func updateEnvEntry(conf *Launcher, appName, key, value string) bool {
+	prefix := key + "="
+	desired := key + "=" + value
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+		// Look for an existing entry with this key.
+		for j := range conf.Apps[i].Env {
+			if !strings.HasPrefix(conf.Apps[i].Env[j], prefix) {
+				continue
+			}
+			if value == "" {
+				conf.Apps[i].Env = append(conf.Apps[i].Env[:j], conf.Apps[i].Env[j+1:]...)
+				return true
+			}
+			if conf.Apps[i].Env[j] == desired {
+				return false
+			}
+			conf.Apps[i].Env[j] = desired
+			return true
+		}
+		// No existing entry; nothing to delete.
+		if value == "" {
+			return false
+		}
+		conf.Apps[i].Env = append(conf.Apps[i].Env, desired)
+		return true
+	}
+	// App not found — silently no-op, mirrors UpdateAppArg's behavior
+	// (it iterates and just doesn't match).
+	return false
+}
+
+// UpdateAppPort update app port for communicat with visor
+func (v1 *V1) UpdateAppPort(launch *launcher.AppLauncher, appName string, port uint16) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+	requestPort := routing.Port(port)
+	conf := v1.Launcher
+	busyPorts := map[routing.Port]bool{}
+	appExist := false
+	for ind, app := range conf.Apps {
+		busyPorts[app.Port] = true
+		if app.Name == appName {
+			appExist = true
+			if requestPort == app.Port {
+				break
+			}
+			if _, ok := busyPorts[requestPort]; ok && requestPort != app.Port {
+				return fmt.Errorf("requested port is busy")
+			}
+			conf.Apps[ind].Port = requestPort
+		}
+	}
+	if !appExist {
+		return fmt.Errorf("app not available")
+	}
+
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// DeleteAppArg Delete entire of args of a custom app
+func (v1 *V1) DeleteAppArg(launch *launcher.AppLauncher, appName string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+
+	configChanged := deleteAppArg(conf, appName)
+
+	if !configChanged {
+		return nil
+	}
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// AddAppConfig add new config to apps if name was not same
+func (v1 *V1) AddAppConfig(launch *launcher.AppLauncher, appName, binaryName string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	busyPorts := map[routing.Port]bool{}
+	for _, app := range conf.Apps {
+		busyPorts[app.Port] = true
+		if app.Name == appName {
+			return fmt.Errorf("the app exist")
+		}
+	}
+	var randomNumber int
+	for {
+		minn := 10
+		maxx := 99
+		randomNumber = rand.Intn(maxx-minn+1) + minn             //nolint: gosec
+		if _, ok := busyPorts[routing.Port(randomNumber)]; !ok { //nolint: gosec
+			break
+		}
+	}
+
+	conf.Apps = append(conf.Apps, appserver.AppConfig{Name: appName, Binary: binaryName, Port: routing.Port(randomNumber)}) //nolint: gosec
+
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// UpdateAppArgsFull replaces the entire Args slice on the named app.
+// Used by the universal app-settings panel where the operator edits
+// the args as a shell-string and we parse + replace; per-flag
+// UpdateAppArg is for targeted CLI surface, not whole-form save.
+func (v1 *V1) UpdateAppArgsFull(launch *launcher.AppLauncher, appName string, args []string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+		conf.Apps[i].Args = args
+		launch.ResetConfig(launcher.AppLauncherConfig{
+			VisorPK:       v1.PK,
+			Apps:          conf.Apps,
+			ServerAddr:    conf.ServerAddr,
+			DisplayNodeIP: conf.DisplayNodeIP,
+		})
+		return v1.flush(v1)
+	}
+	return fmt.Errorf("app %q not found in launcher config", appName)
+}
+
+// UpdateAppEnvFull replaces the entire Env slice on the named app.
+// Counterpart to UpdateAppArgsFull for the env list. Per-key
+// UpdateAppEnv is still available for targeted mutation; this
+// method is for whole-form save where deletion of keys not in the
+// new list is the intended semantics.
+func (v1 *V1) UpdateAppEnvFull(launch *launcher.AppLauncher, appName string, env []string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+		conf.Apps[i].Env = env
+		launch.ResetConfig(launcher.AppLauncherConfig{
+			VisorPK:       v1.PK,
+			Apps:          conf.Apps,
+			ServerAddr:    conf.ServerAddr,
+			DisplayNodeIP: conf.DisplayNodeIP,
+		})
+		return v1.flush(v1)
+	}
+	return fmt.Errorf("app %q not found in launcher config", appName)
+}
+
+// UpdateAppLauncherMode persists the launcher-mode preference for
+// an app entry. Empty string clears the override (visor default).
+// Validated values: "", "internal", "external".
+func (v1 *V1) UpdateAppLauncherMode(launch *launcher.AppLauncher, appName, mode string) error {
+	switch mode {
+	case "", "internal", "external":
+	default:
+		return fmt.Errorf("invalid launcher mode %q (must be empty, 'internal', or 'external')", mode)
+	}
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+		conf.Apps[i].LauncherMode = mode
+		launch.ResetConfig(launcher.AppLauncherConfig{
+			VisorPK:       v1.PK,
+			Apps:          conf.Apps,
+			ServerAddr:    conf.ServerAddr,
+			DisplayNodeIP: conf.DisplayNodeIP,
+		})
+		return v1.flush(v1)
+	}
+	return fmt.Errorf("app %q not found in launcher config", appName)
+}
+
+// DeleteAppConfig removes an app entry from the launcher config and
+// flushes the change. The caller is responsible for stopping the
+// running proc (if any) before calling this — V1 doesn't own the
+// procmanager. Returns an error if the named app isn't in the
+// config so accidental no-ops surface to the operator.
+func (v1 *V1) DeleteAppConfig(launch *launcher.AppLauncher, appName string) error {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+
+	conf := v1.Launcher
+	idx := -1
+	for i, app := range conf.Apps {
+		if app.Name == appName {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("app %q not found in launcher config", appName)
+	}
+	conf.Apps = append(conf.Apps[:idx], conf.Apps[idx+1:]...)
+
+	launch.ResetConfig(launcher.AppLauncherConfig{
+		VisorPK:       v1.PK,
+		Apps:          conf.Apps,
+		ServerAddr:    conf.ServerAddr,
+		DisplayNodeIP: conf.DisplayNodeIP,
+	})
+	return v1.flush(v1)
+}
+
+// updateStringArg updates the cli non-boolean flag of the specified app config and also within the
+// It removes argName from app args if value is an empty string.
+// The updated config gets flushed to file if there are any changes.
+func updateStringArg(conf *Launcher, appName, argName, value string) bool {
+	configChanged := false
+
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+
+		configChanged = true
+
+		argChanged := false
+		l := len(conf.Apps[i].Args)
+		for j := 0; j < l; j++ {
+			equalArgName := conf.Apps[i].Args[j] == argName && j+1 < len(conf.Apps[i].Args)
+			if !equalArgName {
+				continue
+			}
+
+			if value == "" {
+				conf.Apps[i].Args = append(conf.Apps[i].Args[:j], conf.Apps[i].Args[j+2:]...)
+				j-- //nolint:ineffassign
+			} else {
+				conf.Apps[i].Args[j+1] = value
+			}
+
+			argChanged = true
+			break
+		}
+
+		if !argChanged && value != "" {
+			conf.Apps[i].Args = append(conf.Apps[i].Args, argName, value)
+		}
+
+		break
+	}
+
+	return configChanged
+}
+
+// updateBoolArg updates the cli boolean flag of the specified app config and also within the
+// All flag names and values are formatted as "-name=value" to allow arbitrary values with respect to different
+// possible default values.
+// The updated config gets flushed to file if there are any changes.
+func updateBoolArg(conf *Launcher, appName, argName string, value bool) bool {
+	const argFmt = "%s=%v"
+
+	configChanged := false
+
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+
+		// we format it to have a single dash, just to unify representation
+		fmtedArgName := argName
+		if argName[1] == '-' {
+			fmtedArgName = fmtedArgName[1:]
+		}
+
+		arg := fmt.Sprintf(argFmt, fmtedArgName, value)
+
+		configChanged = true
+
+		argChanged := false
+		for j := 0; j < len(conf.Apps[i].Args); j++ {
+			// there shouldn't be such values if config is modified automatically,
+			// but might happen if done manually, so we avoid further panic with this check
+			if len(conf.Apps[i].Args[j]) < 2 {
+				continue
+			}
+
+			equalArgName := conf.Apps[i].Args[j][1] != '-' && strings.HasPrefix(conf.Apps[i].Args[j], fmtedArgName)
+			if conf.Apps[i].Args[j][1] == '-' {
+				equalArgName = strings.HasPrefix(conf.Apps[i].Args[j], "-"+fmtedArgName)
+			}
+
+			if !equalArgName {
+				continue
+			}
+
+			// check next value. currently we store value along with the flag name in a single string,
+			// but there're may be some broken configs because of the previous functionality, so we
+			// make our best effort to fix this on the go
+			if (j + 1) < len(conf.Apps[i].Args) {
+				// bool value shouldn't be present there, so we remove it, if it is
+				if conf.Apps[i].Args[j+1] == "true" || conf.Apps[i].Args[j+1] == "false" {
+					if (j + 2) < len(conf.Apps[i].Args) {
+						conf.Apps[i].Args = append(conf.Apps[i].Args[:j+1], conf.Apps[i].Args[j+2:]...)
+					} else {
+						conf.Apps[i].Args = conf.Apps[i].Args[:j+1]
+					}
+				}
+			}
+
+			conf.Apps[i].Args[j] = arg
+			argChanged = true
+
+			break
+		}
+
+		if !argChanged {
+			conf.Apps[i].Args = append(conf.Apps[i].Args, arg)
+		}
+
+		break
+	}
+
+	return configChanged
+}
+
+// deleteAppArg delete all args of an app by its name
+func deleteAppArg(conf *Launcher, appName string) bool {
+	var configChanged bool
+	for i := range conf.Apps {
+		if conf.Apps[i].Name != appName {
+			continue
+		}
+
+		conf.Apps[i].Args = []string{}
+		configChanged = true
+		break
+	}
+	return configChanged
+}

--- a/pkg/visor/visorconfig/values.go
+++ b/pkg/visor/visorconfig/values.go
@@ -3,19 +3,18 @@ package visorconfig
 
 import (
 	"os"
-	"os/exec"
-	"strings"
-
-	"github.com/bitfield/script"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
 var (
-	// DmsgHTTPPort Listening port for dmsghttp logserver.
-	DmsgHTTPPort = dmsg.DefaultDmsgHTTPPort
+	// DmsgHTTPPort Listening port for dmsghttp logserver. Set to
+	// pkg/dmsg/dmsg.DefaultDmsgHTTPPort's value (80). Hardcoded here
+	// rather than imported so values.go stays WASM-clean — the dmsg
+	// client package pulls in unrelated heavy deps that the
+	// in-browser config-generator doesn't need.
+	DmsgHTTPPort = uint16(80)
 
 	// PublicVisorMaxTransports is the max transport count before deregistering
 	PublicVisorMaxTransports = 1000
@@ -26,22 +25,15 @@ func SkywireConfig() string {
 	return skyenv.SkywirePath + "/" + skyenv.ConfigJSON
 }
 
-// Version gets the version of the installation for the config
+// Version gets the version of the installation for the config.
+//
+// The runtime version-discovery path (git-describe fallback when
+// buildinfo.Version() returns "unknown") lives in values_native.go
+// behind a !js build tag — it shells out to `git`, which is
+// nonsensical in a browser WASM context. Under js the returned value
+// is just buildinfo.Version() with no fallback.
 func Version() string {
-	u := buildinfo.Version()
-	v := u
-	if u == "unknown" {
-		//check for .git folder for versioning
-		if _, err := os.Stat(".git"); err == nil {
-			//attempt to version from git sources
-			if _, err = exec.LookPath("git"); err == nil {
-				if v, err = script.Exec(`git describe --always`).String(); err == nil {
-					v = strings.TrimSpace(v)
-				}
-			}
-		}
-	}
-	return v
+	return resolveVersion(buildinfo.Version())
 }
 
 // HomePath gets the current user's home folder

--- a/pkg/visor/visorconfig/values_js.go
+++ b/pkg/visor/visorconfig/values_js.go
@@ -1,0 +1,59 @@
+//go:build js
+
+// Package visorconfig pkg/visor/visorconfig/values_js.go
+//
+// js/wasm counterpart to the platform-gated values_{linux,darwin,
+// windows}.go files. The browser doesn't have a host filesystem or
+// hardware-inventory facility — none of UserConfig, SystemSurvey,
+// or IsRoot make sense in a WASM context. The in-browser config
+// generator never calls them; they exist here so the package's type
+// surface (Survey) compiles cleanly under GOOS=js for callers that
+// reference it indirectly via visorconfig.V1.
+
+package visorconfig
+
+import (
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// resolveVersion is the js counterpart of the native helper. No
+// git fallback — returns the buildinfo version unchanged.
+func resolveVersion(buildVersion string) string {
+	return buildVersion
+}
+
+// UserConfig returns an empty PkgConfig. Browser WASM has no
+// concept of a host install root.
+func UserConfig() skyenv.PkgConfig {
+	return skyenv.PkgConfig{}
+}
+
+// Survey system hardware survey struct. Browser-side fields are
+// limited to what's meaningful without OS / hardware probes — the
+// time of the survey and any caller-supplied identity fields. The
+// Linux/Darwin/Windows variants populate sysinfo + ghw fields that
+// don't exist here.
+type Survey struct {
+	Timestamp      time.Time     `json:"timestamp"`
+	PubKey         cipher.PubKey `json:"public_key,omitempty"`
+	SkycoinAddress string        `json:"skycoin_address,omitempty"`
+	GOOS           string        `json:"go_os,omitempty"`
+	GOARCH         string        `json:"go_arch,omitempty"`
+	SkywireVersion string        `json:"skywire_version,omitempty"`
+	ServicesURLs   Services      `json:"services,omitempty"`
+	DmsgServers    []string      `json:"dmsg_servers,omitempty"`
+}
+
+// SystemSurvey returns an empty Survey on js — no hardware probes.
+func SystemSurvey() (Survey, error) {
+	return Survey{Timestamp: time.Now()}, nil
+}
+
+// IsRoot returns false on js. The browser doesn't have a uid
+// concept that maps to root.
+func IsRoot() bool {
+	return false
+}

--- a/pkg/visor/visorconfig/values_native.go
+++ b/pkg/visor/visorconfig/values_native.go
@@ -1,0 +1,42 @@
+//go:build !js
+
+// Package visorconfig pkg/visor/visorconfig/values_native.go
+//
+// Native (non-WASM) implementations of helpers that need to shell
+// out or touch the host filesystem in ways that don't make sense in
+// a browser WASM context. Mirror counterpart values_js.go contains
+// no-op stubs for the same surface.
+
+package visorconfig
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/bitfield/script"
+)
+
+// resolveVersion implements the version-discovery fallback for
+// Version(): when buildinfo.Version() returns "unknown" and we're
+// running from a source checkout (.git present), shell out to
+// `git describe --always`. Returns the input unchanged when not
+// running from a source tree or when buildinfo already has a real
+// version.
+func resolveVersion(buildVersion string) string {
+	if buildVersion != "unknown" {
+		return buildVersion
+	}
+	// Check for .git folder for versioning.
+	if _, err := os.Stat(".git"); err != nil {
+		return buildVersion
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return buildVersion
+	}
+	v, err := script.Exec(`git describe --always`).String()
+	if err != nil {
+		return buildVersion
+	}
+	return strings.TrimSpace(v)
+}


### PR DESCRIPTION
Three-layer separation per the architectural plan. Every config-shaped type `pkg/visor/visorconfig.V1` embeds gets a schema sub-package (Layer 1: pure data + JSON methods, stdlib + cipher only) that the original operational package (Layer 2) re-exports via type alias. V1 (Layer 3) references only Layer 1 types as its fields.

**End result: `pkg/visor/visorconfig` compiles under `GOOS=js`/`GOARCH=wasm`** — 8.1 MB blob. The in-browser config-generator (apt-repo install page, follow-up PR) can now construct + emit live visor configs using the canonical V1 type instead of a parallel definition that would drift.

## Schema sub-packages added

| Package | Holds | Layer 2 keeps |
|---|---|---|
| `pkg/dmsgc/spec` | `Deployment`, `DmsgConfig` (Marshal/Unmarshal/Primary/AllDeployments/ResolvedServers/PKFromDmsgURL) | dmsg.Client constructor + lanPriorityDisc |
| `pkg/transport/network/spec` | `STCPConfig` | STCP client / dialer / listener |
| `pkg/transport/spec` | `PersistentTransports` | Manager + reconciliation loop |
| `pkg/app/appserver/spec` | `AppConfig` | AppLauncher, server logic |

Existing call sites — `pkg/dmsgc.DmsgConfig`, `network.STCPConfig`, `transport.PersistentTransports`, `appserver.AppConfig` — keep working unchanged via type aliases.

## `pkg/visor/visorconfig` changes

- **`v1.go`** — field types switched to spec packages. Pure data + pure methods only; compiles under js.
- **`v1_runtime.go`** (new, `//go:build !js`) — every method that takes `*launcher.AppLauncher` (Update*App*, AddAppConfig, DeleteAppConfig, etc., 12 methods) + their helpers (updateStringArg / updateBoolArg / deleteAppArg / updateEnvEntry). Native builds see the full V1 surface unchanged.
- **`args.go`** — `appsList` re-typed from `[]appserver.AppConfig` to `[]appspec.AppConfig` (identical via alias).
- **`config.go`** — `MakeBaseConfig` uses spec types. `dmsgpty.DefaultCLIAddr()` (pulls pty pkg, no js support) replaced by a local `defaultDmsgPtyCLIAddr()` returning the unix temp-socket literal. cli-side `cmd/skywire-cli/commands/config/gen.go` still calls `dmsgpty.DefaultCLIAddr()` in its native build for windows path resolution.
- **`values.go`** — `DmsgHTTPPort = uint16(80)` literal instead of importing `pkg/dmsg/dmsg`. The git-describe version fallback moved to `values_native.go` (`!js`); js builds return `buildinfo.Version()` unchanged.
- **`values_js.go`** (new) — js stubs for `UserConfig`/`SystemSurvey`/`IsRoot`/`Survey`. Type-resolution only; returns zero values.
- **`values_native.go`** (new, `!js`) — native git-describe fallback.

## `pkg/skyenv`

- **`skyenv_js.go`** — `PackageConfig()` stub added. Needed for visorconfig's `values.go` to compile under js.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/visor/visorconfig/ ./pkg/dmsgc/ ./pkg/transport/ ./pkg/transport/network/ ./pkg/app/appserver/` passes
- [x] `GOOS=js GOARCH=wasm go build ./pkg/visor/visorconfig/` produces 8.1 MB blob

## Followup

`pkg/skywireconfig/genvisor` (Generate(opts) → *V1 helper composing `deployment.Prod` + operator opts) on top of this. Then apt-repo's cmd/wasm gets a 'Download skywire.json' button — the original phase-3 ask.