### PR TITLE
feat(autoconfig): --pk-endpoint / --no-pk-endpoint flag

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -128,6 +128,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	// Hypervisor / identity
 	addArray("HYPERVISORPKS", "hvpks", autoconfigVals.Hvpks)
 	addBool("ISHYPERVISOR", "ishv", "no-ishv", autoconfigVals.Ishv, autoconfigVals.NoIshv)
+	addBool("ENABLEPKENDPOINT", "pk-endpoint", "no-pk-endpoint", autoconfigVals.PkEndpoint, autoconfigVals.NoPkEndpoint)
 	addString("HVHTTPADDR", "hvaddr", autoconfigVals.HvAddr)
 	addString("SK", "sk", autoconfigVals.SecretKey)
 	addString("VERSION", "version", autoconfigVals.Version)

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -99,12 +99,14 @@ type Values struct {
 	Verbose bool
 
 	// --- Hypervisor / identity ---
-	Hvpks     string
-	Ishv      bool
-	NoIshv    bool
-	HvAddr    string // HVHTTPADDR
-	SecretKey string // SK — security-sensitive; see flag description
-	Version   string // VERSION — testing override
+	Hvpks        string
+	Ishv         bool
+	NoIshv       bool
+	PkEndpoint   bool // ENABLEPKENDPOINT
+	NoPkEndpoint bool
+	HvAddr       string // HVHTTPADDR
+	SecretKey    string // SK — security-sensitive; see flag description
+	Version      string // VERSION — testing override
 
 	// --- Visor public/private + autoconnect ---
 	RewardAddr     string
@@ -225,6 +227,8 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().StringVar(&v.Hvpks, "hvpks", "", "comma-separated remote hypervisor PKs to dial — writes HYPERVISORPKS in skywire.conf")
 	cmd.Flags().BoolVar(&v.Ishv, "ishv", false, "enable local hypervisor — writes ISHYPERVISOR=true in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoIshv, "no-ishv", false, "disable local hypervisor — writes ISHYPERVISOR=false in skywire.conf")
+	cmd.Flags().BoolVar(&v.PkEndpoint, "pk-endpoint", false, "expose unauthenticated GET /api/pk on the hypervisor — writes ENABLEPKENDPOINT=true in skywire.conf (skybian / Arch-ARM image builds set this)")
+	cmd.Flags().BoolVar(&v.NoPkEndpoint, "no-pk-endpoint", false, "do not expose GET /api/pk — writes ENABLEPKENDPOINT=false in skywire.conf")
 	cmd.Flags().StringVar(&v.HvAddr, "hvaddr", "", "hypervisor HTTP address (host:port) — writes HVHTTPADDR in skywire.conf")
 	cmd.Flags().StringVar(&v.SecretKey, "sk", "", "pin visor secret key (64-hex) — writes SK in skywire.conf. SECURITY: appears in shell history; prefer letting the visor generate its own SK on first boot.")
 	cmd.Flags().StringVar(&v.Version, "version", "", "custom version override for testing — writes VERSION in skywire.conf")
@@ -344,12 +348,14 @@ func EnvMap() map[string]EnvMapping {
 // section comments so cross-referencing stays one-to-one.
 var envMap = map[string]EnvMapping{
 	// Hypervisor / identity
-	"hvpks":   {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
-	"ishv":    {Key: "ISHYPERVISOR", Format: EnvFormatBool},
-	"no-ishv": {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
-	"hvaddr":  {Key: "HVHTTPADDR", Format: EnvFormatString},
-	"sk":      {Key: "SK", Format: EnvFormatString},
-	"version": {Key: "VERSION", Format: EnvFormatString},
+	"hvpks":          {Key: "HYPERVISORPKS", Format: EnvFormatBashArray},
+	"ishv":           {Key: "ISHYPERVISOR", Format: EnvFormatBool},
+	"no-ishv":        {Key: "ISHYPERVISOR", Format: EnvFormatBool, Negate: true},
+	"pk-endpoint":    {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool},
+	"no-pk-endpoint": {Key: "ENABLEPKENDPOINT", Format: EnvFormatBool, Negate: true},
+	"hvaddr":         {Key: "HVHTTPADDR", Format: EnvFormatString},
+	"sk":             {Key: "SK", Format: EnvFormatString},
+	"version":        {Key: "VERSION", Format: EnvFormatString},
 
 	// Visor public/private + autoconnect
 	"rewardaddr":              {Key: "REWARDSKYADDR", Format: EnvFormatString},

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -12,7 +12,7 @@ import (
 var allFlags = []string{
 	"verbose",
 	// Hypervisor / identity
-	"hvpks", "ishv", "no-ishv", "hvaddr", "sk", "version",
+	"hvpks", "ishv", "no-ishv", "pk-endpoint", "no-pk-endpoint", "hvaddr", "sk", "version",
 	// Visor public/private + autoconnect
 	"rewardaddr", "public", "no-public", "publicip", "disable-public-autoconn",
 	// Service discovery / deployment
@@ -49,6 +49,7 @@ var negationPairs = []struct {
 	pos, neg string
 }{
 	{"ishv", "no-ishv"},
+	{"pk-endpoint", "no-pk-endpoint"},
 	{"public", "no-public"},
 	{"vpnserver", "no-vpnserver"},
 	{"proxyserver", "no-proxyserver"},
@@ -102,6 +103,8 @@ func TestNew_BindingsTrackValues(t *testing.T) {
 	}{
 		{"hvpks", "0123,4567", func() bool { return v.Hvpks == "0123,4567" }},
 		{"ishv", "true", func() bool { return v.Ishv }},
+		{"pk-endpoint", "true", func() bool { return v.PkEndpoint }},
+		{"no-pk-endpoint", "true", func() bool { return v.NoPkEndpoint }},
 		{"stcpr", "7777", func() bool { return v.StcprPort == 7777 }},
 		// New flags from the parity expansion: cover one per group.
 		{"testenv", "true", func() bool { return v.TestEnv }},


### PR DESCRIPTION
## Summary

- Adds `--pk-endpoint` and `--no-pk-endpoint` flags on the `skywire autoconfig` subcommand, surfacing `HypervisorConfig.EnablePKEndpoint` (added in #2895/#2896) through the same operator-facing path as the other `ISHYPERVISOR` / `VPNSERVER`-style toggles.
- Without this, the only way to flip `ENABLEPKENDPOINT` on a running visor was hand-editing `/etc/skywire.conf` — autoconfig silently no-op'd because `envMap` didn't carry the mapping, mirroring the bug `TestEnvMap_Coverage` is designed to catch.

Mirrors the `--ishv` / `--no-ishv` pair structurally; sits in the same "Hypervisor / identity" group in the factory.

## Files

- `pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go` — `Values.PkEndpoint` + `Values.NoPkEndpoint`, the two flag bindings, two `envMap` entries.
- `cmd/skywire/commands/autoconfig.go` — `collectSkyenvEdits` `addBool("ENABLEPKENDPOINT", "pk-endpoint", "no-pk-endpoint", …)`.
- `pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go` — extends `allFlags`, `negationPairs`, and `TestNew_BindingsTrackValues`. Existing `TestEnvMap_Coverage`, `TestEnvMap_NegationInversion`, `TestEnvMap_UniqueKeys` pick up the new pair automatically.

## Why this is needed

skybian's first-boot autoconfig (`skymanager.sh`) currently pokes `ENABLEPKENDPOINT=true` into `/etc/skywire.conf` by hand because `skywire autoconfig --pk-endpoint` was a no-op. With this flag, the discovery path simplifies to:

```bash
skywire autoconfig --pk-endpoint 0      # claim hypervisor role
skywire autoconfig --pk-endpoint 1      # join existing hypervisor
```

## Test plan

- [x] `go test ./pkg/skywireconfig/autoconfigcmd/...`
- [x] `go build ./...`
- [x] `gofmt -d` clean
- [ ] Manual: `skywire autoconfig --pk-endpoint` followed by `grep ENABLEPKENDPOINT /etc/skywire.conf` shows `ENABLEPKENDPOINT=true`
- [ ] Manual: `skywire autoconfig --no-pk-endpoint` flips it to `false`
- [ ] Manual: `curl http://localhost:8000/api/pk` returns 200 after `--pk-endpoint`, 404 after `--no-pk-endpoint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)