### PR TITLE
fix(hypervisor): flip pk-endpoint to opt-in + add config-gen flag

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -235,6 +235,8 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "noauth")
 	genConfigCmd.Flags().BoolVarP(&isEnableAuth, "auth", "e", false, "enable auth on hypervisor UI")
 	gHiddenFlags = append(gHiddenFlags, "auth")
+	genConfigCmd.Flags().BoolVar(&isEnablePKEndpoint, "pk-endpoint", scriptExecBool("${ENABLEPKENDPOINT:-false}"), "expose unauthenticated GET /api/pk on the hypervisor (skybian / Arch-ARM image builds set this)")
+	gHiddenFlags = append(gHiddenFlags, "pk-endpoint")
 
 	// Dmsgpty and survey whitelist flags
 	msg = "add dmsgpty whitelist PKs"
@@ -1323,6 +1325,7 @@ func configureHypervisor(log *logging.Logger) {
 	{
 		config := visorconfig.GenerateWorkDirConfig(isTestEnv)
 		config.Enable = isHypervisor
+		config.EnablePKEndpoint = isEnablePKEndpoint
 		if hvHTTPAddr != "" {
 			config.HTTPAddr = hvHTTPAddr
 		} else {

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -49,6 +49,7 @@ var (
 	isVpnServerEnable          bool
 	isDisableAuth              bool
 	isEnableAuth               bool
+	isEnablePKEndpoint         bool
 	selectedOS                 string
 	disableApps                string
 	serviceConfURL             = deployment.ProdConf.Conf

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -617,9 +617,10 @@ func (hv *Hypervisor) makeMux() chi.Router {
 			// Unauthenticated pubkey-discovery route used by
 			// skybian's first-boot autoconfig. SW-Public header
 			// gates it as a soft "looks like another visor"
-			// check. Suppressed entirely when the operator sets
-			// DisablePKEndpoint=true.
-			if !hv.c.DisablePKEndpoint {
+			// check. Off by default — only registered when the
+			// operator (typically the skybian / Arch-ARM image
+			// build) sets EnablePKEndpoint=true.
+			if hv.c.EnablePKEndpoint {
 				r.Get("/pk", hv.getPK())
 			}
 

--- a/pkg/visor/hypervisor_handlers_misc.go
+++ b/pkg/visor/hypervisor_handlers_misc.go
@@ -60,6 +60,11 @@ func (hv *Hypervisor) getAbout() http.HandlerFunc {
 // autoconfig (skymanager.sh) needs the pubkey to peer with the
 // hypervisor before any account exists.
 //
+// Off by default — the route is only registered when
+// HypervisorConfig.EnablePKEndpoint is true. The skybian /
+// Arch-ARM image builds flip it on; vanilla hypervisor configs
+// leave it off.
+//
 // Soft gate: the caller must send an SW-Public header naming its
 // own (well-formed) cipher.PubKey. This is a "looks like another
 // visor" check, not real auth — no nonce, no signature. It's
@@ -70,9 +75,6 @@ func (hv *Hypervisor) getAbout() http.HandlerFunc {
 // Response shape (snake_case to match other /api/ JSON envelopes):
 //
 //	{"public_key": "<66-hex>"}
-//
-// Suppressed entirely when HypervisorConfig.DisablePKEndpoint is
-// true (the route isn't registered at all in that case).
 func (hv *Hypervisor) getPK() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := strings.TrimSpace(r.Header.Get("SW-Public"))

--- a/pkg/visor/hypervisor_test.go
+++ b/pkg/visor/hypervisor_test.go
@@ -436,11 +436,35 @@ func decodeErrorBody(rb io.Reader) (*ErrorBody, error) {
 func TestPKEndpoint(t *testing.T) {
 	const callerPKHex = "030000000000000000000000000000000000000000000000000000000000000001"
 
-	t.Run("default_enabled_with_header_returns_pk", func(t *testing.T) {
+	// Default config has EnablePKEndpoint=false — the route isn't
+	// registered, so any GET /api/pk returns 404 regardless of
+	// header state. Pins the off-by-default semantics.
+	t.Run("default_off_returns_404", func(t *testing.T) {
 		config := visorconfig.MakeConfig(false)
 		config.EnableAuth = false
 		config.FillDefaults(false)
-		config.DBPath = filepath.Join(os.TempDir(), "users_pk_default.db")
+		config.DBPath = filepath.Join(os.TempDir(), "users_pk_off.db")
+
+		addr, client, closeFn := makeStartNode(t, config)
+		defer closeFn()
+
+		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/api/pk", nil)
+		require.NoError(t, err)
+		req.Header.Set("SW-Public", callerPKHex)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close() //nolint:errcheck
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	// Enabled + well-formed SW-Public → 200 with pubkey.
+	t.Run("enabled_with_header_returns_pk", func(t *testing.T) {
+		config := visorconfig.MakeConfig(false)
+		config.EnableAuth = false
+		config.EnablePKEndpoint = true
+		config.FillDefaults(false)
+		config.DBPath = filepath.Join(os.TempDir(), "users_pk_enabled.db")
 
 		addr, client, closeFn := makeStartNode(t, config)
 		defer closeFn()
@@ -462,9 +486,11 @@ func TestPKEndpoint(t *testing.T) {
 		require.Equal(t, config.PK.Hex(), body.PublicKey)
 	})
 
-	t.Run("missing_sw_public_returns_401", func(t *testing.T) {
+	// Enabled + no SW-Public → 401.
+	t.Run("enabled_missing_sw_public_returns_401", func(t *testing.T) {
 		config := visorconfig.MakeConfig(false)
 		config.EnableAuth = false
+		config.EnablePKEndpoint = true
 		config.FillDefaults(false)
 		config.DBPath = filepath.Join(os.TempDir(), "users_pk_noheader.db")
 
@@ -480,9 +506,11 @@ func TestPKEndpoint(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	})
 
-	t.Run("malformed_sw_public_returns_400", func(t *testing.T) {
+	// Enabled + malformed SW-Public → 400.
+	t.Run("enabled_malformed_sw_public_returns_400", func(t *testing.T) {
 		config := visorconfig.MakeConfig(false)
 		config.EnableAuth = false
+		config.EnablePKEndpoint = true
 		config.FillDefaults(false)
 		config.DBPath = filepath.Join(os.TempDir(), "users_pk_malformed.db")
 
@@ -497,25 +525,5 @@ func TestPKEndpoint(t *testing.T) {
 		defer resp.Body.Close() //nolint:errcheck
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	})
-
-	t.Run("disabled_returns_404", func(t *testing.T) {
-		config := visorconfig.MakeConfig(false)
-		config.EnableAuth = false
-		config.DisablePKEndpoint = true
-		config.FillDefaults(false)
-		config.DBPath = filepath.Join(os.TempDir(), "users_pk_disabled.db")
-
-		addr, client, closeFn := makeStartNode(t, config)
-		defer closeFn()
-
-		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/api/pk", nil)
-		require.NoError(t, err)
-		req.Header.Set("SW-Public", callerPKHex)
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close() //nolint:errcheck
-
-		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 }

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -61,24 +61,26 @@ type HypervisorConfig struct {
 	SK         cipher.SecKey `json:"-"`
 	DBPath     string        `json:"db_path"`     // Path to store database file.
 	EnableAuth bool          `json:"enable_auth"` // Whether to enable user management.
-	// DisablePKEndpoint, when true, suppresses the otherwise-
-	// unauthenticated GET /api/pk route used by skybian's first-
-	// boot autoconfig to discover the hypervisor's pubkey. Default
-	// false (route is registered) so the autoconfig path keeps
-	// working. Inverted so a missing JSON field — the common case
-	// for upgrade-in-place configs — preserves existing behavior.
-	// Requests still must carry an SW-Public header naming the
-	// caller's PK; see hypervisor_handlers_misc.go.
-	DisablePKEndpoint bool               `json:"disable_pk_endpoint,omitempty"`
-	Cookies           CookieConfig       `json:"cookies"`                   // Configures cookies (for session management).
-	DmsgDiscovery     string             `json:"-"`                         // Dmsg discovery address.
-	DmsgPort          uint16             `json:"dmsg_port,omitempty"`       // Dmsg port to serve on.
-	HTTPAddr          string             `json:"http_addr"`                 // HTTP address to serve API/web UI on.
-	EnableTLS         bool               `json:"enable_tls"`                // Whether to enable TLS.
-	TLSCertFile       string             `json:"tls_cert_file"`             // TLS cert file location.
-	TLSKeyFile        string             `json:"tls_key_file"`              // TLS key file location.
-	TPViz             TPVizConfig        `json:"tp_viz"`                    // Transport visualizer config.
-	LANDmsgServer     *LANDmsgServerConf `json:"lan_dmsg_server,omitempty"` // LAN DMSG server config.
+	// EnablePKEndpoint, when true, exposes an unauthenticated
+	// GET /api/pk route returning the hypervisor's pubkey. Off by
+	// default — only the skybian / Arch-linux-ARM image builds
+	// flip it on so first-boot visors can discover the bundled
+	// hypervisor's pubkey without an account. The route still
+	// requires an SW-Public header naming the caller's PK as a
+	// soft "looks like another visor" gate; see
+	// hypervisor_handlers_misc.go. No omitempty — the field is
+	// always serialized so operators see it in the generated
+	// config and know it exists.
+	EnablePKEndpoint bool               `json:"enable_pk_endpoint"`
+	Cookies          CookieConfig       `json:"cookies"`                   // Configures cookies (for session management).
+	DmsgDiscovery    string             `json:"-"`                         // Dmsg discovery address.
+	DmsgPort         uint16             `json:"dmsg_port,omitempty"`       // Dmsg port to serve on.
+	HTTPAddr         string             `json:"http_addr"`                 // HTTP address to serve API/web UI on.
+	EnableTLS        bool               `json:"enable_tls"`                // Whether to enable TLS.
+	TLSCertFile      string             `json:"tls_cert_file"`             // TLS cert file location.
+	TLSKeyFile       string             `json:"tls_key_file"`              // TLS key file location.
+	TPViz            TPVizConfig        `json:"tp_viz"`                    // Transport visualizer config.
+	LANDmsgServer    *LANDmsgServerConf `json:"lan_dmsg_server,omitempty"` // LAN DMSG server config.
 	// CXOSubscribeInterval is the resync floor for the on-demand
 	// CXO subscription manager. Subscriptions stay open while a UI
 	// tab is acquired; the manager won't tear down a feed sooner


### PR DESCRIPTION
## Summary
Follow-up to #2895. The original landed with \`DisablePKEndpoint\` (default off → route enabled by default), but the intended polarity is the opposite: the route should be **off on vanilla configs** and only enabled on the custom skybian / Arch-ARM image builds where the first-boot autoconfig needs it.

- Renames \`DisablePKEndpoint\` → \`EnablePKEndpoint\`, default \`false\`.
- Drops \`omitempty\` so \`enable_pk_endpoint\` always serializes — operators see it in JSON and know the knob exists.
- Adds a \`--pk-endpoint\` flag to \`skywire cli config gen\` (also reads \`$ENABLEPKENDPOINT\` from the env-file template) so the skybian / Arch-ARM image build scripts can flip it on at config-gen time:

  \`\`\`
  skywire cli config gen -in --pk-endpoint > /opt/skywire/skywire.json
  \`\`\`

## Smoke test
\`\`\`
$ ./skywire cli config gen -in | grep enable_pk_endpoint
        "enable_pk_endpoint": false,
$ ./skywire cli config gen -in --pk-endpoint | grep enable_pk_endpoint
        "enable_pk_endpoint": true,
\`\`\`

## Test plan
- [x] \`golangci-lint run\` clean
- [x] \`go test ./pkg/visor/ -run TestPKEndpoint\` — 4 sub-tests pass:
  - \`default_off_returns_404\` — vanilla config → 404 even with SW-Public
  - \`enabled_with_header_returns_pk\` — \`EnablePKEndpoint=true\` + SW-Public → 200
  - \`enabled_missing_sw_public_returns_401\` — \`EnablePKEndpoint=true\` + no header → 401
  - \`enabled_malformed_sw_public_returns_400\` — \`EnablePKEndpoint=true\` + bad header → 400
- [x] \`go build .\` clean
- [x] Smoke-tested \`config gen\` JSON output