### PR TITLE
feat(rewards/ui): currently-enforced minimum-version banner + restore detail tree view

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/htmpl.go
+++ b/cmd/skywire-cli/commands/rewards/server/htmpl.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	htmpl "html/template"
 	"net/http"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/bitfield/script"
 	"github.com/gin-gonic/gin"
@@ -51,6 +53,7 @@ nav .dropdown a{display:block;padding:4px 12px;}
   <details><summary>logs</summary><div class='dropdown'>
     <a href='/log-collection'>overview</a>
     <a href='/log-collection/tree'>survey index</a>
+    <a href='/log-collection/tree-detail'>survey detail tree</a>
     <a href='/log-collection/tplogs'>transport logs</a>
   </div></details>
   <details><summary>services</summary><div class='dropdown'>
@@ -144,6 +147,30 @@ func chunkedPageHead(title, description, path string) string {
 	return h
 }
 
+// currentMinVersion reads the cached "currently-enforced minimum
+// skywire version" written by getlogs.sh's auto-derivation. The cache
+// path matches rewards/getlogs.sh which writes /tmp/skywire_minversion.cache.
+// Returns empty string when the cache is missing or older than 24h —
+// callers degrade gracefully to a static "see Version section" link
+// instead of displaying a stale value.
+func currentMinVersion() string {
+	const cachePath = "/tmp/skywire_minversion.cache"
+	const maxAge = 24 * time.Hour
+	info, err := os.Stat(cachePath)
+	if err != nil || time.Since(info.ModTime()) > maxAge {
+		return ""
+	}
+	data, err := os.ReadFile(cachePath) //nolint:gosec
+	if err != nil {
+		return ""
+	}
+	v := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(v, "v") {
+		return ""
+	}
+	return v
+}
+
 // ineligibleReasonLink renders an ineligibility reason as a link
 // into the matching mainnet-rules anchor on the rewards index page,
 // so visitors can click through to the rule that classified them
@@ -194,7 +221,19 @@ func mainPage(c *gin.Context) {
 	// pointer to the eligibility rules — instead of being dropped
 	// straight into a 200-line rules article. Keep this terse;
 	// detailed rules live below.
-	introHTML := `<div style='border:1px solid #333;padding:10px 14px;margin:8px 0;background:#1a1d24;border-radius:4px;'>` +
+	// Currently-enforced minimum version banner. Reads from the cache
+	// that rewards/getlogs.sh writes after consulting the skywire
+	// release feed. Displays empty span if the cache is missing/stale
+	// so we never publish a misleading value.
+	minVerBanner := ""
+	if v := currentMinVersion(); v != "" {
+		minVerBanner = `<div style='border:1px solid #2d4a6b;padding:6px 10px;margin:8px 0;background:#1a2536;border-radius:4px;font-size:11pt;'>` +
+			`<b>Currently enforced minimum skywire version: <span style='color:#3399FF;'>` + v + `</span></b> ` +
+			`<span style='color:#94a3b8;font-size:9pt;'>(auto-derived: each release becomes required 14 days after its tag date — see <a href='/skycoin-rewards/#Version'>Version</a> for full rule)</span>` +
+			`</div>`
+	}
+	introHTML := minVerBanner +
+		`<div style='border:1px solid #333;padding:10px 14px;margin:8px 0;background:#1a1d24;border-radius:4px;'>` +
 		`<b>Skywire</b> is a decentralized mesh network. Run a visor on any computer (Linux, ARM SBC, Windows, macOS) and earn <b>Skycoin</b> rewards for providing uptime and bandwidth to the network. 816,000 SKY are distributed annually across two reward pools (presence + bandwidth) to all eligible visors.<br><br>` +
 		`<b>Get started:</b> <a href='https://deb.theskywirenetwork.net/generator/'>install command generator</a> &middot; ` +
 		`<a href='https://deb.theskywirenetwork.net'>apt repo</a> &middot; ` +
@@ -235,6 +274,7 @@ var htmlMainPageTemplate = `
   <details><summary>logs</summary><div class='dropdown'>
     <a href='/log-collection'>overview</a>
     <a href='/log-collection/tree'>survey index</a>
+    <a href='/log-collection/tree-detail'>survey detail tree</a>
     <a href='/log-collection/tplogs'>transport logs</a>
   </div></details>
   <details><summary>services</summary><div class='dropdown'>

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -151,6 +151,7 @@ func buildRouter() *gin.Engine {
 				{"/stats", "0.7"},
 				{"/log-collection", "0.6"},
 				{"/log-collection/tree", "0.6"},
+				{"/log-collection/tree-detail", "0.5"},
 				{"/transport-graph", "0.5"},
 				{"/stats/version-history", "0.5"},
 				{"/stats/bandwidth-history", "0.5"},
@@ -336,6 +337,8 @@ func buildRouter() *gin.Engine {
 			c.Writer.Flush()
 			c.Writer.Write([]byte(navlinks)) //nolint:errcheck,gosec
 			c.Writer.Flush()
+			c.Writer.Write([]byte("<p style='margin:6px 0;'>View: <b>flat list</b> &middot; <a href='/log-collection/tree-detail'>detail tree (per-PK health.json + version inline)</a></p>\n")) //nolint:errcheck,gosec
+			c.Writer.Flush()
 			surveycount, _ := script.FindFiles(wd + `/` + "log_backups/").Match("node-info.json").CountLines() //nolint:errcheck,gosec
 			c.Writer.Write([]byte(fmt.Sprintf("Total surveys: %v\n\n", surveycount)))                          //nolint:errcheck,gosec,staticcheck
 			c.Writer.Flush()
@@ -374,6 +377,37 @@ func buildRouter() *gin.Engine {
 					fmt.Fprint(c.Writer, "\n") //nolint:errcheck,gosec
 				}
 			}
+			c.Writer.Flush()
+			c.Writer.Write([]byte(htmltoplink)) //nolint:errcheck,gosec
+			c.Writer.Flush()
+			c.Writer.Write([]byte(htmlend)) //nolint:errcheck,gosec
+			c.Writer.Flush()
+		})
+
+		// Detail tree view — restores the pre-2026-03-28 format that
+		// showed per-PK health.json contents and node-info.json version
+		// inline, so operators can spot version distribution at a glance
+		// without clicking into individual visor pages. Output is the
+		// ANSI tree rendered by `skywire cli log st -d log_backups -r`
+		// (Index header, ├/└ branches, color-coded file types, age +
+		// JSON body for health.json, version field for node-info.json),
+		// converted to HTML. The flat list lives at /log-collection/tree.
+		r1.GET("/log-collection/tree-detail", func(c *gin.Context) {
+			c.Writer.Header().Set("Server", "")
+			c.Writer.Header().Set("Transfer-Encoding", "chunked")
+			c.Writer.WriteHeader(http.StatusOK)
+			c.Writer.Write([]byte(chunkedPageHead("Survey Detail Tree", "Detailed Skywire visor survey tree with inline health.json and version info", "/log-collection/tree-detail"))) //nolint:errcheck,gosec
+			c.Writer.Flush()
+			c.Writer.Write([]byte(navlinks)) //nolint:errcheck,gosec
+			c.Writer.Flush()
+			c.Writer.Write([]byte("<p style='margin:6px 0;'>View: <a href='/log-collection/tree'>flat list</a> &middot; <b>detail tree (per-PK health.json + version inline)</b></p>\n")) //nolint:errcheck,gosec
+			c.Writer.Flush()
+			st, err := script.Exec(`skywire cli log st -d ` + wd + `/log_backups -r`).Bytes()
+			if err != nil {
+				log.WithError(err).Error()
+				c.Writer.Write([]byte(err.Error())) //nolint:errcheck,gosec
+			}
+			c.Writer.Write(ansihtml.ConvertToHTML(st)) //nolint:errcheck,gosec
 			c.Writer.Flush()
 			c.Writer.Write([]byte(htmltoplink)) //nolint:errcheck,gosec
 			c.Writer.Flush()

--- a/pkg/dmsg/dmsghttp/http_transport_test.go
+++ b/pkg/dmsg/dmsghttp/http_transport_test.go
@@ -258,15 +258,15 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		gotAcceptEncoding <- r.Header.Get("Accept-Encoding")
 		var buf bytes.Buffer
 		gz := gzip.NewWriter(&buf)
-		_, _ = gz.Write([]byte(payload))
-		_ = gz.Close()
+		_, _ = gz.Write([]byte(payload)) //nolint:errcheck
+		_ = gz.Close()                   //nolint:errcheck
 		w.Header().Set("Content-Encoding", "gzip")
 		w.Header().Set("Content-Type", "text/plain")
-		_, _ = w.Write(buf.Bytes())
+		_, _ = w.Write(buf.Bytes()) //nolint:errcheck
 	})
 	mux.HandleFunc("/plain", func(w http.ResponseWriter, r *http.Request) {
 		gotAcceptEncoding <- r.Header.Get("Accept-Encoding")
-		_, _ = w.Write([]byte(payload))
+		_, _ = w.Write([]byte(payload)) //nolint:errcheck
 	})
 	srv := &http.Server{ReadHeaderTimeout: 3 * time.Second, Handler: mux}
 	errCh := make(chan error, 1)
@@ -304,7 +304,7 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		require.NoError(t, err)
 		resp, err := httpC.Do(req)
 		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 		assert.Contains(t, waitAE(t), "gzip", "transport must advertise Accept-Encoding: gzip")
 
@@ -323,7 +323,7 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		req.Header.Set("Accept-Encoding", "identity")
 		resp, err := httpC.Do(req)
 		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 		assert.Equal(t, "identity", waitAE(t), "caller's Accept-Encoding must be preserved")
 		body, err := io.ReadAll(resp.Body)

--- a/pkg/transport-discovery/api/edge_response_cache_test.go
+++ b/pkg/transport-discovery/api/edge_response_cache_test.go
@@ -44,12 +44,12 @@ func TestEdgeRespCache(t *testing.T) {
 	})
 
 	t.Run("stale-on-error returns last good body", func(t *testing.T) {
-		short := newEdgeRespCache(20 * time.Millisecond)
+		short := newEdgeRespCache(100 * time.Millisecond)
 		good := []byte(`["good"]`)
 		_, _, err := short.body(pkA, func() ([]byte, error) { return good, nil })
 		require.NoError(t, err)
 
-		time.Sleep(30 * time.Millisecond) // expire the slot
+		time.Sleep(150 * time.Millisecond) // expire the slot
 		raw, _, err := short.body(pkA, func() ([]byte, error) { return nil, errors.New("store down") })
 		require.NoError(t, err, "should serve stale, not error, when a prior body exists")
 		assert.Equal(t, good, raw)
@@ -62,7 +62,11 @@ func TestEdgeRespCache(t *testing.T) {
 	})
 
 	t.Run("expired slots are swept on miss", func(t *testing.T) {
-		short := newEdgeRespCache(20 * time.Millisecond)
+		// TTL deliberately well above the cost of two body() calls on a
+		// slow CI runner. Earlier 20ms version flaked on linux runners
+		// when the second body() call took >20ms to reach the sweep,
+		// causing pkA to expire mid-test and the assert.Len(2) to fail.
+		short := newEdgeRespCache(100 * time.Millisecond)
 		// Populate two edges.
 		_, _, err := short.body(pkA, func() ([]byte, error) { return []byte(`["a"]`), nil })
 		require.NoError(t, err)
@@ -70,7 +74,7 @@ func TestEdgeRespCache(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, short.slots, 2)
 
-		time.Sleep(30 * time.Millisecond) // expire both slots
+		time.Sleep(150 * time.Millisecond) // expire both slots
 
 		// One miss on pkA should sweep pkB's expired slot too, leaving only pkA.
 		_, _, err = short.body(pkA, func() ([]byte, error) { return []byte(`["a2"]`), nil })


### PR DESCRIPTION
## Summary

Two visibility improvements to the rewards UI.

### 1. Currently-enforced minimum-version banner on `/skycoin-rewards/`

`rewards/mainnet_rules.md` surfaces the version cutoff schedule but only as **hardcoded text** (currently shows `v1.3.50 - Cutoff May 22nd 2026`). The +14-days-from-tag policy means the actual current floor drifts ahead of that text continuously: v1.3.53 today, v1.3.54 in 2 days, etc.

This change adds a small banner near the top of the home page that displays the live value read from `/tmp/skywire_minversion.cache` — the same cache `rewards/getlogs.sh` writes after consulting the GitHub releases feed. Reuses that single source of truth (no extra GitHub API call from the server). Falls back to empty (no banner) when the cache is missing or older than 24h, so we never publish a stale value if the cache writer is down.

### 2. `/log-collection/tree-detail` — restore the pre-2026-03-28 format

Commit `7c3fd0b81` replaced the rich ANSI tree (per-PK `health.json` contents inline + visor version inline from `node-info.json`) with the minimal "PK + survey/no-survey status" flat list. The flat view is cleaner for click-through navigation but operators lose the at-a-glance view of network-wide version distribution (which is especially useful while we're rolling out a new required minimum).

This change adds a new endpoint that runs the old `skywire cli log st -d <wd>/log_backups -r` command and ANSI-html converts the output — visually identical to the pre-change format. Cross-links both views (flat ↔ detail) at the top of each page, adds the detail endpoint to the **logs** nav dropdown, and adds it to the sitemap.

## Test plan

- [ ] `make format check` — pre-existing baseline staticcheck hits in `loginchain.go` unrelated to this change remain (per [CI scope rule](https://github.com/skycoin/skywire/blob/develop/Makefile))
- [ ] `go build ./cmd/skywire-cli/commands/rewards/server/` clean
- [ ] `go vet ./cmd/skywire-cli/commands/rewards/server/` clean
- [ ] Visit `/skycoin-rewards` — banner appears with the cached value (e.g. `v1.3.53`) when `/tmp/skywire_minversion.cache` is fresh
- [ ] Stop `getlogs.sh` cron / remove the cache file → reload `/skycoin-rewards` → banner gracefully disappears (no error, no stale value)
- [ ] Visit `/log-collection/tree-detail` — see the colored tree with `health.json` body and `node-info.json` version inline per PK (same as pre-7c3fd0b81)
- [ ] Visit `/log-collection/tree` — flat list now has a "View: flat list · detail tree" link at the top; click through to detail and back
- [ ] Logs nav dropdown shows both entries: "survey index" (flat) and "survey detail tree"