### PR TITLE
docs(routing-policy): introduce "skylark" operator-facing name

### DIFF
--- a/cmd/skywire-cli/commands/route/policy.go
+++ b/cmd/skywire-cli/commands/route/policy.go
@@ -1,5 +1,5 @@
 // Package cliroute cmd/skywire-cli/commands/route/policy.go —
-// operator tooling for the Starlark routing-policy DSL
+// operator tooling for the skylark routing-policy DSL
 // (RFC #2882). `skywire cli route policy test` previews what a
 // script would decide for a synthetic dial; `bench` runs the
 // script 1M times and reports per-call latency.
@@ -30,19 +30,19 @@ func init() {
 	policyCmd.AddCommand(policyTestCmd, policyBenchCmd)
 
 	policyTestCmd.Flags().StringVarP(&policyScriptPath, "script", "s", "",
-		"path to the Starlark policy file (.star)")
+		"path to the skylark policy file (.star)")
 	policyTestCmd.Flags().StringVarP(&policyDialJSON, "dial", "d", "{}",
 		"synthetic dial context as JSON — see the docs for the schema")
 
 	policyBenchCmd.Flags().StringVarP(&policyScriptPath, "script", "s", "",
-		"path to the Starlark policy file (.star)")
+		"path to the skylark policy file (.star)")
 	policyBenchCmd.Flags().IntVarP(&policyBenchIter, "iter", "n", 100_000,
 		"number of evaluations to run")
 }
 
 var policyCmd = &cobra.Command{
 	Use:   "policy",
-	Short: "Routing-policy DSL tooling (RFC #2882)",
+	Short: "skylark routing-policy tooling (RFC #2882)",
 	Long: `Operator tooling for the per-dial routing policy:
 
   test    Preview what a policy would decide for a synthetic dial

--- a/docs/examples/routing-policies/README.md
+++ b/docs/examples/routing-policies/README.md
@@ -1,11 +1,19 @@
 # Routing-policy examples
 
-Live, runnable Starlark policies for the operator-programmable
-routing DSL (RFC #2882). Every file parses + decides cleanly
-under `skywire cli route policy test`; the candidate-filtering
-ones return the bare default in the previewer (no candidates →
-no filter) and only do meaningful work in production where the
-SelectRoute hook supplies real candidates.
+Live, runnable **skylark** policies for the operator-programmable
+routing DSL (RFC #2882). Skylark = Starlark (Google's safe
+sandboxed scripting language, original Skylark name predates the
+2017 rename) + the skywire routing stdlib: `datetime`, `geo`,
+`transports`, `peers`, `logging`, `RouteSpec`, `Candidate`,
+`on_leg_change`. Picks up the `sky_*` naming convention used
+elsewhere in the project (skywire, skychat, skynet,
+sky_forward_conn).
+
+Every file parses + decides cleanly under `skywire cli route
+policy test`; the candidate-filtering ones return the bare
+default in the previewer (no candidates → no filter) and only
+do meaningful work in production where the SelectRoute hook
+supplies real candidates.
 
 ## Quickstart
 

--- a/docs/routing_policy_rfc.md
+++ b/docs/routing_policy_rfc.md
@@ -1,6 +1,8 @@
-# RFC: Operator-Programmable Routing Policy
+# RFC: Operator-Programmable Routing Policy (skylark)
 
-Status: **Draft.** Lays out the design space for letting operators write arbitrary per-dial routing decisions in an embedded scripting language. Implementation deferred until the design is agreed.
+Status: **Active** — phases 1–6 landed. Subsequent additions land as new descriptor verbs / hook touchpoints (PRs #2890 → #2911) rather than re-opening the RFC core.
+
+Operator-facing name: **skylark** — the embedded language is Starlark (Skylark was its original name before Google's 2017 rename); the operator-facing surface (Starlark + the skywire routing stdlib `datetime` / `geo` / `transports` / `peers` / `logging` / `RouteSpec` / `Candidate` / `on_leg_change`) keeps the historical name, matching the `sky_*` pattern used elsewhere in the project. Code references stay `starlark` because `go.starlark.net` is the upstream dep we import.
 
 Related work: this builds on the unified-app-framework groundwork (RFC #2863, PRs #2860–#2879). It's downstream of that work but not blocked on it.
 


### PR DESCRIPTION
## Summary
Picks up the \`sky_*\` naming convention used elsewhere in the project (skywire/skychat/skynet/sky_forward_conn). \"Skylark\" is Starlark's original name before Google's 2017 rename — and the operator-facing surface is Starlark + the skywire routing stdlib, so the historical name fits.

## Scope
- **Operator-facing materials** (README intro, RFC title + intro, CLI flag help text) → \"skylark\"
- **Code references** stay \`starlark\` — \`go.starlark.net\` is the upstream dep we import; renaming package symbols would churn without operator benefit
- **CLI subcommand** stays \`route policy test\` / \`bench\` (not renamed to \`route skylark\`) to avoid breaking operator muscle memory
- **In-script comments** about Starlark semantics (chained comparisons, etc.) kept as-is — those describe language behavior where the canonical name is more informative

## Test plan
- [x] \`go build .\` clean
- [x] Cosmetic-only; no behavioral change