### PR TITLE
feat(apps): --reconnect for skysocks-client and skynet-client

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -63,6 +64,17 @@ var (
 	// aggregate the bulk payload.
 	fwdMux int
 	revMux int
+	// reconnect, when set, makes per-accept dial failures retry
+	// indefinitely (with --reconnect-delay between attempts) instead
+	// of dropping the local conn on first failure. Closes the gap
+	// during remote-visor restarts: a browser refresh that lands
+	// during the remote's downtime keeps the local TCP open until
+	// the remote comes back, instead of returning ECONNREFUSED.
+	// Per-accept rather than outer-loop because skynet-client's
+	// local listener already survives indefinitely — the failure
+	// site is inside handleLocalConn's dialRemote, not at startup.
+	reconnect      bool
+	reconnectDelay int64
 )
 
 func init() {
@@ -77,6 +89,8 @@ func init() {
 	RootCmd.Flags().IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse direction only)")
 	RootCmd.Flags().IntVar(&fwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override (>0 sets forward leg count independent of --routes)")
 	RootCmd.Flags().IntVar(&revMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override (>0 sets reverse leg count; canonical download-heavy shape: --forward-mux 1 --reverse-mux N)")
+	RootCmd.Flags().BoolVar(&reconnect, "reconnect", false, "retry per-accept dial indefinitely instead of dropping local conn on remote-visor failure")
+	RootCmd.Flags().Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between per-accept dial retries when --reconnect is set")
 }
 
 // RootCmd is the root command for skynet-client
@@ -112,6 +126,8 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		fs.IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override")
 		fs.IntVar(&fwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override")
 		fs.IntVar(&revMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override")
+		fs.BoolVar(&reconnect, "reconnect", false, "retry per-accept dial indefinitely on failure")
+		fs.Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between per-accept dial retries")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -195,11 +211,42 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	}
 	appCl.Log().Infof("Per-accept dial shape: %s", dialShape)
 
-	dialRemote := func() (net.Conn, error) {
+	rawDial := func() (net.Conn, error) {
 		if routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
 			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
 		}
 		return appCl.Dial(connApp)
+	}
+
+	// --reconnect wraps rawDial in a retry loop bounded only by ctx.
+	// First attempt is immediate (no warmup pause); subsequent
+	// attempts wait --reconnect-delay seconds. pkg/skynet.Client
+	// invokes the factory per local TCP accept, so each accept that
+	// happens during a remote-visor outage keeps trying until the
+	// remote returns or the parent ctx is canceled (e.g. the local
+	// TCP closes because the browser tab gave up).
+	dialRemote := rawDial
+	if reconnect {
+		delay := time.Duration(reconnectDelay) * time.Second
+		dialRemote = func() (net.Conn, error) {
+			attempt := 0
+			for {
+				conn, err := rawDial()
+				if err == nil {
+					if attempt > 0 {
+						appCl.Log().Infof("Dial succeeded after %d retries", attempt)
+					}
+					return conn, nil
+				}
+				attempt++
+				appCl.Log().WithError(err).Warnf("Dial attempt %d failed; retrying in %v", attempt, delay)
+				select {
+				case <-ctx.Done():
+					return nil, fmt.Errorf("dial canceled: %w", ctx.Err())
+				case <-time.After(delay):
+				}
+			}
+		}
 	}
 
 	// Create client with the dial factory; Serve binds the local

--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -39,13 +39,15 @@ const (
 )
 
 var (
-	r          *netutil.Retrier
-	addr       string
-	serverPK   string
-	httpAddr   string
-	retryDelay int64
-	tries      int64
-	appPort    uint16
+	r              *netutil.Retrier
+	addr           string
+	serverPK       string
+	httpAddr       string
+	retryDelay     int64
+	tries          int64
+	appPort        uint16
+	reconnect      bool
+	reconnectDelay int64
 )
 
 func init() {
@@ -56,6 +58,15 @@ func init() {
 	RootCmd.Flags().Int64Var(&tries, "tries", 3, "number of tries")
 	RootCmd.Flags().Int64Var(&retryDelay, "retry-time", 5, "delay between each try")
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
+	// In-proc reconnect loop. When set, the proc does not exit
+	// on dial / stream failure — it sleeps --reconnect-delay
+	// seconds and re-dials. Closes the ~3-5s gap that the
+	// restart_policy:always cycle leaves during remote-visor
+	// restarts (e.g., upstream auto-update). The visor-side
+	// restart_policy is still useful as a backstop for unrecov-
+	// erable proc-level failures.
+	RootCmd.Flags().BoolVar(&reconnect, "reconnect", false, "in-process reconnect on stream failure (vs exiting)")
+	RootCmd.Flags().Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between in-process reconnect attempts")
 }
 
 // RootCmd is the root command for skysocks
@@ -87,6 +98,8 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		fs.Int64Var(&tries, "tries", 3, "number of tries")
 		fs.Int64Var(&retryDelay, "retry-time", 5, "delay between tries")
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
+		fs.BoolVar(&reconnect, "reconnect", false, "in-process reconnect on stream failure")
+		fs.Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between reconnect attempts")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -126,59 +139,115 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 
 	defer setAppStatus(appCl, log, appserver.AppDetailedStatusStopped)
 
-	conn, err := dialServer(ctx, appCl, pk, serverPort)
-	if err != nil {
-		log.WithError(err).Error("Failed to dial to a server")
-		setAppErr(appCl, log, err)
-		return err
-	}
-
-	log.Infof("Connected to %v", pk)
-	client, err := skysocks.NewClient(conn, appCl)
-	if err != nil {
-		log.WithError(err).Error("Failed to create a new client")
-		setAppErr(appCl, log, err)
-		return err
-	}
-	if runtime.GOOS == "windows" {
-		ipcClient, err := ipc.StartClient(skyenv.SkysocksClientName, nil)
-		if err != nil {
-			setAppErr(appCl, log, err)
-			log.WithError(err).Error("Error creating ipc server for skysocks")
-			return err
-		}
-		go client.ListenIPC(ipcClient)
-	} else {
-		termCh := make(chan os.Signal, 1)
-		signal.Notify(termCh, os.Interrupt)
-		go func() {
-			select {
-			case <-termCh:
-				if err := client.Close(); err != nil {
-					log.WithError(err).Warn("Error closing client on interrupt")
-				}
-			case <-ctx.Done():
-				if err := client.Close(); err != nil {
-					log.WithError(err).Warn("Error closing client on context done")
-				}
-			}
-		}()
-	}
-
-	log.Infof("Serving proxy client %v", addr)
-	setAppStatus(appCl, log, appserver.AppDetailedStatusRunning)
+	// httpProxy is bound once per proc lifetime — its connection
+	// per request to the local SOCKS5 listener means it survives
+	// reconnect cycles transparently (browser sees a brief
+	// connection-refused on the gap, retries succeed).
 	httpCtx, httpCancel := context.WithCancel(ctx)
 	defer httpCancel()
 	if httpAddr != "" {
 		go httpProxy(httpCtx, httpAddr, addr, log)
 	}
-	//nolint:staticcheck // ListenAndServe blocks until error; check is necessary
-	if err := client.ListenAndServe(addr); err != nil {
-		log.WithError(err).Error("Error serving proxy client")
-		return err
+
+	// SIGINT goroutine cancels the outer ctx so the cycle loop
+	// breaks out cleanly. Installed once for the proc lifetime;
+	// each cycle's client.ListenAndServe returns when the
+	// underlying conn closes (we close it in the cycle's deferred
+	// cleanup when ctx fires).
+	cycleCtx, cycleCancel := context.WithCancel(ctx)
+	defer cycleCancel()
+	if runtime.GOOS != "windows" {
+		termCh := make(chan os.Signal, 1)
+		signal.Notify(termCh, os.Interrupt)
+		go func() {
+			select {
+			case <-termCh:
+				cycleCancel()
+			case <-cycleCtx.Done():
+			}
+		}()
 	}
-	setAppStatus(appCl, log, appserver.AppDetailedStatusStopped)
-	return nil
+
+	// runCycle does one connect + serve attempt. Returns nil
+	// only on a clean ctx-done stop; any other return is a
+	// (re-)connect trigger when --reconnect is set.
+	runCycle := func() error {
+		conn, err := dialServer(cycleCtx, appCl, pk, serverPort)
+		if err != nil {
+			return fmt.Errorf("dial server: %w", err)
+		}
+		log.Infof("Connected to %v", pk)
+		client, err := skysocks.NewClient(conn, appCl)
+		if err != nil {
+			return fmt.Errorf("new client: %w", err)
+		}
+		// Close the client when the outer ctx fires so
+		// ListenAndServe returns. With --reconnect the loop
+		// just iterates; without it the loop body returns and
+		// the proc exits (existing behavior).
+		closeOnCtx := make(chan struct{})
+		go func() {
+			select {
+			case <-cycleCtx.Done():
+				if cerr := client.Close(); cerr != nil {
+					log.WithError(cerr).Warn("Error closing client on context done")
+				}
+			case <-closeOnCtx:
+			}
+		}()
+		defer close(closeOnCtx)
+
+		if runtime.GOOS == "windows" {
+			ipcClient, err := ipc.StartClient(skyenv.SkysocksClientName, nil)
+			if err != nil {
+				return fmt.Errorf("start IPC client: %w", err)
+			}
+			go client.ListenIPC(ipcClient)
+		}
+
+		log.Infof("Serving proxy client %v", addr)
+		setAppStatus(appCl, log, appserver.AppDetailedStatusRunning)
+		//nolint:staticcheck
+		if err := client.ListenAndServe(addr); err != nil {
+			return fmt.Errorf("serve proxy client: %w", err)
+		}
+		return nil
+	}
+
+	if !reconnect {
+		if err := runCycle(); err != nil {
+			log.WithError(err).Error("skysocks-client failed")
+			setAppErr(appCl, log, err)
+			return err
+		}
+		setAppStatus(appCl, log, appserver.AppDetailedStatusStopped)
+		return nil
+	}
+
+	// Reconnect mode: loop until cycleCtx is canceled (signal /
+	// parent visor stop). Each iteration is one connect+serve
+	// cycle; a failure logs + sleeps + retries indefinitely.
+	// The visor-side restart_policy still wins as a backstop —
+	// if this proc itself panics, the restart loop catches it.
+	delay := time.Duration(reconnectDelay) * time.Second
+	for {
+		if err := runCycle(); err != nil {
+			if cycleCtx.Err() != nil {
+				// Ctx-induced unwind, not a real failure.
+				return nil
+			}
+			log.WithError(err).Warnf("Reconnecting in %v", delay)
+			setAppStatus(appCl, log, appserver.AppDetailedStatusReconnecting)
+		}
+		if cycleCtx.Err() != nil {
+			return nil
+		}
+		select {
+		case <-cycleCtx.Done():
+			return nil
+		case <-time.After(delay):
+		}
+	}
 }
 
 func dialServer(ctx context.Context, appCl *app.Client, pk cipher.PubKey, port routing.Port) (net.Conn, error) {


### PR DESCRIPTION
## Summary

Adds opt-in \`--reconnect\` / \`--reconnect-delay\` flags to skysocks-client and skynet-client so they stay usable across remote-visor restarts (autoupdate, halt, etc.) without relying on the visor-side \`restart_policy: always\` cycle. The visor-side restart loop has a ~3-5s gap that's long enough to error out browsers on long-lived sessions; the in-process retry closes that to ~2s (configurable).

The two apps have different failure shapes, so \`--reconnect\` means different things:

| app | failure site | --reconnect effect |
|---|---|---|
| skysocks-client | dial-once-at-startup, then ListenAndServe blocks; failure unwinds both → proc exits | outer cycle loop: re-dial + re-bind + re-serve |
| skynet-client | local listener bound forever, per-accept dialRemote fails on remote outage | per-accept retry: keep trying the dial until success or browser closes the local TCP |

Default behavior unchanged for both apps; the flag is opt-in.

## skysocks-client (commit 1)

\`--reconnect\` — when set, dialServer + skysocks.NewClient + client.ListenAndServe run inside a for-loop. On any cycle failure, the loop logs the error, sets app status to \`Connection failed, reconnecting\` (existing detailed-status enum), sleeps \`--reconnect-delay\` seconds, and tries again. Loop exits only on ctx done.

\`--reconnect-delay <int>\` — seconds between cycles (default 2).

Refactor: the inner dial+serve flow is extracted into a \`runCycle\` closure so the non-reconnect path preserves existing single-shot behavior exactly. Signal handler + httpProxy lifecycle hoisted out of the cycle so they survive reconnect iterations.

## skynet-client (commit 2)

\`--reconnect\` — when set, the per-accept rawDial is wrapped in a retry loop bounded only by ctx. Per-accept dialRemote keeps trying until success or the parent ctx is canceled (e.g. the browser tab gives up and closes the local TCP). First attempt is immediate; subsequent attempts wait \`--reconnect-delay\` seconds.

Net effect: a browser refresh that lands during a remote-visor restart holds the local TCP open until the remote returns, instead of returning ECONNREFUSED. The skynet route group's existing 5-min keepalive (refreshing the 10-min DefaultRouteKeepAlive rule TTL at intermediate visors) handles the long-idle-then-refresh case independently; \`--reconnect\` only matters when the remote actually went away.

## Out of scope (separate PRs)

- **vpn-client**: same outer-loop shape as skysocks-client, but the \`eventSub.OnTCPDial\` direct-route flow needs an atomic.Pointer swap or persisted route state to survive reconnects cleanly. Its own PR.
- **Resolving proxy / skynetweb**: per-URL ad-hoc dialing model. Future improvement tracked at #2915 — covers multihop + multiplexed routes for the resolving proxy, per-target lifecycle UX.
- **Server-only apps** (skysocks, vpn-server, skynet): no client dial to retry; out of scope.

## Test plan

- [x] \`go build ./\`
- [x] \`go vet ./cmd/apps/skysocks-client/... ./cmd/apps/skynet-client/...\`
- [ ] Runtime skysocks-client: start with \`--reconnect\`, halt the remote skysocks-server visor, confirm the client doesn't exit, logs the reconnect message, and resumes when the server comes back.
- [ ] Runtime skynet-client: start with \`--reconnect\`, halt the remote skynet server, hit the forwarded local port from a browser, confirm the local TCP stays open until the remote returns.