### PR TITLE
fix(tpd): cache /transports/edge:<PK> response body + gzip

### DIFF
--- a/pkg/transport-discovery/api/api.go
+++ b/pkg/transport-discovery/api/api.go
@@ -71,6 +71,11 @@ type API struct {
 	// dominant-egress endpoint doesn't re-marshal/re-send ~3MB per call.
 	allTpsRespCache *allTransportsRespCache
 
+	// edgeRespCache memoizes the marshaled (+gzip) /transports/edge:<PK> body
+	// per edge so the second-busiest read endpoint collapses identical repeat
+	// polls from the same visor into a single Redis round-trip.
+	edgeRespCache *edgeRespCache
+
 	uptimesCache   []store.VisorSummary
 	uptimesV2Cache []store.VisorSummary
 	uptimesMu      sync.RWMutex
@@ -121,6 +126,7 @@ func New(log logrus.FieldLogger, s store.Store, nonceStore httpauth.NonceStore,
 		DmsgServers:                 []string{},
 		backupPath:                  backupPath,
 		allTpsRespCache:             newAllTransportsRespCache(allTransportsRespCacheTTL),
+		edgeRespCache:               newEdgeRespCache(edgeRespCacheTTL),
 	}
 
 	r := chi.NewRouter()

--- a/pkg/transport-discovery/api/edge_response_cache.go
+++ b/pkg/transport-discovery/api/edge_response_cache.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// edgeRespCacheTTL is how long a marshaled /transports/edge:<PK> body is
+// reused before recompute. /transports/edge is the second-busiest TPD read
+// endpoint after /all-transports — ~1300 calls/5min, called by every visor
+// on a frequent poll cadence to learn its own and peers' transports. The
+// short TTL keeps the per-edge list fresh enough for routing decisions
+// while collapsing identical repeat reads into a single Redis round-trip.
+const edgeRespCacheTTL = 3 * time.Second
+
+// edgeRespCache memoizes the marshaled JSON body (and a gzip copy) of the
+// /transports/edge:<PK> response per edge PK, single-flighting the recompute
+// on miss and serving a stale body if the recompute errors. Expired slots
+// are swept opportunistically on every miss so the map size tracks the set
+// of edges actively being queried rather than all edges ever seen.
+type edgeRespCache struct {
+	ttl   time.Duration
+	mu    sync.Mutex
+	slots map[cipher.PubKey]*respCacheSlot
+}
+
+func newEdgeRespCache(ttl time.Duration) *edgeRespCache {
+	if ttl <= 0 {
+		ttl = edgeRespCacheTTL
+	}
+	return &edgeRespCache{ttl: ttl, slots: map[cipher.PubKey]*respCacheSlot{}}
+}
+
+// body returns the marshaled JSON and its gzip-compressed form for the edge,
+// recomputing via compute() at most once per TTL. The lock is held across
+// compute so concurrent misses for the same edge share a single recompute
+// (single-flight). On compute error a still-cached (stale) body is returned
+// when present; otherwise the error is propagated and nothing is cached.
+func (c *edgeRespCache) body(edge cipher.PubKey, compute func() ([]byte, error)) (raw, gz []byte, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	if slot := c.slots[edge]; slot != nil && now.Before(slot.expiresAt) {
+		return slot.raw, slot.gz, nil
+	}
+
+	body, cerr := compute()
+	if cerr != nil {
+		if slot := c.slots[edge]; slot != nil { // stale-on-error
+			return slot.raw, slot.gz, nil
+		}
+		return nil, nil, cerr
+	}
+
+	// Sweep expired slots on miss: bounds memory at the active-edge set
+	// rather than the all-time-queried set, at O(N) per miss where N is
+	// small (one slot per recently-queried edge).
+	for k, s := range c.slots {
+		if now.After(s.expiresAt) {
+			delete(c.slots, k)
+		}
+	}
+
+	gzBody := gzipBytes(body)
+	c.slots[edge] = &respCacheSlot{
+		raw:       body,
+		gz:        gzBody,
+		expiresAt: now.Add(c.ttl),
+	}
+	return body, gzBody, nil
+}

--- a/pkg/transport-discovery/api/edge_response_cache_test.go
+++ b/pkg/transport-discovery/api/edge_response_cache_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestEdgeRespCache(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	t.Run("memoizes within TTL + gzip matches raw", func(t *testing.T) {
+		c := newEdgeRespCache(time.Minute)
+		var calls int32
+		compute := func() ([]byte, error) {
+			atomic.AddInt32(&calls, 1)
+			return []byte(`[{"id":"x"}]`), nil
+		}
+		raw1, gz1, err := c.body(pkA, compute)
+		require.NoError(t, err)
+		raw2, gz2, err := c.body(pkA, compute)
+		require.NoError(t, err)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "second call within TTL must not recompute")
+		assert.Equal(t, raw1, raw2)
+		assert.Equal(t, gz1, gz2)
+		assert.Equal(t, raw1, gunzip(t, gz1), "gzip body must decompress to the raw body")
+	})
+
+	t.Run("per-edge isolation", func(t *testing.T) {
+		c := newEdgeRespCache(time.Minute)
+		rawA, _, err := c.body(pkA, func() ([]byte, error) { return []byte(`["a"]`), nil })
+		require.NoError(t, err)
+		rawB, _, err := c.body(pkB, func() ([]byte, error) { return []byte(`["b"]`), nil })
+		require.NoError(t, err)
+		assert.NotEqual(t, rawA, rawB)
+	})
+
+	t.Run("stale-on-error returns last good body", func(t *testing.T) {
+		short := newEdgeRespCache(20 * time.Millisecond)
+		good := []byte(`["good"]`)
+		_, _, err := short.body(pkA, func() ([]byte, error) { return good, nil })
+		require.NoError(t, err)
+
+		time.Sleep(30 * time.Millisecond) // expire the slot
+		raw, _, err := short.body(pkA, func() ([]byte, error) { return nil, errors.New("store down") })
+		require.NoError(t, err, "should serve stale, not error, when a prior body exists")
+		assert.Equal(t, good, raw)
+	})
+
+	t.Run("error with no prior body propagates", func(t *testing.T) {
+		fresh := newEdgeRespCache(time.Minute)
+		_, _, err := fresh.body(pkA, func() ([]byte, error) { return nil, errors.New("store down") })
+		require.Error(t, err)
+	})
+
+	t.Run("expired slots are swept on miss", func(t *testing.T) {
+		short := newEdgeRespCache(20 * time.Millisecond)
+		// Populate two edges.
+		_, _, err := short.body(pkA, func() ([]byte, error) { return []byte(`["a"]`), nil })
+		require.NoError(t, err)
+		_, _, err = short.body(pkB, func() ([]byte, error) { return []byte(`["b"]`), nil })
+		require.NoError(t, err)
+		require.Len(t, short.slots, 2)
+
+		time.Sleep(30 * time.Millisecond) // expire both slots
+
+		// One miss on pkA should sweep pkB's expired slot too, leaving only pkA.
+		_, _, err = short.body(pkA, func() ([]byte, error) { return []byte(`["a2"]`), nil })
+		require.NoError(t, err)
+		assert.Len(t, short.slots, 1)
+		_, hasB := short.slots[pkB]
+		assert.False(t, hasB, "expired pkB slot should have been swept")
+	})
+}

--- a/pkg/transport-discovery/api/endpoints.go
+++ b/pkg/transport-discovery/api/endpoints.go
@@ -257,7 +257,16 @@ func (api *API) getTransportByEdge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entries, err := api.store.GetTransportsByEdge(r.Context(), pk)
+	// /transports/edge:<PK> is polled by every visor on a short cadence to
+	// learn its own and peers' transports. Serve a memoized, gzipped response
+	// body so identical repeat polls don't hit Redis or re-marshal per call.
+	raw, gz, err := api.edgeRespCache.body(pk, func() ([]byte, error) {
+		entries, e := api.store.GetTransportsByEdge(r.Context(), pk)
+		if e != nil {
+			return nil, e
+		}
+		return json.Marshal(entries)
+	})
 	if err != nil {
 		if err != store.ErrTransportNotFound {
 			api.log(r).WithError(err).Error("Error getting transport")
@@ -265,7 +274,17 @@ func (api *API) getTransportByEdge(w http.ResponseWriter, r *http.Request) {
 		api.writeError(w, r, err)
 		return
 	}
-	httputil.WriteJSON(w, r, http.StatusOK, entries)
+
+	w.Header().Set("Content-Type", "application/json")
+	if gz != nil && strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Vary", "Accept-Encoding")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(gz) //nolint:errcheck
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(raw) //nolint:errcheck
 }
 
 func (api *API) getTransportStats(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Extends the `/all-transports` response-body cache pattern from #2980 to `/transports/edge:<PK>`, the second-busiest TPD read endpoint (~1300 calls/5min observed on prod02). Each call previously hit Redis via `store.GetTransportsByEdge` and re-marshalled the result, even though the same PK is typically polled by the same visor many times per minute with no intervening change.

## Changes

- `pkg/transport-discovery/api/edge_response_cache.go` — new `edgeRespCache` mirroring `allTransportsRespCache`, keyed by `cipher.PubKey`. Memoizes marshalled JSON + gzip copy, single-flight on miss, stale-on-error.
- `pkg/transport-discovery/api/api.go` — adds the cache to the `API` struct + initializes in `New`.
- `pkg/transport-discovery/api/endpoints.go` — `getTransportByEdge` now goes through the cache and serves the gzip body when the client advertises `Accept-Encoding: gzip`.
- `pkg/transport-discovery/api/edge_response_cache_test.go` — covers memoize-within-TTL, gzip==raw, per-edge isolation, stale-on-error, error-with-no-prior-body, and expired-slot sweep.

## Design notes

- **TTL 3 s** — mid of the 1-5 s target range, chosen to comfortably cover the observed worst-case visor poll cadence (4-6 s bursts from a single visor) without staling routing decisions. Conservative enough that a fresh registration is visible to other visors within one cache TTL.
- **Opportunistic sweep of expired slots on miss** keeps the map size tracking the active-edge set rather than the all-time-queried set, at O(N) per miss where N is small.
- **No caching of error paths** — `ErrTransportNotFound` falls through to `api.writeError` exactly like before, so a freshly-registered TP doesn't get masked by a cached not-found.

## Context

Sits on top of #2980 (per-edge-TTL + `/all-transports` cache+gzip) which is already on develop tip `c006182dd`. Together with that PR plus a parallel `Accept-Encoding: gzip` fix in `pkg/dmsghttp` (handled separately), this targets the post-#2980 residual TPD load surfaced by prod02 pprof — most of which is the per-edge endpoint hitting Redis on every visor poll.

## Test plan

- [x] `go test ./pkg/transport-discovery/api/... -count=1` — green
- [x] `go build ./...` — green
- [x] `gofmt -l` clean on touched files
- [x] `go vet ./pkg/transport-discovery/api/...` clean
- [ ] Deploy verification: after this lands + image build, pull on prod02 and watch TPD `/debug/pprof` Redis call rate + response-body distribution for `/transports/edge:*` vs the locked baseline.