### PR TITLE
feat(rewards/ui): title visor counts, fix No-transports cutoff, linkify reasons, pool caption

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/htmpl.go
+++ b/cmd/skywire-cli/commands/rewards/server/htmpl.go
@@ -144,6 +144,29 @@ func chunkedPageHead(title, description, path string) string {
 	return h
 }
 
+// ineligibleReasonLink renders an ineligibility reason as a link
+// into the matching mainnet-rules anchor on the rewards index page,
+// so visitors can click through to the rule that classified them
+// out. Returns the bare reason unwrapped for entries we don't have
+// a mapping for. Anchor strings match the explicit (#…) links in
+// rewards/mainnet_rules.md.
+func ineligibleReasonLink(reason string) string {
+	r := strings.TrimSpace(reason)
+	anchor := ""
+	switch r {
+	case "No transports":
+		anchor = "Transports"
+	case "kvm", "hyperv", "xenhvm", "vmware", "vbox":
+		anchor = "Per-Machine-Limit"
+	case "Invalid survey", "Survey not found":
+		anchor = "Survey"
+	}
+	if anchor == "" {
+		return reason
+	}
+	return `<a href="/skycoin-rewards/#` + anchor + `">` + reason + `</a>`
+}
+
 const htmlFrontPageTemplate = `
 ┌─┐┬┌─┬ ┬┬ ┬┬┬─┐┌─┐  ┬─┐┌─┐┬ ┬┌─┐┬─┐┌┬┐┌─┐
 └─┐├┴┐└┬┘││││├┬┘├┤   ├┬┘├┤ │││├─┤├┬┘ ││└─┐

--- a/cmd/skywire-cli/commands/rewards/server/seo.go
+++ b/cmd/skywire-cli/commands/rewards/server/seo.go
@@ -28,6 +28,7 @@ import (
 type rewardStats struct {
 	Date             string  // YYYY-MM-DD (from "date:" line)
 	QualifyingVisors int     // from "qualifying visors:" (first occurrence — Presence Pool)
+	IneligibleVisors int     // number of rows in hist/<date>_ineligible.csv
 	TotalRewardSKY   float64 // from "Total Reward Amount (both pools):" (or single-pool variant)
 	UniqueIPs        int     // from "Unique IP Addresses:"
 	Countries        int     // distinct country codes in the Regional Saturation table
@@ -93,6 +94,18 @@ func parseRewardStats(wd, date string) rewardStats {
 		}
 	}
 
+	// Ineligible-visor count is just the row count of the matching
+	// ineligible.csv. File may be absent on dates that predate the
+	// feature; absent is a 0 count, not an error.
+	if ineligibleData, err := os.ReadFile(filepath.Join(wd, "hist", date+"_ineligible.csv")); err == nil { //nolint:gosec
+		// Count non-empty lines.
+		for _, line := range strings.Split(string(ineligibleData), "\n") {
+			if strings.TrimSpace(line) != "" {
+				stats.IneligibleVisors++
+			}
+		}
+	}
+
 	return stats
 }
 
@@ -102,6 +115,15 @@ func parseRewardStats(wd, date string) rewardStats {
 func (s rewardStats) title(date string) string {
 	if s.QualifyingVisors == 0 || s.TotalRewardSKY == 0 {
 		return "Skycoin Rewards " + date
+	}
+	// When ineligibles are recorded, surface the full "X of Y (Z
+	// ineligible)" breakdown so the headline numbers don't hide the
+	// excluded visors. Falls back to the simpler "to N visors" form
+	// when no ineligible data is available (dates before the feature).
+	if s.IneligibleVisors > 0 {
+		return fmt.Sprintf("Skycoin Rewards %s — %.2f SKY to %d of %d visors (%d ineligible)",
+			date, s.TotalRewardSKY, s.QualifyingVisors,
+			s.QualifyingVisors+s.IneligibleVisors, s.IneligibleVisors)
 	}
 	return fmt.Sprintf("Skycoin Rewards %s — %.2f SKY to %d visors", date, s.TotalRewardSKY, s.QualifyingVisors)
 }

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -771,12 +771,22 @@ func buildRouter() *gin.Engine {
 				calendar = cal()
 			}
 			l += "\n" + string(ansihtml.ConvertToHTML([]byte(calendar)))
-			l += "\n\n<table style='border-collapse: collapse; width: auto;'>\n"
+			// Caption above the daily history table to explain the two
+			// pool columns. Detailed eligibility rules live further
+			// down the page (#Pool-1-Presence, #Pool-2-Bandwidth); this
+			// keeps the meaning of Pool 1 / Pool 2 inline without
+			// requiring readers to scroll.
+			l += "\n\n<p style='margin:8px 0 4px 0;font-size:12px;color:#aaa;'>" +
+				"<b>Pool 1</b> = presence (Skycoin per visor-share). " +
+				"<b>Pool 2</b> = bandwidth (Skycoin per share or per GB, depending on mode). " +
+				"<b>Distributed</b>: <span style='color:#0f0;'>✔</span> broadcast on-chain · <span style='color:#f00;'>✘</span> pending." +
+				"</p>\n"
+			l += "<table style='border-collapse: collapse; width: auto;'>\n"
 			l += "<thead>\n"
 			l += "<tr>\n"
 			l += "<th style='padding: 4px 12px; border-bottom: 1px solid #444; text-align: left;'>Date</th>"
-			l += "<th style='padding: 4px 12px; border-bottom: 1px solid #444; text-align: right;'>Pool 1</th>"
-			l += "<th style='padding: 4px 12px; border-bottom: 1px solid #444; text-align: right;'>Pool 2</th>"
+			l += "<th style='padding: 4px 12px; border-bottom: 1px solid #444; text-align: right; font-family: monospace;'>Pool 1</th>"
+			l += "<th style='padding: 4px 12px; border-bottom: 1px solid #444; text-align: right; font-family: monospace;'>Pool 2</th>"
 			l += "<th style='padding: 4px 12px; border-bottom: 1px solid #444; text-align: center;'>Distributed</th>\n"
 			l += "</tr>\n"
 			l += "</thead>\n"
@@ -1181,7 +1191,7 @@ func buildRouter() *gin.Engine {
 
 			l1, err := script.File(wd + `/hist/` + c.Param("date") + ".txt").String()
 			if err != nil {
-				l += "Rewards not distributed yet\n\n"
+				l += "Rewards not distributed yet — awaiting broadcast\n\n"
 			} else {
 				if l1 == "" {
 					l += "Reward txid not recorded\n\n"
@@ -1238,18 +1248,29 @@ func buildRouter() *gin.Engine {
 			if err == nil {
 				l += "\n\nIneligible:\n"
 				for _, line := range l2 {
-					thispk, _ := script.Echo(line).Column(2).String()         //nolint:errcheck,gosec
-					reason, _ := script.Echo(line).Column(3).String()         //nolint:errcheck,gosec
+					// Split on ", " (comma+space) — ineligible.csv reason
+					// values can contain spaces ("No transports", "Invalid
+					// survey", etc), and the prior whitespace-tokenizing
+					// Column() call truncated multi-word reasons to their
+					// first word ("No" instead of "No transports").
+					parts := strings.SplitN(line, ", ", 4)
+					thispk := ""
+					reason := ""
+					if len(parts) >= 3 {
+						thispk = parts[1]
+						reason = parts[2]
+					}
+					pkClean := strings.TrimRight(thispk, ",\n")
 					invalid, _ := script.Echo(line).Match(", , , ,").String() //nolint:errcheck,gosec
 					if invalid != "" {
-						_, err = script.IfExists(wd + `/` + "log_backups/" + thispk + "/node-info.json").Echo("").String()
+						_, err = script.IfExists(wd + `/` + "log_backups/" + pkClean + "/node-info.json").Echo("").String()
 						if err != nil {
-							l += "<a id='" + strings.TrimRight(thispk, ",\n") + "'>" + strings.TrimRight(thispk, ",\n") + "</a>," + " Survey not found\n"
+							l += "<a id='" + pkClean + "'>" + pkClean + "</a>, " + ineligibleReasonLink("Survey not found") + "\n"
 						} else {
-							l += "<a id='" + strings.TrimRight(thispk, ",\n") + "'>" + strings.TrimRight(thispk, ",\n") + "</a>," + " Invalid survey\n"
+							l += "<a id='" + pkClean + "'>" + pkClean + "</a>, " + ineligibleReasonLink("Invalid survey") + "\n"
 						}
 					} else {
-						l += "<a id='" + strings.TrimRight(thispk, ",\n") + "'>" + strings.TrimRight(thispk, ",\n") + "</a>," + " Ineligible " + strings.Replace(reason, ",\n", "\n", -1)
+						l += "<a id='" + pkClean + "'>" + pkClean + "</a>, Ineligible " + ineligibleReasonLink(strings.TrimRight(reason, ",\n")) + "\n"
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Reward-UI affordance fixes on the `/skycoin-rewards` server pages. All changes in `cmd/skywire-cli/commands/rewards/server/{server.go,htmpl.go,seo.go}`.

**Date page (`/skycoin-rewards/hist/<date>`):**
- `stats.title()` (seo.go) now surfaces the full eligible/ineligible split: `Skycoin Rewards YYYY-MM-DD — N.NN SKY to X of Y visors (Z ineligible)`. `rewardStats` gained an `IneligibleVisors` field populated by counting rows in `<date>_ineligible.csv`. Falls back to the prior `to N visors` form when no ineligible file is present (pre-feature dates).
- "Rewards not distributed yet" → "Rewards not distributed yet — awaiting broadcast". Sets expectations without committing to a specific ETA.
- Fix the ineligible-reason "No transports" truncation: prior code used `script.Echo(line).Column(3)` which whitespace-tokenizes, so multi-word reasons collapsed to their first word (`No` instead of `No transports`). Switched to `strings.SplitN(line, ", ", 4)` which honours the comma+space CSV separator.
- Linkify ineligible reasons to the matching mainnet-rules anchors (`#Transports`, `#Per-Machine-Limit`, `#Survey`) via a new `ineligibleReasonLink` helper in `htmpl.go`. Visitors can click straight through to the rule that excluded them; unknown reasons stay un-linkified.

**Index page (`/skycoin-rewards`):**
- Caption line above the reward-history table explaining Pool 1 (presence) / Pool 2 (bandwidth or per-GB) and the ✔/✘ Distributed glyphs.
- Pool 1 / Pool 2 `<th>` cells now use `font-family: monospace` so the right-aligned right edges line up with their data cells visually.

## Test plan
- [ ] `make format check` — only pre-existing baseline lint hits in unrelated packages
- [ ] `go build ./...` clean
- [ ] Visit `/skycoin-rewards/hist/<recent-date>` — browser tab shows the X of Y visors title; "awaiting broadcast" string appears for undistributed dates; an ineligible row with reason "No transports" renders the full reason (not truncated) and is wrapped in an anchor that scrolls to `#Transports` on the rules page
- [ ] Visit `/skycoin-rewards/hist/<old-date>` with no `_ineligible.csv` — title gracefully falls back to `to N visors`
- [ ] Visit `/skycoin-rewards` — caption row above table reads correctly; Pool 1 / Pool 2 column headers align with their data rows