### PR TITLE
fix(dmsg): detect zombie yamux sessions via stream-level liveness ping

### DIFF
--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -184,12 +184,52 @@ func (sc *SessionCommon) Ping() (time.Duration, error) {
 	sc.sm.mutx.RLock()
 	defer sc.sm.mutx.RUnlock()
 	if sc.sm.yamux != nil {
-		return sc.sm.yamux.Ping()
+		return sc.yamuxPing()
 	}
 	if sc.sm.smux != nil {
 		return sc.smuxPing()
 	}
 	return 0, fmt.Errorf("no mux session available for ping")
+}
+
+// yamuxPing implements ping over yamux the same way smuxPing does for smux:
+// open a temporary stream, write the ping marker, and wait for the echo.
+//
+// Why NOT yamux.Session.Ping(): that is a yamux *control-frame* keepalive —
+// it round-trips at the mux-control layer over the existing TCP connection
+// and proves only that the client<->server link is alive. It does NOT
+// exercise the server's stream-forwarding path, so it cannot detect a
+// "zombie" session where the control link is healthy but the dmsg server can
+// no longer relay streams to/from us (observed in production: a dial-target
+// service — e.g. a route setup-node behind a Docker bridge — kept advertising
+// 8 "delegated servers" on which 0/8 stream-dials succeeded, while
+// yamux.Ping() reported all 8 alive, so pingSessionsLoop never marked them
+// dead and the node stayed unreachable until a manual restart). Opening a real
+// stream and round-tripping the ping marker through the server's serveStream
+// echo (which handles yamux and smux streams identically) exposes exactly that
+// mismatch, so the existing pingDeadThreshold logic can close + redial the
+// dead session. The smux path already worked this way; this brings yamux to
+// parity.
+func (sc *SessionCommon) yamuxPing() (time.Duration, error) {
+	str, err := sc.sm.yamux.OpenStream()
+	if err != nil {
+		return 0, fmt.Errorf("yamux ping: open stream: %w", err)
+	}
+	defer str.Close() //nolint:errcheck
+
+	if err := str.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return 0, fmt.Errorf("yamux ping: set deadline: %w", err)
+	}
+
+	start := time.Now()
+	if _, err := str.Write(pingMarker); err != nil {
+		return 0, fmt.Errorf("yamux ping: write: %w", err)
+	}
+	resp := make([]byte, 2)
+	if _, err := io.ReadFull(str, resp); err != nil {
+		return 0, fmt.Errorf("yamux ping: read: %w", err)
+	}
+	return time.Since(start), nil
 }
 
 // smuxPing implements ping over smux by opening a temporary stream,

--- a/pkg/dmsg/dmsg/session_ping_test.go
+++ b/pkg/dmsg/dmsg/session_ping_test.go
@@ -1,0 +1,58 @@
+// Package dmsg pkg/dmsg/session_ping_test.go
+package dmsg
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestSessionPing_YamuxStreamRoundTrip verifies that Ping() on a healthy yamux
+// session performs a real stream round-trip (yamuxPing) through the server's
+// serveStream ping-marker echo and returns a positive RTT with no error.
+//
+// Regression guard for the zombie-session bug: the old yamux path used
+// yamux.Session.Ping() (a control-frame keepalive) which reports a session
+// alive even when the server can no longer relay streams to/from us, so
+// pingSessionsLoop never marked half-open sessions dead. The fix routes yamux
+// through a stream round-trip like smux already did. This test also guards the
+// other direction — a HEALTHY yamux session must NOT be false-killed by the new
+// stream-level probe (the server must echo the ping marker for yamux streams).
+func TestSessionPing_YamuxStreamRoundTrip(t *testing.T) {
+	dc := disc.NewMock(0)
+
+	pkSrv, skSrv := GenKeyPair(t, "server")
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: 10, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("server"))
+	lisSrv, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(lisSrv, "") }() //nolint:errcheck
+
+	pkA, skA := GenKeyPair(t, "client A")
+	clientA := NewClient(pkA, skA, dc, DefaultConfig()) // default protocol => yamux
+	clientA.SetLogger(logging.MustGetLogger("client_A"))
+	go clientA.Serve(context.Background())
+	t.Cleanup(func() {
+		_ = clientA.Close() //nolint:errcheck
+		_ = srv.Close()     //nolint:errcheck
+	})
+
+	require.Eventually(t, func() bool {
+		return clientA.SessionCount() > 0
+	}, 10*time.Second, 200*time.Millisecond, "client failed to connect to dmsg server")
+
+	sessions := clientA.allClientSessions(clientA.porter)
+	require.NotEmpty(t, sessions, "expected at least one client session")
+
+	// A healthy yamux session must round-trip the stream-level ping.
+	rtt, err := sessions[0].Ping()
+	require.NoError(t, err, "yamux stream-level ping must succeed on a healthy session")
+	assert.Positive(t, int64(rtt), "ping must report a positive round-trip time")
+}


### PR DESCRIPTION
## Problem

`SessionCommon.Ping()` — called by `pingSessionsLoop`'s dead-session detector — used `yamux.Session.Ping()` for yamux sessions. That's a **control-frame keepalive**: it round-trips at the mux-control layer over the existing TCP connection and proves only that the client↔server link is alive. It does **not** exercise the server's stream-forwarding path.

So a **zombie session** — control link healthy, but the dmsg server can no longer relay streams to/from us — passes the ping forever, never reaches `pingDeadThreshold`, and is never closed/redialed. `pingSessionsLoop`'s own doc comment already said yamux keepalive "does NOT detect the case where our side of the session is healthy but the dmsg server has torn down its view" and claimed an app-level ping covers it — but the yamux path never opened a stream, so the implementation contradicted its comment.

## Production confirmation

Found via live debugging of a route **setup-node** (a dial *sink* — every route setup dials *into* it). Decisive per-server experiment:

- **0/8** stream-dials to the node succeeded ("i/o deadline reached" on every delegated server)
- **8/8** `yamux.Ping()` reported the sessions alive; **0** "Closing dead session" events in 6h
- pprof: 8 active yamux sessions, healthy goroutines, clean ESTAB sockets

All 8 sessions were simultaneously zombie, so zero routable bytes could land — the node stayed unreachable until a manual restart. Dial *sources* (visors) barely notice the same zombies because they route around their own dead sessions when dialing out; a dial sink can't, which is why this bit the setup-node specifically and recurringly.

## Fix

The **smux** path (`smuxPing`) already did the right thing: open a stream, write the ping marker, read the server's echo. This brings **yamux** to parity with `yamuxPing()`, which round-trips through the server's `serveStream` ping-marker echo (which handles yamux and smux streams identically — server_session.go). Now the existing dead-session logic can see and recycle zombie yamux sessions, and the close+reconnect refreshes the discovery entry so the node stops advertising dead servers.

Scope: single site (`SessionCommon.Ping()`), inherited by **every** dmsg client (visors, setup-nodes, transport-setup, embedded RSN, all services) since they share `dmsg.Client`.

## Test

`TestSessionPing_YamuxStreamRoundTrip` spins up a real server + yamux client and asserts `Ping()` returns a positive-RTT stream round-trip — proving the new path works against the server echo and that healthy yamux sessions are not false-killed. Full `pkg/dmsg/dmsg` suite passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)