### PR TITLE
fix(visor): dmsgpty skynet listener silently rejects route-group conns

### DIFF
--- a/pkg/visor/init_dmsg_skywire.go
+++ b/pkg/visor/init_dmsg_skywire.go
@@ -66,15 +66,29 @@ func (skywireDialer) DialStream(ctx context.Context, pk cipher.PubKey, port uint
 
 // skywireConnPK is the dmsgpty.PKExtractor for conns accepted by
 // the SkywireNetworker listener. Reaches into RemoteAddr() to pull
-// the appnet.Addr that carries the remote PK. Returns (zero, false)
-// for any conn type that doesn't carry an appnet.Addr so foreign
-// listeners can't sneak past the whitelist gate.
+// the remote PK. The accepted conn type is always *appnet.SkywireConn,
+// but the EMBEDDED net.Conn's RemoteAddr() varies by path:
+//
+//   - direct-dial path (tryDirectDial): inner is *directConn which
+//     returns appnet.Addr.
+//   - route-group path (DialRoutes → NoiseRouteGroup): inner returns
+//     routing.Addr (via RouteGroup.RemoteAddr → RouteDescriptor.Src).
+//
+// Both carry a PubKey field. Accept either shape; reject anything
+// else so foreign listeners can't sneak past the whitelist gate.
+// Pre-fix this function only recognized appnet.Addr, which meant
+// every route-group-backed dmsgpty skynet conn was silently
+// rejected at the extractor — including self-dial, since loopback
+// to own PK has no direct transport and falls into DialRoutes.
 func skywireConnPK(conn net.Conn) (cipher.PubKey, bool) {
-	addr, ok := conn.RemoteAddr().(appnet.Addr)
-	if !ok {
+	switch addr := conn.RemoteAddr().(type) {
+	case appnet.Addr:
+		return addr.PubKey, true
+	case routing.Addr:
+		return addr.PubKey, true
+	default:
 		return cipher.PubKey{}, false
 	}
-	return addr.PubKey, true
 }
 
 // startSkywirePtyListener opens an appnet listener on (localPK,


### PR DESCRIPTION
## Summary

\`skywireConnPK\` only type-asserted against \`appnet.Addr\`. That works for direct-dial conns (\`directConn\` returns \`appnet.Addr\`) but not route-group conns: \`SkywireConn\` embedding a \`NoiseRouteGroup\` returns \`routing.Addr\` via \`RouteGroup.RemoteAddr → RouteDescriptor.Src\`.

Result: dmsgpty skynet conns that landed on the route-setup path — including loopback-to-self, since there's no direct transport to own PK — got silently rejected at the extractor. Client side reads EOF.

Stacks on top of #2846 (listener init-ordering race). With #2846 alone the listener was up but every route-group accept got dropped silently with "PK extraction failed".

## Test plan

After both #2846 and this PR are deployed:

- [ ] \`./skywire cli dmsg pty exec --scheme skynet --timeout 15s <self-pk> hostname\` — expect hostname output
- [ ] Same against remote peers with updated builds — expect hostname output

🤖 Generated with [Claude Code](https://claude.com/claude-code)