### PR TITLE
fix(dmsg-server): bind listener without waiting on transit-client Ready (cold-start trap)

### DIFF
--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -470,9 +470,25 @@ func (s *service) buildTransitDmsg(ctx context.Context, deployments []dmsgserver
 	dClient := direct.NewClient(direct.GetAllEntries(keys, servers), log)
 
 	conf := &dmsg.Config{MinSessions: 0}
-	dmsgC, closeFn, err := direct.StartDmsg(ctx, log, cfg.PubKey, cfg.SecKey, dClient, conf)
-	if err != nil {
-		return nil, nil, nil, err
+	// Start the transit client WITHOUT blocking on Ready(). A dmsg-server's
+	// INBOUND accept loop (bound after this returns) must come up regardless
+	// of whether the server's own OUTBOUND transit client has reached a peer
+	// yet. In a fleet-wide cold-start every server's transit client dials
+	// every other server — all down — so Ready() never fires; blocking here
+	// (the old direct.StartDmsg path) gated the listener and produced a
+	// CIRCULAR BOOTSTRAP TRAP where no server can be the first to listen, so
+	// the whole fleet stays down even though each binary is healthy. Serving
+	// in the background lets THIS server accept inbound sessions immediately;
+	// its own discovery registration completes the moment any peer (or an
+	// inbound visor providing a relay path) appears, which cascades the fleet
+	// back up. Mirrors direct.StartDmsg minus the <-Ready() wait.
+	dmsgC := dmsg.NewClient(cfg.PubKey, cfg.SecKey, dClient, conf)
+	dmsgC.SetLogger(log)
+	go dmsgC.Serve(ctx)
+	closeFn := func() {
+		if cerr := dmsgC.Close(); cerr != nil {
+			log.WithError(cerr).Debug("transit dmsg client close")
+		}
 	}
 	return dmsgC, dClient, closeFn, nil
 }


### PR DESCRIPTION
Second of the two bugs behind the fleet outage (the first, the `sesMx` re-entrant deadlock, is fixed in #3139/v1.3.72 and verified gone in prod).

**Bug:** the dmsg-server gates its inbound `:8080` accept loop behind its *own* outbound transit dmsg client reaching `Ready()` — `Run` blocks at `buildTransitDmsg` → `direct.StartDmsg`’s `<-Ready()`. In a fleet-wide cold-start, every server’s transit client is dialing every other server (all down), so `Ready()` never fires and the listener never binds → a **circular bootstrap trap**: no server can be the first to come up, so the whole fleet stays down even though every binary is healthy. This was masked until v1.3.72 removed the deadlock that previously hung the servers earlier.

**Fix:** serve the transit client in the background instead of blocking on `Ready()`, so the inbound accept loop binds immediately. The server’s own discovery registration completes once any peer / inbound relay path appears, cascading the fleet back up. A server’s *inbound* reachability must not depend on its *outbound* client being connected. (Gamma confirmed this exact gate via goroutine dumps on prod02 — main parked at `buildTransitDmsg` → `dmsgDC.Ready()`.)

`go build` + `go vet ./pkg/services/dmsgsrv/` clean. Validation is on the deployment: a server on this image binds `:8080` immediately and can bootstrap a dead fleet.