### PR TITLE
docs: RFC — unified service contract (#2775)

### DIFF
--- a/docs/unified_service_contract_rfc.md
+++ b/docs/unified_service_contract_rfc.md
@@ -12,15 +12,21 @@ Status: **Draft.** Scope was revised after the first round of discussion (see "S
 
 ## Scope revision
 
-The original `#2775` issue body included the hypervisor UI in the "make it an app" list. That decision was made before the `skywire web` HTTP-CLI surface was scaffolded. With the web CLI in the picture, the unification this RFC is really after — **uniform operator visibility and control** — gets delivered at the operator-interface layer, not at the supervisor layer:
+The original `#2775` issue body included the hypervisor UI in the "make it an app" list. That decision was made before the `skywire web` surface was scaffolded. With the web PTY in the picture, the unification this RFC is really after — **uniform operator visibility and control** — gets delivered at the operator-interface layer, not at the supervisor layer.
 
-- The web CLI exposes the full `skywire` binary's CLI tree over an HTTP listener (localhost, forwardable). Any capability the binary supports — including hypervisor on/off, config edits, transport ops, RPC introspection — is reachable through one generic surface.
-- The thing that originally made "hypervisor as an app" attractive was uniform visibility (`cli visor app ls` showing the full picture). The web CLI delivers that same uniformity by giving operators a single remote-control surface over the entire binary, not just the apps subset.
+**About the web PTY.** Mechanistically, `skywire web` is **dmsgpty serving its pseudoterminal over HTTP/WebSocket** so the operator's browser can render the terminal. The skywire CLI runs inside that PTY as a normal interactive shell session. It is **not** a REST/RPC gateway exposing per-command endpoints — it is the same PTY mechanism that backs `cli dmsg pty exec`, just rendered in a different transport. The security model inherits dmsgpty's PK-based authentication; no new auth surface is introduced.
+
+The implications for this RFC:
+
+- Any capability the `skywire` binary supports — hypervisor on/off, config edits, transport ops, RPC introspection — is reachable through the PTY by the operator typing the corresponding `skywire ...` command. No code change to expose new things; everything the CLI can already do is already there.
+- The thing that originally made "hypervisor as an app" attractive was uniform visibility (`cli visor app ls` showing the full picture). The web PTY delivers that same uniformity *one level up*: the operator's single remote-control surface is the shell, and `cli visor app ls` is just one of many things they run inside it.
 - Hypervisor stays as a visor subsystem with its existing init wiring. No lifecycle refactor inside critical-path code.
 
 Phase 3 therefore shrinks to **dmsgweb, skynetweb, dmsgpty** — the three runtime-toggleable subsystems where the supervisor-side unification actually buys something. Total scope is ~150 LOC instead of ~500 LOC, and the riskiest piece (hypervisor's lifecycle refactor) is removed.
 
-The web CLI scaffold is a prerequisite for this revision to hold. As long as `skywire web` ships before or alongside Phase 3, operators don't lose anything by hypervisor staying as a subsystem.
+**dmsgpty's elevated role:** since dmsgpty is the mechanism backing the meta-surface, Phase 3.3 (migrating dmsgpty to an Internal app) is touching the very thing that delivers this RFC's "hypervisor stays as subsystem" argument. Still safe — dmsgpty stays running across the migration, just managed via the launcher afterward. But it means Phase 3.3 needs the same operator-regression care that hypervisor would have needed: don't ship dmsgpty's `RestartPolicy` enforcement (Phase 4) until 3.3 has burned in.
+
+The web PTY scaffold is a prerequisite for this revision to hold. As long as `skywire web` ships before or alongside Phase 3, operators don't lose anything by hypervisor staying as a subsystem.
 
 ## Background
 
@@ -36,21 +42,21 @@ Phases 1, 2a, 2b made the launcher-app contract explicit but did not bridge the 
 
 With hypervisor out of scope, the wins are smaller but real:
 
-1. **Uniform `cli visor app ls` view** for dmsgweb / skynetweb / dmsgpty alongside launcher apps. The web CLI itself goes through this surface for runtime control of those three.
+1. **Uniform `cli visor app ls` view** for dmsgweb / skynetweb / dmsgpty alongside launcher apps. An operator inside the web PTY runs the same `cli visor app` subcommands as in a local terminal; the migration just adds these three to the list.
 2. **Drop the bespoke `EmbeddedProxies` RPC** in favor of standard `cli visor app start|stop dmsgweb`. One less ad-hoc control surface.
 3. **dmsgpty gains a runtime on/off switch** it doesn't have today. Operators who don't want PTY access exposed can disable it without restarting the visor (and re-enable for a maintenance window).
 4. **Supervision (`RestartPolicy`) becomes available** for these three when phase 4 lands. dmsgpty restart-on-crash is the most useful — the listener occasionally dies silently in the field.
 5. **Construction site stays where it is for all three.** No init refactor; the AppFunc shim just wraps existing `Start()` / `Stop()` methods.
 
 What unification does **not** buy:
-- Hypervisor's bespoke startup stays. Operators still toggle it via `conf.Hypervisor.Enable` + visor restart (or via the web CLI once that ships, which can invoke the visor RPC to re-init it).
+- Hypervisor's bespoke startup stays. Operators still toggle it via `conf.Hypervisor.Enable` + visor restart (or via the web PTY once that ships, which can invoke the visor RPC to re-init it).
 - Config sprawl is partially addressed: dmsgweb/skynetweb/dmsgpty get synthetic `apps[]` entries, but their `visorconfig.*` sub-structs stay (for the args).
 
 ## Non-goals
 
 - **Not** about merging the pair binaries (`skynet-srv` / `skynet-client`, etc.) into mode-flagged singletons. The two halves of each pair share little code; the gain would be cosmetic. Treated as a separate, optional cleanup.
 - **Not** about changing the `app.NewClient()` pipe-RPC machinery for *external* apps. External apps run in their own process and need that pipe.
-- **Not** about migrating hypervisor. It stays as a visor subsystem; the web CLI is its meta-management surface.
+- **Not** about migrating hypervisor. It stays as a visor subsystem; the web PTY is its meta-management surface.
 - **Not** about deprecating the existing per-subsystem `visorconfig.*` sub-structs in v1. Migration must preserve operator config files.
 
 ## The asymmetry — facts on the ground
@@ -164,7 +170,7 @@ Add a column or grouping that distinguishes "launcher app" from "internal servic
 ## Out of scope for this RFC
 
 - Phase 4 (`RestartPolicy` enforcement). Independent change; can land before or after this RFC's phases.
-- Hypervisor lifecycle. Stays as a visor subsystem; reached via web CLI for operator ops.
+- Hypervisor lifecycle. Stays as a visor subsystem; operators reach it through the web PTY (or any other CLI invocation).
 - Pair-binary collapse (skynet srv+client, etc.). Cosmetic, low-value; not blocking.
 - Full deprecation of `EmbeddedProxies` RPC. After Phase 3.2 ships and burns in, a follow-up can remove the shim.
 - Web CLI itself. Tracked separately; is a prerequisite for this RFC's scope revision to hold.
@@ -173,7 +179,7 @@ Add a column or grouping that distinguishes "launcher app" from "internal servic
 
 For approval:
 
-- [ ] Confirm the scope revision (hypervisor out, web CLI is the meta-surface).
+- [ ] Confirm the scope revision (hypervisor out, web PTY is the meta-surface).
 - [ ] Pick default RestartPolicies per open question 1.
 - [ ] Resolve naming convention per open question 2.
 - [ ] Confirm synthetic-config-visibility direction per open question 3.

--- a/docs/unified_service_contract_rfc.md
+++ b/docs/unified_service_contract_rfc.md
@@ -8,7 +8,19 @@ Predecessor PRs (already merged):
 [#2861](https://github.com/skycoin/skywire/pull/2861) phase 2a — promote `setApp*` helpers onto `*app.Client`.
 [#2862](https://github.com/skycoin/skywire/pull/2862) phase 2b — type `ProcConfig.RunFunc` as `AppFunc`.
 
-Status: **Draft.** Lays out the design space for unifying the supervised-service surface across launcher apps and visor-internal subsystems. Implementation deferred until the recommended path is agreed.
+Status: **Draft.** Scope was revised after the first round of discussion (see "Scope revision" below) — hypervisor is now out of Phase 3.
+
+## Scope revision
+
+The original `#2775` issue body included the hypervisor UI in the "make it an app" list. That decision was made before the `skywire web` HTTP-CLI surface was scaffolded. With the web CLI in the picture, the unification this RFC is really after — **uniform operator visibility and control** — gets delivered at the operator-interface layer, not at the supervisor layer:
+
+- The web CLI exposes the full `skywire` binary's CLI tree over an HTTP listener (localhost, forwardable). Any capability the binary supports — including hypervisor on/off, config edits, transport ops, RPC introspection — is reachable through one generic surface.
+- The thing that originally made "hypervisor as an app" attractive was uniform visibility (`cli visor app ls` showing the full picture). The web CLI delivers that same uniformity by giving operators a single remote-control surface over the entire binary, not just the apps subset.
+- Hypervisor stays as a visor subsystem with its existing init wiring. No lifecycle refactor inside critical-path code.
+
+Phase 3 therefore shrinks to **dmsgweb, skynetweb, dmsgpty** — the three runtime-toggleable subsystems where the supervisor-side unification actually buys something. Total scope is ~150 LOC instead of ~500 LOC, and the riskiest piece (hypervisor's lifecycle refactor) is removed.
+
+The web CLI scaffold is a prerequisite for this revision to hold. As long as `skywire web` ships before or alongside Phase 3, operators don't lose anything by hypervisor staying as a subsystem.
 
 ## Background
 
@@ -18,130 +30,111 @@ The skywire visor today supervises two distinct kinds of long-running things, wi
 
 **Visor subsystems** — `hypervisor` (HTTP server), `dmsgpty` host (PTY listener), `dmsgweb` and `skynetweb` (the resolver SOCKS5 proxies). Started by entries in the `pkg/visor/init.go` module DAG; shutdown via `pushCloseStack`. Each holds direct references to visor-internal state (`v.tpM`, `v.dmsgC`, `v.router`, etc.). Runtime control surfaces are bespoke per-service: hypervisor has no on/off RPC at all, dmsgpty has none, resolvers have `EmbeddedProxies`.
 
-Phases 1, 2a, 2b made the launcher-app contract explicit but did not bridge the two worlds. This RFC is about the bridge.
+Phases 1, 2a, 2b made the launcher-app contract explicit but did not bridge the two worlds. This RFC is about partially bridging — specifically for `dmsgpty`, `dmsgweb`, `skynetweb`.
 
-## Why bridge them
+## What unification still buys (post-revision)
 
-Concrete operator pain that survives the current design:
+With hypervisor out of scope, the wins are smaller but real:
 
-1. **No uniform "what services are running on this visor" query.** `cli visor app ls` lists launcher apps; the subsystems are invisible. Operators chase status across three sources (apps, EmbeddedProxies, "is hypervisor responding to HTTP").
+1. **Uniform `cli visor app ls` view** for dmsgweb / skynetweb / dmsgpty alongside launcher apps. The web CLI itself goes through this surface for runtime control of those three.
+2. **Drop the bespoke `EmbeddedProxies` RPC** in favor of standard `cli visor app start|stop dmsgweb`. One less ad-hoc control surface.
+3. **dmsgpty gains a runtime on/off switch** it doesn't have today. Operators who don't want PTY access exposed can disable it without restarting the visor (and re-enable for a maintenance window).
+4. **Supervision (`RestartPolicy`) becomes available** for these three when phase 4 lands. dmsgpty restart-on-crash is the most useful — the listener occasionally dies silently in the field.
+5. **Construction site stays where it is for all three.** No init refactor; the AppFunc shim just wraps existing `Start()` / `Stop()` methods.
 
-2. **No uniform start/stop for subsystems at runtime.** Hypervisor and dmsgpty are bound to startup config — turning either off requires editing `config.json` and restarting the visor. Resolvers have ad-hoc `EmbeddedProxies` RPCs that nothing else uses.
-
-3. **No supervision (restart-on-failure, panic recovery) for subsystems.** The launcher will eventually grow this via `RestartPolicy` (declared in #2860). Subsystems will not benefit unless they enter the same supervisor.
-
-4. **Config sprawl.** Each subsystem has its own `visorconfig.*` sub-struct duplicating bits of what `apps[]` already expresses (enable, autostart, args, env). Apps and services drift in shape over time.
-
-5. **Bespoke shutdown ordering.** `closeStack` is reverse-order; the launcher has its own stop semantics. Two ordering systems, two places to debug a stuck shutdown.
-
-The architectural question this RFC asks: **can a single supervisor own all five categories, with one set of lifecycle, observability, and control surfaces?**
+What unification does **not** buy:
+- Hypervisor's bespoke startup stays. Operators still toggle it via `conf.Hypervisor.Enable` + visor restart (or via the web CLI once that ships, which can invoke the visor RPC to re-init it).
+- Config sprawl is partially addressed: dmsgweb/skynetweb/dmsgpty get synthetic `apps[]` entries, but their `visorconfig.*` sub-structs stay (for the args).
 
 ## Non-goals
 
-- **Not** about merging the `skynet-srv` / `skynet-client` (and skysocks, vpn) pair binaries into mode-flagged singletons. The two halves of each pair share little code; the gain would be cosmetic. Treated as a separate, optional cleanup.
-- **Not** about changing the `app.NewClient()` pipe-RPC machinery for *external* apps. External apps run in their own process and need that pipe; nothing in this RFC alters their boot path.
+- **Not** about merging the pair binaries (`skynet-srv` / `skynet-client`, etc.) into mode-flagged singletons. The two halves of each pair share little code; the gain would be cosmetic. Treated as a separate, optional cleanup.
+- **Not** about changing the `app.NewClient()` pipe-RPC machinery for *external* apps. External apps run in their own process and need that pipe.
+- **Not** about migrating hypervisor. It stays as a visor subsystem; the web CLI is its meta-management surface.
 - **Not** about deprecating the existing per-subsystem `visorconfig.*` sub-structs in v1. Migration must preserve operator config files.
 
 ## The asymmetry — facts on the ground
 
-| | Launcher apps (A) | Hypervisor (B) | dmsgpty (B) | Resolvers (B) |
+| | Launcher apps (A) | dmsgpty (B) | Resolvers (B) | Hypervisor (out of scope) |
 |---|---|---|---|---|
-| Entry | `AppFunc(ctx, args)` | `NewHypervisor(...)` → `Enable(ctx)` | `dmsgpty.Host.ListenAndServe()` | constructor → `Start()` |
-| Construction site | `cmd/apps/*/commands/*.go` registers via `launcher.RegisterApp` | `pkg/visor/init_apps.go:initHypervisor` | `pkg/visor/init_dmsg.go` / `init_dmsg_skywire.go` | `pkg/visor/embedded_dmsgweb.go`, `embedded_skynetweb.go` |
-| Visor-internal access | None — uses `app.NewClient()` RPC pipe | Full — gets passed `v *Visor` | Full — uses `v.dmsgC` etc. | Full — uses `v.dmsgC`, `v.tpM` |
-| Supervision | `ProcManager` (start/stop/status RPC) | None | None | None (toggle via `EmbeddedProxies`) |
-| Config source | `conf.Launcher.Apps[]` | `conf.Hypervisor` | `conf.Dmsgpty` | `conf.DmsgWeb`, `conf.SkynetWeb` |
-| Restart-on-failure | Declared (not yet enforced — see #2775 phase 4) | None | None | None |
-| Shutdown surface | `ProcManager.Stop(name)` | `pushCloseStack("hypervisor", hv.Disable)` | `pushCloseStack` on ctx-cancel | `pushCloseStack` |
-| `cli visor app ls` visibility | Yes | No | No | No |
-| Per-subsystem RPC | `apps/*` family | None | None | `EmbeddedProxies` only |
+| Entry | `AppFunc(ctx, args)` | `dmsgpty.Host.ListenAndServe()` | constructor → `Start()` | `NewHypervisor(...)` → `Enable(ctx)` |
+| Construction site | `cmd/apps/*/commands/*.go` registers via `launcher.RegisterApp` | `pkg/visor/init_dmsg.go` / `init_dmsg_skywire.go` | `pkg/visor/embedded_dmsgweb.go`, `embedded_skynetweb.go` | `pkg/visor/init_apps.go:initHypervisor` |
+| Visor-internal access | None — uses `app.NewClient()` RPC pipe | Full — uses `v.dmsgC` etc. | Full — uses `v.dmsgC`, `v.tpM` | Full — gets passed `v *Visor` |
+| Supervision today | `ProcManager` (start/stop/status RPC) | None | None (toggle via `EmbeddedProxies`) | None |
+| Config source | `conf.Launcher.Apps[]` | `conf.Dmsgpty` | `conf.DmsgWeb`, `conf.SkynetWeb` | `conf.Hypervisor` |
+| Shutdown surface | `ProcManager.Stop(name)` | `pushCloseStack` on ctx-cancel | `pushCloseStack` | `pushCloseStack("hypervisor", hv.Disable)` |
+| `cli visor app ls` visibility today | Yes | No | No | No |
+| Per-subsystem RPC today | `apps/*` family | None | `EmbeddedProxies` only | None |
 
-The hard fact: **launcher apps talk to the visor over RPC; subsystems hold direct visor refs.** Any unification must reconcile this.
+After Phase 3, the three middle columns gain the launcher-apps row's properties.
 
-## Design options
+## Design
 
-Three credible shapes for the unification. They differ in how the visor-internal access of subsystems gets reconciled with the RPC-distanced posture of launcher apps.
-
-### Option A — Richer `Client`: plumb visor internals through an in-process app client
-
-Extend `*app.Client` so that an **in-process** client (`RunMode: Internal`) has methods backed directly by visor functions, while an **external** client keeps the existing pipe-RPC surface. The contract stays `AppFunc(ctx, args) error`; the difference is that `c.TransportManager()`, `c.DmsgClient()`, `c.RouteManager()` exist when the proc is in-process and panic / return errors when external.
-
-Subsystems become regular AppFuncs that call those new client methods.
-
-**Pros.** One contract for everything. No new interface. The dispatch on `RunMode` already exists. Future "internal app" authors get a clean, discoverable surface.
-
-**Cons.** The in-process `Client` becomes a god object exposing nearly the full visor surface. The "external client is the same type as internal client" property leaks dangerous methods at runtime (a launcher-app developer who wires up a hypervisor-shaped helper accidentally finds the visor's transport manager). Significant scope to define which visor internals are stable enough to expose.
-
-### Option B — App-shaped facades: subsystems keep their init wiring, register thin `AppFunc` shims
-
-Each subsystem keeps its current visor-init construction. We **additionally** register an `AppFunc` whose body is:
+The shape is **app-shaped facades** — keep each subsystem's current construction in visor init, register a thin `AppFunc` shim that wraps the existing `Start()` / `Stop()` methods and blocks on `ctx.Done()`.
 
 ```go
-func runHypervisor(ctx context.Context, args []string) error {
-    hv := v.hvInstance.Load() // populated by initHypervisor
-    if err := hv.Enable(ctx); err != nil { return err }
+// pkg/visor/embedded_dmsgweb.go (after Phase 3.2)
+func initEmbeddedDmsgWeb(ctx, v *Visor, log) error {
+    if !v.conf.DmsgWeb.Enable {
+        return nil
+    }
+    // CONSTRUCTION only — no Start()
+    v.embeddedDmsgWeb = newEmbeddedDmsgWeb(v.dmsgC, v.conf.DmsgWeb.ProxyPort, ...)
+    launcher.RegisterApp("dmsgweb", v.runDmsgWebApp)
+    return nil
+}
+
+func (v *Visor) runDmsgWebApp(ctx context.Context, args []string) error {
+    if err := v.embeddedDmsgWeb.Start(); err != nil {
+        return err
+    }
     <-ctx.Done()
-    return hv.Disable()
+    return v.embeddedDmsgWeb.Stop()
 }
 ```
 
-The visor's init module **does not** auto-`Enable` anymore — instead, it appends a synthetic entry to `conf.Launcher.Apps[]` so the launcher's start-apps phase invokes it during normal startup.
+A config translation layer (Phase 3.1) auto-appends `AppConfig{Name: "dmsgweb", AutoStart: true}` to `conf.Launcher.Apps[]` whenever `conf.DmsgWeb.Enable=true`, so operators don't have to edit their configs.
 
-**Pros.** Smallest change to subsystem internals — construction stays where it is. Operators get the uniform `cli visor app *` surface immediately. Existing `closeStack` ordering can keep dictating shutdown for subsystems if needed (they hand control to the launcher only for start/stop, not for ordering).
+### Why this shape (not a separate Runnable interface)
 
-**Cons.** Lifecycle is split: construction owned by init, start/stop owned by the launcher. Two places to look for "where does X live?" Closing a subsystem via `cli visor app stop hypervisor` calls `hv.Disable()` but does not destruct — a re-`start` reuses the same instance, which may or may not be the right idempotency model for every subsystem.
+The earlier draft of this RFC also discussed Option C — a separate `Runnable` interface that subsystems implement directly. With hypervisor out of scope, the case for Option C collapses:
 
-### Option C — New `Runnable` interface, distinct from `AppFunc`
+- The dmsgpty/dmsgweb/skynetweb subsystems all have natural `Start()`/`Stop()` method pairs. The AppFunc shim wrapping those is trivial; promoting them to implement a new `Runnable` interface buys near-zero additional clarity.
+- The "wart" of split construction-vs-start in Option B was painful mainly for hypervisor's already-tangled lifecycle. For the three simpler subsystems, the wart is invisible — construction is one line, start/stop are one line each.
+- Maintaining a second supervisor contract (`Runnable`) alongside `AppFunc` adds surface for ~50 LOC of net benefit. Not worth it.
 
-Declare a second contract specifically for visor-internal services:
+If hypervisor's lifecycle ever does come into scope later, revisit Option C then.
 
-```go
-type Runnable interface {
-    Name() string
-    Run(ctx context.Context) error
-}
-```
+### Why not Option A (richer Client)
 
-`Runnable` is implemented directly by hypervisor, dmsgpty, the resolvers. The supervisor walks two registries — `launcher.AppFunc` registry and `runnable.Registry` — and presents them uniformly through `cli visor app *`. `AppFunc` is adapted via a wrapper that calls `Fn(ctx, args)` from `Run`.
+Option A — making the in-process `*app.Client` expose visor internals — was an attractive nuisance even when hypervisor was in scope. Without hypervisor, there's no remaining motivation for it. The three middle subsystems already access their needed state via Go-package-level visor methods inside their construction; they don't need a Client-mediated API.
 
-**Pros.** Honest about the asymmetry — apps and subsystems get different contracts because they ARE different things. Subsystems keep their natural method receivers (`hv.Run(ctx)`) and visor-struct closures. Supervisor logic stays type-safe.
+## Migration plan
 
-**Cons.** Two contracts to maintain. The `cli visor app *` surface has to abstract over both, which means either a discriminated union in the RPC reply ("kind = app | runnable") or a forced flattening that loses the distinction.
-
-## Recommendation: B then C, never A
-
-**Land Option B first** as the operator-visible unification. It's the smallest credible change that delivers the headline benefits (uniform start/stop/status, no more bespoke `EmbeddedProxies` RPC, visible service inventory). It does not require designing a stable "in-process Client" interface, which is the riskiest part of Option A.
-
-**Promote to Option C in a later pass** once Option B has burned in for a release. The split between construction and start/stop in Option B is a debt that Option C can pay down — by then the supervisor's contract is well-understood and adding `Runnable` is mechanical.
-
-**Reject Option A.** The "Client is the same type whether in-process or external" property is an attractive nuisance: it invites authors to write code that works in tests (in-process) and silently misbehaves in production (external), or vice versa. Discriminating at the type level (Option C) is cleaner than a runtime kind flag.
-
-## Migration plan (Option B)
-
-Five phases. Each lands as one PR. Each is independently revertable.
+Four phases. Each lands as one PR. Each is independently revertable.
 
 ### Phase 3.1 — config translation layer
 
 Add a `pkg/visor/visorconfig/synth_apps.go` pass that runs after `config.json` parsing. For each enabled subsystem block, append a synthetic entry to `conf.Launcher.Apps[]`:
 
 ```go
-if conf.Hypervisor.Enable {
+if conf.DmsgWeb.Enable {
     conf.Launcher.Apps = append(conf.Launcher.Apps, AppConfig{
-        Name:      "hypervisor",
+        Name:      "dmsgweb",
         AutoStart: true,
-        // args carry the bits operators previously set in conf.Hypervisor
+        // args carry the bits operators previously set in conf.DmsgWeb
     })
 }
-// dmsgpty, dmsgweb, skynetweb analogous
+// skynetweb, dmsgpty analogous
 ```
 
-No subsystem code changes yet. The launcher gets new `apps[]` entries but no `RunFunc` is registered, so they fail-to-start with `ErrAppNotFound` — guarded by a feature flag so the migration doesn't break boot.
+No subsystem code changes yet. The launcher gets new `apps[]` entries but no `RunFunc` is registered, so they fail-to-start with `ErrAppNotFound` — guarded by a feature flag (e.g. `conf.Launcher.SynthesizeSubsystems`) so the migration doesn't break boot. The flag flips to default-on once 3.2/3.3 land.
 
 ### Phase 3.2 — register dmsgweb + skynetweb as Internal apps
 
-The lowest-risk subsystems: already runtime-toggleable, smallest blast radius. Each gets an `AppFunc` body in `pkg/visor/embedded_dmsgweb.go` (and `skynetweb`) that wraps the existing `Start` / `Stop` and blocks on ctx-cancel. `launcher.RegisterApp("dmsgweb", ...)` + `RegisterApp("skynetweb", ...)`.
+The lowest-risk subsystems. Each gets an `AppFunc` body in `pkg/visor/embedded_dmsgweb.go` (and `skynetweb`) that wraps the existing `Start` / `Stop` and blocks on ctx-cancel. `launcher.RegisterApp("dmsgweb", ...)` + `RegisterApp("skynetweb", ...)`.
 
-The existing `initEmbeddedDmsgWeb` skips its auto-`Start` when the synthetic apps[] entry exists. The `EmbeddedProxies` RPC stays around as a thin shim that forwards to the launcher (deprecation deferred).
+The existing `initEmbeddedDmsgWeb` skips its auto-`Start` when the synthetic apps[] entry exists. The `EmbeddedProxies` RPC stays around as a thin shim that forwards to the launcher (deprecation deferred to a follow-up).
 
 Verify operator workflow: `cli visor app start dmsgweb` brings the SOCKS5 up; `stop` brings it down. Behavior matches the current `EmbeddedProxies` toggle.
 
@@ -151,43 +144,39 @@ Same shape. dmsgpty's listener becomes the `AppFunc` body; the existing `init_dm
 
 Verify: `cli dmsg pty exec <pk> -- echo hi` still works. The remote-dial side is unaffected (different code path).
 
-### Phase 3.4 — register hypervisor as Internal app
+### Phase 3.4 — `cli visor app ls` cosmetic pass
 
-Highest blast radius — operators rely on this. Hypervisor's HTTP server becomes the `AppFunc`; `hv.Enable` is called from the `AppFunc`, `hv.Disable` on ctx-cancel.
-
-Verify: the UI loads, the existing `cli visor halt` shutdown sequence still works, restart-loop binary swap behaves identically.
-
-### Phase 3.5 — `cli visor app ls` cosmetic pass
-
-Add a column or grouping that distinguishes "launcher app" from "internal service" in the listing, so operators can still tell at a glance what kind of thing they're looking at. Pure UI; can land last or in parallel with the others.
+Add a column or grouping that distinguishes "launcher app" from "internal service" in the listing, so operators can still tell at a glance what kind of thing they're looking at. Pure UI; can land last or in parallel with 3.2/3.3.
 
 ## Open questions
 
-1. **Idempotent start/stop.** When `cli visor app stop hypervisor` calls `hv.Disable()`, should `cli visor app start hypervisor` reuse the same `*Hypervisor` or construct a fresh one? Current `closeStack` semantics imply teardown — switching to start/stop semantics may need each subsystem to grow a `Reset()` step.
+1. **Default RestartPolicy for the three subsystems.** Phase 4 (independent of this RFC) enforces `RestartPolicy`. The proposed defaults:
+   - dmsgpty: `OnFailure` — listener occasionally dies silently in the field; restart is exactly what operators want.
+   - dmsgweb / skynetweb: `Never` — these are user-driven (operator clicks "enable proxy"), no value in auto-restart.
+   Confirm or adjust.
 
-2. **Synthetic config entry visibility.** Should the synthetic `apps[]` entries appear in `config gen` output? If yes, operators can edit them directly; if no, the `conf.Hypervisor.Enable` flag remains authoritative. There's a real tension between "make it discoverable" and "don't introduce duplicate sources of truth."
+2. **Naming.** App names today collide with binary names (`skychat` is both the app and the executable). For the three subsystems with no binary equivalent, do we keep names like `dmsgweb` (matching the visorconfig key) or prefix them (`_service.dmsgweb`) to avoid future collisions with operator-installable apps named the same? Recommend keeping the bare names — operator-installable apps named "dmsgweb" would be a self-inflicted wound.
 
-3. **Naming.** App names today collide with binary names (`skychat` is both the app and the executable). For subsystems with no binary equivalent, do we keep names like `hypervisor` (matching the visorconfig key) or prefix them (`_service.hypervisor`) to avoid future collisions with operator-installable apps named the same?
+3. **Synthetic config entry visibility.** Should the synthetic `apps[]` entries appear in `skywire config gen` output? If yes, operators can edit them directly; if no, the `conf.DmsgWeb.Enable` flag remains authoritative. Recommend **no** for now — keep `conf.DmsgWeb` etc. as authoritative, synthesis happens at load time. Operators who really want to override pass args through the existing config block.
 
-4. **Restart policy default for subsystems.** Phase 4 enforces `RestartPolicy`. Subsystems registered through this RFC default to which? `RestartOnFailure` matches operator intent ("the hypervisor should come back if it crashes") but means a crash loop won't surface as visibly as today's "the hypervisor is just gone."
-
-5. **External-mode internal services.** A theoretically interesting capability: run hypervisor as a separate process speaking RPC to the visor, for OOM isolation. Option B doesn't preclude this but doesn't enable it either. Worth flagging if anyone has a use case.
+4. **Idempotent start/stop.** When `cli visor app stop dmsgweb` calls `Stop()`, should `cli visor app start dmsgweb` reuse the same instance or construct a fresh one? Current semantics: dmsgweb / skynetweb already cleanly stop-then-start the underlying SOCKS5 listener. dmsgpty's listener is more sensitive — the `dmsgpty.Host` keeps active sessions; stopping kills them. Recommend instance reuse for all three (simpler, matches today's runtime-toggle behavior for dmsgweb/skynetweb), and document the active-session loss for dmsgpty.
 
 ## Out of scope for this RFC
 
 - Phase 4 (`RestartPolicy` enforcement). Independent change; can land before or after this RFC's phases.
+- Hypervisor lifecycle. Stays as a visor subsystem; reached via web CLI for operator ops.
 - Pair-binary collapse (skynet srv+client, etc.). Cosmetic, low-value; not blocking.
-- Replacing `EmbeddedProxies` RPC entirely. Deprecation pass after Option B ships.
-- Promoting to Option C. Separate RFC once Option B has shipped for a release.
+- Full deprecation of `EmbeddedProxies` RPC. After Phase 3.2 ships and burns in, a follow-up can remove the shim.
+- Web CLI itself. Tracked separately; is a prerequisite for this RFC's scope revision to hold.
 
 ## Decision checklist
 
-For approval, the team needs to weigh in on:
+For approval:
 
-- [ ] Pick Option B vs C vs another shape.
-- [ ] Approve phased migration plan order (3.1 → 3.5).
-- [ ] Resolve open question 1 (idempotent start/stop semantics).
-- [ ] Resolve open question 4 (default RestartPolicy for subsystems).
-- [ ] Confirm naming convention for open question 3.
+- [ ] Confirm the scope revision (hypervisor out, web CLI is the meta-surface).
+- [ ] Pick default RestartPolicies per open question 1.
+- [ ] Resolve naming convention per open question 2.
+- [ ] Confirm synthetic-config-visibility direction per open question 3.
+- [ ] Confirm instance-reuse semantics per open question 4.
 
-Phases 3.2–3.5 should not start until all of the above are settled.
+Phases 3.1–3.4 should not start until the above are settled.

--- a/docs/unified_service_contract_rfc.md
+++ b/docs/unified_service_contract_rfc.md
@@ -1,0 +1,193 @@
+# RFC: Unified Service Contract — Folding Visor Subsystems Into the App Framework
+
+Tracking issue:
+[#2775](https://github.com/skycoin/skywire/issues/2775).
+
+Predecessor PRs (already merged):
+[#2860](https://github.com/skycoin/skywire/pull/2860) phase 1 — name the `AppFunc` contract, add `RunMode` and `RestartPolicy` enums.
+[#2861](https://github.com/skycoin/skywire/pull/2861) phase 2a — promote `setApp*` helpers onto `*app.Client`.
+[#2862](https://github.com/skycoin/skywire/pull/2862) phase 2b — type `ProcConfig.RunFunc` as `AppFunc`.
+
+Status: **Draft.** Lays out the design space for unifying the supervised-service surface across launcher apps and visor-internal subsystems. Implementation deferred until the recommended path is agreed.
+
+## Background
+
+The skywire visor today supervises two distinct kinds of long-running things, with overlapping but incompatible lifecycle surfaces:
+
+**Launcher apps** (`pkg/app/launcher`, `pkg/app/appserver`) — skychat, skysocks, skysocks-client, skynet, skynet-client, vpn-server, vpn-client. Either external child processes or in-process goroutines whose entrypoint matches `appcommon.AppFunc = func(ctx, args) error`. Lifecycle is owned by `appserver.ProcManager`; runtime control via `cli visor app start|stop|status|info` (RPC).
+
+**Visor subsystems** — `hypervisor` (HTTP server), `dmsgpty` host (PTY listener), `dmsgweb` and `skynetweb` (the resolver SOCKS5 proxies). Started by entries in the `pkg/visor/init.go` module DAG; shutdown via `pushCloseStack`. Each holds direct references to visor-internal state (`v.tpM`, `v.dmsgC`, `v.router`, etc.). Runtime control surfaces are bespoke per-service: hypervisor has no on/off RPC at all, dmsgpty has none, resolvers have `EmbeddedProxies`.
+
+Phases 1, 2a, 2b made the launcher-app contract explicit but did not bridge the two worlds. This RFC is about the bridge.
+
+## Why bridge them
+
+Concrete operator pain that survives the current design:
+
+1. **No uniform "what services are running on this visor" query.** `cli visor app ls` lists launcher apps; the subsystems are invisible. Operators chase status across three sources (apps, EmbeddedProxies, "is hypervisor responding to HTTP").
+
+2. **No uniform start/stop for subsystems at runtime.** Hypervisor and dmsgpty are bound to startup config — turning either off requires editing `config.json` and restarting the visor. Resolvers have ad-hoc `EmbeddedProxies` RPCs that nothing else uses.
+
+3. **No supervision (restart-on-failure, panic recovery) for subsystems.** The launcher will eventually grow this via `RestartPolicy` (declared in #2860). Subsystems will not benefit unless they enter the same supervisor.
+
+4. **Config sprawl.** Each subsystem has its own `visorconfig.*` sub-struct duplicating bits of what `apps[]` already expresses (enable, autostart, args, env). Apps and services drift in shape over time.
+
+5. **Bespoke shutdown ordering.** `closeStack` is reverse-order; the launcher has its own stop semantics. Two ordering systems, two places to debug a stuck shutdown.
+
+The architectural question this RFC asks: **can a single supervisor own all five categories, with one set of lifecycle, observability, and control surfaces?**
+
+## Non-goals
+
+- **Not** about merging the `skynet-srv` / `skynet-client` (and skysocks, vpn) pair binaries into mode-flagged singletons. The two halves of each pair share little code; the gain would be cosmetic. Treated as a separate, optional cleanup.
+- **Not** about changing the `app.NewClient()` pipe-RPC machinery for *external* apps. External apps run in their own process and need that pipe; nothing in this RFC alters their boot path.
+- **Not** about deprecating the existing per-subsystem `visorconfig.*` sub-structs in v1. Migration must preserve operator config files.
+
+## The asymmetry — facts on the ground
+
+| | Launcher apps (A) | Hypervisor (B) | dmsgpty (B) | Resolvers (B) |
+|---|---|---|---|---|
+| Entry | `AppFunc(ctx, args)` | `NewHypervisor(...)` → `Enable(ctx)` | `dmsgpty.Host.ListenAndServe()` | constructor → `Start()` |
+| Construction site | `cmd/apps/*/commands/*.go` registers via `launcher.RegisterApp` | `pkg/visor/init_apps.go:initHypervisor` | `pkg/visor/init_dmsg.go` / `init_dmsg_skywire.go` | `pkg/visor/embedded_dmsgweb.go`, `embedded_skynetweb.go` |
+| Visor-internal access | None — uses `app.NewClient()` RPC pipe | Full — gets passed `v *Visor` | Full — uses `v.dmsgC` etc. | Full — uses `v.dmsgC`, `v.tpM` |
+| Supervision | `ProcManager` (start/stop/status RPC) | None | None | None (toggle via `EmbeddedProxies`) |
+| Config source | `conf.Launcher.Apps[]` | `conf.Hypervisor` | `conf.Dmsgpty` | `conf.DmsgWeb`, `conf.SkynetWeb` |
+| Restart-on-failure | Declared (not yet enforced — see #2775 phase 4) | None | None | None |
+| Shutdown surface | `ProcManager.Stop(name)` | `pushCloseStack("hypervisor", hv.Disable)` | `pushCloseStack` on ctx-cancel | `pushCloseStack` |
+| `cli visor app ls` visibility | Yes | No | No | No |
+| Per-subsystem RPC | `apps/*` family | None | None | `EmbeddedProxies` only |
+
+The hard fact: **launcher apps talk to the visor over RPC; subsystems hold direct visor refs.** Any unification must reconcile this.
+
+## Design options
+
+Three credible shapes for the unification. They differ in how the visor-internal access of subsystems gets reconciled with the RPC-distanced posture of launcher apps.
+
+### Option A — Richer `Client`: plumb visor internals through an in-process app client
+
+Extend `*app.Client` so that an **in-process** client (`RunMode: Internal`) has methods backed directly by visor functions, while an **external** client keeps the existing pipe-RPC surface. The contract stays `AppFunc(ctx, args) error`; the difference is that `c.TransportManager()`, `c.DmsgClient()`, `c.RouteManager()` exist when the proc is in-process and panic / return errors when external.
+
+Subsystems become regular AppFuncs that call those new client methods.
+
+**Pros.** One contract for everything. No new interface. The dispatch on `RunMode` already exists. Future "internal app" authors get a clean, discoverable surface.
+
+**Cons.** The in-process `Client` becomes a god object exposing nearly the full visor surface. The "external client is the same type as internal client" property leaks dangerous methods at runtime (a launcher-app developer who wires up a hypervisor-shaped helper accidentally finds the visor's transport manager). Significant scope to define which visor internals are stable enough to expose.
+
+### Option B — App-shaped facades: subsystems keep their init wiring, register thin `AppFunc` shims
+
+Each subsystem keeps its current visor-init construction. We **additionally** register an `AppFunc` whose body is:
+
+```go
+func runHypervisor(ctx context.Context, args []string) error {
+    hv := v.hvInstance.Load() // populated by initHypervisor
+    if err := hv.Enable(ctx); err != nil { return err }
+    <-ctx.Done()
+    return hv.Disable()
+}
+```
+
+The visor's init module **does not** auto-`Enable` anymore — instead, it appends a synthetic entry to `conf.Launcher.Apps[]` so the launcher's start-apps phase invokes it during normal startup.
+
+**Pros.** Smallest change to subsystem internals — construction stays where it is. Operators get the uniform `cli visor app *` surface immediately. Existing `closeStack` ordering can keep dictating shutdown for subsystems if needed (they hand control to the launcher only for start/stop, not for ordering).
+
+**Cons.** Lifecycle is split: construction owned by init, start/stop owned by the launcher. Two places to look for "where does X live?" Closing a subsystem via `cli visor app stop hypervisor` calls `hv.Disable()` but does not destruct — a re-`start` reuses the same instance, which may or may not be the right idempotency model for every subsystem.
+
+### Option C — New `Runnable` interface, distinct from `AppFunc`
+
+Declare a second contract specifically for visor-internal services:
+
+```go
+type Runnable interface {
+    Name() string
+    Run(ctx context.Context) error
+}
+```
+
+`Runnable` is implemented directly by hypervisor, dmsgpty, the resolvers. The supervisor walks two registries — `launcher.AppFunc` registry and `runnable.Registry` — and presents them uniformly through `cli visor app *`. `AppFunc` is adapted via a wrapper that calls `Fn(ctx, args)` from `Run`.
+
+**Pros.** Honest about the asymmetry — apps and subsystems get different contracts because they ARE different things. Subsystems keep their natural method receivers (`hv.Run(ctx)`) and visor-struct closures. Supervisor logic stays type-safe.
+
+**Cons.** Two contracts to maintain. The `cli visor app *` surface has to abstract over both, which means either a discriminated union in the RPC reply ("kind = app | runnable") or a forced flattening that loses the distinction.
+
+## Recommendation: B then C, never A
+
+**Land Option B first** as the operator-visible unification. It's the smallest credible change that delivers the headline benefits (uniform start/stop/status, no more bespoke `EmbeddedProxies` RPC, visible service inventory). It does not require designing a stable "in-process Client" interface, which is the riskiest part of Option A.
+
+**Promote to Option C in a later pass** once Option B has burned in for a release. The split between construction and start/stop in Option B is a debt that Option C can pay down — by then the supervisor's contract is well-understood and adding `Runnable` is mechanical.
+
+**Reject Option A.** The "Client is the same type whether in-process or external" property is an attractive nuisance: it invites authors to write code that works in tests (in-process) and silently misbehaves in production (external), or vice versa. Discriminating at the type level (Option C) is cleaner than a runtime kind flag.
+
+## Migration plan (Option B)
+
+Five phases. Each lands as one PR. Each is independently revertable.
+
+### Phase 3.1 — config translation layer
+
+Add a `pkg/visor/visorconfig/synth_apps.go` pass that runs after `config.json` parsing. For each enabled subsystem block, append a synthetic entry to `conf.Launcher.Apps[]`:
+
+```go
+if conf.Hypervisor.Enable {
+    conf.Launcher.Apps = append(conf.Launcher.Apps, AppConfig{
+        Name:      "hypervisor",
+        AutoStart: true,
+        // args carry the bits operators previously set in conf.Hypervisor
+    })
+}
+// dmsgpty, dmsgweb, skynetweb analogous
+```
+
+No subsystem code changes yet. The launcher gets new `apps[]` entries but no `RunFunc` is registered, so they fail-to-start with `ErrAppNotFound` — guarded by a feature flag so the migration doesn't break boot.
+
+### Phase 3.2 — register dmsgweb + skynetweb as Internal apps
+
+The lowest-risk subsystems: already runtime-toggleable, smallest blast radius. Each gets an `AppFunc` body in `pkg/visor/embedded_dmsgweb.go` (and `skynetweb`) that wraps the existing `Start` / `Stop` and blocks on ctx-cancel. `launcher.RegisterApp("dmsgweb", ...)` + `RegisterApp("skynetweb", ...)`.
+
+The existing `initEmbeddedDmsgWeb` skips its auto-`Start` when the synthetic apps[] entry exists. The `EmbeddedProxies` RPC stays around as a thin shim that forwards to the launcher (deprecation deferred).
+
+Verify operator workflow: `cli visor app start dmsgweb` brings the SOCKS5 up; `stop` brings it down. Behavior matches the current `EmbeddedProxies` toggle.
+
+### Phase 3.3 — register dmsgpty as Internal app
+
+Same shape. dmsgpty's listener becomes the `AppFunc` body; the existing `init_dmsg_skywire.go:startSkywirePtyListener` is invoked from there instead of from init directly.
+
+Verify: `cli dmsg pty exec <pk> -- echo hi` still works. The remote-dial side is unaffected (different code path).
+
+### Phase 3.4 — register hypervisor as Internal app
+
+Highest blast radius — operators rely on this. Hypervisor's HTTP server becomes the `AppFunc`; `hv.Enable` is called from the `AppFunc`, `hv.Disable` on ctx-cancel.
+
+Verify: the UI loads, the existing `cli visor halt` shutdown sequence still works, restart-loop binary swap behaves identically.
+
+### Phase 3.5 — `cli visor app ls` cosmetic pass
+
+Add a column or grouping that distinguishes "launcher app" from "internal service" in the listing, so operators can still tell at a glance what kind of thing they're looking at. Pure UI; can land last or in parallel with the others.
+
+## Open questions
+
+1. **Idempotent start/stop.** When `cli visor app stop hypervisor` calls `hv.Disable()`, should `cli visor app start hypervisor` reuse the same `*Hypervisor` or construct a fresh one? Current `closeStack` semantics imply teardown — switching to start/stop semantics may need each subsystem to grow a `Reset()` step.
+
+2. **Synthetic config entry visibility.** Should the synthetic `apps[]` entries appear in `config gen` output? If yes, operators can edit them directly; if no, the `conf.Hypervisor.Enable` flag remains authoritative. There's a real tension between "make it discoverable" and "don't introduce duplicate sources of truth."
+
+3. **Naming.** App names today collide with binary names (`skychat` is both the app and the executable). For subsystems with no binary equivalent, do we keep names like `hypervisor` (matching the visorconfig key) or prefix them (`_service.hypervisor`) to avoid future collisions with operator-installable apps named the same?
+
+4. **Restart policy default for subsystems.** Phase 4 enforces `RestartPolicy`. Subsystems registered through this RFC default to which? `RestartOnFailure` matches operator intent ("the hypervisor should come back if it crashes") but means a crash loop won't surface as visibly as today's "the hypervisor is just gone."
+
+5. **External-mode internal services.** A theoretically interesting capability: run hypervisor as a separate process speaking RPC to the visor, for OOM isolation. Option B doesn't preclude this but doesn't enable it either. Worth flagging if anyone has a use case.
+
+## Out of scope for this RFC
+
+- Phase 4 (`RestartPolicy` enforcement). Independent change; can land before or after this RFC's phases.
+- Pair-binary collapse (skynet srv+client, etc.). Cosmetic, low-value; not blocking.
+- Replacing `EmbeddedProxies` RPC entirely. Deprecation pass after Option B ships.
+- Promoting to Option C. Separate RFC once Option B has shipped for a release.
+
+## Decision checklist
+
+For approval, the team needs to weigh in on:
+
+- [ ] Pick Option B vs C vs another shape.
+- [ ] Approve phased migration plan order (3.1 → 3.5).
+- [ ] Resolve open question 1 (idempotent start/stop semantics).
+- [ ] Resolve open question 4 (default RestartPolicy for subsystems).
+- [ ] Confirm naming convention for open question 3.
+
+Phases 3.2–3.5 should not start until all of the above are settled.

--- a/docs/unified_service_contract_rfc.md
+++ b/docs/unified_service_contract_rfc.md
@@ -16,7 +16,26 @@ The original `#2775` issue body included the hypervisor UI in the "make it an ap
 
 **About the web PTY.** Mechanistically, `skywire web` is **the pty subsystem serving its pseudoterminal over HTTP/WebSocket** so the operator's browser can render the terminal. The skywire CLI runs inside that PTY as a normal interactive shell session. It is **not** a REST/RPC gateway exposing per-command endpoints — it is the same PTY mechanism that backs the existing dmsg-transport pty (`cli dmsg pty exec`), just rendered over a different transport. The security model inherits the pty subsystem's PK-based authentication; no new auth surface is introduced.
 
-**Terminology rename.** The subsystem is conceptually a **pty (pseudoterminal)**. How it connects or serves and over what transport is a detail — dmsg today, HTTP via the web scaffold, potentially a local unix socket later. The current code identifier `dmsgpty` (package, config key, CLI subcommand) bakes the transport into the name; this RFC standardizes on **`pty`** for the concept and treats `dmsg` / `http` / `local` as **modes** (transports) of the same thing. The CLI surface for the standalone serves becomes `skywire app pty serve --transport=dmsg|http|local`; the existing dmsg-transport command tree (`skywire dmsg pty exec`) gains an `skywire app pty exec` alias path. The deeper code rename (`pkg/dmsgpty/` → `pkg/pty/`, `conf.Dmsgpty` → `conf.Pty` with backward-compat, etc.) is a follow-up PR — out of scope here; the rest of this RFC uses **pty** as the concept name and references existing identifiers like `pkg/dmsgpty/` only where pointing at code that hasn't been renamed yet.
+**Terminology rename.** The subsystem is conceptually a **pty (pseudoterminal)**. How it connects, what transport it listens on, and what keys it uses are all operational details — a single subsystem with several modes, not several subsystems with one transport each. The current code identifier `dmsgpty` (package, config key, CLI subcommand) bakes one specific transport into the name; this RFC standardizes on **`pty`** for the concept.
+
+**The four pty modes.** These are the operational shapes the pty subsystem can run in. They are not transports stacked under one mode — each is a distinct way the pty server is set up and addressed:
+
+1. **`visor`** — visor-hosted, multi-transport. The pty runs as a visor Internal app (Phase 3.3 below). It listens on **dmsg and skynet** simultaneously (the visor already has both clients) under the visor's PK. This is what `dmsgpty.Host` does today, plus a skynet listener that doesn't exist yet but is a natural extension.
+
+2. **`dmsg`** — dmsg-standalone. The pty runs as its own process with its own dmsg client; typically uses its own keypair, but may fall back to the visor's keys when the visor isn't running. This is what `cmd/dmsg/dmsgpty-host/` does today as a separate binary.
+
+3. **`tcp`** — TCP-standalone (the "ssh equivalent"). Listens on a TCP port with PK-based auth at the noise-handshake layer. No overlay network. New for the unified pty; today there is no `pkg/dmsg/dmsgpty/` TCP listener.
+
+4. **`http`** — HTTP-on-localhost. Serves the pty over HTTP/WebSocket so a browser can render the terminal. Localhost only — the listener is not directly reachable from the network, but a skynet/dmsg port-forward can expose it remotely (which inherits the overlay's PK auth at the forwarding layer). This is what `cmd/dmsg/dmsgpty-ui/` does today (bridged HTTP→dmsg→pty) and what the stashed `skywire web` scaffold did (direct HTTP→pty).
+
+CLI surface this RFC commits to:
+
+- `skywire app pty <mode>` runs the standalone server in the given mode — `pty dmsg`, `pty tcp`, `pty http`. (`pty visor` exists but is normally invoked by the launcher under Phase 3.3, not by the operator directly.)
+- `skywire app pty exec <pk>` dials out and runs a command on a remote pty server — alias for today's `skywire dmsg pty exec` while the deeper rename is pending.
+
+The existing standalone binaries (`cmd/dmsg/dmsgpty-host/`, `cmd/dmsg/dmsgpty-ui/`, `cmd/dmsg/dmsgpty-cli/`) become deprecation-eligible once the new command tree lands — keep them as thin shims that exec into the new subcommand path, or wire them as aliases inside cobra.
+
+**Deeper code rename** (`pkg/dmsgpty/` → `pkg/pty/`, `conf.Dmsgpty` → `conf.Pty`, listener type renames, etc.) is a follow-up PR — out of scope here. The rest of this RFC uses **pty** as the concept name and references existing identifiers like `pkg/dmsgpty/` only where pointing at code that hasn't been renamed yet.
 
 The implications for this RFC:
 
@@ -146,9 +165,13 @@ The existing `initEmbeddedDmsgWeb` skips its auto-`Start` when the synthetic app
 
 Verify operator workflow: `cli visor app start dmsgweb` brings the SOCKS5 up; `stop` brings it down. Behavior matches the current `EmbeddedProxies` toggle.
 
-### Phase 3.3 — register pty as Internal app
+### Phase 3.3 — register the `visor` pty mode as Internal app
 
-Same shape. The pty listener (code-name `dmsgpty.Host` today) becomes the `AppFunc` body; the existing `init_dmsg_skywire.go:startSkywirePtyListener` is invoked from there instead of from init directly. The Internal app registered name is `pty` (not `dmsgpty`) so the future HTTP and local transports can register the same app name and the operator surface (`cli visor app start pty`) stays stable across the deeper rename.
+Of the four pty modes (`visor` / `dmsg` / `tcp` / `http`), only **`visor`** mode is migrated here. The other three are standalone serves that an operator invokes directly via `skywire app pty <mode>` — they aren't visor-managed and don't go through the launcher.
+
+The pty listener that's already running inside the visor today (code-name `dmsgpty.Host`) becomes the `AppFunc` body; the existing `init_dmsg_skywire.go:startSkywirePtyListener` is invoked from there instead of from init directly. The skynet listener that's planned but not yet built lands inside the same `AppFunc`, so toggling pty via `cli visor app stop pty` takes both listeners down at once.
+
+The Internal app registered name is **`pty`** (not `dmsgpty`) so the future HTTP and local-transport listeners can ride the same registered app without churning the operator surface. `cli visor app start pty` stays stable across the deeper rename.
 
 Verify: `cli dmsg pty exec <pk> -- echo hi` still works. The remote-dial side is unaffected (different code path).
 

--- a/docs/unified_service_contract_rfc.md
+++ b/docs/unified_service_contract_rfc.md
@@ -24,7 +24,7 @@ The original `#2775` issue body included the hypervisor UI in the "make it an ap
 
 2. **`dmsg`** — dmsg-standalone. The pty runs as its own process with its own dmsg client; typically uses its own keypair, but may fall back to the visor's keys when the visor isn't running. This is what `cmd/dmsg/dmsgpty-host/` does today as a separate binary.
 
-3. **`tcp`** — TCP-standalone (the "ssh equivalent"). Listens on a TCP port with PK-based auth at the noise-handshake layer. No overlay network. New for the unified pty; today there is no `pkg/dmsg/dmsgpty/` TCP listener.
+3. **`tcp`** — TCP-standalone (the "ssh equivalent"). Listens on a TCP port. Each accept runs a **Noise XK handshake** for mutual PK auth + an encrypted+integrity-checked channel — same crypto primitive dmsg uses, transported over raw TCP. The primitive lives at `pkg/skywire/tcpnoise/` (factored out of `pkg/dmsg/dmsgpty/`) and is already wired by skychat's TCP-direct mode (`cmd/apps/skychat/commands/tcp_direct.go`). The pty subsystem just needs to use the same package — no new crypto, no new protocol.
 
 4. **`http`** — HTTP-on-localhost. Serves the pty over HTTP/WebSocket so a browser can render the terminal. Localhost only — the listener is not directly reachable from the network, but a skynet/dmsg port-forward can expose it remotely (which inherits the overlay's PK auth at the forwarding layer). This is what `cmd/dmsg/dmsgpty-ui/` does today (bridged HTTP→dmsg→pty) and what the stashed `skywire web` scaffold did (direct HTTP→pty).
 

--- a/docs/unified_service_contract_rfc.md
+++ b/docs/unified_service_contract_rfc.md
@@ -14,7 +14,9 @@ Status: **Draft.** Scope was revised after the first round of discussion (see "S
 
 The original `#2775` issue body included the hypervisor UI in the "make it an app" list. That decision was made before the `skywire web` surface was scaffolded. With the web PTY in the picture, the unification this RFC is really after — **uniform operator visibility and control** — gets delivered at the operator-interface layer, not at the supervisor layer.
 
-**About the web PTY.** Mechanistically, `skywire web` is **dmsgpty serving its pseudoterminal over HTTP/WebSocket** so the operator's browser can render the terminal. The skywire CLI runs inside that PTY as a normal interactive shell session. It is **not** a REST/RPC gateway exposing per-command endpoints — it is the same PTY mechanism that backs `cli dmsg pty exec`, just rendered in a different transport. The security model inherits dmsgpty's PK-based authentication; no new auth surface is introduced.
+**About the web PTY.** Mechanistically, `skywire web` is **the pty subsystem serving its pseudoterminal over HTTP/WebSocket** so the operator's browser can render the terminal. The skywire CLI runs inside that PTY as a normal interactive shell session. It is **not** a REST/RPC gateway exposing per-command endpoints — it is the same PTY mechanism that backs the existing dmsg-transport pty (`cli dmsg pty exec`), just rendered over a different transport. The security model inherits the pty subsystem's PK-based authentication; no new auth surface is introduced.
+
+**Terminology rename.** The subsystem is conceptually a **pty (pseudoterminal)**. How it connects or serves and over what transport is a detail — dmsg today, HTTP via the web scaffold, potentially a local unix socket later. The current code identifier `dmsgpty` (package, config key, CLI subcommand) bakes the transport into the name; this RFC standardizes on **`pty`** for the concept and treats `dmsg` / `http` / `local` as **modes** (transports) of the same thing. The CLI surface for the standalone serves becomes `skywire app pty serve --transport=dmsg|http|local`; the existing dmsg-transport command tree (`skywire dmsg pty exec`) gains an `skywire app pty exec` alias path. The deeper code rename (`pkg/dmsgpty/` → `pkg/pty/`, `conf.Dmsgpty` → `conf.Pty` with backward-compat, etc.) is a follow-up PR — out of scope here; the rest of this RFC uses **pty** as the concept name and references existing identifiers like `pkg/dmsgpty/` only where pointing at code that hasn't been renamed yet.
 
 The implications for this RFC:
 
@@ -22,9 +24,9 @@ The implications for this RFC:
 - The thing that originally made "hypervisor as an app" attractive was uniform visibility (`cli visor app ls` showing the full picture). The web PTY delivers that same uniformity *one level up*: the operator's single remote-control surface is the shell, and `cli visor app ls` is just one of many things they run inside it.
 - Hypervisor stays as a visor subsystem with its existing init wiring. No lifecycle refactor inside critical-path code.
 
-Phase 3 therefore shrinks to **dmsgweb, skynetweb, dmsgpty** — the three runtime-toggleable subsystems where the supervisor-side unification actually buys something. Total scope is ~150 LOC instead of ~500 LOC, and the riskiest piece (hypervisor's lifecycle refactor) is removed.
+Phase 3 therefore shrinks to **dmsgweb, skynetweb, pty** — the three runtime-toggleable subsystems where the supervisor-side unification actually buys something. Total scope is ~150 LOC instead of ~500 LOC, and the riskiest piece (hypervisor's lifecycle refactor) is removed.
 
-**dmsgpty's elevated role:** since dmsgpty is the mechanism backing the meta-surface, Phase 3.3 (migrating dmsgpty to an Internal app) is touching the very thing that delivers this RFC's "hypervisor stays as subsystem" argument. Still safe — dmsgpty stays running across the migration, just managed via the launcher afterward. But it means Phase 3.3 needs the same operator-regression care that hypervisor would have needed: don't ship dmsgpty's `RestartPolicy` enforcement (Phase 4) until 3.3 has burned in.
+**pty's elevated role:** since pty is the mechanism backing the meta-surface, Phase 3.3 (migrating pty to an Internal app) is touching the very thing that delivers this RFC's "hypervisor stays as subsystem" argument. Still safe — pty stays running across the migration, just managed via the launcher afterward. But it means Phase 3.3 needs the same operator-regression care that hypervisor would have needed: don't ship pty's `RestartPolicy` enforcement (Phase 4) until 3.3 has burned in.
 
 The web PTY scaffold is a prerequisite for this revision to hold. As long as `skywire web` ships before or alongside Phase 3, operators don't lose anything by hypervisor staying as a subsystem.
 
@@ -34,23 +36,23 @@ The skywire visor today supervises two distinct kinds of long-running things, wi
 
 **Launcher apps** (`pkg/app/launcher`, `pkg/app/appserver`) — skychat, skysocks, skysocks-client, skynet, skynet-client, vpn-server, vpn-client. Either external child processes or in-process goroutines whose entrypoint matches `appcommon.AppFunc = func(ctx, args) error`. Lifecycle is owned by `appserver.ProcManager`; runtime control via `cli visor app start|stop|status|info` (RPC).
 
-**Visor subsystems** — `hypervisor` (HTTP server), `dmsgpty` host (PTY listener), `dmsgweb` and `skynetweb` (the resolver SOCKS5 proxies). Started by entries in the `pkg/visor/init.go` module DAG; shutdown via `pushCloseStack`. Each holds direct references to visor-internal state (`v.tpM`, `v.dmsgC`, `v.router`, etc.). Runtime control surfaces are bespoke per-service: hypervisor has no on/off RPC at all, dmsgpty has none, resolvers have `EmbeddedProxies`.
+**Visor subsystems** — `hypervisor` (HTTP server), the `pty` host (currently `dmsgpty` in code; PTY listener), `dmsgweb` and `skynetweb` (the resolver SOCKS5 proxies). Started by entries in the `pkg/visor/init.go` module DAG; shutdown via `pushCloseStack`. Each holds direct references to visor-internal state (`v.tpM`, `v.dmsgC`, `v.router`, etc.). Runtime control surfaces are bespoke per-service: hypervisor has no on/off RPC at all, pty has none, resolvers have `EmbeddedProxies`.
 
-Phases 1, 2a, 2b made the launcher-app contract explicit but did not bridge the two worlds. This RFC is about partially bridging — specifically for `dmsgpty`, `dmsgweb`, `skynetweb`.
+Phases 1, 2a, 2b made the launcher-app contract explicit but did not bridge the two worlds. This RFC is about partially bridging — specifically for `pty`, `dmsgweb`, `skynetweb`.
 
 ## What unification still buys (post-revision)
 
 With hypervisor out of scope, the wins are smaller but real:
 
-1. **Uniform `cli visor app ls` view** for dmsgweb / skynetweb / dmsgpty alongside launcher apps. An operator inside the web PTY runs the same `cli visor app` subcommands as in a local terminal; the migration just adds these three to the list.
+1. **Uniform `cli visor app ls` view** for dmsgweb / skynetweb / pty alongside launcher apps. An operator inside the web PTY runs the same `cli visor app` subcommands as in a local terminal; the migration just adds these three to the list.
 2. **Drop the bespoke `EmbeddedProxies` RPC** in favor of standard `cli visor app start|stop dmsgweb`. One less ad-hoc control surface.
-3. **dmsgpty gains a runtime on/off switch** it doesn't have today. Operators who don't want PTY access exposed can disable it without restarting the visor (and re-enable for a maintenance window).
-4. **Supervision (`RestartPolicy`) becomes available** for these three when phase 4 lands. dmsgpty restart-on-crash is the most useful — the listener occasionally dies silently in the field.
+3. **pty gains a runtime on/off switch** it doesn't have today. Operators who don't want PTY access exposed can disable it without restarting the visor (and re-enable for a maintenance window). The same control surface covers all pty transports — dmsg today, HTTP once the web scaffold ships.
+4. **Supervision (`RestartPolicy`) becomes available** for these three when phase 4 lands. pty restart-on-crash is the most useful — the listener occasionally dies silently in the field.
 5. **Construction site stays where it is for all three.** No init refactor; the AppFunc shim just wraps existing `Start()` / `Stop()` methods.
 
 What unification does **not** buy:
 - Hypervisor's bespoke startup stays. Operators still toggle it via `conf.Hypervisor.Enable` + visor restart (or via the web PTY once that ships, which can invoke the visor RPC to re-init it).
-- Config sprawl is partially addressed: dmsgweb/skynetweb/dmsgpty get synthetic `apps[]` entries, but their `visorconfig.*` sub-structs stay (for the args).
+- Config sprawl is partially addressed: dmsgweb/skynetweb/pty get synthetic `apps[]` entries, but their `visorconfig.*` sub-structs stay (for the args).
 
 ## Non-goals
 
@@ -61,9 +63,9 @@ What unification does **not** buy:
 
 ## The asymmetry — facts on the ground
 
-| | Launcher apps (A) | dmsgpty (B) | Resolvers (B) | Hypervisor (out of scope) |
+| | Launcher apps (A) | pty (B) | Resolvers (B) | Hypervisor (out of scope) |
 |---|---|---|---|---|
-| Entry | `AppFunc(ctx, args)` | `dmsgpty.Host.ListenAndServe()` | constructor → `Start()` | `NewHypervisor(...)` → `Enable(ctx)` |
+| Entry | `AppFunc(ctx, args)` | `dmsgpty.Host.ListenAndServe()` (code-name still `dmsgpty`) | constructor → `Start()` | `NewHypervisor(...)` → `Enable(ctx)` |
 | Construction site | `cmd/apps/*/commands/*.go` registers via `launcher.RegisterApp` | `pkg/visor/init_dmsg.go` / `init_dmsg_skywire.go` | `pkg/visor/embedded_dmsgweb.go`, `embedded_skynetweb.go` | `pkg/visor/init_apps.go:initHypervisor` |
 | Visor-internal access | None — uses `app.NewClient()` RPC pipe | Full — uses `v.dmsgC` etc. | Full — uses `v.dmsgC`, `v.tpM` | Full — gets passed `v *Visor` |
 | Supervision today | `ProcManager` (start/stop/status RPC) | None | None (toggle via `EmbeddedProxies`) | None |
@@ -105,7 +107,7 @@ A config translation layer (Phase 3.1) auto-appends `AppConfig{Name: "dmsgweb", 
 
 The earlier draft of this RFC also discussed Option C — a separate `Runnable` interface that subsystems implement directly. With hypervisor out of scope, the case for Option C collapses:
 
-- The dmsgpty/dmsgweb/skynetweb subsystems all have natural `Start()`/`Stop()` method pairs. The AppFunc shim wrapping those is trivial; promoting them to implement a new `Runnable` interface buys near-zero additional clarity.
+- The pty/dmsgweb/skynetweb subsystems all have natural `Start()`/`Stop()` method pairs. The AppFunc shim wrapping those is trivial; promoting them to implement a new `Runnable` interface buys near-zero additional clarity.
 - The "wart" of split construction-vs-start in Option B was painful mainly for hypervisor's already-tangled lifecycle. For the three simpler subsystems, the wart is invisible — construction is one line, start/stop are one line each.
 - Maintaining a second supervisor contract (`Runnable`) alongside `AppFunc` adds surface for ~50 LOC of net benefit. Not worth it.
 
@@ -131,7 +133,7 @@ if conf.DmsgWeb.Enable {
         // args carry the bits operators previously set in conf.DmsgWeb
     })
 }
-// skynetweb, dmsgpty analogous
+// skynetweb, pty analogous
 ```
 
 No subsystem code changes yet. The launcher gets new `apps[]` entries but no `RunFunc` is registered, so they fail-to-start with `ErrAppNotFound` — guarded by a feature flag (e.g. `conf.Launcher.SynthesizeSubsystems`) so the migration doesn't break boot. The flag flips to default-on once 3.2/3.3 land.
@@ -144,9 +146,9 @@ The existing `initEmbeddedDmsgWeb` skips its auto-`Start` when the synthetic app
 
 Verify operator workflow: `cli visor app start dmsgweb` brings the SOCKS5 up; `stop` brings it down. Behavior matches the current `EmbeddedProxies` toggle.
 
-### Phase 3.3 — register dmsgpty as Internal app
+### Phase 3.3 — register pty as Internal app
 
-Same shape. dmsgpty's listener becomes the `AppFunc` body; the existing `init_dmsg_skywire.go:startSkywirePtyListener` is invoked from there instead of from init directly.
+Same shape. The pty listener (code-name `dmsgpty.Host` today) becomes the `AppFunc` body; the existing `init_dmsg_skywire.go:startSkywirePtyListener` is invoked from there instead of from init directly. The Internal app registered name is `pty` (not `dmsgpty`) so the future HTTP and local transports can register the same app name and the operator surface (`cli visor app start pty`) stays stable across the deeper rename.
 
 Verify: `cli dmsg pty exec <pk> -- echo hi` still works. The remote-dial side is unaffected (different code path).
 
@@ -157,7 +159,7 @@ Add a column or grouping that distinguishes "launcher app" from "internal servic
 ## Open questions
 
 1. **Default RestartPolicy for the three subsystems.** Phase 4 (independent of this RFC) enforces `RestartPolicy`. The proposed defaults:
-   - dmsgpty: `OnFailure` — listener occasionally dies silently in the field; restart is exactly what operators want.
+   - pty: `OnFailure` — listener occasionally dies silently in the field; restart is exactly what operators want.
    - dmsgweb / skynetweb: `Never` — these are user-driven (operator clicks "enable proxy"), no value in auto-restart.
    Confirm or adjust.
 
@@ -165,7 +167,7 @@ Add a column or grouping that distinguishes "launcher app" from "internal servic
 
 3. **Synthetic config entry visibility.** Should the synthetic `apps[]` entries appear in `skywire config gen` output? If yes, operators can edit them directly; if no, the `conf.DmsgWeb.Enable` flag remains authoritative. Recommend **no** for now — keep `conf.DmsgWeb` etc. as authoritative, synthesis happens at load time. Operators who really want to override pass args through the existing config block.
 
-4. **Idempotent start/stop.** When `cli visor app stop dmsgweb` calls `Stop()`, should `cli visor app start dmsgweb` reuse the same instance or construct a fresh one? Current semantics: dmsgweb / skynetweb already cleanly stop-then-start the underlying SOCKS5 listener. dmsgpty's listener is more sensitive — the `dmsgpty.Host` keeps active sessions; stopping kills them. Recommend instance reuse for all three (simpler, matches today's runtime-toggle behavior for dmsgweb/skynetweb), and document the active-session loss for dmsgpty.
+4. **Idempotent start/stop.** When `cli visor app stop dmsgweb` calls `Stop()`, should `cli visor app start dmsgweb` reuse the same instance or construct a fresh one? Current semantics: dmsgweb / skynetweb already cleanly stop-then-start the underlying SOCKS5 listener. The pty listener is more sensitive — the host keeps active sessions; stopping kills them. Recommend instance reuse for all three (simpler, matches today's runtime-toggle behavior for dmsgweb/skynetweb), and document the active-session loss for pty.
 
 ## Out of scope for this RFC
 


### PR DESCRIPTION
## Summary

Captures the design space for unifying the visor's supervised-service surface across launcher apps and visor-internal subsystems.

Predecessor PRs #2860 / #2861 / #2862 (phases 1, 2a, 2b) named the launcher-app contract; this RFC charts the path for the next phase that those PRs do not by themselves accomplish.

**Revised after the first round of discussion** — hypervisor is now **out of scope**. The `skywire web` HTTP-CLI surface is the operator-side meta-management interface; it delivers the uniformity originally wanted from "hypervisor as an app" at the interface layer instead of the supervisor layer. Phase 3 shrinks to dmsgpty + dmsgweb + skynetweb only (~150 LOC, no critical-path lifecycle refactor).

## What's in the RFC (revised)

- **Scope revision** at the top explaining why hypervisor was dropped.
- **What unification still buys** with the narrower scope (uniform `cli visor app ls` for the three subsystems, drop the bespoke `EmbeddedProxies` RPC, dmsgpty gains a runtime on/off switch, supervision becomes available via Phase 4, construction sites unchanged).
- **The asymmetry table** with the four categories (launcher apps + the three migrated subsystems + hypervisor as "out of scope").
- **The chosen shape** — app-shaped facades wrapping existing `Start()`/`Stop()` methods. With code sketch.
- **Why this shape and not Option C** (separate Runnable interface) or Option A (richer Client) — both were motivated by hypervisor's complexity; with hypervisor out, both collapse.
- **Four-phase migration plan**: config translation → dmsgweb/skynetweb → dmsgpty → cosmetic UI distinguishing apps from internal services.
- **Open questions** sharpened: default RestartPolicies per service (recommendations included), naming convention, synthetic-config visibility, idempotent start/stop semantics.

## What this PR does *not* do

- No code changes outside `docs/`.
- No implementation. Draft status — waiting on team input on the decision checklist.

## Test plan

- [x] Markdown renders correctly on GitHub.
- [ ] Team confirms scope revision (hypervisor out, web CLI is the meta-surface).
- [ ] Team resolves the four sharpened open questions.