### PR TITLE
fix(tpd): persist transport edge pair so expired transports keep both edges (bandwidth rewards)

### DIFF
--- a/pkg/transport-discovery/store/bandwidth_edges_test.go
+++ b/pkg/transport-discovery/store/bandwidth_edges_test.go
@@ -1,0 +1,46 @@
+//go:build !no_ci
+// +build !no_ci
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestParseBandwidthEdgePair covers the round-trip of the value written by
+// bandwidthEdgesKey at registration and read back in recoverBandwidthEdges —
+// the mechanism that keeps an expired transport's counterparty identifiable
+// even when only one edge ever published bandwidth.
+func TestParseBandwidthEdgePair(t *testing.T) {
+	pk0, _ := cipher.GenerateKeyPair()
+	pk1, _ := cipher.GenerateKeyPair()
+
+	t.Run("valid pair round-trips in order", func(t *testing.T) {
+		edges, ok := parseBandwidthEdgePair(pk0.Hex() + "," + pk1.Hex())
+		require.True(t, ok)
+		assert.Equal(t, pk0, edges[0])
+		assert.Equal(t, pk1, edges[1])
+	})
+
+	t.Run("rejects wrong field count", func(t *testing.T) {
+		_, ok := parseBandwidthEdgePair(pk0.Hex())
+		assert.False(t, ok)
+		_, ok = parseBandwidthEdgePair(pk0.Hex() + "," + pk1.Hex() + "," + pk0.Hex())
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects malformed hex", func(t *testing.T) {
+		_, ok := parseBandwidthEdgePair("not-a-pk," + pk1.Hex())
+		assert.False(t, ok)
+	})
+
+	t.Run("rejects empty", func(t *testing.T) {
+		_, ok := parseBandwidthEdgePair("")
+		assert.False(t, ok)
+	})
+}

--- a/pkg/transport-discovery/store/redis_bandwidth.go
+++ b/pkg/transport-discovery/store/redis_bandwidth.go
@@ -25,6 +25,21 @@ func (s *redisStore) bandwidthDailyKey(tpID string, t time.Time) string {
 	return fmt.Sprintf("%s:bw:daily:%s:%s", serviceName, tpID, t.Format("2006-01-02"))
 }
 
+// bandwidthHistoryTTL matches the daily-bandwidth hash TTL (see
+// UpdateBandwidth). The persisted edge pair must outlive the ~5-min
+// registration TTL for as long as the bandwidth data it identifies, so an
+// expired transport's counterparty stays recoverable.
+const bandwidthHistoryTTL = 35 * 24 * time.Hour
+
+// bandwidthEdgesKey stores a transport's real edge pair ("<edge0hex>,<edge1hex>")
+// so recoverBandwidthEdges can identify BOTH edges of an expired transport even
+// when only one edge ever published bandwidth (the common case). Without it the
+// field-name reconstruction recovers only the reporting edge and the
+// counterparty collapses to the zero PK — uncreditable in the reward calc.
+func (s *redisStore) bandwidthEdgesKey(tpID string) string {
+	return fmt.Sprintf("%s:bw:edges:%s", serviceName, tpID)
+}
+
 // Visor-level bandwidth key generators
 func (s *redisStore) visorBandwidthDailyKey(pkHex string, t time.Time) string {
 	return fmt.Sprintf("%s:bw:visor:daily:%s:%s", serviceName, pkHex, t.Format("2006-01-02"))

--- a/pkg/transport-discovery/store/redis_metrics.go
+++ b/pkg/transport-discovery/store/redis_metrics.go
@@ -418,6 +418,23 @@ func (s *redisStore) expiredTransportEntries(ctx context.Context, registered map
 	return entries, expiredIDs
 }
 
+// parseBandwidthEdgePair parses the "<edge0hex>,<edge1hex>" value written by
+// bandwidthEdgesKey at registration back into an edge pair (kept in entry
+// order, which the transport.Entry contract already sorts ascending).
+func parseBandwidthEdgePair(v string) ([2]cipher.PubKey, bool) {
+	parts := strings.Split(v, ",")
+	if len(parts) != 2 {
+		return [2]cipher.PubKey{}, false
+	}
+	var edges [2]cipher.PubKey
+	for i, p := range parts {
+		if err := edges[i].UnmarshalText([]byte(p)); err != nil {
+			return [2]cipher.PubKey{}, false
+		}
+	}
+	return edges, true
+}
+
 // recoverBandwidthEdges reconstructs an (offline) transport's edge public keys
 // from its most recent daily-bandwidth hash, whose fields are
 // "<edgePK>:sent" / "<edgePK>:recv". Returns false if no day in the window has
@@ -426,6 +443,18 @@ func (s *redisStore) expiredTransportEntries(ctx context.Context, registered map
 // fields simply won't match, contributing 0 — the total stays correct).
 func (s *redisStore) recoverBandwidthEdges(ctx context.Context, id uuid.UUID, now time.Time, days int) ([2]cipher.PubKey, bool) {
 	var edges [2]cipher.PubKey
+
+	// Prefer the real edge pair persisted at registration (bandwidthEdgesKey,
+	// 35-day TTL). It keeps the counterparty identifiable even when only one
+	// edge ever published bandwidth — the field-name reconstruction below can
+	// only recover the reporting edge, collapsing the other to the zero PK
+	// (which the reward calc cannot credit).
+	if pair, err := s.client.Get(ctx, s.bandwidthEdgesKey(id.String())).Result(); err == nil {
+		if e, ok := parseBandwidthEdgePair(pair); ok {
+			return e, true
+		}
+	}
+
 	for d := 0; d < days; d++ {
 		h, err := s.client.HGetAll(ctx, s.bandwidthDailyKey(id.String(), now.AddDate(0, 0, -d))).Result()
 		if err != nil || len(h) == 0 {

--- a/pkg/transport-discovery/store/redis_transport.go
+++ b/pkg/transport-discovery/store/redis_transport.go
@@ -83,6 +83,16 @@ func (s *redisStore) RegisterTransport(ctx context.Context, _ cipher.PubKey, sEn
 	}
 	pipe.Expire(ctx, s.visorAllKey(), 400*24*time.Hour)
 
+	// Persist the real edge pair (35-day TTL, matching the daily bandwidth) so
+	// recoverBandwidthEdges can identify the counterparty after this transport
+	// expires — even when that edge never publishes its own bandwidth, which is
+	// the common case and the reason ~half of expired transports otherwise lose
+	// their second edge to the zero PK.
+	if entry.Edges[0] != (cipher.PubKey{}) && entry.Edges[1] != (cipher.PubKey{}) {
+		pipe.Set(ctx, s.bandwidthEdgesKey(entry.ID.String()),
+			entry.Edges[0].Hex()+","+entry.Edges[1].Hex(), bandwidthHistoryTTL)
+	}
+
 	if _, err := pipe.Exec(ctx); err != nil {
 		return err
 	}
@@ -149,6 +159,13 @@ func (s *redisStore) RegisterTransportsBatch(ctx context.Context, _ cipher.PubKe
 		pipe.SAdd(ctx, s.visorAllKey(), entry.Edges[0].Hex())
 		if entry.Edges[0] != entry.Edges[1] {
 			pipe.SAdd(ctx, s.visorAllKey(), entry.Edges[1].Hex())
+		}
+
+		// Persist the real edge pair (35-day TTL) so recoverBandwidthEdges keeps
+		// the counterparty identifiable after expiry — see RegisterTransport.
+		if entry.Edges[0] != (cipher.PubKey{}) && entry.Edges[1] != (cipher.PubKey{}) {
+			pipe.Set(ctx, s.bandwidthEdgesKey(entry.ID.String()),
+				entry.Edges[0].Hex()+","+entry.Edges[1].Hex(), bandwidthHistoryTTL)
 		}
 	}
 


### PR DESCRIPTION
## Problem (B2 — bandwidth-reward one-sided records)

Measured live via `cli tp metrics -t -v --json`: **~half the network's transport bandwidth (1.44 of 2.73 GB/day, 2552 transports)** sat on transports whose **second edge was the zero PK** — always `edge_b` (the responder).

For an **expired** transport, `recoverBandwidthEdges` rebuilds the edges from the daily-hash field names (`<edgePK>:sent/recv`). When only one edge ever published bandwidth — the common case, since the two edges publish on independent/intermittent schedules (62 reporters/day, 282/week) — the counterparty has no fields, so its PK is unrecoverable and collapses to `000…0`. The reward calc already symmetric-credits both edges of a *real* pair, but a zero-PK counterparty can't be credited, forcing the equal-share Pool fallback.

This is **edge-identity loss on expiry, not a store clobber** — the daily hash uses per-reporter `HIncrBy` and the aggregator attributes by the authenticated feed owner (#2972).

## Fix

At registration (`RegisterTransport` / `RegisterTransportsBatch` — both the HTTP and CXO register paths funnel through these, and the entry carries both real edges) persist the edge pair under `transport-discovery:bw:edges:<id>` with the **same 35-day TTL as the daily bandwidth**. `recoverBandwidthEdges` reads it first and only falls back to the field-name reconstruction when absent. An expired transport's counterparty then stays identifiable and symmetric-creditable.

## Scope / validation

- TPD-side only; **takes effect on TPD redeploy**. No visor change.
- `go test ./pkg/transport-discovery/store/` (added `TestParseBandwidthEdgePair`); vet + gofmt clean.
- Post-deploy validation: the zero-`edge_b` share in `cli tp metrics -t -v --json` should fall toward zero as transports re-register under the new code.

The reward-calc equal-share-fallback retirement remains a **separate trust decision** (single-edge symmetric crediting has an inflation surface that same-day dual-edge corroboration would close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)