### PR TITLE
fix(router/cascade): RSN signs out-of-the-box — no per-RSN config needed

### DIFF
--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -111,13 +111,26 @@ func NewNode(conf *SetupConfig) (*Node, error) {
 		pool:  NewClientPool(dialer, DefaultPoolTTL),
 	}
 
-	// Initialize cascade builder if cascade config is present.
-	// The transport manager for the RSN is initialized separately
-	// by the caller (cmd/setup-node) since it requires network
-	// factory configuration that depends on the deployment environment.
+	// Always create a sign-capable cascade builder so any setup node can act
+	// as a signing oracle for source-driven cascade setup out-of-the-box, with
+	// no per-RSN config. Signing (signReserveCascades/signInstallCascades, via
+	// BuildReserveMessage/BuildInstallMessage) only needs the RSN's identity
+	// (PK/SK) — never a transport manager — so tm stays nil here. A source
+	// visor running the source-driven cascade code can therefore ask ANY setup
+	// node to sign at the source's request; setup nodes that predate this code
+	// lack the CascadeSign* RPCs and the source transparently falls back to the
+	// legacy DMSG @136 dialing model.
+	//
+	// The transport manager — needed only by the experimental embedded-send
+	// path, where the RSN itself injects cascade messages down its own
+	// transports — is wired separately by InitCascade, which replaces this
+	// builder with a tm-backed one when both cascade config and a transport
+	// manager are present.
+	node.cascade = NewCascadeBuilder(log, conf.PK, conf.SK, nil)
 	if conf.Cascade != nil {
 		conf.Cascade.SetCascadeDefaults()
-		log.Info("Cascade route setup enabled")
+		node.cascade.SetTimeouts(conf.Cascade.ReserveTimeout, conf.Cascade.InstallTimeout)
+		log.Info("Cascade route setup config present (embedded-send path eligible)")
 	}
 
 	return node, nil
@@ -465,8 +478,12 @@ func CreateRouteGroup(ctx context.Context, dialer network.Dialer, pool *ClientPo
 		return routing.EdgeRules{}, err
 	}
 
-	// Try cascade path if a CascadeBuilder is available.
-	if cascade != nil {
+	// Try the embedded-send cascade path only when the builder has a transport
+	// manager — i.e. this RSN is configured to inject cascade messages down its
+	// own transports (the experimental embedded model). A sign-only builder
+	// (tm == nil) skips straight to DMSG here; its signing role is exercised
+	// separately via the CascadeSign* RPCs that a source visor drives.
+	if cascade != nil && cascade.tm != nil {
 		cascadeResp, cascadeErr := createRouteGroupCascade(ctx, log, cascade, biRt)
 		if cascadeErr == nil {
 			return cascadeResp, nil


### PR DESCRIPTION
## What

Make cascade route-setup **signing** work out-of-the-box on every setup node, with no per-RSN config change.

## Why

#3006 introduced source-driven cascade setup: the source asks a route-setup node (RSN) to *sign* the cascade, then injects it down its own (proven-reachable) transports — eliminating the dmsg-reach-each-hop failure class that causes route-setup flakiness.

But it gated the RSN's signing role behind config:
- `NewNode` only built `sn.cascade` when `conf.Cascade != nil`.
- `CascadeSignReserve` / `CascadeSignInstall` return `errCascadeUnavailable` when `g.Cascade == nil`.

So source-driven cascade couldn't be used until **every** setup node got a `Cascade` config block + transport manager and was redeployed. Until then every setup falls back to the legacy DMSG `@136` per-hop dialing — the path source-driven cascade exists to replace.

That gate is unnecessary: **signing only needs the RSN's identity (PK/SK)**. `signReserveCascades` / `signInstallCascades` never touch the transport manager. The `tm` is needed only by the experimental *embedded-send* path (`createRouteGroupCascade` / `RelayPeers`), which is already independently guarded on `.tm != nil`.

## Change

- `NewNode` now **always** builds a sign-capable `CascadeBuilder` (`tm == nil`). Any setup node can sign at a source's request out-of-the-box.
- `CreateRouteGroup` guards the embedded-send path on `cascade.tm != nil`, so a sign-only builder skips straight to DMSG there (no behavior change for non-embedded RSNs).
- `InitCascade` is unchanged: it still upgrades the builder with a `tm` when both cascade config and a transport manager are present (enabling the embedded path for experimental deployments).

## Compatibility

- **Out-of-the-box:** a source running #3006 can now use source-driven cascade against any updated setup node — no RSN config.
- **Old setup nodes** (pre-#3006) lack the `CascadeSign*` RPCs → the source's `isUnimplementedRPC` detection transparently falls back to legacy DMSG `@136`.
- **Intermediate hops** only need the cascade *handler* (shipped since v1.3.48); only the source + RSN need #3006-era code.

## Test

- `go build ./pkg/router/...`, `go vet`, `golangci-lint run ./pkg/router/` — clean.
- `go test ./pkg/router/` — pass.
- The nil-`tm` sign path is already exercised by `cascade_source_test.go` (`NewCascadeBuilder(..., nil)` → `signReserveCascades`/`signInstallCascades`), which is exactly the builder shape `NewNode` now uses for the RSN.
