### PR TITLE
feat(router): source-driven cascade route setup (RSN as dmsg signing oracle)

### DIFF
--- a/pkg/router/cascade_ack_registry.go
+++ b/pkg/router/cascade_ack_registry.go
@@ -1,0 +1,63 @@
+// Package router pkg/router/cascade_ack_registry.go
+//
+// ackRegistry is the shared correlation table that maps a cascade
+// sessionID to the goroutine waiting for that session's CascadeAck.
+//
+// It is shared between the CascadeHandler (which receives ACK packets off
+// the transport manager's single cascade-handler slot and dispatches them)
+// and any CascadeBuilder that injects cascades on the same visor. On the
+// SOURCE visor, the source-side CascadeBuilder sends reserve/install
+// cascades down the route's transports, but the ACKs come back on those
+// same transports and are delivered to the visor's one registered cascade
+// handler. Sharing this registry lets the handler hand those ACKs to the
+// waiting builder instead of needing a second handler slot.
+package router
+
+import (
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// ackRegistry correlates cascade sessionIDs to waiting receivers.
+type ackRegistry struct {
+	mu      sync.Mutex
+	pending map[uint64]chan routing.Packet
+}
+
+// newAckRegistry creates an empty registry.
+func newAckRegistry() *ackRegistry {
+	return &ackRegistry{pending: make(map[uint64]chan routing.Packet)}
+}
+
+// register installs a wait channel for sessionID, returning it. The caller
+// must eventually call unregister (directly or via a successful dispatch).
+func (r *ackRegistry) register(sessionID uint64) chan routing.Packet {
+	ch := make(chan routing.Packet, 1)
+	r.mu.Lock()
+	r.pending[sessionID] = ch
+	r.mu.Unlock()
+	return ch
+}
+
+// unregister removes any wait channel for sessionID.
+func (r *ackRegistry) unregister(sessionID uint64) {
+	r.mu.Lock()
+	delete(r.pending, sessionID)
+	r.mu.Unlock()
+}
+
+// dispatch hands the packet to the goroutine waiting on its sessionID, if
+// any, removing the registration. Returns true if a waiter was found.
+func (r *ackRegistry) dispatch(sessionID uint64, p routing.Packet) bool {
+	r.mu.Lock()
+	ch, ok := r.pending[sessionID]
+	if ok {
+		delete(r.pending, sessionID)
+	}
+	r.mu.Unlock()
+	if ok {
+		ch <- p
+	}
+	return ok
+}

--- a/pkg/router/cascade_builder.go
+++ b/pkg/router/cascade_builder.go
@@ -20,15 +20,25 @@ import (
 )
 
 // CascadeBuilder constructs and sends cascade messages.
+//
+// It serves two roles depending on how it is constructed:
+//
+//   - RSN-side (NewCascadeBuilder): holds the RSN's rsnPK/rsnSK and SIGNS
+//     each per-hop cascade layer. The RSN-side builder is a pure signing
+//     oracle — it builds bytes and never sends them itself.
+//   - Source-side (NewSourceCascadeBuilder): holds a zero rsnSK and never
+//     signs; it only INJECTS pre-signed cascade bytes (received from the
+//     RSN over RPC) into the source's own transports and collects ACKs.
 type CascadeBuilder struct {
 	log   *logging.Logger
 	rsnPK cipher.PubKey
 	rsnSK cipher.SecKey
 	tm    *transport.Manager
 
-	// For receiving ACKs (shared with the cascade handler).
-	pendingAcks   map[uint64]chan routing.Packet
-	pendingAcksMu sync.Mutex
+	// acks correlates sessionIDs to waiting senders. On the source visor
+	// it is shared with the CascadeHandler so ACKs arriving on the single
+	// registered cascade handler are delivered to this builder.
+	acks *ackRegistry
 
 	sessionCounter uint64
 	sessionMu      sync.Mutex
@@ -37,7 +47,7 @@ type CascadeBuilder struct {
 	installTimeout time.Duration
 }
 
-// NewCascadeBuilder creates a builder for the RSN.
+// NewCascadeBuilder creates a signing builder for the RSN.
 func NewCascadeBuilder(
 	log *logging.Logger,
 	rsnPK cipher.PubKey,
@@ -49,7 +59,31 @@ func NewCascadeBuilder(
 		rsnPK:          rsnPK,
 		rsnSK:          rsnSK,
 		tm:             tm,
-		pendingAcks:    make(map[uint64]chan routing.Packet),
+		acks:           newAckRegistry(),
+		reserveTimeout: 10 * time.Second,
+		installTimeout: 10 * time.Second,
+	}
+}
+
+// NewSourceCascadeBuilder creates a send-only builder for the SOURCE visor.
+//
+// It carries no RSN secret key (it never signs) and shares the ack registry
+// with the visor's CascadeHandler so that ACKs arriving on the visor's
+// single registered cascade handler are routed back to in-flight sends. The
+// source-side builder injects pre-signed cascade bytes — produced by the RSN
+// via the CascadeSign* RPCs — into the source's own transports.
+func NewSourceCascadeBuilder(
+	log *logging.Logger,
+	tm *transport.Manager,
+	acks *ackRegistry,
+) *CascadeBuilder {
+	if acks == nil {
+		acks = newAckRegistry()
+	}
+	return &CascadeBuilder{
+		log:            log,
+		tm:             tm,
+		acks:           acks,
 		reserveTimeout: 10 * time.Second,
 		installTimeout: 10 * time.Second,
 	}
@@ -191,15 +225,10 @@ func (cb *CascadeBuilder) SendCascade(ctx context.Context, firstHopTpID uuid.UUI
 	}
 
 	// Register for ACK.
-	waitCh := make(chan routing.Packet, 1)
-	cb.pendingAcksMu.Lock()
-	cb.pendingAcks[sessionID] = waitCh
-	cb.pendingAcksMu.Unlock()
+	waitCh := cb.acks.register(sessionID)
 
 	if err := tp.WriteRawPacket(pkt); err != nil {
-		cb.pendingAcksMu.Lock()
-		delete(cb.pendingAcks, sessionID)
-		cb.pendingAcksMu.Unlock()
+		cb.acks.unregister(sessionID)
 		return nil, fmt.Errorf("cascade: write to first hop: %w", err)
 	}
 
@@ -207,14 +236,10 @@ func (cb *CascadeBuilder) SendCascade(ctx context.Context, firstHopTpID uuid.UUI
 	case ackPkt := <-waitCh:
 		return routing.UnmarshalCascadeAck(ackPkt.Payload())
 	case <-ctx.Done():
-		cb.pendingAcksMu.Lock()
-		delete(cb.pendingAcks, sessionID)
-		cb.pendingAcksMu.Unlock()
+		cb.acks.unregister(sessionID)
 		return nil, ctx.Err()
 	case <-time.After(timeout):
-		cb.pendingAcksMu.Lock()
-		delete(cb.pendingAcks, sessionID)
-		cb.pendingAcksMu.Unlock()
+		cb.acks.unregister(sessionID)
 		return nil, fmt.Errorf("cascade: ACK timeout (session %d)", sessionID)
 	}
 }
@@ -229,15 +254,12 @@ func (cb *CascadeBuilder) HandleAck(p routing.Packet, _ *transport.ManagedTransp
 	if err != nil {
 		return
 	}
+	cb.acks.dispatch(ack.SessionID, p)
+}
 
-	cb.pendingAcksMu.Lock()
-	waitCh, ok := cb.pendingAcks[ack.SessionID]
-	if ok {
-		delete(cb.pendingAcks, ack.SessionID)
-	}
-	cb.pendingAcksMu.Unlock()
-
-	if ok {
-		waitCh <- p
-	}
+// AckRegistry returns the builder's ack registry so a CascadeHandler on the
+// same visor can share it (the source visor has one registered cascade
+// handler that must deliver ACKs to this builder's in-flight sends).
+func (cb *CascadeBuilder) AckRegistry() *ackRegistry {
+	return cb.acks
 }

--- a/pkg/router/cascade_handler.go
+++ b/pkg/router/cascade_handler.go
@@ -7,7 +7,6 @@ package router
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,9 +25,10 @@ type CascadeHandler struct {
 	rt          routing.Table // for ReserveKeys and SaveRule
 	tm          *transport.Manager
 
-	// pendingAcks tracks in-flight relay operations awaiting ACK from next hop.
-	pendingAcks   map[uint64]chan routing.Packet
-	pendingAcksMu sync.Mutex
+	// acks tracks in-flight relay operations (and, on the source visor,
+	// source-driven sends) awaiting an ACK. Shared with the source-side
+	// CascadeBuilder so its injected cascades' ACKs are delivered here.
+	acks *ackRegistry
 
 	// defaultTimeout is the per-hop timeout for waiting for a cascade ACK.
 	defaultTimeout time.Duration
@@ -52,9 +52,16 @@ func NewCascadeHandler(
 		trustedRSNs:    trusted,
 		rt:             rt,
 		tm:             tm,
-		pendingAcks:    make(map[uint64]chan routing.Packet),
+		acks:           newAckRegistry(),
 		defaultTimeout: 10 * time.Second,
 	}
+}
+
+// AckRegistry returns the handler's shared ack registry. The source-side
+// CascadeBuilder is constructed against this registry so ACKs arriving on
+// the visor's single registered cascade handler reach the builder's sends.
+func (ch *CascadeHandler) AckRegistry() *ackRegistry {
+	return ch.acks
 }
 
 // HandlePacket is the callback registered with the transport manager.
@@ -176,16 +183,7 @@ func (ch *CascadeHandler) handleAck(p routing.Packet) {
 		return
 	}
 
-	ch.pendingAcksMu.Lock()
-	waitCh, ok := ch.pendingAcks[ack.SessionID]
-	if ok {
-		delete(ch.pendingAcks, ack.SessionID)
-	}
-	ch.pendingAcksMu.Unlock()
-
-	if ok {
-		waitCh <- p
-	}
+	ch.acks.dispatch(ack.SessionID, p)
 }
 
 // relayAndWait sends the cascade payload to the next hop transport and waits for an ACK.
@@ -203,16 +201,11 @@ func (ch *CascadeHandler) relayAndWait(relayTpID uuid.UUID, sessionID uint64, pa
 	}
 
 	// Register for ACK.
-	waitCh := make(chan routing.Packet, 1)
-	ch.pendingAcksMu.Lock()
-	ch.pendingAcks[sessionID] = waitCh
-	ch.pendingAcksMu.Unlock()
+	waitCh := ch.acks.register(sessionID)
 
 	// Send the relay.
 	if err := tp.WriteRawPacket(pkt); err != nil {
-		ch.pendingAcksMu.Lock()
-		delete(ch.pendingAcks, sessionID)
-		ch.pendingAcksMu.Unlock()
+		ch.acks.unregister(sessionID)
 		return nil, fmt.Errorf("write relay packet: %w", err)
 	}
 
@@ -221,9 +214,7 @@ func (ch *CascadeHandler) relayAndWait(relayTpID uuid.UUID, sessionID uint64, pa
 	case ackPkt := <-waitCh:
 		return routing.UnmarshalCascadeAck(ackPkt.Payload())
 	case <-time.After(ch.defaultTimeout):
-		ch.pendingAcksMu.Lock()
-		delete(ch.pendingAcks, sessionID)
-		ch.pendingAcksMu.Unlock()
+		ch.acks.unregister(sessionID)
 		return nil, fmt.Errorf("cascade ACK timeout (session %d)", sessionID)
 	}
 }

--- a/pkg/router/cascade_route.go
+++ b/pkg/router/cascade_route.go
@@ -136,6 +136,98 @@ func createRouteGroupCascade(
 	return initEdge, nil
 }
 
+// signReserveCascades builds and signs the forward and reverse reserve
+// cascades for a bidirectional route WITHOUT sending them. This is the
+// RSN-side half of phase 1: the RSN is a pure signing oracle and never
+// dials hops. The returned bytes are injected by the SOURCE over its own
+// transports.
+//
+// cb must be an RSN-side CascadeBuilder (constructed with the RSN's
+// rsnPK/rsnSK) so each per-hop layer is signed with the RSN's key.
+func signReserveCascades(cb *CascadeBuilder, biRt routing.BidirectionalRoute) (
+	fwdSessionID uint64, fwdReserveBytes []byte,
+	revSessionID uint64, revReserveBytes []byte,
+	err error,
+) {
+	if len(biRt.Forward) == 0 {
+		return 0, nil, 0, nil, fmt.Errorf("cascade: no forward hops")
+	}
+	if len(biRt.Reverse) == 0 {
+		return 0, nil, 0, nil, fmt.Errorf("cascade: no reverse hops")
+	}
+
+	reserveCount := computeReserveCount(biRt.Forward, biRt.Reverse)
+
+	fwdSessionID, fwdReserveBytes, err = buildReserveWithCounts(cb, biRt.Forward, reserveCount)
+	if err != nil {
+		return 0, nil, 0, nil, fmt.Errorf("cascade: build fwd reserve: %w", err)
+	}
+
+	revSessionID, revReserveBytes, err = buildReserveWithCounts(cb, biRt.Reverse, reserveCount)
+	if err != nil {
+		return 0, nil, 0, nil, fmt.Errorf("cascade: build rev reserve: %w", err)
+	}
+
+	return fwdSessionID, fwdReserveBytes, revSessionID, revReserveBytes, nil
+}
+
+// signInstallCascades reconstructs the IDReserver from the route-IDs that
+// the SOURCE collected during the reserve phase, recomputes the routing
+// rules DETERMINISTICALLY from the route (rules are never trusted from the
+// source), then builds and signs the forward and reverse install cascades
+// WITHOUT sending them. This is the RSN-side half of phase 2.
+//
+// It returns the install bytes (for the source to inject over its own
+// transports) plus the initiating-edge EdgeRules that the source installs
+// locally and returns to the dialer.
+func signInstallCascades(
+	cb *CascadeBuilder,
+	biRt routing.BidirectionalRoute,
+	fwdSessionID, revSessionID uint64,
+	fwdRouteIDs, revRouteIDs []routing.RouteID,
+) (fwdInstallBytes, revInstallBytes []byte, initEdge routing.EdgeRules, err error) {
+	fwdRt, revRt := biRt.ForwardAndReverse()
+
+	// Reconstruct the IDReserver from the cascade ACK route IDs. The rules
+	// are recomputed below from this deterministic reserver — we do NOT
+	// trust source-supplied rules.
+	idR, err := newCascadeIDReserver(biRt.Forward, biRt.Reverse, fwdRouteIDs, revRouteIDs)
+	if err != nil {
+		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: reconstruct IDs: %w", err)
+	}
+
+	fwdRules, revRules, interRules, err := GenerateRules(idR, []routing.Route{fwdRt, revRt})
+	if err != nil {
+		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: generate rules: %w", err)
+	}
+
+	srcPK := biRt.Desc.Src()
+	dstPK := biRt.Desc.Dst()
+	initEdge = routing.EdgeRules{
+		Desc:    revRt.Desc,
+		Forward: fwdRules[srcPK.String()][0],
+		Reverse: revRules[srcPK.String()][0],
+	}
+	respEdge := routing.EdgeRules{
+		Desc:    fwdRt.Desc,
+		Forward: fwdRules[dstPK.String()][0],
+		Reverse: revRules[dstPK.String()][0],
+	}
+
+	rulesPerPK := collectRulesPerPK(fwdRules, revRules, interRules, initEdge, respEdge)
+
+	fwdInstallBytes, err = cb.BuildInstallMessage(biRt.Forward, fwdSessionID, rulesPerPK)
+	if err != nil {
+		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: build fwd install: %w", err)
+	}
+	revInstallBytes, err = cb.BuildInstallMessage(biRt.Reverse, revSessionID, rulesPerPK)
+	if err != nil {
+		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: build rev install: %w", err)
+	}
+
+	return fwdInstallBytes, revInstallBytes, initEdge, nil
+}
+
 // computeReserveCount determines how many route IDs each PK needs across both paths.
 func computeReserveCount(forward, reverse []routing.Hop) map[cipher.PubKey]uint8 {
 	counts := make(map[cipher.PubKey]uint8)

--- a/pkg/router/cascade_source.go
+++ b/pkg/router/cascade_source.go
@@ -1,0 +1,156 @@
+// Package router pkg/router/cascade_source.go
+//
+// Source-driven cascade orchestration.
+//
+// In the source-driven design the RSN is a pure dmsg-reachable SIGNING
+// ORACLE: it signs the per-hop reserve/install cascades but never dials hops
+// and is never on the data path. The SOURCE (the requesting visor) drives
+// the cascade down its OWN transports:
+//
+//  1. Source -> RSN (RPC): CascadeSignReserve -> signed reserve cascade bytes
+//     + session IDs for forward and reverse.
+//  2. Source injects the reserve cascades into Forward[0].TpID / Reverse[0].TpID
+//     via its own CascadeBuilder.SendCascade and collects the reserved
+//     route-ID ACKs.
+//  3. Source -> RSN (RPC): CascadeSignInstall (route + session IDs + collected
+//     route IDs) -> signed install cascade bytes + the initiating EdgeRules.
+//     The RSN recomputes the rules deterministically; it does not trust
+//     source-supplied rules.
+//  4. Source injects the install cascades via SendCascade. Done.
+package router
+
+import (
+	"context"
+	"fmt"
+	"net/rpc"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// cascadeSourceProvider is implemented by route-group dialers that own a
+// source-side CascadeBuilder. The router uses it at Serve time to share the
+// builder's ack registry with the visor's single CascadeHandler.
+type cascadeSourceProvider interface {
+	CascadeAckRegistry() *ackRegistry
+}
+
+// errCascadeSignUnimplemented signals that the RSN does not implement the
+// CascadeSign* RPCs (an un-upgraded setup node). Callers fall back to the
+// legacy DMSG @136 path.
+var errCascadeSignUnimplemented = fmt.Errorf("cascade: RSN does not implement source-driven cascade")
+
+// isUnimplementedRPC reports whether err is net/rpc's "can't find method"
+// server error, i.e. the RSN is an older build without the CascadeSign* RPCs.
+func isUnimplementedRPC(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "can't find method") ||
+		strings.Contains(err.Error(), "can't find service")
+}
+
+// runSourceCascade performs the full source-driven cascade against the RSN
+// reachable via rpcC, using srcCB (the source's send-only CascadeBuilder) to
+// inject the signed cascades down this visor's own transports.
+//
+// On success it returns the initiating EdgeRules. If the RSN does not
+// implement the CascadeSign* RPCs it returns errCascadeSignUnimplemented so
+// the caller can fall back to the legacy DMSG path.
+func runSourceCascade(
+	ctx context.Context,
+	log logrus.FieldLogger,
+	rpcC *rpc.Client,
+	srcCB *CascadeBuilder,
+	biRt routing.BidirectionalRoute,
+) (routing.EdgeRules, error) {
+	if srcCB == nil {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: no source-side builder")
+	}
+	if len(biRt.Forward) == 0 || len(biRt.Reverse) == 0 {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: route has no hops")
+	}
+
+	log.Debug("Source-driven cascade: requesting RSN reserve signatures")
+
+	// --- Phase 1: ask RSN to sign reserve cascades ---
+	var reserveReply CascadeSignReserveReply
+	if err := rpcCall(ctx, rpcC, rpcName+".CascadeSignReserve",
+		&CascadeSignReserveArgs{Route: biRt}, &reserveReply); err != nil {
+		if isUnimplementedRPC(err) {
+			return routing.EdgeRules{}, errCascadeSignUnimplemented
+		}
+		return routing.EdgeRules{}, fmt.Errorf("cascade: sign reserve RPC: %w", err)
+	}
+
+	// --- Phase 1 (cont): inject reserve cascades over our own transports ---
+	firstFwdTpID := biRt.Forward[0].TpID
+	fwdAck, err := srcCB.SendCascade(ctx, firstFwdTpID, reserveReply.FwdSessionID, reserveReply.FwdReserveBytes, srcCB.reserveTimeout)
+	if err != nil {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd reserve send: %w", err)
+	}
+	if fwdAck.Error != "" {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd reserve rejected: %s", fwdAck.Error)
+	}
+
+	firstRevTpID := biRt.Reverse[0].TpID
+	revAck, err := srcCB.SendCascade(ctx, firstRevTpID, reserveReply.RevSessionID, reserveReply.RevReserveBytes, srcCB.reserveTimeout)
+	if err != nil {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve send: %w", err)
+	}
+	if revAck.Error != "" {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve rejected: %s", revAck.Error)
+	}
+
+	log.WithField("fwd_ids", len(fwdAck.RouteIDs)).
+		WithField("rev_ids", len(revAck.RouteIDs)).
+		Debug("Source-driven cascade: reserved route IDs, requesting install signatures")
+
+	// --- Phase 2: ask RSN to sign install cascades (recomputes rules) ---
+	var installReply CascadeSignInstallReply
+	if err := rpcCall(ctx, rpcC, rpcName+".CascadeSignInstall", &CascadeSignInstallArgs{
+		Route:        biRt,
+		FwdSessionID: reserveReply.FwdSessionID,
+		RevSessionID: reserveReply.RevSessionID,
+		FwdRouteIDs:  fwdAck.RouteIDs,
+		RevRouteIDs:  revAck.RouteIDs,
+	}, &installReply); err != nil {
+		if isUnimplementedRPC(err) {
+			return routing.EdgeRules{}, errCascadeSignUnimplemented
+		}
+		return routing.EdgeRules{}, fmt.Errorf("cascade: sign install RPC: %w", err)
+	}
+
+	// --- Phase 2 (cont): inject install cascades over our own transports ---
+	fwdInstAck, err := srcCB.SendCascade(ctx, firstFwdTpID, reserveReply.FwdSessionID, installReply.FwdInstallBytes, srcCB.installTimeout)
+	if err != nil {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install send: %w", err)
+	}
+	if fwdInstAck.Error != "" {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install rejected: %s", fwdInstAck.Error)
+	}
+
+	revInstAck, err := srcCB.SendCascade(ctx, firstRevTpID, reserveReply.RevSessionID, installReply.RevInstallBytes, srcCB.installTimeout)
+	if err != nil {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: rev install send: %w", err)
+	}
+	if revInstAck.Error != "" {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: rev install rejected: %s", revInstAck.Error)
+	}
+
+	log.Info("Source-driven cascade route setup succeeded")
+	return installReply.InitEdge, nil
+}
+
+// rpcCall performs a context-aware net/rpc call.
+func rpcCall(ctx context.Context, rpcC *rpc.Client, serviceMethod string, args, reply interface{}) error {
+	call := rpcC.Go(serviceMethod, args, reply, nil)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-call.Done:
+		return call.Error
+	}
+}

--- a/pkg/router/cascade_source_test.go
+++ b/pkg/router/cascade_source_test.go
@@ -1,0 +1,207 @@
+// Package router pkg/router/cascade_source_test.go
+package router
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// buildTestBiRoute builds a 2-hop bidirectional route A -> B -> C (forward)
+// and C -> B -> A (reverse), returning the route plus the per-hop PKs.
+func buildTestBiRoute(t *testing.T) (routing.BidirectionalRoute, cipher.PubKey, cipher.PubKey, cipher.PubKey) {
+	t.Helper()
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	pkC, _ := cipher.GenerateKeyPair()
+
+	desc := routing.NewRouteDescriptor(pkA, pkC, 100, 200)
+	fwd := makeHops(pkA, pkB, pkC)
+	rev := makeHops(pkC, pkB, pkA)
+
+	biRt := routing.BidirectionalRoute{
+		Desc:    desc,
+		Forward: fwd,
+		Reverse: rev,
+	}
+	require.NoError(t, biRt.Check())
+	return biRt, pkA, pkB, pkC
+}
+
+func rsnBuilder(t *testing.T) (*CascadeBuilder, cipher.PubKey) {
+	t.Helper()
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	cb := NewCascadeBuilder(logging.MustGetLogger("test_rsn"), rsnPK, rsnSK, nil)
+	return cb, rsnPK
+}
+
+// verifyReserveChain walks a nested reserve cascade and asserts each layer is
+// signed by the RSN for its target visor PK. targets is the ordered list of
+// visor PKs the cascade addresses: [hops[0].From, hops[0].To, hops[1].To, ...].
+func verifyReserveChain(t *testing.T, payload []byte, rsnPK cipher.PubKey, targets []cipher.PubKey) {
+	t.Helper()
+	for i, target := range targets {
+		cs, err := routing.UnmarshalCascadeSetup(payload)
+		require.NoErrorf(t, err, "unmarshal layer %d", i)
+		assert.Equalf(t, routing.CascadePhaseReserve, cs.Phase, "layer %d phase", i)
+		assert.Equalf(t, rsnPK, cs.RSNPK, "layer %d RSNPK", i)
+		require.NoErrorf(t, cs.Verify(target), "layer %d signature for target %s", i, target)
+		// terminal layer carries no further payload
+		if i == len(targets)-1 {
+			assert.True(t, cs.IsTerminal(), "last layer must be terminal")
+		} else {
+			require.NotEmptyf(t, cs.Payload, "layer %d must wrap an inner payload", i)
+		}
+		payload = cs.Payload
+	}
+}
+
+func TestSignReserveCascades_SignedBytes(t *testing.T) {
+	cb, rsnPK := rsnBuilder(t)
+	biRt, pkA, pkB, pkC := buildTestBiRoute(t)
+
+	fwdSession, fwdBytes, revSession, revBytes, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+	require.NotZero(t, fwdSession)
+	require.NotZero(t, revSession)
+	require.NotEqual(t, fwdSession, revSession, "forward and reverse must use distinct sessions")
+	require.NotEmpty(t, fwdBytes)
+	require.NotEmpty(t, revBytes)
+
+	// Forward targets: A (source) -> B -> C
+	verifyReserveChain(t, fwdBytes, rsnPK, []cipher.PubKey{pkA, pkB, pkC})
+	// Reverse targets: C (source of reverse) -> B -> A
+	verifyReserveChain(t, revBytes, rsnPK, []cipher.PubKey{pkC, pkB, pkA})
+}
+
+func TestSignReserveCascades_WrongTargetFailsVerify(t *testing.T) {
+	cb, _ := rsnBuilder(t)
+	biRt, _, _, _ := buildTestBiRoute(t)
+
+	_, fwdBytes, _, _, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+
+	cs, err := routing.UnmarshalCascadeSetup(fwdBytes)
+	require.NoError(t, err)
+
+	// A different visor PK must not validate the first layer's signature.
+	otherPK, _ := cipher.GenerateKeyPair()
+	assert.Error(t, cs.Verify(otherPK))
+}
+
+func TestSignInstallCascades_RulesAndEdge(t *testing.T) {
+	cb, _ := rsnBuilder(t)
+	biRt, pkA, pkB, pkC := buildTestBiRoute(t)
+
+	fwdSession, _, revSession, _, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+
+	// Simulate route IDs collected from each hop. computeReserveCount gives
+	// each of A, B, C two IDs across both paths; provide enough per path.
+	// Forward path PKs in order: A, B, C ; reverse path PKs: C, B, A.
+	fwdIDs := []routing.RouteID{10, 11, 12}
+	revIDs := []routing.RouteID{20, 21, 22}
+
+	fwdBytes, revBytes, initEdge, err := signInstallCascades(cb, biRt, fwdSession, revSession, fwdIDs, revIDs)
+	require.NoError(t, err)
+	require.NotEmpty(t, fwdBytes)
+	require.NotEmpty(t, revBytes)
+
+	// InitEdge must be populated with non-empty forward/reverse rules.
+	require.NotEmpty(t, initEdge.Forward)
+	require.NotEmpty(t, initEdge.Reverse)
+
+	// Each install layer must be install-phase, RSN-signed for its target,
+	// and (except the terminal) carry rule data + an inner payload.
+	fwdTargets := []cipher.PubKey{pkA, pkB, pkC}
+	payload := fwdBytes
+	for i, target := range fwdTargets {
+		cs, err := routing.UnmarshalCascadeSetup(payload)
+		require.NoErrorf(t, err, "install layer %d", i)
+		assert.Equal(t, routing.CascadePhaseInstall, cs.Phase)
+		require.NoError(t, cs.Verify(target))
+		payload = cs.Payload
+	}
+}
+
+func TestSignInstallCascades_NotEnoughIDs(t *testing.T) {
+	cb, _ := rsnBuilder(t)
+	biRt, _, _, _ := buildTestBiRoute(t)
+	fwdSession, _, revSession, _, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+
+	// Too few IDs -> reconstruct must fail.
+	_, _, _, err = signInstallCascades(cb, biRt, fwdSession, revSession,
+		[]routing.RouteID{1}, []routing.RouteID{2})
+	require.Error(t, err)
+}
+
+func TestIsUnimplementedRPC(t *testing.T) {
+	assert.False(t, isUnimplementedRPC(nil))
+	assert.False(t, isUnimplementedRPC(errors.New("some other error")))
+	assert.True(t, isUnimplementedRPC(errors.New("rpc: can't find method SetupRPCGateway.CascadeSignReserve")))
+	assert.True(t, isUnimplementedRPC(errors.New("rpc: can't find service SetupRPCGateway")))
+}
+
+func TestRunSourceCascade_NilBuilder(t *testing.T) {
+	biRt, _, _, _ := buildTestBiRoute(t)
+	_, err := runSourceCascade(t.Context(), logging.MustGetLogger("test"), nil, nil, biRt)
+	require.Error(t, err)
+}
+
+// TestAckRegistry_Dispatch verifies the shared ack registry correlates a
+// dispatched ACK packet back to a registered waiter and drops unknown ones.
+func TestAckRegistry_Dispatch(t *testing.T) {
+	reg := newAckRegistry()
+	ch := reg.register(7)
+
+	ack := &routing.CascadeAck{SessionID: 7, RouteIDs: []routing.RouteID{42}}
+	data, err := ack.Marshal()
+	require.NoError(t, err)
+	pkt, err := routing.MakeCascadeAckPacket(data)
+	require.NoError(t, err)
+
+	assert.True(t, reg.dispatch(7, pkt), "known session should dispatch")
+	select {
+	case got := <-ch:
+		decoded, err := routing.UnmarshalCascadeAck(got.Payload())
+		require.NoError(t, err)
+		assert.Equal(t, []routing.RouteID{42}, decoded.RouteIDs)
+	default:
+		t.Fatal("expected ACK on wait channel")
+	}
+
+	assert.False(t, reg.dispatch(999, pkt), "unknown session should not dispatch")
+}
+
+// TestSourceBuilderSharesHandlerRegistry verifies a source-side builder and a
+// cascade handler can share one ack registry (the source visor has a single
+// registered handler that must deliver ACKs to the builder's sends).
+func TestSourceBuilderSharesHandlerRegistry(t *testing.T) {
+	localPK, _ := cipher.GenerateKeyPair()
+	ch := NewCascadeHandler(logging.MustGetLogger("test_handler"), localPK, nil, nil, nil)
+	srcCB := NewSourceCascadeBuilder(logging.MustGetLogger("test_src"), nil, ch.AckRegistry())
+
+	// Builder and handler must observe the same registry instance.
+	assert.Same(t, ch.AckRegistry(), srcCB.AckRegistry())
+
+	// A send-side registration must be visible to a handler-side dispatch.
+	waitCh := srcCB.acks.register(5)
+	ack := &routing.CascadeAck{SessionID: 5}
+	data, err := ack.Marshal()
+	require.NoError(t, err)
+	pkt, err := routing.MakeCascadeAckPacket(data)
+	require.NoError(t, err)
+	assert.True(t, ch.acks.dispatch(5, pkt))
+	select {
+	case <-waitCh:
+	default:
+		t.Fatal("handler dispatch did not reach builder's waiter")
+	}
+}

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -80,6 +80,21 @@ func (r *router) Serve(ctx context.Context) error {
 		trustedPKs = append(trustedPKs, pk)
 	}
 	ch := NewCascadeHandler(r.logger, r.conf.PubKey, trustedPKs, r.rt, r.tm)
+
+	// Source-driven cascade: the visor's route-group dialer owns a send-only
+	// CascadeBuilder that injects RSN-signed cascades down this visor's own
+	// transports. ACKs for those sends arrive on this single registered
+	// cascade handler, so share the dialer's ack registry into it and into
+	// the builder so the handler can deliver ACKs to in-flight sends.
+	if r.conf != nil {
+		if sp, ok := r.conf.RouteGroupDialer.(cascadeSourceProvider); ok {
+			if reg := sp.CascadeAckRegistry(); reg != nil {
+				ch.acks = reg
+				r.logger.Debug("Cascade handler sharing source-driven ack registry")
+			}
+		}
+	}
+
 	r.tm.SetCascadeHandler(ch.HandlePacket)
 	r.logger.WithField("trusted_rsns", len(trustedPKs)).Debug("Cascade handler registered")
 

--- a/pkg/router/setup_rpc_gateway.go
+++ b/pkg/router/setup_rpc_gateway.go
@@ -3,6 +3,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"net"
 	"time"
 
@@ -14,6 +15,10 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
+
+// errCascadeUnavailable is returned by the cascade-sign RPCs when the RSN
+// has no CascadeBuilder configured (cascade disabled / DMSG-only mode).
+var errCascadeUnavailable = errors.New("cascade signing unavailable on this setup node")
 
 // SetupRPCGateway is a RPC interface for setup node.
 type SetupRPCGateway struct {
@@ -49,6 +54,100 @@ func (g *SetupRPCGateway) DialRouteGroup(route routing.BidirectionalRoute, rules
 
 	// Confirm routes with initiating visor.
 	*rules = initRules
+	return nil
+}
+
+// CascadeSignReserveArgs is the request for CascadeSignReserve.
+type CascadeSignReserveArgs struct {
+	Route routing.BidirectionalRoute
+}
+
+// CascadeSignReserveReply carries the RSN-signed reserve cascades. The RSN
+// signs but does NOT send — the SOURCE injects these bytes into its own
+// transports (Forward[0].TpID / Reverse[0].TpID) and collects the reserved
+// route-ID ACKs.
+type CascadeSignReserveReply struct {
+	FwdSessionID    uint64
+	FwdReserveBytes []byte
+	RevSessionID    uint64
+	RevReserveBytes []byte
+}
+
+// CascadeSignReserve is the RSN-side half of the cascade reserve phase. The
+// RSN is a pure signing oracle: it builds and signs the nested per-hop
+// reserve cascades for the bidirectional route and returns the bytes plus
+// the session IDs. It never dials hops or sends anything itself.
+func (g *SetupRPCGateway) CascadeSignReserve(args *CascadeSignReserveArgs, reply *CascadeSignReserveReply) error {
+	log := logging.MustGetLogger("cascade-sign-reserve:" + g.ReqPK.String())
+	if g.Cascade == nil {
+		return errCascadeUnavailable
+	}
+	if err := args.Route.Check(); err != nil {
+		log.WithError(err).Warn("CascadeSignReserve: invalid route")
+		return err
+	}
+
+	fwdSessionID, fwdBytes, revSessionID, revBytes, err := signReserveCascades(g.Cascade, args.Route)
+	if err != nil {
+		log.WithError(err).Warn("CascadeSignReserve failed")
+		return err
+	}
+
+	reply.FwdSessionID = fwdSessionID
+	reply.FwdReserveBytes = fwdBytes
+	reply.RevSessionID = revSessionID
+	reply.RevReserveBytes = revBytes
+	return nil
+}
+
+// CascadeSignInstallArgs is the request for CascadeSignInstall. The source
+// supplies the route, the session IDs from the reserve phase, and the route
+// IDs it collected per hop. The RSN recomputes rules deterministically from
+// the route + IDs; it does NOT trust source-supplied rules.
+type CascadeSignInstallArgs struct {
+	Route        routing.BidirectionalRoute
+	FwdSessionID uint64
+	RevSessionID uint64
+	FwdRouteIDs  []routing.RouteID
+	RevRouteIDs  []routing.RouteID
+}
+
+// CascadeSignInstallReply carries the RSN-signed install cascades plus the
+// initiating-edge rules the source installs locally and returns to the dialer.
+type CascadeSignInstallReply struct {
+	FwdInstallBytes []byte
+	RevInstallBytes []byte
+	InitEdge        routing.EdgeRules
+}
+
+// CascadeSignInstall is the RSN-side half of the cascade install phase. It
+// reconstructs the IDReserver from the source-collected route IDs, recomputes
+// the routing rules deterministically (GenerateRules), and builds+signs the
+// nested per-hop install cascades. It returns the install bytes for the
+// source to inject, plus the initiating EdgeRules.
+func (g *SetupRPCGateway) CascadeSignInstall(args *CascadeSignInstallArgs, reply *CascadeSignInstallReply) error {
+	log := logging.MustGetLogger("cascade-sign-install:" + g.ReqPK.String())
+	if g.Cascade == nil {
+		return errCascadeUnavailable
+	}
+	if err := args.Route.Check(); err != nil {
+		log.WithError(err).Warn("CascadeSignInstall: invalid route")
+		return err
+	}
+
+	fwdBytes, revBytes, initEdge, err := signInstallCascades(
+		g.Cascade, args.Route,
+		args.FwdSessionID, args.RevSessionID,
+		args.FwdRouteIDs, args.RevRouteIDs,
+	)
+	if err != nil {
+		log.WithError(err).Warn("CascadeSignInstall failed")
+		return err
+	}
+
+	reply.FwdInstallBytes = fwdBytes
+	reply.RevInstallBytes = revBytes
+	reply.InitEdge = initEdge
 	return nil
 }
 

--- a/pkg/router/setupclient.go
+++ b/pkg/router/setupclient.go
@@ -54,6 +54,13 @@ func (c *SetupClient) ConnectedNode() cipher.PubKey {
 	return c.connectedNode
 }
 
+// RPCClient returns the underlying net/rpc client so the source-driven
+// cascade orchestrator can issue the CascadeSign* RPCs over the same DMSG
+// connection used for the legacy DialRouteGroup path.
+func (c *SetupClient) RPCClient() *rpc.Client {
+	return c.rpc
+}
+
 // perNodeDialTimeout is the maximum time to wait for each individual setup node
 const perNodeDialTimeout = 10 * time.Second
 

--- a/pkg/router/wrappers.go
+++ b/pkg/router/wrappers.go
@@ -44,6 +44,25 @@ type setupNodeDialer struct {
 	relayCache    *RSNRelayCache        // cached RSN relay peers (may be nil)
 	tm            *transport.Manager    // for finding relay transports (may be nil)
 	setupRPCMux   *transport.VStreamMux // virtual stream mux for RSN RPC (may be nil)
+
+	// srcCascade is the SOURCE-side cascade builder used to inject RSN-signed
+	// reserve/install cascades down this visor's own transports. nil when no
+	// transport manager is available (e.g. NewSetupNodeDialer).
+	srcCascade *CascadeBuilder
+}
+
+// CascadeAckRegistry exposes the source-side cascade builder's ack registry
+// so the router's CascadeHandler can share it. ACKs for source-driven
+// cascades arrive on the visor's single registered cascade handler and must
+// be delivered to the source builder's in-flight sends. Returns nil when no
+// source-side builder is configured.
+//
+// This is consumed by the router via the cascadeSourceProvider interface.
+func (d *setupNodeDialer) CascadeAckRegistry() *ackRegistry {
+	if d.srcCascade == nil {
+		return nil
+	}
+	return d.srcCascade.AckRegistry()
 }
 
 // NewSetupNodeDialer returns a wrapper for (*Client).DialRouteGroup.
@@ -58,19 +77,24 @@ func NewSetupNodeDialerWithEmbedded(embedded EmbeddedSetupNode) RouteGroupDialer
 }
 
 // NewSetupNodeDialerFull returns a dialer with all capabilities:
-// embedded RSN, transport relay, and DMSG fallback.
+// embedded RSN, transport relay, DMSG fallback, and source-driven cascade.
 func NewSetupNodeDialerFull(embedded EmbeddedSetupNode, relayCache *RSNRelayCache, tm *transport.Manager) RouteGroupDialer {
 	var mux *transport.VStreamMux
+	var srcCascade *CascadeBuilder
 	if tm != nil {
 		log := logging.MustGetLogger("setup_rpc_mux")
 		mux = transport.NewVStreamMux(tm, routing.SetupRPCPacket, log)
 		tm.SetSetupRPCHandler(mux.HandlePacket)
+		// Source-side cascade builder: send-only (zero rsnSK). Its ack
+		// registry is shared into the router's CascadeHandler at Serve time.
+		srcCascade = NewSourceCascadeBuilder(logging.MustGetLogger("cascade_source"), tm, nil)
 	}
 	return &setupNodeDialer{
 		embeddedSetup: embedded,
 		relayCache:    relayCache,
 		tm:            tm,
 		setupRPCMux:   mux,
+		srcCascade:    srcCascade,
 	}
 }
 
@@ -149,6 +173,23 @@ func (d *setupNodeDialer) Dial(
 		}
 	}
 
+	// Prefer the source-driven cascade over the DMSG connection: the RSN
+	// signs over DMSG, but the reserve/install cascades flow down OUR
+	// transports (not the RSN's). This avoids the RSN having to dial each
+	// hop over dmsg (the dmsg-202 failure mode for zombie sessions). Fall
+	// back to the legacy DMSG DialRouteGroup if the RSN is un-upgraded.
+	if d.srcCascade != nil {
+		rules, cascErr := runSourceCascade(ctx, log, client.RPCClient(), d.srcCascade, req)
+		if cascErr == nil {
+			return rules, connectedNode, nil
+		}
+		if !errors.Is(cascErr, errCascadeSignUnimplemented) {
+			log.WithError(cascErr).Warn("Source-driven cascade failed, falling back to DMSG DialRouteGroup")
+		} else {
+			log.Debug("RSN lacks source-driven cascade RPCs (dmsg), falling back to DialRouteGroup")
+		}
+	}
+
 	resp, err := client.DialRouteGroup(ctx, req)
 	if err != nil {
 		return routing.EdgeRules{}, cipher.PubKey{}, fmt.Errorf("route setup: %w", err)
@@ -179,6 +220,20 @@ func (d *setupNodeDialer) dialViaTransport(
 
 	rpcC := rpc.NewClient(stream)
 	defer rpcC.Close() //nolint:errcheck
+
+	// Prefer the source-driven cascade: the RSN only signs, and we inject the
+	// cascades down our own transports. Fall back to the legacy DialRouteGroup
+	// RPC if the RSN doesn't implement the CascadeSign* methods.
+	if d.srcCascade != nil {
+		rules, cascErr := runSourceCascade(ctx, log, rpcC, d.srcCascade, req)
+		if cascErr == nil {
+			return rules, nil
+		}
+		if !errors.Is(cascErr, errCascadeSignUnimplemented) {
+			return routing.EdgeRules{}, cascErr
+		}
+		log.Debug("RSN lacks source-driven cascade RPCs (vstream), falling back to DialRouteGroup")
+	}
 
 	var rules routing.EdgeRules
 	call := rpcC.Go("SetupRPCGateway.DialRouteGroup", req, &rules, nil)


### PR DESCRIPTION
## Problem

Route setup installs rules on each hop by having the route-setup-node (RSN) dial it over dmsg `@136`. That fails for intermediates that are reachable over their **transport** but dead over **dmsg** (e.g. older nodes with zombie dmsg sessions): `dmsg-202 "connection is shut down"` → setup times out (30 s, empty hops) → multi-hop routing is unreliable (mux setup observed flapping 4/4 → 0/4). Proven live: a failing intermediate pings fine **1-hop over its existing transport** but fails **over dmsg**.

## Design — RSN as a dmsg signing oracle, source drives the cascade

The `CascadeSetup` protocol (Russian-doll, over the route's transports, RSN-signed, whitelist-verified, prev/next-only privacy) already exists but only worked when the RSN *was* the source (embedded). This makes it work with a **dedicated** RSN that only signs:

1. Source → RSN (`CascadeSignReserve` RPC): RSN signs the per-hop reserve cascades, returns bytes + session IDs. **Never sends.**
2. Source injects the reserve cascades into `Forward[0].TpID` / `Reverse[0].TpID` via its own send-only `CascadeBuilder`, collects the reserved route-ID ACKs.
3. Source → RSN (`CascadeSignInstall` RPC): RSN reconstructs the IDReserver from the collected IDs, **recomputes rules deterministically (never trusts source-supplied rules)**, signs the install cascades, returns them + the initiating `EdgeRules`.
4. Source injects the install cascades. Done.

So a transport-reachable-but-dmsg-dead intermediate no longer breaks setup, and the RSN only has to be reachable by the **source** (over dmsg), never by every hop. Each hop still verifies the RSN signature against its `route_setup_nodes` whitelist and sees only prev/next.

## Safety / rollout

- **Default** path whenever a source-side builder exists; **falls back** to the legacy dmsg `@136` `DialRouteGroup` when the RSN returns `can't find method` (un-upgraded RSN) or any cascade error. No behavior change until dedicated RSNs run this code **and** enable cascade — so merging is safe.
- Embedded-RSN and existing dmsg paths untouched.
- A shared `ackRegistry` lets the visor's single cascade handler deliver ACKs to the source builder's in-flight sends.

## Files
`pkg/router/`: `cascade_source.go` (new orchestrator), `cascade_ack_registry.go` (new), `cascade_route.go` (extracted sign-only halves), `setup_rpc_gateway.go` (2 new RPCs), `cascade_builder.go`/`cascade_handler.go` (shared ack registry), `wrappers.go` (wiring + fallback), `setupclient.go`/`router_serve.go`, `cascade_source_test.go` (new tests).

## Verification
`go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test ./pkg/router/... ./pkg/routing/...` all green, including `-race` on the cascade/ack tests.