### PR TITLE
fix(skywire-cli): isUnderBase boundary match — stop /all-transports/per-key-stats aliasing onto the CXO feed

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -471,7 +471,8 @@ func isUnderBase(rawURL, base, suffix string) bool {
 	if len(rawURL) == len(target) {
 		return true
 	}
-	return rawURL[len(target)] == '?'
+	next := rawURL[len(target)]
+	return next == '?' || next == '#'
 }
 
 // queryParam extracts a single query-string value by name. Returns

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -456,15 +456,22 @@ func cxoFeedForURL(rawURL string) (feed, path string, ok bool) {
 	return "", "", false
 }
 
-// isUnderBase reports whether rawURL begins with `base + suffix`.
-// Empty bases never match — keeps deployment configs without a DMSG
-// equivalent from accidentally aliasing onto every URL.
+// isUnderBase reports whether rawURL matches `base + suffix` exactly
+// or with a query string. A trailing sub-path (e.g. /per-key-stats on
+// top of /all-transports) is a different endpoint and must not match.
+// Empty bases never match.
 func isUnderBase(rawURL, base, suffix string) bool {
 	if base == "" {
 		return false
 	}
 	target := base + suffix
-	return len(rawURL) >= len(target) && rawURL[:len(target)] == target
+	if len(rawURL) < len(target) || rawURL[:len(target)] != target {
+		return false
+	}
+	if len(rawURL) == len(target) {
+		return true
+	}
+	return rawURL[len(target)] == '?'
 }
 
 // queryParam extracts a single query-string value by name. Returns

--- a/cmd/skywire-cli/commands/rpc/root_test.go
+++ b/cmd/skywire-cli/commands/rpc/root_test.go
@@ -1,0 +1,36 @@
+// Package clirpc root_test.go
+package clirpc
+
+import "testing"
+
+// TestIsUnderBase locks in the boundary behavior that distinguishes
+// base+suffix from sub-paths beneath it. The pre-fix prefix match
+// caused /all-transports/per-key-stats to alias onto /all-transports
+// and poisoned the CXO subscriber-cache for the 2026-05-31 reward day.
+func TestIsUnderBase(t *testing.T) {
+	const (
+		base   = "https://tpd.skywire.skycoin.com"
+		suffix = "/all-transports"
+	)
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{base + suffix, true},                            // exact
+		{base + suffix + "?selfTransports=true", true},   // query
+		{base + suffix + "#frag", true},                  // fragment
+		{base + suffix + "/per-key-stats", false},        // sub-path — the bug
+		{base + suffix + "/stats", false},                // sub-path — sibling
+		{base + suffix + "extra", false},                 // no boundary char
+		{base + "/other", false},                         // unrelated path
+		{"", false},                                      // empty
+	}
+	for _, c := range cases {
+		if got := isUnderBase(c.url, base, suffix); got != c.want {
+			t.Errorf("isUnderBase(%q,%q,%q) = %v, want %v", c.url, base, suffix, got, c.want)
+		}
+	}
+	if isUnderBase("https://x/y", "", "/y") {
+		t.Error("empty base must never match")
+	}
+}


### PR DESCRIPTION
## Problem

`cxoFeedForURL`'s `isUnderBase` used a plain prefix compare, so `/all-transports/per-key-stats` (a different TPD endpoint) matched the `/all-transports` branch and resolved to the `tpd-all-transports` CXO feed. The visor served the 9754-entry transport listing for that key; `parsePerKeyStats` lenient-unmarshals each entry into `{PK,Total,ByType}` with `PK=""` (no `.pk` field in the raw transport JSON), so every entry overwrites `stats[""]` and the result is a map of length 1 — "Fetched transport stats for 1 visor". That is the mechanism by which the 2026-05-31 reward calc treated 1 visor as eligible and distributed 0 SKY.

## Fix

Tighten `isUnderBase`: a match requires `base+suffix` to be the whole URL or be followed by a query (`?`) or fragment (`#`). A trailing sub-path (e.g. `/per-key-stats`) no longer matches and falls through to the normal RPC/DMSG/HTTP chain — correct for endpoints with no CXO publisher.

## Tests

New table-test (`root_test.go`) pins the boundary contract: exact / `?query` / `#frag` → match; `/per-key-stats`, `/stats`, `extra`, `/other`, empty → no match.

## Relation to #2945

Orthogonal. #2945 fixed the delcq goroutine leak that froze the CXO publisher actor; this fixes a URL→feed misroute that returned the wrong content even on a healthy cache. Both contributed to 2026-05-31. Reviewed (Alpha); diagnosed by Magneto, cross-confirmed by Gamma + Alpha.