### PR TITLE
fix(router/cascade): re-orient reverse cascade source-first + per-path reserve counts

### DIFF
--- a/pkg/router/cascade_route.go
+++ b/pkg/router/cascade_route.go
@@ -35,22 +35,21 @@ func createRouteGroupCascade(
 
 	fwdRt, revRt := biRt.ForwardAndReverse()
 
-	// Determine how many route IDs each hop needs.
-	// Same logic as NewIDReserver: count occurrences of each PK across both paths.
-	reserveCount := computeReserveCount(biRt.Forward, biRt.Reverse)
+	// Both cascades are injected source-first; the reverse path is re-oriented
+	// to start at the source (see signReserveCascades for the rationale). Each
+	// cascade reserves its own path's per-node count.
+	if len(biRt.Forward) == 0 {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: no forward hops")
+	}
+	revInject := reverseHopsFromSource(biRt.Reverse)
 
 	// --- Phase 1: Reserve route IDs ---
 
-	// Build per-hop reserve messages with the correct reserveN for each hop.
-	fwdSessionID, fwdReservePayload, err := buildReserveWithCounts(cb, biRt.Forward, reserveCount)
+	fwdSessionID, fwdReservePayload, err := buildReserveWithCounts(cb, biRt.Forward, singlePathReserveCount(biRt.Forward))
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: build fwd reserve: %w", err)
 	}
 
-	// Find the transport connecting us to the first hop.
-	if len(biRt.Forward) == 0 {
-		return routing.EdgeRules{}, fmt.Errorf("cascade: no forward hops")
-	}
 	firstFwdTpID := biRt.Forward[0].TpID
 
 	fwdAck, err := cb.SendCascade(ctx, firstFwdTpID, fwdSessionID, fwdReservePayload, cb.reserveTimeout)
@@ -61,13 +60,16 @@ func createRouteGroupCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd reserve rejected: %s", fwdAck.Error)
 	}
 
-	// Reverse path reserve.
-	revSessionID, revReservePayload, err := buildReserveWithCounts(cb, biRt.Reverse, reserveCount)
+	// Reverse path reserve (source-oriented).
+	revSessionID, revReservePayload, err := buildReserveWithCounts(cb, revInject, singlePathReserveCount(revInject))
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: build rev reserve: %w", err)
 	}
 
-	firstRevTpID := biRt.Reverse[0].TpID
+	if len(revInject) == 0 {
+		return routing.EdgeRules{}, fmt.Errorf("cascade: no reverse hops")
+	}
+	firstRevTpID := revInject[0].TpID
 	revAck, err := cb.SendCascade(ctx, firstRevTpID, revSessionID, revReservePayload, cb.reserveTimeout)
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve: %w", err)
@@ -76,8 +78,8 @@ func createRouteGroupCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve rejected: %s", revAck.Error)
 	}
 
-	// --- Reconstruct IDReserver from cascade ACKs ---
-	idR, err := newCascadeIDReserver(biRt.Forward, biRt.Reverse, fwdAck.RouteIDs, revAck.RouteIDs)
+	// --- Reconstruct IDReserver from cascade ACKs (reverse re-oriented) ---
+	idR, err := newCascadeIDReserver(biRt.Forward, revInject, fwdAck.RouteIDs, revAck.RouteIDs)
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: reconstruct IDs: %w", err)
 	}
@@ -119,8 +121,8 @@ func createRouteGroupCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install rejected: %s", fwdInstAck.Error)
 	}
 
-	// Reverse path install.
-	revInstallPayload, err := cb.BuildInstallMessage(biRt.Reverse, revSessionID, rulesPerPK)
+	// Reverse path install (source-oriented).
+	revInstallPayload, err := cb.BuildInstallMessage(revInject, revSessionID, rulesPerPK)
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: build rev install: %w", err)
 	}
@@ -156,14 +158,21 @@ func signReserveCascades(cb *CascadeBuilder, biRt routing.BidirectionalRoute) (
 		return 0, nil, 0, nil, fmt.Errorf("cascade: no reverse hops")
 	}
 
-	reserveCount := computeReserveCount(biRt.Forward, biRt.Reverse)
-
-	fwdSessionID, fwdReserveBytes, err = buildReserveWithCounts(cb, biRt.Forward, reserveCount)
+	// Each cascade is injected by the SOURCE over its own transports, so both
+	// must be oriented source-first. The forward path already starts at the
+	// source; the reverse path (dst->src) is re-oriented to start at the source
+	// (src->...->dst over the same bidirectional transports). Each cascade
+	// reserves its OWN path's per-node count (one per appearance); the two sum
+	// to the legacy combined rec[pk] that GenerateRules pops (once per
+	// direction) — and keeps newCascadeIDReserver's one-ID-per-PK assumption
+	// valid.
+	fwdSessionID, fwdReserveBytes, err = buildReserveWithCounts(cb, biRt.Forward, singlePathReserveCount(biRt.Forward))
 	if err != nil {
 		return 0, nil, 0, nil, fmt.Errorf("cascade: build fwd reserve: %w", err)
 	}
 
-	revSessionID, revReserveBytes, err = buildReserveWithCounts(cb, biRt.Reverse, reserveCount)
+	revInject := reverseHopsFromSource(biRt.Reverse)
+	revSessionID, revReserveBytes, err = buildReserveWithCounts(cb, revInject, singlePathReserveCount(revInject))
 	if err != nil {
 		return 0, nil, 0, nil, fmt.Errorf("cascade: build rev reserve: %w", err)
 	}
@@ -188,10 +197,14 @@ func signInstallCascades(
 ) (fwdInstallBytes, revInstallBytes []byte, initEdge routing.EdgeRules, err error) {
 	fwdRt, revRt := biRt.ForwardAndReverse()
 
-	// Reconstruct the IDReserver from the cascade ACK route IDs. The rules
-	// are recomputed below from this deterministic reserver — we do NOT
-	// trust source-supplied rules.
-	idR, err := newCascadeIDReserver(biRt.Forward, biRt.Reverse, fwdRouteIDs, revRouteIDs)
+	// The reverse cascade was injected source-first (see signReserveCascades),
+	// so its ACK route IDs arrive in source->...->dst order. Reconstruct the
+	// IDReserver against the SAME re-oriented reverse path so each ACK ID maps
+	// back to the visor that actually reserved it. The rules are recomputed
+	// below from this deterministic reserver — we do NOT trust source-supplied
+	// rules.
+	revInject := reverseHopsFromSource(biRt.Reverse)
+	idR, err := newCascadeIDReserver(biRt.Forward, revInject, fwdRouteIDs, revRouteIDs)
 	if err != nil {
 		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: reconstruct IDs: %w", err)
 	}
@@ -220,7 +233,7 @@ func signInstallCascades(
 	if err != nil {
 		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: build fwd install: %w", err)
 	}
-	revInstallBytes, err = cb.BuildInstallMessage(biRt.Reverse, revSessionID, rulesPerPK)
+	revInstallBytes, err = cb.BuildInstallMessage(revInject, revSessionID, rulesPerPK)
 	if err != nil {
 		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: build rev install: %w", err)
 	}
@@ -228,19 +241,41 @@ func signInstallCascades(
 	return fwdInstallBytes, revInstallBytes, initEdge, nil
 }
 
-// computeReserveCount determines how many route IDs each PK needs across both paths.
-func computeReserveCount(forward, reverse []routing.Hop) map[cipher.PubKey]uint8 {
+// singlePathReserveCount counts how many route IDs each visor must reserve for a
+// SINGLE path traversal: one per appearance (the path's source + every hop's To).
+// The forward and (re-oriented) reverse cascades each reserve independently, so
+// the per-PK total across both equals the legacy NewIDReserver's combined count
+// — which is exactly what GenerateRules pops (once per direction). Reserving the
+// COMBINED count in each cascade (as the old computeReserveCount did) over-
+// reserved and misaligned newCascadeIDReserver's one-ID-per-PK distribution.
+func singlePathReserveCount(hops []routing.Hop) map[cipher.PubKey]uint8 {
 	counts := make(map[cipher.PubKey]uint8)
-	for _, hops := range [][]routing.Hop{forward, reverse} {
-		if len(hops) == 0 {
-			continue
-		}
-		counts[hops[0].From]++
-		for _, hop := range hops {
-			counts[hop.To]++
-		}
+	if len(hops) == 0 {
+		return counts
+	}
+	counts[hops[0].From]++
+	for _, hop := range hops {
+		counts[hop.To]++
 	}
 	return counts
+}
+
+// reverseHopsFromSource re-orients a path so the route's SOURCE — which sits at
+// the END of the reverse path (dst->src) — can inject the cascade over its own
+// transports. It reverses hop order and swaps each hop's From/To, preserving
+// transport IDs (transports are bidirectional), so the result starts at the
+// source and traverses the same physical transports outward.
+// e.g. reverse path [C->B, B->A] becomes [A->B, B->C].
+func reverseHopsFromSource(hops []routing.Hop) []routing.Hop {
+	out := make([]routing.Hop, 0, len(hops))
+	for i := len(hops) - 1; i >= 0; i-- {
+		out = append(out, routing.Hop{
+			From: hops[i].To,
+			To:   hops[i].From,
+			TpID: hops[i].TpID,
+		})
+	}
+	return out
 }
 
 // buildReserveWithCounts builds a nested reserve cascade with per-hop reserveN.

--- a/pkg/router/cascade_source_test.go
+++ b/pkg/router/cascade_source_test.go
@@ -76,8 +76,9 @@ func TestSignReserveCascades_SignedBytes(t *testing.T) {
 
 	// Forward targets: A (source) -> B -> C
 	verifyReserveChain(t, fwdBytes, rsnPK, []cipher.PubKey{pkA, pkB, pkC})
-	// Reverse targets: C (source of reverse) -> B -> A
-	verifyReserveChain(t, revBytes, rsnPK, []cipher.PubKey{pkC, pkB, pkA})
+	// Reverse targets: re-oriented source-first so the SOURCE (A) injects it
+	// over its own transports — A -> B -> C, NOT the logical reverse C -> B -> A.
+	verifyReserveChain(t, revBytes, rsnPK, []cipher.PubKey{pkA, pkB, pkC})
 }
 
 func TestSignReserveCascades_WrongTargetFailsVerify(t *testing.T) {
@@ -281,4 +282,91 @@ func TestProcessLocalOrigin_Rejections(t *testing.T) {
 	// Trusted RSN, but the layer is signed for otherPK, not us (srcPK).
 	_, err = ch.ProcessLocalOrigin(mk(otherPK, rsnPK))
 	require.ErrorIs(t, err, routing.ErrCascadeSigInvalid)
+}
+
+// simulateReserveCascade walks a nested reserve cascade the way the real hops
+// would: each layer is verified against its target PK in source-first order,
+// the target "reserves" ReserveN fresh route IDs, and the ACK accumulates those
+// IDs source-first (each hop prepends its own, which equals appending in target
+// order). Returns the collected IDs.
+func simulateReserveCascade(t *testing.T, payload []byte, targets []cipher.PubKey, nextID *routing.RouteID) []routing.RouteID {
+	t.Helper()
+	var acc []routing.RouteID
+	for i, target := range targets {
+		cs, err := routing.UnmarshalCascadeSetup(payload)
+		require.NoErrorf(t, err, "reserve layer %d unmarshal", i)
+		require.Equalf(t, routing.CascadePhaseReserve, cs.Phase, "reserve layer %d phase", i)
+		require.NoErrorf(t, cs.Verify(target), "reserve layer %d must be signed for target %s", i, target)
+		for j := uint8(0); j < cs.ReserveN; j++ {
+			acc = append(acc, *nextID)
+			*nextID++
+		}
+		if i == len(targets)-1 {
+			require.Truef(t, cs.IsTerminal(), "reserve last layer must be terminal")
+		} else {
+			require.NotEmptyf(t, cs.Payload, "reserve layer %d must wrap inner payload", i)
+			payload = cs.Payload
+		}
+	}
+	return acc
+}
+
+// assertInstallSourceFirst walks an install cascade and asserts each layer is
+// signed for its source-first target PK.
+func assertInstallSourceFirst(t *testing.T, payload []byte, targets []cipher.PubKey) {
+	t.Helper()
+	for i, target := range targets {
+		cs, err := routing.UnmarshalCascadeSetup(payload)
+		require.NoErrorf(t, err, "install layer %d unmarshal", i)
+		require.Equalf(t, routing.CascadePhaseInstall, cs.Phase, "install layer %d phase", i)
+		require.NoErrorf(t, cs.Verify(target), "install layer %d must be signed for target %s", i, target)
+		if i < len(targets)-1 {
+			payload = cs.Payload
+		}
+	}
+}
+
+// TestSourceCascade_BothDirectionsSourceFirst_EndToEnd is the deterministic
+// regression test for the source-driven cascade bugs found 2026-06-04:
+//   - the reverse cascade was built dst-first (signed for the destination), so
+//     the source could not consume its outermost layer ("rev reserve: RSN
+//     signature verification failed");
+//   - each cascade reserved the COMBINED per-PK count while newCascadeIDReserver
+//     consumed one ID per PK, misaligning route IDs when count>1.
+//
+// It drives the real RSN-side build/sign/ID-reserve/rule-generation path and
+// asserts BOTH cascades are source-first and the install signing — which runs
+// newCascadeIDReserver + GenerateRules — succeeds (i.e. the IDs line up).
+func TestSourceCascade_BothDirectionsSourceFirst_EndToEnd(t *testing.T) {
+	cb, _ := rsnBuilder(t)
+	biRt, pkA, pkB, pkC := buildTestBiRoute(t) // forward A -> B -> C
+
+	fwdSession, fwdBytes, revSession, revBytes, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+
+	// Both the forward AND the re-oriented reverse cascade must address the
+	// SOURCE (pkA) outermost, then pkB, then pkC.
+	srcFirst := []cipher.PubKey{pkA, pkB, pkC}
+
+	var nextID routing.RouteID = 1
+	fwdIDs := simulateReserveCascade(t, fwdBytes, srcFirst, &nextID)
+	revIDs := simulateReserveCascade(t, revBytes, srcFirst, &nextID)
+
+	// Each node reserves once per cascade (singlePathReserveCount); two cascades
+	// => two route IDs per node, matching what GenerateRules pops per PK.
+	require.Len(t, fwdIDs, 3, "one fwd ID per node")
+	require.Len(t, revIDs, 3, "one rev ID per node")
+
+	// Signing the install runs newCascadeIDReserver + GenerateRules. If the IDs
+	// misaligned (the count bug) this returns ErrNoKey.
+	fwdInst, revInst, initEdge, err := signInstallCascades(cb, biRt, fwdSession, revSession, fwdIDs, revIDs)
+	require.NoError(t, err, "install signing must succeed (route IDs aligned)")
+	require.NotEmpty(t, fwdInst)
+	require.NotEmpty(t, revInst)
+	require.NotEmpty(t, initEdge.Forward, "initiating edge must carry a forward rule")
+	require.NotEmpty(t, initEdge.Reverse, "initiating edge must carry a reverse rule")
+
+	// Install cascades are also source-first.
+	assertInstallSourceFirst(t, fwdInst, srcFirst)
+	assertInstallSourceFirst(t, revInst, srcFirst)
 }


### PR DESCRIPTION
## What

Two more source-driven cascade bugs, found by live-testing #3009 end-to-end (Gamma→Beta). #3009 fixed the *forward* path; this fixes the *reverse* path and the route-ID reservation math, so source-driven cascade actually completes.

Symptom after #3009 (Gamma logs):
```
Source-driven cascade failed, falling back to DMSG DialRouteGroup
  error="cascade: rev reserve: cascade: RSN signature verification failed"
```

## Bug 1 — reverse cascade orientation

The RSN built the reverse cascade straight from `biRt.Reverse` (`dst→src`), so its outermost layer was signed for the **destination**. But the route **source** injects *both* cascades over its own transports, and `ProcessLocalOrigin` verifies the outermost layer against the source's PK → reject.

**Fix:** `reverseHopsFromSource()` re-orients the reverse path to start at the source (`src→…→dst` over the same bidirectional transports — transport UUIDs are direction-independent), so the source consumes its own outermost layer exactly like the forward path.

## Bug 2 — reserve count vs ID distribution

`computeReserveCount` summed each PK's occurrences across **both** paths (= 2 for a symmetric 2-hop route), and every cascade reserved that *combined* count. But `newCascadeIDReserver` consumes **one ID per PK per cascade**. With count > 1, the ACK route IDs misaligned — node A's 2nd reserved ID got assigned to B — producing rules that reference IDs the node never reserved.

**Fix:** `singlePathReserveCount()` — each cascade reserves only its *own* path's per-node count (1 each). The forward + re-oriented-reverse cascades sum to the legacy `NewIDReserver`'s combined `rec[pk]`, which `GenerateRules` pops once per direction, and the one-ID-per-PK distribution lines up exactly.

Both the source-driven (`signReserveCascades`/`signInstallCascades`) and embedded (`createRouteGroupCascade`) paths are updated; `newCascadeIDReserver` and the reverse install message use the re-oriented reverse path.

## Test

`TestSourceCascade_BothDirectionsSourceFirst_EndToEnd` — a **deterministic** regression test (no live network or transport manager): drives the real `build → simulated reserve walk → newCascadeIDReserver → GenerateRules` path and asserts BOTH cascades are source-first and install signing succeeds (route IDs aligned). This is the harness that lets these bugs be caught in milliseconds instead of ~30-min live redeploy+transport-recovery cycles. Updated `TestSignReserveCascades_SignedBytes` for the source-first reverse orientation.

`go build/vet`, `golangci-lint run ./pkg/router/`, `go test ./pkg/router/` all clean.

Follow-up to #3006 / #3008 / #3009.
