### PR TITLE
feat(cipher,dmsg/noise,cmdutil): instrument the verify / DH caches + /debug/cache endpoint

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -459,7 +459,9 @@ func (s *memoryStore) GetTransportsByEdge(_ context.Context, pk cipher.PubKey) (
 }
 
 // Unused interface methods - stubs for store.Store compliance
-func (s *memoryStore) RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error { return nil }
+func (s *memoryStore) RegisterTransport(context.Context, cipher.PubKey, *transport.SignedEntry) error {
+	return nil
+}
 func (s *memoryStore) RegisterTransportsBatch(context.Context, cipher.PubKey, []*transport.SignedEntry) error {
 	return nil
 }

--- a/pkg/cipher/cipher.go
+++ b/pkg/cipher/cipher.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/secp256k1-go"
@@ -22,6 +23,10 @@ var (
 	verifyCacheMu   sync.RWMutex
 	verifyCacheMap  = make(map[[130]byte]struct{}, 1024) // key: PK(33) + Sig(65) + Hash(32) = 130 bytes
 	verifyCacheSize int
+
+	verifyCacheHits      atomic.Uint64
+	verifyCacheMisses    atomic.Uint64
+	verifyCacheEvictions atomic.Uint64
 )
 
 const maxVerifyCacheSize = 4096
@@ -39,6 +44,11 @@ func verifyCacheCheck(pk cipher.PubKey, sig cipher.Sig, hash cipher.SHA256) bool
 	verifyCacheMu.RLock()
 	_, ok := verifyCacheMap[key]
 	verifyCacheMu.RUnlock()
+	if ok {
+		verifyCacheHits.Add(1)
+	} else {
+		verifyCacheMisses.Add(1)
+	}
 	return ok
 }
 
@@ -49,10 +59,38 @@ func verifyCacheStore(pk cipher.PubKey, sig cipher.Sig, hash cipher.SHA256) {
 		// Simple eviction: clear entire cache.
 		verifyCacheMap = make(map[[130]byte]struct{}, 1024)
 		verifyCacheSize = 0
+		verifyCacheEvictions.Add(1)
 	}
 	verifyCacheMap[key] = struct{}{}
 	verifyCacheSize++
 	verifyCacheMu.Unlock()
+}
+
+// VerifyCacheStats is a snapshot of the signature-verify cache counters.
+// Hits/Misses are counted on every verifyCacheCheck; Evictions is
+// incremented each time the cache hits maxVerifyCacheSize and is wiped.
+// Size is the current entry count.
+type VerifyCacheStats struct {
+	Hits      uint64
+	Misses    uint64
+	Evictions uint64
+	Size      int
+	Capacity  int
+}
+
+// GetVerifyCacheStats returns a snapshot of the signature-verify
+// cache counters. Safe to call concurrently with verification.
+func GetVerifyCacheStats() VerifyCacheStats {
+	verifyCacheMu.RLock()
+	size := verifyCacheSize
+	verifyCacheMu.RUnlock()
+	return VerifyCacheStats{
+		Hits:      verifyCacheHits.Load(),
+		Misses:    verifyCacheMisses.Load(),
+		Evictions: verifyCacheEvictions.Load(),
+		Size:      size,
+		Capacity:  maxVerifyCacheSize,
+	}
 }
 
 func init() {

--- a/pkg/cipher/cipher_test.go
+++ b/pkg/cipher/cipher_test.go
@@ -132,3 +132,51 @@ func BenchmarkVerifyPubKeySignedPayload(b *testing.B) {
 		_ = VerifyPubKeySignedPayload(pk, sig, payload) //nolint
 	}
 }
+
+// TestVerifyCacheStats validates the hits / misses / evictions
+// counters exposed via GetVerifyCacheStats. First verify is a miss
+// + populates the cache; repeated verifies are hits. Filling past
+// maxVerifyCacheSize triggers a wipe (Evictions++, Size resets to 1).
+func TestVerifyCacheStats(t *testing.T) {
+	resetVerifyCache()
+
+	pk, sk := GenerateKeyPair()
+	payload := []byte("stats test payload")
+	sig, err := SignPayload(payload, sk)
+	require.NoError(t, err)
+
+	// First verify — miss + populate.
+	require.NoError(t, VerifyPubKeySignedPayload(pk, sig, payload))
+	// 5 more — all hits.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, VerifyPubKeySignedPayload(pk, sig, payload))
+	}
+
+	s := GetVerifyCacheStats()
+	assert.Equal(t, uint64(5), s.Hits, "expected 5 hits after first verify populated the cache")
+	assert.Equal(t, uint64(1), s.Misses, "expected 1 miss on first verify")
+	assert.Equal(t, 1, s.Size)
+	assert.Equal(t, maxVerifyCacheSize, s.Capacity)
+	assert.Equal(t, uint64(0), s.Evictions, "expected no evictions yet")
+
+	// Stuff the cache past capacity to trigger a wipe.
+	for i := 0; i <= maxVerifyCacheSize; i++ {
+		spk, ssk := GenerateKeyPair()
+		ssig, _ := SignPayload(payload, ssk)              //nolint
+		_ = VerifyPubKeySignedPayload(spk, ssig, payload) //nolint
+	}
+	s = GetVerifyCacheStats()
+	assert.GreaterOrEqual(t, s.Evictions, uint64(1), "expected at least one eviction (wipe) after overflow")
+}
+
+// resetVerifyCache wipes the package-level cache + counters for
+// test isolation.
+func resetVerifyCache() {
+	verifyCacheMu.Lock()
+	verifyCacheMap = make(map[[130]byte]struct{}, 1024)
+	verifyCacheSize = 0
+	verifyCacheMu.Unlock()
+	verifyCacheHits.Store(0)
+	verifyCacheMisses.Store(0)
+	verifyCacheEvictions.Store(0)
+}

--- a/pkg/dmsg/cmdutil/pprof.go
+++ b/pkg/dmsg/cmdutil/pprof.go
@@ -2,6 +2,7 @@
 package cmdutil
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -9,8 +10,61 @@ import (
 	rpprof "runtime/pprof"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
 	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// cacheStatsHandler exposes the in-process cipher signature-verify
+// cache and noise DH cache counters as JSON. Mounted at
+// /debug/cache by startPProfHTTP. Sits beside the standard
+// /debug/pprof/* endpoints so operators can pull hit/miss/eviction
+// rates from the same pprof server without a separate listener.
+//
+// Output shape (hit_rate is misses>0 ? hits/(hits+misses) : 0):
+//
+//	{
+//	  "verify_cache": {
+//	    "hits": uint64, "misses": uint64, "evictions": uint64,
+//	    "size": int, "capacity": int, "hit_rate": float64
+//	  },
+//	  "dh_cache": {
+//	    "hits": uint64, "misses": uint64, "evictions": uint64,
+//	    "size": int, "capacity": int, "hit_rate": float64
+//	  }
+//	}
+func cacheStatsHandler(w http.ResponseWriter, _ *http.Request) {
+	vs := cipher.GetVerifyCacheStats()
+	ds := noise.GetCacheStats()
+	out := map[string]any{
+		"verify_cache": map[string]any{
+			"hits":      vs.Hits,
+			"misses":    vs.Misses,
+			"evictions": vs.Evictions,
+			"size":      vs.Size,
+			"capacity":  vs.Capacity,
+			"hit_rate":  hitRate(vs.Hits, vs.Misses),
+		},
+		"dh_cache": map[string]any{
+			"hits":      ds.Hits,
+			"misses":    ds.Misses,
+			"evictions": ds.Evictions,
+			"size":      ds.Size,
+			"capacity":  ds.Capacity,
+			"hit_rate":  hitRate(ds.Hits, ds.Misses),
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out) //nolint:errcheck
+}
+
+func hitRate(hits, misses uint64) float64 {
+	total := hits + misses
+	if total == 0 {
+		return 0
+	}
+	return float64(hits) / float64(total)
+}
 
 // InitPProf starts profiling based on the given mode and address.
 // Supported modes: http, cpu, mem, mutex, block, trace.
@@ -142,7 +196,8 @@ func startPProfHTTP(log *logging.Logger, addr string, traceOnly bool) {
 			for _, profile := range []string{"heap", "goroutine", "threadcreate", "block", "mutex", "allocs"} {
 				mux.Handle("/debug/pprof/"+profile, pprof.Handler(profile))
 			}
-			log.Infof("Serving pprof on http://%s (dedicated thread)", addr)
+			mux.HandleFunc("/debug/cache", cacheStatsHandler)
+			log.Infof("Serving pprof on http://%s (dedicated thread); cipher+DH cache stats at /debug/cache", addr)
 		}
 
 		srv := &http.Server{

--- a/pkg/dmsg/cmdutil/pprof_test.go
+++ b/pkg/dmsg/cmdutil/pprof_test.go
@@ -2,9 +2,11 @@
 package cmdutil
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -75,4 +77,65 @@ func TestInitPProf_MemMode(t *testing.T) {
 	assert.NotNil(t, stop)
 	// stop() writes mem.pprof - just verify it doesn't panic
 	// Skip actual file creation in tests to avoid polluting test dirs
+}
+
+// TestCacheStatsHandler verifies the /debug/cache handler renders
+// the expected JSON shape. Counter values themselves come from
+// package-level state populated by real cipher / noise paths
+// (covered by their own tests); this just exercises the handler.
+func TestCacheStatsHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/cache", nil)
+	cacheStatsHandler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var body map[string]map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	for _, section := range []string{"verify_cache", "dh_cache"} {
+		s, ok := body[section]
+		require.True(t, ok, "missing section %q", section)
+		for _, field := range []string{"hits", "misses", "evictions", "size", "capacity", "hit_rate"} {
+			_, ok := s[field]
+			assert.True(t, ok, "missing field %q in %s section", field, section)
+		}
+	}
+}
+
+func TestHitRate(t *testing.T) {
+	cases := []struct {
+		hits, misses uint64
+		want         float64
+	}{
+		{0, 0, 0},      // no data
+		{0, 10, 0},     // pure misses
+		{10, 0, 1},     // pure hits
+		{75, 25, 0.75}, // typical
+		{1, 1, 0.5},    // 50/50
+	}
+	for _, c := range cases {
+		got := hitRate(c.hits, c.misses)
+		assert.Equal(t, c.want, got, "hitRate(%d, %d)", c.hits, c.misses)
+	}
+}
+
+// TestInitPProf_HTTPMode_CacheEndpoint verifies the /debug/cache
+// endpoint is also reachable via the full pprof HTTP server (not
+// just direct handler invocation).
+func TestInitPProf_HTTPMode_CacheEndpoint(t *testing.T) {
+	log := logging.MustGetLogger("test")
+	addr := getFreePort(t)
+
+	stop := InitPProf(log, "http", addr)
+	defer stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/debug/cache", addr)) //nolint:gosec
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }

--- a/pkg/dmsg/noise/dh.go
+++ b/pkg/dmsg/noise/dh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 
 	"github.com/skycoin/noise"
 	"github.com/skycoin/skycoin/src/cipher"
@@ -80,6 +81,10 @@ type dhCacheKey [65]byte
 var (
 	dhCacheMu sync.RWMutex
 	dhCache   = make(map[dhCacheKey][33]byte, dhCacheMax)
+
+	dhCacheHits      atomic.Uint64
+	dhCacheMisses    atomic.Uint64
+	dhCacheEvictions atomic.Uint64
 )
 
 func makeDHKey(sk, pk []byte) dhCacheKey {
@@ -99,10 +104,12 @@ func (Secp256k1) DH(sk, pk []byte) []byte {
 	cached, hit := dhCache[k]
 	dhCacheMu.RUnlock()
 	if hit {
+		dhCacheHits.Add(1)
 		out := make([]byte, 33)
 		copy(out, cached[:])
 		return out
 	}
+	dhCacheMisses.Add(1)
 
 	var pubKey cipher.PubKey
 	var secKey cipher.SecKey
@@ -129,10 +136,38 @@ func (Secp256k1) DH(sk, pk []byte) []byte {
 			delete(dhCache, k0)
 			break
 		}
+		dhCacheEvictions.Add(1)
 	}
 	dhCache[k] = entry
 	dhCacheMu.Unlock()
 	return out
+}
+
+// CacheStats is a snapshot of the noise DH cache counters. Hits/Misses
+// are counted on every call to (Secp256k1).DH; Evictions is incremented
+// each time a single entry is dropped to make room (one per eviction,
+// not per overflowed insertion).
+type CacheStats struct {
+	Hits      uint64
+	Misses    uint64
+	Evictions uint64
+	Size      int
+	Capacity  int
+}
+
+// GetCacheStats returns a snapshot of the noise DH cache counters.
+// Safe to call concurrently with DH.
+func GetCacheStats() CacheStats {
+	dhCacheMu.RLock()
+	size := len(dhCache)
+	dhCacheMu.RUnlock()
+	return CacheStats{
+		Hits:      dhCacheHits.Load(),
+		Misses:    dhCacheMisses.Load(),
+		Evictions: dhCacheEvictions.Load(),
+		Size:      size,
+		Capacity:  dhCacheMax,
+	}
 }
 
 // DHLen helps to implement `noise.DHFunc`.

--- a/pkg/dmsg/noise/dh_test.go
+++ b/pkg/dmsg/noise/dh_test.go
@@ -75,6 +75,59 @@ func resetDHCache() {
 	dhCacheMu.Lock()
 	dhCache = make(map[dhCacheKey][33]byte, dhCacheMax)
 	dhCacheMu.Unlock()
+	dhCacheHits.Store(0)
+	dhCacheMisses.Store(0)
+	dhCacheEvictions.Store(0)
+}
+
+// TestDHCacheStats validates the hits / misses / evictions counters
+// exposed via GetCacheStats. Each unique (sk, pk) input is a miss
+// on first call and a hit on subsequent calls; overflowing the
+// cap triggers an eviction per overflow insertion.
+func TestDHCacheStats(t *testing.T) {
+	resetDHCache()
+
+	dh := Secp256k1{}
+	pk1, sk1 := secp256k1.GenerateKeyPair()
+	pk2, sk2 := secp256k1.GenerateKeyPair()
+
+	// First call on each pair = miss.
+	_ = dh.DH(sk1, pk2)
+	_ = dh.DH(sk2, pk1)
+	// Repeat — both hits.
+	_ = dh.DH(sk1, pk2)
+	_ = dh.DH(sk2, pk1)
+	_ = dh.DH(sk1, pk2)
+
+	s := GetCacheStats()
+	if s.Hits != 3 {
+		t.Fatalf("expected Hits=3, got %d", s.Hits)
+	}
+	if s.Misses != 2 {
+		t.Fatalf("expected Misses=2, got %d", s.Misses)
+	}
+	if s.Size != 2 {
+		t.Fatalf("expected Size=2, got %d", s.Size)
+	}
+	if s.Capacity != dhCacheMax {
+		t.Fatalf("expected Capacity=%d, got %d", dhCacheMax, s.Capacity)
+	}
+	if s.Evictions != 0 {
+		t.Fatalf("expected Evictions=0 (no overflow yet), got %d", s.Evictions)
+	}
+
+	// Push past the cap to trigger evictions.
+	for i := 0; i < dhCacheMax*2; i++ {
+		pk, sk := secp256k1.GenerateKeyPair()
+		_ = dh.DH(sk, pk)
+	}
+	s = GetCacheStats()
+	if s.Evictions == 0 {
+		t.Fatalf("expected Evictions>0 after pushing 2x cap, got 0")
+	}
+	if s.Size > dhCacheMax {
+		t.Fatalf("Size exceeded Capacity: %d > %d", s.Size, dhCacheMax)
+	}
 }
 
 // dhCacheSize returns the current entry count under the lock.


### PR DESCRIPTION
## Summary

- Add atomic **hit / miss / eviction counters** to the two existing in-process crypto caches (`pkg/cipher.verifyCache` + `pkg/dmsg/noise.dhCache`).
- Expose a JSON snapshot at **`/debug/cache`** mounted on the same pprof HTTP server services already run, so operators can read it without any new listener / config knob.

## Why

Production CPU profiles of dmsg-discovery / address-resolver / TPD spend ~22-31% in secp256k1 ECDH on inbound noise handshakes. The two caches in place (added previously) do save the static-static DH and the sig-verify side, but their effectiveness is currently invisible — there's no way to confirm hit rate or know whether `maxVerifyCacheSize` / `dhCacheMax` are sized right.

This change makes the caches observable so the next optimization conversation (stream pooling, batched lookups, etc.) can start from data instead of guesswork.

## Shape

```
GET /debug/cache → 200 application/json
{
  "verify_cache": {
    "hits": uint64, "misses": uint64, "evictions": uint64,
    "size": int, "capacity": int, "hit_rate": float64
  },
  "dh_cache": {
    "hits": uint64, "misses": uint64, "evictions": uint64,
    "size": int, "capacity": int, "hit_rate": float64
  }
}
```

`hit_rate` = `hits / (hits + misses)`; 0 when the cache hasn't been touched yet.

Counters are `atomic.Uint64` so no extra lock acquisitions are added on the hot path. Cache structure / eviction policy is unchanged.

## Test plan

- [x] `go test ./pkg/cipher/... ./pkg/dmsg/noise/... ./pkg/dmsg/cmdutil/...` — all green.
- [x] New unit tests cover counter increments on hit / miss, eviction on cap overflow, JSON shape of the handler, end-to-end fetch via the pprof HTTP listener.
- [x] `gofmt`, `go vet`, `go build ./...` clean.
- [ ] Once deployed on a live service: `curl http://<host>:<pprof-addr>/debug/cache` returns non-zero counts within a minute or two — that's the observability win.