### PR TITLE
fix(cli): drop plain-HTTP fallback from deployment fetches + document the resolving proxy

### DIFF
--- a/cmd/skywire-cli/cliuptime/cliuptime.go
+++ b/cmd/skywire-cli/cliuptime/cliuptime.go
@@ -274,7 +274,7 @@ func fetchEntries(c *cobra.Command, baseURL, version string, visors []string, ca
 	cacheFile := cacheFilePath(cacheDir, baseURL, version, pks)
 	raw := clirpc.FetchCachedServiceURL(c.Flags(), cacheFile, fullURL, cacheAge)
 	if raw == "" {
-		return nil, fmt.Errorf("empty response from %s (all fetch paths failed; see --no-rpc / --no-dmsg / --no-http flags)", fullURL)
+		return nil, fmt.Errorf("empty response from %s (all fetch paths failed; see --no-cxo / --no-rpc / --no-dmsg flags)", fullURL)
 	}
 	var out []uptimestats.VisorSummary
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -359,18 +359,17 @@ var (
 	NoRPC bool
 	// NoDmsg disables the direct DMSG HTTP step in FetchServiceURL.
 	NoDmsg bool
-	// NoHTTP disables the HTTP fallback step in FetchServiceURL.
-	NoHTTP bool
 )
 
-// RegisterFetchFlags adds --no-cxo, --no-rpc, --no-dmsg, and --no-http
-// flags to a command. Call this in init() for any command that uses
-// FetchServiceURL.
+// RegisterFetchFlags adds --no-cxo, --no-rpc, and --no-dmsg flags to a command.
+// Call this in init() for any command that uses FetchServiceURL. There is no
+// plain-HTTP step anymore — deployment services are reached over CXO/DMSG only;
+// for ad-hoc browser access, point the browser at the visor's dmsgweb resolving
+// proxy instead of relying on a clearnet hop.
 func RegisterFetchFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&NoCXO, "no-cxo", false, "skip CXO subscriber-cache step")
 	cmd.Flags().BoolVar(&NoRPC, "no-rpc", false, "skip visor RPC (DmsgHTTP) step")
 	cmd.Flags().BoolVar(&NoDmsg, "no-dmsg", false, "skip direct DMSG HTTP step")
-	cmd.Flags().BoolVar(&NoHTTP, "no-http", false, "skip direct HTTP fallback step")
 }
 
 // isDmsgURL reports whether the given URL is a dmsg:// scheme URL that
@@ -713,16 +712,17 @@ func getCLICacheIfEnabled(cachefile string) *clicache.Cache {
 	return cliCache
 }
 
-// FetchServiceURL fetches a URL from a deployment service using a CXO/DMSG-first
-// chain:
+// FetchServiceURL fetches a URL from a deployment service over a CXO/DMSG-only
+// chain — there is NO plain-HTTP fallback:
 //  0. CXO — read the visor's local subscriber-cache snapshot (no round-trip)
 //  1. RPC — ask the running visor to proxy the request over DMSG (DmsgHTTP RPC)
 //  2. DMSG direct — ephemeral DMSG client (only when --no-rpc)
-//  3. HTTP — direct HTTP, ONLY for services with no DMSG equivalent (e.g.
-//     ip.skycoin.com). The dmsg-mapped deployment services get NO HTTP
-//     fallback — the deprecated plain-HTTP hop is gone for them.
 //
-// Steps can be disabled via --no-cxo, --no-rpc, --no-dmsg, and --no-http flags.
+// The plain-HTTP hop was removed deliberately: deployment services are all
+// dmsg-mapped (see DmsgURLForHTTP), the clearnet fallback was firing
+// erroneously, and there's no value in maintaining it — for ad-hoc browser
+// access to deployment data, point the browser at the visor's dmsgweb resolving
+// proxy. Steps can be disabled via --no-cxo, --no-rpc, and --no-dmsg.
 func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 	var lastErr error
 
@@ -809,33 +809,9 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 		}
 	}
 
-	// Step 3: Direct HTTP — last resort, ONLY for services with no DMSG path.
-	// The dmsg-mapped deployment services (sd/tpd/ar/rf/ut/dmsgd) are reachable
-	// over CXO + DMSG and intentionally get NO HTTP fallback: a plain-HTTP hop
-	// through their HTTP edge is the path being deprecated, so a dmsg-mapped
-	// service that fails CXO+DMSG now errors here rather than silently dropping
-	// to clearnet. HTTP survives only for HTTP-only services with no dmsg
-	// equivalent — currently just ip.skycoin.com (the public-IP echo the
-	// proxy/VPN exit-IP check uses; cli visor ip no longer needs it).
-	if !NoHTTP && DmsgURLForHTTP(url) == "" && !isDmsgURL(url) {
-		httpClient := &http.Client{Timeout: 30 * time.Second}
-		resp, err := httpClient.Get(url) //nolint:gosec
-		if err != nil {
-			lastErr = fmt.Errorf("HTTP: %w", err)
-			logger.Debugf("HTTP failed for %s: %v", url, err)
-		} else {
-			defer resp.Body.Close() //nolint:errcheck
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read HTTP response: %w", err)
-			}
-			if resp.StatusCode < 300 {
-				return body, nil
-			}
-			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
-			logger.Debugf("HTTP status %d for %s", resp.StatusCode, url)
-		}
-	}
+	// No plain-HTTP fallback: deployment services are reached over CXO/DMSG
+	// only. A dmsg-mapped service that fails CXO + DMSG errors below rather than
+	// dropping to clearnet.
 
 	if lastErr != nil {
 		return nil, lastErr

--- a/cmd/skywire-cli/commands/tp/tp-disc.go
+++ b/cmd/skywire-cli/commands/tp/tp-disc.go
@@ -31,11 +31,10 @@ func init() {
 	discTpCmd.Flags().StringVarP(&tpID, "id", "i", "", "obtain transport of given ID")
 	discTpCmd.Flags().StringVarP(&tpPK, "pk", "p", "", "obtain transports by public key")
 	discTpCmd.Flags().StringVar(&tpdURL, "tpdurl", deployment.Prod.TransportDiscovery, "transport discovery url")
-	discTpCmd.Flags().BoolVar(&tpdHTTP, "http", false, "skip the structured visor RPC and query transport discovery via the fetch chain (DmsgHTTP→DMSG→HTTP)")
-	// Wire the common fetch-path flags (--no-cxo/--no-rpc/--no-dmsg/--no-http)
-	// so this command honors them like every other deployment-service fetch.
-	// FetchServiceURL (used in the fallback below) already reads them; they just
-	// weren't registered here, so `tp disc --no-http` errored "unknown flag".
+	discTpCmd.Flags().BoolVar(&tpdHTTP, "http", false, "skip the structured visor RPC and query transport discovery via the fetch chain (CXO→DmsgHTTP→DMSG)")
+	// Wire the common fetch-path flags (--no-cxo/--no-rpc/--no-dmsg) so this
+	// command honors them like every other deployment-service fetch.
+	// FetchServiceURL (used in the fallback below) reads them.
 	clirpc.RegisterFetchFlags(discTpCmd)
 }
 
@@ -65,7 +64,7 @@ var discTpCmd = &cobra.Command{
 		// Skip the structured visor RPC when --http is set, or when --no-rpc
 		// disables the visor RPC step entirely (consistent with the common
 		// fetch chain). In both cases we fall through to FetchServiceURL, which
-		// itself honors --no-cxo/--no-rpc/--no-dmsg/--no-http.
+		// itself honors --no-cxo/--no-rpc/--no-dmsg.
 		useHTTPQuery := tpdHTTP || clirpc.NoRPC
 
 		// Try RPC first unless HTTP query is requested

--- a/docs/apps-overview.md
+++ b/docs/apps-overview.md
@@ -20,6 +20,7 @@ another connects to it. They are configured in `skywire-config.json` under
 | Expose/reach a **specific TCP port** on a remote visor | **[SkyNet](skynet/README.md)** | Peer-to-peer port forwarding (web servers, SSH, databases) |
 | Open a **remote shell / transfer files** on a visor | **[PTY](pty/README.md)** | Key-addressed shell + sftp over the pty subsystem |
 | **Chat** with other visors | **[Skychat](skychat/README.md)** | Direct and group messaging |
+| Reach a visor or deployment service **by public key** from a browser / `curl` over dmsg | **[Resolving proxy](guides/resolving-proxy.md)** | `.dmsg` / `.skynet` SOCKS5 resolver (`skywire cli resolver`); the supported way to view deployment-service data without a clearnet hop |
 
 VPN vs. SOCKS5 is the most common decision: the **VPN** captures everything
 at the IP layer (and must run server and client on *different machines*),

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -21,6 +21,7 @@ cobra subcommand tree.
 - [vpn.md](vpn.md) — Skywire VPN client/server with `skywire cli vpn`
 - [socks5.md](socks5.md) — Skywire SOCKS5 proxy client with `skywire cli proxy`
 - [skynet.md](skynet.md) — SkyNet P2P port forwarding with `skywire cli skynet`
+- [resolving-proxy.md](resolving-proxy.md) — the `.dmsg` / `.skynet` resolving SOCKS5 proxies (`skywire cli resolver`): reach visors and deployment services by public key over dmsg/skynet from a browser or `curl` — the supported way to view deployment-service data now that the CLI has no plain-HTTP fallback
 - [standalone-skychat.md](standalone-skychat.md) — `skywire app skychat --standalone --tcp-listen :PORT` for visor-independent chat-app with direct-TCP entry point; port-forwarding caveats
 - [standalone-dmsgpty-host.md](standalone-dmsgpty-host.md) — `skywire dmsg pty host --tcplisten :PORT` for visor-independent pty server with DMSG + TCP modes; port-forwarding caveats
 

--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -1,0 +1,101 @@
+# The `.dmsg` / `.skynet` resolving proxy
+
+`skywire cli resolver` runs two embedded **resolving SOCKS5 proxies** inside the
+visor. They let any SOCKS5-aware program — a browser, `curl`, etc. — reach
+skywire peers and deployment services **by public key, over dmsg or skynet**,
+with no clearnet hop and no per-target configuration:
+
+- **dmsgweb** — resolves `*.dmsg` hostnames and tunnels them straight over the
+  visor's dmsg client. Default listener: `127.0.0.1:4445`.
+- **skynetweb** — resolves `*.skynet` hostnames over skywire transports (the
+  same routes `cli skynet` port-forwarding uses). Default listener:
+  `127.0.0.1:4446`.
+
+By default `resolver up` brings both up and **chains dmsgweb → skynetweb**, so a
+single browser/curl proxy entry at `127.0.0.1:4445` covers `.dmsg`, `.skynet`,
+and — with `--upstream` — everything else too.
+
+> Since the CLI no longer falls back to plain HTTP for deployment services (they
+> are reached over dmsg only), the resolving proxy is the supported way to view a
+> deployment service's data in a browser or with `curl`.
+
+## Enable / disable / status
+
+```
+skywire cli resolver            # status of both resolvers
+skywire cli resolver up         # enable both (dmsgweb chained to skynetweb)
+skywire cli resolver up --dmsg-only
+skywire cli resolver up --upstream 127.0.0.1:1080   # send other traffic to a SOCKS5 (e.g. skysocks)
+skywire cli resolver down       # disable both
+```
+
+To enable them at config-generation / autoconfig time instead (writes
+`DMSGWEB=true` / `SKYNETWEB=true` into `skywire.conf`):
+
+```
+skywire cli config gen --dmsgweb --skynetweb ...
+# or, on an installed system:
+sudo skywire autoconfig --dmsgweb --skynetweb
+```
+
+## Addressing
+
+A resolver hostname is `<public-key>.<suffix>:<port>/<path>`:
+
+- `<public-key>` — the 66-hex-char public key of the target visor or service.
+- `:<port>` — the **dmsg port** the target serves HTTP on. **Deployment services
+  serve their API on dmsg port `80`.**
+- `.dmsg` addresses may carry routing prefixes, e.g. `<server-pk>.<dest-pk>.dmsg`
+  pins a specific dmsg rendezvous server. Use `cli tp route-addr` to build one.
+
+## From `curl`
+
+Use `socks5h://` (the `h` makes the **proxy** resolve the hostname — required for
+`.dmsg`/`.skynet`):
+
+```
+curl -x socks5h://127.0.0.1:4445 http://<visor-pk>.dmsg:80/health
+```
+
+### Browsing deployment-service data over dmsg
+
+```
+# uptime tracker (dmsg-discovery copy); v3 = with the daily timeline
+curl -x socks5h://127.0.0.1:4445 'http://<dmsgd-pk>.dmsg:80/uptimes?v=v3'
+# service discovery — list VPN servers
+curl -x socks5h://127.0.0.1:4445 'http://<sd-pk>.dmsg:80/api/services?type=vpn'
+# transport discovery — all transports
+curl -x socks5h://127.0.0.1:4445 'http://<tpd-pk>.dmsg:80/all-transports'
+```
+
+Deployment service public keys live in the embedded deployment config; `cli svc`
+and the per-command `--*url` flags also surface them.
+
+## From a browser
+
+Set the browser's SOCKS5 proxy to `127.0.0.1:4445` and enable "proxy DNS when
+using SOCKS v5" / "remote DNS" so the proxy (not your OS) resolves `.dmsg` /
+`.skynet` names. Then open `http://<pk>.dmsg:<port>/` directly. With `--upstream`
+configured, ordinary browsing still works through the same proxy entry.
+
+## HTTPS / TLS
+
+A `.dmsg` / `.skynet` stream is already end-to-end encrypted and authenticated by
+the target's public key, so plain `http://` through the proxy is secure. To
+satisfy a browser's secure-context requirements (or reach a TLS backend), the
+resolver can terminate TLS locally with a per-host leaf certificate — see
+[../skynet-tls.md](../skynet-tls.md) and `skywire cli resolver ca`.
+
+## Running the resolver on a remote visor
+
+A low-power or poorly-connected device can use a well-connected visor's resolver:
+expose that visor's SOCKS5 port over a `cli skynet` port-forward and point your
+browser/curl at the forwarded local port. Add `--direct` to the forward for a
+reliable single-hop route to the resolver host (it creates the direct transport
+on demand and skips the route-finder).
+
+## See also
+
+- [command reference: `skywire cli resolver`](../skywire/cli/resolver/README.md)
+- [skynet.md](skynet.md) — `.skynet` port forwarding that skynetweb builds on
+- [../skynet-tls.md](../skynet-tls.md) — resolver TLS MITM mode

--- a/docs/skysocks/client.md
+++ b/docs/skysocks/client.md
@@ -1,64 +1,160 @@
 # SOCKS5 proxy — client (skysocks-client)
 
-`skysocks-client` is the client half of the [SOCKS5 proxy](README.md). It
-opens a persistent Skywire connection to a configured remote
-[`skysocks` server](README.md) and a local TCP port; all traffic arriving on
-that local port is forwarded over the Skywire connection. Any conventional
-SOCKS5 application can then use the local port.
+`skysocks-client` is the client half of the [SOCKS5 proxy](README.md). It opens
+a Skywire connection to a remote [`skysocks` server](README.md) and presents a
+**local SOCKS5 listener** (default `127.0.0.1:1080`). Any SOCKS5-aware
+application pointed at that local port has its traffic carried over Skywire and
+exits to the internet from the **server visor's** location — so only the apps you
+configure are proxied, and your exit IP becomes the server's.
 
-## Usage
+It is controlled with `skywire cli proxy`.
 
-The client is controlled via `skywire cli proxy`.
+## Quick start
 
 ```bash
-# Start the client against a remote skysocks server
-skywire cli proxy start --pk <server-public-key>
-
-# List known proxy servers
-skywire cli proxy list
-
-# Status
-skywire cli proxy status
-
-# Stop
-skywire cli proxy stop
+skywire cli proxy test                       # find working servers (latency-ranked)
+skywire cli proxy start --pk <server-pk>      # connect; local SOCKS5 on :1080
+curl -x socks5h://127.0.0.1:1080 https://api.ipify.org   # verify exit IP
+skywire cli proxy stop                        # disconnect
 ```
 
-By default the client listens on local SOCKS5 port `1080`.
+## Finding and testing servers
 
-## Configuration
+```bash
+skywire cli proxy list      # public keys of visors running a skysocks server (from service discovery)
+skywire cli proxy test      # test each: has-transport? + an HTTP request through it; shows reachability + latency
+```
 
-`skysocks-client` ships in a generated config (port `13`,
-`auto_start: false`). To start it automatically against a fixed server, set
-`-srv` (and `-passcode` if the server requires one) and flip `auto_start`:
+`proxy list` prints `<public-key> <country> <version>` per server. `proxy test`
+ranks them by response latency; useful flags:
+
+- `--connect` — just open transports to all online proxies (no HTTP test).
+- `--version <v>` — only test servers on a given visor version.
+
+## Starting the client
+
+```bash
+skywire cli proxy start --pk <server-pk> [flags]
+```
+
+Key flags (`skywire cli proxy start --help` for the full list):
+
+| Flag | Purpose |
+|---|---|
+| `-k, --pk` | server public key (required) |
+| `-n, --name` | name this client instance (lets you run several at once) |
+| `-a, --addr` | local SOCKS5 listen address (default `:1080`) |
+| `--http` | also expose an **HTTP** proxy at this address (in addition to SOCKS5) |
+| `--mux` | parallel mux routes: `1`=single (default), `2+`=N routes, `0`=every distinct path (see [Multiplexed routes](#multiplexed-routes)) |
+| `--mux-mode` | mux scheduler weighting: `auto` (latency-based, default) or `equal` (round-robin) |
+| `--min-hops` | minimum routing hops for this session (`1`=no minimum; `>=2` forces traffic through intermediates) |
+| `--reconnect` | keep re-dialing with backoff on route-group collapse instead of dropping the listener (default `true`) |
+| `--existing-tp` | only use existing transports, don't create new ones |
+| `--routing-policy` | per-app routing policy (`@/path/to/policy.star`) |
+| `-t, --timeout` | start timeout (seconds) |
+| `-v, --verbose` | stream the visor's logs scoped to this session (router/mux/setup events) until ctrl-c |
+
+## Using the proxy
+
+Point any SOCKS5 application at the client's local port. Use `socks5h://` (the
+`h`) so DNS is resolved at the exit, not locally:
+
+```bash
+curl -x socks5h://127.0.0.1:1080 https://api.ipify.org
+```
+
+**Browser:** set the SOCKS5 host to `127.0.0.1` port `1080` and enable "proxy DNS
+when using SOCKS v5" / "remote DNS".
+
+**System-wide (one app at a time):** many tools honor `ALL_PROXY` /
+`HTTP(S)_PROXY`:
+
+```bash
+ALL_PROXY=socks5h://127.0.0.1:1080 <command>
+```
+
+If you started with `--http <addr>`, that address is an ordinary HTTP/HTTPS proxy
+for clients that don't speak SOCKS5.
+
+## Multiplexed routes
+
+A single proxy session can spread its traffic across **several parallel Skywire
+routes** ("mux legs") for throughput and resilience, and adapt them at runtime as
+network conditions change.
+
+- Start with N legs: `--mux 2` (or more); `--mux 0` uses every distinct path.
+- Weighting: `--mux-mode auto` favors lower-latency legs; `equal` is round-robin.
+- Force legs through intermediates (e.g. for bandwidth-spreading): add
+  `--min-hops 2`.
+
+Manage the legs of a **running** session with the `mux-*` subcommands:
+
+| Command | Effect |
+|---|---|
+| `proxy mux-info [--watch]` | per-leg traffic / latency (live with `--watch`) |
+| `proxy mux-auto <preset>` | adaptive control loop (see below) |
+| `proxy mux-set <n>` | reconcile to a target leg count |
+| `proxy mux-add` / `mux-rm` | add / remove one leg |
+| `proxy mux-mode auto\|equal` | change weighting at runtime |
+
+`proxy mux-auto` runs an adaptive **prune-and-grow** loop toward a preset, both
+shedding slow legs and re-growing fresh disjoint ones (honoring `--min-hops`)
+when live legs drop — failover in both directions:
+
+- `fastest` — primary + 1 lowest-latency leg
+- `balanced` — primary + 3 lowest-latency legs
+- `resilient` — up to 8 lowest-latency legs (max redundancy)
+
+Pair it with `proxy mux-info --watch` in another terminal to see the effect.
+
+## Reconnect behavior
+
+With `--reconnect` (the default), a route-group collapse doesn't tear down the
+SOCKS5 listener — the client keeps re-dialing the server with backoff, so an app
+that connects during a server restart keeps its local socket and resumes when the
+route comes back. `--reconnect=false` restores exit-on-failure.
+
+## Auto-start config
+
+`skysocks-client` ships in a generated config (visor routing `port: 13`,
+`auto_start: false`). To start it automatically against a fixed server, set the
+server key and flip `auto_start` (note: the **app arg is `-srv`**, while the CLI
+flag is `--pk`):
 
 ```json
 {
   "name": "skysocks-client",
-  "args": ["-srv", "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7"],
+  "args": ["-srv", "<server-public-key>", "--mux", "2"],
   "auto_start": true,
   "port": 13
 }
 ```
 
-## Using the proxy
+## Controlling a remote visor
 
-Point any SOCKS5-aware application at the client's local port:
+`--via dmsg://<pk>` (or `skynet://<pk>`) runs any `cli proxy` subcommand against a
+**remote** visor instead of the local one — e.g. start/stop a proxy session on
+another node you operate.
 
-```bash
-curl -v -x socks5://localhost:1080 https://api.ipify.org
-```
+## Chaining with the resolving proxy
 
-Your traffic exits to the internet from the remote server visor.
+The [`.dmsg`/`.skynet` resolving proxy](../guides/resolving-proxy.md) can use a
+skysocks client as its upstream: `skywire cli resolver up --upstream 127.0.0.1:1080`.
+Then one browser proxy entry resolves `.dmsg`/`.skynet` over Skywire **and**
+sends everything else out through the skysocks exit.
 
-## Multiplexed routes
+## Troubleshooting
 
-A proxy session can spread its traffic across several parallel routes for
-throughput and resilience. The `skywire cli proxy mux-*` commands
-(`mux-add`, `mux-rm`, `mux-set`, `mux-mode`, `mux-auto`, `mux-info`) manage
-the mux legs of an active session at runtime.
+- **`proxy start` times out / no route** — confirm the server is reachable:
+  `proxy test` (or `proxy test --connect` to force transports). A server with no
+  transport and no route won't connect.
+- **Works then drops** — that's what `--reconnect` covers; check `proxy status`
+  and `proxy mux-info` for leg health, and `--verbose` to watch the session live.
+- **Slow** — add legs (`--mux 2+`) and/or `proxy mux-auto balanced`.
 
 ## See also
 
-- [SOCKS5 proxy server](README.md)
-- [Command reference: `skywire cli proxy`](../skywire/README.md)
+- [SOCKS5 proxy server](README.md) — the exit side (`skywire cli proxy server`)
+- [command reference: `skywire cli proxy`](../skywire/cli/proxy/README.md)
+- [resolving-proxy.md](../guides/resolving-proxy.md) — reach services by public key over dmsg/skynet
+- [guides/socks5.md](../guides/socks5.md) — proxy vs VPN, walkthrough

--- a/docs/vpn/client.md
+++ b/docs/vpn/client.md
@@ -1,70 +1,105 @@
 # VPN client (vpn-client)
 
 `vpn-client` is the client half of the [Skywire VPN](README.md). It opens a
-persistent Skywire connection to a configured remote [VPN server](README.md)
-and uses it as a tunnel, forwarding **all** of the machine's traffic through
-the server. Your public IP becomes the VPN server's IP.
+Skywire connection to a remote [VPN server](README.md) and tunnels **all** of the
+machine's traffic through it — your public IP becomes the server's. Unlike the
+[SOCKS5 proxy](../skysocks/client.md) (which proxies one app at a time), the VPN
+captures the whole machine at the IP layer.
 
 !!! note "Separate machines"
 
     The VPN client and VPN server must run on **different machines** (see the
     [server page](README.md)).
 
-## Usage
+!!! warning "Elevated permissions"
 
-The client is controlled via `skywire cli vpn`.
+    The client rewrites the system routing table and creates a TUN device, so it
+    needs `CAP_NET_ADMIN` (run via sudo, or grant the capability). See
+    [guides/permissions.md](../guides/permissions.md).
+
+## Quick start
 
 ```bash
-# List available VPN servers (from service discovery)
-skywire cli vpn list
-
-# Start the VPN against a remote server
-skywire cli vpn start --pk <server-public-key>
-
-# Status
+skywire cli vpn list                     # VPN servers from service discovery
+skywire cli vpn start --pk <server-pk>   # connect; all traffic now tunneled
 skywire cli vpn status
-
-# Stop
 skywire cli vpn stop
-
-# Open / print the VPN UI
-skywire cli vpn ui
-skywire cli vpn url
 ```
 
-## Configuration
+## Subcommands
 
-`vpn-client` ships in a generated config (port `43`, `auto_start: false`).
-To start it automatically against a fixed server, set `-srv` (the server's
-public key) and `-passcode` if required, and flip `auto_start`:
+| Command | Purpose |
+|---|---|
+| `vpn list` | list visors running a VPN server (from service discovery) |
+| `vpn start --pk <pk>` | connect to a server and bring the tunnel up |
+| `vpn status` | show the current client session |
+| `vpn stop` | tear the tunnel down |
+| `vpn ui` / `vpn url` | open / print the VPN web UI |
+| `vpn server` | control the local VPN **server** (see [server page](README.md)) |
+
+## Starting the client
+
+```bash
+skywire cli vpn start --pk <server-pk> [flags]
+```
+
+| Flag | Purpose |
+|---|---|
+| `-k, --pk` | server public key (required) |
+| `-t, --timeout` | start timeout (seconds) |
+| `--existing-tp` | only use existing transports, don't create new ones |
+| `--local-route` | calculate routes locally instead of using the route finder |
+| `--routing-policy` | per-app routing policy (`@/path/to/policy.star`) |
+| `-v, --verbose` | stream the visor's logs scoped to this session (router/mux/setup) until ctrl-c |
+| `--via dmsg://<pk>` | run the command against a **remote** visor instead of the local one |
+
+## Auto-start config
+
+`vpn-client` ships in a generated config (visor routing `port: 43`,
+`auto_start: false`). To connect automatically to a fixed server, set the server
+key (and a passcode if the server requires one) and flip `auto_start` — note the
+**app args use `-srv` / `-passcode`**, while the CLI flag is `--pk`:
 
 ```json5
 {
   "name": "vpn-client",
   "args": [
-    "-srv", "03e9019b3caa021dbee1c23e6295c6034ab4623aec50802fcfdd19764568e2958d",
-    "-passcode", "1234"
+    "-srv", "<server-public-key>",
+    "-passcode", "1234"          // omit if the server has no passcode
   ],
-  "auto_start": false,
+  "auto_start": true,
   "port": 43
 }
 ```
 
-- `-srv` (required) — public key of the remote VPN server.
-- `-passcode` (optional) — passcode to authenticate the connection; omit if
-  the server has none.
-
 ## Verifying
 
-With the VPN running, you should see an extra hop in `traceroute`, and your
-detected public IP should be the VPN server's:
+With the VPN up, your detected public IP should be the server's, and traffic
+takes an extra hop:
 
 ```bash
+curl https://api.ipify.org      # should show the server's IP
 traceroute google.com
-curl https://api.ipify.org
 ```
+
+The web UI (`skywire cli vpn ui`) shows connection status, the server key, and
+live throughput.
+
+## Troubleshooting
+
+- **Permission denied / no tunnel** — the client needs `CAP_NET_ADMIN`; run with
+  sudo or grant the capability ([permissions guide](../guides/permissions.md)).
+- **`start` times out** — the server may be offline or unreachable; pick another
+  from `vpn list`. A server with no transport and no route won't connect.
+- **No internet after connecting / DNS broken** — `vpn stop` restores the
+  original routes; if a hard crash left stale routes, restart networking. Watch a
+  live session with `--verbose`.
+- **Same machine** — client and server cannot share a host; use two visors.
 
 ## See also
 
-- [VPN server](README.md)
-- [Command reference: `skywire cli vpn`](../skywire/README.md)
+- [VPN server](README.md) — the exit side (`skywire cli vpn server`)
+- [command reference: `skywire cli vpn`](../skywire/cli/vpn/README.md)
+- [guides/vpn.md](../guides/vpn.md) — full VPN walkthrough
+- [guides/permissions.md](../guides/permissions.md) — required capabilities
+- [SOCKS5 proxy client](../skysocks/client.md) — per-app alternative to a full VPN


### PR DESCRIPTION
## Why
The plain-HTTP step (step 3) in `FetchServiceURL` was **already skipped for every deployment service** — all six (TPD/dmsgd/AR/RF/UT/SD) are dmsg-mapped via `DmsgURLForHTTP` — and there's **no live HTTP-only caller**. So it was dead code kept "just in case".

Maintaining a clearnet fallback isn't worth it: it was the path that fired **erroneously**, and its only real advantage (eyeballing a service in a browser with no setup) is better served by pointing the browser at the visor's **dmsgweb resolving proxy** (`socks5h://127.0.0.1:4443` → `<pk>.dmsg`).

## Change
- Remove step 3 (the `http.Client.Get` fallback) from `FetchServiceURL` → the chain is **CXO → visor-RPC-DmsgHTTP → direct-DMSG** only.
- Drop the now-meaningless `--no-http` flag + `NoHTTP` var from `RegisterFetchFlags`.
- Update the doc comment, the `empty response (all fetch paths failed; see …)` hint, and `tp disc`'s `--http` help.

## Verified live (over dmsg, no HTTP fallback)
- `ut mdisc graph` → exit 0, 1380 rows; `ut sd graph` → 1215; `ut tpd graph` → 1286 (the v3 uptimes endpoints fixed in #3099).
- `tp disc -p <pk>` → returns transports.
- `--no-http` is now correctly "unknown flag"; `--no-cxo/--no-rpc/--no-dmsg` remain.

Non-deployment direct `http.Get` calls (rewards → skycoin balance API, skychat → peers) are out of scope and unaffected.

Closes the deployment-service HTTP-deprecation work.

## Docs (added in this PR)
The `.dmsg`/`.skynet` resolving proxy had a per-command CLI reference but **no operator guide**, and wasn't in the apps overview or guides index — so browsing deployment-service data over dmsg was undocumented. Added **`docs/guides/resolving-proxy.md`** (enable/status, addressing, `curl` + browser usage incl. viewing deployment data, TLS, remote resolver) and linked it from the guides index and the apps-overview decision table. This is the documented replacement for the removed HTTP fallback.
