### PR TITLE
fix(dmsg/dmsgfirst): use direct-client-backed dmsg.Client for primary path

### DIFF
--- a/pkg/dmsg/disc/dmsgfirst/client.go
+++ b/pkg/dmsg/disc/dmsgfirst/client.go
@@ -47,22 +47,34 @@ import (
 // failure.
 //
 // Parameters:
-//   - dmsgC: the caller's dmsg.Client. May be nil — in which case the
-//     primary path is disabled and the client behaves like
-//     disc.NewHTTP. Pass nil from short-lived tools that only have
-//     HTTP available.
+//   - primaryDmsgC: the dmsg.Client used for the DMSG-primary path.
+//     Should be the visor's direct-client-backed dmsg.Client (the one
+//     dmsg-disc/TPD/SD/etc. are reachable through without an HTTP-
+//     discovery roundtrip). May be nil — in which case the primary
+//     path is disabled and the client behaves like disc.NewHTTP.
+//
+//     Pre-2026-05: callers passed the main visor dmsgC here, which
+//     made the primary path always fall back to HTTP — dmsg-disc has
+//     no entry in its own discovery (by design — it's the root of
+//     trust), so the dmsgC's DialStream to dmsg-disc PK failed with
+//     "cannot connect to delegated server", primary returned that as
+//     a transport error, fallback ran. Using the direct-client-backed
+//     dmsg.Client fixes this: direct.Client carries a synthetic
+//     entry for the dmsg-disc PK with all known server PKs as
+//     delegated, so DialStream resolves locally and the dmsg session
+//     overlap with dmsg-disc's own direct.StartDmsg session set is
+//     reliable.
 //   - dmsgdiscPK: the dmsg-discovery's public key. Used to construct
-//     the DMSG URL (http://<pk>:80). The caller's dmsgC must be able
-//     to resolve this PK — typically via a direct.Client preloaded
-//     with the dmsg-discovery's entry, or via successful registration
-//     in the discovery itself.
+//     the DMSG URL (http://<pk>:80). primaryDmsgC must carry a
+//     synthetic entry for this PK in its direct.Client (or otherwise
+//     be able to resolve it without an HTTP-discovery lookup).
 //   - httpURL: the HTTP fallback URL (e.g. "http://dmsgd.skywire.skycoin.com").
 //     Same shape callers passed to disc.NewHTTP.
 //   - httpClient: optional override for the fallback HTTP client. nil
 //     uses http.DefaultClient.
 //   - log: logger for both legs.
 func New(
-	dmsgC *dmsg.Client,
+	primaryDmsgC *dmsg.Client,
 	dmsgdiscPK cipher.PubKey,
 	httpURL string,
 	httpClient *http.Client,
@@ -76,14 +88,14 @@ func New(
 	}
 	httpFallback := disc.NewHTTP(httpURL, httpClient, log)
 
-	if dmsgC == nil || dmsgdiscPK.Null() {
+	if primaryDmsgC == nil || dmsgdiscPK.Null() {
 		log.WithField("dmsgdisc_pk", dmsgdiscPK.String()).
-			Debug("DMSG-first disc: no dmsg client or null pk; using HTTP only")
+			Debug("DMSG-first disc: no primary dmsg client or null pk; using HTTP only")
 		return httpFallback
 	}
 
 	dmsgURL := fmt.Sprintf("http://%s:%d", dmsgdiscPK.String(), dmsg.DefaultDmsgHTTPPort)
-	dmsgTransport := dmsghttp.MakeHTTPTransport(context.Background(), dmsgC)
+	dmsgTransport := dmsghttp.MakeHTTPTransport(context.Background(), primaryDmsgC)
 	dmsgHTTP := &http.Client{Transport: dmsgTransport}
 	primary := disc.NewHTTP(dmsgURL, dmsgHTTP, log)
 

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -320,7 +320,37 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// for the whole process lifetime — so an outage on the public
 	// HTTP fronting (Caddy, etc.) would break the visor's
 	// discovery refresh even when DMSG was healthy.
-	upgradeDmsgDiscToDmsgfirst(dmsgC, v.conf.Dmsg, log)
+	//
+	// Run the upgrade in a goroutine that waits for v.dmsgHTTPReady
+	// (initDmsgHTTP's dmsgDC) before wiring it in as dmsgfirst's
+	// primary path. dmsgDC is direct.Client-backed — it carries a
+	// synthetic entry for the dmsg-disc PK with all known server PKs
+	// as delegated, so DialStream resolves without ever needing an
+	// HTTP-discovery lookup. Pre-fix the primary used the main dmsgC,
+	// whose own discovery was dmsgfirst, so every Entry/PutEntry call
+	// from the visor's own updateClientEntryLoop fell back to HTTP
+	// after the DMSG primary's DialStream timed out — dmsg-disc has
+	// no entry in its own DB (root of trust, by design) so the dial
+	// never had a chance.
+	//
+	// Until dmsgHTTPReady fires (i.e., dmsgDC has bootstrapped its
+	// session set), dmsgC keeps the plain-HTTP discovery clients
+	// constructed by dmsgc.New. That's the same conservative behavior
+	// as before this fix landed.
+	go func() {
+		select {
+		case <-v.dmsgHTTPReady:
+		case <-ctx.Done():
+			return
+		}
+		v.initLock.Lock()
+		dmsgDC := v.dmsgDC
+		v.initLock.Unlock()
+		if dmsgDC == nil {
+			return
+		}
+		upgradeDmsgDiscToDmsgfirst(dmsgC, dmsgDC, v.conf.Dmsg, log)
+	}()
 
 	// Start periodic config refresh for dynamic key sets
 	go v.startConfigRefresh(ctx) //nolint:errcheck,gosec
@@ -354,9 +384,18 @@ const dmsgServersCacheRefreshInterval = 5 * time.Minute
 // to plain HTTP when the dmsg dial fails. The dmsg-discovery's PK is
 // extracted from each deployment's `discovery_dmsg` URL — when that's
 // absent, the entry stays on plain HTTP because dmsgfirst.New needs a
-// PK to dial. Safe to call after dmsgC.Ready(); a no-op if no
-// deployments yield a non-zero PK.
-func upgradeDmsgDiscToDmsgfirst(dmsgC *dmsg.Client, conf *dmsgc.DmsgConfig, log *logging.Logger) {
+// PK to dial. A no-op if no deployments yield a non-zero PK.
+//
+// primaryDmsgC is the dmsg client dmsgfirst will use for its DMSG-
+// primary path. It must be the direct.Client-backed dmsgDC, not the
+// main dmsgC — the main dmsgC's own discovery is what we're
+// upgrading here, so using it for the primary path would recurse on
+// every Entry() lookup. dmsgDC carries the dmsg-disc PK as a synthetic
+// direct.Client entry with all known server PKs as delegated, so its
+// DialStream(dmsg-disc) resolves locally and goes through a session
+// dmsg-disc actually has (it preloads the same server set via
+// direct.StartDmsg in dmsgdisc.go).
+func upgradeDmsgDiscToDmsgfirst(dmsgC *dmsg.Client, primaryDmsgC *dmsg.Client, conf *dmsgc.DmsgConfig, log *logging.Logger) {
 	if conf == nil {
 		return
 	}
@@ -372,9 +411,9 @@ func upgradeDmsgDiscToDmsgfirst(dmsgC *dmsg.Client, conf *dmsgc.DmsgConfig, log 
 			upgraded[i] = dmsgdisc.NewHTTP(d.Discovery, &http.Client{}, log)
 			continue
 		}
-		upgraded[i] = dmsgfirst.New(dmsgC, pk, d.Discovery, &http.Client{}, log)
+		upgraded[i] = dmsgfirst.New(primaryDmsgC, pk, d.Discovery, &http.Client{}, log)
 		anyUpgraded = true
-		log.WithField("url", d.Discovery).WithField("pk", pk).Info("dmsg discovery client upgraded to dmsgfirst")
+		log.WithField("url", d.Discovery).WithField("pk", pk).Info("dmsg discovery client upgraded to dmsgfirst (primary via direct-client dmsgDC)")
 	}
 	if !anyUpgraded {
 		return

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -285,8 +285,14 @@ func initEmbeddedRouteSetup(ctx context.Context, v *Visor, log *logging.Logger) 
 	// disc client, and overflows the goroutine stack.
 	v.seedDmsgServiceEntries(routeSetupDmsgC, log)
 	// Same dmsgfirst upgrade as the main dmsgC: discovery refresh
-	// prefers DMSG and only falls back to plain HTTP per-call.
-	upgradeDmsgDiscToDmsgfirst(routeSetupDmsgC, v.conf.Dmsg, log)
+	// prefers DMSG and only falls back to plain HTTP per-call. The
+	// dmsg-primary path uses v.dmsgDC (direct-client-backed) so the
+	// DialStream to dmsg-disc resolves locally — see the equivalent
+	// wiring in initDmsg's upgrade for the full rationale.
+	v.initLock.Lock()
+	primary := v.dmsgDC
+	v.initLock.Unlock()
+	upgradeDmsgDiscToDmsgfirst(routeSetupDmsgC, primary, v.conf.Dmsg, log)
 
 	v.initLock.Lock()
 	v.embeddedRouteSetup = &EmbeddedRouteSetup{

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -546,7 +546,11 @@ func initEmbeddedTPS(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// Same dmsgfirst upgrade as the main dmsgC: avoids pinning the
 	// embedded TPS's discovery refresh to plain HTTP for the process
 	// lifetime when initDmsgHTTP's dmsgDC isn't ready at construction.
-	upgradeDmsgDiscToDmsgfirst(tpsDmsgC, v.conf.Dmsg, log)
+	// Primary path uses v.dmsgDC (direct-client-backed) — see initDmsg.
+	v.initLock.Lock()
+	primary := v.dmsgDC
+	v.initLock.Unlock()
+	upgradeDmsgDiscToDmsgfirst(tpsDmsgC, primary, v.conf.Dmsg, log)
 
 	v.initLock.Lock()
 	v.embeddedTPS = &embeddedTPS{


### PR DESCRIPTION
## Symptom

Even on develop tip with #2845 (services no longer self-publish), every visor's own log shows ~2 fallback lines per minute:

\`\`\`
DEBUG [dmsg]: disc Entry: DMSG primary failed; trying HTTP fallback
  error="Get http://022e607e…/dmsg-discovery/entry/<self-pk>:
         dmsg error 202 - cannot connect to delegated server"
\`\`\`

These are the visor's own \`updateClientEntryLoop\` self-entry refreshes (every 5min). Every one of them falls back to HTTP. That's the "extra discovery traffic" you flagged earlier.

## Root cause

\`dmsgfirst.New\` was using the visor's main \`dmsgC\` for the DMSG-primary path. But the main dmsgC's own discovery client **is** dmsgfirst — so every Entry() call recurses:

1. dmsgfirst.Entry → primary http.Get(dmsg://dmsg-disc/.../entry/self)
2. dmsghttp.RoundTrip → dmsgC.DialStream(dmsg-disc-pk)
3. dmsgC discovery lookup for dmsg-disc-pk
4. dmsg-disc has no entry in its own DB (root of trust, by design)
5. seedDmsgServiceEntries' synthetic cache entry hits, but its listed delegated_servers don't reliably overlap dmsg-disc's actual session set
6. Phase 1-3 fail → "dmsg error 202 - cannot connect to delegated server"
7. Primary returns transport error → HTTP fallback fires

## Fix

\`dmsgfirst.New\` now takes the visor's \`dmsgDC\` (direct.Client-backed) as its primary dmsg.Client. \`dmsgDC\` carries the dmsg-disc PK as a synthetic direct.Client entry with all known server PKs as delegated, and dmsg-disc itself preloads the same server set via \`direct.StartDmsg\` (\`pkg/services/dmsgdisc/dmsgdisc.go\`) — so their session sets reliably overlap. DialStream resolves locally, primary call succeeds, fallback only fires when DMSG is genuinely broken.

## Visor wiring

- \`initDmsg\` defers the upgrade into a goroutine that waits for \`v.dmsgHTTPReady\` (dmsgDC's bootstrap) before swapping in the discovery clients.
- \`initRouter\` (embedded route setup) and \`initTransport\` (embedded TPS) snapshot \`v.dmsgDC\` under \`v.initLock\` and pass it through. Both fire after initDmsg, so dmsgDC is typically ready.
- \`pkg/services/dmsgsrv\`: already passes its own direct-client-backed dmsgC via \`direct.StartDmsg\`, no change needed.

## Test plan

- [ ] Rebuild, restart, observe \`./local/log/skywire.log\` over 10 min: \`grep -c "DMSG primary failed"\` should be ~0 (pre-fix: ~22/10min on a quiet visor).
- [ ] Other functions unaffected: hypervisor UI, dmsgpty exec, transports still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)