### PR TITLE
feat(dmsg): non-public server reachability via signed peer announcements

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -67,6 +67,17 @@ type EntityCommon struct {
 	// Only set on Server entities; nil for clients.
 	peerSessionsFunc func() []*SessionCommon
 
+	// acceptPeerAnnouncements, peerAnnounceAllowedFunc and
+	// promoteToPeerFunc support inbound peer announcements: a non-public
+	// server (not in discovery, never dialed by anyone) announcing itself
+	// as a forwardable peer over the link it dials out. Only set on
+	// Server entities that opt in. promoteToPeerFunc files the announced
+	// inbound session in the server's peer set so the reverse path can
+	// forward client streams to it.
+	acceptPeerAnnouncements bool
+	peerAnnounceAllowedFunc func(remotePK cipher.PubKey) bool
+	promoteToPeerFunc       func(remotePK cipher.PubKey, ses *SessionCommon)
+
 	// lastPushedSrvPKs is the set of delegated server PKs most recently
 	// pushed to the dmsg discovery. It is used by updateClientEntry to
 	// short-circuit redundant GET/PUT round-trips when nothing has
@@ -221,6 +232,24 @@ func (c *EntityCommon) peerServerSessions() []ServerSession {
 		sessions[i] = ServerSession{SessionCommon: ses}
 	}
 	return sessions
+}
+
+// peerAnnounceAllowed reports whether an inbound peer announcement from
+// remotePK should be honored (feature opted in + PK allowlisted).
+func (c *EntityCommon) peerAnnounceAllowed(remotePK cipher.PubKey) bool {
+	if c.peerAnnounceAllowedFunc == nil {
+		return false
+	}
+	return c.peerAnnounceAllowedFunc(remotePK)
+}
+
+// promoteToPeer files an announced inbound session in the server's peer
+// set so the reverse path can forward client streams to it. No-op when
+// the feature is not configured.
+func (c *EntityCommon) promoteToPeer(remotePK cipher.PubKey, ses *SessionCommon) {
+	if c.promoteToPeerFunc != nil {
+		c.promoteToPeerFunc(remotePK, ses)
+	}
 }
 
 // clientSession obtains a session as a client.

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -33,6 +33,20 @@ type ServerConfig struct {
 	UpdateInterval time.Duration
 	AuthPassphrase string
 	Peers          []PeerEntry
+
+	// AnnounceAsPeer makes this server send a signed PeerAnnounce on
+	// every outbound peer link it dials, asking the remote to treat
+	// this server as a forwardable peer. Used by a non-public server
+	// (not registered in discovery) so its clients become reachable
+	// inbound via the link it dialed out.
+	AnnounceAsPeer bool
+	// AcceptPeerAnnouncements lets this server honor inbound PeerAnnounce
+	// frames, filing the announcing session in its peer set so it
+	// forwards client streams back down that link. When AcceptedPeerPKs
+	// is non-empty it acts as an allowlist; empty means accept any
+	// announcer (an open relay surface — set deliberately).
+	AcceptPeerAnnouncements bool
+	AcceptedPeerPKs         []cipher.PubKey
 }
 
 // DefaultServerConfig returns the default server config.
@@ -78,6 +92,11 @@ type Server struct {
 	peerPKs        map[cipher.PubKey]struct{} // set of known peer server PKs
 	peerSessions   map[cipher.PubKey]*SessionCommon
 	peerSessionsMx sync.Mutex
+
+	// Inbound peer-announcement support (non-public servers).
+	announceAsPeer          bool
+	acceptPeerAnnouncements bool
+	acceptedPeerPKs         map[cipher.PubKey]struct{} // allowlist; empty = accept any
 }
 
 // GeoLookupFunc returns geolocation data for the given IP. Returns
@@ -140,6 +159,30 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 		}
 		return sessions
 	}
+
+	// Inbound peer-announcement support: a non-public server announces
+	// itself as a forwardable peer over its outbound links; an accepting
+	// server promotes the announced inbound session into peerSessions.
+	s.announceAsPeer = conf.AnnounceAsPeer
+	s.acceptPeerAnnouncements = conf.AcceptPeerAnnouncements
+	s.acceptedPeerPKs = make(map[cipher.PubKey]struct{}, len(conf.AcceptedPeerPKs))
+	for _, pk := range conf.AcceptedPeerPKs {
+		s.acceptedPeerPKs[pk] = struct{}{}
+	}
+	s.EntityCommon.acceptPeerAnnouncements = conf.AcceptPeerAnnouncements
+	s.EntityCommon.peerAnnounceAllowedFunc = func(remotePK cipher.PubKey) bool {
+		if !s.acceptPeerAnnouncements {
+			return false
+		}
+		s.peerSessionsMx.Lock()
+		defer s.peerSessionsMx.Unlock()
+		if len(s.acceptedPeerPKs) == 0 {
+			return true // empty allowlist = accept any announcer
+		}
+		_, ok := s.acceptedPeerPKs[remotePK]
+		return ok
+	}
+	s.EntityCommon.promoteToPeerFunc = s.addAcceptedPeerSession
 
 	return s
 }
@@ -497,10 +540,36 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer PeerEntry) {
 		log.Info("Connected to peer server.")
 		bo = 5 * time.Second // reset backoff on success
 
-		// Block until the yamux session closes or context is done.
+		// Announce ourselves as a forwardable peer over this outbound
+		// link so a non-public server (not in discovery) becomes
+		// reachable inbound: the remote files this session in its peer
+		// set and forwards client streams back down it.
+		if s.announceAsPeer {
+			if aErr := s.sendPeerAnnounce(ses); aErr != nil {
+				log.WithError(aErr).Warn("Failed to announce as peer.")
+			} else {
+				log.Info("Announced as forwardable peer.")
+			}
+		}
+
+		// Serve the outbound peer session so forwarded streams arriving
+		// on it (the reverse path: the remote pushing a client stream
+		// back down this link to one of our local clients) are accepted
+		// and bridged. Without this the outbound link is send-only and
+		// the reverse path cannot be received. Serve returns when the
+		// session closes, which then triggers a reconnect.
+		srvSes := ServerSession{SessionCommon: ses, m: s.m}
+		serveDone := make(chan struct{})
+		go func() {
+			srvSes.Serve()
+			close(serveDone)
+		}()
+
+		// Block until the session closes, the context is done, or shutdown.
 		select {
 		case <-ctx.Done():
 		case <-s.done:
+		case <-serveDone:
 		}
 
 		// Clean up.
@@ -519,6 +588,56 @@ func (s *Server) isPeerPK(pk cipher.PubKey) bool {
 	_, ok := s.peerPKs[pk]
 	s.peerSessionsMx.Unlock()
 	return ok
+}
+
+// sendPeerAnnounce opens a stream on the given (outbound) peer session,
+// sends a signed PeerAnnounce, and waits for the remote's ack. Used on
+// outbound peer links when AnnounceAsPeer is set, so a non-public server
+// becomes reachable inbound.
+func (s *Server) sendPeerAnnounce(ses *SessionCommon) error {
+	ann := &PeerAnnounce{Timestamp: time.Now().UnixNano(), SrcPK: s.pk}
+	obj, err := MakeSignedPeerAnnounce(ann, s.sk)
+	if err != nil {
+		return err
+	}
+	// Peer sessions are always yamux (maintainPeerConnection never uses smux).
+	str, err := ses.sm.yamux.OpenStream()
+	if err != nil {
+		return err
+	}
+	defer str.Close()                                     //nolint:errcheck,gosec
+	_ = str.SetDeadline(time.Now().Add(HandshakeTimeout)) //nolint:errcheck
+	if err := ses.writeObject(str, obj); err != nil {
+		return err
+	}
+	respObj, err := ses.readObject(str)
+	if err != nil {
+		return err
+	}
+	resp, err := respObj.ObtainStreamResponse()
+	if err != nil {
+		return err
+	}
+	if !resp.Accepted {
+		return errors.New("peer announcement not accepted by remote")
+	}
+	return nil
+}
+
+// addAcceptedPeerSession files an announced inbound session as a
+// forwardable peer: marks it isPeer, records the PK in peerPKs (so a
+// reconnect classifies consistently), and inserts it into peerSessions
+// so forwardViaPeer routes client streams down it. The reverse-path
+// enabler for non-public servers; called via the promoteToPeerFunc hook
+// from serveStream when an inbound announcement is accepted.
+func (s *Server) addAcceptedPeerSession(remotePK cipher.PubKey, ses *SessionCommon) {
+	s.peerSessionsMx.Lock()
+	ses.isPeer = true
+	s.peerPKs[remotePK] = struct{}{}
+	s.peerSessions[remotePK] = ses
+	s.peerSessionsMx.Unlock()
+	s.log.WithField("peer_pk", remotePK).
+		Info("Accepted inbound peer announcement; session is now forwardable.")
 }
 
 func (s *Server) handleSession(conn net.Conn) {
@@ -590,6 +709,20 @@ func (s *Server) handleSession(conn net.Conn) {
 	// (replacing and closing any stale predecessor), so always serve it.
 	s.setSession(ctx, dSes.SessionCommon)
 	dSes.Serve()
+
+	// If this inbound session was promoted to a forwardable peer (an
+	// accepted PeerAnnounce from a non-public server), drop it from the
+	// peer set on close — identity-checked so a fresh reconnect that
+	// already replaced us is not evicted. A statically-configured peer's
+	// inbound session is isPeer too but is NOT in peerSessions (only the
+	// outbound dial is), so the identity check makes this a no-op there.
+	if dSes.isPeer {
+		s.peerSessionsMx.Lock()
+		if s.peerSessions[dSes.RemotePK()] == dSes.SessionCommon {
+			delete(s.peerSessions, dSes.RemotePK())
+		}
+		s.peerSessionsMx.Unlock()
+	}
 
 	// Identity-checked: only remove the map entry if it is still THIS
 	// session. setSession may have already replaced us with a fresh

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -165,39 +165,54 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 	}
 
 	// Not a ping — the 2 bytes are the length prefix of a normal object.
-	// Pass them through to readRequest via a prefixed reader.
+	// Pass them through via a prefixed reader.
 	prefixedReader := io.MultiReader(bytes.NewReader(header), yStr)
 
-	readRequest := func() (StreamRequest, error) {
-		obj, err := ss.readObject(prefixedReader)
-		if err != nil {
-			return StreamRequest{}, err
-		}
-		req, err := obj.ObtainStreamRequest()
-		if err != nil {
-			return StreamRequest{}, err
-		}
-		// Timestamp validation: we pass 0 because concurrent streams from
-		// the same client can have timestamps that arrive out of order at
-		// the server. Strict monotonic enforcement would reject valid
-		// concurrent requests. The noise encryption layer already prevents
-		// replay at the session level via nonce tracking.
-		if err := req.Verify(0); err != nil {
-			return StreamRequest{}, err
-		}
-		// For peer sessions, the SrcAddr.PK is the original client, not the
-		// peer server. The request signature is still verified above.
-		if !ss.isPeer && req.SrcAddr.PK != ss.rPK {
-			return StreamRequest{}, ErrReqInvalidSrcPK
-		}
-		return req, nil
-	}
-
-	// Read request.
-	req, err := readRequest()
+	obj, err := ss.readObject(prefixedReader)
 	if err != nil {
 		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
 		return err
+	}
+
+	// Inbound peer announcement: when this server opts in, a dialing
+	// server's first stream may carry a signed PeerAnnounce that promotes
+	// this session to a forwardable peer — the reverse-path enabler for a
+	// non-public server. Checked before the StreamRequest path; a normal
+	// request decoded as an announce has a null/foreign SrcPK and fails
+	// Verify, so it falls through harmlessly.
+	if ss.entity.acceptPeerAnnouncements && !ss.isPeer {
+		if ann, aErr := obj.ObtainPeerAnnounce(); aErr == nil {
+			if ann.Verify(ss.rPK) == nil && ss.entity.peerAnnounceAllowed(ss.rPK) {
+				ss.entity.promoteToPeer(ss.rPK, ss.SessionCommon)
+				resp := StreamResponse{ReqHash: obj.Hash(), Accepted: true}
+				ackObj, mErr := MakeSignedStreamResponse(&resp, ss.entity.LocalSK())
+				if mErr != nil {
+					return mErr
+				}
+				return ss.writeObject(yStr, ackObj)
+			}
+		}
+	}
+
+	req, err := obj.ObtainStreamRequest()
+	if err != nil {
+		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
+		return err
+	}
+	// Timestamp validation: we pass 0 because concurrent streams from
+	// the same client can have timestamps that arrive out of order at
+	// the server. Strict monotonic enforcement would reject valid
+	// concurrent requests. The noise encryption layer already prevents
+	// replay at the session level via nonce tracking.
+	if err := req.Verify(0); err != nil {
+		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
+		return err
+	}
+	// For peer sessions, the SrcAddr.PK is the original client, not the
+	// peer server. The request signature is still verified above.
+	if !ss.isPeer && req.SrcAddr.PK != ss.rPK {
+		ss.m.RecordStream(metrics.DeltaFailed) // record failed stream
+		return ErrReqInvalidSrcPK
 	}
 
 	log = log.

--- a/pkg/dmsg/dmsg/types.go
+++ b/pkg/dmsg/dmsg/types.go
@@ -330,3 +330,63 @@ func SignBytes(b []byte, sk cipher.SecKey) (cipher.Sig, error) {
 	}
 	return sig, nil
 }
+
+// PeerAnnounce is sent by a dialing dmsg server on its first stream
+// after connecting to another server, declaring "I am a server-peer;
+// you may forward client streams to me over this connection." It lets a
+// non-public server (not in the discovery, never dialed by anyone)
+// become reachable inbound: the accepting server, if it opts in, files
+// the announced session in its peer set, so streams destined for the
+// announcer's clients are forwarded back down the link the announcer
+// dialed out. Signed by the announcer's SK and bound to the noise-
+// authenticated session remote (Verify enforces SrcPK == session remote
+// PK), so it cannot be spoofed onto someone else's session.
+type PeerAnnounce struct {
+	Timestamp int64
+	SrcPK     cipher.PubKey // the announcing server's PK
+
+	raw SignedObject `enc:"-"` // back reference.
+}
+
+// MakeSignedPeerAnnounce encodes and signs a PeerAnnounce into a SignedObject.
+func MakeSignedPeerAnnounce(a *PeerAnnounce, sk cipher.SecKey) (SignedObject, error) {
+	obj, err := encodeGob(a)
+	if err != nil {
+		return nil, fmt.Errorf("dmsg: encode peer announce: %w", err)
+	}
+	sig, err := SignBytes(obj, sk)
+	if err != nil {
+		return nil, err
+	}
+	signedObj := append(sig[:], obj...)
+	a.raw = signedObj
+	return signedObj, nil
+}
+
+// ObtainPeerAnnounce obtains a PeerAnnounce from the encoded object bytes.
+func (so SignedObject) ObtainPeerAnnounce() (PeerAnnounce, error) {
+	if !so.Valid() {
+		return PeerAnnounce{}, ErrSignedObjectInvalid
+	}
+	var a PeerAnnounce
+	err := decodeGob(&a, so[sigLen:])
+	a.raw = so
+	return a, err
+}
+
+// Verify checks the PeerAnnounce: SrcPK must be non-null, must equal the
+// session's noise-authenticated remote PK (so an announce can only claim
+// the PK that handshook this session — anti-spoof), and the signature
+// must be valid for SrcPK.
+func (a PeerAnnounce) Verify(remoteStatic cipher.PubKey) error {
+	if a.SrcPK.Null() {
+		return ErrReqInvalidSrcPK
+	}
+	if a.SrcPK != remoteStatic {
+		return ErrReqInvalidSrcPK
+	}
+	if err := cipher.VerifyPubKeySignedPayload(a.SrcPK, a.raw.Sig(), a.raw.Object()); err != nil {
+		return ErrReqInvalidSig.Wrap(err)
+	}
+	return nil
+}

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -129,6 +129,17 @@ type Config struct {
 	MaxSessions      int           `json:"max_sessions"`
 	Peers            []PeerConfig  `json:"peers,omitempty"`
 	EnableRouteSetup bool          `json:"enable_route_setup,omitempty"`
+
+	// AnnounceAsPeer makes this (typically non-public) server announce
+	// itself as a forwardable peer over every outbound peer link it
+	// dials, so its clients become reachable inbound without it being
+	// registered in the discovery. AcceptPeerAnnouncements lets a
+	// (typically public) server honor such announcements, filing the
+	// announcing session in its peer set; AcceptedPeerPKs, when non-empty,
+	// restricts which announcers are honored (allowlist).
+	AnnounceAsPeer          bool            `json:"announce_as_peer,omitempty"`
+	AcceptPeerAnnouncements bool            `json:"accept_peer_announcements,omitempty"`
+	AcceptedPeerPKs         []cipher.PubKey `json:"accepted_peer_pks,omitempty"`
 }
 
 // GenerateDefaultConfig generate default config for dmsg-server

--- a/pkg/dmsg/dmsgtest/mesh_test.go
+++ b/pkg/dmsg/dmsgtest/mesh_test.go
@@ -198,3 +198,183 @@ func TestServerMesh_CrossServerDial(t *testing.T) {
 	srvB.Close()
 	srvWg.Wait()
 }
+
+// nonPublicReverseSetup stands up a public server S_pub (AcceptPeerAnnouncements
+// = accept) and a non-public server S_priv that dials S_pub and announces
+// itself as a forwardable peer; S_priv is NOT registered in the public
+// discovery. It then connects client A (reachable only via S_priv) and client B
+// (on S_pub), and attempts B's dial of A. The dial can only succeed via the
+// announced reverse-forward path. Returns B's dial result so callers can assert
+// both the gate-on (success) and gate-off (failure) behavior.
+func nonPublicReverseSetup(t *testing.T, ctx context.Context, accept bool) (streamB *dmsg.Stream, accA func() (*dmsg.Stream, error), cleanup func(), dialErr error) {
+	t.Helper()
+
+	// Public discovery — only S_pub registers here.
+	sharedDC := disc.NewMock(0)
+
+	pkPub, skPub := cipher.GenerateKeyPair()
+	lisPub, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+	pkPriv, skPriv := cipher.GenerateKeyPair()
+
+	confPub := &dmsg.ServerConfig{
+		MaxSessions:             10,
+		UpdateInterval:          dmsg.DefaultUpdateInterval,
+		AcceptPeerAnnouncements: accept,
+		AcceptedPeerPKs:         []cipher.PubKey{pkPriv},
+	}
+
+	lisPriv, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+	privDC := disc.NewMock(0) // S_priv's own discovery, so its clients can find it
+	confPriv := &dmsg.ServerConfig{
+		MaxSessions:    10,
+		UpdateInterval: dmsg.DefaultUpdateInterval,
+		AnnounceAsPeer: true,
+		Peers:          []dmsg.PeerEntry{{PK: pkPub, Addr: lisPub.Addr().String()}},
+	}
+
+	srvPub := dmsg.NewServer(pkPub, skPub, sharedDC, confPub, nil)
+	srvPriv := dmsg.NewServer(pkPriv, skPriv, privDC, confPriv, nil)
+
+	var srvWg sync.WaitGroup
+	srvWg.Add(2)
+	go func() { defer srvWg.Done(); srvPub.Serve(lisPub, "") }()
+	go func() { defer srvWg.Done(); srvPriv.Serve(lisPriv, "") }()
+
+	select {
+	case <-srvPub.Ready():
+	case <-ctx.Done():
+		t.Fatal("S_pub not ready")
+	}
+	select {
+	case <-srvPriv.Ready():
+	case <-ctx.Done():
+		t.Fatal("S_priv not ready")
+	}
+
+	// The defining property: S_priv is NOT in the public discovery.
+	_, err = sharedDC.Entry(ctx, pkPriv)
+	require.Error(t, err, "S_priv must not be registered in the public discovery")
+
+	// Let the peer announcement complete over the outbound link.
+	time.Sleep(5 * time.Second)
+
+	// Client A — reachable only via S_priv.
+	dcA := disc.NewMock(0)
+	entryPriv, err := privDC.Entry(ctx, pkPriv)
+	require.NoError(t, err)
+	require.NoError(t, dcA.PostEntry(ctx, entryPriv))
+
+	pkA, skA := cipher.GenerateKeyPair()
+	clientA := dmsg.NewClient(pkA, skA, dcA, &dmsg.Config{MinSessions: 1})
+	go clientA.Serve(ctx)
+	select {
+	case <-clientA.Ready():
+	case <-ctx.Done():
+		t.Fatal("Client A not ready")
+	}
+
+	const port = uint16(200)
+	lisA, err := clientA.Listen(port)
+	require.NoError(t, err)
+
+	// Client B — on S_pub; must resolve A's entry (delegated server = S_priv).
+	dcB := disc.NewMock(0)
+	entryPub, err := sharedDC.Entry(ctx, pkPub)
+	require.NoError(t, err)
+	require.NoError(t, dcB.PostEntry(ctx, entryPub))
+	entryA, _ := dcA.Entry(ctx, pkA)
+	require.NoError(t, dcB.PostEntry(ctx, entryA))
+
+	pkB, skB := cipher.GenerateKeyPair()
+	clientB := dmsg.NewClient(pkB, skB, dcB, &dmsg.Config{MinSessions: 1})
+	go clientB.Serve(ctx)
+	select {
+	case <-clientB.Ready():
+	case <-ctx.Done():
+		t.Fatal("Client B not ready")
+	}
+
+	// B dials A — only possible via the announced reverse-forward path.
+	for attempt := 0; attempt < 3; attempt++ {
+		streamB, dialErr = clientB.DialStream(ctx, dmsg.Addr{PK: pkA, Port: port})
+		if dialErr == nil {
+			break
+		}
+		t.Logf("Reverse dial attempt %d: %v", attempt+1, dialErr)
+		time.Sleep(2 * time.Second)
+	}
+
+	accA = lisA.AcceptStream
+	cleanup = func() {
+		if streamB != nil {
+			streamB.Close()
+		}
+		lisA.Close()
+		clientA.Close()
+		clientB.Close()
+		srvPub.Close()
+		srvPriv.Close()
+		srvWg.Wait()
+	}
+	return streamB, accA, cleanup, dialErr
+}
+
+// TestNonPublicServer_ReverseDial verifies the inbound-peer-announcement
+// reverse path: a non-public server (NOT in the public discovery) dials a
+// public server and announces itself as a forwardable peer, after which a
+// client on the public server can dial a client reachable ONLY through the
+// non-public server, with full bidirectional transfer.
+func TestNonPublicServer_ReverseDial(t *testing.T) {
+	const timeout = 40 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	streamB, accA, cleanup, dialErr := nonPublicReverseSetup(t, ctx, true)
+	defer cleanup()
+
+	require.NoError(t, dialErr, "reverse dial must succeed when announcements are accepted")
+	require.NotNil(t, streamB)
+
+	connA, err := accA()
+	require.NoError(t, err)
+	defer connA.Close()
+
+	payload := cipher.RandByte(1024)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); _, wErr := streamB.Write(payload); assert.NoError(t, wErr) }()
+	recv := make([]byte, len(payload))
+	_, err = io.ReadFull(connA, recv)
+	require.NoError(t, err)
+	wg.Wait()
+	require.True(t, bytes.Equal(payload, recv), "data mismatch: B -> A")
+
+	wg.Add(1)
+	go func() { defer wg.Done(); _, wErr := connA.Write(payload); assert.NoError(t, wErr) }()
+	recv2 := make([]byte, len(payload))
+	_, err = io.ReadFull(streamB, recv2)
+	require.NoError(t, err)
+	wg.Wait()
+	require.True(t, bytes.Equal(payload, recv2), "data mismatch: A -> B")
+
+	t.Log("Non-public-server reverse-dial test passed.")
+}
+
+// TestNonPublicServer_ReverseDial_GateOff is the negative control: with
+// AcceptPeerAnnouncements disabled on the public server, the same reverse dial
+// must FAIL — proving it is the announcement gate (not the static-peer path)
+// that makes the non-public server's clients reachable inbound.
+func TestNonPublicServer_ReverseDial_GateOff(t *testing.T) {
+	const timeout = 40 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	streamB, _, cleanup, dialErr := nonPublicReverseSetup(t, ctx, false)
+	defer cleanup()
+
+	require.Error(t, dialErr, "reverse dial must fail when announcements are not accepted")
+	require.Nil(t, streamB)
+}

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -188,10 +188,13 @@ func (s *service) Run(ctx context.Context) error {
 	}
 
 	srvConf := dmsg.ServerConfig{
-		MaxSessions:    cfg.MaxSessions,
-		UpdateInterval: cfg.UpdateInterval,
-		AuthPassphrase: s.cfg.AuthPassphrase,
-		Peers:          peers,
+		MaxSessions:             cfg.MaxSessions,
+		UpdateInterval:          cfg.UpdateInterval,
+		AuthPassphrase:          s.cfg.AuthPassphrase,
+		Peers:                   peers,
+		AnnounceAsPeer:          cfg.AnnounceAsPeer,
+		AcceptPeerAnnouncements: cfg.AcceptPeerAnnouncements,
+		AcceptedPeerPKs:         cfg.AcceptedPeerPKs,
 	}
 
 	deployments := cfg.NormalizedDeployments()


### PR DESCRIPTION
A dmsg server **not registered in the discovery** (run privately) can now dial out to public servers and have its clients reachable **inbound**, via server-server forwarding.

**The gap:** mesh forwarding is directional — a server only forwards over links it *dialed out* (`peerSessions`), and an inbound session becomes a forward target only if the remote PK is in the static `Peers` config or discovery. So a non-public server's clients were unreachable from elsewhere (surfaces as `dmsg error 202`).

**The fix — a signed `PeerAnnounce`:**
- On each outbound peer link, a server with `AnnounceAsPeer` sends a `PeerAnnounce` (signed; `Verify` binds `SrcPK` to the noise-authenticated session remote) as its first stream.
- A server with `AcceptPeerAnnouncements` (optionally gated by an `AcceptedPeerPKs` allowlist) promotes the announced inbound session into `peerSessions`, so `forwardViaPeer` routes client streams back down it.
- The announcing server also now **serves its outbound peer session**, so it accepts the reverse-forwarded streams and bridges them to its local clients — without this the outbound link is send-only and the reverse path can't be received.

**Security:** signed + cannot be spoofed onto another session; acceptance is **opt-in (off by default)** with an optional PK allowlist; the 1-hop-max rule still bounds chaining; promoted sessions are removed from `peerSessions` on close (identity-checked).

**Config:** `announce_as_peer` / `accept_peer_announcements` / `accepted_peer_pks`, threaded through `dmsg.ServerConfig`.

**Tested:** `TestNonPublicServer_ReverseDial` (public-server client dials a non-public-server client; bidirectional transfer) + `_GateOff` negative control (gate off → `dmsg error 202`). Race-clean; existing `TestServerMesh_CrossServerDial` unaffected; lint clean.