### PR TITLE
fix(resolver): don't host-rewrite a raw-TLS stream; fail on direct handshake error

### DIFF
--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -1198,6 +1198,16 @@ func (c *Cache) Want(
 	}
 	if len(it.val) != 0 { // putFillingItem cached the value
 		c.is[key] = it
+	} else if inc > 0 {
+		// putFillingItem declined the value (> CacheMaxItemSize, stale, or the
+		// cache is disabled): the item is NOT published into c.is, so the
+		// filler's later Finc finds no entry and never decrements. But the
+		// speculative c.db().Get(key, inc) above already bumped the CXDS rc by
+		// inc — left pinned, that DB object is never reclaimed by RemoveObjects
+		// (one leak per declined >1 MiB filled leaf). Undo the speculative ref.
+		// This is the rc-side completion of the #3047 phantom-cache fix (which
+		// stopped the c.is phantom but left this DB-rc residual).
+		_, _ = c.db().Inc(key, -inc) //nolint:errcheck // best-effort undo
 	}
 	return err
 }

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -295,8 +295,10 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				// destination PK) so a vhost-capable backend (caddy/nginx/traefik)
 				// serves the right site — the dmsg counterpart of the skynet
 				// resolver's host-rewrite, which makes magnetosphere.net.<pk>.dmsg
-				// reach the magnetosphere.net site.
-				if vhost != "" {
+				// reach the magnetosphere.net site. Only wrap a plaintext-HTTP
+				// stream: skip on the TLS port with MITM off, where the browser
+				// sends raw TLS that the HTTP parser would corrupt.
+				if vhost != "" && (uint16(port) != cfg.TLSPort || cfg.TLSMITM) {
 					stream = skynetweb.NewHostRewriteConn(stream, vhost)
 				}
 

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -217,11 +217,14 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				//   Browser  ──TLS──► MITMTerminate ──plaintext──► hostRewriteConn ──plaintext──► raw conn ──► backend
 				//
 				// hostRewriteConn parses HTTP/1.1 between MITM
-				// decryption and the wire. If MITM is off, the
-				// browser is already sending plaintext directly to
-				// hostRewriteConn — same parser, same effect.
+				// decryption and the wire. It must only wrap a stream
+				// that is actually plaintext HTTP: a non-TLS port, or
+				// the TLS port WITH MITM (which decrypts to plaintext
+				// first). On the TLS port with MITM off, the browser
+				// sends raw TLS — feeding that to the HTTP parser
+				// corrupts the stream and kills the connection.
 				stack := conn
-				if vhost != "" {
+				if vhost != "" && (hport != cfg.TLSPort || cfg.TLSMITM) {
 					// `subdomain` already encodes the operator's
 					// intent (the URL has labels before the PK).
 					// Use it verbatim as the rewritten Host.

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -229,12 +229,17 @@ func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKe
 				Debug("Skynet: using direct transport (no route)")
 			conn := &vstreamConn{VStream: stream}
 			if err := skynetweb.PerformHandshake(conn, port); err != nil {
+				// A handshake failure on a LIVE direct transport (the server
+				// returned an error / the port is closed) is a real error:
+				// return it rather than silently falling through to a multihop
+				// route, which masks the error and burns route-setup budget.
+				// Only a transport-DIAL failure (mux.Dial err) falls through.
 				conn.Close() //nolint:errcheck,gosec
-			} else {
-				return conn, nil
+				return nil, err
 			}
+			return conn, nil
 		}
-		// No direct transport — fall through to route-based dial.
+		// No direct transport (dial failed) — fall through to route-based dial.
 	}
 
 	var opts *router.DialOptions


### PR DESCRIPTION
Two bugs in the skynet/dmsg vhost resolvers (audit-found):

1. **host-rewrite corrupts a TLS stream** (`skynetweb/runtime.go`, `dmsgweb/runtime.go`): `NewHostRewriteConn` wrapped on `vhost != ""` **regardless of port**. With a vhost + HTTPS backend (TLS port) + MITM **off** (the default), the browser sends raw TLS into `hostRewriteConn`'s `http.ReadRequest` → error → connection torn down. Gate on `vhost != "" && (port != TLSPort || TLSMITM)` so it only wraps known-plaintext-HTTP. (The old comment's "MITM off → plaintext" assumption is false for an HTTPS backend — this is the previously-noted `hostRewriteConn`-on-MITM latent bug.)
2. **direct-transport handshake failure silently falls through to multihop** (`embedded_skynetweb.go`): on a live direct transport whose `PerformHandshake` fails, the dialer fell through to `DialRoutes` — masking the error + burning route-setup budget. Now returns the error (the route-based + source-route paths already do).

build + skynetweb `-race` green. The audit also flagged (not in this PR, lower priority): a Close-deadlock + MITM copy-goroutine leak rooted in `vstreamConn`'s no-op deadlines, and a `route-addr --type dmsg` UX issue.