### PR TITLE
ci: enable Windows arm64 MSI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,6 @@ jobs:
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Fetch Windows installer files
-        if: matrix.arch != 'arm64'
         shell: pwsh
         run: |
           $base = "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/scripts/win_installer"
@@ -390,7 +389,6 @@ jobs:
           Get-ChildItem "dist\" -Exclude "*.zip","*.sha256" | Remove-Item
 
       - name: Create MSI installer
-        if: matrix.arch != 'arm64'
         shell: pwsh
         run: |
           $MSI_NAME = "skywire-installer-${{ github.ref_name }}-windows-${{ matrix.arch }}"


### PR DESCRIPTION
## Why

The release workflow matrix already had a \`windows-arm64\` entry (\`arch: arm64\`, \`goarch: arm64\`, \`wix_arch: x64\`, \`wintun_arch: arm64\`) but the "Fetch Windows installer files" and "Create MSI installer" steps both skipped it via \`if: matrix.arch != 'arm64'\`. Result: the arm64 \`.zip\` archive published but no \`.msi\`, so Windows-on-ARM operators had to manually unpack and install.

The install-page generator at deb.skywire.dev/generator/ auto-detects \`\$env:PROCESSOR_ARCHITECTURE\` in its Windows one-liner. With this PR, the ARM detection finally lands a working installer instead of falling back to amd64 with a runtime arch mismatch.

## What

Remove the two \`if: matrix.arch != 'arm64'\` guards.

\`wix_arch=x64\` + \`wintun_arch=arm64\` builds a WiX MSI that targets the x64 MSI engine (Windows-on-ARM ships x64 emulation, so an x64-targeted MSI installs cleanly there) while bundling the ARM64-native \`wintun.dll\` and ARM64-native \`skywire.exe\`. The installed binaries are native arm64; only the installer scaffolding runs under emulation, which is the standard Windows-on-ARM compatibility path for MSI-based installers.

## Test plan

- [x] Existing \`darwin-arm64.pkg\` already uses a parallel cross-build matrix entry — model is proven.
- [x] The workflow's "Verify binary" step already skips arch-mismatch for arm64 (\`if ("\${{ matrix.arch }}" -ne "arm64")\` line 341), so removing the MSI-creation guards doesn't introduce a binary-execution check on the wrong arch.
- [ ] CI builds the artifact on next release tag. Real validation lands when a Windows-ARM operator runs the install command from the install page generator.