### PR TITLE
fix(dmsgclient): stop services self-publishing via fallback wrapper

### DIFF
--- a/pkg/dmsg/dmsgclient/cli_fallback.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback.go
@@ -257,9 +257,19 @@ func (f *fallbackDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) e
 	return f.direct.PostEntry(ctx, entry)
 }
 
-// PutEntry delegates to HTTP client (direct client doesn't support updates)
+// PutEntry delegates to the direct client (which no-ops). Services
+// using this fallback wrapper run as direct dmsg clients and are not
+// supposed to register themselves in dmsg-discovery — they are
+// reachable equally through any dmsg server via the consumer's
+// preloaded direct.Client. Routing PutEntry to HTTP caused TD/SD/
+// dmsg-disc to publish themselves on every dmsg.Client UpdateInterval
+// (5 min default for clients), producing entries with seq numbers
+// growing into the hundreds and pointless write traffic against
+// dmsg-discovery; consumers gain nothing from those entries because
+// the visor's direct.Client already knows the service PK → all-servers
+// mapping at startup.
 func (f *fallbackDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
-	return f.http.PutEntry(ctx, sk, entry)
+	return f.direct.PutEntry(ctx, sk, entry)
 }
 
 // DelEntry delegates to direct client


### PR DESCRIPTION
## Context

Services (TD, SD, dmsg-discovery, uptime-tracker, etc.) bootstrap their dmsg client via \`cmdutil.BootstrapDmsg\`, which wraps a preloaded \`direct.Client\` with an HTTP-discovery fallback for per-PK \`Entry()\` lookups (covers visor peer-PKs not in the embedded server set).

## The bug

\`fallbackDiscClient.PutEntry\` was routing to the HTTP backend, which meant the dmsg.Client's periodic \`updateClientEntryLoop\` (every \`UpdateInterval\`, 5 min default for clients) would PUT each service's own entry into dmsg-discovery on every tick.

Result: stale TD/SD entries with sequence numbers in the hundreds — currently \`curl https://dmsgd.skywire.skycoin.com/dmsg-discovery/entry/02b307ae...\` returns \`seq: 631\`. Pointless write traffic against dmsg-discovery.

## Why services shouldn't be in dmsg-disc

Per design, services are direct dmsg clients and are NOT supposed to register themselves. Consumers reach them via the preloaded \`direct.Client\` which maps each service PK to all known dmsg-server PKs as delegated. The service's "entry" exists only in each consumer's local cache — equally reachable through any dmsg server.

Quoting the design intent: *"the services don't rely on the dmsg discovery basically … the services should just be equally available from all dmsg servers via dmsg direct client."*

## What changed

\`fallbackDiscClient.PutEntry\` now delegates to the direct client (which stores entries locally with no network call) instead of the HTTP backend.

\`PostEntry\` and \`DelEntry\` already correctly delegated to direct; only \`PutEntry\` was crossing the layer. The prior comment ("HTTP client (direct client doesn't support updates)") was misleading — \`direct.PutEntry\` exists and is the correct destination.

## Test plan

- [ ] Deploy. Confirm \`curl https://dmsgd.skywire.skycoin.com/dmsg-discovery/entry/<TD-PK>\` returns 404 after \`clientEntryTTL\` (~60 min) since the last service PUT.
- [ ] Confirm visor → TD / SD / dmsg-disc / uptime-tracker calls still work (visor uses preloaded direct.Client entries; nothing should break).

## Follow-up

Separate issue: the visor's main \`dmsgC\` uses \`dmsgfirst\`-wrapped discovery which logs \`disc Entry: DMSG primary failed; trying HTTP fallback\` regularly. That's the discovery-lookup-for-services path the user wants eliminated. Diagnostics in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)