### PR TITLE
fix(tpd): drain ghost transports (per-edge-TTL) + cache/gzip /all-transports egress storm

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -459,8 +459,8 @@ func (s *memoryStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) (
 }
 
 // Unused interface methods - stubs for store.Store compliance
-func (s *memoryStore) RegisterTransport(context.Context, *transport.SignedEntry) error { return nil }
-func (s *memoryStore) RegisterTransportsBatch(context.Context, []*transport.SignedEntry) error {
+func (s *memoryStore) RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error { return nil }
+func (s *memoryStore) RegisterTransportsBatch(context.Context, cipher.PubKey, []*transport.SignedEntry) error {
 	return nil
 }
 func (s *memoryStore) DeregisterTransport(context.Context, uuid.UUID) error { return nil }

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -29,10 +29,10 @@ func newMockStore() *mockStore {
 	}
 }
 
-func (m *mockStore) RegisterTransport(context.Context, *transport.SignedEntry) error {
+func (m *mockStore) RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error {
 	return nil
 }
-func (m *mockStore) RegisterTransportsBatch(context.Context, []*transport.SignedEntry) error {
+func (m *mockStore) RegisterTransportsBatch(context.Context, cipher.PubKey, []*transport.SignedEntry) error {
 	return nil
 }
 func (m *mockStore) DeregisterTransport(context.Context, uuid.UUID) error {

--- a/pkg/transport-discovery/api/all_transports_response_cache.go
+++ b/pkg/transport-discovery/api/all_transports_response_cache.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"sync"
+	"time"
+)
+
+// allTransportsRespCacheTTL is how long a marshaled /all-transports body is
+// reused before recompute. /all-transports is the dominant TPD egress + CPU
+// driver — thousands of identical multi-MB requests/min from visor TPD clients
+// — and the existing data cache (allTransportsCache) still re-marshaled the
+// ~3MB body per call. 30s collapses a 10-minute storm of ~2000 calls into ~20
+// marshals while keeping the transport list comfortably fresh (the data cache
+// is 5s; the CXO publisher recomputes every 60s).
+const allTransportsRespCacheTTL = 30 * time.Second
+
+// allTransportsRespCache memoizes the marshaled JSON body (and a gzip copy) of
+// the /all-transports response per selfTransports variant, single-flighting the
+// recompute on miss and serving a stale body if the recompute errors.
+type allTransportsRespCache struct {
+	ttl   time.Duration
+	mu    sync.Mutex
+	slots map[bool]*respCacheSlot // keyed by selfTransports
+}
+
+type respCacheSlot struct {
+	raw       []byte
+	gz        []byte
+	expiresAt time.Time
+}
+
+func newAllTransportsRespCache(ttl time.Duration) *allTransportsRespCache {
+	if ttl <= 0 {
+		ttl = allTransportsRespCacheTTL
+	}
+	return &allTransportsRespCache{ttl: ttl, slots: map[bool]*respCacheSlot{}}
+}
+
+// body returns the marshaled JSON and its gzip-compressed form for the variant,
+// recomputing via compute() at most once per TTL. compute returns the marshaled
+// JSON body. The lock is held across compute so concurrent misses for a variant
+// share a single recompute (single-flight). On compute error a still-cached
+// (stale) body is returned when present.
+func (c *allTransportsRespCache) body(selfTransports bool, compute func() ([]byte, error)) (raw, gz []byte, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	slot := c.slots[selfTransports]
+	if slot != nil && time.Now().Before(slot.expiresAt) {
+		return slot.raw, slot.gz, nil
+	}
+
+	body, cerr := compute()
+	if cerr != nil {
+		if slot != nil { // stale-on-error
+			return slot.raw, slot.gz, nil
+		}
+		return nil, nil, cerr
+	}
+
+	gzBody := gzipBytes(body)
+	c.slots[selfTransports] = &respCacheSlot{
+		raw:       body,
+		gz:        gzBody,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	return body, gzBody, nil
+}
+
+func gzipBytes(b []byte) []byte {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, _ = zw.Write(b) //nolint:errcheck
+	_ = zw.Close()     //nolint:errcheck
+	return buf.Bytes()
+}

--- a/pkg/transport-discovery/api/all_transports_response_cache_test.go
+++ b/pkg/transport-discovery/api/all_transports_response_cache_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gunzip(t *testing.T, b []byte) []byte {
+	t.Helper()
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	require.NoError(t, err)
+	out, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	return out
+}
+
+func TestAllTransportsRespCache(t *testing.T) {
+	c := newAllTransportsRespCache(time.Minute)
+
+	t.Run("memoizes within TTL + gzip matches raw", func(t *testing.T) {
+		var calls int32
+		compute := func() ([]byte, error) {
+			atomic.AddInt32(&calls, 1)
+			return []byte(`[{"id":"x"}]`), nil
+		}
+		raw1, gz1, err := c.body(true, compute)
+		require.NoError(t, err)
+		raw2, gz2, err := c.body(true, compute)
+		require.NoError(t, err)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "second call within TTL must not recompute")
+		assert.Equal(t, raw1, raw2)
+		assert.Equal(t, gz1, gz2)
+		assert.Equal(t, raw1, gunzip(t, gz1), "gzip body must decompress to the raw body")
+	})
+
+	t.Run("variants are independent", func(t *testing.T) {
+		rawSelf, _, err := c.body(true, func() ([]byte, error) { return []byte(`["self"]`), nil })
+		require.NoError(t, err)
+		rawNoSelf, _, err := c.body(false, func() ([]byte, error) { return []byte(`["noself"]`), nil })
+		require.NoError(t, err)
+		assert.NotEqual(t, rawSelf, rawNoSelf)
+	})
+
+	t.Run("stale-on-error returns last good body", func(t *testing.T) {
+		short := newAllTransportsRespCache(20 * time.Millisecond)
+		good := []byte(`["good"]`)
+		_, _, err := short.body(true, func() ([]byte, error) { return good, nil })
+		require.NoError(t, err)
+
+		time.Sleep(30 * time.Millisecond) // expire the slot
+		raw, _, err := short.body(true, func() ([]byte, error) { return nil, errors.New("store down") })
+		require.NoError(t, err, "should serve stale, not error, when a prior body exists")
+		assert.Equal(t, good, raw)
+	})
+
+	t.Run("error with no prior body propagates", func(t *testing.T) {
+		fresh := newAllTransportsRespCache(time.Minute)
+		_, _, err := fresh.body(false, func() ([]byte, error) { return nil, errors.New("store down") })
+		require.Error(t, err)
+	})
+}

--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -67,6 +67,10 @@ type API struct {
 	transportsCacheFiltered []*transport.Entry // excludes self-transports
 	transportsMu            sync.RWMutex
 
+	// allTpsRespCache memoizes the marshaled (+gzip) /all-transports body so the
+	// dominant-egress endpoint doesn't re-marshal/re-send ~3MB per call.
+	allTpsRespCache *allTransportsRespCache
+
 	uptimesCache   []store.VisorSummary
 	uptimesV2Cache []store.VisorSummary
 	uptimesMu      sync.RWMutex
@@ -116,6 +120,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
 		backupPath:                  backupPath,
+		allTpsRespCache:             newAllTransportsRespCache(allTransportsRespCacheTTL),
 	}
 
 	r := chi.NewRouter()

--- a/pkg/transport-discovery/api/api_test.go
+++ b/pkg/transport-discovery/api/api_test.go
@@ -156,7 +156,7 @@ func TestGETTransportByID(t *testing.T) {
 
 	entry := newTestEntry()
 	sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
-	require.NoError(t, mock.RegisterTransport(ctx, sEntry))
+	require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry))
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/transports/id:%s", entry.ID), nil)
@@ -190,7 +190,7 @@ func TestDELETETransportByID(t *testing.T) {
 	sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
 
 	t.Run("can delete own transport", func(t *testing.T) {
-		require.NoError(t, mock.RegisterTransport(ctx, sEntry))
+		require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry))
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/transports/id:%s", entry.ID), nil)
 		r.Header = validHeaders(t, nil)
@@ -215,7 +215,7 @@ func TestDELETETransportByID(t *testing.T) {
 			Type:  "dmsg",
 		}
 		sEntry := &transport.SignedEntry{Entry: otherVisorEntry, Signatures: [2]cipher.Sig{}}
-		require.NoError(t, mock.RegisterTransport(ctx, sEntry))
+		require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry))
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/transports/id:%s", otherVisorEntry.ID), nil)
@@ -241,7 +241,7 @@ func TestGETTransportByEdge(t *testing.T) {
 
 	entry := newTestEntry()
 	sEntry := &transport.SignedEntry{Entry: entry, Signatures: [2]cipher.Sig{}}
-	require.NoError(t, mock.RegisterTransport(ctx, sEntry))
+	require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry))
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/transports/edge:%s", entry.Edges[0]), nil)
@@ -273,11 +273,11 @@ func TestGETAllTransports(t *testing.T) {
 
 	entry1 := newTestEntry()
 	sEntry1 := &transport.SignedEntry{Entry: entry1, Signatures: [2]cipher.Sig{}}
-	require.NoError(t, mock.RegisterTransport(ctx, sEntry1))
+	require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry1))
 
 	entry2 := newTestEntry()
 	sEntry2 := &transport.SignedEntry{Entry: entry2, Signatures: [2]cipher.Sig{}}
-	require.NoError(t, mock.RegisterTransport(ctx, sEntry2))
+	require.NoError(t, mock.RegisterTransport(ctx, cipher.PubKey{}, sEntry2))
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/all-transports", nil)

--- a/pkg/transport-discovery/api/cxo_register.go
+++ b/pkg/transport-discovery/api/cxo_register.go
@@ -42,7 +42,7 @@ func (api *API) RegisterTransportFromCXO(ctx context.Context, entry *transport.E
 	}
 
 	sEntry := &transport.SignedEntry{Entry: entry, Version: version}
-	if err := api.store.RegisterTransportsBatch(ctx, []*transport.SignedEntry{sEntry}); err != nil {
+	if err := api.store.RegisterTransportsBatch(ctx, reporter, []*transport.SignedEntry{sEntry}); err != nil {
 		return fmt.Errorf("register batch: %w", err)
 	}
 

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -2,6 +2,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -307,20 +308,61 @@ func (api *API) getAllTransports(w http.ResponseWriter, r *http.Request) {
 	if selfTransportsParam == "hide" {
 		selfTransports = false
 	}
-	entries := api.getTransportsFromCache(selfTransports)
-	if entries == nil {
-		var err error
-		entries, err = api.store.GetAllTransports(r.Context(), selfTransports)
+
+	// /all-transports is the dominant TPD egress + CPU driver. Serve a
+	// memoized, gzipped response body so identical multi-MB requests don't
+	// re-marshal and re-send the full list per call. The rare ?pretty=true
+	// caller bypasses the cache (indented form).
+	pretty, _ := httputil.BoolFromQuery(r, "pretty", false) //nolint:errcheck
+	if pretty {
+		entries, err := api.allTransportsEntries(r.Context(), selfTransports)
 		if err != nil {
 			api.writeError(w, r, err)
 			return
 		}
-	}
-	if len(entries) == 0 {
-		api.writeError(w, r, store.ErrTransportNotFound)
+		httputil.WriteJSON(w, r, http.StatusOK, entries)
 		return
 	}
-	httputil.WriteJSON(w, r, http.StatusOK, entries)
+
+	raw, gz, err := api.allTpsRespCache.body(selfTransports, func() ([]byte, error) {
+		entries, e := api.allTransportsEntries(r.Context(), selfTransports)
+		if e != nil {
+			return nil, e
+		}
+		return json.Marshal(entries)
+	})
+	if err != nil {
+		api.writeError(w, r, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if gz != nil && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Vary", "Accept-Encoding")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(gz) //nolint:errcheck
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(raw) //nolint:errcheck
+}
+
+// allTransportsEntries returns the all-transports list (data cache then store),
+// preserving the empty-list -> ErrTransportNotFound behavior callers expect.
+func (api *API) allTransportsEntries(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
+	entries := api.getTransportsFromCache(selfTransports)
+	if entries == nil {
+		var err error
+		entries, err = api.store.GetAllTransports(ctx, selfTransports)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(entries) == 0 {
+		return nil, store.ErrTransportNotFound
+	}
+	return entries, nil
 }
 
 func (api *API) getAllTransportsStats(w http.ResponseWriter, r *http.Request) {

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -85,7 +85,7 @@ func (api *API) registerTransportV3(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := api.store.RegisterTransportsBatch(r.Context(), signed); err != nil {
+	if err := api.store.RegisterTransportsBatch(r.Context(), authPK, signed); err != nil {
 		api.writeError(w, r, err)
 		return
 	}
@@ -146,9 +146,13 @@ func (api *API) registerTransport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The authenticated caller is the registering edge; the store refreshes
+	// only its per-edge index TTL (zero PK falls back to both edges).
+	reporter, _ := r.Context().Value(httpauth.ContextAuthKey).(cipher.PubKey)
+
 	// Register all transports in a single Redis pipeline (batch).
 	// This reduces N separate pipelines to 1, cutting Redis round-trips.
-	if err := api.store.RegisterTransportsBatch(r.Context(), entries); err != nil {
+	if err := api.store.RegisterTransportsBatch(r.Context(), reporter, entries); err != nil {
 		api.writeError(w, r, err)
 		return
 	}

--- a/pkg/transport-discovery/store/edge_refresh_test.go
+++ b/pkg/transport-discovery/store/edge_refresh_test.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestEdgeRefreshTargets verifies the per-edge-TTL decision: a registration
+// refreshes only the reporting edge's index, so an offline edge's index expires
+// while its live peer keeps re-registering the shared transport. A reporter
+// that is not an edge (zero PK / legacy / unauthenticated) falls back to both.
+func TestEdgeRefreshTargets(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+	edges := [2]cipher.PubKey{a, b}
+
+	t.Run("reporter is edge A -> only A", func(t *testing.T) {
+		ra, rb := edgeRefreshTargets(a, edges)
+		assert.True(t, ra)
+		assert.False(t, rb)
+	})
+	t.Run("reporter is edge B -> only B", func(t *testing.T) {
+		ra, rb := edgeRefreshTargets(b, edges)
+		assert.False(t, ra)
+		assert.True(t, rb)
+	})
+	t.Run("reporter is neither (other PK) -> both (fallback)", func(t *testing.T) {
+		ra, rb := edgeRefreshTargets(other, edges)
+		assert.True(t, ra)
+		assert.True(t, rb)
+	})
+	t.Run("reporter is zero PK -> both (fallback)", func(t *testing.T) {
+		ra, rb := edgeRefreshTargets(cipher.PubKey{}, edges)
+		assert.True(t, ra)
+		assert.True(t, rb)
+	})
+}

--- a/pkg/transport-discovery/store/memory_store.go
+++ b/pkg/transport-discovery/store/memory_store.go
@@ -31,16 +31,18 @@ func (s *memoryStore) SetError(err error) {
 	s.err = err
 }
 
-func (s *memoryStore) RegisterTransportsBatch(ctx context.Context, entries []*transport.SignedEntry) error {
+func (s *memoryStore) RegisterTransportsBatch(ctx context.Context, reporter cipher.PubKey, entries []*transport.SignedEntry) error {
 	for _, entry := range entries {
-		if err := s.RegisterTransport(ctx, entry); err != nil {
+		if err := s.RegisterTransport(ctx, reporter, entry); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *memoryStore) RegisterTransport(_ context.Context, entry *transport.SignedEntry) error {
+// RegisterTransport ignores reporter: the in-memory store has no per-edge TTL
+// index (no expiry), so the per-edge-refresh distinction is moot here.
+func (s *memoryStore) RegisterTransport(_ context.Context, _ cipher.PubKey, entry *transport.SignedEntry) error {
 	if s.err != nil {
 		return s.err
 	}

--- a/pkg/transport-discovery/store/redis_transport.go
+++ b/pkg/transport-discovery/store/redis_transport.go
@@ -14,7 +14,22 @@ import (
 	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
-func (s *redisStore) RegisterTransport(ctx context.Context, sEntry *transport.SignedEntry) error {
+// edgeRefreshTargets decides whose per-edge index TTL to refresh for a
+// registration. When reporter is one of the two edges, only that edge's index
+// is refreshed (so the OTHER edge's index expires unless that edge registers
+// itself — i.e. is still online). When reporter is neither edge (zero PK,
+// unauthenticated, or legacy callers), both are refreshed to preserve the old
+// behavior.
+func edgeRefreshTargets(reporter cipher.PubKey, edges [2]cipher.PubKey) (refreshA, refreshB bool) {
+	refreshA = reporter == edges[0]
+	refreshB = reporter == edges[1]
+	if !refreshA && !refreshB {
+		return true, true
+	}
+	return refreshA, refreshB
+}
+
+func (s *redisStore) RegisterTransport(ctx context.Context, reporter cipher.PubKey, sEntry *transport.SignedEntry) error {
 	entry := sEntry.Entry
 	if entry == nil {
 		return ErrBadEntry
@@ -49,15 +64,24 @@ func (s *redisStore) RegisterTransport(ctx context.Context, sEntry *transport.Si
 	edgeAKey := s.edgeKey(entry.Edges[0])
 	edgeBKey := s.edgeKey(entry.Edges[1])
 
+	// Refresh ONLY the reporter's per-edge index, so an offline edge's index
+	// expires even while its live peer keeps re-registering the shared
+	// transport. The route-finder explores via per-edge indexes, so an expired
+	// index drops that visor as a routable intermediate. Fall back to both
+	// edges when the reporter is not one of them (zero / legacy / unauthed).
+	refreshA, refreshB := edgeRefreshTargets(reporter, entry.Edges)
+
 	// Always apply TTL so stale transports expire when visors stop re-registering.
 	pipe := s.client.Pipeline()
 	pipe.Set(ctx, tpKey, string(raw), s.ttl)
-	pipe.SAdd(ctx, edgeAKey, entry.ID.String())
 	pipe.SAdd(ctx, s.allTpsIndexKey(), entry.ID.String())
-	if s.ttl > 0 {
-		pipe.Expire(ctx, edgeAKey, s.ttl)
+	if refreshA {
+		pipe.SAdd(ctx, edgeAKey, entry.ID.String())
+		if s.ttl > 0 {
+			pipe.Expire(ctx, edgeAKey, s.ttl)
+		}
 	}
-	if entry.Edges[0] != entry.Edges[1] {
+	if entry.Edges[0] != entry.Edges[1] && refreshB {
 		pipe.SAdd(ctx, edgeBKey, entry.ID.String())
 		if s.ttl > 0 {
 			pipe.Expire(ctx, edgeBKey, s.ttl)
@@ -86,7 +110,7 @@ func (s *redisStore) RegisterTransport(ctx context.Context, sEntry *transport.Si
 // pipeline. This reduces TCP round-trips from N pipelines (one per transport)
 // to 1 pipeline for the entire batch. At ~50 registrations/sec × 8 commands
 // each, this cuts Redis syscall overhead significantly.
-func (s *redisStore) RegisterTransportsBatch(ctx context.Context, entries []*transport.SignedEntry) error {
+func (s *redisStore) RegisterTransportsBatch(ctx context.Context, reporter cipher.PubKey, entries []*transport.SignedEntry) error {
 	if len(entries) == 0 {
 		return nil
 	}
@@ -120,13 +144,18 @@ func (s *redisStore) RegisterTransportsBatch(ctx context.Context, entries []*tra
 		tpKey := s.transportKey(entry.ID)
 		edgeAKey := s.edgeKey(entry.Edges[0])
 
+		// Refresh only the reporter's per-edge index (see RegisterTransport).
+		refreshA, refreshB := edgeRefreshTargets(reporter, entry.Edges)
+
 		pipe.Set(ctx, tpKey, string(raw), s.ttl)
-		pipe.SAdd(ctx, edgeAKey, entry.ID.String())
 		pipe.SAdd(ctx, s.allTpsIndexKey(), entry.ID.String())
-		if s.ttl > 0 {
-			pipe.Expire(ctx, edgeAKey, s.ttl)
+		if refreshA {
+			pipe.SAdd(ctx, edgeAKey, entry.ID.String())
+			if s.ttl > 0 {
+				pipe.Expire(ctx, edgeAKey, s.ttl)
+			}
 		}
-		if entry.Edges[0] != entry.Edges[1] {
+		if entry.Edges[0] != entry.Edges[1] && refreshB {
 			edgeBKey := s.edgeKey(entry.Edges[1])
 			pipe.SAdd(ctx, edgeBKey, entry.ID.String())
 			if s.ttl > 0 {

--- a/pkg/transport-discovery/store/store.go
+++ b/pkg/transport-discovery/store/store.go
@@ -172,8 +172,13 @@ type Store interface {
 
 // TransportStore stores Transport metadata.
 type TransportStore interface {
-	RegisterTransport(context.Context, *transport.SignedEntry) error
-	RegisterTransportsBatch(context.Context, []*transport.SignedEntry) error
+	// RegisterTransport registers/refreshes a transport. reporter is the
+	// authenticated registering edge: only that edge's per-edge index TTL is
+	// refreshed, so an offline edge's index expires even while its live peer
+	// keeps re-registering the shared transport. A zero reporter (or one that
+	// is not an edge) falls back to refreshing both edges (legacy behavior).
+	RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error
+	RegisterTransportsBatch(context.Context, cipher.PubKey, []*transport.SignedEntry) error
 	DeregisterTransport(context.Context, uuid.UUID) error
 	GetTransportByID(context.Context, uuid.UUID) (*transport.Entry, error)
 	GetTransportsByEdge(context.Context, cipher.PubKey) ([]*transport.Entry, error)

--- a/pkg/transport-discovery/store/transport_test.go
+++ b/pkg/transport-discovery/store/transport_test.go
@@ -42,7 +42,7 @@ func (s *TransportSuite) TestRegister() {
 	}
 
 	t.Run(".RegisterTransport", func(t *testing.T) {
-		require.NoError(t, s.RegisterTransport(ctx, sEntry))
+		require.NoError(t, s.RegisterTransport(ctx, cipher.PubKey{}, sEntry))
 		assert.True(t, sEntry.Registered > 0)
 	})
 

--- a/pkg/visor/hypervisor_handlers_routing_tools.go
+++ b/pkg/visor/hypervisor_handlers_routing_tools.go
@@ -266,10 +266,10 @@ func (s *hvCalcStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) (
 // Stubs to satisfy tpdstore.Store. None of these are reached during
 // route enumeration; they exist only to make the type assignable to
 // the route-finder's parameter type.
-func (s *hvCalcStore) RegisterTransport(context.Context, *transport.SignedEntry) error {
+func (s *hvCalcStore) RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error {
 	return nil
 }
-func (s *hvCalcStore) RegisterTransportsBatch(context.Context, []*transport.SignedEntry) error {
+func (s *hvCalcStore) RegisterTransportsBatch(context.Context, cipher.PubKey, []*transport.SignedEntry) error {
 	return nil
 }
 func (s *hvCalcStore) DeregisterTransport(context.Context, uuid.UUID) error { return nil }

--- a/pkg/visor/rpcgrpc/server.go
+++ b/pkg/visor/rpcgrpc/server.go
@@ -937,10 +937,10 @@ func (s *calcMemStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) 
 }
 
 // Unused store.Store stubs.
-func (s *calcMemStore) RegisterTransport(context.Context, *transport.SignedEntry) error {
+func (s *calcMemStore) RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error {
 	return nil
 }
-func (s *calcMemStore) RegisterTransportsBatch(context.Context, []*transport.SignedEntry) error {
+func (s *calcMemStore) RegisterTransportsBatch(context.Context, cipher.PubKey, []*transport.SignedEntry) error {
 	return nil
 }
 func (s *calcMemStore) DeregisterTransport(context.Context, uuid.UUID) error { return nil }


### PR DESCRIPTION
Two related TPD fixes (the second is the **pressing** egress/CPU issue, diagnosed with Beta on prod02).

## 1. Per-edge index TTL (drain ghost transports)

`RegisterTransport` refreshed **both** edges' per-edge index TTLs on **either** edge's registration. So a transport A↔B with A online and B offline never expired from B's index (A kept refreshing it), and the route-finder (`GetTransportsByEdge`) kept routing **through the dead B** → route setup failed dialing it `@136` (`dmsg error 100 — entry not found in discovery`). Confirmed from the setup-node's own logs as the dominant route-setup failure class.

Fix: thread the authenticated **reporter PK** into the store register methods and refresh **only the reporter's** per-edge index. Both edges independently re-register (initiator + accepter), so a healthy A↔B stays in both indexes; when B goes offline it stops refreshing its own index → it expires → B drops as a routable intermediate, while A↔B stays visible from A's side. Zero/non-edge reporter falls back to both (legacy). Complements the visor-side half-open detection in #2979.

## 2. `/all-transports` response cache + gzip (PRESSING — egress/CPU)

`/all-transports` is the dominant TPD egress+CPU driver: measured **2127 calls/10 min × ~3 MB flat = 7.5 MB/s = 75% of TPD egress, 130% CPU, tripping the deploy egress budget**. The existing cache memoized only the `[]Entry` **data** — each call still re-marshaled ~3 MB and sent it uncompressed.

Fix: an `allTransportsRespCache` (keyed by `selfTransports`) memoizes the **marshaled body + a gzip copy**, single-flights the recompute on miss, and serves stale-on-error. The handler serves gzip when the client advertises it (Go http clients do) — cutting egress ~6–10× — and the cached raw bytes otherwise, cutting the per-call marshal either way. `?pretty=true` bypasses. No compression middleware in the router (no double-compress); default response is already the slim `Entry` list.

## Tests
`edgeRefreshTargets` decision (reporter=A→only A, =B→only B, non-edge→both); response cache (memoize within TTL, gzip==raw, per-variant isolation, stale-on-error). Full module builds; touched suites + lint clean.

## Follow-ups (NOT in this PR)
- The ~10k-goroutine CXO-aggregator fan-out is in CXO core (`skyobject` fill `splitSchemaHashAsync`), driven by 500+ subscribed feeds — bounding it touches all CXO users; separate careful change.
- Client-side: audit `pkg/transport/client` retry-backoff (a burst-poller was seen hitting `/all-transports` every 4–6 s).

## Ops
Redeploy TPD after merge (`docker pull skycoin/skywire:test` + recreate transport-discovery). No redis/reprepro changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)