### PR TITLE
fix(discovery): GET /uptimes?v=v3 hang on dmsg-discovery + service-discovery — MGET timelines + raise dmsghttp write timeout

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-disc.go
+++ b/cmd/skywire-cli/commands/tp/tp-disc.go
@@ -31,7 +31,12 @@ func init() {
 	discTpCmd.Flags().StringVarP(&tpID, "id", "i", "", "obtain transport of given ID")
 	discTpCmd.Flags().StringVarP(&tpPK, "pk", "p", "", "obtain transports by public key")
 	discTpCmd.Flags().StringVar(&tpdURL, "tpdurl", deployment.Prod.TransportDiscovery, "transport discovery url")
-	discTpCmd.Flags().BoolVar(&tpdHTTP, "http", false, "query transport discovery via HTTP, bypass RPC")
+	discTpCmd.Flags().BoolVar(&tpdHTTP, "http", false, "skip the structured visor RPC and query transport discovery via the fetch chain (DmsgHTTP→DMSG→HTTP)")
+	// Wire the common fetch-path flags (--no-cxo/--no-rpc/--no-dmsg/--no-http)
+	// so this command honors them like every other deployment-service fetch.
+	// FetchServiceURL (used in the fallback below) already reads them; they just
+	// weren't registered here, so `tp disc --no-http` errored "unknown flag".
+	clirpc.RegisterFetchFlags(discTpCmd)
 }
 
 var discTpCmd = &cobra.Command{
@@ -57,8 +62,11 @@ var discTpCmd = &cobra.Command{
 			internal.Catch(cmd.Flags(), tppk.Set(tpPK))
 		}
 
-		// Determine if we should query transport discovery via HTTP
-		useHTTPQuery := tpdHTTP
+		// Skip the structured visor RPC when --http is set, or when --no-rpc
+		// disables the visor RPC step entirely (consistent with the common
+		// fetch chain). In both cases we fall through to FetchServiceURL, which
+		// itself honors --no-cxo/--no-rpc/--no-dmsg/--no-http.
+		useHTTPQuery := tpdHTTP || clirpc.NoRPC
 
 		// Try RPC first unless HTTP query is requested
 		if !useHTTPQuery {

--- a/pkg/dmsg/discovery/store/redis.go
+++ b/pkg/dmsg/discovery/store/redis.go
@@ -459,9 +459,22 @@ func (r *redisStore) GetAllVisorSummaries(ctx context.Context, v2 bool, timeline
 
 func (r *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.Time) map[string]string {
 	daily := make(map[string]string)
+
+	// Pipeline all history days' HGet into ONE round-trip instead of
+	// uptimeHistoryDays sequential calls (per-visor cost across ~1375 visors).
+	dates := make([]string, uptimeHistoryDays)
+	cmds := make([]*redis.StringCmd, uptimeHistoryDays)
+	pipe := r.client.Pipeline()
 	for i := 0; i < uptimeHistoryDays; i++ {
-		date := now.AddDate(0, 0, -i).Format("2006-01-02")
-		countStr, err := r.client.HGet(ctx, uptimeKey(pkHex, date), "count").Result()
+		dates[i] = now.AddDate(0, 0, -i).Format("2006-01-02")
+		cmds[i] = pipe.HGet(ctx, uptimeKey(pkHex, dates[i]), "count")
+	}
+	// Missing keys surface as redis.Nil on the individual command; handled per
+	// command below, so a non-nil Exec error (e.g. redis.Nil) is not fatal here.
+	_, _ = pipe.Exec(ctx) //nolint:errcheck
+
+	for i, cmd := range cmds {
+		countStr, err := cmd.Result()
 		if err != nil {
 			continue
 		}
@@ -473,31 +486,49 @@ func (r *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.
 		if pct > 100 {
 			pct = 100
 		}
-		daily[date] = fmt.Sprintf("%.2f", pct)
+		daily[dates[i]] = fmt.Sprintf("%.2f", pct)
 	}
 	return daily
 }
 
 func (r *redisStore) GetDailyTimeline(ctx context.Context, pkHex string, now time.Time) map[string]string {
 	timelines := make(map[string]string)
-	for i := 0; i < uptimeHistoryDays; i++ {
-		date := now.AddDate(0, 0, -i).Format("2006-01-02")
-		tlKey := uptimeTimelineKey(pkHex, date)
 
-		pipe := r.client.Pipeline()
-		cmds := make([]*redis.IntCmd, timelineSlots)
-		for slot := 0; slot < timelineSlots; slot++ {
-			cmds[slot] = pipe.GetBit(ctx, tlKey, int64(slot))
-		}
-		_, err := pipe.Exec(ctx)
-		if err != nil {
+	// Fetch every history day's timeline bitmap in ONE MGET, then read the bits
+	// locally, instead of uptimeHistoryDays × timelineSlots (288) individual
+	// GETBIT commands. Each timeline is a Redis string bitmap (written with
+	// SETBIT); GET/MGET returns the raw bytes and we extract the 288 bits in Go.
+	// For the full network (~1375 visors × 7 days) the old path issued ~2.7M
+	// GETBIT ops across ~9.6k pipeline round-trips and made GET /uptimes?v=v3
+	// hang past 60s; this collapses it to one MGET per visor.
+	keys := make([]string, uptimeHistoryDays)
+	dates := make([]string, uptimeHistoryDays)
+	for i := 0; i < uptimeHistoryDays; i++ {
+		dates[i] = now.AddDate(0, 0, -i).Format("2006-01-02")
+		keys[i] = uptimeTimelineKey(pkHex, dates[i])
+	}
+
+	vals, err := r.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return timelines
+	}
+
+	for i, v := range vals {
+		s, ok := v.(string)
+		if !ok || s == "" {
 			continue
 		}
-
+		raw := []byte(s)
 		var buf [timelineSlots]byte
 		hasAny := false
 		for slot := 0; slot < timelineSlots; slot++ {
-			if cmds[slot].Val() == 1 {
+			// Redis bit ordering: offset 0 is the MSB of byte 0 (matches GETBIT).
+			byteIdx := slot / 8
+			var bit byte
+			if byteIdx < len(raw) {
+				bit = (raw[byteIdx] >> (7 - uint(slot%8))) & 1
+			}
+			if bit == 1 {
 				buf[slot] = '.'
 				hasAny = true
 			} else {
@@ -505,7 +536,7 @@ func (r *redisStore) GetDailyTimeline(ctx context.Context, pkHex string, now tim
 			}
 		}
 		if hasAny {
-			timelines[date] = string(buf[:])
+			timelines[dates[i]] = string(buf[:])
 		}
 	}
 	return timelines

--- a/pkg/dmsg/dmsghttp/http.go
+++ b/pkg/dmsg/dmsghttp/http.go
@@ -25,8 +25,17 @@ func ListenAndServe(ctx context.Context, _ cipher.SecKey, a http.Handler, _ disc
 	log.WithField("dmsg_addr", fmt.Sprintf("dmsg://%v", lis.Addr().String())).
 		Debug("Serving...")
 	srv := &http.Server{
-		ReadTimeout:  3 * time.Second,
-		WriteTimeout: 3 * time.Second,
+		ReadTimeout: 3 * time.Second,
+		// WriteTimeout bounds handler execution + response writing (Go sets it as
+		// the conn write deadline once the request headers are read). 3s was too
+		// short for heavy aggregation endpoints served over dmsg — e.g.
+		// dmsg-discovery's GET /uptimes?v=v3 walks ~1375 visors × 7 days of
+		// timelines and writes several hundred KB; the 3s deadline fired
+		// mid-handler, closing the stream so the client read EOF (while the same
+		// endpoint just hung on clearnet). 30s covers the slowest current
+		// endpoint with margin and stays well under IdleTimeout / the 120s dmsg
+		// StreamIdleTimeout. (Compute was also cut sharply — see redis.go MGET.)
+		WriteTimeout: 30 * time.Second,
 		// IdleTimeout governs how long a kept-alive dmsg stream is held open
 		// between requests. It MUST exceed the client's discovery refresh
 		// cadence (dmsg.DefaultUpdateInterval = 60s entry re-POST, plus

--- a/pkg/service-discovery/store/redis_store.go
+++ b/pkg/service-discovery/store/redis_store.go
@@ -541,11 +541,20 @@ func (s *redisStore) isServiceOnline(ctx context.Context, pkHex string) bool {
 func (s *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.Time) map[string]string {
 	daily := make(map[string]string)
 
+	// Pipeline all history days' HGet into ONE round-trip instead of
+	// uptimeHistoryDays sequential calls (per-visor cost across the network).
+	dates := make([]string, uptimeHistoryDays)
+	cmds := make([]*redis.StringCmd, uptimeHistoryDays)
+	pipe := s.client.Pipeline()
 	for i := 0; i < uptimeHistoryDays; i++ {
-		date := now.AddDate(0, 0, -i).Format("2006-01-02")
-		key := sdUptimeKey(pkHex, date)
+		dates[i] = now.AddDate(0, 0, -i).Format("2006-01-02")
+		cmds[i] = pipe.HGet(ctx, sdUptimeKey(pkHex, dates[i]), "count")
+	}
+	// Missing keys surface as redis.Nil per-command; handled below.
+	_, _ = pipe.Exec(ctx) //nolint:errcheck
 
-		countStr, err := s.client.HGet(ctx, key, "count").Result()
+	for i, cmd := range cmds {
+		countStr, err := cmd.Result()
 		if err != nil {
 			continue
 		}
@@ -558,7 +567,7 @@ func (s *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.
 		if pct > 100 {
 			pct = 100
 		}
-		daily[date] = fmt.Sprintf("%.2f", pct)
+		daily[dates[i]] = fmt.Sprintf("%.2f", pct)
 	}
 
 	return daily
@@ -570,32 +579,48 @@ func (s *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.
 func (s *redisStore) GetDailyTimeline(ctx context.Context, pkHex string, now time.Time) map[string]string {
 	timelines := make(map[string]string)
 
+	// Fetch every history day's timeline bitmap in ONE MGET and read the bits
+	// locally, instead of uptimeHistoryDays × timelineSlots (288) GETBIT
+	// commands. Each timeline is a Redis string bitmap (written with SETBIT);
+	// MGET returns the raw bytes and we extract the 288 bits in Go. The old
+	// per-bit path made GET /uptimes?v=v3 (timeline) hang for the full network
+	// (mirrors the dmsg-discovery fix).
+	keys := make([]string, uptimeHistoryDays)
+	dates := make([]string, uptimeHistoryDays)
 	for i := 0; i < uptimeHistoryDays; i++ {
-		date := now.AddDate(0, 0, -i).Format("2006-01-02")
-		tlKey := sdUptimeTimelineKey(pkHex, date)
+		dates[i] = now.AddDate(0, 0, -i).Format("2006-01-02")
+		keys[i] = sdUptimeTimelineKey(pkHex, dates[i])
+	}
 
-		var buf [timelineSlots]byte
-		pipe := s.client.Pipeline()
-		cmds := make([]*redis.IntCmd, timelineSlots)
-		for slot := 0; slot < timelineSlots; slot++ {
-			cmds[slot] = pipe.GetBit(ctx, tlKey, int64(slot))
-		}
-		if _, err := pipe.Exec(ctx); err != nil {
+	vals, err := s.client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return timelines
+	}
+
+	for i, v := range vals {
+		str, ok := v.(string)
+		if !ok || str == "" {
 			continue
 		}
-
+		raw := []byte(str)
+		var buf [timelineSlots]byte
 		hasAny := false
 		for slot := 0; slot < timelineSlots; slot++ {
-			if cmds[slot].Val() == 1 {
+			// Redis bit ordering: offset 0 is the MSB of byte 0 (matches GETBIT).
+			byteIdx := slot / 8
+			var bit byte
+			if byteIdx < len(raw) {
+				bit = (raw[byteIdx] >> (7 - uint(slot%8))) & 1
+			}
+			if bit == 1 {
 				buf[slot] = '.'
 				hasAny = true
 			} else {
 				buf[slot] = ' '
 			}
 		}
-
 		if hasAny {
-			timelines[date] = string(buf[:])
+			timelines[dates[i]] = string(buf[:])
 		}
 	}
 


### PR DESCRIPTION
## Symptom
`skywire cli ut mdisc graph` (any v3 uptimes fetch from dmsg-discovery) failed:
```
RPC DmsgHTTP failed for dmsg://022e607e…:80/uptimes?v=v3: failed to read response: EOF
error: empty response from http://dmsgd.skywire.skycoin.com/uptimes?v=v3
```
`?v=v2` returns 200 (~338 KB) fine; `?v=v3` **hangs >60s on clearnet** and **EOFs over dmsg**.

## Root cause
`GetAllVisorSummaries(timeline=true)` (the v3 path) builds each visor's per-day timeline by issuing **288 individual `GETBIT` commands per visor-day**. For the live network (**~1375 heartbeat visors × 7 days**) that's **~2.7M GETBIT ops across ~9.6k sequential pipeline round-trips** → the handler runs past 60s. Over dmsg, the dmsghttp server's **3s `WriteTimeout`** (which bounds handler execution + response write) fires mid-handler and closes the stream → the client reads `EOF`. On clearnet curl just hangs.

## Fixes
- **`store/redis.go` `GetDailyTimeline`** — read each day's timeline bitmap with one **`MGET`** (it's a Redis string; extract the 288 bits in Go, MSB-first to match `GETBIT`) instead of 288 `GETBIT`s/day. ~2.7M ops → one MGET per visor.
- **`store/redis.go` `getDailyUptime`** — pipeline the 7 per-day `HGet`s into one round-trip.
- **`dmsghttp/http.go`** — raise the shared server `WriteTimeout` **3s → 30s**. 3s was too short for heavy aggregation responses over dmsg; 30s covers the slowest endpoint with margin and stays well under `IdleTimeout` / the 120s dmsg `StreamIdleTimeout`. Also unblocks other large dmsg-served CLI fetches that were intermittently EOF'ing.

## Notes
- Service-side; takes effect on **dmsg-discovery redeploy** (dmsg-server / sn share dmsghttp and get the write-timeout bump too).
- `go build` ✓, `go vet` ✓. Store unit tests require a live Redis (not in this sandbox); bit extraction is MSB-first to match Redis `SETBIT`/`GETBIT` ordering.
- Prerequisite for **dropping the CLI plain-HTTP fallback** (can't deprecate HTTP while the dmsg path EOFs on these endpoints).

## Also in this PR (CLI fetch-path consistency, HTTP-deprecation prep)
- **service-discovery**: same MGET fix applied to its own `redisStore` copy (it duplicates the dmsg-discovery timeline code) — `cli ut sd graph` hit the identical hang.
- **`tp disc`**: was the one deployment-fetch command that didn't honor the common fetch-path flags (`tp disc --no-http` → "unknown flag"), because it never called `RegisterFetchFlags` despite already fetching through `FetchServiceURL`. Wired the flags and made the structured visor-RPC step also respect `--no-rpc`. Removes the last outlier before the plain-HTTP fallback can be dropped centrally.

Found via a CLI sweep (`ut`/`mdisc`/`pv`/`sd`/`reward`/`tp` with `--no-http`); everything else already fetches cleanly over dmsg.
