### PR TITLE
fix(cxo): bound Filler goroutines — populate MaxFillingParallel + sane fallback

### DIFF
--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -342,13 +342,25 @@ func (f *fillHead) handleReceivedRoot(cr connRoot) {
 
 }
 
-// value for channels, if hte (*Node).maxFillingParallel
-// is zero, then the skyobject.Filler has no limits for
-// goroutines, but we can't create an unlimited channel,
-// thus we cahnge the zero to 1024 (I think it's enough)
+// maxParallel returns the per-Filler parallelism cap used to size
+// both Filler.limit (max in-flight subtree-walking goroutines per
+// Filler) and Filler.rq (the per-Filler request channel buffer).
+//
+// When (*Node).maxFillingParallel is 0 (Config.MaxFillingParallel
+// wasn't set, e.g. callers that construct Config{} directly instead
+// of via NewConfig), we fall back to the documented package default
+// — skyobject.MaxFillingParallel ("ten parallel subtrees"). The
+// previous fallback was a magic 1024 which sized each Filler's
+// channels to 1024; with a handful of concurrent Fillers that pinned
+// 5000+ goroutines parked in (*Filler).get's select on fill.go:82,
+// creating scheduler pressure visible in production pprof. The
+// skyobject docstring notes the cap "should be closer to number of
+// connections that used to fill a Root" — for the typical CXO node
+// that's <= 20, so 10 is a sensible safety-net default. Operators
+// who want a higher cap set Config.MaxFillingParallel explicitly.
 func (f *fillHead) maxParallel() (mp int) {
 	if mp = f.node().maxFillingParallel; mp <= 0 {
-		mp = 1024 // max parallel requests
+		mp = skyobject.MaxFillingParallel // documented default = 10
 	}
 	return
 }

--- a/pkg/cxo/node/head_test.go
+++ b/pkg/cxo/node/head_test.go
@@ -1,0 +1,59 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+)
+
+// newTestFillHead wires up the minimal embedding chain required for
+// fillHead.node() to resolve to the supplied *Node:
+//
+//	fillHead → embedded *nodeHead → nodeHead.n (*nodeFeed)
+//	         → nodeFeed.fs (*nodeFeeds) → nodeFeeds.n (*Node).
+//
+// Only maxParallel() is exercised so the surrounding fields stay zero.
+func newTestFillHead(n *Node) *fillHead {
+	feeds := &nodeFeeds{n: n}
+	feed := &nodeFeed{fs: feeds}
+	return &fillHead{nodeHead: &nodeHead{n: feed}}
+}
+
+// TestFillHead_maxParallel_FallbackUsesDocumentedDefault verifies the
+// safety-net fallback when (*Node).maxFillingParallel is 0 (Config
+// constructed bare, not via NewConfig). It must use the documented
+// skyobject.MaxFillingParallel constant (= 10) rather than the
+// previous magic 1024 that over-sized Filler.limit + Filler.rq per
+// Filler.
+func TestFillHead_maxParallel_FallbackUsesDocumentedDefault(t *testing.T) {
+	fh := newTestFillHead(&Node{maxFillingParallel: 0})
+	if mp := fh.maxParallel(); mp != skyobject.MaxFillingParallel {
+		t.Fatalf("maxParallel() fallback = %d, want skyobject.MaxFillingParallel = %d",
+			mp, skyobject.MaxFillingParallel)
+	}
+}
+
+// TestFillHead_maxParallel_ExplicitOverride confirms the operator-set
+// value wins over the fallback when Config.MaxFillingParallel is
+// non-zero — exact value pass-through, no clamping.
+func TestFillHead_maxParallel_ExplicitOverride(t *testing.T) {
+	for _, want := range []int{1, 5, 64, 1024, 4096} {
+		fh := newTestFillHead(&Node{maxFillingParallel: want})
+		if mp := fh.maxParallel(); mp != want {
+			t.Fatalf("maxParallel() with operator-set %d = %d, want %d", want, mp, want)
+		}
+	}
+}
+
+// TestFillHead_maxParallel_NegativeFallsBack covers the boundary where
+// the operator-set value is <= 0 (negative or zero); both should fall
+// back to the documented default.
+func TestFillHead_maxParallel_NegativeFallsBack(t *testing.T) {
+	for _, in := range []int{-1, -100, 0} {
+		fh := newTestFillHead(&Node{maxFillingParallel: in})
+		if mp := fh.maxParallel(); mp != skyobject.MaxFillingParallel {
+			t.Fatalf("maxParallel() with %d fell back to %d, want %d",
+				in, mp, skyobject.MaxFillingParallel)
+		}
+	}
+}

--- a/pkg/cxo/skyobject/config.go
+++ b/pkg/cxo/skyobject/config.go
@@ -235,6 +235,17 @@ func NewConfig() (conf *Config) {
 
 	conf.MaxObjectSize = MaxObjectSize
 
+	// MaxFillingParallel was previously left at its int zero value here
+	// — that zeroed through to (*Node).maxFillingParallel and triggered
+	// the magic-1024 fallback in pkg/cxo/node/head.go's maxParallel(),
+	// which sized Filler.limit + Filler.rq to 1024 per Filler. Under
+	// concurrent fillers that pinned thousands of goroutines parked in
+	// (*Filler).get's select, producing scheduler pressure visible in
+	// production pprof (5700+ goroutines stuck on fill.go:82). The
+	// MaxFillingParallel constant was always documented as 10 ("ten
+	// parallel subtrees") in this file — just never assigned.
+	conf.MaxFillingParallel = MaxFillingParallel
+
 	// data dir
 	conf.DataDir = DataDir()
 

--- a/pkg/cxo/skyobject/config_test.go
+++ b/pkg/cxo/skyobject/config_test.go
@@ -1,0 +1,22 @@
+package skyobject
+
+import "testing"
+
+// TestNewConfigPopulatesMaxFillingParallel guards against the
+// regression where NewConfig() left MaxFillingParallel at its int
+// zero value, which then flowed through to (*Node).maxFillingParallel
+// and triggered the magic-1024 fallback in pkg/cxo/node/head.go's
+// maxParallel(), pinning thousands of goroutines parked in
+// (*Filler).get's select. The documented default is the package
+// constant MaxFillingParallel = 10.
+func TestNewConfigPopulatesMaxFillingParallel(t *testing.T) {
+	c := NewConfig()
+	if c.MaxFillingParallel != MaxFillingParallel {
+		t.Fatalf("NewConfig().MaxFillingParallel = %d, want %d (the documented constant)",
+			c.MaxFillingParallel, MaxFillingParallel)
+	}
+	if c.MaxFillingParallel <= 0 {
+		t.Fatalf("NewConfig().MaxFillingParallel must be > 0 to avoid the 1024 fallback in node/head.go, got %d",
+			c.MaxFillingParallel)
+	}
+}


### PR DESCRIPTION
## Summary

Bounds the goroutine churn from `pkg/cxo/skyobject/(*Filler).get` that Beta's pprof flagged (5708 of 6472 goroutines parked in `[select]` at `fill.go:82`). The cap was leaking past its documented 10-subtree limit because two paths combined:

1. `pkg/cxo/skyobject/config.MaxFillingParallel = 10` is **documented** ("ten parallel subtrees") but `NewConfig()` never assigned it — the `Config.MaxFillingParallel` field stayed at its int zero value.
2. The zero flowed through to `(*Node).maxFillingParallel = 0`, and `pkg/cxo/node/head.go`'s `maxParallel()` then fell back to **1024** (per the original `"I think it's enough"` comment).

Net: each Filler sized `Filler.limit` + `Filler.rq` to 1024. With a handful of concurrent Fillers (one per peer-root being filled), the per-Filler caps stacked into the 5000+ parked goroutines observed in production.

## Fix

- `skyobject/config.go` `NewConfig()` now sets `conf.MaxFillingParallel = MaxFillingParallel` (= 10), matching the docstring. **Primary fix** — every caller that goes through `NewConfig` (including `treestore.Publisher` and `skyobject.NewContainer`'s own fallback) picks up the intended default.
- `node/head.go` `maxParallel()` safety-net fallback drops from `1024 → skyobject.MaxFillingParallel` (= 10). Belt-and-suspenders for the small set of callers that construct `Config{}` directly. The doc comment is rewritten to explain the call chain and the operator override path.

Operators who want a higher cap continue to set `Config.MaxFillingParallel` explicitly — no breaking change.

## Test plan

- [x] `TestNewConfigPopulatesMaxFillingParallel` guards the primary fix.
- [x] `TestFillHead_maxParallel_FallbackUsesDocumentedDefault` covers the new safety-net value.
- [x] `TestFillHead_maxParallel_ExplicitOverride` verifies operator-set values pass through verbatim across `{1, 5, 64, 1024, 4096}`.
- [x] `TestFillHead_maxParallel_NegativeFallsBack` covers `<= 0` (negative + zero).
- [x] `go test ./pkg/cxo/skyobject/... ./pkg/cxo/node/...` all green.
- [x] `gofmt`, `go vet`, full `go build ./...` clean.
- [ ] Once deployed: pprof goroutine dump should show the `(*Filler).get` parked-on-select count drop from thousands into the low hundreds, with the same Filler activity rate.