### PR TITLE
feat(autoconfig): add --maxtransports (public-visor limit); drop deprecated --dmsghttp/--dmsgconf

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -392,7 +392,7 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "timeout")
 	genConfigCmd.Flags().StringVar(&publicVisorRegTimeout, "regtimeout", scriptExecString("${REGTIMEOUT}"), "public visor registration timeout (e.g. 10m)")
 	gHiddenFlags = append(gHiddenFlags, "regtimeout")
-	genConfigCmd.Flags().IntVar(&publicVisorMaxTransports, "maxtransports", 0, "public visor max transports")
+	genConfigCmd.Flags().IntVar(&publicVisorMaxTransports, "maxtransports", scriptExecInt("${MAXTRANSPORTS:-0}"), "public visor max transports")
 	gHiddenFlags = append(gHiddenFlags, "maxtransports")
 	genConfigCmd.Flags().IntVar(&muxRoutes, "muxroutes", 0, "number of parallel mux routes per connection")
 	gHiddenFlags = append(gHiddenFlags, "muxroutes")

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -141,11 +141,10 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 
 	// Service discovery / deployment
 	addSoloBool("TESTENV", "testenv", autoconfigVals.TestEnv)
-	addSoloBool("DMSGHTTP", "dmsghttp", autoconfigVals.DmsgHTTP)
-	addString("DMSGCONF", "dmsgconf", autoconfigVals.DmsgConf)
 	addArray("SVCCONFADDR", "url", autoconfigVals.URL)
 	addString("SVCCONF", "svcconf", autoconfigVals.SvcConf)
 	addInt("MINDMSGSESS", "minsess", autoconfigVals.MinSess)
+	addInt("MAXTRANSPORTS", "maxtransports", autoconfigVals.MaxTransports)
 	addArray("STUNSERVERS", "stun", autoconfigVals.StunServers)
 
 	// Transport ports

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -117,12 +117,13 @@ type Values struct {
 
 	// --- Service discovery / deployment ---
 	TestEnv     bool   // TESTENV
-	DmsgHTTP    bool   // DMSGHTTP
-	DmsgConf    string // DMSGCONF
 	URL         string // SVCCONFADDR (services conf URL — accepts comma-list)
 	SvcConf     string // SVCCONF (fallback service-configuration file)
 	MinSess     int    // MINDMSGSESS
 	StunServers string // STUNSERVERS (comma-separated)
+
+	// --- Public-visor transport limit ---
+	MaxTransports int // MAXTRANSPORTS (deregister from AR once this many transports exist)
 
 	// --- Transport ports ---
 	StcprPort     int
@@ -242,11 +243,10 @@ func New(v *Values) *cobra.Command {
 
 	// --- Service discovery / deployment ---
 	cmd.Flags().BoolVar(&v.TestEnv, "testenv", false, "use test deployment (ports offset +10000 from prod) — writes TESTENV=true in skywire.conf")
-	cmd.Flags().BoolVar(&v.DmsgHTTP, "dmsghttp", false, "use only dmsg for skywire services (no http) — writes DMSGHTTP=true in skywire.conf")
-	cmd.Flags().StringVar(&v.DmsgConf, "dmsgconf", "", "dmsghttp config path — writes DMSGCONF in skywire.conf")
 	cmd.Flags().StringVar(&v.URL, "url", "", "services-config URL(s), comma-separated — writes SVCCONFADDR in skywire.conf")
 	cmd.Flags().StringVar(&v.SvcConf, "svcconf", "", "fallback service-configuration file path — writes SVCCONF in skywire.conf")
 	cmd.Flags().IntVar(&v.MinSess, "minsess", 0, "number of dmsg servers to connect to (0 = unlimited; leave unset to keep default 2) — writes MINDMSGSESS in skywire.conf")
+	cmd.Flags().IntVar(&v.MaxTransports, "maxtransports", 0, "public visor transport limit — deregister from the address resolver once this many transports exist (0 = leave unset; default 1000) — writes MAXTRANSPORTS in skywire.conf")
 	cmd.Flags().StringVar(&v.StunServers, "stun", "", "STUN servers, comma-separated — writes STUNSERVERS in skywire.conf")
 
 	// --- Transport ports ---
@@ -365,13 +365,12 @@ var envMap = map[string]EnvMapping{
 	"disable-public-autoconn": {Key: "DISABLEPUBLICAUTOCONN", Format: EnvFormatBool},
 
 	// Service discovery / deployment
-	"testenv":  {Key: "TESTENV", Format: EnvFormatBool},
-	"dmsghttp": {Key: "DMSGHTTP", Format: EnvFormatBool},
-	"dmsgconf": {Key: "DMSGCONF", Format: EnvFormatString},
-	"url":      {Key: "SVCCONFADDR", Format: EnvFormatBashArray},
-	"svcconf":  {Key: "SVCCONF", Format: EnvFormatString},
-	"minsess":  {Key: "MINDMSGSESS", Format: EnvFormatInt, Default: "2"},
-	"stun":     {Key: "STUNSERVERS", Format: EnvFormatBashArray},
+	"testenv":       {Key: "TESTENV", Format: EnvFormatBool},
+	"url":           {Key: "SVCCONFADDR", Format: EnvFormatBashArray},
+	"svcconf":       {Key: "SVCCONF", Format: EnvFormatString},
+	"minsess":       {Key: "MINDMSGSESS", Format: EnvFormatInt, Default: "2"},
+	"maxtransports": {Key: "MAXTRANSPORTS", Format: EnvFormatInt, Default: "1000"},
+	"stun":          {Key: "STUNSERVERS", Format: EnvFormatBashArray},
 
 	// Transport ports. 0 = OS-assigned random port at runtime;
 	// stays unchanged across visor restarts only when pinned to a

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -16,7 +16,7 @@ var allFlags = []string{
 	// Visor public/private + autoconnect
 	"rewardaddr", "public", "no-public", "publicip", "disable-public-autoconn",
 	// Service discovery / deployment
-	"testenv", "dmsghttp", "dmsgconf", "url", "svcconf", "minsess", "stun",
+	"testenv", "url", "svcconf", "minsess", "maxtransports", "stun",
 	// Transport ports
 	"stcpr", "sudph", "lan-dmsg-port", "lan-dmsg-public",
 	// Whitelists


### PR DESCRIPTION
## What

`skywire autoconfig` flag-set changes (this set is also what the apt-repo install-command generator at deb.theskywirenetwork.net/generator/ surfaces via WASM):

### Add `--maxtransports` — public-visor transport limit
The public-visor transport limit (`max_transports` — deregister from the address resolver once this many transports exist, default 1000) had **no autoconfig flag**. The `cli config gen --maxtransports` flag existed but defaulted to `0` and never read its env var, so there was no way to configure it through autoconfig / the install page.

- `autoconfigcmd`: new `--maxtransports` flag + `MAXTRANSPORTS` EnvMap entry (default 1000).
- `autoconfig.go`: `addInt("MAXTRANSPORTS", "maxtransports", …)` writes it to skywire.conf.
- `gen.go`: `--maxtransports` now defaults to `scriptExecInt("${MAXTRANSPORTS:-0}")` so the value written by autoconfig is read back and applied to `max_transports`. Mirrors the `minsess`→`MINDMSGSESS` pattern end-to-end.

### Drop `--dmsghttp`
The dmsghttp-only mode is deprecated — every deployment uses the dmsghttp+http-fallback config by default, and the http write-path is slated for removal. Removed from the autoconfig surface (flag + `Values.DmsgHTTP` + EnvMap + env-write).

### Drop `--dmsgconf`
The separate `dmsghttp-config.json` was folded into the unified `services-config.json` — `gen.go:configureDMSGHTTP` now reads DMSG fields straight from the services struct, and its own comment notes the standalone path is *"retained for backward compatibility and custom deployment overrides"*. It stays available as a hidden `cli config gen --dmsgconf` override for custom deployments, but is dead weight on the autoconfig/install-page surface.

## Verification
- `go test ./pkg/skywireconfig/autoconfigcmd/...` green (allFlags parity test updated); `golangci-lint` clean; full binary builds.
- `skywire cli config gen -n --maxtransports 50 --public` → `"max_transports": 50`; default public visor stays `1000`.
- `skywire autoconfig --help` no longer lists `--dmsghttp` / `--dmsgconf`; lists `--maxtransports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)