### PR TITLE
fix(tpd): stagger MetricsCXOPublisher per-window cadence to bound GC

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -138,6 +138,18 @@ type Client struct {
 	once  sync.Once
 	wg    sync.WaitGroup // tracks background goroutines for clean shutdown
 	sesMx sync.Mutex
+
+	// closed gates new session-serving goroutines once Close has begun.
+	// Protected by EntityCommon.sessionsMx — set true at the start of
+	// Close's critical section and checked in dialSession before
+	// wg.Add(1). Without this gate, a dialSession running concurrently
+	// with Close can race wg.Add against wg.Wait (the race detector
+	// flags this in TestEnv): Close.wg.Wait returns with the counter
+	// at zero just as dialSession is about to wg.Add(1), leaving a
+	// serve-goroutine un-waited-on. Holding sessionsMx around both
+	// the closed-set in Close and the closed-check + Add in
+	// dialSession provides the happens-before edge.
+	closed bool
 }
 
 // AddDiscovery registers an additional dmsg-discovery this client
@@ -498,6 +510,10 @@ func (ce *Client) Close() error {
 		ce.sesMx.Unlock()
 
 		ce.sessionsMx.Lock()
+		// Mark closed before iterating so any concurrent dialSession
+		// blocking on sessionsMx sees the closed flag and bails out
+		// without doing wg.Add(1) (see Client.closed for the race).
+		ce.closed = true
 		for _, dSes := range ce.sessions {
 			ce.log.
 				WithError(dSes.Close()).

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -151,12 +151,37 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 		ce.log.Infof("yamux stream session initial for %s", dSes.RemotePK().String())
 	}
 
-	if !ce.setSession(ctx, dSes.SessionCommon) {
+	// Atomically: refuse-if-closed, dedupe, store, and wg.Add(1) under
+	// sessionsMx — pairs with Close which sets ce.closed under the same
+	// lock before wg.Wait. The Add must happen-before any subsequent
+	// Wait or sync.WaitGroup races (TestEnv race: Add at 159 vs Wait at
+	// client.go:510). The setSessionCallback is invoked outside the lock
+	// to match the previous setSession semantics.
+	ce.sessionsMx.Lock()
+	if ce.closed {
+		ce.sessionsMx.Unlock()
+		_ = dSes.Close() //nolint:errcheck
+		return ClientSession{}, errors.New("client closed")
+	}
+	if _, exists := ce.sessions[dSes.RemotePK()]; exists {
+		ce.sessionsMx.Unlock()
 		_ = dSes.Close() //nolint:errcheck
 		return ClientSession{}, errors.New("session already exists")
 	}
-
+	ce.sessions[dSes.RemotePK()] = dSes.SessionCommon
 	ce.wg.Add(1)
+	setSessCb := ce.setSessionCallback
+	ce.sessionsMx.Unlock()
+
+	if setSessCb != nil {
+		if err := setSessCb(ctx); err != nil {
+			ce.log.
+				WithField("func", "Client.dialSession").
+				WithError(err).
+				Warn("setSessionCallback returned non-nil error.")
+		}
+	}
+
 	go func() {
 		defer ce.wg.Done()
 		defer func() {

--- a/pkg/dmsg/dmsghttp/http_transport_test.go
+++ b/pkg/dmsg/dmsghttp/http_transport_test.go
@@ -258,15 +258,15 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		gotAcceptEncoding <- r.Header.Get("Accept-Encoding")
 		var buf bytes.Buffer
 		gz := gzip.NewWriter(&buf)
-		_, _ = gz.Write([]byte(payload))
-		_ = gz.Close()
+		_, _ = gz.Write([]byte(payload)) //nolint:errcheck
+		_ = gz.Close()                   //nolint:errcheck
 		w.Header().Set("Content-Encoding", "gzip")
 		w.Header().Set("Content-Type", "text/plain")
-		_, _ = w.Write(buf.Bytes())
+		_, _ = w.Write(buf.Bytes()) //nolint:errcheck
 	})
 	mux.HandleFunc("/plain", func(w http.ResponseWriter, r *http.Request) {
 		gotAcceptEncoding <- r.Header.Get("Accept-Encoding")
-		_, _ = w.Write([]byte(payload))
+		_, _ = w.Write([]byte(payload)) //nolint:errcheck
 	})
 	srv := &http.Server{ReadHeaderTimeout: 3 * time.Second, Handler: mux}
 	errCh := make(chan error, 1)
@@ -304,7 +304,7 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		require.NoError(t, err)
 		resp, err := httpC.Do(req)
 		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 		assert.Contains(t, waitAE(t), "gzip", "transport must advertise Accept-Encoding: gzip")
 
@@ -323,7 +323,7 @@ func TestHTTPTransport_TransparentGzip(t *testing.T) {
 		req.Header.Set("Accept-Encoding", "identity")
 		resp, err := httpC.Do(req)
 		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
+		defer func() { _ = resp.Body.Close() }() //nolint:errcheck
 
 		assert.Equal(t, "identity", waitAE(t), "caller's Accept-Encoding must be preserved")
 		body, err := io.ReadAll(resp.Body)

--- a/pkg/transport-discovery/api/cxo_metrics_publisher.go
+++ b/pkg/transport-discovery/api/cxo_metrics_publisher.go
@@ -32,15 +32,33 @@ import (
 	"github.com/skycoin/skywire/pkg/transport-discovery/store"
 )
 
-// metricsPublishDays is the set of day windows the publisher refreshes
-// on every tick. The hvui currently picks one of these via the day
-// selector; everything else falls through to the HTTP path.
-var metricsPublishDays = []int{1, 7, 30}
+// metricsPublishWindow defines a CXO-published day-window and the
+// cadence at which its body is recomputed. Heavy windows (7d, 30d)
+// aggregate over long periods and barely change minute-to-minute, so
+// they recompute less often than the 1d window — the previous
+// uniform 60s tick across all three windows drove TPD into a GC
+// storm (~70% of CPU in gcBgMarkWorker under prod load, since
+// buildTransportMetrics walks all transports × days × per-edge
+// fields each call). Staggering the heavy windows keeps subscribers
+// fed without paying the full cost every minute.
+type metricsPublishWindow struct {
+	days     int
+	interval time.Duration
+}
 
-// metricsPublishInterval is the recompute cadence. 60s is short
-// enough that a typical hvui open will catch a fresh sample within
-// one cycle, long enough that the redis read cost stays bounded.
-const metricsPublishInterval = 60 * time.Second
+// metricsPublishWindows is the set of day windows the publisher
+// refreshes, each on its own ticker. The hvui picks one of these via
+// the day selector; everything else falls through to the HTTP path.
+// Cadence picks: 60s for the 1d window matches a typical hvui-open
+// freshness expectation; 5m for the 7d window and 30m for the 30d
+// window are short enough that an opening hvui sees recent data
+// (well inside human-noticeable freshness on a long aggregate) and
+// long enough that the buildTransportMetrics cost amortizes.
+var metricsPublishWindows = []metricsPublishWindow{
+	{days: 1, interval: 60 * time.Second},
+	{days: 7, interval: 5 * time.Minute},
+	{days: 30, interval: 30 * time.Minute},
+}
 
 // MetricsCXOPublisher periodically computes the /metrics aggregate
 // for a fixed set of day windows and publishes each result as a
@@ -115,50 +133,56 @@ func (m *MetricsCXOPublisher) Close() error {
 func (m *MetricsCXOPublisher) loop(ctx context.Context) {
 	defer close(m.done)
 
-	// Publish once immediately so a subscriber that connects shortly
-	// after TPD starts gets a snapshot without waiting a full tick.
-	m.publishOnce(ctx)
+	var wg sync.WaitGroup
+	for _, w := range metricsPublishWindows {
+		wg.Add(1)
+		go func(w metricsPublishWindow) {
+			defer wg.Done()
+			// Publish once immediately so a subscriber that connects
+			// shortly after TPD starts gets a snapshot without waiting
+			// a full tick.
+			m.publishWindow(ctx, w.days)
 
-	t := time.NewTicker(metricsPublishInterval)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			m.publishOnce(ctx)
-		}
+			t := time.NewTicker(w.interval)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					m.publishWindow(ctx, w.days)
+				}
+			}
+		}(w)
 	}
+	wg.Wait()
 }
 
-func (m *MetricsCXOPublisher) publishOnce(ctx context.Context) {
-	for _, days := range metricsPublishDays {
-		query := store.MetricsQuery{
-			Days:      days,
-			Live:      "all",
-			Edges:     true,
-			Bandwidth: true,
-			Latency:   true,
-		}
-		metrics, err := m.api.store.GetAllTransportMetrics(ctx, query)
-		if err != nil {
-			m.log.WithError(err).WithField("days", days).Debug("metrics fetch failed; will retry next tick")
-			m.recordError(err)
-			continue
-		}
-		body, err := json.Marshal(metrics)
-		if err != nil {
-			m.log.WithError(err).WithField("days", days).Warn("metrics marshal failed")
-			m.recordError(err)
-			continue
-		}
-		path := metricsPath(days)
-		if err := m.pub.Put(path, body); err != nil {
-			m.log.WithError(err).WithField("path", path).Warn("publisher Put failed")
-			m.recordError(err)
-			continue
-		}
+func (m *MetricsCXOPublisher) publishWindow(ctx context.Context, days int) {
+	query := store.MetricsQuery{
+		Days:      days,
+		Live:      "all",
+		Edges:     true,
+		Bandwidth: true,
+		Latency:   true,
+	}
+	metrics, err := m.api.store.GetAllTransportMetrics(ctx, query)
+	if err != nil {
+		m.log.WithError(err).WithField("days", days).Debug("metrics fetch failed; will retry next tick")
+		m.recordError(err)
+		return
+	}
+	body, err := json.Marshal(metrics)
+	if err != nil {
+		m.log.WithError(err).WithField("days", days).Warn("metrics marshal failed")
+		m.recordError(err)
+		return
+	}
+	path := metricsPath(days)
+	if err := m.pub.Put(path, body); err != nil {
+		m.log.WithError(err).WithField("path", path).Warn("publisher Put failed")
+		m.recordError(err)
+		return
 	}
 }
 


### PR DESCRIPTION
## Summary

Production pprof on prod02 showed TPD sustained at 250%+ CPU with **~70% in `runtime.gcBgMarkWorker`** — a GC storm, not workload. Allocation profile traced back to `MetricsCXOPublisher.loop → publishOnce → store.GetAllTransportMetrics → store.buildTransportMetrics`, which alone accounted for **27.7 GB flat allocations per 10 s sample (~25.8% of total cumulative TPD allocations)**.

## Root cause

The old loop fired a single 60 s ticker and inside each tick recomputed all three day windows `{1, 7, 30}`. `buildTransportMetrics` walks every transport × day × per-edge field, so the 7d and 30d windows dominate per-tick allocation cost while their aggregates barely change minute-to-minute.

## Fix

Switch to per-window staggered cadences — each window gets its own goroutine + ticker, and `publishOnce` becomes `publishWindow(days)`:

| Window | Cadence | Rationale |
|---|---|---|
| 1 d | 60 s (unchanged) | Matches typical hvui-open freshness expectation |
| 7 d | 5 m | Aggregates over a week — a few-minute lag is invisible at that scale |
| 30 d | 30 m | Aggregates over a month — same reasoning |

All three windows are still published; subscribers watching `metrics/days/{1, 7, 30}` see no API change. Initial publish on startup is preserved so freshly-connecting subscribers still get a snapshot without waiting a full tick.

## Allocation math

Previous: 60 s × 3 windows = `1` window-publish every `20 s` = **4 320 / day**.
New: `1 440` (1 d @ 60 s) + `288` (7 d @ 5 m) + `48` (30 d @ 30 m) = **1 776 / day** — and the per-window cost weight is non-uniform, so since the 30 d window was previously paying 60 × the necessary cost and 7 d was paying 5 ×, actual allocation drops more than the raw call-count ratio implies. Expected ~70 % reduction in publisher-side alloc rate.

## Side fixes folded in this PR

- **`chore(lint)`** — 6 × `//nolint:errcheck` annotations on intentional discards in `pkg/dmsg/dmsghttp/http_transport_test.go` (lines added by #2986). golangci-lint errcheck was flagging these and blocking CI; matches the convention already used elsewhere in the same file.
- **`fix(dmsg/client)`** — closes the pre-existing `Client.wg.Add(1)` vs `wg.Wait` race surfaced by CI's `TestEnv -race`. The race is in `pkg/dmsg/dmsg/client.go:510` vs `client_sessions.go:159`, predates this PR by ~2 months, but was intermittently breaking CI for any PR that touched related territory. Fix gates `dialSession`'s `wg.Add(1)` behind a `closed` flag guarded by `sessionsMx`, the same lock `Close` takes during its cleanup critical section — providing the happens-before edge Go's `sync.WaitGroup` requires.

## Test plan

- [x] `go build ./pkg/transport-discovery/... ./pkg/dmsg/...` green
- [x] `go vet ./pkg/dmsg/... ./pkg/transport-discovery/api/...` clean
- [x] `gofmt -l` clean on all touched files
- [x] `go test ./pkg/transport-discovery/api/... -count=1 -short` green
- [x] `go test ./pkg/dmsg/dmsgtest -run TestEnv -race -count=10` 10/10 green
- [x] `go test ./pkg/dmsg/dmsgtest -run TestEnv -race -count=50` (225 s wall) green
- [x] `go test ./pkg/dmsg/dmsgtest -race -count=1` green
- [ ] Deploy verification: after merge + image build, pull on prod02 and watch the cumulative `gcBgMarkWorker` share in TPD CPU pprof and the `MetricsCXOPublisher` flat-alloc share — expect the GC share to drop from ~70 % into the normal teens.

## Context

Follow-up to #2992 (delConn fix). With the delConn channel-send leak closed, TPD goroutine count is stable at ~3 K but CPU was still pegged because the GC storm took over as the dominant load driver — visible as `runtime.scanSpan` / `gcDrain` topping the CPU profile while goroutines stayed flat.