### PR TITLE
docs(site): add SkyNet, SOCKS5 proxy, and VPN apps to the Apps nav

### DIFF
--- a/docs/apps-overview.md
+++ b/docs/apps-overview.md
@@ -1,0 +1,66 @@
+# Apps
+
+Skywire visors host **apps** — programs that ride the encrypted Skywire
+network instead of the open internet. Each app is addressed by the hosting
+visor's public key (not an IP), runs over whatever transport the router
+selected (STCPR, SUDPH, or DMSG), and is gated by the visor's whitelist
+where access control applies.
+
+Most apps come in a **server**/**client** pair: one visor hosts the service,
+another connects to it. They are configured in `skywire-config.json` under
+`apps` (start on boot with `auto_start`) and controlled at runtime through
+`skywire cli` or the hypervisor UI.
+
+## Which app do I want?
+
+| You want to… | Use | Why |
+|---|---|---|
+| Route **all** of a machine's traffic through a remote exit | **[VPN](vpn/README.md)** | IP-level tunnel; your public IP becomes the server's |
+| Proxy **one application's** traffic (browser, curl, …) | **[SOCKS5 proxy](skysocks/README.md)** | Per-application SOCKS5; lighter than a full VPN |
+| Expose/reach a **specific TCP port** on a remote visor | **[SkyNet](skynet/README.md)** | Peer-to-peer port forwarding (web servers, SSH, databases) |
+| Open a **remote shell / transfer files** on a visor | **[PTY](pty/README.md)** | Key-addressed shell + sftp over the pty subsystem |
+| **Chat** with other visors | **[Skychat](skychat/README.md)** | Direct and group messaging |
+
+VPN vs. SOCKS5 is the most common decision: the **VPN** captures everything
+at the IP layer (and must run server and client on *different machines*),
+while the **SOCKS5 proxy** only carries traffic from applications you point
+at its local port — no host-network reconfiguration, and both ends can even
+be the same machine.
+
+## App reference
+
+| App | Role | CLI | Default port |
+|---|---|---|---|
+| [PTY](pty/README.md) | shell / sftp host | `skywire cli pty` | dmsg `22` |
+| [Skychat](skychat/README.md) | messaging | `skywire cli skychat` | `1` |
+| [SkyNet server](skynet/README.md) | port-forward host | `skywire cli skynet srv` | forwarding `47` |
+| [SkyNet client](skynet/client.md) | port-forward client | `skywire cli skynet` | `47` |
+| [SOCKS5 server](skysocks/README.md) | SOCKS5 proxy host | `skywire cli proxy server` | `3` |
+| [SOCKS5 client](skysocks/client.md) | SOCKS5 proxy client | `skywire cli proxy` | `13` |
+| [VPN server](vpn/README.md) | VPN host | `skywire cli vpn server` | `44` |
+| [VPN client](vpn/client.md) | VPN client | `skywire cli vpn` | `43` |
+
+Ports are the visor's internal app-routing ports (set per app in
+`skywire-config.json`), not host network ports.
+
+## Configuring an app
+
+Every app entry in `skywire-config.json` has the same shape:
+
+```json
+{
+  "name": "skysocks",
+  "args": ["-passcode", "123456"],
+  "auto_start": true,
+  "port": 3
+}
+```
+
+- `name` — the app binary.
+- `args` — app-specific flags (see each app's page).
+- `auto_start` — start the app when the visor boots.
+- `port` — the visor's internal routing port for the app.
+
+See each app's page for its `args`, CLI commands, and examples. For the full
+flag set of every command, see the
+[Command Reference](skywire/README.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,13 +35,13 @@ extend, or understand a Skywire deployment.
 
 !!! note "Per-app and per-service docs"
 
-    **[PTY](pty/README.md)** and **[Skychat](skychat/README.md)** now have
-    full guides in the **Apps** section above. The remaining visor-hosted
-    apps (skysocks, skynet, vpn) and the deployment services
-    (transport-discovery, route-finder, service-discovery, address-resolver,
-    uptime-tracker) still live alongside the source under
-    [`cmd/apps/`](https://github.com/skycoin/skywire/tree/develop/cmd/apps)
-    and [`cmd/svc/`](https://github.com/skycoin/skywire/tree/develop/cmd/svc),
+    The visor-hosted apps — **[PTY](pty/README.md)**,
+    **[Skychat](skychat/README.md)**, **[SkyNet](skynet/README.md)**,
+    **[SOCKS5 proxy](skysocks/README.md)**, and **[VPN](vpn/README.md)** —
+    now have full guides in the **Apps** section above. The deployment
+    services (transport-discovery, route-finder, service-discovery,
+    address-resolver, uptime-tracker) still live alongside the source under
+    [`cmd/svc/`](https://github.com/skycoin/skywire/tree/develop/cmd/svc)
     and will be integrated here in a follow-up.
 
 ## Other resources

--- a/docs/skynet/README.md
+++ b/docs/skynet/README.md
@@ -1,0 +1,81 @@
+# SkyNet — port forwarding
+
+SkyNet exposes a local TCP port on one visor and forwards it to localhost
+on another, peer-to-peer over the Skywire network. Unlike a DMSG tunnel it
+rides whatever transport the router selected — STCPR, SUDPH, or DMSG — so
+traffic does not have to transit a DMSG relay.
+
+SkyNet has two halves:
+
+- **SkyNet server** (this page) — exposes a local port to the network.
+- **[SkyNet client](client.md)** — connects to a server and forwards the
+  remote port to a local address.
+
+## Overview
+
+The SkyNet server is a visor-native application that:
+
+- Exposes a local TCP port to other Skywire visors.
+- Supports whitelist-based access control by public key.
+- Works over STCPR, SUDPH, or DMSG transports.
+- Registers with the visor's built-in forwarding service (port `47`).
+
+## Usage
+
+The server is controlled via `skywire cli skynet srv`.
+
+### Start a server
+
+```bash
+# Expose local port 8080
+skywire cli skynet srv start --port 8080
+
+# With a custom instance name
+skywire cli skynet srv start --port 3000 --name my-server
+
+# Restrict access to specific public keys (whitelist)
+skywire cli skynet srv start --port 8080 --wl 02abc...,03def...
+```
+
+### Check status
+
+```bash
+skywire cli skynet srv status
+```
+
+### Stop a server
+
+```bash
+# By name
+skywire cli skynet srv stop --name skynet-8080
+
+# By port
+skywire cli skynet srv stop --port 8080
+```
+
+## Configuration
+
+A SkyNet server can also be declared in `skywire-config.json` under `apps`
+so it starts with the visor:
+
+```json
+{
+  "name": "skynet",
+  "args": ["--port", "8080"],
+  "auto_start": false,
+  "port": 90
+}
+```
+
+## How it works
+
+1. The server registers with the visor's built-in forwarding service on
+   port `47`.
+2. A remote [SkyNet client](client.md) connects via a Skywire transport.
+3. Traffic is forwarded between the remote client and the local TCP port.
+4. All communication is encrypted by the Skywire transport layer.
+
+## See also
+
+- [SkyNet client](client.md) — connect to a SkyNet server.
+- [Command reference: `skywire cli skynet`](../skywire/README.md)

--- a/docs/skynet/client.md
+++ b/docs/skynet/client.md
@@ -1,0 +1,92 @@
+# SkyNet client
+
+The SkyNet client connects to a remote [SkyNet server](README.md) and
+forwards the remote port to a local address, giving you access to a service
+hosted on another Skywire visor as if it were running locally.
+
+## Overview
+
+The SkyNet client is a visor-native application that:
+
+- Connects to a remote SkyNet server over a Skywire transport.
+- Forwards a remote port to a local address.
+- Supports both HTTP and raw-TCP forwarding modes.
+- Can run multiple instances at once.
+
+## Usage
+
+The client is controlled via `skywire cli skynet`.
+
+### Start a client
+
+```bash
+# Connect to a server and forward the remote port to a local one
+skywire cli skynet start --pk <server-public-key> --remote 8080 --local 9000
+
+# Raw-TCP mode (databases, SSH, streaming — any non-HTTP traffic)
+skywire cli skynet start --pk <server-pk> --remote 3306 --local 3306 --raw-tcp
+
+# With a custom instance name
+skywire cli skynet start --pk <server-pk> --remote 8080 --local 9000 --name my-connection
+```
+
+### Check status
+
+```bash
+skywire cli skynet status
+```
+
+### Stop a client
+
+```bash
+skywire cli skynet stop --name skynet-client-9000
+```
+
+## Forwarding modes
+
+### HTTP mode (default)
+
+Best for web servers and HTTP-based services; handles request/response
+patterns efficiently.
+
+### Raw-TCP mode (`--raw-tcp`)
+
+Best for:
+
+- Database connections (MySQL, PostgreSQL)
+- SSH tunnelling
+- Streaming protocols
+- Any non-HTTP TCP traffic
+
+## Configuration
+
+A SkyNet client can be declared in `skywire-config.json` under `apps`:
+
+```json
+{
+  "name": "skynet-client",
+  "args": ["--pk", "02abc...", "--remote", "8080", "--local", "9000"],
+  "auto_start": false,
+  "port": 47
+}
+```
+
+## Example: accessing a remote web server
+
+```bash
+# Server side (remote visor) — expose a local web server
+python -m http.server 8080
+skywire cli skynet srv start --port 8080
+
+# Client side (your visor) — forward it to localhost:9000
+SERVER_PK="02abc..."   # the server's public key
+skywire cli skynet start --pk $SERVER_PK --remote 8080 --local 9000
+
+# Now reach the remote server locally
+curl http://localhost:9000
+```
+
+## See also
+
+- [SkyNet server](README.md) — host a SkyNet service.
+- [Command reference: `skywire cli skynet`](../skywire/README.md)

--- a/docs/skysocks/README.md
+++ b/docs/skysocks/README.md
@@ -1,0 +1,69 @@
+# SOCKS5 proxy — server (skysocks)
+
+`skysocks` implements a SOCKS5 proxy over the Skywire network. A visor runs
+the **server**; another visor runs the **[client](client.md)**, which exposes
+a local SOCKS5 port that any conventional SOCKS5 application can use. All
+traffic between the two visors is carried over an encrypted Skywire
+transport.
+
+The server optionally requires a passcode (set in its configuration). If no
+passcode is set, the server accepts connections without authentication.
+
+## Usage
+
+The server is controlled via `skywire cli proxy server`.
+
+```bash
+# Start the SOCKS5 server
+skywire cli proxy server start
+
+# Status
+skywire cli proxy server status
+
+# Stop
+skywire cli proxy server stop
+```
+
+## Configuration
+
+`skysocks` is enabled by default in a generated config (port `3`,
+`auto_start: true`). To require a passcode, pass `-passcode` in `args`:
+
+```json
+{
+  "name": "skysocks",
+  "args": ["-passcode", "123456"],
+  "auto_start": true,
+  "port": 3
+}
+```
+
+Leave `args` empty for an open (no-auth) server:
+
+```json
+{
+  "name": "skysocks",
+  "args": [],
+  "auto_start": true,
+  "port": 3
+}
+```
+
+## Connecting
+
+Point a [SOCKS5 client](client.md) on another visor at this server's public
+key. Once the client is running, a local SOCKS5 proxy is available — e.g.
+verify it with `curl`:
+
+```bash
+curl -v -x socks5://123456:@localhost:1080 https://api.ipify.org
+```
+
+(omit the `123456:@` user:pass segment if the server has no passcode).
+
+## See also
+
+- [SOCKS5 proxy client](client.md)
+- [VPN](../vpn/README.md) — full IP-level tunnelling (vs. per-application
+  SOCKS5)
+- [Command reference: `skywire cli proxy`](../skywire/README.md)

--- a/docs/skysocks/client.md
+++ b/docs/skysocks/client.md
@@ -1,0 +1,64 @@
+# SOCKS5 proxy — client (skysocks-client)
+
+`skysocks-client` is the client half of the [SOCKS5 proxy](README.md). It
+opens a persistent Skywire connection to a configured remote
+[`skysocks` server](README.md) and a local TCP port; all traffic arriving on
+that local port is forwarded over the Skywire connection. Any conventional
+SOCKS5 application can then use the local port.
+
+## Usage
+
+The client is controlled via `skywire cli proxy`.
+
+```bash
+# Start the client against a remote skysocks server
+skywire cli proxy start --pk <server-public-key>
+
+# List known proxy servers
+skywire cli proxy list
+
+# Status
+skywire cli proxy status
+
+# Stop
+skywire cli proxy stop
+```
+
+By default the client listens on local SOCKS5 port `1080`.
+
+## Configuration
+
+`skysocks-client` ships in a generated config (port `13`,
+`auto_start: false`). To start it automatically against a fixed server, set
+`-srv` (and `-passcode` if the server requires one) and flip `auto_start`:
+
+```json
+{
+  "name": "skysocks-client",
+  "args": ["-srv", "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7"],
+  "auto_start": true,
+  "port": 13
+}
+```
+
+## Using the proxy
+
+Point any SOCKS5-aware application at the client's local port:
+
+```bash
+curl -v -x socks5://localhost:1080 https://api.ipify.org
+```
+
+Your traffic exits to the internet from the remote server visor.
+
+## Multiplexed routes
+
+A proxy session can spread its traffic across several parallel routes for
+throughput and resilience. The `skywire cli proxy mux-*` commands
+(`mux-add`, `mux-rm`, `mux-set`, `mux-mode`, `mux-auto`, `mux-info`) manage
+the mux legs of an active session at runtime.
+
+## See also
+
+- [SOCKS5 proxy server](README.md)
+- [Command reference: `skywire cli proxy`](../skywire/README.md)

--- a/docs/vpn/README.md
+++ b/docs/vpn/README.md
@@ -1,0 +1,54 @@
+# VPN — server (vpn-server)
+
+`vpn-server` implements full IP-level VPN functionality over the Skywire
+network. A visor runs the **server**; another visor runs the
+**[client](client.md)**, which tunnels all of its machine's traffic through
+the server. Unlike the per-application [SOCKS5 proxy](../skysocks/README.md),
+the VPN captures traffic at the IP layer.
+
+The server optionally requires a passcode (set in its configuration). If no
+passcode is set, the server accepts connections without authentication.
+
+!!! note "Separate machines"
+
+    Because of how the VPN reconfigures host networking, the VPN server and
+    VPN client must run on **different machines** — you cannot run both on
+    one host.
+
+## Usage
+
+The server is controlled via `skywire cli vpn server`.
+
+```bash
+# Start the VPN server
+skywire cli vpn server start
+
+# Status
+skywire cli vpn server status
+
+# Stop
+skywire cli vpn server stop
+```
+
+## Configuration
+
+`vpn-server` ships in a generated config (port `44`, `auto_start: true`).
+To require a passcode, pass `-passcode` in `args`:
+
+```json
+{
+  "name": "vpn-server",
+  "args": ["-passcode", "1234"],
+  "auto_start": true,
+  "port": 44
+}
+```
+
+Leave `args` empty for an open (no-auth) server.
+
+## See also
+
+- [VPN client](client.md) — tunnel a machine's traffic through a VPN server.
+- [SOCKS5 proxy](../skysocks/README.md) — per-application proxying as a
+  lighter alternative.
+- [Command reference: `skywire cli vpn`](../skywire/README.md)

--- a/docs/vpn/client.md
+++ b/docs/vpn/client.md
@@ -1,0 +1,70 @@
+# VPN client (vpn-client)
+
+`vpn-client` is the client half of the [Skywire VPN](README.md). It opens a
+persistent Skywire connection to a configured remote [VPN server](README.md)
+and uses it as a tunnel, forwarding **all** of the machine's traffic through
+the server. Your public IP becomes the VPN server's IP.
+
+!!! note "Separate machines"
+
+    The VPN client and VPN server must run on **different machines** (see the
+    [server page](README.md)).
+
+## Usage
+
+The client is controlled via `skywire cli vpn`.
+
+```bash
+# List available VPN servers (from service discovery)
+skywire cli vpn list
+
+# Start the VPN against a remote server
+skywire cli vpn start --pk <server-public-key>
+
+# Status
+skywire cli vpn status
+
+# Stop
+skywire cli vpn stop
+
+# Open / print the VPN UI
+skywire cli vpn ui
+skywire cli vpn url
+```
+
+## Configuration
+
+`vpn-client` ships in a generated config (port `43`, `auto_start: false`).
+To start it automatically against a fixed server, set `-srv` (the server's
+public key) and `-passcode` if required, and flip `auto_start`:
+
+```json5
+{
+  "name": "vpn-client",
+  "args": [
+    "-srv", "03e9019b3caa021dbee1c23e6295c6034ab4623aec50802fcfdd19764568e2958d",
+    "-passcode", "1234"
+  ],
+  "auto_start": false,
+  "port": 43
+}
+```
+
+- `-srv` (required) — public key of the remote VPN server.
+- `-passcode` (optional) — passcode to authenticate the connection; omit if
+  the server has none.
+
+## Verifying
+
+With the VPN running, you should see an extra hop in `traceroute`, and your
+detected public IP should be the VPN server's:
+
+```bash
+traceroute google.com
+curl https://api.ipify.org
+```
+
+## See also
+
+- [VPN server](README.md)
+- [Command reference: `skywire cli vpn`](../skywire/README.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Guides: guides/README.md
   - Command Reference: skywire/README.md
   - Apps:
+      - Overview: apps-overview.md
       - PTY:
           - pty/README.md
           - pty/skywire-pty.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,15 @@ nav:
           - skychat/README.md
           - skychat/skychat-visor.md
           - skychat/standalone-skychat.md
+      - SkyNet:
+          - skynet/README.md
+          - skynet/client.md
+      - SOCKS5 Proxy:
+          - skysocks/README.md
+          - skysocks/client.md
+      - VPN:
+          - vpn/README.md
+          - vpn/client.md
   - Specs: specs/index.md
   - Rewards: rewards/index.md
   - Blog: https://blog.theskywirenetwork.net


### PR DESCRIPTION
## Problem

On the docs site (<https://skycoin.github.io/skywire>) the **Apps** nav only listed **PTY** and **Skychat** — the two curated `docs/<app>/` trees. The other six visor apps were missing entirely:

`skynet`, `skynet-client`, `skysocks`, `skysocks-client`, `vpn-server`, `vpn-client`.

They had READMEs only under `cmd/apps/*/`, which `scripts/docs-prepare.sh` deliberately defers staging (their relative links assume the `cmd/` location), so they never reached the site.

## Change

Add curated, grouped pages mirroring the existing pty/skychat pattern, and wire them into the nav:

| Group | Pages |
|---|---|
| **SkyNet** | `docs/skynet/README.md` (server), `docs/skynet/client.md` |
| **SOCKS5 Proxy** | `docs/skysocks/README.md` (server), `docs/skysocks/client.md` |
| **VPN** | `docs/vpn/README.md` (server), `docs/vpn/client.md` |

Content is adapted from the `cmd/apps` READMEs but **modernized**:

- Current config schema (`name`/`args`, not the stale `app`/`version` form the skysocks/vpn READMEs still used).
- Real CLI commands verified against the binary: `skywire cli skynet [srv]`, `skywire cli proxy [server]`, `skywire cli vpn [server]`.
- Canonical ports from `config gen` (skysocks 3, skysocks-client 13, vpn-server 44, vpn-client 43).
- Intra-site relative cross-links (server↔client, → command reference, VPN↔SOCKS5).

Also updates the `docs/index.md` note — these apps are no longer "follow-up"; only the `cmd/svc/` deployment services remain to integrate.

## Result

The **Apps** nav now reads: PTY · Skychat · SkyNet · SOCKS5 Proxy · VPN — all eight visor apps covered.

## Test

- All six nav-referenced files exist; cross-links resolve within `docs/`.
- Docs CI builds the site on PR (non-strict, per `docs.yml`).