### PR TITLE
feat(dmsg-disc): log dmsg-server entry registrations with PK + sequence + source

### DIFF
--- a/pkg/dmsg/discovery/api/api.go
+++ b/pkg/dmsg/discovery/api/api.go
@@ -516,6 +516,27 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 		// Recover previous entry. If key not found we insert with sequence 0
 		// If there was a previous entry we check the new one is a valid iteration
 		oldEntry, err := a.db.Entry(r.Context(), entry.Static)
+
+		// Log SERVER registrations (not the high-volume client heartbeats —
+		// servers are a handful) with the registering PK, sequence jump,
+		// advertised address, and source. This makes a colliding or runaway
+		// server entry identifiable from the discovery logs: two different
+		// `src` for one `server_pk`, or a sequence climbing far faster than the
+		// ~1/min heartbeat, points straight at the offender. Placed before the
+		// iteration check so rejected (out-of-sequence) attempts are logged too.
+		if entry.Server != nil {
+			var prevSeq uint64
+			if err == nil && oldEntry != nil {
+				prevSeq = oldEntry.Sequence
+			}
+			a.log(r).WithField("server_pk", entry.Static).
+				WithField("address", entry.Server.Address).
+				WithField("sequence", entry.Sequence).
+				WithField("prev_sequence", prevSeq).
+				WithField("src", r.RemoteAddr).
+				Info("dmsg-server entry registration")
+		}
+
 		if err == disc.ErrKeyNotFound {
 			setErr := a.db.SetEntry(r.Context(), entry, entryTimeout)
 			if setErr != nil {


### PR DESCRIPTION
## What

`POST /dmsg-discovery/entry/` is logged today only as an HTTP access line with the **source address**, not the **registering public key** (it's in the request body). So when a server entry's `sequence` runs away — the signature of two servers fighting over the same key — the logs can't tell you *which host* is doing it.

This adds a structured log line for **server** registrations only (a handful of servers — not the ~160/sec client heartbeats), in `setEntry()`:

```
dmsg-server entry registration  server_pk=02a49bc0…  address=143.42.59.213:30081  sequence=393901  prev_sequence=393899  src=…
```

## Why

Diagnosing a real incident: one server's `sequence` is climbing ~10×+ faster than the ~1/min heartbeat. That's almost certainly a **duplicate-key collision** (two servers registering the same PK from different addresses, ratcheting each other's sequence up), but the current logs can't confirm it or name the offender. With this line:
- **two different `src` for one `server_pk`** → collision, and you see both hosts;
- **`sequence` jumping fast from a single `src`** → a re-registration loop on that host.

## Notes

- **Server entries only** (`entry.Server != nil`) — keeps volume to the ~dozen servers re-registering ~1/min, not the thousands of clients.
- Placed **before** the sequence-iteration check, so **rejected out-of-sequence attempts are logged too** — which is exactly what a losing party in a collision produces.
- Logged after signature + validation, so only authentic entries appear.

Builds clean; `a.log(r)` is the existing request-scoped `logrus.FieldLogger`.