### PR TITLE
fix(dmsg/server): demote per-stream lifecycle logs INFO->DEBUG (log-spam fills disk)

### DIFF
--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -83,7 +83,7 @@ func (ss *ServerSession) Serve() {
 				continue
 			}
 
-			log.Info("Initiating stream.")
+			log.Debug("Initiating stream.")
 			go func(sStr *smux.Stream) {
 				defer func() { <-sem }()
 				defer func() {
@@ -92,7 +92,7 @@ func (ss *ServerSession) Serve() {
 					}
 				}()
 				err := ss.serveStream(log, sStr, ss.sm.addr)
-				log.WithError(err).Info("Stopped stream.")
+				log.WithError(err).Debug("Stopped stream.")
 			}(sStr)
 		}
 	} else {
@@ -119,7 +119,7 @@ func (ss *ServerSession) Serve() {
 				continue
 			}
 
-			log.Info("Initiating stream.")
+			log.Debug("Initiating stream.")
 			go func(yStr *yamux.Stream) {
 				defer func() { <-sem }()
 				defer func() {
@@ -128,7 +128,7 @@ func (ss *ServerSession) Serve() {
 					}
 				}()
 				err := ss.serveStream(log, yStr, ss.sm.addr)
-				log.WithError(err).Info("Stopped stream.")
+				log.WithError(err).Debug("Stopped stream.")
 			}(yStr)
 		}
 	}
@@ -314,7 +314,7 @@ func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteC
 	yStr = &idleTimeoutConn{rwc: yStr, timeout: streamIdleTimeout}
 	yStr2 = &idleTimeoutConn{rwc: yStr2, timeout: streamIdleTimeout}
 
-	log.Info("Serving stream.")
+	log.Debug("Serving stream.")
 	ss.m.RecordStream(metrics.DeltaConnect)
 	defer ss.m.RecordStream(metrics.DeltaDisconnect)
 	return netutil.CopyReadWriteCloser(yStr, yStr2)


### PR DESCRIPTION
A dmsg server logs `Initiating stream` / `Serving stream` / `Stopped stream` **once per stream at INFO**. On a busy deployment dmsg server (hundreds of transports → thousands of streams) this floods journald + `/var/log/syslog`.

**Observed in the field:** it filled the log filesystem on multiple deployment dmsg-server boards (~2GB/day of `[dmsg_srv]` INFO lines), which aborted dpkg with "No space left on device" and **silently blocked apt auto-updates** — boards sat on an old `skywire-bin` until the disk was cleared by hand. (Root-caused while remediating v1.3.66 boards that wouldn't update.)

**Fix:** demote the five per-stream lifecycle lines to DEBUG. Server- and peer-session lifecycle logs (`Serving server`, `Started/Stopped session`, peer reconnects) stay at INFO; genuine warnings (failed session handshake, max-concurrent-streams) are untouched.

✅ build + gofmt + golangci-lint clean.