### PR TITLE
refactor(visor): dmsgweb + skynetweb as Internal apps (#2775 phase 3.2)

### DIFF
--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -23,6 +23,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/skycoin/skywire/pkg/app"
+	"github.com/skycoin/skywire/pkg/app/appcommon"
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsgweb"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -223,12 +227,42 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()
 
-	if cfg.Enable {
-		if err := runtime.Start(); err != nil {
-			log.WithError(err).Warn("failed to auto-start dmsgweb")
-		}
-	} else {
-		log.Info("Embedded dmsgweb constructed but not started (enable=false); toggle via RPC")
-	}
+	// Register as an Internal app (RFC #2775 Phase 3.2). The
+	// launcher's AutoStart pass brings the SOCKS5 listener up when
+	// cfg.Enable=true; visor halt tears it down via procM.Close.
+	// RestartPolicy=Never so operator-driven toggles via
+	// `cli visor app start|stop dmsgweb` behave as expected (no
+	// surprise auto-restart on stop — different from pty).
+	launcher.RegisterApp(skyenvDmsgWebApp, buildDmsgWebAppFunc(runtime, log))
 	return nil
+}
+
+// skyenvDmsgWebApp is the launcher-registered name for the embedded
+// dmsgweb SOCKS5 proxy. Operators see it in `cli visor app ls` and
+// can toggle it via `cli visor app start|stop dmsgweb`.
+const skyenvDmsgWebApp = "dmsgweb"
+
+// buildDmsgWebAppFunc wraps the EmbeddedDmsgWeb runtime in the
+// AppFunc contract — the launcher invokes it on app start; the
+// returned func opens an app.Client to complete the in-process
+// IPC handshake, calls Start, blocks on ctx cancel, then calls
+// Stop. Same shape as buildPtyAppFunc in init_dmsg.go.
+func buildDmsgWebAppFunc(rt *EmbeddedDmsgWeb, log *logging.Logger) appcommon.AppFunc {
+	return func(ctx context.Context, _ []string) error {
+		appCl := app.NewClient(nil)
+		defer appCl.Close()
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStarting)
+		if err := rt.Start(); err != nil {
+			log.WithError(err).Warn("dmsgweb Start failed")
+			appCl.SetErrorOrLog(err)
+			return err
+		}
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
+		<-ctx.Done()
+		if err := rt.Stop(); err != nil {
+			log.WithError(err).Warn("dmsgweb Stop failed")
+		}
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
+		return nil
+	}
 }

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -19,6 +19,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/app"
+	"github.com/skycoin/skywire/pkg/app/appcommon"
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/router"
@@ -254,12 +258,35 @@ func initEmbeddedSkynetWeb(ctx context.Context, v *Visor, log *logging.Logger) e
 	v.embeddedSkynetWeb = runtime
 	v.initLock.Unlock()
 
-	if v.conf.SkynetWeb.Enable {
-		if err := runtime.Start(); err != nil {
-			log.WithError(err).Warn("failed to auto-start skynetweb")
-		}
-	} else {
-		log.Info("Embedded skynetweb constructed but not started (enable=false); toggle via RPC")
-	}
+	// Register as an Internal app (RFC #2775 Phase 3.2). See
+	// buildDmsgWebAppFunc in embedded_dmsgweb.go for the matching
+	// pattern; both proxies use RestartPolicy=Never (operator
+	// toggles are intentional, not crash-recovery candidates).
+	launcher.RegisterApp(skyenvSkynetWebApp, buildSkynetWebAppFunc(runtime, log))
 	return nil
+}
+
+// skyenvSkynetWebApp is the launcher-registered name for the
+// embedded skynetweb SOCKS5 proxy.
+const skyenvSkynetWebApp = "skynetweb"
+
+// buildSkynetWebAppFunc — same shape as buildDmsgWebAppFunc.
+func buildSkynetWebAppFunc(rt *EmbeddedSkynetWeb, log *logging.Logger) appcommon.AppFunc {
+	return func(ctx context.Context, _ []string) error {
+		appCl := app.NewClient(nil)
+		defer appCl.Close()
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStarting)
+		if err := rt.Start(); err != nil {
+			log.WithError(err).Warn("skynetweb Start failed")
+			appCl.SetErrorOrLog(err)
+			return err
+		}
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusRunning)
+		<-ctx.Done()
+		if err := rt.Stop(); err != nil {
+			log.WithError(err).Warn("skynetweb Stop failed")
+		}
+		appCl.SetStatusOrLog(appserver.AppDetailedStatusStopped)
+		return nil
+	}
 }

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -44,15 +44,17 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 
 	v.pushCloseStack("launcher.proc_manager", procM.Close)
 
-	// Synthesize the "pty" Internal app entry when initDmsgpty has
-	// constructed a Host. This is the visor-binding for RFC #2775
-	// Phase 3.3 — the pty's listener lifecycle moves into the
-	// launcher so `cli visor app start/stop pty` works uniformly
-	// with the rest of the apps surface. RestartPolicy=Always makes
-	// stop a no-op in practice (auto-restart triggers); the only
-	// real disable path is editing the config and restarting the
-	// visor, which is exactly the pre-Phase-3.3 disable path.
+	// Synthesize Internal-app entries for visor subsystems that
+	// have moved into the launcher's lifecycle per RFC #2775
+	// (operator config wins — appsContains skips synthesis when
+	// the operator has set an explicit entry).
 	apps := append([]appserver.AppConfig(nil), conf.Apps...)
+
+	// Phase 3.3 — pty as Internal app. RestartPolicy=Always so
+	// `cli visor app stop pty` is a no-op in practice (auto-restart
+	// triggers after a 1s backoff). The only real disable path is
+	// removing conf.Dmsgpty and restarting the visor — exactly the
+	// pre-Phase-3.3 disable path.
 	if v.dmsgPty != nil && !appsContains(apps, "pty") {
 		apps = append(apps, appserver.AppConfig{
 			Name:          "pty",
@@ -60,6 +62,37 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 			AutoStart:     true,
 			LauncherMode:  string(appcommon.RunModeInternal),
 			RestartPolicy: string(appcommon.RestartAlways),
+		})
+	}
+
+	// Phase 3.2 — embedded SOCKS5 proxies as Internal apps.
+	// RestartPolicy=Never (operator toggles are intentional, not
+	// crash-recovery candidates); AutoStart reflects the operator's
+	// Enable flag in config so the boot-time behavior is unchanged.
+	// initEmbeddedDmsgWeb / initEmbeddedSkynetWeb register the
+	// RunFunc; the launcher's AutoStart pass starts the listener.
+	if v.embeddedDmsgWeb != nil && !appsContains(apps, "dmsgweb") {
+		autostart := false
+		if v.conf.DmsgWeb != nil {
+			autostart = v.conf.DmsgWeb.Enable
+		}
+		apps = append(apps, appserver.AppConfig{
+			Name:          "dmsgweb",
+			AutoStart:     autostart,
+			LauncherMode:  string(appcommon.RunModeInternal),
+			RestartPolicy: string(appcommon.RestartNever),
+		})
+	}
+	if v.embeddedSkynetWeb != nil && !appsContains(apps, "skynetweb") {
+		autostart := false
+		if v.conf.SkynetWeb != nil {
+			autostart = v.conf.SkynetWeb.Enable
+		}
+		apps = append(apps, appserver.AppConfig{
+			Name:          "skynetweb",
+			AutoStart:     autostart,
+			LauncherMode:  string(appcommon.RunModeInternal),
+			RestartPolicy: string(appcommon.RestartNever),
 		})
 	}
 


### PR DESCRIPTION
Same pattern as #2867's pty (RFC #2775 phase 3.3) — applied to the two embedded SOCKS5 proxies. Construction stays in init; lifecycle moves to the launcher via RegisterApp + AppFunc wrappers. RestartPolicy=Never (intentional operator toggles, not crash-recovery candidates). AutoStart mirrors the existing cfg.Enable flag so boot-time behavior is unchanged. The bespoke EmbeddedProxies RPC stays (deprecation is a follow-up).