### PR TITLE
refactor(app): extract status/error/port helpers onto *app.Client (#2775 phase 2a)

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -732,7 +732,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 		port = appCl.Config().RoutingPort
 		if appPort != 0 {
 			port = routing.Port(appPort)
-			setAppPort(appCl, port)
+			appCl.SetAppPortOrLog(port)
 		}
 	} else if appPort != 0 {
 		port = routing.Port(appPort)
@@ -761,7 +761,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 		ipcClient, err := ipc.StartClient(skyenv.SkychatName, nil)
 		if err != nil {
 			appLog("Error creating ipc server for skychat client: %v", err)
-			setAppError(appCl, err)
+			appCl.SetErrorOrLog(err)
 			return err
 		}
 		go handleIPCSignal(ipcClient)
@@ -817,16 +817,16 @@ func RunSkychat(ctx context.Context, args []string) error {
 		go func() {
 			select {
 			case <-termCh:
-				setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+				appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 				cancel()
 			case <-ctx.Done():
-				setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+				appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 				return
 			}
 		}()
 	}
 
-	setAppStatus(appCl, appserver.AppDetailedStatusRunning)
+	appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
 	srv := &http.Server{
 		Addr:         url,
 		Handler:      mux,
@@ -843,11 +843,11 @@ func RunSkychat(ctx context.Context, args []string) error {
 	case err := <-errCh:
 		if err != nil {
 			appLog("HTTP server error: %v", err)
-			setAppError(appCl, err)
+			appCl.SetErrorOrLog(err)
 			return err
 		}
 	case <-ctx.Done():
-		setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 		if err := srv.Shutdown(context.Background()); err != nil {
 			return err
 		}
@@ -860,7 +860,7 @@ func listenLoop(netType appnet.Type, appPort routing.Port) {
 	l, err := appCl.Listen(netType, appPort)
 	if err != nil {
 		appLog("Error listening network %v on port %d: %v", netType, appPort, err)
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		return
 	}
 
@@ -1829,32 +1829,3 @@ func handleIPCSignal(client *ipc.Client) {
 	client.Close()
 }
 
-// setApp* helpers tolerate a nil appCl (standalone mode). Without the
-// guards the visor-RPC path would nil-panic the moment we tried to
-// surface app-state to a visor that isn't there.
-func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
-	if appCl == nil {
-		return
-	}
-	if err := appCl.SetDetailedStatus(string(status)); err != nil {
-		appCl.Log().Errorf("Failed to set status %v: %v", status, err)
-	}
-}
-
-func setAppError(appCl *app.Client, appErr error) {
-	if appCl == nil {
-		return
-	}
-	if err := appCl.SetError(appErr.Error()); err != nil {
-		appCl.Log().Errorf("Failed to set error %v: %v", appErr, err)
-	}
-}
-
-func setAppPort(appCl *app.Client, port routing.Port) {
-	if appCl == nil {
-		return
-	}
-	if err := appCl.SetAppPort(port); err != nil {
-		appCl.Log().Errorf("Failed to set port %v: %v", port, err)
-	}
-}

--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -125,25 +125,25 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	// Validate required flags
 	if srv == "" {
 		err := fmt.Errorf("--srv flag (remote server public key) is required")
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		return err
 	}
 
 	var remotePK cipher.PubKey
 	if err := remotePK.Set(srv); err != nil {
-		setAppError(appCl, fmt.Errorf("invalid server public key: %w", err))
+		appCl.SetErrorOrLog(fmt.Errorf("invalid server public key: %w", err))
 		return fmt.Errorf("invalid server public key: %w", err)
 	}
 
 	if remotePort <= 0 || remotePort > 65535 {
 		err := fmt.Errorf("--remote flag (remote port) must be 1-65535")
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		return err
 	}
 
 	if localPort <= 0 || localPort > 65535 {
 		err := fmt.Errorf("--local flag (local port) must be 1-65535")
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		return err
 	}
 
@@ -152,10 +152,10 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 
 	// Set routing port if specified
 	if appPort != 0 {
-		setAppPort(appCl, routing.Port(appPort))
+		appCl.SetAppPortOrLog(routing.Port(appPort))
 	}
 
-	setAppStatus(appCl, appserver.AppDetailedStatusStarting)
+	appCl.SetStatusOrLog(appserver.AppDetailedStatusStarting)
 
 	// Build a dial factory the client calls per-accept. The factory
 	// captures appCl + remote endpoint so each local connection gets
@@ -207,7 +207,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	client := skynet.NewClient(appCl.Log(), remotePK, remotePort, localPort, dialRemote)
 
 	appCl.Log().Info("Skynet client ready — waiting for local connections")
-	setAppStatus(appCl, appserver.AppDetailedStatusRunning)
+	appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
 
 	// Handle shutdown
 	termCh := make(chan os.Signal, 1)
@@ -221,7 +221,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		}
 	}()
 
-	defer setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+	defer appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 
 	// Serve (accept local connections)
 	serveCh := make(chan error, 1)
@@ -244,27 +244,9 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	return nil
 }
 
-func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
-	if err := appCl.SetDetailedStatus(string(status)); err != nil {
-		appCl.Log().Errorf("Failed to set status %v: %v", status, err)
-	}
-}
-
-func setAppError(appCl *app.Client, appErr error) {
-	if err := appCl.SetError(appErr.Error()); err != nil {
-		appCl.Log().Errorf("Failed to set error %v: %v", appErr, err)
-	}
-}
-
 // Execute executes root CLI command.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
-	}
-}
-
-func setAppPort(appCl *app.Client, port routing.Port) {
-	if err := appCl.SetAppPort(port); err != nil {
-		appCl.Log().Errorf("Failed to set port %v: %v", port, err)
 	}
 }

--- a/cmd/apps/skynet/commands/skynet.go
+++ b/cmd/apps/skynet/commands/skynet.go
@@ -84,11 +84,11 @@ func RunSkynet(ctx context.Context, args []string) error {
 			}
 			var port int
 			if _, err := fmt.Sscanf(p, "%d", &port); err != nil {
-				setAppError(appCl, fmt.Errorf("invalid port: %s", p))
+				appCl.SetErrorOrLog(fmt.Errorf("invalid port: %s", p))
 				return fmt.Errorf("invalid port: %s", p)
 			}
 			if port <= 0 || port > 65535 {
-				setAppError(appCl, fmt.Errorf("port out of range: %d", port))
+				appCl.SetErrorOrLog(fmt.Errorf("port out of range: %d", port))
 				return fmt.Errorf("port out of range: %d", port)
 			}
 			ports = append(ports, port)
@@ -97,7 +97,7 @@ func RunSkynet(ctx context.Context, args []string) error {
 
 	if len(ports) == 0 {
 		err := fmt.Errorf("no ports specified, use --ports flag")
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		return err
 	}
 
@@ -108,12 +108,12 @@ func RunSkynet(ctx context.Context, args []string) error {
 
 	appCl.Log().Infof("Exposing ports: %v via built-in sky_forwarding", ports)
 
-	setAppStatus(appCl, appserver.AppDetailedStatusStarting)
+	appCl.SetStatusOrLog(appserver.AppDetailedStatusStarting)
 
 	// Create RPC client to visor
 	rpcClient, err := createRPCClient(rpcAddr)
 	if err != nil {
-		setAppError(appCl, fmt.Errorf("failed to connect to visor RPC: %w", err))
+		appCl.SetErrorOrLog(fmt.Errorf("failed to connect to visor RPC: %w", err))
 		return fmt.Errorf("failed to connect to visor RPC: %w", err)
 	}
 
@@ -126,7 +126,7 @@ func RunSkynet(ctx context.Context, args []string) error {
 			for _, p := range registeredPorts {
 				_ = rpcClient.DeregisterTCPPort(p) //nolint:errcheck
 			}
-			setAppError(appCl, fmt.Errorf("failed to register port %d: %w", port, err))
+			appCl.SetErrorOrLog(fmt.Errorf("failed to register port %d: %w", port, err))
 			return fmt.Errorf("failed to register port %d: %w", port, err)
 		}
 		appCl.Log().Infof("Registered port %d with visor", port)
@@ -134,7 +134,7 @@ func RunSkynet(ctx context.Context, args []string) error {
 	}
 
 	appCl.Log().Infof("All %d ports registered, server ready", len(ports))
-	setAppStatus(appCl, appserver.AppDetailedStatusRunning)
+	appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
 
 	// Handle shutdown
 	termCh := make(chan os.Signal, 1)
@@ -144,7 +144,7 @@ func RunSkynet(ctx context.Context, args []string) error {
 	select {
 	case <-ctx.Done():
 		appCl.Log().Warnf("Context already canceled before wait: %v", ctx.Err())
-		setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 		return nil
 	default:
 		appCl.Log().Info("Context is valid, waiting for shutdown signal...")
@@ -167,7 +167,7 @@ func RunSkynet(ctx context.Context, args []string) error {
 		}
 	}
 
-	setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+	appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 	return nil
 }
 
@@ -179,18 +179,6 @@ func createRPCClient(addr string) (visor.API, error) {
 	}
 	logger := logging.MustGetLogger("visor-rpc")
 	return visor.NewRPCClient(logger, conn, visor.RPCPrefix, 0), nil
-}
-
-func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
-	if err := appCl.SetDetailedStatus(string(status)); err != nil {
-		appCl.Log().Errorf("Failed to set status %v: %v", status, err)
-	}
-}
-
-func setAppError(appCl *app.Client, appErr error) {
-	if err := appCl.SetError(appErr.Error()); err != nil {
-		appCl.Log().Errorf("Failed to set error %v: %v", appErr, err)
-	}
 }
 
 // Execute executes root CLI command.

--- a/cmd/apps/skysocks/commands/skysocks.go
+++ b/cmd/apps/skysocks/commands/skysocks.go
@@ -87,7 +87,7 @@ func RunSkysocks(ctx context.Context, args []string) error {
 			var pk cipher.PubKey
 			if err := pk.UnmarshalText([]byte(pkStr)); err != nil {
 				appCl.Log().Errorf("Invalid whitelist public key %s: %v", pkStr, err)
-				setAppError(appCl, err)
+				appCl.SetErrorOrLog(err)
 				return err
 			}
 			whitelistPKs = append(whitelistPKs, pk)
@@ -96,7 +96,7 @@ func RunSkysocks(ctx context.Context, args []string) error {
 
 	srv, err := skysocks.NewServer(whitelistPKs, appCl)
 	if err != nil {
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		appCl.Log().Errorf("Failed to create a new server: %v", err)
 		return err
 	}
@@ -104,12 +104,12 @@ func RunSkysocks(ctx context.Context, args []string) error {
 	port := appCl.Config().RoutingPort
 	if appPort != 0 {
 		port = routing.Port(appPort)
-		setAppPort(appCl, port)
+		appCl.SetAppPortOrLog(port)
 	}
 
 	l, err := appCl.Listen(netType, port)
 	if err != nil {
-		setAppError(appCl, err)
+		appCl.SetErrorOrLog(err)
 		appCl.Log().Errorf("Error listening network %v on port %d: %v", netType, port, err)
 		return err
 	}
@@ -119,7 +119,7 @@ func RunSkysocks(ctx context.Context, args []string) error {
 	if runtime.GOOS == "windows" {
 		ipcClient, err := ipc.StartClient(skyenv.SkysocksName, nil)
 		if err != nil {
-			setAppError(appCl, err)
+			appCl.SetErrorOrLog(err)
 			appCl.Log().Errorf("Error creating ipc server for skysocks: %v", err)
 			return err
 		}
@@ -136,7 +136,7 @@ func RunSkysocks(ctx context.Context, args []string) error {
 			}
 		}()
 	}
-	defer setAppStatus(appCl, appserver.AppDetailedStatusStopped)
+	defer appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
 
 	serveCh := make(chan error, 1)
 	go func() {
@@ -158,27 +158,9 @@ func RunSkysocks(ctx context.Context, args []string) error {
 	return nil
 }
 
-func setAppStatus(appCl *app.Client, status appserver.AppDetailedStatus) {
-	if err := appCl.SetDetailedStatus(string(status)); err != nil {
-		appCl.Log().Errorf("Failed to set status %v: %v", status, err)
-	}
-}
-
-func setAppError(appCl *app.Client, appErr error) {
-	if err := appCl.SetError(appErr.Error()); err != nil {
-		appCl.Log().Errorf("Failed to set error %v: %v", appErr, err)
-	}
-}
-
 // Execute executes root CLI command.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
-	}
-}
-
-func setAppPort(appCl *app.Client, port routing.Port) {
-	if err := appCl.SetAppPort(port); err != nil {
-		appCl.Log().Errorf("Failed to set port %v: %v", port, err)
 	}
 }

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -104,6 +104,47 @@ func (c *Client) SetAppPort(appPort routing.Port) error {
 	return c.rpcC.SetAppPort(appPort)
 }
 
+// SetStatusOrLog sets the detailed status and logs the error if any.
+// Status transitions are best-effort — the app keeps running even if
+// the visor can't be notified, so callers don't have to handle the
+// error path. A nil receiver is a no-op so apps that can run in
+// standalone mode (skychat) don't have to guard each call site.
+// Replaces the setAppStatus helper that every app previously defined
+// locally.
+func (c *Client) SetStatusOrLog(status appserver.AppDetailedStatus) {
+	if c == nil {
+		return
+	}
+	if err := c.SetDetailedStatus(string(status)); err != nil {
+		c.Log().Errorf("Failed to set status %v: %v", status, err)
+	}
+}
+
+// SetErrorOrLog records an app error in the visor and logs the
+// failure to record (not the original error — that's already in
+// appErr). Best-effort and nil-safe like SetStatusOrLog. Replaces
+// the setAppError helper that every app previously defined locally.
+func (c *Client) SetErrorOrLog(appErr error) {
+	if c == nil {
+		return
+	}
+	if err := c.SetError(appErr.Error()); err != nil {
+		c.Log().Errorf("Failed to set error %v: %v", appErr, err)
+	}
+}
+
+// SetAppPortOrLog sets the routing port and logs the error if any.
+// Best-effort and nil-safe like SetStatusOrLog. Replaces the
+// setAppPort helper that every app previously defined locally.
+func (c *Client) SetAppPortOrLog(port routing.Port) {
+	if c == nil {
+		return
+	}
+	if err := c.SetAppPort(port); err != nil {
+		c.Log().Errorf("Failed to set port %v: %v", port, err)
+	}
+}
+
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
 	return c.dial(remote, 0, 0, 0, 0, 0, 0)


### PR DESCRIPTION
## Summary

Phase 2a of #2775 — pure dedup pass on the app entrypoints. Every app was carrying a near-identical \`setAppStatus / setAppError / setAppPort\` triple that wrapped the corresponding \`*app.Client\` RPC with a best-effort log. Promote them to methods on \`*app.Client\` and drop the per-file copies.

Sets up cleaner ground for the pair-binary collapses (skynet srv/client, skysocks srv/client, vpn srv/client) that follow.

## What changes

- **\`pkg/app/client.go\`**: three new methods on \`*Client\`:
  - \`SetStatusOrLog(status appserver.AppDetailedStatus)\`
  - \`SetErrorOrLog(appErr error)\`
  - \`SetAppPortOrLog(port routing.Port)\`
  Each is **nil-safe** — calling on a nil receiver is a no-op so apps that can run in standalone mode (skychat) don't have to guard every call site.
- **\`cmd/apps/skynet/commands/skynet.go\`**, **\`skynet-client\`**, **\`skysocks\`**, **\`skychat\`**: drop the local \`setAppStatus / setAppError / setAppPort\` helpers, swap call sites to the new methods.

## What does not change

- No behavior change. The new methods inline the same body as the helpers they replace; the call sites change from \`setAppStatus(appCl, X)\` to \`appCl.SetStatusOrLog(X)\`.
- Apps using the 3-arg variant (\`setAppStatus(appCl, log, X)\` with an externally-provided logger and a richer log format) — \`vpn-client\`, \`vpn-server\`, \`skysocks-client\` — are left untouched. Migrating them needs a separate decision about how to plumb the logger choice through \`*app.Client\` and is a follow-up.
- Net line change: **-108 / +72** across 5 files.

## Test plan

- [x] \`go build ./pkg/app/... ./cmd/apps/... ./cmd/skywire/...\` clean
- [x] \`go test ./pkg/app/...\` green (all packages pass)
- [ ] CI lint