### PR TITLE
fix(visor): per-element log coloring + de-dup landing/health identity

### DIFF
--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -109,8 +109,8 @@ type API struct {
 
 	logger               *logging.Logger
 	startedAt            time.Time
-	publicKey            string // visor PK hex, set via SetIdentity (empty until wired)
-	dmsgAddress          string // <pk>:<dmsg-port>, set via SetIdentity
+	publicKey            string // visor PK hex, shown on the landing page; set via SetIdentity (empty until wired)
+	dmsgAddress          string // <pk>:<dmsg-port>, emitted on /health; set via SetIdentity
 	healthStatsProvider  HealthStatsProvider
 	serviceLister        ServiceLister
 	forwardedPortLister  ForwardedPortLister
@@ -434,16 +434,13 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 			}
 		}
 
-		// Identity header — state which visor this is. Now that resolver
-		// aliases make identity meaningful, the page names itself by PK
-		// (and dmsg address when known). HTML-escaped though both are
-		// fixed-shape hex from config.
+		// Identity header — state which visor this is. The landing page
+		// names itself by PK only; the dmsg address is redundant here (it's
+		// just <pk>:<port>) and is carried on /health instead. HTML-escaped
+		// though the PK is fixed-shape hex from config.
 		var idHeader string
 		if api.publicKey != "" {
 			idHeader = fmt.Sprintf(`<p class="pk">public key: %s</p>`, html.EscapeString(api.publicKey))
-			if api.dmsgAddress != "" {
-				idHeader += fmt.Sprintf(`<p class="pk">dmsg address: %s</p>`, html.EscapeString(api.dmsgAddress))
-			}
 		}
 
 		c.Writer.WriteHeader(http.StatusOK)
@@ -507,11 +504,14 @@ func (api *API) SetWebsiteHandler(h http.Handler) {
 }
 
 func (api *API) health(c *gin.Context) {
+	// /health carries the dmsg_address only — the public_key is redundant
+	// (it's the host part of dmsg_address) and is shown on the landing page
+	// instead. PublicKey is left unset; it's omitempty so it drops from the
+	// JSON entirely.
 	resp := httputil.HealthCheckResponse{
 		ServiceName: "visor",
 		BuildInfo:   buildinfo.Get(),
 		StartedAt:   api.startedAt,
-		PublicKey:   api.publicKey,
 		DmsgAddr:    api.dmsgAddress,
 	}
 
@@ -545,9 +545,10 @@ func (api *API) SetHealthStatsProvider(provider HealthStatsProvider) {
 }
 
 // SetIdentity records the visor's public key (hex) and dmsg listening
-// address (`<pk>:<dmsg-port>`) so the /health response is self-identifying
-// like the deployment services, and the landing page can state which visor
-// it is. Called from visor init.
+// address (`<pk>:<dmsg-port>`). The two are surfaced on different pages to
+// avoid redundancy: the landing page names itself by public key, while the
+// /health response carries the dmsg address (whose host part is the same
+// key). Called from visor init.
 func (api *API) SetIdentity(publicKey, dmsgAddress string) {
 	api.publicKey = publicKey
 	api.dmsgAddress = dmsgAddress

--- a/pkg/visor/logserver/visorlog_html.go
+++ b/pkg/visor/logserver/visorlog_html.go
@@ -5,12 +5,16 @@
 //
 //	[2026-06-18T14:54:52-05:00] DEBUG [tp:02af…]: Serving. remote_pk=… tp_id=…
 //
-// i.e. `[<timestamp>] LEVEL [module]: message key=val…`. We parse the LEVEL
-// token per line and wrap the (HTML-escaped) line in a colored <span> whose
-// color mirrors logrus's console color scheme:
+// i.e. `[<timestamp>] LEVEL [module]: message key=val…`. We parse the line
+// into its elements and wrap each (HTML-escaped) part in its own colored
+// <span> so the page mirrors logrus's console TextFormatter rather than
+// flattening to one uniform color:
 //
-//	TRACE → gray   DEBUG → blue/gray   INFO → green   WARN → yellow
-//	ERROR → red    FATAL/PANIC → bold bright-red
+//	timestamp   → dim gray            message → bright/light (the focus)
+//	key=         → dimmed             value   → default
+//	LEVEL + [module] colored by level:
+//	  TRACE → gray   DEBUG → blue/gray   INFO → green   WARN → yellow
+//	  ERROR → red    FATAL/PANIC → bold bright-red
 //
 // Everything is inline CSS/HTML — no external assets, no JS, dependency-free.
 // All log content is HTML-escaped before being written, so a log line that
@@ -27,6 +31,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -55,6 +60,30 @@ var boldLevels = map[string]bool{
 	"PANIC": true,
 }
 
+// Per-element colors mirroring logrus's console TextFormatter: the timestamp
+// is dim gray, the message is the brightest part of the line, and the
+// key=value fields fade back so the eye lands on the message + level first.
+const (
+	colorTimestamp = "#808080" // dim gray — `[<iso8601>]`
+	colorMessage   = "#e0e0e0" // bright/light — the human-readable message
+	colorFieldKey  = "#8a8a8a" // dimmer — `key=` of a structured field
+	colorDefault   = "#d0d0d0" // fallback level color
+)
+
+// logLineRE splits a standard logrus line into its parts:
+//
+//	[<timestamp>] LEVEL [module]: <rest>
+//
+// group 1 = timestamp (incl. brackets), 2 = LEVEL, 3 = module (incl.
+// brackets), 4 = the remainder (message + any key=value fields). The
+// remainder is optional so a bare `[ts] LEVEL [module]:` still matches.
+var logLineRE = regexp.MustCompile(
+	`^(\[[^\]]+\])\s+(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|PANIC)\s+(\[[^\]]+\]):?\s?(.*)$`)
+
+// fieldRE matches a trailing run of `key=value` structured fields. logrus
+// emits these space-separated after the message; values may be quoted.
+var fieldRE = regexp.MustCompile(`([A-Za-z0-9_.\-]+)=("[^"]*"|\S*)`)
+
 // renderVisorLogHTML streams logFile to the client as a terminal-styled HTML
 // page: near-black background, light monospace text, one colored line per log
 // entry keyed off its parsed level. Content is HTML-escaped per line.
@@ -80,7 +109,6 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 			`body{background:#0a0a0a;color:#d0d0d0;font-family:'DejaVu Sans Mono',Menlo,Consolas,monospace;`+
 			`font-size:13px;line-height:1.35;margin:0;padding:12px}`+
 			`pre{margin:0;white-space:pre-wrap;word-break:break-word}`+
-			`.ts{color:#6c6c6c}`+
 			`</style></head><body><pre>`)
 
 	r := bufio.NewReaderSize(f, 64*1024)
@@ -110,11 +138,16 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 	c.Writer.Flush()
 }
 
-// colorizeLine wraps a single (raw, unescaped) log line in a colored span
-// based on its parsed level, HTML-escaping the content. Lines that don't
-// match the standard logrus shape are emitted escaped in the default color.
+// colorizeLine renders a single (raw, unescaped) log line as terminal-style
+// HTML, coloring each element of the standard logrus shape independently so
+// the page mirrors the console: dim timestamp, level-colored LEVEL + module,
+// a bright message, and faded key=value fields. Every piece of content is
+// HTML-escaped, so a log line containing markup can't inject into the page.
+//
+// Lines that don't match the standard shape (library output, stack frames,
+// continuations) are emitted escaped in the default text color.
 func colorizeLine(line string) string {
-	// Preserve the trailing newline outside the span so copy-paste keeps
+	// Preserve the trailing newline outside the spans so copy-paste keeps
 	// line breaks; strip it for parsing.
 	nl := ""
 	body := line
@@ -126,19 +159,82 @@ func colorizeLine(line string) string {
 		return nl
 	}
 
-	m := logLevelRE.FindStringSubmatch(body)
+	m := logLineRE.FindStringSubmatch(body)
 	if m == nil {
-		// Non-standard line (library output, stack frame, continuation):
-		// escape and emit in the default text color.
+		// Non-standard line: escape and emit in the default text color.
 		return html.EscapeString(body) + nl
 	}
-	color, ok := levelColors[m[1]]
+	ts, level, module, rest := m[1], m[2], m[3], m[4]
+
+	levelColor, ok := levelColors[level]
 	if !ok {
-		color = "#d0d0d0"
+		levelColor = colorDefault
 	}
-	style := "color:" + color
-	if boldLevels[m[1]] {
-		style += ";font-weight:bold"
+	bold := ""
+	if boldLevels[level] {
+		bold = ";font-weight:bold"
 	}
-	return fmt.Sprintf(`<span style="%s">%s</span>%s`, style, html.EscapeString(body), nl)
+
+	var b strings.Builder
+	// Timestamp — dim gray.
+	b.WriteString(span(colorTimestamp, "", ts))
+	b.WriteByte(' ')
+	// LEVEL — level color (bold for FATAL/PANIC).
+	b.WriteString(span(levelColor, bold, level))
+	b.WriteByte(' ')
+	// [module] — level color, keeps the bracketed tag visually tied to
+	// the severity it belongs to.
+	b.WriteString(span(levelColor, "", module))
+	b.WriteString(": ")
+	// Remainder: bright message, with any trailing key=value fields faded.
+	b.WriteString(colorizeRest(rest))
+
+	return b.String() + nl
+}
+
+// colorizeRest renders the message + structured fields portion of a log line.
+// The message text is bright; each `key=value` field has a dimmed key and a
+// default-colored value. All content is HTML-escaped.
+func colorizeRest(rest string) string {
+	if rest == "" {
+		return ""
+	}
+	// Find where the trailing key=value run begins (if any). logrus appends
+	// fields after the message, so we look for the first field match and treat
+	// everything from there on as fields, leaving the message in front of it.
+	loc := fieldRE.FindStringIndex(rest)
+	if loc == nil {
+		// No fields — the whole remainder is the message.
+		return span(colorMessage, "", rest)
+	}
+	msg := rest[:loc[0]]
+	fields := rest[loc[0]:]
+
+	var b strings.Builder
+	if msg != "" {
+		b.WriteString(span(colorMessage, "", msg))
+	}
+	// Walk each key=value, coloring keys dim and values default. Any
+	// separators (spaces) between matches are emitted escaped, default color.
+	last := 0
+	for _, idx := range fieldRE.FindAllStringSubmatchIndex(fields, -1) {
+		if idx[0] > last {
+			b.WriteString(html.EscapeString(fields[last:idx[0]]))
+		}
+		key := fields[idx[2]:idx[3]]
+		val := fields[idx[4]:idx[5]]
+		b.WriteString(span(colorFieldKey, "", key+"="))
+		b.WriteString(span(colorDefault, "", val))
+		last = idx[1]
+	}
+	if last < len(fields) {
+		b.WriteString(html.EscapeString(fields[last:]))
+	}
+	return b.String()
+}
+
+// span wraps HTML-escaped text in a colored inline span. extra is appended to
+// the style attribute (e.g. ";font-weight:bold") and may be empty.
+func span(color, extra, text string) string {
+	return fmt.Sprintf(`<span style="color:%s%s">%s</span>`, color, extra, html.EscapeString(text))
 }

--- a/pkg/visor/logserver/visorlog_html_test.go
+++ b/pkg/visor/logserver/visorlog_html_test.go
@@ -14,10 +14,13 @@ func TestColorizeLine(t *testing.T) {
 		wantBold  bool
 	}{
 		{
+			// The message text stays contiguous and bright; the trailing
+			// `remote=03dd` field is split off into key/value spans, so the
+			// message we assert on is just the prose before the field.
 			name:      "debug line with module",
 			in:        "[2026-06-18T14:54:52-05:00] DEBUG [embedded_tps]: Health check request remote=03dd\n",
 			wantColor: levelColors["DEBUG"],
-			wantText:  "Health check request remote=03dd",
+			wantText:  "Health check request",
 		},
 		{
 			name:      "info line",
@@ -66,6 +69,30 @@ func TestColorizeLine(t *testing.T) {
 				t.Fatalf("expected bold for %s: got %q", tc.name, out)
 			}
 		})
+	}
+}
+
+func TestColorizeLinePerElement(t *testing.T) {
+	// A standard line must split into per-element spans matching the
+	// terminal: dim timestamp, level-colored LEVEL + module, bright
+	// message, and dimmed key / default value for each field.
+	in := "[2026-06-18T15:25:33-05:00] WARN [embedded_tps:dmsg]: Retrying... current_backoff=1.69s\n"
+	out := colorizeLine(in)
+
+	checks := []struct {
+		desc, frag string
+	}{
+		{"dim timestamp", `<span style="color:` + colorTimestamp + `">[2026-06-18T15:25:33-05:00]</span>`},
+		{"level colored", `<span style="color:` + levelColors["WARN"] + `">WARN</span>`},
+		{"module level-colored", `<span style="color:` + levelColors["WARN"] + `">[embedded_tps:dmsg]</span>`},
+		{"bright message", `<span style="color:` + colorMessage + `">Retrying... </span>`},
+		{"dim field key", `<span style="color:` + colorFieldKey + `">current_backoff=</span>`},
+		{"default field value", `<span style="color:` + colorDefault + `">1.69s</span>`},
+	}
+	for _, c := range checks {
+		if !strings.Contains(out, c.frag) {
+			t.Errorf("%s: missing %q in output\n got: %s", c.desc, c.frag, out)
+		}
 	}
 }
 


### PR DESCRIPTION
Per-element log coloring (dim timestamp, colored level/module, bright message — matches the terminal logrus scheme) replacing the uniform-dim render; XSS-escaping test kept green. Identity de-duplicated: landing page → public key, `/health` → `dmsg_address` (neither both). Build + tests green.