### PR TITLE
feat(resolver): reward-system dmsg alias + document the service aliases

### DIFF
--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -105,6 +105,42 @@ own PK.
 `self_loopback: false` is mainly useful to test that your visor is reachable
 over its **own** transports — valid for skynet (dmsg won't self-loopback).
 
+### Service aliases (configured deployment services)
+
+Beyond `skywire` (your own visor), the resolver also exposes **short aliases for
+the deployment services this visor is configured to use**, so you can reach a
+service's HTTP API by name instead of its 66-char public key. They're
+**auto-derived from the visor config** — nothing to maintain — and resolve on the
+**`.dmsg`** suffix:
+
+| alias | service |
+|-------|---------|
+| `dmsgd` | dmsg discovery |
+| `tpd` | transport discovery |
+| `ar` | address resolver |
+| `rf` | route finder |
+| `sd` | service discovery |
+| `ut` | uptime tracker |
+| `reward` | reward system |
+| `rsn`, `rsn0`, `rsn1`, … | route setup nodes (bare label = the first) |
+| `tsn`, `tsn0`, `tsn1`, … | transport setup nodes (bare label = the first) |
+| `dmsg0`, `dmsg1`, … | dmsg servers (the **live** discovery list, sorted by PK) |
+
+So `http://tpd.dmsg/health` reaches the transport discovery, `http://rsn.dmsg/health`
+the first route setup node, and `http://dmsg0.dmsg/health` the first dmsg server.
+
+Notes:
+
+- A service is aliased only when it has a resolvable `dmsg://` URL in the config;
+  a plain-HTTP-only (or unset) service is silently omitted.
+- The `dmsg*` servers aren't registered as discovery *clients*, so they're reached
+  via the visor's **direct** dmsg client (self-rendezvous); everything else goes
+  over the normal discovery dial. The `dmsg*` set tracks the **live** discovery
+  list, not the static bootstrap config.
+- `skywire` (your own visor) wins on any name collision.
+- An unknown label still **fails closed** — it's neither a PK nor a known alias,
+  so it resolves to nothing rather than somewhere wrong.
+
 ## From `curl`
 
 Use `socks5h://` (the `h` makes the **proxy** resolve the hostname — required for
@@ -116,17 +152,23 @@ curl -x socks5h://127.0.0.1:4445 http://<visor-pk>.dmsg:80/health
 
 ### Browsing deployment-service data over dmsg
 
+Using the [service aliases](#service-aliases-configured-deployment-services)
+(or the raw `<service-pk>.dmsg` if you prefer):
+
 ```
 # uptime tracker (dmsg-discovery copy); v3 = with the daily timeline
-curl -x socks5h://127.0.0.1:4445 'http://<dmsgd-pk>.dmsg:80/uptimes?v=v3'
+curl -x socks5h://127.0.0.1:4445 'http://dmsgd.dmsg/uptimes?v=v3'
 # service discovery — list VPN servers
-curl -x socks5h://127.0.0.1:4445 'http://<sd-pk>.dmsg:80/api/services?type=vpn'
+curl -x socks5h://127.0.0.1:4445 'http://sd.dmsg/api/services?type=vpn'
 # transport discovery — all transports
-curl -x socks5h://127.0.0.1:4445 'http://<tpd-pk>.dmsg:80/all-transports'
+curl -x socks5h://127.0.0.1:4445 'http://tpd.dmsg/all-transports'
+# reward system
+curl -x socks5h://127.0.0.1:4445 'http://reward.dmsg/'
 ```
 
-Deployment service public keys live in the embedded deployment config; `cli svc`
-and the per-command `--*url` flags also surface them.
+The aliases are auto-derived from the visor config; the raw public keys also live
+in the embedded deployment config, which `cli svc` and the per-command `--*url`
+flags surface.
 
 ## From a browser
 

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -296,6 +296,8 @@ func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
 	if conf.UptimeTracker != nil {
 		add("ut", conf.UptimeTracker.AddrDmsg, conf.UptimeTracker.Addr)
 	}
+	// Reward system (top-level config fields, not a sub-block).
+	add("reward", conf.RewardSystemDmsg, conf.RewardSystem)
 
 	// Setup nodes are PK lists (not URLs) that serve /health over a dialable
 	// dmsg stream — verified reachable through the resolving proxy. Index them

--- a/pkg/visor/embedded_dmsgweb_test.go
+++ b/pkg/visor/embedded_dmsgweb_test.go
@@ -27,6 +27,7 @@ func TestServiceAliasMap(t *testing.T) {
 	rfURL, rfPK := dmsgURL(t)
 	sdURL, sdPK := dmsgURL(t)
 	dmsgdURL, dmsgdPK := dmsgURL(t)
+	rewardURL, rewardPK := dmsgURL(t)
 
 	conf := &visorconfig.V1{
 		Dmsg: &dmsgspec.DmsgConfig{DiscoveryDmsg: dmsgdURL},
@@ -35,9 +36,10 @@ func TestServiceAliasMap(t *testing.T) {
 			AddressResolverDmsg: arURL,
 			// AddressResolver (plain) left empty on purpose
 		},
-		Routing:       &visorconfig.Routing{RouteFinderDmsg: rfURL},
-		Launcher:      &visorconfig.Launcher{ServiceDiscDmsg: sdURL},
-		UptimeTracker: &visorconfig.UptimeTracker{Addr: "http://ut.skycoin.com"}, // HTTP only → omitted
+		Routing:          &visorconfig.Routing{RouteFinderDmsg: rfURL},
+		Launcher:         &visorconfig.Launcher{ServiceDiscDmsg: sdURL},
+		UptimeTracker:    &visorconfig.UptimeTracker{Addr: "http://ut.skycoin.com"}, // HTTP only → omitted
+		RewardSystemDmsg: rewardURL,
 	}
 
 	m := serviceAliasMap(conf)
@@ -47,10 +49,11 @@ func TestServiceAliasMap(t *testing.T) {
 	assert.Equal(t, arPK, m["ar"].Hex())
 	assert.Equal(t, rfPK, m["rf"].Hex())
 	assert.Equal(t, sdPK, m["sd"].Hex())
+	assert.Equal(t, rewardPK, m["reward"].Hex())
 
 	_, hasUT := m["ut"]
 	assert.False(t, hasUT, "HTTP-only uptime tracker must not be aliased")
-	assert.Len(t, m, 5, "exactly the 5 resolvable services")
+	assert.Len(t, m, 6, "exactly the 6 resolvable services")
 }
 
 // TestServiceAliasMapSetupNodes covers the PK-list setup nodes: indexed aliases


### PR DESCRIPTION
Follow-up to the resolving-proxy service-alias work.

## What

- **`reward` alias** — adds the reward system to the resolving proxy's service-alias map, derived from the top-level `RewardSystemDmsg` config field. The reward system's HTTP API is now reachable as `reward.dmsg` (over SOCKS5), the same way `dmsgd`/`tpd`/`ar`/`rf`/`sd`/`ut` already are.
- **Documentation** — `docs/guides/resolving-proxy.md` gained a `Service aliases` section that was previously undocumented: a table of every auto-derived alias (including the `rsn*`/`tsn*` setup nodes and the live `dmsg*` server list), how each is sourced, the fail-closed behaviour for unknown labels, and the `skywire`-wins-on-collision rule. The deployment-service `curl` examples now use the aliases (`tpd.dmsg`, `sd.dmsg`, …) instead of raw-PK placeholders.

## Why

The aliases are auto-derived from the visor config and there was no user-facing documentation for them. The reward system was the one configured deployment service still missing an alias.

## Test

- `TestServiceAliasMap` extended to assert the `reward` alias resolves to `RewardSystemDmsg` and that the map holds exactly the resolvable services.
- `go build ./pkg/visor/` + `go test ./pkg/visor/` green; `golangci-lint` clean on the changed file.