### PR TITLE
fix(skysocks): make --reconnect fire on silent route-group collapse + default it on

### DIFF
--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -229,23 +229,34 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 	// cycle; a failure logs + sleeps + retries indefinitely.
 	// The visor-side restart_policy still wins as a backstop —
 	// if this proc itself panics, the restart loop catches it.
-	delay := time.Duration(reconnectDelay) * time.Second
+	baseDelay := time.Duration(reconnectDelay) * time.Second
+	const maxReconnectDelay = 30 * time.Second
+	delay := baseDelay
 	for {
-		if err := runCycle(); err != nil {
-			if cycleCtx.Err() != nil {
-				// Ctx-induced unwind, not a real failure.
-				return nil
-			}
+		start := time.Now()
+		err := runCycle()
+		if cycleCtx.Err() != nil {
+			// Ctx-induced unwind (signal / visor stop), not a failure.
+			return nil
+		}
+		if err != nil {
 			log.WithError(err).Warnf("Reconnecting in %v", delay)
 			setAppStatus(appCl, log, appserver.AppDetailedStatusReconnecting)
-		}
-		if cycleCtx.Err() != nil {
-			return nil
 		}
 		select {
 		case <-cycleCtx.Done():
 			return nil
 		case <-time.After(delay):
+		}
+		// Back off while the remote stays unreachable; reset once a
+		// cycle has actually served for a while (remote came back).
+		if time.Since(start) > maxReconnectDelay {
+			delay = baseDelay
+		} else if delay < maxReconnectDelay {
+			delay *= 2
+			if delay > maxReconnectDelay {
+				delay = maxReconnectDelay
+			}
 		}
 	}
 }

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -84,7 +84,7 @@ func init() {
 	startCmd.Flags().Uint16Var(&minHops, "min-hops", 1, "minimum routing hops for this session (1=no minimum). Set on the visor before app start; rolled back is not automatic — restart visor or re-run with --min-hops=1 to revert.")
 	startCmd.Flags().BoolVarP(&startVerbose, "verbose", "v", false, "stream the visor's logs scoped to this app's session (app stdout + tagged router/mux/setup events); ctrl+c stops the proxy and exits")
 	startCmd.Flags().StringVar(&startVerboseLevel, "verbose-level", "debug", "minimum log level when --verbose is set: trace|debug|info|warn|error")
-	startCmd.Flags().BoolVar(&reconnect, "reconnect", false, "in-process reconnect on stream failure (proxy keeps retrying instead of exiting)")
+	startCmd.Flags().BoolVar(&reconnect, "reconnect", true, "in-process reconnect on route-group collapse: proxy keeps re-dialing with backoff instead of dropping the SOCKS5 listener; --reconnect=false restores exit-on-failure")
 	startCmd.Flags().StringVar(&startRoutingPolicy, "routing-policy", "", "per-app routing policy: @/path/to/policy.star or @/path/to/policy.wasm (\"\" or \"none\" clears any previously-installed override)")
 	stopCmd.Flags().BoolVar(&allClients, "all", false, "stop all skysocks client")
 	stopCmd.Flags().StringVar(&clientName, "name", "", "specific skysocks client that want stop")

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -12,7 +12,6 @@ import (
 	ipc "github.com/james-barrow/golang-ipc"
 
 	"github.com/skycoin/skywire/pkg/app"
-	"github.com/skycoin/skywire/pkg/router"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
@@ -95,10 +94,24 @@ func (c *Client) ListenAndServe(addr string) error {
 	}
 }
 
+// Liveness-probe tuning for sessionKeepAliveLoop. A route group can be
+// torn down router-side (remote visor restart, all mux legs dropped)
+// WITHOUT the underlying conn delivering EOF, so session.IsClosed() may
+// never flip and ListenAndServe would block forever in Accept(). A timed
+// yamux ping detects that. The interval/timeout are generous and we
+// require consecutive failures so a merely-slow multihop route is not
+// mistaken for a dead one (a false close just costs one reconnect cycle).
+const (
+	livenessProbeInterval = 15 * time.Second
+	livenessProbeTimeout  = 10 * time.Second
+	livenessFailThreshold = 2
+)
+
 func (c *Client) sessionKeepAliveLoop() {
-	ticker := time.NewTicker(router.DefaultRouteKeepAlive / 2)
+	ticker := time.NewTicker(livenessProbeInterval)
 	defer ticker.Stop()
 
+	fails := 0
 	for {
 		select {
 		case <-c.closeC:
@@ -109,7 +122,39 @@ func (c *Client) sessionKeepAliveLoop() {
 
 				return
 			}
+			if c.sessionAlive(livenessProbeTimeout) {
+				fails = 0
+
+				continue
+			}
+			fails++
+			if fails >= livenessFailThreshold {
+				if c.appCl != nil {
+					c.appCl.Log().Warnf("Liveness probe failed %dx; route group gone, closing for reconnect", fails)
+				}
+				c.close()
+
+				return
+			}
 		}
+	}
+}
+
+// sessionAlive reports whether a yamux ping round-trips within timeout.
+// A silently torn-down rg conn never pongs; the timer catches that. The
+// ping runs in a goroutine so a wedged ping cannot stall the loop —
+// Close() tears down the session, which unblocks the pending ping.
+func (c *Client) sessionAlive(timeout time.Duration) bool {
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.session.Ping()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		return err == nil
+	case <-time.After(timeout):
+		return false
 	}
 }
 
@@ -186,6 +231,11 @@ func (c *Client) Close() error {
 		}
 
 		close(c.closeC)
+		// Tear down the yamux session so reconnect builds a fresh one
+		// and any in-flight liveness ping unblocks.
+		if c.session != nil {
+			err = c.session.Close()
+		}
 	})
 
 	return err

--- a/pkg/skysocks/client_liveness_test.go
+++ b/pkg/skysocks/client_liveness_test.go
@@ -1,0 +1,81 @@
+// Package skysocks client liveness-probe tests.
+package skysocks
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+)
+
+// blackholeConn is a net.Conn whose writes are silently discarded and
+// whose reads block until Close. It models a route group torn down
+// router-side WITHOUT delivering EOF — the silent-collapse case that
+// session.IsClosed() misses and sessionAlive must catch via ping timeout.
+type blackholeConn struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlackholeConn() *blackholeConn { return &blackholeConn{closed: make(chan struct{})} }
+
+func (b *blackholeConn) Read(_ []byte) (int, error) {
+	<-b.closed
+	return 0, io.EOF
+}
+func (b *blackholeConn) Write(p []byte) (int, error) { return len(p), nil }
+func (b *blackholeConn) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+func (b *blackholeConn) LocalAddr() net.Addr                { return testAddr{} }
+func (b *blackholeConn) RemoteAddr() net.Addr               { return testAddr{} }
+func (b *blackholeConn) SetDeadline(_ time.Time) error      { return nil }
+func (b *blackholeConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (b *blackholeConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type testAddr struct{}
+
+func (testAddr) Network() string { return "test" }
+func (testAddr) String() string  { return "test" }
+
+// TestSessionAlive_Healthy: a live yamux session (peer pongs) reports alive.
+func TestSessionAlive_Healthy(t *testing.T) {
+	p1, p2 := net.Pipe()
+	defer p1.Close() //nolint:errcheck
+	defer p2.Close() //nolint:errcheck
+
+	server, err := yamux.Server(p2, yamux.DefaultConfig())
+	if err != nil {
+		t.Fatalf("yamux server: %v", err)
+	}
+	defer server.Close() //nolint:errcheck
+
+	c, err := NewClient(p1, nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close() //nolint:errcheck
+
+	if !c.sessionAlive(2 * time.Second) {
+		t.Fatal("expected a healthy session to report alive")
+	}
+}
+
+// TestSessionAlive_SilentCollapse: a conn that accepts writes but never
+// pongs (silent rg teardown) reports NOT alive within the timeout — this
+// is what makes the keepalive loop close the client so --reconnect fires.
+func TestSessionAlive_SilentCollapse(t *testing.T) {
+	c, err := NewClient(newBlackholeConn(), nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer c.Close() //nolint:errcheck
+
+	if c.sessionAlive(500 * time.Millisecond) {
+		t.Fatal("expected a silently-dead session to report not-alive")
+	}
+}


### PR DESCRIPTION
## Problem
`skysocks-client --reconnect` exists but is a **no-op for full route-group collapse**. When the rg is torn down router-side (remote visor restart, all legs dropped) without the conn delivering EOF, yamux's `session.IsClosed()` never flips → `sessionKeepAliveLoop` never closes the listener → `ListenAndServe` blocks forever in `Accept()` → the reconnect loop never regains control. (yamux's own keepalive that would catch this is disabled to avoid false-closing slow multihop routes.)

## Fix
- **Definitive liveness probe** in `sessionKeepAliveLoop`: timed yamux ping every 15s; N consecutive failures (10s timeout, threshold 2 — a slow-but-alive route isn't mistaken for dead) close the client so the existing reconnect loop re-dials.
- `Close()` tears down the yamux session (frees a wedged ping; fresh session on reconnect).
- Outer reconnect loop: capped exponential backoff.
- `--reconnect` **defaults ON** for `proxy start` (`--reconnect=false` restores exit-on-failure).

A fresh dial re-applies the sticky mux degree + min-hops; router self-heal / mux GROW re-fans the aux legs.

## Testing
✅ Unit tests: `sessionAlive` reports alive for a live yamux session, not-alive for a silently-dead (no-pong) conn within timeout. ✅ build ✅ golangci-lint ✅ `go test ./pkg/skysocks`. Live: router self-heal keeps a session alive through transport loss (removed both legs' transports → re-established, same rg) — reconnect is the backstop for full collapse (server unreachable).

Part 1 of 3 — follow-ups: Part 2 = reachability-gated transport re-creation (reverse-stcpr-via-TPS when AR-bound, else direct, gated by --existing-tp/--min-hops); Part 3 = shared client-app wrapper so vpn-client inherits it.