### PR TITLE
feat(route-finder): expose per-hop measured latency in route responses

### DIFF
--- a/pkg/route-finder/store/finder.go
+++ b/pkg/route-finder/store/finder.go
@@ -258,9 +258,10 @@ func buildRoute(path []*vertex) (routing.Route, error) {
 			return routing.Route{}, errors.New("connection not found between vertices")
 		}
 		route.Hops = append(route.Hops, routing.Hop{
-			From: from.edge,
-			To:   to.edge,
-			TpID: conn.ID,
+			From:    from.edge,
+			To:      to.edge,
+			TpID:    conn.ID,
+			Latency: conn.Latency, // measured per-edge latency (ms); 0 if unmeasured
 		})
 	}
 	return route, nil

--- a/pkg/route-finder/store/graph_test.go
+++ b/pkg/route-finder/store/graph_test.go
@@ -198,6 +198,13 @@ func TestGetRouteWeighted(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, lat, 1)
 	require.Len(t, lat[0].Hops, 3)
+
+	// Each hop carries its measured per-edge latency (the exposed field), and
+	// Route.TotalLatency sums them — populated in both modes via buildRoute.
+	require.Equal(t, 400.0, hop[0].Hops[0].Latency)
+	require.Equal(t, 800.0, hop[0].TotalLatency())
+	require.Equal(t, 100.0, lat[0].Hops[0].Latency)
+	require.Equal(t, 300.0, lat[0].TotalLatency())
 }
 
 func TestNewGraph(t *testing.T) {

--- a/pkg/routing/route.go
+++ b/pkg/routing/route.go
@@ -29,6 +29,19 @@ type Route struct {
 	KeepAlive time.Duration   `json:"keep_alive"`
 }
 
+// TotalLatency returns the route's predicted one-way latency: the sum of its
+// hops' measured per-edge latencies (ms, populated by the route-finder). Hops
+// with no measurement contribute 0, so a route crossing unmeasured edges
+// reports a lower bound — callers that must penalize unmeasured edges should
+// inspect per-hop Hop.Latency directly.
+func (r Route) TotalLatency() float64 {
+	var total float64
+	for _, h := range r.Hops {
+		total += h.Latency
+	}
+	return total
+}
+
 func (r Route) String() string {
 	res := fmt.Sprintf("[KeepAlive: %s] %s\n", r.KeepAlive, r.Desc.String())
 	for _, hop := range r.Hops {
@@ -138,6 +151,12 @@ type Hop struct {
 	TpID uuid.UUID
 	From cipher.PubKey
 	To   cipher.PubKey
+	// Latency is this hop's measured transport latency in milliseconds, as
+	// recorded by the route-finder from per-edge TPD data (0/omitted when the
+	// edge has no measurement). It is informational — it lets callers rank or
+	// display routes by predicted latency without re-querying, and is NOT used
+	// in route-rule setup. Older route-finders simply omit it.
+	Latency float64 `json:"Latency,omitempty"`
 }
 
 // String implements fmt.Stringer


### PR DESCRIPTION
The finder already computes per-edge latency (sorts by it since #3041) but discarded it before returning. This surfaces it so clients can rank routes/servers by predicted latency from a single `FindRoutes` call — the cheap seed-ranking pass, reserving `mux-bw` measurement for the top few.

**Change:** `omitempty` `Latency` field on `routing.Hop`, populated in `buildRoute` (the single construction point → every finder path gets it: `GetRoute`, `GetRouteWeighted`, the `/routes` API, CLI calc via rfclient), plus `Route.TotalLatency()`.

**Backward-compatible both ways:** response shape (`map[PathEdges][][]Hop`) unchanged — no wrapper; old clients ignore the extra field; an old finder omits it (new clients see 0). The cascade/setup path rebuilds hops with only From/To/TpID, so signed payloads are unaffected. Verified with the full `pkg/router` + `pkg/rfclient` suites and a finder unit test (per-hop latency + TotalLatency in both modes).