### PR TITLE
fix(cxo/node): unblock stuck transport read on Close to stop goroutine leak

### DIFF
--- a/pkg/cxo/node/transport/connection.go
+++ b/pkg/cxo/node/transport/connection.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 )
 
 // Connection wraps a net.Conn with channel-based message I/O.
@@ -61,7 +62,19 @@ func (c *Connection) Close() {
 	c.closed = true
 	c.mu.Unlock()
 
-	c.conn.Close() //nolint:errcheck,gosec
+	// Force-unblock any read parked in readLoop's io.ReadFull BEFORE closing.
+	// When the remote peer vanishes without a FIN/RST (the common dmsg
+	// half-dead-stream case), the underlying Read never returns an error and
+	// net.Conn.Close() does NOT reliably interrupt an in-flight Read — only a
+	// read deadline does (dmsg honors SetReadDeadline even when Close cannot
+	// wake the reader). Without this, readLoop never returns, its deferred
+	// close(c.in) never runs, the owning CXO Conn.receiveMsg stays blocked
+	// waiting on c.in, and Conn.run leaks forever on await.Wait(). That leak
+	// accumulated tens of thousands of goroutines and multi-GB RSS on the
+	// transport-discovery CXO node despite the idle watchdog correctly calling
+	// Close() — the Close just never reached the stuck reader.
+	c.conn.SetReadDeadline(time.Now()) //nolint:errcheck,gosec
+	c.conn.Close()                     //nolint:errcheck,gosec
 	close(c.done)
 }
 

--- a/pkg/cxo/node/transport/connection_test.go
+++ b/pkg/cxo/node/transport/connection_test.go
@@ -1,0 +1,70 @@
+package transport
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// halfDeadConn models a dmsg stream whose remote peer has vanished without a
+// FIN/RST: Read blocks indefinitely, and Close() does NOT interrupt an
+// in-flight Read (the production failure mode). Only SetReadDeadline with a
+// non-zero time unblocks the parked Read — mirroring how dmsg actually behaves.
+type halfDeadConn struct {
+	mu       sync.Mutex
+	unblock  chan struct{}
+	released bool
+}
+
+func newHalfDeadConn() *halfDeadConn { return &halfDeadConn{unblock: make(chan struct{})} }
+
+func (c *halfDeadConn) Read(_ []byte) (int, error) {
+	<-c.unblock // parks until a read deadline is armed
+	return 0, errors.New("i/o timeout")
+}
+func (c *halfDeadConn) Write(p []byte) (int, error) { return len(p), nil }
+
+// Close deliberately does NOT release a blocked Read — that is the whole bug.
+func (c *halfDeadConn) Close() error { return nil }
+
+func (c *halfDeadConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !t.IsZero() && !c.released {
+		c.released = true
+		close(c.unblock)
+	}
+	return nil
+}
+func (c *halfDeadConn) SetWriteDeadline(_ time.Time) error { return nil }
+func (c *halfDeadConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *halfDeadConn) LocalAddr() net.Addr                { return fakeAddr{} }
+func (c *halfDeadConn) RemoteAddr() net.Addr               { return fakeAddr{} }
+
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "fake" }
+func (fakeAddr) String() string  { return "fake" }
+
+// TestConnection_Close_UnblocksStuckRead is the regression test for the CXO
+// transport-discovery goroutine leak. readLoop parks in io.ReadFull on a
+// half-dead dmsg stream; Close() must arm a read deadline to force that read
+// to return, otherwise readLoop never exits, close(c.in) never runs, and the
+// owning CXO Conn.run leaks forever on await.Wait() (tens of thousands of
+// stuck goroutines + multi-GB RSS observed in production).
+func TestConnection_Close_UnblocksStuckRead(t *testing.T) {
+	c := newConnection(newHalfDeadConn(), false)
+
+	c.Close()
+
+	select {
+	case _, ok := <-c.GetChanIn():
+		require.False(t, ok, "c.in must be closed once readLoop exits")
+	case <-time.After(3 * time.Second):
+		t.Fatal("readLoop did not exit after Close — the stuck read was not unblocked (leak regression)")
+	}
+}


### PR DESCRIPTION
The transport-discovery CXO node leaked goroutines without bound. Observed live: ~3000 stable goroutines climbing under load, spiking to **37,179** during a reconnection storm, driving the process to **~2 GB RSS and ~300% CPU** and starving its host (co-located route-finder hit 72%, address-resolver 27%).

## Root cause
`Connection.readLoop` parks in `io.ReadFull` on the underlying dmsg stream. When a remote CXO peer vanishes without a FIN/RST (the common dmsg half-dead case), that `Read` never returns an error, and **`net.Conn.Close()` does not reliably interrupt an in-flight `Read` — only a read deadline does** (dmsg honors `SetReadDeadline` even when `Close` cannot wake the reader). The idle watchdog (`Conn.idleWatchdog`, #2657) *correctly* called `Close()` on these dead conns, but the `Close` never reached the stuck reader: `readLoop` never returned, its deferred `close(c.in)` never ran, the owning `Conn.receiveMsg` stayed blocked on `c.in`, and `Conn.run` leaked forever on `await.Wait()`. A pprof goroutine dump from the live node showed exactly this: hundreds of `run` parked at `await.Wait()`, `readLoop`/`receiveMsg` blocked on the dmsg read.

## Fix
`Connection.Close()` arms a past read deadline before closing the conn, forcing any parked `io.ReadFull` to return so `readLoop` exits and the whole `Conn` tears down. Mirrors the read-deadline mechanism the setup-node router client already uses to unblock dmsg reads. Adds a regression test driving `Close()` against a conn whose `Read` blocks and whose `Close()` does not interrupt it.

`go build`, `go vet`, the `cxo/node/transport` suite (incl. the new test), and the `cxo/node` suite all pass.