### PR TITLE
fix(release): stage skywire-autoconfig.bat for the Windows MSI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
           Invoke-WebRequest "$base/Product.wxs" -OutFile "scripts\win_installer\Product.wxs"
           Invoke-WebRequest "$base/UI.wxs" -OutFile "scripts\win_installer\UI.wxs"
           Invoke-WebRequest "$base/skywire.bat" -OutFile "scripts\win_installer\skywire.bat"
+          Invoke-WebRequest "$base/skywire-autoconfig.bat" -OutFile "scripts\win_installer\skywire-autoconfig.bat"
           Invoke-WebRequest "$base/images/Banner.png" -OutFile "scripts\win_installer\images\Banner.png"
           Invoke-WebRequest "$base/images/Dialog.png" -OutFile "scripts\win_installer\images\Dialog.png"
           Invoke-WebRequest "$base/images/ico.ico" -OutFile "scripts\win_installer\images\ico.ico"
@@ -407,6 +408,7 @@ jobs:
           New-Item -ItemType Directory -Force -Path "build\apps"
           Copy-Item ..\..\bin\skywire.exe build\skywire.exe
           Copy-Item skywire.bat build\skywire.bat
+          Copy-Item skywire-autoconfig.bat build\skywire-autoconfig.bat
           New-Item -ItemType File -Path "build\new.update"
           Copy-Item ..\..\wintun_extracted\wintun\bin\${{ matrix.wintun_arch }}\wintun.dll build\wintun.dll
 


### PR DESCRIPTION
### Why the Windows .msi stopped generating
v1.3.62 and v1.3.63 shipped with **no Windows `.msi`/`.zip` assets** (last good: v1.3.61). Both release runs failed at the WiX link step:

```
Product.wxs(29) : error LGHT0103 : The system cannot find the file '.\build\skywire-autoconfig.bat'.
```

The `windows (386)` job failed → matrix fail-fast cancelled `amd64`/`arm64` → nothing uploaded.

### Root cause
#2965 ("run config setup at MSI install") added a `<File ... Source=".\build\skywire-autoconfig.bat"/>` reference (and a `RunSkywireAutoconfig` CustomAction) to `Product.wxs`, and shipped `scripts/win_installer/skywire-autoconfig.bat` — but it did **not** update `release.yml`, which stages the installer payload by an explicit allow-list rather than copying the whole dir. So the new file was never fetched or placed in `build\`, and `light.exe` couldn't find it.

### Fix
Mirror the existing `skywire.bat` handling in both staging steps:
- **Fetch Windows installer files** → also `Invoke-WebRequest` `skywire-autoconfig.bat` from the tag's raw tree.
- **Create MSI installer → Prepare build directory** → also `Copy-Item skywire-autoconfig.bat build\`.

`skywire-autoconfig.bat` is present in-repo and at the v1.3.62/63 tags, so the raw-fetch resolves. Two added lines, both inside `run: |` block-scalars (literal text, sibling indentation). Unblocks the Windows MSI on the next release.