### PR TITLE
fix(dmsg): hold sesMx across done-check to avoid send-on-closed errCh

### DIFF
--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -203,8 +203,15 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 		}()
 		ce.log.WithField("remote_pk", dSes.RemotePK()).Debug("Serving session.")
 		err := dSes.serve()
-		if !isClosed(ce.done) {
-			ce.sesMx.Lock()
+		// Hold sesMx across the done-check AND the errCh send so it is atomic
+		// with Close()'s sesMx-guarded close(ce.errCh): either we send before
+		// errCh is closed, or we observe done closed and skip the send.
+		// Checking done unlocked (the prior code) raced Close -> send on a
+		// closed channel -> recovered panic + skipped delSession/disconnect.
+		ce.sesMx.Lock()
+		if isClosed(ce.done) {
+			ce.sesMx.Unlock()
+		} else {
 			select {
 			case ce.errCh <- fmt.Errorf("failed to serve dialed session to %s: %v", dSes.RemotePK(), err):
 			default:


### PR DESCRIPTION
The dialed-session serve goroutine checked `isClosed(ce.done)` **unlocked**, then sent on `ce.errCh` under `ce.sesMx`. `Client.Close()` closes `ce.done` then, under `ce.sesMx`, closes `ce.errCh`. Interleaving: goroutine sees done open → Close closes errCh → goroutine sends → **send on closed channel → panic**. Caught by the goroutine's `recover()` (no crash), but it logs a misleading "recovered panic … send on closed channel" and **skips** the identity-checked `delSession` + `OnSessionDisconnect`.

**Fix:** move the done-check inside the `sesMx` critical section so it's atomic with `Close()`'s `close(errCh)` — either we send before errCh is closed, or we see done closed and skip. Found by an audit of the dmsg session lifecycle (the #3035 newest-session-wins path it otherwise verified sound). build + dmsg `-race` tests green.