### PR TITLE
fix(cxo/node): non-blocking delConn cleanup (TPD goroutine leak)

### DIFF
--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -35,7 +35,18 @@ type nodeFeeds struct {
 	addcfq chan connFeed // add connection to a feed
 	delcfq chan connFeed // del connection from a feed
 
-	delcq chan *Conn // delete connection (closed connection and similar)
+	// delete-connection cleanup. A closed connection's cleanup must never
+	// block the caller (Conn.run exit / Node.removeConn). The previous
+	// design sent on a bounded buffered channel which BLOCKED once the
+	// single feeds actor fell behind under connection churn — stranding
+	// tens of thousands of goroutines (and GBs of stacks) parked on the
+	// send. delConn now appends to this unbounded queue under delcMu and
+	// nudges the actor via delcwake; the actor drains it in bounded
+	// batches, so the enqueue is always non-blocking and cleanup still
+	// happens (no drop).
+	delcMu    sync.Mutex
+	delcQueue []*Conn
+	delcwake  chan struct{} // wake the actor to drain delcQueue (cap 1)
 
 	brorq chan connRoot // broadcast root to feed (triggered by head)
 
@@ -84,7 +95,7 @@ func newNodeFeeds(node *Node) (n *nodeFeeds) {
 	n.addcfq = make(chan connFeed) // add connection to a feed
 	n.delcfq = make(chan connFeed) // del connection from a feed
 
-	n.delcq = make(chan *Conn, 512) // buffered so (*Conn).run exit doesn't block the actor on the rrq path
+	n.delcwake = make(chan struct{}, 1) // wake the actor to drain the unbounded delcQueue
 
 	n.brorq = make(chan connRoot)
 
@@ -141,10 +152,10 @@ func (n *nodeFeeds) handle() {
 		addq = n.addq
 		delq = n.delq
 
-		addcfq = n.addcfq
-		delcfq = n.delcfq
-		delcq  = n.delcq
-		broq   = n.brorq
+		addcfq   = n.addcfq
+		delcfq   = n.delcfq
+		delcwake = n.delcwake
+		broq     = n.brorq
 
 		listrq  = n.listrq
 		fcrq    = n.fcrq
@@ -184,8 +195,8 @@ func (n *nodeFeeds) handle() {
 		case pk = <-delq:
 			n.handleDelFeed(pk)
 
-		case c = <-delcq:
-			n.handleDelConn(c)
+		case <-delcwake:
+			n.drainDelConn()
 
 		//
 		// info api
@@ -390,12 +401,57 @@ func (n *nodeFeeds) handleBroadcastRoot(cr connRoot) {
 
 // (api)
 func (n *nodeFeeds) delConn(c *Conn) {
+	// Non-blocking: a dead connection's cleanup must not block the caller
+	// (Conn.run exit / Node.removeConn). Append to the unbounded queue and
+	// nudge the actor; if a wake is already pending the actor will drain
+	// the whole queue on the next pass. See the delcQueue field comment.
+	n.delcMu.Lock()
+	n.delcQueue = append(n.delcQueue, c)
+	n.delcMu.Unlock()
 
 	select {
-	case n.delcq <- c:
-	case <-n.closeq:
+	case n.delcwake <- struct{}{}:
+	default: // a wake is already queued
+	}
+}
+
+// (handler) drainDelConn removes a bounded batch of closed connections
+// from all feeds. It runs in the actor goroutine, so n.fs stays
+// single-threaded. The batch cap bounds how long this monopolizes the
+// actor (so root traffic isn't starved); if connections remain queued it
+// re-arms delcwake and the select loop picks it up again, fairly
+// interleaved with the other cases.
+func (n *nodeFeeds) drainDelConn() {
+	const batchMax = 256
+
+	n.delcMu.Lock()
+	nb := len(n.delcQueue)
+	if nb == 0 {
+		n.delcMu.Unlock()
+		return
+	}
+	if nb > batchMax {
+		nb = batchMax
+	}
+	batch := make([]*Conn, nb)
+	copy(batch, n.delcQueue[:nb])
+	n.delcQueue = n.delcQueue[nb:]
+	more := len(n.delcQueue) > 0
+	if !more {
+		n.delcQueue = nil // release the backing array once fully drained
+	}
+	n.delcMu.Unlock()
+
+	for _, c := range batch {
+		n.handleDelConn(c)
 	}
 
+	if more {
+		select {
+		case n.delcwake <- struct{}{}:
+		default:
+		}
+	}
 }
 
 // (handler)

--- a/pkg/cxo/node/feeds_delconn_test.go
+++ b/pkg/cxo/node/feeds_delconn_test.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skycoin/src/cipher"
+)
+
+// TestNodeFeeds_DelConn_NonBlocking pins the fix for the transport-
+// discovery goroutine leak. delConn must never block the caller, even
+// with no actor draining and far more than the old 512-slot buffer's
+// worth of dead connections queued. Pre-fix the 513th send blocked
+// forever on the full bounded channel, stranding the Conn.run-exit
+// goroutine — tens of thousands of these pinned ~2GB of stacks on the
+// production TPD until a restart. Run with -race to exercise delcMu.
+func TestNodeFeeds_DelConn_NonBlocking(t *testing.T) {
+	n := &nodeFeeds{delcwake: make(chan struct{}, 1)}
+
+	const (
+		goroutines = 8
+		perG       = 2500
+		total      = goroutines * perG // 20000 >> the old 512 buffer
+	)
+
+	done := make(chan struct{})
+	go func() {
+		var wg sync.WaitGroup
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < perG; i++ {
+					n.delConn(&Conn{})
+				}
+			}()
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("delConn blocked under backlog — non-blocking enqueue regressed")
+	}
+
+	n.delcMu.Lock()
+	got := len(n.delcQueue)
+	n.delcMu.Unlock()
+	if got != total {
+		t.Fatalf("queued %d connections, want %d (nothing blocked or dropped)", got, total)
+	}
+}
+
+// TestNodeFeeds_DrainDelConn_RemovesFromAllFeeds verifies the actor-side
+// drain still removes a connection from EVERY feed — moving from the
+// blocking channel to the queue must not lose any cleanup.
+func TestNodeFeeds_DrainDelConn_RemovesFromAllFeeds(t *testing.T) {
+	n := &nodeFeeds{delcwake: make(chan struct{}, 1)}
+	n.fs = make(map[cipher.PubKey]*nodeFeed)
+
+	feeds := []cipher.PubKey{{}, {1}, {2}, {3}}
+	c := &Conn{}
+	for _, pk := range feeds {
+		nf := newNodeFeed(n, pk)
+		nf.cs[c] = struct{}{}
+		n.fs[pk] = nf
+	}
+
+	n.delConn(c)
+	drainAll(n)
+
+	for _, pk := range feeds {
+		if n.fs[pk].hasConn(c) {
+			t.Fatalf("connection not removed from feed %x after drain", pk)
+		}
+	}
+}
+
+// TestNodeFeeds_DrainDelConn_BatchesAndConverges checks that a backlog
+// larger than batchMax is drained across multiple passes (the actor
+// re-arms delcwake each batch) and fully cleared.
+func TestNodeFeeds_DrainDelConn_BatchesAndConverges(t *testing.T) {
+	n := &nodeFeeds{delcwake: make(chan struct{}, 1)}
+	n.fs = map[cipher.PubKey]*nodeFeed{{}: newNodeFeed(n, cipher.PubKey{})}
+
+	const total = 1000 // > batchMax (256)
+	for i := 0; i < total; i++ {
+		n.delConn(&Conn{})
+	}
+
+	passes := 0
+	for {
+		n.delcMu.Lock()
+		empty := len(n.delcQueue) == 0
+		n.delcMu.Unlock()
+		if empty {
+			break
+		}
+		n.drainDelConn()
+		passes++
+		if passes > total {
+			t.Fatal("drain did not converge")
+		}
+	}
+	if passes < 2 {
+		t.Fatalf("expected multiple bounded drain passes for %d > batchMax, got %d", total, passes)
+	}
+}
+
+// drainAll runs drainDelConn until the queue is empty (no actor running
+// in these unit tests).
+func drainAll(n *nodeFeeds) {
+	for {
+		n.delcMu.Lock()
+		empty := len(n.delcQueue) == 0
+		n.delcMu.Unlock()
+		if empty {
+			return
+		}
+		n.drainDelConn()
+	}
+}


### PR DESCRIPTION
### Problem
Production `transport-discovery` accumulated **~34.6K goroutines parked on a blocked channel send** (39K total, **2.13 GB RAM, 236% CPU**) until a manual restart, re-accumulating to ~39K within ~2h.

`nodeFeeds.delConn` sent each closed connection on a **bounded buffered channel** (`delcq`, cap 512) for the single feeds actor to process. The actor also handles root broadcast/receive and feed add/del, and `handleDelConn` iterates **all** feeds per connection — so under connection churn it falls behind, the 512-slot buffer fills, and every subsequent `delConn` (from `Conn.run` exit / `Node.removeConn`) **blocks forever** on the send.

### Fix
Replace the bounded blocking channel with an **unbounded queue + a cap-1 wake signal**:
- `delConn` appends under `delcMu` and nudges the actor — always **non-blocking**, so `Conn.run` exit never stalls.
- the actor drains in **bounded batches** (`drainDelConn`, 256), re-arming the wake if more remain — so root traffic isn't starved and cleanup still runs for **every** connection (no drop, no stale conn-refs).

`n.fs` stays exclusively owned by the actor goroutine, so there are **no new races** (verified with `-race`).

Rejected alternatives: a bigger buffer only delays the overflow; a fire-and-forget drop leaks stale connection references into every feed (`handleDelConn` never runs → feeds keep dead conns).

### Tests
- `TestNodeFeeds_DelConn_NonBlocking` — 20K backlog from 8 concurrent senders with no drainer completes without blocking (pre-fix the 513th send hangs); nothing dropped.
- `TestNodeFeeds_DrainDelConn_RemovesFromAllFeeds` — drain removes the conn from every feed.
- `TestNodeFeeds_DrainDelConn_BatchesAndConverges` — backlog > batchMax drains across multiple passes and clears.
- Full `pkg/cxo/node` suite green under `-race`.

Needs the transport-discovery service redeployed to take effect (CXO-core, ships in the visor/TPD binary). Root-caused from production TPD pprof.