### PR TITLE
fix(dmsg): re-check shutdown before client entry publish (zombie-entry race twin of #3145)

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -632,6 +632,18 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 
 	var firstErr error
 	anyOK := false
+	// Re-check shutdown immediately before the publish IO. The work above
+	// (session snapshot + endpoint resolution) can take time, and Close() may
+	// have fired since the top-of-function check. Without this a PutEntry can
+	// land AFTER Close()'s delEntry, leaving a zombie "advertised but
+	// unreachable" client entry until its TTL — the same pathology fixed on the
+	// server side (#3145). Narrows the window sharply; a full join is deferred
+	// because the client wg machinery intentionally avoids wg.Add on these
+	// background loops to dodge an Add-after-Wait race (see Client.closed and
+	// the comment at client.go:145-148).
+	if isClosed(done) {
+		return nil
+	}
 	for _, ep := range endpoints {
 		if updateErr := c.updateClientEntryOnEndpoint(ctx, ep, clientType, srvPKs); updateErr != nil {
 			if firstErr == nil {


### PR DESCRIPTION
Audit finding (HIGH, client-side twin of #3145). `updateClientEntry` checked `isClosed(done)` once at entry, then did session-snapshot + endpoint resolution before the publish IO; `Close()` in that window let a `PutEntry` land after `delEntry` → zombie client entry until TTL. Re-check right before the publish loop. **Narrows** the window; a full join is deferred deliberately because the client `wg` machinery avoids `wg.Add` on these loops to dodge a documented Add-after-Wait race (client.go:145-148) — naive wg-tracking would re-introduce it. Tracked in the audit fix list. Build green.