### PR TITLE
feat(dmsg/probe): standalone `dmsg probe` command (no visor), hidden when bundled

### DIFF
--- a/cmd/dmsg/dmsg/commands/root.go
+++ b/cmd/dmsg/dmsg/commands/root.go
@@ -17,6 +17,7 @@ import (
 	dc "github.com/skycoin/skywire/cmd/dmsg/dmsgcurl/commands"
 	dh "github.com/skycoin/skywire/cmd/dmsg/dmsghttp/commands"
 	di "github.com/skycoin/skywire/cmd/dmsg/dmsgip/commands"
+	dp "github.com/skycoin/skywire/cmd/dmsg/dmsgprobe/commands"
 	dw "github.com/skycoin/skywire/cmd/dmsg/dmsgweb/commands"
 	dpc "github.com/skycoin/skywire/cmd/dmsg/pty-cli/commands"
 	dph "github.com/skycoin/skywire/cmd/dmsg/pty-host/commands"
@@ -58,6 +59,7 @@ func init() {
 		dw.RootCmd,
 		ds5.RootCmd,
 		di.RootCmd,
+		dp.RootCmd,
 		dsp.RootCmd,
 	)
 	dd.RootCmd.Use = "disc"

--- a/cmd/dmsg/dmsgprobe/commands/dmsgprobe.go
+++ b/cmd/dmsg/dmsgprobe/commands/dmsgprobe.go
@@ -1,0 +1,179 @@
+// Package commands cmd/dmsg/dmsgprobe/commands
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/calvin"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skywire/tcpnoise"
+)
+
+var (
+	sk          cipher.SecKey
+	probeServer string
+	probeVia    string
+	logLvl      string
+	plog        = logging.MustGetLogger("dmsgprobe")
+)
+
+func init() {
+	RootCmd.Flags().SortFlags = false
+	dmsgclient.InitFlags(RootCmd)
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]")
+	RootCmd.Flags().StringVar(&probeServer, "server", "", "force the probe through this specific dmsg server (pk hex)")
+	RootCmd.Flags().StringVar(&probeVia, "via", "", "probe a direct noise-TCP connection instead of dmsg: tcp://<pk>@host:port")
+	if os.Getenv("DMSG_SK") != "" {
+		sk.Set(os.Getenv("DMSG_SK")) //nolint
+	}
+	RootCmd.Flags().VarP(&sk, "sk", "s", "secret key to use (a random key is generated if unspecified)")
+}
+
+// RootCmd is the standalone `dmsg probe` command. It is the standalone
+// (no-visor) counterpart to `skywire cli dmsg probe`: same reachability
+// check, but it always bootstraps its own dmsg client (mirrors the
+// dmsgcurl ↔ `cli dmsg curl` split). There is no RPC mode here because a
+// standalone binary has no visor to ask.
+var RootCmd = &cobra.Command{
+	Use:   "probe <public-key> <port>",
+	Short: "Standalone DMSG port-reachability probe",
+	Long: calvin.AsciiFont("dmsg-probe") + `
+	Standalone DMSG port-reachability probe — its own dmsg client, no visor.
+
+	Performs a full noise handshake to <pk>:<port> over dmsg; a completed
+	handshake means a listener is active (reachable). With --server it forces
+	the probe through a specific dmsg server. With --via tcp://<pk>@host:port
+	it instead probes a direct noise-TCP connection (no dmsg at all).`,
+	SilenceErrors:         true,
+	SilenceUsage:          true,
+	DisableFlagsInUseLine: true,
+	Version:               buildinfo.Version(),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if probeVia != "" {
+			return nil
+		}
+		return cobra.ExactArgs(2)(cmd, args)
+	},
+	RunE: func(_ *cobra.Command, args []string) error {
+		if logLvl != "" {
+			if lvl, e := logging.LevelFromString(logLvl); e == nil {
+				logging.SetLevel(lvl)
+			}
+		}
+
+		// Identity: --sk / DMSG_SK, else a fresh ephemeral pair.
+		pk, err := sk.PubKey()
+		if err != nil {
+			_, sk = cipher.GenerateKeyPair()
+			pk, err = sk.PubKey()
+			if err != nil {
+				return fmt.Errorf("derive public key: %w", err)
+			}
+		}
+
+		// Direct noise-TCP connection probe (no dmsg, no router).
+		if probeVia != "" {
+			rPK, hostPort, perr := parseViaTCP(probeVia)
+			if perr != nil {
+				return perr
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			startT := time.Now()
+			conn, derr := tcpnoise.Dial(ctx, hostPort, pk, sk, rPK)
+			lat := time.Since(startT).Round(time.Millisecond)
+			if derr != nil {
+				fmt.Printf("tcp://%s@%s — unreachable (%s)\n", rPK, hostPort, lat)
+				return nil
+			}
+			_ = conn.Close() //nolint:errcheck
+			fmt.Printf("tcp://%s@%s — reachable (%s)\n", rPK, hostPort, lat)
+			return nil
+		}
+
+		var dpk cipher.PubKey
+		if e := dpk.Set(args[0]); e != nil {
+			return fmt.Errorf("invalid public key: %w", e)
+		}
+		p64, e := strconv.ParseUint(args[1], 10, 16)
+		if e != nil {
+			return fmt.Errorf("invalid port: %w", e)
+		}
+		port := uint16(p64)
+
+		var serverPK cipher.PubKey
+		serverSet := probeServer != ""
+		if serverSet {
+			if e := serverPK.Set(probeServer); e != nil {
+				return fmt.Errorf("invalid --server pk: %w", e)
+			}
+		}
+
+		ctx, cancel := cmdutil.SignalContext(context.Background(), plog)
+		defer cancel()
+		probeCtx, probeCancel := context.WithTimeout(ctx, 30*time.Second)
+		defer probeCancel()
+
+		dest := "dmsg://" + dpk.Hex() + ":" + strconv.Itoa(int(port))
+		dmsgC, stop, err := dmsgclient.InitDmsgWithFlags(probeCtx, plog, pk, sk, &http.Client{}, dest)
+		if err != nil || dmsgC == nil {
+			return fmt.Errorf("failed to start dmsg client: %w", err)
+		}
+		defer stop()
+
+		startT := time.Now()
+		var reachable bool
+		if serverSet {
+			reachable = dmsgC.ProbeViaServer(probeCtx, dpk, port, serverPK)
+		} else {
+			reachable = dmsgC.Probe(probeCtx, dpk, port)
+		}
+		lat := time.Since(startT).Round(time.Millisecond)
+
+		suffix := ""
+		if serverSet {
+			suffix = " (via " + probeServer[:min(8, len(probeServer))] + "…)"
+		}
+		state := "unreachable"
+		if reachable {
+			state = "reachable"
+		}
+		fmt.Printf("dmsg://%s:%d%s — %s (%s)\n", dpk, port, suffix, state, lat)
+		return nil
+	},
+}
+
+// parseViaTCP turns "tcp://<66-hex-pk>@host:port" into (pk, "host:port").
+func parseViaTCP(spec string) (cipher.PubKey, string, error) {
+	const prefix = "tcp://"
+	if !strings.HasPrefix(spec, prefix) {
+		return cipher.PubKey{}, "", fmt.Errorf("--via must start with %q", prefix)
+	}
+	rest := spec[len(prefix):]
+	at := strings.IndexByte(rest, '@')
+	if at <= 0 || at >= len(rest)-1 {
+		return cipher.PubKey{}, "", fmt.Errorf("--via tcp: expected tcp://<pk>@host:port, got %q", spec)
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(rest[:at]); err != nil {
+		return cipher.PubKey{}, "", fmt.Errorf("--via tcp: invalid pk: %w", err)
+	}
+	return pk, rest[at+1:], nil
+}
+
+// Execute executes the RootCmd.
+func Execute() {
+	dmsgclient.Execute(RootCmd)
+}

--- a/cmd/dmsg/dmsgprobe/commands/dmsgprobe_test.go
+++ b/cmd/dmsg/dmsgprobe/commands/dmsgprobe_test.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestParseViaTCP pins the tcp://<pk>@host:port parsing used by the
+// standalone probe's --via direct-connection mode.
+func TestParseViaTCP(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	gotPK, hostPort, err := parseViaTCP("tcp://" + pk.Hex() + "@127.0.0.1:8801")
+	if err != nil {
+		t.Fatalf("parseViaTCP error: %v", err)
+	}
+	if gotPK != pk {
+		t.Fatalf("pk = %s, want %s", gotPK, pk)
+	}
+	if hostPort != "127.0.0.1:8801" {
+		t.Fatalf("hostPort = %q, want 127.0.0.1:8801", hostPort)
+	}
+
+	for _, bad := range []string{
+		"dmsg://" + pk.Hex() + "@h:1",
+		"tcp://" + pk.Hex(),
+		"tcp://@127.0.0.1:8801",
+		"tcp://nothex@127.0.0.1:8801",
+	} {
+		if _, _, err := parseViaTCP(bad); err == nil {
+			t.Fatalf("parseViaTCP(%q) expected error", bad)
+		}
+	}
+}

--- a/cmd/dmsg/dmsgprobe/dmsgprobe.go
+++ b/cmd/dmsg/dmsgprobe/dmsgprobe.go
@@ -1,0 +1,15 @@
+// package main cmd/dmsg/dmsgprobe/dmsgprobe.go
+package main
+
+import (
+	"github.com/skycoin/skywire/cmd/dmsg/dmsgprobe/commands"
+	"github.com/skycoin/skywire/pkg/flags"
+)
+
+func init() {
+	flags.InitFlags(commands.RootCmd, true)
+}
+
+func main() {
+	commands.Execute()
+}

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -17,6 +17,7 @@ import (
 	vpns "github.com/skycoin/skywire/cmd/apps/vpn-server/commands"
 	cxo "github.com/skycoin/skywire/cmd/cxo/commands"
 	dmsg "github.com/skycoin/skywire/cmd/dmsg/dmsg/commands"
+	dmsgprobe "github.com/skycoin/skywire/cmd/dmsg/dmsgprobe/commands"
 	scli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
 	"github.com/skycoin/skywire/cmd/skywire/commands/doc"
 	services "github.com/skycoin/skywire/cmd/svc/skywire-services/commands"
@@ -81,6 +82,11 @@ func init() {
 	// still resolves when invoked directly for back-compat with
 	// existing operator scripts.
 	dmsg.DmsgptyCmd.Hidden = true
+	// The standalone `dmsg probe` stays mounted and callable, but is hidden
+	// from the bundled skywire binary's help — the canonical, richer surface
+	// here is `skywire cli dmsg probe` (which adds visor-RPC + skynet modes).
+	// The standalone dmsg binary still advertises it.
+	dmsgprobe.RootCmd.Hidden = true
 	services.RootCmd.Use = "svc"
 
 	scli.RootCmd.Use = "cli"


### PR DESCRIPTION
Follow-up to #2998 — completes the `skywire dmsg probe` piece, following the **dmsgcurl ↔ `cli dmsg curl`** pattern.

### The pattern
Commands that exist both standalone and via the visor live in two places:
- `cmd/dmsg/<name>/commands` — a **standalone-only** command (own dmsg client, no RPC), mounted into the `dmsg` binary (e.g. `dmsg curl` = `cmd/dmsg/dmsgcurl`).
- `cmd/skywire-cli/commands/dmsg` — the **dual-mode** `cli dmsg X` (visor RPC by default, `--sk` standalone).

`probe` previously only had the second (added in #2998). This adds the first.

### What's here
`skywire dmsg probe <pk> <port>` — a standalone reachability probe that always bootstraps its own dmsg client:
- `-s` / `--sk <hex>` — ephemeral or a specific identity (no visor).
- `--server <server-pk>` — force the probe through a specific dmsg server.
- `--via tcp://<pk>@host:port` — a direct noise-TCP **connection** probe (no dmsg).

No RPC or skynet modes here — those need a visor, which a standalone binary doesn't have (that's exactly why mounting the dual-mode `cli` command here would've been wrong, per my note on #2998).

- New: `cmd/dmsg/dmsgprobe/commands` + a standalone `dmsgprobe` binary main.
- Mounted into the dmsg binary's RootCmd.
- **Hidden** from the bundled `skywire` binary's help (like `dmsgpty`), since `skywire cli dmsg probe` is the canonical richer surface there; the standalone `dmsg` binary still shows it. Still fully callable either way.

Build + vet + lint clean; `parseViaTCP` test included.