### PR TITLE
fix(visor/autoconnect): don't re-default dropped service_discovery to prod HTTP

### DIFF
--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ccding/go-stun/stun"
 	"github.com/google/uuid"
 
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -601,9 +600,19 @@ func (v *Visor) startPublicAutoconnectInternal(ctx context.Context, log *logging
 		return nil // already running
 	}
 
+	// Prefer the HTTP service-discovery URL; fall back to the dmsg URL when the
+	// operator dropped the HTTP one (dmsg-only). Never silently substitute the
+	// hardcoded prod HTTP discovery: a dropped field is intentional, and pairing
+	// sd.skycoin.com with the dmsg-http client (v.serviceDisc.Client, built from
+	// the dmsg URL in initDiscovery) makes the connector dial sd.skycoin.com over
+	// dmsg → "invalid host address: Invalid public key". Mirror initDiscovery.
 	serviceDisc := v.conf.Launcher.ServiceDisc
-	if serviceDisc == "" { //it might be intentionally blank ; consider revising.
-		serviceDisc = deployment.Prod.ServiceDiscovery
+	if serviceDisc == "" {
+		serviceDisc = v.conf.Launcher.ServiceDiscDmsg
+	}
+	if serviceDisc == "" {
+		log.Debug("service discovery not configured (neither http nor dmsg URL); skipping public autoconnect")
+		return nil
 	}
 
 	// todo: refactor updatedisc: split connecting to services in updatedisc and


### PR DESCRIPTION
Follow-up to #2982. `startPublicAutoconnectInternal` had its own service-discovery defaulting separate from `initDiscovery`, and I missed it: when `Launcher.ServiceDisc` is empty (dmsg-only config, HTTP SD field dropped) it substituted `deployment.Prod.ServiceDiscovery` (`http://sd.skycoin.com`), then passed that URL to `MakeConnector` **alongside the dmsg-http client** (`v.serviceDisc.Client`, built from the dmsg SD URL back in `initDiscovery`). The connector then dialed sd.skycoin.com over dmsg, spinning forever:

```
WARN [public_autoconnect]: Retrying... error="Get \"http://sd.skycoin.com/api/services?quantity=3&type=visor\": invalid host address: Invalid public key"
```

(the dmsg-http transport tries to parse `sd.skycoin.com` as a dmsg public key).

### Fix
Mirror the dmsg-fallback `initDiscovery` already uses:
- prefer `Launcher.ServiceDisc` (HTTP),
- fall back to `Launcher.ServiceDiscDmsg` (so autoconnect still runs over dmsg),
- **skip** public autoconnect when neither is set, instead of silently re-defaulting to the hardcoded prod HTTP discovery.

A dropped `service_discovery` field is intentional and must never be re-substituted with an HTTP endpoint in a dmsg-only deployment. Drops the now-unused `deployment` import.

Verified: `go build .` clean. `cli dmsg curl` confirms the dmsg SD path itself is reachable; this removes the bogus sd.skycoin.com dial.