### PR TITLE
fix(router): don't downgrade MinHops to 1 over a closed direct transport

### DIFF
--- a/pkg/router/router_config.go
+++ b/pkg/router/router_config.go
@@ -108,19 +108,18 @@ func (r *router) Close() error {
 }
 
 func (r *router) isTpdExist(rPK cipher.PubKey) bool {
-	// check stcpr transport if exist
-	_, err := r.tm.GetTransport(rPK, types.STCPR)
-	if err == nil {
-		return true
+	// A transport only counts for the direct-route downgrade if it is still
+	// OPEN. Previously this checked existence only; a closed/stale transport
+	// would still downgrade MinHops to 1, so the route-finder would hand back a
+	// 1-hop route over a dead direct transport that then fails setup. That is
+	// the stale-direct path that made `cli route trace` (default min-hops 1)
+	// report a direct route the live dial path would skip.
+	for _, netType := range []types.Type{types.STCPR, types.SUDPH, types.DMSG} {
+		if tp, err := r.tm.GetTransport(rPK, netType); err == nil && !tp.IsClosed() {
+			return true
+		}
 	}
-	// check sudph transport if exist
-	_, err = r.tm.GetTransport(rPK, types.SUDPH)
-	if err == nil {
-		return true
-	}
-	// check dmsg transport if exist
-	_, err = r.tm.GetTransport(rPK, types.DMSG)
-	return err == nil
+	return false
 }
 
 // DialHook returns the routing-policy hook installed via


### PR DESCRIPTION
## Problem
`router.isTpdExist()` decides whether a direct transport exists to the destination; if so, the dial's `MinHops` is downgraded to 1 (`router_dial.go`) so the route-finder may return a direct 1-hop route. But the check only tested **existence**, not whether the transport was still **open**:

```go
_, err := r.tm.GetTransport(rPK, types.STCPR)
if err == nil { return true }   // true even for a CLOSED transport
```

A closed/stale direct transport therefore still triggered the downgrade → the route-finder hands back a 1-hop route over a dead transport that then **fails setup**.

This is also the **stale-direct discrepancy** operators reported between `cli route trace` (defaults to `--min 1`, so it surfaces the dead direct route) and the live dial path (which skips it) — surfaced during a route-measurement campaign where multi-hop setups were failing.

## Fix
Gate each transport on `!tp.IsClosed()`, so a closed transport no longer counts toward the direct-route downgrade:

```go
for _, netType := range []types.Type{types.STCPR, types.SUDPH, types.DMSG} {
    if tp, err := r.tm.GetTransport(rPK, netType); err == nil && !tp.IsClosed() {
        return true
    }
}
return false
```

`GetTransport` already returns the `*ManagedTransport`; `IsClosed()` already exists. Behavior is unchanged for open transports.

## Test
- `go test ./pkg/router/` green (incl. the dial / min-hops / mux suites).
- `go vet` + `golangci-lint` clean.
- Full-router unit construction isn't feasible here (matching the package's existing convention of logic-mirror / live-suite tests), so the closed-transport path is best confirmed in the live dial suite.