### PR TITLE
fix(lint): clear golangci-lint failures on develop (release gate)

### DIFF
--- a/cmd/skywire/commands/web/web.go
+++ b/cmd/skywire/commands/web/web.go
@@ -135,7 +135,7 @@ func serve(ctx context.Context, root *cobra.Command) error {
 
 	// Shutdown on ctx cancel — outer command's signal handler
 	// (cobra's default) plumbs SIGINT through.
-	go func() {
+	go func() { //nolint:gosec // G118: shutdown timeout deliberately uses Background — the request ctx is being canceled
 		<-ctx.Done()
 		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -242,14 +242,9 @@ func buildTree(root *cobra.Command, allow []string) map[string]CommandNode {
 	out := make(map[string]CommandNode)
 	var walk func(c *cobra.Command, path string)
 	walk = func(c *cobra.Command, path string) {
-		if len(allow) > 0 {
-			if _, ok := allowSet[path]; !ok && path != "" {
-				// Not on the allowlist — but still walk children so
-				// allowed descendants can mount under an implicit
-				// breadcrumb. We just don't emit this node's flags
-				// + runnable bit.
-			}
-		}
+		// Non-allowlisted nodes are still walked so allowed descendants can
+		// mount under an implicit breadcrumb; the node itself is emitted with
+		// its flags/runnable bit regardless.
 		children := make([]string, 0, len(c.Commands()))
 		for _, sub := range c.Commands() {
 			if sub.Hidden && len(allow) == 0 {
@@ -280,7 +275,7 @@ func buildTree(root *cobra.Command, allow []string) map[string]CommandNode {
 			Path:     path,
 			Name:     c.Name(),
 			Short:    c.Short,
-			Long:    strings.TrimSpace(c.Long),
+			Long:     strings.TrimSpace(c.Long),
 			Example:  strings.TrimSpace(c.Example),
 			Use:      c.Use,
 			Children: children,
@@ -366,7 +361,7 @@ func handleRun(runs *runRegistry, skywireBin string) http.Handler {
 		argv = append(argv, req.Args...)
 
 		runCtx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel routed to run
-		cmd := exec.CommandContext(runCtx, skywireBin, argv...)
+		cmd := exec.CommandContext(runCtx, skywireBin, argv...)    //nolint:gosec // skywireBin is the resolved self-binary path; argv is trusted CLI input
 		// Combined stdout+stderr to one pipe; we don't distinguish
 		// in the SSE stream (the wasm client just renders sequential
 		// lines, like a terminal would).
@@ -471,7 +466,7 @@ func handleSSE(runs *runRegistry) http.Handler {
 					// emit it as a final event, then close.
 					select {
 					case code := <-runEntry.done:
-						fmt.Fprintf(w, "event: exit\ndata: %d\n\n", code)
+						fmt.Fprintf(w, "event: exit\ndata: %d\n\n", code) //nolint:errcheck
 						flusher.Flush()
 					case <-time.After(5 * time.Second):
 						fmt.Fprintf(w, "event: exit\ndata: -1\n\n") //nolint:errcheck

--- a/pkg/dmsg/noise/dh_test.go
+++ b/pkg/dmsg/noise/dh_test.go
@@ -7,6 +7,18 @@ import (
 	secp256k1 "github.com/skycoin/skycoin/src/cipher/secp256k1-go"
 )
 
+// mustDH runs dh.DH and fails the test/benchmark on error. Every call site
+// here uses valid secp256k1 inputs, so an error is a real bug, not an expected
+// path. Takes testing.TB so tests and benchmarks share it.
+func mustDH(tb testing.TB, dh Secp256k1, sk, pk []byte) []byte {
+	tb.Helper()
+	out, err := dh.DH(sk, pk)
+	if err != nil {
+		tb.Fatalf("DH: %v", err)
+	}
+	return out
+}
+
 // TestDHCacheConsistency verifies the cache returns the same bytes
 // as a fresh compute for the same (sk, pk) inputs, and that
 // different (sk, pk) pairs produce different outputs. Existing
@@ -20,8 +32,8 @@ func TestDHCacheConsistency(t *testing.T) {
 
 	dh := Secp256k1{}
 
-	first, _ := dh.DH(sk1, pk2)  // miss → compute + cache
-	second, _ := dh.DH(sk1, pk2) // hit
+	first := mustDH(t, dh, sk1, pk2)  // miss → compute + cache
+	second := mustDH(t, dh, sk1, pk2) // hit
 	if !bytes.Equal(first, second) {
 		t.Fatalf("cache hit returned different bytes: %x vs %x", first, second)
 	}
@@ -31,7 +43,7 @@ func TestDHCacheConsistency(t *testing.T) {
 	// generate a cache-lookup key with a guaranteed-different DH
 	// output.
 	pk3, _ := secp256k1.GenerateKeyPair()
-	other, _ := dh.DH(sk1, pk3)
+	other := mustDH(t, dh, sk1, pk3)
 	if bytes.Equal(first, other) {
 		t.Fatalf("unrelated (sk,pk) pairs produced the same DH output: %x", first)
 	}
@@ -40,14 +52,14 @@ func TestDHCacheConsistency(t *testing.T) {
 	// cleared still matches the cached value (cache is a no-op
 	// optimization, not a divergence source).
 	resetDHCache()
-	fresh, _ := dh.DH(sk1, pk2)
+	fresh := mustDH(t, dh, sk1, pk2)
 	if !bytes.Equal(first, fresh) {
 		t.Fatalf("post-reset compute disagrees with cached value: %x vs %x", fresh, first)
 	}
 
 	// Sanity check: DH is commutative (each party should derive the
 	// same shared secret from their own SK + the peer's PK).
-	commutative, _ := dh.DH(sk2, pk1)
+	commutative := mustDH(t, dh, sk2, pk1)
 	if !bytes.Equal(first, commutative) {
 		t.Fatalf("DH not commutative: DH(sk1, pk2)=%x DH(sk2, pk1)=%x", first, commutative)
 	}
@@ -63,7 +75,7 @@ func TestDHCacheEviction(t *testing.T) {
 	// past the cap.
 	for i := 0; i < dhCacheMax*2; i++ {
 		pk, sk := secp256k1.GenerateKeyPair()
-		_, _ = dh.DH(sk, pk)
+		mustDH(t, dh, sk, pk)
 		if size := dhCacheSize(); size > dhCacheMax {
 			t.Fatalf("cache exceeded cap: %d > %d at iteration %d", size, dhCacheMax, i)
 		}
@@ -92,12 +104,12 @@ func TestDHCacheStats(t *testing.T) {
 	pk2, sk2 := secp256k1.GenerateKeyPair()
 
 	// First call on each pair = miss.
-	_, _ = dh.DH(sk1, pk2)
-	_, _ = dh.DH(sk2, pk1)
+	mustDH(t, dh, sk1, pk2)
+	mustDH(t, dh, sk2, pk1)
 	// Repeat — both hits.
-	_, _ = dh.DH(sk1, pk2)
-	_, _ = dh.DH(sk2, pk1)
-	_, _ = dh.DH(sk1, pk2)
+	mustDH(t, dh, sk1, pk2)
+	mustDH(t, dh, sk2, pk1)
+	mustDH(t, dh, sk1, pk2)
 
 	s := GetCacheStats()
 	if s.Hits != 3 {
@@ -119,7 +131,7 @@ func TestDHCacheStats(t *testing.T) {
 	// Push past the cap to trigger evictions.
 	for i := 0; i < dhCacheMax*2; i++ {
 		pk, sk := secp256k1.GenerateKeyPair()
-		_, _ = dh.DH(sk, pk)
+		mustDH(t, dh, sk, pk)
 	}
 	s = GetCacheStats()
 	if s.Evictions == 0 {
@@ -145,10 +157,10 @@ func BenchmarkDHCacheHit(b *testing.B) {
 	resetDHCache()
 	dh := Secp256k1{}
 	pk, sk := secp256k1.GenerateKeyPair()
-	_, _ = dh.DH(sk, pk) // prime the cache
+	mustDH(b, dh, sk, pk) // prime the cache
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = dh.DH(sk, pk)
+		_, _ = dh.DH(sk, pk) //nolint:errcheck // hot loop; correctness covered by tests
 	}
 }
 
@@ -167,6 +179,6 @@ func BenchmarkDHCacheMiss(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = dh.DH(keys[i][0], keys[i][1])
+		_, _ = dh.DH(keys[i][0], keys[i][1]) //nolint:errcheck // hot loop; correctness covered by tests
 	}
 }

--- a/pkg/dmsg/noise/pqhybrid.go
+++ b/pkg/dmsg/noise/pqhybrid.go
@@ -88,7 +88,7 @@ func (k *pqInitiator) decapsulate(ciphertext []byte) (sharedSecret []byte, err e
 // transcript hash (so the derived key is tied to *this* handshake). Breaking the
 // result requires breaking BOTH the classical DH AND ML-KEM-768 — hybrid
 // security. Returns keyLen bytes.
-func combineHybridKey(classicalKey, pqSharedSecret, transcriptHash []byte, keyLen int) ([]byte, error) {
+func combineHybridKey(classicalKey, pqSharedSecret, transcriptHash []byte, keyLen int) ([]byte, error) { //nolint:unparam // keyLen is the HKDF output length, kept explicit though currently always the 32-byte cipher key
 	if len(pqSharedSecret) != pqSharedKeySize {
 		return nil, fmt.Errorf("pq: unexpected ml-kem shared-secret size %d (want %d)", len(pqSharedSecret), pqSharedKeySize)
 	}


### PR DESCRIPTION
develop is currently **red on golangci-lint**, which blocks cutting a release. This clears the 9 reported issues.

**`cmd/skywire/commands/web/web.go`**
- gofmt formatting
- errcheck on `Fprintf`
- gosec **G118** (shutdown goroutine deliberately uses `Background`) + **G204** (self-exec) — `//nolint` with justification
- staticcheck **SA9003** — removed a **dead empty `if` branch** (no behavior change; non-allowlisted nodes were already walked + emitted regardless)

**`pkg/dmsg/noise/dh_test.go`**
- errcheck: the #3120 two-value `dh.DH` signature left **15 blanked errors**. Wrapped calls in a `mustDH(testing.TB, …)` helper that fails on error; `//nolint:errcheck` on the two benchmark hot-loops (avoids `Helper()` overhead skewing the benchmark).

**`pkg/dmsg/noise/pqhybrid.go`**
- unparam: `//nolint` on `combineHybridKey` `keyLen` (the HKDF output length, kept explicit).

Verified locally with golangci-lint v2.12.2: **0 issues** on the affected packages, and `go test ./pkg/dmsg/noise/` passes. (Two G124 cookie findings appear only under v2.12.2, not CI's v2.11.4, and are false positives — the cookies already set Secure/HttpOnly/SameSite via config — so they're intentionally left untouched.)

Unblocks tagging the next release.