### PR TITLE
fix(service-discovery): chunk the by-type MGET to stop starving single-threaded redis

### DIFF
--- a/pkg/service-discovery/store/redis_store.go
+++ b/pkg/service-discovery/store/redis_store.go
@@ -23,6 +23,16 @@ var json = jsoniter.ConfigFastest
 const (
 	serviceKeyPrefix   = "service:"
 	serviceTypesSetKey = "service_types"
+
+	// mgetChunkSize bounds how many keys go into a single MGET. Redis is
+	// single-threaded, so one MGET over hundreds of keys (e.g. every
+	// service:skysocks:<pk>) blocks the server for the whole batch —
+	// ~40ms in production — starving every other client's command,
+	// including dmsg-discovery's tiny GET entry:<pk>. Issuing the fan-out
+	// in bounded batches lets redis interleave other clients between
+	// chunks. 256 keeps each MGET well under the starvation threshold
+	// while keeping round-trips low.
+	mgetChunkSize = 256
 )
 
 type redisStore struct {
@@ -145,6 +155,45 @@ func (s *redisStore) Service(ctx context.Context, sType string, addr servicedisc
 	return &service, nil
 }
 
+// mgetChunked issues MGET in bounded batches (mgetChunkSize) and concatenates
+// the results in key order, so a large fan-out does not block single-threaded
+// redis for the whole batch at once. The returned slice has exactly len(keys)
+// entries (nil for missing keys), preserving positional correspondence with
+// keys so callers can map results back by index.
+func (s *redisStore) mgetChunked(ctx context.Context, keys []string) ([]interface{}, error) {
+	values := make([]interface{}, 0, len(keys))
+	for _, batch := range chunkKeys(keys, mgetChunkSize) {
+		got, err := s.client.MGet(ctx, batch...).Result()
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, got...)
+	}
+	return values, nil
+}
+
+// chunkKeys splits keys into consecutive batches of at most size, in order and
+// with no key dropped or duplicated, so concatenating the per-batch MGET
+// results reproduces the single-MGET result positionally. A non-positive size
+// yields a single batch (no chunking).
+func chunkKeys(keys []string, size int) [][]string {
+	if len(keys) == 0 {
+		return nil
+	}
+	if size <= 0 || len(keys) <= size {
+		return [][]string{keys}
+	}
+	chunks := make([][]string, 0, (len(keys)+size-1)/size)
+	for start := 0; start < len(keys); start += size {
+		end := start + size
+		if end > len(keys) {
+			end = len(keys)
+		}
+		chunks = append(chunks, keys[start:end])
+	}
+	return chunks
+}
+
 func (s *redisStore) Services(ctx context.Context, sType, version, country string) ([]servicedisc.Service, *servicedisc.HTTPError) {
 	setKey := s.serviceTypeSetKey(sType)
 
@@ -162,7 +211,7 @@ func (s *redisStore) Services(ctx context.Context, sType, version, country strin
 		keys = append(keys, fmt.Sprintf("%s%s:%s", serviceKeyPrefix, sType, pk))
 	}
 
-	values, err := s.client.MGet(ctx, keys...).Result()
+	values, err := s.mgetChunked(ctx, keys)
 	if err != nil {
 		return nil, s.processErr(err, http.StatusInternalServerError)
 	}

--- a/pkg/service-discovery/store/redis_store_test.go
+++ b/pkg/service-discovery/store/redis_store_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestChunkKeys verifies the MGET batching math: every key appears exactly once,
+// in order, no batch exceeds the size, and edge cases (empty, <size, ==size,
+// exact multiple, off-by-one, non-positive size) behave.
+func TestChunkKeys(t *testing.T) {
+	mk := func(n int) []string {
+		ks := make([]string, n)
+		for i := range ks {
+			ks[i] = fmt.Sprintf("k%d", i)
+		}
+		return ks
+	}
+
+	cases := []struct {
+		name       string
+		n, size    int
+		wantChunks int
+	}{
+		{"empty", 0, 256, 0},
+		{"single", 1, 256, 1},
+		{"under", 100, 256, 1},
+		{"exactly_size", 256, 256, 1},
+		{"one_over", 257, 256, 2},
+		{"exact_multiple", 512, 256, 2},
+		{"many", 1000, 256, 4},
+		{"size_one", 5, 1, 5},
+		{"nonpositive_size", 10, 0, 1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			keys := mk(c.n)
+			chunks := chunkKeys(keys, c.size)
+			assert.Len(t, chunks, c.wantChunks)
+
+			// Reassembling the chunks must reproduce the input exactly (order
+			// preserved, nothing dropped or duplicated) — that's what keeps the
+			// concatenated MGET result positionally aligned with the keys.
+			var flat []string
+			for _, ch := range chunks {
+				assert.LessOrEqual(t, len(ch), maxBatch(c.size), "no chunk exceeds size")
+				assert.NotEmpty(t, ch, "no empty chunks")
+				flat = append(flat, ch...)
+			}
+			if c.n == 0 {
+				assert.Empty(t, flat)
+			} else {
+				assert.Equal(t, keys, flat)
+			}
+		})
+	}
+}
+
+// maxBatch is the largest allowed chunk for a given size (a non-positive size
+// means "single batch", so any length is allowed).
+func maxBatch(size int) int {
+	if size <= 0 {
+		return 1 << 30
+	}
+	return size
+}


### PR DESCRIPTION
Identified live on the dmsg-discovery host (DMSGD + service-discovery share a redis).

## Problem

`redisStore.Services(sType, …)` resolves a service type by `SMembers` → **one `MGet` over every member key** — hundreds of `service:skysocks:<pk>` keys in production. Redis is single-threaded, so that single command occupies the server for the whole batch (**~40ms measured**), during which *every other client* blocks — including dmsg-discovery's tiny `GET entry:<pk>`. Under load this compounds into the request-context cancellations that surface as dmsg-discovery 500s (`context canceled` mid-redis-call).

## Fix

Issue the fan-out in bounded batches (`mgetChunkSize = 256`) via a small `mgetChunked` helper, so redis can interleave other clients' commands between chunks instead of being monopolized by one giant `MGET`. No behaviour change: `chunkKeys` preserves key order with nothing dropped or duplicated, so the concatenated result stays positionally aligned with `keys` (the existing nil-key cleanup-by-index path is unaffected).

Scope is deliberately just the hundreds-of-keys by-type path. `ServicesByPK` (one visor's ~3–5 type keys) and the history-timeline MGET (~30 day-bitmaps) are already bounded and left alone.

## Test

`TestChunkKeys` covers the batching math — order preservation, full coverage (no key dropped/duplicated), no batch exceeds the size, and edge cases (empty, &lt;size, ==size, exact multiple, off-by-one, size=1, non-positive size). `go build` + `golangci-lint` clean.

## Follow-up (not in this PR)

This caps per-command blast radius but not query *frequency* (~946 redis ops/sec, no cache on the by-type result). A short-TTL cache on `Services()` (mirroring transport-discovery's `all_transports_cache`) would cut the op rate itself — tracked separately.