### PR TITLE
chore(lint): explicit return in skyobject.NewConfig (nakedret follow-up to #2988)

### DIFF
--- a/pkg/cxo/skyobject/config.go
+++ b/pkg/cxo/skyobject/config.go
@@ -249,7 +249,7 @@ func NewConfig() (conf *Config) {
 	// data dir
 	conf.DataDir = DataDir()
 
-	return
+	return conf
 }
 
 // FromFlags associates config fields


### PR DESCRIPTION
Follow-up to #2988. The CI lint job for that PR caught:

```
pkg/cxo/skyobject/config.go:252:2: naked return in func `NewConfig`
with 31 lines of code (nakedret)
```

#2988 grew `NewConfig` past the 30-line `nakedret` threshold (the new `MaxFillingParallel` block added ~10 lines including its rationale comment), so the existing naked `return` at the end of the function now trips the linter. #2988 was merged anyway with the CI bypass; this restores green lint on develop.

One-character fix: `return` → `return conf`. Behavior unchanged.

## Test plan

- [x] `gofmt`, `go vet`, `go test ./pkg/cxo/skyobject/...` clean.
- [x] Build of touched package green.