### PR TITLE
fix(transport): don't let a dial/accept glare collision evict a live transport

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -897,7 +897,14 @@ func (tm *Manager) acceptTransport(ctx context.Context, lis network.Listener) er
 			mTp.Serve(tm.readCh)
 
 			tm.mx.Lock()
-			delete(tm.tps, mTp.Entry.ID)
+			// Identity-checked delete: a concurrent dial/accept to the same
+			// peer resolves to this same deterministic tpID and may have
+			// replaced us in the map. Only remove the entry if it's still us —
+			// otherwise we'd evict a live successor (route lookups would then
+			// fail on a transport whose conn is actually fine).
+			if cur, ok := tm.tps[mTp.Entry.ID]; ok && cur == mTp {
+				delete(tm.tps, mTp.Entry.ID)
+			}
 			tm.mx.Unlock()
 		}()
 
@@ -1150,10 +1157,20 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 		mTp.closeWithoutDeregister()
 		return nil, err
 	}
-	go mTp.Serve(tm.readCh)
 	tm.mx.Lock()
+	// The lock was released during the dial above (up to ~20s). A concurrent
+	// accept or dial to the same peer — same deterministic tpID — may have
+	// installed a live transport meanwhile. Don't clobber it: discard the one
+	// we just dialed (its TPD entry is shared with the survivor under the same
+	// tpID, so close WITHOUT deregistering) and return the winner.
+	if existing, ok := tm.tps[tpID]; ok && !existing.IsClosed() {
+		tm.mx.Unlock()
+		mTp.closeWithoutDeregister()
+		return existing, nil
+	}
 	tm.tps[tpID] = mTp
 	tm.mx.Unlock()
+	go mTp.Serve(tm.readCh)
 
 	// Check AR transport limit after dialing a new transport.
 	go tm.checkARLimit()


### PR DESCRIPTION
ManagedTransport IDs are deterministic (hash of localPK, remotePK, netType), so a simultaneous **mutual dial+accept** to the same peer resolves to the *same* tpID — a glare collision. Two bugs turned that into a ~3-min route break:

1. `saveTransportInternal` checks the map **before** dialing, releases the lock for the dial (~20s), then installs `tm.tps[tpID] = mTp` with **no re-check** — silently overwriting (orphaning) a live transport an inbound accept installed during the dial window.
2. `acceptTransport`'s Serve goroutine **unconditionally** `delete(tm.tps, mTp.Entry.ID)` on exit. When the orphaned accept-side twin later dies, that delete evicts *whoever* holds the shared deterministic ID — i.e. the **live** dial-side transport — so route lookups fail on a conn that's actually fine.

**Fix:** the dial install re-checks under the final lock and discards the freshly-dialed transport if a live one is already there (`closeWithoutDeregister` — the TPD entry is shared under the same tpID); the accept goroutine's delete is identity-checked (`cur == mTp`). Narrow window (needs simultaneous mutual dial) but real.

Same idiom as the dmsg newest-session-wins fix (#3035). ✅ build + `go test ./pkg/transport -race` + golangci-lint clean.