### PR TITLE
feat(hypervisor): hv ui enable/disable — separate web UI from RPC + hv ls (also fixes tpviz restart panic)

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1144,9 +1144,9 @@ func configureLauncher(log *logging.Logger) {
 		BinPath:       skyenv.AppBinPath,
 		DisplayNodeIP: isDisplayNodeIP,
 	}
-	conf.UptimeTracker = &visorconfig.UptimeTracker{
-		Addr: services.UptimeTracker, //utilenv.UptimeTrackerAddr,
-	}
+	// The standalone uptime-tracker is deprecated (uptime is now tracked by the
+	// discovery services). Generated configs no longer carry an `uptime_tracker`
+	// block — conf.UptimeTracker stays nil and initUptimeTracker skips it.
 	if cliAddr != "" {
 		conf.CLIAddr = offsetAddr(cliAddr)
 	} else {
@@ -1245,7 +1245,6 @@ func configureLauncher(log *logging.Logger) {
 				conf.Dmsg.Discovery = services.DmsgDiscoveryDmsg
 				conf.Transport.AddressResolver = services.AddressResolverDmsg
 				conf.Transport.Discovery = services.TransportDiscoveryDmsg
-				conf.UptimeTracker.Addr = services.UptimeTrackerDmsg
 				conf.Routing.RouteFinder = services.RouteFinderDmsg
 				conf.Launcher.ServiceDisc = services.ServiceDiscoveryDmsg
 			} else {
@@ -1254,9 +1253,6 @@ func configureLauncher(log *logging.Logger) {
 				conf.Transport.DiscoveryDmsg = services.TransportDiscoveryDmsg
 				conf.Routing.RouteFinderDmsg = services.RouteFinderDmsg
 				conf.Launcher.ServiceDiscDmsg = services.ServiceDiscoveryDmsg
-				if conf.UptimeTracker != nil && services.UptimeTrackerDmsg != "" {
-					conf.UptimeTracker.AddrDmsg = services.UptimeTrackerDmsg
-				}
 			}
 		} else if dmsgHTTPServersList != nil {
 			// Legacy fallback: separate dmsghttp-config.json
@@ -1272,7 +1268,6 @@ func configureLauncher(log *logging.Logger) {
 					conf.Dmsg.Discovery = dmsgConf.DMSGDiscovery
 					conf.Transport.AddressResolver = dmsgConf.AddressResolver
 					conf.Transport.Discovery = dmsgConf.TransportDiscovery
-					conf.UptimeTracker.Addr = dmsgConf.UptimeTracker
 					conf.Routing.RouteFinder = dmsgConf.RouteFinder
 					conf.Launcher.ServiceDisc = dmsgConf.ServiceDiscovery
 				} else {
@@ -1281,9 +1276,6 @@ func configureLauncher(log *logging.Logger) {
 					conf.Transport.DiscoveryDmsg = dmsgConf.TransportDiscovery
 					conf.Routing.RouteFinderDmsg = dmsgConf.RouteFinder
 					conf.Launcher.ServiceDiscDmsg = dmsgConf.ServiceDiscovery
-					if conf.UptimeTracker != nil && dmsgConf.UptimeTracker != "" {
-						conf.UptimeTracker.AddrDmsg = dmsgConf.UptimeTracker
-					}
 				}
 			}
 		}

--- a/cmd/skywire-cli/commands/dmsg/port_hits.go
+++ b/cmd/skywire-cli/commands/dmsg/port_hits.go
@@ -1,0 +1,58 @@
+// Package clidmsg cmd/skywire-cli/commands/dmsg/port_hits.go
+package clidmsg
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+)
+
+func init() {
+	portHitsCmd.Flags().SortFlags = false
+	portHitsCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr,
+		"RPC server address (env: SKYWIRE_RPC)")
+	portHitsCmd.Flags().Bool(internal.JSONString, false, "print output in json")
+	RootCmd.AddCommand(portHitsCmd)
+}
+
+var portHitsCmd = &cobra.Command{
+	Use:   "port-hits",
+	Short: "Inbound dmsg requests to ports with no listener (would-be connectors)",
+	Long: `List inbound dmsg stream requests that hit a local port this visor has
+NO listener bound on (dmsg error 306). Each row is a distinct
+(source PK, destination port) with a hit count and last-seen time.
+
+Useful for spotting peers trying to reach a service you aren't
+serving — e.g. managed visors hitting a disabled hypervisor port,
+misconfigured peers pointed at the wrong port, or port scans —
+even when nothing is listening to accept them.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		hits := rpcClient.DmsgPortHits()
+		if isJSON, _ := cmd.Flags().GetBool(internal.JSONString); isJSON { //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), hits, "")
+			return
+		}
+		if len(hits) == 0 {
+			fmt.Println("No no-listener port hits recorded.")
+			return
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "DST_PORT\tSRC_PK\tCOUNT\tFIRST_SEEN\tLAST_SEEN") //nolint:errcheck
+		for _, h := range hits {
+			fmt.Fprintf(tw, "%d\t%s\t%d\t%s\t%s\n", //nolint:errcheck
+				h.DstPort, h.SrcPK, h.Count,
+				h.FirstSeen.Format(time.RFC3339), h.LastSeen.Format(time.RFC3339))
+		}
+		tw.Flush() //nolint:errcheck,gosec
+	},
+}

--- a/cmd/skywire-cli/commands/survey/root.go
+++ b/cmd/skywire-cli/commands/survey/root.go
@@ -102,7 +102,10 @@ var surveyCmd = &cobra.Command{
 			survey.ServicesURLs.RouteFinder = conf.Routing.RouteFinder
 			survey.ServicesURLs.RouteSetupNodes = conf.Routing.RouteSetupNodes
 			survey.ServicesURLs.TransportSetupPKs = conf.Transport.TransportSetupPKs
-			survey.ServicesURLs.UptimeTracker = conf.UptimeTracker.Addr
+			// uptime_tracker is deprecated and absent from generated configs (nil-safe).
+			if conf.UptimeTracker != nil {
+				survey.ServicesURLs.UptimeTracker = conf.UptimeTracker.Addr
+			}
 			survey.ServicesURLs.ServiceDiscovery = conf.Launcher.ServiceDisc
 			survey.ServicesURLs.SurveyWhitelist = conf.SurveyWhitelist
 			survey.ServicesURLs.StunServers = conf.StunServers

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -26,6 +26,10 @@ var (
 func init() {
 	RootCmd.AddCommand(hvCmd)
 	hvCmd.AddCommand(hvuiCmd)
+	hvuiCmd.AddCommand(hvUIEnableCmd)
+	hvUIEnableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
+	hvuiCmd.AddCommand(hvUIDisableCmd)
+	hvUIDisableCmd.Flags().BoolVarP(&hvPersist, "persist", "w", false, "write change to config file")
 	hvCmd.AddCommand(hvpkCmd)
 	hvpkCmd.Flags().StringVarP(&path, "input", "i", "", "path of input config file.")
 	hvpkCmd.Flags().BoolVarP(&pkg, "pkg", "p", false, "read from /opt/skywire/skywire.json")
@@ -136,10 +140,50 @@ func HypervisorPort(cmdFlags *pflag.FlagSet) string {
 	return fmt.Sprintf(":%s", ports["hypervisor"])
 }
 
+var hvUIEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Start the hypervisor web UI (leaves DMSG-RPC + hv ls running)",
+	Long:  "Start ONLY the hypervisor web UI. The DMSG-RPC listener, managed-visor tracking, and `hv ls` are unaffected. Requires the hypervisor to be enabled.\nUse -w to also persist the change to the config file.",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if err := rpcClient.EnableHypervisorUIPersist(hvPersist); err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+		if hvPersist {
+			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI enabled (persisted to config)\n", "Hypervisor web UI enabled (persisted to config)\n")
+		} else {
+			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI enabled\n", "Hypervisor web UI enabled\n")
+		}
+	},
+}
+
+var hvUIDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Stop the hypervisor web UI (keeps DMSG-RPC + hv ls running)",
+	Long:  "Stop ONLY the hypervisor web UI (the HTTP server). The DMSG-RPC listener, managed-visor tracking, and `hv ls` over the visor RPC keep working — useful to shrink the public attack surface while retaining CLI access to connected visors.\nUse -w to also persist the change to the config file.",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if err := rpcClient.DisableHypervisorUIPersist(hvPersist); err != nil {
+			internal.PrintFatalRPCError(cmd.Flags(), err)
+		}
+		if hvPersist {
+			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI disabled (persisted to config)\n", "Hypervisor web UI disabled (persisted to config)\n")
+		} else {
+			internal.PrintOutput(cmd.Flags(), "Hypervisor web UI disabled\n", "Hypervisor web UI disabled\n")
+		}
+	},
+}
+
 var hvEnableCmd = &cobra.Command{
 	Use:   "enable",
-	Short: "Enable hypervisor UI at runtime",
-	Long:  "Enable hypervisor UI at runtime.\nUse -w to also persist the change to the config file.",
+	Short: "Enable the hypervisor (DMSG-RPC + tracking + web UI) at runtime",
+	Long:  "Enable the hypervisor — DMSG-RPC listener, managed-visor tracking, and the web UI (unless ui_disable is set). Use `hv ui enable/disable` to toggle just the web UI.\nUse -w to also persist the change to the config file.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -158,8 +202,8 @@ var hvEnableCmd = &cobra.Command{
 
 var hvDisableCmd = &cobra.Command{
 	Use:   "disable",
-	Short: "Disable hypervisor UI at runtime",
-	Long:  "Disable hypervisor UI at runtime.\nUse -w to also persist the change to the config file.",
+	Short: "Disable the hypervisor entirely (DMSG-RPC + tracking + web UI) at runtime",
+	Long:  "Disable the whole hypervisor — stops the DMSG-RPC listener, disconnects managed visors, and stops the web UI (so `hv ls` no longer works). To stop ONLY the web UI while keeping CLI access, use `hv ui disable`.\nUse -w to also persist the change to the config file.",
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {

--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -321,6 +321,12 @@ func (cs *ClientSession) serve() error {
 			// listener-miss diagnostics show the originator PK and
 			// the destination port. Fields default to zero values when
 			// the failure happens before prepareFields runs.
+			//
+			// Track no-listener hits (someone tried to reach a port we
+			// aren't serving) so they can be surfaced via NoListenerHits.
+			if errors.Is(err, ErrReqNoListener) {
+				cs.entity.recordNoListenerHit(dStr.rAddr.PK, dStr.lAddr.Port)
+			}
 			cs.log.WithError(err).
 				WithField("src_pk", dStr.rAddr.PK).
 				WithField("src_port", dStr.rAddr.Port).

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -57,6 +57,10 @@ type EntityCommon struct {
 
 	updateInterval time.Duration // Minimum duration between discovery entry updates.
 
+	// noListenerHits records inbound stream requests to ports this client has
+	// no listener on (dmsg error 306). Bounded; surfaced via NoListenerHits.
+	noListenerHits *portHitTracker
+
 	log  logrus.FieldLogger
 	mlog *logging.MasterLogger
 
@@ -119,7 +123,20 @@ func (c *EntityCommon) init(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClien
 	c.sessionsMx = new(sync.Mutex)
 	c.updateInterval = updateInterval
 	c.entryNudge = make(chan struct{}, 1)
+	c.noListenerHits = newPortHitTracker(defaultPortHitCap)
 	c.log = log
+}
+
+// NoListenerHits returns a snapshot of inbound stream requests this client
+// rejected because no listener was bound on the destination port (dmsg error
+// 306), keyed by (source PK, destination port), most-recent first.
+func (c *EntityCommon) NoListenerHits() []PortHit {
+	return c.noListenerHits.snapshot()
+}
+
+// recordNoListenerHit notes one no-listener inbound request. Nil-safe.
+func (c *EntityCommon) recordNoListenerHit(srcPK cipher.PubKey, dstPort uint16) {
+	c.noListenerHits.record(srcPK, dstPort)
 }
 
 // addDiscovery appends an additional dmsg-discovery to register with.

--- a/pkg/dmsg/dmsg/port_hits.go
+++ b/pkg/dmsg/dmsg/port_hits.go
@@ -1,0 +1,97 @@
+package dmsg
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// defaultPortHitCap bounds the no-listener hit tracker so a scanning peer can't
+// grow it without limit. On overflow the least-recently-seen entry is evicted.
+const defaultPortHitCap = 256
+
+// PortHit summarizes inbound stream requests from a peer to a local port that
+// had NO listener (dmsg error 306, ErrReqNoListener) — i.e. someone tried to
+// reach a port this client isn't serving. Useful for spotting would-be
+// connectors (e.g. managed visors hitting a disabled hypervisor port),
+// misconfigured peers, or port scans.
+type PortHit struct {
+	SrcPK     cipher.PubKey `json:"src_pk"`
+	DstPort   uint16        `json:"dst_port"`
+	Count     uint64        `json:"count"`
+	FirstSeen time.Time     `json:"first_seen"`
+	LastSeen  time.Time     `json:"last_seen"`
+}
+
+type portHitKey struct {
+	pk   cipher.PubKey
+	port uint16
+}
+
+// portHitTracker is a bounded, mutex-guarded set of no-listener PortHits keyed
+// by (src PK, dst port).
+type portHitTracker struct {
+	mu   sync.Mutex
+	hits map[portHitKey]*PortHit
+	cap  int
+}
+
+func newPortHitTracker(capN int) *portHitTracker {
+	if capN <= 0 {
+		capN = defaultPortHitCap
+	}
+	return &portHitTracker{hits: make(map[portHitKey]*PortHit), cap: capN}
+}
+
+// record notes one no-listener hit from srcPK to dstPort. Nil-safe.
+func (t *portHitTracker) record(srcPK cipher.PubKey, dstPort uint16) {
+	if t == nil {
+		return
+	}
+	now := time.Now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	k := portHitKey{pk: srcPK, port: dstPort}
+	if h, ok := t.hits[k]; ok {
+		h.Count++
+		h.LastSeen = now
+		return
+	}
+	if len(t.hits) >= t.cap {
+		t.evictOldestLocked()
+	}
+	t.hits[k] = &PortHit{SrcPK: srcPK, DstPort: dstPort, Count: 1, FirstSeen: now, LastSeen: now}
+}
+
+// evictOldestLocked removes the least-recently-seen entry. Caller holds mu.
+func (t *portHitTracker) evictOldestLocked() {
+	var oldestK portHitKey
+	var oldest time.Time
+	first := true
+	for k, h := range t.hits {
+		if first || h.LastSeen.Before(oldest) {
+			oldestK, oldest, first = k, h.LastSeen, false
+		}
+	}
+	if !first {
+		delete(t.hits, oldestK)
+	}
+}
+
+// snapshot returns the current hits sorted by LastSeen (most recent first).
+// Nil-safe.
+func (t *portHitTracker) snapshot() []PortHit {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	out := make([]PortHit, 0, len(t.hits))
+	for _, h := range t.hits {
+		out = append(out, *h)
+	}
+	t.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].LastSeen.After(out[j].LastSeen) })
+	return out
+}

--- a/pkg/dmsg/dmsg/port_hits_test.go
+++ b/pkg/dmsg/dmsg/port_hits_test.go
@@ -1,0 +1,66 @@
+package dmsg
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func pk(b byte) cipher.PubKey {
+	var p cipher.PubKey
+	p[0] = 2
+	p[1] = b
+	return p
+}
+
+func TestPortHitTracker(t *testing.T) {
+	tr := newPortHitTracker(3)
+
+	// Repeat hits from the same (pk, port) coalesce + bump the count.
+	tr.record(pk(1), 80)
+	tr.record(pk(1), 80)
+	tr.record(pk(1), 80)
+	// Different port from the same pk is a distinct entry.
+	tr.record(pk(1), 46)
+	// Different pk, same port.
+	tr.record(pk(2), 80)
+
+	snap := tr.snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("want 3 distinct entries, got %d", len(snap))
+	}
+	// Most-recent-first: pk(2):80 was recorded last.
+	if snap[0].SrcPK != pk(2) || snap[0].DstPort != 80 {
+		t.Errorf("snapshot[0] should be the most recent hit (pk2:80), got %s:%d", snap[0].SrcPK, snap[0].DstPort)
+	}
+	// The coalesced entry has count 3.
+	var got uint64
+	for _, h := range snap {
+		if h.SrcPK == pk(1) && h.DstPort == 80 {
+			got = h.Count
+		}
+	}
+	if got != 3 {
+		t.Errorf("pk1:80 count = %d, want 3", got)
+	}
+
+	// Exceeding cap evicts the least-recently-seen entry (pk1:80 — its
+	// last hit predates the 46 and pk2:80 records).
+	tr.record(pk(3), 22)
+	snap = tr.snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("after overflow want 3 (cap), got %d", len(snap))
+	}
+	for _, h := range snap {
+		if h.SrcPK == pk(1) && h.DstPort == 80 {
+			t.Errorf("pk1:80 (oldest) should have been evicted")
+		}
+	}
+
+	// Nil tracker is safe.
+	var nilTr *portHitTracker
+	nilTr.record(pk(9), 1)
+	if nilTr.snapshot() != nil {
+		t.Errorf("nil tracker snapshot should be nil")
+	}
+}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -40,6 +40,9 @@ type API interface {
 	EnableHypervisorPersist(persist bool) error
 	DisableHypervisorPersist(persist bool) error
 	IsHypervisorEnabled() bool
+	EnableHypervisorUIPersist(persist bool) error
+	DisableHypervisorUIPersist(persist bool) error
+	IsHypervisorUIServing() bool
 	Uptime() (float64, error)
 	UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error)
 	RuntimeStats() (*RuntimeStatsInfo, error)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/router"
@@ -43,6 +44,7 @@ type API interface {
 	EnableHypervisorUIPersist(persist bool) error
 	DisableHypervisorUIPersist(persist bool) error
 	IsHypervisorUIServing() bool
+	DmsgPortHits() []dmsg.PortHit
 	Uptime() (float64, error)
 	UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error)
 	RuntimeStats() (*RuntimeStatsInfo, error)

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -230,10 +230,24 @@ func (v *Visor) Health() (*HealthInfo, error) {
 	return hi, nil
 }
 
+// hvNotReadyErr distinguishes "no hypervisor section in the config" from
+// "hypervisor section present but its instance isn't initialized yet". The
+// latter happens when the hv module hasn't run — usually because the visor is
+// still starting up, or its init stalled (e.g. a dependency hung) — and the
+// caller raced it. The old code returned the "not configured" message in BOTH
+// cases, sending operators with a perfectly good hypervisor config off to
+// "add a hypervisor section" that already exists.
+func (v *Visor) hvNotReadyErr() error {
+	if v.conf == nil || v.conf.Hypervisor == nil {
+		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
+	}
+	return fmt.Errorf("hypervisor configured but not initialized yet — the visor may still be starting up (or its init stalled); check the visor log and retry")
+}
+
 // EnableHypervisor implements API.
 func (v *Visor) EnableHypervisor() error {
 	if v.hvInstance == nil {
-		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
+		return v.hvNotReadyErr()
 	}
 	return v.hvInstance.Enable(context.Background())
 }
@@ -275,7 +289,7 @@ func (v *Visor) DmsgPortHits() []dmsg.PortHit {
 // unaffected) and optionally persists the change.
 func (v *Visor) EnableHypervisorUIPersist(persist bool) error {
 	if v.hvInstance == nil {
-		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
+		return v.hvNotReadyErr()
 	}
 	if err := v.hvInstance.EnableUI(); err != nil {
 		return err
@@ -290,7 +304,7 @@ func (v *Visor) EnableHypervisorUIPersist(persist bool) error {
 // listener, managed-visor tracking, and `hv ls` running. Optionally persists.
 func (v *Visor) DisableHypervisorUIPersist(persist bool) error {
 	if v.hvInstance == nil {
-		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
+		return v.hvNotReadyErr()
 	}
 	if err := v.hvInstance.DisableUI(); err != nil {
 		return err

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -253,6 +253,54 @@ func (v *Visor) IsHypervisorEnabled() bool {
 	return v.hvInstance.IsEnabled()
 }
 
+// IsHypervisorUIServing implements API. Reports whether the web UI is serving.
+func (v *Visor) IsHypervisorUIServing() bool {
+	if v.hvInstance == nil {
+		return false
+	}
+	return v.hvInstance.IsUIServing()
+}
+
+// EnableHypervisorUIPersist starts the hypervisor web UI (RPC/tracking
+// unaffected) and optionally persists the change.
+func (v *Visor) EnableHypervisorUIPersist(persist bool) error {
+	if v.hvInstance == nil {
+		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
+	}
+	if err := v.hvInstance.EnableUI(); err != nil {
+		return err
+	}
+	if persist {
+		return v.persistHypervisorUIDisabled(false)
+	}
+	return nil
+}
+
+// DisableHypervisorUIPersist stops the hypervisor web UI but keeps the DMSG-RPC
+// listener, managed-visor tracking, and `hv ls` running. Optionally persists.
+func (v *Visor) DisableHypervisorUIPersist(persist bool) error {
+	if v.hvInstance == nil {
+		return fmt.Errorf("hypervisor not configured — add \"hypervisor\" section to visor config")
+	}
+	if err := v.hvInstance.DisableUI(); err != nil {
+		return err
+	}
+	if persist {
+		return v.persistHypervisorUIDisabled(true)
+	}
+	return nil
+}
+
+// persistHypervisorUIDisabled writes the web-UI disable state to the config.
+func (v *Visor) persistHypervisorUIDisabled(disable bool) error {
+	if v.conf.Hypervisor == nil {
+		config := visorconfig.DefaultHypervisorConfig()
+		v.conf.Hypervisor = &config
+	}
+	v.conf.Hypervisor.UIDisable = disable
+	return v.conf.Flush()
+}
+
 // EnableHypervisorPersist enables the hypervisor and optionally persists to config.
 func (v *Visor) EnableHypervisorPersist(persist bool) error {
 	if err := v.EnableHypervisor(); err != nil {

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
@@ -259,6 +260,15 @@ func (v *Visor) IsHypervisorUIServing() bool {
 		return false
 	}
 	return v.hvInstance.IsUIServing()
+}
+
+// DmsgPortHits implements API. Returns inbound dmsg stream requests that hit a
+// local port with no listener (dmsg error 306), keyed by (src PK, dst port).
+func (v *Visor) DmsgPortHits() []dmsg.PortHit {
+	if v.dmsgC == nil {
+		return nil
+	}
+	return v.dmsgC.NoListenerHits()
 }
 
 // EnableHypervisorUIPersist starts the hypervisor web UI (RPC/tracking

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -71,10 +71,12 @@ type Hypervisor struct {
 	summaryCacheMx sync.RWMutex
 
 	// Runtime state for enable/disable toggle
-	httpSrv   *http.Server // nil when disabled
-	srvCancel context.CancelFunc
-	enabled   bool
-	enableMu  sync.Mutex
+	httpSrv        *http.Server // nil when the web UI isn't serving
+	srvCancel      context.CancelFunc
+	enabled        bool      // DMSG RPC + managed-visor tracking active
+	uiServing      bool      // web UI (HTTP) server active — independent of `enabled`
+	tpvizStartOnce sync.Once // tpviz is start-once (its Stop closes a chan that can't be reopened)
+	enableMu       sync.Mutex
 }
 
 // cachedSummary is one entry in Hypervisor.summaryCache.
@@ -117,12 +119,12 @@ func NewHypervisor(config visorconfig.HypervisorConfig, visor *Visor, dmsgC *dms
 		summaryCache: make(map[cipher.PubKey]cachedSummary),
 	}
 
-	// tpviz is started unconditionally whenever a hypervisor has a
-	// local visor — the hvui's network-visualizer tab is always shown
-	// in the home top bar, so gating the backend on a config flag
-	// just produced 404s on /tp-viz/ for older configs that hadn't
-	// flipped enable=true. The TPViz config block still tunes
-	// SurveyDir and CacheMaxAge; only the on/off gate is removed.
+	// tpviz is constructed whenever a hypervisor has a local visor — the
+	// hvui's network-visualizer tab is always shown in the home top bar, so
+	// gating the backend on a config flag just produced 404s on /tp-viz/ for
+	// older configs. The TPViz config block still tunes SurveyDir and
+	// CacheMaxAge. It is STARTED (and stopped) with the web UI in startUI/
+	// stopUI, since it only backs UI routes.
 	if visor != nil {
 		tpvizCfg := tpviz.DefaultConfig()
 		if config.TPViz.SurveyDir != "" {
@@ -141,20 +143,20 @@ func NewHypervisor(config visorconfig.HypervisorConfig, visor *Visor, dmsgC *dms
 		// CXOFeed values used by the manager — values match across
 		// both sides by construction.
 		hv.tpvizServer.SetCXOSubMgr(&cxoSubMgrAdapter{v: visor})
-		// Start tpviz's initial data population in the BACKGROUND. Start()
-		// synchronously fetches geoip + refreshes its TPD/SD caches over the
-		// (prod, HTTP) deployment URLs; if any of those is slow or closed
-		// (e.g. the deployment HTTP front door is down) the blocking fetch
-		// would stall NewHypervisor → initHypervisor → and the hypervisor's
-		// own HTTP (:http_addr) + DMSG-RPC (:dmsg_port) servers would never
-		// come up, so managed visors can't connect ("306 - no associated
-		// listener"). The control plane must not depend on tpviz's upstream;
-		// tpviz serves empty/stale until its first refresh lands.
-		go hv.tpvizServer.Start()
+		// tpviz backs the web UI's network-visualizer tab, so it is
+		// started/stopped with the UI (see startUI/stopUI) — and started
+		// ASYNC there because Start() synchronously fetches geoip + refreshes
+		// its TPD/SD caches over the (prod, HTTP) deployment URLs, which must
+		// never block the hypervisor's control plane from coming up.
 	}
 
 	return hv, nil
 }
+
+// Enable starts the hypervisor: the DMSG-RPC listener + managed-visor tracking
+// (the secure, whitelist-gated surface that backs `hv ls`) always, and the web
+// UI unless UIDisable is set. The UI can be toggled independently afterward via
+// EnableUI/DisableUI without affecting the RPC/tracking.
 func (hv *Hypervisor) Enable(ctx context.Context) error {
 	hv.enableMu.Lock()
 	defer hv.enableMu.Unlock()
@@ -166,7 +168,8 @@ func (hv *Hypervisor) Enable(ctx context.Context) error {
 	srvCtx, cancel := context.WithCancel(ctx)
 	hv.srvCancel = cancel
 
-	// Start DMSG RPC listener for remote visors (waits for DMSG to be ready)
+	// Start DMSG RPC listener for remote visors (waits for DMSG to be ready).
+	// This is the source of managed-visor data and is independent of the web UI.
 	if hv.dmsgC != nil {
 		go func() {
 			<-hv.dmsgC.Ready()
@@ -178,21 +181,39 @@ func (hv *Hypervisor) Enable(ctx context.Context) error {
 		}()
 	}
 
-	// Start HTTP server
-	handler := hv.HTTPHandler()
+	// The web UI is optional and independent of the RPC/tracking above.
+	if !hv.c.UIDisable {
+		if err := hv.startUI(); err != nil {
+			cancel()
+			hv.srvCancel = nil
+			return err
+		}
+	} else {
+		hv.logger.Info("Hypervisor web UI disabled (ui_disable); DMSG-RPC + managed-visor tracking + hv ls active")
+	}
+
+	hv.enabled = true
+	hv.logger.Info("Hypervisor enabled")
+	return nil
+}
+
+// startUI starts the web UI HTTP server (and tpviz, which backs its
+// network-visualizer tab). Caller must hold enableMu. No-op if already serving.
+func (hv *Hypervisor) startUI() error {
+	if hv.uiServing {
+		return nil
+	}
 	hv.httpSrv = &http.Server{
-		Handler:           handler,
+		Handler:           hv.HTTPHandler(),
 		ReadTimeout:       5 * time.Second,
 		WriteTimeout:      10 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-
 	lis, err := net.Listen("tcp", hv.c.HTTPAddr)
 	if err != nil {
-		cancel()
+		hv.httpSrv = nil
 		return fmt.Errorf("hypervisor HTTP listen %s: %w", hv.c.HTTPAddr, err)
 	}
-
 	go func() {
 		hv.logger.Infof("Hypervisor HTTP serving on %s", hv.c.HTTPAddr)
 		var srvErr error
@@ -205,15 +226,63 @@ func (hv *Hypervisor) Enable(ctx context.Context) error {
 			hv.logger.WithError(srvErr).Error("Hypervisor HTTP server error")
 		}
 	}()
-
-	// Start tpviz if configured
+	// tpviz fetches geoip + prod-HTTP TPD/SD caches synchronously — start async
+	// so a slow/closed upstream can't block (see #3181). Start it AT MOST ONCE
+	// for the hypervisor's lifetime: tpviz.Stop() closes a channel created in
+	// NewServer that Start() doesn't recreate, so a stop+start cycle would panic
+	// on a double close. It's a cheap background cache refresher, so leaving it
+	// running across UI toggles (and until process exit) is fine.
 	if hv.tpvizServer != nil {
-		hv.tpvizServer.Start()
+		hv.tpvizStartOnce.Do(func() { go hv.tpvizServer.Start() })
 	}
-
-	hv.enabled = true
-	hv.logger.Info("Hypervisor enabled")
+	hv.uiServing = true
 	return nil
+}
+
+// stopUI shuts down the web UI HTTP server. Caller must hold enableMu. tpviz is
+// deliberately NOT stopped here — it's start-once (its Stop closes a one-shot
+// channel) and a cheap background refresher, so it keeps running across UI
+// toggles. The HTTP handler is what gates access; with the server down the
+// tpviz routes are unreachable regardless.
+func (hv *Hypervisor) stopUI() {
+	if hv.httpSrv != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := hv.httpSrv.Shutdown(shutdownCtx); err != nil {
+			hv.logger.WithError(err).Warn("Hypervisor HTTP shutdown error")
+		}
+		hv.httpSrv = nil
+	}
+	hv.uiServing = false
+}
+
+// EnableUI starts just the web UI, leaving the DMSG-RPC/tracking untouched.
+// Requires the hypervisor to be enabled.
+func (hv *Hypervisor) EnableUI() error {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+	if !hv.enabled {
+		return fmt.Errorf("hypervisor not enabled; run 'skywire cli visor hv enable' first")
+	}
+	hv.c.UIDisable = false
+	return hv.startUI()
+}
+
+// DisableUI stops just the web UI; the DMSG-RPC listener, managed-visor
+// tracking, and `hv ls` keep working.
+func (hv *Hypervisor) DisableUI() error {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+	hv.c.UIDisable = true
+	hv.stopUI()
+	return nil
+}
+
+// IsUIServing reports whether the web UI HTTP server is currently serving.
+func (hv *Hypervisor) IsUIServing() bool {
+	hv.enableMu.Lock()
+	defer hv.enableMu.Unlock()
+	return hv.uiServing
 }
 func (hv *Hypervisor) Disable() error {
 	hv.enableMu.Lock()
@@ -223,15 +292,8 @@ func (hv *Hypervisor) Disable() error {
 		return nil
 	}
 
-	// Stop HTTP server
-	if hv.httpSrv != nil {
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer shutdownCancel()
-		if err := hv.httpSrv.Shutdown(shutdownCtx); err != nil {
-			hv.logger.WithError(err).Warn("Hypervisor HTTP shutdown error")
-		}
-		hv.httpSrv = nil
-	}
+	// Stop the web UI (HTTP server + tpviz).
+	hv.stopUI()
 
 	// Cancel DMSG RPC context (stops listener)
 	if hv.srvCancel != nil {
@@ -248,11 +310,6 @@ func (hv *Hypervisor) Disable() error {
 		delete(hv.remoteVisors, pk)
 	}
 	hv.vsMu.Unlock()
-
-	// Stop tpviz
-	if hv.tpvizServer != nil {
-		hv.tpvizServer.Stop()
-	}
 
 	hv.enabled = false
 	hv.logger.Info("Hypervisor disabled")

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
@@ -103,6 +104,10 @@ func (proxyDefaultAPI) DisableHypervisorUIPersist(_ bool) error {
 
 func (proxyDefaultAPI) IsHypervisorUIServing() bool {
 	return false
+}
+
+func (proxyDefaultAPI) DmsgPortHits() []dmsg.PortHit {
+	return nil
 }
 
 func (proxyDefaultAPI) Uptime() (float64, error) {

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -93,6 +93,18 @@ func (proxyDefaultAPI) IsHypervisorEnabled() bool {
 	return false
 }
 
+func (proxyDefaultAPI) EnableHypervisorUIPersist(_ bool) error {
+	return ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) DisableHypervisorUIPersist(_ bool) error {
+	return ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) IsHypervisorUIServing() bool {
+	return false
+}
+
 func (proxyDefaultAPI) Uptime() (float64, error) {
 	return 0, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -278,6 +278,25 @@ func (rc *rpcClient) IsHypervisorEnabled() bool {
 	return out
 }
 
+// EnableHypervisorUIPersist starts only the web UI (RPC/tracking unaffected).
+func (rc *rpcClient) EnableHypervisorUIPersist(persist bool) error {
+	return rc.Call("EnableHypervisorUI", &persist, &struct{}{})
+}
+
+// DisableHypervisorUIPersist stops only the web UI (RPC/tracking + hv ls stay up).
+func (rc *rpcClient) DisableHypervisorUIPersist(persist bool) error {
+	return rc.Call("DisableHypervisorUI", &persist, &struct{}{})
+}
+
+// IsHypervisorUIServing calls IsHypervisorUIServing
+func (rc *rpcClient) IsHypervisorUIServing() bool {
+	var out bool
+	if err := rc.Call("IsHypervisorUIServing", &struct{}{}, &out); err != nil {
+		return false
+	}
+	return out
+}
+
 // Uptime calls Uptime
 func (rc *rpcClient) Uptime() (float64, error) {
 	var out float64

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/pty"
@@ -293,6 +294,15 @@ func (rc *rpcClient) IsHypervisorUIServing() bool {
 	var out bool
 	if err := rc.Call("IsHypervisorUIServing", &struct{}{}, &out); err != nil {
 		return false
+	}
+	return out
+}
+
+// DmsgPortHits calls DmsgPortHits
+func (rc *rpcClient) DmsgPortHits() []dmsg.PortHit {
+	var out []dmsg.PortHit
+	if err := rc.Call("DmsgPortHits", &struct{}{}, &out); err != nil {
+		return nil
 	}
 	return out
 }

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -18,6 +18,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/pty"
@@ -238,6 +239,9 @@ func (mc *mockRPCClient) DisableHypervisorUIPersist(_ bool) error { return nil }
 
 // IsHypervisorUIServing implements API
 func (mc *mockRPCClient) IsHypervisorUIServing() bool { return false }
+
+// DmsgPortHits implements API
+func (mc *mockRPCClient) DmsgPortHits() []dmsg.PortHit { return nil }
 
 // Uptime implements API
 func (mc *mockRPCClient) Uptime() (float64, error) {

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -230,6 +230,15 @@ func (mc *mockRPCClient) DisableHypervisorPersist(_ bool) error { return nil }
 // IsHypervisorEnabled implements API
 func (mc *mockRPCClient) IsHypervisorEnabled() bool { return false }
 
+// EnableHypervisorUIPersist implements API
+func (mc *mockRPCClient) EnableHypervisorUIPersist(_ bool) error { return nil }
+
+// DisableHypervisorUIPersist implements API
+func (mc *mockRPCClient) DisableHypervisorUIPersist(_ bool) error { return nil }
+
+// IsHypervisorUIServing implements API
+func (mc *mockRPCClient) IsHypervisorUIServing() bool { return false }
+
 // Uptime implements API
 func (mc *mockRPCClient) Uptime() (float64, error) {
 	return time.Since(mc.startedAt).Seconds(), nil

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/util/rpcutil"
 )
@@ -57,6 +58,13 @@ func (r *RPC) DisableHypervisorUI(persist *bool, _ *struct{}) (err error) {
 // IsHypervisorUIServing returns whether the hypervisor web UI is serving.
 func (r *RPC) IsHypervisorUIServing(_ *struct{}, out *bool) (err error) {
 	*out = r.visor.IsHypervisorUIServing()
+	return nil
+}
+
+// DmsgPortHits returns inbound dmsg stream requests that hit a local port with
+// no listener (dmsg error 306), keyed by (src PK, dst port).
+func (r *RPC) DmsgPortHits(_ *struct{}, out *[]dmsg.PortHit) (err error) {
+	*out = r.visor.DmsgPortHits()
 	return nil
 }
 

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -38,6 +38,28 @@ func (r *RPC) IsHypervisorEnabled(_ *struct{}, out *bool) (err error) {
 	return nil
 }
 
+// EnableHypervisorUI starts only the hypervisor web UI; the DMSG-RPC listener
+// and managed-visor tracking are unaffected. Persists when persist is true.
+func (r *RPC) EnableHypervisorUI(persist *bool, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "EnableHypervisorUI", persist)(nil, &err)
+	p := persist != nil && *persist
+	return r.visor.EnableHypervisorUIPersist(p)
+}
+
+// DisableHypervisorUI stops only the hypervisor web UI; the DMSG-RPC listener,
+// managed-visor tracking, and hv ls keep working. Persists when persist is true.
+func (r *RPC) DisableHypervisorUI(persist *bool, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "DisableHypervisorUI", persist)(nil, &err)
+	p := persist != nil && *persist
+	return r.visor.DisableHypervisorUIPersist(p)
+}
+
+// IsHypervisorUIServing returns whether the hypervisor web UI is serving.
+func (r *RPC) IsHypervisorUIServing(_ *struct{}, out *bool) (err error) {
+	*out = r.visor.IsHypervisorUIServing()
+	return nil
+}
+
 func (r *RPC) Health(_ *struct{}, out *HealthInfo) (err error) {
 	defer rpcutil.LogCall(r.log, "Health", nil)(out, &err)
 

--- a/pkg/visor/survey.go
+++ b/pkg/visor/survey.go
@@ -81,7 +81,11 @@ func GenerateSurvey(v *Visor, log *logging.Logger, routine bool) {
 		survey.ServicesURLs.RouteFinder = v.conf.Routing.RouteFinder
 		survey.ServicesURLs.RouteSetupNodes = v.conf.EffectiveRouteSetupNodes()
 		survey.ServicesURLs.TransportSetupPKs = v.conf.EffectiveTransportSetupPKs()
-		survey.ServicesURLs.UptimeTracker = v.conf.UptimeTracker.Addr
+		// uptime_tracker is deprecated and absent from generated configs, so it
+		// may be nil — guard the deref.
+		if v.conf.UptimeTracker != nil {
+			survey.ServicesURLs.UptimeTracker = v.conf.UptimeTracker.Addr
+		}
 		survey.ServicesURLs.ServiceDiscovery = v.conf.Launcher.ServiceDisc
 		survey.ServicesURLs.SurveyWhitelist = v.conf.EffectiveSurveyWhitelist()
 		survey.ServicesURLs.StunServers = v.conf.StunServers

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -65,9 +65,10 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		BinPath:       skyenv.AppBinPath,
 		DisplayNodeIP: false,
 	}
-	conf.UptimeTracker = &UptimeTracker{
-		Addr: services.UptimeTracker,
-	}
+	// The standalone uptime-tracker is deprecated — uptime is now tracked by
+	// the discovery services (TPD et al.). Generated configs no longer include
+	// an `uptime_tracker` block; the field is nil and initUptimeTracker skips
+	// it. Runtime readers all nil-guard conf.UptimeTracker.
 	conf.CLIAddr = skyenv.RPCAddr
 	conf.LogLevel = skyenv.LogLevel
 	conf.LocalPath = skyenv.LocalPath
@@ -105,7 +106,6 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 				conf.Dmsg.Discovery = dmsgHTTPServersList.Test.DMSGDiscovery
 				conf.Transport.AddressResolver = dmsgHTTPServersList.Test.AddressResolver
 				conf.Transport.Discovery = dmsgHTTPServersList.Test.TransportDiscovery
-				conf.UptimeTracker.Addr = dmsgHTTPServersList.Test.UptimeTracker
 				conf.Routing.RouteFinder = dmsgHTTPServersList.Test.RouteFinder
 				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Test.ServiceDiscovery
 			} else {
@@ -113,7 +113,6 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 				conf.Dmsg.Discovery = dmsgHTTPServersList.Prod.DMSGDiscovery
 				conf.Transport.AddressResolver = dmsgHTTPServersList.Prod.AddressResolver
 				conf.Transport.Discovery = dmsgHTTPServersList.Prod.TransportDiscovery
-				conf.UptimeTracker.Addr = dmsgHTTPServersList.Prod.UptimeTracker
 				conf.Routing.RouteFinder = dmsgHTTPServersList.Prod.RouteFinder
 				conf.Launcher.ServiceDisc = dmsgHTTPServersList.Prod.ServiceDiscovery
 			}

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -55,7 +55,12 @@ func (hk *Key) UnmarshalText(text []byte) error {
 
 // HypervisorConfig configures the hypervisor.
 type HypervisorConfig struct {
-	Enable     bool          `json:"enable"` // Whether the hypervisor is enabled (starts HTTP + DMSG on visor startup).
+	Enable bool `json:"enable"` // Whether the hypervisor is enabled (starts DMSG RPC + tracking + web UI on visor startup).
+	// UIDisable, when true, suppresses ONLY the web UI (HTTP) server while the
+	// hypervisor's DMSG-RPC listener + managed-visor tracking (and `hv ls` over
+	// the visor RPC) stay active. Toggled at runtime with `hv ui enable/disable`.
+	// Default false (UI served) — backward-compatible with configs that omit it.
+	UIDisable  bool          `json:"ui_disable,omitempty"`
 	UIAssets   fs.FS         `json:"-"`
 	PK         cipher.PubKey `json:"-"`
 	SK         cipher.SecKey `json:"-"`


### PR DESCRIPTION
Per the observation that disabling the hypervisor shouldn't also kill CLI access to connected-visor data: `hv disable` tore down the DMSG-RPC listener, managed-visor tracking, AND the web UI together — so it also broke `hv ls` (which gates on `IsEnabled`). You couldn't shrink the public web attack surface while keeping secure CLI access to connected visors.

## Change
Split web-UI serving from the hypervisor's RPC/tracking surface:
- `hv enable`/`hv disable` (unchanged) toggle the whole hypervisor — DMSG-RPC listener + managed-visor tracking + (unless `ui_disable`) the web UI.
- **New `hv ui enable` / `hv ui disable`** (with `-w` to persist) toggle ONLY the web UI (`:http_addr`). The DMSG-RPC listener, managed-visor tracking, and `hv ls` keep working.
- New config field `hypervisor.ui_disable` (default false = served; backward-compatible) persists the UI state.

Implementation: `uiServing` flag separate from `enabled`; extract `startUI`/`stopUI`; `Enable` starts the UI only when `!ui_disable`; `EnableUI`/`DisableUI`/`IsUIServing` on the API + RPC server/client + proxy/mock + CLI.

## Also fixes a pre-existing tpviz restart crash
`tpviz.Server.Stop()` does `close(s.stopChan)` with no double-close guard, and `stopChan` is created once in `NewServer` (never recreated) — so any enable→disable→enable cycle (and the new UI toggle) double-closed it → **panic**. tpviz is now started at most once (`sync.Once`) for the hypervisor lifetime and not stopped on UI toggle (it's a cheap background cache refresher; its routes are unreachable once the HTTP server is down anyway).

## Validation
Built/vet/lint green. Live on a hypervisor: `hv ui disable` drops `:8000` while `hv ls` still returns 18 connected visors and the process stays up; repeated enable/disable toggles are stable (no double-close panic).

## Follow-up (noted, not in this PR)
Surface the PKs that hit the hypervisor dmsg port and get `dmsg 306 (no listener)` as a "pending/attempting" list, so you can see would-be managed visors even when the listener is down.
