### PR TITLE
fix(resolver): rename reward alias to plural 'rewards'

### DIFF
--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -121,7 +121,7 @@ service's HTTP API by name instead of its 66-char public key. They're
 | `rf` | route finder |
 | `sd` | service discovery |
 | `ut` | uptime tracker |
-| `reward` | reward system |
+| `rewards` | reward system |
 | `rsn`, `rsn0`, `rsn1`, … | route setup nodes (bare label = the first) |
 | `tsn`, `tsn0`, `tsn1`, … | transport setup nodes (bare label = the first) |
 | `dmsg0`, `dmsg1`, … | dmsg servers (the **live** discovery list, sorted by PK) |
@@ -163,7 +163,7 @@ curl -x socks5h://127.0.0.1:4445 'http://sd.dmsg/api/services?type=vpn'
 # transport discovery — all transports
 curl -x socks5h://127.0.0.1:4445 'http://tpd.dmsg/all-transports'
 # reward system
-curl -x socks5h://127.0.0.1:4445 'http://reward.dmsg/'
+curl -x socks5h://127.0.0.1:4445 'http://rewards.dmsg/'
 ```
 
 The aliases are auto-derived from the visor config; the raw public keys also live

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -297,7 +297,7 @@ func serviceAliasMap(conf *visorconfig.V1) map[string]cipher.PubKey {
 		add("ut", conf.UptimeTracker.AddrDmsg, conf.UptimeTracker.Addr)
 	}
 	// Reward system (top-level config fields, not a sub-block).
-	add("reward", conf.RewardSystemDmsg, conf.RewardSystem)
+	add("rewards", conf.RewardSystemDmsg, conf.RewardSystem)
 
 	// Setup nodes are PK lists (not URLs) that serve /health over a dialable
 	// dmsg stream — verified reachable through the resolving proxy. Index them

--- a/pkg/visor/embedded_dmsgweb_test.go
+++ b/pkg/visor/embedded_dmsgweb_test.go
@@ -49,7 +49,7 @@ func TestServiceAliasMap(t *testing.T) {
 	assert.Equal(t, arPK, m["ar"].Hex())
 	assert.Equal(t, rfPK, m["rf"].Hex())
 	assert.Equal(t, sdPK, m["sd"].Hex())
-	assert.Equal(t, rewardPK, m["reward"].Hex())
+	assert.Equal(t, rewardPK, m["rewards"].Hex())
 
 	_, hasUT := m["ut"]
 	assert.False(t, hasUT, "HTTP-only uptime tracker must not be aliased")


### PR DESCRIPTION
Follow-up to #3132. Renames the resolving-proxy reward-system alias from singular `reward` to plural **`rewards`**, to match the user-facing `skywire cli rewards` namespace (including `cli rewards ui`) and the dominant `/rewards` HTTP path. Still derived from `RewardSystemDmsg`; reachable as `rewards.dmsg`.

Updates the alias, the `TestServiceAliasMap` assertion, and the docs table + curl example in `docs/guides/resolving-proxy.md`.

`go build`/`go test ./pkg/visor/` green.