### PR TITLE
fix(visor): shorten hypervisor RPC idle-timeout 10min → 90s

### DIFF
--- a/pkg/visor/rpc_client_serve.go
+++ b/pkg/visor/rpc_client_serve.go
@@ -52,7 +52,19 @@ const rpcSkynetCooldown = 5 * time.Minute
 // dies silently: the hypervisor's next poll times out, its close
 // can't deliver a close frame over the broken session, and our
 // blocking Read on the served end of the conn sits parked forever.
-const hypervisorRPCIdleTimeout = 10 * time.Minute
+//
+// 90s lines up with the dmsg.StreamIdleTimeout (2min) on the
+// hypervisor side — by the time the hypervisor's view of the
+// stream is decisively dead, the visor's redial path has already
+// fired here. Previous value (10min) left peers showing
+// "last seen N minutes ago" in the hypervisor UI for the full
+// idle window before the visor finally noticed and redialed;
+// operators correctly flagged this as a regression from before
+// the silent-stream-death fix (#2806). Trade-off: a quieter
+// hypervisor (UI closed for >90s) triggers a single redial per
+// 90s window — cheap, the dial completes in ~100ms over an
+// already-established dmsg session.
+const hypervisorRPCIdleTimeout = 90 * time.Second
 
 // rpcTransport names the transport carrying a given served RPC conn,
 // recorded by dialHypervisorRPC so ServeRPCClient can apply the


### PR DESCRIPTION
## Operator complaint

Magnetosphere visible in hypervisor UI as `last seen 8m ago` — but `dmsg curl dmsg://<mag-pk>:80/health` returns its /health instantly. The underlying dmsg session is fine; the specific yamux stream carrying the hypervisor RPC went silent.

## Trace

1. Hypervisor's `getAllVisorsSummary` calls Summary() per peer
2. Summary() RPC errors out (stream dead)
3. Hypervisor evicts peer from remoteVisors, sweep-branch row sits with last_seen frozen at the last successful poll
4. Hypervisor's close on its end can't propagate to peer over the dead stream (per #2806's commit message)
5. Peer's served end sits in a blocking Read inside `ServeConn`
6. Visor-side idleConn (added in #2806) fires after **10 minutes** of no traffic, closes its end, `ServeRPCClient` redials
7. New conn re-registered → next UI poll updates cache → peer renders online again

The full peer-side recovery window is bounded by the 10-min idle timeout. Operators see 8-9 minute stale-row gaps on every silent-stream-death cycle.

Pre-#2806 the same scenario left the peer parked forever — that was the worse bug. But 10min is overly conservative; tightening to 90s shrinks the recovery window without spamming redials. 90s lines up with `dmsg.StreamIdleTimeout = 2min` so the hypervisor's view of the stream is decisively gone by the time the visor notices.

Trade-off: a quiet hypervisor (UI closed for >90s) triggers a single redial per 90s window. Cheap — the dial completes in ~100ms over the already-established dmsg session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)