### PR TITLE
fix(dmsg/dmsgfirst): don't HTTP-fall-back (or warn) on context.Canceled

### DIFF
--- a/pkg/dmsg/disc/dmsgfirst/client.go
+++ b/pkg/dmsg/disc/dmsgfirst/client.go
@@ -131,6 +131,18 @@ func shouldFallback(err error) bool {
 	if err == nil {
 		return false
 	}
+	// A canceled context is the CALLER giving up — the outer dial was
+	// aborted, a competing transport won, or the peer went away mid-
+	// lookup. It is NOT a dmsg-transport failure of the primary path:
+	// the HTTP fallback would inherit the same dead context and fail
+	// too, so retrying is pointless and the WARN is misleading (it
+	// reads as "dmsg-disc unreachable" when dmsg was fine). Treat it as
+	// authoritative so only genuine transport failures surface. Note:
+	// context.DeadlineExceeded is deliberately NOT included — a real
+	// primary-side timeout should still try HTTP (handled below).
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
 	// Authoritative discovery sentinels — primary's response is the
 	// truth; do not retry on fallback.
 	switch {


### PR DESCRIPTION
## Problem

Observed in visor debug logs — `dmsg_tracker_manager` hitting the dmsg-discovery over **plain HTTP**:

```
dtm.establishTracker: Skipped dmsgtracker client (peer not in discovery or lookup canceled).
  error="dmsg error 100 - entry is not found in discovery:
         Get \"http://dmsgd.skywire.skycoin.com/dmsg-discovery/entry/<peerPK>\": context canceled"
```

The dmsg-discovery and services are supposed to be reached **over dmsg** (via the direct-client-backed `dmsgfirst` path), with plain HTTP only as a fallback when dmsg is genuinely unreachable — and that fallback should be loud (WARN, per #2953).

## Root cause

Confirmed `ce.dc` *is* the dmsgfirst client at runtime (dmsgDC bootstraps, `upgraded to dmsgfirst` fires). So the HTTP hit is the **dmsgfirst fallback firing spuriously**:

- `dmsg_tracker_manager` gives each `establishTracker` lookup a short deadline (`updateTimeout`).
- When that deadline fires mid-dmsg-lookup, the dmsg-primary request returns `context.Canceled` wrapped in a `*url.Error`.
- `shouldFallback` classified **every** `*url.Error` as a transport failure → logged "DMSG primary failed; trying HTTP fallback" at WARN **and** retried over plain HTTP against `dmsgd` — which inherits the same already-dead context and also fails.

A canceled context is the **caller giving up**, not "an issue accessing the discovery over dmsg." So it must not trigger an HTTP round-trip (or a misleading WARN) at all. This affects every dmsgfirst consumer that uses deadlines — the dmsgtracker most visibly, but also TPS / route-setup / router entry lookups.

## Fix

`shouldFallback` now treats `context.Canceled` as authoritative (no fallback, no warn) — placed **before** the `url.Error` check that was catching it. `context.DeadlineExceeded` is deliberately left to fall back, since a genuine primary-side timeout should still try HTTP.

Result: a canceled dtm lookup returns the canceled error directly, with **no `dmsgd` HTTP hit** and no misleading WARN. Real dmsg-transport failures still fall back and still log at WARN (#2953 behavior preserved).

## Tests
`pkg/dmsg/disc/dmsgfirst` suite green; `golangci-lint` clean; binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)