### PR TITLE
feat(route-finder): latency-weighted route selection (default)

### DIFF
--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -52,7 +52,7 @@ func init() {
 	calcCmd.Flags().IntVarP(&calcCount, "count", "c", 1, "max routes to return (0 = all matching)")
 	calcCmd.Flags().StringVar(&calcSource, "source", "tpd", "transport graph source: tpd (HTTP), dht (visor's local DHT store), auto (DHT then TPD)")
 	calcCmd.Flags().IntVar(&calcQueueCap, "queue-cap", 0, "BFS queue cap (0 = server/local default ~200K, negative = unbounded)")
-	calcCmd.Flags().BoolVar(&calcByLatency, "by-latency", true, "rank routes by cumulative transport latency (lowest first) — the default, matching the route-finder service; use --by-latency=false for the cheaper streaming shortest-hop path (full set must be in hand to sort by latency)")
+	calcCmd.Flags().BoolVar(&calcByLatency, "by-latency", false, "rank routes by cumulative transport latency (lowest first); skips the streaming gRPC path since the full set has to be in hand to sort")
 	clirpc.RegisterFetchFlags(calcCmd)
 }
 

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -52,7 +52,7 @@ func init() {
 	calcCmd.Flags().IntVarP(&calcCount, "count", "c", 1, "max routes to return (0 = all matching)")
 	calcCmd.Flags().StringVar(&calcSource, "source", "tpd", "transport graph source: tpd (HTTP), dht (visor's local DHT store), auto (DHT then TPD)")
 	calcCmd.Flags().IntVar(&calcQueueCap, "queue-cap", 0, "BFS queue cap (0 = server/local default ~200K, negative = unbounded)")
-	calcCmd.Flags().BoolVar(&calcByLatency, "by-latency", false, "rank routes by cumulative transport latency (lowest first); skips the streaming gRPC path since the full set has to be in hand to sort")
+	calcCmd.Flags().BoolVar(&calcByLatency, "by-latency", true, "rank routes by cumulative transport latency (lowest first) — the default, matching the route-finder service; use --by-latency=false for the cheaper streaming shortest-hop path (full set must be in hand to sort by latency)")
 	clirpc.RegisterFetchFlags(calcCmd)
 }
 

--- a/pkg/route-finder/api/api.go
+++ b/pkg/route-finder/api/api.go
@@ -163,7 +163,12 @@ func (a *API) getPairedRoutes(w http.ResponseWriter, r *http.Request) {
 		dstPK := edge[1]
 		graph := graphs[srcPK]
 
-		forwardRoutes, err := graph.GetRoute(r.Context(), srcPK, dstPK, minHops, maxHops, numRoutes)
+		// Latency-weighted by default: the graph is already built from
+		// GetTransportsByEdge, which overlays each edge's measured latency, so
+		// returning lowest-total-latency routes (with a per-hop penalty for
+		// unmeasured edges) costs nothing extra and replaces the old
+		// shortest-hop-but-arbitrary ordering.
+		forwardRoutes, err := graph.GetRouteWeighted(r.Context(), srcPK, dstPK, minHops, maxHops, numRoutes, true)
 		if err != nil {
 			a.handleError(w, r, http.StatusNotFound, err)
 			return

--- a/pkg/route-finder/store/finder.go
+++ b/pkg/route-finder/store/finder.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"
@@ -42,6 +43,85 @@ func (g *Graph) GetRoute(ctx context.Context, source, destination cipher.PubKey,
 		return nil, ErrRouteNotFound
 	}
 	return routes, nil
+}
+
+// HopLatencyPenaltyMS is the latency assumed for a transport that has no
+// measured latency. It keeps latency-weighted routing usable when data is
+// missing: an unmeasured edge is treated as worse than a typical measured one
+// (so measured low-latency edges win), and a route of all-unmeasured edges is
+// effectively ranked by hop count (number of hops × penalty) — degrading to the
+// legacy behavior rather than treating missing data as free.
+const HopLatencyPenaltyMS = 500.0
+
+// routeLatency returns a route's total latency in milliseconds: the sum of each
+// hop's measured transport latency from the graph, substituting
+// HopLatencyPenaltyMS for any edge without a measurement.
+func (g *Graph) routeLatency(r routing.Route) float64 {
+	var total float64
+	for _, h := range r.Hops {
+		v, ok := g.graph[h.From]
+		if !ok {
+			total += HopLatencyPenaltyMS
+			continue
+		}
+		conn, ok := v.connections[h.To]
+		if !ok || conn.Latency <= 0 {
+			total += HopLatencyPenaltyMS
+			continue
+		}
+		total += conn.Latency
+	}
+	return total
+}
+
+// GetRouteWeighted returns up to `number` routes from source to destination
+// within [minLen, maxLen]. When byLatency is true it returns the
+// lowest-total-latency routes (a slightly longer path can win over a shorter
+// high-latency one); when false it returns the shortest-hop routes — identical
+// to GetRoute. Latency mode collects a bounded candidate pool from the same BFS
+// and sorts it, so it stays memory-safe on dense graphs.
+func (g *Graph) GetRouteWeighted(ctx context.Context, source, destination cipher.PubKey, minLen, maxLen, number int, byLatency bool) ([]routing.Route, error) {
+	if number <= 0 {
+		number = 1
+	}
+	if !byLatency {
+		return g.GetRoute(ctx, source, destination, minLen, maxLen, number)
+	}
+
+	// Pool larger than `number` so a lower-latency path that BFS emits a little
+	// later (e.g. one more hop, but faster edges) can still win — bounded so
+	// dense graphs don't blow up the sort.
+	poolCap := number * 32
+	if poolCap < 128 {
+		poolCap = 128
+	}
+	if poolCap > 2048 {
+		poolCap = 2048
+	}
+
+	type scored struct {
+		route   routing.Route
+		latency float64
+	}
+	pool := make([]scored, 0, poolCap)
+	err := g.StreamRoutes(ctx, source, destination, minLen, maxLen, func(r routing.Route) bool {
+		pool = append(pool, scored{route: r, latency: g.routeLatency(r)})
+		return len(pool) < poolCap
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pool) == 0 {
+		return nil, ErrRouteNotFound
+	}
+
+	sort.SliceStable(pool, func(i, j int) bool { return pool[i].latency < pool[j].latency })
+
+	out := make([]routing.Route, 0, number)
+	for i := 0; i < len(pool) && i < number; i++ {
+		out = append(out, pool[i].route)
+	}
+	return out, nil
 }
 
 // DefaultMaxBFSQueue is the default per-call BFS queue cap when the

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -157,6 +157,49 @@ func (m *mockStore) DeleteAll() {
 	m.transports = make(map[cipher.PubKey][]*transport.Entry)
 }
 
+// saveEntryLat is SaveEntry with an ID, type and measured latency, for
+// latency-weighted route tests.
+func (m *mockStore) saveEntryLat(source, destiny cipher.PubKey, latencyMS float64) {
+	entry := &transport.Entry{
+		ID:      uuid.New(),
+		Edges:   transport.SortEdges(source, destiny),
+		Type:    tptypes.STCPR,
+		Latency: latencyMS,
+	}
+	m.transports[source] = append(m.transports[source], entry)
+	m.transports[destiny] = append(m.transports[destiny], entry)
+}
+
+// TestGetRouteWeighted verifies that latency mode prefers a longer route with
+// lower cumulative latency over a shorter, higher-latency one — while hop-count
+// mode still returns the shortest route.
+func TestGetRouteWeighted(t *testing.T) {
+	src, a, b, c, dst := generateNodesPK(t)
+	m := newMockStore()
+	// Short path: src -> a -> dst, two slow edges (400+400 = 800ms).
+	m.saveEntryLat(src, a, 400)
+	m.saveEntryLat(a, dst, 400)
+	// Long path: src -> b -> c -> dst, three fast edges (100*3 = 300ms).
+	m.saveEntryLat(src, b, 100)
+	m.saveEntryLat(b, c, 100)
+	m.saveEntryLat(c, dst, 100)
+
+	g, err := NewGraph(context.Background(), m, src)
+	require.NoError(t, err)
+
+	// Hop-count mode → the shortest (2-hop) route.
+	hop, err := g.GetRouteWeighted(context.Background(), src, dst, 0, 5, 1, false)
+	require.NoError(t, err)
+	require.Len(t, hop, 1)
+	require.Len(t, hop[0].Hops, 2)
+
+	// Latency mode → the lower-total-latency (3-hop) route.
+	lat, err := g.GetRouteWeighted(context.Background(), src, dst, 0, 5, 1, true)
+	require.NoError(t, err)
+	require.Len(t, lat, 1)
+	require.Len(t, lat[0].Hops, 3)
+}
+
 func TestNewGraph(t *testing.T) {
 	node1PK, node2PK, node3PK, node4PK, node5PK := generateNodesPK(t)
 


### PR DESCRIPTION
The route-finder built its graph from `GetTransportsByEdge` — which **already overlays each edge's measured latency** onto the entry — but then chose routes by **hop count alone** (BFS), ignoring it. So among equal-hop routes it returned graph-adjacency order, a detour could beat a clean path, and the visor's downstream latency-ranking can't recover a good path the finder never returns.

## Change (service-side, one file of routing logic)
- **`GetRouteWeighted`** ranks routes by **total measured latency** (sum of per-edge latency), collecting a bounded candidate pool from the same BFS and sorting it — so a slightly longer but faster path can win, while staying memory-safe.
- **Fallback:** `HopLatencyPenaltyMS` is substituted for edges with no measurement, so an all-unmeasured route degrades to hop-count rather than treating missing data as free.
- **Service default (api.go):** uses it — **free**, since the graph already carries the latency.

## Audit that motivated it
- **92%** of transports carry measured latency (98–431ms RTT).
- It reaches the finder's graph via `GetTransportsByEdge` (latency overlaid).
- Only the bulk `/all-transports` HTTP endpoint omits latency — and the finder doesn't use that endpoint.

## Test
`TestGetRouteWeighted`: with a 2-hop/800ms path and a 3-hop/300ms path, latency mode returns the 3-hop route, hop-count mode returns the 2-hop. Passes.

## Not in this PR
`cli route calc` already has `--by-latency` (opt-in), but it uses a **separate, older algorithm** (per-visor metric fetch, `+Inf` for unmeasured hops). Aligning it to call `GetRouteWeighted` so the CLI and service share one algorithm is a follow-up (needs the CLI's local graph to carry per-edge latency).

## Rollout / proof
Deployed-service change; falls back to today's behavior when latency is absent. The latency-vs-hops / jitter / queuing sweep is the before/after proof — measured on the BFS finder now, re-measured after this deploys.