### PR TITLE
fix(noise): make silent PQ downgrades observable (wire unused noiseLogger)

### DIFF
--- a/pkg/dmsg/noise/noise.go
+++ b/pkg/dmsg/noise/noise.go
@@ -167,6 +167,8 @@ func (ns *Noise) pqOfferPayload() []byte {
 	if ns.init && ns.pqInit == nil && ns.pqSecret == nil {
 		k, err := newPQInitiator()
 		if err != nil {
+			noiseLogger.WithError(err).
+				Warn("post-quantum keygen failed; proceeding with a CLASSICAL-only handshake")
 			return nil
 		}
 		ns.pqInit = k
@@ -211,6 +213,21 @@ func (ns *Noise) pqHandlePeerPayload(payload []byte) {
 // the hybrid key via the new CipherState (skywire's external nonce is unchanged).
 func (ns *Noise) applyHybrid() error {
 	if ns.pqSecret == nil || ns.enc == nil || ns.dec == nil {
+		// Downgrade observability: if we (the initiator) OFFERED an ML-KEM
+		// public key but the handshake completed (enc+dec set) with no shared
+		// secret, the peer returned no/malformed ciphertext — a PQ-capable
+		// handshake silently fell back to classical. That is expected against
+		// an older classical-only peer, but it is ALSO exactly what an active
+		// MITM stripping the ML-KEM payload looks like: PQ negotiation is not
+		// authenticated, so there is no in-band downgrade signal. Surfacing it
+		// is the minimum mitigation — a silent, undetectable downgrade becomes
+		// an observable one (prerequisite to a future require-PQ enforcement
+		// once the fleet is fully PQ-capable). Responders can't distinguish
+		// "peer is classical" from "MITM stripped", so only the
+		// initiator-offered case is logged.
+		if ns.init && ns.pqInit != nil && ns.enc != nil && ns.dec != nil {
+			noiseLogger.Warn("post-quantum DOWNGRADE: offered ML-KEM but peer returned no ciphertext; session is CLASSICAL-only (older peer, or a payload-stripping MITM)")
+		}
 		return nil
 	}
 	cb := ns.hs.ChannelBinding()


### PR DESCRIPTION
Security audit (HIGH). The post-quantum hybrid negotiation is unauthenticated: `pqHandlePeerPayload` falls back to classical on any empty/malformed ML-KEM payload with **no error and no log** (`noiseLogger` declared but never used), so an active MITM can strip ML-KEM material and force both ends to classical secp256k1 **undetectably** — defeating harvest-now-decrypt-later on every dmsg/stcp/pty/RPC handshake. (HIGH-not-CRITICAL: classical KK/XK auth still protects current traffic from a non-quantum attacker; the loss is the PQ guarantee.)

Minimum mitigation (audit "do this regardless"): surface it. `applyHybrid` warns when an offered ML-KEM key yields no shared secret (downgrade); `pqOfferPayload` logs the previously-silent keygen-failure fallback. **Prevention** (transcript-bound require-PQ hard-fail) is the planned follow-up — needs a config knob default-OFF until the fleet is PQ-capable. Frame-headroom, rekey symmetry, KEM side-channels audited **safe**. noise tests green.