### PR TITLE
fix(visor): wait for dmsg-ready before DMSG-HTTP TPD connect (boot wedge)

### DIFF
--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -1014,6 +1014,11 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 		maxBO  = 10 * time.Second
 		tries  = 0
 		factor = 1
+		// tpdDmsgReadyWait bounds how long boot waits for dmsg to be ready
+		// before the DMSG-HTTP transport-discovery attempt. The select on
+		// dmsgC.Ready() returns early once ready; this cap just prevents a
+		// never-ready dmsg from blocking here (it then falls to plain HTTP).
+		tpdDmsgReadyWait = 60 * time.Second
 	)
 
 	conf := v.conf.Transport
@@ -1025,6 +1030,19 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 
 	// Try DMSG-HTTP first if configured, fall back to plain HTTP
 	if conf.DiscoveryDmsg != "" && v.dmsgC != nil {
+		// At boot, initTransport can run before dmsg has established its
+		// sessions; without waiting, getHTTPClient(DiscoveryDmsg) fails and we
+		// fall through to the plain-HTTP retrier below — which, for a dmsg-only
+		// deployment, has no working egress and spins forever (tries=0),
+		// wedging the whole visorinit. Wait (bounded) for dmsg first so the
+		// DMSG-HTTP path can succeed; the select returns immediately once ready.
+		select {
+		case <-v.dmsgC.Ready():
+		case <-time.After(tpdDmsgReadyWait):
+			log.Warn("dmsg not ready within timeout for DMSG-HTTP transport discovery; attempting anyway")
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 		dmsgHTTPC, err := getHTTPClient(ctx, v, conf.DiscoveryDmsg)
 		if err != nil {
 			log.WithError(err).Warn("Failed to get DMSG-HTTP client for TPD, trying plain HTTP")


### PR DESCRIPTION
`connectToTpDisc` tried the DMSG-HTTP TPD client without waiting for dmsg to be ready. At boot, `initTransport` can run before dmsg has established its sessions, so `getHTTPClient(DiscoveryDmsg)` fails and the code falls through to a plain-HTTP retrier with **`tries=0` (infinite retries)**. For a dmsg-only deployment that retrier has no working egress and **spins forever, wedging the whole `visorinit`** — process up, pprof:6060 listening, but RPC/HTTP never bound. Seen repeatedly after `cli visor halt` (`futex_do_wait` in `visorinit.Module.Wait`; goroutine parked in `connectToTpDisc -> netutil.Retrier.Do`).

**Fix:** bounded wait on `dmsgC.Ready()` (60s cap, returns immediately once ready) before the DMSG-HTTP attempt — the same pattern already in `embedded_dmsgweb.go` + `helpers.go` — so the DMSG-HTTP path succeeds instead of falling into the infinite retrier. Worst case (dmsg never ready) waits the cap then behaves exactly as before; no new failure mode. Build + gofmt clean. Note: the wedge is an intermittent boot race, so live-verify is statistical — the fix is logically closing the fall-through, not adding behavior.