### PR TITLE
refactor(apps): skynet pair collapse (final pair binary)

### DIFF
--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -43,6 +43,7 @@ func init() {
 		pty.RootCmd,
 		skysocksPairCmd,
 		vpnPairCmd,
+		skynetPairCmd,
 	)
 	// Install flag-aware `help` (supports -r/-t/-d modes) on the
 	// Install flag-aware `help` + coloredcobra styling on every
@@ -102,8 +103,14 @@ func init() {
 	ss.RootCmd.Use = "skysocks-srv"
 	ss.RootCmd.Hidden = true
 	sc.RootCmd.Use = "skychat"
+	// skynet pair (server + client) collapsed under
+	// `skywire app skynet {srv,client}`. Legacy direct invocations
+	// stay mounted but Hidden — names already use the -srv / -client
+	// suffix so no collision with the new "skynet" pair name.
 	sn.RootCmd.Use = "skynet-srv"
+	sn.RootCmd.Hidden = true
 	snc.RootCmd.Use = "skynet-client"
+	snc.RootCmd.Hidden = true
 
 	// --all reveals hidden subcommands (e.g., autoconfig)
 	RootCmd.Flags().BoolVar(&skyShowAll, "all", false, "show all subcommands (including hidden)")

--- a/cmd/skywire/commands/skynet_pair.go
+++ b/cmd/skywire/commands/skynet_pair.go
@@ -1,0 +1,45 @@
+// Package commands cmd/skywire/commands/skynet_pair.go — unified
+// `skywire app skynet {srv,client}` parent that thin-wraps the
+// existing skynet-srv / skynet-client RootCmds.
+//
+// Same pattern as skysocks_pair.go (#2873) and vpn_pair.go (#2874).
+// Subcommand names are `srv` and `client` (matching the legacy
+// app-name suffixes) rather than `serve` and `client` — operators
+// already think of these as "skynet srv" / "skynet client" since
+// the existing standalone names follow that convention.
+//
+// Launcher app-name registry is unchanged: config.json's `apps[]`
+// entries still reference "skynet" / "skynet-client" and the
+// launcher's GetApp() lookup hits the same RunFuncs.
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	snc "github.com/skycoin/skywire/cmd/apps/skynet-client/commands"
+	sn "github.com/skycoin/skywire/cmd/apps/skynet/commands"
+)
+
+var skynetPairCmd = &cobra.Command{
+	Use:                   "skynet",
+	Short:                 "skywire port forwarding — pair of server (srv) and client (client) subcommands",
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableSuggestions:    true,
+	DisableFlagsInUseLine: true,
+}
+
+func init() {
+	skynetPairCmd.AddCommand(
+		newDelegateAppCmd(
+			"srv",
+			"Run the skynet port-forwarding server (was: `skywire app skynet-srv`)",
+			sn.RootCmd,
+		),
+		newDelegateAppCmd(
+			"client",
+			"Run the skynet port-forwarding client (was: `skywire app skynet-client`)",
+			snc.RootCmd,
+		),
+	)
+}


### PR DESCRIPTION
Same pattern as #2873 (skysocks) and #2874 (vpn). Final pair collapse — after this, `skywire app --help` shows five clean items (pty / skychat / skynet / skysocks / vpn) instead of the eight separate entries before. Launcher registry unchanged.