### PR TITLE
fix(router,transport-setup): merge dmsg.Prod.DmsgServers into bootstrap seed

### DIFF
--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -59,8 +59,14 @@ func NewNode(conf *SetupConfig) (*Node, error) {
 	// dmsgc.go) and the transport-setup service in
 	// pkg/transport-setup/api/api.go. Plain-HTTP discovery
 	// (conf.Dmsg.Discovery) is no longer supported for deployment
-	// services; conf.Dmsg.DiscoveryDmsg + seed conf.Dmsg.Servers are
-	// required.
+	// services; conf.Dmsg.DiscoveryDmsg is required.
+	//
+	// The seed-server set is conf.Dmsg.Servers ∪ dmsg.Prod.DmsgServers,
+	// deduped by Static PK with operator-supplied entries first. A
+	// deployment may therefore omit conf.Dmsg.Servers and still
+	// bootstrap — the embedded Prod set is the default. Same merge
+	// shape as dmsgsrv.buildTransitDmsg (pkg/services/dmsgsrv/
+	// dmsgsrv.go) so RSNs and dmsg-servers share the cold-start path.
 	//
 	// The previous code here spun a SECOND dmsg client via direct.StartDmsg
 	// just to back the dmsg-HTTP transport, sharing conf.PK with the
@@ -72,8 +78,27 @@ func NewNode(conf *SetupConfig) (*Node, error) {
 	// resolving discovery via a registering-fallback that reads direct-
 	// first (synthetic entries for the local PK + dmsg-service PKs) and
 	// writes via dmsg-HTTP routed through the same client's sessions.
+	servers := make([]*disc.Entry, 0, len(conf.Dmsg.Servers)+len(dmsg.Prod.DmsgServers))
+	seenPK := map[cipher.PubKey]struct{}{}
+	addServer := func(e *disc.Entry) {
+		if e == nil || e.Static.Null() || e.Server == nil {
+			return
+		}
+		if _, ok := seenPK[e.Static]; ok {
+			return
+		}
+		seenPK[e.Static] = struct{}{}
+		servers = append(servers, e)
+	}
+	for _, e := range conf.Dmsg.Servers {
+		addServer(e)
+	}
+	for i := range dmsg.Prod.DmsgServers {
+		addServer(&dmsg.Prod.DmsgServers[i])
+	}
+
 	seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKsFromConf(conf)...)
-	entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
+	entries := direct.GetAllEntries(seedKeys, servers)
 	directDisc := direct.NewClient(entries, masterLogger.PackageLogger("rsn:disc:direct"))
 
 	httpC := &http.Client{}
@@ -82,10 +107,7 @@ func NewNode(conf *SetupConfig) (*Node, error) {
 
 	dmsgConf := &dmsg.Config{MinSessions: conf.Dmsg.SessionsCount}
 	dmsgC := dmsg.NewClient(conf.PK, conf.SK, discClient, dmsgConf)
-	for _, srv := range conf.Dmsg.Servers {
-		if srv == nil || srv.Static.Null() || srv.Server == nil {
-			continue
-		}
+	for _, srv := range servers {
 		dmsgC.SeedEntryCache(srv.Static, srv)
 	}
 	httpC.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgC)

--- a/pkg/transport-setup/api/api.go
+++ b/pkg/transport-setup/api/api.go
@@ -60,8 +60,15 @@ func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	// Single dmsg client with self-hosted dmsg-discovery — matches the
 	// visor's post-#3136 bootstrap (pkg/visor/init_dmsg.go + pkg/dmsgc/
 	// dmsgc.go). Plain-HTTP discovery (conf.Dmsg.Discovery) is no longer
-	// supported for deployment services; conf.Dmsg.DiscoveryDmsg + seed
-	// conf.Dmsg.Servers are required.
+	// supported for deployment services; conf.Dmsg.DiscoveryDmsg is
+	// required.
+	//
+	// The seed-server set is conf.Dmsg.Servers ∪ dmsg.Prod.DmsgServers,
+	// deduped by Static PK with operator-supplied entries first. A
+	// deployment may therefore omit conf.Dmsg.Servers and still
+	// bootstrap — the embedded Prod set is the default. Same merge
+	// shape as dmsgsrv.buildTransitDmsg (pkg/services/dmsgsrv/
+	// dmsgsrv.go) and the RSN (pkg/router/setupnode.go).
 	//
 	// Pattern:
 	//   - direct.Client preloaded with the local PK + dmsg-disc PK,
@@ -74,8 +81,8 @@ func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	//     direct-first, WRITE via dmsg-HTTP so the service's own entry
 	//     IS published to the real dmsg-discovery.
 	//   - SINGLE dmsg.Client built against the wrapped disc.
-	//   - SeedEntryCache for every configured server (bootstrap dial
-	//     path + the Serve-loop fallback in #3146).
+	//   - SeedEntryCache for every seed server (bootstrap dial path
+	//     + the Serve-loop fallback in #3146).
 	//   - httpC.Transport wired to dmsghttp.MakeHTTPTransport(dmsgC)
 	//     AFTER construction — the transport isn't invoked until the
 	//     first PostEntry/Entry call, by which time Serve has already
@@ -84,16 +91,32 @@ func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
 	httpC := &http.Client{}
 	dmsgDisc := disc.NewHTTP(conf.Dmsg.DiscoveryDmsg, httpC, log)
 
+	servers := make([]*disc.Entry, 0, len(conf.Dmsg.Servers)+len(dmsg.Prod.DmsgServers))
+	seenPK := map[cipher.PubKey]struct{}{}
+	addServer := func(e *disc.Entry) {
+		if e == nil || e.Static.Null() || e.Server == nil {
+			return
+		}
+		if _, ok := seenPK[e.Static]; ok {
+			return
+		}
+		seenPK[e.Static] = struct{}{}
+		servers = append(servers, e)
+	}
+	for _, e := range conf.Dmsg.Servers {
+		addServer(e)
+	}
+	for i := range dmsg.Prod.DmsgServers {
+		addServer(&dmsg.Prod.DmsgServers[i])
+	}
+
 	seedKeys := append(cipher.PubKeys{conf.PK}, dmsgServicePKs(conf.Dmsg.DiscoveryDmsg)...)
-	entries := direct.GetAllEntries(seedKeys, conf.Dmsg.Servers)
+	entries := direct.GetAllEntries(seedKeys, servers)
 	directDisc := direct.NewClient(entries, log)
 	discClient := dmsgclient.NewRegisteringFallbackDiscClient(directDisc, dmsgDisc, log)
 
 	client := dmsg.NewClient(conf.PK, conf.SK, discClient, dmsgConf)
-	for _, srv := range conf.Dmsg.Servers {
-		if srv == nil || srv.Static.Null() || srv.Server == nil {
-			continue
-		}
+	for _, srv := range servers {
 		client.SeedEntryCache(srv.Static, srv)
 	}
 	httpC.Transport = dmsghttp.MakeHTTPTransport(context.Background(), client)


### PR DESCRIPTION
## Summary

Follow-up to #3161. The RSN (`pkg/router/setupnode.go`) and transport-setup (`pkg/transport-setup/api/api.go`) single-client dmsg bootstrap built its `direct.Client` discovery purely from `conf.Dmsg.Servers`. With an empty `Dmsg.Servers`, the direct disc held only synthetic client entries (local PK + dmsg-disc PK) — **no server addresses to dial** — and the `RegisteringFallbackDiscClient`'s HTTP-over-dmsg fallback path needs dmsg sessions to make HTTP calls, which it can't form without knowing a server. Result: cold-start deadlock, `dmsgC.Ready()` never fires.

Production setup-node configs that didn't ship a `servers` array (e.g. legacy configs still listing only `discovery: http://dmsgd…`) wedge silently for this reason — the binary just sits in the dialing loop with no targets.

## Change

Mirror `dmsgsrv.buildTransitDmsg`'s seed-merge shape in both RSN and TPS:

- Build the seed set as `conf.Dmsg.Servers ∪ dmsg.Prod.DmsgServers`, deduped by `Static` PK, operator entries first.
- The pre-existing null/`Server`-nil filter moves from the inline `SeedEntryCache` loops into a shared `addServer` closure, so both `direct.GetAllEntries` and `SeedEntryCache` see the same filtered/deduped list.

A deployment may now omit `conf.Dmsg.Servers` entirely and still cold-start from the embedded Prod set — matching the fallback behavior the visor (`pkg/visor/init_dmsg.go:480`) and dmsg-server (`pkg/services/dmsgsrv/dmsgsrv.go:458`) have always had.

No new dependencies; `dmsg` was already imported in both files.

## Test plan

- [x] `go vet ./pkg/router/... ./pkg/transport-setup/...` clean
- [x] `go build ./cmd/skywire/ ./cmd/svc/setup-node/ ./cmd/svc/transport-setup/` clean
- [ ] Manual: deploy with a setup-node config containing `discovery_dmsg` but **no** `servers` array — confirm dmsg sessions establish, entry is published to dmsg-discovery, real route-setup requests succeed
- [ ] Manual: same for a transport-setup config