### PR TITLE
fix(web): platform-split process-group helpers so the Windows release builds

### DIFF
--- a/cmd/skywire/commands/web/procgroup_unix.go
+++ b/cmd/skywire/commands/web/procgroup_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package web
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcGroup puts the child in its own process group so the whole group can
+// be signaled on cancel / client-disconnect (matters for visor halt, dmsg curl
+// downloads, etc).
+func setProcGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcGroup sends SIGINT to the child's process group for graceful cleanup.
+func killProcGroup(p *os.Process) {
+	if p == nil {
+		return
+	}
+	_ = syscall.Kill(-p.Pid, syscall.SIGINT) //nolint:errcheck
+}

--- a/cmd/skywire/commands/web/procgroup_windows.go
+++ b/cmd/skywire/commands/web/procgroup_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package web
+
+import (
+	"os"
+	"os/exec"
+)
+
+// setProcGroup is a no-op on Windows — there are no POSIX process groups, and
+// the default CreateProcess behavior is sufficient for the web command's
+// subprocess lifecycle.
+func setProcGroup(_ *exec.Cmd) {}
+
+// killProcGroup terminates the child process. Windows has no SIGINT-to-group
+// equivalent, so this is a best-effort hard kill of the subprocess.
+func killProcGroup(p *os.Process) {
+	if p == nil {
+		return
+	}
+	_ = p.Kill() //nolint:errcheck
+}

--- a/cmd/skywire/commands/web/web.go
+++ b/cmd/skywire/commands/web/web.go
@@ -29,7 +29,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -374,7 +373,7 @@ func handleRun(runs *runRegistry, skywireBin string) http.Handler {
 		cmd.Stderr = cmd.Stdout
 		// SIGINT on cancel so the subprocess gets a chance to clean
 		// up (matters for visor halt, dmsg curl downloads, etc).
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		setProcGroup(cmd)
 
 		if err := cmd.Start(); err != nil {
 			cancel()
@@ -478,9 +477,7 @@ func handleSSE(runs *runRegistry) http.Handler {
 				flusher.Flush()
 			case <-notify:
 				// Client gone — kill the subprocess group.
-				if runEntry.cmd.Process != nil {
-					_ = syscall.Kill(-runEntry.cmd.Process.Pid, syscall.SIGINT) //nolint:errcheck
-				}
+				killProcGroup(runEntry.cmd.Process)
 				return
 			}
 		}
@@ -502,9 +499,7 @@ func handleCancel(runs *runRegistry) http.Handler {
 			http.Error(w, "no such run", http.StatusNotFound)
 			return
 		}
-		if runEntry.cmd.Process != nil {
-			_ = syscall.Kill(-runEntry.cmd.Process.Pid, syscall.SIGINT) //nolint:errcheck
-		}
+		killProcGroup(runEntry.cmd.Process)
 		w.WriteHeader(http.StatusNoContent)
 	})
 }


### PR DESCRIPTION
The `skywire web` command used `syscall.SysProcAttr{Setpgid: true}` and `syscall.Kill(-pid, SIGINT)` unconditionally — both Unix-only — so the **Windows release build fails** (`unknown field Setpgid`, `undefined: syscall.Kill`), and the release ships **no `.msi`** (broke v1.3.69, would break v1.3.70).

Fix: extract the two operations into `setProcGroup` / `killProcGroup` with build-tag splits:
- `procgroup_unix.go` (`//go:build !windows`) — `Setpgid` + SIGINT-to-group, behavior unchanged on Linux/macOS.
- `procgroup_windows.go` (`//go:build windows`) — no-op `setProcGroup`; best-effort `Process.Kill()` (Windows has no SIGINT-to-group).

Verified: `GOOS=windows GOARCH=amd64 go build ./cmd/skywire/commands/web/` and the linux build both pass; `go build .` clean.