### PR TITLE
feat(autoconfig): config-gen parity — every SKYENV var now exposed

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -84,11 +84,19 @@ func init() {
 // of edits to apply to /etc/skywire.conf. Only flags the operator
 // actually passed are included — un-passed flags leave the
 // corresponding lines untouched.
+//
+// The flag → SKYENV mapping is authoritatively defined in
+// pkg/skywireconfig/autoconfigcmd.EnvMap(); for the actual
+// VALUES we read from autoconfigVals via tiny switch helpers.
+// Keeping the mapping there means the WASM consumer (apt-repo
+// install page) and this Run-path agree on which env var each
+// flag writes.
 func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	var edits []skyenvEdit
+
 	// Bool-pair helper: --flag wins over --no-flag if both somehow set,
 	// but cobra normally only sees one per invocation.
-	addBool := func(key string, onName, offName string, on, off bool) {
+	addBool := func(key, onName, offName string, on, off bool) {
 		switch {
 		case cmd.Flags().Changed(onName) && on:
 			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(true)})
@@ -96,38 +104,113 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(false)})
 		}
 	}
+	addSoloBool := func(key, name string, val bool) {
+		if cmd.Flags().Changed(name) {
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBool(val)})
+		}
+	}
+	addString := func(key, name, val string) {
+		if cmd.Flags().Changed(name) {
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvString(val)})
+		}
+	}
+	addArray := func(key, name, val string) {
+		if cmd.Flags().Changed(name) {
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvBashArray(val)})
+		}
+	}
+	addInt := func(key, name string, val int) {
+		if cmd.Flags().Changed(name) {
+			edits = append(edits, skyenvEdit{Key: key, Value: formatSkyenvInt(val)})
+		}
+	}
 
-	if cmd.Flags().Changed("hvpks") {
-		edits = append(edits, skyenvEdit{Key: "HYPERVISORPKS", Value: formatSkyenvBashArray(autoconfigVals.Hvpks)})
-	}
+	// Hypervisor / identity
+	addArray("HYPERVISORPKS", "hvpks", autoconfigVals.Hvpks)
 	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoconfigVals.Ishv, autoconfigVals.NoIshv)
-	if cmd.Flags().Changed("rewardaddr") {
-		edits = append(edits, skyenvEdit{Key: "REWARDSKYADDR", Value: formatSkyenvString(autoconfigVals.RewardAddr)})
-	}
+	addString("HVHTTPADDR", "hvaddr", autoconfigVals.HvAddr)
+	addString("SK", "sk", autoconfigVals.SecretKey)
+	addString("VERSION", "version", autoconfigVals.Version)
+
+	// Visor public/private + autoconnect
+	addString("REWARDSKYADDR", "rewardaddr", autoconfigVals.RewardAddr)
 	addBool("VISORISPUBLIC", "public", "no-public", autoconfigVals.Public, autoconfigVals.NoPublic)
-	if cmd.Flags().Changed("stcpr") {
-		edits = append(edits, skyenvEdit{Key: "STCPRPORT", Value: formatSkyenvInt(autoconfigVals.StcprPort)})
-	}
-	if cmd.Flags().Changed("sudph") {
-		edits = append(edits, skyenvEdit{Key: "SUDPHPORT", Value: formatSkyenvInt(autoconfigVals.SudphPort)})
-	}
-	if cmd.Flags().Changed("lan-dmsg-port") {
-		edits = append(edits, skyenvEdit{Key: "LANDMSGPORT", Value: formatSkyenvInt(autoconfigVals.LanDmsgPort)})
-	}
-	if cmd.Flags().Changed("lan-dmsg-public") {
-		edits = append(edits, skyenvEdit{Key: "LANDMSGPUBLIC", Value: formatSkyenvString(autoconfigVals.LanDmsgPublic)})
-	}
-	if cmd.Flags().Changed("dmsgpty-pks") {
-		edits = append(edits, skyenvEdit{Key: "DMSGPTYPKS", Value: formatSkyenvBashArray(autoconfigVals.DmsgptyPks)})
-	}
+	addSoloBool("DISPLAYNODEIP", "publicip", autoconfigVals.PublicIP)
+	addSoloBool("DISABLEPUBLICAUTOCONN", "disable-public-autoconn", autoconfigVals.DisablePubAuto)
+
+	// Service discovery / deployment
+	addSoloBool("TESTENV", "testenv", autoconfigVals.TestEnv)
+	addSoloBool("DMSGHTTP", "dmsghttp", autoconfigVals.DmsgHTTP)
+	addString("DMSGCONF", "dmsgconf", autoconfigVals.DmsgConf)
+	addArray("SVCCONFADDR", "url", autoconfigVals.URL)
+	addString("SVCCONF", "svcconf", autoconfigVals.SvcConf)
+	addInt("MINDMSGSESS", "minsess", autoconfigVals.MinSess)
+	addArray("STUNSERVERS", "stun", autoconfigVals.StunServers)
+
+	// Transport ports
+	addInt("STCPRPORT", "stcpr", autoconfigVals.StcprPort)
+	addInt("SUDPHPORT", "sudph", autoconfigVals.SudphPort)
+	addInt("LANDMSGPORT", "lan-dmsg-port", autoconfigVals.LanDmsgPort)
+	addString("LANDMSGPUBLIC", "lan-dmsg-public", autoconfigVals.LanDmsgPublic)
+
+	// Whitelists
+	addArray("DMSGPTYPKS", "dmsgpty-pks", autoconfigVals.DmsgptyPks)
+	addArray("SURVEYPKS", "survey", autoconfigVals.SurveyPks)
+	addArray("ROUTESETUPPKS", "routesetup", autoconfigVals.RouteSetupPKs)
+	addArray("TPSETUPPKS", "tpsetup", autoconfigVals.TransportSetup)
+
+	// Route calculation
+	addSoloBool("CALCULATEROUTES", "calculate-routes", autoconfigVals.CalculateRoutes)
+
+	// VPN server
 	addBool("VPNSERVER", "vpnserver", "no-vpnserver", autoconfigVals.VpnServer, autoconfigVals.NoVpnServer)
+	addString("VPNKS", "killsw", autoconfigVals.VpnKillSw)
+	addString("ADDVPNPK", "addvpn", autoconfigVals.AddVpn)
+	addArray("VPNSERVERWL", "vpnwl", autoconfigVals.VpnWl)
+	addString("VPNSEVERSECURE", "secure", autoconfigVals.VpnSecure)
+	addString("VPNSEVERNETIFC", "netifc", autoconfigVals.VpnNetIfc)
+
+	// Proxy
 	addBool("PROXYSERVER", "proxyserver", "no-proxyserver", autoconfigVals.ProxyServer, autoconfigVals.NoProxyServer)
-	addBool("SKYCHAT", "skychat", "no-skychat", autoconfigVals.Skychat, autoconfigVals.NoSkychat)
+	addString("PROXYCLIENTPK", "proxyclientpk", autoconfigVals.ProxyClientPK)
+	addSoloBool("STARTPROXYCLIENT", "startproxyclient", autoconfigVals.StartProxyCli)
+	addArray("PROXYSERVERWL", "proxywl", autoconfigVals.ProxyWl)
+
+	// SOCKS5 web bridges
 	addBool("DMSGWEB", "dmsgweb", "no-dmsgweb", autoconfigVals.Dmsgweb, autoconfigVals.NoDmsgweb)
 	addBool("SKYNETWEB", "skynetweb", "no-skynetweb", autoconfigVals.Skynetweb, autoconfigVals.NoSkynetweb)
-	if cmd.Flags().Changed("disable-public-autoconn") {
-		edits = append(edits, skyenvEdit{Key: "DISABLEPUBLICAUTOCONN", Value: formatSkyenvBool(autoconfigVals.DisablePubAuto)})
-	}
+	addString("DMSGWEBUPSTREAM", "dmsgweb-upstream", autoconfigVals.DmsgwebUpstream)
+	addString("SKYNETWEBUPSTREAM", "skynetweb-upstream", autoconfigVals.SkynetwebUpstream)
+
+	// Skychat
+	addBool("SKYCHAT", "skychat", "no-skychat", autoconfigVals.Skychat, autoconfigVals.NoSkychat)
+	addString("SKYCHATADDR", "chataddr", autoconfigVals.ChatAddr)
+	addBool("SKYCHATPAIR", "servechatpair", "no-servechatpair", autoconfigVals.ServeChatPair, autoconfigVals.NoServeChatPair)
+
+	// Skymail bridge
+	addBool("SKYMAILBRIDGE", "skymail-bridge", "no-skymail-bridge", autoconfigVals.SkymailBridge, autoconfigVals.NoSkymailBridge)
+
+	// Skycoin daemon
+	addBool("SKYCOIND", "skycoind", "no-skycoind", autoconfigVals.Skycoind, autoconfigVals.NoSkycoind)
+	addString("SKYCOIND_FIBER_TOML", "skycoindfiber", autoconfigVals.SkycoindFiber)
+	addString("SKYCOIND_API_SETS", "skycoindapi", autoconfigVals.SkycoindAPI)
+	addString("SKYCOIND_USER", "skycoindUSER", autoconfigVals.SkycoindUser)
+	addArray("SKYCOIND_INSTANCES", "skycoindinstances", autoconfigVals.SkycoindInstances)
+	addString("SKYCOIND_FLAGS", "skycoindflags", autoconfigVals.SkycoindFlags)
+
+	// Skycoin web wallet
+	addBool("SKYCOINWEB", "skycoinweb", "no-skycoinweb", autoconfigVals.Skycoinweb, autoconfigVals.NoSkycoinweb)
+	addString("SKYCOINWEBADDR", "skycoinwebaddr", autoconfigVals.SkycoinwebAddr)
+	addArray("SKYCOINWEBNODES", "skycoinwebnodes", autoconfigVals.SkycoinwebNodes)
+	addString("SKYCOINWEBWALLET", "skycoinwebwallet", autoconfigVals.SkycoinwebWallet)
+	addString("SKYCOINWEBUSER", "skycoinwebuser", autoconfigVals.SkycoinwebUser)
+
+	// Visor runtime
+	addString("BINPATH", "binpath", autoconfigVals.BinPath)
+	addString("LOGLVL", "loglvl", autoconfigVals.LogLevel)
+	addString("SHUTDOWNTIMEOUT", "timeout", autoconfigVals.ShutdownTimeout)
+	addString("REGTIMEOUT", "regtimeout", autoconfigVals.RegTimeout)
+
 	return edits
 }
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -19,6 +19,16 @@
 // the same place as the flag definition keeps the two from drifting
 // apart, and lets WASM consumers render a form that shows operators
 // exactly which line they're toggling.
+//
+// Parity with `skywire cli config gen`: the autoconfig surface is
+// designed to be a strict superset over the SKYENV-reading subset
+// of `cli config gen` flags. Every variable config gen looks up via
+// scriptExec*("${VAR…}") in cmd/skywire-cli/commands/config/gen.go
+// has an autoconfig flag whose effect on skywire.conf produces the
+// same downstream behavior. The non-SKYENV flags (--stdout, --regen,
+// the per-service generators --sn/--dmsgdisc/etc., the OS selector
+// --os) are intentionally NOT exposed — they have no persistence
+// surface so autoconfig has nothing to do with them.
 package autoconfigcmd
 
 import (
@@ -61,30 +71,111 @@ type EnvMapping struct {
 // installed by New. Callers pass a Values they own (typically a
 // package-level var in cmd/skywire/commands/autoconfig.go) so that
 // post-parse reads stay simple field access — no double-indirection.
+//
+// Field groupings mirror the help-output sections in the
+// `skywire cli config gen --all` output so that operators familiar
+// with config gen find each autoconfig flag in roughly the same
+// neighborhood.
 type Values struct {
-	Verbose        bool
-	Hvpks          string
-	Ishv           bool
-	NoIshv         bool
+	// --- Display-only ---
+	Verbose bool
+
+	// --- Hypervisor / identity ---
+	Hvpks     string
+	Ishv      bool
+	NoIshv    bool
+	HvAddr    string // HVHTTPADDR
+	SecretKey string // SK — security-sensitive; see flag description
+	Version   string // VERSION — testing override
+
+	// --- Visor public/private + autoconnect ---
 	RewardAddr     string
 	Public         bool
 	NoPublic       bool
-	StcprPort      int
-	SudphPort      int
-	LanDmsgPort    int
-	LanDmsgPublic  string
-	DmsgptyPks     string
-	VpnServer      bool
-	NoVpnServer    bool
-	ProxyServer    bool
-	NoProxyServer  bool
-	Skychat        bool
-	NoSkychat      bool
-	Dmsgweb        bool
-	NoDmsgweb      bool
-	Skynetweb      bool
-	NoSkynetweb    bool
+	PublicIP       bool // DISPLAYNODEIP
 	DisablePubAuto bool
+
+	// --- Service discovery / deployment ---
+	TestEnv     bool   // TESTENV
+	DmsgHTTP    bool   // DMSGHTTP
+	DmsgConf    string // DMSGCONF
+	URL         string // SVCCONFADDR (services conf URL — accepts comma-list)
+	SvcConf     string // SVCCONF (fallback service-configuration file)
+	MinSess     int    // MINDMSGSESS
+	StunServers string // STUNSERVERS (comma-separated)
+
+	// --- Transport ports ---
+	StcprPort     int
+	SudphPort     int
+	LanDmsgPort   int
+	LanDmsgPublic string
+
+	// --- Whitelists ---
+	DmsgptyPks     string
+	SurveyPks      string // SURVEYPKS
+	RouteSetupPKs  string // ROUTESETUPPKS
+	TransportSetup string // TPSETUPPKS
+
+	// --- Route calculation ---
+	CalculateRoutes bool // CALCULATEROUTES
+
+	// --- VPN server feature ---
+	VpnServer   bool
+	NoVpnServer bool
+	VpnKillSw   string // VPNKS
+	AddVpn      string // ADDVPNPK
+	VpnWl       string // VPNSERVERWL (comma-separated)
+	VpnSecure   string // VPNSEVERSECURE (sic — typo retained for compat with config gen's env-var name)
+	VpnNetIfc   string // VPNSEVERNETIFC (sic — same)
+
+	// --- Proxy feature ---
+	ProxyServer   bool
+	NoProxyServer bool
+	ProxyClientPK string // PROXYCLIENTPK
+	StartProxyCli bool   // STARTPROXYCLIENT
+	ProxyWl       string // PROXYSERVERWL (comma-separated)
+
+	// --- SOCKS5 web bridges ---
+	Dmsgweb           bool
+	NoDmsgweb         bool
+	Skynetweb         bool
+	NoSkynetweb       bool
+	DmsgwebUpstream   string // DMSGWEBUPSTREAM
+	SkynetwebUpstream string // SKYNETWEBUPSTREAM
+
+	// --- Skychat ---
+	Skychat         bool
+	NoSkychat       bool
+	ChatAddr        string // SKYCHATADDR
+	ServeChatPair   bool   // SKYCHATPAIR — default true in config gen
+	NoServeChatPair bool
+
+	// --- Skymail bridge (SMTP↔skywire) ---
+	SkymailBridge   bool // SKYMAILBRIDGE
+	NoSkymailBridge bool
+
+	// --- Skycoin daemon (legacy + multi-instance) ---
+	Skycoind          bool
+	NoSkycoind        bool
+	SkycoindFiber     string // SKYCOIND_FIBER_TOML
+	SkycoindAPI       string // SKYCOIND_API_SETS
+	SkycoindUser      string // SKYCOIND_USER
+	SkycoindInstances string // SKYCOIND_INSTANCES (comma-separated)
+	SkycoindFlags     string // SKYCOIND_FLAGS
+
+	// --- Skycoin web wallet ---
+	Skycoinweb       bool
+	NoSkycoinweb     bool
+	SkycoinwebAddr   string // SKYCOINWEBADDR
+	SkycoinwebNodes  string // SKYCOINWEBNODES (comma-separated)
+	SkycoinwebWallet string // SKYCOINWEBWALLET
+	SkycoinwebUser   string // SKYCOINWEBUSER
+
+	// --- Visor runtime ---
+	BinPath         string // BINPATH
+	LogLevel        string // LOGLVL
+	ShutdownTimeout string // SHUTDOWNTIMEOUT
+	RegTimeout      string // REGTIMEOUT
 }
 
 // New returns a freshly-constructed autoconfig cobra command with
@@ -108,29 +199,106 @@ func New(v *Values) *cobra.Command {
 	// config-gen surface stay in sync. Operators (and the WASM-
 	// rendered install-page form) see what the flag actually DOES,
 	// not just which env var it writes.
+
+	// --- Display ---
 	cmd.Flags().BoolVarP(&v.Verbose, "verbose", "v", false, "show reward address, support links, and other details")
+
+	// --- Hypervisor / identity ---
 	cmd.Flags().StringVar(&v.Hvpks, "hvpks", "", "comma-separated remote hypervisor PKs to dial — writes HYPERVISORPKS in skywire.conf")
 	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "enable local hypervisor — writes ISHYPERVISOR=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "disable local hypervisor — writes ISHYPERVISOR=false in skywire.conf")
+	cmd.Flags().StringVar(&v.HvAddr, "hvaddr", "", "hypervisor HTTP address (host:port) — writes HVHTTPADDR in skywire.conf")
+	cmd.Flags().StringVar(&v.SecretKey, "sk", "", "pin visor secret key (64-hex) — writes SK in skywire.conf. SECURITY: appears in shell history; prefer letting the visor generate its own SK on first boot.")
+	cmd.Flags().StringVar(&v.Version, "version", "", "custom version override for testing — writes VERSION in skywire.conf")
+
+	// --- Visor public/private + autoconnect ---
 	cmd.Flags().StringVar(&v.RewardAddr, "rewardaddr", "", "skycoin reward address or xpub key — writes REWARDSKYADDR in skywire.conf")
 	cmd.Flags().BoolVar(&v.Public, "public", false, "publicize visor in service discovery — writes VISORISPUBLIC=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoPublic, "no-public", false, "unpublish visor from service discovery — writes VISORISPUBLIC=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.PublicIP, "publicip", false, "display visor IP in service discovery — writes DISPLAYNODEIP=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.DisablePubAuto, "disable-public-autoconn", false, "disable autoconnect to public visors — writes DISABLEPUBLICAUTOCONN=true in skywire.conf")
+
+	// --- Service discovery / deployment ---
+	cmd.Flags().BoolVar(&v.TestEnv, "testenv", false, "use test deployment (ports offset +10000 from prod) — writes TESTENV=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.DmsgHTTP, "dmsghttp", false, "use only dmsg for skywire services (no http) — writes DMSGHTTP=true in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgConf, "dmsgconf", "", "dmsghttp config path — writes DMSGCONF in skywire.conf")
+	cmd.Flags().StringVar(&v.URL, "url", "", "services-config URL(s), comma-separated — writes SVCCONFADDR in skywire.conf")
+	cmd.Flags().StringVar(&v.SvcConf, "svcconf", "", "fallback service-configuration file path — writes SVCCONF in skywire.conf")
+	cmd.Flags().IntVar(&v.MinSess, "minsess", 0, "number of dmsg servers to connect to (0 = unlimited; leave unset to keep default 2) — writes MINDMSGSESS in skywire.conf")
+	cmd.Flags().StringVar(&v.StunServers, "stun", "", "STUN servers, comma-separated — writes STUNSERVERS in skywire.conf")
+
+	// --- Transport ports ---
 	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "stcp transport listening port (0 = leave unchanged, random at runtime) — writes STCPRPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "sudp transport listening port (0 = leave unchanged, random at runtime) — writes SUDPHPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
+
+	// --- Whitelists ---
 	cmd.Flags().StringVar(&v.DmsgptyPks, "dmsgpty-pks", "", "additional dmsgpty-whitelist PKs (hypervisor PKs are already implicit) — writes DMSGPTYPKS in skywire.conf")
+	cmd.Flags().StringVar(&v.SurveyPks, "survey", "", "survey whitelist PKs, comma-separated — writes SURVEYPKS in skywire.conf")
+	cmd.Flags().StringVar(&v.RouteSetupPKs, "routesetup", "", "route setup node PKs, comma-separated — writes ROUTESETUPPKS in skywire.conf")
+	cmd.Flags().StringVar(&v.TransportSetup, "tpsetup", "", "transport setup node PKs, comma-separated — writes TPSETUPPKS in skywire.conf")
+
+	// --- Route calculation ---
+	cmd.Flags().BoolVar(&v.CalculateRoutes, "calculate-routes", false, "enable local route calculation — writes CALCULATEROUTES=true in skywire.conf")
+
+	// --- VPN server ---
 	cmd.Flags().BoolVar(&v.VpnServer, "vpnserver", false, "autostart vpn-server — writes VPNSERVER=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoVpnServer, "no-vpnserver", false, "do not autostart vpn-server — writes VPNSERVER=false in skywire.conf")
+	cmd.Flags().StringVar(&v.VpnKillSw, "killsw", "", "vpn client killswitch — writes VPNKS in skywire.conf")
+	cmd.Flags().StringVar(&v.AddVpn, "addvpn", "", "vpn server public key for vpn client — writes ADDVPNPK in skywire.conf")
+	cmd.Flags().StringVar(&v.VpnWl, "vpnwl", "", "vpn server whitelist PKs, comma-separated (empty = allow all) — writes VPNSERVERWL in skywire.conf")
+	cmd.Flags().StringVar(&v.VpnSecure, "secure", "", "vpn server secure-mode status — writes VPNSEVERSECURE in skywire.conf (env var name has a typo upstream)")
+	cmd.Flags().StringVar(&v.VpnNetIfc, "netifc", "", "vpn server network interface — writes VPNSEVERNETIFC in skywire.conf (env var name has a typo upstream)")
+
+	// --- Proxy ---
 	cmd.Flags().BoolVar(&v.ProxyServer, "proxyserver", false, "autostart skysocks (proxy server) — writes PROXYSERVER=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoProxyServer, "no-proxyserver", false, "do not autostart skysocks — writes PROXYSERVER=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "autostart skychat — writes SKYCHAT=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.NoSkychat, "no-skychat", false, "do not autostart skychat — writes SKYCHAT=false in skywire.conf")
+	cmd.Flags().StringVar(&v.ProxyClientPK, "proxyclientpk", "", "proxy server public key for proxy client — writes PROXYCLIENTPK in skywire.conf")
+	cmd.Flags().BoolVar(&v.StartProxyCli, "startproxyclient", false, "autostart proxy client — writes STARTPROXYCLIENT=true in skywire.conf")
+	cmd.Flags().StringVar(&v.ProxyWl, "proxywl", "", "proxy server whitelist PKs, comma-separated (empty = allow all) — writes PROXYSERVERWL in skywire.conf")
+
+	// --- SOCKS5 web bridges ---
 	cmd.Flags().BoolVar(&v.Dmsgweb, "dmsgweb", false, "enable embedded .dmsg resolving SOCKS5 proxy on 127.0.0.1:4445 — writes DMSGWEB=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDmsgweb, "no-dmsgweb", false, "disable embedded .dmsg resolving SOCKS5 proxy — writes DMSGWEB=false in skywire.conf")
 	cmd.Flags().BoolVar(&v.Skynetweb, "skynetweb", false, "enable embedded .skynet resolving SOCKS5 proxy on 127.0.0.1:4446 — writes SKYNETWEB=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoSkynetweb, "no-skynetweb", false, "disable embedded .skynet resolving SOCKS5 proxy — writes SKYNETWEB=false in skywire.conf")
-	cmd.Flags().BoolVar(&v.DisablePubAuto, "disable-public-autoconn", false, "disable autoconnect to public visors — writes DISABLEPUBLICAUTOCONN=true in skywire.conf")
+	cmd.Flags().StringVar(&v.DmsgwebUpstream, "dmsgweb-upstream", "", "upstream SOCKS5 for non-.dmsg traffic (empty chains to skynetweb) — writes DMSGWEBUPSTREAM in skywire.conf")
+	cmd.Flags().StringVar(&v.SkynetwebUpstream, "skynetweb-upstream", "", "upstream SOCKS5 for non-.skynet traffic — writes SKYNETWEBUPSTREAM in skywire.conf")
+
+	// --- Skychat ---
+	cmd.Flags().BoolVar(&v.Skychat, "skychat", false, "autostart skychat — writes SKYCHAT=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkychat, "no-skychat", false, "do not autostart skychat — writes SKYCHAT=false in skywire.conf")
+	cmd.Flags().StringVar(&v.ChatAddr, "chataddr", "", "skychat local address (host:port) — writes SKYCHATADDR in skywire.conf")
+	cmd.Flags().BoolVar(&v.ServeChatPair, "servechatpair", false, "enable skychat pair RPC channel (required for group chat) — writes SKYCHATPAIR=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoServeChatPair, "no-servechatpair", false, "disable skychat pair RPC channel — writes SKYCHATPAIR=false in skywire.conf")
+
+	// --- Skymail bridge ---
+	cmd.Flags().BoolVar(&v.SkymailBridge, "skymail-bridge", false, "enable SMTP↔skywire bridge on 127.0.0.1:1025 — writes SKYMAILBRIDGE=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkymailBridge, "no-skymail-bridge", false, "disable SMTP↔skywire bridge — writes SKYMAILBRIDGE=false in skywire.conf")
+
+	// --- Skycoin daemon ---
+	cmd.Flags().BoolVar(&v.Skycoind, "skycoind", false, "autostart skycoin daemon (legacy single instance) — writes SKYCOIND=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkycoind, "no-skycoind", false, "do not autostart skycoin daemon — writes SKYCOIND=false in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoindFiber, "skycoindfiber", "", "legacy FIBER_TOML path (single skycoin daemon instance) — writes SKYCOIND_FIBER_TOML in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoindAPI, "skycoindapi", "", "legacy api sets (single skycoin daemon instance) — writes SKYCOIND_API_SETS in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoindUser, "skycoindUSER", "", "skycoin daemon UID (applies to every instance) — writes SKYCOIND_USER in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoindInstances, "skycoindinstances", "", "skycoin daemon instances, comma-separated (skycoin or fiber.toml path) — writes SKYCOIND_INSTANCES in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoindFlags, "skycoindflags", "", "extra flags appended to every skycoin daemon (port + data dir auto-allocated) — writes SKYCOIND_FLAGS in skywire.conf")
+
+	// --- Skycoin web wallet ---
+	cmd.Flags().BoolVar(&v.Skycoinweb, "skycoinweb", false, "autostart skycoin web wallet (thin client) — writes SKYCOINWEB=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoSkycoinweb, "no-skycoinweb", false, "do not autostart skycoin web wallet — writes SKYCOINWEB=false in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoinwebAddr, "skycoinwebaddr", "", "skycoin web bind address (host:port) — writes SKYCOINWEBADDR in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoinwebNodes, "skycoinwebnodes", "", "node URLs the skycoin web wallet talks to, comma-separated — writes SKYCOINWEBNODES in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoinwebWallet, "skycoinwebwallet", "", "skycoin web wallet dir override — writes SKYCOINWEBWALLET in skywire.conf")
+	cmd.Flags().StringVar(&v.SkycoinwebUser, "skycoinwebuser", "", "skycoin web UID (empty inherits visor UID) — writes SKYCOINWEBUSER in skywire.conf")
+
+	// --- Visor runtime ---
+	cmd.Flags().StringVar(&v.BinPath, "binpath", "", "bin_path for visor native apps — writes BINPATH in skywire.conf")
+	cmd.Flags().StringVar(&v.LogLevel, "loglvl", "", "log level (debug/info/warn/error) — writes LOGLVL in skywire.conf")
+	cmd.Flags().StringVar(&v.ShutdownTimeout, "timeout", "", "graceful shutdown timeout (e.g. 10s) — writes SHUTDOWNTIMEOUT in skywire.conf")
+	cmd.Flags().StringVar(&v.RegTimeout, "regtimeout", "", "public visor registration timeout (e.g. 10m) — writes REGTIMEOUT in skywire.conf")
 
 	return cmd
 }
@@ -153,29 +321,106 @@ func EnvMap() map[string]EnvMapping {
 // Negation flags (--no-X) carry Negate=true so the bool literal
 // passed at the CLI (always true when the flag is present) gets
 // inverted to "false" at .conf-render time.
+//
+// Kept in the same group order as the New() flag-registration
+// section comments so cross-referencing stays one-to-one.
 var envMap = map[string]EnvMapping{
-	"hvpks":                   {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
-	"ishv":                    {Key: "ISHYPERVISOR", Format: EnvFormatBool},
-	"no-ishv":                 {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
+	// Hypervisor / identity
+	"hvpks":   {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
+	"ishv":    {Key: "ISHYPERVISOR", Format: EnvFormatBool},
+	"no-ishv": {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
+	"hvaddr":  {Key: "HVHTTPADDR", Format: EnvFormatString},
+	"sk":      {Key: "SK", Format: EnvFormatString},
+	"version": {Key: "VERSION", Format: EnvFormatString},
+
+	// Visor public/private + autoconnect
 	"rewardaddr":              {Key: "REWARDSKYADDR", Format: EnvFormatString},
 	"public":                  {Key: "VISORISPUBLIC", Format: EnvFormatBool},
 	"no-public":               {Key: "VISORISPUBLIC", Format: EnvFormatBool, Negate: true},
-	"stcpr":                   {Key: "STCPRPORT", Format: EnvFormatInt},
-	"sudph":                   {Key: "SUDPHPORT", Format: EnvFormatInt},
-	"lan-dmsg-port":           {Key: "LANDMSGPORT", Format: EnvFormatInt},
-	"lan-dmsg-public":         {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
-	"dmsgpty-pks":             {Key: "DMSGPTYPKS", Format: EnvFormatBashArray},
-	"vpnserver":               {Key: "VPNSERVER", Format: EnvFormatBool},
-	"no-vpnserver":            {Key: "VPNSERVER", Format: EnvFormatBool, Negate: true},
-	"proxyserver":             {Key: "PROXYSERVER", Format: EnvFormatBool},
-	"no-proxyserver":          {Key: "PROXYSERVER", Format: EnvFormatBool, Negate: true},
-	"skychat":                 {Key: "SKYCHAT", Format: EnvFormatBool},
-	"no-skychat":              {Key: "SKYCHAT", Format: EnvFormatBool, Negate: true},
-	"dmsgweb":                 {Key: "DMSGWEB", Format: EnvFormatBool},
-	"no-dmsgweb":              {Key: "DMSGWEB", Format: EnvFormatBool, Negate: true},
-	"skynetweb":               {Key: "SKYNETWEB", Format: EnvFormatBool},
-	"no-skynetweb":            {Key: "SKYNETWEB", Format: EnvFormatBool, Negate: true},
+	"publicip":                {Key: "DISPLAYNODEIP", Format: EnvFormatBool},
 	"disable-public-autoconn": {Key: "DISABLEPUBLICAUTOCONN", Format: EnvFormatBool},
+
+	// Service discovery / deployment
+	"testenv":  {Key: "TESTENV", Format: EnvFormatBool},
+	"dmsghttp": {Key: "DMSGHTTP", Format: EnvFormatBool},
+	"dmsgconf": {Key: "DMSGCONF", Format: EnvFormatString},
+	"url":      {Key: "SVCCONFADDR", Format: EnvFormatBashArray},
+	"svcconf":  {Key: "SVCCONF", Format: EnvFormatString},
+	"minsess":  {Key: "MINDMSGSESS", Format: EnvFormatInt},
+	"stun":     {Key: "STUNSERVERS", Format: EnvFormatBashArray},
+
+	// Transport ports
+	"stcpr":           {Key: "STCPRPORT", Format: EnvFormatInt},
+	"sudph":           {Key: "SUDPHPORT", Format: EnvFormatInt},
+	"lan-dmsg-port":   {Key: "LANDMSGPORT", Format: EnvFormatInt},
+	"lan-dmsg-public": {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
+
+	// Whitelists
+	"dmsgpty-pks": {Key: "DMSGPTYPKS", Format: EnvFormatBashArray},
+	"survey":      {Key: "SURVEYPKS", Format: EnvFormatBashArray},
+	"routesetup":  {Key: "ROUTESETUPPKS", Format: EnvFormatBashArray},
+	"tpsetup":     {Key: "TPSETUPPKS", Format: EnvFormatBashArray},
+
+	// Route calculation
+	"calculate-routes": {Key: "CALCULATEROUTES", Format: EnvFormatBool},
+
+	// VPN server
+	"vpnserver":    {Key: "VPNSERVER", Format: EnvFormatBool},
+	"no-vpnserver": {Key: "VPNSERVER", Format: EnvFormatBool, Negate: true},
+	"killsw":       {Key: "VPNKS", Format: EnvFormatString},
+	"addvpn":       {Key: "ADDVPNPK", Format: EnvFormatString},
+	"vpnwl":        {Key: "VPNSERVERWL", Format: EnvFormatBashArray},
+	"secure":       {Key: "VPNSEVERSECURE", Format: EnvFormatString},
+	"netifc":       {Key: "VPNSEVERNETIFC", Format: EnvFormatString},
+
+	// Proxy
+	"proxyserver":      {Key: "PROXYSERVER", Format: EnvFormatBool},
+	"no-proxyserver":   {Key: "PROXYSERVER", Format: EnvFormatBool, Negate: true},
+	"proxyclientpk":    {Key: "PROXYCLIENTPK", Format: EnvFormatString},
+	"startproxyclient": {Key: "STARTPROXYCLIENT", Format: EnvFormatBool},
+	"proxywl":          {Key: "PROXYSERVERWL", Format: EnvFormatBashArray},
+
+	// SOCKS5 web bridges
+	"dmsgweb":            {Key: "DMSGWEB", Format: EnvFormatBool},
+	"no-dmsgweb":         {Key: "DMSGWEB", Format: EnvFormatBool, Negate: true},
+	"skynetweb":          {Key: "SKYNETWEB", Format: EnvFormatBool},
+	"no-skynetweb":       {Key: "SKYNETWEB", Format: EnvFormatBool, Negate: true},
+	"dmsgweb-upstream":   {Key: "DMSGWEBUPSTREAM", Format: EnvFormatString},
+	"skynetweb-upstream": {Key: "SKYNETWEBUPSTREAM", Format: EnvFormatString},
+
+	// Skychat
+	"skychat":          {Key: "SKYCHAT", Format: EnvFormatBool},
+	"no-skychat":       {Key: "SKYCHAT", Format: EnvFormatBool, Negate: true},
+	"chataddr":         {Key: "SKYCHATADDR", Format: EnvFormatString},
+	"servechatpair":    {Key: "SKYCHATPAIR", Format: EnvFormatBool},
+	"no-servechatpair": {Key: "SKYCHATPAIR", Format: EnvFormatBool, Negate: true},
+
+	// Skymail bridge
+	"skymail-bridge":    {Key: "SKYMAILBRIDGE", Format: EnvFormatBool},
+	"no-skymail-bridge": {Key: "SKYMAILBRIDGE", Format: EnvFormatBool, Negate: true},
+
+	// Skycoin daemon
+	"skycoind":          {Key: "SKYCOIND", Format: EnvFormatBool},
+	"no-skycoind":       {Key: "SKYCOIND", Format: EnvFormatBool, Negate: true},
+	"skycoindfiber":     {Key: "SKYCOIND_FIBER_TOML", Format: EnvFormatString},
+	"skycoindapi":       {Key: "SKYCOIND_API_SETS", Format: EnvFormatString},
+	"skycoindUSER":      {Key: "SKYCOIND_USER", Format: EnvFormatString},
+	"skycoindinstances": {Key: "SKYCOIND_INSTANCES", Format: EnvFormatBashArray},
+	"skycoindflags":     {Key: "SKYCOIND_FLAGS", Format: EnvFormatString},
+
+	// Skycoin web wallet
+	"skycoinweb":       {Key: "SKYCOINWEB", Format: EnvFormatBool},
+	"no-skycoinweb":    {Key: "SKYCOINWEB", Format: EnvFormatBool, Negate: true},
+	"skycoinwebaddr":   {Key: "SKYCOINWEBADDR", Format: EnvFormatString},
+	"skycoinwebnodes":  {Key: "SKYCOINWEBNODES", Format: EnvFormatBashArray},
+	"skycoinwebwallet": {Key: "SKYCOINWEBWALLET", Format: EnvFormatString},
+	"skycoinwebuser":   {Key: "SKYCOINWEBUSER", Format: EnvFormatString},
+
+	// Visor runtime
+	"binpath":    {Key: "BINPATH", Format: EnvFormatString},
+	"loglvl":     {Key: "LOGLVL", Format: EnvFormatString},
+	"timeout":    {Key: "SHUTDOWNTIMEOUT", Format: EnvFormatString},
+	"regtimeout": {Key: "REGTIMEOUT", Format: EnvFormatString},
 }
 
 // longDesc matches the pre-factory autoconfig command's Long field
@@ -195,4 +440,10 @@ Mode is selected by PKGENV/USRENV in the env file:
   USRENV=true            → user install at $HOME, systemctl --user
 
   neither set            → falls back to PKGENV when run as root,
-                           USRENV otherwise.`
+                           USRENV otherwise.
+
+Every flag below corresponds to a SKYENV variable in skywire.conf.
+Passing a flag rewrites that line (uncommenting it if necessary);
+omitting a flag leaves the existing line untouched. The downstream
+'cli config gen' invocation then sources skywire.conf so the new
+values take effect on the same run.`

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -5,30 +5,68 @@ import (
 	"testing"
 )
 
-// TestNew_AllFlagsRegistered asserts every flag the pre-factory
-// autoconfig command exposed is registered by New(). The list is
-// hard-coded — adding a new flag means appending to both the
-// factory and this test, which is the intent: the test guards
-// against accidental flag drops, not against intentional adds.
+// allFlags is the canonical list of every flag the factory exposes.
+// Centralized so the registration + envMap + negation tests all
+// agree on the same source of truth. Adding a new flag means adding
+// it here AND to the factory; CI catches drift between the two.
+var allFlags = []string{
+	"verbose",
+	// Hypervisor / identity
+	"hvpks", "ishv", "no-ishv", "hvaddr", "sk", "version",
+	// Visor public/private + autoconnect
+	"rewardaddr", "public", "no-public", "publicip", "disable-public-autoconn",
+	// Service discovery / deployment
+	"testenv", "dmsghttp", "dmsgconf", "url", "svcconf", "minsess", "stun",
+	// Transport ports
+	"stcpr", "sudph", "lan-dmsg-port", "lan-dmsg-public",
+	// Whitelists
+	"dmsgpty-pks", "survey", "routesetup", "tpsetup",
+	// Route calculation
+	"calculate-routes",
+	// VPN server
+	"vpnserver", "no-vpnserver", "killsw", "addvpn", "vpnwl", "secure", "netifc",
+	// Proxy
+	"proxyserver", "no-proxyserver", "proxyclientpk", "startproxyclient", "proxywl",
+	// SOCKS5 web bridges
+	"dmsgweb", "no-dmsgweb", "skynetweb", "no-skynetweb", "dmsgweb-upstream", "skynetweb-upstream",
+	// Skychat
+	"skychat", "no-skychat", "chataddr", "servechatpair", "no-servechatpair",
+	// Skymail bridge
+	"skymail-bridge", "no-skymail-bridge",
+	// Skycoin daemon
+	"skycoind", "no-skycoind", "skycoindfiber", "skycoindapi", "skycoindUSER", "skycoindinstances", "skycoindflags",
+	// Skycoin web wallet
+	"skycoinweb", "no-skycoinweb", "skycoinwebaddr", "skycoinwebnodes", "skycoinwebwallet", "skycoinwebuser",
+	// Visor runtime
+	"binpath", "loglvl", "timeout", "regtimeout",
+}
+
+// negationPairs enumerates every positive/negation flag pair. The
+// negation flag's envMap entry must have Negate=true and share the
+// same Key. allBoolPairFlags is derived from this for the
+// TestEnvMap_Coverage check.
+var negationPairs = []struct {
+	pos, neg string
+}{
+	{"ishv", "no-ishv"},
+	{"public", "no-public"},
+	{"vpnserver", "no-vpnserver"},
+	{"proxyserver", "no-proxyserver"},
+	{"skychat", "no-skychat"},
+	{"dmsgweb", "no-dmsgweb"},
+	{"skynetweb", "no-skynetweb"},
+	{"servechatpair", "no-servechatpair"},
+	{"skymail-bridge", "no-skymail-bridge"},
+	{"skycoind", "no-skycoind"},
+	{"skycoinweb", "no-skycoinweb"},
+}
+
+// TestNew_AllFlagsRegistered asserts every flag in allFlags is
+// registered by New(). Adding a new flag means appending to the
+// allFlags list AND to the factory; this test catches drift.
 func TestNew_AllFlagsRegistered(t *testing.T) {
-	want := []string{
-		"verbose",
-		"hvpks",
-		"ishv", "no-ishv",
-		"rewardaddr",
-		"public", "no-public",
-		"stcpr", "sudph",
-		"lan-dmsg-port", "lan-dmsg-public",
-		"dmsgpty-pks",
-		"vpnserver", "no-vpnserver",
-		"proxyserver", "no-proxyserver",
-		"skychat", "no-skychat",
-		"dmsgweb", "no-dmsgweb",
-		"skynetweb", "no-skynetweb",
-		"disable-public-autoconn",
-	}
 	cmd := New(&Values{})
-	for _, name := range want {
+	for _, name := range allFlags {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag --%s", name)
 		}
@@ -52,27 +90,35 @@ func TestNew_ShortNames(t *testing.T) {
 // TestNew_BindingsTrackValues asserts the returned command's flag
 // bindings actually write into the Values struct fields. Catches
 // the class of bug where the factory wires a flag to a local that
-// gets garbage-collected after New() returns.
+// gets garbage-collected after New() returns. A few representative
+// flags from different value-types cover the typical breakage modes
+// (string-bool-int / pre-and-post-expansion field positions).
 func TestNew_BindingsTrackValues(t *testing.T) {
 	v := &Values{}
 	cmd := New(v)
-	if err := cmd.Flags().Set("hvpks", "0123,4567"); err != nil {
-		t.Fatalf("Set hvpks: %v", err)
+	cases := []struct {
+		flag, val string
+		check     func() bool
+	}{
+		{"hvpks", "0123,4567", func() bool { return v.Hvpks == "0123,4567" }},
+		{"ishv", "true", func() bool { return v.Ishv }},
+		{"stcpr", "7777", func() bool { return v.StcprPort == 7777 }},
+		// New flags from the parity expansion: cover one per group.
+		{"testenv", "true", func() bool { return v.TestEnv }},
+		{"minsess", "5", func() bool { return v.MinSess == 5 }},
+		{"survey", "abc,def", func() bool { return v.SurveyPks == "abc,def" }},
+		{"killsw", "/etc/foo", func() bool { return v.VpnKillSw == "/etc/foo" }},
+		{"skycoindinstances", "a,b", func() bool { return v.SkycoindInstances == "a,b" }},
+		{"loglvl", "debug", func() bool { return v.LogLevel == "debug" }},
+		{"sk", "01" + strings.Repeat("0", 62), func() bool { return v.SecretKey == "01"+strings.Repeat("0", 62) }},
 	}
-	if v.Hvpks != "0123,4567" {
-		t.Errorf("Values.Hvpks = %q after Set; want %q", v.Hvpks, "0123,4567")
-	}
-	if err := cmd.Flags().Set("ishv", "true"); err != nil {
-		t.Fatalf("Set ishv: %v", err)
-	}
-	if !v.Ishv {
-		t.Errorf("Values.Ishv = false after Set; want true")
-	}
-	if err := cmd.Flags().Set("stcpr", "7777"); err != nil {
-		t.Fatalf("Set stcpr: %v", err)
-	}
-	if v.StcprPort != 7777 {
-		t.Errorf("Values.StcprPort = %d after Set; want 7777", v.StcprPort)
+	for _, c := range cases {
+		if err := cmd.Flags().Set(c.flag, c.val); err != nil {
+			t.Fatalf("Set %s=%q: %v", c.flag, c.val, err)
+		}
+		if !c.check() {
+			t.Errorf("Values field for --%s did not pick up Set value %q", c.flag, c.val)
+		}
 	}
 }
 
@@ -84,22 +130,10 @@ func TestNew_BindingsTrackValues(t *testing.T) {
 // about it.
 func TestEnvMap_Coverage(t *testing.T) {
 	m := EnvMap()
-	want := []string{
-		"hvpks",
-		"ishv", "no-ishv",
-		"rewardaddr",
-		"public", "no-public",
-		"stcpr", "sudph",
-		"lan-dmsg-port", "lan-dmsg-public",
-		"dmsgpty-pks",
-		"vpnserver", "no-vpnserver",
-		"proxyserver", "no-proxyserver",
-		"skychat", "no-skychat",
-		"dmsgweb", "no-dmsgweb",
-		"skynetweb", "no-skynetweb",
-		"disable-public-autoconn",
-	}
-	for _, name := range want {
+	for _, name := range allFlags {
+		if name == "verbose" {
+			continue
+		}
 		if _, ok := m[name]; !ok {
 			t.Errorf("envMap missing entry for --%s", name)
 		}
@@ -107,6 +141,13 @@ func TestEnvMap_Coverage(t *testing.T) {
 	// --verbose must NOT be in envMap (display-only flag).
 	if _, ok := m["verbose"]; ok {
 		t.Errorf("envMap should NOT have --verbose entry; that flag has no .conf effect")
+	}
+	// And every envMap key should be a registered flag.
+	cmd := New(&Values{})
+	for k := range m {
+		if cmd.Flags().Lookup(k) == nil {
+			t.Errorf("envMap has --%s but factory does not register it", k)
+		}
 	}
 }
 
@@ -117,18 +158,7 @@ func TestEnvMap_Coverage(t *testing.T) {
 // the inverse of the operator's intent.
 func TestEnvMap_NegationInversion(t *testing.T) {
 	m := EnvMap()
-	pairs := []struct {
-		pos, neg string
-	}{
-		{"ishv", "no-ishv"},
-		{"public", "no-public"},
-		{"vpnserver", "no-vpnserver"},
-		{"proxyserver", "no-proxyserver"},
-		{"skychat", "no-skychat"},
-		{"dmsgweb", "no-dmsgweb"},
-		{"skynetweb", "no-skynetweb"},
-	}
-	for _, p := range pairs {
+	for _, p := range negationPairs {
 		pos, ok := m[p.pos]
 		if !ok {
 			t.Errorf("envMap missing positive flag --%s", p.pos)
@@ -151,6 +181,25 @@ func TestEnvMap_NegationInversion(t *testing.T) {
 	}
 }
 
+// TestEnvMap_UniqueKeys asserts the SKYENV variable names are
+// unique across positive flags — two distinct positive flags
+// pointing at the same SKYENV key would silently shadow each
+// other when both are passed. Negation flags share keys with
+// their positive partners by design and are excluded here.
+func TestEnvMap_UniqueKeys(t *testing.T) {
+	m := EnvMap()
+	seen := map[string]string{}
+	for flag, mapping := range m {
+		if mapping.Negate {
+			continue
+		}
+		if other, dup := seen[mapping.Key]; dup {
+			t.Errorf("SKYENV key %q is written by both --%s and --%s (positive flags must be unique)", mapping.Key, other, flag)
+		}
+		seen[mapping.Key] = flag
+	}
+}
+
 // TestNew_UsageString_RendersWithoutError asserts cobra's help
 // rendering doesn't panic and produces a non-empty string. The
 // WASM consumer (apt-repo install page) relies on this to render
@@ -161,8 +210,9 @@ func TestNew_UsageString_RendersWithoutError(t *testing.T) {
 	if usage == "" {
 		t.Fatal("UsageString returned empty")
 	}
-	// Sanity: every flag should appear in the help text.
-	for _, name := range []string{"hvpks", "ishv", "rewardaddr"} {
+	// Sanity: every registered flag should appear in the help text.
+	// (We sample a few to keep the failure message readable.)
+	for _, name := range []string{"hvpks", "ishv", "rewardaddr", "testenv", "skycoindinstances", "loglvl"} {
 		if !strings.Contains(usage, "--"+name) {
 			t.Errorf("UsageString missing --%s", name)
 		}


### PR DESCRIPTION
## Why

Before this PR, `skywire autoconfig --help` exposed 15 of the ~55 SKYENV variables that `cli config gen` actually reads. Operators wanting to set any of the remaining ~40 had to either hand-edit `/etc/skywire.conf` or shell out to `cli config gen` directly. The two surfaces had drifted: autoconfig was effectively a "quick install" subset, not a full config-gen alternative.

This PR makes autoconfig a strict superset over the SKYENV-reading subset of config gen, so `/etc/skywire.conf` becomes the complete source of truth.

## What

Total autoconfig flag count: **24 → 69**. New SKYENV bindings, grouped:

- **Service discovery / deployment**: `--testenv`, `--dmsghttp`, `--dmsgconf`, `--url`, `--svcconf`, `--minsess`, `--stun`
- **Whitelists**: `--survey`, `--routesetup`, `--tpsetup`
- **Routing**: `--calculate-routes`
- **Hypervisor / identity**: `--hvaddr`, `--sk` (with security warning), `--version`, `--publicip`
- **VPN feature**: `--killsw`, `--addvpn`, `--vpnwl`, `--secure`, `--netifc`
- **Proxy feature**: `--proxyclientpk`, `--startproxyclient`, `--proxywl`
- **SOCKS5 chain**: `--dmsgweb-upstream`, `--skynetweb-upstream`
- **Skychat**: `--chataddr`, `--servechatpair` / `--no-servechatpair` *(default true in config gen → needs the negation form)*
- **Skymail bridge**: `--skymail-bridge` / `--no-skymail-bridge`
- **Skycoin daemon**: `--skycoind` / `--no-skycoind`, `--skycoindfiber`, `--skycoindapi`, `--skycoindUSER`, `--skycoindinstances`, `--skycoindflags`
- **Skycoin web wallet**: `--skycoinweb` / `--no-skycoinweb`, `--skycoinwebaddr`, `--skycoinwebnodes`, `--skycoinwebwallet`, `--skycoinwebuser`
- **Visor runtime**: `--binpath`, `--loglvl`, `--timeout`, `--regtimeout`

## What's intentionally *not* exposed

Non-SKYENV `cli config gen` flags — meta-output (`--stdout`, `--out`, `--regen`, `--force`, `--hide`, `--envs`, `--envout`, `--squash`, `--nofetch`, `--nodefaults`), per-service generators (`--sn`, `--dmsgdisc`, `--dmsgsrv`, `--tpd`, `--sd`, `--ar`, `--rf`), OS selector (`--os`, `--pkg`, `--user`), and apps-list editing (`--example-apps`, `--external-apps`, `--disableapps`). These either have no persistence surface or control config-gen behavior that doesn't survive into `skywire.conf` — autoconfig has nothing to do with them.

## Implementation

Authoritative flag set lives in `pkg/skywireconfig/autoconfigcmd` (the WASM-clean factory). `cmd/skywire/commands/autoconfig.go` reads `autoconfigVals` + `EnvMap()` and emits `/etc/skywire.conf` edits. The WASM consumer at `apt-repo` automatically picks up the new flags when it re-bumps the skywire pin — no code change required there.

Tests parametrize via shared `allFlags` + `negationPairs` vars so future flag adds touch only those lists. New `TestEnvMap_UniqueKeys` asserts no two positive flags target the same SKYENV variable. Test files now cover ~3× the surface area.

## Test plan

- [x] `make format` clean
- [x] `golangci-lint` clean on touched packages
- [x] `go test ./pkg/skywireconfig/... ./cmd/skywire/...` passes
- [x] Integration: `--testenv --minsess=4 --stun="a:1,b:2"` against a fresh skywire.conf produces the expected uncommented + value-set lines, and downstream `cli config gen` picks up the new values via SKYENV
- [x] `GOOS=js GOARCH=wasm go vet ./pkg/skywireconfig/... ./pkg/visor/visorconfig/` clean (WASM build path unaffected)
- [ ] CI green