### PR TITLE
fix(appserver): wake readyCh waiters on teardown + unblock orphaned AwaitConn (leaks)

### DIFF
--- a/pkg/app/appserver/proc.go
+++ b/pkg/app/appserver/proc.go
@@ -365,8 +365,14 @@ func (p *Proc) startInProcess() error {
 		}
 
 		go func() {
-			<-p.readyCh
-			p.disc.Start()
+			select {
+			case <-p.readyCh:
+				p.disc.Start()
+			case <-p.appCtx.Done():
+				// Torn down before the app reported Running — don't start
+				// discovery for a now-dead app; just exit instead of leaking
+				// this goroutine blocked on readyCh forever.
+			}
 		}()
 		defer p.disc.Stop()
 
@@ -397,6 +403,12 @@ func (p *Proc) startInProcess() error {
 }
 
 func (p *Proc) startExternal() error {
+	// Lifecycle context, canceled on teardown (Stop -> appCancelCtx, and the
+	// deferred m.Stop in the goroutine below). Mirrors startInProcess so the
+	// readyCh waiter can wake on teardown instead of leaking when an external
+	// app dies before it ever reports Running.
+	p.appCtx, p.appCancelCtx = context.WithCancel(context.Background()) //nolint:gosec
+
 	if err := p.cmd.Start(); err != nil {
 		p.waitMx.Unlock()
 		return err
@@ -438,8 +450,14 @@ func (p *Proc) startExternal() error {
 		}
 
 		go func() {
-			<-p.readyCh
-			p.disc.Start()
+			select {
+			case <-p.readyCh:
+				p.disc.Start()
+			case <-p.appCtx.Done():
+				// Torn down before the app reported Running — don't start
+				// discovery for a now-dead app; just exit instead of leaking
+				// this goroutine blocked on readyCh forever.
+			}
 		}()
 		defer p.disc.Stop()
 

--- a/pkg/app/appserver/proc_manager.go
+++ b/pkg/app/appserver/proc_manager.go
@@ -274,8 +274,12 @@ func (m *procManager) Register(conf appcommon.ProcConfig) (appcommon.ProcKey, er
 		if existingProc.IsRunning() {
 			return appcommon.ProcKey{}, ErrAppAlreadyStarted
 		}
-		// Dead proc — clean it up so we can restart
+		// Dead proc — clean it up so we can restart. Close its connCh first so
+		// any AwaitConn goroutine spawned for it at Register time unblocks
+		// instead of leaking forever. Stop() can't be used here: it early-returns
+		// (errProcNotStarted) on a not-running proc without closing connCh.
 		log.WithField("app", conf.AppName).Warn("Found dead proc in registry, cleaning up for restart")
+		existingProc.connOnce.Do(func() { close(existingProc.connCh) })
 		delete(m.procs, conf.AppName)
 		if existingProc.conf.ProcKey != (appcommon.ProcKey{}) {
 			delete(m.procsByKey, existingProc.conf.ProcKey)


### PR DESCRIPTION
Two goroutine leaks under app-restart churn (adversarial audit):

**F3** — both run modes spawn a goroutine that waits on `<-p.readyCh` to call `disc.Start()`. readyCh closes only on `SetDetailedStatus(Running)`, so an app that dies **before** reporting Running leaks that goroutine forever. Fix: the waiter `select`s on readyCh **or** `p.appCtx.Done()` — on teardown it exits without starting discovery (so it neither leaks nor registers a dead app). `startExternal` now also sets `appCtx` (was in-proc only); it's cancelled by `Stop()`/the deferred `m.Stop` teardown.

**F2** — Register's dead-proc cleanup deleted the maps but never closed the proc's `connCh`, leaking its `AwaitConn` goroutine. `Stop()` can't help (early-returns on a not-running proc), so close `connCh` directly.

The audit's *original* suggestions were wrong (Stop early-returns; closing readyCh in Stop would `disc.Start()` a dead app) — these are the corrected fixes. ✅ build + `-race` + golangci-lint clean.