### PR TITLE
feat(cli/svc): svc health --service --dmsg-server — per-server service /health over dmsg

### DIFF
--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -2,22 +2,37 @@
 package clisvc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/logging"
 	skyvisor "github.com/skycoin/skywire/pkg/visor"
 )
 
-var directQuery bool
+var (
+	directQuery     bool
+	healthService   string
+	healthViaServer string
+	healthPort      uint16
+)
 
 // RootCmd is the svc command
 var RootCmd = &cobra.Command{
@@ -29,6 +44,9 @@ var RootCmd = &cobra.Command{
 func init() {
 	healthCmd.Flags().BoolVar(&directQuery, "direct", false, "query services directly instead of via visor RPC")
 	healthCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+	healthCmd.Flags().StringVar(&healthService, "service", "", "check ONE service by its dmsg PK (e.g. the dmsg-discovery), routed over dmsg; required with --dmsg-server")
+	healthCmd.Flags().StringVar(&healthViaServer, "dmsg-server", "", "route the /health check through ONE specific dmsg server (PK or PK@host:port) using a standalone direct dmsg client — tests per-server reachability of --service, even for direct-client services not in discovery")
+	healthCmd.Flags().Uint16Var(&healthPort, "port", 80, "service dmsg port for the /health endpoint (default: 80, the dmsghttp log-server port)")
 	healthCmd.Flags().Bool(internal.JSONString, false, "print output as JSON")
 	RootCmd.AddCommand(healthCmd)
 }
@@ -42,6 +60,16 @@ var healthCmd = &cobra.Command{
     Use --direct to query services directly from the CLI.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		var results []skyvisor.ServiceHealthEntry
+
+		// Per-server mode: pin a standalone direct dmsg client to ONE
+		// server and fetch the target service's /health through it. This
+		// is the only path that can test "is service X reachable VIA
+		// server Y", including direct-client services (the dmsg-discovery
+		// itself) that have no discovery entry.
+		if healthViaServer != "" {
+			printHealthResults(cmd, []skyvisor.ServiceHealthEntry{queryServiceViaServer(cmd)})
+			return
+		}
 
 		if !directQuery {
 			// Try via visor RPC first
@@ -179,4 +207,105 @@ func queryServicesDirect(cmdFlags *pflag.FlagSet) []skyvisor.ServiceHealthEntry 
 	}
 
 	return results
+}
+
+// queryServiceViaServer fetches a single service's /health over dmsg
+// through ONE pinned dmsg server, using a standalone direct client.
+// This is how you test whether service X is reachable VIA server Y —
+// it works even for direct-client services (the dmsg-discovery itself)
+// that publish no discovery entry, because the direct client carries a
+// synthetic entry delegating only the pinned server.
+func queryServiceViaServer(cmd *cobra.Command) skyvisor.ServiceHealthEntry {
+	logging.SetLevel(logrus.ErrorLevel)
+	log := logging.MustGetLogger("svc-health")
+
+	entry := skyvisor.ServiceHealthEntry{Name: "service", Status: "DOWN"}
+
+	if healthService == "" {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--dmsg-server requires --service <service-pk>"))
+	}
+	var svcPK cipher.PubKey
+	if err := svcPK.Set(healthService); err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid --service pk %q: %w", healthService, err))
+	}
+	entry.URL = fmt.Sprintf("dmsg://%s:%d/health", svcPK.Hex(), healthPort)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	srv, err := resolveServerEntry(ctx, healthViaServer, log)
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), err)
+	}
+	entry.Transport = "dmsg via " + srv.Static.String()[:8]
+
+	myPK, mySK := cipher.GenerateKeyPair()
+	dClient := direct.NewClient(direct.GetAllEntries(cipher.PubKeys{myPK, svcPK}, []*disc.Entry{srv}), log)
+	dmsgC, stop, err := direct.StartDmsg(ctx, log, myPK, mySK, dClient, dmsg.DefaultConfig())
+	if err != nil {
+		return entry // DOWN — couldn't even connect to the pinned server
+	}
+	defer stop()
+
+	httpC := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 15 * time.Second}
+	start := time.Now()
+	resp, err := httpC.Get(fmt.Sprintf("http://%s:%d/health", svcPK.Hex(), healthPort))
+	entry.LatencyMs = time.Since(start).Milliseconds()
+	if err != nil {
+		return entry // DOWN — service not reachable via this server
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, rerr := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var health map[string]interface{}
+	if rerr == nil && json.Unmarshal(body, &health) == nil {
+		if bi, ok := health["build_info"].(map[string]interface{}); ok {
+			if v, ok := bi["version"].(string); ok {
+				entry.Version = v
+			}
+		}
+		if entry.Version == "" {
+			if v, ok := health["version"].(string); ok {
+				entry.Version = v
+			}
+		}
+	}
+	if resp.StatusCode == http.StatusOK {
+		entry.Status = "OK"
+	} else {
+		entry.Status = fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
+	return entry
+}
+
+// resolveServerEntry turns a "--dmsg-server" spec into a dmsg server
+// entry. Accepts "<pk>" (address resolved from the discovery's
+// all_servers) or "<pk>@<host:port>" (no discovery dependency).
+func resolveServerEntry(ctx context.Context, spec string, log *logging.Logger) (*disc.Entry, error) {
+	pkHex, addr := spec, ""
+	if at := strings.IndexByte(spec, '@'); at > 0 {
+		pkHex, addr = spec[:at], spec[at+1:]
+	}
+	var srvPK cipher.PubKey
+	if err := srvPK.Set(pkHex); err != nil {
+		return nil, fmt.Errorf("--dmsg-server: invalid server pk %q: %w", pkHex, err)
+	}
+	if addr != "" {
+		return &disc.Entry{Static: srvPK, Server: &disc.Server{Address: addr}}, nil
+	}
+	discURL := deployment.Prod.DmsgDiscovery
+	if discURL == "" {
+		discURL = "http://dmsgd.skywire.skycoin.com"
+	}
+	dc := disc.NewHTTP(discURL, &http.Client{Timeout: 15 * time.Second}, log)
+	servers, err := dc.AllServers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("--dmsg-server: resolve %s via all_servers: %w (or pass <pk>@<host:port>)", srvPK, err)
+	}
+	for _, s := range servers {
+		if s.Static == srvPK {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("--dmsg-server: %s not found in discovery all_servers (pass <pk>@<host:port>)", srvPK)
 }


### PR DESCRIPTION
## What

`skywire cli svc health` checks every deployment service's `/health` over dmsg, but always via whatever path the dmsg client happens to pick. There was **no way to ask "is service X reachable *via* dmsg server Y"** — the exact diagnostic you need when a service's reachability flaps across servers (e.g. the dmsg-discovery appearing healthy through some servers and unreachable through others).

This adds a per-server mode:

```
skywire cli svc health --service <service-pk> --dmsg-server <server-pk>
```

- Spins a **standalone direct dmsg client pinned to that one server** (a synthetic entry delegating only it) and fetches `http://<service-pk>:<port>/health` through it.
- Reports `OK`/`DOWN` + latency + version, in the same table.
- Works even for **direct-client services that publish no discovery entry** — notably the **dmsg-discovery itself** (the original motivating case), since the direct client carries a synthetic target entry.

`--dmsg-server` accepts a bare PK (address resolved from the discovery's `all_servers`) or `<pk>@<host:port>` (no discovery dependency). `--port` defaults to `80` (the dmsghttp log-server port). The default all-services behavior of `svc health` is unchanged.

## Why

This came out of debugging why visors get constant `dmsg error 202` on discovery lookups. The root cause turned out to be TCP-path-level (high RTT + reordering between the discovery host and remote dmsg servers throttling cwnd), and pinning a health check to a single server is what isolates it. That capability didn't exist as a command — only generic `dmsg curl` / throwaway Go.

## Verified live

```
# discovery via a healthy server
svc health --service 022e607e… --dmsg-server 0326978f…   → OK   140ms  v1.3.62
# discovery via a backpressured server
svc health --service 022e607e… --dmsg-server 02c48393…   → DOWN
```

Reproduces the per-server reachability split on demand.

`go build ./...`, `go vet`, `golangci-lint` clean.