### PR TITLE
fix(audit): LOW leaks + races (EnsureSession entry copy, evictLoop stop, skysocks Accept close)

### DIFF
--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -84,12 +84,18 @@ func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 		return nil
 	}
 	ce.sesMx.Unlock()
-	entry.Protocol = ce.conf.Protocol
+	// Work on a shallow copy: callers can share one configured *disc.Entry
+	// across concurrent EnsureSession calls (dmsg-disc's connectConfiguredServers
+	// + updateServers both iterate the same preloaded server slice), so
+	// mutating entry.Protocol in place is a data race against those readers.
+	// The shallow copy shares the read-only Server pointer, which is fine.
+	e := *entry
+	e.Protocol = ce.conf.Protocol
 	// Dial WITHOUT holding sesMx — same re-entrancy hazard as
 	// EnsureAndObtainSession: the dial path can re-enter session
 	// establishment via the self-hosted transport, which would
 	// self-deadlock on the non-reentrant sesMx.
-	_, err := ce.dialSession(ctx, entry)
+	_, err := ce.dialSession(ctx, &e)
 	return err
 }
 

--- a/pkg/router/client_pool.go
+++ b/pkg/router/client_pool.go
@@ -18,11 +18,13 @@ import (
 
 // ClientPool is a thread-safe pool of reusable router RPC clients.
 type ClientPool struct {
-	mu      sync.Mutex
-	clients map[cipher.PubKey]*poolEntry
-	dialer  network.Dialer
-	ttl     time.Duration
-	log     *logging.Logger
+	mu        sync.Mutex
+	clients   map[cipher.PubKey]*poolEntry
+	dialer    network.Dialer
+	ttl       time.Duration
+	log       *logging.Logger
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 type poolEntry struct {
@@ -61,6 +63,7 @@ func NewClientPool(dialer network.Dialer, ttl time.Duration) *ClientPool {
 		dialer:  dialer,
 		ttl:     ttl,
 		log:     logging.MustGetLogger("client_pool"),
+		done:    make(chan struct{}),
 	}
 	go p.evictLoop()
 	return p
@@ -132,6 +135,8 @@ func (p *ClientPool) Size() int {
 
 // Close closes all pooled connections and stops the eviction loop.
 func (p *ClientPool) Close() {
+	// Stop the eviction loop (idempotent — Close may be called more than once).
+	p.closeOnce.Do(func() { close(p.done) })
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for pk, entry := range p.clients {
@@ -143,8 +148,13 @@ func (p *ClientPool) Close() {
 func (p *ClientPool) evictLoop() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
-		p.evict()
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-ticker.C:
+			p.evict()
+		}
 	}
 }
 

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -72,6 +72,13 @@ func (c *Client) ListenAndServe(addr string) error {
 			if c.appCl != nil {
 				c.appCl.Log().Errorf("Error accepting: %v", err)
 			}
+			// Release the yamux session + its keepalive goroutine + the
+			// underlying conn on Accept failure, mirroring the session.Open
+			// error path below. Without this, a listener that fails
+			// independently of an orderly Close (so closeC was never
+			// signalled) leaked the whole session. c.close() is sync.Once-
+			// guarded, so it's a no-op when shutdown already triggered this.
+			c.close()
 			return fmt.Errorf("accept: %w", err)
 		}
 


### PR DESCRIPTION
Three independent audit LOW findings: (1) `EnsureSession` mutated the caller-shared `*disc.Entry.Protocol` racing concurrent dmsg-disc callers → shallow-copy; (2) `ClientPool.evictLoop` had no exit so `Close` leaked the goroutine → done-channel + Once; (3) skysocks `ListenAndServe` leaked the yamux session on independent `Accept` failure → call the Once-guarded `c.close()`. Build green.