### PR TITLE
fix(cxo): undo speculative CXDS rc when a filling item is declined

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -1198,6 +1198,16 @@ func (c *Cache) Want(
 	}
 	if len(it.val) != 0 { // putFillingItem cached the value
 		c.is[key] = it
+	} else if inc > 0 {
+		// putFillingItem declined the value (> CacheMaxItemSize, stale, or the
+		// cache is disabled): the item is NOT published into c.is, so the
+		// filler's later Finc finds no entry and never decrements. But the
+		// speculative c.db().Get(key, inc) above already bumped the CXDS rc by
+		// inc — left pinned, that DB object is never reclaimed by RemoveObjects
+		// (one leak per declined >1 MiB filled leaf). Undo the speculative ref.
+		// This is the rc-side completion of the #3047 phantom-cache fix (which
+		// stopped the c.is phantom but left this DB-rc residual).
+		_, _ = c.db().Inc(key, -inc) //nolint:errcheck // best-effort undo
 	}
 	return err
 }


### PR DESCRIPTION
`Cache.Want`'s not-in-cache→found branch calls `c.db().Get(key, inc)` (bumps the CXDS refcount by `inc`), then tries to publish a filling item. The **#3047** fix correctly stops inserting that item into `c.is` when `putFillingItem` declines a >1 MiB value — closing the ~80 MB/min phantom-cache OOM-loop. But the **speculative rc increment was left pinned**: no `c.is` entry → the filler's later `Finc` has nothing to decrement → that DB object stays `rc>=1` forever and `RemoveObjects` (rc==0 only) never reclaims it. One leaked DB object per declined >1 MiB filled leaf — slow but unbounded over a publisher's lifetime.

**Fix:** `c.db().Inc(key, -inc)` on the decline path, guarded on `inc>0`. **Exactly reverses the preceding `Get`** (the established decrement pattern, cf. `unpack.go:359`), so it cannot over-decrement. The rc-side completion of #3047.

Found by a CXO cache-retention audit that otherwise **confirmed #3047 correct + complete** and cleared the bandwidth/subscriber-disconnect paths as non-bugs. build + skyobject `-race` green. ⚠️ Coverage caveat: the #3047 regression test (`TestPublisherCleanupBoundedWithSubscriber`) is currently `t.Skip`-ped (unrelated `indexStat.secondLoop` hang), so this path is verified by inspection + the deployment (watch TPD publisher RSS), not that test.