### PR TITLE
fix(third_party): silence windows gosec G103 inside Call() args

### DIFF
--- a/third_party/VictoriaMetrics/metrics/process_metrics_windows.go
+++ b/third_party/VictoriaMetrics/metrics/process_metrics_windows.go
@@ -46,7 +46,7 @@ func writeProcessMetrics(w io.Writer) {
 	var mc processMemoryCounters
 	r1, _, err := procGetProcessMemoryInfo.Call( //nolint:gosec // upstream code; safe under documented invariants
 		uintptr(h),
-		uintptr(unsafe.Pointer(&mc)),
+		uintptr(unsafe.Pointer(&mc)), //nolint:gosec // Win32 syscall ABI requires raw pointer; mc is a stack local that outlives the call
 		unsafe.Sizeof(mc),
 	)
 	if r1 != 1 {
@@ -70,7 +70,7 @@ func writeFDMetrics(w io.Writer) {
 	var count uint32
 	r1, _, err := procGetProcessHandleCount.Call( //nolint:gosec // upstream code; safe under documented invariants
 		uintptr(h),
-		uintptr(unsafe.Pointer(&count)),
+		uintptr(unsafe.Pointer(&count)), //nolint:gosec // Win32 syscall ABI requires raw pointer; count is a stack local that outlives the call
 	)
 	if r1 != 1 {
 		log.Printf("ERROR: metrics: cannot determine open file descriptors count: %s", err)


### PR DESCRIPTION
## Why

Since #2825 (~4 days), every PR's **windows** CI job has failed with:

\`\`\`
third_party/VictoriaMetrics/metrics/process_metrics_windows.go:49:11: G103: Use of unsafe calls should be audited (gosec)
		uintptr(unsafe.Pointer(&mc)),
third_party/VictoriaMetrics/metrics/process_metrics_windows.go:73:11: G103: Use of unsafe calls should be audited (gosec)
		uintptr(unsafe.Pointer(&count)),
\`\`\`

Linux + darwin lint don't see this file (windows build tag), so all PRs' linux/darwin jobs stay green and the issue blends in.

The existing \`//nolint:gosec\` on the parent \`procGet*.Call(\` line sits at the outer statement's scope. golangci-lint's nolint matcher treats the inner \`unsafe.Pointer\` expression as a separate AST node, so it gets reported anyway.

## What

Add the \`//nolint:gosec\` directive directly on the flagged \`unsafe.Pointer\` lines with a short rationale: Win32 syscall ABI requires the raw pointer, and the pointee outlives the Call() — the same logic already documented on the parent Call line.

## Repro

\`\`\`
CGO_ENABLED=0 GOOS=windows golangci-lint run -c .golangci.yml \\
  --build-tags 'withoutsystray withoutgotop' \\
  ./third_party/VictoriaMetrics/...
\`\`\`

## Test plan

- [x] \`GOOS=windows golangci-lint run ... ./third_party/VictoriaMetrics/...\` → 0 issues
- [x] Default-OS golangci-lint still 0 issues
- [ ] CI windows job goes green