### PR TITLE
feat(router/policy): directional asymmetry (forward/reverse routing)

### DIFF
--- a/cmd/skywire-cli/commands/route/policy.go
+++ b/cmd/skywire-cli/commands/route/policy.go
@@ -213,20 +213,30 @@ func (c fixedClock) Now() time.Time { return c.t }
 // specToJSON projects RouteSpec into a JSON-printable form. The
 // Chosen field uses a *Candidate; we flatten it for display.
 type specJSON struct {
-	Chosen       *policy.Candidate `json:"chosen,omitempty"`
-	Mux          int               `json:"mux"`
-	MinHops      int               `json:"min_hops"`
-	Fallback     string            `json:"fallback,omitempty"`
-	Distribution string            `json:"distribution,omitempty"`
+	Chosen         *policy.Candidate `json:"chosen,omitempty"`
+	ReverseChosen  *policy.Candidate `json:"reverse_chosen,omitempty"`
+	Mux            int               `json:"mux"`
+	ForwardMux     int               `json:"forward_mux,omitempty"`
+	ReverseMux     int               `json:"reverse_mux,omitempty"`
+	MinHops        int               `json:"min_hops"`
+	ForwardMinHops int               `json:"forward_min_hops,omitempty"`
+	ReverseMinHops int               `json:"reverse_min_hops,omitempty"`
+	Fallback       string            `json:"fallback,omitempty"`
+	Distribution   string            `json:"distribution,omitempty"`
 }
 
 func specToJSON(s policy.RouteSpec) specJSON {
 	return specJSON{
-		Chosen:       s.Chosen,
-		Mux:          s.Mux,
-		MinHops:      s.MinHops,
-		Fallback:     s.Fallback,
-		Distribution: s.Distribution,
+		Chosen:         s.Chosen,
+		ReverseChosen:  s.ReverseChosen,
+		Mux:            s.Mux,
+		ForwardMux:     s.ForwardMux,
+		ReverseMux:     s.ReverseMux,
+		MinHops:        s.MinHops,
+		ForwardMinHops: s.ForwardMinHops,
+		ReverseMinHops: s.ReverseMinHops,
+		Fallback:       s.Fallback,
+		Distribution:   s.Distribution,
 	}
 }
 

--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -52,6 +52,40 @@ SelectRoute. `distribution` can be set in either phase; when both
 set it, SelectRoute's value wins (it fires later in the flow and
 has more information).
 
+### Directional asymmetry
+
+`mux` / `min_hops` / `chosen` have per-direction overrides:
+`forward_mux` / `reverse_mux`, `forward_min_hops` / `reverse_min_hops`,
+and `reverse_chosen`. The reverse-direction candidates are
+exposed in SelectRoute as `ctx.reverse_candidates` (separate
+list from the positional `candidates` argument, which is always
+forward).
+
+```python
+# Different transport kinds per direction:
+# stcpr upstream, sudph downstream.
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec(forward_mux=1, reverse_mux=4)
+
+    fwd = None
+    for c in candidates:
+        if "stcpr" in c.transport_kinds:
+            fwd = c
+            break
+    rev = None
+    for c in ctx.reverse_candidates:
+        if "sudph" in c.transport_kinds:
+            rev = c
+            break
+    return RouteSpec(chosen=fwd, reverse_chosen=rev)
+```
+
+See `asymmetric-stcpr-sudph.star` for a full annotated example.
+Partial picks (only `chosen` or only `reverse_chosen`) are
+valid — the router fills the unset direction with its built-in
+latency-ranked pick.
+
 ### Knowing the leg count
 
 In SelectRoute, the script sees the route-finder's disjoint
@@ -110,6 +144,7 @@ case explicitly.
 | `business-hours.star` | 9–17 weekdays: only SG/JP/ID; off-hours: anything. |
 | `vpn-killswitch.star` | VPN: opt into mux BeforeDial, refuse non-direct-IP legs SelectRoute. |
 | `friday-id.star` | RFC headline: Friday 17:00 → Indonesia-transit only. |
+| `asymmetric-stcpr-sudph.star` | Forward stcpr (TCP), reverse sudph (UDP); different mux/min-hops per direction. |
 | `smoke-test.star` | Visible policy used for integration testing — logs every dial. |
 
 ## Layer 2 — per-packet distribution

--- a/docs/examples/routing-policies/asymmetric-stcpr-sudph.star
+++ b/docs/examples/routing-policies/asymmetric-stcpr-sudph.star
@@ -1,0 +1,49 @@
+# asymmetric-stcpr-sudph.star — different transport kinds for
+# forward vs reverse. Forward (upstream) uses stcpr (TCP, lower
+# loss, slower); reverse (downstream) uses sudph (UDP-hole-punched,
+# better for bulk throughput).
+#
+# Two-phase invocation:
+#   - BeforeDial (candidates empty): set per-direction mux + min
+#     hops asymmetrically. This is the new forward_mux / reverse_mux
+#     pair — Mux (symmetric) still works but is overridden when
+#     forward_mux or reverse_mux is set.
+#   - SelectRoute (candidates populated): pick forward by stcpr,
+#     reverse by sudph. ctx.reverse_candidates exposes the reverse-
+#     direction candidate list (independent from `candidates`,
+#     which is always the forward list).
+#
+# Note: forward and reverse candidates are often the SAME list when
+# the route-finder query was symmetric (same MinHops for both
+# directions). The router only splits into separate queries when
+# the script asks for asymmetric MinHops up front.
+
+def _first_with_kind(cs, kind):
+    for c in cs:
+        if kind in c.transport_kinds:
+            return c
+    return None
+
+def decide_route(ctx, candidates):
+    # BeforeDial: 1 forward leg, 4 reverse legs — typical
+    # download-heavy workload. Forward needs only 1 stcpr; reverse
+    # gets 4 sudph for aggregated bulk.
+    if not candidates:
+        return RouteSpec(
+            forward_mux=1, reverse_mux=4,
+            forward_min_hops=2, reverse_min_hops=2,
+        )
+
+    # SelectRoute: pick by kind per direction.
+    fwd = _first_with_kind(candidates, "stcpr")
+    rev = _first_with_kind(ctx.reverse_candidates, "sudph")
+
+    if fwd == None and rev == None:
+        # Neither direction has a matching candidate — drop so
+        # the operator sees the policy isn't satisfiable for
+        # this dial.
+        return RouteSpec(fallback="drop")
+
+    # Partial picks are fine: the router will fill in the unset
+    # direction via its built-in latency-ranked pick.
+    return RouteSpec(chosen=fwd, reverse_chosen=rev)

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -57,9 +57,22 @@ type DialAdjustment struct {
 	// this dial.
 	MuxRoutes int
 
+	// ForwardMuxRoutes and ReverseMuxRoutes are per-direction
+	// overrides for asymmetric mux. Zero falls back to MuxRoutes.
+	// Used by policies that want different upstream / downstream
+	// fan-out (e.g. ForwardMuxRoutes=1 + ReverseMuxRoutes=4 for
+	// a download-heavy workload).
+	ForwardMuxRoutes int
+	ReverseMuxRoutes int
+
 	// MinHops, when > 0, overrides DialOptions.MinHops for this
 	// dial.
 	MinHops int
+
+	// ForwardMinHops and ReverseMinHops are per-direction
+	// overrides for MinHops. Zero falls back to MinHops.
+	ForwardMinHops int
+	ReverseMinHops int
 
 	// Fallback, when "drop", causes DialRoutes to refuse the
 	// dial with ErrDialPolicyDropped. Any other value is
@@ -161,8 +174,20 @@ func applyAdjustment(opts *DialOptions, adj DialAdjustment) error {
 	if adj.MuxRoutes > 0 {
 		opts.MuxRoutes = adj.MuxRoutes
 	}
+	if adj.ForwardMuxRoutes > 0 {
+		opts.ForwardMuxRoutes = adj.ForwardMuxRoutes
+	}
+	if adj.ReverseMuxRoutes > 0 {
+		opts.ReverseMuxRoutes = adj.ReverseMuxRoutes
+	}
 	if adj.MinHops > 0 {
 		opts.MinHops = adj.MinHops
+	}
+	if adj.ForwardMinHops > 0 {
+		opts.ForwardMinHops = adj.ForwardMinHops
+	}
+	if adj.ReverseMinHops > 0 {
+		opts.ReverseMinHops = adj.ReverseMinHops
 	}
 	if adj.Distribution.Mode != DistributionUnset {
 		opts.Distribution = adj.Distribution
@@ -183,11 +208,13 @@ func applyAdjustment(opts *DialOptions, adj DialAdjustment) error {
 type RouteSelectingHook interface {
 	DialHook
 	// SelectRoute is invoked synchronously after the route-finder
-	// returns candidates and before route setup. The hook may
-	// return a Chosen index (into the candidates slice) or -1 to
-	// defer to the router's built-in selection. Drop=true refuses
-	// the dial with ErrDialPolicyDropped.
-	SelectRoute(ctx context.Context, info DialInfo, candidates []CandidateInfo) (RouteSelection, error)
+	// returns candidates and before route setup. forward and
+	// reverse are the per-direction candidate lists (the same
+	// path returned for both directions when the route-finder
+	// query was symmetric). The hook may return Chosen / ReverseChosen
+	// indices (into the respective lists) or -1 to defer per
+	// direction. Drop=true refuses the dial with ErrDialPolicyDropped.
+	SelectRoute(ctx context.Context, info DialInfo, forward, reverse []CandidateInfo) (RouteSelection, error)
 }
 
 // CandidateInfo is the bare-bones per-candidate description the
@@ -222,7 +249,15 @@ type CandidateInfo struct {
 // Mode == DistributionUnset means "no override at SelectRoute
 // time" — falls back to whatever BeforeDial set on DialOptions.
 type RouteSelection struct {
-	Chosen       int
-	Drop         bool
-	Distribution DistributionConfig
+	// Chosen is the forward-direction index into the forward
+	// candidates slice passed to SelectRoute, or -1 to defer.
+	Chosen int
+	// ReverseChosen is the reverse-direction index into the
+	// reverse candidates slice, or -1 to defer (router uses its
+	// built-in pickBestDirection latency rank for reverse).
+	// Independent of Chosen — a script can override forward but
+	// defer reverse, or vice versa.
+	ReverseChosen int
+	Drop          bool
+	Distribution  DistributionConfig
 }

--- a/pkg/router/policy/bridge.go
+++ b/pkg/router/policy/bridge.go
@@ -190,7 +190,8 @@ func buildContextValue(rctx RoutingContext) starlark.Value {
 			"now": starlark.NewBuiltin("now", func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 				return timeValue(rctx.Now), nil
 			}),
-			"cli_overrides": cliOverrides,
+			"cli_overrides":      cliOverrides,
+			"reverse_candidates": buildCandidatesValue(rctx.ReverseCandidates),
 		},
 	)
 }
@@ -233,11 +234,16 @@ func routeSpecCtor(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple,
 		return nil, fmt.Errorf("RouteSpec: positional arguments not allowed; use kwargs")
 	}
 	dict := starlark.StringDict{
-		"chosen":       starlark.None,
-		"mux":          starlark.MakeInt(0),
-		"min_hops":     starlark.MakeInt(0),
-		"fallback":     starlark.String(""),
-		"distribution": starlark.String(""),
+		"chosen":           starlark.None,
+		"reverse_chosen":   starlark.None,
+		"mux":              starlark.MakeInt(0),
+		"forward_mux":      starlark.MakeInt(0),
+		"reverse_mux":      starlark.MakeInt(0),
+		"min_hops":         starlark.MakeInt(0),
+		"forward_min_hops": starlark.MakeInt(0),
+		"reverse_min_hops": starlark.MakeInt(0),
+		"fallback":         starlark.String(""),
+		"distribution":     starlark.String(""),
 	}
 	for _, kv := range kwargs {
 		key := string(kv[0].(starlark.String))
@@ -295,8 +301,21 @@ func parseRouteSpec(v starlark.Value) (RouteSpec, error) {
 			out.Chosen = &cand
 		}
 	}
+	if rev, err := s.Attr("reverse_chosen"); err == nil && rev != nil {
+		if _, isNone := rev.(starlark.NoneType); !isNone {
+			cand, err := parseCandidate(rev)
+			if err != nil {
+				return RouteSpec{}, fmt.Errorf("reverse_chosen: %w", err)
+			}
+			out.ReverseChosen = &cand
+		}
+	}
 	out.Mux = readIntField(s, "mux")
+	out.ForwardMux = readIntField(s, "forward_mux")
+	out.ReverseMux = readIntField(s, "reverse_mux")
 	out.MinHops = readIntField(s, "min_hops")
+	out.ForwardMinHops = readIntField(s, "forward_min_hops")
+	out.ReverseMinHops = readIntField(s, "reverse_min_hops")
 	out.Fallback = readStrField(s, "fallback")
 	out.Distribution = readStrField(s, "distribution")
 	return out, nil

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -109,9 +109,13 @@ func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.Dia
 		return router.DialAdjustment{}, err
 	}
 	adj := router.DialAdjustment{
-		MuxRoutes: spec.Mux,
-		MinHops:   spec.MinHops,
-		Fallback:  spec.Fallback,
+		MuxRoutes:        spec.Mux,
+		ForwardMuxRoutes: spec.ForwardMux,
+		ReverseMuxRoutes: spec.ReverseMux,
+		MinHops:          spec.MinHops,
+		ForwardMinHops:   spec.ForwardMinHops,
+		ReverseMinHops:   spec.ReverseMinHops,
+		Fallback:         spec.Fallback,
 	}
 	// Distribution descriptor parse — failure is non-fatal
 	// (script keeps the rest of the adjustment; distribution
@@ -138,47 +142,53 @@ func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.Dia
 //
 // "drop" Fallback maps to RouteSelection.Drop. An empty Chosen
 // with no drop signal maps to Chosen=-1 (defer to router's pick).
-func (h *Hook) SelectRoute(ctx context.Context, info router.DialInfo, candidates []router.CandidateInfo) (router.RouteSelection, error) {
+func (h *Hook) SelectRoute(ctx context.Context, info router.DialInfo, forward, reverse []router.CandidateInfo) (router.RouteSelection, error) {
 	loader := h.loaderFor(info.AppName)
-	if loader == nil || !loader.IsActive() || len(candidates) == 0 {
-		return router.RouteSelection{Chosen: -1}, nil
+	if loader == nil || !loader.IsActive() || len(forward) == 0 {
+		return router.RouteSelection{Chosen: -1, ReverseChosen: -1}, nil
 	}
 	prov := h.provider
 	if prov == nil {
 		prov = NopProvider()
 	}
-	policyCandidates := make([]Candidate, 0, len(candidates))
-	for _, c := range candidates {
-		geoCodes := make([]string, len(c.Hops))
-		kinds := make([]string, 0, len(c.Hops))
-		seenKinds := make(map[string]struct{}, len(c.Hops))
-		for i, pk := range c.Hops {
-			geoCodes[i] = prov.Geo(pk)
-			if k := prov.Kind(pk); k != "" {
-				if _, ok := seenKinds[k]; !ok {
-					kinds = append(kinds, k)
-					seenKinds[k] = struct{}{}
+	enrich := func(cs []router.CandidateInfo) []Candidate {
+		out := make([]Candidate, 0, len(cs))
+		for _, c := range cs {
+			geoCodes := make([]string, len(c.Hops))
+			kinds := make([]string, 0, len(c.Hops))
+			seenKinds := make(map[string]struct{}, len(c.Hops))
+			for i, pk := range c.Hops {
+				geoCodes[i] = prov.Geo(pk)
+				if k := prov.Kind(pk); k != "" {
+					if _, ok := seenKinds[k]; !ok {
+						kinds = append(kinds, k)
+						seenKinds[k] = struct{}{}
+					}
 				}
 			}
+			out = append(out, Candidate{
+				Hops:           append([]string(nil), c.Hops...),
+				HopsGeo:        geoCodes,
+				EstLatencyMs:   c.EstLatencyMs,
+				TransportKinds: kinds,
+			})
 		}
-		policyCandidates = append(policyCandidates, Candidate{
-			Hops:           append([]string(nil), c.Hops...),
-			HopsGeo:        geoCodes,
-			EstLatencyMs:   c.EstLatencyMs,
-			TransportKinds: kinds,
-		})
+		return out
 	}
+	policyCandidates := enrich(forward)
+	policyReverse := enrich(reverse)
 	rctx := RoutingContext{
-		App:    info.AppName,
-		PeerPK: info.PeerPK.Hex(),
-		Port:   uint16(info.RPort),
+		App:               info.AppName,
+		PeerPK:            info.PeerPK.Hex(),
+		Port:              uint16(info.RPort),
+		ReverseCandidates: policyReverse,
 	}
 	spec, err := loader.Decide(ctx, rctx, policyCandidates)
 	if err != nil {
-		return router.RouteSelection{Chosen: -1}, err
+		return router.RouteSelection{Chosen: -1, ReverseChosen: -1}, err
 	}
 	if spec.Fallback == "drop" {
-		return router.RouteSelection{Drop: true, Chosen: -1}, nil
+		return router.RouteSelection{Drop: true, Chosen: -1, ReverseChosen: -1}, nil
 	}
 	// Distribution descriptor — parsed from SelectRoute so the
 	// script can branch on the chosen candidate's properties
@@ -193,11 +203,19 @@ func (h *Hook) SelectRoute(ctx context.Context, info router.DialInfo, candidates
 	} else {
 		dist = d
 	}
-	if spec.Chosen == nil {
-		return router.RouteSelection{Chosen: -1, Distribution: dist}, nil
+	fwdIdx := -1
+	if spec.Chosen != nil {
+		fwdIdx = matchCandidate(policyCandidates, *spec.Chosen)
 	}
-	idx := matchCandidate(policyCandidates, *spec.Chosen)
-	return router.RouteSelection{Chosen: idx, Distribution: dist}, nil
+	revIdx := -1
+	if spec.ReverseChosen != nil {
+		revIdx = matchCandidate(policyReverse, *spec.ReverseChosen)
+	}
+	return router.RouteSelection{
+		Chosen:        fwdIdx,
+		ReverseChosen: revIdx,
+		Distribution:  dist,
+	}, nil
 }
 
 // matchCandidate finds the index of want in pool by Hops equality.

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -146,7 +146,7 @@ def decide_route(ctx, candidates):
 		{Hops: []string{hopA, hopB}}, // DE, ID — should win
 		{Hops: []string{hopC}},       // US
 	}
-	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "skychat", PeerPK: pk}, cands)
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "skychat", PeerPK: pk}, cands, nil)
 	if err != nil {
 		t.Fatalf("SelectRoute: %v", err)
 	}
@@ -182,7 +182,7 @@ def decide_route(ctx, candidates):
 	pk := cipher.PubKey{}
 	pk[0] = 0x02
 	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk},
-		[]router.CandidateInfo{{Hops: []string{hopA}}})
+		[]router.CandidateInfo{{Hops: []string{hopA}}}, nil)
 	if err != nil {
 		t.Fatalf("SelectRoute: %v", err)
 	}
@@ -336,7 +336,7 @@ def decide_route(ctx, candidates):
 
 	// Single-kind route → round-robin
 	cands := []router.CandidateInfo{{Hops: []string{hopA}}}
-	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk}, cands)
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk}, cands, nil)
 	if err != nil {
 		t.Fatalf("SelectRoute single-kind: %v", err)
 	}
@@ -368,7 +368,7 @@ def decide_route(ctx, candidates):
 	pk := cipher.PubKey{}
 	pk[0] = 0x02
 	cands := []router.CandidateInfo{{Hops: []string{hopA}}}
-	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk}, cands)
+	sel, err := h.SelectRoute(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk}, cands, nil)
 	if err != nil {
 		t.Fatalf("SelectRoute: %v", err)
 	}
@@ -377,5 +377,97 @@ def decide_route(ctx, candidates):
 	}
 	if logged == "" {
 		t.Errorf("expected the bad distribution to be logged")
+	}
+}
+
+func TestHook_AsymmetricForwardReverseChosen(t *testing.T) {
+	// Pick forward by hop[0]=="stcpr_hop"; pick reverse by
+	// hop[0]=="sudph_hop". Script branches on transport_kinds.
+	src := `
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec()
+    fwd = None
+    for c in candidates:
+        if "stcpr" in c.transport_kinds:
+            fwd = c
+            break
+    rev = None
+    for c in ctx.reverse_candidates:
+        if "sudph" in c.transport_kinds:
+            rev = c
+            break
+    return RouteSpec(chosen=fwd, reverse_chosen=rev)
+`
+	hopStcpr := "020000000000000000000000000000000000000000000000000000000000000011"
+	hopSudph := "020000000000000000000000000000000000000000000000000000000000000022"
+
+	prov := NewFakeProvider().
+		SetKind(hopStcpr, "stcpr").
+		SetKind(hopSudph, "sudph").
+		SetGeo(hopStcpr, "DE").
+		SetGeo(hopSudph, "ID")
+
+	loader, err := NewLoader(src, WithProvider(prov))
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader, WithHookProvider(prov))
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+
+	forward := []router.CandidateInfo{
+		{Hops: []string{hopSudph}}, // first: sudph
+		{Hops: []string{hopStcpr}}, // second: stcpr — script wants this for forward
+	}
+	reverse := []router.CandidateInfo{
+		{Hops: []string{hopStcpr}}, // first: stcpr
+		{Hops: []string{hopSudph}}, // second: sudph — script wants this for reverse
+	}
+
+	sel, err := h.SelectRoute(context.Background(),
+		router.DialInfo{AppName: "vpn-client", PeerPK: pk}, forward, reverse)
+	if err != nil {
+		t.Fatalf("SelectRoute: %v", err)
+	}
+	if sel.Chosen != 1 {
+		t.Errorf("forward Chosen=%d, want 1 (stcpr)", sel.Chosen)
+	}
+	if sel.ReverseChosen != 1 {
+		t.Errorf("ReverseChosen=%d, want 1 (sudph)", sel.ReverseChosen)
+	}
+}
+
+func TestHook_BeforeDial_AsymmetricMuxAndMinHops(t *testing.T) {
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec(forward_mux=1, reverse_mux=4, forward_min_hops=1, reverse_min_hops=3)
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{AppName: "x", PeerPK: pk})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.ForwardMuxRoutes != 1 {
+		t.Errorf("ForwardMuxRoutes=%d, want 1", adj.ForwardMuxRoutes)
+	}
+	if adj.ReverseMuxRoutes != 4 {
+		t.Errorf("ReverseMuxRoutes=%d, want 4", adj.ReverseMuxRoutes)
+	}
+	if adj.ForwardMinHops != 1 {
+		t.Errorf("ForwardMinHops=%d, want 1", adj.ForwardMinHops)
+	}
+	if adj.ReverseMinHops != 3 {
+		t.Errorf("ReverseMinHops=%d, want 3", adj.ReverseMinHops)
 	}
 }

--- a/pkg/router/policy/types.go
+++ b/pkg/router/policy/types.go
@@ -48,6 +48,16 @@ type RoutingContext struct {
 	// policy can choose to honor or override them. Empty map when
 	// the dial came from a launched app rather than a CLI command.
 	CLIOverrides map[string]string
+
+	// ReverseCandidates is the reverse-direction candidate list
+	// when SelectRoute is invoked, exposed to Starlark as
+	// `ctx.reverse_candidates`. Empty during BeforeDial (no
+	// candidates yet) and during SelectRoute when the dial used
+	// a symmetric route-finder query (forward and reverse share
+	// the same path candidates — same list). Scripts that want
+	// per-direction filtering iterate this list separately and
+	// set RouteSpec.reverse_chosen.
+	ReverseCandidates []Candidate
 }
 
 // Candidate is one possible route from the visor to the peer that
@@ -84,24 +94,49 @@ type Candidate struct {
 // script. The router consumes this to drive route selection +
 // per-dial knob settings.
 type RouteSpec struct {
-	// Chosen is the candidate the policy picked. Nil means "fall
-	// back to the visor's built-in default" — either because the
-	// policy returned an explicit None or because every candidate
-	// was filtered out.
+	// Chosen is the forward-direction candidate the policy picked.
+	// Nil means "fall back to the visor's built-in default" —
+	// either because the policy returned an explicit None or
+	// because every candidate was filtered out. For directional-
+	// asymmetric policies, set ReverseChosen separately.
 	Chosen *Candidate
 
-	// Mux is the number of parallel mux legs to open. Zero or 1
-	// means a single route. The router caps it at the number of
-	// disjoint candidates the route-finder returned — scripts
-	// that want to know that count up-front should read
-	// `len(candidates)` in SelectRoute.
+	// ReverseChosen is the reverse-direction candidate, when the
+	// policy wants different forward and reverse routes (e.g.
+	// "stcpr upstream, sudph downstream"). Nil means "no override;
+	// let the router pick the lowest-latency reverse independently."
+	// The script accesses reverse candidates via ctx.reverse_candidates
+	// in SelectRoute.
+	ReverseChosen *Candidate
+
+	// Mux is the symmetric number of parallel mux legs to open.
+	// Zero or 1 means a single route. The router caps it at the
+	// number of disjoint candidates the route-finder returned —
+	// scripts that want to know that count up-front should read
+	// `len(candidates)` in SelectRoute. Overridden per-direction
+	// by ForwardMux / ReverseMux when those are non-zero.
 	Mux int
 
-	// MinHops is the minimum acceptable intermediate count.
-	// Honored as a hint by the router; if Chosen already satisfies
-	// it, no change. If Chosen doesn't, the router rejects Chosen
-	// and falls back per Fallback.
+	// ForwardMux and ReverseMux are per-direction overrides for
+	// Mux. The common use case is asymmetric workloads — a
+	// download-heavy app benefits from ReverseMux=N (multiple
+	// download paths aggregated) and ForwardMux=1 (one cheap
+	// upstream). Zero falls back to Mux.
+	ForwardMux int
+	ReverseMux int
+
+	// MinHops is the symmetric minimum acceptable intermediate
+	// count. Honored as a hint by the router. Overridden per-
+	// direction by ForwardMinHops / ReverseMinHops when those
+	// are non-zero.
 	MinHops int
+
+	// ForwardMinHops and ReverseMinHops are per-direction
+	// overrides for MinHops. Useful when one direction needs more
+	// hops than the other for compliance or trust reasons. Zero
+	// falls back to MinHops.
+	ForwardMinHops int
+	ReverseMinHops int
 
 	// Fallback names the backup strategy when Chosen is nil or
 	// rejected. Recognized values:

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -689,49 +689,74 @@ fetchRoutesAgain:
 	// the existing latency-ranked pick. Failure-safe — any error
 	// from the hook falls through to pickDisjointPath.
 	if sh, ok := r.conf.DialHook.(RouteSelectingHook); ok && sh != nil && len(paths[forward]) > 0 {
-		hookCandidates := make([]CandidateInfo, 0, len(paths[forward]))
-		for _, hops := range paths[forward] {
-			intermediates := intermediatesOfHops(hops, src, dst)
-			hopHex := make([]string, 0, len(intermediates))
-			for _, pk := range intermediates {
-				hopHex = append(hopHex, pk.Hex())
+		toHookCandidates := func(hopsList [][]routing.Hop, isForward bool) []CandidateInfo {
+			out := make([]CandidateInfo, 0, len(hopsList))
+			endpoint := src
+			if !isForward {
+				endpoint = dst
 			}
-			latSum := pathLatencyScore(hops, latencyFor)
-			hookCandidates = append(hookCandidates, CandidateInfo{
-				Hops:         hopHex,
-				EstLatencyMs: int(latSum),
-			})
+			otherEnd := dst
+			if !isForward {
+				otherEnd = src
+			}
+			for _, hops := range hopsList {
+				intermediates := intermediatesOfHops(hops, endpoint, otherEnd)
+				hopHex := make([]string, 0, len(intermediates))
+				for _, pk := range intermediates {
+					hopHex = append(hopHex, pk.Hex())
+				}
+				latSum := pathLatencyScore(hops, latencyFor)
+				out = append(out, CandidateInfo{
+					Hops:         hopHex,
+					EstLatencyMs: int(latSum),
+				})
+			}
+			return out
 		}
+		fwdHookCandidates := toHookCandidates(paths[forward], true)
+		revHookCandidates := toHookCandidates(paths[backward], false)
 		info := DialInfo{
 			AppName: opts.AppName,
 			PeerPK:  dst,
 		}
-		if sel, herr := sh.SelectRoute(ctx, info, hookCandidates); herr != nil {
+		if sel, herr := sh.SelectRoute(ctx, info, fwdHookCandidates, revHookCandidates); herr != nil {
 			log.WithError(herr).Debug("Routing policy SelectRoute errored; falling back to disjoint-path pick.")
 		} else if sel.Drop {
 			log.WithField("policy_decision", "drop").Info("Routing policy dropped dial at SelectRoute.")
 			return nil, nil, ErrDialPolicyDropped
 		} else {
-			// SelectRoute may also override the per-packet
-			// distribution descriptor based on the candidate it
-			// chose. Apply it (if set) to opts so the post-mux
-			// applyDistribution call picks it up; the BeforeDial-
-			// supplied distribution stays in effect when SelectRoute
-			// leaves Mode == DistributionUnset.
 			if sel.Distribution.Mode != DistributionUnset {
 				opts.Distribution = sel.Distribution
 			}
-			if sel.Chosen >= 0 && sel.Chosen < len(paths[forward]) {
-				chosenFwd := paths[forward][sel.Chosen]
+			// Pick forward and reverse independently — a policy
+			// can override one direction and leave the other to
+			// the router's default pick.
+			haveFwd := sel.Chosen >= 0 && sel.Chosen < len(paths[forward])
+			haveRev := sel.ReverseChosen >= 0 && sel.ReverseChosen < len(paths[backward])
+			if haveFwd || haveRev {
 				excludeSet := make(map[cipher.PubKey]struct{}, len(opts.ExcludeIntermediatePKs))
 				for _, pk := range opts.ExcludeIntermediatePKs {
 					excludeSet[pk] = struct{}{}
 				}
-				if revPath, revOk := pickBestDirection(paths[backward], excludeSet, latencyFor); revOk {
-					log.WithField("policy_chosen", sel.Chosen).Debug("Routing policy selected forward route.")
-					return chosenFwd, revPath, nil
+				var chosenFwd, chosenRev []routing.Hop
+				if haveFwd {
+					chosenFwd = paths[forward][sel.Chosen]
+				} else if best, ok := pickBestDirection(paths[forward], excludeSet, latencyFor); ok {
+					chosenFwd = best
 				}
-				log.Debug("Routing policy picked a forward route but no acceptable reverse; falling back to disjoint pick.")
+				if haveRev {
+					chosenRev = paths[backward][sel.ReverseChosen]
+				} else if best, ok := pickBestDirection(paths[backward], excludeSet, latencyFor); ok {
+					chosenRev = best
+				}
+				if chosenFwd != nil && chosenRev != nil {
+					log.
+						WithField("policy_chosen", sel.Chosen).
+						WithField("policy_reverse_chosen", sel.ReverseChosen).
+						Debug("Routing policy selected route(s).")
+					return chosenFwd, chosenRev, nil
+				}
+				log.Debug("Routing policy made a partial pick but no acceptable counterpart; falling back to disjoint pick.")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Answers the round-3 question — "can a policy use stcpr for forward and sudph for reverse?" — by wiring the existing \`DialOptions.Forward/ReverseMuxRoutes\` / \`Forward/ReverseMinHops\` through the policy DSL.

### New surface

**\`RouteSpec\`:**
- \`forward_mux\` / \`reverse_mux\` — per-direction mux counts
- \`forward_min_hops\` / \`reverse_min_hops\` — per-direction MinHops
- \`reverse_chosen\` — per-direction picked candidate

**\`ctx\` in SelectRoute:**
- \`ctx.reverse_candidates\` — reverse-direction list (separate from the positional \`candidates\` arg, which is always forward)

### Wired through
- Policy package: types + bridge + hook (BeforeDial populates new \`DialAdjustment\` fields; SelectRoute now takes \`(forward, reverse)\` and returns \`Chosen + ReverseChosen\` independently — interface signature change)
- Router: \`applyAdjustment\` propagates new fields; \`toHookCandidates\` helper builds per-direction lists with correct src/dst endpoints; forward and reverse picks resolve independently with partial-pick fallback to \`pickBestDirection\`
- CLI: \`specJSON\` shows new fields with \`omitempty\`

### Example
\`docs/examples/routing-policies/asymmetric-stcpr-sudph.star\` — exactly the case asked about: forward stcpr (TCP, lower loss), reverse sudph (UDP, better bulk). BeforeDial sets \`forward_mux=1 + reverse_mux=4\`; SelectRoute filters \`ctx.reverse_candidates\` by kind.

## Test plan
- [x] Two new TestHook_Asymmetric* tests pass
- [x] All previous tests updated for new SelectRoute signature
- [x] All 14 examples preview cleanly under \`cli route policy test\`
- [x] \`golangci-lint run\` clean