### PR TITLE
feat(cli): --reconnect + --routing-policy on proxy start; --routing-policy on vpn start

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -84,6 +84,8 @@ func init() {
 	startCmd.Flags().Uint16Var(&minHops, "min-hops", 1, "minimum routing hops for this session (1=no minimum). Set on the visor before app start; rolled back is not automatic — restart visor or re-run with --min-hops=1 to revert.")
 	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream the visor's logs scoped to this app's session (app stdout + tagged router/mux/setup events); ctrl+c stops the proxy and exits")
 	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
+	startCmd.Flags().BoolVar(&reconnect, "reconnect", false, "in-process reconnect on stream failure (proxy keeps retrying instead of exiting)")
+	startCmd.Flags().StringVar(&startRoutingPolicy, "routing-policy", "", "per-app routing policy: @/path/to/policy.star or @/path/to/policy.wasm (\"\" or \"none\" clears any previously-installed override)")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")
 	dep := getDeployment()
@@ -109,6 +111,19 @@ func init() {
 	testCmd.Flags().StringVarP(&pk, "pk", "s", "", "test a specific proxy server by public key")
 	testCmd.Flags().StringVar(&viaVisor, "via", "", "test 2-hop routes via specified visor (queries TPD for its transports)")
 	testCmd.Flags().IntVar(&testDelay, "delay", 0, "delay in ms between dispatching tests (0=auto: 500ms for batch>1, 0 for batch=1)")
+}
+
+// applyRoutingPolicy installs (or clears) the per-app routing policy
+// for the given client before the app starts, but only when the
+// operator actually passed --routing-policy. Mirrors the behavior of
+// `cli visor app start --routing-policy`: install happens pre-start so
+// the very first dial the proxy makes already runs through the policy.
+// Passing "" / "none" clears a previously-installed override.
+func applyRoutingPolicy(cmd *cobra.Command, rpcClient visor.API, clientName string) {
+	if !cmd.Flags().Changed("routing-policy") {
+		return
+	}
+	internal.Catch(cmd.Flags(), rpcClient.SetAppRoutingPolicy(clientName, startRoutingPolicy))
 }
 
 var startCmd = &cobra.Command{
@@ -276,6 +291,15 @@ var startCmd = &cobra.Command{
 				arguments["--http"] = httpAddr
 			}
 
+			// --reconnect is a flag-style (valueless) arg on the
+			// skysocks-client binary; passing it as a bool in the
+			// custom-setting map adds (true) or removes (false) the
+			// bare "--reconnect" token from the app's Args. With it
+			// set, the proxy proc retries in-process on stream
+			// failure instead of exiting, so a flaky route doesn't
+			// drop the SOCKS5 listener.
+			arguments["--reconnect"] = reconnect
+
 			if clientName == "" {
 				clientName = "skysocks-client"
 			}
@@ -306,6 +330,7 @@ var startCmd = &cobra.Command{
 					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("Error occurs during set args to custom skysocks client. error: %s", err))
 				}
 			}
+			applyRoutingPolicy(cmd, rpcClient, clientName)
 			internal.Catch(cmd.Flags(), rpcClient.StartAppWithMode(clientName, getLauncherMode()))
 			if !startVerbose {
 				internal.PrintOutput(cmd.Flags(), nil, "Starting.")
@@ -314,6 +339,7 @@ var startCmd = &cobra.Command{
 			if clientName == "" {
 				clientName = "skysocks-client"
 			}
+			applyRoutingPolicy(cmd, rpcClient, clientName)
 			internal.Catch(cmd.Flags(), rpcClient.StartAppWithMode(clientName, getLauncherMode()))
 			if !startVerbose {
 				internal.PrintOutput(cmd.Flags(), nil, "Starting.")

--- a/cmd/skywire-cli/commands/proxy/root.go
+++ b/cmd/skywire-cli/commands/proxy/root.go
@@ -116,13 +116,15 @@ var (
 	testConnectOnly bool
 	testVersion     string
 	// existing transport flag
-	existingTpOnly    bool
-	forceLocalRoutes  bool
-	muxRoutes         int
-	muxMode           string
-	minHops           uint16
-	startVerbose      bool
-	startVerboseLevel string
+	existingTpOnly     bool
+	forceLocalRoutes   bool
+	muxRoutes          int
+	muxMode            string
+	minHops            uint16
+	startVerbose       bool
+	startVerboseLevel  string
+	reconnect          bool
+	startRoutingPolicy string
 	// multi-hop testing
 	viaVisor string
 	testEnv  bool

--- a/cmd/skywire-cli/commands/vpn/root.go
+++ b/cmd/skywire-cli/commands/vpn/root.go
@@ -79,35 +79,36 @@ func getDeployment() deployment.Services {
 }
 
 var (
-	stateName         = "vpn-client"
-	serviceType       = servicedisc.ServiceTypeVPN
-	rawData           bool
-	sdURL             string
-	utURL             string
-	cacheDirSD        string
-	cacheDirUT        string
-	cacheFilesAge     int
-	noFilterOnline    bool
-	path              string
-	isPkg             bool
-	isStats           bool
-	pubkey            cipher.PubKey
-	pk                string
-	startingTimeout   int
-	jsonOutput        bool
-	country           string
-	version           string
-	minVersion        string
-	maxVersion        string
-	showOffline       bool
-	geoipURL          string
-	useInternal       bool
-	useExternal       bool
-	existingTpOnly    bool
-	forceLocalRoutes  bool
-	testEnv           bool
-	startVerbose      bool
-	startVerboseLevel string
+	stateName          = "vpn-client"
+	serviceType        = servicedisc.ServiceTypeVPN
+	rawData            bool
+	sdURL              string
+	utURL              string
+	cacheDirSD         string
+	cacheDirUT         string
+	cacheFilesAge      int
+	noFilterOnline     bool
+	path               string
+	isPkg              bool
+	isStats            bool
+	pubkey             cipher.PubKey
+	pk                 string
+	startingTimeout    int
+	jsonOutput         bool
+	country            string
+	version            string
+	minVersion         string
+	maxVersion         string
+	showOffline        bool
+	geoipURL           string
+	useInternal        bool
+	useExternal        bool
+	existingTpOnly     bool
+	forceLocalRoutes   bool
+	testEnv            bool
+	startVerbose       bool
+	startVerboseLevel  string
+	startRoutingPolicy string
 )
 
 // RootCmd contains commands that interact with the skywire-visor

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -47,6 +47,7 @@ func init() {
 	startCmd.Flags().BoolVar(&forceLocalRoutes, "local-route", false, "calculate routes locally instead of using route finder")
 	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream the visor's logs scoped to vpn-client (app stdout + tagged router/mux/setup events); ctrl+c stops the vpn and exits")
 	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
+	startCmd.Flags().StringVar(&startRoutingPolicy, "routing-policy", "", "per-app routing policy: @/path/to/policy.star or @/path/to/policy.wasm (\"\" or \"none\" clears any previously-installed override)")
 }
 
 var startCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -130,6 +130,13 @@ var startCmd = &cobra.Command{
 			}
 		}
 
+		// Install the per-app routing policy before the app starts
+		// (only when the operator passed --routing-policy) so the
+		// first dial vpn-client makes already runs through the policy.
+		// "" / "none" clears a previously-installed override.
+		if cmd.Flags().Changed("routing-policy") {
+			internal.Catch(cmd.Flags(), rpcClient.SetAppRoutingPolicy(stateName, startRoutingPolicy))
+		}
 		internal.Catch(cmd.Flags(), rpcClient.StartVPNClientWithMode(pubkey, launcherMode))
 		if !startVerbose {
 			internal.PrintOutput(cmd.Flags(), nil, "Starting.")

--- a/pkg/visor/visorconfig/values_windows.go
+++ b/pkg/visor/visorconfig/values_windows.go
@@ -128,7 +128,7 @@ func genSysInfo() customSysinfo {
 // Threads is populated from runtime.NumCPU() so the field is never
 // zero even if the registry read fails.
 func getWindowsCPUInfo() cpuInfo {
-	ci := cpuInfo{Threads: uint(runtime.NumCPU())}
+	ci := cpuInfo{Threads: uint(runtime.NumCPU())} //nolint:gosec // runtime.NumCPU() is always positive
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
 		`HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
 	if err != nil {

--- a/third_party/zcalusic/sysinfo/cpu_other.go
+++ b/third_party/zcalusic/sysinfo/cpu_other.go
@@ -10,9 +10,9 @@ package sysinfo
 import "runtime"
 
 // getCPUInfo is a no-op on non-Linux targets that import this package
-// (only for the SysInfo / CPU type shape used in survey marshalling).
+// (only for the SysInfo / CPU type shape used in survey marshaling).
 // Linux is where /proc/cpuinfo lives; everywhere else we report the
 // thread count from the Go runtime so the field isn't zero.
 func (si *SysInfo) getCPUInfo() {
-	si.CPU.Threads = uint(runtime.NumCPU())
+	si.CPU.Threads = uint(runtime.NumCPU()) //nolint:gosec // runtime.NumCPU() is always positive
 }

--- a/third_party/zcalusic/sysinfo/kernel_other.go
+++ b/third_party/zcalusic/sysinfo/kernel_other.go
@@ -16,6 +16,6 @@ type Kernel struct {
 
 // getKernelInfo is a no-op on non-Linux targets that import this
 // package only for the SysInfo / Kernel type shape used in survey
-// marshalling. The Linux build (kernel_linux.go) reads
+// marshaling. The Linux build (kernel_linux.go) reads
 // /proc/sys/kernel and syscall.Uname.
 func (si *SysInfo) getKernelInfo() {}


### PR DESCRIPTION
Wires two existing capabilities into the ergonomic `proxy start` / `vpn start` commands.

## proxy start
- **`--reconnect`** — passed into the custom-setting args map as a bool; `updateAppArg` adds the bare `--reconnect` token to skysocks-client's Args. The proxy proc retries in-process on stream failure instead of exiting, so the SOCKS5 listener survives a flaky route.
- **`--routing-policy <@path.star|@path.wasm>`** — installed via `SetAppRoutingPolicy` before `StartAppWithMode` (shared `applyRoutingPolicy` helper covers both the pk-set and pk-empty branches) so the first dial already runs the policy. `""` / `none` clears a prior override.

## vpn start
- **`--routing-policy`** — same pre-start `SetAppRoutingPolicy` install on both branches. vpn-client has no `--reconnect` flag, so that one is proxy-only.

Both mirror the semantics of the existing `cli visor app start --routing-policy` and the app-level `--reconnect`.

## Test plan
- [x] `go build ./...`
- [x] gofmt + golangci-lint clean
- [x] `proxy start --help` shows both flags; `vpn start --help` shows `--routing-policy`