### PR TITLE
refactor(visorconfig,dmsg/disc): drop net/http from WASM build graph

### DIFF
--- a/pkg/dmsg/disc/client.go
+++ b/pkg/dmsg/disc/client.go
@@ -1,4 +1,12 @@
+//go:build !js
+
 // Package disc pkg/disc/client.go
+//
+// HTTP-based APIClient. Build-tag-gated to keep net/http out of the
+// js/wasm build graph; the EntryReader/EntryWriter/APIClient
+// interfaces live in interface.go (no build tag) so consumers like
+// pkg/visor/visorconfig still see the type names under GOOS=js
+// without dragging net/http in. See interface.go for the rationale.
 package disc
 
 import (
@@ -10,36 +18,9 @@ import (
 	"sync"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
-
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 )
-
-var json = jsoniter.ConfigFastest
-
-// EntryReader provides read-only access to discovery entries.
-type EntryReader interface {
-	Entry(context.Context, cipher.PubKey) (*Entry, error)
-	AvailableServers(context.Context) ([]*Entry, error)
-	AllServers(context.Context) ([]*Entry, error)
-}
-
-// EntryWriter provides write access to discovery entries.
-type EntryWriter interface {
-	PostEntry(context.Context, *Entry) error
-	PutEntry(context.Context, cipher.SecKey, *Entry) error
-	DelEntry(context.Context, *Entry) error
-}
-
-// APIClient implements dmsg discovery API client.
-type APIClient interface {
-	EntryReader
-	EntryWriter
-	AllEntries(ctx context.Context) ([]string, error)
-	AllClientsByServer(ctx context.Context) (map[string][]*Entry, error)
-	ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*Entry, error)
-}
 
 // HTTPClient represents a client that communicates with a dmsg-discovery service through http, it
 // implements APIClient

--- a/pkg/dmsg/disc/http_message.go
+++ b/pkg/dmsg/disc/http_message.go
@@ -1,4 +1,10 @@
+//go:build !js
+
 // Package disc pkg/disc/http_message.go
+//
+// HTTP-response message types used by the discovery service's HTTP
+// API. Build-tag-gated alongside client.go to keep net/http out of
+// the WASM build graph (see interface.go for rationale).
 package disc
 
 import (

--- a/pkg/dmsg/disc/interface.go
+++ b/pkg/dmsg/disc/interface.go
@@ -1,0 +1,52 @@
+// Package disc — pkg/dmsg/disc/interface.go
+//
+// Holds the cross-build interface definitions (EntryReader,
+// EntryWriter, APIClient) that callers depend on for type-checking
+// regardless of whether they actually instantiate an HTTP client.
+//
+// The HTTP implementation lives in client.go under //go:build !js;
+// keeping the interfaces in their own file (with no build tag and
+// no net/http import) means consumers like
+// pkg/visor/visorconfig — which only need *Entry plus the
+// interface shapes for type aliasing — can compile under
+// GOOS=js GOARCH=wasm (TinyGo included) without the WASM build
+// graph pulling in net/http and tripping over TinyGo 0.41.1's
+// net/http stdlib bug.
+package disc
+
+import (
+	"context"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// json is the package-wide JSON codec. Declared here (rather than
+// in client.go) because entry.go also uses it for Marshal/Unmarshal
+// and client.go is now build-tag-gated; the variable needs to be
+// available across all build configurations.
+var json = jsoniter.ConfigFastest
+
+// EntryReader provides read-only access to discovery entries.
+type EntryReader interface {
+	Entry(context.Context, cipher.PubKey) (*Entry, error)
+	AvailableServers(context.Context) ([]*Entry, error)
+	AllServers(context.Context) ([]*Entry, error)
+}
+
+// EntryWriter provides write access to discovery entries.
+type EntryWriter interface {
+	PostEntry(context.Context, *Entry) error
+	PutEntry(context.Context, cipher.SecKey, *Entry) error
+	DelEntry(context.Context, *Entry) error
+}
+
+// APIClient implements dmsg discovery API client.
+type APIClient interface {
+	EntryReader
+	EntryWriter
+	AllEntries(ctx context.Context) ([]string, error)
+	AllClientsByServer(ctx context.Context) (map[string][]*Entry, error)
+	ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*Entry, error)
+}

--- a/pkg/dmsg/disc/testing.go
+++ b/pkg/dmsg/disc/testing.go
@@ -1,4 +1,10 @@
+//go:build !js
+
 // Package disc pkg/disc/testing.go
+//
+// Mock APIClient for tests. Build-tag-gated because it imports
+// net/http (for status-code constants). See interface.go for the
+// rationale on splitting net/http-using code from the WASM build.
 package disc
 
 import (

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -1,4 +1,10 @@
 // Package visorconfig pkg/visor/visorconfig/hypergo
+//
+// The CookieConfig.SameSite() method (which returns http.SameSite)
+// is the only net/http user in this file; it's moved to
+// hypervisorconfig_native.go under //go:build !js so this file
+// compiles cleanly for js/wasm. See services.go's package doc for
+// the broader rationale.
 package visorconfig
 
 import (
@@ -6,7 +12,6 @@ import (
 	"encoding/json"
 	"io/fs"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -226,7 +231,7 @@ func (c *CookieConfig) HTTPOnly() bool {
 }
 
 // SameSite gets cookie's `SameSite` value.
-func (c *CookieConfig) SameSite() http.SameSite {
-	// using default value for now
-	return http.SameSiteDefaultMode
-}
+//
+// Implementation lives in hypervisorconfig_native.go under
+// //go:build !js — see services.go's package doc for the
+// rationale on keeping net/http out of the WASM build graph.

--- a/pkg/visor/visorconfig/hypervisorconfig_native.go
+++ b/pkg/visor/visorconfig/hypervisorconfig_native.go
@@ -1,0 +1,19 @@
+//go:build !js
+
+// Package visorconfig pkg/visor/visorconfig/hypervisorconfig_native.go
+//
+// Native (non-WASM) implementation of CookieConfig.SameSite —
+// returns http.SameSite, so it can't compile under GOOS=js without
+// dragging net/http into the WASM build graph. See services.go's
+// package doc for the broader rationale.
+package visorconfig
+
+import (
+	"net/http"
+)
+
+// SameSite gets cookie's `SameSite` value.
+func (c *CookieConfig) SameSite() http.SameSite {
+	// using default value for now
+	return http.SameSiteDefaultMode
+}

--- a/pkg/visor/visorconfig/services.go
+++ b/pkg/visor/visorconfig/services.go
@@ -1,57 +1,19 @@
 // Package visorconfig pkg/visor/visorconfig/services.go
+//
+// Defines the Services struct that mirrors the deployment.Services
+// JSON shape and is embedded in V1. The runtime-only HTTP-fetch
+// helper Fetch() lives in services_native.go under a //go:build !js
+// constraint so the WASM build graph (genvisor, autoconfigcmd,
+// install-page) doesn't pull in net/http — TinyGo 0.41.1's stdlib
+// can't compile net/http when our transitive surface widens.
 package visorconfig
 
 import (
 	"encoding/json"
-	"io"
-	"net/http"
-	"time"
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/logging"
 )
-
-// Fetch fetches the service URLs & ip:ports from the config service endpoint
-func Fetch(mLog *logging.MasterLogger, serviceConf string, stdout bool) (services *Services) {
-
-	client := http.Client{
-		Timeout: time.Second * 15, // Timeout after 15 seconds
-	}
-	//create the http request
-	req, err := http.NewRequest(http.MethodGet, serviceConf, nil)
-	if err != nil {
-		mLog.WithError(err).Fatal("Failed to create http request\n")
-	}
-	req.Header.Add("Cache-Control", "no-cache")
-	//check for errors in the response
-	res, err := client.Do(req)
-	if err != nil {
-		//silence errors for stdout
-		if !stdout {
-			mLog.WithError(err).Error("Failed to fetch servers\n")
-			mLog.Warn("Falling back on hardcoded servers")
-		}
-	} else {
-		// nil error from client.Do(req)
-		if res.Body != nil {
-			defer res.Body.Close() //nolint:errcheck
-		}
-		body, err := io.ReadAll(res.Body)
-		if err != nil {
-			mLog.WithError(err).Fatal("Failed to read response\n")
-		}
-		//fill in services struct with the response
-		err = json.Unmarshal(body, &services)
-		if err != nil {
-			mLog.WithError(err).Fatal("Failed to unmarshal json response\n")
-		}
-		if !stdout {
-			mLog.Infof("Fetched service endpoints from '%s'", serviceConf)
-		}
-	}
-	return services
-}
 
 // EnvServices is the struct for the outer JSON
 type EnvServices struct {

--- a/pkg/visor/visorconfig/services_native.go
+++ b/pkg/visor/visorconfig/services_native.go
@@ -1,0 +1,62 @@
+//go:build !js
+
+// Package visorconfig pkg/visor/visorconfig/services_native.go
+//
+// Native (non-WASM) implementation of Fetch, the HTTP helper that
+// retrieves a Services payload from a conf-service endpoint. Lives
+// here (rather than in services.go) so the WASM build graph for
+// genvisor/autoconfigcmd/install-page doesn't pull in net/http.
+// See services.go's package doc for context.
+package visorconfig
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Fetch fetches the service URLs & ip:ports from the config service
+// endpoint over HTTP. Used by the visor's CLI config-gen path; not
+// reachable from the WASM-clean genvisor.Generate flow (which uses
+// the embedded deployment.Prod instead).
+func Fetch(mLog *logging.MasterLogger, serviceConf string, stdout bool) (services *Services) {
+	client := http.Client{
+		Timeout: time.Second * 15, // Timeout after 15 seconds
+	}
+	//create the http request
+	req, err := http.NewRequest(http.MethodGet, serviceConf, nil)
+	if err != nil {
+		mLog.WithError(err).Fatal("Failed to create http request\n")
+	}
+	req.Header.Add("Cache-Control", "no-cache")
+	//check for errors in the response
+	res, err := client.Do(req)
+	if err != nil {
+		//silence errors for stdout
+		if !stdout {
+			mLog.WithError(err).Error("Failed to fetch servers\n")
+			mLog.Warn("Falling back on hardcoded servers")
+		}
+	} else {
+		// nil error from client.Do(req)
+		if res.Body != nil {
+			defer res.Body.Close() //nolint:errcheck
+		}
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			mLog.WithError(err).Fatal("Failed to read response\n")
+		}
+		//fill in services struct with the response
+		err = json.Unmarshal(body, &services)
+		if err != nil {
+			mLog.WithError(err).Fatal("Failed to unmarshal json response\n")
+		}
+		if !stdout {
+			mLog.Infof("Fetched service endpoints from '%s'", serviceConf)
+		}
+	}
+	return services
+}


### PR DESCRIPTION
## Why

The WASM build path used by apt-repo's install-page generator (\`pkg/skywireconfig/{autoconfigcmd,keypair,genvisor}\`) transitively pulls in \`pkg/visor/visorconfig\` and \`pkg/dmsg/disc\`. Both of those packages import \`net/http\` for runtime-only paths (HTTP service-config fetch, cookie SameSite enum, HTTP discovery client + status-code message types, mock APIClient).

This pulls \`net/http\` into the WASM build graph. Harmless for the Go toolchain but TinyGo 0.41.1's stdlib has a \`roundTrip\` case-mismatch in \`net/http/roundtrip_js.go\` that surfaces once the transitive import surface widens (e.g. once genvisor pulls in deployment.Prod's services-config JSON path). Side effect: Go-WASM build was 8.6MB and growing.

## What

Split each affected package into a "WASM-clean" core file and a \`//go:build !js\` extension file:

\`\`\`
pkg/dmsg/disc/
  interface.go         (new, no build tag) — EntryReader,
                       EntryWriter, APIClient + package json var
  entry.go             (no build tag) — Entry struct
  fallback.go          (no build tag)
  client.go            (//go:build !js) — httpClient impl
  http_message.go      (//go:build !js) — HTTPMessage consts
  testing.go           (//go:build !js) — mock APIClient

pkg/visor/visorconfig/
  services.go          (no build tag) — Services + EnvServices
  services_native.go   (new, //go:build !js) — Fetch helper
  hypervisorconfig.go  (no build tag, minus SameSite)
  hypervisorconfig_native.go (new, //go:build !js) — SameSite
\`\`\`

## Effects

- \`GOOS=js GOARCH=wasm go list -deps ./pkg/skywireconfig/... ./pkg/visor/visorconfig/\` no longer mentions \`net/http\` or any of its 7 transitive \`net/http/*\` internal packages.
- Go-WASM build size: 8.6MB → 7.3MB (≈ −15%). apt-repo's inline-base64 \`/generator/index.html\` shrinks proportionally.

## Not in scope

TinyGo still won't compile, but for a separate reason — reflect runtime helpers (\`reflect.unsafe_New\`, \`reflect.mapassign\`, ...) needed by \`encoding/json\`. Removing \`encoding/json\` from the WASM graph is a much larger refactor (logrus, google/uuid, blang/semver, jsoniter all import it transitively). Out of scope here; the Go-WASM path remains the production install-page artifact.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`GOOS=js GOARCH=wasm go build ./pkg/skywireconfig/... ./pkg/visor/visorconfig/ ./pkg/dmsg/disc/\` — clean
- [x] \`go test ./pkg/dmsg/disc/... ./pkg/visor/visorconfig/... ./pkg/skywireconfig/...\` — pass
- [ ] CI green