### PR TITLE
fix(router): retry id-reservation on stale pooled connection (#1 RSN setup failure)

### DIFF
--- a/pkg/router/id_reserver.go
+++ b/pkg/router/id_reserver.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -44,11 +45,13 @@ type IDReserver interface {
 }
 
 type idReserver struct {
-	total int                                 // the total number of route IDs we reserve from the routers
-	rcM   Map                                 // map of router clients
-	rec   map[cipher.PubKey]uint8             // this records the number of expected rules per visor PK
-	ids   map[cipher.PubKey][]routing.RouteID // this records the obtained rules per visor PK
-	mx    sync.Mutex
+	total  int                                 // the total number of route IDs we reserve from the routers
+	rcM    Map                                 // map of router clients
+	rec    map[cipher.PubKey]uint8             // this records the number of expected rules per visor PK
+	ids    map[cipher.PubKey][]routing.RouteID // this records the obtained rules per visor PK
+	pool   *ClientPool                         // non-nil → re-dial a stale conn through the pool
+	dialer network.Dialer                      // fresh-dial source when pool is nil
+	mx     sync.Mutex
 }
 
 // NewIDReserver creates a new route ID reserver from a dialer and a slice of paths.
@@ -92,11 +95,50 @@ func NewIDReserver(ctx context.Context, dialer network.Dialer, pool *ClientPool,
 
 	// Return result.
 	return &idReserver{
-		total: total,
-		rcM:   clients,
-		rec:   rec,
-		ids:   make(map[cipher.PubKey][]routing.RouteID, total),
+		total:  total,
+		rcM:    clients,
+		rec:    rec,
+		ids:    make(map[cipher.PubKey][]routing.RouteID, total),
+		pool:   pool,
+		dialer: dialer,
 	}, nil
+}
+
+// isPooledConnShutdown reports whether err is net/rpc's "connection is shut
+// down" — returned when a call is made on an already-closed rpc.Client, the
+// signature of a stale connection handed back by the pool.
+func isPooledConnShutdown(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection is shut down")
+}
+
+// redial discards a dead client and dials a fresh one for pk, replacing it in
+// the client map so the later rule-install reuses the live connection. Returns
+// nil when no fresh connection can be established (caller surfaces the original
+// error). See ReserveIDs for why this is needed.
+func (idr *idReserver) redial(ctx context.Context, pk cipher.PubKey, dead *Client) *Client {
+	if dead != nil {
+		_ = dead.Close() //nolint:errcheck,gosec // never return a corpse to the pool
+	}
+	var (
+		fresh *Client
+		err   error
+	)
+	switch {
+	case idr.pool != nil:
+		// The pool entry for pk was consumed at build time, so Get dials fresh.
+		fresh, err = idr.pool.Get(ctx, pk)
+	case idr.dialer != nil:
+		fresh, err = NewClient(ctx, idr.dialer, pk)
+	default:
+		return nil
+	}
+	if err != nil || fresh == nil {
+		return nil
+	}
+	idr.mx.Lock()
+	idr.rcM[pk] = fresh
+	idr.mx.Unlock()
+	return fresh
 }
 
 func (idr *idReserver) ReserveIDs(ctx context.Context) error {
@@ -126,6 +168,21 @@ func (idr *idReserver) ReserveIDs(ctx context.Context) error {
 				return
 			}
 			rtIDs, err := client.ReserveIDs(ctx, n)
+			if isPooledConnShutdown(err) {
+				// Stale pooled connection. ClientPool.Get's liveness check
+				// (client_pool.go) only discards conns idle past the stream
+				// read deadline — so a conn that died for any OTHER reason (the
+				// intermediate restarted, its dmsg session/transport dropped)
+				// is handed back as a corpse and this first call returns
+				// "connection is shut down". Re-dial fresh ONCE and retry: a
+				// reachable hop succeeds on the retry, a genuinely-dead one
+				// still fails below. This was the dominant route-setup failure
+				// (id_reservation, ~59% on a live RSN) — a single bad pooled
+				// conn was failing the whole reservation with no retry.
+				if fresh := idr.redial(ctx, pk, client); fresh != nil {
+					rtIDs, err = fresh.ReserveIDs(ctx, n)
+				}
+			}
 			if err != nil {
 				errCh <- fmt.Errorf("reserve routeID from %s failed: %w", pk, err)
 				return

--- a/pkg/router/id_reserver_test.go
+++ b/pkg/router/id_reserver_test.go
@@ -4,7 +4,10 @@ package router
 import (
 	"context"
 	"errors"
+	"net"
+	"net/rpc"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 // We check the contents of 'idReserver.rec' is as expected after calling 'NewIDReserver'.
@@ -280,4 +284,73 @@ func TestIdReserver_ReserveIDs_NoSiblingCancelOnFailure(t *testing.T) {
 	cIDs := idr.ids[pkC]
 	idr.mx.Unlock()
 	assert.Len(t, cIDs, 1, "healthy sibling C should reserve its ID despite A failing")
+}
+
+// shutdownGateway is a mock router.RPCGateway whose ReserveIDs returns net/rpc's
+// "connection is shut down" — the error a stale pooled connection produces.
+type shutdownGateway struct{}
+
+func (shutdownGateway) ReserveIDs(_ uint8, _ *[]routing.RouteID) error {
+	return errors.New("connection is shut down")
+}
+
+// flakyReserveDialer serves a shutdownGateway on the FIRST dial to each pk and a
+// working mockGatewayForDialer on every subsequent dial — modeling a pooled
+// connection that is dead on first use but reachable on a fresh re-dial.
+type flakyReserveDialer struct {
+	t  *testing.T
+	mu sync.Mutex
+	n  map[cipher.PubKey]int
+}
+
+func (d *flakyReserveDialer) Type() string                                      { return string(types.DMSG) }
+func (d *flakyReserveDialer) Probe(context.Context, cipher.PubKey, uint16) bool { return true }
+
+func (d *flakyReserveDialer) Dial(_ context.Context, pk cipher.PubKey, _ uint16) (net.Conn, error) {
+	d.mu.Lock()
+	k := d.n[pk]
+	d.n[pk]++
+	d.mu.Unlock()
+
+	var gw interface{} = &mockGatewayForDialer{}
+	if k == 0 {
+		gw = shutdownGateway{}
+	}
+	connC, connS := net.Pipe()
+	rpcS := rpc.NewServer()
+	require.NoError(d.t, rpcS.RegisterName(RPCName, gw))
+	go rpcS.ServeConn(connS)
+	d.t.Cleanup(func() {
+		assert.NoError(d.t, connC.Close())
+		assert.NoError(d.t, connS.Close())
+	})
+	return connC, nil
+}
+
+// TestIdReserver_ReserveIDs_RetriesStalePooledConn covers the fix for the #1 live
+// route-setup failure (id_reservation, ~59% on a real RSN): a pooled connection
+// returning "connection is shut down" must be re-dialed fresh and the
+// reservation retried, instead of failing the whole route. Without the retry,
+// ReserveIDs returns that error directly.
+func TestIdReserver_ReserveIDs_RetriesStalePooledConn(t *testing.T) {
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	d := &flakyReserveDialer{t: t, n: make(map[cipher.PubKey]int)}
+
+	rtIDR, err := NewIDReserver(context.TODO(), d, nil, [][]routing.Hop{makeHops(pkA, pkB)})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, rtIDR.Close()) })
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	defer cancel()
+
+	// The first pooled conn to each hop is dead → "connection is shut down"; the
+	// reserver must re-dial fresh and succeed.
+	require.NoError(t, rtIDR.ReserveIDs(ctx))
+
+	// Each hop was dialed at least twice: the initial dead conn + one re-dial.
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	assert.GreaterOrEqual(t, d.n[pkA], 2, "hop A should have been re-dialed")
+	assert.GreaterOrEqual(t, d.n[pkB], 2, "hop B should have been re-dialed")
 }


### PR DESCRIPTION
## Diagnosed live from the route setup node itself
Read straight off the RSN over dmsg — `/stats` (`cli dmsg curl dmsg://<sn>:80/stats`) and pprof (`:81`, survey-whitelist key):

| | |
|---|---|
| success rate | **91.1%** (5691/6249 over 5.4h) |
| **id_reservation** | **331 (59% of failures)** — "connection is shut down" |
| context_deadline | 170 (30%) |
| source_unreachable / circuit_open / destination_rules | 41 / 8 / 8 |
| goroutines (pprof) | 108, **no leak** → failures are transient, not overload |

So ~90% of route-setup failures are the setup node failing to **reserve route IDs from intermediates**, dominated by a **stale pooled connection**.

## Root cause — the gap in #3032
`ClientPool.Get` discards a pooled connection only once it has **idled** past the stream read deadline (idle time as a liveness proxy). A connection that died for **any other reason** — the intermediate restarted, its dmsg session/transport dropped — has a recent `lastUsed`, so `Get` hands back a corpse, the first `ReserveIDs` returns rpc's "connection is shut down", and the reserver had **no retry** → one dead pooled conn failed the whole route setup.

## Fix
`idReserver.ReserveIDs` now re-dials a fresh connection **once** on "connection is shut down", retries the reservation, and replaces the client in the map so the later rule-install reuses the live conn. A reachable hop succeeds on the retry; a genuinely-dead one still fails (unchanged). Preserves the existing no-sibling-cancel behavior (per-hop, doesn't touch the shared ctx).

Test: `TestIdReserver_ReserveIDs_RetriesStalePooledConn` (dead conn on first dial → re-dial → success). Full router suite green.

## Rollout / validation
Deployed-service change (`pkg/router`, used by the standalone setup node `pkg/services/sn` and the embedded RSN). Validate post-redeploy via the same `/stats`: `id_reservation` failures should drop and success rate rise.