### PR TITLE
fix(cxo): close the feeds actor in Node.Close() (goroutine leak → GC-bound CPU)

### DIFF
--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -128,7 +128,7 @@ func newNodeFeeds(node *Node) (n *nodeFeeds) {
 	return n
 }
 
-func (n *nodeFeeds) close() { //nolint:unused
+func (n *nodeFeeds) close() {
 	n.closeo.Do(func() {
 		close(n.closeq)
 	})

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -821,6 +821,19 @@ func (n *Node) Close() (err error) {
 			rpc.Close() //nolint:errcheck,gosec
 		}
 
+		// Terminate the feeds actor and the per-feed / per-head goroutine
+		// tree it owns. close(closeq) unblocks handle()'s select (every
+		// feed/info channel op is guarded by `case <-closeq`), and its
+		// deferred terminate() closes each nodeFeed -> nodeHead. Without
+		// this, nodeFeeds.handle and all its nodeHead.handle goroutines
+		// LEAK on every Node teardown — a subscriber that reconnects
+		// periodically piled up thousands of parked goroutines, bloating
+		// the heap so GC consumed most of the CPU. Closed before the DB so
+		// any per-head flush completes against an open container.
+		if n.fs != nil {
+			n.fs.close()
+		}
+
 		// Close database.
 		err = n.c.Close() //nolint:errcheck,gosec
 


### PR DESCRIPTION
## Problem
`Node.Close()` shut down peer-exchange, connections, transports, and the DB — but **never closed `n.fs`** (the per-Node feeds actor). `nodeFeeds.close()` existed but was `//nolint:unused`: never called.

So **every `Node` teardown leaked** the `nodeFeeds.handle` dispatcher goroutine *and* every `nodeFeed → nodeHead.handle` goroutine it owned. A subscriber that reconnects periodically (recreating its `Node` each time) piles these up without bound.

Observed live on a visor: **~1650 parked `nodeFeeds.handle`/`nodeHead.handle` goroutines** (of ~4700 total), bloating the live heap so **GC consumed ~80% of CPU** (the process sat at ~42% CPU, almost entirely `runtime.scanObject`/`scanSpan`/`sweep`). After the fix + restart: **445 goroutines, ~12% CPU, 3.9% RAM**.

## Fix
`Node.Close()` now calls `n.fs.close()`:
- `close(closeq)` unblocks `handle()`'s `select` — every feed/info channel op is already guarded by `case <-closeq`.
- the deferred `terminate()` closes each `nodeFeed`, which closes each `nodeHead`.
- Every level exits cleanly on `closeq`, so there's no deadlock against the trailing `n.await.Wait()`.
- Closed *before* the DB so any per-head flush completes against an open container.
- Drops the now-stale `//nolint:unused`.

`go test ./pkg/cxo/node/` passes.