### PR TITLE
fix(cli): don't silently serve stale data when --cache-age 0

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -633,7 +633,14 @@ func fetchViaDmsgDirect(dmsgURL string) ([]byte, error) {
 //   - Otherwise we fetch via FetchServiceURL and write the response through
 //     to the bbolt cache for the next call.
 //   - On fetch failure, a stale cached entry is returned as a last resort
-//     rather than propagating an empty string.
+//     rather than propagating an empty string — UNLESS the caller passed
+//     cacheFilesAge == 0, which signals "I want fresh data, no fallback".
+//     A loud failure is better than a silent stale response for callers
+//     that explicitly opted out of caching (e.g. nightly reward calcs
+//     that script against today's date and have no way to detect that
+//     the body they got was yesterday's).
+//   - When a stale entry IS returned, a warning is logged so callers
+//     who didn't opt out can still notice the data isn't fresh.
 //
 // Returns the response body as a string, or "" if every path failed and
 // there was no cache to fall back on. Errors are logged at debug level.
@@ -652,9 +659,14 @@ func FetchCachedServiceURL(cmdFlags *pflag.FlagSet, cachefile, thisurl string, c
 	body, err := FetchServiceURL(cmdFlags, thisurl)
 	if err != nil {
 		logger.Debugf("FetchCachedServiceURL: all fetch paths failed for %s: %v", thisurl, err)
-		// Last-ditch: return stale cache if we have one.
-		if cache != nil {
+		// Last-ditch: return stale cache if we have one, but only when
+		// the caller hasn't explicitly opted out of caching. cacheFilesAge
+		// == 0 means "fresh only, don't lie to me with yesterday's data";
+		// honoring that here keeps --cache-age 0 semantically meaningful
+		// even when the fresh-fetch chain has failed.
+		if cache != nil && cacheFilesAge > 0 {
 			if e, ok := cache.Get(thisurl); ok {
+				logger.Warnf("FetchCachedServiceURL: fresh fetch failed for %s; serving stale cache (data may be out of date)", thisurl)
 				return string(e.Body)
 			}
 		}


### PR DESCRIPTION
## Summary

`FetchCachedServiceURL` falls back to a stale cache entry when the fresh `RPC → DMSG → HTTP` chain fails. That's a reasonable last-resort when caching is enabled, but the fallback ignored `cacheFilesAge == 0` — the explicit *"I want fresh data, no fallback"* signal. Any caller running with `--cache-age 0` would silently receive yesterday's response if today's fetch failed, with no error and no log line at default verbosity.

## Repro

Two failures stack to produce this in practice for a dmsg-mapped service like TPD:

1. The visor's `RPC DmsgHTTP` step fails because the dmsg-discovery entry for the service can't be resolved in time (`dmsg error 100`, timeout on the delegated server).
2. Steps 2 (direct DMSG) and 3 (HTTP) are conditionally gated to only run when `--no-rpc` is set or the URL has no dmsg twin, so the fetch chain bottoms out with no successful body.
3. The last-ditch path returns whatever's in the bbolt cache from the previous run — typically a day or more old.

Hit while debugging the reward calc:

```
$ skywire cli ut tpd --since 2026-06-10 --until 2026-06-10 --cache-age 0 --cache-dir /tmp/probe
pk                                                                  ver        on
0200b3c311…                                                         -          no
```

NF=3, no `2026-06-10` column — that's the previous day's cached response served as if it were today's. `--cache-age 0` was meant to bypass cache entirely.

## Fix

Honor `cacheFilesAge == 0` in the last-ditch path. When the caller explicitly opted out of caching, a loud `error: empty response from … (all fetch paths failed)` is better than a silent stale response. When `cacheFilesAge > 0` the existing fallback still runs, but now logs a `WARN` line so callers can notice the data may be out of date.

## Test plan

- [x] `go test ./cmd/skywire-cli/commands/rpc/…` passes.
- [x] `go build ./cmd/skywire-cli/` succeeds.
- [x] With clean cache and broken RPC + `--cache-age 0`: errors loudly (`empty response from … (all fetch paths failed)`) instead of returning empty silently. ✓
- [x] With stale cache, broken RPC, and `--cache-age 60`: existing fallback fires, plus a `WARN` line announces the staleness. ✓
- [x] With working RPC: behavior unchanged. ✓