### PR TITLE
fix(transport): count VStream + ping bytes in sent counter

### DIFF
--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -413,7 +413,9 @@ func (mt *ManagedTransport) tickPing() {
 	}
 }
 
-// sendTransportPing writes a transport-level ping packet.
+// sendTransportPing writes a transport-level ping packet. Bytes are
+// logged via logSent so they show up symmetrically with the pong
+// the peer's readPacket logs via logRecv.
 func (mt *ManagedTransport) sendTransportPing() {
 	mt.transportMx.Lock()
 	tp := mt.transport
@@ -423,12 +425,19 @@ func (mt *ManagedTransport) sendTransportPing() {
 	}
 
 	p := routing.MakeTransportPingPacket(time.Now().UnixNano())
-	if _, err := tp.Write(p); err != nil {
+	n, err := tp.Write(p)
+	if err != nil {
 		mt.log.WithError(err).Debug("Failed to send transport ping")
+		return
+	}
+	if n > routing.PacketHeaderSize {
+		mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
 	}
 }
 
 // handleTransportPing responds to a transport-level ping with a pong.
+// Pong bytes are logged via logSent for the same reason as
+// sendTransportPing.
 func (mt *ManagedTransport) handleTransportPing(p routing.Packet) {
 	payload := p.Payload()
 	if len(payload) < routing.TransportPingPayloadSize {
@@ -444,8 +453,13 @@ func (mt *ManagedTransport) handleTransportPing(p routing.Packet) {
 	}
 
 	pong := routing.MakeTransportPongPacket(timestamp)
-	if _, err := tp.Write(pong); err != nil {
+	n, err := tp.Write(pong)
+	if err != nil {
 		mt.log.WithError(err).Debug("Failed to send transport pong")
+		return
+	}
+	if n > routing.PacketHeaderSize {
+		mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
 	}
 }
 
@@ -743,19 +757,36 @@ func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Pack
 }
 
 // WriteRawPacket writes a pre-constructed packet to the transport.
-// Used by the cascade handler to send ACKs and relay messages on route ID 0.
+// Used by the cascade handler and VStreamMux to send route-ID-0
+// traffic (cascade RPC, DHT, VStream / sky_forward_conn direct
+// dials).
+//
+// Logs the payload bytes via logSent so bandwidth accounting
+// matches WritePacket's behavior. Without this, every direct-
+// dial byte sent by sky_forward_conn (skysocks-client / vpn-
+// client / skynet-client over a direct stcpr/sudph transport)
+// was invisible to the bandwidth counters — only inbound bytes
+// got counted via readPacket, producing the systematic
+// "sent>>recv" or "recv>>sent" asymmetry seen on per-transport
+// metrics for visors that use direct-dial heavily. The recv
+// counter has always counted all packets because readPacket
+// is the only inbound path.
 func (mt *ManagedTransport) WriteRawPacket(packet routing.Packet) error {
 	mt.transportMx.Lock()
 	if mt.transport == nil {
 		mt.transportMx.Unlock()
 		return fmt.Errorf("write raw packet: transport not set up")
 	}
-	_, err := mt.transport.Write(packet)
+	n, err := mt.transport.Write(packet)
 	mt.transportMx.Unlock()
 	if err != nil {
 		mt.close()
+		return err
 	}
-	return err
+	if n > routing.PacketHeaderSize {
+		mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
+	}
+	return nil
 }
 
 // WARNING: Not thread safe.


### PR DESCRIPTION
## Summary

**Critical for bandwidth-rewards.** Three transport-level write paths were bypassing \`logSent\` while \`readPacket\` counted everything via \`logRecv\` — producing a systematic asymmetry on per-transport bandwidth metrics. With the fix in place, all four write paths increment the sent counter.

## Missing send paths

| Path | What flows through it | Was logged? |
|---|---|---|
| \`WritePacket\` | routed app/keep-alive/close packets | ✅ |
| \`WriteRawPacket\` | **VStreamMux (sky_forward_conn direct dials), cascade RPC** | ❌ → ✅ |
| \`sendTransportPing\` | 60s transport-level liveness ping | ❌ → ✅ |
| \`handleTransportPing\` | the pong-respond half | ❌ → ✅ |

\`readPacket\` was already counting all inbound bytes — pings, pongs, VStream payload, cascade ACKs. So the asymmetry was strictly one-sided: **sent under-reports; recv was accurate.**

## Why this matters for bandwidth-rewards

A per-visor reward attribution would pay a visor only for inbound bytes on a direct-dial transport, not the outbound bytes it also moved. A skysocks-client proxying HTTP responses to a peer over direct stcpr would be entirely uncompensated for the response data it serves.

## Observed impact (current state)

\`skywire cli tp metrics --by-transport -p <pk>\` on direct-dial-heavy visors shows entries like:

\`\`\`
sent=2.75MB  recv=0B
sent=0B      recv=3.83MB
\`\`\`

Same transport viewed from BOTH edges renders \"0 in one column\" because \`verifiedBandwidth = min(A.Sent, B.Recv)\` and the absent VStream-outbound count zeros out one of the directions even when both edges accurately report what they read inbound.

## Fix shape

Each of the three missing paths now does:

\`\`\`go
if n > routing.PacketHeaderSize {
    mt.logSent(uint64(n - routing.PacketHeaderSize))
}
\`\`\`

matching \`WritePacket\`'s existing behavior. \`PacketHeaderSize\` subtraction is consistent with the inbound side (\`readPacket\`), so the counters track payload bytes, not bytes-on-wire — that asymmetry has always been present and intentional.

## Full pipeline audit

Confirmed clean below the visor layer:

- **Latency**: per-side ping → own pong → \`SetLatency\` ✅ outlier-clamped at \`MaxReasonableRTTMs=30s\`
- **CXO push**: symmetric \`liveSnapshot\` JSON, per-reporter delta with counter-reset detection
- **TPD verification**: \`min(A.Sent, B.Recv)\` and \`min(A.Recv, B.Sent)\` — correct math, was just receiving incomplete inputs from the visor

## Test plan

- [x] \`go build ./pkg/transport/...\`
- [x] \`go test ./pkg/transport/\` — passes.
- [ ] Live re-verification: after this lands, run \`cli tp metrics --by-transport\` on a visor doing direct-dial work and confirm per-transport entries show non-zero in BOTH \`sent\` and \`recv\` columns where direct-dial bidirectional traffic flowed.