### PR TITLE
fix(transport-setup,router): drop plain-HTTP disc; single-client dmsg-HTTP everywhere

### DIFF
--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -16,6 +16,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
@@ -53,55 +54,45 @@ func NewNode(conf *SetupConfig) (*Node, error) {
 	type setupNodeKey struct{}
 	ctx := context.WithValue(context.Background(), setupNodeKey{}, true)
 
-	// Pick the dmsg-discovery URL and the HTTP client used to query it.
-	// Mirrors the visor bootstrap (pkg/visor/init_dmsg.go) so the RSN
-	// can talk to dmsg-discovery over DMSG when configured to.
+	// Single dmsg client with self-hosted dmsg-discovery — matches the
+	// visor's post-#3136 bootstrap (pkg/visor/init_dmsg.go + pkg/dmsgc/
+	// dmsgc.go) and the transport-setup service in
+	// pkg/transport-setup/api/api.go. Plain-HTTP discovery
+	// (conf.Dmsg.Discovery) is no longer supported for deployment
+	// services; conf.Dmsg.DiscoveryDmsg + seed conf.Dmsg.Servers are
+	// required.
 	//
-	//   - If conf.Dmsg.DiscoveryDmsg is set AND we have static seed
-	//     servers (conf.Dmsg.Servers), bring up a direct dmsg client
-	//     against the seeds, wrap it as a dmsghttp transport, and use
-	//     that as the http.Client for the real disc.NewHTTP. The seed
-	//     servers break the chicken-and-egg of "need DMSG to query
-	//     dmsg-discovery via DMSG."
-	//   - Otherwise: plain HTTP, same as before.
-	discURL := conf.Dmsg.Discovery
+	// The previous code here spun a SECOND dmsg client via direct.StartDmsg
+	// just to back the dmsg-HTTP transport, sharing conf.PK with the
+	// main dmsgC. dmsg servers key sessions by client-PK with newest-
+	// session-wins eviction (#3035), so the two clients evicted each
+	// other on every shared server — the dual-client self-eviction storm
+	// Alpha eliminated for the visor in #3136/#3139. The collapsed
+	// pattern below uses ONE client whose http.Transport is itself,
+	// resolving discovery via a registering-fallback that reads direct-
+	// first (synthetic entries for the local PK + dmsg-service PKs) and
+	// writes via dmsg-HTTP routed through the same client's sessions.
+	seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKsFromConf(conf)...)
+	entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
+	directDisc := direct.NewClient(entries, masterLogger.PackageLogger("rsn:disc:direct"))
+
 	httpC := &http.Client{}
-	if conf.Dmsg.DiscoveryDmsg != "" && len(conf.Dmsg.Servers) > 0 {
-		seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKsFromConf(conf)...)
-		entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
-		dClient := direct.NewClient(entries, masterLogger.PackageLogger("rsn:dmsg_http:direct_client"))
+	dmsgDisc := disc.NewHTTP(conf.Dmsg.DiscoveryDmsg, httpC, packageLogger)
+	discClient := dmsgclient.NewRegisteringFallbackDiscClient(directDisc, dmsgDisc, masterLogger.PackageLogger("rsn:disc:fallback"))
 
-		dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx,
-			masterLogger.PackageLogger("rsn:dmsg_http:dmsgDC"),
-			conf.PK, conf.SK, dClient, dmsg.DefaultConfig())
-		if err != nil {
-			log.WithError(err).Warn("DMSG-HTTP bootstrap failed, falling back to plain HTTP for dmsg-discovery")
-		} else {
-			httpC = &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgDC)}
-			discURL = conf.Dmsg.DiscoveryDmsg
-			log.Info("Using DMSG-HTTP for dmsg-discovery")
-			// closeDmsgDC will run when the setup node shuts down via
-			// its context cancellation; we don't track this in a close
-			// stack here because Node.Stop is not exposed and the
-			// process exits when ctx is canceled.
-			_ = closeDmsgDC
-		}
-	} else if discURL == "" && conf.Dmsg.DiscoveryDmsg != "" {
-		// DMSG URL set but no seed servers — try plain HTTP against
-		// the dmsg URL anyway. dmsg URLs don't work over plain HTTP,
-		// so this will fail at first request, but that's the same
-		// failure mode as before this change.
-		discURL = conf.Dmsg.DiscoveryDmsg
-		log.Warn("DiscoveryDmsg set but no seed servers in conf.Dmsg.Servers; cannot bootstrap dmsg-http")
-	}
-
-	dmsgDisc := disc.NewHTTP(discURL, httpC, packageLogger)
 	dmsgConf := &dmsg.Config{MinSessions: conf.Dmsg.SessionsCount}
-	dmsgC := dmsg.NewClient(conf.PK, conf.SK, dmsgDisc, dmsgConf)
+	dmsgC := dmsg.NewClient(conf.PK, conf.SK, discClient, dmsgConf)
+	for _, srv := range conf.Dmsg.Servers {
+		if srv == nil || srv.Static.Null() || srv.Server == nil {
+			continue
+		}
+		dmsgC.SeedEntryCache(srv.Static, srv)
+	}
+	httpC.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgC)
 	go dmsgC.Serve(ctx)
 
 	log.WithField("local_pk", conf.PK).WithField("dmsg_conf", conf.Dmsg).
-		WithField("disc_url", discURL).
+		WithField("disc_url", conf.Dmsg.DiscoveryDmsg).
 		Info("Connecting to the dmsg network.")
 	<-dmsgC.Ready()
 	log.Info("Connected!")

--- a/pkg/transport-setup/api/api.go
+++ b/pkg/transport-setup/api/api.go
@@ -83,7 +83,7 @@ func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	}
 
 	dmsgDisc := disc.NewHTTP(discURL, httpC, log)
-	var discClient disc.APIClient = dmsgDisc
+	discClient := dmsgDisc
 	if useSelfHostedDisc {
 		seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKs(conf.Dmsg.DiscoveryDmsg)...)
 		entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)

--- a/pkg/transport-setup/api/api.go
+++ b/pkg/transport-setup/api/api.go
@@ -57,62 +57,46 @@ func New(log *logging.Logger, conf config.Config) *API {
 func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	dmsgConf := dmsg.DefaultConfig()
 
-	// Pick the dmsg-discovery URL and the http.Client used to query it.
-	// Mirrors pkg/router/setupnode.go and dmsgclient.StartDmsgSelfHostedDisc:
+	// Single dmsg client with self-hosted dmsg-discovery — matches the
+	// visor's post-#3136 bootstrap (pkg/visor/init_dmsg.go + pkg/dmsgc/
+	// dmsgc.go). Plain-HTTP discovery (conf.Dmsg.Discovery) is no longer
+	// supported for deployment services; conf.Dmsg.DiscoveryDmsg + seed
+	// conf.Dmsg.Servers are required.
 	//
-	//   - If conf.Dmsg.Discovery (plain HTTP) is set, use it as before.
-	//   - Else if conf.Dmsg.DiscoveryDmsg + seed servers are set, fall
-	//     into the self-hosted disc pattern: a registering fallback
-	//     disc client whose READ path resolves seeded servers directly
-	//     (no round-trip) and whose WRITE path (PutEntry — so this
-	//     service's own entry IS published to the real dmsg-discovery)
-	//     goes through an http.Client whose Transport is dmsghttp,
-	//     routed over the same dmsg.Client we are building. Self-
-	//     hosted: one client both registers itself and resolves
-	//     bootstrap PKs statically, no plain-HTTP fallback.
-	//   - Else: the original NewHTTP("") path, which returns a no-op
-	//     discovery client; the Serve-loop fallback (#3146) still
-	//     pulls seeded servers from SeedEntryCache for the initial
-	//     dial, but the service can't publish its own entry — useful
-	//     only for air-gapped / single-host setups.
-	discURL := conf.Dmsg.Discovery
+	// Pattern:
+	//   - direct.Client preloaded with the local PK + dmsg-disc PK,
+	//     synthesizing client entries that delegate to every seed
+	//     server. Reads (Entry/AvailableServers) short-circuit through
+	//     this for service PKs and configured servers — no HTTP-over-
+	//     dmsg round-trip to the entry-less, root-of-trust dmsg-disc.
+	//   - disc.NewHTTP against the dmsg:// URL with an empty http.Client.
+	//   - NewRegisteringFallbackDiscClient over (direct, http): READ
+	//     direct-first, WRITE via dmsg-HTTP so the service's own entry
+	//     IS published to the real dmsg-discovery.
+	//   - SINGLE dmsg.Client built against the wrapped disc.
+	//   - SeedEntryCache for every configured server (bootstrap dial
+	//     path + the Serve-loop fallback in #3146).
+	//   - httpC.Transport wired to dmsghttp.MakeHTTPTransport(dmsgC)
+	//     AFTER construction — the transport isn't invoked until the
+	//     first PostEntry/Entry call, by which time Serve has already
+	//     established sessions to the seeded servers. Same ordering the
+	//     visor relies on.
 	httpC := &http.Client{}
-	useSelfHostedDisc := discURL == "" && conf.Dmsg.DiscoveryDmsg != "" && len(conf.Dmsg.Servers) > 0
-	if useSelfHostedDisc {
-		discURL = conf.Dmsg.DiscoveryDmsg
-	}
+	dmsgDisc := disc.NewHTTP(conf.Dmsg.DiscoveryDmsg, httpC, log)
 
-	dmsgDisc := disc.NewHTTP(discURL, httpC, log)
-	discClient := dmsgDisc
-	if useSelfHostedDisc {
-		seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKs(conf.Dmsg.DiscoveryDmsg)...)
-		entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
-		directDisc := direct.NewClient(entries, log)
-		discClient = dmsgclient.NewRegisteringFallbackDiscClient(directDisc, dmsgDisc, log)
-	}
+	seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKs(conf.Dmsg.DiscoveryDmsg)...)
+	entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
+	directDisc := direct.NewClient(entries, log)
+	discClient := dmsgclient.NewRegisteringFallbackDiscClient(directDisc, dmsgDisc, log)
 
 	client := dmsg.NewClient(conf.PK, conf.SK, discClient, dmsgConf)
-
-	// Pre-seed the entry cache with the configured dmsg servers so the
-	// Serve loop's seeded-fallback path (#3146) has something to fall
-	// back to during a fleet cold-start where live discovery briefly
-	// has no entries. Also bootstraps the no-disc-URL fallback path.
 	for _, srv := range conf.Dmsg.Servers {
 		if srv == nil || srv.Static.Null() || srv.Server == nil {
 			continue
 		}
 		client.SeedEntryCache(srv.Static, srv)
 	}
-
-	if useSelfHostedDisc {
-		// Wire the dmsg.Client as its OWN http.Transport so disc.NewHTTP
-		// reaches dmsg-discovery via dmsg-HTTP. Safe to set after
-		// NewClient: the transport isn't dialed until the first PostEntry
-		// /Entry call, by which time Serve has already established
-		// sessions to the seeded servers. Pattern matches
-		// dmsgclient.StartDmsgSelfHostedDisc.
-		httpC.Transport = dmsghttp.MakeHTTPTransport(context.Background(), client)
-	}
+	httpC.Transport = dmsghttp.MakeHTTPTransport(context.Background(), client)
 
 	return client
 }

--- a/pkg/transport-setup/api/api.go
+++ b/pkg/transport-setup/api/api.go
@@ -2,14 +2,19 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-playground/validator/v10"
 
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/direct"
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/transport-setup/config"
@@ -51,20 +56,84 @@ func New(log *logging.Logger, conf config.Config) *API {
 
 func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	dmsgConf := dmsg.DefaultConfig()
-	disc := disc.NewHTTP(conf.Dmsg.Discovery, &http.Client{}, log)
-	client := dmsg.NewClient(conf.PK, conf.SK, disc, dmsgConf)
+
+	// Pick the dmsg-discovery URL and the http.Client used to query it.
+	// Mirrors pkg/router/setupnode.go and dmsgclient.StartDmsgSelfHostedDisc:
+	//
+	//   - If conf.Dmsg.Discovery (plain HTTP) is set, use it as before.
+	//   - Else if conf.Dmsg.DiscoveryDmsg + seed servers are set, fall
+	//     into the self-hosted disc pattern: a registering fallback
+	//     disc client whose READ path resolves seeded servers directly
+	//     (no round-trip) and whose WRITE path (PutEntry — so this
+	//     service's own entry IS published to the real dmsg-discovery)
+	//     goes through an http.Client whose Transport is dmsghttp,
+	//     routed over the same dmsg.Client we are building. Self-
+	//     hosted: one client both registers itself and resolves
+	//     bootstrap PKs statically, no plain-HTTP fallback.
+	//   - Else: the original NewHTTP("") path, which returns a no-op
+	//     discovery client; the Serve-loop fallback (#3146) still
+	//     pulls seeded servers from SeedEntryCache for the initial
+	//     dial, but the service can't publish its own entry — useful
+	//     only for air-gapped / single-host setups.
+	discURL := conf.Dmsg.Discovery
+	httpC := &http.Client{}
+	useSelfHostedDisc := discURL == "" && conf.Dmsg.DiscoveryDmsg != "" && len(conf.Dmsg.Servers) > 0
+	if useSelfHostedDisc {
+		discURL = conf.Dmsg.DiscoveryDmsg
+	}
+
+	dmsgDisc := disc.NewHTTP(discURL, httpC, log)
+	var discClient disc.APIClient = dmsgDisc
+	if useSelfHostedDisc {
+		seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKs(conf.Dmsg.DiscoveryDmsg)...)
+		entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
+		directDisc := direct.NewClient(entries, log)
+		discClient = dmsgclient.NewRegisteringFallbackDiscClient(directDisc, dmsgDisc, log)
+	}
+
+	client := dmsg.NewClient(conf.PK, conf.SK, discClient, dmsgConf)
+
 	// Pre-seed the entry cache with the configured dmsg servers so the
 	// Serve loop's seeded-fallback path (#3146) has something to fall
-	// back to when conf.Dmsg.Discovery is empty (dmsg-only deployment,
-	// disc.NewHTTP returns a no-op client) or during a fleet cold-start
-	// where live discovery briefly has no entries. Without this, dmsg-
-	// only TPS instances spin on "No entries found" indefinitely even
-	// though tps.json explicitly lists upstream servers.
+	// back to during a fleet cold-start where live discovery briefly
+	// has no entries. Also bootstraps the no-disc-URL fallback path.
 	for _, srv := range conf.Dmsg.Servers {
 		if srv == nil || srv.Static.Null() || srv.Server == nil {
 			continue
 		}
 		client.SeedEntryCache(srv.Static, srv)
 	}
+
+	if useSelfHostedDisc {
+		// Wire the dmsg.Client as its OWN http.Transport so disc.NewHTTP
+		// reaches dmsg-discovery via dmsg-HTTP. Safe to set after
+		// NewClient: the transport isn't dialed until the first PostEntry
+		// /Entry call, by which time Serve has already established
+		// sessions to the seeded servers. Pattern matches
+		// dmsgclient.StartDmsgSelfHostedDisc.
+		httpC.Transport = dmsghttp.MakeHTTPTransport(context.Background(), client)
+	}
+
 	return client
+}
+
+// dmsgServicePKs extracts the public key from a dmsg:// service URL
+// (e.g. "dmsg://<pk>:<port>") so the dmsg-discovery PK can be added to
+// the static seed-client mapping. Returns an empty slice for blank or
+// malformed URLs — the caller is then bootstrapped with only its own
+// PK in the synthetic seed map, which is the same shape as a brand-new
+// service with no DiscoveryDmsg configured.
+func dmsgServicePKs(discoveryDmsg string) cipher.PubKeys {
+	if discoveryDmsg == "" {
+		return nil
+	}
+	const prefix = "dmsg://"
+	if len(discoveryDmsg) <= len(prefix) || discoveryDmsg[:len(prefix)] != prefix {
+		return nil
+	}
+	var addr dmsg.Addr
+	if err := addr.Set(discoveryDmsg[len(prefix):]); err != nil {
+		return nil
+	}
+	return cipher.PubKeys{addr.PK}
 }

--- a/pkg/visor/init_stats.go
+++ b/pkg/visor/init_stats.go
@@ -394,9 +394,9 @@ func isDMSGOnline(v *Visor) bool {
 	// uptime probe that is simply wrong: it can't see dmsg drop mid-run, and
 	// it produces nonsensical comparisons against the live skynet/transport
 	// probe (e.g. skynet uptime appearing higher than dmsg, which is
-	// impossible when both are measured live). ConnectedServers() reads the
+	// impossible when both are measured live). AllSessions() reads the
 	// current client-session set, so this tracks real dmsg connectivity.
-	return len(v.dmsgC.ConnectedServers()) > 0
+	return len(v.dmsgC.AllSessions()) > 0
 }
 
 func countLiveTransports(v *Visor) int {


### PR DESCRIPTION
## Summary

Make both `transport-setup` (TPS) and `pkg/router` (route-setup node, RSN) match the visor's post-#3136 single-client bootstrap exactly, and **drop the plain-HTTP discovery path from both** — that config is no longer supported for deployment services.

## What changes

### `pkg/transport-setup/api/api.go`

- Remove the `useSelfHostedDisc` conditional; always build:
  - `direct.NewClient` preloaded with synthetic entries for the local PK + the dmsg-disc PK (from `conf.Dmsg.DiscoveryDmsg`)
  - `disc.NewHTTP(DiscoveryDmsg, httpC, log)` against an empty `http.Client`
  - `dmsgclient.NewRegisteringFallbackDiscClient` over the two: READS short-circuit through `direct`, WRITES (the service's own entry registration) go via `dmsg-HTTP`
  - one `dmsg.NewClient` whose `http.Transport` is itself (`dmsghttp.MakeHTTPTransport(ctx, dmsgC)` post-construction)
  - `SeedEntryCache` for every configured server (bootstrap dial path + the Serve-loop fallback from #3146)
- Drop `conf.Dmsg.Discovery`; use `conf.Dmsg.DiscoveryDmsg` unconditionally.

### `pkg/router/setupnode.go`

- Replace the legacy dual-dmsg-client setup with the same single-client pattern. The previous code used `direct.StartDmsg` to spin up a **second** `dmsg.Client` with `conf.PK` just to back the dmsg-HTTP transport — exactly the dual-client self-eviction storm Alpha eliminated for the visor in #3136 / #3139. dmsg servers key sessions by client-PK with newest-wins eviction (#3035), so the two clients evicted each other on every shared server.
- Drop `conf.Dmsg.Discovery`; use `conf.Dmsg.DiscoveryDmsg` unconditionally.

After this, both services run with **one** dmsg client per PK, share no session slots, and have no plain-HTTP fallback path — consistent with the direction that dmsg-HTTP is becoming the only supported config for deployment services.

## Test plan

- [x] `go build ./cmd/skywire` succeeds
- [x] `go vet ./pkg/transport-setup/... ./pkg/router/...` clean
- [ ] Deploy via autopull; verify on a TPS instance with `tps.json.dmsg.discovery` removed: (a) `Initial post entry succeeded` log appears, (b) `/dmsg-discovery/entry/<tps-pk>` returns 200, (c) visors dial the TPS service successfully.
- [ ] If/when a route-setup node is brought up via autopull, verify it bootstraps the same way (no dual-client churn in dmsg-server logs against the RSN's PK).

## Related

Builds on:
- #3146 (Serve-loop fallback to seeded servers)
- #3157 (TPS seeds the entry cache from config)
- #3136 / #3139 (visor single-client convergence + recursive-mutex fix)