### PR TITLE
fix(dmsghttp): stop dmsg-discovery CPU storm — server idle timeout was defeating the client stream pool

### DIFF
--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -137,6 +137,14 @@ func New(log logrus.FieldLogger, db store.Storer, m metrics.Metrics, testMode, e
 		clientEntryTTL:              clientEntryTTL,
 	}
 
+	// Per-remote rate limiting FIRST, before RealIP — it keys on the
+	// noise-authenticated dmsg PK in RemoteAddr, which RealIP would overwrite
+	// from a (spoofable) X-Real-IP header. Caps any single client so a
+	// busy-looping dmsg client can't pin the service at 100% CPU. Skipped under
+	// load testing, which deliberately drives high request rates.
+	if !enableLoadTesting {
+		r.Use(newRemoteRateLimiter().middleware)
+	}
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP) //nolint:staticcheck
 	r.Use(middleware.Logger)

--- a/pkg/dmsg/discovery/api/ratelimit.go
+++ b/pkg/dmsg/discovery/api/ratelimit.go
@@ -1,0 +1,119 @@
+// Package api pkg/dmsg/discovery/api/ratelimit.go
+//
+// Per-client request rate limiting for the discovery HTTP API. This is the
+// server-side counterpart to the client-side serve-loop floor: it protects the
+// discovery service even from clients that DON'T have that fix, by capping how
+// many requests any single dmsg client can issue per second. The limits are set
+// far above any legitimate client's discovery usage; the only thing they stop
+// is a misbehaving client busy-looping its discover/dial loop and pinning the
+// service at 100% CPU with tens of thousands of requests a second.
+//
+// Keyed by the dmsg public key — the noise-authenticated transport identity in
+// RemoteAddr — NOT a request header, so a client can't evade the limit by
+// opening fresh streams (the PK is constant) or by spoofing X-Real-IP. The
+// middleware is registered BEFORE chi's RealIP middleware for exactly that
+// reason. Fail-open: anything that isn't a dmsg PK (clearnet IPs, which may sit
+// behind a shared proxy) passes through untouched.
+package api
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	// rlPerRemoteRPS / rlPerRemoteBurst bound a single client PK. 100/s
+	// sustained with a 200 burst dwarfs real usage (a healthy client queries
+	// discovery a handful of times a second; even a connect-to-all enumeration
+	// is a one-shot burst), while turning a >10k/s storm into a non-event.
+	rlPerRemoteRPS   = 100
+	rlPerRemoteBurst = 200
+	// Stale limiters are swept so the map can't grow without bound across the
+	// service's lifetime (the incident saw a huge number of distinct clients).
+	rlEntryTTL      = 10 * time.Minute
+	rlSweepInterval = 5 * time.Minute
+)
+
+type rlEntry struct {
+	lim  *rate.Limiter
+	seen time.Time
+}
+
+// remoteRateLimiter is a per-key token-bucket limiter with TTL eviction.
+type remoteRateLimiter struct {
+	mu sync.Mutex
+	m  map[string]*rlEntry
+}
+
+func newRemoteRateLimiter() *remoteRateLimiter {
+	rl := &remoteRateLimiter{m: make(map[string]*rlEntry)}
+	go rl.sweepLoop()
+	return rl
+}
+
+func (rl *remoteRateLimiter) sweepLoop() {
+	t := time.NewTicker(rlSweepInterval)
+	defer t.Stop()
+	for range t.C {
+		cutoff := time.Now().Add(-rlEntryTTL)
+		rl.mu.Lock()
+		for k, e := range rl.m {
+			if e.seen.Before(cutoff) {
+				delete(rl.m, k)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+func (rl *remoteRateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	e := rl.m[key]
+	if e == nil {
+		e = &rlEntry{lim: rate.NewLimiter(rlPerRemoteRPS, rlPerRemoteBurst)}
+		rl.m[key] = e
+	}
+	e.seen = time.Now()
+	rl.mu.Unlock()
+	return e.lim.Allow()
+}
+
+// middleware throttles requests per remote dmsg PK. Non-dmsg callers (clearnet)
+// are passed through untouched.
+func (rl *remoteRateLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if key := dmsgRemoteKey(r.RemoteAddr); key != "" && !rl.allow(key) {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// dmsgRemoteKey returns the dmsg public key from a RemoteAddr ("PK:port"), or
+// "" if it isn't a dmsg PK — so only dmsg clients are rate-limited here.
+func dmsgRemoteKey(remoteAddr string) string {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	if len(host) == 66 && isHexStr(host) {
+		return host
+	}
+	return ""
+}
+
+func isHexStr(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/dmsg/discovery/api/ratelimit_test.go
+++ b/pkg/dmsg/discovery/api/ratelimit_test.go
@@ -1,0 +1,66 @@
+// Package api pkg/dmsg/discovery/api/ratelimit_test.go
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testPK = "022e607e0914d6e7ccda7587f95790c09e126bbd506cc476a1eda852325aadd1aa"
+
+func TestDmsgRemoteKey(t *testing.T) {
+	require.Equal(t, testPK, dmsgRemoteKey(testPK+":49457"), "dmsg PK:port -> PK")
+	require.Equal(t, testPK, dmsgRemoteKey(testPK), "bare PK -> PK")
+	require.Equal(t, "", dmsgRemoteKey("84.20.25.136:51234"), "clearnet IP is not rate-limited")
+	require.Equal(t, "", dmsgRemoteKey(""), "empty addr fails open")
+	require.Equal(t, "", dmsgRemoteKey("not-a-pk:80"), "non-hex host fails open")
+}
+
+func TestRemoteRateLimiter_BurstThenThrottle(t *testing.T) {
+	rl := &remoteRateLimiter{m: map[string]*rlEntry{}}
+	// Up to the burst is allowed; the next is denied (sustained rate is 100/s,
+	// so a tight burst beyond rlPerRemoteBurst can't be replenished in time).
+	allowed := 0
+	for i := 0; i < rlPerRemoteBurst+50; i++ {
+		if rl.allow(testPK) {
+			allowed++
+		}
+	}
+	require.LessOrEqual(t, allowed, rlPerRemoteBurst+1, "burst must be capped")
+	require.GreaterOrEqual(t, allowed, rlPerRemoteBurst-1, "should allow ~burst")
+
+	// A different PK has its own independent bucket.
+	other := strings.Repeat("0", 66)
+	require.True(t, rl.allow(other), "distinct client key gets its own budget")
+}
+
+func TestRateLimiterMiddleware_429AndPassthrough(t *testing.T) {
+	rl := &remoteRateLimiter{m: map[string]*rlEntry{}}
+	var served int
+	h := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { served++; w.WriteHeader(200) }))
+
+	// Drain a dmsg client's bucket, then expect a 429.
+	got429 := false
+	for i := 0; i < rlPerRemoteBurst+50; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/dmsg-discovery/all_servers", nil)
+		req.RemoteAddr = testPK + ":40000"
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	require.True(t, got429, "a flooding dmsg client must eventually get 429")
+
+	// A clearnet caller is never rate-limited here.
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.RemoteAddr = "84.20.25.136:51234"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, 200, w.Code, "clearnet caller passes through")
+}

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -264,33 +264,10 @@ func (ce *Client) Serve(ctx context.Context) {
 
 	needInitialPost := true
 
-	// minDiscoverInterval is the floor between discover→dial passes of the
-	// loop below. The select at the bottom of the loop normally blocks until a
-	// session drops or the 1-minute ticker fires, but a session whose dial
-	// fails immediately (bad/unreachable server entry, a handshake that errors
-	// or panics on the spot) can signal ce.errCh as fast as it can be
-	// re-dialed — turning this into a tight loop that re-queries dmsg-discovery
-	// (/all_servers, /entries, /entry, …) thousands of times a second and pins
-	// the discovery service at 100% CPU. A floor between passes bounds it to at
-	// most one discover+dial attempt per interval, no matter how fast errCh
-	// fires, without delaying a healthy reconnect meaningfully.
-	const minDiscoverInterval = 1 * time.Second
-	var lastDiscoverPass time.Time
-
 	for {
 		if isClosed(ce.done) {
 			return
 		}
-		if !lastDiscoverPass.IsZero() {
-			if wait := minDiscoverInterval - time.Since(lastDiscoverPass); wait > 0 {
-				select {
-				case <-ce.done:
-					return
-				case <-time.After(wait):
-				}
-			}
-		}
-		lastDiscoverPass = time.Now()
 		var entries []*disc.Entry
 		var err error
 		ce.log.Debug("Discovering dmsg servers...")

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -264,10 +264,33 @@ func (ce *Client) Serve(ctx context.Context) {
 
 	needInitialPost := true
 
+	// minDiscoverInterval is the floor between discover→dial passes of the
+	// loop below. The select at the bottom of the loop normally blocks until a
+	// session drops or the 1-minute ticker fires, but a session whose dial
+	// fails immediately (bad/unreachable server entry, a handshake that errors
+	// or panics on the spot) can signal ce.errCh as fast as it can be
+	// re-dialed — turning this into a tight loop that re-queries dmsg-discovery
+	// (/all_servers, /entries, /entry, …) thousands of times a second and pins
+	// the discovery service at 100% CPU. A floor between passes bounds it to at
+	// most one discover+dial attempt per interval, no matter how fast errCh
+	// fires, without delaying a healthy reconnect meaningfully.
+	const minDiscoverInterval = 1 * time.Second
+	var lastDiscoverPass time.Time
+
 	for {
 		if isClosed(ce.done) {
 			return
 		}
+		if !lastDiscoverPass.IsZero() {
+			if wait := minDiscoverInterval - time.Since(lastDiscoverPass); wait > 0 {
+				select {
+				case <-ce.done:
+					return
+				case <-time.After(wait):
+				}
+			}
+		}
+		lastDiscoverPass = time.Now()
 		var entries []*disc.Entry
 		var err error
 		ce.log.Debug("Discovering dmsg servers...")

--- a/pkg/dmsg/dmsghttp/http.go
+++ b/pkg/dmsg/dmsghttp/http.go
@@ -25,9 +25,24 @@ func ListenAndServe(ctx context.Context, _ cipher.SecKey, a http.Handler, _ disc
 	log.WithField("dmsg_addr", fmt.Sprintf("dmsg://%v", lis.Addr().String())).
 		Debug("Serving...")
 	srv := &http.Server{
-		ReadTimeout:       3 * time.Second,
-		WriteTimeout:      3 * time.Second,
-		IdleTimeout:       30 * time.Second,
+		ReadTimeout:  3 * time.Second,
+		WriteTimeout: 3 * time.Second,
+		// IdleTimeout governs how long a kept-alive dmsg stream is held open
+		// between requests. It MUST exceed the client's discovery refresh
+		// cadence (dmsg.DefaultUpdateInterval = 60s entry re-POST, plus
+		// dial-path entry lookups) or the server tears the stream down before
+		// the client reuses it — defeating the client-side stream pool
+		// (dmsghttp.HTTPTransport, 90s pool) and forcing a fresh noise-KK
+		// handshake on EVERY periodic call. That per-request handshake storm
+		// (secp256k1 ECDH in ClientSession.handshakeResponder) is exactly what
+		// pinned dmsg-discovery at 100% CPU: a profile showed ~40% cum in the
+		// handshake responder while the actual request rate was modest.
+		//
+		// Set just below dmsg.StreamIdleTimeout (120s) so the HTTP server
+		// always closes the idle stream cleanly before the underlying stream's
+		// read deadline fires. Was 30s — below the 60s refresh interval, so
+		// the pool could never span two refreshes.
+		IdleTimeout:       dmsg.StreamIdleTimeout - 5*time.Second,
 		ReadHeaderTimeout: 3 * time.Second,
 		MaxHeaderBytes:    1 << 14, // 16KB
 		Handler:           a,


### PR DESCRIPTION
## Root cause (corrected after profiling)

The dmsg-discovery CPU storm was **not** a request-rate problem. A live CPU profile of the pinned service showed ~**40% cumulative in `dmsg.(*ClientSession).handshakeResponder` → `noise.Secp256k1.DH` → `cipher.ECDH`** (secp256k1 point multiplication). The cost was a **fresh noise-KK handshake on essentially every discovery HTTP request**.

Why: each HTTP-over-dmsg request rides a dmsg stream, and every newly-accepted stream pays one handshake. The client already pools idle streams (`dmsghttp.HTTPTransport`, 90s) so periodic discovery calls reuse a stream instead of re-handshaking — but the **server** side (`dmsghttp.ListenAndServe`) set `http.Server.IdleTimeout = 30s`, **below the 60s entry-refresh cadence** (`dmsg.DefaultUpdateInterval`). The server tore the idle stream down at 30s, before the client's 60s refresh could reuse it; the pooled reuse then failed and the client re-dialed, paying a fresh handshake **every refresh**. The client pool was silently defeated fleet-wide → dmsgd pinned at 100% CPU for hours.

Measured at the service: `GET /dmsg-discovery/entry/<pk>` across ~330 distinct peers (~90/s, dial-path lookups) + `POST /entry/` (~36/s, entry re-registration) — modest rates, but each arriving on a brand-new stream + handshake.

## The fix

Raise the dmsghttp **server** `IdleTimeout` from 30s to `dmsg.StreamIdleTimeout - 5s` (115s): comfortably above the 60s refresh cadence so a pooled stream spans multiple refreshes, and just under the 120s dmsg stream read-deadline so the HTTP server still closes idle streams cleanly first. **Takes effect for every current client the moment dmsg-discovery and the dmsg-servers redeploy — no fleet update required.**

## Also in this PR

- **Per-PK request rate limiter** (`pkg/dmsg/discovery/api/ratelimit.go`, 100 rps / 200 burst per dmsg PK) — retained as complementary defense-in-depth. Post-fix, a misbehaving client reuses one kept-alive stream (one handshake) but could still flood requests on it; the limiter sheds that without forcing new handshakes. Keyed by the noise-authenticated dmsg PK (not a spoofable header), fails open for clearnet.
- **Reverted** the earlier client serve-loop discover floor: it targeted `/all_servers` (~5 req/s, not the storm) and gated `dmsgtest`'s reconnect cycles hard enough to trip the package's 5-minute test timeout.

## Test
- `pkg/dmsg/dmsghttp` ✓
- `pkg/dmsg/dmsgtest` ✓ (timeout gone after reverting the floor)
- ratelimit unit tests ✓