### PR TITLE
fix(visor): dmsgpty skynet listener never started due to init ordering

### DIFF
--- a/pkg/visor/init_dmsg_skywire.go
+++ b/pkg/visor/init_dmsg_skywire.go
@@ -27,6 +27,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgpty"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 )
 
@@ -81,47 +82,58 @@ func skywireConnPK(conn net.Conn) (cipher.PubKey, bool) {
 // Mirror of pty.ListenAndServe but on the skynet path; runs in its
 // own goroutine alongside the dmsg listener.
 //
-// Returns a func that cancels + waits for the goroutine. Nil
-// returned cancel means setup failed and the caller can ignore
-// shutdown bookkeeping — typical when the skynet networker isn't
-// available yet at init time.
+// The skynet networker is registered during initRouter, which may
+// run AFTER initDmsg invokes us here. We can't gate the wire-up on
+// "networker present now" — that'd silently drop the entire skynet
+// pty listener for the lifetime of the process whenever init steps
+// ran in this order. Instead, spawn a goroutine that polls until
+// the networker registers (using the same backoff as
+// goServeSkynetMirror in dual_listen.go), then binds + serves. If
+// ctx cancels before the networker shows up the goroutine exits
+// cleanly.
+//
+// Returns a func that cancels + waits for the serve goroutine.
 func startSkywirePtyListener(ctx context.Context, pty *dmsgpty.Host, localPK cipher.PubKey, port uint16, runtimeErrors chan<- error) func() error {
-	n, err := appnet.ResolveNetworker(appnet.TypeSkynet)
-	if err != nil {
-		// Skynet networker not wired yet — operator will still get
-		// the dmsg listener and the dmsg-only MultiDialer fallback;
-		// pty over skynet routes is then a no-op for this visor run.
-		// Not a fatal init error because the dmsgpty service itself
-		// still functions.
-		return nil
-	}
-	sn, ok := n.(*appnet.SkywireNetworker)
-	if !ok {
-		return nil
-	}
-
-	lis, err := sn.Listen(appnet.Addr{
-		Net:    appnet.TypeSkynet,
-		PubKey: localPK,
-		Port:   routing.Port(port),
-	})
-	if err != nil {
-		// Listen failure is non-fatal for the same reason the
-		// networker-missing branch is: dmsg path keeps working.
-		// Surface as a runtime warning rather than killing init.
-		select {
-		case runtimeErrors <- fmt.Errorf("skywire dmsgpty Listen: %w", err):
-		default:
-		}
-		return nil
-	}
-
 	serveCtx, cancel := context.WithCancel(ctx)
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 
+	log := logging.MustGetLogger("dmsgpty_skynet")
+
 	go func() {
 		defer wg.Done()
+
+		if !waitForSkynetNetworker(serveCtx) {
+			return // ctx canceled before networker registered
+		}
+
+		n, err := appnet.ResolveNetworker(appnet.TypeSkynet)
+		if err != nil {
+			log.WithError(err).Warn("dmsgpty skynet: resolve networker failed after wait")
+			return
+		}
+		sn, ok := n.(*appnet.SkywireNetworker)
+		if !ok {
+			log.Warn("dmsgpty skynet: resolved networker is not SkywireNetworker")
+			return
+		}
+
+		lis, err := sn.Listen(appnet.Addr{
+			Net:    appnet.TypeSkynet,
+			PubKey: localPK,
+			Port:   routing.Port(port),
+		})
+		if err != nil {
+			// Listen failure is non-fatal — dmsg listener still works.
+			select {
+			case runtimeErrors <- fmt.Errorf("skywire dmsgpty Listen: %w", err):
+			default:
+			}
+			return
+		}
+
+		log.WithField("port", port).Info("dmsgpty skynet listener bound")
+
 		if err := pty.ListenAndServeNet(serveCtx, lis, skywireConnPK); err != nil {
 			select {
 			case runtimeErrors <- fmt.Errorf("skywire dmsgpty serve: %w", err):


### PR DESCRIPTION
## Summary

\`startSkywirePtyListener\` (init_dmsg_skywire.go:88) called \`appnet.ResolveNetworker(TypeSkynet)\` synchronously and silently returned nil if the networker wasn't registered yet. \`initDmsg\` invokes this helper, and the skynet networker isn't wired until \`initRouter\` — which runs **after** \`initDmsg\`. Result: the skynet leg of dmsgpty was effectively dead in every visor process.

## Verification

Pre-fix, against my hypervisor's 6 connected visors:

\`\`\`
=== skynet 027087fe40d9 (magnetosphere) ===   exec: interrupted (timeout)
=== skynet 033ae337a525 (spiron)         ===  exec: interrupted (timeout)
=== skynet 03d1d78e7323 (prod02)         ===  exec: interrupted (timeout)
=== skynet 032a07b99383 (skywire-prod-2) ===  exec: interrupted (timeout)
=== skynet 02f9aa588dff (skywire-prod)   ===  exec: interrupted (timeout)
=== skynet 03a590eac67f (localhost)      ===  exec: interrupted (timeout)
\`\`\`

0/6 over \`--scheme skynet\`. Meanwhile 6/6 worked over \`--scheme dmsg\` (the dmsg listener path doesn't depend on appnet, so it was unaffected).

## Fix

Spawn a goroutine that polls \`appnet.ResolveNetworker\` with the shared 200ms → 5s backoff (\`waitForSkynetNetworker\` from dual_listen.go), then binds the appnet listener and runs \`pty.ListenAndServeNet\`. Mirrors the \`goServeSkynetMirror\` pattern that other parity-listeners already use.

Existing cancel/WaitGroup contract preserved so the \`pushCloseStack\` caller doesn't need any change.

## Test plan

- [ ] Rebuild visor, restart, retry \`./skywire cli dmsg pty exec --scheme skynet --timeout 15s <peer-pk> hostname\` against multiple peers — expect hostname output instead of timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)