### PR TITLE
feat(skywireconfig): genvisor — WASM-clean visor config generator

### DIFF
--- a/pkg/skywireconfig/genvisor/genvisor.go
+++ b/pkg/skywireconfig/genvisor/genvisor.go
@@ -1,0 +1,151 @@
+// Package genvisor provides Generate — a single entry point that
+// composes a fresh visor configuration (pkg/visor/visorconfig.V1)
+// from a small Options struct plus the deployment-default services
+// embedded in pkg/skycoin/skywire/deployment (deployment.Prod /
+// deployment.Test).
+//
+// Lives in pkg/skywireconfig so it sits alongside autoconfigcmd
+// and keypair as the third leg of the WASM-clean configuration
+// surface: the apt-repo install-page form generates a downloadable
+// /opt/skywire/skywire.json by calling Generate, encoding the
+// returned V1 as JSON, and offering it as a Blob the operator
+// downloads.
+//
+// Generate is a thin shim around the visorconfig package's
+// MakeBaseConfig helper (the same function cmd/skywire-cli's
+// `config gen` builds on) — semantics are identical between the
+// CLI's config-gen path and this WASM-compatible path. The Options
+// struct exposes the most commonly-tuned knobs as fields so a
+// WASM caller doesn't have to compose a full cobra command flag
+// set just to set ISHYPERVISOR or REWARDSKYADDR; everything else
+// can be edited on the returned V1 directly before JSON-encoding.
+//
+// WASM cleanliness: this package imports only WASM-clean leaves
+// (visorconfig, deployment, cipher, skyenv-spec). It compiles
+// under GOOS=js GOARCH=wasm — verified end-to-end by the
+// apt-repo install page's WASM build.
+package genvisor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// Options groups the operator-tunable knobs Generate honors.
+// Every field is optional — zero values mean "use the visorconfig
+// default for that field". Anything not exposed here (advanced
+// transport setup tweaks, multi-deployment dmsg, etc.) is still
+// reachable on the returned *visorconfig.V1 — Generate gives you
+// a well-formed config; further mutation is the caller's call.
+type Options struct {
+	// SecretKey, when non-zero, becomes the visor's identity. The
+	// matching PK is derived and written into Common.PK. Empty
+	// triggers a fresh keypair via cipher.GenerateKeyPair (the
+	// same path visorconfig.NewCommon takes when sk==nil but a
+	// SecKey pointer is passed; see ensureKeys).
+	SecretKey cipher.SecKey
+
+	// IsHypervisor enables the local hypervisor stanza
+	// (V1.Hypervisor.Enable=true and the rest of HypervisorConfig
+	// gets populated by visorconfig.GenerateWorkDirConfig).
+	IsHypervisor bool
+
+	// HypervisorPKs is a list of remote hypervisor public keys to
+	// dial. The visor opens a persistent RPC channel to each on
+	// start. Empty leaves V1.Hypervisors nil.
+	HypervisorPKs []cipher.PubKey
+
+	// RewardAddress, when non-empty, is written verbatim to
+	// V1.RewardAddress. Validated only at the wire level (must be
+	// a Skycoin address or xpub string); the visor performs its
+	// own deeper validation on first start.
+	RewardAddress string
+
+	// IsPublic toggles V1.IsPublic — when true, the visor
+	// announces itself to the service-discovery service so other
+	// operators can dial it as a transport endpoint.
+	IsPublic bool
+
+	// TestEnv selects the test deployment instead of prod. Affects
+	// every service URL Generate composes (dmsg-discovery,
+	// transport-discovery, route-finder, etc.). Mirrors the
+	// `--testenv` flag in cli config gen.
+	TestEnv bool
+}
+
+// Generate composes a fresh visorconfig.V1 from opts + the
+// embedded deployment configuration. Returns the V1 and any error
+// from key derivation or services unmarshaling.
+//
+// The returned V1 is operationally complete enough to load into a
+// fresh visor: all required fields are populated with deployment
+// defaults, the operator's identity is wired into Common, and the
+// flags from Options that translate to V1 fields are applied.
+// Optional sub-systems (Stats, Skychat, SkymailBridge, UI server,
+// log server, etc.) are left at visorconfig's defaults.
+//
+// The same set of fields can be tuned post-call by mutating the
+// returned V1 directly — Generate is the prelude to "marshal +
+// download" in the WASM flow.
+func Generate(opts Options) (*visorconfig.V1, error) {
+	sk := opts.SecretKey
+	common, err := visorconfig.NewCommon(nil, "", &sk)
+	if err != nil {
+		return nil, fmt.Errorf("genvisor: derive identity: %w", err)
+	}
+
+	// MakeBaseConfig unmarshals deployment.ServicesJSON internally
+	// when services==nil. We pass nil so the embedded Prod (or
+	// Test) deployment is used — same path the visor takes on
+	// first boot when the conf-service is unreachable.
+	conf := visorconfig.MakeBaseConfig(common, opts.TestEnv, false, nil, nil)
+	if conf == nil {
+		return nil, errors.New("genvisor: MakeBaseConfig returned nil (services unmarshal failed)")
+	}
+
+	if opts.IsHypervisor {
+		conf.Hypervisor = hypervisorConfigDefault()
+	}
+
+	if len(opts.HypervisorPKs) > 0 {
+		conf.Hypervisors = append([]cipher.PubKey{}, opts.HypervisorPKs...)
+	}
+
+	if opts.RewardAddress != "" {
+		conf.RewardAddress = opts.RewardAddress
+	}
+
+	conf.IsPublic = opts.IsPublic
+
+	return conf, nil
+}
+
+// hypervisorConfigDefault returns a HypervisorConfig with the
+// fields a fresh hypervisor needs to come up. The deeper LAN-dmsg
+// keypair / cookie keys are left empty; visorconfig.V1's load path
+// generates them on first persist. The form-level "enable" toggle
+// is what the operator usually means by --ishv, and that's what's
+// set here.
+func hypervisorConfigDefault() *visorconfig.HypervisorConfig {
+	hv := visorconfig.GenerateWorkDirConfig(false)
+	hv.Enable = true
+	return &hv
+}
+
+// MustMarshalJSON renders the given V1 as indented JSON ready for
+// download from the install page. Panics on error — visorconfig.V1
+// is a known-good shape and MarshalJSON never fails under normal
+// conditions. The convenience wrapper is here so the WASM caller
+// doesn't have to handle an impossible error in its js.FuncOf
+// adapter.
+func MustMarshalJSON(v *visorconfig.V1) []byte {
+	buf, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic("genvisor: V1.MarshalJSON failed: " + err.Error())
+	}
+	return buf
+}

--- a/pkg/skywireconfig/genvisor/genvisor_test.go
+++ b/pkg/skywireconfig/genvisor/genvisor_test.go
@@ -1,0 +1,151 @@
+package genvisor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+func TestGenerate_FreshIdentity(t *testing.T) {
+	v, err := Generate(Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if v.PK.Null() {
+		t.Error("PK should be derived (non-zero) when SecretKey is empty")
+	}
+	if v.SK.Null() {
+		t.Error("SK should be generated when Options.SecretKey is empty")
+	}
+	if v.Dmsg == nil {
+		t.Error("Dmsg config should be populated from deployment.Prod")
+	}
+	if v.Transport == nil {
+		t.Error("Transport config should be populated")
+	}
+	if v.Routing == nil {
+		t.Error("Routing config should be populated")
+	}
+	if v.Launcher == nil {
+		t.Error("Launcher config should be populated")
+	}
+}
+
+func TestGenerate_PinnedIdentity(t *testing.T) {
+	_, sk := cipher.GenerateKeyPair()
+	v, err := Generate(Options{SecretKey: sk})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if v.SK != sk {
+		t.Errorf("V1.SK = %v; want pinned %v", v.SK, sk)
+	}
+}
+
+func TestGenerate_Hypervisor(t *testing.T) {
+	v, err := Generate(Options{IsHypervisor: true})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if v.Hypervisor == nil {
+		t.Fatal("Hypervisor stanza should be populated when IsHypervisor=true")
+	}
+	if !v.Hypervisor.Enable {
+		t.Error("Hypervisor.Enable should be true when IsHypervisor=true")
+	}
+}
+
+func TestGenerate_HypervisorPKs(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	v, err := Generate(Options{HypervisorPKs: []cipher.PubKey{pk1, pk2}})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(v.Hypervisors) != 2 {
+		t.Fatalf("V1.Hypervisors len = %d; want 2", len(v.Hypervisors))
+	}
+	if v.Hypervisors[0] != pk1 || v.Hypervisors[1] != pk2 {
+		t.Error("V1.Hypervisors did not preserve order / PKs")
+	}
+}
+
+func TestGenerate_RewardAddress(t *testing.T) {
+	addr := "2jnZqqJsCMB1v4VUKk6f1PDN9EuLZQxqoqp"
+	v, err := Generate(Options{RewardAddress: addr})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if v.RewardAddress != addr {
+		t.Errorf("V1.RewardAddress = %q; want %q", v.RewardAddress, addr)
+	}
+}
+
+func TestGenerate_IsPublic(t *testing.T) {
+	v, err := Generate(Options{IsPublic: true})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !v.IsPublic {
+		t.Error("V1.IsPublic = false; want true")
+	}
+}
+
+// TestGenerate_JSONRoundTrip verifies the generated V1 marshals to
+// JSON cleanly and re-unmarshals into a V1 without loss. Catches
+// drift between the WASM-clean V1 (and its leaf-package field
+// types) and the on-disk visor config shape — if a future field
+// change breaks JSON round-trip, this test goes red.
+func TestGenerate_JSONRoundTrip(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	original, err := Generate(Options{
+		IsHypervisor:  true,
+		HypervisorPKs: []cipher.PubKey{pk1},
+		RewardAddress: "2jnZqqJsCMB1v4VUKk6f1PDN9EuLZQxqoqp",
+		IsPublic:      true,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	buf, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var roundTripped visorconfig.V1
+	if err := json.Unmarshal(buf, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if roundTripped.RewardAddress != original.RewardAddress {
+		t.Errorf("RewardAddress drift: %q vs %q", roundTripped.RewardAddress, original.RewardAddress)
+	}
+	if !roundTripped.IsPublic {
+		t.Error("IsPublic dropped through round-trip")
+	}
+	if len(roundTripped.Hypervisors) != 1 || roundTripped.Hypervisors[0] != pk1 {
+		t.Errorf("Hypervisors drift: %v vs %v", roundTripped.Hypervisors, original.Hypervisors)
+	}
+	if roundTripped.Dmsg == nil || roundTripped.Dmsg.Discovery == "" {
+		t.Error("Dmsg.Discovery dropped through round-trip")
+	}
+}
+
+func TestMustMarshalJSON(t *testing.T) {
+	v, err := Generate(Options{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	buf := MustMarshalJSON(v)
+	if len(buf) == 0 {
+		t.Fatal("MustMarshalJSON returned empty")
+	}
+	// Should re-parse cleanly.
+	var rt visorconfig.V1
+	if err := json.Unmarshal(buf, &rt); err != nil {
+		t.Fatalf("re-unmarshal of indented JSON: %v", err)
+	}
+}


### PR DESCRIPTION
Closes phase 3 of the install-page WASM stack. `genvisor.Generate` composes a fresh `visorconfig.V1` from a small `Options` struct + the embedded deployment configuration (`deployment.Prod` or `.Test`) and returns the V1 ready to JSON-encode. The apt-repo install page (in a follow-up PR) calls this from its WASM to offer a downloadable `/opt/skywire/skywire.json` — the operator drops it at `/opt/skywire/skywire.json` on the target host and skips first-boot autoconfig.

Built on the foundation laid by #2829 (visorconfig schema/operational split): genvisor imports only WASM-clean packages — `visorconfig`, `cipher` — and compiles under `GOOS=js GOARCH=wasm` (8.1 MB combined with the WASM the install page already ships).

## API

```go
func Generate(opts Options) (*visorconfig.V1, error)
func MustMarshalJSON(v *visorconfig.V1) []byte

type Options struct {
    SecretKey     cipher.SecKey   // empty = generate fresh
    IsHypervisor  bool            // hypervisor stanza enable
    HypervisorPKs []cipher.PubKey // remote hypervisors to dial
    RewardAddress string          // V1.RewardAddress
    IsPublic      bool            // V1.IsPublic
    TestEnv       bool            // use deployment.Test instead
}
```

Generate is a thin shim over `visorconfig.MakeBaseConfig` (the same helper `cmd/skywire-cli`'s config gen builds on) — same semantics, same deployment defaults. Options exposes the most commonly-tuned knobs as struct fields; everything else is reachable by mutating the returned V1 directly before JSON-encoding.

## Tests

Cover fresh / pinned identity, hypervisor toggle, hypervisor PK list, reward address, IsPublic, MustMarshalJSON, and JSON round-trip — generated V1 marshals + unmarshals back into V1 with no field drift across the schema/operational split. CI test catches future schema drift automatically.

```
go test ./pkg/skywireconfig/genvisor/ -v
```

passes locally.

## Followup

apt-repo's `cmd/wasm/main.go` gets a `generateVisorConfig(opts)` JS-callable export that wraps Generate + MustMarshalJSON; the install-page form gains a 'Download skywire.json' button.