### PR TITLE
fix(cli/route): dispatch `route policy test`/`bench` to the WASM backend for .wasm scripts

### DIFF
--- a/cmd/skywire-cli/commands/route/policy.go
+++ b/cmd/skywire-cli/commands/route/policy.go
@@ -11,13 +11,45 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/router/policy"
+	policywasm "github.com/skycoin/skywire/pkg/router/policy/wasm"
 )
+
+// policyTestEngine is the minimal surface `route policy test` / `bench`
+// need from either policy backend.
+type policyTestEngine interface {
+	Decide(ctx context.Context, rctx policy.RoutingContext, candidates []policy.Candidate) (policy.RouteSpec, error)
+}
+
+// loadPolicyEngine dispatches by file extension — ".wasm" loads the
+// WASM backend (pkg/router/policy/wasm), anything else loads Starlark —
+// mirroring the visor's SetAppRoutingPolicy dispatch so `route policy
+// test` previews the SAME backend the visor would actually run. Before
+// this, both subcommands fed the file to the Starlark evaluator
+// unconditionally, so testing a .wasm policy failed with "missing
+// decide_route function" (the wasm bytes don't parse as Starlark).
+func loadPolicyEngine(path string, src []byte, clock fixedClock) (policyTestEngine, error) {
+	logger := func(format string, args ...interface{}) {
+		fmt.Fprintf(os.Stderr, "[policy log] "+format+"\n", args...)
+	}
+	if strings.EqualFold(filepath.Ext(path), ".wasm") {
+		return policywasm.NewEvaluator(path, src,
+			policywasm.WithClock(clock),
+			policywasm.WithLogger(logger),
+		)
+	}
+	return policy.NewEvaluator(path, string(src),
+		policy.WithClock(clock),
+		policy.WithFailureMode(policy.FailureDrop),
+		policy.WithLogger(logger),
+	)
+}
 
 var (
 	policyScriptPath string
@@ -94,13 +126,7 @@ values.`,
 		// unset) so the test result is deterministic regardless
 		// of when the operator runs the command.
 		clock := fixedClock{t: rctx.Now}
-		eval, err := policy.NewEvaluator(policyScriptPath, string(src),
-			policy.WithClock(clock),
-			policy.WithFailureMode(policy.FailureDrop),
-			policy.WithLogger(func(format string, args ...interface{}) {
-				fmt.Fprintf(os.Stderr, "[policy log] "+format+"\n", args...)
-			}),
-		)
+		eval, err := loadPolicyEngine(policyScriptPath, src, clock)
 		if err != nil {
 			return fmt.Errorf("load policy: %w", err)
 		}
@@ -132,7 +158,7 @@ deploying a complex policy to confirm it stays inside the
 		if err != nil {
 			return fmt.Errorf("read script: %w", err)
 		}
-		eval, err := policy.NewEvaluator(policyScriptPath, string(src))
+		eval, err := loadPolicyEngine(policyScriptPath, src, fixedClock{t: time.Now()})
 		if err != nil {
 			return fmt.Errorf("load policy: %w", err)
 		}
@@ -262,6 +288,3 @@ func percentile(samples []time.Duration, p int) time.Duration {
 	}
 	return samples[idx]
 }
-
-// Silence "unused import" if strings isn't reached above (template).
-var _ = strings.TrimSpace


### PR DESCRIPTION
## Problem
`skywire cli route policy test --script X.wasm` (and `bench`) failed with **`missing decide_route function`** for *every* WASM policy — including the shipped examples (`docs/examples/routing-policies/wasm/{app-mux,rotating-bw}`). The error is misleading: it comes from the **Starlark** evaluator (`pkg/router/policy/evaluator.go`), because both subcommands loaded the script through `policy.NewEvaluator` (Starlark) **unconditionally** — the wasm bytes don't parse as Starlark, so it reports a missing `decide_route`. The WASM modules are fine (they export `decide_route`/`alloc`); the CLI just never dispatched by file extension the way the visor's `SetAppRoutingPolicy` already does.

## Fix
Add `loadPolicyEngine`, which dispatches on the script extension — `.wasm` → `pkg/router/policy/wasm.NewEvaluator`, anything else → Starlark `policy.NewEvaluator` — and use it from both `test` and `bench`. Both backends satisfy the same `Decide(ctx, rctx, candidates)` surface, and the CLI's `fixedClock` satisfies both packages' (structurally identical) `Clock` interface, so the deterministic-clock behavior carries over to the WASM path.

## Verification
With the fix, against the shipped examples:
- `route policy test --script app-mux.wasm --dial {app:vpn-client,…}` → `{"mux":4,"min_hops":2}`
- `route policy test --script rotating-bw.wasm …` → `{"mux":4,"min_hops":2,"distribution":"weighted: 1, 1, 1, 1"}`

Previously both errored. `go build`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)