### PR TITLE
fix(dmsg): retry entry-publish on failure + bound the attempt

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -729,9 +729,71 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 // while shrinking the stale-entry window by 80 %.
 const entryUpdateDebounce = 1 * time.Second
 
+// entryUpdateAttemptTimeout bounds a single updateClientEntry call so a
+// stuck PUT (e.g. dmsg-HTTP stream-dial that the underlying transport never
+// errors out of) doesn't hang the loop forever. Without this, a service
+// whose first PUT-via-dmsg-HTTP raced its dmsg-disc peer's outbound-session
+// establishment could stall here permanently — observed on a fresh dmsg-
+// only deployment service post-autopull: nothing returns, nothing retries,
+// the entry never registers.
+const entryUpdateAttemptTimeout = 30 * time.Second
+
+// entryUpdateMinBackoff / entryUpdateMaxBackoff bracket the exponential
+// backoff applied when updateClientEntry returns a non-nil error. The loop
+// otherwise rearms its timer at c.updateInterval (default 1 min, often 5
+// in service configs) which would leave dmsg-only services unregistered
+// for minutes after a transient publish failure.
+const (
+	entryUpdateMinBackoff = time.Second
+	entryUpdateMaxBackoff = 30 * time.Second
+)
+
+// entryFailureBackoff returns the delay before the next attempt after
+// `consecutiveFailures` consecutive failed updates. Exponential, clamped
+// to entryUpdateMaxBackoff.
+func entryFailureBackoff(consecutiveFailures int) time.Duration {
+	if consecutiveFailures <= 0 {
+		return entryUpdateMinBackoff
+	}
+	d := entryUpdateMinBackoff << (consecutiveFailures - 1) //nolint:gosec
+	if d <= 0 || d > entryUpdateMaxBackoff {
+		return entryUpdateMaxBackoff
+	}
+	return d
+}
+
 func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan struct{}, clientType string) {
 	t := time.NewTimer(c.updateInterval)
 	defer t.Stop()
+
+	// runUpdate calls updateClientEntry with a per-attempt context timeout
+	// and returns whether the attempt succeeded. The timeout bounds a stuck
+	// underlying HTTP/dmsg-HTTP call without affecting the outer ctx the
+	// service runs under.
+	runUpdate := func(label string) bool {
+		callCtx, cancel := context.WithTimeout(ctx, entryUpdateAttemptTimeout)
+		defer cancel()
+		if err := c.updateClientEntry(callCtx, done, clientType); err != nil {
+			c.log.WithError(err).Warnf("Failed to update discovery entry (%s).", label)
+			return false
+		}
+		return true
+	}
+
+	// rearm rearms the timer at either c.updateInterval on success or a
+	// short exponential backoff on failure, so a transient publish failure
+	// (e.g. dmsg-HTTP cold-start race) doesn't leave the service silently
+	// unregistered for minutes.
+	consecutiveFailures := 0
+	rearm := func(ok bool) {
+		if ok {
+			consecutiveFailures = 0
+			t.Reset(c.updateInterval)
+			return
+		}
+		consecutiveFailures++
+		t.Reset(entryFailureBackoff(consecutiveFailures))
+	}
 
 	for {
 		select {
@@ -746,11 +808,7 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 
 			// updateClientEntry takes sessionsMx itself for its snapshot;
 			// holding it here would self-deadlock via the dmsgfirst path.
-			if err := c.updateClientEntry(ctx, done, clientType); err != nil {
-				c.log.WithError(err).Warn("Failed to update discovery entry.")
-			}
-
-			t.Reset(c.updateInterval)
+			rearm(runUpdate("tick"))
 
 		case <-c.entryNudge:
 			// Session added/removed — debounce to batch rapid changes.
@@ -769,10 +827,7 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 			}
 		clientUpdate:
 			// See timer-tick comment above re: sessionsMx.
-			if err := c.updateClientEntry(ctx, done, clientType); err != nil {
-				c.log.WithError(err).Warn("Failed to update discovery entry (nudge).")
-			}
-			t.Reset(c.updateInterval)
+			rearm(runUpdate("nudge"))
 		}
 	}
 }

--- a/pkg/visor/logserver/visorlog_html.go
+++ b/pkg/visor/logserver/visorlog_html.go
@@ -74,7 +74,7 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 
 	// Page head + terminal styling. <pre> preserves the log's own spacing;
 	// per-line <span>s carry the level color.
-	io.WriteString(c.Writer, //nolint:errcheck
+	_, _ = io.WriteString(c.Writer,
 		`<!doctype html><html><head><meta charset="utf-8"><title>skywire.log</title>`+
 			`<style>`+
 			`body{background:#0a0a0a;color:#d0d0d0;font-family:'DejaVu Sans Mono',Menlo,Consolas,monospace;`+
@@ -99,14 +99,14 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 			}
 			flushEvery++
 			if flushEvery%256 == 0 {
-				_ = c.Writer.Flush() //nolint:errcheck
+				c.Writer.Flush()
 			}
 		}
 		if rerr != nil {
 			break
 		}
 	}
-	io.WriteString(c.Writer, "</pre></body></html>") //nolint:errcheck
+	_, _ = io.WriteString(c.Writer, "</pre></body></html>")
 	c.Writer.Flush()
 }
 

--- a/pkg/visor/logserver/visorlog_html.go
+++ b/pkg/visor/logserver/visorlog_html.go
@@ -99,7 +99,7 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 			}
 			flushEvery++
 			if flushEvery%256 == 0 {
-				c.Writer.Flush()
+				_ = c.Writer.Flush() //nolint:errcheck
 			}
 		}
 		if rerr != nil {

--- a/pkg/visor/logserver/visorlog_html.go
+++ b/pkg/visor/logserver/visorlog_html.go
@@ -74,6 +74,7 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 
 	// Page head + terminal styling. <pre> preserves the log's own spacing;
 	// per-line <span>s carry the level color.
+	//nolint:errcheck // .golangci.yml has check-blank:true so the _,_ discard alone is not enough; nolint silences errcheck while the discard satisfies gosec G104
 	_, _ = io.WriteString(c.Writer,
 		`<!doctype html><html><head><meta charset="utf-8"><title>skywire.log</title>`+
 			`<style>`+
@@ -106,7 +107,7 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 			break
 		}
 	}
-	_, _ = io.WriteString(c.Writer, "</pre></body></html>")
+	_, _ = io.WriteString(c.Writer, "</pre></body></html>") //nolint:errcheck
 	c.Writer.Flush()
 }
 


### PR DESCRIPTION
## Summary

`updateClientEntryLoop` rearmed its timer at `c.updateInterval` (default 1 min, 5 min under `dmsg.DefaultConfig`) whether the previous `updateClientEntry` returned success or error, **and** called `updateClientEntry` with the long-lived service ctx — no per-attempt deadline. Two pathologies follow:

1. A transient publish failure leaves the service unregistered for a full `updateInterval`. Visors that look up the service PK get 404 until the next tick — and if the next tick fails too, another full interval.

2. If the underlying PUT call doesn't error out cleanly (e.g. a `dmsg-HTTP` `RoundTrip` whose `DialStream` retries push the overall call past several internal deadlines without surfacing a terminal error), the loop body **blocks in `updateClientEntry` indefinitely**. No log, no retry, no recovery.

Both bite hardest on a fresh dmsg-only deployment service when the service and dmsg-discovery cold-start together via autopull: the service's first `PutEntry` races dmsg-discovery's own outbound dmsg sessions establishing, hits `i/o deadline reached` repeatedly, and then sits silent for 5+ minutes (often forever).

Verified on `transport-setup-4` with the `discovery_dmsg`-only config introduced in #3161 + #3157: the entry-publish path is correct, only the retry cadence and attempt-bounding are missing.

## Change

Two narrowly-scoped pieces in `updateClientEntryLoop`:

- Wrap each `updateClientEntry` call with `context.WithTimeout(entryUpdateAttemptTimeout=30s)`. A genuinely stuck PUT errors at the call boundary instead of wedging the loop. The caller's ctx still drives shutdown.

- On error from `updateClientEntry`, rearm the timer with exponential backoff (`entryFailureBackoff`: 1s, 2s, 4s, 8s, 16s, clamped at `entryUpdateMaxBackoff` = 30s) instead of `c.updateInterval`. On success, reset to `c.updateInterval` as before. `consecutiveFailures` resets on the first success.

## Why this matters

- A newly-deployed dmsg-only service that loses the cold-start race recovers within ~30s instead of waiting a full minute (or 5) — and recovers at all even if the previous attempt blocked instead of returning an error.
- No change to the happy path: successful updates schedule the next attempt at `c.updateInterval` exactly as before. The change is purely in failure-mode behavior.

## Test plan

- [x] `go build ./cmd/skywire` succeeds
- [x] `go vet ./pkg/dmsg/dmsg/...` clean
- [x] `go test ./pkg/dmsg/dmsg/...` passes
- [ ] Deploy via autopull; with `tps-4/tps.json.dmsg.discovery` removed, verify the service registers in dmsg-discovery within ~30s of startup even when both containers recreate together (the scenario that produced the original observation).

## Related

Closes the last gap blocking #3161's full dmsg-only TPS rollout. Without this, the dmsg-Client's entry-publish path is correct on paper but unreliable across an autopull cycle.