### PR TITLE
fix(router): tune circuit breaker for dmsg-session refresh cadence

### DIFF
--- a/pkg/router/setupmetrics/stats.go
+++ b/pkg/router/setupmetrics/stats.go
@@ -98,16 +98,35 @@ const (
 const (
 	// circuitFailureThreshold is the number of consecutive failures
 	// to a destination that trips the breaker to OPEN.
-	circuitFailureThreshold = 5
+	//
+	// Lowered from 5 → 3 after the 1.3.59-era observation that
+	// dmsg-error-202 (intermediate's stale dmsg session) consistently
+	// produces 3+ failures back-to-back; tolerating 5 wastes the next
+	// two setup attempts on doomed routes. With the open duration
+	// tuned to dmsg-session-refresh cadence (below), tripping earlier
+	// is the right balance.
+	circuitFailureThreshold = 3
 	// circuitOpenDuration is how long the breaker stays OPEN before
 	// transitioning to HALF_OPEN to allow a probe setup.
-	circuitOpenDuration = 60 * time.Second
+	//
+	// Bumped from 60s → 5min to align with dmsg's own session-refresh
+	// cadence (~5min). dmsg-error-202 means a visor is registered in
+	// dmsg-disc but its actual delegated-server session is stale; the
+	// session re-publishes itself on a ~5min cycle, so retrying inside
+	// that window is doomed to hit the same stale state. 60s let
+	// half-open probes burn through the same failure on every cycle.
+	circuitOpenDuration = 5 * time.Minute
 	// circuitMaxOpenDuration is the maximum time a breaker can stay
 	// in the open/half_open cycle before being force-reset to closed.
 	// This prevents permanent lockout when the RSN's own DMSG sessions
 	// are stale but the destination is actually alive — fresh traffic
 	// will establish new DMSG paths.
-	circuitMaxOpenDuration = 10 * time.Minute
+	//
+	// Bumped from 10min → 30min in concert with the longer open
+	// duration; with 5min between half-open probes, 10min is only two
+	// retry windows which is tight for a genuinely-down peer waiting
+	// to come back. 30min gives ~6 half-open probes before force-reset.
+	circuitMaxOpenDuration = 30 * time.Minute
 	// circuitFailureWindow bounds how long consecutive failures must
 	// occur within to count toward the threshold. Failures older than
 	// this window are considered stale and the consecutive counter is


### PR DESCRIPTION
## Summary

Three changes to the per-destination/intermediate circuit breaker in \`setupmetrics\`. The current settings (5-failure threshold + 60-second open) were tuned before the \`dmsg-error-202\` failure mode was the dominant intermediate-fail signal.

\`dmsg-error-202\` = \"cannot connect to delegated server\" — the intermediate is registered in dmsg-disc with a stale delegated server (visor restarted, dmsg session dropped, etc.). dmsg clients re-publish their session-set on a ~5-minute cadence, so the failure persists for up to 5 minutes regardless of how many retries the caller throws at it. With circuit-open at 60s, half-open probes burned the next 4 setup attempts on the same known-bad intermediate before finally tripping again.

## Changes

| const | old | new | why |
|---|---|---|---|
| \`circuitFailureThreshold\` | 5 | **3** | dmsg-error-202 produces 3+ back-to-back failures consistently |
| \`circuitOpenDuration\` | 60s | **5 min** | aligns with dmsg session-refresh cadence |
| \`circuitMaxOpenDuration\` | 10 min | **30 min** | companion bump; ~6 half-open probes vs. 2 |

## Motivation

Captured during live testing of the rotation hook (see #2916 / #2925). Every multi-hop route setup attempt to a peer with one persistently-broken intermediate (\`02fab97b...\`) hit \`dmsg error 202\` on every retry until the breaker tripped, then **re-tripped every minute when the half-open probe re-failed**. With these settings, the breaker absorbs that intermediate for 5 minutes per trip, freeing the route-finder to try the (3+) other healthy candidates the route-finder offered.

## Tests

\`pkg/router/setupmetrics/stats_test.go\` references the constants by name, not by literal — all 13 subtests pass with the new values, including the per-intermediate breaker tests from #2750.

## Follow-up (separate PR)

A passive \"I have a live dmsg session to this PK\" reachability filter would bias route-finder candidates toward intermediates the local visor has recently exchanged dmsg traffic with. That's orthogonal to breaker tuning and benefits from this PR landing first.