### PR TITLE
feat(logserver): server-side filtering on /visor.log + docs

### DIFF
--- a/cmd/skywire-cli/commands/log/single_visor_log.go
+++ b/cmd/skywire-cli/commands/log/single_visor_log.go
@@ -4,11 +4,17 @@
 // dmsghttp. Requires the remote visor to have been started with
 // -s/--save-log; without that flag, the endpoint returns 404 and
 // this command surfaces a clear hint.
+//
+// Filtering flags translate to URL query params that the remote
+// visor applies server-side before streaming — avoids pulling the
+// whole file just to grep it locally over a slow dmsg/skynet hop.
 package clilog
 
 import (
 	"context"
+	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -16,7 +22,29 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
+var (
+	fileMinLevel  string
+	fileModule    string
+	fileGrep      string
+	fileSinceLine int
+	fileLimit     int
+	fileFollow    bool
+)
+
 func init() {
+	singleFileCmd.Flags().SortFlags = false
+	singleFileCmd.Flags().StringVar(&fileMinLevel, "min-level", "",
+		"keep only lines >= this severity (trace|debug|info|warn|error|fatal|panic); empty = no filter")
+	singleFileCmd.Flags().StringVar(&fileModule, "module", "",
+		"regex filter on the [module] tag (e.g. 'sudph' or '^tp:')")
+	singleFileCmd.Flags().StringVar(&fileGrep, "grep", "",
+		"regex filter on the full line text")
+	singleFileCmd.Flags().IntVar(&fileSinceLine, "since-line", 0,
+		"skip the first N lines (1-based) — useful for resume after disconnect")
+	singleFileCmd.Flags().IntVar(&fileLimit, "limit", 0,
+		"stop after N matching lines (0 = no limit)")
+	singleFileCmd.Flags().BoolVarP(&fileFollow, "follow", "f", false,
+		"keep streaming new appends after EOF (tail -f); cancel with ctrl+c")
 	RootCmd.AddCommand(singleFileCmd)
 }
 
@@ -26,6 +54,17 @@ var singleFileCmd = &cobra.Command{
 	Long: `Stream /visor.log from one visor over dmsghttp. Visor must have been
 started with -s/--save-log; without that flag the file doesn't exist
 and the endpoint returns 404.
+
+Filtering flags translate to URL query params applied server-side, so
+the visor only ships lines that match — useful over slow dmsg/skynet
+hops where pulling the whole file is wasteful.
+
+  --min-level    keep lines >= severity
+  --module       regex on [module] tag
+  --grep         regex on full line
+  --since-line   skip first N lines
+  --limit        stop after N matches
+  --follow / -f  tail -f mode
 
 Gated by the remote visor's survey_whitelist.`,
 	Args: cobra.ExactArgs(1),
@@ -46,8 +85,37 @@ Gated by the remote visor's survey_whitelist.`,
 		}
 		defer cleanup()
 
-		if err := fetchSurveyEndpoint(ctx, hc, pk, "/visor.log", os.Stdout); err != nil {
+		if err := fetchSurveyEndpoint(ctx, hc, pk, "/visor.log"+buildVisorLogQuery(), os.Stdout); err != nil {
 			log.Fatal(err)
 		}
 	},
+}
+
+// buildVisorLogQuery assembles the ?... query string from the filter
+// flags. Returns "" when no filter is set so the remote falls through
+// to its raw-file fast path.
+func buildVisorLogQuery() string {
+	q := url.Values{}
+	if fileMinLevel != "" {
+		q.Set("min-level", fileMinLevel)
+	}
+	if fileModule != "" {
+		q.Set("module", fileModule)
+	}
+	if fileGrep != "" {
+		q.Set("grep", fileGrep)
+	}
+	if fileSinceLine > 0 {
+		q.Set("since-line", strconv.Itoa(fileSinceLine))
+	}
+	if fileLimit > 0 {
+		q.Set("limit", strconv.Itoa(fileLimit))
+	}
+	if fileFollow {
+		q.Set("follow", "1")
+	}
+	if len(q) == 0 {
+		return ""
+	}
+	return "?" + q.Encode()
 }

--- a/docs/visor-doctor-rfc.md
+++ b/docs/visor-doctor-rfc.md
@@ -1,0 +1,249 @@
+# `cli visor doctor` — proactive health checks (RFC)
+
+## Status
+
+Draft. Extends the existing `skywire cli visor doctor` (currently a rollup
+of Summary RPC + skychat /status). This RFC proposes a second mode that
+actively probes transport-type reachability, AR registration freshness,
+stale-TPD detection, dmsg-server reachability, RSN reachability, and
+config-sanity checks — each producing a structured finding so the
+operator's alerting pipeline can act on it without parsing prose.
+
+## Motivation
+
+Over the past week three operator-visible bugs all turned out to be
+diagnosable signals the visor itself already exposed — but only on
+explicit query:
+
+1. **Stale AR sudph registration** (PR #3003). Visor restarts → AR keeps
+   serving the old random port → peers dial a closed socket → handshake
+   times out indefinitely. The visor knew its current port was 58674 the
+   whole time; the AR was serving 39726.
+2. **Stale TPD null-PK orphan transports** (Beta's network-wide finding;
+   PR #2970/#2971). Route-finder builds routes through ghost transports;
+   RSN can't dial them at port 136. The TPD knew it had 3218 null-PK
+   records; nobody was watching for them.
+3. **RSN dmsg unreachability** (Alpha's diagnosis; led to PR #3006). RSN
+   advertises 8 delegated dmsg servers via `/health-over-dmsg`, but every
+   one fails with i/o deadline. The /health endpoint and the dmsg-ping
+   results disagreed for hours; no alarm fired.
+
+In every case the failure mode was **diagnosable in <1s of probing**, but
+the diagnosis happened reactively (after a campaign measurement failed)
+rather than continuously. The new doctor mode runs the probes proactively
+and surfaces findings in a single structured report.
+
+## Out of scope
+
+- Continuous monitoring as a background daemon. This is a CLI invocation;
+  operators (or hypervisor dashboards) drive cadence.
+- Auto-remediation. Findings carry a suggested next step (in `next_step`),
+  but doctor never restarts the visor or rewrites config on its own.
+
+## Command shape
+
+```
+skywire cli visor doctor [--check name1,name2,...] [--probe-timeout 3s] [--json] [--explain]
+```
+
+| Flag                 | Purpose                                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| `--check`            | Comma-separated subset to run (default = all). Names: `summary`, `skychat`, `transports`, `ar-self`, `tpd-self`, `dmsg-servers`, `rsn`, `config`, `routing-policy`. |
+| `--probe-timeout`    | Per-probe deadline (default `3s`).                                                                 |
+| `--json`             | Structured output for alerting pipelines.                                                          |
+| `--explain`          | For each YELLOW/RED finding, print the underlying probe data (not just the verdict).               |
+
+Exit code mirrors the verdict: 0 GREEN, 1 YELLOW, 2 RED (unchanged from
+today). The verdict is the max severity across all findings.
+
+## Checks
+
+Each check is independent. A timeout in one doesn't abort the rest —
+each emits a `timeout` finding and the report continues.
+
+### 1. `summary` (existing)
+
+Composes the existing `Summary` RPC. Reachable / ready / uptime /
+transport counts / service health. Already implemented; documented here
+so the check list is complete.
+
+### 2. `skychat` (existing)
+
+Best-effort probe to the local skychat /status endpoint. Already
+implemented.
+
+### 3. `transports` (new)
+
+For each transport type (`STCPR`, `SUDPH`, `DMSG`), pick one or two
+canary peers — by default the configured `transport_setup_nodes`, or
+operator-provided via `--probe-peer pk@type`. For each (peer, type) pair:
+
+- Attempt to dial through `transport.Manager.CreateTransport(peer, type)`.
+- Record: handshake duration, success/failure, error category
+  (timeout, NAT-blocked, peer-refused).
+- Tear down the transport (don't leave probe TPs lingering).
+
+Finding levels:
+- `green` — at least one transport type per direction succeeded under
+  `--probe-timeout`.
+- `yellow` — STCPR works but SUDPH/DMSG handshake-timed-out (typical
+  symmetric-NAT / dmsg-relay degradation; non-blocking).
+- `red` — all transport types failed (visor is effectively isolated).
+
+### 4. `ar-self` (new)
+
+Asks the AR `/resolve/<sudph|stcpr>/<our-PK>` for our own registration.
+Compares to what the visor *thinks* it's listening on:
+
+- Sudph port: AR-served port vs `transport.Manager`'s actual bound port.
+- Sudph public IP: AR-served vs the visor's `/health public_ip`.
+- Sudph protocol: registered or "no UDP target"?
+- Stcpr address: same shape.
+
+Finding levels:
+- `green` — AR registration matches local state.
+- `yellow` — drift detected (e.g., port mismatch: AR has X, visor bound Y).
+  Suggested next step: restart visor; if persistent, indicates the
+  publish path is failing (PR #3003 fixed one such class). 
+- `red` — AR returns 404/empty for our PK (we're not registered at all).
+
+This is the check that would have caught the bug PR #3003 fixed.
+
+### 5. `tpd-self` (new)
+
+Pulls the TPD entries for our own PK and inspects:
+
+- Any transports with `a.sent + a.recv + b.sent + b.recv == 0` AND
+  `live=false` (dangling, never used) — flag count.
+- Any transports with a zero-PK on either edge (the null-PK orphan
+  class PR #2971 fixed at the TPD-write side) — flag count.
+- Any transports the visor doesn't recognize in its own
+  `transport.Manager` registration (TPD has them but we don't) —
+  flag count + IDs.
+- Most recent registration timestamp; if oldest "registered" timestamp
+  is > 1 day ago, recommend a `cli tp rm` sweep.
+
+Finding levels:
+- `green` — TPD-side state matches local transport manager.
+- `yellow` — non-zero stale/orphan counts.
+- `red` — count > some threshold (default 10) — drives route selection
+  through ghost paths; campaign measurements will fail.
+
+This is the check that would have caught the cli-tp-rm orphan situation
+Beta diagnosed.
+
+### 6. `dmsg-servers` (new)
+
+For each delegated dmsg server in our discovery entry, do a low-cost
+liveness probe — open a yamux session, no app traffic, record handshake
+time, then close. Report:
+
+- Number of delegated servers vs number reachable.
+- Per-server handshake duration (sorted) — outliers might be flapping.
+
+Finding levels:
+- `green` — at least 4 of N reachable (configurable).
+- `yellow` — fewer than 4 of N (degraded dmsg overlay; expect intermittent
+  unreachability symptoms).
+- `red` — none reachable.
+
+### 7. `rsn` (new)
+
+For each route-setup-node in `route_setup_nodes` (and embedded RSN if the
+visor runs one), dmsg-ping the PK. Record reachability + RTT.
+
+Finding levels:
+- `green` — at least one RSN reachable.
+- `yellow` — RSNs configured but all currently unreachable (route setup
+  will fail; this matches what Alpha hit before PR #3006).
+- `red` — no RSNs configured AND no `user_route_setup_nodes` AND visor
+  doesn't run an embedded RSN (route setup *cannot* work).
+
+### 8. `config` (new)
+
+Pure local — reads `skywire.json` and emits findings on:
+
+- `transport.sudph_port == 0` → yellow finding "sudph port will rotate on
+  every restart; stale AR registration is recoverable but expect
+  reachability gaps each restart cycle."
+- `transport.stcpr_port == 0` → same.
+- `transport.address_resolver` empty AND scheme is not `dmsg://` → yellow
+  (touched by Alpha's discovery during the PR #3003 thread — non-dmsg AR
+  URL skips the sudph udp_address publish path).
+- `dmsgpty.whitelist` empty AND `dmsgpty.ssh_listen` non-empty → yellow
+  (TCP listener exposed with no peer allowed; either configure or unset).
+- `survey_whitelist` empty AND visor is `public: true` → yellow (any
+  reachable peer can pull `/visor.log`).
+- `hypervisors` empty AND we're not running standalone → yellow (visor
+  has no remote admin path).
+
+### 9. `routing-policy` (new, optional)
+
+If a routing policy is loaded (WASM module from PR #2913), walk it for:
+
+- Rules that never match any candidate transport in the current state.
+- Rules that match every candidate (no-op).
+- Rules that ban every transport for a destination (the destination is
+  effectively un-routable).
+
+Finding levels:
+- `green` — every rule has at least one matching candidate.
+- `yellow` — at least one rule never matches (likely operator mistake).
+- `red` — at least one destination is unreachable under the current
+  policy.
+
+## Output shape
+
+```json
+{
+  "verdict": "yellow",
+  "reasons": ["transports.sudph: handshake timeout to canary 02f9aa58…"],
+  "findings": [
+    {
+      "check": "ar-self",
+      "level": "yellow",
+      "summary": "AR sudph entry is stale: registered 39726, visor bound 58674",
+      "next_step": "restart visor; if still stale, see PR #3003 (liveness fix)",
+      "data": {
+        "ar_registered_port": 39726,
+        "visor_bound_port": 58674,
+        "registered_at": "2026-06-04T15:15:03Z"
+      }
+    },
+    ...
+  ]
+}
+```
+
+`findings[].data` carries raw probe results — only printed with
+`--explain` in human mode (avoids burying the operator). The `next_step`
+field is the single most useful line for operators triaging in a hurry.
+
+## Implementation sketch
+
+- New file `cmd/skywire-cli/commands/visor/doctor_probes.go` with one
+  function per check. Each takes `(ctx, rpcClient, conf, probeTimeout)`
+  and returns a `[]finding`.
+- `runDoctor()` in `doctor.go` dispatches to the selected checks
+  (default-all) via a registry map.
+- Probes that need direct AR / TPD / dmsg-disc HTTP calls reuse the
+  existing `httputil.DMSGHTTPClient` helpers — no new transport code.
+- For probes that need to drive the visor's transport manager
+  (`transports` check), call existing RPC methods
+  (`AddTransport` / `RemoveTransport`); doctor cleans up on exit.
+
+Total LOC estimate: ~600 incl. tests. Each probe is independently
+testable with a mocked RPC client.
+
+## Open questions
+
+- Should doctor cache its own findings? Some checks (`ar-self`,
+  `tpd-self`) are mildly expensive; caching the last result with a 60s
+  TTL would let operators alarming on it run doctor every 30s without
+  amplifying load. Probably yes, default `--cache-ttl 0` for parity with
+  today's behavior.
+- Should hypervisor dashboards pull these findings? If yes, expose
+  `/doctor` on the logserver alongside `/health` — but gate it carefully
+  (it surfaces more than `/health` does today).
+- Routing-policy walk (#9) is the most speculative — it could ship as a
+  separate `cli rg policy lint` instead of folding into doctor.

--- a/docs/visor-logging-access.md
+++ b/docs/visor-logging-access.md
@@ -1,0 +1,232 @@
+# Visor logging — access paths and authentication
+
+This page documents every way to read a Skywire visor's runtime logs, the
+filters available on each path, and the trust model (which whitelist gates
+which surface). Operator-facing — if you're trying to debug a misbehaving
+visor on your own host or a peer's host, start here.
+
+## Quick reference
+
+| Goal                                              | Command                                        | Transport                              | Gate                          |
+| ------------------------------------------------- | ---------------------------------------------- | -------------------------------------- | ----------------------------- |
+| Tail the local visor with structured filters      | `skywire cli visor log --follow --min-level …` | Local RPC (`localhost:3435`)           | filesystem (loopback)         |
+| Same, but against a *remote* visor                | `skywire cli visor log --via dmsg://<pk> …`    | Local visor → dmsg/skynet RPC bridge   | remote `hypervisors` whitelist or `dmsgpty_whitelist` |
+| Download a remote visor's persistent log file     | `skywire cli log file <pk>`                    | dmsghttp / skynet → `/visor.log`       | remote `survey_whitelist`     |
+| Filtered tail of remote `/visor.log` (server-side)| `skywire cli log file <pk> --min-level warn …` | dmsghttp / skynet → `/visor.log?…`     | remote `survey_whitelist`     |
+| Pull a runtime pprof profile from a remote visor  | `skywire cli log pprof <pk> heap`              | dmsghttp / skynet → `/debug/pprof/heap`| remote `survey_whitelist`     |
+| Fetch `/stats[/path]` / `/uptime[/path]` / `/node-info` from a peer | `skywire cli log {stats,uptime,info} <pk>` | dmsghttp / skynet                  | remote `survey_whitelist`     |
+| Public health check, no auth                      | `curl dmsg://<pk>:80/health`                   | dmsghttp                               | **public** (no gate)          |
+
+The runtime log and the persistent file are two different things. The
+runtime log is a fixed-size in-memory ring buffer kept by every visor
+(default 5000 entries); the persistent file `/visor.log` is the on-disk
+sink that only exists when the visor is started with `-s` / `--save-log`.
+
+---
+
+## 1. Local visor — `cli visor log`
+
+Speaks net/rpc to the running visor on `localhost:3435` (configurable via
+`SKYWIRE_RPC` or `--rpc`). Reads from the **in-memory ring buffer**, so it
+works without `--save-log`.
+
+```
+skywire cli visor log [--follow] [--min-level <lvl>] [--module <regex>] [--json] [--interval <dur>]
+```
+
+| Flag           | Purpose                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| `--follow`     | Stream new entries as they arrive (polls `RuntimeLogsSince` every `--interval`, default 500ms). |
+| `--min-level`  | Drop entries below this severity. `trace<debug<info<warn<error<fatal<panic`. |
+| `--module`     | Regex on the `_module` field (matches whatever the logger tagged itself with). |
+| `--json`       | Keep the raw structured JSON instead of pretty-printing.                 |
+| `--interval`   | Poll cadence in follow mode.                                             |
+
+If the buffer overflows between two polls a `[N entries dropped]` marker is
+printed once. The buffer is bounded by `runtimeLogMaxEntries` (5000 by default).
+
+### Reaching a remote visor with the same command
+
+Add `--via dmsg://<pk>` or `--via skynet://<pk>`. The CLI dials the *local*
+visor's RPC port, which proxies the call to the remote over a dmsg or
+skywire transport. **The local visor's PK must be on the remote visor's
+`hypervisors` list or `dmsgpty_whitelist` for the bridge to accept it.**
+This is independent of `survey_whitelist`.
+
+```
+skywire cli visor log --via dmsg://03d1d78e7323…:44 --follow --min-level warn --module sudph
+```
+
+This gives you the same structured, filtered, follow-able view you have
+locally, just routed through dmsg/skynet — the filtering happens on the
+remote side, so you don't pull the whole buffer just to grep it.
+
+---
+
+## 2. Remote persistent log — `cli log file <pk>`
+
+Streams the on-disk `/visor.log` over dmsghttp (or skynet, with `--via`).
+Requires the remote visor to have been started with `-s`/`--save-log`; if
+the file doesn't exist the endpoint returns 404 with a hint.
+
+```
+skywire cli log file <pk> [--min-level <lvl>] [--module <regex>] [--grep <regex>] \
+                          [--since-line <N>] [--limit <N>] [--follow]
+```
+
+| Flag             | Maps to            | Purpose                                                  |
+| ---------------- | ------------------ | -------------------------------------------------------- |
+| `--min-level`    | `?min-level=`      | Keep lines `>=` severity (logrus-formatted lines only).  |
+| `--module`       | `?module=`         | Regex on the `[module]` tag.                             |
+| `--grep`         | `?grep=`           | Regex on the full line text.                             |
+| `--since-line`   | `?since-line=`     | Skip the first N lines (1-based) — useful for resuming after a disconnect. |
+| `--limit`        | `?limit=`          | Stop after N matching lines.                             |
+| `--follow / -f`  | `?follow=1`        | Keep streaming new appends after EOF (tail -f mode).     |
+
+Filtering happens **server-side** on the remote visor — over a slow dmsg
+or skynet hop you don't want to ship the whole multi-MB log just to grep
+it locally. When no filter flag is set the endpoint serves the raw file
+via `c.File` (same behavior as before; backwards-compatible).
+
+### Strict-level mode
+
+When `--min-level` is set, lines that don't match the standard logrus
+format (`[ts] LEVEL [module]: msg…`) are dropped — so free-form lines
+from libraries that emit unstructured text can't sneak past a strict
+filter. When `--min-level` is unset, unparseable lines pass through.
+
+---
+
+## 3. Remote pprof — `cli log pprof <pk> <profile>`
+
+```
+skywire cli log pprof <pk> {cpu|heap|goroutine|threadcreate|block|mutex|allocs|trace|cmdline|symbol} [--seconds N]
+```
+
+Streams the binary profile to stdout — pipe to `go tool pprof`:
+
+```
+skywire cli log pprof <pk> heap > heap.pprof
+go tool pprof heap.pprof
+```
+
+For sampling profiles (`cpu`, `profile`, `trace`), `--seconds` controls
+the sample duration. The visor caps this at 30s by default.
+
+---
+
+## 4. Other remote endpoints
+
+| Endpoint                       | CLI                          | Purpose                                                                  |
+| ------------------------------ | ---------------------------- | ------------------------------------------------------------------------ |
+| `/health`                      | (any HTTP client)            | Public liveness + transport counts. **No auth gate.**                    |
+| `/services`                    | (any HTTP client)            | Public list of forwarded ports. **No auth gate.**                        |
+| `/feeds`                       | (any HTTP client)            | Public list of CXO feeds the visor publishes. **No auth gate.**          |
+| `/node-info`                   | `cli log info <pk>`          | Survey (host info, geolocation, etc.).                                   |
+| `/node-info/checksum`          | (HTTP)                       | SHA256 of the survey — collectors use this to skip unchanged surveys.    |
+| `/stats[/path]`                | `cli log stats <pk> [path]`  | Per-visor telemetry rollup (bbolt-backed).                               |
+| `/uptime[/path]`               | `cli log uptime <pk> [path]` | Three-tier uptime bitmaps + session history.                             |
+| `/reward.txt`                  | `cli log reward <pk>`        | Reward address (file only present if configured).                        |
+| `/visor.log`                   | `cli log file <pk>`          | On-disk log (requires `-s`/`--save-log`). Filterable; see §2.            |
+| `/pty`, `/pty/*`               | (browser, dmsgpty UI)        | Web terminal — distinct auth path (see §6).                              |
+| `/`                            | (browser)                    | Landing page; hides authed links from non-whitelisted PKs.               |
+
+All `/stats/*` and `/uptime/*` handlers degrade gracefully to **503** when
+the visor hasn't wired its `statsReader`/`uptimeRecorder` (e.g., the bbolt
+store didn't open).
+
+---
+
+## 5. Auth model — which whitelist gates which surface
+
+The visor has **three** distinct PK whitelists. They overlap in practice
+but don't have to.
+
+| Whitelist                | Config field                 | Gates                                                                                 |
+| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------------- |
+| `survey_whitelist`       | `survey_whitelist`           | HTTP endpoints on the logserver: `/visor.log`, `/debug/pprof/*`, `/stats/*`, `/uptime/*`, `/node-info`, `/reward.txt`. **Empty list = publicly accessible.** |
+| `dmsgpty_whitelist`      | `dmsgpty.whitelist`          | `/pty` (web terminal) and the sftp subsystem on the dmsgpty mux (PR #3002). **Empty list = pty/sftp disabled.** |
+| `hypervisors`            | `hypervisors[]`              | RPC over the `--via dmsg://` / `--via skynet://` bridge. Local visor accepts the bridge dial only from PKs in the configured hypervisor set (and itself). |
+
+`EffectiveSurveyWhitelist()` returns the union of the deployment-supplied
+list (`survey_whitelist`, refreshed from conf service) and operator-added
+entries (`user_survey_whitelist`, persisted across config refresh). The
+same pattern exists for `user_route_setup_nodes` and `user_transport_setup`.
+
+### Important quirks
+
+- **An empty `survey_whitelist` means *everyone* can read `/visor.log`** —
+  any peer who can reach you over dmsg/skynet can pull the file. Operators
+  who don't want that should populate the whitelist with the PKs they
+  trust (their own + maintenance hosts + survey collectors).
+- **`dmsgpty_whitelist` is independent from `survey_whitelist`.** A peer
+  on the survey list cannot necessarily open `/pty`; a peer with pty
+  access cannot necessarily fetch `/visor.log`. This is deliberate — pty
+  is a shell, survey is read-only telemetry.
+- **The RPC bridge auth is *neither* of the above** — it's the
+  `hypervisors` list (or `dmsgpty_whitelist` as fallback in some
+  configurations). Don't assume "I'm on the survey whitelist" gets you
+  `cli visor log --via dmsg://...`.
+
+### Adding yourself to a remote's `survey_whitelist`
+
+Whitelists in this repo can be updated at runtime via:
+
+```
+# Append a PK
+skywire cli config update --user-survey-whitelist add <pk>
+
+# Remove
+skywire cli config update --user-survey-whitelist remove <pk>
+```
+
+The change writes to `user_survey_whitelist`, which is preserved across
+the periodic conf-service refresh.
+
+---
+
+## 6. The web terminal at `/pty`
+
+Distinct from logging but worth knowing because it shares the same HTTP
+listener. `/pty` and `/pty/*` are gated by `dmsgpty_whitelist` separately
+from the survey-whitelist — that's by design, since a shell is much more
+powerful than read-only telemetry. The route returns 404 (not 403) when
+no pty handler is wired, so a misconfigured deployment can't accidentally
+expose a shell to a peer on the wrong whitelist.
+
+---
+
+## 7. Common operator recipes
+
+```bash
+# Tail the local visor for everything sudph-related, just warnings+.
+skywire cli visor log --follow --min-level warn --module 'sudph'
+
+# Same, but on Beta's prod02 visor (works when this host is on Beta's
+# `hypervisors` whitelist).
+skywire cli visor log --via dmsg://02f9aa58…:44 --follow --min-level warn --module sudph
+
+# Pull the last 200 lines containing "BindSUDPH" from a peer's visor.log,
+# filtered at the source so you don't ship the whole 50MB file.
+skywire cli log file 02f9aa58… --grep 'BindSUDPH' --limit 200
+
+# Watch for new error-level entries on a peer in real time.
+skywire cli log file 02f9aa58… --follow --min-level error
+
+# Heap snapshot of a remote visor:
+skywire cli log pprof 02f9aa58… heap > peer-heap.pprof
+go tool pprof peer-heap.pprof
+```
+
+---
+
+## 8. Diagnosing access failures
+
+| Symptom                                                 | Likely cause                                                                   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `cli visor log` fails: `RPC connection failed`          | Visor not running, or `--rpc`/`SKYWIRE_RPC` points at the wrong address.       |
+| `cli visor log --via` fails: `bridge: write header`     | Local visor not running. The bridge needs a *local* visor to proxy through.    |
+| `cli log file <pk>` returns `visor.log not found`       | Remote was started without `-s`/`--save-log`. The runtime ring buffer is still readable via the `--via` RPC path. |
+| `cli log file <pk>` returns 403 / hangs                 | You're not on the remote's `survey_whitelist`. Ask the operator to add your PK or check `cli config view`. |
+| `cli visor log --via` returns 403                       | You're not on the remote's `hypervisors` list. Survey-whitelist doesn't gate the RPC bridge. |
+| `cli log pprof <pk> trace` truncates                    | Visor caps trace duration at 30s. Drop `--seconds` or pull a smaller window.   |

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -197,13 +197,37 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 	})
 
 	// Serve visor log file (auth'd) — written when visor runs with -s/--save-log
+	//
+	// With no query params: behaves like a static file dump (c.File).
+	//
+	// Query params (any set → switches to streaming filtered mode):
+	//   ?min-level=<lvl>    keep only lines >= <lvl> (trace<debug<info<warn<error<fatal<panic)
+	//   ?module=<regex>     keep only lines whose `[module]` tag matches the regex
+	//   ?grep=<regex>       keep only lines whose full text matches the regex
+	//   ?since-line=<N>     skip the first N lines (1-based, useful for resume after disconnect)
+	//   ?limit=<N>          stop after writing N matching lines
+	//   ?follow=1           keep reading after EOF (tail -f), polling for appends until ctx fires
+	//
+	// Filtering happens server-side so callers over dmsg/skynet don't burn bandwidth
+	// pulling everything just to grep locally. The standard line format is
+	//   `[<iso8601>] LEVEL [module:...]: msg key=val…`
+	// — anything that doesn't match this shape is passed through unchanged when
+	// no level/module filters apply, and conservatively dropped when they do (so
+	// stray lines from libraries that don't follow the format don't sneak past
+	// a strict --min-level filter).
 	authRoute.GET("/visor.log", func(c *gin.Context) {
 		logFile := filepath.Join(localPath, "visor.log")
 		if _, err := os.Stat(logFile); err != nil {
 			c.String(http.StatusNotFound, "visor.log not found (start visor with -s flag)")
 			return
 		}
-		c.File(logFile)
+		q := c.Request.URL.Query()
+		if q.Get("min-level") == "" && q.Get("module") == "" && q.Get("grep") == "" &&
+			q.Get("since-line") == "" && q.Get("limit") == "" && q.Get("follow") == "" {
+			c.File(logFile)
+			return
+		}
+		streamFilteredVisorLog(c, logFile, q)
 	})
 
 	// pprof endpoints (auth'd) — runtime profiling

--- a/pkg/visor/logserver/visorlog_filter.go
+++ b/pkg/visor/logserver/visorlog_filter.go
@@ -1,0 +1,177 @@
+// Package logserver pkg/visor/logserver/visorlog_filter.go — server-side
+// filtering for the /visor.log endpoint.
+//
+// /visor.log is logrus-formatted text on disk; over dmsg/skynet the wire is
+// often the slowest hop, so filtering at the source — even at the cost of a
+// regex per line — typically beats shipping the whole file to a client that's
+// only going to grep it. The endpoint stays compatible when no query params
+// are set (caller still receives the raw file via c.File).
+package logserver
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// logLevelRE captures `LEVEL` and `[module]` from a line shaped like
+// `[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving. …`. The level token
+// is one of the logrus levels we accept; module is anything that's not
+// a `]`. Lines that don't match are handled per the strict-filter rule
+// in streamFilteredVisorLog.
+var logLevelRE = regexp.MustCompile(`^\[[^\]]+\]\s+(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|PANIC)\s+\[([^\]]+)\]`)
+
+// levelOrder is the canonical severity order used by --min-level. Higher
+// = more severe. WARN and WARNING are aliased to the same rank so logs
+// from libraries that emit either spell variant filter identically.
+var levelOrder = map[string]int{
+	"TRACE":   0,
+	"DEBUG":   1,
+	"INFO":    2,
+	"WARN":    3,
+	"WARNING": 3,
+	"ERROR":   4,
+	"FATAL":   5,
+	"PANIC":   6,
+}
+
+// streamFilteredVisorLog walks logFile line-by-line, applies the filters
+// declared in q, and writes matching lines to the gin response writer.
+// Returns when the writer is closed, the limit is hit, the file ends
+// (unless ?follow=1), or the context fires.
+func streamFilteredVisorLog(c *gin.Context, logFile string, q map[string][]string) {
+	getOne := func(k string) string {
+		v := q[k]
+		if len(v) == 0 {
+			return ""
+		}
+		return v[0]
+	}
+
+	minLevel := strings.ToUpper(strings.TrimSpace(getOne("min-level")))
+	minRank, hasMinLevel := levelOrder[minLevel]
+	if minLevel != "" && !hasMinLevel {
+		c.String(http.StatusBadRequest,
+			"invalid min-level %q; expected one of trace, debug, info, warn, error, fatal, panic",
+			minLevel)
+		return
+	}
+
+	var modRE, grepRE *regexp.Regexp
+	if s := getOne("module"); s != "" {
+		re, err := regexp.Compile(s)
+		if err != nil {
+			c.String(http.StatusBadRequest, "invalid module regex: %v", err)
+			return
+		}
+		modRE = re
+	}
+	if s := getOne("grep"); s != "" {
+		re, err := regexp.Compile(s)
+		if err != nil {
+			c.String(http.StatusBadRequest, "invalid grep regex: %v", err)
+			return
+		}
+		grepRE = re
+	}
+
+	sinceLine, _ := strconv.Atoi(getOne("since-line")) //nolint:errcheck
+	if sinceLine < 0 {
+		sinceLine = 0
+	}
+	limit, _ := strconv.Atoi(getOne("limit")) //nolint:errcheck
+	follow := getOne("follow") == "1" || strings.EqualFold(getOne("follow"), "true")
+
+	f, err := os.Open(logFile) //nolint:gosec // path comes from localPath config, not request
+	if err != nil {
+		c.String(http.StatusInternalServerError, "open visor.log: %v", err)
+		return
+	}
+	defer f.Close() //nolint:errcheck
+
+	c.Writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Flush()
+
+	r := bufio.NewReaderSize(f, 64*1024)
+	ctx := c.Request.Context()
+	var lineNum, written int
+	strictLevelMode := hasMinLevel // when set, lines that don't parse get dropped, not passed through
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			lineNum++
+			if lineNum > sinceLine && passesFilters(line, minRank, hasMinLevel, modRE, grepRE, strictLevelMode) {
+				if _, werr := io.WriteString(c.Writer, line); werr != nil {
+					return
+				}
+				c.Writer.Flush()
+				written++
+				if limit > 0 && written >= limit {
+					return
+				}
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err != io.EOF {
+			return
+		}
+		// EOF — either we're done, or we follow and wait for more appends.
+		if !follow {
+			return
+		}
+		// Bounded poll. 250ms strikes a balance between latency and CPU.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// passesFilters returns true when line satisfies every active filter.
+// strictLevelMode drops lines that don't match the standard log shape
+// when a min-level filter is set (so a free-form library line can't
+// sneak past --min-level=error).
+func passesFilters(line string, minRank int, hasMinLevel bool, modRE, grepRE *regexp.Regexp, strictLevelMode bool) bool {
+	if grepRE != nil && !grepRE.MatchString(line) {
+		return false
+	}
+	if !hasMinLevel && modRE == nil {
+		return true
+	}
+	m := logLevelRE.FindStringSubmatch(line)
+	if m == nil {
+		// Line didn't parse — drop on strict level filter, drop when caller
+		// wanted a module match (no module = no match).
+		if strictLevelMode || modRE != nil {
+			return false
+		}
+		return true
+	}
+	if hasMinLevel {
+		rank, ok := levelOrder[m[1]]
+		if !ok || rank < minRank {
+			return false
+		}
+	}
+	if modRE != nil && !modRE.MatchString(m[2]) {
+		return false
+	}
+	return true
+}

--- a/pkg/visor/logserver/visorlog_filter_test.go
+++ b/pkg/visor/logserver/visorlog_filter_test.go
@@ -1,0 +1,199 @@
+package logserver
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestPassesFilters covers the per-line predicate independently of the
+// streaming machinery. Each case lists the level/module filters and
+// asserts the expected verdict on a representative line shape.
+func TestPassesFilters(t *testing.T) {
+	cases := []struct {
+		name           string
+		line           string
+		minLevel       string // "" = no level filter
+		moduleRe       string // "" = no module filter
+		grepRe         string // "" = no grep filter
+		strictLevel    bool
+		wantPass       bool
+	}{
+		{
+			name:     "no filters keeps everything",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving",
+			wantPass: true,
+		},
+		{
+			name:     "min-level INFO drops DEBUG",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving",
+			minLevel: "INFO", strictLevel: true,
+			wantPass: false,
+		},
+		{
+			name:     "min-level INFO keeps WARN",
+			line:     "[2026-06-05T13:36:41Z] WARN [tp:abc]: stale conn",
+			minLevel: "INFO", strictLevel: true,
+			wantPass: true,
+		},
+		{
+			name:     "module regex matches",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [sudph]: bound 56194",
+			moduleRe: "sudph",
+			wantPass: true,
+		},
+		{
+			name:     "module regex misses",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [stcp]: bound :7777",
+			moduleRe: "sudph",
+			wantPass: false,
+		},
+		{
+			name:     "module regex with anchor matches prefix",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving",
+			moduleRe: "^tp:",
+			wantPass: true,
+		},
+		{
+			name:     "strict level drops unparseable line",
+			line:     "free-form line from some library without standard format",
+			minLevel: "INFO", strictLevel: true,
+			wantPass: false,
+		},
+		{
+			name:     "module filter drops unparseable line",
+			line:     "free-form line from some library without standard format",
+			moduleRe: "sudph",
+			wantPass: false,
+		},
+		{
+			name:     "WARNING aliases to WARN rank",
+			line:     "[2026-06-05T13:36:41Z] WARNING [tp:abc]: stale",
+			minLevel: "WARN", strictLevel: true,
+			wantPass: true,
+		},
+		{
+			name:     "grep regex on full line",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving remote_pk=abc",
+			grepRe:   "remote_pk=abc",
+			wantPass: true,
+		},
+		{
+			name:     "grep regex misses",
+			line:     "[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving",
+			grepRe:   "remote_pk=xyz",
+			wantPass: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var modRE, grepRE *regexp.Regexp
+			if tc.moduleRe != "" {
+				modRE = regexp.MustCompile(tc.moduleRe)
+			}
+			if tc.grepRe != "" {
+				grepRE = regexp.MustCompile(tc.grepRe)
+			}
+			minRank, hasMinLevel := levelOrder[tc.minLevel]
+			got := passesFilters(tc.line, minRank, hasMinLevel, modRE, grepRE, tc.strictLevel)
+			if got != tc.wantPass {
+				t.Fatalf("passesFilters(%q, level=%q, mod=%q, grep=%q) = %v, want %v",
+					tc.line, tc.minLevel, tc.moduleRe, tc.grepRe, got, tc.wantPass)
+			}
+		})
+	}
+}
+
+// TestStreamFilteredVisorLog drives the gin handler end-to-end with a
+// tempfile log + query params, then asserts what comes back over the
+// response body matches the expected filtered subset. Covers the
+// common operator-facing combos.
+func TestStreamFilteredVisorLog(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "logserver-filter-")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	defer os.RemoveAll(tmp) //nolint:errcheck
+
+	logFile := filepath.Join(tmp, "visor.log")
+	body := strings.Join([]string{
+		"[2026-06-05T13:36:41Z] DEBUG [tp:abc]: Serving",
+		"[2026-06-05T13:36:42Z] INFO [sudph]: bound port 56194",
+		"[2026-06-05T13:36:43Z] WARN [tp:abc]: stale conn",
+		"[2026-06-05T13:36:44Z] ERROR [sudph]: handshake timeout",
+		"free-form unstructured line",
+		"[2026-06-05T13:36:45Z] INFO [stcp]: listening :7777",
+	}, "\n") + "\n"
+	if err := os.WriteFile(logFile, []byte(body), 0o644); err != nil { //nolint:gosec
+		t.Fatalf("write log: %v", err)
+	}
+
+	cases := []struct {
+		name        string
+		query       url.Values
+		wantContain []string
+		wantOmit    []string
+	}{
+		{
+			name:        "min-level WARN drops DEBUG/INFO + unparseable",
+			query:       url.Values{"min-level": []string{"WARN"}},
+			wantContain: []string{"WARN [tp:abc]", "ERROR [sudph]"},
+			wantOmit:    []string{"DEBUG [tp:abc]", "INFO [sudph]", "INFO [stcp]", "free-form"},
+		},
+		{
+			name:        "module sudph keeps only sudph lines",
+			query:       url.Values{"module": []string{"sudph"}},
+			wantContain: []string{"INFO [sudph]: bound", "ERROR [sudph]: handshake"},
+			wantOmit:    []string{"[tp:abc]", "[stcp]", "free-form"},
+		},
+		{
+			name:        "limit caps output",
+			query:       url.Values{"min-level": []string{"DEBUG"}, "limit": []string{"2"}},
+			wantContain: []string{"DEBUG [tp:abc]: Serving", "INFO [sudph]: bound"},
+			wantOmit:    []string{"WARN [tp:abc]", "ERROR [sudph]"},
+		},
+		{
+			name:        "grep on body text",
+			query:       url.Values{"grep": []string{"port 56194"}},
+			wantContain: []string{"INFO [sudph]: bound port 56194"},
+			wantOmit:    []string{"DEBUG [tp:abc]", "WARN", "ERROR", "stcp"},
+		},
+		{
+			name:        "since-line skips first N lines",
+			query:       url.Values{"since-line": []string{"3"}},
+			wantContain: []string{"ERROR [sudph]", "free-form", "INFO [stcp]"},
+			wantOmit:    []string{"DEBUG [tp:abc]: Serving", "INFO [sudph]: bound", "WARN [tp:abc]: stale"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			req := httptest.NewRequest("GET", "/visor.log?"+tc.query.Encode(), nil)
+			c.Request = req
+
+			streamFilteredVisorLog(c, logFile, tc.query)
+
+			got := rec.Body.String()
+			for _, want := range tc.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("response missing %q\nbody:\n%s", want, got)
+				}
+			}
+			for _, omit := range tc.wantOmit {
+				if strings.Contains(got, omit) {
+					t.Errorf("response unexpectedly contains %q\nbody:\n%s", omit, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/visor/logserver/visorlog_filter_test.go
+++ b/pkg/visor/logserver/visorlog_filter_test.go
@@ -17,13 +17,13 @@ import (
 // asserts the expected verdict on a representative line shape.
 func TestPassesFilters(t *testing.T) {
 	cases := []struct {
-		name           string
-		line           string
-		minLevel       string // "" = no level filter
-		moduleRe       string // "" = no module filter
-		grepRe         string // "" = no grep filter
-		strictLevel    bool
-		wantPass       bool
+		name        string
+		line        string
+		minLevel    string // "" = no level filter
+		moduleRe    string // "" = no module filter
+		grepRe      string // "" = no grep filter
+		strictLevel bool
+		wantPass    bool
 	}{
 		{
 			name:     "no filters keeps everything",


### PR DESCRIPTION
## Summary

Adds query-param filters to the dmsg/skynet-served \`/visor.log\` endpoint, plumbs the same filters through \`cli log file <pk>\`, and documents the full visor-logging access model (local RPC, \`--via\` RPC bridge, dmsghttp endpoints) including which whitelist gates which surface.

Backwards-compatible: when no filter query param is set, the endpoint still serves the raw file via \`c.File\` — same behavior as today.

## Why

Over slow dmsg/skynet hops, \`cli log file <pk>\` today ships the whole multi-MB log just for the operator to grep it locally. Adding server-side filters lets the visor ship only matching lines.

## Filters

| Query param | CLI flag | Purpose |
| --- | --- | --- |
| \`?min-level=<lvl>\` | \`--min-level\` | keep lines \`>=\` severity (logrus order) |
| \`?module=<regex>\` | \`--module\` | regex on the \`[module]\` tag |
| \`?grep=<regex>\` | \`--grep\` | regex on the full line text |
| \`?since-line=<N>\` | \`--since-line\` | skip the first N lines (resume after disconnect) |
| \`?limit=<N>\` | \`--limit\` | stop after N matching lines |
| \`?follow=1\` | \`--follow / -f\` | tail -f mode (poll for appends until ctx fires) |

**Strict-level mode**: when \`--min-level\` is set, lines that don't match the standard logrus shape \`[ts] LEVEL [module]: msg…\` are dropped so free-form library lines can't sneak past a strict filter. When unset, unparseable lines pass through.

## Auth

Unchanged. \`/visor.log\` stays gated by the remote visor's \`survey_whitelist\` (empty list = publicly accessible, per existing semantics). Filtering adds no new auth surface.

## Docs

- **\`docs/visor-logging-access.md\`** — every CLI command, HTTP endpoint, and the three-whitelist auth model (\`survey_whitelist\` / \`dmsgpty_whitelist\` / \`hypervisors\`), with common recipes and a failure-diagnosis table. This is the doc operators kept asking for when debugging access issues.
- **\`docs/visor-doctor-rfc.md\`** — concrete spec for extending the existing \`cli visor doctor\` with proactive probes (transport reachability per type, AR registration drift, TPD self-view, dmsg-server liveness, RSN reachability, config sanity, optional routing-policy lint). Motivated by three operational bugs this week (PR #3001 TPD edge-index, PR #3003 SUDPH↔AR liveness, PR #3006 RSN cascade) that were all diagnosable with <1s of probing but went undiagnosed because nothing was probing. RFC only; implementation in a follow-up.

## Tests

- **\`TestPassesFilters\`** — 10-case table covering level/module/grep/strict combos and unparseable-line behavior.
- **\`TestStreamFilteredVisorLog\`** — end-to-end via gin testcontext + tempfile log; covers min-level, module, limit, grep, since-line.

## Test plan

- [ ] CI green (gofmt, lint, race, vet, tests across linux/darwin/windows).
- [ ] Manual: \`cli log file <peer-pk> --min-level warn --module sudph --follow\` — verify server-side filtering by sniffing the dmsghttp request (only matching lines on the wire).
- [ ] Backwards-compat: \`cli log file <peer-pk>\` without filter flags still streams the raw file (no behavior change for existing scripts).
- [ ] Whitelist negative: peer not on \`survey_whitelist\` still gets 401/403, regardless of query params.

## Out of scope

- Implementing the doctor probes from the RFC — separate PR, behind operator review of the spec.
- A streaming JSON endpoint for the in-memory ring buffer (\`RuntimeLogs\` over HTTP). The bridge-RPC path covers most use cases via \`cli visor log --via dmsg://<pk>\`; a follow-up could expose the same via HTTP for callers without a local visor.