### PR TITLE
fix(router): gate aux mux legs on readiness — fixes mux>=2 stall (0 bytes / close code 0)

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1280,6 +1280,23 @@ func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 		})
 		return rg.handleDataPacket(packet)
 	case routing.HandshakePacket:
+		// A handshake on an aux leg proves the peer registered that leg's
+		// rule, so it is safe to start sending on it. The primary leg's
+		// handshake (which creates the mux below) needs no marking — leg 0
+		// is ready from growLegs. This matters most for download-heavy
+		// flows: the bulk-sending side would otherwise never receive data
+		// on its aux legs and so never learn it may spread onto them.
+		if rg.mux != nil {
+			rg.mu.Lock()
+			rid := packet.RouteID()
+			for i, rule := range rg.rvs {
+				if rule != nil && rule.KeyRouteID() == rid {
+					rg.mux.markLegReady(i)
+					break
+				}
+			}
+			rg.mu.Unlock()
+		}
 		rg.handshakeProcessedOnce.Do(func() {
 			// first packet is handshake packet, so we're communicating with the new visor
 			rg.encrypt = true
@@ -1362,6 +1379,9 @@ func (rg *RouteGroup) handleDataPacket(packet routing.Packet) (err error) {
 		for i, rule := range rg.rvs {
 			if rule != nil && rule.KeyRouteID() == rid {
 				rg.mux.recordRecv(i, uint64(packet.Size()))
+				// Inbound traffic on leg i proves the peer registered its
+				// rule for this leg, so it is now safe to send on it.
+				rg.mux.markLegReady(i)
 				break
 			}
 		}

--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -102,6 +102,13 @@ func createMuxRouteGroup(t *testing.T, nTransports int) (*RouteGroup, []*transpo
 	rg.fwd = fwds
 	rg.rvs = rvss
 	rg.mux.rebuildWeights(mts)
+	// These helpers model already-established legs, so mark every leg
+	// ready for selection. In live operation an aux leg becomes ready
+	// only after inbound traffic proves the peer registered its rule.
+	rg.mux.growLegs(len(mts))
+	for i := range mts {
+		rg.mux.markLegReady(i)
+	}
 	rg.mu.Unlock()
 
 	return rg, mts, conns
@@ -175,6 +182,43 @@ func TestPrunePreservesLastTransport(t *testing.T) {
 	rg.mu.Unlock()
 
 	require.Equal(t, 1, remaining, "should not prune the last transport")
+}
+
+// TestMuxSelectTransportSkipsNotReadyLeg verifies that an aux leg that has
+// not yet been confirmed ready is never selected for sending, so the first
+// writes can't be steered onto a route the peer hasn't registered (the
+// mux>=2 "0 bytes / close code 0" bug). The primary leg (0) is always ready.
+func TestMuxSelectTransportSkipsNotReadyLeg(t *testing.T) {
+	rg, mts, _ := createMuxRouteGroup(t, 2)
+
+	// Reset readiness: primary ready, aux (leg 1) not ready.
+	rg.mux.legMu.Lock()
+	rg.mux.ready = []bool{true, false}
+	rg.mux.legMu.Unlock()
+
+	// Every selection must return the primary while leg 1 is not ready.
+	for i := 0; i < 20; i++ {
+		rg.mu.Lock()
+		tp, _, idx, err := rg.mux.selectTransport(rg.tps, rg.fwd, nil)
+		rg.mu.Unlock()
+		require.NoError(t, err)
+		require.Equal(t, 0, idx, "must not select the not-ready aux leg")
+		require.Equal(t, mts[0], tp)
+	}
+
+	// Once leg 1 is marked ready, it becomes eligible.
+	rg.mux.markLegReady(1)
+	sawLeg1 := false
+	for i := 0; i < 50 && !sawLeg1; i++ {
+		rg.mu.Lock()
+		_, _, idx, err := rg.mux.selectTransport(rg.tps, rg.fwd, nil)
+		rg.mu.Unlock()
+		require.NoError(t, err)
+		if idx == 1 {
+			sawLeg1 = true
+		}
+	}
+	require.True(t, sawLeg1, "leg 1 should be selectable once marked ready")
 }
 
 // TestMuxSelectTransportSkipsDead verifies that the mux transport selector

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -69,6 +69,15 @@ type routeMux struct {
 	// the individual counters.
 	legMu sync.RWMutex
 	legs  []*legCounters
+	// ready[i] reports whether leg i may be SELECTED for sending. The
+	// primary leg (0) is ready from the start; an aux leg only becomes
+	// ready once we have received a packet (data or handshake) on it,
+	// which proves the peer finished registering its rule. Without this,
+	// the selector could steer the first writes onto an aux leg the peer
+	// has not set up yet — those packets are dropped, the reorder buffer
+	// stalls on the missing sequence, and the stream hangs until it is
+	// closed (the mux>=2 "0 bytes / close code 0" bug). Guarded by legMu.
+	ready []bool
 }
 
 // newRouteMux creates a new routeMux instance with all sub-components initialized.
@@ -117,7 +126,7 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 			idx := m.tpSelector.SelectForPayload(payload)
 			if idx < len(tps) {
 				tp := tps[idx]
-				if tp != nil && !tp.IsClosed() {
+				if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
 					return tp, fwd[idx], idx, nil
 				}
 			}
@@ -129,19 +138,22 @@ func (m *routeMux) selectTransport(tps []*transport.ManagedTransport, fwd []rout
 		idx := m.tpSelector.Select()
 		if idx < len(tps) {
 			tp := tps[idx]
-			if tp != nil && !tp.IsClosed() {
+			if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
 				return tp, fwd[idx], idx, nil
 			}
 		}
 	}
 
-	// Fallback: round-robin with skip-dead
+	// Fallback: round-robin with skip-dead and skip-not-ready. An aux leg
+	// the peer has not confirmed yet is skipped so we never send the first
+	// packets onto a route whose rule the peer has not registered; the
+	// primary leg (0) is always ready, so this loop always finds it.
 	n := uint32(len(tps)) //nolint:gosec
 	start := atomic.AddUint32(&m.tpIndex, 1) - 1
 	for i := uint32(0); i < n; i++ {
 		idx := int((start + i) % n) //nolint:gosec
 		tp := tps[idx]
-		if tp != nil && !tp.IsClosed() {
+		if tp != nil && !tp.IsClosed() && m.legReadyAt(idx) {
 			return tp, fwd[idx], idx, nil
 		}
 	}
@@ -157,7 +169,41 @@ func (m *routeMux) growLegs(n int) {
 	for len(m.legs) < n {
 		m.legs = append(m.legs, &legCounters{})
 	}
+	for len(m.ready) < n {
+		// The primary leg (index 0) is ready immediately; aux legs start
+		// not-ready and are marked ready on the first inbound packet.
+		m.ready = append(m.ready, len(m.ready) == 0)
+	}
 	m.legMu.Unlock()
+}
+
+// markLegReady records that leg idx has carried inbound traffic, so it
+// is now safe to select for sending. Idempotent and bounds-checked.
+func (m *routeMux) markLegReady(idx int) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.Lock()
+	if idx < len(m.ready) {
+		m.ready[idx] = true
+	}
+	m.legMu.Unlock()
+}
+
+// legReadyAt reports whether leg idx may be selected for sending.
+// Out-of-range indices and the never-grown case report not-ready, except
+// the primary leg (0) which is always ready so a group with no readiness
+// info still sends on its primary route.
+func (m *routeMux) legReadyAt(idx int) bool {
+	if idx < 0 {
+		return false
+	}
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	if idx >= len(m.ready) {
+		return idx == 0
+	}
+	return m.ready[idx]
 }
 
 // recordSent atomically increments the sent-bytes/packets counters


### PR DESCRIPTION
## Summary

Fixes the **mux ≥ 2 stall** (the route-group "spreading" blocker): a multiplexed dial transfers **0 bytes** and closes with **"close code 0"** after ~4s, while mux=1 works perfectly. This is the bug Gamma's mux=4 harness reproduces (iperf3 cookie never round-trips).

## Root cause

At mux degree ≥ 2, `RouteGroup.nextTransport` → `routeMux.selectTransport` can steer a `Write` onto a freshly-appended **aux leg before the peer has registered that leg's routing rule**. The packet — often the very first one (the iperf3 cookie, seq 0) — is dropped at the peer; its sequence number never arrives, so the receiver's `reorderBuffer` stalls waiting for the gap and the application reads nothing. ~4s later the app gives up and closes the group (`CloseRequested`, code 0).

`mux=1` has only the always-ready primary leg, so it never hits this — matching the observed "mux=1 = 9.4 GB, mux≥2 = 0 bytes".

Key evidence: `pkg/router/route_group.go:768` (`nextTransport` calls `selectTransport` for any `len(tps) > 1`) and `pkg/router/route_mux.go:selectTransport` (no readiness check — aux legs are eligible the instant they're appended + weighted).

## Fix

Track **per-leg readiness** in `routeMux`:

- The primary leg (index 0) is ready immediately.
- An aux leg becomes ready only once we've **received a packet (data or handshake) on it**, proving the peer finished registering its rule.
- `selectTransport` skips not-ready legs in all three selection paths (payload-mode, weighted, round-robin), always falling back to the primary.
- An aux handshake (sent by the appending side) marks the leg ready on the receiver — this bootstraps the download-heavy case, where the bulk-sending side would otherwise never receive on its aux legs and so never learn it may spread onto them.

No protocol/wire change; purely a send-side selection gate plus a recv-side readiness mark.

## Tests

- New `TestMuxSelectTransportSkipsNotReadyLeg`: a not-ready aux leg is never selected; once marked ready it becomes eligible.
- Updated the mux test helper to mark its pre-established legs ready.
- Full `pkg/router` suite green; `go build ./...` and `make lint` (0 issues) pass.

## ⚠️ Needs live verification before merge

I could **not** validate this on a live mux ≥ 2 transfer — this host has no working mux path (and no `CAP_NET_ADMIN` for the VPN TUN). It needs the **mux=4 test harness** (Gamma's) to confirm end-to-end throughput recovers. Holding for that before merge.

Follow-up to consider: have the SACK retransmit path also prefer ready legs (currently the main send path is gated; retx is a smaller surface).
