### PR TITLE
feat(router/policy): finish Layer 2 packet distribution (RFC phase 5)

### DIFF
--- a/docs/routing_policy_rfc.md
+++ b/docs/routing_policy_rfc.md
@@ -202,11 +202,21 @@ After this phase, the Indonesia-Friday example *works*.
 
 `cli route policy test` + `cli route policy bench` subcommands. File-watcher for hot-reload. Per-app override field on `AppConfig`.
 
-### Phase 5 — Layer 2 distribution descriptor
+### Phase 5 — Layer 2 distribution descriptor (LANDED)
 
-`RouteSpec.distribution` field is parsed and translated into the per-packet Go code's fast path. Starlark stays out of the per-packet path; operator gets to configure distribution from Layer 1.
+`RouteSpec.distribution` field is parsed by `pkg/router/policy.ParseDistribution` and applied to the route group's existing `transportSelector` via `DialAdjustment.Distribution`. Starlark stays out of the per-packet path; operator gets to configure distribution from Layer 1.
 
-Real per-packet scripting (CEL or compiled bytecode) is a separate RFC, opened only when an operator demonstrates a use case that can't be expressed as a static distribution descriptor.
+**Descriptor vocabulary (v1, finalized):**
+
+| Descriptor | Mode | Behavior |
+|---|---|---|
+| `""` | `DistributionUnset` | No override — route group uses the router's visor-wide `muxMode` default (`WeightModeAuto`, latency-weighted). |
+| `"auto"` | `DistributionAuto` | Force `WeightModeAuto` (latency-weighted with round-robin fallback). |
+| `"round-robin"` / `"equal"` | `DistributionRoundRobin` | Force `WeightModeEqual` — packets alternate across legs ignoring latency. |
+| `"weighted: f1, f2, ..."` | `DistributionWeighted` | Operator-supplied fractional weights normalized into the selector's integer schedule. Length must match leg count; mismatches fall through with a log line. |
+| `"size-threshold: N"` | `DistributionSizeThreshold` | Payloads `> N` bytes go to leg 0 (wide pipe); payloads `≤ N` round-robin across the remaining legs. Single-leg routes ignore the descriptor. Control/handshake packets (size unknown) take leg 0. |
+
+Real per-packet scripting (CEL or compiled bytecode) is a separate RFC, opened only when an operator demonstrates a use case that can't be expressed as a static distribution descriptor. The vocabulary above leaves room for that follow-up: descriptors not on this list (`"sticky: 5tuple"`, `"latency-aware"`, etc.) return a parse error today so they can be added meaningfully later without ambiguity.
 
 ## Open questions
 
@@ -216,7 +226,7 @@ Real per-packet scripting (CEL or compiled bytecode) is a separate RFC, opened o
 
 3. **Multi-script composition.** Should an operator be able to `load("./common.star")` shared helpers from their own policy file? Starlark supports this natively; cost is reading multiple files at policy-load time. Default: yes, allow within a single directory; out-of-directory loads rejected.
 
-4. **Layer 2 contract finalization.** What exactly is the distribution descriptor's vocabulary? Just `round-robin` / `weighted-list` / `size-threshold`, or richer? Worth sketching before phase 1 lands so `RouteSpec` doesn't need a breaking change later.
+4. ~~**Layer 2 contract finalization.** What exactly is the distribution descriptor's vocabulary?~~ **Resolved** — see Phase 5 table above. Vocabulary is `""` / `"auto"` / `"round-robin"` / `"equal"` / `"weighted: f1, f2, ..."` / `"size-threshold: N"`. Unknown descriptors error at parse time so future additions stay unambiguous.
 
 5. **Policy granularity vs. CLI flags.** Today's `--routes N --min-hops K` per-CLI-invocation overrides interact with policies how? Suggested rule: CLI flags supplant the policy's matching fields on that invocation; the operator's policy sees `ctx.cli_overrides` so they can choose to honor or override the flag.
 

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -65,7 +65,72 @@ type DialAdjustment struct {
 	// dial with ErrDialPolicyDropped. Any other value is
 	// ignored (the dial proceeds normally).
 	Fallback string
+
+	// Distribution, when Mode != DistributionUnset, overrides
+	// the route group's mux distribution strategy (which by
+	// default tracks the router's visor-wide muxMode). The
+	// policy layer parses the operator's descriptor string
+	// (Starlark RouteSpec.Distribution) into this struct so
+	// the router stays free of parser logic.
+	Distribution DistributionConfig
 }
+
+// DistributionConfig drives the per-packet leg-selection
+// strategy for a mux-enabled route group. Set on DialAdjustment
+// (per-dial, from a routing-policy script) or on DialOptions
+// (per-call from a CLI flag); zero-value (Mode == DistributionUnset)
+// means "no override — use the router's visor-wide muxMode."
+//
+// See pkg/router/policy/distribution.go for the descriptor
+// grammar that policy scripts emit.
+type DistributionConfig struct {
+	// Mode selects the per-packet algorithm. DistributionUnset
+	// means "no override."
+	Mode DistributionMode
+
+	// Weights are the operator-supplied fractional weights for
+	// DistributionWeighted. Must be the same length as the route
+	// group's leg count; values are normalized into an integer
+	// schedule by the selector. Empty for non-weighted modes.
+	Weights []float64
+
+	// SizeThreshold is the payload-size boundary for
+	// DistributionSizeThreshold. Packets larger than this go to
+	// leg 0 (assumed to be the wider pipe — the first leg the
+	// route-finder returned, ranked by latency); smaller packets
+	// round-robin across the remaining legs.
+	SizeThreshold int
+}
+
+// DistributionMode enumerates the per-packet distribution
+// strategies the operator can pick from. Names match the
+// vocabulary the RFC's Starlark descriptor parses to.
+type DistributionMode int
+
+const (
+	// DistributionUnset means "no policy override." The route
+	// group uses the router's visor-wide muxMode (currently
+	// WeightModeAuto: latency-weighted with round-robin fallback).
+	DistributionUnset DistributionMode = iota
+	// DistributionRoundRobin distributes packets evenly across
+	// all legs, ignoring latency. Same effect as the existing
+	// WeightModeEqual.
+	DistributionRoundRobin
+	// DistributionAuto picks WeightModeAuto explicitly — useful
+	// when a script wants to override an operator's globally-
+	// configured Equal mode back to latency-weighted for one app.
+	DistributionAuto
+	// DistributionWeighted uses the operator-supplied fractional
+	// weights in Weights[]. Length must match the leg count.
+	DistributionWeighted
+	// DistributionSizeThreshold routes packets by payload size:
+	// > SizeThreshold goes to leg 0, ≤ SizeThreshold round-robins
+	// across the rest. Useful for bulk + control mixes (VPN,
+	// terminal multiplexing) where large packets should claim
+	// the wider pipe and small packets stay on the low-latency
+	// leg.
+	DistributionSizeThreshold
+)
 
 // applyAdjustment is a helper used inside DialRoutes — applies
 // the hook's non-zero fields to opts. Returns ErrDialPolicyDropped
@@ -79,6 +144,9 @@ func applyAdjustment(opts *DialOptions, adj DialAdjustment) error {
 	}
 	if adj.MinHops > 0 {
 		opts.MinHops = adj.MinHops
+	}
+	if adj.Distribution.Mode != DistributionUnset {
+		opts.Distribution = adj.Distribution
 	}
 	return nil
 }

--- a/pkg/router/policy/distribution.go
+++ b/pkg/router/policy/distribution.go
@@ -1,0 +1,132 @@
+// Package policy pkg/router/policy/distribution.go — parses the
+// Starlark-emitted RouteSpec.Distribution descriptor into the
+// router-domain DistributionConfig the route group's selector
+// consumes. Keeps the parser in the policy package so pkg/router
+// stays free of the grammar (it just sees a populated struct).
+//
+// Vocabulary (RFC #2882 phase 5):
+//
+//	""                          → DistributionUnset (no override)
+//	"auto"                      → DistributionAuto (latency-weighted)
+//	"round-robin" / "equal"     → DistributionRoundRobin
+//	"weighted: f1, f2, ..., fN" → DistributionWeighted with N weights
+//	"size-threshold: N"         → DistributionSizeThreshold with N bytes
+//
+// Whitespace is tolerant; case is not (descriptors are lowercase).
+package policy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/router"
+)
+
+// ParseDistribution translates the script's descriptor into a
+// router.DistributionConfig. Empty / "auto" / "round-robin" /
+// "equal" map to the existing selector modes; "weighted:..." and
+// "size-threshold:..." carry their config fields.
+//
+// Returns DistributionConfig{} (Mode=DistributionUnset) for the
+// empty string so callers can branch on Mode and skip the
+// override when no policy was set. Any other parse failure
+// returns an error — the caller (the policy Hook) treats parse
+// errors as "no override, log it" rather than failing the dial.
+func ParseDistribution(s string) (router.DistributionConfig, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return router.DistributionConfig{Mode: router.DistributionUnset}, nil
+	}
+
+	switch s {
+	case "auto":
+		return router.DistributionConfig{Mode: router.DistributionAuto}, nil
+	case "round-robin", "equal":
+		return router.DistributionConfig{Mode: router.DistributionRoundRobin}, nil
+	}
+
+	// Prefix-based: "weighted: ..." and "size-threshold: ..."
+	if name, body, ok := splitDescriptor(s); ok {
+		switch name {
+		case "weighted":
+			return parseWeighted(body)
+		case "size-threshold":
+			return parseSizeThreshold(body)
+		default:
+			return router.DistributionConfig{}, fmt.Errorf("unknown distribution descriptor %q", name)
+		}
+	}
+	return router.DistributionConfig{}, fmt.Errorf("malformed distribution descriptor %q", s)
+}
+
+// splitDescriptor pulls "name" and "body" out of "name: body".
+// Accepts whitespace around the colon. Returns ok=false when
+// there's no colon.
+func splitDescriptor(s string) (name, body string, ok bool) {
+	colon := strings.IndexByte(s, ':')
+	if colon < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(s[:colon]), strings.TrimSpace(s[colon+1:]), true
+}
+
+// parseWeighted parses a comma-separated weight list.
+//
+//	"0.5, 0.3, 0.2" → [0.5, 0.3, 0.2]
+//	"3, 1"          → [3, 1]
+//
+// Weights must be non-negative; at least one must be positive.
+// Length matching against actual leg count is the route-side
+// responsibility — the parser stays oblivious because the leg
+// count isn't known at parse time.
+func parseWeighted(body string) (router.DistributionConfig, error) {
+	parts := strings.Split(body, ",")
+	weights := make([]float64, 0, len(parts))
+	anyPositive := false
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t == "" {
+			continue
+		}
+		w, err := strconv.ParseFloat(t, 64)
+		if err != nil {
+			return router.DistributionConfig{}, fmt.Errorf("weighted: parse %q: %w", t, err)
+		}
+		if w < 0 {
+			return router.DistributionConfig{}, fmt.Errorf("weighted: weight %g is negative", w)
+		}
+		if w > 0 {
+			anyPositive = true
+		}
+		weights = append(weights, w)
+	}
+	if len(weights) == 0 {
+		return router.DistributionConfig{}, fmt.Errorf("weighted: empty weight list")
+	}
+	if !anyPositive {
+		return router.DistributionConfig{}, fmt.Errorf("weighted: all weights are zero")
+	}
+	return router.DistributionConfig{
+		Mode:    router.DistributionWeighted,
+		Weights: weights,
+	}, nil
+}
+
+// parseSizeThreshold parses the byte threshold. Must be positive
+// — a zero threshold would push every packet to the wide-pipe
+// leg, which is what the operator gets with mux=1 anyway.
+func parseSizeThreshold(body string) (router.DistributionConfig, error) {
+	t := strings.TrimSpace(body)
+	n, err := strconv.Atoi(t)
+	if err != nil {
+		return router.DistributionConfig{}, fmt.Errorf("size-threshold: parse %q: %w", t, err)
+	}
+	if n <= 0 {
+		return router.DistributionConfig{}, fmt.Errorf("size-threshold: %d is not positive", n)
+	}
+	return router.DistributionConfig{
+		Mode:          router.DistributionSizeThreshold,
+		SizeThreshold: n,
+	}, nil
+}

--- a/pkg/router/policy/distribution_test.go
+++ b/pkg/router/policy/distribution_test.go
@@ -1,0 +1,114 @@
+// Package policy pkg/router/policy/distribution_test.go — pins
+// the descriptor grammar promised by RFC #2882 phase 5.
+package policy
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/router"
+)
+
+func TestParseDistribution_EmptyAndAliases(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantMode router.DistributionMode
+	}{
+		{"", router.DistributionUnset},
+		{"  ", router.DistributionUnset},
+		{"auto", router.DistributionAuto},
+		{"round-robin", router.DistributionRoundRobin},
+		{"equal", router.DistributionRoundRobin},
+	}
+	for _, c := range cases {
+		cfg, err := ParseDistribution(c.in)
+		if err != nil {
+			t.Errorf("ParseDistribution(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if cfg.Mode != c.wantMode {
+			t.Errorf("ParseDistribution(%q): Mode=%v, want %v", c.in, cfg.Mode, c.wantMode)
+		}
+	}
+}
+
+func TestParseDistribution_Weighted(t *testing.T) {
+	cfg, err := ParseDistribution("weighted: 0.5, 0.3, 0.2")
+	if err != nil {
+		t.Fatalf("ParseDistribution: %v", err)
+	}
+	if cfg.Mode != router.DistributionWeighted {
+		t.Errorf("Mode=%v, want DistributionWeighted", cfg.Mode)
+	}
+	if len(cfg.Weights) != 3 {
+		t.Fatalf("Weights len=%d, want 3", len(cfg.Weights))
+	}
+	if cfg.Weights[0] != 0.5 || cfg.Weights[1] != 0.3 || cfg.Weights[2] != 0.2 {
+		t.Errorf("Weights=%v, want [0.5 0.3 0.2]", cfg.Weights)
+	}
+}
+
+func TestParseDistribution_WeightedIntegerForm(t *testing.T) {
+	// Integer weights are also valid (parser doesn't care about
+	// magnitude, just the relative ratio).
+	cfg, err := ParseDistribution("weighted: 3, 1")
+	if err != nil {
+		t.Fatalf("ParseDistribution: %v", err)
+	}
+	if cfg.Mode != router.DistributionWeighted {
+		t.Errorf("Mode=%v, want DistributionWeighted", cfg.Mode)
+	}
+	if len(cfg.Weights) != 2 || cfg.Weights[0] != 3 || cfg.Weights[1] != 1 {
+		t.Errorf("Weights=%v, want [3 1]", cfg.Weights)
+	}
+}
+
+func TestParseDistribution_WeightedErrors(t *testing.T) {
+	cases := []string{
+		"weighted:",
+		"weighted: ,",
+		"weighted: -1, 1",
+		"weighted: 0, 0, 0",
+		"weighted: abc",
+	}
+	for _, c := range cases {
+		if _, err := ParseDistribution(c); err == nil {
+			t.Errorf("ParseDistribution(%q): expected error, got nil", c)
+		}
+	}
+}
+
+func TestParseDistribution_SizeThreshold(t *testing.T) {
+	cfg, err := ParseDistribution("size-threshold: 1400")
+	if err != nil {
+		t.Fatalf("ParseDistribution: %v", err)
+	}
+	if cfg.Mode != router.DistributionSizeThreshold {
+		t.Errorf("Mode=%v, want DistributionSizeThreshold", cfg.Mode)
+	}
+	if cfg.SizeThreshold != 1400 {
+		t.Errorf("SizeThreshold=%d, want 1400", cfg.SizeThreshold)
+	}
+}
+
+func TestParseDistribution_SizeThresholdErrors(t *testing.T) {
+	cases := []string{
+		"size-threshold:",
+		"size-threshold: 0",
+		"size-threshold: -1",
+		"size-threshold: foo",
+	}
+	for _, c := range cases {
+		if _, err := ParseDistribution(c); err == nil {
+			t.Errorf("ParseDistribution(%q): expected error, got nil", c)
+		}
+	}
+}
+
+func TestParseDistribution_UnknownDescriptor(t *testing.T) {
+	if _, err := ParseDistribution("sticky: 5tuple"); err == nil {
+		t.Errorf("expected error for unimplemented descriptor, got nil")
+	}
+	if _, err := ParseDistribution("not-a-descriptor"); err == nil {
+		t.Errorf("expected error for malformed descriptor, got nil")
+	}
+}

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -27,6 +27,7 @@ type Hook struct {
 	loader   *Loader
 	byApp    map[string]*Loader
 	provider Provider // used for HopsGeo enrichment during SelectRoute
+	logger   func(format string, args ...interface{})
 }
 
 // HookOption configures a Hook at construction.
@@ -42,9 +43,17 @@ func WithHookProvider(p Provider) HookOption {
 	return func(h *Hook) { h.provider = p }
 }
 
+// WithHookLogger supplies the log function the hook uses for
+// non-fatal events (e.g. malformed distribution descriptor that
+// can be safely ignored). Default is a no-op so silent operation
+// stays the default in tests.
+func WithHookLogger(f func(format string, args ...interface{})) HookOption {
+	return func(h *Hook) { h.logger = f }
+}
+
 // NewHook wraps a Loader as a DialHook.
 func NewHook(l *Loader, opts ...HookOption) *Hook {
-	h := &Hook{loader: l}
+	h := &Hook{loader: l, logger: func(string, ...interface{}) {}}
 	for _, opt := range opts {
 		opt(h)
 	}
@@ -99,11 +108,21 @@ func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.Dia
 	if err != nil {
 		return router.DialAdjustment{}, err
 	}
-	return router.DialAdjustment{
+	adj := router.DialAdjustment{
 		MuxRoutes: spec.Mux,
 		MinHops:   spec.MinHops,
 		Fallback:  spec.Fallback,
-	}, nil
+	}
+	// Distribution descriptor parse — failure is non-fatal
+	// (script keeps the rest of the adjustment; distribution
+	// falls back to the visor-wide default). Empty Distribution
+	// parses to DistributionUnset, which applyAdjustment skips.
+	if dist, perr := ParseDistribution(spec.Distribution); perr != nil {
+		h.logger("policy %s: invalid distribution %q: %v", info.AppName, spec.Distribution, perr)
+	} else {
+		adj.Distribution = dist
+	}
+	return adj, nil
 }
 
 // SelectRoute implements router.RouteSelectingHook. Enriches the

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -218,3 +218,90 @@ def decide_route(ctx, candidates):
 		t.Skip()
 	}
 }
+
+func TestHook_BeforeDial_DistributionDescriptorParsed(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec(mux=2, distribution="weighted: 3, 1")
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.MuxRoutes != 2 {
+		t.Errorf("MuxRoutes=%d, want 2", adj.MuxRoutes)
+	}
+	if adj.Distribution.Mode != router.DistributionWeighted {
+		t.Errorf("Distribution.Mode=%v, want DistributionWeighted", adj.Distribution.Mode)
+	}
+	if len(adj.Distribution.Weights) != 2 || adj.Distribution.Weights[0] != 3 || adj.Distribution.Weights[1] != 1 {
+		t.Errorf("Distribution.Weights=%v, want [3 1]", adj.Distribution.Weights)
+	}
+}
+
+func TestHook_BeforeDial_DistributionSizeThreshold(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec(mux=2, distribution="size-threshold: 1400")
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.Distribution.Mode != router.DistributionSizeThreshold {
+		t.Errorf("Distribution.Mode=%v, want DistributionSizeThreshold", adj.Distribution.Mode)
+	}
+	if adj.Distribution.SizeThreshold != 1400 {
+		t.Errorf("Distribution.SizeThreshold=%d, want 1400", adj.Distribution.SizeThreshold)
+	}
+}
+
+func TestHook_BeforeDial_BadDistributionLogsAndContinues(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec(mux=2, distribution="not-a-real-descriptor")
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	var logged string
+	h := NewHook(loader, WithHookLogger(func(format string, _ ...interface{}) {
+		logged += format
+	}))
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.MuxRoutes != 2 {
+		t.Errorf("MuxRoutes=%d, want 2 (rest of adjustment must survive bad distribution)", adj.MuxRoutes)
+	}
+	if adj.Distribution.Mode != router.DistributionUnset {
+		t.Errorf("Distribution.Mode=%v, want DistributionUnset (parse failed)", adj.Distribution.Mode)
+	}
+	if logged == "" {
+		t.Errorf("expected the parse failure to be logged")
+	}
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -307,7 +307,7 @@ func (rg *RouteGroup) Write(p []byte) (n int, err error) {
 	}
 
 	rg.mu.Lock()
-	tp, rule, leg, err := rg.nextTransport()
+	tp, rule, leg, err := rg.nextTransport(len(p))
 	if err != nil {
 		rg.mu.Unlock()
 		return 0, err
@@ -527,15 +527,57 @@ func (rg *RouteGroup) writePacket(ctx context.Context, tp *transport.ManagedTran
 	return err
 }
 
+// applyDistribution configures the route group's transport
+// selector from a DistributionConfig (typically supplied by a
+// routing-policy script via DialAdjustment.Distribution). No-op
+// when mux is unset or Mode is DistributionUnset.
+//
+// Idempotent — calling with the same config is cheap. Called
+// after establishMuxRoutes so the distribution applies to every
+// leg, including ones added by the mux loop.
+func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
+	if rg.mux == nil || rg.mux.tpSelector == nil {
+		return
+	}
+	if cfg.Mode == DistributionUnset {
+		return
+	}
+	var wm WeightMode
+	switch cfg.Mode {
+	case DistributionRoundRobin:
+		wm = WeightModeEqual
+	case DistributionAuto:
+		wm = WeightModeAuto
+	case DistributionWeighted:
+		wm = WeightModeExplicit
+		rg.mux.tpSelector.SetExplicitWeights(cfg.Weights)
+	case DistributionSizeThreshold:
+		wm = WeightModeSizeThreshold
+		rg.mux.tpSelector.SetSizeThreshold(cfg.SizeThreshold)
+	default:
+		return
+	}
+	rg.mu.Lock()
+	rg.mux.tpSelector.SetMode(wm)
+	rg.mux.tpSelector.Rebuild(rg.tps)
+	rg.mu.Unlock()
+}
+
 // nextTransport selects the next transport/rule pair. When mux is enabled and
 // multiple transports exist, uses latency-weighted selection. Falls back to
 // round-robin when latency data is unavailable, and to index 0 for single
 // transport (legacy behavior).
+//
+// payloadSize is the upcoming packet's payload byte count, used
+// only by WeightModeSizeThreshold to route large payloads to the
+// wide-pipe leg. Pass 0 from callers that don't have a meaningful
+// size (control / retx paths).
+//
 // Returns the leg index (position in rg.tps) so the caller can record
 // per-leg byte counts after a successful write; -1 for the
 // single-transport / legacy path.
 // NOTE: not thread-safe, caller must hold rg.mu.
-func (rg *RouteGroup) nextTransport() (*transport.ManagedTransport, routing.Rule, int, error) {
+func (rg *RouteGroup) nextTransport(payloadSize int) (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(rg.tps) == 0 {
 		return nil, nil, -1, ErrNoTransports
 	}
@@ -547,7 +589,7 @@ func (rg *RouteGroup) nextTransport() (*transport.ManagedTransport, routing.Rule
 	}
 
 	if rg.mux != nil && len(rg.tps) > 1 {
-		return rg.mux.selectTransport(rg.tps, rg.fwd)
+		return rg.mux.selectTransport(rg.tps, rg.fwd, payloadSize)
 	}
 
 	if rg.tps[0] == nil {
@@ -1152,7 +1194,7 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 		}
 
 		rg.mu.Lock()
-		tp, rule, leg, err := rg.nextTransport()
+		tp, rule, leg, err := rg.nextTransport(len(data))
 		rg.mu.Unlock()
 		if err != nil {
 			return err

--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -188,7 +188,7 @@ func TestMuxSelectTransportSkipsDead(t *testing.T) {
 
 	// Select should return transport 2 (the only alive one)
 	rg.mu.Lock()
-	tp, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd)
+	tp, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd, 0)
 	rg.mu.Unlock()
 
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestMuxSelectTransportFailsAllDead(t *testing.T) {
 	}
 
 	rg.mu.Lock()
-	_, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd)
+	_, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd, 0)
 	rg.mu.Unlock()
 
 	require.ErrorIs(t, err, ErrNoSuitableTransport)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -88,13 +88,34 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 // Uses latency-weighted selection when data is available, falls back to round-robin.
 // Returns the index in tps[] alongside the tp/rule so the caller can
 // record per-leg byte counts after a successful write.
+//
+// payloadSize is the upcoming packet's payload byte count, used by
+// WeightModeSizeThreshold to route large payloads to the wide-pipe
+// leg. Pass 0 for handshake / control / retx packets whose size
+// isn't a routing signal — the selector falls back to its normal
+// schedule in that case.
+//
 // NOTE: not thread-safe, caller must hold the RouteGroup mu.
-func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule) (*transport.ManagedTransport, routing.Rule, int, error) {
+func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule, payloadSize int) (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(tps) == 0 {
 		return nil, nil, -1, ErrNoTransports
 	}
 	if len(fwd) == 0 {
 		return nil, nil, -1, ErrNoRules
+	}
+
+	// SizeThreshold path: ask the selector for the size-aware
+	// leg. Falls back to the regular schedule when payloadSize
+	// is 0 (control packets) since the threshold can't be
+	// meaningfully applied to packets whose size we don't know.
+	if m.tpSelector != nil && m.tpSelector.Mode() == WeightModeSizeThreshold && payloadSize > 0 {
+		idx := m.tpSelector.SelectForSize(payloadSize)
+		if idx < len(tps) {
+			tp := tps[idx]
+			if tp != nil && !tp.IsClosed() {
+				return tp, fwd[idx], idx, nil
+			}
+		}
 	}
 
 	// Use weighted selector if available

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -171,8 +171,15 @@ type DialOptions struct {
 	// callers outside the mux loop can pre-populate exclusions if
 	// they have constraints to express.
 	ExcludeIntermediatePKs []cipher.PubKey
-	ExcludeDMSG            bool          // Exclude DMSG transports (for mux — DMSG is a relay, not suitable for multiplexing)
-	KeepAlive              time.Duration // Route keepalive (0 = DefaultRouteKeepAlive). Routes idle longer expire.
+	ExcludeDMSG            bool // Exclude DMSG transports (for mux — DMSG is a relay, not suitable for multiplexing)
+	// Distribution overrides the route group's per-packet
+	// distribution strategy when set (Mode != DistributionUnset).
+	// Populated either by a routing-policy script (see
+	// DialAdjustment.Distribution) or directly by a CLI caller
+	// constructing DialOptions. Zero-value means "use the
+	// router's visor-wide muxMode default."
+	Distribution DistributionConfig
+	KeepAlive    time.Duration // Route keepalive (0 = DefaultRouteKeepAlive). Routes idle longer expire.
 	// AppName is the originating app's name. Set by appnet's
 	// DialContextWithOptions when the caller threaded a context
 	// carrying it (RPCIngressGateway.Dial uses appnet.WithAppName).

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -257,6 +257,14 @@ func (r *router) DialRoutes(
 		// Establish additional mux routes if requested
 		r.establishMuxRoutes(ctx, nrg, opts, forwardDesc, rules.Forward.NextTransportID())
 
+		// Apply per-dial distribution policy (from a routing-
+		// policy script via DialAdjustment.Distribution, or a
+		// CLI caller populating DialOptions.Distribution
+		// directly). No-op when Mode is DistributionUnset.
+		// Must run AFTER establishMuxRoutes so the selector's
+		// rebuild sees every leg, not just the primary.
+		nrg.rg.applyDistribution(opts.Distribution)
+
 		// reset MinHops default value if changed before
 		if defaultMinHops != 1 {
 			r.conf.MinHops = defaultMinHops

--- a/pkg/router/transport_selector.go
+++ b/pkg/router/transport_selector.go
@@ -17,6 +17,18 @@ const (
 	WeightModeAuto WeightMode = iota
 	// WeightModeEqual distributes packets equally across all transports (round-robin).
 	WeightModeEqual
+	// WeightModeExplicit uses operator-supplied fractional
+	// weights stored in explicitWeights. Normalized into an
+	// integer schedule at Rebuild time. Set via the routing-
+	// policy DSL's `distribution="weighted: f1, f2, ..."`.
+	WeightModeExplicit
+	// WeightModeSizeThreshold routes packets by payload size,
+	// not by a pre-built schedule: > sizeThreshold goes to leg
+	// 0, smaller packets RR across the rest. The Select()
+	// fallback path returns 0 for callers that don't supply a
+	// size (handshake / control packets); SelectForSize is the
+	// primary entry point.
+	WeightModeSizeThreshold
 )
 
 // transportSelector implements weighted transport selection based on latency.
@@ -27,10 +39,41 @@ type transportSelector struct {
 	schedule []int // pre-computed selection sequence of transport indices
 	counter  uint32
 	mode     WeightMode
+
+	// Mode-specific config. Set via SetExplicitWeights or
+	// SetSizeThreshold; the next Rebuild picks them up.
+	explicitWeights []float64
+	sizeThreshold   int
+	// smallLegSchedule holds the round-robin schedule across the
+	// non-leg-0 transports used by WeightModeSizeThreshold when
+	// the packet is at or under the threshold. Built at Rebuild
+	// time so per-packet selection stays lock-free.
+	smallLegSchedule []int
+	smallLegCounter  uint32
 }
 
 func newTransportSelector() *transportSelector {
 	return &transportSelector{mode: WeightModeAuto}
+}
+
+// SetExplicitWeights stores operator-supplied fractional weights
+// used by WeightModeExplicit. Caller must call Rebuild afterwards
+// for them to take effect. Passing a non-empty slice does NOT
+// implicitly switch mode — call SetMode(WeightModeExplicit)
+// explicitly when the operator's intent is to use them.
+func (ts *transportSelector) SetExplicitWeights(w []float64) {
+	ts.mu.Lock()
+	ts.explicitWeights = append([]float64(nil), w...)
+	ts.mu.Unlock()
+}
+
+// SetSizeThreshold stores the payload-size boundary used by
+// WeightModeSizeThreshold. Caller must call Rebuild afterwards
+// (or SetMode + Rebuild) for it to take effect.
+func (ts *transportSelector) SetSizeThreshold(n int) {
+	ts.mu.Lock()
+	ts.sizeThreshold = n
+	ts.mu.Unlock()
 }
 
 // SetMode changes the weight mode and returns the previous mode.
@@ -79,6 +122,86 @@ func (ts *transportSelector) Rebuild(tps []*transport.ManagedTransport) {
 			schedule = []int{0}
 		}
 		ts.schedule = schedule
+		return
+	}
+
+	// Explicit mode: operator-supplied fractional weights, one
+	// per leg. Normalize to integer multiples by dividing each by
+	// the smallest positive weight (clamped to 1 for the leg to
+	// appear at all), then build the schedule the same way Auto
+	// does. Rounding (not truncation) so 0.3/0.1 normalizes to 3
+	// instead of 2 — float-precision loss on division would
+	// otherwise distort the operator's stated ratios.
+	if ts.mode == WeightModeExplicit {
+		if len(ts.explicitWeights) == 0 {
+			// Misconfigured — fall back to equal.
+			schedule := make([]int, 0, n)
+			for i, tp := range tps {
+				if tp != nil && !tp.IsClosed() {
+					schedule = append(schedule, i)
+				}
+			}
+			if len(schedule) == 0 {
+				schedule = []int{0}
+			}
+			ts.schedule = schedule
+			return
+		}
+		minW := 0.0
+		for _, w := range ts.explicitWeights {
+			if w > 0 && (minW == 0 || w < minW) {
+				minW = w
+			}
+		}
+		if minW == 0 {
+			minW = 1
+		}
+		schedule := make([]int, 0, 16)
+		for i, tp := range tps {
+			if tp == nil || tp.IsClosed() {
+				continue
+			}
+			w := 1.0
+			if i < len(ts.explicitWeights) && ts.explicitWeights[i] > 0 {
+				w = ts.explicitWeights[i]
+			}
+			count := int(w/minW + 0.5)
+			if count < 1 {
+				count = 1
+			}
+			for j := 0; j < count; j++ {
+				schedule = append(schedule, i)
+			}
+		}
+		if len(schedule) == 0 {
+			schedule = []int{0}
+		}
+		ts.schedule = schedule
+		return
+	}
+
+	// SizeThreshold mode: keep the primary schedule as just leg
+	// 0 (the wide-pipe leg for large packets), and build a
+	// separate round-robin over the remaining legs for small
+	// packets. SelectForSize picks between them at write time;
+	// Select() without a size returns leg 0 (the safer choice
+	// for control packets whose layer doesn't know their size).
+	if ts.mode == WeightModeSizeThreshold {
+		ts.schedule = []int{0}
+		smallSched := make([]int, 0, n-1)
+		for i, tp := range tps {
+			if i == 0 {
+				continue
+			}
+			if tp != nil && !tp.IsClosed() {
+				smallSched = append(smallSched, i)
+			}
+		}
+		if len(smallSched) == 0 {
+			// Only one leg active — small packets ride leg 0 too.
+			smallSched = []int{0}
+		}
+		ts.smallLegSchedule = smallSched
 		return
 	}
 
@@ -177,4 +300,33 @@ func (ts *transportSelector) Len() int {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 	return len(ts.schedule)
+}
+
+// SelectForSize returns the leg index for a packet of the given
+// payload size. Only meaningful for WeightModeSizeThreshold —
+// other modes ignore the size argument and fall back to Select().
+//
+// Decision: payloads strictly greater than sizeThreshold go to
+// leg 0 (the wide pipe — first leg the route-finder returned,
+// ranked by latency). Payloads at or below the threshold
+// round-robin across the remaining legs via smallLegSchedule.
+// Single-leg routes always return 0.
+func (ts *transportSelector) SelectForSize(size int) int {
+	ts.mu.RLock()
+	mode := ts.mode
+	threshold := ts.sizeThreshold
+	smallSched := ts.smallLegSchedule
+	ts.mu.RUnlock()
+
+	if mode != WeightModeSizeThreshold {
+		return ts.Select()
+	}
+	if size > threshold {
+		return 0
+	}
+	if len(smallSched) == 0 {
+		return 0
+	}
+	idx := atomic.AddUint32(&ts.smallLegCounter, 1) - 1
+	return smallSched[idx%uint32(len(smallSched))] //nolint:gosec
 }

--- a/pkg/router/transport_selector_test.go
+++ b/pkg/router/transport_selector_test.go
@@ -93,3 +93,117 @@ func TestTransportSelector_MixedLatency(t *testing.T) {
 	assert.Equal(t, 50, counts[0])
 	assert.Equal(t, 50, counts[1])
 }
+
+func TestTransportSelector_ExplicitWeights(t *testing.T) {
+	// Operator-supplied fractional weights [0.6, 0.3, 0.1].
+	// Normalized to ints (smallest = 0.1) → [6, 3, 1] → 60/30/10 distribution.
+	ts := newTransportSelector()
+	ts.SetExplicitWeights([]float64{0.6, 0.3, 0.1})
+	ts.SetMode(WeightModeExplicit)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < 1000; i++ {
+		counts[ts.Select()]++
+	}
+	// Allow ±2% slack on a 1000-sample run.
+	assert.InDelta(t, 600, counts[0], 20)
+	assert.InDelta(t, 300, counts[1], 20)
+	assert.InDelta(t, 100, counts[2], 20)
+}
+
+func TestTransportSelector_ExplicitWeightsIntegerForm(t *testing.T) {
+	// Integer-style weights [3, 1] should produce 75/25.
+	ts := newTransportSelector()
+	ts.SetExplicitWeights([]float64{3, 1})
+	ts.SetMode(WeightModeExplicit)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < 1000; i++ {
+		counts[ts.Select()]++
+	}
+	assert.InDelta(t, 750, counts[0], 20)
+	assert.InDelta(t, 250, counts[1], 20)
+}
+
+func TestTransportSelector_ExplicitWeightsEmptyFallsBackToEqual(t *testing.T) {
+	// Misconfigured explicit mode (no weights set) falls back to
+	// equal — never panic, never select an out-of-range index.
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeExplicit)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < 100; i++ {
+		counts[ts.Select()]++
+	}
+	assert.Equal(t, 50, counts[0])
+	assert.Equal(t, 50, counts[1])
+}
+
+func TestTransportSelector_SizeThreshold_LargePacketsToLeg0(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetSizeThreshold(1400)
+	ts.SetMode(WeightModeSizeThreshold)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// 1401 bytes → leg 0 every time.
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, 0, ts.SelectForSize(1401))
+	}
+}
+
+func TestTransportSelector_SizeThreshold_SmallPacketsRRRest(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetSizeThreshold(1400)
+	ts.SetMode(WeightModeSizeThreshold)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// 100 bytes → RR across legs 1 and 2 (50/50).
+	counts := make(map[int]int)
+	for i := 0; i < 1000; i++ {
+		counts[ts.SelectForSize(100)]++
+	}
+	assert.Equal(t, 0, counts[0], "leg 0 should never get small packets")
+	assert.InDelta(t, 500, counts[1], 20)
+	assert.InDelta(t, 500, counts[2], 20)
+}
+
+func TestTransportSelector_SizeThreshold_ExactlyAtThreshold(t *testing.T) {
+	// Boundary case: size == threshold goes to the small-leg RR
+	// (strict ">" check). Pins the semantics so they don't drift.
+	ts := newTransportSelector()
+	ts.SetSizeThreshold(1400)
+	ts.SetMode(WeightModeSizeThreshold)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	counts := make(map[int]int)
+	for i := 0; i < 100; i++ {
+		counts[ts.SelectForSize(1400)]++
+	}
+	// 1400 == threshold → small-leg RR. With one small leg
+	// (leg 1), all 100 land on leg 1.
+	assert.Equal(t, 0, counts[0])
+	assert.Equal(t, 100, counts[1])
+}
+
+func TestTransportSelector_SizeThreshold_SelectWithoutSizeReturns0(t *testing.T) {
+	// Select() called from a path that doesn't know the size
+	// (handshake/control) returns leg 0 — safe default.
+	ts := newTransportSelector()
+	ts.SetSizeThreshold(1400)
+	ts.SetMode(WeightModeSizeThreshold)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	for i := 0; i < 100; i++ {
+		assert.Equal(t, 0, ts.Select())
+	}
+}

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -215,7 +215,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 				if werr := loader.Watch(policyLogger); werr != nil {
 					log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
 				}
-				hook = policy.NewHook(loader, policy.WithHookProvider(makeProvider()))
+				hook = policy.NewHook(loader, policy.WithHookProvider(makeProvider()), policy.WithHookLogger(policyLogger))
 				v.pushCloseStack("router.policy", loader.Close)
 				log.WithField("source", loader.Source()).Info("Routing policy active.")
 			}
@@ -239,7 +239,7 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 					log.WithError(werr).WithField("app", app.Name).Warn("Per-app routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
 				}
 				if hook == nil {
-					hook = policy.NewHook(nil, policy.WithHookProvider(makeProvider()))
+					hook = policy.NewHook(nil, policy.WithHookProvider(makeProvider()), policy.WithHookLogger(policyLogger))
 				}
 				hook.RegisterApp(app.Name, appLoader)
 				appName := app.Name


### PR DESCRIPTION
## Summary
Lands Phase 5 of RFC #2882 — the previously-deferred packet-distribution layer. \`RouteSpec.Distribution\` now plumbs end-to-end from Starlark through the policy hook into the route group's existing \`transportSelector\`. Until this commit the field round-tripped from Starlark to Go and was dropped on the floor; now it's parsed, applied to the selector, and actually changes per-packet behavior.

### Finalized descriptor vocabulary

| Descriptor | Mode | Behavior |
|---|---|---|
| \`""\` | \`DistributionUnset\` | No override — uses router's visor-wide \`muxMode\` |
| \`"auto"\` | \`DistributionAuto\` | Latency-weighted (existing \`WeightModeAuto\`) |
| \`"round-robin"\` / \`"equal"\` | \`DistributionRoundRobin\` | Even RR (existing \`WeightModeEqual\`) |
| \`"weighted: f1, f2, ..."\` | \`DistributionWeighted\` | Operator fractional weights → normalized integer schedule |
| \`"size-threshold: N"\` | \`DistributionSizeThreshold\` | Payload > N → leg 0; ≤ N → RR across the rest |

Unknown descriptors (\`"sticky: 5tuple"\`, \`"latency-aware"\`, etc.) parse-error rather than silently doing nothing — the namespace stays unambiguous for the future-RFC follow-up.

### Plumb path
\`script returns RouteSpec(distribution=...)\` → \`policy.parseRouteSpec → RouteSpec.Distribution\` → \`Hook.BeforeDial → policy.ParseDistribution → DialAdjustment.Distribution\` → \`applyAdjustment → DialOptions.Distribution\` → \`router_dial: nrg.rg.applyDistribution(opts.Distribution)\` (after \`establishMuxRoutes\` so every leg is in scope) → \`transportSelector.SetMode + SetExplicitWeights / SetSizeThreshold + Rebuild\` → per-packet leg selection.

### selectTransport now takes payloadSize
\`Write([]byte p)\` passes \`len(p)\`; retx loop passes \`len(data)\`; \`route_group_mux_test\` callers pass \`0\`. Only \`WeightModeSizeThreshold\` looks at the value — other modes ignore it.

## Test plan
- [x] \`golangci-lint run\` clean
- [x] \`go test ./pkg/router/...\` passes
- [x] New tests cover the new modes:
  - **Parser** (\`distribution_test.go\`): empty + aliases, weighted (float + integer + error cases), size-threshold (success + error cases), unknown descriptor
  - **Selector** (\`transport_selector_test.go\`): explicit-weights (fractional 0.6/0.3/0.1 ≈ 60/30/10, integer 3/1 ≈ 75/25, empty-weights fallback to equal), size-threshold (large → leg 0, small → RR rest, boundary at threshold, \`Select()\` without size returns leg 0)
  - **Hook roundtrip** (\`hook_test.go\`): weighted descriptor reaches \`DialAdjustment\`, size-threshold reaches \`DialAdjustment\`, malformed descriptor logs and rest of adjustment still applies

## Float-rounding note
Fractional weights normalize via round-to-nearest (\`int(w/minW + 0.5)\`), not truncation. \`0.3/0.1\` is \`2.999...\` in IEEE-754; truncation would map 0.6/0.3/0.1 to 5/2/1 (62.5/25/12.5%) instead of the operator's intended 60/30/10. Caught in the first test run; pinned by \`TestTransportSelector_ExplicitWeights\` with a 1000-sample check at ±2% slack.

## RFC update
\`docs/routing_policy_rfc.md\` Phase 5 flipped from "deferred" to "LANDED" with the descriptor vocabulary table. Open question #4 (Layer 2 contract finalization) resolved.