### PR TITLE
fix(visor): decouple RPC from AR public-IP discovery (async SetPublicIP)

### DIFF
--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -37,6 +37,12 @@ const (
 	// UDPKeepHeartbeatMessage is used as a heartbeat packet to keep connection alive.
 	UDPKeepHeartbeatMessage = "heartbeat"
 	defaultUDPPort          = "30178"
+	// stcprBindPublicIPWait bounds how long BindSTCPR waits for the visor's
+	// asynchronously-determined public IP before binding without it. Sized to
+	// comfortably cover the dmsg LookupIPGeo (10s) + STUN (20s) fallback path;
+	// on timeout the bind proceeds and the re-registration loop carries the
+	// real IP once it lands.
+	stcprBindPublicIPWait = 35 * time.Second
 	// UDPDelBindMessage is used as a deletebind packet on visor shutdown.
 	UDPDelBindMessage = "delBind"
 	// sudphReconnectInitialBackoff is the initial sleep before the first
@@ -81,6 +87,11 @@ type APIClient interface {
 	TransportsType(ctx context.Context, tpType types.Type) (map[cipher.PubKey][]string, error)
 	Addresses(ctx context.Context) string
 	LocalPublicIP() string
+	// SetPublicIP records the visor's externally-reachable IPs once they have
+	// been determined asynchronously (so the control plane need not wait on
+	// the dmsg/STUN lookup). Passing empty strings signals "determination
+	// finished, none available" and unblocks any pending bind.
+	SetPublicIP(publicIP, publicIPv6 string)
 	Close() error
 }
 
@@ -114,24 +125,35 @@ type VisorData struct {
 // reached via dmsg, when v6 init failed, or when the caller didn't
 // supply a v6 client — preserves pre-#1525 v4-only behavior.
 type httpClient struct {
-	log              *logging.Logger
-	mLog             *logging.MasterLogger
-	httpClient       *httpauthclient.Client
-	httpClientV6     *httpauthclient.Client
-	pk               cipher.PubKey
-	sk               cipher.SecKey
-	remoteHTTPAddr   string
-	remoteHTTPURL    *url.URL
-	remoteUDPAddr    string
-	sudphConn        net.PacketConn
-	sudphArConn      net.Conn
-	sudphArConnMu    sync.Mutex
-	sudphLocalAddr   LocalAddresses
+	log            *logging.Logger
+	mLog           *logging.MasterLogger
+	httpClient     *httpauthclient.Client
+	httpClientV6   *httpauthclient.Client
+	pk             cipher.PubKey
+	sk             cipher.SecKey
+	remoteHTTPAddr string
+	remoteHTTPURL  *url.URL
+	remoteUDPAddr  string
+	sudphConn      net.PacketConn
+	sudphArConn    net.Conn
+	sudphArConnMu  sync.Mutex
+	sudphLocalAddr LocalAddresses
+	// clientPublicIP / clientPublicIPv6 are the visor's externally-reachable
+	// IPs declared to the AR on bind. They may be determined asynchronously
+	// (see SetPublicIP) so the visor's control plane (RPC) need not wait on
+	// the slow dmsg/STUN public-IP lookup — guard every access with pubIPMu.
+	pubIPMu          sync.RWMutex
 	clientPublicIP   string
 	clientPublicIPv6 string
-	ready            chan struct{}
-	closed           chan struct{}
-	delBindSudphWg   sync.WaitGroup
+	// ipReady is closed once the public IP has been determined (or determined
+	// to be unavailable) via SetPublicIP — or immediately at construction when
+	// a non-empty IP was supplied. The bind path waits on it (bounded) so
+	// registrations carry the public IP without blocking the control plane.
+	ipReady        chan struct{}
+	ipReadyOnce    sync.Once
+	ready          chan struct{}
+	closed         chan struct{}
+	delBindSudphWg sync.WaitGroup
 }
 
 // NewHTTP creates a new client setting a public key to the client to be used for auth.
@@ -171,8 +193,16 @@ func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC, httpC
 		remoteUDPAddr:    remoteUDP,
 		clientPublicIP:   clientPublicIP,
 		clientPublicIPv6: clientPublicIPv6,
+		ipReady:          make(chan struct{}),
 		ready:            make(chan struct{}),
 		closed:           make(chan struct{}),
+	}
+
+	// When a public IP was supplied at construction the synchronous behavior
+	// is unchanged — mark it ready so the bind path never waits. Callers that
+	// defer the lookup pass "" here and call SetPublicIP once it's known.
+	if clientPublicIP != "" {
+		client.ipReadyOnce.Do(func() { close(client.ipReady) })
 	}
 
 	client.log.Debugf("Remote UDP server: %q", remoteUDP)
@@ -183,7 +213,12 @@ func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC, httpC
 }
 
 func (c *httpClient) initHTTPClient(httpC, httpCV6 *http.Client) {
-	httpAuthClient, err := httpauthclient.NewClient(context.Background(), c.remoteHTTPAddr, c.pk, c.sk, httpC, c.clientPublicIP, c.mLog)
+	// Snapshot the public IP once under the lock — it may be set concurrently
+	// by SetPublicIP. Empty is fine: the SW-PublicIP header is simply omitted
+	// until the next request that the AR observes the source IP for, and the
+	// bind POST body carries the IP independently once SetPublicIP fires.
+	pubIP := c.localPublicIPRaw()
+	httpAuthClient, err := httpauthclient.NewClient(context.Background(), c.remoteHTTPAddr, c.pk, c.sk, httpC, pubIP, c.mLog)
 	if err != nil {
 		c.log.WithError(err).
 			Warnf("Failed to connect to address resolver. STCPR/SUDPH services are temporarily unavailable. Retrying...")
@@ -191,7 +226,7 @@ func (c *httpClient) initHTTPClient(httpC, httpCV6 *http.Client) {
 		retry := netutil.NewRetrier(c.log, 1*time.Second, 10*time.Second, 0, 1)
 
 		err := retry.Do(context.Background(), func() error {
-			httpAuthClient, err = httpauthclient.NewClient(context.Background(), c.remoteHTTPAddr, c.pk, c.sk, httpC, c.clientPublicIP, c.mLog)
+			httpAuthClient, err = httpauthclient.NewClient(context.Background(), c.remoteHTTPAddr, c.pk, c.sk, httpC, c.localPublicIPRaw(), c.mLog)
 			return err
 		})
 
@@ -211,7 +246,7 @@ func (c *httpClient) initHTTPClient(httpC, httpCV6 *http.Client) {
 	// behavior as a pre-#1525 build. The retry+fatal contract from the
 	// primary client doesn't apply here: v6 is additive, not required.
 	if httpCV6 != nil {
-		v6AuthClient, v6Err := httpauthclient.NewClient(context.Background(), c.remoteHTTPAddr, c.pk, c.sk, httpCV6, c.clientPublicIP, c.mLog)
+		v6AuthClient, v6Err := httpauthclient.NewClient(context.Background(), c.remoteHTTPAddr, c.pk, c.sk, httpCV6, c.localPublicIPRaw(), c.mLog)
 		if v6Err != nil {
 			c.log.WithError(v6Err).Debug("v6 address-resolver init failed; proceeding v4-only")
 		} else {
@@ -379,14 +414,56 @@ func (c *httpClient) Addresses(_ context.Context) string {
 // This can be used to detect when a remote visor shares the same public IP
 // (i.e., is behind the same NAT), allowing LAN addresses to be tried first.
 func (c *httpClient) LocalPublicIP() string {
-	if c.clientPublicIP == "" {
+	ip := c.localPublicIPRaw()
+	if ip == "" {
 		return ""
 	}
 	// Extract just the IP (without port) from clientPublicIP
-	if host, _, err := net.SplitHostPort(c.clientPublicIP); err == nil {
+	if host, _, err := net.SplitHostPort(ip); err == nil {
 		return host
 	}
+	return ip
+}
+
+// localPublicIPRaw returns the declared public IPv4 (possibly "host:port")
+// under the lock. Empty until determined.
+func (c *httpClient) localPublicIPRaw() string {
+	c.pubIPMu.RLock()
+	defer c.pubIPMu.RUnlock()
 	return c.clientPublicIP
+}
+
+// localPublicIPv6Raw returns the declared public IPv6 under the lock.
+func (c *httpClient) localPublicIPv6Raw() string {
+	c.pubIPMu.RLock()
+	defer c.pubIPMu.RUnlock()
+	return c.clientPublicIPv6
+}
+
+// SetPublicIP records the visor's externally-reachable IPs (determined
+// asynchronously by the visor after dmsg/STUN lookups) and unblocks any bind
+// waiting on awaitPublicIP. Safe to call once with empty strings to signal
+// "determination finished, none available" so binds don't wait the full
+// timeout. Idempotent for the ready signal.
+func (c *httpClient) SetPublicIP(publicIP, publicIPv6 string) {
+	c.pubIPMu.Lock()
+	c.clientPublicIP = publicIP
+	c.clientPublicIPv6 = publicIPv6
+	c.pubIPMu.Unlock()
+	c.ipReadyOnce.Do(func() { close(c.ipReady) })
+}
+
+// awaitPublicIP blocks until the public IP has been determined (SetPublicIP),
+// the client is closed, or the timeout elapses — whichever comes first. It is
+// called off the control-plane critical path (only by the bind goroutines), so
+// a bounded wait here lets the first registration carry the public IP without
+// the RPC ever waiting on dmsg/STUN.
+func (c *httpClient) awaitPublicIP(timeout time.Duration) {
+	select {
+	case <-c.ipReady:
+	case <-c.closed:
+	case <-time.After(timeout):
+	}
 }
 
 // BindSTCPR binds client PK to IP:port on address resolver.
@@ -398,16 +475,25 @@ func (c *httpClient) BindSTCPR(ctx context.Context, port string) error {
 		log.Debug("Address resolver became ready, binding")
 	}
 
+	// The visor determines its public IP asynchronously so the RPC control
+	// plane never waits on dmsg/STUN. This bind runs in its own goroutine
+	// (off that critical path), so wait — bounded — for the IP to land. If it
+	// doesn't arrive in time we bind without it; the AR falls back to the
+	// observed source IP and the stcpr re-registration loop carries the real
+	// IP on the next pass once it's known.
+	c.awaitPublicIP(stcprBindPublicIPWait)
+
 	addresses, err := netutil.LocalAddresses()
 	if err != nil {
 		return err
 	}
 
+	clientPublicIP := c.localPublicIPRaw()
 	// Include public IP in addresses list to pass address resolver's hasAddress check
 	// when behind NAT (public IP won't be on local interfaces)
-	if c.clientPublicIP != "" {
+	if clientPublicIP != "" {
 		// Extract just the IP (without port) from clientPublicIP
-		publicIP := c.clientPublicIP
+		publicIP := clientPublicIP
 		if host, _, err := net.SplitHostPort(publicIP); err == nil {
 			publicIP = host
 		}
@@ -428,7 +514,7 @@ func (c *httpClient) BindSTCPR(ctx context.Context, port string) error {
 		Addresses:  addresses,
 		Port:       port,
 		PublicIP:   c.LocalPublicIP(),
-		PublicIPv6: c.clientPublicIPv6,
+		PublicIPv6: c.localPublicIPv6Raw(),
 	}
 	log.Debugf("Address resolver binding with: %v", addresses)
 	resp, err := c.Post(ctx, stcprBindPath, localAddresses)
@@ -622,7 +708,7 @@ func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (n
 		Addresses:  addresses,
 		Port:       localPort,
 		PublicIP:   c.LocalPublicIP(),
-		PublicIPv6: c.clientPublicIPv6,
+		PublicIPv6: c.localPublicIPv6Raw(),
 	}
 
 	laData, err := json.Marshal(localAddresses)

--- a/pkg/transport/network/addrresolver/mock_api_client.go
+++ b/pkg/transport/network/addrresolver/mock_api_client.go
@@ -18,6 +18,11 @@ type MockAPIClient struct {
 	mock.Mock
 }
 
+// SetPublicIP provides a mock function with given fields: publicIP, publicIPv6
+func (_m *MockAPIClient) SetPublicIP(publicIP string, publicIPv6 string) {
+	_m.Called(publicIP, publicIPv6)
+}
+
 // Addresses provides a mock function with given fields: ctx
 func (_m *MockAPIClient) Addresses(ctx context.Context) string {
 	ret := _m.Called(ctx)

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -57,31 +57,96 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		return err
 	}
 
-	// Get public IP (and ideally geolocation) from a connected
-	// dmsg-server. LookupIPGeo asks the server to fold in the geoip
-	// data using its own embedded MaxMind DB so the visor doesn't
-	// need an HTTP round-trip to the geoip service. Older
-	// dmsg-servers without the geo lookup hook return GeoCountry=""
-	// — we fall back to the visor's own embedded LookupGeo in that
-	// case. STUN is the last-resort path when dmsg can't answer.
-	var pIP string
-	var serverGeo *GeoData
+	// Check AR transport limit — if negative, never register with AR.
+	if v.conf.Transport != nil && v.conf.Transport.ARTransportLimit < 0 {
+		log.Info("AR registration disabled (ar_transport_limit < 0)")
+		if v.conf.Transport.PublicAutoconnect {
+			log.Warn("ar_transport_limit < 0 conflicts with public_autoconnect — public visors must be discoverable")
+		}
+	}
 
+	// #1525 Phase 2b: when the AR URL is plain HTTP (not dmsg://),
+	// build a SECOND http.Client whose Transport.DialContext forces
+	// "tcp6". The AR client uses it to fire a secondary BindSTCPR
+	// POST so the AR server captures the visor's v6 source family
+	// (via splitFamilyAddr) and stores RemoteAddrV6 alongside
+	// RemoteAddr. nil for dmsg://-routed AR — v6 forcing is
+	// meaningless when the transport is a dmsg stream rather than
+	// raw TCP. Also nil if the operator builds a custom httpC that
+	// already specifies its own Transport, since we don't want to
+	// silently override their dial choice.
+	var httpCV6 *http.Client
+	if arURL := arURL; strings.HasPrefix(arURL, "http://") || strings.HasPrefix(arURL, "https://") {
+		httpCV6 = newV6ForcedHTTPClient()
+	}
+
+	// Construct the AR client immediately with an EMPTY public IP. Determining
+	// the visor's public IP needs a dmsg LookupIPGeo and/or a STUN probe that
+	// can take tens of seconds when dmsg is slow at boot. ar is a transitive
+	// dependency of the RPC (cli → tr → ar), and the init module runner has no
+	// per-module timeout — so doing that lookup synchronously here wedges the
+	// visor's entire control plane until dmsg/STUN answer. Instead push the IP
+	// in asynchronously via SetPublicIP (see resolvePublicIPForAR); BindSTCPR
+	// waits for it (bounded, off the RPC critical path), so registrations still
+	// carry the public IP while the RPC binds promptly.
+	arClient, err := addrresolver.NewHTTP(arURL, v.conf.PK, v.conf.SK, httpC, httpCV6, "", "", log, v.MasterLogger())
+	if err != nil {
+		err = fmt.Errorf("failed to create address resolver client: %w", err)
+		return err
+	}
+
+	v.initLock.Lock()
+	v.arClient = arClient
+	v.initLock.Unlock()
+
+	doneCh := make(chan struct{}, 1)
+	v.pushCloseStack("address_resolver", func() error {
+		doneCh <- struct{}{}
+		return nil
+	})
+
+	go v.resolvePublicIPForAR(arClient, log)
+
+	return nil
+}
+
+// resolvePublicIPForAR determines the visor's public IP(s) and geolocation —
+// via a connected dmsg-server (LookupIPGeo, then the Phase 2c family-aware
+// lookup), falling back to STUN — and pushes the result into the AR client. It
+// runs in the background, off the ar→tr→cli(RPC) init critical path, so the
+// slow lookup never delays the control plane. SetPublicIP is always called
+// exactly once (even with empty values) so the bind path's bounded wait is
+// released the moment the determination concludes.
+func (v *Visor) resolvePublicIPForAR(arClient addrresolver.APIClient, log *logging.Logger) {
+	ctx := v.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var pIP, pIPv6 string
+	// Always publish the outcome — even an empty result unblocks BindSTCPR's
+	// bounded wait so the data plane stops waiting and binds with whatever the
+	// AR can observe from the source IP.
+	defer func() { arClient.SetPublicIP(pIP, pIPv6) }()
+
+	// Get public IP (and ideally geolocation) from a connected dmsg-server.
+	// LookupIPGeo asks the server to fold in the geoip data using its own
+	// embedded MaxMind DB so the visor doesn't need an HTTP round-trip to the
+	// geoip service. Older dmsg-servers without the geo lookup hook return
+	// GeoCountry="" — we fall back to the visor's own embedded LookupGeo in
+	// that case. STUN is the last-resort path when dmsg can't answer.
+	var serverGeo *GeoData
 	lookupCtx, lookupCancel := context.WithTimeout(ctx, 10*time.Second)
 	resp, err := v.dmsgC.LookupIPGeo(lookupCtx, nil)
 	lookupCancel()
 	if err != nil {
 		log.WithError(err).Debug("Failed to get public IP+geo from dmsg server, trying STUN")
-		// Bound the STUN wait. initAddressResolver runs early in the init
-		// chain and tr (transport) + cli (RPC) depend on ar, so an unbounded
-		// <-v.stun.ready blocks the WHOLE visor — including the RPC, leaving
-		// the operator with no control — whenever STUN is slow (e.g. during a
-		// deployment-side dmsg/AR hiccup). Proceed without a STUN-derived
-		// public IP after the timeout rather than wedge the control plane.
 		select {
 		case <-v.stun.ready:
 		case <-time.After(20 * time.Second):
 			log.Warn("STUN not ready within 20s; proceeding without a STUN-derived public IP")
+		case <-ctx.Done():
+			return
 		}
 		if v.stun.client != nil && v.stun.client.PublicIP != nil {
 			pIP = v.stun.client.PublicIP.IP()
@@ -116,7 +181,6 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 	// families. A v4-only visor (or a dual-stack visor whose only
 	// reachable dmsg-server is v4) leaves pIPv6 empty and the visor
 	// proceeds without a v6 declaration — same as pre-Phase-2c.
-	var pIPv6 string
 	if v.dmsgC != nil {
 		v4FamilyIP, v6FamilyIP := v.dmsgC.LookupIPsByFamily(ctx)
 		// Prefer the family-aware results when populated; fall back to
@@ -143,46 +207,6 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		v.geo.data = geoData
 		v.geo.mu.Unlock()
 	}
-
-	// Check AR transport limit — if negative, never register with AR.
-	if v.conf.Transport != nil && v.conf.Transport.ARTransportLimit < 0 {
-		log.Info("AR registration disabled (ar_transport_limit < 0)")
-		if v.conf.Transport.PublicAutoconnect {
-			log.Warn("ar_transport_limit < 0 conflicts with public_autoconnect — public visors must be discoverable")
-		}
-	}
-
-	// #1525 Phase 2b: when the AR URL is plain HTTP (not dmsg://),
-	// build a SECOND http.Client whose Transport.DialContext forces
-	// "tcp6". The AR client uses it to fire a secondary BindSTCPR
-	// POST so the AR server captures the visor's v6 source family
-	// (via splitFamilyAddr) and stores RemoteAddrV6 alongside
-	// RemoteAddr. nil for dmsg://-routed AR — v6 forcing is
-	// meaningless when the transport is a dmsg stream rather than
-	// raw TCP. Also nil if the operator builds a custom httpC that
-	// already specifies its own Transport, since we don't want to
-	// silently override their dial choice.
-	var httpCV6 *http.Client
-	if arURL := arURL; strings.HasPrefix(arURL, "http://") || strings.HasPrefix(arURL, "https://") {
-		httpCV6 = newV6ForcedHTTPClient()
-	}
-	arClient, err := addrresolver.NewHTTP(arURL, v.conf.PK, v.conf.SK, httpC, httpCV6, pIP, pIPv6, log, v.MasterLogger())
-	if err != nil {
-		err = fmt.Errorf("failed to create address resolver client: %w", err)
-		return err
-	}
-
-	v.initLock.Lock()
-	v.arClient = arClient
-	v.initLock.Unlock()
-
-	doneCh := make(chan struct{}, 1)
-	v.pushCloseStack("address_resolver", func() error {
-		doneCh <- struct{}{}
-		return nil
-	})
-
-	return nil
 }
 
 func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
@@ -226,8 +250,17 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 		lookupCancel()
 		if err != nil {
 			logger.WithError(err).Debug("Failed to get public IP from dmsg server, trying STUN")
-			<-v.stun.ready
-			if v.stun.client.PublicIP != nil {
+			// Bound the STUN wait — an unbounded <-v.stun.ready blocks the
+			// discovery module (and the launcher that depends on it) whenever
+			// STUN is slow at boot, the same wedge class as the AR path.
+			select {
+			case <-v.stun.ready:
+			case <-time.After(20 * time.Second):
+				logger.Warn("STUN not ready within 20s; service discovery proceeding without a STUN-derived public IP")
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			if v.stun.client != nil && v.stun.client.PublicIP != nil {
 				pIP = v.stun.client.PublicIP.IP()
 				logger.WithField("public_ip", pIP).Debug("Got public IP from STUN for service discovery")
 			} else {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -105,7 +105,10 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		return nil
 	})
 
-	go v.resolvePublicIPForAR(arClient, log)
+	// Deliberately decoupled from the init ctx: resolvePublicIPForAR uses the
+	// visor's long-lived v.ctx, since the init ctx is canceled once this
+	// function returns and would kill the background lookup prematurely.
+	go v.resolvePublicIPForAR(arClient, log) //nolint:gosec // G118: intentional — uses v.ctx, not the request-scoped init ctx (which is canceled when init returns)
 
 	return nil
 }


### PR DESCRIPTION
The RPC control plane (`cli`) transitively depends on `ar` via `cli→tr→ar`, and the init module runner has **no per-module timeout**. `initAddressResolver` determined the visor's public IP **synchronously** (dmsg `LookupIPGeo` ≤10s + STUN ≤20s + the Phase-2c family lookup) before returning — so a slow-dmsg boot left ~30s of data-plane IP discovery wedging the entire control plane (on top of the 30s dmsg-connect wait in `initDmsgHTTP`). The operator could not reach the visor over RPC for the better part of a minute. #3166 only bounded the STUN leg; this removes the whole block.

## Fix
- Construct the AR client immediately with an **empty** public IP; determine the IP in a background goroutine (`resolvePublicIPForAR`) that pushes it in via a new `APIClient.SetPublicIP`. `ar` now completes in ms → `tr`→`cli`(RPC) bind promptly regardless of dmsg/STUN state.
- **Data plane stays correct:** `BindSTCPR` does a bounded wait (35s) on the async IP before registering, so the first bind still carries the public IP in the common case; on timeout it binds with what the AR observes from the source IP and the stcpr re-registration loop (90s) carries the real IP once it lands.
- All `clientPublicIP`/`v6` access is now guarded by an `RWMutex` (concurrent `SetPublicIP` vs bind reads).
- Also bound the previously-**unbounded** `<-v.stun.ready` in `initDiscovery` (same wedge class on the launcher path) + nil-guard `v.stun.client` there.

## Validation
- `go build`, `go vet`, `go test -race` (addrresolver, transport/network) green.
- Rolled the local visor onto this commit: clean boot, async Public IP applied (`70.121.13.123`), **7 STCPR transports registered** — control plane up, data plane correct.