### PR TITLE
fix(router): strip DMSG hops from multihop routes everywhere

### DIFF
--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -56,9 +56,15 @@ multiple disjoint candidates). Single-leg dials log
 `"Route group distribution skipped: not mux-enabled"` and use the
 sole leg.
 
+DMSG transports never appear in multihop / mux routes — the
+router strips them at route construction (a dmsg server is an
+opaque intermediary that neither endpoint can observe, possibly
+chained via server-to-server forwarding). So no distribution
+example needs to reason about DMSG legs; they can't be there.
+
 | File | Use case |
 |---|---|
-| `weighted-by-kind.star` | Two legs of mixed kinds (stcpr + dmsg) → 3:1 to stcpr. |
+| `weighted-by-kind.star` | Two legs of mixed direct-IP kinds (stcpr + sudph) → 3:1 to stcpr. |
 | `vpn-bulk-split.star` | VPN packets > 1400B → wide-pipe leg; small → RR rest. |
 | `force-equal-rt.star` | Real-time apps force equal RR (lower jitter than auto). |
 | `friday-id-mux.star` | Friday-ID combined with VPN size-threshold split. |

--- a/docs/examples/routing-policies/weighted-by-kind.star
+++ b/docs/examples/routing-policies/weighted-by-kind.star
@@ -1,17 +1,28 @@
-# weighted-by-kind.star — when a route has two mux legs of mixed
-# transport kinds (e.g. stcpr + dmsg), give the direct-IP leg more
-# of the per-packet share than the relayed dmsg leg.
+# weighted-by-kind.star — operator-supplied per-leg fractional
+# weights for a mux route, applied when the route's transport
+# kinds aren't all the same. Useful when one leg is stcpr (direct
+# IP, faster) and the other is sudph (UDP-hole-punched, also
+# direct but can have different congestion behavior).
 #
 # Layer-2 descriptor: "weighted: f1, f2, ..., fN" — fractional
 # weights normalized to an integer schedule by the router's
 # transport selector. Length must match mux.
+#
+# NOTE: DMSG transports never appear in multihop / mux routes —
+# the router filters them out at route construction time because
+# a dmsg server is an unaccountable intermediary (potentially
+# chained via server-to-server forwarding) that the route's
+# endpoints can't observe. So no policy needs to special-case
+# DMSG-in-mux; it can't happen.
 
 def decide_route(ctx, candidates):
     if not candidates:
         return RouteSpec(mux=2)
     chosen = candidates[0]
-    # Heuristic: stcpr + dmsg present → 3:1 in favor of stcpr.
-    if "stcpr" in chosen.transport_kinds and "dmsg" in chosen.transport_kinds:
+    # Heuristic: when the chosen route mixes stcpr and sudph,
+    # weight stcpr 3:1 (TCP-based, generally lower jitter than
+    # UDP hole-punched). Operators tune the ratio to their links.
+    if "stcpr" in chosen.transport_kinds and "sudph" in chosen.transport_kinds:
         return RouteSpec(chosen=chosen, mux=2, distribution="weighted: 3, 1")
     # Default: round-robin (the empty "" descriptor leaves it
     # to the visor-wide muxMode, which is latency-weighted).

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -656,6 +656,26 @@ fetchRoutesAgain:
 	// but never iterated).
 	latencyFor := r.buildLatencyLookup(ctx, paths[forward], paths[backward])
 
+	// Drop any multihop candidate that contains a DMSG hop. A DMSG
+	// transport relays through a dmsg server (possibly chained via
+	// server-to-server forwarding) that neither endpoint can
+	// observe — using one in a multihop route means traffic could
+	// transit the same dmsg server multiple times with no way to
+	// detect it. Single-hop DMSG paths survive (direct DMSG dials
+	// are fine). If every candidate in either direction was DMSG-
+	// multihop, the disjoint-path pick below will fail and we'll
+	// fall through to calculateLocalRoutes (which applies the same
+	// filter at BFS construction time).
+	typeFor := r.buildTypeLookup(ctx, paths[forward], paths[backward])
+	if filtered := rejectDMSGMultihop(paths[forward], typeFor); len(filtered) != len(paths[forward]) {
+		log.Debugf("rejected %d DMSG-multihop forward candidate(s)", len(paths[forward])-len(filtered))
+		paths[forward] = filtered
+	}
+	if filtered := rejectDMSGMultihop(paths[backward], typeFor); len(filtered) != len(paths[backward]) {
+		log.Debugf("rejected %d DMSG-multihop reverse candidate(s)", len(paths[backward])-len(filtered))
+		paths[backward] = filtered
+	}
+
 	// Routing-policy candidate selection. When the configured
 	// DialHook also implements RouteSelectingHook, hand it the
 	// forward-direction candidates so the operator's script can
@@ -873,6 +893,97 @@ func (r *router) buildLatencyLookup(ctx context.Context, fwd, rev [][]routing.Ho
 	return func(id uuid.UUID) float64 {
 		return cache[id]
 	}
+}
+
+// buildTypeLookup constructs a TpID → transport-type lookup over the
+// union of TpIDs appearing in fwd and rev path candidates. Used by
+// rejectDMSGMultihop to drop route-finder responses that contain
+// DMSG hops in a multihop path — DMSG transports relay through a
+// dmsg server (and any server-to-server forwarding hops) that
+// neither endpoint of the route can observe.
+//
+// Sources mirror buildLatencyLookup: local transport manager first,
+// TPD GetTransportByID for hops the local visor doesn't own.
+// Returns "" for IDs that couldn't be resolved — the multihop
+// filter treats unknown as "not DMSG" (we can't prove it's bad,
+// so we let it through; the route still has to handshake which
+// will fail loudly if the type is actually a problem).
+func (r *router) buildTypeLookup(ctx context.Context, fwd, rev [][]routing.Hop) func(uuid.UUID) string {
+	unique := make(map[uuid.UUID]struct{})
+	for _, paths := range [][][]routing.Hop{fwd, rev} {
+		for _, p := range paths {
+			for _, h := range p {
+				unique[h.TpID] = struct{}{}
+			}
+		}
+	}
+	cache := make(map[uuid.UUID]string, len(unique))
+	for id := range unique {
+		if r.tm != nil {
+			if tp := r.tm.Transport(id); tp != nil {
+				cache[id] = string(tp.Entry.Type)
+				continue
+			}
+		}
+		if r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil {
+			entry, err := r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, id)
+			if err == nil && entry != nil {
+				cache[id] = string(entry.Type)
+			}
+		}
+	}
+	return func(id uuid.UUID) string {
+		return cache[id]
+	}
+}
+
+// rejectDMSGMultihop returns paths with any multihop candidate
+// containing a DMSG hop removed. Single-hop DMSG candidates are
+// kept (direct DMSG dials are fine — both endpoints know who
+// they're talking to). Stable order — survivors retain their
+// original index, so downstream rank/pick logic isn't perturbed.
+//
+// Returns the input slice unchanged when nothing was filtered, to
+// avoid an allocation in the common case.
+func rejectDMSGMultihop(paths [][]routing.Hop, typeFor func(uuid.UUID) string) [][]routing.Hop {
+	if len(paths) == 0 || typeFor == nil {
+		return paths
+	}
+	anyDropped := false
+	for _, p := range paths {
+		if len(p) <= 1 {
+			continue
+		}
+		for _, h := range p {
+			if typeFor(h.TpID) == "dmsg" {
+				anyDropped = true
+				break
+			}
+		}
+		if anyDropped {
+			break
+		}
+	}
+	if !anyDropped {
+		return paths
+	}
+	out := make([][]routing.Hop, 0, len(paths))
+	for _, p := range paths {
+		if len(p) > 1 {
+			drop := false
+			for _, h := range p {
+				if typeFor(h.TpID) == "dmsg" {
+					drop = true
+					break
+				}
+			}
+			if drop {
+				continue
+			}
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // pathTouchesIntermediate reports whether route hops contain any PK
@@ -1130,8 +1241,22 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 	// Seed the BFS with the local transports (each is a 1-hop path
 	// from src to a direct neighbor). Sort for determinism — same
 	// seeding order across calls means same expansion order.
+	//
+	// DMSG seeds are dropped here on purpose. A DMSG transport
+	// relays through a dmsg server (and, since server-to-server
+	// forwarding landed, potentially a chain of dmsg servers) that
+	// neither end of the route can observe — the intermediate
+	// server is unaccounted-for in the transport entry. Using a
+	// DMSG hop anywhere in a multihop route would let data transit
+	// the same dmsg server multiple times with no way to detect it.
+	// Direct DMSG dials (1-hop, src→dst over a DMSG transport) are
+	// fine and were already handled above; the BFS only produces
+	// multihop paths, so we strictly require non-DMSG hops here.
 	seed := make([]bfsNode, 0, len(localTps))
 	for _, tp := range localTps {
+		if tp.tpType == "dmsg" {
+			continue
+		}
 		if _, hit := excludeIntermediates[tp.remotePK]; hit {
 			continue
 		}
@@ -1223,11 +1348,18 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 			expandedAtDepth[node.pk][level] = true
 			// Expand: every transport from this node to a new neighbor
 			// becomes a candidate next node, sorted by remote-PK for
-			// deterministic order.
+			// deterministic order. DMSG entries are skipped — see the
+			// seed-loop comment above; a DMSG hop anywhere in a
+			// multihop path makes the route unaccountable since the
+			// dmsg server (and any server-to-server hops) are
+			// invisible to both endpoints.
 			entries := transportsByEdge[node.pk]
 			children := make([]bfsNode, 0, len(entries))
 			for _, entry := range entries {
 				if entry == nil {
+					continue
+				}
+				if entry.Type == tptypes.DMSG {
 					continue
 				}
 				nextPK := entry.RemoteEdge(node.pk)

--- a/pkg/router/router_dial_dmsg_multihop_test.go
+++ b/pkg/router/router_dial_dmsg_multihop_test.go
@@ -1,0 +1,140 @@
+// Package router pkg/router/router_dial_dmsg_multihop_test.go —
+// pins the "no DMSG in multihop routes" invariant. DMSG transports
+// relay through an opaque dmsg server (potentially a chain of
+// servers via server-to-server forwarding), so a DMSG hop in a
+// multihop path makes the route unaccountable — traffic could
+// transit the same server multiple times with no way to detect it.
+// Single-hop DMSG dials stay allowed; both endpoints are explicit.
+package router
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+func TestRejectDMSGMultihop_PreservesSingleHopDMSG(t *testing.T) {
+	tpID := uuid.New()
+	src, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	paths := [][]routing.Hop{
+		{{TpID: tpID, From: src, To: dst}}, // 1-hop direct DMSG
+	}
+	typeFor := func(uuid.UUID) string { return "dmsg" }
+	out := rejectDMSGMultihop(paths, typeFor)
+	if len(out) != 1 {
+		t.Errorf("len(out)=%d, want 1 (1-hop DMSG must survive)", len(out))
+	}
+}
+
+func TestRejectDMSGMultihop_DropsMultihopWithDMSG(t *testing.T) {
+	tpA := uuid.New()
+	tpB := uuid.New()
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	paths := [][]routing.Hop{
+		{ // 2-hop with DMSG first leg — must be rejected
+			{TpID: tpA, From: src, To: mid},
+			{TpID: tpB, From: mid, To: dst},
+		},
+	}
+	typeFor := func(id uuid.UUID) string {
+		if id == tpA {
+			return "dmsg"
+		}
+		return "stcpr"
+	}
+	out := rejectDMSGMultihop(paths, typeFor)
+	if len(out) != 0 {
+		t.Errorf("len(out)=%d, want 0 (DMSG-bearing multihop must be dropped)", len(out))
+	}
+}
+
+func TestRejectDMSGMultihop_KeepsNonDMSGMultihop(t *testing.T) {
+	tpA := uuid.New()
+	tpB := uuid.New()
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	paths := [][]routing.Hop{
+		{
+			{TpID: tpA, From: src, To: mid},
+			{TpID: tpB, From: mid, To: dst},
+		},
+	}
+	typeFor := func(uuid.UUID) string { return "stcpr" }
+	out := rejectDMSGMultihop(paths, typeFor)
+	if len(out) != 1 {
+		t.Errorf("len(out)=%d, want 1 (non-DMSG multihop must survive)", len(out))
+	}
+}
+
+func TestRejectDMSGMultihop_StableOrder(t *testing.T) {
+	// Survivors must keep their original index so downstream
+	// ranking (which assumes paths[0] is "first") isn't perturbed.
+	tpA := uuid.New() // DMSG
+	tpB := uuid.New() // stcpr
+	tpC := uuid.New() // stcpr
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	paths := [][]routing.Hop{
+		{{TpID: tpB, From: src, To: mid}, {TpID: tpC, From: mid, To: dst}}, // stcpr+stcpr → keep
+		{{TpID: tpA, From: src, To: mid}, {TpID: tpB, From: mid, To: dst}}, // dmsg+stcpr → drop
+		{{TpID: tpC, From: src, To: dst}},                                  // 1-hop stcpr → keep
+	}
+	typeFor := func(id uuid.UUID) string {
+		if id == tpA {
+			return "dmsg"
+		}
+		return "stcpr"
+	}
+	out := rejectDMSGMultihop(paths, typeFor)
+	if len(out) != 2 {
+		t.Fatalf("len(out)=%d, want 2", len(out))
+	}
+	if out[0][0].TpID != tpB {
+		t.Errorf("first survivor TpID=%v, want %v (order must be preserved)", out[0][0].TpID, tpB)
+	}
+	if out[1][0].TpID != tpC {
+		t.Errorf("second survivor TpID=%v, want %v", out[1][0].TpID, tpC)
+	}
+}
+
+func TestRejectDMSGMultihop_EmptyAndNilSafe(t *testing.T) {
+	out := rejectDMSGMultihop(nil, func(uuid.UUID) string { return "dmsg" })
+	if out != nil {
+		t.Errorf("nil input → non-nil output %v", out)
+	}
+	out = rejectDMSGMultihop([][]routing.Hop{}, func(uuid.UUID) string { return "dmsg" })
+	if len(out) != 0 {
+		t.Errorf("empty input → non-empty output (len=%d)", len(out))
+	}
+	out = rejectDMSGMultihop([][]routing.Hop{{{TpID: uuid.New()}}}, nil)
+	if len(out) != 1 {
+		t.Errorf("nil typeFor → input not returned (len=%d)", len(out))
+	}
+}
+
+func TestRejectDMSGMultihop_UnknownTypeTreatedAsAllowed(t *testing.T) {
+	// "Unknown" type (typeFor returns "") must not cause a multihop
+	// to be dropped — we can't prove it's bad, the handshake will
+	// fail loudly if it actually is.
+	tpA := uuid.New()
+	tpB := uuid.New()
+	src, _ := cipher.GenerateKeyPair()
+	mid, _ := cipher.GenerateKeyPair()
+	dst, _ := cipher.GenerateKeyPair()
+	paths := [][]routing.Hop{
+		{{TpID: tpA, From: src, To: mid}, {TpID: tpB, From: mid, To: dst}},
+	}
+	typeFor := func(uuid.UUID) string { return "" }
+	out := rejectDMSGMultihop(paths, typeFor)
+	if len(out) != 1 {
+		t.Errorf("unknown type treated as DMSG; len(out)=%d, want 1", len(out))
+	}
+}


### PR DESCRIPTION
## Summary
Codifies the architectural rule:

> A DMSG transport relays through a dmsg server (and, since server-to-server forwarding landed, potentially a chain of dmsg servers) that neither end of the route can observe. Using one anywhere in a multihop path makes the route unaccountable — traffic could transit the same dmsg server multiple times with no way to detect it.

Single-hop DMSG dials are still allowed (both endpoints explicit). The mux path already enforced this (rejecting DMSG appends and refusing mux setup when the primary contains a DMSG hop) but nothing filtered DMSG out of **multihop primary routes** — local BFS expanded through DMSG entries, and rfclient responses were consumed as-is. This PR closes that gap.

### Changes
- **`calculateLocalRoutes` BFS**: drop DMSG transports at both the seed step (no DMSG-first multihop) and the expansion step (no DMSG-intermediate hops). The pre-existing direct-route check above the BFS still uses single-hop DMSG.
- **`fetchBestRoutes`**: new `buildTypeLookup` (mirroring `buildLatencyLookup`) returns TpID→type. `rejectDMSGMultihop` filters the rfclient's response paths, dropping any multihop candidate that contains a DMSG hop. Stable order; if everything was DMSG-multihop, falls through to `calculateLocalRoutes`.
- **`router_dial_dmsg_multihop_test.go`**: six unit tests pinning the invariant.

### Examples
The Layer-2 \`weighted-by-kind.star\` example was framed around stcpr+dmsg mux legs — but that combination can't exist post-filter. Reframed to **stcpr + sudph** (both direct IP, both valid in mux). README updated to note that no Layer-2 example needs to reason about DMSG legs because they can't appear in mux.

## Test plan
- [x] \`go test ./pkg/router/...\` passes (incl. 6 new \`TestRejectDMSGMultihop_*\` tests)
- [x] \`golangci-lint run\` clean
- [x] Live verification: rebuilt visor, sent skychat to two peers, both acked normally — confirms the filter doesn't break legitimate routes