### PR TITLE
feat(router/policy): RouteSelectingHook + Starlark route selection

### DIFF
--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -82,3 +82,51 @@ func applyAdjustment(opts *DialOptions, adj DialAdjustment) error {
 	}
 	return nil
 }
+
+// RouteSelectingHook is an optional secondary interface that a
+// DialHook can implement to influence route selection AFTER the
+// route-finder has returned its candidates. The router type-
+// asserts for this interface; implementers that don't need
+// candidate filtering simply omit SelectRoute and continue using
+// the simpler BeforeDial path.
+//
+// Both hook points fire per dial:
+//   - BeforeDial   (sync, before route-finder)  — adjusts opts
+//   - SelectRoute  (sync, after route-finder)   — picks a route
+type RouteSelectingHook interface {
+	DialHook
+	// SelectRoute is invoked synchronously after the route-finder
+	// returns candidates and before route setup. The hook may
+	// return a Chosen index (into the candidates slice) or -1 to
+	// defer to the router's built-in selection. Drop=true refuses
+	// the dial with ErrDialPolicyDropped.
+	SelectRoute(ctx context.Context, info DialInfo, candidates []CandidateInfo) (RouteSelection, error)
+}
+
+// CandidateInfo is the bare-bones per-candidate description the
+// router hands to RouteSelectingHook.SelectRoute. The hook is
+// responsible for any further enrichment (geo lookup, transport-
+// kind classification) — the router only owns the route-finder
+// response and the latency lookup it already builds for its
+// disjoint-path selection.
+type CandidateInfo struct {
+	// Hops is the ordered intermediate PKs (hex) from source
+	// (excluded) to destination (excluded). Empty for a direct
+	// transport.
+	Hops []string
+
+	// EstLatencyMs is the sum of per-hop latencies along the
+	// route, in milliseconds, drawn from the router's existing
+	// transport-tracker lookup. Zero when no measurements are
+	// available — treat as "unknown," not "fast."
+	EstLatencyMs int
+}
+
+// RouteSelection is the SelectRoute return value. Chosen is an
+// index into the candidates slice passed in; -1 means "no
+// preference, fall back to the router's built-in disjoint-path
+// pick." Drop=true overrides everything and refuses the dial.
+type RouteSelection struct {
+	Chosen int
+	Drop   bool
+}

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -24,12 +24,32 @@ import (
 // returns a no-op spec) rather than escaping to the default — the
 // per-app policy is the operator's intent for that app.
 type Hook struct {
-	loader *Loader
-	byApp  map[string]*Loader
+	loader   *Loader
+	byApp    map[string]*Loader
+	provider Provider // used for HopsGeo enrichment during SelectRoute
+}
+
+// HookOption configures a Hook at construction.
+type HookOption func(*Hook)
+
+// WithHookProvider supplies the Provider used to enrich per-route
+// candidate metadata (HopsGeo, TransportKinds) before the script's
+// decide_route function sees the candidates slice. Without this the
+// hook's SelectRoute still works, but every HopsGeo entry is "??"
+// and TransportKinds is empty — geographic / transport-kind filters
+// in the script would match nothing.
+func WithHookProvider(p Provider) HookOption {
+	return func(h *Hook) { h.provider = p }
 }
 
 // NewHook wraps a Loader as a DialHook.
-func NewHook(l *Loader) *Hook { return &Hook{loader: l} }
+func NewHook(l *Loader, opts ...HookOption) *Hook {
+	h := &Hook{loader: l}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
 
 // RegisterApp attaches a per-app Loader that overrides the default
 // for dials originating from the named app. Safe to call only
@@ -84,4 +104,91 @@ func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.Dia
 		MinHops:   spec.MinHops,
 		Fallback:  spec.Fallback,
 	}, nil
+}
+
+// SelectRoute implements router.RouteSelectingHook. Enriches the
+// router's bare CandidateInfo list with HopsGeo and TransportKinds
+// (via the Hook's Provider), passes the enriched candidates to the
+// script's decide_route function, and translates the returned
+// RouteSpec.Chosen back into an index for the router.
+//
+// Index translation: the script's Chosen is a *Candidate; we match
+// it back to the input candidates by Hops equality. Hops is the
+// stable key because it's the only field the script can't fabricate
+// (provider-derived fields are read-only inside Starlark).
+//
+// "drop" Fallback maps to RouteSelection.Drop. An empty Chosen
+// with no drop signal maps to Chosen=-1 (defer to router's pick).
+func (h *Hook) SelectRoute(ctx context.Context, info router.DialInfo, candidates []router.CandidateInfo) (router.RouteSelection, error) {
+	loader := h.loaderFor(info.AppName)
+	if loader == nil || !loader.IsActive() || len(candidates) == 0 {
+		return router.RouteSelection{Chosen: -1}, nil
+	}
+	prov := h.provider
+	if prov == nil {
+		prov = NopProvider()
+	}
+	policyCandidates := make([]Candidate, 0, len(candidates))
+	for _, c := range candidates {
+		geoCodes := make([]string, len(c.Hops))
+		kinds := make([]string, 0, len(c.Hops))
+		seenKinds := make(map[string]struct{}, len(c.Hops))
+		for i, pk := range c.Hops {
+			geoCodes[i] = prov.Geo(pk)
+			if k := prov.Kind(pk); k != "" {
+				if _, ok := seenKinds[k]; !ok {
+					kinds = append(kinds, k)
+					seenKinds[k] = struct{}{}
+				}
+			}
+		}
+		policyCandidates = append(policyCandidates, Candidate{
+			Hops:           append([]string(nil), c.Hops...),
+			HopsGeo:        geoCodes,
+			EstLatencyMs:   c.EstLatencyMs,
+			TransportKinds: kinds,
+		})
+	}
+	rctx := RoutingContext{
+		App:    info.AppName,
+		PeerPK: info.PeerPK.Hex(),
+		Port:   uint16(info.RPort),
+	}
+	spec, err := loader.Decide(ctx, rctx, policyCandidates)
+	if err != nil {
+		return router.RouteSelection{Chosen: -1}, err
+	}
+	if spec.Fallback == "drop" {
+		return router.RouteSelection{Drop: true, Chosen: -1}, nil
+	}
+	if spec.Chosen == nil {
+		return router.RouteSelection{Chosen: -1}, nil
+	}
+	idx := matchCandidate(policyCandidates, *spec.Chosen)
+	return router.RouteSelection{Chosen: idx}, nil
+}
+
+// matchCandidate finds the index of want in pool by Hops equality.
+// Returns -1 if no match — the script returned a fabricated
+// candidate that doesn't correspond to any input, in which case we
+// defer to the router's built-in pick.
+func matchCandidate(pool []Candidate, want Candidate) int {
+	for i, c := range pool {
+		if hopsEqual(c.Hops, want.Hops) {
+			return i
+		}
+	}
+	return -1
+}
+
+func hopsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -110,6 +110,87 @@ func TestHook_NoopLoader_ReturnsEmptyAdjustment(t *testing.T) {
 	}
 }
 
+func TestHook_SelectRoute_PicksByGeo(t *testing.T) {
+	// Indonesia-Friday-style filter, distilled: pick whichever
+	// candidate route includes a hop in country "ID". Three input
+	// candidates with different geo footprints; only candidate 1
+	// touches ID.
+	src := `
+def decide_route(ctx, candidates):
+    for c in candidates:
+        if "ID" in c.hops_geo:
+            return RouteSpec(chosen = c)
+    return RouteSpec()
+`
+	hopA := "020000000000000000000000000000000000000000000000000000000000000001"
+	hopB := "020000000000000000000000000000000000000000000000000000000000000002"
+	hopC := "020000000000000000000000000000000000000000000000000000000000000003"
+
+	prov := NewFakeProvider().
+		SetGeo(hopA, "DE").
+		SetGeo(hopB, "ID").
+		SetGeo(hopC, "US")
+
+	loader, err := NewLoader(src, WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader, WithHookProvider(prov))
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+
+	cands := []router.CandidateInfo{
+		{Hops: []string{hopA, hopC}}, // DE, US
+		{Hops: []string{hopA, hopB}}, // DE, ID — should win
+		{Hops: []string{hopC}},       // US
+	}
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "skychat", PeerPK: pk}, cands)
+	if err != nil {
+		t.Fatalf("SelectRoute: %v", err)
+	}
+	if sel.Drop {
+		t.Fatalf("unexpected drop")
+	}
+	if sel.Chosen != 1 {
+		t.Errorf("Chosen=%d, want 1 (the ID-touching candidate)", sel.Chosen)
+	}
+}
+
+func TestHook_SelectRoute_NoMatchDefers(t *testing.T) {
+	// Script returns an empty RouteSpec when nothing matches —
+	// hook surfaces Chosen=-1 so the router falls back to its
+	// built-in disjoint-path pick.
+	src := `
+def decide_route(ctx, candidates):
+    for c in candidates:
+        if "ZZ" in c.hops_geo:
+            return RouteSpec(chosen = c)
+    return RouteSpec()
+`
+	hopA := "020000000000000000000000000000000000000000000000000000000000000001"
+	prov := NewFakeProvider().SetGeo(hopA, "DE")
+
+	loader, err := NewLoader(src, WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader, WithHookProvider(prov))
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk},
+		[]router.CandidateInfo{{Hops: []string{hopA}}})
+	if err != nil {
+		t.Fatalf("SelectRoute: %v", err)
+	}
+	if sel.Chosen != -1 {
+		t.Errorf("Chosen=%d, want -1 (defer to router pick)", sel.Chosen)
+	}
+}
+
 func TestHook_DropMode_ErrorPropagates(t *testing.T) {
 	// Script that always errors. With FailureDrop, the loader
 	// propagates the error; the hook surfaces it as a non-nil

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -646,6 +646,52 @@ fetchRoutesAgain:
 	// the route-finder returned a single candidate (lookup is built
 	// but never iterated).
 	latencyFor := r.buildLatencyLookup(ctx, paths[forward], paths[backward])
+
+	// Routing-policy candidate selection. When the configured
+	// DialHook also implements RouteSelectingHook, hand it the
+	// forward-direction candidates so the operator's script can
+	// filter / pick by geo / latency / transport-kind. The hook's
+	// Chosen index overrides the disjoint-path pick for the
+	// forward direction; the reverse direction still goes through
+	// the existing latency-ranked pick. Failure-safe — any error
+	// from the hook falls through to pickDisjointPath.
+	if sh, ok := r.conf.DialHook.(RouteSelectingHook); ok && sh != nil && len(paths[forward]) > 0 {
+		hookCandidates := make([]CandidateInfo, 0, len(paths[forward]))
+		for _, hops := range paths[forward] {
+			intermediates := intermediatesOfHops(hops, src, dst)
+			hopHex := make([]string, 0, len(intermediates))
+			for _, pk := range intermediates {
+				hopHex = append(hopHex, pk.Hex())
+			}
+			latSum := pathLatencyScore(hops, latencyFor)
+			hookCandidates = append(hookCandidates, CandidateInfo{
+				Hops:         hopHex,
+				EstLatencyMs: int(latSum),
+			})
+		}
+		info := DialInfo{
+			AppName: opts.AppName,
+			PeerPK:  dst,
+		}
+		if sel, herr := sh.SelectRoute(ctx, info, hookCandidates); herr != nil {
+			log.WithError(herr).Debug("Routing policy SelectRoute errored; falling back to disjoint-path pick.")
+		} else if sel.Drop {
+			log.WithField("policy_decision", "drop").Info("Routing policy dropped dial at SelectRoute.")
+			return nil, nil, ErrDialPolicyDropped
+		} else if sel.Chosen >= 0 && sel.Chosen < len(paths[forward]) {
+			chosenFwd := paths[forward][sel.Chosen]
+			excludeSet := make(map[cipher.PubKey]struct{}, len(opts.ExcludeIntermediatePKs))
+			for _, pk := range opts.ExcludeIntermediatePKs {
+				excludeSet[pk] = struct{}{}
+			}
+			if revPath, revOk := pickBestDirection(paths[backward], excludeSet, latencyFor); revOk {
+				log.WithField("policy_chosen", sel.Chosen).Debug("Routing policy selected forward route.")
+				return chosenFwd, revPath, nil
+			}
+			log.Debug("Routing policy picked a forward route but no acceptable reverse; falling back to disjoint pick.")
+		}
+	}
+
 	fwdPath, revPath, ok := pickDisjointPath(paths[forward], paths[backward], opts.ExcludeIntermediatePKs, latencyFor)
 	if !ok {
 		log.Debugf("No route-finder path avoids the %d excluded intermediates; trying local route calc fallback", len(opts.ExcludeIntermediatePKs))

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -215,7 +215,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 				if werr := loader.Watch(policyLogger); werr != nil {
 					log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
 				}
-				hook = policy.NewHook(loader)
+				hook = policy.NewHook(loader, policy.WithHookProvider(makeProvider()))
 				v.pushCloseStack("router.policy", loader.Close)
 				log.WithField("source", loader.Source()).Info("Routing policy active.")
 			}
@@ -239,7 +239,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 					log.WithError(werr).WithField("app", app.Name).Warn("Per-app routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
 				}
 				if hook == nil {
-					hook = policy.NewHook(nil)
+					hook = policy.NewHook(nil, policy.WithHookProvider(makeProvider()))
 				}
 				hook.RegisterApp(app.Name, appLoader)
 				appName := app.Name


### PR DESCRIPTION
## Summary
Closes the last gap in the routing-policy stack (#2882 → #2885 → #2890): the script's `decide_route(ctx, candidates)` now actually receives the route-finder's candidate list with `HopsGeo`, `EstLatencyMs`, and `TransportKinds` populated, so geo / transport-kind / latency filters can filter routes instead of just decorating logs.

- **`router.RouteSelectingHook`** — optional secondary interface (`DialHook` + `SelectRoute`). Router type-asserts; implementers that don't need candidate filtering keep the simpler `BeforeDial`-only contract.
- **`router_dial.go.fetchBestRoutes`** — after `RouteFinder.FindRoutes` returns and the latency lookup is built, fold each forward path into a `CandidateInfo` and call `SelectRoute`. A chosen index replaces the disjoint-path forward pick; the reverse direction still goes through the existing latency-ranked `pickBestDirection`. Errors fall through to the disjoint-path code path (failure-safe).
- **`policy.Hook.SelectRoute`** — enriches each input candidate with `HopsGeo` and `TransportKinds` via the configured Provider, calls the loader's `Decide`, and maps the script's returned `Candidate` back to an index by `Hops` equality. Fabricated candidates → defer to router.
- **Provider wiring** — `WithHookProvider(p)` option on `NewHook` (back-compat via variadic); `init_router.go` passes the visor's Provider so the enrichment paths get real geo data instead of `"??"`.

Together with #2890, the operator's `if "ID" in c.hops_geo: return RouteSpec(chosen=c)` filter actually works now.

## Test plan
- [x] `go build .` clean
- [x] `pkg/router/policy/...` tests pass
- [x] Full `pkg/router/...` suite passes
- [x] `TestHook_SelectRoute_PicksByGeo` — three candidates, only middle one touches `"ID"`, script picks it, hook returns Chosen=1
- [x] `TestHook_SelectRoute_NoMatchDefers` — script returns empty spec when nothing matches, hook returns Chosen=-1 (router falls back)
- [ ] Live visor with a `decide_route` that picks by `hops_geo` — verify log shows `Routing policy selected forward route.` with the expected `policy_chosen` index

## Notes
- The reverse direction is intentionally NOT script-controllable today. Most workloads care about forward-direction selection (where the bandwidth lives) and the disjoint-path pick already runs each direction's latency rank independently.
- Hook errors are debug-logged and fall through to the disjoint-path pick — a buggy policy never breaks dialing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)