### PR TITLE
chore(lint): gofmt + misspell + errcheck cleanup on develop

### DIFF
--- a/cmd/skywire-cli/commands/route/policy.go
+++ b/cmd/skywire-cli/commands/route/policy.go
@@ -85,10 +85,11 @@ values.`,
 		if err := json.Unmarshal([]byte(policyDialJSON), &dial); err != nil {
 			return fmt.Errorf("parse --dial JSON: %w", err)
 		}
-		rctx, candidates, err := dial.toContext()
+		rctx, err := dial.toContext()
 		if err != nil {
 			return err
 		}
+		var candidates []policy.Candidate
 		// Clock fixed to the dial's `now` (or system time if
 		// unset) so the test result is deterministic regardless
 		// of when the operator runs the command.
@@ -182,7 +183,7 @@ type dialJSON struct {
 	// uses empty candidates.
 }
 
-func (d dialJSON) toContext() (policy.RoutingContext, []policy.Candidate, error) {
+func (d dialJSON) toContext() (policy.RoutingContext, error) {
 	rctx := policy.RoutingContext{
 		App:    d.App,
 		PeerPK: d.PeerPK,
@@ -191,7 +192,7 @@ func (d dialJSON) toContext() (policy.RoutingContext, []policy.Candidate, error)
 	if d.Now != "" {
 		t, err := time.Parse(time.RFC3339, d.Now)
 		if err != nil {
-			return rctx, nil, fmt.Errorf("parse now: %w", err)
+			return rctx, fmt.Errorf("parse now: %w", err)
 		}
 		rctx.Now = t
 	} else if d.Friday {
@@ -202,7 +203,7 @@ func (d dialJSON) toContext() (policy.RoutingContext, []policy.Candidate, error)
 	} else {
 		rctx.Now = time.Now()
 	}
-	return rctx, nil, nil
+	return rctx, nil
 }
 
 type fixedClock struct{ t time.Time }

--- a/pkg/dmsg/dmsgscp/host.go
+++ b/pkg/dmsg/dmsgscp/host.go
@@ -30,8 +30,8 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/pty"
 )
 
 // Whitelist is an alias for pty.Whitelist so operators can pass

--- a/pkg/router/policy/evaluator.go
+++ b/pkg/router/policy/evaluator.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
 // DefaultTimeout is the per-call timeout enforced via a step
@@ -70,9 +70,9 @@ type Evaluator struct {
 
 	// globals holds the result of executing the script's
 	// top-level statements once. The decide_route function lives
-	// here. Cached so each Decide doesn't re-evaluate top-level.
-	globalsMu sync.Mutex
-	globals   starlark.StringDict
+	// here. Cached at NewEvaluator time and frozen, so concurrent
+	// Decide calls can read it without locking.
+	globals starlark.StringDict
 }
 
 // Option configures an Evaluator at construction.
@@ -136,8 +136,11 @@ func NewEvaluator(name, src string, opts ...Option) (*Evaluator, error) {
 		opt(e)
 	}
 
-	// Parse + compile once. Each Decide reuses the program.
-	_, program, err := starlark.SourceProgram(name, src, e.preDeclared().Has)
+	// Parse + compile once. Each Decide reuses the program. Use
+	// FileOptions explicitly so the linter doesn't flag the
+	// legacy SourceProgram which carries global-state side effects.
+	fileOpts := syntax.LegacyFileOptions()
+	_, program, err := starlark.SourceProgramOptions(fileOpts, name, src, e.preDeclared().Has)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", name, err)
 	}
@@ -180,10 +183,10 @@ func NewEvaluator(name, src string, opts ...Option) (*Evaluator, error) {
 // goroutine-based wall-clock timeout (which had a race: the
 // cancel-watch goroutine could fire Cancel before starlark.Call
 // even started executing, surfacing as a spurious "computation
-// cancelled" error on scripts that actually take microseconds).
+// canceled" error on scripts that actually take microseconds).
 //
 // ctx is checked once at entry — if the caller's dial ctx is
-// already cancelled, we short-circuit to the fallback without
+// already canceled, we short-circuit to the fallback without
 // attempting evaluation. We don't propagate ctx cancellation
 // mid-script because the step cap already gives us a tight
 // upper bound on execution time.

--- a/pkg/router/policy/evaluator_test.go
+++ b/pkg/router/policy/evaluator_test.go
@@ -147,13 +147,19 @@ func TestPerApp_VPNGetsMux4_SkychatGetsMux1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEvaluator: %v", err)
 	}
-	specSkychat, _ := eval.Decide(context.Background(), RoutingContext{App: "skychat"},
+	specSkychat, decErr := eval.Decide(context.Background(), RoutingContext{App: "skychat"},
 		[]Candidate{candidateThroughUSFastest})
+	if decErr != nil {
+		t.Fatalf("Decide(skychat): %v", decErr)
+	}
 	if specSkychat.Mux != 1 {
 		t.Errorf("skychat: mux=%d, want 1", specSkychat.Mux)
 	}
-	specVPN, _ := eval.Decide(context.Background(), RoutingContext{App: "vpn-client"},
+	specVPN, decErr := eval.Decide(context.Background(), RoutingContext{App: "vpn-client"},
 		[]Candidate{candidateThroughUSFastest})
+	if decErr != nil {
+		t.Fatalf("Decide(vpn-client): %v", decErr)
+	}
 	if specVPN.Mux != 4 {
 		t.Errorf("vpn-client: mux=%d, want 4", specVPN.Mux)
 	}

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -79,12 +79,12 @@ func (h *Hook) loaderFor(appName string) *Loader {
 //
 // The loader's failure-mode wiring (Fallback vs. Drop) determines
 // what the policy script's failure looks like to the router:
-// - FailureFallback (default): a broken script returns an empty
-//   RouteSpec → empty DialAdjustment → router proceeds with the
-//   caller's original opts. No error surfaced.
-// - FailureDrop: errors propagate up here as a real error; the
-//   router sees an error from BeforeDial and logs it but still
-//   proceeds (failure-safe at the router layer too).
+//   - FailureFallback (default): a broken script returns an empty
+//     RouteSpec → empty DialAdjustment → router proceeds with the
+//     caller's original opts. No error surfaced.
+//   - FailureDrop: errors propagate up here as a real error; the
+//     router sees an error from BeforeDial and logs it but still
+//     proceeds (failure-safe at the router layer too).
 func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.DialAdjustment, error) {
 	loader := h.loaderFor(info.AppName)
 	if loader == nil || !loader.IsActive() {


### PR DESCRIPTION
## Summary
Five lint failures piled up on develop after recent merges (#2890/#2891/#2892 + #2876 rename). This sweep clears them so unrelated open PRs (#2881 dependabot, #2882/#2863 RFCs, #2886 rewards) can land without inheriting the broken state.

- \`pkg/dmsg/dmsgscp/host.go\` — import group reorder for gofmt
- \`pkg/router/policy/hook.go\` — gofmt doc-comment indentation
- \`pkg/router/policy/evaluator.go\`:
  - drop legacy \`SourceProgram\` (SA1019) for \`SourceProgramOptions\` + \`LegacyFileOptions\`
  - \`cancelled\` → \`canceled\` (misspell)
  - drop unused \`globalsMu\` mutex (frozen StringDict needs no lock)
- \`pkg/router/policy/evaluator_test.go\` — check \`Decide\` error returns instead of \`_, _ :=\` discard (errcheck)
- \`cmd/skywire-cli/commands/route/policy.go\` — drop always-nil candidates slot from \`dialJSON.toContext\` (unparam)

## Test plan
- [x] \`golangci-lint run\` clean
- [x] \`go test ./pkg/router/policy/...\` passes
- [x] \`go build .\` clean