### PR TITLE
feat(rewards/ui): per-pool tables + bandwidth-mode shares SKY column fix

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1032,13 +1032,26 @@ func buildRouter() *gin.Engine {
 				_, err3 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), "_ineligible.csv", "", -1))
 				_, err4 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), "_shares.csv", "", -1))
 				_, err5 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), ".txt", "", -1))
-				if err1 != nil && err2 != nil && err3 != nil && err4 != nil && err5 != nil {
+				// Per-pool detail CSVs from the bandwidth-mode reward calc
+				// (PR #2946). Served as raw text — they have non-standard
+				// column layouts (pool1_shares: presence-share+P1 SKY;
+				// pool2_shares: bytes+weight+P2 SKY; pool*_rewardtxn0:
+				// per-pool aggregation by address) so falling through to
+				// the same raw-bytes serving branch as _rewardtxn0.csv is
+				// the right move — no per-column rewrite needed for now.
+				_, err6 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), "_pool1_shares.csv", "", -1))
+				_, err7 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), "_pool2_shares.csv", "", -1))
+				_, err8 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), "_pool1_rewardtxn0.csv", "", -1))
+				_, err9 := time.Parse("2006-01-02", strings.Replace(c.Param("date"), "_pool2_rewardtxn0.csv", "", -1))
+				if err1 != nil && err2 != nil && err3 != nil && err4 != nil && err5 != nil &&
+					err6 != nil && err7 != nil && err8 != nil && err9 != nil {
 					fmt.Println("cant parse date or match filename")
 					c.Writer.WriteHeader(http.StatusNotFound)
 					c.Writer.Flush()
 					return
 				}
-				if err1 == nil || err2 == nil || err5 == nil {
+				if err1 == nil || err2 == nil || err5 == nil ||
+					err6 == nil || err7 == nil || err8 == nil || err9 == nil {
 					filetoserve, err := script.File(wd + `/hist/` + c.Param("date")).Bytes()
 					if err == nil {
 						c.Writer.Header().Set("Content-Type", "text/plain")
@@ -1157,6 +1170,16 @@ func buildRouter() *gin.Engine {
 			if err != nil {
 				l += "<div style='float: right;'>PK,Share,SKY Amount\nReward shares file not found\nerror: " + err.Error() + "\n\n"
 			} else {
+				// Bandwidth-mode shares.csv has 11 columns where col4 is
+				// "Bandwidth (bytes)" and col5 is "Total Reward SKY";
+				// legacy-mode has 10 columns where col4 is the SKY amount
+				// and col5 is the IP. Detect the layout from the header
+				// row so the wrong column doesn't get displayed as SKY.
+				bwMode := len(l2) > 0 && strings.Contains(l2[0], "Bandwidth (bytes)")
+				skyCol := 4
+				if bwMode {
+					skyCol = 5
+				}
 				l += "<div style='float: right;'>PK,Share,SKY Amount\n"
 				for i, line := range l2 {
 					if i == 0 {
@@ -1176,9 +1199,9 @@ func buildRouter() *gin.Engine {
 						c.Writer.Flush()
 						return
 					}
-					sky, err := script.Echo(line).Column(4).String()
+					sky, err := script.Echo(line).Column(skyCol).String()
 					if err != nil {
-						fmt.Println("non nil script.Echo(line).Column(4).String() error")
+						fmt.Printf("non nil script.Echo(line).Column(%d).String() error\n", skyCol)
 						c.Writer.WriteHeader(http.StatusNotFound)
 						c.Writer.Flush()
 						return
@@ -1205,6 +1228,46 @@ func buildRouter() *gin.Engine {
 					}
 				}
 			}
+
+			// Per-pool detail tables (from PR #2946 calc.go side outputs).
+			// Each section reads the corresponding hist/<date>_pool[12]_*.csv
+			// and renders PK + qualifier + per-pool SKY. Missing files are
+			// silently skipped — they may not exist on dates that
+			// pre-date the per-pool feature, or when running without
+			// bandwidth mode.
+			//   pool1_shares.csv columns: SkyAddr, PK, PresenceShare, Pool1SKY, IP, Arch, UUID, Interfaces, Country, XPub
+			//   pool2_shares.csv columns: SkyAddr, PK, Bandwidth(bytes), Pool2Weight, Pool2SKY, IP, ...
+			l2, err = script.File(wd + `/hist/` + c.Param("date") + "_pool1_shares.csv").Slice()
+			if err == nil {
+				l += "\n\nPool 1 (Presence):\nPK,Presence Share,Pool 1 SKY\n"
+				for i, line := range l2 {
+					if i == 0 {
+						continue
+					}
+					thispk, _ := script.Echo(line).Column(2).String() //nolint:errcheck,gosec
+					share, _ := script.Echo(line).Column(3).String()  //nolint:errcheck,gosec
+					p1sky, _ := script.Echo(line).Column(4).String()  //nolint:errcheck,gosec
+					l += "<a id='" + strings.TrimRight(thispk, ",\n") + "'>" + strings.TrimRight(thispk, ",\n") + "</a>," + strings.TrimRight(share, "\n") + strings.Replace(p1sky, ",\n", "\n", -1)
+				}
+			}
+			l2, err = script.File(wd + `/hist/` + c.Param("date") + "_pool2_shares.csv").Slice()
+			if err == nil {
+				l += "\n\nPool 2 (Bandwidth):\nPK,Bandwidth (bytes),Pool 2 SKY\n"
+				for i, line := range l2 {
+					if i == 0 {
+						continue
+					}
+					thispk, _ := script.Echo(line).Column(2).String() //nolint:errcheck,gosec
+					bytes, _ := script.Echo(line).Column(3).String()  //nolint:errcheck,gosec
+					p2sky, _ := script.Echo(line).Column(5).String()  //nolint:errcheck,gosec
+					// Column(3) already brings the trailing comma so
+					// it serves as the separator before p2sky — no
+					// explicit "," needed (matches Pool 1 + main shares
+					// render pattern).
+					l += "<a id='" + strings.TrimRight(thispk, ",\n") + "'>" + strings.TrimRight(thispk, ",\n") + "</a>," + strings.TrimRight(bytes, "\n") + strings.Replace(p2sky, ",\n", "\n", -1)
+				}
+			}
+
 			l += "</div>"
 
 			l1, err = script.File(wd + `/hist/` + c.Param("date") + "_stats.txt").String()


### PR DESCRIPTION
## Summary

Three additive changes to `cmd/skywire-cli/commands/rewards/server/server.go` for the `/skycoin-rewards/hist/:date` route. Follows up #2946 which added the per-pool CSV outputs.

### 1. Per-pool tables on the date page

Reads `hist/<date>_pool1_shares.csv` and `hist/<date>_pool2_shares.csv` (emitted by the calc since #2946) and renders two new sections in the right-floating column, appearing after the existing shares + ineligible lists:

```
Pool 1 (Presence):       PK, Presence Share, Pool 1 SKY
Pool 2 (Bandwidth):      PK, Bandwidth (bytes), Pool 2 SKY
```

Pool 2 includes senders only (rows where `Bandwidth > 0`, by the calc's filtering in #2946). Missing files are silently skipped — dates that pre-date #2946 continue to render exactly as before.

### 2. Direct-serve regex extended

The route already supported raw-text downloads for `_rewardtxn0.csv`, `_stats.txt`, `.txt`. The four new per-pool CSVs (`_pool[12]_{shares,rewardtxn0}.csv`) now match the same date-suffix probe and fall through to the raw-bytes serving branch, so operators can `curl /skycoin-rewards/hist/2026-05-31_pool1_shares.csv` directly.

### 3. Bug fix — bandwidth-mode shares SKY column

The combined `_shares.csv` has different column layouts in bandwidth vs legacy mode:

| Mode | Cols | Layout |
|---|---|---|
| legacy | 10 | SkyAddr, PK, Shares, **SKY**, IP, Arch, … |
| bandwidth | 11 | SkyAddr, PK, PresenceShare, Bandwidth (bytes), **Total SKY**, IP, … |

The UI hard-coded `script.Echo(line).Column(4).String()` — correct for legacy mode, but in bandwidth mode that reads `Bandwidth (bytes)` and displayed it in the `SKY Amount` position. Every row in the main shares table on every bandwidth-mode reward day rendered the wrong value silently.

Fix: detect bandwidth mode by checking the header for `"Bandwidth (bytes)"` and pick `Column(5)` accordingly.

## Verification

Tested locally against the recovered 2026-05-31 data (671 qualifying visors). For visor `020a4c4fe187e43b1d391e62217e430eafb470770ca1f294b0daff3130d6e65210` (presence share 0.565402, P1 0.977, P2 0.925, bandwidth 2232 bytes):

| Section | Rendered | Correct |
|---|---|---|
| Main shares row | `pk, 0.565402, 1.901925` (= 0.977 + 0.925, **total** SKY) | ✅ |
| Pool 1 (new) | `pk, 0.565402, 0.976834` (share + P1 SKY) | ✅ |
| Pool 2 (new) | `pk, 2232, 0.925092` (bytes + P2 SKY) | ✅ |

Before the fix, the main shares row would have shown `pk, 0.565402, 2232` — bandwidth bytes in the SKY column.

Direct-serve verified: all 4 of `_pool[12]_{shares,rewardtxn0}.csv` return HTTP 200 with their raw CSV bodies (sizes 190150 / 37434 / 4074 / 1830 bytes for the 2026-05-31 dataset).

## Test plan

- [ ] Restart `fiberreward.service` (or equivalent) after binary update.
- [ ] Visit `/skycoin-rewards/hist/<date>` for a bandwidth-mode day — confirm Pool 1 + Pool 2 sections appear after the existing shares/ineligible blocks.
- [ ] Confirm the main shares column shows a SKY-looking float (e.g. `0.x` or `1.x`), NOT a large integer (which would be bytes).
- [ ] Visit `/skycoin-rewards/hist/<date>` for an OLD date that pre-dates #2946 — no Pool 1/Pool 2 sections should appear (graceful skip).
- [ ] `curl /skycoin-rewards/hist/<date>_pool1_shares.csv` returns the CSV body directly.

## Non-goals

- No template/HTML/CSS restructure. The new sections follow the existing text-based table render pattern (PK as `<a id>` anchor + comma-separated values inside the right-floating div).
- No per-pool rewardtxn0 inline rendering. The combined rewardtxn0 table is the operational record (it's what gets broadcast); per-pool aggregations are accessible via the new direct-download routes for operators who need them.
- The empty `_shares.csv` page rendering (when no qualifying visors) is unchanged.