### PR TITLE
fix(hypervisor): apply cache-fresh window to sweep branch too

### DIFF
--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -698,11 +698,20 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 				continue
 			}
 			stale := *cached.sum
-			offlineSince := time.Now().UTC()
-			resp := makeSummaryResp(false, false, &stale)
+			// Same freshness window as the in-remoteVisors fallback
+			// path above: a peer that was just Summary'd N seconds
+			// ago (within the dmsg stream-idle cycle) hasn't been
+			// disconnected long enough to render as offline. Once
+			// outside the window the row keeps showing "last seen
+			// at" with offline_since stamped.
+			fresh := time.Since(cached.seenAt) < cacheFreshWindow
 			seenAt := cached.seenAt
+			resp := makeSummaryResp(fresh, false, &stale)
 			resp.LastSeenAt = &seenAt
-			resp.OfflineSince = &offlineSince
+			if !fresh {
+				offlineSince := time.Now().UTC()
+				resp.OfflineSince = &offlineSince
+			}
 			summaries = append(summaries, resp)
 		}
 		hv.summaryCacheMx.RUnlock()


### PR DESCRIPTION
## Symptom (continued from #2842 + #2852)

After widening the freshness window from 30s → 3min in #2852, operators still saw some peers flip to `last seen at` during the 2-min stream-idle cycle.

## Root cause

#2842's `getAllVisorsSummary` has two cache-fallback paths:

1. **In-remoteVisors fallback** — used when a peer is currently registered but Summary timed out / failed mid-round. Already gated by `cacheFreshWindow` (now 3min).
2. **Post-loop sweep branch** — renders cached rows for peers NOT in this round's response (i.e. peers that got evicted from remoteVisors earlier). Hardcoded `online=false` on every row.

A peer that briefly enters the sweep branch during a dmsg stream-idle / redial flap (peer disconnects at 2min idle, accept hasn't fired for the redial yet) was rendering as offline even with `last_seen` < 3 minutes ago.

## Fix

Sweep branch now uses the same freshness check:

```go
fresh := time.Since(cached.seenAt) < cacheFreshWindow
resp := makeSummaryResp(fresh, false, &stale)
resp.LastSeenAt = &seenAt
if !fresh { resp.OfflineSince = &offlineSince }
```

Within the 3-min window the row stays `online=true` (last_seen still surfaces); outside the window it flips to `online=false` with `offline_since` stamped (same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)