### PR TITLE
fix(pty): keep interactive dmsgpty terminals alive past the 2-minute idle deadline

### DIFF
--- a/pkg/pty/cli.go
+++ b/pkg/pty/cli.go
@@ -195,6 +195,27 @@ func (cli *CLI) servePty(ctx context.Context, ptyC *PtyClient, cmd string, args 
 		}
 	}()
 
+	// dmsg-stream keepalive. An idle interactive session rides a dmsg
+	// stream whose 2-minute idle read deadline (StreamIdleTimeout) is
+	// refreshed only on a successful read; with no typing or output it
+	// would be torn down every ~2 minutes. A periodic no-op Ping RPC
+	// forces a response read well within that window — the dmsg analog of
+	// SSH's ServerAliveInterval.
+	go func() {
+		t := time.NewTicker(30 * time.Second)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if err := ptyC.Ping(); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
 	// Write loop.
 	go func() {
 		defer cancel()

--- a/pkg/pty/host_test.go
+++ b/pkg/pty/host_test.go
@@ -256,6 +256,11 @@ func checkPty(t *testing.T, ptyC *PtyClient, msg string) {
 		require.Equal(t, msg, string(readB))
 	}
 
+	// The keepalive Ping (used by the interactive terminal to refresh the
+	// dmsg stream's idle read deadline) must round-trip through the host —
+	// direct and proxied.
+	require.NoError(t, ptyC.Ping())
+
 	require.NoError(t, ptyC.Stop())
 }
 

--- a/pkg/pty/pty_client.go
+++ b/pkg/pty/pty_client.go
@@ -161,3 +161,11 @@ func (sc *PtyClient) StartWithSize(name string, arg []string, c *WinSize, env []
 func (sc *PtyClient) SetPtySize(size *WinSize) error {
 	return sc.call("SetPtySize", size, &empty)
 }
+
+// Ping issues a no-op RPC round-trip. The interactive web terminal calls
+// it periodically as a keepalive: the response read refreshes the dmsg
+// stream's idle read deadline, so a terminal left idle isn't dropped
+// after StreamIdleTimeout (2m). The dmsg analog of SSH ServerAliveInterval.
+func (sc *PtyClient) Ping() error {
+	return sc.call("Ping", &empty, &empty)
+}

--- a/pkg/pty/pty_gateway.go
+++ b/pkg/pty/pty_gateway.go
@@ -27,6 +27,10 @@ type PtyGateway interface {
 	Write(reqB *[]byte, respN *int) error
 	SetPtySize(size *WinSize, _ *struct{}) error
 	Exec(req *CommandExecReq, resp *CommandExecResult) error
+	// Ping is a no-op round-trip used as a dmsg-stream keepalive for the
+	// interactive terminal — its response read refreshes the stream's
+	// idle read deadline. See pkg/pty/ui.go's keepalive goroutine.
+	Ping(_, _ *struct{}) error
 }
 
 // CommandReq represents a pty command.
@@ -87,6 +91,14 @@ func (g *LocalPtyGateway) SetPtySize(size *WinSize, _ *struct{}) error {
 	return g.ses.SetPtySize(size)
 }
 
+// Ping is a no-op keepalive round-trip. The interactive web terminal
+// calls it periodically so an idle pty stream keeps refreshing its
+// StreamIdleTimeout read deadline and isn't torn down after 2 minutes of
+// inactivity (the dmsg analog of SSH's ServerAliveInterval).
+func (g *LocalPtyGateway) Ping(_, _ *struct{}) error {
+	return nil
+}
+
 // SetPtySize sets the remote pty's window size.
 func (g *ProxiedPtyGateway) SetPtySize(size *WinSize, _ *struct{}) error {
 	return g.ptyC.SetPtySize(size)
@@ -132,4 +144,9 @@ func (g *ProxiedPtyGateway) Write(reqB *[]byte, respN *int) error {
 	var err error
 	*respN, err = g.ptyC.Write(*reqB)
 	return err
+}
+
+// Ping forwards the keepalive round-trip to the remote pty.
+func (g *ProxiedPtyGateway) Ping(_, _ *struct{}) error {
+	return g.ptyC.Ping()
 }

--- a/pkg/pty/ui.go
+++ b/pkg/pty/ui.go
@@ -221,6 +221,33 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 		// io
 		done, once := make(chan struct{}), new(sync.Once)
 		closeDone := func() { once.Do(func() { close(done) }) }
+
+		// dmsg-stream keepalive. The interactive pty rides a dmsg stream
+		// whose 2-minute idle read deadline (StreamIdleTimeout) is
+		// refreshed only on a successful read. An idle terminal (no
+		// typing, no shell output) produces no reads, so the stream would
+		// otherwise be torn down every ~2 minutes. A periodic no-op Ping
+		// RPC forces a response read well within that window — the dmsg
+		// analog of SSH's ServerAliveInterval. (The ws Ping above only
+		// warms the browser<->hypervisor websocket, not the dmsg stream.)
+		go func() {
+			t := time.NewTicker(30 * time.Second)
+			defer t.Stop()
+			for {
+				select {
+				case <-r.Context().Done():
+					return
+				case <-done:
+					return
+				case <-t.C:
+					if err := ptyC.Ping(); err != nil {
+						// Stream gone; the output pump closes the session.
+						return
+					}
+				}
+			}
+		}()
+
 		go func() {
 			// Buffer PTY output and flush periodically to reduce WebSocket message count
 			bw := newBufferedWSWriter(wsConn, 16*time.Millisecond)


### PR DESCRIPTION
## Problem
The hypervisor UI web terminal (and the CLI interactive pty) to remote visors **disconnects every ~2 minutes of inactivity**. 

**Root cause:** the interactive pty rides a dmsg stream whose `StreamIdleTimeout` (2m) read deadline is refreshed **only on a successful read** (`dmsg/stream.go:373`). An idle terminal — no typing, no shell output — produces no reads, so the deadline fires and the stream is torn down. The existing keepalives all miss it:
- the ws Ping (#3050) warms only the browser↔hypervisor websocket — no dmsg-stream traffic;
- the dmsg session ping rides a different (control) stream;
- the exec-pool TTL is the one-shot `pty exec` path.

SSH avoids this with `ServerAliveInterval`; the interactive pty had no equivalent.

## Fix
A no-op `Ping` RPC on the pty gateway + a 30s keepalive goroutine on the interactive path (UI handler + CLI `servePty`). Each Ping round-trip's response read refreshes the dmsg stream's idle deadline, well within the 2-min window — the dmsg analog of `ServerAliveInterval`. **Not** bumping `StreamIdleTimeout` itself (it's load-bearing for ephemeral-port release on stuck streams).

## No regression on old remotes
A remote without the `Ping` method returns a call-level "method not found" **without** closing the stream; the keepalive goroutine stops and the terminal behaves exactly as today. The fix activates as the fleet auto-updates (both ends need the method).

## Tested
`TestHost` asserts `Ping` round-trips through a **real dmsg-backed host**, direct + proxied. ✅ build ✅ golangci-lint (0 issues) ✅ `go test ./pkg/pty`.