### PR TITLE
fix(tpd): never attribute bandwidth to the zero PubKey (null-PK orphans + ghost /metrics)

### DIFF
--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -352,6 +352,15 @@ func (a *Aggregator) handleRootFilled(r *registry.Root) {
 		return
 	}
 	reporter := cipher.PubKey(r.Pub)
+	// A root with no publisher identity can't be attributed to a visor.
+	// Dispatching it would write bandwidth under the zero PubKey — the
+	// "0000…:sent" per-edge fields and the zero-PK per-visor key that became
+	// the null-PK orphan transports and the ghost-attributed bandwidth in
+	// /metrics. Drop it rather than mis-attribute.
+	if reporter == (cipher.PubKey{}) {
+		a.log.Debug("CXO aggregator: dropping root with zero publisher PK")
+		return
+	}
 	a.walkAndDispatch(pack, &rootNode, "", reporter)
 }
 

--- a/pkg/transport-discovery/store/redis_bandwidth.go
+++ b/pkg/transport-discovery/store/redis_bandwidth.go
@@ -46,6 +46,16 @@ func (s *redisStore) visorAllKey() string {
 func (s *redisStore) UpdateBandwidth(ctx context.Context, transportID string,
 	reporterPK cipher.PubKey, currentSent, currentRecv uint64) error {
 
+	// Never attribute bandwidth to the zero PubKey. A zero reporter would
+	// write "0000…:sent"/"0000…:recv" fields into the per-transport daily hash
+	// (later read back by recoverBandwidthEdges as a null transport edge) and a
+	// zero-PK per-visor daily key — the source of the null-PK orphan transports
+	// and the ghost-attributed bandwidth seen in /metrics. Defense-in-depth
+	// alongside the aggregator's zero-publisher gate.
+	if reporterPK == (cipher.PubKey{}) {
+		return nil
+	}
+
 	now := time.Now().UTC()
 	reporterHex := reporterPK.Hex()
 


### PR DESCRIPTION
## Problem
Operators found TPD `/metrics` carrying thousands of **orphan** transport records with a zero second edge (`edges[1]=0x00…0`, `type=""`, `live=false`), and a large amount of bandwidth **ghost-attributed to the zero PubKey** in per-visor aggregation (~GBs, inflating per-visor totals → reward distortion).

## Root cause
The CXO aggregator dispatches every root with `reporter = cipher.PubKey(r.Pub)` (the root's publisher key). If a root arrives with **no publisher identity**, `reporter` is the zero PubKey. `UpdateBandwidth` then writes, keyed on that zero reporter:

- `"0000…:sent"` / `"0000…:recv"` fields into the per-transport daily hash — which `recoverBandwidthEdges` (the offline-history reconstruction from #2966) later parses back into a **null transport edge** → the null-PK orphan entries; and
- a **zero-PK per-visor daily key** → the ghost-attributed bandwidth.

So one zero-reporter source produces *both* symptoms.

## Fix (defense-in-depth, two layers)
1. **`aggregator.handleRootFilled`** — drop a root whose publisher PK is zero; it can't be attributed to any visor, so dispatching it can only mis-attribute.
2. **`store.UpdateBandwidth`** — reject a zero reporter PK at the write chokepoint, so no per-edge/per-visor bandwidth is ever written under the zero key regardless of caller.

Existing entries age out via the 35-day bw TTL once the source stops writing.

## Notes / scope
- The per-transport **heartbeat/timeline** dispatch path intentionally tolerates a zero reporter (it's per-transport, not per-visor) — see `TestDispatchLeafHeartbeatGate`. This change only gates the per-visor/per-edge **bandwidth** write, so those tests are unaffected.
- A follow-up is warranted on *why* a root can carry a zero publisher PK at all (the visor CXO publisher ↔ TPD CXO subscriber auto-subscribe wiring) — investigating separately.

## Test
- `go build ./pkg/transport-discovery/...`, `go vet`, `golangci-lint` clean.
- `go test ./pkg/transport-discovery/store/ ./pkg/transport-discovery/cxoaggregator/` green.