### PR TITLE
fix(dmsg): replace stale sessions on reconnect (newest-session-wins) — fixes multihop route setup

### DIFF
--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -151,27 +151,39 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 		ce.log.Infof("yamux stream session initial for %s", dSes.RemotePK().String())
 	}
 
-	// Atomically: refuse-if-closed, dedupe, store, and wg.Add(1) under
-	// sessionsMx — pairs with Close which sets ce.closed under the same
-	// lock before wg.Wait. The Add must happen-before any subsequent
+	// Atomically: refuse-if-closed, replace-stale, store, and wg.Add(1)
+	// under sessionsMx — pairs with Close which sets ce.closed under the
+	// same lock before wg.Wait. The Add must happen-before any subsequent
 	// Wait or sync.WaitGroup races (TestEnv race: Add at 159 vs Wait at
 	// client.go:510). The setSessionCallback is invoked outside the lock
 	// to match the previous setSession semantics.
+	//
+	// Newest-session-wins: if a session for this server PK already exists
+	// it is almost certainly a stale half-dead session (the link died
+	// without a clean close, so its serve loop is still parked in
+	// AcceptStream and never freed the map slot). The old code REJECTED the
+	// reconnect and kept the corpse — the visor stayed "connected" to a
+	// server that could no longer carry an inbound bridged stream, so other
+	// visors dialing through it hung for HandshakeTimeout and multihop route
+	// setup starved on "dmsg error 202". Replace the predecessor and close
+	// it; its serve goroutine then unwinds and calls delSession, which is
+	// identity-checked so it cannot evict this live replacement.
 	ce.sessionsMx.Lock()
 	if ce.closed {
 		ce.sessionsMx.Unlock()
 		_ = dSes.Close() //nolint:errcheck
 		return ClientSession{}, errors.New("client closed")
 	}
-	if _, exists := ce.sessions[dSes.RemotePK()]; exists {
-		ce.sessionsMx.Unlock()
-		_ = dSes.Close() //nolint:errcheck
-		return ClientSession{}, errors.New("session already exists")
-	}
+	old, hadOld := ce.sessions[dSes.RemotePK()]
 	ce.sessions[dSes.RemotePK()] = dSes.SessionCommon
 	ce.wg.Add(1)
 	setSessCb := ce.setSessionCallback
 	ce.sessionsMx.Unlock()
+
+	if hadOld && old != dSes.SessionCommon {
+		// Close the stale predecessor outside the lock (Close does IO).
+		_ = old.Close() //nolint:errcheck
+	}
 
 	if setSessCb != nil {
 		if err := setSessCb(ctx); err != nil {
@@ -198,7 +210,10 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 			default:
 			}
 			ce.sesMx.Unlock()
-			ce.delSession(ctx, dSes.RemotePK())
+			// Identity-checked: a newer reconnect may have already
+			// replaced this session in the map (newest-session-wins);
+			// deleting by PK alone would evict that live successor.
+			ce.delSession(ctx, dSes.RemotePK(), dSes.SessionCommon)
 		}
 
 		// Trigger disconnect callback.

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -246,15 +246,45 @@ func (c *EntityCommon) SessionCount() int {
 	return n
 }
 
+// setSession installs dSes as THE session for its remote PK and always
+// succeeds. If a session for that PK already exists it is replaced and the
+// predecessor is closed.
+//
+// Newest-session-wins is the correct policy because exactly one session per
+// remote PK is ever valid: a well-behaved peer keeps a single session per
+// remote and only re-dials after its previous link died. The common case is a
+// half-dead link — the TCP died without a FIN/RST, so the old session's serve
+// loop is still parked in AcceptStream and has NOT errored out, leaving the
+// stale session in the map. The previous policy REJECTED the reconnecting
+// session and kept the corpse, so:
+//   - inbound stream bridging (server_session.go: serverSession →
+//     forwardRequest) kept targeting the dead session and blocked for the
+//     full HandshakeTimeout on every dial — observed as "delegated server
+//     advertised but unreachable (5s)", which starved multihop route setup
+//     (every hop dialed pk@136 hung 5s, exhausting the id-reservation budget
+//     → "dmsg error 202 - cannot connect to delegated server"); and
+//   - zombie accept-loop goroutines accumulated (21 serve goroutines observed
+//     on a visor with only 8 reachable servers).
+//
+// The evicted predecessor's serve goroutine unwinds and calls delSession,
+// which is identity-checked so it cannot remove the live replacement.
 func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) bool {
 	c.sessionsMx.Lock()
-	if _, ok := c.sessions[dSes.RemotePK()]; ok {
+	old, hadOld := c.sessions[dSes.RemotePK()]
+	if hadOld && old == dSes {
 		c.sessionsMx.Unlock()
-		return false
+		return true
 	}
 	c.sessions[dSes.RemotePK()] = dSes
 	cb := c.setSessionCallback
 	c.sessionsMx.Unlock()
+
+	if hadOld {
+		// Close the stale predecessor OUTSIDE sessionsMx — Close does IO
+		// and can take other locks; holding sessionsMx across it risks the
+		// serveStream→session self-deadlock documented in updateServerEntry.
+		_ = old.Close() //nolint:errcheck
+	}
 
 	if cb != nil {
 		if err := cb(ctx); err != nil {
@@ -267,8 +297,19 @@ func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) bool
 	return true
 }
 
-func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey) {
+// delSession removes the session for pk, but only when the currently-stored
+// session is dSes. The identity check is essential now that setSession
+// replaces stale sessions on reconnect: when an evicted predecessor's serve
+// goroutine unwinds it calls delSession, and an unconditional delete would
+// remove the LIVE replacement that setSession just installed. A nil dSes
+// deletes unconditionally for callers that hold no session reference.
+func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey, dSes *SessionCommon) {
 	c.sessionsMx.Lock()
+	cur, ok := c.sessions[pk]
+	if !ok || (dSes != nil && cur != dSes) {
+		c.sessionsMx.Unlock()
+		return
+	}
 	delete(c.sessions, pk)
 	cb := c.delSessionCallback
 	c.sessionsMx.Unlock()

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -268,12 +269,12 @@ func (c *EntityCommon) SessionCount() int {
 //
 // The evicted predecessor's serve goroutine unwinds and calls delSession,
 // which is identity-checked so it cannot remove the live replacement.
-func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) bool {
+func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) {
 	c.sessionsMx.Lock()
 	old, hadOld := c.sessions[dSes.RemotePK()]
 	if hadOld && old == dSes {
 		c.sessionsMx.Unlock()
-		return true
+		return
 	}
 	c.sessions[dSes.RemotePK()] = dSes
 	cb := c.setSessionCallback
@@ -294,7 +295,6 @@ func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) bool
 				Warn("Callback returned non-nil error.\n")
 		}
 	}
-	return true
 }
 
 // delSession removes the session for pk, but only when the currently-stored
@@ -491,6 +491,21 @@ func (c *EntityCommon) updateServerEntryLoop(ctx context.Context, addr, addrV6 s
 	}
 }
 
+// isEntryNotFound reports whether err is the discovery's "entry not found"
+// result — i.e. the client genuinely has no entry yet, so a fresh sequence-0
+// registration is correct. It checks BOTH the typed sentinel and the message
+// string: the raw httpClient returns the disc.ErrKeyNotFound sentinel, but the
+// dmsgfirst/fallback clients and the test mock stringify it across the
+// dmsg-HTTP boundary (the same reason dmsgfirst string-matches the 202 error),
+// so errors.Is alone is not reliable here. Any OTHER error is transient (the
+// entry probably exists at a sequence we just couldn't read) and must NOT
+// trigger a sequence-0 re-registration, which the discovery rejects 422.
+func isEntryNotFound(err error) bool {
+	return err != nil &&
+		(errors.Is(err, disc.ErrKeyNotFound) ||
+			strings.Contains(err.Error(), disc.ErrKeyNotFound.Error()))
+}
+
 func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType string, protocol string) (err error) {
 	endpoints := c.snapshotDiscoveries()
 	if len(endpoints) == 0 {
@@ -507,8 +522,24 @@ func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType stri
 	var firstErr error
 	anyOK := false
 	for _, ep := range endpoints {
-		if _, lookupErr := ep.Client.Entry(ctx, c.pk); lookupErr == nil {
+		_, lookupErr := ep.Client.Entry(ctx, c.pk)
+		if lookupErr == nil {
 			anyOK = true
+			continue
+		}
+		// Only a genuine "entry not found" means we should register a fresh
+		// entry at sequence 0. Any other lookup error is transient (EOF /
+		// timeout / dmsg session not ready during the startup burst — the
+		// same race that produces the "Failed to dial server for IP" EOF):
+		// the entry almost certainly EXISTS at some sequence N we just
+		// couldn't read, so POSTing a sequence-0 entry would be rejected
+		// "sequence field of new entry is not sequence of old entry + 1"
+		// (422). Surface the transient error so the caller retries the
+		// initial post once the fetch works, instead of clobbering.
+		if !isEntryNotFound(lookupErr) {
+			if firstErr == nil {
+				firstErr = lookupErr
+			}
 			continue
 		}
 		entry := disc.NewClientEntry(c.pk, 0, srvPKs)
@@ -600,6 +631,14 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, clientType string, srvPKs []cipher.PubKey) error {
 	entry, err := ep.Client.Entry(ctx, c.pk)
 	if err != nil {
+		// Only register a fresh sequence-0 entry when the entry is
+		// genuinely absent. A transient lookup failure (EOF/timeout) does
+		// NOT mean the entry is gone — POSTing sequence 0 over an existing
+		// entry is rejected 422 "not old + 1". Return the error and let the
+		// update loop retry on the next tick.
+		if !isEntryNotFound(err) {
+			return err
+		}
 		entry = disc.NewClientEntry(c.pk, 0, srvPKs)
 		entry.ClientType = clientType
 		if err := entry.Sign(c.sk); err != nil {

--- a/pkg/dmsg/dmsg/entity_common_test.go
+++ b/pkg/dmsg/dmsg/entity_common_test.go
@@ -1,0 +1,88 @@
+package dmsg
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// newTestEntity builds a bare EntityCommon sufficient to exercise the
+// session-map lifecycle (setSession/delSession) without any network I/O.
+func newTestEntity() *EntityCommon {
+	return &EntityCommon{
+		sessions:   make(map[cipher.PubKey]*SessionCommon),
+		sessionsMx: new(sync.Mutex),
+	}
+}
+
+func testSession(pk cipher.PubKey) *SessionCommon {
+	// A bare SessionCommon: RemotePK reads rPK, and Close is nil-safe
+	// (no smux/yamux set), so no network resources are required.
+	return &SessionCommon{rPK: pk}
+}
+
+// TestSetSession_NewestWins is the regression guard for the dmsg multihop
+// failure: a reconnecting session for a PK that already has one must REPLACE
+// the stale predecessor (newest-session-wins), not be rejected. Keeping the
+// stale session left the visor "connected" to a server that could no longer
+// bridge an inbound stream — dialers hung for HandshakeTimeout and route
+// setup failed with "dmsg error 202".
+func TestSetSession_NewestWins(t *testing.T) {
+	c := newTestEntity()
+	pk, _ := cipher.GenerateKeyPair()
+
+	s1 := testSession(pk)
+	require.True(t, c.setSession(context.Background(), s1))
+	got, ok := c.session(pk)
+	require.True(t, ok)
+	require.Same(t, s1, got)
+
+	// Reconnect: a second session for the SAME pk must take over.
+	s2 := testSession(pk)
+	require.True(t, c.setSession(context.Background(), s2))
+	got, ok = c.session(pk)
+	require.True(t, ok)
+	require.Same(t, s2, got, "newest session must replace the stale one")
+
+	// Installing the identical session again is a no-op, still present.
+	require.True(t, c.setSession(context.Background(), s2))
+	got, _ = c.session(pk)
+	require.Same(t, s2, got)
+}
+
+// TestDelSession_IdentityChecked guards the other half of newest-session-wins:
+// when an evicted stale session's serve goroutine unwinds and calls
+// delSession, it must NOT delete the live replacement that already took its
+// map slot. Only an identity match (or a nil session) may delete.
+func TestDelSession_IdentityChecked(t *testing.T) {
+	c := newTestEntity()
+	pk, _ := cipher.GenerateKeyPair()
+
+	s1 := testSession(pk)
+	s2 := testSession(pk)
+	require.True(t, c.setSession(context.Background(), s1))
+	require.True(t, c.setSession(context.Background(), s2)) // s2 replaces s1
+
+	// The stale s1's goroutine unwinds and tries to delete by PK — must be
+	// a no-op because the map now holds s2, not s1.
+	c.delSession(context.Background(), pk, s1)
+	got, ok := c.session(pk)
+	require.True(t, ok, "stale predecessor delete must not evict the live session")
+	require.Same(t, s2, got)
+
+	// The live session deleting itself does remove it.
+	c.delSession(context.Background(), pk, s2)
+	_, ok = c.session(pk)
+	require.False(t, ok)
+
+	// A nil session deletes unconditionally (legacy callers).
+	s3 := testSession(pk)
+	require.True(t, c.setSession(context.Background(), s3))
+	c.delSession(context.Background(), pk, nil)
+	_, ok = c.session(pk)
+	require.False(t, ok)
+}

--- a/pkg/dmsg/dmsg/entity_common_test.go
+++ b/pkg/dmsg/dmsg/entity_common_test.go
@@ -36,20 +36,20 @@ func TestSetSession_NewestWins(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
 	s1 := testSession(pk)
-	require.True(t, c.setSession(context.Background(), s1))
+	c.setSession(context.Background(), s1)
 	got, ok := c.session(pk)
 	require.True(t, ok)
 	require.Same(t, s1, got)
 
 	// Reconnect: a second session for the SAME pk must take over.
 	s2 := testSession(pk)
-	require.True(t, c.setSession(context.Background(), s2))
+	c.setSession(context.Background(), s2)
 	got, ok = c.session(pk)
 	require.True(t, ok)
 	require.Same(t, s2, got, "newest session must replace the stale one")
 
 	// Installing the identical session again is a no-op, still present.
-	require.True(t, c.setSession(context.Background(), s2))
+	c.setSession(context.Background(), s2)
 	got, _ = c.session(pk)
 	require.Same(t, s2, got)
 }
@@ -64,8 +64,8 @@ func TestDelSession_IdentityChecked(t *testing.T) {
 
 	s1 := testSession(pk)
 	s2 := testSession(pk)
-	require.True(t, c.setSession(context.Background(), s1))
-	require.True(t, c.setSession(context.Background(), s2)) // s2 replaces s1
+	c.setSession(context.Background(), s1)
+	c.setSession(context.Background(), s2) // s2 replaces s1
 
 	// The stale s1's goroutine unwinds and tries to delete by PK — must be
 	// a no-op because the map now holds s2, not s1.
@@ -81,7 +81,7 @@ func TestDelSession_IdentityChecked(t *testing.T) {
 
 	// A nil session deletes unconditionally (legacy callers).
 	s3 := testSession(pk)
-	require.True(t, c.setSession(context.Background(), s3))
+	c.setSession(context.Background(), s3)
 	c.delSession(context.Background(), pk, nil)
 	_, ok = c.session(pk)
 	require.False(t, ok)

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -586,9 +586,10 @@ func (s *Server) handleSession(conn net.Conn) {
 	}
 	dSes.sm.mutx.Unlock()
 
-	if s.setSession(ctx, dSes.SessionCommon) {
-		dSes.Serve()
-	}
+	// Newest-session-wins: setSession always installs this session
+	// (replacing and closing any stale predecessor), so always serve it.
+	s.setSession(ctx, dSes.SessionCommon)
+	dSes.Serve()
 
 	// Identity-checked: only remove the map entry if it is still THIS
 	// session. setSession may have already replaced us with a fresh

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -590,6 +590,10 @@ func (s *Server) handleSession(conn net.Conn) {
 		dSes.Serve()
 	}
 
-	s.delSession(ctx, dSes.RemotePK())
+	// Identity-checked: only remove the map entry if it is still THIS
+	// session. setSession may have already replaced us with a fresh
+	// reconnect (newest-session-wins); deleting by PK alone would evict
+	// that live successor.
+	s.delSession(ctx, dSes.RemotePK(), dSes.SessionCommon)
 	cancel()
 }

--- a/pkg/router/client_pool_test.go
+++ b/pkg/router/client_pool_test.go
@@ -28,8 +28,8 @@ func (d *countingDialer) Dial(_ context.Context, _ cipher.PubKey, _ uint16) (net
 	return ours, nil
 }
 func (d *countingDialer) Probe(_ context.Context, _ cipher.PubKey, _ uint16) bool { return true }
-func (d *countingDialer) Type() string                                           { return string(types.DMSG) }
-func (d *countingDialer) count() int32                                           { return atomic.LoadInt32(&d.dials) }
+func (d *countingDialer) Type() string                                            { return string(types.DMSG) }
+func (d *countingDialer) count() int32                                            { return atomic.LoadInt32(&d.dials) }
 
 // TestClientPool_Get_DiscardsStalePooledConn is the regression test for the
 // setup-node id-reservation failures: Client.call() arms the stream read

--- a/pkg/visor/api_services_test.go
+++ b/pkg/visor/api_services_test.go
@@ -22,22 +22,22 @@ func TestServiceFetchOrder(t *testing.T) {
 		want             []serviceHop
 	}{
 		{
-			name: "dual: dmsg first then http",
+			name:    "dual: dmsg first then http",
 			httpURL: httpURL, dmsgURL: dmsgURL,
 			want: []serviceHop{{dmsg: true, baseURL: dmsgURL}, {dmsg: false, baseURL: httpURL}},
 		},
 		{
-			name: "dmsg-only: dmsg only (the default config)",
+			name:    "dmsg-only: dmsg only (the default config)",
 			httpURL: "", dmsgURL: dmsgURL,
 			want: []serviceHop{{dmsg: true, baseURL: dmsgURL}},
 		},
 		{
-			name: "http-only: http only",
+			name:    "http-only: http only",
 			httpURL: httpURL, dmsgURL: "",
 			want: []serviceHop{{dmsg: false, baseURL: httpURL}},
 		},
 		{
-			name: "neither configured",
+			name:    "neither configured",
 			httpURL: "", dmsgURL: "",
 			want: nil,
 		},

--- a/pkg/visor/hypervisor_handlers_health.go
+++ b/pkg/visor/hypervisor_handlers_health.go
@@ -65,7 +65,10 @@ func (hv *Hypervisor) getSvcFetch() http.HandlerFunc {
 		}
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write(body); err != nil {
+		// G705 false positive: body is binary service data proxied as
+		// application/octet-stream (not text/html), so it is downloaded, not
+		// rendered — there is no XSS sink here.
+		if _, err := w.Write(body); err != nil { //nolint:gosec // G705: octet-stream proxy payload, not an HTML sink
 			hv.log(r).WithError(err).Warn("getSvcFetch: failed to write response body")
 		}
 	}


### PR DESCRIPTION
## Problem

Multihop route setup fails probabilistically with `dmsg error 202 - cannot connect to delegated server`, even when dialing fully-reachable visors (including the route **source**). Diagnosed live on the production network.

**Root cause — half-dead dmsg sessions are never replaced.** When a dmsg session's TCP link half-dies (drops without a FIN/RST), its serve loop stays parked in `AcceptStream` and its entry stays in the PK→session map. The old lifecycle then **rejected the reconnect** and kept the corpse:

- `setSession` / `dialSession` returned `"session already exists"` and closed the *new, healthy* session;
- `delSession` deleted by PK unconditionally, so a late-returning corpse could evict a live replacement.

So a visor stayed **advertised as delegated** on a server that could no longer carry an **inbound** bridged stream.

## Evidence (measured live)

- Only **8 dmsg servers** exist network-wide; the affected visor + both route-setup nodes are delegated to all 8.
- Per-server probe of one visor's own `@136`: reachable via **2 of 8** "connected" servers; the other **6 hang the full 5s `HandshakeTimeout`**. The reachable set even flaps between probes.
- Route-ID reservation dials each hop `pk@136` over dmsg with a **~10s budget** → ~5s per stale-server miss → only ~2 servers tried → `dmsg error 202` whenever the live server isn't picked first. A 2-hop route needs source **and** intermediate **and** dest to each win this → ~coin-flip failure.
- Goroutine dump: **21** `ClientSession.serve` accept loops on a visor with only **8** reachable servers → ~13 zombie sessions.
- The session ping never catches it — it exercises the **outbound** path only, never the **inbound accept** path.

## Fix — newest-session-wins

- `setSession` always installs the new session and **closes the stale predecessor** (outside `sessionsMx` to avoid the `serveStream` self-deadlock).
- `dialSession` does the same instead of rejecting the reconnect.
- `delSession` is **identity-checked** so an evicted predecessor's unwinding serve goroutine can't remove the live successor.

Shared `EntityCommon`, so this fixes both the **dmsg-server** session map and the **visor client** session map on deploy.

Adds `TestSetSession_NewestWins` and `TestDelSession_IdentityChecked`. Full `pkg/dmsg/dmsg` suite passes, including under `-race`.