### PR TITLE
fix(transport/addrresolver): guard sudphArConn with a mutex (data race)

### DIFF
--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -125,6 +125,7 @@ type httpClient struct {
 	remoteUDPAddr    string
 	sudphConn        net.PacketConn
 	sudphArConn      net.Conn
+	sudphArConnMu    sync.Mutex
 	sudphLocalAddr   LocalAddresses
 	clientPublicIP   string
 	clientPublicIPv6 string
@@ -544,7 +545,9 @@ func (c *httpClient) BindSUDPH(filter *pfilter.PacketFilter, hs Handshake) (<-ch
 		return nil, err
 	}
 
+	c.sudphArConnMu.Lock()
 	c.sudphArConn = arConn
+	c.sudphArConnMu.Unlock()
 	c.sudphLocalAddr = localAddresses
 
 	// addrCh is the long-lived channel returned to the caller. It survives
@@ -668,7 +671,9 @@ func (c *httpClient) serveSUDPHReconnect(filter *pfilter.PacketFilter, hs Handsh
 		}
 		backoff = sudphReconnectInitialBackoff
 		arConn = newConn
+		c.sudphArConnMu.Lock()
 		c.sudphArConn = arConn
+		c.sudphArConnMu.Unlock()
 		c.sudphLocalAddr = newLocalAddrs
 		c.log.Info("SUDPH reconnected to address-resolver")
 	}
@@ -1066,7 +1071,9 @@ func (c *httpClient) delBindSUDPHLoop() {
 	defer c.delBindSudphWg.Done()
 	<-c.closed
 
+	c.sudphArConnMu.Lock()
 	arConn := c.sudphArConn
+	c.sudphArConnMu.Unlock()
 	if arConn == nil {
 		return
 	}


### PR DESCRIPTION
`httpClient.sudphArConn` is written by `serveSUDPHReconnect` (client.go:671) + `BindSUDPH` (client.go:547) and read by `delBindSUDPHLoop` (client.go:1069) with **no synchronization** — a data race (trips `-race`). Low severity (single long-lived AR client, race window is an AR-conn flap near shutdown, no leak), but real.

Fix: a small `sudphArConnMu` mutex around the three accesses. No semantic change. ✅ build ✅ `go test ./pkg/transport/network/addrresolver -race` ✅ golangci-lint 0 issues.

Found by an adversarial transport-layer audit during live deploy-churn — which also flagged two **RISKY** transport-map dial/accept races (manager.go:1155 / :900, the deterministic-tpID analog of the dmsg newest-session-wins issue) left for human review.