### PR TITLE
feat(cxo): pk-as-identity for the standalone `cxo daemon`/`cxo cli`

### DIFF
--- a/cmd/cxo/commands/cli.go
+++ b/cmd/cxo/commands/cli.go
@@ -191,37 +191,37 @@ func init() {
 			},
 		},
 		&cobra.Command{
-			Use:   "subscribe <address> <public-key>",
+			Use:   "subscribe <public-key>@<address> | <address> <public-key>",
 			Short: "Subscribe to a feed via TCP connection",
-			Args:  cobra.ExactArgs(2),
+			Args:  cobra.RangeArgs(1, 2),
 			RunE: func(cmd *cobra.Command, args []string) error {
+				address, pk, err := addrAndPK(args)
+				if err != nil {
+					return err
+				}
 				r, err := getCLIRPCClient()
 				if err != nil {
 					return err
 				}
 				defer r.Close() //nolint:errcheck,gosec
-				pk, err := pubKeyFromHex(args[1])
-				if err != nil {
-					return err
-				}
-				return r.TCP().Subscribe(args[0], pk)
+				return r.TCP().Subscribe(address, pk)
 			},
 		},
 		&cobra.Command{
-			Use:   "unsubscribe <address> <public-key>",
+			Use:   "unsubscribe <public-key>@<address> | <address> <public-key>",
 			Short: "Unsubscribe from a feed via TCP connection",
-			Args:  cobra.ExactArgs(2),
+			Args:  cobra.RangeArgs(1, 2),
 			RunE: func(cmd *cobra.Command, args []string) error {
+				address, pk, err := addrAndPK(args)
+				if err != nil {
+					return err
+				}
 				r, err := getCLIRPCClient()
 				if err != nil {
 					return err
 				}
 				defer r.Close() //nolint:errcheck,gosec
-				pk, err := pubKeyFromHex(args[1])
-				if err != nil {
-					return err
-				}
-				return r.TCP().Unsubscribe(args[0], pk)
+				return r.TCP().Unsubscribe(address, pk)
 			},
 		},
 		&cobra.Command{
@@ -285,37 +285,37 @@ func init() {
 			},
 		},
 		&cobra.Command{
-			Use:   "subscribe <address> <public-key>",
+			Use:   "subscribe <public-key>@<address> | <address> <public-key>",
 			Short: "Subscribe to a feed via UDP connection",
-			Args:  cobra.ExactArgs(2),
+			Args:  cobra.RangeArgs(1, 2),
 			RunE: func(cmd *cobra.Command, args []string) error {
+				address, pk, err := addrAndPK(args)
+				if err != nil {
+					return err
+				}
 				r, err := getCLIRPCClient()
 				if err != nil {
 					return err
 				}
 				defer r.Close() //nolint:errcheck,gosec
-				pk, err := pubKeyFromHex(args[1])
-				if err != nil {
-					return err
-				}
-				return r.UDP().Subscribe(args[0], pk)
+				return r.UDP().Subscribe(address, pk)
 			},
 		},
 		&cobra.Command{
-			Use:   "unsubscribe <address> <public-key>",
+			Use:   "unsubscribe <public-key>@<address> | <address> <public-key>",
 			Short: "Unsubscribe from a feed via UDP connection",
-			Args:  cobra.ExactArgs(2),
+			Args:  cobra.RangeArgs(1, 2),
 			RunE: func(cmd *cobra.Command, args []string) error {
+				address, pk, err := addrAndPK(args)
+				if err != nil {
+					return err
+				}
 				r, err := getCLIRPCClient()
 				if err != nil {
 					return err
 				}
 				defer r.Close() //nolint:errcheck,gosec
-				pk, err := pubKeyFromHex(args[1])
-				if err != nil {
-					return err
-				}
-				return r.UDP().Unsubscribe(args[0], pk)
+				return r.UDP().Unsubscribe(address, pk)
 			},
 		},
 		&cobra.Command{
@@ -934,6 +934,37 @@ func execStat(r *node.RPCClient) error {
 }
 
 // --- Helpers ---
+
+// addrAndPK parses a (un)subscribe target in either form:
+//
+//	<address> <public-key>   (two args, the historical form)
+//	<public-key>@<address>   (one arg, the pk-as-identity convention used by
+//	                          the treestore-backed CXO utilities, e.g. skychat)
+//
+// e.g. "tcp subscribe 039d...@1.2.3.4:8870" == "tcp subscribe 1.2.3.4:8870 039d...".
+func addrAndPK(args []string) (address string, pk cipher.PubKey, err error) {
+	switch len(args) {
+	case 1:
+		at := strings.LastIndex(args[0], "@")
+		if at < 0 {
+			return "", pk, errors.New("single argument must be <public-key>@<address>")
+		}
+		pk, err = pubKeyFromHex(args[0][:at])
+		if err != nil {
+			return "", pk, err
+		}
+		address = args[0][at+1:]
+		if address == "" {
+			return "", pk, errors.New("missing address after '@'")
+		}
+		return address, pk, nil
+	case 2:
+		pk, err = pubKeyFromHex(args[1])
+		return args[0], pk, err
+	default:
+		return "", pk, errors.New("expected <address> <public-key> or <public-key>@<address>")
+	}
+}
 
 func pubKeyFromHex(pks string) (pk cipher.PubKey, err error) {
 	var b []byte

--- a/cmd/cxo/commands/daemon.go
+++ b/cmd/cxo/commands/daemon.go
@@ -13,6 +13,14 @@ import (
 
 var cfg = node.NewConfig()
 
+// skHex is the optional node identity secret key (hex). Empty = the node
+// generates a random ephemeral identity each start (the historical default),
+// which means its public key — and therefore the `<pk>@host:port` address other
+// nodes/utilities use to reach it — changes on every restart. Provide --sk to
+// pin a stable identity, matching the pk-as-identity convention the treestore-
+// backed CXO utilities (e.g. skychat) already use.
+var skHex string
+
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Run CXO daemon",
@@ -24,6 +32,10 @@ func init() {
 	cfg.OnSubscribeRemote = acceptAllSubscriptions
 
 	f := daemonCmd.Flags()
+
+	// identity
+	f.StringVar(&skHex, "sk", "",
+		"node identity secret key (hex); empty = random ephemeral identity (PK changes each restart)")
 
 	// node
 	f.IntVar(&cfg.MaxConnections, "max-connections", cfg.MaxConnections,
@@ -69,11 +81,34 @@ func init() {
 }
 
 func runDaemon(_ *cobra.Command, _ []string) {
+	if skHex != "" {
+		sk, err := cipher.SecKeyFromHex(skHex)
+		if err != nil {
+			log.Fatalf("invalid --sk: %v", err)
+		}
+		cfg.SecKey = sk
+	}
+
 	n, err := node.NewNode(cfg)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer n.Close() //nolint:errcheck,gosec
+
+	// Surface the node's identity + how to reach it, so operators can use the
+	// pk-as-identity (<pk>@host:port) convention. Without --sk the PK below is
+	// random and changes on the next restart.
+	pk := n.ID()
+	log.Printf("CXO node identity (pk): %s", pk.Hex())
+	if skHex == "" {
+		log.Printf("CXO: ephemeral identity (random) — pass --sk <hex> to pin a stable pk across restarts")
+	}
+	if cfg.TCP.Listen != "" {
+		log.Printf("CXO reachable (tcp): %s@<host>%s", pk.Hex(), cfg.TCP.Listen)
+	}
+	if cfg.UDP.Listen != "" {
+		log.Printf("CXO reachable (udp): %s@<host>%s", pk.Hex(), cfg.UDP.Listen)
+	}
 
 	waitInterrupt()
 }


### PR DESCRIPTION
## What

Carry the **pk-as-identity** addressing convention (`<pk>@host:port`) — already used by the treestore-backed CXO utilities (skychat, the TPD aggregator) — back to the original standalone CXO node (`skywire cxo daemon` / `skywire cxo cli`).

## Why

The standalone CXO node is the multi-feed skycoin CXO node controlled over RPC. It supports a node identity (`Config.SecKey`), feeds, and TCP/UDP — but it never exposed the identity or the `<pk>@host:port` addressing, so reaching a standalone node by a stable key was awkward/impossible. Nothing fundamental was missing; this is the identity-exposure + addressing-ergonomics layer that was never carried back.

## Gaps fixed

**1. No stable / visible identity.** With no key set, the node generated a **random** identity each start (PK changes every restart) and **never printed it** — so operators couldn't address it by PK.
- Add `--sk <hex>` to pin a stable node identity (default stays random).
- Print the node PK on startup plus `<pk>@<host><tcp/udp-listen>` reachability lines, with a hint to use `--sk` when ephemeral.

**2. Decoupled addressing in the cli.** `tcp/udp subscribe` took `<address> <public-key>` as two args. They now **also** accept the single-arg `<public-key>@<address>` form (the two-arg form still works), matching `skychat send --via tcp://<pk>@host:port`.

## Validation

- Same `--sk` → same PK across restarts; startup prints `<pk>@<host>:<port>`.
- `cli tcp subscribe <pk>@<addr>` and `<addr> <pk>` dispatch identically (both reach the daemon Subscribe RPC); a bare single arg without `@` is rejected with a clear message.
- `go build`/`vet`, `golangci-lint` green.

## Note (separate finding)

While here I also verified the **visor→TPD→CLI CXO data flow** is fully wired (visor `buildStatsPublisher` + `AnnounceTo` → TPD aggregator subscribes on inbound conn → TPD metrics/uptime/all-transports publishers → CLI `CXOSubscriptionManager` on-demand subscriber with intentional CXO-miss→HTTP fallback). No change needed there.
