### PR TITLE
feat(skychat): CXO-backed messaging over native TCP in standalone (P2P, no dmsg)

### DIFF
--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -81,15 +81,15 @@ func startCXOTCP(ctx context.Context) error {
 				surfaceCXOInbound(fpk, string(ev.Value))
 			}
 		})
-		if cerr := sub.ConnectTCP(ctx, addr); cerr != nil {
-			// Non-fatal: the reconnect watchdog retries by address.
-			appLog("skychat: cxo ConnectTCP %s (%s) failed (watchdog will retry): %v", addr, fpk, cerr)
-		} else {
-			appLog("skychat: cxo subscribed to feed %s via %s", fpk, addr)
-		}
 		cxoMu.Lock()
 		cxoSubs = append(cxoSubs, sub)
 		cxoMu.Unlock()
+		// Retry the initial dial until it connects — the peer may not be
+		// listening yet at startup. ConnectTCP arms the reconnect
+		// watchdog only after a first success, so a failed initial dial
+		// would otherwise never retry; the watchdog handles re-connects
+		// once we are connected.
+		go cxoDialUntilConnected(ctx, sub, addr, fpk)
 	}
 
 	go func() {
@@ -104,6 +104,30 @@ func startCXOTCP(ctx context.Context) error {
 		}
 	}()
 	return nil
+}
+
+// cxoDialUntilConnected retries Subscriber.ConnectTCP with capped
+// exponential backoff until the first successful connect (the peer may
+// not be listening yet at startup). After success the subscriber's
+// reconnect watchdog takes over, so this returns.
+func cxoDialUntilConnected(ctx context.Context, sub *treestore.Subscriber, addr, fpk string) {
+	backoff := time.Second
+	for {
+		err := sub.ConnectTCP(ctx, addr)
+		if err == nil {
+			appLog("skychat: cxo subscribed to feed %s via %s", fpk, addr)
+			return
+		}
+		appLog("skychat: cxo dial %s (%s) failed, retry in %s: %v", addr, fpk, backoff, err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
 }
 
 // publishCXO publishes a chat message body to our own CXO feed. Every

--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -223,7 +223,7 @@ func startCXOGroup(ctx context.Context) error {
 		},
 		TCPListenAddr: cxoListen,
 		PeerAddrs:     peerAddrs,
-		DataDir:       filepath.Join(os.TempDir(), "skychat-cxo"),
+		DataDir:       filepath.Join(os.TempDir(), "skychat-cxo-data"),
 		Logger:        logging.MustGetLogger("skychat-cxo-group"),
 		BatchWindow:   300 * time.Millisecond,
 	})

--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -245,6 +245,34 @@ func startCXOGroup(ctx context.Context) error {
 			appLog("skychat: cxo-group Connect: %v", cerr)
 		}
 	}()
+	// group.Session (used here without the group Manager) does not retry a
+	// peer-sub whose INITIAL connect failed — the treestore watchdog only
+	// arms after a first success. Drive reconnects ourselves: periodically
+	// re-attempt every member peer that has never delivered (PeerLastInbound
+	// zero, i.e. never connected). Once a peer connects and its first Root
+	// lands, lastInbound is set and the treestore watchdog takes over
+	// quiet-reconnects, so we stop poking it.
+	go func() {
+		t := time.NewTicker(15 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				for _, ppk := range members {
+					if ppk == pk || !sess.PeerLastInbound(ppk).IsZero() {
+						continue
+					}
+					rctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+					if rerr := sess.ReconnectPeer(rctx, ppk); rerr != nil {
+						appLog("skychat: cxo-group reconnect %s: %v", ppk, rerr)
+					}
+					cancel()
+				}
+			}
+		}
+	}()
 	go func() {
 		<-ctx.Done()
 		_ = sess.Close() //nolint:errcheck

--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -1,0 +1,167 @@
+// Package commands — cxo_tcp.go: CXO-backed messaging over the CXO
+// node's NATIVE TCP transport (no dmsg). Opt-in via --cxo; works in
+// --standalone. Outbound /message is published to our own CXO feed;
+// each --cxo-peer feed is subscribed and surfaced on the SSE stream,
+// reusing the same /message + /sse surfaces as the tcp-direct bridge.
+//
+// A 1:1 P2P pair is just a two-member group on this publish/subscribe
+// mechanism, so groups (docs/skychat_cxo_tcp_standalone.md, Phase 2)
+// extend this by adding more --cxo-peer subscriptions to a shared feed.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+)
+
+var (
+	cxoEnable bool
+	cxoListen string
+	cxoPeers  []string
+
+	cxoMu   sync.Mutex
+	cxoPub  *treestore.Publisher
+	cxoMyPK cipher.PubKey
+	cxoSubs []*treestore.Subscriber
+	cxoSeq  uint64
+)
+
+// startCXOTCP brings up CXO-over-native-TCP messaging when --cxo is set.
+// It publishes our feed on --cxo-listen and subscribes to every
+// --cxo-peer feed, bridging received messages onto the SSE hub. Mirrors
+// startTCPDirect; fully opt-in (returns nil when --cxo is unset). The
+// identity (feed PK) is resolved exactly like tcp-direct (--sk / env /
+// -c config), so the CXO feed PK equals the chat identity.
+func startCXOTCP(ctx context.Context) error {
+	if !cxoEnable {
+		return nil
+	}
+	pk, sk, source, err := resolveTCPIdentity()
+	if err != nil {
+		return fmt.Errorf("cxo: %w", err)
+	}
+	pub, err := treestore.NewWithTCP(cxoListen, sk, treestore.PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 300 * time.Millisecond,
+	})
+	if err != nil {
+		return fmt.Errorf("cxo: publisher on %s: %w", cxoListen, err)
+	}
+	cxoMu.Lock()
+	cxoPub = pub
+	cxoMyPK = pk
+	cxoMu.Unlock()
+	appLog("skychat: cxo feed publishing as pk=%s on %s (identity source: %s)", pk, cxoListen, source)
+
+	for _, spec := range cxoPeers {
+		feedPK, addr, perr := parseCXOPeer(spec)
+		if perr != nil {
+			appLog("skychat: cxo skipping invalid --cxo-peer %q: %v", spec, perr)
+			continue
+		}
+		sub, serr := treestore.NewSubscriberTCP("", feedPK, treestore.SubConfig{InMemoryDB: true})
+		if serr != nil {
+			appLog("skychat: cxo subscriber for %s failed: %v", feedPK, serr)
+			continue
+		}
+		fpk := feedPK.Hex()
+		sub.OnUpdate(func(events []treestore.UpdateEvent) {
+			for _, ev := range events {
+				if ev.Value == nil {
+					continue
+				}
+				surfaceCXOInbound(fpk, string(ev.Value))
+			}
+		})
+		if cerr := sub.ConnectTCP(ctx, addr); cerr != nil {
+			// Non-fatal: the reconnect watchdog retries by address.
+			appLog("skychat: cxo ConnectTCP %s (%s) failed (watchdog will retry): %v", addr, fpk, cerr)
+		} else {
+			appLog("skychat: cxo subscribed to feed %s via %s", fpk, addr)
+		}
+		cxoMu.Lock()
+		cxoSubs = append(cxoSubs, sub)
+		cxoMu.Unlock()
+	}
+
+	go func() {
+		<-ctx.Done()
+		cxoMu.Lock()
+		defer cxoMu.Unlock()
+		for _, s := range cxoSubs {
+			_ = s.Close() //nolint:errcheck
+		}
+		if cxoPub != nil {
+			_ = cxoPub.Close() //nolint:errcheck
+		}
+	}()
+	return nil
+}
+
+// publishCXO publishes a chat message body to our own CXO feed. Every
+// peer subscribed to our feed receives it. Returns the leaf path used.
+func publishCXO(body string) (string, error) {
+	cxoMu.Lock()
+	pub := cxoPub
+	cxoMu.Unlock()
+	if pub == nil {
+		return "", fmt.Errorf("cxo publisher not ready")
+	}
+	seq := atomic.AddUint64(&cxoSeq, 1)
+	// Timestamp-nano + seq keeps paths lexically ordered and unique even
+	// for two messages within the same nanosecond.
+	path := fmt.Sprintf("msgs/%019d-%06d", time.Now().UTC().UnixNano(), seq)
+	if err := pub.Put(path, []byte(body)); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// surfaceCXOInbound pushes a message received from a subscribed CXO feed
+// onto the SSE hub, mirroring handleConn's inbound clientMsg shape.
+func surfaceCXOInbound(senderPK, text string) {
+	counterMu.Lock()
+	inboundMsgCount++
+	lastRxAt = time.Now().UTC()
+	counterMu.Unlock()
+
+	clientMsg, err := json.Marshal(map[string]interface{}{
+		"sender":  senderPK,
+		"message": text,
+		"network": "cxo",
+		"dir":     "in",
+		"id":      newEventID(),
+		"len":     len(text),
+	})
+	if err != nil {
+		appLog("skychat: cxo inbound marshal failed: %v", err)
+		return
+	}
+	hub.broadcast(string(clientMsg))
+}
+
+// parseCXOPeer parses "tcp://<feedpk>@<host:port>".
+func parseCXOPeer(spec string) (cipher.PubKey, string, error) {
+	s := strings.TrimPrefix(spec, "tcp://")
+	at := strings.IndexByte(s, '@')
+	if at <= 0 {
+		return cipher.PubKey{}, "", fmt.Errorf("expected tcp://<feedpk>@<host:port>")
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(s[:at]); err != nil {
+		return cipher.PubKey{}, "", fmt.Errorf("invalid feed pk: %w", err)
+	}
+	addr := s[at+1:]
+	if addr == "" {
+		return cipher.PubKey{}, "", fmt.Errorf("missing host:port")
+	}
+	return pk, addr, nil
+}

--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -13,25 +13,39 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/skycoin/skywire/cmd/apps/skychat/group"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// cxoGroupNominalPort is a non-zero placeholder for group.Record.Port,
+// which is vestigial in native-TCP mode (it drives only the dmsg port +
+// relay offset, both unused on TCP). The session's real listener is
+// --cxo-listen.
+const cxoGroupNominalPort uint16 = 8870
 
 var (
 	cxoEnable bool
 	cxoListen string
 	cxoPeers  []string
 
-	cxoMu   sync.Mutex
-	cxoPub  *treestore.Publisher
-	cxoMyPK cipher.PubKey
-	cxoSubs []*treestore.Subscriber
-	cxoSeq  uint64
+	cxoGroup      string // --cxo-group <id>: enable federated group mode
+	cxoGroupOwner string // --cxo-group-owner <pk>
+
+	cxoMu        sync.Mutex
+	cxoPub       *treestore.Publisher
+	cxoMyPK      cipher.PubKey
+	cxoSubs      []*treestore.Subscriber
+	cxoSeq       uint64
+	cxoGroupSess *group.Session
 )
 
 // startCXOTCP brings up CXO-over-native-TCP messaging when --cxo is set.
@@ -41,6 +55,12 @@ var (
 // identity (feed PK) is resolved exactly like tcp-direct (--sk / env /
 // -c config), so the CXO feed PK equals the chat identity.
 func startCXOTCP(ctx context.Context) error {
+	// Federated group mode (--cxo-group) takes over when set: it uses the
+	// group subsystem (roster / signing / gossip) over the same CXO-TCP
+	// transport instead of the flat per-feed mesh below.
+	if cxoGroup != "" {
+		return startCXOGroup(ctx)
+	}
 	if !cxoEnable {
 		return nil
 	}
@@ -134,8 +154,14 @@ func cxoDialUntilConnected(ctx context.Context, sub *treestore.Subscriber, addr,
 // peer subscribed to our feed receives it. Returns the leaf path used.
 func publishCXO(body string) (string, error) {
 	cxoMu.Lock()
+	sess := cxoGroupSess
 	pub := cxoPub
 	cxoMu.Unlock()
+	// Federated group mode: outbound goes through the group session
+	// (publishes to our own member feed; the group receives via subs).
+	if sess != nil {
+		return "group", sess.Send(body)
+	}
 	if pub == nil {
 		return "", fmt.Errorf("cxo publisher not ready")
 	}
@@ -147,6 +173,83 @@ func publishCXO(body string) (string, error) {
 		return "", err
 	}
 	return path, nil
+}
+
+// startCXOGroup brings up a federated CXO group over native TCP using
+// the group subsystem (roster, signing, gossip — all transport-agnostic)
+// on the dmsg-free TCP transport. Enabled by --cxo-group <id> with
+// --cxo-group-owner <pk>; members and their addresses come from
+// --cxo-peer (tcp://<pk>@host:port). Outbound /message routes through
+// Session.Send; inbound messages surface on the SSE hub. Everyone is an
+// admin (full-mesh peerSubs) so every member follows every other.
+func startCXOGroup(ctx context.Context) error {
+	pk, sk, source, err := resolveTCPIdentity()
+	if err != nil {
+		return fmt.Errorf("cxo-group: %w", err)
+	}
+	var ownerPK cipher.PubKey
+	if err := ownerPK.Set(cxoGroupOwner); err != nil {
+		return fmt.Errorf("cxo-group: invalid --cxo-group-owner %q: %w", cxoGroupOwner, err)
+	}
+
+	peerAddrs := make(map[cipher.PubKey]string)
+	members := []cipher.PubKey{pk}
+	for _, spec := range cxoPeers {
+		ppk, addr, perr := parseCXOPeer(spec)
+		if perr != nil {
+			appLog("skychat: cxo-group skipping invalid --cxo-peer %q: %v", spec, perr)
+			continue
+		}
+		peerAddrs[ppk] = addr
+		members = append(members, ppk)
+	}
+
+	role := group.RoleMember
+	if pk == ownerPK {
+		role = group.RoleOwner
+	}
+
+	sess, err := group.Open(group.Config{
+		MyPK: pk,
+		MySK: sk,
+		Record: group.Record{
+			ID:      cxoGroup,
+			OwnerPK: ownerPK,
+			Port:    cxoGroupNominalPort,
+			Mode:    group.ModePublic,
+			Members: members,
+			Admins:  members, // full-mesh: every member follows every other
+			Role:    role,
+		},
+		TCPListenAddr: cxoListen,
+		PeerAddrs:     peerAddrs,
+		DataDir:       filepath.Join(os.TempDir(), "skychat-cxo"),
+		Logger:        logging.MustGetLogger("skychat-cxo-group"),
+		BatchWindow:   300 * time.Millisecond,
+	})
+	if err != nil {
+		return fmt.Errorf("cxo-group: open %q: %w", cxoGroup, err)
+	}
+	cxoMu.Lock()
+	cxoGroupSess = sess
+	cxoMyPK = pk
+	cxoMu.Unlock()
+	appLog("skychat: cxo-group %q OPEN as pk=%s role=%s on %s, %d members (identity source: %s)",
+		cxoGroup, pk, role, cxoListen, len(members), source)
+
+	sess.SetMessageHandler(func(_ string, sender cipher.PubKey, msg group.Message) {
+		surfaceCXOInbound(sender.Hex(), msg.Text)
+	})
+	go func() {
+		if cerr := sess.Connect(ctx); cerr != nil {
+			appLog("skychat: cxo-group Connect: %v", cerr)
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		_ = sess.Close() //nolint:errcheck
+	}()
+	return nil
 }
 
 // surfaceCXOInbound pushes a message received from a subscribed CXO feed

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -602,6 +602,8 @@ func init() {
 	RootCmd.Flags().BoolVar(&cxoEnable, "cxo", false, "enable CXO-backed messaging over native TCP (no dmsg): publish outbound to your CXO feed, subscribe to --cxo-peer feeds. Works in --standalone.")
 	RootCmd.Flags().StringVar(&cxoListen, "cxo-listen", ":8802", "CXO-TCP listen address for your feed (peers dial this)")
 	RootCmd.Flags().StringSliceVar(&cxoPeers, "cxo-peer", nil, "subscribe to a peer's CXO feed: tcp://<feedpk>@host:port (repeat for many)")
+	RootCmd.Flags().StringVar(&cxoGroup, "cxo-group", "", "enable federated CXO GROUP chat with this group id (over native TCP, roster/signing/gossip); members from --cxo-peer, owner from --cxo-group-owner")
+	RootCmd.Flags().StringVar(&cxoGroupOwner, "cxo-group-owner", "", "group owner PK (your role is owner if it equals your identity, else member)")
 	RootCmd.Flags().BoolVar(&standalone, "standalone", false, "run without a parent visor: skip PROC_CONFIG handshake, disable skynet/dmsg listenLoops, keep --tcp-listen/--tcp-peer + the HTTP control surface. Pair-RPC endpoints become 503 (no visor pair-rpc to relay through). Use this to run a long-lived chat-app that survives visor restarts — reachable via TCP-direct only.")
 }
 
@@ -761,7 +763,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 	if err := startCXOTCP(ctx); err != nil {
 		appLog("skychat: cxo startup failed: %v — continuing without CXO mode", err)
 	}
-	if !useSkynet && !useDmsg && tcpListen == "" && len(tcpPeers) == 0 && !cxoEnable {
+	if !useSkynet && !useDmsg && tcpListen == "" && len(tcpPeers) == 0 && !cxoEnable && cxoGroup == "" {
 		appLog("Warning: no network types enabled, skychat will not accept connections")
 	}
 
@@ -1047,7 +1049,7 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		// peer subscribed to our feed receives it. No per-message ack
 		// (CXO is eventual) — success means the leaf was published. This
 		// short-circuits the tcp-direct/skynet/dmsg send path below.
-		if cxoEnable {
+		if cxoEnable || cxoGroup != "" {
 			path, perr := publishCXO(data.Message)
 			if perr != nil {
 				http.Error(w, fmt.Sprintf("cxo publish: %v", perr), http.StatusServiceUnavailable)

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -594,9 +594,9 @@ func init() {
 	RootCmd.Flags().DurationVar(&pairPollInterval, "pair-poll-interval", time.Second, "how often skychat drains the visor's pair-message inbox onto the SSE stream")
 
 	// TCP-direct entry points — see tcp_direct.go. Defaults disabled.
-	RootCmd.Flags().StringVar(&tcpListen, "tcp-listen", "", "accept noise-XK on TCP (e.g. ':8800'); requires --tcp-whitelist + an identity (--sk/-c/env). Bidirectional once established.")
+	RootCmd.Flags().StringVar(&tcpListen, "tcp-listen", "", "accept noise-XK on TCP (e.g. ':8800'); needs an identity (--sk/-c/env). --tcp-whitelist optional (empty = open to any authenticated key). Bidirectional once established.")
 	RootCmd.Flags().StringSliceVar(&tcpPeers, "tcp-peer", nil, "persistent outbound TCP-direct peer: tcp://<pk>@host:port (repeat for many). For NAT-side hosts that dial out to public-IP peers.")
-	RootCmd.Flags().StringVar(&tcpWhitelist, "tcp-whitelist", "", "comma-separated peer PKs allowed to connect via --tcp-listen (empty rejects all)")
+	RootCmd.Flags().StringVar(&tcpWhitelist, "tcp-whitelist", "", "comma-separated peer PKs allowed to connect via --tcp-listen (empty = open to any authenticated key, matching skynet/CXO convention)")
 	RootCmd.Flags().StringVar(&tcpSKFlag, "sk", "", "identity SK for TCP-direct (hex). Overrides env + config.")
 	RootCmd.Flags().StringVarP(&tcpConfigPath, "config", "c", "", "path to skywire.json — only the sk field is read, for TCP-direct / CXO identity")
 	RootCmd.Flags().BoolVar(&cxoEnable, "cxo", false, "enable CXO-backed messaging over native TCP (no dmsg): publish outbound to your CXO feed, subscribe to --cxo-peer feeds. Works in --standalone.")

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -1070,7 +1070,7 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			})
 			hub.broadcast(string(outMsg))
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"ok":true,"network":"cxo"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"network":"cxo"}`)) //nolint:errcheck,gosec
 			return
 		}
 

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -598,7 +598,10 @@ func init() {
 	RootCmd.Flags().StringSliceVar(&tcpPeers, "tcp-peer", nil, "persistent outbound TCP-direct peer: tcp://<pk>@host:port (repeat for many). For NAT-side hosts that dial out to public-IP peers.")
 	RootCmd.Flags().StringVar(&tcpWhitelist, "tcp-whitelist", "", "comma-separated peer PKs allowed to connect via --tcp-listen (empty rejects all)")
 	RootCmd.Flags().StringVar(&tcpSKFlag, "sk", "", "identity SK for TCP-direct (hex). Overrides env + config.")
-	RootCmd.Flags().StringVarP(&tcpConfigPath, "config", "c", "", "path to skywire.json — only the sk field is read, for TCP-direct identity")
+	RootCmd.Flags().StringVarP(&tcpConfigPath, "config", "c", "", "path to skywire.json — only the sk field is read, for TCP-direct / CXO identity")
+	RootCmd.Flags().BoolVar(&cxoEnable, "cxo", false, "enable CXO-backed messaging over native TCP (no dmsg): publish outbound to your CXO feed, subscribe to --cxo-peer feeds. Works in --standalone.")
+	RootCmd.Flags().StringVar(&cxoListen, "cxo-listen", ":8802", "CXO-TCP listen address for your feed (peers dial this)")
+	RootCmd.Flags().StringSliceVar(&cxoPeers, "cxo-peer", nil, "subscribe to a peer's CXO feed: tcp://<feedpk>@host:port (repeat for many)")
 	RootCmd.Flags().BoolVar(&standalone, "standalone", false, "run without a parent visor: skip PROC_CONFIG handshake, disable skynet/dmsg listenLoops, keep --tcp-listen/--tcp-peer + the HTTP control surface. Pair-RPC endpoints become 503 (no visor pair-rpc to relay through). Use this to run a long-lived chat-app that survives visor restarts — reachable via TCP-direct only.")
 }
 
@@ -753,7 +756,12 @@ func RunSkychat(ctx context.Context, args []string) error {
 	if err := startTCPDirect(ctx); err != nil {
 		appLog("skychat: tcp-direct startup failed: %v — continuing with dmsg/skynet only", err)
 	}
-	if !useSkynet && !useDmsg && tcpListen == "" && len(tcpPeers) == 0 {
+	// CXO-backed messaging entry point (native TCP, no dmsg). Opt-in via
+	// --cxo; nil-effect when unset. See cxo_tcp.go.
+	if err := startCXOTCP(ctx); err != nil {
+		appLog("skychat: cxo startup failed: %v — continuing without CXO mode", err)
+	}
+	if !useSkynet && !useDmsg && tcpListen == "" && len(tcpPeers) == 0 && !cxoEnable {
 		appLog("Warning: no network types enabled, skychat will not accept connections")
 	}
 
@@ -1033,6 +1041,35 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			Net:    netType,
 			PubKey: pk,
 			Port:   1,
+		}
+
+		// CXO-backed mode: publish outbound to our own CXO feed; every
+		// peer subscribed to our feed receives it. No per-message ack
+		// (CXO is eventual) — success means the leaf was published. This
+		// short-circuits the tcp-direct/skynet/dmsg send path below.
+		if cxoEnable {
+			path, perr := publishCXO(data.Message)
+			if perr != nil {
+				http.Error(w, fmt.Sprintf("cxo publish: %v", perr), http.StatusServiceUnavailable)
+				return
+			}
+			cxoMu.Lock()
+			myPK := cxoMyPK
+			cxoMu.Unlock()
+			outMsg, _ := json.Marshal(map[string]interface{}{ //nolint:errcheck
+				"sender":    myPK.Hex(),
+				"recipient": data.Recipient,
+				"message":   data.Message,
+				"network":   "cxo",
+				"dir":       "out",
+				"id":        newEventID(),
+				"len":       len(data.Message),
+				"path":      path,
+			})
+			hub.broadcast(string(outMsg))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true,"network":"cxo"}`))
+			return
 		}
 
 		// Self-send detection — log it clearly so the user can tell self

--- a/cmd/apps/skychat/commands/tcp_direct.go
+++ b/cmd/apps/skychat/commands/tcp_direct.go
@@ -20,9 +20,12 @@
 //
 // Identity comes from the chat-app's --sk / -c / DMSGCURL_SK
 // resolution chain (skychat.go owns those flags). Whitelist (the
-// chat-app's existing --tcp-whitelist set) gates incoming peers
-// the same way dmsgpty's whitelist does — empty list rejects all,
-// which is fail-safe.
+// chat-app's --tcp-whitelist set) gates incoming peers: a non-empty
+// list restricts to those PKs; an EMPTY list is open (accepts any
+// authenticated peer), matching the skywire convention (skynet
+// Server.useWL, CXO treestore nil-allowlist). Peers are always
+// authenticated by the noise XK handshake — open means unrestricted,
+// not anonymous.
 package commands
 
 import (
@@ -198,18 +201,18 @@ func acceptTCPConn(
 		appLog("skychat: tcp-direct handshake failed from %s: %v", raw.RemoteAddr(), err)
 		return
 	}
-	// Whitelist gate. Empty whitelist = reject all (the chat-app
-	// must be explicitly configured to accept). This matches
-	// dmsgpty's host_tcp.go behavior.
-	if len(whitelist) == 0 {
-		appLog("skychat: tcp-direct rejecting %s: no whitelist configured", rPK)
-		_ = wrapped.Close() //nolint:errcheck
-		return
-	}
-	if _, ok := whitelist[rPK]; !ok {
-		appLog("skychat: tcp-direct rejecting %s: not on whitelist", rPK)
-		_ = wrapped.Close() //nolint:errcheck
-		return
+	// Whitelist gate. Empty whitelist = OPEN: accept any authenticated
+	// peer. Matches the skywire convention (skynet Server.useWL, CXO
+	// treestore nil-allowlist, TPD publishers) where an empty/nil
+	// whitelist means "no restriction". The noise XK handshake still
+	// authenticates each peer's PK, so open means unrestricted, not
+	// anonymous. A non-empty whitelist restricts to the listed PKs.
+	if len(whitelist) > 0 {
+		if _, ok := whitelist[rPK]; !ok {
+			appLog("skychat: tcp-direct rejecting %s: not on whitelist", rPK)
+			_ = wrapped.Close() //nolint:errcheck
+			return
+		}
 	}
 
 	tdc := &tcpDirectConn{Conn: wrapped, rPK: rPK}
@@ -369,7 +372,7 @@ func startTCPDirect(ctx context.Context) error {
 	whitelist := tcpWhitelistSet(tcpWhitelist)
 	if tcpListen != "" {
 		if len(whitelist) == 0 {
-			appLog("skychat: tcp-direct WARNING --tcp-listen set without --tcp-whitelist; will reject all incoming peers")
+			appLog("skychat: tcp-direct OPEN MODE — --tcp-listen set without --tcp-whitelist; accepting ANY authenticated peer key (set --tcp-whitelist to restrict)")
 		}
 		go func() {
 			if err := runTCPListen(ctx, tcpListen, pk, sk, whitelist); err != nil {

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -847,6 +847,21 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 // inbound yet". On error, lastInboundNs stays at whatever it was
 // (seeded from Record.LastMessageAt at Open) and the Manager's
 // background reconnect loop keeps retrying.
+// connectSub dials a subscriber over the session's transport and waits
+// for its first Root: native TCP (by the peer's PeerAddrs "host:port")
+// in TCP mode, else dmsg (by PK via discovery). Used by Connect and the
+// reconnect paths for the legacy owner sub and every peerSub.
+func (s *Session) connectSub(ctx context.Context, sub *treestore.Subscriber, pk cipher.PubKey) error {
+	if s.cfg.DmsgC == nil { // native-TCP mode
+		addr := s.cfg.PeerAddrs[pk]
+		if addr == "" {
+			return fmt.Errorf("group: no TCP address configured for peer %s", pk)
+		}
+		return sub.ConnectAndWaitForRootTCP(ctx, addr)
+	}
+	return sub.ConnectAndWaitForRoot(ctx, pk)
+}
+
 func (s *Session) Connect(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -872,7 +887,7 @@ func (s *Session) Connect(ctx context.Context) error {
 	// goroutine that runs to completion before discarding its result.
 	if s.sub != nil {
 		done := make(chan error, 1)
-		go func() { done <- s.sub.ConnectAndWaitForRoot(ctx, s.cfg.Record.OwnerPK) }()
+		go func() { done <- s.connectSub(ctx, s.sub, s.cfg.Record.OwnerPK) }()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -920,7 +935,7 @@ func (s *Session) Connect(ctx context.Context) error {
 		}
 		done := make(chan error, 1)
 		pkLocal, psLocal := pk, ps
-		go func() { done <- psLocal.ConnectAndWaitForRoot(ctx, pkLocal) }()
+		go func() { done <- s.connectSub(ctx, psLocal, pkLocal) }()
 		select {
 		case <-ctx.Done():
 			// Outer deadline fired mid-Connect. The goroutine will
@@ -1104,7 +1119,7 @@ func (s *Session) ReconnectPeer(ctx context.Context, pk cipher.PubKey) error {
 		return nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- ps.ConnectAndWaitForRoot(ctx, pk) }()
+	go func() { done <- s.connectSub(ctx, ps, pk) }()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1153,7 +1168,7 @@ func (s *Session) ReconnectLegacySub(ctx context.Context) error {
 		return nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- s.sub.ConnectAndWaitForRoot(ctx, s.cfg.Record.OwnerPK) }()
+	go func() { done <- s.connectSub(ctx, s.sub, s.cfg.Record.OwnerPK) }()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -1392,7 +1407,7 @@ func (s *Session) SetAllowlist(members []cipher.PubKey) ([]cipher.PubKey, error)
 		// in the allowlist doesn't block roster expansion. The retry
 		// loop will pick it up on a later tick with its own deadline.
 		dctx, dcancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
-		err = ps.ConnectAndWaitForRoot(dctx, pk)
+		err = s.connectSub(dctx, ps, pk)
 		dcancel()
 		if err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).
@@ -1527,7 +1542,7 @@ func (s *Session) SetAdminRoster(admins []cipher.PubKey) ([]cipher.PubKey, error
 		// SetAllowlist. A peer that's offline now will be picked up
 		// on the next reconnect tick once the publisher comes back.
 		dctx, dcancel := context.WithTimeout(context.Background(), reconnectAttemptTimeout)
-		err = ps.ConnectAndWaitForRoot(dctx, pk)
+		err = s.connectSub(dctx, ps, pk)
 		dcancel()
 		if err != nil {
 			s.log.WithError(err).WithField("peer", pk.String()).

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -551,6 +551,14 @@ func (cfg Config) newPublisher(pc treestore.PubConfig) (*treestore.Publisher, er
 	if cfg.DmsgC != nil {
 		return treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, pc)
 	}
+	// Native-TCP / standalone: use the in-memory CXDS. A live standalone
+	// chat session needs no on-disk persistence (the publisher
+	// republishes from its in-memory tree on restart), and the
+	// disk-backed store on this path failed to establish the feed head —
+	// subscribers got "no such head" and could never fill the Root. The
+	// flat --cxo path uses InMemoryDB and works; match it here. (Bonus:
+	// no DataDir on disk, so no work-dir/binary path collision.)
+	pc.InMemoryDB = true
 	return treestore.NewWithTCP(cfg.TCPListenAddr, cfg.MySK, pc)
 }
 

--- a/cmd/apps/skychat/group/session.go
+++ b/cmd/apps/skychat/group/session.go
@@ -244,6 +244,18 @@ type Config struct {
 	// deployments that want to opt out of the ~1KB/min/group wire
 	// cost). Recommended production value: 30s.
 	HeartbeatInterval time.Duration
+
+	// TCPListenAddr selects native-TCP transport instead of dmsg: when
+	// DmsgC is nil and this is set, the session's CXO publisher listens
+	// here over the node's built-in TCP transport (no dmsg/discovery).
+	// Used by the standalone skychat --cxo group mode.
+	TCPListenAddr string
+
+	// PeerAddrs maps a peer PK to its "host:port" for the TCP path
+	// (dmsg resolves PK->addr via discovery; native TCP has none, so the
+	// caller supplies addresses). Consulted by the per-peer dial loop in
+	// TCP mode; ignored under dmsg.
+	PeerAddrs map[cipher.PubKey]string
 }
 
 // Session is one live group as this visor knows it — either as the
@@ -532,9 +544,19 @@ const relayAckReadTimeout = 5 * time.Second
 // publisher's SubscriberAllowlist is set to every member PK in the
 // record. For member role, the subscriber is created attached to a
 // fresh CXO node and waits for Connect to dial the owner.
+// newPublisher builds the session's CXO publisher over the configured
+// transport: DMSG when cfg.DmsgC is set, otherwise the CXO node's
+// native TCP transport on cfg.TCPListenAddr (no dmsg/discovery).
+func (cfg Config) newPublisher(pc treestore.PubConfig) (*treestore.Publisher, error) {
+	if cfg.DmsgC != nil {
+		return treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, pc)
+	}
+	return treestore.NewWithTCP(cfg.TCPListenAddr, cfg.MySK, pc)
+}
+
 func Open(cfg Config) (*Session, error) {
-	if cfg.DmsgC == nil {
-		return nil, errors.New("group: Open: DmsgC required")
+	if cfg.DmsgC == nil && cfg.TCPListenAddr == "" {
+		return nil, errors.New("group: Open: DmsgC or TCPListenAddr (native-TCP mode) required")
 	}
 	if cfg.Record.ID == "" {
 		return nil, errors.New("group: Open: Record.ID required")
@@ -573,7 +595,7 @@ func Open(cfg Config) (*Session, error) {
 // openOwner brings up a publisher with the member allowlist plus
 // the relay listener that members dial when submitting messages.
 func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
-	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
+	pub, err := cfg.newPublisher(treestore.PubConfig{
 		BatchWindow:         cfg.BatchWindow,
 		Logger:              log,
 		DataDir:             filepath.Join(cfg.DataDir, "group", cfg.Record.ID),
@@ -642,16 +664,22 @@ func openOwner(cfg Config, log *logging.Logger) (*Session, error) {
 		ps.OnUpdate(s.makePeerOnUpdate(peerPK))
 		s.peerSubs[peerPK] = ps
 	}
-	if dmsgLis, err := cfg.DmsgC.Listen(relayPort); err != nil {
-		log.WithError(err).WithField("port", relayPort).
-			Warn("group: owner relay dmsg listen failed")
-	} else {
-		s.relayDmsg = dmsgLis
+	// Relay listeners are the owner-centric/visor fallback path; the
+	// federated peerSubs mesh (above) makes them vestigial. They depend
+	// on dmsg + the visor's skynet app context, so skip them entirely in
+	// native-TCP standalone mode (DmsgC == nil).
+	if cfg.DmsgC != nil {
+		if dmsgLis, err := cfg.DmsgC.Listen(relayPort); err != nil {
+			log.WithError(err).WithField("port", relayPort).
+				Warn("group: owner relay dmsg listen failed")
+		} else {
+			s.relayDmsg = dmsgLis
+			s.relayWG.Add(1)
+			go s.acceptRelayOn(dmsgLis, "dmsg")
+		}
 		s.relayWG.Add(1)
-		go s.acceptRelayOn(dmsgLis, "dmsg")
+		go s.bindRelaySkynet(relayPort)
 	}
-	s.relayWG.Add(1)
-	go s.bindRelaySkynet(relayPort)
 
 	// Heartbeat emission. Publishes a tiny no-op message to the feed
 	// every HeartbeatInterval so members can detect a silently-stalled
@@ -718,7 +746,7 @@ func openMember(cfg Config, log *logging.Logger) (*Session, error) {
 	// Record.Port (~1/65535 birthday collision per-pair across
 	// groups). When it does happen, bind fails with a clear "address
 	// in use" error; not silent corruption.
-	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
+	pub, err := cfg.newPublisher(treestore.PubConfig{
 		BatchWindow: cfg.BatchWindow,
 		Logger:      log,
 		DataDir:     filepath.Join(cfg.DataDir, "group", cfg.Record.ID, "member"),

--- a/docs/skychat_cxo_tcp_standalone.md
+++ b/docs/skychat_cxo_tcp_standalone.md
@@ -1,0 +1,84 @@
+# CXO-backed standalone skychat over native TCP — design
+
+Status: design / Phase 1 in progress. Owner: Alpha (operator-host agent).
+
+## Goal
+
+Add a **CXO-backed mode** to the standalone skychat: **P2P (1:1) first, then
+group chat**. CXO runs over its **own native TCP transport — no dmsg** — keeping
+the standalone dmsg-free and matching CXO's standalone heritage. The existing
+tcp-direct standalone (noise-XK coordination channel, `--tcp-listen`/`--tcp-peer`)
+keeps running unchanged for base coordination.
+
+## Why standalone, not in-visor
+
+The visor-hosted CXO group chat stalled earlier because the participating
+**visors restart after each PR merge** (binary rebuild), churning CXO subscriber
+state mid-sync. The standalone app is a **separate, operator-controlled process
+that does not rebuild/restart on merges** — so building the CXO chat here
+sidesteps the exact blocker that stalled the visor-hosted version.
+
+## Architecture (what already exists)
+
+CXO chat machinery is present and transport-pluggable:
+
+- `pkg/cxo/treestore` — `Publisher` / `Subscriber` over a `pkg/cxo/node.Node`.
+- `cmd/apps/skychat/pairing` (1:1) and `cmd/apps/skychat/group` (group) Managers
+  — each needs only `{transport, SK, DataDir, Logger}`.
+- The CXO node **natively supports TCP** (`config.go`: `cfg.TCP.Listen=":8870"`).
+  `treestore.NewWithDMSG` deliberately *disables* TCP/UDP/RPC and swaps in a dmsg
+  factory (`cxoNode.EnableDMSG`). The TCP analog is: **keep TCP, skip dmsg**.
+- **Transport symmetry** is the key enabler:
+  - dmsg: `Subscriber.Connect` → `cxoNode.DMSG().ConnectPK(pk)` → `conn.Subscribe(feedPK)`
+  - tcp:  `cxoNode.TCP().Connect(address)` → `conn.Subscribe(feedPK)`
+  - Both yield the same `*node.Conn` with `.Subscribe(feedPK)`.
+  - Only difference: dmsg dials **by PK** (discovery-resolved); TCP dials **by
+    explicit `host:port`** — supplied by the operator, exactly like `--tcp-peer`.
+
+## New API surface (`pkg/cxo/treestore`)
+
+- `NewWithTCP(listenAddr string, sk cipher.SecKey, conf PubConfig) (*Publisher, error)`
+  — mirror of `NewWithDMSG`: keep `cfg.TCP.Listen = listenAddr`, do **not** call
+  `EnableDMSG`, keep the same `OnSubscribeRemote` allowlist hook.
+- `Subscriber.ConnectTCP(ctx, address string) error` — mirror of `Connect` but via
+  `cxoNode.TCP().Connect(address)`; store the **address** (not the publisher PK) for
+  the reconnect watchdog to re-dial.
+- `runReconnectWatchdog` — re-dial by stored address when in TCP mode (#2713 silent-
+  subscriber recovery carries over unchanged otherwise).
+- A shared-node helper so a pair can run publisher + subscriber on one TCP node
+  (pairing's existing pattern).
+
+## Phases
+
+1. **Phase 1 — CXO P2P over TCP.** treestore TCP foundation (`NewWithTCP`,
+   `ConnectTCP`, watchdog) + a TCP variant of `pairing.Manager` + standalone flags
+   (`--cxo`, `--cxo-listen :8870`, `--cxo-peer tcp://pk@host:port`) + in-process pair
+   HTTP endpoints (replacing the visor pair-RPC the standalone lacks). **Exit
+   criterion:** two standalones reliably 1:1-chat over CXO-TCP, survive a peer
+   restart (watchdog re-dial), and replay missed history.
+2. **Phase 2 — CXO groups over TCP.** TCP variant of `group.Manager` + group HTTP
+   endpoints. Owner/member topology over CXO-TCP.
+
+## Review questions (raised by Gamma)
+
+1. **URL-prefix collision class** (the `isUnderBase` bug): N/A to CXO chat — that
+   was HTTP `/all-transports` CLI feed-routing in `cmd/.../rpc/root.go`. CXO chat
+   addresses by **feed PK + path prefix** (`msgs/<ts-nano>/<seq>`), with explicit
+   per-pair / per-group feed PKs (pair feed deterministic; group feed = owner PK).
+   **Action:** audit `Subscriber.matchesPrefixLocked` / `SetPrefixes` for the same
+   loose-prefix class — require a path-segment boundary, not a raw substring.
+2. **In-visor vs standalone:** standalone, new sub-mode (per Moses). Preserves the
+   dmsg-free + restart-stable property that unblocks it.
+3. **Silent-subscriber recovery:** inherited from treestore — `runReconnectWatchdog`
+   (#2713) + `ConnectAndWaitForRoot` + history replay. In TCP mode the watchdog
+   re-dials the stored TCP address; no extra heartbeat needed beyond the quiet-
+   threshold re-Connect.
+
+## Coordination / ops
+
+- Current tcp-direct standalone stays up for coordination; operator port-forwards
+  the extra CXO-TCP port(s) (`:8870`…).
+- Reuse the same `-c skywire-config.json` identity (sk) so the CXO node PK == the
+  coordination identity.
+- Agents review after the 2026-05-31 reward recovery and `fix/cxo-url-boundary-match`
+  land.

--- a/pkg/cxo/node/transport/noise_tcp.go
+++ b/pkg/cxo/node/transport/noise_tcp.go
@@ -1,0 +1,57 @@
+package transport
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/skycoin/noise"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	skynoise "github.com/skycoin/skywire/pkg/dmsg/noise"
+)
+
+// noiseHandshakeTimeout bounds the XX handshake on a CXO TCP conn.
+const noiseHandshakeTimeout = 30 * time.Second
+
+// noiseConn is a net.Conn whose Read/Write are encrypted by a Noise
+// ReadWriter. The embedded net.Conn supplies addrs / deadlines / Close;
+// only Read/Write are overridden to go through the cipher.
+type noiseConn struct {
+	net.Conn
+	rw  *skynoise.ReadWriter
+	rPK cipher.PubKey
+}
+
+func (c *noiseConn) Read(p []byte) (int, error)  { return c.rw.Read(p) }
+func (c *noiseConn) Write(p []byte) (int, error) { return c.rw.Write(p) }
+
+// RemotePK returns the peer's static public key, learned during the XX
+// handshake.
+func (c *noiseConn) RemotePK() cipher.PubKey { return c.rPK }
+
+// wrapNoiseXX runs a Noise_XX handshake over raw and returns an
+// encrypted net.Conn. XX is mutual-authentication with no pre-pinned
+// remote key: both sides transmit AND learn each other's static key
+// during the handshake. That matches the CXO transport's "dial by
+// address, learn the PK during the handshake" model, so it works for
+// every caller (swarm, rpc, subscriber) without threading a remote PK
+// through Connect. It uses the SAME canonical noise package
+// (secp256k1 / ChaCha20-Poly1305 / SHA-256, replay-windowed nonces)
+// that dmsg, tcpnoise, and the skywire transports use — so CXO-TCP is
+// no longer the one plaintext transport.
+func wrapNoiseXX(raw net.Conn, localPK cipher.PubKey, localSK cipher.SecKey, initiator bool) (*noiseConn, error) {
+	ns, err := skynoise.New(noise.HandshakeXX, skynoise.Config{
+		LocalPK:   localPK,
+		LocalSK:   localSK,
+		Initiator: initiator,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cxo-tcp noise init: %w", err)
+	}
+	rw := skynoise.NewReadWriter(raw, ns)
+	if err := rw.Handshake(noiseHandshakeTimeout); err != nil {
+		return nil, fmt.Errorf("cxo-tcp noise handshake: %w", err)
+	}
+	return &noiseConn{Conn: raw, rw: rw, rPK: rw.RemoteStatic()}, nil
+}

--- a/pkg/cxo/node/transport/tcp.go
+++ b/pkg/cxo/node/transport/tcp.go
@@ -3,11 +3,20 @@ package transport
 import (
 	"net"
 	"sync"
+
+	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-// TCPFactory creates and manages TCP connections.
+// TCPFactory creates and manages TCP connections. Every connection
+// (dial + accept) is Noise_XX-encrypted via wrapNoiseXX using the
+// factory's identity, so CXO-TCP is no longer a plaintext transport.
 type TCPFactory struct {
 	AcceptedCallback func(conn *Connection)
+
+	// localPK / localSK is the node identity used for the Noise XX
+	// handshake on every TCP conn.
+	localPK cipher.PubKey
+	localSK cipher.SecKey
 
 	// MaxPendingAccepts caps in-flight AcceptedCallback invocations.
 	// Zero (default) leaves accepts unbounded for backwards compatibility;
@@ -21,9 +30,10 @@ type TCPFactory struct {
 	sem      chan struct{} // nil when MaxPendingAccepts == 0
 }
 
-// NewTCPFactory creates a new TCPFactory.
-func NewTCPFactory() *TCPFactory {
-	return &TCPFactory{}
+// NewTCPFactory creates a new TCPFactory bound to the given identity,
+// used for the Noise XX handshake on every TCP connection.
+func NewTCPFactory(localPK cipher.PubKey, localSK cipher.SecKey) *TCPFactory {
+	return &TCPFactory{localPK: localPK, localSK: localSK}
 }
 
 // Listen starts listening on the given address for incoming TCP connections.
@@ -56,11 +66,16 @@ func (f *TCPFactory) ListenerAddress() string {
 
 // Connect dials a TCP address and returns a Connection.
 func (f *TCPFactory) Connect(address string) (*Connection, error) {
-	conn, err := net.Dial("tcp", address)
+	raw, err := net.Dial("tcp", address)
 	if err != nil {
 		return nil, err
 	}
-	return newConnection(conn, true), nil
+	nc, err := wrapNoiseXX(raw, f.localPK, f.localSK, true)
+	if err != nil {
+		_ = raw.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return newConnection(nc, true), nil
 }
 
 // Close stops the factory and closes the listener.
@@ -95,9 +110,9 @@ func (f *TCPFactory) acceptLoop(ln net.Listener) {
 			}
 			return
 		}
-		c := newConnection(conn, true)
 		cb := f.AcceptedCallback
 		if cb == nil {
+			conn.Close() //nolint:errcheck,gosec
 			if sem != nil {
 				<-sem
 			}
@@ -109,7 +124,15 @@ func (f *TCPFactory) acceptLoop(ln net.Listener) {
 					<-sem
 				}
 			}()
-			cb(c)
+			// Noise XX handshake runs here (in the accept goroutine, not
+			// the accept loop) so a slow handshake never stalls accepts;
+			// the sem bounds concurrent handshakes.
+			nc, herr := wrapNoiseXX(conn, f.localPK, f.localSK, false)
+			if herr != nil {
+				conn.Close() //nolint:errcheck,gosec
+				return
+			}
+			cb(newConnection(nc, true))
 		}()
 	}
 }

--- a/pkg/cxo/node/transports.go
+++ b/pkg/cxo/node/transports.go
@@ -57,7 +57,7 @@ func newTCP(n *Node) (t *TCP) {
 	t.MaxPendingAccepts = n.config.MaxPendingConnections
 	t.cs = make(map[string]*Conn)
 
-	return
+	return t
 }
 func (t *TCP) addConn(c *Conn) {
 	t.mx.Lock()

--- a/pkg/cxo/node/transports.go
+++ b/pkg/cxo/node/transports.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	swcipher "github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/node/transport"
 )
 
@@ -29,7 +30,24 @@ func newTCP(n *Node) (t *TCP) {
 
 	t = new(TCP)
 
-	t.TCPFactory = transport.NewTCPFactory()
+	// Encrypt CXO-TCP with the canonical Noise (XX pattern). Use the
+	// node's identity (skycoin SecKey -> skywire cipher via hex; both
+	// are 32-byte keys). A subscribe-only node may have no SecKey set —
+	// fall back to an ephemeral keypair so the XX handshake still
+	// authenticates + encrypts (open feeds accept any subscriber PK).
+	var (
+		lpk swcipher.PubKey
+		lsk swcipher.SecKey
+	)
+	if lsk.Set(n.config.SecKey.Hex()) == nil {
+		if pk, err := lsk.PubKey(); err == nil {
+			lpk = pk
+		}
+	}
+	if lpk.Null() {
+		lpk, lsk = swcipher.GenerateKeyPair()
+	}
+	t.TCPFactory = transport.NewTCPFactory(lpk, lsk)
 
 	t.n = n
 	t.AcceptedCallback = t.acceptConn

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -229,6 +229,58 @@ func NewWithDMSG(dmsgC *dmsg.Client, sk cipher.SecKey, conf PubConfig) (*Publish
 	return p, nil
 }
 
+// NewWithTCP is the native-TCP analog of NewWithDMSG: it constructs a
+// CXO node that listens on listenAddr over the node's built-in TCP
+// transport (no dmsg, no discovery) and hands back a Publisher with the
+// node already wired. Use this for standalone / dmsg-free deployments
+// where peers connect by an explicit tcp address rather than a
+// discovery-resolved PK (see Subscriber.ConnectTCP). The Publisher owns
+// the node — Close releases both.
+//
+// listenAddr is a "host:port" (e.g. ":8870"). Each node binds its own
+// listener, so distinct feeds hosted in the same process need distinct
+// addresses. The node identity is bound to sk (so the handshake-
+// advertised PK matches the feed PK), mirroring NewWithDMSG.
+func NewWithTCP(listenAddr string, sk cipher.SecKey, conf PubConfig) (*Publisher, error) {
+	cfg := node.NewConfig()
+	// Bind the CXO node's identity to the publisher's keypair so remote
+	// peers see the feed PK on the handshake — same rationale as
+	// NewWithDMSG (subscriber-allowlist gating keys off the feed PK).
+	cfg.SecKey = skycipher.SecKey(sk)
+	cfg.Config = skyobject.NewConfig()
+	cfg.Config.InMemoryDB = conf.InMemoryDB
+	cfg.Config.NoSyncCXDS = conf.NoSyncCXDS
+	if conf.DataDir != "" {
+		cfg.Config.DataDir = conf.DataDir
+	}
+	// Native-TCP transport: keep the TCP listener (NewNode starts it when
+	// TCP.Listen != ""), and disable UDP / RPC / dmsg. We do NOT call
+	// EnableDMSG.
+	cfg.TCP.Listen = listenAddr
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
+
+	allow := newAllowState(conf.SubscriberAllowlist)
+	cfg.OnSubscribeRemote = subscribeHook(allow)
+
+	cxoNode, err := node.NewNode(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := New(cxoNode, sk, Config{
+		BatchWindow: conf.BatchWindow,
+		Logger:      conf.Logger,
+		sharedAllow: allow,
+	})
+	if err != nil {
+		_ = cxoNode.Close() //nolint:errcheck
+		return nil, err
+	}
+	p.ownsNode = true
+	return p, nil
+}
+
 // New constructs a Publisher backed by the given CXO node. The feed
 // PK is derived from sk — the node's own keypair, by convention.
 // The publish loop starts immediately; call Close to stop it.

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -533,6 +533,29 @@ func (s *Subscriber) ConnectAndWaitForRoot(ctx context.Context, publisherPK ciph
 	}
 }
 
+// ConnectAndWaitForRootTCP is the native-TCP analog of
+// ConnectAndWaitForRoot: it dials the publisher by address (ConnectTCP,
+// no discovery) and waits until the first Root for this subscriber's
+// feedPK fills, so the caller gets a verified-live subscription rather
+// than just "subscribe frame queued". Used by the group session's
+// per-peer dial loop in TCP mode.
+func (s *Subscriber) ConnectAndWaitForRootTCP(ctx context.Context, address string) error {
+	s.rootObservedMu.Lock()
+	s.rootObservedSignal = make(chan struct{})
+	signal := s.rootObservedSignal
+	s.rootObservedMu.Unlock()
+
+	if err := s.ConnectTCP(ctx, address); err != nil {
+		return err
+	}
+	select {
+	case <-signal:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // SetPrefixes restricts which paths surface via Get / Walk / the
 // OnUpdate callback. An empty slice (or nil) means "no filter".
 //

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -121,6 +121,13 @@ type Subscriber struct {
 	// Connect succeeds.
 	publisherPK atomic.Pointer[cipher.PubKey]
 
+	// publisherAddr stores the most recent ConnectTCP target address
+	// (native-TCP mode) so the watchdog re-dials by address rather than
+	// by discovery-resolved PK. When set it takes precedence over
+	// publisherPK in the watchdog. nil until the first ConnectTCP
+	// succeeds.
+	publisherAddr atomic.Pointer[string]
+
 	// reconnectStop, when closed, terminates the watchdog. Created
 	// when Connect is first called; closed by Close. Idempotent
 	// close via reconnectOnce.
@@ -218,6 +225,57 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 	return s, nil
 }
 
+// NewSubscriberTCP is the native-TCP analog of NewSubscriber: it
+// creates a Subscriber whose CXO node uses the built-in TCP transport
+// (no dmsg, no discovery). Call ConnectTCP with the publisher's tcp
+// address to attach. The returned Subscriber owns its node; Close
+// releases it.
+//
+// listenAddr is the node's TCP listen address. Subscribe-only flows can
+// pass "" (dial-only): the conn opened by ConnectTCP carries the
+// publisher's Root pushes back, so a listener isn't required. Pass a
+// real "host:port" when this node must also accept inbound (e.g. a pair
+// node that publishes its own feed too).
+func NewSubscriberTCP(listenAddr string, feedPK cipher.PubKey, conf SubConfig) (*Subscriber, error) {
+	if conf.Logger == nil {
+		conf.Logger = logging.MustGetLogger("cxo-treestore-sub")
+	}
+
+	cfg := node.NewConfig()
+	cfg.Config = skyobject.NewConfig()
+	cfg.Config.InMemoryDB = conf.InMemoryDB
+	if conf.DataDir != "" {
+		cfg.Config.DataDir = conf.DataDir
+	}
+	// Native-TCP: keep the TCP listener (NewNode starts it when non-empty;
+	// "" = dial-only), disable UDP / RPC, and do NOT enable dmsg.
+	cfg.TCP.Listen = listenAddr
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
+
+	cxoNode, err := node.NewNode(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Subscriber{
+		log:                conf.Logger,
+		cxoNode:            cxoNode,
+		ownsNode:           true,
+		feedPK:             feedPK,
+		cache:              make(map[string][]byte),
+		rootObservedSignal: make(chan struct{}),
+	}
+
+	cxoNode.SwapOnRootFilled(func(_ *node.Node, r *registry.Root) {
+		s.handleRootFilled(r)
+	})
+	cxoNode.SwapOnFillingBreaks(func(_ *node.Node, r *registry.Root, err error) {
+		s.handleFillingBreaks(r, err)
+	})
+	return s, nil
+}
+
 // NewSubscriberOnNode attaches a Subscriber to an existing CXO node.
 // Caller retains ownership of the node — the Subscriber's Close does
 // NOT release it.
@@ -306,6 +364,44 @@ func (s *Subscriber) Connect(ctx context.Context, publisherPK cipher.PubKey) err
 	return nil
 }
 
+// ConnectTCP is the native-TCP analog of Connect: it dials the
+// publisher at the given tcp address over the node's TCP transport and
+// subscribes to feedPK. Unlike Connect — which resolves a publisher PK
+// through dmsg discovery — native TCP has no discovery, so the caller
+// supplies the "host:port". The reconnect watchdog re-dials this same
+// address (stored in publisherAddr) when the feed goes quiet.
+//
+// ctx is accepted for API symmetry with Connect and future cancellable
+// dials; the current node TCP transport dials with its own timeout.
+func (s *Subscriber) ConnectTCP(ctx context.Context, address string) error {
+	_ = ctx
+	tcpT := s.cxoNode.TCP()
+	if tcpT == nil {
+		return node.ErrAlreadyListen
+	}
+	conn, err := tcpT.Connect(address)
+	if err != nil {
+		return err
+	}
+	if err := conn.Subscribe(skycipher.PubKey(s.feedPK)); err != nil {
+		return err
+	}
+
+	// Remember the address for the watchdog (stored as a copy so the
+	// watchdog goroutine doesn't alias a caller-owned variable).
+	addr := address
+	s.publisherAddr.Store(&addr)
+	// Reset the activity clock — a fresh subscribe should not count as
+	// stale; handleRootFilled bumps it on real updates.
+	s.lastUpdateNs.Store(time.Now().UnixNano())
+	// Start the watchdog on the FIRST successful connect only.
+	s.reconnectStartOnce.Do(func() {
+		s.reconnectStop = make(chan struct{})
+		go s.runReconnectWatchdog()
+	})
+	return nil
+}
+
 // runReconnectWatchdog polls for stalled subscriptions and re-Connects
 // when the local subscriber has gone quiet for longer than the
 // threshold. Fix for issue #2713: when a peer restarts, the dmsg
@@ -346,29 +442,43 @@ func (s *Subscriber) runReconnectWatchdogWith(tickEvery, quietThreshold time.Dur
 		if quiet < quietThreshold {
 			continue
 		}
+		// Native-TCP subscriptions re-dial by stored address; dmsg
+		// subscriptions re-Connect by publisher PK. ConnectTCP takes
+		// precedence when an address is set.
+		addrPtr := s.publisherAddr.Load()
 		pkPtr := s.publisherPK.Load()
-		if pkPtr == nil {
+		if addrPtr == nil && pkPtr == nil {
 			continue
 		}
-		// Bounded Connect so a hung dial doesn't wedge the watchdog
+		// Bounded re-Connect so a hung dial doesn't wedge the watchdog
 		// past the next tick. ConnectAndWaitForRoot would be more
-		// thorough (it confirms the new subscription actually
-		// delivers a Root) but here we want a non-blocking refresh —
-		// the next tick will catch a still-quiet feed.
+		// thorough (it confirms the new subscription actually delivers
+		// a Root) but here we want a non-blocking refresh — the next
+		// tick will catch a still-quiet feed.
 		s.reconnectAttempts.Add(1)
 		ctx, cancel := context.WithTimeout(context.Background(), reconnectConnectTimeout)
-		err := s.Connect(ctx, *pkPtr)
+		var (
+			err    error
+			target string
+		)
+		if addrPtr != nil {
+			target = *addrPtr
+			err = s.ConnectTCP(ctx, *addrPtr)
+		} else {
+			target = pkPtr.Hex()[:8]
+			err = s.Connect(ctx, *pkPtr)
+		}
 		cancel()
 		if err != nil {
 			if s.log != nil {
-				s.log.WithError(err).WithField("publisher_pk", pkPtr.Hex()[:8]).
+				s.log.WithError(err).WithField("publisher", target).
 					WithField("quiet_seconds", quiet.Seconds()).
-					Debug("treestore: reconnect-watchdog Connect failed; will retry next tick")
+					Debug("treestore: reconnect-watchdog re-Connect failed; will retry next tick")
 			}
 			continue
 		}
 		if s.log != nil {
-			s.log.WithField("publisher_pk", pkPtr.Hex()[:8]).
+			s.log.WithField("publisher", target).
 				WithField("quiet_seconds", quiet.Seconds()).
 				Info("treestore: reconnect-watchdog re-Connected after quiet period")
 		}

--- a/pkg/cxo/treestore/tcp_pubsub_test.go
+++ b/pkg/cxo/treestore/tcp_pubsub_test.go
@@ -1,0 +1,83 @@
+// Package treestore — tcp_pubsub_test.go: in-process guard that a CXO
+// feed syncs publisher→subscriber over the node's NATIVE TCP transport
+// with no dmsg / discovery. This is the foundation for the CXO-backed
+// standalone skychat (docs/skychat_cxo_tcp_standalone.md): publisher A
+// listens on an ephemeral TCP port; subscriber B dials it by address
+// (ConnectTCP) and must receive every message A publishes.
+package treestore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestCXOTCPPubSub(t *testing.T) {
+	pkA, skA := cipher.GenerateKeyPair()
+
+	// Publisher A on an ephemeral localhost TCP port — no dmsg.
+	pub, err := NewWithTCP("127.0.0.1:0", skA, PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 5 * time.Millisecond,
+	})
+	require.NoError(t, err, "NewWithTCP publisher")
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+
+	addr := pub.Node().TCP().Address()
+	require.NotEmpty(t, addr, "publisher TCP listen address")
+
+	// Subscriber B (dial-only node) connects to A by address.
+	sub, err := NewSubscriberTCP("", pkA, SubConfig{InMemoryDB: true})
+	require.NoError(t, err, "NewSubscriberTCP")
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+
+	var (
+		mu  sync.Mutex
+		rcv [][]byte
+	)
+	sub.OnUpdate(func(events []UpdateEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, ev := range events {
+			if ev.Value == nil {
+				continue
+			}
+			buf := make([]byte, len(ev.Value))
+			copy(buf, ev.Value)
+			rcv = append(rcv, buf)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	require.NoError(t, sub.ConnectTCP(ctx, addr), "ConnectTCP")
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		require.NoErrorf(t,
+			pub.Put(fmt.Sprintf("msgs/%05d", i), []byte(fmt.Sprintf("hello-%d", i))),
+			"publisher.Put %d", i)
+	}
+
+	// Poll for receipt — bounded so a fast machine doesn't sleep for
+	// nothing and a slow one doesn't false-fail.
+	end := time.Now().Add(10 * time.Second)
+	for {
+		mu.Lock()
+		got := len(rcv)
+		mu.Unlock()
+		if got >= n {
+			return // success: all messages synced over CXO-TCP
+		}
+		if time.Now().After(end) {
+			t.Fatalf("subscriber received %d/%d messages over CXO-TCP (addr=%s)", got, n, addr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **CXO-backed messaging mode to the standalone skychat over the CXO node's native TCP transport** (no dmsg, no discovery): 1:1 P2P and federated group chat. Proven live cross-host, and the federated group verified bidirectionally. Also closes a real security gap — the CXO native-TCP transport was the one transport in the repo not using Noise.

## What's in it

**treestore — native-TCP transport for CXO pub/sub**
- `NewWithTCP` (publisher), `NewSubscriberTCP` / `ConnectTCP` / `ConnectAndWaitForRootTCP` (subscriber, dial-by-address). The reconnect watchdog (#2713) re-dials by address in TCP mode. In-process guard `TestCXOTCPPubSub` + full treestore suite pass over TCP.

**skychat — `--cxo` (P2P) and `--cxo-group` (federated) modes**
- `--cxo` / `--cxo-listen` / `--cxo-peer`: publish outbound `/message` to your CXO feed, subscribe to peer feeds, surface inbound on the existing `/sse`. Reuses the tcp-direct identity resolver (feed PK == chat identity). Opt-in; works in `--standalone`.
- `--cxo-group <id>` / `--cxo-group-owner <pk>`: the existing group subsystem (roster / signing / gossip — all transport-agnostic) over native TCP. The group session layer is made transport-pluggable (`Config.TCPListenAddr`/`PeerAddrs`, a `newPublisher` helper, `connectSub`); the dmsg path is unchanged.

**CXO native-TCP transport — encrypted with the canonical Noise**
- The CXO TCP transport was plaintext (raw `net.Dial`/`Listen` + length framing). Every conn (dial + accept) now does a **Noise_XX handshake via `pkg/dmsg/noise`** (secp256k1 / ChaCha20-Poly1305 / SHA-256, replay-windowed nonces) — the same package dmsg, tcpnoise, and the skywire transports use. XX (mutual-auth, no pre-pinned remote PK) fits the CXO dial-by-address model, so all callers (swarm/rpc/subscriber) work without API changes. dmsg-backed CXO is unaffected.

**Behavioral tweak**
- tcp-direct `--tcp-whitelist`: empty now means **open** (accept any *authenticated* peer), matching the skywire convention (`skynet.Server.useWL`, CXO treestore nil-allowlist). Was reject-all, which made `--tcp-listen` a no-op without a whitelist.

**Fixes found while bringing it up**
- Retry the initial peer dial until connected (`--cxo`) + a reconnect loop for `--cxo-group` peer-subs (group.Session used standalone has no Manager reconnect driver).
- Standalone group publisher uses in-memory CXDS — the disk-backed store on the TCP path didn't establish the feed head (subscribers got "no such head / no connections to fill"); a live chat needs no on-disk persistence. (This was the federated-group fill stall; isolated to *not* be encryption — flat `--cxo` delivered fine encrypted.)

## Testing
- `TestCXOTCPPubSub` + full `pkg/cxo/treestore` suite pass over the encrypted transport.
- Live cross-host `--cxo` P2P confirmed (3 hosts). Federated `--cxo-group` verified bidirectionally as 2 local processes (owner↔member) over the encrypted transport.

## Design
`docs/skychat_cxo_tcp_standalone.md`.