### PR TITLE
fix(got): propagate Got.Client/ctx into hand-built Download

### DIFF
--- a/pkg/got/got.go
+++ b/pkg/got/got.go
@@ -171,7 +171,21 @@ func (g *Got) Download(URL, dest string) error {
 }
 
 // Do initializes and runs a Download, calling ProgressFunc if set.
+//
+// Callers who construct a *Download by hand (e.g. `skywire-cli got dl`)
+// typically don't set Client or ctx — without this propagation step,
+// Download.Init falls back to DefaultClient(), silently discarding the
+// proxy / context configured on the Got receiver. That manifests as the
+// SOCKS5 proxy being bypassed (DNS lookups resolved locally instead of
+// through the dialer wired up in NewWithProxy) — exactly the failure
+// mode that turned out to outlive #3029.
 func (g *Got) Do(dl *Download) error {
+	if dl.Client == nil {
+		dl.Client = g.Client
+	}
+	if dl.ctx == nil {
+		dl.ctx = g.ctx
+	}
 	if err := dl.Init(); err != nil {
 		return err
 	}

--- a/pkg/got/got_test.go
+++ b/pkg/got/got_test.go
@@ -1,6 +1,10 @@
 package got
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -45,6 +49,57 @@ func TestParseProxyAddr(t *testing.T) {
 		})
 	}
 }
+
+// TestDoPropagatesClient guards against the regression where Got.Do, given
+// a hand-built *Download whose Client field is nil, lets Download.Init
+// install a fresh DefaultClient — silently dropping any proxy / context
+// configured on the Got receiver. That bypass made `got dl -x socks5h://`
+// useless even after #3029 landed scheme support: the SOCKS5 dialer was
+// on g.Client but g.Do never copied it into dl, so the download dialed
+// directly. Verify both g.Client and g.ctx are propagated.
+func TestDoPropagatesClient(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Accept-Ranges", "none")
+		_, _ = w.Write([]byte("hello")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	// A client that fails every request so we can prove dl.Client is the
+	// one being used (not a quietly-installed DefaultClient).
+	sentinel := errors.New("sentinel: g.Client was reached")
+	stubClient := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, sentinel
+	})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g := &Got{Client: stubClient, ctx: ctx}
+
+	// Hand-built download with no Client / ctx — Do must inject g.Client.
+	dl := &Download{URL: srv.URL, Dest: t.TempDir() + "/out"}
+	err := g.Do(dl)
+	if err == nil {
+		t.Fatalf("want sentinel error from stub client, got nil (real default client used? hits=%d)", hits)
+	}
+	if !errors.Is(err, sentinel) && !contains(err.Error(), sentinel.Error()) {
+		t.Fatalf("want sentinel error, got %v", err)
+	}
+	if dl.Client != stubClient {
+		t.Errorf("dl.Client was not propagated from g.Client")
+	}
+	if dl.ctx != ctx {
+		t.Errorf("dl.ctx was not propagated from g.ctx")
+	}
+	if hits != 0 {
+		t.Errorf("test server should not have been reached, got hits=%d", hits)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {


### PR DESCRIPTION
## Summary

Follow-up to #3029. After that PR, `skywire-cli got dl -x socks5h://127.0.0.1:4443 http://<pk>.dmsg/health` still failed:

\`\`\`
got: Get \"http://<pk>.dmsg/health\": dial tcp: lookup <pk>.dmsg: no such host
\`\`\`

— while \`curl -x socks5h://127.0.0.1:4443 http://<pk>.dmsg/health\` (same proxy, same URL) succeeded.

Root cause: \`Got.Do\` let any \`*Download\` whose \`Client\` field was nil fall through to \`Download.Init\`'s \`if d.Client == nil { d.Client = DefaultClient() }\` fallback, silently discarding the http.Client (and the SOCKS5 dialer) configured on the Got receiver. The scheme parsing landed in #3029 built the proxy client correctly and attached it to \`g.Client\`, but \`g.Do\` never carried it into the hand-built \`*Download\` that \`dlCmd\` passes in (\`cmd/skywire-cli/commands/got/got.go:125-138\`).

Fix: in \`Got.Do\`, inject \`g.Client\` / \`g.ctx\` into the download before \`Init\` when the caller left them unset. Matches what \`Got.Download\` already does for its convenience path.

## Test plan
- [x] \`go test ./pkg/got/...\` — new \`TestDoPropagatesClient\` stubs g.Client with a sentinel-error round-tripper and asserts the download surfaces that error (proving g.Client was used, not a DefaultClient). Also verifies ctx propagation.
- [x] \`golangci-lint run ./pkg/got/...\` — 0 issues
- [ ] Operator: \`skywire-cli got dl -x socks5h://127.0.0.1:4445 http://<pk>.dmsg/health\` against a running \`skywire dmsg web\` returns the body instead of the DNS error