### PR TITLE
refactor(app): name the implicit app contract (#2775 phase 1)

### DIFF
--- a/pkg/app/appcommon/proc_config.go
+++ b/pkg/app/appcommon/proc_config.go
@@ -29,9 +29,57 @@ var (
 )
 
 // AppFunc is a function that runs an app in-process.
-// It receives a context for cancellation and command-line args.
-// The app is responsible for creating its own app.Client via app.NewClient().
+//
+// Contract:
+//   - Run until the supplied context is canceled, then return.
+//   - On clean shutdown, return nil. On unrecoverable error, return a
+//     non-nil error and log via the per-app logger obtained through
+//     app.NewClient().
+//   - args mirrors os.Args[1:] for the equivalent external binary, so
+//     internal and external invocations of the same logical app share
+//     CLI semantics.
+//   - The app is responsible for creating its own app.Client via
+//     app.NewClient(); the visor-side conn is wired in by ProcManager
+//     before the function is called.
 type AppFunc func(ctx context.Context, args []string) error
+
+// RunMode declares whether a Proc runs as a separate OS process
+// (External) or as a goroutine inside the visor (Internal). It is
+// the explicit form of what was previously implied by RunFunc != nil.
+type RunMode string
+
+const (
+	// RunModeUnspecified means the dispatch path will be derived from
+	// the presence of ProcConfig.RunFunc. Kept for backward
+	// compatibility with code paths that build ProcConfig directly.
+	RunModeUnspecified RunMode = ""
+	// RunModeExternal launches the proc as a separate OS process via
+	// ProcConfig.BinaryLoc. POSIX credentials (ProcUser/ProcGroup) and
+	// stderr capture are honored.
+	RunModeExternal RunMode = "external"
+	// RunModeInternal runs the proc in-process by invoking the AppFunc
+	// stored in ProcConfig.RunFunc. POSIX credential drops are ignored
+	// since setuid is process-wide.
+	RunModeInternal RunMode = "internal"
+)
+
+// RestartPolicy declares how the supervisor should react when a Proc
+// exits. Currently only Never is enforced — OnFailure and Always are
+// declared up-front so the contract is stable while supervision is
+// wired in a later phase.
+type RestartPolicy string
+
+const (
+	// RestartNever leaves the proc stopped when it exits. Operators
+	// must call StartApp again. This matches today's behavior across
+	// all apps.
+	RestartNever RestartPolicy = ""
+	// RestartOnFailure relaunches the proc only when it returned a
+	// non-nil error (or exited non-zero for external procs).
+	RestartOnFailure RestartPolicy = "on-failure"
+	// RestartAlways relaunches the proc on any exit, including clean.
+	RestartAlways RestartPolicy = "always"
+)
 
 // ProcKey is a unique key to authenticate a proc within the app server.
 type ProcKey [16]byte
@@ -96,6 +144,28 @@ type ProcConfig struct {
 	ProcUser  string      `json:"proc_user,omitempty"`
 	ProcGroup string      `json:"proc_group,omitempty"`
 	RunFunc   interface{} `json:"-"`
+	// RunMode is the explicit dispatch hint. When unset, EffectiveRunMode
+	// derives the mode from RunFunc presence — preserving legacy callers
+	// that construct ProcConfig directly without setting RunMode.
+	RunMode RunMode `json:"run_mode,omitempty"`
+	// Restart declares the supervisor's reaction when the proc exits.
+	// Declared now for contract stability; enforcement lands with the
+	// supervisor pass (#2775 phase 4).
+	Restart RestartPolicy `json:"restart,omitempty"`
+}
+
+// EffectiveRunMode returns the RunMode the proc manager should
+// dispatch on. When RunMode is explicitly set, it wins. Otherwise we
+// fall back to the legacy heuristic — RunFunc != nil → Internal — so
+// existing callers continue to work unchanged.
+func (c *ProcConfig) EffectiveRunMode() RunMode {
+	if c.RunMode != RunModeUnspecified {
+		return c.RunMode
+	}
+	if c.RunFunc != nil {
+		return RunModeInternal
+	}
+	return RunModeExternal
 }
 
 // ProcConfigFromEnv obtains a ProcConfig from the associated env variable, returning an error if any.

--- a/pkg/app/appserver/proc.go
+++ b/pkg/app/appserver/proc.go
@@ -95,7 +95,7 @@ func NewProc(mLog *logging.MasterLogger, conf appcommon.ProcConfig, disc appdisc
 	var cmd *exec.Cmd
 	var stderr io.ReadCloser
 
-	if conf.RunFunc == nil {
+	if conf.EffectiveRunMode() == appcommon.RunModeExternal {
 		envs := conf.Envs()
 		cmd = exec.Command(conf.BinaryLoc, conf.ProcArgs...) //nolint:gosec
 		cmd.Env = append(os.Environ(), envs...)
@@ -230,11 +230,12 @@ func (p *Proc) Start() error {
 	p.startTime = time.Now().UTC()
 	p.startTimeMx.Unlock()
 
-	if p.conf.RunFunc != nil {
+	switch p.conf.EffectiveRunMode() {
+	case appcommon.RunModeInternal:
 		return p.startInProcess()
+	default:
+		return p.startExternal()
 	}
-
-	return p.startExternal()
 }
 
 func (p *Proc) startInProcess() error {

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -287,13 +287,17 @@ func (l *AppLauncher) startAppWithMode(cmd string, args, envs []string, launcher
 		ac.Args = args
 	}
 
-	// Override launcher mode if specified
+	// Override launcher mode if specified. The string form matches
+	// appcommon.RunMode for the typed constants — at the RPC boundary
+	// this still arrives as a string so we compare against the named
+	// constants rather than introducing a new conversion.
 	if launcherMode != "" {
 		acCopy := ac
-		if launcherMode == "internal" {
+		switch appcommon.RunMode(launcherMode) {
+		case appcommon.RunModeInternal:
 			// Force internal: clear binary
 			acCopy.Binary = ""
-		} else if launcherMode == "external" {
+		case appcommon.RunModeExternal:
 			// Force external: ensure binary is set
 			if ac.Binary == "" {
 				// Use default binary name (app name)
@@ -438,6 +442,15 @@ func makeProcConfig(lc AppLauncherConfig, ac appserver.AppConfig, envs []string)
 			// Clear BinaryLoc since we're using internal function
 			procConf.BinaryLoc = ""
 		}
+	}
+
+	// Record the dispatch mode explicitly so downstream consumers
+	// (proc.go, RPC introspection, future supervision) don't have to
+	// re-derive it from RunFunc presence.
+	if procConf.RunFunc != nil {
+		procConf.RunMode = appcommon.RunModeInternal
+	} else {
+		procConf.RunMode = appcommon.RunModeExternal
 	}
 
 	err := ensureDir(&procConf.ProcWorkDir)


### PR DESCRIPTION
## Summary

Phase 1 of #2775 — the unified app framework refactor that aims to collapse skynet srv/client, resolver, hypervisor, dmsgpty into one app contract with declared run-modes.

This first phase **names what is already there** without changing behavior:

- The launcher already supports both external-binary and in-process apps; `ProcManager` dispatches on `RunFunc != nil`. The "contract" was an implicit heuristic.
- This PR makes it explicit so later phases can extend the contract (supervision, run-modes, declarative registration) without rewiring the dispatch path.

## What changes

- **Document `AppFunc`'s lifecycle contract** in `pkg/app/appcommon/proc_config.go` — Run until ctx cancel, return nil on clean shutdown, args mirror `os.Args[1:]` of the equivalent binary.
- **Add `RunMode` type** (`External` | `Internal` | unspecified-fallback) replacing the implicit `RunFunc != nil` heuristic. `EffectiveRunMode()` preserves legacy fallback so direct `ProcConfig` builders don't have to set `RunMode`.
- **Add `RestartPolicy` type** (`Never` | `OnFailure` | `Always`) — declared now for contract stability. Enforcement lands in phase 4 with the supervisor pass; today only `Never` is the effective behavior across the codebase.
- **Wire `RunMode` in `launcher.makeProcConfig`** — records the mode explicitly after the RunFunc lookup.
- **Switch `Proc.Start` + `NewProc` dispatch gate** to `EffectiveRunMode()`. Same outcome as before for every existing caller because `EffectiveRunMode()` falls back to the RunFunc heuristic when RunMode is unset.
- **`StartAppWithMode`'s `"internal"`/`"external"` magic strings** now compare against the `appcommon.RunMode` typed constants. The RPC wire format is unchanged (still string), but the linkage is now visible in code.

## What does not change

- No behavior change. Every existing app path (external binaries via `apps[]`, in-process via `RegisterApp`) keeps the same lifecycle.
- The RPC wire format for `StartAppWithMode` remains a string parameter — no rolling-update concerns.
- No new RPCs, no config.json schema changes, no supervision logic yet.

## Phased plan reference (from #2775 design)

- **Phase 1 (this PR)** — name the contract. ~90 LOC, no risk.
- Phase 2 — collapse skynet/skysocks/vpn pair binaries into mode-flagged singletons.
- Phase 3 — register hypervisor/dmsgpty/dmsgweb/skynetweb as `RunMode: Internal` pseudo-apps.
- Phase 4 — common supervision + restart policy enforcement.

## Test plan

- [x] `go build ./pkg/app/... ./pkg/visor/... ./cmd/skywire/...` clean
- [x] `go test ./pkg/app/appcommon/... ./pkg/app/launcher/... ./pkg/app/appserver/...` green
- [x] `go vet ./pkg/app/...` clean
- [ ] CI lint