### PR TITLE
fix(sudph): detect a dead AR connection so visors re-register after an AR restart

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -925,6 +925,20 @@ func (a *API) bindSUDPH(conn net.Conn, remoteAddr, strPK string) {
 
 			data := buf[:n]
 			a.log.Debugf("(SUDPH) New packet from %v@%v: %v", pk, fromAddr, string(data))
+			if string(data) == addrresolver.UDPKeepHeartbeatMessage {
+				// Echo heartbeats so the visor can detect a dead AR
+				// connection. Over KCP-on-UDP a visor's writes keep
+				// "succeeding" even after this AR process is gone (e.g. a
+				// redeploy), so without an inbound signal the visor never
+				// notices, never reconnects, and its SUDPH entry goes
+				// stale. The echo gives the visor read loop a liveness
+				// deadline to trip. Best-effort.
+				if _, err := conn.Write(data); err != nil {
+					a.log.Debugf("Failed to echo SUDPH heartbeat to %v: %v", pk, err)
+					return
+				}
+				continue
+			}
 			if string(data) == addrresolver.UDPDelBindMessage {
 				err = a.store.DelBind(context.Background(), types.SUDPH, pk)
 				if err != nil {

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -46,6 +46,14 @@ const (
 	// sudphReconnectMaxBackoff caps the reconnect sleep so a long AR
 	// outage doesn't push the retry interval out indefinitely.
 	sudphReconnectMaxBackoff = 60 * time.Second
+	// sudphARReadTimeout bounds how long the SUDPH read loop waits for any
+	// inbound packet from the AR before treating the connection as dead.
+	// Over KCP-on-UDP a visor's writes keep "succeeding" even after the AR
+	// process is gone (e.g. a redeploy), so an inbound-silence deadline is
+	// the only reliable liveness signal. The AR echoes our 10s heartbeats,
+	// so a live AR resets this every interval; ~4 missed echoes trips it and
+	// drives a reconnect+re-register via serveSUDPHReconnect.
+	sudphARReadTimeout = 40 * time.Second
 )
 
 var (
@@ -914,6 +922,25 @@ func (c *httpClient) readSUDPHIntoChan(arConn net.Conn, out chan<- RemoteVisor) 
 
 	buf := make([]byte, 4096)
 	for {
+		select {
+		case <-c.closed:
+			return
+		default:
+		}
+
+		// Bound the read so a silently-dead AR connection (e.g. the AR
+		// process restarted/redeployed) is detected: KCP-on-UDP reads
+		// never EOF and our heartbeat writes keep "succeeding", so without
+		// this deadline the visor would block here forever, never
+		// reconnect, and leave a stale SUDPH entry in the AR. The AR
+		// echoes our heartbeats, so a live AR resets this every interval.
+		if err := arConn.SetReadDeadline(time.Now().Add(sudphARReadTimeout)); err != nil {
+			if !c.isClosed() {
+				c.log.Debugf("SUDPH set read deadline failed (will reconnect): %v", err)
+			}
+			return
+		}
+
 		n, err := arConn.Read(buf)
 		if err != nil {
 			if c.isClosed() {
@@ -922,6 +949,13 @@ func (c *httpClient) readSUDPHIntoChan(arConn net.Conn, out chan<- RemoteVisor) 
 				c.log.Debugf("SUDPH read error (will reconnect): %v", err)
 			}
 			return
+		}
+
+		// Echoed heartbeat from the AR: a liveness signal only (the
+		// successful read above already reset the deadline). Not a
+		// RemoteVisor payload, so skip before unmarshalling.
+		if string(buf[:n]) == UDPKeepHeartbeatMessage {
+			continue
 		}
 
 		c.log.Debugf("New SUDPH message: %v", string(buf[:n]))


### PR DESCRIPTION
## Symptom

After the address-resolver was redeployed, **27 visors' sudph became unreachable network-wide**: peers resolved each visor's *old* UDP port from the AR and every sudph dial timed out. The AR logged ~**300 `read/write on closed pipe`** across those 27 PKs as their dead connections churned, while the affected visors **never re-registered** their current port. (Diagnosed live against prod: Gamma resolves the AR UDP target and binds `58674`, re-registers every 90 s — yet the AR keeps serving her dead `39726`.)

## Root cause

The SUDPH↔AR connection has **no liveness detection**:
- `keepSudphHeartbeatLoop` returns only on a **Write error** — but over KCP-on-UDP a write to a dead AR **succeeds locally** (no peer to NAK), so it never returns.
- `readSUDPHIntoChan` had **no read deadline** (only a close-triggered one), so after the AR goes away it blocks on `Read` forever.

So neither per-connection loop ever returns → `serveSUDPHReconnect` never re-handshakes → the visor keeps firing heartbeats/re-registers into a dead KCP conv. The AR's entry (`entry_timeout ≈ 69 days`) then serves the stale address indefinitely. The 27 affected PKs were simply every visor connected at the moment of the AR restart.

## Fix — round-trip heartbeat

- **AR** (`address-resolver/api`): echo each received heartbeat back, giving the visor a periodic inbound liveness signal. Best-effort.
- **visor** (`addrresolver/client`): bound the SUDPH read loop with `sudphARReadTimeout` (40 s ≈ 4 heartbeats), reset on every inbound packet; skip the echoed heartbeat before unmarshalling. A dead AR stops echoing → the deadline trips → the conn closes → `serveSUDPHReconnect` re-handshakes and re-registers the **live** port.

**An AR restart now self-heals in ~40 s for every connected visor**, instead of staying broken until that visor happens to restart.

## Compatibility & deploy
- New AR ↔ old visor: harmless (old read loop logs an unmarshal error + continues).
- New visor ↔ old AR: relies on the AR's normal `RemoteVisor` notifications to reset the deadline; the **AR half deploys first** (service redeploy) before visors update, so the echo is live by then.
- AR half lands on the next AR redeploy; visor half ships in the next release.

## Verification
- `go build`/`vet`/`golangci-lint` clean on both packages; `go test ./pkg/transport/network/addrresolver/... ./pkg/address-resolver/api/...` green; full `skywire` + `address-resolver` binaries build.
- Live validation to follow on the AR host (Beta) post-redeploy: confirm the 27 stuck visors re-register and sudph dials to Gamma succeed.