### PR TITLE
diag(router): log route-group rule linkage on setup-failure (both ends)

### DIFF
--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -301,8 +301,18 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 		// Hard-fail loudly so the dial returns a real error to the caller
 		// and the operator can see "remote not responding" instead of a
 		// phantom success.
+		// Enrich the failure with this side's full rule linkage so an
+		// initiator timeout and the peer's wrap-failure log can be compared to
+		// detect a reverse-leg route-ID mismatch: the initiator listens on
+		// rev_key over rev_tp and the responder must stamp its reverse packets
+		// with that same ID over the matching transport. fwd_next is the ID this
+		// side stamps toward the peer (should equal the peer's consume keyRtID).
 		log.WithField("desc", rules.Desc.String()).
 			WithField("timeout", handshakeAwaitTimeout).
+			WithField("fwd_next", rules.Forward.NextRouteID()).
+			WithField("fwd_tp", rules.Forward.NextTransportID()).
+			WithField("rev_key", rules.Reverse.KeyRouteID()).
+			WithField("rev_tp", rules.Reverse.NextTransportID()).
 			Warn("Remote handshake not received within timeout — failing dial")
 		// Clean up rgsRaw + delete the rules we installed locally so the
 		// keyRouteIDs are free for the next attempt.
@@ -348,7 +358,18 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 		// wrapping rg with noise
 		wrappedRG, err := network.EncryptConn(nsConf, rg)
 		if err != nil {
-			log.WithError(err).Errorf("Failed to wrap route group (%s): %v, closing...", &rules.Desc, err)
+			// Rule linkage on the responder side, to pair with the initiator's
+			// "Remote handshake not received" log: rev_next is the ID this side
+			// stamps on reverse packets (must equal the initiator's rev_key);
+			// fwd_key is what this side consumes on (must equal the initiator's
+			// fwd_next). A "no data captured" wrap-failure usually means the
+			// initiator already timed out and never sent the noise first message.
+			log.WithError(err).
+				WithField("fwd_key", rules.Forward.KeyRouteID()).
+				WithField("fwd_tp", rules.Forward.NextTransportID()).
+				WithField("rev_next", rules.Reverse.NextRouteID()).
+				WithField("rev_tp", rules.Reverse.NextTransportID()).
+				Errorf("Failed to wrap route group (%s): %v, closing...", &rules.Desc, err)
 			if err := rg.Close(); err != nil {
 				log.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)
 			}


### PR DESCRIPTION
## Why

Route-group setup intermittently fails: the **initiator** times out (`Remote handshake not received`) while the **responder**'s noise wrap reads `no data captured` — i.e. the responder's reverse handshake reply isn't reaching the initiator.

Investigation (live, both ends via `--via` RPC + pty root on the deployment boxes) **ruled out** the obvious causes:
- **Not a one-way/dead transport** — the transport the route uses is provably bidirectional (`latency_ms>0` round-trip pong + symmetric `recv==sent` bytes).
- **Not whitelist denial** — the initiator's PK is on the destination app's whitelist.

The leading suspect is a **reverse-leg route-ID mismatch**: the responder stamps its reverse packets with an ID the initiator has no rule for, so they're dropped (`rule not found (routeID=N, Ping)` is seen on the initiator). But the failure is **intermittent** (tracks transient transport/load + the old `min_hops:2/mux_routes:2` config) and currently doesn't reproduce on demand.

## What

Rather than ship a speculative fix, this enriches **both** existing setup-failure logs with the local rule linkage so the next real occurrence is fully diagnosable by pairing the two ends:

| log | added fields |
|---|---|
| initiator `Remote handshake not received` | `fwd_next`, `rev_key`, `fwd_tp`, `rev_tp` |
| responder `Failed to wrap route group` | `fwd_key`, `rev_next`, `fwd_tp`, `rev_tp` |

A mismatch is then immediate: responder `rev_next` ≠ initiator `rev_key`, or responder `fwd_key` ≠ initiator `fwd_next`.

**Diagnostics only — no behavior change**, on the already-logged failure paths. Deploying network-wide means the next failure anywhere is captured with definitive both-ends data, so the real fix can target the confirmed cause.