### PR TITLE
feat(rewards): drop receiver-side min() cap (pending v1.3.63); per-IP 12 for June 2026

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -222,11 +222,26 @@ func countFrequency(values []string) map[string]int {
 	return counts
 }
 
+// perIPShareLimit returns the per-IP visor reward-share cap in effect
+// on the given calc date. Default is 8 (matching rewards/mainnet_rules.md
+// "Per IP Limit" section). June 2026 is a one-month exception at 12 —
+// see operator announcement 2026-06-03 for the rationale (per-operator
+// request to accommodate visor-relocation work blocked by the
+// bandwidth-pool issues). The limit auto-reverts to 8 on 2026-07-01
+// without any code change required.
+func perIPShareLimit(t time.Time) int {
+	if t.Year() == 2026 && t.Month() == time.June {
+		return 12
+	}
+	return 8
+}
+
 // calcPresenceShare computes a visor's share after IP cap and MAC dedup.
 func calcPresenceShare(ni nodeinfo, ipCounts, macCounts map[string]int) float64 {
 	share := 1.0
-	if count := ipCounts[ni.IPAddr]; count >= 8 {
-		share = 8.0 / float64(count)
+	limit := perIPShareLimit(wDate)
+	if count := ipCounts[ni.IPAddr]; count >= limit {
+		share = float64(limit) / float64(count)
 	}
 	if count := macCounts[ni.MacAddr]; count > 1 {
 		share /= float64(count)

--- a/cmd/skywire-cli/commands/rewards/transports.go
+++ b/cmd/skywire-cli/commands/rewards/transports.go
@@ -470,6 +470,19 @@ func fetchTransportBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logg
 		// An edge whose record is present but {sent:0, recv:0} is
 		// treated as "hasn't reported real data yet" rather than
 		// "verified zero traffic" — same rationale as the cli.
+		//
+		// TODO(B2): the both-reported branch used to cap each side's
+		// sent by the counterparty's recv (min(A.Sent, B.Recv) +
+		// min(B.Sent, A.Recv)). That anti-inflation cap collapsed
+		// dual-edge pool 2 contribution to ~0 whenever the receiver-
+		// side counter was zero — the dominant symptom of B2 (TPD
+		// upsert clobbers the prior side's perspective when the
+		// counterparty heartbeats). The cap has been temporarily
+		// removed; both branches now trust the sender unconditionally,
+		// matching the unilateral-trust branches below. Restore the
+		// min() cap once v1.3.63 (with the TPD per-edge merge upsert)
+		// is the required minimum version and the dual-edge ratio is
+		// reliably >50%. See operator announcement 2026-06-03.
 		var sentA, sentB uint64
 		for _, d := range tp.Daily {
 			if dateFilter != "" && d.Date != dateFilter {
@@ -479,8 +492,8 @@ func fetchTransportBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logg
 			bReported := d.B != nil && (d.B.Sent > 0 || d.B.Recv > 0)
 			switch {
 			case aReported && bReported:
-				sentA += minUint64(d.A.Sent, d.B.Recv)
-				sentB += minUint64(d.B.Sent, d.A.Recv)
+				sentA += d.A.Sent
+				sentB += d.B.Sent
 			case aReported:
 				sentA += d.A.Sent
 				sentB += d.A.Recv
@@ -529,6 +542,12 @@ func fetchTransportBandwidthFromTPD(cmdFlags *pflag.FlagSet, bwLog *logging.Logg
 	return out, nil
 }
 
+// minUint64 is the receiver-side anti-inflation cap previously used in
+// fetchTransportBandwidthFromTPD's both-reported branch. Retained so
+// the restore on v1.3.63 minimum is a single-line diff at the call
+// site. Marked unused-ok until then.
+//
+//nolint:unused
 func minUint64(a, b uint64) uint64 {
 	if a < b {
 		return a

--- a/rewards/mainnet_rules.md
+++ b/rewards/mainnet_rules.md
@@ -72,7 +72,7 @@ To receive Skycoin rewards for running skywire, the following requirements must 
 
 * [4)](#Per-Machine-Limit) **Only 1 (one) visor per machine** - virtual machines are ineligible
 
-* [5)](#Per-IP-Limit) **Up to 8 (eight) visors may each receive 1 (one) reward share per location (ip address)** - with 8 shares divided between all visors at that ip address which achieved the minimum uptime.
+* [5)](#Per-IP-Limit) **Up to 8 (eight) visors may each receive 1 (one) reward share per location (ip address)** - with 8 shares divided between all visors at that ip address which achieved the minimum uptime. *(Temporary exception: for the month of June 2026 only, the per-IP cap is raised to 12 shares — see [Per IP Limit](#Per-IP-Limit) for the rationale; the cap auto-reverts to 8 on 2026-07-01.)*
 
 * [6)](#Skycoin-Address) **A valid [skycoin address](#Skycoin-Address)** must be set for the visor
 
@@ -312,6 +312,8 @@ Multiple instances of skywire which are otherwise determined to be running on th
 A maximum of 8 reward shares per ip address is divided between all visors which made uptime at a given ip address.
 
 For example, if 9 visors at a given ip address meet the minimum uptime requirement, the reward share for each visor will be 8/9ths of a share (~0.8888) which sum to a total of ~7.99999 shares.
+
+**Temporary exception — June 2026 only**: the per-IP cap is raised from 8 to **12** shares for calc dates within June 2026 (UTC). Rationale: a specific operator was unable to relocate excess visors off a single IP address because OS-level update infrastructure was blocked by ongoing bandwidth-pool issues this month, and several boards in their official miner died reducing the visor count to 11+1 at one location. The cap reverts automatically to 8 on 2026-07-01 with no further action required.
 
 ### Regional Saturation Scaling
 


### PR DESCRIPTION
## Summary

Two interim policy changes addressing the bandwidth-pool reward issues diagnosed 2026-06-02. See operator announcement 2026-06-03 for the full context.

### 1) `transports.go`: drop the receiver-side `min()` anti-inflation cap

**Diagnosis recap** (community pump operators independently confirmed):
- TPD daily transport records almost never contain matched A+B counters — when the counterparty heartbeats into TPD, the prior side's perspective is overwritten with zeros. Dual-edge ratio in TPD records: ~14% on 2026-06-02; gamma 41/41, beta 52/52 transports universally one-sided.
- The both-reported branch's `min(A.Sent, B.Recv) + min(B.Sent, A.Recv)` therefore collapsed to ~0 whenever the receiver-side counter was clobbered. Network-wide pair-verified contribution on 2026-06-02: ~0.38 MB out of ~5.83 GB raw — pool 2 credit was essentially a heartbeat-race lottery.

**Change**: both-reported branch now sums `d.A.Sent + d.B.Sent` directly, matching the unilateral-trust branches already in place for one-sided records. `minUint64` retained with `//nolint:unused` so restoring the cap is a single-line call-site diff.

**Restore when**: v1.3.63 (with the TPD per-edge merge upsert / B2 fix) is the required minimum version and dual-edge ratio in TPD records is reliably >50%.

### 2) `calc.go`: per-IP visor share cap raised from 8 → 12 for June 2026

A specific operator was unable to relocate excess visors off a single IP address because the OS-level update infrastructure they depend on was blocked by the bandwidth-pool issues this month, and several boards in their official miner died (reducing visor count to 11+1 at the affected location).

`calcPresenceShare` now consults `perIPShareLimit(wDate)` which returns 12 for June 2026 (UTC) calc dates and 8 otherwise. The exception auto-reverts on 2026-07-01 with no code change.

### 3) `mainnet_rules.md`: document both rule changes

Inline note under rule 5 and a dedicated paragraph under "Per IP Limit" explaining the exception window and the automatic revert.

## Test plan

- [ ] `make format check` clean
- [ ] `go vet ./cmd/skywire-cli/commands/rewards/` clean
- [ ] `go build ./cmd/skywire-cli/commands/rewards/...` clean
- [ ] `skywire cli rewards bw-collect` against a TPD with mixed dual-edge / one-sided daily records — verify that dual-edge transports now contribute `A.Sent + B.Sent` instead of `min(A.Sent, B.Recv) + min(B.Sent, A.Recv)`
- [ ] `skywire cli rewards -b -B 0 -d 2026-06-15` — manual calc for a June date with a mocked 9-visors-on-one-IP scenario should produce 9 × (12/9) = 12 shares total at that IP (vs the prior 8)
- [ ] Same calc for a July date should revert to 8 shares total