### PR TITLE
fix(visor): async uptime-tracker + tpviz connect — an unreachable upstream must not hang the hypervisor

### DIFF
--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -141,7 +141,16 @@ func NewHypervisor(config visorconfig.HypervisorConfig, visor *Visor, dmsgC *dms
 		// CXOFeed values used by the manager — values match across
 		// both sides by construction.
 		hv.tpvizServer.SetCXOSubMgr(&cxoSubMgrAdapter{v: visor})
-		hv.tpvizServer.Start()
+		// Start tpviz's initial data population in the BACKGROUND. Start()
+		// synchronously fetches geoip + refreshes its TPD/SD caches over the
+		// (prod, HTTP) deployment URLs; if any of those is slow or closed
+		// (e.g. the deployment HTTP front door is down) the blocking fetch
+		// would stall NewHypervisor → initHypervisor → and the hypervisor's
+		// own HTTP (:http_addr) + DMSG-RPC (:dmsg_port) servers would never
+		// come up, so managed visors can't connect ("306 - no associated
+		// listener"). The control plane must not depend on tpviz's upstream;
+		// tpviz serves empty/stale until its first refresh lands.
+		go hv.tpvizServer.Start()
 	}
 
 	return hv, nil

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -69,48 +69,72 @@ func initUptimeTracker(ctx context.Context, v *Visor, log *logging.Logger) error
 		return nil
 	}
 
-	httpC, err := getHTTPClient(ctx, v, utURL)
-	if err != nil {
-		return err
+	// Connect to the uptime tracker IN THE BACKGROUND. utclient.NewHTTP runs a
+	// blocking auth handshake with infinite exponential-backoff retry, so a
+	// synchronous connect here hangs initUptimeTracker forever whenever the UT
+	// service is unreachable (e.g. it is being deprecated/torn down — "dmsg
+	// error 202 - cannot connect to delegated server"). That stalls the whole
+	// `visor` module from completing, which blocks every module that depends on
+	// it — most visibly the hypervisor, whose HTTP + DMSG-RPC servers then never
+	// start and managed visors fail to connect ("306 - no associated listener").
+	// UT is non-critical (transport re-registration also records uptime), so it
+	// must never gate startup. Use the visor's long-lived ctx, not the init ctx.
+	bgCtx := v.ctx
+	if bgCtx == nil {
+		bgCtx = context.Background()
 	}
-
-	pIP, err := getPublicIP(v, utURL)
-	if err != nil {
-		return err
-	}
-
-	ut, err := utclient.NewHTTP(utURL, v.conf.PK, v.conf.SK, httpC, pIP, v.MasterLogger())
-	if err != nil {
-		v.log.WithError(err).Warn("Failed to connect to uptime tracker.")
-		return nil
-	}
-
-	// Also create a heartbeat client for the TPD so visors without
-	// transports still report uptime. The TPD's /v4/update endpoint
-	// uses the same auth + protocol as the uptime tracker.
-	var tpdUT utclient.APIClient
-	tpdURL := v.conf.Transport.Discovery
-	if tpdURL == "" && v.conf.Transport.DiscoveryDmsg != "" {
-		tpdURL = v.conf.Transport.DiscoveryDmsg
-	}
-	if tpdURL != "" {
-		tpdHTTP, err := getHTTPClient(ctx, v, tpdURL)
+	go func() { //nolint:gosec,contextcheck
+		httpC, err := getHTTPClient(bgCtx, v, utURL)
 		if err != nil {
-			log.WithError(err).Warn("Failed to create TPD heartbeat client")
-		} else {
-			tpdPIP, _ := getPublicIP(v, tpdURL) //nolint:errcheck
-			tpdClient, err := utclient.NewHTTP(tpdURL, v.conf.PK, v.conf.SK, tpdHTTP, tpdPIP, v.MasterLogger())
+			v.log.WithError(err).Warn("uptime tracker: failed to build http client")
+			return
+		}
+
+		pIP, err := getPublicIP(v, utURL)
+		if err != nil {
+			v.log.WithError(err).Warn("uptime tracker: failed to resolve public IP")
+			return
+		}
+
+		ut, err := utclient.NewHTTP(utURL, v.conf.PK, v.conf.SK, httpC, pIP, v.MasterLogger())
+		if err != nil {
+			v.log.WithError(err).Warn("Failed to connect to uptime tracker.")
+			return
+		}
+
+		// Also create a heartbeat client for the TPD so visors without
+		// transports still report uptime. The TPD's /v4/update endpoint
+		// uses the same auth + protocol as the uptime tracker.
+		var tpdUT utclient.APIClient
+		tpdURL := v.conf.Transport.Discovery
+		if tpdURL == "" && v.conf.Transport.DiscoveryDmsg != "" {
+			tpdURL = v.conf.Transport.DiscoveryDmsg
+		}
+		if tpdURL != "" {
+			tpdHTTP, err := getHTTPClient(bgCtx, v, tpdURL)
 			if err != nil {
-				log.WithError(err).Warn("Failed to connect to TPD for heartbeat")
+				log.WithError(err).Warn("Failed to create TPD heartbeat client")
 			} else {
-				tpdUT = tpdClient
+				tpdPIP, _ := getPublicIP(v, tpdURL) //nolint:errcheck
+				tpdClient, err := utclient.NewHTTP(tpdURL, v.conf.PK, v.conf.SK, tpdHTTP, tpdPIP, v.MasterLogger())
+				if err != nil {
+					log.WithError(err).Warn("Failed to connect to TPD for heartbeat")
+				} else {
+					tpdUT = tpdClient
+				}
 			}
 		}
-	}
 
-	ticker := time.NewTicker(tickDuration)
+		ticker := time.NewTicker(tickDuration)
+		v.pushCloseStack("uptime_tracker", func() error {
+			ticker.Stop()
+			return nil
+		})
 
-	go func() { //nolint:gosec
+		v.initLock.Lock()
+		v.uptimeTracker = ut
+		v.initLock.Unlock()
+
 		for range ticker.C {
 			c := context.Background()
 			if err := ut.UpdateVisorUptime(c, v.conf.Version); err != nil {
@@ -131,15 +155,6 @@ func initUptimeTracker(ctx context.Context, v *Visor, log *logging.Logger) error
 			}
 		}
 	}()
-
-	v.pushCloseStack("uptime_tracker", func() error {
-		ticker.Stop()
-		return nil
-	})
-
-	v.initLock.Lock()
-	v.uptimeTracker = ut
-	v.initLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
When the standalone uptime-tracker is unreachable (it is being deprecated/torn down — `dmsg error 202`), `initUptimeTracker` hung **forever** on `utclient.NewHTTP` (blocking auth handshake, infinite backoff retry). That stalled the `visor` module from completing → the `hypervisor` module (`maker(hv, …, &vis)`) never ran `hv.Enable()` → its HTTP `:8000` and DMSG-RPC `:dmsg_port` servers never started → **managed/SBC visors failed to connect (`dmsg error 306 - request has no associated listener`)** and `hv status` showed disabled despite a valid, enabled config.

- **init_services.go**: move the entire UT connect + TPD-heartbeat-client + heartbeat loop into a background goroutine (using `v.ctx`). UT is non-critical (transport re-registration also records uptime) and must never gate startup.
- **hypervisor.go**: also start `tpviz.Server.Start()` async — it synchronously fetches geoip + refreshes TPD/SD caches over the (prod, HTTP) deployment URLs; with the deployment HTTP front door closed those blocking fetches could likewise stall `NewHypervisor`.

Surfaced fleet-wide as the deployment HTTP was retired (dmsg-only) and the standalone UT torn down. Validated on a live hypervisor: was hung with `:8000` unbound + SBCs 306-ing; after the fix the hypervisor binds `:8000`/`:46`, `hv status=enabled`, and managed visors connect.