### PR TITLE
feat(cli/gotop): multiload-ng-style display behind --multiload (CPU + RAM breakdown)

### DIFF
--- a/cmd/skywire-cli/commands/gotop/root.go
+++ b/cmd/skywire-cli/commands/gotop/root.go
@@ -51,6 +51,7 @@ var (
 	fahrenheit   bool
 	percpu       bool
 	averagecpu   bool
+	multiload    bool
 	statusbar    bool
 	exportPort   string
 	mbps         bool
@@ -73,6 +74,7 @@ func init() {
 	RootCmd.Flags().BoolVar(&fahrenheit, "fahrenheit", false, "use fahrenheit for temperature")
 	RootCmd.Flags().BoolVarP(&percpu, "percpu", "p", false, "show per-cpu usage")
 	RootCmd.Flags().BoolVarP(&averagecpu, "averagecpu", "a", false, "show average CPU usage")
+	RootCmd.Flags().BoolVarP(&multiload, "multiload", "M", false, "multiload-ng-style display (CPU usage broken down by state: user/sys/iowait/irq/steal + total)")
 	RootCmd.Flags().BoolVarP(&statusbar, "statusbar", "s", false, "show status bar")
 	RootCmd.Flags().StringVarP(&exportPort, "export", "x", "", "export metrics on port (e.g., :8080)")
 	RootCmd.Flags().BoolVar(&mbps, "mbps", false, "show network in Mbps")
@@ -168,6 +170,7 @@ func runDirectGotop() error {
 	conf.Layout = layoutFlag
 	conf.PercpuLoad = percpu
 	conf.AverageLoad = averagecpu
+	conf.Multiload = multiload
 	conf.Statusbar = statusbar
 	conf.ExportPort = exportPort
 	conf.Mbps = mbps
@@ -377,6 +380,7 @@ func runGotopWithConfig(updateInterval time.Duration, remoteMode bool) error {
 	}
 	conf.PercpuLoad = percpu
 	conf.AverageLoad = averagecpu
+	conf.Multiload = multiload
 	conf.Statusbar = statusbar
 	conf.ExportPort = exportPort
 	conf.Mbps = mbps

--- a/third_party/xxxserxxx/gotop/v4/config.go
+++ b/third_party/xxxserxxx/gotop/v4/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	UpdateInterval       time.Duration
 	AverageLoad          bool
 	PercpuLoad           bool
+	Multiload            bool
 	Statusbar            bool
 	TempScale            widgets.TempScale
 	NetInterface         string
@@ -64,6 +65,7 @@ func NewConfig() Config {
 		UpdateInterval:       time.Second,
 		AverageLoad:          false,
 		PercpuLoad:           true,
+		Multiload:            false,
 		TempScale:            widgets.Celsius,
 		Statusbar:            false,
 		NetInterface:         widgets.NetInterfaceAll,
@@ -154,6 +156,12 @@ func load(in io.Reader, conf *Config) error {
 				return errors.New(conf.Tr.Value("config.err.line", ln, err.Error()))
 			}
 			conf.PercpuLoad = bv
+		case multiload:
+			bv, err := strconv.ParseBool(kv[1])
+			if err != nil {
+				return errors.New(conf.Tr.Value("config.err.line", ln, err.Error()))
+			}
+			conf.Multiload = bv
 		case tempscale:
 			switch kv[1] {
 			case "C":
@@ -249,6 +257,8 @@ func marshal(c *Config) []byte {
 	fmt.Fprintf(buff, "%s=%t\n", averagecpu, c.AverageLoad)
 	fmt.Fprintln(buff, "# If true, show load per CPU")
 	fmt.Fprintf(buff, "%s=%t\n", percpuload, c.PercpuLoad)
+	fmt.Fprintln(buff, "# If true, use a multiload-ng-style display (per-state CPU breakdown, etc.)")
+	fmt.Fprintf(buff, "%s=%t\n", multiload, c.Multiload)
 	fmt.Fprintln(buff, "# Temperature units. C for Celsius, F for Fahrenheit")
 	fmt.Fprintf(buff, "%s=%c\n", tempscale, c.TempScale)
 	fmt.Fprintln(buff, "# If true, display a status bar")
@@ -285,6 +295,7 @@ const (
 	updateinterval       = "updateinterval"
 	averagecpu           = "averagecpu"
 	percpuload           = "percpuload"
+	multiload            = "multiload"
 	tempscale            = "tempscale"
 	statusbar            = "statusbar"
 	netinterface         = "netinterface"

--- a/third_party/xxxserxxx/gotop/v4/devices/cpu_breakdown.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/cpu_breakdown.go
@@ -1,0 +1,101 @@
+package devices
+
+import (
+	"sync"
+
+	psCpu "github.com/shirou/gopsutil/v3/cpu"
+)
+
+// CPU-time states reported by UpdateCPUBreakdown, in a fixed order. Unlike the
+// single "busy" figure reported by UpdateCPU (gopsutil cpu.Percent, which is
+// just 100-idle), these mirror multiload-ng's CPU graph: they expose *what* the
+// CPU is busy doing, including iowait (idle while blocked on I/O), which the
+// aggregate busy number hides entirely.
+const (
+	CPUStateUser  = "usr"   // user-mode (includes guest, as the kernel counts it)
+	CPUStateNice  = "nice"  // low-priority (niced) user-mode
+	CPUStateSys   = "sys"   // kernel-mode
+	CPUStateIO    = "io"    // iowait: idle while waiting on I/O
+	CPUStateIRQ   = "irq"   // hardware + soft interrupt servicing
+	CPUStateSteal = "steal" // time stolen by the hypervisor (VMs)
+	CPUStateTotal = "total" // all non-idle time (sum of the above)
+)
+
+// CPUBreakdownLabels is the set of keys UpdateCPUBreakdown fills, ordered for
+// stable iteration by callers. (The line-graph assigns colors by sorted key
+// independently of this order.)
+var CPUBreakdownLabels = []string{
+	CPUStateUser,
+	CPUStateNice,
+	CPUStateSys,
+	CPUStateIO,
+	CPUStateIRQ,
+	CPUStateSteal,
+	CPUStateTotal,
+}
+
+var (
+	cpuBreakdownMu   sync.Mutex
+	lastCPUTimes     psCpu.TimesStat
+	haveLastCPUTimes bool
+)
+
+// UpdateCPUBreakdown fills cpus with the percentage of total CPU time spent in
+// each kernel CPU-time state since the previous call, aggregated across all
+// logical CPUs. The first call has no prior snapshot to diff against and
+// returns no data (the map is left untouched).
+func UpdateCPUBreakdown(cpus map[string]int) map[string]error {
+	ts, err := psCpu.Times(false)
+	if err != nil {
+		return map[string]error{"gopsutil": err}
+	}
+	if len(ts) == 0 {
+		return nil
+	}
+	cur := ts[0]
+
+	cpuBreakdownMu.Lock()
+	defer cpuBreakdownMu.Unlock()
+	prev := lastCPUTimes
+	lastCPUTimes = cur
+	if !haveLastCPUTimes {
+		haveLastCPUTimes = true
+		return nil
+	}
+
+	// On Linux /proc/stat, the user field already includes guest time and nice
+	// includes guest_nice, so we use them as-is to avoid double counting.
+	dUser := cur.User - prev.User
+	dNice := cur.Nice - prev.Nice
+	dSys := cur.System - prev.System
+	dIO := cur.Iowait - prev.Iowait
+	dIRQ := (cur.Irq + cur.Softirq) - (prev.Irq + prev.Softirq)
+	dSteal := cur.Steal - prev.Steal
+	dIdle := cur.Idle - prev.Idle
+
+	busy := dUser + dNice + dSys + dIO + dIRQ + dSteal
+	total := busy + dIdle
+	if total <= 0 {
+		return nil
+	}
+
+	pct := func(d float64) int {
+		v := d / total * 100.0
+		switch {
+		case v < 0:
+			return 0
+		case v > 100:
+			return 100
+		default:
+			return int(v + 0.5)
+		}
+	}
+	cpus[CPUStateUser] = pct(dUser)
+	cpus[CPUStateNice] = pct(dNice)
+	cpus[CPUStateSys] = pct(dSys)
+	cpus[CPUStateIO] = pct(dIO)
+	cpus[CPUStateIRQ] = pct(dIRQ)
+	cpus[CPUStateSteal] = pct(dSteal)
+	cpus[CPUStateTotal] = pct(busy)
+	return nil
+}

--- a/third_party/xxxserxxx/gotop/v4/devices/mem_breakdown.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/mem_breakdown.go
@@ -1,0 +1,51 @@
+package devices
+
+import (
+	psMem "github.com/shirou/gopsutil/v3/mem"
+)
+
+// Memory-usage components reported by UpdateMemBreakdown, mirroring multiload-ng's
+// RAM graph: it splits the single "used %" into what the memory is actually
+// doing — application-used vs. reclaimable buffers/cache — so a box that looks
+// "full" is distinguishable from one that's merely caching.
+const (
+	MemUsed  = "used"  // application/anonymous memory (gopsutil Used)
+	MemBuff  = "buff"  // I/O buffers
+	MemCache = "cache" // page cache + reclaimable slab
+	MemTotal = "total" // used + buff + cache (the real footprint)
+)
+
+// MemBreakdownLabels lists the keys UpdateMemBreakdown fills, ordered so a
+// shade gradient runs used (darkest) -> total (lightest).
+var MemBreakdownLabels = []string{MemUsed, MemBuff, MemCache, MemTotal}
+
+// UpdateMemBreakdown fills m with each memory component as a percentage of total
+// RAM. Buffers and cache are reclaimable, so they are shown distinctly from
+// application memory rather than lumped into one "used" figure.
+func UpdateMemBreakdown(m map[string]int) map[string]error {
+	vm, err := psMem.VirtualMemory()
+	if err != nil {
+		return map[string]error{"Main": err}
+	}
+	if vm.Total == 0 {
+		return nil
+	}
+	total := float64(vm.Total)
+	cache := vm.Cached + vm.Sreclaimable
+	pct := func(v uint64) int {
+		p := float64(v) / total * 100.0
+		switch {
+		case p < 0:
+			return 0
+		case p > 100:
+			return 100
+		default:
+			return int(p + 0.5)
+		}
+	}
+	m[MemUsed] = pct(vm.Used)
+	m[MemBuff] = pct(vm.Buffers)
+	m[MemCache] = pct(cache)
+	m[MemTotal] = pct(vm.Used + vm.Buffers + cache)
+	return nil
+}

--- a/third_party/xxxserxxx/gotop/v4/devices/temp_linux.go
+++ b/third_party/xxxserxxx/gotop/v4/devices/temp_linux.go
@@ -17,29 +17,47 @@ func devs() []string {
 	}
 	sensors, err := host.SensorsTemperatures()
 	if err != nil {
-		log.Printf("gopsutil reports %s", err)
+		// gopsutil returns *host.Warnings for sensors it couldn't fully read;
+		// that is not fatal, so only complain about real errors.
+		if _, ok := err.(*host.Warnings); !ok {
+			log.Printf("gopsutil reports %s", err)
+		}
 		if len(sensors) == 0 {
 			log.Printf("no temperature sensors returned")
 			return []string{}
 		}
 	}
 	rv := make([]string, 0, len(sensors))
+	seen := make(map[string]bool)
 	for _, sensor := range sensors {
+		// gopsutil v3 already strips the _input/_thermal suffixes from
+		// SensorKey; trim them anyway for older versions, then use the key as
+		// the label. (The previous code only kept keys that still had a suffix,
+		// which under gopsutil v3 is none of them — so the widget showed nothing.)
 		label := strings.TrimSuffix(sensor.SensorKey, "_input")
 		label = strings.TrimSuffix(label, "_thermal")
-		rv = append(rv, label)
+		if label == "" || sensor.Temperature <= 0 { // skip empty/dead sensors
+			continue
+		}
 		sensorMap[sensor.SensorKey] = label
+		if !seen[label] {
+			seen[label] = true
+			rv = append(rv, label)
+		}
 	}
 	return rv
 }
 
-// Only include sensors with input in their name; these are the only sensors
-// returning live data
+// defs returns every detected sensor label (deduplicated). gopsutil v3 reports
+// one entry per live sensor, so there is no _input/_max/_crit duplication to
+// filter out.
 func defs() []string {
 	// MUST be called AFTER init()
-	rv := make([]string, 0)
-	for k, v := range sensorMap {
-		if k != v { // then it's an _input sensor
+	rv := make([]string, 0, len(sensorMap))
+	seen := make(map[string]bool)
+	for _, v := range sensorMap {
+		if !seen[v] {
+			seen[v] = true
 			rv = append(rv, v)
 		}
 	}

--- a/third_party/xxxserxxx/gotop/v4/layout/layout.go
+++ b/third_party/xxxserxxx/gotop/v4/layout/layout.go
@@ -203,7 +203,7 @@ func makeWidget(c gotop.Config, widRule widgetRule) interface{} {
 		if c.Multiload {
 			// multiload-ng style: plot each sensor as a line over time instead
 			// of the text readout.
-			tg := widgets.NewTempGraphWidget(c.TempScale, c.Temps, c.GraphHorizontalScale)
+			tg := widgets.NewTempGraphWidget(c.UpdateInterval, c.TempScale, c.Temps, c.GraphHorizontalScale)
 			assignColors(tg.Data, c.Colorscheme.CPULines, tg.LineColors)
 			w = tg
 		} else {

--- a/third_party/xxxserxxx/gotop/v4/layout/layout.go
+++ b/third_party/xxxserxxx/gotop/v4/layout/layout.go
@@ -167,12 +167,22 @@ func makeWidget(c gotop.Config, widRule widgetRule) interface{} {
 		dw := widgets.NewDiskWidget()
 		w = dw
 	case "cpu":
-		cpu := widgets.NewCPUWidget(c.UpdateInterval, c.GraphHorizontalScale, c.AverageLoad, c.PercpuLoad)
+		cpu := widgets.NewCPUWidget(c.UpdateInterval, c.GraphHorizontalScale, c.AverageLoad, c.PercpuLoad, c.Multiload)
 		assignColors(cpu.Data, c.Colorscheme.CPULines, cpu.LineColors)
 		w = cpu
 	case "mem":
-		m := widgets.NewMemWidget(c.UpdateInterval, c.GraphHorizontalScale)
-		assignColors(m.Data, c.Colorscheme.MemLines, m.LineColors)
+		m := widgets.NewMemWidget(c.UpdateInterval, c.GraphHorizontalScale, c.Multiload)
+		if c.Multiload {
+			// Color the used/buff/cache/total components as shades of the
+			// colorscheme's first memory hue (multiload-ng style).
+			base := ui.Color(0)
+			if len(c.Colorscheme.MemLines) > 0 {
+				base = ui.Color(c.Colorscheme.MemLines[0])
+			}
+			m.AssignShades(base)
+		} else {
+			assignColors(m.Data, c.Colorscheme.MemLines, m.LineColors)
+		}
 		w = m
 	case "batt":
 		b := widgets.NewBatteryWidget(c.GraphHorizontalScale)

--- a/third_party/xxxserxxx/gotop/v4/layout/layout.go
+++ b/third_party/xxxserxxx/gotop/v4/layout/layout.go
@@ -200,10 +200,18 @@ func makeWidget(c gotop.Config, widRule widgetRule) interface{} {
 		assignColors(b.Data, c.Colorscheme.BattLines, b.LineColors)
 		w = b
 	case "temp":
-		t := widgets.NewTempWidget(c.TempScale, c.Temps)
-		t.TempLowColor = ui.Color(c.Colorscheme.TempLow)
-		t.TempHighColor = ui.Color(c.Colorscheme.TempHigh)
-		w = t
+		if c.Multiload {
+			// multiload-ng style: plot each sensor as a line over time instead
+			// of the text readout.
+			tg := widgets.NewTempGraphWidget(c.TempScale, c.Temps, c.GraphHorizontalScale)
+			assignColors(tg.Data, c.Colorscheme.CPULines, tg.LineColors)
+			w = tg
+		} else {
+			t := widgets.NewTempWidget(c.TempScale, c.Temps)
+			t.TempLowColor = ui.Color(c.Colorscheme.TempLow)
+			t.TempHighColor = ui.Color(c.Colorscheme.TempHigh)
+			w = t
+		}
 	case "net":
 		n := widgets.NewNetWidget(c.NetInterface)
 		n.Lines[0].LineColor = ui.Color(c.Colorscheme.Sparklines[0])

--- a/third_party/xxxserxxx/gotop/v4/layout/layout.go
+++ b/third_party/xxxserxxx/gotop/v4/layout/layout.go
@@ -164,8 +164,23 @@ func makeWidget(c gotop.Config, widRule widgetRule) interface{} {
 	var w Metric
 	switch widRule.Widget {
 	case "disk":
-		dw := widgets.NewDiskWidget()
-		w = dw
+		if c.Multiload {
+			// multiload-ng style: aggregate disk read/write throughput graph
+			// instead of the per-partition usage table.
+			d := widgets.NewDiskIOWidget()
+			if len(c.Colorscheme.Sparklines) > 0 {
+				d.Lines[0].LineColor = ui.Color(c.Colorscheme.Sparklines[0])
+			}
+			d.Lines[0].TitleColor = ui.Color(c.Colorscheme.BorderLabel)
+			if len(c.Colorscheme.Sparklines) > 1 {
+				d.Lines[1].LineColor = ui.Color(c.Colorscheme.Sparklines[1])
+			}
+			d.Lines[1].TitleColor = ui.Color(c.Colorscheme.BorderLabel)
+			w = d
+		} else {
+			dw := widgets.NewDiskWidget()
+			w = dw
+		}
 	case "cpu":
 		cpu := widgets.NewCPUWidget(c.UpdateInterval, c.GraphHorizontalScale, c.AverageLoad, c.PercpuLoad, c.Multiload)
 		assignColors(cpu.Data, c.Colorscheme.CPULines, cpu.LineColors)
@@ -173,13 +188,9 @@ func makeWidget(c gotop.Config, widRule widgetRule) interface{} {
 	case "mem":
 		m := widgets.NewMemWidget(c.UpdateInterval, c.GraphHorizontalScale, c.Multiload)
 		if c.Multiload {
-			// Color the used/buff/cache/total components as shades of the
-			// colorscheme's first memory hue (multiload-ng style).
-			base := ui.Color(0)
-			if len(c.Colorscheme.MemLines) > 0 {
-				base = ui.Color(c.Colorscheme.MemLines[0])
-			}
-			m.AssignShades(base)
+			// Color the used/buff/cache/total components as shades of green
+			// (multiload-ng's RAM convention), regardless of colorscheme.
+			m.AssignShades(widgets.MultiloadMemBase)
 		} else {
 			assignColors(m.Data, c.Colorscheme.MemLines, m.LineColors)
 		}

--- a/third_party/xxxserxxx/gotop/v4/termui/linegraph.go
+++ b/third_party/xxxserxxx/gotop/v4/termui/linegraph.go
@@ -1,6 +1,7 @@
 package termui
 
 import (
+	"fmt"
 	"image"
 	"sort"
 	"strconv"
@@ -46,6 +47,36 @@ func NewLineGraph() *LineGraph {
 		LineColors:  make(map[string]ui.Color),
 		LabelStyles: make(map[string]ui.Modifier),
 	}
+}
+
+// Tint returns a lighter variant of a 256-color "color cube" color (palette
+// indices 16-231) by blending each channel toward white by fraction t (0..1).
+// t<=0 returns the base color; colors outside the cube are returned unchanged.
+// Used to derive shades of a single base hue (e.g. light vs. dark green for
+// memory used/buffers/cache) the way multiload-ng tints one color per subtype.
+func Tint(base ui.Color, t float64) ui.Color {
+	c := int(base)
+	if c < 16 || c > 231 || t <= 0 {
+		return base
+	}
+	if t > 1 {
+		t = 1
+	}
+	c -= 16
+	blend := func(v int) int {
+		nv := int(float64(v) + (5.0-float64(v))*t + 0.5)
+		if nv < 0 {
+			nv = 0
+		}
+		if nv > 5 {
+			nv = 5
+		}
+		return nv
+	}
+	r := blend(c / 36)
+	g := blend((c % 36) / 6)
+	b := blend(c % 6)
+	return ui.Color(16 + 36*r + 6*g + b)
 }
 
 func (lg *LineGraph) Draw(buf *ui.Buffer) {
@@ -131,7 +162,20 @@ func (lg *LineGraph) Draw(buf *ui.Buffer) {
 		}
 	}
 
-	// renders key/label ontop
+	lg.drawLabels(buf)
+}
+
+// drawLabels renders the per-series key + value text overlaid on the graph.
+// Series names are left-justified to the widest name so the value column lines
+// up instead of floating right after each variable-width name. Shared by the
+// line and stacked render paths.
+func (lg *LineGraph) drawLabels(buf *ui.Buffer) {
+	nameWid := 0
+	for _, seriesName := range lg.seriesList {
+		if len(seriesName) > nameWid {
+			nameWid = len(seriesName)
+		}
+	}
 	maxWid := 0
 	xoff := 0 // X offset for additional columns of text
 	yoff := 0 // Y offset for resetting column to top of widget
@@ -151,7 +195,7 @@ func (lg *LineGraph) Draw(buf *ui.Buffer) {
 		}
 
 		// render key ontop, but let braille be drawn over space characters
-		str := seriesName + " " + lg.Labels[seriesName]
+		str := fmt.Sprintf("%-*s %s", nameWid, seriesName, lg.Labels[seriesName])
 		if len(str) > maxWid {
 			maxWid = len(str)
 		}

--- a/third_party/xxxserxxx/gotop/v4/widgets/cpu.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/cpu.go
@@ -18,26 +18,43 @@ type CPUWidget struct {
 	CPUCount        int
 	ShowAverageLoad bool
 	ShowPerCPULoad  bool
-	updateInterval  time.Duration
-	cpuLoads        map[string]float64
-	average         ewma.MovingAverage
+	// ShowBreakdown switches the CPU graph to a multiload-ng-style per-state
+	// breakdown (user/sys/iowait/irq/steal + a bold total) instead of the
+	// single busy figure. Driven by the global multiload display flag; when set
+	// it overrides the average/per-cpu modes.
+	ShowBreakdown  bool
+	updateInterval time.Duration
+	cpuLoads       map[string]float64
+	average        ewma.MovingAverage
 }
 
 var cpuLabels []string
 
-func NewCPUWidget(updateInterval time.Duration, horizontalScale int, showAverageLoad bool, showPerCPULoad bool) *CPUWidget {
+func NewCPUWidget(updateInterval time.Duration, horizontalScale int, showAverageLoad bool, showPerCPULoad bool, showBreakdown bool) *CPUWidget {
 	self := &CPUWidget{
 		LineGraph:       ui.NewLineGraph(),
 		CPUCount:        len(cpuLabels),
 		updateInterval:  updateInterval,
 		ShowAverageLoad: showAverageLoad,
 		ShowPerCPULoad:  showPerCPULoad,
+		ShowBreakdown:   showBreakdown,
 		cpuLoads:        make(map[string]float64),
 		average:         ewma.NewMovingAverage(),
 	}
 	self.LabelStyles[AVRG] = termui.ModifierBold
 	self.Title = tr.Value("widget.label.cpu")
 	self.HorizontalScale = horizontalScale
+
+	if self.ShowBreakdown {
+		// Per-state breakdown: pre-seed the state keys so the colorscheme
+		// assigns each one a distinct color at construction, and bold the total.
+		self.LabelStyles[devices.CPUStateTotal] = termui.ModifierBold
+		for _, k := range devices.CPUBreakdownLabels {
+			self.Data[k] = []float64{0}
+		}
+		self.startUpdating()
+		return self
+	}
 
 	if !(self.ShowAverageLoad || self.ShowPerCPULoad) {
 		if self.CPUCount <= 8 {
@@ -59,20 +76,31 @@ func NewCPUWidget(updateInterval time.Duration, horizontalScale int, showAverage
 		}
 	}
 
-	self.update()
+	self.startUpdating()
+	return self
+}
 
+func (cpu *CPUWidget) startUpdating() {
+	cpu.update()
 	go func() {
-		for range time.NewTicker(self.updateInterval).C {
-			self.update()
+		for range time.NewTicker(cpu.updateInterval).C {
+			cpu.update()
 		}
 	}()
-
-	return self
 }
 
 const AVRG = "AVRG"
 
 func (cpu *CPUWidget) EnableMetric() {
+	if cpu.ShowBreakdown {
+		for _, state := range devices.CPUBreakdownLabels {
+			sc := state
+			metrics.NewGauge(makeName("cpu", " "+sc), func() float64 {
+				return cpu.cpuLoads[sc]
+			})
+		}
+		return
+	}
 	if cpu.ShowAverageLoad {
 		metrics.NewGauge(makeName("cpu", " avg"), func() float64 {
 			return cpu.cpuLoads[AVRG]
@@ -96,6 +124,20 @@ func (cpu *CPUWidget) Scale(i int) {
 
 func (cpu *CPUWidget) update() {
 	go func() {
+		if cpu.ShowBreakdown {
+			states := make(map[string]int)
+			devices.UpdateCPUBreakdown(states)
+			cpu.Lock()
+			defer cpu.Unlock()
+			for _, state := range devices.CPUBreakdownLabels {
+				percent := states[state]
+				cpu.Data[state] = append(cpu.Data[state], float64(percent))
+				cpu.Labels[state] = fmt.Sprintf("%3d%%", percent)
+				cpu.cpuLoads[state] = float64(percent)
+			}
+			return
+		}
+
 		cpus := make(map[string]int)
 		devices.UpdateCPU(cpus, cpu.updateInterval, true)
 		cpu.Lock()

--- a/third_party/xxxserxxx/gotop/v4/widgets/disk_io.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/disk_io.go
@@ -1,0 +1,123 @@
+package widgets
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	psDisk "github.com/shirou/gopsutil/v3/disk"
+
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
+	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"
+)
+
+// DiskIOWidget shows aggregate disk read/write throughput over time as two
+// auto-scaling sparklines (multiload-ng style), in contrast to the default
+// per-partition usage table (DiskWidget). Used for the "disk" slot under the
+// global multiload display flag.
+type DiskIOWidget struct {
+	*ui.SparklineGroup
+	updateInterval time.Duration
+	totalRead      uint64
+	totalWrite     uint64
+	readMetric     *metrics.Counter
+	writeMetric    *metrics.Counter
+}
+
+func NewDiskIOWidget() *DiskIOWidget {
+	read := ui.NewSparkline()
+	read.Data = []int{}
+	write := ui.NewSparkline()
+	write.Data = []int{}
+
+	self := &DiskIOWidget{
+		SparklineGroup: ui.NewSparklineGroup(read, write),
+		updateInterval: time.Second,
+	}
+	self.Title = tr.Value("widget.label.disk")
+
+	self.update()
+	go func() {
+		for range time.NewTicker(self.updateInterval).C {
+			self.Lock()
+			self.update()
+			self.Unlock()
+		}
+	}()
+	return self
+}
+
+func (d *DiskIOWidget) EnableMetric() {
+	d.readMetric = metrics.NewCounter(makeName("disk", "read"))
+	d.writeMetric = metrics.NewCounter(makeName("disk", "write"))
+}
+
+// aggregateDiskIO sums cumulative read/write bytes across whole physical disks,
+// skipping partitions (a device whose name extends another device's name, e.g.
+// sda1 under sda, nvme0n1p1 under nvme0n1) so the totals aren't double counted.
+func aggregateDiskIO() (read, write uint64) {
+	counters, err := psDisk.IOCounters()
+	if err != nil {
+		log.Print(err)
+		return 0, 0
+	}
+	names := make([]string, 0, len(counters))
+	for name := range counters {
+		names = append(names, name)
+	}
+	isPartition := func(name string) bool {
+		for _, other := range names {
+			if other != name && strings.HasPrefix(name, other) {
+				return true
+			}
+		}
+		return false
+	}
+	for name, c := range counters {
+		if isPartition(name) {
+			continue
+		}
+		read += c.ReadBytes
+		write += c.WriteBytes
+	}
+	return read, write
+}
+
+func (d *DiskIOWidget) update() {
+	read, write := aggregateDiskIO()
+	if d.totalRead != 0 || d.totalWrite != 0 { // not the first sample
+		// compare before subtracting so a counter reset (read < previous) can't
+		// wrap the unsigned delta into a huge spike.
+		var recentRead, recentWrite uint64
+		if read >= d.totalRead {
+			recentRead = read - d.totalRead
+		}
+		if write >= d.totalWrite {
+			recentWrite = write - d.totalWrite
+		}
+		rr := int(recentRead)  //nolint:gosec // per-second byte delta, never overflows int64
+		rw := int(recentWrite) //nolint:gosec // per-second byte delta, never overflows int64
+
+		d.Lines[0].Data = append(d.Lines[0].Data, rr)
+		d.Lines[1].Data = append(d.Lines[1].Data, rw)
+		if d.readMetric != nil {
+			d.readMetric.Add(rr)
+			d.writeMetric.Add(rw)
+		}
+
+		recentReadConv, recentReadUnit := utils.ConvertBytes(recentRead)
+		recentWriteConv, recentWriteUnit := utils.ConvertBytes(recentWrite)
+		totalReadConv, totalReadUnit := utils.ConvertBytes(read)
+		totalWriteConv, totalWriteUnit := utils.ConvertBytes(write)
+
+		d.Lines[0].Title1 = fmt.Sprintf(" Total R: %5.1f %s", totalReadConv, totalReadUnit)
+		d.Lines[0].Title2 = fmt.Sprintf(" R/s: %9.1f %2s/s", recentReadConv, recentReadUnit)
+		d.Lines[1].Title1 = fmt.Sprintf(" Total W: %5.1f %s", totalWriteConv, totalWriteUnit)
+		d.Lines[1].Title2 = fmt.Sprintf(" W/s: %9.1f %2s/s", recentWriteConv, recentWriteUnit)
+	}
+
+	d.totalRead = read
+	d.totalWrite = write
+}

--- a/third_party/xxxserxxx/gotop/v4/widgets/mem.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/mem.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gizak/termui/v3"
+
 	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
 	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
 	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
@@ -12,16 +14,38 @@ import (
 
 type MemWidget struct {
 	*ui.LineGraph
+	// ShowBreakdown switches the memory graph to a multiload-ng-style breakdown
+	// (used/buff/cache + a bold total) instead of a single used-% line. Driven
+	// by the global multiload display flag.
+	ShowBreakdown  bool
 	updateInterval time.Duration
 }
 
-func NewMemWidget(updateInterval time.Duration, horizontalScale int) *MemWidget {
+func NewMemWidget(updateInterval time.Duration, horizontalScale int, showBreakdown bool) *MemWidget {
 	widg := &MemWidget{
 		LineGraph:      ui.NewLineGraph(),
+		ShowBreakdown:  showBreakdown,
 		updateInterval: updateInterval,
 	}
 	widg.Title = tr.Value("widget.label.mem")
 	widg.HorizontalScale = horizontalScale
+
+	if widg.ShowBreakdown {
+		widg.LabelStyles[devices.MemTotal] = termui.ModifierBold
+		for _, k := range devices.MemBreakdownLabels {
+			widg.Data[k] = []float64{0}
+		}
+		widg.updateBreakdown()
+		go func() {
+			for range time.NewTicker(widg.updateInterval).C {
+				widg.Lock()
+				widg.updateBreakdown()
+				widg.Unlock()
+			}
+		}()
+		return widg
+	}
+
 	mems := make(map[string]devices.MemoryInfo)
 	devices.UpdateMem(mems)
 	for name, mem := range mems {
@@ -47,7 +71,34 @@ func NewMemWidget(updateInterval time.Duration, horizontalScale int) *MemWidget 
 	return widg
 }
 
+// AssignShades colors the breakdown components as tints of a single base hue
+// (multiload-ng style): used (base) -> total (lightest), with the total label
+// bolded. Called by the layout once the colorscheme's base memory color is known.
+func (mem *MemWidget) AssignShades(base termui.Color) {
+	order := devices.MemBreakdownLabels
+	for i, name := range order {
+		t := 0.0
+		if len(order) > 1 {
+			t = float64(i) / float64(len(order)-1)
+		}
+		mem.LineColors[name] = ui.Tint(base, 0.10+t*0.75)
+	}
+	mem.LabelStyles[devices.MemTotal] = termui.ModifierBold
+}
+
 func (mem *MemWidget) EnableMetric() {
+	if mem.ShowBreakdown {
+		for _, k := range devices.MemBreakdownLabels {
+			kc := k
+			metrics.NewGauge(makeName("memory", " "+kc), func() float64 {
+				if ds, ok := mem.Data[kc]; ok && len(ds) > 0 {
+					return ds[len(ds)-1]
+				}
+				return 0.0
+			})
+		}
+		return
+	}
 	mems := make(map[string]devices.MemoryInfo)
 	devices.UpdateMem(mems)
 	for l := range mems {
@@ -63,6 +114,30 @@ func (mem *MemWidget) EnableMetric() {
 
 func (mem *MemWidget) Scale(i int) {
 	mem.LineGraph.HorizontalScale = i
+}
+
+// updateBreakdown appends the latest per-component percentages, labeling each
+// with its percent and absolute size. Caller holds the lock.
+func (mem *MemWidget) updateBreakdown() {
+	pcts := make(map[string]int)
+	devices.UpdateMemBreakdown(pcts)
+	total := mem.totalBytes()
+	for _, k := range devices.MemBreakdownLabels {
+		p := pcts[k]
+		mem.Data[k] = append(mem.Data[k], float64(p))
+		bytes, mag := utils.ConvertBytes(uint64(float64(p) / 100.0 * float64(total)))
+		mem.Labels[k] = fmt.Sprintf("%3d%% %5.1f%s", p, bytes, mag)
+	}
+}
+
+// totalBytes returns total physical RAM for sizing the breakdown labels.
+func (mem *MemWidget) totalBytes() uint64 {
+	mems := make(map[string]devices.MemoryInfo)
+	devices.UpdateMem(mems)
+	if mi, ok := mems["Main"]; ok {
+		return mi.Total
+	}
+	return 0
 }
 
 func (mem *MemWidget) renderMemInfo(line string, memoryInfo devices.MemoryInfo) {

--- a/third_party/xxxserxxx/gotop/v4/widgets/mem.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/mem.go
@@ -71,9 +71,15 @@ func NewMemWidget(updateInterval time.Duration, horizontalScale int, showBreakdo
 	return widg
 }
 
+// MultiloadMemBase is the base hue for the multiload-ng-style memory breakdown:
+// a saturated green (256-color cube (r,g,b)=(0,5,0)), matching multiload's RAM
+// convention regardless of the active colorscheme. used is the vivid base green
+// and the lighter components fade toward white.
+const MultiloadMemBase = termui.Color(46)
+
 // AssignShades colors the breakdown components as tints of a single base hue
-// (multiload-ng style): used (base) -> total (lightest), with the total label
-// bolded. Called by the layout once the colorscheme's base memory color is known.
+// (multiload-ng style): used (vivid base) -> total (lightest, near white), with
+// the total label bolded.
 func (mem *MemWidget) AssignShades(base termui.Color) {
 	order := devices.MemBreakdownLabels
 	for i, name := range order {
@@ -81,7 +87,9 @@ func (mem *MemWidget) AssignShades(base termui.Color) {
 		if len(order) > 1 {
 			t = float64(i) / float64(len(order)-1)
 		}
-		mem.LineColors[name] = ui.Tint(base, 0.10+t*0.75)
+		// spread from 0 (pure base hue for `used`) to 0.85 (near white for the
+		// lightest component) so the subtypes stay clearly distinct.
+		mem.LineColors[name] = ui.Tint(base, t*0.85)
 	}
 	mem.LabelStyles[devices.MemTotal] = termui.ModifierBold
 }

--- a/third_party/xxxserxxx/gotop/v4/widgets/temp_graph.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/temp_graph.go
@@ -23,10 +23,10 @@ type TempGraphWidget struct {
 	TempScale      TempScale
 }
 
-func NewTempGraphWidget(tempScale TempScale, filter []string, horizontalScale int) *TempGraphWidget {
+func NewTempGraphWidget(updateInterval time.Duration, tempScale TempScale, filter []string, horizontalScale int) *TempGraphWidget {
 	self := &TempGraphWidget{
 		LineGraph:      ui.NewLineGraph(),
-		updateInterval: time.Second * 5,
+		updateInterval: updateInterval,
 		TempScale:      tempScale,
 	}
 	self.Title = tr.Value("widget.label.temp")

--- a/third_party/xxxserxxx/gotop/v4/widgets/temp_graph.go
+++ b/third_party/xxxserxxx/gotop/v4/widgets/temp_graph.go
@@ -1,0 +1,88 @@
+package widgets
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/skycoin/skywire/third_party/VictoriaMetrics/metrics"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/devices"
+	ui "github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/termui"
+	"github.com/skycoin/skywire/third_party/xxxserxxx/gotop/v4/utils"
+)
+
+// TempGraphWidget plots each temperature sensor as a line over time
+// (multiload-ng style), used for the "temp" slot under the global multiload
+// display flag. The default display uses the text-readout TempWidget instead.
+//
+// The graph value is the sensor's Celsius reading, which maps directly onto the
+// LineGraph's 0-100 scale (sensors rarely exceed 100 C). When Fahrenheit is
+// selected only the label is converted, so the graph stays correctly scaled.
+type TempGraphWidget struct {
+	*ui.LineGraph
+	updateInterval time.Duration
+	TempScale      TempScale
+}
+
+func NewTempGraphWidget(tempScale TempScale, filter []string, horizontalScale int) *TempGraphWidget {
+	self := &TempGraphWidget{
+		LineGraph:      ui.NewLineGraph(),
+		updateInterval: time.Second * 5,
+		TempScale:      tempScale,
+	}
+	self.Title = tr.Value("widget.label.temp")
+	self.HorizontalScale = horizontalScale
+
+	sensors := filter
+	if len(sensors) == 0 {
+		sensors = devices.Devices(devices.Temperatures, false)
+	}
+	for _, s := range sensors {
+		self.Data[s] = []float64{0}
+	}
+
+	self.update()
+	go func() {
+		for range time.NewTicker(self.updateInterval).C {
+			self.Lock()
+			self.update()
+			self.Unlock()
+		}
+	}()
+
+	return self
+}
+
+func (t *TempGraphWidget) EnableMetric() {
+	for k := range t.Data {
+		kc := k
+		metrics.NewGauge(makeName("temp", kc), func() float64 {
+			if ds, ok := t.Data[kc]; ok && len(ds) > 0 {
+				return ds[len(ds)-1]
+			}
+			return 0.0
+		})
+	}
+}
+
+func (t *TempGraphWidget) Scale(i int) {
+	t.LineGraph.HorizontalScale = i
+}
+
+// update appends the latest Celsius reading per sensor, labeled in the chosen
+// scale. Caller holds the lock (except the initial construction call).
+func (t *TempGraphWidget) update() {
+	temps := make(map[string]int)
+	for k := range t.Data {
+		temps[k] = 0
+	}
+	devices.UpdateTemps(temps) // fills Celsius values for known keys
+
+	for name, c := range temps {
+		t.Data[name] = append(t.Data[name], float64(c))
+		disp := c
+		if t.TempScale == Fahrenheit {
+			disp = utils.CelsiusToFahrenheit(c)
+		}
+		t.Labels[name] = fmt.Sprintf("%d°%c", disp, t.TempScale)
+	}
+}


### PR DESCRIPTION
## What

Adds a single global display flag **`-M` / `--multiload`** (config key `multiload`) to the bundled `skywire cli gotop` that switches its graphs to a [multiload-ng](https://github.com/udda/multiload-ng)-style **breakdown by subtype**, instead of the single aggregate figure gotop shows today.

The **default display is unchanged**, and the pre-existing **`-a/--averagecpu`** keeps its original average-load meaning. The multiload look is opt-in, and one flag drives all the breakdowns (not a flag per graph).

### CPU (`-M`)
gotop's CPU graph only ever showed `100 - idle` per core — so a core pegged on **iowait** looked identical to one pegged on user compute. Under `-M` the CPU graph now shows per-state lines computed from `gopsutil cpu.Times` deltas:

`user · sys · iowait (io) · irq (+softirq) · steal` + a bold **total**.

### RAM (`-M`)
gotop's memory graph showed a single `used %`. Under `-M` it splits into `used · buff · cache` + a bold **total** (from `gopsutil VirtualMemory`), coloured as **shades of the colorscheme's memory hue** (light vs. dark) the way multiload tints one base colour per subtype — so reclaimable cache/buffers are visually distinct from application memory.

### Also
- **Label alignment:** line-graph value labels are now left-justified into a column (`drawLabels`) so the percentages line up instead of floating right after each variable-width series name. Applies to every line-graph widget (CPU/RAM/Net/Disk).

## Implementation
- `devices/cpu_breakdown.go`, `devices/mem_breakdown.go` — new collectors (snapshot-delta for CPU; component %s for RAM). No new dependency — gopsutil was already vendored.
- `widgets/cpu.go`, `widgets/mem.go` — `ShowBreakdown` mode; original modes untouched.
- `termui/linegraph.go` — `Tint()` shade helper + the label-column alignment.
- `config.go`, `layout/layout.go`, `cmd/skywire-cli/commands/gotop/root.go` — the `multiload` flag/config plumbing.

## Scope / follow-ups
Confined to the vendored gotop + its CLI command. Disk-I/O throughput and Network are the natural next graphs to give the same `-M` treatment (will stack onto this branch).

## Test
- `go build ./...`, `go vet`, `golangci-lint` clean on the touched packages.
- Verified live: default, `-a`, and `-M` all render without panic; `-M` shows the CPU per-state breakdown (iowait visible) and the RAM used/buff/cache breakdown.