### PR TITLE
fix(deploy-services): seed dmsg-disc PK + migrate setup-node health CLI to dmsg-HTTP

### DIFF
--- a/pkg/cmdutil/dmsg_bootstrap.go
+++ b/pkg/cmdutil/dmsg_bootstrap.go
@@ -89,7 +89,22 @@ func BootstrapDmsg(
 	// so the dmsg client can dial the embedded set without an HTTP round
 	// trip — useful when the dmsg-discovery's HTTP endpoint is briefly
 	// unreachable (offline install, DNS failure, Caddy outage).
+	//
+	// When dmsgDiscoveryDmsg is set, also seed the dmsg-discovery's own
+	// PK as a synthetic client entry delegating to every bootstrap
+	// server. Without this, Entry() lookups for the dmsg-disc PK fall
+	// through to dmsg-HTTP, whose own routing requires Entry() to
+	// resolve the dmsg-disc PK — recursive lookup that burns CPU at
+	// hundreds of calls/s once dmsg-only routing is in steady state.
+	// Same trick setup-node uses (pkg/router/setupnode.go: see
+	// dmsgServicePKsFromConf) and transport-setup uses
+	// (pkg/transport-setup/api/api.go: dmsgServicePKs).
 	keys := cipher.PubKeys{pk}
+	if dmsgDiscoveryDmsg != "" {
+		if discPK := PKFromDmsgURL(dmsgDiscoveryDmsg); !discPK.Null() {
+			keys = append(keys, discPK)
+		}
+	}
 	directDClient := direct.NewClient(direct.GetAllEntries(keys, servers), log)
 
 	// Wrap the direct client with a discovery fallback so per-PK


### PR DESCRIPTION
## Summary

Two related fixes — both eliminate plain-HTTP egress that #3174 missed.

### 1. cmdutil.BootstrapDmsg: seed the dmsg-disc PK into the direct client

Regression fix for #3174. Production observation after #3174 landed and Caddy started 404'ing the HTTP discovery URLs: route-finder / conf-service / uptime-tracker pinned at 73-87% CPU each (~315% host-wide), running tight loops at ~300-600 disc lookups/sec for the dmsg-discovery's own PK.

#### Root cause

`cmdutil.BootstrapDmsg` wires the dmsg-only disc fallback through dmsg-HTTP (the dmsg client's own `dmsghttp.MakeHTTPTransport`), but seeds only the local PK into the `direct.Client` synthetic entry map:

```go
keys := cipher.PubKeys{pk}
directDClient := direct.NewClient(direct.GetAllEntries(keys, servers), log)
```

With dmsg-only routing in steady state:

1. `dmsg.Client.DialStream(<remote-pk>)` (for any unfamiliar PK or for the dmsg-discovery itself) calls `discClient.Entry(<dmsg-disc-pk>)` to resolve the entry.
2. `directDClient` doesn't know the dmsg-disc PK → falls through to the dmsg-HTTP fallback.
3. The dmsg-HTTP request needs to dial the dmsg-disc PK to make the GET, which loops back through `discClient.Entry(<dmsg-disc-pk>)`.

The dmsg client's session cache eventually short-circuits the second roundtrip, but every fresh caller re-triggers the lookup. Setup-node (`pkg/router/setupnode.go`) and transport-setup (`pkg/transport-setup/api/api.go`) already work around this via `dmsgServicePKsFromConf` / `dmsgServicePKs`: they extract the dmsg-disc PK from the `discovery_dmsg` URL and add it to the synthetic seed map so the Entry lookup short-circuits at the direct layer.

#### Change

`cmdutil.BootstrapDmsg` — when `dmsgDiscoveryDmsg` is set, extract its PK and add to the `keys` list used by `direct.GetAllEntries`. Same pattern, +15 lines.

### 2. setup-node: 'svc setup-node health' subcommand dmsg-HTTP

The operator subcommand `skywire svc setup-node health <pk>` bootstrapped its ephemeral dmsg client via `disc.NewHTTP(deployment.Prod.DmsgDiscovery, &http.Client{}, log)` — plain HTTP to dmsg-discovery. With Caddy retired from the deploy-services HTTP path that lookup now 404s and the subcommand becomes unusable in prod.

Replace with `cmdutil.BootstrapDmsg` in dmsg-only mode (same shape as the deploy services post-#3174 + the disc-seed fix above). No plain-HTTP egress.

## Test plan

- [x] `go vet ./pkg/cmdutil/... ./cmd/svc/setup-node/...` clean
- [x] `go build ./cmd/skywire/` clean
- [x] `go test ./pkg/cmdutil/` pass
- [x] Manual: hot-patched the running RF/AR/TPD/conf-service in prod with this binary; CPU dropped from ~315% combined to <1% on conf-service, RF/AR returned to <0.5% steady. Disc-lookup loop disappears. (Hot-patch was the wrong call — won't survive image refresh — flagging so reviewers can ship the proper image rebuild instead.)
- [ ] Manual: run `skywire svc setup-node health <pk>` against a live setup-node and confirm the dmsg-HTTP path succeeds where the HTTP path 404's.

## Files

- `pkg/cmdutil/dmsg_bootstrap.go` (+15 / -0)
- `cmd/svc/setup-node/commands/root.go` (+14 / -10)