### PR TITLE
fix(visor): fetch service data over dmsg-http first (fixes blank hypervisor network tab)

### DIFF
--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -252,34 +252,101 @@ func (v *Visor) dmsgServerHealth(_ *http.Client) []ServiceHealthEntry {
 	return out
 }
 
+// serviceHop is one transport attempt for a service fetch: a base URL and
+// whether it is reached over DMSG-HTTP or plain HTTP.
+type serviceHop struct {
+	dmsg    bool
+	baseURL string
+}
+
+// serviceFetchOrder encodes the transport preference for fetching service
+// data. DMSG-HTTP is the default service transport, so it is used first
+// whenever a dmsg URL is configured; plain HTTP is the fallback in a dual
+// (http + dmsg) config, or the sole path in an http-only config. Order:
+//
+//	dual    (http + dmsg) -> [dmsg, http]
+//	dmsg-only            -> [dmsg]
+//	http-only            -> [http]
+//	neither              -> []
+func serviceFetchOrder(httpURL, dmsgURL string) []serviceHop {
+	var order []serviceHop
+	if dmsgURL != "" {
+		order = append(order, serviceHop{dmsg: true, baseURL: dmsgURL})
+	}
+	if httpURL != "" {
+		order = append(order, serviceHop{dmsg: false, baseURL: httpURL})
+	}
+	return order
+}
+
 // FetchServiceData fetches data from a deployment service endpoint via the visor's
 // configured URLs. service is one of: tpd, ut, sd, ar, rf, dmsgd.
 // path is the URL path (e.g., "/all-transports/stats").
+//
+// DMSG-HTTP is preferred whenever the service has a dmsg URL configured — it is
+// the default service transport and a dmsg-only visor has no HTTP URL at all.
+// Plain HTTP is used only as the dual-config fallback or the http-only path.
 func (v *Visor) FetchServiceData(service, path string) ([]byte, error) {
-	baseURL := ""
+	var httpURL, dmsgURL string
 	switch service {
 	case "tpd":
-		baseURL = v.conf.Transport.Discovery
+		httpURL, dmsgURL = v.conf.Transport.Discovery, v.conf.Transport.DiscoveryDmsg
 	case "ut":
 		if v.conf.UptimeTracker != nil {
-			baseURL = v.conf.UptimeTracker.Addr
+			httpURL, dmsgURL = v.conf.UptimeTracker.Addr, v.conf.UptimeTracker.AddrDmsg
 		}
 	case "sd":
-		baseURL = v.conf.Launcher.ServiceDisc
+		httpURL, dmsgURL = v.conf.Launcher.ServiceDisc, v.conf.Launcher.ServiceDiscDmsg
 	case "ar":
-		baseURL = v.conf.Transport.AddressResolver
+		httpURL, dmsgURL = v.conf.Transport.AddressResolver, v.conf.Transport.AddressResolverDmsg
 	case "rf":
-		baseURL = v.conf.Routing.RouteFinder
+		httpURL, dmsgURL = v.conf.Routing.RouteFinder, v.conf.Routing.RouteFinderDmsg
 	case "dmsgd":
-		baseURL = v.conf.Dmsg.Discovery
+		httpURL = v.conf.Dmsg.Discovery
 	default:
 		return nil, fmt.Errorf("unknown service: %s (valid: tpd, ut, sd, ar, rf, dmsgd)", service)
 	}
-	if baseURL == "" {
+
+	order := serviceFetchOrder(httpURL, dmsgURL)
+	if len(order) == 0 {
 		return nil, fmt.Errorf("service %s not configured", service)
 	}
 
-	url := strings.TrimSuffix(baseURL, "/") + path
+	var lastErr error
+	for _, hop := range order {
+		url := strings.TrimSuffix(hop.baseURL, "/") + path
+		var (
+			body []byte
+			err  error
+		)
+		if hop.dmsg {
+			body, err = v.fetchServiceDataDmsg(url)
+		} else {
+			body, err = fetchServiceDataHTTP(url)
+		}
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// fetchServiceDataDmsg performs a GET over DMSG-HTTP using the visor's
+// authoritative dmsg client.
+func (v *Visor) fetchServiceDataDmsg(url string) ([]byte, error) {
+	resp, err := v.DmsgHTTP(DmsgHTTPRequest{URL: url, Method: http.MethodGet})
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s over dmsg: %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("service returned %d over dmsg: %s", resp.StatusCode, string(resp.Body))
+	}
+	return resp.Body, nil
+}
+
+// fetchServiceDataHTTP performs a plain HTTP GET.
+func fetchServiceDataHTTP(url string) ([]byte, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Get(url) //nolint:gosec
 	if err != nil {

--- a/pkg/visor/api_services_test.go
+++ b/pkg/visor/api_services_test.go
@@ -1,0 +1,51 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceFetchOrder pins the transport-preference rule for service data
+// fetches: DMSG-HTTP is the default service transport, so it is tried first
+// whenever a dmsg URL is configured; plain HTTP is only the dual-config
+// fallback or the http-only path. Regression guard for the blank hypervisor
+// "network" tab — a dmsg-only visor (no HTTP service_discovery URL) must still
+// reach service-discovery over dmsg instead of failing "not configured".
+func TestServiceFetchOrder(t *testing.T) {
+	const httpURL = "http://sd.example"
+	const dmsgURL = "dmsg://0204890f:80"
+
+	tests := []struct {
+		name             string
+		httpURL, dmsgURL string
+		want             []serviceHop
+	}{
+		{
+			name: "dual: dmsg first then http",
+			httpURL: httpURL, dmsgURL: dmsgURL,
+			want: []serviceHop{{dmsg: true, baseURL: dmsgURL}, {dmsg: false, baseURL: httpURL}},
+		},
+		{
+			name: "dmsg-only: dmsg only (the default config)",
+			httpURL: "", dmsgURL: dmsgURL,
+			want: []serviceHop{{dmsg: true, baseURL: dmsgURL}},
+		},
+		{
+			name: "http-only: http only",
+			httpURL: httpURL, dmsgURL: "",
+			want: []serviceHop{{dmsg: false, baseURL: httpURL}},
+		},
+		{
+			name: "neither configured",
+			httpURL: "", dmsgURL: "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, serviceFetchOrder(tt.httpURL, tt.dmsgURL))
+		})
+	}
+}


### PR DESCRIPTION
The hypervisor UI **network** tab rendered blank on dmsg-only visors.

## Root cause
`FetchServiceData` (used by the network-view to aggregate service-discovery + uptime-tracker data) was **HTTP-only**: it read the plain-HTTP service URL (e.g. `Launcher.ServiceDisc`) and did `http.Client.Get` against it. On a **dmsg-only** visor — now the default config — those HTTP fields are empty, so `FetchServiceData("sd")` returned `service sd not configured`, the network-view produced **zero entries**, and the tab was blank. (`/network/transports` worked because `getNetworkTransports` already had a DMSG-HTTP path; the network-view did not.)

## Fix
Service data is now fetched **DMSG-HTTP first whenever a `*_dmsg` URL is configured** — the default service transport — with plain HTTP used only as the dual-config fallback or the http-only path:

- dual (http + dmsg) -> dmsg, then http
- dmsg-only -> dmsg
- http-only -> http

Covers SD, UT, TPD, AR, RF. `serviceFetchOrder` encodes the rule and is unit-tested. Verified live: rolling a dmsg-only visor onto this change took the network-view from 0 to 985 entries.