### PR TITLE
fix(router/policy): SelectRoute distribution + leg-count truth + TPD perf

### DIFF
--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -35,18 +35,47 @@ sudo install -m 0644 docs/examples/routing-policies/app-mux.star \
    `candidates` argument is **empty**. The router honors:
    - `mux` — number of parallel mux legs
    - `min_hops` — minimum acceptable intermediate count
-   - `distribution` — per-packet distribution descriptor
+   - `distribution` — per-packet distribution descriptor (baseline)
    - `fallback="drop"` — refuse the dial outright
 2. **`SelectRoute`** — fires *after* the route-finder returns
    candidates. The `candidates` argument is populated. The router
    honors:
    - `chosen` — the candidate to use
+   - `distribution` — per-packet distribution descriptor (overrides
+     BeforeDial's when set; lets the script branch on the chosen
+     candidate's `transport_kinds` / `est_latency_ms` / `hops_geo`)
    - `fallback="drop"` — refuse the dial
 
-Distribution and mux **cannot be set** in `SelectRoute` (the
-router doesn't read those fields from that hook). So a policy
-that wants a specific distribution must set it in `BeforeDial`,
-which means it can't branch on candidate properties.
+`mux` and `min_hops` are BeforeDial-only — the route-finder query
+needs them before it runs, so they can't be reconsidered in
+SelectRoute. `distribution` can be set in either phase; when both
+set it, SelectRoute's value wins (it fires later in the flow and
+has more information).
+
+### Knowing the leg count
+
+In SelectRoute, the script sees the route-finder's disjoint
+candidates — `len(candidates)` is the maximum number of mux legs
+the router could potentially establish (capped further by the
+script's `mux` value and what `establishMuxRoutes` actually
+manages to negotiate). Use it to size `weighted: ...` arrays:
+
+```python
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec(mux=4, distribution="auto")
+    n = min(len(candidates), 4)
+    # Equal weights, n entries — matches the actual leg count.
+    weights = ", ".join(["1"] * n)
+    return RouteSpec(chosen=candidates[0], distribution="weighted: " + weights)
+```
+
+When `weighted: ...` weight count doesn't match the actual
+established leg count, the router logs a warning and the selector
+substitutes weight=1 for missing entries (or ignores trailing
+ones). There's no callback when a leg drops or is added after
+setup — the selector adapts internally (skips nil/closed
+transports) but the script's distribution config is set once.
 
 The canonical pattern:
 
@@ -106,18 +135,15 @@ opaque intermediary that neither endpoint can observe, possibly
 chained via server-to-server forwarding). So no distribution
 example needs to reason about DMSG legs; they can't be there.
 
-Distribution and mux are **BeforeDial-only** — they're not
-propagated from SelectRoute. So a distribution policy is
-necessarily static (`if ctx.app == "vpn-client": distribution = ...`).
-Dynamic per-route distribution selection isn't a thing today;
-the candidate's `transport_kinds` field is visible to the
-script but doesn't help with distribution because by the time
-the script sees it (SelectRoute), it's too late to set
-distribution.
+Distribution can be set in either BeforeDial or SelectRoute. A
+SelectRoute distribution overrides the BeforeDial one — useful
+when the script wants to branch on the chosen candidate's
+properties (`weighted-by-kind.star` demonstrates the pattern).
 
 | File | Use case |
 |---|---|
 | `weighted-static.star` | Static 3:1 weighted distribution for any mux dial. |
+| `weighted-by-kind.star` | Dynamic: stcpr+sudph → weighted; otherwise auto. |
 | `vpn-bulk-split.star` | VPN packets > 1400B → wide-pipe leg; small → RR rest. |
 | `force-equal-rt.star` | Real-time apps force equal RR (lower jitter than auto). |
 | `friday-id-mux.star` | Friday-ID combined with VPN size-threshold split. |

--- a/docs/examples/routing-policies/weighted-by-kind.star
+++ b/docs/examples/routing-policies/weighted-by-kind.star
@@ -1,0 +1,34 @@
+# weighted-by-kind.star — dynamic distribution: branch on the
+# chosen candidate's transport-kinds. Routes with stcpr+sudph
+# legs get a 3:1 weighted split (stcpr first); single-kind routes
+# fall through to the default round-robin.
+#
+# This shows the SelectRoute path setting distribution. Until
+# RouteSelection.Distribution was wired through, distribution was
+# BeforeDial-only and a script couldn't branch on candidate
+# properties. Now both phases can contribute:
+#   - BeforeDial: set a baseline mux + a default distribution.
+#   - SelectRoute: see the candidate, override distribution if a
+#     better strategy applies.
+#
+# The router prefers SelectRoute's distribution over BeforeDial's
+# when both are set (SelectRoute fires later in the flow).
+#
+# Two-phase invocation:
+#   - BeforeDial (candidates empty): opt into mux=2 with a
+#     conservative default ("auto"). The router falls back to
+#     this when SelectRoute leaves Mode==DistributionUnset.
+#   - SelectRoute (candidates populated): pick the first
+#     candidate; if it has stcpr+sudph kinds, override
+#     distribution to weighted 3:1.
+
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec(mux=2, distribution="auto")
+
+    c = candidates[0]
+    if "stcpr" in c.transport_kinds and "sudph" in c.transport_kinds:
+        return RouteSpec(chosen=c, distribution="weighted: 3, 1")
+    # Single-kind: leave distribution unset → BeforeDial's "auto"
+    # stays in effect.
+    return RouteSpec(chosen=c)

--- a/docs/examples/routing-policies/weighted-static.star
+++ b/docs/examples/routing-policies/weighted-static.star
@@ -1,4 +1,4 @@
-# weighted-by-kind.star — static weighted distribution for the
+# weighted-static.star — static weighted distribution for the
 # operator's bandwidth-asymmetric apps. The first mux leg gets 3x
 # the per-packet share of the second, matching the typical case
 # where the route-finder's first-pick is the lower-latency path

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -213,7 +213,16 @@ type CandidateInfo struct {
 // index into the candidates slice passed in; -1 means "no
 // preference, fall back to the router's built-in disjoint-path
 // pick." Drop=true overrides everything and refuses the dial.
+//
+// Distribution lets a SelectRoute hook reconsider the per-packet
+// distribution descriptor after seeing the chosen candidate's
+// transport-kinds / latency / hops_geo. The hook can branch on
+// the candidate it picked and return a tailored distribution
+// (e.g. "if route has stcpr+sudph legs: weighted 3,1 else: auto").
+// Mode == DistributionUnset means "no override at SelectRoute
+// time" — falls back to whatever BeforeDial set on DialOptions.
 type RouteSelection struct {
-	Chosen int
-	Drop   bool
+	Chosen       int
+	Drop         bool
+	Distribution DistributionConfig
 }

--- a/pkg/router/policy/bridge.go
+++ b/pkg/router/policy/bridge.go
@@ -215,11 +215,10 @@ func buildCandidatesValue(cs []Candidate) starlark.Value {
 		out[i] = starlarkstruct.FromStringDict(
 			starlarkstruct.Default,
 			starlark.StringDict{
-				"hops":               starlark.NewList(hops),
-				"hops_geo":           starlark.NewList(hopsGeo),
-				"est_latency_ms":     starlark.MakeInt(c.EstLatencyMs),
-				"transport_kinds":    starlark.NewList(kinds),
-				"mux_legs_available": starlark.MakeInt(c.MuxLegsAvailable),
+				"hops":            starlark.NewList(hops),
+				"hops_geo":        starlark.NewList(hopsGeo),
+				"est_latency_ms":  starlark.MakeInt(c.EstLatencyMs),
+				"transport_kinds": starlark.NewList(kinds),
 			},
 		)
 	}
@@ -258,11 +257,10 @@ func candidateCtor(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple,
 		return nil, fmt.Errorf("Candidate: positional arguments not allowed; use kwargs")
 	}
 	dict := starlark.StringDict{
-		"hops":               starlark.NewList(nil),
-		"hops_geo":           starlark.NewList(nil),
-		"est_latency_ms":     starlark.MakeInt(0),
-		"transport_kinds":    starlark.NewList(nil),
-		"mux_legs_available": starlark.MakeInt(0),
+		"hops":            starlark.NewList(nil),
+		"hops_geo":        starlark.NewList(nil),
+		"est_latency_ms":  starlark.MakeInt(0),
+		"transport_kinds": starlark.NewList(nil),
 	}
 	for _, kv := range kwargs {
 		key := string(kv[0].(starlark.String))
@@ -310,11 +308,10 @@ func parseCandidate(v starlark.Value) (Candidate, error) {
 		return Candidate{}, fmt.Errorf("expected candidate struct, got %s", v.Type())
 	}
 	return Candidate{
-		Hops:             readStrListField(s, "hops"),
-		HopsGeo:          readStrListField(s, "hops_geo"),
-		EstLatencyMs:     readIntField(s, "est_latency_ms"),
-		TransportKinds:   readStrListField(s, "transport_kinds"),
-		MuxLegsAvailable: readIntField(s, "mux_legs_available"),
+		Hops:           readStrListField(s, "hops"),
+		HopsGeo:        readStrListField(s, "hops_geo"),
+		EstLatencyMs:   readIntField(s, "est_latency_ms"),
+		TransportKinds: readStrListField(s, "transport_kinds"),
 	}, nil
 }
 

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -180,11 +180,24 @@ func (h *Hook) SelectRoute(ctx context.Context, info router.DialInfo, candidates
 	if spec.Fallback == "drop" {
 		return router.RouteSelection{Drop: true, Chosen: -1}, nil
 	}
+	// Distribution descriptor — parsed from SelectRoute so the
+	// script can branch on the chosen candidate's properties
+	// (transport_kinds, hops_geo, est_latency_ms). When the
+	// descriptor is empty or fails to parse, the SelectRoute-side
+	// override is left unset and DialOptions.Distribution (set
+	// from BeforeDial) stays in effect.
+	var dist router.DistributionConfig
+	if d, perr := ParseDistribution(spec.Distribution); perr != nil {
+		h.logger("policy %s: invalid distribution in SelectRoute %q: %v",
+			info.AppName, spec.Distribution, perr)
+	} else {
+		dist = d
+	}
 	if spec.Chosen == nil {
-		return router.RouteSelection{Chosen: -1}, nil
+		return router.RouteSelection{Chosen: -1, Distribution: dist}, nil
 	}
 	idx := matchCandidate(policyCandidates, *spec.Chosen)
-	return router.RouteSelection{Chosen: idx}, nil
+	return router.RouteSelection{Chosen: idx, Distribution: dist}, nil
 }
 
 // matchCandidate finds the index of want in pool by Hops equality.

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -305,3 +305,77 @@ def decide_route(ctx, candidates):
 		t.Errorf("expected the parse failure to be logged")
 	}
 }
+
+func TestHook_SelectRoute_DistributionPropagates(t *testing.T) {
+	// Script picks a candidate and ALSO returns distribution
+	// based on its properties — the previously-impossible
+	// dynamic-distribution case.
+	src := `
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec(mux=2)
+    c = candidates[0]
+    if "stcpr" in c.transport_kinds and "sudph" in c.transport_kinds:
+        return RouteSpec(chosen=c, distribution="weighted: 3, 1")
+    return RouteSpec(chosen=c, distribution="round-robin")
+`
+	hopA := "020000000000000000000000000000000000000000000000000000000000000001"
+	prov := NewFakeProvider().
+		SetGeo(hopA, "DE").
+		SetKind(hopA, "stcpr")
+
+	loader, err := NewLoader(src, WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader, WithHookProvider(prov))
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+
+	// Single-kind route → round-robin
+	cands := []router.CandidateInfo{{Hops: []string{hopA}}}
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk}, cands)
+	if err != nil {
+		t.Fatalf("SelectRoute single-kind: %v", err)
+	}
+	if sel.Distribution.Mode != router.DistributionRoundRobin {
+		t.Errorf("single-kind: Distribution.Mode=%v, want DistributionRoundRobin", sel.Distribution.Mode)
+	}
+}
+
+func TestHook_SelectRoute_BadDistributionLogsAndDefers(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec()
+    return RouteSpec(chosen=candidates[0], distribution="not-a-thing")
+`
+	hopA := "020000000000000000000000000000000000000000000000000000000000000001"
+	prov := NewFakeProvider().SetGeo(hopA, "DE")
+
+	loader, err := NewLoader(src, WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	var logged string
+	h := NewHook(loader, WithHookProvider(prov), WithHookLogger(func(f string, _ ...interface{}) {
+		logged += f
+	}))
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	cands := []router.CandidateInfo{{Hops: []string{hopA}}}
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk}, cands)
+	if err != nil {
+		t.Fatalf("SelectRoute: %v", err)
+	}
+	if sel.Distribution.Mode != router.DistributionUnset {
+		t.Errorf("bad descriptor in SelectRoute: Distribution.Mode=%v, want DistributionUnset", sel.Distribution.Mode)
+	}
+	if logged == "" {
+		t.Errorf("expected the bad distribution to be logged")
+	}
+}

--- a/pkg/router/policy/types.go
+++ b/pkg/router/policy/types.go
@@ -78,11 +78,6 @@ type Candidate struct {
 	// mixed-transport routes). Used by policies that want to
 	// prefer direct-tcp paths over relayed-dmsg paths.
 	TransportKinds []string
-
-	// MuxLegsAvailable indicates how many parallel mux legs can
-	// be opened along this route. Bounded by the route's
-	// intermediates' capabilities. Zero means "single leg only."
-	MuxLegsAvailable int
 }
 
 // RouteSpec is the structured return value from the policy
@@ -96,7 +91,10 @@ type RouteSpec struct {
 	Chosen *Candidate
 
 	// Mux is the number of parallel mux legs to open. Zero or 1
-	// means a single route. Capped by Chosen.MuxLegsAvailable.
+	// means a single route. The router caps it at the number of
+	// disjoint candidates the route-finder returned — scripts
+	// that want to know that count up-front should read
+	// `len(candidates)` in SelectRoute.
 	Mux int
 
 	// MinHops is the minimum acceptable intermediate count.
@@ -107,9 +105,18 @@ type RouteSpec struct {
 
 	// Fallback names the backup strategy when Chosen is nil or
 	// rejected. Recognized values:
-	//   ""       — use the visor's built-in default
-	//   "direct" — try a direct transport, no overlay
-	//   "drop"   — fail the dial loudly (operator notices)
+	//   ""     — use the visor's built-in default (router's
+	//            disjoint-path pick on the unfiltered candidates,
+	//            or direct-transport short-circuit if one exists)
+	//   "drop" — fail the dial loudly with ErrDialPolicyDropped
+	//            (operator notices; app sees a connection error)
+	//
+	// Any other value is treated as "". The earlier doc mentioned
+	// a "direct" value with "try a direct transport, no overlay"
+	// semantics; that was aspirational and never implemented — use
+	// "drop" instead when a script wants to force the no-overlay
+	// path (or set MinHops=1 to nudge the router toward direct
+	// without refusing the dial outright).
 	Fallback string
 
 	// Distribution is the per-packet distribution descriptor for

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -573,6 +573,18 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 	rg.mux.tpSelector.Rebuild(rg.tps)
 	legs := len(rg.tps)
 	rg.mu.Unlock()
+	// Weighted mode silently substitutes weight=1 for missing
+	// entries when len(weights) < legs and ignores trailing
+	// weights when len(weights) > legs. Surface the mismatch
+	// at warn so operators can correlate "my schedule isn't
+	// what I asked for" with a script/leg-count discrepancy.
+	if rg.logger != nil && cfg.Mode == DistributionWeighted && len(cfg.Weights) != legs {
+		rg.logger.
+			WithField("weights_len", len(cfg.Weights)).
+			WithField("legs", legs).
+			Warn("Routing policy weighted distribution: weight count != leg count. " +
+				"Missing weights default to 1; trailing weights are ignored.")
+	}
 	if rg.logger != nil {
 		entry := rg.logger.
 			WithField("distribution", cfg.Mode.String()).

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -654,7 +654,12 @@ fetchRoutesAgain:
 	// fall back to GetTransport's cached entry. Pass-through when
 	// the route-finder returned a single candidate (lookup is built
 	// but never iterated).
-	latencyFor := r.buildLatencyLookup(ctx, paths[forward], paths[backward])
+	// Single TPD walk: builds both the latency rank lookup and the
+	// type lookup the DMSG-multihop filter needs. Before merging,
+	// each was a separate GetTransportByID per ID — doubling the
+	// TPD query rate per dial and tripping the service's
+	// 30-req/min rate limit on heavier workloads.
+	latencyFor, typeFor := r.buildHopLookups(ctx, paths[forward], paths[backward])
 
 	// Drop any multihop candidate that contains a DMSG hop. A DMSG
 	// transport relays through a dmsg server (possibly chained via
@@ -666,7 +671,6 @@ fetchRoutesAgain:
 	// multihop, the disjoint-path pick below will fail and we'll
 	// fall through to calculateLocalRoutes (which applies the same
 	// filter at BFS construction time).
-	typeFor := r.buildTypeLookup(ctx, paths[forward], paths[backward])
 	if filtered := rejectDMSGMultihop(paths[forward], typeFor); len(filtered) != len(paths[forward]) {
 		log.Debugf("rejected %d DMSG-multihop forward candidate(s)", len(paths[forward])-len(filtered))
 		paths[forward] = filtered
@@ -707,17 +711,28 @@ fetchRoutesAgain:
 		} else if sel.Drop {
 			log.WithField("policy_decision", "drop").Info("Routing policy dropped dial at SelectRoute.")
 			return nil, nil, ErrDialPolicyDropped
-		} else if sel.Chosen >= 0 && sel.Chosen < len(paths[forward]) {
-			chosenFwd := paths[forward][sel.Chosen]
-			excludeSet := make(map[cipher.PubKey]struct{}, len(opts.ExcludeIntermediatePKs))
-			for _, pk := range opts.ExcludeIntermediatePKs {
-				excludeSet[pk] = struct{}{}
+		} else {
+			// SelectRoute may also override the per-packet
+			// distribution descriptor based on the candidate it
+			// chose. Apply it (if set) to opts so the post-mux
+			// applyDistribution call picks it up; the BeforeDial-
+			// supplied distribution stays in effect when SelectRoute
+			// leaves Mode == DistributionUnset.
+			if sel.Distribution.Mode != DistributionUnset {
+				opts.Distribution = sel.Distribution
 			}
-			if revPath, revOk := pickBestDirection(paths[backward], excludeSet, latencyFor); revOk {
-				log.WithField("policy_chosen", sel.Chosen).Debug("Routing policy selected forward route.")
-				return chosenFwd, revPath, nil
+			if sel.Chosen >= 0 && sel.Chosen < len(paths[forward]) {
+				chosenFwd := paths[forward][sel.Chosen]
+				excludeSet := make(map[cipher.PubKey]struct{}, len(opts.ExcludeIntermediatePKs))
+				for _, pk := range opts.ExcludeIntermediatePKs {
+					excludeSet[pk] = struct{}{}
+				}
+				if revPath, revOk := pickBestDirection(paths[backward], excludeSet, latencyFor); revOk {
+					log.WithField("policy_chosen", sel.Chosen).Debug("Routing policy selected forward route.")
+					return chosenFwd, revPath, nil
+				}
+				log.Debug("Routing policy picked a forward route but no acceptable reverse; falling back to disjoint pick.")
 			}
-			log.Debug("Routing policy picked a forward route but no acceptable reverse; falling back to disjoint pick.")
 		}
 	}
 
@@ -837,26 +852,25 @@ func pathLatencyScore(path []routing.Hop, latencyFor func(uuid.UUID) float64) fl
 	return total
 }
 
-// buildLatencyLookup constructs a TpID → avg-latency-ms lookup over
-// the union of TpIDs appearing in fwd and rev path candidates.
-// Sources, in preference order:
+// buildHopLookups constructs TpID → avg-latency-ms and TpID →
+// transport-type lookups over the union of TpIDs appearing in fwd
+// and rev path candidates. Sources, in preference order:
 //
-//  1. Local transport manager — `tm.GetLatencyStats().Avg` for any
-//     transport this visor holds. Constant-time map read; reflects the
-//     freshest measured RSN-ping value, including transports that
-//     haven't yet propagated to TPD.
+//  1. Local transport manager — `tm.Transport(id)` for any transport
+//     this visor holds. Constant-time map read.
 //  2. TPD `GetTransport(tpID)` — entries the local visor doesn't own
-//     (the intermediate-to-intermediate hops). Latency hydrated by
-//     pkg/transport-discovery/cxoaggregator from the per-visor CXO
-//     telemetry feed.
+//     (intermediate-to-intermediate hops). One round-trip per unique
+//     ID.
 //
-// Returns a closure rather than a map so the caller pays for lookups
-// only for hops actually visited during ranking; the candidate slice
-// is typically 2-3 paths × ≤6 hops = small.
-func (r *router) buildLatencyLookup(ctx context.Context, fwd, rev [][]routing.Hop) func(uuid.UUID) float64 {
-	// Single dial's candidate set is small — collect unique TpIDs first
-	// so we don't double-fetch when an intermediate appears in both
-	// forward and reverse paths.
+// Both lookups share a single GetTransportByID per ID so callers
+// that need both (the dial path: pickDisjointPath's latency rank
+// + rejectDMSGMultihop's type filter) don't double the TPD load.
+// Before #2899 added the type lookup as a sibling, the dial path
+// hit TPD once per hop; sharing brings it back to that level.
+//
+// typeFor returns "" for IDs the lookup failed for — rejectDMSGMultihop
+// treats unknown as "not DMSG" (can't prove it's bad).
+func (r *router) buildHopLookups(ctx context.Context, fwd, rev [][]routing.Hop) (latencyFor func(uuid.UUID) float64, typeFor func(uuid.UUID) string) {
 	unique := make(map[uuid.UUID]struct{})
 	for _, paths := range [][][]routing.Hop{fwd, rev} {
 		for _, p := range paths {
@@ -865,76 +879,37 @@ func (r *router) buildLatencyLookup(ctx context.Context, fwd, rev [][]routing.Ho
 			}
 		}
 	}
-	cache := make(map[uuid.UUID]float64, len(unique))
+	latencyCache := make(map[uuid.UUID]float64, len(unique))
+	typeCache := make(map[uuid.UUID]string, len(unique))
 	for id := range unique {
-		// Local transport first — freshest signal, no TPD round-trip.
+		// Local transport first.
 		if r.tm != nil {
 			if tp := r.tm.Transport(id); tp != nil {
 				if stats := tp.GetLatencyStats(); stats.Avg > 0 {
-					cache[id] = stats.Avg
-					continue
+					latencyCache[id] = stats.Avg
 				}
+				typeCache[id] = string(tp.Entry.Type)
+				continue
 			}
 		}
-		// Fall through to TPD: hydrated latency from the CXO aggregator.
-		// Errors are logged at debug and treated as unknown — ranker's
-		// unknownLatencyCostMs penalty handles missing data.
+		// TPD fallback — one fetch covers both lookups.
 		if r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil {
 			entry, err := r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, id)
 			if err != nil {
-				r.logger.WithError(err).Debugf("buildLatencyLookup: GetTransportByID failed for %s — treating as unknown latency", id)
+				r.logger.WithError(err).Debugf("buildHopLookups: GetTransportByID failed for %s", id)
 				continue
 			}
-			if entry != nil && entry.Latency > 0 {
-				cache[id] = entry.Latency
-			}
-		}
-	}
-	return func(id uuid.UUID) float64 {
-		return cache[id]
-	}
-}
-
-// buildTypeLookup constructs a TpID → transport-type lookup over the
-// union of TpIDs appearing in fwd and rev path candidates. Used by
-// rejectDMSGMultihop to drop route-finder responses that contain
-// DMSG hops in a multihop path — DMSG transports relay through a
-// dmsg server (and any server-to-server forwarding hops) that
-// neither endpoint of the route can observe.
-//
-// Sources mirror buildLatencyLookup: local transport manager first,
-// TPD GetTransportByID for hops the local visor doesn't own.
-// Returns "" for IDs that couldn't be resolved — the multihop
-// filter treats unknown as "not DMSG" (we can't prove it's bad,
-// so we let it through; the route still has to handshake which
-// will fail loudly if the type is actually a problem).
-func (r *router) buildTypeLookup(ctx context.Context, fwd, rev [][]routing.Hop) func(uuid.UUID) string {
-	unique := make(map[uuid.UUID]struct{})
-	for _, paths := range [][][]routing.Hop{fwd, rev} {
-		for _, p := range paths {
-			for _, h := range p {
-				unique[h.TpID] = struct{}{}
-			}
-		}
-	}
-	cache := make(map[uuid.UUID]string, len(unique))
-	for id := range unique {
-		if r.tm != nil {
-			if tp := r.tm.Transport(id); tp != nil {
-				cache[id] = string(tp.Entry.Type)
+			if entry == nil {
 				continue
 			}
-		}
-		if r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil {
-			entry, err := r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, id)
-			if err == nil && entry != nil {
-				cache[id] = string(entry.Type)
+			if entry.Latency > 0 {
+				latencyCache[id] = entry.Latency
 			}
+			typeCache[id] = string(entry.Type)
 		}
 	}
-	return func(id uuid.UUID) string {
-		return cache[id]
-	}
+	return func(id uuid.UUID) float64 { return latencyCache[id] },
+		func(id uuid.UUID) string { return typeCache[id] }
 }
 
 // rejectDMSGMultihop returns paths with any multihop candidate


### PR DESCRIPTION
## Summary
Round-2 review of the routing-policy stack caught four real issues:

1. **\`SelectRoute\` couldn't propagate distribution.** Script's \`spec.Distribution\` from SelectRoute was dropped on the floor — \`RouteSelection\` only had \`Chosen\` and \`Drop\`. Fixed by adding \`RouteSelection.Distribution\`; the router overrides \`opts.Distribution\` from SelectRoute when set; BeforeDial's value stays in effect otherwise. This enables dynamic per-candidate distribution decisions (the original intent of \`weighted-by-kind.star\`).

2. **\`Candidate.MuxLegsAvailable\` was always zero.** Starlark surface exposed \`c.mux_legs_available\` but it was never populated. Misleading. Dropped from the Candidate surface; \`len(candidates)\` in SelectRoute is the right metric and the README explains the pattern.

3. **Weighted distribution silently mismatched leg count.** No warning when \`weighted: 3, 1\` was applied to a 3-leg route group. Now logs at warn level so the discrepancy is auditable.

4. **TPD perf regression from #2899.** \`buildLatencyLookup\` and \`buildTypeLookup\` each called \`GetTransportByID\` per ID — doubling TPD load per dial. Heavier workloads hit the service's 30/min rate limit. Merged into a single \`buildHopLookups\` that returns both closures from one walk.

Doc cleanups in the same pass:
- \`RouteSpec.Fallback\` doc no longer claims \`"direct"\` works (only \`"drop"\` triggers refusal).
- README: two-phase model now mentions that SelectRoute CAN set distribution; new "Knowing the leg count" section.
- \`weighted-by-kind.star\` is back as a working dynamic example.
- \`weighted-static.star\` header fixed (was still saying weighted-by-kind).

## Test plan
- [x] \`go test ./pkg/router/...\` passes (incl. 2 new TestHook_SelectRoute_Distribution* tests)
- [x] \`golangci-lint run\` clean
- [x] All 13 example .star files preview cleanly (no drops on empty candidates)
- [x] Live verification on running visor: distribution flows from script through SelectRoute into route group selector

## Known follow-up
Directional asymmetry (\`stcpr forward, sudph reverse\`-style policies) isn't supported by the policy DSL yet. The router has \`Forward/ReverseMuxRoutes\` but the Starlark \`RouteSpec\` doesn't expose them, and \`SelectRoute\` only sees forward candidates. Tracked as a separate PR.