### PR TITLE
feat(deploy-services): dmsg-only discovery for RF/AR/TPD/SD/UT/CONFBS

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -803,7 +803,7 @@ func fetchServiceConfigDmsg(log *logging.Logger) bool {
 	}
 
 	dmsgBoot, err := cmdutil.BootstrapDmsg(ctx, dmsgLog, pk, sk,
-		dmsg.Prod.DmsgServers, embeddedConf.DmsgDiscovery, "")
+		dmsg.Prod.DmsgServers, embeddedConf.DmsgDiscovery, "", "")
 	if err != nil {
 		logIfNotStdout(log, err, "DMSG bootstrap failed for config fetch")
 		return false

--- a/cmd/skywire-cli/commands/log/dmsghttp_client.go
+++ b/cmd/skywire-cli/commands/log/dmsghttp_client.go
@@ -93,7 +93,7 @@ func dmsgHTTPClient(ctx context.Context, timeout time.Duration) (*http.Client, f
 	}
 	log.WithField("source", source).WithField("local_pk", pk.String()).Debug("Resolved survey-whitelist identity for CLI request")
 
-	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, resolvedSK, dmsg.Prod.DmsgServers, dmsgDiscURL, "")
+	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, resolvedSK, dmsg.Prod.DmsgServers, dmsgDiscURL, "", "")
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("dmsg bootstrap: %w", err)
 	}

--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -104,7 +104,7 @@ var logCmd = &cobra.Command{
 		if err != nil {
 			pk, sk = cipher.GenerateKeyPair()
 		}
-		bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers, dmsgDisc, "")
+		bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers, dmsgDisc, "", "")
 		if err != nil {
 			log.WithError(err).Error("Failed to bootstrap dmsg client.")
 			return

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -31,6 +31,7 @@ var (
 	stunPath       string
 	domain         string
 	dmsgDisc       string
+	dmsgDiscDmsg   string
 	sk             cipher.SecKey
 	keyFile        string
 	dmsgPort       uint16
@@ -95,7 +96,8 @@ func init() {
 	RootCmd.Flags().StringVar(&tag, "tag", "config_bootstrapper", "logging tag\n\r")
 	RootCmd.Flags().StringVarP(&stunPath, "config", "c", "./config.json", "stun server list file location\n\r")
 	RootCmd.Flags().StringVarP(&domain, "domain", "d", "skywire.skycoin.com", "the domain of the endpoints\n\r")
-	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsg.DiscURL(false), "url of dmsg-discovery\n\r")
+	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", "", "plain-HTTP url of dmsg-discovery (deprecated; leave empty for dmsg-only)\n\r")
+	RootCmd.Flags().StringVar(&dmsgDiscDmsg, "dmsg-disc-dmsg", dmsg.DiscAddr(false), "dmsg-PK url of dmsg-discovery (default: embedded prod)\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
@@ -170,6 +172,7 @@ HTTP Endpoints:
 			SK:                  sk,
 			DmsgPort:            dmsgPort,
 			DmsgDiscovery:       dmsgDisc,
+			DmsgDiscoveryDmsg:   dmsgDiscDmsg,
 			DmsgServerType:      dmsgServerType,
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,

--- a/cmd/svc/uptime-tracker/commands/root.go
+++ b/cmd/svc/uptime-tracker/commands/root.go
@@ -53,6 +53,7 @@ var (
 	enableLoadTesting bool
 	testing           bool
 	dmsgDisc          string
+	dmsgDiscDmsg      string
 	sk                cipher.SecKey
 	keyFile           string
 	dmsgPort          uint16
@@ -79,7 +80,8 @@ func init() {
 	RootCmd.Flags().StringVar(&geoipURL, "geoip", deployment.Prod.GeoIP, "url of geoip service\n\r")
 	RootCmd.Flags().BoolVar(&enableLoadTesting, "enable-load-testing", false, "enable load testing")
 	RootCmd.Flags().BoolVarP(&testing, "testing", "t", false, "enable testing to start without redis")
-	RootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", dmsg.DiscURL(false), "url of dmsg discovery\n\r")
+	RootCmd.Flags().StringVar(&dmsgDisc, "dmsg-disc", "", "plain-HTTP url of dmsg-discovery (deprecated; leave empty for dmsg-only)\n\r")
+	RootCmd.Flags().StringVar(&dmsgDiscDmsg, "dmsg-disc-dmsg", dmsg.DiscAddr(false), "dmsg-PK url of dmsg-discovery (default: embedded prod)\n\r")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n\r")
 	RootCmd.Flags().StringVar(&keyFile, "keyfile", "", "path to file containing secret key (auto-generated if missing)\n\r")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsg-port", dmsg.DefaultDmsgHTTPPort, "dmsg port value\n\r")
@@ -296,6 +298,7 @@ HTTP Endpoints:
 			// DmsgServerType to BootstrapDmsg; preserve that.
 			DmsgServerType:      "",
 			DmsgDiscovery:       dmsgDisc,
+			DmsgDiscoveryDmsg:   dmsgDiscDmsg,
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,

--- a/pkg/cmdutil/dmsg_bootstrap.go
+++ b/pkg/cmdutil/dmsg_bootstrap.go
@@ -4,6 +4,7 @@ package cmdutil
 import (
 	"context"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -24,10 +25,18 @@ type DmsgBootstrap struct {
 
 // BootstrapDmsg creates a DMSG client for a service using the bootstrap priority:
 //  1. Embedded deployment config (dmsg.Prod/Test servers) — no network needed
-//  2. HTTP discovery fallback if embedded servers are empty
+//  2. HTTP discovery fallback (only when dmsgDiscoveryDmsg is empty AND
+//     dmsgDisc is set) if embedded servers are empty
+//
+// dmsgDiscoveryDmsg, when non-empty, switches the discovery fallback and
+// the background refresh onto dmsg-HTTP — the http.Client used by the
+// disc.APIClient gets its Transport wired to dmsghttp.MakeHTTPTransport,
+// routing all discovery RPC over the dmsg client's sessions. No plain-
+// HTTP egress occurs in this mode; dmsgDisc is ignored.
 //
 // After connecting, a background goroutine refreshes the server list from
-// discovery (preferring DMSG transport, falling back to HTTP).
+// discovery: dmsg-HTTP only when dmsgDiscoveryDmsg is set, otherwise
+// dmsg-first with HTTP fallback.
 func BootstrapDmsg(
 	ctx context.Context,
 	log *logging.Logger,
@@ -35,6 +44,7 @@ func BootstrapDmsg(
 	sk cipher.SecKey,
 	embeddedServers []disc.Entry,
 	dmsgDisc string,
+	dmsgDiscoveryDmsg string,
 	dmsgServerType string,
 ) (*DmsgBootstrap, error) {
 	// Step 1: Use embedded servers for initial bootstrap
@@ -47,8 +57,12 @@ func BootstrapDmsg(
 		log.Infof("Using %d embedded DMSG servers for bootstrap", len(servers))
 	}
 
-	// Step 2: If no embedded servers, fall back to HTTP discovery
-	if len(servers) == 0 && dmsgDisc != "" {
+	// Step 2: If no embedded servers AND we're in plain-HTTP mode,
+	// fall back to HTTP discovery to seed the initial server set.
+	// In dmsg-only mode (dmsgDiscoveryDmsg set) there is no plain-HTTP
+	// fallback — operators ship a non-empty embedded set or the
+	// service simply has no targets to dial at boot.
+	if len(servers) == 0 && dmsgDiscoveryDmsg == "" && dmsgDisc != "" {
 		log.Info("No embedded DMSG servers, fetching from discovery via HTTP...")
 		servers = dmsghttp.GetServers(ctx, dmsgDisc, dmsgServerType, log)
 	}
@@ -78,7 +92,7 @@ func BootstrapDmsg(
 	keys := cipher.PubKeys{pk}
 	directDClient := direct.NewClient(direct.GetAllEntries(keys, servers), log)
 
-	// Wrap the direct client with an HTTP-discovery fallback so per-PK
+	// Wrap the direct client with a discovery fallback so per-PK
 	// Entry() lookups query the real dmsg-discovery instead of the
 	// in-memory bootstrap set. Without this, dmsg.DialStream returned
 	// "dmsg error 100 - entry is not found in discovery" for every PK
@@ -87,11 +101,22 @@ func BootstrapDmsg(
 	// stay on the direct client so the bootstrap phase is unchanged;
 	// only the Entry() path now consults real discovery.
 	//
-	// When dmsgDisc is empty the caller has explicitly opted out of
-	// HTTP discovery (e.g. fully air-gapped deployments) — keep the
-	// direct-only behavior in that case.
+	// When dmsgDiscoveryDmsg is set, the fallback http.Client has its
+	// Transport wired to dmsghttp.MakeHTTPTransport(ctx, dmsgDC) AFTER
+	// dmsgDC is constructed but BEFORE Serve runs — same single-client
+	// trick post-#3161 setup-node/transport-setup use to dodge the
+	// dual-client self-eviction storm. The dmsg client and the http
+	// client that backs its disc fallback are wired to each other.
+	// When dmsgDiscoveryDmsg is empty the caller has explicitly opted
+	// out of dmsg-only discovery; plain-HTTP behavior follows dmsgDisc.
 	dClient := directDClient
-	if dmsgDisc != "" {
+	var dmsgHTTPC *http.Client
+	switch {
+	case dmsgDiscoveryDmsg != "":
+		dmsgHTTPC = &http.Client{}
+		httpDiscClient := disc.NewHTTP(dmsgDiscoveryDmsg, dmsgHTTPC, log)
+		dClient = dmsgclient.NewFallbackDiscClient(directDClient, httpDiscClient, log)
+	case dmsgDisc != "":
 		httpDiscClient := disc.NewHTTP(dmsgDisc, &http.Client{Timeout: 30 * time.Second}, log)
 		dClient = dmsgclient.NewFallbackDiscClient(directDClient, httpDiscClient, log)
 	}
@@ -102,15 +127,50 @@ func BootstrapDmsg(
 		ConnectedServersType: dmsgServerType,
 	}
 
-	dmsgDC, closeDmsgDC, err := direct.StartDmsg(ctx, log, pk, sk, dClient, config)
-	if err != nil {
-		return nil, err
+	// Build dmsgDC inline (rather than via direct.StartDmsg) so the
+	// dmsg-HTTP transport can be wired into dmsgHTTPC AFTER NewClient
+	// but BEFORE Serve. The disc fallback is invoked lazily — only on
+	// Entry() for PKs not in the direct seed — so wiring before Serve
+	// is sufficient; any earlier-startup AvailableServers / PostEntry
+	// short-circuit through the direct client.
+	dmsgDC := dmsg.NewClient(pk, sk, dClient, config)
+	dmsgDC.SetLogger(log)
+	for _, e := range servers {
+		if e == nil || e.Static.Null() || e.Server == nil {
+			continue
+		}
+		dmsgDC.SeedEntryCache(e.Static, e)
+	}
+	if dmsgDiscoveryDmsg != "" {
+		dmsgHTTPC.Transport = dmsghttp.MakeHTTPTransport(ctx, dmsgDC)
 	}
 
-	// Background: refresh servers — try DMSG first, fall back to HTTP.
-	// Updates are PostEntry'd into the direct client so AllServers stays
-	// current; the fallback wrapper delegates PostEntry to direct.
-	go updateServersDmsgFirst(ctx, dClient, dmsgDC, dmsgDisc, dmsgServerType, log)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		dmsgDC.Serve(ctx)
+	}()
+	closeDmsgDC := func() {
+		if err := dmsgDC.Close(); err != nil {
+			log.WithError(err).Debug("Disconnected from dmsg network.")
+		}
+		wg.Wait()
+	}
+
+	select {
+	case <-ctx.Done():
+		closeDmsgDC()
+		return nil, ctx.Err()
+	case <-dmsgDC.Ready():
+	}
+
+	// Background: refresh servers. dmsg-only when dmsgDiscoveryDmsg
+	// is set (no plain-HTTP egress); otherwise dmsg-first with HTTP
+	// fallback. Updates are PostEntry'd into the direct client so
+	// AllServers stays current; the fallback wrapper delegates
+	// PostEntry to direct.
+	go updateServersDmsgFirst(ctx, dClient, dmsgDC, dmsgDisc, dmsgDiscoveryDmsg, dmsgServerType, log)
 
 	return &DmsgBootstrap{
 		Client:  dmsgDC,
@@ -120,16 +180,24 @@ func BootstrapDmsg(
 }
 
 // updateServersDmsgFirst periodically refreshes the DMSG server list.
-// It tries to reach discovery over DMSG first (private, no DNS dependency),
-// falling back to HTTP if DMSG fails.
+// dmsgDiscoveryDmsg (when non-empty) forces dmsg-HTTP — no plain-HTTP
+// egress. Otherwise tries dmsg first, falls back to plain HTTP on
+// dmsgDisc.
 func updateServersDmsgFirst(
 	ctx context.Context,
 	dClient disc.APIClient,
 	dmsgC *dmsg.Client,
 	dmsgDisc string,
+	dmsgDiscoveryDmsg string,
 	dmsgServerType string,
 	log *logging.Logger,
 ) {
+	if dmsgDisc == "" && dmsgDiscoveryDmsg == "" {
+		// Nothing to refresh against; the embedded seed is the
+		// final word for this process. Same behavior as pre-
+		// existing code when dmsgDisc was empty.
+		return
+	}
 	ticker := time.NewTicker(10 * time.Minute)
 	defer ticker.Stop()
 
@@ -138,7 +206,7 @@ func updateServersDmsgFirst(
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			servers := fetchServers(ctx, dmsgC, dmsgDisc, dmsgServerType, log)
+			servers := fetchServers(ctx, dmsgC, dmsgDisc, dmsgDiscoveryDmsg, dmsgServerType, log)
 			for _, server := range servers {
 				dClient.PostEntry(ctx, server) //nolint:errcheck,gosec
 				if err := dmsgC.EnsureSession(ctx, server); err != nil {
@@ -149,15 +217,40 @@ func updateServersDmsgFirst(
 	}
 }
 
-// fetchServers tries to get servers over DMSG first, falls back to HTTP.
+// fetchServers refreshes the dmsg-server list from discovery. dmsg-HTTP
+// is the only path when dmsgDiscoveryDmsg is set; otherwise dmsg-first
+// over dmsgDisc with a plain-HTTP fallback on the same URL.
 func fetchServers(
 	ctx context.Context,
 	dmsgC *dmsg.Client,
 	dmsgDisc string,
+	dmsgDiscoveryDmsg string,
 	dmsgServerType string,
 	log *logging.Logger,
 ) []*disc.Entry {
-	// Try DMSG transport first
+	// dmsg-only mode: dmsg-HTTP exclusively. No plain-HTTP egress
+	// regardless of dmsgDisc — operators have opted out of HTTP and
+	// a failed refresh is preferable to a silent fallback.
+	if dmsgDiscoveryDmsg != "" {
+		if dmsgC == nil {
+			return nil
+		}
+		dmsgHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
+		dmsgDiscClient := disc.NewHTTP(dmsgDiscoveryDmsg, dmsgHTTP, log)
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		servers, err := dmsgDiscClient.AllServers(timeoutCtx)
+		cancel()
+		if err != nil {
+			log.WithError(err).Debug("dmsg-HTTP server refresh failed (dmsg-only mode; no HTTP fallback)")
+			return nil
+		}
+		log.Debugf("Refreshed %d servers via dmsg-HTTP", len(servers))
+		return filterByType(servers, dmsgServerType)
+	}
+
+	// Legacy plain-HTTP-permitted mode: try dmsg first, fall back to
+	// HTTP on the same URL.
 	if dmsgC != nil {
 		dmsgHTTP := &http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
 		dmsgDiscClient := disc.NewHTTP(dmsgDisc, dmsgHTTP, log)

--- a/pkg/services/ar/ar.go
+++ b/pkg/services/ar/ar.go
@@ -158,9 +158,10 @@ func (s *service) Run(ctx context.Context) error {
 		return fmt.Errorf("address-resolver: invalid mode: %w", err)
 	}
 
-	dmsgDisc := cfg.Dmsg.Discovery
-	if dmsgDisc == "" {
-		dmsgDisc = dmsg.DiscURL(false)
+	// dmsg-only discovery: see pkg/services/rf/rf.go for rationale.
+	dmsgDiscDmsg := cfg.Dmsg.DiscoveryDmsg
+	if dmsgDiscDmsg == "" {
+		dmsgDiscDmsg = dmsg.DiscAddr(false)
 	}
 	embeddedServers := dmsgDiscEntries(cfg.Dmsg.Servers)
 	surveyWL := deployment.Prod.SurveyWhitelist
@@ -183,7 +184,7 @@ func (s *service) Run(ctx context.Context) error {
 		PK:                  pk,
 		SK:                  sk,
 		DmsgPort:            dmsgPort,
-		DmsgDiscovery:       dmsgDisc,
+		DmsgDiscoveryDmsg:   dmsgDiscDmsg,
 		DmsgServerType:      cfg.Dmsg.ServerType,
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,

--- a/pkg/services/rf/rf.go
+++ b/pkg/services/rf/rf.go
@@ -182,9 +182,14 @@ func (s *service) Run(ctx context.Context) error {
 		return fmt.Errorf("route-finder: invalid mode: %w", err)
 	}
 
-	dmsgDisc := cfg.Dmsg.Discovery
-	if dmsgDisc == "" {
-		dmsgDisc = dmsg.DiscURL(false)
+	// dmsg-only discovery: the plain-HTTP cfg.Dmsg.Discovery field is
+	// ignored. Operators configure cfg.Dmsg.DiscoveryDmsg explicitly,
+	// or the embedded dmsg-PK URL (deployment.Prod.DmsgDiscoveryDmsg
+	// via dmsg.DiscAddr) is used. svcmode routes discovery RPC over
+	// dmsg-HTTP via the bootstrap dmsg client — no plain-HTTP egress.
+	dmsgDiscDmsg := cfg.Dmsg.DiscoveryDmsg
+	if dmsgDiscDmsg == "" {
+		dmsgDiscDmsg = dmsg.DiscAddr(false)
 	}
 	embeddedServers := dmsgDiscEntries(cfg.Dmsg.Servers)
 	surveyWL := deployment.Prod.SurveyWhitelist
@@ -207,7 +212,7 @@ func (s *service) Run(ctx context.Context) error {
 		PK:                  pk,
 		SK:                  sk,
 		DmsgPort:            dmsgPort,
-		DmsgDiscovery:       dmsgDisc,
+		DmsgDiscoveryDmsg:   dmsgDiscDmsg,
 		DmsgServerType:      cfg.Dmsg.ServerType,
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,

--- a/pkg/services/sd/sd.go
+++ b/pkg/services/sd/sd.go
@@ -146,9 +146,10 @@ func (s *service) Run(ctx context.Context) error {
 		return fmt.Errorf("service-discovery: invalid mode: %w", err)
 	}
 
-	dmsgDisc := cfg.Dmsg.Discovery
-	if dmsgDisc == "" {
-		dmsgDisc = dmsg.DiscURL(false)
+	// dmsg-only discovery: see pkg/services/rf/rf.go for rationale.
+	dmsgDiscDmsg := cfg.Dmsg.DiscoveryDmsg
+	if dmsgDiscDmsg == "" {
+		dmsgDiscDmsg = dmsg.DiscAddr(false)
 	}
 	embeddedServers := dmsgDiscEntries(cfg.Dmsg.Servers)
 	surveyWL := deployment.Prod.SurveyWhitelist
@@ -167,7 +168,7 @@ func (s *service) Run(ctx context.Context) error {
 		PK:                  pk,
 		SK:                  sk,
 		DmsgPort:            dmsgPort,
-		DmsgDiscovery:       dmsgDisc,
+		DmsgDiscoveryDmsg:   dmsgDiscDmsg,
 		DmsgServerType:      cfg.Dmsg.ServerType,
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,

--- a/pkg/services/tpd/tpd.go
+++ b/pkg/services/tpd/tpd.go
@@ -209,9 +209,10 @@ func (s *service) Run(ctx context.Context) error {
 		return fmt.Errorf("transport-discovery: invalid mode: %w", err)
 	}
 
-	dmsgDisc := cfg.Dmsg.Discovery
-	if dmsgDisc == "" {
-		dmsgDisc = deployment.Prod.DmsgDiscovery
+	// dmsg-only discovery: see pkg/services/rf/rf.go for rationale.
+	dmsgDiscDmsg := cfg.Dmsg.DiscoveryDmsg
+	if dmsgDiscDmsg == "" {
+		dmsgDiscDmsg = dmsg.DiscAddr(false)
 	}
 	embeddedServers := dmsgDiscEntries(cfg.Dmsg.Servers)
 	surveyWL := deployment.Prod.SurveyWhitelist
@@ -229,7 +230,7 @@ func (s *service) Run(ctx context.Context) error {
 		PK:                  pk,
 		SK:                  sk,
 		DmsgPort:            dmsgPort,
-		DmsgDiscovery:       dmsgDisc,
+		DmsgDiscoveryDmsg:   dmsgDiscDmsg,
 		DmsgServerType:      cfg.Dmsg.ServerType,
 		EmbeddedDmsgServers: embeddedServers,
 		SurveyWhitelist:     surveyWL,

--- a/pkg/svcmode/svcmode.go
+++ b/pkg/svcmode/svcmode.go
@@ -154,11 +154,21 @@ type Config struct {
 	// dmsg.DefaultDmsgHTTPPort (80) if zero.
 	DmsgPort uint16
 
-	// DmsgDiscovery is the URL of the dmsg-discovery service, used
-	// as a fallback for the embedded-server bootstrap and for
-	// periodic server-list refresh. Required when Mode includes
-	// dmsg unless EmbeddedDmsgServers is non-empty.
+	// DmsgDiscovery is the plain-HTTP URL of the dmsg-discovery
+	// service, used as a fallback for the embedded-server bootstrap
+	// and for periodic server-list refresh. Required when Mode
+	// includes dmsg unless EmbeddedDmsgServers or DmsgDiscoveryDmsg
+	// is non-empty. Ignored when DmsgDiscoveryDmsg is set —
+	// deployment services that want strict dmsg-only operation
+	// should leave this empty.
 	DmsgDiscovery string
+
+	// DmsgDiscoveryDmsg is the dmsg-PK URL of the dmsg-discovery
+	// service (form `dmsg://<PK>:<port>`). When set, svcmode routes
+	// all discovery RPC over dmsg-HTTP via the bootstrap dmsg client
+	// — no plain-HTTP egress to dmsg-discovery occurs. Mutually
+	// preferred over DmsgDiscovery; the HTTP field is ignored.
+	DmsgDiscoveryDmsg string
 
 	// DmsgServerType, if non-empty, restricts the dmsg client to
 	// servers whose ServerType matches (e.g. "official").
@@ -268,8 +278,8 @@ func Start(ctx context.Context, cfg Config) (*Handle, error) {
 	// either the embedded server list OR an HTTP discovery URL to
 	// bootstrap against.
 	wantDmsgBootstrap := !cfg.SK.Null()
-	if wantDmsgBootstrap && len(cfg.EmbeddedDmsgServers) == 0 && cfg.DmsgDiscovery == "" {
-		return nil, errors.New("svcmode: dmsg bootstrap requires either EmbeddedDmsgServers or DmsgDiscovery")
+	if wantDmsgBootstrap && len(cfg.EmbeddedDmsgServers) == 0 && cfg.DmsgDiscovery == "" && cfg.DmsgDiscoveryDmsg == "" {
+		return nil, errors.New("svcmode: dmsg bootstrap requires EmbeddedDmsgServers, DmsgDiscoveryDmsg, or DmsgDiscovery")
 	}
 	if cfg.DmsgPort == 0 {
 		cfg.DmsgPort = dmsg.DefaultDmsgHTTPPort
@@ -302,7 +312,7 @@ func Start(ctx context.Context, cfg Config) (*Handle, error) {
 	// a dmsghttp listener — see note at top of Start.
 	if wantDmsgBootstrap {
 		boot, err := cmdutil.BootstrapDmsg(ctx, cfg.Log, cfg.PK, cfg.SK,
-			cfg.EmbeddedDmsgServers, cfg.DmsgDiscovery, cfg.DmsgServerType)
+			cfg.EmbeddedDmsgServers, cfg.DmsgDiscovery, cfg.DmsgDiscoveryDmsg, cfg.DmsgServerType)
 		if err != nil {
 			return nil, fmt.Errorf("svcmode: dmsg bootstrap: %w", err)
 		}


### PR DESCRIPTION
## Summary

Stops route-finder, address-resolver, transport-discovery, service-discovery, uptime-tracker, and config-bootstrapper from making plain-HTTP calls to dmsg-discovery. They now route all discovery RPC over dmsg-HTTP via their bootstrap dmsg client. This is the deploy-services-wide version of the dmsg-only transition that #3161 / #3171 landed for setup-node and transport-setup.

After this lands, deployment configs may drop their `discovery` HTTP URLs entirely. The HTTP URL fields remain in the embedded deployment config as reference data only — the deployment binaries never call them.

## Change

### `pkg/svcmode/svcmode.go`
- New `DmsgDiscoveryDmsg string` field on `Config`. Form `dmsg://<PK>:<port>`.
- Validation now accepts `EmbeddedDmsgServers || DmsgDiscoveryDmsg || DmsgDiscovery`.
- When `DmsgDiscoveryDmsg` is set, the legacy HTTP `DmsgDiscovery` is ignored.

### `pkg/cmdutil/dmsg_bootstrap.go`
- New `dmsgDiscoveryDmsg string` parameter on `BootstrapDmsg`.
- When set: the disc-fallback `http.Client`'s `Transport` is wired to `dmsghttp.MakeHTTPTransport(ctx, dmsgC)` between `dmsg.NewClient` and `Serve` — the same single-client wiring pattern setup-node and transport-setup use post-#3161. The dmsg client is built inline (rather than via `direct.StartDmsg`) so the transport can be late-bound before `Serve` starts; bootstrap-phase `AvailableServers` / `PostEntry` short-circuit through the direct client, so the disc-fallback transport is only invoked once dmsg sessions exist.
- The background server refresh (`updateServersDmsgFirst` / `fetchServers`) uses dmsg-HTTP exclusively in this mode — no plain-HTTP fallback. A failed refresh is preferable to a silent fallback once the operator has opted out of HTTP.
- `SeedEntryCache` is now called per embedded server during bootstrap (parity with the setup-node / transport-setup pattern).

### Service plumb-through
- `pkg/services/{rf,ar,tpd,sd}.go` — read `cfg.Dmsg.DiscoveryDmsg`; default to `dmsg.DiscAddr(false)` (the embedded dmsg-PK URL) when omitted. The HTTP fallback (`if dmsgDisc == "" { dmsgDisc = dmsg.DiscURL(false) }` and the TPD variant against `deployment.Prod.DmsgDiscovery`) is removed.
- `cfg.Dmsg.Discovery` (HTTP URL) is now an ignored field on these service configs — preserved on the struct for backward-compat JSON parsing.

### Flag-driven services
- `cmd/svc/uptime-tracker/commands/root.go` and `cmd/svc/config-bootstrapper/commands/root.go` gain a `--dmsg-disc-dmsg` flag (default `dmsg.DiscAddr(false)`). The existing `--dmsg-disc` flag no longer defaults to an HTTP URL — operators who still need plain-HTTP must set it explicitly. Both flags are forwarded to `svcmode`; when `--dmsg-disc-dmsg` is non-empty (the new default), the binary runs dmsg-only.

### Compat for non-svcmode callers
- `cmd/skywire-cli/commands/config/gen.go` and `cmd/skywire-cli/commands/log/{log,dmsghttp_client}.go` pass `""` for the new `dmsgDiscoveryDmsg` parameter — preserves their existing HTTP behavior.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./cmd/skywire/ ./cmd/svc/uptime-tracker/ ./cmd/svc/config-bootstrapper/` clean
- [x] `go test ./pkg/cmdutil/... ./pkg/svcmode/...` pass (RF/AR/TPD/SD have no test files)
- [ ] Manual: deploy a stack where every deploy-service config omits `discovery` (HTTP URL field) and only sets `discovery_dmsg` — confirm RF/AR/TPD/SD/UT/CONFBS register in dmsg-discovery, refresh server lists, and serve clients without any plain-HTTP egress to `dmsgd.skywire.skycoin.com`
- [ ] Manual: confirm setup-node and transport-setup are unaffected (they already used `discovery_dmsg`-only since #3161/#3171)

## Follow-up (config-only, separate)

After binaries with this change ship to prod:
- Drop `discovery` field from `services-config/*.json`, `tps-*/tps.json`, `dmsg-server/config.json` on the deployment hosts.
- Drop `--dmsg-disc http://...` from the uptime-tracker compose entrypoint (or replace with `--dmsg-disc-dmsg dmsg://...` if a custom URL is needed; default suffices for prod).