### PR TITLE
feat(router/policy): on_leg_change callback (RFC #2882 phase 6)

### DIFF
--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -86,6 +86,27 @@ Partial picks (only `chosen` or only `reverse_chosen`) are
 valid — the router fills the unset direction with its built-in
 latency-ranked pick.
 
+### Post-setup leg changes (`on_leg_change`)
+
+Scripts can optionally define `on_leg_change(ctx, legs, change)`:
+the route group calls it whenever its leg set mutates — a new
+mux leg established via `appendRouteToGroup`, or a leg dropped
+because the transport closed. Only `distribution` is honored
+from the return value (mux/min_hops/chosen are dial-time
+decisions).
+
+```python
+def on_leg_change(ctx, legs, change):
+    # legs: [{index, kind, latency_ms, alive}, ...]
+    # change: {event: "added"|"dropped", leg_index: N}
+    n = sum([1 for l in legs if l.alive])
+    return RouteSpec(distribution = "weighted: " + ", ".join(["1"] * n))
+```
+
+See `rebalance-on-leg-change.star` for a worked example.
+Scripts that don't define `on_leg_change` get the static
+phase-5 behavior — the function is optional.
+
 ### Knowing the leg count
 
 In SelectRoute, the script sees the route-finder's disjoint
@@ -182,6 +203,7 @@ properties (`weighted-by-kind.star` demonstrates the pattern).
 | `vpn-bulk-split.star` | VPN packets > 1400B → wide-pipe leg; small → RR rest. |
 | `force-equal-rt.star` | Real-time apps force equal RR (lower jitter than auto). |
 | `friday-id-mux.star` | Friday-ID combined with VPN size-threshold split. |
+| `rebalance-on-leg-change.star` | Track live leg count with an even-weight schedule via `on_leg_change`. |
 
 ## Authoring notes
 

--- a/docs/examples/routing-policies/rebalance-on-leg-change.star
+++ b/docs/examples/routing-policies/rebalance-on-leg-change.star
@@ -1,0 +1,39 @@
+# rebalance-on-leg-change.star — keep an even-weighted schedule
+# in sync with the live leg count. Useful when an operator wants
+# equal split across however many mux legs end up active, as legs
+# come and go after initial setup.
+#
+# Three phases:
+#   - BeforeDial: set mux baseline.
+#   - SelectRoute: pick the first candidate; the router's mux loop
+#     adds more.
+#   - on_leg_change (RFC #2882 phase 6): the route group fires
+#     this whenever a leg is added (mux loop appended an aux
+#     route, or appendRouteToGroup ran) or dropped (transport
+#     close). Return a fresh distribution descriptor sized to the
+#     current live leg count.
+#
+# Only `distribution` is honored from the on_leg_change return —
+# mux/min_hops/chosen are dial-time decisions that can't change
+# after setup. Failure / parse-error / script panic in
+# on_leg_change is non-fatal: the previous distribution stays in
+# effect and the leg change is logged but not undone.
+
+def decide_route(ctx, candidates):
+    if not candidates:
+        return RouteSpec(mux=4, distribution="auto")
+    return RouteSpec(chosen=candidates[0])
+
+def on_leg_change(ctx, legs, change):
+    # Count live legs and emit an equal-weight schedule sized
+    # to match. Empty schedule (no live legs) → no override.
+    n = 0
+    for l in legs:
+        if l.alive:
+            n += 1
+    if n == 0:
+        return RouteSpec()
+    parts = []
+    for i in range(n):
+        parts.append("1")
+    return RouteSpec(distribution = "weighted: " + ", ".join(parts))

--- a/docs/routing_policy_rfc.md
+++ b/docs/routing_policy_rfc.md
@@ -218,6 +218,33 @@ After this phase, the Indonesia-Friday example *works*.
 
 Real per-packet scripting (CEL or compiled bytecode) is a separate RFC, opened only when an operator demonstrates a use case that can't be expressed as a static distribution descriptor. The vocabulary above leaves room for that follow-up: descriptors not on this list (`"sticky: 5tuple"`, `"latency-aware"`, etc.) return a parse error today so they can be added meaningfully later without ambiguity.
 
+### Phase 6 — Post-setup leg-change callback (LANDED)
+
+`decide_route(ctx, candidates)` is one-shot at dial-setup time. But mux route groups have dynamic legs: `appendRouteToGroup` can add legs after setup, and transport failure can drop legs mid-session. Phase 5's distribution descriptor was set once and the selector adapted internally (skipping nil / closed transports during `Rebuild`), but the script had no way to react — a `"weighted: 3, 1"` schedule against an initial 2 legs stayed at `[3, 1]` even after the route group grew to 3 legs.
+
+Phase 6 adds an optional script function:
+
+```python
+def on_leg_change(ctx, legs, change):
+    # ctx is the dial's RoutingContext (same fields as decide_route's ctx).
+    # legs is the route group's current legs: [{index, kind, latency_ms, alive}, ...].
+    # change is {"event": "added" | "dropped", "leg_index": N}.
+    #
+    # Return a RouteSpec; only the distribution field is honored
+    # — mux/min_hops/chosen are dial-time decisions that can't be
+    # changed after setup.
+    n = sum([1 for l in legs if l.alive])
+    if n == 0:
+        return RouteSpec()
+    # Re-balance weights across all live legs.
+    weights = ", ".join(["1"] * n)
+    return RouteSpec(distribution = "weighted: " + weights)
+```
+
+Scripts that don't define `on_leg_change` get phase 5's static behavior — the function is optional. The route group fires the callback synchronously from leg-mutation paths (`appendForwardLeg`, transport close detection) so the schedule rebuild stays consistent with the leg set. Failure / panic / parse-error in the callback falls through to the previous distribution; the leg change itself isn't undone.
+
+The callback runs under the same step-ceiling budget as `decide_route` (`DefaultMaxSteps` = 100k). A leg-change storm (e.g. mass transport failure on dmsg server outage) won't pin the read loop — each callback is bounded.
+
 ## Open questions
 
 1. **Trace / audit storage.** Per the operator's direction, trace is deferred. But policies will eventually need an audit trail — "why did this dial in 2026-Q3 route through Singapore?" Needs to land *before* anyone uses policies for security-sensitive routing (e.g. "never route through country X"). Suggested: trace events land in the existing visor log pipeline with a `policy=true` tag, plus a ring buffer for the last N decisions readable via RPC.

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -145,6 +145,46 @@ const (
 	DistributionSizeThreshold
 )
 
+// LegChangeHook is an optional hook fired by the route group
+// whenever its set of mux legs mutates — a new leg added via
+// the establishment loop or appendRouteToGroup, or a leg dropping
+// due to a transport close. The hook can return a new
+// DistributionConfig to re-balance the per-packet selector against
+// the updated leg count; returning the zero value
+// (Mode == DistributionUnset) leaves the existing distribution in
+// place.
+//
+// The route group calls OnLegChange synchronously from its leg-
+// mutation paths so the schedule rebuild stays consistent with
+// the leg set. Implementations must return quickly — the call
+// budget mirrors the dial-time policy timeout (step ceiling).
+type LegChangeHook interface {
+	OnLegChange(info DialInfo, legs []LegInfo, change LegChange) DistributionConfig
+}
+
+// LegInfo describes one mux leg's current state. Index is the
+// position in the route group's tps[] slice; Kind is the transport
+// type ("stcpr" / "sudph" / "stcp" / "dmsg" — though DMSG is
+// filtered out of mux groups at setup so it shouldn't appear here).
+// LatencyMs is the most recent measurement, 0 for "unknown."
+// Alive reflects whether the transport is currently serving (not
+// closed / nil).
+type LegInfo struct {
+	Index     int
+	Kind      string
+	LatencyMs int
+	Alive     bool
+}
+
+// LegChange describes the mutation that triggered the OnLegChange
+// callback. Event is "added" or "dropped"; LegIndex is the leg
+// that changed (the new leg's index for "added", the dropped
+// leg's last-known index for "dropped").
+type LegChange struct {
+	Event    string
+	LegIndex int
+}
+
 // String returns the stable label for a DistributionMode. Used
 // by router-side log fields so operator-facing log lines say
 // "round-robin" instead of "1".

--- a/pkg/router/policy/bridge.go
+++ b/pkg/router/policy/bridge.go
@@ -196,6 +196,37 @@ func buildContextValue(rctx RoutingContext) starlark.Value {
 	)
 }
 
+// buildLegsValue converts the route group's leg list into a
+// Starlark list of struct-shaped values: [{index, kind,
+// latency_ms, alive}, ...].
+func buildLegsValue(legs []LegInfo) starlark.Value {
+	out := make([]starlark.Value, 0, len(legs))
+	for _, l := range legs {
+		out = append(out, starlarkstruct.FromStringDict(
+			starlarkstruct.Default,
+			starlark.StringDict{
+				"index":      starlark.MakeInt(l.Index),
+				"kind":       starlark.String(l.Kind),
+				"latency_ms": starlark.MakeInt(l.LatencyMs),
+				"alive":      starlark.Bool(l.Alive),
+			},
+		))
+	}
+	return starlark.NewList(out)
+}
+
+// buildLegChangeValue converts LegChange to a Starlark struct:
+// {event, leg_index}.
+func buildLegChangeValue(change LegChange) starlark.Value {
+	return starlarkstruct.FromStringDict(
+		starlarkstruct.Default,
+		starlark.StringDict{
+			"event":     starlark.String(change.Event),
+			"leg_index": starlark.MakeInt(change.LegIndex),
+		},
+	)
+}
+
 // buildCandidatesValue converts the Go candidate list into a
 // Starlark list of struct-shaped values.
 func buildCandidatesValue(cs []Candidate) starlark.Value {

--- a/pkg/router/policy/evaluator.go
+++ b/pkg/router/policy/evaluator.go
@@ -242,6 +242,80 @@ func (e *Evaluator) Decide(ctx context.Context, rctx RoutingContext, candidates 
 	return spec, nil
 }
 
+// OnLegChange invokes the script's optional `on_leg_change(ctx,
+// legs, change)` function. Returns the empty RouteSpec when the
+// script doesn't define the function (the common case for scripts
+// that don't care about post-setup leg events) — the route group
+// treats that as "no distribution update."
+//
+// Same step ceiling as Decide; failures are non-fatal (logged,
+// then return empty spec).
+func (e *Evaluator) OnLegChange(ctx context.Context, rctx RoutingContext, legs []LegInfo, change LegChange) (RouteSpec, error) {
+	fn, ok := e.globals["on_leg_change"]
+	if !ok {
+		return RouteSpec{}, nil
+	}
+	if _, ok := fn.(starlark.Callable); !ok {
+		return RouteSpec{}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return RouteSpec{}, nil
+	}
+	if rctx.Now.IsZero() {
+		rctx.Now = e.clock.Now()
+	}
+	thread := &starlark.Thread{
+		Name: e.source + "/on_leg_change",
+		Print: func(_ *starlark.Thread, msg string) {
+			e.logger("policy %s: print: %s", e.source, msg)
+		},
+	}
+	thread.SetMaxExecutionSteps(uint64(e.maxSteps)) //nolint:gosec
+	starCtx := buildContextValue(rctx)
+	starLegs := buildLegsValue(legs)
+	starChange := buildLegChangeValue(change)
+	var result starlark.Value
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				e.logger("policy %s: panic in on_leg_change: %v", e.source, r)
+				result = nil
+			}
+		}()
+		v, callErr := starlark.Call(thread, fn, starlark.Tuple{starCtx, starLegs, starChange}, nil)
+		if callErr != nil {
+			e.logger("policy %s: on_leg_change returned error: %v", e.source, callErr)
+			result = nil
+			return
+		}
+		result = v
+	}()
+	if result == nil {
+		return RouteSpec{}, errors.New("on_leg_change call failed")
+	}
+	spec, err := parseRouteSpec(result)
+	if err != nil {
+		return RouteSpec{}, fmt.Errorf("on_leg_change returned malformed value: %w", err)
+	}
+	return spec, nil
+}
+
+// LegInfo and LegChange mirror the router package's types so
+// scripts can reason about them without the policy package
+// pulling in the router. The bridge layer converts between the
+// two when the hook fires.
+type LegInfo struct {
+	Index     int
+	Kind      string
+	LatencyMs int
+	Alive     bool
+}
+
+type LegChange struct {
+	Event    string
+	LegIndex int
+}
+
 func (e *Evaluator) handleFailure(err error) (RouteSpec, error) {
 	if e.failureMode == FailureDrop {
 		return RouteSpec{Fallback: "drop"}, err

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -242,3 +242,48 @@ func hopsEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// OnLegChange implements router.LegChangeHook. Called by the
+// route group whenever its leg set mutates. Translates the
+// router-side LegInfo / LegChange to the policy-side equivalents,
+// invokes the script's optional on_leg_change function, and
+// projects any returned distribution descriptor into a
+// DistributionConfig for the route group to apply.
+//
+// Returns the zero DistributionConfig (Mode == DistributionUnset)
+// when the script doesn't define on_leg_change, when the loader
+// is inactive, or when the parse fails — the route group treats
+// that as "leave distribution unchanged."
+func (h *Hook) OnLegChange(info router.DialInfo, legs []router.LegInfo, change router.LegChange) router.DistributionConfig {
+	loader := h.loaderFor(info.AppName)
+	if loader == nil || !loader.IsActive() {
+		return router.DistributionConfig{}
+	}
+	policyLegs := make([]LegInfo, 0, len(legs))
+	for _, l := range legs {
+		policyLegs = append(policyLegs, LegInfo{
+			Index:     l.Index,
+			Kind:      l.Kind,
+			LatencyMs: l.LatencyMs,
+			Alive:     l.Alive,
+		})
+	}
+	policyChange := LegChange{Event: change.Event, LegIndex: change.LegIndex}
+	rctx := RoutingContext{
+		App:    info.AppName,
+		PeerPK: info.PeerPK.Hex(),
+		Port:   uint16(info.RPort),
+	}
+	spec, err := loader.OnLegChange(context.Background(), rctx, policyLegs, policyChange)
+	if err != nil {
+		h.logger("policy %s: OnLegChange error: %v", info.AppName, err)
+		return router.DistributionConfig{}
+	}
+	dist, perr := ParseDistribution(spec.Distribution)
+	if perr != nil {
+		h.logger("policy %s: OnLegChange returned invalid distribution %q: %v",
+			info.AppName, spec.Distribution, perr)
+		return router.DistributionConfig{}
+	}
+	return dist
+}

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -471,3 +471,135 @@ def decide_route(ctx, candidates):
 		t.Errorf("ReverseMinHops=%d, want 3", adj.ReverseMinHops)
 	}
 }
+
+func TestHook_OnLegChange_RebalanceOnDrop(t *testing.T) {
+	// Script re-balances weights when a leg drops: returns
+	// "weighted: 1, 1" sized to the live leg count.
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec(mux=3, distribution="weighted: 3, 2, 1")
+
+def on_leg_change(ctx, legs, change):
+    alive = [l for l in legs if l.alive]
+    n = len(alive)
+    if n == 0:
+        return RouteSpec()
+    parts = []
+    for i in range(n):
+        parts.append("1")
+    return RouteSpec(distribution = "weighted: " + ", ".join(parts))
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	info := router.DialInfo{AppName: "vpn-client", PeerPK: pk}
+
+	// Simulate a drop event: 3 legs total, leg 1 is dead.
+	legs := []router.LegInfo{
+		{Index: 0, Kind: "stcpr", LatencyMs: 30, Alive: true},
+		{Index: 1, Kind: "sudph", LatencyMs: 50, Alive: false},
+		{Index: 2, Kind: "stcpr", LatencyMs: 80, Alive: true},
+	}
+	change := router.LegChange{Event: "dropped", LegIndex: 1}
+
+	dist := h.OnLegChange(info, legs, change)
+	if dist.Mode != router.DistributionWeighted {
+		t.Errorf("Mode=%v, want DistributionWeighted", dist.Mode)
+	}
+	if len(dist.Weights) != 2 {
+		t.Errorf("Weights len=%d, want 2 (for 2 alive legs)", len(dist.Weights))
+	}
+}
+
+func TestHook_OnLegChange_ScriptWithoutFnReturnsUnset(t *testing.T) {
+	// Most scripts don't define on_leg_change — the hook should
+	// return the zero DistributionConfig so the route group
+	// leaves its distribution unchanged.
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec()
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	dist := h.OnLegChange(
+		router.DialInfo{AppName: "x", PeerPK: pk},
+		[]router.LegInfo{{Index: 0, Kind: "stcpr", Alive: true}},
+		router.LegChange{Event: "added", LegIndex: 0},
+	)
+	if dist.Mode != router.DistributionUnset {
+		t.Errorf("Mode=%v, want DistributionUnset (script didn't define on_leg_change)", dist.Mode)
+	}
+}
+
+func TestHook_OnLegChange_InactiveLoaderReturnsUnset(t *testing.T) {
+	loader, err := NewLoader("") // noop mode
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	dist := h.OnLegChange(
+		router.DialInfo{AppName: "x", PeerPK: pk},
+		nil,
+		router.LegChange{Event: "added", LegIndex: 0},
+	)
+	if dist.Mode != router.DistributionUnset {
+		t.Errorf("Mode=%v, want DistributionUnset", dist.Mode)
+	}
+}
+
+func TestHook_OnLegChange_AddedEvent(t *testing.T) {
+	// Script handles "added" event: when a leg is added, switch
+	// to round-robin from auto.
+	src := `
+def decide_route(ctx, candidates):
+    return RouteSpec()
+
+def on_leg_change(ctx, legs, change):
+    if change.event == "added":
+        return RouteSpec(distribution = "round-robin")
+    return RouteSpec()
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+	dist := h.OnLegChange(
+		router.DialInfo{AppName: "x", PeerPK: pk},
+		[]router.LegInfo{{Index: 0, Alive: true}, {Index: 1, Alive: true}},
+		router.LegChange{Event: "added", LegIndex: 1},
+	)
+	if dist.Mode != router.DistributionRoundRobin {
+		t.Errorf("added → Mode=%v, want DistributionRoundRobin", dist.Mode)
+	}
+	// Dropped event leaves it unset
+	dist = h.OnLegChange(
+		router.DialInfo{AppName: "x", PeerPK: pk},
+		[]router.LegInfo{{Index: 0, Alive: true}},
+		router.LegChange{Event: "dropped", LegIndex: 1},
+	)
+	if dist.Mode != router.DistributionUnset {
+		t.Errorf("dropped → Mode=%v, want DistributionUnset", dist.Mode)
+	}
+}

--- a/pkg/router/policy/loader.go
+++ b/pkg/router/policy/loader.go
@@ -222,6 +222,16 @@ func (l *Loader) Decide(ctx context.Context, rctx RoutingContext, candidates []C
 	return eval.Decide(ctx, rctx, candidates)
 }
 
+// OnLegChange forwards to the currently-loaded Evaluator's
+// OnLegChange. Returns empty spec when no evaluator is loaded.
+func (l *Loader) OnLegChange(ctx context.Context, rctx RoutingContext, legs []LegInfo, change LegChange) (RouteSpec, error) {
+	eval := l.current.Load()
+	if eval == nil {
+		return RouteSpec{}, nil
+	}
+	return eval.OnLegChange(ctx, rctx, legs, change)
+}
+
 // Source returns the human-readable source identifier (file path
 // or "<inline>" or "<noop>"). Used by callers for logging.
 func (l *Loader) Source() string { return l.source }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -152,6 +152,19 @@ type RouteGroup struct {
 	// Route multiplexing layer (nil when mux not negotiated).
 	// Encapsulates sequencing, reordering, SACK, and transport selection.
 	mux *routeMux
+
+	// legChangeHook, when non-nil, fires from the leg-mutation
+	// paths (appendForwardLeg / appendRules / leg-prune on
+	// transport close). Returning a non-Unset DistributionConfig
+	// causes the route group to re-apply distribution against the
+	// new leg set. See pkg/router/dial_hook.go LegChangeHook for
+	// the contract.
+	legChangeHook LegChangeHook
+	// legChangeInfo is the DialInfo the hook receives. Set once
+	// at route group construction time when the dialing visor
+	// configures the hook; unset on accept-side rg's (the
+	// hook is only meaningful on the dialing side).
+	legChangeInfo DialInfo
 }
 
 // NewRouteGroup creates a new RouteGroup.
@@ -527,6 +540,67 @@ func (rg *RouteGroup) writePacket(ctx context.Context, tp *transport.ManagedTran
 	return err
 }
 
+// SetLegChangeHook attaches a leg-change callback to the route
+// group. Called once at construction time (from saveRouteGroupRules)
+// by the dialing side; accept-side route groups are unaffected
+// because they don't run policies.
+func (rg *RouteGroup) SetLegChangeHook(hook LegChangeHook, info DialInfo) {
+	rg.mu.Lock()
+	rg.legChangeHook = hook
+	rg.legChangeInfo = info
+	rg.mu.Unlock()
+}
+
+// snapshotLegs builds a []LegInfo from the current rg.tps. Caller
+// must hold rg.mu. Used by the leg-change fire path to give the
+// policy script a snapshot it can iterate.
+func (rg *RouteGroup) snapshotLegs() []LegInfo {
+	legs := make([]LegInfo, 0, len(rg.tps))
+	for i, tp := range rg.tps {
+		l := LegInfo{Index: i, Alive: false}
+		if tp != nil {
+			l.Kind = string(tp.Entry.Type)
+			l.Alive = !tp.IsClosed()
+			if stats := tp.GetLatencyStats(); stats.Avg > 0 {
+				l.LatencyMs = int(stats.Avg)
+			}
+		}
+		legs = append(legs, l)
+	}
+	return legs
+}
+
+// fireLegChange calls the policy's OnLegChange hook (if any) and
+// applies the returned DistributionConfig. Must NOT be called
+// while holding rg.mu — applyDistribution acquires it.
+//
+// Called from leg-mutation paths: appendForwardLeg, appendRules
+// (added events), and the leg-prune path inside the read loop
+// (dropped events).
+func (rg *RouteGroup) fireLegChange(event string, legIdx int) {
+	hook := rg.legChangeHook
+	info := rg.legChangeInfo
+	if hook == nil {
+		return
+	}
+	rg.mu.Lock()
+	legs := rg.snapshotLegs()
+	rg.mu.Unlock()
+	change := LegChange{Event: event, LegIndex: legIdx}
+	cfg := hook.OnLegChange(info, legs, change)
+	if cfg.Mode == DistributionUnset {
+		return
+	}
+	if rg.logger != nil {
+		rg.logger.
+			WithField("event", event).
+			WithField("leg_index", legIdx).
+			WithField("new_distribution", cfg.Mode.String()).
+			Debug("Routing policy on_leg_change reconfigured distribution.")
+	}
+	rg.applyDistribution(cfg)
+}
+
 // applyDistribution configures the route group's transport
 // selector from a DistributionConfig (typically supplied by a
 // routing-policy script via DialAdjustment.Distribution). No-op
@@ -819,28 +893,39 @@ func (rg *RouteGroup) keepAliveServiceFn(interval time.Duration) {
 	}
 
 	// Prune dead transports and rebuild weights
+	var droppedLegs []int
 	if rg.mux != nil {
 		rg.mu.Lock()
-		rg.pruneDeadTransports()
+		droppedLegs = rg.pruneDeadTransports()
 		if len(rg.tps) > 1 {
 			rg.mux.rebuildWeights(rg.tps)
 		}
 		rg.mu.Unlock()
 	}
+	// Fire the policy hook outside the lock so the script can
+	// safely call back into rg methods (the on_leg_change script
+	// returning a new distribution causes applyDistribution which
+	// re-takes rg.mu).
+	for _, idx := range droppedLegs {
+		rg.fireLegChange("dropped", idx)
+	}
 }
 
 // pruneDeadTransports removes closed transports from the mux.
 // Cleans up the corresponding forward/reverse rules from the routing table.
-// Must be called with rg.mu held.
-func (rg *RouteGroup) pruneDeadTransports() {
+// Must be called with rg.mu held. Returns the original indexes
+// of legs that were pruned, so the caller can fire OnLegChange
+// events for them after releasing the lock.
+func (rg *RouteGroup) pruneDeadTransports() []int {
 	if len(rg.tps) <= 1 {
-		return // Don't prune the last transport
+		return nil // Don't prune the last transport
 	}
 
 	aliveTps := make([]*transport.ManagedTransport, 0, len(rg.tps))
 	aliveFwd := make([]routing.Rule, 0, len(rg.fwd))
 	aliveRvs := make([]routing.Rule, 0, len(rg.rvs))
 	var deadRuleIDs []routing.RouteID
+	var droppedIdx []int
 
 	for i, tp := range rg.tps {
 		if tp != nil && !tp.IsClosed() {
@@ -861,11 +946,12 @@ func (rg *RouteGroup) pruneDeadTransports() {
 			if tp != nil {
 				rg.logger.Infof("Pruning dead mux transport %v", tp.Entry.ID)
 			}
+			droppedIdx = append(droppedIdx, i)
 		}
 	}
 
 	if len(aliveTps) == len(rg.tps) {
-		return // Nothing was pruned
+		return nil // Nothing was pruned
 	}
 
 	// Clean up dead rules from routing table
@@ -878,6 +964,7 @@ func (rg *RouteGroup) pruneDeadTransports() {
 	rg.rvs = aliveRvs
 
 	rg.logger.Infof("Pruned dead transports: %d alive, %d removed", len(aliveTps), len(deadRuleIDs)/2)
+	return droppedIdx
 }
 
 func (rg *RouteGroup) sendKeepAlive() error {
@@ -1488,11 +1575,11 @@ func (rg *RouteGroup) isClosed() bool {
 
 func (rg *RouteGroup) appendRules(forward, reverse routing.Rule, tp *transport.ManagedTransport) {
 	rg.mu.Lock()
-	defer rg.mu.Unlock()
 
 	rg.fwd = append(rg.fwd, forward)
 	rg.rvs = append(rg.rvs, reverse)
 	rg.tps = append(rg.tps, tp)
+	newIdx := len(rg.tps) - 1
 
 	// Rebuild transport weights when transports change
 	if rg.mux != nil && len(rg.tps) > 1 {
@@ -1501,6 +1588,16 @@ func (rg *RouteGroup) appendRules(forward, reverse routing.Rule, tp *transport.M
 	// Keep per-leg counters parallel to tps[].
 	if rg.mux != nil {
 		rg.mux.growLegs(len(rg.tps))
+	}
+	// Initial single-leg rg's get their first leg via appendRules
+	// too, but the policy doesn't need on_leg_change to fire for
+	// that — the BeforeDial/SelectRoute knobs already handled it.
+	// Only fire on subsequent appends (mux growth).
+	hookSet := rg.legChangeHook != nil && newIdx > 0
+	rg.mu.Unlock()
+
+	if hookSet {
+		rg.fireLegChange("added", newIdx)
 	}
 }
 
@@ -1517,16 +1614,22 @@ func (rg *RouteGroup) appendRules(forward, reverse routing.Rule, tp *transport.M
 // this as a new forward leg.
 func (rg *RouteGroup) appendForwardLeg(forward routing.Rule, tp *transport.ManagedTransport) {
 	rg.mu.Lock()
-	defer rg.mu.Unlock()
 
 	rg.fwd = append(rg.fwd, forward)
 	rg.tps = append(rg.tps, tp)
+	newIdx := len(rg.tps) - 1
 
 	if rg.mux != nil && len(rg.tps) > 1 {
 		rg.mux.rebuildWeights(rg.tps)
 	}
 	if rg.mux != nil {
 		rg.mux.growLegs(len(rg.tps))
+	}
+	hookSet := rg.legChangeHook != nil
+	rg.mu.Unlock()
+
+	if hookSet {
+		rg.fireLegChange("added", newIdx)
 	}
 }
 

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -266,6 +266,21 @@ func (r *router) DialRoutes(
 		// rebuild sees every leg, not just the primary.
 		nrg.rg.applyDistribution(opts.Distribution)
 
+		// Wire the post-setup leg-change hook (RFC #2882 phase 6).
+		// The dial-side DialHook may also implement LegChangeHook;
+		// when it does, the route group fires on_leg_change
+		// callbacks whenever its leg set mutates after this point
+		// (additional aux legs from appendRouteToGroup, or
+		// transport-close pruning).
+		if lch, ok := r.conf.DialHook.(LegChangeHook); ok && lch != nil {
+			nrg.rg.SetLegChangeHook(lch, DialInfo{
+				AppName: opts.AppName,
+				PeerPK:  rPK,
+				LPort:   lPort,
+				RPort:   rPort,
+			})
+		}
+
 		// reset MinHops default value if changed before
 		if defaultMinHops != 1 {
 			r.conf.MinHops = defaultMinHops


### PR DESCRIPTION
## Summary
Closes the round-3 gap: scripts can now react to post-setup leg changes. Optional \`on_leg_change(ctx, legs, change)\` function fires whenever the route group's mux legs mutate (added via mux loop / \`appendRouteToGroup\`, dropped via transport-close prune). Lets a policy re-balance distribution against the live leg count instead of being stuck with the dial-time schedule.

### Script contract
\`\`\`python
def on_leg_change(ctx, legs, change):
    # ctx:    same RoutingContext shape as decide_route's ctx
    # legs:   [{index, kind, latency_ms, alive}, ...]
    # change: {event: "added"|"dropped", leg_index: N}
    n = sum([1 for l in legs if l.alive])
    return RouteSpec(distribution = "weighted: " + ", ".join(["1"] * n))
\`\`\`

Only \`distribution\` is honored — mux/min_hops/chosen are dial-time decisions. The function is **optional**; scripts that don't define it get the static phase-5 behavior. Failure / panic / parse-error is non-fatal (logged, then no-op).

### Implementation
- \`pkg/router/dial_hook.go\` — \`LegChangeHook\` interface, \`LegInfo\` + \`LegChange\` structs.
- \`pkg/router/policy/{evaluator,loader,bridge,hook}.go\` — \`OnLegChange\` plumbing through the policy stack.
- \`pkg/router/route_group.go\` — \`legChangeHook\` field; fires from \`appendForwardLeg\` / \`appendRules\` (mux growth, not initial leg) / \`pruneDeadTransports\` (which now returns dropped-leg indexes so the caller can fire outside \`rg.mu\` — avoids deadlock from the script's \`applyDistribution\` retaking the lock).
- \`pkg/router/router_dial.go\` — wires \`SetLegChangeHook\` right after \`applyDistribution\`; type-asserts \`DialHook\` to \`LegChangeHook\`.

### Tests
4 new TestHook_OnLegChange_* tests covering: rebalance on drop, missing-function back-compat, noop loader, added-vs-dropped event branching.

### Example
\`docs/examples/routing-policies/rebalance-on-leg-change.star\` — canonical "track live leg count with even weights" pattern.

### RFC
Phase 6 (LANDED) added to \`docs/routing_policy_rfc.md\` with the callback contract.