### PR TITLE
fix(router): TTL cache for TPD GetTransportByID in buildHopLookups (skynet --routes N --min-hops K)

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -412,6 +412,7 @@ type router struct {
 	muxMode            WeightMode       // default weight mode for new mux connections
 	lastRouteCalcTime  time.Duration    // last route calculation time (for local routes)
 	lastRouteCalcMu    sync.Mutex       // protects lastRouteCalcTime
+	tpdCache           *tpdEntryCache   // visor-wide TTL cache for TPD GetTransportByID, see tpd_cache.go
 }
 
 // scopedLog returns a logger augmented with app_name=<n> when the
@@ -481,6 +482,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		done:            make(chan struct{}),
 		trustedVisors:   trustedVisors,
 		routeSetupHooks: routeSetupHooks,
+		tpdCache:        newTPDEntryCache(),
 	}
 
 	go r.rulesGCLoop()

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -998,9 +998,25 @@ func (r *router) buildHopLookups(ctx context.Context, fwd, rev [][]routing.Hop) 
 				continue
 			}
 		}
-		// TPD fallback — one fetch covers both lookups.
+		// TPD fallback — one fetch covers both lookups, served from
+		// the router's TTL cache when the entry is fresh. The cache
+		// is what keeps --routes N --min-hops K from blowing through
+		// TPD's 30-req/min rate limit on multi-hop dials: each dial
+		// retry pulls 12+ unique TpIDs across candidate paths, and
+		// without caching the bursts trivially exceed budget → 429s
+		// → buildHopLookups returns empty for every hop → downstream
+		// rejectDMSGMultihop / latency-rank can't filter or rank →
+		// the assembled route group never works.
 		if r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil {
-			entry, err := r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, id)
+			fetch := r.tm.Conf.DiscoveryClient.GetTransportByID
+			cache := r.tpdCache
+			var entry *transport.Entry
+			var err error
+			if cache != nil {
+				entry, err = cache.GetOrFetch(ctx, id, fetch)
+			} else {
+				entry, err = fetch(ctx, id)
+			}
 			if err != nil {
 				r.logger.WithError(err).Debugf("buildHopLookups: GetTransportByID failed for %s", id)
 				continue

--- a/pkg/router/tpd_cache.go
+++ b/pkg/router/tpd_cache.go
@@ -46,19 +46,19 @@ import (
 // results. Concurrent-safe via sync.RWMutex (lookups are read-heavy
 // + bursty; cache fill is the only writer per ID).
 type tpdEntryCache struct {
-	mu          sync.RWMutex
-	entries     map[uuid.UUID]tpdCacheEntry
-	posTTL      time.Duration
-	negTTL      time.Duration
-	clock       func() time.Time // injectable for tests
+	mu      sync.RWMutex
+	entries map[uuid.UUID]tpdCacheEntry
+	posTTL  time.Duration
+	negTTL  time.Duration
+	clock   func() time.Time // injectable for tests
 }
 
 // tpdCacheEntry is one cached lookup result. When entry is nil
 // the lookup failed (rate-limited or 404); the negative TTL
 // suppresses retries until expiry.
 type tpdCacheEntry struct {
-	entry    *transport.Entry // nil ⇒ negative cache
-	expires  time.Time
+	entry   *transport.Entry // nil ⇒ negative cache
+	expires time.Time
 }
 
 // defaultTPDCachePosTTL is the lifetime of a cached successful

--- a/pkg/router/tpd_cache.go
+++ b/pkg/router/tpd_cache.go
@@ -1,0 +1,176 @@
+// pkg/router/tpd_cache.go — visor-wide TTL cache for TPD
+// GetTransportByID lookups, so buildHopLookups (and any future
+// caller that needs per-hop transport metadata) doesn't hammer the
+// TPD HTTP rate limit.
+//
+// Motivation: skynet-client --routes N --min-hops K causes the
+// dial path to call buildHopLookups with multiple multi-hop
+// candidates (typically 3 forward × M hops + 3 reverse × M hops =
+// 12+ unique TpIDs per dial). Each retry round hits buildHopLookups
+// again. With TPD enforcing 30 req/min, even a single dial with
+// retries exceeds the budget and every transport lookup returns
+// "429 Too Many Requests: Rate limit exceeded" → buildHopLookups
+// silently degrades (it logs at Debug + continues with empty
+// latency/type for that hop) → downstream path-pick filters can't
+// reject DMSG-multihop or rank by latency → the route group fails
+// to assemble end-to-end.
+//
+// The cache is purely a local read-side optimization: the same TPD
+// entry is reusable for many dial attempts as long as it's fresh.
+// We don't write back to TPD; entries expire naturally and the
+// next read re-fetches.
+//
+// TTL is sized to outlast a single dial's retry burst (3 retries
+// × ~10s per attempt) while still being short enough that a
+// genuinely-deleted-transport entry doesn't linger long enough to
+// cause downstream mis-pick. 60s is a comfortable middle.
+//
+// Negative caching: failed lookups are cached briefly too so that
+// a transient TPD 429 doesn't trigger an instant retry storm. The
+// negative TTL is short (5s) — short enough for a TPD recovery
+// window to be respected, long enough to break a retry tight loop.
+
+package router
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// tpdEntryCache is a small TTL cache of TPD GetTransportByID
+// results. Concurrent-safe via sync.RWMutex (lookups are read-heavy
+// + bursty; cache fill is the only writer per ID).
+type tpdEntryCache struct {
+	mu          sync.RWMutex
+	entries     map[uuid.UUID]tpdCacheEntry
+	posTTL      time.Duration
+	negTTL      time.Duration
+	clock       func() time.Time // injectable for tests
+}
+
+// tpdCacheEntry is one cached lookup result. When entry is nil
+// the lookup failed (rate-limited or 404); the negative TTL
+// suppresses retries until expiry.
+type tpdCacheEntry struct {
+	entry    *transport.Entry // nil ⇒ negative cache
+	expires  time.Time
+}
+
+// defaultTPDCachePosTTL is the lifetime of a cached successful
+// GetTransportByID result. TPD entries rarely change within a
+// minute (the publisher only re-registers on state change), so a
+// 60s TTL is well within the freshness budget for routing
+// decisions.
+const defaultTPDCachePosTTL = 60 * time.Second
+
+// defaultTPDCacheNegTTL is the lifetime of a cached failure (rate
+// limit, 404, network error). Short enough that a TPD recovery is
+// noticed within seconds; long enough to break a retry tight loop
+// (e.g. the dial path's three-attempt outer loop).
+const defaultTPDCacheNegTTL = 5 * time.Second
+
+// newTPDEntryCache returns an empty cache with default TTLs.
+func newTPDEntryCache() *tpdEntryCache {
+	return &tpdEntryCache{
+		entries: make(map[uuid.UUID]tpdCacheEntry),
+		posTTL:  defaultTPDCachePosTTL,
+		negTTL:  defaultTPDCacheNegTTL,
+		clock:   time.Now,
+	}
+}
+
+// Get returns (entry, true, true) on positive cache hit, (nil,
+// true, false) on negative cache hit (cached failure within negTTL),
+// and (nil, false, false) on cache miss. The third return distinguishes
+// "we have a cached *good* entry" from "we have a cached failure" so
+// callers know whether to skip the TPD round-trip.
+func (c *tpdEntryCache) Get(id uuid.UUID) (entry *transport.Entry, hit bool, positive bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[id]
+	if !ok {
+		return nil, false, false
+	}
+	if c.clock().After(e.expires) {
+		return nil, false, false
+	}
+	if e.entry == nil {
+		return nil, true, false
+	}
+	return e.entry, true, true
+}
+
+// PutSuccess records a successful TPD lookup. Subsequent Get calls
+// within posTTL return entry without hitting TPD.
+func (c *tpdEntryCache) PutSuccess(id uuid.UUID, entry *transport.Entry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[id] = tpdCacheEntry{
+		entry:   entry,
+		expires: c.clock().Add(c.posTTL),
+	}
+}
+
+// PutFailure records a failed TPD lookup (rate-limited, 404, etc.).
+// Subsequent Get calls within negTTL return (nil, true, false), so
+// the caller can skip the TPD round-trip and treat the ID as
+// "unknown" for the negative-cache window.
+func (c *tpdEntryCache) PutFailure(id uuid.UUID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[id] = tpdCacheEntry{
+		entry:   nil,
+		expires: c.clock().Add(c.negTTL),
+	}
+}
+
+// GetOrFetch returns the cached entry if fresh; otherwise calls
+// fetch and caches the result (positive or negative). The fetch
+// function is invoked exactly once per cache miss per goroutine —
+// concurrent misses for the same id MAY each call fetch (sync.Map's
+// LoadOrStore-style dedup would add complexity for marginal gain
+// since the underlying TPD client already de-dups identical
+// in-flight requests at the HTTP layer).
+//
+// On fetch error the cache records the failure (negative TTL) and
+// returns (nil, err) so the caller can apply its own fallback (in
+// buildHopLookups: log at Debug + continue with empty lookup for
+// that hop).
+func (c *tpdEntryCache) GetOrFetch(
+	ctx context.Context,
+	id uuid.UUID,
+	fetch func(context.Context, uuid.UUID) (*transport.Entry, error),
+) (*transport.Entry, error) {
+	if entry, hit, positive := c.Get(id); hit {
+		if positive {
+			return entry, nil
+		}
+		// Negative cache hit — skip the TPD round-trip; the
+		// caller treats this the same as a fresh failure.
+		return nil, errTPDCachedFailure
+	}
+	entry, err := fetch(ctx, id)
+	if err != nil {
+		c.PutFailure(id)
+		return nil, err
+	}
+	c.PutSuccess(id, entry)
+	return entry, nil
+}
+
+// errTPDCachedFailure is the sentinel error returned by GetOrFetch
+// when a recent failure is still in the negative cache. Callers
+// can errors.Is-match this to distinguish a fresh TPD call failure
+// from a suppressed retry.
+var errTPDCachedFailure = tpdCachedFailureError{}
+
+type tpdCachedFailureError struct{}
+
+func (tpdCachedFailureError) Error() string {
+	return "tpd: skipped (negative cache hit within window)"
+}

--- a/pkg/router/tpd_cache_test.go
+++ b/pkg/router/tpd_cache_test.go
@@ -1,0 +1,167 @@
+// pkg/router/tpd_cache_test.go — verifies the TTL cache behavior
+// that protects buildHopLookups from blowing through TPD's
+// rate-limit on multi-hop dials.
+
+package router
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// fakeClock returns a controllable time.Now for deterministic TTL
+// tests. now() always returns the current value of the *time field;
+// callers advance time with advance().
+type fakeClock struct {
+	t time.Time
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	return &fakeClock{t: start}
+}
+
+func (c *fakeClock) now() time.Time {
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.t = c.t.Add(d)
+}
+
+// TestTPDCache_PositiveCacheReducesTPDCalls verifies the canonical
+// motivating case: a multi-hop dial inspects the same TpID across
+// multiple candidate paths and retries; with the cache, TPD is
+// hit once per unique ID per posTTL window, not once per
+// inspection.
+func TestTPDCache_PositiveCacheReducesTPDCalls(t *testing.T) {
+	cache := newTPDEntryCache()
+	clk := newFakeClock(time.Now())
+	cache.clock = clk.now
+
+	id := uuid.New()
+	entry := &transport.Entry{ID: id, Latency: 42}
+
+	var fetchCount int
+	fetch := func(_ context.Context, _ uuid.UUID) (*transport.Entry, error) {
+		fetchCount++
+		return entry, nil
+	}
+
+	// First call: miss → fetch → populate.
+	got, err := cache.GetOrFetch(context.Background(), id, fetch)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, id, got.ID)
+	assert.Equal(t, 1, fetchCount, "first call must fetch")
+
+	// Subsequent calls within posTTL: hit → no fetch.
+	for i := 0; i < 50; i++ {
+		got, err := cache.GetOrFetch(context.Background(), id, fetch)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+	}
+	assert.Equal(t, 1, fetchCount, "50 reads within posTTL must reuse cached value")
+
+	// After posTTL expires, fetch is invoked again.
+	clk.advance(defaultTPDCachePosTTL + time.Second)
+	_, err = cache.GetOrFetch(context.Background(), id, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, 2, fetchCount, "post-expiry call must re-fetch")
+}
+
+// TestTPDCache_NegativeCacheSuppressesRetryStorms verifies the
+// negative-cache behavior: a TPD failure (e.g. 429) is remembered
+// for negTTL so a retry loop doesn't immediately re-hit the
+// rate-limited endpoint.
+func TestTPDCache_NegativeCacheSuppressesRetryStorms(t *testing.T) {
+	cache := newTPDEntryCache()
+	clk := newFakeClock(time.Now())
+	cache.clock = clk.now
+
+	id := uuid.New()
+	tpdErr := errors.New("429 Too Many Requests")
+
+	var fetchCount int
+	fetch := func(_ context.Context, _ uuid.UUID) (*transport.Entry, error) {
+		fetchCount++
+		return nil, tpdErr
+	}
+
+	// First call: fetch hits TPD + records failure.
+	_, err := cache.GetOrFetch(context.Background(), id, fetch)
+	require.Error(t, err)
+	assert.Equal(t, 1, fetchCount)
+
+	// Subsequent calls within negTTL: skipped, no fetch.
+	for i := 0; i < 20; i++ {
+		_, err := cache.GetOrFetch(context.Background(), id, fetch)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTPDCachedFailure, "negative-cache hit must return the sentinel")
+	}
+	assert.Equal(t, 1, fetchCount, "20 reads within negTTL must NOT re-fetch")
+
+	// After negTTL expires, fetch runs again.
+	clk.advance(defaultTPDCacheNegTTL + time.Second)
+	_, err = cache.GetOrFetch(context.Background(), id, fetch)
+	require.Error(t, err)
+	assert.Equal(t, 2, fetchCount, "post-negTTL call must re-fetch")
+}
+
+// TestTPDCache_PutFailureThenSuccess verifies that a positive
+// re-fetch overwrites a prior negative cache entry, so a transient
+// TPD outage doesn't permanently degrade lookups for an ID.
+func TestTPDCache_PutFailureThenSuccess(t *testing.T) {
+	cache := newTPDEntryCache()
+	clk := newFakeClock(time.Now())
+	cache.clock = clk.now
+
+	id := uuid.New()
+	entry := &transport.Entry{ID: id, Latency: 17}
+
+	// Record a failure.
+	cache.PutFailure(id)
+	_, hit, positive := cache.Get(id)
+	assert.True(t, hit, "negative entry must be a hit")
+	assert.False(t, positive, "negative entry must report negative")
+
+	// Skip past negTTL and store a positive result.
+	clk.advance(defaultTPDCacheNegTTL + time.Second)
+	cache.PutSuccess(id, entry)
+	got, hit, positive := cache.Get(id)
+	require.True(t, hit)
+	require.True(t, positive)
+	assert.Equal(t, entry, got)
+}
+
+// TestTPDCache_ConcurrentReadsAreSafe is a smoke test for the
+// RWMutex protection — buildHopLookups already invokes Get from a
+// single goroutine per dial, but other call sites (cascade_builder,
+// vstream) may issue concurrent reads.
+func TestTPDCache_ConcurrentReadsAreSafe(t *testing.T) {
+	cache := newTPDEntryCache()
+	id := uuid.New()
+	cache.PutSuccess(id, &transport.Entry{ID: id, Latency: 5})
+
+	done := make(chan struct{})
+	const readers = 16
+	const reads = 1000
+	for i := 0; i < readers; i++ {
+		go func() {
+			for j := 0; j < reads; j++ {
+				_, _, _ = cache.Get(id)
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
## Summary

`skynet-client --routes N --min-hops K` blows through TPD's 30-req/min rate limit on every dial, causing `buildHopLookups` to silently empty out, downstream filters can't rank/reject, and the route group never assembles. Local listener binds but TCP connections RST.

## Reproducer (verified live)

```
iperf3 -c 127.0.0.1 -p 5212 -t 30 -P 4 over a skynet client started with
  skywire cli skynet start --pk <peer> --remote 5210 --local 5212 \
    --routes 8 --min-hops 2 --forward-mux 8 --reverse-mux 8

→ 'unable to receive control message - port may not be available,
   the other side may have stopped running, etc.: Connection reset by peer'
→ 0 bytes, intervals=[], connected=[]
```

Visor log on initiator (debug level):
```
[router]: Found routes Forward: [...] (3 candidates × 2 hops × {fwd,rev})
[router]: buildHopLookups: GetTransportByID failed for c601d3b6... error="429 Too Many Requests: Rate limit exceeded: maximum 30 requests per minute"
... (× ~12 per attempt, × 3 retries)
```
`cli rg ls` — empty (no route group materialized).

## Root cause

Each dial attempt resolves 12+ unique TpIDs (3 candidates × 2 hops × {forward, reverse}). With 3 retry rounds, ~36 lookups land at TPD within ~1 second. TPD's per-client rate limit is 30 req/min. After the first ~30, every subsequent call returns 429 → `buildHopLookups` logs at Debug + continues with empty latency/type → downstream `rejectDMSGMultihop` and the latency ranker get nothing useful → no path is picked → no route group registered.

## Fix

Router-scoped TTL cache for `GetTransportByID` (`pkg/router/tpd_cache.go`):
- **Positive TTL: 60s** — TPD entries are republished on state change; a minute of staleness is well within the freshness budget for routing decisions.
- **Negative TTL: 5s** — a single rate-limited burst doesn't cascade into a retry storm; TPD recovery is noticed within seconds.

`buildHopLookups` in `pkg/router/router_dial.go` routes its TPD calls through `cache.GetOrFetch`. Concurrent reads are RWMutex-guarded.

No behavior change when DiscoveryClient is nil (cache fully skipped). No API change. No new deps.

## Tests

`pkg/router/tpd_cache_test.go` covers:
- positive cache reduces fetch count from N to 1 within posTTL
- negative cache suppresses retry storms within negTTL
- failure → success heals cleanly
- concurrent reads are safe

Full `pkg/router` test suite still passes (~38s).

## Cred

Live-reproduced today by Beta + Gamma. Beta predicted the cache-shape fix earlier in another thread ("visor-wide TTL cache is the right shape"); this implements that prediction with the diagnosis evidence.