### PR TITLE
fix(rewards/ui): exclude per-pool CSVs from /skycoin-rewards/csv endpoint

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -920,11 +920,16 @@ func buildRouter() *gin.Engine {
 				c.Writer.Write([]byte("skywire skycoin cli status:\n\n" + status + "\n\nskywire skycoin cli status error:\n\n" + err.Error())) //nolint:errcheck,gosec
 				return
 			}
-			//find all transacion csvs
-			f, err := script.FindFiles(wd + `/hist/`).MatchRegexp(regexp.MustCompile(".*_rewardtxn0.csv")).Slice()
+			// Find all combined transaction CSVs. Anchored to
+			// YYYY-MM-DD_rewardtxn0.csv so the per-pool variants
+			// (_pool1_rewardtxn0.csv / _pool2_rewardtxn0.csv) from
+			// PR #2946 are NOT listed here — those are informational
+			// only, not broadcast inputs, and would derail the
+			// distribution flow.
+			f, err := script.FindFiles(wd + `/hist/`).MatchRegexp(regexp.MustCompile(`[0-9]{4}-[0-9]{2}-[0-9]{2}_rewardtxn0\.csv$`)).Slice()
 			if err != nil {
 				c.Writer.WriteHeader(http.StatusInternalServerError)
-				c.Writer.Write([]byte(`script.FindFiles(wd + /hist/).MatchRegexp(regexp.MustCompile(".*_rewardtxn0.csv")).Slice():\n\n` + strings.Join(f, "\n") + "\n\nError:\n\n" + err.Error())) //nolint:errcheck,gosec
+				c.Writer.Write([]byte("script.FindFiles(wd + /hist/).MatchRegexp(combined rewardtxn0).Slice():\n\n" + strings.Join(f, "\n") + "\n\nError:\n\n" + err.Error())) //nolint:errcheck,gosec
 				return
 			}
 			//and range through the results
@@ -982,7 +987,11 @@ func buildRouter() *gin.Engine {
 				return
 			}
 			c.Writer.Header().Set("Server", "")
-			f, _ := script.FindFiles(wd + `/hist/`).MatchRegexp(regexp.MustCompile(".*_rewardtxn0.csv")).Basename().Slice() //nolint:errcheck,gosec
+			// Anchored to YYYY-MM-DD_rewardtxn0.csv so per-pool variants
+			// (_pool1_rewardtxn0.csv / _pool2_rewardtxn0.csv from PR
+			// #2946) are excluded — they are informational, not
+			// broadcast inputs.
+			f, _ := script.FindFiles(wd + `/hist/`).MatchRegexp(regexp.MustCompile(`[0-9]{4}-[0-9]{2}-[0-9]{2}_rewardtxn0\.csv$`)).Basename().Slice() //nolint:errcheck,gosec
 			for _, f1 := range f {
 				g, err := script.File(wd + `/hist/` + strings.Replace(f1, "_rewardtxn0.csv", ".txt", -1)).String()
 				if err != nil || g == "" || g == "\n" || g == "test" || g == "test\n" {
@@ -1010,7 +1019,11 @@ func buildRouter() *gin.Engine {
 			}
 			c.Writer.Header().Set("Server", "")
 			c.Writer.Header().Set("Content-Type", "text/plain")
-			f, _ := script.FindFiles(wd + `/hist/`).MatchRegexp(regexp.MustCompile(".*_rewardtxn0.csv")).Basename().Slice() //nolint:errcheck,gosec
+			// Anchored to YYYY-MM-DD_rewardtxn0.csv so per-pool variants
+			// (_pool1_rewardtxn0.csv / _pool2_rewardtxn0.csv from PR
+			// #2946) are excluded — they are informational, not
+			// broadcast inputs.
+			f, _ := script.FindFiles(wd + `/hist/`).MatchRegexp(regexp.MustCompile(`[0-9]{4}-[0-9]{2}-[0-9]{2}_rewardtxn0\.csv$`)).Basename().Slice() //nolint:errcheck,gosec
 			for _, f1 := range f {
 				g, _ := script.File(wd + `/hist/` + strings.Replace(f1, "_rewardtxn0.csv", ".txt", -1)).String() //nolint:errcheck,gosec
 				if g != "" && g != "\n" {

--- a/cmd/skywire-cli/commands/rpc/root_test.go
+++ b/cmd/skywire-cli/commands/rpc/root_test.go
@@ -16,14 +16,14 @@ func TestIsUnderBase(t *testing.T) {
 		url  string
 		want bool
 	}{
-		{base + suffix, true},                            // exact
-		{base + suffix + "?selfTransports=true", true},   // query
-		{base + suffix + "#frag", true},                  // fragment
-		{base + suffix + "/per-key-stats", false},        // sub-path — the bug
-		{base + suffix + "/stats", false},                // sub-path — sibling
-		{base + suffix + "extra", false},                 // no boundary char
-		{base + "/other", false},                         // unrelated path
-		{"", false},                                      // empty
+		{base + suffix, true},                          // exact
+		{base + suffix + "?selfTransports=true", true}, // query
+		{base + suffix + "#frag", true},                // fragment
+		{base + suffix + "/per-key-stats", false},      // sub-path — the bug
+		{base + suffix + "/stats", false},              // sub-path — sibling
+		{base + suffix + "extra", false},               // no boundary char
+		{base + "/other", false},                       // unrelated path
+		{"", false},                                    // empty
 	}
 	for _, c := range cases {
 		if got := isUnderBase(c.url, base, suffix); got != c.want {


### PR DESCRIPTION
## Summary

Regression from #2946. The `/skycoin-rewards/csv` and `/skycoin-rewards/csv/plain` endpoints — which the operator-side `sendrewards.sh` distribution script consumes to discover the next undistributed reward date — used the regex `.*_rewardtxn0.csv` to enumerate broadcast inputs.

After #2946 introduced `_pool1_rewardtxn0.csv` / `_pool2_rewardtxn0.csv` side-channel files into the same hist/ directory, that pattern matches all three variants per date. Because `_pool1_…` sorts lexicographically before `_rewardtxn0.csv` (`p` < `r`), the loop returns the pool variant first. The distribution script then substitutes `_rewardtxn0.csv` → `_stats.txt`, requests `<date>_pool1_stats.txt` (doesn't exist), gets empty content, and presents **no preview** to the operator before broadcast.

Operator hit this trying to broadcast the 2026-05-09 backlog distribution — saw `Reward system status: inactive` followed immediately by the `Send rewards? [y/N]:` prompt with no stats block in between.

## Fix

Anchor the regex to a strict `YYYY-MM-DD` prefix immediately followed by `_rewardtxn0.csv$` at the three over-greedy callsites (lines 924, 985, 1013). The pool variants no longer pass the filter.

The other two callsites (lines 784 + 1346, the main rewards-list page) already use a different anchored pattern (`.?.?.?.?-.?.?-.?.?_rewardtxn0.csv`) that doesn't match `_pool1_…`, so they're untouched.

## Verification

Standalone regex test:

```
input                                       old=.*_rewardtxn0.csv    new=[0-9]{4}-[0-9]{2}-[0-9]{2}_rewardtxn0\.csv$
hist/2026-05-09_rewardtxn0.csv              true                     true   ✓
hist/2026-05-09_pool1_rewardtxn0.csv        true                     false  ✓ excluded
hist/2026-05-09_pool2_rewardtxn0.csv        true                     false  ✓ excluded
hist/2026-05-31_rewardtxn0.csv              true                     true   ✓
hist/2026-05-31_pool1_rewardtxn0.csv        true                     false  ✓ excluded
```

Tested live: with pool-marker workaround (`<date>_pool1.txt` / `<date>_pool2.txt` set to non-empty content per the loop's "skip distributed" semantics), `/skycoin-rewards/csv` returns `skycoin-rewards/hist/2026-05-09_rewardtxn0.csv` correctly. Without the workaround but with this PR's binary, same result via the regex itself.

## Operator-side immediate workaround (before this PR deploys)

```bash
cd /path/to/hist
for f in *_pool[12]_rewardtxn0.csv; do
  marker="${f%_rewardtxn0.csv}.txt"
  echo "informational-only (not broadcast); per PR #2946 / fix-pending" > "$marker"
done
```

This populates the `_pool[12].txt` marker slot the loop's "already distributed" check looks at, so the loop skips the pool variants and falls through to the combined `_rewardtxn0.csv`. Safe to delete the markers after this PR lands.

## Test plan

- [ ] `curl /skycoin-rewards/csv` returns `skycoin-rewards/hist/<date>_rewardtxn0.csv` (NOT `…_pool1_…`).
- [ ] `curl /skycoin-rewards/csv/plain` 302-redirects to `/skycoin-rewards/hist/<date>_rewardtxn0.csv`.
- [ ] `sendrewards.sh` now shows the full stats preview before the y/N prompt.
- [ ] Main rewards page (`/skycoin-rewards/`) still lists all distributed and undistributed dates correctly (line 784/1346 unchanged).

Follows up #2946 + #2947.