### PR TITLE
fix(dmsg-server): run Accept loop immediately — final cold-start trap (gates disc dial-in)

### DIFF
--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -244,9 +244,23 @@ func (s *Server) Serve(lis net.Listener, addr string) error {
 		log.WithError(lis.Close()).Info("Stopping server...")
 	}()
 
-	if err := s.startUpdateEntryLoop(ctx); err != nil {
-		return err
-	}
+	// Publish this server's discovery entry in the BACKGROUND. startUpdateEntryLoop
+	// blocks on a Retrier that registers over dmsg-HTTP, which needs an upstream
+	// dmsg session — which at cold-start needs THIS server (and its peers) to be
+	// accepting first. Gating Accept on it is a circular, fleet-wide cold-start
+	// trap: every dmsg-server blocks on a registration that can only succeed once
+	// servers are already accepting, so nobody is ever first. Start Accept
+	// immediately; registration completes on its own once dmsg-disc dials in (it
+	// connects to its configured server set — see dmsgdisc.connectConfiguredServers)
+	// and a session exists. Same shape as the buildTransitDmsg cold-start fix one
+	// layer up — accepting before being registered is safe: the listener only
+	// needs the bound socket, and configured/embedded peers reach us without a
+	// discovery entry.
+	go func() {
+		if err := s.startUpdateEntryLoop(ctx); err != nil {
+			s.log.WithError(err).Error("server entry-publish loop exited")
+		}
+	}()
 
 	s.connectToPeers(ctx)
 

--- a/pkg/dmsg/dmsgtest/coldstart_test.go
+++ b/pkg/dmsg/dmsgtest/coldstart_test.go
@@ -59,8 +59,18 @@ func TestColdStart_UnregisteredDiscReachableViaSharedServer(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("server S not ready")
 	}
-	entryS, err := sharedDC.Entry(ctx, pkS)
-	require.NoError(t, err)
+	// Registration is async — Serve no longer gates Accept on the
+	// entry-publish loop (the cold-start fix), so Ready() means "accepting",
+	// not "registered". Wait for the entry to land in discovery.
+	var entryS *disc.Entry
+	require.Eventually(t, func() bool {
+		e, eerr := sharedDC.Entry(ctx, pkS)
+		if eerr != nil {
+			return false
+		}
+		entryS = e
+		return true
+	}, 15*time.Second, 200*time.Millisecond, "server S must register in discovery")
 
 	// --- "disc": unregistered client that dials OUT to S ------------------
 	// Its discovery knows S (so it can connect to S), but disc never

--- a/pkg/dmsg/dmsgtest/env.go
+++ b/pkg/dmsg/dmsgtest/env.go
@@ -122,7 +122,22 @@ func (env *Env) newServer(ctx context.Context, updateInterval time.Duration) (*d
 		_ = srv.Close() //nolint:errcheck
 		return nil, ctx.Err()
 	case <-srv.Ready():
-		return srv, nil
+	}
+
+	// Serve no longer gates Accept on the entry-publish loop (the cold-start
+	// fix in dmsg.Server.Serve), so Ready() now means "accepting", not
+	// "registered". Tests built on this helper expect the server discoverable
+	// on return, so wait for its entry to land in discovery.
+	for {
+		if _, eerr := env.d.Entry(ctx, srv.LocalPK()); eerr == nil {
+			return srv, nil
+		}
+		select {
+		case <-ctx.Done():
+			_ = srv.Close() //nolint:errcheck
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 }
 


### PR DESCRIPTION
The remaining cold-start trap, found by deploy verification of v1.3.74.

`dmsg.Server.Serve` ran `startUpdateEntryLoop` (a Retrier around `updateServerEntry`, which registers over dmsg-HTTP) **blocking, before** the Accept loop. At cold-start that registration needs an upstream dmsg session → needs a reachable server that is **accepting** → so every dmsg-server blocked on a registration that could only succeed once servers accept. Listener bound (#3140), 4097 SYNs kernel-queued, userspace Accept never runs, no session completes.

This is why v1.3.74 still failed despite #3142: disc **did** dial out to every configured server (gate 1 passed), but the servers Accept loops were parked behind `startUpdateEntryLoop`, so disc dials never completed the handshake and no server registered (gates 2/3 failed).

**Fix:** background `startUpdateEntryLoop` so Accept runs immediately. Accepting before being registered is safe — configured/embedded peers (incl. disc via `connectConfiguredServers`) reach us without a discovery entry. Once Accept runs → disc completes its dial → session forms → backgrounded registration reaches disc over that session → cascade.

`Ready()` now means "accepting", not "registered"; `dmsgtest.Env.newServer` waits for the entry so dependent tests keep their contract. Full dmsg + dmsgtest suites green. Same shape as the v1.3.73 buildTransitDmsg fix, one layer down.