### PR TITLE
fix(rewards): pin UT cache to hist/ + bandwidth pool sender-pays + eligible-pair filter

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -816,41 +816,38 @@ Architectures:
 			return
 		}
 
-		// v2 bandwidth: aggregate per-edge sent bytes over the eligible
-		// set only. A transport contributes iff BOTH edges passed the
-		// pool 1 eligibility check above (valid survey, allowed arch,
-		// valid skyaddr, non-hypervisor, met transport requirement, met
-		// uptime). The bandwidthMap was empty during the eligibility
-		// loop in this path, so initial ni.Bandwidth=0 for everyone —
-		// we re-assign from the filtered aggregation here.
-		//
-		// Why this gate matters: pre-fix, a single eligible visor could
-		// dominate pool 2 by pushing traffic through transports to
-		// throwaway counterparties (wrong arch, no skyaddr, no survey,
-		// sub-75% uptime — none of which would ever earn rewards). The
-		// other-edge filter forecloses that pattern entirely.
+		// v2 bandwidth: aggregate per-edge sent bytes for any edge that
+		// itself passed the pool 1 eligibility check (valid survey,
+		// allowed arch, valid skyaddr, non-hypervisor, met transport
+		// requirement, met uptime). Each edge is evaluated independently
+		// — counterparty eligibility is irrelevant under sender-pays,
+		// because credit only ever flows to the sender. If A is eligible
+		// and sends to B (ineligible), A still earns SentA; B was never
+		// going to receive a share regardless. The bandwidthMap was
+		// empty during the eligibility loop in this path, so initial
+		// ni.Bandwidth=0 for everyone — we re-assign from the filtered
+		// aggregation here.
 		if requireBandwidth && bwTransports != nil {
 			eligibleSet := make(map[string]struct{}, len(nodesInfos1))
 			for _, ni := range nodesInfos1 {
 				eligibleSet[ni.PK] = struct{}{}
 			}
-			creditedTransports := 0
+			var creditedEdges int
 			for _, tp := range bwTransports {
-				if _, okA := eligibleSet[tp.A]; !okA {
-					continue
+				if _, ok := eligibleSet[tp.A]; ok {
+					bandwidthMap[tp.A] += tp.SentA
+					creditedEdges++
 				}
-				if _, okB := eligibleSet[tp.B]; !okB {
-					continue
+				if _, ok := eligibleSet[tp.B]; ok {
+					bandwidthMap[tp.B] += tp.SentB
+					creditedEdges++
 				}
-				bandwidthMap[tp.A] += tp.SentA
-				bandwidthMap[tp.B] += tp.SentB
-				creditedTransports++
 			}
 			for i := range nodesInfos1 {
 				nodesInfos1[i].Bandwidth = bandwidthMap[nodesInfos1[i].PK]
 			}
-			log.Infof("v2 bandwidth filter: %d/%d transports between two pool-1-eligible visors, sender-side credit applied",
-				creditedTransports, len(bwTransports))
+			log.Infof("v2 bandwidth filter: %d eligible sender-side credits applied across %d transports",
+				creditedEdges, len(bwTransports))
 		}
 
 		// Calculate daily reward amount

--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -658,20 +658,33 @@ Architectures:
 			}
 		}
 
-		// Load bandwidth data
+		// Load bandwidth data. Prefer v2 (per-transport sender-side
+		// totals) so we can credit each visor only for bytes it actually
+		// sent, and only on transports where the counterparty is also
+		// reward-eligible. Old v1 files (bare {pk:bytes} map) still
+		// parse — they're aggregated, full sent+recv, and credited to
+		// BOTH edges with no counterparty filter, matching the
+		// pre-v2 behavior so historical rerun stays bit-exact.
 		bandwidthMap := make(map[string]uint64)
+		var bwTransports []TransportBW // populated only for v2
 		if requireBandwidth {
 			bwFile := fmt.Sprintf("%s/%s_bandwidth.json", transportHistPath, wdate)
-			if data, err := os.ReadFile(bwFile); err == nil { //nolint:gosec
-				if err := json.Unmarshal(data, &bandwidthMap); err != nil {
-					log.Warnf("Failed to parse bandwidth file %s: %v", bwFile, err)
-					requireBandwidth = false
-				} else {
-					log.Infof("Loaded bandwidth data for %d visors from %s", len(bandwidthMap), bwFile)
-				}
-			} else {
+			data, readErr := os.ReadFile(bwFile) //nolint:gosec
+			switch {
+			case readErr != nil:
 				log.Warnf("Bandwidth file not found: %s (bandwidth pool will be skipped)", bwFile)
 				requireBandwidth = false
+			default:
+				var v2 BandwidthData
+				if err := json.Unmarshal(data, &v2); err == nil && v2.Version >= BandwidthDataVersion {
+					bwTransports = v2.Transports
+					log.Infof("Loaded v2 bandwidth data: %d transports from %s", len(bwTransports), bwFile)
+				} else if err := json.Unmarshal(data, &bandwidthMap); err == nil {
+					log.Infof("Loaded v1 bandwidth data for %d visors from %s (legacy aggregated format — no counterparty eligibility filter)", len(bandwidthMap), bwFile)
+				} else {
+					log.Warnf("Failed to parse bandwidth file %s: %v", bwFile, err)
+					requireBandwidth = false
+				}
 			}
 		}
 
@@ -801,6 +814,43 @@ Architectures:
 				fmt.Printf("%s, %s, %s, %.6f, %.6f, %s, %s, %s, %s \n", ni.SkyAddr, ni.PK, ni.Reason, ni.Share, ni.Reward, ni.IPAddr, ni.Arch, ni.UUID, ni.Interfaces)
 			}
 			return
+		}
+
+		// v2 bandwidth: aggregate per-edge sent bytes over the eligible
+		// set only. A transport contributes iff BOTH edges passed the
+		// pool 1 eligibility check above (valid survey, allowed arch,
+		// valid skyaddr, non-hypervisor, met transport requirement, met
+		// uptime). The bandwidthMap was empty during the eligibility
+		// loop in this path, so initial ni.Bandwidth=0 for everyone —
+		// we re-assign from the filtered aggregation here.
+		//
+		// Why this gate matters: pre-fix, a single eligible visor could
+		// dominate pool 2 by pushing traffic through transports to
+		// throwaway counterparties (wrong arch, no skyaddr, no survey,
+		// sub-75% uptime — none of which would ever earn rewards). The
+		// other-edge filter forecloses that pattern entirely.
+		if requireBandwidth && bwTransports != nil {
+			eligibleSet := make(map[string]struct{}, len(nodesInfos1))
+			for _, ni := range nodesInfos1 {
+				eligibleSet[ni.PK] = struct{}{}
+			}
+			creditedTransports := 0
+			for _, tp := range bwTransports {
+				if _, okA := eligibleSet[tp.A]; !okA {
+					continue
+				}
+				if _, okB := eligibleSet[tp.B]; !okB {
+					continue
+				}
+				bandwidthMap[tp.A] += tp.SentA
+				bandwidthMap[tp.B] += tp.SentB
+				creditedTransports++
+			}
+			for i := range nodesInfos1 {
+				nodesInfos1[i].Bandwidth = bandwidthMap[nodesInfos1[i].PK]
+			}
+			log.Infof("v2 bandwidth filter: %d/%d transports between two pool-1-eligible visors, sender-side credit applied",
+				creditedTransports, len(bwTransports))
 		}
 
 		// Calculate daily reward amount

--- a/cmd/skywire-cli/commands/rewards/reward.sh
+++ b/cmd/skywire-cli/commands/rewards/reward.sh
@@ -26,9 +26,26 @@ if [[ -z ${_wdate} ]] ; then
 #_wdate=$(date --date="yesterday" +%Y-%m-%d) ./reward.sh
 fi
 ####################################################
-skywire cli ut | tee "hist/${_wdate}_ut.txt"
-# Extract just the target date's data from cached JSON to a date-specific file
-jq --arg date "${_wdate}" '[.[] | {pk, on, version, daily: {($date): .daily[$date]}}]' /tmp/ut.skywire.skycoin.com/uptimes.json > "hist/${_wdate}_ut.json" 2>/dev/null || true
+# Pin the UT cache to hist/ instead of the default `/tmp/<UThost>/`.
+# Default cacheDirPath() uses os.TempDir() which is shared across all
+# UIDs; if any other user (e.g. a root-owned visor on the same host)
+# touches that path first it's created mode 0750 root:root and the
+# reward service (running as the rewards user) silently EACCES on the
+# jq read below. Bash truncates the redirect target BEFORE jq runs,
+# so the failure surfaces as an empty hist/<date>_ut.json — which
+# `ParseHistoricUptimeData` then skips, freezing the version-history
+# chart on the last good day.
+skywire cli ut --cdu hist/ | tee "hist/${_wdate}_ut.txt"
+# Extract just the target date's data from the user-owned cache into
+# a date-specific file. Write to a .tmp first and mv-on-success so a
+# failed jq leaves the previous (possibly populated) file intact
+# instead of zeroing it.
+if jq --arg date "${_wdate}" '[.[] | {pk, on, version, daily: {($date): .daily[$date]}}]' hist/uptimes.json > "hist/${_wdate}_ut.json.tmp" 2>/dev/null; then
+    mv "hist/${_wdate}_ut.json.tmp" "hist/${_wdate}_ut.json"
+else
+    echo "WARN: failed to build hist/${_wdate}_ut.json from hist/uptimes.json" >&2
+    rm -f "hist/${_wdate}_ut.json.tmp"
+fi
 # Calculate rewards
 skywire cli rewards --utfile "hist/${_wdate}_ut.txt" -ed ${_wdate} -p log_backups  |  tee hist/${_wdate}_ineligible.csv
 skywire cli rewards --utfile "hist/${_wdate}_ut.txt" -20d ${_wdate} -p log_backups |  tee hist/${_wdate}_shares.csv

--- a/cmd/skywire-cli/commands/rewards/transports.go
+++ b/cmd/skywire-cli/commands/rewards/transports.go
@@ -62,7 +62,9 @@ func init() {
 
 const (
 	defaultMinBandwidth = 64 // minimum bytes to qualify; real TPD data shows P5=796B for 2-transport visors
-	bwCacheFile         = "/tmp/tpd_bandwidth.json"
+	// Bump the cache filename whenever the on-disk shape changes so a
+	// v2 binary doesn't deserialize a leftover v1 cache as garbage.
+	bwCacheFile = "/tmp/tpd_bandwidth_v2.json"
 )
 
 var (
@@ -210,8 +212,39 @@ func parsePerKeyStats(data []byte) (PerKeyStats, error) {
 	return stats, nil
 }
 
-// VisorBandwidthResult maps public key hex to daily bandwidth in bytes
+// VisorBandwidthResult maps public key hex to daily bandwidth in bytes.
+// This is the pre-v2 bandwidth.json shape — retained for backward
+// compatibility when the reward calculator encounters a file written
+// by an older bw-collect.
 type VisorBandwidthResult map[string]uint64
+
+// BandwidthDataVersion is the current bw-collect output schema version.
+// v1 = bare {pk:bytes} map (no per-transport detail; full sent+recv
+//      credited to BOTH edges; no counterparty eligibility filter
+//      possible at calc time).
+// v2 = {version:2, transports:[{a,b,sent_a,sent_b}]} — preserves
+//      per-transport detail so the calculator can (a) drop transports
+//      where either edge is reward-ineligible and (b) credit each edge
+//      only for the bytes it actually sent (sender-pays model).
+const BandwidthDataVersion = 2
+
+// TransportBW is one bidirectional transport's per-edge sent bytes,
+// each capped by the counterparty's reported recv (so a one-sided
+// inflation of .sent can't pump the credit). sent_a is the bytes A
+// sent that B confirmed receiving; sent_b is the mirror.
+type TransportBW struct {
+	A     string `json:"a"`
+	B     string `json:"b"`
+	SentA uint64 `json:"sent_a"`
+	SentB uint64 `json:"sent_b"`
+}
+
+// BandwidthData is the v2 wire format for hist/<date>_bandwidth.json.
+// See comment on BandwidthDataVersion for the migration story.
+type BandwidthData struct {
+	Version    int           `json:"version"`
+	Transports []TransportBW `json:"transports"`
+}
 
 // tpdTransport represents a transport from TPD /metrics endpoint with edge info
 type tpdTransport struct {
@@ -235,18 +268,26 @@ type tpdTransport struct {
 var bwCollectCmd = &cobra.Command{
 	Use:   "bw-collect",
 	Short: "collect bandwidth data from TPD for reward calculation",
-	Long: `Fetches per-visor bandwidth data from TPD and records daily bandwidth.
+	Long: `Fetches per-transport bandwidth data from TPD and records the daily
+per-edge sent totals so the reward calculator can credit each visor
+only for the bytes it actually sent, and only on transports between
+two reward-eligible visors.
 
 This command:
 1. Fetches all transport metrics from TPD /metrics?days=1&bandwidth=true&edges=true
 2. Builds a PK→IP map from hardware surveys to detect same-LAN transports
-3. Excludes bandwidth from transports where both edges share the same external IP
-4. Aggregates remaining bandwidth per visor
-5. Writes hist/YYYY-MM-DD_bandwidth.json as map[string]uint64 (pk → daily bytes)
-6. Caches results in /tmp/tpd_bandwidth.json with 5-min TTL
+3. Excludes transports where both edges share the same external IP (same-LAN sybil)
+4. For each remaining transport, records (a, b, sent_a, sent_b) where
+   sent_a = min(A.Sent, B.Recv) and sent_b = min(B.Sent, A.Recv)
+   — sender-pays, capped by the receiver's confirmation so a one-sided
+   .sent inflation cannot pump credit
+5. Writes hist/YYYY-MM-DD_bandwidth.json as the v2 BandwidthData schema
+6. Caches the raw transport list in /tmp/tpd_bandwidth_v2.json (5-min TTL)
 
-Visors below the minimum bandwidth threshold are excluded.
-Designed to be run hourly by the reward service.`,
+The minimum-bandwidth filter and counterparty-eligibility filter are
+both applied later by the reward calculator — bw-collect does not have
+the eligibility set at run time and the data is needed pre-filter for
+sender-side aggregation. Designed to be run hourly by the reward service.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		bwLog := logging.MustGetLogger("bw-collect")
 		if logLvl != "" {
@@ -262,30 +303,28 @@ Designed to be run hourly by the reward service.`,
 
 		today := time.Now().UTC().Format("2006-01-02")
 
-		// Build PK→IP map from hardware surveys for same-LAN detection
+		// Build PK→IP map from hardware surveys for same-LAN detection.
+		// Same-LAN filtering belongs at this stage rather than calc time
+		// because it depends on visor IP from the survey, not on reward
+		// eligibility — a transport between two PKs on one host is
+		// excluded regardless of whether either side ends up eligible.
 		pkIPMap := buildPKtoIPMap(bwLog, bwSurveyPath)
 		bwLog.Infof("Built PK→IP map with %d entries from %s", len(pkIPMap), bwSurveyPath)
 
-		// Fetch bandwidth data from TPD with same-LAN filtering
-		bwData, err := fetchVisorBandwidthFromTPD(cmd.Flags(), bwLog, pkIPMap, !noCache)
+		// Fetch per-transport sender-side bandwidth from TPD (same-LAN
+		// already filtered out).
+		transports, err := fetchTransportBandwidthFromTPD(cmd.Flags(), bwLog, pkIPMap, !noCache)
 		if err != nil {
 			bwLog.Fatal("Failed to fetch bandwidth data: ", err)
 		}
 
-		// Filter by minimum bandwidth threshold
-		qualifying := make(VisorBandwidthResult)
-		for pk, bw := range bwData {
-			if bw >= minBandwidth {
-				qualifying[pk] = bw
-			}
+		// Write the v2 bandwidth JSON
+		out := BandwidthData{
+			Version:    BandwidthDataVersion,
+			Transports: transports,
 		}
-
-		bwLog.Infof("Total visors with bandwidth: %d, qualifying (>= %d bytes): %d",
-			len(bwData), minBandwidth, len(qualifying))
-
-		// Write bandwidth JSON
 		dailyFile := fmt.Sprintf("%s/%s_bandwidth.json", histPath, today)
-		jsonData, err := json.MarshalIndent(qualifying, "", "  ")
+		jsonData, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {
 			bwLog.Fatal("Failed to marshal bandwidth data: ", err)
 		}
@@ -293,13 +332,19 @@ Designed to be run hourly by the reward service.`,
 			bwLog.Fatal("Failed to write bandwidth file: ", err)
 		}
 
-		// Print summary stats
-		var totalBW uint64
-		for _, bw := range qualifying {
-			totalBW += bw
+		// Print summary stats. The "qualifying visors" count under the
+		// old aggregated format is no longer meaningful here — eligibility
+		// and min-bandwidth are now applied at calc time — so report the
+		// raw transport count and total sender-side bytes instead.
+		var totalSent uint64
+		uniqueEdges := make(map[string]struct{})
+		for _, tp := range transports {
+			totalSent += tp.SentA + tp.SentB
+			uniqueEdges[tp.A] = struct{}{}
+			uniqueEdges[tp.B] = struct{}{}
 		}
-		fmt.Printf("Bandwidth collection complete: %d qualifying visors, total bandwidth: %s, written to %s\n",
-			len(qualifying), formatBytes(totalBW), dailyFile)
+		fmt.Printf("Bandwidth collection complete: %d transports across %d unique visors, total sender-side bandwidth: %s, written to %s\n",
+			len(transports), len(uniqueEdges), formatBytes(totalSent), dailyFile)
 	},
 }
 
@@ -341,9 +386,18 @@ func buildPKtoIPMap(bwLog *logging.Logger, surveyPath string) map[string]string 
 	return pkIPMap
 }
 
-// fetchVisorBandwidthFromTPD fetches all transport metrics from TPD,
-// filters out same-LAN transports (both edges share an IP), and aggregates per visor
-func fetchVisorBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logger, pkIPMap map[string]string, useCache bool) (VisorBandwidthResult, error) {
+// fetchTransportBandwidthFromTPD fetches per-transport metrics from TPD,
+// filters out same-LAN transports (both edges share an external IP), and
+// returns the per-edge sender-side daily totals. Each entry's SentA is
+// what edge A claims sent capped by what B confirmed receiving (and
+// mirror for SentB) so a one-sided .sent inflation in TPD cannot pump
+// a visor's credit.
+//
+// No counterparty-eligibility filter here — bw-collect doesn't have the
+// pool 1 eligibility set at run time (it's recomputed during calc using
+// the day's surveys + uptime). The calculator does that filter after
+// reading this list.
+func fetchTransportBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logger, pkIPMap map[string]string, useCache bool) ([]TransportBW, error) {
 	// Check cache
 	if useCache {
 		if info, err := os.Stat(bwCacheFile); err == nil {
@@ -351,7 +405,7 @@ func fetchVisorBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logger, 
 				bwLog.Debug("Using cached bandwidth data")
 				data, err := os.ReadFile(bwCacheFile)
 				if err == nil {
-					var cached VisorBandwidthResult
+					var cached []TransportBW
 					if err := json.Unmarshal(data, &cached); err == nil {
 						return cached, nil
 					}
@@ -372,65 +426,71 @@ func fetchVisorBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logger, 
 		return nil, fmt.Errorf("TPD fetch failed: %w", err)
 	}
 
-	var transports []tpdTransport
-	if err := json.Unmarshal(body, &transports); err != nil {
+	var rawTransports []tpdTransport
+	if err := json.Unmarshal(body, &rawTransports); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	bwLog.Infof("Fetched %d transports from TPD", len(transports))
+	bwLog.Infof("Fetched %d transports from TPD", len(rawTransports))
 
-	// Aggregate bandwidth per visor, excluding same-LAN transports
-	result := make(VisorBandwidthResult)
+	out := make([]TransportBW, 0, len(rawTransports))
 	sameLANCount := 0
 
-	for _, tp := range transports {
+	for _, tp := range rawTransports {
 		if len(tp.Edges) != 2 {
 			continue
 		}
 
-		// Calculate agreed bandwidth for this transport
-		// Use the minimum of what both edges report: min(A.Sent, B.Recv) + min(A.Recv, B.Sent)
-		// This ensures only bandwidth that both sides agree on is counted
-		var tpBW uint64
+		// Sender-side per-edge totals, each capped by the receiver's
+		// confirmation. Pre-fix this summed both directions and credited
+		// the union to both edges — letting a receiver-heavy visor earn
+		// rewards purely from bytes it pulled. Splitting it lets the
+		// calculator apply the sender-pays model the network intends.
+		var sentA, sentB uint64
 		for _, d := range tp.Daily {
 			if d.A != nil && d.B != nil {
-				tpBW += minUint64(d.A.Sent, d.B.Recv) + minUint64(d.A.Recv, d.B.Sent)
+				sentA += minUint64(d.A.Sent, d.B.Recv)
+				sentB += minUint64(d.B.Sent, d.A.Recv)
 			}
 		}
-		if tpBW == 0 {
+		if sentA == 0 && sentB == 0 {
 			continue
 		}
 
 		edgeA := tp.Edges[0]
 		edgeB := tp.Edges[1]
 
-		// Check if both edges are on the same LAN (same external IP)
+		// Same-LAN: both edges report the same external IP from their
+		// surveys. Drop the whole transport — neither side gets credit.
 		ipA, hasA := pkIPMap[edgeA]
 		ipB, hasB := pkIPMap[edgeB]
 		if hasA && hasB && ipA == ipB {
 			sameLANCount++
-			bwLog.Debugf("Excluding same-LAN transport %s: %s and %s both on %s (%d bytes)",
-				tp.ID[:8], edgeA[:12], edgeB[:12], ipA, tpBW)
+			bwLog.Debugf("Excluding same-LAN transport %s: %s and %s both on %s (sent_a=%d sent_b=%d)",
+				tp.ID[:8], edgeA[:12], edgeB[:12], ipA, sentA, sentB)
 			continue
 		}
 
-		// Credit bandwidth to both edges
-		result[edgeA] += tpBW
-		result[edgeB] += tpBW
+		out = append(out, TransportBW{
+			A:     edgeA,
+			B:     edgeB,
+			SentA: sentA,
+			SentB: sentB,
+		})
 	}
 
-	bwLog.Infof("Excluded %d same-LAN transports, %d visors with bandwidth remaining",
-		sameLANCount, len(result))
+	bwLog.Infof("Excluded %d same-LAN transports, %d remaining in per-edge sender-side dataset",
+		sameLANCount, len(out))
 
 	// Update cache
-	cacheData, err := json.Marshal(result)
+	cacheData, err := json.Marshal(out)
 	if err == nil {
 		if err := os.WriteFile(bwCacheFile, cacheData, 0600); err != nil {
 			bwLog.WithError(err).Warn("Failed to update bandwidth cache file")
 		}
 	}
 
-	return result, nil
+	return out, nil
 }
 
 func minUint64(a, b uint64) uint64 {

--- a/cmd/skywire-cli/commands/rewards/transports.go
+++ b/cmd/skywire-cli/commands/rewards/transports.go
@@ -270,8 +270,10 @@ var bwCollectCmd = &cobra.Command{
 	Short: "collect bandwidth data from TPD for reward calculation",
 	Long: `Fetches per-transport bandwidth data from TPD and records the daily
 per-edge sent totals so the reward calculator can credit each visor
-only for the bytes it actually sent, and only on transports between
-two reward-eligible visors.
+only for the bytes it actually sent — and only when the sender itself
+is reward-eligible. Counterparty eligibility is irrelevant under the
+sender-pays model: an eligible visor's transport to an ineligible peer
+still earns the eligible side credit for what it sent.
 
 This command:
 1. Fetches all transport metrics from TPD /metrics?days=1&bandwidth=true&edges=true


### PR DESCRIPTION
Bundled because both ship to the same scheduled run on the same reward host. Reviewing one without the other risks a partial rollout.

## 1. \`reward.sh\`: pin UT cache to hist/ (fix)

The embedded \`reward.sh\` (printed by \`skywire cli rewards script reward\` and piped to bash from the systemd service) called \`skywire cli ut\` with the default \`--cdu\`. \`cacheDirPath()\` derives that from \`os.TempDir()\`, which is shared across all UIDs.

On hosts where another user (a root-owned visor in our case) hit the same UT endpoint first, \`/tmp/ut.skywire.skycoin.com/\` was created \`0750 root:root\`, and the reward user EACCES'd on the jq read of \`uptimes.json\`. \`bash\` truncated the redirect target *before* jq ran, so each day's \`hist/<date>_ut.json\` ended up as 0 bytes. \`2>/dev/null || true\` swallowed the error.

Reward calc was unaffected (it reads \`_ut.txt\`) but \`ParseHistoricUptimeData\` skips empty files, so the public \`/stats/version-history\` chart silently froze on the last good day. Production chart was stuck at 2026-05-17 for 10+ days while everything else looked fine.

Fix:
- \`skywire cli ut --cdu hist/\` so the UT cache lives at \`hist/uptimes.json\` (user-owned working dir).
- Build the per-day \`_ut.json\` via \`.tmp\` + \`mv\`-on-success instead of \`> file 2>/dev/null || true\`. A jq failure now leaves the previous good file untouched and emits a warning to stderr.

## 2. \`bw-collect\` + \`calc\`: sender-pays (feature)

Reshape the bandwidth (pool 2) reward path around a sender-pays model.

Pre-fix, each transport's full agreed bandwidth (\`min(A.Sent, B.Recv) + min(A.Recv, B.Sent)\`) was credited to BOTH edges. A receiver-heavy visor — one that mostly pulls bytes from others — earned the same per-transport credit as the sender. With pool 2 weight proportional to bytes, the network was paying for consumption equally with provision.

Now \`sent_a = min(A.Sent, B.Recv)\` credits only edge A, \`sent_b\` mirrors. Each side is capped by the counterparty's recv confirmation so a one-sided \`.sent\` inflation can't pump credit. At calc time, an edge is credited iff that edge passes the pool 1 eligibility check (uptime, allowed arch, valid skyaddr, non-hypervisor, met transport requirement, valid survey). Counterparty status doesn't matter — credit only flows to the sender, so an ineligible peer was never going to be paid regardless.

Implementation:

- \`hist/<date>_bandwidth.json\` gains a v2 schema:
  \`\`\`json
  {"version": 2, "transports": [{"a","b","sent_a","sent_b"}, ...]}
  \`\`\`
  bw-collect emits v2. The calculator reads v2 when present, falls back to the v1 \`{pk:bytes}\` map for historical files (no sender filter on v1 — matches the original behavior so any re-run against archived files stays bit-exact).
- bw-collect no longer pre-aggregates or applies the min-bandwidth threshold. Both happen at calc time, after the sender-eligibility filter, on the v2-derived per-edge totals.
- Same-LAN exclusion stays in bw-collect — it depends on survey IPs, not on eligibility, and applies regardless of either edge's reward status.
- Cache file renamed (\`/tmp/tpd_bandwidth.json\` → \`/tmp/tpd_bandwidth_v2.json\`) so a v2 binary doesn't deserialize a leftover v1 cache as garbage.

## Test plan

- [x] \`go build ./cmd/skywire-cli/...\` + \`go vet ./cmd/skywire-cli/commands/rewards/\`
- [x] \`skywire-cli rewards script reward\` prints the updated reward.sh (embed picked up the edit)
- [x] Manual round-trip of v2 \`BandwidthData\` and v1 \`{pk:bytes}\` fallback parse
- [x] Production backfill (separate manual step against current UT) unstuck the version-history chart immediately
- [ ] Next scheduled \`skywire-reward.service\` run produces a non-empty \`hist/<tomorrow>_ut.json\` and a v2 \`hist/<tomorrow>_bandwidth.json\`
- [ ] Pool 2 share distribution shifts toward sender-heavy visors