### PR TITLE
feat(dmsgserver): fall back to embedded deployment config when no block is set

### DIFF
--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/skycoin/skycoin/src/util/logging"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -169,7 +170,16 @@ func (c *Config) NormalizedDeployments() []Deployment {
 	case c.Discovery != "" || c.DiscoveryDmsg != "":
 		src = []Deployment{{Discovery: c.Discovery, DiscoveryDmsg: c.DiscoveryDmsg}}
 	default:
-		return nil
+		// No explicit dmsg/discovery block in the config: fall back to
+		// the embedded deployment config so a dmsg server needs no
+		// `config gen` step to track deployment changes — the binary
+		// carries the current discovery + servers. The explicit cases
+		// above stay authoritative.
+		src = []Deployment{{
+			Discovery:     deployment.Prod.DmsgDiscovery,
+			DiscoveryDmsg: deployment.Prod.DmsgDiscoveryDmsg,
+			Servers:       deployment.Prod.ToDiscEntries(),
+		}}
 	}
 	out := make([]Deployment, len(src))
 	for i, d := range src {

--- a/pkg/dmsg/dmsgserver/config_fallback_test.go
+++ b/pkg/dmsg/dmsgserver/config_fallback_test.go
@@ -1,0 +1,38 @@
+// Package dmsgserver pkg/dmsg/dmsgserver/config_fallback_test.go
+package dmsgserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/deployment"
+)
+
+// A config with no dmsg / discovery / servers block falls back to the embedded
+// deployment, so a dmsg server needs no `config gen` step to track deployment
+// changes — the binary carries the current discovery + servers.
+func TestNormalizedDeployments_EmbeddedFallback(t *testing.T) {
+	cfg := &Config{PublicAddress: "1.2.3.4:8081"}
+
+	deps := cfg.NormalizedDeployments()
+	require.Len(t, deps, 1)
+	assert.Equal(t, deployment.Prod.DmsgDiscovery, deps[0].Discovery)
+	assert.Equal(t, deployment.Prod.DmsgDiscoveryDmsg, deps[0].DiscoveryDmsg)
+	assert.NotEmpty(t, deps[0].Servers, "fallback should carry the embedded dmsg servers")
+	assert.Equal(t, "1.2.3.4:8081", deps[0].AdvertisedAddress,
+		"top-level PublicAddress folds into AdvertisedAddress")
+}
+
+// An explicit discovery field stays authoritative — the embedded fallback is
+// NOT used when the config specifies its own deployment.
+func TestNormalizedDeployments_ExplicitAuthoritative(t *testing.T) {
+	cfg := &Config{Discovery: "http://my-disc.example"}
+
+	deps := cfg.NormalizedDeployments()
+	require.Len(t, deps, 1)
+	assert.Equal(t, "http://my-disc.example", deps[0].Discovery)
+	assert.NotEqual(t, deployment.Prod.DmsgDiscovery, deps[0].Discovery)
+	assert.Empty(t, deps[0].Servers, "an explicit block carries only what it specifies")
+}


### PR DESCRIPTION
A dmsg server config that omits the `dmsg` / `discovery` / `servers` block now falls back to the embedded `deployment.Prod` (its discovery + `dmsg_servers`), so a dmsg server needs **no `config gen` step** to track deployment changes — the binary carries the current config.

Injected in `NormalizedDeployments()`'s `default` case so the existing `AdvertisedAddress` fold applies automatically. An **explicit block stays authoritative** (the prior cases are checked first). +tests (fallback + explicit-authoritative).