### PR TITLE
feat(visor): transitive hypervisor whitelist — trust flows up the hypervisor chain

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -91,6 +91,10 @@ type API interface {
 	RestartApp(appName string) error
 	SetAutoStart(appName string, autostart bool) error
 	SetAppWhitelist(appName, whitelist string) error
+	// AddPtyWhitelist merges PKs into the visor's shared peer
+	// whitelist (a connected hypervisor pushing its own hypervisors
+	// for transitive pty + RPC trust).
+	AddPtyWhitelist(pks []cipher.PubKey) error
 	SetAppPK(appName string, pk cipher.PubKey) error
 	SetAppSecure(appName string, isSecure bool) error
 	SetAppAddress(appName string, address string) error

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -336,6 +336,10 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 				// Warm-cache: see comment in the dmsg accept path
 				// below — same intent, same one-shot Summary.
 				go hv.warmSummaryCache(peerPK, visorConn.API)
+
+				// Push this hypervisor's own hypervisors so the visor
+				// trusts them transitively (pty + RPC) up the chain.
+				go hv.pushHypervisorWhitelist(visorConn.API)
 				if hv.lanDmsg != nil {
 					discoveryURL := hv.c.LANDmsgServer.PublicDiscoveryURL
 					if discoveryURL == "" {
@@ -399,6 +403,10 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 		// populated as fast as peers redial". Independent of the
 		// LAN DMSG goroutine below — they don't share state.
 		go hv.warmSummaryCache(addr.PK, visorConn.API)
+
+		// Push this hypervisor's own hypervisors so the visor trusts
+		// them transitively (pty + RPC) up the chain.
+		go hv.pushHypervisorWhitelist(visorConn.API)
 
 		// Push LAN DMSG server info to the connected visor
 		if hv.lanDmsg != nil {
@@ -499,6 +507,26 @@ func (hv *Hypervisor) pollAllForCache(ctx context.Context) {
 		}(pk, api)
 	}
 	wg.Wait()
+}
+
+// pushHypervisorWhitelist tells a freshly-connected visor to also
+// trust this hypervisor's OWN configured hypervisors, so a
+// super-hypervisor that manages this hypervisor can reach the visor
+// transitively (pty + RPC) without being listed on the visor itself.
+// No-op when this hypervisor has no hypervisors configured. The
+// caller spawns it in a goroutine; failures are logged at debug and
+// the next reconnect retries.
+func (hv *Hypervisor) pushHypervisorWhitelist(api API) {
+	if api == nil {
+		return
+	}
+	hvPKs := hv.visor.conf.Hypervisors
+	if len(hvPKs) == 0 {
+		return
+	}
+	if err := api.AddPtyWhitelist(hvPKs); err != nil {
+		hv.logger.WithError(err).Debug("Failed to push transitive hypervisor whitelist to visor")
+	}
 }
 
 // warmSummaryCache fires a Summary() RPC against a freshly-accepted

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -23,6 +23,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
+	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -575,9 +576,9 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		} else {
 			// Wrap listener with access control
 			authL := &authorizedDmsgListener{
-				Listener:      dmsgGRPCL,
-				authorizedPKs: authorizedPKs,
-				log:           dmsgGRPCLog,
+				Listener:  dmsgGRPCL,
+				whitelist: v.peerWhitelist,
+				log:       dmsgGRPCLog,
 			}
 
 			v.pushCloseStack("dmsg.grpc.listener", dmsgGRPCL.Close)
@@ -604,9 +605,9 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 			goServeSkynetMirror(ctx, v.conf.PK, skyenv.DmsgGRPCPort, "dmsg_grpc", dmsgGRPCLog,
 				func(skyLis net.Listener) {
 					authSky := &authorizedDmsgListener{
-						Listener:      skyLis,
-						authorizedPKs: authorizedPKs,
-						log:           dmsgGRPCLog,
+						Listener:  skyLis,
+						whitelist: v.peerWhitelist,
+						log:       dmsgGRPCLog,
 					}
 					if err := dmsgGRPCServer.Serve(authSky); err != nil &&
 						!errors.Is(err, net.ErrClosed) &&
@@ -646,7 +647,7 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 			if tpRPCErr != nil {
 				log.WithError(tpRPCErr).Warn("Failed to create transport RPC server")
 			} else {
-				tpRPCSrv := NewTransportRPCServer(tpRPCLog, tpRPCS, whitelistPKs, v.transportRPCMux)
+				tpRPCSrv := NewTransportRPCServer(tpRPCLog, tpRPCS, v.peerWhitelist, v.transportRPCMux)
 				v.pushCloseStack("transport_rpc.server", tpRPCSrv.Close)
 				go tpRPCSrv.Serve()
 				tpRPCLog.WithField("whitelist_pks", len(whitelistPKs)).
@@ -683,9 +684,9 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 				dmsgRPCLog.WithError(err).Warn("Failed to listen on dmsg visor-RPC port")
 			} else {
 				authL := &authorizedDmsgListener{
-					Listener:      dmsgRPCL,
-					authorizedPKs: authorizedPKs,
-					log:           dmsgRPCLog,
+					Listener:  dmsgRPCL,
+					whitelist: v.peerWhitelist,
+					log:       dmsgRPCLog,
 				}
 				v.pushCloseStack("dmsg.visor_rpc.listener", dmsgRPCL.Close)
 
@@ -714,9 +715,9 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 				goServeSkynetMirror(ctx, v.conf.PK, skyenv.DmsgVisorRPCPort, "dmsg_visor_rpc", dmsgRPCLog,
 					func(skyLis net.Listener) {
 						authSky := &authorizedDmsgListener{
-							Listener:      skyLis,
-							authorizedPKs: authorizedPKs,
-							log:           dmsgRPCLog,
+							Listener:  skyLis,
+							whitelist: v.peerWhitelist,
+							log:       dmsgRPCLog,
 						}
 						for {
 							conn, err := authSky.Accept()
@@ -1005,8 +1006,8 @@ func initHypervisor(ctx context.Context, v *Visor, log *logging.Logger) error {
 // "Dmsg" name, the same wrapper is used for the skynet mirror.
 type authorizedDmsgListener struct {
 	net.Listener
-	authorizedPKs map[cipher.PubKey]bool
-	log           *logging.Logger
+	whitelist pty.Whitelist
+	log       *logging.Logger
 }
 
 func (l *authorizedDmsgListener) Accept() (net.Conn, error) {
@@ -1033,7 +1034,7 @@ func (l *authorizedDmsgListener) Accept() (net.Conn, error) {
 			conn.Close() //nolint:errcheck,gosec
 			continue
 		}
-		if !l.authorizedPKs[pk] {
+		if ok, err := l.whitelist.Get(pk); err != nil || !ok {
 			l.log.WithField("remote_pk", pk).Warn("Rejected unauthorized gRPC connection")
 			conn.Close() //nolint:errcheck,gosec
 			continue

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -640,13 +640,12 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 		ptyHandler := ptyUI.Handler(map[string][]string{
 			"update": visorconfig.UpdateCommand(),
 		})
-		ptyWL := []cipher.PubKey{v.conf.PK}
-		ptyWL = append(ptyWL, v.conf.Hypervisors...)
-		if v.conf.Pty.Whitelist != nil {
-			ptyWL = append(ptyWL, v.conf.Pty.Whitelist...)
-		}
-		lsAPI.SetPtyHandler(ptyHandler, ptyWL)
-		logger.WithField("whitelist_size", len(ptyWL)).Info("Mounted /pty on logserver")
+		// Gate /pty on the shared peer whitelist (own PK + hypervisors
+		// + configured pty whitelist, plus any runtime transitive
+		// additions) so the web terminal honors the same live set as
+		// the dmsgpty host.
+		lsAPI.SetPtyHandler(ptyHandler, v.peerWhitelist)
+		logger.Info("Mounted /pty on logserver (gated by shared peer whitelist)")
 	}
 
 	// Mount the website handler for port 80 — rewards UI if configured,
@@ -833,21 +832,13 @@ func initDmsgpty(ctx context.Context, v *Visor, log *logging.Logger) error {
 		}
 	}
 
-	wl := pty.NewMemoryWhitelist()
-
-	// Initialize the dmsgpty whitelist
-	if err := wl.Add(v.conf.Pty.Whitelist...); err != nil {
-		return err
-	}
-
-	// Ensure hypervisors are added to the whitelist.
-	if err := wl.Add(v.conf.Hypervisors...); err != nil {
-		return err
-	}
-	// add the visor's own public key to the whitelist to allow local pty
-	if err := wl.Add(v.conf.PK); err != nil {
-		v.log.Errorf("Cannot add itself to the pty whitelist: %s", err)
-	}
+	// Use the visor's shared peer whitelist as the dmsgpty host's
+	// whitelist. It's seeded with the configured pty whitelist +
+	// hypervisors + the visor's own PK, and is the same reference
+	// dmsgscp and the /pty web terminal consult — so a runtime
+	// transitive addition (a connected hypervisor pushing its own
+	// hypervisors via AddPtyWhitelist) reaches all of them at once.
+	wl := v.peerWhitelist
 
 	dmsgC := v.dmsgC
 	if dmsgC == nil {

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/serviceuptime"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -99,7 +100,22 @@ type API struct {
 	// Gated by ptyWhitelist — typically the dmsgpty whitelist (configured
 	// PKs + hypervisor PKs + the visor's own PK).
 	ptyHandler   http.Handler
-	ptyWhitelist []cipher.PubKey
+	ptyWhitelist pty.Whitelist
+}
+
+// ptyPKAllowed reports whether the request's remote host (a PK hex
+// string) is on the live pty whitelist. Fails closed on a nil
+// whitelist or an unparseable host — /pty is high-power.
+func ptyPKAllowed(wl pty.Whitelist, remoteHost string) bool {
+	if wl == nil {
+		return false
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(remoteHost); err != nil {
+		return false
+	}
+	ok, err := wl.Get(pk)
+	return err == nil && ok
 }
 
 // New creates a new API.
@@ -217,24 +233,13 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 			c.AbortWithStatus(http.StatusNotFound)
 			return
 		}
-		// Empty whitelist on the API means "no PK allowed" rather than
-		// "open to all" — pty is high-power, fail closed.
-		if len(api.ptyWhitelist) == 0 {
-			c.AbortWithStatus(http.StatusForbidden)
-			return
-		}
+		// Nil whitelist means "no PK allowed" — pty is high-power,
+		// fail closed.
 		remoteHost, _, err := net.SplitHostPort(c.Request.RemoteAddr)
 		if err != nil {
 			remoteHost = c.Request.RemoteAddr
 		}
-		allowed := false
-		for _, pk := range api.ptyWhitelist {
-			if remoteHost == pk.String() {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
+		if !ptyPKAllowed(api.ptyWhitelist, remoteHost) {
 			c.AbortWithStatus(http.StatusForbidden)
 			return
 		}
@@ -290,15 +295,10 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 			// distinct from the survey whitelist (it can include
 			// Dmsgpty.Whitelist entries the survey list doesn't), so
 			// we re-check rather than reuse `wl`.
-			if api.ptyHandler != nil && len(api.ptyWhitelist) > 0 {
+			if api.ptyHandler != nil && api.ptyWhitelist != nil {
 				remoteHost, _, err := net.SplitHostPort(c.Request.RemoteAddr)
-				if err == nil {
-					for _, pk := range api.ptyWhitelist {
-						if remoteHost == pk.String() {
-							links = append(links, `<a href="/pty">/pty</a> - web terminal (dmsgpty)`)
-							break
-						}
-					}
+				if err == nil && ptyPKAllowed(api.ptyWhitelist, remoteHost) {
+					links = append(links, `<a href="/pty">/pty</a> - web terminal (dmsgpty)`)
 				}
 			}
 		}
@@ -449,7 +449,7 @@ func (api *API) SetForwardedPortLister(lister ForwardedPortLister) {
 // Pass a nil/empty whitelist or nil handler to disable; the route
 // stays registered and returns 404/403, which is the correct
 // signal to a probing client.
-func (api *API) SetPtyHandler(h http.Handler, whitelist []cipher.PubKey) {
+func (api *API) SetPtyHandler(h http.Handler, whitelist pty.Whitelist) {
 	api.ptyHandler = h
 	api.ptyWhitelist = whitelist
 }

--- a/pkg/visor/peer_whitelist.go
+++ b/pkg/visor/peer_whitelist.go
@@ -1,0 +1,64 @@
+// Package visor pkg/visor/peer_whitelist.go
+//
+// peerWhitelist is the visor's single source of truth for "which peer
+// PKs may manage this visor". Every management surface consults it
+// live, per-connection: the dmsgpty host, dmsgscp, the /pty web
+// terminal, and the transport-RPC / dmsg-gRPC / dmsg visor-RPC
+// servers. Because they all hold the same mutable reference, a
+// runtime addition propagates to all of them at once.
+//
+// Transitive trust: a visor configured with hypervisor H connects to
+// H and serves its RPC to it. On accept, H pushes its OWN configured
+// hypervisors to the visor via AddPtyWhitelist, so a super-hypervisor
+// SH that manages H can also reach the visor — trust flows up the
+// hypervisor chain without the operator re-listing SH on every visor.
+package visor
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/pty"
+	"github.com/skycoin/skywire/pkg/util/rpcutil"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// newPeerWhitelist builds the shared authorized-peer whitelist from
+// static config: the visor's own PK (local self-management), its
+// configured hypervisors, and any explicit pty whitelist.
+func newPeerWhitelist(conf *visorconfig.V1) pty.Whitelist {
+	wl := pty.NewMemoryWhitelist()
+	pks := []cipher.PubKey{conf.PK}
+	pks = append(pks, conf.Hypervisors...)
+	if conf.Pty != nil {
+		pks = append(pks, conf.Pty.Whitelist...)
+	}
+	_ = wl.Add(pks...) //nolint:errcheck,gosec // memoryWhitelist.Add never errors
+	return wl
+}
+
+// AddPtyWhitelist merges PKs into the live shared whitelist, extending
+// pty + RPC trust to peers a connected hypervisor vouches for (its own
+// hypervisors). Idempotent. Every mutation is logged with full PKs for
+// audit. Implements API.
+func (v *Visor) AddPtyWhitelist(pks []cipher.PubKey) error {
+	if v.peerWhitelist == nil || len(pks) == 0 {
+		return nil
+	}
+	for _, pk := range pks {
+		v.log.WithField("pk", pk.String()).
+			Info("Adding PK to peer whitelist (transitive hypervisor trust)")
+	}
+	return v.peerWhitelist.Add(pks...)
+}
+
+// AddPtyWhitelistIn carries the PKs to merge into the visor's shared
+// peer whitelist (a hypervisor pushing its own hypervisors).
+type AddPtyWhitelistIn struct {
+	PKs []cipher.PubKey
+}
+
+// AddPtyWhitelist is the RPC gateway for Visor.AddPtyWhitelist.
+func (r *RPC) AddPtyWhitelist(in *AddPtyWhitelistIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "AddPtyWhitelist", in)(nil, &err)
+
+	return r.visor.AddPtyWhitelist(in.PKs)
+}

--- a/pkg/visor/peer_whitelist_test.go
+++ b/pkg/visor/peer_whitelist_test.go
@@ -1,0 +1,78 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/pty"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// whitelisted reports whether pk is on wl, failing the test on a
+// whitelist error.
+func whitelisted(t *testing.T, wl pty.Whitelist, pk cipher.PubKey) bool {
+	t.Helper()
+	ok, err := wl.Get(pk)
+	if err != nil {
+		t.Fatalf("whitelist Get(%s): %v", pk, err)
+	}
+	return ok
+}
+
+// TestNewPeerWhitelist_SeedsConfig verifies the shared whitelist is
+// seeded from the visor's own PK, its hypervisors, and its configured
+// pty whitelist — and nothing else.
+func TestNewPeerWhitelist_SeedsConfig(t *testing.T) {
+	ownPK, _ := cipher.GenerateKeyPair()
+	hvPK, _ := cipher.GenerateKeyPair()
+	ptyPK, _ := cipher.GenerateKeyPair()
+	otherPK, _ := cipher.GenerateKeyPair()
+
+	conf := &visorconfig.V1{Common: &visorconfig.Common{PK: ownPK}}
+	conf.Hypervisors = []cipher.PubKey{hvPK}
+	conf.Pty = &visorconfig.Pty{Whitelist: []cipher.PubKey{ptyPK}}
+
+	wl := newPeerWhitelist(conf)
+
+	for _, pk := range []cipher.PubKey{ownPK, hvPK, ptyPK} {
+		if !whitelisted(t, wl, pk) {
+			t.Errorf("expected %s to be whitelisted", pk)
+		}
+	}
+	if whitelisted(t, wl, otherPK) {
+		t.Errorf("unconfigured PK %s should not be whitelisted", otherPK)
+	}
+}
+
+// TestVisor_AddPtyWhitelist verifies the transitive-trust mutation:
+// a PK pushed via AddPtyWhitelist becomes part of the live shared
+// whitelist, and nil/empty input is a safe no-op.
+func TestVisor_AddPtyWhitelist(t *testing.T) {
+	ownPK, _ := cipher.GenerateKeyPair()
+	conf := &visorconfig.V1{Common: &visorconfig.Common{PK: ownPK}}
+	v := &Visor{
+		log:           logging.NewMasterLogger().PackageLogger("test"),
+		peerWhitelist: newPeerWhitelist(conf),
+	}
+
+	transitivePK, _ := cipher.GenerateKeyPair()
+	if whitelisted(t, v.peerWhitelist, transitivePK) {
+		t.Fatal("precondition failed: transitivePK should not be whitelisted yet")
+	}
+
+	if err := v.AddPtyWhitelist([]cipher.PubKey{transitivePK}); err != nil {
+		t.Fatalf("AddPtyWhitelist: %v", err)
+	}
+	if !whitelisted(t, v.peerWhitelist, transitivePK) {
+		t.Error("transitivePK should be whitelisted after AddPtyWhitelist")
+	}
+
+	// nil and empty are safe no-ops.
+	if err := v.AddPtyWhitelist(nil); err != nil {
+		t.Errorf("AddPtyWhitelist(nil): %v", err)
+	}
+	if err := v.AddPtyWhitelist([]cipher.PubKey{}); err != nil {
+		t.Errorf("AddPtyWhitelist(empty): %v", err)
+	}
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -253,6 +253,10 @@ func (proxyDefaultAPI) SetAppWhitelist(_ string, _ string) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) AddPtyWhitelist(_ []cipher.PubKey) error {
+	return ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) SetAppPK(_ string, _ cipher.PubKey) error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -457,6 +457,11 @@ func (rc *rpcClient) SetAppWhitelist(appName, whitelist string) error {
 	}, &struct{}{})
 }
 
+// AddPtyWhitelist calls AddPtyWhitelist.
+func (rc *rpcClient) AddPtyWhitelist(pks []cipher.PubKey) error {
+	return rc.Call("AddPtyWhitelist", &AddPtyWhitelistIn{PKs: pks}, &struct{}{})
+}
+
 // SetAppPK calls SetAppPK.
 func (rc *rpcClient) SetAppPK(appName string, pk cipher.PubKey) error {
 	return rc.Call("SetAppPK", &SetAppPKIn{

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -419,6 +419,11 @@ func (mc *mockRPCClient) SetAppWhitelist(string, string) error {
 	})
 }
 
+// AddPtyWhitelist implements API.
+func (mc *mockRPCClient) AddPtyWhitelist([]cipher.PubKey) error {
+	return nil
+}
+
 // SetAppNetworkInterface implements API.
 func (mc *mockRPCClient) SetAppNetworkInterface(string, string) error {
 	return mc.do(true, func() error {

--- a/pkg/visor/transport_rpc.go
+++ b/pkg/visor/transport_rpc.go
@@ -13,8 +13,8 @@ import (
 	"net/rpc"
 	"sync"
 
-	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
@@ -22,7 +22,7 @@ import (
 type TransportRPCServer struct {
 	log       *logging.Logger
 	rpcServer *rpc.Server
-	whitelist map[cipher.PubKey]struct{}
+	whitelist pty.Whitelist
 	mux       *transport.VStreamMux
 	done      chan struct{}
 	once      sync.Once
@@ -30,7 +30,8 @@ type TransportRPCServer struct {
 
 // NewTransportRPCServer creates a transport-level RPC server.
 // rpcServer is the visor's existing RPC server (same one that serves localhost).
-// whitelistPKs controls who can connect — typically the hypervisor PKs.
+// whitelist is the visor's shared peer whitelist — consulted live per
+// accept, so runtime transitive additions take effect without a restart.
 //
 // mux MUST be the same VStreamMux that's registered as the transport
 // manager's VisorRPCPacket handler (via tm.SetVisorRPCHandler) AND is
@@ -43,18 +44,13 @@ type TransportRPCServer struct {
 func NewTransportRPCServer(
 	log *logging.Logger,
 	rpcServer *rpc.Server,
-	whitelistPKs []cipher.PubKey,
+	whitelist pty.Whitelist,
 	mux *transport.VStreamMux,
 ) *TransportRPCServer {
-	wl := make(map[cipher.PubKey]struct{}, len(whitelistPKs))
-	for _, pk := range whitelistPKs {
-		wl[pk] = struct{}{}
-	}
-
 	srv := &TransportRPCServer{
 		log:       log,
 		rpcServer: rpcServer,
-		whitelist: wl,
+		whitelist: whitelist,
 		mux:       mux,
 		done:      make(chan struct{}),
 	}
@@ -80,7 +76,7 @@ func (s *TransportRPCServer) Serve() {
 		remotePK := stream.RemotePK()
 
 		// Check whitelist.
-		if _, ok := s.whitelist[remotePK]; !ok {
+		if ok, err := s.whitelist.Get(remotePK); err != nil || !ok {
 			s.log.WithField("remote_pk", remotePK.String()).
 				Warn("Transport RPC rejected: PK not in whitelist")
 			stream.Close() //nolint:errcheck,gosec
@@ -104,13 +100,4 @@ func (s *TransportRPCServer) Close() error {
 		s.mux.Close() //nolint:errcheck,gosec
 	})
 	return nil
-}
-
-// UpdateWhitelist replaces the whitelist at runtime.
-func (s *TransportRPCServer) UpdateWhitelist(pks []cipher.PubKey) {
-	wl := make(map[cipher.PubKey]struct{}, len(pks))
-	for _, pk := range pks {
-		wl[pk] = struct{}{}
-	}
-	s.whitelist = wl
 }

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -150,6 +150,12 @@ type Visor struct {
 	isTransportabilityHealthy *internalHealthInfo
 	remoteVisors              map[cipher.PubKey]Conn // remote hypervisors the visor is attempting to connect to
 	connectedHypervisors      map[cipher.PubKey]bool // remote hypervisors the visor is currently connected to
+	// peerWhitelist is the shared "who may manage this visor" set
+	// consulted live by every management surface (dmsgpty, dmsgscp,
+	// /pty web terminal, transport-RPC / dmsg-gRPC / dmsg visor-RPC).
+	// Seeded from config; extended at runtime when a connected
+	// hypervisor pushes its own hypervisors. See peer_whitelist.go.
+	peerWhitelist pty.Whitelist
 	// hypervisorCancels holds the per-hypervisor context.CancelFunc
 	// installed by AddHypervisor, keyed by the remote hypervisor PK.
 	// RemoveHypervisor looks up the cancel func and invokes it; the
@@ -569,6 +575,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 		isAutoconnectHealthy:      newInternalHealthInfo(),
 		isTransportabilityHealthy: newInternalHealthInfo(),
 		connectedHypervisors:      make(map[cipher.PubKey]bool),
+		peerWhitelist:             newPeerWhitelist(conf),
 		hypervisorCancels:         make(map[cipher.PubKey]context.CancelFunc),
 		allowed: allowedPortsState{
 			ports: make(map[int]bool),


### PR DESCRIPTION
## What

A visor configured with hypervisor **H** now also trusts **H's own hypervisors**, so a super-hypervisor **SH** that manages H can reach the visor (pty + full RPC) without being explicitly listed on every visor. Trust flows transitively up the hypervisor chain.

## Why

Previously each management surface seeded a **separate static snapshot** of `conf.Hypervisors` at init — the dmsgpty host, dmsgscp, the `/pty` web terminal, and the transport-RPC / dmsg-gRPC / dmsg visor-RPC servers. Nothing merged in the connected hypervisor's *own* hypervisors, and there was no runtime mutation path. So in an `SH → H → V` chain, SH could not reach V even though SH controls H which controls V.

## How

**Single source of truth.** New `v.peerWhitelist` (`pty.Whitelist`, thread-safe `memoryWhitelist`), seeded from own PK + `conf.Hypervisors` + configured pty whitelist. All five surfaces now consult it **live, per-connection**, so one addition propagates everywhere:
- `peer_whitelist.go` (new) — `newPeerWhitelist`, `Visor.AddPtyWhitelist`, the RPC gateway
- `visor.go` — field + seed in `NewVisor`
- `init_dmsg.go` — dmsgpty host + `/pty` mount use the shared whitelist
- `init_apps.go` — `authorizedDmsgListener` (gRPC + dmsg visor-RPC) checks it live
- `transport_rpc.go` — checks it live (removes the old racy `UpdateWhitelist`)
- `logserver/api.go` — `/pty` auth + landing-page link consult `pty.Whitelist`

**Push mechanism.** When hypervisor H accepts a visor's RPC-serve connection (`hypervisor.go` accept loops, both dmsg and skynet), it calls the new `AddPtyWhitelist` RPC to push its own `conf.Hypervisors` to the visor, which merges them into `peerWhitelist`. The call rides the **PK-authenticated link the visor itself opened to H**, so it's inherently attributable to a trusted hypervisor. Mirrors the existing `SetLANDmsgServer` push and the existing `SetAppWhitelist` RPC trust posture. Every mutation is logged with **full PKs** for audit.

## Notes / trust model

- The RPC-server **enable** decision still keys on configured hypervisors / pty whitelist, so a visor with no hypervisors never starts those servers — and never receives a push (the push only arrives over a hypervisor link, which only exists if the visor has a hypervisor configured).
- `dmsgscp` with an **explicit operator whitelist** keeps its own static set and does not receive transitive additions (explicit operator intent wins).

## Tests

- `TestNewPeerWhitelist_SeedsConfig`, `TestVisor_AddPtyWhitelist`
- `go build ./...`, `go vet`, `golangci-lint` (all GOOS), and `pkg/visor` + `pkg/visor/logserver` + `pkg/pty` suites all clean.