### PR TITLE
feat(cli/config): generate dmsg-only config by default; add --dual flag

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -159,8 +159,9 @@ func init() {
 	gHiddenFlags = append(gHiddenFlags, "url")
 	genConfigCmd.Flags().BoolVarP(&isTestEnv, "testenv", "t", scriptExecBool("${TESTENV:-false}"), "use test deployment (ports offset +10000 from prod)")
 	gHiddenFlags = append(gHiddenFlags, "testenv")
-	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", scriptExecBool("${DMSGHTTP:-false}"), "use only dmsg for skywire services (no http)")
+	genConfigCmd.Flags().BoolVarP(&isDmsgHTTP, "dmsghttp", "d", scriptExecBool("${DMSGHTTP:-false}"), "use only dmsg for skywire services, no http (this is the default)")
 	genConfigCmd.Flags().BoolVar(&isHTTPOnly, "http", false, "use only http for skywire services (no dmsg)")
+	genConfigCmd.Flags().BoolVar(&isDual, "dual", false, "use http for skywire services with dmsg as fallback (dual)")
 	genConfigCmd.MarkFlagsMutuallyExclusive("dmsghttp", "http")
 	gHiddenFlags = append(gHiddenFlags, "dmsghttp")
 	genConfigCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "D", scriptExecString("${DMSGCONF}"), "dmsghttp config path")
@@ -1219,14 +1220,18 @@ func configureLauncher(log *logging.Logger) {
 	// Configure service URLs based on connection mode:
 	// --dmsghttp: DMSG-only (overwrite HTTP URLs with DMSG URLs)
 	// --http: HTTP-only (no DMSG fields, default HTTP URLs kept)
-	// neither: dual mode (HTTP URLs + DMSG URLs in _dmsg fields)
+	// Service-URL mode: dmsg-only by DEFAULT (dmsg:// URLs in the primary
+	// fields, no http). --dual keeps the http URLs with dmsg in the _dmsg
+	// fallback fields. --http (isHTTPOnly) skips the dmsg fields entirely.
+	// --dmsghttp forces dmsg-only (== the default) for backward compatibility.
+	dmsgOnly := isDmsgHTTP || !isDual
 	if !isHTTPOnly {
 		// Prefer unified services config; fall back to legacy dmsgHTTPServersList
 		if services.HasDmsgEndpoints() {
 			// Unified config: DMSG fields from services-config.json
 			conf.Dmsg.Servers = deployment.DmsgServerEntriesToDisc(services.DmsgServers)
 
-			if isDmsgHTTP {
+			if dmsgOnly {
 				conf.Dmsg.Discovery = services.DmsgDiscoveryDmsg
 				conf.Transport.AddressResolver = services.AddressResolverDmsg
 				conf.Transport.Discovery = services.TransportDiscoveryDmsg
@@ -1253,7 +1258,7 @@ func configureLauncher(log *logging.Logger) {
 			}
 			if dmsgConf != nil {
 				conf.Dmsg.Servers = dmsgConf.DMSGServers
-				if isDmsgHTTP {
+				if dmsgOnly {
 					conf.Dmsg.Discovery = dmsgConf.DMSGDiscovery
 					conf.Transport.AddressResolver = dmsgConf.AddressResolver
 					conf.Transport.Discovery = dmsgConf.TransportDiscovery

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -45,6 +45,7 @@ var (
 	transportSetupPKs          string
 	isDmsgHTTP                 bool
 	isHTTPOnly                 bool
+	isDual                     bool
 	minDmsgSess                int
 	isVpnServerEnable          bool
 	isDisableAuth              bool

--- a/pkg/dmsg/disc/client.go
+++ b/pkg/dmsg/disc/client.go
@@ -71,7 +71,7 @@ func (noDiscoveryClient) PostEntry(context.Context, *Entry) error            { r
 func (noDiscoveryClient) PutEntry(context.Context, cipher.SecKey, *Entry) error {
 	return nil
 }
-func (noDiscoveryClient) DelEntry(context.Context, *Entry) error      { return nil }
+func (noDiscoveryClient) DelEntry(context.Context, *Entry) error       { return nil }
 func (noDiscoveryClient) AllEntries(context.Context) ([]string, error) { return nil, nil }
 func (noDiscoveryClient) AllClientsByServer(context.Context) (map[string][]*Entry, error) {
 	return nil, nil

--- a/pkg/dmsg/disc/client.go
+++ b/pkg/dmsg/disc/client.go
@@ -32,7 +32,20 @@ type httpClient struct {
 }
 
 // NewHTTP constructs a new APIClient that communicates with discovery via http.
+//
+// Defense-in-depth: an empty address (the operator dropped/blanked the
+// discovery URL to force dmsg-only) must NOT build a host-less httpClient —
+// that turns every request into "GET /dmsg-discovery/...: invalid host address"
+// and spins the dmsg serve-loop retrier indefinitely. Return a no-op client
+// that reports "no servers" cleanly so callers fall back to seeded / dmsg
+// entries instead of hammering an invalid URL.
 func NewHTTP(address string, client *http.Client, log *logging.Logger) APIClient {
+	if address == "" {
+		if log != nil {
+			log.Warn("disc.NewHTTP: empty discovery address; using no-op discovery client (relying on seeded servers / dmsg)")
+		}
+		return noDiscoveryClient{}
+	}
 	log.WithField("func", "disc.NewHTTP").
 		WithField("addr", address).
 		Debug("Created HTTP client.")
@@ -41,6 +54,30 @@ func NewHTTP(address string, client *http.Client, log *logging.Logger) APIClient
 		address: address,
 		log:     log,
 	}
+}
+
+// noDiscoveryClient is the APIClient returned by NewHTTP when no discovery
+// address is configured. Server-list lookups return empty (no error) so the
+// dmsg client falls through to its seeded / config servers without retrying;
+// entry lookups return ErrNoAvailableServers; writes are no-ops.
+type noDiscoveryClient struct{}
+
+func (noDiscoveryClient) Entry(context.Context, cipher.PubKey) (*Entry, error) {
+	return nil, ErrNoAvailableServers
+}
+func (noDiscoveryClient) AvailableServers(context.Context) ([]*Entry, error) { return nil, nil }
+func (noDiscoveryClient) AllServers(context.Context) ([]*Entry, error)       { return nil, nil }
+func (noDiscoveryClient) PostEntry(context.Context, *Entry) error            { return nil }
+func (noDiscoveryClient) PutEntry(context.Context, cipher.SecKey, *Entry) error {
+	return nil
+}
+func (noDiscoveryClient) DelEntry(context.Context, *Entry) error      { return nil }
+func (noDiscoveryClient) AllEntries(context.Context) ([]string, error) { return nil, nil }
+func (noDiscoveryClient) AllClientsByServer(context.Context) (map[string][]*Entry, error) {
+	return nil, nil
+}
+func (noDiscoveryClient) ClientsByServer(context.Context, cipher.PubKey) ([]*Entry, error) {
+	return nil, nil
 }
 
 // Entry retrieves an entry associated with the given public key.

--- a/pkg/dmsg/disc/noop_client_test.go
+++ b/pkg/dmsg/disc/noop_client_test.go
@@ -1,0 +1,37 @@
+//go:build !js
+
+package disc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestNewHTTP_EmptyAddress_NoOp verifies that an empty discovery address yields
+// a no-op client: server-list lookups return empty without error (so the dmsg
+// serve-loop doesn't spin on an invalid host), and entry lookups fail cleanly.
+func TestNewHTTP_EmptyAddress_NoOp(t *testing.T) {
+	c := NewHTTP("", nil, logging.MustGetLogger("disc-test"))
+	_, ok := c.(noDiscoveryClient)
+	require.True(t, ok, "empty address must yield the no-op client")
+
+	srvs, err := c.AvailableServers(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, srvs)
+
+	all, err := c.AllServers(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, all)
+
+	pk, _ := cipher.GenerateKeyPair()
+	_, err = c.Entry(context.Background(), pk)
+	assert.ErrorIs(t, err, ErrNoAvailableServers)
+
+	assert.NoError(t, c.PostEntry(context.Background(), nil))
+}

--- a/pkg/servicedisc/client.go
+++ b/pkg/servicedisc/client.go
@@ -129,8 +129,20 @@ func (c *HTTPClient) Auth(ctx context.Context) (*httpauthclient.Client, error) {
 	return auth, nil
 }
 
+// Configured reports whether this client can perform HTTP service discovery —
+// it has both a non-nil http.Client and a discovery address. Callers (e.g. the
+// autoconnector) should skip the HTTP path when this is false instead of
+// invoking it, which would otherwise nil-deref c.client. This happens when the
+// operator drops/blanks the service_discovery URL to force dmsg-only.
+func (c *HTTPClient) Configured() bool {
+	return c != nil && c.client != nil && c.conf.DiscAddr != ""
+}
+
 // Services calls 'GET /api/services'.
 func (c *HTTPClient) Services(ctx context.Context, quantity int, version, country string) (out []Service, err error) {
+	if c.client == nil {
+		return nil, errors.New("servicedisc: no HTTP client configured (service_discovery URL not set)")
+	}
 	url, err := c.addr("/api/services", c.entry.Type, version, country, quantity)
 	if err != nil {
 		return nil, err

--- a/pkg/visor/autoconnect.go
+++ b/pkg/visor/autoconnect.go
@@ -429,7 +429,14 @@ func (a *autoconnector) fetchPubAddresses(ctx context.Context, v *Visor) ([]ciph
 		}
 	}
 
-	// Fall back to HTTP service discovery.
+	// Fall back to HTTP service discovery — only when it's configured.
+	// With service_discovery dropped (dmsg-only), there is no HTTP client; the
+	// CXO snapshot above is the only public-visor source, so return cleanly
+	// instead of nil-dereferencing the absent client.
+	if !a.client.Configured() {
+		a.log.Debug("Autoconnect: HTTP service discovery not configured; relying on CXO snapshot only")
+		return nil, nil
+	}
 	var services []servicedisc.Service
 	retrier := netutil.NewDefaultRetrier(a.log)
 	fetch := func() (err error) {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -185,15 +185,24 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 
 	conf := v.conf.Launcher
 
-	httpC, err := getHTTPClient(ctx, v, conf.ServiceDisc)
+	// Prefer the HTTP service-discovery URL; fall back to the dmsg URL when the
+	// operator dropped the HTTP one (dmsg-only). getHTTPClient returns the
+	// dmsg-http client for a dmsg:// URL, so the autoconnector still fetches
+	// public visors over dmsg. Same http-or-dmsg selection as route-finder/AR.
+	sdURL := conf.ServiceDisc
+	if sdURL == "" && conf.ServiceDiscDmsg != "" {
+		sdURL = conf.ServiceDiscDmsg
+	}
+
+	httpC, err := getHTTPClient(ctx, v, sdURL)
 	if err != nil {
 		return err
 	}
 
-	if conf.ServiceDisc != "" {
+	if sdURL != "" {
 		factory.PK = v.conf.PK
 		factory.SK = v.conf.SK
-		factory.ServiceDisc = conf.ServiceDisc
+		factory.ServiceDisc = sdURL
 		factory.DisplayNodeIP = conf.DisplayNodeIP
 		factory.HeartbeatInterval = time.Duration(conf.HeartbeatInterval)
 		factory.Client = httpC


### PR DESCRIPTION
## What

`skywire cli config gen` now produces a **dmsg-only (dmsghttp) config by default** — `dmsg://` URLs in the service fields, no plain-http endpoints — so visors use the decentralized path out of the box and stop hammering the public HTTP services (and Caddy/TPD HTTP logs).

| flag | service URLs |
|------|--------------|
| **(default)** | **dmsg-only** — `dmsg://` in the primary fields (was: dual) |
| `--dual` | http URLs **+** dmsg in the `_dmsg` fallback fields (the old default) |
| `--http` | http-only (unchanged) |
| `--dmsghttp` / `-d` | dmsg-only — now == the default; kept for back-compat |

## How

The three URL representations already existed in `gen.go`; this gates them on `dmsgOnly := isDmsgHTTP || !isDual` (default true) and adds the `--dual` flag. `geoip` stays http (it has no dmsg endpoint).

The dmsg-only form puts a valid `dmsg://` URL in the primary fields (not an empty field), so it's the safe representation — `getHTTPClient` resolves `dmsg://` to the dmsg-http client.

## Verified
All four modes generated and inspected (`-n`): default → dmsg-only, `--dual` → both, `--http` → http-only, `--dmsghttp` → dmsg-only. Config package tests + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)