### PR TITLE
fix(visor): never leave v.dClient nil — seed embedded dmsg servers + guard getHTTPClient

### DIFF
--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -284,6 +284,13 @@ func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client,
 		if err != nil {
 			return nil, fmt.Errorf("provided URL is invalid: %w", err)
 		}
+		// Defense-in-depth: v.dClient is seeded from the embedded deployment
+		// set in initDmsgHTTP so it is normally never nil, but an
+		// empty-keyring build could still leave it nil — fail the call with a
+		// clear error instead of nil-dereferencing and crashing visor startup.
+		if v.dClient == nil {
+			return nil, fmt.Errorf("dmsg direct client unavailable (no configured/cached/embedded dmsg servers); cannot resolve %s", serviceURL.Host)
+		}
 		// get delegated servers and add them to the client entry
 		servers, err := v.dClient.AvailableServers(ctx)
 		if err != nil {

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -98,7 +98,22 @@ func initDmsgHTTP(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	servers := shuffleServers(configured)
 
 	if len(servers) == 0 {
-		return nil
+		// No configured/cached dmsg servers (a minimal dmsg-only config on
+		// first boot, before dmsg_servers.json is written). Fall back to the
+		// embedded deployment set so v.dClient is NEVER left nil — mirrors
+		// seedDmsgServiceEntries' dmsg.Prod.DmsgServers fallback. A nil
+		// v.dClient nil-derefs getHTTPClient on dmsg:// URLs (crashes visor
+		// startup) AND makes dmsgc.New fall through to a plain-HTTP disc with
+		// no seeded server entries, whose first resolve recurses
+		// resolve->RoundTrip->resolve into a goroutine-stack overflow.
+		servers = shuffleServers(deployment.Prod.ToDiscEntries())
+		if len(servers) == 0 {
+			// Truly nothing embedded (e.g. an empty-keyring build); leaving
+			// dClient nil is unavoidable, but downstream nil-guards must hold.
+			return nil
+		}
+		log.WithField("count", len(servers)).
+			Warn("no configured/cached dmsg servers; seeding direct client from embedded deployment set")
 	}
 
 	keys = append(keys, v.conf.PK)


### PR DESCRIPTION
Audit finding (HIGH, highest correctness risk). On a minimal dmsg-only first boot (empty `dmsg.servers`, no `dmsg_servers.json`), `initDmsgHTTP` returned early **before** assigning `v.dClient` → nil. That nil then either nil-dereferenced in `getHTTPClient` on a `dmsg://` URL (crash at startup) or made `dmsgc.New` fall through to a plain-HTTP disc with no seeded entries whose first resolve recursed `resolve→RoundTrip→resolve` into a stack overflow.

Fix: when the configured/cached server list is empty, seed from `deployment.Prod.ToDiscEntries()` (mirrors `seedDmsgServiceEntries` fallback) so `dClient` is built and never nil. Plus a defense-in-depth nil-guard in `getHTTPClient` for the empty-keyring-build edge.

**Live-validated:** visor rolled onto the change via `halt`/rebuild boots clean (0 panics) and reconnects to **9/9** dmsg servers.