### PR TITLE
fix(router): stop one hop's failure from RST-ing the whole route (setup cascade)

### DIFF
--- a/pkg/router/id_reserver.go
+++ b/pkg/router/id_reserver.go
@@ -110,13 +110,23 @@ func (idr *idReserver) ReserveIDs(ctx context.Context) error {
 		go func(pk cipher.PubKey, n uint8) {
 			client := idr.rcM.Client(pk)
 			if client == nil {
-				cancel()
+				// NOTE: deliberately do NOT cancel the shared ctx on a single
+				// hop's failure. cancel() here propagated to every sibling
+				// goroutine still blocked in client.ReserveIDs(ctx); their
+				// Client.call() reacts to ctx.Done() by closing the underlying
+				// (pooled) DMSG stream — RST-ing perfectly healthy
+				// intermediates mid-reservation and turning one hop's blip into
+				// a whole-route setup failure (the "RST race" that made
+				// multi-hop / mux route setup fail at a high rate). Each hop is
+				// independently bounded by its own per-call rpcDeadline, and
+				// firstError below already waits for all N goroutines and
+				// returns the first error — so a genuinely dead hop still fails
+				// the route, without resetting the healthy hops.
 				errCh <- fmt.Errorf("reserve routeID from %s failed: no client available", pk)
 				return
 			}
 			rtIDs, err := client.ReserveIDs(ctx, n)
 			if err != nil {
-				cancel()
 				errCh <- fmt.Errorf("reserve routeID from %s failed: %w", pk, err)
 				return
 			}

--- a/pkg/router/id_reserver_test.go
+++ b/pkg/router/id_reserver_test.go
@@ -235,3 +235,49 @@ func checkIDReserver(t *testing.T, rtIDR *idReserver) {
 		assert.Len(t, idMap, len(ids))
 	}
 }
+
+// errReserveGateway is a mock router RPCGateway whose ReserveIDs always fails.
+type errReserveGateway struct{}
+
+func (errReserveGateway) ReserveIDs(_ uint8, _ *[]routing.RouteID) error {
+	return errors.New("mock: reserve failed")
+}
+
+// TestIdReserver_ReserveIDs_NoSiblingCancelOnFailure is a regression test for the
+// route-setup "RST race": one hop's reservation failure must NOT cancel the
+// shared context, because that tore down the (pooled) DMSG streams of the other
+// in-flight hops mid-call, RST-ing healthy intermediates and failing the whole
+// route. Here hop A fails immediately while hop C is slow but healthy; C must
+// still reserve its ID rather than being canceled by A's failure.
+func TestIdReserver_ReserveIDs_NoSiblingCancelOnFailure(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair() // fails fast
+	pkC, _ := cipher.GenerateKeyPair() // slow but healthy
+
+	routers := map[cipher.PubKey]interface{}{
+		pkA: errReserveGateway{},
+		pkC: &mockGatewayForDialer{hangDuration: 150 * time.Millisecond},
+	}
+	dialer := newMockDialer(t, routers)
+
+	rtIDR, err := NewIDReserver(context.TODO(), dialer, nil, [][]routing.Hop{makeHops(pkA, pkC)})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, rtIDR.Close()) })
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
+	defer cancel()
+
+	err = rtIDR.ReserveIDs(ctx)
+
+	// A failed, so the overall reservation returns an error — but it must be
+	// A's reservation error, not a context cancellation that leaked into C.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), context.Canceled.Error())
+
+	// The key assertion: C's reservation completed and was recorded, proving
+	// A's failure did not cancel/RST the healthy sibling.
+	idr := rtIDR.(*idReserver)
+	idr.mx.Lock()
+	cIDs := idr.ids[pkC]
+	idr.mx.Unlock()
+	assert.Len(t, cIDs, 1, "healthy sibling C should reserve its ID despite A failing")
+}

--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -635,10 +635,14 @@ func BroadcastIntermediaryRules(ctx context.Context, log logrus.FieldLogger, rtI
 			return err
 		}
 		go func(pk cipher.PubKey, rules []routing.Rule) {
+			// Same RST-race fix as idReserver.ReserveIDs: do NOT cancel the
+			// shared ctx when one intermediary's AddIntermediaryRules fails —
+			// that propagated to every sibling goroutine, whose Client.call()
+			// closed the underlying pooled DMSG stream on ctx.Done(), RST-ing
+			// healthy intermediaries mid-broadcast and leaving a half-installed
+			// route. firstError below waits for all N and returns the first
+			// error; each call is bounded by its own per-call rpcDeadline.
 			_, err := rtIDR.Client(pk).AddIntermediaryRules(ctx, rules)
-			if err != nil {
-				cancel()
-			}
 			errCh <- err
 		}(pk, rules)
 	}


### PR DESCRIPTION
## Problem
Multi-hop / multiplexed route **setup** fails at a high rate (operators observed a "~96% per-route setup RST race"). Root cause is a **cascading cancel** in the reservation fan-out:

- `idReserver.ReserveIDs` (`pkg/router/id_reserver.go`) spawns one goroutine per hop sharing a single `context.WithCancel`, and calls `cancel()` on the **first** hop's error.
- Every sibling goroutine is still blocked in `client.ReserveIDs(ctx)` → `Client.call()`, which on `ctx.Done()` calls **`c.rpc.Close()`** — tearing down that hop's underlying **pooled DMSG stream**.
- So one hop's transient blip **RSTs the in-flight reservations of every other (healthy) hop** in the same route → the whole route fails. `BroadcastIntermediaryRules` (`setupnode.go`) has the identical anti-pattern for `AddIntermediaryRules`, additionally leaving a half-installed route.

This was confirmed from code; mux-leg cross-sharing was **ruled out** (legs dial fresh clients; `ClientPool.Get` deletes-on-borrow) — the cascade is **intra-route**.

## Fix
Remove the sibling-canceling `cancel()` in both `ReserveIDs` and `BroadcastIntermediaryRules`. This is safe because:
- each hop's call is **already bounded** by its own per-call `rpcDeadline` (30s), so a genuinely dead hop still fails on its own;
- `firstError()` **already waits for all N** goroutines and returns the first error.

So a real dead hop still fails the route — without resetting the healthy hops. **Trade-off:** a dead hop now waits up to its per-call deadline instead of short-circuiting siblings (well within the route-setup handler timeout). This is what lets mux K-of-N actually reach K.

## Test
`TestIdReserver_ReserveIDs_NoSiblingCancelOnFailure`: hop A fails fast while a slow-but-healthy hop C must still reserve its ID (pre-fix the cascade canceled C). Passes; full `go test ./pkg/router/` green; `go vet` + `golangci-lint` clean.

## Follow-ups (separate PRs)
Per the investigation: (3) on error, discard only the broken pooled conn rather than the whole route's map; (4) bounded per-hop retry on transient reservation failure; (5) explicit ≥K-of-N mux success criterion. This PR is the highest-leverage single change.