### PR TITLE
feat(cli/hv): hv passwd --force — set/reset the hypervisor UI password without the old one

### DIFF
--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -42,15 +42,17 @@ func init() {
 	hvLsCmd.Flags().BoolVar(&hvLsFlat, "flat", false, "single flat table instead of one section per hypervisor")
 	hvCmd.AddCommand(hvTreeCmd)
 	hvCmd.AddCommand(hvPasswdCmd)
-	hvPasswdCmd.Flags().StringVar(&hvPasswdOld, "old", "", "current password (prompts if unset)")
-	hvPasswdCmd.Flags().StringVar(&hvPasswdNew, "new", "", "new password (prompts if unset)")
+	hvPasswdCmd.Flags().StringVar(&hvPasswdOld, "old", "", "current password (required unless --force)")
+	hvPasswdCmd.Flags().StringVar(&hvPasswdNew, "new", "", "new password")
+	hvPasswdCmd.Flags().BoolVar(&hvPasswdForce, "force", false, "set --new without the old password (reset a forgotten password, or first-time set)")
 }
 
 var (
-	hvRmAll     bool
-	hvPasswdOld string
-	hvPasswdNew string
-	hvLsFlat    bool
+	hvRmAll       bool
+	hvPasswdOld   string
+	hvPasswdNew   string
+	hvPasswdForce bool
+	hvLsFlat      bool
 )
 
 var hvCmd = &cobra.Command{
@@ -260,21 +262,37 @@ required.`,
 
 var hvPasswdCmd = &cobra.Command{
 	Use:   "passwd",
-	Short: "Change the hypervisor UI admin password",
-	Long: `Change the password for the hypervisor UI's "admin" account.
+	Short: "Set the hypervisor UI admin password",
+	Long: `Set the password for the hypervisor UI's "admin" account.
 Mirrors the /api/change-password endpoint the UI uses, but without
 the HTTP session check (RPC is local-only and already privileged).
 
-Both --old and --new are required. Use the value-only form (avoid
-shell history capturing the password) by sourcing them from an
-env-var or a process-substitution.`,
+Normal change: --old and --new are both required.
+
+--force sets --new without the old password — to reset a forgotten
+password, or to set the password for the first time from the CLI
+(creating the "admin" account if none exists, so you don't need the
+UI's create-account page). All existing sessions are invalidated.
+
+Avoid shell history capturing the password by sourcing the values
+from an env-var or a process-substitution.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		if hvPasswdOld == "" || hvPasswdNew == "" {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("both --old and --new are required"))
+		if hvPasswdNew == "" {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--new is required"))
 		}
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if hvPasswdForce {
+			if err := rpcClient.SetHypervisorPasswordForce(hvPasswdNew); err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			fmt.Println("Hypervisor UI password set; all existing sessions invalidated.")
+			return
+		}
+		if hvPasswdOld == "" {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--old is required (or use --force to set without it)"))
 		}
 		if err := rpcClient.SetHypervisorPassword(hvPasswdOld, hvPasswdNew); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -317,6 +317,7 @@ type API interface {
 	RemoveHypervisor(pk cipher.PubKey) error
 	RemoveAllHypervisors() (int, error)
 	SetHypervisorPassword(oldPassword, newPassword string) error
+	SetHypervisorPasswordForce(newPassword string) error
 	CheckAREntry(pk string) ([]string, error)
 	ARSelfInfo() (*ARSelfRegistration, error)
 	TransportRPCCall(remotePK cipher.PubKey, method string, args json.RawMessage) (json.RawMessage, error)

--- a/pkg/visor/api_hypervisors.go
+++ b/pkg/visor/api_hypervisors.go
@@ -110,3 +110,15 @@ func (v *Visor) SetHypervisorPassword(oldPassword, newPassword string) error {
 	}
 	return v.hvInstance.users.ChangeAdminPassword(oldPassword, newPassword)
 }
+
+// SetHypervisorPasswordForce sets the hypervisor UI's "admin" account
+// password WITHOUT the old one, creating the account if none exists. For
+// the local privileged RPC path (skywire cli visor hv passwd --force):
+// forgotten-password reset, or a first-time set from the CLI.
+// Returns an error when this visor isn't hosting a hypervisor.
+func (v *Visor) SetHypervisorPasswordForce(newPassword string) error {
+	if v.hvInstance == nil {
+		return fmt.Errorf("hypervisor not running on this visor")
+	}
+	return v.hvInstance.users.SetAdminPassword(newPassword)
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -905,6 +905,10 @@ func (proxyDefaultAPI) SetHypervisorPassword(_ string, _ string) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) SetHypervisorPasswordForce(_ string) error {
+	return ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) CheckAREntry(_ string) ([]string, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -452,6 +452,15 @@ func (r *RPC) SetHypervisorPassword(in *HypervisorPasswordChangeIn, _ *struct{})
 	return r.visor.SetHypervisorPassword(in.OldPassword, in.NewPassword)
 }
 
+// SetHypervisorPasswordForce sets the hypervisor UI admin password
+// without the old one (reset / first-time set). Local-only RPC; same
+// privileged-local rationale as SetHypervisorPassword. OldPassword in the
+// request is ignored.
+func (r *RPC) SetHypervisorPasswordForce(in *HypervisorPasswordChangeIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "SetHypervisorPasswordForce", nil)(nil, &err)
+	return r.visor.SetHypervisorPasswordForce(in.NewPassword)
+}
+
 type DHTSyncRequest struct {
 	RemotePK string `json:"remote_pk"`
 	Salt     string `json:"salt"`

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1715,6 +1715,14 @@ func (rc *rpcClient) SetHypervisorPassword(oldPassword, newPassword string) erro
 	}, &struct{}{})
 }
 
+// SetHypervisorPasswordForce sets the hypervisor UI admin password
+// without the old one (reset / first-time set).
+func (rc *rpcClient) SetHypervisorPasswordForce(newPassword string) error {
+	return rc.Call("SetHypervisorPasswordForce", &HypervisorPasswordChangeIn{
+		NewPassword: newPassword,
+	}, &struct{}{})
+}
+
 // DmsgSetMinSessions updates the minimum DMSG session count.
 func (rc *rpcClient) DmsgSetMinSessions(n int) error {
 	return rc.Call("DmsgSetMinSessions", &n, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1540,6 +1540,11 @@ func (mc *mockRPCClient) SetHypervisorPassword(string, string) error {
 	return nil
 }
 
+// SetHypervisorPasswordForce implements API.
+func (mc *mockRPCClient) SetHypervisorPasswordForce(string) error {
+	return nil
+}
+
 // DmsgSetMinSessions implements API.
 func (mc *mockRPCClient) DmsgSetMinSessions(_ int) error {
 	return nil

--- a/pkg/visor/usermanager/set_admin_password_test.go
+++ b/pkg/visor/usermanager/set_admin_password_test.go
@@ -1,0 +1,108 @@
+package usermanager
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// memUserStore is a tiny in-memory UserStore for tests. User() returns a
+// copy (as BoltUserStore does via gob-decode), so mutating the returned
+// *User only persists via SetUser.
+type memUserStore struct{ m map[string]User }
+
+func newMemUserStore() *memUserStore { return &memUserStore{m: make(map[string]User)} }
+
+func (s *memUserStore) User(name string) (*User, error) {
+	u, ok := s.m[name]
+	if !ok {
+		return nil, errors.New("user not found")
+	}
+	cp := u
+	return &cp, nil
+}
+
+func (s *memUserStore) AddUser(u User) error {
+	if _, ok := s.m[u.Name]; ok {
+		return ErrUserExists
+	}
+	s.m[u.Name] = u
+	return nil
+}
+
+func (s *memUserStore) SetUser(u User) error         { s.m[u.Name] = u; return nil }
+func (s *memUserStore) RemoveUser(name string) error { delete(s.m, name); return nil }
+func (s *memUserStore) Close() error                 { return nil }
+
+// newTestUserManager builds a UserManager using only the fields
+// SetAdminPassword touches (store, sessions, mutex) — no cookie crypto.
+func newTestUserManager(store UserStore) *UserManager {
+	return &UserManager{
+		db:       store,
+		sessions: make(map[uuid.UUID]Session),
+		mu:       new(sync.RWMutex),
+	}
+}
+
+// TestSetAdminPassword_CreatesAdminWhenAbsent: a first-time set from the
+// CLI (--force) must create the "admin" account, so no UI create-account
+// round-trip is needed.
+func TestSetAdminPassword_CreatesAdminWhenAbsent(t *testing.T) {
+	store := newMemUserStore()
+	um := newTestUserManager(store)
+
+	if _, err := store.User("admin"); err == nil {
+		t.Fatal("precondition: admin must not exist yet")
+	}
+
+	const pw = "Sky!wire9"
+	if err := um.SetAdminPassword(pw); err != nil {
+		t.Fatalf("SetAdminPassword (create): %v", err)
+	}
+
+	u, err := store.User("admin")
+	if err != nil {
+		t.Fatalf("admin account not created: %v", err)
+	}
+	if !u.VerifyPassword(pw) {
+		t.Fatal("created admin does not verify the set password")
+	}
+}
+
+// TestSetAdminPassword_ResetsWithoutOld: a forgotten-password reset must
+// overwrite the existing admin password without supplying the old one.
+func TestSetAdminPassword_ResetsWithoutOld(t *testing.T) {
+	store := newMemUserStore()
+	um := newTestUserManager(store)
+
+	const oldPw, newPw = "Old!pass1", "New!pass2"
+	if err := um.SetAdminPassword(oldPw); err != nil {
+		t.Fatalf("setup set: %v", err)
+	}
+
+	if err := um.SetAdminPassword(newPw); err != nil {
+		t.Fatalf("SetAdminPassword (reset): %v", err)
+	}
+
+	u, err := store.User("admin")
+	if err != nil {
+		t.Fatalf("admin missing after reset: %v", err)
+	}
+	if !u.VerifyPassword(newPw) {
+		t.Fatal("reset password does not verify")
+	}
+	if u.VerifyPassword(oldPw) {
+		t.Fatal("old password still verifies after reset")
+	}
+}
+
+// TestSetAdminPassword_RejectsBadFormat: the force path must NOT bypass
+// the password-format rules.
+func TestSetAdminPassword_RejectsBadFormat(t *testing.T) {
+	um := newTestUserManager(newMemUserStore())
+	if err := um.SetAdminPassword("weak"); err == nil {
+		t.Fatal("expected a weak password to be rejected")
+	}
+}

--- a/pkg/visor/usermanager/user_manager.go
+++ b/pkg/visor/usermanager/user_manager.go
@@ -357,6 +357,38 @@ func (s *UserManager) ChangeAdminPassword(oldPassword, newPassword string) error
 	return nil
 }
 
+// SetAdminPassword sets the "admin" account password WITHOUT requiring
+// the old one, creating the admin account if it doesn't exist yet.
+// Intended for the local privileged RPC path
+// (skywire cli visor hv passwd --force): a forgotten-password reset, or a
+// first-time set straight from the CLI without the UI's create-account
+// page. Enforces the same checkPasswordFormat rules and invalidates every
+// active session for the user so old cookies can't be replayed.
+func (s *UserManager) SetAdminPassword(newPassword string) error {
+	user, err := s.db.User("admin")
+	if err != nil || user == nil {
+		// No admin account yet — create it (first-time set from CLI).
+		var u User
+		if ok := u.SetName("admin"); !ok {
+			return ErrBadUsernameFormat
+		}
+		if err := u.SetPassword(newPassword); err != nil {
+			return err
+		}
+		return s.db.AddUser(u)
+	}
+
+	// Existing admin — overwrite the password without the old one.
+	if err := user.SetPassword(newPassword); err != nil {
+		return err
+	}
+	if err := s.db.SetUser(*user); err != nil {
+		return err
+	}
+	s.delAllSessionsOfUser(user.Name)
+	return nil
+}
+
 func (s *UserManager) delSession(w http.ResponseWriter, r *http.Request) error {
 	cookie, err := r.Cookie(sessionCookieName)
 	if err != nil {


### PR DESCRIPTION
### Problem
`skywire cli visor hv passwd` could only **change** the password — it verifies `--old` via `UserManager.ChangeAdminPassword`. So:
- a **forgotten** hypervisor-UI password could only be cleared by deleting the bolt user store (`hypervisor.db_path`, e.g. `local/hypervisor/users.db`), and
- the **first** password could only be set through the UI's create-account page.

There was no CLI path to reset or set it without the old one.

### Fix — `--force`
`skywire cli visor hv passwd --new <pw> --force` sets the password **without** the old one, **creating** the `admin` account if none exists. Covers both:
- **forgotten-password reset**, and
- **first-time set straight from the CLI** (no UI round-trip).

Same privileged-local rationale as the existing command (the RPC is local-only and already privileged). Password-format rules still apply (no bypass), and all existing sessions are invalidated.

### Implementation
- `UserManager.SetAdminPassword(newPassword)` — no old-password check; create-if-absent; format-checked; sessions invalidated.
- `SetHypervisorPasswordForce` RPC plumbed through all six layers: API interface, Visor impl, RPC server, RPC client, mock, proxy.
- `hv passwd` gains `--force`; `--new` always required, `--old` required only without `--force`.

### Tests
`TestSetAdminPassword_CreatesAdminWhenAbsent`, `TestSetAdminPassword_ResetsWithoutOld`, `TestSetAdminPassword_RejectsBadFormat` (format rules not bypassed). Full `pkg/visor/usermanager` suite + build green; lint clean.

### Usage
```
skywire cli visor hv passwd --new 'NewP@ss1' --force
```
(reset a forgotten password, or set it for the first time).