### PR TITLE
fix(cxo): close indexStat on Container.Close; unblock Node.Close on shutdown

### DIFF
--- a/pkg/cxo/node/head.go
+++ b/pkg/cxo/node/head.go
@@ -525,8 +525,18 @@ func (f *fillHead) request(c *Conn, seq uint64, key cipher.SHA256) {
 
 	var reply, err = c.sendRequest(&msg.RqObject{Key: key})
 
+	// Each send below is guarded with <-f.closeq (the nodeHead's close
+	// channel, promoted via the embedded *nodeHead). handle() — the only
+	// receiver of successq/failureq — stops draining them once it takes its
+	// own <-closeq and terminates, so an unguarded send on these unbuffered
+	// channels would block forever; the deferred await.Done() would never
+	// fire and nodeHead.close's await.Wait() would deadlock (the hang that
+	// t.Skip'd the #3047 leak test).
 	if err != nil {
-		f.failureq <- failedRequest{c, seq, key, err}
+		select {
+		case f.failureq <- failedRequest{c, seq, key, err}:
+		case <-f.closeq:
+		}
 		return
 	}
 
@@ -535,7 +545,10 @@ func (f *fillHead) request(c *Conn, seq uint64, key cipher.SHA256) {
 		var rk = cipher.SumSHA256(x.Value)
 
 		if rk != key {
-			f.failureq <- failedRequest{c, seq, key, ErrInvalidResponse}
+			select {
+			case f.failureq <- failedRequest{c, seq, key, ErrInvalidResponse}:
+			case <-f.closeq:
+			}
 			return
 		}
 
@@ -545,10 +558,16 @@ func (f *fillHead) request(c *Conn, seq uint64, key cipher.SHA256) {
 			return
 		}
 
-		f.successq <- c
+		select {
+		case f.successq <- c:
+		case <-f.closeq:
+		}
 
 	default:
-		f.failureq <- failedRequest{c, seq, key, ErrInvalidResponse}
+		select {
+		case f.failureq <- failedRequest{c, seq, key, ErrInvalidResponse}:
+		case <-f.closeq:
+		}
 	}
 
 }

--- a/pkg/cxo/skyobject/cache.go
+++ b/pkg/cxo/skyobject/cache.go
@@ -1198,6 +1198,16 @@ func (c *Cache) Want(
 	}
 	if len(it.val) != 0 { // putFillingItem cached the value
 		c.is[key] = it
+	} else if inc > 0 {
+		// putFillingItem declined the value (> CacheMaxItemSize, stale, or the
+		// cache is disabled): the item is NOT published into c.is, so the
+		// filler's later Finc finds no entry and never decrements. But the
+		// speculative c.db().Get(key, inc) above already bumped the CXDS rc by
+		// inc — left pinned, that DB object is never reclaimed by RemoveObjects
+		// (one leak per declined >1 MiB filled leaf). Undo the speculative ref.
+		// This is the rc-side completion of the #3047 phantom-cache fix (which
+		// stopped the c.is phantom but left this DB-rc residual).
+		_, _ = c.db().Inc(key, -inc) //nolint:errcheck // best-effort undo
 	}
 	return err
 }

--- a/pkg/cxo/skyobject/container.go
+++ b/pkg/cxo/skyobject/container.go
@@ -363,6 +363,14 @@ func (c *Container) RootByHash(
 // with user-provided DB.
 func (c *Container) Close() (err error) {
 
+	// Stop the embedded Index's indexStat.secondLoop goroutine first.
+	// Container defines its own Close, which shadows the embedded
+	// Index.Close — so without this call it never runs and every Container
+	// teardown leaks one secondLoop goroutine (proven: N close cycles leak
+	// N goroutines). i.stat.Close runs before any Index.Close error, so the
+	// goroutine is reaped regardless of the best-effort return.
+	_ = c.Index.Close() //nolint:errcheck,gosec
+
 	// the Cache.Close closes CXDS
 	if err = c.Cache.Close(); err == nil {
 		err = c.db.Close() //nolint:errcheck,gosec

--- a/pkg/cxo/treestore/leak_subscriber_repro_test.go
+++ b/pkg/cxo/treestore/leak_subscriber_repro_test.go
@@ -23,12 +23,11 @@ import (
 // shows the CXDS growing ~80 MB/min — so the subscriber path is the trigger.
 // This asserts the publisher's CXDS stays bounded with a subscriber attached.
 func TestPublisherCleanupBoundedWithSubscriber(t *testing.T) {
-	t.Skip("FIXME: hangs (whole-suite timeout) on current develop — the TCP " +
-		"publisher<->subscriber sync or Close wedges after an upstream CXO change " +
-		"(goroutine stuck in skyobject.indexStat.secondLoop). The #3047 cache-leak " +
-		"fix this validated is merged and intact; skipping to unblock CI until the " +
-		"sync/close hang is root-caused.")
-
+	// Re-enabled: the Close hang was a blocking failureq/successq send in
+	// fillHead.request (now guarded by <-f.closeq, pkg/cxo/node/head.go) plus a
+	// leaked indexStat.secondLoop goroutine (Container.Close now closes the
+	// embedded Index, pkg/cxo/skyobject/container.go). With both fixed,
+	// Node.Close no longer deadlocks and this validates the #3047 fix again.
 	pkA, skA := cipher.GenerateKeyPair()
 
 	pub, err := NewWithTCP("127.0.0.1:0", skA, PubConfig{

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -295,8 +295,10 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				// destination PK) so a vhost-capable backend (caddy/nginx/traefik)
 				// serves the right site — the dmsg counterpart of the skynet
 				// resolver's host-rewrite, which makes magnetosphere.net.<pk>.dmsg
-				// reach the magnetosphere.net site.
-				if vhost != "" {
+				// reach the magnetosphere.net site. Only wrap a plaintext-HTTP
+				// stream: skip on the TLS port with MITM off, where the browser
+				// sends raw TLS that the HTTP parser would corrupt.
+				if vhost != "" && (uint16(port) != cfg.TLSPort || cfg.TLSMITM) {
 					stream = skynetweb.NewHostRewriteConn(stream, vhost)
 				}
 

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -217,11 +217,14 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				//   Browser  ──TLS──► MITMTerminate ──plaintext──► hostRewriteConn ──plaintext──► raw conn ──► backend
 				//
 				// hostRewriteConn parses HTTP/1.1 between MITM
-				// decryption and the wire. If MITM is off, the
-				// browser is already sending plaintext directly to
-				// hostRewriteConn — same parser, same effect.
+				// decryption and the wire. It must only wrap a stream
+				// that is actually plaintext HTTP: a non-TLS port, or
+				// the TLS port WITH MITM (which decrypts to plaintext
+				// first). On the TLS port with MITM off, the browser
+				// sends raw TLS — feeding that to the HTTP parser
+				// corrupts the stream and kills the connection.
 				stack := conn
-				if vhost != "" {
+				if vhost != "" && (hport != cfg.TLSPort || cfg.TLSMITM) {
 					// `subdomain` already encodes the operator's
 					// intent (the URL has labels before the PK).
 					// Use it verbatim as the rewritten Host.

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -229,12 +229,17 @@ func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKe
 				Debug("Skynet: using direct transport (no route)")
 			conn := &vstreamConn{VStream: stream}
 			if err := skynetweb.PerformHandshake(conn, port); err != nil {
+				// A handshake failure on a LIVE direct transport (the server
+				// returned an error / the port is closed) is a real error:
+				// return it rather than silently falling through to a multihop
+				// route, which masks the error and burns route-setup budget.
+				// Only a transport-DIAL failure (mux.Dial err) falls through.
 				conn.Close() //nolint:errcheck,gosec
-			} else {
-				return conn, nil
+				return nil, err
 			}
+			return conn, nil
 		}
-		// No direct transport — fall through to route-based dial.
+		// No direct transport (dial failed) — fall through to route-based dial.
 	}
 
 	var opts *router.DialOptions


### PR DESCRIPTION
Two independent defects (surfaced by tracking a live goroutine climb to `skyobject.newIndexStat`, then investigating) that together **un-skip the #3047 regression test**.

1. **indexStat.secondLoop goroutine leak:** `Container.Close()` closed Cache + db but **never the embedded Index** — and since `Container` defines its own `Close`, the embedded `Index.Close` (which stops `indexStat.secondLoop`) was *shadowed* and never ran. Every Container teardown leaked one goroutine (**proven: N close cycles → N leaked goroutines**). Now calls `c.Index.Close()`.
2. **Node.Close deadlock:** `fillHead.request` sent on the unbuffered `failureq`/`successq` with no close-guard. On shutdown the only receiver (`handle`) stops draining once it takes `<-closeq`, so an in-flight send blocks forever → deferred `await.Done()` never fires → `nodeHead.close`'s `await.Wait()` hangs. Guard each send with `<-f.closeq`.

The #3047 leak test was `t.Skip`-ped because of #2's hang; **with both fixed it's re-enabled and passes `-race` in 7s** — restoring the coverage gap noted in #3061. Found via live goroutine-trend monitoring.