### PR TITLE
fix(hypervisor): scope dmsg round-trip tracker to currently-connected visors

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -442,6 +442,15 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 // the cache is always-fresh from the UI's perspective.
 const hypervisorBackgroundPollInterval = 30 * time.Second
 
+// cacheFreshWindow is how recently a remote visor must have answered a
+// Summary RPC (tracked via summaryCache.seenAt) to count as currently
+// connected. Sized to span the 2-minute dmsg.StreamIdleTimeout plus
+// the peer's redial → hypervisor-accept → next-poll cycle, so a peer
+// whose stream just idle-closed isn't flagged disconnected mid-cycle.
+// Used both by the UI summary handler and by getDmsgSummary to scope
+// the dmsg round-trip tracker to live connections only.
+const cacheFreshWindow = 3 * time.Minute
+
 // runBackgroundSummaryPoll keeps hv.summaryCache fresh independent of
 // UI activity. Spawned once from ServeRPC; runs until ctx cancels.
 // Iterates every entry in remoteVisors, fires Summary() in parallel

--- a/pkg/visor/hypervisor_handlers_dmsg.go
+++ b/pkg/visor/hypervisor_handlers_dmsg.go
@@ -154,15 +154,36 @@ func (hv *Hypervisor) putVisorDmsgSessionsCount() http.HandlerFunc {
 }
 
 func (hv *Hypervisor) getDmsgSummary() []dmsgtracker.DmsgClientSummary {
-	hv.mu.RLock()
 	pks := make([]cipher.PubKey, 0, len(hv.remoteVisors)+1)
 	if hv.visor != nil {
-		pks = append(pks, hv.visor.conf.PK)
+		pks = append(pks, hv.visor.conf.PK) // always track self
 	}
+
+	// Track dmsg round-trip ONLY for visors that are currently
+	// connected — i.e. answered a Summary RPC within cacheFreshWindow.
+	// remoteVisors accumulates every visor that ever connected (it's
+	// pruned on a broken-conn Summary in the UI handler, but only while
+	// the UI is polling), so tracking it directly made the dmsg-tracker
+	// re-resolve + ping long-disconnected peers every cycle — hammering
+	// the dmsg-discovery (the source of the 202 → HTTP-fallback churn)
+	// and emitting "Failed to re-create dmsgtracker" warns for dead
+	// peers. A disconnected visor stops refreshing its summaryCache
+	// entry and ages out here, so the tracker follows live connections.
+	hv.mu.RLock()
+	remotes := make([]cipher.PubKey, 0, len(hv.remoteVisors))
 	for pk := range hv.remoteVisors {
-		pks = append(pks, pk)
+		remotes = append(remotes, pk)
 	}
 	hv.mu.RUnlock()
+
+	now := time.Now()
+	hv.summaryCacheMx.RLock()
+	for _, pk := range remotes {
+		if c, ok := hv.summaryCache[pk]; ok && now.Sub(c.seenAt) < cacheFreshWindow {
+			pks = append(pks, pk)
+		}
+	}
+	hv.summaryCacheMx.RUnlock()
 
 	if hv.visor.isDTMReady() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/pkg/visor/hypervisor_handlers_visors.go
+++ b/pkg/visor/hypervisor_handlers_visors.go
@@ -599,7 +599,7 @@ func (hv *Hypervisor) getAllVisorsSummary() http.HandlerFunc {
 		// flicker that operators flag as "nodes are stale". 30s
 		// (the original value) caught only inline RPC slowness
 		// and missed the steady-state 2-min idle pattern entirely.
-		const cacheFreshWindow = 3 * time.Minute
+		// (cacheFreshWindow is now a package const — see hypervisor.go.)
 
 		for _, entry := range remotes {
 			go func(pk cipher.PubKey, c Conn) {


### PR DESCRIPTION
## Problem
`getDmsgSummary` (which feeds the hypervisor's dmsg round-trip tracker via `dmsgTracker.manager.GetBulk`) built its PK list from the **entire `hv.remoteVisors` map**. That map accumulates **every visor that ever connected** — it's only pruned on a broken-conn `Summary` inside the *UI-driven* `getAllVisorsSummary` handler (the always-on background poll explicitly does not evict). So a hypervisor with no open UI never prunes disconnected visors, and the dmsg-tracker kept **re-resolving + ping-dialing long-dead peers every cycle**:
- needless dmsg-discovery load — a contributor to the `dmsg error 202 - cannot connect to delegated server` → HTTP-fallback churn;
- a stream of `Failed to re-create dmsgtracker client` warns for peers that disconnected long ago.

(Observed live: the tracker's per-peer pings were 202-ing for a visor that was no longer reachable over dmsg.)

## Fix
Scope the tracker to **currently-connected** visors: include a remote visor only if it answered a `Summary` RPC within `cacheFreshWindow` (the same liveness signal the UI summary handler already uses via `summaryCache.seenAt`). A disconnected visor stops refreshing its cache entry and ages out within the window, so the tracker follows live connections rather than the ever-connected set. The hypervisor's own PK is always tracked.

`cacheFreshWindow` is promoted from a local const in the summary handler to a package const so both call sites share one definition.

## Notes
Companion to the entry-cache TTL fix (separate PR) — together they keep the dmsg-first discovery path on dmsg (no HTTP fallback) by both (a) not re-resolving the same peers faster than the cache TTL and (b) not tracking peers that are gone.

## Verification
`go build ./...`, `go vet`, `go test ./pkg/visor/`, `golangci-lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)