### PR TITLE
chore(deps): bump hono from 4.12.18 to 4.12.23 in /static/skywire-manager-src

### DIFF
--- a/static/skywire-manager-src/package-lock.json
+++ b/static/skywire-manager-src/package-lock.json
@@ -11771,9 +11771,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Replicates skycoin/skywire#3007 (a dependabot npm bump). `hono` is a transitive dev-dep in `skywire-manager-src`; the change is lockfile-only (version + resolved URL + integrity hash). The diff is byte-identical to the dependabot PR.

## Why a fresh PR

#3007 stalled on CI: linux job failed on `TestFullMeshFourVisor_NoCrossContamination` in `pkg/cxo/treestore` — a **pre-existing develop-tip Go test flake**, completely unrelated to this JS dep bump. darwin + windows both passed there. Same flake class has hit every recent PR (#3000, #3001, #3003, #3004, #3006, #3019).

## Release notes (hono v4.12.19..v4.12.23)

- fix(serve-static): normalize all backslashes in file paths
- feat(context): export Context class publicly
- feat(compress): `contentTypeFilter` option + `COMPRESSIBLE_CONTENT_TYPE_REGEX` re-export
- fix(utils/ipaddr): do not compress a single 0 group to `::`
- fix(mime): specify charset parameter per MIME type

## Test plan

- [ ] CI green (or pre-existing flake only, as on #3007).
- [ ] `skywire-manager-src` build still works — should, since `hono` is only used by the test runner (`"dev": true` in the lockfile).