### PR TITLE
feat(autoconfigcmd): expose config-gen defaults via EnvMapping

### DIFF
--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -33,6 +33,8 @@ package autoconfigcmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
 // EnvFormat describes how a flag's runtime value is rendered into
@@ -65,6 +67,22 @@ type EnvMapping struct {
 	// --no-ishv has Negate=true so passing it (which sets the
 	// bool to true) writes ISHYPERVISOR=false to the .conf file.
 	Negate bool
+	// Default is the effective default the visor's `cli config gen`
+	// uses when the SKYENV variable is unset/commented. Empty when
+	// the underlying default is "" (no useful hint to show). This
+	// field exists so the WASM install-page can display the actual
+	// default as a placeholder hint — operators see "default:
+	// 127.0.0.1:8001" rather than the misleading "(unset)" the
+	// flag's own DefValue reports (which is "" because autoconfig
+	// itself defaults every flag to empty, deferring to skywire.conf
+	// / config-gen for the real default).
+	//
+	// Source of truth: the `:-` fallbacks in
+	// cmd/skywire-cli/commands/config/gen.go's scriptExec* calls,
+	// plus the skyenv constants those calls reference for the
+	// string-typed defaults. Keep in sync — if config-gen's
+	// defaults change, update this table too.
+	Default string
 }
 
 // Values holds the destination addresses for every flag binding
@@ -346,13 +364,15 @@ var envMap = map[string]EnvMapping{
 	"dmsgconf": {Key: "DMSGCONF", Format: EnvFormatString},
 	"url":      {Key: "SVCCONFADDR", Format: EnvFormatBashArray},
 	"svcconf":  {Key: "SVCCONF", Format: EnvFormatString},
-	"minsess":  {Key: "MINDMSGSESS", Format: EnvFormatInt},
+	"minsess":  {Key: "MINDMSGSESS", Format: EnvFormatInt, Default: "2"},
 	"stun":     {Key: "STUNSERVERS", Format: EnvFormatBashArray},
 
-	// Transport ports
-	"stcpr":           {Key: "STCPRPORT", Format: EnvFormatInt},
-	"sudph":           {Key: "SUDPHPORT", Format: EnvFormatInt},
-	"lan-dmsg-port":   {Key: "LANDMSGPORT", Format: EnvFormatInt},
+	// Transport ports. 0 = OS-assigned random port at runtime;
+	// stays unchanged across visor restarts only when pinned to a
+	// non-zero value.
+	"stcpr":           {Key: "STCPRPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"sudph":           {Key: "SUDPHPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"lan-dmsg-port":   {Key: "LANDMSGPORT", Format: EnvFormatInt, Default: "0 (random)"},
 	"lan-dmsg-public": {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
 
 	// Whitelists
@@ -391,7 +411,7 @@ var envMap = map[string]EnvMapping{
 	// Skychat
 	"skychat":          {Key: "SKYCHAT", Format: EnvFormatBool},
 	"no-skychat":       {Key: "SKYCHAT", Format: EnvFormatBool, Negate: true},
-	"chataddr":         {Key: "SKYCHATADDR", Format: EnvFormatString},
+	"chataddr":         {Key: "SKYCHATADDR", Format: EnvFormatString, Default: skyenv.SkychatAddr},
 	"servechatpair":    {Key: "SKYCHATPAIR", Format: EnvFormatBool},
 	"no-servechatpair": {Key: "SKYCHATPAIR", Format: EnvFormatBool, Negate: true},
 
@@ -411,14 +431,14 @@ var envMap = map[string]EnvMapping{
 	// Skycoin web wallet
 	"skycoinweb":       {Key: "SKYCOINWEB", Format: EnvFormatBool},
 	"no-skycoinweb":    {Key: "SKYCOINWEB", Format: EnvFormatBool, Negate: true},
-	"skycoinwebaddr":   {Key: "SKYCOINWEBADDR", Format: EnvFormatString},
+	"skycoinwebaddr":   {Key: "SKYCOINWEBADDR", Format: EnvFormatString, Default: "127.0.0.1:8002"},
 	"skycoinwebnodes":  {Key: "SKYCOINWEBNODES", Format: EnvFormatBashArray},
 	"skycoinwebwallet": {Key: "SKYCOINWEBWALLET", Format: EnvFormatString},
 	"skycoinwebuser":   {Key: "SKYCOINWEBUSER", Format: EnvFormatString},
 
 	// Visor runtime
-	"binpath":    {Key: "BINPATH", Format: EnvFormatString},
-	"loglvl":     {Key: "LOGLVL", Format: EnvFormatString},
+	"binpath":    {Key: "BINPATH", Format: EnvFormatString, Default: skyenv.AppBinPath},
+	"loglvl":     {Key: "LOGLVL", Format: EnvFormatString, Default: skyenv.LogLevel},
 	"timeout":    {Key: "SHUTDOWNTIMEOUT", Format: EnvFormatString},
 	"regtimeout": {Key: "REGTIMEOUT", Format: EnvFormatString},
 }


### PR DESCRIPTION
## Why

The install-page WASM (apt-repo's \`cmd/wasm\`) renders the autoconfig flag set as a form. For non-bool flags it shows a placeholder hint, but the only available value (\`pflag.Flag.DefValue\`) is \`""\` — because the autoconfig flag itself defaults to empty, deferring to skywire.conf / \`cli config gen\` for the real default. Operators thus see "(unset)" with no clue what value the visor will actually fall back to.

## What

Add a \`Default string\` field to \`autoconfigcmd.EnvMapping\`. Populate for the flags whose effective default is non-empty and worth showing:

| flag | default | source |
|---|---|---|
| \`minsess\` | \`2\` | \`${MINDMSGSESS:-2}\` |
| \`stcpr\` | \`0 (random)\` | port semantic |
| \`sudph\` | \`0 (random)\` | port semantic |
| \`lan-dmsg-port\` | \`0 (random)\` | port semantic |
| \`chataddr\` | \`127.0.0.1:8001\` | \`skyenv.SkychatAddr\` |
| \`skycoinwebaddr\` | \`127.0.0.1:8002\` | \`${SKYCOINWEBADDR:-...}\` |
| \`binpath\` | \`./\` | \`skyenv.AppBinPath\` |
| \`loglvl\` | \`info\` | \`skyenv.LogLevel\` |

The WASM install-page reads \`EnvMap()[name].Default\` and surfaces it as the input placeholder — operators see "default: 127.0.0.1:8001" rather than "(unset)".

## Drift policy

This table mirrors the \`scriptExec\` defaults in \`cmd/skywire-cli/commands/config/gen.go\`. If config-gen's defaults change, update both. A future refactor could centralize the defaults in a shared spec package so the duplication goes away — out of scope here.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`GOOS=js GOARCH=wasm go build ./pkg/skywireconfig/...\` — clean
- [x] \`go test ./pkg/skywireconfig/autoconfigcmd/\` — pass
- [x] \`golangci-lint\` — 0 issues
- [ ] CI green