### PR TITLE
refactor(apps): skysocks pair collapse + fix delegating-wrapper recursion

### DIFF
--- a/cmd/apps/pty/commands/pty.go
+++ b/cmd/apps/pty/commands/pty.go
@@ -92,28 +92,42 @@ func init() {
 }
 
 // newDelegateCmd builds a thin wrapper cobra.Command whose RunE
-// forwards all args (flags included) to the supplied target's
-// Execute method. Flag parsing is disabled on the wrapper so the
-// target sees the raw args — including --help, which prints the
-// target's own help text. This avoids both (a) sharing cobra
-// command instances between the dmsg tree and this tree (cobra
-// can't handle one Command having two parents) and (b) duplicating
-// each underlying RunE body here.
+// parses flags onto the supplied target's flagset and invokes the
+// target's Run/RunE directly. The wrapper avoids re-entering
+// cobra's dispatcher (which would resolve os.Args back through
+// itself and recurse to a stack overflow — the original shape used
+// target.SetArgs+Execute and hit this bug as soon as both wrapper
+// and target shared an ancestor in the cobra tree).
+//
+// --help intercept fires before ParseFlags so the target's own
+// help text is what operators see, not cobra's flag-help shortcut
+// error path.
 func newDelegateCmd(use, short string, target *cobra.Command) *cobra.Command {
 	return &cobra.Command{
-		Use:                use,
-		Short:              short,
-		DisableFlagParsing: true,
-		// Suppress the wrapper's auto-generated usage on error so
-		// the target's error path stays clean; the target prints
-		// its own help.
+		Use:                   use,
+		Short:                 short,
+		DisableFlagParsing:    true,
 		SilenceErrors:         true,
 		SilenceUsage:          true,
 		DisableSuggestions:    true,
 		DisableFlagsInUseLine: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			target.SetArgs(args)
-			return target.Execute()
+			for _, a := range args {
+				if a == "--help" || a == "-h" {
+					return target.Help()
+				}
+			}
+			if err := target.ParseFlags(args); err != nil {
+				return err
+			}
+			remaining := target.Flags().Args()
+			if target.RunE != nil {
+				return target.RunE(target, remaining)
+			}
+			if target.Run != nil {
+				target.Run(target, remaining)
+			}
+			return nil
 		},
 	}
 }

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -41,6 +41,7 @@ func init() {
 		sn.RootCmd,
 		snc.RootCmd,
 		pty.RootCmd,
+		skysocksPairCmd,
 	)
 	// Install flag-aware `help` (supports -r/-t/-d modes) on the
 	// Install flag-aware `help` + coloredcobra styling on every
@@ -84,8 +85,15 @@ func init() {
 	visor.RootCmd.Use = "visor"
 	vpns.RootCmd.Use = "vpn-server"
 	vpnc.RootCmd.Use = "vpn-client"
+	// skysocks pair (server + client) is collapsed under
+	// `skywire app skysocks {serve,client}`. The legacy direct
+	// invocations stay mounted but Hidden so operator scripts
+	// hitting the old paths keep working; `skywire app --help`
+	// only advertises the new unified path.
 	ssc.RootCmd.Use = "skysocks-client"
-	ss.RootCmd.Use = "skysocks"
+	ssc.RootCmd.Hidden = true
+	ss.RootCmd.Use = "skysocks-srv"
+	ss.RootCmd.Hidden = true
 	sc.RootCmd.Use = "skychat"
 	sn.RootCmd.Use = "skynet-srv"
 	snc.RootCmd.Use = "skynet-client"

--- a/cmd/skywire/commands/skysocks_pair.go
+++ b/cmd/skywire/commands/skysocks_pair.go
@@ -1,0 +1,94 @@
+// Package commands cmd/skywire/commands/skysocks_pair.go — unified
+// `skywire app skysocks {serve,client}` parent that thin-wraps the
+// existing skysocks / skysocks-client RootCmds.
+//
+// Pattern lifted from `skywire app pty` (PR #2866 / RFC #2863):
+// build a fresh cobra command whose subcommands disable flag parsing
+// and forward args verbatim to the target's Execute via SetArgs.
+// This avoids sharing cobra.Command instances between two parents
+// (cobra can't handle one Command having two parents cleanly) and
+// avoids duplicating each underlying RunE body here.
+//
+// The launcher's app-name registry is unchanged: config.json's
+// `apps[]` entries still reference "skysocks" / "skysocks-client"
+// and the launcher's GetApp() lookup hits the same RunFuncs. This
+// file only restructures the operator's CLI discoverability.
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	ssc "github.com/skycoin/skywire/cmd/apps/skysocks-client/commands"
+	ss "github.com/skycoin/skywire/cmd/apps/skysocks/commands"
+)
+
+// skysocksPairCmd is the new visible `skywire app skysocks`. The
+// old direct invocations of `app skysocks` (server) and `app
+// skysocks-client` (client) are still mounted but Hidden — see
+// root.go where the hide flags are set.
+var skysocksPairCmd = &cobra.Command{
+	Use:                   "skysocks",
+	Short:                 "skywire socks5 proxy — pair of server (serve) and client (client) subcommands",
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+}
+
+func init() {
+	skysocksPairCmd.AddCommand(
+		newSkysocksDelegateCmd(
+			"serve",
+			"Run the skysocks server (was: `skywire app skysocks`)",
+			ss.RootCmd,
+		),
+		newSkysocksDelegateCmd(
+			"client",
+			"Run the skysocks client (was: `skywire app skysocks-client`)",
+			ssc.RootCmd,
+		),
+	)
+}
+
+// newSkysocksDelegateCmd builds a thin wrapper cobra.Command whose
+// RunE parses flags onto the supplied target's flagset and calls
+// the target's Run/RunE directly. This avoids re-entering cobra's
+// dispatcher, which would otherwise resolve `os.Args` back through
+// the wrapper and recurse to a stack overflow — a bug that bit the
+// earlier `target.SetArgs(args); target.Execute()` shape (used in
+// the original #2866 pty wrapper) once both wrapper and target
+// shared a parent cobra tree.
+//
+// --help is intercepted up front since cobra's flag-help shortcut
+// only fires through the dispatcher; without the intercept,
+// `app skysocks serve --help` would hit ParseFlags's "help
+// requested" error path and never reach the target's help text.
+func newSkysocksDelegateCmd(use, short string, target *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:                   use,
+		Short:                 short,
+		DisableFlagParsing:    true,
+		SilenceErrors:         true,
+		SilenceUsage:          true,
+		DisableSuggestions:    true,
+		DisableFlagsInUseLine: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			for _, a := range args {
+				if a == "--help" || a == "-h" {
+					return target.Help()
+				}
+			}
+			if err := target.ParseFlags(args); err != nil {
+				return err
+			}
+			remaining := target.Flags().Args()
+			if target.RunE != nil {
+				return target.RunE(target, remaining)
+			}
+			if target.Run != nil {
+				target.Run(target, remaining)
+			}
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
Pair-binary collapse for skysocks (same pattern as #2864/#2866 pty), AND a bug fix for the delegating-wrapper recursion that bit the pty wrapper once both wrapper and target sat in the same cobra tree. Both newDelegateCmd (pty) and the new skysocks pair wrapper now parse flags onto the target's flagset and invoke Run/RunE directly instead of re-entering cobra's dispatcher.