### PR TITLE
refactor(visorconfig): rename Dmsgpty → Pty w/ JSON backward-compat

### DIFF
--- a/cmd/apps/pty/commands/pty.go
+++ b/cmd/apps/pty/commands/pty.go
@@ -27,7 +27,7 @@
 // binary needs that surface intact); the skywire-binary import
 // hides the dmsg-pty group so help output funnels operators here.
 // The package-level code identifiers (`pkg/dmsg/dmsgpty/`,
-// `conf.Dmsgpty`, etc.) are unchanged — deeper rename is a
+// `conf.Pty`, etc.) are unchanged — deeper rename is a
 // follow-up PR.
 package commands
 

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -911,7 +911,7 @@ func readExistingConfig(log *logging.Logger) {
 					for _, j := range oldConf.Hypervisors {
 						hypervisorPKs = hypervisorPKs + "," + fmt.Sprintf("\t%s\n", j)
 					}
-					for _, j := range oldConf.Dmsgpty.Whitelist {
+					for _, j := range oldConf.Pty.Whitelist {
 						dmsgptyWlPKs = dmsgptyWlPKs + "," + fmt.Sprintf("\t%s\n", j)
 					}
 				}
@@ -1190,7 +1190,7 @@ func configureLauncher(log *logging.Logger) {
 	if isTestEnv {
 		dmsgptyAddr = filepath.Join(os.TempDir(), "dmsgpty-test.sock")
 	}
-	conf.Dmsgpty = &visorconfig.Dmsgpty{
+	conf.Pty = &visorconfig.Pty{
 		DmsgPort: skyenv.DmsgPtyPort,
 		CLINet:   skyenv.DmsgPtyCLINet,
 		CLIAddr:  dmsgptyAddr,
@@ -1362,7 +1362,7 @@ func configureHypervisor(log *logging.Logger) {
 	}
 
 	// Manipulate dmsgpty whitelist PKs
-	conf.Dmsgpty.Whitelist = make([]cipher.PubKey, 0)
+	conf.Pty.Whitelist = make([]cipher.PubKey, 0)
 	if dmsgptyWlPKs != "" {
 		keys := strings.Split(dmsgptyWlPKs, ",")
 		for _, key := range keys {
@@ -1371,7 +1371,7 @@ func configureHypervisor(log *logging.Logger) {
 				if err != nil {
 					log.WithError(err).Fatalf("Failed to parse Dmsgpty Whitelist public key: %s.", key)
 				}
-				conf.Dmsgpty.Whitelist = append(conf.Dmsgpty.Whitelist, cipher.PubKey(keyParsed))
+				conf.Pty.Whitelist = append(conf.Pty.Whitelist, cipher.PubKey(keyParsed))
 			}
 		}
 	}

--- a/pkg/skywireconfig/genvisor/marshal_compat_native.go
+++ b/pkg/skywireconfig/genvisor/marshal_compat_native.go
@@ -248,9 +248,9 @@ func marshalV1Native(w *strings.Builder, v *visorconfig.V1, indent int) {
 		marshalDmsgNative(w, v.Dmsg, o.indent+1)
 	}
 
-	if v.Dmsgpty != nil {
+	if v.Pty != nil {
 		o.field("dmsgpty")
-		marshalDmsgptyNative(w, v.Dmsgpty, o.indent+1)
+		marshalPtyNative(w, v.Pty, o.indent+1)
 	}
 	if v.Dmsgscp != nil {
 		o.field("dmsgscp")
@@ -567,7 +567,7 @@ func marshalDiscServerNative(w *strings.Builder, s *disc.Server, indent int) {
 	o.close()
 }
 
-func marshalDmsgptyNative(w *strings.Builder, d *visorconfig.Dmsgpty, indent int) {
+func marshalPtyNative(w *strings.Builder, d *visorconfig.Pty, indent int) {
 	o := newObjNative(w, indent)
 	o.field("dmsg_port")
 	writeUintNative(w, uint64(d.DmsgPort))

--- a/pkg/skywireconfig/genvisor/marshal_js.go
+++ b/pkg/skywireconfig/genvisor/marshal_js.go
@@ -230,9 +230,9 @@ func marshalV1(w *strings.Builder, v *visorconfig.V1, indent int) {
 		marshalDmsg(w, v.Dmsg, o.indent+1)
 	}
 
-	if v.Dmsgpty != nil {
+	if v.Pty != nil {
 		o.field("dmsgpty")
-		marshalDmsgpty(w, v.Dmsgpty, o.indent+1)
+		marshalPty(w, v.Pty, o.indent+1)
 	}
 	if v.Dmsgscp != nil {
 		o.field("dmsgscp")
@@ -549,7 +549,7 @@ func marshalDiscServer(w *strings.Builder, s *disc.Server, indent int) {
 	o.close()
 }
 
-func marshalDmsgpty(w *strings.Builder, d *visorconfig.Dmsgpty, indent int) {
+func marshalPty(w *strings.Builder, d *visorconfig.Pty, indent int) {
 	o := newObj(w, indent)
 	o.field("dmsg_port")
 	writeUint(w, uint64(d.DmsgPort))

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -517,7 +517,7 @@ func (v *Visor) Ports() (map[string]PortDetail, error) {
 		ports["hypervisor"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Hypervisor.HTTPAddr, ":")[1]), Type: "TCP"}
 	}
 
-	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(v.conf.Dmsgpty.DmsgPort), Type: "DMSG"}
+	ports["dmsg_pty"] = PortDetail{Port: fmt.Sprint(v.conf.Pty.DmsgPort), Type: "DMSG"}
 	ports["cli_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.CLIAddr, ":")[1]), Type: "TCP"}
 	ports["proc_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.Launcher.ServerAddr, ":")[1]), Type: "TCP"}
 	ports["stcp_addr"] = PortDetail{Port: fmt.Sprint(strings.Split(v.conf.STCP.ListeningAddress, ":")[1]), Type: "TCP"}

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -282,8 +282,8 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 
 	// setup local PTY using direct connection (bypasses DMSG for local visor)
 	hv.mu.Lock()
-	if hv.visor != nil && hv.visor.conf.Dmsgpty != nil && hv.visor.conf.Dmsgpty.CLINet != "" {
-		hv.selfConn.PtyUI = setupLocalPtyUI(hv.visor.conf.Dmsgpty.CLINet, hv.visor.conf.Dmsgpty.CLIAddr)
+	if hv.visor != nil && hv.visor.conf.Pty != nil && hv.visor.conf.Pty.CLINet != "" {
+		hv.selfConn.PtyUI = setupLocalPtyUI(hv.visor.conf.Pty.CLINet, hv.visor.conf.Pty.CLIAddr)
 	} else {
 		// Fallback to DMSG if local CLI config not available
 		hv.selfConn.PtyUI = setupDmsgPtyUI(hv.dmsgC, hv.c.PK)

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -53,7 +53,7 @@ func initLauncher(_ context.Context, v *Visor, _ *logging.Logger) error {
 	// Phase 3.3 — pty as Internal app. RestartPolicy=Always so
 	// `cli visor app stop pty` is a no-op in practice (auto-restart
 	// triggers after a 1s backoff). The only real disable path is
-	// removing conf.Dmsgpty and restarting the visor — exactly the
+	// removing conf.Pty and restarting the visor — exactly the
 	// pre-Phase-3.3 disable path.
 	if v.dmsgPty != nil && !appsContains(apps, "pty") {
 		apps = append(apps, appserver.AppConfig{
@@ -562,8 +562,8 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		for _, pk := range v.conf.Hypervisors {
 			authorizedPKs[pk] = true
 		}
-		if v.conf.Dmsgpty != nil {
-			for _, pk := range v.conf.Dmsgpty.Whitelist {
+		if v.conf.Pty != nil {
+			for _, pk := range v.conf.Pty.Whitelist {
 				authorizedPKs[pk] = true
 			}
 		}
@@ -638,8 +638,8 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		v.pushCloseStack("transport_rpc.mux", v.transportRPCMux.Close)
 
 		whitelistPKs := append([]cipher.PubKey{}, v.conf.Hypervisors...)
-		if v.conf.Dmsgpty != nil {
-			whitelistPKs = append(whitelistPKs, v.conf.Dmsgpty.Whitelist...)
+		if v.conf.Pty != nil {
+			whitelistPKs = append(whitelistPKs, v.conf.Pty.Whitelist...)
 		}
 		if len(whitelistPKs) > 0 {
 			tpRPCS, tpRPCErr := newRPCServer(v, "TransportRPC")
@@ -667,8 +667,8 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		for _, pk := range v.conf.Hypervisors {
 			authorizedPKs[pk] = true
 		}
-		if v.conf.Dmsgpty != nil {
-			for _, pk := range v.conf.Dmsgpty.Whitelist {
+		if v.conf.Pty != nil {
+			for _, pk := range v.conf.Pty.Whitelist {
 				authorizedPKs[pk] = true
 			}
 		}

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -591,9 +591,9 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 	if v.conf.Hypervisors != nil {
 		whitelistedPKs = append(whitelistedPKs, v.conf.Hypervisors...)
 	}
-	if v.conf.Dmsgpty != nil {
-		if v.conf.Dmsgpty.Whitelist != nil {
-			whitelistedPKs = append(whitelistedPKs, v.conf.Dmsgpty.Whitelist...)
+	if v.conf.Pty != nil {
+		if v.conf.Pty.Whitelist != nil {
+			whitelistedPKs = append(whitelistedPKs, v.conf.Pty.Whitelist...)
 		}
 	}
 
@@ -629,10 +629,10 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 	// in-process. When no CLI socket is configured we fall back to
 	// dialing our own dmsg client at DmsgPtyPort, which works the
 	// same way the hypervisor's per-PK ptyUI does for remote visors.
-	if v.conf.Dmsgpty != nil {
+	if v.conf.Pty != nil {
 		var ptyDialer pty.UIDialer
-		if v.conf.Dmsgpty.CLINet != "" {
-			ptyDialer = pty.NetUIDialer(v.conf.Dmsgpty.CLINet, v.conf.Dmsgpty.CLIAddr)
+		if v.conf.Pty.CLINet != "" {
+			ptyDialer = pty.NetUIDialer(v.conf.Pty.CLINet, v.conf.Pty.CLIAddr)
 		} else {
 			ptyDialer = pty.DmsgUIDialer(dmsgC, dmsg.Addr{PK: v.conf.PK, Port: skyenv.DmsgPtyPort})
 		}
@@ -642,8 +642,8 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 		})
 		ptyWL := []cipher.PubKey{v.conf.PK}
 		ptyWL = append(ptyWL, v.conf.Hypervisors...)
-		if v.conf.Dmsgpty.Whitelist != nil {
-			ptyWL = append(ptyWL, v.conf.Dmsgpty.Whitelist...)
+		if v.conf.Pty.Whitelist != nil {
+			ptyWL = append(ptyWL, v.conf.Pty.Whitelist...)
 		}
 		lsAPI.SetPtyHandler(ptyHandler, ptyWL)
 		logger.WithField("whitelist_size", len(ptyWL)).Info("Mounted /pty on logserver")
@@ -814,7 +814,7 @@ func initDmsgTrackers(_ context.Context, v *Visor, _ *logging.Logger) error {
 //
 //gocyclo:ignore
 func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
-	conf := v.conf.Dmsgpty
+	conf := v.conf.Pty
 
 	if conf == nil {
 		log.Debug("'dmsgpty' is not configured, skipping.")
@@ -827,8 +827,8 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 			conf.CLIAddr = pty.ParseWindowsEnv(conf.CLIAddr)
 		}
 
-		if err := osutil.UnlinkSocketFiles(v.conf.Dmsgpty.CLIAddr); err != nil {
-			log.WithError(err).Errorf("Insufficient permissions to unlink socket file %q", v.conf.Dmsgpty.CLIAddr)
+		if err := osutil.UnlinkSocketFiles(v.conf.Pty.CLIAddr); err != nil {
+			log.WithError(err).Errorf("Insufficient permissions to unlink socket file %q", v.conf.Pty.CLIAddr)
 			return err
 		}
 	}
@@ -836,7 +836,7 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 	wl := pty.NewMemoryWhitelist()
 
 	// Initialize the dmsgpty whitelist
-	if err := wl.Add(v.conf.Dmsgpty.Whitelist...); err != nil {
+	if err := wl.Add(v.conf.Pty.Whitelist...); err != nil {
 		return err
 	}
 

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -83,7 +83,7 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 	}
 	conf.ShutdownTimeout = DefaultTimeout
 
-	conf.Dmsgpty = &Dmsgpty{
+	conf.Pty = &Pty{
 		DmsgPort: skyenv.DmsgPtyPort,
 		CLINet:   skyenv.DmsgPtyCLINet,
 		CLIAddr:  defaultDmsgPtyCLIAddr(),

--- a/pkg/visor/visorconfig/config_compat.go
+++ b/pkg/visor/visorconfig/config_compat.go
@@ -1,0 +1,44 @@
+// Package visorconfig pkg/visor/visorconfig/config_compat.go —
+// backward-compat JSON unmarshaling for renamed config keys.
+//
+// V1.Pty (canonical) corresponds to operator-config-json's "pty"
+// key. The legacy key "dmsgpty" is still accepted on load so that
+// existing operator config.json files don't break across the
+// rename. Marshaling always emits the canonical "pty" key — V1's
+// struct tag is `json:"pty,omitempty"`.
+//
+// When both keys appear, the canonical "pty" wins. When neither
+// appears, V1.Pty stays nil (the visor's init path treats nil as
+// "pty subsystem disabled").
+package visorconfig
+
+import (
+	"encoding/json"
+)
+
+// v1Alias avoids unbounded recursion in V1.UnmarshalJSON. Embedding
+// V1 directly would call UnmarshalJSON again; aliasing V1 to a
+// new type with no methods uses the struct-tag-driven default
+// unmarshaler.
+type v1Alias V1
+
+// UnmarshalJSON implements json.Unmarshaler for V1. Reads the
+// canonical schema via the alias, then patches V1.Pty from the
+// legacy "dmsgpty" key if the canonical "pty" key was absent.
+func (v *V1) UnmarshalJSON(data []byte) error {
+	var alias v1Alias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*v = V1(alias)
+
+	if v.Pty == nil {
+		var legacy struct {
+			Dmsgpty *Pty `json:"dmsgpty"`
+		}
+		if err := json.Unmarshal(data, &legacy); err == nil && legacy.Dmsgpty != nil {
+			v.Pty = legacy.Dmsgpty
+		}
+	}
+	return nil
+}

--- a/pkg/visor/visorconfig/config_compat_test.go
+++ b/pkg/visor/visorconfig/config_compat_test.go
@@ -1,0 +1,72 @@
+// Package visorconfig pkg/visor/visorconfig/config_compat_test.go
+// — pins the legacy "dmsgpty" → V1.Pty migration.
+package visorconfig
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPtyLegacyKeyAccepted: an operator config.json carrying the
+// pre-rename `"dmsgpty"` key still populates V1.Pty after the
+// rename. Verifies the UnmarshalJSON fallback path in
+// config_compat.go.
+func TestPtyLegacyKeyAccepted(t *testing.T) {
+	const raw = `{"dmsgpty": {"dmsg_port": 22, "cli_network": "unix", "cli_address": "/tmp/dmsgpty.sock", "whitelist": [], "ssh_listen": ":2022"}}`
+	var v V1
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if v.Pty == nil {
+		t.Fatal("V1.Pty was nil; legacy dmsgpty key did not populate it")
+	}
+	if v.Pty.DmsgPort != 22 {
+		t.Errorf("Pty.DmsgPort = %d, want 22", v.Pty.DmsgPort)
+	}
+	if v.Pty.SshListen != ":2022" {
+		t.Errorf("Pty.SshListen = %q, want %q", v.Pty.SshListen, ":2022")
+	}
+}
+
+// TestPtyCanonicalKeyWins: when both "pty" and "dmsgpty" appear,
+// the canonical "pty" key wins. Defensive — shouldn't happen in
+// practice (operators have one or the other) but pin the behavior.
+func TestPtyCanonicalKeyWins(t *testing.T) {
+	const raw = `{"pty": {"dmsg_port": 22, "ssh_listen": ":canonical"}, "dmsgpty": {"dmsg_port": 99, "ssh_listen": ":legacy"}}`
+	var v V1
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if v.Pty == nil {
+		t.Fatal("V1.Pty was nil")
+	}
+	if v.Pty.SshListen != ":canonical" {
+		t.Errorf("canonical key didn't win: SshListen = %q, want :canonical", v.Pty.SshListen)
+	}
+}
+
+// TestPtyMarshalsAsPty: round-trip — set V1.Pty, marshal, confirm
+// the JSON output uses the canonical "pty" key (not "dmsgpty").
+func TestPtyMarshalsAsPty(t *testing.T) {
+	v := V1{Pty: &Pty{DmsgPort: 22, SshListen: ":2022"}}
+	data, err := json.Marshal(&v)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	str := string(data)
+	if !contains(str, `"pty":`) {
+		t.Errorf("expected canonical \"pty\" key in output, got: %s", str)
+	}
+	if contains(str, `"dmsgpty":`) {
+		t.Errorf("legacy \"dmsgpty\" key leaked into marshal output: %s", str)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -16,7 +16,7 @@ type V1 struct {
 	mu sync.RWMutex
 
 	Dmsg          *dmsgspec.DmsgConfig `json:"dmsg"`
-	Dmsgpty       *Dmsgpty             `json:"dmsgpty,omitempty"`
+	Pty           *Pty                 `json:"pty,omitempty"`
 	Dmsgscp       *Dmsgscp             `json:"dmsgscp,omitempty"`
 	UIServer      *UIServer            `json:"ui_server,omitempty"`
 	LogServer     *LogServer           `json:"log_server,omitempty"`
@@ -91,8 +91,11 @@ type Skychat struct {
 	GroupHistoryDB string `json:"group_history_db,omitempty"`
 }
 
-// Dmsgpty configures the dmsgpty-host.
-type Dmsgpty struct {
+// Pty configures the pseudoterminal subsystem (formerly Dmsgpty).
+// The struct shape is unchanged across the rename; the V1.Pty
+// field's JSON tag accepts both "pty" (canonical) and "dmsgpty"
+// (legacy) via V1.UnmarshalJSON in config_compat.go.
+type Pty struct {
 	DmsgPort  uint16          `json:"dmsg_port"`
 	CLINet    string          `json:"cli_network"`
 	CLIAddr   string          `json:"cli_address"`
@@ -129,7 +132,7 @@ type Dmsgpty struct {
 // The host is on by default — access is gated by the same whitelist
 // that dmsgpty uses (a peer's PK must be on the list to be served).
 // Operators who want to disable it entirely set Disabled=true. When
-// Whitelist is empty the host reuses Dmsgpty.Whitelist so trusting
+// Whitelist is empty the host reuses Pty.Whitelist so trusting
 // a peer for pty implicitly trusts them for file transfer too.
 //
 // The host listens on BOTH dmsg and the skywire router (skynet) at
@@ -151,7 +154,7 @@ type Dmsgscp struct {
 	// <local_path>/scp-root is used.
 	RootDir string `json:"root_dir,omitempty"`
 	// Whitelist optionally overrides the dmsgpty whitelist. When
-	// nil or empty, init reuses Dmsgpty.Whitelist.
+	// nil or empty, init reuses Pty.Whitelist.
 	Whitelist []cipher.PubKey `json:"whitelist,omitempty"`
 }
 


### PR DESCRIPTION
Continues the dmsgpty → pty rename (after #2876's package move). Config struct + V1 field renamed; legacy "dmsgpty" JSON key still accepted via custom V1.UnmarshalJSON so operator config.json files don't break. Three new round-trip tests pin the migration. Marshal-side is canonical ("pty" key). Follow-ups: cmd/dmsg/dmsgpty-* binary renames; wire-protocol constants stay as-is for peer compat.