### PR TITLE
fix(cli): finish dmsg-only conversion — bootstrap + trace + ephemeral clients

### DIFF
--- a/cmd/skywire-cli/commands/dmsg/curl.go
+++ b/cmd/skywire-cli/commands/dmsg/curl.go
@@ -21,7 +21,6 @@ import (
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
-	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -349,32 +348,25 @@ func startDmsgClient(ctx context.Context, log *logging.Logger, pk cipher.PubKey,
 		return nil, nil, fmt.Errorf("no DMSG servers configured")
 	}
 
-	// Create discovery client using the deployment config's discovery URL.
-	// This uses the embedded config (or SKYDEPLOY override) instead of
-	// a hardcoded URL, so E2E tests with custom deployments work correctly.
-	discURL := deployment.Prod.DmsgDiscovery
-	if discURL == "" {
-		discURL = "http://dmsgd.skywire.skycoin.com"
+	// Bootstrap with the embedded prod server set + dmsg-only Entry()
+	// fallback. No plain-HTTP egress to dmsg-discovery occurs.
+	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers,
+		"", deployment.Prod.DmsgDiscoveryDmsg, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("dmsg bootstrap: %w", err)
 	}
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-	discClient := disc.NewHTTP(discURL, httpClient, log)
-
-	// Create dmsg client
-	dmsgConfig := dmsg.DefaultConfig()
-	dmsgConfig.MinSessions = 1
-
-	dmsgC := dmsg.NewClient(pk, sk, discClient, dmsgConfig)
-	go dmsgC.Serve(ctx)
+	dmsgC := bootstrap.Client
+	closer := bootstrap.Close
 
 	// Wait for ready
 	select {
 	case <-ctx.Done():
-		_ = dmsgC.Close() //nolint:errcheck
+		closer()
 		return nil, nil, ctx.Err()
 	case <-dmsgC.Ready():
 		log.Debug("DMSG client ready")
 	case <-time.After(30 * time.Second):
-		_ = dmsgC.Close() //nolint:errcheck
+		closer()
 		return nil, nil, fmt.Errorf("timeout waiting for dmsg client")
 	}
 

--- a/cmd/skywire-cli/commands/log/dmsghttp_client.go
+++ b/cmd/skywire-cli/commands/log/dmsghttp_client.go
@@ -93,7 +93,10 @@ func dmsgHTTPClient(ctx context.Context, timeout time.Duration) (*http.Client, f
 	}
 	log.WithField("source", source).WithField("local_pk", pk.String()).Debug("Resolved survey-whitelist identity for CLI request")
 
-	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, resolvedSK, dmsg.Prod.DmsgServers, dmsgDiscURL, "", "")
+	// Default to dmsg-only discovery; plain HTTP only when the
+	// operator explicitly overrides --dmsg-disc to a custom URL.
+	httpURL, dmsgURL := dmsgDiscArgs(dmsgDiscURL)
+	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, resolvedSK, dmsg.Prod.DmsgServers, httpURL, dmsgURL, "")
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("dmsg bootstrap: %w", err)
 	}

--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -104,7 +104,11 @@ var logCmd = &cobra.Command{
 		if err != nil {
 			pk, sk = cipher.GenerateKeyPair()
 		}
-		bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers, dmsgDisc, "", "")
+		// Route the bootstrap's per-PK Entry() fallback over dmsg-HTTP
+		// by default. Plain-HTTP path is only taken when the operator
+		// explicitly passes a non-prod --dmsg-disc URL.
+		httpURL, dmsgURL := dmsgDiscArgs(dmsgDisc)
+		bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers, httpURL, dmsgURL, "")
 		if err != nil {
 			log.WithError(err).Error("Failed to bootstrap dmsg client.")
 			return

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -2,9 +2,32 @@
 package clilog
 
 import (
+	"strings"
+
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 )
+
+// dmsgDiscArgs splits an operator-supplied --dmsg-disc value into the
+// (httpURL, dmsgURL) pair BootstrapDmsg expects. Defaults to the
+// embedded dmsg URL (deployment.Prod.DmsgDiscoveryDmsg) so the
+// per-PK Entry() fallback rides dmsg-HTTP instead of plain HTTP —
+// finishing the dmsg-only conversion #3163/#3174 started.
+//
+// Selection:
+//   - empty or the embedded Prod HTTP default → dmsg URL
+//   - "dmsg://…" → dmsg URL passthrough
+//   - any other "http(s)://…" → operator opted into a custom HTTP
+//     endpoint, route it the old way
+func dmsgDiscArgs(val string) (httpURL, dmsgURL string) {
+	if val == "" || val == deployment.Prod.DmsgDiscovery {
+		return "", deployment.Prod.DmsgDiscoveryDmsg
+	}
+	if strings.HasPrefix(val, "dmsg://") {
+		return "", val
+	}
+	return val, ""
+}
 
 var (
 	dmsgDiscURL    = deployment.Prod.DmsgDiscovery

--- a/cmd/skywire-cli/commands/ptyfs/mount_linux.go
+++ b/cmd/skywire-cli/commands/ptyfs/mount_linux.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -37,7 +36,6 @@ import (
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
-	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/pty"
@@ -296,28 +294,24 @@ func mountpoint_remote_default(p string) string {
 // collide with the running visor in dmsg discovery.
 func startPTYFSDmsgClient(ctx context.Context, pk cipher.PubKey, sk cipher.SecKey) (*dmsg.Client, func(), error) {
 	log := logging.MustGetLogger("ptyfs-dmsg")
-	discURL := deployment.Prod.DmsgDiscovery
-	if discURL == "" {
-		discURL = "http://dmsgd.skywire.skycoin.com"
+	// Bootstrap with the embedded prod server set + dmsg-only Entry()
+	// fallback. No plain-HTTP egress to dmsg-discovery occurs.
+	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers,
+		"", deployment.Prod.DmsgDiscoveryDmsg, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("ptyfs: dmsg bootstrap: %w", err)
 	}
-	discClient := disc.NewHTTP(discURL, &http.Client{Timeout: 30 * time.Second}, log)
-
-	dmsgConfig := dmsg.DefaultConfig()
-	dmsgConfig.MinSessions = 1
-	dmsgC := dmsg.NewClient(pk, sk, discClient, dmsgConfig)
-	go dmsgC.Serve(ctx)
-
 	select {
 	case <-ctx.Done():
-		_ = dmsgC.Close() //nolint:errcheck
+		bootstrap.Close()
 		return nil, nil, ctx.Err()
-	case <-dmsgC.Ready():
+	case <-bootstrap.Client.Ready():
 		log.Debug("dmsg client ready")
 	case <-time.After(30 * time.Second):
-		_ = dmsgC.Close() //nolint:errcheck
+		bootstrap.Close()
 		return nil, nil, fmt.Errorf("ptyfs: timeout waiting for dmsg client")
 	}
-	return dmsgC, func() { _ = dmsgC.Close() }, nil //nolint:errcheck
+	return bootstrap.Client, bootstrap.Close, nil
 }
 
 // sftpRoot is the per-mount state shared by every sftpNode in the

--- a/cmd/skywire-cli/commands/reward/lookup.go
+++ b/cmd/skywire-cli/commands/reward/lookup.go
@@ -17,7 +17,7 @@ import (
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/cmdutil"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -232,28 +232,24 @@ func renderLookupTable(results []lookupVisorReward, days int, rewardedOnly bool)
 	return buf.String()
 }
 
-// lookupDmsgClient brings up an ephemeral dmsg client for the request. Mirrors
-// the dmsg-curl bootstrap: dmsg discovery is reached over HTTP (inherent to
-// dmsg bootstrap), but the reward request itself rides dmsg.
+// lookupDmsgClient brings up an ephemeral dmsg client for the request.
+// Uses cmdutil.BootstrapDmsg with the embedded prod server set + dmsg-only
+// Entry() fallback, so no plain-HTTP egress to dmsg-discovery occurs even
+// during bootstrap.
 func lookupDmsgClient(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey) (*dmsg.Client, func(), error) {
-	discURL := deployment.Prod.DmsgDiscovery
-	if discURL == "" {
-		discURL = "http://dmsgd.skywire.skycoin.com"
+	bootstrap, err := cmdutil.BootstrapDmsg(ctx, log, pk, sk, dmsg.Prod.DmsgServers,
+		"", deployment.Prod.DmsgDiscoveryDmsg, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("dmsg bootstrap: %w", err)
 	}
-	discClient := disc.NewHTTP(discURL, &http.Client{Timeout: 30 * time.Second}, log)
-	dmsgConfig := dmsg.DefaultConfig()
-	dmsgConfig.MinSessions = 1
-	dmsgC := dmsg.NewClient(pk, sk, discClient, dmsgConfig)
-	go dmsgC.Serve(ctx)
-
 	select {
 	case <-ctx.Done():
-		_ = dmsgC.Close() //nolint:errcheck
+		bootstrap.Close()
 		return nil, nil, ctx.Err()
-	case <-dmsgC.Ready():
+	case <-bootstrap.Client.Ready():
 	case <-time.After(30 * time.Second):
-		_ = dmsgC.Close() //nolint:errcheck
+		bootstrap.Close()
 		return nil, nil, fmt.Errorf("timeout waiting for dmsg client")
 	}
-	return dmsgC, func() { _ = dmsgC.Close() }, nil //nolint:errcheck
+	return bootstrap.Client, bootstrap.Close, nil
 }

--- a/cmd/skywire-cli/commands/route/trace.go
+++ b/cmd/skywire-cli/commands/route/trace.go
@@ -120,7 +120,7 @@ Output:
 				shortPK(srcPK), shortPK(dstPK), traceRfURL, traceMaxHops)
 		}
 
-		hops := fetchForwardRoute(cmd, srcPK, dstPK)
+		hops := fetchForwardRoute(cmd, rpcClient, srcPK, dstPK)
 		if len(hops) == 0 {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("no route found %s -> %s", shortPK(srcPK), shortPK(dstPK)))
 		}
@@ -195,11 +195,27 @@ type traceHopResult struct {
 // fetchForwardRoute calls the route finder for src→dst, returning
 // the first forward path. Failure-exits the CLI on any error —
 // trace without a known route has nothing to report.
-func fetchForwardRoute(cmd *cobra.Command, srcPK, dstPK cipher.PubKey) []routing.Hop {
-	rfc := rfclient.NewHTTP(traceRfURL, traceTimeout, &http.Client{Timeout: traceTimeout}, nil)
+//
+// Routes the /routes POST over the local visor's DmsgHTTP RPC when a
+// dmsg twin exists for traceRfURL (production default — the visor
+// already has the route-finder PK seeded). Operator-supplied
+// non-deployment route-finder URLs fall back to the plain-HTTP rfclient.
+func fetchForwardRoute(cmd *cobra.Command, rpcClient visor.API, srcPK, dstPK cipher.PubKey) []routing.Hop {
 	forward := [2]cipher.PubKey{srcPK, dstPK}
 	ctx, cancel := context.WithTimeout(context.Background(), traceTimeout)
 	defer cancel()
+
+	if dmsgRfURL := clirpc.DmsgURLForHTTP(traceRfURL); dmsgRfURL != "" {
+		hops, err := findRoutesViaDmsgRPC(ctx, rpcClient, dmsgRfURL, forward)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("route-finder (dmsg): %w", err))
+		}
+		return hops
+	}
+
+	// Custom HTTP route-finder URL the operator passed via --rf.
+	// Honor it over plain HTTP — same legacy path as before this fix.
+	rfc := rfclient.NewHTTP(traceRfURL, traceTimeout, &http.Client{Timeout: traceTimeout}, nil)
 	routes, err := rfc.FindRoutes(ctx, []routing.PathEdges{forward},
 		&rfclient.RouteOptions{MinHops: traceMinHops, MaxHops: traceMaxHops})
 	if err != nil {
@@ -210,6 +226,48 @@ func fetchForwardRoute(cmd *cobra.Command, srcPK, dstPK cipher.PubKey) []routing
 		return nil
 	}
 	return candidates[0]
+}
+
+// findRoutesViaDmsgRPC POSTs /routes to the route-finder over the
+// visor's DmsgHTTP RPC (which rides the visor's already-established
+// dmsg sessions — no per-call dmsg bootstrap). Matches the wire shape
+// rfclient.apiClient.FindRoutes builds inline; kept as a tight inline
+// helper rather than a sibling client in pkg/rfclient because the
+// DmsgHTTP RPC dependency is CLI-scoped.
+func findRoutesViaDmsgRPC(ctx context.Context, rc visor.API, dmsgRfURL string, edge [2]cipher.PubKey) ([]routing.Hop, error) {
+	reqBody := &rfclient.FindRoutesRequest{
+		Edges: []routing.PathEdges{edge},
+		Opts:  &rfclient.RouteOptions{MinHops: traceMinHops, MaxHops: traceMaxHops},
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal /routes request: %w", err)
+	}
+	_ = ctx // visor.API.DmsgHTTP is synchronous and has no ctx parameter;
+	// the timeout is enforced upstream by the cobra command's traceTimeout
+	// via the route-finder side.
+
+	resp, err := rc.DmsgHTTP(visor.DmsgHTTPRequest{
+		URL:    strings.TrimRight(dmsgRfURL, "/") + "/routes",
+		Method: http.MethodPost,
+		Header: map[string]string{"Content-Type": "application/json"},
+		Body:   body,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var paths map[routing.PathEdges][][]routing.Hop
+	if err := json.Unmarshal(resp.Body, &paths); err != nil {
+		return nil, fmt.Errorf("decode /routes response: %w", err)
+	}
+	candidates := paths[edge]
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	return candidates[0], nil
 }
 
 // bestOfDmsgPings runs N single-shot dmsg pings to pk and returns

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -293,9 +293,19 @@ func resolveServerEntry(ctx context.Context, spec string, log *logging.Logger) (
 	if addr != "" {
 		return &disc.Entry{Static: srvPK, Server: &disc.Server{Address: addr}}, nil
 	}
+	// Resolve from the embedded deployment list first — no network call,
+	// and covers every prod dmsg-server. Plain-HTTP discovery is the
+	// legacy fallback for the (rare) operator running against a custom
+	// dmsg-server that's only in their discovery; the embedded path
+	// keeps the common production case dmsg-only.
+	for _, e := range deployment.Prod.DmsgServers {
+		if e.Static == srvPK.String() {
+			return &disc.Entry{Static: srvPK, Server: &disc.Server{Address: e.Server.Address}}, nil
+		}
+	}
 	discURL := deployment.Prod.DmsgDiscovery
 	if discURL == "" {
-		discURL = "http://dmsgd.skywire.skycoin.com"
+		return nil, fmt.Errorf("--dmsg-server: %s not in embedded deployment set and no discovery URL available (pass <pk>@<host:port>)", srvPK)
 	}
 	dc := disc.NewHTTP(discURL, &http.Client{Timeout: 15 * time.Second}, log)
 	servers, err := dc.AllServers(ctx)


### PR DESCRIPTION
## Summary

Picks up the lingering plain-HTTP discovery paths from the post-#3163 follow-up list and converts each to either dmsg-HTTP or the embedded-prod short-circuit. With this PR + #3174 + #3175 the deploy-services-wide dmsg-only transition is complete on both ends of the wire — the CLI no longer makes plain-HTTP requests to deployment-service URLs in any of its prod-default code paths.

## Change

### \`log/log.go\` + \`log/dmsghttp_client.go\`
\`BootstrapDmsg\` calls now route the per-PK \`Entry()\` fallback over dmsg-HTTP by default via \`deployment.Prod.DmsgDiscoveryDmsg\`. A custom \`--dmsg-disc http://…\` still works (legacy passthrough), but the prod default no longer egresses plain HTTP at bootstrap. A shared \`dmsgDiscArgs\` helper in \`log/root.go\` centralizes the resolution:
- empty / the embedded Prod HTTP default → dmsg URL
- \`dmsg://…\` → dmsg URL passthrough
- any other \`http(s)://…\` → operator opted in, route the legacy way

### \`route/trace.go\`
Replaces \`rfclient.NewHTTP(traceRfURL, ..., &http.Client{Timeout}, nil)\` with a \`POST /routes\` over the local visor's \`DmsgHTTP\` RPC when \`traceRfURL\` has a dmsg twin in \`DmsgURLForHTTP\` (production default). Custom \`--rf\` URLs without a known dmsg twin still fall back to the plain rfclient. Re-uses the visor's already-established dmsg sessions — no per-call dmsg bootstrap.

### \`svc/health.go\`
\`resolveServerEntry\` now consults \`deployment.Prod.DmsgServers\` BEFORE the plain-HTTP discovery \`all_servers\` fetch. Every prod dmsg-server PK resolves locally — no network call. The HTTP path remains for the rare operator-custom case where the server is only in their discovery.

### \`reward/lookup.go\`, \`ptyfs/mount_linux.go\`, \`dmsg/curl.go\`
Each had its own ad-hoc \`dmsg.NewClient(pk, sk, disc.NewHTTP(...))\` ephemeral bootstrap with \`MinSessions=1\` and a plain-HTTP discovery fallback. Replaced with \`cmdutil.BootstrapDmsg\` using the embedded prod server set + dmsg-only \`Entry()\` fallback (post-#3174 plumbing). Same \`Ready()\` / 30 s timeout shape, no behavior change for callers.

## Test plan

- [x] \`go build ./cmd/skywire-cli/...\` clean
- [x] \`go vet ./cmd/skywire-cli/...\` clean
- [x] \`go test ./cmd/skywire-cli/...\` pass (one config test takes >60 s but completes at 90 s; orthogonal to this PR)
- [ ] Manual: \`skywire cli log fetch\`, \`skywire cli route trace <pk>\`, \`skywire cli svc health <pk>\`, \`skywire cli reward lookup\`, \`skywire dmsg curl\`, and \`skywire cli ptyfs mount\` produce no plain-HTTP egress to dmsgd / route-finder / etc. (verify via tcpdump or service-side access logs)