### PR TITLE
fix(visor): dmsg uptime probe must be live, not a one-shot Ready() latch

### DIFF
--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -387,12 +387,16 @@ func isDMSGOnline(v *Visor) bool {
 	if v.dmsgC == nil {
 		return false
 	}
-	select {
-	case <-v.dmsgC.Ready():
-		return true
-	default:
-		return false
-	}
+	// Live check: dmsg is online iff it currently holds at least one server
+	// session. Do NOT use Ready() here — Ready() is a one-shot latch
+	// (readyOnce closes it on FIRST readiness and it never reopens), so it
+	// reports "ready ever since startup", not "ready now". As a per-sample
+	// uptime probe that is simply wrong: it can't see dmsg drop mid-run, and
+	// it produces nonsensical comparisons against the live skynet/transport
+	// probe (e.g. skynet uptime appearing higher than dmsg, which is
+	// impossible when both are measured live). ConnectedServers() reads the
+	// current client-session set, so this tracks real dmsg connectivity.
+	return len(v.dmsgC.ConnectedServers()) > 0
 }
 
 func countLiveTransports(v *Visor) int {


### PR DESCRIPTION
The local-uptime `dmsg` probe selected on `v.dmsgC.Ready()`, which is a **one-shot latch** (`readyOnce` closes it on first readiness, never reopens) — so it reported "ready ever since startup", not "connected now". It can't see dmsg drop mid-run and produces a non-comparable figure, which is why the 24h panel showed **skynet uptime > dmsg uptime** (impossible when both are live). Fix: probe `len(ConnectedServers()) > 0` (live session set). Caught by the operator. Build green.