### PR TITLE
fix(router): bulk-snapshot TPD for hop lookups + honor mux degree in route count

### DIFF
--- a/pkg/rfclient/client.go
+++ b/pkg/rfclient/client.go
@@ -27,6 +27,14 @@ var ErrTransportNotFound = errors.New("transport not found")
 type RouteOptions struct {
 	MinHops uint16
 	MaxHops uint16
+	// NumRoutes is the desired number of distinct routes per edge the
+	// finder should return. Zero means "use the service default"
+	// (maxNumberOfRoutes). Callers requesting a multiplexed dial set
+	// this to the mux degree (+ headroom) so the finder returns enough
+	// disjoint legs instead of the hard-coded default — without it the
+	// finder caps at 3 routes and any --forward-mux/--reverse-mux above
+	// that silently degrades. See router.findRouteOptions.
+	NumRoutes uint16
 }
 
 // FindRoutesRequest parses json body for /routes endpoint request

--- a/pkg/rfclient/client_test.go
+++ b/pkg/rfclient/client_test.go
@@ -1,0 +1,48 @@
+package rfclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestFindRoutesRequest_NumRoutesRoundTrip guards the wire contract
+// between the rfclient (marshals FindRoutesRequest) and the
+// route-finder API (unmarshals the same struct): the NumRoutes field
+// must survive JSON so a multiplexed dial's requested route count
+// actually reaches the finder. A missing/renamed json tag would
+// silently drop it and re-cap the finder at its default of 3.
+func TestFindRoutesRequest_NumRoutesRoundTrip(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+
+	req := &FindRoutesRequest{
+		Edges: []routing.PathEdges{{a, b}},
+		Opts:  &RouteOptions{MinHops: 2, MaxHops: 7, NumRoutes: 10},
+	}
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var got FindRoutesRequest
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.NotNil(t, got.Opts)
+	assert.Equal(t, uint16(2), got.Opts.MinHops)
+	assert.Equal(t, uint16(7), got.Opts.MaxHops)
+	assert.Equal(t, uint16(10), got.Opts.NumRoutes)
+}
+
+// TestRouteOptions_ZeroNumRoutesOmittedDefault confirms the zero value
+// round-trips as zero (the API treats 0 as "use the service default"),
+// so pre-NumRoutes callers and non-mux dials keep the old behavior.
+func TestRouteOptions_ZeroNumRoutesDefault(t *testing.T) {
+	raw, err := json.Marshal(&RouteOptions{MinHops: 0, MaxHops: 5})
+	require.NoError(t, err)
+	var got RouteOptions
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, uint16(0), got.NumRoutes)
+}

--- a/pkg/route-finder/api/api.go
+++ b/pkg/route-finder/api/api.go
@@ -21,7 +21,15 @@ import (
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
+// maxNumberOfRoutes is the default per-edge route count when the
+// request doesn't specify RouteOptions.NumRoutes (back-compat with
+// pre-NumRoutes clients).
 const maxNumberOfRoutes = 3
+
+// routesCeiling bounds RouteOptions.NumRoutes so a client can't make
+// the finder collect an unbounded number of routes (BFS work scales
+// with the count). Sized comfortably above any realistic mux degree.
+const routesCeiling = 20
 
 // API represents the api of the route-finder service.
 type API struct {
@@ -111,9 +119,18 @@ func (a *API) getPairedRoutes(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	var minHops, maxHops int
+	numRoutes := maxNumberOfRoutes
 	if grr.Opts != nil {
 		minHops = int(grr.Opts.MinHops)
 		maxHops = int(grr.Opts.MaxHops)
+		// Honor the caller's requested route count (mux degree +
+		// headroom), bounded by routesCeiling. Zero keeps the default.
+		if grr.Opts.NumRoutes > 0 {
+			numRoutes = int(grr.Opts.NumRoutes)
+			if numRoutes > routesCeiling {
+				numRoutes = routesCeiling
+			}
+		}
 	}
 
 	// Limit graph exploration depth to prevent OOM on large networks.
@@ -146,7 +163,7 @@ func (a *API) getPairedRoutes(w http.ResponseWriter, r *http.Request) {
 		dstPK := edge[1]
 		graph := graphs[srcPK]
 
-		forwardRoutes, err := graph.GetRoute(r.Context(), srcPK, dstPK, minHops, maxHops, maxNumberOfRoutes)
+		forwardRoutes, err := graph.GetRoute(r.Context(), srcPK, dstPK, minHops, maxHops, numRoutes)
 		if err != nil {
 			a.handleError(w, r, http.StatusNotFound, err)
 			return

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -403,15 +403,16 @@ type router struct {
 	done               chan struct{}
 	once               sync.Once
 	routeSetupHookMu   sync.Mutex
-	routeSetupHooks    []RouteSetupHook // see RouteSetupHook description
-	existingTpOnly     bool             // when true, don't create new transports for routing
-	existingTpOnlyMu   sync.Mutex       // protects existingTpOnly
-	forceLocalRoutes   bool             // when true, skip route finder and use local route calculation
-	forceLocalRoutesMu sync.Mutex       // protects forceLocalRoutes
-	muxRoutes          int              // number of parallel mux routes (0 or 1 = disabled)
-	muxMode            WeightMode       // default weight mode for new mux connections
-	lastRouteCalcTime  time.Duration    // last route calculation time (for local routes)
-	lastRouteCalcMu    sync.Mutex       // protects lastRouteCalcTime
+	routeSetupHooks    []RouteSetupHook  // see RouteSetupHook description
+	existingTpOnly     bool              // when true, don't create new transports for routing
+	existingTpOnlyMu   sync.Mutex        // protects existingTpOnly
+	forceLocalRoutes   bool              // when true, skip route finder and use local route calculation
+	forceLocalRoutesMu sync.Mutex        // protects forceLocalRoutes
+	muxRoutes          int               // number of parallel mux routes (0 or 1 = disabled)
+	muxMode            WeightMode        // default weight mode for new mux connections
+	lastRouteCalcTime  time.Duration     // last route calculation time (for local routes)
+	lastRouteCalcMu    sync.Mutex        // protects lastRouteCalcTime
+	tpdCache           *tpdSnapshotCache // one-snapshot TTL cache of GetAllTransports, see tpd_cache.go
 }
 
 // scopedLog returns a logger augmented with app_name=<n> when the
@@ -481,6 +482,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		done:            make(chan struct{}),
 		trustedVisors:   trustedVisors,
 		routeSetupHooks: routeSetupHooks,
+		tpdCache:        newTPDSnapshotCache(),
 	}
 
 	go r.rulesGCLoop()

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -647,20 +647,35 @@ fetchRoutesAgain:
 		revMinHops = uint16(revEff) //nolint:gosec // bounded by caller; CLI flag values are small
 	}
 
+	// Route count to request per edge: the route-finder defaults to 3
+	// routes, so a mux degree above that would be silently capped and
+	// starve the mux splitter of legs. Ask for the mux degree (+ small
+	// headroom for disjoint-pick overlap) so --forward-mux/--reverse-mux
+	// above 3 actually get enough disjoint routes. Zero mux → 0 →
+	// finder uses its default.
+	fwdNum := findRouteNum(opts.EffectiveMuxRoutes(true))
+	revNum := findRouteNum(opts.EffectiveMuxRoutes(false))
+
 	var paths map[routing.PathEdges][][]routing.Hop
 	if fwdMinHops == revMinHops {
-		// Common path: single query covers both directions.
+		// Common path: single query covers both directions. One count
+		// applies to all PathEdges in the call, so request the larger
+		// of the two directions' mux degrees.
+		num := fwdNum
+		if revNum > num {
+			num = revNum
+		}
 		paths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward, backward},
-			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops})
+			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops, NumRoutes: num})
 	} else {
 		// Asymmetric: two queries with different MinHops per direction.
 		// Merge their results into a single map keyed by PathEdges.
 		var fwdPaths, revPaths map[routing.PathEdges][][]routing.Hop
 		fwdPaths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{forward},
-			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops})
+			&rfclient.RouteOptions{MinHops: fwdMinHops, MaxHops: r.conf.MaxHops, NumRoutes: fwdNum})
 		if err == nil {
 			revPaths, err = r.conf.RouteFinder.FindRoutes(ctx, []routing.PathEdges{backward},
-				&rfclient.RouteOptions{MinHops: revMinHops, MaxHops: r.conf.MaxHops})
+				&rfclient.RouteOptions{MinHops: revMinHops, MaxHops: r.conf.MaxHops, NumRoutes: revNum})
 		}
 		if err == nil {
 			paths = make(map[routing.PathEdges][][]routing.Hop, 2)
@@ -958,6 +973,33 @@ func pathLatencyScore(path []routing.Hop, latencyFor func(uuid.UUID) float64) fl
 	return total
 }
 
+// baseRouteCandidates mirrors the route-finder's historical default
+// route count — request at least this many so non-mux dials keep their
+// latency-rank choice. muxRouteHeadroom is the extra routes requested
+// on top of the mux degree so the disjoint-path pick can still reach
+// the target count when some returned candidates share intermediates.
+const (
+	baseRouteCandidates = 3
+	muxRouteHeadroom    = 2
+)
+
+// findRouteNum returns the per-edge route count to request from the
+// route-finder for a dial with the given effective mux degree. Zero
+// (mux off) returns 0, letting the finder apply its own default. A
+// positive mux degree returns mux+headroom, floored at the historical
+// default so we never request fewer candidates than before. The
+// finder clamps the value to its own ceiling.
+func findRouteNum(mux int) uint16 {
+	if mux <= 0 {
+		return 0
+	}
+	n := mux + muxRouteHeadroom
+	if n < baseRouteCandidates {
+		n = baseRouteCandidates
+	}
+	return uint16(n) //nolint:gosec // mux degree is a small CLI-bounded value
+}
+
 // buildHopLookups constructs TpID → avg-latency-ms and TpID →
 // transport-type lookups over the union of TpIDs appearing in fwd
 // and rev path candidates. Sources, in preference order:
@@ -987,8 +1029,11 @@ func (r *router) buildHopLookups(ctx context.Context, fwd, rev [][]routing.Hop) 
 	}
 	latencyCache := make(map[uuid.UUID]float64, len(unique))
 	typeCache := make(map[uuid.UUID]string, len(unique))
+
+	var misses []uuid.UUID
 	for id := range unique {
-		// Local transport first.
+		// Local transport first — constant-time map read, with the
+		// freshest latency stats this visor holds.
 		if r.tm != nil {
 			if tp := r.tm.Transport(id); tp != nil {
 				if stats := tp.GetLatencyStats(); stats.Avg > 0 {
@@ -998,22 +1043,41 @@ func (r *router) buildHopLookups(ctx context.Context, fwd, rev [][]routing.Hop) 
 				continue
 			}
 		}
-		// TPD fallback — one fetch covers both lookups.
-		if r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil {
-			entry, err := r.tm.Conf.DiscoveryClient.GetTransportByID(ctx, id)
-			if err != nil {
-				r.logger.WithError(err).Debugf("buildHopLookups: GetTransportByID failed for %s", id)
-				continue
+		misses = append(misses, id)
+	}
+
+	// Resolve non-local hops (intermediate-to-intermediate) from ONE
+	// cached GetAllTransports snapshot rather than a GetTransportByID
+	// per ID. A multiplexed multi-hop dial touches 12+ unique IDs ×
+	// retries; per-ID fetches blow through TPD's 30-req/min limit, so
+	// every lookup 429s, buildHopLookups degrades to empty latency/
+	// type, and the route group can't rank/filter → never assembles.
+	// The bulk snapshot is a single fetch (cached, see tpd_cache.go),
+	// so the same data costs one round-trip per TTL instead of one
+	// per hop per dial.
+	if len(misses) > 0 && r.tm != nil && r.tm.Conf != nil && r.tm.Conf.DiscoveryClient != nil && r.tpdCache != nil {
+		snap, err := r.tpdCache.snapshot(ctx, r.tm.Conf.DiscoveryClient.GetAllTransports)
+		if err != nil {
+			// snap is non-nil when a prior snapshot was served stale;
+			// only a cold-cache failure yields nil. Either way, log
+			// and proceed — unknown hops degrade gracefully (latency 0,
+			// type "" which rejectDMSGMultihop treats as "not DMSG").
+			r.logger.WithError(err).Debug("buildHopLookups: transport snapshot refresh failed; using local + any stale data")
+		}
+		if snap != nil {
+			for _, id := range misses {
+				entry := snap.byID[id]
+				if entry == nil {
+					continue
+				}
+				if entry.Latency > 0 {
+					latencyCache[id] = entry.Latency
+				}
+				typeCache[id] = string(entry.Type)
 			}
-			if entry == nil {
-				continue
-			}
-			if entry.Latency > 0 {
-				latencyCache[id] = entry.Latency
-			}
-			typeCache[id] = string(entry.Type)
 		}
 	}
+
 	return func(id uuid.UUID) float64 { return latencyCache[id] },
 		func(id uuid.UUID) string { return typeCache[id] }
 }
@@ -1200,12 +1264,27 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		}
 	}
 
-	// Build transport cache from single GetAllTransports() call
-	// This replaces N individual GetTransportsByEdge API calls with one bulk fetch
-	allEntries, err := dc.GetAllTransports(ctx)
-	if err != nil {
-		log.WithError(err).Warn("Failed to fetch all transports for route calculation")
-		return nil, nil, fmt.Errorf("failed to fetch transport discovery data: %w", err)
+	// Build transport cache from a single GetAllTransports() snapshot,
+	// shared with buildHopLookups via r.tpdCache (5m TTL). This both
+	// replaces N individual GetTransportsByEdge calls with one bulk
+	// fetch AND amortizes that fetch across dials so repeated local
+	// route calculations don't re-pull the whole dataset each time.
+	var allEntries []*transport.Entry
+	if r.tpdCache != nil {
+		snap, serr := r.tpdCache.snapshot(ctx, dc.GetAllTransports)
+		if snap == nil {
+			// Cold-cache failure only — a stale snapshot would be
+			// returned non-nil. Nothing to compute routes from.
+			log.WithError(serr).Warn("Failed to fetch all transports for route calculation")
+			return nil, nil, fmt.Errorf("failed to fetch transport discovery data: %w", serr)
+		}
+		allEntries = snap.entries
+	} else {
+		allEntries, err = dc.GetAllTransports(ctx)
+		if err != nil {
+			log.WithError(err).Warn("Failed to fetch all transports for route calculation")
+			return nil, nil, fmt.Errorf("failed to fetch transport discovery data: %w", err)
+		}
 	}
 
 	// Build lookup map: pubkey -> transports involving that pubkey.

--- a/pkg/router/tpd_cache.go
+++ b/pkg/router/tpd_cache.go
@@ -1,0 +1,134 @@
+// pkg/router/tpd_cache.go — a small TTL cache holding ONE snapshot of
+// the whole transport-discovery dataset (the result of a single
+// GetAllTransports call), shared by the router's route-calculation
+// paths.
+//
+// Motivation: route calculation is a local operation over the
+// transport graph, so the visor needs the transport set in hand
+// anyway. calculateLocalRoutes already fetches it in one bulk
+// GetAllTransports call; buildHopLookups (the latency-rank + DMSG
+// filter for the route-finder path) previously re-derived the same
+// data with one GetTransportByID HTTP call *per hop ID*. On a
+// multiplexed multi-hop dial that's 12+ IDs × retries — easily past
+// TPD's 30-req/min rate limit, so every per-hop lookup returns
+// "429 Too Many Requests", buildHopLookups silently degrades to empty
+// latency/type, and the route group never assembles.
+//
+// The fix is structural, not a per-ID band-aid: fetch the whole set
+// ONCE, cache it with a short TTL, and serve every hop lookup from the
+// in-memory snapshot. TPD entries only change on transport
+// register/deregister, so a snapshot is fresh enough for routing
+// decisions for minutes; 5m is a comfortable middle that keeps a
+// genuinely-removed transport from lingering long enough to mis-route.
+//
+// This is purely a local read-side cache — we never write back to TPD.
+// On a refresh error the previous snapshot is served stale rather than
+// dropping to empty, so a transient TPD blip can't break routing.
+//
+// Longer term the snapshot source should be the on-demand CXO
+// subscriber to TPD (the transport manager already mirrors
+// register/deregister into a CXO publisher tree) rather than an HTTP
+// GetAllTransports round-trip — at which point this cache becomes a
+// thin adapter over the CXO-backed store.
+
+package router
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// defaultTPDSnapshotTTL is how long a GetAllTransports snapshot is
+// served before a refresh. TPD entries are republished on transport
+// state change, so minutes-scale staleness is acceptable for routing.
+const defaultTPDSnapshotTTL = 5 * time.Minute
+
+// tpdSnapshotCache caches one whole-dataset GetAllTransports result.
+// Concurrent-safe: readers take the RLock to grab the current
+// immutable snapshot; a refresh builds a NEW snapshot and swaps the
+// pointer under the write lock, so a snapshot handed to a caller is
+// never mutated underneath it.
+type tpdSnapshotCache struct {
+	mu    sync.RWMutex
+	snap  *tpdSnapshot
+	ttl   time.Duration
+	clock func() time.Time // injectable for tests
+}
+
+// tpdSnapshot is one immutable view of the transport-discovery set.
+type tpdSnapshot struct {
+	entries []*transport.Entry
+	byID    map[uuid.UUID]*transport.Entry
+	expires time.Time
+}
+
+// newTPDSnapshotCache returns an empty cache with the default TTL.
+func newTPDSnapshotCache() *tpdSnapshotCache {
+	return &tpdSnapshotCache{
+		ttl:   defaultTPDSnapshotTTL,
+		clock: time.Now,
+	}
+}
+
+// fresh returns the current snapshot if it exists and hasn't expired.
+func (c *tpdSnapshotCache) fresh() *tpdSnapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.snap != nil && c.clock().Before(c.snap.expires) {
+		return c.snap
+	}
+	return nil
+}
+
+// snapshot returns a fresh transport-discovery snapshot, fetching a
+// new one via fetchAll only when the cache is empty or expired. On a
+// fetch error the previous snapshot is returned stale (with the error)
+// so callers can choose to proceed on slightly-old data rather than
+// fail the dial; only when there is no prior snapshot at all does it
+// return (nil, err).
+//
+// fetchAll is typically DiscoveryClient.GetAllTransports.
+func (c *tpdSnapshotCache) snapshot(
+	ctx context.Context,
+	fetchAll func(context.Context) ([]*transport.Entry, error),
+) (*tpdSnapshot, error) {
+	if s := c.fresh(); s != nil {
+		return s, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Double-check: another goroutine may have refreshed while we
+	// waited for the write lock.
+	if c.snap != nil && c.clock().Before(c.snap.expires) {
+		return c.snap, nil
+	}
+
+	entries, err := fetchAll(ctx)
+	if err != nil {
+		// Serve the prior snapshot stale rather than dropping to
+		// empty — a transient TPD failure shouldn't break routing.
+		if c.snap != nil {
+			return c.snap, err
+		}
+		return nil, err
+	}
+
+	byID := make(map[uuid.UUID]*transport.Entry, len(entries))
+	for _, e := range entries {
+		if e != nil {
+			byID[e.ID] = e
+		}
+	}
+	c.snap = &tpdSnapshot{
+		entries: entries,
+		byID:    byID,
+		expires: c.clock().Add(c.ttl),
+	}
+	return c.snap, nil
+}

--- a/pkg/router/tpd_cache_test.go
+++ b/pkg/router/tpd_cache_test.go
@@ -1,0 +1,209 @@
+// pkg/router/tpd_cache_test.go — verifies the whole-dataset TTL
+// snapshot cache that keeps buildHopLookups / calculateLocalRoutes
+// from re-pulling (or per-ID hammering) the transport-discovery set.
+
+package router
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// fakeClock is a controllable time source for deterministic TTL tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1_700_000_000, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newTestCache(clk *fakeClock) *tpdSnapshotCache {
+	c := newTPDSnapshotCache()
+	c.clock = clk.now
+	return c
+}
+
+func entry(id uuid.UUID, latency float64) *transport.Entry {
+	return &transport.Entry{ID: id, Latency: latency}
+}
+
+// TestTPDSnapshotCache_ReusesWithinTTL: repeated snapshot() calls
+// within the TTL trigger exactly ONE fetch — the canonical fix for the
+// per-ID 429 storm.
+func TestTPDSnapshotCache_ReusesWithinTTL(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	id := uuid.New()
+	var calls int
+	fetch := func(context.Context) ([]*transport.Entry, error) {
+		calls++
+		return []*transport.Entry{entry(id, 12)}, nil
+	}
+
+	for i := 0; i < 20; i++ {
+		snap, err := c.snapshot(context.Background(), fetch)
+		require.NoError(t, err)
+		require.NotNil(t, snap)
+		assert.Equal(t, 12.0, snap.byID[id].Latency)
+	}
+	assert.Equal(t, 1, calls, "20 lookups within TTL must collapse to a single fetch")
+}
+
+// TestTPDSnapshotCache_RefreshAfterTTL: once the TTL elapses the next
+// call re-fetches.
+func TestTPDSnapshotCache_RefreshAfterTTL(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	var calls int
+	fetch := func(context.Context) ([]*transport.Entry, error) {
+		calls++
+		return []*transport.Entry{entry(uuid.New(), 1)}, nil
+	}
+
+	_, err := c.snapshot(context.Background(), fetch)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+
+	// Still fresh just before expiry.
+	clk.advance(defaultTPDSnapshotTTL - time.Second)
+	_, err = c.snapshot(context.Background(), fetch)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+
+	// Expired → refetch.
+	clk.advance(2 * time.Second)
+	_, err = c.snapshot(context.Background(), fetch)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+// TestTPDSnapshotCache_StaleOnRefreshError: a refresh failure after a
+// prior success serves the stale snapshot (plus the error) rather than
+// dropping to nil — a transient TPD blip must not break routing.
+func TestTPDSnapshotCache_StaleOnRefreshError(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	id := uuid.New()
+	good := func(context.Context) ([]*transport.Entry, error) {
+		return []*transport.Entry{entry(id, 7)}, nil
+	}
+	_, err := c.snapshot(context.Background(), good)
+	require.NoError(t, err)
+
+	clk.advance(defaultTPDSnapshotTTL + time.Second)
+	boom := errors.New("429 Too Many Requests")
+	snap, err := c.snapshot(context.Background(), func(context.Context) ([]*transport.Entry, error) {
+		return nil, boom
+	})
+	require.ErrorIs(t, err, boom)
+	require.NotNil(t, snap, "stale snapshot must be served on refresh error")
+	assert.Equal(t, 7.0, snap.byID[id].Latency)
+}
+
+// TestTPDSnapshotCache_ColdFailureReturnsNil: with no prior snapshot a
+// fetch error yields (nil, err) so the caller fails the route calc.
+func TestTPDSnapshotCache_ColdFailureReturnsNil(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	boom := errors.New("cold")
+	snap, err := c.snapshot(context.Background(), func(context.Context) ([]*transport.Entry, error) {
+		return nil, boom
+	})
+	require.ErrorIs(t, err, boom)
+	assert.Nil(t, snap)
+}
+
+// TestTPDSnapshotCache_ByIDSkipsNil: nil entries in the fetched slice
+// are dropped from the byID index.
+func TestTPDSnapshotCache_ByIDSkipsNil(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	id := uuid.New()
+	snap, err := c.snapshot(context.Background(), func(context.Context) ([]*transport.Entry, error) {
+		return []*transport.Entry{nil, entry(id, 3), nil}, nil
+	})
+	require.NoError(t, err)
+	assert.Len(t, snap.byID, 1)
+	assert.Equal(t, 3.0, snap.byID[id].Latency)
+	assert.Len(t, snap.entries, 3) // slice keeps originals; only index filters
+}
+
+// TestTPDSnapshotCache_ConcurrentReads: concurrent snapshot() calls are
+// race-free and still collapse to a single fetch when fresh.
+func TestTPDSnapshotCache_ConcurrentReads(t *testing.T) {
+	clk := newFakeClock()
+	c := newTestCache(clk)
+
+	id := uuid.New()
+	var mu sync.Mutex
+	var calls int
+	// signature is fixed by tpdSnapshotCache.snapshot's fetchAll param.
+	fetch := func(context.Context) ([]*transport.Entry, error) { //nolint:unparam
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return []*transport.Entry{entry(id, 5)}, nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			snap, err := c.snapshot(context.Background(), fetch)
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
+		}()
+	}
+	wg.Wait()
+	// The double-checked lock means at most a small number of racing
+	// cold fetches; once one wins, the rest hit the cache. Assert it's
+	// not "one per goroutine".
+	mu.Lock()
+	defer mu.Unlock()
+	assert.LessOrEqual(t, calls, 3, "concurrent cold fetches should be deduped to ~1")
+}
+
+// TestFindRouteNum covers the mux-degree → requested-route-count helper.
+func TestFindRouteNum(t *testing.T) {
+	cases := []struct {
+		mux  int
+		want uint16
+	}{
+		{0, 0},  // mux off → 0 → finder default
+		{-1, 0}, // defensive
+		{1, 3},  // 1+2 headroom = 3 (== base floor)
+		{2, 4},
+		{4, 6},
+		{8, 10},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, findRouteNum(c.mux), "findRouteNum(%d)", c.mux)
+	}
+}


### PR DESCRIPTION
## Problem

Multi-hop **mux** skynet route groups fail to assemble (`iperf3` RST / 0 bytes, `cli rg ls` shows only `port:46` latency probes, no app route group) for all `--routes N --min-hops K --forward-mux/--reverse-mux` combos. Positive controls are clean: route-finder returns multi-hop candidates, visor-ping works, 400+ transports active. Diagnosed by Gamma + Beta during a bandwidth-pump test.

Two root causes:

### 1. `buildHopLookups` hammered TPD per-hop → 429 rate-limit
`router.buildHopLookups` re-derived per-hop latency/type with **one `GetTransportByID` HTTP call per hop ID**. A multiplexed multi-hop dial touches 12+ unique TpIDs × retries, which blows through TPD's `30 req/min` limit:
```
[router]: buildHopLookups: GetTransportByID failed ... error="429 Too Many Requests: Rate limit exceeded"
```
Every lookup 429s → `buildHopLookups` degrades to empty latency/type → `rejectDMSGMultihop` / latency-rank can't filter or rank → **the route group never assembles**.

Route calculation is a *local* operation that already needs the transport set in hand — `calculateLocalRoutes` already pulls it in **one** `GetAllTransports()`. So the per-ID re-fetch was redundant.

**Fix:** a single whole-dataset `GetAllTransports` snapshot, cached with a 5-minute TTL and **shared** by `buildHopLookups` and `calculateLocalRoutes` (`pkg/router/tpd_cache.go`). One fetch per TTL instead of one per hop per dial. Transient TPD failures serve the prior snapshot **stale** rather than breaking routing.

### 2. Route-finder hard-capped routes at 3 → mux silently degraded
The `/routes` handler hard-coded `maxNumberOfRoutes = 3`, so a dial requesting `--forward-mux 8` could **never** get more than 3 legs regardless of the requested degree.

**Fix:** add `RouteOptions.NumRoutes` (wire-compatible; `0` = service default), honored by the handler up to a ceiling. The router now requests the effective mux degree (+ small disjoint-pick headroom) per direction. The store already supports a bounded count — this only plumbs it through.

## Relationship to #2954
Supersedes #2954 (same root-cause diagnosis by Gamma — credit to them — fixed at the dataset layer instead of a per-ID cache, and additionally lifts the route-count cap so mux degrees above 3 work).

## Follow-up
Longer term the snapshot source should be the **on-demand CXO subscriber to TPD** (the transport manager already mirrors register/deregister into a CXO publisher tree) rather than an HTTP `GetAllTransports` round-trip — at which point `tpd_cache.go` becomes a thin adapter over the CXO-backed store.

## Tests
- Snapshot cache: reuse-within-TTL, refresh-after-TTL, stale-on-error, cold-failure, nil-skip, concurrent (`-race`).
- `findRouteNum` mux-degree mapping.
- `NumRoutes` JSON wire round-trip (rfclient ↔ route-finder API).
- Full `pkg/router` suite green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)