### PR TITLE
fix(router): park frames during route-group registration window (multihop setup race)

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -409,6 +409,7 @@ type router struct {
 	rt                 routing.Table
 	rgsNs              map[routing.RouteDescriptor]*NoiseRouteGroup // Noise-wrapped route groups to push incoming reads from transports.
 	rgsRaw             map[routing.RouteDescriptor]*RouteGroup      // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
+	pending            *pendingPackets                              // frames parked during the rule-save -> route-group-register window (see router_pending.go)
 	rpcSrv             *rpc.Server
 	accept             chan routing.EdgeRules
 	done               chan struct{}
@@ -488,6 +489,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		dmsgC:           dmsgC,
 		rgsNs:           make(map[routing.RouteDescriptor]*NoiseRouteGroup),
 		rgsRaw:          make(map[routing.RouteDescriptor]*RouteGroup),
+		pending:         newPendingPackets(),
 		rpcSrv:          rpc.NewServer(),
 		accept:          make(chan routing.EdgeRules, acceptSize),
 		done:            make(chan struct{}),

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/routing"
 )
@@ -96,6 +97,13 @@ func (r *router) dispatchToRouteGroup(ctx context.Context, packet routing.Packet
 		return rg.handlePacket(packet)
 	}
 
+	// The rule resolved but no route group is registered yet: this frame
+	// arrived in the rule-save -> route-group-register window (the receive-side
+	// setup race). Park it and re-dispatch on registration instead of dropping
+	// it, which would otherwise stall the noise handshake. See router_pending.go.
+	if r.pending.park(desc, packet, time.Now()) {
+		return nil
+	}
 	return errRouteDescNotExist
 }
 

--- a/pkg/router/router_pending.go
+++ b/pkg/router/router_pending.go
@@ -1,0 +1,125 @@
+// Package router pkg/router/router_pending.go
+package router
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// Receive-side setup-race mitigation.
+//
+// AcceptRoutes / DialRoutes save the routing rules BEFORE saveRouteGroupRules
+// registers the route group, so a handshake or ping frame for a freshly
+// installed route can arrive in that window: the frame's routing rule resolves,
+// but no route group exists yet, so dispatchToRouteGroup would return
+// errRouteDescNotExist and DROP it. Dropping the noise handshake's first frame
+// stalls the handshake — the initiator then times out at handshakeAwaitTimeout
+// and futilely retries through a different intermediate, which on a loaded node
+// turns a sub-second multihop setup into a multi-second or timed-out one (the
+// rare, intermediate-agnostic, busy-node-concentrated failures).
+//
+// Instead of dropping, we park such frames briefly and re-dispatch them the
+// moment the route group registers.
+const (
+	// pendingPacketTTL must exceed the registration window but stay well under
+	// handshakeAwaitTimeout (see router.go) so a parked handshake frame is
+	// re-delivered while the initiator is still waiting.
+	pendingPacketTTL     = 2 * time.Second
+	pendingSweepInterval = time.Second
+	// Memory bounds: a flood of frames for descriptors that never register
+	// must not grow the buffer without limit.
+	maxPendingPerDesc = 16
+	maxPendingTotal   = 1024
+)
+
+type pendingPacket struct {
+	pkt      routing.Packet
+	deadline time.Time
+}
+
+// pendingPackets buffers transport frames whose routing rule exists but whose
+// route group has not registered yet (the receive-side setup race). It is safe
+// for concurrent use.
+type pendingPackets struct {
+	mu     sync.Mutex
+	byDesc map[routing.RouteDescriptor][]pendingPacket
+	total  int
+}
+
+func newPendingPackets() *pendingPackets {
+	return &pendingPackets{byDesc: make(map[routing.RouteDescriptor][]pendingPacket)}
+}
+
+// park stores pkt for desc until the route group registers (take) or the TTL
+// expires (sweep). Returns false when the buffer is full, in which case the
+// caller should fall back to dropping the frame.
+func (p *pendingPackets) park(desc routing.RouteDescriptor, pkt routing.Packet, now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.total >= maxPendingTotal || len(p.byDesc[desc]) >= maxPendingPerDesc {
+		return false
+	}
+	p.byDesc[desc] = append(p.byDesc[desc], pendingPacket{pkt: pkt, deadline: now.Add(pendingPacketTTL)})
+	p.total++
+	return true
+}
+
+// take removes and returns all packets parked for desc. Called when the route
+// group for desc registers.
+func (p *pendingPackets) take(desc routing.RouteDescriptor) []pendingPacket {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pkts := p.byDesc[desc]
+	if len(pkts) == 0 {
+		return nil
+	}
+	delete(p.byDesc, desc)
+	p.total -= len(pkts)
+	return pkts
+}
+
+// sweep drops packets past their deadline and returns the count dropped.
+func (p *pendingPackets) sweep(now time.Time) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	dropped := 0
+	for desc, pkts := range p.byDesc {
+		kept := pkts[:0]
+		for _, pp := range pkts {
+			if now.Before(pp.deadline) {
+				kept = append(kept, pp)
+			} else {
+				dropped++
+			}
+		}
+		if len(kept) == 0 {
+			delete(p.byDesc, desc)
+		} else {
+			p.byDesc[desc] = kept
+		}
+	}
+	p.total -= dropped
+	return dropped
+}
+
+// runSweep periodically drops expired parked packets until ctx is done. Parked
+// frames are normally taken within milliseconds (on route-group registration);
+// the sweep only reclaims frames for descriptors that never register.
+func (p *pendingPackets) runSweep(ctx context.Context, log *logging.Logger) {
+	t := time.NewTicker(pendingSweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			if n := p.sweep(now); n > 0 && log != nil {
+				log.WithField("dropped", n).Debug("Dropped parked packets whose route group never registered")
+			}
+		}
+	}
+}

--- a/pkg/router/router_pending_test.go
+++ b/pkg/router/router_pending_test.go
@@ -1,0 +1,75 @@
+// Package router pkg/router/router_pending_test.go
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+func testPendingDesc(srcPort, dstPort routing.Port) routing.RouteDescriptor {
+	var src, dst cipher.PubKey
+	return routing.NewRouteDescriptor(src, dst, srcPort, dstPort)
+}
+
+func TestPendingPackets_ParkAndTakeOnce(t *testing.T) {
+	p := newPendingPackets()
+	desc := testPendingDesc(1, 2)
+	pkt := routing.MakePingPacket(routing.RouteID(7), 0, 0)
+	now := time.Now()
+
+	require.True(t, p.park(desc, pkt, now))
+	require.True(t, p.park(desc, pkt, now))
+
+	taken := p.take(desc)
+	require.Len(t, taken, 2)
+	// A second take yields nothing and the buffer is empty.
+	require.Empty(t, p.take(desc))
+	require.Zero(t, p.total)
+}
+
+func TestPendingPackets_Bounds(t *testing.T) {
+	pkt := routing.MakePingPacket(routing.RouteID(1), 0, 0)
+	now := time.Now()
+
+	// Per-descriptor cap rejects beyond maxPendingPerDesc.
+	p := newPendingPackets()
+	desc := testPendingDesc(1, 2)
+	for i := 0; i < maxPendingPerDesc; i++ {
+		require.True(t, p.park(desc, pkt, now))
+	}
+	require.False(t, p.park(desc, pkt, now), "per-desc cap should reject")
+
+	// Total cap rejects beyond maxPendingTotal across distinct descriptors.
+	p2 := newPendingPackets()
+	parked := 0
+	for d := 0; parked < maxPendingTotal; d++ {
+		if p2.park(testPendingDesc(1000, routing.Port(d)), pkt, now) {
+			parked++
+		}
+	}
+	require.Equal(t, maxPendingTotal, parked)
+	require.False(t, p2.park(testPendingDesc(1, 1), pkt, now), "total cap should reject")
+}
+
+func TestPendingPackets_SweepExpired(t *testing.T) {
+	p := newPendingPackets()
+	desc := testPendingDesc(1, 2)
+	pkt := routing.MakePingPacket(routing.RouteID(1), 0, 0)
+	base := time.Now()
+
+	require.True(t, p.park(desc, pkt, base))
+	// Before the deadline nothing is swept and the frame is still deliverable.
+	require.Equal(t, 0, p.sweep(base.Add(pendingPacketTTL/2)))
+	require.Len(t, p.take(desc), 1)
+
+	// Past the deadline the parked frame is reclaimed.
+	require.True(t, p.park(desc, pkt, base))
+	require.Equal(t, 1, p.sweep(base.Add(pendingPacketTTL+time.Second)))
+	require.Empty(t, p.take(desc))
+	require.Zero(t, p.total)
+}

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -110,6 +110,10 @@ func (r *router) Serve(ctx context.Context) error {
 
 	go r.serveSetup()
 
+	// Reclaim frames parked during the route-group registration window whose
+	// route group never registers (see router_pending.go).
+	go r.pending.runSweep(ctx, r.logger)
+
 	return nil
 }
 
@@ -238,6 +242,16 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	// we put raw rg so it can be accessible to the router when handshake packets come in
 	r.rgsRaw[rules.Desc] = rg
 	r.mx.Unlock()
+
+	// Re-dispatch any frames that arrived for this descriptor during the
+	// rule-save -> registration window (the receive-side setup race). They were
+	// parked instead of dropped; deliver them now that the route group exists so
+	// a handshake frame that raced registration still completes the handshake.
+	for _, pp := range r.pending.take(rules.Desc) {
+		if err := rg.handlePacket(pp.pkt); err != nil {
+			log.WithError(err).Debug("Failed to re-dispatch parked packet after route group registration")
+		}
+	}
 
 	if nsConf.Initiator {
 		if err := rg.sendHandshake(true); err != nil {


### PR DESCRIPTION
Fixes a **receive-side route-setup race** behind the rare, intermediate-agnostic, busy-node-concentrated multihop-setup failures and the 4s-vs-40s setup-time variance.

**The race:** On the accept/responder side, `AcceptRoutes` (and source-side `DialRoutes`) call `SaveRoutingRules` **before** `saveRouteGroupRules` registers the route group (`rgsRaw[desc]`). A handshake/ping frame for the freshly-installed route can arrive in that window — its routing rule resolves, but no route group exists yet, so `dispatchToRouteGroup` returned `errRouteDescNotExist` and **dropped** it. Dropping the noise handshake's first frame stalls the handshake; the initiator times out at `handshakeAwaitTimeout` (6s) and futilely retries through a *different* intermediate, burning the setup budget.

**Evidence:** remote-log capture (`cli visor log --via dmsg://<pk>`) of a busy destination (651 transports) showed `[router] Failed to handle transport frame: route descriptor does not exist` immediately before each `Remote handshake not received within timeout`. A diagnostic sweep confirmed the failures were intermediate-agnostic (same dest succeeded via other relays before/after) — not version-skew, not bad relays.

**Fix:** park such frames (keyed by route descriptor, bounded + TTL'd) and re-dispatch them the moment the route group registers, instead of dropping. A background sweep reclaims frames whose group never registers.

- new `router_pending.go` + unit tests (park/take/bounds/sweep)
- ✅ build, `go test ./pkg/router -race` (full suite, 45s), golangci-lint clean
- ✅ validated on a live visor: clean boot, no router errors, 1-hop + 2-hop setup work