### PR TITLE
fix(dmsg): detect dead sessions in 20s not 60s — stop services advertising dead servers

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -860,7 +860,7 @@ func (ce *Client) reconnectMissing(ctx context.Context) {
 // for deadness detection). With ~6 sessions per visor the traffic is
 // 6 round-trips/min — negligible.
 func (ce *Client) pingSessionsLoop(ctx context.Context) {
-	ticker := time.NewTicker(60 * time.Second)
+	ticker := time.NewTicker(pingSessionsInterval)
 	defer ticker.Stop()
 
 	// Per-session consecutive-failure counter. Keyed on the session's
@@ -887,6 +887,19 @@ func (ce *Client) pingSessionsLoop(ctx context.Context) {
 // give up on a session and close it. Set to 2 so a single transient
 // hiccup (packet loss, brief server blip) does not kill the session.
 const pingDeadThreshold = 2
+
+// pingSessionsInterval is how often each client pings its server
+// sessions for liveness. A dead / half-open session is only evicted
+// (and then re-dialed by the reconnect loop) after pingDeadThreshold
+// consecutive failures, so worst-case recovery is roughly
+// pingSessionsInterval * pingDeadThreshold. This matters most for
+// services (MinSessions=0, sessions to ALL servers): until a degraded
+// session is evicted, reconnectMissing skips that server (it still has
+// a session entry) and the service keeps advertising it via
+// ConnectedServersPK / /health while forwards through it fail. Kept
+// short (20s → ~40s worst-case recovery) so services don't appear
+// connected to servers they can't actually forward through for minutes.
+const pingSessionsInterval = 20 * time.Second
 
 func (ce *Client) pingSessions(_ context.Context, fails map[*SessionCommon]int) {
 	sessions := ce.allClientSessions(ce.porter)


### PR DESCRIPTION
## Symptom

The live `dmsg-discovery` advertises **all 8** dmsg servers in `/health` (`dmsg_servers`), but is reliably reachable over dmsg through only **~1–2 of them at any instant**, and the working set **flaps run to run**. Measured with a direct-client probe pinned to each server one at a time:

```
run1: 2/8 reachable   run2: 3/8   run3: 1/8   run4: 2/8
(one lightly-loaded server always works; the busy official cluster flaps)
```

Downstream, any visor whose direct client (`dmsgDC`) lands on one of the currently-dead servers fails every dmsg-first discovery lookup (`dmsg error 202 - cannot connect to delegated server`) and falls back to HTTP — on every poll.

## Root cause

A dmsg client evicts a dead / half-open session only after `pingDeadThreshold` (2) consecutive ping failures, and `pingSessionsLoop` ran every **60s** → a degraded session lingered up to **~120s** before eviction. Meanwhile `reconnectMissing` *skips any server that still has a session entry* (`if _, ok := ce.session(entry.Static); ok { continue }`), so the dead session isn't re-dialed until it's evicted.

For a **service** (`MinSessions:0`, sessions to *all* servers — e.g. the discovery, `pkg/services/dmsgdisc/dmsgdisc.go:216`) this means: when a session to an overloaded server goes half-open, the service keeps reporting that server via `ConnectedServersPK()` / `/health` (refreshed every 1s) and keeps it in the map, while forwards through it fail — for up to two minutes. With several official servers churning, a random subset is always mid-eviction → the measured flapping.

## Fix

Drop the liveness-ping interval to **20s** (named const `pingSessionsInterval`), so worst-case dead-session recovery is **~40s** (`2 × 20s`) instead of ~120s. `pingDeadThreshold` stays **2**, so a single transient ping blip still won't kill a healthy session. Ping is a lightweight smux keepalive — 3× frequency is negligible bandwidth against the reachability win.

## Scope / honesty

This fixes the **recovery-lag** half — services stop advertising and lingering on servers they can't forward through. It does **not** fix *why* the official servers drop sessions in the first place (they each carry ~400–600 clients per the discovery's `all_servers` map — i.e. capacity/overload, an operational concern). But faster eviction + the existing 15s reconnect loop keeps the dead window small, which is the code-controllable part and directly reduces the flapping.

`go build ./...`, `go vet`, `golangci-lint`, and `pkg/dmsg/dmsg` tests pass.