### PR TITLE
feat(router/policy): visor-backed Provider + per-app routing policy

### DIFF
--- a/pkg/app/appserver/spec/spec.go
+++ b/pkg/app/appserver/spec/spec.go
@@ -63,4 +63,10 @@ type AppConfig struct {
 	//                   disable an Always-policy app is to remove
 	//                   its config entry and restart the visor.
 	RestartPolicy string `json:"restart_policy,omitempty"`
+	// RoutingPolicy overrides the visor-wide routing policy for
+	// dials originating from this app. Same `@/path` vs. inline-
+	// script convention as conf.Routing.PolicyPerDial. Empty =
+	// fall through to the visor-wide policy (which is itself
+	// empty by default). See docs/routing_policy_rfc.md.
+	RoutingPolicy string `json:"routing_policy,omitempty"`
 }

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -13,15 +13,44 @@ import (
 	"github.com/skycoin/skywire/pkg/router"
 )
 
-// Hook adapts a *Loader to the router.DialHook interface. Pass
-// to router.Config.DialHook to plug a routing policy into the
-// dial path.
+// Hook adapts one default Loader plus optional per-app Loaders to
+// the router.DialHook interface. Pass to router.Config.DialHook to
+// plug a routing policy into the dial path.
+//
+// Per-app loaders take precedence over the default; an app with a
+// configured RoutingPolicy gets its own evaluator, every other app
+// falls through to the visor-wide default. An app whose per-app
+// loader is registered but inactive still uses that loader (which
+// returns a no-op spec) rather than escaping to the default — the
+// per-app policy is the operator's intent for that app.
 type Hook struct {
 	loader *Loader
+	byApp  map[string]*Loader
 }
 
 // NewHook wraps a Loader as a DialHook.
 func NewHook(l *Loader) *Hook { return &Hook{loader: l} }
+
+// RegisterApp attaches a per-app Loader that overrides the default
+// for dials originating from the named app. Safe to call only
+// during init (before the hook is handed to the router).
+func (h *Hook) RegisterApp(appName string, l *Loader) {
+	if h.byApp == nil {
+		h.byApp = make(map[string]*Loader)
+	}
+	h.byApp[appName] = l
+}
+
+// loaderFor returns the per-app loader if one is registered for
+// info.AppName, else the default.
+func (h *Hook) loaderFor(appName string) *Loader {
+	if h.byApp != nil {
+		if l, ok := h.byApp[appName]; ok {
+			return l
+		}
+	}
+	return h.loader
+}
 
 // BeforeDial implements router.DialHook. Constructs a
 // RoutingContext from the per-dial DialInfo, invokes the loader,
@@ -37,7 +66,8 @@ func NewHook(l *Loader) *Hook { return &Hook{loader: l} }
 //   router sees an error from BeforeDial and logs it but still
 //   proceeds (failure-safe at the router layer too).
 func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.DialAdjustment, error) {
-	if h.loader == nil || !h.loader.IsActive() {
+	loader := h.loaderFor(info.AppName)
+	if loader == nil || !loader.IsActive() {
 		return router.DialAdjustment{}, nil
 	}
 	rctx := RoutingContext{
@@ -45,7 +75,7 @@ func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.Dia
 		PeerPK: info.PeerPK.Hex(),
 		Port:   uint16(info.RPort),
 	}
-	spec, err := h.loader.Decide(ctx, rctx, nil)
+	spec, err := loader.Decide(ctx, rctx, nil)
 	if err != nil {
 		return router.DialAdjustment{}, err
 	}

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -858,3 +858,26 @@ func (mt *ManagedTransport) Remote() cipher.PubKey { return mt.rPK }
 
 // Type returns the transport type.
 func (mt *ManagedTransport) Type() types.Type { return mt.client.Type() }
+
+// RemoteIP returns the host portion of the underlying transport's
+// remote raw address (e.g. "1.2.3.4" for an stcpr transport to
+// 1.2.3.4:5000). Returns "" when the transport isn't serving, or
+// the underlying type doesn't have an IP-shaped remote (notably
+// dmsg, which relays through a server rather than directly to the
+// peer). Used by the routing-policy provider's Geo() lookup so an
+// operator's policy can branch on `geo.country(pk) == "ID"`.
+func (mt *ManagedTransport) RemoteIP() string {
+	tp := mt.getTransport()
+	if tp == nil {
+		return ""
+	}
+	addr := tp.RemoteRawAddr()
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return ""
+	}
+	return host
+}

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -180,23 +180,76 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 	// start its file-watcher if the path is file-backed, and
 	// plug it into the router as a DialHook. Nil hook = no
 	// integration cost when no policy is configured.
-	if v.conf.Routing.PolicyPerDial != "" {
+	// Operator-programmable routing policy. Two scopes:
+	//   - visor-wide:  conf.Routing.PolicyPerDial
+	//   - per-app:     AppConfig.RoutingPolicy (overrides the
+	//                  visor-wide default for dials from that app)
+	// A Hook is installed if either scope has a configured source.
+	// Real Provider backed by the running visor's transport manager,
+	// embedded geoip db, hypervisor list, and dmsgpty whitelist —
+	// without this the script's geo.*, transports.*, and peers.*
+	// stdlib calls would return zero values from policy.NopProvider.
+	{
 		policyLogger := func(format string, args ...interface{}) {
 			log.Infof(format, args...)
 		}
-		loader, perr := policy.NewLoader(
-			v.conf.Routing.PolicyPerDial,
-			policy.WithLogger(policyLogger),
-		)
-		if perr != nil {
-			log.WithError(perr).Warn("Routing policy failed to load; visor will run without policy.")
-		} else {
-			if werr := loader.Watch(policyLogger); werr != nil {
-				log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
+		var provider *visorPolicyProvider
+		makeProvider := func() *visorPolicyProvider {
+			if provider == nil {
+				provider = newVisorPolicyProvider(v)
 			}
-			rConf.DialHook = policy.NewHook(loader)
-			v.pushCloseStack("router.policy", loader.Close)
-			log.WithField("source", loader.Source()).Info("Routing policy active.")
+			return provider
+		}
+
+		var hook *policy.Hook
+
+		if v.conf.Routing.PolicyPerDial != "" {
+			loader, perr := policy.NewLoader(
+				v.conf.Routing.PolicyPerDial,
+				policy.WithLogger(policyLogger),
+				policy.WithProvider(makeProvider()),
+			)
+			if perr != nil {
+				log.WithError(perr).Warn("Routing policy failed to load; visor will run without visor-wide policy.")
+			} else {
+				if werr := loader.Watch(policyLogger); werr != nil {
+					log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
+				}
+				hook = policy.NewHook(loader)
+				v.pushCloseStack("router.policy", loader.Close)
+				log.WithField("source", loader.Source()).Info("Routing policy active.")
+			}
+		}
+
+		if v.conf.Launcher != nil {
+			for _, app := range v.conf.Launcher.Apps {
+				if app.RoutingPolicy == "" {
+					continue
+				}
+				appLoader, perr := policy.NewLoader(
+					app.RoutingPolicy,
+					policy.WithLogger(policyLogger),
+					policy.WithProvider(makeProvider()),
+				)
+				if perr != nil {
+					log.WithError(perr).WithField("app", app.Name).Warn("Per-app routing policy failed to load; app will fall back to default policy.")
+					continue
+				}
+				if werr := appLoader.Watch(policyLogger); werr != nil {
+					log.WithError(werr).WithField("app", app.Name).Warn("Per-app routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
+				}
+				if hook == nil {
+					hook = policy.NewHook(nil)
+				}
+				hook.RegisterApp(app.Name, appLoader)
+				appName := app.Name
+				v.pushCloseStack("router.policy.app:"+appName, appLoader.Close)
+				log.WithField("app", appName).WithField("source", appLoader.Source()).Info("Per-app routing policy active.")
+			}
+		}
+
+		if hook != nil {
+			rConf.DialHook = hook
 		}
 	}
 

--- a/pkg/visor/policy_provider.go
+++ b/pkg/visor/policy_provider.go
@@ -1,0 +1,184 @@
+// Package visor pkg/visor/policy_provider.go — visor-backed
+// implementation of pkg/router/policy.Provider. Surfaces the
+// visor's transport-tracker state, embedded geoip database,
+// operator-configured trust list, and configured hypervisor PKs
+// to the operator's Starlark routing policy script.
+//
+// Per-call lookups, no caching — the underlying state (transport
+// manager, geoip mmdb) is already optimized for in-process queries
+// (sub-µs). Adding a TTL cache here would only matter if a policy
+// hammers the same PKs in a tight loop, which today's per-dial
+// policy invocation model doesn't.
+package visor
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/oschwald/geoip2-golang/v2"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/geoip"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// parsePK is the local helper for the multiple Provider methods
+// that take a hex PK string. cipher.PubKey doesn't have a single-
+// expression constructor; .Set() mutates the receiver.
+func parsePK(s string) (cipher.PubKey, bool) {
+	var pk cipher.PubKey
+	if err := pk.Set(s); err != nil {
+		return cipher.PubKey{}, false
+	}
+	return pk, true
+}
+
+// visorPolicyProvider implements router/policy.Provider on top of
+// the running visor's state. Construct via newVisorPolicyProvider
+// inside the router init.
+type visorPolicyProvider struct {
+	tpM *transport.Manager
+
+	geoMu sync.Mutex
+	geoDB *geoip2.Reader // nil when OpenEmbedded failed
+
+	hypervisors map[string]struct{} // hex PK → present
+	trusted     map[string]struct{} // hex PK → present (dmsgpty whitelist + hypervisors)
+}
+
+func newVisorPolicyProvider(v *Visor) *visorPolicyProvider {
+	p := &visorPolicyProvider{
+		tpM:         v.tpM,
+		hypervisors: make(map[string]struct{}),
+		trusted:     make(map[string]struct{}),
+	}
+
+	// Embedded geoip DB. Failure to open isn't fatal — Geo() just
+	// returns "??" until OpenEmbedded() works.
+	if db, err := geoip.OpenEmbedded(); err == nil {
+		p.geoDB = db
+	} else if v.log != nil {
+		v.log.WithError(err).Warn("routing-policy provider: embedded geoip db unavailable; geo.country() will return \"??\"")
+	}
+
+	// Pre-build the hypervisor set from config. Hypervisors are
+	// auto-trusted (they're the operator's control plane).
+	for _, pk := range v.conf.Hypervisors {
+		p.hypervisors[pk.Hex()] = struct{}{}
+		p.trusted[pk.Hex()] = struct{}{}
+	}
+
+	// Pre-build the trust set from the dmsgpty whitelist — it's
+	// the most operator-curated trust signal the visor maintains.
+	// (After the dmsgpty → pty rename track this is v.conf.Pty.)
+	if v.conf.Pty != nil {
+		for _, pk := range v.conf.Pty.Whitelist {
+			p.trusted[pk.Hex()] = struct{}{}
+		}
+	}
+
+	return p
+}
+
+// Geo implements policy.Provider. Looks up the peer's most-recent
+// transport's remote IP and queries the embedded geoip db. Returns
+// "??" when:
+//   - the geoip db isn't loaded
+//   - no transport exists for this PK
+//   - the IP isn't in the db
+func (p *visorPolicyProvider) Geo(pk string) string {
+	if p.geoDB == nil || p.tpM == nil {
+		return "??"
+	}
+	pubkey, ok := parsePK(pk)
+	if !ok {
+		return "??"
+	}
+	ip := p.remoteIPForPeer(pubkey)
+	if ip == "" {
+		return "??"
+	}
+	p.geoMu.Lock()
+	res, err := geoip.Lookup(p.geoDB, ip)
+	p.geoMu.Unlock()
+	if err != nil || res == nil || res.CountryCode == "" {
+		return "??"
+	}
+	return res.CountryCode
+}
+
+// Latency implements policy.Provider. Returns the most recent
+// ms reading from the transport tracker. Zero means "unknown" —
+// either no transport, no recent measurement, or a measurement
+// of literally zero (which we conflate with unknown).
+func (p *visorPolicyProvider) Latency(pk string) int {
+	if p.tpM == nil {
+		return 0
+	}
+	pubkey, ok := parsePK(pk)
+	if !ok {
+		return 0
+	}
+	if mt := p.preferredTransport(pubkey); mt != nil {
+		return int(mt.GetLatency())
+	}
+	return 0
+}
+
+// Kind implements policy.Provider. Returns the network type of
+// the visor's preferred transport to the peer ("stcpr" / "sudph"
+// / "stcp" / "dmsg"). Empty when no transport exists.
+func (p *visorPolicyProvider) Kind(pk string) string {
+	if p.tpM == nil {
+		return ""
+	}
+	pubkey, ok := parsePK(pk)
+	if !ok {
+		return ""
+	}
+	if mt := p.preferredTransport(pubkey); mt != nil {
+		return string(mt.Entry.Type)
+	}
+	return ""
+}
+
+// IsTrusted implements policy.Provider. True when the PK is in
+// either the dmsgpty whitelist or the hypervisor list (which is
+// auto-trusted).
+func (p *visorPolicyProvider) IsTrusted(pk string) bool {
+	_, ok := p.trusted[strings.ToLower(pk)]
+	return ok
+}
+
+// IsHypervisor implements policy.Provider. True when the PK is
+// in conf.Hypervisors.
+func (p *visorPolicyProvider) IsHypervisor(pk string) bool {
+	_, ok := p.hypervisors[strings.ToLower(pk)]
+	return ok
+}
+
+// preferredTransport returns the most-preferred existing transport
+// to the peer (stcpr > sudph > stcp > dmsg) or nil. Used by
+// Latency() and Kind() to get a single representative transport
+// per peer without enumerating all of them.
+func (p *visorPolicyProvider) preferredTransport(peer cipher.PubKey) *transport.ManagedTransport {
+	for _, t := range []tptypes.Type{tptypes.STCPR, tptypes.SUDPH, tptypes.STCP, tptypes.DMSG} {
+		if mt, err := p.tpM.GetTransport(peer, t); err == nil && mt != nil {
+			return mt
+		}
+	}
+	return nil
+}
+
+// remoteIPForPeer extracts the remote IP (no port) from the
+// peer's preferred transport's raw remote address. Returns "" if
+// no transport exists or the address isn't an IP form (dmsg
+// addresses don't have a routable IP — they go through a relay).
+func (p *visorPolicyProvider) remoteIPForPeer(peer cipher.PubKey) string {
+	mt := p.preferredTransport(peer)
+	if mt == nil || mt.Entry.Type == tptypes.DMSG {
+		return ""
+	}
+	return mt.RemoteIP()
+}


### PR DESCRIPTION
## Summary
Two follow-ups to the RFC #2882 routing-policy stack:

- **Visor-backed `policy.Provider`** — Starlark's `geo.country(pk)`, `transports.latency(pk)`, `transports.kind(pk)`, `peers.is_trusted(pk)`, `peers.is_hypervisor(pk)` now return real values from the running visor's transport manager, embedded geoip db, hypervisor list, and dmsgpty whitelist instead of zeros from `NopProvider`. Per-call lookups; no caching layer added (transport-manager and geoip mmdb are already in-process).

- **Per-app `RoutingPolicy` override** — new `AppConfig.RoutingPolicy` field with the same `@/path/to/script.star` or inline-script convention as `conf.Routing.PolicyPerDial`. `policy.Hook` now dispatches per app: if an app has a registered policy, dials from that app use it; otherwise fall through to the visor-wide default. Per-app load failures don't disable the default, and vice versa.

Also adds `(*ManagedTransport).RemoteIP()` so the policy provider can ask "what IP is this transport pointed at" for the geoip lookup without exposing the unexported `network.Transport` field. Returns `""` for dmsg transports (relayed; no peer IP).

## Test plan
- [ ] `go build .` clean (verified locally)
- [ ] Visor boots with `Routing.PolicyPerDial: ""` — no Hook installed, zero behavior change
- [ ] Visor boots with `Routing.PolicyPerDial: "@policies/smoke.star"` — log shows `Routing policy active.`
- [ ] AppConfig with `routing_policy: "@/path/app.star"` set — log shows `Per-app routing policy active.` and a dial from that app uses the per-app loader
- [ ] In a script: `geo.country(some_pk)` returns ISO country code for a peer with an active stcpr/sudph/stcp transport; `"??"` for dmsg-only peers or unknown IPs
- [ ] `peers.is_hypervisor(my_hypervisor_pk)` returns `True`

## Follow-up (next commit on this branch)
Candidate enumeration so `decide_route(ctx, candidates)` actually has routes to filter — needs a second hook firing after the route-finder query, enriching paths with `HopsGeo` / `EstLatencyMs` / `TransportKinds`. Without it the Indonesia-Friday filter the RFC promises has nothing to filter against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)