### PR TITLE
feat(cli): add --load (CPU load / mem% / disk%) columns to hv ls

### DIFF
--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -40,6 +40,7 @@ func init() {
 	hvRmCmd.Flags().BoolVar(&hvRmAll, "all", false, "remove every runtime-added hypervisor connection")
 	hvCmd.AddCommand(hvLsCmd)
 	hvLsCmd.Flags().BoolVar(&hvLsFlat, "flat", false, "single flat table instead of one section per hypervisor")
+	hvLsCmd.Flags().BoolVar(&hvLsLoad, "load", false, "add LOAD (1m/cores), MEM%, and DISK% columns per visor")
 	hvCmd.AddCommand(hvTreeCmd)
 	hvCmd.AddCommand(hvPasswdCmd)
 	hvPasswdCmd.Flags().StringVar(&hvPasswdOld, "old", "", "current password (required unless --force)")
@@ -53,6 +54,7 @@ var (
 	hvPasswdNew   string
 	hvPasswdForce bool
 	hvLsFlat      bool
+	hvLsLoad      bool
 )
 
 var hvCmd = &cobra.Command{
@@ -301,10 +303,37 @@ from an env-var or a process-substitution.`,
 	},
 }
 
+// hvLsHeader returns the table header, appending the resource columns when
+// showLoad is set. A function (not a const) so flat- and tree-mode share one
+// definition that tracks the --load flag.
+func hvLsHeader(showLoad bool) string {
+	h := "PK\tLABEL\tVERSION\tUPTIME\tTP\tAPPS\tIP\tCC\tSTATUS"
+	if showLoad {
+		h += "\tLOAD\tMEM%\tDISK%"
+	}
+	return h
+}
+
+// fmtLoadCells renders the LOAD / MEM% / DISK% cells for a visor. LOAD is the
+// 1-minute average over the core count ("9.43/4") so saturation is obvious at a
+// glance; a value >= cores means the run queue is backed up. "-" when the visor
+// reported no load snapshot (older binary, or the metric was unavailable).
+func fmtLoadCells(e visor.HVVisorEntry) string {
+	if e.Load == nil {
+		return "-\t-\t-"
+	}
+	loadCell := fmt.Sprintf("%.2f", e.Load.Load1)
+	if e.Load.CPUCores > 0 {
+		loadCell = fmt.Sprintf("%.2f/%d", e.Load.Load1, e.Load.CPUCores)
+	}
+	return fmt.Sprintf("%s\t%.0f%%\t%.0f%%", loadCell, e.Load.MemUsedPercent, e.Load.DiskUsedPercent)
+}
+
 // formatHVVisorRow writes a single visor row to the tabwriter with optional
 // row-indent prefix. Centralized so the flat-mode and tree-mode renderings
-// stay in lockstep (same columns, same width, same null sentinels).
-func formatHVVisorRow(tw *tabwriter.Writer, e visor.HVVisorEntry, indent string) {
+// stay in lockstep (same columns, same width, same null sentinels). When
+// showLoad is set it appends the LOAD / MEM% / DISK% cells.
+func formatHVVisorRow(tw *tabwriter.Writer, e visor.HVVisorEntry, indent string, showLoad bool) {
 	pk := e.PK.String()
 	status := "ok"
 	if e.IsLocal {
@@ -336,11 +365,13 @@ func formatHVVisorRow(tw *tabwriter.Writer, e visor.HVVisorEntry, indent string)
 	if label == "" {
 		label = "-"
 	}
-	fmt.Fprintf(tw, "%s%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s\n", //nolint:errcheck
+	row := fmt.Sprintf("%s%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\t%s",
 		indent, pk, label, ver, uptime, e.Transports, e.Apps, ip, cc, status)
+	if showLoad {
+		row += "\t" + fmtLoadCells(e)
+	}
+	fmt.Fprintln(tw, row) //nolint:errcheck
 }
-
-const hvLsTableHeader = "PK\tLABEL\tVERSION\tUPTIME\tTP\tAPPS\tIP\tCC\tSTATUS"
 
 var hvLsCmd = &cobra.Command{
 	Use:   "ls",
@@ -376,9 +407,9 @@ For the legacy single flat-table output (e.g. for scripts), pass --flat.`,
 			}
 			var buf strings.Builder
 			tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(tw, hvLsTableHeader) //nolint:errcheck
+			fmt.Fprintln(tw, hvLsHeader(hvLsLoad)) //nolint:errcheck
 			for _, e := range entries {
-				formatHVVisorRow(tw, e, "")
+				formatHVVisorRow(tw, e, "", hvLsLoad)
 			}
 			tw.Flush() //nolint:errcheck,gosec
 			internal.PrintOutput(cmd.Flags(), entries, buf.String())
@@ -415,9 +446,9 @@ For the legacy single flat-table output (e.g. for scripts), pass --flat.`,
 				continue
 			}
 			tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(tw, "  "+hvLsTableHeader) //nolint:errcheck
+			fmt.Fprintln(tw, "  "+hvLsHeader(hvLsLoad)) //nolint:errcheck
 			for _, e := range section.Visors {
-				formatHVVisorRow(tw, e, "  ")
+				formatHVVisorRow(tw, e, "  ", hvLsLoad)
 			}
 			tw.Flush() //nolint:errcheck,gosec
 		}

--- a/cmd/skywire-cli/commands/visor/hv_load_test.go
+++ b/cmd/skywire-cli/commands/visor/hv_load_test.go
@@ -1,0 +1,50 @@
+// Package clivisor cmd/skywire-cli/commands/visor/hv_load_test.go
+package clivisor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+func TestHvLsHeader_LoadColumns(t *testing.T) {
+	base := hvLsHeader(false)
+	require.NotContains(t, base, "LOAD")
+	require.NotContains(t, base, "MEM%")
+
+	withLoad := hvLsHeader(true)
+	require.True(t, strings.HasPrefix(withLoad, base), "load header must extend the base header")
+	require.Equal(t, base+"\tLOAD\tMEM%\tDISK%", withLoad)
+}
+
+func TestFmtLoadCells(t *testing.T) {
+	tests := []struct {
+		name string
+		e    visor.HVVisorEntry
+		want string
+	}{
+		{
+			name: "nil load → dashes",
+			e:    visor.HVVisorEntry{},
+			want: "-\t-\t-",
+		},
+		{
+			name: "with cores → load/cores",
+			e:    visor.HVVisorEntry{Load: &visor.LoadStats{Load1: 9.43, CPUCores: 4, MemUsedPercent: 35.2, DiskUsedPercent: 100}},
+			want: "9.43/4\t35%\t100%",
+		},
+		{
+			name: "no cores → bare load",
+			e:    visor.HVVisorEntry{Load: &visor.LoadStats{Load1: 1.07, CPUCores: 0, MemUsedPercent: 12.9, DiskUsedPercent: 48.4}},
+			want: "1.07\t13%\t48%",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, fmtLoadCells(tt.e))
+		})
+	}
+}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -514,6 +514,10 @@ type Summary struct {
 	ConfigVersion        string                           `json:"config_version"`
 	PublicAutoconnect    bool                             `json:"public_autoconnect"`
 	IsPublic             bool                             `json:"is_public"`
+	// Load is a lightweight resource snapshot (load average, mem %, disk %)
+	// for the `hv ls --load` view. omitempty so the field is absent on
+	// summaries from older visors that don't populate it.
+	Load *LoadStats `json:"load,omitempty"`
 }
 
 // HealthInfo carries information about visor's services health.

--- a/pkg/visor/api_host_stats.go
+++ b/pkg/visor/api_host_stats.go
@@ -23,10 +23,45 @@ import (
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/load"
 	"github.com/shirou/gopsutil/v3/mem"
 	gnet "github.com/shirou/gopsutil/v3/net"
 	"github.com/shirou/gopsutil/v3/process"
 )
+
+// LoadStats is a lightweight, always-meaningful resource snapshot used by
+// `cli visor hv ls --load`: load averages (which, unlike a single CPUPercent
+// sample, need no prior baseline to be meaningful) plus instantaneous memory
+// and root-disk usage percentages. Cheap to gather (a few /proc reads + one
+// statfs), so it's populated on every Summary without a sampling interval.
+type LoadStats struct {
+	Load1           float64 `json:"load1"`
+	Load5           float64 `json:"load5"`
+	Load15          float64 `json:"load15"`
+	CPUCores        int     `json:"cpu_cores"`
+	MemUsedPercent  float64 `json:"mem_used_percent"`
+	DiskUsedPercent float64 `json:"disk_used_percent"`
+}
+
+// collectLoadStats gathers a LoadStats snapshot. Every field degrades
+// independently: a metric whose syscall fails (e.g. load.Avg on Windows) is
+// left at zero rather than failing the whole snapshot.
+func collectLoadStats() *LoadStats {
+	ls := &LoadStats{}
+	if avg, err := load.Avg(); err == nil && avg != nil {
+		ls.Load1, ls.Load5, ls.Load15 = avg.Load1, avg.Load5, avg.Load15
+	}
+	if n, err := cpu.Counts(true); err == nil {
+		ls.CPUCores = n
+	}
+	if vm, err := mem.VirtualMemory(); err == nil && vm != nil {
+		ls.MemUsedPercent = vm.UsedPercent
+	}
+	if du, err := disk.Usage("/"); err == nil && du != nil {
+		ls.DiskUsedPercent = du.UsedPercent
+	}
+	return ls
+}
 
 // HostStatsInfo carries a snapshot of host system + visor process
 // resource utilization. Returned by Visor.HostStats and surfaced

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -200,6 +200,7 @@ func (v *Visor) Summary() (*Summary, error) {
 		ConnectedDmsgServers: connectedDmsgServers,
 		DMSGServers:          dmsgServers,
 		IsHypervisor:         v.IsHypervisorEnabled(),
+		Load:                 collectLoadStats(),
 	}
 	if v.conf.Hypervisor != nil {
 		summary.HypervisorAddr = v.conf.Hypervisor.HTTPAddr

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -108,6 +108,10 @@ type HVVisorEntry struct {
 	// sub-hypervisor rather than a direct connection. The value is the PK
 	// of the sub-hypervisor that proxies operations on this visor.
 	ProxiedVia *cipher.PubKey `json:"proxied_via,omitempty"`
+	// Load is the visor's resource snapshot (load average, mem %, disk %),
+	// from summary.Load. Rendered by `hv ls --load`. omitempty so older
+	// sub-hypervisor binaries that don't carry it don't break the JSON shape.
+	Load *LoadStats `json:"load,omitempty"`
 }
 
 func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
@@ -124,6 +128,7 @@ func populateEntryFromSummary(entry *HVVisorEntry, summary *Summary) {
 	entry.ConfigVersion = summary.ConfigVersion
 	entry.RewardAddress = summary.RewardAddress
 	entry.Hostname = summary.Overview.Hostname
+	entry.Load = summary.Load
 	if summary.Health != nil {
 		entry.ServicesHealth = summary.Health.ServicesHealth
 	}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load.go
@@ -1,0 +1,33 @@
+package load
+
+import (
+	"encoding/json"
+
+	"github.com/shirou/gopsutil/v3/internal/common"
+)
+
+var invoke common.Invoker = common.Invoke{}
+
+type AvgStat struct {
+	Load1  float64 `json:"load1"`
+	Load5  float64 `json:"load5"`
+	Load15 float64 `json:"load15"`
+}
+
+func (l AvgStat) String() string {
+	s, _ := json.Marshal(l)
+	return string(s)
+}
+
+type MiscStat struct {
+	ProcsTotal   int `json:"procsTotal"`
+	ProcsCreated int `json:"procsCreated"`
+	ProcsRunning int `json:"procsRunning"`
+	ProcsBlocked int `json:"procsBlocked"`
+	Ctxt         int `json:"ctxt"`
+}
+
+func (m MiscStat) String() string {
+	s, _ := json.Marshal(m)
+	return string(s)
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_aix.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_aix.go
@@ -1,0 +1,19 @@
+//go:build aix
+// +build aix
+
+package load
+
+import (
+	"context"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+// Misc returns miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as Darwin implementation, but state is different.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_aix_cgo.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_aix_cgo.go
@@ -1,0 +1,60 @@
+//go:build aix && cgo
+// +build aix,cgo
+
+package load
+
+/*
+#cgo LDFLAGS: -L/usr/lib -lperfstat
+
+#include <libperfstat.h>
+#include <procinfo.h>
+*/
+import "C"
+
+import (
+	"context"
+	"unsafe"
+
+	"github.com/power-devops/perfstat"
+)
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	c, err := perfstat.CpuTotalStat()
+	if err != nil {
+		return nil, err
+	}
+	ret := &AvgStat{
+		Load1:  float64(c.LoadAvg1),
+		Load5:  float64(c.LoadAvg5),
+		Load15: float64(c.LoadAvg15),
+	}
+
+	return ret, nil
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	info := C.struct_procentry64{}
+	cpid := C.pid_t(0)
+
+	ret := MiscStat{}
+	for {
+		// getprocs first argument is a void*
+		num, err := C.getprocs64(unsafe.Pointer(&info), C.sizeof_struct_procentry64, nil, 0, &cpid, 1)
+		if err != nil {
+			return nil, err
+		}
+
+		ret.ProcsTotal++
+		switch info.pi_state {
+		case C.SACTIVE:
+			ret.ProcsRunning++
+		case C.SSTOP:
+			ret.ProcsBlocked++
+		}
+
+		if num == 0 {
+			break
+		}
+	}
+	return &ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_aix_nocgo.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_aix_nocgo.go
@@ -1,0 +1,66 @@
+//go:build aix && !cgo
+// +build aix,!cgo
+
+package load
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v3/internal/common"
+)
+
+var separator = regexp.MustCompile(`,?\s+`)
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	line, err := invoke.CommandWithContext(ctx, "uptime")
+	if err != nil {
+		return nil, err
+	}
+
+	idx := strings.Index(string(line), "load average:")
+	if idx < 0 {
+		return nil, common.ErrNotImplementedError
+	}
+	ret := &AvgStat{}
+
+	p := separator.Split(string(line[idx:len(line)]), 5)
+	if 4 < len(p) && p[0] == "load" && p[1] == "average:" {
+		if t, err := strconv.ParseFloat(p[2], 64); err == nil {
+			ret.Load1 = t
+		}
+		if t, err := strconv.ParseFloat(p[3], 64); err == nil {
+			ret.Load5 = t
+		}
+		if t, err := strconv.ParseFloat(p[4], 64); err == nil {
+			ret.Load15 = t
+		}
+		return ret, nil
+	}
+
+	return nil, common.ErrNotImplementedError
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	out, err := invoke.CommandWithContext(ctx, "ps", "-Ao", "state")
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &MiscStat{}
+	for _, line := range strings.Split(string(out), "\n") {
+		ret.ProcsTotal++
+		switch line {
+		case "R":
+		case "A":
+			ret.ProcsRunning++
+		case "T":
+			ret.ProcsBlocked++
+		default:
+			continue
+		}
+	}
+	return ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_bsd.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_bsd.go
@@ -1,0 +1,76 @@
+//go:build freebsd || openbsd
+// +build freebsd openbsd
+
+package load
+
+import (
+	"context"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	// This SysctlRaw method borrowed from
+	// https://github.com/prometheus/node_exporter/blob/master/collector/loadavg_freebsd.go
+	type loadavg struct {
+		load  [3]uint32
+		scale int
+	}
+	b, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+	load := *(*loadavg)(unsafe.Pointer((&b[0])))
+	scale := float64(load.scale)
+	ret := &AvgStat{
+		Load1:  float64(load.load[0]) / scale,
+		Load5:  float64(load.load[1]) / scale,
+		Load15: float64(load.load[2]) / scale,
+	}
+
+	return ret, nil
+}
+
+type forkstat struct {
+	forks    int
+	vforks   int
+	__tforks int
+}
+
+// Misc returns miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as Darwin implementation, but state is different.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	out, err := invoke.CommandWithContext(ctx, "ps", "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning++
+		} else if strings.Contains(l, "D") {
+			ret.ProcsBlocked++
+		}
+	}
+
+	f, err := getForkStat()
+	if err != nil {
+		return nil, err
+	}
+	ret.ProcsCreated = f.forks
+
+	return &ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_darwin.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_darwin.go
@@ -1,0 +1,67 @@
+//go:build darwin
+// +build darwin
+
+package load
+
+import (
+	"context"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	// This SysctlRaw method borrowed from
+	// https://github.com/prometheus/node_exporter/blob/master/collector/loadavg_freebsd.go
+	// this implementation is common with BSDs
+	type loadavg struct {
+		load  [3]uint32
+		scale int
+	}
+	b, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+	load := *(*loadavg)(unsafe.Pointer((&b[0])))
+	scale := float64(load.scale)
+	ret := &AvgStat{
+		Load1:  float64(load.load[0]) / scale,
+		Load5:  float64(load.load[1]) / scale,
+		Load15: float64(load.load[2]) / scale,
+	}
+
+	return ret, nil
+}
+
+// Misc returns miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as FreeBSD implementation, but state is different.
+// U means 'Uninterruptible Sleep'.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	out, err := invoke.CommandWithContext(ctx, "ps", "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning++
+		} else if strings.Contains(l, "U") {
+			// uninterruptible sleep == blocked
+			ret.ProcsBlocked++
+		}
+	}
+
+	return &ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_fallback.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_fallback.go
@@ -1,0 +1,26 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !windows && !solaris && !aix
+// +build !darwin,!linux,!freebsd,!openbsd,!windows,!solaris,!aix
+
+package load
+
+import (
+	"context"
+
+	"github.com/shirou/gopsutil/v3/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	return nil, common.ErrNotImplementedError
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_freebsd.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_freebsd.go
@@ -1,0 +1,8 @@
+//go:build freebsd
+// +build freebsd
+
+package load
+
+func getForkStat() (forkstat, error) {
+	return forkstat{}, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_linux.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_linux.go
@@ -1,0 +1,128 @@
+//go:build linux
+// +build linux
+
+package load
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/shirou/gopsutil/v3/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	stat, err := fileAvgWithContext(ctx)
+	if err != nil {
+		stat, err = sysinfoAvgWithContext()
+	}
+	return stat, err
+}
+
+func sysinfoAvgWithContext() (*AvgStat, error) {
+	var info syscall.Sysinfo_t
+	err := syscall.Sysinfo(&info)
+	if err != nil {
+		return nil, err
+	}
+
+	const si_load_shift = 16
+	return &AvgStat{
+		Load1:  float64(info.Loads[0]) / float64(1<<si_load_shift),
+		Load5:  float64(info.Loads[1]) / float64(1<<si_load_shift),
+		Load15: float64(info.Loads[2]) / float64(1<<si_load_shift),
+	}, nil
+}
+
+func fileAvgWithContext(ctx context.Context) (*AvgStat, error) {
+	values, err := readLoadAvgFromFile(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	load1, err := strconv.ParseFloat(values[0], 64)
+	if err != nil {
+		return nil, err
+	}
+	load5, err := strconv.ParseFloat(values[1], 64)
+	if err != nil {
+		return nil, err
+	}
+	load15, err := strconv.ParseFloat(values[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &AvgStat{
+		Load1:  load1,
+		Load5:  load5,
+		Load15: load15,
+	}
+
+	return ret, nil
+}
+
+// Misc returns miscellaneous host-wide statistics.
+// Note: the name should be changed near future.
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	filename := common.HostProcWithContext(ctx, "stat")
+	out, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &MiscStat{}
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		v, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch fields[0] {
+		case "processes":
+			ret.ProcsCreated = int(v)
+		case "procs_running":
+			ret.ProcsRunning = int(v)
+		case "procs_blocked":
+			ret.ProcsBlocked = int(v)
+		case "ctxt":
+			ret.Ctxt = int(v)
+		default:
+			continue
+		}
+
+	}
+
+	procsTotal, err := common.NumProcsWithContext(ctx)
+	if err != nil {
+		return ret, err
+	}
+	ret.ProcsTotal = int(procsTotal)
+
+	return ret, nil
+}
+
+func readLoadAvgFromFile(ctx context.Context) ([]string, error) {
+	loadavgFilename := common.HostProcWithContext(ctx, "loadavg")
+	line, err := os.ReadFile(loadavgFilename)
+	if err != nil {
+		return nil, err
+	}
+
+	values := strings.Fields(string(line))
+	return values, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_openbsd.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_openbsd.go
@@ -1,0 +1,18 @@
+//go:build openbsd
+// +build openbsd
+
+package load
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func getForkStat() (forkstat, error) {
+	b, err := unix.SysctlRaw("kern.forkstat")
+	if err != nil {
+		return forkstat{}, err
+	}
+	return *(*forkstat)(unsafe.Pointer((&b[0]))), nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_solaris.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_solaris.go
@@ -1,0 +1,74 @@
+//go:build solaris
+// +build solaris
+
+package load
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+)
+
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	out, err := invoke.CommandWithContext(ctx, "kstat", "-p", "unix:0:system_misc:avenrun_*")
+	if err != nil {
+		return nil, err
+	}
+
+	avg := &AvgStat{}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		flds := strings.Fields(scanner.Text())
+		if len(flds) < 2 {
+			continue
+		}
+		var tgt *float64
+		switch {
+		case strings.HasSuffix(flds[0], ":avenrun_1min"):
+			tgt = &avg.Load1
+		case strings.HasSuffix(flds[0], ":avenrun_5min"):
+			tgt = &avg.Load5
+		case strings.HasSuffix(flds[0], ":avenrun_15min"):
+			tgt = &avg.Load15
+		default:
+			continue
+		}
+		v, err := strconv.ParseInt(flds[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		*tgt = float64(v) / (1 << 8)
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return avg, nil
+}
+
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	out, err := invoke.CommandWithContext(ctx, "ps", "-efo", "s")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if l == "O" {
+			ret.ProcsRunning++
+		}
+	}
+
+	return &ret, nil
+}

--- a/vendor/github.com/shirou/gopsutil/v3/load/load_windows.go
+++ b/vendor/github.com/shirou/gopsutil/v3/load/load_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+// +build windows
+
+package load
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/internal/common"
+)
+
+var (
+	loadErr              error
+	loadAvg1M            float64 = 0.0
+	loadAvg5M            float64 = 0.0
+	loadAvg15M           float64 = 0.0
+	loadAvgMutex         sync.RWMutex
+	loadAvgGoroutineOnce sync.Once
+)
+
+// loadAvgGoroutine updates avg data by fetching current load by interval
+// TODO instead of this goroutine, we can register a Win32 counter just as psutil does
+// see https://psutil.readthedocs.io/en/latest/#psutil.getloadavg
+// code https://github.com/giampaolo/psutil/blob/8415355c8badc9c94418b19bdf26e622f06f0cce/psutil/arch/windows/wmi.c
+func loadAvgGoroutine(ctx context.Context) {
+	var (
+		samplingFrequency time.Duration = 5 * time.Second
+		loadAvgFactor1M   float64       = 1 / math.Exp(samplingFrequency.Seconds()/time.Minute.Seconds())
+		loadAvgFactor5M   float64       = 1 / math.Exp(samplingFrequency.Seconds()/(5*time.Minute).Seconds())
+		loadAvgFactor15M  float64       = 1 / math.Exp(samplingFrequency.Seconds()/(15*time.Minute).Seconds())
+		currentLoad       float64
+	)
+
+	counter, err := common.ProcessorQueueLengthCounter()
+	if err != nil || counter == nil {
+		return
+	}
+
+	tick := time.NewTicker(samplingFrequency).C
+
+	f := func() {
+		currentLoad, err = counter.GetValue()
+		loadAvgMutex.Lock()
+		loadErr = err
+		loadAvg1M = loadAvg1M*loadAvgFactor1M + currentLoad*(1-loadAvgFactor1M)
+		loadAvg5M = loadAvg5M*loadAvgFactor5M + currentLoad*(1-loadAvgFactor5M)
+		loadAvg15M = loadAvg15M*loadAvgFactor15M + currentLoad*(1-loadAvgFactor15M)
+		loadAvgMutex.Unlock()
+	}
+
+	f() // run first time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick:
+			f()
+		}
+	}
+}
+
+// Avg for Windows may return 0 values for the first few 5 second intervals
+func Avg() (*AvgStat, error) {
+	return AvgWithContext(context.Background())
+}
+
+func AvgWithContext(ctx context.Context) (*AvgStat, error) {
+	loadAvgGoroutineOnce.Do(func() {
+		go loadAvgGoroutine(ctx)
+	})
+	loadAvgMutex.RLock()
+	defer loadAvgMutex.RUnlock()
+	ret := AvgStat{
+		Load1:  loadAvg1M,
+		Load5:  loadAvg5M,
+		Load15: loadAvg15M,
+	}
+
+	return &ret, loadErr
+}
+
+func Misc() (*MiscStat, error) {
+	return MiscWithContext(context.Background())
+}
+
+func MiscWithContext(ctx context.Context) (*MiscStat, error) {
+	ret := MiscStat{}
+
+	return &ret, common.ErrNotImplementedError
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -778,6 +778,7 @@ github.com/shirou/gopsutil/v3/cpu
 github.com/shirou/gopsutil/v3/disk
 github.com/shirou/gopsutil/v3/host
 github.com/shirou/gopsutil/v3/internal/common
+github.com/shirou/gopsutil/v3/load
 github.com/shirou/gopsutil/v3/mem
 github.com/shirou/gopsutil/v3/net
 github.com/shirou/gopsutil/v3/process


### PR DESCRIPTION
## What

`skywire cli visor hv ls --load` adds **LOAD**, **MEM%**, and **DISK%** columns so an operator can spot an overloaded or disk-full connected visor straight from the CLI — without needing gotop.

```
PK    LABEL          VERSION   UPTIME    TP   APPS  IP             CC  STATUS  LOAD     MEM%  DISK%
...   localhost      v1.3.67   13h13m    182  6     172.105.179.5  AU  ok      3.03/1   65%   100%
...   alarm          v1.3.67   26h13m    3    6     70.121.13.123  US  ok      9.43/4   65%   13%
```

LOAD renders as the **1-minute load average over the core count** (`9.43/4`) so saturation is obvious at a glance (≥ cores = backed-up run queue).

## How

The *visor* self-reports its own numbers — no gotop/agent dependency on the hypervisor. The data already existed in `api_host_stats.go` (gopsutil); this threads a lightweight, always-meaningful snapshot through the existing `hv ls` path:

```
collectLoadStats()   load avg + mem% + disk%  (gopsutil, cheap: a few /proc reads + one statfs)
  -> Summary.Load            populated on every visor Summary()
  -> HVVisorEntry.Load       hypervisor aggregation (populateEntryFromSummary)
  -> hv ls --load columns    CLI render (flat + tree modes)
```

**Load average** is used instead of a `cpu.Percent` sample because it's meaningful without a prior baseline (a single `cpu.Percent(0,…)` call returns 0). Each metric degrades independently (a failing syscall — e.g. `load.Avg` on Windows — leaves zero), and the field is `omitempty` + nil-guarded, so against an **older** hypervisor/visor the columns render as `-` rather than breaking. Verified live against a running old hypervisor.

## Notes

- Vendors `github.com/shirou/gopsutil/v3/load` (the rest of gopsutil/v3 was already a dependency; only this subpackage was newly imported).
- Real values appear once both the hypervisor and the target visors run this build; until then `-`.
- Motivated by a live incident: a connected visor filled its disk (16G runaway syslog) and this is the at-a-glance readout that would have surfaced it.

## Test

- `go test ./cmd/skywire-cli/commands/visor/` — header toggle + cell formatting (nil / with-cores / without-cores).
- `go build ./...`, `go vet` clean.
- Manual: `hv ls --load --flat` against a running old hypervisor → graceful `-` columns, aligned, no crash.