### PR TITLE
feat(config): add --cascade flag to opt into cascade route setup (default stays legacy)

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -208,6 +208,7 @@ func init() {
 	}
 	genConfigCmd.Flags().StringVar(&transportSetupPKs, "tpsetup", scriptExecArray("${TPSETUPPKS[@]}"), msg)
 	gHiddenFlags = append(gHiddenFlags, "tpsetup")
+	genConfigCmd.Flags().BoolVar(&cascadeRouteSetup, "cascade", false, "opt into source-driven cascade route setup (default: legacy setup-node path)")
 	genConfigCmd.Flags().BoolVar(&snConfig, "sn", false, "generate config for route setup node")
 	gHiddenFlags = append(gHiddenFlags, "sn")
 	genConfigCmd.Flags().BoolVar(&dmsgDiscConfig, "dmsgdisc", false, "generate config for dmsg-discovery service")
@@ -1105,6 +1106,10 @@ func configureRouting() {
 		RouteFinderTimeout: visorconfig.DefaultTimeout,
 		MinHops:            1,
 		CalculateRoutes:    enableCalculateRoutes,
+		// Cascade route setup is opt-in (--cascade); the legacy setup-node
+		// path stays the default until the cascade multihop data-plane bug
+		// is fixed and enough of the network has updated to support it.
+		EnableCascadeRouteSetup: cascadeRouteSetup,
 	}
 
 	if muxRoutes > 0 {
@@ -1114,6 +1119,11 @@ func configureRouting() {
 	if oldConfCache != nil && oldConfCache.Routing != nil {
 		if oldConfCache.Routing.MinHops != 0 {
 			conf.Routing.MinHops = oldConfCache.Routing.MinHops
+		}
+		// Preserve an opted-in cascade across regen (matches MinHops). To turn
+		// it back off, edit enable_cascade_route_setup in the JSON directly.
+		if oldConfCache.Routing.EnableCascadeRouteSetup {
+			conf.Routing.EnableCascadeRouteSetup = true
 		}
 	}
 }

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -87,6 +87,7 @@ var (
 	isResetSkysocks            bool
 	setPublicAutoconnect       string
 	minHops                    int
+	cascadeRouteSetup          bool
 	isUsr                      bool
 	isPublic                   bool
 	disablePublicAutoConn      bool


### PR DESCRIPTION
The source-driven cascade route-setup path is gated by `routing.enable_cascade_route_setup`, **OFF by default** — the legacy setup-node path stays the default until the cascade multihop data-plane bug is fixed and the network has updated. Until now that field could only be flipped by hand-editing the JSON.

This adds `config gen --cascade` so operators can opt in explicitly. **Default stays false (legacy)** — confirmed: `config gen -n` omits the field, `config gen --cascade -n` sets `enable_cascade_route_setup: true`. Regen preserves an opted-in cascade like it does a non-default MinHops.

When cascade later becomes the default, this flips to the opt-out side — but the network-safe default is legacy for now. ✅ build + flag-behavior + golangci-lint verified.