### PR TITLE
fix(hypervisor): widen cache-fresh window 30s → 3min to absorb stream-idle cycle

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -585,7 +585,16 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 		// Visors whose cache was refreshed within this freshness
 		// window count as "live" even if THIS round's Summary RPC
 		// timed out at the 5s outer cap — they're slow, not broken.
-		const cacheFreshWindow = 30 * time.Second
+		// 3 minutes covers the 2-minute dmsg.StreamIdleTimeout
+		// (pkg/dmsg/dmsg/types.go) plus a generous slack for the
+		// peer-side redial → hypervisor-accept → next-poll cycle.
+		// Without this, a peer whose stream just idle-closed shows
+		// "last seen 2-3min ago" in the UI for one or two polls
+		// before the new conn's first Summary lands — visible
+		// flicker that operators flag as "nodes are stale". 30s
+		// (the original value) caught only inline RPC slowness
+		// and missed the steady-state 2-min idle pattern entirely.
+		const cacheFreshWindow = 3 * time.Minute
 
 		for _, entry := range remotes {
 			go func(pk cipher.PubKey, c Conn) {


### PR DESCRIPTION
## Symptom

After visor restart, operator sees the hypervisor UI initially go all-green, then 2-3 minutes later about half the nodes flip to `last seen at: …` timestamps. Eventually they return to green. Visible flicker on every `dmsg.StreamIdleTimeout` (2min) cycle.

## Root cause

The freshness window from #2842 (30s) was tuned for absorbing in-line slow RPCs (Summary call exceeding the outer 5s cap), not the steady-state stream-idle cycle:

- Peer-side dmsg stream goes idle after 2min of no read (`dmsg.StreamIdleTimeout` = 2min, pkg/dmsg/dmsg/types.go)
- Peer redials within ~1-2s
- Hypervisor accept loop registers the new conn
- Next UI poll succeeds against the fresh conn — last_seen updates
- But the poll BETWEEN the close and the next-after-accept sees a stale-cache row with `last_seen` 2-3min old → falls outside the 30s window → `online=false` in the response

## Fix

Bump `cacheFreshWindow` from 30s to 3min. That covers the 2-min idle gap plus generous slack for the redial → accept → next-poll latency, so the in-between poll keeps surfacing the visor as online. Genuinely-down peers (>60min since last successful Summary, which is when `clientEntryTTL` would also expire their dmsg-disc entry) still mark offline correctly.

## Better long-term

A hypervisor-side background poll loop that keeps the cache fresh regardless of UI activity — the stream would then never go idle in the first place. Tracking separately; this bump is the conservative mitigation that ships now without restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)