### PR TITLE
fix(dmsg-disc): cold-start bootstrap — dial configured servers immediately to break the dmsg-only registration trap

### DIFF
--- a/pkg/dmsg/dmsgtest/coldstart_test.go
+++ b/pkg/dmsg/dmsgtest/coldstart_test.go
@@ -1,0 +1,151 @@
+// Package dmsgtest pkg/dmsgtest/coldstart_test.go
+//
+//nolint:errcheck,gosec
+package dmsgtest
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/nettest"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+// TestColdStart_UnregisteredDiscReachableViaSharedServer reproduces the
+// dmsg-only cold-start registration path and proves the property the fleet
+// recovery depends on:
+//
+//	dmsg-discovery is NOT discoverable (it never registers itself), and a
+//	dmsg-server cannot dial a client. So the ONLY way a server can register
+//	itself over dmsg-HTTP is: disc dials OUT to the dmsg-server (the
+//	connectConfiguredServers fix), and the server's transit client reaches
+//	disc through that shared server via dialViaConnectedServers — with no
+//	discovery entry for disc anywhere.
+//
+// The test wires:
+//   - server S (real listener)
+//   - "disc": an unregistered client that dials S (stands in for
+//     connectConfiguredServers) and listens on its dmsg-HTTP port
+//   - "transit": a dmsg-server's transit client that dials S and must reach
+//     disc with NO disc entry in its discovery
+//
+// The positive assertion is that transit→disc succeeds purely via the shared
+// server. The negative control is that an unregistered PK NOT connected to any
+// shared server is unreachable — proving disc's outbound dial is the necessary
+// enabler.
+func TestColdStart_UnregisteredDiscReachableViaSharedServer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	// --- Server S ---------------------------------------------------------
+	sharedDC := disc.NewMock(0)
+	pkS, skS := cipher.GenerateKeyPair()
+	lisS, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+	srvS := dmsg.NewServer(pkS, skS, sharedDC, &dmsg.ServerConfig{
+		MaxSessions:    10,
+		UpdateInterval: dmsg.DefaultUpdateInterval,
+	}, nil)
+	go srvS.Serve(lisS, "")
+	defer srvS.Close()
+	select {
+	case <-srvS.Ready():
+	case <-ctx.Done():
+		t.Fatal("server S not ready")
+	}
+	entryS, err := sharedDC.Entry(ctx, pkS)
+	require.NoError(t, err)
+
+	// --- "disc": unregistered client that dials OUT to S ------------------
+	// Its discovery knows S (so it can connect to S), but disc never
+	// PostEntry's ITSELF anywhere — exactly like dmsg-discovery.
+	discDC := disc.NewMock(0)
+	require.NoError(t, discDC.PostEntry(ctx, entryS))
+	pkDisc, skDisc := cipher.GenerateKeyPair()
+	discClient := dmsg.NewClient(pkDisc, skDisc, discDC, &dmsg.Config{MinSessions: 1})
+	go discClient.Serve(ctx)
+	defer discClient.Close()
+	select {
+	case <-discClient.Ready():
+	case <-ctx.Done():
+		t.Fatal("disc client not ready")
+	}
+	// disc listens on its dmsg-HTTP port and echoes — stands in for the
+	// dmsg-discovery setEntry handler the server registers against.
+	const discPort = uint16(80)
+	lisDisc, err := discClient.Listen(discPort)
+	require.NoError(t, err)
+	go func() {
+		for {
+			s, aerr := lisDisc.AcceptStream()
+			if aerr != nil {
+				return
+			}
+			go func(st *dmsg.Stream) {
+				defer st.Close()
+				buf := make([]byte, 4)
+				if _, rerr := io.ReadFull(st, buf); rerr != nil {
+					return
+				}
+				st.Write(buf)
+			}(s)
+		}
+	}()
+
+	// --- "transit": a dmsg-server's transit client ------------------------
+	// Knows S (to connect to S) but has NO entry for disc. It must reach
+	// disc purely via the shared server.
+	transitDC := disc.NewMock(0)
+	require.NoError(t, transitDC.PostEntry(ctx, entryS))
+	pkT, skT := cipher.GenerateKeyPair()
+	transitClient := dmsg.NewClient(pkT, skT, transitDC, &dmsg.Config{MinSessions: 1})
+	go transitClient.Serve(ctx)
+	defer transitClient.Close()
+	select {
+	case <-transitClient.Ready():
+	case <-ctx.Done():
+		t.Fatal("transit client not ready")
+	}
+
+	// Defining precondition: disc is NOT discoverable by the transit client.
+	_, err = transitDC.Entry(ctx, pkDisc)
+	require.Error(t, err, "disc must be unregistered in the transit client's discovery")
+
+	// --- Positive: transit reaches unregistered disc via the shared server.
+	var stream *dmsg.Stream
+	for attempt := 0; attempt < 8; attempt++ {
+		stream, err = transitClient.DialStream(ctx, dmsg.Addr{PK: pkDisc, Port: discPort})
+		if err == nil {
+			break
+		}
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			t.Fatal("ctx done while dialing disc")
+		}
+	}
+	require.NoError(t, err, "transit client must reach unregistered disc via the shared server (dialViaConnectedServers)")
+	defer stream.Close()
+
+	// Confirm it is a real working stream end-to-end.
+	_, err = stream.Write([]byte("ping"))
+	require.NoError(t, err)
+	got := make([]byte, 4)
+	_, err = io.ReadFull(stream, got)
+	require.NoError(t, err)
+	require.Equal(t, "ping", string(got))
+
+	// --- Negative control: an unregistered PK NOT on any shared server is
+	// unreachable. Proves disc's OUTBOUND dial to S is the necessary enabler.
+	pkGhost, _ := cipher.GenerateKeyPair()
+	nctx, ncancel := context.WithTimeout(ctx, 10*time.Second)
+	defer ncancel()
+	_, err = transitClient.DialStream(nctx, dmsg.Addr{PK: pkGhost, Port: discPort})
+	require.Error(t, err, "an unregistered PK not connected to any shared server must be unreachable")
+}

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -243,6 +243,14 @@ func (s *service) runDMSG(
 		}
 	}()
 
+	// Cold-start bootstrap: aggressively dial the CONFIGURED/embedded
+	// dmsg-server set immediately, so each server gets a path to register
+	// itself (directly over disc's inbound session, or relayed through any
+	// server disc is already connected to). Distinct from updateServers,
+	// which resolves from the redis store — empty at cold-start, so it can
+	// never bootstrap an empty deployment on its own.
+	go connectConfiguredServers(ctx, servers, dClient, dmsgDC, log)
+
 	go updateServers(ctx, a, dClient, dmsgDC, cfg.DmsgServerType, log)
 
 	wl := deployment.Prod.SurveyWhitelist
@@ -330,6 +338,59 @@ func pollServersUntilFound(ctx context.Context, a *api.API, dmsgServerType strin
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
+		}
+	}
+}
+
+// connectConfiguredServers is the cold-start bootstrap dialer. It keeps
+// sessions open from dmsg-disc to every CONFIGURED dmsg-server (the
+// preloaded cfg.DmsgServers / embedded-keyring set), NOT the redis-store
+// set — at cold-start the store is empty, so a store-driven loop can never
+// be the thing that brings the fleet up.
+//
+// Why disc dialing matters: in the dmsg-only deployment a server registers
+// itself over dmsg-HTTP, which needs a session, which needs a reachable
+// server — circular if every server cold-starts at once. disc breaks the
+// cycle: it dials servers directly from config (no discovery lookup, no
+// circular dependency), and the moment it is connected to even ONE server,
+// every server can reach disc — directly if disc dialed it, or relayed
+// through a disc-connected peer (or via self-loopback for the first one) —
+// and self-register with its own key (proper signature; disc never authors
+// entries it cannot sign).
+//
+// Cadence: tight retry (exponential 1s→30s) while any configured server is
+// still unreachable, then steady 30s maintenance so dropped sessions are
+// re-established promptly. EnsureSession is idempotent — already-connected
+// servers cost a cheap map check.
+func connectConfiguredServers(ctx context.Context, servers []*disc.Entry, dClient disc.APIClient, dmsgC *dmsg.Client, log logrus.FieldLogger) {
+	const minInterval, maxInterval = time.Second, 30 * time.Second
+	interval := minInterval
+	for {
+		connected := 0
+		for _, server := range servers {
+			dClient.PostEntry(ctx, server) //nolint:errcheck,gosec
+			if err := dmsgC.EnsureSession(ctx, server); err != nil {
+				log.WithField("remote_pk", server.Static).WithError(err).
+					Debug("dmsg-disc: dialing configured dmsg-server")
+				continue
+			}
+			connected++
+		}
+		if connected == len(servers) {
+			interval = maxInterval // fully connected: drop to maintenance cadence
+		} else {
+			log.WithField("connected", connected).WithField("total", len(servers)).
+				Info("dmsg-disc: bootstrapping configured dmsg-server sessions")
+			if interval < maxInterval {
+				if interval *= 2; interval > maxInterval {
+					interval = maxInterval
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
 		}
 	}
 }


### PR DESCRIPTION
Fixes the fleet-wide dmsg-only cold-start outage.

## Root cause
In the dmsg-only deployment a dmsg-server self-registers over **dmsg-HTTP**, which needs a session, which needs a reachable+registered server — circular when the whole fleet cold-starts at once. dmsg-disc is the only entity that can break it: it is **not discoverable** and a dmsg-server **cannot dial a client**, so the only path is disc dialing **out** to the servers. But the existing `updateServers` resolved its dial set from `a.AllServers` (the redis **store**, empty at cold-start) on a 10-min ticker with no immediate pass — so disc never dialed anything and the fleet could not bootstrap. Bare-metal servers were hit identically → proved it is registration logic, not Docker.

## Fix
`connectConfiguredServers`: disc dials its **configured/embedded** server set immediately, tight exponential retry (1s→30s) until all connected, then 30s maintenance. Once disc is on even one server, every server reaches disc via `dialViaConnectedServers` through the shared server and self-registers **with its own key** (disc never authors entries it cannot sign).

## Proof
New `TestColdStart_UnregisteredDiscReachableViaSharedServer` (pkg/dmsg/dmsgtest): an unregistered disc, after dialing out to a shared server, is reachable by a transit client with no disc entry; negative control confirms a PK not on a shared server is unreachable. Full dmsgtest + dmsg + dmsgclient suites green.

Composes with v1.3.72 (sesMx deadlock) + v1.3.73 (listener binds regardless of outbound Ready) + #3141 (ping-deadline 5s→18s).