### PR TITLE
fix(router): stop the setup-node pool from handing out dead connections

### DIFF
--- a/pkg/router/client_pool.go
+++ b/pkg/router/client_pool.go
@@ -30,11 +30,26 @@ type poolEntry struct {
 	lastUsed time.Time
 }
 
-// DefaultPoolTTL is how long an idle connection stays in the pool.
-// The RSN's top 3 destinations get hit every few seconds, so they'll
-// never idle out. Less popular destinations evict after 5 minutes,
-// freeing DMSG streams and ephemeral ports.
-const DefaultPoolTTL = 5 * time.Minute
+// maxPooledReuseIdle is the longest a pooled connection may have idled and
+// still be safely handed back for reuse. It sits just under
+// streamIdleTimeoutForPool — the read deadline Client.call() arms on the
+// underlying DMSG stream after every call. Once that deadline fires, the
+// rpc.Client.input() goroutine times out, exits, and shuts the client down
+// permanently; the next call on it returns "connection is shut down". Reusing
+// such a corpse is exactly what failed id-reservation against perfectly
+// reachable visors and wedged their destination circuit breakers on the live
+// setup nodes. The 15s margin leaves a freshly-dequeued connection time to
+// start its next call (which re-arms the deadline) before the old one fires.
+const maxPooledReuseIdle = streamIdleTimeoutForPool - 15*time.Second
+
+// DefaultPoolTTL is how long an idle connection stays in the pool before the
+// eviction loop reaps it. It MUST stay at or below maxPooledReuseIdle: a
+// connection that idles past the stream read deadline is already shut down, so
+// keeping it pooled only risks Get handing out a dead connection. The RSN's
+// hot destinations are hit every few seconds (lastUsed refreshed on Put) so
+// they never idle out; colder ones re-dial fresh, which is correct since their
+// pooled stream would have died anyway.
+const DefaultPoolTTL = maxPooledReuseIdle
 
 // NewClientPool creates a pool that reuses connections to remote visors.
 func NewClientPool(dialer network.Dialer, ttl time.Duration) *ClientPool {
@@ -56,16 +71,25 @@ func NewClientPool(dialer network.Dialer, ttl time.Duration) *ClientPool {
 // must call Put when done (or Close if the connection is broken).
 func (p *ClientPool) Get(ctx context.Context, pk cipher.PubKey) (*Client, error) {
 	p.mu.Lock()
-	if entry, ok := p.clients[pk]; ok {
+	entry, ok := p.clients[pk]
+	if ok {
 		delete(p.clients, pk)
-		p.mu.Unlock()
-		// Test the connection with a short deadline — if the remote end
-		// closed, we'll find out here instead of mid-RPC.
-		// We can't cheaply probe an rpc.Client, so just return it and
-		// let the caller retry on error.
-		return entry.client, nil
 	}
 	p.mu.Unlock()
+
+	if ok {
+		// Only reuse a connection that cannot already be dead. Past
+		// maxPooledReuseIdle the stream read deadline has fired, the
+		// rpc.Client.input() goroutine has exited, and the next call would
+		// return "connection is shut down" — failing id-reservation against a
+		// reachable visor and tripping its destination circuit breaker. We
+		// can't cheaply probe an rpc.Client, but idle time is a reliable proxy
+		// for the deterministic shutdown horizon, so discard and dial fresh.
+		if time.Since(entry.lastUsed) < maxPooledReuseIdle {
+			return entry.client, nil
+		}
+		entry.client.Close() //nolint:errcheck,gosec
+	}
 
 	// Dial a new connection.
 	return NewClient(ctx, p.dialer, pk)

--- a/pkg/router/client_pool_test.go
+++ b/pkg/router/client_pool_test.go
@@ -1,0 +1,79 @@
+// Package router pkg/router/client_pool_test.go
+package router
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// countingDialer hands out a fresh in-memory conn per Dial and counts dials,
+// so a test can distinguish "reused a pooled connection" from "dialed fresh".
+type countingDialer struct {
+	dials int32
+	conns []net.Conn // kept so the pipe peers aren't GC'd mid-test
+}
+
+func (d *countingDialer) Dial(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	atomic.AddInt32(&d.dials, 1)
+	ours, theirs := net.Pipe()
+	d.conns = append(d.conns, ours, theirs)
+	return ours, nil
+}
+func (d *countingDialer) Probe(_ context.Context, _ cipher.PubKey, _ uint16) bool { return true }
+func (d *countingDialer) Type() string                                           { return string(types.DMSG) }
+func (d *countingDialer) count() int32                                           { return atomic.LoadInt32(&d.dials) }
+
+// TestClientPool_Get_DiscardsStalePooledConn is the regression test for the
+// setup-node id-reservation failures: Client.call() arms the stream read
+// deadline at streamIdleTimeoutForPool, after which the rpc.Client.input()
+// goroutine exits and the client is permanently shut down. The pool used to
+// hand such a corpse back (TTL > that horizon), failing the next reservation
+// with "connection is shut down" against a perfectly reachable visor — which
+// tripped the destination's circuit breaker. Get must now reuse only
+// connections idled below maxPooledReuseIdle and dial fresh past it.
+func TestClientPool_Get_DiscardsStalePooledConn(t *testing.T) {
+	d := &countingDialer{}
+	pool := NewClientPool(d, DefaultPoolTTL)
+	t.Cleanup(pool.Close)
+
+	pk, _ := cipher.GenerateKeyPair()
+	ctx := context.Background()
+
+	// Cold get dials fresh.
+	c1, err := pool.Get(ctx, pk)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, d.count())
+
+	// A recently-used pooled connection is reused — no new dial.
+	pool.Put(c1)
+	got, err := pool.Get(ctx, pk)
+	require.NoError(t, err)
+	require.Same(t, c1, got, "a fresh pooled connection must be reused")
+	require.EqualValues(t, 1, d.count(), "reuse must not dial")
+
+	// Age the pooled entry past the reuse horizon: it is now (deterministically)
+	// shut down, so Get must discard it and dial fresh instead of returning it.
+	pool.Put(got)
+	pool.mu.Lock()
+	require.Contains(t, pool.clients, pk)
+	stale := pool.clients[pk].client
+	pool.clients[pk].lastUsed = time.Now().Add(-maxPooledReuseIdle - time.Second)
+	pool.mu.Unlock()
+
+	fresh, err := pool.Get(ctx, pk)
+	require.NoError(t, err)
+	require.NotSame(t, stale, fresh, "a stale pooled connection must NOT be reused")
+	require.EqualValues(t, 2, d.count(), "a stale entry must force a fresh dial")
+
+	// Sanity: the configured TTL cannot exceed the reuse horizon, otherwise the
+	// eviction loop would keep dead connections poolable.
+	require.LessOrEqual(t, int64(DefaultPoolTTL), int64(maxPooledReuseIdle))
+}


### PR DESCRIPTION
Setup-node per-destination circuit breakers were wedging open against perfectly reachable visors, blocking all multihop route setup to them (observed live against the skysocks proxy server and many others).

## Diagnosis (live)
A standalone RSN `/stats` snapshot showed thousands of `id_reservation` failures with `connection is shut down` against demonstrably reachable PKs (including the querying visor itself and the dmsgweb host). A pprof goroutine dump from the RSN over dmsg showed dozens of `net/rpc.(*Client).input` goroutines parked reading dead DMSG streams. A fresh dmsg probe of a "failing" destination on the setup port `@136` succeeded in ~200ms, ruling out genuine unreachability.

## Root cause
A timeout mismatch in `ClientPool`. `Client.call()` arms the stream read deadline at `streamIdleTimeoutForPool` (2m) after every call so the `rpc.Client.input()` goroutine eventually unblocks and frees the ephemeral port. But `DefaultPoolTTL` was 5m, so for the window `[lastUsed+2m, lastUsed+5m]` a pooled connection is already shut down yet still poolable. `ClientPool.Get` returned it without probing ("let the caller retry on error"); the next `ReserveIDs` failed with `rpc.ErrShutdown`, and three such failures tripped the destination breaker for 5-30 minutes — locking out a healthy destination.

## Fix
`Get` now reuses a pooled connection only while it has idled below `maxPooledReuseIdle` (just under the read-deadline horizon) and dials fresh past it. `DefaultPoolTTL` is pinned to that horizon so eviction can never outlive liveness. Reachable destinations stop accumulating spurious `id_reservation` failures, so their breakers stay closed and multihop setup through them works.

Adds a regression test (`TestClientPool_Get_DiscardsStalePooledConn`). `go build`, `go vet`, and the full `pkg/router` suite pass.