### PR TITLE
fix(router): protect primary leg + compact mux leg arrays on removal

### DIFF
--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1214,6 +1214,13 @@ func (rg *RouteGroup) pruneDeadTransports() []int {
 	rg.fwd = aliveFwd
 	rg.rvs = aliveRvs
 
+	// Compact the per-leg counter/readiness arrays in lockstep so they stay
+	// aligned with the pruned tps[]/fwd[]/rvs[]. droppedIdx are the original
+	// pre-compaction indices.
+	if rg.mux != nil {
+		rg.mux.removeLegs(droppedIdx...)
+	}
+
 	rg.logger.Infof("Pruned dead transports: %d alive, %d removed", len(aliveTps), len(deadRuleIDs)/2)
 	return droppedIdx
 }

--- a/pkg/router/route_group_mux_test.go
+++ b/pkg/router/route_group_mux_test.go
@@ -273,3 +273,50 @@ func TestConsecutiveWriteFailuresOnlyOnTotalFailure(t *testing.T) {
 	rg.keepAliveServiceFn(0)
 	require.Equal(t, int32(1), rg.consecutiveWriteFailures)
 }
+
+// TestRouteMuxRemoveLegs verifies removeLegs compacts legs[] and ready[] in
+// lockstep so readiness/accounting stay attached to the right leg after a
+// middle leg is removed (the bug: ready[] was never shrunk → wrong-leg
+// readiness, the mux>=2 hang).
+func TestRouteMuxRemoveLegs(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(5) // ready = [T,F,F,F,F]
+	m.markLegReady(2)
+	m.markLegReady(4) // ready = [T,F,T,F,T]
+	for i := range m.legs {
+		m.legs[i].sentBytes = uint64(i * 10) // tag identity: 0,10,20,30,40
+	}
+
+	m.removeLegs(1, 3) // drop middle legs (ascending, as pruneDeadTransports passes)
+
+	require.Len(t, m.legs, 3, "legs not compacted")
+	require.Len(t, m.ready, 3, "ready not compacted")
+	// Survivors are original legs 0,2,4 in order.
+	require.Equal(t, []bool{true, true, true}, m.ready, "ready bits must follow the surviving legs")
+	require.Equal(t, uint64(0), m.legs[0].sentBytes)
+	require.Equal(t, uint64(20), m.legs[1].sentBytes, "former leg 2's counters must move to index 1")
+	require.Equal(t, uint64(40), m.legs[2].sentBytes, "former leg 4's counters must move to index 2")
+	require.True(t, m.legReadyAt(1), "former leg 2 (ready) must read ready at its new index")
+}
+
+// TestRouteMuxRemoveLegsPromotesPrimary covers the pruneDeadTransports
+// dead-primary case: removing leg 0 promotes the next leg, which must be
+// re-marked always-ready.
+func TestRouteMuxRemoveLegsPromotesPrimary(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(3)     // ready = [T,F,F]
+	m.markLegReady(2) // ready = [T,F,T]
+	m.removeLegs(0)   // drop the primary; former leg 1 becomes the new leg 0
+	require.Len(t, m.ready, 2)
+	require.True(t, m.ready[0], "promoted primary must be marked ready")
+	require.True(t, m.ready[1], "former leg 2 keeps its ready bit")
+}
+
+// TestRouteMuxRemoveLegsEmpty is the no-op guard.
+func TestRouteMuxRemoveLegsEmpty(t *testing.T) {
+	m := &routeMux{}
+	m.growLegs(2)
+	m.removeLegs() // no indices → no change
+	require.Len(t, m.legs, 2)
+	require.Len(t, m.ready, 2)
+}

--- a/pkg/router/route_mux.go
+++ b/pkg/router/route_mux.go
@@ -183,6 +183,49 @@ func (m *routeMux) growLegs(n int) {
 	m.legMu.Unlock()
 }
 
+// removeLegs drops the given ORIGINAL leg indices from legs[] and ready[] so
+// they stay aligned with the rg's compacted tps[]/fwd[]/rvs[] after a leg is
+// removed (RemoveMuxRouteByTransport / pruneDeadTransports). It rebuilds both
+// slices skipping the dropped indices (order-independent), then re-asserts the
+// leg-0-always-ready invariant — leg 0 may have been promoted from an aux when
+// a primary transport is pruned. Without this lockstep compaction the arrays
+// desync from tps[]: readiness and per-leg accounting attach to the wrong leg,
+// which can flip a live leg to not-ready (the mux>=2 hang — see the ready[]
+// note above) or mis-attribute bytes after an index is reused. The counterpart
+// to growLegs.
+func (m *routeMux) removeLegs(indices ...int) {
+	if len(indices) == 0 {
+		return
+	}
+	drop := make(map[int]bool, len(indices))
+	for _, i := range indices {
+		drop[i] = true
+	}
+	m.legMu.Lock()
+	if len(m.legs) > 0 {
+		kept := make([]*legCounters, 0, len(m.legs))
+		for i, c := range m.legs {
+			if !drop[i] {
+				kept = append(kept, c)
+			}
+		}
+		m.legs = kept
+	}
+	if len(m.ready) > 0 {
+		kept := make([]bool, 0, len(m.ready))
+		for i, r := range m.ready {
+			if !drop[i] {
+				kept = append(kept, r)
+			}
+		}
+		m.ready = kept
+		if len(m.ready) > 0 {
+			m.ready[0] = true // the (possibly newly-promoted) primary is always ready
+		}
+	}
+	m.legMu.Unlock()
+}
+
 // markLegReady records that leg idx has carried inbound traffic, so it
 // is now safe to select for sending. Idempotent and bounds-checked.
 func (m *routeMux) markLegReady(idx int) {

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -246,6 +246,13 @@ func (r *router) RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uu
 	if idx < 0 {
 		return fmt.Errorf("transport %s not found in route group", tpID)
 	}
+	// The primary leg (index 0) is privileged throughout the route group:
+	// ping/pong/SACK and latency attribution hardcode tps[0], and the mux
+	// selector treats leg 0 as always-ready. Removing it silently breaks the
+	// group, so refuse it (the last-leg guard above does not cover this).
+	if idx == 0 {
+		return errors.New("cannot remove the primary leg (index 0) of a route group")
+	}
 
 	// Collect rule IDs to delete
 	var deadRuleIDs []routing.RouteID
@@ -268,8 +275,10 @@ func (r *router) RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uu
 		rg.rt.DelRules(deadRuleIDs)
 	}
 
-	// Rebuild selector
+	// Compact the per-leg counter/readiness arrays in lockstep with the
+	// tps/fwd/rvs compaction above, then rebuild the selector.
 	if rg.mux != nil {
+		rg.mux.removeLegs(idx)
 		rg.mux.rebuildWeights(rg.tps)
 	}
 


### PR DESCRIPTION
Two defects in the runtime mux-leg removal path (`mux-rm`/`mux-auto`/transport-close prune), found by an adversarial audit of the route-group lifecycle (its 5 other concerns verified safe):

**1. Primary leg removable** — `RemoveMuxRouteByTransport` only refused removing the *last* leg, not leg **0**. Leg 0 is privileged everywhere (ping/pong/SACK + latency attribution hardcode `tps[0]`; the selector treats it always-ready), so removing it silently breaks the group. Added an `idx == 0` guard.

**2. `legs[]`/`ready[]` never compacted on removal** — `growLegs` only grew; no `removeLegs`. After a middle leg was pruned, `tps`/`fwd`/`rvs` shrank but `legs`/`ready` didn't → readiness + per-leg accounting attach to the **wrong leg**: a live leg can flip to not-ready (**the documented mux≥2 0-bytes/hang failure mode**) or bytes mis-attribute after index reuse. Added `routeMux.removeLegs` (counterpart to `growLegs`), called in lockstep from both removal paths; it re-asserts leg-0-always-ready for a promoted primary.

Plausibly contributing to multihop/mux unreliability — a pruned dead intermediate could be flipping a live leg dark.

**Tests:** `TestRouteMuxRemoveLegs` (compaction + counter identity), `RemoveLegsPromotesPrimary`, `RemoveLegsEmpty`; existing Mux suite + `-race` green; gofmt + lint clean.