### PR TITLE
fix(autoconfig): propagate -p/-u to cli config gen so writes hit the resolved path

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -485,23 +485,53 @@ func resolveConfig() resolvedConfig {
 }
 
 // generateConfig invokes `skywire cli config gen` with regen +
-// hide flags. -p/-u are NOT passed: cli config gen reads PKGENV /
-// USRENV from the SKYENV file via scriptExecBool, so the env-var
-// path picks up the same resolution autoconfig made — without
-// hard-coding the mode in the args (the operator's intent lives in
-// /etc/skywire.conf, not in this Cmd line).
+// hide flags. -p/-u is propagated from the autoconfig-resolved mode
+// so cli config gen writes to the SAME absolute config path that
+// autoconfig resolved.
+//
+// History: an earlier version intentionally OMITTED -p/-u under the
+// theory that cli config gen would re-derive PKGENV/USRENV from the
+// SKYENV file via scriptExecBool. That theory only holds when
+// PKGENV=true (or USRENV=true) is set explicitly in /etc/skywire.conf.
+// In the common operator case where neither key is set,
+// resolveConfig auto-elects pkgEnv via `os.Geteuid() == 0`, but cli
+// config gen — running as a separate process — sees both flags
+// default to false, falls through to the relative-path branch in
+// PreRun (`confPath = skyenv.ConfigName`), and writes
+// `skywire-config.json` to the autoconfig invoker's cwd (typically
+// /root/). The pre-existing `/opt/skywire/skywire.json` stayed
+// untouched, autoconfig's downstream `os.Stat` check passed against
+// the stale file, the visor restarted on its old config, and
+// `cli config show .hypervisors` returned `[]` even though
+// HYPERVISORPKS / ISHYPERVISOR were set in the env file. Propagating
+// -p/-u from resolvedConfig closes the gap.
 func generateConfig(r resolvedConfig, hvArg string) error {
 	// printableArgs is what we PRINT for the operator to copy-paste.
 	// Intentionally omits -w (we suppress the noisy fetch logs
-	// ourselves) and -p/-u (resolved via SKYENV vars). If the
-	// install fails, the operator can paste this exact line and see
-	// the full debug logging that we hid.
+	// ourselves). If the install fails, the operator can paste this
+	// exact line and see the full debug logging that we hid.
 	printableArgs := []string{"cli", "config", "gen", "-r"}
 
 	// args is what we ACTUALLY pass. -w suppresses the success-path
 	// JSON dump (echoing the SK + every service URL on every install
 	// is noisy and a perceived secret-leak risk on shared terminals).
 	args := []string{"cli", "config", "gen", "-r", "-w"}
+
+	// Pin the write target to the same mode autoconfig resolved.
+	// Without this, cli config gen's own scriptExecBool defaults
+	// (`${PKGENV:-false}` / `${USRENV:-false}`) silently mis-resolve
+	// to false when the env file doesn't set those keys explicitly,
+	// and gen writes to a cwd-relative path instead of the absolute
+	// /opt/skywire/skywire.json (PKGENV) or ~/skywire-config.json
+	// (USRENV) that autoconfig already stat-checks downstream.
+	switch {
+	case r.usrEnv:
+		args = append(args, "-u")
+		printableArgs = append(printableArgs, "-u")
+	case r.pkgEnv:
+		args = append(args, "-p")
+		printableArgs = append(printableArgs, "-p")
+	}
 
 	switch hvArg {
 	case "0":


### PR DESCRIPTION
## Summary

`skywire autoconfig` was silently writing the regenerated config to `./skywire-config.json` (cwd-relative) instead of `/opt/skywire/skywire.json` (or `~/skywire-config.json`) when the operator's `/etc/skywire.conf` didn't explicitly set `PKGENV=true` (or `USRENV=true`).

Effect on operators: `HYPERVISORPKS=('…')` + `ISHYPERVISOR=true` in `/etc/skywire.conf` → autoconfig appears to succeed (prints "Skywire configuration updated", "config path: /opt/skywire/skywire.json", "Restarting skywire service…"), but `cli config show .hypervisors` returns `[]` because the visor restarted on the stale pre-existing config — the new config was written to `/root/skywire-config.json` and never read.

## Root cause

`autoconfig`'s `resolveConfig()` auto-elects pkgEnv when `os.Geteuid() == 0` AND neither `PKGENV` nor `USRENV` is set explicitly in the env file. But `generateConfig` was deliberately not propagating `-p`/`-u` to `cli config gen`, under the assumption the child would re-derive the same mode from `SKYENV`. That assumption holds only when `PKGENV=true` is explicit in the env file. In the common case where it isn't, the child sees both flags default to false via `scriptExecBool("${PKGENV:-false}")`, falls through to PreRun's relative-path branch (`confPath = skyenv.ConfigName`), and writes a `skywire-config.json` to cwd.

## Fix

Propagate `-p` / `-u` from the autoconfig-resolved mode. The mode is already known at `generateConfig` call time.

## Test plan

- [x] `go test ./cmd/skywire/commands/...`
- [x] Reproduced bug + verified fix locally: `SKYENV=/etc/skywire.conf skywire cli config gen -w -p` writes to `/opt/skywire/skywire.json` (permission denied without sudo, but correct path); without `-p` it writes `skywire-config.json` to cwd
- [x] gofmt clean
- [x] Tag-on-merge for v1.3.61