### PR TITLE
fix(visor/dmsgtracker): resolve tracked peers via the direct client, not dmsg-discovery

### DIFF
--- a/pkg/visor/dmsg_direct_entry_test.go
+++ b/pkg/visor/dmsg_direct_entry_test.go
@@ -1,0 +1,60 @@
+package visor
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestEnsureDirectDmsgEntry verifies that the dmsg-tracker resolver hook
+// makes a previously-unknown peer resolvable on the direct-client path,
+// advertising the known dmsg servers as delegated — so the subsequent
+// dial doesn't depend on the peer having a dmsg-discovery entry.
+func TestEnsureDirectDmsgEntry(t *testing.T) {
+	srvPK, _ := cipher.GenerateKeyPair()
+	servers := []*dmsgdisc.Entry{{Static: srvPK}}
+
+	// Direct client seeded with the server only — not the peer.
+	dc := direct.NewClient(direct.GetAllEntries(cipher.PubKeys{}, servers),
+		logging.NewMasterLogger().PackageLogger("test"))
+
+	v := &Visor{
+		log:               logging.NewMasterLogger().PackageLogger("test"),
+		initLock:          new(sync.RWMutex),
+		dClient:           dc,
+		dmsgDirectServers: servers,
+	}
+
+	peerPK, _ := cipher.GenerateKeyPair()
+
+	// Precondition: peer is not resolvable on the direct client.
+	if _, err := dc.Entry(context.Background(), peerPK); err == nil {
+		t.Fatal("precondition failed: peer should not be resolvable yet")
+	}
+
+	v.ensureDirectDmsgEntry(peerPK)
+
+	e, err := dc.Entry(context.Background(), peerPK)
+	if err != nil {
+		t.Fatalf("peer should resolve after ensureDirectDmsgEntry: %v", err)
+	}
+	if e.Client == nil || len(e.Client.DelegatedServers) != 1 || e.Client.DelegatedServers[0] != srvPK {
+		t.Errorf("synthetic entry should delegate the known server %s, got %+v", srvPK, e.Client)
+	}
+}
+
+// TestEnsureDirectDmsgEntry_NoServers is a no-op when the direct client
+// isn't up (no servers stashed) — it must not panic or register anything.
+func TestEnsureDirectDmsgEntry_NoServers(t *testing.T) {
+	v := &Visor{
+		log:      logging.NewMasterLogger().PackageLogger("test"),
+		initLock: new(sync.RWMutex),
+	}
+	peerPK, _ := cipher.GenerateKeyPair()
+	v.ensureDirectDmsgEntry(peerPK) // must not panic
+}

--- a/pkg/visor/dmsgtracker/dmsg_tracker.go
+++ b/pkg/visor/dmsgtracker/dmsg_tracker.go
@@ -27,15 +27,21 @@ func isExpectedTrackerLookupErr(err error) bool {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	if errors.Is(err, disc.ErrKeyNotFound) {
+	if errors.Is(err, disc.ErrKeyNotFound) || errors.Is(err, disc.ErrNoAvailableServers) {
 		return true
 	}
 	// Fallback: dmsg discovery returns the error wrapped with a string
-	// path through net/http, so errors.Is won't catch every case.
+	// path through net/http, so errors.Is won't catch every case. The
+	// direct-client path adds "no delegated dmsg servers" / "cannot
+	// connect to delegated server" for a peer that's connected to us
+	// over a skywire transport but has no live dmsg session on a shared
+	// server — also an expected, non-actionable condition.
 	msg := err.Error()
 	if strings.Contains(msg, "context canceled") ||
 		strings.Contains(msg, "context deadline exceeded") ||
-		strings.Contains(msg, "entry is not found") {
+		strings.Contains(msg, "entry is not found") ||
+		strings.Contains(msg, "no delegated dmsg servers") ||
+		strings.Contains(msg, "cannot connect to delegated server") {
 		return true
 	}
 	return false
@@ -111,6 +117,13 @@ type Manager struct {
 	dc  *dmsg.Client
 	dts map[cipher.PubKey]*DmsgTracker
 	mx  sync.Mutex
+
+	// ensureResolvable, when set, is invoked with a peer PK right
+	// before the tracker dials it. It lets the owner make the peer
+	// locally resolvable (e.g. register a synthetic direct-client
+	// entry) so the dial doesn't depend on the peer having a
+	// dmsg-discovery entry. nil = no-op (discovery-based resolution).
+	ensureResolvable func(cipher.PubKey)
 
 	// Track PKs with establishment attempts in progress to avoid duplicate goroutines
 	inProgress   map[cipher.PubKey]struct{}
@@ -213,6 +226,16 @@ func (dtm *Manager) updateAllTrackers(ctx context.Context) {
 	}
 }
 
+// SetPeerResolver installs a hook called with a peer PK right before
+// the tracker dials it, so the owner can make the peer locally
+// resolvable (register a synthetic direct-client entry) instead of
+// relying on a dmsg-discovery lookup. Safe to call once during setup.
+func (dtm *Manager) SetPeerResolver(f func(cipher.PubKey)) {
+	dtm.mx.Lock()
+	dtm.ensureResolvable = f
+	dtm.mx.Unlock()
+}
+
 // ShouldGet obtains a DmsgClientSummary of the client of given pk.
 // If one are not found internally, a new goroutine of tracker stream is to be established.
 func (dtm *Manager) ShouldGet(ctx context.Context, pk cipher.PubKey) (DmsgClientSummary, error) {
@@ -267,6 +290,18 @@ func (dtm *Manager) establishTracker(ctx context.Context, pk cipher.PubKey) {
 
 	dCtx, cancel := context.WithDeadline(ctx, time.Now().Add(dtm.updateTimeout))
 	defer cancel()
+
+	// Make the peer resolvable without a dmsg-discovery lookup when the
+	// owner has wired a resolver (direct-client path). Peers connected
+	// to us over skywire transports don't register in dmsg-discovery, so
+	// the discovery route would always fail; the resolver registers a
+	// synthetic direct entry instead.
+	dtm.mx.Lock()
+	resolve := dtm.ensureResolvable
+	dtm.mx.Unlock()
+	if resolve != nil {
+		resolve(pk)
+	}
 
 	dt, err := newDmsgTracker(dCtx, dtm.dc, pk)
 	if err != nil {

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -110,9 +110,12 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	entries := direct.GetAllEntries(keys, servers)
 	dClient := direct.NewClient(entries, v.MasterLogger().PackageLogger("dmsg_http:direct_client"))
 
-	// Set dClient immediately for direct discovery access.
+	// Set dClient immediately for direct discovery access. Stash the
+	// server set too so the dmsg tracker can register synthetic entries
+	// for connected peers on the same direct path (ensureDirectDmsgEntry).
 	v.initLock.Lock()
 	v.dClient = dClient
+	v.dmsgDirectServers = servers
 	v.initLock.Unlock()
 
 	// Start DMSG HTTP connection in background so it doesn't block visor startup.
@@ -796,18 +799,89 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 	return nil
 }
 
-func initDmsgTrackers(_ context.Context, v *Visor, _ *logging.Logger) error {
-	dmsgC := v.dmsgC
+// dmsgTrackerDirectClientTimeout bounds how long the tracker waits for
+// the direct-client-backed dmsgDC to come up before falling back to the
+// discovery-based dmsgC. dmsgDC is normally ready within seconds; the
+// fallback only matters on nodes where dmsg-http is disabled / has no
+// servers (dmsgHTTPReady never fires).
+const dmsgTrackerDirectClientTimeout = 60 * time.Second
 
-	dtm := dmsgtracker.NewDmsgTrackerManager(v.MasterLogger(), dmsgC, 0, 0)
-	v.pushCloseStack("dmsg_tracker_manager", func() error {
-		return dtm.Close()
-	})
-	v.initLock.Lock()
-	v.dmsgTracker.manager = dtm
-	v.initLock.Unlock()
-	v.dmsgTracker.readyOnce.Do(func() { close(v.dmsgTracker.ready) })
+func initDmsgTrackers(ctx context.Context, v *Visor, _ *logging.Logger) error {
+	// Build the tracker against the DIRECT client (dmsgDC) rather than
+	// the discovery-based dmsgC. The tracker dials each connected peer
+	// on DmsgCtrlPort to measure its dmsg server + round-trip; resolving
+	// those peers through dmsg-discovery fails for any peer that reached
+	// us over a skywire transport and never registered a discovery entry
+	// (the repeated "entry not found" / "cannot connect to delegated
+	// server" lookups). The direct client resolves peers locally via
+	// synthetic entries (ensureDirectDmsgEntry), dialing them through the
+	// known servers without a discovery round-trip. dmsgDC is set
+	// asynchronously by initDmsgHTTP, so wait for it (bounded).
+	go func() {
+		dmsgC := v.dmsgC // discovery-based fallback
+		select {
+		case <-v.dmsgHTTPReady:
+			v.initLock.RLock()
+			dc := v.dmsgDC
+			v.initLock.RUnlock()
+			if dc != nil {
+				dmsgC = dc
+			}
+		case <-time.After(dmsgTrackerDirectClientTimeout):
+			v.log.Debug("dmsg tracker: direct client not ready; using discovery-based client")
+		case <-ctx.Done():
+			return
+		}
+
+		dtm := dmsgtracker.NewDmsgTrackerManager(v.MasterLogger(), dmsgC, 0, 0)
+		// Only wire the direct resolver when we're actually on the direct
+		// client; with the discovery fallback the synthetic entries would
+		// be unused (dmsgC doesn't consult dClient).
+		v.initLock.RLock()
+		onDirect := dmsgC == v.dmsgDC && v.dmsgDC != nil
+		v.initLock.RUnlock()
+		if onDirect {
+			dtm.SetPeerResolver(v.ensureDirectDmsgEntry)
+		}
+
+		v.pushCloseStack("dmsg_tracker_manager", func() error {
+			return dtm.Close()
+		})
+		v.initLock.Lock()
+		v.dmsgTracker.manager = dtm
+		v.initLock.Unlock()
+		v.dmsgTracker.readyOnce.Do(func() { close(v.dmsgTracker.ready) })
+	}()
 	return nil
+}
+
+// ensureDirectDmsgEntry makes pk resolvable on the direct-client path
+// without a dmsg-discovery lookup: if the direct client doesn't already
+// know pk, it registers a synthetic entry advertising all known dmsg
+// servers as delegated, mirroring how deployment service PKs are seeded
+// (init_dmsg.go's GetAllEntries). The subsequent DialStream then tries
+// those servers directly. No-op when the direct client isn't up.
+func (v *Visor) ensureDirectDmsgEntry(pk cipher.PubKey) {
+	v.initLock.RLock()
+	dc := v.dClient
+	servers := v.dmsgDirectServers
+	v.initLock.RUnlock()
+
+	if dc == nil || len(servers) == 0 {
+		return
+	}
+	if _, err := dc.Entry(context.Background(), pk); err == nil {
+		return // already resolvable (service PK or previously registered)
+	}
+	for _, e := range direct.GetAllEntries(cipher.PubKeys{pk}, servers) {
+		if e.Static != pk {
+			continue // GetAllEntries also returns the server entries; skip them
+		}
+		if err := dc.PostEntry(context.Background(), e); err != nil {
+			v.log.WithError(err).WithField("pk", pk.String()).
+				Debug("dmsg tracker: failed to register direct entry for peer")
+		}
+	}
 }
 
 // nolint: gocyclo

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -93,13 +93,18 @@ type Visor struct {
 	startupComplete chan struct{}
 	uptimeTracker   utclient.APIClient
 
-	ebc                *appevent.Broadcaster // event broadcaster
-	dmsgC              *dmsg.Client
-	dmsgDC             *dmsg.Client       // dmsg direct client
-	dClient            dmsgdisc.APIClient // dmsg direct api client
-	dmsgHTTP           *http.Client       // dmsghttp client
-	dmsgHTTPReady      chan struct{}      // closed when dmsgHTTP is set
-	awaitSetupListener *dmsg.Listener     // pre-opened DmsgAwaitSetupPort listener; consumed by initRouter
+	ebc     *appevent.Broadcaster // event broadcaster
+	dmsgC   *dmsg.Client
+	dmsgDC  *dmsg.Client       // dmsg direct client
+	dClient dmsgdisc.APIClient // dmsg direct api client
+	// dmsgDirectServers is the dmsg-server entry set the direct client
+	// (dClient/dmsgDC) was seeded with. Stashed so peers can be made
+	// resolvable on the direct path at runtime (synthetic entries with
+	// these servers as delegated) — see ensureDirectDmsgEntry.
+	dmsgDirectServers  []*dmsgdisc.Entry
+	dmsgHTTP           *http.Client   // dmsghttp client
+	dmsgHTTPReady      chan struct{}  // closed when dmsgHTTP is set
+	awaitSetupListener *dmsg.Listener // pre-opened DmsgAwaitSetupPort listener; consumed by initRouter
 
 	// dmsgWL is the live, in-memory whitelist shared with the running
 	// pty.Host and (when scp is enabled) dmsgscp.Host. VisorCat's


### PR DESCRIPTION
## Problem

The dmsg tracker dials each connected peer on `DmsgCtrlPort` to read its dmsg server + round-trip for the hypervisor UI (`dmsgtracker.newDmsgTracker` → `dmsgC.DialStream`). It was wired to the **discovery-based** main client (`v.dmsgC`):

```go
// init_dmsg.go — before
dmsgC := v.dmsgC
dtm := dmsgtracker.NewDmsgTrackerManager(v.MasterLogger(), dmsgC, 0, 0)
```

So every dial first resolved the peer's **dmsg-discovery entry**. But peers that reach the hypervisor over a skywire transport don't register in dmsg-discovery — services and direct clients don't, by design. Those lookups failed on **every UI poll**:

```
[dmsg] disc Entry: DMSG primary failed; trying HTTP fallback
  error="...entry/<peer>: dmsg error 202 - cannot connect to delegated server"
dtm.establishTracker: Skipped dmsgtracker client (peer not in discovery...)
  error="dmsg error 100 - entry is not found in discovery"
```

re-fired every few seconds with no backoff (the tracker never establishes, so `GetBulk`/`ShouldGet` re-attempt each poll). As discussed on the issue, this isn't log spam — it's genuinely **wrong, discovery-dependent connection attempts** for peers that should be reached directly. The codebase already avoids exactly this for service lookups by using the **direct client** (`v.dmsgDC`, `direct.Client`-backed with synthetic entries — see `dmsgfirst` and `init_router.go`); the tracker just wasn't using it.

## Fix

Build the tracker against the **direct client** (`v.dmsgDC`) and register a synthetic entry for each tracked peer right before dialing — all known dmsg servers as delegated, mirroring how deployment service PKs are seeded (`direct.GetAllEntries`). `DialStream` then tries those servers directly, no discovery round-trip.

- **`dmsgtracker.Manager`**: optional `SetPeerResolver` hook, invoked with the peer PK just before the dial (race-free, read under the manager mutex). Broaden `isExpectedTrackerLookupErr` so a direct-dial miss (`ErrNoAvailableServers` / "cannot connect to delegated server" — peer connected to us but not currently on a shared dmsg server) stays at debug, not warn.
- **`Visor`**: stash the direct server set (`dmsgDirectServers`); add `ensureDirectDmsgEntry(pk)` to register synthetic peer entries on `v.dClient`.
- **`initDmsgTrackers`**: construct the manager once `dmsgDC` is ready (bounded 60s wait via `dmsgHTTPReady`; falls back to the discovery client if dmsg-http never comes up — e.g. no servers), and wire the resolver only on the direct path.

Net effect: for peers that are dmsg-reachable on the shared server set, the tracker now **establishes** (and then just refreshes every 30s) instead of re-failing a discovery lookup every poll.

## Tests

- `TestEnsureDirectDmsgEntry` — a previously-unknown peer becomes resolvable on the direct client, delegating the known server.
- `TestEnsureDirectDmsgEntry_NoServers` — no-op / no panic when the direct client isn't up.
- `go build ./...`, `go vet`, `golangci-lint` clean; `pkg/visor` + `pkg/visor/dmsgtracker` (incl. `-race`) pass.

## Note

This fixes the *resolution path*. If a managed visor genuinely has **no** live dmsg session on any shared server (reachable only via stcpr/sudph), the direct dial still can't reach it — but that now fails fast locally (no discovery round-trip) and stays at debug, rather than hammering discovery every poll.