### PR TITLE
fix(hypervisor): guard getPty against nil PtyUI instead of crashing the visor

### DIFF
--- a/pkg/visor/hypervisor_handlers_misc.go
+++ b/pkg/visor/hypervisor_handlers_misc.go
@@ -101,6 +101,16 @@ func (hv *Hypervisor) getPK() http.HandlerFunc {
 
 func (hv *Hypervisor) getPty() http.HandlerFunc {
 	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
+		// PtyUI is nil for connections that never had a pty UI set up
+		// (the Conn zero-value, or a conn path that skips pty setup).
+		// Dereferencing it unconditionally segfaults the whole visor on
+		// a single getPty request, so guard and return an error instead.
+		if ctx.PtyUI == nil || ctx.PtyUI.PtyUI == nil {
+			httputil.WriteJSON(w, r, http.StatusServiceUnavailable, struct {
+				Error string `json:"error"`
+			}{Error: "pty UI not available for this visor"})
+			return
+		}
 		customCommand := make(map[string][]string)
 		customCommand["update"] = visorconfig.UpdateCommand()
 		ctx.PtyUI.PtyUI.Handler(customCommand)(w, r)


### PR DESCRIPTION
## Problem

`getPty` (`pkg/visor/hypervisor_handlers_misc.go:106`) dereferenced `ctx.PtyUI.PtyUI` unconditionally:

```go
ctx.PtyUI.PtyUI.Handler(customCommand)(w, r)
```

The `Conn` zero-value sets `PtyUI: nil` (hypervisor.go:98); it's only populated for `selfConn` (~289) and per-peer conns (~322/376). For any connection where the pty UI was never set up, a single `getPty` HTTP request nil-derefs and **takes down the entire visor** with a SIGSEGV:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation ...]
github.com/skycoin/skywire/pkg/visor.(*Hypervisor).getPty.1
    .../pkg/visor/hypervisor_handlers_misc.go:106
```

A request must never be able to crash the process.

## Fix

Guard the nil case and return `503 Service Unavailable` with a clear message instead of dereferencing:

```go
if ctx.PtyUI == nil || ctx.PtyUI.PtyUI == nil {
    httputil.WriteJSON(w, r, http.StatusServiceUnavailable, struct {
        Error string `json:"error"`
    }{Error: "pty UI not available for this visor"})
    return
}
```

## Notes

- This is the immediate crash-stopper. The secondary question of *why* `PtyUI` was nil for the offending connection (likely a startup race vs. the `selfConn` setup at hypervisor.go:289, or a conn path that skips pty setup) is worth a follow-up, but the guard is correct on its own — a per-request nil should degrade gracefully, not segfault.
- `go build ./pkg/visor/` clean.