### PR TITLE
fix(visor): stable app-list order (sort AppStates by name) — hypervisor UI apps no longer shuffle/flicker

### DIFF
--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -231,6 +232,13 @@ func (l *AppLauncher) AppStates() []*appserver.AppState {
 		names = append(names, app.Name)
 	}
 	l.mx.Unlock()
+
+	// Stable, deterministic order. l.apps is a map, so ranging it returns a
+	// random order on every call — which made the hypervisor UI's apps list
+	// reshuffle on each poll (rows "moving around" and flickering in/out as the
+	// *ngFor re-rendered). Sorting by name pins the order for every consumer
+	// (UI + `cli visor app ls`).
+	sort.Strings(names)
 
 	var states []*appserver.AppState
 	for _, name := range names {


### PR DESCRIPTION
## Symptom
On the hypervisor UI apps tab, app rows **move around** between polls and some **appear/disappear**.

## Cause
`AppLauncher.AppStates()` builds its result by ranging the `l.apps` **map**, so Go's randomized map-iteration returns the apps in a different order on every call. The UI polls this; its table uses a stable JS sort, which **preserves input order for equal-key ties** — so tied apps reshuffle each poll (rows "move around"), and with pagination (`numberOfPages > 1`) they cross page boundaries (apps appear/disappear). The `@for` already uses `track app.name`, so the order was the only instability.

## Fix
Sort the app names before building the states, so every consumer (`cli visor app ls` and the hypervisor UI) gets a deterministic order. One-line root-cause fix in the launcher; no UI change needed.

Built + vetted.