### PR TITLE
fix(hypervisor): background summaryCache poll independent of UI activity

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -266,6 +266,20 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 		}
 	}
 
+	// Background poll loop — keeps summaryCache fresh + streams warm
+	// independent of UI activity. Without this, the hypervisor only
+	// fires Summary RPCs when the operator hits /api/visors-summary;
+	// a closed-UI hypervisor goes silent, peer-side idleConn (#2856)
+	// closes every served stream at 90s, the cache rots, and the
+	// reopened UI takes one poll round per peer to repopulate.
+	//
+	// 30s cadence is faster than the 90s peer-side idle so each
+	// Summary call resets the idle clock — peers stop cycling
+	// redial+re-accept needlessly. It's slower than typical UI
+	// poll cadence so we don't double-fire when both are active
+	// (UI polls overlap-and-skip via summary's own goroutine).
+	go hv.runBackgroundSummaryPoll(ctx)
+
 	// setup local PTY using direct connection (bypasses DMSG for local visor)
 	hv.mu.Lock()
 	if hv.visor != nil && hv.visor.conf.Dmsgpty != nil && hv.visor.conf.Dmsgpty.CLINet != "" {
@@ -408,6 +422,83 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 			}()
 		}
 	}
+}
+
+// hypervisorBackgroundPollInterval is the cadence of the background
+// summaryCache refresh loop spawned from ServeRPC. Tuned against the
+// visor-side hypervisorRPCIdleTimeout (90s, see rpc_client_serve.go):
+// 30s gives every served stream a Summary RPC three times per idle
+// window so peer-side idleConn never fires from "no UI traffic"
+// alone. Also tuned against the 3-minute cacheFreshWindow in
+// hypervisor_handlers_visors.go: 30s is well inside the window so
+// the cache is always-fresh from the UI's perspective.
+const hypervisorBackgroundPollInterval = 30 * time.Second
+
+// runBackgroundSummaryPoll keeps hv.summaryCache fresh independent of
+// UI activity. Spawned once from ServeRPC; runs until ctx cancels.
+// Iterates every entry in remoteVisors, fires Summary() in parallel
+// goroutines (one per peer), updates the cache on success. Failures
+// are silent — the UI-driven getAllVisorsSummary handler still does
+// its own per-peer Summary against the same conns and will surface
+// real failures via the deadVisors eviction path. The background
+// poll is purely a cache-warmer + stream-keepalive.
+//
+// Why this matters operationally: pre-this-change, the hypervisor
+// only fired Summary RPCs when the operator hit /api/visors-summary.
+// A closed-UI hypervisor went silent — peer-side idleConn (90s, per
+// #2856) closed every served stream every 90s, peer redialed,
+// hypervisor re-accepted, repeat. Plus the summaryCache rotted, so
+// when the operator reopened the UI it took one poll round per peer
+// to repopulate (visible "list slowly fills" symptom).
+//
+// With this loop running, streams are reset every 30s by the
+// Summary call's wire traffic, peer-side idle never fires
+// gratuitously, and the cache is always-warm — UI reopen renders
+// every peer instantly from cache.
+func (hv *Hypervisor) runBackgroundSummaryPoll(ctx context.Context) {
+	ticker := time.NewTicker(hypervisorBackgroundPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			hv.pollAllForCache(ctx)
+		}
+	}
+}
+
+// pollAllForCache snapshots remoteVisors under the read lock, then
+// fans out one goroutine per peer to call Summary() concurrently.
+// Successful calls write to summaryCache; failures are dropped on
+// the floor (the UI-driven path handles eviction). Bounded by the
+// inner RPC timeout (skyenv.RPCTimeout, 20s); a tick that takes
+// longer than the next tick interval is fine — Go's ticker drops
+// elapsed ticks, so we don't pile up goroutines on a slow round.
+func (hv *Hypervisor) pollAllForCache(ctx context.Context) {
+	hv.mu.RLock()
+	remotes := make(map[cipher.PubKey]API, len(hv.remoteVisors))
+	for pk, c := range hv.remoteVisors {
+		remotes[pk] = c.API
+	}
+	hv.mu.RUnlock()
+
+	if len(remotes) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(remotes))
+	for pk, api := range remotes {
+		go func(pk cipher.PubKey, api API) {
+			defer wg.Done()
+			if ctx.Err() != nil {
+				return
+			}
+			hv.warmSummaryCache(pk, api)
+		}(pk, api)
+	}
+	wg.Wait()
 }
 
 // warmSummaryCache fires a Summary() RPC against a freshly-accepted


### PR DESCRIPTION
## Problem

Opening the hypervisor UI after a long closed-tab gap surfaces "fewer nodes / more last-seen-at" rows that fill in over the next 30-60s as the UI's per-peer Summary polls land. Operator described it as "things were instant before, now nodes slowly appear."

## Mechanism

The hypervisor only fires Summary RPCs when `/api/visors-summary` is hit. Closed UI = no polling = `summaryCache` rots. Worse: peer-side `idleConn` (90s, #2856) closes every served stream from "no UI traffic" alone, peers cycle redial + re-accept on every idle window for nothing.

## Fix

Spawn a 30s background poll loop from `ServeRPC` that iterates `remoteVisors` and calls `Summary()` per peer in parallel goroutines. Successful calls update `summaryCache`; failures are dropped on the floor (the UI-driven `getAllVisorsSummary` still handles eviction via its `deadVisors` path). The background loop is purely a cache-warmer + stream-keepalive.

**30s cadence reasoning:**
- 3× per peer-side `hypervisorRPCIdleTimeout` window (90s, #2856) — peer never sees "no UI traffic" alone trigger an idle close.
- Well inside the 3-min `cacheFreshWindow` (#2852) — cache is always-fresh from the UI's perspective.
- Slower than typical UI poll cadence (5-10s) — when UI is active, background tick mostly piggybacks on UI's recent successful Summary, no double work to speak of.

## Result

- Opening the UI now renders every connected peer from cache instantly.
- Streams stay warm — no churn cycle when UI is closed.
- Existing behavior unchanged when UI is actively polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)