### PR TITLE
fix(pty): never hold execMu across a pooled-session Close

### DIFF
--- a/pkg/pty/exec_pool.go
+++ b/pkg/pty/exec_pool.go
@@ -14,6 +14,14 @@
 // retires the session, so the caller's next exec re-dials. A dead pooled
 // conn is never silently reused — the trap that bit the RSN pool (a TTL
 // outliving the underlying conn → handing out shut-down connections).
+//
+// Locking discipline: execMu guards the pool map and every pooledExec
+// field, but is NEVER held across a session Close. *PtyClient.Close() is a
+// synchronous, un-timeouted RPC round-trip (Stop() + rpcC.Close()) over a
+// possibly-dead stream; since execMu is Host-global, closing under it would
+// stall every peer's pooled-exec ops behind one dead peer's slow Close.
+// retireLocked therefore RETURNS the session to close and each public
+// method closes it after releasing the lock.
 package pty
 
 import (
@@ -56,17 +64,22 @@ type pooledExec struct {
 // return the caller MUST call releaseExec exactly once.
 func (h *Host) acquireExec(key execKey) *pooledExec {
 	h.execMu.Lock()
-	defer h.execMu.Unlock()
 	pe := h.execPool[key]
 	if pe == nil || pe.dead {
+		h.execMu.Unlock()
 		return nil
 	}
 	if pe.refs == 0 && time.Since(pe.lastUsed) > execSessionTTL {
-		h.retireLocked(key, pe) // idle too long → force a fresh dial
+		stale := h.retireLocked(key, pe) // idle too long → force a fresh dial
+		h.execMu.Unlock()
+		if stale != nil {
+			_ = stale.Close() //nolint:errcheck,gosec
+		}
 		return nil
 	}
 	pe.refs++
 	pe.lastUsed = time.Now()
+	h.execMu.Unlock()
 	return pe
 }
 
@@ -75,51 +88,63 @@ func (h *Host) acquireExec(key execKey) *pooledExec {
 // err==nil) — the session is retired so no one reuses a dead conn.
 func (h *Host) releaseExec(key execKey, pe *pooledExec, execErr error) {
 	h.execMu.Lock()
-	defer h.execMu.Unlock()
 	pe.refs--
 	pe.lastUsed = time.Now()
-	if execErr != nil && !pe.dead {
-		h.retireLocked(key, pe)
-		return
+	var toClose execSession
+	switch {
+	case execErr != nil && !pe.dead:
+		toClose = h.retireLocked(key, pe)
+	case pe.dead && pe.refs == 0:
+		// A concurrent Exec retired it while we were in flight; close once
+		// we're the last one out.
+		toClose = pe.sess
 	}
-	// A concurrent Exec may have retired it while we were in flight; close
-	// once we're the last one out.
-	if pe.dead && pe.refs == 0 {
-		_ = pe.sess.Close() //nolint:errcheck
+	h.execMu.Unlock()
+	if toClose != nil {
+		_ = toClose.Close() //nolint:errcheck,gosec
 	}
 }
 
-// retireLocked unmaps pe and closes it if no Exec is in flight; if one still
-// is (refs>0), it's marked dead so no new caller reuses it and the last
-// releaseExec closes it. Caller holds execMu.
-func (h *Host) retireLocked(key execKey, pe *pooledExec) {
+// retireLocked unmaps pe and marks it dead, returning the session the CALLER
+// must Close() AFTER releasing execMu (or nil if an Exec is still in flight —
+// the last releaseExec closes it then). It never closes under the lock; see
+// the package "Locking discipline" note. Caller holds execMu.
+func (h *Host) retireLocked(key execKey, pe *pooledExec) execSession {
 	pe.dead = true
 	if h.execPool[key] == pe {
 		delete(h.execPool, key)
 	}
 	if pe.refs == 0 {
-		_ = pe.sess.Close() //nolint:errcheck
+		return pe.sess
 	}
+	return nil
 }
 
 // cacheExec stores a freshly-dialed live session for reuse and
 // opportunistically retires idle ones (bounds the pool by recently-active
 // peers without a background goroutine). First-writer wins if another
-// goroutine cached the same key concurrently.
+// goroutine cached the same key concurrently. All Close()s happen after the
+// lock is released.
 func (h *Host) cacheExec(key execKey, sess execSession) {
 	h.execMu.Lock()
-	defer h.execMu.Unlock()
+	var toClose []execSession
 	for k, pe := range h.execPool {
 		if pe.refs == 0 && time.Since(pe.lastUsed) > execSessionTTL {
-			h.retireLocked(k, pe)
+			if stale := h.retireLocked(k, pe); stale != nil {
+				toClose = append(toClose, stale)
+			}
 		}
 	}
 	if existing := h.execPool[key]; existing != nil && !existing.dead {
-		_ = sess.Close() //nolint:errcheck // lost the race; don't leak ours
-		return
+		toClose = append(toClose, sess) // lost the race; don't leak ours
+	} else {
+		if h.execPool == nil {
+			h.execPool = make(map[execKey]*pooledExec)
+		}
+		h.execPool[key] = &pooledExec{sess: sess, lastUsed: time.Now()}
 	}
-	if h.execPool == nil {
-		h.execPool = make(map[execKey]*pooledExec)
+	h.execMu.Unlock()
+	for _, s := range toClose {
+		_ = s.Close() //nolint:errcheck,gosec
 	}
-	h.execPool[key] = &pooledExec{sess: sess, lastUsed: time.Now()}
 }

--- a/pkg/pty/exec_pool_test.go
+++ b/pkg/pty/exec_pool_test.go
@@ -10,11 +10,14 @@ import (
 )
 
 // fakeExecSession is a stand-in for *PtyClient that counts Exec/Close calls
-// and can be told to fail Exec (simulating a dead conn).
+// and can be told to fail Exec (simulating a dead conn) or block in Close
+// (simulating a slow Close over a dead stream).
 type fakeExecSession struct {
-	execN  int
-	failAt int // fail Exec at/after this call number; 0 = never
-	closed int
+	execN        int
+	failAt       int // fail Exec at/after this call number; 0 = never
+	closed       int
+	closeEntered chan struct{} // non-nil: signals (cap-1) that Close was entered
+	blockClose   chan struct{} // non-nil: Close blocks until this is closed
 }
 
 func (f *fakeExecSession) Exec(*CommandExecReq) (*CommandExecResult, error) {
@@ -25,7 +28,19 @@ func (f *fakeExecSession) Exec(*CommandExecReq) (*CommandExecResult, error) {
 	return &CommandExecResult{ExitCode: 0}, nil
 }
 
-func (f *fakeExecSession) Close() error { f.closed++; return nil }
+func (f *fakeExecSession) Close() error {
+	f.closed++
+	if f.closeEntered != nil {
+		select {
+		case f.closeEntered <- struct{}{}:
+		default:
+		}
+	}
+	if f.blockClose != nil {
+		<-f.blockClose
+	}
+	return nil
+}
 
 func testKey() execKey {
 	var pk cipher.PubKey
@@ -124,4 +139,41 @@ func TestExecPool_ConcurrentReleaseClosesOnce(t *testing.T) {
 	if got := h.acquireExec(k); got != nil {
 		t.Fatal("retired session should not be re-acquirable")
 	}
+}
+
+// execMu must never be held across a session Close: a slow/blocking Close on
+// one peer must not freeze pooled-exec ops for other peers. Regression test
+// for the audit finding that retireLocked/releaseExec/cacheExec closed the
+// session inline under the Host-global execMu — a blocking *PtyClient.Close()
+// (an un-timeouted RPC round-trip) would stall every other peer behind it.
+func TestExecPool_CloseNotUnderLock(t *testing.T) {
+	h := &Host{}
+	kA := execKey{port: 1, dialer: "a"}
+	kB := execKey{port: 2, dialer: "b"}
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	h.cacheExec(kA, &fakeExecSession{closeEntered: entered, blockClose: release})
+	h.cacheExec(kB, &fakeExecSession{})
+
+	// Retire A; its Close() blocks until release is closed. If Close ran
+	// under execMu, the whole pool is frozen meanwhile.
+	go func() {
+		pe := h.acquireExec(kA)
+		h.releaseExec(kA, pe, errors.New("dead"))
+	}()
+	<-entered // A.Close() is now in progress (and blocked)
+
+	// An op on a DIFFERENT key must not block behind A's Close.
+	got := make(chan *pooledExec, 1)
+	go func() { got <- h.acquireExec(kB) }()
+	select {
+	case pe := <-got:
+		if pe == nil {
+			t.Fatal("acquireExec(kB) returned nil")
+		}
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("acquireExec(kB) blocked behind another peer's Close — execMu held across Close")
+	}
+	close(release) // let A.Close() finish
 }


### PR DESCRIPTION
The pooled-exec session pool from #3050 closed sessions **inline under the Host-global `execMu`** (releaseExec, retireLocked, cacheExec). For a real `*PtyClient`, `Close()` is a synchronous, **un-timeouted** RPC round-trip (`Stop()` + `rpcC.Close()`) over a possibly-dead stream — so one dead peer's slow Close **stalls every pooled-exec/cache op to every other peer** behind the global lock (latency cliff / near-deadlock under a dead-conn + concurrent-exec interleaving).

**Fix:** `retireLocked` returns the session to close; `acquireExec`/`releaseExec`/`cacheExec` close it *after* releasing `execMu`. Refcount + close-exactly-once + stale-eviction contract unchanged (existing tests still pass).

**Test:** `TestExecPool_CloseNotUnderLock` — retire one peer whose `Close()` blocks, assert acquiring a *different* peer still returns promptly. Hits the 2s timeout against the old code; immediate with the fix. All `-race` clean; gofmt + lint clean.

Found by an adversarial concurrency audit of the pool (its 7 other concerns — refcount, double-close, flush-loss, WriteAsync ordering — verified safe).