### PR TITLE
fix(cxo): bind a received Root's Pub to its authenticated feed

### DIFF
--- a/pkg/cxo/skyobject/index.go
+++ b/pkg/cxo/skyobject/index.go
@@ -254,17 +254,29 @@ func (i *Index) receivedRoot(
 
 	var hash = cipher.SumSHA256(val)
 	if err = cipher.VerifyPubKeySignedHash(pk, sig, hash); err != nil {
-		return
+		return r, err
 	}
 
 	if r, err = registry.DecodeRoot(val); err != nil {
-		return
+		return r, err
+	}
+
+	// The signature above authenticates `val` against `pk` — the feed the Root
+	// actually arrived on. But every downstream consumer (feed routing, index
+	// keying, OnRootFilled, and TPD's reward/bandwidth attribution) keys on the
+	// *decoded* r.Pub, which the publisher serialized into the value and which
+	// the signature does NOT bind. A Root signed by a real feed but carrying a
+	// mismatched (or zero) Pub would therefore be attributed to the wrong — or
+	// to no — visor. Reject any such Root so the attribution key is provably the
+	// authenticated feed.
+	if r.Pub != pk {
+		return nil, fmt.Errorf("root pub %s does not match authenticated feed %s", r.Pub.Hex(), pk.Hex())
 	}
 
 	r.Hash = hash // set the hash
 	r.Sig = sig   // set the signature
 
-	return
+	return r, nil
 }
 
 // PreviewRoot method used by node package to check


### PR DESCRIPTION
## Problem (root cause behind the TPD null-PK / ghost-bandwidth class)
`Index.receivedRoot()` (`pkg/cxo/skyobject/index.go`) verifies a Root's signature against `pk` — the feed the Root arrived on — then returns the **decoded** `registry.Root` whose `Pub` field is whatever the publisher serialized into the value. The signature does **not** cover the decoded `Pub`, yet everything downstream keys on it:

- feed routing — `handleReceivedRoot` → `n.fs[r.Pub]`
- index keying — `addRoot` → `i.feeds[r.Pub]`
- `OnRootFilled` (the filled Root object is the decoded one)
- **TPD CXO aggregator reward/bandwidth attribution** — `reporter = cipher.PubKey(r.Pub)`

So a Root **signed by a real visor feed but carrying a mismatched or zero `Pub`** is attributed to the wrong visor — or to the zero PubKey, which is the upstream source of the null-PK orphan transports and ghost-attributed bandwidth seen in TPD `/metrics` (mitigated downstream in #2971, fixed at the source here). Existing node-level guards drop the *all-zero* case pre-fill, but a **non-zero wrong** `Pub` slips through.

## Fix
After decoding, reject any Root whose `Pub != pk`:

```go
if r.Pub != pk {
    return nil, fmt.Errorf("root pub %s does not match authenticated feed %s", r.Pub.Hex(), pk.Hex())
}
```

This makes the attribution key provably equal to the feed the signature authenticates. (Also converted the function's pre-existing naked returns to explicit ones to satisfy `nakedret` after the added lines.)

## Why this is safe
Well-formed publishers always set `Pub == feed`: the visor's CXO publisher is built with identity == feed == visor PK, and always emits `Pub = visor PK`. So only **malformed / mis-attributed** Roots are rejected.

## Blast radius / release
Shared CXO core — affects every Root reception path (visors, TPD aggregator, the CXO-group feeds). Ships to all of them in the next skywire release. Verified:
- `go build ./...` clean.
- `go test ./pkg/cxo/skyobject/ ./pkg/cxo/node/ ./pkg/cxo/treestore/` green (well-formed roots unaffected).
- `go vet` + `golangci-lint` clean.

## Context
Found via an audit of the visor-publisher ↔ TPD-subscriber CXO wiring. Companion to #2971 (TPD-side reporter guard) and #2970 (router stale-direct). A follow-up may additionally bind TPD's attribution to the authenticated conn `PeerID()` rather than the publisher-supplied `Pub`, and give the aggregator node a stable identity.