### PR TITLE
feat(skychat): `cli skychat events` — structured NDJSON event stream

### DIFF
--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -11,7 +11,6 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -288,19 +287,15 @@ func surfaceCXOInbound(senderPK, text string) {
 	lastRxAt = time.Now().UTC()
 	counterMu.Unlock()
 
-	clientMsg, err := json.Marshal(map[string]interface{}{
-		"sender":  senderPK,
-		"message": text,
-		"network": "cxo",
-		"dir":     "in",
-		"id":      newEventID(),
-		"len":     len(text),
+	hub.publishEvent(chatEvent{
+		ID:        newEventID(),
+		Channel:   channelGroup,
+		Transport: "cxo",
+		Dir:       "in",
+		From:      senderPK,
+		GroupID:   cxoGroup,
+		Text:      text,
 	})
-	if err != nil {
-		appLog("skychat: cxo inbound marshal failed: %v", err)
-		return
-	}
-	hub.broadcast(string(clientMsg))
 }
 
 // parseCXOPeer parses "tcp://<feedpk>@<host:port>".

--- a/cmd/apps/skychat/commands/events_hub_test.go
+++ b/cmd/apps/skychat/commands/events_hub_test.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func drainSeqs(ch <-chan chatEvent) []uint64 {
+	var got []uint64
+	for {
+		select {
+		case ev := <-ch:
+			got = append(got, ev.Seq)
+		case <-time.After(20 * time.Millisecond):
+			return got
+		}
+	}
+}
+
+func TestHub_RecordEvent_AssignsMonotonicSeq(t *testing.T) {
+	h := newSSEHub()
+	for i := 0; i < 3; i++ {
+		h.recordEvent(chatEvent{ID: fmt.Sprintf("id%d", i), Channel: channelDM, Text: "x"})
+	}
+	if h.seq != 3 {
+		t.Fatalf("seq=%d want 3", h.seq)
+	}
+}
+
+func TestHub_SubscribeEvents_ReplaysSinceCursor(t *testing.T) {
+	h := newSSEHub()
+	for i := 0; i < 4; i++ {
+		h.recordEvent(chatEvent{ID: fmt.Sprintf("id%d", i), Channel: channelDM})
+	}
+	// since=2 → replay seq 3,4 only
+	ch, unsub := h.subscribeEvents(nil, 2)
+	defer unsub()
+	got := drainSeqs(ch)
+	if len(got) != 2 || got[0] != 3 || got[1] != 4 {
+		t.Fatalf("replay since=2 got %v want [3 4]", got)
+	}
+}
+
+func TestHub_DefaultExcludesSystem_OptInIncludes(t *testing.T) {
+	h := newSSEHub()
+	h.recordEvent(chatEvent{ID: "dm", Channel: channelDM})
+	h.recordEvent(chatEvent{ID: "sys", Channel: channelSystem})
+	h.recordEvent(chatEvent{ID: "grp", Channel: channelGroup})
+
+	// Default (nil) = dm+group+pair, NOT system.
+	def, unsub1 := h.subscribeEvents(nil, 0)
+	defer unsub1()
+	if got := len(drainSeqs(def)); got != 2 {
+		t.Fatalf("default replay got %d events want 2 (dm+group, no system)", got)
+	}
+
+	// Opt into system explicitly.
+	sys, unsub2 := h.subscribeEvents(map[string]bool{channelSystem: true}, 0)
+	defer unsub2()
+	if got := drainSeqs(sys); len(got) != 1 {
+		t.Fatalf("system-only replay got %v want 1", got)
+	}
+}
+
+func TestHub_LiveFanoutRespectsChannelFilter(t *testing.T) {
+	h := newSSEHub()
+	sys, unsub := h.subscribeEvents(map[string]bool{channelSystem: true}, 0)
+	defer unsub()
+	h.recordEvent(chatEvent{ID: "dm", Channel: channelDM})      // filtered out
+	h.recordEvent(chatEvent{ID: "sys", Channel: channelSystem}) // delivered
+	got := drainSeqs(sys)
+	if len(got) != 1 {
+		t.Fatalf("live system sub got %v want exactly the system event", got)
+	}
+}
+
+func TestParseEventChannels(t *testing.T) {
+	if parseEventChannels("") != nil {
+		t.Error(`"" should be nil (default)`)
+	}
+	if parseEventChannels("all") != nil {
+		t.Error(`"all" should be nil (default)`)
+	}
+	sys := parseEventChannels("system")
+	if sys == nil || !sys[channelSystem] || sys[channelDM] {
+		t.Errorf(`"system" got %v want {system}`, sys)
+	}
+	mix := parseEventChannels("all,system")
+	for _, c := range []string{channelDM, channelGroup, channelPair, channelSystem} {
+		if !mix[c] {
+			t.Errorf(`"all,system" missing %s in %v`, c, mix)
+		}
+	}
+}
+
+func TestRenderLegacySSE_BackcompatShape(t *testing.T) {
+	s := renderLegacySSE(chatEvent{From: "alice", Text: "hi", Transport: "dmsg", Dir: "in", ID: "x", Len: 2})
+	for _, want := range []string{`"sender":"alice"`, `"message":"hi"`, `"network":"dmsg"`, `"dir":"in"`, `"id":"x"`, `"len":2`} {
+		if !contains(s, want) {
+			t.Errorf("legacy SSE %s missing %s", s, want)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -138,6 +138,16 @@ func notifyInviteSSE(peerPK cipher.PubKey, kind string) {
 		return
 	}
 	hub.broadcast(string(body))
+	// Also surface on the structured /events stream's "pair" channel,
+	// keeping the legacy /sse control-envelope above untouched.
+	hub.recordEvent(chatEvent{
+		ID:        newEventID(),
+		Channel:   channelPair,
+		Transport: "pair",
+		Dir:       "in",
+		From:      peerPK.Hex(),
+		Text:      kind, // received | accepted | declined
+	})
 }
 
 // connectPairRPC dials the local visor's RPC and stores the client
@@ -210,6 +220,14 @@ func startPairPoller(parent context.Context) {
 					continue
 				}
 				hub.broadcast(string(body))
+				hub.recordEvent(chatEvent{
+					ID:        newEventID(),
+					Channel:   channelPair,
+					Transport: "pair",
+					Dir:       "in",
+					From:      m.PeerPK.Hex(),
+					Text:      m.Text,
+				})
 			}
 		}
 	}()

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -458,12 +458,75 @@ type sseHub struct {
 	replay     []string
 	replayHead int
 	replayLen  int
+
+	// Structured event stream backing GET /events (cli skychat events).
+	// Each published event gets a monotonic seq; the ring keeps the last
+	// eventRingSize events (also bounded by eventTTL on replay) so a
+	// reconnecting consumer resumes from its last seq via ?since=. Separate
+	// from the legacy string replay above so /sse stays byte-for-byte
+	// unchanged.
+	seq        uint64
+	events     []chatEvent
+	eventsHead int
+	eventsLen  int
+	eventSubs  map[*eventSub]struct{}
+}
+
+// chatEvent is the structured form of a chat event, streamed as NDJSON by
+// GET /events. Agreed schema (Beta+Gamma consensus): seq cursor + id-keyed
+// dedupe, channel taxonomy, in/out direction.
+type chatEvent struct {
+	Seq       uint64    `json:"seq"`
+	ID        string    `json:"id"`
+	TS        time.Time `json:"ts"`
+	Channel   string    `json:"channel"`   // dm|group|pair|system
+	Transport string    `json:"transport"` // skynet|dmsg|cxo|tcp-direct
+	Dir       string    `json:"dir"`       // in|out
+	From      string    `json:"from,omitempty"`
+	To        string    `json:"to,omitempty"`
+	GroupID   string    `json:"group_id,omitempty"`
+	Text      string    `json:"text"`
+	ReplyToID string    `json:"reply_to_id,omitempty"`
+	Len       int       `json:"len"`
+}
+
+// eventSub is a /events subscriber: a buffered channel plus the set of
+// channels it wants (nil = the default dm+group+pair set).
+type eventSub struct {
+	ch       chan chatEvent
+	channels map[string]bool
+}
+
+const (
+	// eventRingSize bounds the structured-event replay ring.
+	eventRingSize = 10000
+	// eventTTL bounds replay age — events older than this are not replayed
+	// even if still in the ring (the 24h window from the agreed design).
+	eventTTL = 24 * time.Hour
+	// eventSubBufSize is the per-/events-client buffer depth.
+	eventSubBufSize = 256
+)
+
+// Channel taxonomy.
+const (
+	channelDM     = "dm"
+	channelGroup  = "group"
+	channelPair   = "pair"
+	channelSystem = "system"
+)
+
+// defaultEventChannels is what `--channel all` (or no filter) resolves to:
+// dm+group+pair. "system" is opt-in only.
+func defaultEventChannels() map[string]bool {
+	return map[string]bool{channelDM: true, channelGroup: true, channelPair: true}
 }
 
 func newSSEHub() *sseHub {
 	return &sseHub{
-		clients: make(map[chan string]struct{}),
-		replay:  make([]string, sseReplayBufSize),
+		clients:   make(map[chan string]struct{}),
+		replay:    make([]string, sseReplayBufSize),
+		events:    make([]chatEvent, eventRingSize),
+		eventSubs: make(map[*eventSub]struct{}),
 	}
 }
 
@@ -561,6 +624,162 @@ func (h *sseHub) broadcast(msg string) {
 		sseDropCount += drops
 		counterMu.Unlock()
 	}
+}
+
+// recordEvent assigns the monotonic seq + timestamp, stores the event in the
+// structured ring, and fans it out to /events subscribers (channel-filtered).
+// It does NOT touch the legacy /sse stream — callers that also want /sse
+// either use publishEvent (chat messages) or keep their own hub.broadcast call
+// (pairing, which has its own /sse control-event shape).
+func (h *sseHub) recordEvent(ev chatEvent) {
+	if ev.Len == 0 {
+		ev.Len = len(ev.Text)
+	}
+	if ev.Channel == "" {
+		ev.Channel = channelDM
+	}
+
+	h.mu.Lock()
+	h.seq++
+	ev.Seq = h.seq
+	if ev.TS.IsZero() {
+		ev.TS = time.Now().UTC()
+	}
+	h.events[h.eventsHead] = ev
+	h.eventsHead = (h.eventsHead + 1) % len(h.events)
+	if h.eventsLen < len(h.events) {
+		h.eventsLen++
+	}
+	for sub := range h.eventSubs {
+		if !sub.channels[ev.Channel] {
+			continue
+		}
+		select {
+		case sub.ch <- ev:
+		default: // slow consumer — recoverable via ?since= on reconnect
+		}
+	}
+	h.mu.Unlock()
+}
+
+// publishEvent records a chat-message event for /events AND renders the legacy
+// SSE JSON into the unchanged /sse path — one call reaches both surfaces in
+// order. Use for chat messages (dm/group); pairing uses recordEvent + its own
+// broadcast.
+func (h *sseHub) publishEvent(ev chatEvent) {
+	if ev.Len == 0 {
+		ev.Len = len(ev.Text)
+	}
+	if ev.Channel == "" {
+		ev.Channel = channelDM
+	}
+	h.recordEvent(ev)
+	h.broadcast(renderLegacySSE(ev))
+}
+
+// renderLegacySSE renders a chatEvent into the historical /sse JSON shape
+// {sender, message, network, dir, id, len, [to]} so existing /sse consumers
+// (incl. `cli skychat listen`) are unaffected by the richer /events schema.
+func renderLegacySSE(ev chatEvent) string {
+	m := map[string]interface{}{
+		"sender":  ev.From,
+		"message": ev.Text,
+		"network": ev.Transport,
+		"dir":     ev.Dir,
+		"id":      ev.ID,
+		"len":     ev.Len,
+	}
+	if ev.To != "" {
+		m["to"] = ev.To
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// subscribeEvents registers a /events subscriber that wants the given channels
+// (nil = the default dm+group+pair set) and replays buffered events with
+// seq > since (within eventTTL) before live-following. Returns the channel and
+// an unsubscribe func the caller MUST invoke.
+func (h *sseHub) subscribeEvents(channels map[string]bool, since uint64) (<-chan chatEvent, func()) {
+	// Resolve nil ("default") to the dm+group+pair set so system stays opt-in
+	// and the fan-out/replay filters can assume a concrete set.
+	if channels == nil {
+		channels = defaultEventChannels()
+	}
+	sub := &eventSub{ch: make(chan chatEvent, eventSubBufSize), channels: channels}
+	h.mu.Lock()
+	if h.eventsLen > 0 {
+		start := (h.eventsHead - h.eventsLen + len(h.events)) % len(h.events)
+	replay:
+		for i := 0; i < h.eventsLen; i++ {
+			ev := h.events[(start+i)%len(h.events)]
+			if ev.Seq <= since {
+				continue
+			}
+			if !channels[ev.Channel] {
+				continue
+			}
+			if time.Since(ev.TS) > eventTTL {
+				continue
+			}
+			select {
+			case sub.ch <- ev:
+			default:
+				break replay // buffer full; remainder recoverable via ?since=
+			}
+		}
+	}
+	h.eventSubs[sub] = struct{}{}
+	h.mu.Unlock()
+	return sub.ch, func() {
+		h.mu.Lock()
+		if _, ok := h.eventSubs[sub]; ok {
+			delete(h.eventSubs, sub)
+			close(sub.ch)
+		}
+		h.mu.Unlock()
+	}
+}
+
+// parseEventChannels turns a comma-separated channel list into a set. Empty or
+// "all" → the default dm+group+pair set. "all" combined with extras (e.g.
+// "all,system") expands "all" then unions the extras. Unknown tokens are
+// ignored. Returns nil only for the pure-default case so callers can treat nil
+// as "default set" cheaply.
+func parseEventChannels(csv string) map[string]bool {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil
+	}
+	set := make(map[string]bool)
+	onlyAll := true
+	for _, tok := range strings.Split(csv, ",") {
+		switch strings.ToLower(strings.TrimSpace(tok)) {
+		case "", "all":
+			for c := range defaultEventChannels() {
+				set[c] = true
+			}
+		case channelDM:
+			set[channelDM] = true
+			onlyAll = false
+		case channelGroup:
+			set[channelGroup] = true
+			onlyAll = false
+		case channelPair:
+			set[channelPair] = true
+			onlyAll = false
+		case channelSystem:
+			set[channelSystem] = true
+			onlyAll = false
+		}
+	}
+	if len(set) == 0 || onlyAll {
+		return nil // pure default
+	}
+	return set
 }
 
 func init() {
@@ -801,6 +1020,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 	mux.Handle("/", requireAuth(http.FileServer(getFileSystem())))
 	mux.HandleFunc("/message", requireAuthFunc(messageHandler(ctx)))
 	mux.HandleFunc("/sse", requireAuthFunc(sseHandler))
+	mux.HandleFunc("/events", requireAuthFunc(eventsHandler))
 	mux.HandleFunc("/history", requireAuthFunc(historyHandler))
 	mux.HandleFunc("/history/peers", requireAuthFunc(historyPeersHandler))
 	mux.HandleFunc("/status", requireAuthFunc(statusHandler))
@@ -982,18 +1202,14 @@ func handleConn(conn *framedConn) {
 		// so consumers can already use it for log correlation / dedup.
 		// "len" is the body byte length, surfaced for size-debug
 		// without forcing consumers to count after a json round-trip.
-		clientMsg, err := json.Marshal(map[string]interface{}{
-			"sender":  peerPK,
-			"message": text,
-			"network": string(raddr.Net),
-			"dir":     "in",
-			"id":      newEventID(),
-			"len":     len(text),
+		hub.publishEvent(chatEvent{
+			ID:        newEventID(),
+			Channel:   channelDM,
+			Transport: string(raddr.Net),
+			Dir:       "in",
+			From:      peerPK,
+			Text:      text,
 		})
-		if err != nil {
-			appLog("Failed to marshal json: %v", err)
-		}
-		hub.broadcast(string(clientMsg))
 	}
 }
 
@@ -1058,17 +1274,17 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			cxoMu.Lock()
 			myPK := cxoMyPK
 			cxoMu.Unlock()
-			outMsg, _ := json.Marshal(map[string]interface{}{ //nolint:errcheck
-				"sender":    myPK.Hex(),
-				"recipient": data.Recipient,
-				"message":   data.Message,
-				"network":   "cxo",
-				"dir":       "out",
-				"id":        newEventID(),
-				"len":       len(data.Message),
-				"path":      path,
+			_ = path
+			hub.publishEvent(chatEvent{
+				ID:        newEventID(),
+				Channel:   channelGroup,
+				Transport: "cxo",
+				Dir:       "out",
+				From:      myPK.Hex(),
+				To:        data.Recipient,
+				GroupID:   cxoGroup,
+				Text:      data.Message,
 			})
-			hub.broadcast(string(outMsg))
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"ok":true,"network":"cxo"}`)) //nolint:errcheck,gosec
 			return
@@ -1347,18 +1563,15 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 		if mirrorID == "" {
 			mirrorID = newEventID()
 		}
-		mirrorMsg, mErr := json.Marshal(map[string]interface{}{
-			"sender":  myPK,
-			"to":      pk.Hex(),
-			"message": data.Message,
-			"network": string(netType),
-			"dir":     "out",
-			"id":      mirrorID,
-			"len":     len(data.Message),
+		hub.publishEvent(chatEvent{
+			ID:        mirrorID,
+			Channel:   channelDM,
+			Transport: string(netType),
+			Dir:       "out",
+			From:      myPK,
+			To:        pk.Hex(),
+			Text:      data.Message,
 		})
-		if mErr == nil {
-			hub.broadcast(string(mirrorMsg))
-		}
 
 		counterMu.Lock()
 		outboundMsgCount++
@@ -1468,6 +1681,83 @@ func sseHandler(w http.ResponseWriter, req *http.Request) {
 
 		case <-req.Context().Done():
 			chatLog.Debug("SSE connection was closed.")
+			return
+		}
+	}
+}
+
+// eventsHandler is the structured event stream backing `cli skychat events`.
+// It is SSE (text/event-stream) with one NDJSON chatEvent per `data:` line.
+//
+//	GET /events?channel=<csv>&since=<seq>
+//
+// channel: comma-separated dm|group|pair|system|all (default/empty/all =
+//
+//	dm+group+pair; "system" is opt-in). since: resume after this seq (replay
+//	buffered events with seq>since within the 24h window, then live-follow).
+func eventsHandler(w http.ResponseWriter, req *http.Request) {
+	f, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported!", http.StatusBadRequest)
+		return
+	}
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		chatLog.Debugf("events SetWriteDeadline: %v", err)
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	channels := parseEventChannels(req.URL.Query().Get("channel"))
+	var since uint64
+	if v := req.URL.Query().Get("since"); v != "" {
+		if _, err := fmt.Sscanf(v, "%d", &since); err != nil {
+			http.Error(w, "invalid since", http.StatusBadRequest)
+			return
+		}
+	}
+
+	ch, unsubscribe := hub.subscribeEvents(channels, since)
+	defer unsubscribe()
+
+	if _, err := fmt.Fprint(w, ": connected\n\n"); err != nil {
+		chatLog.Debugf("events initial keepalive write failed: %v", err)
+		return
+	}
+	f.Flush()
+
+	keepalive := time.NewTicker(sseKeepaliveInterval)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			b, err := json.Marshal(ev)
+			if err != nil {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", b); err != nil {
+				chatLog.Debugf("events write failed, dropping subscriber: %v", err)
+				return
+			}
+			f.Flush()
+
+		case <-keepalive.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				chatLog.Debugf("events keepalive write failed: %v", err)
+				return
+			}
+			f.Flush()
+
+		case <-req.Context().Done():
+			chatLog.Debug("events connection was closed.")
 			return
 		}
 	}

--- a/cmd/skywire-cli/commands/skychat/events.go
+++ b/cmd/skywire-cli/commands/skychat/events.go
@@ -1,0 +1,195 @@
+// Package skychat — events.go: `skywire cli skychat events`, a structured
+// NDJSON stream of chat events from the chat app's GET /events SSE endpoint.
+//
+// Replaces fragile `tail -F | awk | grep` log monitors (which broke under
+// logrotate copytruncate). Each event carries a monotonic seq cursor; on
+// reconnect the CLI resends --since=<last seq> so no events are missed, and
+// dedupes by id. Agreed schema (Beta+Gamma consensus).
+package cliskychat
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+)
+
+var (
+	eventsChannel string
+	eventsSince   uint64
+)
+
+func init() {
+	eventsCmd.Flags().StringVar(&eventsChannel, "channel", "",
+		"comma-separated channels: dm,group,pair,system,all (default/all = dm+group+pair; system is opt-in)")
+	eventsCmd.Flags().Uint64Var(&eventsSince, "since", 0,
+		"resume after this seq cursor (0 = from the start of the server's buffer)")
+}
+
+// cliChatEvent mirrors the chat app's chatEvent NDJSON shape.
+type cliChatEvent struct {
+	Seq       uint64    `json:"seq"`
+	ID        string    `json:"id"`
+	TS        time.Time `json:"ts"`
+	Channel   string    `json:"channel"`
+	Transport string    `json:"transport"`
+	Dir       string    `json:"dir"`
+	From      string    `json:"from,omitempty"`
+	To        string    `json:"to,omitempty"`
+	GroupID   string    `json:"group_id,omitempty"`
+	Text      string    `json:"text"`
+	ReplyToID string    `json:"reply_to_id,omitempty"`
+	Len       int       `json:"len"`
+}
+
+var eventsCmd = &cobra.Command{
+	Use:   "events",
+	Short: "Stream structured chat events (NDJSON) from the chat app",
+	Long: `Stream the chat app's structured event feed, one NDJSON event per line:
+  {"seq","id","ts","channel","transport","dir","from","to","group_id","text","reply_to_id","len"}
+
+Lossless resume: each event carries a monotonic seq; on reconnect the CLI
+resends --since=<last seq> so no events are missed, and dedupes by id.
+Channels: dm | group | pair | system | all (default/all = dm+group+pair;
+"system" is opt-in). This replaces fragile log-file tailing.`,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, _ []string) {
+		out := cmd.OutOrStdout()
+		errOut := cmd.ErrOrStderr()
+		jsonMode, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		lastSeq := eventsSince
+		seen := newIDDedupe(20000)
+		delay := minReconnectDelay
+
+		for {
+			err := streamEventsOnce(ctx, out, jsonMode, eventsChannel, &lastSeq, seen)
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(errOut, "events stream error: %v; reconnecting in %s (since=%d)\n", err, delay, lastSeq) //nolint:errcheck
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(delay):
+				}
+				if delay < maxReconnectDelay {
+					delay *= 2
+				}
+				continue
+			}
+			// Clean server close — reconnect promptly from where we left off.
+			delay = minReconnectDelay
+		}
+	},
+}
+
+// streamEventsOnce opens one /events stream from since=*lastSeq and pumps
+// events to out until the stream ends or errors. It advances *lastSeq to the
+// highest seq seen so a reconnect resumes losslessly, and skips ids already
+// emitted. Returns nil on a clean server-side close.
+func streamEventsOnce(ctx context.Context, out io.Writer, jsonMode bool, channel string, lastSeq *uint64, seen *idDedupe) error {
+	url := fmt.Sprintf("http://%s/events?since=%d", httpAddr, *lastSeq)
+	if channel != "" {
+		url += "&channel=" + channel
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("chat app /events: HTTP %s", resp.Status)
+	}
+
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue // ": ping"/": connected" keepalives and blank lines
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		var ev cliChatEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			continue
+		}
+		if ev.Seq > *lastSeq {
+			*lastSeq = ev.Seq
+		}
+		if ev.ID != "" {
+			if seen.has(ev.ID) {
+				continue
+			}
+			seen.add(ev.ID)
+		}
+		if jsonMode {
+			fmt.Fprintln(out, payload) //nolint:errcheck // pass the NDJSON through verbatim
+			continue
+		}
+		fmt.Fprintln(out, formatEvent(ev)) //nolint:errcheck
+	}
+	return sc.Err()
+}
+
+// formatEvent renders a human one-liner for non-JSON mode.
+func formatEvent(ev cliChatEvent) string {
+	ts := ev.TS.Local().Format("15:04:05")
+	who := shortPK(ev.From)
+	if ev.Dir == "out" && ev.To != "" {
+		who = shortPK(ev.From) + "→" + shortPK(ev.To)
+	}
+	scope := ev.Channel
+	if ev.GroupID != "" {
+		scope = ev.Channel + ":" + ev.GroupID
+	}
+	return fmt.Sprintf("[%s] #%d %-6s %-3s %s  %s", ts, ev.Seq, scope, ev.Dir, who, ev.Text)
+}
+
+// idDedupe is a bounded id-seen set: insertion-ordered, evicting the oldest
+// half when it exceeds cap. Cheap and good enough — the server's seq-based
+// replay already prevents most duplicates; this guards the reconnect boundary.
+type idDedupe struct {
+	set   map[string]struct{}
+	order []string
+	cap   int
+}
+
+func newIDDedupe(capacity int) *idDedupe {
+	return &idDedupe{set: make(map[string]struct{}, capacity), cap: capacity}
+}
+
+func (d *idDedupe) has(id string) bool {
+	_, ok := d.set[id]
+	return ok
+}
+
+func (d *idDedupe) add(id string) {
+	d.set[id] = struct{}{}
+	d.order = append(d.order, id)
+	if len(d.order) > d.cap {
+		drop := d.cap / 2
+		for _, old := range d.order[:drop] {
+			delete(d.set, old)
+		}
+		d.order = append(d.order[:0], d.order[drop:]...)
+	}
+}

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -52,6 +52,7 @@ func init() {
 	RootCmd.AddCommand(
 		sendCmd,
 		listenCmd,
+		eventsCmd,
 		chatCmd,
 		historyCmd,
 		statusCmd,


### PR DESCRIPTION
## What

Adds **`skywire cli skychat events`** — a structured, resumable NDJSON event stream — to replace the fragile `tail -F | awk | grep` log monitors (which broke under logrotate copytruncate). Implements the Beta+Gamma agent design consensus.

## Server (`cmd/apps/skychat`)

- `chatEvent` struct + a **monotonic `seq`** assigned per event, stored in a 10k-deep ring (also bounded by a **24h TTL** on replay), backing a new SSE endpoint: **`GET /events?channel=<csv>&since=<seq>`**.
- `hub.recordEvent` (structured ring + channel-filtered fan-out) and `hub.publishEvent` (= `recordEvent` + the legacy `/sse` render). **`/sse` and `cli skychat listen` are byte-for-byte unchanged** — every chat broadcast now routes through `publishEvent`, which still emits the historical `{sender,message,network,dir,id,len}` shape to `/sse`. (No consumer depended on the dropped CXO-only `path`/`recipient` fields — verified.)
- **Channel taxonomy** `dm|group|pair|system`: dm (p2p in/out), group (CXO feed in/out), pair (pairing events). `--channel all`/default = `dm+group+pair`; **`system` is opt-in**. `since` replays `seq>since` within the 24h window, then live-follows.

## CLI (`cmd/skywire-cli`)

`skywire cli skychat events [--channel dm|group|pair|system|all] [--since <seq>] [--json]` — streams NDJSON, dedupes by id, and **resumes losslessly** across reconnects by resending `--since=<last seq>`.

## Schema

`{seq, id, ts, channel, transport, dir, from, to, group_id, text, reply_to_id, len}` (`reply_to_id` reserved for future threading).

## Validation (local, end-to-end)

- **Unit tests** (`events_hub_test.go`): monotonic seq; `since`-cursor replay; **default excludes `system`** / opt-in includes it; live channel-filter fan-out; legacy-`/sse`-shape backcompat.
- **Live standalone chat app**: `POST /message` produced the exact agreed NDJSON on `/events`; `channel=dm` correctly **excluded** a group event; the CLI rendered both human and JSON forms.
- `go build`/`vet`, `golangci-lint`, package tests all green.

Closes the roadmap's "skychat comms upgrade" item.
