### PR TITLE
fix(pty): UI terminal — scheme override, visible disconnect, surface async write errors

### DIFF
--- a/pkg/pty/pty_client.go
+++ b/pkg/pty/pty_client.go
@@ -19,6 +19,13 @@ type PtyClient struct {
 	rpcC *rpc.Client
 	done chan struct{}
 	once sync.Once
+
+	// writeDone receives completed WriteAsync RPC calls so a later
+	// WriteAsync can surface a prior write's error, instead of silently
+	// dropping keystrokes until the Read path eventually notices the
+	// broken conn. Buffered; net/rpc drops replies (with a log line)
+	// rather than crashing if it ever fills.
+	writeDone chan *rpc.Call
 }
 
 // NewPtyClient creates a new pty client that interacts with a local pty.
@@ -30,9 +37,10 @@ func NewPtyClient(conn io.ReadWriteCloser) (*PtyClient, error) {
 		return nil, err
 	}
 	return &PtyClient{
-		log:  logging.MustGetLogger("pty:pty-client"),
-		rpcC: rpc.NewClient(conn),
-		done: make(chan struct{}),
+		log:       logging.MustGetLogger("pty:pty-client"),
+		rpcC:      rpc.NewClient(conn),
+		done:      make(chan struct{}),
+		writeDone: make(chan *rpc.Call, 64),
 	}, nil
 }
 
@@ -47,9 +55,10 @@ func NewProxyClient(conn io.ReadWriteCloser, rPK cipher.PubKey, rPort uint16) (*
 		return nil, err
 	}
 	return &PtyClient{
-		log:  logging.MustGetLogger("pty:proxy-client"),
-		rpcC: rpc.NewClient(conn),
-		done: make(chan struct{}),
+		log:       logging.MustGetLogger("pty:proxy-client"),
+		rpcC:      rpc.NewClient(conn),
+		done:      make(chan struct{}),
+		writeDone: make(chan *rpc.Call, 64),
 	}, nil
 }
 
@@ -95,16 +104,31 @@ func (sc *PtyClient) Write(b []byte) (int, error) {
 // interactive caller (the web terminal's input loop) isn't blocked a full
 // round-trip per keystroke. Ordering is preserved — net/rpc serializes
 // request sends, and the send encodes b before returning, so the caller may
-// reuse the buffer. The per-write result and error are intentionally dropped:
-// a broken conn surfaces on the Read path, which tears the session down.
-// Returns an error only if the client is already closed.
+// reuse the buffer.
+//
+// It returns an error if the client is closed OR if a PRIOR async write has
+// since failed: completed Write calls land on sc.writeDone, and each call
+// reaps them first, so a broken conn surfaces on the input path within a
+// keystroke or two instead of only when the Read path notices it.
 func (sc *PtyClient) WriteAsync(b []byte) error {
 	select {
 	case <-sc.done:
 		return io.ErrClosedPipe
 	default:
 	}
-	sc.rpcC.Go(sc.rpcMethod("Write"), &b, new(int), nil)
+	// Reap completed prior writes; report the first error encountered.
+	for {
+		select {
+		case call := <-sc.writeDone:
+			if call.Error != nil {
+				return processRPCError(call.Error)
+			}
+			continue
+		default:
+		}
+		break
+	}
+	sc.rpcC.Go(sc.rpcMethod("Write"), &b, new(int), sc.writeDone)
 	return nil
 }
 

--- a/pkg/pty/ui.go
+++ b/pkg/pty/ui.go
@@ -146,9 +146,21 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 		// Use binary mode for PTY data - text mode fails on non-UTF-8 bytes
 		wsConn := websocket.NetConn(r.Context(), ws, websocket.MessageBinary)
 
-		// open pty
+		// open pty. ?scheme=dmsg / ?scheme=skynet lets an operator force a
+		// transport when the default (skynet-first) is wedged to this peer;
+		// dialers that don't support schemes ignore it and use Dial().
 		logWS(wsConn, "Dialing...")
-		ptyConn, err := ui.dialer.Dial()
+		var ptyConn net.Conn
+		if scheme := r.URL.Query().Get("scheme"); scheme != "" {
+			if sd, ok := ui.dialer.(SchemeUIDialer); ok {
+				log.WithField("scheme", scheme).Debug("Dialing pty with operator-forced scheme.")
+				ptyConn, err = sd.DialScheme(scheme)
+			} else {
+				ptyConn, err = ui.dialer.Dial()
+			}
+		} else {
+			ptyConn, err = ui.dialer.Dial()
+		}
 		if err != nil {
 			writeWSError(log, wsConn, err)
 			return
@@ -276,6 +288,12 @@ func (ui *UI) Handler(customCommands map[string][]string) http.HandlerFunc {
 			}
 		}()
 		<-done
+
+		// The session ended — the pty stream dropped, the shell exited, or a
+		// keepalive failed. Tell the browser explicitly instead of leaving a
+		// frozen, blank-looking terminal, so the user reloads to reconnect
+		// rather than wondering whether it has hung.
+		logWS(wsConn, "\r\n\x1b[33m[skywire: session closed — reload the page to reconnect]\x1b[0m\r\n")
 	}
 }
 

--- a/pkg/pty/ui_dialer.go
+++ b/pkg/pty/ui_dialer.go
@@ -14,6 +14,16 @@ type UIDialer interface {
 	AddrString() string
 }
 
+// SchemeUIDialer is an optional extension of UIDialer for dialers that can
+// reach the peer over more than one transport scheme. When the pty handler
+// receives ?scheme=dmsg or ?scheme=skynet it calls DialScheme, letting an
+// operator force a transport — e.g. fall back to dmsg when the skynet route to
+// a peer is wedged. Dialers that don't implement this just use Dial().
+type SchemeUIDialer interface {
+	UIDialer
+	DialScheme(scheme string) (net.Conn, error)
+}
+
 // DmsgUIDialer returns a UIDialer that dials with dmsg.
 func DmsgUIDialer(dmsgC *dmsg.Client, rAddr dmsg.Addr) UIDialer {
 	return &dmsgUIDialer{dmsgC: dmsgC, rAddr: rAddr}

--- a/pkg/visor/skynet_first_dialer.go
+++ b/pkg/visor/skynet_first_dialer.go
@@ -57,6 +57,10 @@ type skynetFirstUIDialer struct {
 	rAddr dmsg.Addr
 }
 
+// Compile-time check that the dialer satisfies the scheme-aware interface the
+// pty UI handler probes for via ?scheme=.
+var _ pty.SchemeUIDialer = (*skynetFirstUIDialer)(nil)
+
 // SkynetFirstUIDialer returns a dmsgpty UIDialer that prefers the
 // skywire router for the pty stream and falls back to dmsg. The
 // dmsg client is required as the fallback transport.
@@ -122,6 +126,33 @@ func (d *skynetFirstUIDialer) Dial() (net.Conn, error) {
 	dmsgCtx, dmsgCancel := context.WithTimeout(context.Background(), dmsgFallbackDialTimeout)
 	defer dmsgCancel()
 	return d.dmsgC.Dial(dmsgCtx, d.rAddr)
+}
+
+// DialScheme implements pty.SchemeUIDialer, letting the hypervisor UI force a
+// transport via ?scheme=. "dmsg" skips the skynet attempt entirely (use when a
+// stale skynet route to the peer wedges the default skynet-first path);
+// "skynet" tries only skynet with no dmsg fallback; anything else is the
+// default skynet-first behavior.
+func (d *skynetFirstUIDialer) DialScheme(scheme string) (net.Conn, error) {
+	switch scheme {
+	case "dmsg":
+		if d.dmsgC == nil {
+			return nil, errNilDmsgClient
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), dmsgFallbackDialTimeout)
+		defer cancel()
+		return d.dmsgC.Dial(ctx, d.rAddr)
+	case "skynet":
+		ctx, cancel := context.WithTimeout(context.Background(), skynetFirstDialTimeout)
+		defer cancel()
+		return appnet.DialContext(ctx, appnet.Addr{
+			Net:    appnet.TypeSkynet,
+			PubKey: d.rAddr.PK,
+			Port:   routing.Port(d.rAddr.Port),
+		})
+	default:
+		return d.Dial()
+	}
 }
 
 func (d *skynetFirstUIDialer) AddrString() string {


### PR DESCRIPTION
Three reliability fixes for the hypervisor web terminal (`pkg/pty/ui.go`), which dials a connected visor's dmsgpty-host via `SkynetFirstUIDialer` (skynet first, dmsg fallback):

1. **Operator scheme override.** The UI always tried skynet first with no way to force dmsg when a stale skynet route to a peer wedges that path — the operator had to drop to the CLI (which has `--scheme`) or restart the hypervisor. Adds an optional `pty.SchemeUIDialer` interface; the handler reads `?scheme=dmsg` / `?scheme=skynet` and the visor's dialer honors it (dmsg = skip skynet entirely, skynet = no dmsg fallback, default = skynet-first). This is the highest operator-value fix for *"can I reliably get a terminal to any connected visor."*

2. **Visible disconnect.** When a session ended (stream dropped, shell exited, keepalive failed) the terminal just went blank — a dead session looked identical to a hung one. Now writes a clear `[session closed — reload to reconnect]` line to the websocket before closing.

3. **Surface WriteAsync errors.** WriteAsync fired keystrokes fire-and-forget and dropped the result, so a broken conn was only noticed later on the Read path — keystrokes vanished silently in between. Completed Write calls now land on a buffered channel each WriteAsync reaps first, so the input loop reports a failed write within a keystroke or two.

✅ build + `go test ./pkg/pty -race` + golangci-lint clean.

Full **auto-reconnect** (re-dial keeping the tab open) is a deliberate follow-up — it restructures the live pump loop (shared ptyC swap, wsReader re-point, keepalive re-bind) and warrants its own tested PR rather than being rushed into this one.