### PR TITLE
fix(router): data race on idReserver.rcM (ReserveIDs read vs redial write)

### DIFF
--- a/pkg/router/id_reserver.go
+++ b/pkg/router/id_reserver.go
@@ -150,7 +150,12 @@ func (idr *idReserver) ReserveIDs(ctx context.Context) error {
 
 	for pk, n := range idr.rec {
 		go func(pk cipher.PubKey, n uint8) {
+			// Read under idr.mx: a sibling goroutine's redial() writes rcM[pk]
+			// under the same lock, so an unlocked read here is a data race on
+			// the shared map (different keys still touch the map's internals).
+			idr.mx.Lock()
 			client := idr.rcM.Client(pk)
+			idr.mx.Unlock()
 			if client == nil {
 				// NOTE: deliberately do NOT cancel the shared ctx on a single
 				// hop's failure. cancel() here propagated to every sibling


### PR DESCRIPTION
#3042's `redial()` writes `idr.rcM[pk]` under `idr.mx`, but the per-hop goroutine in `ReserveIDs` read `idr.rcM.Client(pk)` **unlocked** — concurrent map access that `go test -race` flags in `TestIdReserver_ReserveIDs_RetriesStalePooledConn`. This is the real cause of the linux `make check` failure on every branch off develop (e.g. #3044), not those branches' changes. Fix: take `idr.mx` around the read. Verified with `go test -race -count=5` and the full `pkg/router` suite under `-race`.