### PR TITLE
fix(cxo): publisher heap leak — phantom cache entries serving >1MiB objects to subscribers

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -1178,13 +1178,27 @@ func (c *Cache) Want(
 
 	sendWanted(gc, Object{key, val, int(urc) - inc, nil})
 
-	// create filling item in the cache
+	// Create the filling item, but publish it into c.is only if
+	// putFillingItem actually caches the value. putFillingItem declines values
+	// larger than CacheMaxItemSize, stale (rc==0) values, and everything while
+	// the cache is disabled — in each case it leaves it.val unset and touches
+	// neither amount nor volume. The original code inserted the item into c.is
+	// *before* that call, so a declined value left a phantom val-empty
+	// "filling" entry in the map: reported by CachedKeys forever (so
+	// RemoveObjects skips the underlying rc==0 CXDS object) yet never fillable
+	// or evictable. That phantom — one per >1 MiB snapshot leaf served to a
+	// subscriber after its Root was superseded — is the TPD-publisher heap leak
+	// under attached subscribers (~80 MB/min, OOM in hours).
 
 	it = new(item)
 	it.fc = inc
-	c.is[key] = it
 
-	err = c.putFillingItem(val, int(urc), it)
+	if err = c.putFillingItem(val, int(urc), it); err != nil {
+		return err
+	}
+	if len(it.val) != 0 { // putFillingItem cached the value
+		c.is[key] = it
+	}
 	return err
 }
 

--- a/pkg/cxo/treestore/leak_subscriber_repro_test.go
+++ b/pkg/cxo/treestore/leak_subscriber_repro_test.go
@@ -1,0 +1,74 @@
+package treestore
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestPublisherCleanupBoundedWithSubscriber reproduces the production TPD
+// leak: a publisher re-publishing a large changing value to a FIXED path
+// (the all-transports / metrics / uptime snapshot pattern) while a real
+// subscriber is connected and syncing.
+//
+// TestPublisherAsyncCleanupBounded covers the same publish pattern with NO
+// subscriber and stays bounded. Production has 179 subscribers, and the heap
+// shows the CXDS growing ~80 MB/min — so the subscriber path is the trigger.
+// This asserts the publisher's CXDS stays bounded with a subscriber attached.
+func TestPublisherCleanupBoundedWithSubscriber(t *testing.T) {
+	pkA, skA := cipher.GenerateKeyPair()
+
+	pub, err := NewWithTCP("127.0.0.1:0", skA, PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 5 * time.Millisecond,
+	})
+	require.NoError(t, err, "NewWithTCP publisher")
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+
+	addr := pub.Node().TCP().Address()
+	require.NotEmpty(t, addr)
+
+	sub, err := NewSubscriberTCP("", pkA, SubConfig{InMemoryDB: true})
+	require.NoError(t, err, "NewSubscriberTCP")
+	t.Cleanup(func() { _ = sub.Close() }) //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, sub.ConnectTCP(ctx, addr), "ConnectTCP")
+
+	mkRandom := func(size int) []byte {
+		b := make([]byte, size)
+		_, _ = rand.Read(b)
+		return b
+	}
+
+	// all-transports pattern: one fixed path, a fresh large value every tick.
+	for i := 0; i < 40; i++ {
+		require.NoError(t, pub.Put("all-transports", mkRandom(2*1024*1024)))
+		require.NoError(t, pub.Flush())
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	cxds := pub.cxoNode.Container().DB().CXDS()
+	all, _ := cxds.Amount()
+	vol, _ := cxds.Volume()
+	rcHist := map[uint32]int{}
+	if err := cxds.Iterate(func(_ skycipher.SHA256, rc uint32, _ []byte) error { rcHist[rc]++; return nil }); err != nil {
+		t.Fatalf("Iterate: %v", err)
+	}
+	t.Logf("After 40 ticks with subscriber: amount=%d volume=%d rcHist=%v", all, vol, rcHist)
+
+	// One ~2 MB leaf + a handful of small structural objects per kept Root.
+	// keepLast=1 means ~4 MB steady state. 40 ticks × 2 MB = 80 MB if the
+	// per-Root cleanup is fully defeated; anything past 16 MB is the leak.
+	if vol > 16*1024*1024 {
+		t.Errorf("CXDS volume %d > 16 MB — leak with a subscriber connected (per-Root retention should be ~4 MB)", vol)
+	}
+}


### PR DESCRIPTION
**TPD OOM-crash-loop.** The CXO publishers (all-transports/metrics/uptime, InMemoryDB) leaked **~80 MB/min** under attached subscribers — OOMing the 7.7 GiB container in ~1.3 h. pprof: 80% of heap in `treestore.encodeNode → Refs.AppendValues → encoder.Serialize`, growing. A **single** connected subscriber reproduces it (CXDS 84 MB after 40 ticks vs ~4 MB; `rcHist map[0:39 1:5]`).

**Root cause:** serving a subscriber's `RqObject` for an object whose Root was superseded loads the value and `Want`s it into the cache. `Cache.Want`'s not-in-cache→found path inserted the item into `c.is` **before** `putFillingItem`, which **declines values > `CacheMaxItemSize` (1 MiB)** — and the snapshot leaves are >1 MiB. The declined call left `it.val` unset, so a **phantom val-empty "filling" entry** lingered in `c.is`: reported by `CachedKeys()` forever (so `RemoveObjects`, which skips cached keys, never reclaimed the rc=0 object) yet never fillable or evictable.

**Fix** (`pkg/cxo/skyobject/cache.go`, +17/−3): publish into `c.is` only when `putFillingItem` actually cached the value (`len(it.val) != 0`).

**Verified:** new `TestPublisherCleanupBoundedWithSubscriber` (84 MB→2.1 MB, `map[0:39 1:5]`→`map[1:5]`); existing `Sync/AsyncCleanupBounded` pass; full `pkg/cxo/...` green; `-race` clean.

Deeper follow-up: CXO's three retention mechanisms (CXDS rc / cache cc / LRU) lack a single reachability-based GC — tracked separately.