### PR TITLE
feat(cli): operator-facing faithful-UDP port forwarding (#2607 stage-4d)

### DIFF
--- a/cmd/skywire-cli/commands/skynet/port.go
+++ b/cmd/skywire-cli/commands/skynet/port.go
@@ -26,6 +26,7 @@ var (
 	portWhitelist    string
 	portPreserveHost bool
 	portInjectPK     bool
+	portUDP          bool
 )
 
 func init() {
@@ -39,10 +40,16 @@ func init() {
 	portAddCmd.Flags().StringVar(&portWhitelist, "whitelist", "", "comma-separated PKs allowed to access this port (empty = allow all)")
 	portAddCmd.Flags().BoolVar(&portPreserveHost, "preserve-host", false, "pass the incoming Host header through to the backend (required for vhost backends like Caddy/nginx)")
 	portAddCmd.Flags().BoolVar(&portInjectPK, "inject-pk", false, "HTTP mode: inject the authenticated caller's PK as X-Skywire-Remote-PK (strips any client-supplied copy); bind the backend to loopback only")
+	portAddCmd.Flags().BoolVar(&portUDP, "udp", false, "faithful-UDP mode: serve the local port as a UDP datagram service over skynet (loss-tolerant, unordered) instead of TCP")
+
+	udpDialCmd.Flags().IntVar(&portLocalPort, "local-port", 0, "local UDP port to bind (default: same as the remote port)")
 
 	portCmd.AddCommand(portAddCmd)
 	portCmd.AddCommand(portRmCmd)
 	portCmd.AddCommand(portLsCmd)
+	portCmd.AddCommand(udpDialCmd)
+	portCmd.AddCommand(udpStopCmd)
+	portCmd.AddCommand(udpLsCmd)
 	RootCmd.AddCommand(portCmd)
 }
 
@@ -136,6 +143,7 @@ Examples:
 			Whitelist:     wl,
 			PreserveHost:  portPreserveHost,
 			InjectPK:      portInjectPK,
+			UDP:           portUDP,
 		}
 		if err := rpcClient.RegisterForwardedPort(fp); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
@@ -177,4 +185,84 @@ func dashIfEmpty(s string) string {
 		return "-"
 	}
 	return s
+}
+
+// udpDialCmd opens a client-side faithful-UDP forward (#2607): bridge a
+// local UDP socket to a remote forwarded_ports.udp service over skynet.
+var udpDialCmd = &cobra.Command{
+	Use:   "udp-dial <remote-pk> <remote-port>",
+	Short: "Forward a local UDP port to a remote forwarded_ports.udp service over skynet",
+	Long: `Open a faithful-UDP (datagram) forward to a remote visor's UDP service.
+
+The remote visor must serve the port with 'skynet port add <port> --udp'.
+This binds 127.0.0.1:<local-port> locally; your UDP app sends there and the
+datagrams reach the remote service (and replies come back) — loss-tolerant
+and unordered, like real UDP.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		var pk cipher.PubKey
+		if err := pk.Set(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid remote PK: %w", err))
+		}
+		rPort, err := strconv.Atoi(args[1])
+		if err != nil || rPort < 1 || rPort > 65535 {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid remote port: %s", args[1]))
+		}
+		lPort := portLocalPort
+		if lPort == 0 {
+			lPort = rPort
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.DialUDPForward(pk, rPort, lPort); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("UDP forward up: 127.0.0.1:%d -> %s:%d\n", lPort, pk, rPort)
+	},
+}
+
+// udpStopCmd tears down a client-side faithful-UDP forward by local port.
+var udpStopCmd = &cobra.Command{
+	Use:   "udp-stop <local-port>",
+	Short: "Stop a client-side UDP forward",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		lPort, err := strconv.Atoi(args[0])
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid local port: %s", args[0]))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.StopUDPForward(lPort); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("UDP forward on local port %d stopped\n", lPort)
+	},
+}
+
+// udpLsCmd lists active client-side faithful-UDP forwards.
+var udpLsCmd = &cobra.Command{
+	Use:   "udp-ls",
+	Short: "List active client-side UDP forwards",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		ports, err := rpcClient.ListUDPForwards()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if len(ports) == 0 {
+			fmt.Println("No active UDP forwards.")
+			return
+		}
+		for _, p := range ports {
+			fmt.Printf("127.0.0.1:%d\n", p)
+		}
+	},
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -201,6 +201,12 @@ type API interface {
 	RegisterForwardedPort(p ForwardedPort) error
 	UpdateForwardedPort(p ForwardedPort) error
 	ListForwardedPorts() ([]ForwardedPort, error)
+	// DialUDPForward / StopUDPForward / ListUDPForwards drive client-side
+	// faithful-UDP port forwarding (#2607): bridge a local UDP socket to
+	// a remote forwarded_ports.udp service via DialPacket.
+	DialUDPForward(remotePK cipher.PubKey, remotePort, localPort int) error
+	StopUDPForward(localPort int) error
+	ListUDPForwards() ([]int, error)
 	ConnectRawTCP(network string, remotePK cipher.PubKey, remotePort, localPort int) (uuid.UUID, error)
 	DisconnectRawTCP(id uuid.UUID) error
 	ListRawTCP() (map[uuid.UUID]*appnet.RawTCPForwardConn, error)

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -578,6 +578,18 @@ func (proxyDefaultAPI) DeregisterTCPPort(_ int) error {
 	return ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) DialUDPForward(_ cipher.PubKey, _, _ int) error {
+	return ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) StopUDPForward(_ int) error {
+	return ErrProxyNotSupported
+}
+
+func (proxyDefaultAPI) ListUDPForwards() ([]int, error) {
+	return nil, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) ListTCPPorts() ([]int, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -304,6 +304,14 @@ type ConnectIn struct {
 	RemotePort int
 	LocalPort  int
 }
+
+// UDPForwardIn is the argument for DialUDPForward (#2607): dial a remote
+// forwarded_ports.udp service and bridge it to a local UDP socket.
+type UDPForwardIn struct {
+	RemotePK   cipher.PubKey
+	RemotePort int
+	LocalPort  int
+}
 type StopAllPingsOut struct {
 	Stopped int
 	Errors  []string

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1182,6 +1182,23 @@ func (rc *rpcClient) RegisterTCPPort(localPort int) error {
 	return rc.Call("RegisterTCPPort", &localPort, &struct{}{})
 }
 
+// DialUDPForward calls DialUDPForward (#2607 client-side UDP forward).
+func (rc *rpcClient) DialUDPForward(remotePK cipher.PubKey, remotePort, localPort int) error {
+	return rc.Call("DialUDPForward", &UDPForwardIn{RemotePK: remotePK, RemotePort: remotePort, LocalPort: localPort}, &struct{}{})
+}
+
+// StopUDPForward calls StopUDPForward.
+func (rc *rpcClient) StopUDPForward(localPort int) error {
+	return rc.Call("StopUDPForward", &localPort, &struct{}{})
+}
+
+// ListUDPForwards calls ListUDPForwards.
+func (rc *rpcClient) ListUDPForwards() ([]int, error) {
+	var out []int
+	err := rc.Call("ListUDPForwards", &struct{}{}, &out)
+	return out, err
+}
+
 // DeregisterTCPPort calls DeregisterTCPPort.
 func (rc *rpcClient) DeregisterTCPPort(localPort int) error {
 	err := rc.Call("DeregisterTCPPort", &localPort, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1030,6 +1030,21 @@ func (mc *mockRPCClient) DeregisterTCPPort(_ int) error {
 	return nil
 }
 
+// DialUDPForward implements API.
+func (mc *mockRPCClient) DialUDPForward(_ cipher.PubKey, _, _ int) error {
+	return nil
+}
+
+// StopUDPForward implements API.
+func (mc *mockRPCClient) StopUDPForward(_ int) error {
+	return nil
+}
+
+// ListUDPForwards implements API.
+func (mc *mockRPCClient) ListUDPForwards() ([]int, error) {
+	return nil, nil
+}
+
 // ListTCPPorts implements API.
 func (mc *mockRPCClient) ListTCPPorts() ([]int, error) {
 	return nil, nil

--- a/pkg/visor/rpc_network.go
+++ b/pkg/visor/rpc_network.go
@@ -11,6 +11,26 @@ func (r *RPC) RegisterTCPPort(port *int, _ *struct{}) (err error) {
 	return r.visor.RegisterTCPPort(*port)
 }
 
+// DialUDPForward starts a client-side faithful-UDP forward (#2607).
+func (r *RPC) DialUDPForward(in *UDPForwardIn, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "DialUDPForward", in)(nil, &err)
+	return r.visor.DialUDPForward(in.RemotePK, in.RemotePort, in.LocalPort)
+}
+
+// StopUDPForward stops a client-side faithful-UDP forward by local port.
+func (r *RPC) StopUDPForward(localPort *int, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "StopUDPForward", localPort)(nil, &err)
+	return r.visor.StopUDPForward(*localPort)
+}
+
+// ListUDPForwards lists active client-side faithful-UDP forwards.
+func (r *RPC) ListUDPForwards(_ *struct{}, out *[]int) (err error) {
+	defer rpcutil.LogCall(r.log, "ListUDPForwards", nil)(out, &err)
+	ports, err := r.visor.ListUDPForwards()
+	*out = ports
+	return err
+}
+
 // DeregisterTCPPort deregisters the local port that can be accessed by remote visors
 func (r *RPC) DeregisterTCPPort(port *int, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "DeregisterTCPPort", port)(nil, &err)

--- a/pkg/visor/udp_client_forward.go
+++ b/pkg/visor/udp_client_forward.go
@@ -1,0 +1,97 @@
+// Package visor pkg/visor/udp_client_forward.go: client side of
+// faithful-UDP port forwarding (#2607 stage-4d). The server side
+// (init_udp_forwarding.go) bridges inbound datagram routes to a local
+// service; this is the mirror: it dials a remote forwarded_ports.udp
+// service via DialPacket and bridges it to a local UDP socket the
+// operator's UDP app talks to.
+package visor
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// DialUDPForward opens a faithful-UDP forward: it DialPackets to
+// remotePK:remotePort (which must be a forwarded_ports.udp service on
+// the peer) and binds a local UDP socket on localPort, bridging the two.
+// The operator's UDP app then talks to 127.0.0.1:localPort and its
+// datagrams reach the remote service (and replies come back). Runs until
+// StopUDPForward(localPort) or visor shutdown.
+func (v *Visor) DialUDPForward(remotePK cipher.PubKey, remotePort, localPort int) error {
+	if remotePort < 1 || remotePort > 65535 || localPort < 1 || localPort > 65535 {
+		return fmt.Errorf("ports must be in 1..65535 (remote=%d local=%d)", remotePort, localPort)
+	}
+	nw, err := appnet.ResolveNetworker(appnet.TypeSkynet)
+	if err != nil {
+		return fmt.Errorf("skynet networker unavailable: %w", err)
+	}
+	pn, ok := nw.(appnet.PacketNetworker)
+	if !ok {
+		return errors.New("skynet networker does not support datagrams (build too old?)")
+	}
+
+	v.udpFwdMu.Lock()
+	if _, exists := v.udpClientBridges[localPort]; exists {
+		v.udpFwdMu.Unlock()
+		return fmt.Errorf("local UDP port %d already forwarding", localPort)
+	}
+	v.udpFwdMu.Unlock()
+
+	// Bind the local UDP socket the operator's app sends to.
+	local, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: localPort}) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("bind local udp :%d: %w", localPort, err)
+	}
+
+	addr := appnet.Addr{Net: appnet.TypeSkynet, PubKey: remotePK, Port: routing.Port(remotePort)} //nolint:gosec
+	dgConn, err := pn.DialPacketContext(v.ctx, addr)
+	if err != nil {
+		local.Close() //nolint:errcheck,gosec
+		return fmt.Errorf("dial UDP forward %s:%d: %w", remotePK, remotePort, err)
+	}
+
+	bridge := NewUDPBridge(local, dgConn, UDPBridgeConfig{Logger: v.log})
+	// Client side: no SetLocalPeer — the first datagram from the local
+	// app captures its source addr; replies route back to it.
+	bridge.Start()
+
+	v.udpFwdMu.Lock()
+	v.udpClientBridges[localPort] = bridge
+	v.udpFwdMu.Unlock()
+
+	v.log.WithField("remote", fmt.Sprintf("%s:%d", remotePK, remotePort)).
+		WithField("local", fmt.Sprintf("127.0.0.1:%d", localPort)).
+		Info("UDP forward established")
+	return nil
+}
+
+// StopUDPForward tears down a client-side UDP forward by its local port.
+func (v *Visor) StopUDPForward(localPort int) error {
+	v.udpFwdMu.Lock()
+	bridge, ok := v.udpClientBridges[localPort]
+	if ok {
+		delete(v.udpClientBridges, localPort)
+	}
+	v.udpFwdMu.Unlock()
+	if !ok {
+		return fmt.Errorf("no UDP forward on local port %d", localPort)
+	}
+	return bridge.Close()
+}
+
+// ListUDPForwards returns the local ports with active client-side UDP
+// forwards.
+func (v *Visor) ListUDPForwards() ([]int, error) {
+	v.udpFwdMu.Lock()
+	defer v.udpFwdMu.Unlock()
+	ports := make([]int, 0, len(v.udpClientBridges))
+	for p := range v.udpClientBridges {
+		ports = append(ports, p)
+	}
+	return ports, nil
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -181,6 +181,13 @@ type Visor struct {
 	dmsgFwdMu        sync.Mutex
 	dmsgFwdListeners map[int]context.CancelFunc
 
+	// udpClientBridges holds active client-side faithful-UDP forwards
+	// (#2607), keyed by the local UDP port they bind. Each bridges a
+	// local UDP socket to a remote forwarded_ports.udp service via
+	// DialPacket. Started by DialUDPForward, stopped by StopUDPForward.
+	udpFwdMu         sync.Mutex
+	udpClientBridges map[int]*UDPBridge
+
 	// Service handler registry — maps ports to connection handlers
 	// so the sky-forwarding server can dispatch without localhost TCP.
 	services *ServiceRegistry
@@ -591,6 +598,7 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 		forwardedPorts:   NewForwardedPorts(filepath.Join(conf.LocalPath, "forwarded_ports.json")),
 		dmsgServersCache: NewDmsgServersCache(filepath.Join(conf.LocalPath, "dmsg_servers.json")),
 		dmsgFwdListeners: make(map[int]context.CancelFunc),
+		udpClientBridges: make(map[int]*UDPBridge),
 		dmsgTracker: dtmState{
 			ready: make(chan struct{}),
 		},


### PR DESCRIPTION
The trigger/operator layer for faithful UDP (#2607). After #3183/#3184/#3185 the datagram machinery is wired, but nothing registered a `forwarded_ports.udp` or called `DialPacket` — so it couldn't be exercised. This makes it usable and fleet-testable.

## Server
`skywire cli skynet port add <port> --udp` — registers a UDP datagram service over skynet (`ForwardedPort.UDP` → `RegisterDatagramPort` → the stage-4c accept loop bridges inbound datagram routes to the local UDP service).

## Client
`skywire cli skynet port udp-dial <remote-pk> <remote-port> [--local-port L]` — dials a remote `forwarded_ports.udp` service and bridges it to `127.0.0.1:L`. The operator's UDP app talks to `L`; datagrams reach the remote service and replies come back — loss-tolerant + unordered.

Backed by a new visor RPC `DialUDPForward` that does `ResolveNetworker(skynet)` → `PacketNetworker.DialPacketContext` → a client-side `UDPBridge`, tracked in `v.udpClientBridges` and torn down by `udp-stop` or visor shutdown. `udp-ls` lists active client forwards.

## Plumbing
`DialUDPForward` / `StopUDPForward` / `ListUDPForwards` on the API interface + gateway (`UDPForwardIn`) + rpc client + mock + proxy stubs (not routed via the hypervisor proxy — use direct `--rpc`).

## Status
Build/vet/lint green; CLI smoke-checked (`port --help` lists `udp-dial`/`udp-stop`/`udp-ls`; `port add --udp` present). 

This completes the faithful-UDP feature end to end (#2609/#2610/#2612/#2613/#2614 components → #3183 dispatch → #3184 route-setup → #3185 app/forwarded-ports → this operator CLI). Live two-visor UDP-echo validation happens once the fleet auto-updates to develop:
```
# on visor B (server): echo service on :9999, then
skywire cli skynet port add 9999 --udp --skynet=false
# on visor A (client):
skywire cli skynet port udp-dial <B-pk> 9999 --local-port 9999
# send UDP to 127.0.0.1:9999 on A → echoed by B's service
```