### PR TITLE
feat(rewards): source uptime from TPD-integrated tracker; drop manual tp gate

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -666,7 +666,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&h2, "h2", "2", false, "hide reward csv data")
 	RootCmd.Flags().BoolVarP(&grr, "err", "e", false, "account for non rewarded keys")
 	RootCmd.Flags().BoolVarP(&processRewards, "process", "r", false, "run complete reward processing workflow")
-	RootCmd.Flags().BoolVarP(&requireTransports, "require-tp", "t", true, "require minimum transports (from hist/YYYY-MM-DD_transports.txt)")
+	RootCmd.Flags().BoolVarP(&requireTransports, "require-tp", "t", false, "require minimum transports from hist/YYYY-MM-DD_transports.txt (deprecated — TPD-integrated UT data now gates >= 2 transports inherently; this flag is kept only for historical re-runs of dates before the migration)")
 	RootCmd.Flags().StringVarP(&transportHistPath, "tp-hist", "T", "hist", "path to transport history directory")
 	RootCmd.Flags().BoolVarP(&requireBandwidth, "require-bw", "b", false, "require minimum bandwidth (proportional reward based on bandwidth)")
 	RootCmd.Flags().BoolVar(&noBWPool, "no-bw-pool", false, "recovery mode: skip the bandwidth pool and fold its budget into a doubled presence pool (requires -b)")

--- a/cmd/skywire-cli/commands/rewards/runday.go
+++ b/cmd/skywire-cli/commands/rewards/runday.go
@@ -174,9 +174,15 @@ func runLogCollection(minVer string) error {
 // .daily map to only the requested date, and writes the pruned views to
 // hist/{date}_ut.json and hist/{date}_ut.txt. This replaces the previous
 // `skywire cli ut | tee ...` (which kept all 7 days) plus the jq prune step.
+//
+// The source is the TPD-integrated uptime endpoint (`tpd/.../uptimes?v=v2`),
+// not the standalone uptime tracker. TPD only credits heartbeats from
+// visors that hold >= 2 transports, so the formerly-separate
+// hist/{date}_transports.txt eligibility gate is now implicit in the UT
+// data itself — no manual transport-count tracking required.
 func fetchAndSaveUT(date, histDir string) error {
 	dep := getDeploymentForUT()
-	url := strings.TrimRight(dep.UptimeTracker, "/") + "/uptimes?v=v2"
+	url := strings.TrimRight(dep.TransportDiscovery, "/") + "/uptimes?v=v2"
 
 	client := &http.Client{Timeout: 60 * time.Second}
 	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
@@ -329,20 +335,13 @@ func calcDay(opts calcOpts) (*dayResult, error) {
 		}
 	}
 
-	// Transport requirement.
-	transportMap := make(map[string]struct{})
-	tpFile := filepath.Join(opts.HistDir, opts.Date+"_transports.txt")
-	if data, err := os.ReadFile(tpFile); err == nil { //nolint:gosec
-		for _, line := range strings.Split(string(data), "\n") {
-			if line = strings.TrimSpace(line); line != "" {
-				transportMap[line] = struct{}{}
-			}
-		}
-		log.Infof("Loaded %d visors with sufficient transports from %s", len(transportMap), tpFile)
-	} else {
-		log.Warnf("Transport file not found: %s (transport requirement will be skipped)", tpFile)
-	}
-	requireTPs := len(transportMap) > 0
+	// Transport requirement is now implicit in the UT source. Since
+	// fetchAndSaveUT pulls from TPD's integrated /uptimes endpoint
+	// (which only credits heartbeats while the visor holds >= 2
+	// transports), any PK in hist/{date}_ut.txt has already passed the
+	// "had transports yesterday" gate. We no longer read or honor a
+	// separate hist/{date}_transports.txt file here. tp-collect remains
+	// available for diagnostics but is not load-bearing for rewards.
 
 	// Get PKs that met uptime on this date.
 	res, _ := script.File(utfilePath).Match(strings.TrimRight(opts.Date, "\n")).Column(1).Slice() //nolint:errcheck
@@ -375,8 +374,9 @@ func calcDay(opts calcOpts) (*dayResult, error) {
 		_, allowed2 := allowArchMap2[arch]
 		_, _, addrErr := rewardconfig.ValidateRewardAddress(sky)
 
-		_, hasTransports := transportMap[pk]
-		meetsTransportReq := !requireTPs || hasTransports
+		// TPD-integrated UT already gated >= 2 transports at heartbeat
+		// time, so every pk we're iterating qualified by definition.
+		meetsTransportReq := true
 
 		archAllowed := allowed1 || allowed2
 


### PR DESCRIPTION
## Summary

The reward calc previously composed two sources to define an "eligible visor":

1. `hist/{date}_ut.txt` from the standalone uptime tracker — heartbeats only, no transport requirement.
2. `hist/{date}_transports.txt` from `skywire cli rewards tp-collect` — a separate hourly snapshot of which PKs held ≥ 2 transports.

The TPD-integrated uptime endpoint already exposes the same data with the transport gate built in — it only credits heartbeats while the visor holds ≥ 2 transports. So `online && has_transports` is exactly the set TPD publishes; the second file was redundant bookkeeping vulnerable to race conditions between the two snapshots (one taken hourly, the other when the day rolled over).

Sample comparison on 2026-06-06 of ≥ 75% on 2026-06-05:

| Source | Total PKs | ≥ 75% yesterday |
|---|---|---|
| `ut.skywire.skycoin.com` (standalone) | 1384 | 1162 |
| `tpd.skywire.skycoin.com/uptimes` (TPD-integrated) | 1214 | 750 |

PK overlap: 1147 common · 237 standalone-only (would be filtered out by the manual transport gate anyway) · 67 TPD-only.

## Changes

- **`runday.go::fetchAndSaveUT`** — source URL flips from `dep.UptimeTracker` to `dep.TransportDiscovery` (both endpoints share `/uptimes?v=v2` shape).
- **`runday.go::calcDay`** — drops the `hist/{date}_transports.txt` read and the conditional `requireTPs` flag. `meetsTransportReq` is hard-true with a comment recording the invariant; the `ineligibilityReason` helper signature is left intact so a future different gate can slot in cleanly.
- **`calc.go` RootCmd `--require-tp`** — default flips from `true` to `false`. Operators re-running pre-migration dates can still pass `--require-tp=true` explicitly.

`tp-collect` remains available as a diagnostic command but is no longer load-bearing for reward calculation. A follow-up can prune its call from `runRewardProcessing` and from operator `getlogs.sh` once we've run clean for a billing cycle on the new source.

## Test plan
- [x] `go build ./cmd/skywire-cli/...`
- [x] `go test ./cmd/skywire-cli/commands/rewards/...` (no test files exist for this package)
- [x] `golangci-lint run ./cmd/skywire-cli/commands/rewards/...` — 0 issues
- [ ] Operator: dry-run a known historical date with `cli rewards runday --date <pre-migration-date> --require-tp` to confirm the legacy file is still honored when explicitly requested
- [ ] Operator: run the next billing day through the new path and compare the rewardtxn0.csv against a parallel run with the old path; differences should be limited to the 237 standalone-only PKs (now correctly excluded) and the 67 TPD-only PKs (now correctly included)