### PR TITLE
fix(ar): rebuild SUDPH packet-filter conn on reconnect (kcp closes it)

### DIFF
--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -570,10 +570,14 @@ func (c *httpClient) BindSUDPH(filter *pfilter.PacketFilter, hs Handshake) (<-ch
 // listener and posts the initial register payload. Called once on initial
 // BindSUDPH and again on every reconnect attempt.
 //
-// The underlying packet listener (c.sudphConn) is created on the first call
-// and reused across reconnects so the local UDP port stays stable — both
-// for AR's record of our public address and for any remote visors that
-// already received our (PK, port) tuple via Resolve.
+// A fresh per-connection packet-filter conn (c.sudphConn) is built on every
+// call. kcp client sockets close their underlying conn on Close (see
+// xtaci/kcp-go sess.go: a session with no listener closes s.conn), so the
+// prior c.sudphConn is already dead by reconnect time and reusing it fails
+// every attempt with "use of closed network connection". The local UDP port
+// is the SHARED listener's — filter.NewConn does not allocate a new port — so
+// it stays stable across rebuilds anyway, both for AR's record of our public
+// address and for remote visors that received our (PK, port) tuple via Resolve.
 func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (net.Conn, LocalAddresses, error) {
 	if c.remoteUDPAddr == "" {
 		// dmsg-only AR with no udp_address in /health. Surface a clear
@@ -585,9 +589,13 @@ func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (n
 		return nil, LocalAddresses{}, err
 	}
 
-	if c.sudphConn == nil {
-		c.sudphConn = filter.NewConn(sudphPriority, packetfilter.NewAddressFilter(rAddr, c.mLog))
+	// Drop any prior (kcp-closed) conn and build a fresh one. The defensive
+	// Close is a no-op when kcp already closed it and guards against leaking a
+	// filter conn on the rare path where it is still open.
+	if c.sudphConn != nil {
+		_ = c.sudphConn.Close() //nolint:errcheck,gosec
 	}
+	c.sudphConn = filter.NewConn(sudphPriority, packetfilter.NewAddressFilter(rAddr, c.mLog))
 
 	_, localPort, err := net.SplitHostPort(c.sudphConn.LocalAddr().String())
 	if err != nil {


### PR DESCRIPTION
## Bug

A visor whose SUDPH↔address-resolver link drops gets **permanently wedged** out of SUDPH registration, spamming:
```
[address_resolver] SUDPH connection to address-resolver lost, reconnecting...
[address_resolver] SUDPH reconnect failed, will retry  error="handshake failed: use of closed network connection"
```
every minute forever (observed live for 13+ min straight). It also produces the steady `sudph handshake timeout` noise from peers that can no longer reach it.

## Root cause

`connectSUDPH` reused `c.sudphConn` across reconnects (`if c.sudphConn == nil`) to keep the local UDP port stable. But a **kcp client session closes its underlying conn on Close** — `xtaci/kcp-go` `sess.go`:
```go
if s.l != nil { ... } else { // client socket close
    return s.conn.Close()
}
```
So when an `arConn` dies and is closed, kcp closes the shared `c.sudphConn` too. The nil-guard still sees it as non-nil → every reconnect reuses the **dead** socket → `use of closed network connection`, forever.

## Fix

Build a fresh `filter.NewConn` on every `connectSUDPH`. The local UDP port is the **shared** listener's (`filter.NewConn` doesn't allocate a new port), so it stays stable across rebuilds — which is the only thing the reuse was protecting. The reuse never actually delivered port stability; it just hid the closed-conn problem and then re-broke on it. `pfilter` re-registration is clean (`NewConn` allocates a fresh conn; `Close`→`removeConn` unregisters the old).

## Validation

- Root cause traced through kcp-go + pfilter source.
- Unit tests pass (`pkg/transport/network/addrresolver`).
- Rolled onto the live wedged visor: SUDPH/AR came back healthy (`New SUDPH message` flowing), `use of closed network connection` count → **0**.