### PR TITLE
feat(transport): OS-level TCP keepalive + TCP_USER_TIMEOUT for fast silent-death detection

### DIFF
--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -214,6 +214,7 @@ func (c *genericClient) acceptTransport() error {
 	// no-op for non-TCP listeners.
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+		configureTCPLiveness(tcpConn)
 	}
 	remoteAddr := conn.RemoteAddr()
 	c.log.Debugf("Accepted connection from %v", remoteAddr)

--- a/pkg/transport/network/stcp.go
+++ b/pkg/transport/network/stcp.go
@@ -57,6 +57,7 @@ func (c *stcpClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) 
 	// traffic (skypty, ssh, RPC) bottlenecks on Nagle without this.
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+		configureTCPLiveness(tcpConn)
 	}
 
 	c.log.Debugf("Dialed %v:%v@%v", rPK, rPort, conn.RemoteAddr())

--- a/pkg/transport/network/stcpr.go
+++ b/pkg/transport/network/stcpr.go
@@ -69,6 +69,7 @@ func (c *stcprClient) dial(ctx context.Context, addr string) (net.Conn, error) {
 	// throughput-side packaging at the kernel level).
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+		configureTCPLiveness(tcpConn)
 	}
 	return conn, nil
 }

--- a/pkg/transport/network/tcp_liveness.go
+++ b/pkg/transport/network/tcp_liveness.go
@@ -1,0 +1,30 @@
+package network
+
+import (
+	"net"
+	"time"
+)
+
+// OS-level TCP liveness so a silently-dead peer (no RST/FIN — crash, power
+// loss, NAT/hole-punch decay) is detected by the kernel in ~Idle+Interval*Count
+// instead of relying on the ~3-minute app-level transport ping. Keepalive is
+// portable (Go >=1.23 maps SetKeepAliveConfig to the right per-OS setsockopt:
+// linux/darwin/windows/android); TCP_USER_TIMEOUT is linux/android only (see
+// tcp_usertimeout_*.go) and only additionally speeds failing a pending write.
+const (
+	tcpKeepAliveIdle     = 15 * time.Second
+	tcpKeepAliveInterval = 5 * time.Second
+	tcpKeepAliveCount    = 4
+	tcpUserTimeout       = 30 * time.Second
+)
+
+// configureTCPLiveness enables fast silent-death detection on a TCP transport.
+func configureTCPLiveness(c *net.TCPConn) {
+	_ = c.SetKeepAliveConfig(net.KeepAliveConfig{ //nolint:errcheck
+		Enable:   true,
+		Idle:     tcpKeepAliveIdle,
+		Interval: tcpKeepAliveInterval,
+		Count:    tcpKeepAliveCount,
+	})
+	_ = setTCPUserTimeout(c, tcpUserTimeout) //nolint:errcheck
+}

--- a/pkg/transport/network/tcp_usertimeout_linux.go
+++ b/pkg/transport/network/tcp_usertimeout_linux.go
@@ -20,7 +20,9 @@ func setTCPUserTimeout(c *net.TCPConn, d time.Duration) error {
 	}
 	var serr error
 	if cerr := rc.Control(func(fd uintptr) {
-		serr = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(d.Milliseconds()))
+		// fd is a valid OS descriptor from RawConn.Control (small positive int);
+		// the timeout is a bounded constant — neither conversion can overflow.
+		serr = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(d.Milliseconds())) //nolint:gosec
 	}); cerr != nil {
 		return cerr
 	}

--- a/pkg/transport/network/tcp_usertimeout_linux.go
+++ b/pkg/transport/network/tcp_usertimeout_linux.go
@@ -1,0 +1,28 @@
+//go:build linux || android
+
+package network
+
+import (
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// setTCPUserTimeout sets TCP_USER_TIMEOUT so a write to a silently-dead peer
+// errors in ~d instead of after minutes of kernel retransmits. Linux/Android
+// only (Android runs the Linux kernel; note GOOS=android != linux in Go, hence
+// the explicit build tag).
+func setTCPUserTimeout(c *net.TCPConn, d time.Duration) error {
+	rc, err := c.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var serr error
+	if cerr := rc.Control(func(fd uintptr) {
+		serr = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(d.Milliseconds()))
+	}); cerr != nil {
+		return cerr
+	}
+	return serr
+}

--- a/pkg/transport/network/tcp_usertimeout_other.go
+++ b/pkg/transport/network/tcp_usertimeout_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !android
+
+package network
+
+import (
+	"net"
+	"time"
+)
+
+// setTCPUserTimeout is a no-op where TCP_USER_TIMEOUT doesn't exist (macOS,
+// Windows, BSD). Keepalive (portable, set separately) handles silent-death
+// detection on those platforms.
+func setTCPUserTimeout(_ *net.TCPConn, _ time.Duration) error { return nil }


### PR DESCRIPTION
## Root cause (the dead-edge saga)

stcpr/stcp sockets set only `SetNoDelay(true)` — **no TCP keepalive, no `TCP_USER_TIMEOUT`.** A *silently*-dead peer (crash, power loss, NAT/hole-punch decay — no RST/FIN) is invisible to the kernel, so the only detection is the app-level transport ping: `transportPingInterval(60s) × pongMissThreshold(3)` = **up to ~3 minutes** — and **never** for an *intermittently*-flaky link, because a stray pong resets the consecutive-miss counter. During that window the transport stays registered, advertises stale latency, and gets selected for routes that then fail. That's the underlying cause behind the intermittent multi-hop route-setup failures.

## Fix — detect silent death at the layer it happens

| option | platforms | effect |
|---|---|---|
| `SetKeepAliveConfig` (Idle 15s, Interval 5s, Count 4) | **all** (Go ≥1.23 per-OS setsockopt) | kernel probes idle links → socket errors in ~35s → `readLoop` closes the transport. Not reset by stray pongs, so it catches the intermittent case too. |
| `TCP_USER_TIMEOUT` (30s) | **linux/android only** | a write to a dead peer errors in ~30s instead of minutes of retransmit |

Detection drops from **~3 min (or never) → ~35s, reliably**, at **zero** added CPU/goroutines (the kernel does the probing). Applied to both dial sides (stcpr, stcp) and the accept side.

## Cross-platform correctness

- Keepalive: portable (linux/darwin/windows/android).
- `TCP_USER_TIMEOUT`: build-tagged `//go:build linux || android` with a no-op stub for `!linux && !android`. **Note `GOOS=android` is not `linux` in Go** — the explicit `|| android` ensures a future Android port keeps it (Android runs the Linux kernel). Where it's a no-op (macOS/Windows), keepalive alone covers silent-death detection.
- **Cross-compiles clean on linux/amd64, windows/amd64, darwin/arm64, android/arm64.**

Follow-up: sudph/KCP `SetDeadlink` tuning (KCP already has default dead-link detection, unlike TCP which had none).