### PR TITLE
fix(router/cascade): source must consume its own outermost cascade layer

### DIFF
--- a/pkg/router/cascade_handler.go
+++ b/pkg/router/cascade_handler.go
@@ -107,73 +107,119 @@ func (ch *CascadeHandler) handleSetup(p routing.Packet, sourceTp *transport.Mana
 }
 
 func (ch *CascadeHandler) handleReserve(msg *routing.CascadeSetup, sourceTp *transport.ManagedTransport) {
+	ack, err := ch.processReserve(msg)
+	if err != nil {
+		ch.log.WithError(err).Warn("Cascade reserve failed")
+		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, err.Error())
+		return
+	}
+	ch.sendAck(sourceTp, ack)
+}
+
+// processReserve reserves this hop's route IDs and, for non-terminal hops,
+// relays the inner payload to the next hop and prepends our IDs to the
+// downstream ACK. It returns the ACK to send upstream. Shared by the wire path
+// (handleReserve) and the source-origin path (ProcessLocalOrigin).
+func (ch *CascadeHandler) processReserve(msg *routing.CascadeSetup) (*routing.CascadeAck, error) {
 	// Reserve local route IDs.
 	ids, err := ch.rt.ReserveKeys(int(msg.ReserveN))
 	if err != nil {
-		ch.log.WithError(err).Warn("Cascade reserve: failed to reserve route IDs")
-		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, fmt.Sprintf("reserve IDs: %v", err))
-		return
+		return nil, fmt.Errorf("reserve IDs: %w", err)
 	}
 
 	if msg.IsTerminal() {
-		// Terminal hop — send ACK with our reserved IDs back.
-		ack := &routing.CascadeAck{
+		// Terminal hop — ACK with our reserved IDs.
+		return &routing.CascadeAck{
 			SessionID: msg.SessionID,
 			Phase:     msg.Phase,
 			RouteIDs:  ids,
-		}
-		ch.sendAck(sourceTp, ack)
-		return
+		}, nil
 	}
 
 	// Relay to next hop and wait for ACK.
 	downstreamAck, err := ch.relayAndWait(msg.RelayTpID, msg.SessionID, msg.Payload)
 	if err != nil {
-		ch.log.WithError(err).Warn("Cascade reserve: relay failed")
-		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, fmt.Sprintf("relay: %v", err))
-		return
+		return nil, fmt.Errorf("relay: %w", err)
 	}
 
 	// Prepend our IDs to the downstream ACK.
 	downstreamAck.PrependRouteIDs(ids)
-	ch.sendAck(sourceTp, downstreamAck)
+	return downstreamAck, nil
 }
 
 func (ch *CascadeHandler) handleInstall(msg *routing.CascadeSetup, sourceTp *transport.ManagedTransport) {
+	ack, err := ch.processInstall(msg)
+	if err != nil {
+		ch.log.WithError(err).Warn("Cascade install failed")
+		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, err.Error())
+		return
+	}
+	ch.sendAck(sourceTp, ack)
+}
+
+// processInstall saves this hop's rules and, for non-terminal hops, relays the
+// inner payload to the next hop and returns the downstream ACK. Shared by the
+// wire path (handleInstall) and the source-origin path (ProcessLocalOrigin).
+func (ch *CascadeHandler) processInstall(msg *routing.CascadeSetup) (*routing.CascadeAck, error) {
 	// Deserialize and install rules.
 	rules, err := routing.DeserializeRules(msg.RuleData)
 	if err != nil {
-		ch.log.WithError(err).Warn("Cascade install: failed to deserialize rules")
-		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, fmt.Sprintf("deserialize rules: %v", err))
-		return
+		return nil, fmt.Errorf("deserialize rules: %w", err)
 	}
 
 	for _, rule := range rules {
 		if err := ch.rt.SaveRule(rule); err != nil {
-			ch.log.WithError(err).Warn("Cascade install: failed to save rule")
-			ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, fmt.Sprintf("save rule: %v", err))
-			return
+			return nil, fmt.Errorf("save rule: %w", err)
 		}
 	}
 
 	if msg.IsTerminal() {
-		ack := &routing.CascadeAck{
+		return &routing.CascadeAck{
 			SessionID: msg.SessionID,
 			Phase:     msg.Phase,
-		}
-		ch.sendAck(sourceTp, ack)
-		return
+		}, nil
 	}
 
 	// Relay to next hop.
 	downstreamAck, err := ch.relayAndWait(msg.RelayTpID, msg.SessionID, msg.Payload)
 	if err != nil {
-		ch.log.WithError(err).Warn("Cascade install: relay failed")
-		ch.sendErrorAck(sourceTp, msg.SessionID, msg.Phase, fmt.Sprintf("relay: %v", err))
-		return
+		return nil, fmt.Errorf("relay: %w", err)
 	}
 
-	ch.sendAck(sourceTp, downstreamAck)
+	return downstreamAck, nil
+}
+
+// ProcessLocalOrigin processes a cascade layer addressed to THIS visor as the
+// route's origin (source). Unlike handleSetup, the origin has no upstream
+// transport to ACK back on: it verifies the RSN signature against our own PK,
+// performs the reserve/install locally, relays the inner payload to the first
+// hop over our own transport, and RETURNS the collected ACK to the caller
+// (runSourceCascade) instead of writing it to a sourceTp.
+//
+// This is the crux of source-driven cascade: the RSN builds the nested cascade
+// with the source as the OUTERMOST layer (signed for the source's PK). The
+// source must consume that layer itself — shipping it verbatim to the first hop
+// made the hop reject it ("RSN signature verification failed"), since it was
+// signed for the source's PK, not the hop's.
+func (ch *CascadeHandler) ProcessLocalOrigin(payload []byte) (*routing.CascadeAck, error) {
+	msg, err := routing.UnmarshalCascadeSetup(payload)
+	if err != nil {
+		return nil, fmt.Errorf("cascade origin: unmarshal: %w", err)
+	}
+	if _, ok := ch.trustedRSNs[msg.RSNPK]; !ok {
+		return nil, routing.ErrCascadeUntrustedRSN
+	}
+	if err := msg.Verify(ch.localPK); err != nil {
+		return nil, err
+	}
+	switch msg.Phase {
+	case routing.CascadePhaseReserve:
+		return ch.processReserve(msg)
+	case routing.CascadePhaseInstall:
+		return ch.processInstall(msg)
+	default:
+		return nil, fmt.Errorf("cascade origin: unknown phase %d", msg.Phase)
+	}
 }
 
 func (ch *CascadeHandler) handleAck(p routing.Packet) {

--- a/pkg/router/cascade_source.go
+++ b/pkg/router/cascade_source.go
@@ -37,6 +37,14 @@ type cascadeSourceProvider interface {
 	CascadeAckRegistry() *ackRegistry
 }
 
+// cascadeOriginSetter is implemented by route-group dialers that drive
+// source-driven cascade. The router calls SetCascadeOrigin at Serve time to
+// hand the dialer the visor's CascadeHandler, which the dialer uses to consume
+// the source-addressed outermost cascade layer locally.
+type cascadeOriginSetter interface {
+	SetCascadeOrigin(p cascadeOriginProcessor)
+}
+
 // errCascadeSignUnimplemented signals that the RSN does not implement the
 // CascadeSign* RPCs (an un-upgraded setup node). Callers fall back to the
 // legacy DMSG @136 path.
@@ -63,11 +71,11 @@ func runSourceCascade(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	rpcC *rpc.Client,
-	srcCB *CascadeBuilder,
+	originProc cascadeOriginProcessor,
 	biRt routing.BidirectionalRoute,
 ) (routing.EdgeRules, error) {
-	if srcCB == nil {
-		return routing.EdgeRules{}, fmt.Errorf("cascade: no source-side builder")
+	if originProc == nil {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: no source-origin processor")
 	}
 	if len(biRt.Forward) == 0 || len(biRt.Reverse) == 0 {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: route has no hops")
@@ -85,20 +93,20 @@ func runSourceCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: sign reserve RPC: %w", err)
 	}
 
-	// --- Phase 1 (cont): inject reserve cascades over our own transports ---
-	firstFwdTpID := biRt.Forward[0].TpID
-	fwdAck, err := srcCB.SendCascade(ctx, firstFwdTpID, reserveReply.FwdSessionID, reserveReply.FwdReserveBytes, srcCB.reserveTimeout)
+	// --- Phase 1 (cont): consume our own (outermost) layer locally, which
+	// reserves our route IDs and relays the inner payload down our own
+	// transport to the first hop, collecting the cascade ACK. ---
+	fwdAck, err := originProc.ProcessLocalOrigin(reserveReply.FwdReserveBytes)
 	if err != nil {
-		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd reserve send: %w", err)
+		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd reserve: %w", err)
 	}
 	if fwdAck.Error != "" {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd reserve rejected: %s", fwdAck.Error)
 	}
 
-	firstRevTpID := biRt.Reverse[0].TpID
-	revAck, err := srcCB.SendCascade(ctx, firstRevTpID, reserveReply.RevSessionID, reserveReply.RevReserveBytes, srcCB.reserveTimeout)
+	revAck, err := originProc.ProcessLocalOrigin(reserveReply.RevReserveBytes)
 	if err != nil {
-		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve send: %w", err)
+		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve: %w", err)
 	}
 	if revAck.Error != "" {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve rejected: %s", revAck.Error)
@@ -123,18 +131,18 @@ func runSourceCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: sign install RPC: %w", err)
 	}
 
-	// --- Phase 2 (cont): inject install cascades over our own transports ---
-	fwdInstAck, err := srcCB.SendCascade(ctx, firstFwdTpID, reserveReply.FwdSessionID, installReply.FwdInstallBytes, srcCB.installTimeout)
+	// --- Phase 2 (cont): consume our own install layer locally and relay. ---
+	fwdInstAck, err := originProc.ProcessLocalOrigin(installReply.FwdInstallBytes)
 	if err != nil {
-		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install send: %w", err)
+		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install: %w", err)
 	}
 	if fwdInstAck.Error != "" {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install rejected: %s", fwdInstAck.Error)
 	}
 
-	revInstAck, err := srcCB.SendCascade(ctx, firstRevTpID, reserveReply.RevSessionID, installReply.RevInstallBytes, srcCB.installTimeout)
+	revInstAck, err := originProc.ProcessLocalOrigin(installReply.RevInstallBytes)
 	if err != nil {
-		return routing.EdgeRules{}, fmt.Errorf("cascade: rev install send: %w", err)
+		return routing.EdgeRules{}, fmt.Errorf("cascade: rev install: %w", err)
 	}
 	if revInstAck.Error != "" {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: rev install rejected: %s", revInstAck.Error)

--- a/pkg/router/cascade_source_test.go
+++ b/pkg/router/cascade_source_test.go
@@ -205,3 +205,80 @@ func TestSourceBuilderSharesHandlerRegistry(t *testing.T) {
 		t.Fatal("handler dispatch did not reach builder's waiter")
 	}
 }
+
+// TestReserveCascade_OutermostLayerAddressesSource is the regression test for
+// the source-driven cascade signature bug: the RSN builds the nested reserve
+// cascade with the SOURCE (hops[0].From) as the OUTERMOST layer. Shipping that
+// layer verbatim to the first hop made the hop reject it with "RSN signature
+// verification failed" — because it is signed for the source's PK, not the
+// hop's. The source must consume its own layer (ProcessLocalOrigin).
+func TestReserveCascade_OutermostLayerAddressesSource(t *testing.T) {
+	cb, _ := rsnBuilder(t)
+	biRt, pkA, pkB, _ := buildTestBiRoute(t)
+
+	_, fwdBytes, _, _, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+
+	outer, err := routing.UnmarshalCascadeSetup(fwdBytes)
+	require.NoError(t, err)
+	require.NoError(t, outer.Verify(pkA), "outermost layer must verify for the source (pkA)")
+	require.Error(t, outer.Verify(pkB),
+		"outermost layer must NOT verify for the first hop (pkB) — the bug that 0/N'd source-driven setup")
+}
+
+// TestProcessLocalOrigin_TerminalReserve verifies the source consumes a layer
+// addressed to itself: it passes the trusted-RSN + own-PK signature checks and
+// reserves its own route IDs. (Terminal layer => no relay, so no tm needed.)
+func TestProcessLocalOrigin_TerminalReserve(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+
+	msg := &routing.CascadeSetup{
+		Phase:     routing.CascadePhaseReserve,
+		SessionID: 42,
+		RSNPK:     rsnPK,
+		Nonce:     1,
+		ReserveN:  2,
+		// RelayTpID zero => terminal, no downstream relay
+	}
+	require.NoError(t, msg.Sign(srcPK, rsnSK))
+	payload, err := msg.Marshal()
+	require.NoError(t, err)
+
+	ch := NewCascadeHandler(logging.MustGetLogger("test_src"), srcPK,
+		[]cipher.PubKey{rsnPK}, routing.NewTable(logging.MustGetLogger("test_rt")), nil)
+
+	ack, err := ch.ProcessLocalOrigin(payload)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), ack.SessionID)
+	assert.Len(t, ack.RouteIDs, 2, "source must reserve its own route IDs")
+}
+
+// TestProcessLocalOrigin_Rejections covers the two guard paths that fail before
+// any relay: an untrusted RSN and a signature not addressed to this visor.
+func TestProcessLocalOrigin_Rejections(t *testing.T) {
+	rsnPK, rsnSK := cipher.GenerateKeyPair()
+	srcPK, _ := cipher.GenerateKeyPair()
+	otherPK, _ := cipher.GenerateKeyPair()
+	rt := routing.NewTable(logging.MustGetLogger("test_rt"))
+	ch := NewCascadeHandler(logging.MustGetLogger("test_src"), srcPK,
+		[]cipher.PubKey{rsnPK}, rt, nil)
+
+	mk := func(target cipher.PubKey, rsn cipher.PubKey) []byte {
+		msg := &routing.CascadeSetup{
+			Phase: routing.CascadePhaseReserve, SessionID: 1, RSNPK: rsn, Nonce: 1, ReserveN: 1,
+		}
+		require.NoError(t, msg.Sign(target, rsnSK))
+		b, err := msg.Marshal()
+		require.NoError(t, err)
+		return b
+	}
+
+	// RSNPK not in the trusted set.
+	_, err := ch.ProcessLocalOrigin(mk(srcPK, otherPK))
+	require.ErrorIs(t, err, routing.ErrCascadeUntrustedRSN)
+
+	// Trusted RSN, but the layer is signed for otherPK, not us (srcPK).
+	_, err = ch.ProcessLocalOrigin(mk(otherPK, rsnPK))
+	require.ErrorIs(t, err, routing.ErrCascadeSigInvalid)
+}

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -93,6 +93,14 @@ func (r *router) Serve(ctx context.Context) error {
 				r.logger.Debug("Cascade handler sharing source-driven ack registry")
 			}
 		}
+		// Wire the handler in as the dialer's source-origin processor so the
+		// source consumes the outermost (source-addressed) cascade layer
+		// itself — reserving its own route IDs and relaying inward — instead
+		// of shipping it to the first hop (which would reject the signature).
+		if os, ok := r.conf.RouteGroupDialer.(cascadeOriginSetter); ok {
+			os.SetCascadeOrigin(ch)
+			r.logger.Debug("Cascade handler wired as source-origin processor")
+		}
 	}
 
 	r.tm.SetCascadeHandler(ch.HandlePacket)

--- a/pkg/router/wrappers.go
+++ b/pkg/router/wrappers.go
@@ -49,6 +49,25 @@ type setupNodeDialer struct {
 	// reserve/install cascades down this visor's own transports. nil when no
 	// transport manager is available (e.g. NewSetupNodeDialer).
 	srcCascade *CascadeBuilder
+
+	// cascadeOrigin processes the outermost (source-addressed) cascade layer
+	// locally: it reserves this visor's own route IDs / saves its own rules and
+	// relays the inner payload to the first hop. Set by the router at Serve time
+	// (the visor's CascadeHandler implements it). nil until then.
+	cascadeOrigin cascadeOriginProcessor
+}
+
+// cascadeOriginProcessor consumes the source-addressed outermost layer of a
+// cascade and returns the collected ACK. Implemented by *CascadeHandler.
+type cascadeOriginProcessor interface {
+	ProcessLocalOrigin(payload []byte) (*routing.CascadeAck, error)
+}
+
+// SetCascadeOrigin wires the visor's CascadeHandler in as the source-origin
+// processor. Called by the router at Serve time via the cascadeOriginSetter
+// interface.
+func (d *setupNodeDialer) SetCascadeOrigin(p cascadeOriginProcessor) {
+	d.cascadeOrigin = p
 }
 
 // CascadeAckRegistry exposes the source-side cascade builder's ack registry
@@ -178,8 +197,8 @@ func (d *setupNodeDialer) Dial(
 	// transports (not the RSN's). This avoids the RSN having to dial each
 	// hop over dmsg (the dmsg-202 failure mode for zombie sessions). Fall
 	// back to the legacy DMSG DialRouteGroup if the RSN is un-upgraded.
-	if d.srcCascade != nil {
-		rules, cascErr := runSourceCascade(ctx, log, client.RPCClient(), d.srcCascade, req)
+	if d.srcCascade != nil && d.cascadeOrigin != nil {
+		rules, cascErr := runSourceCascade(ctx, log, client.RPCClient(), d.cascadeOrigin, req)
 		if cascErr == nil {
 			return rules, connectedNode, nil
 		}
@@ -224,8 +243,8 @@ func (d *setupNodeDialer) dialViaTransport(
 	// Prefer the source-driven cascade: the RSN only signs, and we inject the
 	// cascades down our own transports. Fall back to the legacy DialRouteGroup
 	// RPC if the RSN doesn't implement the CascadeSign* methods.
-	if d.srcCascade != nil {
-		rules, cascErr := runSourceCascade(ctx, log, rpcC, d.srcCascade, req)
+	if d.srcCascade != nil && d.cascadeOrigin != nil {
+		rules, cascErr := runSourceCascade(ctx, log, rpcC, d.cascadeOrigin, req)
 		if cascErr == nil {
 			return rules, nil
 		}


### PR DESCRIPTION
## What

Make source-driven cascade route setup (#3006) actually complete. After #3008 made the RSN sign out-of-the-box, the source-driven path ran in production for the first time — and failed 0/N.

## Symptom (observed live)

A #3008 source (Gamma) → Beta, `mux-bw --routes N --min-hops 2`: **0/N, every route "setup timeout after 30s" with empty hops.** Gamma's logs:

```
DEBUG [router]: Source-driven cascade: requesting RSN reserve signatures
WARN  [router]: Source-driven cascade failed, falling back to DMSG DialRouteGroup
        error="cascade: fwd reserve rejected: cascade: RSN signature verification failed"
ERROR [router]: Error dialing ping route group error="... dmsg error 202 - cannot connect to delegated server"
```

So cascade was rejected at the first hop, then the legacy DMSG fallback hit the exact `dmsg-202` failure class cascade exists to avoid → both paths fail. (Beta→Gamma worked because its fallback route happened to be dmsg-reachable; Alpha→Beta worked only because Alpha predates #3006 and never tries cascade.)

## Root cause

The RSN builds the nested reserve/install cascade with the **source** (`hops[0].From`) as the **outermost layer**, signed for the source's PK. `runSourceCascade` shipped that layer verbatim down `Forward[0].TpID` to the **first hop**, which verifies the RSN signature against **its own** PK (`msg.Verify(ch.localPK)`) and rejected it. The source's own layer must be consumed by the source.

Invisible until now because pre-#3008 the RSN sign RPCs were config-gated, so the source-driven path never ran end-to-end in production.

## Fix

The source consumes its own outermost layer locally. `CascadeHandler` grows **`ProcessLocalOrigin`**: verify the RSN signature against our own PK, reserve our route IDs (reserve phase) / save our rules (install phase), relay the inner payload to the first hop over our own transport, and return the collected ACK to `runSourceCascade`.

- `handleReserve` / `handleInstall` refactored to share `processReserve` / `processInstall` with `ProcessLocalOrigin` — **wire-path behavior for intermediate hops is byte-for-byte unchanged.**
- The router wires its `CascadeHandler` into the dialer as the origin processor at Serve time (`cascadeOriginSetter`).
- `runSourceCascade` drives all four reserve/install injections through `ProcessLocalOrigin` instead of `CascadeBuilder.SendCascade` (which blindly transmitted the source layer to hop1).

## Safety

No regression risk to the cascade wire path (intermediate hops unchanged). The source-driven path still falls back to legacy DMSG `DialRouteGroup` on any error — so worst case is the prior behavior.

## Tests

- `TestReserveCascade_OutermostLayerAddressesSource` — outermost layer verifies for the source but **not** the first hop (the bug).
- `TestProcessLocalOrigin_TerminalReserve` / `_Rejections` — accept path + untrusted-RSN / wrong-PK guards.
- `go build/vet`, `golangci-lint run ./pkg/router/` clean; `go test ./pkg/router/` pass.

Follow-up to #3006 / #3008.
