### PR TITLE
fix(transport): write deadline + lock/race fixes in managed-transport

### DIFF
--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -727,6 +727,11 @@ func (mt *ManagedTransport) deleteFromDiscovery() error {
 	<<< PACKET MANAGEMENT >>>
 */
 
+// writeTimeout bounds a single transport write so a half-open conn cannot
+// park a write goroutine (and its packet buffer) forever. The write side had
+// no deadline at all; this mirrors readPacket's readTimeout.
+const writeTimeout = 1 * time.Minute
+
 // WritePacket writes a packet to the remote.
 // Respects context cancellation to prevent blocking forever on dead transports.
 func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Packet) error {
@@ -735,6 +740,15 @@ func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Pack
 	if mt.transport == nil {
 		mt.transportMx.Unlock()
 		return fmt.Errorf("write packet: cannot write to transport, transport is not set up")
+	}
+
+	// Capture the transport under the lock so the goroutine below never reads
+	// the shared mt.transport field (which setTransport/close can mutate once
+	// we release the lock on the ctx-cancel path — a data race). Set a write
+	// deadline so the goroutine can't park in Write forever on a half-open conn.
+	tp := mt.transport
+	if err := tp.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		mt.log.WithError(err).Debug("Failed to set write deadline")
 	}
 
 	// Run the write in a goroutine so we can respect context cancellation.
@@ -751,7 +765,7 @@ func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Pack
 				ch <- writeResult{0, fmt.Errorf("panic in transport write: %v", r)}
 			}
 		}()
-		n, err := mt.transport.Write(packet)
+		n, err := tp.Write(packet)
 		ch <- writeResult{n, err}
 	}()
 
@@ -790,13 +804,22 @@ func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Pack
 // counter has always counted all packets because readPacket
 // is the only inbound path.
 func (mt *ManagedTransport) WriteRawPacket(packet routing.Packet) error {
+	// Capture the transport, then write WITHOUT holding transportMx: a wedged
+	// conn must not block here while holding the lock, which would freeze the
+	// whole transport — including its own close(), getTransport(), and every
+	// other method that needs the lock. WritePacket already avoids this via its
+	// goroutine; WriteRawPacket (cascade + VStreamMux direct-dial traffic) did
+	// not, and held the lock across an unbounded Write.
 	mt.transportMx.Lock()
-	if mt.transport == nil {
-		mt.transportMx.Unlock()
+	tp := mt.transport
+	mt.transportMx.Unlock()
+	if tp == nil {
 		return fmt.Errorf("write raw packet: transport not set up")
 	}
-	n, err := mt.transport.Write(packet)
-	mt.transportMx.Unlock()
+	if err := tp.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		mt.log.WithError(err).Debug("Failed to set write deadline")
+	}
+	n, err := tp.Write(packet)
 	if err != nil {
 		mt.close()
 		return err

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1083,10 +1083,13 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 	tm.Logger.Debugf("Initializing TP with ID %s", tpID)
 
 	oldMTp, err := tm.GetTransportByID(tpID)
-	if err == nil {
+	if err == nil && !oldMTp.IsClosed() {
 		tm.Logger.Debug("Found an old mTp from internal map.")
 		return oldMTp, nil
 	}
+	// A closed-but-not-yet-reaped transport (cleanupTransports polls on a 1s
+	// tick) must not be handed back as if it were live — the stale-conn trap.
+	// Fall through to create a fresh one.
 
 	tm.mx.RLock()
 	client, ok := tm.netClients[netType]
@@ -1170,8 +1173,12 @@ func (tm *Manager) STCPRRemoteAddrs() []string {
 	defer tm.mx.RUnlock()
 
 	for _, tp := range tm.tps {
-		if tp.transport != nil {
-			remoteRaw := tp.transport.RemoteRawAddr().String()
+		// Use getTransport() (locks transportMx) rather than reading
+		// tp.transport directly: close() can nil it between the nil-check and
+		// the deref — a data race and a nil-deref crash.
+		netTp := tp.getTransport()
+		if netTp != nil {
+			remoteRaw := netTp.RemoteRawAddr().String()
 			if tp.Entry.Type == types.STCPR && remoteRaw != "" {
 				addrs = append(addrs, remoteRaw)
 			}


### PR DESCRIPTION
Four defects from an audit of the managed-transport lifecycle; the first two share a root cause — **no write deadline anywhere in the write paths**, so a half-open conn could block `Write` forever.

- **F2 (deadlock):** `WriteRawPacket` (cascade + VStreamMux direct-dial) held `transportMx` across an unbounded `Write` — a wedged conn froze the *whole* transport (incl. its own `close()`/`getTransport()`). Now captures tp, releases the lock before Write, adds a deadline.
- **F1 (leak+race):** `WritePacket`'s goroutine had no deadline (parks forever on a half-open conn) and read `mt.transport` unlocked after the ctx-cancel path released the lock. Captures tp under the lock + deadline.
- **F7 (race+crash):** `STCPRRemoteAddrs` did check-then-deref of `tp.transport` while `close()` could nil it between — uses `getTransport()`.
- **F6 (stale-conn):** `saveTransportInternal` returned a closed-but-unreaped transport (1s cleanup poll) as live — now guards on `IsClosed()`.

`writeTimeout=1m`. build + transport `-race` green. Audit cleared the bandwidth byte accounting (atomic) + #3023 edge-collapse (TPD-side) as non-bugs.