### PR TITLE
fix(visor): startup segfault on cli visor log + wire log surfaces before init

### DIFF
--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -427,6 +427,13 @@ func (v *Visor) Shutdown() error {
 
 // RuntimeLogs returns visor runtime logs
 func (v *Visor) RuntimeLogs() (string, error) {
+	// Defensive: the logstore is wired early (before module init) but a log
+	// query that races a not-yet-wired logstore must NEVER segfault the whole
+	// visor — return an empty array instead. A nil deref here previously took
+	// the process down (a `cli visor log` during the startup window).
+	if v.logstore == nil {
+		return "[]", nil
+	}
 	var builder strings.Builder
 	builder.WriteString("[")
 	logs, _ := v.logstore.GetLogs()
@@ -457,6 +464,12 @@ type RuntimeLogsDelta struct {
 // runtime-logs buffer; pass the previous response's Latest as
 // `since` to fetch only the new entries since the last poll.
 func (v *Visor) RuntimeLogsSince(since int64) (RuntimeLogsDelta, error) {
+	// Defensive nil-guard — see RuntimeLogs. A `cli visor log --follow` polls
+	// this on a tight loop and reconnects the instant RPC binds on restart, so
+	// it is the most likely caller to race a not-yet-wired logstore.
+	if v.logstore == nil {
+		return RuntimeLogsDelta{}, nil
+	}
 	logs, dropped, latest := v.logstore.GetLogsSince(since)
 	return RuntimeLogsDelta{
 		Entries: logs,

--- a/pkg/visor/api_visor_test.go
+++ b/pkg/visor/api_visor_test.go
@@ -1,0 +1,30 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRuntimeLogsNilLogstore is a regression guard: a runtime-log RPC that
+// arrives before the logstore is wired (the startup window, when the RPC has
+// bound but NewVisor's early wiring hasn't run in some construction path) must
+// return an empty result, NOT segfault the whole visor on a nil-pointer deref.
+// A `cli visor log` during startup previously took the process down this way.
+func TestRuntimeLogsNilLogstore(t *testing.T) {
+	v := &Visor{} // logstore is nil
+
+	require.NotPanics(t, func() {
+		out, err := v.RuntimeLogs()
+		require.NoError(t, err)
+		require.Equal(t, "[]", out)
+	})
+
+	require.NotPanics(t, func() {
+		delta, err := v.RuntimeLogsSince(0)
+		require.NoError(t, err)
+		require.Empty(t, delta.Entries)
+		require.Zero(t, delta.Latest)
+		require.Zero(t, delta.Dropped)
+	})
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -516,7 +516,7 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 	}
 
 	ctx, cancel := cmdutil.SignalContext(parentCtx, mLog)
-	vis, ok := NewVisor(ctx, conf)
+	vis, ok := NewVisor(ctx, conf, logBroadcaster)
 	if !ok {
 		select {
 		case <-ctx.Done():
@@ -539,7 +539,8 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 		cancel()
 	}
 	vis.SetLogstore(store)
-	vis.SetLogBroadcaster(logBroadcaster)
+	// logBroadcaster is now installed inside NewVisor (before module init) so the
+	// --verbose stream works during startup; no post-init wiring needed here.
 	//	vis.uiAssets = uiAssets
 	if launchBrowser {
 		if conf.Hypervisor == nil {
@@ -554,8 +555,12 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 	return nil
 }
 
-// NewVisor constructs new Visor.
-func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
+// NewVisor constructs new Visor. logBcast is the master-logger Broadcaster hook
+// (created and attached to the loggers by the caller); it is installed on the
+// Visor BEFORE module init so the RPC --verbose log stream is available while
+// the visor is still starting up. May be nil (e.g. tests) — SubscribeLogs is
+// nil-safe.
+func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broadcaster) (*Visor, bool) {
 	if conf == nil {
 		conf = initConfig()
 	}
@@ -622,6 +627,13 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 	}
 
 	v.ctx = ctx
+	// Install the log broadcaster BEFORE the modules init below (the gRPC/RPC
+	// "cli" module among them) so a `cli ... --verbose` log stream that connects
+	// during startup finds the broadcaster already wired, instead of racing the
+	// post-NewVisor SetLogBroadcaster call and getting "log broadcaster not
+	// available". The broadcaster's logger hooks were attached by the caller, so
+	// entries are already being captured regardless.
+	v.logBcast = logBcast
 	v.services = NewServiceRegistry()
 	v.startedAt = time.Now()
 	v.startupComplete = make(chan struct{})

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -516,7 +516,7 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 	}
 
 	ctx, cancel := cmdutil.SignalContext(parentCtx, mLog)
-	vis, ok := NewVisor(ctx, conf, logBroadcaster)
+	vis, ok := NewVisor(ctx, conf, logBroadcaster, store)
 	if !ok {
 		select {
 		case <-ctx.Done():
@@ -538,9 +538,9 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 		}
 		cancel()
 	}
-	vis.SetLogstore(store)
-	// logBroadcaster is now installed inside NewVisor (before module init) so the
-	// --verbose stream works during startup; no post-init wiring needed here.
+	// logBroadcaster + logstore are now installed inside NewVisor (before module
+	// init) so the --verbose stream and `cli visor log` work during startup; no
+	// post-init wiring needed here.
 	//	vis.uiAssets = uiAssets
 	if launchBrowser {
 		if conf.Hypervisor == nil {
@@ -555,12 +555,14 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 	return nil
 }
 
-// NewVisor constructs new Visor. logBcast is the master-logger Broadcaster hook
-// (created and attached to the loggers by the caller); it is installed on the
-// Visor BEFORE module init so the RPC --verbose log stream is available while
-// the visor is still starting up. May be nil (e.g. tests) — SubscribeLogs is
-// nil-safe.
-func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broadcaster) (*Visor, bool) {
+// NewVisor constructs new Visor. logBcast (the master-logger Broadcaster hook)
+// and logStore (the in-memory runtime-log ring) are created and attached to the
+// loggers by the caller; both are installed on the Visor BEFORE module init so
+// the RPC log surfaces (--verbose stream + RuntimeLogs/RuntimeLogsSince) work
+// while the visor is still starting up — the RPC binds during module init, so
+// wiring these afterward left a window where a log query hit a nil field and
+// segfaulted the process. Both may be nil (e.g. tests); all readers nil-guard.
+func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broadcaster, logStore logstore.Store) (*Visor, bool) {
 	if conf == nil {
 		conf = initConfig()
 	}
@@ -627,13 +629,15 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 	}
 
 	v.ctx = ctx
-	// Install the log broadcaster BEFORE the modules init below (the gRPC/RPC
-	// "cli" module among them) so a `cli ... --verbose` log stream that connects
-	// during startup finds the broadcaster already wired, instead of racing the
-	// post-NewVisor SetLogBroadcaster call and getting "log broadcaster not
-	// available". The broadcaster's logger hooks were attached by the caller, so
-	// entries are already being captured regardless.
+	// Install the log broadcaster AND logstore BEFORE the modules init below
+	// (the gRPC/RPC "cli" module among them) so log queries that arrive during
+	// startup — a `cli ... --verbose` stream, or `cli visor log[ --follow]`
+	// hitting RuntimeLogs/RuntimeLogsSince — find these wired instead of racing
+	// the post-NewVisor setters and either getting "log broadcaster not
+	// available" or segfaulting on a nil logstore. The hooks were attached to
+	// the loggers by the caller, so entries are already being captured.
 	v.logBcast = logBcast
+	v.logstore = logStore
 	v.services = NewServiceRegistry()
 	v.startedAt = time.Now()
 	v.startupComplete = make(chan struct{})


### PR DESCRIPTION
A one-shot `cli visor log` (or the `--follow` poller) could **SIGSEGV the whole visor** during startup:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/skycoin/skywire/pkg/visor.(*Visor).RuntimeLogs(...) pkg/visor/api_visor.go:432
```

## Root cause
`RuntimeLogs` / `RuntimeLogsSince` dereference `v.logstore`, but `run()` wired it via `SetLogstore` only **after** `NewVisor` returns — and the RPC binds **during** module init *inside* `NewVisor`. A log query in that window hit a nil `v.logstore`. A long-lived `cli visor log --follow` reconnects the instant RPC binds on every restart, so it reliably lands in the window and **crash-loops a freshly-started visor** (plausibly part of the "visor won’t recover / RPC flaps at boot" symptom). #3169 (faster RPC bind) widened the window.

## Fix
- **Nil-guard** `RuntimeLogs` (→ `"[]"`) and `RuntimeLogsSince` (→ empty delta): a CLI log query must never crash the visor.
- **Wire the logstore + log broadcaster into `NewVisor` before module init**, eliminating the window so startup log queries return real data. (The broadcaster move also fixes `--verbose` "log broadcaster not available" during startup.)
- Regression test: nil-logstore `RuntimeLogs`/`RuntimeLogsSince` do not panic.

## Validation
- `go build`/`vet`/lint green; new unit test passes.
- Rolled the local visor onto the fix: clean boot, and **20× `cli visor log` (the exact crash trigger) no longer kills it** — returns real log data.