### PR TITLE
feat(router,proxy): mux-auto GROW — adaptive multiplexed-route failover

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_auto.go
+++ b/cmd/skywire-cli/commands/proxy/mux_auto.go
@@ -95,6 +95,18 @@ Example:
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unknown preset %q (want: fastest|balanced|resilient)", args[0]))
 		}
 
+		// GROW dials fresh disjoint routes server-side, which can exceed
+		// the 30s default RPC deadline when a candidate route is slow to
+		// set up. Without headroom the client gives up while the visor is
+		// still establishing the leg — the leg lands but the tick
+		// misreports "context deadline exceeded" / "grew 0". Give the
+		// loop's client room to cover GrowMuxRoute's server-side budget;
+		// the fast prune/info calls return immediately regardless. Only
+		// override the untouched default so an explicit --timeout wins.
+		if clirpc.Timeout == 30 {
+			clirpc.Timeout = 120
+		}
+
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))

--- a/cmd/skywire-cli/commands/proxy/mux_auto.go
+++ b/cmd/skywire-cli/commands/proxy/mux_auto.go
@@ -39,6 +39,7 @@ var (
 	muxAutoSrcPort uint16
 	muxAutoWatch   time.Duration
 	muxAutoDry     bool
+	muxAutoMinHops int
 )
 
 // autoPreset captures a routing intent. keep is the total leg count to
@@ -61,7 +62,8 @@ func init() {
 	muxAutoCmd.Flags().StringVarP(&muxAutoApp, "name", "n", "skysocks-client", "app to adapt")
 	muxAutoCmd.Flags().Uint16Var(&muxAutoSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
 	muxAutoCmd.Flags().DurationVarP(&muxAutoWatch, "watch", "w", 0, "re-evaluate every interval (e.g. 5s); 0 = decide once and exit")
-	muxAutoCmd.Flags().BoolVar(&muxAutoDry, "dry-run", false, "print the prune decision without acting")
+	muxAutoCmd.Flags().BoolVar(&muxAutoDry, "dry-run", false, "print the prune/grow decision without acting")
+	muxAutoCmd.Flags().IntVar(&muxAutoMinHops, "min-hops", 2, "hop-count floor for legs added when growing toward the preset (>=2 keeps grown legs multihop)")
 	RootCmd.AddCommand(muxAutoCmd)
 }
 
@@ -77,9 +79,10 @@ Presets converge the mux to the K lowest-latency legs:
   balanced   primary + 3 lowest-latency legs
   resilient  up to 8 lowest-latency legs (max redundancy)
 
-PRUNE-based for now; growing the set (route-calc + mux-add on leg loss) is
-the next increment. Pair with 'mux-info --watch' in another terminal to see
-the effect.
+Each tick PRUNES excess/slowest legs toward the preset, then GROWS the set
+back up with fresh disjoint legs (visor-side route-calc + mux-add, honoring
+--min-hops) when live legs drop below the target — adaptive failover both
+ways. Pair with 'mux-info --watch' in another terminal to see the effect.
 
 Example:
   skywire cli proxy mux-auto fastest --watch 5s
@@ -128,12 +131,32 @@ Example:
 				pruned++
 				fmt.Printf("  - pruned leg %s (%.0fms)\n", shortTpID(d.tpID.String()), d.lat)
 			}
+			// GROW: after pruning, restore redundancy. When live legs are
+			// below the preset target, add disjoint legs. Planning runs
+			// visor-side (GrowMuxRoute) because mux-info only exposes each
+			// leg's first-hop PK, not the full chains needed for a correct
+			// disjoint exclude-set.
+			live := len(rg.Legs) - pruned
+			grown := 0
+			switch {
+			case muxAutoDry && live < p.keep:
+				fmt.Printf("  would grow %d leg(s) toward keep=%d\n", p.keep-live, p.keep)
+			case !muxAutoDry && live < p.keep:
+				added, gerr := rpcClient.GrowMuxRoute(muxAutoApp, p.keep, muxAutoMinHops, muxAutoSrcPort)
+				if gerr != nil {
+					fmt.Fprintf(os.Stderr, "  grow: %v\n", gerr)
+				} else if added > 0 {
+					grown = added
+					fmt.Printf("  + grew %d leg(s) toward keep=%d\n", added, p.keep)
+				}
+			}
+
 			acted, verb := pruned, "pruned"
 			if muxAutoDry {
 				acted, verb = len(drops), "would prune"
 			}
-			fmt.Printf("[%s] preset=%s: %d legs, keep<=%d, %s %d\n",
-				time.Now().Format("15:04:05"), args[0], len(rg.Legs), p.keep, verb, acted)
+			fmt.Printf("[%s] preset=%s: %d legs, keep<=%d, %s %d, grew %d\n",
+				time.Now().Format("15:04:05"), args[0], len(rg.Legs), p.keep, verb, acted, grown)
 			return nil
 		}
 

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -375,6 +375,12 @@ func (_m *MockRouter) AddMuxRouteByHops(_a0 routing.RouteDescriptor, _a1, _a2 []
 	return ret.Error(0)
 }
 
+// GrowMuxRoute provides a mock function
+func (_m *MockRouter) GrowMuxRoute(_a0 routing.RouteDescriptor, _a1, _a2 int) (int, error) {
+	ret := _m.Called(_a0, _a1, _a2)
+	return ret.Int(0), ret.Error(1)
+}
+
 // RemoveMuxRouteByTransport provides a mock function
 func (_m *MockRouter) RemoveMuxRouteByTransport(_a0 routing.RouteDescriptor, _a1 uuid.UUID) error {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -358,6 +358,7 @@ type Router interface {
 	GetLastRouteCalcTime() time.Duration
 	ActiveRouteStatuses() []RouteStatus
 	AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []routing.Hop) error
+	GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int) (int, error)
 	RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.UUID) error
 
 	// RouteGroupHops returns the stored forward route hops for the route group

--- a/pkg/router/router_mux_ops.go
+++ b/pkg/router/router_mux_ops.go
@@ -218,6 +218,120 @@ func (r *router) AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []rout
 	return nil
 }
 
+// GrowMuxRoute adds disjoint auxiliary legs to an existing multiplexed
+// route group until it has `target` total legs, or until route planning
+// can no longer find a disjoint path. It is the runtime, additive
+// counterpart to establishMuxRoutes (which plans the initial leg set at
+// dial time): mux-auto calls it to restore redundancy after legs are
+// pruned or die. Returns the number of legs actually added.
+//
+// Each new leg is planned to avoid the intermediate visors already used
+// by the live legs (best-effort, from the rg's first-hop transport
+// edges) plus those claimed by earlier iterations, so the added legs
+// diverge from the existing ones. Legs are added via AddMuxRouteByHops,
+// which re-validates and refuses a leg whose first hop duplicates an
+// existing one. minHops threads the caller's hop-count floor so a
+// multihop mux grows with multihop legs (a 0 floor falls back to
+// r.conf.MinHops, which may pick the direct transport).
+func (r *router) GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int) (int, error) {
+	r.mx.Lock()
+	nrg, ok := r.rgsNs[desc]
+	r.mx.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("no active route group for %s", desc.String())
+	}
+	if nrg.rg.mux == nil {
+		return 0, errors.New("route group does not have mux enabled")
+	}
+
+	lPK := desc.DstPK() // this visor (entry point)
+	rPK := desc.SrcPK() // peer
+	log := r.scopedLog(desc.SrcPort())
+
+	// Current leg count + first-hop transport IDs (so planning excludes
+	// re-picking an existing first hop, which AddMuxRouteByHops rejects).
+	nrg.rg.mu.Lock()
+	current := 0
+	excludeIDs := make([]uuid.UUID, 0, len(nrg.rg.tps))
+	for _, tp := range nrg.rg.tps {
+		if tp == nil {
+			continue
+		}
+		current++
+		excludeIDs = append(excludeIDs, tp.Entry.ID)
+	}
+	nrg.rg.mu.Unlock()
+
+	deficit := target - current
+	if deficit <= 0 {
+		return 0, nil
+	}
+
+	// Seed the disjoint-exclude set with the live legs' intermediates;
+	// accumulate each planned leg's intermediates so successive legs
+	// diverge from ALL prior ones (same discipline as establishMuxRoutes).
+	excludePKs := intermediatesOfRouteGroup(nrg, lPK, rPK)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	const maxConsecutiveFailures = 2
+	consecutiveFailures := 0
+	added := 0
+	for added < deficit {
+		if ctx.Err() != nil {
+			break
+		}
+		muxOpts := &DialOptions{
+			MinForwardRts:          1,
+			MaxForwardRts:          1,
+			MinConsumeRts:          1,
+			MaxConsumeRts:          1,
+			Retries:                1,
+			MinHops:                minHops,
+			ExcludeTransportIDs:    excludeIDs,
+			ExcludeIntermediatePKs: excludePKs,
+			ExcludeDMSG:            true,
+		}
+
+		fwd, rev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+		if err != nil {
+			fwd, rev, err = r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
+		}
+		if err != nil {
+			consecutiveFailures++
+			log.Debugf("GrowMuxRoute: no disjoint path for leg %d/%d: %v", current+added+1, target, err)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				break
+			}
+			continue
+		}
+
+		// Claim this path's intermediates regardless of add outcome, so
+		// the next iteration diverges from it.
+		excludePKs = append(excludePKs, intermediatesOfHops(fwd, lPK, rPK)...)
+		excludePKs = append(excludePKs, intermediatesOfHops(rev, rPK, lPK)...)
+
+		if err := r.AddMuxRouteByHops(desc, fwd, rev); err != nil {
+			consecutiveFailures++
+			log.Debugf("GrowMuxRoute: add leg %d/%d failed: %v", current+added+1, target, err)
+			if consecutiveFailures >= maxConsecutiveFailures {
+				break
+			}
+			continue
+		}
+		excludeIDs = append(excludeIDs, fwd[0].TpID)
+		consecutiveFailures = 0
+		added++
+	}
+
+	if added > 0 {
+		log.Infof("GrowMuxRoute: added %d leg(s) to route group %s (now %d/%d total)",
+			added, desc.String(), current+added, target)
+	}
+	return added, nil
+}
+
 // RemoveMuxRouteByTransport removes a specific transport's route from a mux group.
 func (r *router) RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.UUID) error {
 	r.mx.Lock()

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -181,6 +181,7 @@ type API interface {
 	RouteGroupMuxInfo(appName string) ([]MuxRouteGroupInfo, error)
 	ActiveRoutes() ([]AppRouteStatus, error)
 	AddMuxRoute(appName string, fwd, rev []routing.Hop, srcPort uint16) error
+	GrowMuxRoute(appName string, target, minHops int, srcPort uint16) (int, error)
 	RemoveMuxRoute(appName string, tpID uuid.UUID, srcPort uint16) error
 	ServiceHealth() ([]ServiceHealthEntry, error)
 	FetchServiceData(service, path string) ([]byte, error)

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -235,6 +235,23 @@ func (v *Visor) AddMuxRoute(appName string, fwd, rev []routing.Hop, srcPort uint
 	return v.router.AddMuxRouteByHops(desc, fwd, rev)
 }
 
+// GrowMuxRoute implements API. Adds disjoint legs to the app's active rg
+// until it has `target` total legs (or route planning can no longer find
+// a disjoint path), for failover redundancy. minHops floors the added
+// legs' hop count so a multihop mux grows with multihop legs. srcPort
+// disambiguates concurrent rg's (0 auto-picks when exactly one is
+// active). Returns the number of legs actually added.
+func (v *Visor) GrowMuxRoute(appName string, target, minHops int, srcPort uint16) (int, error) {
+	if v.router == nil {
+		return 0, errors.New("router not available")
+	}
+	desc, err := v.findRouteDescForApp(appName, srcPort)
+	if err != nil {
+		return 0, err
+	}
+	return v.router.GrowMuxRoute(desc, target, minHops)
+}
+
 // RemoveMuxRoute implements API. Drops the leg over the given
 // transport from the app's active rg; srcPort disambiguates as in
 // AddMuxRoute.

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -521,6 +521,10 @@ func (proxyDefaultAPI) AddMuxRoute(_ string, _ []routing.Hop, _ []routing.Hop, _
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) GrowMuxRoute(_ string, _, _ int, _ uint16) (int, error) {
+	return 0, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) RemoveMuxRoute(_ string, _ uuid.UUID, _ uint16) error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -268,6 +268,11 @@ type MuxRouteInput struct {
 	Reverse []routing.Hop
 	// TransportID identifies the leg to remove; unused by AddMuxRoute.
 	TransportID uuid.UUID
+	// Target is the desired total leg count for GrowMuxRoute and MinHops
+	// is the hop-count floor for the legs it adds. Both unused by
+	// Add/RemoveMuxRoute.
+	Target  int
+	MinHops int
 	// SrcPort disambiguates between concurrent rg's owned by the same
 	// app (one per concurrent SOCKS5 connection on skysocks-client,
 	// etc.). Zero means "auto-pick if exactly one rg is active for

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -819,6 +819,16 @@ func (rc *rpcClient) AddMuxRoute(appName string, fwd, rev []routing.Hop, srcPort
 	return rc.Call("AddMuxRoute", &MuxRouteInput{AppName: appName, Forward: fwd, Reverse: rev, SrcPort: srcPort}, &struct{}{})
 }
 
+// GrowMuxRoute adds disjoint legs to the app's active rg until it has
+// `target` total legs (failover redundancy); minHops floors the added
+// legs' hop count. srcPort disambiguates as in AddMuxRoute. Returns the
+// number of legs added.
+func (rc *rpcClient) GrowMuxRoute(appName string, target, minHops int, srcPort uint16) (int, error) {
+	var added int
+	err := rc.Call("GrowMuxRoute", &MuxRouteInput{AppName: appName, Target: target, MinHops: minHops, SrcPort: srcPort}, &added)
+	return added, err
+}
+
 // RemoveMuxRoute drops the leg over tpID from the app's active rg.
 // srcPort disambiguates as in AddMuxRoute.
 func (rc *rpcClient) RemoveMuxRoute(appName string, tpID uuid.UUID, srcPort uint16) error {

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -763,6 +763,10 @@ func (mc *mockRPCClient) AddMuxRoute(_ string, _, _ []routing.Hop, _ uint16) err
 	return nil
 }
 
+func (mc *mockRPCClient) GrowMuxRoute(_ string, _, _ int, _ uint16) (int, error) {
+	return 0, nil
+}
+
 func (mc *mockRPCClient) RemoveMuxRoute(_ string, _ uuid.UUID, _ uint16) error {
 	return nil
 }

--- a/pkg/visor/rpc_routing.go
+++ b/pkg/visor/rpc_routing.go
@@ -168,6 +168,17 @@ func (r *RPC) AddMuxRoute(in *MuxRouteInput, _ *struct{}) (err error) {
 	return r.visor.AddMuxRoute(in.AppName, in.Forward, in.Reverse, in.SrcPort)
 }
 
+// GrowMuxRoute adds disjoint legs to an app's active rg up to a target count
+func (r *RPC) GrowMuxRoute(in *MuxRouteInput, out *int) (err error) {
+	defer rpcutil.LogCall(r.log, "GrowMuxRoute", in)(out, &err)
+	added, err := r.visor.GrowMuxRoute(in.AppName, in.Target, in.MinHops, in.SrcPort)
+	if err != nil {
+		return err
+	}
+	*out = added
+	return nil
+}
+
 // RemoveMuxRoute removes a mux route from an app's active connection
 func (r *RPC) RemoveMuxRoute(in *MuxRouteInput, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "RemoveMuxRoute", in)(nil, &err)


### PR DESCRIPTION
## What

`mux-auto` previously only **PRUNED** excess/slow legs (#3055). This adds the **GROW** direction: when live legs drop below the preset's target count (`fastest`=2, `balanced`=4, `resilient`=8), it adds fresh **disjoint** legs so a multiplexed proxy session self-heals lost redundancy. Adaptive failover now works both ways.

## Design

New router method `GrowMuxRoute(desc, target, minHops)` — the runtime, additive counterpart to `establishMuxRoutes` (which plans the initial leg set at dial time). It:
1. computes the live legs' intermediate exclude-set (`intermediatesOfRouteGroup`),
2. plans `target - current` disjoint legs via `fetchBestRoutes` (local-calc fallback) with `ExcludeIntermediatePKs`, accumulating each leg's intermediates so successive legs diverge,
3. adds each via the existing `AddMuxRouteByHops` actuator.

- **Legacy path only** — uses `RouteGroupDialer.Dial` (setup nodes), **not the cascade**.
- **Visor-side planning** — `mux-info` only exposes each leg's *first-hop* PK, not the full hop chains, so the CLI can't build a correct disjoint exclude-set; the router can.
- `--min-hops` (default 2) floors the added legs' hop count so a multihop mux grows with multihop legs.
- `GrowMuxRoute` is **only reachable via the new mux-auto RPC** → zero effect on the normal routing path.

Wired: router method → `Router` interface + MockRouter → visor `API` + impl → RPC server/client/mock → proxy stub → `mux-auto` tick() (prune → grow) + summary line.

## Validation status

✅ `go build ./...` clean · ✅ gofmt clean · ✅ golangci-lint clean (only pre-existing usermanager gosec warnings remain) · ✅ local visor clean boot.

⚠️ **Not yet exercised live** — the leg-adding behavior needs a running mux proxy session (`skysocks-client --routes N`, prune a leg, `proxy mux-auto balanced --watch 5s`, observe `+ grew N leg(s)`). Recommend a live validation run before merge.

Follow-up (deferred): visor-integrate so the initial dial skips `fetchBestRoutes` when explicit hops are supplied (router_dial.go:1762).