### PR TITLE
feat(router): build the faithful-UDP datagram sibling during route setup (#2607 stage-4b)

### DIFF
--- a/pkg/dmsg/noise/net.go
+++ b/pkg/dmsg/noise/net.go
@@ -185,6 +185,13 @@ func (c *Conn) Write(b []byte) (int, error) {
 	return c.ns.Write(b)
 }
 
+// ChannelBinding returns the completed handshake's channel binding — see
+// Noise.ChannelBinding. Lets a caller key a sibling channel (e.g. the
+// faithful-UDP datagram route, #2607) off this encrypted route's session.
+func (c *Conn) ChannelBinding() []byte {
+	return c.ns.ChannelBinding()
+}
+
 // LocalAddr returns the local address of the connection.
 func (c *Conn) LocalAddr() net.Addr {
 	return &Addr{

--- a/pkg/dmsg/noise/noise.go
+++ b/pkg/dmsg/noise/noise.go
@@ -281,6 +281,20 @@ func (ns *Noise) HandshakeFinished() bool {
 	return ns.hs.MessageIndex() == len(ns.pattern.Messages)
 }
 
+// ChannelBinding returns a value that uniquely identifies the completed
+// handshake session — the Noise handshake hash. Both peers derive an identical
+// value, and it is bound to the full transcript (static keys + ephemerals + any
+// PQ hybrid payload), so it is safe to use as keying material for a sibling
+// channel keyed off the same session. The faithful-UDP path (#2607) HKDFs this
+// into a per-datagram AEAD master key so the datagram sibling of a route shares
+// the reliable route's authenticated session without a second handshake.
+//
+// Only meaningful once HandshakeFinished() is true; before that the binding is
+// still over a partial transcript.
+func (ns *Noise) ChannelBinding() []byte {
+	return ns.hs.ChannelBinding()
+}
+
 // LocalStatic returns the local static public key.
 func (ns *Noise) LocalStatic() cipher.PubKey {
 	return ns.pk

--- a/pkg/dmsg/noise/read_writer.go
+++ b/pkg/dmsg/noise/read_writer.go
@@ -224,6 +224,12 @@ func (rw *ReadWriter) RemoteStatic() cipher.PubKey {
 	return rw.ns.RemoteStatic()
 }
 
+// ChannelBinding returns the completed handshake's channel binding — see
+// Noise.ChannelBinding. Meaningful only after Handshake has returned.
+func (rw *ReadWriter) ChannelBinding() []byte {
+	return rw.ns.ChannelBinding()
+}
+
 // InitiatorHandshake performs a noise handshake as an initiator.
 func InitiatorHandshake(ns *Noise, r *bufio.Reader, w io.Writer) error {
 	for {

--- a/pkg/router/datagram_keys.go
+++ b/pkg/router/datagram_keys.go
@@ -1,0 +1,57 @@
+// Package router pkg/router/datagram_keys.go: derivation of the
+// faithful-UDP per-datagram AEAD master key from a route's Noise
+// session. Stage 4b of #2607.
+//
+// The datagram path deliberately has no stream-Noise channel of its
+// own (per-datagram AEAD replaces the continuous keystream). Rather
+// than run a second handshake, the datagram sibling of a route keys
+// itself off the reliable route's *already-completed* Noise session:
+// both peers take the session's ChannelBinding (the Noise handshake
+// hash — identical on both ends, bound to the full transcript incl.
+// any PQ-hybrid payload) and HKDF-expand it into a shared 32-byte
+// master key. NewDatagramCipher then expands that master, per
+// direction, into the actual ChaCha20-Poly1305 subkeys.
+//
+// Domain separation: this derivation uses info label
+// "skywire-datagram-master-v1", distinct from the per-direction
+// labels NewDatagramCipher uses ("skywire-datagram-v1-init/-resp"),
+// so the master and the direction subkeys can never collide even
+// though both HKDF off related material.
+package router
+
+import (
+	"crypto/sha256"
+	"errors"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// datagramMasterKeyInfo domain-separates the master-key derivation
+// from the per-direction subkey expansion in datagram_crypto.go.
+var datagramMasterKeyInfo = []byte("skywire-datagram-master-v1")
+
+// errEmptyChannelBinding is returned when the caller passes a
+// zero-length channel binding — a sign the Noise handshake hadn't
+// finished, which must never reach key derivation.
+var errEmptyChannelBinding = errors.New("datagram-keys: empty channel binding (handshake not finished?)")
+
+// deriveDatagramMasterKey turns a route's Noise session ChannelBinding
+// into the 32-byte master key consumed by NewDatagramCipher. Both
+// peers of a route derive an identical key because ChannelBinding is
+// identical on both ends.
+//
+// The caller MUST pass a binding from a *finished* handshake
+// (noise.Noise.HandshakeFinished() == true); a partial-transcript
+// binding would derive a key the peer can't reproduce.
+func deriveDatagramMasterKey(channelBinding []byte) ([32]byte, error) {
+	var master [32]byte
+	if len(channelBinding) == 0 {
+		return master, errEmptyChannelBinding
+	}
+	h := hkdf.New(sha256.New, channelBinding, nil, datagramMasterKeyInfo)
+	if _, err := io.ReadFull(h, master[:]); err != nil {
+		return master, err
+	}
+	return master, nil
+}

--- a/pkg/router/datagram_keys_test.go
+++ b/pkg/router/datagram_keys_test.go
@@ -1,0 +1,75 @@
+// Package router pkg/router/datagram_keys_test.go: tests for the
+// faithful-UDP master-key derivation (#2607 stage-4b).
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestDeriveDatagramMasterKeyDeterministic verifies both peers derive
+// the SAME master key from the SAME channel binding — the property the
+// whole keyless-second-handshake design relies on.
+func TestDeriveDatagramMasterKeyDeterministic(t *testing.T) {
+	cb := []byte("a-noise-channel-binding-32-bytes!!") // stand-in transcript hash
+	k1, err := deriveDatagramMasterKey(cb)
+	require.NoError(t, err)
+	k2, err := deriveDatagramMasterKey(cb)
+	require.NoError(t, err)
+	assert.Equal(t, k1, k2, "same channel binding must derive the same master key")
+	assert.NotEqual(t, [32]byte{}, k1, "derived key must not be all-zero")
+}
+
+// TestDeriveDatagramMasterKeyDistinctPerSession verifies different
+// sessions (different bindings) derive different keys.
+func TestDeriveDatagramMasterKeyDistinctPerSession(t *testing.T) {
+	k1, err := deriveDatagramMasterKey([]byte("session-one-binding"))
+	require.NoError(t, err)
+	k2, err := deriveDatagramMasterKey([]byte("session-two-binding"))
+	require.NoError(t, err)
+	assert.NotEqual(t, k1, k2, "distinct sessions must derive distinct master keys")
+}
+
+// TestDeriveDatagramMasterKeyEmptyRejected guards the handshake-not-
+// finished footgun.
+func TestDeriveDatagramMasterKeyEmptyRejected(t *testing.T) {
+	_, err := deriveDatagramMasterKey(nil)
+	require.ErrorIs(t, err, errEmptyChannelBinding)
+	_, err = deriveDatagramMasterKey([]byte{})
+	require.ErrorIs(t, err, errEmptyChannelBinding)
+}
+
+// TestDeriveDatagramMasterKeyFeedsCipherRoundTrip is the end-to-end
+// property that matters: a master key derived from a shared binding,
+// fed to NewDatagramCipher on each side with opposite roles, produces
+// ciphers that interoperate — initiator seals, responder opens.
+func TestDeriveDatagramMasterKeyFeedsCipherRoundTrip(t *testing.T) {
+	cb := []byte("shared-noise-session-transcript-hash")
+	master, err := deriveDatagramMasterKey(cb)
+	require.NoError(t, err)
+
+	// The receiver in this exchange is the responder; its PK is the AAD
+	// binding on both the initiator's out-cipher and the responder's
+	// in-cipher (AAD binds to the *receiver*).
+	respPK, _ := cipher.GenerateKeyPair()
+
+	// Initiator's outbound cipher (init-direction subkey, AAD=receiver).
+	initOut, err := NewDatagramCipher(master, RoleInitiator, respPK, nil)
+	require.NoError(t, err)
+	// Responder's inbound cipher opens what the initiator sealed: same
+	// init-direction subkey, same AAD binding PK (the receiver).
+	respIn, err := NewDatagramCipher(master, RoleInitiator, respPK, nil)
+	require.NoError(t, err)
+
+	const routeID = uint32(7)
+	plaintext := []byte("voip-frame")
+	sealed, err := initOut.Seal(routeID, plaintext)
+	require.NoError(t, err)
+	opened, err := respIn.Open(routeID, sealed)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, opened)
+}

--- a/pkg/router/datagram_setup.go
+++ b/pkg/router/datagram_setup.go
@@ -1,0 +1,141 @@
+// Package router pkg/router/datagram_setup.go: route-setup-side
+// construction of the faithful-UDP DatagramRouteGroup sibling. Stage
+// 4b of #2607.
+//
+// A datagram route is NOT a separate route. The reliable route is set
+// up exactly as usual (saveRouteGroupRules: rules + transport +
+// one-time Noise KK handshake → RouteGroup in rgsNs). When BOTH ends
+// locally intend datagram mode for the route, each additionally builds
+// a DatagramRouteGroup over the *same* forward/reverse rules and
+// transport, keyed off the reliable session's ChannelBinding — no
+// second handshake. DataPackets then flow through the reliable group,
+// DatagramPackets through the sibling, dispatched by packet type
+// (router_packet.go).
+//
+// "Both ends locally intend it" (on-demand-by-local-intent, not a wire
+// negotiation):
+//   - dial side: DialOptions.Datagram (the DialPacket / forwarded-UDP
+//     dialer sets it);
+//   - accept side: RegisterDatagramPort marks the local serving port
+//     (a forwarded_ports.udp port, or a packet-mode app listener).
+//
+// If only one side intends it, that side's sibling exists but the peer
+// drops its DatagramPackets — no reliable traffic is affected.
+package router
+
+import (
+	"net"
+
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// channelBinder is satisfied by the Noise-encrypted conn returned by
+// network.EncryptConn (concrete *noise.Conn). It exposes the completed
+// handshake's channel binding so the datagram sibling can key off the
+// reliable session without a second handshake.
+type channelBinder interface {
+	ChannelBinding() []byte
+}
+
+// RegisterDatagramPort marks a local port as faithful-UDP-capable, so
+// the accept side builds a DatagramRouteGroup sibling for routes whose
+// local (destination) port is this one. Idempotent. Call when binding
+// a forwarded_ports.udp port or a packet-mode app listener; pair with
+// UnregisterDatagramPort on teardown.
+func (r *router) RegisterDatagramPort(port routing.Port) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	r.datagramPorts[port] = struct{}{}
+}
+
+// UnregisterDatagramPort clears a port's faithful-UDP intent.
+func (r *router) UnregisterDatagramPort(port routing.Port) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	delete(r.datagramPorts, port)
+}
+
+// isDatagramPort reports whether port carries faithful-UDP intent.
+func (r *router) isDatagramPort(port routing.Port) bool {
+	r.mx.Lock()
+	defer r.mx.Unlock()
+	_, ok := r.datagramPorts[port]
+	return ok
+}
+
+// closeDatagramSibling closes + de-registers the datagram route group for
+// desc, if one exists. The sibling's lifetime is coupled to the reliable
+// route's: it has no keep-alive of its own (a receive-only datagram group
+// never writes, so it can't detect a dead route), so it must be reaped
+// whenever the reliable route for the same descriptor is torn down — the
+// close-packet path and the GC. Safe to call when no sibling exists.
+func (r *router) closeDatagramSibling(desc routing.RouteDescriptor) {
+	r.mx.Lock()
+	dg, ok := r.rgsDatagrams[desc]
+	if ok {
+		delete(r.rgsDatagrams, desc)
+	}
+	r.mx.Unlock()
+	if ok && dg != nil {
+		dg.Close() //nolint:errcheck,gosec // idempotent, always returns nil
+	}
+}
+
+// buildDatagramSibling constructs + registers a DatagramRouteGroup over
+// the same rules/transport as the just-established reliable route,
+// keyed off the reliable session's ChannelBinding. Best-effort: any
+// failure (no channel binding because the route is unencrypted, key
+// derivation, cipher construction) logs and returns without a sibling —
+// the reliable route is unaffected, and a missing sibling just means
+// datagrams for this route are dropped (faithful-UDP loss tolerance).
+//
+// wrapped is the encrypted conn from network.EncryptConn (nrg.Conn on
+// the encrypt path). tp is the first-hop transport for the route.
+func (r *router) buildDatagramSibling(rules routing.EdgeRules, nsConf noise.Config, wrapped net.Conn, tp *transport.ManagedTransport) {
+	binder, ok := wrapped.(channelBinder)
+	if !ok {
+		// Unencrypted route (legacy/no-noise) — the datagram AEAD has
+		// no key to derive. Modern visors always encrypt, so this is a
+		// genuine skip, not a downgrade.
+		r.logger.WithField("desc", rules.Desc.String()).
+			Warn("datagram sibling requested but route is not noise-encrypted; skipping")
+		return
+	}
+	master, err := deriveDatagramMasterKey(binder.ChannelBinding())
+	if err != nil {
+		r.logger.WithError(err).WithField("desc", rules.Desc.String()).
+			Warn("datagram sibling: master-key derivation failed; skipping")
+		return
+	}
+
+	// Direction keying: my outbound cipher uses my role's subkey and
+	// binds AAD to the receiver (the remote); my inbound cipher uses
+	// the peer's role subkey and binds AAD to the receiver (me). See
+	// datagram_keys_test.go for the round-trip invariant.
+	myRole, peerRole := RoleResponder, RoleInitiator
+	if nsConf.Initiator {
+		myRole, peerRole = RoleInitiator, RoleResponder
+	}
+	outCipher, err := NewDatagramCipher(master, myRole, nsConf.RemotePK, nil)
+	if err != nil {
+		r.logger.WithError(err).WithField("desc", rules.Desc.String()).
+			Warn("datagram sibling: out-cipher construction failed; skipping")
+		return
+	}
+	inCipher, err := NewDatagramCipher(master, peerRole, nsConf.LocalPK, nil)
+	if err != nil {
+		r.logger.WithError(err).WithField("desc", rules.Desc.String()).
+			Warn("datagram sibling: in-cipher construction failed; skipping")
+		return
+	}
+
+	dg := NewDatagramRouteGroup(DefaultRouteGroupConfig(), r.rt, rules.Desc, r.mLogger)
+	dg.AddRule(rules.Forward, tp, rules.Reverse)
+	dg.SetCiphers(outCipher, inCipher)
+	r.setDatagramRouteGroup(rules.Desc, dg)
+
+	r.logger.WithField("desc", rules.Desc.String()).
+		Debugf("datagram sibling registered (role=%d)", myRole)
+}

--- a/pkg/router/datagram_setup_test.go
+++ b/pkg/router/datagram_setup_test.go
@@ -1,0 +1,121 @@
+// Package router pkg/router/datagram_setup_test.go: integration test
+// for the route-setup-side datagram sibling (#2607 stage-4b). Verifies
+// the receive path end to end WITH crypto: a datagram sealed by an
+// initiator-side cipher (same master key, derived from the shared
+// channel binding) flows through the responder's handleTransportPacket
+// and is decrypted by the in-cipher that buildDatagramSibling installed.
+package router
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/noise"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// fakeBinderConn is a net.Conn that only implements ChannelBinding —
+// stands in for the *noise.Conn that network.EncryptConn returns.
+type fakeBinderConn struct {
+	net.Conn
+	cb []byte
+}
+
+func (f fakeBinderConn) ChannelBinding() []byte { return f.cb }
+
+func TestBuildDatagramSiblingReceivePathWithCrypto(t *testing.T) {
+	r := newDispatchTestRouter()
+	r.datagramPorts = make(map[routing.Port]struct{})
+
+	// Responder identity (this router) + remote initiator identity.
+	respPK, respSK := cipher.GenerateKeyPair()
+	initPK, _ := cipher.GenerateKeyPair()
+
+	keyRouteID := routing.RouteID(55)
+	consume := routing.ConsumeRule(time.Hour, keyRouteID, respPK, initPK, 10, 20)
+	require.NoError(t, r.rt.SaveRule(consume))
+	desc := consume.RouteDescriptor()
+
+	// Build the responder's datagram sibling exactly as saveRouteGroupRules
+	// would on the accept side: Initiator=false, keyed off the shared
+	// channel binding via a fake encrypted conn.
+	binding := []byte("a-shared-noise-session-channel-binding")
+	nsConf := noise.Config{LocalPK: respPK, LocalSK: respSK, RemotePK: initPK, Initiator: false}
+	rules := routing.EdgeRules{Desc: desc, Forward: consume, Reverse: consume}
+	r.buildDatagramSibling(rules, nsConf, fakeBinderConn{cb: binding}, nil)
+
+	dg, ok := r.datagramRouteGroup(desc)
+	require.True(t, ok, "buildDatagramSibling must register a datagram route group")
+	require.NotNil(t, dg)
+
+	// Initiator side: derive the SAME master key from the SAME binding,
+	// seal a payload with the initiator-direction cipher bound to the
+	// receiver (responder) PK — mirroring what the initiator's
+	// DatagramRouteGroup.WriteTo does.
+	master, err := deriveDatagramMasterKey(binding)
+	require.NoError(t, err)
+	initOut, err := NewDatagramCipher(master, RoleInitiator, respPK, nil)
+	require.NoError(t, err)
+
+	payload := []byte("udp-voice-frame")
+	sealed, err := initOut.Seal(uint32(keyRouteID), payload)
+	require.NoError(t, err)
+
+	pkt, err := routing.MakeDatagramPacket(keyRouteID, sealed)
+	require.NoError(t, err)
+
+	// Drive it through the real dispatch.
+	require.NoError(t, r.handleTransportPacket(context.Background(), pkt))
+
+	// The sibling decrypted + delivered the original plaintext.
+	require.NoError(t, dg.SetReadDeadline(time.Now().Add(2*time.Second)))
+	buf := make([]byte, 1500)
+	n, _, err := dg.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, buf[:n])
+	assert.Zero(t, dg.AEADAuthFailures(), "no auth failures for a correctly-sealed datagram")
+}
+
+// TestBuildDatagramSiblingSkipsUnencrypted verifies a route whose conn
+// exposes no channel binding (unencrypted/legacy) gets NO sibling —
+// the datagram AEAD has no key to derive, so it must skip rather than
+// register a keyless group.
+func TestBuildDatagramSiblingSkipsUnencrypted(t *testing.T) {
+	r := newDispatchTestRouter()
+	r.datagramPorts = make(map[routing.Port]struct{})
+
+	respPK, respSK := cipher.GenerateKeyPair()
+	initPK, _ := cipher.GenerateKeyPair()
+	consume := routing.ConsumeRule(time.Hour, routing.RouteID(1), respPK, initPK, 1, 2)
+	desc := consume.RouteDescriptor()
+	nsConf := noise.Config{LocalPK: respPK, LocalSK: respSK, RemotePK: initPK, Initiator: false}
+	rules := routing.EdgeRules{Desc: desc, Forward: consume, Reverse: consume}
+
+	// A plain net.Conn (no ChannelBinding) — e.g. an unencrypted route.
+	r.buildDatagramSibling(rules, nsConf, fakeNoBinderConn{}, nil)
+
+	_, ok := r.datagramRouteGroup(desc)
+	assert.False(t, ok, "no sibling should be registered for an unencrypted route")
+}
+
+// fakeNoBinderConn is a net.Conn with no ChannelBinding method.
+type fakeNoBinderConn struct{ net.Conn }
+
+// TestDatagramPortRegistry covers the accept-side intent registry.
+func TestDatagramPortRegistry(t *testing.T) {
+	r := newDispatchTestRouter()
+	r.datagramPorts = make(map[routing.Port]struct{})
+
+	assert.False(t, r.isDatagramPort(80))
+	r.RegisterDatagramPort(80)
+	assert.True(t, r.isDatagramPort(80))
+	assert.False(t, r.isDatagramPort(81))
+	r.UnregisterDatagramPort(80)
+	assert.False(t, r.isDatagramPort(80))
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -154,6 +154,15 @@ type DialOptions struct {
 	ReverseHops           []routing.Hop // If set, use these hops for reverse path (skips route calculation)
 	MuxRoutes             int           // Number of parallel routes to establish (0 or 1 = single route, >1 = mux)
 	ExcludeTransportIDs   []uuid.UUID   // Transport IDs to exclude from route calculation (for mux)
+	// Datagram, when true, asks the dial to build a faithful-UDP
+	// DatagramRouteGroup sibling over the established route (#2607).
+	// The route's reliable RouteGroup is still set up exactly as
+	// usual (and is what carries the one-time Noise handshake whose
+	// ChannelBinding keys the datagram AEAD); the datagram sibling is
+	// built alongside it once the handshake completes. The accept
+	// side opts in independently via RegisterDatagramPort — both ends
+	// must locally intend datagram mode for it to work.
+	Datagram bool
 	// MinHops, when > 0, is the per-call minimum hop count constraint.
 	// Overrides Config.MinHops for this dial only — needed by callers
 	// that want a non-direct path even when the visor's global
@@ -411,6 +420,7 @@ type router struct {
 	rgsNs              map[routing.RouteDescriptor]*NoiseRouteGroup    // Noise-wrapped route groups to push incoming reads from transports.
 	rgsRaw             map[routing.RouteDescriptor]*RouteGroup         // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
 	rgsDatagrams       map[routing.RouteDescriptor]*DatagramRouteGroup // faithful-UDP (DatagramPacket) route groups, keyed like rgsNs; #2607 stage-4 dispatch
+	datagramPorts      map[routing.Port]struct{}                       // local ports with faithful-UDP intent; the accept side builds a datagram sibling only for these (#2607 on-demand-by-local-intent)
 	pending            *pendingPackets                                 // frames parked during the rule-save -> route-group-register window (see router_pending.go)
 	rpcSrv             *rpc.Server
 	accept             chan routing.EdgeRules
@@ -492,6 +502,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		rgsNs:           make(map[routing.RouteDescriptor]*NoiseRouteGroup),
 		rgsRaw:          make(map[routing.RouteDescriptor]*RouteGroup),
 		rgsDatagrams:    make(map[routing.RouteDescriptor]*DatagramRouteGroup),
+		datagramPorts:   make(map[routing.Port]struct{}),
 		pending:         newPendingPackets(),
 		rpcSrv:          rpc.NewServer(),
 		accept:          make(chan routing.EdgeRules, acceptSize),

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -270,10 +270,12 @@ func (r *router) DialRoutes(
 		}
 
 		appName := ""
+		datagram := false
 		if opts != nil {
 			appName = opts.AppName
+			datagram = opts.Datagram
 		}
-		nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, appName)
+		nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, appName, datagram)
 		if err != nil {
 			// Clean up saved rules on failure
 			r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
@@ -463,10 +465,12 @@ func (r *router) setupPingRoute(
 	}
 
 	appName := ""
+	datagram := false
 	if opts != nil {
 		appName = opts.AppName
+		datagram = opts.Datagram
 	}
-	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, appName)
+	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, appName, datagram)
 	if err != nil {
 		// Clean up saved rules if route group setup fails
 		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})

--- a/pkg/router/router_gc.go
+++ b/pkg/router/router_gc.go
@@ -58,11 +58,25 @@ func (r *router) sweepClosedRouteGroups() {
 	for desc, nrg := range r.rgsNs {
 		if nrg == nil || nrg.isClosed() {
 			delete(r.rgsNs, desc)
+			// Couple the faithful-UDP sibling's lifetime to the reliable
+			// route (#2607): when the reliable group is reaped, reap its
+			// datagram sibling too. dg.Close is independent of r.mx.
+			if dg := r.rgsDatagrams[desc]; dg != nil {
+				delete(r.rgsDatagrams, desc)
+				dg.Close() //nolint:errcheck,gosec // idempotent, always returns nil
+			}
 		}
 	}
 	for desc, rg := range r.rgsRaw {
 		if rg == nil || rg.isClosed() {
 			delete(r.rgsRaw, desc)
+		}
+	}
+	// Defensive: drop any datagram sibling that closed itself
+	// (e.g. consecutive write failures tripped its IsAlive threshold).
+	for desc, dg := range r.rgsDatagrams {
+		if dg == nil || dg.isClosed() {
+			delete(r.rgsDatagrams, desc)
 		}
 	}
 }
@@ -84,6 +98,10 @@ func (r *router) removeRouteGroupOfRule(rule routing.Rule) {
 	rDesc := rule.RouteDescriptor()
 	log.WithField("rt_desc", rDesc.String()).
 		Debug("Closing route group associated with rule...")
+
+	// Reap the faithful-UDP sibling (if any) with the reliable route (#2607);
+	// fires on every return path below. No-op when no sibling exists.
+	defer r.closeDatagramSibling(rDesc)
 
 	// First try noise-wrapped route groups (fully initialized)
 	nrg, ok := r.popNoiseRouteGroup(rDesc)

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -179,6 +179,8 @@ func (r *router) handleClosePacket(ctx context.Context, packet routing.Packet) e
 	}
 
 	defer r.removeNoiseRouteGroup(desc)
+	// Reap the faithful-UDP sibling (if any) with the reliable route (#2607).
+	defer r.closeDatagramSibling(desc)
 
 	if nrg == nil {
 		return errNilNoiseRG

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -57,7 +57,10 @@ func (r *router) AcceptRoutes(ctx context.Context) (net.Conn, error) {
 	}
 
 	// IntroduceRules / accepted-route path: no app context to thread.
-	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, "")
+	// Accept-side datagram intent comes from the local serving port
+	// being registered as faithful-UDP-capable (RegisterDatagramPort).
+	datagram := r.isDatagramPort(rules.Desc.DstPort())
+	nrg, err := r.saveRouteGroupRules(ctx, rules, nsConf, "", datagram)
 	if err != nil {
 		// Clean up saved rules if route group setup fails
 		r.rt.DelRules([]routing.RouteID{rules.Forward.KeyRouteID(), rules.Reverse.KeyRouteID()})
@@ -197,7 +200,7 @@ func (r *router) serveSetup() {
 // nolint: gocyclo
 //
 //gocyclo:ignore
-func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRules, nsConf noise.Config, appName string) (*NoiseRouteGroup, error) {
+func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRules, nsConf noise.Config, appName string, datagram bool) (*NoiseRouteGroup, error) {
 	// Check context before starting
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -393,6 +396,14 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	r.rgsNs[rules.Desc] = nrg
 	delete(r.rgsRaw, rules.Desc)
 	r.mx.Unlock()
+
+	// Faithful-UDP (#2607): when this end intends datagram mode for the
+	// route, build a DatagramRouteGroup sibling over the same rules +
+	// transport, keyed off the reliable session's Noise ChannelBinding.
+	// Best-effort and additive — never affects the reliable route.
+	if datagram {
+		r.buildDatagramSibling(rules, nsConf, nrg.Conn, tp)
+	}
 
 	return nrg, nil
 }


### PR DESCRIPTION
Stacked on #3183 (now merged). With dispatch wired, route setup can now construct the `DatagramRouteGroup` so datagrams actually flow.

## Design
A datagram route is **not** a separate route. The reliable route is set up exactly as usual (Noise KK handshake → `RouteGroup`); when both ends locally intend datagram mode, each additionally builds a `DatagramRouteGroup` sibling over the **same** rules/transport, keyed off the reliable session — no second handshake.

## Key exchange — one-time Noise → HKDF
- `dmsg/noise`: export `Noise.ChannelBinding()` (already used internally for the PQ-hybrid binding) and delegate it through `ReadWriter`/`Conn`, so `network.EncryptConn`'s returned conn exposes the session binding.
- `router.deriveDatagramMasterKey(binding)`: HKDF-SHA256 the binding into the 32-byte master both peers feed to `NewDatagramCipher` (domain-separated from the per-direction subkey labels). Identical binding on both ends → identical key.

## On-demand by LOCAL intent (no wire negotiation)
- **dial side**: `DialOptions.Datagram` (set by the `DialPacket` / forwarded-UDP dialer);
- **accept side**: `RegisterDatagramPort` marks the local serving port.

`saveRouteGroupRules` gains a `datagram bool`; on the encrypt path it calls `buildDatagramSibling` → derive master → build the out/in cipher pair (AAD binds to the **receiver's** PK; verified by a seal→dispatch→open round-trip) → register the sibling. Best-effort: any failure logs + skips, never touching the reliable route.

*(Auto-every-route was considered and rejected — it would tax every route with ~25 KB + rekey bookkeeping + an undrained-buffer injection sink for a niche feature. On-demand gets "zero signaling" for the real entry points anyway since both ends know from local config.)*

## Lifetime
The sibling has no keep-alive of its own (a receive-only group never writes), so it's coupled to the reliable route — `closeDatagramSibling` reaps it from the close-packet path, `removeRouteGroupOfRule`, and the GC sweep (+ a defensive self-closed sweep).

## Safety
Still **inert end to end** until stage-4c wires `SkywireNetworker.PacketNetworker` + the forwarded-ports UDP listener loop (`NewUDPBridge`) + `RegisterDatagramPort`. `datagram` defaults false everywhere, so `buildDatagramSibling` is never invoked yet — reliable routing is unchanged. The `saveRouteGroupRules` signature + dial-site edits ARE in the hot path, guarded by the passing dial/serve/handshake router suite.

## Tests
Master-key determinism/interop, port registry, and a full seal→`handleTransportPacket`→AEAD-open→`ReadFrom` round-trip. Build/vet/lint green; full router suite passes.

## Follow-up
Stage-4c (app path): `DialPacketContext` returning the sibling + forwarded-ports UDP listener loop + two-visor UDP-echo live validation.