### PR TITLE
fix(visorconfig): V1.UnmarshalJSON must not wipe preset *Common

### DIFF
--- a/pkg/visor/visorconfig/config_compat.go
+++ b/pkg/visor/visorconfig/config_compat.go
@@ -25,8 +25,14 @@ type v1Alias V1
 // UnmarshalJSON implements json.Unmarshaler for V1. Reads the
 // canonical schema via the alias, then patches V1.Pty from the
 // legacy "dmsgpty" key if the canonical "pty" key was absent.
+//
+// The alias is seeded with *v (not zero) so caller-populated
+// fields like the embedded *Common — set by MakeBaseConfig before
+// the JSON decode runs in ReadRaw — survive the unmarshal. A
+// `var alias v1Alias` zero-initializer would wipe *Common to nil
+// and panic the visor's first conf.MasterLogger() call.
 func (v *V1) UnmarshalJSON(data []byte) error {
-	var alias v1Alias
+	alias := v1Alias(*v)
 	if err := json.Unmarshal(data, &alias); err != nil {
 		return err
 	}

--- a/pkg/visor/visorconfig/config_compat_test.go
+++ b/pkg/visor/visorconfig/config_compat_test.go
@@ -45,6 +45,22 @@ func TestPtyCanonicalKeyWins(t *testing.T) {
 	}
 }
 
+// TestPtyUnmarshalPreservesPresetCommon: the loader pre-populates
+// V1.Common before calling json.Unmarshal (see ReadRaw in read.go).
+// V1.UnmarshalJSON must NOT wipe Common — visor.run panics on the
+// first conf.MasterLogger() call if it does. Regression test for
+// the "var alias v1Alias" zero-init mistake.
+func TestPtyUnmarshalPreservesPresetCommon(t *testing.T) {
+	sentinel := &Common{Version: "preset-sentinel"}
+	v := V1{Common: sentinel}
+	if err := json.Unmarshal([]byte(`{"pty": {"dmsg_port": 22}}`), &v); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if v.Common != sentinel {
+		t.Fatalf("preset Common was overwritten by UnmarshalJSON")
+	}
+}
+
 // TestPtyMarshalsAsPty: round-trip — set V1.Pty, marshal, confirm
 // the JSON output uses the canonical "pty" key (not "dmsgpty").
 func TestPtyMarshalsAsPty(t *testing.T) {


### PR DESCRIPTION
Hotfix for #2877. The custom UnmarshalJSON used zero-init for the alias and overwrote *v wholesale, wiping the *Common that ReadRaw pre-populates via MakeBaseConfig. First conf.MasterLogger() call in visor.run then nil-panicked at startup. Fix: seed alias from *v so preset pointer fields survive. Regression test added (TestPtyUnmarshalPreservesPresetCommon).