### PR TITLE
feat(landing): identity- & relationship-aware landing page + home.dmsg service endpoints

### DIFF
--- a/pkg/dmsgweb/home.go
+++ b/pkg/dmsgweb/home.go
@@ -12,7 +12,27 @@ import (
 	"strings"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skyenv/svcendpoints"
 )
+
+// serviceEndpointAlias maps a svcendpoints.Manifest service id to the resolver
+// alias label that points at that service's base dmsg address. The id and the
+// label coincide for every service except "reward" (aliased "rewards"). Only
+// services with a configured, resolvable alias are rendered — a service whose
+// base address is empty has no alias entry and is skipped.
+var serviceEndpointAlias = map[string]string{
+	"dmsgd":  "dmsgd",
+	"tpd":    "tpd",
+	"ar":     "ar",
+	"rf":     "rf",
+	"sd":     "sd",
+	"ut":     "ut",
+	"reward": "rewards",
+}
+
+// serviceEndpointOrder fixes the render order of the per-service endpoint
+// directory so the page is stable across runs (map iteration is random).
+var serviceEndpointOrder = []string{"dmsgd", "tpd", "ar", "rf", "sd", "ut", "reward"}
 
 // HomeAlias is a reserved resolver label that serves a synthetic directory of
 // every alias this resolver knows — a navigation index for the proxy. It is
@@ -66,9 +86,11 @@ func renderHomePage(aliases map[string]cipher.PubKey, suffix string, localPK cip
 	b.WriteString("<title>skywire resolver</title><style>")
 	b.WriteString("body{font:14px/1.5 system-ui,sans-serif;max-width:48rem;margin:2rem auto;padding:0 1rem;color:#222}")
 	b.WriteString("h1{font-size:1.4rem}h2{font-size:1rem;margin:1.5rem 0 .3rem;color:#555}")
+	b.WriteString("h3{font-size:.9rem;margin:.8rem 0 .2rem;color:#444}")
 	b.WriteString("ul{list-style:none;padding:0;margin:0}li{padding:.15rem 0}")
 	b.WriteString("a{text-decoration:none;font-weight:600}code{color:#999;font-size:11px;word-break:break-all}")
-	b.WriteString("@media(prefers-color-scheme:dark){body{background:#1a1a1a;color:#ddd}h2{color:#aaa}code{color:#777}}")
+	b.WriteString("small{color:#888;font-size:10px;font-weight:600;text-transform:uppercase}")
+	b.WriteString("@media(prefers-color-scheme:dark){body{background:#1a1a1a;color:#ddd}h2{color:#aaa}h3{color:#bbb}code{color:#777}}")
 	b.WriteString("</style></head><body>")
 	b.WriteString("<h1>skywire resolver</h1>")
 	b.WriteString("<p>Services reachable by name through this resolving proxy. Each link tunnels over the mesh — no clearnet hop.</p>")
@@ -76,6 +98,7 @@ func renderHomePage(aliases map[string]cipher.PubKey, suffix string, localPK cip
 	// setup nodes and dmsg servers don't, but they all answer "/health".
 	writeHomeGroup(&b, "This visor", self, suffix, "/")
 	writeHomeGroup(&b, "Deployment services", services, suffix, "/health")
+	writeServiceEndpoints(&b, aliases, suffix)
 	writeHomeGroup(&b, "Setup nodes", setup, suffix, "/health")
 	writeHomeGroup(&b, "dmsg servers", servers, suffix, "/health")
 	if len(self)+len(services)+len(setup)+len(servers) == 0 {
@@ -96,6 +119,43 @@ func writeHomeGroup(b *strings.Builder, title string, es []homeEntry, suffix, pa
 		fmt.Fprintf(b, `<li><a href="%s">%s%s</a> <code>%s</code></li>`, href, host, html.EscapeString(path), e.pk.Hex())
 	}
 	b.WriteString("</ul>")
+}
+
+// writeServiceEndpoints renders a per-service directory of each deployment
+// service's notable PUBLIC API endpoints (not just /health). Paths come from
+// the deployment-independent svcendpoints.Manifest; the base host comes from
+// the resolver's alias map (this visor's resolved config), so links resolve as
+// "<alias><suffix><path>" through the same proxy. A service whose base address
+// is not configured has no alias entry and is skipped entirely.
+func writeServiceEndpoints(b *strings.Builder, aliases map[string]cipher.PubKey, suffix string) {
+	var any bool
+	for _, id := range serviceEndpointOrder {
+		eps := svcendpoints.Manifest[id]
+		if len(eps) == 0 {
+			continue
+		}
+		label, ok := serviceEndpointAlias[id]
+		if !ok {
+			continue
+		}
+		// Skip services with no configured (resolvable) base address.
+		if _, ok := aliases[label]; !ok {
+			continue
+		}
+		if !any {
+			b.WriteString("<h2>Service API endpoints</h2>")
+			any = true
+		}
+		host := html.EscapeString(label + suffix)
+		fmt.Fprintf(b, "<h3>%s <code>%s</code></h3><ul>", html.EscapeString(label), host)
+		for _, ep := range eps {
+			href := html.EscapeString("http://" + label + suffix + ep.Path)
+			fmt.Fprintf(b, `<li><a href="%s">%s</a> <small>%s</small> — %s</li>`,
+				href, html.EscapeString(host+ep.Path),
+				html.EscapeString(ep.Method), html.EscapeString(ep.Desc))
+		}
+		b.WriteString("</ul>")
+	}
 }
 
 // homeNatLess compares labels with trailing-number awareness so an indexed set

--- a/pkg/dmsgweb/home_test.go
+++ b/pkg/dmsgweb/home_test.go
@@ -54,6 +54,25 @@ func TestRenderHomePage(t *testing.T) {
 	assert.Less(t, strings.Index(page, "This visor"), strings.Index(page, "Deployment services"))
 }
 
+func TestRenderHomePageServiceEndpoints(t *testing.T) {
+	tpdPK, _ := cipher.GenerateKeyPair()
+	dmsgdPK, _ := cipher.GenerateKeyPair()
+
+	// Only tpd + dmsgd configured → only those services get an endpoint
+	// directory; ar/rf/sd/ut/reward (no alias) are skipped.
+	aliases := map[string]cipher.PubKey{"tpd": tpdPK, "dmsgd": dmsgdPK}
+	page := string(renderHomePage(aliases, ".dmsg", cipher.PubKey{}))
+
+	assert.Contains(t, page, "Service API endpoints")
+	// A non-/health endpoint from the manifest, paired with the service's
+	// resolver alias and tunneled through the same proxy.
+	assert.Contains(t, page, `href="http://tpd.dmsg/all-transports"`)
+	assert.Contains(t, page, `href="http://dmsgd.dmsg/dmsg-discovery/available_servers"`)
+	// A service with no configured alias is not rendered.
+	assert.NotContains(t, page, "http://ar.dmsg/resolve")
+	assert.NotContains(t, page, "http://sd.dmsg/api/services")
+}
+
 func TestRenderHomePageNatSort(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 	aliases := map[string]cipher.PubKey{"dmsg0": pk, "dmsg2": pk, "dmsg10": pk}

--- a/pkg/skyenv/svcendpoints/svcendpoints.go
+++ b/pkg/skyenv/svcendpoints/svcendpoints.go
@@ -1,0 +1,114 @@
+// Package svcendpoints is a data-only leaf package describing the notable
+// PUBLIC HTTP GET endpoints each deployment service exposes. It carries no
+// behavior and no heavy imports — just a static manifest — so the resolving
+// proxy's home page (pkg/dmsgweb) can render a per-service endpoint directory
+// without depending on the service implementations.
+//
+// The PATHS here are deployment-INDEPENDENT (they come from each service's chi
+// router); the ADDRESSES they pair with are deployment-SPECIFIC and supplied by
+// the caller from the visor's resolved config. Keep this file in sync with the
+// services' actual routers (pkg/dmsg/discovery/api, pkg/transport-discovery/api,
+// pkg/address-resolver/api, pkg/route-finder/api, pkg/service-discovery/api,
+// pkg/uptime-tracker/api, and the reward server in
+// cmd/skywire-cli/commands/rewards/server).
+package svcendpoints
+
+// Endpoint is one notable public HTTP endpoint of a deployment service.
+type Endpoint struct {
+	// Method is the HTTP method (e.g. "GET", "POST").
+	Method string
+	// Path is the request path, deployment-independent.
+	Path string
+	// Desc is a short human-readable description for the directory page.
+	Desc string
+}
+
+// Manifest maps a stable service id to its notable public endpoints. The ids
+// match the resolver's canonical service-alias labels so the home page can pair
+// each id with the service's base dmsg address:
+//
+//	"dmsgd"  — dmsg-discovery
+//	"tpd"    — transport-discovery
+//	"ar"     — address-resolver
+//	"rf"     — route-finder
+//	"sd"     — service-discovery
+//	"ut"     — uptime-tracker
+//	"reward" — reward system
+//
+// Only PUBLIC, browser-reachable GET endpoints (and a couple of notable POSTs)
+// are listed — auth'd registration/heartbeat/deregister and security-nonce
+// endpoints are intentionally omitted from the directory.
+var Manifest = map[string][]Endpoint{
+	// dmsg-discovery — pkg/dmsg/discovery/api/api.go
+	"dmsgd": {
+		{"GET", "/health", "service health + build info"},
+		{"GET", "/dmsg-discovery/entry/{pk}", "client/server entry by PK"},
+		{"GET", "/dmsg-discovery/entries", "all client entry PKs"},
+		{"GET", "/dmsg-discovery/visorEntries", "all visor client entries"},
+		{"GET", "/dmsg-discovery/available_servers", "available dmsg servers"},
+		{"GET", "/dmsg-discovery/all_servers", "all dmsg servers"},
+		{"GET", "/dmsg-discovery/servers/clients", "clients grouped by server"},
+		{"GET", "/dmsg-discovery/server/{pk}/clients", "clients delegated to a server"},
+		{"GET", "/uptimes", "visor uptime summaries (?v=v2|v3&visors=)"},
+	},
+	// transport-discovery — pkg/transport-discovery/api/api.go
+	"tpd": {
+		{"GET", "/health", "service health + build info"},
+		{"GET", "/all-transports", "all registered transports"},
+		{"GET", "/all-transports/stats", "all-transports bandwidth stats"},
+		{"GET", "/all-transports/per-key-stats", "per-visor transport stats"},
+		{"GET", "/transports/id:{id}", "transport by ID"},
+		{"GET", "/transports/edge:{edge}", "transports by edge PK"},
+		{"GET", "/transports/stats/{edge}", "transport stats by edge"},
+		{"GET", "/v3/transports/edge:{edge}", "DHT-aligned transports by edge"},
+		{"GET", "/bandwidth/transport/{id}", "transport bandwidth"},
+		{"GET", "/bandwidth/visor/{pk}", "visor bandwidth"},
+		{"GET", "/metric", "network-wide transport metric"},
+		{"GET", "/metric/visor/{pks}", "aggregate metric for visors"},
+		{"GET", "/metrics", "all transport metrics"},
+		{"GET", "/metrics/{ids}", "metrics for transport IDs"},
+		{"GET", "/metrics/visor/{pks}", "metrics for visors"},
+		{"GET", "/metrics/uptime", "network transport uptime"},
+		{"GET", "/uptimes", "visor uptime summaries"},
+		{"GET", "/uptimes/transports", "transport uptime summaries"},
+		{"GET", "/version", "version stats"},
+		{"GET", "/versions", "per-visor versions"},
+		{"GET", "/uptime/now", "service-self uptime (now)"},
+	},
+	// address-resolver — pkg/address-resolver/api/api.go
+	"ar": {
+		{"GET", "/health", "service health + build info"},
+		{"GET", "/transports", "registered stcpr/sudph bindings"},
+		{"GET", "/resolve/{type}/{pk}", "resolve a visor's network address"},
+	},
+	// route-finder — pkg/route-finder/api/api.go
+	"rf": {
+		{"GET", "/health", "service health + build info"},
+		{"POST", "/routes", "find paired routes between two visors"},
+	},
+	// service-discovery — pkg/service-discovery/api/api.go
+	"sd": {
+		{"GET", "/health", "service health + build info"},
+		{"GET", "/api/services", "service entries (?type=&version=&country=&quantity=)"},
+		{"GET", "/api/services/{addr}", "service entry by address"},
+		{"GET", "/uptimes", "visor uptime summaries"},
+	},
+	// uptime-tracker — pkg/uptime-tracker/api/api.go
+	"ut": {
+		{"GET", "/health", "service health + build info"},
+		{"GET", "/visors", "all tracked visors"},
+		{"GET", "/uptimes", "uptime summaries"},
+		{"GET", "/uptime/{pk}", "uptime for a single visor"},
+		{"GET", "/dashboard", "uptime dashboard chart"},
+	},
+	// reward system — cmd/skywire-cli/commands/rewards/server
+	"reward": {
+		{"GET", "/health", "service health"},
+		{"GET", "/transports", "transport visualization page"},
+		{"GET", "/transports-map", "transport map page"},
+		{"GET", "/transport-graph", "transport graph page"},
+		{"GET", "/log-collection", "reward log collection overview"},
+		{"GET", "/log-collection/tree", "reward log collection tree"},
+		{"GET", "/stats/ut", "uptime stats"},
+	},
+}

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -89,7 +89,7 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			cfg.UpstreamSOCKS = fmt.Sprintf("127.0.0.1:%d", defaultSkynetWebProxyPort)
 			log := logging.MustGetLogger("embedded_dmsgweb")
 			aliases, dmsgSet := resolverAliasesAndDmsgServers(v)
-			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, aliases, dmsgSet, cfg, log)
+			runtime = newEmbeddedDmsgWeb(v.ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, aliases, dmsgSet, cfg, log)
 			v.embeddedDmsgWeb = runtime
 		}
 		v.initLock.Unlock()
@@ -120,7 +120,7 @@ func (v *Visor) SetEmbeddedProxyEnabled(kind string, enable bool) error {
 			}
 			cfg := &visorconfig.SkynetWebConfig{Enable: true}
 			log := logging.MustGetLogger("embedded_skynetweb")
-			runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, cfg, log)
+			runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, cfg, log)
 			v.embeddedSkynetWeb = runtime
 		}
 		v.initLock.Unlock()
@@ -271,7 +271,7 @@ func (v *Visor) autoStartSkynetWeb() {
 		}
 		cfg := &visorconfig.SkynetWebConfig{Enable: true}
 		log := logging.MustGetLogger("embedded_skynetweb")
-		runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, cfg, log)
+		runtime = newEmbeddedSkynetWeb(v.ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, cfg, log)
 		v.embeddedSkynetWeb = runtime
 	}
 	v.initLock.Unlock()

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -537,6 +537,37 @@ func (v *Visor) RemoteVisors() ([]string, error) {
 	return visors, nil
 }
 
+// ManagedVisors implements logserver.RelatedNodesProvider. It returns the PKs
+// of the visors this node manages as a hypervisor — the same connected set as
+// `hv ls`. Empty when this node is not acting as a hypervisor (v.conf.Hypervisor
+// nil), so the landing page only shows the managed-visors section for a node
+// that actually IS a hypervisor. Reads v.remoteVisors lock-free, matching the
+// existing RemoteVisors() accessor.
+func (v *Visor) ManagedVisors() []cipher.PubKey {
+	if v == nil || v.conf == nil || v.conf.Hypervisor == nil {
+		return nil
+	}
+	out := make([]cipher.PubKey, 0, len(v.remoteVisors))
+	for _, conn := range v.remoteVisors {
+		out = append(out, conn.Addr.PK)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Hex() < out[j].Hex() })
+	return out
+}
+
+// ConfiguredHypervisors implements logserver.RelatedNodesProvider. It returns
+// the PKs of the hypervisors this visor is configured to be managed by
+// (v.conf.Hypervisors).
+func (v *Visor) ConfiguredHypervisors() []cipher.PubKey {
+	if v == nil || v.conf == nil {
+		return nil
+	}
+	out := make([]cipher.PubKey, 0, len(v.conf.Hypervisors))
+	out = append(out, v.conf.Hypervisors...)
+	sort.Slice(out, func(i, j int) bool { return out[i].Hex() < out[j].Hex() })
+	return out
+}
+
 // DmsgPtyExec runs a one-shot command on the remote visor identified
 // by args.RemotePK using this visor's embedded dmsgpty host. Skips
 // the host's CLI control listener (the unix socket / TCP loopback

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -56,6 +56,11 @@ type EmbeddedDmsgWeb struct {
 	stats    *dmsgweb.Stats                      // persists across Start/Stop cycles
 	localPK  cipher.PubKey                       // this visor's PK, for self-loopback + "self" alias
 	selfDial func(port uint16) (net.Conn, error) // in-process serve of a local service port (nil disables loopback)
+	// selfDialAs is the PK-stamping variant of selfDial: it makes the
+	// in-process self-loopback conn present remotePK as the caller. Used to
+	// render the self view as authenticated (with localPK). Nil falls back to
+	// the unauthenticated selfDial.
+	selfDialAs func(port uint16, remotePK cipher.PubKey) (net.Conn, error)
 
 	// serviceAliases maps canonical short labels (tpd, ar, rf, sd, ut, dmsgd,
 	// rsn*, tsn*, dmsg*) to the configured deployment services' PKs, so the
@@ -84,7 +89,7 @@ type EmbeddedDmsgWeb struct {
 // "resolver never ran" from "running but idle". localPK + selfDial
 // enable self-loopback (serving requests for this visor's own PK
 // in-process); pass a zero PK / nil selfDial to disable.
-func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC, directClient *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), serviceAliases map[string]cipher.PubKey, directServerPKs map[cipher.PubKey]struct{}, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
+func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC, directClient *dmsg.Client, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), selfDialAs func(uint16, cipher.PubKey) (net.Conn, error), serviceAliases map[string]cipher.PubKey, directServerPKs map[cipher.PubKey]struct{}, cfg *visorconfig.DmsgWebConfig, log *logging.Logger) *EmbeddedDmsgWeb {
 	return &EmbeddedDmsgWeb{
 		dmsgC:           dmsgC,
 		cfg:             cfg,
@@ -92,6 +97,7 @@ func newEmbeddedDmsgWeb(parentCtx context.Context, dmsgC, directClient *dmsg.Cli
 		stats:           dmsgweb.NewStats(),
 		localPK:         localPK,
 		selfDial:        selfDial,
+		selfDialAs:      selfDialAs,
 		serviceAliases:  serviceAliases,
 		directClient:    directClient,
 		directServerPKs: directServerPKs,
@@ -197,6 +203,18 @@ func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 		cfg.LocalPK = e.localPK
 		cfg.SelfLoopback = true
 		cfg.SelfDial = e.selfDial
+		// Self-loopback-authenticated (default on): present THIS visor's own
+		// PK as the caller so the in-process self view renders the
+		// authenticated landing page (pprof, /visor.log, …). The visor's PK
+		// is always on its own landing-page whitelist; local self-access
+		// through one's own proxy is inherently authorized. Disable with
+		// self_loopback_authenticated:false to render the self view anonymously.
+		if e.selfDialAs != nil && (e.cfg.SelfLoopbackAuthenticated == nil || *e.cfg.SelfLoopbackAuthenticated) {
+			localPK := e.localPK
+			cfg.SelfDial = func(port uint16) (net.Conn, error) {
+				return e.selfDialAs(port, localPK)
+			}
+		}
 	}
 	// Canonical service aliases (tpd, ar, rf, …) first, then this visor's own
 	// alias on top so a colliding self-alias always wins.
@@ -424,7 +442,7 @@ func initEmbeddedDmsgWeb(ctx context.Context, v *Visor, log *logging.Logger) err
 	}
 
 	aliases, dmsgSet := resolverAliasesAndDmsgServers(v)
-	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, aliases, dmsgSet, cfg, log)
+	runtime := newEmbeddedDmsgWeb(ctx, v.dmsgC, v.dmsgDC, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, aliases, dmsgSet, cfg, log)
 	v.initLock.Lock()
 	v.embeddedDmsgWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -48,9 +48,11 @@ type EmbeddedSkynetWeb struct {
 	skynetMux **transport.VStreamMux // pointer to visor's mux pointer (late-bound)
 	localPK   cipher.PubKey
 	selfDial  func(port uint16) (net.Conn, error) // in-process serve of a local service port (nil disables loopback)
-	cfg       *visorconfig.SkynetWebConfig
-	log       *logging.Logger
-	stats     *skynetweb.Stats
+	// selfDialAs is the PK-stamping variant of selfDial — see EmbeddedDmsgWeb.
+	selfDialAs func(port uint16, remotePK cipher.PubKey) (net.Conn, error)
+	cfg        *visorconfig.SkynetWebConfig
+	log        *logging.Logger
+	stats      *skynetweb.Stats
 
 	mu        sync.Mutex
 	running   bool
@@ -59,17 +61,18 @@ type EmbeddedSkynetWeb struct {
 	parentCtx context.Context
 }
 
-func newEmbeddedSkynetWeb(parentCtx context.Context, r router.Router, tpM *transport.Manager, skynetMuxPtr **transport.VStreamMux, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), cfg *visorconfig.SkynetWebConfig, log *logging.Logger) *EmbeddedSkynetWeb {
+func newEmbeddedSkynetWeb(parentCtx context.Context, r router.Router, tpM *transport.Manager, skynetMuxPtr **transport.VStreamMux, localPK cipher.PubKey, selfDial func(uint16) (net.Conn, error), selfDialAs func(uint16, cipher.PubKey) (net.Conn, error), cfg *visorconfig.SkynetWebConfig, log *logging.Logger) *EmbeddedSkynetWeb {
 	return &EmbeddedSkynetWeb{
-		router:    r,
-		tpM:       tpM,
-		skynetMux: skynetMuxPtr,
-		localPK:   localPK,
-		selfDial:  selfDial,
-		cfg:       cfg,
-		log:       log,
-		stats:     skynetweb.NewStats(),
-		parentCtx: parentCtx,
+		router:     r,
+		tpM:        tpM,
+		skynetMux:  skynetMuxPtr,
+		localPK:    localPK,
+		selfDial:   selfDial,
+		selfDialAs: selfDialAs,
+		cfg:        cfg,
+		log:        log,
+		stats:      skynetweb.NewStats(),
+		parentCtx:  parentCtx,
 	}
 }
 
@@ -169,6 +172,13 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 		cfg.LocalPK = e.localPK
 		cfg.SelfLoopback = true
 		cfg.SelfDial = e.selfDial
+		// Self-loopback-authenticated (default on): see EmbeddedDmsgWeb.serve.
+		if e.selfDialAs != nil && (e.cfg.SelfLoopbackAuthenticated == nil || *e.cfg.SelfLoopbackAuthenticated) {
+			localPK := e.localPK
+			cfg.SelfDial = func(port uint16) (net.Conn, error) {
+				return e.selfDialAs(port, localPK)
+			}
+		}
 	}
 	cfg.Aliases = resolverAliasMap(e.cfg.Alias, e.localPK)
 
@@ -403,7 +413,7 @@ func initEmbeddedSkynetWeb(ctx context.Context, v *Visor, log *logging.Logger) e
 		log.Warn("skynet_web configured but router not available; skipping")
 		return nil
 	}
-	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.conf.SkynetWeb, log)
+	runtime := newEmbeddedSkynetWeb(ctx, v.router, v.tpM, &v.skynetFwdMux, v.conf.PK, v.services.SelfDial, v.services.SelfDialAs, v.conf.SkynetWeb, log)
 	v.initLock.Lock()
 	v.embeddedSkynetWeb = runtime
 	v.initLock.Unlock()

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -608,6 +608,9 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 	// what ports are available for skynet forwarding.
 	lsAPI.SetServiceLister(v.services)
 	lsAPI.SetForwardedPortLister(v.forwardedPorts)
+	// Related nodes (managed visors + configured hypervisors) — shown as
+	// links to authenticated callers on the landing page.
+	lsAPI.SetRelatedNodesProvider(v)
 
 	// Mount the dmsgpty web terminal at /pty, gated by the same
 	// whitelist the dmsgpty Host enforces on direct connections —

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -74,6 +74,25 @@ type CXOFeedEntry struct {
 	System      bool   `json:"system,omitempty"`
 }
 
+// RelatedNodesProvider exposes this node's mesh relationships for the
+// landing page: the visors a hypervisor manages, and the hypervisors a
+// visor is configured to trust. Both are shown ONLY to an authenticated
+// (survey-whitelisted, or self-loopback) caller — they reveal the node's
+// management topology — and rendered as links to each peer's landing page
+// (http://<pk>.dmsg), reachable through a resolving proxy.
+//
+// Implemented by the visor. A nil provider (or empty slices) renders no
+// related-nodes section.
+type RelatedNodesProvider interface {
+	// ManagedVisors returns the PKs of the visors this node currently
+	// manages as a hypervisor (the same set as `hv ls`). Empty when this
+	// node is not acting as a hypervisor or has no connected visors.
+	ManagedVisors() []cipher.PubKey
+	// ConfiguredHypervisors returns the PKs of the hypervisors this visor
+	// is configured to be managed by (v.conf.Hypervisors).
+	ConfiguredHypervisors() []cipher.PubKey
+}
+
 // CXOFeedsLister provides the list of CXO feeds the visor is publishing.
 // Returns the always-on system feed (stats/telemetry) plus any
 // user-registered feeds. Pure metadata — actual feed content is served
@@ -87,15 +106,16 @@ type CXOFeedsLister interface {
 type API struct {
 	http.Handler
 
-	logger              *logging.Logger
-	startedAt           time.Time
-	healthStatsProvider HealthStatsProvider
-	serviceLister       ServiceLister
-	forwardedPortLister ForwardedPortLister
-	cxoFeedsLister      CXOFeedsLister
-	statsReader         StatsReader             // visor-local telemetry store, set via SetStatsReader
-	uptimeRecorder      *serviceuptime.Recorder // service-self uptime, set via SetUptimeRecorder
-	websiteHandler      http.Handler            // optional: serves unmatched routes (custom website)
+	logger               *logging.Logger
+	startedAt            time.Time
+	healthStatsProvider  HealthStatsProvider
+	serviceLister        ServiceLister
+	forwardedPortLister  ForwardedPortLister
+	cxoFeedsLister       CXOFeedsLister
+	relatedNodesProvider RelatedNodesProvider
+	statsReader          StatsReader             // visor-local telemetry store, set via SetStatsReader
+	uptimeRecorder       *serviceuptime.Recorder // service-self uptime, set via SetUptimeRecorder
+	websiteHandler       http.Handler            // optional: serves unmatched routes (custom website)
 	// ptyHandler serves /pty (web terminal) when set by the visor.
 	// Gated by ptyWhitelist — typically the dmsgpty whitelist (configured
 	// PKs + hypervisor PKs + the visor's own PK).
@@ -329,6 +349,29 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 					links = append(links, `<a href="/pty">/pty</a> - web terminal (dmsgpty)`)
 				}
 			}
+
+			// Related nodes — shown ONLY to authenticated callers (this
+			// section is gated strictly on `wl`). As LINKS to each peer's
+			// landing page over a resolving proxy (http://<pk>.dmsg).
+			if api.relatedNodesProvider != nil {
+				// Part 2: visors this node manages as a hypervisor.
+				if managed := api.relatedNodesProvider.ManagedVisors(); len(managed) > 0 {
+					links = append(links, "")
+					links = append(links, "managed visors (this hypervisor):")
+					for _, pk := range managed {
+						links = append(links, fmt.Sprintf(`  <a href="http://%s.dmsg">%s.dmsg</a>`, pk.Hex(), pk.Hex()))
+					}
+				}
+				// Part 3: hypervisors this visor is configured to trust.
+				if hvs := api.relatedNodesProvider.ConfiguredHypervisors(); len(hvs) > 0 {
+					links = append(links, "")
+					links = append(links, "configured hypervisors:")
+					for _, pk := range hvs {
+						links = append(links, fmt.Sprintf(`  <a href="http://%s.dmsg">%s.dmsg</a>`, pk.Hex(), pk.Hex()))
+					}
+					links = append(links, `  <small>(an hv link resolves only through a proxy that can route to it)</small>`)
+				}
+			}
 		}
 		// Add forwarded ports visible on the landing page.
 		// Use the request Host to construct proper URLs that work
@@ -484,6 +527,13 @@ func (api *API) SetPtyHandler(h http.Handler, whitelist pty.Whitelist) {
 
 func (api *API) SetCXOFeedsLister(lister CXOFeedsLister) {
 	api.cxoFeedsLister = lister
+}
+
+// SetRelatedNodesProvider installs the provider whose managed-visors and
+// configured-hypervisors lists are shown (as links) on the landing page to
+// authenticated callers. Called from visor init.
+func (api *API) SetRelatedNodesProvider(p RelatedNodesProvider) {
+	api.relatedNodesProvider = p
 }
 
 func whitelistAuth(whitelistedPKs []cipher.PubKey) gin.HandlerFunc {

--- a/pkg/visor/service_registry.go
+++ b/pkg/visor/service_registry.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
 )
 
@@ -101,6 +103,40 @@ func (r *ServiceRegistry) SelfDial(port uint16) (net.Conn, error) {
 	go h(serverEnd)
 	return clientEnd, nil
 }
+
+// SelfDialAs is SelfDial but stamps the server-end conn's RemoteAddr with
+// remotePK (as a dmsg.Addr, which stringifies to "<pk>:<port>") so the
+// in-process handler sees a noise-authenticated-equivalent caller identity.
+//
+// Used by the embedded resolving proxies' self-loopback path: a request for
+// THIS visor's own PK is served in-process over net.Pipe (no transport, no
+// remote PK), which would otherwise render as anonymous on the landing page.
+// Stamping the visor's OWN PK — which is always on its own landing-page
+// whitelist — makes the self view authenticated, because local self-access
+// through one's own proxy is inherently authorized. Only the SERVER end is
+// stamped (the side the handler reads RemoteAddr from); the returned client
+// end is unchanged. The port stamped into the addr is informational only —
+// the landing-page whitelist check keys off the PK host part.
+func (r *ServiceRegistry) SelfDialAs(port uint16, remotePK cipher.PubKey) (net.Conn, error) {
+	h, ok := r.Get(port)
+	if !ok {
+		return nil, fmt.Errorf("no local service registered on port %d", port)
+	}
+	clientEnd, serverEnd := net.Pipe()
+	go h(&pkAddrConn{Conn: serverEnd, remote: dmsg.Addr{PK: remotePK, Port: port}})
+	return clientEnd, nil
+}
+
+// pkAddrConn overrides RemoteAddr so an in-process self-loopback conn reports a
+// dmsg.Addr ("<pk>:<port>") instead of net.Pipe's address-less pipeAddr. The
+// HTTP server populates Request.RemoteAddr from RemoteAddr().String(), and the
+// logserver landing page extracts the caller PK from it via net.SplitHostPort.
+type pkAddrConn struct {
+	net.Conn
+	remote net.Addr
+}
+
+func (c *pkAddrConn) RemoteAddr() net.Addr { return c.remote }
 
 // Ports returns all registered port numbers, sorted ascending.
 func (r *ServiceRegistry) Ports() []uint16 {

--- a/pkg/visor/service_registry_test.go
+++ b/pkg/visor/service_registry_test.go
@@ -1,0 +1,66 @@
+package visor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestSelfDialAsStampsPK verifies the Part-1 self-loopback-authenticated
+// mechanism: SelfDialAs stamps the server-end conn's RemoteAddr so it
+// stringifies to "<pk>:<port>" — exactly the form the landing-page whitelist
+// extracts the caller PK from via net.SplitHostPort. Plain SelfDial leaves the
+// pipe address-less (renders anonymous), which is the behavior the toggle
+// switches between.
+func TestSelfDialAsStampsPK(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	reg := NewServiceRegistry()
+
+	gotAddr := make(chan net.Addr, 1)
+	reg.Register(80, "test", func(conn net.Conn) {
+		gotAddr <- conn.RemoteAddr()
+		_ = conn.Close()
+	})
+
+	cli, err := reg.SelfDialAs(80, pk)
+	if err != nil {
+		t.Fatalf("SelfDialAs: %v", err)
+	}
+	defer cli.Close() //nolint:errcheck
+
+	addr := <-gotAddr
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		t.Fatalf("server-end RemoteAddr %q not host:port: %v", addr.String(), err)
+	}
+	if host != pk.Hex() {
+		t.Errorf("stamped host = %q, want visor PK %q", host, pk.Hex())
+	}
+}
+
+// TestSelfDialAnonymous confirms the un-stamped self-dial does NOT report a PK
+// host — so disabling self_loopback_authenticated renders the self view as an
+// anonymous caller.
+func TestSelfDialAnonymous(t *testing.T) {
+	reg := NewServiceRegistry()
+	gotAddr := make(chan net.Addr, 1)
+	reg.Register(80, "test", func(conn net.Conn) {
+		gotAddr <- conn.RemoteAddr()
+		_ = conn.Close()
+	})
+
+	cli, err := reg.SelfDial(80)
+	if err != nil {
+		t.Fatalf("SelfDial: %v", err)
+	}
+	defer cli.Close() //nolint:errcheck
+
+	addr := <-gotAddr
+	var pk cipher.PubKey
+	if host, _, err := net.SplitHostPort(addr.String()); err == nil {
+		if perr := pk.Set(host); perr == nil {
+			t.Errorf("plain SelfDial RemoteAddr %q parsed as a PK; expected address-less pipe", addr.String())
+		}
+	}
+}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -262,6 +262,15 @@ type DmsgWebConfig struct {
 	// "<alias>.dmsg" resolves to the local visor without hardcoding its
 	// public key. Defaults to "skywire" when unset (→ "skywire.dmsg").
 	Alias string `json:"alias,omitempty"`
+	// SelfLoopbackAuthenticated, when nil or true (the default), makes a
+	// self-loopback request (skywire.dmsg / <self-pk>.dmsg served in-process
+	// via SelfDial) present THIS visor's own PK as the authenticated caller.
+	// The local visor's PK is always on its own landing-page whitelist, so the
+	// in-process self view renders the same authenticated endpoints (pprof,
+	// /visor.log, …) a survey-whitelisted remote peer sees — local self-access
+	// through one's own proxy is inherently authorized. Set false to render the
+	// self-loopback landing page as an anonymous (unauthenticated) caller.
+	SelfLoopbackAuthenticated *bool `json:"self_loopback_authenticated,omitempty"`
 }
 
 // SkynetWebConfig enables the embedded `.skynet` resolving proxy — the
@@ -313,6 +322,13 @@ type SkynetWebConfig struct {
 	// "<alias>.skynet" resolves to the local visor without hardcoding its
 	// public key. Defaults to "skywire" when unset (→ "skywire.skynet").
 	Alias string `json:"alias,omitempty"`
+	// SelfLoopbackAuthenticated, when nil or true (the default), makes a
+	// self-loopback request (skywire.skynet / <self-pk>.skynet served
+	// in-process via SelfDial) present THIS visor's own PK as the
+	// authenticated caller, so the in-process self view renders the same
+	// authenticated landing-page endpoints a survey-whitelisted remote peer
+	// sees. Set false to render the self-loopback landing page anonymously.
+	SelfLoopbackAuthenticated *bool `json:"self_loopback_authenticated,omitempty"`
 }
 
 // SkymailBridgeConfig configures the embedded SMTP-aware bridge that


### PR DESCRIPTION
Four-part landing-page feature (designed with the operator):

1. **Self-loopback authenticated view** — `skywire.dmsg` now renders the authenticated view (pprof/log). New `SelfDialAs(port, pk)` stamps the server-end pipe conn RemoteAddr with `v.conf.PK` (already whitelisted). **SECURITY:** confined to the in-process self-loopback (only reachable via the resolver self-dest short-circuit `dest==LocalPK && len(route)==0` = genuine local browsing); remote callers unchanged. Toggle `self_loopback_authenticated` (default on).
2. **HV → managed-visor links** (`http://<visor-pk>.dmsg`), gated on authenticated view, only when this node is a hypervisor.
3. **Visor → configured-hypervisor links** (`http://<hv-pk>.dmsg`), gated on authenticated view.
4. **`home.dmsg` service endpoints** — new data-only `pkg/skyenv/svcendpoints` manifest (real paths per service) × base dmsg address from `v.conf` (not `deployment.Prod`); services with no configured address skipped.

Build + `pkg/dmsgweb`/`pkg/visor` tests green. Please eyeball part 1 (the auth path).