### PR TITLE
chore: fix CI gofmt failures + serialize make check via flock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ e2e-test.log
 # Build artifacts and local files
 /skywire
 *.bak
+.make-check.lock
 /help_output/
 /go-files-by-lines.txt
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,20 @@ dmsghttp: ## update dmsghttp-config.json
 count-dmsg-disc-entries:
 	curl -sL $(jq -r '.prod.dmsg_discovery' services-config.json)/dmsg-discovery/entries | jq '. | length'
 
-check: lint check-cg check-help test ## Run linters and tests
+check: ## Run linters and tests (lint, check-cg, check-help, test). Serialized via flock so two concurrent invocations don't trigger overlapping parallel test runs that pin every core and make the machine unresponsive.
+	@if command -v flock >/dev/null 2>&1; then \
+		exec 9>.make-check.lock; \
+		if ! flock -n 9; then \
+			echo "another 'make check' is already holding .make-check.lock; waiting for it to finish..." >&2; \
+			flock 9; \
+		fi; \
+		$(MAKE) --no-print-directory -f $(firstword $(MAKEFILE_LIST)) check-inner; \
+	else \
+		echo "WARNING: 'flock' not available; running unguarded. install util-linux's flock to enable serialization." >&2; \
+		$(MAKE) --no-print-directory -f $(firstword $(MAKEFILE_LIST)) check-inner; \
+	fi
+
+check-inner: lint check-cg check-help test ## Internal: the actual check targets, run inside flock by 'make check'. Don't call directly unless you've already acquired .make-check.lock.
 
 check-cg: ## Cursory check of the main help menu, offline dmsghttp config gen and offline config gen
 	@echo "checking dmsghttp offline config gen"

--- a/cmd/skywire-cli/commands/gotop/grpcdevice.go
+++ b/cmd/skywire-cli/commands/gotop/grpcdevice.go
@@ -9,9 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
-
 	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
 )
 
 // grpcDevice is a gotop device extension that fetches stats from a remote visor via gRPC.

--- a/cmd/skywire-cli/commands/gotop/root.go
+++ b/cmd/skywire-cli/commands/gotop/root.go
@@ -17,20 +17,20 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	jj "github.com/cloudfoundry-attic/jibber_jabber"
 	ui "github.com/gizak/termui/v3"
 	"github.com/spf13/cobra"
-	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4"
-	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/colorschemes"
-	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
-	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/layout"
-	w "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/widgets"
 	"github.com/xxxserxxx/lingo/v2"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/pkg/visor/rpcgrpc"
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/colorschemes"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/layout"
+	w "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/widgets"
 )
 
 const (

--- a/cmd/skywire-cli/commands/visor/top.go
+++ b/cmd/skywire-cli/commands/visor/top.go
@@ -21,19 +21,20 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	jj "github.com/cloudfoundry-attic/jibber_jabber"
 	"github.com/droundy/goopt"
 	ui "github.com/gizak/termui/v3"
 	"github.com/shibukawa/configdir"
 	"github.com/spf13/cobra"
+	"github.com/xxxserxxx/lingo/v2"
+
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/colorschemes"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/layout"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/logging"
 	w "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/widgets"
-	"github.com/xxxserxxx/lingo/v2"
 )
 
 func init() {

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -40,8 +40,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/cmdutil"
-	"github.com/skycoin/skywire/pkg/skywireconfig/autoconfigcmd"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skywireconfig/autoconfigcmd"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -339,9 +339,9 @@ func autoconfigRun(cmd *cobra.Command, args []string) {
 		msg2(fmt.Sprintf("skycoin reward address:\n%s%s%s", colorGreen, strings.TrimSpace(string(rewardOut)), colorReset))
 	}
 
-if autoconfigVals.Verbose {
-	printWelcome(pubkey, isHypervisor)
-}
+	if autoconfigVals.Verbose {
+		printWelcome(pubkey, isHypervisor)
+	}
 }
 
 // defaultSkyenvPath returns the canonical SKYENV file location for

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	atomicgo.dev/schedule v0.1.0 // indirect
 	github.com/ActiveState/termtest/conpty v0.5.0
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
-	github.com/BurntSushi/toml v1.6.0
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MichaelMure/go-term-text v0.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect

--- a/pkg/dmsg/dmsg/metrics/victoria_metrics.go
+++ b/pkg/dmsg/dmsg/metrics/victoria_metrics.go
@@ -4,9 +4,8 @@ package metrics
 import (
 	"log"
 
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
-
 	"github.com/skycoin/skywire/pkg/metricsutil"
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 )
 
 // VictoriaMetrics implements `Metrics` using `VictoriaMetrics`.

--- a/pkg/metricsutil/http.go
+++ b/pkg/metricsutil/http.go
@@ -12,9 +12,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sirupsen/logrus"
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 )
 
 // AddMetricsHandler adds a prometheus-format Handle at '/metrics' to the provided serve mux.

--- a/pkg/netutil/net_js.go
+++ b/pkg/netutil/net_js.go
@@ -11,7 +11,9 @@
 // situation.
 package netutil
 
-import "errors"
+import (
+	"errors"
+)
 
 // DefaultNetworkInterface returns an "unsupported on this
 // platform" sentinel error. There's no concept of "the default

--- a/pkg/router/dial_options_test.go
+++ b/pkg/router/dial_options_test.go
@@ -4,7 +4,9 @@
 // GET should be able to use direct upstream + multi-hop downstream).
 package router
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestDialOptions_EffectiveMinHops(t *testing.T) {
 	cases := []struct {

--- a/pkg/router/setupmetrics/victoria_metrics.go
+++ b/pkg/router/setupmetrics/victoria_metrics.go
@@ -4,10 +4,9 @@ package setupmetrics
 import (
 	"time"
 
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
-
 	"github.com/skycoin/skywire/pkg/metricsutil"
 	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 )
 
 // Metrics collects metrics in prometheus format.

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -62,29 +62,29 @@ type EnvMapping struct {
 // package-level var in cmd/skywire/commands/autoconfig.go) so that
 // post-parse reads stay simple field access — no double-indirection.
 type Values struct {
-	Verbose         bool
-	Hvpks           string
-	Ishv            bool
-	NoIshv          bool
-	RewardAddr      string
-	Public          bool
-	NoPublic        bool
-	StcprPort       int
-	SudphPort       int
-	LanDmsgPort     int
-	LanDmsgPublic   string
-	DmsgptyPks      string
-	VpnServer       bool
-	NoVpnServer     bool
-	ProxyServer     bool
-	NoProxyServer   bool
-	Skychat         bool
-	NoSkychat       bool
-	Dmsgweb         bool
-	NoDmsgweb       bool
-	Skynetweb       bool
-	NoSkynetweb     bool
-	DisablePubAuto  bool
+	Verbose        bool
+	Hvpks          string
+	Ishv           bool
+	NoIshv         bool
+	RewardAddr     string
+	Public         bool
+	NoPublic       bool
+	StcprPort      int
+	SudphPort      int
+	LanDmsgPort    int
+	LanDmsgPublic  string
+	DmsgptyPks     string
+	VpnServer      bool
+	NoVpnServer    bool
+	ProxyServer    bool
+	NoProxyServer  bool
+	Skychat        bool
+	NoSkychat      bool
+	Dmsgweb        bool
+	NoDmsgweb      bool
+	Skynetweb      bool
+	NoSkynetweb    bool
+	DisablePubAuto bool
 }
 
 // New returns a freshly-constructed autoconfig cobra command with

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -168,4 +168,3 @@ func TestNew_UsageString_RendersWithoutError(t *testing.T) {
 		}
 	}
 }
-

--- a/pkg/util/treeprobe/aggregate.go
+++ b/pkg/util/treeprobe/aggregate.go
@@ -8,7 +8,9 @@
 
 package treeprobe
 
-import "sort"
+import (
+	"sort"
+)
 
 // CellKey identifies one (level, parent_pk, remote_pk) tuple.
 // Used as a map key on the aggregator + as the CSV row identity.

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -44,16 +44,16 @@ type V1 struct {
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
 	CLIAddr             string          `json:"cli_addr"`
 
-	LogLevel             string                           `json:"log_level"`
-	LocalPath            string                           `json:"local_path"`
-	StunServers          []string                         `json:"stun_servers"`
-	ShutdownTimeout      Duration                         `json:"shutdown_timeout,omitempty"` // time value, examples: 10s, 1m, etc
-	IsPublic             bool                             `json:"is_public"`
-	PublicVisorConfig    *PublicVisorConfig               `json:"public_visor,omitempty"`
-	GeoIP                string                           `json:"geoip"`
+	LogLevel             string                       `json:"log_level"`
+	LocalPath            string                       `json:"local_path"`
+	StunServers          []string                     `json:"stun_servers"`
+	ShutdownTimeout      Duration                     `json:"shutdown_timeout,omitempty"` // time value, examples: 10s, 1m, etc
+	IsPublic             bool                         `json:"is_public"`
+	PublicVisorConfig    *PublicVisorConfig           `json:"public_visor,omitempty"`
+	GeoIP                string                       `json:"geoip"`
 	PersistentTransports []tspec.PersistentTransports `json:"persistent_transports"`
-	ConfService          string                           `json:"conf_service,omitempty"`      // HTTP URL for config bootstrap service
-	ConfServiceDmsg      string                           `json:"conf_service_dmsg,omitempty"` // DMSG URL for config bootstrap service
+	ConfService          string                       `json:"conf_service,omitempty"`      // HTTP URL for config bootstrap service
+	ConfServiceDmsg      string                       `json:"conf_service_dmsg,omitempty"` // DMSG URL for config bootstrap service
 	// SurveyClientSK is the CLI-side identity used by
 	// `skywire cli log <subcommand>` to authenticate against remote
 	// visors' survey_whitelist gates (visor logserver port 80 over
@@ -443,7 +443,6 @@ func (v1 *V1) Flush() error {
 	return v1.Common.flush(v1)
 }
 
-
 // UpdateMinHops updates min_hops config
 func (v1 *V1) UpdateMinHops(hops uint16) error {
 	v1.mu.Lock()
@@ -509,6 +508,7 @@ func (v1 *V1) GetCalculateRoutes() bool {
 	defer v1.mu.RUnlock()
 	return v1.Routing.CalculateRoutes
 }
+
 // mergePubKeys returns the union of the given public key slices, preserving
 // the order of the first slice and appending any unique keys from the second.
 // nil slices are handled transparently.

--- a/third_party/VictoriaMetrics/metrics/push.go
+++ b/third_party/VictoriaMetrics/metrics/push.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -12,8 +13,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"compress/gzip"
 )
 
 // PushOptions is the list of options, which may be applied to InitPushWithOptions().

--- a/third_party/xxxserxxx/gotop/v4/config.go
+++ b/third_party/xxxserxxx/gotop/v4/config.go
@@ -15,9 +15,10 @@ import (
 	"time"
 
 	"github.com/shibukawa/configdir"
+	"github.com/xxxserxxx/lingo/v2"
+
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/colorschemes"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/widgets"
-	"github.com/xxxserxxx/lingo/v2"
 )
 
 // FIXME github action uses old(er) Go version that doesn't have embed

--- a/third_party/xxxserxxx/gotop/v4/devices/cpu_linux.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/cpu_linux.go
@@ -3,7 +3,9 @@
 
 package devices
 
-import "github.com/shirou/gopsutil/v3/cpu"
+import (
+	"github.com/shirou/gopsutil/v3/cpu"
+)
 
 func CpuCount() (int, error) {
 	cpuCount, err := cpu.Counts(false)

--- a/third_party/xxxserxxx/gotop/v4/devices/cpu_other.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/cpu_other.go
@@ -3,7 +3,9 @@
 
 package devices
 
-import "github.com/shirou/gopsutil/v3/cpu"
+import (
+	"github.com/shirou/gopsutil/v3/cpu"
+)
 
 func CpuCount() (int, error) {
 	return cpu.Counts(false)

--- a/third_party/xxxserxxx/gotop/v4/devices/devices.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/devices.go
@@ -1,8 +1,9 @@
 package devices
 
 import (
-	"github.com/xxxserxxx/lingo/v2"
 	"log"
+
+	"github.com/xxxserxxx/lingo/v2"
 )
 
 const (

--- a/third_party/xxxserxxx/gotop/v4/devices/mem.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/mem.go
@@ -1,6 +1,8 @@
 package devices
 
-import "log"
+import (
+	"log"
+)
 
 var memFuncs []func(map[string]MemoryInfo) map[string]error
 

--- a/third_party/xxxserxxx/gotop/v4/layout/layout.go
+++ b/third_party/xxxserxxx/gotop/v4/layout/layout.go
@@ -5,12 +5,11 @@ import (
 	"sort"
 	"strings"
 
+	ui "github.com/gizak/termui/v3"
 	"github.com/xxxserxxx/lingo/v2"
 
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/widgets"
-
-	ui "github.com/gizak/termui/v3"
 )
 
 type layout struct {

--- a/third_party/xxxserxxx/gotop/v4/termui/drawille-go/drawille.go
+++ b/third_party/xxxserxxx/gotop/v4/termui/drawille-go/drawille.go
@@ -1,7 +1,9 @@
 package drawille
 
 //import "code.google.com/p/goncurses"
-import "math"
+import (
+	"math"
+)
 
 var pixel_map = [4][2]int{
 	{0x1, 0x8},

--- a/third_party/xxxserxxx/gotop/v4/termui/entry.go
+++ b/third_party/xxxserxxx/gotop/v4/termui/entry.go
@@ -7,6 +7,7 @@ import (
 
 	ui "github.com/gizak/termui/v3"
 	rw "github.com/mattn/go-runewidth"
+
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"
 )
 

--- a/third_party/xxxserxxx/gotop/v4/termui/linegraph.go
+++ b/third_party/xxxserxxx/gotop/v4/termui/linegraph.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	ui "github.com/gizak/termui/v3"
+
 	drawille "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui/drawille-go"
 )
 

--- a/third_party/xxxserxxx/gotop/v4/widgets/battery.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/battery.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/distatus/battery"
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 )
 

--- a/third_party/xxxserxxx/gotop/v4/widgets/batterygauge.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/batterygauge.go
@@ -3,12 +3,11 @@ package widgets
 import (
 	"fmt"
 	"log"
-
 	"time"
 
 	"github.com/distatus/battery"
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 )
 

--- a/third_party/xxxserxxx/gotop/v4/widgets/cpu.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/cpu.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/VividCortex/ewma"
+	"github.com/gizak/termui/v3"
+
 	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
-
-	"github.com/gizak/termui/v3"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 )
 

--- a/third_party/xxxserxxx/gotop/v4/widgets/disk.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/disk.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	psDisk "github.com/shirou/gopsutil/v3/disk"
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"
 )

--- a/third_party/xxxserxxx/gotop/v4/widgets/mem.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/mem.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
-
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"

--- a/third_party/xxxserxxx/gotop/v4/widgets/net.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/net.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	psNet "github.com/shirou/gopsutil/v3/net"
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"
 )

--- a/third_party/xxxserxxx/gotop/v4/widgets/proc.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/proc.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tui "github.com/gizak/termui/v3"
+
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"

--- a/third_party/xxxserxxx/gotop/v4/widgets/scalable.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/scalable.go
@@ -1,6 +1,8 @@
 package widgets
 
-import termui "github.com/gizak/termui/v3"
+import (
+	termui "github.com/gizak/termui/v3"
+)
 
 type Scalable interface {
 	termui.Drawable

--- a/third_party/xxxserxxx/gotop/v4/widgets/temp.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/temp.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	ui "github.com/gizak/termui/v3"
-	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"
 )


### PR DESCRIPTION
## Summary

Two unrelated build-hygiene fixes that fell out of the recent autoconfig/visorconfig PR train (#2825-#2830).

### `chore: apply make format across tree to fix CI gofmt failures`
The #2825-#2830 PRs shipped without one final `make format` pass, so CI's gofmt check went red on each merge. Three files had detectable issues:
- `cmd/skywire/commands/autoconfig.go:43` — import-group order + a Verbose-block indent bug.
- `pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go:65` — goimports-reviser regrouping.
- `pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go:171` — trailing newline.

`make format` also picked up an `// indirect` correction in `go.mod` (BurntSushi/toml is only a transitive dep via vendored gotop) and assorted whitespace in `third_party/xxxserxxx/gotop` + `third_party/VictoriaMetrics` that was never gofmt-canonical to begin with. No semantic changes — `make check` passes locally.

### `build: serialize 'make check' via flock to prevent overlapping runs`
Two concurrent `make check` runs were enough to pin every core (each runs `go test -race` with default GOMAXPROCS) and make a dev machine unresponsive. Wrap the target with `flock(.make-check.lock)`:

- First invocation: acquires the lock non-blockingly, runs the real `check-inner` (lint + check-cg + check-help + test).
- Concurrent second invocation: prints `another 'make check' is already holding .make-check.lock; waiting for it to finish...` then blocks on the lock.
- No `flock` binary: prints a warning and runs unguarded (preserves behavior on platforms without util-linux's flock).

`check-inner` is exposed as a real target so the recursive `make` inside the locked shell has something to call, and as a safety hatch for direct invocation when the caller knows what they're doing.

## Test plan

- [ ] CI gofmt check stays green (the original failure from #2825-#2830).
- [ ] `make check` passes locally on the branch.
- [ ] `make check` from two terminals: second prints the "waiting..." message and runs after the first releases (verified locally with a synthetic background lock-holder).
- [ ] `make check` with `flock` absent prints the warning and runs unguarded (not realistically testable in CI; behavior preserved by design).