### PR TITLE
fix(visor): seed direct-service entries on minimal configs

### DIFF
--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -454,7 +454,12 @@ func (v *Visor) refreshDmsgServersCacheLoop(ctx context.Context, discURL string,
 }
 
 // dmsgServicePKs extracts public keys from dmsg:// URLs in the visor config.
-// Falls back to embedded deployment defaults for missing fields.
+// Falls back to embedded deployment defaults for each missing field so a
+// minimal config (which is the common case — most operators only override
+// the few fields they need) still seeds every direct-client deployment
+// service. Without these fallbacks all but ConfDmsg dropped to "" silently,
+// so DialStream for e.g. TPD hit the HTTP discovery, found no entry (TPD
+// is direct-client by design), and bailed with "entry not found".
 func (v *Visor) dmsgServicePKs() cipher.PubKeys {
 	pick := func(a, b string) string {
 		if a != "" {
@@ -463,16 +468,21 @@ func (v *Visor) dmsgServicePKs() cipher.PubKeys {
 		return b
 	}
 	dmsgURLs := []string{
-		v.conf.Dmsg.DiscoveryDmsg,
-		v.conf.Transport.DiscoveryDmsg,
-		v.conf.Transport.AddressResolverDmsg,
-		v.conf.Routing.RouteFinderDmsg,
-		v.conf.Launcher.ServiceDiscDmsg,
+		pick(v.conf.Dmsg.DiscoveryDmsg, deployment.Prod.DmsgDiscoveryDmsg),
+		pick(v.conf.Transport.DiscoveryDmsg, deployment.Prod.TransportDiscoveryDmsg),
+		pick(v.conf.Transport.AddressResolverDmsg, deployment.Prod.AddressResolverDmsg),
+		pick(v.conf.Routing.RouteFinderDmsg, deployment.Prod.RouteFinderDmsg),
+		pick(v.conf.Launcher.ServiceDiscDmsg, deployment.Prod.ServiceDiscoveryDmsg),
 		pick(v.conf.ConfServiceDmsg, deployment.Prod.ConfDmsg),
 	}
+	// UptimeTracker is the only nullable sub-config; treat a nil block
+	// the same as an empty AddrDmsg field and fall through to the embedded
+	// default so we still seed UT's PK on minimal configs.
+	utDmsg := deployment.Prod.UptimeTrackerDmsg
 	if v.conf.UptimeTracker != nil {
-		dmsgURLs = append(dmsgURLs, v.conf.UptimeTracker.AddrDmsg)
+		utDmsg = pick(v.conf.UptimeTracker.AddrDmsg, utDmsg)
 	}
+	dmsgURLs = append(dmsgURLs, utDmsg)
 	var pks cipher.PubKeys
 	for _, rawURL := range dmsgURLs {
 		if rawURL == "" {
@@ -499,10 +509,23 @@ func (v *Visor) dmsgServicePKs() cipher.PubKeys {
 // The synthetic entries list ALL known DMSG server PKs as delegated servers.
 // This lets DialStream try each server the visor is connected to — one of
 // them will be able to forward the stream to the service.
+//
+// Server PK list: prefer the visor config's explicit dmsg.servers list,
+// fall back to the embedded prod set (dmsg.Prod.DmsgServers) when the
+// config has none. Most minimal configs leave dmsg.servers empty and
+// rely on discovery to populate sessions at runtime; before this
+// fallback the seed returned early in that case and the service-PK
+// entries were never installed, so direct-client services like TPD
+// remained unreachable via DialStream until a manual seed.
 func (v *Visor) seedDmsgServiceEntries(dmsgC *dmsg.Client, log *logging.Logger) {
 	var serverPKs []cipher.PubKey
 	for _, srv := range v.conf.Dmsg.Servers {
 		serverPKs = append(serverPKs, srv.Static)
+	}
+	if len(serverPKs) == 0 {
+		for _, srv := range dmsg.Prod.DmsgServers {
+			serverPKs = append(serverPKs, srv.Static)
+		}
 	}
 	if len(serverPKs) == 0 {
 		return


### PR DESCRIPTION
## Summary

`seedDmsgServiceEntries()` only worked for visor configs that explicitly populated every `dmsg.*` / `transport.*` / `routing.*` / `launcher.*` / `dmsg.servers` field. On a minimal config — the common case, since most of those fields are optional and operators only override what they need — most fields are empty strings and the embedded deployment defaults never get used.

Two compounding gaps caused TPD (and every other direct-client deployment service) to remain unreachable via the visor's `DialStream`:

1. **`dmsgServicePKs()` built `dmsgURLs` from `v.conf.*` with no fallbacks except `ConfDmsg`.** Empty fields silently dropped out of the seed list. So an operator who never set `transport.discovery_dmsg` got no TPD PK seeded even though the binary embeds the prod default.
2. **`seedDmsgServiceEntries()` returned early when `v.conf.Dmsg.Servers` was empty.** Most minimal configs leave that field empty and rely on discovery to populate sessions at runtime; the seed bailed before installing any entry, leaving direct-client services unreachable until the operator either populated `dmsg.servers` or re-generated the config.

## How it surfaces

Any CLI call the visor proxies via its `DmsgHTTP` RPC — `skywire cli ut tpd …`, `skywire cli rewards bw-collect`, etc. — fails with:

```
RPC DmsgHTTP failed for dmsg://02b307aee5c8…:80/uptimes?v=v2:
  request failed: ... dmsg error 100 - entry is not found in discovery
```

The bug hides because `FetchCachedServiceURL` then falls back to whatever stale entry happens to be in the bbolt cache from a previous successful run (separate fix in #3087 — TODO: link), so the CLI returns yesterday's data with no error indication.

## Fix

- `pick(v.conf.X, deployment.Prod.X)` for every service URL field in `dmsgServicePKs()` so empty config fields fall through to the embedded prod default.
- Fall back to `dmsg.Prod.DmsgServers` for the server PK list in `seedDmsgServiceEntries()` when `v.conf.Dmsg.Servers` is empty.

Both fallbacks degrade gracefully — when nothing is available (test deployments, fully-custom configs) the seed still no-ops correctly.

## Test plan

- [x] `go build ./...` succeeds.
- [x] `go test ./pkg/visor/...` passes.
- [x] Verified by inspecting `dmsgServicePKs()` output on a minimal config: before fix, returns just `[ConfDmsg.PK]`; after fix, returns 7 PKs (dmsg-disc + TPD + AR + RF + SD + ConfDmsg + UT).