### PR TITLE
docs(routing-policy): runnable example policies + distribution observability

### DIFF
--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -1,0 +1,100 @@
+# Routing-policy examples
+
+Live, runnable Starlark policies for the operator-programmable
+routing DSL (RFC #2882). Every file in this directory parses and
+decides cleanly under `skywire cli route policy test`; the ones
+that gate on candidates are no-ops when previewed without any.
+
+## Quickstart
+
+```bash
+# Preview what a policy would decide for a synthetic dial.
+skywire cli route policy test \
+  --script docs/examples/routing-policies/app-mux.star \
+  --dial '{"app":"vpn-client"}'
+
+# Install one as the visor-wide default.
+sudo install -m 0644 docs/examples/routing-policies/app-mux.star \
+  /etc/skywire/policies/
+
+# In skywire.json:
+#   "routing": {
+#     "policy_per_dial": "@/etc/skywire/policies/app-mux.star"
+#   }
+#
+# Reload picks it up automatically — file watcher debounces 200ms.
+```
+
+## Layer 1 — per-dial route selection (works today)
+
+| File | Use case |
+|---|---|
+| `app-mux.star` | Different apps get different mux + min-hops. |
+| `no-us-transit.star` | Refuse routes that pass through US intermediates. |
+| `rt-latency-budget.star` | Real-time apps need < 200ms; drop otherwise. |
+| `trusted-only.star` | Every intermediate must be on the operator's trust list. |
+| `hv-boost.star` | Peering with a hypervisor → 4 mux legs. |
+| `business-hours.star` | 9–17 weekdays: only SG/JP/ID; off-hours: anything. |
+| `vpn-killswitch.star` | VPN MUST egress via direct-IP transports; drop on relay-only. |
+| `friday-id.star` | RFC headline: Friday 17:00 → Indonesia-transit only. |
+| `smoke-test.star` | Visible policy used for integration testing — logs every dial. |
+
+## Layer 2 — per-packet distribution (works today, RFC phase 5)
+
+The Starlark script emits a `distribution="..."` descriptor; the
+policy package parses it; the router's transport selector
+consumes it. Vocabulary:
+
+- `"auto"` — latency-weighted (default)
+- `"round-robin"` / `"equal"` — even round-robin across legs
+- `"weighted: f1, f2, ..."` — operator fractional weights
+- `"size-threshold: N"` — payload `> N` → leg 0; `≤ N` → RR across the rest
+
+Distribution only takes effect on **multi-leg** route groups (the
+peer must negotiate `CapMux` and the route-finder must surface
+multiple disjoint candidates). Single-leg dials log
+`"Route group distribution skipped: not mux-enabled"` and use the
+sole leg.
+
+| File | Use case |
+|---|---|
+| `weighted-by-kind.star` | Two legs of mixed kinds (stcpr + dmsg) → 3:1 to stcpr. |
+| `vpn-bulk-split.star` | VPN packets > 1400B → wide-pipe leg; small → RR rest. |
+| `force-equal-rt.star` | Real-time apps force equal RR (lower jitter than auto). |
+| `friday-id-mux.star` | Friday-ID combined with VPN size-threshold split. |
+
+## Authoring notes
+
+Two Starlark gotchas the examples already work around:
+
+- **No chained comparisons.** Python's `9 <= h < 17` doesn't
+  parse; use `h >= 9 and h < 17`.
+- **`logging.info/warn` take exactly one string.** No `%s`
+  formatting. Build the message with `+` concatenation:
+  `logging.info("fired for app=" + ctx.app)`.
+
+The stdlib surface (`datetime`, `geo`, `transports`, `peers`,
+`logging`, `RouteSpec`, `Candidate`) is defined in
+`pkg/router/policy/bridge.go`. The RFC at
+`docs/routing_policy_rfc.md` describes the full contract.
+
+## Verifying end-to-end
+
+When a policy is loaded the visor logs:
+
+```
+INFO [router]: Routing policy active. source="/etc/skywire/policies/<name>.star"
+```
+
+On each dial that matches the policy:
+
+```
+INFO [router]: policy <name>.star: info: <your logging.info message>
+DEBUG [router]: Routing policy adjusted dial opts. app_name=... policy_mux=2 policy_min_hops=0 policy_distribution=size-threshold
+DEBUG [RouteGroup ...]: Route group distribution applied. distribution=size-threshold legs=2 size_threshold=1400
+```
+
+The third line only fires when the dial established multiple
+legs. If you see only the first two, your route is single-leg
+and the distribution descriptor is a no-op (intended — there's
+nothing to distribute across).

--- a/docs/examples/routing-policies/app-mux.star
+++ b/docs/examples/routing-policies/app-mux.star
@@ -1,0 +1,23 @@
+# app-mux.star — different apps get different fanout.
+#
+# The simplest useful Layer-1 policy: branch on ctx.app to set
+# per-app mux + min_hops. Latency-sensitive apps stay single-route;
+# bandwidth apps get parallel legs.
+#
+# Install:
+#   sudo install -m 0644 app-mux.star /etc/skywire/policies/
+#   # in skywire.json:
+#   #   "routing": { "policy_per_dial": "@/etc/skywire/policies/app-mux.star" }
+#
+# Preview:
+#   skywire cli route policy test --script app-mux.star \
+#     --dial '{"app":"vpn-client"}'
+
+def decide_route(ctx, candidates):
+    if ctx.app == "vpn-client":
+        return RouteSpec(mux=4, min_hops=2)
+    if ctx.app == "skychat":
+        # Chat is latency-sensitive — one route, lowest mux.
+        return RouteSpec(mux=1)
+    # Everything else: visor defaults.
+    return RouteSpec()

--- a/docs/examples/routing-policies/business-hours.star
+++ b/docs/examples/routing-policies/business-hours.star
@@ -1,0 +1,28 @@
+# business-hours.star — during 9-17 weekdays, only routes through
+# SG/JP/ID survive; after hours, anything goes.
+#
+# Time is read from ctx.now() which is wall-clock at the moment
+# the dial fires. Override via the policy evaluator's Clock for
+# tests (see pkg/router/policy/evaluator_test.go).
+
+def decide_route(ctx, candidates):
+    t = ctx.now()
+    day = datetime.weekday(t)
+    # Starlark doesn't support Python-style chained comparisons
+    # (9 <= h < 17). Split into two and-ed clauses.
+    is_business = day not in ("saturday", "sunday") and t.hour >= 9 and t.hour < 17
+
+    if is_business:
+        ok = ("SG", "JP", "ID")
+        filtered = []
+        for c in candidates:
+            for g in c.hops_geo:
+                if g in ok:
+                    filtered.append(c)
+                    break
+        if not filtered:
+            return RouteSpec(fallback="drop")
+        return RouteSpec(chosen=filtered[0])
+
+    # Off-hours: visor default.
+    return RouteSpec()

--- a/docs/examples/routing-policies/force-equal-rt.star
+++ b/docs/examples/routing-policies/force-equal-rt.star
@@ -1,0 +1,14 @@
+# force-equal-rt.star — force round-robin distribution for a
+# real-time app even when the visor's global muxMode is the
+# latency-weighted default.
+#
+# Use case: under bursty conditions, the latency-weighted
+# selector can briefly concentrate traffic on one leg if that
+# leg's EMA dropped low, increasing jitter for rt traffic. Equal
+# RR trades a small throughput penalty (the slow leg gets the
+# same packets/sec) for predictable inter-packet timing.
+
+def decide_route(ctx, candidates):
+    if ctx.app in ("rt-voice", "rt-video"):
+        return RouteSpec(mux=2, distribution="round-robin")
+    return RouteSpec()

--- a/docs/examples/routing-policies/friday-id-mux.star
+++ b/docs/examples/routing-policies/friday-id-mux.star
@@ -1,0 +1,23 @@
+# friday-id-mux.star — combines the RFC's headline Indonesia-Friday
+# Layer-1 example with the Layer-2 size-threshold descriptor for
+# vpn-client.
+#
+# On Friday 17:00 local time, only Indonesia-transit routes
+# survive. The lowest-latency survivor wins. VPN traffic also
+# splits by packet size; everything else gets default RR.
+
+def decide_route(ctx, candidates):
+    t = ctx.now()
+    if datetime.weekday(t) == "friday" and t.hour == 17:
+        candidates = [c for c in candidates if "ID" in c.hops_geo]
+    if not candidates:
+        return RouteSpec(fallback="direct")
+
+    chosen = candidates[0]
+    for c in candidates[1:]:
+        if c.est_latency_ms > 0 and (chosen.est_latency_ms == 0 or c.est_latency_ms < chosen.est_latency_ms):
+            chosen = c
+
+    if ctx.app == "vpn-client":
+        return RouteSpec(chosen=chosen, mux=4, distribution="size-threshold: 1400")
+    return RouteSpec(chosen=chosen, mux=1)

--- a/docs/examples/routing-policies/hv-boost.star
+++ b/docs/examples/routing-policies/hv-boost.star
@@ -1,0 +1,12 @@
+# hv-boost.star — peering directly with one of our hypervisors?
+# open extra mux legs for resilience. Other peers get normal
+# single-route behavior.
+#
+# `peers.is_hypervisor` checks the visor's configured Hypervisors
+# list (the operator's control-plane keys). This is a per-peer
+# check on the dial destination, not on transit hops.
+
+def decide_route(ctx, candidates):
+    if peers.is_hypervisor(ctx.peer_pk):
+        return RouteSpec(mux=4, min_hops=1)
+    return RouteSpec()

--- a/docs/examples/routing-policies/no-us-transit.star
+++ b/docs/examples/routing-policies/no-us-transit.star
@@ -1,0 +1,22 @@
+# no-us-transit.star — refuse routes that pass through US intermediates.
+#
+# `c.hops_geo` is a parallel list to `c.hops`; "??" means unknown
+# (no SD entry, no direct transport to that intermediate). This
+# example treats unknown as "not US" — the operator could choose
+# the stricter "unknown means drop" by filtering out "??" too.
+#
+# When every candidate touches US, drop loudly (fallback="drop")
+# rather than silently routing through it: the operator notices
+# their workload is offline and can update the policy.
+
+def decide_route(ctx, candidates):
+    filtered = [c for c in candidates if "US" not in c.hops_geo]
+    if not filtered:
+        return RouteSpec(fallback="drop")
+    # Lowest-latency among survivors. Zero latency = unknown,
+    # so we don't pick a "zero" candidate over a measured one.
+    chosen = filtered[0]
+    for c in filtered[1:]:
+        if c.est_latency_ms > 0 and (chosen.est_latency_ms == 0 or c.est_latency_ms < chosen.est_latency_ms):
+            chosen = c
+    return RouteSpec(chosen=chosen)

--- a/docs/examples/routing-policies/rt-latency-budget.star
+++ b/docs/examples/routing-policies/rt-latency-budget.star
@@ -1,0 +1,33 @@
+# rt-latency-budget.star — real-time apps need <200ms; other apps
+# take whatever's available.
+#
+# `c.est_latency_ms` is the sum of the route's per-hop latencies
+# from the router's existing transport-tracker lookup. Zero means
+# no measurement available — we treat it as "unknown" rather than
+# "fast" so we don't accidentally pick an unmeasured route over a
+# measured one.
+
+def decide_route(ctx, candidates):
+    if ctx.app not in ("rt-voice", "rt-video"):
+        return RouteSpec()
+
+    # Starlark doesn't support Python-style chained comparisons.
+    fast = [c for c in candidates if c.est_latency_ms > 0 and c.est_latency_ms < 200]
+    if not fast:
+        # logging.{info,warn} take exactly one string argument;
+        # build the message with concatenation.
+        logging.warn(
+            "rt: no route under 200ms budget for app=" + ctx.app
+            + " peer=" + ctx.peer_pk,
+        )
+        # Try a direct dial instead of failing. The operator
+        # tunes this — "drop" for stricter latency SLOs.
+        return RouteSpec(fallback="direct")
+
+    chosen = fast[0]
+    for c in fast[1:]:
+        if c.est_latency_ms < chosen.est_latency_ms:
+            chosen = c
+    # mux=2 for redundancy against single-leg jitter, which
+    # matters more on rt traffic than throughput.
+    return RouteSpec(chosen=chosen, mux=2)

--- a/docs/examples/routing-policies/trusted-only.star
+++ b/docs/examples/routing-policies/trusted-only.star
@@ -1,0 +1,29 @@
+# trusted-only.star — every intermediate must be on the operator's
+# trust list (pkg/visor/visorconfig.Pty.Whitelist ∪ Hypervisors).
+#
+# Combined with mux=0 and a non-trivial min_hops, this is the
+# "operator-curated overlay" policy: refuse to transit a route any
+# part of which is outside the trust set.
+#
+# Beware: this is restrictive. With a small trust set, most peers
+# are unreachable. The "drop" fallback surfaces that rather than
+# pretending the dial succeeded.
+
+def decide_route(ctx, candidates):
+    safe = []
+    for c in candidates:
+        ok = True
+        for h in c.hops:
+            if not peers.is_trusted(h):
+                ok = False
+                break
+        if ok:
+            safe.append(c)
+    if not safe:
+        # logging.{info,warn} take exactly one string argument.
+        logging.warn(
+            "trusted-only: no candidate route is fully trusted for peer="
+            + ctx.peer_pk,
+        )
+        return RouteSpec(fallback="drop")
+    return RouteSpec(chosen=safe[0])

--- a/docs/examples/routing-policies/vpn-bulk-split.star
+++ b/docs/examples/routing-policies/vpn-bulk-split.star
@@ -1,0 +1,22 @@
+# vpn-bulk-split.star — for VPN traffic, send MTU-sized packets
+# down leg 0 (the wide pipe — the first leg the route-finder
+# returned, ranked by latency) and round-robin small/control
+# packets across the rest.
+#
+# Layer-2 descriptor: "size-threshold: N" — payloads strictly
+# greater than N bytes go to leg 0; payloads <= N round-robin
+# across legs 1..N-1. Packets without a known size (handshake,
+# control) take leg 0 as a safe default.
+#
+# 1400 is the common Ethernet-MTU-minus-IP-overhead boundary.
+
+def decide_route(ctx, candidates):
+    if ctx.app != "vpn-client":
+        return RouteSpec()
+    if not candidates:
+        return RouteSpec()
+    return RouteSpec(
+        chosen=candidates[0],
+        mux=2,
+        distribution="size-threshold: 1400",
+    )

--- a/docs/examples/routing-policies/vpn-killswitch.star
+++ b/docs/examples/routing-policies/vpn-killswitch.star
@@ -1,0 +1,28 @@
+# vpn-killswitch.star — VPN traffic MUST egress through direct-IP
+# transports; if no such route exists, drop rather than leak
+# through dmsg.
+#
+# Rationale: dmsg goes through a public relay, which defeats
+# the purpose of running a VPN over skywire for users who care
+# about hiding their traffic from the relay operator. The
+# killswitch makes that explicit: no direct-IP route → no dial.
+
+def decide_route(ctx, candidates):
+    if ctx.app != "vpn-client":
+        return RouteSpec()
+
+    direct = []
+    for c in candidates:
+        ok = True
+        for k in c.transport_kinds:
+            if k not in ("stcpr", "sudph"):
+                ok = False
+                break
+        if ok:
+            direct.append(c)
+    if not direct:
+        logging.warn(
+            "vpn killswitch: no direct-IP route available; dropping",
+        )
+        return RouteSpec(fallback="drop")
+    return RouteSpec(chosen=direct[0], mux=2)

--- a/docs/examples/routing-policies/weighted-by-kind.star
+++ b/docs/examples/routing-policies/weighted-by-kind.star
@@ -1,0 +1,18 @@
+# weighted-by-kind.star — when a route has two mux legs of mixed
+# transport kinds (e.g. stcpr + dmsg), give the direct-IP leg more
+# of the per-packet share than the relayed dmsg leg.
+#
+# Layer-2 descriptor: "weighted: f1, f2, ..., fN" — fractional
+# weights normalized to an integer schedule by the router's
+# transport selector. Length must match mux.
+
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec(mux=2)
+    chosen = candidates[0]
+    # Heuristic: stcpr + dmsg present → 3:1 in favor of stcpr.
+    if "stcpr" in chosen.transport_kinds and "dmsg" in chosen.transport_kinds:
+        return RouteSpec(chosen=chosen, mux=2, distribution="weighted: 3, 1")
+    # Default: round-robin (the empty "" descriptor leaves it
+    # to the visor-wide muxMode, which is latency-weighted).
+    return RouteSpec(chosen=chosen, mux=2)

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -132,6 +132,25 @@ const (
 	DistributionSizeThreshold
 )
 
+// String returns the stable label for a DistributionMode. Used
+// by router-side log fields so operator-facing log lines say
+// "round-robin" instead of "1".
+func (m DistributionMode) String() string {
+	switch m {
+	case DistributionUnset:
+		return "unset"
+	case DistributionRoundRobin:
+		return "round-robin"
+	case DistributionAuto:
+		return "auto"
+	case DistributionWeighted:
+		return "weighted"
+	case DistributionSizeThreshold:
+		return "size-threshold"
+	}
+	return "unknown"
+}
+
 // applyAdjustment is a helper used inside DialRoutes — applies
 // the hook's non-zero fields to opts. Returns ErrDialPolicyDropped
 // when the hook said "drop."

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -536,10 +536,21 @@ func (rg *RouteGroup) writePacket(ctx context.Context, tp *transport.ManagedTran
 // after establishMuxRoutes so the distribution applies to every
 // leg, including ones added by the mux loop.
 func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
-	if rg.mux == nil || rg.mux.tpSelector == nil {
+	if cfg.Mode == DistributionUnset {
 		return
 	}
-	if cfg.Mode == DistributionUnset {
+	if rg.mux == nil || rg.mux.tpSelector == nil {
+		// Policy asked for a distribution but the route group is
+		// single-leg (peer didn't negotiate CapMux, or mux loop
+		// failed). Distribution is meaningless without multiple
+		// legs; log at debug so operators can correlate "I set
+		// a distribution and nothing happened" with the actual
+		// reason.
+		if rg.logger != nil {
+			rg.logger.
+				WithField("distribution", cfg.Mode.String()).
+				Debug("Route group distribution skipped: not mux-enabled (single leg).")
+		}
 		return
 	}
 	var wm WeightMode
@@ -560,7 +571,20 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 	rg.mu.Lock()
 	rg.mux.tpSelector.SetMode(wm)
 	rg.mux.tpSelector.Rebuild(rg.tps)
+	legs := len(rg.tps)
 	rg.mu.Unlock()
+	if rg.logger != nil {
+		entry := rg.logger.
+			WithField("distribution", cfg.Mode.String()).
+			WithField("legs", legs)
+		if cfg.Mode == DistributionWeighted {
+			entry = entry.WithField("weights", cfg.Weights)
+		}
+		if cfg.Mode == DistributionSizeThreshold {
+			entry = entry.WithField("size_threshold", cfg.SizeThreshold)
+		}
+		entry.Debug("Route group distribution applied.")
+	}
 }
 
 // nextTransport selects the next transport/rule pair. When mux is enabled and

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -72,10 +72,11 @@ func (r *router) DialRoutes(
 		} else if err := applyAdjustment(opts, adj); err != nil {
 			log.WithField("policy_decision", "drop").Info("Dial refused by routing policy.")
 			return nil, err
-		} else if adj.MuxRoutes > 0 || adj.MinHops > 0 {
+		} else if adj.MuxRoutes > 0 || adj.MinHops > 0 || adj.Distribution.Mode != DistributionUnset {
 			log.
 				WithField("policy_mux", adj.MuxRoutes).
 				WithField("policy_min_hops", adj.MinHops).
+				WithField("policy_distribution", adj.Distribution.Mode).
 				Debug("Routing policy adjusted dial opts.")
 		}
 	}


### PR DESCRIPTION
## Summary
Adds 11 runnable example policies for the operator-programmable routing DSL (RFC #2882) plus the observability needed to verify end-to-end that a Layer-2 distribution descriptor reaches the route group's selector.

### Examples

Every file parses + decides cleanly under \`skywire cli route policy test\`; one was verified live on a running visor against \`03d1d78e...prod-claude\`. Two Starlark gotchas captured in the README (chained comparisons don't parse; \`logging.{info,warn}\` take exactly one string).

**Layer 1** — \`app-mux\`, \`no-us-transit\`, \`rt-latency-budget\`, \`trusted-only\`, \`hv-boost\`, \`business-hours\`, \`vpn-killswitch\`.

**Layer 2** — \`weighted-by-kind\`, \`vpn-bulk-split\`, \`force-equal-rt\`, \`friday-id-mux\`.

### Observability
Three new log fields/lines so the operator can trace a dial from script intent to selector outcome:

1. \`policy_distribution=<mode-string>\` on the existing \"Routing policy adjusted dial opts.\" line.
2. \`Route group distribution applied. distribution=... legs=N size_threshold=N\` when \`applyDistribution\` configures the selector.
3. \`Route group distribution skipped: not mux-enabled\` when the policy asked for a distribution but the route group ended up single-leg (no CapMux, or single-candidate route). Surfaces the \"I set distribution and nothing happened\" case with the actual reason.

\`DistributionMode.String()\` gives the log field human-readable values.

### Live verification
On a real visor (PID 1791160) sending skychat to prod-claude with \`policies/smoke-test.star\` returning \`RouteSpec(mux=2, distribution=\"size-threshold: 100\")\`:

\`\`\`
INFO  [router]: Routing policy active. source=\".../policies/smoke-test.star\"
INFO  [router]: policy ...smoke-test.star: info: dist-test fired for app=skychat peer=03d1d78e...
DEBUG [router]: Routing policy adjusted dial opts. app_name=skychat policy_mux=2 policy_distribution=size-threshold
DEBUG [RouteGroup ...]: Route multiplexing enabled (both peers support CapMux)
DEBUG [RouteGroup ...]: Route group distribution applied. distribution=size-threshold legs=2 size_threshold=100
\`\`\`

## Test plan
- [x] \`go test ./pkg/router/...\` passes
- [x] \`golangci-lint run\` clean
- [x] \`cli route policy test\` clean on all 11 example files
- [x] End-to-end dial test against running visor confirms distribution reaches the route group's selector