### PR TITLE
feat(router/policy): hook into sky_forward_conn direct dials

### DIFF
--- a/docs/examples/routing-policies/direct-dial-killswitch.star
+++ b/docs/examples/routing-policies/direct-dial-killswitch.star
@@ -1,0 +1,35 @@
+# direct-dial-killswitch.star — VPN apps may never use a DMSG
+# direct transport. The default vpn-killswitch.star covers the
+# overlay (DialRoutes) path; this one covers the direct
+# (sky_forward_conn / VStreamMux) short-circuit that bypasses
+# the route-finder when an existing direct transport to the
+# peer exists. Without it, a VPN dial would happily use a DMSG
+# direct transport even when the operator's overlay policy
+# would have refused it.
+#
+# How direct dials surface:
+#   - ctx.is_direct_dial = True
+#   - ctx.transport_kind = "stcpr" / "sudph" / "stcp" / "dmsg"
+#   - candidates is empty (no overlay candidates exist for
+#     a direct dial)
+#
+# Returning fallback="drop" causes VStreamMux.Dial to fail with
+# ErrDialPolicyDropped, which the app sees as a normal dial
+# error. Anything else allows the dial.
+#
+# Other RouteSpec fields (mux / min_hops / distribution) are
+# no-ops on direct dials — there's a single transport, no
+# routing decisions to make beyond accept/refuse.
+
+def decide_route(ctx, candidates):
+    if ctx.is_direct_dial:
+        # Direct path: VPN apps refuse DMSG; everything else passes.
+        if ctx.app in ("vpn-client", "vpn-server"):
+            if ctx.transport_kind == "dmsg":
+                logging.warn("vpn killswitch (direct): refusing DMSG transport")
+                return RouteSpec(fallback="drop")
+        return RouteSpec()
+
+    # Overlay path (the existing vpn-killswitch logic applies
+    # here — see vpn-killswitch.star for the canonical version).
+    return RouteSpec()

--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -56,6 +56,24 @@ type DialInfo struct {
 	// The policy's adjustment runs AFTER this is captured, so
 	// the script gets a true "what did the operator pass" view.
 	CLIOverrides map[string]string
+
+	// IsDirectDial is true when the hook is being invoked from
+	// the sky_forward_conn / VStreamMux direct-dial path (the
+	// short-circuit that uses an existing direct transport
+	// instead of going through the route-finder). False for the
+	// overlay paths (DialRoutes, PingRoute). Lets scripts apply
+	// killswitch-style rules to direct dials too (e.g.
+	// "vpn-client must never dial direct over dmsg"). Surfaced
+	// as `ctx.is_direct_dial` in Starlark.
+	IsDirectDial bool
+
+	// TransportKind is the network type ("stcpr"/"sudph"/"stcp"/
+	// "dmsg") of the transport the direct dial would use.
+	// Populated only when IsDirectDial is true. Empty for
+	// overlay dials. Surfaced as `ctx.transport_kind` so a
+	// script can branch on the kind even before the overlay's
+	// candidates are available.
+	TransportKind string
 }
 
 // DialAdjustment is the hook's return value. Each field is a

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -475,3 +475,19 @@ func NewMockRouter(t interface {
 
 	return mock
 }
+
+// DialHook provides a mock function with given fields:
+func (_m *MockRouter) DialHook() DialHook {
+	ret := _m.Called()
+
+	var r0 DialHook
+	if rf, ok := ret.Get(0).(func() DialHook); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(DialHook)
+		}
+	}
+
+	return r0
+}

--- a/pkg/router/policy/bridge.go
+++ b/pkg/router/policy/bridge.go
@@ -192,6 +192,8 @@ func buildContextValue(rctx RoutingContext) starlark.Value {
 			}),
 			"cli_overrides":      cliOverrides,
 			"reverse_candidates": buildCandidatesValue(rctx.ReverseCandidates),
+			"is_direct_dial":     starlark.Bool(rctx.IsDirectDial),
+			"transport_kind":     starlark.String(rctx.TransportKind),
 		},
 	)
 }

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -100,10 +100,12 @@ func (h *Hook) BeforeDial(ctx context.Context, info router.DialInfo) (router.Dia
 		return router.DialAdjustment{}, nil
 	}
 	rctx := RoutingContext{
-		App:          info.AppName,
-		PeerPK:       info.PeerPK.Hex(),
-		Port:         uint16(info.RPort),
-		CLIOverrides: info.CLIOverrides,
+		App:           info.AppName,
+		PeerPK:        info.PeerPK.Hex(),
+		Port:          uint16(info.RPort),
+		CLIOverrides:  info.CLIOverrides,
+		IsDirectDial:  info.IsDirectDial,
+		TransportKind: info.TransportKind,
 	}
 	spec, err := loader.Decide(ctx, rctx, nil)
 	if err != nil {

--- a/pkg/router/policy/hook_test.go
+++ b/pkg/router/policy/hook_test.go
@@ -675,3 +675,66 @@ def decide_route(ctx, candidates):
 func TestApplyAdjustment_FallbackDirect(t *testing.T) {
 	t.Skip("router-package internal — see router_test")
 }
+
+func TestHook_BeforeDial_DirectDialCtxFields(t *testing.T) {
+	// Script reads ctx.is_direct_dial + ctx.transport_kind and
+	// branches: refuse vpn-client direct dials over dmsg, allow
+	// everything else.
+	src := `
+def decide_route(ctx, candidates):
+    if ctx.is_direct_dial and ctx.app == "vpn-client" and ctx.transport_kind == "dmsg":
+        return RouteSpec(fallback="drop")
+    return RouteSpec()
+`
+	loader, err := NewLoader(src)
+	if err != nil {
+		t.Fatalf("NewLoader: %v", err)
+	}
+	defer loader.Close() //nolint:errcheck
+
+	h := NewHook(loader)
+	pk := cipher.PubKey{}
+	pk[0] = 0x02
+
+	// vpn-client direct over dmsg → drop
+	adj, err := h.BeforeDial(context.Background(), router.DialInfo{
+		AppName:       "vpn-client",
+		PeerPK:        pk,
+		IsDirectDial:  true,
+		TransportKind: "dmsg",
+	})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.Fallback != "drop" {
+		t.Errorf("vpn+dmsg+direct: Fallback=%q, want drop", adj.Fallback)
+	}
+
+	// vpn-client direct over stcpr → allow
+	adj, err = h.BeforeDial(context.Background(), router.DialInfo{
+		AppName:       "vpn-client",
+		PeerPK:        pk,
+		IsDirectDial:  true,
+		TransportKind: "stcpr",
+	})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.Fallback != "" {
+		t.Errorf("vpn+stcpr+direct: Fallback=%q, want empty", adj.Fallback)
+	}
+
+	// vpn-client overlay (not direct) → allow even if kind="dmsg"
+	adj, err = h.BeforeDial(context.Background(), router.DialInfo{
+		AppName:       "vpn-client",
+		PeerPK:        pk,
+		IsDirectDial:  false,
+		TransportKind: "dmsg",
+	})
+	if err != nil {
+		t.Fatalf("BeforeDial: %v", err)
+	}
+	if adj.Fallback != "" {
+		t.Errorf("vpn+dmsg+overlay: Fallback=%q, want empty (gate only fires for direct)", adj.Fallback)
+	}
+}

--- a/pkg/router/policy/types.go
+++ b/pkg/router/policy/types.go
@@ -51,6 +51,20 @@ type RoutingContext struct {
 	// the dial came from a launched app rather than a CLI command.
 	CLIOverrides map[string]string
 
+	// IsDirectDial signals the dial is going through the
+	// sky_forward_conn / VStreamMux short-circuit (an existing
+	// direct transport) rather than the overlay route-finder.
+	// Mux / distribution are no-ops on direct dials; the most
+	// useful return from the script in this case is
+	// fallback="drop" to refuse, or a bare RouteSpec() to allow.
+	// Surfaced as `ctx.is_direct_dial` in Starlark.
+	IsDirectDial bool
+
+	// TransportKind is the network type ("stcpr"/"sudph"/"stcp"/
+	// "dmsg") of the direct transport when IsDirectDial is true.
+	// Surfaced as `ctx.transport_kind`.
+	TransportKind string
+
 	// ReverseCandidates is the reverse-direction candidate list
 	// when SelectRoute is invoked, exposed to Starlark as
 	// `ctx.reverse_candidates`. Empty during BeforeDial (no

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -343,6 +343,13 @@ type Router interface {
 	// matching route group is found.
 	RouteGroupHops(desc routing.RouteDescriptor) []RouteHopInfo
 
+	// DialHook returns the configured routing-policy hook (nil
+	// if none configured). Visor wiring uses this to bridge the
+	// policy into non-router dial paths like VStreamMux's direct
+	// dial — the policy script's BeforeDial fires there too with
+	// ctx.is_direct_dial=true.
+	DialHook() DialHook
+
 	// RouteGroupMuxInfo returns a snapshot of per-leg mux state for
 	// the rg matching desc (or its inversion). Returns false when no
 	// matching active rg is found. Used by 'cli proxy mux-info' to

--- a/pkg/router/router_config.go
+++ b/pkg/router/router_config.go
@@ -122,3 +122,11 @@ func (r *router) isTpdExist(rPK cipher.PubKey) bool {
 	_, err = r.tm.GetTransport(rPK, types.DMSG)
 	return err == nil
 }
+
+// DialHook returns the routing-policy hook installed via
+// Config.DialHook (nil when no policy is configured). Exposed
+// on the Router interface so the visor can wire the same hook
+// into non-router dial paths like VStreamMux's direct dial.
+func (r *router) DialHook() DialHook {
+	return r.conf.DialHook
+}

--- a/pkg/transport/vstream.go
+++ b/pkg/transport/vstream.go
@@ -46,6 +46,13 @@ type VStreamMux struct {
 	incoming chan *VStream
 	done     chan struct{}
 	once     sync.Once
+
+	// Routing-policy hook for direct dials. Set via
+	// SetDirectDialHook; nil = no policy check. Read on every
+	// Dial; the RWMutex covers the swap (hook itself must be
+	// thread-safe).
+	directDialHookMu sync.RWMutex
+	directDialHook   DirectDialHookFn
 }
 
 // NewVStreamMux creates a virtual stream multiplexer for the given packet type.
@@ -68,6 +75,34 @@ func (m *VStreamMux) localPK() cipher.PubKey {
 	return m.tm.Local()
 }
 
+// DirectDialHookFn is the policy hook fired before a VStreamMux
+// direct dial. Returns a non-nil error to refuse the dial (the
+// error surfaces as the Dial return). Pass through a non-error
+// nil return to allow. nil hook = no policy check.
+//
+// Lives as a func type rather than an interface so the transport
+// package doesn't take a dependency on the router/policy package
+// — the visor wires this with a closure that bridges into the
+// existing routing-policy stack.
+type DirectDialHookFn func(remotePK cipher.PubKey, transportKind string) error
+
+// SetDirectDialHook attaches a hook fired before every Dial.
+// Returning an error from the hook causes Dial to fail with that
+// error — useful for vpn-killswitch-style policies that want to
+// refuse direct dials over the wrong transport kind. Goroutine-
+// safe; the hook itself must be thread-safe.
+func (m *VStreamMux) SetDirectDialHook(hook DirectDialHookFn) {
+	m.directDialHookMu.Lock()
+	m.directDialHook = hook
+	m.directDialHookMu.Unlock()
+}
+
+func (m *VStreamMux) loadDirectDialHook() DirectDialHookFn {
+	m.directDialHookMu.RLock()
+	defer m.directDialHookMu.RUnlock()
+	return m.directDialHook
+}
+
 // Dial opens a virtual stream to a remote PK over an existing transport.
 func (m *VStreamMux) Dial(remotePK cipher.PubKey) (*VStream, error) {
 	// Find a non-DMSG transport to this peer. DMSG transports use their
@@ -82,6 +117,20 @@ func (m *VStreamMux) Dial(remotePK cipher.PubKey) (*VStream, error) {
 	})
 	if targetTp == nil {
 		return nil, fmt.Errorf("vstream: no non-DMSG transport to %s", remotePK.String())
+	}
+
+	// Routing-policy hook: give the operator's script a chance to
+	// refuse the direct dial (e.g. vpn-killswitch refusing
+	// sudph-only on a busy uplink). Hook errors are propagated as
+	// the Dial error.
+	if hook := m.loadDirectDialHook(); hook != nil {
+		if err := hook(remotePK, string(targetTp.Type())); err != nil {
+			m.log.WithField("remote", remotePK.String()).
+				WithField("type", targetTp.Type()).
+				WithError(err).
+				Debug("VStreamMux: dial refused by routing policy")
+			return nil, err
+		}
 	}
 
 	m.log.WithField("tp", targetTp.Entry.ID.String()).

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -24,6 +24,7 @@ import (
 	"github.com/skycoin/skywire/pkg/geo"
 	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/tpviz"
@@ -300,6 +301,7 @@ func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) 
 		skynetMux := transport.NewVStreamMux(v.tpM, routing.SkynetForwardPacket, log)
 		v.tpM.SetSkynetForwardHandler(skynetMux.HandlePacket)
 		v.skynetFwdMux = skynetMux
+		wireDirectDialPolicyHook(v, skynetMux)
 		go func() {
 			for {
 				stream, err := skynetMux.Accept()
@@ -335,6 +337,7 @@ func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) 
 		appDirectMux := transport.NewVStreamMux(v.tpM, routing.AppDirectPacket, log)
 		v.tpM.SetAppDirectHandler(appDirectMux.HandlePacket)
 		v.appDirectMux = appDirectMux
+		wireDirectDialPolicyHook(v, appDirectMux)
 		if n, err := appnet.ResolveNetworker(appnet.TypeSkynet); err == nil {
 			if sn, ok := n.(*appnet.SkywireNetworker); ok {
 				sn.SetAppDirectMux(appDirectMux)
@@ -1413,4 +1416,44 @@ func initUIServer(ctx context.Context, v *Visor, log *logging.Logger) error {
 	})
 
 	return nil
+}
+
+// wireDirectDialPolicyHook attaches the visor's routing-policy
+// hook to a VStreamMux so direct dials (sky_forward_conn /
+// VStreamMux short-circuit, which bypasses the route-finder)
+// also fire the operator's script. The script sees
+// ctx.is_direct_dial=true and ctx.transport_kind="stcpr"/etc.
+// A bare RouteSpec() allows the dial; fallback="drop" refuses
+// it (the error propagates as the VStream.Dial return).
+//
+// Other RouteSpec fields (mux/min_hops/distribution) are no-ops
+// for direct dials — there's a single transport, no routing
+// decisions to make beyond accept/refuse.
+func wireDirectDialPolicyHook(v *Visor, mux *transport.VStreamMux) {
+	if v.router == nil || mux == nil {
+		return
+	}
+	hook := v.router.DialHook()
+	if hook == nil {
+		return
+	}
+	mux.SetDirectDialHook(func(remotePK cipher.PubKey, transportKind string) error {
+		info := router.DialInfo{
+			PeerPK:        remotePK,
+			IsDirectDial:  true,
+			TransportKind: transportKind,
+		}
+		adj, err := hook.BeforeDial(context.Background(), info)
+		if err != nil {
+			// Hook errored — proceed without refusing. The hook's
+			// own failure-mode (Fallback vs Drop) already decided
+			// what to return; surface as no-op here, matching
+			// how DialRoutes handles a hook error.
+			return nil
+		}
+		if adj.Fallback == "drop" {
+			return router.ErrDialPolicyDropped
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
## Summary
Closes the third coverage gap. The routing-policy hook fires for the overlay paths (\`DialRoutes\`, \`PingRoute\` since #2908) but the \`sky_forward_conn\` / \`VStreamMux\` short-circuit — the path skychat/vpn/skysocks take when a direct transport to the peer exists — bypassed policy entirely. A vpn-killswitch that refused dmsg overlay was silent when a dmsg direct transport existed and the app happily took it.

## Wiring
- **\`pkg/transport/vstream.go\`** — \`DirectDialHookFn\` (func type, not interface, so \`pkg/transport\` doesn't depend on \`pkg/router/policy\`). VStreamMux holds an optional hook; \`Dial\` calls it after picking a transport but before opening the stream.
- **Router interface** — new \`DialHook()\` getter so callers outside \`pkg/router\` can pull the configured policy hook.
- **\`DialInfo\` + \`RoutingContext\`** — new \`IsDirectDial\` + \`TransportKind\` fields, surfaced as \`ctx.is_direct_dial\` and \`ctx.transport_kind\` in Starlark.
- **\`init_services.go\`** — \`wireDirectDialPolicyHook\` helper attached to both skynetMux and appDirectMux. \`fallback="drop"\` returns \`router.ErrDialPolicyDropped\` from \`VStreamMux.Dial\`.

## Example
\`docs/examples/routing-policies/direct-dial-killswitch.star\` — canonical "refuse VPN apps from using DMSG direct" pattern.

\`\`\`python
def decide_route(ctx, candidates):
    if ctx.is_direct_dial and ctx.app in ("vpn-client", "vpn-server"):
        if ctx.transport_kind == "dmsg":
            return RouteSpec(fallback="drop")
    return RouteSpec()
\`\`\`

## Test plan
- [x] \`go test ./pkg/router/... ./pkg/transport/... ./pkg/visor/...\` passes
- [x] \`golangci-lint run\` clean
- [x] New \`TestHook_BeforeDial_DirectDialCtxFields\` pins three cases