### PR TITLE
fix(router): panic-safe setup-failure diagnostics — NextRouteID() panics on Consume rule (#3107 regression)

### DIFF
--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -301,18 +301,15 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 		// Hard-fail loudly so the dial returns a real error to the caller
 		// and the operator can see "remote not responding" instead of a
 		// phantom success.
-		// Enrich the failure with this side's full rule linkage so an
-		// initiator timeout and the peer's wrap-failure log can be compared to
-		// detect a reverse-leg route-ID mismatch: the initiator listens on
-		// rev_key over rev_tp and the responder must stamp its reverse packets
-		// with that same ID over the matching transport. fwd_next is the ID this
-		// side stamps toward the peer (should equal the peer's consume keyRtID).
-		log.WithField("desc", rules.Desc.String()).
-			WithField("timeout", handshakeAwaitTimeout).
-			WithField("fwd_next", rules.Forward.NextRouteID()).
-			WithField("fwd_tp", rules.Forward.NextTransportID()).
-			WithField("rev_key", rules.Reverse.KeyRouteID()).
-			WithField("rev_tp", rules.Reverse.NextTransportID()).
+		// Enrich the failure with this side's full rule linkage so an initiator
+		// timeout and the peer's wrap-failure log can be compared to detect a
+		// reverse-leg route-ID mismatch. Both rules are rendered via the
+		// panic-safe Rule.String() (keyRtID/nxtRtID/nxtTpID per rule type);
+		// calling NextRouteID()/NextTransportID() directly panics on a Consume
+		// (reverse) rule.
+		log.WithField("timeout", handshakeAwaitTimeout).
+			WithField("fwd_rule", rules.Forward.String()).
+			WithField("rev_rule", rules.Reverse.String()).
 			Warn("Remote handshake not received within timeout — failing dial")
 		// Clean up rgsRaw + delete the rules we installed locally so the
 		// keyRouteIDs are free for the next attempt.
@@ -358,17 +355,16 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 		// wrapping rg with noise
 		wrappedRG, err := network.EncryptConn(nsConf, rg)
 		if err != nil {
-			// Rule linkage on the responder side, to pair with the initiator's
-			// "Remote handshake not received" log: rev_next is the ID this side
-			// stamps on reverse packets (must equal the initiator's rev_key);
-			// fwd_key is what this side consumes on (must equal the initiator's
-			// fwd_next). A "no data captured" wrap-failure usually means the
-			// initiator already timed out and never sent the noise first message.
+			// Rule linkage to pair with the initiator's "Remote handshake not
+			// received" log. Both rules are rendered via the panic-safe
+			// Rule.String() (it prints keyRtID/nxtRtID/nxtTpID per rule type);
+			// calling type-specific accessors like NextRouteID()/NextTransportID()
+			// directly panics on a Consume (reverse) rule. A "no data captured"
+			// wrap-failure usually means the initiator already timed out and never
+			// sent the noise first message.
 			log.WithError(err).
-				WithField("fwd_key", rules.Forward.KeyRouteID()).
-				WithField("fwd_tp", rules.Forward.NextTransportID()).
-				WithField("rev_next", rules.Reverse.NextRouteID()).
-				WithField("rev_tp", rules.Reverse.NextTransportID()).
+				WithField("fwd_rule", rules.Forward.String()).
+				WithField("rev_rule", rules.Reverse.String()).
 				Errorf("Failed to wrap route group (%s): %v, closing...", &rules.Desc, err)
 			if err := rg.Close(); err != nil {
 				log.WithError(err).Errorf("Failed to close route group (%s): %v", &rules.Desc, err)


### PR DESCRIPTION
## Critical regression from #3107

The route-group setup-failure diagnostics added in #3107 called type-specific `Rule` accessors directly:

```go
rules.Reverse.NextRouteID()      // responder wrap-failure log (router_serve.go:370)
rules.Reverse.NextTransportID()  // initiator timeout log
```

On the reverse leg `rules.Reverse` is a **Consume** (`RuleReverse`) rule, for which `NextRouteID()` / `NextTransportID()` **panic** (`invalid rule: Consume` — see `pkg/routing/rule.go:178`). Both diagnostics fire on route-setup **failure** paths, so instead of just logging the failure the visor crashes:

```
panic: invalid rule: Consume
  routing.Rule.NextRouteID            (rule.go:178)
  router.(*router).saveRouteGroupRules (router_serve.go:370)
  router.(*router).AcceptRoutes        (router_serve.go:60)
```

i.e. any visor that responds to (or initiates) a failing route-group setup panics and crash-loops. This was reproduced live on a visor that crash-looped every ~2-3 min.

## Fix

Render each rule via the **panic-safe `Rule.String()`** instead of hand-picked accessors. `String()` prints `keyRtID`/`nxtRtID`/`nxtTpID` per rule type (`REV`/`FWD`/`INTER`) and makes no type assumptions, so it's strictly more diagnostic detail with zero panic risk. The reverse-leg route-ID mismatch the logging targets is still fully visible by comparing `fwd_rule`/`rev_rule` across the two ends.

Validated: `pkg/router` + full binary build green; local visor that was crash-looping on this panic boots and stays up.