### PR TITLE
feat(rewards/ui): SEO enrichment for per-date reward pages

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/htmpl.go
+++ b/cmd/skywire-cli/commands/rewards/server/htmpl.go
@@ -85,6 +85,13 @@ type htmlTemplateData struct {
 	OGImage     string
 	Page        string
 	Content     htmpl.HTML
+	// JSONLD is an optional schema.org structured-data block (already
+	// wrapped in a <script type='application/ld+json'> tag) that gets
+	// emitted in <head> when set. Used on per-date reward pages to
+	// give Google et al a machine-readable Dataset summary
+	// (qualifying visor count, total SKY distributed, country count,
+	// date) so search-result rich snippets can render properly.
+	JSONLD htmpl.HTML
 }
 
 // withCanonical returns a copy of the template data with canonical URL and OG image set
@@ -105,16 +112,24 @@ func chunkedPageHead(title, description, path string) string {
 	h := `<!doctype html><html lang='en'><head>` +
 		`<meta charset='UTF-8'>` +
 		`<meta name='viewport' content='width=device-width, initial-scale=1.0'>` +
+		`<meta name='theme-color' content='#1a1d24'>` +
+		`<meta name='keywords' content='Skycoin, Skywire, rewards, mesh network, transport bandwidth, dmsg, visor'>` +
 		`<title>` + title + ` - Skywire Network</title>` +
 		`<meta name='description' content='` + description + `'>` +
 		`<meta property='og:title' content='` + title + ` - Skywire Network'>` +
 		`<meta property='og:description' content='` + description + `'>` +
-		`<meta property='og:type' content='website'>`
+		`<meta property='og:type' content='website'>` +
+		`<meta property='og:site_name' content='Skywire Network'>` +
+		`<meta name='twitter:card' content='summary_large_image'>` +
+		`<meta name='twitter:title' content='` + title + ` - Skywire Network'>` +
+		`<meta name='twitter:description' content='` + description + `'>`
 	if canonicalDomain != "" {
 		canonical := strings.TrimRight(canonicalDomain, "/") + path
+		ogImage := strings.TrimRight(canonicalDomain, "/") + "/favicon.ico"
 		h += `<link rel='canonical' href='` + canonical + `'>` +
 			`<meta property='og:url' content='` + canonical + `'>` +
-			`<meta property='og:image' content='` + strings.TrimRight(canonicalDomain, "/") + `/favicon.ico'>`
+			`<meta property='og:image' content='` + ogImage + `'>` +
+			`<meta name='twitter:image' content='` + ogImage + `'>`
 	}
 	h += `<style type='text/css'>` +
 		`a { color: #3399FF; } a:visited { color: #FF00FF; } ` +
@@ -209,14 +224,22 @@ var htmlMainPageTemplate = `
 var htmlHeadTemplate = `<head>
 <meta charset='UTF-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=4.9,'>
+<meta name='theme-color' content='#1a1d24'>
+<meta name='keywords' content='Skycoin, Skywire, rewards, mesh network, transport bandwidth, dmsg, visor'>
 <title>{{.Page.Title}} - Skywire Network</title>
 {{if .Page.Description}}<meta name='description' content='{{.Page.Description}}'>
-<meta property='og:description' content='{{.Page.Description}}'>{{end}}
+<meta property='og:description' content='{{.Page.Description}}'>
+<meta name='twitter:description' content='{{.Page.Description}}'>{{end}}
 <meta property='og:title' content='{{.Page.Title}} - Skywire Network'>
 <meta property='og:type' content='website'>
+<meta property='og:site_name' content='Skywire Network'>
+<meta name='twitter:card' content='summary_large_image'>
+<meta name='twitter:title' content='{{.Page.Title}} - Skywire Network'>
 {{if .Page.Canonical}}<link rel='canonical' href='{{.Page.Canonical}}'>
 <meta property='og:url' content='{{.Page.Canonical}}'>
-<meta property='og:image' content='{{.Page.OGImage}}'>{{end}}
+<meta property='og:image' content='{{.Page.OGImage}}'>
+<meta name='twitter:image' content='{{.Page.OGImage}}'>{{end}}
+{{if .Page.JSONLD}}{{.Page.JSONLD}}{{end}}
 <style type='text/css'>
 a {
 		color: #3399FF;

--- a/cmd/skywire-cli/commands/rewards/server/seo.go
+++ b/cmd/skywire-cli/commands/rewards/server/seo.go
@@ -50,14 +50,17 @@ func parseRewardStats(wd, date string) rewardStats {
 	// Single-line scalar extractors. Use FIRST match for fields that
 	// appear multiple times (qualifying visors appears once per pool
 	// in bandwidth mode but is the same count by construction).
+	// strconv errors are unreachable: the regex capture groups
+	// guarantee the matched substring parses as the target type
+	// (\d+ → Atoi; \d+\.\d+ → ParseFloat). errcheck-ignored.
 	if m := regexp.MustCompile(`(?m)^qualifying visors:\s*(\d+)`).FindStringSubmatch(body); len(m) == 2 {
-		stats.QualifyingVisors, _ = strconv.Atoi(m[1])
+		stats.QualifyingVisors, _ = strconv.Atoi(m[1]) //nolint:errcheck
 	}
 	if m := regexp.MustCompile(`(?m)^Total Reward Amount.*:\s*([0-9]+\.[0-9]+)`).FindStringSubmatch(body); len(m) == 2 {
-		stats.TotalRewardSKY, _ = strconv.ParseFloat(m[1], 64)
+		stats.TotalRewardSKY, _ = strconv.ParseFloat(m[1], 64) //nolint:errcheck
 	}
 	if m := regexp.MustCompile(`(?m)^Unique IP Addresses:\s*(\d+)`).FindStringSubmatch(body); len(m) == 2 {
-		stats.UniqueIPs, _ = strconv.Atoi(m[1])
+		stats.UniqueIPs, _ = strconv.Atoi(m[1]) //nolint:errcheck
 	}
 	if m := regexp.MustCompile(`(?m)^total network bandwidth:\s*(.+)$`).FindStringSubmatch(body); len(m) == 2 {
 		stats.TotalBandwidth = strings.TrimSpace(m[1])

--- a/cmd/skywire-cli/commands/rewards/server/seo.go
+++ b/cmd/skywire-cli/commands/rewards/server/seo.go
@@ -1,0 +1,208 @@
+// Package clirewardsserver seo.go — SEO enrichment for per-date reward
+// pages.
+//
+// Crawlers index per-page metadata better when the title + description
+// carry the actual reward numbers (visor count, total SKY, country
+// count) instead of templated stubs, and the schema.org Dataset
+// JSON-LD block gives Google et al a machine-readable rich-snippet
+// target. All inputs come from the same hist/<date>_stats.txt the
+// /skycoin-rewards/hist/:date route already reads to render the page,
+// so there's no extra disk hit and no risk of metadata diverging
+// from rendered content.
+package clirewardsserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// rewardStats is the parsed summary of a per-date _stats.txt file
+// surfaced for SEO meta generation. Zero values mean the field
+// couldn't be parsed — callers degrade gracefully to a generic
+// description instead of asserting.
+type rewardStats struct {
+	Date             string  // YYYY-MM-DD (from "date:" line)
+	QualifyingVisors int     // from "qualifying visors:" (first occurrence — Presence Pool)
+	TotalRewardSKY   float64 // from "Total Reward Amount (both pools):" (or single-pool variant)
+	UniqueIPs        int     // from "Unique IP Addresses:"
+	Countries        int     // distinct country codes in the Regional Saturation table
+	TotalBandwidth   string  // from "total network bandwidth:" (already human-readable)
+	RewardMode       string  // from "reward mode:" (e.g. "presence + bandwidth")
+}
+
+// parseRewardStats reads hist/<date>_stats.txt and extracts the fields
+// used for SEO meta + JSON-LD. Missing or malformed stats files yield
+// an empty struct; the caller methods are designed to handle that.
+func parseRewardStats(wd, date string) rewardStats {
+	stats := rewardStats{Date: date}
+	path := filepath.Join(wd, "hist", date+"_stats.txt")
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return stats
+	}
+	body := string(data)
+
+	// Single-line scalar extractors. Use FIRST match for fields that
+	// appear multiple times (qualifying visors appears once per pool
+	// in bandwidth mode but is the same count by construction).
+	if m := regexp.MustCompile(`(?m)^qualifying visors:\s*(\d+)`).FindStringSubmatch(body); len(m) == 2 {
+		stats.QualifyingVisors, _ = strconv.Atoi(m[1])
+	}
+	if m := regexp.MustCompile(`(?m)^Total Reward Amount.*:\s*([0-9]+\.[0-9]+)`).FindStringSubmatch(body); len(m) == 2 {
+		stats.TotalRewardSKY, _ = strconv.ParseFloat(m[1], 64)
+	}
+	if m := regexp.MustCompile(`(?m)^Unique IP Addresses:\s*(\d+)`).FindStringSubmatch(body); len(m) == 2 {
+		stats.UniqueIPs, _ = strconv.Atoi(m[1])
+	}
+	if m := regexp.MustCompile(`(?m)^total network bandwidth:\s*(.+)$`).FindStringSubmatch(body); len(m) == 2 {
+		stats.TotalBandwidth = strings.TrimSpace(m[1])
+	}
+	if m := regexp.MustCompile(`(?m)^reward mode:\s*(.+)$`).FindStringSubmatch(body); len(m) == 2 {
+		stats.RewardMode = strings.TrimSpace(m[1])
+	}
+
+	// Country count = number of data rows in the Regional Saturation
+	// table. Header is "CC    Visors   IPs     Shares  SKY/visor";
+	// data rows start with a 2-letter country code followed by
+	// whitespace and digits. Stop scanning at the next blank line or
+	// "Total Reward Amount" line so we don't accidentally count
+	// tail content.
+	if i := strings.Index(body, "CC    Visors"); i >= 0 {
+		tail := body[i:]
+		// Drop the header line itself.
+		if nl := strings.Index(tail, "\n"); nl >= 0 {
+			tail = tail[nl+1:]
+		}
+		ccLine := regexp.MustCompile(`^[A-Z]{2}\s+\d+`)
+		for _, line := range strings.Split(tail, "\n") {
+			line = strings.TrimRight(line, "\r")
+			if line == "" || strings.HasPrefix(line, "Total Reward Amount") {
+				break
+			}
+			if ccLine.MatchString(line) {
+				stats.Countries++
+			}
+		}
+	}
+
+	return stats
+}
+
+// title returns a descriptive page title for the per-date page. The
+// templated <title> in htmlHeadTemplate already appends " - Skywire
+// Network", so this just supplies the prefix.
+func (s rewardStats) title(date string) string {
+	if s.QualifyingVisors == 0 || s.TotalRewardSKY == 0 {
+		return "Skycoin Rewards " + date
+	}
+	return fmt.Sprintf("Skycoin Rewards %s — %.2f SKY to %d visors", date, s.TotalRewardSKY, s.QualifyingVisors)
+}
+
+// description returns a rich, indexable per-page description. Crawlers
+// see real numbers (visor count, total SKY, country count) instead of
+// the previous generic "reward calculation details for <date>" stub.
+func (s rewardStats) description(date string) string {
+	// Graceful degradation: if stats parse failed, fall back to the
+	// pre-PR templated stub so we don't render an obviously-empty
+	// page description.
+	if s.QualifyingVisors == 0 || s.TotalRewardSKY == 0 {
+		return "Skycoin reward calculation details for " + date + " on the Skywire Network."
+	}
+	parts := []string{
+		fmt.Sprintf("On %s the Skywire Network distributed %.6f SKY to %d qualifying visors", date, s.TotalRewardSKY, s.QualifyingVisors),
+	}
+	if s.Countries > 0 {
+		parts = append(parts, fmt.Sprintf("across %d countries", s.Countries))
+	}
+	if s.UniqueIPs > 0 {
+		parts = append(parts, fmt.Sprintf("from %d unique IPs", s.UniqueIPs))
+	}
+	desc := strings.Join(parts, " ") + "."
+	if s.TotalBandwidth != "" {
+		desc += fmt.Sprintf(" Bandwidth pool aggregate: %s.", s.TotalBandwidth)
+	}
+	return desc
+}
+
+// jsonLD returns the schema.org Dataset block (already wrapped in a
+// <script type='application/ld+json'> tag) describing this date's
+// reward distribution. Empty string when the stats file couldn't be
+// parsed — the htmlHeadTemplate conditional skips emitting anything
+// in that case.
+func (s rewardStats) jsonLD(canonicalURL, date string) string {
+	if s.QualifyingVisors == 0 || s.TotalRewardSKY == 0 || canonicalURL == "" {
+		return ""
+	}
+	// Derive the index-page URL from the canonical so the isPartOf
+	// link points at the same host the page was served from rather
+	// than hard-coding theskywirenetwork.net (the configured canonical
+	// could be anything via the --canonical flag).
+	idx := canonicalURL
+	if i := strings.Index(canonicalURL, "/skycoin-rewards/"); i >= 0 {
+		idx = canonicalURL[:i+len("/skycoin-rewards")]
+	}
+
+	type propVal struct {
+		Type     string      `json:"@type"`
+		Name     string      `json:"name"`
+		Value    interface{} `json:"value"`
+		UnitText string      `json:"unitText,omitempty"`
+	}
+	type dataDl struct {
+		Type           string `json:"@type"`
+		EncodingFormat string `json:"encodingFormat"`
+		Name           string `json:"name"`
+		ContentURL     string `json:"contentUrl"`
+	}
+	type partOf struct {
+		Type string `json:"@type"`
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	}
+	type creator struct {
+		Type string `json:"@type"`
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	}
+	doc := map[string]interface{}{
+		"@context":    "https://schema.org",
+		"@type":       "Dataset",
+		"name":        fmt.Sprintf("Skycoin Rewards %s", date),
+		"description": s.description(date),
+		"url":         canonicalURL,
+		"isPartOf": partOf{
+			Type: "Dataset",
+			Name: "Skywire Network Daily Reward Distributions",
+			URL:  idx,
+		},
+		"creator": creator{
+			Type: "Organization",
+			Name: "Skywire",
+			URL:  "https://github.com/skycoin/skywire",
+		},
+		"dateCreated": date,
+		"license":     "https://github.com/skycoin/skywire/blob/develop/LICENSE",
+		"variableMeasured": []propVal{
+			{Type: "PropertyValue", Name: "qualifying visors", Value: s.QualifyingVisors},
+			{Type: "PropertyValue", Name: "total SKY distributed", Value: s.TotalRewardSKY, UnitText: "SKY"},
+			{Type: "PropertyValue", Name: "unique IP addresses", Value: s.UniqueIPs},
+			{Type: "PropertyValue", Name: "countries represented", Value: s.Countries},
+		},
+		"distribution": []dataDl{
+			{Type: "DataDownload", EncodingFormat: "text/csv", Name: "reward transactions (broadcast input)", ContentURL: canonicalURL + "_rewardtxn0.csv"},
+			{Type: "DataDownload", EncodingFormat: "text/csv", Name: "per-visor shares + reward breakdown", ContentURL: canonicalURL + "_shares.csv"},
+			{Type: "DataDownload", EncodingFormat: "text/csv", Name: "ineligibility audit", ContentURL: canonicalURL + "_ineligible.csv"},
+			{Type: "DataDownload", EncodingFormat: "text/plain", Name: "statistical summary", ContentURL: canonicalURL + "_stats.txt"},
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		return ""
+	}
+	return `<script type='application/ld+json'>` + string(b) + `</script>`
+}

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1068,6 +1068,16 @@ func buildRouter() *gin.Engine {
 					filetoserve, err := script.File(wd + `/hist/` + c.Param("date")).Bytes()
 					if err == nil {
 						c.Writer.Header().Set("Content-Type", "text/plain")
+						// Raw CSV / stats / txt downloads are bulk data
+						// artifacts the indexable per-date HTML page
+						// already summarizes. Tell crawlers not to
+						// index the raw-file URLs themselves so they
+						// don't dilute the indexable surface (we want
+						// /skycoin-rewards/hist/<date> to be THE result
+						// for "skycoin rewards <date>", not a dozen
+						// .csv siblings). `follow` keeps any links
+						// inside the file (typically none) crawlable.
+						c.Writer.Header().Set("X-Robots-Tag", "noindex, follow")
 						c.Writer.WriteHeader(http.StatusOK)
 						c.Writer.Flush()
 						_, _ = c.Writer.Write(filetoserve) //nolint:errcheck,gosec
@@ -1094,6 +1104,7 @@ func buildRouter() *gin.Engine {
 						toserve += fmt.Sprintf("%s%s\n", strings.TrimRight(strings.TrimRight(thispk, "\n"), "\r"), strings.TrimRight(strings.TrimRight(strings.TrimRight(reason, "\n"), "\r"), ","))
 					}
 					c.Writer.Header().Set("Content-Type", "text/plain")
+					c.Writer.Header().Set("X-Robots-Tag", "noindex, follow")
 					c.Writer.WriteHeader(http.StatusOK)
 					c.Writer.Flush()
 					c.Writer.Write([]byte(toserve)) //nolint:errcheck,gosec
@@ -1137,6 +1148,7 @@ func buildRouter() *gin.Engine {
 						toserve += fmt.Sprintf("%s%s%s\n", strings.TrimRight(strings.TrimRight(thispk, "\n"), "\r"), strings.TrimRight(strings.TrimRight(share, "\n"), "\r"), strings.TrimRight(strings.TrimRight(strings.TrimRight(sky, "\n"), "\r"), ","))
 					}
 					c.Writer.Header().Set("Content-Type", "text/plain")
+					c.Writer.Header().Set("X-Robots-Tag", "noindex, follow")
 					c.Writer.WriteHeader(http.StatusOK)
 					c.Writer.Flush()
 					c.Writer.Write([]byte(toserve)) //nolint:errcheck,gosec
@@ -1352,10 +1364,23 @@ func buildRouter() *gin.Engine {
 				fmt.Println("Error parsing Front Page template:", err1)
 			}
 			tmpl := tmpl0
+			// Build SEO-rich Title + Description + JSON-LD from the
+			// freshly-rendered stats file. Crawlers index per-date
+			// pages much better when the description carries the
+			// actual reward totals + visor count + country count
+			// instead of a templated stub, and the JSON-LD Dataset
+			// block gives Google a clean rich-snippet target.
+			stats := parseRewardStats(wd, c.Param("date"))
+			pageDescription := stats.description(c.Param("date"))
+			pageTitle := stats.title(c.Param("date"))
+			pageCanonical := strings.TrimRight(canonicalDomain, "/") + "/skycoin-rewards/hist/" + c.Param("date")
+			jsonLD := stats.jsonLD(pageCanonical, c.Param("date"))
+
 			htmlPageTemplateData1 := (htmlTemplateData{
-				Title:       "Skycoin Rewards " + c.Param("date"),
-				Description: "Skycoin reward calculation details for " + c.Param("date") + " on the Skywire Network.",
-				Content:     htmpl.HTML(l), //nolint:gosec
+				Title:       pageTitle,
+				Description: pageDescription,
+				Content:     htmpl.HTML(l),      //nolint:gosec
+				JSONLD:      htmpl.HTML(jsonLD), //nolint:gosec
 			}).withCanonical("/skycoin-rewards/hist/" + c.Param("date"))
 			tmplData := map[string]interface{}{
 				"Page": htmlPageTemplateData1,


### PR DESCRIPTION
## Summary

Five additive changes to the `/skycoin-rewards/hist/:date` page and shared SEO surfaces in `cmd/skywire-cli/commands/rewards/server/`. No behavior changes for the broadcast pipeline.

### 1. Rich per-page title + description

Parses `hist/<date>_stats.txt` at render time to extract qualifying-visor count, total SKY, unique-IP count, country count, and bandwidth pool aggregate. The page `<title>` now reads:

> Skycoin Rewards 2026-05-31 — 2235.62 SKY to 671 visors - Skywire Network

The `<meta name='description'>` becomes:

> On 2026-05-31 the Skywire Network distributed 2235.616438 SKY to 671 qualifying visors across 26 countries from 227 unique IPs. Bandwidth pool aggregate: 86.2 MB.

Crawlers index real numbers, not the pre-PR templated stub (`"Skycoin reward calculation details for <date> on the Skywire Network."`). Stats parse failure degrades gracefully back to the prior generic description.

### 2. schema.org `Dataset` JSON-LD on /hist/<date>

Embedded as `<script type='application/ld+json'>` in `<head>`. Includes:
- `@type: Dataset`, `name`, `description`, `url`, `dateCreated`
- `variableMeasured` array: qualifying visors, total SKY distributed, unique IPs, countries represented
- `distribution` array: links to the four downloadable artifacts (`_rewardtxn0.csv`, `_shares.csv`, `_ineligible.csv`, `_stats.txt`) with their MIME types
- `isPartOf` pointing at the parent index
- `creator` (Skywire) + `license`

Validated locally for valid JSON; conforms to the [Google Rich Results Test](https://search.google.com/test/rich-results) Dataset format expectations.

### 3. Twitter card meta tags

Added `twitter:card=summary_large_image` plus `twitter:title`, `twitter:description`, `twitter:image` to both the template (`htmlHeadTemplate`) and chunked-head path (`chunkedPageHead`). Previously Twitter/X social-share previews fell back to og: which renders as a small text card; now they render the large-image summary card.

### 4. `X-Robots-Tag: noindex, follow` on raw-data downloads

Three file-serving branches in the `/skycoin-rewards/hist/:date` route (the catch-all `_rewardtxn0.csv` / `_stats.txt` / pool CSV serving, the `_ineligible.csv` custom rendering, the `_shares.csv` custom rendering) now set `X-Robots-Tag: noindex, follow`. The HTML per-date page already summarizes these files; we want `/skycoin-rewards/hist/<date>` to be THE search result for that date, not its dozen CSV siblings diluting the indexable surface. `follow` keeps any URLs inside the files crawlable.

### 5. Cosmetic head improvements

`og:site_name` (Skywire Network), `theme-color` (#1a1d24 matching the existing dark background), `keywords` meta (Skycoin, Skywire, rewards, mesh network, transport bandwidth, dmsg, visor). Applied in both template and chunked-head paths for consistency across all routes.

## Files

- New: `seo.go` — `rewardStats` struct + `parseRewardStats()` + `title()` + `description()` + `jsonLD()` methods
- Modified: `htmpl.go` — `htmlHeadTemplate` (Twitter + theme-color + JSONLD slot), `htmlTemplateData` (new `JSONLD` field), `chunkedPageHead()` (parity additions)
- Modified: `server.go` — `/hist/:date` route wires the enrichment into `htmlTemplateData`; three raw-file branches gain `X-Robots-Tag`

## Important caveat — robots.txt at canonical domain

The SEO work in this PR is **gated upstream by the canonical domain's robots.txt**. `theskywirenetwork.net` (the configured `--canonical` default) currently serves `Disallow: /` because its Caddy reverse-proxy imports a `(norobots)` snippet — that's an operational issue (Caddyfile config on the hosting box), not code. The rewards UI binary itself correctly serves `User-agent: *\nAllow: /\nSitemap: ...` on `/robots.txt` (verified against the `haltingstate.net` mirror which uses a clean Caddy snippet).

Once the canonical Caddy is fixed, all the meta + JSON-LD additions in this PR become immediately effective. Crawlers can then re-index `theskywirenetwork.net` and rich-snippet structured data becomes available for "skycoin rewards <date>" queries.

## Test plan

- [ ] `curl /skycoin-rewards/hist/<date>` — verify `<title>` and `<meta description>` contain real numbers from the stats file.
- [ ] `curl /skycoin-rewards/hist/<date>` — verify `<script type='application/ld+json'>` block present in `<head>` and parses as valid JSON; paste into [Google Rich Results Test](https://search.google.com/test/rich-results) and confirm Dataset is detected.
- [ ] `curl /skycoin-rewards/hist/<date>` — verify `<meta name='twitter:card' content='summary_large_image'>` present.
- [ ] `curl -I /skycoin-rewards/hist/<date>_rewardtxn0.csv` — verify `X-Robots-Tag: noindex, follow` header present.
- [ ] `curl -I /skycoin-rewards/hist/<date>` — verify NO `X-Robots-Tag` header on the HTML page itself.
- [ ] `curl /skycoin-rewards/hist/<date-pre-stats.txt-format>` — verify graceful fallback to the generic description when stats can't be parsed.
- [ ] Visit `/stats` etc. — confirm the chunked-head SEO additions (twitter:card, theme-color) render.

## Non-goals

- No real branded `og:image` asset. Still defaults to `/favicon.ico`. Adding a 1200×630 share image is a separate asset-add PR if desired.
- No template/HTML restructure of the per-date page body — only `<head>` enrichment and headers.
- No SEO changes to the main `/` front page beyond template-level parity (already had reasonable meta).
- No JSON-LD on listing pages (only per-date Dataset blocks).

Follows up #2946 + #2947 + #2949.