### PR TITLE
fix(lint): clear pre-existing lint debt (wasm policy gosec/gofmt + cxo connmap errcheck)

### DIFF
--- a/pkg/cxo/node/connmap_test.go
+++ b/pkg/cxo/node/connmap_test.go
@@ -26,8 +26,14 @@ func TestAddrConnMap_ReservePending_Idempotent(t *testing.T) {
 	c1 := &Conn{}
 	c2 := &Conn{}
 
-	_, _, isNew1, _ := m.reservePending(addr, c1, nil)
-	existing, isPending, isNew2, _ := m.reservePending(addr, c2, nil)
+	_, _, isNew1, err := m.reservePending(addr, c1, nil)
+	if err != nil {
+		t.Fatalf("first reserve errored: %v", err)
+	}
+	existing, isPending, isNew2, err := m.reservePending(addr, c2, nil)
+	if err != nil {
+		t.Fatalf("second reserve errored: %v", err)
+	}
 
 	if !isNew1 {
 		t.Fatalf("first reserve should be new")
@@ -58,7 +64,9 @@ func TestAddrConnMap_Promote_IdentityCheck(t *testing.T) {
 	live := &Conn{}
 
 	// Stale path goes through reserve → promote.
-	m.reservePending(addr, stale, nil)
+	if _, _, _, err := m.reservePending(addr, stale, nil); err != nil {
+		t.Fatalf("reserve stale errored: %v", err)
+	}
 	m.promote(addr, stale)
 	if got := m.activeLen(); got != 1 {
 		t.Fatalf("active len after stale promote: got %d, want 1", got)
@@ -66,7 +74,9 @@ func TestAddrConnMap_Promote_IdentityCheck(t *testing.T) {
 
 	// Live replacement: a new Conn takes the same addr slot.
 	m.removeActive(addr, stale)
-	m.reservePending(addr, live, nil)
+	if _, _, _, err := m.reservePending(addr, live, nil); err != nil {
+		t.Fatalf("reserve live errored: %v", err)
+	}
 	m.promote(addr, live)
 
 	// A late "remove stale" must not wipe the live slot.
@@ -118,7 +128,10 @@ func TestAddrConnMap_ConcurrentInsertsDifferentShards(t *testing.T) {
 		c := &Conn{}
 		go func() {
 			defer wg.Done()
-			_, _, isNew, _ := m.reservePending(addr, c, nil)
+			_, _, isNew, err := m.reservePending(addr, c, nil)
+			if err != nil {
+				t.Errorf("reserve for unique addr %q errored: %v", addr, err)
+			}
 			if !isNew {
 				t.Errorf("reserve for unique addr %q reported not new", addr)
 			}

--- a/pkg/router/policy/wasm/evaluator.go
+++ b/pkg/router/policy/wasm/evaluator.go
@@ -6,7 +6,7 @@
 //   - alloc(size: i32) → ptr: i32      // host-driven malloc
 //   - free(ptr: i32, size: i32)        // host-driven free
 //   - decide_route(in_ptr: i32, in_len: i32) → packed: i64
-//                                       // packed = ptr | len<<32
+//     (packed = ptr | len<<32)
 //
 // Optional:
 //   - on_leg_change(in_ptr: i32, in_len: i32) → packed: i64
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -33,6 +34,21 @@ import (
 
 	"github.com/skycoin/skywire/pkg/router/policy"
 )
+
+// wasmPtr narrows a wazero alloc/return result (uint64) to the uint32
+// WASM32 linear-memory pointer it always is in practice. wazero runs
+// guests in a 32-bit address space, so alloc can only ever hand back a
+// value that fits in uint32 — but gosec (G115) can't know that, and a
+// bare uint32(v) conversion reads as a potential silent truncation.
+// The explicit MaxUint32 guard makes the safety provable to the linter
+// and turns the impossible-in-practice overflow into a loud failure
+// instead of a wrapped pointer.
+func wasmPtr(v uint64) (uint32, bool) {
+	if v > math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(v), true
+}
 
 // Clock mirrors policy.Clock so the wasm evaluator can be
 // driven by an injected clock in tests.
@@ -250,7 +266,10 @@ func (e *Evaluator) callRotation(ctx context.Context, fn api.Function, name stri
 	if err != nil || len(allocRes) == 0 {
 		return RotationActionWire{}, fmt.Errorf("wasm: alloc for %s failed: %v", name, err)
 	}
-	inPtr := uint32(allocRes[0])
+	inPtr, ok := wasmPtr(allocRes[0])
+	if !ok {
+		return RotationActionWire{}, fmt.Errorf("wasm: alloc for %s returned out-of-range ptr %d", name, allocRes[0])
+	}
 	if ok := e.instance.Memory().Write(inPtr, jsonIn); !ok {
 		return RotationActionWire{}, fmt.Errorf("wasm: write %s input to memory failed", name)
 	}
@@ -322,7 +341,10 @@ func (e *Evaluator) call(ctx context.Context, fn api.Function, name string, inpu
 	if err != nil || len(allocRes) == 0 {
 		return RouteSpecWire{}, fmt.Errorf("wasm: alloc for %s failed: %v", name, err)
 	}
-	inPtr := uint32(allocRes[0])
+	inPtr, ok := wasmPtr(allocRes[0])
+	if !ok {
+		return RouteSpecWire{}, fmt.Errorf("wasm: alloc for %s returned out-of-range ptr %d", name, allocRes[0])
+	}
 	if ok := e.instance.Memory().Write(inPtr, jsonIn); !ok {
 		return RouteSpecWire{}, fmt.Errorf("wasm: write %s input to memory failed", name)
 	}

--- a/pkg/router/policy/wasm/host.go
+++ b/pkg/router/policy/wasm/host.go
@@ -64,7 +64,10 @@ func writeOutput(ctx context.Context, mod api.Module, data []byte) uint64 {
 	if err != nil || len(res) == 0 {
 		return 0
 	}
-	offset := uint32(res[0])
+	offset, ok := wasmPtr(res[0])
+	if !ok {
+		return 0
+	}
 	if ok := mod.Memory().Write(offset, data); !ok {
 		return 0
 	}

--- a/pkg/router/policy/wasm/loader_test.go
+++ b/pkg/router/policy/wasm/loader_test.go
@@ -14,7 +14,7 @@ import (
 // looking for the docs/examples/routing-policies/wasm/app-mux/
 // app-mux.wasm artifact. Returns "" when not found (caller
 // t.Skip's).
-func findExampleWASM(t *testing.T) string {
+func findExampleWASM() string {
 	_, here, _, _ := runtime.Caller(0)
 	repoRoot := here
 	for i := 0; i < 8; i++ {
@@ -28,7 +28,7 @@ func findExampleWASM(t *testing.T) string {
 }
 
 func TestWasmEvaluator_DecidesByApp(t *testing.T) {
-	wasmPath := findExampleWASM(t)
+	wasmPath := findExampleWASM()
 	if wasmPath == "" {
 		t.Skip("app-mux.wasm not built; run `tinygo build -target=wasi -no-debug -opt=2 -o app-mux.wasm .` in docs/examples/routing-policies/wasm/app-mux/")
 	}


### PR DESCRIPTION
Clears the 8 whole-tree lint failures that have been failing CI on every open PR. These live on `develop` itself — `.golangci.yml` runs with `issues.new: false` and `errcheck.check-blank: true`, so any PR's lint job re-reports them.

## Fixes
- **gofmt** (`evaluator.go`): re-flow a doc-comment continuation line gofmt rejected.
- **gosec G115** (`evaluator.go` ×2, `host.go` ×1): `uint32(allocRes[0])` / `uint32(res[0])` narrowings of wazero alloc results. wazero guests are wasm32 so these can't overflow, but gosec can't prove it — added a shared `wasmPtr(uint64) (uint32, bool)` helper with a `math.MaxUint32` guard. Real bounds check, not a `//nolint`.
- **unparam** (`loader_test.go`): dropped unused `t *testing.T` from `findExampleWASM`, updated the caller.
- **errcheck** (`connmap_test.go`): capture + assert the `err` return from `reservePending` at the four sites discarding it.

## Verification
- `golangci-lint run -c .golangci.yml --build-tags 'withoutsystray withoutgotop' ./...` → exit 0, zero issues (was 8)
- `go build ./...` clean
- `go test ./pkg/cxo/node/ ./pkg/router/policy/wasm/` → both pass

Once merged, the other open PRs (#2929, #2933, #2934) just need develop re-merged to go green.