### PR TITLE
refactor(app): type ProcConfig.RunFunc as AppFunc (#2775 phase 2b)

### DIFF
--- a/pkg/app/appcommon/proc_config.go
+++ b/pkg/app/appcommon/proc_config.go
@@ -141,9 +141,9 @@ type ProcConfig struct {
 	// UID/GID before exec (POSIX, external launcher only). Ignored
 	// silently when RunFunc != nil (internal launcher) since
 	// credentials are process-wide.
-	ProcUser  string      `json:"proc_user,omitempty"`
-	ProcGroup string      `json:"proc_group,omitempty"`
-	RunFunc   interface{} `json:"-"`
+	ProcUser  string  `json:"proc_user,omitempty"`
+	ProcGroup string  `json:"proc_group,omitempty"`
+	RunFunc   AppFunc `json:"-"`
 	// RunMode is the explicit dispatch hint. When unset, EffectiveRunMode
 	// derives the mode from RunFunc presence — preserving legacy callers
 	// that construct ProcConfig directly without setting RunMode.

--- a/pkg/app/appserver/proc.go
+++ b/pkg/app/appserver/proc.go
@@ -241,11 +241,7 @@ func (p *Proc) Start() error {
 func (p *Proc) startInProcess() error {
 	p.appCtx, p.appCancelCtx = context.WithCancel(context.Background()) //nolint:gosec
 
-	runFunc, ok := p.conf.RunFunc.(appcommon.AppFunc)
-	if !ok {
-		p.waitMx.Unlock()
-		return fmt.Errorf("invalid RunFunc signature for app %s", p.conf.AppName)
-	}
+	runFunc := p.conf.RunFunc
 
 	appConn, serverConn := net.Pipe()
 	appcommon.RegisterInProcessConn(p.conf.ProcKey, appConn)


### PR DESCRIPTION
## Summary

Phase 2b of #2775 — type the \`ProcConfig.RunFunc\` field as \`AppFunc\` instead of \`interface{}\`. Drops the runtime type assertion + bail-on-mismatch dance in \`startInProcess\` now that \`AppFunc\` is the explicit contract (landed in #2860).

## What changes

- \`pkg/app/appcommon/proc_config.go\`: \`RunFunc interface{}\` → \`RunFunc AppFunc\`.
- \`pkg/app/appserver/proc.go\`: \`startInProcess\` no longer needs \`runFunc, ok := p.conf.RunFunc.(appcommon.AppFunc)\` + the \`invalid RunFunc signature\` error path. The field is the function.

## What does not change

- No behavior change. Every existing assignment site (\`launcher.makeProcConfig\` at two points) was already passing an \`AppFunc\`-valued expression into the \`interface{}\` slot.
- Nil comparisons (\`RunFunc != nil\`) still work — function types are nil-comparable in Go.
- The field stays \`json:"-"\` so no wire format changes.

## Test plan

- [x] \`go build ./pkg/app/... ./cmd/apps/... ./cmd/skywire/...\` clean
- [x] \`go test ./pkg/app/...\` green
- [x] \`go vet ./pkg/app/...\` clean
- [ ] CI lint