### PR TITLE
fix(dmsg): converge visor to a single dmsg client (eliminate self-eviction storm)

### DIFF
--- a/pkg/dmsg/dmsgclient/cli_fallback.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback.go
@@ -365,12 +365,18 @@ func (f *fallbackDiscClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc
 	return f.http.Entry(ctx, pk)
 }
 
-// PostEntry: registering variant publishes to HTTP discovery; service
-// variant no-ops via the direct client.
+// PostEntry ALWAYS no-ops via the direct client — even in the registering
+// variant. The dmsg serve loop calls PostEntry PRE-session
+// (initilizeClientEntry, "Initial post entry") BEFORE any session exists;
+// routing that to HTTP-over-dmsg would dial dmsg-disc over the client's own
+// not-yet-established sessions, blocking the serve loop on a chicken-egg and
+// starving the rest of the server-dialing loop — the visor gets stuck on a
+// single server / wedges. Durable registration is done by the POST-session
+// updateClientEntry loop via PutEntry (runs only after sessions exist); the
+// dmsg-disc setEntry handler upserts, so PutEntry creates the entry. Mirrors
+// StartDmsgSelfHostedDisc, whose single client works precisely because its
+// PostEntry no-ops and returns instantly so sessions can establish.
 func (f *fallbackDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
-	if f.register {
-		return f.http.PostEntry(ctx, entry)
-	}
 	return f.direct.PostEntry(ctx, entry)
 }
 

--- a/pkg/dmsg/dmsgclient/cli_fallback.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback.go
@@ -311,17 +311,44 @@ type fallbackDiscClient struct {
 	direct disc.APIClient
 	http   disc.APIClient
 	log    *logging.Logger
+	// register routes the WRITE methods (Put/Post/DelEntry). When false
+	// (the service variant), writes go to the direct client, which no-ops —
+	// services run as direct clients and don't publish to dmsg-discovery.
+	// When true (the visor variant), writes go to the HTTP client so the
+	// caller's entry IS published to the real dmsg-discovery, while READS
+	// still resolve direct-first. This lets one client both register itself
+	// AND resolve seeded service/server PKs statically (no HTTP-over-dmsg
+	// round-trip — the round-trip to the entry-less, root-of-trust dmsg-disc
+	// is what hot-loops when the whole disc is dmsgfirst).
+	register bool
 }
 
 // NewFallbackDiscClient creates a discovery client that tries direct first, then HTTP.
 // Used by callers that need to dial arbitrary client PKs registered in the real
 // dmsg-discovery while keeping a pre-loaded direct.Client for the bootstrap server
 // list (and any synthetic/seeded entries the caller wants to short-circuit).
+// WRITES no-op (direct) — the non-registering "service" variant.
 func NewFallbackDiscClient(direct, http disc.APIClient, log *logging.Logger) disc.APIClient {
 	return &fallbackDiscClient{
 		direct: direct,
 		http:   http,
 		log:    log,
+	}
+}
+
+// NewRegisteringFallbackDiscClient is the visor variant: READS resolve
+// direct-first (seeded service/server PKs short-circuit, no HTTP-over-dmsg
+// round-trip), but WRITES (Put/Post/DelEntry) go to the HTTP client so the
+// visor's own entry IS published to the real dmsg-discovery. This lets a
+// SINGLE dmsg client both register itself and resolve bootstrap PKs
+// statically — replacing the two-client (dmsgC discovery + dmsgDC direct)
+// setup whose shared PK self-evicts on the dmsg servers.
+func NewRegisteringFallbackDiscClient(direct, http disc.APIClient, log *logging.Logger) disc.APIClient {
+	return &fallbackDiscClient{
+		direct:   direct,
+		http:     http,
+		log:      log,
+		register: true,
 	}
 }
 
@@ -338,8 +365,12 @@ func (f *fallbackDiscClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc
 	return f.http.Entry(ctx, pk)
 }
 
-// PostEntry delegates to direct client
+// PostEntry: registering variant publishes to HTTP discovery; service
+// variant no-ops via the direct client.
 func (f *fallbackDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
+	if f.register {
+		return f.http.PostEntry(ctx, entry)
+	}
 	return f.direct.PostEntry(ctx, entry)
 }
 
@@ -355,11 +386,18 @@ func (f *fallbackDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) e
 // the visor's direct.Client already knows the service PK → all-servers
 // mapping at startup.
 func (f *fallbackDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
+	if f.register {
+		return f.http.PutEntry(ctx, sk, entry)
+	}
 	return f.direct.PutEntry(ctx, sk, entry)
 }
 
-// DelEntry delegates to direct client
+// DelEntry: registering variant removes from HTTP discovery; service
+// variant no-ops via the direct client.
 func (f *fallbackDiscClient) DelEntry(ctx context.Context, entry *disc.Entry) error {
+	if f.register {
+		return f.http.DelEntry(ctx, entry)
+	}
 	return f.direct.DelEntry(ctx, entry)
 }
 

--- a/pkg/dmsg/dmsgclient/cli_fallback_register_test.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback_register_test.go
@@ -55,16 +55,19 @@ func TestFallbackDiscClient_WriteRouting(t *testing.T) {
 		assert.Zero(t, h.puts+h.posts+h.del, "service variant must NOT publish to HTTP discovery")
 	})
 
-	t.Run("registering variant writes go to HTTP (publish)", func(t *testing.T) {
+	t.Run("registering: Put/DelEntry publish to HTTP, PostEntry no-ops", func(t *testing.T) {
 		d, h := &recordingDisc{}, &recordingDisc{}
 		c := NewRegisteringFallbackDiscClient(d, h, log)
 		require.NoError(t, c.PutEntry(context.Background(), sk, e))
 		require.NoError(t, c.PostEntry(context.Background(), e))
 		require.NoError(t, c.DelEntry(context.Background(), e))
-		assert.Equal(t, 1, h.puts)
-		assert.Equal(t, 1, h.posts)
+		assert.Equal(t, 1, h.puts, "PutEntry = durable post-session registration")
 		assert.Equal(t, 1, h.del)
-		assert.Zero(t, d.puts+d.posts+d.del, "registering variant must NOT write to the direct no-op client")
+		// PostEntry ALWAYS no-ops (direct): it's the PRE-session call that would
+		// otherwise wedge the dmsg serve loop. PutEntry (post-session) registers.
+		assert.Equal(t, 1, d.posts, "PostEntry no-ops via direct even when registering")
+		assert.Zero(t, h.posts, "PostEntry must NOT block-publish pre-session")
+		assert.Zero(t, d.puts+d.del, "Put/DelEntry must NOT hit the direct no-op client")
 	})
 }
 

--- a/pkg/dmsg/dmsgclient/cli_fallback_register_test.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback_register_test.go
@@ -1,0 +1,106 @@
+package dmsgclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// recordingDisc embeds disc.APIClient so only the methods exercised below need
+// implementing; any other call would nil-panic (and would be a test bug).
+type recordingDisc struct {
+	disc.APIClient
+	entry            *disc.Entry // returned by Entry when non-nil
+	puts, posts, del int
+	entryCalls       int
+}
+
+func (r *recordingDisc) Entry(_ context.Context, pk cipher.PubKey) (*disc.Entry, error) {
+	r.entryCalls++
+	if r.entry != nil && r.entry.Static == pk {
+		return r.entry, nil
+	}
+	return &disc.Entry{}, nil // not found (Static != pk)
+}
+func (r *recordingDisc) PutEntry(_ context.Context, _ cipher.SecKey, _ *disc.Entry) error {
+	r.puts++
+	return nil
+}
+func (r *recordingDisc) PostEntry(_ context.Context, _ *disc.Entry) error { r.posts++; return nil }
+func (r *recordingDisc) DelEntry(_ context.Context, _ *disc.Entry) error  { r.del++; return nil }
+
+// TestFallbackDiscClient_WriteRouting is the crux of the single-client
+// convergence: the registering variant must publish writes to HTTP discovery
+// (so the visor registers) while the service variant no-ops via direct.
+func TestFallbackDiscClient_WriteRouting(t *testing.T) {
+	log := logging.MustGetLogger("test")
+	pk, sk := cipher.GenerateKeyPair()
+	e := &disc.Entry{Static: pk}
+
+	t.Run("service variant writes go to direct (no-op)", func(t *testing.T) {
+		d, h := &recordingDisc{}, &recordingDisc{}
+		c := NewFallbackDiscClient(d, h, log)
+		require.NoError(t, c.PutEntry(context.Background(), sk, e))
+		require.NoError(t, c.PostEntry(context.Background(), e))
+		require.NoError(t, c.DelEntry(context.Background(), e))
+		assert.Equal(t, 1, d.puts)
+		assert.Equal(t, 1, d.posts)
+		assert.Equal(t, 1, d.del)
+		assert.Zero(t, h.puts+h.posts+h.del, "service variant must NOT publish to HTTP discovery")
+	})
+
+	t.Run("registering variant writes go to HTTP (publish)", func(t *testing.T) {
+		d, h := &recordingDisc{}, &recordingDisc{}
+		c := NewRegisteringFallbackDiscClient(d, h, log)
+		require.NoError(t, c.PutEntry(context.Background(), sk, e))
+		require.NoError(t, c.PostEntry(context.Background(), e))
+		require.NoError(t, c.DelEntry(context.Background(), e))
+		assert.Equal(t, 1, h.puts)
+		assert.Equal(t, 1, h.posts)
+		assert.Equal(t, 1, h.del)
+		assert.Zero(t, d.puts+d.posts+d.del, "registering variant must NOT write to the direct no-op client")
+	})
+}
+
+// TestFallbackDiscClient_ReadDirectFirst confirms reads resolve direct-first in
+// BOTH variants — that's what keeps seeded service/dmsg-disc PKs off the
+// HTTP-over-dmsg round-trip that hot-loops.
+func TestFallbackDiscClient_ReadDirectFirst(t *testing.T) {
+	log := logging.MustGetLogger("test")
+	pk, _ := cipher.GenerateKeyPair()
+	seeded := &disc.Entry{Static: pk}
+
+	for _, tc := range []struct {
+		name string
+		ctor func(direct, http disc.APIClient, log *logging.Logger) disc.APIClient
+	}{
+		{"service", NewFallbackDiscClient},
+		{"registering", NewRegisteringFallbackDiscClient},
+	} {
+		t.Run(tc.name+" hit: direct resolves, http untouched", func(t *testing.T) {
+			d, h := &recordingDisc{entry: seeded}, &recordingDisc{}
+			c := tc.ctor(d, h, log)
+			got, err := c.Entry(context.Background(), pk)
+			require.NoError(t, err)
+			assert.Equal(t, pk, got.Static)
+			assert.Equal(t, 1, d.entryCalls)
+			assert.Zero(t, h.entryCalls, "a direct (seeded) hit must NOT round-trip to HTTP")
+		})
+
+		t.Run(tc.name+" miss: falls back to http", func(t *testing.T) {
+			d, h := &recordingDisc{}, &recordingDisc{entry: seeded} // direct misses, http has it
+			c := tc.ctor(d, h, log)
+			got, err := c.Entry(context.Background(), pk)
+			require.NoError(t, err)
+			assert.Equal(t, pk, got.Static)
+			assert.Equal(t, 1, d.entryCalls)
+			assert.Equal(t, 1, h.entryCalls, "an unknown PK must fall back to HTTP discovery")
+		})
+	}
+}

--- a/pkg/dmsgc/dmsgc.go
+++ b/pkg/dmsgc/dmsgc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/dmsgc/spec"
 	"github.com/skycoin/skywire/pkg/logging"
 )
@@ -61,7 +62,19 @@ func (d *lanPriorityDisc) AllServers(ctx context.Context) ([]*disc.Entry, error)
 }
 
 // New makes new dmsg client from configuration
-func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, masterLogger *logging.MasterLogger) *dmsg.Client {
+// New builds the visor's SINGLE dmsg client. directClient (when non-nil)
+// carries the preloaded static entries — every dmsg server + a synthetic
+// dmsg-disc entry + the visor's own — so this one client connects and reaches
+// dmsg-disc with no discovery round-trip, replacing the legacy second "direct"
+// client (dmsgDC) that shared this PK and self-evicted on the servers
+// (newest-session-wins). directOnly selects the mode: false (default) =
+// "discovery" (registering fallback: direct-first reads + the visor publishes
+// its entry to dmsg-disc over its own sessions); true = "direct-only" (static
+// direct resolution only, no dmsg-discovery, no registration — experimental).
+// The caller wires httpC.Transport = MakeHTTPTransport(ctx, dmsgC) AFTER this
+// returns, so discovery HTTP rides the client's own sessions (the empty
+// transport is never used before Serve).
+func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *DmsgConfig, httpC *http.Client, directClient disc.APIClient, directOnly bool, masterLogger *logging.MasterLogger) *dmsg.Client {
 	primary := conf.Primary()
 	dmsgConf := &dmsg.Config{
 		MinSessions: primary.SessionsCount,
@@ -89,7 +102,15 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 		deployments = []Deployment{{}}
 	}
 
-	primaryC := disc.NewHTTP(deployments[0].Discovery, httpC, masterLogger.PackageLogger("dmsgC:disc"))
+	// Prefer the plain-HTTP discovery URL; in dmsg-only deployments it is
+	// empty, so fall back to the dmsg:// URL — httpC's transport is dmsg-HTTP
+	// over this very client (wired by the caller post-construction), so the
+	// discovery lookups ride the client's own sessions.
+	discURL := deployments[0].Discovery
+	if discURL == "" {
+		discURL = deployments[0].DiscoveryDmsg
+	}
+	primaryC := disc.NewHTTP(discURL, httpC, masterLogger.PackageLogger("dmsgC:disc"))
 	// When the operator (or a hypervisor's auto-discovery push) has set
 	// HypervisorDiscovery, wrap the public discovery as the fallback
 	// behind it. The hypervisor's proxy serves locally-known PKs from
@@ -107,6 +128,20 @@ func New(pk cipher.PubKey, sk cipher.SecKey, eb *appevent.Broadcaster, conf *Dms
 	if len(primary.LANServers) > 0 {
 		masterLogger.PackageLogger("dmsgC").Infof("Using %d LAN DMSG servers (tried first)", len(primary.LANServers))
 		primaryC = &lanPriorityDisc{APIClient: primaryC, lanEntries: primary.LANServers}
+	}
+
+	// Single-client convergence: resolve seeded direct entries (servers +
+	// dmsg-disc + services) STATICALLY (no HTTP-over-dmsg round-trip to the
+	// entry-less, root-of-trust dmsg-disc — that round-trip is what hot-loops),
+	// while still registering over the client's own sessions. This makes the
+	// ONE dmsgC subsume what the separate dmsgDC used to do, so no second
+	// same-PK client competes for the per-server session slot.
+	if directClient != nil {
+		if directOnly {
+			primaryC = directClient
+		} else {
+			primaryC = dmsgclient.NewRegisteringFallbackDiscClient(directClient, primaryC, masterLogger.PackageLogger("dmsgC:disc:fallback"))
+		}
 	}
 
 	dmsgC := dmsg.NewClient(pk, sk, primaryC, dmsgConf)

--- a/pkg/dmsgc/spec/spec.go
+++ b/pkg/dmsgc/spec/spec.go
@@ -85,6 +85,15 @@ type DmsgConfig struct {
 	Protocol             string        `json:"-"`
 	LANServers           []*disc.Entry `json:"-"`
 	HypervisorDiscovery  string        `json:"-"`
+
+	// DirectOnly selects the single dmsg client's discovery MODE. Default
+	// false = "discovery" (registering fallback: the visor publishes its
+	// entry to dmsg-discovery and resolves via it, direct-first). true =
+	// "direct-only": static direct client ONLY, no dmsg-discovery — the visor
+	// does not register (unreachable by lookup, can't relay, NOT
+	// rewards-eligible), a stealthy leaf reaching only statically-known
+	// services/servers. Experimental; default stays discovery.
+	DirectOnly bool `json:"direct_only,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -115,33 +115,16 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	v.dClient = dClient
 	v.initLock.Unlock()
 
-	// Start DMSG HTTP connection in background so it doesn't block visor startup.
-	// Downstream modules check v.dmsgHTTP != nil before using DMSG transport
-	// and fall back to plain HTTP if it's not ready yet.
-	go func() {
-		dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx, v.MasterLogger().PackageLogger("dmsg_http:dmsgDC"),
-			v.conf.PK, v.conf.SK, dClient, dmsg.DefaultConfig())
-		if err != nil {
-			log.WithError(err).Warn("DMSG HTTP transport unavailable")
-			return
-		}
-
-		dmsgHTTP := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgDC)}
-
-		v.pushCloseStack("dmsg_http", func() error {
-			closeDmsgDC()
-			return nil
-		})
-
-		v.initLock.Lock()
-		v.dmsgHTTP = &dmsgHTTP
-		v.dmsgDC = dmsgDC
-		v.initLock.Unlock()
-		close(v.dmsgHTTPReady)
-
-		log.Info("DMSG HTTP transport ready")
-	}()
-
+	// SINGLE-CLIENT CONVERGENCE: do NOT spin up a separate "direct" dmsg
+	// client (dmsgDC) here. It shared the visor PK with the main dmsgC, and
+	// dmsg servers key sessions by client-PK with newest-session-wins
+	// eviction (#3035), so the two clients evicted each other on every shared
+	// server — a continuous self-eviction storm (server-confirmed ~56
+	// session-deaths/min/server, 100% from visors). initDmsg now builds ONE
+	// dmsgC whose disc is a registering fallback over this dClient (static
+	// direct-first reads + self-registration), and wires v.dmsgHTTP to a
+	// dmsg-HTTP transport over that same client. dClient (set above) carries
+	// the preloaded static entries the single client resolves against.
 	return nil
 }
 
@@ -185,29 +168,9 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// Prefer DMSG-HTTP for discovery if configured (more private, no DNS dependency),
 	// fall back to plain HTTP URL. If HTTP URL is empty (DMSG-only deployment),
 	// DMSG is required — not optional.
-	discURL := primary
-	if primaryDmsg != "" && v.dmsgHTTP != nil {
-		if _, err := getHTTPClient(ctx, v, primaryDmsg); err == nil {
-			discURL = primaryDmsg
-			log.Info("Using DMSG-HTTP for dmsg discovery")
-		} else if discURL != "" {
-			log.WithError(err).Warn("DMSG-HTTP discovery failed, using plain HTTP")
-		} else {
-			return fmt.Errorf("DMSG-only deployment but DMSG discovery unreachable: %w", err)
-		}
-	} else if discURL == "" && primaryDmsg != "" {
-		// DMSG URL set but dmsgHTTP not ready — can't proceed without either
-		discURL = primaryDmsg
-		log.Warn("HTTP discovery URL empty, attempting DMSG discovery without dmsgHTTP transport")
-	}
-
-	httpC, err := getHTTPClient(ctx, v, discURL)
-	if err != nil {
-		return err
-	}
-	// Override the discovery URL used by the DMSG client
+	_ = primary // discovery URL selection now lives in dmsgc.New (Discovery || DiscoveryDmsg)
+	_ = primaryDmsg
 	dmsgConf := *v.conf.Dmsg
-	dmsgConf.Discovery = discURL
 	// --dmsg-server pins the client to one server (discovery filter in
 	// dmsg.Client.serve). Force sessions_count=1 so the client doesn't
 	// burn retries trying to open additional sessions when only one
@@ -225,7 +188,21 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 		log.WithField("dmsg_server", dmsgServer).
 			Info("--dmsg-server set: forcing dmsg.sessions_count=1")
 	}
-	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.MasterLogger())
+
+	// SINGLE-CLIENT CONVERGENCE. One dmsg client with a deferred dmsg-HTTP
+	// transport: build the client with an empty http.Client, then wire its
+	// Transport to MakeHTTPTransport(dmsgC) so discovery lookups AND the
+	// visor's own registration ride this client's own sessions. No request
+	// is issued before Serve, so the empty transport is never used. dmsgc.New
+	// wraps the disc in a registering fallback over v.dClient (preloaded with
+	// servers + dmsg-disc + service entries) so those resolve statically with
+	// no HTTP-over-dmsg round-trip — eliminating the second same-PK client
+	// (dmsgDC) that self-evicted on the dmsg servers.
+	httpC := &http.Client{}
+	directOnly := v.conf.Dmsg != nil && v.conf.Dmsg.DirectOnly
+	dmsgC := dmsgc.New(v.conf.PK, v.conf.SK, v.ebc, &dmsgConf, httpC, v.dClient, directOnly, v.MasterLogger())
+	httpC.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgC)
+
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	go func() {
@@ -243,7 +220,14 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 
 	v.initLock.Lock()
 	v.dmsgC = dmsgC
+	v.dmsgDC = dmsgC // single client: dmsgDC consumers (router, resolver, vpn) ride dmsgC
+	v.dmsgHTTP = httpC
 	v.initLock.Unlock()
+	select {
+	case <-v.dmsgHTTPReady:
+	default:
+		close(v.dmsgHTTPReady)
+	}
 
 	// Wait for DMSG to connect before returning. All modules that depend on
 	// dmsg will only start after this, ensuring DMSG is ready before any
@@ -313,58 +297,25 @@ func initDmsg(ctx context.Context, v *Visor, log *logging.Logger) (err error) {
 	// → cache miss → ...) until the goroutine stack overflows.
 	v.seedDmsgServiceEntries(dmsgC, log)
 
-	// Now safe to upgrade. dmsgC's background discovery refreshes
-	// will hit the seeded dmsgdiscPK entry from cache, route
-	// through the delegated-server path, and never recurse back
-	// into the disc client looking for that PK.
-	//
-	// The initial-construction httpC was forced to plain HTTP
-	// whenever initDmsgHTTP's dmsgDC wasn't ready yet (a startup
-	// race), which pinned the dmsgC's discovery refresh to HTTP
-	// for the whole process lifetime — so an outage on the public
-	// HTTP fronting (Caddy, etc.) would break the visor's
-	// discovery refresh even when DMSG was healthy.
-	//
-	// Run the upgrade in a goroutine that waits for v.dmsgHTTPReady
-	// (initDmsgHTTP's dmsgDC) before wiring it in as dmsgfirst's
-	// primary path. dmsgDC is direct.Client-backed — it carries a
-	// synthetic entry for the dmsg-disc PK with all known server PKs
-	// as delegated, so DialStream resolves without ever needing an
-	// HTTP-discovery lookup. Pre-fix the primary used the main dmsgC,
-	// whose own discovery was dmsgfirst, so every Entry/PutEntry call
-	// from the visor's own updateClientEntryLoop fell back to HTTP
-	// after the DMSG primary's DialStream timed out — dmsg-disc has
-	// no entry in its own DB (root of trust, by design) so the dial
-	// never had a chance.
-	//
-	// Until dmsgHTTPReady fires (i.e., dmsgDC has bootstrapped its
-	// session set), dmsgC keeps the plain-HTTP discovery clients
-	// constructed by dmsgc.New. That's the same conservative behavior
-	// as before this fix landed.
-	go func() {
-		select {
-		case <-v.dmsgHTTPReady:
-		case <-ctx.Done():
-			return
-		}
-		v.initLock.Lock()
-		dmsgDC := v.dmsgDC
-		v.initLock.Unlock()
-		if dmsgDC == nil {
-			return
-		}
-		upgradeDmsgDiscToDmsgfirst(dmsgC, dmsgDC, v.conf.Dmsg, log)
-	}()
+	// No dmsgfirst upgrade needed: dmsgc.New already wired dmsgC's disc to a
+	// registering fallback whose HTTP half rides this single client's own
+	// dmsg-HTTP transport (httpC, set above). The one client both registers
+	// itself over dmsg and resolves seeded static entries direct-first.
 
 	// Start periodic config refresh for dynamic key sets
 	go v.startConfigRefresh(ctx) //nolint:errcheck,gosec
 
-	// Refresh the on-disk dmsg-servers cache from dmsg-discovery so the
-	// next bootstrap uses the live addresses, not whatever's in
-	// skywire.json. Uses a separate disc.HTTP client (the dmsg.Client
-	// doesn't expose its inner discovery client).
-	if v.dmsgServersCache != nil && discURL != "" {
-		go v.refreshDmsgServersCacheLoop(ctx, discURL, httpC)
+	// Refresh the on-disk dmsg-servers cache from dmsg-discovery so the next
+	// bootstrap uses live addresses. Rides httpC (the single client's
+	// dmsg-HTTP transport).
+	if v.dmsgServersCache != nil {
+		refreshURL := v.conf.Dmsg.Discovery
+		if refreshURL == "" {
+			refreshURL = v.conf.Dmsg.DiscoveryDmsg
+		}
+		if refreshURL != "" {
+			go v.refreshDmsgServersCacheLoop(ctx, refreshURL, httpC)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes a fleet-wide dmsg instability: every dmsg-only visor ran **two** dmsg clients under **one** PK — `dmsgC` (discovery) + `dmsgDC` (direct/dmsg-HTTP). dmsg servers key sessions by client-PK with newest-session-wins eviction (#3035), so a visor's two clients **evicted each other** on every shared server — a continuous self-eviction storm (server-confirmed ~56 evict-driven session-deaths/min on a single server, 100% from visors), worst during redeploys when the whole fleet re-dials at once (multi-minute "visor offline" reports). Unmasked once the fleet went uniformly ≥v1.3.69 (all servers now evict).

## Fix

Converge to **one** dmsg client (the `StartDmsgSelfHostedDisc` pattern, applied to the visor):
- `dmsgc.New` builds a single client whose disc is `NewRegisteringFallbackDiscClient(directClient, httpDisc)`: **direct-first reads** (servers + dmsg-disc + services resolve statically — no HTTP-over-dmsg round-trip to the entry-less root-of-trust dmsg-disc, which otherwise hot-loops) and **self-registration** over the client's own sessions.
- **Deferred transport**: empty `http.Client` → `dmsgc.New` → `httpC.Transport = MakeHTTPTransport(dmsgC)`; discovery rides the client's own sessions (no request before Serve, so the empty transport is never used).
- `initDmsgHTTP` no longer spawns `dmsgDC`; `v.dmsgDC = dmsgC`. The `dmsgfirst` upgrade dance is removed.
- **`PostEntry` no-ops** in the registering fallback: the dmsg serve loop calls `PostEntry` PRE-session (before the server-dialing loop); routing it to HTTP-over-dmsg dialed dmsg-disc over not-yet-established sessions, blocking the loop and stranding the visor on one server. Durable registration is done by the POST-session `PutEntry` loop (dmsg-disc upserts).
- **Mode** (`DmsgConfig.DirectOnly`, default false): `discovery` (registering fallback, registers) vs experimental `direct-only` (static only, no registration).

Route-setup / transport-setup clients (their own keys) are unchanged.

## Validation

Live on a visor (`0323272a`): **9/9 servers connected** (was stuck on 1), **0** `dmsg_http:dmsgDC` lines (one client), **0 eviction events**, **registered** in dmsg-disc (entry `sequence:3`, `delegated_servers` populated), no wedge. `NewRegisteringFallbackDiscClient` unit-tested (write-routing + direct-first reads); `go build` + `golangci-lint` clean.