### PR TITLE
feat(resolver): pin dmsg server + source-route skynet by PK or transport ID

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-route-addr.go
+++ b/cmd/skywire-cli/commands/tp/tp-route-addr.go
@@ -1,0 +1,71 @@
+// Package clitp cmd/skywire-cli/commands/tp/tp-route-addr.go
+package clitp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	tptypes "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+var (
+	routeAddrType   string
+	routeAddrSuffix string
+)
+
+func init() {
+	routeAddrCmd.Flags().StringVarP(&routeAddrType, "type", "t", "sudph", "transport type for the hops (dmsg, stcp, stcpr, sudph)")
+	routeAddrCmd.Flags().StringVarP(&routeAddrSuffix, "suffix", "s", ".skynet", "address suffix")
+	tpCmd.AddCommand(routeAddrCmd)
+}
+
+var routeAddrCmd = &cobra.Command{
+	Use:   "route-addr <src-pk> <hop-pk>... <dest-pk>",
+	Short: "Build a source-routed resolver address (<tpid>...<dest>.skynet) for a PK path",
+	Long: `Build the resolving-proxy address that source-routes through an explicit PK
+path, by computing the deterministic transport ID of each hop.
+
+The arguments are the ordered visor public keys of the path, SOURCE first and
+DESTINATION last (source is your own visor). For each consecutive pair the
+transport ID is computed with transport.MakeTransportID(pair, --type), and the
+result is assembled as:
+
+	<tpid-1>.<tpid-2>...<tpid-N>.<dest-pk>.skynet
+
+Paste it into the resolving proxy (skywire dmsg web / the visor skynet resolver)
+to route to <dest-pk> through exactly those transports. This is a pure local
+computation (no RPC, no discovery); the transports it names must already exist
+(or be created) for the route to set up.
+
+Valid transport types: dmsg, stcp, stcpr, sudph (default: sudph — dmsg transports
+are not used for multi-hop routes).`,
+	Args: cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch routeAddrType {
+		case "dmsg", "stcp", "stcpr", "sudph":
+		default:
+			internal.Catch(cmd.Flags(), fmt.Errorf("invalid transport type %q (valid: dmsg, stcp, stcpr, sudph)", routeAddrType))
+		}
+
+		path := make([]cipher.PubKey, len(args))
+		for i, a := range args {
+			if err := path[i].Set(a); err != nil {
+				internal.Catch(cmd.Flags(), fmt.Errorf("invalid pk #%d %q: %w", i+1, a, err))
+			}
+		}
+
+		labels := make([]string, 0, len(path))
+		for i := 0; i < len(path)-1; i++ {
+			id := transport.MakeTransportID(path[i], path[i+1], tptypes.Type(routeAddrType))
+			labels = append(labels, id.String())
+		}
+		labels = append(labels, path[len(path)-1].Hex())
+
+		fmt.Println(strings.Join(labels, ".") + routeAddrSuffix)
+	},
+}

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -249,7 +249,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			}
 
 			if _, ok := dialCtx.Value(dmsgResolverPortKey).(string); ok {
-				_, route, dest, _, perr := skynetweb.ParseResolverHost(origHost, cfg.DomainSuffix)
+				vhost, route, dest, _, perr := skynetweb.ParseResolverHost(origHost, cfg.DomainSuffix)
 				if perr != nil {
 					return nil, fmt.Errorf("invalid dmsg hostname %q: %w", origHost, perr)
 				}
@@ -263,9 +263,10 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 					// Pinned rendezvous: dial the destination THROUGH the named
 					// dmsg server's session instead of resolving it via
 					// discovery. This lets a browser reach a direct/hidden client
-					// by naming its server — <client-pk>.<server-pk>.dmsg. A
-					// .dmsg address carries a single routing PK (the server); if
-					// more are present the one nearest the destination wins.
+					// by naming its server — <server-pk>.<client-pk>.dmsg (the
+					// destination is the label adjacent to the suffix; routing PKs
+					// precede it). A .dmsg address carries a single routing PK (the
+					// server); if more are present the one nearest the dest wins.
 					rl := route[len(route)-1]
 					if rl.IsTpID {
 						return nil, fmt.Errorf("dmsg address %q: routing label must be a dmsg server PK, not a transport ID", origHost)
@@ -288,6 +289,15 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 						return nil, derr
 					}
 					stream = c
+				}
+
+				// Rewrite the Host header to the vhost (the labels before the
+				// destination PK) so a vhost-capable backend (caddy/nginx/traefik)
+				// serves the right site — the dmsg counterpart of the skynet
+				// resolver's host-rewrite, which makes magnetosphere.net.<pk>.dmsg
+				// reach the magnetosphere.net site.
+				if vhost != "" {
+					stream = skynetweb.NewHostRewriteConn(stream, vhost)
 				}
 
 				// Optional TLS MITM: terminate the browser's TLS

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -266,7 +266,11 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 					// by naming its server — <client-pk>.<server-pk>.dmsg. A
 					// .dmsg address carries a single routing PK (the server); if
 					// more are present the one nearest the destination wins.
-					serverPK := route[len(route)-1]
+					rl := route[len(route)-1]
+					if rl.IsTpID {
+						return nil, fmt.Errorf("dmsg address %q: routing label must be a dmsg server PK, not a transport ID", origHost)
+					}
+					serverPK := rl.PK
 					log.WithField("server", serverPK).WithField("port", port).Debug("SOCKS5 → DMSG pinned via server")
 					ses, serr := dmsgC.EnsureAndObtainSession(ctx, serverPK)
 					if serr != nil {

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -38,6 +38,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/ioutil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skynetca"
+	"github.com/skycoin/skywire/pkg/skynetweb"
 )
 
 // DefaultDomainSuffix is the TLD treated as DMSG addresses when
@@ -248,19 +249,41 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			}
 
 			if _, ok := dialCtx.Value(dmsgResolverPortKey).(string); ok {
-				pkLabel := strings.TrimSuffix(origHost, cfg.DomainSuffix)
-				pk, err := parsePKLabel(pkLabel)
-				if err != nil {
-					return nil, fmt.Errorf("invalid PK in hostname %q: %w", origHost, err)
+				_, route, dest, _, perr := skynetweb.ParseResolverHost(origHost, cfg.DomainSuffix)
+				if perr != nil {
+					return nil, fmt.Errorf("invalid dmsg hostname %q: %w", origHost, perr)
 				}
 				port, err := strconv.ParseUint(origPort, 10, 16)
 				if err != nil {
 					return nil, fmt.Errorf("invalid port: %w", err)
 				}
-				log.WithField("port", port).Debug("SOCKS5 → DMSG direct")
-				stream, err := dmsgC.Dial(ctx, dmsg.Addr{PK: pk, Port: uint16(port)})
-				if err != nil {
-					return nil, err
+				dstAddr := dmsg.Addr{PK: dest, Port: uint16(port)}
+				var stream net.Conn
+				if len(route) > 0 {
+					// Pinned rendezvous: dial the destination THROUGH the named
+					// dmsg server's session instead of resolving it via
+					// discovery. This lets a browser reach a direct/hidden client
+					// by naming its server — <client-pk>.<server-pk>.dmsg. A
+					// .dmsg address carries a single routing PK (the server); if
+					// more are present the one nearest the destination wins.
+					serverPK := route[len(route)-1]
+					log.WithField("server", serverPK).WithField("port", port).Debug("SOCKS5 → DMSG pinned via server")
+					ses, serr := dmsgC.EnsureAndObtainSession(ctx, serverPK)
+					if serr != nil {
+						return nil, fmt.Errorf("pin via dmsg server %s: %w", serverPK, serr)
+					}
+					str, derr := ses.DialStream(ctx, dstAddr)
+					if derr != nil {
+						return nil, derr
+					}
+					stream = str
+				} else {
+					log.WithField("port", port).Debug("SOCKS5 → DMSG direct")
+					c, derr := dmsgC.Dial(ctx, dstAddr)
+					if derr != nil {
+						return nil, derr
+					}
+					stream = c
 				}
 
 				// Optional TLS MITM: terminate the browser's TLS
@@ -414,22 +437,4 @@ func handleTCPConn(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client,
 	_ = conn.Close()     //nolint:errcheck
 	_ = dmsgConn.Close() //nolint:errcheck
 	<-done
-}
-
-// parsePKLabel accepts either the legacy 66-char hex form or the
-// 53-char base32 DNSLabel form. See pkg/cipher/dnslabel.go for the
-// motivation: only the base32 form fits in a DNS label and an X.509
-// Subject.CommonName, so TLS-MITM browser URLs must use it. Hex is
-// kept accepted for backcompat with plain-HTTP URLs already in use.
-func parsePKLabel(label string) (cipher.PubKey, error) {
-	switch len(label) {
-	case cipher.PubKeyDNSLabelLen: // 53 — base32
-		return cipher.ParseDNSLabel(label)
-	default:
-		var pk cipher.PubKey
-		if err := pk.Set(label); err != nil {
-			return cipher.PubKey{}, err
-		}
-		return pk, nil
-	}
 }

--- a/pkg/skynetweb/hostrewrite.go
+++ b/pkg/skynetweb/hostrewrite.go
@@ -65,11 +65,12 @@ type hostRewriteConn struct {
 	doneCh    chan struct{}
 }
 
-// newHostRewriteConn wraps backend so writes are HTTP-parsed and
+// NewHostRewriteConn wraps backend so writes are HTTP-parsed and
 // have their Host header replaced with targetHost. targetHost must
-// be non-empty; the caller (runtime.go) decides whether to apply
-// the wrapper based on the parsed URL.
-func newHostRewriteConn(backend net.Conn, targetHost string) *hostRewriteConn {
+// be non-empty; the caller decides whether to apply the wrapper based
+// on the parsed URL. Exported so the dmsg resolver (pkg/dmsgweb) can
+// reuse it for the same vhost handling.
+func NewHostRewriteConn(backend net.Conn, targetHost string) net.Conn {
 	if targetHost == "" {
 		// Caller bug — guard rather than silently passing through.
 		// A panic is preferable to silent breakage because this

--- a/pkg/skynetweb/hostrewrite_test.go
+++ b/pkg/skynetweb/hostrewrite_test.go
@@ -107,7 +107,7 @@ func TestSplitHostSubdomain(t *testing.T) {
 // received the request with Host: rewritten.
 func TestHostRewriteConn_RewritesHostHeader(t *testing.T) {
 	backend := newFakeConn()
-	hr := newHostRewriteConn(backend, "example.com")
+	hr := NewHostRewriteConn(backend, "example.com")
 	defer hr.Close() //nolint:errcheck,gosec
 
 	// Browser request. Host header should be the .skynet-flavor URL;
@@ -154,7 +154,7 @@ func TestHostRewriteConn_RewritesHostHeader(t *testing.T) {
 // each get Host rewritten.
 func TestHostRewriteConn_RewritesTwoSequentialRequests(t *testing.T) {
 	backend := newFakeConn()
-	hr := newHostRewriteConn(backend, "example.com")
+	hr := NewHostRewriteConn(backend, "example.com")
 	defer hr.Close() //nolint:errcheck,gosec
 
 	body := "GET /a HTTP/1.1\r\nHost: example.com.<pk>.skynet\r\n\r\n" +

--- a/pkg/skynetweb/resolverhost.go
+++ b/pkg/skynetweb/resolverhost.go
@@ -1,0 +1,88 @@
+// Package skynetweb pkg/skynetweb/resolverhost.go
+//
+// Shared parser for resolver hostnames used by BOTH the skynet resolving
+// proxy (.skynet) and the dmsg resolving proxy (.dmsg). It generalises the
+// existing "<vhost>.<pk>.<suffix>" form to carry an optional routing chain:
+//
+//	[<vhost>.]<r1>.<r2>…<rN>.<destPK>.<suffix>[:port]
+//
+// The destination PK is the label immediately before the suffix (unchanged
+// from the existing convention, so single-PK hostnames parse identically).
+// PK-shaped labels to its LEFT are the routing chain, returned in SOURCE order
+// (route[0] is nearest the source, route[len-1] is nearest the destination).
+// Everything to the left of the first non-PK label is the vhost, returned for
+// Host-header rewriting.
+//
+// The suffix decides what the routing PKs MEAN — the parser only extracts them:
+//   - ".dmsg":   a single rendezvous dmsg SERVER to dial the destination through.
+//   - ".skynet": the visor route HOPS (source-routed path to the destination).
+//
+// A PK label is recognized purely by shape (53-char base32 DNS label or 66-char
+// hex), so an ordinary vhost label like "magnetosphere" or "net" is never
+// mistaken for a PK. The one ambiguity intentionally left out of scope: a vhost
+// label that happens to be exactly PK-shaped.
+package skynetweb
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// ParseResolverHost parses host (e.g. from a browser's SOCKS5 CONNECT) into its
+// vhost, routing chain, destination PK and port. suffix must start with "."
+// (e.g. ".dmsg", ".skynet"). It returns an error when the host doesn't end in
+// suffix or the destination label isn't a valid PK.
+func ParseResolverHost(host, suffix string) (vhost string, route []cipher.PubKey, dest cipher.PubKey, port uint16, err error) {
+	hostPart, portStr, hasPort := splitHostPort(host)
+	port = 80
+	if hasPort {
+		p, perr := parseUint16(portStr)
+		if perr != nil {
+			return "", nil, cipher.PubKey{}, 0, fmt.Errorf("invalid port %q: %w", portStr, perr)
+		}
+		port = p
+	}
+
+	if len(hostPart) <= len(suffix) || hostPart[len(hostPart)-len(suffix):] != suffix {
+		return "", nil, cipher.PubKey{}, 0, fmt.Errorf("host %q has no suffix %q", hostPart, suffix)
+	}
+	stripped := hostPart[:len(hostPart)-len(suffix)]
+	if stripped == "" {
+		return "", nil, cipher.PubKey{}, 0, fmt.Errorf("host %q has no labels before %q", host, suffix)
+	}
+
+	labels := strings.Split(stripped, ".")
+	last := len(labels) - 1
+
+	// Destination = the label adjacent to the suffix (must be a PK).
+	dest, err = parsePKLabel(labels[last])
+	if err != nil {
+		return "", nil, cipher.PubKey{}, 0, fmt.Errorf("invalid destination PK %q: %w", labels[last], err)
+	}
+
+	// Walk left while labels are PK-shaped — those are the routing chain,
+	// collected nearest-the-dest first. The first non-PK label is the vhost
+	// boundary.
+	i := last - 1
+	var nearestDestFirst []cipher.PubKey
+	for ; i >= 0; i-- {
+		pk, perr := parsePKLabel(labels[i])
+		if perr != nil {
+			break
+		}
+		nearestDestFirst = append(nearestDestFirst, pk)
+	}
+
+	// Reverse to source order (route[0] = nearest the source).
+	route = make([]cipher.PubKey, 0, len(nearestDestFirst))
+	for j := len(nearestDestFirst) - 1; j >= 0; j-- {
+		route = append(route, nearestDestFirst[j])
+	}
+
+	if i >= 0 {
+		vhost = strings.Join(labels[:i+1], ".")
+	}
+	return vhost, route, dest, port, nil
+}

--- a/pkg/skynetweb/resolverhost.go
+++ b/pkg/skynetweb/resolverhost.go
@@ -1,40 +1,64 @@
 // Package skynetweb pkg/skynetweb/resolverhost.go
 //
 // Shared parser for resolver hostnames used by BOTH the skynet resolving
-// proxy (.skynet) and the dmsg resolving proxy (.dmsg). It generalises the
+// proxy (.skynet) and the dmsg resolving proxy (.dmsg). It generalizes the
 // existing "<vhost>.<pk>.<suffix>" form to carry an optional routing chain:
 //
 //	[<vhost>.]<r1>.<r2>…<rN>.<destPK>.<suffix>[:port]
 //
 // The destination PK is the label immediately before the suffix (unchanged
 // from the existing convention, so single-PK hostnames parse identically).
-// PK-shaped labels to its LEFT are the routing chain, returned in SOURCE order
-// (route[0] is nearest the source, route[len-1] is nearest the destination).
-// Everything to the left of the first non-PK label is the vhost, returned for
-// Host-header rewriting.
+// Labels to its LEFT that are PK-shaped or TpID-shaped form the routing chain,
+// returned in SOURCE order (route[0] nearest the source, route[len-1] nearest
+// the destination). Everything to the left of the first label that is neither a
+// PK nor a TpID is the vhost, returned for Host-header rewriting.
 //
-// The suffix decides what the routing PKs MEAN — the parser only extracts them:
-//   - ".dmsg":   a single rendezvous dmsg SERVER to dial the destination through.
-//   - ".skynet": the visor route HOPS (source-routed path to the destination).
+// The suffix decides what the routing labels MEAN — the parser only extracts
+// and classifies them:
+//   - ".dmsg":   a single rendezvous dmsg SERVER (a PK) to dial the dest through.
+//   - ".skynet": the route to the destination, where each hop is either a visor
+//     PK (any/auto transport) or a specific transport ID (uuid).
 //
-// A PK label is recognized purely by shape (53-char base32 DNS label or 66-char
-// hex), so an ordinary vhost label like "magnetosphere" or "net" is never
-// mistaken for a PK. The one ambiguity intentionally left out of scope: a vhost
-// label that happens to be exactly PK-shaped.
+// Classification is purely by shape — a PK label is 53-char base32 or 66-char
+// hex; a TpID label is a 32-char hex or 36-char dashed uuid. An ordinary vhost
+// label ("magnetosphere", "net") matches none of these. The one ambiguity left
+// out of scope: a vhost label that is itself exactly PK- or TpID-shaped.
 package skynetweb
 
 import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-// ParseResolverHost parses host (e.g. from a browser's SOCKS5 CONNECT) into its
-// vhost, routing chain, destination PK and port. suffix must start with "."
-// (e.g. ".dmsg", ".skynet"). It returns an error when the host doesn't end in
-// suffix or the destination label isn't a valid PK.
-func ParseResolverHost(host, suffix string) (vhost string, route []cipher.PubKey, dest cipher.PubKey, port uint16, err error) {
+// RouteLabel is one parsed routing-chain element: either a visor public key
+// (auto/any transport) or a specific transport ID.
+type RouteLabel struct {
+	IsTpID bool
+	PK     cipher.PubKey // valid when !IsTpID
+	TpID   uuid.UUID     // valid when IsTpID
+}
+
+// classifyRouteLabel reports whether label is a routing element (PK or TpID)
+// and, if so, which. A non-routing label (the vhost boundary) returns ok=false.
+// PK and TpID shapes don't overlap (66/53 vs 32/36 chars), so order is safe.
+func classifyRouteLabel(label string) (RouteLabel, bool) {
+	if pk, err := parsePKLabel(label); err == nil {
+		return RouteLabel{PK: pk}, true
+	}
+	if id, err := uuid.Parse(label); err == nil {
+		return RouteLabel{IsTpID: true, TpID: id}, true
+	}
+	return RouteLabel{}, false
+}
+
+// ParseResolverHost parses host into its vhost, routing chain, destination PK
+// and port. suffix must start with "." (e.g. ".dmsg", ".skynet"). It errors
+// when the host doesn't end in suffix or the destination label isn't a valid PK.
+func ParseResolverHost(host, suffix string) (vhost string, route []RouteLabel, dest cipher.PubKey, port uint16, err error) {
 	hostPart, portStr, hasPort := splitHostPort(host)
 	port = 80
 	if hasPort {
@@ -56,27 +80,28 @@ func ParseResolverHost(host, suffix string) (vhost string, route []cipher.PubKey
 	labels := strings.Split(stripped, ".")
 	last := len(labels) - 1
 
-	// Destination = the label adjacent to the suffix (must be a PK).
+	// Destination = the label adjacent to the suffix (must be a PK — a route
+	// always ends at a visor, never a transport).
 	dest, err = parsePKLabel(labels[last])
 	if err != nil {
 		return "", nil, cipher.PubKey{}, 0, fmt.Errorf("invalid destination PK %q: %w", labels[last], err)
 	}
 
-	// Walk left while labels are PK-shaped — those are the routing chain,
-	// collected nearest-the-dest first. The first non-PK label is the vhost
-	// boundary.
+	// Walk left while labels classify as routing elements (PK or TpID),
+	// collecting nearest-the-dest first. The first non-routing label is the
+	// vhost boundary.
 	i := last - 1
-	var nearestDestFirst []cipher.PubKey
+	var nearestDestFirst []RouteLabel
 	for ; i >= 0; i-- {
-		pk, perr := parsePKLabel(labels[i])
-		if perr != nil {
+		rl, ok := classifyRouteLabel(labels[i])
+		if !ok {
 			break
 		}
-		nearestDestFirst = append(nearestDestFirst, pk)
+		nearestDestFirst = append(nearestDestFirst, rl)
 	}
 
 	// Reverse to source order (route[0] = nearest the source).
-	route = make([]cipher.PubKey, 0, len(nearestDestFirst))
+	route = make([]RouteLabel, 0, len(nearestDestFirst))
 	for j := len(nearestDestFirst) - 1; j >= 0; j-- {
 		route = append(route, nearestDestFirst[j])
 	}

--- a/pkg/skynetweb/resolverhost_test.go
+++ b/pkg/skynetweb/resolverhost_test.go
@@ -1,0 +1,78 @@
+package skynetweb
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func mustPK(t *testing.T, hex string) cipher.PubKey {
+	t.Helper()
+	var pk cipher.PubKey
+	if err := pk.Set(hex); err != nil {
+		t.Fatalf("bad test PK %q: %v", hex, err)
+	}
+	return pk
+}
+
+func TestParseResolverHost(t *testing.T) {
+	dest := "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+	hop1 := "027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed"
+	hop2 := "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36"
+
+	dp := mustPK(t, dest)
+	h1 := mustPK(t, hop1)
+	h2 := mustPK(t, hop2)
+
+	cases := []struct {
+		name      string
+		host      string
+		suffix    string
+		wantVhost string
+		wantRoute []cipher.PubKey
+		wantDest  cipher.PubKey
+		wantPort  uint16
+		wantErr   bool
+	}{
+		{"bare dest", dest + ".dmsg", ".dmsg", "", nil, dp, 80, false},
+		{"vhost + dest", "example.com." + dest + ".dmsg", ".dmsg", "example.com", nil, dp, 80, false},
+		{"pinned server", "example.com." + hop1 + "." + dest + ".dmsg", ".dmsg", "example.com", []cipher.PubKey{h1}, dp, 80, false},
+		{"two-hop skynet (source order)", "site." + hop1 + "." + hop2 + "." + dest + ".skynet", ".skynet", "site", []cipher.PubKey{h1, h2}, dp, 80, false},
+		{"no vhost + one hop", hop1 + "." + dest + ".dmsg", ".dmsg", "", []cipher.PubKey{h1}, dp, 80, false},
+		{"explicit port", dest + ".dmsg:8080", ".dmsg", "", nil, dp, 8080, false},
+		{"wrong suffix", dest + ".onion", ".dmsg", "", nil, cipher.PubKey{}, 0, true},
+		{"bad dest", "notapk.dmsg", ".dmsg", "", nil, cipher.PubKey{}, 0, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			vhost, route, gotDest, port, err := ParseResolverHost(c.host, c.suffix)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if vhost != c.wantVhost {
+				t.Errorf("vhost = %q, want %q", vhost, c.wantVhost)
+			}
+			if port != c.wantPort {
+				t.Errorf("port = %d, want %d", port, c.wantPort)
+			}
+			if gotDest != c.wantDest {
+				t.Errorf("dest = %s, want %s", gotDest, c.wantDest)
+			}
+			if len(route) != len(c.wantRoute) {
+				t.Fatalf("route len = %d, want %d (%v)", len(route), len(c.wantRoute), route)
+			}
+			for i := range route {
+				if route[i] != c.wantRoute[i] {
+					t.Errorf("route[%d] = %s, want %s", i, route[i], c.wantRoute[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/skynetweb/resolverhost_test.go
+++ b/pkg/skynetweb/resolverhost_test.go
@@ -3,6 +3,8 @@ package skynetweb
 import (
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
@@ -15,30 +17,36 @@ func mustPK(t *testing.T, hex string) cipher.PubKey {
 	return pk
 }
 
+func pkLabel(pk cipher.PubKey) RouteLabel { return RouteLabel{PK: pk} }
+func tpLabel(id uuid.UUID) RouteLabel     { return RouteLabel{IsTpID: true, TpID: id} }
+
 func TestParseResolverHost(t *testing.T) {
 	dest := "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
 	hop1 := "027087fe40d97f7f0be4a0dc768462ddbb371d4b9e7679d4f11f117d757b9856ed"
 	hop2 := "02f9aa588dffa20b205e1c10bd0236130f080af157044d0eaa35753d2f2fcd6c36"
+	tp1 := "8d91173a-6101-0989-ba81-684a359c0cd9"
 
 	dp := mustPK(t, dest)
 	h1 := mustPK(t, hop1)
 	h2 := mustPK(t, hop2)
+	t1 := uuid.MustParse(tp1)
 
 	cases := []struct {
 		name      string
 		host      string
 		suffix    string
 		wantVhost string
-		wantRoute []cipher.PubKey
+		wantRoute []RouteLabel
 		wantDest  cipher.PubKey
 		wantPort  uint16
 		wantErr   bool
 	}{
 		{"bare dest", dest + ".dmsg", ".dmsg", "", nil, dp, 80, false},
 		{"vhost + dest", "example.com." + dest + ".dmsg", ".dmsg", "example.com", nil, dp, 80, false},
-		{"pinned server", "example.com." + hop1 + "." + dest + ".dmsg", ".dmsg", "example.com", []cipher.PubKey{h1}, dp, 80, false},
-		{"two-hop skynet (source order)", "site." + hop1 + "." + hop2 + "." + dest + ".skynet", ".skynet", "site", []cipher.PubKey{h1, h2}, dp, 80, false},
-		{"no vhost + one hop", hop1 + "." + dest + ".dmsg", ".dmsg", "", []cipher.PubKey{h1}, dp, 80, false},
+		{"pinned server (PK)", "example.com." + hop1 + "." + dest + ".dmsg", ".dmsg", "example.com", []RouteLabel{pkLabel(h1)}, dp, 80, false},
+		{"two-hop skynet PKs (source order)", "site." + hop1 + "." + hop2 + "." + dest + ".skynet", ".skynet", "site", []RouteLabel{pkLabel(h1), pkLabel(h2)}, dp, 80, false},
+		{"tpid hop", "site." + tp1 + "." + dest + ".skynet", ".skynet", "site", []RouteLabel{tpLabel(t1)}, dp, 80, false},
+		{"mixed tpid + pk hop", tp1 + "." + hop2 + "." + dest + ".skynet", ".skynet", "", []RouteLabel{tpLabel(t1), pkLabel(h2)}, dp, 80, false},
 		{"explicit port", dest + ".dmsg:8080", ".dmsg", "", nil, dp, 8080, false},
 		{"wrong suffix", dest + ".onion", ".dmsg", "", nil, cipher.PubKey{}, 0, true},
 		{"bad dest", "notapk.dmsg", ".dmsg", "", nil, cipher.PubKey{}, 0, true},
@@ -70,7 +78,7 @@ func TestParseResolverHost(t *testing.T) {
 			}
 			for i := range route {
 				if route[i] != c.wantRoute[i] {
-					t.Errorf("route[%d] = %s, want %s", i, route[i], c.wantRoute[i])
+					t.Errorf("route[%d] = %+v, want %+v", i, route[i], c.wantRoute[i])
 				}
 			}
 		})

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -45,8 +45,14 @@ const DefaultDomainSuffix = ".skynet"
 // See pkg/visor/embedded_skynetweb.go for the visor-side adapter
 // that fulfills this interface using router.DialRoutes + the handshake
 // helper below (PerformHandshake).
+//
+// route is an optional explicit source-route to the destination, parsed from
+// the hostname (e.g. <hop>.<dest>.skynet). Each element is a visor PK
+// (any/auto transport) or a specific transport ID. When empty the dialer picks
+// the path itself (direct transport, else route-finder). A non-empty route is
+// single-path: no mux, and the reverse path mirrors the forward path.
 type SkynetDialer interface {
-	DialSkynet(ctx context.Context, remote cipher.PubKey, port uint16) (net.Conn, error)
+	DialSkynet(ctx context.Context, remote cipher.PubKey, port uint16, route []RouteLabel) (net.Conn, error)
 }
 
 // PerformHandshake runs the skynet client-side handshake on an
@@ -182,17 +188,18 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				if addrPort != "" && addrPort != "80" {
 					hostWithPort = origHost + ":" + addrPort
 				}
-				target, err := parseHostHeader(hostWithPort, cfg.DomainSuffix)
+				vhost, route, dest, hport, err := ParseResolverHost(hostWithPort, cfg.DomainSuffix)
 				if err != nil {
 					return nil, fmt.Errorf("skynet dial: %w", err)
 				}
 
 				done := cfg.Stats.RecordRequest()
-				log.WithField("pk", target.pk.Hex()).
-					WithField("port", target.port).
-					Debug("SOCKS5 → skynet direct")
+				log.WithField("pk", dest.Hex()).
+					WithField("port", hport).
+					WithField("hops", len(route)).
+					Debug("SOCKS5 → skynet")
 
-				conn, err := dialer.DialSkynet(dialCtx, target.pk, target.port)
+				conn, err := dialer.DialSkynet(dialCtx, dest, hport, route)
 				if err != nil {
 					done(err)
 					return nil, fmt.Errorf("skynet dial: %w", err)
@@ -214,13 +221,13 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				// browser is already sending plaintext directly to
 				// hostRewriteConn — same parser, same effect.
 				stack := conn
-				if target.subdomain != "" {
+				if vhost != "" {
 					// `subdomain` already encodes the operator's
 					// intent (the URL has labels before the PK).
 					// Use it verbatim as the rewritten Host.
-					stack = newHostRewriteConn(stack, target.subdomain)
-					log.WithField("pk", target.pk.Hex()).
-						WithField("rewrite_host", target.subdomain).
+					stack = newHostRewriteConn(stack, vhost)
+					log.WithField("pk", dest.Hex()).
+						WithField("rewrite_host", vhost).
 						Debug("SOCKS5 → skynet host-rewrite active")
 				}
 
@@ -231,7 +238,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				// underlying skywire conn is already authenticated
 				// by visor pubkey; the local cert exists only to
 				// satisfy the browser's secure-context machinery.
-				if cfg.TLSMITM && target.port == cfg.TLSPort {
+				if cfg.TLSMITM && hport == cfg.TLSPort {
 					leaf, lerr := cfg.LeafMinter.For(origHost)
 					if lerr != nil {
 						_ = stack.Close() //nolint:errcheck,gosec
@@ -308,35 +315,6 @@ func isSkynetHost(host, suffix string) bool {
 	pattern := `\` + suffix + `(:[0-9]+)?$`
 	match, _ := regexp.MatchString(pattern, host) //nolint:errcheck
 	return match
-}
-
-type target struct {
-	pk   cipher.PubKey
-	port uint16
-	// subdomain is the label(s) before the PK in the original
-	// hostname, when the visitor used a vhost-style URL like
-	// "<subdomain>.<pk>.skynet". Empty when the URL was just
-	// "<pk>.skynet". Triggers the Host-header rewrite path in the
-	// dial wiring — see newHostRewriteConn in hostrewrite.go.
-	subdomain string
-}
-
-// parseHostHeader turns "<pk>.skynet[:<port>]" or
-// "<subdomain>.<pk>.skynet[:<port>]" into a target struct. Port
-// defaults to 80 when absent to match conventional HTTP semantics.
-// The subdomain field is non-empty only when there was at least one
-// label before the PK; that signals the runtime to apply the
-// Host-rewrite wrapper.
-func parseHostHeader(host, suffix string) (target, error) {
-	pkLabel, subdomain, port, err := splitHostSubdomain(host, suffix)
-	if err != nil {
-		return target{}, err
-	}
-	pk, err := parsePKLabel(pkLabel)
-	if err != nil {
-		return target{}, fmt.Errorf("invalid pk %q: %w", pkLabel, err)
-	}
-	return target{pk: pk, port: port, subdomain: subdomain}, nil
 }
 
 // parsePKLabel accepts either the legacy 66-char hex form or the

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -225,7 +225,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 					// `subdomain` already encodes the operator's
 					// intent (the URL has labels before the PK).
 					// Use it verbatim as the rewritten Host.
-					stack = newHostRewriteConn(stack, vhost)
+					stack = NewHostRewriteConn(stack, vhost)
 					log.WithField("pk", dest.Hex()).
 						WithField("rewrite_host", vhost).
 						Debug("SOCKS5 → skynet host-rewrite active")

--- a/pkg/skynetweb/runtime_test.go
+++ b/pkg/skynetweb/runtime_test.go
@@ -159,7 +159,7 @@ type fakeDialer struct {
 	onDial func() (net.Conn, error)
 }
 
-func (f fakeDialer) DialSkynet(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+func (f fakeDialer) DialSkynet(_ context.Context, _ cipher.PubKey, _ uint16, _ []RouteLabel) (net.Conn, error) {
 	if f.onDial == nil {
 		return nil, errors.New("fakeDialer: no onDial set")
 	}

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
@@ -36,6 +37,10 @@ import (
 // Default SOCKS5 listener port — matches `skywire dmsg web` so the two
 // surfaces behave identically from a browser's perspective.
 const defaultDmsgWebProxyPort = 4445
+
+// dmsgWebReadyWait bounds how long serve() waits for the dmsg client to be
+// ready before binding the listener anyway.
+const dmsgWebReadyWait = 20 * time.Second
 
 // EmbeddedDmsgWeb holds the runtime state for the visor-hosted
 // dmsgweb resolver. Safe for concurrent Start/Stop calls.
@@ -164,6 +169,18 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 		}
 	}
 
+	// Best-effort, BOUNDED wait for the dmsg client so the first request
+	// doesn't race the initial discovery publish — but never block the
+	// listener bind indefinitely (the app must come up and accept
+	// connections regardless; early requests just fail until dmsg is ready).
+	select {
+	case <-e.dmsgC.Ready():
+	case <-time.After(dmsgWebReadyWait):
+		e.log.Warn("dmsgweb: dmsg client not ready within timeout; serving anyway")
+	case <-ctx.Done():
+		return
+	}
+
 	e.log.WithField("socks_port", cfg.ProxyPort).
 		WithField("domain", cfg.DomainSuffix).
 		WithField("tls_mitm", cfg.TLSMITM).
@@ -202,14 +219,13 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 		return nil
 	}
 
-	// Wait for the visor's dmsg client to be ready before spinning up
-	// the resolver so the first browser request doesn't race the
-	// initial discovery publish.
-	select {
-	case <-v.dmsgC.Ready():
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	// NOTE: do NOT block here on v.dmsgC.Ready(). This init runs under a
+	// bounded boot context; when dmsg is slow to publish (e.g. churn right
+	// after a restart) the wait outlived that context, returned early, and
+	// the app was never registered — so its SOCKS5 listener never bound
+	// (4445), while skynetweb (which doesn't wait on dmsg) came up fine. The
+	// readiness wait now lives in serve(), bounded, so the app always
+	// registers and binds; only the first requests race a not-yet-ready dmsg.
 
 	// Auto-chain: if the config doesn't explicitly set an upstream
 	// and skynet_web is also configured, wire dmsgweb → skynetweb so

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -19,6 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appserver"
@@ -30,6 +32,7 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skynetweb"
 	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -202,7 +205,14 @@ type routerSkynetDialer struct {
 	nextPort     uint32                 // ephemeral port counter for route fallback
 }
 
-func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKey, port uint16) (net.Conn, error) {
+func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKey, port uint16, route []skynetweb.RouteLabel) (net.Conn, error) {
+	// Explicit source-route from the hostname (<hop>.<dest>.skynet): build the
+	// exact forward+reverse hops and dial them, bypassing the direct-transport
+	// fast path and the route-finder. Single-path only (no mux).
+	if len(route) > 0 {
+		return d.dialSourceRoute(ctx, remote, port, route)
+	}
+
 	// Try direct transport first — no route setup needed, no RSN dependency.
 	// Uses the shared VStreamMux (same instance as the forwarding server).
 	// Dereference at dial time so we pick up a mux that finished
@@ -242,6 +252,128 @@ func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKe
 		return nil, err
 	}
 	return conn, nil
+}
+
+// dialSourceRoute builds explicit forward+reverse hops from a parsed route and
+// dials them with DialRoutes (route-finder bypassed). Single-path; the reverse
+// path mirrors the forward path (transport IDs are symmetric, so the same TpIDs
+// are reused with edges swapped).
+func (d *routerSkynetDialer) dialSourceRoute(ctx context.Context, dest cipher.PubKey, port uint16, route []skynetweb.RouteLabel) (net.Conn, error) {
+	fwd, rev, err := d.buildSourceRoute(ctx, dest, route)
+	if err != nil {
+		return nil, fmt.Errorf("skynet source-route to %s: %w", dest, err)
+	}
+	opts := router.DefaultDialOptions()
+	if d.routeTimeout > 0 {
+		opts.KeepAlive = d.routeTimeout
+	}
+	opts.ForwardHops = fwd
+	opts.ReverseHops = rev
+	lPort := routing.Port(atomic.AddUint32(&d.nextPort, 1)) //nolint:gosec
+	conn, err := d.router.DialRoutes(ctx, dest, lPort, routing.Port(skyenv.SkyForwardingServerPort), opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := skynetweb.PerformHandshake(conn, port); err != nil {
+		_ = conn.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return conn, nil
+}
+
+// buildSourceRoute turns the parsed route into forward+reverse routing hops. A
+// TpID label resolves to its edges (and thus the next visor); a PK label names
+// the next visor, whose transport is found or — for this visor's own hop —
+// created. A final hop to dest is appended unless the chain already ends there.
+func (d *routerSkynetDialer) buildSourceRoute(ctx context.Context, dest cipher.PubKey, route []skynetweb.RouteLabel) (fwd, rev []routing.Hop, err error) {
+	current := d.localPK
+	for _, rl := range route {
+		var next cipher.PubKey
+		var tpID uuid.UUID
+		if rl.IsTpID {
+			tpID = rl.TpID
+			a, b, rerr := d.resolveTpEdges(ctx, tpID)
+			if rerr != nil {
+				return nil, nil, rerr
+			}
+			switch current {
+			case a:
+				next = b
+			case b:
+				next = a
+			default:
+				return nil, nil, fmt.Errorf("transport %s does not connect from %s", tpID, current)
+			}
+		} else {
+			next = rl.PK
+			id, terr := d.findOrCreateTransport(ctx, current, next)
+			if terr != nil {
+				return nil, nil, terr
+			}
+			tpID = id
+		}
+		fwd = append(fwd, routing.Hop{TpID: tpID, From: current, To: next})
+		current = next
+	}
+	if current != dest {
+		id, terr := d.findOrCreateTransport(ctx, current, dest)
+		if terr != nil {
+			return nil, nil, terr
+		}
+		fwd = append(fwd, routing.Hop{TpID: id, From: current, To: dest})
+	}
+	rev = make([]routing.Hop, len(fwd))
+	for i, h := range fwd {
+		rev[len(fwd)-1-i] = routing.Hop{TpID: h.TpID, From: h.To, To: h.From}
+	}
+	return fwd, rev, nil
+}
+
+// resolveTpEdges returns the two visor PKs a transport connects — from the local
+// transport manager (this visor's own transports) or the transport discovery
+// (downstream hops).
+func (d *routerSkynetDialer) resolveTpEdges(ctx context.Context, tpID uuid.UUID) (cipher.PubKey, cipher.PubKey, error) {
+	if mt, e := d.tpM.GetTransportByID(tpID); e == nil {
+		return d.localPK, mt.Remote(), nil
+	}
+	entry, e := d.tpM.Conf.DiscoveryClient.GetTransportByID(ctx, tpID)
+	if e != nil {
+		return cipher.PubKey{}, cipher.PubKey{}, fmt.Errorf("resolve transport %s: %w", tpID, e)
+	}
+	return entry.Edges[0], entry.Edges[1], nil
+}
+
+// findOrCreateTransport returns the ID of a transport connecting from→to. When
+// `from` is this visor it reuses an existing stcpr/sudph transport or creates
+// one; for an intermediate pair it can only find an existing transport via the
+// discovery (no remote-create yet). Skynet routes never use dmsg transports.
+func (d *routerSkynetDialer) findOrCreateTransport(ctx context.Context, from, to cipher.PubKey) (uuid.UUID, error) {
+	if from == d.localPK {
+		for _, t := range []types.Type{types.STCPR, types.SUDPH} {
+			if mt, e := d.tpM.GetTransport(to, t); e == nil {
+				return mt.Entry.ID, nil
+			}
+		}
+		var lastErr error
+		for _, t := range []types.Type{types.STCPR, types.SUDPH} {
+			mt, e := d.tpM.SaveTransport(ctx, to, t, transport.LabelUser)
+			if e == nil {
+				return mt.Entry.ID, nil
+			}
+			lastErr = e
+		}
+		return uuid.UUID{}, fmt.Errorf("no transport to %s and could not create one: %w", to, lastErr)
+	}
+	entries, e := d.tpM.Conf.DiscoveryClient.GetTransportsByEdge(ctx, from)
+	if e != nil {
+		return uuid.UUID{}, fmt.Errorf("look up transports of %s: %w", from, e)
+	}
+	for _, en := range entries {
+		if en.Edges[0] == to || en.Edges[1] == to {
+			return en.ID, nil
+		}
+	}
+	return uuid.UUID{}, fmt.Errorf("no known transport between %s and %s (remote-create not supported yet)", from, to)
 }
 
 func initEmbeddedSkynetWeb(ctx context.Context, v *Visor, log *logging.Logger) error {


### PR DESCRIPTION
Lets the resolving proxies reach a destination over an **operator-chosen path**, encoded in the hostname, alongside the existing `<vhost>.<pk>.<suffix>` form.

## Address grammar (shared parser)
`[<vhost>.]<r1>...<rN>.<destPK>.<suffix>[:port]` — destination PK stays adjacent to the suffix (existing hostnames parse identically); labels to its left are a routing chain in source order; remaining non-PK labels are the vhost. Classification is by **shape**: 66-hex/53-base32 = PK, 32-hex/36-dash uuid = TpID, else vhost. (`pkg/skynetweb/ParseResolverHost`, unit-tested.)

## dmsg — pin via a rendezvous server
`<server-pk>.<client-pk>.dmsg` dials the client **through** the named dmsg server's session (`EnsureAndObtainSession` + `ClientSession.DialStream`) instead of resolving via discovery — so a browser can reach a **direct/hidden** dmsg client by naming its server. Bare `<pk>.dmsg` unchanged. dmsgweb also gains the **Host-rewrite** the skynet side already had, so `<vhost>.<pk>.dmsg` serves the right vhost from a caddy/nginx backend.

## skynet — source-route by PK or transport ID
`<hop>...<dest>.skynet`, where each hop is a **visor PK** (auto stcpr/sudph transport, found-or-created) or a **specific transport ID**. The visor adapter builds explicit `ForwardHops`/`ReverseHops` and dials them via `DialRoutes`, bypassing the route-finder. Single-path (no mux, fwd==rev, TpIDs symmetric); intermediate-pair transports must already exist (remote-create is a follow-up).

## CLI helper
`skywire cli tp route-addr <src> <hop>... <dest> --type sudph` prints the `<tpid>...<dest>.skynet` address (deterministic `MakeTransportID` per hop).

## Live validation (against magnetosphere through the resolving proxy)
| address form | result |
|---|---|
| `<pk>.skynet` (bare + vhost) | **200** |
| `<tpid>.<pk>.skynet` (source-route) | **200** — router log confirms the forward rule used the specified transport `55d43098…` |
| `<pk>.dmsg` (bare + vhost) | **200** |
| `<server>.<pk>.dmsg` (pin) | **200** |
| `<vhost>.<server>.<pk>.dmsg` (vhost + pin) | **200** |
| `tp route-addr` | computed TpID == the real on-visor transport ID |

Out of scope (you OK'd these): mux/asymmetric paths under explicit hops; a vhost label that is itself PK/TpID-shaped; remote transport creation for intermediate pairs.