### PR TITLE
feat(resolver): home.dmsg directory page of all resolver aliases

### DIFF
--- a/docs/guides/resolving-proxy.md
+++ b/docs/guides/resolving-proxy.md
@@ -141,6 +141,20 @@ Notes:
 - An unknown label still **fails closed** — it's neither a PK nor a known alias,
   so it resolves to nothing rather than somewhere wrong.
 
+### Directory page (`home.dmsg`)
+
+`http://home.dmsg/` is a **directory of every alias above**, rendered by the
+resolver itself so you don't have to remember the names. Open it in a browser
+(with the SOCKS5 proxy set) and click through to any service.
+
+It is **synthetic and proxy-only**: the resolver generates the page in-process
+and serves it straight back over the SOCKS5 connection — nothing is dialed out,
+and the visor does **not** serve it on any real port. It exists only *as seen
+through the proxy*. The service links point at each service's `/health` endpoint
+(deployment services don't serve `/`), while the `skywire` link opens your
+visor's real landing page at `/`. `home` is a reserved label (it shadows any
+same-named configured alias).
+
 ## From `curl`
 
 Use `socks5h://` (the `h` makes the **proxy** resolve the hostname — required for

--- a/pkg/dmsgweb/home.go
+++ b/pkg/dmsgweb/home.go
@@ -1,0 +1,154 @@
+package dmsgweb
+
+import (
+	"bufio"
+	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// HomeAlias is a reserved resolver label that serves a synthetic directory of
+// every alias this resolver knows — a navigation index for the proxy. It is
+// generated in-process by the resolver and is reachable ONLY through the proxy
+// (e.g. http://home.dmsg/); the visor never serves it on a real port. The label
+// is reserved: it shadows any same-named configured alias.
+const HomeAlias = "home"
+
+var (
+	homeServerLabelRe = regexp.MustCompile(`^dmsg[0-9]+$`)
+	homeSetupLabelRe  = regexp.MustCompile(`^(?:rsn|tsn)[0-9]*$`)
+)
+
+// isHomeHost reports whether host (sans the resolver suffix) is exactly the
+// reserved home label — so "home.dmsg" matches but "x.home.dmsg" does not.
+func isHomeHost(host, suffix string) bool {
+	return strings.EqualFold(strings.TrimSuffix(host, suffix), HomeAlias)
+}
+
+type homeEntry struct {
+	label string
+	pk    cipher.PubKey
+}
+
+// renderHomePage builds the self-contained HTML directory from the resolver's
+// alias map. Links use the resolver's own suffix so they resolve back through
+// the same proxy. Aliases are grouped (this visor / deployment services / setup
+// nodes / dmsg servers) and naturally sorted so dmsg2 precedes dmsg10.
+func renderHomePage(aliases map[string]cipher.PubKey, suffix string, localPK cipher.PubKey) []byte {
+	var self, services, setup, servers []homeEntry
+	for label, pk := range aliases {
+		e := homeEntry{label, pk}
+		switch {
+		case localPK != (cipher.PubKey{}) && pk == localPK:
+			self = append(self, e)
+		case homeServerLabelRe.MatchString(label):
+			servers = append(servers, e)
+		case homeSetupLabelRe.MatchString(label):
+			setup = append(setup, e)
+		default:
+			services = append(services, e)
+		}
+	}
+	for _, g := range [][]homeEntry{self, services, setup, servers} {
+		sort.Slice(g, func(i, j int) bool { return homeNatLess(g[i].label, g[j].label) })
+	}
+
+	var b strings.Builder
+	b.WriteString("<!doctype html><html lang=en><head><meta charset=utf-8>")
+	b.WriteString(`<meta name=viewport content="width=device-width, initial-scale=1">`)
+	b.WriteString("<title>skywire resolver</title><style>")
+	b.WriteString("body{font:14px/1.5 system-ui,sans-serif;max-width:48rem;margin:2rem auto;padding:0 1rem;color:#222}")
+	b.WriteString("h1{font-size:1.4rem}h2{font-size:1rem;margin:1.5rem 0 .3rem;color:#555}")
+	b.WriteString("ul{list-style:none;padding:0;margin:0}li{padding:.15rem 0}")
+	b.WriteString("a{text-decoration:none;font-weight:600}code{color:#999;font-size:11px;word-break:break-all}")
+	b.WriteString("@media(prefers-color-scheme:dark){body{background:#1a1a1a;color:#ddd}h2{color:#aaa}code{color:#777}}")
+	b.WriteString("</style></head><body>")
+	b.WriteString("<h1>skywire resolver</h1>")
+	b.WriteString("<p>Services reachable by name through this resolving proxy. Each link tunnels over the mesh — no clearnet hop.</p>")
+	// The visor serves a real landing page at "/"; the deployment services,
+	// setup nodes and dmsg servers don't, but they all answer "/health".
+	writeHomeGroup(&b, "This visor", self, suffix, "/")
+	writeHomeGroup(&b, "Deployment services", services, suffix, "/health")
+	writeHomeGroup(&b, "Setup nodes", setup, suffix, "/health")
+	writeHomeGroup(&b, "dmsg servers", servers, suffix, "/health")
+	if len(self)+len(services)+len(setup)+len(servers) == 0 {
+		b.WriteString("<p><em>No aliases configured.</em></p>")
+	}
+	b.WriteString("</body></html>")
+	return []byte(b.String())
+}
+
+func writeHomeGroup(b *strings.Builder, title string, es []homeEntry, suffix, path string) {
+	if len(es) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "<h2>%s</h2><ul>", html.EscapeString(title))
+	for _, e := range es {
+		host := html.EscapeString(e.label + suffix)
+		href := html.EscapeString("http://" + e.label + suffix + path)
+		fmt.Fprintf(b, `<li><a href="%s">%s%s</a> <code>%s</code></li>`, href, host, html.EscapeString(path), e.pk.Hex())
+	}
+	b.WriteString("</ul>")
+}
+
+// homeNatLess compares labels with trailing-number awareness so an indexed set
+// (dmsg0, dmsg2, dmsg10) sorts numerically rather than lexically.
+func homeNatLess(a, b string) bool {
+	ap, an := homeSplitNum(a)
+	bp, bn := homeSplitNum(b)
+	if ap != bp {
+		return ap < bp
+	}
+	if an != bn {
+		return an < bn
+	}
+	return a < b
+}
+
+func homeSplitNum(s string) (string, int) {
+	i := len(s)
+	for i > 0 && s[i-1] >= '0' && s[i-1] <= '9' {
+		i--
+	}
+	if i == len(s) {
+		return s, -1
+	}
+	n, _ := strconv.Atoi(s[i:]) //nolint:errcheck // s[i:] is all digits by construction
+	return s[:i], n
+}
+
+// serveHomeInProcess returns one end of an in-memory pipe; the other end is fed
+// the rendered home page as a single HTTP/1.1 response. Nothing is dialed out —
+// the page exists only as seen through the proxy. The returned conn is handed to
+// go-socks5, which pipes the browser's request in and the response back.
+func serveHomeInProcess(aliases map[string]cipher.PubKey, suffix string, localPK cipher.PubKey) net.Conn {
+	body := renderHomePage(aliases, suffix, localPK)
+	srvConn, cliConn := net.Pipe()
+	go func() {
+		defer srvConn.Close() //nolint:errcheck
+		br := bufio.NewReader(srvConn)
+		// Consume the request line + headers so the peer's write completes;
+		// the path is ignored (the directory is the same for every path).
+		if _, err := http.ReadRequest(br); err != nil {
+			return
+		}
+		var resp strings.Builder
+		resp.WriteString("HTTP/1.1 200 OK\r\n")
+		resp.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+		fmt.Fprintf(&resp, "Content-Length: %d\r\n", len(body))
+		resp.WriteString("Cache-Control: no-store\r\n")
+		resp.WriteString("Connection: close\r\n\r\n")
+		if _, err := srvConn.Write([]byte(resp.String())); err != nil {
+			return
+		}
+		_, _ = srvConn.Write(body) //nolint:errcheck // best-effort; peer may have gone
+	}()
+	return cliConn
+}

--- a/pkg/dmsgweb/home_test.go
+++ b/pkg/dmsgweb/home_test.go
@@ -1,0 +1,89 @@
+package dmsgweb
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestIsHomeHost(t *testing.T) {
+	assert.True(t, isHomeHost("home.dmsg", ".dmsg"))
+	assert.True(t, isHomeHost("HOME.dmsg", ".dmsg"))
+	assert.True(t, isHomeHost("home.skynet", ".skynet"))
+	assert.False(t, isHomeHost("x.home.dmsg", ".dmsg"), "a vhost left of home is not the reserved label")
+	assert.False(t, isHomeHost("tpd.dmsg", ".dmsg"))
+}
+
+func TestRenderHomePage(t *testing.T) {
+	selfPK, _ := cipher.GenerateKeyPair()
+	tpdPK, _ := cipher.GenerateKeyPair()
+	dmsg0PK, _ := cipher.GenerateKeyPair()
+	rsnPK, _ := cipher.GenerateKeyPair()
+
+	aliases := map[string]cipher.PubKey{
+		"skywire": selfPK,
+		"tpd":     tpdPK,
+		"dmsg0":   dmsg0PK,
+		"rsn":     rsnPK,
+	}
+	page := string(renderHomePage(aliases, ".dmsg", selfPK))
+
+	// Grouped under the right headings.
+	assert.Contains(t, page, "This visor")
+	assert.Contains(t, page, "Deployment services")
+	assert.Contains(t, page, "Setup nodes")
+	assert.Contains(t, page, "dmsg servers")
+
+	// Service links target /health (services don't serve "/"); the visor's own
+	// landing page does, so the self link stays at "/".
+	assert.Contains(t, page, `href="http://tpd.dmsg/health"`)
+	assert.Contains(t, page, `href="http://skywire.dmsg/"`)
+	assert.Contains(t, page, `href="http://dmsg0.dmsg/health"`)
+
+	// Full 66-char PKs, never truncated.
+	assert.Contains(t, page, tpdPK.Hex())
+	assert.Contains(t, page, selfPK.Hex())
+
+	// The self alias is in the "This visor" group, ahead of the service group.
+	assert.Less(t, strings.Index(page, "This visor"), strings.Index(page, "Deployment services"))
+}
+
+func TestRenderHomePageNatSort(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	aliases := map[string]cipher.PubKey{"dmsg0": pk, "dmsg2": pk, "dmsg10": pk}
+	page := string(renderHomePage(aliases, ".dmsg", cipher.PubKey{}))
+	i0, i2, i10 := strings.Index(page, "dmsg0.dmsg"), strings.Index(page, "dmsg2.dmsg"), strings.Index(page, "dmsg10.dmsg")
+	assert.True(t, i0 < i2 && i2 < i10, "dmsg2 must sort before dmsg10 (numeric, not lexical)")
+}
+
+func TestRenderHomePageEmpty(t *testing.T) {
+	page := string(renderHomePage(nil, ".dmsg", cipher.PubKey{}))
+	assert.Contains(t, page, "No aliases configured")
+}
+
+// TestServeHomeInProcess drives the in-memory pipe with a real HTTP request and
+// asserts a well-formed HTML response comes back — the path go-socks5 exercises.
+func TestServeHomeInProcess(t *testing.T) {
+	tpdPK, _ := cipher.GenerateKeyPair()
+	conn := serveHomeInProcess(map[string]cipher.PubKey{"tpd": tpdPK}, ".dmsg", cipher.PubKey{})
+	defer conn.Close() //nolint:errcheck
+
+	req, err := http.NewRequest(http.MethodGet, "http://home.dmsg/", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, req.Write(conn))
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	assert.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(body), `href="http://tpd.dmsg/health"`)
+}

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -276,6 +276,14 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			}
 
 			if _, ok := dialCtx.Value(dmsgResolverPortKey).(string); ok {
+				// Reserved synthetic directory: serve the alias index in-process.
+				// Never dials out and is not a real PK/alias, so intercept it
+				// before host resolution (which would fail closed on "home").
+				if isHomeHost(origHost, cfg.DomainSuffix) {
+					log.Debug("SOCKS5 → resolver home page (in-process)")
+					return &tcpAddrConn{Conn: serveHomeInProcess(cfg.Aliases, cfg.DomainSuffix, cfg.LocalPK)}, nil
+				}
+
 				vhost, route, dest, _, perr := skynetweb.ParseResolverHost(origHost, cfg.DomainSuffix, cfg.Aliases)
 				if perr != nil {
 					return nil, fmt.Errorf("invalid dmsg hostname %q: %w", origHost, perr)


### PR DESCRIPTION
Adds a reserved `home` label to the resolving proxy that serves a **directory of every alias the resolver knows** — a navigation index so you don't have to remember names or public keys. Open `http://home.dmsg/` in a browser (with the SOCKS5 proxy set) and click through.

Follow-up to the resolver service-alias work (#3127, #3132, #3133).

## Design

- **Synthetic and proxy-only.** The page is generated in-process in the resolver's SOCKS5 Dial path and written straight back over the connection. Nothing is dialed out, and the visor does **not** serve it on any real port — it exists only *as seen through the proxy*. (Unlike `skywire.dmsg`, which loopbacks to the visor's actual landing page.)
- **Per-group link targets.** Deployment services, setup nodes and dmsg servers don't serve `/`, so their links point at `/health`; the `skywire` self link opens the visor's real landing page at `/`.
- **Grouped + naturally sorted** (this visor / deployment services / setup nodes / dmsg servers; `dmsg2` before `dmsg10`). Full 66-char PKs shown, never truncated.
- `home` is a reserved label (shadows any same-named configured alias); intercepted before host resolution, which would otherwise fail closed on it.

## Test

- Unit: `TestIsHomeHost`, `TestRenderHomePage`, `TestRenderHomePageNatSort`, `TestRenderHomePageEmpty`, and `TestServeHomeInProcess` (drives the in-memory pipe with a real HTTP request and asserts a well-formed HTML response).
- `go build`/`go test ./pkg/dmsgweb/` green; `golangci-lint` clean.
- **Live-validated** on a local visor: `curl -x socks5h://127.0.0.1:4445 http://home.dmsg/` renders all groups with correct `/health` vs `/` links. Notably it works even while the dmsg fleet is degraded — confirming the in-process, no-dial-out property.

Documented in `docs/guides/resolving-proxy.md` (new "Directory page" subsection).