### PR TITLE
refactor(visor): pty as Internal app w/ RestartPolicy=Always (#2775 phase 3.3)

### DIFF
--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -28,7 +28,12 @@ const (
 var (
 	// ErrAppAlreadyStarted is returned when trying to run the already running app.
 	ErrAppAlreadyStarted = errors.New("app already started")
-	errNoSuchApp         = errors.New("no such app")
+	// ErrNoSuchApp is returned by ProcManager getters (ProcByName,
+	// Wait, Stop, etc.) when no app is registered under the given
+	// name. Exported so callers like the launcher's auto-restart
+	// watcher can distinguish "proc exited" from "proc was
+	// de-registered" without string-matching.
+	ErrNoSuchApp = errors.New("no such app")
 
 	// ErrClosed occurs when an action is called after proc manager is closed.
 	ErrClosed = errors.New("proc manager is already closed")
@@ -497,7 +502,7 @@ func (m *procManager) pop(name string) (*Proc, error) {
 
 	p, ok := m.procs[name]
 	if !ok {
-		return nil, errNoSuchApp
+		return nil, ErrNoSuchApp
 	}
 
 	delete(m.procs, name)
@@ -512,7 +517,7 @@ func (m *procManager) get(name string) (*Proc, error) {
 
 	p, ok := m.procs[name]
 	if !ok {
-		return nil, errNoSuchApp
+		return nil, ErrNoSuchApp
 	}
 
 	return p, nil

--- a/pkg/app/appserver/proc_manager_test.go
+++ b/pkg/app/appserver/proc_manager_test.go
@@ -70,7 +70,7 @@ func TestProcManager_Pop(t *testing.T) {
 	appName := "app"
 
 	app, err := m.pop(appName)
-	require.Equal(t, err, errNoSuchApp)
+	require.Equal(t, err, ErrNoSuchApp)
 	require.Nil(t, app)
 
 	m.procs[appName] = nil
@@ -105,7 +105,7 @@ func TestProcManager_SetDetailedStatus(t *testing.T) {
 
 	nonExistingAppName := "none"
 	err = m.SetDetailedStatus(nonExistingAppName, wantStatus)
-	require.Equal(t, errNoSuchApp, err)
+	require.Equal(t, ErrNoSuchApp, err)
 }
 
 func TestProcManager_DetailedStatus(t *testing.T) {
@@ -128,7 +128,7 @@ func TestProcManager_DetailedStatus(t *testing.T) {
 
 	nonExistingAppName := "none"
 	_, err = m.DetailedStatus(nonExistingAppName)
-	require.Equal(t, errNoSuchApp, err)
+	require.Equal(t, ErrNoSuchApp, err)
 }
 
 func TestProcManager_RegisterAndDeregister(t *testing.T) {
@@ -161,5 +161,5 @@ func TestProcManager_RegisterAndDeregister(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = m.DetailedStatus(appName)
-	require.Equal(t, errNoSuchApp, err)
+	require.Equal(t, ErrNoSuchApp, err)
 }

--- a/pkg/app/appserver/spec/spec.go
+++ b/pkg/app/appserver/spec/spec.go
@@ -49,4 +49,18 @@ type AppConfig struct {
 	// (today: external when Binary is set, internal otherwise).
 	// Honored by StartApp; StartAppWithMode still wins per-call.
 	LauncherMode string `json:"launcher_mode,omitempty"`
+	// RestartPolicy controls what happens when the proc exits.
+	// String form of appcommon.RestartPolicy (kept as string in spec
+	// to keep this package WASM-clean — no appcommon import).
+	//   ""            = Never (default — proc stays stopped on exit)
+	//   "on-failure"  = Restart only when the proc returns a non-nil
+	//                   error.
+	//   "always"      = Restart on any exit, including operator-
+	//                   initiated stop. Used by critical apps (pty,
+	//                   etc.) where accidentally stopping the proc
+	//                   would lock the operator out of remote
+	//                   management. The only path to actually
+	//                   disable an Always-policy app is to remove
+	//                   its config entry and restart the visor.
+	RestartPolicy string `json:"restart_policy,omitempty"`
 }

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -321,8 +322,68 @@ func (l *AppLauncher) startAppWithMode(cmd string, args, envs []string, launcher
 		log.WithError(err).Warn("Failed to persist pid.")
 	}
 
+	// Spawn the auto-restart watcher when the AppConfig declares a
+	// non-Never policy. The watcher blocks on the proc's exit and
+	// re-Starts if the policy demands. Costs one goroutine per
+	// running app; harmless for Never-policy apps (immediate return).
+	if rp := appcommon.RestartPolicy(ac.RestartPolicy); rp != appcommon.RestartNever {
+		go l.watchAndRestart(cmd, args, envs, launcherMode, rp)
+	}
+
 	return nil
 }
+
+// watchAndRestart blocks on a proc's exit, then re-Starts it if the
+// supplied RestartPolicy demands. Used by RestartPolicy=Always
+// (critical apps like pty, where operator-initiated stop must not
+// permanently disable the proc) and RestartPolicy=OnFailure (apps
+// that should come back after a crash).
+//
+// Backoff is a fixed 1s — not exponential — because the proc is
+// expected to be either healthy (rare restart) or permanently
+// broken (operator notices in the logs and intervenes). Tight loops
+// burn cycles but don't accumulate state; the visor's app logger
+// surfaces the restart events.
+//
+// Quietly returns when the proc was already de-registered from the
+// proc manager (e.g. visor shutdown removed it before Wait
+// returned) — Wait surfaces ErrNoSuchApp in that case.
+func (l *AppLauncher) watchAndRestart(name string, args, envs []string, launcherMode string, policy appcommon.RestartPolicy) {
+	log := l.log.WithField("func", "watchAndRestart").
+		WithField("app_name", name).
+		WithField("policy", string(policy))
+
+	exitErr := l.procM.Wait(name)
+
+	// Shutdown / de-registration path — proc gone from the manager.
+	// Without this guard we'd loop on an app the operator already
+	// detached.
+	if errors.Is(exitErr, appserver.ErrNoSuchApp) {
+		log.Debug("proc de-registered before exit; not restarting")
+		return
+	}
+
+	shouldRestart := policy == appcommon.RestartAlways ||
+		(policy == appcommon.RestartOnFailure && exitErr != nil)
+	if !shouldRestart {
+		return
+	}
+
+	log.WithError(exitErr).Info("proc exited; auto-restarting per RestartPolicy")
+	time.Sleep(restartBackoff)
+
+	if err := l.StartAppWithMode(name, args, envs, launcherMode); err != nil {
+		log.WithError(err).Error("auto-restart failed")
+	}
+}
+
+// restartBackoff is the fixed delay between a proc exit and its
+// policy-driven restart. Fixed (not exponential) because tight
+// restart loops happen on permanently-broken procs and we'd rather
+// the operator see the log flood than have the loop slow down and
+// hide the issue. 1s is generous enough that one or two test
+// restarts during operator workflows aren't perceptible.
+const restartBackoff = time.Second
 
 // StopApp stops running app.
 func (l *AppLauncher) StopApp(name string) (*appserver.Proc, error) {
@@ -452,6 +513,11 @@ func makeProcConfig(lc AppLauncherConfig, ac appserver.AppConfig, envs []string)
 	} else {
 		procConf.RunMode = appcommon.RunModeExternal
 	}
+
+	// Carry the AppConfig's restart policy through to the proc. The
+	// launcher's watchAndRestart goroutine consults this field after
+	// the proc exits to decide whether to re-Start.
+	procConf.Restart = appcommon.RestartPolicy(ac.RestartPolicy)
 
 	err := ensureDir(&procConf.ProcWorkDir)
 	return procConf, err

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -15,6 +15,7 @@ import (
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 
+	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -43,10 +44,29 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 
 	v.pushCloseStack("launcher.proc_manager", procM.Close)
 
+	// Synthesize the "pty" Internal app entry when initDmsgpty has
+	// constructed a Host. This is the visor-binding for RFC #2775
+	// Phase 3.3 — the pty's listener lifecycle moves into the
+	// launcher so `cli visor app start/stop pty` works uniformly
+	// with the rest of the apps surface. RestartPolicy=Always makes
+	// stop a no-op in practice (auto-restart triggers); the only
+	// real disable path is editing the config and restarting the
+	// visor, which is exactly the pre-Phase-3.3 disable path.
+	apps := append([]appserver.AppConfig(nil), conf.Apps...)
+	if v.dmsgPty != nil && !appsContains(apps, "pty") {
+		apps = append(apps, appserver.AppConfig{
+			Name:          "pty",
+			Binary:        "", // internal — RunFunc registered by initDmsgpty
+			AutoStart:     true,
+			LauncherMode:  string(appcommon.RunModeInternal),
+			RestartPolicy: string(appcommon.RestartAlways),
+		})
+	}
+
 	// Prepare launcher.
 	launchConf := launcher.AppLauncherConfig{
 		VisorPK:       v.conf.PK,
-		Apps:          conf.Apps,
+		Apps:          apps,
 		ServerAddr:    conf.ServerAddr,
 		BinPath:       conf.BinPath,
 		LocalPath:     v.conf.LocalPath,
@@ -78,6 +98,19 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	v.initLock.Unlock()
 
 	return nil
+}
+
+// appsContains reports whether an apps[] slice already contains an
+// entry under name. Used to skip synthesizing pty (and future
+// Internal-app) entries when the operator has set them explicitly
+// in config.json — operator config wins.
+func appsContains(apps []appserver.AppConfig, name string) bool {
+	for _, ac := range apps {
+		if ac.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Make an env maker function for vpn application

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/app/appcommon"
+	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/direct"
@@ -867,63 +869,19 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// with separate permissions from the visor's RPC.
 	v.dmsgPty = pty
 
-	if ptyPort := conf.DmsgPort; ptyPort != 0 {
-		serveCtx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is called in pushCloseStack
-		wg := new(sync.WaitGroup)
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-			runtimeErrors := getErrors(ctx)
-			if err := pty.ListenAndServe(serveCtx, ptyPort); err != nil {
-				runtimeErrors <- fmt.Errorf("listen and serve stopped: %w", err)
-			}
-		}()
-
-		v.pushCloseStack("router.serve", func() error {
-			cancel()
-			wg.Wait()
-			return nil
-		})
-
-		// Parallel skynet listener — accepts dmsgpty over
-		// appnet.SkywireNetworker so remote peers that have a
-		// negotiated route to us can reach the pty service without
-		// opening a fresh dmsg stream. Returns nil close-func when
-		// the skynet networker isn't wired yet (init ordering) or
-		// when Listen fails; in either case the dmsg listener
-		// above keeps the service functional.
-		runtimeErrors := getErrors(ctx)
-		if closer := startSkywirePtyListener(context.Background(), pty, v.conf.PK, ptyPort, runtimeErrors); closer != nil {
-			v.pushCloseStack("dmsgpty.skywire.serve", closer)
-		}
-
-	}
-
-	// Direct-TCP dmsgpty entry point — operator opts in via
-	// Dmsgpty.SshListen ("" disables). Same whitelist as the
-	// dmsg-overlay path; XK-noise handshake gates the accepted PK
-	// before the stream reaches the dmsgpty mux. See
-	// dmsgpty/host_tcp.go for the per-connection flow. Exposed at
-	// CLI as `skywire cli ssh` / `skywire cli sshd`.
-	if tcpAddr := conf.SshListen; tcpAddr != "" {
-		tcpCtx, tcpCancel := context.WithCancel(context.Background()) //nolint:gosec // cancel called in pushCloseStack
-		tcpWg := new(sync.WaitGroup)
-		tcpWg.Add(1)
-		go func() {
-			defer tcpWg.Done()
-			runtimeErrors := getErrors(ctx)
-			if err := pty.ListenAndServeTCP(tcpCtx, tcpAddr, v.conf.PK, v.conf.SK); err != nil {
-				runtimeErrors <- fmt.Errorf("dmsgpty tcp listen %s stopped: %w", tcpAddr, err)
-			}
-		}()
-		v.pushCloseStack("dmsgpty.tcp.serve", func() error {
-			tcpCancel()
-			tcpWg.Wait()
-			return nil
-		})
-		log.WithField("addr", tcpAddr).Info("Mounted dmsgpty direct-TCP entry point")
-	}
+	// The dmsg + skynet + TCP listeners moved from the init module
+	// into a launcher-managed Internal app (RFC #2775 Phase 3.3).
+	// Register the AppFunc here while we have closure-access to the
+	// constructed Host and the per-mode config. The launcher's
+	// AutoStart pass (see init_apps.go) brings the listeners up
+	// once the launcher is constructed; visor halt tears them down
+	// via procM.Close. RestartPolicy=Always ensures stop just
+	// triggers an auto-restart — operator-initiated `cli visor app
+	// stop pty` doesn't permanently remove the pty surface from a
+	// remote machine (lockout safety).
+	ptyPort := conf.DmsgPort
+	sshAddr := conf.SshListen
+	launcher.RegisterApp("pty", buildPtyAppFunc(v, pty, ptyPort, sshAddr))
 
 	// dmsgscp Host (scp-over-dmsg). On by default — access is gated
 	// by the same whitelist that dmsgpty uses. Operators opt OUT
@@ -1258,3 +1216,84 @@ func initDmsgServerLatency(ctx context.Context, v *Visor, log *logging.Logger) e
 	log.Info("DMSG server latency tracking started")
 	return nil
 }
+
+// buildPtyAppFunc constructs the AppFunc registered as the "pty"
+// Internal app (RFC #2775 Phase 3.3). Captures the constructed
+// dmsgpty.Host plus the configured listener parameters from
+// initDmsgpty so the launcher can start / stop the listeners
+// after init has finished. The shape mirrors what initDmsgpty
+// itself used to do before this phase:
+//
+//   - dmsg listener on conf.DmsgPort (primary entry point)
+//   - skynet listener on the same port (routed peers)
+//   - TCP listener on conf.SshListen (operator-opt-in, ssh-style)
+//
+// All three share the dmsgpty.Host's mux and whitelist; the host
+// itself is constructed once at init time and re-used across
+// restart cycles.
+func buildPtyAppFunc(v *Visor, host *dmsgpty.Host, dmsgPort uint16, sshAddr string) appcommon.AppFunc {
+	return func(ctx context.Context, _ []string) error {
+		log := v.MasterLogger().PackageLogger("app:pty")
+		log.Info("Starting pty listeners.")
+
+		wg := new(sync.WaitGroup)
+		listenerCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// dmsg listener — primary entry. ListenAndServe blocks
+		// until listenerCtx cancels or the listener fails.
+		if dmsgPort != 0 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := host.ListenAndServe(listenerCtx, dmsgPort); err != nil && !errors.Is(err, context.Canceled) {
+					log.WithError(err).Warn("dmsg listener stopped with error")
+				}
+			}()
+
+			// Parallel skynet listener — accepts pty over the
+			// skywire networker so routed peers can reach the
+			// service without opening a fresh dmsg stream. nil
+			// runtimeErrors channel is OK; the helper's select
+			// has a default case.
+			if closer := startSkywirePtyListener(listenerCtx, host, v.conf.PK, dmsgPort, nil); closer != nil {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-listenerCtx.Done()
+					_ = closer() //nolint:errcheck
+				}()
+			}
+		}
+
+		// Direct-TCP entry point — operator opt-in via
+		// Dmsgpty.SshListen. XK-noise handshake gates each accept;
+		// the whitelist is shared with the dmsg path. Exposed at
+		// CLI as `skywire cli ssh` / `skywire cli sshd`.
+		if sshAddr != "" {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := host.ListenAndServeTCP(listenerCtx, sshAddr, v.conf.PK, v.conf.SK); err != nil && !errors.Is(err, context.Canceled) {
+					log.WithError(err).WithField("addr", sshAddr).Warn("tcp listener stopped with error")
+				}
+			}()
+			log.WithField("addr", sshAddr).Info("Mounted pty TCP entry point.")
+		}
+
+		// Block until app ctx cancel — either operator-initiated
+		// `cli visor app stop pty` (auto-restart by Always policy)
+		// or visor halt (procM.Close cancels all proc contexts).
+		<-ctx.Done()
+		log.Info("Stopping pty listeners.")
+		cancel()
+		wg.Wait()
+		return nil
+	}
+}
+
+// Ensure the launcher package is referenced. The RegisterApp call
+// in initDmsgpty's body uses launcher.RegisterApp; this nolint hint
+// keeps tooling that scans for unused imports happy in case the
+// init path is conditionally compiled out somewhere.
+var _ = launcher.RegisterApp


### PR DESCRIPTION
## Summary

RFC #2775 / #2863 Phase 3.3 — the visor-hosted pty becomes a launcher-managed Internal app so \`cli visor app start|stop|status pty\` works uniformly with the rest of the apps surface.

**Lockout safety is preserved** via \`RestartPolicy=Always\` — a stop just triggers an auto-restart; permanent disable still requires editing the config and restarting the visor (exactly the pre-3.3 disable path, no regression). This is the safety model agreed in the design discussion.

## Changes

### Phase 4 enforcement (minimum viable: Always + OnFailure)

- **\`pkg/app/appserver/spec/spec.go\`** — add \`RestartPolicy\` field to \`AppConfig\` (wire-format string mirroring \`appcommon.RestartPolicy\` to keep \`spec\` WASM-clean).
- **\`pkg/app/launcher/launcher.go\`** — propagate \`AppConfig.RestartPolicy\` into \`ProcConfig.Restart\` inside \`makeProcConfig\`. Add \`watchAndRestart\` goroutine spawned by \`StartApp\` when policy != Never. \`Always\` re-Starts on any exit; \`OnFailure\` re-Starts only on non-nil exit error. Fixed 1s backoff. \`ErrNoSuchApp\` suppresses the restart attempt (e.g. de-registered during shutdown).
- **\`pkg/app/appserver/proc_manager.go\`** — export \`ErrNoSuchApp\` so \`watchAndRestart\` can distinguish "proc exited" from "proc was de-registered" without string-matching.

### Phase 3.3 (pty as Internal app)

- **\`pkg/visor/init_dmsg.go\`** — replace the inline dmsg / skynet / TCP listener startup in \`initDmsgpty\` with a \`launcher.RegisterApp\` call that captures the constructed Host + listener params in a closure (\`buildPtyAppFunc\`). The AppFunc starts all three listeners on launcher startup, blocks on \`ctx.Done()\`, tears them down on stop.
- **\`pkg/visor/init_apps.go\`** — synthesize an \`apps[]\` entry for \`"pty"\` before \`NewLauncher\` when \`initDmsgpty\` has constructed a Host and config.json doesn't already specify one (operator config wins). \`AutoStart=true\` + \`RestartPolicy=Always\` so pty comes up with the visor and survives accidental stops.

The pty Host's whitelist, CLI socket, and dmsgscp host stay where they are in \`initDmsgpty\` — they're not part of the listener lifecycle that needs operator-runtime control. \`v.dmsgPty\` assignment also stays in init so the rest of the visor (dmsghttp_logserver depends on \`&pty\` in the module DAG) sees a constructed Host even before the launcher's AutoStart fires.

## Operator-visible effects

- \`cli visor app ls\` now lists pty alongside launcher apps.
- \`cli visor app stop pty\` stops listeners; auto-restart kicks in after 1s. Practical effect = brief listener interruption.
- \`cli visor app start pty\` works for the (unusual) case where pty was somehow not running.
- **Disabling pty permanently** still requires \`conf.Dmsgpty = null\` in config.json + visor restart. This is the lockout-safety guarantee.

## Test plan

- [x] \`go build ./pkg/app/... ./pkg/visor/... ./cmd/skywire/...\` clean
- [x] \`go test ./pkg/app/...\` green
- [x] \`go vet\` clean
- [ ] CI lint
- [ ] Smoke test on a running visor: verify pty shows in \`cli visor app ls\`, stop+auto-restart works, visor halt cleanly stops pty