### PR TITLE
fix(dmsg): cut multihop-setup & dmsgweb churn — id-reserver 202 retry + single-client dmsgweb

### DIFF
--- a/pkg/dmsg/dmsgclient/cli.go
+++ b/pkg/dmsg/dmsgclient/cli.go
@@ -92,54 +92,15 @@ func InitDmsgWithFlags(ctx context.Context, dlog *logging.Logger, pk cipher.PubK
 		return StartDmsgWithDirectClient(ctx, dlog, pk, sk, DmsgSessions)
 	}
 
-	// Default dmsghttp mode
-	var dmsgHTTP *http.Client
-	var dmsgClients []*dmsg.Client
-	var closeFns []func()
-
-	dlog.Debug("Starting DMSG direct clients.")
-	for _, server := range dmsg.Prod.DmsgServers {
-		if len(dmsgClients) >= DmsgSessions {
-			break
-		}
-
-		dmsgDC, closeFn, err := StartDmsgDirectWithServers(ctx, dlog, pk, sk, DmsgDiscAddr, []*disc.Entry{&server}, DmsgSessions, dmsg.ExtractPKFromDmsgAddr(DmsgDiscAddr))
-		if err != nil {
-			dlog.WithError(err).Error("Failed to start DMSG direct client. Skipping server...")
-			continue
-		}
-
-		dmsgClients = append(dmsgClients, dmsgDC)
-		closeFns = append(closeFns, closeFn)
-	}
-
-	if len(dmsgClients) == 0 {
-		dlog.Fatal("Failed to start any DMSG direct clients.")
-	}
-
-	// Build HTTP client with fallback round tripper
-	dmsgHTTP = &http.Client{
-		Transport: NewFallbackRoundTripper(ctx, dmsgClients),
-	}
-
-	dlog.Debug("Checking discovery /health using DMSG HTTP client.")
-	resp, err := dmsgHTTP.Get(DmsgDiscAddr + "/health")
-	if err != nil {
-		for _, fn := range closeFns {
-			fn()
-		}
-		dlog.WithError(err).Fatal("All DMSG transports failed to reach discovery /health")
-	}
-	defer ioutil.CloseQuietly(resp.Body, dlog)
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		dlog.WithError(err).Error("Failed to read discovery /health response body")
-	} else {
-		dlog.Infof("Received response from dmsg-discovery server %s/health:\n%s", DmsgDiscAddr, string(body))
-	}
-
-	return StartDmsgWithSyntheticDiscovery(ctx, dlog, pk, sk, dmsgHTTP, DmsgDiscAddr, DmsgSessions)
+	// Default mode: a SINGLE dmsg client that reaches the dmsg-only discovery
+	// over its OWN sessions. This previously started N direct "bootstrap" clients
+	// (one per server) sharing pk/sk just to carry discovery HTTP, then a main
+	// client on top — all under one PK. A dmsg server allows one session per PK,
+	// so the bootstrap clients and the main client kicked each other off every
+	// shared server, producing a continuous reconnect storm. StartDmsgSelfHostedDisc
+	// folds them into one client; direct/hidden peers are still reachable via
+	// DialStream's existing dmsg-100 fallback over the same sessions.
+	return StartDmsgSelfHostedDisc(ctx, dlog, pk, sk, DmsgDiscAddr, DmsgSessions)
 }
 
 // StartDmsg starts dmsg returns a dmsg client for the given dmsg discovery

--- a/pkg/dmsg/dmsgclient/cli_fallback.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback.go
@@ -155,6 +155,92 @@ func StartDmsgWithDirectClient(ctx context.Context, dlog *logging.Logger, pk cip
 	}
 }
 
+// StartDmsgSelfHostedDisc starts a SINGLE dmsg client that reaches the
+// (dmsg-only) discovery over its OWN sessions — instead of the previous default
+// path, which spun up N separate "bootstrap" direct clients sharing this same
+// key just to carry discovery HTTP. A dmsg server permits one session per PK, so
+// those bootstrap clients and the main client kicked each other off every shared
+// server, producing a continuous reconnect/re-dial storm (observed on
+// dmsgweb-surveys at ~30 session events/sec).
+//
+// How it avoids the bootstrap clients: a direct disc client is preloaded with
+// every dmsg server entry plus a synthetic entry for the discovery server, so
+// this one client can connect to servers AND dial the discovery server without
+// any prior discovery lookup. Discovery HTTP (peer lookups) is then routed over
+// this client's own sessions via dmsghttp. PutEntry is a no-op through the
+// fallback wrapper, so the client doesn't register itself — it only dials out.
+// Reaching direct/hidden services still works through DialStream's existing
+// dmsg-100 fallback (dialViaConnectedServers over the same sessions).
+func StartDmsgSelfHostedDisc(ctx context.Context, dlog *logging.Logger, pk cipher.PubKey, sk cipher.SecKey, dmsgDiscAddr string, dmsgSessions int) (dmsgC *dmsg.Client, stop func(), err error) {
+	if dlog == nil {
+		return nil, nil, fmt.Errorf("nil logger")
+	}
+
+	// Preload direct entries: every dmsg server (so AvailableServers works with
+	// no discovery round-trip) plus a synthetic entry for the discovery server
+	// (so we can dial it directly over dmsg).
+	var entries []*disc.Entry
+	var delegatedServers []cipher.PubKey
+	for i := range dmsg.Prod.DmsgServers {
+		entries = append(entries, &dmsg.Prod.DmsgServers[i])
+		delegatedServers = append(delegatedServers, dmsg.Prod.DmsgServers[i].Static)
+	}
+	if discPK := dmsg.ExtractPKFromDmsgAddr(dmsgDiscAddr); discPK != "" {
+		var discoveryPK cipher.PubKey
+		if uerr := discoveryPK.UnmarshalText([]byte(discPK)); uerr == nil {
+			entries = append(entries, &disc.Entry{
+				Version: "0.0.1",
+				Static:  discoveryPK,
+				Client:  &disc.Client{DelegatedServers: delegatedServers},
+			})
+		}
+	}
+	// Synthetic entry for our OWN client. Without it the client's start-up
+	// self-lookup misses the direct client and falls back to an HTTP-disc dial of
+	// the discovery server before any session can reach it — which stalls Ready.
+	entries = append(entries, &disc.Entry{
+		Version: "0.0.1",
+		Static:  pk,
+		Client:  &disc.Client{DelegatedServers: delegatedServers},
+	})
+	directClient := direct.NewClient(entries, dlog)
+
+	// dmsgSessions <= 0 means "connect to all servers" (e.g. `dmsg web -e 0`),
+	// not an error. MinSessions is the number of sessions the client must
+	// establish before Ready; capping it at the known server count keeps the
+	// client from blocking forever waiting for more sessions than exist.
+	if dmsgSessions <= 0 || dmsgSessions > len(dmsg.Prod.DmsgServers) {
+		dmsgSessions = len(dmsg.Prod.DmsgServers)
+	}
+
+	// HTTP discovery fallback (for looking up arbitrary regular peers) rides this
+	// client's own sessions. The transport is bound after the client is created;
+	// no request is issued before Serve starts below, so the empty Transport is
+	// never used.
+	httpClient := &http.Client{}
+	httpDisc := disc.NewHTTP(dmsgDiscAddr, httpClient, dlog)
+	fallbackDisc := NewFallbackDiscClient(directClient, httpDisc, dlog)
+
+	dmsgC = dmsg.NewClient(pk, sk, fallbackDisc, &dmsg.Config{MinSessions: dmsgSessions})
+	httpClient.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgC)
+	dlog.Debug("Created single dmsg client with self-hosted discovery over its own sessions.")
+
+	go dmsgC.Serve(ctx)
+
+	stop = func() {
+		cerr := dmsgC.Close()
+		dlog.WithError(cerr).Debug("Disconnected from dmsg network.")
+	}
+	select {
+	case <-ctx.Done():
+		stop()
+		return nil, nil, ctx.Err()
+	case <-dmsgC.Ready():
+		dlog.Debug("Dmsg network ready.")
+		return dmsgC, stop, nil
+	}
+}
+
 // cachingDiscClient wraps a discovery client and caches a synthetic entry
 type cachingDiscClient struct {
 	base           disc.APIClient

--- a/pkg/router/map.go
+++ b/pkg/router/map.go
@@ -3,9 +3,12 @@ package router
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
 
@@ -14,6 +17,59 @@ import (
 // the primary cause of goroutine accumulation in the setup-node (113+ stuck goroutines
 // observed in production pprof dumps).
 const MakeMapTimeout = 60 * time.Second
+
+// dialHopAttempts bounds how many times a single hop's reservation dial is
+// tried before giving up. A dmsg-202 ("cannot connect to delegated server")
+// during route-id reservation is almost always transient: the hop is online and
+// reachable again within seconds — a dmsg server on the path briefly churned
+// (dropped/zombied a session). Each re-dial re-runs DialStream's own
+// multi-server selection, so after a short backoff it routes around the churn.
+// Without this, one transient blip on ONE hop fails the entire reservation and
+// trips the far more expensive whole-route-setup retry above it. Bounded by the
+// MakeMapTimeout ctx.
+const dialHopAttempts = 3
+
+// isRetryableDialErr reports whether a hop dial failed with a transient dmsg
+// bridge error (dmsg 202) that is worth re-dialing.
+func isRetryableDialErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, dmsg.ErrCannotConnectToDelegated) {
+		return true
+	}
+	// The sentinel can be lost when the error is reconstructed from a wire code
+	// or wrapped as a plain string; fall back to the message (same approach as
+	// pkg/dmsg/disc/dmsgfirst).
+	return strings.Contains(err.Error(), "cannot connect to delegated server")
+}
+
+// dialHopWithRetry dials one hop, retrying on a transient dmsg-202 bridge
+// failure with a short linear backoff. It stops early on success, on a
+// non-retryable error, or when ctx is cancelled (e.g. another hop failed
+// genuinely, or MakeMapTimeout fired).
+func dialHopWithRetry(ctx context.Context, pk cipher.PubKey, dial func(context.Context, cipher.PubKey) (*Client, error)) (*Client, error) {
+	var (
+		client *Client
+		err    error
+	)
+	for attempt := 0; attempt < dialHopAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(time.Duration(attempt) * time.Second):
+			case <-ctx.Done():
+				return nil, err
+			}
+		}
+		if client, err = dial(ctx, pk); err == nil {
+			return client, nil
+		}
+		if !isRetryableDialErr(err) || ctx.Err() != nil {
+			return nil, err
+		}
+	}
+	return nil, err
+}
 
 // Map is a map of router RPC clients associated with the router's visor PK.
 type Map map[cipher.PubKey]*Client
@@ -44,7 +100,9 @@ func MakeMap(ctx context.Context, dialer network.Dialer, pks []cipher.PubKey) (M
 
 	for _, pk := range pks {
 		go func(pk cipher.PubKey) {
-			client, err := NewClient(ctx, dialer, pk)
+			client, err := dialHopWithRetry(ctx, pk, func(c context.Context, pk cipher.PubKey) (*Client, error) {
+				return NewClient(c, dialer, pk)
+			})
 			results <- dialResult{client: client, err: err}
 		}(pk)
 	}
@@ -141,7 +199,9 @@ func MakePooledMap(ctx context.Context, pool *ClientPool, pks []cipher.PubKey) (
 
 	for _, pk := range pks {
 		go func(pk cipher.PubKey) {
-			client, err := pool.Get(ctx, pk)
+			client, err := dialHopWithRetry(ctx, pk, func(c context.Context, pk cipher.PubKey) (*Client, error) {
+				return pool.Get(c, pk)
+			})
 			results <- dialResult{client: client, err: err}
 		}(pk)
 	}

--- a/pkg/router/map.go
+++ b/pkg/router/map.go
@@ -46,7 +46,7 @@ func isRetryableDialErr(err error) bool {
 
 // dialHopWithRetry dials one hop, retrying on a transient dmsg-202 bridge
 // failure with a short linear backoff. It stops early on success, on a
-// non-retryable error, or when ctx is cancelled (e.g. another hop failed
+// non-retryable error, or when ctx is canceled (e.g. another hop failed
 // genuinely, or MakeMapTimeout fired).
 func dialHopWithRetry(ctx context.Context, pk cipher.PubKey, dial func(context.Context, cipher.PubKey) (*Client, error)) (*Client, error) {
 	var (


### PR DESCRIPTION
Two related fixes that reduce dmsg session churn / transient `dmsg error 202` failures.

## 1. Route-id reservation: retry a hop dial on transient dmsg-202 (`pkg/router/map.go`)
Multihop route setup dials every hop on `:136` to reserve route IDs (`MakeMap`/`MakePooledMap`) and failed the **whole** reservation on the first error → the expensive 6× whole-route-setup retry. The common trigger is a **transient** `dmsg error 202 - cannot connect to delegated server` on one hop (measured: the same intermediate probed 12/12 reachable seconds later). Each hop dial now gets a short bounded retry (3 attempts, linear backoff) on a transient 202; each re-dial re-runs `DialStream`'s multi-server selection so the brief churn clears. Non-retryable errors / ctx-cancel return immediately.

## 2. dmsgweb/dmsghttp default mode: ONE client, not N+1 colliding (`pkg/dmsg/dmsgclient/`)
`InitDmsgWithFlags`' default mode started N direct "bootstrap" clients (one per server) **sharing pk/sk** to carry discovery HTTP, plus a main client — all under one PK. A dmsg server allows one session per PK, so they kicked each other off every shared server → a continuous reconnect storm (observed on dmsgweb-surveys at ~30 session events/sec).

`StartDmsgSelfHostedDisc` folds them into a **single** client whose discovery HTTP rides its own sessions: a direct disc client preloaded with every server entry + a synthetic disc-server entry + a self entry, so it connects and dials the disc server with no bootstrap client. PutEntry is a no-op via the fallback wrapper (dials out, doesn't register); direct/hidden peers stay reachable via `DialStream`'s existing dmsg-100 fallback (`dialViaConnectedServers`).

Also fixes `dmsg web -e 0` (used to error; now means "connect to all servers").

**Local A/B (`dmsg web -e 8`, ~50s):** EOF session kicks **55 → 0**, `session already exists` **26 → 0**, log volume **690 → 53** lines, one client PK instead of ~9 colliding, reaches Ready with 6 sessions.

`go test ./pkg/router/` passes; dmsgclient lint clean.