### PR TITLE
fix(dmsg/disc): don't HTTP-fallback on dmsg 202 "cannot connect to delegated server"

### DIFF
--- a/pkg/dmsg/disc/dmsgfirst/client.go
+++ b/pkg/dmsg/disc/dmsgfirst/client.go
@@ -145,6 +145,18 @@ func shouldFallback(err error) bool {
 	if errors.As(err, &ve) {
 		return false
 	}
+	// A dmsg "cannot connect to delegated server" (dmsg error 202) is a
+	// transient per-server session-overlap failure reaching the discovery
+	// over dmsg — not a sign the discovery endpoint is down. An HTTP fallback
+	// can't fix the underlying dmsg reachability; it just adds a doomed
+	// roundtrip and a WARN per refresh. Don't fall back — let the caller retry
+	// over dmsg on its next refresh (discovery refresh / re-registration is
+	// periodic, so a transient 202 self-heals once sessions realign). Matched
+	// on the message because the typed sentinel is wrapped by the dmsghttp
+	// RoundTrip's *url.Error before it reaches here.
+	if strings.Contains(err.Error(), "cannot connect to delegated server") {
+		return false
+	}
 	// net.Error timeout / temporary — fall back.
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {

--- a/pkg/dmsg/disc/dmsgfirst/client_test.go
+++ b/pkg/dmsg/disc/dmsgfirst/client_test.go
@@ -110,6 +110,13 @@ func TestShouldFallback(t *testing.T) {
 		{"no such host", errors.New("dial tcp: lookup x: no such host"), true},
 		{"context deadline exceeded", context.DeadlineExceeded, true},
 
+		// dmsg "cannot connect to delegated server" (error 202) — a
+		// transient dmsg reachability problem, not a dead discovery
+		// endpoint. Must NOT fall back even though the production form is
+		// wrapped in a *url.Error (so it would otherwise hit that branch).
+		{"dmsg 202 raw", errors.New("dmsg error 202 - cannot connect to delegated server"), false},
+		{"dmsg 202 wrapped in url.Error", &url.Error{Op: "Get", URL: "http://pk:80/dmsg-discovery/entry/x", Err: errors.New("dmsg error 202 - cannot connect to delegated server")}, false},
+
 		// Random unrelated error — DON'T fallback (we can't tell if
 		// it's authoritative or transport, so prefer to surface it).
 		{"random", errors.New("totally unrelated bug"), false},


### PR DESCRIPTION
## Problem
The dmsg-first discovery client (`pkg/dmsg/disc/dmsgfirst`) falls back to plain HTTP whenever the DMSG-primary leg returns a transport-class error (`shouldFallback`). The primary is HTTP-*over*-dmsg, so a `dmsg error 202 - cannot connect to delegated server` surfaces wrapped in a `*url.Error` (`Get "http://<disc-pk>:80/…": dmsg error 202 …`) → it matched the generic `url.Error` branch → **every transient 202 triggered a doomed HTTP fallback plus a `WARN` per discovery refresh**:

```
WARN [dmsg]: disc Entry: DMSG primary failed; trying HTTP fallback error="… dmsg error 202 - cannot connect to delegated server"
```

A `202` is a *transient per-server session-overlap* failure reaching the discovery over dmsg (the visor's `dmsgDC` momentarily shares no server with dmsg-disc). It is **not** a sign the discovery endpoint is down, and the HTTP fallback can't fix the underlying dmsg reachability — it just adds a roundtrip and log noise, and silently degrades a dmsg-first deployment to HTTP on a recoverable blip.

## Fix
Treat `cannot connect to delegated server` as **non-fallback** in `shouldFallback` (placed before the `url.Error` catch-all). The dmsg client re-refreshes discovery / re-registers periodically, so a transient 202 self-heals once sessions realign. Matched on the message because the typed `dmsg.ErrCannotConnectToDelegated` sentinel is wrapped by the dmsghttp `RoundTrip`'s `*url.Error` before it reaches here (consistent with the existing string-based classifications in this function).

## Test
`TestShouldFallback` extended with the raw and the production `url.Error`-wrapped 202 forms (both must return `false`). `go test ./pkg/dmsg/disc/dmsgfirst/` green; `go vet` + `golangci-lint` clean.

## Context
Found while verifying "no HTTP fallback" on the running visor (a transient 202 from a briefly-unreachable dmsg server was driving repeated fallbacks). The live occurrence cleared on a restart once the server was reachable again; this guard prevents the doomed fallback recurring on the next blip.