### PR TITLE
fix(dmsg): raise entry-cache TTL above the tracker interval to stop disc-dial thrash

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -23,7 +23,23 @@ type entryCacheEntry struct {
 	fetchedAt time.Time
 }
 
-const entryCacheTTL = 30 * time.Second
+// entryCacheTTL bounds how long a resolved discovery entry is reused
+// before a fresh lookup. It MUST stay comfortably larger than the
+// callers that re-resolve the same peers on a fixed cadence — most
+// notably the dmsg-tracker (skyenv.DmsgTrackerUpdateInterval, 30s),
+// which re-establishes trackers for the same handful of peers every
+// cycle. When this TTL equalled that interval, every tracker cycle
+// landed just after expiry → cache miss → a burst of concurrent
+// dmsg-discovery dials for the same ~10 peers → contention →
+// canceled/timed-out dials → "cannot connect to delegated server"
+// (202) → HTTP fallback. Sizing the TTL to span many tracker cycles
+// collapses those repeat lookups into one disc hit per peer per TTL,
+// which is what lets the DMSG-primary path stay on dmsg instead of
+// falling back to HTTP. Peer entries are stable (they change only on
+// a dmsg-server reconnect), and a stale entry self-heals: DialStream's
+// mesh phase reaches the peer via any shared server regardless of the
+// cached delegated-server list.
+const entryCacheTTL = 5 * time.Minute
 
 // SessionDialCallback is triggered BEFORE a session is dialed to.
 // If a non-nil error is returned, the session dial is instantly terminated.


### PR DESCRIPTION
## Problem
A live visor was logging a steady stream of `disc Entry: DMSG primary failed; trying HTTP fallback` (~40-54/min, **433** over one window) — the dmsg-first discovery client falling back to plain HTTP because its DMSG dial to the discovery returned `dmsg error 202 - cannot connect to delegated server`.

## Root cause
`entryCacheTTL` (the dmsg client's discovery-entry cache) was **`30s` — exactly equal** to `skyenv.DmsgTrackerUpdateInterval` (30s). The hypervisor's dmsg-tracker (`getDmsgSummary` → `dmsgTracker.manager.GetBulk`) re-resolves the same set of hypervisor-tracked remote visors every 30s. With TTL == interval, each cycle's lookup landed just after the entry expired → cache miss → a **burst of concurrent discovery dials for the same ~10 PKs** → contention → dials canceled / hitting i/o deadline before completing → 202 → HTTP fallback. The route cache couldn't stay warm under the repeating burst.

Diagnosed from the live log: **433 fallbacks driven by only 10 distinct peer PKs** (one resolved 97×) — all visors the hypervisor tracks, none of them services.

## Fix
Raise `entryCacheTTL` to **5m** (≈10 tracker cycles) so the repeated lookups collapse into one discovery resolution per peer per TTL.

Peer entries are stable — a visor's delegated-server list changes only on a dmsg-server reconnect — and a stale entry self-heals: `DialStream`'s mesh phase reaches the peer via any shared server regardless of the cached delegated-server list. So the longer TTL trades nothing meaningful for a large reduction in discovery load.

## Verification (live visor)
- **Before:** ~40-54 HTTP fallbacks/min; 433 in one window.
- **After:** **0** HTTP fallbacks over a 5-minute run, with the dmsg-tracker still establishing its trackers normally.

This keeps the DMSG-primary discovery path on dmsg instead of HTTP — a prerequisite for eventually retiring the HTTP fallback (and the http write path) entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)