### PR TITLE
fix(dmsghttp): advertise Accept-Encoding: gzip + transparent decompress

### DIFF
--- a/pkg/dmsg/dmsghttp/http_transport.go
+++ b/pkg/dmsg/dmsghttp/http_transport.go
@@ -3,11 +3,13 @@ package dmsghttp
 
 import (
 	"bufio"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -112,13 +114,32 @@ func (t *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		hostAddr.Port = defaultHTTPPort
 	}
 
+	// Mirror net/http.Transport's transparent gzip. This custom
+	// RoundTripper bypasses the stdlib Transport (see type doc), so
+	// without this it never advertises Accept-Encoding and TPD/AR/SD
+	// reply with uncompressed bodies — the "gzip gap" that drove the
+	// residual dmsg-server write CPU + egress after the TPD #2980 cache
+	// landed (TPD already pre-marshals gzip; the dmsg client just never
+	// asked). Only auto-gzip when the caller set no encoding of its own
+	// and it's not a HEAD/Range request, then transparently decompress
+	// in do() so callers are unaffected. Computed once here (not in
+	// do()) so the pooled-then-fresh retry path doesn't see the header
+	// we set on the first attempt and skip decompression on the second.
+	requestedGzip := false
+	if req.Header.Get("Accept-Encoding") == "" &&
+		req.Header.Get("Range") == "" &&
+		req.Method != http.MethodHead {
+		requestedGzip = true
+		req.Header.Set("Accept-Encoding", "gzip")
+	}
+
 	// Try one pooled stream first; if the write or response read fails
 	// (idle conn was closed by peer between requests), fall through to
 	// a fresh dial. We never retry idempotent requests beyond a single
 	// pooled-then-fresh attempt because the test/production cost of
 	// multi-retry is higher than just paying a fresh handshake.
 	if ps := t.takeIdle(hostAddr); ps != nil {
-		resp, err := t.do(ps, req)
+		resp, err := t.do(ps, req, requestedGzip)
 		if err == nil {
 			return resp, nil
 		}
@@ -143,7 +164,7 @@ func (t *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	ps := &pooledStream{s: stream, br: bufio.NewReader(stream), host: hostAddr}
 	t.track(ps)
-	resp, err := t.do(ps, req)
+	resp, err := t.do(ps, req, requestedGzip)
 	if err != nil {
 		ps.discard()
 		t.untrack(ps)
@@ -173,13 +194,27 @@ func rewindBody(req *http.Request) error {
 // do writes req to ps and reads back the response. The response body
 // is wrapped so that closing it returns the stream to the idle pool
 // (or discards it on error).
-func (t *HTTPTransport) do(ps *pooledStream, req *http.Request) (*http.Response, error) {
+func (t *HTTPTransport) do(ps *pooledStream, req *http.Request, requestedGzip bool) (*http.Response, error) {
 	if err := req.Write(ps.s); err != nil {
 		return nil, err
 	}
 	resp, err := http.ReadResponse(ps.br, req)
 	if err != nil {
 		return nil, err
+	}
+	// When we asked for gzip on the caller's behalf, decompress
+	// transparently so callers see a plain body — same contract as
+	// net/http.Transport. Drop the now-misleading Content-Encoding and
+	// Content-Length and mark the response Uncompressed. The gzipReader
+	// wraps the raw body and is itself wrapped by pooledBody below, so
+	// Close still drains the underlying compressed stream before the
+	// dmsg stream returns to the idle pool.
+	if requestedGzip && strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		resp.Header.Del("Content-Encoding")
+		resp.Header.Del("Content-Length")
+		resp.ContentLength = -1
+		resp.Uncompressed = true
+		resp.Body = &gzipReader{body: resp.Body}
 	}
 	resp.Body = &pooledBody{
 		ReadCloser: resp.Body,
@@ -335,4 +370,33 @@ func (b *pooledBody) Close() error {
 		b.t.putIdle(b.ps)
 	}
 	return closeErr
+}
+
+// gzipReader transparently decompresses a gzip-encoded response body,
+// mirroring net/http.Transport's internal gzipReader (which this custom
+// RoundTripper bypasses). The gzip.Reader is created lazily on first
+// Read so a never-read body still closes cleanly, and Close closes the
+// underlying body rather than the gzip reader — draining the underlying
+// (compressed) stream is what pooledBody.Close relies on to recycle the
+// dmsg stream.
+type gzipReader struct {
+	body io.ReadCloser
+	zr   *gzip.Reader
+	zerr error
+}
+
+func (gz *gzipReader) Read(p []byte) (int, error) {
+	if gz.zr == nil {
+		if gz.zerr == nil {
+			gz.zr, gz.zerr = gzip.NewReader(gz.body)
+		}
+		if gz.zerr != nil {
+			return 0, gz.zerr
+		}
+	}
+	return gz.zr.Read(p)
+}
+
+func (gz *gzipReader) Close() error {
+	return gz.body.Close()
 }

--- a/pkg/dmsg/dmsghttp/http_transport_test.go
+++ b/pkg/dmsg/dmsghttp/http_transport_test.go
@@ -3,10 +3,12 @@ package dmsghttp
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -225,4 +227,107 @@ func newDmsgClient(t *testing.T, dc disc.APIClient, minSessions int, name string
 		t.Fatal("timed out waiting for dmsg client to be ready")
 	}
 	return dmsgC
+}
+
+// TestHTTPTransport_TransparentGzip pins the "gzip gap" fix: because this
+// transport is a custom http.RoundTripper that bypasses net/http.Transport,
+// it must itself advertise Accept-Encoding: gzip on the caller's behalf and
+// transparently decompress the response — otherwise dmsg service callers
+// (TPD/AR/SD) receive uncompressed bodies even though the server can gzip,
+// driving dmsg-server write CPU + egress (Beta's post-#2980 residual).
+func TestHTTPTransport_TransparentGzip(t *testing.T) {
+	logging.SetLevel(logrus.WarnLevel)
+
+	const (
+		nSrvs       = 1
+		minSessions = 1
+		maxSessions = 10
+		port        = uint16(80)
+	)
+	// A payload large/repetitive enough that gzip is unmistakably applied.
+	payload := strings.Repeat("the quick brown fox jumps over the lazy dog. ", 200)
+
+	dc := startDmsgEnv(t, nSrvs, maxSessions)
+
+	lis, err := newDmsgClient(t, dc, minSessions, "gzipsrv").Listen(port)
+	require.NoError(t, err)
+
+	gotAcceptEncoding := make(chan string, 4)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/gzip", func(w http.ResponseWriter, r *http.Request) {
+		gotAcceptEncoding <- r.Header.Get("Accept-Encoding")
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write([]byte(payload))
+		_ = gz.Close()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write(buf.Bytes())
+	})
+	mux.HandleFunc("/plain", func(w http.ResponseWriter, r *http.Request) {
+		gotAcceptEncoding <- r.Header.Get("Accept-Encoding")
+		_, _ = w.Write([]byte(payload))
+	})
+	srv := &http.Server{ReadHeaderTimeout: 3 * time.Second, Handler: mux}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(lis); close(errCh) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx) //nolint:errcheck
+		_ = lis.Close()       //nolint:errcheck
+		<-errCh
+	})
+
+	addr := lis.Addr().String()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	httpC := http.Client{
+		Transport: MakeHTTPTransport(ctx, newDmsgClient(t, dc, minSessions, "gzipcli")),
+		Timeout:   30 * time.Second,
+	}
+	time.Sleep(2 * time.Second)
+
+	waitAE := func(t *testing.T) string {
+		t.Helper()
+		select {
+		case ae := <-gotAcceptEncoding:
+			return ae
+		case <-time.After(10 * time.Second):
+			t.Fatal("server never received the request")
+			return ""
+		}
+	}
+
+	t.Run("gzip_response_transparently_decompressed", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/gzip", nil)
+		require.NoError(t, err)
+		resp, err := httpC.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Contains(t, waitAE(t), "gzip", "transport must advertise Accept-Encoding: gzip")
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(body), "body must be transparently decompressed")
+		assert.True(t, resp.Uncompressed, "resp.Uncompressed must be set after transparent decode")
+		assert.Empty(t, resp.Header.Get("Content-Encoding"), "Content-Encoding must be stripped")
+	})
+
+	t.Run("caller_accept_encoding_preserved_no_autodecode", func(t *testing.T) {
+		// A caller that sets its own Accept-Encoding must be left alone:
+		// we neither override the header nor auto-decompress (net/http parity).
+		req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/plain", nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept-Encoding", "identity")
+		resp, err := httpC.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, "identity", waitAE(t), "caller's Accept-Encoding must be preserved")
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(body))
+	})
 }


### PR DESCRIPTION
Follow-up to #2980. Closes the **gzip gap** Beta found in the post-#2980 TPD re-check.

### Problem
`dmsghttp.HTTPTransport` is a **custom `http.RoundTripper`** that deliberately bypasses `net/http.Transport` (dmsg.Stream's read-deadline auto-extend fights net/http's idle-conn detection — see the type doc). A side effect: it loses the stdlib Transport's automatic `Accept-Encoding: gzip` + transparent decompression that clearnet callers get for free.

Beta's pprof after the #2980 TPD cache/gzip work landed:
- clearnet callers: **179/179** gzip
- dmsg callers: **155/104** — ~40% getting raw **~2.9MB** bodies, hitting the 3s write deadline → residual `syscall.Write` CPU + egress on the dmsg-server.

TPD already pre-marshals gzip per #2980; the dmsg client just never advertised `Accept-Encoding`.

### Fix
Mirror `net/http.Transport`'s transparent gzip inside the custom transport:
- When the caller set **no** `Accept-Encoding` (and it's not HEAD/Range), advertise `gzip`.
- Transparently decompress via a lazily-initialised `gzipReader`, strip `Content-Encoding`/`Content-Length`, set `resp.Uncompressed = true`.
- The flag is computed **once in `RoundTrip`** (not in `do()`) so the pooled-then-fresh retry path doesn't re-see the header and skip decompression on the second attempt.
- `gzipReader` wraps the raw body and is itself wrapped by `pooledBody`, so the existing drain-on-Close still consumes the underlying compressed stream before the dmsg stream returns to the idle pool.

Callers that set their own `Accept-Encoding` are left untouched (no override, no auto-decode) — net/http parity.

### Impact
Drops the remaining ~40% raw dmsg responses to gzip. Especially relevant now that **#2983 makes dmsg-only the default config** — every visor's TPD/AR/SD reads go through this transport.

### Tests
`TestHTTPTransport_TransparentGzip` over a real dmsg-routed HTTP server: (a) gzip response is transparently decompressed + headers stripped + `Accept-Encoding: gzip` reached the server; (b) a caller-set `Accept-Encoding: identity` is preserved and not auto-decoded. Full package suite + `-race` green; `go build .` clean.