### PR TITLE
feat(cli): --sk + --config for the direct-DMSG fetch identity

### DIFF
--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -4,6 +4,7 @@ package clirpc
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -25,6 +26,7 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/dmsgc"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor"
@@ -359,17 +361,127 @@ var (
 	NoRPC bool
 	// NoDmsg disables the direct DMSG HTTP step in FetchServiceURL.
 	NoDmsg bool
+	// FetchSK, when set, is the secret key to use for the direct DMSG HTTP
+	// step's ephemeral client. Otherwise the precedence in resolveFetchIdentity
+	// applies (--config -> $DMSG_SK -> $DMSGCURL_SK -> ephemeral random).
+	FetchSK cipher.SecKey
+	// FetchConfigPath is a path to a JSON config supplying the SK and an
+	// optional dmsg-bootstrap section. Lets operators keep the SK out of
+	// shell history. See FetchConfig for the file shape.
+	FetchConfigPath string
 )
 
-// RegisterFetchFlags adds --no-cxo, --no-rpc, and --no-dmsg flags to a command.
-// Call this in init() for any command that uses FetchServiceURL. There is no
-// plain-HTTP step anymore — deployment services are reached over CXO/DMSG only;
-// for ad-hoc browser access, point the browser at the visor's dmsgweb resolving
-// proxy instead of relying on a clearnet hop.
+// FetchConfig is the minimal CLI-side identity/dmsg-bootstrap config consumed
+// by --config. The schema is compatible with a visor's skywire.json: top-level
+// "sk"/"pk" + a "dmsg" block with "discovery_dmsg" and "servers", so the same
+// file can be reused for both purposes. Extra fields in the file are ignored.
+type FetchConfig struct {
+	SK   cipher.SecKey    `json:"sk,omitempty"`
+	PK   cipher.PubKey    `json:"pk,omitempty"`
+	Dmsg dmsgc.DmsgConfig `json:"dmsg,omitempty"`
+}
+
+// RegisterFetchFlags adds the fetch-path flags to a command. Call this in
+// init() for any command that uses FetchServiceURL. There is no plain-HTTP
+// step — deployment services are reached over CXO/DMSG only; for ad-hoc
+// browser access, point the browser at the visor's dmsgweb resolving proxy
+// instead of relying on a clearnet hop.
+//
+// Flags:
+//   --no-cxo     skip the CXO subscriber-cache step.
+//   --no-rpc     skip the visor RPC (DmsgHTTP) step; forces fall-through to the
+//                direct DMSG step using a CLI-owned dmsg client.
+//   --no-dmsg    skip the direct DMSG HTTP step.
+//   --sk         secret key (hex) for the CLI-owned dmsg client when the direct
+//                step runs (--no-rpc or RPC unavailable). Visible in shell
+//                history — prefer --config for production use.
+//   --config     path to a JSON file supplying {"sk":..., "dmsg":{...}}. SK
+//                precedence: --sk > --config > $DMSG_SK > $DMSGCURL_SK > random
+//                ephemeral. Dmsg.Servers from the config seeds the direct
+//                client; absent, the embedded deployment server set is used.
 func RegisterFetchFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&NoCXO, "no-cxo", false, "skip CXO subscriber-cache step")
 	cmd.Flags().BoolVar(&NoRPC, "no-rpc", false, "skip visor RPC (DmsgHTTP) step")
 	cmd.Flags().BoolVar(&NoDmsg, "no-dmsg", false, "skip direct DMSG HTTP step")
+	cmd.Flags().Var(&FetchSK, "sk",
+		"secret key for the CLI-owned dmsg client (random if unset; prefer --config to avoid shell-history leak)")
+	cmd.Flags().StringVar(&FetchConfigPath, "config", "",
+		"path to a JSON file with the CLI's dmsg identity + bootstrap (see clirpc.FetchConfig)")
+}
+
+// resolveFetchIdentity picks the secret key and bootstrap server set the
+// direct-DMSG step will use, in this precedence:
+//
+//  1. --sk flag (flags.Changed("sk"))
+//  2. --config path: parsed as FetchConfig; SK and Dmsg.Servers taken from it
+//  3. $DMSG_SK environment variable (same convention as `dmsg curl`/`dmsg cat`)
+//  4. $DMSGCURL_SK environment variable (same convention as log-fetch helpers)
+//  5. ephemeral random key (cipher.GenerateKeyPair)
+//
+// servers comes from --config when set, else from dmsg.Prod.DmsgServers.
+// Returns (pk, sk, servers, label) — label describes the resolution path
+// for logging.
+func resolveFetchIdentity(flags *pflag.FlagSet) (cipher.PubKey, cipher.SecKey, []disc.Entry, string) {
+	servers := dmsg.Prod.DmsgServers
+	label := "ephemeral"
+
+	if flags != nil && flags.Changed("sk") {
+		pk, err := FetchSK.PubKey()
+		if err == nil {
+			return pk, FetchSK, servers, "--sk flag"
+		}
+		logger.Debugf("--sk flag set but pubkey derivation failed: %v; falling through", err)
+	}
+
+	if FetchConfigPath != "" {
+		raw, err := os.ReadFile(FetchConfigPath) //nolint:gosec
+		if err != nil {
+			logger.Debugf("--config %q read failed: %v; falling through", FetchConfigPath, err)
+		} else {
+			var fc FetchConfig
+			if jerr := json.Unmarshal(raw, &fc); jerr != nil {
+				logger.Debugf("--config %q parse failed: %v; falling through", FetchConfigPath, jerr)
+			} else {
+				if len(fc.Dmsg.Servers) > 0 {
+					srv := make([]disc.Entry, 0, len(fc.Dmsg.Servers))
+					for _, e := range fc.Dmsg.Servers {
+						if e == nil {
+							continue
+						}
+						srv = append(srv, *e)
+					}
+					if len(srv) > 0 {
+						servers = srv
+					}
+				}
+				if !fc.SK.Null() {
+					pk, perr := fc.SK.PubKey()
+					if perr == nil {
+						return pk, fc.SK, servers, "--config sk"
+					}
+					logger.Debugf("--config sk pubkey derivation failed: %v", perr)
+				}
+			}
+		}
+	}
+
+	for _, env := range []string{"DMSG_SK", "DMSGCURL_SK"} {
+		if v := os.Getenv(env); v != "" {
+			var sk cipher.SecKey
+			if err := sk.Set(v); err == nil {
+				pk, perr := sk.PubKey()
+				if perr == nil {
+					return pk, sk, servers, "$" + env
+				}
+				logger.Debugf("$%s pubkey derivation failed: %v", env, perr)
+			} else {
+				logger.Debugf("$%s parse failed: %v", env, err)
+			}
+		}
+	}
+
+	pk, sk := cipher.GenerateKeyPair()
+	return pk, sk, servers, label
 }
 
 // isDmsgURL reports whether the given URL is a dmsg:// scheme URL that
@@ -557,20 +669,20 @@ func splitOn(s string, sep byte) []string {
 // and uses a FallbackRoundTripper to try each until one reaches the target service.
 // This matches the pattern used by `skywire dmsg curl -B`: services connect to DMSG
 // servers directly (not via discovery), so we must connect to each server to find them.
-func fetchViaDmsgDirect(dmsgURL string) ([]byte, error) {
+func fetchViaDmsgDirect(flags *pflag.FlagSet, dmsgURL string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
-	// Keep the ephemeral direct-client loggers quiet. They otherwise
-	// dump session-open / yamux / EOF / entry-delete chatter at debug
-	// level for every fetch, which drowns the caller's own output.
-	// Use a dedicated master logger so we don't mutate the global one.
+	// Keep the direct-client loggers quiet. They otherwise dump
+	// session-open / yamux / EOF / entry-delete chatter at debug level
+	// for every fetch, which drowns the caller's own output. Use a
+	// dedicated master logger so we don't mutate the global one.
 	dmaster := logging.NewMasterLogger()
 	dmaster.SetLevel(logrus.ErrorLevel)
 	dlog := dmaster.PackageLogger("cli:dmsg-fetch")
-	pk, sk := cipher.GenerateKeyPair()
 
-	servers := dmsg.Prod.DmsgServers
+	pk, sk, servers, idSource := resolveFetchIdentity(flags)
+	logger.Debugf("direct DMSG identity: pk=%s source=%s", pk, idSource)
 	if len(servers) == 0 {
 		return nil, fmt.Errorf("no DMSG servers configured")
 	}
@@ -798,7 +910,7 @@ func FetchServiceURL(cmdFlags *pflag.FlagSet, url string) ([]byte, error) {
 		dmsgURL := DmsgURLForHTTP(url)
 		if dmsgURL != "" {
 			logger.Debugf("Trying direct DMSG fetch: %s", dmsgURL)
-			body, err := fetchViaDmsgDirect(dmsgURL)
+			body, err := fetchViaDmsgDirect(cmdFlags, dmsgURL)
 			if err == nil {
 				return body, nil
 			}

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -388,17 +388,18 @@ type FetchConfig struct {
 // instead of relying on a clearnet hop.
 //
 // Flags:
-//   --no-cxo     skip the CXO subscriber-cache step.
-//   --no-rpc     skip the visor RPC (DmsgHTTP) step; forces fall-through to the
-//                direct DMSG step using a CLI-owned dmsg client.
-//   --no-dmsg    skip the direct DMSG HTTP step.
-//   --sk         secret key (hex) for the CLI-owned dmsg client when the direct
-//                step runs (--no-rpc or RPC unavailable). Visible in shell
-//                history — prefer --config for production use.
-//   --config     path to a JSON file supplying {"sk":..., "dmsg":{...}}. SK
-//                precedence: --sk > --config > $DMSG_SK > $DMSGCURL_SK > random
-//                ephemeral. Dmsg.Servers from the config seeds the direct
-//                client; absent, the embedded deployment server set is used.
+//
+//	--no-cxo     skip the CXO subscriber-cache step.
+//	--no-rpc     skip the visor RPC (DmsgHTTP) step; forces fall-through to the
+//	             direct DMSG step using a CLI-owned dmsg client.
+//	--no-dmsg    skip the direct DMSG HTTP step.
+//	--sk         secret key (hex) for the CLI-owned dmsg client when the direct
+//	             step runs (--no-rpc or RPC unavailable). Visible in shell
+//	             history — prefer --config for production use.
+//	--config     path to a JSON file supplying {"sk":..., "dmsg":{...}}. SK
+//	             precedence: --sk > --config > $DMSG_SK > $DMSGCURL_SK > random
+//	             ephemeral. Dmsg.Servers from the config seeds the direct
+//	             client; absent, the embedded deployment server set is used.
 func RegisterFetchFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&NoCXO, "no-cxo", false, "skip CXO subscriber-cache step")
 	cmd.Flags().BoolVar(&NoRPC, "no-rpc", false, "skip visor RPC (DmsgHTTP) step")

--- a/pkg/visor/service_registry_test.go
+++ b/pkg/visor/service_registry_test.go
@@ -20,7 +20,7 @@ func TestSelfDialAsStampsPK(t *testing.T) {
 	gotAddr := make(chan net.Addr, 1)
 	reg.Register(80, "test", func(conn net.Conn) {
 		gotAddr <- conn.RemoteAddr()
-		_ = conn.Close()
+		_ = conn.Close() //nolint:errcheck
 	})
 
 	cli, err := reg.SelfDialAs(80, pk)
@@ -47,7 +47,7 @@ func TestSelfDialAnonymous(t *testing.T) {
 	gotAddr := make(chan net.Addr, 1)
 	reg.Register(80, "test", func(conn net.Conn) {
 		gotAddr <- conn.RemoteAddr()
-		_ = conn.Close()
+		_ = conn.Close() //nolint:errcheck
 	})
 
 	cli, err := reg.SelfDial(80)


### PR DESCRIPTION
## Summary

`clirpc.FetchServiceURL` already routes deployment-service fetches over **CXO → visor-RPC-DmsgHTTP → direct-DMSG** (no plain-HTTP fallback). The direct-DMSG step generated a fresh ephemeral key on every call though, which means:

- every fetch makes the CLI look like a different client to dmsg-servers (more session churn than necessary), and
- operators have no way to supply a stable secret key without exposing it in shell history.

## Change

Add two flags to `RegisterFetchFlags` so every fetch-using subcommand picks them up uniformly:

- `--sk` — hex secret key for the CLI-owned dmsg client. Visible in shell history — prefer `--config` for production.
- `--config` — path to a JSON file with the CLI's dmsg identity + bootstrap. Shape mirrors a visor's `skywire.json` so the same file can be reused:

```json
{
  "sk": "<hex>",
  "pk": "<hex>",
  "dmsg": {
    "discovery_dmsg": "dmsg://<dmsgd-pk>:80",
    "servers": [
      {"version":"","sequence":0,"timestamp":0,
       "static":"<server-pk>",
       "server":{"address":"<ip>:<port>","availableSessions":0}},
      ...
    ],
    "servers_type": "all",
    "protocol": "yamux"
  }
}
```

Extra fields are ignored, so a production visor config can be pointed at directly.

`resolveFetchIdentity` centralizes the precedence:

> `--sk` > `--config` > `$DMSG_SK` > `$DMSGCURL_SK` > ephemeral random

The dmsg-server bootstrap list comes from the config's `Dmsg.Servers` when supplied; absent, falls back to `dmsg.Prod.DmsgServers` (embedded deployment default).

`fetchViaDmsgDirect` now takes `*pflag.FlagSet` so it can consult `Flags().Changed()` without changing `FetchServiceURL`'s existing signature.

## Why this matters

- Stable identity for CLI fetches (no per-fetch session churn).
- `--config` keeps the SK out of shell history.
- Per-flag rationale matches the user direction:
  - "optionally skip visor RPC" → already there via `--no-rpc`
  - "SK via flag" → `--sk`
  - "SK via config (no shell-history exposure)" → `--config`

Plain-HTTP is **not** added back. The fetch path remains CXO → visor-RPC → direct-DMSG only; deployment services that have no discovery entry (everything except RSN + TPS by design) are reached via the static dmsg-server set the config or embedded deployment provides.

## Test plan

- [x] `go build ./cmd/skywire ./cmd/skywire-cli/...` succeeds
- [x] `go vet ./cmd/skywire-cli/...` clean
- [x] `skywire-cli svc tpd stats --help` shows the new `--sk` and `--config` flags alongside the existing `--no-cxo` / `--no-rpc` / `--no-dmsg`
- [ ] Smoke: `skywire-cli --no-rpc --sk <hex> svc tpd stats` fetches via direct-DMSG with the supplied SK.
- [ ] Smoke: `skywire-cli --no-rpc --config /path/to/visor.json svc tpd stats` fetches via direct-DMSG using the SK + servers from the config.

## Follow-up (out of scope, noted for tracking)

A handful of older subcommands still issue `http.Get` directly instead of going through `FetchServiceURL` (e.g. `cmd/skywire-cli/commands/log/log.go`, `cmd/skywire-cli/commands/svc/health.go`, `cmd/skywire-cli/commands/route/trace.go`). Each call site should be audited and routed through the central helper so the no-plain-HTTP guarantee holds across the whole CLI surface. Splitting those conversions into per-command PRs keeps each reviewable.