### PR TITLE
feat(router): wire DialHook into PingRoute

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -398,6 +398,40 @@ func (r *router) PingRoute(
 	lPK := r.conf.PubKey
 	forwardDesc := routing.NewRouteDescriptor(lPK, rPK, lPort, rPort)
 
+	// Operator-programmable routing policy. PingRoute is the
+	// natural entry point operators use to test mux behavior
+	// (`cli visor ping mux-bw --routes N --min-hops 2`); a
+	// policy that wants to verify its distribution descriptor
+	// applies on every multi-leg setup needs to see those dials
+	// too. Same shape as DialRoutes' hook block, minus the
+	// post-mux applyDistribution call — setupPingRoute handles
+	// distribution + leg-change hook wiring downstream.
+	if r.conf.DialHook != nil {
+		appName := ""
+		if opts != nil {
+			appName = opts.AppName
+		}
+		info := DialInfo{
+			AppName:      appName,
+			PeerPK:       rPK,
+			LPort:        lPort,
+			RPort:        rPort,
+			CLIOverrides: buildCLIOverrides(opts),
+		}
+		if adj, hookErr := r.conf.DialHook.BeforeDial(ctx, info); hookErr != nil {
+			log.WithError(hookErr).Debug("policy hook errored on PingRoute; proceeding without adjustment")
+		} else if err := applyAdjustment(opts, adj); err != nil {
+			log.WithField("policy_decision", "drop").Info("PingRoute refused by routing policy.")
+			return nil, err
+		} else if adj.MuxRoutes > 0 || adj.MinHops > 0 || adj.Distribution.Mode != DistributionUnset {
+			log.
+				WithField("policy_mux", adj.MuxRoutes).
+				WithField("policy_min_hops", adj.MinHops).
+				WithField("policy_distribution", adj.Distribution.Mode).
+				Debug("Routing policy adjusted PingRoute opts.")
+		}
+	}
+
 	// Debug: log what options we received
 	log.Debugf("PingRoute opts: TransportID=%s, ForwardHops=%d, ReverseHops=%d", opts.TransportID, len(opts.ForwardHops), len(opts.ReverseHops))
 


### PR DESCRIPTION
## Summary
Operators reach for \`cli visor ping mux-bw --routes N --min-hops 2\` when they want to verify the routing policy stack against real multi-hop traffic. That path bypassed the policy hook — \`Router.PingRoute\` is a parallel implementation of \`DialRoutes\` that didn't invoke \`r.conf.DialHook\`. This PR fixes that gap.

## What changed
- \`PingRoute\` now invokes \`BeforeDial\` with the same \`DialInfo\` shape as \`DialRoutes\` (including the \`CLIOverrides\` snapshot from #2905)
- \`applyAdjustment\` runs against the opts; \`fallback="drop"\` short-circuits with \`ErrDialPolicyDropped\`
- Same \`policy_distribution\` / \`policy_mux\` / \`policy_min_hops\` debug log fields

## Live verification
With a policy that returns \`RouteSpec(distribution="sticky:5tuple")\`, running mux-bw produces:
\`\`\`
DEBUG [router]: Routing policy adjusted PingRoute opts.
  policy_distribution=sticky:5tuple policy_min_hops=0 policy_mux=0
\`\`\`
on every parallel PingRoute.

## Known limitation
\`setupPingRoute\` downstream doesn't call \`applyDistribution\` or \`SetLegChangeHook\` — each \`PingRoute\` is a single-leg route group, so per-packet distribution + leg-change callbacks are no-ops in that context. The hook still fires because the policy may want to:
- refuse the dial via \`fallback="drop"\`
- set \`min_hops\` for the route-finder query
- audit via \`ctx.cli_overrides\` even when the per-packet selector won't apply

Multi-leg behavior continues to require \`DialRoutes\` + a successful \`establishMuxRoutes\` round.

## Test plan
- [x] \`go test ./pkg/router/...\` clean
- [x] Live-verified against running visor with sticky:5tuple policy