### PR TITLE
deployment: re-key relay + resync embedded dmsg servers to all_servers + fix gen path

### DIFF
--- a/deployment/cmd/gen/main.go
+++ b/deployment/cmd/gen/main.go
@@ -78,11 +78,24 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Resolve paths relative to the generator's own location so the
-	// generator works whether invoked via `go generate` (cwd =
-	// deployment/) or `go run .` from this dir.
-	jsonPath := filepath.Join(wd, "../../services-config.json")
-	outPath := filepath.Join(wd, "../../data_static_js.go")
+	// Resolve services-config.json robustly across both invocation
+	// styles: `go generate ./deployment/` runs with cwd = deployment/,
+	// while `go run .` runs with cwd = deployment/cmd/gen/. Probe each
+	// candidate base and use the one that has the file. (A previous
+	// fixed "../../" assumed the cmd/gen cwd and broke under go generate,
+	// overshooting to the repo parent.)
+	var base string
+	for _, rel := range []string{".", "../.."} {
+		if _, statErr := os.Stat(filepath.Join(wd, rel, "services-config.json")); statErr == nil {
+			base = filepath.Join(wd, rel)
+			break
+		}
+	}
+	if base == "" {
+		log.Fatalf("services-config.json not found relative to cwd %s", wd)
+	}
+	jsonPath := filepath.Join(base, "services-config.json")
+	outPath := filepath.Join(base, "data_static_js.go")
 
 	raw, err := os.ReadFile(jsonPath) //nolint:gosec // generator reads a known repo-relative input
 	if err != nil {

--- a/deployment/data_static_js.go
+++ b/deployment/data_static_js.go
@@ -66,9 +66,15 @@ var prodData = Services{
 		{Static: "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13", Server: struct {
 			Address string `json:"address"`
 		}{Address: "45.79.213.251:30087"}},
-		{Static: "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0", Server: struct {
+		{Static: "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7", Server: struct {
 			Address string `json:"address"`
-		}{Address: "143.42.59.213:30081"}},
+		}{Address: "172.105.179.5:30085"}},
+		{Static: "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7", Server: struct {
+			Address string `json:"address"`
+		}{Address: "172.104.166.8:30084"}},
+		{Static: "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf", Server: struct {
+			Address string `json:"address"`
+		}{Address: "172.235.168.146:30081"}},
 		{Static: "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7", Server: struct {
 			Address string `json:"address"`
 		}{Address: "70.121.13.123:9083"}},
@@ -135,9 +141,15 @@ var testData = Services{
 		{Static: "0371ab4bcff7b121f4b91f6856d6740c6f9dc1fe716977850aeb5d84378b300a13", Server: struct {
 			Address string `json:"address"`
 		}{Address: "45.79.213.251:30087"}},
-		{Static: "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0", Server: struct {
+		{Static: "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7", Server: struct {
 			Address string `json:"address"`
-		}{Address: "143.42.59.213:30081"}},
+		}{Address: "172.105.179.5:30085"}},
+		{Static: "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7", Server: struct {
+			Address string `json:"address"`
+		}{Address: "172.104.166.8:30084"}},
+		{Static: "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf", Server: struct {
+			Address string `json:"address"`
+		}{Address: "172.235.168.146:30081"}},
 		{Static: "0326978f5a53aff537dbb47fed58b1f123af3b00132d365f1309a14db4168dcff7", Server: struct {
 			Address string `json:"address"`
 		}{Address: "70.121.13.123:9083"}},

--- a/deployment/services-config.json
+++ b/deployment/services-config.json
@@ -53,9 +53,21 @@
         }
       },
       {
-        "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
+        "static": "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7",
         "server": {
-          "address": "143.42.59.213:30081"
+          "address": "172.105.179.5:30085"
+        }
+      },
+      {
+        "static": "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7",
+        "server": {
+          "address": "172.104.166.8:30084"
+        }
+      },
+      {
+        "static": "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf",
+        "server": {
+          "address": "172.235.168.146:30081"
         }
       },
       {
@@ -140,9 +152,21 @@
         }
       },
       {
-        "static": "02a49bc0aa1b5b78f638e9189be4ed095bac5d6839c828465a8350f80ac07629c0",
+        "static": "0255117bf8d4687dacd5f7ac4c241f008060f1972911552a5b67b76f0e7922f5c7",
         "server": {
-          "address": "143.42.59.213:30081"
+          "address": "172.105.179.5:30085"
+        }
+      },
+      {
+        "static": "02c483938539bd7820f72e48ed6056bab68e221e1108d23965a2903221495e4af7",
+        "server": {
+          "address": "172.104.166.8:30084"
+        }
+      },
+      {
+        "static": "03f57e7cf26c0764c5ab659a606add056ddf8bfad4f5bc7e8613cad05e5f228adf",
+        "server": {
+          "address": "172.235.168.146:30081"
         }
       },
       {


### PR DESCRIPTION
A dmsg relay was running the **same keypair (`02a49bc0`) on two boxes** (`172.235.168.146` and `143.42.59.213`), so they clobbered each other's discovery entry — the entry flip-flopped between the two IPs, splitting clients across two relays that can't see each other's sessions (intermittent dmsg-unreachable failures).

- Re-key the `172.235.168.146` relay to `03f57e7c`; drop the decommissioned `02a49bc0`/`143.42.59.213`.
- Resync embedded `dmsg_servers` to live `all_servers`: add `0255117b`/`172.105.179.5:30085` + `02c48393`/`172.104.166.8:30084` (had drifted out). Now an exact 8-server match.
- Fix `deployment/cmd/gen` path: hardcoded `../../` overshot to the repo parent under `go generate ./deployment/`; now probes both bases. Regenerated `data_static_js.go`; js/wasm + native build green.