### PR TITLE
refactor(resolver): single `alias` string for the local PK (not a label→PK map)

### DIFF
--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -56,20 +56,24 @@ straight to the local service instead of dialing out over dmsg/skynet back to
 yourself (a wasteful, 202-prone round-trip dmsg doesn't loopback anyway). This
 is on by default.
 
-A friendly **alias** makes this convenient: `skywire` resolves to the local
-visor, so `http://skywire.dmsg/` and `http://skywire.skynet/` both open the
-local visor's port-80 landing page through the resolver.
+A friendly **alias** makes this convenient: the label `skywire` resolves to the
+local visor, so `http://skywire.dmsg/` and `http://skywire.skynet/` both open
+the local visor's port-80 landing page through the resolver — no need to type
+(or hardcode) the visor's public key.
 
 Both are configurable per resolver (`dmsg_web` / `skynet_web` in the visor
 config):
 
 ```json5
 {
-  "self_loopback": true,                 // false → take the real self-route (testing)
-  "aliases": { "skywire": "self" }       // map a label to "self" or a PK hex;
-                                         // {"skywire": ""} removes the default
+  "self_loopback": true,   // false → take the real self-route (testing)
+  "alias": "skywire"       // hostname label for THIS visor; default "skywire"
 }
 ```
+
+The `alias` is just a rename of the local label — set it to `"myhost"` to use
+`myhost.dmsg` / `myhost.skynet` instead. It always points at the local visor's
+own PK.
 
 `self_loopback: false` is mainly useful to test that your visor is reachable
 over its **own** transports — valid for skynet (dmsg won't self-loopback).

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -177,12 +177,7 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 		cfg.SelfLoopback = true
 		cfg.SelfDial = e.selfDial
 	}
-	aliases, err := resolverAliases(e.cfg.Aliases, e.localPK)
-	if err != nil {
-		e.log.WithError(err).Warn("dmsgweb: invalid alias config; using default skywire->self")
-		aliases = map[string]cipher.PubKey{"skywire": e.localPK}
-	}
-	cfg.Aliases = aliases
+	cfg.Aliases = resolverAliasMap(e.cfg.Alias, e.localPK)
 
 	// Optional TLS MITM. CA load failure is non-fatal — the
 	// resolver continues without MITM and logs the reason.
@@ -220,28 +215,15 @@ func stringOrDefault(v, d string) string {
 	return v
 }
 
-// resolverAliases turns the config alias map (label → "self" | "<pk-hex>")
-// into a label → PK map for ParseResolverHost. "self" resolves to localPK.
-// The label "skywire" → self is included by default; map it to "" to
-// remove that default, or to another target to override it. Shared by the
-// dmsgweb and skynetweb resolvers.
-func resolverAliases(cfg map[string]string, localPK cipher.PubKey) (map[string]cipher.PubKey, error) {
-	out := map[string]cipher.PubKey{"skywire": localPK}
-	for label, target := range cfg {
-		switch target {
-		case "":
-			delete(out, label) // explicit disable / remove default
-		case "self":
-			out[label] = localPK
-		default:
-			var pk cipher.PubKey
-			if err := pk.Set(target); err != nil {
-				return nil, fmt.Errorf("alias %q: invalid PK %q: %w", label, target, err)
-			}
-			out[label] = pk
-		}
+// resolverAliasMap builds the single-entry label → PK map ParseResolverHost
+// uses to resolve a friendly name for THIS visor. The label defaults to
+// "skywire" when alias is empty (so "skywire.dmsg"/"skywire.skynet" works
+// out of the box). Shared by the dmsgweb and skynetweb resolvers.
+func resolverAliasMap(alias string, localPK cipher.PubKey) map[string]cipher.PubKey {
+	if alias == "" {
+		alias = "skywire"
 	}
-	return out, nil
+	return map[string]cipher.PubKey{alias: localPK}
 }
 
 func uintOrDefault(v, d uint) uint {

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -170,12 +170,7 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 		cfg.SelfLoopback = true
 		cfg.SelfDial = e.selfDial
 	}
-	aliases, err := resolverAliases(e.cfg.Aliases, e.localPK)
-	if err != nil {
-		e.log.WithError(err).Warn("skynetweb: invalid alias config; using default skywire->self")
-		aliases = map[string]cipher.PubKey{"skywire": e.localPK}
-	}
-	cfg.Aliases = aliases
+	cfg.Aliases = resolverAliasMap(e.cfg.Alias, e.localPK)
 
 	// Optional TLS MITM mode. Loading the CA can fail (file
 	// missing, permissions, malformed) — those failures are not

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -258,11 +258,10 @@ type DmsgWebConfig struct {
 	// does not loopback and which is 202-prone. Set false to exercise the
 	// full self-dial transport path (testing self-reachability).
 	SelfLoopback *bool `json:"self_loopback,omitempty"`
-	// Aliases maps a friendly destination label to a PK hex or the literal
-	// "self" (this visor). e.g. {"skywire":"self"} makes "skywire.dmsg"
-	// resolve to the local visor. When unset, "skywire"→self is added by
-	// default; set {"skywire":""} to disable that default.
-	Aliases map[string]string `json:"aliases,omitempty"`
+	// Alias is a friendly hostname label for THIS visor's own PK, so
+	// "<alias>.dmsg" resolves to the local visor without hardcoding its
+	// public key. Defaults to "skywire" when unset (→ "skywire.dmsg").
+	Alias string `json:"alias,omitempty"`
 }
 
 // SkynetWebConfig enables the embedded `.skynet` resolving proxy — the
@@ -310,11 +309,10 @@ type SkynetWebConfig struct {
 	// to exercise the full self-route path (valid for skynet, useful for
 	// testing self-transports).
 	SelfLoopback *bool `json:"self_loopback,omitempty"`
-	// Aliases maps a friendly destination label to a PK hex or the literal
-	// "self" (this visor). e.g. {"skywire":"self"} makes "skywire.skynet"
-	// resolve to the local visor. When unset, "skywire"→self is added by
-	// default; set {"skywire":""} to disable that default.
-	Aliases map[string]string `json:"aliases,omitempty"`
+	// Alias is a friendly hostname label for THIS visor's own PK, so
+	// "<alias>.skynet" resolves to the local visor without hardcoding its
+	// public key. Defaults to "skywire" when unset (→ "skywire.skynet").
+	Alias string `json:"alias,omitempty"`
 }
 
 // SkymailBridgeConfig configures the embedded SMTP-aware bridge that


### PR DESCRIPTION
Follow-up to #3102.

That PR shipped an `aliases` `map[label]→PK` on `dmsg_web` / `skynet_web` that could point any label at any PK (including the literal `"self"`). The only intended use is giving **this visor's own PK** a friendly hostname without hardcoding the key — so the map was more config surface than the feature needs.

This replaces it with a single **`alias` string** per resolver (default `"skywire"`):

```json5
// dmsg_web / skynet_web
{ "self_loopback": true, "alias": "skywire" }
```

- `<alias>.dmsg` / `<alias>.skynet` resolve to the local visor.
- Defaults to `skywire` when unset (so `skywire.skynet` / `skywire.dmsg` work out of the box — no config needed).
- Rename it (`"alias": "myhost"`) to use a different local label.

Drops the `"self"` / PK-hex parsing and its error path. `ParseResolverHost` still takes a (now single-entry) alias map, so its signature and `resolverhost_test.go` are unchanged.

## Validation

Rolled the local visor onto the change: `skywire.skynet` and `skywire.dmsg` still return the landing page in-process (HTTP 200, `<title>Skywire Visor</title>`, ~1ms, visor stable). Build, `go vet`, lint, and `pkg/skynetweb` tests pass.