### PR TITLE
feat(dmsg-server): borrow embedded servers when `servers` is empty (matched by discovery PK)

### DIFF
--- a/deployment/config.go
+++ b/deployment/config.go
@@ -17,6 +17,7 @@ package deployment
 
 import (
 	_ "embed"
+	"net/url"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
@@ -94,6 +95,49 @@ func (s *Services) ToDiscEntries() []*disc.Entry {
 // HasDmsgEndpoints returns true if the deployment has DMSG service endpoints.
 func (s *Services) HasDmsgEndpoints() bool {
 	return s.DmsgDiscoveryDmsg != ""
+}
+
+// pkFromDmsgURL extracts the public key from a `dmsg://<pk>:<port>` URL.
+// Returns the zero PK on empty / malformed / non-PK input.
+func pkFromDmsgURL(raw string) cipher.PubKey {
+	if raw == "" {
+		return cipher.PubKey{}
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return cipher.PubKey{}
+	}
+	var pk cipher.PubKey
+	if pk.Set(u.Hostname()) != nil {
+		return cipher.PubKey{}
+	}
+	return pk
+}
+
+// EmbeddedServersForDiscoveryDmsg returns the embedded dmsg-server transit
+// entries belonging to the embedded deployment whose dmsg-discovery matches
+// discoveryDmsgURL (compared by public key), or nil when nothing matches or the
+// URL is empty/malformed.
+//
+// This lets a dmsg-server omit its `servers` list yet still bootstrap, by
+// borrowing the binary's embedded server set — but ONLY for a recognized
+// discovery, so transit servers stay coupled to the discovery they belong to.
+// An unknown discovery yields nil (the server keeps an empty list), never a
+// mismatched set from a different deployment.
+func EmbeddedServersForDiscoveryDmsg(discoveryDmsgURL string) []*disc.Entry {
+	want := pkFromDmsgURL(discoveryDmsgURL)
+	if (want == cipher.PubKey{}) {
+		return nil
+	}
+	for _, s := range []Services{Prod, Test} {
+		if len(s.DmsgServers) == 0 {
+			continue
+		}
+		if pkFromDmsgURL(s.DmsgDiscoveryDmsg) == want {
+			return s.ToDiscEntries()
+		}
+	}
+	return nil
 }
 
 // Services are URLs, IP addresses, and public keys of the skywire services as deployed.

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -194,6 +194,18 @@ func (c *Config) NormalizedDeployments() []Deployment {
 	}
 	out := make([]Deployment, len(src))
 	for i, d := range src {
+		// A deployment with no explicit transit servers borrows the
+		// embedded set for whichever embedded deployment its discovery
+		// matches (by PK). This lets an operator drop the hand-maintained
+		// `servers` list from a dmsg-server config — keeping discovery_dmsg
+		// and per-deployment knobs like sessions_count — and track the
+		// binary's embedded deployment data instead. Servers stay coupled to
+		// their discovery: an unrecognized discovery is left empty, never
+		// filled from a mismatched deployment. The explicit `default` branch
+		// above already carries embedded servers, so this is a no-op there.
+		if len(d.Servers) == 0 {
+			d.Servers = deployment.EmbeddedServersForDiscoveryDmsg(d.DiscoveryDmsg)
+		}
 		if d.AdvertisedAddress == "" {
 			d.AdvertisedAddress = c.PublicAddress
 		}

--- a/pkg/dmsg/dmsgserver/config_fallback_test.go
+++ b/pkg/dmsg/dmsgserver/config_fallback_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/deployment"
+	"github.com/skycoin/skywire/pkg/cipher"
 )
 
 // A config with no dmsg / discovery / servers block falls back to the embedded
@@ -35,4 +36,35 @@ func TestNormalizedDeployments_ExplicitAuthoritative(t *testing.T) {
 	assert.Equal(t, "http://my-disc.example", deps[0].Discovery)
 	assert.NotEqual(t, deployment.Prod.DmsgDiscovery, deps[0].Discovery)
 	assert.Empty(t, deps[0].Servers, "an explicit block carries only what it specifies")
+}
+
+// A deployment that specifies its discovery_dmsg but omits `servers` borrows the
+// embedded server set for the matching embedded deployment (by discovery PK),
+// while keeping its own per-deployment knobs like sessions_count. This lets an
+// operator drop the hand-maintained servers list yet stay strictly dmsg-only.
+func TestNormalizedDeployments_EmptyServersBorrowsEmbedded(t *testing.T) {
+	cfg := &Config{Dmsg: DmsgConfig{Deployments: []Deployment{{
+		DiscoveryDmsg: deployment.Prod.DmsgDiscoveryDmsg,
+		SessionsCount: 2,
+	}}}}
+
+	deps := cfg.NormalizedDeployments()
+	require.Len(t, deps, 1)
+	assert.Equal(t, deployment.Prod.DmsgDiscoveryDmsg, deps[0].DiscoveryDmsg)
+	assert.Equal(t, 2, deps[0].SessionsCount, "per-deployment knobs are preserved")
+	assert.NotEmpty(t, deps[0].Servers, "empty servers + known discovery → embedded servers")
+	assert.Equal(t, deployment.Prod.ToDiscEntries(), deps[0].Servers)
+}
+
+// Empty servers with an UNRECOGNIZED (but valid) discovery PK stays empty — the
+// embedded set is never grafted onto a deployment it doesn't belong to.
+func TestNormalizedDeployments_EmptyServersUnknownDiscoveryStaysEmpty(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	cfg := &Config{Dmsg: DmsgConfig{Deployments: []Deployment{{
+		DiscoveryDmsg: "dmsg://" + pk.Hex() + ":80",
+	}}}}
+
+	deps := cfg.NormalizedDeployments()
+	require.Len(t, deps, 1)
+	assert.Empty(t, deps[0].Servers, "unknown discovery must not borrow embedded servers")
 }


### PR DESCRIPTION
## What

A dmsg-server config can now **omit its `servers` list** and have it filled from the binary's **embedded deployment data** — matched to the deployment by **discovery PK**. So instead of:

```json
"dmsg": { "discovery_dmsg": "dmsg://022e607e…:80", "sessions_count": 2, "servers": [ …8 hand-maintained entries… ] }
```

operators can write:

```json
"dmsg": { "discovery_dmsg": "dmsg://022e607e…:80", "sessions_count": 2 }
```

and the transit servers come from embedded `deployment.Prod` (kept current by the existing `services-config.json` refresh).

## Why

Hand-maintained per-server `servers` lists drift. When an anchor server's address changes and the configs aren't regenerated, a **cold restart of the whole fleet wedges**: every server boots against a stale list, can't open a session to any delegated server, and can't register (`dmsg error 202`). Dropping the list and tracking the embedded set removes that whole class of misconfiguration.

## How

- `deployment.EmbeddedServersForDiscoveryDmsg(url)` returns the embedded servers for the embedded deployment whose `dmsg_discovery_dmsg` PK matches `url`, else nil.
- `Config.NormalizedDeployments()`: for any deployment with empty `Servers`, fill from that matcher.

## Guarantees preserved

- **Strictly dmsg-only.** Untouched: the discovery client is still built solely from `discovery_dmsg` via `newDmsgOnly`; this change only seeds *transit servers*, never the discovery path. A deployment with no `discovery_dmsg` PK still refuses to start.
- **Servers stay coupled to their discovery.** An unrecognized discovery PK is left **empty** — never grafted with a different deployment's servers. So "my custom discovery + prod's servers" can't happen by accident.
- **Per-deployment knobs kept.** `sessions_count` etc. survive, since you keep the `dmsg` block.
- The pre-existing whole-block fallback (absent `dmsg` block → embedded discovery + servers) is unchanged.

## Test

Added to `config_fallback_test.go`:
- `{discovery_dmsg: <prod>, sessions_count: 2}` with no `servers` → embedded prod servers + `sessions_count` preserved.
- empty servers + a valid-but-**unknown** discovery PK → stays empty.

Full `dmsgserver`/`dmsgsrv`/`deployment` suites pass; `cmd/dmsg/dmsg-server` and the `js/wasm` deployment build both compile.

## Follow-up (not in this PR)

Persistent `dmsgServersCache`-on-the-server (like the visor already has) so even a stale *embedded* list self-heals from `all_servers` at runtime without a redeploy. This PR is the build-time half; that's the runtime half.