### PR TITLE
fix(dmsg): unblock first-session callback so a stalled publish can't wedge the client

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -202,24 +202,69 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 
 	// Init callback: on set session.
 	c.EntityCommon.setSessionCallback = func(ctx context.Context) error {
-		// The first session must update discovery immediately so the
-		// client becomes "ready" (other modules wait on c.ready).
-		// Subsequent sessions use the debounced nudge path.
+		// The first session must update discovery before declaring
+		// Ready so other modules can immediately dial through us; see
+		// the wave of dmsghttp transport tests that fail with
+		// "client entry in discovery has no delegated servers" if
+		// Ready fires pre-publish. Subsequent sessions use the
+		// debounced nudge path.
 		select {
 		case <-c.ready:
 			// Already ready — nudge the update loop.
 			c.nudgeEntryUpdate()
 			return nil
 		default:
-			// First session — update immediately. updateClientEntry
-			// takes sessionsMx itself for its snapshot; holding it
-			// here would self-deadlock via the dmsgfirst path.
-			if err := c.EntityCommon.updateClientEntry(ctx, c.done, c.conf.ClientType); err != nil {
-				return err
-			}
-			c.readyOnce.Do(func() { close(c.ready) })
-			return nil
 		}
+		// First-session path runs the publish on its OWN goroutine,
+		// then waits up to entryUpdateAttemptTimeout for it to finish.
+		// The publish bounds itself with the same per-attempt timeout
+		// the entry loop uses (#3168). If it completes within the
+		// window we close c.ready on its result; if the wait expires
+		// we close c.ready anyway so the rest of the visor doesn't
+		// deadlock on us, and the publish goroutine continues to
+		// completion in the background (its own ctx will fire and
+		// unblock the dmsg-HTTP stream via the transport's ctx
+		// watcher). The updateClientEntryLoop handles further retries
+		// with exponential backoff.
+		//
+		// Originally this called updateClientEntry SYNCHRONOUSLY here
+		// with the unbounded session-dial ctx and closed c.ready only
+		// on success. That blocked the session-add path forever if
+		// the publish stalled — a dmsg-only deployment service
+		// (#3157, #3168) whose only established session couldn't
+		// reach the discovery PK saw the dmsg-HTTP transport get a
+		// stream via DialStream phase 3, then req.Write/ReadResponse
+		// hung on the stream's own deadlines (write: none, read:
+		// StreamIdleTimeout = 2 min). The cascade:
+		//   - first setSessionCallback blocks → dialSession never
+		//     returns → Serve loop's EnsureSession chain freezes;
+		//   - subsequent session callbacks (ready never closed) re-
+		//     enter this default branch and block on
+		//     httpClient.updateMux which the first call holds;
+		//   - updateClientEntryLoop's runUpdate (with the #3168 30 s
+		//     attempt timeout) ALSO blocks on updateMux because mutex
+		//     acquisition does not honor context — so the loop's
+		//     retry never fires either.
+		// The result was a wedged service that logged "Updating
+		// entry" once at startup and then went silent for hours.
+		publishCtx, publishCancel := context.WithTimeout(ctx, entryUpdateAttemptTimeout)
+		publishDone := make(chan error, 1)
+		go func() {
+			defer publishCancel()
+			publishDone <- c.EntityCommon.updateClientEntry(publishCtx, c.done, c.conf.ClientType)
+		}()
+		select {
+		case err := <-publishDone:
+			if err != nil {
+				c.log.WithError(err).Warn("Initial client entry update failed; loop will retry.")
+			}
+		case <-time.After(entryUpdateAttemptTimeout):
+			c.log.Warn("Initial client entry update did not complete within bound; closing Ready and letting the loop retry.")
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		c.readyOnce.Do(func() { close(c.ready) })
+		return nil
 	}
 
 	// Init callback: on delete session.

--- a/pkg/dmsg/dmsghttp/http_transport.go
+++ b/pkg/dmsg/dmsghttp/http_transport.go
@@ -194,11 +194,33 @@ func rewindBody(req *http.Request) error {
 // do writes req to ps and reads back the response. The response body
 // is wrapped so that closing it returns the stream to the idle pool
 // (or discards it on error).
+//
+// A watcher goroutine bounds the write + header-read by closing the
+// stream when req.Context() is canceled. Without it req.Write blocks
+// indefinitely (Stream has no write deadline once handshake completes,
+// see client_session.go:184) and http.ReadResponse blocks for up to
+// StreamIdleTimeout (2 min). Either path produced the wedge that
+// caused #3168 and the dmsg-only deployment-service deadlock cascade:
+// the caller's WithTimeout cancellation went unnoticed because the
+// stream's own deadlines were the only bound.
 func (t *HTTPTransport) do(ps *pooledStream, req *http.Request, requestedGzip bool) (*http.Response, error) {
+	ctx := req.Context()
+	writeReadDone := make(chan struct{})
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = ps.s.Close() //nolint:errcheck,gosec
+			case <-writeReadDone:
+			}
+		}()
+	}
 	if err := req.Write(ps.s); err != nil {
+		close(writeReadDone)
 		return nil, err
 	}
 	resp, err := http.ReadResponse(ps.br, req)
+	close(writeReadDone)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The first session's `setSessionCallback` was calling `updateClientEntry` **synchronously on the session-dial goroutine with an unbounded ctx** and only closing `c.ready` on success. When the publish stalled — concretely: a dmsg-only deployment service (#3157, #3168) whose only established session couldn't reach the dmsg-discovery PK through any mesh path — the entire dmsg client wedged. Three reinforcing failures stacked:

1. The first `setSessionCallback` blocks → `dialSession` never returns → `Client.Serve`'s `EnsureSession` chain freezes.
2. Subsequent session callbacks (ready never closed) re-enter the same default branch and block on `httpClient.updateMux` which the first call holds.
3. `updateClientEntryLoop`'s `runUpdate` (with the #3168 30 s attempt timeout) **also** blocks on `updateMux` because mutex acquisition does NOT honor context — so the loop's retry never fires either.

Production symptom: post-#3168 deployment of TPS-4/5/6 + SD with the plain-http `discovery` URL stripped. Each service logged `Updating entry.` once at ~21:35 and went silent for hours. dmsg-discovery's access log showed zero POSTs from those PKs — yet visors kept GETting those entries and 404ing. Goroutine state was the canonical deadlock cascade above.

## Change

Two complementary changes:

### \`pkg/dmsg/dmsg/client.go\` — bound the first-session publish

`setSessionCallback` now runs the first-session publish on its **own goroutine** with the same per-attempt timeout the entry loop uses (`entryUpdateAttemptTimeout`), waits up to that bound, then closes `c.ready` regardless of result. The publish goroutine continues in the background; `updateClientEntryLoop` retries on failure with the exponential backoff added in #3168.

Ready semantics: \"first session is dialed AND we either successfully published or attempted-and-bounded\" — strictly stronger than the trivial \"first session\" semantics that broke dmsghttp tests with `client entry in discovery has no delegated servers`, strictly safer than the original \"blocks forever on a stalled publish\".

### \`pkg/dmsg/dmsghttp/http_transport.go\` — make \`do\` ctx-aware

`HTTPTransport.do` now installs a watcher goroutine that closes the underlying dmsg stream when `req.Context()` is canceled. Without it `req.Write` blocked indefinitely (stream has no write deadline once handshake completes, see `client_session.go:184`) and `http.ReadResponse` blocked up to `StreamIdleTimeout` (2 min). Either path made the #3168 30 s per-attempt ctx ineffective against a stuck stream — the stream's own deadlines were the only bound.

Together: the per-attempt ctx now actually propagates through to the stream, the publish goroutine returns, the mutex releases, and the loop keeps retrying.

## Relation to other in-flight work

Complementary to #3171 (which patches a *different* dmsg-bootstrap edge case — empty `conf.Dmsg.Servers` for setup-node / transport-setup). Both are needed for the dmsg-only deployment-service path:
- #3171 ensures the seed set is non-empty so DialStream has somewhere to start.
- This PR ensures that when DialStream *does* succeed but the publish to the dmsg-discovery PK can't immediately complete, the client doesn't wedge.

## Test plan

- [x] `go test ./pkg/dmsg/dmsg/... ./pkg/dmsg/dmsghttp/... ./pkg/dmsg/dmsgtest/...` (all green including the `TestMakeHTTPTransport_*` triplet that initially regressed on a too-aggressive Ready-relaxation)
- [x] `go vet ./pkg/dmsg/...` clean
- [ ] Deploy on prod02 and verify TPS-4/5/6 + SD register in dmsg-discovery within seconds of session establishment, then continue publishing on the standard updateInterval cadence
- [ ] Confirm no regression in client-Ready timing on the normal (non-stalled) startup path