### PR TITLE
refactor(pty): consolidate dmsgpty cli/host/ui under `skywire app pty`

### DIFF
--- a/cmd/apps/pty/commands/pty.go
+++ b/cmd/apps/pty/commands/pty.go
@@ -1,0 +1,145 @@
+// Package commands cmd/apps/pty/commands/pty.go — the unified
+// `skywire app pty <mode>` command tree.
+//
+// The pty (pseudoterminal) subsystem has four operational modes:
+//
+//   - visor   visor-hosted Internal app. Started by the launcher;
+//             not exposed here. (See RFC #2775 Phase 3.3.)
+//   - dmsg    standalone process with a dmsg listener (own keys,
+//             own dmsg client). Can also enable a TCP listener
+//             via --tcp-listen; --no-dmsg makes it TCP-only.
+//   - tcp     standalone TCP-only (ssh equivalent). Convenience
+//             wrapper that forces --no-dmsg on `dmsg`; --addr is
+//             required and seeds --tcp-listen.
+//   - http    HTTP/WebSocket bridge — serves a real PTY in a
+//             browser via the dmsgpty.UI machinery. Bridges to a
+//             running mode-1/2/3 pty server via --hnet + --haddr.
+//
+// Plus an `exec` subcommand that dials a remote pty server and
+// runs a command (the old `dmsgpty-cli` flow), with `whitelist`
+// management subcommands underneath it.
+//
+// Code layout: each mode mounts the existing dmsgpty-host /
+// dmsgpty-ui / dmsgpty-cli cobra command from cmd/dmsg/ as a
+// subcommand under this tree, with the Use field renamed. The
+// dmsg subcommand tree (`skywire dmsg pty *`) no longer mounts
+// these — that path moved to `skywire app pty *`. The package-
+// level code identifiers (`pkg/dmsg/dmsgpty/`, `conf.Dmsgpty`,
+// etc.) are unchanged; that deeper rename is a follow-up PR.
+package commands
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	dpc "github.com/skycoin/skywire/cmd/dmsg/dmsgpty-cli/commands"
+	dph "github.com/skycoin/skywire/cmd/dmsg/dmsgpty-host/commands"
+	dpu "github.com/skycoin/skywire/cmd/dmsg/dmsgpty-ui/commands"
+)
+
+// RootCmd is the `app pty` command. Mounted onto the top-level
+// appsCmd by cmd/skywire/commands/root.go.
+var RootCmd = &cobra.Command{
+	Use:   "pty",
+	Short: "Pseudoterminal (interactive shell) server and client",
+	Long: `Pseudoterminal (pty) — interactive shell over a network.
+
+The same pty subsystem runs in four modes:
+
+  visor     Visor-hosted Internal app (managed by the launcher;
+            invoke via 'cli visor app start pty' once Phase 3.3
+            lands, not via this command).
+  dmsg      Standalone server with a dmsg listener. Pair with
+            --no-dmsg + --tcp-listen for a tcp-only deployment.
+  tcp       Standalone tcp-only listener (ssh equivalent). Same
+            crypto as dmsg's noise layer, transported over raw
+            TCP. Requires --addr.
+  http      HTTP/WebSocket bridge serving a real pty in a browser.
+            Connects to a running mode-1/2/3 pty server.
+
+Auth model inherits the underlying transport's noise-XK + PK
+whitelist. See 'skywire app pty <mode> --help' for per-mode flags.`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+}
+
+func init() {
+	// Mount each existing implementation under the unified tree
+	// with its operator-facing mode name. The dmsg subcommand tree
+	// (cmd/dmsg/dmsg/commands/root.go) no longer mounts these, so
+	// each *.RootCmd has a single parent (this tree).
+	dph.RootCmd.Use = "dmsg"
+	dph.RootCmd.Short = "Run a standalone pty server (dmsg listener; +TCP via --tcp-listen)"
+
+	dpu.RootCmd.Use = "http"
+	dpu.RootCmd.Short = "Serve a pty over HTTP/WebSocket for browser-rendered terminal"
+
+	dpc.RootCmd.Use = "exec"
+	dpc.RootCmd.Short = "Dial a remote pty server and run a command (whitelist subcommands underneath)"
+
+	RootCmd.AddCommand(
+		dph.RootCmd, // dmsg
+		newTCPCmd(), // tcp — wraps dmsg with --no-dmsg forced
+		dpu.RootCmd, // http
+		dpc.RootCmd, // exec
+	)
+}
+
+// newTCPCmd builds the `tcp` mode wrapper. It's a thin shim over
+// the dmsg-host RootCmd that forces --no-dmsg and seeds --tcp-listen
+// from a required --addr. Operators get a discoverable subcommand
+// for the ssh-equivalent deployment shape without having to know
+// the underlying flag combination.
+func newTCPCmd() *cobra.Command {
+	var addr string
+	cmd := &cobra.Command{
+		Use:   "tcp",
+		Short: "Run a standalone pty server with a TCP listener only (ssh equivalent, --no-dmsg)",
+		Long: `Run the pty server in tcp-standalone mode — no dmsg client,
+no dmsg-discovery entry. TCP listener with mutual-PK Noise XK
+handshake gates inbound connections. The same crypto as dmsg's
+noise layer, transported over raw TCP.
+
+Equivalent to:
+  skywire app pty dmsg --no-dmsg --tcp-listen <addr>
+
+Other dmsg-host flags (--sk, --whitelist, --sk-from-visor, etc.)
+are accepted by the underlying server but expressed here only
+through --addr; pass them via the dmsg subcommand if you need
+the full surface.`,
+		SilenceErrors:         true,
+		SilenceUsage:          true,
+		DisableSuggestions:    true,
+		DisableFlagsInUseLine: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if addr == "" {
+				return fmt.Errorf("--addr is required for tcp mode (e.g. --addr :2022)")
+			}
+			// Inject the equivalent flag combo on the underlying
+			// dmsg-host RootCmd and re-enter its parsing. This avoids
+			// duplicating the host's RunE; the trade-off is that the
+			// tcp subcommand only forwards --addr, not the rest of
+			// the host's flag surface.
+			dph.RootCmd.SetArgs([]string{"--no-dmsg", "--tcp-listen", addr})
+			return dph.RootCmd.Execute()
+		},
+	}
+	cmd.Flags().StringVar(&addr, "addr", "",
+		"TCP bind address (required, e.g. ':2022' or '0.0.0.0:2022')")
+	return cmd
+}
+
+// Execute is the standalone-binary entry point. Used by
+// cmd/apps/pty/pty.go when the app is invoked as a separate
+// binary; the main `skywire app pty` path goes through the
+// top-level Execute in cmd/skywire/commands/root.go and doesn't
+// call this.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		log.Fatal("Failed to execute command: ", err)
+	}
+}

--- a/cmd/apps/pty/pty.go
+++ b/cmd/apps/pty/pty.go
@@ -1,0 +1,46 @@
+// Package main cmd/apps/pty/pty.go — standalone binary entry point
+// for `skywire app pty`. Mostly a courtesy: the main use of this
+// command tree is via the unified `skywire` binary's `app pty`
+// subcommand, mounted from cmd/skywire/commands/root.go.
+package main
+
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/cmd/apps/pty/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help menu")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint:errcheck,gosec
+}
+
+func main() {
+	cc.Init(&cc.Config{
+		RootCmd:         commands.RootCmd,
+		Headings:        cc.HiBlue + cc.Bold,
+		Commands:        cc.HiBlue + cc.Bold,
+		CmdShortDescr:   cc.HiBlue,
+		Example:         cc.HiBlue + cc.Italic,
+		ExecName:        cc.HiBlue + cc.Bold,
+		Flags:           cc.HiBlue + cc.Bold,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+	commands.Execute()
+}
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsg/dmsg/commands/root.go
+++ b/cmd/dmsg/dmsg/commands/root.go
@@ -17,9 +17,6 @@ import (
 	dc "github.com/skycoin/skywire/cmd/dmsg/dmsgcurl/commands"
 	dh "github.com/skycoin/skywire/cmd/dmsg/dmsghttp/commands"
 	di "github.com/skycoin/skywire/cmd/dmsg/dmsgip/commands"
-	dpc "github.com/skycoin/skywire/cmd/dmsg/dmsgpty-cli/commands"
-	dph "github.com/skycoin/skywire/cmd/dmsg/dmsgpty-host/commands"
-	dpu "github.com/skycoin/skywire/cmd/dmsg/dmsgpty-ui/commands"
 	dw "github.com/skycoin/skywire/cmd/dmsg/dmsgweb/commands"
 	dsp "github.com/skycoin/skywire/cmd/dmsg/self-ping/commands"
 	"github.com/skycoin/skywire/pkg/buildinfo"
@@ -34,17 +31,15 @@ var (
 )
 
 func init() {
-	dmsgptyCmd.AddCommand(
-		dpc.RootCmd,
-		dph.RootCmd,
-		dpu.RootCmd,
-	)
+	// pty subcommands (dmsgpty-cli / -host / -ui) moved to the
+	// unified `skywire app pty <mode>` tree in cmd/apps/pty/commands.
+	// `skywire dmsg pty <cli|host|ui>` is no longer a valid path;
+	// operators should use `skywire app pty <exec|dmsg|tcp|http>`.
 
 	ds.RootCmd.AddCommand(
 		dl.RootCmd,
 	)
 	RootCmd.AddCommand(
-		dmsgptyCmd,
 		dd.RootCmd,
 		ds.RootCmd,
 		df.RootCmd,
@@ -63,9 +58,6 @@ func init() {
 	dc.RootCmd.Use = "curl"
 	dw.RootCmd.Use = "web"
 	ds5.RootCmd.Use = "socks"
-	dpc.RootCmd.Use = "cli"
-	dph.RootCmd.Use = "host"
-	dpu.RootCmd.Use = "ui"
 	di.RootCmd.Use = "ip"
 	dsp.RootCmd.Use = "self-ping"
 
@@ -127,19 +119,6 @@ var RootCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
-var dmsgptyCmd = &cobra.Command{
-	Use:   "pty",
-	Short: "DMSG pseudoterminal (pty)",
-	Long: `
-	┌─┐┌┬┐┬ ┬
-	├─┘ │ └┬┘
-	┴   ┴  ┴
-DMSG pseudoterminal (pty)`,
-	SilenceErrors:         true,
-	SilenceUsage:          true,
-	DisableSuggestions:    true,
-	DisableFlagsInUseLine: true,
-}
 
 // Execute executes root CLI command.
 func Execute() {

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	pty "github.com/skycoin/skywire/cmd/apps/pty/commands"
 	sc "github.com/skycoin/skywire/cmd/apps/skychat/commands"
 	snc "github.com/skycoin/skywire/cmd/apps/skynet-client/commands"
 	sn "github.com/skycoin/skywire/cmd/apps/skynet/commands"
@@ -39,6 +40,7 @@ func init() {
 		sc.RootCmd,
 		sn.RootCmd,
 		snc.RootCmd,
+		pty.RootCmd,
 	)
 	// Install flag-aware `help` (supports -r/-t/-d modes) on the
 	// Install flag-aware `help` + coloredcobra styling on every


### PR DESCRIPTION
## Summary

Per RFC #2863, the pty (pseudoterminal) subsystem is a single concept that runs in several operational modes. The old CLI path mixed the dmsg transport name into the structure (\`skywire dmsg pty <cli|host|ui>\`) which obscured that. This PR consolidates onto:

\`\`\`
skywire app pty dmsg    standalone server with dmsg listener
                        (--no-dmsg + --tcp-listen for tcp-only)
skywire app pty tcp     tcp-standalone (ssh equivalent); thin
                        wrapper that forces --no-dmsg
skywire app pty http    HTTP/WebSocket bridge — real pty in browser
skywire app pty exec    dial a remote pty server and run a command
\`\`\`

The fourth mode (\`visor\` — pty running inside the visor as an Internal app) is RFC #2775 Phase 3.3 and lands as a separate PR.

## What moves

- **\`cmd/apps/pty/\`** — new package + standalone binary entrypoint; mounts the existing \`dmsgpty-host / dmsgpty-ui / dmsgpty-cli\` RootCmds under operator-facing mode names. \`tcp\` mode is a thin wrapper that injects \`--no-dmsg\` + \`--tcp-listen\` on top of \`dmsg\`.
- **\`cmd/skywire/commands/root.go\`** — \`pty.RootCmd\` added to \`appsCmd\` so \`skywire app pty\` is discoverable through the unified binary.
- **\`cmd/dmsg/dmsg/commands/root.go\`** — removes the \`dmsgptyCmd\` group + its AddCommand block. The \`dpc\` / \`dph\` / \`dpu\` RootCmds now have a single parent (the new pty tree) rather than being shared between the dmsg and app trees, which cobra doesn't handle cleanly.

## Behavior preserved

- All flags on each underlying server / client are unchanged. An invocation like \`skywire app pty dmsg --sk … --tcp-listen :2022\` hits exactly the same code paths as \`skywire dmsg pty host\` did before, with the same config + whitelist semantics.
- The \`cmd/dmsg/dmsgpty-{host,ui,cli}/\` standalone binaries continue to build and ship unchanged for operators who invoke them directly.
- \`pkg/dmsg/dmsgpty/\` package identifiers and \`conf.Dmsgpty\` stay. The deeper code-level rename (package → \`pkg/pty/\`, config key, etc.) is a separate follow-up PR.

## Breaking change for operators

- \`skywire dmsg pty cli|host|ui\` is no longer a valid path. The new path is \`skywire app pty exec|dmsg|http\` respectively.
- Operator scripts referencing the old path need a one-line update.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./cmd/apps/pty/... ./cmd/dmsg/... ./cmd/skywire/...\` clean
- [x] Smoke test: \`skywire app pty --help\` lists the four modes
- [x] Smoke test: \`skywire app pty tcp --help\` shows the required \`--addr\` flag
- [x] Smoke test: \`skywire dmsg --help\` no longer lists \`pty\` in its subcommand set
- [ ] CI lint

## Follow-ups (deferred, separate PRs)

- RFC #2775 Phase 3.3: register pty as a visor Internal app (mode \`visor\`).
- Deeper code rename: \`pkg/dmsg/dmsgpty/\` → \`pkg/pty/\`, \`conf.Dmsgpty\` → \`conf.Pty\`, etc.
- Integrate the stashed cobra-tree explorer as a sub-handler under \`skywire app pty http\` at path \`/skywire\` (the dmsgpty.UI pty stays at \`/\`).