### PR TITLE
fix(cli/ut): write JSON cache file when --cdu/--cdt is set

### DIFF
--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -75,6 +75,20 @@ func cacheFile(cacheDir, fullURL string) string {
 	return filepath.Join(cacheDir, name+".json")
 }
 
+// writeCacheJSON mirrors a fetched response body to the on-disk JSON path
+// resolved by cacheFile. The bbolt singleton cache used by
+// FetchCachedServiceURL is opaque to outside tools, so without this mirror
+// the --cdu / --cdt flags only flip caching on; the literal "<dir>/<name>.json"
+// the flag's documentation describes never gets written. Best-effort: write
+// errors are silently ignored so a non-writable cache dir never breaks the
+// query itself.
+func writeCacheJSON(path, body string) {
+	if path == "" || body == "" {
+		return
+	}
+	_ = os.WriteFile(path, []byte(body), 0o600) //nolint:errcheck,gosec
+}
+
 // getDeployment returns the appropriate deployment config based on test env
 func getDeployment() deployment.Services {
 	if isTestEnv() {
@@ -155,12 +169,25 @@ var utCmd = &cobra.Command{
 		utFullURL := utURL + "/uptimes?v=v2"
 		tpdFullURL := tpdURL + "/all-transports"
 
-		uts := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
+		// Resolve cache file paths up-front so we can mirror response bodies
+		// to them after fetch. FetchCachedServiceURL only treats the path as
+		// a "caching enabled" flag; the actual cache lives in a separate
+		// bbolt DB at clicache.DefaultPath. Without this mirror, --cdu /dir
+		// never produces /dir/uptimes.json, silently breaking legacy
+		// consumers (e.g. the embedded reward.sh that jq-slices a per-day
+		// view from hist/uptimes.json — without the file, ${date}_ut.json
+		// comes out empty and ParseHistoricUptimeData freezes the
+		// version-history chart on the last good day).
+		utCacheFile := cacheFile(cacheDirUT, utFullURL)
+		uts := clirpc.FetchCachedServiceURL(cmd.Flags(), utCacheFile, utFullURL, cacheFilesAge)
+		writeCacheJSON(utCacheFile, uts)
 
 		// Build transport count map if --max-tp is specified
 		var tpCount map[string]int
 		if maxTP >= 0 {
-			tpd := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirTPD, tpdFullURL), tpdFullURL, cacheFilesAge)
+			tpdCacheFile := cacheFile(cacheDirTPD, tpdFullURL)
+			tpd := clirpc.FetchCachedServiceURL(cmd.Flags(), tpdCacheFile, tpdFullURL, cacheFilesAge)
+			writeCacheJSON(tpdCacheFile, tpd)
 			var entries []*transport.Entry
 			if err := json.Unmarshal([]byte(tpd), &entries); err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse TPD data: %w", err))


### PR DESCRIPTION
## Summary

After the bbolt cache refactor, `--cdu <dir>` / `--cdt <dir>` only flipped caching on (signaling `FetchCachedServiceURL` to use its singleton bbolt DB at `clicache.DefaultPath`); the literal `<dir>/uptimes.json` / `<dir>/all-transports.json` path the flag's docstring describes was never written. The bbolt DB is opaque to outside tools.

This breaks the embedded `reward.sh`, which runs `skywire cli ut --cdu hist/` and then `jq`-slices `hist/uptimes.json` into `hist/${date}_ut.json`. With the file missing, `jq` silently failed and the per-day `_ut.json` came out empty/absent — `ParseHistoricUptimeData` then froze the version-history chart on the last good day, and any downstream consumer that read the sliced file got nothing. Operators running the daily reward service have been silently producing empty `hist/${date}_ut.json` files since the bbolt refactor.

This PR mirrors the fetched response body to the documented path after fetch, so the legacy directory cache works again alongside the bbolt cache.

## Test plan
- [x] `go build ./cmd/skywire-cli/...` passes
- [x] `golangci-lint run ./cmd/skywire-cli/commands/ut/...` — 0 issues
- [x] Live test: `skywire-cli ut --cdu /tmp/ut_test_cache -n 0` produces `/tmp/ut_test_cache/uptimes.json` (~347 KB)
- [x] `jq --arg date 2026-06-05 '[.[] | {pk, on, version, daily: {(\$date): .daily[\$date]}}] | length' /tmp/ut_test_cache/uptimes.json` → `1384` (matches expected per-day PK count)
- [ ] Operator: run the reward service after upgrading; confirm `hist/uptimes.json` is created and `hist/${date}_ut.json` is non-empty