### PR TITLE
feat(dmsgpty): add --scheme flag to bypass MultiDialer chain

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/pty.go
+++ b/cmd/skywire-cli/commands/dmsg/pty.go
@@ -52,6 +52,13 @@ var (
 	// pin --sk or seed DMSGPTY_SK. An explicit --sk / DMSGPTY_SK
 	// always wins.
 	ptyViaVisor bool
+	// ptyScheme pins the visor-side dialer choice for the exec
+	// (forwarded to the visor RPC as DmsgPtyExecArgs.Scheme).
+	// Empty (default) uses the visor's MultiDialer chain (skynet
+	// first, dmsg fallback). "dmsg" forces dmsg-only; "skynet"
+	// forces skynet-only. Useful for unblocking debug when one
+	// strategy in the chain hangs without honoring ctx.
+	ptyScheme string
 )
 
 // ptyTCPViaRE matches `tcp://<66-hex-pk>@<host:port>` for the --via
@@ -93,6 +100,8 @@ func init() {
 		"local secret key for the --via direct-TCP path's noise handshake (random if unset; pin for stable whitelist authorization)")
 	ptyExecCmd.Flags().BoolVar(&ptyViaVisor, "via-visor", false,
 		"borrow local visor's secret key from "+visorconfig.SkywireConfig()+" for the --via noise handshake (--sk wins if set)")
+	ptyExecCmd.Flags().StringVar(&ptyScheme, "scheme", "",
+		"pin transport: \"dmsg\" (force dmsg only), \"skynet\" (force skynet only), or empty (default MultiDialer chain: skynet first, dmsg fallback)")
 
 	// Flags for ui command
 	ptyUICmd.Flags().StringVarP(&ptyPath, "input", "i", "", "read from specified config file")
@@ -258,6 +267,7 @@ RPC-layer failure). stdout flows to local stdout, stderr to local stderr.`,
 				Env:       ptyExecEnv,
 				TimeoutMS: timeout.Milliseconds(),
 			},
+			Scheme: ptyScheme,
 		})
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "exec: %v\n", err) //nolint:errcheck

--- a/pkg/dmsg/dmsgpty/host.go
+++ b/pkg/dmsg/dmsgpty/host.go
@@ -69,10 +69,22 @@ func NewHostWithDialer(dmsgC *dmsg.Client, wl Whitelist, dialer StreamDialer) *H
 // unix-socket-or-tcp control listener. Same trust model: the remote's
 // whitelist gates the connection on its own PK admission.
 func (h *Host) ExecRemote(ctx context.Context, rPK cipher.PubKey, rPort uint16, req *CommandExecReq) (*CommandExecResult, error) {
+	return h.ExecRemoteVia(ctx, h.dialer, rPK, rPort, req)
+}
+
+// ExecRemoteVia runs ExecRemote against the supplied dialer instead
+// of the Host's configured one. Used when the caller wants to pin
+// the transport (e.g. dmsg-only / skynet-only) rather than ride the
+// Host's MultiDialer chain. Pass dmsgpty.NewDmsgDialer(c) to force
+// dmsg, or the visor's skywireDialer to force skynet.
+//
+// Same protocol, same wire shape — the dialer only changes the
+// underlying transport that carries the dmsgpty stream.
+func (h *Host) ExecRemoteVia(ctx context.Context, dialer StreamDialer, rPK cipher.PubKey, rPort uint16, req *CommandExecReq) (*CommandExecResult, error) {
 	if rPort == 0 {
 		rPort = DefaultPort
 	}
-	stream, err := h.dialer.DialStream(ctx, rPK, rPort)
+	stream, err := dialer.DialStream(ctx, rPK, rPort)
 	if err != nil {
 		return nil, fmt.Errorf("dmsgpty: dial %s:%d: %w", rPK, rPort, err)
 	}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -513,10 +513,23 @@ type HealthInfo struct {
 // defaults to dmsgpty.DefaultPort (22) when zero. Req carries the
 // command, arguments, optional environment overrides, optional stdin,
 // and per-call timeout — see dmsgpty.CommandExecReq.
+//
+// Scheme overrides the dialer choice. The visor's dmsgpty Host is
+// wired with a MultiDialer that tries skynet first (transport-aware,
+// rides existing transports for low latency) and falls back to dmsg
+// on miss. That ordering breaks down when skynet's dial blocks past
+// the caller's ctx without honoring it — dmsg never gets tried and
+// the whole exec hangs. Operators who know the peer has a working
+// dmsg session can pass Scheme="dmsg" to skip skynet entirely. Empty
+// keeps the default MultiDialer behavior.
 type DmsgPtyExecArgs struct {
 	RemotePK   cipher.PubKey
 	RemotePort uint16
 	Req        dmsgpty.CommandExecReq
+	// Scheme: "" (default — MultiDialer chain), "dmsg" (force dmsg
+	// only), or "skynet" (force skynet only). Unknown values
+	// return a clear error rather than silently falling back.
+	Scheme string
 }
 
 // UptimeHistoryArgs is the request shape for API.UptimeHistory. All

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -487,7 +487,25 @@ func (v *Visor) DmsgPtyExec(args DmsgPtyExecArgs) (*dmsgpty.CommandExecResult, e
 	callTimeout := time.Duration(req.TimeoutMS)*time.Millisecond + dialBudget
 	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
 	defer cancel()
-	return v.dmsgPty.ExecRemote(ctx, args.RemotePK, args.RemotePort, &req)
+
+	// Scheme selects a specific dialer over the Host's default
+	// MultiDialer chain. Useful when skynet's dial hangs without
+	// honoring ctx and the operator knows dmsg is reachable —
+	// passing Scheme="dmsg" skips skynet entirely. Empty keeps the
+	// default chain (skynet first, dmsg fallback).
+	switch args.Scheme {
+	case "":
+		return v.dmsgPty.ExecRemote(ctx, args.RemotePK, args.RemotePort, &req)
+	case "dmsg":
+		if v.dmsgC == nil {
+			return nil, fmt.Errorf("dmsgpty: dmsg scheme requested but dmsg client not initialized")
+		}
+		return v.dmsgPty.ExecRemoteVia(ctx, dmsgpty.NewDmsgDialer(v.dmsgC), args.RemotePK, args.RemotePort, &req)
+	case "skynet":
+		return v.dmsgPty.ExecRemoteVia(ctx, skywireDialer{}, args.RemotePK, args.RemotePort, &req)
+	default:
+		return nil, fmt.Errorf("dmsgpty: unknown scheme %q (want \"\", \"dmsg\", or \"skynet\")", args.Scheme)
+	}
 }
 
 // Ports return list of all ports used by visor services and apps


### PR DESCRIPTION
Adds `--scheme dmsg` / `--scheme skynet` to `skywire cli dmsg pty exec` so operators can pin the visor-side dialer when the default MultiDialer chain (skynet first, dmsg fallback) hangs because skynet's DialContextWithOptions doesn't honor ctx. Empty (default) preserves the existing chain.

Three plumbing changes:
- `DmsgPtyExecArgs.Scheme` (new field) carries the choice through the RPC.
- `dmsgpty.Host.ExecRemoteVia` (new) runs ExecRemote against an explicit dialer.
- CLI `--scheme` flag on `pty exec` populates the field.

Unblocks the debug workflow when one strategy in the MultiDialer chain wedges.