### PR TITLE
fix(router): reliable multihop route setup — legacy default, handshake fallover, self-healing mux

### DIFF
--- a/pkg/router/cascade_builder.go
+++ b/pkg/router/cascade_builder.go
@@ -60,7 +60,7 @@ func NewCascadeBuilder(
 		rsnSK:          rsnSK,
 		tm:             tm,
 		acks:           newAckRegistry(),
-		reserveTimeout: 10 * time.Second,
+		reserveTimeout: 6 * time.Second,
 		installTimeout: 10 * time.Second,
 	}
 }
@@ -84,7 +84,7 @@ func NewSourceCascadeBuilder(
 		log:            log,
 		tm:             tm,
 		acks:           acks,
-		reserveTimeout: 10 * time.Second,
+		reserveTimeout: 6 * time.Second,
 		installTimeout: 10 * time.Second,
 	}
 }

--- a/pkg/router/cascade_source.go
+++ b/pkg/router/cascade_source.go
@@ -112,8 +112,8 @@ func runSourceCascade(
 		return routing.EdgeRules{}, fmt.Errorf("cascade: rev reserve rejected: %s", revAck.Error)
 	}
 
-	log.WithField("fwd_ids", len(fwdAck.RouteIDs)).
-		WithField("rev_ids", len(revAck.RouteIDs)).
+	log.WithField("fwd_ids", fmt.Sprintf("%v", fwdAck.RouteIDs)).
+		WithField("rev_ids", fmt.Sprintf("%v", revAck.RouteIDs)).
 		Debug("Source-driven cascade: reserved route IDs, requesting install signatures")
 
 	// --- Phase 2: ask RSN to sign install cascades (recomputes rules) ---

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -176,6 +176,17 @@ type RouteGroup struct {
 	rotationHook     RotationHook
 	rotationApplyAdd func(excludeHops []string)
 	rotationInterval time.Duration
+
+	// selfHealAdd restores the multiplexed degree in the background when a
+	// leg dies. pruneDeadTransports drops the dead leg (surviving legs
+	// immediately carry its share via the selector), then maybeSelfHeal
+	// dials replacement aux legs up to selfHealTarget — without blocking
+	// traffic. Wired for EVERY mux dial, not just policy-rotation ones, so
+	// a plain `--routes N` group self-heals too. healInFlight guards against
+	// piling up concurrent heals while a replacement is still dialing.
+	selfHealAdd    func(excludeHops []string)
+	selfHealTarget int
+	healInFlight   atomic.Bool
 }
 
 // NewRouteGroup creates a new RouteGroup.
@@ -596,6 +607,77 @@ func (rg *RouteGroup) SetRotation(hook RotationHook, applyAdd func(excludeHops [
 	}
 }
 
+// SetSelfHeal wires the background degree-restoration callback for a
+// multiplexed route group. When a leg is pruned and the live degree drops
+// below target, the route group dials replacement aux legs (via applyAdd)
+// without blocking traffic — surviving legs carry the load meanwhile. target
+// is the requested mux degree (legs the group should maintain). A target of
+// 0 or 1 disables self-heal (a single-leg group has nothing to spread to).
+func (rg *RouteGroup) SetSelfHeal(applyAdd func(excludeHops []string), target int) {
+	rg.mu.Lock()
+	rg.selfHealAdd = applyAdd
+	rg.selfHealTarget = target
+	rg.mu.Unlock()
+}
+
+// aliveLegCount returns the number of live legs (non-nil, unclosed
+// transports). Caller must NOT hold rg.mu.
+func (rg *RouteGroup) aliveLegCount() int {
+	rg.mu.Lock()
+	defer rg.mu.Unlock()
+	n := 0
+	for _, tp := range rg.tps {
+		if tp != nil && !tp.IsClosed() {
+			n++
+		}
+	}
+	return n
+}
+
+// maybeSelfHeal restores the multiplexed degree after a leg drop. If the live
+// leg count fell below target and no replacement is already in flight, it
+// dials replacement aux legs in the background until the degree is restored
+// (or a bounded number of attempts is exhausted, so a destination with no
+// remaining disjoint paths can't loop forever). Non-blocking: surviving legs
+// keep carrying traffic while replacements set up. healInFlight bounds this to
+// one concurrent heal so a flapping leg can't spawn a storm of setup dials.
+//
+// Must NOT be called while holding rg.mu.
+func (rg *RouteGroup) maybeSelfHeal() {
+	rg.mu.Lock()
+	add := rg.selfHealAdd
+	target := rg.selfHealTarget
+	rg.mu.Unlock()
+	if add == nil || target <= 1 || rg.isClosed() {
+		return
+	}
+	if rg.aliveLegCount() >= target {
+		return
+	}
+	if !rg.healInFlight.CompareAndSwap(false, true) {
+		return // a replacement is already dialing
+	}
+	go func() {
+		defer rg.healInFlight.Store(false)
+		// Each add(nil) blocks ~one setup-node dial and, on success,
+		// appends one leg. Re-check the live count between attempts and
+		// stop as soon as the degree is restored, the group closes, or we
+		// hit the attempt cap (target+1 gives a little headroom for dials
+		// that fail on a bad intermediate before one lands).
+		for attempt := 0; attempt < target+1; attempt++ {
+			if rg.isClosed() || rg.aliveLegCount() >= target {
+				return
+			}
+			if rg.logger != nil {
+				rg.logger.WithField("alive", rg.aliveLegCount()).
+					WithField("target", target).
+					Debug("Mux self-heal: dialing replacement leg to restore degree")
+			}
+			add(nil)
+		}
+	}()
+}
+
 // snapshotLegs builds a []LegInfo from the current rg.tps. Caller
 // must hold rg.mu. Used by the leg-change fire path to give the
 // policy script a snapshot it can iterate.
@@ -955,6 +1037,9 @@ func (rg *RouteGroup) dropLegsByIndex(indices []int) {
 	for _, idx := range droppedIdx {
 		rg.fireLegChange("dropped", idx)
 	}
+	if len(droppedIdx) > 0 {
+		rg.maybeSelfHeal()
+	}
 	if rg.logger != nil && len(closed) > 0 {
 		rg.logger.
 			WithField("dropped_indices", closed).
@@ -1071,6 +1156,9 @@ func (rg *RouteGroup) keepAliveServiceFn(interval time.Duration) {
 	// re-takes rg.mu).
 	for _, idx := range droppedLegs {
 		rg.fireLegChange("dropped", idx)
+	}
+	if len(droppedLegs) > 0 {
+		rg.maybeSelfHeal()
 	}
 }
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -36,7 +36,15 @@ const (
 	DefaultRulesGCInterval = 10 * time.Second
 	acceptSize             = 1024
 
-	handshakeAwaitTimeout = 30 * time.Second
+	// handshakeAwaitTimeout bounds the dial-side wait for the remote's
+	// reciprocal route-group handshake. A handshake is a single small packet
+	// each way, so even a 6-hop high-latency route completes in a few seconds;
+	// 30s was ~20x the worst realistic RTT and meant a single flaky / dead
+	// intermediate stalled the whole dial for half a minute before the
+	// retry-with-exclude loop in DialRoutes could try another candidate. A
+	// tighter bound turns "remote not responding" into a fast failure that the
+	// fallback loop converts into the next candidate route. See DialRoutes.
+	handshakeAwaitTimeout = 12 * time.Second
 
 	maxHops       = 1000
 	retryDuration = 2 * time.Second

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -317,15 +317,22 @@ func (r *router) DialRoutes(
 			})
 		}
 
-		// Rotation hook (RFC #2882 — periodic-tick / bandwidth-
-		// spreading). The dial-side DialHook may also implement
-		// RotationHook; when it does AND the policy returned
-		// RotationIntervalSeconds > 0, the route group's rotation
-		// servicePacketLoop fires the hook periodically. The
-		// applyAdd callback closes over the current dial context
-		// and forwardDesc so the rotation can add aux legs that
-		// match the original dial shape.
-		if rh, ok := r.conf.DialHook.(RotationHook); ok && rh != nil && opts.RotationIntervalSeconds > 0 {
+		// Add-leg callback for any multiplexed dial. It closes over the
+		// dial context + forwardDesc so a replacement leg matches the
+		// original dial shape (same peer, ports, min-hops, app). Used by
+		// BOTH the route group's self-healing (restore the degree in the
+		// background when a leg dies) AND the periodic rotation hook
+		// (policy on_tick / bandwidth-spreading, RFC #2882).
+		muxTarget := 1
+		if opts != nil {
+			if eff := opts.EffectiveMuxRoutes(true); eff > muxTarget {
+				muxTarget = eff
+			}
+			if eff := opts.EffectiveMuxRoutes(false); eff > muxTarget {
+				muxTarget = eff
+			}
+		}
+		if muxTarget > 1 {
 			optsCopy := *opts
 			fwdDescCopy := forwardDesc
 			nrgCapture := nrg
@@ -340,11 +347,27 @@ func (r *router) DialRoutes(
 					}
 				}
 				if err := r.addOneAuxForwardLeg(addCtx, nrgCapture, &optsCopy, fwdDescCopy, excludePKs); err != nil {
-					r.logger.WithError(err).Debug("Rotation add-leg failed; route group keeps current leg set")
+					r.logger.WithError(err).Debug("Mux add-leg failed; route group keeps current leg set")
 				}
 			}
-			interval := time.Duration(opts.RotationIntervalSeconds) * time.Second
-			nrg.rg.SetRotation(rh, applyAdd, interval)
+			// Self-healing: any leg death triggers a background replacement
+			// dial to restore the requested degree, while surviving legs
+			// carry the traffic. General to every mux dial, not just ones
+			// with a rotation policy.
+			nrg.rg.SetSelfHeal(applyAdd, muxTarget)
+
+			// Top up an initial shortfall: establishMuxRoutes sets up aux
+			// legs best-effort, so a flaky intermediate can leave the group
+			// below the requested degree at dial time. Heal it now in the
+			// background (same mechanism as runtime leg death) — the dial
+			// still returns immediately on the legs that did establish.
+			nrg.rg.maybeSelfHeal()
+
+			// Periodic rotation (policy on_tick) reuses the same callback.
+			if rh, ok := r.conf.DialHook.(RotationHook); ok && rh != nil && opts.RotationIntervalSeconds > 0 {
+				interval := time.Duration(opts.RotationIntervalSeconds) * time.Second
+				nrg.rg.SetRotation(rh, applyAdd, interval)
+			}
 		}
 
 		// NOTE: no MinHops restore needed — baseMinHops is a local var now,

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -254,12 +254,32 @@ func (r *router) DialRoutes(
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-			// Check if this is a "no suitable transport" error (stale TPD data)
-			if errors.Is(err, ErrNoSuitableTransport) {
-				if attempt < maxRetries {
-					log.WithError(err).Warnf("Route handshake failed due to transport issue (attempt %d/%d), querying route-finder for fresh route...", attempt, maxRetries)
-					continue
+			// The dialer (cascade or DMSG) returned SUCCESS — routing rules
+			// were installed on every hop — yet saveRouteGroupRules failed:
+			// the route's reverse handshake never completed, so the data
+			// plane is dead. This is the dominant multihop failure mode: an
+			// intermediate that ACKs rule-install (so the source-driven
+			// cascade reports success and the dialer never falls back to the
+			// legacy setup-node path) but does not actually forward packets.
+			//
+			// Because the cascade already "succeeded", neither the dialer's
+			// own cascade->DMSG fallback nor the old ErrNoSuitableTransport
+			// branch fired here, so a single bad intermediate failed the
+			// whole dial. Treat a dead route like any other retryable route
+			// failure: exclude THIS route's intermediates and re-fetch a
+			// fresh route through different ones. Walking candidate
+			// intermediates is what turns probabilistic multihop setup into
+			// reliable setup. Direct routes (no intermediates) that aren't a
+			// stale-TPD error still fail fast — retrying the same direct path
+			// to a down peer would only burn the budget.
+			deadInter := intermediatePKsOfPath(forwardPath, lPK, rPK)
+			if (len(deadInter) > 0 || errors.Is(err, ErrNoSuitableTransport)) && attempt < maxRetries {
+				for _, ipk := range deadInter {
+					opts = appendExcludeIntermediate(opts, ipk)
 				}
+				log.WithError(err).Warnf("Route setup failed at handshake/data plane (attempt %d/%d); excluding %d intermediate(s) and retrying with a fresh route",
+					attempt, maxRetries, len(deadInter))
+				continue
 			}
 			return nil, fmt.Errorf("saveRouteGroupRules: %w", err)
 		}
@@ -1987,4 +2007,27 @@ func appendExcludeIntermediate(opts *DialOptions, pk cipher.PubKey) *DialOptions
 	}
 	opts.ExcludeIntermediatePKs = append(opts.ExcludeIntermediatePKs, pk)
 	return opts
+}
+
+// intermediatePKsOfPath returns the distinct intermediate-visor PKs of a
+// forward path: every hop.To that is neither the source nor the destination.
+// For a direct route (src->dst) it returns nil. Used to exclude a dead
+// route's intermediates from the next route-finder pick when a route sets up
+// (rules installed on every hop) but its data plane never carries the
+// handshake — i.e. one of the intermediates ACKs install but won't forward.
+func intermediatePKsOfPath(hops []routing.Hop, src, dst cipher.PubKey) []cipher.PubKey {
+	seen := make(map[cipher.PubKey]struct{}, len(hops))
+	var out []cipher.PubKey
+	for _, h := range hops {
+		pk := h.To
+		if pk == src || pk == dst {
+			continue
+		}
+		if _, ok := seen[pk]; ok {
+			continue
+		}
+		seen[pk] = struct{}{}
+		out = append(out, pk)
+	}
+	return out
 }

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -149,7 +149,15 @@ func (r *router) DialRoutes(
 	r.forceLocalRoutesMu.Lock()
 	forceLocal := r.forceLocalRoutes
 	r.forceLocalRoutesMu.Unlock()
-	const maxRetries = 3
+	// maxRetries bounds how many candidate routes the fallback loop below
+	// walks before giving up. On each setup failure we exclude the failing
+	// intermediate and re-fetch a fresh route (a different intermediate), so
+	// a higher bound = more of the candidate set tried before the dial fails.
+	// Multihop setups over flaky intermediates need several tries to land a
+	// healthy path; combined with the tightened handshake/cascade timeouts
+	// (fast per-attempt failure) this stays well within a reasonable dial
+	// budget while greatly improving multihop establishment odds.
+	const maxRetries = 6
 	maxFetchAttempts := maxRetries
 	if forceLocal {
 		maxFetchAttempts = 1

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -525,7 +525,10 @@ func (r *router) PingRoute(
 	r.forceLocalRoutesMu.Lock()
 	pingForceLocal := r.forceLocalRoutes
 	r.forceLocalRoutesMu.Unlock()
-	const maxRetries = 3
+	// Match DialRoutes: walk up to 6 candidate intermediates (excluding the
+	// dead route's hops each time) before giving up, so a flaky intermediate
+	// that ACKs install but won't forward doesn't fail the whole probe.
+	const maxRetries = 6
 	pingMaxFetch := maxRetries
 	if pingForceLocal {
 		pingMaxFetch = 1
@@ -559,6 +562,14 @@ func (r *router) PingRoute(
 				opts = appendExcludeIntermediate(opts, failedPK)
 				log.WithError(err).Warnf("Ping route setup failed on intermediate %s (attempt %d/%d); excluding from next route-finder pick",
 					failedPK, attempt, maxRetries)
+			} else {
+				// Handshake/data-plane failure: the error names the dst, not
+				// the intermediate that ACKed install but won't forward. Exclude
+				// the whole dead route's intermediates so the retry diverges —
+				// same rationale as DialRoutes' saveRouteGroupRules retry.
+				for _, ipk := range intermediatePKsOfPath(forwardPath, lPK, rPK) {
+					opts = appendExcludeIntermediate(opts, ipk)
+				}
 			}
 			if attempt < maxRetries {
 				log.WithError(err).Warnf("Ping route setup failed (attempt %d/%d), retrying...", attempt, maxRetries)

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -65,7 +65,11 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 func (r *router) dispatchToRouteGroup(ctx context.Context, packet routing.Packet) error {
 	rule, err := r.GetRule(packet.RouteID())
 	if err != nil {
-		return err
+		// Surface the offending route ID + packet type. A bare "rule not
+		// found" is useless for diagnosing multihop setup failures where a
+		// handshake/data frame arrives stamped with a route ID this visor
+		// never installed a rule for (e.g. a mis-stitched reverse chain).
+		return fmt.Errorf("%w (routeID=%d, pktType=%s)", err, packet.RouteID(), packet.Type())
 	}
 
 	// Forward/intermediary rules get forwarded

--- a/pkg/router/wrappers.go
+++ b/pkg/router/wrappers.go
@@ -100,9 +100,9 @@ func NewSetupNodeDialerWithEmbedded(embedded EmbeddedSetupNode) RouteGroupDialer
 //
 // When forceLegacy is true the source-driven cascade is left nil, so every
 // dial uses the legacy path: the setup node dials each hop directly over dmsg
-// to reserve IDs and install rules. Operators set this via
-// Routing.ForceLegacyRouteSetup as an escape hatch when the cascade sets up
-// routes whose data plane does not carry traffic.
+// to reserve IDs and install rules. This is the default for now (the cascade
+// has a multihop data-plane bug); operators opt back into the cascade via
+// Routing.enable_cascade_route_setup once it is fixed.
 func NewSetupNodeDialerFull(embedded EmbeddedSetupNode, relayCache *RSNRelayCache, tm *transport.Manager, forceLegacy bool) RouteGroupDialer {
 	var mux *transport.VStreamMux
 	var srcCascade *CascadeBuilder
@@ -116,7 +116,7 @@ func NewSetupNodeDialerFull(embedded EmbeddedSetupNode, relayCache *RSNRelayCach
 		if !forceLegacy {
 			srcCascade = NewSourceCascadeBuilder(logging.MustGetLogger("cascade_source"), tm, nil)
 		} else {
-			log.Warn("Routing.ForceLegacyRouteSetup is set: source-driven cascade disabled, using legacy setup-node dialing for every route")
+			log.Info("Source-driven cascade disabled (default): using legacy setup-node dialing for every route")
 		}
 	}
 	return &setupNodeDialer{

--- a/pkg/router/wrappers.go
+++ b/pkg/router/wrappers.go
@@ -97,7 +97,13 @@ func NewSetupNodeDialerWithEmbedded(embedded EmbeddedSetupNode) RouteGroupDialer
 
 // NewSetupNodeDialerFull returns a dialer with all capabilities:
 // embedded RSN, transport relay, DMSG fallback, and source-driven cascade.
-func NewSetupNodeDialerFull(embedded EmbeddedSetupNode, relayCache *RSNRelayCache, tm *transport.Manager) RouteGroupDialer {
+//
+// When forceLegacy is true the source-driven cascade is left nil, so every
+// dial uses the legacy path: the setup node dials each hop directly over dmsg
+// to reserve IDs and install rules. Operators set this via
+// Routing.ForceLegacyRouteSetup as an escape hatch when the cascade sets up
+// routes whose data plane does not carry traffic.
+func NewSetupNodeDialerFull(embedded EmbeddedSetupNode, relayCache *RSNRelayCache, tm *transport.Manager, forceLegacy bool) RouteGroupDialer {
 	var mux *transport.VStreamMux
 	var srcCascade *CascadeBuilder
 	if tm != nil {
@@ -106,7 +112,12 @@ func NewSetupNodeDialerFull(embedded EmbeddedSetupNode, relayCache *RSNRelayCach
 		tm.SetSetupRPCHandler(mux.HandlePacket)
 		// Source-side cascade builder: send-only (zero rsnSK). Its ack
 		// registry is shared into the router's CascadeHandler at Serve time.
-		srcCascade = NewSourceCascadeBuilder(logging.MustGetLogger("cascade_source"), tm, nil)
+		// Skipped entirely when the operator forces the legacy setup path.
+		if !forceLegacy {
+			srcCascade = NewSourceCascadeBuilder(logging.MustGetLogger("cascade_source"), tm, nil)
+		} else {
+			log.Warn("Routing.ForceLegacyRouteSetup is set: source-driven cascade disabled, using legacy setup-node dialing for every route")
+		}
 	}
 	return &setupNodeDialer{
 		embeddedSetup: embedded,

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -144,10 +144,14 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	relayCache := router.NewRSNRelayCache(logger)
-	if v.conf.Routing.ForceLegacyRouteSetup {
-		log.Warn("Routing.force_legacy_route_setup is enabled: route setup will dial each hop directly over dmsg (cascade disabled)")
+	// Legacy route setup (RSN dials each hop directly over dmsg) is the default
+	// for now; the source-driven cascade is opt-in until its multihop data-plane
+	// bug is fixed. forceLegacy is therefore the inverse of the opt-in flag.
+	forceLegacy := !v.conf.Routing.EnableCascadeRouteSetup
+	if forceLegacy {
+		log.Info("Route setup using legacy direct-dial path (source-driven cascade disabled; set routing.enable_cascade_route_setup=true to opt in)")
 	}
-	rgDialer := router.NewSetupNodeDialerFull(embeddedRSN, relayCache, v.tpM, v.conf.Routing.ForceLegacyRouteSetup)
+	rgDialer := router.NewSetupNodeDialerFull(embeddedRSN, relayCache, v.tpM, forceLegacy)
 
 	if order := types.ParsePreferenceOrder(v.conf.Routing.TransportPreference); len(order) > 0 {
 		types.SetPreferenceOrder(order)

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -144,7 +144,10 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	relayCache := router.NewRSNRelayCache(logger)
-	rgDialer := router.NewSetupNodeDialerFull(embeddedRSN, relayCache, v.tpM)
+	if v.conf.Routing.ForceLegacyRouteSetup {
+		log.Warn("Routing.force_legacy_route_setup is enabled: route setup will dial each hop directly over dmsg (cascade disabled)")
+	}
+	rgDialer := router.NewSetupNodeDialerFull(embeddedRSN, relayCache, v.tpM, v.conf.Routing.ForceLegacyRouteSetup)
 
 	if order := types.ParsePreferenceOrder(v.conf.Routing.TransportPreference); len(order) > 0 {
 		types.SetPreferenceOrder(order)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -398,6 +398,16 @@ type Routing struct {
 	// (stcpr > sudph > stcp > dmsg) is used. Types not listed here sort last.
 	TransportPreference []string `json:"transport_preference,omitempty"`
 
+	// ForceLegacyRouteSetup disables the source-driven cascade and forces the
+	// legacy route-setup path, where the setup node (RSN) dials each hop
+	// directly over dmsg to reserve route IDs and install rules. The cascade
+	// avoids that dmsg dependency (it injects signed cascades down the
+	// source's own transports), but when it sets up a route whose data plane
+	// does not carry traffic, falling back to the directly-dialed legacy
+	// install is a useful escape hatch / A-B test. Default false (cascade
+	// preferred, legacy used only when the RSN lacks the CascadeSign RPCs).
+	ForceLegacyRouteSetup bool `json:"force_legacy_route_setup,omitempty"`
+
 	// PolicyPerDial is an optional operator-supplied routing
 	// policy. Accepts either:
 	//   "preset:<name>"          — a curated policy embedded in the

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -398,15 +398,15 @@ type Routing struct {
 	// (stcpr > sudph > stcp > dmsg) is used. Types not listed here sort last.
 	TransportPreference []string `json:"transport_preference,omitempty"`
 
-	// ForceLegacyRouteSetup disables the source-driven cascade and forces the
-	// legacy route-setup path, where the setup node (RSN) dials each hop
-	// directly over dmsg to reserve route IDs and install rules. The cascade
-	// avoids that dmsg dependency (it injects signed cascades down the
-	// source's own transports), but when it sets up a route whose data plane
-	// does not carry traffic, falling back to the directly-dialed legacy
-	// install is a useful escape hatch / A-B test. Default false (cascade
-	// preferred, legacy used only when the RSN lacks the CascadeSign RPCs).
-	ForceLegacyRouteSetup bool `json:"force_legacy_route_setup,omitempty"`
+	// EnableCascadeRouteSetup opts INTO the source-driven cascade route-setup
+	// path (RSN signs, source injects the cascade down its own transports,
+	// avoiding the RSN's dmsg dependency). It is OFF by default: the cascade
+	// currently has a multihop data-plane bug (control plane succeeds on every
+	// hop, but the set-up route does not carry traffic), so the legacy path —
+	// where the setup node dials each hop directly over dmsg to install rules —
+	// is the default until that is fixed. Flip this to true (or change the
+	// default) once the cascade data plane is corrected.
+	EnableCascadeRouteSetup bool `json:"enable_cascade_route_setup,omitempty"`
 
 	// PolicyPerDial is an optional operator-supplied routing
 	// policy. Accepts either:


### PR DESCRIPTION
Makes multihop (min_hops>1) route setup reliable, after live testing showed two-hop dials were establishing rules on every hop yet not carrying traffic.

## Findings (live)
- The source-driven **cascade** route setup succeeds at the control plane (rules ACKed on every hop) but the set-up route's **data plane does not carry traffic** — 0/N two-hop establishments.
- The **legacy** path (setup node dials each hop directly over dmsg to install rules) establishes and pumps data on the same destinations (3.3s setup, ~350 KB/s), and the skysocks proxy works end-to-end over multihop through it.
- Failure is intermediate-dependent and was being masked: the cascade reports success, so neither the dialer's legacy fallback nor the old retry path fired when the later handshake timed out.

## Changes
- **Default to legacy route setup** (`routing.enable_cascade_route_setup`, default false). The cascade is opt-in until its multihop data-plane bug is fixed; existing configs get legacy automatically.
- **Handshake/data-plane fallover**: when a set-up route's reverse handshake never completes, `DialRoutes` and the ping/probe path now exclude that route's intermediates and retry through different ones (was only retried for the narrow stale-TPD error).
- **Fast-fail multihop setup**: 12s handshake await + 6 candidate retries so a flaky intermediate fails fast and the dial walks more of the candidate set.
- **Self-healing mux degree**: any leg death triggers a background replacement dial to restore the requested degree while surviving legs carry the traffic — general to every mux dial, plus an initial top-up. No waiting for a route to fail before adding another.
- **Diagnostics**: route ID + packet type on "rule not found"; cascade reserved route-ID slices logged.

## Validation
- skysocks proxy over min_hops=2/mux=4 to a remote server: HTTP 200, 0.72s.
- Legacy two-hop batch to a clean DE destination: 6/6 established; cascade was 0/10.
- `go build ./...`, `go test ./pkg/router/... ./pkg/visor/...` green.

The cascade data-plane bug (it traces correct at every step yet is empirically 0%) is left for a follow-up pin via a controlled intermediate's installed-rule capture.