### PR TITLE
feat(resolver): canonical service aliases (tpd/ar/rf/sd/dmsgd) for the dmsg resolving proxy

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -115,6 +115,17 @@ type Config struct {
 	// Aliases maps a destination label to a PK (e.g. "skywire" -> LocalPK), so
 	// "skywire.dmsg" resolves exactly like "<pk>.dmsg".
 	Aliases map[string]cipher.PubKey
+
+	// DirectClient is an optional dmsg client that reaches servers by their
+	// configured address rather than via discovery. A dest in DirectServerPKs
+	// is dialed through it by self-rendezvous (EnsureAndObtainSession(dest) +
+	// DialStream(dest:port)), which makes non-discovery dmsg SERVERS — they
+	// serve /health etc. over dmsg but never register a client entry, so the
+	// discovery client cannot resolve them — reachable by name. Nil disables
+	// this path (dests fall through to the normal discovery dial).
+	DirectClient *dmsg.Client
+	// DirectServerPKs is the set of destination PKs to dial via DirectClient.
+	DirectServerPKs map[cipher.PubKey]struct{}
 }
 
 // DmsgTarget is a (publicKey, dmsgPort) pair used in fixed-mapping mode.
@@ -295,7 +306,25 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 
 				dstAddr := dmsg.Addr{PK: dest, Port: uint16(port)}
 				var stream net.Conn
-				if len(route) > 0 {
+				_, isDirectServer := cfg.DirectServerPKs[dest]
+				switch {
+				case isDirectServer && cfg.DirectClient != nil && len(route) == 0:
+					// Non-discovery dmsg SERVER: dial it through the direct
+					// client by self-rendezvous — connect to the server (the
+					// direct client knows its address) and dial the server's
+					// own listener over that session. The discovery client
+					// can't reach it (no client entry registered).
+					log.WithField("server", dest).WithField("port", port).Debug("SOCKS5 → DMSG direct server")
+					ses, serr := cfg.DirectClient.EnsureAndObtainSession(ctx, dest)
+					if serr != nil {
+						return nil, fmt.Errorf("direct session to dmsg server %s: %w", dest, serr)
+					}
+					str, derr := ses.DialStream(ctx, dstAddr)
+					if derr != nil {
+						return nil, derr
+					}
+					stream = str
+				case len(route) > 0:
 					// Pinned rendezvous: dial the destination THROUGH the named
 					// dmsg server's session instead of resolving it via
 					// discovery. This lets a browser reach a direct/hidden client
@@ -318,7 +347,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 						return nil, derr
 					}
 					stream = str
-				} else {
+				default:
 					log.WithField("port", port).Debug("SOCKS5 → DMSG direct")
 					c, derr := dmsgC.Dial(ctx, dstAddr)
 					if derr != nil {

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -88,7 +88,7 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			// it starts — no data loss, just "not available yet".
 			cfg.UpstreamSOCKS = fmt.Sprintf("127.0.0.1:%d", defaultSkynetWebProxyPort)
 			log := logging.MustGetLogger("embedded_dmsgweb")
-			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), cfg, log)
+			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), dmsgServerPKSet(v.conf), cfg, log)
 			v.embeddedDmsgWeb = runtime
 		}
 		v.initLock.Unlock()

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -88,7 +88,8 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			// it starts — no data loss, just "not available yet".
 			cfg.UpstreamSOCKS = fmt.Sprintf("127.0.0.1:%d", defaultSkynetWebProxyPort)
 			log := logging.MustGetLogger("embedded_dmsgweb")
-			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), dmsgServerPKSet(v.conf), cfg, log)
+			aliases, dmsgSet := resolverAliasesAndDmsgServers(v)
+			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, aliases, dmsgSet, cfg, log)
 			v.embeddedDmsgWeb = runtime
 		}
 		v.initLock.Unlock()

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -88,7 +88,7 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			// it starts — no data loss, just "not available yet".
 			cfg.UpstreamSOCKS = fmt.Sprintf("127.0.0.1:%d", defaultSkynetWebProxyPort)
 			log := logging.MustGetLogger("embedded_dmsgweb")
-			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, cfg, log)
+			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), cfg, log)
 			v.embeddedDmsgWeb = runtime
 		}
 		v.initLock.Unlock()

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"sync"
 	"time"
 
@@ -54,6 +55,13 @@ type EmbeddedDmsgWeb struct {
 	localPK  cipher.PubKey                       // this visor's PK, for self-loopback + "self" alias
 	selfDial func(port uint16) (net.Conn, error) // in-process serve of a local service port (nil disables loopback)
 
+	// serviceAliases maps canonical short labels (tpd, ar, rf, sd, ut, dmsgd)
+	// to the configured deployment services' PKs, so the resolving proxy can
+	// reach a service's HTTP API by name (e.g. http://tpd.dmsg/). Derived once
+	// from the visor config at construction; empty when no service has a
+	// resolvable dmsg PK.
+	serviceAliases map[string]cipher.PubKey
+
 	mu        sync.Mutex
 	running   bool
 	cancel    context.CancelFunc
@@ -66,15 +74,16 @@ type EmbeddedDmsgWeb struct {
 // "resolver never ran" from "running but idle". localPK + selfDial
 // enable self-loopback (serving requests for this visor's own PK
 // in-process); pass a zero PK / nil selfDial to disable.
-func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
+func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), serviceAliases map[string]cipher.PubKey, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
 	return &EmbeddedDmsgWeb{
-		dmsgC:     dmsgC,
-		cfg:       cfg,
-		log:       log,
-		stats:     dmsgweb.NewStats(),
-		localPK:   localPK,
-		selfDial:  selfDial,
-		parentCtx: parentCtx,
+		dmsgC:          dmsgC,
+		cfg:            cfg,
+		log:            log,
+		stats:          dmsgweb.NewStats(),
+		localPK:        localPK,
+		selfDial:       selfDial,
+		serviceAliases: serviceAliases,
+		parentCtx:      parentCtx,
 	}
 }
 
@@ -177,7 +186,15 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 		cfg.SelfLoopback = true
 		cfg.SelfDial = e.selfDial
 	}
-	cfg.Aliases = resolverAliasMap(e.cfg.Alias, e.localPK)
+	// Canonical service aliases (tpd, ar, rf, …) first, then this visor's own
+	// alias on top so a colliding self-alias always wins.
+	cfg.Aliases = map[string]cipher.PubKey{}
+	for label, pk := range e.serviceAliases {
+		cfg.Aliases[label] = pk
+	}
+	for label, pk := range resolverAliasMap(e.cfg.Alias, e.localPK) {
+		cfg.Aliases[label] = pk
+	}
 
 	// Optional TLS MITM. CA load failure is non-fatal — the
 	// resolver continues without MITM and logs the reason.
@@ -226,6 +243,65 @@ func resolverAliasMap(alias string, localPK cipher.PubKey) map[string]cipher.Pub
 	return map[string]cipher.PubKey{alias: localPK}
 }
 
+// parseDmsgURLPK extracts the visor PK from a "dmsg://<pk>:<port>" service URL.
+// A plain-HTTP URL (or empty / malformed) yields ok=false, since it carries no
+// dmsg PK to resolve through.
+func parseDmsgURLPK(raw string) (cipher.PubKey, bool) {
+	if raw == "" {
+		return cipher.PubKey{}, false
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "dmsg" {
+		return cipher.PubKey{}, false
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(u.Hostname()); err != nil {
+		return cipher.PubKey{}, false
+	}
+	return pk, true
+}
+
+// serviceAliasMap derives canonical short aliases for the deployment services
+// this visor is configured to use, by pulling each service's PK out of its
+// dmsg:// URL. The resolving proxy then reaches a service's HTTP API by name —
+// e.g. `curl -x socks5h://127.0.0.1:4445 http://tpd.dmsg/health`. Services
+// without a resolvable dmsg PK (plain-HTTP-only or unset) are simply omitted.
+// The label set mirrors the existing `cli` service namespace (tpd, ar, rf, …).
+func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
+	m := map[string]cipher.PubKey{}
+	if conf == nil {
+		return m
+	}
+	// add registers the first candidate URL that carries a dmsg PK. The *Dmsg
+	// field is preferred; the primary field is a fallback for configs that put
+	// the dmsg URL there directly.
+	add := func(alias string, candidates ...string) {
+		for _, raw := range candidates {
+			if pk, ok := parseDmsgURLPK(raw); ok {
+				m[alias] = pk
+				return
+			}
+		}
+	}
+	if conf.Dmsg != nil {
+		add("dmsgd", conf.Dmsg.DiscoveryDmsg, conf.Dmsg.Discovery)
+	}
+	if conf.Transport != nil {
+		add("tpd", conf.Transport.DiscoveryDmsg, conf.Transport.Discovery)
+		add("ar", conf.Transport.AddressResolverDmsg, conf.Transport.AddressResolver)
+	}
+	if conf.Routing != nil {
+		add("rf", conf.Routing.RouteFinderDmsg, conf.Routing.RouteFinder)
+	}
+	if conf.Launcher != nil {
+		add("sd", conf.Launcher.ServiceDiscDmsg, conf.Launcher.ServiceDisc)
+	}
+	if conf.UptimeTracker != nil {
+		add("ut", conf.UptimeTracker.AddrDmsg, conf.UptimeTracker.Addr)
+	}
+	return m
+}
+
 func uintOrDefault(v, d uint) uint {
 	if v == 0 {
 		return d
@@ -267,7 +343,7 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 			Info("Auto-chaining dmsgweb → skynetweb for unified proxy")
 	}
 
-	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, cfg, log)
+	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), cfg, log)
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -299,6 +299,27 @@ func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
 	if conf.UptimeTracker != nil {
 		add("ut", conf.UptimeTracker.AddrDmsg, conf.UptimeTracker.Addr)
 	}
+
+	// Setup nodes are PK lists (not URLs) that serve /health over a dialable
+	// dmsg stream — verified reachable through the resolving proxy. Index them
+	// rsn0.. / tsn0.. with the bare alias pointing at the first.
+	//
+	// dmsg SERVERS are deliberately NOT aliased: they're relays whose /health
+	// lives on a clearnet metrics port, not on a dmsg stream, so the proxy
+	// cannot reach them by PK.
+	addList := func(prefix string, pks []cipher.PubKey) {
+		for i, pk := range pks {
+			if pk.Null() {
+				continue
+			}
+			m[fmt.Sprintf("%s%d", prefix, i)] = pk
+			if i == 0 {
+				m[prefix] = pk
+			}
+		}
+	}
+	addList("rsn", conf.EffectiveRouteSetupNodes())
+	addList("tsn", conf.EffectiveTransportSetupPKs())
 	return m
 }
 

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/dmsgweb"
@@ -315,37 +317,67 @@ func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
 	}
 	addList("rsn", conf.EffectiveRouteSetupNodes())
 	addList("tsn", conf.EffectiveTransportSetupPKs())
-
-	// dmsg servers serve /health (and other endpoints) over dmsg-HTTP but are
-	// not registered as discovery clients, so they're reached via the DIRECT
-	// client (see dmsgServerPKSet + EmbeddedDmsgWeb.directClient), not the
-	// discovery dial. Aliased dmsg0...
-	if conf.Dmsg != nil {
-		for i, e := range conf.Dmsg.ResolvedServers() {
-			if e == nil || e.Static.Null() {
-				continue
-			}
-			m[fmt.Sprintf("dmsg%d", i)] = e.Static
-		}
-	}
+	// dmsg-server aliases (dmsg0..) are added separately from the LIVE server
+	// list, not this static config — see dmsgServerAliases / liveDmsgServerEntries.
 	return m
 }
 
-// dmsgServerPKSet returns the set of configured dmsg-server PKs. These are
-// dialed through the resolver's direct client (self-rendezvous) rather than
-// resolved via discovery, since a dmsg server registers no client entry.
-func dmsgServerPKSet(conf *visorconfig.V1) map[cipher.PubKey]struct{} {
-	set := map[cipher.PubKey]struct{}{}
-	if conf == nil || conf.Dmsg == nil {
-		return set
+// liveDmsgServerEntries returns the visor's current dmsg-server set: the
+// config's bootstrap servers merged with (and preferring) the on-disk cache
+// the background loop refreshes from dmsg-discovery's all_servers. This is the
+// same list the dmsg clients actually use, so aliases track reality instead of
+// the possibly-stale embedded config (which is bootstrap-only).
+func liveDmsgServerEntries(v *Visor) []*dmsgdisc.Entry {
+	if v == nil || v.conf == nil || v.conf.Dmsg == nil {
+		return nil
 	}
-	for _, e := range conf.Dmsg.ResolvedServers() {
+	// Prefer the live cache (refreshed from dmsg-discovery's all_servers) so
+	// aliases reflect what discovery currently advertises, NOT the stale
+	// bootstrap config. MergePreferringCache unions config+cache by PK, which
+	// would re-introduce decommissioned config-only PKs — so pass nil to get
+	// exactly the cache contents instead.
+	if v.dmsgServersCache != nil {
+		if live := v.dmsgServersCache.MergePreferringCache(nil); len(live) > 0 {
+			return live
+		}
+	}
+	// Bootstrap fallback: empty cache (fresh visor, before the first refresh).
+	return v.conf.Dmsg.ResolvedServers()
+}
+
+// dmsgServerAliases builds dmsg0.. aliases and the matching direct-dial PK set
+// from a server list, sorted by PK for stable indices across restarts. dmsg
+// servers serve /health (etc.) over dmsg-HTTP but register no discovery client
+// entry, so they're reached via the resolver's direct client (self-rendezvous),
+// not the discovery dial. Null PKs are skipped.
+func dmsgServerAliases(servers []*dmsgdisc.Entry) (map[string]cipher.PubKey, map[cipher.PubKey]struct{}) {
+	pks := make([]cipher.PubKey, 0, len(servers))
+	for _, e := range servers {
 		if e == nil || e.Static.Null() {
 			continue
 		}
-		set[e.Static] = struct{}{}
+		pks = append(pks, e.Static)
 	}
-	return set
+	sort.Slice(pks, func(i, j int) bool { return pks[i].Hex() < pks[j].Hex() })
+	aliases := make(map[string]cipher.PubKey, len(pks))
+	set := make(map[cipher.PubKey]struct{}, len(pks))
+	for i, pk := range pks {
+		aliases[fmt.Sprintf("dmsg%d", i)] = pk
+		set[pk] = struct{}{}
+	}
+	return aliases, set
+}
+
+// resolverAliasesAndDmsgServers assembles the full alias map (URL services +
+// setup nodes from static config, plus dmsg0.. from the LIVE server list) and
+// the direct-dial dmsg-server PK set, for the embedded dmsg resolver.
+func resolverAliasesAndDmsgServers(v *Visor) (map[string]cipher.PubKey, map[cipher.PubKey]struct{}) {
+	aliases := serviceAliasMap(v.conf)
+	dmsgAliases, set := dmsgServerAliases(liveDmsgServerEntries(v))
+	for label, pk := range dmsgAliases {
+		aliases[label] = pk
+	}
+	return aliases, set
 }
 
 func uintOrDefault(v, d uint) uint {
@@ -389,7 +421,8 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 			Info("Auto-chaining dmsgweb → skynetweb for unified proxy")
 	}
 
-	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), dmsgServerPKSet(v.conf), cfg, log)
+	aliases, dmsgSet := resolverAliasesAndDmsgServers(v)
+	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, aliases, dmsgSet, cfg, log)
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"sync"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/launcher"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/dmsgweb"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
@@ -55,12 +55,20 @@ type EmbeddedDmsgWeb struct {
 	localPK  cipher.PubKey                       // this visor's PK, for self-loopback + "self" alias
 	selfDial func(port uint16) (net.Conn, error) // in-process serve of a local service port (nil disables loopback)
 
-	// serviceAliases maps canonical short labels (tpd, ar, rf, sd, ut, dmsgd)
-	// to the configured deployment services' PKs, so the resolving proxy can
-	// reach a service's HTTP API by name (e.g. http://tpd.dmsg/). Derived once
-	// from the visor config at construction; empty when no service has a
-	// resolvable dmsg PK.
+	// serviceAliases maps canonical short labels (tpd, ar, rf, sd, ut, dmsgd,
+	// rsn*, tsn*, dmsg*) to the configured deployment services' PKs, so the
+	// resolving proxy can reach a service's HTTP API by name (e.g.
+	// http://tpd.dmsg/). Derived once from the visor config at construction;
+	// empty when no service has a resolvable dmsg PK.
 	serviceAliases map[string]cipher.PubKey
+
+	// directClient + directServerPKs let the resolver reach dmsg SERVERS, which
+	// serve over dmsg-HTTP but register no discovery client entry. A dest in
+	// directServerPKs is dialed through directClient by self-rendezvous instead
+	// of the discovery dial. directClient is the visor's direct dmsg client
+	// (v.dmsgDC); nil disables the path.
+	directClient    *dmsg.Client
+	directServerPKs map[cipher.PubKey]struct{}
 
 	mu        sync.Mutex
 	running   bool
@@ -74,16 +82,18 @@ type EmbeddedDmsgWeb struct {
 // "resolver never ran" from "running but idle". localPK + selfDial
 // enable self-loopback (serving requests for this visor's own PK
 // in-process); pass a zero PK / nil selfDial to disable.
-func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), serviceAliases map[string]cipher.PubKey, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
+func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC, directClient *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), serviceAliases map[string]cipher.PubKey, directServerPKs map[cipher.PubKey]struct{}, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
 	return &EmbeddedDmsgWeb{
-		dmsgC:          dmsgC,
-		cfg:            cfg,
-		log:            log,
-		stats:          dmsgweb.NewStats(),
-		localPK:        localPK,
-		selfDial:       selfDial,
-		serviceAliases: serviceAliases,
-		parentCtx:      parentCtx,
+		dmsgC:           dmsgC,
+		cfg:             cfg,
+		log:             log,
+		stats:           dmsgweb.NewStats(),
+		localPK:         localPK,
+		selfDial:        selfDial,
+		serviceAliases:  serviceAliases,
+		directClient:    directClient,
+		directServerPKs: directServerPKs,
+		parentCtx:       parentCtx,
 	}
 }
 
@@ -195,6 +205,9 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 	for label, pk := range resolverAliasMap(e.cfg.Alias, e.localPK) {
 		cfg.Aliases[label] = pk
 	}
+	// Direct-client path for non-discovery dmsg servers.
+	cfg.DirectClient = e.directClient
+	cfg.DirectServerPKs = e.directServerPKs
 
 	// Optional TLS MITM. CA load failure is non-fatal — the
 	// resolver continues without MITM and logs the reason.
@@ -243,24 +256,6 @@ func resolverAliasMap(alias string, localPK cipher.PubKey) map[string]cipher.Pub
 	return map[string]cipher.PubKey{alias: localPK}
 }
 
-// parseDmsgURLPK extracts the visor PK from a "dmsg://<pk>:<port>" service URL.
-// A plain-HTTP URL (or empty / malformed) yields ok=false, since it carries no
-// dmsg PK to resolve through.
-func parseDmsgURLPK(raw string) (cipher.PubKey, bool) {
-	if raw == "" {
-		return cipher.PubKey{}, false
-	}
-	u, err := url.Parse(raw)
-	if err != nil || u.Scheme != "dmsg" {
-		return cipher.PubKey{}, false
-	}
-	var pk cipher.PubKey
-	if err := pk.Set(u.Hostname()); err != nil {
-		return cipher.PubKey{}, false
-	}
-	return pk, true
-}
-
 // serviceAliasMap derives canonical short aliases for the deployment services
 // this visor is configured to use, by pulling each service's PK out of its
 // dmsg:// URL. The resolving proxy then reaches a service's HTTP API by name —
@@ -277,7 +272,7 @@ func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
 	// the dmsg URL there directly.
 	add := func(alias string, candidates ...string) {
 		for _, raw := range candidates {
-			if pk, ok := parseDmsgURLPK(raw); ok {
+			if pk := dmsgspec.PKFromDmsgURL(raw); !pk.Null() {
 				m[alias] = pk
 				return
 			}
@@ -320,7 +315,37 @@ func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
 	}
 	addList("rsn", conf.EffectiveRouteSetupNodes())
 	addList("tsn", conf.EffectiveTransportSetupPKs())
+
+	// dmsg servers serve /health (and other endpoints) over dmsg-HTTP but are
+	// not registered as discovery clients, so they're reached via the DIRECT
+	// client (see dmsgServerPKSet + EmbeddedDmsgWeb.directClient), not the
+	// discovery dial. Aliased dmsg0...
+	if conf.Dmsg != nil {
+		for i, e := range conf.Dmsg.ResolvedServers() {
+			if e == nil || e.Static.Null() {
+				continue
+			}
+			m[fmt.Sprintf("dmsg%d", i)] = e.Static
+		}
+	}
 	return m
+}
+
+// dmsgServerPKSet returns the set of configured dmsg-server PKs. These are
+// dialed through the resolver's direct client (self-rendezvous) rather than
+// resolved via discovery, since a dmsg server registers no client entry.
+func dmsgServerPKSet(conf *visorconfig.V1) map[cipher.PubKey]struct{} {
+	set := map[cipher.PubKey]struct{}{}
+	if conf == nil || conf.Dmsg == nil {
+		return set
+	}
+	for _, e := range conf.Dmsg.ResolvedServers() {
+		if e == nil || e.Static.Null() {
+			continue
+		}
+		set[e.Static] = struct{}{}
+	}
+	return set
 }
 
 func uintOrDefault(v, d uint) uint {
@@ -364,7 +389,7 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 			Info("Auto-chaining dmsgweb → skynetweb for unified proxy")
 	}
 
-	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), cfg, log)
+	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, serviceAliasMap(v.conf), dmsgServerPKSet(v.conf), cfg, log)
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_dmsgweb_test.go
+++ b/pkg/visor/embedded_dmsgweb_test.go
@@ -1,0 +1,81 @@
+package visor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+func dmsgURL(t *testing.T) (string, string) {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return fmt.Sprintf("dmsg://%s:80", pk.Hex()), pk.Hex()
+}
+
+// TestParseDmsgURLPK covers the dmsg-URL → PK extraction and the non-dmsg /
+// malformed rejections.
+func TestParseDmsgURLPK(t *testing.T) {
+	raw, hexPK := dmsgURL(t)
+
+	pk, ok := parseDmsgURLPK(raw)
+	require.True(t, ok, "valid dmsg:// URL must parse")
+	assert.Equal(t, hexPK, pk.Hex())
+
+	for _, bad := range []string{
+		"",                           // unset
+		"http://transport.discovery", // plain HTTP — no dmsg PK
+		"https://sd.skycoin.com",
+		"dmsg://not-a-pubkey:80", // dmsg scheme but bad PK
+		"dmsg://:80",             // empty host
+	} {
+		_, ok := parseDmsgURLPK(bad)
+		assert.False(t, ok, "must reject %q", bad)
+	}
+}
+
+// TestServiceAliasMap asserts the canonical acronyms map to the configured
+// service PKs, that the *Dmsg field is preferred, and that plain-HTTP / unset
+// services are omitted (not aliased to a zero PK).
+func TestServiceAliasMap(t *testing.T) {
+	tpdURL, tpdPK := dmsgURL(t)
+	arURL, arPK := dmsgURL(t)
+	rfURL, rfPK := dmsgURL(t)
+	sdURL, sdPK := dmsgURL(t)
+	dmsgdURL, dmsgdPK := dmsgURL(t)
+
+	conf := &visorconfig.V1{
+		Dmsg: &dmsgspec.DmsgConfig{DiscoveryDmsg: dmsgdURL},
+		Transport: &visorconfig.Transport{
+			DiscoveryDmsg:       tpdURL,
+			AddressResolverDmsg: arURL,
+			// AddressResolver (plain) left empty on purpose
+		},
+		Routing:       &visorconfig.Routing{RouteFinderDmsg: rfURL},
+		Launcher:      &visorconfig.Launcher{ServiceDiscDmsg: sdURL},
+		UptimeTracker: &visorconfig.UptimeTracker{Addr: "http://ut.skycoin.com"}, // HTTP only → omitted
+	}
+
+	m := serviceAliasMap(conf)
+
+	assert.Equal(t, dmsgdPK, m["dmsgd"].Hex())
+	assert.Equal(t, tpdPK, m["tpd"].Hex())
+	assert.Equal(t, arPK, m["ar"].Hex())
+	assert.Equal(t, rfPK, m["rf"].Hex())
+	assert.Equal(t, sdPK, m["sd"].Hex())
+
+	_, hasUT := m["ut"]
+	assert.False(t, hasUT, "HTTP-only uptime tracker must not be aliased")
+	assert.Len(t, m, 5, "exactly the 5 resolvable services")
+}
+
+// TestServiceAliasMapNil guards the nil-config and empty-services paths.
+func TestServiceAliasMapNil(t *testing.T) {
+	assert.Empty(t, serviceAliasMap(nil))
+	assert.Empty(t, serviceAliasMap(&visorconfig.V1{}))
+}

--- a/pkg/visor/embedded_dmsgweb_test.go
+++ b/pkg/visor/embedded_dmsgweb_test.go
@@ -74,6 +74,35 @@ func TestServiceAliasMap(t *testing.T) {
 	assert.Len(t, m, 5, "exactly the 5 resolvable services")
 }
 
+// TestServiceAliasMapSetupNodes covers the PK-list setup nodes: indexed aliases
+// plus a bare alias pointing at the first, and null-PK skipping.
+func TestServiceAliasMapSetupNodes(t *testing.T) {
+	rsn0, _ := cipher.GenerateKeyPair()
+	rsn1, _ := cipher.GenerateKeyPair()
+	tsn0, _ := cipher.GenerateKeyPair()
+
+	conf := &visorconfig.V1{
+		Routing: &visorconfig.Routing{
+			RouteSetupNodes: []cipher.PubKey{rsn0, rsn1},
+		},
+		Transport: &visorconfig.Transport{
+			TransportSetupPKs:     []cipher.PubKey{tsn0},
+			UserTransportSetupPKs: []cipher.PubKey{{}}, // null PK must be skipped
+		},
+	}
+
+	m := serviceAliasMap(conf)
+
+	assert.Equal(t, rsn0.Hex(), m["rsn"].Hex(), "bare rsn points at the first")
+	assert.Equal(t, rsn0.Hex(), m["rsn0"].Hex())
+	assert.Equal(t, rsn1.Hex(), m["rsn1"].Hex())
+	assert.Equal(t, tsn0.Hex(), m["tsn"].Hex())
+	assert.Equal(t, tsn0.Hex(), m["tsn0"].Hex())
+
+	_, hasNull := m["tsn1"]
+	assert.False(t, hasNull, "null setup-node PK must not be aliased")
+}
+
 // TestServiceAliasMapNil guards the nil-config and empty-services paths.
 func TestServiceAliasMapNil(t *testing.T) {
 	assert.Empty(t, serviceAliasMap(nil))

--- a/pkg/visor/embedded_dmsgweb_test.go
+++ b/pkg/visor/embedded_dmsgweb_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsgspec "github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
@@ -16,27 +16,6 @@ func dmsgURL(t *testing.T) (string, string) {
 	t.Helper()
 	pk, _ := cipher.GenerateKeyPair()
 	return fmt.Sprintf("dmsg://%s:80", pk.Hex()), pk.Hex()
-}
-
-// TestParseDmsgURLPK covers the dmsg-URL → PK extraction and the non-dmsg /
-// malformed rejections.
-func TestParseDmsgURLPK(t *testing.T) {
-	raw, hexPK := dmsgURL(t)
-
-	pk, ok := parseDmsgURLPK(raw)
-	require.True(t, ok, "valid dmsg:// URL must parse")
-	assert.Equal(t, hexPK, pk.Hex())
-
-	for _, bad := range []string{
-		"",                           // unset
-		"http://transport.discovery", // plain HTTP — no dmsg PK
-		"https://sd.skycoin.com",
-		"dmsg://not-a-pubkey:80", // dmsg scheme but bad PK
-		"dmsg://:80",             // empty host
-	} {
-		_, ok := parseDmsgURLPK(bad)
-		assert.False(t, ok, "must reject %q", bad)
-	}
 }
 
 // TestServiceAliasMap asserts the canonical acronyms map to the configured
@@ -103,8 +82,37 @@ func TestServiceAliasMapSetupNodes(t *testing.T) {
 	assert.False(t, hasNull, "null setup-node PK must not be aliased")
 }
 
+// TestServiceAliasMapDmsgServers covers dmsg-server aliasing (dmsg0..) and the
+// matching direct-dial PK set, including null-PK skipping.
+func TestServiceAliasMapDmsgServers(t *testing.T) {
+	s0, _ := cipher.GenerateKeyPair()
+	s1, _ := cipher.GenerateKeyPair()
+
+	conf := &visorconfig.V1{
+		Dmsg: &dmsgspec.DmsgConfig{
+			Servers: []*dmsgdisc.Entry{
+				{Static: s0},
+				{Static: s1},
+				{Static: cipher.PubKey{}}, // null PK must be skipped
+			},
+		},
+	}
+
+	m := serviceAliasMap(conf)
+	assert.Equal(t, s0.Hex(), m["dmsg0"].Hex())
+	assert.Equal(t, s1.Hex(), m["dmsg1"].Hex())
+
+	set := dmsgServerPKSet(conf)
+	assert.Contains(t, set, s0)
+	assert.Contains(t, set, s1)
+	assert.NotContains(t, set, cipher.PubKey{}, "null PK must not be in the direct-dial set")
+	assert.Len(t, set, 2)
+}
+
 // TestServiceAliasMapNil guards the nil-config and empty-services paths.
 func TestServiceAliasMapNil(t *testing.T) {
 	assert.Empty(t, serviceAliasMap(nil))
 	assert.Empty(t, serviceAliasMap(&visorconfig.V1{}))
+	assert.Empty(t, dmsgServerPKSet(nil))
+	assert.Empty(t, dmsgServerPKSet(&visorconfig.V1{}))
 }

--- a/pkg/visor/embedded_dmsgweb_test.go
+++ b/pkg/visor/embedded_dmsgweb_test.go
@@ -82,37 +82,40 @@ func TestServiceAliasMapSetupNodes(t *testing.T) {
 	assert.False(t, hasNull, "null setup-node PK must not be aliased")
 }
 
-// TestServiceAliasMapDmsgServers covers dmsg-server aliasing (dmsg0..) and the
-// matching direct-dial PK set, including null-PK skipping.
-func TestServiceAliasMapDmsgServers(t *testing.T) {
+// TestDmsgServerAliases covers dmsg-server aliasing (dmsg0.., sorted by PK for
+// stable indices) and the matching direct-dial PK set, including null-PK skip.
+func TestDmsgServerAliases(t *testing.T) {
 	s0, _ := cipher.GenerateKeyPair()
 	s1, _ := cipher.GenerateKeyPair()
 
-	conf := &visorconfig.V1{
-		Dmsg: &dmsgspec.DmsgConfig{
-			Servers: []*dmsgdisc.Entry{
-				{Static: s0},
-				{Static: s1},
-				{Static: cipher.PubKey{}}, // null PK must be skipped
-			},
-		},
+	servers := []*dmsgdisc.Entry{
+		{Static: s0},
+		{Static: s1},
+		{Static: cipher.PubKey{}}, // null PK must be skipped
 	}
 
-	m := serviceAliasMap(conf)
-	assert.Equal(t, s0.Hex(), m["dmsg0"].Hex())
-	assert.Equal(t, s1.Hex(), m["dmsg1"].Hex())
+	aliases, set := dmsgServerAliases(servers)
 
-	set := dmsgServerPKSet(conf)
+	// Indices are assigned in PK-sorted order, so derive the expectation.
+	lo, hi := s0, s1
+	if hi.Hex() < lo.Hex() {
+		lo, hi = hi, lo
+	}
+	assert.Equal(t, lo.Hex(), aliases["dmsg0"].Hex())
+	assert.Equal(t, hi.Hex(), aliases["dmsg1"].Hex())
+	assert.Len(t, aliases, 2)
+
 	assert.Contains(t, set, s0)
 	assert.Contains(t, set, s1)
 	assert.NotContains(t, set, cipher.PubKey{}, "null PK must not be in the direct-dial set")
 	assert.Len(t, set, 2)
 }
 
-// TestServiceAliasMapNil guards the nil-config and empty-services paths.
+// TestServiceAliasMapNil guards the nil-config and empty paths.
 func TestServiceAliasMapNil(t *testing.T) {
 	assert.Empty(t, serviceAliasMap(nil))
 	assert.Empty(t, serviceAliasMap(&visorconfig.V1{}))
-	assert.Empty(t, dmsgServerPKSet(nil))
-	assert.Empty(t, dmsgServerPKSet(&visorconfig.V1{}))
+	a, s := dmsgServerAliases(nil)
+	assert.Empty(t, a)
+	assert.Empty(t, s)
 }


### PR DESCRIPTION
## What

Auto-derive short, well-known aliases for the services a visor is configured to use, so the **dmsg resolving proxy** can reach a service's HTTP API *by name* instead of by raw 66-char PK:

```
curl -x socks5h://127.0.0.1:4445 http://tpd.dmsg/health
```

This extends the existing `skywire.dmsg` self-alias to the whole configured service set.

## Aliases (auto-derived, mirroring the `cli` namespace)

| alias            | service                          | dial path |
|------------------|----------------------------------|-----------|
| `dmsgd`          | dmsg discovery                   | discovery |
| `tpd`            | transport discovery              | discovery |
| `ar`             | address resolver                 | discovery |
| `rf`             | route finder                     | discovery |
| `sd`             | service discovery                | discovery |
| `ut`             | uptime tracker                   | discovery |
| `rsn`, `rsn0..` | route setup nodes (PK list)      | discovery |
| `tsn`, `tsn0..` | transport setup nodes (PK list)  | discovery |
| `dmsg0..`        | dmsg servers                     | **direct client** |

Bare `rsn`/`tsn` point at the first node; null PKs are skipped.

## How

- **URL services** (`dmsgd`/`tpd`/`ar`/`rf`/`sd`/`ut`): PK pulled from each service's `dmsg://` URL via the canonical `spec.PKFromDmsgURL`. Plain-HTTP-only / unset services are omitted (not aliased to a zero PK).
- **Setup nodes**: PK lists from `EffectiveRouteSetupNodes()` / `EffectiveTransportSetupPKs()` (includes user-added), indexed `rsn0..`/`tsn0..`.
- **dmsg servers**: they serve over dmsg-HTTP but register **no discovery client entry**, so the discovery dial can't resolve them. New optional `DirectClient`+`DirectServerPKs` path in the dmsgweb resolver dials them by **self-rendezvous** through the visor's direct client (`v.dmsgDC`): `EnsureAndObtainSession(server)` + `DialStream(server:80)`.
- **No new config surface** — everything is auto-derived from existing config. The visor's own alias (default `skywire`) wins on any collision. Scoped to the **`.dmsg`** resolver; `.skynet` unchanged.

## Test

- Unit tests for `serviceAliasMap` (URL services + `*Dmsg` preference + HTTP-only omission), setup-node indexing + null-skip, dmsg-server aliasing + the direct-dial PK set, and nil-safety.
- **Live-validated** on a running visor: `tpd`/`ar`/`rf`/`sd`/`dmsgd` → 200 (real service JSON); `rsn`/`tsn` → 200 after warmup; `dmsg*` → result tracks each server's TCP reachability exactly (reachable server returns 200 via self-rendezvous, down servers fail); `skywire.dmsg` self-alias unaffected; unknown labels still fail closed.