### PR TITLE
fix(e2e): dmsg-only configs + slim to 1 redis / 1 deployment-services / N visors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,10 +492,13 @@ e2e-run: ## E2E. Start e2e environment and wait for all health checks to pass
 	@# After #2471 the nine deployment-side services (tpd, rf,
 	@# dmsg-disc, dmsg-server, sn, sd, ar, tps, stun) collapse into
 	@# one `deployment-services` container; the previous per-service
-	@# staging is replaced by one wait on the supervisor.
-	bash -c "DOCKER_TAG=e2e docker compose up -d --wait dmsgd-redis ar-redis sd-redis tpd-redis ut-redis postgres-db"
+	@# staging is replaced by one wait on the supervisor. The five
+	@# per-service redis containers are now a single `redis` (each
+	@# service uses its own logical DB), and the deprecated
+	@# uptime-tracker + its postgres are gone (uptime is integrated
+	@# into the discovery services).
+	bash -c "DOCKER_TAG=e2e docker compose up -d --wait redis"
 	bash -c "DOCKER_TAG=e2e docker compose up -d --wait deployment-services"
-	bash -c "DOCKER_TAG=e2e docker compose up -d uptime-tracker"
 	bash -c "DOCKER_TAG=e2e docker compose up -d --wait visor-b"
 	bash -c "DOCKER_TAG=e2e docker compose up -d --wait visor-a visor-c"
 	bash -c "DOCKER_TAG=e2e docker compose ps"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,104 +26,26 @@ networks:
       com.docker.network.bridge.name: br-intra
 
 services:
-  dmsgd-redis:
+  # Single shared redis for every discovery service. Each service uses
+  # its own logical DB (redis://redis:6379/<N>) to preserve the keyspace
+  # isolation the previous per-service redis containers gave:
+  #   /0 dmsg-discovery   /1 transport-discovery + route-finder (shared,
+  #   route-finder reads TPD's transport data)   /2 service-discovery
+  #   /3 address-resolver
+  redis:
     image: "redis:alpine"
     networks:
       srv:
         ipv4_address: 175.0.0.250
       intra:
         ipv4_address: 174.0.0.250
-    container_name: "dmsgd-redis"
-    hostname: dmsgd-redis
+    container_name: "redis"
+    hostname: redis
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 3s
       retries: 5
-
-  ar-redis:
-    image: "redis:alpine"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.251
-      intra:
-        ipv4_address: 174.0.0.251
-    container_name: "ar-redis"
-    hostname: ar-redis
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
-  sd-redis:
-    image: "redis:alpine"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.252
-      intra:
-        ipv4_address: 174.0.0.252
-    container_name: "sd-redis"
-    hostname: sd-redis
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
-  tpd-redis:
-    image: "redis:alpine"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.253
-      intra:
-        ipv4_address: 174.0.0.253
-    container_name: "tpd-redis"
-    hostname: tpd-redis
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
-  ut-redis:
-    image: "redis:alpine"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.255
-      intra:
-        ipv4_address: 174.0.0.255
-    container_name: "ut-redis"
-    hostname: ut-redis
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-
-  postgres-db:
-    image: "postgres:alpine"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.248
-      intra:
-        ipv4_address: 174.0.0.248
-    environment:
-      - GODEBUG=madvdontneed=1
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=postgres
-    # ports:
-    #   - '5432:5432'
-    shm_size: 256mb
-    container_name: "postgres-db"
-    hostname: postgres-db
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
-      timeout: 5s
-      retries: 15
-      start_period: 15s
 
   # deployment-services collapses the nine deployment-side containers
   # (transport-discovery, route-finder, dmsg-discovery, dmsg-server,
@@ -172,13 +94,7 @@ services:
         aliases:
           - stun-server
     depends_on:
-      tpd-redis:
-        condition: service_healthy
-      sd-redis:
-        condition: service_healthy
-      ar-redis:
-        condition: service_healthy
-      dmsgd-redis:
+      redis:
         condition: service_healthy
     restart: always
     environment:
@@ -217,30 +133,10 @@ services:
     stdin_open: true # docker run -i
     tty: true        # docker run -t
 
-  uptime-tracker:
-    privileged: true
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: uptime-tracker
-    container_name: "uptime-tracker"
-    restart: always
-    networks:
-      srv:
-        ipv4_address: 175.0.0.7
-      intra:
-        ipv4_address: 174.0.0.7
-    depends_on:
-      ut-redis:
-        condition: service_healthy
-      postgres-db:
-        condition: service_healthy
-    environment:
-      - GODEBUG=madvdontneed=1
-      - PG_USER=postgres
-      - PG_PASSWORD=postgres
-      - PG_DATABASE=postgres
-    entrypoint: "/release/skywire svc ut --addr :9095 --pprof :6095 --pg-host postgres-db --pg-port 5432 --redis redis://ut-redis:6379 --sk e20681b4fd1eb1904ebfbf8fba79a138bbac481e1c3f77bcfab3a877525fda32 --dmsg-disc http://dmsg-discovery:9090"
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
+  # NOTE: the standalone uptime-tracker service (+ its postgres + redis) was
+  # removed — uptime tracking is now integrated into every discovery service
+  # (TPD et al.), so the deprecated `skywire svc ut` deployment is no longer
+  # part of the e2e topology.
 
   # skywire visors, which by being on a different network are to be isolated from the first one
 
@@ -265,7 +161,6 @@ services:
       - "route-finder:174.0.0.17"
       - "address-resolver:174.0.0.17"
       - "service-discovery:174.0.0.17"
-      - "uptime-tracker:174.0.0.7"
       - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
       - "transport-setup:174.0.0.17"
@@ -311,7 +206,6 @@ services:
       - "route-finder:174.0.0.17"
       - "address-resolver:174.0.0.17"
       - "service-discovery:174.0.0.17"
-      - "uptime-tracker:174.0.0.7"
       - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
       - "transport-setup:174.0.0.17"
@@ -366,7 +260,6 @@ services:
       - "route-finder:174.0.0.17"
       - "address-resolver:174.0.0.17"
       - "service-discovery:174.0.0.17"
-      - "uptime-tracker:174.0.0.7"
       - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
       - "transport-setup:174.0.0.17"
@@ -391,23 +284,12 @@ services:
       retries: 30
       start_period: 10s
 
-  network-monitor:
-    image: "${REGISTRY}/skywire:${DOCKER_TAG}"
-    hostname: network-monitor
-    container_name: "network-monitor"
-    networks:
-      srv:
-        ipv4_address: 175.0.0.30
-      intra:
-        ipv4_address: 174.0.0.30
-    environment:
-      - GODEBUG=madvdontneed=1
-    entrypoint: "/release/skywire svc nm --addr :9080 --pprof :6080 --ut-url http://uptime-tracker:9095 --tpd-url http://transport-discovery:9094 --sd-url http://service-discovery:9091 --dmsgd-url http://dmsg-discovery:9090 --ar-url http://address-resolver:9093"
-    depends_on:
-      - visor-c
-    restart: always
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
+  # network-monitor was removed from the e2e topology: it was already
+  # disabled (never started by `make e2e-run`, excluded from env_test's
+  # expected containers) and its `svc nm` entrypoint monitored services
+  # over plain HTTP — including the now-removed uptime-tracker. The
+  # pkg/network-monitor code is unaffected; re-add a dmsg-only container
+  # here if e2e network monitoring is wanted again.
 
   e2e-test:
     image: golang:1.26-alpine
@@ -430,7 +312,6 @@ services:
       - "route-finder:174.0.0.17"
       - "address-resolver:174.0.0.17"
       - "service-discovery:174.0.0.17"
-      - "uptime-tracker:174.0.0.7"
       - "setup-node:174.0.0.17"
       - "stun-server:174.0.0.17"
       - "transport-setup:174.0.0.17"

--- a/docker/integration/dmsg-server.json
+++ b/docker/integration/dmsg-server.json
@@ -1,11 +1,11 @@
 {
   "public_key": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
   "secret_key": "6eddf9399b14f29a60e6a652b321d082f9ed2f0172e02c9d9c1a2a22acf4bee3",
-  "discovery": "http://dmsg-discovery:9090",
   "public_address": "174.0.0.17:8080",
   "local_address": ":8080",
   "health_endpoint_address": ":8082",
   "max_sessions": 100,
   "log_level": "debug",
-  "enable_route_setup": true
+  "enable_route_setup": true,
+  "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
 }

--- a/docker/integration/services-config.json
+++ b/docker/integration/services-config.json
@@ -1,17 +1,11 @@
 {
   "test": {
-    "dmsg_discovery": "http://dmsg-discovery:9090",
-    "transport_discovery": "http://transport-discovery:9094",
-    "address_resolver": "http://address-resolver:9093",
-    "route_finder": "http://route-finder:9092",
     "route_setup_nodes": [
       "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
     ],
     "transport_setup": [
       "0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae"
     ],
-    "uptime_tracker": "http://uptime-tracker:9095",
-    "service_discovery": "http://service-discovery:9091",
     "stun_servers": [
       "174.0.0.17:3478"
     ],
@@ -33,18 +27,12 @@
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80"
   },
   "prod": {
-    "dmsg_discovery": "http://dmsg-discovery:9090",
-    "transport_discovery": "http://transport-discovery:9094",
-    "address_resolver": "http://address-resolver:9093",
-    "route_finder": "http://route-finder:9092",
     "route_setup_nodes": [
       "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
     ],
     "transport_setup": [
       "0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae"
     ],
-    "uptime_tracker": "http://uptime-tracker:9095",
-    "service_discovery": "http://service-discovery:9091",
     "stun_servers": [
       "174.0.0.17:3478"
     ],

--- a/docker/integration/services-config.json
+++ b/docker/integration/services-config.json
@@ -23,7 +23,6 @@
     "transport_discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
     "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80",
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80",
-    "uptime_tracker_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80",
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80"
   },
   "prod": {
@@ -50,7 +49,6 @@
     "transport_discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
     "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80",
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80",
-    "uptime_tracker_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80",
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80"
   }
 }

--- a/docker/integration/services.json
+++ b/docker/integration/services.json
@@ -11,7 +11,6 @@
       "uptime_db": "",
       "store_data_path": "/var/lib/skywire/tpd/bandwidth",
       "dmsg": {
-        "discovery": "http://dmsg-discovery:9090",
         "servers": [
           {
             "version": "",
@@ -23,7 +22,8 @@
               "availableSessions": 0
             }
           }
-        ]
+        ],
+        "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
       }
     },
     {
@@ -34,7 +34,6 @@
       "redis": "redis://tpd-redis:6379",
       "secret_key": "640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca",
       "dmsg": {
-        "discovery": "http://dmsg-discovery:9090",
         "servers": [
           {
             "version": "",
@@ -46,7 +45,8 @@
               "availableSessions": 0
             }
           }
-        ]
+        ],
+        "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
       }
     },
     {
@@ -78,7 +78,6 @@
       "entry_timeout": "2m",
       "secret_key": "ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f",
       "dmsg": {
-        "discovery": "http://dmsg-discovery:9090",
         "servers": [
           {
             "version": "",
@@ -90,7 +89,8 @@
               "availableSessions": 0
             }
           }
-        ]
+        ],
+        "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
       }
     },
     {
@@ -103,7 +103,6 @@
       "entry_timeout": "2m",
       "secret_key": "1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a",
       "dmsg": {
-        "discovery": "http://dmsg-discovery:9090",
         "servers": [
           {
             "version": "",
@@ -115,7 +114,8 @@
               "availableSessions": 0
             }
           }
-        ]
+        ],
+        "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
       }
     },
     {

--- a/docker/integration/services.json
+++ b/docker/integration/services.json
@@ -5,7 +5,7 @@
       "name": "tpd",
       "addr": ":9094",
       "pprof_addr": ":6094",
-      "redis": "redis://tpd-redis:6379",
+      "redis": "redis://redis:6379/1",
       "entry_timeout": "2m",
       "secret_key": "85789cd7efcdf35340c8f4cb3e15bccdff57efda49af5bcdddaae57374d25ab8",
       "uptime_db": "",
@@ -31,7 +31,7 @@
       "name": "rf",
       "addr": ":9092",
       "pprof_addr": ":6092",
-      "redis": "redis://tpd-redis:6379",
+      "redis": "redis://redis:6379/1",
       "secret_key": "640905f9fd60d6bf1ee88519f61035765d65319d9f3bac6c5f2fc14ea5cf15ca",
       "dmsg": {
         "servers": [
@@ -53,7 +53,7 @@
       "type": "dmsg-discovery",
       "name": "dmsgd",
       "addr": ":9090",
-      "redis": "redis://dmsgd-redis:6379",
+      "redis": "redis://redis:6379/0",
       "secret_key": "b3f6706cb72215d3873ef92cc0c6037a47fe651112b1685017d6347eed0fb714",
       "test_mode": true
     },
@@ -74,7 +74,7 @@
       "name": "sd",
       "addr": ":9091",
       "pprof_addr": ":6091",
-      "redis": "redis://sd-redis:6379",
+      "redis": "redis://redis:6379/2",
       "entry_timeout": "2m",
       "secret_key": "ccc3ae9993ed03bed80b1f9feb747d7c6ca3342a65c3923191b7527c2c00ef0f",
       "dmsg": {
@@ -99,7 +99,7 @@
       "addr": ":9093",
       "udp_addr": ":9093",
       "pprof_addr": ":6093",
-      "redis": "redis://ar-redis:6379",
+      "redis": "redis://redis:6379/3",
       "entry_timeout": "2m",
       "secret_key": "1fa0a7b80438b8d31655b5c69efd57bcf931ac828438ff2925ab36e4abcc426a",
       "dmsg": {

--- a/docker/integration/setup-node.json
+++ b/docker/integration/setup-node.json
@@ -1,10 +1,22 @@
 {
-    "public_key": "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1",
-    "secret_key": "8535d62ea3d19c8ce09e77ffe0f173c733e1798b23c84d9b72d2a70888c90a3b",
-    "dmsg": {
-        "discovery": "http://dmsg-discovery:9090",
-        "sessions_count": 1
-    },
-    "transport_discovery": "http://transport-discovery:9094",
-    "log_level": "debug"
+  "public_key": "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1",
+  "secret_key": "8535d62ea3d19c8ce09e77ffe0f173c733e1798b23c84d9b72d2a70888c90a3b",
+  "dmsg": {
+    "sessions_count": 1,
+    "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80",
+    "servers": [
+      {
+        "version": "",
+        "sequence": 0,
+        "timestamp": 0,
+        "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
+        "server": {
+          "address": "174.0.0.17:8080",
+          "availableSessions": 0
+        }
+      }
+    ]
+  },
+  "log_level": "debug",
+  "transport_discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80"
 }

--- a/docker/integration/transport-setup.json
+++ b/docker/integration/transport-setup.json
@@ -1,9 +1,21 @@
 {
-    "secret_key": "40de503bd8dff2921ae2b070cc3104e5e700c84b481064f877ab0877f9320ace",
-    "public_key": "0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae",
-    "port": 80,
-    "dmsg": {
-        "discovery": "http://dmsg-discovery:9090",
-        "sessions_count": 0
-    }
+  "secret_key": "40de503bd8dff2921ae2b070cc3104e5e700c84b481064f877ab0877f9320ace",
+  "public_key": "0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae",
+  "port": 80,
+  "dmsg": {
+    "sessions_count": 1,
+    "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80",
+    "servers": [
+      {
+        "version": "",
+        "sequence": 0,
+        "timestamp": 0,
+        "static": "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
+        "server": {
+          "address": "174.0.0.17:8080",
+          "availableSessions": 0
+        }
+      }
+    ]
+  }
 }

--- a/docker/integration/visorA-internal.json
+++ b/docker/integration/visorA-internal.json
@@ -43,9 +43,6 @@
     "min_hops": 1,
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
-  "uptime_tracker": {
-    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
-  },
   "launcher": {
     "apps": [
       {

--- a/docker/integration/visorA-internal.json
+++ b/docker/integration/visorA-internal.json
@@ -1,92 +1,92 @@
 {
-	"version": "unknown",
-	"sk": "42bca4df2f3189b28872d40e6c61aacd5e85b8e91f8fea65780af27c142419e5",
-	"pk": "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
-	"dmsg": {
-		"discovery": "http://dmsg-discovery:9090",
-		"sessions_count": 1,
-		"servers": [],
-		"servers_type": "all",
-		"protocol": "smux"
-	},
-	"dmsgpty": {
-		"dmsg_port": 22,
-		"cli_network": "unix",
-		"cli_address": "/tmp/dmsgpty.sock",
-		"whitelist": null
-	},
-	"skywire-tcp": {
-		"pk_table": null,
-		"listening_address": ":7777"
-	},
-	"transport": {
-		"discovery": "http://transport-discovery:9094",
-		"address_resolver": "http://address-resolver:9093",
-		"public_autoconnect": false,
-		"transport_setup_nodes": [
-			"0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae"
-		],
-		"log_store": {
-			"type": "file",
-			"location": "./local/transport_logs",
-			"rotation_interval": "168h0m0s"
-		},
-		"stcpr_port": 40550,
-		"sudph_port": 40560
-	},
-	"routing": {
-		"route_setup_nodes": [
+  "version": "unknown",
+  "sk": "42bca4df2f3189b28872d40e6c61aacd5e85b8e91f8fea65780af27c142419e5",
+  "pk": "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
+  "dmsg": {
+    "sessions_count": 1,
+    "servers": [],
+    "servers_type": "all",
+    "protocol": "smux",
+    "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
+  },
+  "dmsgpty": {
+    "dmsg_port": 22,
+    "cli_network": "unix",
+    "cli_address": "/tmp/dmsgpty.sock",
+    "whitelist": null
+  },
+  "skywire-tcp": {
+    "pk_table": null,
+    "listening_address": ":7777"
+  },
+  "transport": {
+    "public_autoconnect": false,
+    "transport_setup_nodes": [
+      "0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae"
+    ],
+    "log_store": {
+      "type": "file",
+      "location": "./local/transport_logs",
+      "rotation_interval": "168h0m0s"
+    },
+    "stcpr_port": 40550,
+    "sudph_port": 40560,
+    "discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
+    "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80"
+  },
+  "routing": {
+    "route_setup_nodes": [
       "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
-			"02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
-		],
-		"route_finder": "http://route-finder:9092",
-		"route_finder_timeout": "10s",
-		"min_hops": 1
-	},
-	"uptime_tracker": {
-		"addr": "http://uptime-tracker:9095"
-	},
-	"launcher": {
-		"service_discovery": "http://service-discovery:9091",
-		"apps": [
-			{
-				"name": "vpn-client",
-				"auto_start": false,
-				"port": 43
-			},
-			{
-				"name": "skychat",
-				"args": [
-					"--addr",
-					"*:8001"
-				],
-				"auto_start": true,
-				"port": 1
-			},
-			{
-				"name": "skysocks",
-				"auto_start": true,
-				"port": 3
-			},
-			{
-				"name": "vpn-server",
-				"auto_start": true,
-				"port": 44
-			}
-		],
-		"server_addr": ":5505",
-		"bin_path": "/release",
-		"display_node_ip": false
-	},
-	"hypervisors": [
-		"0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe"
-	],
-	"cli_addr": "0.0.0.0:3435",
-	"log_level": "debug",
-	"local_path": "./local",
-	"dmsghttp_server_path": "./local/custom",
-	"stun_servers": null,
-	"shutdown_timeout": "30s",
-	"is_public": false,
-	"persistent_transports": null
+      "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
+    ],
+    "route_finder_timeout": "10s",
+    "min_hops": 1,
+    "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
+  },
+  "uptime_tracker": {
+    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
+  },
+  "launcher": {
+    "apps": [
+      {
+        "name": "vpn-client",
+        "auto_start": false,
+        "port": 43
+      },
+      {
+        "name": "skychat",
+        "args": [
+          "--addr",
+          "*:8001"
+        ],
+        "auto_start": true,
+        "port": 1
+      },
+      {
+        "name": "skysocks",
+        "auto_start": true,
+        "port": 3
+      },
+      {
+        "name": "vpn-server",
+        "auto_start": true,
+        "port": 44
+      }
+    ],
+    "server_addr": ":5505",
+    "bin_path": "/release",
+    "display_node_ip": false,
+    "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80"
+  },
+  "hypervisors": [
+    "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe"
+  ],
+  "cli_addr": "0.0.0.0:3435",
+  "log_level": "debug",
+  "local_path": "./local",
+  "dmsghttp_server_path": "./local/custom",
+  "stun_servers": null,
+  "shutdown_timeout": "30s",
+  "is_public": false,
+  "persistent_transports": null
 }

--- a/docker/integration/visorA.json
+++ b/docker/integration/visorA.json
@@ -64,9 +64,6 @@
     "min_hops": 1,
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
-  "uptime_tracker": {
-    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
-  },
   "launcher": {
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80",
     "apps": [

--- a/docker/integration/visorA.json
+++ b/docker/integration/visorA.json
@@ -3,7 +3,6 @@
   "sk": "42bca4df2f3189b28872d40e6c61aacd5e85b8e91f8fea65780af27c142419e5",
   "pk": "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
   "dmsg": {
-    "discovery": "http://dmsg-discovery:9090",
     "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80",
     "sessions_count": 2,
     "servers": [
@@ -42,9 +41,7 @@
     "listening_address": ":7777"
   },
   "transport": {
-    "discovery": "http://transport-discovery:9094",
     "discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
-    "address_resolver": "http://address-resolver:9093",
     "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80",
     "public_autoconnect": true,
     "transport_setup": [
@@ -63,15 +60,14 @@
       "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
       "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
     ],
-    "route_finder": "http://route-finder:9092",
     "route_finder_timeout": "10s",
-    "min_hops": 1
+    "min_hops": 1,
+    "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
   "uptime_tracker": {
-    "addr": "http://uptime-tracker:9095"
+    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
   },
   "launcher": {
-    "service_discovery": "http://service-discovery:9091",
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80",
     "apps": [
       {
@@ -128,7 +124,7 @@
   ],
   "shutdown_timeout": "10s",
   "is_public": false,
-  "geoip": "http://ip.skycoin.com",
+  "geoip": "",
   "persistent_transports": null,
   "memory_limit": "auto"
 }

--- a/docker/integration/visorB-internal.json
+++ b/docker/integration/visorB-internal.json
@@ -33,9 +33,6 @@
     "min_hops": 1,
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
-  "uptime_tracker": {
-    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
-  },
   "launcher": {
     "apps": [
       {

--- a/docker/integration/visorB-internal.json
+++ b/docker/integration/visorB-internal.json
@@ -1,81 +1,81 @@
 {
-	"version": "unknown",
-	"sk": "da4f48916e99aa3de794bffe1b5ecd465335e38b55457a9f78b411eb8585e36f",
-	"pk": "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe",
-	"dmsg": {
-		"discovery": "http://dmsg-discovery:9090",
-		"sessions_count": 1,
-		"servers": [],
-		"servers_type": "all",
-		"protocol": "smux"
-	},
-	"dmsgpty": {
-		"dmsg_port": 22,
-		"cli_network": "unix",
-		"cli_address": "/tmp/dmsgpty.sock"
-	},
-	"transport": {
-		"discovery": "http://transport-discovery:9094",
-		"address_resolver": "http://address-resolver:9093",
-		"public_autoconnect": false,
-		"transport_setup_nodes": [
-			"0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae"
-		],
-		"stcpr_port": 40551,
-		"sudph_port": 40561
-	},
-	"routing": {
-		"route_setup_nodes": [
+  "version": "unknown",
+  "sk": "da4f48916e99aa3de794bffe1b5ecd465335e38b55457a9f78b411eb8585e36f",
+  "pk": "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe",
+  "dmsg": {
+    "sessions_count": 1,
+    "servers": [],
+    "servers_type": "all",
+    "protocol": "smux",
+    "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
+  },
+  "dmsgpty": {
+    "dmsg_port": 22,
+    "cli_network": "unix",
+    "cli_address": "/tmp/dmsgpty.sock"
+  },
+  "transport": {
+    "public_autoconnect": false,
+    "transport_setup_nodes": [
+      "0277dda8a284d43b4d5ee2a4152771e76131e9437c47be5d8e835aafe02c45a9ae"
+    ],
+    "stcpr_port": 40551,
+    "sudph_port": 40561,
+    "discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
+    "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80"
+  },
+  "routing": {
+    "route_setup_nodes": [
       "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
-			"02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
-		],
-		"route_finder": "http://route-finder:9092",
-		"route_finder_timeout": "10s",
-		"min_hops": 1
-	},
-	"uptime_tracker": {
-		"addr": "http://uptime-tracker:9095"
-	},
-	"launcher": {
-		"service_discovery": "http://service-discovery:9091",
-		"apps": [
-			{
-				"name": "vpn-client",
-				"auto_start": false,
-				"port": 43
-			},
-			{
-				"name": "vpn-server",
-				"auto_start": false,
-				"port": 44
-			}
-		],
-		"server_addr": ":5506",
-		"bin_path": "/release"
-	},
-	"hypervisors": [],
-	"cli_addr": "0.0.0.0:3435",
-	"log_level": "info",
-	"local_path": "./local",
-	"stun_servers": null,
-	"shutdown_timeout": "30s",
-	"restart_check_delay": "1s",
-	"is_public": false,
-	"persistent_transports": null,
-	"hypervisor": {
-		"db_path": "./local/hypervisor/users.db",
-		"enable_auth": false,
-		"cookies": {
-			"hash_key": "fe629f5531a017ab065fee09065a75ae3b57684daa033915eb8dda4cc0bf555678bbce74f8416603e72b0edf744a8d7a2850e6f065092af0ae50c09d6ae0d258",
-			"block_key": "4a8bbf6ac5ff929a18be4a3ec186f6f17f208dd94c9c58d219b0282d584f0727",
-			"expires_duration": 43200000000000,
-			"path": "/",
-			"domain": ""
-		},
-		"dmsg_port": 46,
-		"http_addr": ":8000",
-		"enable_tls": true,
-		"tls_cert_file": "/opt/integration/hypervisor.crt",
-		"tls_key_file": "/opt/integration/hypervisor.key"
-	}
+      "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
+    ],
+    "route_finder_timeout": "10s",
+    "min_hops": 1,
+    "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
+  },
+  "uptime_tracker": {
+    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
+  },
+  "launcher": {
+    "apps": [
+      {
+        "name": "vpn-client",
+        "auto_start": false,
+        "port": 43
+      },
+      {
+        "name": "vpn-server",
+        "auto_start": false,
+        "port": 44
+      }
+    ],
+    "server_addr": ":5506",
+    "bin_path": "/release",
+    "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80"
+  },
+  "hypervisors": [],
+  "cli_addr": "0.0.0.0:3435",
+  "log_level": "info",
+  "local_path": "./local",
+  "stun_servers": null,
+  "shutdown_timeout": "30s",
+  "restart_check_delay": "1s",
+  "is_public": false,
+  "persistent_transports": null,
+  "hypervisor": {
+    "db_path": "./local/hypervisor/users.db",
+    "enable_auth": false,
+    "cookies": {
+      "hash_key": "fe629f5531a017ab065fee09065a75ae3b57684daa033915eb8dda4cc0bf555678bbce74f8416603e72b0edf744a8d7a2850e6f065092af0ae50c09d6ae0d258",
+      "block_key": "4a8bbf6ac5ff929a18be4a3ec186f6f17f208dd94c9c58d219b0282d584f0727",
+      "expires_duration": 43200000000000,
+      "path": "/",
+      "domain": ""
+    },
+    "dmsg_port": 46,
+    "http_addr": ":8000",
+    "enable_tls": true,
+    "tls_cert_file": "/opt/integration/hypervisor.crt",
+    "tls_key_file": "/opt/integration/hypervisor.key"
+  }
 }

--- a/docker/integration/visorB.json
+++ b/docker/integration/visorB.json
@@ -64,9 +64,6 @@
     "min_hops": 1,
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
-  "uptime_tracker": {
-    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
-  },
   "launcher": {
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80",
     "apps": [

--- a/docker/integration/visorB.json
+++ b/docker/integration/visorB.json
@@ -3,7 +3,6 @@
   "sk": "da4f48916e99aa3de794bffe1b5ecd465335e38b55457a9f78b411eb8585e36f",
   "pk": "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe",
   "dmsg": {
-    "discovery": "http://dmsg-discovery:9090",
     "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80",
     "sessions_count": 2,
     "servers": [
@@ -42,9 +41,7 @@
     "listening_address": ":7777"
   },
   "transport": {
-    "discovery": "http://transport-discovery:9094",
     "discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
-    "address_resolver": "http://address-resolver:9093",
     "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80",
     "public_autoconnect": true,
     "transport_setup": [
@@ -63,15 +60,14 @@
       "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
       "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
     ],
-    "route_finder": "http://route-finder:9092",
     "route_finder_timeout": "10s",
-    "min_hops": 1
+    "min_hops": 1,
+    "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
   "uptime_tracker": {
-    "addr": "http://uptime-tracker:9095"
+    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
   },
   "launcher": {
-    "service_discovery": "http://service-discovery:9091",
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80",
     "apps": [
       {
@@ -126,7 +122,7 @@
   ],
   "shutdown_timeout": "10s",
   "is_public": false,
-  "geoip": "http://ip.skycoin.com",
+  "geoip": "",
   "persistent_transports": null,
   "memory_limit": "auto",
   "hypervisor": {

--- a/docker/integration/visorC-internal.json
+++ b/docker/integration/visorC-internal.json
@@ -41,9 +41,6 @@
     "min_hops": 1,
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
-  "uptime_tracker": {
-    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
-  },
   "launcher": {
     "apps": [
       {

--- a/docker/integration/visorC-internal.json
+++ b/docker/integration/visorC-internal.json
@@ -1,108 +1,108 @@
 {
-	"version": "unknown",
-	"sk": "0e17cd505d81f998950e22864ae4692249124441bd9148b801f76f1595ac688f",
-	"pk": "031b80cd5773143a39d940dc0710b93dcccc262a85108018a7a95ab9af734f8055",
-	"dmsg": {
-		"discovery": "http://dmsg-discovery:9090",
-		"sessions_count": 1,
-		"servers": [],
-		"servers_type": "all",
-		"protocol": "smux"
-	},
-	"dmsgpty": {
-		"dmsg_port": 22,
-		"cli_network": "unix",
-		"cli_address": "/tmp/dmsgpty.sock",
-		"whitelist": null
-	},
-	"skywire-tcp": {
-		"pk_table": null,
-		"listening_address": ":7777"
-	},
-	"transport": {
-		"discovery": "http://transport-discovery:9094",
-		"address_resolver": "http://address-resolver:9093",
-		"public_autoconnect": false,
-		"transport_setup": null,
-		"log_store": {
-			"type": "file",
-			"location": "./local/transport_logs",
-			"rotation_interval": "168h0m0s"
-		},
-		"stcpr_port": 40552,
-		"sudph_port": 40562
-	},
-	"routing": {
-		"route_setup_nodes": [
+  "version": "unknown",
+  "sk": "0e17cd505d81f998950e22864ae4692249124441bd9148b801f76f1595ac688f",
+  "pk": "031b80cd5773143a39d940dc0710b93dcccc262a85108018a7a95ab9af734f8055",
+  "dmsg": {
+    "sessions_count": 1,
+    "servers": [],
+    "servers_type": "all",
+    "protocol": "smux",
+    "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80"
+  },
+  "dmsgpty": {
+    "dmsg_port": 22,
+    "cli_network": "unix",
+    "cli_address": "/tmp/dmsgpty.sock",
+    "whitelist": null
+  },
+  "skywire-tcp": {
+    "pk_table": null,
+    "listening_address": ":7777"
+  },
+  "transport": {
+    "public_autoconnect": false,
+    "transport_setup": null,
+    "log_store": {
+      "type": "file",
+      "location": "./local/transport_logs",
+      "rotation_interval": "168h0m0s"
+    },
+    "stcpr_port": 40552,
+    "sudph_port": 40562,
+    "discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
+    "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80"
+  },
+  "routing": {
+    "route_setup_nodes": [
       "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
-			"02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
-		],
-		"route_finder": "http://route-finder:9092",
-		"route_finder_timeout": "10s",
-		"min_hops": 1
-	},
-	"uptime_tracker": {
-		"addr": "http://uptime-tracker:9095"
-	},
-	"launcher": {
-		"service_discovery": "http://service-discovery:9091",
-		"apps": [
-			{
-				"name": "vpn-client",
-				"args": [
-					"--srv",
-					"024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
-					"-killswitch=false"
-				],
-				"auto_start": false,
-				"port": 43
-			},
-			{
-				"name": "skychat",
-				"args": [
-					"--addr",
-					"*:8001"
-				],
-				"auto_start": true,
-				"port": 1
-			},
-			{
-				"name": "skysocks-client",
-				"args": [
-					"--srv",
-					"024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
-					"--addr",
-					":1080"
-				],
-				"auto_start": true,
-				"port": 13
-			},
-			{
-				"name": "skysocks",
-				"auto_start": true,
-				"port": 3
-			},
-			{
-				"name": "vpn-server",
-				"auto_start": false,
-				"port": 44
-			}
-		],
-		"server_addr": ":5507",
-		"bin_path": "/release",
-		"display_node_ip": false
-	},
-	"survey_whitelist": null,
-	"hypervisors": [
-		"0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe"
-	],
-	"cli_addr": "0.0.0.0:3435",
-	"log_level": "debug",
-	"local_path": "./local",
-	"dmsghttp_server_path": "./local/custom",
-	"stun_servers": null,
-	"shutdown_timeout": "30s",
-	"is_public": false,
-	"geoip": "http://ip.skycoin.com",
-	"persistent_transports": null
+      "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
+    ],
+    "route_finder_timeout": "10s",
+    "min_hops": 1,
+    "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
+  },
+  "uptime_tracker": {
+    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
+  },
+  "launcher": {
+    "apps": [
+      {
+        "name": "vpn-client",
+        "args": [
+          "--srv",
+          "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
+          "-killswitch=false"
+        ],
+        "auto_start": false,
+        "port": 43
+      },
+      {
+        "name": "skychat",
+        "args": [
+          "--addr",
+          "*:8001"
+        ],
+        "auto_start": true,
+        "port": 1
+      },
+      {
+        "name": "skysocks-client",
+        "args": [
+          "--srv",
+          "024ec47420176680816e0406250e7156465e4531f5b26057c9f6297bb0303558c7",
+          "--addr",
+          ":1080"
+        ],
+        "auto_start": true,
+        "port": 13
+      },
+      {
+        "name": "skysocks",
+        "auto_start": true,
+        "port": 3
+      },
+      {
+        "name": "vpn-server",
+        "auto_start": false,
+        "port": 44
+      }
+    ],
+    "server_addr": ":5507",
+    "bin_path": "/release",
+    "display_node_ip": false,
+    "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80"
+  },
+  "survey_whitelist": null,
+  "hypervisors": [
+    "0348c941c5015a05c455ff238af2e57fb8f914c399aab604e9abb5b32b91a4c1fe"
+  ],
+  "cli_addr": "0.0.0.0:3435",
+  "log_level": "debug",
+  "local_path": "./local",
+  "dmsghttp_server_path": "./local/custom",
+  "stun_servers": null,
+  "shutdown_timeout": "30s",
+  "is_public": false,
+  "geoip": "",
+  "persistent_transports": null
 }

--- a/docker/integration/visorC.json
+++ b/docker/integration/visorC.json
@@ -64,9 +64,6 @@
     "min_hops": 1,
     "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
-  "uptime_tracker": {
-    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
-  },
   "launcher": {
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80",
     "apps": [

--- a/docker/integration/visorC.json
+++ b/docker/integration/visorC.json
@@ -3,7 +3,6 @@
   "sk": "0e17cd505d81f998950e22864ae4692249124441bd9148b801f76f1595ac688f",
   "pk": "031b80cd5773143a39d940dc0710b93dcccc262a85108018a7a95ab9af734f8055",
   "dmsg": {
-    "discovery": "http://dmsg-discovery:9090",
     "discovery_dmsg": "dmsg://02857a87410b3709eddb99bc00508cc7cfeb588d5ed87e3ef9d2aac838ad49470a:80",
     "sessions_count": 2,
     "servers": [
@@ -42,9 +41,7 @@
     "listening_address": ":7777"
   },
   "transport": {
-    "discovery": "http://transport-discovery:9094",
     "discovery_dmsg": "dmsg://02a5993cb6792eb18908cb7c6c9c742ef5fbe3dcfcce2862bbc4615a5f35cbed46:80",
-    "address_resolver": "http://address-resolver:9093",
     "address_resolver_dmsg": "dmsg://02252c40a1ac021dcf6d93f1aae38023e8fd20bb0d35b7d07cba9435a7cb7ef34f:80",
     "public_autoconnect": true,
     "transport_setup": [
@@ -63,15 +60,14 @@
       "035915c609f71d0c7df27df85ec698ceca0cb262590a54f732e3bbd0cc68d89282",
       "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1"
     ],
-    "route_finder": "http://route-finder:9092",
     "route_finder_timeout": "10s",
-    "min_hops": 1
+    "min_hops": 1,
+    "route_finder_dmsg": "dmsg://02b88fe426b2f6f83f19b151c427c155aae186d734cbd45f12b57ddbd237b49278:80"
   },
   "uptime_tracker": {
-    "addr": "http://uptime-tracker:9095"
+    "addr_dmsg": "dmsg://031ecf9a2aefa62398b305481f9a00365e4a1247ae0ea46bdb92223a43a306a98e:80"
   },
   "launcher": {
-    "service_discovery": "http://service-discovery:9091",
     "service_discovery_dmsg": "dmsg://026f96adae04285f8b35eeba23b9aa2be3470ea4bb005118f4e64006afdeea85a7:80",
     "apps": [
       {
@@ -128,7 +124,7 @@
   ],
   "shutdown_timeout": "10s",
   "is_public": false,
-  "geoip": "http://ip.skycoin.com",
+  "geoip": "",
   "persistent_transports": null,
   "memory_limit": "auto"
 }

--- a/internal/integration/env_test.go
+++ b/internal/integration/env_test.go
@@ -65,12 +65,11 @@ func NewEnv() *TestEnv {
 		serviceNames: []string{
 			// Nine deployment-side services (tpd, rf, dmsg-disc,
 			// dmsg-server, sn, sd, ar, tps, stun) collapsed into
-			// /deployment-services in compose; uptime-tracker
-			// stays separate pending its replacement by TPD's
-			// uptime tracking. network-monitor is intentionally
-			// disabled in the production deployment.
+			// /deployment-services in compose. The standalone
+			// uptime-tracker was removed — uptime tracking is now
+			// integrated into the discovery services. network-monitor
+			// is intentionally disabled in the production deployment.
 			"/deployment-services",
-			"/uptime-tracker",
 		},
 		visorNames: []string{
 			"/" + visorA,


### PR DESCRIPTION
Modernizes the e2e to match the live network: **dmsg-only** + a **minimal container set**. Fixes the long-standing `deployment-services unhealthy` linux-e2e failure (config-vs-code drift after the dmsg-only convergence) and slims the topology.

## 1. All e2e configs dmsg-only (zero `http://` service URLs)
With only `discovery: http://…` set, setup-node/transport-setup (which build their dmsg client from `conf.Dmsg.DiscoveryDmsg`) couldn't bootstrap → deadlocked the shared `skywire svc run` supervisor → unhealthy.
- **Visor configs**: every service URL → its `*_dmsg` form (`dmsg://<pk>:80`); `geoip` → `""`.
- **setup-node / transport-setup**: `discovery_dmsg` + `servers`; transport-setup `sessions_count` 0→1.
- **services.json / dmsg-server.json / services-config.json**: http discovery keys → dmsg-only.

## 2. Container set: 11 → 5 (1 redis + 1 deployment-services + 3 visors)
- **Five per-service redis → one `redis`**, each discovery service on its own logical DB (`redis://redis:6379/<N>`; go-redis honors the DB selector): `/0` dmsgd, `/1` tpd+rf (shared — RF reads TPD data), `/2` sd, `/3` ar.
- **Drop the standalone uptime-tracker + its postgres + ut-redis** — uptime tracking is now integrated into the discovery services (TPD et al.), so `skywire svc ut` is deprecated. Removed from compose, `e2e-run`, `env_test` expected containers, visor configs, and services-config.
- **Drop network-monitor** — already disabled (never started by `e2e-run`, excluded in `env_test`) and monitored services over plain HTTP incl. the removed UT. `pkg/network-monitor` untouched.

## Validation
- `docker compose config -q` valid; integration test (`go vet ./internal/integration`) compiles.
- `grep -r http:// docker/integration/*.json` → **0**; the only `http://` left is the container-local `:6094/debug/service` healthcheck. All PKs cross-checked + derived from SKs; no new null fields.
- Best-effort for CI per maintainer direction — the linux e2e job validates end-to-end.

## Depends on
#3171 + #3172 (first-session bootstrap/publish must not wedge). #3174 + #3175 already merged.
