### PR TITLE
fix(appserver): visor-crash nil-panic on stale Deregister + conns-map leak

### DIFF
--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -72,6 +72,7 @@ type procManager struct {
 
 	lis     net.Listener
 	conns   map[string]net.Conn
+	connsMx sync.Mutex
 	connsWG sync.WaitGroup
 
 	discF      *appdisc.Factory
@@ -130,9 +131,11 @@ func NewProcManager(mLog *logging.MasterLogger, discF *appdisc.Factory, eb *appe
 
 func (m *procManager) serve() {
 	defer func() {
+		m.connsMx.Lock()
 		for _, conn := range m.conns {
 			_ = conn.Close() //nolint:errcheck
 		}
+		m.connsMx.Unlock()
 	}()
 
 	for {
@@ -144,11 +147,22 @@ func (m *procManager) serve() {
 			m.log.WithError(err).Debug("Failed to accept app conn, continuing")
 			continue
 		}
-		m.conns[conn.RemoteAddr().String()] = conn
+		key := conn.RemoteAddr().String()
+		m.connsMx.Lock()
+		m.conns[key] = conn
+		m.connsMx.Unlock()
 
 		m.connsWG.Add(1)
-		go func(conn net.Conn) {
+		go func(conn net.Conn, key string) {
 			defer m.connsWG.Done()
+			// Drop the map entry when this conn's handler returns. Without
+			// this, m.conns accumulates one dead entry per app (re)connect
+			// for the visor's lifetime — a slow leak under app-restart churn.
+			defer func() {
+				m.connsMx.Lock()
+				delete(m.conns, key)
+				m.connsMx.Unlock()
+			}()
 
 			if ok := m.handleConn(conn); !ok {
 				if err := conn.Close(); err != nil {
@@ -156,7 +170,7 @@ func (m *procManager) serve() {
 						Warn("Failed to close problematic app conn.")
 				}
 			}
-		}(conn)
+		}(conn, key)
 	}
 }
 
@@ -304,6 +318,13 @@ func (m *procManager) Deregister(key appcommon.ProcKey) error {
 	m.mx.Lock()
 	proc := m.procsByKey[key]
 	m.mx.Unlock()
+
+	// A duplicate or stale Deregister (e.g. a double DeregisterApp during
+	// churn) yields a nil proc; dereferencing proc.appName would nil-panic
+	// and crash the whole visor. Return ErrNoSuchApp instead.
+	if proc == nil {
+		return ErrNoSuchApp
+	}
 
 	_, err := m.pop(proc.appName) //nolint:errcheck
 

--- a/pkg/app/appserver/proc_manager_deregister_test.go
+++ b/pkg/app/appserver/proc_manager_deregister_test.go
@@ -1,0 +1,25 @@
+package appserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/app/appcommon"
+)
+
+// TestDeregister_UnknownKey_NoPanic is a regression test for a visor-crash
+// nil-deref: Deregister with a key absent from procsByKey returned a nil
+// *Proc, and the subsequent proc.appName dereference panicked — taking down
+// the whole visor. Reachable via a duplicate/stale DeregisterApp during
+// deploy churn. It must now return ErrNoSuchApp instead of panicking.
+func TestDeregister_UnknownKey_NoPanic(t *testing.T) {
+	m := &procManager{
+		procsByKey: make(map[appcommon.ProcKey]*Proc),
+	}
+
+	require.NotPanics(t, func() {
+		err := m.Deregister(appcommon.ProcKey{})
+		require.ErrorIs(t, err, ErrNoSuchApp)
+	})
+}


### PR DESCRIPTION
Two churn-exposed proc-manager bugs found by an adversarial visor-layer audit:

**1. (crash, HIGH)** `procManager.Deregister` dereferenced `procsByKey[key].appName` with no nil check. A duplicate/stale `Deregister` (e.g. double `DeregisterApp` during churn) yields a nil `*Proc` → `proc.appName` nil-panic → **whole visor crashes**. Now returns `ErrNoSuchApp`.

**2. (leak)** `serve()`'s accept loop inserted every app conn into `m.conns` and **never deleted** it (freed only at shutdown). Every external-app (re)connect — i.e. every app restart under `restart_policy` — leaked a dead `net.Conn` for the visor's lifetime. The per-conn goroutine now deletes its entry on return, guarded by a dedicated `connsMx` (separate from `m.mx` to avoid proc-lock coupling).

✅ build ✅ `go test ./pkg/app/appserver -race` ✅ golangci-lint 0 issues. Regression test covers the nil-panic.

The same audit confirmed autoconnect's self-transport bug is NOT present (self-PK filtered) and the mux RPCs are clean. Two further AwaitConn/readyCh goroutine leaks (proc.go crash-before-ready) left for a careful follow-up.