### PR TITLE
fix(cli): CXO/DMSG-first fetch — lazy-acquire sd-services, STUN-based `visor ip`, drop HTTP fallback

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -701,17 +701,16 @@ func getCLICacheIfEnabled(cachefile string) *clicache.Cache {
 	return cliCache
 }
 
-// FetchServiceURL fetches a URL from a deployment service using a three-step chain:
+// FetchServiceURL fetches a URL from a deployment service using a CXO/DMSG-first
+// chain:
+//  0. CXO — read the visor's local subscriber-cache snapshot (no round-trip)
 //  1. RPC — ask the running visor to proxy the request over DMSG (DmsgHTTP RPC)
-//  2. DMSG direct — create ephemeral DMSG client and fetch directly
-//  3. HTTP — direct HTTP request as last resort
+//  2. DMSG direct — ephemeral DMSG client (only when --no-rpc)
+//  3. HTTP — direct HTTP, ONLY for services with no DMSG equivalent (e.g.
+//     ip.skycoin.com). The dmsg-mapped deployment services get NO HTTP
+//     fallback — the deprecated plain-HTTP hop is gone for them.
 //
-// Steps can be disabled via --no-rpc, --no-dmsg, and --no-http flags.
-//
-// This pattern ensures CLI commands work for:
-//   - Visors running with DMSG (step 1)
-//   - Standalone CLI without a running visor on DMSG network (step 2)
-//   - Environments without DMSG connectivity (step 3)
+// Steps can be disabled via --no-cxo, --no-rpc, --no-dmsg, and --no-http flags.
 func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 	var lastErr error
 
@@ -798,8 +797,15 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 		}
 	}
 
-	// Step 3: Direct HTTP fallback
-	if !NoHTTP {
+	// Step 3: Direct HTTP — last resort, ONLY for services with no DMSG path.
+	// The dmsg-mapped deployment services (sd/tpd/ar/rf/ut/dmsgd) are reachable
+	// over CXO + DMSG and intentionally get NO HTTP fallback: a plain-HTTP hop
+	// through their HTTP edge is the path being deprecated, so a dmsg-mapped
+	// service that fails CXO+DMSG now errors here rather than silently dropping
+	// to clearnet. HTTP survives only for HTTP-only services with no dmsg
+	// equivalent — currently just ip.skycoin.com (the public-IP echo the
+	// proxy/VPN exit-IP check uses; cli visor ip no longer needs it).
+	if !NoHTTP && DmsgURLForHTTP(url) == "" && !isDmsgURL(url) {
 		httpClient := &http.Client{Timeout: 30 * time.Second}
 		resp, err := httpClient.Get(url) //nolint:gosec
 		if err != nil {

--- a/cmd/skywire-cli/commands/visor/ip.go
+++ b/cmd/skywire-cli/commands/visor/ip.go
@@ -1,25 +1,19 @@
-// Package clivisor cmd/skywire-cli/commands/visor/info.go
+// Package clivisor cmd/skywire-cli/commands/visor/ip.go
 package clivisor
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
-	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
-	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport/network"
 )
 
-var geoipURL string
-
 func init() {
-	RootCmd.Flags().StringVar(&geoipURL, "geoip", deployment.Prod.GeoIP, "url of geoip service")
 	RootCmd.AddCommand(ipCmd)
 }
 
@@ -32,57 +26,20 @@ var ipCmd = &cobra.Command{
 		mLog.SetLevel(logrus.PanicLevel)
 		logger := mLog.PackageLogger("visor_ip_information")
 
-		ip, err := getIPAddress(cmd.Flags(), geoipURL)
-		if err != nil {
-			internal.Catch(cmd.Flags(), err)
+		// Discover the public IP + NAT type in a single STUN round, using the
+		// embedded STUN-server list. No HTTP hop through ip.skycoin.com (the
+		// public-IP echo) or conf.skywire.skycoin.com (the STUN-server list):
+		// STUN's mapped address IS the public IP, so the geoip echo was always
+		// redundant with the NAT check this command already runs, and the STUN
+		// servers ship in the binary. (Geolocation of that IP is a separate,
+		// trivial follow-up; ip.skycoin.com stays up for the proxy/VPN exit-IP
+		// check, but the CLI no longer depends on it.)
+		sc := network.GetStunDetails(skyenv.GetStunServers(), logger)
+		var ip string
+		if sc.PublicIP != nil {
+			ip = sc.PublicIP.IP()
 		}
-		isPublic := isPublic(cmd.Flags(), logger)
-		internal.PrintOutput(cmd.Flags(), ip, fmt.Sprintf("IP: %s\nPublic Status: %s\n", ip, isPublic))
+		internal.PrintOutput(cmd.Flags(), ip,
+			fmt.Sprintf("IP: %s\nPublic Status: %s\n", ip, sc.NATType.String()))
 	},
-}
-
-func getIPAddress(cmdFlags *pflag.FlagSet, geoipURL string) (string, error) {
-	var info ipInfo
-
-	body, err := clirpc.FetchServiceURL(cmdFlags, geoipURL)
-	if err != nil {
-		return info.IP, err
-	}
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return info.IP, err
-	}
-	return info.IP, err
-}
-
-type ipInfo struct {
-	IP string `json:"ip_address"`
-}
-
-func isPublic(cmdFlags *pflag.FlagSet, logger *logging.Logger) string {
-	stunServers, err := getStunServers(cmdFlags)
-	if err != nil {
-		return err.Error()
-	}
-	sc := network.GetStunDetails(stunServers, logger)
-	return sc.NATType.String()
-}
-
-func getStunServers(cmdFlags *pflag.FlagSet) ([]string, error) {
-	var info stunInfo
-
-	confURL := deployment.ProdConf.Conf
-	body, err := clirpc.FetchServiceURL(cmdFlags, confURL+"/")
-	if err != nil {
-		return info.Stun, err
-	}
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return info.Stun, err
-	}
-	return info.Stun, err
-}
-
-type stunInfo struct {
-	Stun []string `json:"stun_servers"`
 }

--- a/pkg/visor/api_fetch_cxo.go
+++ b/pkg/visor/api_fetch_cxo.go
@@ -67,6 +67,18 @@ func (v *Visor) FetchCXO(args FetchCXOArgs) (*FetchCXOResult, error) {
 		if serviceType == "" {
 			return &FetchCXOResult{Reason: "sd-services: missing service type"}, nil
 		}
+		// Lazily hold FeedSDServices so the on-demand sync runs, mirroring
+		// tpd-metrics / tpd-uptime / all-transports (each AcquireFor's its tab
+		// in its fetch helper). Without this, servicesFromCXO only ever reads a
+		// snapshot some OTHER consumer (autoconnect, hvui) happened to warm — so
+		// on a visor with no such consumer, `cli tp -m` / `proxy list` /
+		// `vpn list` miss FeedSDServices forever. AcquireFor starts the cycle
+		// (the first probe still misses while it syncs); the close-grace window
+		// keeps it warm so the next probe hits.
+		if mgr := v.CXOSubMgr(); mgr != nil {
+			mgr.AcquireFor(TabCLIServices)
+			defer mgr.ReleaseFor(TabCLIServices)
+		}
 		services, ok := v.servicesFromCXO(serviceType, "", "")
 		if !ok {
 			return &FetchCXOResult{Reason: "sd-services: cache miss"}, nil


### PR DESCRIPTION
Stops the CLI leaning on the being-deprecated plain-HTTP edge of the deployment services. Three related changes:

1. **sd-services CXO lazy-acquire** (`api_fetch_cxo.go`): the `FetchCXO` sd-services case only walked an existing `FeedSDServices` snapshot — unlike tpd-metrics/uptime/all-transports, which `AcquireFor` their tab to trigger the on-demand sync. So `cli tp -m` / `proxy list` / `vpn list` missed `FeedSDServices` forever on any visor with no other warm consumer (the `CXO miss … sd-services: cache miss` debug spam) and always fell back to HTTP. Now it `AcquireFor(TabCLIServices)` like the others.

2. **`cli visor ip` via STUN** (`ip.go`): dropped its two HTTP fetches (ip.skycoin.com public-IP echo + conf.skywire.skycoin.com STUN-server list). It already runs a STUN NAT check, and STUN's mapped address IS the public IP — so one STUN round (embedded server list) gives both. Verified live: `IP: 70.121.13.123 / Port restricted NAT`.

3. **HTTP fallback gated to no-DMSG services** (`root.go`): dmsg-mapped deployment services (sd/tpd/ar/rf/ut/dmsgd) get NO HTTP fallback — CXO+DMSG only; failing both errors rather than dropping to clearnet. HTTP survives only for HTTP-only services (ip.skycoin.com, the proxy/VPN exit-IP echo).

Build / gofmt / lint clean.