### PR TITLE
feat(router): dispatch + forward DatagramPacket — wire faithful UDP into the router (#2607 stage-4a)

### DIFF
--- a/pkg/router/datagram_dispatch_test.go
+++ b/pkg/router/datagram_dispatch_test.go
@@ -1,0 +1,126 @@
+// Package router pkg/router/datagram_dispatch_test.go: integration
+// tests for the router-side DatagramPacket dispatch wired in stage 4
+// of #2607. Unlike datagram_route_group_test.go (which calls Handle
+// directly), these drive a real DatagramPacket through
+// handleTransportPacket → GetRule → datagramRouteGroup → Handle, i.e.
+// the path a frame off a transport actually takes.
+package router
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// newDispatchTestRouter builds the minimal router needed to exercise
+// the consume-side datagram dispatch: a routing table and the
+// datagram route-group map. The forward/intermediary path needs a
+// transport manager and is covered separately.
+func newDispatchTestRouter() *router {
+	return &router{
+		logger:       logging.MustGetLogger("test_dg_dispatch"),
+		rt:           routing.NewTable(logging.MustGetLogger("test_dg_rt")),
+		rgsDatagrams: make(map[routing.RouteDescriptor]*DatagramRouteGroup),
+	}
+}
+
+// TestDatagramDispatchDeliversToRegisteredGroup verifies the full
+// receive-side wiring: a DatagramPacket whose route ID maps to a
+// local consume rule is delivered to the DatagramRouteGroup
+// registered for that rule's descriptor.
+func TestDatagramDispatchDeliversToRegisteredGroup(t *testing.T) {
+	r := newDispatchTestRouter()
+
+	lPK, _ := cipher.GenerateKeyPair()
+	rPK, _ := cipher.GenerateKeyPair()
+	keyRouteID := routing.RouteID(42)
+
+	// Install a consume (reverse) rule keyed by keyRouteID. Its
+	// RouteDescriptor() is what the datagram group is registered under.
+	consume := routing.ConsumeRule(time.Hour, keyRouteID, lPK, rPK, 100, 200)
+	require.NoError(t, r.rt.SaveRule(consume))
+	desc := consume.RouteDescriptor()
+
+	dg := NewDatagramRouteGroup(nil, nil, desc, nil)
+	defer dg.Close() //nolint:errcheck
+	r.setDatagramRouteGroup(desc, dg)
+
+	// A DatagramPacket stamped with keyRouteID enters via the same
+	// switch a transport read loop uses.
+	payload := []byte("faithful-udp-payload")
+	pkt, err := routing.MakeDatagramPacket(keyRouteID, payload)
+	require.NoError(t, err)
+	require.NoError(t, r.handleTransportPacket(context.Background(), pkt))
+
+	// The group received it.
+	require.NoError(t, dg.SetReadDeadline(time.Now().Add(2*time.Second)))
+	buf := make([]byte, 1500)
+	n, addr, err := dg.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, buf[:n])
+	assert.Equal(t, dg.RemoteAddr().String(), addr.String())
+}
+
+// TestDatagramDispatchDropsWhenNoGroup verifies that a DatagramPacket
+// for a known consume rule with NO registered group is dropped
+// silently (faithful-UDP loss tolerance) rather than erroring or
+// parking — the receive-side setup race must not buffer datagrams.
+func TestDatagramDispatchDropsWhenNoGroup(t *testing.T) {
+	r := newDispatchTestRouter()
+
+	lPK, _ := cipher.GenerateKeyPair()
+	rPK, _ := cipher.GenerateKeyPair()
+	keyRouteID := routing.RouteID(7)
+	consume := routing.ConsumeRule(time.Hour, keyRouteID, lPK, rPK, 1, 2)
+	require.NoError(t, r.rt.SaveRule(consume))
+
+	pkt, err := routing.MakeDatagramPacket(keyRouteID, []byte("dropped"))
+	require.NoError(t, err)
+	// No group registered → handled (dropped) without error.
+	require.NoError(t, r.handleTransportPacket(context.Background(), pkt))
+}
+
+// TestDatagramDispatchUnknownRouteErrors verifies that a
+// DatagramPacket for a route ID with no rule at all surfaces the
+// rule-lookup error (annotated with route ID + packet type), matching
+// the reliable dispatch's behavior.
+func TestDatagramDispatchUnknownRouteErrors(t *testing.T) {
+	r := newDispatchTestRouter()
+	pkt, err := routing.MakeDatagramPacket(routing.RouteID(999), []byte("x"))
+	require.NoError(t, err)
+	err = r.handleTransportPacket(context.Background(), pkt)
+	require.Error(t, err)
+}
+
+// TestDatagramDispatchClosedGroupDeregisters verifies that delivering
+// to a closed group de-registers it (so subsequent datagrams take the
+// fast drop path) and does not surface an error.
+func TestDatagramDispatchClosedGroupDeregisters(t *testing.T) {
+	r := newDispatchTestRouter()
+
+	lPK, _ := cipher.GenerateKeyPair()
+	rPK, _ := cipher.GenerateKeyPair()
+	keyRouteID := routing.RouteID(11)
+	consume := routing.ConsumeRule(time.Hour, keyRouteID, lPK, rPK, 5, 6)
+	require.NoError(t, r.rt.SaveRule(consume))
+	desc := consume.RouteDescriptor()
+
+	dg := NewDatagramRouteGroup(nil, nil, desc, nil)
+	require.NoError(t, dg.Close())
+	r.setDatagramRouteGroup(desc, dg)
+
+	pkt, err := routing.MakeDatagramPacket(keyRouteID, []byte("to-closed"))
+	require.NoError(t, err)
+	require.NoError(t, r.handleTransportPacket(context.Background(), pkt))
+
+	// The closed group was de-registered by the dispatch.
+	_, ok := r.datagramRouteGroup(desc)
+	assert.False(t, ok, "closed datagram group should be de-registered after dispatch")
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -408,9 +408,10 @@ type router struct {
 	trustedVisors      map[cipher.PubKey]struct{}
 	tm                 *transport.Manager
 	rt                 routing.Table
-	rgsNs              map[routing.RouteDescriptor]*NoiseRouteGroup // Noise-wrapped route groups to push incoming reads from transports.
-	rgsRaw             map[routing.RouteDescriptor]*RouteGroup      // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
-	pending            *pendingPackets                              // frames parked during the rule-save -> route-group-register window (see router_pending.go)
+	rgsNs              map[routing.RouteDescriptor]*NoiseRouteGroup    // Noise-wrapped route groups to push incoming reads from transports.
+	rgsRaw             map[routing.RouteDescriptor]*RouteGroup         // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
+	rgsDatagrams       map[routing.RouteDescriptor]*DatagramRouteGroup // faithful-UDP (DatagramPacket) route groups, keyed like rgsNs; #2607 stage-4 dispatch
+	pending            *pendingPackets                                 // frames parked during the rule-save -> route-group-register window (see router_pending.go)
 	rpcSrv             *rpc.Server
 	accept             chan routing.EdgeRules
 	done               chan struct{}
@@ -490,6 +491,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		dmsgC:           dmsgC,
 		rgsNs:           make(map[routing.RouteDescriptor]*NoiseRouteGroup),
 		rgsRaw:          make(map[routing.RouteDescriptor]*RouteGroup),
+		rgsDatagrams:    make(map[routing.RouteDescriptor]*DatagramRouteGroup),
 		pending:         newPendingPackets(),
 		rpcSrv:          rpc.NewServer(),
 		accept:          make(chan routing.EdgeRules, acceptSize),

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -48,6 +48,8 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 		return r.dispatchToRouteGroup(ctx, packet)
 	case routing.SACKPacket:
 		return r.handleSACKRouterPacket(ctx, packet)
+	case routing.DatagramPacket:
+		return r.handleDatagramPacket(ctx, packet)
 	case routing.TransportPingPacket, routing.TransportPongPacket,
 		routing.CascadeSetupPacket, routing.CascadeAckPacket, routing.DHTPacket,
 		routing.SetupRPCPacket, routing.VisorRPCPacket:
@@ -112,6 +114,46 @@ func (r *router) dispatchToRouteGroup(ctx context.Context, packet routing.Packet
 // distinct code path in handleTransportPacket.
 func (r *router) handleDataHandshakePacket(ctx context.Context, packet routing.Packet) error {
 	return r.dispatchToRouteGroup(ctx, packet)
+}
+
+// handleDatagramPacket dispatches a faithful-UDP DatagramPacket (#2607). It
+// mirrors dispatchToRouteGroup but routes to the datagram route-group map and,
+// critically, does NOT park frames for an as-yet-unregistered descriptor: a
+// datagram is loss-tolerant by definition, so a frame that races route-group
+// registration is simply dropped rather than buffered. An intermediary rule
+// forwards the datagram to the next hop unchanged.
+func (r *router) handleDatagramPacket(ctx context.Context, packet routing.Packet) error {
+	rule, err := r.GetRule(packet.RouteID())
+	if err != nil {
+		return fmt.Errorf("%w (routeID=%d, pktType=%s)", err, packet.RouteID(), packet.Type())
+	}
+
+	// Forward/intermediary rules relay the datagram to the next hop.
+	if rt := rule.Type(); rt == routing.RuleForward || rt == routing.RuleIntermediary {
+		return r.forwardPacket(ctx, packet, rule)
+	}
+
+	// Consume rule: deliver to the local datagram route group.
+	desc := rule.RouteDescriptor()
+	dg, ok := r.datagramRouteGroup(desc)
+	if !ok || dg == nil {
+		// No group registered (yet, or already torn down). Drop — faithful
+		// UDP tolerates loss; parking/retransmit would violate the semantics.
+		r.logger.WithField("desc", desc.String()).
+			Debug("DatagramPacket for unregistered route group, dropping")
+		return nil
+	}
+
+	if err := dg.Handle(packet); err != nil {
+		// A closed group means the route should be torn down; de-register so
+		// subsequent datagrams take the fast drop path above.
+		if errors.Is(err, io.ErrClosedPipe) {
+			r.removeDatagramRouteGroup(desc)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *router) handleClosePacket(ctx context.Context, packet routing.Packet) error {
@@ -259,6 +301,15 @@ func (r *router) forwardPacket(ctx context.Context, packet routing.Packet, rule 
 		}
 	case routing.SACKPacket:
 		p = routing.MakeSACKPacket(rule.NextRouteID(), packet.SACKLastContiguousSeq(), packet.SACKBitmap())
+	case routing.DatagramPacket:
+		// Faithful-UDP relay (#2607): re-stamp the next-hop route ID and pass
+		// the opaque (AEAD-sealed) payload through unchanged — intermediaries
+		// never decrypt, the seal is end-to-end.
+		var err error
+		p, err = routing.MakeDatagramPacket(rule.NextRouteID(), packet.Payload())
+		if err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("packet of type %s can't be forwarded", packet.Type())
 	}

--- a/pkg/router/router_rules.go
+++ b/pkg/router/router_rules.go
@@ -141,6 +141,45 @@ func (r *router) removeNoiseRouteGroup(desc routing.RouteDescriptor) {
 	delete(r.rgsNs, desc)
 }
 
+// datagramRouteGroup returns the faithful-UDP route group registered for desc,
+// if any. Mirrors noiseRouteGroup; the datagram groups live in their own map so
+// a DatagramPacket is never confused with a reliable RouteGroup keyed by the
+// same descriptor. #2607 stage-4 dispatch.
+func (r *router) datagramRouteGroup(desc routing.RouteDescriptor) (*DatagramRouteGroup, bool) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+
+	dg, ok := r.rgsDatagrams[desc]
+
+	return dg, ok
+}
+
+// setDatagramRouteGroup registers (or replaces) the datagram route group for
+// desc. A pre-existing group for the same descriptor is closed first so a
+// re-dial doesn't leak the old pump. Called by the route-setup integration once
+// it constructs a DatagramRouteGroup.
+func (r *router) setDatagramRouteGroup(desc routing.RouteDescriptor, dg *DatagramRouteGroup) {
+	r.mx.Lock()
+	old, ok := r.rgsDatagrams[desc]
+	r.rgsDatagrams[desc] = dg
+	r.mx.Unlock()
+
+	if ok && old != nil && old != dg {
+		if err := old.Close(); err != nil {
+			r.logger.WithError(err).Debugf("Failed to close replaced datagram route group %s", desc.String())
+		}
+	}
+}
+
+// removeDatagramRouteGroup de-registers the datagram route group for desc. The
+// caller owns closing the group; this only drops the dispatch mapping.
+func (r *router) removeDatagramRouteGroup(desc routing.RouteDescriptor) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+
+	delete(r.rgsDatagrams, desc)
+}
+
 func (r *router) IntroduceRules(rules routing.EdgeRules) error {
 	// Save rules immediately to avoid race with incoming transport packets
 	if err := r.SaveRoutingRules(rules.Forward, rules.Reverse); err != nil {


### PR DESCRIPTION
## Summary
The faithful-UDP stack (#2607) shipped its **components** across 5 merged PRs — `DatagramPacket` wire type (#2609), `DatagramRouteGroup` (#2610), per-datagram AEAD (#2612), `UDPBridge` + appnet `DialPacket` API (#2613/#2614) — but the **router-side dispatch was never wired**. A `DatagramPacket` arriving off a transport fell through `handleTransportPacket`'s switch to `ErrUnknownPacketType` and was **dropped**, leaving the unit-tested `DatagramRouteGroup.Handle` unreachable in a running visor.

This PR wires the **receive + relay** path (stage-4a):

- **Storage**: router gains an `rgsDatagrams` map (keyed like `rgsNs`) + `datagramRouteGroup` / `setDatagramRouteGroup` / `removeDatagramRouteGroup` accessors. Datagram groups live in their own map so a `DatagramPacket` is never confused with a reliable `RouteGroup` on the same descriptor.
- **Dispatch**: `handleTransportPacket` routes `DatagramPacket` → `handleDatagramPacket`:
  - intermediary/forward rule → relay to next hop;
  - consume rule → deliver to the registered `DatagramRouteGroup.Handle`;
  - **no parking** — a datagram that races route-group registration is dropped (faithful-UDP loss tolerance), unlike the reliable path which parks handshake frames;
  - a closed group de-registers itself.
- **Forward**: `forwardPacket` relays `DatagramPacket` — re-stamp the next-hop route ID, pass the opaque AEAD-sealed payload through unchanged (the seal is end-to-end; intermediaries never decrypt).

## Safety
**Inert in production**: nothing emits a `DatagramPacket` yet (route-setup construction is the stacked follow-up, stage-4b), so this is purely additive and does not change any existing routing behavior. Build / `go vet` / `golangci-lint` / unit tests all green.

## Tests
New `datagram_dispatch_test.go` drives real `DatagramPacket`s through `handleTransportPacket` (not `Handle` directly): deliver-to-registered-group, drop-when-unregistered, unknown-route-errors, closed-group-deregisters.

## Follow-up (stacked)
Stage-4b: datagram route-setup (one-time Noise KK handshake → HKDF master key → per-datagram AEAD) + `SkywireNetworker.PacketNetworker` + `NewUDPBridge` wiring for `forwarded_ports.udp`.