### PR TITLE
fix(cxo/node): buffer delcq so connection cleanup doesn't block the actor

### DIFF
--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -84,7 +84,7 @@ func newNodeFeeds(node *Node) (n *nodeFeeds) {
 	n.addcfq = make(chan connFeed) // add connection to a feed
 	n.delcfq = make(chan connFeed) // del connection from a feed
 
-	n.delcq = make(chan *Conn)
+	n.delcq = make(chan *Conn, 512) // buffered so (*Conn).run exit doesn't block the actor on the rrq path
 
 	n.brorq = make(chan connRoot)
 


### PR DESCRIPTION
## Problem

Production transport-discovery accumulated **38,760 goroutines (92% of total)** stuck in `(*nodeFeeds).delConn` at `feeds.go:394`, each blocked sending into the **unbuffered `delcq`** channel. Heap held **1.94 GB inuse** — 550 MB flat in `cxo/node/transport.newConnection` + 320 MB in `bufio.NewReaderSize` — because every stuck sender retained its `*Conn` (and its bufio buffers) on its goroutine stack.

## Root cause

`nodeFeeds.handle()` is a single actor goroutine selecting across 13 channels. When it serves a heavy `receivedRoot` (the publish path allocates ~671 MB through `cipher.Serialize` per traversed branch), every `(*Conn).run` exit on a dropped dmsg peer queues at the unbuffered `delcq` send and parks there until the actor finishes the root and loops back. Under production CXO churn the actor never drains fast enough to keep queue depth at zero, so connection-close goroutines pile up holding heap that should already be GC-eligible.

## Fix

Buffer `delcq` (512). The closing-conn goroutine returns immediately, frees its stack, and drops the `*Conn` into a fixed-size slot the actor processes on its next loop. `handleDelConn` is microsecond-fast direct map deletes (not channel sends), so 512 absorbs realistic disconnect bursts during root processing without trading goroutine stacks for an unbounded heap queue (worst case ~500 MB held in the buffer, bounded).

`handle()`'s `closeq` case still drains the buffer at shutdown via the existing select; the unbuffered `closeq` race is unchanged because `terminate()` iterates `n.fs` to close per-feed handles directly, not through `delcq`.

## Validation

- `go test -race -count=1 ./pkg/cxo/node/...` passes.
- Heap/goroutine profiles captured independently on two deployment hosts match the same shape (delConn senders + newConnection/bufio retention).
- Builds on top of #2907 (sharded conn maps), already merged.