### PR TITLE
feat(resolver): self-loopback + PK alias for the dmsg/skynet resolving proxies

### DIFF
--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -48,6 +48,32 @@ A resolver hostname is `<public-key>.<suffix>:<port>/<path>`:
 - `.dmsg` addresses may carry routing prefixes, e.g. `<server-pk>.<dest-pk>.dmsg`
   pins a specific dmsg rendezvous server. Use `cli tp route-addr` to build one.
 
+### Your own visor (self-loopback + alias)
+
+Requesting **your own visor's PK** through the proxy
+(`http://<self-pk>.dmsg/`) is served **in-process** — the request is handed
+straight to the local service instead of dialing out over dmsg/skynet back to
+yourself (a wasteful, 202-prone round-trip dmsg doesn't loopback anyway). This
+is on by default.
+
+A friendly **alias** makes this convenient: `skywire` resolves to the local
+visor, so `http://skywire.dmsg/` and `http://skywire.skynet/` both open the
+local visor's port-80 landing page through the resolver.
+
+Both are configurable per resolver (`dmsg_web` / `skynet_web` in the visor
+config):
+
+```json5
+{
+  "self_loopback": true,                 // false → take the real self-route (testing)
+  "aliases": { "skywire": "self" }       // map a label to "self" or a PK hex;
+                                         // {"skywire": ""} removes the default
+}
+```
+
+`self_loopback: false` is mainly useful to test that your visor is reachable
+over its **own** transports — valid for skynet (dmsg won't self-loopback).
+
 ## From `curl`
 
 Use `socks5h://` (the `h` makes the **proxy** resolve the hostname — required for

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -99,6 +99,22 @@ type Config struct {
 	// LeafMinter mints per-host leaf certs. Required when TLSMITM
 	// is true; ignored otherwise.
 	LeafMinter skynetca.LeafMinter
+
+	// LocalPK is this visor's public key, used to detect self-lookups for the
+	// SelfLoopback short-circuit.
+	LocalPK cipher.PubKey
+	// SelfLoopback, when true (the default), serves a request whose destination
+	// is LocalPK from the local service in-process via SelfDial, instead of
+	// dialing out over dmsg back to self (a wasteful, 202-prone round-trip).
+	// Set false to force the full transport path — e.g. to test self-transports.
+	SelfLoopback bool
+	// SelfDial returns an in-process connection to the local service registered
+	// on the given dmsg port. Used only when SelfLoopback short-circuits a
+	// self-destined request. Nil disables the short-circuit.
+	SelfDial func(port uint16) (net.Conn, error)
+	// Aliases maps a destination label to a PK (e.g. "skywire" -> LocalPK), so
+	// "skywire.dmsg" resolves exactly like "<pk>.dmsg".
+	Aliases map[string]cipher.PubKey
 }
 
 // DmsgTarget is a (publicKey, dmsgPort) pair used in fixed-mapping mode.
@@ -249,7 +265,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			}
 
 			if _, ok := dialCtx.Value(dmsgResolverPortKey).(string); ok {
-				vhost, route, dest, _, perr := skynetweb.ParseResolverHost(origHost, cfg.DomainSuffix)
+				vhost, route, dest, _, perr := skynetweb.ParseResolverHost(origHost, cfg.DomainSuffix, cfg.Aliases)
 				if perr != nil {
 					return nil, fmt.Errorf("invalid dmsg hostname %q: %w", origHost, perr)
 				}
@@ -257,6 +273,26 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 				if err != nil {
 					return nil, fmt.Errorf("invalid port: %w", err)
 				}
+
+				// Self-lookup short-circuit: a request whose destination is THIS
+				// visor is served from the local service in-process, rather than
+				// dialing out over dmsg back to ourselves (a wasteful, 202-prone
+				// round-trip). Disabled via SelfLoopback=false to exercise the
+				// full self-transport path for testing.
+				if cfg.SelfLoopback && cfg.SelfDial != nil && dest == cfg.LocalPK && len(route) == 0 {
+					log.WithField("port", port).Debug("SOCKS5 → DMSG self-loopback (in-process)")
+					c, derr := cfg.SelfDial(uint16(port))
+					if derr != nil {
+						return nil, derr
+					}
+					// Wrap so LocalAddr()/RemoteAddr() return *net.TCPAddr —
+					// go-socks5 (request.go:194) does an unchecked assertion
+					// when building the BND reply, AFTER this Dial callback
+					// returns (so the recover above does not cover it), and
+					// would panic on the raw net.Pipe conn otherwise.
+					return &tcpAddrConn{Conn: c}, nil
+				}
+
 				dstAddr := dmsg.Addr{PK: dest, Port: uint16(port)}
 				var stream net.Conn
 				if len(route) > 0 {

--- a/pkg/skynetweb/resolverhost.go
+++ b/pkg/skynetweb/resolverhost.go
@@ -58,7 +58,10 @@ func classifyRouteLabel(label string) (RouteLabel, bool) {
 // ParseResolverHost parses host into its vhost, routing chain, destination PK
 // and port. suffix must start with "." (e.g. ".dmsg", ".skynet"). It errors
 // when the host doesn't end in suffix or the destination label isn't a valid PK.
-func ParseResolverHost(host, suffix string) (vhost string, route []RouteLabel, dest cipher.PubKey, port uint16, err error) {
+//
+// aliases maps a human-friendly destination label (e.g. "skywire") to a PK, so
+// "skywire.dmsg" resolves exactly like "<pk>.dmsg". Nil/empty disables aliasing.
+func ParseResolverHost(host, suffix string, aliases map[string]cipher.PubKey) (vhost string, route []RouteLabel, dest cipher.PubKey, port uint16, err error) {
 	hostPart, portStr, hasPort := splitHostPort(host)
 	port = 80
 	if hasPort {
@@ -81,10 +84,15 @@ func ParseResolverHost(host, suffix string) (vhost string, route []RouteLabel, d
 	last := len(labels) - 1
 
 	// Destination = the label adjacent to the suffix (must be a PK — a route
-	// always ends at a visor, never a transport).
-	dest, err = parsePKLabel(labels[last])
-	if err != nil {
-		return "", nil, cipher.PubKey{}, 0, fmt.Errorf("invalid destination PK %q: %w", labels[last], err)
+	// always ends at a visor, never a transport). An alias label substitutes
+	// for its mapped PK before the PK parse.
+	if aliasPK, ok := aliases[labels[last]]; ok {
+		dest = aliasPK
+	} else {
+		dest, err = parsePKLabel(labels[last])
+		if err != nil {
+			return "", nil, cipher.PubKey{}, 0, fmt.Errorf("invalid destination PK %q: %w", labels[last], err)
+		}
 	}
 
 	// Walk left while labels classify as routing elements (PK or TpID),

--- a/pkg/skynetweb/resolverhost_test.go
+++ b/pkg/skynetweb/resolverhost_test.go
@@ -31,30 +31,37 @@ func TestParseResolverHost(t *testing.T) {
 	h2 := mustPK(t, hop2)
 	t1 := uuid.MustParse(tp1)
 
+	aliases := map[string]cipher.PubKey{"skywire": dp}
+
 	cases := []struct {
 		name      string
 		host      string
 		suffix    string
+		aliases   map[string]cipher.PubKey
 		wantVhost string
 		wantRoute []RouteLabel
 		wantDest  cipher.PubKey
 		wantPort  uint16
 		wantErr   bool
 	}{
-		{"bare dest", dest + ".dmsg", ".dmsg", "", nil, dp, 80, false},
-		{"vhost + dest", "example.com." + dest + ".dmsg", ".dmsg", "example.com", nil, dp, 80, false},
-		{"pinned server (PK)", "example.com." + hop1 + "." + dest + ".dmsg", ".dmsg", "example.com", []RouteLabel{pkLabel(h1)}, dp, 80, false},
-		{"two-hop skynet PKs (source order)", "site." + hop1 + "." + hop2 + "." + dest + ".skynet", ".skynet", "site", []RouteLabel{pkLabel(h1), pkLabel(h2)}, dp, 80, false},
-		{"tpid hop", "site." + tp1 + "." + dest + ".skynet", ".skynet", "site", []RouteLabel{tpLabel(t1)}, dp, 80, false},
-		{"mixed tpid + pk hop", tp1 + "." + hop2 + "." + dest + ".skynet", ".skynet", "", []RouteLabel{tpLabel(t1), pkLabel(h2)}, dp, 80, false},
-		{"explicit port", dest + ".dmsg:8080", ".dmsg", "", nil, dp, 8080, false},
-		{"wrong suffix", dest + ".onion", ".dmsg", "", nil, cipher.PubKey{}, 0, true},
-		{"bad dest", "notapk.dmsg", ".dmsg", "", nil, cipher.PubKey{}, 0, true},
+		{"bare dest", dest + ".dmsg", ".dmsg", nil, "", nil, dp, 80, false},
+		{"vhost + dest", "example.com." + dest + ".dmsg", ".dmsg", nil, "example.com", nil, dp, 80, false},
+		{"pinned server (PK)", "example.com." + hop1 + "." + dest + ".dmsg", ".dmsg", nil, "example.com", []RouteLabel{pkLabel(h1)}, dp, 80, false},
+		{"two-hop skynet PKs (source order)", "site." + hop1 + "." + hop2 + "." + dest + ".skynet", ".skynet", nil, "site", []RouteLabel{pkLabel(h1), pkLabel(h2)}, dp, 80, false},
+		{"tpid hop", "site." + tp1 + "." + dest + ".skynet", ".skynet", nil, "site", []RouteLabel{tpLabel(t1)}, dp, 80, false},
+		{"mixed tpid + pk hop", tp1 + "." + hop2 + "." + dest + ".skynet", ".skynet", nil, "", []RouteLabel{tpLabel(t1), pkLabel(h2)}, dp, 80, false},
+		{"explicit port", dest + ".dmsg:8080", ".dmsg", nil, "", nil, dp, 8080, false},
+		{"alias dest", "skywire.skynet", ".skynet", aliases, "", nil, dp, 80, false},
+		{"alias dest + port", "skywire.dmsg:8080", ".dmsg", aliases, "", nil, dp, 8080, false},
+		{"alias with hop", hop1 + ".skywire.skynet", ".skynet", aliases, "", []RouteLabel{pkLabel(h1)}, dp, 80, false},
+		{"wrong suffix", dest + ".onion", ".dmsg", nil, "", nil, cipher.PubKey{}, 0, true},
+		{"bad dest", "notapk.dmsg", ".dmsg", nil, "", nil, cipher.PubKey{}, 0, true},
+		{"unknown alias (no map)", "skywire.dmsg", ".dmsg", nil, "", nil, cipher.PubKey{}, 0, true},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			vhost, route, gotDest, port, err := ParseResolverHost(c.host, c.suffix)
+			vhost, route, gotDest, port, err := ParseResolverHost(c.host, c.suffix, c.aliases)
 			if c.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got none")

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -120,6 +120,22 @@ type Config struct {
 	// LeafMinter mints per-host leaf certs. Required when TLSMITM
 	// is true; ignored otherwise.
 	LeafMinter skynetca.LeafMinter
+
+	// LocalPK is this visor's public key, used to detect self-lookups for the
+	// SelfLoopback short-circuit.
+	LocalPK cipher.PubKey
+	// SelfLoopback, when true (the default), serves a request whose destination
+	// is LocalPK from the local service in-process via SelfDial, instead of
+	// routing out over skynet back to ourselves. Set false to force the full
+	// self-route path — e.g. to test self-transports (a legitimate use case).
+	SelfLoopback bool
+	// SelfDial returns an in-process connection to the local service registered
+	// on the given port. Used only when SelfLoopback short-circuits a
+	// self-destined request. Nil disables the short-circuit.
+	SelfDial func(port uint16) (net.Conn, error)
+	// Aliases maps a destination label to a PK (e.g. "skywire" -> LocalPK), so
+	// "skywire.skynet" resolves exactly like "<pk>.skynet".
+	Aliases map[string]cipher.PubKey
 }
 
 // Run starts the SOCKS5 proxy. Blocks until ctx is canceled.
@@ -188,9 +204,26 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				if addrPort != "" && addrPort != "80" {
 					hostWithPort = origHost + ":" + addrPort
 				}
-				vhost, route, dest, hport, err := ParseResolverHost(hostWithPort, cfg.DomainSuffix)
+				vhost, route, dest, hport, err := ParseResolverHost(hostWithPort, cfg.DomainSuffix, cfg.Aliases)
 				if err != nil {
 					return nil, fmt.Errorf("skynet dial: %w", err)
+				}
+
+				// Self-lookup short-circuit: serve a request destined for THIS
+				// visor from the local service in-process instead of routing out
+				// over skynet back to ourselves. SelfLoopback=false forces the
+				// full self-route path (a valid self-transport test).
+				if cfg.SelfLoopback && cfg.SelfDial != nil && dest == cfg.LocalPK && len(route) == 0 {
+					log.WithField("port", hport).Debug("SOCKS5 → skynet self-loopback (in-process)")
+					c, derr := cfg.SelfDial(hport)
+					if derr != nil {
+						return nil, derr
+					}
+					// Wrap so LocalAddr()/RemoteAddr() return *net.TCPAddr —
+					// go-socks5 (request.go:194) does an unchecked assertion
+					// when building the BND reply and would panic on the raw
+					// net.Pipe conn's pipeAddr otherwise.
+					return &tcpAddrConn{Conn: c}, nil
 				}
 
 				done := cfg.Stats.RecordRequest()

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -88,7 +88,7 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			// it starts — no data loss, just "not available yet".
 			cfg.UpstreamSOCKS = fmt.Sprintf("127.0.0.1:%d", defaultSkynetWebProxyPort)
 			log := logging.MustGetLogger("embedded_dmsgweb")
-			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, cfg, log)
+			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, cfg, log)
 			v.embeddedDmsgWeb = runtime
 		}
 		v.initLock.Unlock()
@@ -119,7 +119,7 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			}
 			cfg := &visorconfig.SkynetWebConfig{Enable: true}
 			log := logging.MustGetLogger("embedded_skynetweb")
-			runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, cfg, log)
+			runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, cfg, log)
 			v.embeddedSkynetWeb = runtime
 		}
 		v.initLock.Unlock()
@@ -270,7 +270,7 @@ func (v *Visor) autoStartSkynetWeb() {
 		}
 		cfg := &visorconfig.SkynetWebConfig{Enable: true}
 		log := logging.MustGetLogger("embedded_skynetweb")
-		runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, cfg, log)
+		runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, cfg, log)
 		v.embeddedSkynetWeb = runtime
 	}
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -21,6 +21,7 @@ package visor
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsgweb"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -45,10 +47,12 @@ const dmsgWebReadyWait = 20 * time.Second
 // EmbeddedDmsgWeb holds the runtime state for the visor-hosted
 // dmsgweb resolver. Safe for concurrent Start/Stop calls.
 type EmbeddedDmsgWeb struct {
-	dmsgC *dmsg.Client
-	cfg   *visorconfig.DmsgWebConfig
-	log   *logging.Logger
-	stats *dmsgweb.Stats // persists across Start/Stop cycles
+	dmsgC    *dmsg.Client
+	cfg      *visorconfig.DmsgWebConfig
+	log      *logging.Logger
+	stats    *dmsgweb.Stats                      // persists across Start/Stop cycles
+	localPK  cipher.PubKey                       // this visor's PK, for self-loopback + "self" alias
+	selfDial func(port uint16) (net.Conn, error) // in-process serve of a local service port (nil disables loopback)
 
 	mu        sync.Mutex
 	running   bool
@@ -59,13 +63,17 @@ type EmbeddedDmsgWeb struct {
 
 // newEmbeddedDmsgWeb is the constructor used by initEmbeddedDmsgWeb.
 // Stats starts counting from construction, so UI can distinguish
-// "resolver never ran" from "running but idle".
-func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC *dmsg.Client, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
+// "resolver never ran" from "running but idle". localPK + selfDial
+// enable self-loopback (serving requests for this visor's own PK
+// in-process); pass a zero PK / nil selfDial to disable.
+func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
 	return &EmbeddedDmsgWeb{
 		dmsgC:     dmsgC,
 		cfg:       cfg,
 		log:       log,
 		stats:     dmsgweb.NewStats(),
+		localPK:   localPK,
+		selfDial:  selfDial,
 		parentCtx: parentCtx,
 	}
 }
@@ -161,6 +169,21 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 		Stats:         e.stats,
 	}
 
+	// Self-loopback: serve requests for THIS visor's own PK in-process
+	// (default on) instead of dialing over dmsg back to self. Aliases map
+	// friendly labels (default "skywire") to a PK or self.
+	if e.selfDial != nil && (e.cfg.SelfLoopback == nil || *e.cfg.SelfLoopback) {
+		cfg.LocalPK = e.localPK
+		cfg.SelfLoopback = true
+		cfg.SelfDial = e.selfDial
+	}
+	aliases, err := resolverAliases(e.cfg.Aliases, e.localPK)
+	if err != nil {
+		e.log.WithError(err).Warn("dmsgweb: invalid alias config; using default skywire->self")
+		aliases = map[string]cipher.PubKey{"skywire": e.localPK}
+	}
+	cfg.Aliases = aliases
+
 	// Optional TLS MITM. CA load failure is non-fatal — the
 	// resolver continues without MITM and logs the reason.
 	if e.cfg.TLSMITM {
@@ -195,6 +218,30 @@ func stringOrDefault(v, d string) string {
 		return d
 	}
 	return v
+}
+
+// resolverAliases turns the config alias map (label → "self" | "<pk-hex>")
+// into a label → PK map for ParseResolverHost. "self" resolves to localPK.
+// The label "skywire" → self is included by default; map it to "" to
+// remove that default, or to another target to override it. Shared by the
+// dmsgweb and skynetweb resolvers.
+func resolverAliases(cfg map[string]string, localPK cipher.PubKey) (map[string]cipher.PubKey, error) {
+	out := map[string]cipher.PubKey{"skywire": localPK}
+	for label, target := range cfg {
+		switch target {
+		case "":
+			delete(out, label) // explicit disable / remove default
+		case "self":
+			out[label] = localPK
+		default:
+			var pk cipher.PubKey
+			if err := pk.Set(target); err != nil {
+				return nil, fmt.Errorf("alias %q: invalid PK %q: %w", label, target, err)
+			}
+			out[label] = pk
+		}
+	}
+	return out, nil
 }
 
 func uintOrDefault(v, d uint) uint {
@@ -238,7 +285,7 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 			Info("Auto-chaining dmsgweb → skynetweb for unified proxy")
 	}
 
-	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, cfg, log)
+	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, cfg, log)
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -47,6 +47,7 @@ type EmbeddedSkynetWeb struct {
 	tpM       *transport.Manager
 	skynetMux **transport.VStreamMux // pointer to visor's mux pointer (late-bound)
 	localPK   cipher.PubKey
+	selfDial  func(port uint16) (net.Conn, error) // in-process serve of a local service port (nil disables loopback)
 	cfg       *visorconfig.SkynetWebConfig
 	log       *logging.Logger
 	stats     *skynetweb.Stats
@@ -58,12 +59,13 @@ type EmbeddedSkynetWeb struct {
 	parentCtx context.Context
 }
 
-func newEmbeddedSkynetWeb(parentCtx context.Context, r router.Router, tpM *transport.Manager, skynetMuxPtr **transport.VStreamMux, localPK cipher.PubKey, cfg *visorconfig.SkynetWebConfig, log *logging.Logger) *EmbeddedSkynetWeb {
+func newEmbeddedSkynetWeb(parentCtx context.Context, r router.Router, tpM *transport.Manager, skynetMuxPtr **transport.VStreamMux, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), cfg *visorconfig.SkynetWebConfig, log *logging.Logger) *EmbeddedSkynetWeb {
 	return &EmbeddedSkynetWeb{
 		router:    r,
 		tpM:       tpM,
 		skynetMux: skynetMuxPtr,
 		localPK:   localPK,
+		selfDial:  selfDial,
 		cfg:       cfg,
 		log:       log,
 		stats:     skynetweb.NewStats(),
@@ -158,6 +160,22 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 		UpstreamSOCKS: e.cfg.UpstreamSOCKS,
 		Stats:         e.stats,
 	}
+
+	// Self-loopback: serve requests for THIS visor's own PK in-process
+	// (default on) instead of dialing a skynet route back to self. Set
+	// self_loopback:false to exercise the real self-route (valid for
+	// skynet). Aliases map friendly labels (default "skywire") to a PK.
+	if e.selfDial != nil && (e.cfg.SelfLoopback == nil || *e.cfg.SelfLoopback) {
+		cfg.LocalPK = e.localPK
+		cfg.SelfLoopback = true
+		cfg.SelfDial = e.selfDial
+	}
+	aliases, err := resolverAliases(e.cfg.Aliases, e.localPK)
+	if err != nil {
+		e.log.WithError(err).Warn("skynetweb: invalid alias config; using default skywire->self")
+		aliases = map[string]cipher.PubKey{"skywire": e.localPK}
+	}
+	cfg.Aliases = aliases
 
 	// Optional TLS MITM mode. Loading the CA can fail (file
 	// missing, permissions, malformed) — those failures are not
@@ -390,7 +408,7 @@ func initEmbeddedSkynetWeb(ctx context.Context, v *Visor, log *logging.Logger) e
 		log.Warn("skynet_web configured but router not available; skipping")
 		return nil
 	}
-	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.conf.SkynetWeb, log)
+	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.conf.SkynetWeb, log)
 	v.initLock.Lock()
 	v.embeddedSkynetWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/service_registry.go
+++ b/pkg/visor/service_registry.go
@@ -84,6 +84,24 @@ func (r *ServiceRegistry) Get(port uint16) (ConnHandler, bool) {
 	return svc.handler, true
 }
 
+// SelfDial returns a client-side net.Conn whose peer is the handler
+// registered on port, served in-process over net.Pipe — no transport,
+// no dmsg/skynet hop, no loopback. Used by the embedded resolving
+// proxies to short-circuit a request destined for THIS visor's own PK
+// instead of dialing out over the network back to self (which dmsg does
+// not loopback and which is 202-prone). Errors if no handler is
+// registered on port. The caller owns the returned conn and must close
+// it; the handler goroutine exits when its end closes.
+func (r *ServiceRegistry) SelfDial(port uint16) (net.Conn, error) {
+	h, ok := r.Get(port)
+	if !ok {
+		return nil, fmt.Errorf("no local service registered on port %d", port)
+	}
+	clientEnd, serverEnd := net.Pipe()
+	go h(serverEnd)
+	return clientEnd, nil
+}
+
 // Ports returns all registered port numbers, sorted ascending.
 func (r *ServiceRegistry) Ports() []uint16 {
 	r.mu.RLock()

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -252,6 +252,17 @@ type DmsgWebConfig struct {
 	// either is missing or unreadable; it does not refuse to start.
 	TLSCAPath    string `json:"tls_ca_path,omitempty"`
 	TLSCAKeyPath string `json:"tls_ca_key_path,omitempty"`
+	// SelfLoopback, when nil or true (the default), serves a request whose
+	// destination is THIS visor's own PK from the local service in-process
+	// (net.Pipe) instead of dialing out over dmsg back to self — which dmsg
+	// does not loopback and which is 202-prone. Set false to exercise the
+	// full self-dial transport path (testing self-reachability).
+	SelfLoopback *bool `json:"self_loopback,omitempty"`
+	// Aliases maps a friendly destination label to a PK hex or the literal
+	// "self" (this visor). e.g. {"skywire":"self"} makes "skywire.dmsg"
+	// resolve to the local visor. When unset, "skywire"→self is added by
+	// default; set {"skywire":""} to disable that default.
+	Aliases map[string]string `json:"aliases,omitempty"`
 }
 
 // SkynetWebConfig enables the embedded `.skynet` resolving proxy — the
@@ -293,6 +304,17 @@ type SkynetWebConfig struct {
 	// either is missing or unreadable; it does not refuse to start.
 	TLSCAPath    string `json:"tls_ca_path,omitempty"`
 	TLSCAKeyPath string `json:"tls_ca_key_path,omitempty"`
+	// SelfLoopback, when nil or true (the default), serves a request whose
+	// destination is THIS visor's own PK from the local service in-process
+	// (net.Pipe) instead of dialing a skynet route back to self. Set false
+	// to exercise the full self-route path (valid for skynet, useful for
+	// testing self-transports).
+	SelfLoopback *bool `json:"self_loopback,omitempty"`
+	// Aliases maps a friendly destination label to a PK hex or the literal
+	// "self" (this visor). e.g. {"skywire":"self"} makes "skywire.skynet"
+	// resolve to the local visor. When unset, "skywire"→self is added by
+	// default; set {"skywire":""} to disable that default.
+	Aliases map[string]string `json:"aliases,omitempty"`
 }
 
 // SkymailBridgeConfig configures the embedded SMTP-aware bridge that


### PR DESCRIPTION
## What

When a browser pointed at the visor's resolving SOCKS5 proxy requests the **local visor's own PK** (`http://<self-pk>.dmsg/` or `.skynet`), the request previously dialed out over dmsg/skynet back to the same visor — a wasteful, 202-prone round-trip (dmsg doesn't even loopback self-dials).

Two changes, both opt-out / backward-compatible:

- **Self-loopback (default on)** — a request whose destination is this visor's own PK, with no explicit route, is served from the local service registry **in-process over `net.Pipe`** (`ServiceRegistry.SelfDial`) — no transport hop. Set `"self_loopback": false` on `dmsg_web` / `skynet_web` to exercise the full self-transport path instead (a valid self-reachability test, especially for skynet).

- **Aliases** — a configurable label resolves to a PK (or the literal `"self"`), so `skywire.skynet` / `skywire.dmsg` loads the local visor's **port-80 landing page** through the resolver. `"skywire" → self` is added by default; override via the `"aliases"` map (`{"skywire": ""}` disables it).

```json5
// dmsg_web / skynet_web
{ "self_loopback": true, "aliases": { "skywire": "self" } }
```

The in-process conn is wrapped in `tcpAddrConn` so go-socks5's unchecked `*net.TCPAddr` assertion (`request.go:194`, building the BND reply *after* the Dial callback returns — so the existing dmsgweb `recover` does not cover it) does not panic on `net.Pipe`'s `pipeAddr`.

Wiring is shared by both embedded resolvers; `ParseResolverHost` gains an `aliases` map applied before the destination-PK parse.

## Validation

Rolled the local visor onto the change. All three paths return the landing page in-process (`<title>Skywire Visor</title>`), ~1ms, visor stays up:

| request | result |
|---|---|
| `skywire.skynet` (alias→self) | HTTP 200, 288B, 1.1ms |
| `skywire.dmsg` (alias→self) | HTTP 200, 288B, 1.1ms |
| `<self-pk>.skynet` | HTTP 200, 288B, 1.0ms |

Build, `go vet`, and `pkg/skynetweb` unit tests (incl. new alias cases) pass; config round-trips cleanly with the new `*bool`/map fields.