### PR TITLE
fix(bbolthealth): synchronous integrity walk — recover() can't catch tx.Check()'s goroutine panic

### DIFF
--- a/pkg/util/bbolthealth/repair.go
+++ b/pkg/util/bbolthealth/repair.go
@@ -21,9 +21,9 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// RepairIfCorrupt opens the bbolt file at path (if it exists), runs
-// bbolt's built-in tx.Check() consistency walk, and — if any problem
-// is found — moves the file aside with a timestamped
+// RepairIfCorrupt opens the bbolt file at path (if it exists), runs a
+// synchronous integrity walk of every reachable page, and — if any
+// problem is found — moves the file aside with a timestamped
 // ".corrupt.<unix>" suffix so the subsequent bolt.Open creates a
 // fresh, empty file.
 //
@@ -45,12 +45,14 @@ import (
 // commit-time panics live. The handle is closed immediately so the
 // caller's real open isn't blocked.
 //
-// Both bolt.Open and tx.Check() can themselves panic on certain
-// freelist inconsistencies (e.g. "invalid freelist page: N, page
-// type is leaf" panics from freelist.read during Open). The probe
-// wraps both calls in recover() so a panic during the integrity
-// check is treated as proof of corruption and the file is moved
-// aside, rather than propagating up to crash-loop the caller.
+// Both bolt.Open and the synchronous integrity walk can panic on
+// corruption (freelist inconsistencies like "invalid freelist page:
+// N, page type is leaf" during Open; FastCheck page assertions during
+// the walk). The probe wraps both in recover() so a panic during the
+// integrity check is treated as proof of corruption and the file is
+// moved aside, rather than propagating up to crash-loop the caller.
+// (bbolt's own tx.Check() is unusable here: it scans in an internal
+// goroutine whose panic recover() cannot reach — see probeIntegrity.)
 //
 // Callers that want operator visibility into the repair should
 // snapshot the directory's ".corrupt.<unix>" entries before calling
@@ -69,14 +71,15 @@ func RepairIfCorrupt(path string) error {
 	return nil
 }
 
-// probeIntegrity opens the file, runs tx.Check(), and closes the
-// handle. Returns nil on a clean file. Returns an error describing
-// the failure on any of: open error, integrity-check problem, or
-// panic from inside Open / Check (which bbolt can throw on certain
-// freelist inconsistencies). The recover() block is the load-
-// bearing piece — without it, the freelist-corruption panic in
-// freelist.read would propagate to the caller and crash-loop the
-// visor that bbolthealth was meant to protect.
+// probeIntegrity opens the file, walks every reachable page
+// synchronously, and closes the handle. Returns nil on a clean file.
+// Returns an error describing the failure on any of: open error, walk
+// error, or panic from inside Open / the walk (which bbolt throws on
+// freelist inconsistencies and on FastCheck page-header assertions).
+// The recover() block is the load-bearing piece — and the walk MUST be
+// synchronous (not tx.Check(), which panics in its own goroutine) so
+// that recover() actually catches the corruption panic instead of the
+// visor crash-looping.
 func probeIntegrity(path string) (probeErr error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -102,27 +105,52 @@ func probeIntegrity(path string) (probeErr error) {
 		}
 	}()
 
-	// Collect up to a few problems for diagnostic context. Don't
-	// keep all of them — bbolt's Check can emit hundreds on a badly
-	// damaged file, and the reason field only carries the first one
-	// to the rename-aside message anyway.
-	var problems []error
-	const maxProblemsKept = 5
-	viewErr := db.View(func(tx *bolt.Tx) error {
-		for e := range tx.Check() {
-			if len(problems) < maxProblemsKept {
-				problems = append(problems, e)
-			}
+	// Integrity probe: a SYNCHRONOUS full walk of every reachable b-tree page.
+	//
+	// We deliberately do NOT use bbolt's tx.Check(): it runs its consistency
+	// scan in an internal goroutine (`go tx.check(ch)`), so a page-assertion
+	// panic — e.g. bbolt v1.4.x FastCheck "Page expected to be: N, but self
+	// identifies as 0" on an SD-card-corrupted file — fires in THAT goroutine,
+	// which no caller-side recover() can reach. That defeated probeIntegrity's
+	// recover() entirely and crash-looped the visor (the very thing
+	// bbolthealth exists to prevent).
+	//
+	// Instead we cursor-walk all buckets and keys ourselves. Every page access
+	// goes through tx.page(), which runs the same FastCheck — but now
+	// synchronously, in THIS goroutine, where the deferred recover() above
+	// converts the panic into a corruption verdict and moves the file aside.
+	// Combined with the writable Open above (which surfaces freelist
+	// corruption synchronously), this covers the corruption modes that
+	// actually crash a visor at access time.
+	if viewErr := db.View(walkAllPages); viewErr != nil {
+		return fmt.Errorf("integrity walk: %w", viewErr)
+	}
+	return nil
+}
+
+// walkAllPages forces synchronous access to every reachable b-tree page by
+// cursoring over all buckets (recursing into nested buckets) and all keys. A
+// corrupt page panics inside tx.page()'s FastCheck during this walk — in the
+// caller's goroutine, so probeIntegrity's recover() catches it.
+func walkAllPages(tx *bolt.Tx) error {
+	return tx.ForEach(func(_ []byte, b *bolt.Bucket) error {
+		return walkBucket(b)
+	})
+}
+
+// walkBucket cursors over every key in b, recursing into nested buckets so the
+// whole sub-tree's pages are touched.
+func walkBucket(b *bolt.Bucket) error {
+	return b.ForEach(func(k, v []byte) error {
+		if v != nil {
+			return nil // plain key — its leaf page was already read
+		}
+		// A nil value marks a nested bucket; descend to touch its pages.
+		if sub := b.Bucket(k); sub != nil {
+			return walkBucket(sub)
 		}
 		return nil
 	})
-	if viewErr != nil {
-		return fmt.Errorf("check view: %w", viewErr)
-	}
-	if len(problems) > 0 {
-		return fmt.Errorf("bbolt check found %d problems (first: %v)", len(problems), problems[0])
-	}
-	return nil
 }
 
 // moveCorruptAside renames the bbolt file at path to

--- a/pkg/util/bbolthealth/repair_test.go
+++ b/pkg/util/bbolthealth/repair_test.go
@@ -1,6 +1,7 @@
 package bbolthealth
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,5 +150,94 @@ func TestRepairIfCorrupt_IsIdempotentOnRepair(t *testing.T) {
 	}
 	if err := RepairIfCorrupt(path); err != nil {
 		t.Fatalf("second repair (path absent now): %v", err)
+	}
+}
+
+// TestRepairIfCorrupt_SyncWalkCatchesPageCorruption reproduces the production
+// crash: a bbolt file with a corrupted b-tree page header (page id zeroed,
+// yielding bbolt's "Page expected to be: N, but self identifies as 0" FastCheck
+// panic). The old probe used tx.Check(), which panics in an internal goroutine
+// that recover() can't reach — so the visor crash-looped. The synchronous walk
+// hits the same FastCheck in the caller's goroutine, where recover() converts
+// it into a corruption verdict and the file is moved aside. If this test panics
+// instead of passing, the regression is back.
+func TestRepairIfCorrupt_SyncWalkCatchesPageCorruption(t *testing.T) {
+	const pageSize = 4096
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.db")
+
+	db, err := bolt.Open(path, 0600, &bolt.Options{Timeout: time.Second, PageSize: pageSize})
+	if err != nil {
+		t.Fatalf("create bbolt: %v", err)
+	}
+	// Write enough keys (plus a nested bucket) to span many leaf/branch pages.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, e := tx.CreateBucketIfNotExists([]byte("data"))
+		if e != nil {
+			return e
+		}
+		val := make([]byte, 256)
+		for i := 0; i < 800; i++ {
+			if e := b.Put([]byte(fmt.Sprintf("key-%06d", i)), val); e != nil {
+				return e
+			}
+		}
+		nb, e := b.CreateBucketIfNotExists([]byte("nested"))
+		if e != nil {
+			return e
+		}
+		return nb.Put([]byte("nk"), []byte("nv"))
+	}); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Zero the page-id header (first 8 bytes) of every page from index 4 to the
+	// end, preserving the meta (0,1) and freelist pages so bolt.Open succeeds
+	// and the corruption is hit during the b-tree WALK (the fixed path).
+	f, err := os.OpenFile(path, os.O_RDWR, 0600) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatalf("open for corruption: %v", err)
+	}
+	fi, statErr := f.Stat()
+	if statErr != nil {
+		t.Fatalf("stat: %v", statErr)
+	}
+	zeros := make([]byte, 8)
+	corrupted := 0
+	for off := int64(4 * pageSize); off+8 <= fi.Size(); off += pageSize {
+		if _, e := f.WriteAt(zeros, off); e != nil {
+			t.Fatalf("corrupt at %d: %v", off, e)
+		}
+		corrupted++
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close corrupt file: %v", err)
+	}
+	if corrupted == 0 {
+		t.Skip("db too small to corrupt interior pages")
+	}
+
+	// Must NOT crash; must move the file aside and return nil.
+	if err := RepairIfCorrupt(path); err != nil {
+		t.Fatalf("RepairIfCorrupt returned error: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("corrupt file should have been moved aside; still present (err=%v)", err)
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("readdir: %v", readErr)
+	}
+	movedAside := false
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".corrupt.") {
+			movedAside = true
+		}
+	}
+	if !movedAside {
+		t.Errorf("expected a .corrupt.<ts> sibling after repair; dir=%v", entries)
 	}
 }


### PR DESCRIPTION
## What

Fix a visor crash-loop from bbolt database corruption — reported on an ARM SBC running v1.3.64:

```
panic: assertion failed: Page expected to be: 185, but self identifies as 0
go.etcd.io/bbolt/internal/common.(*Page).FastCheck ...
go.etcd.io/bbolt.(*Tx).Check.func1()
created by go.etcd.io/bbolt.(*Tx).Check in goroutine 128
```

## Root cause

`bbolthealth.RepairIfCorrupt` (the central defense for every visor bbolt open — CXO cxds/idxdb, visor stats, serviceuptime, app log stores, clicache, usermanager, skychat) probes a file by running bbolt's `tx.Check()` inside a `recover()`, treating a panic as proof of corruption and moving the file aside.

But **`tx.Check()` runs its scan in an internal goroutine** (`go tx.check(ch)`). bbolt v1.4.x's `FastCheck` page-header assertion therefore panics in *that* goroutine, which **no caller-side `recover()` can reach**. So the recover was dead for this corruption class and the visor crash-looped — the exact outcome bbolthealth exists to prevent. SD-card-backed SBCs corrupt their DB on unclean shutdown, so this hits real deployments (and the existing `.corrupt.*` files on my own node confirm corruption happens in practice).

## Fix

Replace `tx.Check()` with a **synchronous** full walk of every reachable b-tree page — cursor over all buckets and keys, recursing into nested buckets. Every page access goes through `tx.page()`, which runs the same `FastCheck` — but now in the **caller's** goroutine, where the existing `recover()` catches it and moves the file aside. Combined with the writable `Open` (which surfaces freelist corruption synchronously), this covers the corruption modes that crash a visor at access time, without bbolt's unrecoverable checking goroutine.

`probeIntegrity` is the only `tx.Check()` caller, so this fixes every `RepairIfCorrupt` consumer at once.

## Validation

- **New test** corrupts a real bbolt file's page headers (reproducing the exact `self identifies as 0` panic) and asserts `RepairIfCorrupt` recovers + moves the file aside instead of crashing. (With the old code this test would crash the test binary.)
- Existing healthy / garbage / open-panic / idempotent tests still pass.
- Ran the new probe against **all six real local visor stores** — including the 193 MB CXO content store with deep nested buckets — all pass with **no false-positive**.
- `go build`, `go vet`, `golangci-lint run`, full `pkg/util/bbolthealth` suite green.
