### PR TITLE
feat(noise): wire post-quantum hybrid (ML-KEM-768) into the handshake — phase 2

### DIFF
--- a/pkg/dmsg/noise/noise.go
+++ b/pkg/dmsg/noise/noise.go
@@ -45,14 +45,31 @@ type Noise struct {
 	decNonce uint64 // expect increment with each subsequent packet
 
 	encBuf [nonceSize]byte // reusable nonce buffer for encryption
+
+	// Post-quantum hybrid (ML-KEM-768). PQ is offered UNCONDITIONALLY and
+	// composes with the classical handshake; if the peer doesn't reciprocate
+	// (empty payload — an older visor), we transparently fall back to classical.
+	// No flag, reverse-compatible by construction. See pqhybrid.go +
+	// docs/design/pq-hybrid-noise-handshake.md.
+	suite      noise.CipherSuite // retained to rebuild CipherStates for the hybrid re-key
+	pqInit     *pqInitiator      // initiator's ephemeral ML-KEM keys (lazily generated)
+	pqSendData []byte            // PQ payload queued for the next handshake message
+	pqSecret   []byte            // derived ML-KEM shared secret, once available
+	pqActive   bool              // true once the hybrid key has been mixed in
 }
+
+// PQActive reports whether the session negotiated the post-quantum hybrid (both
+// peers exchanged ML-KEM material and the shared secret was mixed into the
+// transport keys). False means a classical-only handshake (e.g. an older peer).
+func (ns *Noise) PQActive() bool { return ns.pqActive }
 
 // New creates a new Noise with:
 //   - provided pattern for handshake.
 //   - Secp256k1 for the curve.
 func New(pattern noise.HandshakePattern, config Config) (*Noise, error) {
+	suite := noise.NewCipherSuite(Secp256k1{}, noise.CipherChaChaPoly, noise.HashSHA256)
 	nc := noise.Config{
-		CipherSuite: noise.NewCipherSuite(Secp256k1{}, noise.CipherChaChaPoly, noise.HashSHA256),
+		CipherSuite: suite,
 		Random:      rand.Reader,
 		Pattern:     pattern,
 		Initiator:   config.Initiator,
@@ -75,6 +92,7 @@ func New(pattern noise.HandshakePattern, config Config) (*Noise, error) {
 		init:    config.Initiator,
 		pattern: pattern,
 		hs:      hs,
+		suite:   suite,
 	}, nil
 }
 
@@ -103,25 +121,121 @@ func (ns *Noise) GetDecNonce() uint64 {
 }
 
 // MakeHandshakeMessage generates handshake message for a current handshake state.
+// The handshake payload carries the post-quantum offer/response (ML-KEM public
+// key from the initiator, ciphertext from the responder); see pqOfferPayload.
 func (ns *Noise) MakeHandshakeMessage() (res []byte, err error) {
+	payload := ns.pqOfferPayload()
 	if ns.hs.MessageIndex() < len(ns.pattern.Messages)-1 {
-		res, _, _, err = ns.hs.WriteMessage(nil, nil)
+		res, _, _, err = ns.hs.WriteMessage(nil, payload)
 		return
 	}
 
-	res, ns.dec, ns.enc, err = ns.hs.WriteMessage(nil, nil)
+	res, ns.dec, ns.enc, err = ns.hs.WriteMessage(nil, payload)
+	if err == nil {
+		err = ns.applyHybrid()
+	}
 	return res, err
 }
 
 // ProcessHandshakeMessage processes a received handshake message and appends the payload.
 func (ns *Noise) ProcessHandshakeMessage(msg []byte) (err error) {
 	if ns.hs.MessageIndex() < len(ns.pattern.Messages)-1 {
-		_, _, _, err = ns.hs.ReadMessage(nil, msg)
+		var payload []byte
+		payload, _, _, err = ns.hs.ReadMessage(nil, msg)
+		if err == nil {
+			ns.pqHandlePeerPayload(payload)
+		}
 		return
 	}
 
-	_, ns.enc, ns.dec, err = ns.hs.ReadMessage(nil, msg)
+	var payload []byte
+	payload, ns.enc, ns.dec, err = ns.hs.ReadMessage(nil, msg)
+	if err == nil {
+		ns.pqHandlePeerPayload(payload)
+		err = ns.applyHybrid()
+	}
 	return err
+}
+
+// pqOfferPayload returns the post-quantum data to embed in the next handshake
+// message: the initiator's ephemeral ML-KEM public key on its first message, or
+// a responder's ML-KEM ciphertext once it has encapsulated. Returns nil when
+// there's nothing to offer — which produces an empty payload, the natural "I'm
+// not doing PQ / I'm an older visor" signal that yields a classical handshake.
+// Best-effort: an ML-KEM keygen failure silently proceeds classical.
+func (ns *Noise) pqOfferPayload() []byte {
+	if ns.init && ns.pqInit == nil && ns.pqSecret == nil {
+		k, err := newPQInitiator()
+		if err != nil {
+			return nil
+		}
+		ns.pqInit = k
+		return k.PublicKey
+	}
+	if ns.pqSendData != nil {
+		out := ns.pqSendData
+		ns.pqSendData = nil
+		return out
+	}
+	return nil
+}
+
+// pqHandlePeerPayload reacts to a peer's handshake payload: a responder
+// encapsulates against the initiator's ML-KEM public key; an initiator
+// decapsulates the responder's ciphertext. A malformed, empty, or unexpected
+// payload simply leaves PQ off (classical fallback) — it NEVER fails the
+// handshake, which is what makes this reverse-compatible with older visors.
+func (ns *Noise) pqHandlePeerPayload(payload []byte) {
+	if len(payload) == 0 || ns.pqSecret != nil {
+		return
+	}
+	switch {
+	case !ns.init && len(payload) == pqPublicKeySize:
+		ct, ss, err := pqEncapsulate(payload)
+		if err == nil {
+			ns.pqSecret = ss
+			ns.pqSendData = ct
+		}
+	case ns.init && ns.pqInit != nil && len(payload) == pqCiphertextSize:
+		if ss, err := ns.pqInit.decapsulate(payload); err == nil {
+			ns.pqSecret = ss
+		}
+	}
+}
+
+// applyHybrid mixes the ML-KEM shared secret into the post-Split transport
+// CipherStates, binding it to the handshake transcript (ChannelBinding). Both
+// ends derive matching per-direction keys (same ss_pq, same transcript, and the
+// classical enc-key on one side equals the dec-key on the other). No-op when PQ
+// wasn't negotiated. After this, EncryptUnsafe/DecryptUnsafe transparently use
+// the hybrid key via the new CipherState (skywire's external nonce is unchanged).
+func (ns *Noise) applyHybrid() error {
+	if ns.pqSecret == nil || ns.enc == nil || ns.dec == nil {
+		return nil
+	}
+	cb := ns.hs.ChannelBinding()
+	encKey := ns.enc.UnsafeKey()
+	decKey := ns.dec.UnsafeKey()
+	newEnc, err := combineHybridKey(encKey[:], ns.pqSecret, cb, 32)
+	if err != nil {
+		return err
+	}
+	newDec, err := combineHybridKey(decKey[:], ns.pqSecret, cb, 32)
+	if err != nil {
+		return err
+	}
+	var ek, dk [32]byte
+	copy(ek[:], newEnc)
+	copy(dk[:], newDec)
+	ns.enc = noise.UnsafeNewCipherState(ns.suite, ek, 0)
+	ns.dec = noise.UnsafeNewCipherState(ns.suite, dk, 0)
+	ns.pqActive = true
+	// Best-effort wipe of the shared secret; it's no longer needed.
+	for i := range ns.pqSecret {
+		ns.pqSecret[i] = 0
+	}
+	ns.pqSecret = nil
+	return nil
 }
 
 // HandshakeFinished indicate whether handshake was completed.

--- a/pkg/dmsg/noise/noise_test.go
+++ b/pkg/dmsg/noise/noise_test.go
@@ -139,3 +139,76 @@ func TestXKAndSecp256k1(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("baz"), decrypted)
 }
+
+// TestPQHybridHandshake drives a full KK handshake between two PQ-aware
+// instances and asserts the post-quantum hybrid was negotiated on BOTH ends
+// (not a silent classical fallback) and that the resulting hybrid keys agree —
+// proven by a successful bidirectional transport round trip.
+func TestPQHybridHandshake(t *testing.T) {
+	pkI, skI := cipher.GenerateKeyPair()
+	pkR, skR := cipher.GenerateKeyPair()
+	nI, err := KKAndSecp256k1(Config{LocalPK: pkI, LocalSK: skI, RemotePK: pkR, Initiator: true})
+	require.NoError(t, err)
+	nR, err := KKAndSecp256k1(Config{LocalPK: pkR, LocalSK: skR, RemotePK: pkI, Initiator: false})
+	require.NoError(t, err)
+
+	msg1, err := nI.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nR.ProcessHandshakeMessage(msg1))
+	msg2, err := nR.MakeHandshakeMessage()
+	require.NoError(t, err)
+	require.NoError(t, nI.ProcessHandshakeMessage(msg2))
+
+	require.True(t, nI.HandshakeFinished())
+	require.True(t, nR.HandshakeFinished())
+	require.True(t, nI.PQActive(), "initiator must negotiate PQ with a PQ-aware peer")
+	require.True(t, nR.PQActive(), "responder must negotiate PQ with a PQ-aware peer")
+
+	ct := nI.EncryptUnsafe([]byte("post-quantum"))
+	pt, err := nR.DecryptUnsafe(ct)
+	require.NoError(t, err)
+	require.Equal(t, "post-quantum", string(pt))
+	ct = nR.EncryptUnsafe([]byte("hybrid"))
+	pt, err = nI.DecryptUnsafe(ct)
+	require.NoError(t, err)
+	require.Equal(t, "hybrid", string(pt))
+}
+
+// TestPQHandshakeFallbackToClassical proves reverse-compatibility: a new PQ-aware
+// initiator vs a simulated OLD responder (one that drives its handshake with nil
+// payloads, as pre-PQ code did, ignoring the PQ offer) transparently falls back
+// to a classical handshake and still communicates — no flag, no failed attempt.
+func TestPQHandshakeFallbackToClassical(t *testing.T) {
+	pkI, skI := cipher.GenerateKeyPair()
+	pkR, skR := cipher.GenerateKeyPair()
+	nI, err := KKAndSecp256k1(Config{LocalPK: pkI, LocalSK: skI, RemotePK: pkR, Initiator: true})
+	require.NoError(t, err)
+	nR, err := KKAndSecp256k1(Config{LocalPK: pkR, LocalSK: skR, RemotePK: pkI, Initiator: false})
+	require.NoError(t, err)
+
+	// New initiator offers PQ (ML-KEM pubkey in msg1's payload).
+	msg1, err := nI.MakeHandshakeMessage()
+	require.NoError(t, err)
+
+	// Simulate an OLD responder: read msg1 IGNORING the payload, and reply with a
+	// nil payload (the pre-PQ behavior). Drive the raw flynn handshake directly.
+	_, _, _, err = nR.hs.ReadMessage(nil, msg1)
+	require.NoError(t, err)
+	msg2, cs0, cs1, err := nR.hs.WriteMessage(nil, nil)
+	require.NoError(t, err)
+	nR.dec, nR.enc = cs0, cs1 // mirror MakeHandshakeMessage's final assignment
+
+	// Initiator sees an empty payload → classical fallback, no PQ.
+	require.NoError(t, nI.ProcessHandshakeMessage(msg2))
+	require.False(t, nI.PQActive(), "initiator must fall back to classical with an old peer")
+
+	// Classical transport still works in both directions.
+	ct := nI.EncryptUnsafe([]byte("compat"))
+	pt, err := nR.DecryptUnsafe(ct)
+	require.NoError(t, err)
+	require.Equal(t, "compat", string(pt))
+	ct = nR.EncryptUnsafe([]byte("classical"))
+	pt, err = nI.DecryptUnsafe(ct)
+	require.NoError(t, err)
+	require.Equal(t, "classical", string(pt))
+}


### PR DESCRIPTION
Composes the phase-1 crypto layer (#3121) into the **live Noise handshake**. **Not flag-gated, reverse-compatible by construction.**

## How
- Initiator offers its ephemeral **ML-KEM-768 public key** in handshake **msg-1's payload** (was `nil`); a PQ-aware responder encapsulates → returns the **ciphertext** in msg-2's payload; both mix `ss_pq` into the post-`Split` transport keys via **HKDF bound to `ChannelBinding()`**. → **hybrid**: break requires breaking the classical DH *and* ML-KEM-768.
- An **older peer** ignores the payload (as always) and replies empty → the new side sees no ciphertext and **falls back to classical in the same round trip** — no flag, no retry.
- **Downgrade-safe (KK):** payloads are authenticated, so a MITM can't strip the PQ offer to force two PQ-capable peers down without breaking the handshake MAC.

## Mechanism
Re-keys the CipherStates after `Split()` via flynn/noise's `UnsafeKey()` / `UnsafeNewCipherState()` — **no framework changes**, KEM mixed at the key-schedule boundary (KEM≠DH). `EncryptUnsafe`/`DecryptUnsafe` transparently use the hybrid key; skywire's external nonce management is untouched. Both ends derive matching per-direction keys (same `ss_pq`, same transcript, enc-key one side == dec-key the other).

## Wire
PQ handshake messages are **1233 / 1137 B**, within the **4096** `maxFrameSize` — and an old peer's reader is the same 4096, so interop holds **both ways**.

## Tests
- two PQ instances → hybrid negotiated on both ends (`PQActive`) + working bidirectional round trip
- new initiator vs **simulated old responder** (nil payloads) → **classical fallback**, still communicates
- full noise suite + `-race` + the FIPS-203 KAT-backed phase-1 units — green

Depends on #3121 (crypto layer) + #3120 (flynn/noise). Realizes the design in #3119. **Live reverse-compat against the (pre-PQ) fleet validated before merge.**