### PR TITLE
fix(transport-setup): seed dmsg-Client entry cache from config servers

### DIFF
--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -216,10 +216,7 @@ func (s *service) Run(ctx context.Context) error {
 
 	// Build the transit dmsg client BEFORE the server so even the first
 	// (seq-0) registration goes over dmsg, never plain HTTP.
-	dmsgC, dClient, closeDmsg, err := s.buildTransitDmsg(ctx, deployments, discPKs)
-	if err != nil {
-		return fmt.Errorf("dmsg-server: build transit dmsg client: %w", err)
-	}
+	dmsgC, dClient, closeDmsg := s.buildTransitDmsg(ctx, deployments, discPKs)
 	defer closeDmsg()
 
 	srv := dmsg.NewServer(cfg.PubKey, cfg.SecKey, newDmsgOnly(dmsgC, discPKs[0], log), &srvConf, m)
@@ -429,7 +426,7 @@ func newDmsgOnly(dmsgC *dmsg.Client, discPK cipher.PubKey, log *logging.Logger) 
 // through a peer relay. No discovery HTTP is contacted. Returns the dmsg
 // client, the direct disc client (reused by the DMSG health/pprof listener),
 // and a close func.
-func (s *service) buildTransitDmsg(ctx context.Context, deployments []dmsgserver.Deployment, discPKs []cipher.PubKey) (*dmsg.Client, disc.APIClient, func(), error) {
+func (s *service) buildTransitDmsg(ctx context.Context, deployments []dmsgserver.Deployment, discPKs []cipher.PubKey) (*dmsg.Client, disc.APIClient, func()) {
 	cfg := &s.cfg.Config
 	log := s.log
 
@@ -490,5 +487,5 @@ func (s *service) buildTransitDmsg(ctx context.Context, deployments []dmsgserver
 			log.WithError(cerr).Debug("transit dmsg client close")
 		}
 	}
-	return dmsgC, dClient, closeFn, nil
+	return dmsgC, dClient, closeFn
 }

--- a/pkg/skysocks/client.go
+++ b/pkg/skysocks/client.go
@@ -76,7 +76,7 @@ func (c *Client) ListenAndServe(addr string) error {
 			// underlying conn on Accept failure, mirroring the session.Open
 			// error path below. Without this, a listener that fails
 			// independently of an orderly Close (so closeC was never
-			// signalled) leaked the whole session. c.close() is sync.Once-
+			// signaled) leaked the whole session. c.close() is sync.Once-
 			// guarded, so it's a no-op when shutdown already triggered this.
 			c.close()
 			return fmt.Errorf("accept: %w", err)

--- a/pkg/transport-setup/api/api.go
+++ b/pkg/transport-setup/api/api.go
@@ -53,5 +53,18 @@ func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	dmsgConf := dmsg.DefaultConfig()
 	disc := disc.NewHTTP(conf.Dmsg.Discovery, &http.Client{}, log)
 	client := dmsg.NewClient(conf.PK, conf.SK, disc, dmsgConf)
+	// Pre-seed the entry cache with the configured dmsg servers so the
+	// Serve loop's seeded-fallback path (#3146) has something to fall
+	// back to when conf.Dmsg.Discovery is empty (dmsg-only deployment,
+	// disc.NewHTTP returns a no-op client) or during a fleet cold-start
+	// where live discovery briefly has no entries. Without this, dmsg-
+	// only TPS instances spin on "No entries found" indefinitely even
+	// though tps.json explicitly lists upstream servers.
+	for _, srv := range conf.Dmsg.Servers {
+		if srv == nil || srv.Static.Null() || srv.Server == nil {
+			continue
+		}
+		client.SeedEntryCache(srv.Static, srv)
+	}
 	return client
 }

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -237,7 +237,7 @@ func (v *Visor) connectRawTCPSkynet(remotePK cipher.PubKey, remotePort, localPor
 	// Ownership transfers to forwardConn on success, where cleanup is cleared.
 	// Without this, every reject/marshal/io error leaked one open route group
 	// per ConnectRawTCP attempt, unbounded until visor restart.
-	var cleanup net.Conn = conn
+	cleanup := conn
 	defer func() {
 		if cleanup != nil {
 			_ = cleanup.Close() //nolint:errcheck


### PR DESCRIPTION
## Summary

#3146 added a fallback in `dmsg.Client.Serve` that uses `seededServerEntries()` when `discoverServers` returns nothing — covering dmsg-only deployments (empty HTTP discovery URL → no-op disc client) and fleet cold-starts. The fallback only works if something has called `SeedEntryCache` to populate the cache.

`dmsgc.New` (the visor path) does this seeding, but the deployment services that bypass `dmsgc.New` and construct their `dmsg.Client` directly never seed. `transport-setup` is the cleanest example: `setupDmsgC` was a three-line `NewHTTP` + `NewClient` with no cache priming, so `tps.json`'s `dmsg.servers` list was dead weight — present in config, never consulted.

## Change

Iterate `conf.Dmsg.Servers` after constructing the client and call `SeedEntryCache` for each non-null entry. Mirrors the seedFn pattern in `dmsgc.New`.

## Why this matters

With this, removing the `discovery` http URL from `tps.json` (keeping `discovery_dmsg` + `servers`) lets the service bootstrap purely through its configured upstreams. Verified in PR #3146's intent — the seeded fallback path was correct, this PR ensures it has something to fall back to in TPS specifically.

## Test plan

- [x] `go vet ./pkg/transport-setup/...` clean
- [x] `go build ./pkg/transport-setup/...` succeeds
- [ ] Deploy via autopull, remove `dmsg.discovery` from a TPS config, restart that service, verify the "falling back to seeded servers from config" debug log fires and dmsg sessions establish.

## Follow-ups (out of scope)

Other services that bypass `dmsgc.New` (`service-discovery`, several `cmd/` tools) likely need the same treatment to participate in dmsg-only deployments. Each call site can be patched the same way.