### PR TITLE
feat(cli/got): accept socks5:// and socks5h:// proxy URL schemes

### DIFF
--- a/cmd/skywire-cli/commands/got/got.go
+++ b/cmd/skywire-cli/commands/got/got.go
@@ -33,21 +33,21 @@ func init() {
 	dlCmd.Flags().UintVarP(&concurrency, "concurrency", "c", 0, "number of concurrent chunks (0 = auto)")
 	dlCmd.Flags().Uint64Var(&chunkSize, "chunk-size", 0, "chunk size in bytes (0 = auto)")
 	dlCmd.Flags().StringSliceVarP(&headers, "header", "H", nil, `HTTP header "Key: Value"`)
-	dlCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "SOCKS5 proxy address (host:port)")
+	dlCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "SOCKS5 proxy (host:port, socks5://host:port, or socks5h://host:port — h has the proxy resolve the destination, e.g. dmsgweb's <pk>.dmsg)")
 	dlCmd.Flags().StringVarP(&userAgent, "agent", "A", "", "user agent string")
 	dlCmd.Flags().BoolVarP(&resume, "resume", "r", false, "resume interrupted download")
 
 	// Request flags
 	reqCmd.Flags().StringVarP(&output, "output", "o", "", "write response body to file")
 	reqCmd.Flags().StringSliceVarP(&headers, "header", "H", nil, `HTTP header "Key: Value"`)
-	reqCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "SOCKS5 proxy address (host:port)")
+	reqCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "SOCKS5 proxy (host:port, socks5://host:port, or socks5h://host:port — h has the proxy resolve the destination, e.g. dmsgweb's <pk>.dmsg)")
 	reqCmd.Flags().StringVarP(&userAgent, "agent", "A", "", "user agent string")
 	reqCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print response headers")
 	reqCmd.Flags().StringVarP(&data, "data", "D", "", `request body (or @filename to read from file)`)
 
 	// Head flags
 	headCmd.Flags().StringSliceVarP(&headers, "header", "H", nil, `HTTP header "Key: Value"`)
-	headCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "SOCKS5 proxy address (host:port)")
+	headCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "SOCKS5 proxy (host:port, socks5://host:port, or socks5h://host:port — h has the proxy resolve the destination, e.g. dmsgweb's <pk>.dmsg)")
 	headCmd.Flags().StringVarP(&userAgent, "agent", "A", "", "user agent string")
 
 	RootCmd.AddCommand(dlCmd, reqCmd, headCmd)

--- a/pkg/got/got.go
+++ b/pkg/got/got.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -63,8 +65,22 @@ func NewWithContext(ctx context.Context) *Got {
 }
 
 // NewWithProxy returns a Got configured to route through a SOCKS5 proxy.
+//
+// The proxyAddr is accepted in any of:
+//
+//	socks5h://host:port  destination resolved by the proxy (curl --socks5-hostname).
+//	                     Required for proxies that resolve non-DNS hostnames
+//	                     themselves — e.g. dmsgweb's <pk>.dmsg URLs.
+//	socks5://host:port   destination resolved by this client first, then the
+//	                     IP is sent to the proxy (curl --socks5).
+//	host:port            bare form, treated as socks5h:// for backward compat.
 func NewWithProxy(ctx context.Context, proxyAddr string) (*Got, error) {
-	dialer, err := proxy.SOCKS5("tcp", proxyAddr, nil, proxy.Direct)
+	addr, resolveLocally, err := parseProxyAddr(proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer, err := proxy.SOCKS5("tcp", addr, nil, proxy.Direct)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SOCKS5 dialer: %w", err)
 	}
@@ -74,9 +90,14 @@ func NewWithProxy(ctx context.Context, proxyAddr string) (*Got, error) {
 		return nil, errors.New("SOCKS5 dialer does not support DialContext")
 	}
 
+	dialContext := contextDialer.DialContext
+	if resolveLocally {
+		dialContext = resolveBeforeDial(dialContext)
+	}
+
 	client := &http.Client{
 		Transport: &http.Transport{
-			DialContext:         contextDialer.DialContext,
+			DialContext:         dialContext,
 			MaxIdleConns:        10,
 			IdleConnTimeout:     30 * time.Second,
 			TLSHandshakeTimeout: 5 * time.Second,
@@ -87,6 +108,56 @@ func NewWithProxy(ctx context.Context, proxyAddr string) (*Got, error) {
 		ctx:    ctx,
 		Client: client,
 	}, nil
+}
+
+// parseProxyAddr returns the bare host:port to hand to proxy.SOCKS5 and
+// whether the destination hostname should be resolved client-side before
+// the dial. See NewWithProxy's docstring for the accepted forms.
+func parseProxyAddr(raw string) (addr string, resolveLocally bool, err error) {
+	if !strings.Contains(raw, "://") {
+		return raw, false, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", false, fmt.Errorf("parse proxy address %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return "", false, fmt.Errorf("proxy address %q has no host", raw)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "socks5h":
+		return u.Host, false, nil
+	case "socks5":
+		return u.Host, true, nil
+	default:
+		return "", false, fmt.Errorf("unsupported proxy scheme %q (expected socks5:// or socks5h://)", u.Scheme)
+	}
+}
+
+// resolveBeforeDial wraps a SOCKS5 dialer with client-side DNS resolution
+// of the destination address. IP literals pass through unchanged so this
+// is a no-op when the URL host is already an IP. This is the
+// `socks5://` (no h) semantic; for `socks5h://` we leave the dialer alone
+// and the SOCKS5 protocol encodes the hostname as ATYP=FQDN, leaving
+// resolution to the proxy.
+func resolveBeforeDial(inner func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return inner(ctx, network, address)
+		}
+		if net.ParseIP(host) != nil {
+			return inner(ctx, network, address)
+		}
+		ips, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if lookupErr != nil {
+			return nil, &net.OpError{Op: "dial", Net: network, Err: lookupErr}
+		}
+		if len(ips) == 0 {
+			return nil, &net.OpError{Op: "dial", Net: network, Err: fmt.Errorf("no addresses for %s", host)}
+		}
+		return inner(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+	}
 }
 
 // Download creates a Download for the given URL and destination, then runs it.

--- a/pkg/got/got_test.go
+++ b/pkg/got/got_test.go
@@ -1,0 +1,56 @@
+package got
+
+import (
+	"testing"
+)
+
+func TestParseProxyAddr(t *testing.T) {
+	cases := []struct {
+		name           string
+		in             string
+		wantAddr       string
+		wantResolve    bool
+		wantErrContain string
+	}{
+		{"bare host:port treated as socks5h (back-compat)", "127.0.0.1:4445", "127.0.0.1:4445", false, ""},
+		{"socks5h scheme — proxy resolves", "socks5h://127.0.0.1:4445", "127.0.0.1:4445", false, ""},
+		{"socks5 scheme — client resolves", "socks5://127.0.0.1:4445", "127.0.0.1:4445", true, ""},
+		{"scheme case-insensitive", "SOCKS5H://127.0.0.1:4445", "127.0.0.1:4445", false, ""},
+		{"hostname proxy ok", "socks5h://proxy.example.com:1080", "proxy.example.com:1080", false, ""},
+		{"missing host", "socks5h://", "", false, "no host"},
+		{"http scheme rejected", "http://127.0.0.1:8080", "", false, "unsupported proxy scheme"},
+		{"unparseable", "socks5h://[::bad", "", false, "parse proxy address"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			addr, resolve, err := parseProxyAddr(c.in)
+			if c.wantErrContain != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (addr=%q resolve=%v)", c.wantErrContain, addr, resolve)
+				}
+				if !contains(err.Error(), c.wantErrContain) {
+					t.Fatalf("want error containing %q, got %q", c.wantErrContain, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if addr != c.wantAddr {
+				t.Errorf("addr: want %q, got %q", c.wantAddr, addr)
+			}
+			if resolve != c.wantResolve {
+				t.Errorf("resolveLocally: want %v, got %v", c.wantResolve, resolve)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

`skywire cli got dl|req|head -x` previously took only a bare `host:port` and silently assumed one SOCKS5 mode. Operators trying to fetch through `skywire dmsg web`'s resolving SOCKS5 proxy hit `dial tcp: lookup <pk>.dmsg: no such host` because the client tried to resolve the synthetic hostname locally before talking to the proxy.

This PR accepts curl-style scheme prefixes on the same flag:

| form | semantic | curl equivalent |
|---|---|---|
| `socks5h://host:port` | destination resolved by the **proxy** (required for dmsgweb's `<pk>.dmsg` URLs) | `--socks5-hostname` / `--proxy socks5h://...` |
| `socks5://host:port` | destination resolved by this client first, IP sent to proxy | `--socks5` / `--proxy socks5://...` |
| `host:port` | bare form — treated as `socks5h://` for backward compat | — |

Implementation: scheme is stripped and the bare `host:port` is handed to `proxy.SOCKS5` as before. For the resolve-locally variant the dialer is wrapped with a `net.DefaultResolver.LookupIPAddr` step that pre-resolves the destination hostname; IP literals pass through unchanged. Unknown schemes are rejected with a clear error.

## Test plan
- [x] `go test ./pkg/got/...` — new `TestParseProxyAddr` covers bare, both schemes, case-insensitivity, missing host, unsupported scheme, malformed URL
- [x] `golangci-lint run ./pkg/got/... ./cmd/skywire-cli/commands/got/...` — 0 issues
- [x] `skywire-cli got dl --help` shows updated usage string
- [ ] Operator: `skywire-cli got dl -x socks5h://127.0.0.1:4445 http://<pk>.dmsg/health` against a running `skywire dmsg web` returns 200 instead of DNS error