### PR TITLE
fix(visor): don't block SetRewardAddress on survey generation

### DIFF
--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -370,8 +370,12 @@ func (v *Visor) SetRewardAddress(p string) (string, error) {
 	if err != nil {
 		return p, fmt.Errorf("failed to write config to file. err=%v", err)
 	}
-	// generate survey after set/update reward address
-	GenerateSurvey(v, v.log, false)
+	// Refresh the survey in the background. Setting the reward address must
+	// not block on survey generation — the address is already persisted above,
+	// and survey-gen depends on the address, not the other way around. Running
+	// it synchronously made SetRewardAddress hang whenever the survey's dmsg
+	// IP lookup couldn't complete (see GenerateSurvey's IP-lookup loop).
+	go GenerateSurvey(v, v.log, false)
 	return p, nil
 }
 

--- a/pkg/visor/survey.go
+++ b/pkg/visor/survey.go
@@ -98,6 +98,12 @@ func GenerateSurvey(v *Visor, log *logging.Logger, routine bool) {
 		const (
 			ipLookupAttemptTimeout = 30 * time.Second
 			ipLookupRetryDelay     = 15 * time.Second
+			// One-shot (non-routine) refreshes — e.g. the background goroutine
+			// SetRewardAddress now spawns — give up after a few attempts so they
+			// can't spin forever when dmsg IP lookup is unavailable. The periodic
+			// survey (routine=true) still retries indefinitely and backstops it
+			// once dmsg recovers.
+			ipLookupOneShotMaxAttempts = 3
 		)
 		for attempt := 1; ; attempt++ {
 			ctx, cancel := context.WithTimeout(context.Background(), ipLookupAttemptTimeout)
@@ -108,6 +114,10 @@ func GenerateSurvey(v *Visor, log *logging.Logger, routine bool) {
 				break
 			}
 			log.WithError(err).Warnf("Public IP lookup via dmsg failed (attempt %d) — retrying", attempt)
+			if !routine && attempt >= ipLookupOneShotMaxAttempts {
+				log.Warn("Giving up IP lookup for one-shot survey refresh; the periodic survey will retry")
+				return
+			}
 			time.Sleep(ipLookupRetryDelay)
 		}
 


### PR DESCRIPTION
`SetRewardAddress` persisted the address then called `GenerateSurvey` **synchronously**. GenerateSurvey's inner public-IP loop (`survey.go`) retries `dmsgC.LookupIP` with no exit except success, and the `!routine` early-returns are only in the *outer* error branches — so if dmsg can't return the IP, the RPC **hangs forever**.

Setting the reward address shouldn't depend on survey generation (it's the other way around, and the address is already persisted first). Fix: run `GenerateSurvey` in the background, and bound the one-shot IP-lookup loop to 3 attempts (the periodic survey still retries indefinitely). ✅ build + gofmt + golangci-lint clean.