### PR TITLE
feat(visor): wire faithful-UDP app + forwarded-ports paths end to end (#2607 stage-4c)

### DIFF
--- a/pkg/app/appnet/skywire_networker.go
+++ b/pkg/app/appnet/skywire_networker.go
@@ -142,6 +142,81 @@ func (r *SkywireNetworker) DialContextWithOptions(ctx context.Context, addr Addr
 	}, nil
 }
 
+// DialPacketContext implements PacketNetworker — it opens a faithful-UDP
+// (#2607) datagram conn to addr. The dial goes through route setup with
+// Datagram intent, which builds a DatagramRouteGroup sibling over the
+// reliable route; the returned conn wraps that sibling and keeps the
+// reliable route alive (closing the packet conn tears the route down and
+// frees the local port).
+//
+// The remote port must also be in datagram mode (the accept side must
+// have called RegisterDatagramPort) or the dial fails — both ends opt in
+// locally, there is no wire negotiation.
+func (r *SkywireNetworker) DialPacketContext(ctx context.Context, addr Addr) (_ DatagramPacketConn, err error) {
+	localPort, freePort, err := r.porter.ReserveEphemeral(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			freePort()
+		}
+	}()
+
+	opts := router.DefaultDialOptions()
+	opts.AppName = AppNameFromContext(ctx)
+	// Datagram routes go through route setup (the sibling is built in
+	// saveRouteGroupRules). The AppDirectMux shortcut + mux fan-out are
+	// not supported for datagrams yet, so don't take the direct path and
+	// leave MuxRoutes at its single-route default. DialRoutesDatagram
+	// forces opts.Datagram = true.
+
+	reliable, dg, err := r.r.DialRoutesDatagram(ctx, addr.PubKey, routing.Port(localPort), addr.Port, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &skywirePacketConn{
+		DatagramRouteGroup: dg,
+		reliable:           reliable,
+		freePort:           freePort,
+	}, nil
+}
+
+// skywirePacketConn is the faithful-UDP conn handed to apps via
+// DialPacket. It IS the DatagramRouteGroup (ReadFrom/WriteTo/MaxPayload/
+// InboundDropped/AEADAuthFailures all promoted) but owns two extra
+// resources whose lifetimes are tied to it: the reliable route the
+// sibling rides on, and the reserved local port.
+type skywirePacketConn struct {
+	*router.DatagramRouteGroup
+	reliable  net.Conn
+	freePort  func()
+	closeOnce sync.Once
+}
+
+// Close tears the whole datagram conn down: the sibling, then the
+// reliable route (whose ClosePacket reaps the peer's sibling too), then
+// the local port. Idempotent.
+func (c *skywirePacketConn) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		dErr := c.DatagramRouteGroup.Close()
+		rErr := c.reliable.Close()
+		c.freePort()
+		if rErr != nil {
+			err = rErr
+			return
+		}
+		err = dErr
+	})
+	return err
+}
+
+// compile-time check that the wrapper still satisfies the app-facing
+// datagram contract after overriding Close.
+var _ DatagramPacketConn = (*skywirePacketConn)(nil)
+
 // tryDirectDial attempts to dial `addr` via the AppDirectMux. Returns
 // (conn, true) on success or (nil, false) on any failure — the caller
 // then falls back to the route-setup path. Any error is logged at

--- a/pkg/router/datagram_dispatch_test.go
+++ b/pkg/router/datagram_dispatch_test.go
@@ -25,9 +25,12 @@ import (
 // transport manager and is covered separately.
 func newDispatchTestRouter() *router {
 	return &router{
-		logger:       logging.MustGetLogger("test_dg_dispatch"),
-		rt:           routing.NewTable(logging.MustGetLogger("test_dg_rt")),
-		rgsDatagrams: make(map[routing.RouteDescriptor]*DatagramRouteGroup),
+		logger:         logging.MustGetLogger("test_dg_dispatch"),
+		rt:             routing.NewTable(logging.MustGetLogger("test_dg_rt")),
+		rgsDatagrams:   make(map[routing.RouteDescriptor]*DatagramRouteGroup),
+		datagramPorts:  make(map[routing.Port]struct{}),
+		acceptDatagram: make(chan datagramAccept, acceptDatagramBuf),
+		done:           make(chan struct{}),
 	}
 }
 

--- a/pkg/router/datagram_setup.go
+++ b/pkg/router/datagram_setup.go
@@ -24,12 +24,49 @@
 package router
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"net"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/noise"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/transport"
 )
+
+// DialRoutesDatagram implements Router. It dials a normal route with
+// opts.Datagram forced on — so saveRouteGroupRules builds a datagram
+// sibling alongside the reliable RouteGroup — then returns both the
+// reliable conn and the registered sibling. The caller MUST keep the
+// reliable conn alive for the sibling to function (the rules/transport
+// are shared; closing the reliable conn tears the route down and reaps
+// the sibling).
+func (r *router) DialRoutesDatagram(ctx context.Context, rPK cipher.PubKey, lPort, rPort routing.Port, opts *DialOptions) (net.Conn, *DatagramRouteGroup, error) {
+	if opts == nil {
+		opts = DefaultDialOptions()
+	}
+	opts.Datagram = true
+
+	conn, err := r.DialRoutes(ctx, rPK, lPort, rPort, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The sibling is keyed by the same descriptor the initiator's route
+	// uses: NewRouteDescriptor(localPK, rPK, lPort, rPort) — see the dial
+	// path's forwardDesc.
+	desc := routing.NewRouteDescriptor(r.conf.PubKey, rPK, lPort, rPort)
+	dg, ok := r.datagramRouteGroup(desc)
+	if !ok || dg == nil {
+		// Route came up reliably but the peer never registered datagram
+		// intent for rPort, so no sibling exists. Tear the route down — a
+		// datagram dial that can't carry datagrams is a failed dial.
+		conn.Close() //nolint:errcheck,gosec // tearing down on the error path
+		return nil, nil, fmt.Errorf("datagram: route to %s:%d established but peer registered no datagram sibling (is the remote port in datagram mode?)", rPK, rPort)
+	}
+	return conn, dg, nil
+}
 
 // channelBinder is satisfied by the Noise-encrypted conn returned by
 // network.EncryptConn (concrete *noise.Conn). It exposes the completed
@@ -37,6 +74,48 @@ import (
 // reliable session without a second handshake.
 type channelBinder interface {
 	ChannelBinding() []byte
+}
+
+// acceptDatagramBuf bounds the accept-side datagram backlog. A datagram
+// sibling that can't be queued (consumer not draining) is dropped — its
+// route still exists, the consumer just missed the accept; nothing on
+// the live network depends on a particular sibling being accepted.
+const acceptDatagramBuf = 64
+
+// datagramAccept pairs an accepted (accept-side) datagram sibling with
+// the local port the route targets, so the consumer (the forwarded-UDP
+// server loop) knows which local service to bridge it to.
+type datagramAccept struct {
+	dg      *DatagramRouteGroup
+	dstPort routing.Port
+}
+
+// AcceptDatagram blocks until a new accept-side datagram sibling is
+// available (built by saveRouteGroupRules for an inbound route whose
+// local port had datagram intent), or ctx is done. Returns the sibling
+// and the local port it targets. The forwarded_ports.udp server loop
+// drains this and bridges each sibling to its local UDP service.
+func (r *router) AcceptDatagram(ctx context.Context) (*DatagramRouteGroup, routing.Port, error) {
+	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	case <-r.done:
+		return nil, 0, io.ErrClosedPipe
+	case a := <-r.acceptDatagram:
+		return a.dg, a.dstPort, nil
+	}
+}
+
+// offerAcceptDatagram non-blockingly hands an accept-side sibling to the
+// consumer. Dropped (with a log) if the backlog is full — the route is
+// unaffected, only this accept notification is lost.
+func (r *router) offerAcceptDatagram(dg *DatagramRouteGroup, dstPort routing.Port) {
+	select {
+	case r.acceptDatagram <- datagramAccept{dg: dg, dstPort: dstPort}:
+	default:
+		r.logger.WithField("dst_port", dstPort).
+			Warn("datagram accept backlog full, dropping sibling notification")
+	}
 }
 
 // RegisterDatagramPort marks a local port as faithful-UDP-capable, so
@@ -138,4 +217,12 @@ func (r *router) buildDatagramSibling(rules routing.EdgeRules, nsConf noise.Conf
 
 	r.logger.WithField("desc", rules.Desc.String()).
 		Debugf("datagram sibling registered (role=%d)", myRole)
+
+	// Accept side: hand the sibling to the consumer (the forwarded-UDP
+	// server loop) so it can bridge it to the local service. The dial
+	// side keeps the sibling for itself (returned by DialRoutesDatagram),
+	// so it is NOT offered here.
+	if !nsConf.Initiator {
+		r.offerAcceptDatagram(dg, rules.Desc.DstPort())
+	}
 }

--- a/pkg/router/datagram_setup_test.go
+++ b/pkg/router/datagram_setup_test.go
@@ -110,7 +110,6 @@ type fakeNoBinderConn struct{ net.Conn }
 // TestDatagramPortRegistry covers the accept-side intent registry.
 func TestDatagramPortRegistry(t *testing.T) {
 	r := newDispatchTestRouter()
-	r.datagramPorts = make(map[routing.Port]struct{})
 
 	assert.False(t, r.isDatagramPort(80))
 	r.RegisterDatagramPort(80)
@@ -118,4 +117,39 @@ func TestDatagramPortRegistry(t *testing.T) {
 	assert.False(t, r.isDatagramPort(81))
 	r.UnregisterDatagramPort(80)
 	assert.False(t, r.isDatagramPort(80))
+}
+
+// TestBuildDatagramSiblingAcceptSideOffers verifies that an accept-side
+// sibling (Initiator=false) is handed to AcceptDatagram with the right
+// local port, while a dial-side sibling (Initiator=true) is NOT offered
+// (the dialer keeps it via DialRoutesDatagram).
+func TestBuildDatagramSiblingAcceptSideOffers(t *testing.T) {
+	r := newDispatchTestRouter()
+
+	localPK, localSK := cipher.GenerateKeyPair()
+	remotePK, _ := cipher.GenerateKeyPair()
+	binding := []byte("session-binding-for-accept-offer")
+
+	// Accept side: dst port 7777 is the local serving port.
+	consume := routing.ConsumeRule(time.Hour, routing.RouteID(3), localPK, remotePK, 1234, 7777)
+	desc := consume.RouteDescriptor()
+	acceptConf := noise.Config{LocalPK: localPK, LocalSK: localSK, RemotePK: remotePK, Initiator: false}
+	rules := routing.EdgeRules{Desc: desc, Forward: consume, Reverse: consume}
+	r.buildDatagramSibling(rules, acceptConf, fakeBinderConn{cb: binding}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	dg, dstPort, err := r.AcceptDatagram(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, dg)
+	assert.Equal(t, routing.Port(7777), dstPort, "accept must surface the local serving port")
+
+	// Dial side: same shape but Initiator=true must NOT offer.
+	dialConf := noise.Config{LocalPK: localPK, LocalSK: localSK, RemotePK: remotePK, Initiator: true}
+	r.buildDatagramSibling(rules, dialConf, fakeBinderConn{cb: binding}, nil)
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel2()
+	_, _, err = r.AcceptDatagram(ctx2)
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "dial-side sibling must not be offered to AcceptDatagram")
 }

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -120,6 +120,89 @@ func (_m *MockRouter) IntroduceRules(rules routing.EdgeRules) error {
 	return r0
 }
 
+// DialRoutesDatagram provides a mock function with given fields: ctx, rPK, lPort, rPort, opts
+func (_m *MockRouter) DialRoutesDatagram(ctx context.Context, rPK cipher.PubKey, lPort routing.Port, rPort routing.Port, opts *DialOptions) (net.Conn, *DatagramRouteGroup, error) {
+	ret := _m.Called(ctx, rPK, lPort, rPort, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DialRoutesDatagram")
+	}
+
+	var r0 net.Conn
+	var r1 *DatagramRouteGroup
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, cipher.PubKey, routing.Port, routing.Port, *DialOptions) (net.Conn, *DatagramRouteGroup, error)); ok {
+		return rf(ctx, rPK, lPort, rPort, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, cipher.PubKey, routing.Port, routing.Port, *DialOptions) net.Conn); ok {
+		r0 = rf(ctx, rPK, lPort, rPort, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(net.Conn)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, cipher.PubKey, routing.Port, routing.Port, *DialOptions) *DatagramRouteGroup); ok {
+		r1 = rf(ctx, rPK, lPort, rPort, opts)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*DatagramRouteGroup)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, cipher.PubKey, routing.Port, routing.Port, *DialOptions) error); ok {
+		r2 = rf(ctx, rPK, lPort, rPort, opts)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// RegisterDatagramPort provides a mock function with given fields: port
+func (_m *MockRouter) RegisterDatagramPort(port routing.Port) {
+	_m.Called(port)
+}
+
+// UnregisterDatagramPort provides a mock function with given fields: port
+func (_m *MockRouter) UnregisterDatagramPort(port routing.Port) {
+	_m.Called(port)
+}
+
+// AcceptDatagram provides a mock function with given fields: ctx
+func (_m *MockRouter) AcceptDatagram(ctx context.Context) (*DatagramRouteGroup, routing.Port, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcceptDatagram")
+	}
+
+	var r0 *DatagramRouteGroup
+	var r1 routing.Port
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*DatagramRouteGroup, routing.Port, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) *DatagramRouteGroup); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*DatagramRouteGroup)
+		}
+	}
+	if rf, ok := ret.Get(1).(func(context.Context) routing.Port); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Get(1).(routing.Port)
+	}
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
 // PingRoute provides a mock function with given fields: ctx, rPK, lPort, rPort, opts
 func (_m *MockRouter) PingRoute(ctx context.Context, rPK cipher.PubKey, lPort routing.Port, rPort routing.Port, opts *DialOptions) (net.Conn, error) {
 	ret := _m.Called(ctx, rPK, lPort, rPort, opts)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -346,6 +346,26 @@ type Router interface {
 	DialRoutes(ctx context.Context, rPK cipher.PubKey, lPort, rPort routing.Port, opts *DialOptions) (net.Conn, error)
 	PingRoute(ctx context.Context, rPK cipher.PubKey, lPort, rPort routing.Port, opts *DialOptions) (net.Conn, error)
 
+	// DialRoutesDatagram dials a faithful-UDP (#2607) route. It performs a
+	// normal DialRoutes (forcing opts.Datagram=true so the reliable route's
+	// Noise handshake also keys a DatagramRouteGroup sibling), then returns
+	// both the reliable conn (which the caller must keep alive — closing it
+	// tears down the route and the sibling) and the datagram sibling. Errors
+	// if the peer did not also register datagram intent for the port (no
+	// sibling registered).
+	DialRoutesDatagram(ctx context.Context, rPK cipher.PubKey, lPort, rPort routing.Port, opts *DialOptions) (net.Conn, *DatagramRouteGroup, error)
+
+	// RegisterDatagramPort / UnregisterDatagramPort mark a local port as
+	// faithful-UDP-capable (#2607). The accept side builds a datagram
+	// sibling only for routes whose local port is registered.
+	RegisterDatagramPort(port routing.Port)
+	UnregisterDatagramPort(port routing.Port)
+
+	// AcceptDatagram blocks until an accept-side datagram sibling is
+	// available (or ctx/visor is done), returning it and the local port
+	// it targets. Drained by the forwarded_ports.udp server loop.
+	AcceptDatagram(ctx context.Context) (*DatagramRouteGroup, routing.Port, error)
+
 	// AcceptRoutes should block until we receive an AddRules packet from SetupNode
 	// that contains ConsumeRule(s) or ForwardRule(s).
 	// Then the following should happen:
@@ -421,6 +441,7 @@ type router struct {
 	rgsRaw             map[routing.RouteDescriptor]*RouteGroup         // Not-yet-noise-wrapped route groups. when one of these gets wrapped, it gets removed from here
 	rgsDatagrams       map[routing.RouteDescriptor]*DatagramRouteGroup // faithful-UDP (DatagramPacket) route groups, keyed like rgsNs; #2607 stage-4 dispatch
 	datagramPorts      map[routing.Port]struct{}                       // local ports with faithful-UDP intent; the accept side builds a datagram sibling only for these (#2607 on-demand-by-local-intent)
+	acceptDatagram     chan datagramAccept                             // accept-side datagram siblings, drained by AcceptDatagram (the forwarded_ports.udp server loop)
 	pending            *pendingPackets                                 // frames parked during the rule-save -> route-group-register window (see router_pending.go)
 	rpcSrv             *rpc.Server
 	accept             chan routing.EdgeRules
@@ -503,6 +524,7 @@ func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (
 		rgsRaw:          make(map[routing.RouteDescriptor]*RouteGroup),
 		rgsDatagrams:    make(map[routing.RouteDescriptor]*DatagramRouteGroup),
 		datagramPorts:   make(map[routing.Port]struct{}),
+		acceptDatagram:  make(chan datagramAccept, acceptDatagramBuf),
 		pending:         newPendingPackets(),
 		rpcSrv:          rpc.NewServer(),
 		accept:          make(chan routing.EdgeRules, acceptSize),

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -332,11 +332,17 @@ func (v *Visor) RegisterTCPPort(localPort int) error {
 
 // DeregisterTCPPort implements API.
 func (v *Visor) DeregisterTCPPort(localPort int) error {
-	if v.forwardedPorts.Get(localPort) == nil {
+	fp := v.forwardedPorts.Get(localPort)
+	if fp == nil {
 		return fmt.Errorf("port :%v not registered", localPort)
 	}
 	// Stop DMSG listener if running.
 	v.stopDmsgForwarder(localPort)
+	// Clear faithful-UDP datagram intent so new inbound datagram routes
+	// to this port stop building siblings (#2607).
+	if fp.UDP && v.router != nil {
+		v.router.UnregisterDatagramPort(routing.Port(fp.Port)) //nolint:gosec // port fits routing.Port
+	}
 	// Remove from both the rich store and legacy allowed map.
 	v.allowed.mu.Lock()
 	delete(v.allowed.ports, localPort)
@@ -385,6 +391,12 @@ func (v *Visor) RegisterForwardedPort(p ForwardedPort) error {
 	// Create a DMSG listener for this port so .dmsg:<port> works.
 	if p.DMSG {
 		v.startDmsgForwarder(p.Port, p.LocalPort)
+	}
+	// Faithful-UDP (#2607): mark datagram intent so the router's accept
+	// side builds a sibling for inbound datagram routes to this port. The
+	// accept loop (serveUDPForwards) bridges them to the local service.
+	if p.UDP && v.router != nil {
+		v.router.RegisterDatagramPort(routing.Port(p.Port)) //nolint:gosec // port fits routing.Port
 	}
 	// If this is the dmsghttp port (80) entry, refresh the logserver's
 	// website handler so a new ProxyAddr takes effect immediately.

--- a/pkg/visor/init_skynet_ports.go
+++ b/pkg/visor/init_skynet_ports.go
@@ -99,6 +99,15 @@ func initSkynetForwardPorts(_ context.Context, v *Visor, log *logging.Logger) er
 			v.startDmsgForwarder(fp.Port, fp.LocalPort)
 		}
 	}
+
+	// Faithful-UDP forwarding (#2607): register datagram intent for
+	// persisted UDP ports and start the accept loop that bridges
+	// inbound datagram routes to their local UDP services. The loop runs
+	// for the visor's lifetime; runtime UDP-port registrations come in
+	// via RegisterForwardedPort.
+	v.registerUDPForwardPorts()
+	go v.serveUDPForwards(log)
+
 	return nil
 }
 

--- a/pkg/visor/init_udp_forwarding.go
+++ b/pkg/visor/init_udp_forwarding.go
@@ -1,0 +1,105 @@
+// Package visor pkg/visor/init_udp_forwarding.go: server side of
+// faithful-UDP port forwarding (#2607 stage-4c). The dial/client side
+// lives in appnet (DialPacket). This is the accept side: for every
+// forwarded port marked UDP, the visor registers datagram intent with
+// the router, then a single accept loop drains the datagram siblings
+// the route-setup builds for inbound datagram routes and bridges each
+// to the local UDP service via a UDPBridge.
+package visor
+
+import (
+	"net"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/router"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// udpForwardLivenessPoll is how often a UDP-forward bridge checks whether
+// its datagram route is still alive. A one-way UDP flow produces no write
+// traffic to trip the sibling's write-failure detector, so the bridge
+// polls IsAlive instead.
+const udpForwardLivenessPoll = 10 * time.Second
+
+// registerUDPForwardPorts marks every UDP forwarded port as datagram-
+// capable so the router's accept side builds a sibling for inbound
+// datagram routes targeting them. Idempotent.
+func (v *Visor) registerUDPForwardPorts() {
+	if v.router == nil {
+		return
+	}
+	for _, fp := range v.forwardedPorts.List() {
+		if fp.UDP {
+			v.router.RegisterDatagramPort(routing.Port(fp.Port)) //nolint:gosec // port fits routing.Port
+		}
+	}
+}
+
+// serveUDPForwards is the accept loop: it drains datagram siblings the
+// router accepts and bridges each to its local UDP service. Runs for the
+// visor's lifetime (exits when v.ctx is done / the router closes).
+func (v *Visor) serveUDPForwards(log *logging.Logger) {
+	for {
+		dg, dstPort, err := v.router.AcceptDatagram(v.ctx)
+		if err != nil {
+			log.WithError(err).Debug("UDP-forward accept loop stopping")
+			return
+		}
+		fp := v.forwardedPorts.Get(int(dstPort))
+		if fp == nil || !fp.UDP {
+			log.WithField("dst_port", dstPort).
+				Warn("accepted datagram for an unknown/non-UDP forwarded port; closing sibling")
+			dg.Close() //nolint:errcheck,gosec
+			continue
+		}
+		go v.bridgeUDPForward(dg, *fp, log)
+	}
+}
+
+// bridgeUDPForward pumps datagrams between an accepted skynet sibling and
+// the local UDP service the forwarded port targets, until either the
+// route or the visor goes away.
+func (v *Visor) bridgeUDPForward(dg *router.DatagramRouteGroup, fp ForwardedPort, log *logging.Logger) {
+	target := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: fp.EffectiveLocalPort()}
+
+	// Ephemeral local socket that talks to the service. skynetToLocal
+	// writes inbound datagrams to `target`; localToSkynet reads the
+	// service's replies and sends them back over the sibling.
+	local, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		log.WithError(err).WithField("target", target.String()).
+			Warn("UDP-forward: failed to bind local socket; dropping route")
+		dg.Close() //nolint:errcheck,gosec
+		return
+	}
+
+	bridge := NewUDPBridge(local, dg, UDPBridgeConfig{Logger: log})
+	bridge.SetLocalPeer(target) // server side: send inbound to the service
+	bridge.Start()
+	log.WithField("port", fp.Port).WithField("local", target.String()).
+		Debug("UDP-forward bridge established")
+
+	// Tear the bridge down when the datagram route dies (the sibling is
+	// reaped by the router on route close → IsAlive goes false) or the
+	// visor shuts down. The sibling has no write traffic on a one-way
+	// flow, so poll IsAlive rather than relying on a write-failure trip.
+	defer bridge.Close() //nolint:errcheck
+	for {
+		select {
+		case <-v.ctx.Done():
+			return
+		case <-bridge.closed:
+			return
+		default:
+		}
+		if !dg.IsAlive() {
+			return
+		}
+		select {
+		case <-v.ctx.Done():
+			return
+		case <-time.After(udpForwardLivenessPoll):
+		}
+	}
+}


### PR DESCRIPTION
Final stage of #2607. With dispatch (#3183) + route-setup sibling construction (#3184) merged, this wires the two endpoints so datagrams flow app-to-app — `appnet.DialPacket` works and `forwarded_ports.udp` is served.

## Client (dial) path
- `router.DialRoutesDatagram` (on the `Router` interface + `MockRouter`): dials a normal route with `Datagram` intent, then returns both the **reliable conn** (kept alive — closing it tears the route down) and the registered `DatagramRouteGroup` sibling.
- `appnet.SkywireNetworker.DialPacketContext` (implements `PacketNetworker`): dials via `DialRoutesDatagram` and returns a `skywirePacketConn` — the sibling wrapped so `Close` also tears down the reliable route and frees the local port. **`appnet.DialPacket` now works** for skynet addrs (was `ErrPacketNetworkerNotSupported`).

## Server (accept) path
- The router gains an accept channel: `buildDatagramSibling` offers each **accept-side** sibling (`Initiator=false`) to `AcceptDatagram` along with the route's local port. `RegisterDatagramPort` / `UnregisterDatagramPort` / `AcceptDatagram` added to the `Router` interface.
- visor `serveUDPForwards` accept loop (started from `initSkynetForwardPorts`) drains accepted siblings and, per the `forwarded_ports.udp` registry, bridges each to its local UDP service via `NewUDPBridge` (`SetLocalPeer` = the service; polls `IsAlive` to reap on route close).
- `RegisterForwardedPort(UDP)` → `RegisterDatagramPort`; `DeregisterTCPPort(UDP)` → `UnregisterDatagramPort`; startup restores datagram intent for persisted UDP ports.

Both ends opt in by **local intent** (`DialOptions.Datagram` on the dialer; the server's forwarded-UDP port registration) — no wire negotiation. `NewUDPBridge` is no longer dead code.

## Safety
Inert until an app calls `DialPacket` or a `forwarded_ports.udp` port is registered (`datagram` defaults false; the accept loop blocks harmlessly with no UDP ports). The `Router` interface grew, but the reliable `DialRoutes` hot path is unchanged.

## Tests
Accept-side-offers-but-dial-side-doesn't; plus the existing seal→dispatch→AEAD-open→ReadFrom round-trip and port registry. Build/vet/lint green; full router + appnet suites pass.

## Validation
Two-visor UDP-echo live validation happens once this lands on develop and the fleet auto-updates (per maintainer). The faithful-UDP stack (#2609/#2610/#2612/#2613/#2614 components → #3183/#3184/this dispatch+setup+app wiring) is now complete.