### PR TITLE
feat(router/policy): sticky:5tuple + latency-adaptive + dscp-priority

### DIFF
--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -179,6 +179,9 @@ consumes it. Vocabulary:
 - `"round-robin"` / `"equal"` — even round-robin across legs
 - `"weighted: f1, f2, ..."` — operator fractional weights
 - `"size-threshold: N"` — payload `> N` → leg 0; `≤ N` → RR across the rest
+- `"sticky:5tuple"` — same IPv4 flow → same leg (avoids TCP-over-overlay reordering)
+- `"latency-adaptive"` / `"latency-aware"` — per-packet lowest-RTT pick
+- `"dscp-priority: N"` — IPv4 DSCP `≥ N` → leg 0; rest → RR. Threshold `[1, 63]`; e.g. `46` for EF/VoIP, `18` for AF21
 
 Distribution only takes effect on **multi-leg** route groups (the
 peer must negotiate `CapMux` and the route-finder must surface
@@ -205,6 +208,9 @@ properties (`weighted-by-kind.star` demonstrates the pattern).
 | `force-equal-rt.star` | Real-time apps force equal RR (lower jitter than auto). |
 | `friday-id-mux.star` | Friday-ID combined with VPN size-threshold split. |
 | `rebalance-on-leg-change.star` | Track live leg count with an even-weight schedule via `on_leg_change`. |
+| `sticky-tcp-flows.star` | Pin each IPv4 5-tuple flow to one leg for VPN apps (avoids reordering). |
+| `latency-adaptive-rt.star` | Real-time apps: per-packet lowest-RTT leg pick. |
+| `vpn-dscp-priority.star` | VPN: DSCP-marked traffic (EF/AF) on leg 0, rest RR. |
 
 ## Authoring notes
 

--- a/docs/examples/routing-policies/latency-adaptive-rt.star
+++ b/docs/examples/routing-policies/latency-adaptive-rt.star
@@ -1,0 +1,16 @@
+# latency-adaptive-rt.star — for real-time apps, pick the lowest-
+# latency leg *per packet* (re-evaluates every packet, so a leg
+# whose RTT spikes mid-session loses traffic immediately).
+#
+# Differs from "auto" — auto builds a latency-weighted schedule
+# and rebuilds it periodically. Adaptive scans the live legs on
+# every packet, so the operator's choice tracks the live state
+# instantly at the cost of a small per-packet scan (linear in
+# mux count, typically <=4 legs).
+
+def decide_route(ctx, candidates):
+    if ctx.app not in ("rt-voice", "rt-video"):
+        return RouteSpec()
+    if not candidates:
+        return RouteSpec(mux=3, distribution="latency-adaptive")
+    return RouteSpec(chosen=candidates[0])

--- a/docs/examples/routing-policies/sticky-tcp-flows.star
+++ b/docs/examples/routing-policies/sticky-tcp-flows.star
@@ -1,0 +1,24 @@
+# sticky-tcp-flows.star — pin each TCP flow (5-tuple) to a single
+# mux leg for its lifetime. Useful for vpn-client / vpn-server
+# where packet reordering across legs hurts TCP congestion
+# control (out-of-order ACKs trigger spurious retransmits).
+#
+# Layer-2 descriptor: "sticky:5tuple" — selector hashes the IPv4
+# 5-tuple (src/dst IP + src/dst port + protocol) and picks
+# hash %% live-leg-count. Same flow always lands on the same leg.
+# Non-IPv4 payloads fall back to a payload-prefix hash (still
+# deterministic, just without flow semantics).
+#
+# Two-phase invocation:
+#   - BeforeDial (candidates empty): set mux + the sticky
+#     descriptor. SelectRoute doesn't propagate distribution,
+#     so this must be BeforeDial.
+#   - SelectRoute (candidates populated): pick the first
+#     candidate; the disjoint-mux loop adds the rest.
+
+def decide_route(ctx, candidates):
+    if ctx.app not in ("vpn-client", "vpn-server"):
+        return RouteSpec()
+    if not candidates:
+        return RouteSpec(mux=3, distribution="sticky:5tuple")
+    return RouteSpec(chosen=candidates[0])

--- a/docs/examples/routing-policies/vpn-dscp-priority.star
+++ b/docs/examples/routing-policies/vpn-dscp-priority.star
@@ -1,0 +1,25 @@
+# vpn-dscp-priority.star — for VPN traffic, route by IPv4 DSCP:
+# packets marked Expedited Forwarding (DSCP=46 / EF — typical
+# VoIP) take leg 0 (the low-latency leg); everything else
+# round-robins across the other legs.
+#
+# Layer-2 descriptor: "dscp-priority: N" — reads the upper 6
+# bits of the ToS byte (offset 1) in the IPv4 header. Threshold
+# in [1, 63]; common values:
+#   46 — EF, Expedited Forwarding (VoIP, real-time)
+#   18 — AF21, Assured Forwarding (interactive)
+#   10 — AF11, lower-priority assured
+#
+# Non-IPv4 payloads (rare in VPN traffic but possible for
+# control packets) fall back to round-robin without taking leg 0.
+#
+# Pair with sticky:5tuple in a separate route group for the
+# bulk traffic if the operator wants flow affinity on the
+# non-prio side; today distribution is one-per-route-group.
+
+def decide_route(ctx, candidates):
+    if ctx.app not in ("vpn-client", "vpn-server"):
+        return RouteSpec()
+    if not candidates:
+        return RouteSpec(mux=3, distribution="dscp-priority: 46")
+    return RouteSpec(chosen=candidates[0])

--- a/docs/routing_policy_rfc.md
+++ b/docs/routing_policy_rfc.md
@@ -215,8 +215,11 @@ After this phase, the Indonesia-Friday example *works*.
 | `"round-robin"` / `"equal"` | `DistributionRoundRobin` | Force `WeightModeEqual` — packets alternate across legs ignoring latency. |
 | `"weighted: f1, f2, ..."` | `DistributionWeighted` | Operator-supplied fractional weights normalized into the selector's integer schedule. Length must match leg count; mismatches fall through with a log line. |
 | `"size-threshold: N"` | `DistributionSizeThreshold` | Payloads `> N` bytes go to leg 0 (wide pipe); payloads `≤ N` round-robin across the remaining legs. Single-leg routes ignore the descriptor. Control/handshake packets (size unknown) take leg 0. |
+| `"sticky:5tuple"` | `DistributionSticky5Tuple` | Hashes the IPv4 5-tuple (src/dst IP + src/dst port + protocol) and picks `hash % live-leg-count`. Same flow → same leg deterministically. Non-IPv4 payloads fall back to a payload-prefix FNV hash. Avoids TCP-over-overlay reordering. |
+| `"latency-adaptive"` / `"latency-aware"` | `DistributionLatencyAdaptive` | Per-packet linear scan over live legs for lowest `GetLatency()`. Differs from `"auto"`: adaptive evaluates every packet, so a leg whose RTT spikes mid-session loses traffic immediately. |
+| `"dscp-priority: N"` | `DistributionDSCPPriority` | Reads IPv4 DSCP (upper 6 bits of ToS byte). DSCP ≥ N → leg 0; rest → RR. Threshold in `[1, 63]`; common values: 46 (EF/VoIP), 18 (AF21), 10 (AF11). Non-IPv4 payloads default to RR. |
 
-Real per-packet scripting (CEL or compiled bytecode) is a separate RFC, opened only when an operator demonstrates a use case that can't be expressed as a static distribution descriptor. The vocabulary above leaves room for that follow-up: descriptors not on this list (`"sticky: 5tuple"`, `"latency-aware"`, etc.) return a parse error today so they can be added meaningfully later without ambiguity.
+Real per-packet scripting (CEL or compiled bytecode) remains a separate RFC, opened only when an operator demonstrates a use case that no descriptor can express. As of this update, the vocabulary covers the realistic per-packet decision space — future additions (e.g. `"chaff: rate"` for anti-traffic-analysis chaff insertion) would land as new verbs rather than scripting.
 
 ### Phase 6 — Post-setup leg-change callback (LANDED)
 

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -128,6 +128,12 @@ type DistributionConfig struct {
 	// route-finder returned, ranked by latency); smaller packets
 	// round-robin across the remaining legs.
 	SizeThreshold int
+
+	// DSCPThreshold is the IPv4 DSCP boundary for
+	// DistributionDSCPPriority. Packets with DSCP >= this value
+	// take leg 0; others round-robin across the rest. Common
+	// values: 0x2E (EF — VoIP), 0x10 (AF — interactive).
+	DSCPThreshold int
 }
 
 // DistributionMode enumerates the per-packet distribution
@@ -158,6 +164,32 @@ const (
 	// the wider pipe and small packets stay on the low-latency
 	// leg.
 	DistributionSizeThreshold
+	// DistributionSticky5Tuple pins each flow (identified by the
+	// IPv4 5-tuple — src/dst IP + src/dst port + protocol) to a
+	// single leg for the flow's lifetime. Same flow → same leg
+	// every packet, deterministic. Meaningful for VPN traffic
+	// (vpn-client, vpn-server) where the payload is an IPv4
+	// packet; for other apps the selector falls back to hashing
+	// the payload prefix (still deterministic by content but no
+	// flow semantics). Useful for TCP-over-overlay where leg
+	// reordering hurts congestion control.
+	DistributionSticky5Tuple
+	// DistributionLatencyAdaptive picks the leg with the lowest
+	// current transport-layer latency for every packet. Differs
+	// from DistributionAuto (latency-weighted schedule, built
+	// every Rebuild cycle): adaptive evaluates per-packet, so a
+	// leg whose RTT spikes mid-session loses traffic
+	// immediately. Cost: one linear scan over the leg array per
+	// packet (typically <=4 legs, sub-µs).
+	DistributionLatencyAdaptive
+	// DistributionDSCPPriority routes packets by the IPv4 DSCP
+	// field (upper 6 bits of the ToS byte at IP-header offset 1).
+	// Packets with DSCP >= the configured threshold (commonly
+	// 0x2E for EF / VoIP, or 0x10+ for AF / interactive) take
+	// leg 0 — the low-latency leg. Lower-priority packets
+	// round-robin across the rest. Like sticky:5tuple, meaningful
+	// for VPN apps; non-IPv4 payloads default to round-robin.
+	DistributionDSCPPriority
 )
 
 // LegChangeHook is an optional hook fired by the route group
@@ -215,6 +247,12 @@ func (m DistributionMode) String() string {
 		return "weighted"
 	case DistributionSizeThreshold:
 		return "size-threshold"
+	case DistributionSticky5Tuple:
+		return "sticky:5tuple"
+	case DistributionLatencyAdaptive:
+		return "latency-adaptive"
+	case DistributionDSCPPriority:
+		return "dscp-priority"
 	}
 	return "unknown"
 }

--- a/pkg/router/policy/distribution.go
+++ b/pkg/router/policy/distribution.go
@@ -44,15 +44,21 @@ func ParseDistribution(s string) (router.DistributionConfig, error) {
 		return router.DistributionConfig{Mode: router.DistributionAuto}, nil
 	case "round-robin", "equal":
 		return router.DistributionConfig{Mode: router.DistributionRoundRobin}, nil
+	case "latency-adaptive", "latency-aware":
+		return router.DistributionConfig{Mode: router.DistributionLatencyAdaptive}, nil
 	}
 
-	// Prefix-based: "weighted: ..." and "size-threshold: ..."
+	// Prefix-based.
 	if name, body, ok := splitDescriptor(s); ok {
 		switch name {
 		case "weighted":
 			return parseWeighted(body)
 		case "size-threshold":
 			return parseSizeThreshold(body)
+		case "sticky":
+			return parseSticky(body)
+		case "dscp-priority":
+			return parseDSCPPriority(body)
 		default:
 			return router.DistributionConfig{}, fmt.Errorf("unknown distribution descriptor %q", name)
 		}
@@ -128,5 +134,49 @@ func parseSizeThreshold(body string) (router.DistributionConfig, error) {
 	return router.DistributionConfig{
 		Mode:          router.DistributionSizeThreshold,
 		SizeThreshold: n,
+	}, nil
+}
+
+// parseSticky handles the sticky family. Today only "5tuple" is
+// supported (IPv4 src/dst IP + src/dst port + protocol). Other
+// qualifiers reserved for future verbs (e.g. "sticky:flow" for
+// app-level flow ID, "sticky:hash" for raw payload-prefix hash).
+func parseSticky(body string) (router.DistributionConfig, error) {
+	t := strings.TrimSpace(body)
+	switch t {
+	case "5tuple":
+		return router.DistributionConfig{Mode: router.DistributionSticky5Tuple}, nil
+	case "":
+		return router.DistributionConfig{}, fmt.Errorf("sticky: qualifier required (e.g. sticky:5tuple)")
+	default:
+		return router.DistributionConfig{}, fmt.Errorf("sticky: unknown qualifier %q (only \"5tuple\" supported today)", t)
+	}
+}
+
+// parseDSCPPriority parses the IPv4 DSCP threshold. Accepts
+// decimal ("46") or hex ("0x2e") values; must be in [1, 63].
+// Common values: 46 (EF — VoIP), 18 (AF21 — interactive),
+// 10 (AF11 — bulk-prio).
+func parseDSCPPriority(body string) (router.DistributionConfig, error) {
+	t := strings.TrimSpace(body)
+	if t == "" {
+		return router.DistributionConfig{}, fmt.Errorf("dscp-priority: threshold required")
+	}
+	var n int64
+	var err error
+	if strings.HasPrefix(t, "0x") || strings.HasPrefix(t, "0X") {
+		n, err = strconv.ParseInt(t[2:], 16, 32)
+	} else {
+		n, err = strconv.ParseInt(t, 10, 32)
+	}
+	if err != nil {
+		return router.DistributionConfig{}, fmt.Errorf("dscp-priority: parse %q: %w", t, err)
+	}
+	if n < 1 || n > 63 {
+		return router.DistributionConfig{}, fmt.Errorf("dscp-priority: threshold %d out of range [1, 63]", n)
+	}
+	return router.DistributionConfig{
+		Mode:          router.DistributionDSCPPriority,
+		DSCPThreshold: int(n),
 	}, nil
 }

--- a/pkg/router/policy/distribution_test.go
+++ b/pkg/router/policy/distribution_test.go
@@ -105,10 +105,88 @@ func TestParseDistribution_SizeThresholdErrors(t *testing.T) {
 }
 
 func TestParseDistribution_UnknownDescriptor(t *testing.T) {
-	if _, err := ParseDistribution("sticky: 5tuple"); err == nil {
-		t.Errorf("expected error for unimplemented descriptor, got nil")
-	}
 	if _, err := ParseDistribution("not-a-descriptor"); err == nil {
 		t.Errorf("expected error for malformed descriptor, got nil")
+	}
+	if _, err := ParseDistribution("nonsense:foo"); err == nil {
+		t.Errorf("expected error for unknown prefixed descriptor, got nil")
+	}
+	if _, err := ParseDistribution("sticky:not-a-qualifier"); err == nil {
+		t.Errorf("expected error for unknown sticky qualifier, got nil")
+	}
+}
+
+func TestParseDistribution_Sticky5Tuple(t *testing.T) {
+	cfg, err := ParseDistribution("sticky: 5tuple")
+	if err != nil {
+		t.Fatalf("ParseDistribution: %v", err)
+	}
+	if cfg.Mode != router.DistributionSticky5Tuple {
+		t.Errorf("Mode=%v, want DistributionSticky5Tuple", cfg.Mode)
+	}
+}
+
+func TestParseDistribution_StickyErrors(t *testing.T) {
+	cases := []string{
+		"sticky:",
+		"sticky: hash",
+		"sticky: 5",
+	}
+	for _, c := range cases {
+		if _, err := ParseDistribution(c); err == nil {
+			t.Errorf("ParseDistribution(%q): expected error, got nil", c)
+		}
+	}
+}
+
+func TestParseDistribution_LatencyAdaptive(t *testing.T) {
+	for _, s := range []string{"latency-adaptive", "latency-aware"} {
+		cfg, err := ParseDistribution(s)
+		if err != nil {
+			t.Fatalf("ParseDistribution(%q): %v", s, err)
+		}
+		if cfg.Mode != router.DistributionLatencyAdaptive {
+			t.Errorf("%q Mode=%v, want DistributionLatencyAdaptive", s, cfg.Mode)
+		}
+	}
+}
+
+func TestParseDistribution_DSCPPriority(t *testing.T) {
+	cases := []struct {
+		in        string
+		threshold int
+	}{
+		{"dscp-priority: 46", 46},   // EF
+		{"dscp-priority: 18", 18},   // AF21
+		{"dscp-priority: 0x2e", 46}, // hex EF
+		{"dscp-priority: 0x10", 16}, // hex AF11ish
+	}
+	for _, c := range cases {
+		cfg, err := ParseDistribution(c.in)
+		if err != nil {
+			t.Errorf("ParseDistribution(%q): %v", c.in, err)
+			continue
+		}
+		if cfg.Mode != router.DistributionDSCPPriority {
+			t.Errorf("%q Mode=%v, want DistributionDSCPPriority", c.in, cfg.Mode)
+		}
+		if cfg.DSCPThreshold != c.threshold {
+			t.Errorf("%q DSCPThreshold=%d, want %d", c.in, cfg.DSCPThreshold, c.threshold)
+		}
+	}
+}
+
+func TestParseDistribution_DSCPPriorityErrors(t *testing.T) {
+	cases := []string{
+		"dscp-priority:",
+		"dscp-priority: 0",
+		"dscp-priority: 64",
+		"dscp-priority: -1",
+		"dscp-priority: foo",
+	}
+	for _, c := range cases {
+		if _, err := ParseDistribution(c); err == nil {
+			t.Errorf("ParseDistribution(%q): expected error, got nil", c)
+		}
 	}
 }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -320,7 +320,7 @@ func (rg *RouteGroup) Write(p []byte) (n int, err error) {
 	}
 
 	rg.mu.Lock()
-	tp, rule, leg, err := rg.nextTransport(len(p))
+	tp, rule, leg, err := rg.nextTransport(p)
 	if err != nil {
 		rg.mu.Unlock()
 		return 0, err
@@ -639,6 +639,13 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 	case DistributionSizeThreshold:
 		wm = WeightModeSizeThreshold
 		rg.mux.tpSelector.SetSizeThreshold(cfg.SizeThreshold)
+	case DistributionSticky5Tuple:
+		wm = WeightModeSticky5Tuple
+	case DistributionLatencyAdaptive:
+		wm = WeightModeLatencyAdaptive
+	case DistributionDSCPPriority:
+		wm = WeightModeDSCPPriority
+		rg.mux.tpSelector.SetDSCPThreshold(cfg.DSCPThreshold)
 	default:
 		return
 	}
@@ -678,16 +685,16 @@ func (rg *RouteGroup) applyDistribution(cfg DistributionConfig) {
 // round-robin when latency data is unavailable, and to index 0 for single
 // transport (legacy behavior).
 //
-// payloadSize is the upcoming packet's payload byte count, used
-// only by WeightModeSizeThreshold to route large payloads to the
-// wide-pipe leg. Pass 0 from callers that don't have a meaningful
-// size (control / retx paths).
+// payload is the upcoming packet's payload bytes (or nil for
+// control / retx paths). Used by payload-inspecting modes
+// (size-threshold, sticky:5tuple, latency-adaptive,
+// dscp-priority); other modes ignore it.
 //
 // Returns the leg index (position in rg.tps) so the caller can record
 // per-leg byte counts after a successful write; -1 for the
 // single-transport / legacy path.
 // NOTE: not thread-safe, caller must hold rg.mu.
-func (rg *RouteGroup) nextTransport(payloadSize int) (*transport.ManagedTransport, routing.Rule, int, error) {
+func (rg *RouteGroup) nextTransport(payload []byte) (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(rg.tps) == 0 {
 		return nil, nil, -1, ErrNoTransports
 	}
@@ -699,7 +706,7 @@ func (rg *RouteGroup) nextTransport(payloadSize int) (*transport.ManagedTranspor
 	}
 
 	if rg.mux != nil && len(rg.tps) > 1 {
-		return rg.mux.selectTransport(rg.tps, rg.fwd, payloadSize)
+		return rg.mux.selectTransport(rg.tps, rg.fwd, payload)
 	}
 
 	if rg.tps[0] == nil {
@@ -1317,7 +1324,7 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 		}
 
 		rg.mu.Lock()
-		tp, rule, leg, err := rg.nextTransport(len(data))
+		tp, rule, leg, err := rg.nextTransport(data)
 		rg.mu.Unlock()
 		if err != nil {
 			return err

--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -188,7 +188,7 @@ func TestMuxSelectTransportSkipsDead(t *testing.T) {
 
 	// Select should return transport 2 (the only alive one)
 	rg.mu.Lock()
-	tp, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd, 0)
+	tp, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd, nil)
 	rg.mu.Unlock()
 
 	require.NoError(t, err)
@@ -205,7 +205,7 @@ func TestMuxSelectTransportFailsAllDead(t *testing.T) {
 	}
 
 	rg.mu.Lock()
-	_, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd, 0)
+	_, _, _, err := rg.mux.selectTransport(rg.tps, rg.fwd, nil)
 	rg.mu.Unlock()
 
 	require.ErrorIs(t, err, ErrNoSuitableTransport)

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -89,14 +89,15 @@ func newRouteMux(logger *logging.Logger, sackEnabled bool) *routeMux {
 // Returns the index in tps[] alongside the tp/rule so the caller can
 // record per-leg byte counts after a successful write.
 //
-// payloadSize is the upcoming packet's payload byte count, used by
-// WeightModeSizeThreshold to route large payloads to the wide-pipe
-// leg. Pass 0 for handshake / control / retx packets whose size
-// isn't a routing signal — the selector falls back to its normal
-// schedule in that case.
+// payload is the upcoming packet's payload bytes (or nil for
+// handshake / control / retx paths that don't have a meaningful
+// payload). Used by WeightModeSizeThreshold, WeightModeSticky5Tuple,
+// WeightModeLatencyAdaptive, and WeightModeDSCPPriority — they
+// inspect the payload directly. Other modes ignore it and fall
+// back to the schedule-based pick.
 //
 // NOTE: not thread-safe, caller must hold the RouteGroup mu.
-func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule, payloadSize int) (*transport.ManagedTransport, routing.Rule, int, error) {
+func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []routing.Rule, payload []byte) (*transport.ManagedTransport, routing.Rule, int, error) {
 	if len(tps) == 0 {
 		return nil, nil, -1, ErrNoTransports
 	}
@@ -104,16 +105,21 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		return nil, nil, -1, ErrNoRules
 	}
 
-	// SizeThreshold path: ask the selector for the size-aware
-	// leg. Falls back to the regular schedule when payloadSize
-	// is 0 (control packets) since the threshold can't be
-	// meaningfully applied to packets whose size we don't know.
-	if m.tpSelector != nil && m.tpSelector.Mode() == WeightModeSizeThreshold && payloadSize > 0 {
-		idx := m.tpSelector.SelectForSize(payloadSize)
-		if idx < len(tps) {
-			tp := tps[idx]
-			if tp != nil && !tp.IsClosed() {
-				return tp, fwd[idx], idx, nil
+	// Payload-inspecting modes: ask the selector for a leg
+	// derived from the bytes. Empty payload (handshake / retx)
+	// falls through to the schedule-based pick.
+	if m.tpSelector != nil && len(payload) > 0 {
+		switch m.tpSelector.Mode() {
+		case WeightModeSizeThreshold,
+			WeightModeSticky5Tuple,
+			WeightModeLatencyAdaptive,
+			WeightModeDSCPPriority:
+			idx := m.tpSelector.SelectForPayload(payload)
+			if idx < len(tps) {
+				tp := tps[idx]
+				if tp != nil && !tp.IsClosed() {
+					return tp, fwd[idx], idx, nil
+				}
 			}
 		}
 	}

--- a/pkg/router/transport_selector.go
+++ b/pkg/router/transport_selector.go
@@ -29,6 +29,26 @@ const (
 	// size (handshake / control packets); SelectForSize is the
 	// primary entry point.
 	WeightModeSizeThreshold
+	// WeightModeSticky5Tuple hashes the IPv4 5-tuple of the
+	// payload (src/dst IP + src/dst port + protocol) and picks
+	// a leg by hash % live-leg-count. Same flow → same leg
+	// always, deterministic. SelectForPayload is the entry
+	// point; non-IPv4 payloads fall back to a payload-prefix
+	// FNV hash.
+	WeightModeSticky5Tuple
+	// WeightModeLatencyAdaptive picks the live leg with the
+	// lowest current GetLatency() per packet. Differs from
+	// WeightModeAuto (latency-weighted schedule, rebuilt
+	// periodically): adaptive evaluates per-packet, so a leg
+	// whose RTT spikes mid-session loses traffic immediately.
+	// Cost is one linear scan over the leg array per packet
+	// (small constant for typical mux counts).
+	WeightModeLatencyAdaptive
+	// WeightModeDSCPPriority reads the IPv4 DSCP (upper 6 bits
+	// of payload[1]) and routes packets >= threshold to leg 0,
+	// others round-robin across the rest. Non-IPv4 payloads
+	// fall back to round-robin.
+	WeightModeDSCPPriority
 )
 
 // transportSelector implements weighted transport selection based on latency.
@@ -44,12 +64,23 @@ type transportSelector struct {
 	// SetSizeThreshold; the next Rebuild picks them up.
 	explicitWeights []float64
 	sizeThreshold   int
+	dscpThreshold   int
 	// smallLegSchedule holds the round-robin schedule across the
-	// non-leg-0 transports used by WeightModeSizeThreshold when
-	// the packet is at or under the threshold. Built at Rebuild
-	// time so per-packet selection stays lock-free.
+	// non-leg-0 transports used by WeightModeSizeThreshold,
+	// WeightModeDSCPPriority, and as the fallback for size-aware
+	// modes when the packet is at or under the threshold. Built
+	// at Rebuild time so per-packet selection stays lock-free.
 	smallLegSchedule []int
 	smallLegCounter  uint32
+	// liveLegs holds the indexes of currently-serving transports,
+	// used by WeightModeSticky5Tuple (hash %% len) and
+	// WeightModeLatencyAdaptive (linear scan). Built at Rebuild
+	// time.
+	liveLegs []int
+	// liveTps holds pointers to the same transports as liveLegs,
+	// for adaptive's GetLatency lookups — avoids reaching back
+	// through the route group's tps[] under a lock per packet.
+	liveTps []*transport.ManagedTransport
 }
 
 func newTransportSelector() *transportSelector {
@@ -73,6 +104,14 @@ func (ts *transportSelector) SetExplicitWeights(w []float64) {
 func (ts *transportSelector) SetSizeThreshold(n int) {
 	ts.mu.Lock()
 	ts.sizeThreshold = n
+	ts.mu.Unlock()
+}
+
+// SetDSCPThreshold stores the IPv4 DSCP boundary used by
+// WeightModeDSCPPriority. Caller must call Rebuild afterwards.
+func (ts *transportSelector) SetDSCPThreshold(n int) {
+	ts.mu.Lock()
+	ts.dscpThreshold = n
 	ts.mu.Unlock()
 }
 
@@ -205,6 +244,52 @@ func (ts *transportSelector) Rebuild(tps []*transport.ManagedTransport) {
 		return
 	}
 
+	// DSCPPriority: same primary/small split as SizeThreshold,
+	// but the gating predicate at write time reads the IP DSCP
+	// instead of the payload length.
+	if ts.mode == WeightModeDSCPPriority {
+		ts.schedule = []int{0}
+		smallSched := make([]int, 0, n-1)
+		for i, tp := range tps {
+			if i == 0 {
+				continue
+			}
+			if tp != nil && !tp.IsClosed() {
+				smallSched = append(smallSched, i)
+			}
+		}
+		if len(smallSched) == 0 {
+			smallSched = []int{0}
+		}
+		ts.smallLegSchedule = smallSched
+		return
+	}
+
+	// Sticky5Tuple and LatencyAdaptive: build the live-leg
+	// arrays. Sticky hashes mod len; adaptive scans for lowest
+	// GetLatency. The primary schedule is also populated so a
+	// caller using Select() (no payload) still gets a reasonable
+	// leg.
+	if ts.mode == WeightModeSticky5Tuple || ts.mode == WeightModeLatencyAdaptive {
+		live := make([]int, 0, n)
+		liveTps := make([]*transport.ManagedTransport, 0, n)
+		for i, tp := range tps {
+			if tp != nil && !tp.IsClosed() {
+				live = append(live, i)
+				liveTps = append(liveTps, tp)
+			}
+		}
+		if len(live) == 0 {
+			live = []int{0}
+			liveTps = []*transport.ManagedTransport{tps[0]}
+		}
+		ts.liveLegs = live
+		ts.liveTps = liveTps
+		// Mirror in primary schedule as the Select() fallback.
+		ts.schedule = append(ts.schedule[:0], live...)
+		return
+	}
+
 	// Auto mode: weight by inverse latency
 	weights := make([]int, n)
 	maxLatency := 0.0
@@ -329,4 +414,126 @@ func (ts *transportSelector) SelectForSize(size int) int {
 	}
 	idx := atomic.AddUint32(&ts.smallLegCounter, 1) - 1
 	return smallSched[idx%uint32(len(smallSched))] //nolint:gosec
+}
+
+// SelectForPayload returns the leg index for a packet whose
+// payload is `p`. Used by modes that inspect packet contents:
+//   - WeightModeSticky5Tuple: hash the IPv4 5-tuple, mod live
+//     leg count. Same flow always picks the same leg.
+//   - WeightModeDSCPPriority: read DSCP byte; >= threshold → leg
+//     0, else round-robin across the rest.
+//   - WeightModeLatencyAdaptive: ignore p, scan live legs for
+//     lowest GetLatency.
+//
+// Other modes ignore p and fall back to SelectForSize(len(p)) or
+// Select(). Callers that don't have payload bytes (handshake,
+// retx) should pass nil — the selector treats nil as "no
+// information" and reverts to the schedule-based pick.
+func (ts *transportSelector) SelectForPayload(p []byte) int {
+	ts.mu.RLock()
+	mode := ts.mode
+	live := ts.liveLegs
+	liveTps := ts.liveTps
+	dscpThreshold := ts.dscpThreshold
+	smallSched := ts.smallLegSchedule
+	ts.mu.RUnlock()
+
+	switch mode {
+	case WeightModeSticky5Tuple:
+		if len(live) == 0 {
+			return 0
+		}
+		h := fiveTupleHash(p)
+		return live[h%uint32(len(live))] //nolint:gosec
+	case WeightModeLatencyAdaptive:
+		return pickLowestLatency(live, liveTps)
+	case WeightModeDSCPPriority:
+		if isIPv4DSCPGE(p, dscpThreshold) {
+			return 0
+		}
+		if len(smallSched) == 0 {
+			return 0
+		}
+		idx := atomic.AddUint32(&ts.smallLegCounter, 1) - 1
+		return smallSched[idx%uint32(len(smallSched))] //nolint:gosec
+	case WeightModeSizeThreshold:
+		return ts.SelectForSize(len(p))
+	}
+	return ts.Select()
+}
+
+// fiveTupleHash returns an FNV-1a 32-bit hash over the IPv4
+// 5-tuple bytes when p is a valid IPv4 packet (version nibble
+// == 4, length >= 24). Falls back to hashing the first 24 bytes
+// of the payload when it isn't IPv4 — still deterministic, just
+// without flow semantics. Empty payloads hash to 0.
+func fiveTupleHash(p []byte) uint32 {
+	const fnvOffset = 2166136261
+	const fnvPrime = 16777619
+	h := uint32(fnvOffset)
+	if len(p) >= 24 && p[0]>>4 == 4 {
+		// IPv4: src IP (12-15), dst IP (16-19), src port (20-21),
+		// dst port (22-23), protocol (9). Hash that exact slice.
+		// Order is fixed so packets in either direction of the
+		// same flow hash equally (we hash src-then-dst; same
+		// flow's reverse direction has src/dst swapped and hashes
+		// differently — operator should accept that as "leg per
+		// half-flow," matching the typical TCP behavior).
+		for _, b := range p[12:24] {
+			h ^= uint32(b)
+			h *= fnvPrime
+		}
+		h ^= uint32(p[9])
+		h *= fnvPrime
+		return h
+	}
+	// Fallback: hash the first 24 bytes (or fewer).
+	n := len(p)
+	if n > 24 {
+		n = 24
+	}
+	for i := 0; i < n; i++ {
+		h ^= uint32(p[i])
+		h *= fnvPrime
+	}
+	return h
+}
+
+// isIPv4DSCPGE reports whether p is an IPv4 packet whose DSCP
+// (upper 6 bits of the ToS byte at offset 1) is >= threshold.
+// Non-IPv4 or short payloads return false (caller treats as
+// "below threshold").
+func isIPv4DSCPGE(p []byte, threshold int) bool {
+	if len(p) < 2 || p[0]>>4 != 4 {
+		return false
+	}
+	dscp := int(p[1] >> 2)
+	return dscp >= threshold
+}
+
+// pickLowestLatency returns the live-leg index with the smallest
+// GetLatency() value. Legs reporting 0 (unknown) are deprioritized
+// — they only win when no leg has a measurement. Linear scan;
+// fine for the small mux counts skywire actually uses (typically
+// 2-4).
+func pickLowestLatency(live []int, liveTps []*transport.ManagedTransport) int {
+	if len(live) == 0 {
+		return 0
+	}
+	bestIdx := live[0]
+	bestLat := -1.0
+	for i, tp := range liveTps {
+		if tp == nil {
+			continue
+		}
+		lat := tp.GetLatency()
+		if lat <= 0 {
+			continue
+		}
+		if bestLat < 0 || lat < bestLat {
+			bestLat = lat
+			bestIdx = live[i]
+		}
+	}
+	return bestIdx
 }

--- a/pkg/router/transport_selector_test.go
+++ b/pkg/router/transport_selector_test.go
@@ -207,3 +207,138 @@ func TestTransportSelector_SizeThreshold_SelectWithoutSizeReturns0(t *testing.T)
 		assert.Equal(t, 0, ts.Select())
 	}
 }
+
+func TestTransportSelector_Sticky5Tuple_DeterministicByFlow(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeSticky5Tuple)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// Construct a minimal IPv4 packet: 20-byte header + 4 bytes
+	// TCP/UDP header (src + dst port). Same 5-tuple → same leg
+	// every call.
+	pkt := make([]byte, 24)
+	pkt[0] = 0x45 // version=4, IHL=5
+	pkt[9] = 0x06 // protocol=TCP
+	// src IP 10.0.0.1
+	pkt[12], pkt[13], pkt[14], pkt[15] = 10, 0, 0, 1
+	// dst IP 10.0.0.2
+	pkt[16], pkt[17], pkt[18], pkt[19] = 10, 0, 0, 2
+	// src port 12345, dst port 80
+	pkt[20], pkt[21] = 0x30, 0x39
+	pkt[22], pkt[23] = 0x00, 0x50
+
+	firstLeg := ts.SelectForPayload(pkt)
+	for i := 0; i < 100; i++ {
+		if got := ts.SelectForPayload(pkt); got != firstLeg {
+			t.Fatalf("call %d: leg=%d, want %d (deterministic by flow)", i, got, firstLeg)
+		}
+	}
+}
+
+func TestTransportSelector_Sticky5Tuple_DifferentFlows(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeSticky5Tuple)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// Build two flows differing only in src port.
+	mk := func(srcPort uint16) []byte {
+		p := make([]byte, 24)
+		p[0] = 0x45
+		p[9] = 0x06
+		p[12], p[13], p[14], p[15] = 10, 0, 0, 1
+		p[16], p[17], p[18], p[19] = 10, 0, 0, 2
+		p[20] = byte(srcPort >> 8)
+		p[21] = byte(srcPort & 0xff)
+		p[22], p[23] = 0x00, 0x50
+		return p
+	}
+
+	// 1000 different flows should not all land on the same leg.
+	counts := make(map[int]int)
+	for port := uint16(1024); port < 1024+1000; port++ {
+		counts[ts.SelectForPayload(mk(port))]++
+	}
+	if len(counts) < 2 {
+		t.Errorf("1000 different flows mapped to only %d legs: %v", len(counts), counts)
+	}
+}
+
+func TestTransportSelector_LatencyAdaptive_PicksLowestLatency(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeLatencyAdaptive)
+	tps := []*transport.ManagedTransport{
+		mockTP(200), // leg 0
+		mockTP(50),  // leg 1 — lowest
+		mockTP(150), // leg 2
+	}
+	ts.Rebuild(tps)
+
+	for i := 0; i < 100; i++ {
+		if got := ts.SelectForPayload([]byte("anything")); got != 1 {
+			t.Fatalf("call %d: leg=%d, want 1 (lowest latency)", i, got)
+		}
+	}
+}
+
+func TestTransportSelector_DSCPPriority_HighGoesToLeg0(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeDSCPPriority)
+	ts.SetDSCPThreshold(46) // EF
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// IPv4 packet with DSCP = 46 (ToS byte = 0xB8 — 46 << 2)
+	high := make([]byte, 24)
+	high[0] = 0x45
+	high[1] = 0xB8
+
+	for i := 0; i < 100; i++ {
+		if got := ts.SelectForPayload(high); got != 0 {
+			t.Fatalf("high-DSCP: leg=%d, want 0", got)
+		}
+	}
+}
+
+func TestTransportSelector_DSCPPriority_LowRR(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeDSCPPriority)
+	ts.SetDSCPThreshold(46)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// IPv4 packet with DSCP = 0 (best-effort)
+	low := make([]byte, 24)
+	low[0] = 0x45
+	low[1] = 0x00
+
+	counts := make(map[int]int)
+	for i := 0; i < 1000; i++ {
+		counts[ts.SelectForPayload(low)]++
+	}
+	if counts[0] > 0 {
+		t.Errorf("leg 0 got %d low-DSCP packets, want 0", counts[0])
+	}
+	// Should round-robin between leg 1 and leg 2.
+	assert.InDelta(t, 500, counts[1], 20)
+	assert.InDelta(t, 500, counts[2], 20)
+}
+
+func TestTransportSelector_DSCPPriority_NonIPv4FallsToRR(t *testing.T) {
+	ts := newTransportSelector()
+	ts.SetMode(WeightModeDSCPPriority)
+	ts.SetDSCPThreshold(46)
+	tps := []*transport.ManagedTransport{mockTP(0), mockTP(0)}
+	ts.Rebuild(tps)
+
+	// Random bytes that don't look like IPv4.
+	junk := []byte{0xFF, 0xFF, 0x00, 0x00}
+	counts := make(map[int]int)
+	for i := 0; i < 100; i++ {
+		counts[ts.SelectForPayload(junk)]++
+	}
+	if counts[0] > 0 {
+		t.Errorf("non-IPv4 should never go to leg 0 (no DSCP read), got %d", counts[0])
+	}
+}


### PR DESCRIPTION
## Summary
Three new Layer-2 distribution verbs that fill out the per-packet decision space without introducing a scripting language. Per the round-4 thread: instead of opening a Layer-2 scripting RFC, expand the static vocabulary to cover the shapes operators actually want.

### New verbs

| Descriptor | Behavior |
|---|---|
| \`sticky:5tuple\` | Hash the IPv4 5-tuple (FNV-1a), pick \`hash % live-leg-count\`. Same flow → same leg deterministically. Avoids TCP-over-overlay reordering. |
| \`latency-adaptive\` / \`latency-aware\` | Per-packet linear scan over live legs for lowest \`GetLatency()\`. Differs from \`auto\`: re-evaluates every packet. |
| \`dscp-priority: N\` | IPv4 DSCP ≥ N → leg 0, rest → RR. Threshold in \`[1, 63]\`; common: 46 (EF/VoIP), 18 (AF21). Non-IPv4 → RR. |

### Implementation notes
- \`selectTransport\` signature: \`payloadSize int\` → \`payload []byte\`. New verbs inspect the bytes (hash 5-tuple, read ToS). Size-threshold path derives size from \`len(payload)\`.
- \`SelectForPayload(p)\` is the new selector entry point; dispatches on mode.
- \`fiveTupleHash\` / \`isIPv4DSCPGE\` / \`pickLowestLatency\` helpers in \`transport_selector.go\`.
- Non-IPv4 / short payloads fall back gracefully (RR for DSCP, prefix hash for sticky).

### Examples
- \`sticky-tcp-flows.star\` — VPN apps get \`mux=3 + sticky:5tuple\`
- \`latency-adaptive-rt.star\` — rt-voice / rt-video get per-packet lowest-RTT pick
- \`vpn-dscp-priority.star\` — VPN with DSCP=46 threshold (EF/VoIP)

### Tests
9 new tests pinning parser + selector behavior:
- Parser: each verb success + error cases (including hex DSCP, sticky qualifier errors)
- Selector: sticky-deterministic-by-flow, sticky-different-flows, latency-adaptive-picks-lowest, dscp-high-to-leg0, dscp-low-RR, dscp-non-IPv4-fallback

### Doc updates
README + RFC Phase 5 table extended. RFC's closing paragraph reframed: per-packet scripting RFC stays deferred because the vocabulary now covers the realistic space; future additions (e.g. \`chaff: rate\`) would land as new verbs.

## Test plan
- [x] \`make format check\` clean (0 lint issues, all router/policy tests pass)
- [x] All 20 example .star files preview cleanly
- [x] Selector tests pin determinism + fallback behavior