### PR TITLE
fix(visor): dmsg-only TPD boot wedge — drop plain-HTTP fallback in connectToTpDisc

### DIFF
--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -1015,9 +1015,9 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 		tries  = 0
 		factor = 1
 		// tpdDmsgReadyWait bounds how long boot waits for dmsg to be ready
-		// before the DMSG-HTTP transport-discovery attempt. The select on
-		// dmsgC.Ready() returns early once ready; this cap just prevents a
-		// never-ready dmsg from blocking here (it then falls to plain HTTP).
+		// before the transport-discovery attempt. The select on dmsgC.Ready()
+		// returns early once ready; this cap just prevents a never-ready dmsg
+		// from blocking boot here indefinitely.
 		tpdDmsgReadyWait = 60 * time.Second
 	)
 
@@ -1028,39 +1028,32 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 		return nil, err
 	}
 
-	// Try DMSG-HTTP first if configured, fall back to plain HTTP
+	// Resolve the transport-discovery URL. Prefer the dmsg address; use the
+	// plain-HTTP URL only when no dmsg address is configured. There is no
+	// fallback between the two transports: a dmsg-only deployment that cannot
+	// yet reach the TPD over dmsg retries the dmsg path rather than silently
+	// degrading to the (empty) HTTP URL — which previously resolved to
+	// http://localhost and wedged boot forever (tries=0).
+	tpdURL := conf.DiscoveryDmsg
+	if tpdURL == "" {
+		tpdURL = conf.Discovery
+	}
+	if tpdURL == "" {
+		return nil, errors.New("no transport discovery configured: both Transport.Discovery and Transport.DiscoveryDmsg are empty")
+	}
+
+	// For a dmsg TPD, wait (bounded) for dmsg sessions to be ready so the first
+	// request does not fail before any session exists.
 	if conf.DiscoveryDmsg != "" && v.dmsgC != nil {
-		// At boot, initTransport can run before dmsg has established its
-		// sessions; without waiting, getHTTPClient(DiscoveryDmsg) fails and we
-		// fall through to the plain-HTTP retrier below — which, for a dmsg-only
-		// deployment, has no working egress and spins forever (tries=0),
-		// wedging the whole visorinit. Wait (bounded) for dmsg first so the
-		// DMSG-HTTP path can succeed; the select returns immediately once ready.
 		select {
 		case <-v.dmsgC.Ready():
 		case <-time.After(tpdDmsgReadyWait):
-			log.Warn("dmsg not ready within timeout for DMSG-HTTP transport discovery; attempting anyway")
+			log.Warn("dmsg not ready within timeout for transport discovery; attempting anyway")
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
-		dmsgHTTPC, err := getHTTPClient(ctx, v, conf.DiscoveryDmsg)
-		if err != nil {
-			log.WithError(err).Warn("Failed to get DMSG-HTTP client for TPD, trying plain HTTP")
-		} else {
-			tpdC, err := tpdclient.NewHTTP(conf.DiscoveryDmsg, v.conf.PK, v.conf.SK, dmsgHTTPC, pIP, v.MasterLogger())
-			if err == nil {
-				log.Info("Connected to transport discovery via DMSG-HTTP")
-				return tpdC, nil
-			}
-			log.WithError(err).Warn("DMSG-HTTP transport discovery failed, falling back to plain HTTP")
-		}
 	}
 
-	// Plain HTTP (primary if no DMSG config, fallback if DMSG failed)
-	tpdURL := conf.Discovery
-	if tpdURL == "" && conf.DiscoveryDmsg != "" {
-		tpdURL = conf.DiscoveryDmsg // DMSG-only deployment
-	}
 	httpC, err := getHTTPClient(ctx, v, tpdURL)
 	if err != nil {
 		return nil, err
@@ -1071,7 +1064,7 @@ func connectToTpDisc(ctx context.Context, v *Visor, log *logging.Logger) (transp
 	var tpdC transport.DiscoveryClient
 	retryFunc := func() error {
 		var err error
-		tpdC, err = tpdclient.NewHTTP(conf.Discovery, v.conf.PK, v.conf.SK, httpC, pIP, v.MasterLogger())
+		tpdC, err = tpdclient.NewHTTP(tpdURL, v.conf.PK, v.conf.SK, httpC, pIP, v.MasterLogger())
 		if err != nil {
 			log.WithError(err).Error("Failed to connect to transport discovery, retrying...")
 			return err


### PR DESCRIPTION
## Symptom

A dmsg-only visor (config with `transport.discovery: ""` and only `transport.discovery_dmsg` set) **intermittently wedges at boot** — RPC never binds, `cli` can't reach it — while spamming:

```
WARN  retrier [transport_manager]: Retrying... error="transport discovery httpauth:
  Get \"http://localhost/security/nonces/<pk>\": invalid host address: Invalid public key"
ERROR [transport_manager]: Failed to connect to transport discovery, retrying...
```

`transport_manager.Serve` blocks on `connectToTpDisc`, which retries forever (`tries=0`), so visorinit never completes.

## Root cause

`connectToTpDisc` tried DMSG-HTTP first and, on any miss, **fell through to a plain-HTTP retrier**. In dmsg-only mode that fallback built its httpauth client against the empty `Discovery` URL → resolves to `http://localhost`. The request still goes out over the **dmsg-HTTP RoundTripper**, which rejects host `localhost` as a dmsg address (`Invalid public key`). With `tries=0` it spins on that forever.

It only triggered when the DMSG-HTTP-first attempt happened to miss (e.g. dmsg sessions to the TPD's dmsg server not yet established at boot) — hence intermittent. Whenever the first attempt succeeded, the visor booted fine and the bug was invisible.

## Fix

Collapse the two paths into one, **no silent transport fallback**:
- Resolve the TPD URL once — prefer `DiscoveryDmsg`, use `Discovery` only when no dmsg address is configured.
- Build the matching client via `getHTTPClient`, which already dispatches on the `dmsg://` vs `http://` scheme.
- Retry that single client. A dmsg-only visor now retries the **dmsg** path instead of degrading to an empty HTTP URL.
- Error out clearly if neither is configured.

Validated on a live dmsg-only visor that was reproducibly wedged: with the fix it boots clean and binds RPC.