### PR TITLE
fix(router): start rotation loop from SetRotation, not init

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -579,6 +579,16 @@ func (rg *RouteGroup) SetRotation(hook RotationHook, applyAdd func(excludeHops [
 	rg.rotationApplyAdd = applyAdd
 	rg.rotationInterval = interval
 	rg.mu.Unlock()
+	// Start the rotation goroutine now (startOffServiceLoops fired
+	// during initial setup before SetRotation was called, so the
+	// conditional in startOffServiceLoops saw zero values and didn't
+	// spawn this loop). Safe to call here because the loop checks
+	// the same close channels (rg.closed / rg.remoteClosed) that
+	// startOffServiceLoops' loops do — a Close() racing with
+	// SetRotation just terminates the loop immediately.
+	if interval > 0 && hook != nil {
+		go rg.servicePacketLoop("rotation", interval, rg.rotationServiceFn)
+	}
 }
 
 // snapshotLegs builds a []LegInfo from the current rg.tps. Caller
@@ -834,13 +844,10 @@ func (rg *RouteGroup) RouteHopDetails() []RouteHopInfo {
 func (rg *RouteGroup) startOffServiceLoops() {
 	go rg.servicePacketLoop("keep-alive", rg.cfg.KeepAliveInterval, rg.keepAliveServiceFn)
 	// Note: Automatic ping loop removed. Latency is now measured once at transport creation.
-	// Rotation loop: only starts when the dialing-side policy
-	// returned a non-zero RotationIntervalSeconds in decide_route.
-	// Accept-side route groups (no policy) have rotationInterval=0
-	// and skip this entirely.
-	if rg.rotationInterval > 0 && rg.rotationHook != nil {
-		go rg.servicePacketLoop("rotation", rg.rotationInterval, rg.rotationServiceFn)
-	}
+	// Rotation loop is NOT started here — startOffServiceLoops runs
+	// during initial route-group setup, before the router-side
+	// SetRotation call wires the hook + interval. SetRotation spawns
+	// the rotation goroutine itself.
 }
 
 // rotationServiceFn fires the policy's on_tick hook against the


### PR DESCRIPTION
## Summary

PR #2916's rotation \`servicePacketLoop\` was wired up in \`startOffServiceLoops\` with a \`rotationInterval > 0 && rotationHook != nil\` guard. Problem: \`startOffServiceLoops\` runs during initial route-group setup, BEFORE the router-side \`SetRotation\` call in \`router_dial.go\` wires the hook + interval. Both fields are zero at check time, so the rotation goroutine never spawns even when the policy returned a non-zero \`RotationIntervalSeconds\`.

## Found via live test

Loaded the rotating-bw.wasm policy (\`mux=4\`, \`rotation_interval_seconds=90\`, \`distribution=\"weighted: 1,1,1,1\"\`) on a running visor, brought up a route group to a known peer (skysocks-client → Beta's proxy server). decide_route fired and applied mux=4 + distribution correctly:

\`\`\`
DEBUG [RouteGroup ... :49156, ... :3]:
  Route group distribution applied.
  app_name=skysocks-client distribution=weighted legs=4 weights=[1 1 1 1]
\`\`\`

But across the first 90s rotation tick window: zero rotation events in the log. The route group sat at 4 legs indefinitely.

## Fix

\`SetRotation\` spawns the rotation goroutine itself. \`startOffServiceLoops\` drops the dead conditional.

\`\`\`go
func (rg *RouteGroup) SetRotation(hook RotationHook, applyAdd func([]string), interval time.Duration) {
    rg.mu.Lock()
    rg.rotationHook = hook
    rg.rotationApplyAdd = applyAdd
    rg.rotationInterval = interval
    rg.mu.Unlock()
    if interval > 0 && hook != nil {
        go rg.servicePacketLoop(\"rotation\", interval, rg.rotationServiceFn)
    }
}
\`\`\`

## Race-safety

\`servicePacketLoop\` exits cleanly on \`rg.closed\` / \`rg.remoteClosed\` regardless of when it starts, so spawning from \`SetRotation\` doesn't break shutdown ordering. \`SetRotation\` is called once per route group (from \`DialRoutes\`, after \`SetLegChangeHook\`); a \`Close()\` racing with \`SetRotation\` just terminates the loop immediately, no leak.

## Test plan

- [x] \`go build ./\`
- [x] \`go test ./pkg/router/policy/...\` — all green.
- [ ] Runtime re-verification: after the visor restart-loop picks up this fix, re-run the same rotating-bw setup against Beta's proxy server and confirm \"Rotation aux leg established\" / \"Rotation hook dropped legs\" events fire on the 90s tick window.