### PR TITLE
feat(skynet): `--direct` route — self-healing direct transport for control-plane forwards

### DIFF
--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -64,6 +64,14 @@ var (
 	// aggregate the bulk payload.
 	fwdMux int
 	revMux int
+	// direct, when set, forces a direct-transport-only route to the server:
+	// the router creates a direct transport if none exists and dials 1-hop
+	// over it, bypassing the route-finder. For control-plane forwards (e.g.
+	// the rsn-pprof resolving-proxy bridge) that need a reliable single hop
+	// and must self-heal when the peer restarts and its transport drops —
+	// avoiding the silent flaky-multihop fallback. Mutually exclusive with
+	// --min-hops >= 2 / --routes > 1 (which exist to force multi-hop).
+	direct bool
 	// reconnect, when set, makes per-accept dial failures retry
 	// indefinitely (with --reconnect-delay between attempts) instead
 	// of dropping the local conn on first failure. Closes the gap
@@ -89,6 +97,7 @@ func init() {
 	RootCmd.Flags().IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse direction only)")
 	RootCmd.Flags().IntVar(&fwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override (>0 sets forward leg count independent of --routes)")
 	RootCmd.Flags().IntVar(&revMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override (>0 sets reverse leg count; canonical download-heavy shape: --forward-mux 1 --reverse-mux N)")
+	RootCmd.Flags().BoolVar(&direct, "direct", false, "force a direct-transport-only route (create the transport on demand, dial 1-hop, bypass the route-finder); self-heals when the peer restarts")
 	RootCmd.Flags().BoolVar(&reconnect, "reconnect", false, "retry per-accept dial indefinitely instead of dropping local conn on remote-visor failure")
 	RootCmd.Flags().Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between per-accept dial retries when --reconnect is set")
 }
@@ -126,6 +135,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		fs.IntVar(&revMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override")
 		fs.IntVar(&fwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override")
 		fs.IntVar(&revMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override")
+		fs.BoolVar(&direct, "direct", false, "force a direct-transport-only route (create on demand, dial 1-hop, bypass route-finder)")
 		fs.BoolVar(&reconnect, "reconnect", false, "retry per-accept dial indefinitely on failure")
 		fs.Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between per-accept dial retries")
 		if err := fs.Parse(args); err != nil {
@@ -209,11 +219,14 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	if revMux > 0 {
 		dialShape += fmt.Sprintf(" reverse-mux=%d", revMux)
 	}
+	if direct {
+		dialShape += " direct(force-direct-tp, ensure-on-demand)"
+	}
 	appCl.Log().Infof("Per-accept dial shape: %s", dialShape)
 
 	rawDial := func() (net.Conn, error) {
-		if routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
-			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+		if direct || routes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
+			return appCl.DialWithOptions(connApp, routes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 		}
 		return appCl.Dial(connApp)
 	}

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -34,6 +34,7 @@ var (
 	startRevMinHops int    // per-direction reverse MinHops override
 	startFwdMux     int    // per-direction forward MuxRoutes override
 	startRevMux     int    // per-direction reverse MuxRoutes override
+	startDirect     bool   // force a direct-transport-only route (create on demand, dial 1-hop)
 )
 
 func init() {
@@ -57,6 +58,7 @@ func init() {
 	startCmd.Flags().IntVar(&startRevMinHops, "reverse-min-hops", 0, "per-direction reverse MinHops override (>=2 forces multi-hop on reverse only; combine with low/0 --min-hops for direct-upstream + multi-hop-downstream)")
 	startCmd.Flags().IntVar(&startFwdMux, "forward-mux", 0, "per-direction forward MuxRoutes override (>0 sets forward leg count independent of --routes)")
 	startCmd.Flags().IntVar(&startRevMux, "reverse-mux", 0, "per-direction reverse MuxRoutes override (download-heavy: --forward-mux 1 --reverse-mux N)")
+	startCmd.Flags().BoolVar(&startDirect, "direct", false, "force a direct-transport-only route: create the transport to the server on demand, dial 1-hop over it, bypass the route-finder; self-heals if the transport drops (e.g. server restart). For reliable control-plane forwards like the rsn-pprof resolving-proxy bridge.")
 	startCmd.MarkFlagsMutuallyExclusive("internal", "external")
 
 	stopCmd.Flags().StringVarP(&clientName, "name", "n", "", "name of the client instance to stop")
@@ -152,6 +154,10 @@ var startCmd = &cobra.Command{
 
 		if startRevMux > 0 {
 			arguments["--reverse-mux"] = fmt.Sprintf("%d", startRevMux)
+		}
+
+		if startDirect {
+			arguments["--direct"] = true
 		}
 
 		err = rpcClient.DoCustomSetting(appName, arguments)

--- a/pkg/app/appserver/mock_rpc_ingress_client.go
+++ b/pkg/app/appserver/mock_rpc_ingress_client.go
@@ -124,8 +124,8 @@ func (_m *MockRPCIngressClient) Dial(remote appnet.Addr) (uint16, routing.Port, 
 }
 
 // DialWithOptions provides a mock function with given fields: remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux
-func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int, fwdMux int, revMux int) (uint16, routing.Port, error) {
-	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes int, minHops int, fwdMinHops int, revMinHops int, fwdMux int, revMux int, direct bool) (uint16, routing.Port, error) {
+	ret := _m.Called(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DialWithOptions")
@@ -134,23 +134,23 @@ func (_m *MockRPCIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes in
 	var r0 uint16
 	var r1 routing.Port
 	var r2 error
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int) (uint16, routing.Port, error)); ok {
-		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int, bool) (uint16, routing.Port, error)); ok {
+		return rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 	}
-	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int) uint16); ok {
-		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+	if rf, ok := ret.Get(0).(func(appnet.Addr, int, int, int, int, int, int, bool) uint16); ok {
+		r0 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int, int, int) routing.Port); ok {
-		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+	if rf, ok := ret.Get(1).(func(appnet.Addr, int, int, int, int, int, int, bool) routing.Port); ok {
+		r1 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 	} else {
 		r1 = ret.Get(1).(routing.Port)
 	}
 
-	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int, int, int) error); ok {
-		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+	if rf, ok := ret.Get(2).(func(appnet.Addr, int, int, int, int, int, int, bool) error); ok {
+		r2 = rf(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/app/appserver/rpc_ingress_client.go
+++ b/pkg/app/appserver/rpc_ingress_client.go
@@ -28,7 +28,7 @@ type RPCIngressClient interface {
 	//   - fwdMux / revMux (per-direction MuxRoutes overrides; setting
 	//     fwdMux=1 + revMux=N yields 1 forward leg + N reverse legs)
 	// All <= 1 is equivalent to plain Dial.
-	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (connID uint16, localPort routing.Port, err error)
+	DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (connID uint16, localPort routing.Port, err error)
 	Listen(local appnet.Addr) (uint16, error)
 	Accept(lisID uint16) (connID uint16, remote appnet.Addr, err error)
 	Write(connID uint16, b []byte) (int, error)
@@ -96,7 +96,7 @@ func (c *rpcIngressClient) Dial(remote appnet.Addr) (connID uint16, localPort ro
 // DialWithOptions sends `DialWithOptions` command to the server.
 // All fields <= 1 falls through to plain Dial semantics on the server
 // side (no extra round-trip cost beyond the slightly larger request).
-func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (connID uint16, localPort routing.Port, err error) {
+func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (connID uint16, localPort routing.Port, err error) {
 	req := DialOptionsReq{
 		Addr:             remote,
 		MuxRoutes:        muxRoutes,
@@ -105,6 +105,7 @@ func (c *rpcIngressClient) DialWithOptions(remote appnet.Addr, muxRoutes, minHop
 		ReverseMinHops:   revMinHops,
 		ForwardMuxRoutes: fwdMux,
 		ReverseMuxRoutes: revMux,
+		Direct:           direct,
 	}
 	var resp DialResp
 	if err := c.rpc.Call(c.formatMethod("DialWithOptions"), &req, &resp); err != nil {

--- a/pkg/app/appserver/rpc_ingress_client_test.go
+++ b/pkg/app/appserver/rpc_ingress_client_test.go
@@ -129,7 +129,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// back to plain DialContext; the round-trip still succeeds and
 		// returns a valid ConnID. We're pinning the wire shape, not the
 		// router-level mux behavior (which is integration-tested).
-		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0, 0, 0)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 4, 0, 0, 0, 0, 0, false)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)
@@ -160,7 +160,7 @@ func TestRPCIngressClient_DialWithOptions(t *testing.T) {
 		// minHops=2 over a non-skynet networker — same fallthrough as
 		// the muxRoutes case. Pins that MinHops is wire-carried through
 		// DialOptionsReq even when the destination family ignores it.
-		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0, 0, 0)
+		connID, localPort, err := rpcC.DialWithOptions(remote, 0, 2, 0, 0, 0, 0, false)
 		require.NoError(t, err)
 		require.Equal(t, uint16(1), connID)
 		require.Equal(t, routing.Port(dmsgLocal.Port), localPort)

--- a/pkg/app/appserver/rpc_ingress_gateway.go
+++ b/pkg/app/appserver/rpc_ingress_gateway.go
@@ -151,6 +151,11 @@ type DialOptionsReq struct {
 	ReverseMinHops   int
 	ForwardMuxRoutes int
 	ReverseMuxRoutes int
+	// Direct, when true, forces a direct-transport-only dial: the router
+	// creates a direct transport to the destination if none exists, then dials
+	// 1-hop over it, bypassing the route-finder. The `--direct` skynet flag
+	// sets this. In spirit mutually exclusive with MinHops >= 2.
+	Direct bool
 }
 
 // Dial dials to the remote.
@@ -234,7 +239,7 @@ func (r *RPCIngressGateway) dialInternal(remote appnet.Addr, req *DialOptionsReq
 // mock or future alternative networker silently degrades to single-
 // route, preserving correctness with no extra plumbing).
 func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptionsReq) (net.Conn, error) {
-	if req == nil || (req.MuxRoutes <= 1 && req.MinHops <= 1 &&
+	if req == nil || (!req.Direct && req.MuxRoutes <= 1 && req.MinHops <= 1 &&
 		req.ForwardMinHops <= 1 && req.ReverseMinHops <= 1 &&
 		req.ForwardMuxRoutes <= 1 && req.ReverseMuxRoutes <= 1) {
 		return appnet.DialContext(ctx, remote)
@@ -256,6 +261,18 @@ func dialWithMuxRoutes(ctx context.Context, remote appnet.Addr, req *DialOptions
 	opts.ReverseMinHops = req.ReverseMinHops
 	opts.ForwardMuxRoutes = req.ForwardMuxRoutes
 	opts.ReverseMuxRoutes = req.ReverseMuxRoutes
+	if req.Direct {
+		// Force a 1-hop direct dial that creates the transport on demand and
+		// bypasses the route-finder. Mirrors the policy-layer Fallback="direct"
+		// short-circuit (UseExistingTpOnly + MinHops=1), plus EnsureDirectTransport
+		// so a missing/dropped transport is recreated instead of failing.
+		opts.EnsureDirectTransport = true
+		opts.UseExistingTpOnly = true
+		opts.MinHops = 1
+		opts.MuxRoutes = 0
+		opts.ForwardMuxRoutes = 0
+		opts.ReverseMuxRoutes = 0
+	}
 	return sw.DialContextWithOptions(ctx, remote, opts)
 }
 

--- a/pkg/app/client.go
+++ b/pkg/app/client.go
@@ -147,7 +147,7 @@ func (c *Client) SetAppPortOrLog(port routing.Port) {
 
 // Dial dials the remote visor using `remote`.
 func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
-	return c.dial(remote, 0, 0, 0, 0, 0, 0)
+	return c.dial(remote, 0, 0, 0, 0, 0, 0, false)
 }
 
 // DialWithOptions dials remote with per-call dial options.
@@ -171,8 +171,11 @@ func (c *Client) Dial(remote appnet.Addr) (net.Conn, error) {
 // --forward-min-hops / --reverse-min-hops / --forward-mux /
 // --reverse-mux flags) call this instead of Dial; non-mux callers
 // keep using Dial unchanged.
-func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (net.Conn, error) {
-	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+//   - direct: when true, forces a direct-transport-only dial — the router
+//     creates a direct transport to the remote if none exists and dials
+//     1-hop over it, bypassing the route-finder (the `--direct` skynet flag).
+func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (net.Conn, error) {
+	return c.dial(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 }
 
 // dial is the common body for Dial + DialWithOptions. When all opts
@@ -180,14 +183,14 @@ func (c *Client) DialWithOptions(remote appnet.Addr, muxRoutes, minHops, fwdMinH
 // existing wire shape for non-mux callers); otherwise sends the
 // DialWithOptions request so the server-side knows to take the
 // SkywireNetworker per-call-opts path.
-func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int) (net.Conn, error) {
+func (c *Client) dial(remote appnet.Addr, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux int, direct bool) (net.Conn, error) {
 	var (
 		connID    uint16
 		localPort routing.Port
 		err       error
 	)
-	if muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
-		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux)
+	if direct || muxRoutes > 1 || minHops > 1 || fwdMinHops > 1 || revMinHops > 1 || fwdMux > 1 || revMux > 1 {
+		connID, localPort, err = c.rpcC.DialWithOptions(remote, muxRoutes, minHops, fwdMinHops, revMinHops, fwdMux, revMux, direct)
 	} else {
 		connID, localPort, err = c.rpcC.Dial(remote)
 	}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -148,6 +148,7 @@ type DialOptions struct {
 	MaxConsumeRts       int
 	Retries             int
 	UseExistingTpOnly   bool          // If true, only use routes through existing transports, don't create new ones
+	EnsureDirectTransport bool        // If true, create a direct transport to the destination if none exists, then dial direct-only (the `--direct` foot-gun fix). Implies a 1-hop, route-finder-bypassing dial that self-heals when the transport drops.
 	TransportID         uuid.UUID     // If set, use this specific transport (skips route calculation for direct transports)
 	ForwardHops         []routing.Hop // If set, use these hops for forward path (skips route calculation)
 	ReverseHops         []routing.Hop // If set, use these hops for reverse path (skips route calculation)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -142,18 +142,18 @@ func (c *Config) SetDefaults() {
 
 // DialOptions describes dial options.
 type DialOptions struct {
-	MinForwardRts       int
-	MaxForwardRts       int
-	MinConsumeRts       int
-	MaxConsumeRts       int
-	Retries             int
-	UseExistingTpOnly   bool          // If true, only use routes through existing transports, don't create new ones
-	EnsureDirectTransport bool        // If true, create a direct transport to the destination if none exists, then dial direct-only (the `--direct` foot-gun fix). Implies a 1-hop, route-finder-bypassing dial that self-heals when the transport drops.
-	TransportID         uuid.UUID     // If set, use this specific transport (skips route calculation for direct transports)
-	ForwardHops         []routing.Hop // If set, use these hops for forward path (skips route calculation)
-	ReverseHops         []routing.Hop // If set, use these hops for reverse path (skips route calculation)
-	MuxRoutes           int           // Number of parallel routes to establish (0 or 1 = single route, >1 = mux)
-	ExcludeTransportIDs []uuid.UUID   // Transport IDs to exclude from route calculation (for mux)
+	MinForwardRts         int
+	MaxForwardRts         int
+	MinConsumeRts         int
+	MaxConsumeRts         int
+	Retries               int
+	UseExistingTpOnly     bool          // If true, only use routes through existing transports, don't create new ones
+	EnsureDirectTransport bool          // If true, create a direct transport to the destination if none exists, then dial direct-only (the `--direct` foot-gun fix). Implies a 1-hop, route-finder-bypassing dial that self-heals when the transport drops.
+	TransportID           uuid.UUID     // If set, use this specific transport (skips route calculation for direct transports)
+	ForwardHops           []routing.Hop // If set, use these hops for forward path (skips route calculation)
+	ReverseHops           []routing.Hop // If set, use these hops for reverse path (skips route calculation)
+	MuxRoutes             int           // Number of parallel routes to establish (0 or 1 = single route, >1 = mux)
+	ExcludeTransportIDs   []uuid.UUID   // Transport IDs to exclude from route calculation (for mux)
 	// MinHops, when > 0, is the per-call minimum hop count constraint.
 	// Overrides Config.MinHops for this dial only — needed by callers
 	// that want a non-direct path even when the visor's global

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -108,6 +108,23 @@ func (r *router) DialRoutes(
 	// set (symmetric or per-direction). Even if only ReverseMinHops > 1,
 	// downgrading globally to 1 would defeat that constraint for the
 	// reverse direction's route-finder query below.
+	// --direct: ensure a direct transport to the destination exists, creating
+	// one on demand if none is open. This is the self-healing half of the
+	// `--direct` foot-gun fix — when the direct transport drops (peer restart,
+	// etc.) the next dial recreates it instead of silently riding a flaky
+	// multihop route (the route-finder only returns a 1-hop route when a live
+	// direct transport is already known to TPD). After this, isTpdExist(rPK) is
+	// true → baseMinHops downgrades to 1, and UseExistingTpOnly (set alongside
+	// EnsureDirectTransport) bypasses the route-finder → a 1-hop direct dial.
+	if opts != nil && opts.EnsureDirectTransport && !r.isTpdExist(rPK) {
+		for _, nt := range []tptypes.Type{tptypes.STCPR, tptypes.SUDPH, tptypes.DMSG} {
+			if _, sErr := r.tm.SaveTransport(ctx, rPK, nt, transport.LabelAutomatic); sErr == nil {
+				log.WithField("tp_type", nt).WithField("remote", rPK).
+					Debug("--direct: created direct transport on demand")
+				break
+			}
+		}
+	}
 	if r.isTpdExist(rPK) && !opts.AnyMinHopsConstraint() {
 		baseMinHops = 1
 	}

--- a/pkg/vpn/client.go
+++ b/pkg/vpn/client.go
@@ -723,7 +723,7 @@ func (c *Client) dialServer(appCl *app.Client, pk cipher.PubKey) (net.Conn, erro
 	// Use the per-call dial options only when the user asked for multiplexed
 	// or multihop routing; otherwise keep the plain single-route dial.
 	if c.cfg.MuxRoutes > 1 || c.cfg.MinHops >= 2 {
-		conn, err = appCl.DialWithOptions(addr, c.cfg.MuxRoutes, c.cfg.MinHops, 0, 0, 0, 0)
+		conn, err = appCl.DialWithOptions(addr, c.cfg.MuxRoutes, c.cfg.MinHops, 0, 0, 0, 0, false)
 	} else {
 		conn, err = appCl.Dial(addr)
 	}


### PR DESCRIPTION
## Problem (the foot-gun)
A `skynet-client` forward silently rides whatever the route-finder returns. The finder only yields a **1-hop** route when the router's `isTpdExist()` sees an **open** direct transport *and* that edge is already in TPD's graph; otherwise the hop floor stays ≥2 and the dial goes **multihop** through an intermediate. When the peer restarts and its direct transport drops, **nothing recreates it**, so the forward degrades to a flaky multihop route.

Observed live on the `rsn-pprof` resolving-proxy bridge (`local:4443 → magnetosphere dmsgweb SOCKS5`): ~50% request loss through the local forward while the resolver was **100%** reliable directly on the magnetosphere host. Root cause: the route to magnetosphere was multihop via an intermediate (`next-transport` pointed at a *different* visor) despite a direct transport existing.

## Fix: `skynet start --direct`
- **Bypasses the route-finder** (`UseExistingTpOnly` + `MinHops=1`, mirroring the existing policy-layer `Fallback="direct"` short-circuit) → a 1-hop direct dial.
- **Ensures the transport on demand** — new `DialOptions.EnsureDirectTransport` makes `DialRoutes` create a direct transport (`stcpr→sudph→dmsg`) if none is open, on **every** dial. So the forward **self-heals** when the transport drops (peer restart) instead of falling back to flaky multihop.

## Plumbing (mirrors the existing `MinHops` path end-to-end)
CLI flag → app arg `--direct` → `Client.DialWithOptions(direct)` → `rpcIngressClient` → `DialOptionsReq.Direct` → `dialWithMuxRoutes` → `router.DialOptions{EnsureDirectTransport,UseExistingTpOnly,MinHops=1}` → per-dial `SaveTransport`.

In spirit mutually exclusive with `--min-hops>=2` / `--routes>1` (which force multi-hop). VPN's lone `DialWithOptions` caller updated (`direct=false`).

## Test
- `go build ./...` ✓, `go vet` ✓ (touched pkgs)
- `pkg/app/appserver` DialWithOptions tests ✓
- Pending: live validation by rolling the local visor + re-running `rsn-pprof` with `--direct` against the magnetosphere forward.
