### PR TITLE
fix(transport): detect half-open links via missed transport pongs (drain ghost transports from TPD)

### DIFF
--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -184,12 +184,52 @@ func (sc *SessionCommon) Ping() (time.Duration, error) {
 	sc.sm.mutx.RLock()
 	defer sc.sm.mutx.RUnlock()
 	if sc.sm.yamux != nil {
-		return sc.sm.yamux.Ping()
+		return sc.yamuxPing()
 	}
 	if sc.sm.smux != nil {
 		return sc.smuxPing()
 	}
 	return 0, fmt.Errorf("no mux session available for ping")
+}
+
+// yamuxPing implements ping over yamux the same way smuxPing does for smux:
+// open a temporary stream, write the ping marker, and wait for the echo.
+//
+// Why NOT yamux.Session.Ping(): that is a yamux *control-frame* keepalive —
+// it round-trips at the mux-control layer over the existing TCP connection
+// and proves only that the client<->server link is alive. It does NOT
+// exercise the server's stream-forwarding path, so it cannot detect a
+// "zombie" session where the control link is healthy but the dmsg server can
+// no longer relay streams to/from us (observed in production: a dial-target
+// service — e.g. a route setup-node behind a Docker bridge — kept advertising
+// 8 "delegated servers" on which 0/8 stream-dials succeeded, while
+// yamux.Ping() reported all 8 alive, so pingSessionsLoop never marked them
+// dead and the node stayed unreachable until a manual restart). Opening a real
+// stream and round-tripping the ping marker through the server's serveStream
+// echo (which handles yamux and smux streams identically) exposes exactly that
+// mismatch, so the existing pingDeadThreshold logic can close + redial the
+// dead session. The smux path already worked this way; this brings yamux to
+// parity.
+func (sc *SessionCommon) yamuxPing() (time.Duration, error) {
+	str, err := sc.sm.yamux.OpenStream()
+	if err != nil {
+		return 0, fmt.Errorf("yamux ping: open stream: %w", err)
+	}
+	defer str.Close() //nolint:errcheck
+
+	if err := str.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return 0, fmt.Errorf("yamux ping: set deadline: %w", err)
+	}
+
+	start := time.Now()
+	if _, err := str.Write(pingMarker); err != nil {
+		return 0, fmt.Errorf("yamux ping: write: %w", err)
+	}
+	resp := make([]byte, 2)
+	if _, err := io.ReadFull(str, resp); err != nil {
+		return 0, fmt.Errorf("yamux ping: read: %w", err)
+	}
+	return time.Since(start), nil
 }
 
 // smuxPing implements ping over smux by opening a temporary stream,

--- a/pkg/dmsg/dmsg/session_ping_test.go
+++ b/pkg/dmsg/dmsg/session_ping_test.go
@@ -1,0 +1,58 @@
+// Package dmsg pkg/dmsg/session_ping_test.go
+package dmsg
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestSessionPing_YamuxStreamRoundTrip verifies that Ping() on a healthy yamux
+// session performs a real stream round-trip (yamuxPing) through the server's
+// serveStream ping-marker echo and returns a positive RTT with no error.
+//
+// Regression guard for the zombie-session bug: the old yamux path used
+// yamux.Session.Ping() (a control-frame keepalive) which reports a session
+// alive even when the server can no longer relay streams to/from us, so
+// pingSessionsLoop never marked half-open sessions dead. The fix routes yamux
+// through a stream round-trip like smux already did. This test also guards the
+// other direction — a HEALTHY yamux session must NOT be false-killed by the new
+// stream-level probe (the server must echo the ping marker for yamux streams).
+func TestSessionPing_YamuxStreamRoundTrip(t *testing.T) {
+	dc := disc.NewMock(0)
+
+	pkSrv, skSrv := GenKeyPair(t, "server")
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: 10, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("server"))
+	lisSrv, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(lisSrv, "") }() //nolint:errcheck
+
+	pkA, skA := GenKeyPair(t, "client A")
+	clientA := NewClient(pkA, skA, dc, DefaultConfig()) // default protocol => yamux
+	clientA.SetLogger(logging.MustGetLogger("client_A"))
+	go clientA.Serve(context.Background())
+	t.Cleanup(func() {
+		_ = clientA.Close() //nolint:errcheck
+		_ = srv.Close()     //nolint:errcheck
+	})
+
+	require.Eventually(t, func() bool {
+		return clientA.SessionCount() > 0
+	}, 10*time.Second, 200*time.Millisecond, "client failed to connect to dmsg server")
+
+	sessions := clientA.allClientSessions(clientA.porter)
+	require.NotEmpty(t, sessions, "expected at least one client session")
+
+	// A healthy yamux session must round-trip the stream-level ping.
+	rtt, err := sessions[0].Ping()
+	require.NoError(t, err, "yamux stream-level ping must succeed on a healthy session")
+	assert.Positive(t, int64(rtt), "ping must report a positive round-trip time")
+}

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -101,6 +101,22 @@ type ManagedTransport struct {
 	// touch it lock-free.
 	pingReadyAtNanos atomic.Int64
 
+	// pongSeen is set true on the first transport pong ever received on
+	// this transport, ARMING the half-open-link detector. Until a peer
+	// has answered at least one ping we never close on missed pongs —
+	// older visors that don't implement transport ping/pong would
+	// otherwise be falsely reaped, severing working links to them.
+	pongSeen atomic.Bool
+	// missedPongs counts pings sent with no intervening pong. Reset to 0
+	// on every pong received and whenever the underlying transport is
+	// (re)set. Once pongSeen is true and this reaches pongMissThreshold,
+	// the far end has gone silent (a half-open link the OS hasn't torn
+	// down) — the transport is closed + deregistered so it stops being
+	// re-registered and routed through. This is what makes a dead edge's
+	// transports actually expire from TPD instead of being kept alive by
+	// the still-live edge's re-registration.
+	missedPongs atomic.Int64
+
 	// cascadeHandler handles cascade protocol packets (route ID 0).
 	// Set by the transport manager from the router's CascadeHandler.
 	cascadeHandler func(p routing.Packet, mt *ManagedTransport)
@@ -244,6 +260,13 @@ func (mt *ManagedTransport) GetBandwidth() *BandwidthData {
 // goroutine.
 const transportPingInterval = 60 * time.Second
 
+// pongMissThreshold is the number of consecutive transport pings with no
+// intervening pong after which an ARMED (pongSeen) transport is treated as a
+// dead half-open link and closed. At transportPingInterval (60s) this is ~3
+// minutes of silence — long enough to ride out a brief blip or a momentarily
+// slow peer, short enough that dead edges drain from TPD promptly.
+const pongMissThreshold = 3
+
 // Serve serves and manages the transport.
 //
 // Goroutine layout: one readLoop goroutine plus the Serve goroutine
@@ -371,6 +394,20 @@ func (mt *ManagedTransport) tickPing() {
 		return
 	}
 
+	// Half-open-link detection: if the peer has answered a ping before
+	// (pongSeen) but has since gone silent for pongMissThreshold
+	// consecutive pings, the far end is gone while our local socket
+	// still looks "open" (no RST). Close + deregister so the dead edge
+	// stops being re-registered and routed through. Guarded by pongSeen
+	// so peers that never implement transport ping/pong are untouched.
+	if mt.pongSeen.Load() && mt.missedPongs.Load() >= pongMissThreshold {
+		mt.log.WithField("missed_pongs", mt.missedPongs.Load()).
+			WithField("remote", mt.Remote()).
+			Warn("Transport peer stopped answering pings; closing half-open transport")
+		mt.close()
+		return
+	}
+
 	// First time observed ready — stamp + send first ping. CAS makes
 	// the stamp idempotent in case the maintenance loop ever overlaps
 	// with itself (a precaution; in the current design only one
@@ -400,6 +437,8 @@ func (mt *ManagedTransport) sendTransportPing() {
 		mt.log.WithError(err).Debug("Failed to send transport ping")
 		return
 	}
+	// Count this ping as awaiting a pong; handleTransportPong resets it.
+	mt.missedPongs.Add(1)
 	if n > routing.PacketHeaderSize {
 		mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
 	}
@@ -439,6 +478,11 @@ func (mt *ManagedTransport) handleTransportPong(p routing.Packet) {
 	if len(payload) < routing.TransportPingPayloadSize {
 		return
 	}
+	// A valid pong proves the far end is alive: arm the detector and
+	// reset the miss counter, regardless of the RTT-outlier filtering
+	// below (an outlier-RTT pong still proves liveness).
+	mt.pongSeen.Store(true)
+	mt.missedPongs.Store(0)
 	sentAt := int64(binary.BigEndian.Uint64(payload[:8])) //nolint:gosec
 	rttMs := float64(time.Now().UnixNano()-sentAt) / 1e6
 	if rttMs <= 0 {
@@ -645,6 +689,10 @@ func (mt *ManagedTransport) setTransport(newTransport network.Transport) {
 		}
 		mt.transport = nil
 	}
+
+	// Fresh underlying connection — reset the half-open miss counter so a
+	// stale count from a prior connection can't immediately reap the new one.
+	mt.missedPongs.Store(0)
 
 	// Set new underlying transport.
 	mt.transport = newTransport

--- a/pkg/transport/managed_transport_pong_test.go
+++ b/pkg/transport/managed_transport_pong_test.go
@@ -1,0 +1,79 @@
+package transport
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// okTransport is a mock network.Transport whose Write always succeeds (so
+// sendTransportPing counts a ping without erroring) and whose Read blocks —
+// modeling a half-open link where the local socket still looks alive.
+type okTransport struct{ pk1, pk2 cipher.PubKey }
+
+func (o *okTransport) Write(p []byte) (int, error)      { return len(p), nil }
+func (o *okTransport) Read([]byte) (int, error)         { select {} }
+func (o *okTransport) Close() error                     { return nil }
+func (o *okTransport) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (o *okTransport) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (o *okTransport) SetDeadline(time.Time) error      { return nil }
+func (o *okTransport) SetReadDeadline(time.Time) error  { return nil }
+func (o *okTransport) SetWriteDeadline(time.Time) error { return nil }
+func (o *okTransport) LocalPK() cipher.PubKey           { return o.pk1 }
+func (o *okTransport) RemotePK() cipher.PubKey          { return o.pk2 }
+func (o *okTransport) LocalPort() uint16                { return 0 }
+func (o *okTransport) RemotePort() uint16               { return 0 }
+func (o *okTransport) LocalRawAddr() net.Addr           { return &net.TCPAddr{} }
+func (o *okTransport) RemoteRawAddr() net.Addr          { return &net.TCPAddr{} }
+func (o *okTransport) Network() types.Type              { return "test" }
+
+func testPong() routing.Packet { return routing.MakeTransportPongPacket(time.Now().UnixNano()) }
+
+// TestManagedTransport_HalfOpenClosesAfterMissedPongs: a transport that has
+// answered a ping (armed) but then goes silent must be closed once
+// pongMissThreshold pings go unanswered — the fix that drains dead edges from
+// TPD (a closed transport is skipped by reRegisterTransports + deregistered).
+func TestManagedTransport_HalfOpenClosesAfterMissedPongs(t *testing.T) {
+	mt := NewManagedTransportForTest(&okTransport{})
+	mt.handleTransportPong(testPong()) // arm: pongSeen=true, missedPongs=0
+	require.False(t, mt.IsClosed())
+
+	closed := false
+	for i := 0; i < pongMissThreshold+3; i++ {
+		mt.tickPing()
+		if mt.IsClosed() {
+			closed = true
+			break
+		}
+	}
+	assert.True(t, closed, "armed transport with no pongs must close after pongMissThreshold pings")
+}
+
+// TestManagedTransport_NeverPongedNeverCloses: a peer that never answers a
+// transport ping (e.g. an older visor without ping/pong support) must NOT be
+// reaped — the detector is armed only by a first pong (pongSeen).
+func TestManagedTransport_NeverPongedNeverCloses(t *testing.T) {
+	mt := NewManagedTransportForTest(&okTransport{})
+	for i := 0; i < pongMissThreshold+10; i++ {
+		mt.tickPing()
+	}
+	assert.False(t, mt.IsClosed(), "a peer that never pongs (old visor) must NOT be reaped")
+}
+
+// TestManagedTransport_HealthyPeerStaysOpen: a peer that keeps answering pings
+// resets the miss counter each cycle and is never closed.
+func TestManagedTransport_HealthyPeerStaysOpen(t *testing.T) {
+	mt := NewManagedTransportForTest(&okTransport{})
+	for i := 0; i < pongMissThreshold+10; i++ {
+		mt.tickPing()
+		mt.handleTransportPong(testPong())
+	}
+	assert.False(t, mt.IsClosed(), "a peer that keeps answering pings must stay open")
+}

--- a/pkg/transport/testing_helpers.go
+++ b/pkg/transport/testing_helpers.go
@@ -28,5 +28,6 @@ func NewManagedTransportForTest(conn network.Transport) *ManagedTransport {
 		transportCh:   make(chan struct{}, 1),
 		done:          make(chan struct{}),
 		queueDeletion: func(_ uuid.UUID) {}, // no-op for tests
+		LogEntry:      NewLogEntry(),        // so logSent/logRecv don't nil-deref
 	}
 }


### PR DESCRIPTION
## Problem

The transport-level ping (`transportPingInterval` = 60s) was **latency-only** — a missed pong did nothing. So when a peer vanished **without a TCP RST** (a half-open link — common on NAT / Docker-bridge / flaky networks), the local edge never noticed:

- the transport stayed `!IsClosed()`, so `reRegisterTransports` kept re-registering it;
- and because TPD's `RegisterTransport` refreshes **both** edges' set-TTLs on **either** edge's registration (`redis_transport.go`), the dead peer's transports **never expired** from TPD.

Route selection then built routes through the dead peer, and route setup failed: the setup-node dialing it `@136` got **`dmsg error 100 — entry is not found in discovery`**. Confirmed from the setup-node's own logs (via dmsgpty): **192 dmsg-100 "not found" + 180 i/o-deadline over 8 min**, while direct (no-intermediate) routes succeeded. This is the recurring "stale transports in TPD for a visor that has no dmsg-discovery entry" — the live edge keeps the dead edge's listing alive.

## Fix

A half-open detector on `ManagedTransport`:
- `handleTransportPong` sets `pongSeen` and resets `missedPongs`.
- `sendTransportPing` increments `missedPongs` (pings awaiting a pong).
- `tickPing` **closes + deregisters** the transport once `pongSeen` is set **and** `missedPongs >= pongMissThreshold` (3 → ~3 min of silence).
- `setTransport` resets `missedPongs` on a fresh underlying connection.

**Gated by `pongSeen`:** the detector arms only *after* the peer has answered at least one ping, so older visors that don't implement transport ping/pong are **never falsely reaped** (no regression for the many pre-ping nodes still on the network). A closed transport is skipped by `reRegisterTransports` and deregistered from TPD, so dead edges finally drain instead of being kept alive by the still-live edge.

## Test

`managed_transport_pong_test.go` covers all three paths under `-race`:
- ponged-then-silent → **closes** after `pongMissThreshold` pings;
- never-ponged (old peer) → **never closes**;
- healthy (keeps ponging) → **stays open**.

Full `pkg/transport` suite + lint clean.

## Follow-ups (not in this PR)
- **TPD per-edge-TTL** (`RegisterTransport` should refresh only the *registering* edge's set TTL, keyed on the authenticated requester PK) — drains ghosts created by un-updated visors too, regardless of visor version.
- The separate dmsg-202 / i-o-deadline class (the 8 dmsg servers flapping) is a distinct reliability track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)