### PR TITLE
feat(home.dmsg): interactive API explorer — path/query inputs, POST forms, dedup /health

### DIFF
--- a/pkg/dmsgweb/home.go
+++ b/pkg/dmsgweb/home.go
@@ -46,6 +46,47 @@ var (
 	homeSetupLabelRe  = regexp.MustCompile(`^(?:rsn|tsn)[0-9]*$`)
 )
 
+// explorerScript is the dependency-free inline JS that powers the interactive
+// rows. It shares two helpers (skyURL builds the target URL from a button's
+// row; skyOpen navigates; skySend POSTs and shows the response). All values are
+// read from DOM nodes the renderer emitted (data-base / data-path / inputs), so
+// there is no server-side string interpolation into JS — no XSS surface beyond
+// the attribute escaping already applied.
+const explorerScript = `<script>
+function skyURL(btn){
+  var base=btn.getAttribute('data-base');
+  var path=btn.getAttribute('data-path');
+  var row=btn.parentNode;
+  var inputs=row.querySelectorAll('input');
+  var qs=[];
+  for(var i=0;i<inputs.length;i++){
+    var inp=inputs[i];
+    var name=inp.getAttribute('data-name');
+    var val=inp.value.trim();
+    if(inp.getAttribute('data-kind')==='path'){
+      path=path.replace('{'+name+'}',encodeURIComponent(val));
+    }else if(val!==''){
+      qs.push(encodeURIComponent(name)+'='+encodeURIComponent(val));
+    }
+  }
+  var url='http://'+base+path;
+  if(qs.length){url+='?'+qs.join('&');}
+  return url;
+}
+function skyOpen(btn){window.location.href=skyURL(btn);}
+function skySend(btn){
+  var url=skyURL(btn);
+  var ep=btn.closest('.ep');
+  var ta=ep.querySelector('textarea[data-kind="body"]');
+  var out=ep.querySelector('pre[data-kind="resp"]');
+  out.hidden=false;out.textContent='Sending '+url+' …';
+  fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:ta?ta.value:''})
+    .then(function(r){return r.text().then(function(t){
+      out.textContent=r.status+' '+r.statusText+'\n\n'+t;});})
+    .catch(function(e){out.textContent='error: '+e;});
+}
+</script>`
+
 // isHomeHost reports whether host (sans the resolver suffix) is exactly the
 // reserved home label — so "home.dmsg" matches but "x.home.dmsg" does not.
 func isHomeHost(host, suffix string) bool {
@@ -90,22 +131,64 @@ func renderHomePage(aliases map[string]cipher.PubKey, suffix string, localPK cip
 	b.WriteString("ul{list-style:none;padding:0;margin:0}li{padding:.15rem 0}")
 	b.WriteString("a{text-decoration:none;font-weight:600}code{color:#999;font-size:11px;word-break:break-all}")
 	b.WriteString("small{color:#888;font-size:10px;font-weight:600;text-transform:uppercase}")
-	b.WriteString("@media(prefers-color-scheme:dark){body{background:#1a1a1a;color:#ddd}h2{color:#aaa}h3{color:#bbb}code{color:#777}}")
+	// Explorer rows: a flex line per endpoint, with inline param inputs and a
+	// response area for POST.
+	b.WriteString(".ep{padding:.25rem 0;border-top:1px solid #eee}")
+	b.WriteString(".ep .row{display:flex;flex-wrap:wrap;gap:.3rem;align-items:baseline}")
+	b.WriteString(".ep .desc{color:#888;font-size:11px;flex-basis:100%}")
+	b.WriteString(".ep input,.ep textarea{font:inherit;font-size:12px;padding:.1rem .3rem;border:1px solid #ccc;border-radius:3px;background:#fff;color:#222}")
+	b.WriteString(".ep input{width:9rem}.ep textarea{width:100%;min-height:3rem;font-family:ui-monospace,monospace}")
+	b.WriteString(".ep button{font:inherit;font-size:12px;padding:.1rem .5rem;cursor:pointer;border:1px solid #888;border-radius:3px;background:#f4f4f4;color:#222}")
+	b.WriteString(".ep pre{margin:.3rem 0 0;padding:.3rem;background:#f6f6f6;border:1px solid #ddd;border-radius:3px;font-size:11px;white-space:pre-wrap;word-break:break-all;max-height:14rem;overflow:auto}")
+	b.WriteString("@media(prefers-color-scheme:dark){body{background:#1a1a1a;color:#ddd}h2{color:#aaa}h3{color:#bbb}code{color:#777}")
+	b.WriteString(".ep{border-color:#333}.ep input,.ep textarea{background:#222;color:#ddd;border-color:#444}.ep button{background:#2a2a2a;color:#ddd;border-color:#555}.ep pre{background:#222;border-color:#333}}")
 	b.WriteString("</style></head><body>")
 	b.WriteString("<h1>skywire resolver</h1>")
 	b.WriteString("<p>Services reachable by name through this resolving proxy. Each link tunnels over the mesh — no clearnet hop.</p>")
 	// The visor serves a real landing page at "/"; the deployment services,
-	// setup nodes and dmsg servers don't, but they all answer "/health".
+	// setup nodes and dmsg servers don't, but they all answer "/health". A
+	// service that has a manifest section below is omitted from the flat
+	// "Deployment services" index so its /health renders exactly once (from the
+	// manifest); the rest still get a plain /health link here.
+	manifested := manifestedLabels(aliases)
 	writeHomeGroup(&b, "This visor", self, suffix, "/")
-	writeHomeGroup(&b, "Deployment services", services, suffix, "/health")
+	var plainServices []homeEntry
+	for _, e := range services {
+		if !manifested[e.label] {
+			plainServices = append(plainServices, e)
+		}
+	}
+	writeHomeGroup(&b, "Deployment services", plainServices, suffix, "/health")
 	writeServiceEndpoints(&b, aliases, suffix)
 	writeHomeGroup(&b, "Setup nodes", setup, suffix, "/health")
 	writeHomeGroup(&b, "dmsg servers", servers, suffix, "/health")
 	if len(self)+len(services)+len(setup)+len(servers) == 0 {
 		b.WriteString("<p><em>No aliases configured.</em></p>")
 	}
+	b.WriteString(explorerScript)
 	b.WriteString("</body></html>")
 	return []byte(b.String())
+}
+
+// manifestedLabels returns the set of resolver labels that will be rendered as
+// a full manifest section (i.e. the service has manifest endpoints AND a
+// configured, resolvable base address). Those labels are dropped from the flat
+// "Deployment services" index so /health is not listed twice.
+func manifestedLabels(aliases map[string]cipher.PubKey) map[string]bool {
+	out := make(map[string]bool)
+	for _, id := range serviceEndpointOrder {
+		if len(svcendpoints.Manifest[id]) == 0 {
+			continue
+		}
+		label, ok := serviceEndpointAlias[id]
+		if !ok {
+			continue
+		}
+		if _, ok := aliases[label]; ok {
+			out[label] = true
+		}
+	}
+	return out
 }
 
 func writeHomeGroup(b *strings.Builder, title string, es []homeEntry, suffix, path string) {
@@ -144,18 +227,91 @@ func writeServiceEndpoints(b *strings.Builder, aliases map[string]cipher.PubKey,
 		}
 		if !any {
 			b.WriteString("<h2>Service API endpoints</h2>")
+			b.WriteString("<p><small>Fill any inputs and Open/Send — requests tunnel through this proxy.</small></p>")
 			any = true
 		}
-		host := html.EscapeString(label + suffix)
-		fmt.Fprintf(b, "<h3>%s <code>%s</code></h3><ul>", html.EscapeString(label), host)
+		host := label + suffix
+		pk := aliases[label]
+		fmt.Fprintf(b, "<h3>%s <code>%s</code></h3>", html.EscapeString(label), html.EscapeString(host+" "+pk.Hex()))
 		for _, ep := range eps {
-			href := html.EscapeString("http://" + label + suffix + ep.Path)
-			fmt.Fprintf(b, `<li><a href="%s">%s</a> <small>%s</small> — %s</li>`,
-				href, html.EscapeString(host+ep.Path),
-				html.EscapeString(ep.Method), html.EscapeString(ep.Desc))
+			writeEndpoint(b, host, ep)
 		}
-		b.WriteString("</ul>")
 	}
+}
+
+// pathParamRe matches a chi-style "{name}" path-parameter segment. The name is
+// captured so it can label the input the renderer emits in its place.
+var pathParamRe = regexp.MustCompile(`\{([^/}]+)\}`)
+
+// writeEndpoint renders one endpoint as an interactive row. The control shape is
+// chosen from the endpoint: a plain GET with no params is a link; anything with
+// path/query params gets inputs + an "Open" button; a POST gets a body textarea
+// (plus any path/query inputs) + a "Send" button that fetches through the proxy
+// and shows the response without navigating away. base is "<alias><suffix>";
+// the inline JS finds this row's inputs by DOM traversal, so no id is needed.
+func writeEndpoint(b *strings.Builder, base string, ep svcendpoints.Endpoint) {
+	pathParams := pathParamRe.FindAllStringSubmatch(ep.Path, -1)
+	isPost := strings.EqualFold(ep.Method, "POST")
+	simple := !isPost && len(pathParams) == 0 && len(ep.Query) == 0
+
+	b.WriteString(`<div class="ep">`)
+
+	if simple {
+		// No params, GET — a plain link, exactly as before.
+		href := html.EscapeString("http://" + base + ep.Path)
+		fmt.Fprintf(b, `<div class="row"><a href="%s">%s</a> <small>%s</small> — %s</div>`,
+			href, html.EscapeString(base+ep.Path), html.EscapeString(ep.Method), html.EscapeString(ep.Desc))
+		b.WriteString("</div>")
+		return
+	}
+
+	// Header row: method + the path template (params shown literally) + desc.
+	b.WriteString(`<div class="row">`)
+	fmt.Fprintf(b, `<small>%s</small> <code>%s%s</code>`,
+		html.EscapeString(ep.Method), html.EscapeString(base), html.EscapeString(ep.Path))
+	b.WriteString("</div>")
+	fmt.Fprintf(b, `<div class="desc">%s</div>`, html.EscapeString(ep.Desc))
+
+	// Inputs row: one input per path param, then one per query param.
+	b.WriteString(`<div class="row">`)
+	for _, m := range pathParams {
+		name := m[1]
+		fmt.Fprintf(b, `<input data-kind="path" data-name="%s" placeholder="%s" aria-label="%s">`,
+			html.EscapeString(name), html.EscapeString(name), html.EscapeString(name))
+	}
+	for _, q := range ep.Query {
+		ph := q.Name
+		if q.Example != "" {
+			ph = q.Name + "=" + q.Example
+		}
+		title := q.Name
+		if q.Desc != "" {
+			title = q.Name + " — " + q.Desc
+		}
+		fmt.Fprintf(b, `<input data-kind="query" data-name="%s" placeholder="%s" title="%s" aria-label="%s">`,
+			html.EscapeString(q.Name), html.EscapeString(ph), html.EscapeString(title), html.EscapeString(q.Name))
+	}
+
+	// data-base / data-path carry the (already-safe) values the JS substitutes
+	// into. They are attribute-escaped; the JS treats them as opaque strings.
+	dataAttrs := fmt.Sprintf(`data-base="%s" data-path="%s"`,
+		html.EscapeString(base), html.EscapeString(ep.Path))
+
+	if isPost {
+		fmt.Fprintf(b, `<button type="button" onclick="skySend(this)" %s>Send</button>`, dataAttrs)
+		b.WriteString("</div>") // close inputs row
+		body := ep.Body
+		if body == "" {
+			body = "request body"
+		}
+		fmt.Fprintf(b, `<div class="row"><textarea data-kind="body" placeholder="%s" aria-label="request body"></textarea></div>`,
+			html.EscapeString(body))
+		b.WriteString(`<pre data-kind="resp" hidden></pre>`)
+	} else {
+		fmt.Fprintf(b, `<button type="button" onclick="skyOpen(this)" %s>Open</button>`, dataAttrs)
+		b.WriteString("</div>") // close inputs row
+	}
+	b.WriteString("</div>")
 }
 
 // homeNatLess compares labels with trailing-number awareness so an indexed set

--- a/pkg/dmsgweb/home_test.go
+++ b/pkg/dmsgweb/home_test.go
@@ -26,24 +26,35 @@ func TestRenderHomePage(t *testing.T) {
 	dmsg0PK, _ := cipher.GenerateKeyPair()
 	rsnPK, _ := cipher.GenerateKeyPair()
 
+	// "other" is a deployment-service alias with NO manifest entry, so it stays
+	// in the flat "Deployment services" index and keeps its plain /health link.
+	otherPK, _ := cipher.GenerateKeyPair()
 	aliases := map[string]cipher.PubKey{
 		"skywire": selfPK,
 		"tpd":     tpdPK,
+		"other":   otherPK,
 		"dmsg0":   dmsg0PK,
 		"rsn":     rsnPK,
 	}
 	page := string(renderHomePage(aliases, ".dmsg", selfPK))
 
-	// Grouped under the right headings.
+	// Grouped under the right headings. "tpd" has a manifest, so it renders as a
+	// "Service API endpoints" section; "other" has none, so it falls under the
+	// flat "Deployment services" index.
 	assert.Contains(t, page, "This visor")
 	assert.Contains(t, page, "Deployment services")
+	assert.Contains(t, page, "Service API endpoints")
 	assert.Contains(t, page, "Setup nodes")
 	assert.Contains(t, page, "dmsg servers")
 
-	// Service links target /health (services don't serve "/"); the visor's own
-	// landing page does, so the self link stays at "/".
+	// /health renders once for tpd — from the manifest section (not also from
+	// the flat index, which now omits manifested services).
 	assert.Contains(t, page, `href="http://tpd.dmsg/health"`)
+	assert.Equal(t, 1, strings.Count(page, `href="http://tpd.dmsg/health"`), "/health must render exactly once for tpd")
+	// The visor's own landing page serves "/"; non-manifest services keep their
+	// plain /health link.
 	assert.Contains(t, page, `href="http://skywire.dmsg/"`)
+	assert.Contains(t, page, `href="http://other.dmsg/health"`)
 	assert.Contains(t, page, `href="http://dmsg0.dmsg/health"`)
 
 	// Full 66-char PKs, never truncated.
@@ -64,13 +75,43 @@ func TestRenderHomePageServiceEndpoints(t *testing.T) {
 	page := string(renderHomePage(aliases, ".dmsg", cipher.PubKey{}))
 
 	assert.Contains(t, page, "Service API endpoints")
-	// A non-/health endpoint from the manifest, paired with the service's
-	// resolver alias and tunneled through the same proxy.
+	// A no-param GET endpoint from the manifest stays a plain link, paired with
+	// the service's resolver alias and tunneled through the same proxy.
 	assert.Contains(t, page, `href="http://tpd.dmsg/all-transports"`)
 	assert.Contains(t, page, `href="http://dmsgd.dmsg/dmsg-discovery/available_servers"`)
 	// A service with no configured alias is not rendered.
 	assert.NotContains(t, page, "http://ar.dmsg/resolve")
 	assert.NotContains(t, page, "http://sd.dmsg/api/services")
+
+	// Path-param endpoints render an input + Open button, NOT a broken link with
+	// an URL-encoded "{pk}" placeholder.
+	assert.NotContains(t, page, "%7Bpk%7D", "path placeholders must not be URL-encoded into a dead link")
+	assert.NotContains(t, page, `href="http://tpd.dmsg/transports/id:{id}"`)
+	assert.Contains(t, page, `data-kind="path" data-name="id"`)
+	assert.Contains(t, page, `data-path="/transports/id:{id}"`)
+	assert.Contains(t, page, `onclick="skyOpen(this)"`)
+
+	// Query-param endpoints surface an input per declared query param.
+	assert.Contains(t, page, `data-kind="query" data-name="v"`)
+	assert.Contains(t, page, `data-kind="query" data-name="visors"`)
+}
+
+func TestRenderHomePagePostEndpoint(t *testing.T) {
+	rfPK, _ := cipher.GenerateKeyPair()
+	page := string(renderHomePage(map[string]cipher.PubKey{"rf": rfPK}, ".dmsg", cipher.PubKey{}))
+
+	// route-finder POST /routes renders a body textarea + Send button (which
+	// fetches through the proxy) instead of a navigating link.
+	assert.Contains(t, page, "Service API endpoints")
+	assert.Contains(t, page, `onclick="skySend(this)"`)
+	assert.Contains(t, page, `textarea data-kind="body"`)
+	assert.Contains(t, page, `pre data-kind="resp"`)
+	// The body hint / example JSON is surfaced as the textarea placeholder.
+	assert.Contains(t, page, "&#34;Edges&#34;")
+	// rf /health (a no-param GET) is still a plain link, rendered once.
+	assert.Equal(t, 1, strings.Count(page, `href="http://rf.dmsg/health"`))
+	// The explorer JS is present.
+	assert.Contains(t, page, "function skySend(")
 }
 
 func TestRenderHomePageNatSort(t *testing.T) {

--- a/pkg/skyenv/svcendpoints/svcendpoints.go
+++ b/pkg/skyenv/svcendpoints/svcendpoints.go
@@ -1,8 +1,9 @@
 // Package svcendpoints is a data-only leaf package describing the notable
-// PUBLIC HTTP GET endpoints each deployment service exposes. It carries no
+// PUBLIC HTTP endpoints each deployment service exposes. It carries no
 // behavior and no heavy imports — just a static manifest — so the resolving
 // proxy's home page (pkg/dmsgweb) can render a per-service endpoint directory
-// without depending on the service implementations.
+// (and a small interactive API explorer) without depending on the service
+// implementations.
 //
 // The PATHS here are deployment-INDEPENDENT (they come from each service's chi
 // router); the ADDRESSES they pair with are deployment-SPECIFIC and supplied by
@@ -11,16 +12,41 @@
 // pkg/address-resolver/api, pkg/route-finder/api, pkg/service-discovery/api,
 // pkg/uptime-tracker/api, and the reward server in
 // cmd/skywire-cli/commands/rewards/server).
+//
+// Path parameters are expressed inline in Path with chi's "{name}" syntax and
+// are parsed by the renderer at display time — they need no dedicated field.
+// Query parameters and POST request-body hints are declared explicitly (Query,
+// Body) so the explorer can surface an input per query param and a body
+// textarea per POST. Only params that are verifiable in the service code are
+// declared; everything else is left empty.
 package svcendpoints
+
+// Param is one query parameter an endpoint accepts.
+type Param struct {
+	// Name is the query-string key (e.g. "v").
+	Name string
+	// Desc is a short human-readable description.
+	Desc string
+	// Example is a representative value, used as the input placeholder.
+	Example string
+}
 
 // Endpoint is one notable public HTTP endpoint of a deployment service.
 type Endpoint struct {
 	// Method is the HTTP method (e.g. "GET", "POST").
 	Method string
-	// Path is the request path, deployment-independent.
+	// Path is the request path, deployment-independent. It may contain
+	// chi-style "{name}" path parameters, which the renderer turns into
+	// per-param inputs.
 	Path string
 	// Desc is a short human-readable description for the directory page.
 	Desc string
+	// Query lists the query parameters the endpoint understands. Empty when
+	// the endpoint takes none.
+	Query []Param
+	// Body is a request-body format hint / example JSON for POST endpoints
+	// (used as the textarea placeholder). Empty for endpoints with no body.
+	Body string
 }
 
 // Manifest maps a stable service id to its notable public endpoints. The ids
@@ -41,74 +67,96 @@ type Endpoint struct {
 var Manifest = map[string][]Endpoint{
 	// dmsg-discovery — pkg/dmsg/discovery/api/api.go
 	"dmsgd": {
-		{"GET", "/health", "service health + build info"},
-		{"GET", "/dmsg-discovery/entry/{pk}", "client/server entry by PK"},
-		{"GET", "/dmsg-discovery/entries", "all client entry PKs"},
-		{"GET", "/dmsg-discovery/visorEntries", "all visor client entries"},
-		{"GET", "/dmsg-discovery/available_servers", "available dmsg servers"},
-		{"GET", "/dmsg-discovery/all_servers", "all dmsg servers"},
-		{"GET", "/dmsg-discovery/servers/clients", "clients grouped by server"},
-		{"GET", "/dmsg-discovery/server/{pk}/clients", "clients delegated to a server"},
-		{"GET", "/uptimes", "visor uptime summaries (?v=v2|v3&visors=)"},
+		{Method: "GET", Path: "/health", Desc: "service health + build info"},
+		{Method: "GET", Path: "/dmsg-discovery/entry/{pk}", Desc: "client/server entry by PK"},
+		{Method: "GET", Path: "/dmsg-discovery/entries", Desc: "all client entry PKs"},
+		{Method: "GET", Path: "/dmsg-discovery/visorEntries", Desc: "all visor client entries"},
+		{Method: "GET", Path: "/dmsg-discovery/available_servers", Desc: "available dmsg servers"},
+		{Method: "GET", Path: "/dmsg-discovery/all_servers", Desc: "all dmsg servers"},
+		{Method: "GET", Path: "/dmsg-discovery/servers/clients", Desc: "clients grouped by server"},
+		{Method: "GET", Path: "/dmsg-discovery/server/{pk}/clients", Desc: "clients delegated to a server"},
+		{Method: "GET", Path: "/uptimes", Desc: "visor uptime summaries", Query: []Param{
+			{Name: "v", Desc: "response version: v2 (daily %) or v3 (+ timeline)", Example: "v3"},
+			{Name: "visors", Desc: "filter to a ;-separated PK list", Example: "pk1;pk2"},
+		}},
 	},
 	// transport-discovery — pkg/transport-discovery/api/api.go
 	"tpd": {
-		{"GET", "/health", "service health + build info"},
-		{"GET", "/all-transports", "all registered transports"},
-		{"GET", "/all-transports/stats", "all-transports bandwidth stats"},
-		{"GET", "/all-transports/per-key-stats", "per-visor transport stats"},
-		{"GET", "/transports/id:{id}", "transport by ID"},
-		{"GET", "/transports/edge:{edge}", "transports by edge PK"},
-		{"GET", "/transports/stats/{edge}", "transport stats by edge"},
-		{"GET", "/v3/transports/edge:{edge}", "DHT-aligned transports by edge"},
-		{"GET", "/bandwidth/transport/{id}", "transport bandwidth"},
-		{"GET", "/bandwidth/visor/{pk}", "visor bandwidth"},
-		{"GET", "/metric", "network-wide transport metric"},
-		{"GET", "/metric/visor/{pks}", "aggregate metric for visors"},
-		{"GET", "/metrics", "all transport metrics"},
-		{"GET", "/metrics/{ids}", "metrics for transport IDs"},
-		{"GET", "/metrics/visor/{pks}", "metrics for visors"},
-		{"GET", "/metrics/uptime", "network transport uptime"},
-		{"GET", "/uptimes", "visor uptime summaries"},
-		{"GET", "/uptimes/transports", "transport uptime summaries"},
-		{"GET", "/version", "version stats"},
-		{"GET", "/versions", "per-visor versions"},
-		{"GET", "/uptime/now", "service-self uptime (now)"},
+		{Method: "GET", Path: "/health", Desc: "service health + build info"},
+		{Method: "GET", Path: "/all-transports", Desc: "all registered transports"},
+		{Method: "GET", Path: "/all-transports/stats", Desc: "all-transports bandwidth stats"},
+		{Method: "GET", Path: "/all-transports/per-key-stats", Desc: "per-visor transport stats"},
+		{Method: "GET", Path: "/transports/id:{id}", Desc: "transport by ID"},
+		{Method: "GET", Path: "/transports/edge:{edge}", Desc: "transports by edge PK"},
+		{Method: "GET", Path: "/transports/stats/{edge}", Desc: "transport stats by edge"},
+		{Method: "GET", Path: "/v3/transports/edge:{edge}", Desc: "DHT-aligned transports by edge"},
+		{Method: "GET", Path: "/bandwidth/transport/{id}", Desc: "transport bandwidth"},
+		{Method: "GET", Path: "/bandwidth/visor/{pk}", Desc: "visor bandwidth"},
+		{Method: "GET", Path: "/metric", Desc: "network-wide transport metric"},
+		{Method: "GET", Path: "/metric/visor/{pks}", Desc: "aggregate metric for visors"},
+		{Method: "GET", Path: "/metrics", Desc: "all transport metrics"},
+		{Method: "GET", Path: "/metrics/{ids}", Desc: "metrics for transport IDs"},
+		{Method: "GET", Path: "/metrics/visor/{pks}", Desc: "metrics for visors"},
+		{Method: "GET", Path: "/metrics/uptime", Desc: "network transport uptime"},
+		{Method: "GET", Path: "/uptimes", Desc: "visor uptime summaries"},
+		{Method: "GET", Path: "/uptimes/transports", Desc: "transport uptime summaries"},
+		{Method: "GET", Path: "/version", Desc: "version stats"},
+		{Method: "GET", Path: "/versions", Desc: "per-visor versions"},
+		{Method: "GET", Path: "/uptime/now", Desc: "service-self uptime (now)"},
 	},
 	// address-resolver — pkg/address-resolver/api/api.go
 	"ar": {
-		{"GET", "/health", "service health + build info"},
-		{"GET", "/transports", "registered stcpr/sudph bindings"},
-		{"GET", "/resolve/{type}/{pk}", "resolve a visor's network address"},
+		{Method: "GET", Path: "/health", Desc: "service health + build info"},
+		{Method: "GET", Path: "/transports", Desc: "registered stcpr/sudph bindings"},
+		{Method: "GET", Path: "/resolve/{type}/{pk}", Desc: "resolve a visor's network address (type = stcpr|sudph)"},
 	},
 	// route-finder — pkg/route-finder/api/api.go
 	"rf": {
-		{"GET", "/health", "service health + build info"},
-		{"POST", "/routes", "find paired routes between two visors"},
+		{Method: "GET", Path: "/health", Desc: "service health + build info"},
+		{Method: "POST", Path: "/routes", Desc: "find paired routes between two visors",
+			Body: `{"Edges":[["<src-pk>","<dst-pk>"]],"Opts":{"MinHops":0,"MaxHops":0,"NumRoutes":0}}`},
 	},
 	// service-discovery — pkg/service-discovery/api/api.go
 	"sd": {
-		{"GET", "/health", "service health + build info"},
-		{"GET", "/api/services", "service entries (?type=&version=&country=&quantity=)"},
-		{"GET", "/api/services/{addr}", "service entry by address"},
-		{"GET", "/uptimes", "visor uptime summaries"},
+		{Method: "GET", Path: "/health", Desc: "service health + build info"},
+		{Method: "GET", Path: "/api/services", Desc: "service entries", Query: []Param{
+			{Name: "type", Desc: "service type (required)", Example: "vpn"},
+			{Name: "version", Desc: "filter by visor version", Example: ""},
+			{Name: "country", Desc: "filter by 2-letter country code", Example: "US"},
+			{Name: "quantity", Desc: "cap result count (random sample)", Example: "10"},
+		}},
+		{Method: "GET", Path: "/api/services/{addr}", Desc: "service entry by address", Query: []Param{
+			{Name: "type", Desc: "service type (required)", Example: "vpn"},
+		}},
+		{Method: "GET", Path: "/uptimes", Desc: "visor uptime summaries", Query: []Param{
+			{Name: "v", Desc: "response version: v2 or v3", Example: "v3"},
+			{Name: "visors", Desc: "filter to a ;-separated PK list", Example: "pk1;pk2"},
+		}},
 	},
 	// uptime-tracker — pkg/uptime-tracker/api/api.go
 	"ut": {
-		{"GET", "/health", "service health + build info"},
-		{"GET", "/visors", "all tracked visors"},
-		{"GET", "/uptimes", "uptime summaries"},
-		{"GET", "/uptime/{pk}", "uptime for a single visor"},
-		{"GET", "/dashboard", "uptime dashboard chart"},
+		{Method: "GET", Path: "/health", Desc: "service health + build info"},
+		{Method: "GET", Path: "/visors", Desc: "all tracked visors"},
+		{Method: "GET", Path: "/uptimes", Desc: "uptime summaries", Query: []Param{
+			{Name: "visors", Desc: "filter to a ,-separated PK list", Example: "pk1,pk2"},
+			{Name: "v", Desc: "response version: v2 (daily history)", Example: "v2"},
+			{Name: "status", Desc: "filter by online state: on or off", Example: "on"},
+			{Name: "startDate", Desc: "period start (unix seconds)", Example: ""},
+			{Name: "endDate", Desc: "period end (unix seconds)", Example: ""},
+		}},
+		{Method: "GET", Path: "/uptime/{pk}", Desc: "uptime for a single visor"},
+		{Method: "GET", Path: "/dashboard", Desc: "uptime dashboard chart", Query: []Param{
+			{Name: "length", Desc: "number of months to chart", Example: "6"},
+		}},
 	},
 	// reward system — cmd/skywire-cli/commands/rewards/server
 	"reward": {
-		{"GET", "/health", "service health"},
-		{"GET", "/transports", "transport visualization page"},
-		{"GET", "/transports-map", "transport map page"},
-		{"GET", "/transport-graph", "transport graph page"},
-		{"GET", "/log-collection", "reward log collection overview"},
-		{"GET", "/log-collection/tree", "reward log collection tree"},
-		{"GET", "/stats/ut", "uptime stats"},
+		{Method: "GET", Path: "/health", Desc: "service health"},
+		{Method: "GET", Path: "/transports", Desc: "transport visualization page"},
+		{Method: "GET", Path: "/transports-map", Desc: "transport map page"},
+		{Method: "GET", Path: "/transport-graph", Desc: "transport graph page"},
+		{Method: "GET", Path: "/log-collection", Desc: "reward log collection overview"},
+		{Method: "GET", Path: "/log-collection/tree", Desc: "reward log collection tree"},
+		{Method: "GET", Path: "/stats/ut", Desc: "uptime stats"},
 	},
 }


### PR DESCRIPTION
Operator follow-up to the home.dmsg endpoint list. Makes it an interactive console: dedup `/health` (renders once from the manifest, count==1 test), path-param `{pk}` endpoints get an input + Open (substitutes into the path — no more `%7Bpk%7D` dead links), query params (enriched manifest, verified against the real handlers) render as labeled inputs, and POST endpoints get a textarea + Send that fetch-POSTs through the proxy and shows the response inline. Vanilla inline JS, no server-side interpolation into JS, all values `html.EscapeString`-d — no new XSS. Build/vet/tests clean.