### PR TITLE
fix(cxo/node): shard connection maps to remove Node.mx accept-path serialization

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -29,8 +29,11 @@ type Conn struct {
 	initErr error
 	initq   chan struct{}
 	// initClosed is set true the first time onConnInit or onConnInitErr
-	// publishes the init result on this Conn. Protected by Node.mx (the
-	// only callers hold it). Guards close(initq) against a double-close
+	// publishes the init result on this Conn. Atomic CAS-gated — pre-
+	// shard this was a plain bool under Node.mx, but the conn-map
+	// sharding moved the init signal off the global mutex (so accept
+	// and removeConn paths no longer serialize on init), and the
+	// guard had to follow. Guards close(initq) against a double-close
 	// race: pre-fix the isPending branch of Node.initConn called
 	// onConnInitErr a second time after its waitForInit returned the
 	// error already published by the isNew handshaker, panicking the
@@ -39,7 +42,7 @@ type Conn struct {
 	// and every per-peer ConnectPK times out). Idempotency here means
 	// any future caller of onConnInit/onConnInitErr can't reintroduce
 	// the panic even if a new code path adds a redundant signal.
-	initClosed bool
+	initClosed atomic.Bool
 
 	closeq chan struct{}  // signal for all goroutines to exit
 	doneq  chan struct{}  // closed when run() has fully completed (maps cleaned, transport closed)

--- a/pkg/cxo/node/conn_init_idempotent_test.go
+++ b/pkg/cxo/node/conn_init_idempotent_test.go
@@ -25,29 +25,41 @@ import (
 	"errors"
 	"sync"
 	"testing"
-
-	"github.com/skycoin/skycoin/src/cipher"
 )
+
+// newTestNode builds a Node with the sharded conn maps initialized.
+// Test-only: callers don't need a Container/transports/RPC, just the
+// init-signal plumbing.
+func newTestNode() *Node {
+	return &Node{
+		conns:   newAddrConnMap(),
+		pkConns: newPkConnMap(),
+	}
+}
+
+// newTestConnInitClosed returns a Conn pre-signaled as init-published
+// (initClosed=true, initq already closed). Mirrors the state any
+// production Conn is in after onConnInit or onConnInitErr has run.
+func newTestConnInitClosed(initErr error) *Conn {
+	c := &Conn{
+		initq:   make(chan struct{}),
+		initErr: initErr,
+	}
+	c.initClosed.Store(true)
+	close(c.initq)
+	return c
+}
 
 func TestNode_OnConnInitErr_SecondCallNoOp(t *testing.T) {
 	// Pre-set c.initClosed to simulate "first onConnInitErr already
 	// ran"; call onConnInitErr again and assert it returned without
 	// mutating state. Pre-fix the function would have proceeded to
 	// `close(c.initq)` and panicked. Post-fix it returns at the
-	// initClosed gate before touching c.initq, c.initErr, or
-	// n.pendConns.
-	n := &Node{
-		pendConns:  map[string]*Conn{},
-		addrToConn: map[string]*Conn{},
-		pkToConn:   map[cipher.PubKey]*Conn{},
-	}
+	// initClosed gate before touching c.initq, c.initErr, or the
+	// conn maps.
+	n := newTestNode()
 	firstErr := errors.New("first publisher's error")
-	c := &Conn{
-		initq:      make(chan struct{}),
-		initErr:    firstErr,
-		initClosed: true,
-	}
-	close(c.initq) // mirror what the first call would have done
+	c := newTestConnInitClosed(firstErr)
 
 	// Second call. Pre-fix this panicked at the unconditional
 	// close(c.initq). Post-fix it must early-return.
@@ -67,29 +79,21 @@ func TestNode_OnConnInit_SecondCallNoOp(t *testing.T) {
 	// closes c.initq and must respect the c.initClosed gate so a
 	// stale callback (e.g. a reused Conn pointer after the cleanup
 	// path) can't panic the visor either.
-	n := &Node{
-		pendConns:  map[string]*Conn{},
-		addrToConn: map[string]*Conn{},
-		pkToConn:   map[cipher.PubKey]*Conn{},
-	}
-	c := &Conn{
-		initq:      make(chan struct{}),
-		initClosed: true,
-	}
-	close(c.initq)
+	n := newTestNode()
+	c := newTestConnInitClosed(nil)
 
 	// Should be a no-op; absence of panic is the assertion.
 	n.onConnInit(c)
 
-	// Maps must be untouched — pre-fix the function unconditionally
-	// wrote n.addrToConn[c.Address()] = c, which would nil-deref on
-	// the bare-Conn test fixture; the guard's early-return prevents
-	// the deref entirely.
-	if len(n.addrToConn) != 0 {
-		t.Errorf("addrToConn mutated past the initClosed guard: len = %d, want 0", len(n.addrToConn))
+	// Sharded conn maps must be untouched — pre-fix the function
+	// unconditionally wrote into addrToConn/pkToConn, which would
+	// nil-deref on the bare-Conn test fixture; the guard's early-
+	// return prevents the deref entirely.
+	if got := n.conns.activeLen(); got != 0 {
+		t.Errorf("active conn map mutated past the initClosed guard: len = %d, want 0", got)
 	}
-	if len(n.pkToConn) != 0 {
-		t.Errorf("pkToConn mutated past the initClosed guard: len = %d, want 0", len(n.pkToConn))
+	if _, ok := n.pkConns.get(c.peerID); ok {
+		t.Errorf("pkConns mutated past the initClosed guard")
 	}
 }
 
@@ -104,16 +108,10 @@ func TestNode_OnConnInitErr_ConcurrentCallersNoPanic(t *testing.T) {
 	// Bypass c.Address() (would nil-deref on the bare Conn) by
 	// pre-asserting initClosed=true before the goroutines start, so
 	// every concurrent caller hits the guard. The race detector
-	// would still flag an unsynchronized write to initClosed if the
-	// fix moved the bool outside Node.mx — which is why the test is
-	// `go test -race`-aware.
-	n := &Node{
-		pendConns:  map[string]*Conn{},
-		addrToConn: map[string]*Conn{},
-		pkToConn:   map[cipher.PubKey]*Conn{},
-	}
-	c := &Conn{initq: make(chan struct{}), initClosed: true}
-	close(c.initq)
+	// would catch an unsynchronized write to initClosed if a future
+	// change weakened it from atomic.Bool back to a plain bool.
+	n := newTestNode()
+	c := newTestConnInitClosed(nil)
 
 	const N = 32
 	var wg sync.WaitGroup

--- a/pkg/cxo/node/connmap.go
+++ b/pkg/cxo/node/connmap.go
@@ -1,0 +1,268 @@
+// Package node — connmap.go: sharded address- and pubkey-keyed
+// connection maps. Replaces the single Node.mx-guarded pendConns +
+// addrToConn + pkToConn triple.
+//
+// Why sharded:
+//   Pre-fix every accept/init/removeConn serialized on Node.mx. On a
+//   production transport-discovery the visor pile-up reached ~1000
+//   goroutines waiting on (*Node).onNewConn + ~400 on (*Node).removeConn
+//   while the dmsg listener dropped streams with "accept chan maxed".
+//   The critical sections are themselves microsecond-fast; the
+//   problem is the single mutex, not the work under it. Sharding by
+//   addr/pk decorrelates accepts from different peers so they no
+//   longer fight for the same lock.
+//
+// Shape choice:
+//   - addrConnMap holds BOTH pending and active entries in the same
+//     shard. onNewConn's three-way check (active? pending? new?)
+//     becomes one lock acquire instead of two.
+//   - pkConnMap is a sibling sharded map for peer-pk lookups, used
+//     by hasPeer / onConnInit / removeConn. Separate because pk is
+//     not derivable from addr at accept time.
+//   - Atomic counters (pendCount, activeCount) back pendingLen /
+//     activeLen, so cap checks (connCap, pendingConnCap) and Stats
+//     don't touch any shard mutex.
+
+package node
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+// connMapShards: count of shards for both connection maps. Picked 32
+// (rather than NumCPU) because the contention sources are per-peer
+// dmsg accepts — scales with deployment topology (hundreds to
+// thousands of peers), not with local CPU count. 32 absorbs the
+// observed ~1000-waiter pile-up without overdoing memory for the
+// low-peer case. Power of two so the modulo lowers to a mask.
+const connMapShards = 32
+
+// addrShardFor reduces an address string to a shard index via a
+// tiny djb2 hash. Inline, alloc-free — onNewConn runs in the accept
+// hot path; the previous fnv.New32a()+Write+Sum32 added a heap
+// allocation per accept which the contention profile already
+// flagged via chacha20poly1305.Seal allocations downstream.
+func addrShardIndex(addr string) uint32 {
+	var h uint32 = 5381
+	for i := 0; i < len(addr); i++ {
+		h = h*33 + uint32(addr[i])
+	}
+	return h & (connMapShards - 1)
+}
+
+// pkShardIndex reads the first 4 bytes of the pubkey as a uniform
+// random uint32. Pubkeys are uniformly random by construction, so
+// no hashing is needed.
+func pkShardIndex(pk cipher.PubKey) uint32 {
+	return (uint32(pk[0])<<24 | uint32(pk[1])<<16 | uint32(pk[2])<<8 | uint32(pk[3])) & (connMapShards - 1)
+}
+
+// addrConnShard holds pending + active conns for one shard. Both
+// maps share the same mutex so onNewConn's lookup-then-insert
+// across the two maps is one lock acquire per shard.
+type addrConnShard struct {
+	mu      sync.Mutex
+	pending map[string]*Conn
+	active  map[string]*Conn
+}
+
+// addrConnMap replaces Node.pendConns + Node.addrToConn. Sharded by
+// remote address; per-shard mutex; atomic counters for cap reads.
+type addrConnMap struct {
+	shards      [connMapShards]addrConnShard
+	pendCount   atomic.Int64
+	activeCount atomic.Int64
+}
+
+func newAddrConnMap() *addrConnMap {
+	m := &addrConnMap{}
+	for i := range m.shards {
+		m.shards[i].pending = make(map[string]*Conn)
+		m.shards[i].active = make(map[string]*Conn)
+	}
+	return m
+}
+
+func (m *addrConnMap) shardFor(addr string) *addrConnShard {
+	return &m.shards[addrShardIndex(addr)]
+}
+
+// reservePending is the atomic combo onNewConn used to do under
+// Node.mx: check the address against both maps and, if neither
+// holds it, insert c into pending. Returns the existing entry on
+// hit (with isPending reflecting which map it came from), or
+// isNew=true on a fresh insert. Single shard mutex acquisition.
+//
+// capCheck (when non-nil) runs under the shard lock just before
+// the insert and may veto with an error — used by onNewConn to
+// enforce MaxConnections / MaxPendingConnections without a separate
+// lock acquire. The cap reads use the atomic counters so capCheck
+// itself is lock-free.
+func (m *addrConnMap) reservePending(addr string, c *Conn, capCheck func() error) (existing *Conn, isPending, isNew bool, err error) {
+	s := m.shardFor(addr)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.active[addr]; ok {
+		return e, false, false, nil
+	}
+	if e, ok := s.pending[addr]; ok {
+		return e, true, false, nil
+	}
+	if capCheck != nil {
+		if err := capCheck(); err != nil {
+			return nil, false, false, err
+		}
+	}
+	s.pending[addr] = c
+	m.pendCount.Add(1)
+	return nil, false, true, nil
+}
+
+// promote moves the pending entry for addr to active, but only if
+// the slot currently holds c. The identity check guards against a
+// late promote of an evicted Conn overwriting a live replacement.
+func (m *addrConnMap) promote(addr string, c *Conn) {
+	s := m.shardFor(addr)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.pending[addr]; ok && existing == c {
+		delete(s.pending, addr)
+		m.pendCount.Add(-1)
+	}
+	if _, ok := s.active[addr]; !ok {
+		m.activeCount.Add(1)
+	}
+	s.active[addr] = c
+}
+
+// removePending deletes the pending entry for addr if it points at
+// c. Identity-checked — same reason as promote.
+func (m *addrConnMap) removePending(addr string, c *Conn) {
+	s := m.shardFor(addr)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.pending[addr]; ok && existing == c {
+		delete(s.pending, addr)
+		m.pendCount.Add(-1)
+	}
+}
+
+// removeActive deletes the active entry for addr if it points at c.
+// Identity check preserves the pre-shard removeConn semantics: a
+// late remove from an evicted Conn must not wipe the slot now
+// pointing at the live replacement Conn (see node.go removeConn
+// comment).
+func (m *addrConnMap) removeActive(addr string, c *Conn) {
+	s := m.shardFor(addr)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.active[addr]; ok && existing == c {
+		delete(s.active, addr)
+		m.activeCount.Add(-1)
+	}
+}
+
+func (m *addrConnMap) pendingLen() int { return int(m.pendCount.Load()) }
+func (m *addrConnMap) activeLen() int  { return int(m.activeCount.Load()) }
+
+// rangeActive calls fn for each active Conn. Snapshots each shard
+// under its own lock then invokes fn outside the lock so a slow
+// callback can't stall accepts on the same shard.
+func (m *addrConnMap) rangeActive(fn func(*Conn)) {
+	for i := range m.shards {
+		s := &m.shards[i]
+		s.mu.Lock()
+		snap := make([]*Conn, 0, len(s.active))
+		for _, c := range s.active {
+			snap = append(snap, c)
+		}
+		s.mu.Unlock()
+		for _, c := range snap {
+			fn(c)
+		}
+	}
+}
+
+// closePending closes every pending Conn. Used by Node.Close.
+func (m *addrConnMap) closePending() {
+	for i := range m.shards {
+		s := &m.shards[i]
+		s.mu.Lock()
+		snap := make([]*Conn, 0, len(s.pending))
+		for _, c := range s.pending {
+			snap = append(snap, c)
+		}
+		s.mu.Unlock()
+		for _, c := range snap {
+			c.Close() //nolint:errcheck,gosec
+		}
+	}
+}
+
+// pkConnShard mirrors addrConnShard but keyed by cipher.PubKey.
+type pkConnShard struct {
+	mu sync.Mutex
+	m  map[cipher.PubKey]*Conn
+}
+
+// pkConnMap replaces Node.pkToConn. Sharded by peer pubkey.
+type pkConnMap struct {
+	shards [connMapShards]pkConnShard
+}
+
+func newPkConnMap() *pkConnMap {
+	m := &pkConnMap{}
+	for i := range m.shards {
+		m.shards[i].m = make(map[cipher.PubKey]*Conn)
+	}
+	return m
+}
+
+func (m *pkConnMap) shardFor(pk cipher.PubKey) *pkConnShard {
+	return &m.shards[pkShardIndex(pk)]
+}
+
+func (m *pkConnMap) set(pk cipher.PubKey, c *Conn) {
+	s := m.shardFor(pk)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[pk] = c
+}
+
+func (m *pkConnMap) get(pk cipher.PubKey) (*Conn, bool) {
+	s := m.shardFor(pk)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.m[pk]
+	return c, ok
+}
+
+// remove deletes pk → c if the slot currently holds c. Identity-
+// checked for the same evict-then-replace race as addrConnMap.
+func (m *pkConnMap) remove(pk cipher.PubKey, c *Conn) {
+	s := m.shardFor(pk)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.m[pk]; ok && existing == c {
+		delete(s.m, pk)
+	}
+}
+
+// closeAll closes every Conn in the map. Used by Node.Close.
+func (m *pkConnMap) closeAll() {
+	for i := range m.shards {
+		s := &m.shards[i]
+		s.mu.Lock()
+		snap := make([]*Conn, 0, len(s.m))
+		for _, c := range s.m {
+			snap = append(snap, c)
+		}
+		s.mu.Unlock()
+		for _, c := range snap {
+			c.Close() //nolint:errcheck,gosec
+		}
+	}
+}

--- a/pkg/cxo/node/connmap_test.go
+++ b/pkg/cxo/node/connmap_test.go
@@ -1,0 +1,170 @@
+// Package node — connmap_test.go: contract tests for the sharded
+// connection maps. The point of the maps is to remove the single-
+// mutex serialization that previously had ~1000 dmsg-accept
+// goroutines piled up on Node.mx in production transport-discovery;
+// these tests pin the invariants the shard implementation relies
+// on so a future "simplification" back to a global mutex can't
+// silently regress that.
+
+package node
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+// TestAddrConnMap_ReservePending_Idempotent: two callers reserving
+// the same addr concurrently both observe a single insert.
+// Mirrors onNewConn's contract — one wins isNew, the other gets
+// the existing entry back.
+func TestAddrConnMap_ReservePending_Idempotent(t *testing.T) {
+	m := newAddrConnMap()
+	addr := "02b307aee5c8ce1666c63891f8af25ad2f0a47a243914c963942b3ba35b9d095ae:50"
+	c1 := &Conn{}
+	c2 := &Conn{}
+
+	_, _, isNew1, _ := m.reservePending(addr, c1, nil)
+	existing, isPending, isNew2, _ := m.reservePending(addr, c2, nil)
+
+	if !isNew1 {
+		t.Fatalf("first reserve should be new")
+	}
+	if isNew2 {
+		t.Fatalf("second reserve must not be new — c2 shouldn't have replaced c1")
+	}
+	if !isPending {
+		t.Errorf("second reserve should report isPending=true (entry is still pending)")
+	}
+	if existing != c1 {
+		t.Errorf("second reserve returned wrong existing entry: got %p, want %p", existing, c1)
+	}
+	if got := m.pendingLen(); got != 1 {
+		t.Errorf("pendingLen after double reserve: got %d, want 1", got)
+	}
+}
+
+// TestAddrConnMap_Promote_IdentityCheck: promote with a stale Conn
+// pointer must not wipe the slot now holding a live replacement.
+// Pre-shard removeConn already had this invariant; the shard
+// implementation has to preserve it (see connmap.go promote comment).
+func TestAddrConnMap_Promote_IdentityCheck(t *testing.T) {
+	m := newAddrConnMap()
+	addr := "stale-vs-live-addr"
+
+	stale := &Conn{}
+	live := &Conn{}
+
+	// Stale path goes through reserve → promote.
+	m.reservePending(addr, stale, nil)
+	m.promote(addr, stale)
+	if got := m.activeLen(); got != 1 {
+		t.Fatalf("active len after stale promote: got %d, want 1", got)
+	}
+
+	// Live replacement: a new Conn takes the same addr slot.
+	m.removeActive(addr, stale)
+	m.reservePending(addr, live, nil)
+	m.promote(addr, live)
+
+	// A late "remove stale" must not wipe the live slot.
+	m.removeActive(addr, stale)
+	if got := m.activeLen(); got != 1 {
+		t.Errorf("activeLen after late stale-remove: got %d, want 1 (live entry stranded)", got)
+	}
+}
+
+// TestAddrConnMap_CapCheckVeto: capCheck returning non-nil must
+// veto the insert AND leave the counters untouched.
+func TestAddrConnMap_CapCheckVeto(t *testing.T) {
+	m := newAddrConnMap()
+	addr := "veto-addr"
+	c := &Conn{}
+
+	vetoErr := fmt.Errorf("cap exceeded")
+	existing, isPending, isNew, err := m.reservePending(addr, c, func() error {
+		return vetoErr
+	})
+
+	if err != vetoErr {
+		t.Errorf("expected vetoErr, got %v", err)
+	}
+	if isNew || isPending || existing != nil {
+		t.Errorf("vetoed reserve returned non-nil state: existing=%v isPending=%v isNew=%v", existing, isPending, isNew)
+	}
+	if got := m.pendingLen(); got != 0 {
+		t.Errorf("pendingLen after veto: got %d, want 0 (insert leaked past cap check)", got)
+	}
+}
+
+// TestAddrConnMap_ConcurrentInsertsDifferentShards: the central
+// regression target — N goroutines inserting on N different addrs
+// should make progress in parallel, not serialize. Functionally:
+// every insert must succeed exactly once, regardless of scheduling.
+//
+// This isn't a benchmark — it's a correctness check that hammers
+// the shard mutexes the way the production accept loop does
+// (different addr per goroutine = different shards in expectation).
+func TestAddrConnMap_ConcurrentInsertsDifferentShards(t *testing.T) {
+	m := newAddrConnMap()
+	const N = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		addr := fmt.Sprintf("peer-%04d", i)
+		c := &Conn{}
+		go func() {
+			defer wg.Done()
+			_, _, isNew, _ := m.reservePending(addr, c, nil)
+			if !isNew {
+				t.Errorf("reserve for unique addr %q reported not new", addr)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := m.pendingLen(); got != N {
+		t.Errorf("pendingLen after %d concurrent unique inserts: got %d, want %d", N, got, N)
+	}
+}
+
+// TestPkConnMap_RemoveIdentityCheck: same evict-replace race as
+// addrConnMap, on the pubkey side. The pre-shard removeConn
+// identity-checked Conn pointers against pkToConn — the sharded
+// version must do the same.
+func TestPkConnMap_RemoveIdentityCheck(t *testing.T) {
+	m := newPkConnMap()
+	var pk cipher.PubKey
+	pk[0] = 0x02
+	pk[1] = 0xab
+	pk[2] = 0xcd
+	pk[3] = 0xef
+
+	stale := &Conn{}
+	live := &Conn{}
+
+	m.set(pk, stale)
+	m.set(pk, live) // live replaces
+
+	// Late remove of stale must not wipe the live slot.
+	m.remove(pk, stale)
+
+	got, ok := m.get(pk)
+	if !ok || got != live {
+		t.Errorf("late stale-remove wiped live entry: ok=%v got=%p want=%p", ok, got, live)
+	}
+}
+
+// TestAddrShardIndex_PowerOfTwoMask: relies on connMapShards being
+// a power of two so the modulo lowers to a mask. Catches a future
+// change to a non-power-of-two count that would silently break
+// shardFor — the hash returns 0..uint32 max, the mask returns
+// 0..connMapShards-1, the modulo wouldn't.
+func TestAddrShardIndex_PowerOfTwoMask(t *testing.T) {
+	if connMapShards&(connMapShards-1) != 0 {
+		t.Errorf("connMapShards=%d is not a power of two — addrShardIndex's mask wraps incorrectly", connMapShards)
+	}
+}

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -39,9 +39,12 @@ type Node struct {
 
 	fs *nodeFeeds // feeds
 
-	pendConns  map[string]*Conn        // peer addr -> pending connection
-	addrToConn map[string]*Conn        // peer addr -> connection
-	pkToConn   map[cipher.PubKey]*Conn // peer pubkey (ID) -> connection
+	// conns holds both pending and active address-keyed Conns.
+	// Sharded — accept-path serialization on Node.mx is the
+	// reason this isn't a plain map (see connmap.go).
+	conns *addrConnMap
+	// pkConns is the sharded pk → Conn map. Sibling to conns.
+	pkConns *pkConnMap
 
 	ss map[cipher.PubKey]*Swarm // swarms
 
@@ -171,9 +174,8 @@ func NewNodeContainer(
 	n.c = c
 	n.fs = newNodeFeeds(n)
 
-	n.pendConns = make(map[string]*Conn)
-	n.addrToConn = make(map[string]*Conn)
-	n.pkToConn = make(map[cipher.PubKey]*Conn)
+	n.conns = newAddrConnMap()
+	n.pkConns = newPkConnMap()
 
 	n.ss = make(map[cipher.PubKey]*Swarm)
 
@@ -267,18 +269,13 @@ func (n *Node) ConnectionsOfFeed(feed cipher.PubKey) (cs []*Conn) {
 	return n.fs.connectionsOfFeed(feed)
 }
 
-// Connections returns all established connections
+// Connections returns all established connections. Snapshots the
+// sharded active map; no Node-wide lock held during the walk.
 func (n *Node) Connections() (cs []*Conn) {
-
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	cs = make([]*Conn, 0, len(n.addrToConn))
-
-	for _, c := range n.addrToConn {
+	cs = make([]*Conn, 0, n.conns.activeLen())
+	n.conns.rangeActive(func(c *Conn) {
 		cs = append(cs, c)
-	}
-
+	})
 	return
 }
 
@@ -309,16 +306,13 @@ type PublisherStats struct {
 }
 
 // Stats returns a snapshot of the Node's publisher-side health
-// counters + active gauges. Cheap: atomic loads + map-length read
-// under the node mutex.
+// counters + active gauges. Cheap: pure atomic loads — no shard
+// mutex acquired.
 func (n *Node) Stats() PublisherStats {
-	n.mx.Lock()
-	conns := len(n.addrToConn)
-	n.mx.Unlock()
 	return PublisherStats{
 		SendMsgTimeouts:   n.sendMsgTimeoutCount.Load(),
 		DeadConnsClosed:   n.deadConnsClosed.Load(),
-		ActiveConnections: conns,
+		ActiveConnections: n.conns.activeLen(),
 		ActiveFeeds:       len(n.fs.list()),
 	}
 }
@@ -439,26 +433,18 @@ func (n *Node) onDisconnect(c *Conn, reason error) {
 }
 
 func (n *Node) connCap() int {
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	count := len(n.pendConns) + len(n.addrToConn)
+	count := n.conns.pendingLen() + n.conns.activeLen()
 	if count >= n.config.MaxConnections {
 		return 0
 	}
-
 	return n.config.MaxConnections - count
 }
 
 func (n *Node) pendingConnCap() int {
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	count := len(n.pendConns)
+	count := n.conns.pendingLen()
 	if count >= n.config.MaxPendingConnections {
 		return 0
 	}
-
 	return n.config.MaxPendingConnections - count
 }
 
@@ -527,35 +513,38 @@ func (n *Node) initConn(
 }
 
 // onNewConn atomically checks for existing connection
-// to/form address and creates new one if necessary.
+// to/from address and creates new one if necessary.
+//
+// Replaces the prior Node.mx-guarded version with a single per-shard
+// lock acquisition. Cap checks run inside reservePending via the
+// capCheck closure so they observe the post-decrement counter from
+// any concurrent removeConn — not the pre-insert snapshot a
+// separate locked read would have given.
 func (n *Node) onNewConn(
 	fc *transport.Connection, isIncoming bool) (c *Conn, isNew, isPending bool, err error) {
 
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	// Check limits for number of open connections.
-	if len(n.pendConns)+len(n.addrToConn) >= n.config.MaxConnections {
-		return nil, false, false, ErrConnLimit
-	}
-	if len(n.pendConns) >= n.config.MaxPendingConnections {
-		return nil, false, false, ErrPendConnLimit
-	}
-
 	addr := fc.GetRemoteAddr().String()
-
-	// Check if connection to/from address already exists.
-	if c, ok := n.addrToConn[addr]; ok {
-		return c, false, false, nil
-	}
-	if c, ok := n.pendConns[addr]; ok {
-		return c, false, true, nil
-	}
-
-	// Create new pending connection.
 	c = n.newConnection(fc, isIncoming)
-	n.pendConns[addr] = c
 
+	maxConns := n.config.MaxConnections
+	maxPending := n.config.MaxPendingConnections
+	capCheck := func() error {
+		if n.conns.pendingLen()+n.conns.activeLen() >= maxConns {
+			return ErrConnLimit
+		}
+		if n.conns.pendingLen() >= maxPending {
+			return ErrPendConnLimit
+		}
+		return nil
+	}
+
+	existing, isPend, isFresh, capErr := n.conns.reservePending(addr, c, capCheck)
+	if capErr != nil {
+		return nil, false, false, capErr
+	}
+	if !isFresh {
+		return existing, false, isPend, nil
+	}
 	return c, true, false, nil
 }
 
@@ -564,67 +553,50 @@ func (n *Node) onNewConn(
 // of initq so a double-call (which pre-fix the isPending branch of
 // initConn triggered, double-closing initq and panicking the visor
 // under handshake-failure load) becomes a no-op after the first.
+//
+// Post-shard the guard is an atomic CAS rather than a Node.mx-held
+// bool — moves the init signal off the global mutex so the success/
+// failure publish doesn't queue behind unrelated address lookups.
 func (n *Node) onConnInitErr(c *Conn, initErr error) {
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	if c.initClosed {
+	if !c.initClosed.CompareAndSwap(false, true) {
 		return
 	}
-	c.initClosed = true
-
-	delete(n.pendConns, c.Address())
-
+	n.conns.removePending(c.Address(), c)
 	c.initErr = initErr
 	close(c.initq)
 }
 
 // onConnInit atomically moves pending connection to cache
-// and signals about initConn success. It also chekcs if
-// peer's pubkey, receieved during hanshake is duplicate.
+// and signals about initConn success.
 //
 // Mirrors onConnInitErr's c.initClosed gate: success and failure
 // must publish exactly one close of initq, regardless of which
 // goroutine wins the race for the final write.
 func (n *Node) onConnInit(c *Conn) {
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	if c.initClosed {
+	if !c.initClosed.CompareAndSwap(false, true) {
 		return
 	}
-	c.initClosed = true
-
-	delete(n.pendConns, c.Address())
-
-	n.addrToConn[c.Address()] = c
-	n.pkToConn[c.peerID] = c
-
+	addr := c.Address()
+	n.conns.promote(addr, c)
+	n.pkConns.set(c.peerID, c)
 	close(c.initq)
 }
 
-// removeConn reomoves connection from cache.
+// removeConn removes connection from cache.
 //
 // Identity-checks the slot before deleting: when evictStalePeer
 // closes a stale Conn AND its run() drains past evictStalePeer's
 // timeout AND the handshake completes AND onConnInit overwrites
-// pkToConn[id] with a NEW Conn — all before the old run() finally
+// pkConns[id] with a NEW Conn — all before the old run() finally
 // calls removeConn(old) — the old removeConn must NOT wipe the
-// slot now pointing at the live new Conn. Same shape for
-// addrToConn. Without the identity check, the late removeConn of
+// slot now pointing at the live new Conn. Same shape for the
+// address map. Without the identity check, the late removeConn of
 // the evicted Conn silently strands the live one (hasPeer returns
 // false, feed routing skips the peer) until something else
 // re-registers.
 func (n *Node) removeConn(c *Conn) {
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	if existing, ok := n.addrToConn[c.Address()]; ok && existing == c {
-		delete(n.addrToConn, c.Address())
-	}
-	if existing, ok := n.pkToConn[c.peerID]; ok && existing == c {
-		delete(n.pkToConn, c.peerID)
-	}
+	n.conns.removeActive(c.Address(), c)
+	n.pkConns.remove(c.peerID, c)
 
 	// Remove from feed tracking
 	n.fs.delConn(c)
@@ -758,11 +730,7 @@ func (n *Node) SwapOnFillingBreaks(next func(*Node, *registry.Root, error)) (pre
 
 // has connection to peer with given id (pk)
 func (n *Node) hasPeer(id cipher.PubKey) (c *Conn, yep bool) { //nolint:unparam
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	c, yep = n.pkToConn[id]
-	return
+	return n.pkConns.get(id)
 }
 
 // evictStalePeer closes the existing Conn for `id` and waits up to
@@ -814,36 +782,43 @@ func (n *Node) Stat() (s *Stat) {
 
 // Close the Node. The Close returns error
 // of (skyobject.Container).Close once.
+//
+// Note: connection close cascades drain shard mutexes rather than
+// holding Node.mx — closing a Conn signals goroutines that may
+// re-enter Node methods (removeConn, etc.) and pre-fix that
+// re-entry deadlocked against the Node.mx held here.
 func (n *Node) Close() (err error) {
 	n.closeo.Do(func() {
-		n.mx.Lock()
-		defer n.mx.Unlock()
 
-		// Shutdown peer exchange.
+		// Shutdown peer exchange (under n.mx — guards n.ss).
+		n.mx.Lock()
 		for _, s := range n.ss {
 			s.shutdown()
 		}
+		n.mx.Unlock()
 
-		// Close all connections.
-		for _, c := range n.pendConns {
-			c.Close() //nolint:errcheck,gosec
-		}
-		for _, c := range n.pkToConn {
-			c.Close() //nolint:errcheck,gosec
-		}
+		// Close all connections. Drains shard mutexes only; the
+		// per-conn Close → removeConn re-entry is now decoupled
+		// from n.mx.
+		n.conns.closePending()
+		n.pkConns.closeAll()
 
-		// Shutdown all transports.
-		if n.tcp != nil {
-			n.tcp.Close() //nolint:errcheck,gosec
+		// Shutdown all transports (under n.mx — guards transport
+		// fields).
+		n.mx.Lock()
+		tcp, udp, dmsg, rpc := n.tcp, n.udp, n.dmsg, n.rpc
+		n.mx.Unlock()
+		if tcp != nil {
+			tcp.Close() //nolint:errcheck,gosec
 		}
-		if n.udp != nil {
-			n.udp.Close() //nolint:errcheck,gosec
+		if udp != nil {
+			udp.Close() //nolint:errcheck,gosec
 		}
-		if n.dmsg != nil {
-			n.dmsg.Close()
+		if dmsg != nil {
+			dmsg.Close()
 		}
-		if n.rpc != nil {
-			n.rpc.Close() //nolint:errcheck,gosec
+		if rpc != nil {
+			rpc.Close() //nolint:errcheck,gosec
 		}
 
 		// Close database.

--- a/pkg/cxo/node/rpc.go
+++ b/pkg/cxo/node/rpc.go
@@ -99,21 +99,25 @@ func (r *RPC) IsSharing(pk cipher.PubKey, yep *bool) (_ error) {
 	return
 }
 
-// strings with all connections
+// strings with all connections.
+//
+// Drains each shard under its own lock — same shape as
+// addrConnMap.rangeActive, but inlined here so the pending pass
+// can also walk the pending map alongside active without a second
+// exported helper.
 func (n *Node) connections() (cs []string) {
-	n.mx.Lock()
-	defer n.mx.Unlock()
-
-	cs = make([]string, 0, len(n.pendConns)+len(n.addrToConn))
-
-	for _, c := range n.pendConns {
-		cs = append(cs, c.String()+"(⌛)") // pending
+	cs = make([]string, 0, n.conns.pendingLen()+n.conns.activeLen())
+	for i := range n.conns.shards {
+		s := &n.conns.shards[i]
+		s.mu.Lock()
+		for _, c := range s.pending {
+			cs = append(cs, c.String()+"(⌛)") // pending
+		}
+		for _, c := range s.active {
+			cs = append(cs, c.String()+"(✓)") // established
+		}
+		s.mu.Unlock()
 	}
-
-	for _, c := range n.addrToConn {
-		cs = append(cs, c.String()+"(✓)") // established
-	}
-
 	return
 }
 


### PR DESCRIPTION
## Summary

Replaces the single `Node.mx`-guarded `pendConns` + `addrToConn` + `pkToConn` triple with 32-way sharded maps keyed by remote address (and pubkey). Moves the init-signal idempotency guard (`initClosed`) off `Node.mx` onto `atomic.Bool`.

## What this fixes

Production transport-discovery on a 4-core host (`v1.3.60-0`, image built 2026-05-29 00:03 UTC) pegged at **load 7.6, TPD process at 185% CPU and 3.4 GB RSS**, host swap saturated. Live `pprof` goroutine profile from the running container (`:6094`):

```
974 @ pkg/cxo/node.(*Node).onNewConn       — sync.(*Mutex).Lock
436 @ pkg/cxo/node.(*Node).removeConn      — sync.(*Mutex).Lock
 26 @ pkg/cxo/node.(*Node).onConnInitErr   — sync.(*Mutex).Lock
```

DMSG listener log was full of `dmsg error 401 - listener accept chan maxed` / `[dmsg_listener] Accept buffer full, dropping stream`. The `MaxPendingAccepts` cap added in #2625 was holding goroutine count at ~1000 instead of unbounded — but the work behind that cap (single-mutex on Node.mx) was the bottleneck.

The critical sections under `Node.mx` are themselves microsecond-fast (map ops + small alloc). The problem is the **single mutex**: every accept, init, init-error, removeConn, hasPeer, Stats and connCap from every peer serialized on the same lock. Past the lock's service rate, parking + wake-up overhead dominated and the system entered an accept-backpressure feedback loop.

## What changed

- **`addrConnMap`**: 32 shards keyed by addr-djb2. Pending + active for a given addr share the same shard mutex, so `onNewConn`'s "active? pending? new?" three-way check is one lock acquire on the addr's shard, not two on the global mutex.
- **`pkConnMap`**: 32 shards keyed by the first 4 bytes of the peer pubkey (uniformly random by construction, no hash needed).
- **Atomic counters** (`pendCount`, `activeCount`) back `pendingLen()` / `activeLen()`. `connCap`, `pendingConnCap`, `Stats` are now pure atomic loads — no mutex acquired. Cap checks in `onNewConn` thread into `reservePending` as a closure that runs under the shard lock — `capCheck` still observes a coherent post-decrement counter from any concurrent `removeConn`, but no second lock acquire is needed.
- **`initClosed`**: plain bool under `Node.mx` → `atomic.Bool`. The init publish (`close(initq)` + `initErr` write) no longer queues behind unrelated address lookups. CAS preserves the existing "exactly one publisher" invariant pinned by `TestNode_OnConnInitErr_ConcurrentCallersNoPanic`.

`Node.mx` is kept for the small set of fields it still uniquely guards: `tcp`/`udp`/`dmsg` transport pointers, the `ss` swarm map, the `rpc` server pointer. `Node.Close` now releases `n.mx` between the swarm-shutdown and transport-shutdown phases, and the conn-close cascade drains shard mutexes — pre-fix that cascade re-entered Node methods (`removeConn`) under `n.mx`, which would have deadlocked once those methods stopped taking `n.mx`.

## Invariants preserved

- `reservePending` + `promote` + `removeActive` keep the same identity-checked semantics that the prior `removeConn` had: a late remove of an evicted Conn must not wipe the slot now holding a live replacement (see `node.go` removeConn comment, also see new `TestAddrConnMap_Promote_IdentityCheck` / `TestPkConnMap_RemoveIdentityCheck`).
- `onConnInit` / `onConnInitErr` idempotency (the #2538 / panic-on-double-close fix) is preserved via `atomic.Bool.CompareAndSwap`. The three pre-existing tests in `conn_init_idempotent_test.go` run verbatim against the new shape.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./pkg/cxo/...` — all packages green (node, treestore, skyobject, data, etc.)
- [x] `go test -race -count=1 -v -run 'AddrConnMap|PkConnMap|OnConnInit' ./pkg/cxo/node/` — 8/8 pass
- [x] New tests in `pkg/cxo/node/connmap_test.go`:
  - `TestAddrConnMap_ReservePending_Idempotent` — two callers reserving same addr both observe a single insert
  - `TestAddrConnMap_Promote_IdentityCheck` — late stale-remove doesn't wipe live slot
  - `TestAddrConnMap_CapCheckVeto` — capCheck returning non-nil vetoes insert AND leaves counters untouched
  - `TestAddrConnMap_ConcurrentInsertsDifferentShards` — 1000 unique-addr inserts in parallel, all succeed
  - `TestPkConnMap_RemoveIdentityCheck` — pk-side evict-replace race
  - `TestAddrShardIndex_PowerOfTwoMask` — guards against a future change to non-power-of-two shard count
- [ ] Deploy to one of two TPDs and watch goroutine count at `:6094/debug/pprof/goroutine?debug=1` + host load; compare against the unmodified TPD on the other deployment server.