### PR TITLE
fix(router): tear down remote rules on partial route-setup failure

### DIFF
--- a/pkg/router/routerclient.go
+++ b/pkg/router/routerclient.go
@@ -112,6 +112,16 @@ func (c *Client) AddIntermediaryRules(ctx context.Context, rules []routing.Rule)
 	return ok, err
 }
 
+// DelRules removes the routing rules identified by routeIDs from the remote
+// router. Used by CreateRouteGroup's partial-failure cleanup to tear down the
+// rules it installed on this hop before returning an error, instead of
+// orphaning them for the ~10-min keepalive GC.
+func (c *Client) DelRules(ctx context.Context, routeIDs []routing.RouteID) (ok bool, err error) {
+	const method = "DelRules"
+	err = c.call(ctx, method, routeIDs, &ok)
+	return ok, err
+}
+
 // ReserveIDs reserves n IDs and returns them.
 func (c *Client) ReserveIDs(ctx context.Context, n uint8) (rtIDs []routing.RouteID, err error) {
 	const method = "ReserveIDs"

--- a/pkg/router/rpc_gateway.go
+++ b/pkg/router/rpc_gateway.go
@@ -62,3 +62,16 @@ func (r *RPCGateway) ReserveIDs(n uint8, routeIDs *[]routing.RouteID) error {
 
 	return nil
 }
+
+// DelRules removes the routing rules identified by routeIDs from this router.
+// The setup-node calls this to tear down rules it installed on intermediary /
+// edge hops when a later step of route-group setup fails, so a partially built
+// route does not orphan rules (each orphan pins its NextTransportID against
+// transport teardown until the ~10-min keepalive GC reaps it). Router.DelRules
+// logs per-id "rule not found" internally and cannot fail, so this is
+// best-effort by contract and always reports ok.
+func (r *RPCGateway) DelRules(routeIDs []routing.RouteID, ok *bool) error {
+	r.router.DelRules(routeIDs)
+	*ok = true
+	return nil
+}

--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/rpc"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -511,6 +512,18 @@ func CreateRouteGroup(ctx context.Context, dialer network.Dialer, pool *ClientPo
 		}
 	}()
 
+	// Track rules as they are installed on remote hops so a later failure can
+	// tear them down instead of orphaning them (each orphan pins its
+	// NextTransportID against teardown until the ~10-min keepalive GC). This
+	// defer is registered AFTER the rtIDR defer above, so by LIFO it runs
+	// FIRST — while the idReserver's per-PK clients are still live.
+	installed := newInstalledRules()
+	defer func() {
+		if err != nil {
+			installed.teardown(ctx, log, rtIDR)
+		}
+	}()
+
 	// Generate forward and reverse routes.
 	fwdRt, revRt := biRt.ForwardAndReverse()
 	srcPK := biRt.Desc.Src()
@@ -528,8 +541,9 @@ func CreateRouteGroup(ctx context.Context, dialer network.Dialer, pool *ClientPo
 	log.Infof("Generated routing rules:\nInitiating edge: %v\nResponding edge: %v\nIntermediaries: %v",
 		initEdge.String(), respEdge.String(), interRules.String())
 
-	// Broadcast intermediary rules to intermediary routers.
-	if err := BroadcastIntermediaryRules(ctx, log, rtIDR, interRules); err != nil {
+	// Broadcast intermediary rules to intermediary routers. Pass the tracker
+	// so each hop's successful install is recorded for teardown-on-failure.
+	if err = BroadcastIntermediaryRules(ctx, log, rtIDR, interRules, installed); err != nil {
 		return routing.EdgeRules{}, err
 	}
 
@@ -539,6 +553,9 @@ func CreateRouteGroup(ctx context.Context, dialer network.Dialer, pool *ClientPo
 	if err != nil || !ok {
 		return routing.EdgeRules{}, fmt.Errorf("failed to broadcast rules to destination router: %v", err)
 	}
+	// Destination edge installed successfully — track it too, so any failure
+	// step added below this point still tears it down.
+	installed.add(biRt.Desc.DstPK(), respEdge.Forward, respEdge.Reverse)
 
 	// Return rules to initiating router.
 	return initEdge, nil
@@ -630,7 +647,10 @@ func GenerateRules(idR IDReserver, routes []routing.Route) (fwdRules, revRules, 
 }
 
 // BroadcastIntermediaryRules broadcasts routing rules to the intermediary routers.
-func BroadcastIntermediaryRules(ctx context.Context, log logrus.FieldLogger, rtIDR IDReserver, interRules RulesMap) (err error) {
+// On each hop's successful install it records the installed RouteIDs into
+// `installed` (when non-nil) so a later setup failure can tear them down
+// instead of orphaning them.
+func BroadcastIntermediaryRules(ctx context.Context, log logrus.FieldLogger, rtIDR IDReserver, interRules RulesMap, installed *installedRules) (err error) {
 	log.WithField("intermediary_routers", len(interRules)).Debug("Broadcasting intermediary rules...")
 	defer func() {
 		if err != nil {
@@ -659,10 +679,86 @@ func BroadcastIntermediaryRules(ctx context.Context, log logrus.FieldLogger, rtI
 			// healthy intermediaries mid-broadcast and leaving a half-installed
 			// route. firstError below waits for all N and returns the first
 			// error; each call is bounded by its own per-call rpcDeadline.
-			_, err := rtIDR.Client(pk).AddIntermediaryRules(ctx, rules)
+			ok, err := rtIDR.Client(pk).AddIntermediaryRules(ctx, rules)
+			if err == nil && ok && installed != nil {
+				installed.add(pk, rules...)
+			}
 			errCh <- err
 		}(pk, rules)
 	}
 
 	return firstError(len(interRules), errCh)
+}
+
+// installedRules tracks, per remote hop PK, the RouteIDs that CreateRouteGroup
+// has successfully installed, so a later setup failure can tear them down
+// instead of orphaning them. The RouteID stored per rule is its KeyRouteID —
+// the key under which the installing router stores the rule and therefore the
+// exact ID its DelRules expects.
+type installedRules struct {
+	mu sync.Mutex
+	m  map[cipher.PubKey][]routing.RouteID
+}
+
+func newInstalledRules() *installedRules {
+	return &installedRules{m: make(map[cipher.PubKey][]routing.RouteID)}
+}
+
+func (ir *installedRules) add(pk cipher.PubKey, rules ...routing.Rule) {
+	if len(rules) == 0 {
+		return
+	}
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	for _, rule := range rules {
+		ir.m[pk] = append(ir.m[pk], rule.KeyRouteID())
+	}
+}
+
+// teardown best-effort deletes every tracked rule from its hop, reusing the
+// idReserver's live per-PK clients. It runs only on the error path. If the
+// inbound ctx is already done (the common trigger — setup failed on a
+// deadline), it derives a fresh bounded context so the teardown RPCs still get
+// sent: cleanup must not be skipped just because the request that necessitated
+// it timed out. Errors are logged, never returned — this is cleanup.
+func (ir *installedRules) teardown(ctx context.Context, log logrus.FieldLogger, rtIDR IDReserver) {
+	ir.mu.Lock()
+	snapshot := make(map[cipher.PubKey][]routing.RouteID, len(ir.m))
+	for pk, ids := range ir.m {
+		if len(ids) > 0 {
+			snapshot[pk] = ids
+		}
+	}
+	ir.mu.Unlock()
+	if len(snapshot) == 0 {
+		return
+	}
+
+	tctx := ctx
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		tctx, cancel = context.WithTimeout(context.Background(), rpcDeadline)
+		defer cancel()
+	}
+
+	var wg sync.WaitGroup
+	for pk, ids := range snapshot {
+		client := rtIDR.Client(pk)
+		if client == nil {
+			log.WithField("hop", pk).Debug("orphan-rule teardown: no live client for hop; skipping")
+			continue
+		}
+		wg.Add(1)
+		go func(pk cipher.PubKey, ids []routing.RouteID, client *Client) {
+			defer wg.Done()
+			if _, err := client.DelRules(tctx, ids); err != nil {
+				log.WithError(err).WithField("hop", pk).
+					Debug("orphan-rule teardown: DelRules failed (rules will GC in ~10m)")
+				return
+			}
+			log.WithField("hop", pk).WithField("count", len(ids)).
+				Debug("orphan-rule teardown: deleted installed rules")
+		}(pk, ids, client)
+	}
+	wg.Wait()
 }

--- a/pkg/router/setupnode_teardown_test.go
+++ b/pkg/router/setupnode_teardown_test.go
@@ -1,0 +1,93 @@
+// Package router pkg/router/setupnode_teardown_test.go
+package router
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// delRulesRecorder is a mock router RPCGateway that records the KeyRouteIDs it
+// is asked to install (AddIntermediaryRules) and the RouteIDs it is asked to
+// delete (DelRules), so a test can assert that a setup teardown removes exactly
+// what it installed — i.e. leaves no orphan rules and over-deletes nothing.
+type delRulesRecorder struct {
+	mu      sync.Mutex
+	added   []routing.RouteID
+	deleted []routing.RouteID
+}
+
+func (g *delRulesRecorder) AddIntermediaryRules(rules []routing.Rule, ok *bool) error {
+	g.mu.Lock()
+	for _, r := range rules {
+		g.added = append(g.added, r.KeyRouteID())
+	}
+	g.mu.Unlock()
+	*ok = true
+	return nil
+}
+
+func (g *delRulesRecorder) DelRules(routeIDs []routing.RouteID, ok *bool) error {
+	g.mu.Lock()
+	g.deleted = append(g.deleted, routeIDs...)
+	g.mu.Unlock()
+	*ok = true
+	return nil
+}
+
+func newRecorderReserver(t *testing.T, n int) (IDReserver, RulesMap, map[cipher.PubKey]*delRulesRecorder) {
+	pks := randPKs(n)
+	gateways := make(map[cipher.PubKey]interface{}, len(pks))
+	recorders := make(map[cipher.PubKey]*delRulesRecorder, len(pks))
+	for _, pk := range pks {
+		g := &delRulesRecorder{}
+		gateways[pk] = g
+		recorders[pk] = g
+	}
+	return newMockReserver(t, gateways), randRulesMap(pks), recorders
+}
+
+// TestInstalledRulesTeardownDeletesEverythingInstalled verifies the
+// orphan-rule fix: rules recorded by BroadcastIntermediaryRules are torn down
+// exactly by installedRules.teardown — every installed rule is deleted, and no
+// rule that was not installed is deleted.
+func TestInstalledRulesTeardownDeletesEverythingInstalled(t *testing.T) {
+	rtIDR, rules, recorders := newRecorderReserver(t, 3)
+	installed := newInstalledRules()
+	ctx := context.Background()
+
+	require.NoError(t, BroadcastIntermediaryRules(ctx, logrus.New(), rtIDR, rules, installed))
+	installed.teardown(ctx, logrus.New(), rtIDR)
+
+	for pk, g := range recorders {
+		g.mu.Lock()
+		assert.NotEmpty(t, g.added, "hop %s should have installed rules", pk)
+		assert.ElementsMatch(t, g.added, g.deleted,
+			"hop %s: every installed rule must be torn down with no orphans and no over-deletion", pk)
+		g.mu.Unlock()
+	}
+}
+
+// TestInstalledRulesNoTeardownOnSuccess is the negative control: the success
+// path records the installed set but never calls teardown, so nothing is
+// deleted.
+func TestInstalledRulesNoTeardownOnSuccess(t *testing.T) {
+	rtIDR, rules, recorders := newRecorderReserver(t, 2)
+	installed := newInstalledRules()
+
+	require.NoError(t, BroadcastIntermediaryRules(context.Background(), logrus.New(), rtIDR, rules, installed))
+	// success path: teardown is intentionally NOT called.
+
+	for pk, g := range recorders {
+		g.mu.Lock()
+		assert.Empty(t, g.deleted, "hop %s: nothing should be deleted on the success path", pk)
+		g.mu.Unlock()
+	}
+}

--- a/pkg/router/setupnode_test.go
+++ b/pkg/router/setupnode_test.go
@@ -308,7 +308,7 @@ func TestBroadcastIntermediaryRules(t *testing.T) {
 			defer cancel()
 
 			// act
-			err := BroadcastIntermediaryRules(ctx, logrus.New(), rtIDR, rules)
+			err := BroadcastIntermediaryRules(ctx, logrus.New(), rtIDR, rules, nil)
 
 			// assert
 			if tc.failingRouters > 0 {


### PR DESCRIPTION
The setup-node↔router RPC surface had **no rule-delete method**, so when `CreateRouteGroup` failed partway (a hop errors after others succeeded), the succeeded hops' `IntermediaryForwardRule`s **orphaned** — self-healing in ~10 min via keepalive GC, but the exclude-and-retry loop (≤6 attempts) and mux fan-out multiply them, each pinning its `NextTransportID` against teardown → "rule not found" noise + route-table bloat on popular intermediates.

- Add `DelRules` RPC to `RPCGateway` (remote `Router.DelRules` already exists).
- Add `(*Client).DelRules`.
- Track per-hop installed `RouteID`s (KeyRouteID) as broadcasts succeed; on any later error, best-effort fan-out `DelRules` to confirmed hops, reusing the idReserver's live per-PK clients. Teardown defer registered **after** the rtIDR-close defer (LIFO → runs first, clients still live); derives a fresh bounded ctx when the inbound one is already done so cleanup still lands.

Scoped to the DMSG path (cascade installs rules differently — out of scope). Retry loop unchanged: each failed attempt tears down its own rules. +tests (`-race`) asserting a partial-failure setup leaves **no orphan rules**. Found by a setup-node rule-lifecycle audit.