### PR TITLE
fix(rewards/server): credit single-edge-reported transports in the stats summary

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/stats.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats.go
@@ -1398,7 +1398,19 @@ func getTPDNetworkSummary() (*tpdNetworkSummary, error) {
 			summary.LatencyCount++
 		}
 		for _, daily := range m.Daily {
-			if daily.A != nil && daily.B != nil {
+			// Mirror the canonical three-branch trust model used by the reward
+			// bw-collect (cmd/.../rewards/transports.go) and `cli tp metrics`
+			// (verifiedBandwidth): an edge whose record is present but
+			// {sent:0,recv:0} has "not reported yet", NOT "verified zero". Key
+			// on reported-data, not record presence — otherwise a present
+			// {0,0} edge takes the min() branch and zeroes the counterparty's
+			// real bandwidth (e.g. min(0, 986MB)=0), which is exactly why
+			// single-edge-reporting transports showed 0 verified bandwidth here
+			// while the actual reward calc credited them.
+			aReported := daily.A != nil && (daily.A.Sent > 0 || daily.A.Recv > 0)
+			bReported := daily.B != nil && (daily.B.Sent > 0 || daily.B.Recv > 0)
+			switch {
+			case aReported && bReported:
 				aToB := daily.A.Sent
 				if daily.B.Recv < aToB {
 					aToB = daily.B.Recv
@@ -1408,9 +1420,9 @@ func getTPDNetworkSummary() (*tpdNetworkSummary, error) {
 					bToA = daily.B.Sent
 				}
 				summary.TotalBandwidth += aToB + bToA
-			} else if daily.A != nil {
+			case aReported:
 				summary.TotalBandwidth += daily.A.Sent + daily.A.Recv
-			} else if daily.B != nil {
+			case bReported:
 				summary.TotalBandwidth += daily.B.Sent + daily.B.Recv
 			}
 		}


### PR DESCRIPTION
## Problem
The reward-server dashboard's verified `TotalBandwidth` (`cmd/skywire-cli/commands/rewards/server/stats.go`) branched on record **presence**:

```go
if daily.A != nil && daily.B != nil {
    // min(A.Sent, B.Recv) + min(A.Recv, B.Sent)   <-- AND-gated min
} else if daily.A != nil { ... } else if daily.B != nil { ... }
```

But edges re-register on different schedules, so at any given moment usually only **one** side has a fresh non-empty daily record; the other side's record is often present but `{sent:0, recv:0}`. With both records present, this took the `min()` branch: `min(A.Sent=0, B.Recv=986MB) = 0`. Result: **every single-edge-reporting transport showed 0 verified bandwidth in the dashboard** — surfaced operator-side as real, demonstrated traffic (e.g. a 986 MB pump) earning **0 verified credit**.

The actual reward **bw-collect** (`cmd/.../rewards/transports.go`) and **`cli tp metrics`** (`verifiedBandwidth`) already handle this correctly with a three-branch trust model that treats a present `{0,0}` edge as "hasn't reported yet" (the #2923 fix). This stats path was the inconsistent one.

## Fix
Gate on **reported data** (`Sent > 0 || Recv > 0`), not record presence, and fall back to single-edge trust — mirroring `verifiedBandwidth`/bw-collect exactly:

```go
aReported := daily.A != nil && (daily.A.Sent > 0 || daily.A.Recv > 0)
bReported := daily.B != nil && (daily.B.Sent > 0 || daily.B.Recv > 0)
switch {
case aReported && bReported: // min-cap both directions
case aReported:              // trust A's counters
case bReported:              // trust B's counters
}
```

## Scope
Only the verified `summary.TotalBandwidth` block. The sibling chart aggregations in this file sum both edges as gross totals (a separate display concern) and are unchanged. TPD-service/dashboard side — applies on redeploy.

## Test
`go build ./cmd/skywire-cli/...`, `go vet`, `golangci-lint` clean.