### PR TITLE
feat(router): integrate routing policy into dial path (RFC #2882)

### DIFF
--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -1,0 +1,84 @@
+// Package router pkg/router/dial_hook.go — operator-programmable
+// routing policy integration point. The router calls a configured
+// DialHook before each DialRoutes invocation; the hook can adjust
+// the per-dial knobs (MuxRoutes, MinHops) or refuse the dial.
+//
+// The hook is optional. With no hook configured (Config.DialHook
+// is nil), DialRoutes behaves identically to its pre-integration
+// shape. This keeps the integration zero-cost when no operator
+// policy is in play.
+//
+// The hook is failure-safe: any error from BeforeDial is treated
+// as "no adjustment" and dialing proceeds with the caller's
+// original opts. A buggy or panicking policy cannot break
+// dialing.
+package router
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// DialHook is called by DialRoutes before route setup. Returns
+// adjustments that the router applies to the dial's opts.
+//
+// Implementations live in pkg/router/policy and elsewhere. The
+// interface here keeps pkg/router free of the Starlark machinery.
+type DialHook interface {
+	// BeforeDial is invoked synchronously before route setup. Its
+	// return value adjusts the dial's opts in-place. Returning the
+	// zero DialAdjustment + nil error means "no override; proceed
+	// with the caller's opts unchanged."
+	//
+	// Implementations MUST return quickly — DialRoutes blocks on
+	// this call before the route-finder query begins. Budget is
+	// the same as the policy's per-call timeout (default 50ms).
+	BeforeDial(ctx context.Context, info DialInfo) (DialAdjustment, error)
+}
+
+// DialInfo summarizes the dial for the hook. It's a flat struct
+// rather than passing DialOptions so the hook stays decoupled
+// from DialOptions' field churn.
+type DialInfo struct {
+	AppName string
+	PeerPK  cipher.PubKey
+	LPort   routing.Port
+	RPort   routing.Port
+}
+
+// DialAdjustment is the hook's return value. Each field is a
+// "override this if non-zero" hint; zero values mean "no change
+// for this knob." Fallback can be set to "drop" to refuse the
+// dial entirely.
+type DialAdjustment struct {
+	// MuxRoutes, when > 0, overrides DialOptions.MuxRoutes for
+	// this dial.
+	MuxRoutes int
+
+	// MinHops, when > 0, overrides DialOptions.MinHops for this
+	// dial.
+	MinHops int
+
+	// Fallback, when "drop", causes DialRoutes to refuse the
+	// dial with ErrDialPolicyDropped. Any other value is
+	// ignored (the dial proceeds normally).
+	Fallback string
+}
+
+// applyAdjustment is a helper used inside DialRoutes — applies
+// the hook's non-zero fields to opts. Returns ErrDialPolicyDropped
+// when the hook said "drop."
+func applyAdjustment(opts *DialOptions, adj DialAdjustment) error {
+	if adj.Fallback == "drop" {
+		return ErrDialPolicyDropped
+	}
+	if adj.MuxRoutes > 0 {
+		opts.MuxRoutes = adj.MuxRoutes
+	}
+	if adj.MinHops > 0 {
+		opts.MinHops = adj.MinHops
+	}
+	return nil
+}

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -1,0 +1,57 @@
+// Package policy pkg/router/policy/hook.go — adapter that turns
+// a Loader (the operator's Starlark policy file) into a
+// router.DialHook the router can invoke per dial.
+//
+// Living in the policy package keeps the router package free of
+// the Starlark machinery; pkg/router only depends on the small
+// DialHook interface in dial_hook.go.
+package policy
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/router"
+)
+
+// Hook adapts a *Loader to the router.DialHook interface. Pass
+// to router.Config.DialHook to plug a routing policy into the
+// dial path.
+type Hook struct {
+	loader *Loader
+}
+
+// NewHook wraps a Loader as a DialHook.
+func NewHook(l *Loader) *Hook { return &Hook{loader: l} }
+
+// BeforeDial implements router.DialHook. Constructs a
+// RoutingContext from the per-dial DialInfo, invokes the loader,
+// projects the returned RouteSpec into a DialAdjustment the
+// router can consume.
+//
+// The loader's failure-mode wiring (Fallback vs. Drop) determines
+// what the policy script's failure looks like to the router:
+// - FailureFallback (default): a broken script returns an empty
+//   RouteSpec → empty DialAdjustment → router proceeds with the
+//   caller's original opts. No error surfaced.
+// - FailureDrop: errors propagate up here as a real error; the
+//   router sees an error from BeforeDial and logs it but still
+//   proceeds (failure-safe at the router layer too).
+func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.DialAdjustment, error) {
+	if h.loader == nil || !h.loader.IsActive() {
+		return router.DialAdjustment{}, nil
+	}
+	rctx := RoutingContext{
+		App:    info.AppName,
+		PeerPK: info.PeerPK.Hex(),
+		Port:   uint16(info.RPort),
+	}
+	spec, err := h.loader.Decide(ctx, rctx, nil)
+	if err != nil {
+		return router.DialAdjustment{}, err
+	}
+	return router.DialAdjustment{
+		MuxRoutes: spec.Mux,
+		MinHops:   spec.MinHops,
+		Fallback:  spec.Fallback,
+	}, nil
+}

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -1,0 +1,139 @@
+// Package policy pkg/router/policy/hook_test.go — pins the
+// Loader → DialHook adapter. Tests the loader-side semantics
+// (script defines decide_route returning mux/min_hops/fallback)
+// translate cleanly into the router-facing DialAdjustment shape.
+package policy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+func TestHook_AdjustsMuxAndMinHops(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    if ctx.app == "vpn-client":
+        return RouteSpec(mux = 4, min_hops = 2)
+    return RouteSpec()
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+
+	pk := cipher.PubKey{}
+	pk[0] = 0x02 // any non-null PK
+
+	cases := []struct {
+		app          string
+		wantMux      int
+		wantMinHops  int
+		wantFallback string
+	}{
+		{"vpn-client", 4, 2, ""},
+		{"skychat", 0, 0, ""},
+	}
+	for _, tc := range cases {
+		adj, err := h.BeforeDial(context.Background(), router.DialInfo{
+			AppName: tc.app,
+			PeerPK:  pk,
+			LPort:   routing.Port(1),
+			RPort:   routing.Port(2),
+		})
+		if err != nil {
+			t.Errorf("BeforeDial(%s): %v", tc.app, err)
+			continue
+		}
+		if adj.MuxRoutes != tc.wantMux {
+			t.Errorf("app=%s: MuxRoutes=%d, want %d", tc.app, adj.MuxRoutes, tc.wantMux)
+		}
+		if adj.MinHops != tc.wantMinHops {
+			t.Errorf("app=%s: MinHops=%d, want %d", tc.app, adj.MinHops, tc.wantMinHops)
+		}
+		if adj.Fallback != tc.wantFallback {
+			t.Errorf("app=%s: Fallback=%q, want %q", tc.app, adj.Fallback, tc.wantFallback)
+		}
+	}
+}
+
+func TestHook_DropFallback(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    if ctx.app == "blocked-app":
+        return RouteSpec(fallback = "drop")
+    return RouteSpec()
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{
+		AppName: "blocked-app",
+		PeerPK:  pk,
+	})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.Fallback != "drop" {
+		t.Errorf("Fallback=%q, want %q", adj.Fallback, "drop")
+	}
+}
+
+func TestHook_NoopLoader_ReturnsEmptyAdjustment(t *testing.T) {
+	loader, err := NewLoader("")
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{AppName: "x"})
+	if err != nil {
+		t.Errorf("BeforeDial: %v", err)
+	}
+	if adj.MuxRoutes != 0 || adj.MinHops != 0 || adj.Fallback != "" {
+		t.Errorf("noop loader: expected empty adjustment, got %+v", adj)
+	}
+}
+
+func TestHook_DropMode_ErrorPropagates(t *testing.T) {
+	// Script that always errors. With FailureDrop, the loader
+	// propagates the error; the hook surfaces it as a non-nil
+	// error from BeforeDial. Router-side, that's logged and
+	// the dial proceeds with unchanged opts (the router's own
+	// failure-safety; see init_router.go).
+	src := `
+def decide_route(ctx, candidates):
+    return 1 / 0
+`
+	loader, err := NewLoader(src, WithFailureMode(FailureDrop))
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	_, err = h.BeforeDial(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk})
+	if err == nil {
+		t.Fatal("expected non-nil error in drop mode")
+	}
+	if !errors.Is(err, err) { // just exercises the path; errors.Is here is trivially true
+		t.Skip()
+	}
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -50,6 +50,13 @@ var (
 	// ErrRemoteEmptyPK occurs when the specified remote public key is empty.
 	ErrRemoteEmptyPK = errors.New("empty remote public key")
 
+	// ErrDialPolicyDropped is returned by DialRoutes when the
+	// configured DialHook's BeforeDial returns Fallback="drop".
+	// Operators see this as the explicit signal that their
+	// routing policy refused this dial; it's distinct from any
+	// route-finder failure or transport error.
+	ErrDialPolicyDropped = errors.New("dial refused by routing policy")
+
 	// ErrNoTransportFound is returned when not even one transport is found.
 	ErrNoTransportFound = errors.New("no transport found")
 )
@@ -86,6 +93,18 @@ type Config struct {
 	// means no lookup is performed and entries are emitted untagged
 	// (the existing behavior).
 	AppLookup func(routing.Port) (string, bool)
+
+	// DialHook, when non-nil, is invoked before each DialRoutes
+	// to let an operator-supplied routing policy adjust the
+	// per-dial knobs (MuxRoutes, MinHops) or refuse the dial
+	// entirely. See pkg/router/dial_hook.go for the contract and
+	// pkg/router/policy/ for the Starlark-backed implementation
+	// the visor wires up when conf.Routing.PolicyPerDial is set.
+	//
+	// When nil (the default) DialRoutes behaves identically to
+	// its pre-integration shape — zero-cost when no policy is
+	// configured.
+	DialHook DialHook
 }
 
 // SetDefaults sets default values for certain empty values.

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -44,6 +44,42 @@ func (r *router) DialRoutes(
 		return nil, fmt.Errorf("failed to dial routes: %w", err)
 	}
 
+	// Operator-programmable routing policy hook (RFC #2882).
+	// When configured, the hook adjusts opts.MuxRoutes /
+	// opts.MinHops before route setup, and can refuse the dial
+	// entirely via Fallback="drop". A nil hook short-circuits
+	// the entire block so policy-free deployments pay zero cost.
+	if r.conf.DialHook != nil {
+		if opts == nil {
+			opts = &DialOptions{}
+		}
+		appName := ""
+		if opts != nil {
+			appName = opts.AppName
+		}
+		info := DialInfo{
+			AppName: appName,
+			PeerPK:  rPK,
+			LPort:   lPort,
+			RPort:   rPort,
+		}
+		if adj, hookErr := r.conf.DialHook.BeforeDial(ctx, info); hookErr != nil {
+			// Failure to evaluate the policy is non-fatal — the
+			// hook's own failure-mode wiring decides whether to
+			// return a "drop" adjustment or fall back to defaults.
+			// Here we just log it and proceed without adjustment.
+			log.WithError(hookErr).Debug("policy hook errored; proceeding without adjustment")
+		} else if err := applyAdjustment(opts, adj); err != nil {
+			log.WithField("policy_decision", "drop").Info("Dial refused by routing policy.")
+			return nil, err
+		} else if adj.MuxRoutes > 0 || adj.MinHops > 0 {
+			log.
+				WithField("policy_mux", adj.MuxRoutes).
+				WithField("policy_min_hops", adj.MinHops).
+				Debug("Routing policy adjusted dial opts.")
+		}
+	}
+
 	if r.conf.MinHops == 0 {
 		log.Error("Routing disabled. (minhop=0)")
 		return nil, fmt.Errorf("routing disabled. (minhop=0)")

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/router/policy"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -172,6 +173,31 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 			}
 			return v.procM.AppByPort(p)
 		},
+	}
+
+	// Operator-programmable routing policy (RFC #2882).
+	// When conf.Routing.PolicyPerDial is set, build a Loader,
+	// start its file-watcher if the path is file-backed, and
+	// plug it into the router as a DialHook. Nil hook = no
+	// integration cost when no policy is configured.
+	if v.conf.Routing.PolicyPerDial != "" {
+		policyLogger := func(format string, args ...interface{}) {
+			log.Infof(format, args...)
+		}
+		loader, perr := policy.NewLoader(
+			v.conf.Routing.PolicyPerDial,
+			policy.WithLogger(policyLogger),
+		)
+		if perr != nil {
+			log.WithError(perr).Warn("Routing policy failed to load; visor will run without policy.")
+		} else {
+			if werr := loader.Watch(policyLogger); werr != nil {
+				log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
+			}
+			rConf.DialHook = policy.NewHook(loader)
+			v.pushCloseStack("router.policy", loader.Close)
+			log.WithField("source", loader.Source()).Info("Routing policy active.")
+		}
 	}
 
 	routeSetupHooks := getRouteSetupHooks(ctx, v, log)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -397,6 +397,21 @@ type Routing struct {
 	// "stcpr", "sudph", "stcp", "dmsg". If empty, the built-in default order
 	// (stcpr > sudph > stcp > dmsg) is used. Types not listed here sort last.
 	TransportPreference []string `json:"transport_preference,omitempty"`
+
+	// PolicyPerDial is an optional operator-supplied routing
+	// policy script (Starlark, RFC #2882). Accepts either:
+	//   "@/path/to/policy.star"  — file-backed, hot-reloaded
+	//   "<inline script source>" — small inline policies
+	//   "" / unset                — no policy, built-in defaults
+	//
+	// The script's decide_route(ctx, candidates) function is
+	// called per dial; its returned RouteSpec adjusts MuxRoutes
+	// and MinHops, and can refuse the dial via fallback="drop".
+	//
+	// See docs/routing_policy_rfc.md for the policy DSL design,
+	// docs/examples/routing-policies/ for example scripts, and
+	// `skywire cli route policy test/bench` for iteration tools.
+	PolicyPerDial string `json:"policy_per_dial,omitempty"`
 }
 
 // UptimeTracker configures uptime tracker.


### PR DESCRIPTION
Wires the policy.Loader from #2884 into the router as a DialHook so operator-supplied Starlark policies actually affect dialing.

## Surface

- \`pkg/router/dial_hook.go\` — \`DialHook\` interface + \`DialInfo\` + \`DialAdjustment\`. Router-side keeps zero Starlark machinery.
- \`pkg/router/router.go\` — \`Config.DialHook\` field, \`ErrDialPolicyDropped\` error.
- \`pkg/router/router_dial.go\` — \`DialRoutes\` invokes the hook before route setup; non-zero Mux/MinHops override DialOptions; \`Fallback=\"drop\"\` returns ErrDialPolicyDropped; hook failures fall through to caller's original opts (failure-safe at the router layer too).
- \`pkg/router/policy/hook.go\` — \`Hook\` adapter wraps a \`*Loader\` as a \`router.DialHook\`.
- \`pkg/visor/visorconfig/v1.go\` — \`Routing.PolicyPerDial\` field.
- \`pkg/visor/init_router.go\` — when set, builds Loader + Watch + plugs into \`router.Config.DialHook\`. Load failure is non-fatal.

## Zero-cost when no policy configured

Empty \`PolicyPerDial\` string short-circuits everything; \`Config.DialHook\` stays nil; the per-dial nil-check skips the policy block entirely.

## Tests

23 tests across \`pkg/router/policy\` (scaffold + stdlib + loader + hook). The new hook tests pin:
- Mux+MinHops adjustment from script return
- Drop fallback signals
- Noop loader returns empty adjustment
- FailureDrop mode propagates the error

## Live smoke test plan

Set \`routing.policy_per_dial = \"@/etc/skywire/policies/test.star\"\` in skywire.json, restart visor, dial.