### PR TITLE
feat(config): document RESTART_SERVICES in the auto-update env template

### DIFF
--- a/cmd/skywire-cli/commands/config/envfiles.go
+++ b/cmd/skywire-cli/commands/config/envfiles.go
@@ -264,6 +264,15 @@ const envfileLinux = `#
 #	The directory must contain a compose.yaml or docker-compose.yml.
 #DEPLOY_DIR=''
 
+#--	Extra services to restart after a successful binary update.
+#	Bash array of systemd unit names, restarted at the END of
+#	skywire-update — ONLY when a new binary was actually installed (never
+#	on a no-op update tick or a plain 'skywire autoconfig' run). Use for
+#	standalone units that depend on the skywire binary, e.g. a separate
+#	dmsgweb SOCKS5 proxy. The skywire service is always restarted on
+#	update; do not list it here.
+#RESTART_SERVICES=('dmsgweb-surveys.service')
+
 ### Miscellaneous #######################################################
 
 #--	Set secret key


### PR DESCRIPTION
Adds a commented `RESTART_SERVICES=('dmsgweb-surveys.service')` to the Auto-Update section of the generated `/etc/skywire.conf`.

It's a bash array of systemd unit names that **`skywire-update` restarts at the END of an update — only when a new binary was actually installed** (the no-op early-exits guarantee it never fires on a daily no-op tick), and it is **not** part of `skywire autoconfig` (so config regens never trigger it).

Use for standalone out-of-tree units that depend on the skywire binary (e.g. a separate `dmsgweb` SOCKS5 proxy) — which otherwise keep running a stale in-memory binary after an auto-update until restarted by hand.

The acting half is the matching loop in `skywire-update` (skywire-autoupdate AUR package); this PR is the template/documentation half. ✅ cli builds + renders the new section.