### PR TITLE
fix(router): guard ClosePacket panic, double-close, reverse-rule leak, MinHops race

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -140,7 +140,8 @@ type RouteGroup struct {
 	// "WaitGroup reused before previous Wait returned" panics.
 	closeDonePending int32         // atomic counter of outstanding close acks
 	closeDoneCh      chan struct{} // closed when closeDonePending reaches 0
-	once             sync.Once
+	once             sync.Once     // guards the readCh/remoteClosed cleanup
+	closedOnce       sync.Once     // guards close(rg.closed) — closable from two paths
 
 	errorMu    sync.RWMutex
 	closeError error
@@ -348,8 +349,12 @@ func (rg *RouteGroup) Close() error {
 
 	if rg.isRemoteClosed() {
 		// remote already closed, everything is cleaned up,
-		// we just need to close signal channel at this point
-		close(rg.closed)
+		// we just need to close signal channel at this point.
+		// Guard with closedOnce: two concurrent Close() callers (e.g. an
+		// app-level Close and the GC's removeRouteGroupOfRule->Close) can both
+		// pass the isClosed() gate in the window before the channel is closed,
+		// and a bare close() here would panic with "close of closed channel".
+		rg.closedOnce.Do(func() { close(rg.closed) })
 		return nil
 	}
 
@@ -1250,17 +1255,25 @@ func (rg *RouteGroup) close(code routing.CloseCode) error {
 		}
 	}
 
-	rules := make([]routing.RouteID, 0, len(rg.fwd))
+	rules := make([]routing.RouteID, 0, len(rg.fwd)+len(rg.rvs))
 	for _, r := range rg.fwd {
+		rules = append(rules, r.KeyRouteID())
+	}
+	// Also delete the reverse/consume rules. Without this they linger in the
+	// routing table until the keep-alive GC reaps them, leaking N stale rules
+	// per close (N legs for a mux group) and opening the window where a packet
+	// resolves the orphaned consume rule but finds no route group
+	// (errRouteDescNotExist log-spam).
+	for _, r := range rg.rvs {
 		rules = append(rules, r.KeyRouteID())
 	}
 
 	rg.rt.DelRules(rules)
 
+	if closeInitiator {
+		rg.closedOnce.Do(func() { close(rg.closed) })
+	}
 	rg.once.Do(func() {
-		if closeInitiator {
-			close(rg.closed)
-		}
 		rg.setRemoteClosed()
 		close(rg.readCh)
 	})
@@ -1271,7 +1284,11 @@ func (rg *RouteGroup) close(code routing.CloseCode) error {
 func (rg *RouteGroup) handlePacket(packet routing.Packet) error {
 	switch packet.Type() {
 	case routing.ClosePacket:
-		return rg.handleClosePacket(routing.CloseCode(packet.Payload()[0]))
+		closeCode, err := closeCodeFromPacket(packet)
+		if err != nil {
+			return err
+		}
+		return rg.handleClosePacket(closeCode)
 	case routing.DataPacket:
 		rg.handshakeProcessedOnce.Do(func() {
 			// first packet is data packet, so we're communicating with the old visor

--- a/pkg/router/route_group_audit_fixes_test.go
+++ b/pkg/router/route_group_audit_fixes_test.go
@@ -1,0 +1,89 @@
+package router
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// makeRawClosePacket builds a ClosePacket with an arbitrary (possibly empty)
+// payload, bypassing routing.MakeClosePacket which always appends a code byte.
+// A remote peer fully controls the on-wire payload length, so this models the
+// hostile/corrupted input.
+func makeRawClosePacket(id routing.RouteID, payload []byte) routing.Packet {
+	p := make(routing.Packet, routing.PacketHeaderSize+len(payload))
+	p[routing.PacketTypeOffset] = byte(routing.ClosePacket)
+	binary.BigEndian.PutUint32(p[routing.PacketRouteIDOffset:], uint32(id))
+	binary.BigEndian.PutUint16(p[routing.PacketPayloadSizeOffset:], uint16(len(payload))) //nolint:gosec
+	copy(p[routing.PacketPayloadOffset:], payload)
+	return p
+}
+
+// TestHandlePacket_EmptyClosePayload_NoPanic is a regression test: a peer can
+// send a ClosePacket with a zero-length payload; indexing Payload()[0] blindly
+// panicked the router read loop (no recover) and took down all routing. The
+// handler must now return an error instead.
+func TestHandlePacket_EmptyClosePayload_NoPanic(t *testing.T) {
+	rg := createRouteGroup(DefaultRouteGroupConfig())
+
+	pkt := makeRawClosePacket(1, nil)
+	require.Len(t, pkt, routing.PacketHeaderSize)
+	require.Equal(t, routing.ClosePacket, pkt.Type())
+	require.Empty(t, pkt.Payload())
+
+	var err error
+	require.NotPanics(t, func() { err = rg.handlePacket(pkt) })
+	require.ErrorIs(t, err, errMalformedClosePacket)
+}
+
+// TestClose_ConcurrentRemoteClosed_NoPanic is a regression test for the
+// double-close panic: when the remote already closed, two concurrent Close()
+// callers could both pass the isClosed() gate and both close(rg.closed) ->
+// "close of closed channel". closedOnce must serialize it.
+func TestClose_ConcurrentRemoteClosed_NoPanic(t *testing.T) {
+	rg := createRouteGroup(DefaultRouteGroupConfig())
+	rg.setRemoteClosed() // make the isRemoteClosed() early-return path fire
+
+	const n = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			require.NotPanics(t, func() { rg.Close() }) //nolint:errcheck,gosec
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.True(t, rg.isClosed(), "rg.closed must be closed after Close()")
+}
+
+// TestClose_DeletesReverseRules is a regression test: close() previously deleted
+// only forward rules, leaking the reverse/consume rules until the keep-alive GC
+// reaped them. Both must be removed from the routing table on Close().
+func TestClose_DeletesReverseRules(t *testing.T) {
+	rg, _ := createTestRouteGroupWithBlockingTransport(t) // sets matching fwd+tps
+
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	rvsRule := routing.ConsumeRule(DefaultRouteKeepAlive, 3, pk2, pk1, 2, 1)
+	require.NoError(t, rg.rt.SaveRule(rvsRule))
+	require.Equal(t, 2, rg.rt.Count()) // 1 fwd (from helper) + 1 reverse
+
+	rg.mu.Lock()
+	rg.rvs = []routing.Rule{rvsRule}
+	rg.mu.Unlock()
+
+	require.NoError(t, rg.Close())
+
+	assert.Equal(t, 0, rg.rt.Count(), "both forward and reverse rules must be deleted on close")
+}

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -96,13 +96,20 @@ func (r *router) DialRoutes(
 	// direct transport when one happens to exist would defeat the constraint
 	// (this was the symptom of `mux-bw --min-hops 2` riding direct stcpr
 	// instead of going via intermediates).
-	defaultMinHops := r.conf.MinHops
+	// baseMinHops is a LOCAL effective min-hops for this dial. We must NOT
+	// mutate the shared r.conf.MinHops here: DialRoutes runs concurrently per
+	// app dial, so writing the field both races other in-flight dials and —
+	// because the old restore only ran on the success path while 7 early
+	// `return nil, err` sit between mutation and restore — would permanently
+	// pin the visor-global MinHops to 1 after the first failed dial, silently
+	// disabling the operator's min-hops policy for every subsequent dial.
+	baseMinHops := r.conf.MinHops
 	// Suppress the direct-tp downgrade when ANY min-hops constraint is
 	// set (symmetric or per-direction). Even if only ReverseMinHops > 1,
 	// downgrading globally to 1 would defeat that constraint for the
 	// reverse direction's route-finder query below.
 	if r.isTpdExist(rPK) && !opts.AnyMinHopsConstraint() {
-		r.conf.MinHops = 1
+		baseMinHops = 1
 	}
 
 	// Check if existing transport only mode is set on the router
@@ -113,7 +120,7 @@ func (r *router) DialRoutes(
 	// Only run route setup hooks (which may create new transports) if UseExistingTpOnly is false
 	// on both the router level and the dial options level
 	useExistingOnly := routerExistingTpOnly || (opts != nil && opts.UseExistingTpOnly)
-	if r.conf.MinHops == 1 && !useExistingOnly {
+	if baseMinHops == 1 && !useExistingOnly {
 		r.routeSetupHookMu.Lock()
 		if len(r.routeSetupHooks) != 0 {
 			for _, rsf := range r.routeSetupHooks {
@@ -148,7 +155,7 @@ func (r *router) DialRoutes(
 		maxFetchAttempts = 1
 	}
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
+		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts, baseMinHops)
 		if err != nil {
 			if attempt < maxFetchAttempts {
 				log.WithError(err).Warnf("Route finder failed (attempt %d/%d), retrying with fresh query...", attempt, maxRetries)
@@ -312,10 +319,8 @@ func (r *router) DialRoutes(
 			nrg.rg.SetRotation(rh, applyAdd, interval)
 		}
 
-		// reset MinHops default value if changed before
-		if defaultMinHops != 1 {
-			r.conf.MinHops = defaultMinHops
-		}
+		// NOTE: no MinHops restore needed — baseMinHops is a local var now,
+		// r.conf.MinHops is never mutated by the dial path.
 
 		return nrg, nil
 	}
@@ -499,7 +504,8 @@ func (r *router) PingRoute(
 	}
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts)
+		// PingRoute has no direct-tp downgrade; use the visor-global base.
+		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts, r.conf.MinHops)
 		if err != nil {
 			if pingForceLocal {
 				lastErr = fmt.Errorf("local route calc: %w", err)
@@ -539,7 +545,12 @@ func (r *router) PingRoute(
 	return nil, fmt.Errorf("failed to establish ping route after %d attempts: %w", maxRetries, lastErr)
 }
 
-func (r *router) fetchBestRoutes(ctx context.Context, log *logging.Logger, src, dst cipher.PubKey, opts *DialOptions) (fwd, rev []routing.Hop, err error) {
+// baseMinHops is the per-dial base min-hops to use when opts carries no
+// per-call / per-direction override. The caller (DialRoutes) computes it as a
+// LOCAL value — applying the direct-transport downgrade there rather than
+// mutating the shared r.conf.MinHops, which used to race across concurrent
+// dials and permanently lose the constraint on any early-return error path.
+func (r *router) fetchBestRoutes(ctx context.Context, log *logging.Logger, src, dst cipher.PubKey, opts *DialOptions, baseMinHops uint16) (fwd, rev []routing.Hop, err error) {
 	if log == nil {
 		log = r.logger
 	}
@@ -593,8 +604,8 @@ fetchRoutesAgain:
 	// asymmetric constraints can't be expressed in one round-trip.
 	fwdEff := opts.EffectiveMinHops(true)
 	revEff := opts.EffectiveMinHops(false)
-	fwdMinHops := r.conf.MinHops
-	revMinHops := r.conf.MinHops
+	fwdMinHops := baseMinHops
+	revMinHops := baseMinHops
 	if fwdEff > 0 {
 		fwdMinHops = uint16(fwdEff) //nolint:gosec // bounded by caller; CLI flag values are small
 	}
@@ -1686,7 +1697,7 @@ func (r *router) establishMuxRoutes(
 			ExcludeDMSG:            true,
 		}
 
-		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts)
+		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
 		if err != nil {
 			log.Debugf("Mux route %d/%d: route-finder returned no path: %v — trying local-calc fallback",
 				i+1, maxCount, err)
@@ -1831,7 +1842,7 @@ func (r *router) addOneAuxForwardLeg(ctx context.Context, nrg *NoiseRouteGroup, 
 		ExcludeDMSG:            true,
 	}
 
-	muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts)
+	muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
 	if err != nil {
 		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
 		if localErr != nil {

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -12,10 +12,24 @@ import (
 )
 
 var (
-	errRouteDescNotExist = errors.New("route descriptor does not exist")
-	errNilNoiseRG        = errors.New("noiseRouteGroup is nil")
-	errNilInitRG         = errors.New("initializing RouteGroup is nil")
+	errRouteDescNotExist    = errors.New("route descriptor does not exist")
+	errNilNoiseRG           = errors.New("noiseRouteGroup is nil")
+	errNilInitRG            = errors.New("initializing RouteGroup is nil")
+	errMalformedClosePacket = errors.New("close packet has empty payload")
 )
+
+// closeCodeFromPacket safely extracts the close code from a ClosePacket. A
+// remote peer fully controls the on-wire payload length (managedTransport reads
+// exactly the declared size), so a malformed/zero-length close payload must not
+// be indexed blindly — doing so panics the router read loop, which has no
+// recover and would take down all routing on the visor.
+func closeCodeFromPacket(packet routing.Packet) (routing.CloseCode, error) {
+	payload := packet.Payload()
+	if len(payload) == 0 {
+		return 0, errMalformedClosePacket
+	}
+	return routing.CloseCode(payload[0]), nil
+}
 
 func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packet) error {
 	switch packet.Type() {
@@ -116,7 +130,10 @@ func (r *router) handleClosePacket(ctx context.Context, packet routing.Packet) e
 		return errNilNoiseRG
 	}
 
-	closeCode := routing.CloseCode(packet.Payload()[0])
+	closeCode, err := closeCodeFromPacket(packet)
+	if err != nil {
+		return err
+	}
 
 	if nrg.isClosed() {
 		return io.ErrClosedPipe
@@ -210,7 +227,11 @@ func (r *router) forwardPacket(ctx context.Context, packet routing.Packet, rule 
 	case routing.KeepAlivePacket:
 		p = routing.MakeKeepAlivePacket(rule.NextRouteID())
 	case routing.ClosePacket:
-		p = routing.MakeClosePacket(rule.NextRouteID(), routing.CloseCode(packet.Payload()[0]))
+		closeCode, err := closeCodeFromPacket(packet)
+		if err != nil {
+			return err
+		}
+		p = routing.MakeClosePacket(rule.NextRouteID(), closeCode)
 	case routing.PingPacket:
 		timestamp := int64(binary.BigEndian.Uint64(packet[routing.PacketPayloadOffset:]))    //nolint:gosec
 		throughput := int64(binary.BigEndian.Uint64(packet[routing.PacketPayloadOffset+8:])) //nolint:gosec


### PR DESCRIPTION
Four confirmed bugs surfaced by a read-only audit of the routing subsystem (each reproduced from code; regression tests for 1–3 run under `-race`).

### 1. [crash — remotely triggerable] Malformed `ClosePacket` panics the router read loop
A peer fully controls the on-wire payload length (`managedTransport.readPacket` reads exactly the declared size). A `ClosePacket` with a zero-length payload made `routing.CloseCode(packet.Payload()[0])` index out of range. The serve path has no `recover()`, so the panic killed `serveTransportManager` and took down **all** routing on the visor. Three unguarded sites (`handleClosePacket`, `forwardPacket`, `RouteGroup.handlePacket`) now go through a `closeCodeFromPacket()` helper that returns `errMalformedClosePacket` instead of indexing blindly.

### 2. [crash] Double-close panic on `rg.closed`
`RouteGroup.Close()`'s remote-already-closed early-return closed `rg.closed` directly (not via `sync.Once`). Two concurrent `Close()` callers (app-level + the GC's `removeRouteGroupOfRule`) could both pass the `isClosed()` gate and double-close → `panic: close of closed channel`. `rg.closed` now has its own `closedOnce`; `rg.once` is left for the `readCh`/`remoteClosed` cleanup it co-guards (reusing it here would have consumed the once and skipped that cleanup).

### 3. [leak] Reverse/consume rules not deleted on close
`close()` built its `DelRules` set from `rg.fwd` only; the reverse rules (`rg.rvs`) lingered until the keep-alive GC reaped them — N stale rules per mux-group close, and the window that produces `route descriptor does not exist` log-spam. Reverse-rule IDs are now deleted too.

### 4. [data race + silent policy loss] Shared `r.conf.MinHops` mutation in `DialRoutes`
`DialRoutes` wrote `r.conf.MinHops = 1` for the direct-transport downgrade and only restored it on the **success** path — with 7 early `return nil, err` in between. Concurrent dials raced the field, and any failed dial that took the downgrade left the visor-global `MinHops` pinned at 1 forever, silently disabling the operator's min-hops policy for every later dial. Fixed by computing a **local** `baseMinHops` and threading it into `fetchBestRoutes`; the shared field is no longer written by the dial path.

Deferred (need careful protocol/API work, tracked separately): SACK/reorder seq-0 off-by-one; selective pooled-connection discard on reserve error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)