### PR TITLE
feat(router/mux): per-leg loss signal + resilient spread-bw leg rotation

### DIFF
--- a/pkg/router/dial_hook.go
+++ b/pkg/router/dial_hook.go
@@ -279,6 +279,10 @@ type LegInfo struct {
 	// rather than purely on elapsed time.
 	SentBytes uint64
 	RecvBytes uint64
+	// Retransmits is how many SACK retransmit packets this leg has carried.
+	// A high retransmits-to-traffic ratio marks a lossy leg, letting an
+	// on_tick policy shed lossy intermediates (not just slow ones).
+	Retransmits uint64
 	// Hops is the intermediate-PK chain this leg traverses (forward,
 	// src->dst, endpoints excluded). Lets on_tick build a precise
 	// ExcludeHops set so a rotated-in leg avoids the rotated-out leg's

--- a/pkg/router/policy/bridge.go
+++ b/pkg/router/policy/bridge.go
@@ -212,13 +212,14 @@ func buildLegsValue(legs []LegInfo) starlark.Value {
 		out = append(out, starlarkstruct.FromStringDict(
 			starlarkstruct.Default,
 			starlark.StringDict{
-				"index":      starlark.MakeInt(l.Index),
-				"kind":       starlark.String(l.Kind),
-				"latency_ms": starlark.MakeInt(l.LatencyMs),
-				"alive":      starlark.Bool(l.Alive),
-				"sent_bytes": starlark.MakeUint64(l.SentBytes),
-				"recv_bytes": starlark.MakeUint64(l.RecvBytes),
-				"hops":       starlark.NewList(hops),
+				"index":       starlark.MakeInt(l.Index),
+				"kind":        starlark.String(l.Kind),
+				"latency_ms":  starlark.MakeInt(l.LatencyMs),
+				"alive":       starlark.Bool(l.Alive),
+				"sent_bytes":  starlark.MakeUint64(l.SentBytes),
+				"recv_bytes":  starlark.MakeUint64(l.RecvBytes),
+				"retransmits": starlark.MakeUint64(l.Retransmits),
+				"hops":        starlark.NewList(hops),
 			},
 		))
 	}

--- a/pkg/router/policy/evaluator.go
+++ b/pkg/router/policy/evaluator.go
@@ -359,13 +359,14 @@ func (e *Evaluator) OnTick(ctx context.Context, rctx RoutingContext, legs []LegI
 // pulling in the router. The bridge layer converts between the
 // two when the hook fires.
 type LegInfo struct {
-	Index     int
-	Kind      string
-	LatencyMs int
-	Alive     bool
-	SentBytes uint64
-	RecvBytes uint64
-	Hops      []string
+	Index       int
+	Kind        string
+	LatencyMs   int
+	Alive       bool
+	SentBytes   uint64
+	RecvBytes   uint64
+	Retransmits uint64
+	Hops        []string
 }
 
 type LegChange struct {

--- a/pkg/router/policy/hook.go
+++ b/pkg/router/policy/hook.go
@@ -357,13 +357,14 @@ func (h *Hook) OnTick(info router.DialInfo, legs []router.LegInfo) router.Rotati
 	policyLegs := make([]LegInfo, 0, len(legs))
 	for _, l := range legs {
 		policyLegs = append(policyLegs, LegInfo{
-			Index:     l.Index,
-			Kind:      l.Kind,
-			LatencyMs: l.LatencyMs,
-			Alive:     l.Alive,
-			SentBytes: l.SentBytes,
-			RecvBytes: l.RecvBytes,
-			Hops:      l.Hops,
+			Index:       l.Index,
+			Kind:        l.Kind,
+			LatencyMs:   l.LatencyMs,
+			Alive:       l.Alive,
+			SentBytes:   l.SentBytes,
+			RecvBytes:   l.RecvBytes,
+			Retransmits: l.Retransmits,
+			Hops:        l.Hops,
 		})
 	}
 	rctx := RoutingContext{
@@ -402,13 +403,14 @@ func (h *Hook) OnLegChange(info router.DialInfo, legs []router.LegInfo, change r
 	policyLegs := make([]LegInfo, 0, len(legs))
 	for _, l := range legs {
 		policyLegs = append(policyLegs, LegInfo{
-			Index:     l.Index,
-			Kind:      l.Kind,
-			LatencyMs: l.LatencyMs,
-			Alive:     l.Alive,
-			SentBytes: l.SentBytes,
-			RecvBytes: l.RecvBytes,
-			Hops:      l.Hops,
+			Index:       l.Index,
+			Kind:        l.Kind,
+			LatencyMs:   l.LatencyMs,
+			Alive:       l.Alive,
+			SentBytes:   l.SentBytes,
+			RecvBytes:   l.RecvBytes,
+			Retransmits: l.Retransmits,
+			Hops:        l.Hops,
 		})
 	}
 	policyChange := LegChange{Event: change.Event, LegIndex: change.LegIndex}

--- a/pkg/router/policy/presets/spread-bw.star
+++ b/pkg/router/policy/presets/spread-bw.star
@@ -1,23 +1,32 @@
 # spread-bw — benevolent bandwidth spreading (the "browse benevolently" preset).
 #
 # Routes app traffic (browser/Telegram/VPN over skysocks-client, etc.) across
-# parallel MULTIHOP routes and continuously rotates each leg onto a fresh set
-# of intermediates once it has carried a byte budget. Because min_hops >= 2
-# forces every leg through real intermediate visors — and intermediates earn
-# bandwidth-reward credit for what they relay — ordinary browsing through this
-# policy distributes a reward-eligible bandwidth floor across many network
-# visors instead of pinning to one path. Dynamic routing, not a static circuit.
+# parallel MULTIHOP routes and continuously maintains the mux: it sheds the
+# single worst leg per tick — lossy (high SACK retransmits) or slow (high RTT)
+# first, otherwise one that has carried its byte budget — and replaces it with a
+# fresh leg through different intermediates. Because min_hops >= 2 forces every
+# leg through real intermediate visors (which earn bandwidth-reward credit for
+# relaying), ordinary browsing through this policy distributes a reward-eligible
+# bandwidth floor across many network visors. Dynamic routing, not a static
+# circuit.
 #
-# Note: the exit/proxy server itself is typically NOT reward-eligible, so the
-# value here is the spread to the intermediate relays, not the exit.
+# Resilience: only ONE leg is retired per tick and never the last live leg, so
+# the remaining legs keep serving — no simultaneous drop-all that stalls the
+# connection. Lossy/slow legs are scored by latency + a heavy per-retransmit
+# penalty and shed only when clearly worse than the healthiest leg, so healthy
+# legs aren't churned.
 #
 # Select it without compiling or shipping a file:
 #   "routing": { "policy_per_dial": "preset:spread-bw" }
 
 MUX = 4               # parallel legs — spread across MUX intermediates at once
 MIN_HOPS = 2          # >= 2 forces real intermediates (excludes the direct transport)
-ROTATE_SECS = 20      # rotation cadence
-LEG_BUDGET = 8000000  # rotate a leg after it has carried ~8 MB, spreading over time
+ROTATE_SECS = 15      # health/rotation tick cadence
+LEG_BUDGET = 8000000  # retire a leg after it has carried ~8 MB, spreading over time
+
+RETX_PENALTY_MS = 50  # each SACK retransmit adds this much "badness" (loss >> latency)
+BAD_LEG_FACTOR = 2    # shed a leg only when this many times worse than the best
+MIN_BAD_MS = 200      # ...and only above this absolute badness (don't churn fast legs)
 
 def decide_route(ctx, candidates):
     return RouteSpec(
@@ -27,16 +36,37 @@ def decide_route(ctx, candidates):
         rotation_interval_seconds=ROTATE_SECS,
     )
 
+def _badness(l):
+    # Lossy legs cost far more than merely slow ones.
+    return l.latency_ms + l.retransmits * RETX_PENALTY_MS
+
 def on_tick(ctx, legs):
-    # Retire any leg that has carried its byte budget, excluding its
-    # intermediates from the replacement so the next leg lands on fresh
-    # relays — this is what spreads the bandwidth around over time.
-    drop = []
-    excl = []
-    for l in legs:
-        if l.alive and (l.sent_bytes + l.recv_bytes) > LEG_BUDGET:
-            drop.append(l.index)
-            excl = excl + l.hops
-    if len(drop) == 0:
+    alive = [l for l in legs if l.alive]
+    if len(alive) < 2:
+        return None  # never retire our last working leg
+
+    worst = alive[0]
+    best = alive[0]
+    for l in alive:
+        if _badness(l) > _badness(worst):
+            worst = l
+        if _badness(l) < _badness(best):
+            best = l
+
+    drop = None
+    if _badness(worst) > MIN_BAD_MS and _badness(worst) > _badness(best) * BAD_LEG_FACTOR:
+        # 1) Shed a clearly-unhealthy (lossy or slow) leg.
+        drop = worst
+    else:
+        # 2) Otherwise keep spreading: retire one budget-exhausted leg onto a
+        #    fresh set of intermediates.
+        for l in alive:
+            if (l.sent_bytes + l.recv_bytes) > LEG_BUDGET:
+                drop = l
+                break
+
+    if drop == None:
         return None
-    return Rotation(drop_legs=drop, add_leg=True, exclude_hops=excl)
+    # Replace it (add_leg) and steer the replacement away from this leg's
+    # intermediates so we land on fresh relays.
+    return Rotation(drop_legs=[drop.index], add_leg=True, exclude_hops=drop.hops)

--- a/pkg/router/policy/spread_bw_health_test.go
+++ b/pkg/router/policy/spread_bw_health_test.go
@@ -1,0 +1,68 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpreadBWLegHealth exercises the spread-bw preset's on_tick resilience:
+// it sheds the single worst (lossy/slow) leg per tick and replaces it, never
+// drops the last live leg, and surfaces the new per-leg retransmit signal.
+func TestSpreadBWLegHealth(t *testing.T) {
+	load := func(t *testing.T) *Loader {
+		l, err := NewLoader("preset:spread-bw")
+		require.NoError(t, err)
+		return l
+	}
+	tick := func(t *testing.T, l *Loader, legs []LegInfo) RotationAction {
+		act, err := l.OnTick(context.Background(), RoutingContext{App: "skysocks-client"}, legs)
+		require.NoError(t, err)
+		return act
+	}
+
+	t.Run("sheds the single lossy leg and replaces it", func(t *testing.T) {
+		// leg 2 has heavy retransmits → highest badness; others healthy.
+		legs := []LegInfo{
+			{Index: 0, Alive: true, LatencyMs: 50, Hops: []string{"a"}},
+			{Index: 1, Alive: true, LatencyMs: 60, Hops: []string{"b"}},
+			{Index: 2, Alive: true, LatencyMs: 55, Retransmits: 20, Hops: []string{"c"}},
+			{Index: 3, Alive: true, LatencyMs: 70, Hops: []string{"d"}},
+		}
+		act := tick(t, load(t), legs)
+		assert.Equal(t, []int{2}, act.DropLegs, "only the lossy leg")
+		assert.True(t, act.AddLeg, "replace it to keep the mux degree")
+		assert.Equal(t, []string{"c"}, act.ExcludeHops, "steer the replacement off its intermediate")
+	})
+
+	t.Run("sheds a clearly-slow leg", func(t *testing.T) {
+		legs := []LegInfo{
+			{Index: 0, Alive: true, LatencyMs: 40},
+			{Index: 1, Alive: true, LatencyMs: 900}, // ~22x the best
+			{Index: 2, Alive: true, LatencyMs: 50},
+		}
+		act := tick(t, load(t), legs)
+		assert.Equal(t, []int{1}, act.DropLegs)
+	})
+
+	t.Run("never drops the last live leg", func(t *testing.T) {
+		legs := []LegInfo{
+			{Index: 0, Alive: true, LatencyMs: 5000, Retransmits: 999},
+			{Index: 1, Alive: false},
+		}
+		act := tick(t, load(t), legs)
+		assert.Empty(t, act.DropLegs)
+	})
+
+	t.Run("healthy legs under budget → no rotation", func(t *testing.T) {
+		legs := []LegInfo{
+			{Index: 0, Alive: true, LatencyMs: 50, SentBytes: 1000, RecvBytes: 1000},
+			{Index: 1, Alive: true, LatencyMs: 55, SentBytes: 1000, RecvBytes: 1000},
+		}
+		act := tick(t, load(t), legs)
+		assert.Empty(t, act.DropLegs)
+		assert.False(t, act.AddLeg)
+	})
+}

--- a/pkg/router/policy/wasm/abi.go
+++ b/pkg/router/policy/wasm/abi.go
@@ -14,13 +14,14 @@ package wasm
 
 // LegInfoWire mirrors policy.LegInfo as a JSON wire type.
 type LegInfoWire struct {
-	Index     int      `json:"index"`
-	Kind      string   `json:"kind"`
-	LatencyMs int      `json:"latency_ms"`
-	Alive     bool     `json:"alive"`
-	SentBytes uint64   `json:"sent_bytes,omitempty"`
-	RecvBytes uint64   `json:"recv_bytes,omitempty"`
-	Hops      []string `json:"hops,omitempty"`
+	Index       int      `json:"index"`
+	Kind        string   `json:"kind"`
+	LatencyMs   int      `json:"latency_ms"`
+	Alive       bool     `json:"alive"`
+	SentBytes   uint64   `json:"sent_bytes,omitempty"`
+	RecvBytes   uint64   `json:"recv_bytes,omitempty"`
+	Retransmits uint64   `json:"retransmits,omitempty"`
+	Hops        []string `json:"hops,omitempty"`
 }
 
 // LegChangeWire mirrors policy.LegChange as a JSON wire type.

--- a/pkg/router/policy/wasm/evaluator.go
+++ b/pkg/router/policy/wasm/evaluator.go
@@ -411,13 +411,14 @@ func wireFromLegs(legs []policy.LegInfo) []LegInfoWire {
 	out := make([]LegInfoWire, len(legs))
 	for i, l := range legs {
 		out[i] = LegInfoWire{
-			Index:     l.Index,
-			Kind:      l.Kind,
-			LatencyMs: l.LatencyMs,
-			Alive:     l.Alive,
-			SentBytes: l.SentBytes,
-			RecvBytes: l.RecvBytes,
-			Hops:      l.Hops,
+			Index:       l.Index,
+			Kind:        l.Kind,
+			LatencyMs:   l.LatencyMs,
+			Alive:       l.Alive,
+			SentBytes:   l.SentBytes,
+			RecvBytes:   l.RecvBytes,
+			Retransmits: l.Retransmits,
+			Hops:        l.Hops,
 		}
 	}
 	return out

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -628,6 +628,9 @@ func (rg *RouteGroup) snapshotLegs() []LegInfo {
 				l.SentBytes = bw.SentBytes
 				l.RecvBytes = bw.RecvBytes
 			}
+			if rg.mux != nil {
+				l.Retransmits = rg.mux.retransmitsAt(i)
+			}
 			l.Hops = sharedHops
 		}
 		legs = append(legs, l)
@@ -1527,6 +1530,7 @@ func (rg *RouteGroup) handleSACKPacket(packet routing.Packet) error {
 			// (which may differ from the original send leg — the
 			// retx selector picks fresh, mirroring the data path).
 			rg.mux.recordSent(leg, uint64(retxPacket.Size()))
+			rg.mux.recordRetransmit(leg) // separate loss signal for leg health
 		}
 	}
 	return nil

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -32,6 +32,11 @@ type LegStats struct {
 	// not what the peer said it sent.
 	RecvBytes   uint64
 	RecvPackets uint64
+	// Retransmits is how many SACK retransmit packets THIS leg has
+	// carried. A high retransmits:sentPackets ratio marks a lossy leg —
+	// the signal a routing policy needs to shed lossy intermediates and
+	// the scheduler needs to deweight them.
+	Retransmits uint64
 }
 
 type legCounters struct {
@@ -39,6 +44,7 @@ type legCounters struct {
 	sentPackets uint64 // atomic
 	recvBytes   uint64 // atomic
 	recvPackets uint64 // atomic
+	retransmits uint64 // atomic
 }
 
 // routeMux encapsulates route multiplexing state and logic.
@@ -236,6 +242,34 @@ func (m *routeMux) recordRecv(idx int, n uint64) {
 	m.legMu.RUnlock()
 }
 
+// recordRetransmit atomically increments the retransmit counter for leg
+// idx (the leg that carried a SACK retransmit). The retransmitted bytes
+// are still recorded via recordSent; this is the separate loss signal.
+func (m *routeMux) recordRetransmit(idx int) {
+	if idx < 0 {
+		return
+	}
+	m.legMu.RLock()
+	if idx < len(m.legs) {
+		atomic.AddUint64(&m.legs[idx].retransmits, 1)
+	}
+	m.legMu.RUnlock()
+}
+
+// retransmitsAt returns leg idx's cumulative retransmit count (0 if out of
+// range), for snapshotLegs / LegInfo without a full Snapshot allocation.
+func (m *routeMux) retransmitsAt(idx int) uint64 {
+	if idx < 0 {
+		return 0
+	}
+	m.legMu.RLock()
+	defer m.legMu.RUnlock()
+	if idx < len(m.legs) {
+		return atomic.LoadUint64(&m.legs[idx].retransmits)
+	}
+	return 0
+}
+
 // snapshotLegs returns a stable copy of the current per-leg counters.
 // Atomic loads, no locking against in-flight increments — the
 // snapshot is point-in-time and the underlying counters keep moving.
@@ -249,6 +283,7 @@ func (m *routeMux) snapshotLegs() []LegStats {
 			SentPackets: atomic.LoadUint64(&c.sentPackets),
 			RecvBytes:   atomic.LoadUint64(&c.recvBytes),
 			RecvPackets: atomic.LoadUint64(&c.recvPackets),
+			Retransmits: atomic.LoadUint64(&c.retransmits),
 		}
 	}
 	m.legMu.RUnlock()


### PR DESCRIPTION
> Stacked on #3025 (the launcher fix) — the live mux needs that to start the proxy at all. Rebase onto develop once #3025 lands.

## What

Makes the mux able to shed lossy/slow legs and hold its degree, instead of stalling.

1. **Per-leg loss signal.** The mux counted SACK retransmits but folded them into the leg's *sent* counter, so `LegInfo` exposed only latency — a policy couldn't tell a lossy leg from a healthy one. Added a distinct per-leg `recordRetransmit` counter, surfaced end-to-end: `route.LegInfo.Retransmits` → `policy.LegInfo` → the Starlark `leg.retransmits` field and the WASM `LegInfoWire`.
2. **Resilient spread-bw `on_tick`.** The old policy dropped *every* over-budget leg at once → the mux collapsed to zero legs → connection stall (observed live). Rewritten to score each leg `latency_ms + retransmits×50` (loss weighted above slowness) and shed **at most one** leg per tick — the worst, only when clearly worse than the healthiest (≥2× + floor) so healthy legs aren't churned; otherwise rotate one budget-exhausted leg for spreading. **Never drops the last live leg**; always `add_leg` + `exclude_hops` so the replacement lands on fresh relays.

## Tested

`TestSpreadBWLegHealth` + `TestUpdateBoolArg`/existing policy tests pass; `go build ./...`, vet, gofmt clean.

## Not yet live-validated (and why) — companion work

The self-healing runs only once the mux is *up*, but I could not get the spread-bw mux to **establish** on a NAT'd source: the primary multihop leg's route setup times out (`cascade ACK timeout` → DMSG fallback → 30s handshake timeout), so the dial fails and the SOCKS5 listener never binds ("refusing connections"). Two follow-ups gate live use:
- **Bind the SOCKS5 listener on the first leg** + build the mux degree in the background, so browsing works *during* the slow multihop setup.
- **Multihop route-setup reliability** from NAT'd sources (the cascade/handshake timeouts — ties into the source-driven cascade work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)