### PR TITLE
fix(dmsg/disc): empty discovery URL → no-op client (no invalid-host retry spin)

### DIFF
--- a/pkg/dmsg/disc/client.go
+++ b/pkg/dmsg/disc/client.go
@@ -71,7 +71,7 @@ func (noDiscoveryClient) PostEntry(context.Context, *Entry) error            { r
 func (noDiscoveryClient) PutEntry(context.Context, cipher.SecKey, *Entry) error {
 	return nil
 }
-func (noDiscoveryClient) DelEntry(context.Context, *Entry) error      { return nil }
+func (noDiscoveryClient) DelEntry(context.Context, *Entry) error       { return nil }
 func (noDiscoveryClient) AllEntries(context.Context) ([]string, error) { return nil, nil }
 func (noDiscoveryClient) AllClientsByServer(context.Context) (map[string][]*Entry, error) {
 	return nil, nil

--- a/pkg/dmsg/disc/client.go
+++ b/pkg/dmsg/disc/client.go
@@ -32,7 +32,20 @@ type httpClient struct {
 }
 
 // NewHTTP constructs a new APIClient that communicates with discovery via http.
+//
+// Defense-in-depth: an empty address (the operator dropped/blanked the
+// discovery URL to force dmsg-only) must NOT build a host-less httpClient —
+// that turns every request into "GET /dmsg-discovery/...: invalid host address"
+// and spins the dmsg serve-loop retrier indefinitely. Return a no-op client
+// that reports "no servers" cleanly so callers fall back to seeded / dmsg
+// entries instead of hammering an invalid URL.
 func NewHTTP(address string, client *http.Client, log *logging.Logger) APIClient {
+	if address == "" {
+		if log != nil {
+			log.Warn("disc.NewHTTP: empty discovery address; using no-op discovery client (relying on seeded servers / dmsg)")
+		}
+		return noDiscoveryClient{}
+	}
 	log.WithField("func", "disc.NewHTTP").
 		WithField("addr", address).
 		Debug("Created HTTP client.")
@@ -41,6 +54,30 @@ func NewHTTP(address string, client *http.Client, log *logging.Logger) APIClient
 		address: address,
 		log:     log,
 	}
+}
+
+// noDiscoveryClient is the APIClient returned by NewHTTP when no discovery
+// address is configured. Server-list lookups return empty (no error) so the
+// dmsg client falls through to its seeded / config servers without retrying;
+// entry lookups return ErrNoAvailableServers; writes are no-ops.
+type noDiscoveryClient struct{}
+
+func (noDiscoveryClient) Entry(context.Context, cipher.PubKey) (*Entry, error) {
+	return nil, ErrNoAvailableServers
+}
+func (noDiscoveryClient) AvailableServers(context.Context) ([]*Entry, error) { return nil, nil }
+func (noDiscoveryClient) AllServers(context.Context) ([]*Entry, error)       { return nil, nil }
+func (noDiscoveryClient) PostEntry(context.Context, *Entry) error            { return nil }
+func (noDiscoveryClient) PutEntry(context.Context, cipher.SecKey, *Entry) error {
+	return nil
+}
+func (noDiscoveryClient) DelEntry(context.Context, *Entry) error      { return nil }
+func (noDiscoveryClient) AllEntries(context.Context) ([]string, error) { return nil, nil }
+func (noDiscoveryClient) AllClientsByServer(context.Context) (map[string][]*Entry, error) {
+	return nil, nil
+}
+func (noDiscoveryClient) ClientsByServer(context.Context, cipher.PubKey) ([]*Entry, error) {
+	return nil, nil
 }
 
 // Entry retrieves an entry associated with the given public key.

--- a/pkg/dmsg/disc/noop_client_test.go
+++ b/pkg/dmsg/disc/noop_client_test.go
@@ -1,0 +1,37 @@
+//go:build !js
+
+package disc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestNewHTTP_EmptyAddress_NoOp verifies that an empty discovery address yields
+// a no-op client: server-list lookups return empty without error (so the dmsg
+// serve-loop doesn't spin on an invalid host), and entry lookups fail cleanly.
+func TestNewHTTP_EmptyAddress_NoOp(t *testing.T) {
+	c := NewHTTP("", nil, logging.MustGetLogger("disc-test"))
+	_, ok := c.(noDiscoveryClient)
+	require.True(t, ok, "empty address must yield the no-op client")
+
+	srvs, err := c.AvailableServers(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, srvs)
+
+	all, err := c.AllServers(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, all)
+
+	pk, _ := cipher.GenerateKeyPair()
+	_, err = c.Entry(context.Background(), pk)
+	assert.ErrorIs(t, err, ErrNoAvailableServers)
+
+	assert.NoError(t, c.PostEntry(context.Background(), nil))
+}


### PR DESCRIPTION
## Problem

`disc.NewHTTP("")` built a **host-less** `httpClient`, so every request became `GET /dmsg-discovery/…: invalid host address: Invalid public key length`, and the dmsg serve-loop retrier **spun indefinitely**:

```
WARN retrier [dmsgC]: Retrying... error="Get \"/dmsg-discovery/available_servers\": invalid host address: Invalid public key length"
```

This bites when an operator **drops/blanks a discovery URL to force dmsg-only** (the seeded `dmsg.servers` still bootstrap dmsg fine, but the broken HTTP discovery client keeps retrying in the background).

## Fix (defense-in-depth)

`NewHTTP` with an empty address now returns a **no-op `APIClient`** instead of a host-less one:
- `AvailableServers`/`AllServers` → empty, **no error** (the serve loop falls through to seeded/config servers without retrying),
- `Entry` → `ErrNoAvailableServers`,
- writes → no-ops,
- logs a one-line warning so the misconfiguration is visible.

So a missing/empty discovery URL is handled gracefully (dmsg-only) instead of producing an endless invalid-host retry loop.

## Test
`TestNewHTTP_EmptyAddress_NoOp` — empty address yields the no-op client; server-list lookups return empty without error; entry lookups return `ErrNoAvailableServers`; writes succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)