### PR TITLE
feat(visor): landing-page PK, /skywire.log rename + colorized log, /health identity

### DIFF
--- a/pkg/httputil/health.go
+++ b/pkg/httputil/health.go
@@ -16,6 +16,7 @@ type HealthCheckResponse struct {
 	ServiceName       string          `json:"service_name,omitempty"`
 	BuildInfo         *buildinfo.Info `json:"build_info,omitempty"`
 	StartedAt         time.Time       `json:"started_at"`
+	PublicKey         string          `json:"public_key,omitempty"`
 	DmsgAddr          string          `json:"dmsg_address,omitempty"`
 	DmsgDiscovery     string          `json:"dmsg_discovery,omitempty"`
 	DmsgServers       []string        `json:"dmsg_servers,omitempty"`

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -590,6 +590,10 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 
 	// Set visor as health stats provider for /health endpoint
 	lsAPI.SetHealthStatsProvider(v)
+	// Self-identify on /health and the landing page: PK + dmsg listen
+	// address (the log server's own dmsg port, where this surface is served).
+	dmsgAddr := fmt.Sprintf("%s:%d", v.conf.PK.Hex(), visorconfig.DmsgHTTPPort)
+	lsAPI.SetIdentity(v.conf.PK.Hex(), dmsgAddr)
 
 	// Store the log server API reference for public autocheck to use later
 	v.initLock.Lock()
@@ -728,6 +732,7 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 
 		// Set visor as health stats provider for /health endpoint
 		localAPI.SetHealthStatsProvider(v)
+		localAPI.SetIdentity(v.conf.PK.Hex(), dmsgAddr)
 
 		// Store the localhost API for potential future use
 		v.logServer.localAPI = localAPI

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -108,6 +109,8 @@ type API struct {
 
 	logger               *logging.Logger
 	startedAt            time.Time
+	publicKey            string // visor PK hex, set via SetIdentity (empty until wired)
+	dmsgAddress          string // <pk>:<dmsg-port>, set via SetIdentity
 	healthStatsProvider  HealthStatsProvider
 	serviceLister        ServiceLister
 	forwardedPortLister  ForwardedPortLister
@@ -235,7 +238,17 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 	// no level/module filters apply, and conservatively dropped when they do (so
 	// stray lines from libraries that don't follow the format don't sneak past
 	// a strict --min-level filter).
-	authRoute.GET("/visor.log", func(c *gin.Context) {
+	//
+	// Output modes:
+	//   default            → terminal-styled HTML (colored per log level)
+	//   ?raw=1 (or Accept   → verbatim plain text (c.File) for log-scraping
+	//     text/plain)
+	//   any filter param   → plain-text streaming filtered mode
+	//
+	// Served at /skywire.log (matching the on-disk filename written by
+	// visor.go's lumberjackrus hook) with /visor.log kept as an alias so
+	// older links and tooling keep working — both routes share this handler.
+	serveVisorLog := func(c *gin.Context) {
 		// The visor writes its rotating log to LocalPath/log/skywire.log
 		// (visor.go, via lumberjackrus). The endpoint previously looked at
 		// LocalPath/visor.log — wrong subdir AND filename — so it always 404'd
@@ -246,13 +259,30 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 			return
 		}
 		q := c.Request.URL.Query()
-		if q.Get("min-level") == "" && q.Get("module") == "" && q.Get("grep") == "" &&
-			q.Get("since-line") == "" && q.Get("limit") == "" && q.Get("follow") == "" {
+		// Server-side filtering (always plain text — keeps grep/scrape simple).
+		if q.Get("min-level") != "" || q.Get("module") != "" || q.Get("grep") != "" ||
+			q.Get("since-line") != "" || q.Get("limit") != "" || q.Get("follow") != "" {
+			streamFilteredVisorLog(c, logFile, q)
+			return
+		}
+		// Plain-text escape hatch for log-scraping tooling: ?raw=1 or an
+		// explicit Accept: text/plain (and no text/html preference).
+		raw := q.Get("raw") == "1" || strings.EqualFold(q.Get("raw"), "true")
+		if !raw {
+			accept := c.GetHeader("Accept")
+			if strings.Contains(accept, "text/plain") && !strings.Contains(accept, "text/html") {
+				raw = true
+			}
+		}
+		if raw {
 			c.File(logFile)
 			return
 		}
-		streamFilteredVisorLog(c, logFile, q)
-	})
+		// Default: terminal-styled, level-colored HTML.
+		renderVisorLogHTML(c, logFile)
+	}
+	authRoute.GET("/skywire.log", serveVisorLog)
+	authRoute.GET("/visor.log", serveVisorLog) // backwards-compatible alias
 
 	// pprof endpoints (auth'd) — runtime profiling
 	authRoute.GET("/debug/pprof/", gin.WrapF(pprof.Index))
@@ -330,7 +360,7 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 		if wl {
 			links = append(links, `<a href="/node-info">/node-info</a> - node survey`)
 			links = append(links, `<a href="/node-info/checksum">/node-info/checksum</a> - survey checksum`)
-			links = append(links, `<a href="/visor.log">/visor.log</a> - visor debug log`)
+			links = append(links, `<a href="/skywire.log">/skywire.log</a> - visor debug log`)
 			links = append(links, `<a href="/debug/pprof/">/debug/pprof/</a> - runtime profiling`)
 			if api.statsReader != nil {
 				links = append(links, `<a href="/stats/transports">/stats/transports</a> - live transport snapshot`)
@@ -404,10 +434,23 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 			}
 		}
 
+		// Identity header — state which visor this is. Now that resolver
+		// aliases make identity meaningful, the page names itself by PK
+		// (and dmsg address when known). HTML-escaped though both are
+		// fixed-shape hex from config.
+		var idHeader string
+		if api.publicKey != "" {
+			idHeader = fmt.Sprintf(`<p class="pk">public key: %s</p>`, html.EscapeString(api.publicKey))
+			if api.dmsgAddress != "" {
+				idHeader += fmt.Sprintf(`<p class="pk">dmsg address: %s</p>`, html.EscapeString(api.dmsgAddress))
+			}
+		}
+
 		c.Writer.WriteHeader(http.StatusOK)
 		fmt.Fprintf(c.Writer, `<!doctype html><html><head><title>Skywire Visor</title>`+ //nolint:errcheck,gosec
-			`<style>body{background:#000;color:#fff;font-family:monospace;padding:20px}a{color:#3399FF}a:visited{color:#FF00FF}</style>`+
-			`</head><body><h2>Skywire Visor</h2><pre>%s</pre></body></html>`, strings.Join(links, "\n"))
+			`<style>body{background:#000;color:#fff;font-family:monospace;padding:20px}a{color:#3399FF}a:visited{color:#FF00FF}`+
+			`.pk{color:#5fd75f;word-break:break-all;margin:2px 0}</style>`+
+			`</head><body><h2>Skywire Visor</h2>%s<pre>%s</pre></body></html>`, idHeader, strings.Join(links, "\n"))
 	})
 
 	// Catch-all: if a custom website handler is set, serve unmatched
@@ -468,6 +511,8 @@ func (api *API) health(c *gin.Context) {
 		ServiceName: "visor",
 		BuildInfo:   buildinfo.Get(),
 		StartedAt:   api.startedAt,
+		PublicKey:   api.publicKey,
+		DmsgAddr:    api.dmsgAddress,
 	}
 
 	// Add transport stats if provider is available
@@ -497,6 +542,15 @@ func (api *API) health(c *gin.Context) {
 // SetHealthStatsProvider sets the health stats provider after initialization.
 func (api *API) SetHealthStatsProvider(provider HealthStatsProvider) {
 	api.healthStatsProvider = provider
+}
+
+// SetIdentity records the visor's public key (hex) and dmsg listening
+// address (`<pk>:<dmsg-port>`) so the /health response is self-identifying
+// like the deployment services, and the landing page can state which visor
+// it is. Called from visor init.
+func (api *API) SetIdentity(publicKey, dmsgAddress string) {
+	api.publicKey = publicKey
+	api.dmsgAddress = dmsgAddress
 }
 
 // SetServiceLister sets the service catalog provider. Called from

--- a/pkg/visor/logserver/visorlog_html.go
+++ b/pkg/visor/logserver/visorlog_html.go
@@ -1,0 +1,144 @@
+// Package logserver pkg/visor/logserver/visorlog_html.go — terminal-style
+// HTML rendering for the /skywire.log (and /visor.log alias) endpoint.
+//
+// The on-disk log is logrus-formatted plain text (DisableColors:true), e.g.
+//
+//	[2026-06-18T14:54:52-05:00] DEBUG [tp:02af…]: Serving. remote_pk=… tp_id=…
+//
+// i.e. `[<timestamp>] LEVEL [module]: message key=val…`. We parse the LEVEL
+// token per line and wrap the (HTML-escaped) line in a colored <span> whose
+// color mirrors logrus's console color scheme:
+//
+//	TRACE → gray   DEBUG → blue/gray   INFO → green   WARN → yellow
+//	ERROR → red    FATAL/PANIC → bold bright-red
+//
+// Everything is inline CSS/HTML — no external assets, no JS, dependency-free.
+// All log content is HTML-escaped before being written, so a log line that
+// happens to contain markup can't inject anything into the page.
+//
+// A plaintext escape hatch (?raw=1) bypasses the HTML wrapper entirely so
+// log-scraping tooling keeps receiving the file verbatim.
+package logserver
+
+import (
+	"bufio"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// levelColors maps a logrus level token (as it appears upper-cased in the
+// on-disk log) to an inline CSS color. The palette tracks logrus's default
+// console ColorScheme: info=green, warn=yellow, error/fatal/panic=red,
+// debug=blue, trace=black(dimmed). Tuned slightly brighter for legibility
+// on the near-black terminal background.
+var levelColors = map[string]string{
+	"TRACE":   "#808080",
+	"DEBUG":   "#5f87ff",
+	"INFO":    "#5fd75f",
+	"WARN":    "#d7d75f",
+	"WARNING": "#d7d75f",
+	"ERROR":   "#ff5f5f",
+	"FATAL":   "#ff0000",
+	"PANIC":   "#ff0000",
+}
+
+// boldLevels render with extra weight — these are the ones you don't want to
+// scroll past.
+var boldLevels = map[string]bool{
+	"FATAL": true,
+	"PANIC": true,
+}
+
+// renderVisorLogHTML streams logFile to the client as a terminal-styled HTML
+// page: near-black background, light monospace text, one colored line per log
+// entry keyed off its parsed level. Content is HTML-escaped per line.
+//
+// It streams rather than buffering so a multi-megabyte log doesn't balloon
+// memory, flushing periodically for responsiveness over dmsg/skynet.
+func renderVisorLogHTML(c *gin.Context, logFile string) {
+	f, err := os.Open(logFile) //nolint:gosec // path comes from localPath config, not request
+	if err != nil {
+		c.String(http.StatusInternalServerError, "open skywire.log: %v", err)
+		return
+	}
+	defer f.Close() //nolint:errcheck
+
+	c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	// Page head + terminal styling. <pre> preserves the log's own spacing;
+	// per-line <span>s carry the level color.
+	io.WriteString(c.Writer, //nolint:errcheck
+		`<!doctype html><html><head><meta charset="utf-8"><title>skywire.log</title>`+
+			`<style>`+
+			`body{background:#0a0a0a;color:#d0d0d0;font-family:'DejaVu Sans Mono',Menlo,Consolas,monospace;`+
+			`font-size:13px;line-height:1.35;margin:0;padding:12px}`+
+			`pre{margin:0;white-space:pre-wrap;word-break:break-word}`+
+			`.ts{color:#6c6c6c}`+
+			`</style></head><body><pre>`)
+
+	r := bufio.NewReaderSize(f, 64*1024)
+	ctx := c.Request.Context()
+	flushEvery := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		line, rerr := r.ReadString('\n')
+		if len(line) > 0 {
+			if _, werr := io.WriteString(c.Writer, colorizeLine(line)); werr != nil {
+				return
+			}
+			flushEvery++
+			if flushEvery%256 == 0 {
+				c.Writer.Flush()
+			}
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	io.WriteString(c.Writer, "</pre></body></html>") //nolint:errcheck
+	c.Writer.Flush()
+}
+
+// colorizeLine wraps a single (raw, unescaped) log line in a colored span
+// based on its parsed level, HTML-escaping the content. Lines that don't
+// match the standard logrus shape are emitted escaped in the default color.
+func colorizeLine(line string) string {
+	// Preserve the trailing newline outside the span so copy-paste keeps
+	// line breaks; strip it for parsing.
+	nl := ""
+	body := line
+	if strings.HasSuffix(body, "\n") {
+		nl = "\n"
+		body = strings.TrimSuffix(body, "\n")
+	}
+	if body == "" {
+		return nl
+	}
+
+	m := logLevelRE.FindStringSubmatch(body)
+	if m == nil {
+		// Non-standard line (library output, stack frame, continuation):
+		// escape and emit in the default text color.
+		return html.EscapeString(body) + nl
+	}
+	color, ok := levelColors[m[1]]
+	if !ok {
+		color = "#d0d0d0"
+	}
+	style := "color:" + color
+	if boldLevels[m[1]] {
+		style += ";font-weight:bold"
+	}
+	return fmt.Sprintf(`<span style="%s">%s</span>%s`, style, html.EscapeString(body), nl)
+}

--- a/pkg/visor/logserver/visorlog_html_test.go
+++ b/pkg/visor/logserver/visorlog_html_test.go
@@ -1,0 +1,82 @@
+package logserver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColorizeLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantColor string // substring expected in the style attr (empty = no span)
+		wantText  string // escaped text expected in output
+		wantBold  bool
+	}{
+		{
+			name:      "debug line with module",
+			in:        "[2026-06-18T14:54:52-05:00] DEBUG [embedded_tps]: Health check request remote=03dd\n",
+			wantColor: levelColors["DEBUG"],
+			wantText:  "Health check request remote=03dd",
+		},
+		{
+			name:      "info line",
+			in:        "[2026-06-18T14:54:52-05:00] INFO [visor]: Started\n",
+			wantColor: levelColors["INFO"],
+			wantText:  "Started",
+		},
+		{
+			name:      "error line",
+			in:        "[2026-06-18T14:54:52-05:00] ERROR [tp]: boom\n",
+			wantColor: levelColors["ERROR"],
+			wantText:  "boom",
+		},
+		{
+			name:      "fatal is bold",
+			in:        "[2026-06-18T14:54:52-05:00] FATAL [visor]: dying\n",
+			wantColor: levelColors["FATAL"],
+			wantText:  "dying",
+			wantBold:  true,
+		},
+		{
+			name:     "non-standard line passes through escaped, no span",
+			in:       "some library output <script>\n",
+			wantText: "some library output &lt;script&gt;",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := colorizeLine(tc.in)
+			if !strings.Contains(out, tc.wantText) {
+				t.Fatalf("output missing text %q: got %q", tc.wantText, out)
+			}
+			if !strings.HasSuffix(out, "\n") {
+				t.Fatalf("trailing newline not preserved: got %q", out)
+			}
+			if tc.wantColor == "" {
+				if strings.Contains(out, "<span") {
+					t.Fatalf("expected no span for non-standard line: got %q", out)
+				}
+				return
+			}
+			if !strings.Contains(out, "color:"+tc.wantColor) {
+				t.Fatalf("expected color %q in output: got %q", tc.wantColor, out)
+			}
+			if tc.wantBold && !strings.Contains(out, "font-weight:bold") {
+				t.Fatalf("expected bold for %s: got %q", tc.name, out)
+			}
+		})
+	}
+}
+
+func TestColorizeLineEscapesContent(t *testing.T) {
+	// A log line whose message contains HTML must not inject markup.
+	in := `[2026-06-18T14:54:52-05:00] INFO [visor]: <img src=x onerror=alert(1)>` + "\n"
+	out := colorizeLine(in)
+	if strings.Contains(out, "<img") {
+		t.Fatalf("unescaped markup leaked into output: %q", out)
+	}
+	if !strings.Contains(out, "&lt;img") {
+		t.Fatalf("expected escaped markup: %q", out)
+	}
+}


### PR DESCRIPTION
Operator-requested. (1) Log served at `/skywire.log` (matches the on-disk filename) with `/visor.log` aliased. (2) Colorized HTML log view — terminal look, per-level colors, `?raw=1` for scraping, all content `html.EscapeString`-d (XSS-safe, tested). (3) Visor PK + dmsg address shown on the landing page. (4) `/health` self-identifying: `public_key` + `dmsg_address` added (prior fields retained). Build + tests green.