### PR TITLE
feat(services): pprof + /debug/log on dmsg :80 for all deployment services; fix visor /visor.log path

### DIFF
--- a/pkg/dmsg/dmsghttp/debug.go
+++ b/pkg/dmsg/dmsghttp/debug.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"strings"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -14,11 +15,15 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 )
 
-// DefaultDebugPort is the dmsg port used for serving debug/pprof endpoints.
+// DefaultDebugPort is the dmsg port historically used for serving debug/pprof on
+// its own listener. Prefer WithDebug to fold the same endpoints onto the
+// service's main dmsg :80 handler (one port for /health + /metrics + /debug/*).
 const DefaultDebugPort = uint16(81)
 
-// DebugMux returns an http.ServeMux with standard pprof endpoints registered.
-func DebugMux() *http.ServeMux {
+// DebugMux returns an http.ServeMux with the standard pprof endpoints, plus
+// /debug/log serving logSource() when it is non-nil — the service's recent log
+// output from an in-memory ring buffer (no disk file, no -s flag).
+func DebugMux(logSource func() []byte) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -28,7 +33,29 @@ func DebugMux() *http.ServeMux {
 	for _, p := range []string{"heap", "goroutine", "threadcreate", "block", "mutex", "allocs"} {
 		mux.Handle("/debug/pprof/"+p, pprof.Handler(p))
 	}
+	if logSource != nil {
+		mux.HandleFunc("/debug/log", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			_, _ = w.Write(logSource()) //nolint:errcheck
+		})
+	}
 	return mux
+}
+
+// WithDebug returns a handler that serves the survey-gated debug endpoints
+// (/debug/pprof/* and, when logSource != nil, /debug/log) on the SAME listener
+// as next, delegating every other path to next. This consolidates pprof + logs
+// onto the service's main dmsg :80 instead of a separate debug port (matching
+// the visor's logserver). Only /debug/* is whitelist-gated; next is unchanged.
+func WithDebug(next http.Handler, whitelistPKs []cipher.PubKey, logSource func() []byte) http.Handler {
+	debug := WhitelistMiddleware(whitelistPKs, DebugMux(logSource))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/debug/") {
+			debug.ServeHTTP(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // WhitelistMiddleware wraps an http.Handler with public-key-based access control.
@@ -68,6 +95,9 @@ func WhitelistMiddleware(whitelistedPKs []cipher.PubKey, next http.Handler) http
 // provided whitelist public keys. It blocks until the context is canceled or
 // an error occurs.
 //
+// Deprecated: prefer WithDebug, which folds pprof + /debug/log onto the
+// service's main dmsg :80 handler instead of a separate :81 listener.
+//
 // An empty whitelist is logged at WARN and the middleware will reject every
 // request — see WhitelistMiddleware for rationale.
 func ServeDebug(ctx context.Context, dmsgC *dmsg.Client, log *logging.Logger, whitelistPKs []cipher.PubKey) error {
@@ -76,7 +106,7 @@ func ServeDebug(ctx context.Context, dmsgC *dmsg.Client, log *logging.Logger, wh
 	} else {
 		log.WithField("whitelisted_pks", len(whitelistPKs)).Info("ServeDebug: pprof access restricted to whitelisted PKs")
 	}
-	handler := WhitelistMiddleware(whitelistPKs, DebugMux())
+	handler := WhitelistMiddleware(whitelistPKs, DebugMux(nil))
 
 	lis, err := dmsgC.Listen(DefaultDebugPort)
 	if err != nil {

--- a/pkg/dmsg/dmsghttp/debug_test.go
+++ b/pkg/dmsg/dmsghttp/debug_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDebugMux_PprofEndpoints(t *testing.T) {
-	mux := dmsghttp.DebugMux()
+	mux := dmsghttp.DebugMux(nil)
 
 	endpoints := []string{
 		"/debug/pprof/",

--- a/pkg/dmsg/dmsghttp/withdebug_test.go
+++ b/pkg/dmsg/dmsghttp/withdebug_test.go
@@ -1,0 +1,47 @@
+// Package dmsghttp_test pkg/dmsghttp/withdebug_test.go
+package dmsghttp_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+)
+
+func TestWithDebug_RoutesAndGates(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "service-handler") //nolint:errcheck
+	})
+	logSource := func() []byte { return []byte("recent-log-line\n") }
+	h := dmsghttp.WithDebug(next, []cipher.PubKey{pk}, logSource)
+
+	// Non-/debug path → service handler, no auth required.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.RemoteAddr = "anything:1"
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "service-handler")
+
+	// /debug/log with a whitelisted PK → serves logSource().
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/debug/log", nil)
+	req.RemoteAddr = pk.String() + ":1234"
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "recent-log-line")
+
+	// /debug/pprof with a NON-whitelisted PK → 401.
+	other, _ := cipher.GenerateKeyPair()
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	req.RemoteAddr = other.String() + ":1234"
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/pkg/logging/ringbuffer.go
+++ b/pkg/logging/ringbuffer.go
@@ -1,0 +1,55 @@
+//go:build !js
+
+// Package logging pkg/logging/ringbuffer.go
+package logging
+
+import (
+	"bytes"
+	"sync"
+)
+
+// DefaultRingBufferBytes is the default capacity of a RingBuffer.
+const DefaultRingBufferBytes = 256 * 1024
+
+// RingBuffer is a thread-safe, fixed-capacity io.Writer that retains the most
+// recent bytes written (oldest dropped, trimmed to a line boundary). It exists
+// so a service can expose its recent log output over a debug endpoint without
+// writing to disk: attach it with AddHook(NewWriteHook(rb)) and serve rb.Bytes().
+type RingBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	max int
+}
+
+// NewRingBuffer returns a RingBuffer holding up to maxBytes (DefaultRingBufferBytes
+// when maxBytes <= 0).
+func NewRingBuffer(maxBytes int) *RingBuffer {
+	if maxBytes <= 0 {
+		maxBytes = DefaultRingBufferBytes
+	}
+	return &RingBuffer{max: maxBytes}
+}
+
+// Write appends p, dropping the oldest bytes (trimmed to the next line boundary
+// so the buffer never starts mid-line) when capacity is exceeded. Never errors.
+func (rb *RingBuffer) Write(p []byte) (int, error) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	rb.buf = append(rb.buf, p...)
+	if len(rb.buf) > rb.max {
+		rb.buf = rb.buf[len(rb.buf)-rb.max:]
+		if i := bytes.IndexByte(rb.buf, '\n'); i >= 0 && i+1 <= len(rb.buf) {
+			rb.buf = rb.buf[i+1:]
+		}
+	}
+	return len(p), nil
+}
+
+// Bytes returns a copy of the current buffer contents.
+func (rb *RingBuffer) Bytes() []byte {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	out := make([]byte, len(rb.buf))
+	copy(out, rb.buf)
+	return out
+}

--- a/pkg/logging/ringbuffer_test.go
+++ b/pkg/logging/ringbuffer_test.go
@@ -1,0 +1,45 @@
+//go:build !js
+
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRingBuffer_RetainsRecentAndBounds(t *testing.T) {
+	rb := NewRingBuffer(16)
+
+	// Recent content is retained verbatim while under capacity.
+	if _, err := rb.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := string(rb.Bytes()); got != "hello\n" {
+		t.Fatalf("got %q, want %q", got, "hello\n")
+	}
+
+	// Past capacity, oldest bytes are dropped (trimmed to a line boundary) and
+	// the buffer never exceeds its cap.
+	for i := 0; i < 20; i++ {
+		_, _ = rb.Write([]byte("xxxxx\n")) //nolint:errcheck // 6 bytes each, far over cap
+	}
+	got := rb.Bytes()
+	if len(got) > 16 {
+		t.Fatalf("buffer exceeded cap: %d > 16", len(got))
+	}
+	if strings.Contains(string(got), "hello") {
+		t.Fatalf("expected oldest content dropped, got %q", got)
+	}
+	if !strings.Contains(string(got), "xxxxx") {
+		t.Fatalf("expected recent content retained, got %q", got)
+	}
+
+	// Bytes returns a copy — mutating it must not affect the buffer.
+	cp := rb.Bytes()
+	if len(cp) > 0 {
+		cp[0] = '!'
+	}
+	if string(rb.Bytes()) == string(cp) && len(cp) > 0 {
+		t.Fatal("Bytes() did not return a copy")
+	}
+}

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -245,20 +245,19 @@ func (s *service) runDMSG(
 
 	go updateServers(ctx, a, dClient, dmsgDC, cfg.DmsgServerType, log)
 
-	go func() {
-		if dmsgErr := dmsghttp.ListenAndServe(ctx, sk, a, dClient, dmsg.DefaultDmsgHTTPPort, dmsgDC, log); dmsgErr != nil {
-			log.Errorf("dmsghttp.ListenAndServe: %v", dmsgErr)
-			cancel()
-		}
-	}()
-
 	wl := deployment.Prod.SurveyWhitelist
 	if cfg.TestEnvironment {
 		wl = deployment.Test.SurveyWhitelist
 	}
+	// Fold pprof + /debug/log onto the main dmsg :80 (survey-gated) instead of a
+	// separate :81 listener. The ring buffer captures recent global-logger output.
+	rb := logging.NewRingBuffer(0)
+	logging.AddHook(logging.NewWriteHook(rb))
+	handler := dmsghttp.WithDebug(a, wl, rb.Bytes)
 	go func() {
-		if debugErr := dmsghttp.ServeDebug(ctx, dmsgDC, log, wl); debugErr != nil {
-			log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
+		if dmsgErr := dmsghttp.ListenAndServe(ctx, sk, handler, dClient, dmsg.DefaultDmsgHTTPPort, dmsgDC, log); dmsgErr != nil {
+			log.Errorf("dmsghttp.ListenAndServe: %v", dmsgErr)
+			cancel()
 		}
 	}()
 

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -370,19 +370,18 @@ func (s *service) serveDmsgSurfaces(
 		json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
 	})
 
+	// Fold pprof + /debug/log onto the main dmsg :80 (survey-gated) instead of a
+	// separate :81 listener. The ring buffer captures recent global-logger output.
+	rb := logging.NewRingBuffer(0)
+	logging.AddHook(logging.NewWriteHook(rb))
+	handler := dmsghttp.WithDebug(healthMux, deployment.Prod.SurveyWhitelist, rb.Bytes)
 	go func() {
-		if err := dmsghttp.ListenAndServe(ctx, cfg.SecKey, healthMux, dClient,
+		if err := dmsghttp.ListenAndServe(ctx, cfg.SecKey, handler, dClient,
 			dmsg.DefaultDmsgHTTPPort, dmsgC, log); err != nil {
-			log.WithError(err).Error("DMSG HTTP health server stopped")
+			log.WithError(err).Error("DMSG HTTP server stopped")
 		}
 	}()
-	log.Infof("DMSG HTTP health endpoint available at %s", dmsgAddr)
-
-	go func() {
-		if debugErr := dmsghttp.ServeDebug(ctx, dmsgC, log, deployment.Prod.SurveyWhitelist); debugErr != nil {
-			log.Errorf("dmsghttp.ServeDebug: %v", debugErr)
-		}
-	}()
+	log.Infof("DMSG HTTP (health/debug) available at %s", dmsgAddr)
 
 	if cfg.EnableRouteSetup {
 		go s.serveRouteSetup(ctx, dmsgC)

--- a/pkg/services/sn/sn.go
+++ b/pkg/services/sn/sn.go
@@ -293,18 +293,20 @@ func (s *service) startDMSGHealth(
 	})
 
 	snClient := sn.DmsgClient()
+	// Fold pprof + /debug/log onto the main dmsg :80 (survey-gated) instead of a
+	// separate :81 listener. The ring buffer captures route-setup logs (the
+	// router logs via the global logger) so /debug/log needs no disk file —
+	// e.g. the live id-reservation failures behind the /stats counters.
+	rb := logging.NewRingBuffer(0)
+	logging.AddHook(logging.NewWriteHook(rb))
+	handler := dmsghttp.WithDebug(mux, deployment.Prod.SurveyWhitelist, rb.Bytes)
 	go func() {
-		if err := dmsghttp.ListenAndServe(ctx, conf.SK, mux, nil,
+		if err := dmsghttp.ListenAndServe(ctx, conf.SK, handler, nil,
 			dmsg.DefaultDmsgHTTPPort, snClient, log); err != nil {
-			log.WithError(err).Error("DMSG HTTP health server stopped")
+			log.WithError(err).Error("DMSG HTTP server stopped")
 		}
 	}()
-	go func() {
-		if err := dmsghttp.ServeDebug(ctx, snClient, log, deployment.Prod.SurveyWhitelist); err != nil {
-			log.WithError(err).Error("DMSG HTTP debug server stopped")
-		}
-	}()
-	log.Infof("DMSG HTTP health endpoint available at %s", dmsgAddr)
+	log.Infof("DMSG HTTP (health/stats/debug) available at %s", dmsgAddr)
 }
 
 // getHTTPClient returns an *http.Client for the given service URL,

--- a/pkg/svcmode/svcmode.go
+++ b/pkg/svcmode/svcmode.go
@@ -311,8 +311,19 @@ func Start(ctx context.Context, cfg Config) (*Handle, error) {
 
 		if cfg.Mode.IncludesDmsg() {
 			cfg.Log.Infof("svcmode: dmsghttp listener on port %d", cfg.DmsgPort)
+			handler := cfg.Handler
+			if len(cfg.SurveyWhitelist) > 0 {
+				// Fold pprof + /debug/log onto the main dmsg :80 (survey-gated)
+				// instead of a separate :81 listener. The ring buffer captures
+				// recent log output (the service uses the global logger via
+				// MustGetLogger) so /debug/log needs no disk file.
+				rb := logging.NewRingBuffer(0)
+				logging.AddHook(logging.NewWriteHook(rb))
+				handler = dmsghttp.WithDebug(cfg.Handler, cfg.SurveyWhitelist, rb.Bytes)
+				cfg.Log.Info("svcmode: debug (pprof + /debug/log) served on dmsg :80, survey-gated")
+			}
 			go func() {
-				if err := dmsghttp.ListenAndServe(ctx, cfg.SK, cfg.Handler,
+				if err := dmsghttp.ListenAndServe(ctx, cfg.SK, handler,
 					boot.DClient, cfg.DmsgPort, boot.Client, cfg.Log); err != nil && !errors.Is(err, context.Canceled) {
 					select {
 					case h.errCh <- fmt.Errorf("dmsghttp: %w", err):
@@ -320,14 +331,6 @@ func Start(ctx context.Context, cfg Config) (*Handle, error) {
 					}
 				}
 			}()
-
-			if len(cfg.SurveyWhitelist) > 0 {
-				go func() {
-					if err := dmsghttp.ServeDebug(ctx, boot.Client, cfg.Log, cfg.SurveyWhitelist); err != nil && !errors.Is(err, context.Canceled) {
-						cfg.Log.WithError(err).Warn("svcmode: ServeDebug exited with error")
-					}
-				}()
-			}
 		} else {
 			cfg.Log.Info("svcmode: dmsg client bootstrapped for outbound use (no dmsghttp listener; mode=http)")
 		}

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -216,9 +216,13 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 	// stray lines from libraries that don't follow the format don't sneak past
 	// a strict --min-level filter).
 	authRoute.GET("/visor.log", func(c *gin.Context) {
-		logFile := filepath.Join(localPath, "visor.log")
+		// The visor writes its rotating log to LocalPath/log/skywire.log
+		// (visor.go, via lumberjackrus). The endpoint previously looked at
+		// LocalPath/visor.log — wrong subdir AND filename — so it always 404'd
+		// even with file logging enabled.
+		logFile := filepath.Join(localPath, "log", "skywire.log")
 		if _, err := os.Stat(logFile); err != nil {
-			c.String(http.StatusNotFound, "visor.log not found (start visor with -s flag)")
+			c.String(http.StatusNotFound, "%s not found (is file logging enabled?)", logFile)
 			return
 		}
 		q := c.Request.URL.Query()


### PR DESCRIPTION
Unifies debug access across visors and deployment services, and fixes a visor log-endpoint path bug.

## Problem
- Deployment services (route setup node, TPD, route-finder, AR, SD, UT, dmsg-disc, dmsg-srv) served **pprof on a separate dmsg `:81`** (`ServeDebug`) and had **no log endpoint over dmsg** — their debug logs only existed on the service host's stdout. The **visor** already serves logs + pprof on `:80` via its logserver, so the two were inconsistent and you had to know `:81` for service pprof.
- The visor's **`/visor.log` was broken**: it opened `LocalPath/visor.log`, but the visor writes its rotating log to `LocalPath/log/skywire.log` (`visor.go` via lumberjackrus) — so it returned 404 even with file logging enabled.

## Change
- **`dmsghttp.WithDebug(next, whitelist, logSource)`** folds `/debug/pprof/*` + `/debug/log` onto the service's **main dmsg `:80`** handler, survey-whitelist-gated, delegating all other paths to the service handler. Retires the `:81` `ServeDebug` listener. `DebugMux` gains an optional `/debug/log`.
- **`logging.RingBuffer`** — a thread-safe, line-trimmed, bounded `io.Writer` fed by a logrus `WriteHook`, so `/debug/log` serves recent log output **in-memory, no disk file** (avoids the visor's disk-path coupling). Wired into `svcmode` (covers TPD/RF/AR/SD/UT), the setup node (`sn`), `dmsg-disc`, and `dmsg-srv`.
- **Fixed visor `/visor.log`** to read the real path (`LocalPath/log/skywire.log`).

## Result
Every deployment service now exposes **pprof *and* debug logging over dmsg on one port** via the survey-whitelist proxy — e.g. `http://<svc>.dmsg/debug/log` and `/debug/pprof/…`. Concretely this lets us watch the route setup node's live id-reservation failures behind its `/stats` counters while validating #3042.

## Tests
`TestRingBuffer_RetainsRecentAndBounds`, `TestWithDebug_RoutesAndGates` (routing + whitelist + logSource). Full builds green; `ServeDebug` kept (deprecated) for back-compat.

## Rollout
Deployed-service change (redeploys network-wide ~10 min). The visor `/visor.log` fix takes effect on visor update.