### PR TITLE
feat(serve): inject authenticated caller PK into HTTP-mode forwarded ports

### DIFF
--- a/cmd/skywire-cli/commands/serve/serve.go
+++ b/cmd/skywire-cli/commands/serve/serve.go
@@ -44,6 +44,7 @@ var (
 	serveDmsg         bool
 	serveLanding      bool
 	servePreserveHost bool
+	serveInjectPK     bool
 	serveJSON         bool
 )
 
@@ -59,6 +60,10 @@ func init() {
 			"to --to target. Use when the backend (Caddy / nginx / traefik) dispatches "+
 			"its virtual hosts by Host (e.g. paired with the resolver's subdomain rewrite)")
 	servePortCmd.Flags().StringVar(&serveWhitelist, "whitelist", "", "comma-separated PKs allowed to access this port (empty = allow all)")
+	servePortCmd.Flags().BoolVar(&serveInjectPK, "inject-pk", false,
+		"HTTP mode: inject the authenticated caller's PK as the X-Skywire-Remote-PK header "+
+			"(any client-supplied copy is stripped) so the backend can do per-PK auth. "+
+			"Bind the backend to loopback only — see docs/guides/skynet-website-auth.md")
 
 	servePortLsCmd.Flags().BoolVar(&serveJSON, "json", false, "emit raw JSON")
 	RootCmd.Flags().BoolVar(&serveJSON, "json", false, "emit raw JSON")
@@ -135,6 +140,7 @@ Examples:
 			DMSG:          serveDmsg,
 			ShowOnLanding: serveLanding,
 			PreserveHost:  servePreserveHost,
+			InjectPK:      serveInjectPK,
 		}
 
 		// Resolve --to into the right field. The visor schema has two

--- a/cmd/skywire-cli/commands/skynet/port.go
+++ b/cmd/skywire-cli/commands/skynet/port.go
@@ -16,14 +16,16 @@ import (
 )
 
 var (
-	portLabel       string
-	portDesc        string
-	portSkynet      bool
-	portDmsg        bool
-	portShowLanding bool
-	portProxyAddr   string
-	portLocalPort   int
-	portWhitelist   string
+	portLabel        string
+	portDesc         string
+	portSkynet       bool
+	portDmsg         bool
+	portShowLanding  bool
+	portProxyAddr    string
+	portLocalPort    int
+	portWhitelist    string
+	portPreserveHost bool
+	portInjectPK     bool
 )
 
 func init() {
@@ -35,6 +37,8 @@ func init() {
 	portAddCmd.Flags().StringVar(&portProxyAddr, "proxy-addr", "", "forward to this address (host:port) instead of localhost:<local-port>; on port 80 it also replaces the landing page via reverse proxy")
 	portAddCmd.Flags().IntVar(&portLocalPort, "local-port", 0, "local TCP port to forward (default: same as skynet/dmsg port)")
 	portAddCmd.Flags().StringVar(&portWhitelist, "whitelist", "", "comma-separated PKs allowed to access this port (empty = allow all)")
+	portAddCmd.Flags().BoolVar(&portPreserveHost, "preserve-host", false, "pass the incoming Host header through to the backend (required for vhost backends like Caddy/nginx)")
+	portAddCmd.Flags().BoolVar(&portInjectPK, "inject-pk", false, "HTTP mode: inject the authenticated caller's PK as X-Skywire-Remote-PK (strips any client-supplied copy); bind the backend to loopback only")
 
 	portCmd.AddCommand(portAddCmd)
 	portCmd.AddCommand(portRmCmd)
@@ -130,6 +134,8 @@ Examples:
 			ShowOnLanding: portShowLanding,
 			ProxyAddr:     portProxyAddr,
 			Whitelist:     wl,
+			PreserveHost:  portPreserveHost,
+			InjectPK:      portInjectPK,
 		}
 		if err := rpcClient.RegisterForwardedPort(fp); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)

--- a/docs/examples/pk-aware-website/Caddyfile
+++ b/docs/examples/pk-aware-website/Caddyfile
@@ -1,0 +1,28 @@
+# PK-aware website demo — Option A (trust by listener, not source IP).
+#
+# Two listeners serve the SAME site:
+#   :80            public/clearnet door — the spoofable header is stripped.
+#   127.0.0.1:8080 skywire-only door — bound to loopback, so only the visor
+#                  can reach it; the PK injected there is authentic.
+#
+# Forward the loopback listener over skynet (NOT :80):
+#   skywire cli serve 80 --inject-pk --preserve-host --proxy-addr 127.0.0.1:8080
+#
+# See docs/guides/skynet-website-auth.md for the trust model.
+
+# --- public clearnet door: never trust the injected header here ---
+:80 {
+	request_header -X-Skywire-Remote-PK
+	import site
+}
+
+# --- skywire-only door: loopback, reachable only via the visor ---
+127.0.0.1:8080 {
+	import site
+}
+
+# The site itself. reverse_proxy passes X-Skywire-Remote-PK through to the
+# backend unchanged, so the backend sees whatever the door decided.
+(site) {
+	reverse_proxy 127.0.0.1:3000
+}

--- a/docs/examples/pk-aware-website/README.md
+++ b/docs/examples/pk-aware-website/README.md
@@ -1,0 +1,69 @@
+# PK-aware website example
+
+A skynet/dmsg-forwarded website that shows **different content per caller** by
+reading the authenticated public key the visor injects. Demonstrates the
+[skynet-website-auth](../../guides/skynet-website-auth.md) feature with the
+recommended **Option A** trust model (separate the skywire ingress from the
+clearnet ingress by *listener*, not source IP).
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `backend.go` | tiny web app (loopback `127.0.0.1:3000`) that renders a page based on `X-Skywire-Remote-PK` |
+| `Caddyfile` | Caddy fronting the backend: public `:80` strips the header, loopback `127.0.0.1:8080` trusts it |
+
+You can run the backend **with or without Caddy**. Caddy is only needed if you
+also serve the site on clearnet and/or host multiple vhosts; for a single
+skynet-only site you can point the visor straight at the backend.
+
+## Run it (visor → backend, no Caddy)
+
+```bash
+# 1. start the backend (loopback only)
+go run backend.go
+
+# 2. forward port 80 over skynet, injecting the caller PK, to the backend
+skywire cli serve 80 --inject-pk --proxy-addr 127.0.0.1:3000
+```
+
+Now from another machine with the resolving proxy configured
+(see [resolving-proxy.md](../../guides/resolving-proxy.md)):
+
+```bash
+# authenticated — the page shows your PK
+curl -x socks5h://127.0.0.1:4446 http://<visor-pk>.skynet/
+```
+
+Reach the backend directly on the host and you get the anonymous page (no PK):
+
+```bash
+curl http://127.0.0.1:3000/        # X-Skywire-Remote-PK absent → "Anonymous"
+```
+
+## Run it with Caddy (clearnet + skynet, multi-site capable)
+
+```bash
+go run backend.go                       # 127.0.0.1:3000
+caddy run --config Caddyfile            # :80 public, 127.0.0.1:8080 skywire-only
+skywire cli serve 80 --inject-pk --preserve-host --proxy-addr 127.0.0.1:8080
+```
+
+- Clearnet visitors hit Caddy `:80` → header stripped → anonymous.
+- skynet visitors are forwarded to Caddy `127.0.0.1:8080` → header authentic →
+  per-PK page.
+
+## Recognize specific PKs
+
+Edit the `allowlist` map in `backend.go` to map full 66-hex public keys to
+names. Known PKs get a personalized page; other authenticated PKs get a generic
+signed-in page; clearnet gets the anonymous page. Find your PK with
+`skywire cli visor pk`.
+
+## Why a loopback listener and not `trusted_proxies 127.0.0.1`?
+
+Because source-IP trust **fails open**: put a tunnel (cloudflared/ngrok) or a
+container port-proxy in front of Caddy and every external request suddenly
+appears to come from `127.0.0.1`, so a forged header would be trusted. A
+loopback-bound listener is unreachable from off-host by construction, so it
+fails *closed*. See the [guide](../../guides/skynet-website-auth.md#the-trust-boundary-read-this).

--- a/docs/examples/pk-aware-website/backend.go
+++ b/docs/examples/pk-aware-website/backend.go
@@ -1,0 +1,60 @@
+//go:build ignore
+
+// Command backend is a minimal PK-aware website for the
+// docs/examples/pk-aware-website demo. It binds to loopback only and reads
+// the caller's skywire public key from the X-Skywire-Remote-PK header that
+// the visor injects on an `inject_pk` forwarded port (optionally via Caddy).
+//
+// It shows three behaviors to illustrate per-PK auth:
+//   - a known PK (in the allowlist below) gets a personalized "member" page,
+//   - any other authenticated PK gets a generic signed-in page,
+//   - no PK (clearnet, header stripped) gets the anonymous page.
+//
+// Run:  go run backend.go      # listens on 127.0.0.1:3000
+//
+// NOTE: bind loopback only. The header is trustworthy *because* the only way
+// to reach this server is through the visor (or the loopback Caddy listener);
+// see docs/guides/skynet-website-auth.md.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// allowlist maps a full 66-hex public key to a display name. Replace these
+// with the PKs you want to recognize (find yours with `skywire cli visor pk`).
+var allowlist = map[string]string{
+	// "0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c": "alice",
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		pk := r.Header.Get("X-Skywire-Remote-PK")
+		transport := r.Header.Get("X-Skywire-Transport")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+		switch {
+		case pk == "":
+			fmt.Fprint(w, page("Anonymous", "You are not connecting over skywire (no verified PK). "+
+				"This is the public/clearnet view."))
+		case allowlist[pk] != "":
+			fmt.Fprint(w, page("Welcome, "+allowlist[pk],
+				fmt.Sprintf("Recognized member.<br>PK: <code>%s</code><br>via: %s", pk, transport)))
+		default:
+			fmt.Fprint(w, page("Signed in",
+				fmt.Sprintf("Authenticated skywire peer (not in the allowlist).<br>PK: <code>%s</code><br>via: %s", pk, transport)))
+		}
+	})
+
+	addr := "127.0.0.1:3000"
+	log.Printf("PK-aware demo backend listening on http://%s (loopback only)", addr)
+	log.Fatal(http.ListenAndServe(addr, nil)) //nolint:gosec
+}
+
+func page(title, body string) string {
+	return fmt.Sprintf(`<!doctype html><html><head><meta charset="utf-8"><title>%s</title></head>`+
+		`<body style="font-family:sans-serif;max-width:40rem;margin:4rem auto"><h1>%s</h1><p>%s</p></body></html>`,
+		title, title, body)
+}

--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -48,6 +48,33 @@ A resolver hostname is `<public-key>.<suffix>:<port>/<path>`:
 - `.dmsg` addresses may carry routing prefixes, e.g. `<server-pk>.<dest-pk>.dmsg`
   pins a specific dmsg rendezvous server. Use `cli tp route-addr` to build one.
 
+### Named sites / virtual hosts
+
+A label to the **left** of the destination PK that is *not* itself PK- or
+TpID-shaped becomes a **vhost** — the resolver rewrites the outgoing HTTP `Host:`
+header to it. So:
+
+```
+http://example.com.<visor-pk>.skynet/
+```
+
+dials `<visor-pk>`'s port 80 and sends `Host: example.com`. If that visor forwards
+its port 80 to a reverse proxy (Caddy/nginx/traefik) that dispatches by Host, the
+proxy serves the `example.com` vhost — letting **one visor expose many real-domain
+sites** over skynet (or dmsg). The vhost may have dots (`a.b.example.com.<pk>.skynet`)
+and combine with routing prefixes; it's purely shape-based.
+
+For this to do anything, the destination visor must actually **forward `:80` to the
+vhost server** (`skywire cli serve 80 --preserve-host --proxy-addr 127.0.0.1:8080`);
+if `:80` is just the default landing page, the rewritten Host is ignored.
+`--preserve-host` is what keeps the rewritten Host intact end-to-end. The rewrite
+is skipped on the TLS port when MITM is off (a raw-TLS stream isn't HTTP), but
+applies on plain `:80`.
+
+To make those sites **PK-aware** (different content per caller), see
+[skynet-website-auth.md](skynet-website-auth.md) — the visor can inject the
+authenticated caller's PK as a header the site can trust.
+
 ### Your own visor (self-loopback + alias)
 
 Requesting **your own visor's PK** through the proxy

--- a/docs/guides/skynet-website-auth.md
+++ b/docs/guides/skynet-website-auth.md
@@ -1,0 +1,116 @@
+# PK-aware websites over skynet / dmsg
+
+A website forwarded over skynet or dmsg is, by default, a **blind TCP splice**:
+the visor pipes bytes between the remote peer and your local web server, so the
+web server never learns *who* is connecting. The visor, however, already knows —
+the skywire transport is authenticated by the caller's public key (the noise
+handshake). `inject_pk` hands that identity to your backend so a site can do
+per-PK behavior (auth, personalization, gating) the splice can't.
+
+## What it does
+
+With `inject_pk` enabled on a forwarded port, the visor stops splicing and
+instead terminates HTTP and reverse-proxies to your backend, stamping two
+headers on every request:
+
+| Header | Value |
+|---|---|
+| `X-Skywire-Remote-PK` | the caller's 66-hex public key (omitted if the peer can't be identified) |
+| `X-Skywire-Transport` | `dmsg` or `skynet` |
+
+Any client-supplied copy of those headers is **stripped first**, then the
+authentic value is set — so a caller cannot forge them *over this path*. This is
+the moral equivalent of an mTLS-terminating reverse proxy exposing the verified
+client certificate to its backend: the visor did the one handshake and vouches
+for the PK.
+
+```bash
+skywire cli serve 80 --inject-pk --preserve-host --proxy-addr 127.0.0.1:8080
+# (or the deprecated `skywire cli skynet port add 80 --inject-pk ...`)
+```
+
+Your backend then just reads a header — in any language:
+
+```go
+pk := r.Header.Get("X-Skywire-Remote-PK") // "" = anonymous / not via skywire
+```
+
+## The trust boundary (read this)
+
+The header is only trustworthy if **your backend is reachable ONLY through the
+visor.** The visor strips-and-sets the header on requests that pass *through* it;
+a request that reaches the backend by any other door was never sanitized.
+
+- **Safe (default):** bind your backend to `127.0.0.1`. The visor dials
+  `localhost`, and nothing off-host can reach a loopback listener — so the visor
+  is the sole ingress and the header is authoritative.
+- **Unsafe:** if the *same* backend listener is also exposed directly to
+  clearnet, a direct client can send a forged `X-Skywire-Remote-PK` and your
+  backend will believe it. The visor cannot sanitize a request it never saw.
+
+**Trust the destination, not the source IP.** Don't try to solve the dual-exposure
+case with "trust the header only from `127.0.0.1`" (e.g. Caddy `trusted_proxies`):
+it *fails open*. The moment anything that re-dials your server from localhost sits
+in front of it — a cloudflared/ngrok tunnel, a container's port-proxy, another
+reverse proxy — every external request appears to come from `127.0.0.1` and the
+forged header is trusted, silently. Separation by listener fails *closed*
+(misconfig → no header → treated as anonymous), which is what you want for auth.
+
+## Serving on both skynet AND clearnet (Caddy example)
+
+The common setup: **Caddy** is the public front door on `:80`, serving several
+sites, and you forward Caddy's port over skynet. Because that single `:80`
+listener takes both clearnet and skynet traffic, you can't trust the header on
+it. The fix is a **dedicated loopback listener** that only the visor reaches:
+
+```caddyfile
+# Public clearnet door — never trust the injected header here.
+:80 {
+	request_header -X-Skywire-Remote-PK
+	import sites
+}
+
+# skywire-only door — bound to loopback, so only the visor can reach it.
+# The visor forwards skynet/dmsg traffic here and injects the PK.
+127.0.0.1:8080 {
+	import sites   # same sites; here {http.request.header.X-Skywire-Remote-PK} is authentic
+}
+
+(sites) {
+	# your vhosts; reverse_proxy passes the header through to each app
+	@example host example.com
+	handle @example {
+		reverse_proxy 127.0.0.1:3000
+	}
+}
+```
+
+Then forward the **loopback** listener (not the public `:80`):
+
+```bash
+skywire cli serve 80 --inject-pk --preserve-host --proxy-addr 127.0.0.1:8080
+```
+
+- `--preserve-host` passes the incoming `Host:` through so Caddy's vhost routing
+  works — pair it with the resolver's subdomain form
+  (`http://example.com.<visor-pk>.skynet`, see
+  [resolving-proxy.md](resolving-proxy.md)).
+- The PK header propagates to every site behind Caddy for free — each app just
+  reads `X-Skywire-Remote-PK`; no per-app visor config.
+- Clearnet visitors hit `:80`, where the header is stripped, so they're simply
+  anonymous.
+
+A working end-to-end example (Caddyfile + a tiny PK-aware backend) lives in
+[../examples/pk-aware-website/](../examples/pk-aware-website/).
+
+## Limits
+
+- **HTTP only.** `inject_pk` makes the visor parse HTTP; enabling it on a
+  non-HTTP service breaks the stream. Leave it off for raw TCP forwards.
+- **Plain HTTP between visor and backend.** The visor injects into cleartext
+  HTTP; if the backend speaks end-to-end TLS the visor can't add a header
+  without terminating TLS. Put the backend on plain-HTTP loopback.
+- **Whitelist still applies.** `inject_pk` is orthogonal to the per-port PK
+  whitelist: the whitelist gates *whether* a peer may connect at all; the header
+  tells your app *who* connected so it can decide what to show. Use either or
+  both.

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -74,6 +74,61 @@ func buildReverseProxy(log *logging.Logger, target *url.URL, preserveHost bool) 
 	return proxy
 }
 
+// servePKInjectedForward serves one forwarded HTTP connection by
+// reverse-proxying it to target while stamping the noise-authenticated
+// caller identity into request headers the backend can trust:
+//
+//	X-Skywire-Remote-PK   caller's 66-hex PK (omitted when havePK is false)
+//	X-Skywire-Transport   "dmsg" or "skynet"
+//
+// Any client-supplied copies of those headers are stripped before the
+// authentic values are set, so a caller cannot forge them over this path —
+// the visor (not the client) terminated the skywire transport, so the PK
+// is the cryptographically-verified peer. This is the moral equivalent of
+// an mTLS-terminating proxy exposing the verified client cert to a backend.
+//
+// The header is only meaningful if the backend is reachable ONLY through
+// the visor (bind it to loopback); a backend also exposed directly to
+// clearnet would let a direct client forge the header. See
+// docs/guides/skynet-website-auth.md for the trust model.
+// stampSkywireIdentity rewrites the outbound request so the backend sees the
+// noise-authenticated caller identity and cannot be lied to about it: any
+// client-supplied X-Skywire-* identity headers are stripped first, then the
+// authentic values are set. With havePK false (peer unidentifiable) the PK
+// header is left absent rather than set to a zero value.
+func stampSkywireIdentity(out *http.Request, pk cipher.PubKey, havePK bool, transport string) {
+	out.Header.Del("X-Skywire-Remote-PK")
+	out.Header.Del("X-Skywire-Transport")
+	if havePK {
+		out.Header.Set("X-Skywire-Remote-PK", pk.Hex())
+	}
+	out.Header.Set("X-Skywire-Transport", transport)
+}
+
+func (v *Visor) servePKInjectedForward(conn net.Conn, target, transport string, pk cipher.PubKey, havePK, preserveHost bool) {
+	u := &url.URL{Scheme: "http", Host: target}
+	rp := buildReverseProxy(v.log, u, preserveHost)
+	base := rp.Rewrite
+	rp.Rewrite = func(r *httputil.ProxyRequest) {
+		base(r)
+		stampSkywireIdentity(r.Out, pk, havePK, transport)
+	}
+	// Serve HTTP over this single connection. ConnState closes the
+	// one-shot listener once the connection is done so Serve's accept
+	// loop returns instead of leaking a goroutine.
+	lis := &singleConnListener{conn: conn}
+	srv := &http.Server{
+		Handler:           rp,
+		ReadHeaderTimeout: 30 * time.Second,
+		ConnState: func(_ net.Conn, s http.ConnState) {
+			if s == http.StateClosed || s == http.StateHijacked {
+				_ = lis.Close() //nolint:errcheck
+			}
+		},
+	}
+	_ = srv.Serve(lis) //nolint:errcheck
+}
+
 // refreshWebsiteHandler (re)applies the right website handler to the
 // dmsghttp logserver based on current config + forwarded-port state.
 // Called at startup AND on every register/update/deregister of port 80
@@ -549,13 +604,15 @@ func (v *Visor) startDmsgForwarder(port, localPort int) {
 			}
 			go func() {
 				defer conn.Close() //nolint:errcheck
-				// Per-port PK whitelist applies regardless of transport.
-				// remotePK pulls the peer's PK from either dmsg.Addr or
-				// appnet.Addr; fail closed if we can't identify them.
+				// Identify the peer once (used for the whitelist gate AND,
+				// when enabled, the X-Skywire-Remote-PK header injection).
+				// remotePK pulls the PK from either dmsg.Addr or appnet.Addr.
 				fp := v.forwardedPorts.Get(port)
+				pk, pkOK := remotePK(conn.RemoteAddr())
+				// Per-port PK whitelist applies regardless of transport;
+				// fail closed if we can't identify the caller.
 				if fp != nil && len(fp.Whitelist) > 0 {
-					pk, ok := remotePK(conn.RemoteAddr())
-					if !ok {
+					if !pkOK {
 						log.Warn("Rejected: cannot identify peer on whitelisted port")
 						return
 					}
@@ -569,6 +626,13 @@ func (v *Visor) startDmsgForwarder(port, localPort int) {
 				target := fmt.Sprintf("localhost:%d", localPort)
 				if fp != nil && fp.ProxyAddr != "" {
 					target = fp.ProxyAddr
+				}
+				// HTTP-aware mode: terminate HTTP and stamp the authenticated
+				// caller PK into a header the backend can trust, instead of a
+				// blind byte splice.
+				if fp != nil && fp.InjectPK {
+					v.servePKInjectedForward(conn, target, transport, pk, pkOK, fp.PreserveHost)
+					return
 				}
 				local, err := net.Dial("tcp", target)
 				if err != nil {

--- a/pkg/visor/api_network_test.go
+++ b/pkg/visor/api_network_test.go
@@ -8,8 +8,53 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// TestStampSkywireIdentity verifies the anti-spoof contract of the
+// inject_pk forward: a client-supplied X-Skywire-* header is overwritten
+// (never trusted), the authentic PK + transport are set, other headers are
+// untouched, and an unidentifiable peer leaves the PK header absent.
+func TestStampSkywireIdentity(t *testing.T) {
+	var pk cipher.PubKey
+	if err := pk.Set("0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"); err != nil {
+		t.Fatalf("set pk: %v", err)
+	}
+
+	t.Run("authenticated overwrites a spoofed header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://backend/", nil)
+		req.Header.Set("X-Skywire-Remote-PK", "deadbeef-forged-by-client") // spoof attempt
+		req.Header.Set("X-Skywire-Transport", "lies")
+		req.Header.Set("X-Other", "keep-me")
+
+		stampSkywireIdentity(req, pk, true, "skynet")
+
+		if got := req.Header.Get("X-Skywire-Remote-PK"); got != pk.Hex() {
+			t.Errorf("PK = %q, want authentic %q", got, pk.Hex())
+		}
+		if got := req.Header.Get("X-Skywire-Transport"); got != "skynet" {
+			t.Errorf("transport = %q, want skynet", got)
+		}
+		if got := req.Header.Get("X-Other"); got != "keep-me" {
+			t.Errorf("unrelated header dropped: %q", got)
+		}
+	})
+
+	t.Run("anonymous strips a spoofed header and sets none", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "http://backend/", nil)
+		req.Header.Set("X-Skywire-Remote-PK", "forged") // must not survive
+
+		stampSkywireIdentity(req, cipher.PubKey{}, false, "dmsg")
+
+		if got := req.Header.Get("X-Skywire-Remote-PK"); got != "" {
+			t.Errorf("PK = %q, want absent for unidentified peer", got)
+		}
+		if got := req.Header.Get("X-Skywire-Transport"); got != "dmsg" {
+			t.Errorf("transport = %q, want dmsg", got)
+		}
+	})
+}
 
 // TestBuildReverseProxy_HostRewriteDefault checks the historical
 // default — preserveHost=false → backend sees Host = target.Host —

--- a/pkg/visor/forwarded_ports.go
+++ b/pkg/visor/forwarded_ports.go
@@ -65,6 +65,24 @@ type ForwardedPort struct {
 	//                    backend (Caddy, nginx, traefik) dispatches
 	//                    its virtual hosts by Host header.
 	PreserveHost bool `json:"preserve_host,omitempty"`
+	// InjectPK, when true, makes this forward HTTP-aware: instead of a
+	// raw TCP splice, the visor terminates HTTP and reverse-proxies to
+	// the backend, stamping the noise-authenticated caller into request
+	// headers the backend can trust:
+	//
+	//   X-Skywire-Remote-PK   the caller's 66-hex public key (omitted if
+	//                         the peer can't be identified)
+	//   X-Skywire-Transport   "dmsg" or "skynet"
+	//
+	// Any client-supplied copies of those headers are stripped first, so
+	// they cannot be spoofed over this path. This lets a forwarded website
+	// do per-PK behavior (auth, personalization) that a raw splice can't,
+	// because the backend otherwise never learns who is connecting.
+	//
+	// HTTP only — enabling it on a non-HTTP service breaks the stream. The
+	// header is only trustworthy if the backend is reachable ONLY through
+	// the visor (bind it to loopback); see docs/guides/skynet-website-auth.md.
+	InjectPK bool `json:"inject_pk,omitempty"`
 }
 
 // EffectiveLocalPort returns the local TCP port to forward to.


### PR DESCRIPTION
Lets a skynet/dmsg-forwarded website do **per-PK behavior** (auth, personalization). Today a forwarded port is a blind TCP splice, so the backend never learns who is connecting — even though the visor already holds the noise-authenticated caller PK (it uses it for the per-port whitelist).

## What

`inject_pk` on a forwarded port makes it HTTP-aware: the visor reverse-proxies to the backend and stamps

| header | value |
|---|---|
| `X-Skywire-Remote-PK` | caller's 66-hex PK (omitted if unidentifiable) |
| `X-Skywire-Transport` | `dmsg` or `skynet` |

Any client-supplied copy is **stripped first**, then the authentic value is set — so it can't be spoofed over this path. Moral equivalent of an mTLS-terminating proxy exposing the verified client cert. Backends read one header, in any language.

```bash
skywire cli serve 80 --inject-pk --preserve-host --proxy-addr 127.0.0.1:8080
```

## Trust model (documented, important)

The header is only authoritative if the backend is reachable **only through the visor** (bind loopback). For a site also on clearnet, separate the skywire ingress by **listener** (a loopback-only Caddy listener the visor forwards to), **not** by source IP — `trusted_proxies 127.0.0.1` *fails open* the moment a tunnel/container/fronting proxy re-dials the backend from localhost. Listener separation *fails closed* (→ anonymous). Full writeup + Caddy config in `docs/guides/skynet-website-auth.md`; runnable demo in `docs/examples/pk-aware-website/`.

## Changes

- `ForwardedPort.InjectPK`; `servePKInjectedForward` reuses `buildReverseProxy` (Host-preserve + WS) and adds a strip-then-set `Rewrite` (`stampSkywireIdentity`). Single conn served via `singleConnListener` + a `ConnState` hook so `Serve`'s accept loop exits instead of leaking a goroutine.
- CLI: `serve --inject-pk` / `--preserve-host`; same on deprecated `skynet port add`.
- Also documents the resolver **vhost host-rewrite** (`example.com.<pk>.skynet`) in `resolving-proxy.md` — the addressing side of serving real-domain sites over skynet.
- Unit test covers the anti-spoof contract (overwrite forged header / omit when anonymous / preserve unrelated headers).

## Validation status

Builds, `go test ./pkg/visor` (new + existing reverse-proxy tests) pass, visor boots clean on this build. **End-to-end header injection over a live skynet forward is not yet validated** (needs a second visor as the caller) — please don't merge before that runtime check.