### PR TITLE
refactor(visor): RestartPolicy=OnFailure for dmsgweb + skynetweb (#2775 phase 4)

### DIFF
--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -65,10 +65,11 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 		})
 	}
 
-	// Phase 3.2 — embedded SOCKS5 proxies as Internal apps.
-	// RestartPolicy=Never (operator toggles are intentional, not
-	// crash-recovery candidates); AutoStart reflects the operator's
-	// Enable flag in config so the boot-time behavior is unchanged.
+	// Phase 3.2 + Phase 4 — embedded SOCKS5 proxies as Internal apps
+	// with RestartPolicy=OnFailure. Operator stop respects intent
+	// (clean exit, no restart) but a runtime crash is recovered
+	// automatically. AutoStart reflects the operator's Enable flag
+	// in config so boot-time behavior is unchanged.
 	// initEmbeddedDmsgWeb / initEmbeddedSkynetWeb register the
 	// RunFunc; the launcher's AutoStart pass starts the listener.
 	if v.embeddedDmsgWeb != nil && !appsContains(apps, "dmsgweb") {
@@ -80,7 +81,7 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 			Name:          "dmsgweb",
 			AutoStart:     autostart,
 			LauncherMode:  string(appcommon.RunModeInternal),
-			RestartPolicy: string(appcommon.RestartNever),
+			RestartPolicy: string(appcommon.RestartOnFailure),
 		})
 	}
 	if v.embeddedSkynetWeb != nil && !appsContains(apps, "skynetweb") {
@@ -92,7 +93,7 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 			Name:          "skynetweb",
 			AutoStart:     autostart,
 			LauncherMode:  string(appcommon.RunModeInternal),
-			RestartPolicy: string(appcommon.RestartNever),
+			RestartPolicy: string(appcommon.RestartOnFailure),
 		})
 	}
 


### PR DESCRIPTION
Upgrade the two embedded SOCKS5 proxies from RestartPolicy=Never to RestartPolicy=OnFailure. OnFailure preserves stop-is-intentional semantics (procM.Stop's clean exit → no restart) while gaining crash recovery (non-nil exit → auto-restart per #2867's watchAndRestart). pty stays Always (lockout-safety override). Operator-config apps untouched (default stays Never).