### PR TITLE
fix rewards calculation

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -249,17 +249,34 @@ func calcPresenceShare(ni nodeinfo, ipCounts, macCounts map[string]int) float64 
 	return share
 }
 
-// applyRegionalSaturation applies diminishing returns scaling based on the
-// number of unique IP addresses per country. Each country's weight is
-// unique_ips^exponent (default sqrt). This scales each visor's share so that
-// the total pool allocation is redistributed to favor geographic diversity.
+// applyRegionalSaturation scales each visor's share by a per-country
+// density factor unique_ips_country^(exponent - 1). This is a per-visor
+// multiplier, not a country-pot allocation: a country's total reward
+// grows linearly with the number of visors (subject to the per-IP cap
+// already enforced in calcPresenceShare), so adding visors at an existing
+// IP within the cap no longer dilutes existing visors' rewards. The
+// renormalization back to the daily pool happens in computePoolRewards.
+//
+// Exponent semantics match the prior implementation:
+//
+//	exponent = 1.0  → scale = 1 everywhere (no derating)
+//	exponent = 0.5  → scale = 1/sqrt(N) (default, sqrt-style saturation)
+//	exponent = 0.0  → scale = 1/N (every country's total reward equal,
+//	                  regardless of how many IPs or visors)
+//
+// Earlier versions of this function computed a country pot from
+// N^exponent and split it equally across the country's visors, which
+// froze each country's total at the single-visor amount and penalized
+// the 2nd-Nth visor at any IP — undoing the per-IP capacity that the
+// per-IP cap was supposed to grant. The new formulation preserves the
+// per-IP visor capacity from calcPresenceShare while still discounting
+// dense-IP countries on a per-visor basis.
 func applyRegionalSaturation(nodes []nodeinfo, exponent float64) {
 	if exponent >= 1.0 || len(nodes) == 0 {
 		return
 	}
 
 	countryIPs := make(map[string]map[string]struct{})
-	countryShares := make(map[string]float64)
 	for _, ni := range nodes {
 		c := ni.Country
 		if c == "" {
@@ -269,30 +286,11 @@ func applyRegionalSaturation(nodes []nodeinfo, exponent float64) {
 			countryIPs[c] = make(map[string]struct{})
 		}
 		countryIPs[c][ni.IPAddr] = struct{}{}
-		countryShares[c] += ni.Share
-	}
-
-	totalWeight := 0.0
-	countryWeight := make(map[string]float64)
-	for c, ips := range countryIPs {
-		w := math.Pow(float64(len(ips)), exponent)
-		countryWeight[c] = w
-		totalWeight += w
-	}
-
-	totalRawShares := 0.0
-	for _, s := range countryShares {
-		totalRawShares += s
-	}
-	if totalRawShares == 0 || totalWeight == 0 {
-		return
 	}
 
 	countryScale := make(map[string]float64)
-	for c, raw := range countryShares {
-		if raw > 0 {
-			countryScale[c] = (countryWeight[c] / totalWeight * totalRawShares) / raw
-		}
+	for c, ips := range countryIPs {
+		countryScale[c] = math.Pow(float64(len(ips)), exponent-1.0)
 	}
 
 	for i := range nodes {


### PR DESCRIPTION
## Problem

The existing \`applyRegionalSaturation\` computes a per-country pot from \`unique_ips^exponent\` (default \`sqrt\`), then splits that fixed pot **equally** across every visor in the country. The country pot doesn't grow with visor count — so:

- A 1-IP country gets the same **total** reward whether 1 or 12 visors run there.
- Adding visors #2..#12 at that IP cuts each existing visor's reward by Nx (12x at the cap).
- The per-IP visor cap in \`calcPresenceShare\` (8 normally, 12 in June 2026) was effectively undone by the regional step — the cap allows up to 8/12 visors per IP, but the regional formula tells visors #2..#cap they're worth ~1/N each.

On 2026-06-13: every 1-IP country (MU, ZW, SE, BG, MT, TR, BZ, RO, CH, MY, ZA) gets exactly **37.72 SKY total** regardless of whether 1 or 10 visors run there.

## Fix

Apply the regional weight as a **per-visor scale**, not a country-pot allocation:

\`\`\`go
visor.Share *= unique_ips_country ^ (exponent - 1)
\`\`\`

A country's total reward now grows linearly with visor count (subject to the per-IP cap \`calcPresenceShare\` already enforces). Adding visors 2..cap at an existing IP no longer dilutes — the country pot grows proportionally, per-visor reward stays essentially flat. Dense-IP countries still see a lower per-visor reward, which is the regional-density correction that was intended.

## Exponent semantics preserved exactly

| value | scale | meaning |
|---|---|---|
| 1.0 | 1 everywhere | no derating |
| 0.5 | 1/sqrt(N) | sqrt-style saturation (default) |
| 0.0 | 1/N | every country's total reward equal regardless of IPs/visors |

Identical to the prior \`--sat-exp\` flag help text.

## Modeled deltas on 2026-06-13 (975 visors, 277 IPs, June cap=12)

| | Before | After | Δ |
|---|---|---|---|
| MU / ZW (1v/1IP) total | 37.72 | 7.32 | −81% |
| SE (10v/1IP) total | 37.72 | 73.20 | +94% |
| SE (10v/1IP) per-visor | 3.77 | 7.32 | +94% |
| TR/BG/MT (8v/1IP) total | 37.72 | 58.56 | +55% |
| ID (443v/191IPs) total | 521.32 | 215.26 | −59% |
| ID per-visor | 1.18 | 0.47 | −60% |

Total pool sum unchanged (renormalized in \`computePoolRewards\`).

## Same-IP fill behavior, hypothetical 1-IP country

| visors at 1 IP | before total | before /v | after total | after /v |
|---:|---:|---:|---:|---:|
| 1 | 37.72 | 37.72 | 7.32 | 7.32 |
| 2 | 37.72 | 18.86 | 14.47 | 7.23 |
| 4 | 37.72 |  9.43 | 28.74 | 7.19 |
| 8 | 37.72 |  4.72 | 56.76 | 7.09 |
| 12 (cap) | 37.72 |  3.14 | 84.07 | 7.01 |

## Test plan

- [x] \`make format check\` clean on the modified file (pre-existing baseline lint issues in \`pkg/dmsg/\` are out of scope)
- [x] Local re-run of \`skywire cli rewards -12d 2026-06-13 -u ut.txt -p log_backups -b -B 0 --no-bw-pool\` produces the modeled output (total = 2235.616438 SKY, per-1-IP-country = 7.32 SKY/visor)