### PR TITLE
fix(win_installer): run config setup at MSI install (postinstall parity with Linux) [needs Windows test]

### DIFF
--- a/scripts/win_installer/Product.wxs
+++ b/scripts/win_installer/Product.wxs
@@ -26,6 +26,7 @@
                <Component Id="ApplicationFiles" Guid="d6963d6c-acea-49a0-bd9b-610f8a8bce82">
                     <File Id="SKYWIRE" Source=".\build\skywire.exe"/>
                     <File Id="SKYWIREBAT" Source=".\build\skywire.bat"/>
+                    <File Id="SKYWIREAUTOCONFIGBAT" Source=".\build\skywire-autoconfig.bat"/>
                     <File Id="ICON" Source=".\images\ico.ico"/>
                     <File Id="WINTUN" Source=".\build\wintun.dll"/>
                     <File Id="NEWUPDATE" Source=".\build\new.update"/>
@@ -92,8 +93,27 @@
 
 
 
+      <!-- Windows analogue of the Linux package postinstall: generate the
+           env file (%ProgramData%\Skywire\skywire.conf) and the visor config
+           at INSTALL time, so a fresh install is configured without the
+           operator having to launch first. Deferred + non-impersonated so it
+           runs elevated (it writes under %ProgramData% and Program Files),
+           after the files are on disk. Return="ignore" so a config-gen hiccup
+           never rolls back the install — skywire.bat re-runs the same
+           idempotent script at launch as a fallback. Directory="INSTALLDIR"
+           sets the working dir so the bare script name + %~dp0 resolve to the
+           install dir. -->
+      <CustomAction Id="RunSkywireAutoconfig"
+                    Directory="INSTALLDIR"
+                    ExeCommand="cmd.exe /c &quot;skywire-autoconfig.bat&quot;"
+                    Execute="deferred"
+                    Impersonate="no"
+                    Return="ignore"/>
+
       <InstallExecuteSequence>
          <RemoveExistingProducts After="InstallValidate"/>
+         <!-- Run on install/upgrade only, not on uninstall. -->
+         <Custom Action="RunSkywireAutoconfig" After="InstallFiles">NOT REMOVE</Custom>
       </InstallExecuteSequence>
 
       <Feature Id="DefaultFeature" Level="1">

--- a/scripts/win_installer/script.ps1
+++ b/scripts/win_installer/script.ps1
@@ -68,6 +68,7 @@ function BuildInstaller()
     mkdir -p ".\build\apps" > $null
     Move-Item ..\..\archive\skywire.exe .\build\skywire.exe
     Copy-Item skywire.bat .\build\skywire.bat
+    Copy-Item skywire-autoconfig.bat .\build\skywire-autoconfig.bat
     New-Item new.update  > $null
     Move-Item new.update .\build\new.update
     Invoke-WebRequest "https://deb.skywire.dev/wintun-0.14.1.zip" -OutFile wintun.zip

--- a/scripts/win_installer/skywire-autoconfig.bat
+++ b/scripts/win_installer/skywire-autoconfig.bat
@@ -1,0 +1,55 @@
+@Echo Off
+:: skywire-autoconfig.bat — Windows config setup, the rough equivalent of the
+:: Linux package post_install (skywire autoconfig). It is run in TWO places:
+::
+::   1. By the MSI as a deferred CustomAction at INSTALL time (Product.wxs),
+::      so a fresh install has skywire.conf + skywire-config.json immediately,
+::      without the operator having to launch first. This is the Windows
+::      analogue of the deb/arch postinstall.
+::   2. By skywire.bat at LAUNCH, as an idempotent fallback (generate-if-
+::      missing), so manual / direct launches still self-configure.
+::
+:: It is intentionally idempotent: every step is gated on "if not exist", so
+:: re-running it (install + launch, or repeated installs) never clobbers an
+:: existing env file, config, or the operator's edits.
+::
+:: IMPORTANT: at MSI-install time INSTALLDIR is NOT yet on PATH (the PATH
+:: environment component is applied separately), so this script calls the
+:: installed skywire.exe by ABSOLUTE path (%~dp0skywire.exe), never bare
+:: "skywire". %~dp0 is the directory this script lives in = the install dir.
+
+cd /d "%~dp0"
+
+:: Windows-side equivalent of Linux's /etc/skywire.conf. Lives under
+:: %ProgramData% (typically C:\ProgramData\Skywire\) so operator edits survive
+:: MSI upgrades — the MSI installs into Program Files but doesn't touch
+:: ProgramData. `defaultSkyenvPath` in cmd/skywire/commands/autoconfig.go
+:: points at the same path; the SKYENV var here makes cli + autoconfig pick
+:: the file up regardless of CWD (and is inherited by the visor when
+:: skywire.bat calls this script before launching).
+set "SKYENV=%ProgramData%\Skywire\skywire.conf"
+if not exist "%ProgramData%\Skywire\" (
+    mkdir "%ProgramData%\Skywire" >nul 2>&1
+)
+
+:: Generate the env-file template ONLY if missing. -p forces package-mode
+:: defaults (paths under C:\Program Files\Skywire), -q renders the template,
+:: -Q writes it to the file. Mirrors the deb/arch
+:: `[[ ! -f /etc/skywire.conf ]] && skywire cli config gen -pqQ ...` pattern.
+if not exist "%SKYENV%" (
+    "%~dp0skywire.exe" cli config gen -pqQ "%SKYENV%"
+)
+
+:: First install (no skywire-config.json yet) — generate a fresh config. cli
+:: reads %SKYENV% for PKGENV / HYPERVISORPKS / DISABLEPUBLICAUTOCONN / etc.
+if not exist "skywire-config.json" (
+    "%~dp0skywire.exe" cli config gen -irpw --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info
+)
+
+:: Upgrade marker (new.update shipped in the MSI) — regenerate with -r/-x so
+:: the existing secret key and hypervisor PK list are preserved across the
+:: update (mirrors the deb/arch post_install regen). Then consume the marker.
+if exist "new.update" (
+    "%~dp0skywire.exe" cli config gen -irpwx --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info
+    del new.update >nul 2>&1
+)

--- a/scripts/win_installer/skywire.bat
+++ b/scripts/win_installer/skywire.bat
@@ -42,55 +42,13 @@ if exist "%HOMEPATH%\skywire-config.json" (
 	move /Y "%HOMEPATH%\skywire-config.json" . >nul 2>&1
 )
 
-:: Windows-side equivalent of Linux's /etc/skywire.conf. Lives under
-:: %ProgramData% (typically C:\ProgramData\Skywire\) so operator
-:: edits survive MSI upgrades — the MSI installs into Program Files
-:: but doesn't touch ProgramData. `defaultSkyenvPath` in
-:: cmd/skywire/commands/autoconfig.go points at the same path; the
-:: SKYENV env var here makes cli + autoconfig pick the file up
-:: regardless of CWD.
-set "SKYENV=%ProgramData%\Skywire\skywire.conf"
-if not exist "%ProgramData%\Skywire\" (
-    mkdir "%ProgramData%\Skywire" >nul 2>&1
-)
-
-:: Generate the env-file template ONLY if missing. -p forces the
-:: package-mode defaults (paths under C:\Program Files\Skywire), -q
-:: prints the template, -Q writes to the file. Mirrors the deb/arch
-:: `[[ ! -f /etc/skywire.conf ]] && skywire cli config gen -pqQ ...`
-:: pattern from PR #2796 — once the file exists, every subsequent
-:: install / upgrade leaves operator edits intact.
-if not exist "%SKYENV%" (
-    skywire cli config gen -pqQ "%SKYENV%" >nul 2>&1
-)
-
-:: Config generation. The `-b` flag used to map to a removed
-:: BESTPROTO knob; passing it to current binaries makes cobra reject
-:: the entire command line ("unknown shorthand flag: 'b'") and the
-:: gen never ran. With the gen short-circuited, the visor's own
-:: bootstrap fell through to fresh-key generation on every schema
-:: change, which is what operators were reporting as "my SK changed
-:: on update". Dropping `-b` lets gen actually run; `-r` then
-:: preserves the SK from the existing config (mirrors the deb/arch
-:: post_install logic).
-::
-:: First install (no skywire-config.json yet) — generate fresh.
-:: cli reads %SKYENV% via the SKYENV env var; its PKGENV / HYPERVISORPKS
-:: / DISABLEPUBLICAUTOCONN / etc. settings are picked up here.
-if not exist "skywire-config.json" (
-    skywire cli config gen -irpw --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
-)
-
-:: Upgrade marker (new.update shipped in MSI) — regenerate with `-r`.
-:: The regen path reads the existing skywire-config.json, extracts
-:: the SK, then writes a fresh config carrying that same SK. `-x`
-:: also preserves the existing hypervisor PK list. SK preserved
-:: across every MSI update. cli still reads %SKYENV% for any
-:: operator-edited knobs in skywire.conf.
-if exist "new.update" (
-    skywire cli config gen -irpwx --disableapps vpn-server -S services-config.json -D dmsghttp-config.json --loglvl info >nul 2>&1
-    del new.update >nul 2>&1
-)
+:: Config setup — env file (%ProgramData%\Skywire\skywire.conf) + visor
+:: config (skywire-config.json). Shared with the MSI install-time
+:: CustomAction (Product.wxs) so install and launch run identical,
+:: idempotent generate-if-missing logic. The called script also sets
+:: SKYENV, which is inherited by the visor launch below.
+:: See skywire-autoconfig.bat.
+call "%~dp0skywire-autoconfig.bat"
 
 :: Opening UI
 start "" http://127.0.0.1:8000


### PR DESCRIPTION
## ⚠️ Not yet tested on Windows — needs a real MSI build + install/upgrade test before merge.

## Problem

Windows operators report **no `skywire.conf` anywhere** and the config not being set up "on postinstall."

Root cause: there's a **when-it-runs** mismatch with Linux.
- **Linux:** the package postinstall runs autoconfig at **install time** → creates `/etc/skywire.conf` + the visor config.
- **Windows:** the same logic lives only inside `skywire.bat`, which runs at **launch** (via the Start-menu/desktop shortcut). `Product.wxs` had **no install-time action**. So a user who runs `skywire.exe` directly, or never clicks the shortcut, gets **no `%ProgramData%\Skywire\skywire.conf`** and no generated config.

(The `skywire.conf` logic itself is correct and released since v1.3.56 — `config gen -pqQ <file>` does write the template; it just never runs unless the shortcut is used.)

## Fix — install-time parity with Linux

- **`skywire-autoconfig.bat`** (new): the config-setup block (env-file gen + `config gen`, **no** visor launch / UI) factored out of `skywire.bat`. Idempotent (generate-if-missing). Calls the installed `skywire.exe` by **absolute path** (`%~dp0skywire.exe`) — at MSI-install time `INSTALLDIR` is not yet on `PATH`, so a bare `skywire` would fail.
- **`Product.wxs`**: ships the new script and runs it via a **deferred, non-impersonated `CustomAction`** (`RunSkywireAutoconfig`) sequenced `After InstallFiles`, gated `NOT REMOVE` (install/upgrade, not uninstall). Deferred + no-impersonate → runs elevated (writes under `%ProgramData%` + `Program Files`); `Return="ignore"` → a config-gen hiccup never rolls back the install.
- **`skywire.bat`**: the duplicated config block is replaced by a `call` to the shared script (still sets `SKYENV` for the visor launch) — install and launch now share identical logic, and launch remains an idempotent fallback.
- **`script.ps1`**: copies the new script into the build dir for packaging.

## Verification done here (no Windows/WiX env)
- `Product.wxs` is well-formed XML.
- `skywire cli config gen -pqQ <file>` confirmed to write the 276-line env template.

## Verification still needed (Windows)
1. Build the MSI (`script.ps1`), install on a clean Windows box **without launching** → confirm `%ProgramData%\Skywire\skywire.conf` and `C:\Program Files\Skywire\skywire-config.json` both appear.
2. Upgrade install → confirm the SK is preserved (the `new.update`/`-x` regen path).
3. Confirm the deferred `CustomAction`'s `Directory="INSTALLDIR"` working-dir resolution behaves as expected (the one bit I can't validate statically).
