### PR TITLE
fix(dmsg): start updateClientEntryLoop on first session, not after the whole seed-entry iteration

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -500,10 +500,40 @@ func (ce *Client) Serve(ctx context.Context) {
 				if pinned {
 					ce.pinnedFailures.Store(0)
 				}
+				// Start the background loops the moment a session
+				// exists. Pre-fix they were started AFTER the inner
+				// for-loop iterated every seed entry — fine when
+				// EnsureSession returned quickly, but the dial path
+				// runs setSessionCallback synchronously and that
+				// callback's first-session publish blocks for up to
+				// entryUpdateAttemptTimeout (#3172). During that 30 s
+				// window Phase 3 of the publish's own DialStream
+				// recursively dials extra sessions, pushing
+				// SessionCount past MinSessions. When EnsureSession
+				// finally returns, the next iteration of THIS for
+				// loop trips the
+				//   if MinSessions != 0 && SessionCount() >= MinSessions
+				// guard and parks on <-errCh — for the rest of the
+				// process's life if sessions are stable. The for loop
+				// then never completes its iteration and the lines
+				// below (updateClientEntryLoop start) never run, so
+				// the entry-publish retry loop never starts and the
+				// service stays unregistered until the very first
+				// session dies. Idempotent via sync.Once so duplicate
+				// triggers across entries are a no-op.
+				updateEntryLoopOnce.Do(func() { go ce.updateClientEntryLoop(cancellabelCtx, ce.done, ce.conf.ClientType) })
+				pingLoopOnce.Do(func() { go ce.pingSessionsLoop(cancellabelCtx) })
+				porterReapLoopOnce.Do(func() { go ce.porterReapLoop(cancellabelCtx) })
+				if ce.conf.MinSessions == 0 {
+					reconnectLoopOnce.Do(func() { go ce.reconnectLoop(cancellabelCtx) })
+				}
 			}
 		}
 
-		// Only start the update entry loop once we have at least one session established.
+		// Defensive: also start loops post-iteration in case the
+		// inner for-loop drained without hitting the success branch
+		// (everything failed, then the loop fell through to the
+		// outer-select retry path). sync.Once makes this safe.
 		updateEntryLoopOnce.Do(func() { go ce.updateClientEntryLoop(cancellabelCtx, ce.done, ce.conf.ClientType) })
 		pingLoopOnce.Do(func() { go ce.pingSessionsLoop(cancellabelCtx) })
 		porterReapLoopOnce.Do(func() { go ce.porterReapLoop(cancellabelCtx) })


### PR DESCRIPTION
## Summary

The Serve loop's per-iteration background-loop start lines — `updateClientEntryLoop`, `pingSessionsLoop`, `porterReapLoop` — sit **after** the inner for-loop that iterates seed entries. That was correct under the original assumption that `EnsureSession` returns quickly: iterate all entries, hit MinSessions on the last few, fall through to start the loops, then park on `<-errCh`.

Post-#3172, `setSessionCallback` runs the first-session publish synchronously and blocks for up to `entryUpdateAttemptTimeout` (30 s). Phase 3 of THAT publish's own `DialStream` recursively dials extra sessions via `EnsureAndObtainSession`, pushing `SessionCount` past `MinSessions` before the original `EnsureSession` returns. When it finally does, the next inner-for iteration trips

```go
if ce.conf.MinSessions != 0 && ce.SessionCount() >= ce.conf.MinSessions {
    select { case <-ce.done: ... case err := <-ce.errCh: ... }
}
```

and parks on `<-errCh` — for the rest of the process's lifetime if sessions are stable. The for-loop never completes, the lines below never run, `updateClientEntryLoop` never starts, and the entry-publish retry path never fires. The service stays unregistered until the very first session dies.

## Production symptom

prod02 TPS-4 today, post-#3174/#3175 deploy:
- 23:00:28 first `Updating entry.` debug (setSessionCallback's initial publish goroutine)
- 23:00:58 `Initial client entry update did not complete within bound; closing Ready and letting the loop retry.` fires (the #3172 30 s timeout)
- 23:00:58 `client entry update failed for discovery; will retry next tick` debug (PutEntry returned dmsg error 202)
- then 12+ minutes of silence — no `Failed to update discovery entry (tick).` warn ever, because the loop the comment refers to was never started. 9 sessions established, all healthy. Visor health checks succeed (via dialViaConnectedServers fallback). TPS-4 just never publishes its entry.

## Change

Moves the same `updateEntryLoopOnce.Do` / `pingLoopOnce.Do` / `porterReapLoopOnce.Do` block into the inner for-loop's success branch, so they fire on the FIRST successful `EnsureSession` instead of after the whole iteration completes. `sync.Once` makes the post-iteration block a no-op when this path fired. The post-iteration block is kept as a defensive net for the case where every entry's `EnsureSession` failed and we fell through to the outer-select retry path.

## Test plan

- [x] `go test ./pkg/dmsg/dmsg/... ./pkg/dmsg/dmsghttp/... ./pkg/dmsg/dmsgtest/...` pass
- [x] `go vet ./pkg/dmsg/...` clean
- [ ] Post-deploy: TPS-4/5/6 publish their entries to dmsg-discovery within ~30 s of startup, and DMSGD's access log shows POSTs from each TPS PK