### PR TITLE
fix(router/cascade): destination creates a route group (IntroduceRules), not just rules

### DIFF
--- a/pkg/router/cascade_builder.go
+++ b/pkg/router/cascade_builder.go
@@ -156,10 +156,15 @@ func (cb *CascadeBuilder) BuildReserveMessage(hops []routing.Hop, reserveN uint8
 
 // BuildInstallMessage constructs a nested install cascade from last hop to first.
 // rulesPerHop maps each visor PK to the rules that should be installed on it.
+// edgeDesc, when non-zero, is stamped onto the TERMINAL hop's layer (the
+// responding destination) so that hop calls router.IntroduceRules — creating a
+// route group — instead of only installing forwarding rules. Pass the zero
+// RouteDescriptor for a path whose terminal must not introduce a route group.
 func (cb *CascadeBuilder) BuildInstallMessage(
 	hops []routing.Hop,
 	sessionID uint64,
 	rulesPerHop map[cipher.PubKey][]routing.Rule,
+	edgeDesc routing.RouteDescriptor,
 ) ([]byte, error) {
 	if len(hops) == 0 {
 		return nil, fmt.Errorf("cascade: no hops")
@@ -197,6 +202,11 @@ func (cb *CascadeBuilder) BuildInstallMessage(
 			RuleData:  ruleData,
 			RelayTpID: targets[i].relayTpID,
 			Payload:   innerPayload,
+		}
+		// Mark the terminal hop (the responding destination) as a route-group
+		// edge so it calls IntroduceRules. Signed below along with the rest.
+		if i == len(targets)-1 {
+			msg.EdgeDesc = edgeDesc
 		}
 		if err := msg.Sign(targets[i].pk, cb.rsnSK); err != nil {
 			return nil, fmt.Errorf("cascade sign hop %d: %w", i, err)

--- a/pkg/router/cascade_handler.go
+++ b/pkg/router/cascade_handler.go
@@ -25,6 +25,12 @@ type CascadeHandler struct {
 	rt          routing.Table // for ReserveKeys and SaveRule
 	tm          *transport.Manager
 
+	// introduceRules creates/joins a route group from edge rules and notifies
+	// the launcher (router.IntroduceRules). Called when an Install-phase hop is
+	// marked as the responding destination edge (msg.IsEdge()). nil in contexts
+	// without a router (e.g. the RSN, tests) — those fall back to SaveRule.
+	introduceRules func(routing.EdgeRules) error
+
 	// acks tracks in-flight relay operations (and, on the source visor,
 	// source-driven sends) awaiting an ACK. Shared with the source-side
 	// CascadeBuilder so its injected cascades' ACKs are delivered here.
@@ -34,13 +40,17 @@ type CascadeHandler struct {
 	defaultTimeout time.Duration
 }
 
-// NewCascadeHandler creates a new cascade handler.
+// NewCascadeHandler creates a new cascade handler. introduceRules is the
+// router's IntroduceRules (creates a route group + notifies the launcher) and
+// may be nil where no router is available (RSN, tests) — edge installs then
+// fall back to plain rule saving.
 func NewCascadeHandler(
 	log *logging.Logger,
 	localPK cipher.PubKey,
 	trustedRSNPKs []cipher.PubKey,
 	rt routing.Table,
 	tm *transport.Manager,
+	introduceRules func(routing.EdgeRules) error,
 ) *CascadeHandler {
 	trusted := make(map[cipher.PubKey]struct{}, len(trustedRSNPKs))
 	for _, pk := range trustedRSNPKs {
@@ -52,6 +62,7 @@ func NewCascadeHandler(
 		trustedRSNs:    trusted,
 		rt:             rt,
 		tm:             tm,
+		introduceRules: introduceRules,
 		acks:           newAckRegistry(),
 		defaultTimeout: 10 * time.Second,
 	}
@@ -167,9 +178,23 @@ func (ch *CascadeHandler) processInstall(msg *routing.CascadeSetup) (*routing.Ca
 		return nil, fmt.Errorf("deserialize rules: %w", err)
 	}
 
-	for _, rule := range rules {
-		if err := ch.rt.SaveRule(rule); err != nil {
-			return nil, fmt.Errorf("save rule: %w", err)
+	if msg.IsEdge() && ch.introduceRules != nil {
+		// Responding destination edge: create a route group (and notify the
+		// launcher) rather than only installing forwarding rules — the
+		// cascade equivalent of the legacy AddEdgeRules RPC. RuleData carries
+		// [Forward, Reverse] (respEdge order); SerializeRules round-trips them.
+		if len(rules) != 2 {
+			return nil, fmt.Errorf("cascade edge install: expected 2 rules, got %d", len(rules))
+		}
+		edge := routing.EdgeRules{Desc: msg.EdgeDesc, Forward: rules[0], Reverse: rules[1]}
+		if err := ch.introduceRules(edge); err != nil {
+			return nil, fmt.Errorf("introduce edge rules: %w", err)
+		}
+	} else {
+		for _, rule := range rules {
+			if err := ch.rt.SaveRule(rule); err != nil {
+				return nil, fmt.Errorf("save rule: %w", err)
+			}
 		}
 	}
 

--- a/pkg/router/cascade_route.go
+++ b/pkg/router/cascade_route.go
@@ -108,8 +108,8 @@ func createRouteGroupCascade(
 	// Collect all rules per PK for the cascade install.
 	rulesPerPK := collectRulesPerPK(fwdRules, revRules, interRules, initEdge, respEdge)
 
-	// Forward path install.
-	fwdInstallPayload, err := cb.BuildInstallMessage(biRt.Forward, fwdSessionID, rulesPerPK)
+	// Forward path install — terminal is the responding destination edge.
+	fwdInstallPayload, err := cb.BuildInstallMessage(biRt.Forward, fwdSessionID, rulesPerPK, respEdge.Desc)
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: build fwd install: %w", err)
 	}
@@ -121,8 +121,8 @@ func createRouteGroupCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: fwd install rejected: %s", fwdInstAck.Error)
 	}
 
-	// Reverse path install (source-oriented).
-	revInstallPayload, err := cb.BuildInstallMessage(revInject, revSessionID, rulesPerPK)
+	// Reverse path install (source-oriented); route group already introduced.
+	revInstallPayload, err := cb.BuildInstallMessage(revInject, revSessionID, rulesPerPK, routing.RouteDescriptor{})
 	if err != nil {
 		return routing.EdgeRules{}, fmt.Errorf("cascade: build rev install: %w", err)
 	}
@@ -229,11 +229,15 @@ func signInstallCascades(
 
 	rulesPerPK := collectRulesPerPK(fwdRules, revRules, interRules, initEdge, respEdge)
 
-	fwdInstallBytes, err = cb.BuildInstallMessage(biRt.Forward, fwdSessionID, rulesPerPK)
+	// The forward cascade terminates at the responding destination — stamp its
+	// EdgeRules descriptor so it creates a route group (IntroduceRules). The
+	// reverse cascade terminates at the destination too but the route group is
+	// already introduced by the forward terminal, so no edge marking there.
+	fwdInstallBytes, err = cb.BuildInstallMessage(biRt.Forward, fwdSessionID, rulesPerPK, respEdge.Desc)
 	if err != nil {
 		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: build fwd install: %w", err)
 	}
-	revInstallBytes, err = cb.BuildInstallMessage(revInject, revSessionID, rulesPerPK)
+	revInstallBytes, err = cb.BuildInstallMessage(revInject, revSessionID, rulesPerPK, routing.RouteDescriptor{})
 	if err != nil {
 		return nil, nil, routing.EdgeRules{}, fmt.Errorf("cascade: build rev install: %w", err)
 	}

--- a/pkg/router/cascade_source_test.go
+++ b/pkg/router/cascade_source_test.go
@@ -186,7 +186,7 @@ func TestAckRegistry_Dispatch(t *testing.T) {
 // registered handler that must deliver ACKs to the builder's sends).
 func TestSourceBuilderSharesHandlerRegistry(t *testing.T) {
 	localPK, _ := cipher.GenerateKeyPair()
-	ch := NewCascadeHandler(logging.MustGetLogger("test_handler"), localPK, nil, nil, nil)
+	ch := NewCascadeHandler(logging.MustGetLogger("test_handler"), localPK, nil, nil, nil, nil)
 	srcCB := NewSourceCascadeBuilder(logging.MustGetLogger("test_src"), nil, ch.AckRegistry())
 
 	// Builder and handler must observe the same registry instance.
@@ -247,7 +247,7 @@ func TestProcessLocalOrigin_TerminalReserve(t *testing.T) {
 	require.NoError(t, err)
 
 	ch := NewCascadeHandler(logging.MustGetLogger("test_src"), srcPK,
-		[]cipher.PubKey{rsnPK}, routing.NewTable(logging.MustGetLogger("test_rt")), nil)
+		[]cipher.PubKey{rsnPK}, routing.NewTable(logging.MustGetLogger("test_rt")), nil, nil)
 
 	ack, err := ch.ProcessLocalOrigin(payload)
 	require.NoError(t, err)
@@ -263,7 +263,7 @@ func TestProcessLocalOrigin_Rejections(t *testing.T) {
 	otherPK, _ := cipher.GenerateKeyPair()
 	rt := routing.NewTable(logging.MustGetLogger("test_rt"))
 	ch := NewCascadeHandler(logging.MustGetLogger("test_src"), srcPK,
-		[]cipher.PubKey{rsnPK}, rt, nil)
+		[]cipher.PubKey{rsnPK}, rt, nil, nil)
 
 	mk := func(target cipher.PubKey, rsn cipher.PubKey) []byte {
 		msg := &routing.CascadeSetup{
@@ -369,4 +369,55 @@ func TestSourceCascade_BothDirectionsSourceFirst_EndToEnd(t *testing.T) {
 	// Install cascades are also source-first.
 	assertInstallSourceFirst(t, fwdInst, srcFirst)
 	assertInstallSourceFirst(t, revInst, srcFirst)
+}
+
+// TestInstallCascade_EdgeMarkedOnDestinationOnly verifies the route-group fix:
+// the forward install cascade stamps EdgeDesc (= the forward route descriptor)
+// onto the TERMINAL hop only — the responding destination — so that hop calls
+// IntroduceRules (creates a route group); intermediaries and the reverse
+// cascade carry no edge marking. Without this, the destination only installs
+// forwarding rules, never creates a route group, and the source's noise
+// handshake over the route times out.
+func TestInstallCascade_EdgeMarkedOnDestinationOnly(t *testing.T) {
+	cb, _ := rsnBuilder(t)
+	biRt, pkA, pkB, pkC := buildTestBiRoute(t) // A -> B -> C
+	fwdRt, _ := biRt.ForwardAndReverse()
+
+	fwdSession, _, revSession, _, err := signReserveCascades(cb, biRt)
+	require.NoError(t, err)
+	fwdInst, revInst, _, err := signInstallCascades(cb, biRt, fwdSession, revSession,
+		[]routing.RouteID{10, 11, 12}, []routing.RouteID{20, 21, 22})
+	require.NoError(t, err)
+
+	srcFirst := []cipher.PubKey{pkA, pkB, pkC}
+
+	// Forward install: only the terminal (pkC = destination) is an edge.
+	payload := fwdInst
+	for i, target := range srcFirst {
+		cs, err := routing.UnmarshalCascadeSetup(payload)
+		require.NoErrorf(t, err, "fwd install layer %d", i)
+		require.NoError(t, cs.Verify(target))
+		if i == len(srcFirst)-1 {
+			require.True(t, cs.IsEdge(), "destination layer must be an edge")
+			require.Equal(t, fwdRt.Desc, cs.EdgeDesc, "edge desc must be the forward route descriptor")
+			rules, err := routing.DeserializeRules(cs.RuleData)
+			require.NoError(t, err)
+			require.Len(t, rules, 2, "edge carries exactly [Forward, Reverse]")
+		} else {
+			require.Falsef(t, cs.IsEdge(), "intermediary layer %d must not be an edge", i)
+			payload = cs.Payload
+		}
+	}
+
+	// Reverse install: no layer is an edge (route group already introduced).
+	payload = revInst
+	for i, target := range srcFirst {
+		cs, err := routing.UnmarshalCascadeSetup(payload)
+		require.NoErrorf(t, err, "rev install layer %d", i)
+		require.NoError(t, cs.Verify(target))
+		require.Falsef(t, cs.IsEdge(), "reverse install layer %d must not be an edge", i)
+		if i < len(srcFirst)-1 {
+			payload = cs.Payload
+		}
+	}
 }

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -79,7 +79,7 @@ func (r *router) Serve(ctx context.Context) error {
 	for pk := range r.trustedVisors {
 		trustedPKs = append(trustedPKs, pk)
 	}
-	ch := NewCascadeHandler(r.logger, r.conf.PubKey, trustedPKs, r.rt, r.tm)
+	ch := NewCascadeHandler(r.logger, r.conf.PubKey, trustedPKs, r.rt, r.tm, r.IntroduceRules)
 
 	// Source-driven cascade: the visor's route-group dialer owns a send-only
 	// CascadeBuilder that injects RSN-signed cascades down this visor's own

--- a/pkg/routing/cascade.go
+++ b/pkg/routing/cascade.go
@@ -49,11 +49,18 @@ type CascadeSetup struct {
 	SessionID uint64        // correlates reserve/install phases
 	RSNPK     cipher.PubKey // RSN that authorized this setup (33 bytes)
 	Nonce     uint64        // anti-replay, unique per session+hop
-	RSNSig    cipher.Sig    // signature over (Phase||SessionID||RSNPK||Nonce||TargetPK||RuleData)
+	RSNSig    cipher.Sig    // signature over (Phase||SessionID||RSNPK||Nonce||TargetPK||EdgeDesc||RuleData)
 	RuleData  []byte        // serialized routing rules for this hop (empty in Reserve phase)
 	ReserveN  uint8         // number of route IDs to reserve (Reserve phase only)
 	RelayTpID uuid.UUID     // transport to forward Payload on (zero = terminal hop)
-	Payload   []byte        // next hop's CascadeSetup (opaque to this hop)
+	// EdgeDesc, when non-zero, marks this hop as a route-group EDGE (the
+	// responding destination): the hop must call router.IntroduceRules with
+	// EdgeRules{Desc: EdgeDesc, Forward: RuleData[0], Reverse: RuleData[1]} so it
+	// creates/joins a route group (and notifies its launcher) rather than only
+	// installing forwarding rules. Zero on intermediaries (Install phase) and
+	// throughout the Reserve phase.
+	EdgeDesc RouteDescriptor
+	Payload  []byte // next hop's CascadeSetup (opaque to this hop)
 }
 
 // IsTerminal returns true if this is the last hop (no further relay).
@@ -61,7 +68,22 @@ func (cs *CascadeSetup) IsTerminal() bool {
 	return cs.RelayTpID == uuid.Nil
 }
 
+// IsEdge reports whether this Install-phase hop is a route-group edge (the
+// responding destination): EdgeDesc is set, so the hop must IntroduceRules.
+func (cs *CascadeSetup) IsEdge() bool {
+	return cs.EdgeDesc != RouteDescriptor{}
+}
+
 // SignablePayload returns the bytes that are signed/verified.
+//
+// EdgeDesc is deliberately NOT signed: it is appended as optional trailing wire
+// data so that un-upgraded intermediaries (which predate EdgeDesc) still parse
+// and verify the message and relay the inner payload opaquely — cascade then
+// works as soon as the SOURCE and DESTINATION are upgraded, regardless of
+// intermediary versions. EdgeDesc only selects the destination's local action
+// (IntroduceRules vs SaveRule); the rules it acts on ARE signed via RuleData, so
+// a tampered EdgeDesc can at worst break that one route (a relay can already do
+// that by dropping packets), never forge or escalate.
 func (cs *CascadeSetup) SignablePayload(targetPK cipher.PubKey) []byte {
 	// Phase(1) + SessionID(8) + RSNPK(33) + Nonce(8) + TargetPK(33) + RuleData
 	buf := make([]byte, 1+8+33+8+33+len(cs.RuleData))
@@ -99,11 +121,16 @@ func (cs *CascadeSetup) Verify(targetPK cipher.PubKey) error {
 // Wire format:
 //
 //	[Phase:1][SessionID:8][RSNPK:33][Nonce:8][RSNSig:65][ReserveN:1][RelayTpID:16]
-//	[RuleDataLen:2][RuleData:...][PayloadLen:2][Payload:...]
+//	[RuleDataLen:2][RuleData:...][PayloadLen:2][Payload:...][EdgeDesc:70]
+//
+// EdgeDesc is appended LAST as optional trailing data: nodes that predate it
+// parse up to Payload and ignore the trailing bytes (and relay the inner payload
+// — which carries the destination's own trailing EdgeDesc — opaquely), so only
+// the source and destination need to understand it.
 func (cs *CascadeSetup) Marshal() ([]byte, error) {
 	ruleLen := len(cs.RuleData)
 	payloadLen := len(cs.Payload)
-	totalLen := cascadeFixedSize + 2 + ruleLen + 2 + payloadLen
+	totalLen := cascadeFixedSize + 2 + ruleLen + 2 + payloadLen + routeDescriptorSize
 
 	buf := make([]byte, totalLen)
 	off := 0
@@ -131,6 +158,9 @@ func (cs *CascadeSetup) Marshal() ([]byte, error) {
 	binary.BigEndian.PutUint16(buf[off:], uint16(payloadLen)) //nolint:gosec
 	off += 2
 	copy(buf[off:], cs.Payload)
+	off += payloadLen
+
+	copy(buf[off:], cs.EdgeDesc[:])
 
 	return buf, nil
 }
@@ -182,6 +212,13 @@ func UnmarshalCascadeSetup(data []byte) (*CascadeSetup, error) {
 	}
 	cs.Payload = make([]byte, payloadLen)
 	copy(cs.Payload, data[off:off+payloadLen])
+	off += payloadLen
+
+	// EdgeDesc is optional trailing data (see Marshal). Absent on messages from
+	// nodes that predate it — leave it zero (IsEdge()==false) in that case.
+	if off+routeDescriptorSize <= len(data) {
+		copy(cs.EdgeDesc[:], data[off:off+routeDescriptorSize])
+	}
 
 	return cs, nil
 }

--- a/pkg/routing/cascade_test.go
+++ b/pkg/routing/cascade_test.go
@@ -1,0 +1,69 @@
+// Package routing pkg/routing/cascade_test.go
+package routing
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestCascadeSetup_MarshalRoundTrip_WithEdgeDesc verifies EdgeDesc survives a
+// marshal/unmarshal round-trip and that IsEdge reflects it.
+func TestCascadeSetup_MarshalRoundTrip_WithEdgeDesc(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	var desc RouteDescriptor
+	for i := range desc {
+		desc[i] = byte(i + 1)
+	}
+	cs := &CascadeSetup{
+		Phase:     CascadePhaseInstall,
+		SessionID: 7,
+		RSNPK:     pk,
+		Nonce:     3,
+		ReserveN:  0,
+		RelayTpID: uuid.Nil, // terminal
+		RuleData:  []byte{1, 2, 3, 4},
+		EdgeDesc:  desc,
+		Payload:   nil,
+	}
+	b, err := cs.Marshal()
+	require.NoError(t, err)
+
+	got, err := UnmarshalCascadeSetup(b)
+	require.NoError(t, err)
+	assert.Equal(t, desc, got.EdgeDesc)
+	assert.True(t, got.IsEdge())
+	assert.Equal(t, cs.RuleData, got.RuleData)
+	assert.True(t, got.IsTerminal())
+}
+
+// TestCascadeSetup_BackwardCompat_NoTrailingEdgeDesc simulates a message from a
+// node that predates EdgeDesc: the trailing descriptor bytes are absent. The
+// new parser must accept it and leave EdgeDesc zero (IsEdge()==false), proving
+// old intermediaries interoperate with new source/destination.
+func TestCascadeSetup_BackwardCompat_NoTrailingEdgeDesc(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	cs := &CascadeSetup{
+		Phase:     CascadePhaseInstall,
+		SessionID: 9,
+		RSNPK:     pk,
+		Nonce:     1,
+		RelayTpID: uuid.Nil,
+		RuleData:  []byte{9, 9},
+	}
+	b, err := cs.Marshal()
+	require.NoError(t, err)
+
+	// Drop the trailing EdgeDesc to mimic the old wire format.
+	require.Greater(t, len(b), routeDescriptorSize)
+	oldWire := b[:len(b)-routeDescriptorSize]
+
+	got, err := UnmarshalCascadeSetup(oldWire)
+	require.NoError(t, err)
+	assert.False(t, got.IsEdge(), "missing trailing EdgeDesc must parse as non-edge")
+	assert.Equal(t, cs.RuleData, got.RuleData)
+}


### PR DESCRIPTION
## What

The final piece of source-driven cascade route setup. With #3009/#3010 the cascade **control plane** works end-to-end (`Source-driven cascade route setup succeeded`, observed live Gamma→Beta), but mux setup still timed out: the source built its route group and sent a noise handshake over the route, while the **destination had nothing to terminate it**.

## Root cause

The cascade installed forwarding rules on *every* hop via `SaveRule` — treating the destination like an intermediary. The legacy path instead calls `AddEdgeRules → router.IntroduceRules` on the two **edges**, which creates/joins a route group **and notifies the launcher** (`r.accept`). The source edge is already handled (it gets `initEdge` back and the dial path creates its route group); only the **destination** edge was missing — so the source's noise handshake got `no data captured, deadline exceeded` → `setup timeout`.

Confirmed live: Beta's logs showed route groups for *other* peers but none for Gamma during the test.

## Fix

Mark the destination's install layer as an edge and have it call `IntroduceRules`:

- `CascadeSetup` gains an `EdgeDesc` (`RouteDescriptor`). When non-zero on an Install-phase hop, that hop is the responding destination: it calls `router.IntroduceRules(EdgeRules{Desc: EdgeDesc, Forward: RuleData[0], Reverse: RuleData[1]})` — the exact `respEdge` the legacy `AddEdgeRules` delivers — instead of plain `SaveRule`. Stamped only on the forward cascade's terminal.
- `CascadeHandler` gets the router's `IntroduceRules`; `processInstall` branches on `IsEdge()`. `nil` (RSN/tests) falls back to `SaveRule`.

## Backward compatible

`EdgeDesc` is appended as **optional trailing wire data** and is **not signed**. Un-upgraded intermediaries parse up to `Payload`, ignore the trailing bytes, and relay the inner payload (which carries the destination's own `EdgeDesc`) opaquely. So cascade works as soon as the **source and destination** are upgraded, regardless of intermediary versions — important since the route-finder draws intermediaries from the whole network. `EdgeDesc` only selects the destination's local action on **already-signed** rules, so a tampered `EdgeDesc` can at most break that one route (a relay can already drop packets), never forge or escalate.

## Test

- `pkg/routing`: `EdgeDesc` marshal round-trip + old-wire-without-trailing backward-compat.
- `pkg/router`: edge-marked-on-destination-only drives the real sign/build path (forward terminal is an edge with the forward route descriptor; intermediaries and the reverse cascade are not).
- `go build ./...`, `go vet`, `golangci-lint run`, full `pkg/routing` + `pkg/router` suites green.

Follow-up to #3006 / #3008 / #3009 / #3010.
