### PR TITLE
feat(hypervisor): GET /api/pk + DisablePKEndpoint + SW-Public gate

### DIFF
--- a/cmd/skywire-cli/commands/rewards/transports.go
+++ b/cmd/skywire-cli/commands/rewards/transports.go
@@ -220,12 +220,15 @@ type VisorBandwidthResult map[string]uint64
 
 // BandwidthDataVersion is the current bw-collect output schema version.
 // v1 = bare {pk:bytes} map (no per-transport detail; full sent+recv
-//      credited to BOTH edges; no counterparty eligibility filter
-//      possible at calc time).
+//
+//	credited to BOTH edges; no counterparty eligibility filter
+//	possible at calc time).
+//
 // v2 = {version:2, transports:[{a,b,sent_a,sent_b}]} — preserves
-//      per-transport detail so the calculator can (a) drop transports
-//      where either edge is reward-ineligible and (b) credit each edge
-//      only for the bytes it actually sent (sender-pays model).
+//
+//	per-transport detail so the calculator can (a) drop transports
+//	where either edge is reward-ineligible and (b) credit each edge
+//	only for the bytes it actually sent (sender-pays model).
 const BandwidthDataVersion = 2
 
 // TransportBW is one bidirectional transport's per-edge sent bytes,

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -614,6 +614,15 @@ func (hv *Hypervisor) makeMux() chi.Router {
 
 			r.Get("/user-exists", hv.users.UserExists())
 
+			// Unauthenticated pubkey-discovery route used by
+			// skybian's first-boot autoconfig. SW-Public header
+			// gates it as a soft "looks like another visor"
+			// check. Suppressed entirely when the operator sets
+			// DisablePKEndpoint=true.
+			if !hv.c.DisablePKEndpoint {
+				r.Get("/pk", hv.getPK())
+			}
+
 			if hv.c.EnableAuth {
 				r.Group(func(r chi.Router) {
 					r.Post("/create-account", hv.users.CreateAccount())

--- a/pkg/visor/hypervisor_handlers_misc.go
+++ b/pkg/visor/hypervisor_handlers_misc.go
@@ -3,8 +3,10 @@ package visor
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -49,6 +51,48 @@ func (hv *Hypervisor) getAbout() http.HandlerFunc {
 			Build:         buildinfo.Get(),
 			DmsgConnected: dmsgConnected,
 			DmsgSessions:  dmsgSessions,
+		})
+	}
+}
+
+// getPK serves GET /api/pk — returns the hypervisor's own pubkey
+// as JSON. Unauthenticated by design: skybian's first-boot
+// autoconfig (skymanager.sh) needs the pubkey to peer with the
+// hypervisor before any account exists.
+//
+// Soft gate: the caller must send an SW-Public header naming its
+// own (well-formed) cipher.PubKey. This is a "looks like another
+// visor" check, not real auth — no nonce, no signature. It's
+// enough to keep casual scanners from harvesting hypervisor
+// pubkeys via random GETs without raising the bar so high that
+// the autoconfig flow breaks.
+//
+// Response shape (snake_case to match other /api/ JSON envelopes):
+//
+//	{"public_key": "<66-hex>"}
+//
+// Suppressed entirely when HypervisorConfig.DisablePKEndpoint is
+// true (the route isn't registered at all in that case).
+func (hv *Hypervisor) getPK() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := strings.TrimSpace(r.Header.Get("SW-Public"))
+		if caller == "" {
+			httputil.WriteJSON(w, r, http.StatusUnauthorized, struct {
+				Error string `json:"error"`
+			}{Error: "SW-Public header required"})
+			return
+		}
+		var callerPK cipher.PubKey
+		if err := callerPK.Set(caller); err != nil {
+			httputil.WriteJSON(w, r, http.StatusBadRequest, struct {
+				Error string `json:"error"`
+			}{Error: "SW-Public header is not a valid public key"})
+			return
+		}
+		httputil.WriteJSON(w, r, http.StatusOK, struct {
+			PublicKey cipher.PubKey `json:"public_key"`
+		}{
+			PublicKey: hv.c.PK,
 		})
 	}
 }

--- a/pkg/visor/hypervisor_test.go
+++ b/pkg/visor/hypervisor_test.go
@@ -432,3 +432,90 @@ func decodeErrorBody(rb io.Reader) (*ErrorBody, error) {
 
 	return b, dec.Decode(b)
 }
+
+func TestPKEndpoint(t *testing.T) {
+	const callerPKHex = "030000000000000000000000000000000000000000000000000000000000000001"
+
+	t.Run("default_enabled_with_header_returns_pk", func(t *testing.T) {
+		config := visorconfig.MakeConfig(false)
+		config.EnableAuth = false
+		config.FillDefaults(false)
+		config.DBPath = filepath.Join(os.TempDir(), "users_pk_default.db")
+
+		addr, client, closeFn := makeStartNode(t, config)
+		defer closeFn()
+
+		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/api/pk", nil)
+		require.NoError(t, err)
+		req.Header.Set("SW-Public", callerPKHex)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body struct {
+			PublicKey string `json:"public_key"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		require.Len(t, body.PublicKey, 66, "public_key should be 66 hex chars")
+		require.Equal(t, config.PK.Hex(), body.PublicKey)
+	})
+
+	t.Run("missing_sw_public_returns_401", func(t *testing.T) {
+		config := visorconfig.MakeConfig(false)
+		config.EnableAuth = false
+		config.FillDefaults(false)
+		config.DBPath = filepath.Join(os.TempDir(), "users_pk_noheader.db")
+
+		addr, client, closeFn := makeStartNode(t, config)
+		defer closeFn()
+
+		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/api/pk", nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("malformed_sw_public_returns_400", func(t *testing.T) {
+		config := visorconfig.MakeConfig(false)
+		config.EnableAuth = false
+		config.FillDefaults(false)
+		config.DBPath = filepath.Join(os.TempDir(), "users_pk_malformed.db")
+
+		addr, client, closeFn := makeStartNode(t, config)
+		defer closeFn()
+
+		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/api/pk", nil)
+		require.NoError(t, err)
+		req.Header.Set("SW-Public", "notapubkey")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("disabled_returns_404", func(t *testing.T) {
+		config := visorconfig.MakeConfig(false)
+		config.EnableAuth = false
+		config.DisablePKEndpoint = true
+		config.FillDefaults(false)
+		config.DBPath = filepath.Join(os.TempDir(), "users_pk_disabled.db")
+
+		addr, client, closeFn := makeStartNode(t, config)
+		defer closeFn()
+
+		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/api/pk", nil)
+		require.NoError(t, err)
+		req.Header.Set("SW-Public", callerPKHex)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -55,21 +55,30 @@ func (hk *Key) UnmarshalText(text []byte) error {
 
 // HypervisorConfig configures the hypervisor.
 type HypervisorConfig struct {
-	Enable        bool               `json:"enable"` // Whether the hypervisor is enabled (starts HTTP + DMSG on visor startup).
-	UIAssets      fs.FS              `json:"-"`
-	PK            cipher.PubKey      `json:"-"`
-	SK            cipher.SecKey      `json:"-"`
-	DBPath        string             `json:"db_path"`                   // Path to store database file.
-	EnableAuth    bool               `json:"enable_auth"`               // Whether to enable user management.
-	Cookies       CookieConfig       `json:"cookies"`                   // Configures cookies (for session management).
-	DmsgDiscovery string             `json:"-"`                         // Dmsg discovery address.
-	DmsgPort      uint16             `json:"dmsg_port,omitempty"`       // Dmsg port to serve on.
-	HTTPAddr      string             `json:"http_addr"`                 // HTTP address to serve API/web UI on.
-	EnableTLS     bool               `json:"enable_tls"`                // Whether to enable TLS.
-	TLSCertFile   string             `json:"tls_cert_file"`             // TLS cert file location.
-	TLSKeyFile    string             `json:"tls_key_file"`              // TLS key file location.
-	TPViz         TPVizConfig        `json:"tp_viz"`                    // Transport visualizer config.
-	LANDmsgServer *LANDmsgServerConf `json:"lan_dmsg_server,omitempty"` // LAN DMSG server config.
+	Enable     bool          `json:"enable"` // Whether the hypervisor is enabled (starts HTTP + DMSG on visor startup).
+	UIAssets   fs.FS         `json:"-"`
+	PK         cipher.PubKey `json:"-"`
+	SK         cipher.SecKey `json:"-"`
+	DBPath     string        `json:"db_path"`     // Path to store database file.
+	EnableAuth bool          `json:"enable_auth"` // Whether to enable user management.
+	// DisablePKEndpoint, when true, suppresses the otherwise-
+	// unauthenticated GET /api/pk route used by skybian's first-
+	// boot autoconfig to discover the hypervisor's pubkey. Default
+	// false (route is registered) so the autoconfig path keeps
+	// working. Inverted so a missing JSON field — the common case
+	// for upgrade-in-place configs — preserves existing behavior.
+	// Requests still must carry an SW-Public header naming the
+	// caller's PK; see hypervisor_handlers_misc.go.
+	DisablePKEndpoint bool               `json:"disable_pk_endpoint,omitempty"`
+	Cookies           CookieConfig       `json:"cookies"`                   // Configures cookies (for session management).
+	DmsgDiscovery     string             `json:"-"`                         // Dmsg discovery address.
+	DmsgPort          uint16             `json:"dmsg_port,omitempty"`       // Dmsg port to serve on.
+	HTTPAddr          string             `json:"http_addr"`                 // HTTP address to serve API/web UI on.
+	EnableTLS         bool               `json:"enable_tls"`                // Whether to enable TLS.
+	TLSCertFile       string             `json:"tls_cert_file"`             // TLS cert file location.
+	TLSKeyFile        string             `json:"tls_key_file"`              // TLS key file location.
+	TPViz             TPVizConfig        `json:"tp_viz"`                    // Transport visualizer config.
+	LANDmsgServer     *LANDmsgServerConf `json:"lan_dmsg_server,omitempty"` // LAN DMSG server config.
 	// CXOSubscribeInterval is the resync floor for the on-demand
 	// CXO subscription manager. Subscriptions stay open while a UI
 	// tab is acquired; the manager won't tear down a feed sooner


### PR DESCRIPTION
## Summary
Implements the \`/api/pk\` endpoint described in \`skybian/docs/skywire-pk-endpoint-spec.md\` (skymanager.sh's first-boot pubkey discovery), with two additions from the original spec:

1. **Operator opt-out** via \`HypervisorConfig.DisablePKEndpoint\` (default \`false\`). When set, the route isn't registered at all — chi returns 404, indistinguishable from a hypervisor that doesn't implement \`/api/pk\`. Field is inverted (\`Disable*\`) so a missing JSON key preserves existing behavior on upgrade-in-place configs.

2. **SW-Public header gate.** Caller must send the standard \`SW-Public\` header naming its own \`cipher.PubKey\` (66-hex). Soft "looks like another visor" check — no nonce, no signature, no real auth. Matches the existing pkg/httpauthclient convention. Enough to keep casual scanners from harvesting hypervisor pubkeys via untargeted GETs without breaking the autoconfig flow.

| Request | Response |
|---|---|
| no SW-Public | 401 |
| malformed SW-Public | 400 |
| well-formed SW-Public | 200 \`{"public_key":"<66-hex>"}\` |
| route disabled | 404 |

### Files
- \`pkg/visor/visorconfig/hypervisorconfig.go\` — \`DisablePKEndpoint bool\` field
- \`pkg/visor/hypervisor_handlers_misc.go\` — \`getPK()\` handler
- \`pkg/visor/hypervisor.go\` — route registration in existing unauth block, gated on \`!hv.c.DisablePKEndpoint\`
- \`pkg/visor/hypervisor_test.go\` — \`TestPKEndpoint\` with 4 sub-tests (header present, missing, malformed, disabled)

Includes a one-line gofmt cleanup of \`cmd/skywire-cli/commands/rewards/transports.go\` — a develop-state lint failure blocking every PR's CI.

### Companion change
\`skymanager.sh\` in skybian needs to send the \`SW-Public\` header naming the requesting visor's PK. Spec doc will be updated to reflect both knobs in a separate skybian PR.

## Test plan
- [x] \`golangci-lint run\` clean
- [x] \`go test ./pkg/visor/ -run TestPKEndpoint\` — all 4 sub-tests pass
- [x] \`go build .\` clean
- [ ] Live hypervisor: \`curl -fsS -H 'SW-Public: <visor-pk>' http://<hv>:8000/api/pk\` returns hypervisor PK
- [ ] Same \`curl\` without header → 401
- [ ] Hypervisor with \`disable_pk_endpoint: true\` → 404 with SW-Public set