### PR TITLE
docs(site): PTY + Skychat guides on the published docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,14 +35,14 @@ extend, or understand a Skywire deployment.
 
 !!! note "Per-app and per-service docs"
 
-    Deep documentation for visor-hosted apps (skychat, skysocks, skynet, vpn)
-    and for the deployment services (transport-discovery, route-finder,
-    service-discovery, address-resolver, uptime-tracker) currently lives
-    alongside the source under
+    **[PTY](pty/README.md)** and **[Skychat](skychat/README.md)** now have
+    full guides in the **Apps** section above. The remaining visor-hosted
+    apps (skysocks, skynet, vpn) and the deployment services
+    (transport-discovery, route-finder, service-discovery, address-resolver,
+    uptime-tracker) still live alongside the source under
     [`cmd/apps/`](https://github.com/skycoin/skywire/tree/develop/cmd/apps)
-    and [`cmd/svc/`](https://github.com/skycoin/skywire/tree/develop/cmd/svc).
-    They'll be integrated into this site in a follow-up once their
-    cmd/-relative links are rewritten to live under `docs/`.
+    and [`cmd/svc/`](https://github.com/skycoin/skywire/tree/develop/cmd/svc),
+    and will be integrated here in a follow-up.
 
 ## Other resources
 

--- a/docs/pty/README.md
+++ b/docs/pty/README.md
@@ -1,0 +1,116 @@
+# Skywire PTY
+
+A **pty** (pseudoterminal) gives you an interactive remote shell, one-shot
+command execution, and a remote filesystem mount on another skywire
+node — addressed by **public key**, secured by a **noise-XK** handshake.
+No SSH is involved; the `host` / `shell` / `fs` names parallel
+`sshd` / `ssh` / `sshfs` only by analogy.
+
+This is one subsystem reachable through **two command structures that are
+converging**:
+
+- **`skywire cli pty …`** — the operator/client surface, and the *only*
+  way to drive the **visor-hosted** pty.
+- **`skywire app pty …`** — the pty as a native app: the **standalone
+  servers** plus the browser (`http`) and `exec` clients.
+
+A third tree, **`skywire dmsg pty …`**, is the *same commands* as
+`app pty`, kept mounted but **hidden** in the default build. It exists so
+the dmsg command-structure can be compiled as its **own standalone
+binary** (a pure `dmsgpty` with no visor/skywire deps). In the main
+`skywire` binary it's hidden to funnel operators to `app pty` — see
+[Redundant / equivalent commands](#redundant--equivalent-commands).
+
+## The three modes
+
+| Mode | Identity | Transport | Run / reach it with | Use when |
+|------|----------|-----------|---------------------|----------|
+| **1 — visor-hosted** | the **visor's** key | skynet **or** dmsg | `skywire cli pty …` (server is the running visor; not under `app pty`) | the node runs a visor — the default, fleet-ops case |
+| **2 — standalone dmsg** | its **own** keypair (**cannot** borrow the visor's) | dmsg (+ optional TCP) | `skywire app pty dmsg` (≡ `dmsg pty host`) | a box with no visor, or one that mustn't contend with the visor's dmsg entry |
+| **3 — standalone TCP** | **can use the visor's PK** (`--sk-from-visor`) | direct TCP (noise-XK) | `skywire app pty tcp` (≡ `dmsg pty host --no-dmsg --tcp-listen`), or operator-friendly `skywire cli pty host` | you want a process **independent of the visor's lifecycle** — survives visor restarts, so it's the right tool to **update skywire itself** or as a plain ssh-equivalent |
+
+Detailed docs:
+
+- **[skywire-pty.md](skywire-pty.md)** — mode 1 (visor-hosted) and the
+  `cli pty` client commands. **Start here.**
+- **[standalone-pty.md](standalone-pty.md)** — modes 2 & 3 (the standalone
+  servers) plus the `http` and `exec` clients, via `app pty`.
+
+## The trust model (identical everywhere)
+
+Every mode and every transport uses the same authorization:
+
+| SSH concept            | Skywire pty equivalent                                       |
+|------------------------|--------------------------------------------------------------|
+| host-key check         | noise **XK** pins the **server PK** from the destination     |
+| `authorized_keys`      | the host's **whitelist** of client PKs                       |
+| password / pubkey auth | the **client PK alone** (from the local visor's SK by default)|
+
+The server's own PK is always implicitly allowed; for a visor, its
+**hypervisors** and `pty.whitelist` are allowed too. One whitelist gates
+dmsg, TCP, and the gated web UI alike. (The standalone `http` browser
+bridge is the exception — it's a *local* socket bridge with no PK gate;
+secure it by not exposing its port.)
+
+## Things built on the pty
+
+- **`fs` — the `sshfs` equivalent.** `cli pty fs mount <pk>@<host>:<port>
+  <dir>` mounts a peer's filesystem over the pty subsystem's sftp channel
+  (Linux + FUSE). Same PK/whitelist trust model as a shell.
+- **`exec` — the agent-friendly path.** `cli pty exec <pk> -- <cmd>`
+  captures stdout/stderr/exit-code with no TTY — the form scripts and
+  automated agents use to drive a fleet. Mirrors the remote exit code
+  locally (`124` on timeout).
+- **`http` — browser terminal.** A WebSocket terminal. The visor serves
+  one at `/pty` (whitelist-gated); the standalone `app pty http` bridges a
+  browser to a *local* host socket (see [standalone-pty.md](standalone-pty.md)).
+
+## Full command map
+
+### `skywire cli pty …` — operator / client (and visor-hosted access)
+| Command | Role |
+|---------|------|
+| `cli pty exec <pk> -- <cmd>` | one-shot exec (agent-friendly), via local-visor RPC or `--via` TCP |
+| `cli pty start <pk>` | interactive shell via the visor |
+| `cli pty shell <pk>@<host>:<port> [-- <cmd>]` | ssh-shaped direct-TCP shell/exec |
+| `cli pty fs mount` / `fs umount` | sshfs-shaped FUSE mount |
+| `cli pty list` | peers the local visor sees |
+| `cli pty ui` / `cli pty url` | open / print the visor's web-terminal URL (can target a remote visor per-PK) |
+| `cli pty host` | run a TCP-only (mode-3) server — `--listen`/`--allow`/`--sk-from-visor` |
+
+### `skywire app pty …` — the native app (standalone servers + clients)
+| Command | Role | Hidden alias |
+|---------|------|--------------|
+| `app pty dmsg` | **mode 2** server (dmsg; `--tcp-listen`/`--no-dmsg`) | `dmsg pty host` |
+| `app pty tcp` | **mode 3** server (TCP-only, `--addr`) | `dmsg pty host --no-dmsg --tcp-listen` |
+| `app pty http` | browser bridge to a **local** host socket | `dmsg pty ui` |
+| `app pty exec` | standalone client (interactive) | `dmsg pty cli` |
+| `app pty exec exec <pk> -- <cmd>` | standalone one-shot exec | `dmsg pty cli exec` |
+| `app pty exec whitelist` | list a host's whitelist | `dmsg pty cli whitelist` |
+| `app pty exec whitelist-add <pk>…` | add to a host's whitelist | `dmsg pty cli whitelist-add` |
+| `app pty exec whitelist-remove <pk>…` | remove from a host's whitelist | `dmsg pty cli whitelist-remove` |
+| `app pty dmsg confgen` | scaffold a standalone host config | `dmsg pty host confgen` |
+
+## Redundant / equivalent commands
+
+Because the two structures are converging, several commands are the same
+code at different paths. Prefer the left column:
+
+| Canonical (`app pty` / `cli pty`) | Hidden legacy (`dmsg pty`) | Notes |
+|-----------------------------------|----------------------------|-------|
+| `app pty dmsg` | `dmsg pty host` | identical |
+| `app pty tcp` *or* `cli pty host` | `dmsg pty host --no-dmsg …` | `cli pty host` is the operator-friendly mode-3 server (`--allow`, `--sk-from-visor`); `app pty tcp` is the app-framework one. Same protocol. |
+| `app pty http` | `dmsg pty ui` | identical |
+| `app pty exec [exec\|whitelist*]` | `dmsg pty cli [exec\|whitelist*]` | identical |
+
+The `dmsg pty` tree is `Hidden = true` in the main binary
+(`cmd/skywire/commands/root.go`) but still callable — and it's the
+*visible* surface if you compile the dmsg structure as its own binary.
+
+**No longer present:** `cli sshd` / `cli ssh` (folded into `cli pty host`
+/ `cli pty shell`); `cli dmsg pty …` (the pty tree moved to `cli pty`).
+
+## See also
+
+- [skywire-pty.md](skywire-pty.md) — visor-hosted mode + `cli pty`
+- [standalone-pty.md](standalone-pty.md) — standalone dmsg / TCP servers + http/exec clients

--- a/docs/pty/skywire-pty.md
+++ b/docs/pty/skywire-pty.md
@@ -1,0 +1,180 @@
+# Mode 1 — the visor-hosted pty (`skywire cli pty`)
+
+When you run `skywire visor`, it launches the pty as a managed
+**Internal app** (`RestartPolicy=Always`; RFC #2775 Phase 3.3). This is
+the interface most people mean by "the skywire pty": no separate daemon,
+no SSH keys — any peer whose PK is whitelisted can open a shell, run a
+command, mount the filesystem, or open the web terminal, keyed by public
+key over noise-XK, **over skynet or dmsg using the visor's own key**.
+
+The visor-hosted mode is deliberately **not** exposed under
+`skywire app pty` — you drive it with **`skywire cli pty`**. For hosts
+that run *without* a visor, see [standalone-pty.md](standalone-pty.md).
+
+## What the visor brings up
+
+On start the visor's `pty` Internal app opens, per its config:
+
+- a **dmsg listener** on `pty.dmsg_port` (default `22`) — the
+  dmsg-overlay entry point, reached through dmsg discovery;
+- a **skynet/route listener** in parallel, so the visor's MultiDialer can
+  reach peers over skywire routes as well as dmsg (skynet-first, dmsg
+  fallback);
+- a **local CLI control socket** on `pty.cli_network` + `pty.cli_address`
+  (default `unix` at `/tmp/pty.sock`) — used by same-host tooling and the
+  web UI;
+- a **direct-TCP listener** on `pty.ssh_listen` **only if that field is
+  set** (e.g. `:2022`) — see the note below;
+- a **web terminal** at `/pty` on the visor's local HTTP (logserver)
+  endpoint, gated by the same whitelist.
+
+Teardown is automatic on `skywire cli visor halt`.
+
+> **`pty.ssh_listen` vs. mode 3.** Setting `pty.ssh_listen` makes the
+> visor *itself* serve the TCP entry point — but it shares the visor's
+> process lifecycle. If you want a TCP pty that **survives visor
+> restarts** (e.g. to update skywire), run a *separate* mode-3 process
+> instead — see [standalone-pty.md](standalone-pty.md).
+
+## Configuration (`pty` section of `skywire-config.json`)
+
+The legacy key `dmsgpty` is still accepted on load.
+
+```json
+{
+  "pty": {
+    "dmsg_port": 22,
+    "cli_network": "unix",
+    "cli_address": "/tmp/pty.sock",
+    "whitelist": [
+      "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
+    ],
+    "ssh_listen": ":2022"
+  }
+}
+```
+
+| JSON key | Meaning |
+|----------|---------|
+| `dmsg_port` | dmsg-overlay listener port. Default `22`. |
+| `cli_network` / `cli_address` | local control socket. Default `unix` / `/tmp/pty.sock`. |
+| `whitelist` | client PKs allowed to connect (in addition to the implicit ones below). |
+| `ssh_listen` | optional direct-TCP entry point (`:2022`, `0.0.0.0:2022`, …). **Empty (default) = dmsg/skynet only.** |
+
+### Who is authorized
+
+The effective whitelist is assembled at start from:
+
+1. the visor's **own PK**;
+2. every PK in the visor's **`hypervisors`** list;
+3. every PK in **`pty.whitelist`**.
+
+One whitelist gates the dmsg path, the skynet path, the `ssh_listen` TCP
+path, and the `/pty` web terminal.
+
+#### Changing the whitelist at runtime
+
+There is no `cli pty` whitelist verb; runtime changes go through the
+host's **control socket** (so run these *on the visor's host*, pointed at
+`pty.cli_address`):
+
+```bash
+skywire app pty exec whitelist-add    <pk> [<pk>…] --cliaddr /tmp/pty.sock
+skywire app pty exec whitelist-remove <pk> [<pk>…] --cliaddr /tmp/pty.sock
+skywire app pty exec whitelist                      --cliaddr /tmp/pty.sock   # list
+# (hidden-alias equivalents: `dmsg pty cli whitelist-add`, etc.)
+```
+
+To persist across restarts, also add the PK to `pty.whitelist` in the
+config.
+
+## Reaching the host
+
+### Through your local visor (the common path)
+
+Your CLI talks to your **local** visor over RPC (`localhost:3435`); the
+visor dials the remote host over its best transport.
+
+```bash
+# one-shot exec — captures stdout/stderr/exit (agent-friendly)
+skywire cli pty exec <remote-pk> -- systemctl status skywire
+
+# interactive shell
+skywire cli pty start <remote-pk>
+
+# peers the local visor can see
+skywire cli pty list
+```
+
+`cli pty exec` mirrors the remote exit code locally (`0` ok, remote code
+on failure, `124` on timeout, `1` on RPC-layer failure). Host-side
+command cap is **5m**; favor bounded commands and use `start` for
+streaming. Up to 16 MiB each of stdout/stderr is captured.
+
+**Pin the transport** (default tries skynet, then dmsg):
+
+```bash
+skywire cli pty exec <remote-pk> --scheme dmsg   -- uname -a
+skywire cli pty exec <remote-pk> --scheme skynet -- uname -a
+```
+
+### Direct TCP (ssh-shaped) — needs `ssh_listen` (or a mode-3 host)
+
+```bash
+skywire cli pty shell <remote-pk>@<host-ip>:2022                 # interactive
+skywire cli pty shell <remote-pk>@<host-ip>:2022 -- uptime       # one-shot
+skywire cli pty exec  <remote-pk> --via tcp://<remote-pk>@<host-ip>:2022 -- hostname
+```
+
+The client borrows the **local visor's SK** as its identity by default
+(`--sk <hex>` to pin, `--no-visor-key` for a random one). Default port
+`2022` (`--port`).
+
+### Remote filesystem — `fs` (the `sshfs` equivalent)
+
+Linux + FUSE only:
+
+```bash
+skywire cli pty fs mount <remote-pk>@<host-ip>:2022 ~/mnt/peer
+skywire cli pty fs umount ~/mnt/peer
+```
+
+### Web terminal
+
+```bash
+skywire cli pty url                 # print the URL
+skywire cli pty ui                  # open it
+skywire cli pty ui  --visor <pk>    # a specific remote visor, via your hypervisor
+```
+
+`-p/--pkg` reads identity from `/opt/skywire/skywire.json`; `-i/--input`
+from a named config. (Unlike the standalone `app pty http`, the visor UI
+is whitelist-gated and can reach *remote* visors per-PK.)
+
+## Operational notes
+
+- **Detached long-running work.** A `pty exec` is bounded (5m cap, and the
+  transport can drop). For anything that must outlive the call — a package
+  upgrade, a long build — launch it as a detached unit so it survives both
+  the pty session dropping *and* the controlling visor restarting:
+
+  ```bash
+  skywire cli pty exec <pk> -- systemd-run --unit=myjob --collect \
+    --service-type=oneshot --property=TimeoutStartSec=4h --no-block \
+    /usr/local/sbin/myjob.sh
+  skywire cli pty exec <pk> -- systemctl is-active myjob          # poll
+  ```
+
+  (`--no-block` so `systemd-run` returns immediately instead of blocking
+  your `exec` until the oneshot finishes.)
+
+- **A package upgrade can restart the remote visor** — which restarts its
+  pty host and drops your in-flight `exec`. A `systemd-run` unit owned by
+  the remote's PID 1 is unaffected. (This is exactly why **mode 3** — a
+  TCP pty independent of the visor lifecycle — is the right tool for
+  updating skywire itself.)
+
+## See also
+
+- [README.md](README.md) — the model, all modes, command map
+- [standalone-pty.md](standalone-pty.md) — modes 2 & 3, http/exec clients

--- a/docs/pty/standalone-pty.md
+++ b/docs/pty/standalone-pty.md
@@ -1,0 +1,185 @@
+# Modes 2 & 3 — the standalone pty (`skywire app pty`)
+
+The visor-hosted pty ([skywire-pty.md](skywire-pty.md)) is launched and
+owned by the visor. The **standalone** modes run the pty as its own
+process via `skywire app pty …`. Two server modes, plus the `http` and
+`exec` clients:
+
+| | Mode 2 — **standalone dmsg** | Mode 3 — **standalone TCP** |
+|--|------------------------------|-----------------------------|
+| Command | `app pty dmsg` (≡ `dmsg pty host`) | `app pty tcp` (≡ `dmsg pty host --no-dmsg --tcp-listen`); or `cli pty host` |
+| Identity | its **own** keypair — **cannot** borrow the visor's | **can use the visor's PK** (`--sk-from-visor`) |
+| Transport | dmsg (+ optional TCP via `--tcp-listen`) | direct TCP only, noise-XK |
+| Best for | a box with no visor, or one that mustn't contend with the visor's dmsg-disc entry | a process **independent of the visor lifecycle** — survives restarts, so it's how you **update skywire itself**; plain ssh-equivalent |
+
+Both serve the identical protocol and the same noise-XK + whitelist trust
+model as the visor-hosted host. Reach either from a client with
+`cli pty shell` / `cli pty exec --via` ([skywire-pty.md](skywire-pty.md))
+or the standalone `app pty exec` client (below).
+
+## Mode 2 — standalone dmsg host
+
+### Config
+
+Standalone hosts are config-driven and use their **own** config shape
+(note: `dmsgport`/`clinet`/`cliaddr`/`wl` — *not* the visor's
+`dmsg_port`/`cli_network`/`cli_address`/`whitelist`). Scaffold one:
+
+```bash
+skywire app pty dmsg confgen > ./pty-host-config.json     # ≡ dmsg pty host confgen
+```
+
+```json
+{
+  "sk": "<32-byte hex>",
+  "pk": "<derived>",
+  "dmsgdisc": "dmsg://022e607e...:80",
+  "dmsgsessions": 1,
+  "dmsgport": 22,
+  "wl": ["<peer-pk-1>", "<peer-pk-2>"],
+  "clinet": "unix",
+  "cliaddr": "/tmp/pty.sock",
+  "ssh_listen": ""
+}
+```
+
+| Key | Meaning |
+|-----|---------|
+| `sk` / `pk` | the host's **own** identity (a standalone dmsg host cannot share the visor's key). |
+| `dmsgdisc` / `dmsgsessions` | dmsg discovery + min sessions. |
+| `dmsgport` | dmsg-side listener port. Default `22`. |
+| `wl` | whitelist — **empty rejects all incoming requests.** The host's own PK is implicitly allowed. |
+| `clinet` / `cliaddr` | local control socket (drives the host locally; also what `app pty http` bridges to). Default `unix` / `/tmp/pty.sock`. |
+| `ssh_listen` | optional direct-TCP entry point (same as `--tcplisten`); empty disables it. |
+
+### Run it
+
+```bash
+# dmsg-only
+skywire app pty dmsg -c ./pty-host-config.json --dmsgport 22
+
+# dmsg + a direct-TCP entry point (whitelist-gated, mirrors pty.ssh_listen)
+skywire app pty dmsg -c ./pty-host-config.json --dmsgport 22 --tcplisten :2022
+```
+
+Peers reach it exactly as they would a visor (their PK must be in `wl`):
+
+```bash
+skywire cli pty exec  <host-pk> -- hostname        # via their visor, over dmsg
+skywire cli pty start <host-pk>
+```
+
+Useful flags (`app pty dmsg --help` for the full list): `--no-dmsg`
+(drop the dmsg side — that's mode 3), `--sk-from-visor <skywire.json>`,
+`--listen-fd N` (systemd socket-activation, one conn per process),
+`--confstdin`.
+
+## Mode 3 — standalone TCP host (ssh-equivalent)
+
+TCP-only, no dmsg client, no discovery entry. **Its key point is process
+independence:** because it's a separate process from the visor, it keeps
+serving across visor restarts — so it's the right surface for **updating
+skywire itself** or as a plain low-latency ssh replacement on a known IP.
+
+Two ways to start it:
+
+```bash
+# operator-friendly (recommended): cli pty host
+skywire cli pty host --listen :2022 --allow <client-pk>,<client-pk> \
+  --sk-from-visor /opt/skywire/skywire.json
+
+# app-framework form
+skywire app pty tcp --addr :2022          # ≡ app pty dmsg --no-dmsg --tcp-listen :2022
+```
+
+`cli pty host` flags (the `sshd`-equivalent surface):
+
+| Flag | Meaning |
+|------|---------|
+| `-l, --listen` | TCP bind (`:2022` default; `0.0.0.0:2022`, `127.0.0.1:2022`, IPv6 ok). |
+| `--sk-from-visor` | use a `skywire-config.json`'s `.sk` as identity — **this is how mode 3 runs under the visor's PK**; empty tries `/opt/skywire/skywire.json`. |
+| `--allow` | client PKs allowed (the `authorized_keys` equivalent); merged with `--conf`. |
+| `-c, --conf` | optional standalone config for whitelist + identity. |
+
+### Client side (any mode-2/3 host)
+
+From a peer, the ssh-shaped client lives under `cli pty`:
+
+```bash
+skywire cli pty shell <host-pk>@<host-ip>:2022                  # interactive
+skywire cli pty shell <host-pk>@<host-ip>:2022 -- systemctl status skywire
+skywire cli pty fs mount <host-pk>@<host-ip>:2022 ~/mnt/peer    # sshfs equivalent
+```
+
+The client borrows the local visor's SK by default (`--sk` to pin,
+`--no-visor-key` for random).
+
+## Exposing a TCP entry point outside the LAN
+
+`--listen :2022` (and `pty.ssh_listen ":2022"`) bind all interfaces; to
+accept from outside the LAN you must route the port in:
+
+- **Home router:** forward external TCP `2022` → `<host-lan-ip>:2022`.
+- **VPS / cloud:** open the port in the provider firewall **and** the host
+  firewall (`ufw allow 2022/tcp`, `firewall-cmd --add-port=2022/tcp
+  --permanent`).
+- **Mesh (Tailscale/WireGuard/ZeroTier):** bind the mesh interface —
+  `--listen 100.x.y.z:2022` — and don't expose publicly.
+- **systemd socket-activation:** `--listen-fd N` and front the `.socket`
+  unit however you like.
+
+## The `app pty http` browser client
+
+`app pty http` (≡ `dmsg pty ui`) serves a WebSocket browser terminal — but
+note what it actually does:
+
+```bash
+skywire app pty http --addr :8080 --hnet unix --haddr /tmp/pty.sock
+```
+
+- It dials a **local control socket** (`--hnet`/`--haddr`, default
+  `unix`/`/tmp/pty.sock`) — the *same* socket a mode-1/2/3 host exposes as
+  its `cliaddr`. So it gives a browser shell **on that local host**; it
+  does **not** traverse dmsg/TCP/skynet to remote peers (that's the
+  visor's `/pty` UI, `cli pty ui --visor <pk>`).
+- It serves **without a PK gate** (`Handler(nil)`). Secure it by **not
+  exposing `:8080`** (bind localhost / firewall) — unlike the dmsg/TCP
+  paths, which are whitelist-gated.
+- **Socket collision:** all hosts default `cliaddr` to `/tmp/pty.sock`, so
+  on one machine only one owns it — set distinct `cliaddr`s to bridge a
+  specific host.
+
+In short: a local browser convenience for a standalone host; for the
+visor you'd normally use its built-in `/pty` UI instead.
+
+## The `app pty exec` standalone client
+
+When you don't want to route through a visor, `app pty exec`
+(≡ `dmsg pty cli`) is the standalone client:
+
+```bash
+skywire app pty exec                                   # interactive (local or --addr <pk:port>)
+skywire app pty exec exec <pk> -- <cmd>                # one-shot (≡ dmsg pty cli exec)
+skywire app pty exec whitelist                         # list a host's whitelist
+skywire app pty exec whitelist-add    <pk> [<pk>…]     # mutate via its control socket
+skywire app pty exec whitelist-remove <pk> [<pk>…]
+```
+
+`--addr <pk>:<port>` targets a remote host; without it the session is
+local. `--cliaddr`/`--clinet` select the control socket for the
+whitelist verbs.
+
+## Verifying
+
+```bash
+ls -la /tmp/pty.sock                                   # control socket up?
+skywire cli pty exec  <host-pk> -- hostname            # dmsg round-trip (mode 2)
+nc -zv <host-ip> 2022                                  # TCP reachable (mode 3)
+skywire cli pty shell <host-pk>@<host-ip>:2022 -- hostname
+```
+
+## See also
+
+- [README.md](README.md) — the model, all modes, redundancy table
+- [skywire-pty.md](skywire-pty.md) — mode 1 (visor-hosted) + `cli pty`
+- `skywire app pty <mode> --help` — current per-mode flags

--- a/docs/skychat/README.md
+++ b/docs/skychat/README.md
@@ -1,0 +1,114 @@
+# Skywire Skychat
+
+**Skychat** is skywire's messaging app: direct messages, group chat, and a
+pairing handshake between two keys — addressed by **public key**, carried
+over skynet, dmsg, a direct noise-XK TCP transport, or CXO feeds. Like the
+[pty](../pty/README.md), it's one subsystem reached through two command
+structures:
+
+- **`skywire app skychat`** — the **server app**. One binary; its *mode* is
+  chosen by **flags** (not subcommands): which transports it listens on,
+  whether it runs under a visor or `--standalone`, and whether CXO feeds
+  are enabled.
+- **`skywire cli skychat …`** — the **client**: `send`, `listen`, `group`,
+  `pair`, `history`, `events`, `chat` (TUI), `alias`, `status`.
+
+A lighter, separate tool — **`skywire cli dmsg chat`** — is a standalone
+interactive chat over dmsg with no visor and no app; handy for a quick
+one-off conversation, distinct from the `app skychat` server.
+
+## The modes
+
+Modes are flag-selected on `app skychat`; several combine.
+
+| Mode | Identity | Transport(s) | Run it with | Use when |
+|------|----------|--------------|-------------|----------|
+| **visor-hosted** (default) | the **visor's** key | dmsg + skynet (`--dmsg`/`--skynet`, both on) | launched by the visor; driven by `cli skychat` | the node runs a visor — the default, fleet case |
+| **standalone** | `-c`/`--sk`/env (no visor key handover) | **TCP-direct only** | `app skychat --standalone …` | you want a chat process **independent of the visor lifecycle** — survives restarts; reachable via TCP-direct |
+| **TCP-direct** (transport) | `-c`/`--sk`/env | direct noise-XK TCP | `--tcp-listen :8800` / `--tcp-peer tcp://pk@host:port`; client `send --via tcp://…` | NAT-pierce, deterministic latency, survives dmsg outages — works **embedded or standalone** |
+| **CXO-backed** | `-c`/`--sk`/env | native TCP CXO feeds (no dmsg) | `--cxo` (DM) / `--cxo-group …` (groups), `--cxo-listen :8802`, `--cxo-peer …` | restart-stable DM/group chat; backs `cli skychat group`. Works in `--standalone`. |
+
+Detailed docs:
+
+- **[skychat-visor.md](skychat-visor.md)** — the visor-hosted app and the
+  `cli skychat` client. **Start here.**
+- **[standalone-skychat.md](standalone-skychat.md)** — `--standalone`,
+  TCP-direct, and CXO (DM + groups).
+
+## The trust model
+
+Identity is a **secret key**; the derived **PK** is the address peers pin.
+Provide it with `-c <skywire-config.json>` (reuses the visor's SK → same
+PK as the visor), `--sk <hex>`, or `DMSGCURL_SK`. In standalone with no
+identity, a **random ephemeral SK** is generated each start — fine for
+testing, useless for durable whitelists.
+
+- **TCP-direct**: a noise-XK handshake pins the server PK; `--tcp-whitelist`
+  is the `authorized_keys` (empty = open to any authenticated key).
+- **CXO**: feeds are addressed by feed PK; group rosters are owner-signed;
+  `--cxo-peer` lists who you subscribe to.
+- **HTTP control surface**: localhost by default; `--password-file` (bcrypt)
+  gates it if exposed; the hypervisor reverse-proxies it with
+  `--internal-token`.
+
+## Features built on skychat
+
+- **`group` — owner-centric group chat** over CXO feeds: `create`, `invite`
+  /`join`, `send`/`listen`, `history`, `promote`/`demote`/`leave`,
+  `list`/`info`. `public` or `private` (AES key shipped in the invite link).
+- **`pair` — per-partner pairing**: `--pair-enable` brings up per-partner
+  CXO pair feeds (HTTP `/pair` + handshake). `pair add` (request),
+  `accept`/`decline`, `send`, `list`, `remove`. **Note:** `pair poll` has
+  no SSE — you **poll** for replies (`--since`/`--limit`).
+- **`events` — agent-friendly stream**: structured **NDJSON** chat events —
+  the scripting/automation surface (skychat's analog of `pty exec`).
+- **`history` — persisted store**: optional BoltDB (`--persist…`) with
+  per-peer caps, TTL, rate-limit, and SSE seed.
+- **`alias`** — local PK→name aliases. **`chat`** — a bubbletea split-pane
+  TUI.
+
+## Ports (defaults / conventions)
+
+| Port | What |
+|------|------|
+| `:8001` | visor-hosted HTTP control surface (`--addr`) |
+| `:8002` | standalone HTTP control surface (convention) |
+| `:8800` / `:8801` | TCP-direct (`--tcp-listen`; guides commonly forward `:8801`) |
+| `:8802` | CXO feed listener (`--cxo-listen`) |
+
+> **SSE-hub gotcha.** Each HTTP control surface has its **own SSE hub**. A
+> message that lands on the visor-managed `:8001` hub does **not** appear on
+> a standalone `:8002` hub, and vice versa. If you run both, `listen` on
+> **both** or you'll miss messages. DMs sent through a visor route land on
+> `:8001`, not the standalone surface.
+
+## Full command map
+
+### `skywire cli skychat …` — the client
+| Command | Role |
+|---------|------|
+| `cli skychat send -t <pk> -m <msg> [-n skynet\|dmsg] [--via tcp://…] [-w 5s]` | send a DM (ack with `--wait`; `--via` bypasses the local app over TCP) |
+| `cli skychat listen [--from <pk>] [-n net]` | stream incoming messages (SSE) |
+| `cli skychat chat [-t <pk>] [-n net]` | interactive TUI |
+| `cli skychat events` | structured NDJSON event stream |
+| `cli skychat history` | print persisted history |
+| `cli skychat status` | app counters / health |
+| `cli skychat alias add\|ls\|rm` | local PK aliases |
+| `cli skychat group create\|invite\|join\|send\|listen\|history\|list\|info\|add\|promote\|demote\|leave\|delete` | group chat |
+| `cli skychat pair add\|accept\|decline\|send\|poll\|list\|remove` | pairing (poll, no SSE) |
+
+### `skywire app skychat` — the server
+One command, mode chosen by flags: `--standalone`, `--dmsg`/`--skynet`,
+`--tcp-listen`/`--tcp-peer`/`--tcp-whitelist`, `--cxo`/`--cxo-group`/
+`--cxo-listen`/`--cxo-peer`, `--pair-enable`, `--persist…`, `--addr`,
+`-c`/`--sk`, `--password-file`. See [standalone-skychat.md](standalone-skychat.md)
+and `skywire app skychat --help`.
+
+### `skywire cli dmsg chat`
+Standalone interactive chat over dmsg, no visor — a separate lightweight tool.
+
+## See also
+
+- [skychat-visor.md](skychat-visor.md) — visor-hosted app + `cli skychat`
+- [standalone-skychat.md](standalone-skychat.md) — standalone / TCP-direct / CXO
+- [../pty/README.md](../pty/README.md) — the parallel pty subsystem

--- a/docs/skychat/skychat-visor.md
+++ b/docs/skychat/skychat-visor.md
@@ -1,0 +1,109 @@
+# Visor-hosted skychat (`skywire cli skychat`)
+
+By default `skywire app skychat` runs as a **child of the visor**: the
+visor hands it its identity, opens its **skynet + dmsg** listeners, and
+mediates pair-RPC. You don't start it by hand — you drive it with
+**`skywire cli skychat`**, which talks to the app's HTTP control surface
+(default **`:8001`**). This is the common, fleet-ops case.
+
+For a chat process that runs *without* a visor (or survives visor
+restarts), see [standalone-skychat.md](standalone-skychat.md).
+
+## What the visor brings up
+
+Launched as part of the visor's app set, `app skychat` defaults to:
+
+- `--dmsg` **and** `--skynet` listeners **on** — messages ride either
+  network using the **visor's key** (so the chat PK == the visor PK);
+- the HTTP control surface on `--addr :8001` (localhost) — history, send,
+  status, and the **SSE** stream the `cli` client consumes;
+- pair-RPC wired to the visor (`--pair-rpc localhost:3435`) so pairing
+  works (in standalone these endpoints return 503).
+
+Operators who want it in the visor's managed app set wire it into
+`skywire-config.json`'s `launcher.apps[]` (flags in the `args` array);
+`skywire-autoconfig` can scaffold this.
+
+## Sending and receiving
+
+```bash
+# send a DM (default network skynet; -w waits for a peer-receipt ack)
+skywire cli skychat send -t <peer-pk> -m "hello"
+skywire cli skychat send -t <peer-pk> -m "hi over dmsg" -n dmsg -w 8s
+
+# stream incoming messages (SSE); optionally filter by sender/network
+skywire cli skychat listen
+skywire cli skychat listen --from <peer-pk>
+
+# interactive split-pane TUI
+skywire cli skychat chat -t <peer-pk>
+
+# health / counters, persisted history, structured event stream
+skywire cli skychat status
+skywire cli skychat history
+skywire cli skychat events            # NDJSON — the agent/automation surface
+```
+
+`send` notes: `-n/--net skynet|dmsg` (default `skynet`); `-w/--wait`
+(default `5s`, `0` = fire-and-forget); `-r/--retries` for transient
+HTTP/transport failures; `--verbose` surfaces per-layer detail to debug a
+failing send; `--via tcp://<pk>@host:port` bypasses the local app and dials
+a peer's chat-app directly (survives visor/dmsg outages — see
+[standalone-skychat.md](standalone-skychat.md)).
+
+`Acked by <pk> in Xms (via skynet)` confirms delivery end-to-end.
+
+## Groups (`cli skychat group`)
+
+Owner-centric group chat over CXO feeds:
+
+```bash
+skywire cli skychat group create --name "ops" --member <pk> --member <pk>   # --mode public|private
+skywire cli skychat group invite <group>           # produces an invite link
+skywire cli skychat group join   <invite-link>
+skywire cli skychat group send   <group> -m "hello team"
+skywire cli skychat group listen <group>           # poll-based; --interval, --since, --raw
+skywire cli skychat group history <group>
+skywire cli skychat group list | info <group>
+skywire cli skychat group promote|demote|leave|add|delete …
+```
+
+`--mode private` encrypts feed messages with an AES key shipped inside the
+invite link. The owner holds the roster; `promote`/`demote` manage admins.
+
+## Pairing (`cli skychat pair`)
+
+A two-key handshake with per-partner CXO pair feeds (needs the app started
+with `--pair-enable`):
+
+```bash
+skywire cli skychat pair add <peer-pk>          # request
+skywire cli skychat pair accept|decline <peer-pk>
+skywire cli skychat pair send -t <peer-pk> -m "hi"
+skywire cli skychat pair poll --since <RFC3339> --limit 100   # NO SSE — poll for replies
+skywire cli skychat pair list | remove <peer-pk>
+```
+
+> **`pair poll` has no SSE.** Unlike `listen`, pair replies are not pushed —
+> you must `pair poll` (or run it on an interval) to drain them.
+
+## Aliases
+
+```bash
+skywire cli skychat alias add <pk> <name>
+skywire cli skychat alias ls
+skywire cli skychat alias rm <name>
+```
+
+## The SSE-hub gotcha
+
+The control surface you talk to *is* the SSE hub. If you also run a
+**standalone** skychat (its own `:8002` hub), messages don't cross between
+hubs — DMs routed through the visor land on **`:8001`**, not the
+standalone. Run `listen` against **both** surfaces if you operate both, and
+read deduplicated by message id (SSE replays on reconnect).
+
+## See also
+
+- [README.md](README.md) — the model, all modes, ports, command map
+- [standalone-skychat.md](standalone-skychat.md) — standalone / TCP-direct / CXO

--- a/docs/skychat/standalone-skychat.md
+++ b/docs/skychat/standalone-skychat.md
@@ -1,0 +1,169 @@
+# Standalone skychat — TCP-direct & CXO
+
+The visor-hosted app ([skychat-visor.md](skychat-visor.md)) lives and dies
+with the visor. The **`--standalone`** flag detaches the chat-app so it
+runs as its **own process** — it survives visor restarts and is reached
+over a direct noise-XK **TCP** transport and/or **CXO** feeds.
+
+This is the right tool when chat must stay up across visor rebuilds (e.g.
+fleets where every PR merge restarts the visor), or for a NAT-pierced,
+deterministic-latency channel that doesn't depend on dmsg.
+
+## The two ways to run it
+
+- **standalone** (`--standalone`): no parent visor. Skips the
+  `PROC_CONFIG` handshake, **disables the skynet + dmsg listenLoops**, and
+  keeps `--tcp-listen`/`--tcp-peer` + CXO + the HTTP control surface.
+  Reachable via **TCP-direct/CXO only**. Pair-RPC endpoints return **503**
+  (no visor to relay through).
+- **embedded + TCP/CXO**: drop `--standalone` and the app re-attaches to
+  the visor (skynet+dmsg as usual) **and** serves the extra TCP/CXO entry
+  points. Best of both, but tied to the visor lifecycle.
+
+## Identity
+
+Every mode needs a secret key; the derived PK is the address peers pin:
+
+```bash
+-c /opt/skywire/skywire-config.json   # preferred — same SK as the visor → same PK
+--sk <64-hex>                         # explicit
+export DMSGCURL_SK=<64-hex>           # env (same shape as --sk)
+```
+
+No identity in standalone → a **random ephemeral SK** each start (PK
+changes every restart; useless for durable whitelists).
+
+## TCP-direct
+
+### Server side (accept inbound)
+
+```bash
+skywire app skychat \
+  --standalone \
+  --addr 127.0.0.1:8002 \
+  --tcp-listen :8801 \
+  --tcp-whitelist <peer-pk-1>,<peer-pk-2> \
+  -c /opt/skywire/skywire-config.json
+```
+
+- `--addr` — local HTTP control surface (history, send, SSE). Keep it
+  loopback unless you intend browser access (`--addr "*:8002"` + reverse
+  proxy + `--password-file`).
+- `--tcp-listen :8801` — accept noise-XK on TCP; bidirectional once
+  established.
+- `--tcp-whitelist` — the `authorized_keys`. Empty = **open to any
+  authenticated key** (matches the skynet/CXO convention); set it to pin
+  specific peers.
+
+Peers dial in with the client's `--via`:
+
+```bash
+skywire cli skychat send \
+  --via tcp://<your-pk>@<your-public-ip>:8801 \
+  -c /their/skywire-config.json -w 8s -m "ping"
+```
+
+The `<your-pk>` in the URL must match the SK on the listening side — the
+noise-XK handshake binds the connection to that PK.
+
+### Client side (dial out from behind NAT)
+
+For a host that can't accept inbound, hold a persistent outbound link:
+
+```bash
+skywire app skychat \
+  --standalone --addr 127.0.0.1:8002 \
+  --tcp-peer tcp://<remote-pk>@<remote-host>:8801 \
+  -c /path/to/skywire-config.json
+```
+
+`--tcp-peer` is repeatable and auto-reconnects; this side needs no port
+forward (it initiates the TCP).
+
+### Exposing the TCP port outside the LAN
+
+`--tcp-listen :8801` binds all interfaces; to accept from outside the LAN:
+
+- **Home router:** forward external TCP `8801` → `<host-lan-ip>:8801`.
+- **VPS / cloud:** open the provider firewall **and** the host firewall
+  (`ufw allow 8801/tcp`, `firewall-cmd --add-port=8801/tcp --permanent`).
+- **Mesh (Tailscale/WireGuard/ZeroTier):** bind the mesh interface —
+  `--tcp-listen 100.x.y.z:8801` — and skip NAT forwarding.
+
+## CXO-backed (DM + groups, no dmsg)
+
+CXO runs over its **own native TCP transport** — keeping the standalone
+dmsg-free and restart-stable. The tcp-direct channel above can keep running
+alongside for coordination; CXO carries the durable, replayable messaging.
+
+### Direct messages (P2P)
+
+```bash
+skywire app skychat \
+  --standalone --addr 127.0.0.1:8002 \
+  --cxo \
+  --cxo-listen :8802 \
+  --cxo-peer tcp://<peer-feedpk>@<peer-host>:8802 \
+  -c /opt/skywire/skywire-config.json
+```
+
+- `--cxo` — publish your outbound to your CXO feed, subscribe to
+  `--cxo-peer` feeds. A reconnect watchdog re-dials the stored address and
+  replays missed history on recovery.
+- `--cxo-listen :8802` — where peers dial your feed (forward this port like
+  the tcp-direct one).
+- `--cxo-peer tcp://<feedpk>@host:port` — repeatable; who you subscribe to.
+
+### Federated groups
+
+```bash
+skywire app skychat \
+  --standalone --addr 127.0.0.1:8002 \
+  --cxo-group <group-id> \
+  --cxo-group-owner <owner-pk> \
+  --cxo-listen :8802 \
+  --cxo-peer tcp://<member-feedpk>@<host>:8802 \
+  -c /opt/skywire/skywire-config.json
+```
+
+- `--cxo-group <id>` — enable federated group chat (roster, signing,
+  gossip) over native TCP.
+- `--cxo-group-owner <pk>` — the owner PK. **Your role is owner** if it
+  equals your identity, else **member**.
+- Members come from `--cxo-peer`. Drive the group from the client with
+  `cli skychat group …` ([skychat-visor.md](skychat-visor.md)).
+
+## Persisted history
+
+Off by default; enable a local BoltDB:
+
+```bash
+  --persist --persist-db /var/lib/skychat/history.db \
+  --persist-per-peer-cap 500 --persist-ttl 30 --persist-seed 50 \
+  --persist-whitelist /etc/skychat/persist-peers.txt
+```
+
+Per-peer FIFO cap, per-minute rate limit, total-size cap, TTL sweep, and a
+seed count that backfills new SSE clients.
+
+## Verifying
+
+```bash
+curl -s http://127.0.0.1:8002/status | jq          # HTTP control surface up?
+nc -zv <your-public-ip> 8801                        # TCP listener reachable?
+skywire cli skychat send --via tcp://<your-pk>@<your-public-ip>:8801 \
+  -c /peer/skywire-config.json -w 8s -m "ping"      # full round-trip
+```
+
+`Acked by <pk> in Xms (via tcp)` confirms the handshake and receive
+pipeline.
+
+> Remember the **SSE-hub split**: this standalone's `:8002` hub is separate
+> from a visor's `:8001` hub. Run `cli skychat listen` against the surface
+> you actually want to read, or both. (See [README.md](README.md).)
+
+## See also
+
+- [README.md](README.md) — the model, all modes, ports, SSE-hub gotcha
+- [skychat-visor.md](skychat-visor.md) — visor-hosted app + `cli skychat`
+- `skywire app skychat --help` — full, current flag reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,15 @@ nav:
   - Home: index.md
   - Guides: guides/README.md
   - Command Reference: skywire/README.md
+  - Apps:
+      - PTY:
+          - pty/README.md
+          - pty/skywire-pty.md
+          - pty/standalone-pty.md
+      - Skychat:
+          - skychat/README.md
+          - skychat/skychat-visor.md
+          - skychat/standalone-skychat.md
   - Specs: specs/index.md
   - Rewards: rewards/index.md
   - Blog: https://blog.theskywirenetwork.net


### PR DESCRIPTION
Brings the **pty** and **skychat** user guides onto the published docs site (skycoin.github.io/skywire), under a new **Apps** nav section.

- `docs/pty/` — overview + visor-hosted + standalone pty guides
- `docs/skychat/` — overview + visor-hosted + standalone skychat guides
- `mkdocs.yml` — new **Apps › PTY / Skychat** nav section so they render + publish (the site builds from `docs/` on push to develop → gh-pages)
- `docs/index.md` — updates the "per-app docs follow-up" note (pty + skychat now integrated; skysocks/skynet/vpn + services still pending)

Each topic dir is an overview README + per-mode pages, cross-linked. The docs match the current command structure (`cli pty` / `app pty` / `dmsg pty`; `app skychat` / `cli skychat`). mkdocs isn't installed locally to build, but `.github/workflows/docs.yml` builds + publishes on merge.