### PR TITLE
feat(router/policy): embedded routing-policy presets + spread-bw (benevolent bandwidth spreading)

### DIFF
--- a/pkg/router/policy/loader.go
+++ b/pkg/router/policy/loader.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/skycoin/skywire/pkg/router/policy/presets"
 )
 
 // Loader manages an Evaluator constructed from a config field.
@@ -80,6 +82,23 @@ func NewLoader(raw string, opts ...Option) (*Loader, error) {
 		// WithLogger explicitly if they want reload events
 		// logged.
 		_ = o
+	}
+
+	// preset:<name> — a curated policy embedded in the binary (no file, no
+	// compile). Resolves to inline Starlark source from the presets registry.
+	if name, ok := strings.CutPrefix(raw, "preset:"); ok {
+		src, found := presets.Source(name)
+		if !found {
+			return nil, fmt.Errorf("policy: unknown preset %q (available: %s)",
+				name, strings.Join(presets.Names(), ", "))
+		}
+		l.source = "<preset:" + name + ">"
+		eval, err := NewEvaluator(l.source, src, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("policy: preset %q failed to load: %w", name, err)
+		}
+		l.current.Store(eval)
+		return l, nil
 	}
 
 	if strings.HasPrefix(raw, "@") {

--- a/pkg/router/policy/preset_loader_test.go
+++ b/pkg/router/policy/preset_loader_test.go
@@ -1,0 +1,39 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/router/policy/presets"
+)
+
+// TestPresetLoader covers the "preset:<name>" config form: an embedded,
+// no-compile policy selectable by name (the mechanism behind the spread-bw /
+// benevolent-browsing preset).
+func TestPresetLoader(t *testing.T) {
+	t.Run("registry exposes spread-bw", func(t *testing.T) {
+		assert.Contains(t, presets.Names(), "spread-bw")
+		src, ok := presets.Source("spread-bw")
+		require.True(t, ok)
+		assert.Contains(t, src, "decide_route")
+	})
+
+	t.Run("spread-bw loads and forces parallel multihop", func(t *testing.T) {
+		l, err := NewLoader("preset:spread-bw")
+		require.NoError(t, err)
+		spec, err := l.Decide(context.Background(), RoutingContext{App: "skysocks-client"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 4, spec.Mux)
+		assert.Equal(t, 2, spec.MinHops)
+		assert.Greater(t, spec.RotationIntervalSeconds, 0)
+	})
+
+	t.Run("unknown preset errors with available list", func(t *testing.T) {
+		_, err := NewLoader("preset:does-not-exist")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spread-bw")
+	})
+}

--- a/pkg/router/policy/presets/presets.go
+++ b/pkg/router/policy/presets/presets.go
@@ -1,0 +1,60 @@
+// Package presets pkg/router/policy/presets — curated routing-policy programs
+// embedded in the skywire binary, selectable by name without writing or
+// compiling a policy file. A config value of the form "preset:<name>" resolves
+// to one of these (see pkg/router/policy/loader.go), so a remote visor runs the
+// exact same tested policy by name — no fetching or compiling source on the
+// target.
+//
+// Each *.star file in this directory is a preset; the preset name is the
+// filename without the ".star" suffix. Adding a preset is just dropping a file
+// here. Starlark presets need no build step (interpreted at load); precompiled
+// TinyGo .wasm presets can be added alongside in a follow-up via a parallel
+// registry keyed the same way.
+package presets
+
+import (
+	"embed"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+//go:embed *.star
+var fsys embed.FS
+
+var registry = loadRegistry()
+
+func loadRegistry() map[string]string {
+	m := map[string]string{}
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return m
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".star") {
+			continue
+		}
+		b, err := fsys.ReadFile(e.Name())
+		if err != nil {
+			continue
+		}
+		m[strings.TrimSuffix(e.Name(), ".star")] = string(b)
+	}
+	return m
+}
+
+// Source returns the embedded Starlark source for a preset name, if it exists.
+func Source(name string) (string, bool) {
+	s, ok := registry[name]
+	return s, ok
+}
+
+// Names returns the available preset names, sorted.
+func Names() []string {
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/router/policy/presets/spread-bw.star
+++ b/pkg/router/policy/presets/spread-bw.star
@@ -1,0 +1,42 @@
+# spread-bw — benevolent bandwidth spreading (the "browse benevolently" preset).
+#
+# Routes app traffic (browser/Telegram/VPN over skysocks-client, etc.) across
+# parallel MULTIHOP routes and continuously rotates each leg onto a fresh set
+# of intermediates once it has carried a byte budget. Because min_hops >= 2
+# forces every leg through real intermediate visors — and intermediates earn
+# bandwidth-reward credit for what they relay — ordinary browsing through this
+# policy distributes a reward-eligible bandwidth floor across many network
+# visors instead of pinning to one path. Dynamic routing, not a static circuit.
+#
+# Note: the exit/proxy server itself is typically NOT reward-eligible, so the
+# value here is the spread to the intermediate relays, not the exit.
+#
+# Select it without compiling or shipping a file:
+#   "routing": { "policy_per_dial": "preset:spread-bw" }
+
+MUX = 4               # parallel legs — spread across MUX intermediates at once
+MIN_HOPS = 2          # >= 2 forces real intermediates (excludes the direct transport)
+ROTATE_SECS = 20      # rotation cadence
+LEG_BUDGET = 8000000  # rotate a leg after it has carried ~8 MB, spreading over time
+
+def decide_route(ctx, candidates):
+    return RouteSpec(
+        mux=MUX,
+        min_hops=MIN_HOPS,
+        distribution="auto",
+        rotation_interval_seconds=ROTATE_SECS,
+    )
+
+def on_tick(ctx, legs):
+    # Retire any leg that has carried its byte budget, excluding its
+    # intermediates from the replacement so the next leg lands on fresh
+    # relays — this is what spreads the bandwidth around over time.
+    drop = []
+    excl = []
+    for l in legs:
+        if l.alive and (l.sent_bytes + l.recv_bytes) > LEG_BUDGET:
+            drop.append(l.index)
+            excl = excl + l.hops
+    if len(drop) == 0:
+        return None
+    return Rotation(drop_legs=drop, add_leg=True, exclude_hops=excl)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -400,6 +400,10 @@ type Routing struct {
 
 	// PolicyPerDial is an optional operator-supplied routing
 	// policy. Accepts either:
+	//   "preset:<name>"          — a curated policy embedded in the
+	//                              binary, no file or compile needed
+	//                              (e.g. "preset:spread-bw"); presets
+	//                              live in pkg/router/policy/presets
 	//   "@/path/to/policy.star"  — Starlark, file-backed, hot-reloaded
 	//   "@/path/to/policy.wasm"  — WASM, file-backed, hot-reloaded
 	//   "<inline script source>" — small inline Starlark policies


### PR DESCRIPTION
## What

A `preset:<name>` form for `PolicyPerDial` that resolves to a curated routing policy **embedded in the binary** — no policy file to ship, no compile step. A remote visor runs the exact same tested policy by name, so remote testing no longer depends on fetching or compiling source.

```json
"routing": { "policy_per_dial": "preset:spread-bw" }
```

Presets live in `pkg/router/policy/presets/` as `*.star` files (the preset name is the filename). Adding one is just dropping a file there. The Starlark loader resolves `preset:<name>` to inline source; `isWasmPath` already routes non-`@` values to Starlark, so backend dispatch is unchanged.

## Flagship preset: `spread-bw` (browse benevolently)

Routes app traffic (browser / Telegram / VPN over `skysocks-client`, etc.) across **parallel multihop routes** (`mux=4, min_hops=2`) and **continuously rotates** each leg onto fresh intermediates once it has carried a byte budget (`on_tick` → drop + `exclude_hops` + add).

Because `min_hops >= 2` forces real intermediate hops, and intermediates earn bandwidth-reward credit for relaying, ordinary browsing through this policy **distributes a reward-eligible bandwidth floor across many network visors** instead of pinning to one path. Dynamic routing, not a static circuit — and the basis for a future selectable UI preset.

## Scope

- `go test ./pkg/router/policy/...` passes (added `TestPresetLoader`); vet + gofmt clean.
- Starlark presets need no build step (interpreted at load). Precompiled TinyGo `.wasm` presets can be added via a parallel registry keyed the same way in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)