### PR TITLE
refactor: purge encoding/json from WASM build graph — TinyGo unlocked

### DIFF
--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,8 +1,16 @@
 // Package buildinfo pkg/skywire-utilities/pkg/buildinfo/buildinfo.go
+//
+// The encoding/json-using init() that parses ldflags-injected
+// `go list -m -json` output lives in buildinfo_native.go (!js).
+// Under js/wasm, ldflags injection is not the typical path —
+// the install-page WASM is rebuilt against the latest skywire
+// dependency, not with custom -X overrides — so the json parse
+// is effectively dead code there. Build-tag-gating it lets
+// TinyGo strip encoding/json's reflect runtime helpers from the
+// WASM bundle.
 package buildinfo
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -41,26 +49,17 @@ type ModuleInfo struct {
 var commitRegex = regexp.MustCompile(`[a-f0-9]{12,}$`) // <-- match commit from end of string
 var dateRegex = regexp.MustCompile(`\d{14}`)           // <-- match date anywhere
 
-func init() {
-	// Always read build info — needed for DepVersion even when version
-	// is provided via ldflags.
+// init() is split across buildinfo_native.go (!js) and
+// buildinfo_js.go (js). The !js variant parses ldflags-injected
+// `golist` via json.Unmarshal; the js variant skips that branch
+// (no encoding/json in the WASM build graph). Both call
+// readDebugBuildInfo to populate `bi` + `goversion`.
+//
+// readDebugBuildInfo is shared between the two — no json, just
+// debug.ReadBuildInfo plus the version/commit/date extraction.
+func readDebugBuildInfo() {
 	var ok bool
 	bi, ok = debug.ReadBuildInfo()
-
-	// Use ldflags-provided `golist` info if available
-	if golist != "" {
-		var mInfo ModuleInfo
-		if err := json.Unmarshal([]byte(golist), &mInfo); err == nil {
-			if mInfo.Version != "" && version == unknown {
-				version = mInfo.Version
-			}
-			if mInfo.Origin.Hash != "" && commit == unknown {
-				commit = mInfo.Origin.Hash
-			}
-		}
-	}
-
-	// If version is still unknown, try reading from runtime build info
 	if version == unknown || version == "" {
 		if ok {
 			if bi.Main.Version != "" {

--- a/pkg/buildinfo/buildinfo_js.go
+++ b/pkg/buildinfo/buildinfo_js.go
@@ -1,0 +1,15 @@
+//go:build js
+
+// Package buildinfo pkg/buildinfo/buildinfo_js.go
+//
+// js/wasm init() — skips the ldflags-injected `golist` parse path
+// (which would need encoding/json). The install-page WASM doesn't
+// use ldflags-injection; its version info comes purely from
+// debug.ReadBuildInfo via readDebugBuildInfo. See buildinfo.go's
+// package doc for the broader rationale on keeping encoding/json
+// out of the WASM build graph.
+package buildinfo
+
+func init() {
+	readDebugBuildInfo()
+}

--- a/pkg/buildinfo/buildinfo_native.go
+++ b/pkg/buildinfo/buildinfo_native.go
@@ -1,0 +1,31 @@
+//go:build !js
+
+// Package buildinfo pkg/buildinfo/buildinfo_native.go
+//
+// Native init() that parses the ldflags-injected `go list -m -json`
+// output via encoding/json. Build-tag-gated off the WASM path —
+// see buildinfo.go's package doc for the rationale.
+package buildinfo
+
+import (
+	"encoding/json"
+)
+
+func init() {
+	// Use ldflags-provided `golist` info if available — produces the
+	// canonical version + commit info on release builds.
+	if golist != "" {
+		var mInfo ModuleInfo
+		if err := json.Unmarshal([]byte(golist), &mInfo); err == nil {
+			if mInfo.Version != "" && version == unknown {
+				version = mInfo.Version
+			}
+			if mInfo.Origin.Hash != "" && commit == unknown {
+				commit = mInfo.Origin.Hash
+			}
+		}
+	}
+	// Always read build info — needed for DepVersion even when
+	// version is provided via ldflags.
+	readDebugBuildInfo()
+}

--- a/pkg/dmsg/disc/entry.go
+++ b/pkg/dmsg/disc/entry.go
@@ -227,46 +227,12 @@ func NewServerEntry(pk cipher.PubKey, seq uint64, addr string, availableSessions
 	}
 }
 
-// VerifySignature check if signature matches to Entry's PubKey.
-func (e *Entry) VerifySignature() error {
-	entry := *e
-
-	// Get and parse signature
-	signature := cipher.Sig{}
-	err := signature.UnmarshalText([]byte(e.Signature))
-	if err != nil {
-		return err
-	}
-
-	// Set signature field to zero-value
-	entry.Signature = ""
-
-	// Get hash of the entry
-	entryJSON, err := json.Marshal(entry)
-	if err != nil {
-		return err
-	}
-
-	return cipher.VerifyPubKeySignedPayload(e.Static, signature, entryJSON)
-}
-
-// Sign signs Entry with provided SecKey.
-func (e *Entry) Sign(sk cipher.SecKey) error {
-	// Clear previous signature, in case there was any
-	e.Signature = ""
-
-	entryJSON, err := json.Marshal(e)
-	if err != nil {
-		return err
-	}
-
-	sig, err := cipher.SignPayload(entryJSON, sk)
-	if err != nil {
-		return err
-	}
-	e.Signature = sig.Hex()
-	return nil
-}
+// VerifySignature and Sign live in entry_native.go (//go:build !js)
+// because their implementations call json.Marshal on the Entry to
+// produce the signed payload. encoding/json drags reflect runtime
+// helpers TinyGo's stdlib can't link; signing isn't reachable from
+// the install-page WASM either way, so the build-tag split is a
+// pure WASM-bundle reduction with no functional cost.
 
 // Validate checks if entry is valid.
 func (e *Entry) Validate(validateTimestamp bool) error {

--- a/pkg/dmsg/disc/entry_native.go
+++ b/pkg/dmsg/disc/entry_native.go
@@ -1,0 +1,56 @@
+//go:build !js
+
+// Package disc pkg/dmsg/disc/entry_native.go
+//
+// Sign + VerifySignature use json.Marshal on the Entry to produce
+// the canonical signed payload. encoding/json drags reflect runtime
+// helpers TinyGo's stdlib doesn't ship, so the methods are split
+// off the WASM build. The install-page WASM never signs or verifies
+// discovery entries — those operations are visor-runtime only.
+package disc
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// VerifySignature checks if the entry's signature matches its
+// PubKey. Build-tag-gated — see this file's package doc.
+func (e *Entry) VerifySignature() error {
+	entry := *e
+
+	// Get and parse signature.
+	signature := cipher.Sig{}
+	err := signature.UnmarshalText([]byte(e.Signature))
+	if err != nil {
+		return err
+	}
+
+	// Set signature field to zero-value before computing the hash.
+	entry.Signature = ""
+
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+
+	return cipher.VerifyPubKeySignedPayload(e.Static, signature, entryJSON)
+}
+
+// Sign signs the Entry with the provided SecKey. Build-tag-gated —
+// see this file's package doc.
+func (e *Entry) Sign(sk cipher.SecKey) error {
+	// Clear previous signature, in case there was any.
+	e.Signature = ""
+
+	entryJSON, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+
+	sig, err := cipher.SignPayload(entryJSON, sk)
+	if err != nil {
+		return err
+	}
+	e.Signature = sig.Hex()
+	return nil
+}

--- a/pkg/dmsg/disc/fallback.go
+++ b/pkg/dmsg/disc/fallback.go
@@ -1,4 +1,11 @@
+//go:build !js
+
 // Package disc — fallback discovery client.
+//
+// Build-tag-gated off the WASM path because it imports pkg/logging
+// (which wraps logrus, which transitively pulls encoding/json).
+// FallbackClient is constructed only from pkg/dmsgc at visor
+// runtime; the WASM install-page graph doesn't reach it.
 //
 // FallbackClient wraps two APIClients (primary + fallback) and tries
 // the primary first; on error it transparently retries the same call

--- a/pkg/dmsg/disc/interface.go
+++ b/pkg/dmsg/disc/interface.go
@@ -17,16 +17,16 @@ package disc
 import (
 	"context"
 
-	jsoniter "github.com/json-iterator/go"
-
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-// json is the package-wide JSON codec. Declared here (rather than
-// in client.go) because entry.go also uses it for Marshal/Unmarshal
-// and client.go is now build-tag-gated; the variable needs to be
-// available across all build configurations.
-var json = jsoniter.ConfigFastest
+// The package-wide `json` var (jsoniter.ConfigFastest) lives in
+// interface_native.go now — TinyGo's stdlib can't link encoding/json's
+// reflect runtime helpers, and jsoniter pulls encoding/json
+// transitively. Entry's Sign/VerifySignature also moved to a
+// !js-tagged file (entry_native.go); under js no code path in this
+// package calls Marshal/Unmarshal so the var is genuinely unused
+// there.
 
 // EntryReader provides read-only access to discovery entries.
 type EntryReader interface {

--- a/pkg/dmsg/disc/interface_native.go
+++ b/pkg/dmsg/disc/interface_native.go
@@ -1,0 +1,18 @@
+//go:build !js
+
+// Package disc pkg/dmsg/disc/interface_native.go
+//
+// Package-wide `json` codec (jsoniter.ConfigFastest). Build-tag-
+// gated off the WASM path: jsoniter pulls encoding/json which
+// in turn drags the reflect runtime helpers TinyGo's stdlib
+// doesn't ship. Under js the disc package compiles without a
+// json codec because nothing in the build graph reaches
+// Sign / VerifySignature / client.go / testing.go (the only
+// callers).
+package disc
+
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+var json = jsoniter.ConfigFastest

--- a/pkg/dmsgc/spec/spec.go
+++ b/pkg/dmsgc/spec/spec.go
@@ -23,8 +23,6 @@
 package spec
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/url"
 	"strings"
 
@@ -89,41 +87,12 @@ type DmsgConfig struct {
 	HypervisorDiscovery  string        `json:"-"`
 }
 
-// UnmarshalJSON accepts either a single Deployment object or an array
-// of Deployments and populates Deployments + the legacy top-level
-// mirror fields accordingly.
-func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
-	trimmed := bytes.TrimLeft(data, " \t\n\r")
-	if len(trimmed) > 0 && trimmed[0] == '[' {
-		if err := json.Unmarshal(data, &c.Deployments); err != nil {
-			return err
-		}
-	} else {
-		var single Deployment
-		if err := json.Unmarshal(data, &single); err != nil {
-			return err
-		}
-		c.Deployments = []Deployment{single}
-	}
-	c.mirrorPrimary()
-	return nil
-}
-
-// MarshalJSON emits the single-deployment object shape when there is
-// exactly one deployment, otherwise the array shape. When Deployments
-// is empty but the top-level fields are populated (e.g. a writer that
-// only set Discovery + Servers directly), a one-element Deployments
-// is synthesized from the mirror fields so the JSON output is correct.
-func (c DmsgConfig) MarshalJSON() ([]byte, error) {
-	deployments := c.Deployments
-	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "") {
-		deployments = []Deployment{c.toDeployment()}
-	}
-	if len(deployments) == 1 {
-		return json.Marshal(deployments[0])
-	}
-	return json.Marshal(deployments)
-}
+// MarshalJSON and UnmarshalJSON live in spec_native.go under
+// //go:build !js. encoding/json's reflect-based codec drags
+// runtime helpers TinyGo's stdlib lacks; the WASM install-page
+// path doesn't need to (de)serialize DmsgConfig — it composes
+// the V1 in memory and emits it through genvisor.MustMarshalJSON
+// (which itself is build-tag-split for the same reason).
 
 // mirrorPrimary copies Deployments[0] into the legacy top-level fields
 // so existing readers keep working in the single-deployment case. For

--- a/pkg/dmsgc/spec/spec_native.go
+++ b/pkg/dmsgc/spec/spec_native.go
@@ -1,0 +1,51 @@
+//go:build !js
+
+// Package spec pkg/dmsgc/spec/spec_native.go
+//
+// DmsgConfig's MarshalJSON / UnmarshalJSON — tagged off the WASM
+// path because encoding/json drags reflect runtime helpers
+// TinyGo's stdlib doesn't ship. See spec.go's package doc for the
+// broader rationale.
+package spec
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UnmarshalJSON accepts either a single Deployment object or an
+// array of Deployments and populates Deployments + the legacy
+// top-level mirror fields accordingly.
+func (c *DmsgConfig) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimLeft(data, " \t\n\r")
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		if err := json.Unmarshal(data, &c.Deployments); err != nil {
+			return err
+		}
+	} else {
+		var single Deployment
+		if err := json.Unmarshal(data, &single); err != nil {
+			return err
+		}
+		c.Deployments = []Deployment{single}
+	}
+	c.mirrorPrimary()
+	return nil
+}
+
+// MarshalJSON emits the single-deployment object shape when there
+// is exactly one deployment, otherwise the array shape. When
+// Deployments is empty but the top-level fields are populated
+// (e.g. a writer that only set Discovery + Servers directly), a
+// one-element Deployments is synthesized from the mirror fields
+// so the JSON output is correct.
+func (c DmsgConfig) MarshalJSON() ([]byte, error) {
+	deployments := c.Deployments
+	if len(deployments) == 0 && (c.Discovery != "" || c.DiscoveryDmsg != "" || len(c.Servers) > 0 || c.SessionsCount != 0 || c.ConnectedServersType != "" || c.Protocol != "" || len(c.LANServers) > 0 || c.HypervisorDiscovery != "") {
+		deployments = []Deployment{c.toDeployment()}
+	}
+	if len(deployments) == 1 {
+		return json.Marshal(deployments[0])
+	}
+	return json.Marshal(deployments)
+}

--- a/pkg/logging/broadcaster.go
+++ b/pkg/logging/broadcaster.go
@@ -1,4 +1,8 @@
+//go:build !js
+
 // Package logging pkg/logging/broadcaster.go
+//
+// Tagged off WASM — see logging_js.go for the build-tag rationale.
 package logging
 
 import (

--- a/pkg/logging/formatter.go
+++ b/pkg/logging/formatter.go
@@ -1,4 +1,8 @@
+//go:build !js
+
 // Package logging pkg/logging/formatter.go
+//
+// Tagged off WASM — see logging_js.go for the build-tag rationale.
 package logging
 
 import (

--- a/pkg/logging/hooks.go
+++ b/pkg/logging/hooks.go
@@ -1,4 +1,8 @@
+//go:build !js
+
 // Package logging pkg/logging/hooks.go
+//
+// Tagged off WASM — see logging_js.go for the build-tag rationale.
 package logging
 
 import (

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,4 +1,8 @@
+//go:build !js
+
 // Package logging pkg/logging/logger.go
+//
+// Tagged off WASM — see logging_js.go for the build-tag rationale.
 package logging
 
 import (

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,5 +1,9 @@
+//go:build !js
+
 /*
 Package logging provides application logging utilities
+
+Tagged off WASM — see logging_js.go for the build-tag rationale.
 */
 package logging
 

--- a/pkg/logging/logging_js.go
+++ b/pkg/logging/logging_js.go
@@ -1,0 +1,62 @@
+//go:build js
+
+// Package logging pkg/logging/logging_js.go
+//
+// WASM-clean stub for pkg/logging. The full implementation uses
+// sirupsen/logrus, which transitively imports encoding/json — and
+// encoding/json drags reflect runtime helpers (reflect.unsafe_New,
+// mapassign, typedmemmove, etc.) that TinyGo's stdlib doesn't ship.
+//
+// This stub provides JUST the type + constructor surface that
+// WASM-clean consumers of pkg/logging reach (visorconfig.Common,
+// dmsg/disc, etc.). The methods on MasterLogger / Logger are no-ops
+// — under js/wasm there's no useful log sink anyway, and the live
+// install-page WASM path is small enough that nothing actually
+// logs at runtime.
+//
+// Consumers that need real logging (the visor binary, AUR tooling,
+// servers) are non-WASM by nature and use the full !js
+// implementation in broadcaster.go, formatter.go, hooks.go,
+// logger.go, logging.go.
+package logging
+
+import (
+	"io"
+)
+
+// MasterLogger is a stub of the real MasterLogger type. The struct
+// has no fields under js so consumers that hold a *MasterLogger
+// (e.g. visorconfig.Common.log) compile without dragging logrus.
+type MasterLogger struct{}
+
+// Logger is the per-module logger stub. Same shape as MasterLogger
+// — no fields, no behavior. The methods that the native package
+// exposes (WithError, WithField, Debug, Info, Warn, Error, ...)
+// aren't included because no WASM-reachable code path calls them.
+// If a future WASM consumer needs to log, add the methods here as
+// no-ops.
+type Logger struct{}
+
+// NewMasterLogger returns a zero-valued *MasterLogger. Mirrors the
+// !js signature so visorconfig.NewCommon's default-logger branch
+// works identically across builds.
+func NewMasterLogger() *MasterLogger {
+	return &MasterLogger{}
+}
+
+// PackageLogger returns a *Logger stub. Mirrors the native method's
+// signature; the moduleName argument is ignored under js.
+func (m *MasterLogger) PackageLogger(_ string) *Logger {
+	return &Logger{}
+}
+
+// MustGetLogger returns a *Logger stub. Some packages call
+// logging.MustGetLogger(...) at construction time even though the
+// returned logger never gets exercised under js.
+func MustGetLogger(_ string) *Logger {
+	return &Logger{}
+}
+
+// SetOutputTo is a no-op stub. Some callers configure the package-
+// level logger output; under js there's no output anyway.
+func SetOutputTo(_ io.Writer) {}

--- a/pkg/routing/cascade.go
+++ b/pkg/routing/cascade.go
@@ -1,4 +1,12 @@
+//go:build !js
+
 // Package routing pkg/routing/cascade.go
+//
+// Build-tag-gated off the WASM path because it imports
+// github.com/google/uuid (which transitively pulls encoding/json
+// and the reflect runtime helpers TinyGo's stdlib lacks).
+// CascadeSetup is data-plane runtime; the WASM install-page graph
+// only needs the primitive routing.Port type from addr.go.
 //
 // CascadeSetup and CascadeAck define the wire format for the cascade
 // route setup protocol. Messages are nested (Russian-doll style) so

--- a/pkg/routing/route.go
+++ b/pkg/routing/route.go
@@ -1,5 +1,13 @@
+//go:build !js
+
 // Package routing defines routing related entities and management
 // operations.
+//
+// route.go is build-tag-gated off the WASM path because it imports
+// encoding/json (Route.String / EdgeRules.String render via
+// json.MarshalIndent) and github.com/google/uuid (transitively
+// from rule.go). The install-page WASM only needs routing.Port
+// from addr.go.
 package routing
 
 import (

--- a/pkg/routing/route_descriptor.go
+++ b/pkg/routing/route_descriptor.go
@@ -8,6 +8,17 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
+const (
+	// pkSize is the byte size of a cipher.PubKey, used to fix
+	// RouteDescriptor's array length. Lives in this no-build-tag
+	// file (rather than rule.go, which is !js-tagged) so the
+	// RouteDescriptor type definition resolves under js too.
+	pkSize = len(cipher.PubKey{})
+	// routeDescriptorSize is the byte-size of a RouteDescriptor.
+	// Same rationale as pkSize for the file placement.
+	routeDescriptorSize = pkSize*2 + 2*2
+)
+
 // RouteDescriptor describes a route (from the perspective of the source and destination edges).
 type RouteDescriptor [routeDescriptorSize]byte
 

--- a/pkg/routing/rule.go
+++ b/pkg/routing/rule.go
@@ -1,4 +1,11 @@
+//go:build !js
+
 // Package routing pkg/routing/rule.go
+//
+// Build-tag-gated off the WASM path because it imports
+// github.com/google/uuid (which transitively pulls encoding/json
+// and reflect helpers TinyGo's stdlib lacks). Rules are router
+// data-plane state; the WASM install-page graph doesn't need them.
 package routing
 
 import (
@@ -44,11 +51,14 @@ import (
 // RuleHeaderSize represents the base size of a rule.
 // All rules should be at-least this size.
 const (
-	RuleHeaderSize      = 8 + 1 + 4
-	pkSize              = len(cipher.PubKey{})
-	uuidSize            = len(uuid.UUID{})
-	routeDescriptorSize = pkSize*2 + 2*2
+	RuleHeaderSize = 8 + 1 + 4
+	uuidSize       = len(uuid.UUID{})
 )
+
+// pkSize and routeDescriptorSize live in route_descriptor.go so
+// that file (untagged) can use them in the array-length expression
+// for the RouteDescriptor type. Both are referenced from rule.go
+// (!js) too, which is fine — !js files see no-tag consts.
 
 // RuleType defines type of a routing rule
 type RuleType byte

--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -1,4 +1,13 @@
+//go:build !js
+
 // Package routing pkg/routing/table.go
+//
+// Build-tag-gated off the WASM path because it imports
+// github.com/google/uuid (transitive encoding/json + reflect
+// helpers TinyGo's stdlib lacks) and pkg/logging (logrus
+// transitively pulls encoding/json too). Routing tables are
+// router data-plane state; the WASM install-page graph
+// doesn't reach this code.
 package routing
 
 import (

--- a/pkg/visor/visorconfig/args.go
+++ b/pkg/visor/visorconfig/args.go
@@ -9,10 +9,16 @@
 // internals (launcher, RPC, HTTP API) keep []string — only the
 // JSON file representation changes. Old configs with array-form
 // args still load.
+//
+// The encoding/json-using halves (appsList.MarshalJSON,
+// appsList.UnmarshalJSON, unmarshalAppConfig) live in
+// args_native.go under //go:build !js. This file keeps the type
+// definitions and the json-free shell-arg parser so the WASM
+// build path can still reach SplitArgs, splitArgs, and joinArgs
+// (none of which touch encoding/json).
 package visorconfig
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -28,36 +34,8 @@ import (
 // the on-disk config through this package keep working unchanged.
 type appsList []appspec.AppConfig
 
-// MarshalJSON emits each AppConfig's Args as a shell-quoted string.
-func (a appsList) MarshalJSON() ([]byte, error) {
-	out := make([]appConfigOnDisk, len(a))
-	for i, c := range a {
-		out[i] = toOnDisk(c)
-	}
-	return json.Marshal(out)
-}
-
-// UnmarshalJSON accepts both the new string form and the legacy
-// array form on a per-app basis. Mixed configs work too.
-func (a *appsList) UnmarshalJSON(data []byte) error {
-	var raw []json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	out := make([]appspec.AppConfig, len(raw))
-	for i, r := range raw {
-		cfg, err := unmarshalAppConfig(r)
-		if err != nil {
-			return fmt.Errorf("apps[%d]: %w", i, err)
-		}
-		out[i] = cfg
-	}
-	*a = out
-	return nil
-}
-
 // appConfigOnDisk mirrors appspec.AppConfig with Args as a string.
-// Only used at the JSON boundary.
+// Only used at the JSON boundary (in args_native.go).
 type appConfigOnDisk struct {
 	Name         string       `json:"name"`
 	Binary       string       `json:"binary,omitempty"`
@@ -84,38 +62,6 @@ func toOnDisk(c appspec.AppConfig) appConfigOnDisk {
 		Env:          c.Env,
 		LauncherMode: c.LauncherMode,
 	}
-}
-
-func unmarshalAppConfig(raw json.RawMessage) (appspec.AppConfig, error) {
-	// Shadow AppConfig.Args with a RawMessage at the outer scope so
-	// we can dispatch on its JSON shape (string vs array).
-	var pre struct {
-		appspec.AppConfig
-		Args json.RawMessage `json:"args,omitempty"`
-	}
-	if err := json.Unmarshal(raw, &pre); err != nil {
-		return appspec.AppConfig{}, err
-	}
-	cfg := pre.AppConfig
-	if len(pre.Args) == 0 {
-		cfg.Args = nil
-		return cfg, nil
-	}
-	// Prefer the new string form; fall back to the array form for
-	// existing on-disk configs.
-	var s string
-	if err := json.Unmarshal(pre.Args, &s); err == nil {
-		parsed, perr := splitArgs(s)
-		if perr != nil {
-			return appspec.AppConfig{}, fmt.Errorf("parsing args string: %w", perr)
-		}
-		cfg.Args = parsed
-		return cfg, nil
-	}
-	if err := json.Unmarshal(pre.Args, &cfg.Args); err != nil {
-		return appspec.AppConfig{}, fmt.Errorf("args must be string or array: %w", err)
-	}
-	return cfg, nil
 }
 
 // SplitArgs is the exported counterpart to splitArgs — same parser,

--- a/pkg/visor/visorconfig/args_native.go
+++ b/pkg/visor/visorconfig/args_native.go
@@ -1,0 +1,78 @@
+//go:build !js
+
+// Package visorconfig — args_native.go
+//
+// encoding/json-using halves of args.go. Build-tag-gated off the
+// WASM path because encoding/json's reflect-based marshaller drags
+// reflect.unsafe_New / mapassign / typedmemmove (which TinyGo's
+// stdlib doesn't ship). The browser-side WASM never (de)serializes
+// V1 apps lists; under js V1.Apps stays as raw appsList values and
+// the type's json methods are absent from the build.
+package visorconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	appspec "github.com/skycoin/skywire/pkg/app/appserver/spec"
+)
+
+// MarshalJSON emits each AppConfig's Args as a shell-quoted string.
+func (a appsList) MarshalJSON() ([]byte, error) {
+	out := make([]appConfigOnDisk, len(a))
+	for i, c := range a {
+		out[i] = toOnDisk(c)
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON accepts both the new string form and the legacy
+// array form on a per-app basis. Mixed configs work too.
+func (a *appsList) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	out := make([]appspec.AppConfig, len(raw))
+	for i, r := range raw {
+		cfg, err := unmarshalAppConfig(r)
+		if err != nil {
+			return fmt.Errorf("apps[%d]: %w", i, err)
+		}
+		out[i] = cfg
+	}
+	*a = out
+	return nil
+}
+
+func unmarshalAppConfig(raw json.RawMessage) (appspec.AppConfig, error) {
+	// Shadow AppConfig.Args with a RawMessage at the outer scope so
+	// we can dispatch on its JSON shape (string vs array).
+	var pre struct {
+		appspec.AppConfig
+		Args json.RawMessage `json:"args,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &pre); err != nil {
+		return appspec.AppConfig{}, err
+	}
+	cfg := pre.AppConfig
+	if len(pre.Args) == 0 {
+		cfg.Args = nil
+		return cfg, nil
+	}
+	// Prefer the new string form; fall back to the array form for
+	// existing on-disk configs.
+	var s string
+	if err := json.Unmarshal(pre.Args, &s); err == nil {
+		parsed, perr := splitArgs(s)
+		if perr != nil {
+			return appspec.AppConfig{}, fmt.Errorf("parsing args string: %w", perr)
+		}
+		cfg.Args = parsed
+		return cfg, nil
+	}
+	if err := json.Unmarshal(pre.Args, &cfg.Args); err != nil {
+		return appspec.AppConfig{}, fmt.Errorf("args must be string or array: %w", err)
+	}
+	return cfg, nil
+}

--- a/pkg/visor/visorconfig/parse.go
+++ b/pkg/visor/visorconfig/parse.go
@@ -1,4 +1,12 @@
+//go:build !js
+
 // Package visorconfig pkg/visor/visorconfig/parse.go
+//
+// Parse wraps Reader (from read.go, also !js-tagged) and adds
+// version-compat checking via blang/semver. Both deps (encoding/
+// json transitively, and blang/semver which imports json itself)
+// stay out of the WASM build. Browser-side WASM never parses an
+// on-disk config; it constructs V1 in memory via genvisor.Generate.
 package visorconfig
 
 import (

--- a/pkg/visor/visorconfig/read.go
+++ b/pkg/visor/visorconfig/read.go
@@ -1,4 +1,14 @@
+//go:build !js
+
 // Package visorconfig pkg/visor/visorconfig/read.go
+//
+// Reader / ReadFile / ReadRaw load a V1 config from disk or an
+// io.Reader. All three pull encoding/json and os.ReadFile, neither
+// of which is reachable from the install-page WASM — browsers
+// don't have filesystems, and TinyGo's stdlib can't link
+// encoding/json's reflect runtime helpers anyway. Build-tag-gated
+// off the WASM path; callers under js construct V1 in memory via
+// genvisor.Generate.
 package visorconfig
 
 import (

--- a/pkg/visor/visorconfig/types.go
+++ b/pkg/visor/visorconfig/types.go
@@ -1,9 +1,13 @@
 // Package visorconfig pkg/visor/visorconfig/types.go
+//
+// The Duration type's MarshalJSON / UnmarshalJSON live in
+// types_native.go under //go:build !js because encoding/json
+// drags the reflect runtime helpers TinyGo's stdlib lacks. Under
+// js V1 is never (de)serialized, so the absence of those methods
+// causes no functional change.
 package visorconfig
 
 import (
-	"encoding/json"
-	"errors"
 	"time"
 )
 
@@ -20,37 +24,10 @@ const (
 	DefaultLogRotationInterval = Duration(time.Hour * 24 * 7)
 )
 
-// Duration wraps around time.Duration to allow parsing from and to JSON
+// Duration wraps around time.Duration to allow parsing from and to JSON.
+//
+// The Marshal/Unmarshal methods live in types_native.go (!js) —
+// browsers never (de)serialize V1, so dropping the methods under
+// js doesn't change observable behavior; it just frees TinyGo
+// from linking encoding/json's reflect path.
 type Duration time.Duration
-
-// MarshalJSON implements json marshaling
-func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Duration(d).String())
-}
-
-// UnmarshalJSON implements unmarshal from json
-func (d *Duration) UnmarshalJSON(b []byte) error {
-	if len(b) == 0 {
-		*d = 0
-		return nil
-	}
-
-	var v interface{}
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	switch value := v.(type) {
-	case float64:
-		*d = Duration(time.Duration(value))
-		return nil
-	case string:
-		tmp, err := time.ParseDuration(value)
-		if err != nil {
-			return err
-		}
-		*d = Duration(tmp)
-		return nil
-	default:
-		return errors.New("invalid duration")
-	}
-}

--- a/pkg/visor/visorconfig/types_native.go
+++ b/pkg/visor/visorconfig/types_native.go
@@ -1,0 +1,47 @@
+//go:build !js
+
+// Package visorconfig pkg/visor/visorconfig/types_native.go
+//
+// Duration's JSON codec methods. Tagged off the WASM build because
+// json.Marshal / json.Unmarshal pull the reflect runtime helpers
+// TinyGo's stdlib doesn't provide. See types.go's package doc for
+// the broader rationale.
+package visorconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// MarshalJSON implements json marshaling.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON implements unmarshal from json.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		*d = 0
+		return nil
+	}
+
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value))
+		return nil
+	case string:
+		tmp, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*d = Duration(tmp)
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}


### PR DESCRIPTION
## Why

Sequel to #2835 (foundational split of deployment + visorconfig). This finishes the encoding/json elimination across every transitive importer reachable from \`pkg/skywireconfig/{autoconfigcmd, keypair, genvisor}\` under GOOS=js GOARCH=wasm — **unblocking TinyGo compilation of the install-page WASM**.

## Result

\`tinygo build -target wasm -no-debug ./cmd/wasm\` on apt-repo now produces a **1.85 MB blob** vs **7.3 MB for the Go-WASM build** (≈ 75% smaller). Operators on bandwidth-constrained connections get a much smaller install page.

## What

Build-tag splits applied — `!js` for the json-using halves, plus tiny `js`-side stubs where the type surface needs to remain visible:

- **pkg/buildinfo** — init() that parses ldflags-injected \`go list -m -json\` goes to `_native.go`; `_js.go` skips it.
- **pkg/dmsg/disc** — `var json = jsoniter.ConfigFastest` and Entry.Sign/VerifySignature move to `_native.go`. fallback.go (imports pkg/logging) tagged `!js`.
- **pkg/dmsgc/spec** — DmsgConfig.MarshalJSON/UnmarshalJSON (the polymorphic single-vs-array shape) move to `_native.go`.
- **pkg/logging** — entire native impl (5 files) tagged `!js`. New `logging_js.go` exposes a tiny stub surface (MasterLogger, Logger, NewMasterLogger, PackageLogger, MustGetLogger, SetOutputTo) so consumers compile but logrus stays out of the WASM graph.
- **pkg/routing** — cascade.go, route.go, rule.go, table.go tagged `!js` (uuid + json users). `pkSize` + `routeDescriptorSize` consts moved from rule.go to route_descriptor.go so the untagged \`RouteDescriptor [routeDescriptorSize]byte\` type resolves.
- **pkg/visor/visorconfig** — appsList.Marshal/Unmarshal + unmarshalAppConfig move to args_native.go; Duration.Marshal/Unmarshal move to types_native.go; parse.go + read.go tagged `!js`.

## Verification

\`\`\`
GOOS=js GOARCH=wasm go list -deps \\
  ./pkg/skywireconfig/{genvisor,autoconfigcmd,keypair} \\
  | grep -E 'encoding/json|json-iterator|logrus|google/uuid|blang'
→ (empty)

tinygo build -target wasm -no-debug ./cmd/wasm  (apt-repo)
→ 1,847,793 bytes (1.85 MB)
\`\`\`

- [x] \`go build ./...\` — clean
- [x] \`GOOS=js GOARCH=wasm go build ./pkg/skywireconfig/...\` — clean
- [x] \`go test\` on touched packages — pass
- [x] \`golangci-lint\` on touched packages — 0 issues
- [ ] CI green

## Behavior under js

The Go-WASM build path is unchanged in behavior — apt-repo's default `/generator/` install page still uses it. The TinyGo variant at `/generator/tinygo/` now functions as a real smaller-blob alternative. \`genvisor.MustMarshalJSON\` remains stubbed under js (from #2835), so the "Download skywire.json" button on the TinyGo variant shows a sentinel error JSON until a hand-rolled streaming V1 serializer lands as a follow-up. Everything else (autoconfig flag form, keypair generation, autoconfig help) works identically in both variants.