### PR TITLE
feat(noise): post-quantum hybrid key-agreement layer (ML-KEM-768) — phase 1

### DIFF
--- a/pkg/dmsg/noise/pqhybrid.go
+++ b/pkg/dmsg/noise/pqhybrid.go
@@ -1,0 +1,108 @@
+// Package noise — pkg/dmsg/noise/pqhybrid.go
+//
+// Self-contained post-quantum hybrid key-agreement layer (ML-KEM-768) that
+// composes with the classical Noise_KK handshake. See
+// docs/design/pq-hybrid-noise-handshake.md.
+//
+// This file is JUST the crypto: ephemeral ML-KEM keygen / encapsulate /
+// decapsulate, and the HKDF combiner that mixes the classical Noise session key
+// with the ML-KEM shared secret. It deliberately does NOT touch the live
+// handshake — wiring the payloads + capability negotiation into the handshake is
+// a separate, flag-gated change so this layer can be reviewed and tested in
+// isolation. Everything here is Go stdlib (crypto/mlkem + crypto/hkdf), no new
+// dependency.
+package noise
+
+import (
+	"crypto/hkdf"
+	"crypto/mlkem"
+	"crypto/sha256"
+	"fmt"
+)
+
+const (
+	// pqSharedKeySize is the ML-KEM-768 shared-secret length (bytes).
+	pqSharedKeySize = mlkem.SharedKeySize // 32
+	// pqPublicKeySize is the wire size of the ML-KEM-768 encapsulation key
+	// sent in handshake message 1's payload.
+	pqPublicKeySize = mlkem.EncapsulationKeySize768 // 1184
+	// pqCiphertextSize is the wire size of the ML-KEM-768 ciphertext sent in
+	// handshake message 2's payload.
+	pqCiphertextSize = mlkem.CiphertextSize768 // 1088
+	// pqHybridInfo domain-separates the hybrid KDF so its output can never
+	// collide with any other use of the same inputs.
+	pqHybridInfo = "skywire-pq-hybrid-v1"
+)
+
+// pqInitiator holds an initiator's ephemeral ML-KEM-768 decapsulation key and
+// the serialized public (encapsulation) key to send to the responder. A fresh
+// instance per handshake gives the PQ leg forward secrecy, matching the
+// ephemeral X25519/secp256k1 `e` in Noise.
+type pqInitiator struct {
+	dk        *mlkem.DecapsulationKey768
+	PublicKey []byte // wire: handshake msg-1 payload (pqPublicKeySize bytes)
+}
+
+// newPQInitiator generates a fresh ephemeral ML-KEM-768 keypair.
+func newPQInitiator() (*pqInitiator, error) {
+	dk, err := mlkem.GenerateKey768()
+	if err != nil {
+		return nil, fmt.Errorf("pq: ml-kem keygen: %w", err)
+	}
+	return &pqInitiator{dk: dk, PublicKey: dk.EncapsulationKey().Bytes()}, nil
+}
+
+// pqEncapsulate is the responder side: given the initiator's ML-KEM public key
+// (from msg-1's payload), produce the ciphertext to return in msg-2's payload
+// and the PQ shared secret to mix in.
+func pqEncapsulate(initiatorPublicKey []byte) (ciphertext, sharedSecret []byte, err error) {
+	if len(initiatorPublicKey) != pqPublicKeySize {
+		return nil, nil, fmt.Errorf("pq: bad ml-kem public key size %d (want %d)", len(initiatorPublicKey), pqPublicKeySize)
+	}
+	ek, err := mlkem.NewEncapsulationKey768(initiatorPublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pq: parse peer ml-kem key: %w", err)
+	}
+	sharedSecret, ciphertext = ek.Encapsulate()
+	return ciphertext, sharedSecret, nil
+}
+
+// decapsulate is the initiator side: recover the PQ shared secret from the
+// responder's ciphertext (msg-2's payload). ML-KEM-768 uses implicit rejection,
+// so a tampered (but correctly-sized) ciphertext yields a *different* secret
+// rather than an error — the handshake then fails at the AEAD tag, which is the
+// intended IND-CCA2 behavior. A wrong-sized ciphertext is rejected outright.
+func (k *pqInitiator) decapsulate(ciphertext []byte) (sharedSecret []byte, err error) {
+	if len(ciphertext) != pqCiphertextSize {
+		return nil, fmt.Errorf("pq: bad ml-kem ciphertext size %d (want %d)", len(ciphertext), pqCiphertextSize)
+	}
+	sharedSecret, err = k.dk.Decapsulate(ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("pq: ml-kem decapsulate: %w", err)
+	}
+	return sharedSecret, nil
+}
+
+// combineHybridKey derives the final transport key by mixing the classical
+// Noise session key with the ML-KEM shared secret, bound to the handshake
+// transcript hash (so the derived key is tied to *this* handshake). Breaking the
+// result requires breaking BOTH the classical DH AND ML-KEM-768 — hybrid
+// security. Returns keyLen bytes.
+func combineHybridKey(classicalKey, pqSharedSecret, transcriptHash []byte, keyLen int) ([]byte, error) {
+	if len(pqSharedSecret) != pqSharedKeySize {
+		return nil, fmt.Errorf("pq: unexpected ml-kem shared-secret size %d (want %d)", len(pqSharedSecret), pqSharedKeySize)
+	}
+	if len(classicalKey) == 0 {
+		return nil, fmt.Errorf("pq: empty classical key")
+	}
+	// IKM = classical || pq. Both must contribute; concatenation under HKDF's
+	// extract step binds them so neither alone determines the output.
+	ikm := make([]byte, 0, len(classicalKey)+len(pqSharedSecret))
+	ikm = append(ikm, classicalKey...)
+	ikm = append(ikm, pqSharedSecret...)
+	out, err := hkdf.Key(sha256.New, ikm, transcriptHash, pqHybridInfo, keyLen)
+	if err != nil {
+		return nil, fmt.Errorf("pq: hkdf: %w", err)
+	}
+	return out, nil
+}

--- a/pkg/dmsg/noise/pqhybrid_test.go
+++ b/pkg/dmsg/noise/pqhybrid_test.go
@@ -1,0 +1,114 @@
+package noise
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPQHybridAgreement is the end-to-end happy path: initiator and responder
+// independently derive the same ML-KEM shared secret, and feeding it through the
+// combiner with a shared classical key + transcript yields the same final key on
+// both ends.
+func TestPQHybridAgreement(t *testing.T) {
+	ini, err := newPQInitiator()
+	require.NoError(t, err)
+
+	ct, ssResp, err := pqEncapsulate(ini.PublicKey)
+	require.NoError(t, err)
+
+	ssInit, err := ini.decapsulate(ct)
+	require.NoError(t, err)
+
+	require.Equal(t, ssResp, ssInit, "ML-KEM shared secret must agree on both ends")
+
+	classical := make([]byte, 32)
+	_, _ = rand.Read(classical)
+	transcript := make([]byte, 32)
+	_, _ = rand.Read(transcript)
+
+	kInit, err := combineHybridKey(classical, ssInit, transcript, 32)
+	require.NoError(t, err)
+	kResp, err := combineHybridKey(classical, ssResp, transcript, 32)
+	require.NoError(t, err)
+	require.Equal(t, kInit, kResp, "hybrid final key must agree on both ends")
+}
+
+// TestPQWireSizes pins the FIPS-203 ML-KEM-768 wire sizes we advertise.
+func TestPQWireSizes(t *testing.T) {
+	ini, err := newPQInitiator()
+	require.NoError(t, err)
+	assert.Len(t, ini.PublicKey, pqPublicKeySize, "encapsulation key must be 1184 B")
+
+	ct, ss, err := pqEncapsulate(ini.PublicKey)
+	require.NoError(t, err)
+	assert.Len(t, ct, pqCiphertextSize, "ciphertext must be 1088 B")
+	assert.Len(t, ss, pqSharedKeySize, "shared secret must be 32 B")
+}
+
+// TestCombineMixesBothInputs is the hybrid-security property: the final key must
+// change if EITHER the classical key, the PQ secret, or the transcript changes —
+// i.e. neither secret alone determines the output.
+func TestCombineMixesBothInputs(t *testing.T) {
+	classical := bytes.Repeat([]byte{0xA1}, 32)
+	pq := bytes.Repeat([]byte{0xB2}, pqSharedKeySize)
+	transcript := bytes.Repeat([]byte{0xC3}, 32)
+
+	base, err := combineHybridKey(classical, pq, transcript, 32)
+	require.NoError(t, err)
+
+	classical2 := bytes.Repeat([]byte{0xA2}, 32)
+	kc, err := combineHybridKey(classical2, pq, transcript, 32)
+	require.NoError(t, err)
+	assert.NotEqual(t, base, kc, "changing the classical key must change the output")
+
+	pq2 := bytes.Repeat([]byte{0xB3}, pqSharedKeySize)
+	kp, err := combineHybridKey(classical, pq2, transcript, 32)
+	require.NoError(t, err)
+	assert.NotEqual(t, base, kp, "changing the PQ secret must change the output")
+
+	transcript2 := bytes.Repeat([]byte{0xC4}, 32)
+	kt, err := combineHybridKey(classical, pq, transcript2, 32)
+	require.NoError(t, err)
+	assert.NotEqual(t, base, kt, "changing the transcript must change the output")
+
+	// Deterministic for identical inputs.
+	again, err := combineHybridKey(classical, pq, transcript, 32)
+	require.NoError(t, err)
+	assert.Equal(t, base, again, "combiner must be deterministic")
+}
+
+// TestPQRejectsBadSizes guards the wire-parse boundaries.
+func TestPQRejectsBadSizes(t *testing.T) {
+	ini, err := newPQInitiator()
+	require.NoError(t, err)
+
+	_, _, err = pqEncapsulate(make([]byte, pqPublicKeySize-1))
+	require.Error(t, err, "short public key must be rejected")
+
+	_, err = ini.decapsulate(make([]byte, pqCiphertextSize-1))
+	require.Error(t, err, "short ciphertext must be rejected")
+
+	_, err = combineHybridKey(make([]byte, 32), make([]byte, pqSharedKeySize-1), nil, 32)
+	require.Error(t, err, "wrong PQ-secret size must be rejected")
+}
+
+// TestPQTamperedCiphertextDiverges documents ML-KEM implicit rejection: a
+// tampered (correctly-sized) ciphertext decapsulates to a DIFFERENT secret
+// rather than erroring, so the hybrid key won't match and the handshake fails at
+// the AEAD tag — the intended IND-CCA2 behavior.
+func TestPQTamperedCiphertextDiverges(t *testing.T) {
+	ini, err := newPQInitiator()
+	require.NoError(t, err)
+	ct, ssResp, err := pqEncapsulate(ini.PublicKey)
+	require.NoError(t, err)
+
+	tampered := bytes.Clone(ct)
+	tampered[0] ^= 0xFF
+	ssBad, err := ini.decapsulate(tampered)
+	require.NoError(t, err, "implicit rejection: still returns a (pseudo-random) secret")
+	assert.NotEqual(t, ssResp, ssBad, "tampered ciphertext must not recover the real secret")
+}


### PR DESCRIPTION
## What

Phase 1 of the PQ hybrid handshake (design: #3119). The **self-contained crypto layer** only — it does **not** touch the live Noise handshake.

`pkg/dmsg/noise/pqhybrid.go`:
- ephemeral **ML-KEM-768** keygen / encapsulate / decapsulate (`crypto/mlkem`, stdlib)
- the **HKDF combiner** (`crypto/hkdf`, stdlib) mixing the classical Noise session key with the ML-KEM shared secret, bound to the handshake transcript

**No new dependency** (both stdlib, Go 1.24+).

## Why a separate phase

Wiring payloads + capability negotiation + CipherState re-key into the KK handshake is **phase 2** (flag-gated, default-off). Shipping the crypto in isolation first means it's reviewable and fully unit-tested without any risk to the live handshake. Combining at the **key-schedule boundary** (not substituting the noise DH — KEM≠DH) is also why this needs zero changes to the framework (now maintained `flynn/noise`, #3120).

## Tests (all green)

- end-to-end **hybrid agreement** — both ends derive the same final key
- FIPS-203 **wire sizes** (1184 / 1088 / 32)
- **hybrid-security property** — the final key changes if the classical key, the PQ secret, *or* the transcript changes (neither secret alone determines it); and is deterministic
- wire-size rejection
- ML-KEM **implicit rejection** — a tampered ciphertext diverges (won't recover the real secret) rather than erroring

Depends on #3120 (flynn/noise). Next: phase-2 handshake wiring behind a capability flag, per the design doc's 4-phase rollout.