### PR TITLE
feat(router): prefer local route calc for mux aux legs (disjoint + live first-hop)

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1234,7 +1234,7 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		// Skip closed / black-holing first-hop transports. A transport pruned by
 		// pong-liveness is closed+deregistered (see managed_transport), so
 		// IsClosed() catches both explicitly-closed and silently-dead legs — we
-		// must not build a route out over one. This is the local-calc analogue
+		// must not build a route out over one. This is the local-calc analog
 		// of the per-leg liveness probe: don't originate a leg on a dead edge.
 		if tp.IsClosed() {
 			return true

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -1231,6 +1231,14 @@ func (r *router) calculateLocalRoutes(ctx context.Context, log *logging.Logger, 
 		if tp == nil {
 			return true
 		}
+		// Skip closed / black-holing first-hop transports. A transport pruned by
+		// pong-liveness is closed+deregistered (see managed_transport), so
+		// IsClosed() catches both explicitly-closed and silently-dead legs — we
+		// must not build a route out over one. This is the local-calc analogue
+		// of the per-leg liveness probe: don't originate a leg on a dead edge.
+		if tp.IsClosed() {
+			return true
+		}
 		// Exclude "setup" labeled transports — those are for RSN control-plane
 		// traffic only and must not be used as hops in data routes.
 		if tp.Entry.Label == transport.LabelSetup {
@@ -1776,13 +1784,20 @@ func (r *router) establishMuxRoutes(
 			ExcludeDMSG:            true,
 		}
 
-		muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+		// Mux aux legs PREFER local route calc: it picks a disjoint first-hop
+		// from the visor's OWN live transports (liveness- + exclusion-aware),
+		// which the stateless latency-weighted route-finder can't — the RF
+		// returns lowest-latency routes that cluster on the same few
+		// intermediates, capping mux bandwidth scaling (measured: disjointness
+		// collapses at high degree → throughput plateaus). The route-finder is
+		// the fallback for when local calc can't reach a disjoint deep-hop.
+		muxFwd, muxRev, err := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
 		if err != nil {
-			log.Debugf("Mux route %d/%d: route-finder returned no path: %v — trying local-calc fallback",
+			log.Debugf("Mux route %d/%d: local-calc no path: %v — trying route-finder fallback",
 				i+1, maxCount, err)
-			localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
-			if localErr != nil {
-				log.Debugf("Mux route %d/%d: local-calc fallback also failed: %v", i+1, maxCount, localErr)
+			rfFwd, rfRev, rfErr := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+			if rfErr != nil {
+				log.Debugf("Mux route %d/%d: route-finder fallback also failed: %v", i+1, maxCount, rfErr)
 				consecutiveFailures++
 				if consecutiveFailures >= maxConsecutiveMuxFailures {
 					log.Debugf("Mux route planning: %d consecutive failures; giving up on remaining %d aux slots",
@@ -1791,7 +1806,7 @@ func (r *router) establishMuxRoutes(
 				}
 				continue
 			}
-			muxFwd, muxRev = localFwd, localRev
+			muxFwd, muxRev = rfFwd, rfRev
 		}
 		consecutiveFailures = 0
 
@@ -1921,13 +1936,18 @@ func (r *router) addOneAuxForwardLeg(ctx context.Context, nrg *NoiseRouteGroup, 
 		ExcludeDMSG:            true,
 	}
 
-	muxFwd, muxRev, err := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+	// Prefer local route calc for the replacement/added leg (disjoint first-hop
+	// from the visor's own live transports); route-finder is the fallback for a
+	// disjoint deep-hop not in the local cache. Same rationale as
+	// establishMuxRoutes — keeps self-healed/rotated legs disjoint and off dead
+	// edges, which the stateless route-finder can't guarantee.
+	muxFwd, muxRev, err := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
 	if err != nil {
-		localFwd, localRev, localErr := r.calculateLocalRoutes(ctx, log, lPK, rPK, muxOpts)
-		if localErr != nil {
-			return fmt.Errorf("rotation add-leg: no route found (route-finder=%v, local-calc=%v)", err, localErr)
+		rfFwd, rfRev, rfErr := r.fetchBestRoutes(ctx, log, lPK, rPK, muxOpts, r.conf.MinHops)
+		if rfErr != nil {
+			return fmt.Errorf("rotation add-leg: no route found (local-calc=%v, route-finder=%v)", err, rfErr)
 		}
-		muxFwd, muxRev = localFwd, localRev
+		muxFwd, muxRev = rfFwd, rfRev
 	}
 
 	muxKeepAlive := DefaultRouteKeepAlive


### PR DESCRIPTION
## Why

Measured mux bandwidth-vs-degree (3 hubs × degree 1–8): **throughput scales ~linearly when legs are disjoint, and plateaus when they aren't.**

| | degree 8 | scaling | disjoint% @ deg8 |
|---|---|---|---|
| prod02_US | 8.55 Mbps | **8.1× (101% of linear)** | 75% |
| 02f9aa_DE | 1.86 Mbps | 5.0× (63%) — **plateau from deg 6** | **31%** |

The stateless, latency-weighted route-finder returns lowest-latency-N routes that **cluster on the same few intermediates**, so at high degree the added legs share a bottleneck and add no throughput.

## What

Local route calc has what the RF lacks: the visor's **own live first-hop transports** (hundreds of candidates, exclusion-aware) vs the RF's clustered top-N. For 2-hop mux the first hop is the disjointness/liveness-critical part.

- **`calculateLocalRoutes`:** skip `IsClosed()` first-hop transports. A pong-liveness-pruned transport is closed+deregistered, so this also excludes silently-dead (black-holing) edges — the local-calc analogue of the per-leg liveness probe (#3114). Benefits all callers.
- **`establishMuxRoutes` + `addOneAuxForwardLeg`:** try local calc **first** for aux/replacement legs, route-finder as fallback. The **primary** route still uses the RF (latency-optimized); only the disjointness-seeking **aux** legs flip.

## Scope / safety

Phase 1 of the local-route-calc-for-mux plan. Deep-hop data still comes from the TPD cache; later phases source it peer-to-peer via a setup-node signing oracle (cascade pattern). Build + vet + full `pkg/router` suite + race green. Validation: local before/after mux-bw-vs-degree (disjoint% at high degree) — in PR comments.

**Not auto-merged** — pending local before/after validation + review.