### PR TITLE
fix(hypervisor): enable web pty terminal for sub-hypervisor visors

### DIFF
--- a/pkg/visor/hypervisor_handlers_ctx.go
+++ b/pkg/visor/hypervisor_handlers_ctx.go
@@ -56,6 +56,15 @@ func (hv *Hypervisor) proxiedVisorConn(pk cipher.PubKey) (Conn, bool) {
 			return Conn{
 				Addr: hyperConn.Addr,
 				API:  newProxiedVisorAPI(pk, hyperConn.API),
+				// Operator actions (RPC) re-route through the
+				// sub-hypervisor, but the pty stream does NOT: this
+				// hypervisor dials the visor's dmsgpty-host directly
+				// over skynet/dmsg (SkynetFirstUIDialer), same as a
+				// directly-connected visor. The visor's dmsgpty
+				// whitelist admits this hypervisor, so the web
+				// terminal works for sub-hypervisor visors too
+				// instead of 503-ing on the nil-PtyUI guard.
+				PtyUI: setupDmsgPtyUI(hv.dmsgC, pk),
 			}, true
 		}
 	}


### PR DESCRIPTION
## Problem

The hypervisor web terminal (Terminal button → `/pty/{pk}`) returned **503 "pty UI not available for this visor"** for any visor that isn't directly connected to the hypervisor but is reachable through a connected **sub-hypervisor** (nested topology A → B → C, where you're on A and the visor C is connected to sub-hypervisor B).

## Root cause

`proxiedVisorConn` (`hypervisor_handlers_ctx.go`) builds a `Conn` whose operator-action **RPC API** is re-routed through the sub-hypervisor (`newProxiedVisorAPI`), but it left **`PtyUI` nil**. Directly-connected visors get `PtyUI: setupDmsgPtyUI(hv.dmsgC, pk)`. So `getPty`'s nil-guard (`ctx.PtyUI == nil`) fired and returned 503.

## Fix

Give the proxied `Conn` a `PtyUI` built the same way as a direct visor's. The pty **stream** does not need to proxy through the sub-hypervisor — this hypervisor dials the visor's dmsgpty-host **directly** over skynet/dmsg (`SkynetFirstUIDialer`); only the RPC actions route through B.

Verified live before writing the fix: from the parent hypervisor, `cli pty exec <proxied-visor-pk>` against a real sub-hypervisor visor returns its output — i.e. the visor's dmsgpty whitelist already admits the parent hypervisor and the direct dial reaches it. The web terminal just needed the same dialer.

As a bonus, the `?scheme=dmsg`/`?scheme=skynet` operator override (#3089) works for sub-hypervisor visors too, since it's the same `SkynetFirstUIDialer` (a `SchemeUIDialer`).

## Test

- `go build .` / `go vet ./pkg/visor/` clean.
- Manual: parent-hypervisor web terminal against a sub-hypervisor visor — was 503, now opens.