### PR TITLE
refactor(apps): vpn pair collapse + extract shared delegating-wrapper helper

### DIFF
--- a/cmd/skywire/commands/app_delegate.go
+++ b/cmd/skywire/commands/app_delegate.go
@@ -1,0 +1,50 @@
+// Package commands cmd/skywire/commands/app_delegate.go — shared
+// delegating-wrapper helper for `skywire app <pair> {serve,client}`
+// command trees (skysocks_pair.go, vpn_pair.go, skynet_pair.go).
+//
+// Pattern: build a fresh cobra.Command whose RunE parses flags onto
+// the supplied target's flagset and invokes the target's Run/RunE
+// directly. Skipping cobra's dispatcher avoids the recursion bug
+// that bites `target.SetArgs(args); target.Execute()` once both
+// wrapper and target share a parent cobra tree — Execute walks up
+// to root, dispatches via os.Args, resolves back through the
+// wrapper, recurses, stack-overflows. (Bug originally hit the pty
+// wrapper in #2864/#2866; fix landed in #2873 alongside skysocks.)
+//
+// --help is intercepted up front because cobra's flag-help shortcut
+// only fires through the dispatcher; without the intercept,
+// `app skysocks serve --help` would hit ParseFlags's "help
+// requested" error path and never reach the target's help text.
+package commands
+
+import "github.com/spf13/cobra"
+
+func newDelegateAppCmd(use, short string, target *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:                   use,
+		Short:                 short,
+		DisableFlagParsing:    true,
+		SilenceErrors:         true,
+		SilenceUsage:          true,
+		DisableSuggestions:    true,
+		DisableFlagsInUseLine: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			for _, a := range args {
+				if a == "--help" || a == "-h" {
+					return target.Help()
+				}
+			}
+			if err := target.ParseFlags(args); err != nil {
+				return err
+			}
+			remaining := target.Flags().Args()
+			if target.RunE != nil {
+				return target.RunE(target, remaining)
+			}
+			if target.Run != nil {
+				target.Run(target, remaining)
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -42,6 +42,7 @@ func init() {
 		snc.RootCmd,
 		pty.RootCmd,
 		skysocksPairCmd,
+		vpnPairCmd,
 	)
 	// Install flag-aware `help` (supports -r/-t/-d modes) on the
 	// Install flag-aware `help` + coloredcobra styling on every
@@ -83,8 +84,14 @@ func init() {
 
 	scli.RootCmd.Use = "cli"
 	visor.RootCmd.Use = "visor"
+	// vpn pair (server + client) collapsed under
+	// `skywire app vpn {serve,client}`. Legacy direct invocations
+	// stay mounted but Hidden — no Use rename needed (no collision
+	// with the new "vpn" pair name).
 	vpns.RootCmd.Use = "vpn-server"
+	vpns.RootCmd.Hidden = true
 	vpnc.RootCmd.Use = "vpn-client"
+	vpnc.RootCmd.Hidden = true
 	// skysocks pair (server + client) is collapsed under
 	// `skywire app skysocks {serve,client}`. The legacy direct
 	// invocations stay mounted but Hidden so operator scripts

--- a/cmd/skywire/commands/skysocks_pair.go
+++ b/cmd/skywire/commands/skysocks_pair.go
@@ -37,58 +37,15 @@ var skysocksPairCmd = &cobra.Command{
 
 func init() {
 	skysocksPairCmd.AddCommand(
-		newSkysocksDelegateCmd(
+		newDelegateAppCmd(
 			"serve",
 			"Run the skysocks server (was: `skywire app skysocks`)",
 			ss.RootCmd,
 		),
-		newSkysocksDelegateCmd(
+		newDelegateAppCmd(
 			"client",
 			"Run the skysocks client (was: `skywire app skysocks-client`)",
 			ssc.RootCmd,
 		),
 	)
-}
-
-// newSkysocksDelegateCmd builds a thin wrapper cobra.Command whose
-// RunE parses flags onto the supplied target's flagset and calls
-// the target's Run/RunE directly. This avoids re-entering cobra's
-// dispatcher, which would otherwise resolve `os.Args` back through
-// the wrapper and recurse to a stack overflow — a bug that bit the
-// earlier `target.SetArgs(args); target.Execute()` shape (used in
-// the original #2866 pty wrapper) once both wrapper and target
-// shared a parent cobra tree.
-//
-// --help is intercepted up front since cobra's flag-help shortcut
-// only fires through the dispatcher; without the intercept,
-// `app skysocks serve --help` would hit ParseFlags's "help
-// requested" error path and never reach the target's help text.
-func newSkysocksDelegateCmd(use, short string, target *cobra.Command) *cobra.Command {
-	return &cobra.Command{
-		Use:                   use,
-		Short:                 short,
-		DisableFlagParsing:    true,
-		SilenceErrors:         true,
-		SilenceUsage:          true,
-		DisableSuggestions:    true,
-		DisableFlagsInUseLine: true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			for _, a := range args {
-				if a == "--help" || a == "-h" {
-					return target.Help()
-				}
-			}
-			if err := target.ParseFlags(args); err != nil {
-				return err
-			}
-			remaining := target.Flags().Args()
-			if target.RunE != nil {
-				return target.RunE(target, remaining)
-			}
-			if target.Run != nil {
-				target.Run(target, remaining)
-			}
-			return nil
-		},
-	}
 }

--- a/cmd/skywire/commands/vpn_pair.go
+++ b/cmd/skywire/commands/vpn_pair.go
@@ -1,0 +1,44 @@
+// Package commands cmd/skywire/commands/vpn_pair.go — unified
+// `skywire app vpn {serve,client}` parent that thin-wraps the
+// existing vpn-server / vpn-client RootCmds.
+//
+// Same pattern as cmd/skywire/commands/skysocks_pair.go (#2873).
+// Wrapper invokes target.Run/RunE directly rather than re-entering
+// cobra's dispatcher to avoid the os.Args-resolves-back-through-
+// the-wrapper recursion bug.
+//
+// Launcher app-name registry is unchanged: config.json's `apps[]`
+// entries still reference "vpn-server" / "vpn-client" and the
+// launcher's GetApp() lookup hits the same RunFuncs.
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	vpnc "github.com/skycoin/skywire/cmd/apps/vpn-client/commands"
+	vpns "github.com/skycoin/skywire/cmd/apps/vpn-server/commands"
+)
+
+var vpnPairCmd = &cobra.Command{
+	Use:                   "vpn",
+	Short:                 "skywire VPN — pair of server (serve) and client (client) subcommands",
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+}
+
+func init() {
+	vpnPairCmd.AddCommand(
+		newDelegateAppCmd(
+			"serve",
+			"Run the VPN server (was: `skywire app vpn-server`)",
+			vpns.RootCmd,
+		),
+		newDelegateAppCmd(
+			"client",
+			"Run the VPN client (was: `skywire app vpn-client`)",
+			vpnc.RootCmd,
+		),
+	)
+}


### PR DESCRIPTION
Same pattern as #2873 (skysocks). Plus extracts the shared delegating-wrapper helper to app_delegate.go so skysocks/vpn/skynet pairs can all use it. Legacy paths kept hidden; launcher registry unchanged.