### PR TITLE
perf(pty): web-terminal flush-on-write + pooled Exec sessions

### DIFF
--- a/pkg/pty/exec_pool.go
+++ b/pkg/pty/exec_pool.go
@@ -1,0 +1,125 @@
+// Package pty pkg/pty/exec_pool.go
+//
+// Session reuse for one-shot remote Exec. Establishing a dmsgpty session
+// (dial + noise + the RPC writeRequest/readResponse handshake + the
+// remote's proxy dial) costs ~10-15s and was paid fresh on EVERY
+// `cli pty exec`. The remote Exec gateway is STATELESS — each Exec spawns
+// its own os/exec.Cmd and touches no gateway state (see exec_gateway.go) —
+// so one established session can serve unlimited sequential Exec calls.
+// This pool caches one session per (remote PK, port, dialer) so only the
+// first exec to a peer pays setup; the rest are an RPC round-trip.
+//
+// Correctness over a flaky overlay: a failed Exec (an RPC/connection
+// error, distinct from a non-zero command exit which returns err==nil)
+// retires the session, so the caller's next exec re-dials. A dead pooled
+// conn is never silently reused — the trap that bit the RSN pool (a TTL
+// outliving the underlying conn → handing out shut-down connections).
+package pty
+
+import (
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// execSessionTTL bounds how long an idle pooled session is kept before it's
+// closed. Short enough that a remote restart / transport drop doesn't leave
+// many dead streams pooled; the stale-on-Exec eviction is the correctness
+// backstop regardless of this value.
+const execSessionTTL = 90 * time.Second
+
+// execSession is the slice of *PtyClient the pool needs. An interface so the
+// pool is unit-testable without a live dmsg stream + RPC handshake.
+type execSession interface {
+	Exec(req *CommandExecReq) (*CommandExecResult, error)
+	Close() error
+}
+
+// execKey identifies a pooled session. The dialer identity is part of the
+// key so the same peer reached via dmsg vs skynet doesn't alias to one
+// session (different underlying transport, different latency).
+type execKey struct {
+	pk     cipher.PubKey
+	port   uint16
+	dialer string
+}
+
+type pooledExec struct {
+	sess     execSession
+	refs     int
+	lastUsed time.Time
+	dead     bool
+}
+
+// acquireExec returns a live pooled session for key with refs incremented,
+// or nil if none is usable (absent / retired / idle past TTL). On a non-nil
+// return the caller MUST call releaseExec exactly once.
+func (h *Host) acquireExec(key execKey) *pooledExec {
+	h.execMu.Lock()
+	defer h.execMu.Unlock()
+	pe := h.execPool[key]
+	if pe == nil || pe.dead {
+		return nil
+	}
+	if pe.refs == 0 && time.Since(pe.lastUsed) > execSessionTTL {
+		h.retireLocked(key, pe) // idle too long → force a fresh dial
+		return nil
+	}
+	pe.refs++
+	pe.lastUsed = time.Now()
+	return pe
+}
+
+// releaseExec returns a session after an Exec. A non-nil execErr means the
+// RPC/connection failed (NOT a non-zero command exit, which comes back with
+// err==nil) — the session is retired so no one reuses a dead conn.
+func (h *Host) releaseExec(key execKey, pe *pooledExec, execErr error) {
+	h.execMu.Lock()
+	defer h.execMu.Unlock()
+	pe.refs--
+	pe.lastUsed = time.Now()
+	if execErr != nil && !pe.dead {
+		h.retireLocked(key, pe)
+		return
+	}
+	// A concurrent Exec may have retired it while we were in flight; close
+	// once we're the last one out.
+	if pe.dead && pe.refs == 0 {
+		_ = pe.sess.Close() //nolint:errcheck
+	}
+}
+
+// retireLocked unmaps pe and closes it if no Exec is in flight; if one still
+// is (refs>0), it's marked dead so no new caller reuses it and the last
+// releaseExec closes it. Caller holds execMu.
+func (h *Host) retireLocked(key execKey, pe *pooledExec) {
+	pe.dead = true
+	if h.execPool[key] == pe {
+		delete(h.execPool, key)
+	}
+	if pe.refs == 0 {
+		_ = pe.sess.Close() //nolint:errcheck
+	}
+}
+
+// cacheExec stores a freshly-dialed live session for reuse and
+// opportunistically retires idle ones (bounds the pool by recently-active
+// peers without a background goroutine). First-writer wins if another
+// goroutine cached the same key concurrently.
+func (h *Host) cacheExec(key execKey, sess execSession) {
+	h.execMu.Lock()
+	defer h.execMu.Unlock()
+	for k, pe := range h.execPool {
+		if pe.refs == 0 && time.Since(pe.lastUsed) > execSessionTTL {
+			h.retireLocked(k, pe)
+		}
+	}
+	if existing := h.execPool[key]; existing != nil && !existing.dead {
+		_ = sess.Close() //nolint:errcheck // lost the race; don't leak ours
+		return
+	}
+	if h.execPool == nil {
+		h.execPool = make(map[execKey]*pooledExec)
+	}
+	h.execPool[key] = &pooledExec{sess: sess, lastUsed: time.Now()}
+}

--- a/pkg/pty/exec_pool_test.go
+++ b/pkg/pty/exec_pool_test.go
@@ -1,0 +1,127 @@
+// Package pty pkg/pty/exec_pool_test.go
+package pty
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// fakeExecSession is a stand-in for *PtyClient that counts Exec/Close calls
+// and can be told to fail Exec (simulating a dead conn).
+type fakeExecSession struct {
+	execN  int
+	failAt int // fail Exec at/after this call number; 0 = never
+	closed int
+}
+
+func (f *fakeExecSession) Exec(*CommandExecReq) (*CommandExecResult, error) {
+	f.execN++
+	if f.failAt != 0 && f.execN >= f.failAt {
+		return nil, errors.New("rpc: connection is shut down")
+	}
+	return &CommandExecResult{ExitCode: 0}, nil
+}
+
+func (f *fakeExecSession) Close() error { f.closed++; return nil }
+
+func testKey() execKey {
+	var pk cipher.PubKey
+	return execKey{pk: pk, port: 22, dialer: "test"}
+}
+
+// A pooled session is reused across many acquires and never closed while live.
+func TestExecPool_Reuse(t *testing.T) {
+	h := &Host{}
+	k := testKey()
+	s := &fakeExecSession{}
+	h.cacheExec(k, s)
+
+	for i := 0; i < 3; i++ {
+		pe := h.acquireExec(k)
+		if pe == nil {
+			t.Fatalf("acquire %d: expected pooled session, got nil", i)
+		}
+		if pe.sess != s {
+			t.Fatalf("acquire %d: got a different session", i)
+		}
+		_, err := pe.sess.Exec(nil)
+		h.releaseExec(k, pe, err)
+	}
+	if s.closed != 0 {
+		t.Fatalf("live session closed %d times; want 0 (still pooled)", s.closed)
+	}
+}
+
+// A failed Exec retires the session: next acquire misses, and it's closed once.
+func TestExecPool_StaleEviction(t *testing.T) {
+	h := &Host{}
+	k := testKey()
+	s := &fakeExecSession{failAt: 1}
+	h.cacheExec(k, s)
+
+	pe := h.acquireExec(k)
+	if pe == nil {
+		t.Fatal("acquire: expected session")
+	}
+	_, err := pe.sess.Exec(nil)
+	if err == nil {
+		t.Fatal("expected an Exec error from the fake")
+	}
+	h.releaseExec(k, pe, err)
+
+	if got := h.acquireExec(k); got != nil {
+		t.Fatal("acquire after stale: expected nil (evicted)")
+	}
+	if s.closed != 1 {
+		t.Fatalf("stale session closed %d times; want exactly 1", s.closed)
+	}
+}
+
+// An idle session past TTL is retired (and closed) on the next acquire.
+func TestExecPool_IdleTTL(t *testing.T) {
+	h := &Host{}
+	k := testKey()
+	s := &fakeExecSession{}
+	h.cacheExec(k, s)
+
+	h.execMu.Lock()
+	h.execPool[k].lastUsed = time.Now().Add(-2 * execSessionTTL)
+	h.execMu.Unlock()
+
+	if got := h.acquireExec(k); got != nil {
+		t.Fatal("acquire idle-expired: expected nil")
+	}
+	if s.closed != 1 {
+		t.Fatalf("idle session closed %d times; want exactly 1", s.closed)
+	}
+}
+
+// A session retired while a second Exec is in flight is closed exactly once,
+// by the last releaseExec — never early (which would break the in-flight call).
+func TestExecPool_ConcurrentReleaseClosesOnce(t *testing.T) {
+	h := &Host{}
+	k := testKey()
+	s := &fakeExecSession{}
+	h.cacheExec(k, s)
+
+	pe1 := h.acquireExec(k)
+	pe2 := h.acquireExec(k) // refs == 2, same instance
+	if pe1 == nil || pe2 == nil || pe1 != pe2 {
+		t.Fatal("expected the same pooled session acquired twice")
+	}
+
+	h.releaseExec(k, pe1, errors.New("broken")) // retires, but pe2 still in flight
+	if s.closed != 0 {
+		t.Fatalf("closed early while refs>0: closed=%d", s.closed)
+	}
+	h.releaseExec(k, pe2, nil) // last one out → close
+	if s.closed != 1 {
+		t.Fatalf("want exactly 1 close after last release, got %d", s.closed)
+	}
+	if got := h.acquireExec(k); got != nil {
+		t.Fatal("retired session should not be re-acquirable")
+	}
+}

--- a/pkg/pty/host.go
+++ b/pkg/pty/host.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/rpc"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -33,6 +34,15 @@ type Host struct {
 
 	cliN  int32
 	connN int32
+
+	// execPool caches established one-shot Exec sessions keyed by
+	// (remote PK, port, dialer) so repeated `cli pty exec` to the same
+	// peer skip the dial + handshake (the ~10-15s/exec cost). See
+	// exec_pool.go — the remote Exec gateway is stateless, so reuse is
+	// safe, and a failed Exec retires the session so a dead conn never
+	// wedges.
+	execMu   sync.Mutex
+	execPool map[execKey]*pooledExec
 }
 
 // NewHost creates a new pty.Host with a given dmsg.Client and
@@ -84,19 +94,40 @@ func (h *Host) ExecRemoteVia(ctx context.Context, dialer StreamDialer, rPK ciphe
 	if rPort == 0 {
 		rPort = DefaultPort
 	}
+	key := execKey{pk: rPK, port: rPort, dialer: fmt.Sprintf("%T", dialer)}
+
+	// Fast path: reuse a pooled session, skipping the dial + handshake (the
+	// dominant ~10-15s/exec). Safe because the remote Exec gateway is
+	// stateless (exec_gateway.go). On an RPC/connection error — NOT a
+	// non-zero command exit, which returns err==nil with the code in resp —
+	// releaseExec retires the dead session; we return the error rather than
+	// silently re-dialing + re-running (the command may already have run, so
+	// auto-retry isn't at-most-once safe). The caller's retry then re-dials
+	// because the stale session is gone.
+	if pe := h.acquireExec(key); pe != nil {
+		resp, err := pe.sess.Exec(req)
+		h.releaseExec(key, pe, err)
+		return resp, err
+	}
+
+	// Cold path: no pooled session — dial + handshake, run, then pool the
+	// live session instead of tearing it down.
 	stream, err := dialer.DialStream(ctx, rPK, rPort)
 	if err != nil {
 		return nil, fmt.Errorf("dmsgpty: dial %s:%d: %w", rPK, rPort, err)
 	}
-	defer stream.Close() //nolint:errcheck
-
 	ptyC, err := NewPtyClient(stream)
 	if err != nil {
+		_ = stream.Close() //nolint:errcheck
 		return nil, fmt.Errorf("dmsgpty: new pty client: %w", err)
 	}
-	defer ptyC.Close() //nolint:errcheck
-
-	return ptyC.Exec(req)
+	resp, err := ptyC.Exec(req)
+	if err != nil {
+		_ = ptyC.Close() //nolint:errcheck // closes the underlying stream too
+		return nil, err
+	}
+	h.cacheExec(key, ptyC)
+	return resp, nil
 }
 
 // ServeCLI listens for CLI connections via the provided listener.

--- a/pkg/pty/pty_client.go
+++ b/pkg/pty/pty_client.go
@@ -91,6 +91,23 @@ func (sc *PtyClient) Write(b []byte) (int, error) {
 	return n, processRPCError(err)
 }
 
+// WriteAsync writes to the pty WITHOUT waiting for the RPC reply, so an
+// interactive caller (the web terminal's input loop) isn't blocked a full
+// round-trip per keystroke. Ordering is preserved — net/rpc serializes
+// request sends, and the send encodes b before returning, so the caller may
+// reuse the buffer. The per-write result and error are intentionally dropped:
+// a broken conn surfaces on the Read path, which tears the session down.
+// Returns an error only if the client is already closed.
+func (sc *PtyClient) WriteAsync(b []byte) error {
+	select {
+	case <-sc.done:
+		return io.ErrClosedPipe
+	default:
+	}
+	sc.rpcC.Go(sc.rpcMethod("Write"), &b, new(int), nil)
+	return nil
+}
+
 func (*PtyClient) rpcMethod(m string) string {
 	return PtyRPCName + "." + m
 }

--- a/pkg/pty/ui.go
+++ b/pkg/pty/ui.go
@@ -3,6 +3,7 @@ package pty
 
 import (
 	"bytes"
+	"context"
 	stdjson "encoding/json"
 	"fmt"
 	"io"
@@ -174,13 +175,29 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 			return
 		}
 
-		// websocket keep alive
+		// Keepalive: send a websocket PING every 10s. The browser's ws library
+		// auto-pongs, so this keeps BOTH directions warm (NAT/proxies silently
+		// drop idle conns) AND detects a dead peer — Ping errors when no pong
+		// returns, so we close the session cleanly instead of leaving a
+		// half-open conn that surfaces later as an "inexplicable" error. The
+		// old null-byte DATA frame only warmed server->browser and couldn't
+		// notice a dead browser.
 		go func() {
+			t := time.NewTicker(10 * time.Second)
+			defer t.Stop()
 			for {
-				if _, err := wsConn.Write([]byte("\x00")); err != nil {
+				select {
+				case <-r.Context().Done():
 					return
+				case <-t.C:
+					pctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+					err := ws.Ping(pctx)
+					cancel()
+					if err != nil {
+						_ = ws.Close(websocket.StatusGoingAway, "keepalive ping failed") //nolint:errcheck
+						return
+					}
 				}
-				time.Sleep(10 * time.Second)
 			}
 		}()
 
@@ -212,8 +229,24 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 			closeDone()
 		}()
 		go func() {
-			_, _ = io.Copy(ptyC, wsReader) //nolint:errcheck
-			closeDone()
+			defer closeDone()
+			// Pipeline keystrokes: fire each write without blocking a full RPC
+			// round-trip per keystroke (the old io.Copy used the synchronous
+			// Write, so fast typing / paste queued behind per-key acks). Order
+			// is preserved; a broken conn surfaces on the output path above and
+			// closes the session.
+			buf := make([]byte, 4096)
+			for {
+				n, rerr := wsReader.Read(buf)
+				if n > 0 {
+					if werr := ptyC.WriteAsync(buf[:n]); werr != nil {
+						return
+					}
+				}
+				if rerr != nil {
+					return
+				}
+			}
 		}()
 		<-done
 	}

--- a/pkg/pty/ui.go
+++ b/pkg/pty/ui.go
@@ -384,6 +384,7 @@ type bufferedWSWriter struct {
 	closed   bool
 	interval time.Duration
 	done     chan struct{}
+	wake     chan struct{}
 }
 
 func newBufferedWSWriter(conn net.Conn, flushInterval time.Duration) *bufferedWSWriter {
@@ -392,6 +393,7 @@ func newBufferedWSWriter(conn net.Conn, flushInterval time.Duration) *bufferedWS
 		buf:      make([]byte, 0, 4096),
 		interval: flushInterval,
 		done:     make(chan struct{}),
+		wake:     make(chan struct{}, 1),
 	}
 	go bw.flushLoop()
 	return bw
@@ -399,21 +401,46 @@ func newBufferedWSWriter(conn net.Conn, flushInterval time.Duration) *bufferedWS
 
 func (bw *bufferedWSWriter) Write(p []byte) (int, error) {
 	bw.mu.Lock()
-	defer bw.mu.Unlock()
 	if bw.closed {
+		bw.mu.Unlock()
 		return 0, io.ErrClosedPipe
 	}
+	wasEmpty := len(bw.buf) == 0
 	bw.buf = append(bw.buf, p...)
+	bw.mu.Unlock()
+	// Nudge the flusher on an idle->first-write so interactive echo (the PTY
+	// echoing each keystroke) flushes promptly instead of waiting out a fixed
+	// tick. Non-blocking: the data is already buffered; this is only a signal.
+	if wasEmpty {
+		select {
+		case bw.wake <- struct{}{}:
+		default:
+		}
+	}
 	return len(p), nil
 }
 
+// flushLoop coalesces output bursts — it never writes more than once per
+// interval, but flushes an idle->first-write immediately. The old fixed ticker
+// added up to `interval` of latency to EVERY keystroke's echo; waking on write
+// makes interactive echo prompt while still batching high-frequency bulk output.
 func (bw *bufferedWSWriter) flushLoop() {
-	ticker := time.NewTicker(bw.interval)
-	defer ticker.Stop()
+	var lastFlush time.Time
 	for {
 		select {
-		case <-ticker.C:
+		case <-bw.wake:
+			if wait := bw.interval - time.Since(lastFlush); wait > 0 {
+				t := time.NewTimer(wait)
+				select {
+				case <-t.C:
+				case <-bw.done:
+					t.Stop()
+					bw.flush() // Final flush
+					return
+				}
+			}
 			bw.flush()
+			lastFlush = time.Now()
 		case <-bw.done:
 			bw.flush() // Final flush
 			return


### PR DESCRIPTION
Two independent dmsgpty performance fixes from a measured investigation. The map: route setup is cheap (~1-4s; ~5ms over a direct transport, no setup-node), so the cost is elsewhere — the **per-exec session handshake** on the CLI side, and the **per-keystroke echo round-trip + a fixed output-buffer tick** on the UI side.

## 1. Web terminal: flush on write, not a fixed tick
The hypervisor UI terminal buffered PTY output and flushed on a fixed **16ms ticker**, so every keystroke's echo waited up to a full tick before reaching the browser. The flusher now wakes on an idle→first-write and flushes immediately, while still coalescing high-frequency bulk output to ≤1 flush/interval. Removes the fixed-tick tax from interactive echo.

## 2. CLI: pool dmsgpty Exec sessions
`cli pty exec` paid the full session handshake (dial + noise + RPC handshake + the remote's proxy dial, **~10-15s**) on *every* call — no reuse. The remote Exec gateway is **stateless** (each Exec spawns its own `os/exec.Cmd`, touches no gateway state), so one session serves unlimited sequential execs. `Host.ExecRemoteVia` now pools a session per `(remote PK, port, dialer)`: the first exec to a peer pays setup, the rest are an RPC round-trip.

Robustness: a failed Exec (an RPC/connection error — *not* a non-zero command exit, which returns `err==nil` with the code in the result) retires the session so the caller re-dials. A dead pooled conn is never silently reused — the trap that bit the RSN pool (a TTL outliving the conn). Idle sessions are retired after a 90s TTL. Unit-tested (`-race` clean): reuse, stale eviction, idle TTL, and close-exactly-once under a concurrent in-flight Exec.

Build + full `pkg/pty` suite + lint green. Live-visor validation (the exec speedup shows over repeated execs to one peer) pending — will roll onto the local visor once an in-flight remote op settles.