### PR TITLE
feat(router/policy): re-land extension dispatch + runtime per-app swap

### DIFF
--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -30,6 +30,7 @@ var procKey string
 var useInternal bool
 var useExternal bool
 var lsAppsLive bool
+var startAppRoutingPolicy string
 
 func init() {
 	// cobra.EnableCommandSorting used to be set to false here, which
@@ -67,6 +68,10 @@ func init() {
 	startAppCmd.Flags().BoolVar(&useInternal, "internal", false, "force internal launcher")
 	startAppCmd.Flags().BoolVar(&useExternal, "external", false, "force external launcher")
 	startAppCmd.MarkFlagsMutuallyExclusive("internal", "external")
+	startAppCmd.Flags().StringVar(&startAppRoutingPolicy, "routing-policy", "",
+		"per-app routing policy: @/path/to/policy.star or @/path/to/policy.wasm. "+
+			"Installed before the app starts; backend dispatched by file extension. "+
+			"Pass an empty string or \"none\" to clear a previously-installed override.")
 	lsAppsCmd.Flags().BoolVarP(&lsAppsLive, "live", "L", false,
 		"live-refresh mode (bubbletea TUI, 1s tick); shows app status transitions in place")
 }
@@ -180,6 +185,17 @@ var startAppCmd = &cobra.Command{
 			launcherMode = "internal"
 		} else if useExternal {
 			launcherMode = "external"
+		}
+
+		// Install the per-app routing policy *before* the app
+		// starts. SetAppRoutingPolicy returns immediately once
+		// the engine is registered, so by the time StartApp
+		// returns, the very first dial the app makes already
+		// runs through the new policy. Passing "" / "none" still
+		// fires — that's how the operator clears a previously-
+		// installed runtime override.
+		if cmd.Flags().Changed("routing-policy") {
+			internal.Catch(cmd.Flags(), rpcClient.SetAppRoutingPolicy(args[0], startAppRoutingPolicy))
 		}
 
 		internal.Catch(cmd.Flags(), rpcClient.StartAppWithMode(args[0], launcherMode))

--- a/docs/examples/routing-policies/wasm/README.md
+++ b/docs/examples/routing-policies/wasm/README.md
@@ -76,17 +76,34 @@ Install:
 sudo install -m 0644 app-mux.wasm /etc/skywire/policies/
 ```
 
-Point the visor at it via `skywire.json`:
+Point the visor at it via `skywire.json` — same field as the
+skylark policy; backend is picked by file extension:
 
 ```json
 "routing": {
-  "policy_per_dial_wasm": "@/etc/skywire/policies/app-mux.wasm"
+  "policy_per_dial": "@/etc/skywire/policies/app-mux.wasm"
 }
 ```
 
-`policy_per_dial_wasm` wins over `policy_per_dial` when both are set —
-WASM is the explicit opt-in. Per-app overrides
-(`launcher.apps[].routing_policy`) remain skylark-only for now.
+Per-app overrides accept WASM too:
+
+```json
+"launcher": {
+  "apps": [
+    {
+      "name": "vpn-client",
+      "routing_policy": "@/etc/skywire/policies/vpn.wasm"
+    }
+  ]
+}
+```
+
+Or supply at app-start time via CLI:
+
+```bash
+skywire cli visor app start vpn-client \
+    --routing-policy @/etc/skywire/policies/vpn.wasm
+```
 
 ## Hot reload
 

--- a/docs/examples/routing-policies/wasm/app-mux/main.go
+++ b/docs/examples/routing-policies/wasm/app-mux/main.go
@@ -8,8 +8,9 @@
 //
 //	sudo install -m 0644 app-mux.wasm /etc/skywire/policies/
 //	# in skywire.json: "routing": {
-//	#   "policy_per_dial_wasm": "@/etc/skywire/policies/app-mux.wasm"
+//	#   "policy_per_dial": "@/etc/skywire/policies/app-mux.wasm"
 //	# }
+//	# backend dispatched by file extension.
 //
 // Same semantic as the skylark version: per-app mux + min_hops,
 // latency-sensitive apps stay single-route, bandwidth apps get

--- a/pkg/app/appserver/spec/spec.go
+++ b/pkg/app/appserver/spec/spec.go
@@ -64,9 +64,14 @@ type AppConfig struct {
 	//                   its config entry and restart the visor.
 	RestartPolicy string `json:"restart_policy,omitempty"`
 	// RoutingPolicy overrides the visor-wide routing policy for
-	// dials originating from this app. Same `@/path` vs. inline-
-	// script convention as conf.Routing.PolicyPerDial. Empty =
-	// fall through to the visor-wide policy (which is itself
-	// empty by default). See docs/routing_policy_rfc.md.
+	// dials originating from this app. Accepts the same shape
+	// as conf.Routing.PolicyPerDial:
+	//   "@/path/to/policy.star"  — Starlark, hot-reloaded
+	//   "@/path/to/policy.wasm"  — WASM, hot-reloaded
+	//   "<inline script source>" — small inline Starlark
+	//   "" / unset                — fall through to visor-wide
+	// Backend dispatch is by file extension. See
+	// docs/routing_policy_rfc.md and
+	// docs/examples/routing-policies/wasm/README.md.
 	RoutingPolicy string `json:"routing_policy,omitempty"`
 }

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -9,6 +9,7 @@ package policy
 
 import (
 	"context"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/router"
 )
@@ -25,9 +26,11 @@ import (
 // per-app policy is the operator's intent for that app.
 type Hook struct {
 	loader   Engine
-	byApp    map[string]Engine
 	provider Provider // used for HopsGeo enrichment during SelectRoute
 	logger   func(format string, args ...interface{})
+
+	mu    sync.RWMutex
+	byApp map[string]Engine
 }
 
 // HookOption configures a Hook at construction.
@@ -79,12 +82,12 @@ type EngineSnapshot struct {
 	Active bool
 }
 
-// Snapshot returns the Hook's current engine state. Reads are
-// safe today because RegisterApp is init-only (writes happen
-// during single-threaded startup); when SetAppRoutingPolicy
-// re-lands as a runtime swap, this method picks up the
-// required mutex alongside it.
+// Snapshot returns the Hook's current engine state. Takes the
+// RLock for the duration so it's safe to call concurrently with
+// the dial path and with SetDefault / RegisterApp.
 func (h *Hook) Snapshot() HookSnapshot {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	out := HookSnapshot{}
 	if h.loader != nil {
 		out.Default = &EngineSnapshot{
@@ -107,19 +110,48 @@ func (h *Hook) Snapshot() HookSnapshot {
 	return out
 }
 
-// RegisterApp attaches a per-app Engine that overrides the default
-// for dials originating from the named app. Safe to call only
-// during init (before the hook is handed to the router).
-func (h *Hook) RegisterApp(appName string, l Engine) {
+// SetDefault swaps the visor-wide (default) Engine. Returns the
+// previous engine for caller-side cleanup. Same concurrency
+// rules as RegisterApp.
+func (h *Hook) SetDefault(l Engine) Engine {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	prev := h.loader
+	h.loader = l
+	return prev
+}
+
+// RegisterApp attaches a per-app Engine that overrides the
+// default for dials originating from the named app. Safe to
+// call concurrently with the dial path: writes are serialized
+// by h.mu and the read path in loaderFor takes an RLock.
+//
+// Returns the previously-registered Engine (or nil) so the
+// caller can Close it if it owns the lifecycle. Runtime swaps
+// (e.g. `cli visor app start --routing-policy <path>`) should
+// Close the previous engine after a successful swap to release
+// the wazero runtime / fsnotify watcher.
+func (h *Hook) RegisterApp(appName string, l Engine) Engine {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.byApp == nil {
 		h.byApp = make(map[string]Engine)
 	}
-	h.byApp[appName] = l
+	prev := h.byApp[appName]
+	if l == nil {
+		delete(h.byApp, appName)
+	} else {
+		h.byApp[appName] = l
+	}
+	return prev
 }
 
 // loaderFor returns the per-app engine if one is registered for
-// info.AppName, else the default.
+// info.AppName, else the default. Hot path on every dial — uses
+// an RLock so concurrent dials don't serialize on byApp lookups.
 func (h *Hook) loaderFor(appName string) Engine {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.byApp != nil {
 		if l, ok := h.byApp[appName]; ok {
 			return l

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -74,6 +74,12 @@ type API interface {
 	Apps() ([]*appserver.AppState, error)
 	StartApp(appName string) error
 	StartAppWithMode(appName, launcherMode string) error
+	// SetAppRoutingPolicy installs (or clears, when path is "" /
+	// "none") a per-app routing policy. Backend is dispatched by
+	// file extension: "@/path.star" uses Starlark, "@/path.wasm"
+	// uses WASM. The swap is live — the running app picks up the
+	// new policy on its next dial without a restart.
+	SetAppRoutingPolicy(appName, path string) error
 	AddApp(appName, binaryName string) error
 	DeleteApp(appName string) error
 	RegisterApp(procConf appcommon.ProcConfig) (appcommon.ProcKey, error)

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -17,8 +17,22 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/router/policy"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
+
+// ErrRouterNotAvailable is returned by RPC handlers that need a
+// router (e.g. SetAppRoutingPolicy) before the visor has finished
+// router init.
+var ErrRouterNotAvailable = errors.New("router not available")
+
+// ErrPolicyHookUnavailable is returned when no router.DialHook is
+// installed — typically because no policy was configured at startup
+// and the runtime swap is the first policy this visor has seen.
+// (Not currently reachable: init_router.go always installs a hook
+// for the runtime-swap path. Reserved for the case where DialHook
+// is explicitly disabled.)
+var ErrPolicyHookUnavailable = errors.New("routing-policy hook unavailable")
 
 // Apps implements API.
 func (v *Visor) Apps() ([]*appserver.AppState, error) {
@@ -91,6 +105,69 @@ func (v *Visor) StartAppWithMode(appName, launcherMode string) error {
 		return v.appL.StartAppWithMode(appName, nil, envs, launcherMode)
 	}
 	return ErrProcNotAvailable
+}
+
+// SetAppRoutingPolicy installs (or clears) a per-app routing
+// policy at runtime. Backend is dispatched by file extension
+// — `.wasm` uses the WASM loader, anything else (including the
+// inline-Starlark form) uses the Starlark loader. The swap is
+// live: the running app picks up the new policy on its next
+// dial, no restart required.
+//
+// path == "" or "none" clears the per-app entry, falling the
+// app back to the visor-wide policy (or no policy if none is
+// configured).
+//
+// Returns ErrRouterNotAvailable when called before router
+// initialization completes.
+func (v *Visor) SetAppRoutingPolicy(appName, path string) error {
+	if v.router == nil {
+		return ErrRouterNotAvailable
+	}
+	dh := v.router.DialHook()
+	hook, ok := dh.(*policy.Hook)
+	if !ok || hook == nil {
+		return ErrPolicyHookUnavailable
+	}
+
+	logger := func(format string, args ...interface{}) {
+		v.log.Infof(format, args...)
+	}
+	provider := newVisorPolicyProvider(v)
+
+	pe, err := loadPolicyEngine(path, provider, logger)
+	if err != nil {
+		return fmt.Errorf("load policy %q: %w", path, err)
+	}
+
+	var newEngine policy.Engine
+	if pe != nil {
+		if werr := pe.watch(logger); werr != nil {
+			v.log.WithError(werr).WithField("app", appName).
+				Warn("Per-app routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
+		}
+		newEngine = pe.engine
+	}
+	prev := hook.RegisterApp(appName, newEngine)
+	if prev != nil {
+		// Close the displaced engine to release its wazero
+		// runtime / fsnotify watcher. Idempotent for both
+		// backends; safe to call after the new engine is
+		// already serving dials.
+		if cerr := prev.Close(); cerr != nil {
+			v.log.WithError(cerr).WithField("app", appName).
+				Warn("Closing displaced routing-policy engine returned an error.")
+		}
+	}
+	if newEngine != nil {
+		v.pushCloseStack(pe.tag+".app:"+appName+".runtime", newEngine.Close)
+		v.log.WithField("app", appName).WithField("source", newEngine.Source()).
+			Info("Per-app routing policy installed at runtime.")
+	} else {
+		v.log.WithField("app", appName).
+			Info("Per-app routing policy cleared at runtime.")
+	}
+	return nil
 }
 
 // AddApp implement API.

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -17,7 +17,6 @@ import (
 	"github.com/skycoin/skywire/pkg/rfclient"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/router/policy"
-	policywasm "github.com/skycoin/skywire/pkg/router/policy/wasm"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -202,45 +201,24 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 			return provider
 		}
 
-		var hook *policy.Hook
+		// Always install a Hook even when no policy is
+		// configured at startup. The Hook with a nil default
+		// engine and empty byApp map is zero-cost on the dial
+		// path (loaderFor returns nil → BeforeDial / SelectRoute
+		// / OnLegChange all early-return), and an installed
+		// Hook is what makes runtime swaps via
+		// SetAppRoutingPolicy possible without restart.
+		hook := policy.NewHook(nil, policy.WithHookProvider(makeProvider()), policy.WithHookLogger(policyLogger))
 
-		// PolicyPerDialWasm wins over PolicyPerDial when both
-		// are set — WASM is the explicit, compiled-artifact
-		// opt-in; a Starlark fallback at the same time would be
-		// dead config.
-		switch {
-		case v.conf.Routing.PolicyPerDialWasm != "":
-			wloader, perr := policywasm.NewLoader(
-				v.conf.Routing.PolicyPerDialWasm,
-				policywasm.WithLogger(policyLogger),
-				policywasm.WithProvider(makeProvider()),
-			)
-			if perr != nil {
-				log.WithError(perr).Warn("WASM routing policy failed to load; visor will run without visor-wide policy.")
-			} else {
-				if werr := wloader.Watch(policyLogger); werr != nil {
-					log.WithError(werr).Warn("WASM routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
-				}
-				hook = policy.NewHook(wloader, policy.WithHookProvider(makeProvider()), policy.WithHookLogger(policyLogger))
-				v.pushCloseStack("router.policy.wasm", wloader.Close)
-				log.WithField("source", wloader.Source()).Info("WASM routing policy active.")
+		if pe, perr := loadPolicyEngine(v.conf.Routing.PolicyPerDial, makeProvider(), policyLogger); perr != nil {
+			log.WithError(perr).Warn("Routing policy failed to load; visor will run without visor-wide policy.")
+		} else if pe != nil {
+			if werr := pe.watch(policyLogger); werr != nil {
+				log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
 			}
-		case v.conf.Routing.PolicyPerDial != "":
-			loader, perr := policy.NewLoader(
-				v.conf.Routing.PolicyPerDial,
-				policy.WithLogger(policyLogger),
-				policy.WithProvider(makeProvider()),
-			)
-			if perr != nil {
-				log.WithError(perr).Warn("Routing policy failed to load; visor will run without visor-wide policy.")
-			} else {
-				if werr := loader.Watch(policyLogger); werr != nil {
-					log.WithError(werr).Warn("Routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
-				}
-				hook = policy.NewHook(loader, policy.WithHookProvider(makeProvider()), policy.WithHookLogger(policyLogger))
-				v.pushCloseStack("router.policy", loader.Close)
-				log.WithField("source", loader.Source()).Info("Routing policy active.")
-			}
+			hook.SetDefault(pe.engine)
+			v.pushCloseStack(pe.tag, pe.engine.Close)
+			log.WithField("source", pe.engine.Source()).Info("Routing policy active.")
 		}
 
 		if v.conf.Launcher != nil {
@@ -248,31 +226,25 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 				if app.RoutingPolicy == "" {
 					continue
 				}
-				appLoader, perr := policy.NewLoader(
-					app.RoutingPolicy,
-					policy.WithLogger(policyLogger),
-					policy.WithProvider(makeProvider()),
-				)
+				pe, perr := loadPolicyEngine(app.RoutingPolicy, makeProvider(), policyLogger)
 				if perr != nil {
 					log.WithError(perr).WithField("app", app.Name).Warn("Per-app routing policy failed to load; app will fall back to default policy.")
 					continue
 				}
-				if werr := appLoader.Watch(policyLogger); werr != nil {
+				if pe == nil {
+					continue
+				}
+				if werr := pe.watch(policyLogger); werr != nil {
 					log.WithError(werr).WithField("app", app.Name).Warn("Per-app routing policy hot-reload watcher failed to start; policy still active but won't auto-reload.")
 				}
-				if hook == nil {
-					hook = policy.NewHook(nil, policy.WithHookProvider(makeProvider()), policy.WithHookLogger(policyLogger))
-				}
-				hook.RegisterApp(app.Name, appLoader)
+				hook.RegisterApp(app.Name, pe.engine)
 				appName := app.Name
-				v.pushCloseStack("router.policy.app:"+appName, appLoader.Close)
-				log.WithField("app", appName).WithField("source", appLoader.Source()).Info("Per-app routing policy active.")
+				v.pushCloseStack(pe.tag+".app:"+appName, pe.engine.Close)
+				log.WithField("app", appName).WithField("source", pe.engine.Source()).Info("Per-app routing policy active.")
 			}
 		}
 
-		if hook != nil {
-			rConf.DialHook = hook
-		}
+		rConf.DialHook = hook
 	}
 
 	routeSetupHooks := getRouteSetupHooks(ctx, v, log)

--- a/pkg/visor/policy_loader.go
+++ b/pkg/visor/policy_loader.go
@@ -1,0 +1,64 @@
+// Package visor pkg/visor/policy_loader.go — extension-dispatch
+// for routing-policy backends. A single config field
+// (`routing.policy_per_dial`, per-app `routing_policy`, or the
+// runtime `app start --routing-policy <path>` flag) accepts
+// both `.star` (Starlark) and `.wasm` (WASM) artifacts; this
+// helper inspects the path and instantiates the matching
+// Loader, returning the shared policy.Engine interface so
+// callers don't branch on backend.
+package visor
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/router/policy"
+	policywasm "github.com/skycoin/skywire/pkg/router/policy/wasm"
+)
+
+// policyEngine is the runtime triple a caller needs after loading
+// a routing policy: the Engine itself, a Watch callback that
+// installs the hot-reload watcher (no-op when the backend doesn't
+// support it), and a close-stack tag identifying the backend
+// (used as the prefix in v.pushCloseStack).
+type policyEngine struct {
+	engine policy.Engine
+	watch  func(logger func(string, ...interface{})) error
+	tag    string // "router.policy" or "router.policy.wasm"
+}
+
+// loadPolicyEngine reads raw and instantiates either a Starlark
+// or WASM Loader by file extension. Returns nil + nil on
+// empty/none (caller treats as "no policy"). Errors propagate
+// from the underlying NewLoader.
+func loadPolicyEngine(raw string, provider policy.Provider, logger func(string, ...interface{})) (*policyEngine, error) {
+	if raw == "" || raw == "none" {
+		return nil, nil
+	}
+	if isWasmPath(raw) {
+		l, err := policywasm.NewLoader(raw,
+			policywasm.WithLogger(logger),
+			policywasm.WithProvider(provider))
+		if err != nil {
+			return nil, err
+		}
+		return &policyEngine{engine: l, watch: l.Watch, tag: "router.policy.wasm"}, nil
+	}
+	l, err := policy.NewLoader(raw,
+		policy.WithLogger(logger),
+		policy.WithProvider(provider))
+	if err != nil {
+		return nil, err
+	}
+	return &policyEngine{engine: l, watch: l.Watch, tag: "router.policy"}, nil
+}
+
+// isWasmPath reports whether raw refers to a `.wasm` file.
+// Inline values (no leading `@`) are always Starlark — a
+// compiled WASM module doesn't fit in a JSON string.
+func isWasmPath(raw string) bool {
+	if !strings.HasPrefix(raw, "@") {
+		return false
+	}
+	return strings.EqualFold(filepath.Ext(strings.TrimPrefix(raw, "@")), ".wasm")
+}

--- a/pkg/visor/policy_loader_test.go
+++ b/pkg/visor/policy_loader_test.go
@@ -1,0 +1,141 @@
+package visor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/router/policy"
+)
+
+// findRepoArtifact walks up from the test's runtime directory
+// looking for path. Returns "" when not found.
+func findRepoArtifact(t *testing.T, path ...string) string {
+	t.Helper()
+	_, here, _, _ := runtime.Caller(0)
+	dir := here
+	for i := 0; i < 8; i++ {
+		dir = filepath.Dir(dir)
+		parts := append([]string{dir}, path...)
+		candidate := filepath.Join(parts...)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func TestLoadPolicyEngine_DispatchesByExtension(t *testing.T) {
+	wasmPath := findRepoArtifact(t, "docs", "examples", "routing-policies",
+		"wasm", "app-mux", "app-mux.wasm")
+	if wasmPath == "" {
+		t.Skip("app-mux.wasm not built; see docs/examples/routing-policies/wasm/")
+	}
+
+	// .wasm path → WASM backend (tag carries the backend name).
+	pe, err := loadPolicyEngine("@"+wasmPath, nil, nil)
+	if err != nil {
+		t.Fatalf("loadPolicyEngine(wasm): %v", err)
+	}
+	defer pe.engine.Close() //nolint:errcheck
+	if pe.tag != "router.policy.wasm" {
+		t.Errorf("wasm path picked tag %q, want router.policy.wasm", pe.tag)
+	}
+
+	// Empty / "none" → nil engine, no error.
+	for _, raw := range []string{"", "none"} {
+		got, err := loadPolicyEngine(raw, nil, nil)
+		if err != nil {
+			t.Errorf("loadPolicyEngine(%q): err=%v, want nil", raw, err)
+		}
+		if got != nil {
+			t.Errorf("loadPolicyEngine(%q): engine=%v, want nil", raw, got)
+		}
+	}
+}
+
+func TestLoadPolicyEngine_DecidesViaWASM(t *testing.T) {
+	wasmPath := findRepoArtifact(t, "docs", "examples", "routing-policies",
+		"wasm", "app-mux", "app-mux.wasm")
+	if wasmPath == "" {
+		t.Skip("app-mux.wasm not built")
+	}
+	pe, err := loadPolicyEngine("@"+wasmPath, nil, nil)
+	if err != nil {
+		t.Fatalf("loadPolicyEngine: %v", err)
+	}
+	defer pe.engine.Close() //nolint:errcheck
+
+	// Same expectations as the wasm package's own
+	// TestWasmEvaluator_DecidesByApp — but here we go through
+	// the visor-side helper, which is what production code uses.
+	cases := []struct {
+		app         string
+		wantMux     int
+		wantMinHops int
+	}{
+		{"vpn-client", 4, 2},
+		{"skychat", 1, 0},
+		{"skysocks-client", 0, 0},
+	}
+	for _, c := range cases {
+		spec, err := pe.engine.Decide(context.Background(),
+			policy.RoutingContext{App: c.app}, nil)
+		if err != nil {
+			t.Errorf("Decide(%s): %v", c.app, err)
+			continue
+		}
+		if spec.Mux != c.wantMux {
+			t.Errorf("Decide(%s): Mux=%d, want %d", c.app, spec.Mux, c.wantMux)
+		}
+		if spec.MinHops != c.wantMinHops {
+			t.Errorf("Decide(%s): MinHops=%d, want %d", c.app, spec.MinHops, c.wantMinHops)
+		}
+	}
+}
+
+func TestHookRegisterApp_ReturnsPrevForRuntimeSwap(t *testing.T) {
+	wasmPath := findRepoArtifact(t, "docs", "examples", "routing-policies",
+		"wasm", "app-mux", "app-mux.wasm")
+	if wasmPath == "" {
+		t.Skip("app-mux.wasm not built")
+	}
+
+	pe1, err := loadPolicyEngine("@"+wasmPath, nil, nil)
+	if err != nil {
+		t.Fatalf("load #1: %v", err)
+	}
+	pe2, err := loadPolicyEngine("@"+wasmPath, nil, nil)
+	if err != nil {
+		t.Fatalf("load #2: %v", err)
+	}
+	defer pe2.engine.Close() //nolint:errcheck
+
+	hook := policy.NewHook(nil)
+
+	// First registration returns nil (no prior engine).
+	if prev := hook.RegisterApp("vpn-client", pe1.engine); prev != nil {
+		t.Errorf("first RegisterApp returned non-nil prev: %v", prev)
+	}
+	// Second registration returns the first engine — caller is
+	// expected to Close it. SetAppRoutingPolicy's runtime swap
+	// path relies on this contract.
+	prev := hook.RegisterApp("vpn-client", pe2.engine)
+	if prev == nil {
+		t.Fatalf("second RegisterApp returned nil prev, want pe1.engine")
+	}
+	if prev != pe1.engine {
+		t.Errorf("RegisterApp returned wrong prev engine")
+	}
+	if err := prev.Close(); err != nil {
+		t.Errorf("Close prev: %v", err)
+	}
+
+	// Nil engine clears the registration; returns the current.
+	prev2 := hook.RegisterApp("vpn-client", nil)
+	if prev2 != pe2.engine {
+		t.Errorf("RegisterApp(nil) returned wrong prev engine")
+	}
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -205,6 +205,10 @@ func (proxyDefaultAPI) StartAppWithMode(_ string, _ string) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) SetAppRoutingPolicy(_ string, _ string) error {
+	return ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) AddApp(_ string, _ string) error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -111,6 +111,15 @@ type StartAppIn struct {
 	AppName      string
 	LauncherMode string // "internal", "external", or "" for default
 }
+
+// SetAppRoutingPolicyIn carries (app name, policy-path) for the
+// runtime per-app routing-policy swap RPC. Path forms match the
+// config field: "@/path.star", "@/path.wasm", inline-Starlark,
+// or "" / "none" to clear.
+type SetAppRoutingPolicyIn struct {
+	AppName string
+	Path    string
+}
 type SetAppAddIn struct {
 	AppName    string
 	BinaryName string

--- a/pkg/visor/rpc_apps.go
+++ b/pkg/visor/rpc_apps.go
@@ -58,6 +58,15 @@ func (r *RPC) StartApp(in *StartAppIn, _ *struct{}) (err error) {
 	return r.visor.StartAppWithMode(in.AppName, in.LauncherMode)
 }
 
+// SetAppRoutingPolicy installs (or clears, when Path is empty
+// / "none") a per-app routing-policy override at runtime.
+// Backend dispatched by file extension; the running app picks
+// up the change on its next dial.
+func (r *RPC) SetAppRoutingPolicy(in *SetAppRoutingPolicyIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetAppRoutingPolicy", in)(nil, &err)
+	return r.visor.SetAppRoutingPolicy(in.AppName, in.Path)
+}
+
 // AddApp add app to config
 func (r *RPC) AddApp(in *SetAppAddIn, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "AddApp", in)(nil, &err)

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -347,6 +347,14 @@ func (rc *rpcClient) StartAppWithMode(appName, launcherMode string) error {
 	}, &struct{}{})
 }
 
+// SetAppRoutingPolicy calls SetAppRoutingPolicy.
+func (rc *rpcClient) SetAppRoutingPolicy(appName, path string) error {
+	return rc.Call("SetAppRoutingPolicy", &SetAppRoutingPolicyIn{
+		AppName: appName,
+		Path:    path,
+	}, &struct{}{})
+}
+
 // AddApp calls AddApp.
 func (rc *rpcClient) AddApp(appName, binaryName string) error {
 	return rc.Call("AddApp", &SetAppAddIn{

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -298,6 +298,11 @@ func (*mockRPCClient) StartAppWithMode(string, string) error {
 	return nil
 }
 
+// SetAppRoutingPolicy implements API.
+func (*mockRPCClient) SetAppRoutingPolicy(string, string) error {
+	return nil
+}
+
 // AddApp implement API.
 func (*mockRPCClient) AddApp(string, string) error {
 	return nil

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -399,38 +399,24 @@ type Routing struct {
 	TransportPreference []string `json:"transport_preference,omitempty"`
 
 	// PolicyPerDial is an optional operator-supplied routing
-	// policy script (Starlark, RFC #2882). Accepts either:
-	//   "@/path/to/policy.star"  — file-backed, hot-reloaded
-	//   "<inline script source>" — small inline policies
+	// policy. Accepts either:
+	//   "@/path/to/policy.star"  — Starlark, file-backed, hot-reloaded
+	//   "@/path/to/policy.wasm"  — WASM, file-backed, hot-reloaded
+	//   "<inline script source>" — small inline Starlark policies
 	//   "" / unset                — no policy, built-in defaults
 	//
-	// The script's decide_route(ctx, candidates) function is
-	// called per dial; its returned RouteSpec adjusts MuxRoutes
-	// and MinHops, and can refuse the dial via fallback="drop".
+	// The visor picks the backend by file extension when the
+	// value starts with "@" (`.wasm` → WASM, anything else →
+	// Starlark). Inline values are always Starlark — compiled
+	// WASM doesn't fit in a JSON string. Both backends produce
+	// the same RouteSpec per dial and route through the same
+	// router.DialHook.
 	//
-	// See docs/routing_policy_rfc.md for the policy DSL design,
-	// docs/examples/routing-policies/ for example scripts, and
-	// `skywire cli route policy test/bench` for iteration tools.
+	// See docs/routing_policy_rfc.md for the Starlark DSL,
+	// docs/examples/routing-policies/wasm/README.md for the
+	// WASM ABI + trade-offs, and `skywire cli route policy
+	// test/bench` for iteration tools.
 	PolicyPerDial string `json:"policy_per_dial,omitempty"`
-
-	// PolicyPerDialWasm is the WASM-policy alternative to
-	// PolicyPerDial. Accepts "@/path/to/policy.wasm" only —
-	// inline modules aren't supported. The compiled module must
-	// export decide_route + alloc + free (and optionally
-	// on_leg_change) per the wire-format ABI in
-	// pkg/router/policy/wasm/abi.go. When both PolicyPerDial and
-	// PolicyPerDialWasm are set, PolicyPerDialWasm wins on the
-	// visor-wide default; the skylark loader still owns per-app
-	// overrides via AppConfig.RoutingPolicy.
-	//
-	// Trade-offs (see docs/examples/routing-policies/wasm/README.md):
-	//   skylark — text source, sub-second hot-reload, ~10 LoC
-	//             policies; the right default for casual policies.
-	//   wasm    — compiled artifact, near-native perf, Go/Rust/
-	//             AssemblyScript/etc.; the right choice for
-	//             power users with existing Go-WASM experience
-	//             or per-flow stateful policies.
-	PolicyPerDialWasm string `json:"policy_per_dial_wasm,omitempty"`
 }
 
 // UptimeTracker configures uptime tracker.


### PR DESCRIPTION
## Summary

Re-applies the two follow-up commits from #2913 that didn't land when \`gh pr merge --auto\` fired on commit 1 before commits 2 + 3 were pushed. Two pieces:

1. **Extension-dispatch** — collapse \`policy_per_dial\` + \`policy_per_dial_wasm\` into a single field that picks the backend by file extension (\`.star\` → Starlark, \`.wasm\` → WASM). Same dispatch on the per-app \`launcher.apps[].routing_policy\` field so it's WASM-capable too.

2. **Runtime per-app override** — new \`SetAppRoutingPolicy(name, path)\` RPC + \`cli visor app start <name> --routing-policy @/path\` CLI flag. Lets operators swap a per-app policy live without editing config + restarting the visor.

## What changed since the original commits

Conflict in \`pkg/router/policy/hook.go\` between this PR's mutex / SetDefault / RegisterApp-return-prev and #2918's Snapshot method. Resolved by keeping all four — Snapshot now takes the RLock (matching the runtime-safe pattern), so live SetAppRoutingPolicy calls are race-free against the hypervisor UI's polling read.

## Refactor A — extension dispatch

- Drops the \`PolicyPerDialWasm\` config field. \`policy_per_dial\` accepts both \`.star\` and \`.wasm\` paths.
- \`pkg/visor/policy_loader.go\` — new internal helper \`loadPolicyEngine\` that takes the raw config value, instantiates the matching loader, and returns a \`policyEngine\` (engine + watch + close-stack tag). Used by both visor-wide and per-app wiring in \`init_router.go\`.
- \`pkg/visor/init_router.go\` — switch+two-branch block collapses to one helper call. Also: a Hook is now **always installed** (even when no policy is configured at startup) so the runtime swap path can find it. Empty Hook is zero-cost — \`BeforeDial\` / \`SelectRoute\` / \`OnLegChange\` / \`OnTick\` all early-return when \`loader == nil\`.
- \`pkg/visor/visorconfig/v1.go\` — drops \`PolicyPerDialWasm\`.
- \`pkg/app/appserver/spec/spec.go\` — \`RoutingPolicy\` doc updated to list both extensions.
- \`docs/examples/routing-policies/wasm/README.md\` + \`.../app-mux/main.go\` — reference the single field.

## Refactor B — runtime per-app routing-policy override

- \`pkg/router/policy/hook.go\` — \`Hook\` gains \`sync.RWMutex\` around \`loader\` + \`byApp\`. Adds \`SetDefault(Engine) Engine\` and changes \`RegisterApp\` to return the displaced Engine so runtime callers can \`Close\` it. \`Snapshot\` now takes the RLock. \`loaderFor\` (hot path on every dial) takes only an RLock.
- \`pkg/visor/api.go\`, \`rpc.go\`, \`rpc_apps.go\`, \`rpc_client.go\`, \`rpc_client_mock.go\`, \`proxy_default_api.go\` — new \`SetAppRoutingPolicy(appName, path) error\` entry on \`visor.API\`; full RPC + client wiring.
- \`pkg/visor/api_apps.go\` — \`SetAppRoutingPolicy\` impl: pulls the running router's hook via \`DialHook()\`, instantiates the engine through \`loadPolicyEngine\` (same dispatch as init), starts its file watcher, swaps via \`hook.RegisterApp\`, closes the displaced engine.
- \`cmd/skywire-cli/commands/visor/app.go\` — \`cli visor app start <name>\` gets a \`--routing-policy\` flag. Fires \`SetAppRoutingPolicy\` before \`StartApp\` so the policy is live by the time the app makes its first dial. Passing \`\"\"\` or \`\"none\"\` clears a previously-installed runtime override.

## Tests

- \`pkg/visor/policy_loader_test.go\` (re-applied from #2913's commit 3):
  - \`TestLoadPolicyEngine_DispatchesByExtension\` — \`.wasm\` path picks WASM, empty / \"none\" returns nil engine.
  - \`TestLoadPolicyEngine_DecidesViaWASM\` — round-trips through \`policy.Engine.Decide\` and produces the app-mux RouteSpec (vpn-client → mux=4 min_hops=2, skychat → mux=1).
  - \`TestHookRegisterApp_ReturnsPrevForRuntimeSwap\` — first registration returns nil prev, second returns the displaced engine, \`RegisterApp(name, nil)\` clears.

## Test plan

- [x] \`go build ./\`
- [x] \`go vet ./pkg/router/... ./pkg/visor/... ./cmd/skywire-cli/...\`
- [x] \`go test ./pkg/router/policy/... ./pkg/visor/\` — all green.
- [ ] Runtime: live-verified against the running visor in #2913 (all five flag paths returned OK, including extension-dispatch picking Starlark vs WASM). Will re-verify after this lands.

## Context: how this got lost

\`gh pr merge 2913 --auto --squash\` was armed right after I pushed the first commit. CI passed quickly on the first commit; auto-merge fired and squash-merged it onto develop before my next two commits made it onto the PR branch. The follow-up commits stayed on \`origin/feat/routing-policy-wasm\` and have been sitting there. Cherry-picked here as the recovery path. Tracked by feedback memory \`feedback_verify_pr_state.md\`.