### PR TITLE
fix(transport-setup): honor conf.Dmsg.SessionsCount (TPS was using MinSessions=1 default)

### DIFF
--- a/pkg/transport-setup/api/api.go
+++ b/pkg/transport-setup/api/api.go
@@ -55,7 +55,19 @@ func New(log *logging.Logger, conf config.Config) *API {
 }
 
 func setupDmsgC(conf config.Config, log *logging.Logger) *dmsg.Client {
-	dmsgConf := dmsg.DefaultConfig()
+	// Honor conf.Dmsg.SessionsCount the same way RSN does
+	// (pkg/router/setupnode.go:83). dmsg.DefaultConfig hardcodes
+	// MinSessions=1, so without this override TPS would dial a single
+	// random seed server and the Serve loop would park on <-errCh as
+	// soon as that one session establishes. For the registering
+	// variant (TPS publishes its own dmsg-disc entry), that one
+	// session has to also be one that can forward to the discovery PK
+	// — when the random pick can't reach the discovery, PutEntry
+	// returns dmsg error 202 forever and the entry stays unpublished
+	// until the session dies. SessionsCount=6 in the prod TPS configs
+	// covers every seed server so at least one path to the discovery
+	// always exists.
+	dmsgConf := &dmsg.Config{MinSessions: conf.Dmsg.SessionsCount}
 
 	// Single dmsg client with self-hosted dmsg-discovery — matches the
 	// visor's post-#3136 bootstrap (pkg/visor/init_dmsg.go + pkg/dmsgc/


### PR DESCRIPTION
## Summary

`setupDmsgC` in `pkg/transport-setup/api/api.go` was calling `dmsg.DefaultConfig()`, which hardcodes `MinSessions: 1`. The Serve loop's

\`\`\`go
if MinSessions != 0 && SessionCount() >= MinSessions { wait <-errCh }
\`\`\`

gate fires the moment the FIRST seeded server's session establishes, leaving the other 5 (including the only server definitely connected to the discovery PK in single-host deployments) un-dialed.

TPS is one of the two services (TPSN + RSN) that **does** register its own dmsg-discovery entry. With only one random seed session — and `cli` discovery (registering variant) needing to dial the discovery PK via that session — `PutEntry`'s `DialStream` to the discovery PK returns dmsg error 202 (\"cannot connect to delegated server\") forever and the entry never publishes. The retry/ctx-watcher work in #3168 + #3172 bounds the attempt and unblocks the Serve loop, but the loop has already parked on `<-errCh` so the next attempt only comes when that single session dies.

## Change

Mirror RSN's pattern in `pkg/router/setupnode.go:83`:

\`\`\`go
dmsgConf := &dmsg.Config{MinSessions: conf.Dmsg.SessionsCount}
\`\`\`

So `sessions_count: 6` in the prod TPS configs actually takes effect and TPS dials all 6 seeded servers — at least one of which has a session to the discovery PK, so `PutEntry` succeeds.

## Production verification

Symptom on prod02 post-#3171/#3172 deploy:
- TPS-4/5/6 logged \`Updating entry.\` once at startup, then went silent on the publish path even though both the deadlock fix (#3172) and the ctx-watcher fired correctly (visible as `error=\"context deadline exceeded\"` instead of the pre-#3172 `\"i/o deadline reached\"` and as the `WARN: Initial client entry update did not complete within bound` log).
- All `Dialing session...` log lines stopped after the first session establish + Phase 3 cascade (3 sessions total), with the local dmsg-server-7 — the one DMSGD definitely has a session to — never tried.
- `conf.Dmsg.SessionsCount = 6` was set in `tps.json` but silently ignored.

## Test plan

- [x] \`go build ./pkg/transport-setup/... ./cmd/svc/transport-setup/\` clean
- [x] \`go vet ./pkg/transport-setup/...\` clean
- [ ] Post-deploy: TPS-4/5/6 dial all 6 seeded servers, publish entry in DMSGD successfully (visible as a POST in dmsg-discovery's access log from each TPS PK), and `GET /dmsg-discovery/entry/<tps-pk>` returns the entry rather than 404.