### PR TITLE
feat(logserver): stream /skywire.log live (tail -f in the browser)

### DIFF
--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -240,9 +240,11 @@ func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.Pu
 	// a strict --min-level filter).
 	//
 	// Output modes:
-	//   default            → terminal-styled HTML (colored per log level)
+	//   default            → terminal-styled HTML (colored per log level),
+	//                        STREAMED: renders the backlog then tails the file
+	//                        live (chunked) until the client disconnects
 	//   ?raw=1 (or Accept   → verbatim plain text (c.File) for log-scraping
-	//     text/plain)
+	//     text/plain)         (one-shot — completes for scrapers)
 	//   any filter param   → plain-text streaming filtered mode
 	//
 	// Served at /skywire.log (matching the on-disk filename written by

--- a/pkg/visor/logserver/visorlog_html.go
+++ b/pkg/visor/logserver/visorlog_html.go
@@ -33,9 +33,35 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+// htmlLogPreamble is the <head> + opening <body> for the colorized log view.
+// It includes a tiny inline auto-scroll script (progressive enhancement: the
+// log streams fine with JS disabled, you just scroll manually) that keeps the
+// view pinned to the newest line while the reader is at the bottom, and stops
+// following the instant they scroll up to inspect history.
+const htmlLogPreamble = `<!doctype html><html><head><meta charset="utf-8"><title>skywire.log</title>` +
+	`<style>` +
+	`body{background:#0a0a0a;color:#d0d0d0;font-family:'DejaVu Sans Mono',Menlo,Consolas,monospace;` +
+	`font-size:13px;line-height:1.35;margin:0;padding:12px}` +
+	`pre{margin:0;white-space:pre-wrap;word-break:break-word}` +
+	`</style></head><body>` +
+	`<script>(function(){var stick=true;` +
+	`addEventListener('scroll',function(){stick=(window.innerHeight+window.scrollY)>=document.documentElement.scrollHeight-40;});` +
+	`setInterval(function(){if(stick)window.scrollTo(0,document.documentElement.scrollHeight);},500);})();</script>` +
+	`<pre>`
+
+// logRotatedNotice is emitted inline when the underlying file is rotated or
+// truncated out from under the tail, so the reader sees the discontinuity.
+const logRotatedNotice = `<span style="color:#808080">--- log rotated ---</span>` + "\n"
+
+// logFollowPollInterval is how often the streaming view re-checks the file for
+// appended lines once it has caught up to EOF. Matches the plain-text follow
+// mode in visorlog_filter.go.
+const logFollowPollInterval = 250 * time.Millisecond
 
 // levelColors maps a logrus level token (as it appears upper-cased in the
 // on-disk log) to an inline CSS color. The palette tracks logrus's default
@@ -85,36 +111,42 @@ var logLineRE = regexp.MustCompile(
 var fieldRE = regexp.MustCompile(`([A-Za-z0-9_.\-]+)=("[^"]*"|\S*)`)
 
 // renderVisorLogHTML streams logFile to the client as a terminal-styled HTML
-// page: near-black background, light monospace text, one colored line per log
-// entry keyed off its parsed level. Content is HTML-escaped per line.
+// page (near-black background, light monospace, one colored line per log entry
+// keyed off its parsed level; content HTML-escaped per line) as a never-ending
+// chunked response: it writes the current backlog, then tails the file —
+// flushing each new line as it is appended — until the client disconnects.
 //
-// It streams rather than buffering so a multi-megabyte log doesn't balloon
-// memory, flushing periodically for responsiveness over dmsg/skynet.
+// The response carries no Content-Length, so Go uses chunked transfer-encoding
+// and each Flush reaches the browser (over the dmsg-HTTP tunnel) immediately,
+// giving a live `tail -f`-in-the-browser view without buffering a multi-MB log
+// into memory. Log rotation/truncation is detected and the tail re-opens the
+// new file. The plaintext one-shot (?raw=1) and filtered follow (?follow=1)
+// modes are unaffected.
 func renderVisorLogHTML(c *gin.Context, logFile string) {
 	f, err := os.Open(logFile) //nolint:gosec // path comes from localPath config, not request
 	if err != nil {
 		c.String(http.StatusInternalServerError, "open skywire.log: %v", err)
 		return
 	}
-	defer f.Close() //nolint:errcheck
+	defer func() { _ = f.Close() }() //nolint:errcheck // f is reassigned on rotation; close the final fd
 
 	c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("X-Content-Type-Options", "nosniff")
 	c.Writer.WriteHeader(http.StatusOK)
 
 	// Page head + terminal styling. <pre> preserves the log's own spacing;
 	// per-line <span>s carry the level color.
-	//nolint:errcheck // .golangci.yml has check-blank:true so the _,_ discard alone is not enough; nolint silences errcheck while the discard satisfies gosec G104
-	_, _ = io.WriteString(c.Writer,
-		`<!doctype html><html><head><meta charset="utf-8"><title>skywire.log</title>`+
-			`<style>`+
-			`body{background:#0a0a0a;color:#d0d0d0;font-family:'DejaVu Sans Mono',Menlo,Consolas,monospace;`+
-			`font-size:13px;line-height:1.35;margin:0;padding:12px}`+
-			`pre{margin:0;white-space:pre-wrap;word-break:break-word}`+
-			`</style></head><body><pre>`)
+	if _, werr := io.WriteString(c.Writer, htmlLogPreamble); werr != nil {
+		return
+	}
+	c.Writer.Flush()
 
 	r := bufio.NewReaderSize(f, 64*1024)
 	ctx := c.Request.Context()
-	flushEvery := 0
+	var offset int64 // bytes consumed — used to detect rotation/truncation
+	caughtUp := false
+	batch := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -123,20 +155,50 @@ func renderVisorLogHTML(c *gin.Context, logFile string) {
 		}
 		line, rerr := r.ReadString('\n')
 		if len(line) > 0 {
+			offset += int64(len(line))
 			if _, werr := io.WriteString(c.Writer, colorizeLine(line)); werr != nil {
-				return
+				return // client gone
 			}
-			flushEvery++
-			if flushEvery%256 == 0 {
+			if caughtUp {
+				// Live phase: flush every line for minimal latency.
 				c.Writer.Flush()
+			} else {
+				// Backlog phase: flush in batches to avoid a chunk per line.
+				batch++
+				if batch%256 == 0 {
+					c.Writer.Flush()
+				}
+			}
+			continue
+		}
+		if rerr != nil && rerr != io.EOF {
+			return
+		}
+		// EOF — caught up to the end of the file.
+		if !caughtUp {
+			caughtUp = true
+			c.Writer.Flush() // push the remaining backlog now
+		}
+		// Rotation/truncation: the path now resolves to a file smaller than
+		// where we are reading — reopen from the start of the new file.
+		if fi, serr := os.Stat(logFile); serr == nil && fi.Size() < offset {
+			if nf, oerr := os.Open(logFile); oerr == nil { //nolint:gosec // path from config, not request
+				_ = f.Close() //nolint:errcheck
+				f = nf
+				r.Reset(f)
+				offset = 0
+				_, _ = io.WriteString(c.Writer, logRotatedNotice) //nolint:errcheck
+				c.Writer.Flush()
+				continue
 			}
 		}
-		if rerr != nil {
-			break
+		// Poll for appends.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(logFollowPollInterval):
 		}
 	}
-	_, _ = io.WriteString(c.Writer, "</pre></body></html>") //nolint:errcheck
-	c.Writer.Flush()
 }
 
 // colorizeLine renders a single (raw, unescaped) log line as terminal-style

--- a/pkg/visor/logserver/visorlog_stream_test.go
+++ b/pkg/visor/logserver/visorlog_stream_test.go
@@ -1,0 +1,175 @@
+package logserver
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestRenderVisorLogHTMLStreams verifies the colorized log view tails the file:
+// it renders the existing backlog AND a line appended after the response has
+// started, then returns when the client (request context) disconnects. Body is
+// read only after the handler goroutine has returned, so there's no concurrent
+// access to the recorder buffer.
+func TestRenderVisorLogHTMLStreams(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "skywire.log")
+	if err := os.WriteFile(logFile, []byte("[2026-06-18T10:00:00-05:00] INFO [test]: backlog line\n"), 0o600); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.Request = httptest.NewRequest("GET", "/skywire.log", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		renderVisorLogHTML(c, logFile)
+		close(done)
+	}()
+
+	// Give it time to render the backlog and enter the follow loop, then append
+	// a line; the tail should pick it up within a couple of poll intervals.
+	time.Sleep(2 * logFollowPollInterval)
+	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec
+	if err != nil {
+		t.Fatalf("reopen log for append: %v", err)
+	}
+	if _, err := f.WriteString("[2026-06-18T10:00:01-05:00] WARN [test]: appended line\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = f.Close() //nolint:errcheck
+	time.Sleep(3 * logFollowPollInterval)
+
+	// Disconnect → handler must return promptly.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("renderVisorLogHTML did not return after client disconnect")
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"<pre>",         // preamble written
+		"backlog line",  // existing content rendered
+		"appended line", // proves it streamed an append after start
+		"color:",        // colorized (per-element spans)
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("streamed body missing %q\nbody:\n%s", want, body)
+		}
+	}
+	// A live tail must NOT terminate the document — the </pre></body></html>
+	// only ever follows a finite render, which this no longer is.
+	if strings.Contains(body, "</body></html>") {
+		t.Errorf("streaming view should not emit a closing document; body:\n%s", body)
+	}
+}
+
+// TestRenderVisorLogHTMLStreamsOverHTTP proves the view streams over a REAL
+// http.Server (chunked transfer-encoding over a TCP conn) — the same transport
+// the dmsg-HTTP server and the in-process self-loopback use. It confirms the
+// response has no Content-Length (so Go chunks it) and that a line appended
+// AFTER the response started reaches the client before the request ends.
+func TestRenderVisorLogHTMLStreamsOverHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "skywire.log")
+	if err := os.WriteFile(logFile, []byte("[2026-06-18T10:00:00-05:00] INFO [test]: backlog over http\n"), 0o600); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	r := gin.New()
+	r.GET("/skywire.log", func(c *gin.Context) { renderVisorLogHTML(c, logFile) })
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/skywire.log", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck
+
+	// A streamed response carries no Content-Length — that's what makes Go use
+	// chunked transfer-encoding and flush incrementally.
+	if resp.ContentLength != -1 {
+		t.Errorf("expected unbounded (chunked) response, got Content-Length=%d", resp.ContentLength)
+	}
+
+	// Drain the body in the background into a mutex-guarded buffer; the test
+	// polls it for markers so a blocking Read never stalls the test.
+	var (
+		mu  sync.Mutex
+		buf strings.Builder
+	)
+	go func() {
+		br := bufio.NewReader(resp.Body)
+		p := make([]byte, 4096)
+		for {
+			n, rerr := br.Read(p)
+			if n > 0 {
+				mu.Lock()
+				buf.Write(p[:n])
+				mu.Unlock()
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	contains := func(s string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return strings.Contains(buf.String(), s)
+	}
+	waitFor := func(s string, d time.Duration) bool {
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			if contains(s) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitFor("backlog over http", 3*time.Second) {
+		t.Fatal("did not receive backlog over the streamed connection")
+	}
+
+	// Append AFTER the stream is established; it must arrive without us closing.
+	f, ferr := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec
+	if ferr != nil {
+		t.Fatalf("reopen for append: %v", ferr)
+	}
+	_, _ = f.WriteString("[2026-06-18T10:00:01-05:00] ERROR [test]: live append over http\n") //nolint:errcheck
+	_ = f.Close()                                                                             //nolint:errcheck
+
+	if !waitFor("live append over http", 3*time.Second) {
+		t.Fatal("appended line did not stream to the client (buffering, not streaming)")
+	}
+
+	cancel() // disconnect; server handler must observe ctx and stop
+}


### PR DESCRIPTION
Per request: `http://<visor>.dmsg/skywire.log` should keep updating instead of being a one-shot dump.

## Change
The colorized `/skywire.log` view is now a **never-ending chunked response**: it renders the backlog, then tails the file — flushing each newly-appended line — until the client disconnects (detected via the request context). No `Content-Length`, so Go uses chunked transfer-encoding and each `Flush` reaches the browser over the dmsg-HTTP tunnel immediately — a live `tail -f` in the browser.

- Flush per-line once caught up to EOF; batch-flush the initial backlog (every 256 lines).
- Detect log rotation/truncation (path resolves to a file smaller than our read offset) → reopen the new file, emit an inline `--- log rotated ---`.
- Tiny inline auto-scroll (progressive enhancement): pins to the newest line while the reader is at the bottom, releases when they scroll up.
- `?raw=1` (one-shot plain text) and `?follow=1` (filtered plain-text stream) unchanged.

## Validation
- `TestRenderVisorLogHTMLStreams` — gin-level: backlog + an append-after-start both render; returns promptly on disconnect; no closing document.
- `TestRenderVisorLogHTMLStreamsOverHTTP` — over a **real `http.Server`** (chunked-over-TCP, the same transport dmsg-HTTP and the in-process self-loopback use): asserts `Content-Length == -1` and that a line appended after the response started reaches the client before the request ends (i.e. it streams, not buffers).
- Build + vet + lint + `-race` green.