### PR TITLE
feat(transport): QUIC skynet transport + faithful UDP over QUIC datagrams (#2607)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.60.0 // indirect
+	github.com/quic-go/quic-go v0.60.0
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -231,6 +231,7 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 
 		r.Post("/bind/stcpr", api.bind)
 		r.Delete("/bind/stcpr", api.delBind)
+		r.Post("/bind/quic", api.bindQUIC)
 		r.Get("/resolve/{type}/{pk}", api.resolve)
 	})
 
@@ -339,8 +340,22 @@ func splitFamilyAddr(addr string) (v4, v6 string) {
 }
 
 func (a *API) bind(w http.ResponseWriter, r *http.Request) {
+	a.bindForType(w, r, types.STCPR)
+}
+
+// bindQUIC handles POST /bind/quic — registers the visor's QUIC UDP address
+// (#2607 QUIC follow-on). Same validation as STCPR; stored under the QUIC type
+// for peers to Resolve.
+func (a *API) bindQUIC(w http.ResponseWriter, r *http.Request) {
+	a.bindForType(w, r, types.QUIC)
+}
+
+// bindForType is the shared body for the address-registration handlers. The
+// transport type selects the store bucket peers Resolve against; STCPR
+// additionally mirrors to the secondary (v6) AR.
+func (a *API) bindForType(w http.ResponseWriter, r *http.Request, tpType types.Type) {
 	remoteAddr := httpauth.GetRemoteAddr(r)
-	a.logger(r).Infof("New POST /bind/stcpr request from %v", remoteAddr)
+	a.logger(r).Infof("New POST /bind/%s request from %v", tpType, remoteAddr)
 
 	ctx := r.Context()
 
@@ -352,7 +367,7 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 
 	rawBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		a.logger(r).WithError(err).Errorf("Failed to read /bind/stcpr request body")
+		a.logger(r).WithError(err).Errorf("Failed to read /bind/%s request body", tpType)
 	}
 
 	var localAddresses addrresolver.LocalAddresses
@@ -367,15 +382,15 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 		// a Docker bridge (e.g., 172.x.y.z) rather than its real public
 		// IP. If the visor declared a known-public PublicIP in the bind
 		// payload, trust that instead; rejecting the bind would lose all
-		// AR coverage for that visor's STCPR. Visors that don't declare
+		// AR coverage for that visor's transport. Visors that don't declare
 		// (older clients, or genuinely-misconfigured proxy/IPv6 traffic)
 		// still hit the original reject below.
 		if localAddresses.PublicIP != "" && netutil.IsPublicIP(net.ParseIP(localAddresses.PublicIP)) {
-			a.logger(r).Infof("STCPR: observed %v non-public; using declared PublicIP %v for %v",
-				remoteAddr, localAddresses.PublicIP, pk)
+			a.logger(r).Infof("%s: observed %v non-public; using declared PublicIP %v for %v",
+				tpType, remoteAddr, localAddresses.PublicIP, pk)
 			remoteAddr = localAddresses.PublicIP
 		} else {
-			err := fmt.Sprintf("Cannot bind %v to %v (STCPR). Invalid IP address in request: %v", pk, remoteAddr, localAddresses)
+			err := fmt.Sprintf("Cannot bind %v to %v (%s). Invalid IP address in request: %v", pk, remoteAddr, tpType, localAddresses)
 			a.logger(r).Errorf(err)
 			a.writeJSON(w, r, http.StatusBadRequest, &Error{
 				Error: err,
@@ -387,7 +402,7 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 	if !a.hasAddress(remoteAddr, localAddresses) {
 		// visor didn't provide the IP it's trying to bind from
 		// probably is behind NAT and shouldn't bind
-		err := fmt.Sprintf("Cannot bind %v to %v (STCPR). Remote address not present in request: %v", pk, remoteAddr, localAddresses)
+		err := fmt.Sprintf("Cannot bind %v to %v (%s). Remote address not present in request: %v", pk, remoteAddr, tpType, localAddresses)
 		a.logger(r).Errorf(err)
 
 		a.writeJSON(w, r, http.StatusBadRequest, &Error{
@@ -410,7 +425,7 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 		if isPublicIPv6(net.ParseIP(localAddresses.PublicIPv6)) {
 			v6Addr = localAddresses.PublicIPv6
 		} else {
-			a.logger(r).Debugf("STCPR: ignoring declared PublicIPv6 %q (not a public IPv6)", localAddresses.PublicIPv6)
+			a.logger(r).Debugf("%s: ignoring declared PublicIPv6 %q (not a public IPv6)", tpType, localAddresses.PublicIPv6)
 		}
 	}
 	visorData := addrresolver.VisorData{
@@ -419,17 +434,19 @@ func (a *API) bind(w http.ResponseWriter, r *http.Request) {
 		LocalAddresses: localAddresses,
 	}
 
-	if err := a.store.Bind(ctx, types.STCPR, pk, visorData); err != nil {
+	if err := a.store.Bind(ctx, tpType, pk, visorData); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		a.logger(r).Errorf("Failed to bind PK (STCPR): %v", err)
+		a.logger(r).Errorf("Failed to bind PK (%s): %v", tpType, err)
 
 		return
 	}
 
-	a.mirrorSTCPR(pk, &visorData)
+	if tpType == types.STCPR {
+		a.mirrorSTCPR(pk, &visorData)
+	}
 
 	w.WriteHeader(http.StatusOK)
-	a.logger(r).Debugf("Bound %v to %v (STCPR)", pk, remoteAddr)
+	a.logger(r).Debugf("Bound %v to %v (%s)", pk, remoteAddr, tpType)
 }
 
 func (a *API) delBind(w http.ResponseWriter, r *http.Request) {

--- a/pkg/router/datagram_route_group.go
+++ b/pkg/router/datagram_route_group.go
@@ -282,7 +282,12 @@ func (dg *DatagramRouteGroup) WriteTo(data []byte, addr net.Addr) (int, error) {
 	default:
 	}
 
-	if err := tp.WritePacket(ctx, packet); err != nil {
+	// Prefer the transport's native datagram channel (QUIC RFC 9221) so the
+	// datagram rides the wire with real UDP semantics — no head-of-line
+	// blocking, genuine loss tolerance. WriteDatagram falls back to the
+	// reliable stream when the transport has no datagram channel (stcp/sudph/
+	// dmsg) or the datagram is too large, so this is always correct.
+	if err := tp.WriteDatagram(ctx, packet); err != nil {
 		atomic.AddInt32(&dg.consecutiveWriteFailures, 1)
 		return 0, err
 	}

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -299,7 +299,55 @@ func (mt *ManagedTransport) Serve(readCh chan<- routing.Packet) {
 	}()
 
 	go mt.readLoop(readCh)
+
+	// On a datagram-capable transport (QUIC), also drain the native datagram
+	// channel into the same readCh so faithful-UDP DatagramPackets the router
+	// dispatches arrive over real unreliable datagrams (no HOL blocking). The
+	// context is canceled when Serve returns (i.e. mt.done fires), unblocking
+	// the blocking ReadDatagram.
+	if dc, ok := datagramConnOf(mt.transport); ok {
+		mt.wg.Add(1)
+		// Serve is a transport-lifetime goroutine with no request-scoped
+		// parent; Background is correct here. Canceled below when Serve returns.
+		ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: long-lived transport goroutine
+		defer cancel()
+		go mt.datagramReadLoop(ctx, dc, readCh)
+	}
+
 	<-mt.done
+}
+
+// datagramReadLoop drains the transport's native datagram channel (QUIC) into
+// readCh. Each datagram is a routing.Packet (a faithful-UDP DatagramPacket,
+// end-to-end AEAD-sealed). Faithful-UDP semantics: if readCh is momentarily
+// full the datagram is dropped rather than blocking, matching what a real UDP
+// receiver would do under load.
+func (mt *ManagedTransport) datagramReadLoop(ctx context.Context, dc network.DatagramConn, readCh chan<- routing.Packet) {
+	defer mt.wg.Done()
+	log := mt.log.WithField("src", "datagram_read_loop")
+	for {
+		b, err := dc.ReadDatagram(ctx)
+		if err != nil {
+			log.WithError(err).Debug("Datagram read loop stopping")
+			return
+		}
+		if len(b) < routing.PacketHeaderSize {
+			continue // runt / not a routing packet
+		}
+		p := routing.Packet(b)
+		if n := len(b); n > routing.PacketHeaderSize {
+			mt.logRecv(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
+		}
+		select {
+		case <-mt.done:
+			return
+		case <-ctx.Done():
+			return
+		case readCh <- p:
+		default:
+			// readCh full — drop (faithful-UDP loss tolerance).
+		}
+	}
 }
 
 // readLoop continuously reads packets from the underlying transport
@@ -786,6 +834,46 @@ func (mt *ManagedTransport) WritePacket(ctx context.Context, packet routing.Pack
 		mt.transportMx.Unlock()
 		return nil
 	}
+}
+
+// datagramConnOf returns the transport's native datagram channel (QUIC) and
+// true when the underlying connection supports unreliable datagrams. Uses a
+// type assertion so reliable-only transports and mocks need no interface change.
+func datagramConnOf(tp network.Transport) (network.DatagramConn, bool) {
+	dt, ok := tp.(interface {
+		Datagram() (network.DatagramConn, bool)
+	})
+	if !ok {
+		return nil, false
+	}
+	return dt.Datagram()
+}
+
+// WriteDatagram writes a (faithful-UDP) packet over the transport's native
+// datagram channel when available (QUIC RFC 9221) — no head-of-line blocking,
+// genuine loss tolerance. If the transport has no datagram channel, or the
+// datagram send fails (e.g. the payload exceeds the path MTU), it falls back
+// to the reliable stream so the packet is still delivered. The payload is
+// already end-to-end AEAD-sealed by the DatagramRouteGroup; QUIC's own TLS
+// adds hop-by-hop encryption to the datagram.
+func (mt *ManagedTransport) WriteDatagram(ctx context.Context, packet routing.Packet) error {
+	mt.transportMx.Lock()
+	tp := mt.transport
+	mt.transportMx.Unlock()
+	if tp == nil {
+		return fmt.Errorf("write datagram: cannot write to transport, transport is not set up")
+	}
+	if dc, ok := datagramConnOf(tp); ok {
+		if err := dc.WriteDatagram(packet); err == nil {
+			if n := len(packet); n > routing.PacketHeaderSize {
+				mt.logSent(uint64(n - routing.PacketHeaderSize)) //nolint:gosec
+			}
+			return nil
+		}
+		// Datagram send failed (too large for the path MTU, or transient) —
+		// fall back to the reliable stream below so the packet still arrives.
+	}
+	return mt.WritePacket(ctx, packet)
 }
 
 // WriteRawPacket writes a pre-constructed packet to the transport.

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -1170,7 +1170,10 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 	}
 	tm.tps[tpID] = mTp
 	tm.mx.Unlock()
-	go mTp.Serve(tm.readCh)
+	// Serve runs for the transport's lifetime, not the dial's; its internal
+	// datagram-read context correctly derives from Background (a short-lived
+	// dial ctx would kill the QUIC datagram loop prematurely). #2607.
+	go mTp.Serve(tm.readCh) //nolint:gosec // G118: long-lived transport goroutine, not request-scoped
 
 	// Check AR transport limit after dialing a new transport.
 	go tm.checkARLimit()

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -31,6 +31,7 @@ const (
 	// sudphPriority is used to set an order how connection filters apply.
 	sudphPriority            = 1
 	stcprBindPath            = "/bind/stcpr"
+	quicBindPath             = "/bind/quic"
 	addrChSize               = 1024
 	udpKeepHeartbeatInterval = 10 * time.Second
 	sudphReRegisterInterval  = 90 * time.Second
@@ -81,6 +82,7 @@ type Error struct {
 // APIClient implements address resolver API client.
 type APIClient interface {
 	BindSTCPR(ctx context.Context, port string) error
+	BindQUIC(ctx context.Context, port string) error
 	BindSUDPH(filter *pfilter.PacketFilter, handshake Handshake) (<-chan RemoteVisor, error)
 	Resolve(ctx context.Context, netType string, pk cipher.PubKey) (VisorData, error)
 	Transports(ctx context.Context) (map[cipher.PubKey][]string, error)
@@ -467,6 +469,69 @@ func (c *httpClient) awaitPublicIP(timeout time.Duration) {
 }
 
 // BindSTCPR binds client PK to IP:port on address resolver.
+// BindQUIC registers this visor's QUIC UDP port with the address resolver
+// (mirrors BindSTCPR — an HTTP POST of the local addresses + port, stored
+// under the "quic" type for peers to Resolve). The declared port is the
+// visor's QUIC listen port; for publicly-reachable visors the AR's observed
+// source IP + this port are reachable. (NAT-mapped UDP discovery / hole
+// punching is a follow-up; this path targets reachable nodes first.)
+func (c *httpClient) BindQUIC(ctx context.Context, port string) error {
+	log := c.log.WithField("func", "httpClient.BindQUIC")
+	if !c.isReady() {
+		log.Debug("Address resolver is not ready yet, waiting...")
+		<-c.ready
+		log.Debug("Address resolver became ready, binding")
+	}
+
+	c.awaitPublicIP(stcprBindPublicIPWait)
+
+	addresses, err := netutil.LocalAddresses()
+	if err != nil {
+		return err
+	}
+	clientPublicIP := c.localPublicIPRaw()
+	if clientPublicIP != "" {
+		publicIP := clientPublicIP
+		if host, _, err := net.SplitHostPort(publicIP); err == nil {
+			publicIP = host
+		}
+		found := false
+		for _, addr := range addresses {
+			if addr == publicIP {
+				found = true
+				break
+			}
+		}
+		if !found {
+			addresses = append(addresses, publicIP)
+		}
+	}
+
+	localAddresses := LocalAddresses{
+		Addresses:  addresses,
+		Port:       port,
+		PublicIP:   c.LocalPublicIP(),
+		PublicIPv6: c.localPublicIPv6Raw(),
+	}
+	log.Debugf("Address resolver binding QUIC with: %v port %s", addresses, port)
+	resp, err := c.Post(ctx, quicBindPath, localAddresses)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.WithError(err).Warn("Failed to close response body")
+		}
+	}()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return fmt.Errorf("rate limited by address resolver (status 429)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status: %d, error: %w", resp.StatusCode, httpauthclient.ExtractError(resp.Body))
+	}
+	return nil
+}
+
 func (c *httpClient) BindSTCPR(ctx context.Context, port string) error {
 	log := c.log.WithField("func", "httpClient.BindSTCPR")
 	if !c.isReady() {

--- a/pkg/transport/network/addrresolver/mock_api_client.go
+++ b/pkg/transport/network/addrresolver/mock_api_client.go
@@ -59,6 +59,24 @@ func (_m *MockAPIClient) BindSTCPR(ctx context.Context, port string) error {
 	return r0
 }
 
+// BindQUIC provides a mock function with given fields: ctx, port
+func (_m *MockAPIClient) BindQUIC(ctx context.Context, port string) error {
+	ret := _m.Called(ctx, port)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BindQUIC")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, port)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // BindSUDPH provides a mock function with given fields: filter, handshake
 func (_m *MockAPIClient) BindSUDPH(filter *pfilter.PacketFilter, handshake Handshake) (<-chan RemoteVisor, error) {
 	ret := _m.Called(filter, handshake)

--- a/pkg/transport/network/client.go
+++ b/pkg/transport/network/client.go
@@ -97,6 +97,8 @@ func (f *ClientFactory) MakeClient(netType types.Type, port int) (Client, error)
 		return newStcpr(resolved, port), nil
 	case types.SUDPH:
 		return newSudph(resolved, port), nil
+	case types.QUIC:
+		return newQuic(resolved, port), nil
 	case types.DMSG:
 		return newDmsgClient(f.DmsgC), nil
 	}

--- a/pkg/transport/network/connection.go
+++ b/pkg/transport/network/connection.go
@@ -3,6 +3,7 @@ package network
 
 import (
 	"bufio"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -49,11 +50,36 @@ type Transport interface {
 	Network() types.Type
 }
 
+// DatagramConn is implemented by transport connections that carry unreliable
+// datagrams natively over the wire (currently QUIC, RFC 9221). When a
+// transport's underlying conn supports it, the router sends faithful-UDP
+// DatagramPackets over this channel instead of the reliable stream —
+// realizing genuine UDP semantics (no head-of-line blocking, loss tolerance).
+// Reliable-only transports (TCP/KCP/dmsg) don't implement it, and the router
+// transparently falls back to the reliable stream.
+type DatagramConn interface {
+	WriteDatagram(b []byte) error
+	ReadDatagram(ctx context.Context) ([]byte, error)
+}
+
 type transport struct {
 	net.Conn
 	lAddr, rAddr  dmsg.Addr
 	freePort      func()
 	transportType types.Type
+	// dgram is the underlying conn's native datagram channel, captured in
+	// encrypt() before the noise wrapper (stream-only) replaces c.Conn. Nil
+	// for reliable-only transports.
+	dgram DatagramConn
+}
+
+// Datagram returns the transport's native datagram channel and true when the
+// underlying connection supports unreliable datagrams (QUIC); otherwise
+// (nil, false). The concrete method (not on the Transport interface) is
+// consumed via a type assertion in pkg/transport so reliable-only transports
+// and mocks need no changes.
+func (c *transport) Datagram() (DatagramConn, bool) {
+	return c.dgram, c.dgram != nil
 }
 
 // DoHandshake performs given handshake over given raw connection and wraps
@@ -85,6 +111,15 @@ func doHandshake(rawConn net.Conn, hs handshake.Handshake, netType types.Type, t
 }
 
 func (c *transport) encrypt(lPK cipher.PubKey, lSK cipher.SecKey, initator bool) error {
+	// Capture a native datagram channel (QUIC) before the noise wrapper
+	// replaces c.Conn — the wrapper is stream-only and can't carry datagrams.
+	// The captured channel rides the raw QUIC connection (its own TLS gives
+	// hop-by-hop encryption; the payload is already end-to-end AEAD-sealed by
+	// the DatagramRouteGroup).
+	if dc, ok := c.Conn.(DatagramConn); ok {
+		c.dgram = dc
+	}
+
 	config := noise.Config{
 		LocalPK:   lPK,
 		LocalSK:   lSK,

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -1,0 +1,296 @@
+// Package network pkg/transport/network/quic.go: a QUIC-based skywire
+// transport. Mirrors the sudph/stcpr structure (AR-resolved, UDP-based)
+// but rides quic-go instead of KCP: the connection is secured by the
+// skywire-PK-bound TLS identity (quic_identity.go, option A), one QUIC
+// stream carries one skywire transport, and the existing handshake +
+// noise layers run over the stream exactly as for the other types.
+//
+// QUIC gives reliable streams AND RFC 9221 unreliable datagrams over one
+// connection — the stream half is wired here; the datagram half (which
+// makes faithful-UDP wire-real) is the follow-on tp.WriteDatagram path.
+package network
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/quic-go/quic-go"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+const (
+	quicReRegisterInterval  = 90 * time.Second
+	quicBindRetryDelay      = 5 * time.Second
+	quicBindMaxRetryDelay   = 60 * time.Second
+	quicMaxIdleTimeout      = 60 * time.Second
+	quicKeepAlivePeriod     = 25 * time.Second
+	quicStreamAcceptTimeout = 30 * time.Second
+)
+
+// quicErrNoStream is the QUIC application error code used when closing a
+// connection that never opened (dial side) or yielded (accept side) a stream.
+const quicErrNoStream quic.ApplicationErrorCode = 1
+
+type quicClient struct {
+	*resolvedClient
+	port     int
+	udpConn  net.PacketConn
+	listener *quic.Listener
+	tlsCert  tls.Certificate
+	qconf    *quic.Config
+}
+
+func newQuic(resolved *resolvedClient, port int) Client {
+	client := &quicClient{resolvedClient: resolved, port: port}
+	client.netType = types.QUIC
+	return client
+}
+
+// quicStreamConn adapts a single QUIC stream (+ its connection) to net.Conn.
+// quic.Stream provides Read/Write/Close/deadlines but not Local/RemoteAddr;
+// those come from the connection. Close tears down the whole QUIC connection
+// (and the per-dial UDP socket on the dial side) — one transport == one
+// connection in this v1 (stream multiplexing is a later optimization).
+type quicStreamConn struct {
+	*quic.Stream
+	conn    *quic.Conn
+	udpConn net.PacketConn // non-nil on the dial side (per-dial ephemeral socket)
+}
+
+func (c *quicStreamConn) LocalAddr() net.Addr  { return c.conn.LocalAddr() }
+func (c *quicStreamConn) RemoteAddr() net.Addr { return c.conn.RemoteAddr() }
+
+func (c *quicStreamConn) Close() error {
+	_ = c.Stream.Close() //nolint:errcheck,gosec // half-close the stream, then the conn
+	err := c.conn.CloseWithError(0, "closed")
+	if c.udpConn != nil {
+		c.udpConn.Close() //nolint:errcheck,gosec
+	}
+	return err
+}
+
+// quicListener adapts a *quic.Listener to net.Listener. Each accepted QUIC
+// connection yields one bidirectional stream = one skywire transport. Stream
+// acceptance runs per-connection in a goroutine so a peer that connects but
+// never opens a stream can't stall the accept loop.
+type quicListener struct {
+	lis   *quic.Listener
+	conns chan net.Conn
+	done  chan struct{}
+	log   *logging.Logger
+}
+
+func newQuicListener(lis *quic.Listener, log *logging.Logger) *quicListener {
+	l := &quicListener{lis: lis, conns: make(chan net.Conn, 16), done: make(chan struct{}), log: log}
+	go l.acceptLoop()
+	return l
+}
+
+func (l *quicListener) acceptLoop() {
+	for {
+		conn, err := l.lis.Accept(context.Background())
+		if err != nil {
+			close(l.conns)
+			return
+		}
+		go l.handleConn(conn)
+	}
+}
+
+func (l *quicListener) handleConn(conn *quic.Conn) {
+	ctx, cancel := context.WithTimeout(context.Background(), quicStreamAcceptTimeout)
+	defer cancel()
+	stream, err := conn.AcceptStream(ctx)
+	if err != nil {
+		conn.CloseWithError(quicErrNoStream, "no stream opened") //nolint:errcheck,gosec
+		return
+	}
+	select {
+	case l.conns <- &quicStreamConn{Stream: stream, conn: conn}:
+	case <-l.done:
+		conn.CloseWithError(0, "listener closed") //nolint:errcheck,gosec
+	}
+}
+
+func (l *quicListener) Accept() (net.Conn, error) {
+	c, ok := <-l.conns
+	if !ok {
+		return nil, net.ErrClosed
+	}
+	return c, nil
+}
+
+func (l *quicListener) Close() error {
+	close(l.done)
+	return l.lis.Close()
+}
+
+func (l *quicListener) Addr() net.Addr { return l.lis.Addr() }
+
+// Dial implements Client.
+func (c *quicClient) Dial(ctx context.Context, rPK cipher.PubKey, rPort uint16) (Transport, error) {
+	if c.isClosed() {
+		return nil, io.ErrClosedPipe
+	}
+	c.log.Debugf("Dialing PK %v over QUIC", rPK)
+	conn, err := c.dialVisor(ctx, rPK, func(ctx context.Context, addr string) (net.Conn, error) {
+		return c.dial(ctx, addr, rPK)
+	})
+	if err != nil {
+		return nil, err
+	}
+	tp, err := c.initTransport(ctx, conn, rPK, rPort)
+	if err != nil {
+		conn.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return tp, nil
+}
+
+func (c *quicClient) dial(ctx context.Context, addr string, rPK cipher.PubKey) (net.Conn, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("resolve udp addr %q: %w", addr, err)
+	}
+	// Dial from a fresh ephemeral UDP socket. (Reusing the listen socket
+	// for both roles needs quic.Transport routing — a later optimization;
+	// ephemeral dial sockets work for publicly-reachable peers, which is the
+	// v1 target. NAT hole-punching is a follow-up.)
+	dialUDP, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		return nil, fmt.Errorf("bind quic dial socket: %w", err)
+	}
+	tlsConf := quicTLSConfig(c.tlsCert, &rPK, nil) // pin the remote PK at the TLS layer
+	qc, err := quic.Dial(ctx, dialUDP, udpAddr, tlsConf, c.qconf)
+	if err != nil {
+		dialUDP.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	stream, err := qc.OpenStreamSync(ctx)
+	if err != nil {
+		qc.CloseWithError(quicErrNoStream, "open stream") //nolint:errcheck,gosec
+		dialUDP.Close()                                   //nolint:errcheck,gosec
+		return nil, err
+	}
+	return &quicStreamConn{Stream: stream, conn: qc, udpConn: dialUDP}, nil
+}
+
+// Start implements Client.
+func (c *quicClient) Start() error {
+	if c.connListener != nil {
+		return ErrAlreadyListening
+	}
+	cert, err := newQUICCertificate(c.PK(), c.SK())
+	if err != nil {
+		return fmt.Errorf("quic: build identity certificate: %w", err)
+	}
+	c.tlsCert = cert
+	c.qconf = &quic.Config{
+		EnableDatagrams: true,
+		MaxIdleTimeout:  quicMaxIdleTimeout,
+		KeepAlivePeriod: quicKeepAlivePeriod,
+	}
+	go c.serve()
+	return nil
+}
+
+func (c *quicClient) serve() {
+	lis, err := c.listen()
+	if err != nil {
+		c.log.Errorf("Failed to listen: %v", err)
+		return
+	}
+	c.acceptTransports(lis)
+}
+
+func (c *quicClient) listen() (net.Listener, error) {
+	var udpConn net.PacketConn
+	var err error
+	confPort := ""
+	if c.port != 0 {
+		confPort = fmt.Sprintf(":%d", c.port)
+	}
+	for {
+		udpConn, err = net.ListenPacket("udp", confPort)
+		if err != nil {
+			c.log.WithError(err).Warnf("Failed to listen on UDP port %d", c.port)
+			c.port++
+			confPort = fmt.Sprintf(":%d", c.port)
+			continue
+		}
+		break
+	}
+	c.udpConn = udpConn
+
+	srvTLS := quicTLSConfig(c.tlsCert, nil, nil) // accept any valid skywire PK
+	qlis, err := quic.Listen(udpConn, srvTLS, c.qconf)
+	if err != nil {
+		udpConn.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	c.listener = qlis
+
+	_, localPort, err := net.SplitHostPort(udpConn.LocalAddr().String())
+	if err != nil {
+		return nil, err
+	}
+	c.log.Debugf("Successfully bound quic to UDP port %s", localPort)
+
+	// Register the QUIC UDP port with the address resolver (best-effort,
+	// retrying — mirrors STCPR). Without AR, dialing-by-PK can't resolve us,
+	// but we still listen so direct-address dials / tests work.
+	go c.bindAndReRegister(localPort)
+
+	return newQuicListener(qlis, c.log), nil
+}
+
+func (c *quicClient) bindAndReRegister(port string) {
+	delay := quicBindRetryDelay
+	for attempt := 1; ; attempt++ {
+		if err := c.ar.BindQUIC(context.Background(), port); err == nil {
+			c.log.Debugf("Successfully bound QUIC to port %s on address resolver", port)
+			break
+		} else {
+			c.log.WithError(err).Warnf("Failed to bind QUIC (attempt %d), retrying in %v", attempt, delay)
+		}
+		if c.isClosed() {
+			return
+		}
+		time.Sleep(delay)
+		delay *= 2
+		if delay > quicBindMaxRetryDelay {
+			delay = quicBindMaxRetryDelay
+		}
+	}
+
+	ticker := time.NewTicker(quicReRegisterInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.done:
+			c.log.Debug("Stopping QUIC re-registration loop")
+			return
+		case <-ticker.C:
+			if err := c.ar.BindQUIC(context.Background(), port); err != nil {
+				c.log.WithError(err).Warn("Failed to re-register QUIC with address resolver")
+			}
+		}
+	}
+}
+
+// Close implements Client. Overrides genericClient.Close to also close the
+// underlying UDP socket (quic.Listen does not own the PacketConn).
+func (c *quicClient) Close() error {
+	err := c.resolvedClient.Close()
+	if c.udpConn != nil {
+		c.udpConn.Close() //nolint:errcheck,gosec
+	}
+	return err
+}

--- a/pkg/transport/network/quic.go
+++ b/pkg/transport/network/quic.go
@@ -67,6 +67,23 @@ type quicStreamConn struct {
 func (c *quicStreamConn) LocalAddr() net.Addr  { return c.conn.LocalAddr() }
 func (c *quicStreamConn) RemoteAddr() net.Addr { return c.conn.RemoteAddr() }
 
+// WriteDatagram / ReadDatagram expose the QUIC connection's RFC 9221
+// unreliable datagram channel, making *quicStreamConn a DatagramConn. The
+// router sends faithful-UDP DatagramPackets over this channel (no head-of-line
+// blocking, genuine loss tolerance) instead of the reliable stream. These run
+// on the raw QUIC connection — below the noise stream wrapper — so the
+// transport layer captures the capability before wrapping (see transport.encrypt).
+func (c *quicStreamConn) WriteDatagram(b []byte) error {
+	return c.conn.SendDatagram(b)
+}
+
+func (c *quicStreamConn) ReadDatagram(ctx context.Context) ([]byte, error) {
+	return c.conn.ReceiveDatagram(ctx)
+}
+
+// compile-time assertion that *quicStreamConn provides the native datagram channel.
+var _ DatagramConn = (*quicStreamConn)(nil)
+
 func (c *quicStreamConn) Close() error {
 	_ = c.Stream.Close() //nolint:errcheck,gosec // half-close the stream, then the conn
 	err := c.conn.CloseWithError(0, "closed")

--- a/pkg/transport/network/quic_conn_test.go
+++ b/pkg/transport/network/quic_conn_test.go
@@ -1,0 +1,142 @@
+// Package network pkg/transport/network/quic_conn_test.go: in-process
+// integration test of a real QUIC connection secured by the skywire-PK-
+// bound TLS identity (option A). Proves the transport core — quic.Dial /
+// quic.Listen + mutual PK authentication over a stream — works end to end
+// before the address-resolver / transport-framework wiring.
+package network
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func quicTestUDP(t *testing.T) *net.UDPConn {
+	t.Helper()
+	c, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	return c
+}
+
+// TestQUICConnMutualPKAuth dials a real QUIC connection where the client
+// pins the server's skywire PK and the server learns the client's — both
+// via the option-A TLS binding — then round-trips bytes on a stream.
+func TestQUICConnMutualPKAuth(t *testing.T) {
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+
+	srvCert, err := newQUICCertificate(srvPK, srvSK)
+	require.NoError(t, err)
+	cliCert, err := newQUICCertificate(cliPK, cliSK)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var gotClientPK cipher.PubKey
+	srvTLS := quicTLSConfig(srvCert, nil, func(pk cipher.PubKey) {
+		mu.Lock()
+		gotClientPK = pk
+		mu.Unlock()
+	})
+	cliTLS := quicTLSConfig(cliCert, &srvPK, nil) // client pins server PK
+
+	qconf := &quic.Config{EnableDatagrams: true, HandshakeIdleTimeout: 5 * time.Second}
+
+	srvUDP := quicTestUDP(t)
+	defer srvUDP.Close() //nolint:errcheck
+	lis, err := quic.Listen(srvUDP, srvTLS, qconf)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	srvDone := make(chan error, 1)
+	go func() {
+		conn, err := lis.Accept(context.Background())
+		if err != nil {
+			srvDone <- err
+			return
+		}
+		stream, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			srvDone <- err
+			return
+		}
+		buf := make([]byte, 5)
+		if _, err := io.ReadFull(stream, buf); err != nil {
+			srvDone <- err
+			return
+		}
+		_, err = stream.Write(buf) // echo
+		srvDone <- err
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cliUDP := quicTestUDP(t)
+	defer cliUDP.Close() //nolint:errcheck
+	conn, err := quic.Dial(ctx, cliUDP, srvUDP.LocalAddr(), cliTLS, qconf)
+	require.NoError(t, err)
+	defer conn.CloseWithError(0, "done") //nolint:errcheck,gosec
+
+	stream, err := conn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+	_, err = stream.Write([]byte("hello"))
+	require.NoError(t, err)
+	buf := make([]byte, 5)
+	require.NoError(t, stream.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, err = io.ReadFull(stream, buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(buf))
+
+	require.NoError(t, <-srvDone)
+	mu.Lock()
+	assert.Equal(t, cliPK, gotClientPK, "server must learn the client's skywire PK")
+	mu.Unlock()
+}
+
+// TestQUICConnRejectsWrongServerPK verifies the client-side pin: dialing a
+// server while expecting a different PK fails the handshake.
+func TestQUICConnRejectsWrongServerPK(t *testing.T) {
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+	wrongPK, _ := cipher.GenerateKeyPair()
+
+	srvCert, err := newQUICCertificate(srvPK, srvSK)
+	require.NoError(t, err)
+	cliCert, err := newQUICCertificate(cliPK, cliSK)
+	require.NoError(t, err)
+
+	srvTLS := quicTLSConfig(srvCert, nil, nil)
+	cliTLS := quicTLSConfig(cliCert, &wrongPK, nil) // pin the WRONG server PK
+
+	qconf := &quic.Config{HandshakeIdleTimeout: 3 * time.Second}
+
+	srvUDP := quicTestUDP(t)
+	defer srvUDP.Close() //nolint:errcheck
+	lis, err := quic.Listen(srvUDP, srvTLS, qconf)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+	go func() {
+		// Accept may error when the client rejects the cert; ignore.
+		if c, err := lis.Accept(context.Background()); err == nil {
+			c.CloseWithError(0, "") //nolint:errcheck,gosec
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	cliUDP := quicTestUDP(t)
+	defer cliUDP.Close() //nolint:errcheck
+	conn, err := quic.Dial(ctx, cliUDP, srvUDP.LocalAddr(), cliTLS, qconf)
+	if err == nil {
+		conn.CloseWithError(0, "") //nolint:errcheck,gosec
+	}
+	require.Error(t, err, "dialing with a wrong pinned server PK must fail")
+}

--- a/pkg/transport/network/quic_conn_test.go
+++ b/pkg/transport/network/quic_conn_test.go
@@ -101,6 +101,72 @@ func TestQUICConnMutualPKAuth(t *testing.T) {
 	mu.Unlock()
 }
 
+// TestQUICDatagramRoundTrip proves the RFC 9221 datagram channel works over a
+// real QUIC connection through the quicStreamConn wrapper — this is what makes
+// faithful-UDP wire-real (no head-of-line blocking, unreliable delivery).
+func TestQUICDatagramRoundTrip(t *testing.T) {
+	srvPK, srvSK := cipher.GenerateKeyPair()
+	cliPK, cliSK := cipher.GenerateKeyPair()
+	srvCert, err := newQUICCertificate(srvPK, srvSK)
+	require.NoError(t, err)
+	cliCert, err := newQUICCertificate(cliPK, cliSK)
+	require.NoError(t, err)
+
+	srvTLS := quicTLSConfig(srvCert, nil, nil)
+	cliTLS := quicTLSConfig(cliCert, &srvPK, nil)
+	qconf := &quic.Config{EnableDatagrams: true, HandshakeIdleTimeout: 5 * time.Second}
+
+	srvUDP := quicTestUDP(t)
+	defer srvUDP.Close() //nolint:errcheck
+	lis, err := quic.Listen(srvUDP, srvTLS, qconf)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	srvConnCh := make(chan *quic.Conn, 1)
+	go func() {
+		conn, err := lis.Accept(context.Background())
+		if err != nil {
+			srvConnCh <- nil
+			return
+		}
+		// Accept the stream the client opens to drive the handshake to completion.
+		if _, err := conn.AcceptStream(context.Background()); err != nil {
+			srvConnCh <- nil
+			return
+		}
+		srvConnCh <- conn
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cliUDP := quicTestUDP(t)
+	defer cliUDP.Close() //nolint:errcheck
+	cliConn, err := quic.Dial(ctx, cliUDP, srvUDP.LocalAddr(), cliTLS, qconf)
+	require.NoError(t, err)
+	defer cliConn.CloseWithError(0, "done") //nolint:errcheck,gosec
+
+	// Open + write a stream to force the handshake (datagrams require a
+	// completed handshake).
+	stream, err := cliConn.OpenStreamSync(ctx)
+	require.NoError(t, err)
+	_, err = stream.Write([]byte("x"))
+	require.NoError(t, err)
+
+	srvConn := <-srvConnCh
+	require.NotNil(t, srvConn)
+	defer srvConn.CloseWithError(0, "done") //nolint:errcheck,gosec
+
+	// Datagram round-trip via the wrapper.
+	cliWrap := &quicStreamConn{conn: cliConn}
+	srvWrap := &quicStreamConn{conn: srvConn}
+
+	payload := []byte("faithful-udp-over-quic")
+	require.NoError(t, cliWrap.WriteDatagram(payload))
+	got, err := srvWrap.ReadDatagram(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
 // TestQUICConnRejectsWrongServerPK verifies the client-side pin: dialing a
 // server while expecting a different PK fails the handshake.
 func TestQUICConnRejectsWrongServerPK(t *testing.T) {

--- a/pkg/transport/network/quic_identity.go
+++ b/pkg/transport/network/quic_identity.go
@@ -94,11 +94,17 @@ func quicTLSConfig(cert tls.Certificate, expectedRemotePK *cipher.PubKey, onPeer
 		Certificates: []tls.Certificate{cert},
 		// We bypass the standard chain/hostname/expiry verification and run
 		// our own skywire-identity check in VerifyPeerCertificate.
-		InsecureSkipVerify:    true, //nolint:gosec // custom PK-binding verification below
-		ClientAuth:            tls.RequireAnyClientCert,
-		MinVersion:            tls.VersionTLS13,
-		NextProtos:            []string{quicTLSNextProto},
-		VerifyPeerCertificate: makeVerifyPeerCertificate(expectedRemotePK, onPeerPK),
+		InsecureSkipVerify: true, //nolint:gosec // custom PK-binding verification below
+		ClientAuth:         tls.RequireAnyClientCert,
+		MinVersion:         tls.VersionTLS13,
+		NextProtos:         []string{quicTLSNextProto},
+		// Disable session resumption so the full handshake — and thus our
+		// VerifyPeerCertificate identity check — runs on every connection.
+		// A resumed session could otherwise skip the cert check and let a
+		// peer reuse a ticket without re-proving its skywire PK. Transports
+		// are long-lived (one per peer), so the per-handshake cost is amortized.
+		SessionTicketsDisabled: true,
+		VerifyPeerCertificate:  makeVerifyPeerCertificate(expectedRemotePK, onPeerPK),
 	}
 }
 

--- a/pkg/transport/network/quic_identity.go
+++ b/pkg/transport/network/quic_identity.go
@@ -1,0 +1,169 @@
+// Package network pkg/transport/network/quic_identity.go: binds a QUIC
+// transport's TLS session to the skywire static identity (the QUIC
+// transport, option A). QUIC mandates TLS 1.3, but skywire authenticates
+// with secp256k1 keys, not a CA/PKI. So — following the libp2p-tls
+// pattern — each side presents a self-signed certificate with an ephemeral
+// TLS key, and a custom X.509 extension carries the skywire public key plus
+// a signature, by the matching skywire secret key, over the TLS key. The
+// peer's VerifyPeerCertificate extracts the extension, checks the signature
+// (proving the TLS key — hence the QUIC session — is controlled by the
+// holder of the skywire SK), and pins it to the expected remote PK. A
+// connection from the wrong PK is rejected at the TLS layer, before any
+// route setup.
+package network
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// skywireTLSExtensionOID identifies the X.509 extension that binds a QUIC
+// TLS certificate to a skywire static public key. Arc under skywire's
+// private-enterprise-style OID (53594 is arbitrary-but-fixed for skywire).
+var skywireTLSExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 53594, 1, 1}
+
+// quicTLSNextProto is the ALPN protocol id for skywire QUIC transports.
+const quicTLSNextProto = "skywire-quic-1"
+
+// skywireSignedKey is the payload carried in the skywire X.509 extension:
+// the skywire PK and a signature, by the matching skywire SK, over the
+// certificate's ephemeral TLS public key.
+type skywireSignedKey struct {
+	PubKey []byte // skywire cipher.PubKey (33-byte compressed secp256k1)
+	Sig    []byte // cipher.Sig over the cert's ed25519 public key
+}
+
+// newQUICCertificate creates a self-signed TLS certificate whose ephemeral
+// ed25519 key is bound to the skywire static identity (lPK/lSK).
+func newQUICCertificate(lPK cipher.PubKey, lSK cipher.SecKey) (tls.Certificate, error) {
+	tlsPub, tlsPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("quic: generate tls key: %w", err)
+	}
+
+	// Bind the TLS key to the skywire identity: sign the TLS public key
+	// with the skywire SK. A verifier trusting the skywire PK then trusts
+	// this TLS key (and the QUIC session it secures).
+	sig, err := cipher.SignPayload(tlsPub, lSK)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("quic: sign tls key: %w", err)
+	}
+	extVal, err := asn1.Marshal(skywireSignedKey{PubKey: lPK[:], Sig: sig[:]})
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("quic: marshal identity extension: %w", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "skywire-quic"},
+		// Validity is irrelevant — verification is the identity binding,
+		// not a CA chain or expiry (we set InsecureSkipVerify + a custom
+		// VerifyPeerCertificate). Use a wide, fixed window so clock skew
+		// across visors never rejects a peer.
+		NotBefore:             time.Unix(0, 0),
+		NotAfter:              time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		ExtraExtensions:       []pkix.Extension{{Id: skywireTLSExtensionOID, Value: extVal}},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, tlsPub, tlsPriv)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("quic: create certificate: %w", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: tlsPriv}, nil
+}
+
+// quicTLSConfig builds a *tls.Config that presents the local skywire-bound
+// certificate and verifies the peer's certificate binds to a skywire PK.
+//
+//   - expectedRemotePK != nil (dialer): the peer MUST present that exact PK.
+//   - onPeerPK != nil (listener): called with the verified remote PK so the
+//     accepting side learns who connected.
+func quicTLSConfig(cert tls.Certificate, expectedRemotePK *cipher.PubKey, onPeerPK func(cipher.PubKey)) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		// We bypass the standard chain/hostname/expiry verification and run
+		// our own skywire-identity check in VerifyPeerCertificate.
+		InsecureSkipVerify:    true, //nolint:gosec // custom PK-binding verification below
+		ClientAuth:            tls.RequireAnyClientCert,
+		MinVersion:            tls.VersionTLS13,
+		NextProtos:            []string{quicTLSNextProto},
+		VerifyPeerCertificate: makeVerifyPeerCertificate(expectedRemotePK, onPeerPK),
+	}
+}
+
+func makeVerifyPeerCertificate(expectedRemotePK *cipher.PubKey, onPeerPK func(cipher.PubKey)) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		pk, err := verifySkywireCert(rawCerts)
+		if err != nil {
+			return err
+		}
+		if expectedRemotePK != nil && pk != *expectedRemotePK {
+			return fmt.Errorf("quic: peer PK %s does not match expected %s", pk, *expectedRemotePK)
+		}
+		if onPeerPK != nil {
+			onPeerPK(pk)
+		}
+		return nil
+	}
+}
+
+// verifySkywireCert parses the leaf certificate, extracts the skywire
+// identity extension, verifies the binding signature, and returns the
+// authenticated skywire public key.
+func verifySkywireCert(rawCerts [][]byte) (cipher.PubKey, error) {
+	var zero cipher.PubKey
+	if len(rawCerts) == 0 {
+		return zero, errors.New("quic: peer presented no certificate")
+	}
+	cert, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return zero, fmt.Errorf("quic: parse peer certificate: %w", err)
+	}
+
+	var extVal []byte
+	for i := range cert.Extensions {
+		if cert.Extensions[i].Id.Equal(skywireTLSExtensionOID) {
+			extVal = cert.Extensions[i].Value
+			break
+		}
+	}
+	if extVal == nil {
+		return zero, errors.New("quic: peer certificate missing skywire identity extension")
+	}
+
+	var sk skywireSignedKey
+	if _, err := asn1.Unmarshal(extVal, &sk); err != nil {
+		return zero, fmt.Errorf("quic: bad skywire identity extension: %w", err)
+	}
+	if len(sk.PubKey) != len(cipher.PubKey{}) {
+		return zero, fmt.Errorf("quic: bad skywire PK length %d in certificate", len(sk.PubKey))
+	}
+	if len(sk.Sig) != len(cipher.Sig{}) {
+		return zero, fmt.Errorf("quic: bad signature length %d in certificate", len(sk.Sig))
+	}
+	var pk cipher.PubKey
+	copy(pk[:], sk.PubKey)
+	var sig cipher.Sig
+	copy(sig[:], sk.Sig)
+
+	edPub, ok := cert.PublicKey.(ed25519.PublicKey)
+	if !ok {
+		return zero, errors.New("quic: certificate public key is not ed25519")
+	}
+	// The signed payload is the certificate's own ed25519 public key.
+	if err := cipher.VerifyPubKeySignedPayload(pk, sig, edPub); err != nil {
+		return zero, fmt.Errorf("quic: skywire identity binding invalid: %w", err)
+	}
+	return pk, nil
+}

--- a/pkg/transport/network/quic_identity_test.go
+++ b/pkg/transport/network/quic_identity_test.go
@@ -1,0 +1,73 @@
+// Package network pkg/transport/network/quic_identity_test.go: tests the
+// skywire-PK-bound QUIC TLS identity (option A).
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// TestQUICCertBindsSkywirePK verifies a generated cert carries the skywire
+// PK and that verification recovers exactly that PK.
+func TestQUICCertBindsSkywirePK(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	cert, err := newQUICCertificate(pk, sk)
+	require.NoError(t, err)
+	require.Len(t, cert.Certificate, 1)
+
+	got, err := verifySkywireCert(cert.Certificate)
+	require.NoError(t, err)
+	assert.Equal(t, pk, got, "verification must recover the binding skywire PK")
+}
+
+// TestQUICVerifyPeerPinning verifies the dialer-side pinning: the correct
+// expected PK passes, a wrong one fails, and the listener-side onPeerPK
+// callback learns the verified PK.
+func TestQUICVerifyPeerPinning(t *testing.T) {
+	pk, sk := cipher.GenerateKeyPair()
+	other, _ := cipher.GenerateKeyPair()
+	cert, err := newQUICCertificate(pk, sk)
+	require.NoError(t, err)
+
+	// Dialer expecting the correct PK: passes.
+	verifyCorrect := makeVerifyPeerCertificate(&pk, nil)
+	require.NoError(t, verifyCorrect(cert.Certificate, nil))
+
+	// Dialer expecting a different PK: rejected.
+	verifyWrong := makeVerifyPeerCertificate(&other, nil)
+	require.Error(t, verifyWrong(cert.Certificate, nil))
+
+	// Listener (no expected PK) learns who connected.
+	var learned cipher.PubKey
+	verifyListen := makeVerifyPeerCertificate(nil, func(p cipher.PubKey) { learned = p })
+	require.NoError(t, verifyListen(cert.Certificate, nil))
+	assert.Equal(t, pk, learned)
+}
+
+// TestQUICVerifyRejectsTamperedSignature ensures a cert whose binding
+// signature was forged/corrupted fails verification — i.e. you can't
+// present someone else's skywire PK without their SK.
+func TestQUICVerifyRejectsTamperedSignature(t *testing.T) {
+	pkVictim, _ := cipher.GenerateKeyPair()
+	_, skAttacker := cipher.GenerateKeyPair()
+	// Attacker signs their own TLS key but claims the victim's PK — the
+	// binding signature won't verify against the victim's PK.
+	cert, err := newQUICCertificate(pkVictim, skAttacker)
+	require.NoError(t, err)
+
+	_, err = verifySkywireCert(cert.Certificate)
+	require.Error(t, err, "a PK not matching the signing SK must fail verification")
+}
+
+// TestQUICVerifyRejectsMissingExtension ensures a vanilla cert without the
+// skywire extension is rejected.
+func TestQUICVerifyRejectsMissingExtension(t *testing.T) {
+	_, err := verifySkywireCert([][]byte{[]byte("not-a-cert")})
+	require.Error(t, err)
+	_, err = verifySkywireCert(nil)
+	require.Error(t, err)
+}

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -15,4 +15,9 @@ const (
 	STCP Type = "stcp"
 	// DMSG is a type of a transport that works through an intermediary service
 	DMSG Type = "dmsg"
+	// QUIC is a type of a transport that works via QUIC over UDP, resolving
+	// addresses using the address-resolver service. Gives reliable streams
+	// plus RFC 9221 unreliable datagrams; the TLS session is bound to the
+	// skywire static key (#2607 QUIC follow-on).
+	QUIC Type = "quic"
 )

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -57,6 +57,8 @@ var (
 	stcprC vinit.Module
 	// STCP module
 	stcpC vinit.Module
+	// QUIC module (#2607 QUIC follow-on)
+	quicC vinit.Module
 	// dmsg pty: a remote terminal to the visor working over dmsg protocol
 	ptyModule vinit.Module
 	// Dmsg module
@@ -158,6 +160,7 @@ func registerModules(logger *logging.MasterLogger) {
 	sudphC = maker("sudph", initSudphClient, &sc, &tr)
 	stcprC = maker("stcpr", initStcprClient, &tr)
 	stcpC = maker("stcp", initStcpClient, &tr)
+	quicC = maker("quic", initQuicClient, &tr)
 	dmsgC = maker("dmsg", initDmsg, &ebc, &dmsgHTTP)
 	dmsgCtrl = maker("dmsg_ctrl", initDmsgCtrl, &dmsgC, &tr)
 	// dmsghttp_logserver mounts /pty on top of dmsgpty's CLI socket
@@ -226,7 +229,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// store. See init_group.go.
 	groupingMod = maker("grouping", initGrouping, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -399,6 +399,17 @@ func initStcprClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	return nil
 }
 
+// initQuicClient starts the experimental QUIC transport when a quic_port is
+// configured (#2607 QUIC follow-on). Opt-in: a zero port leaves it disabled.
+func initQuicClient(ctx context.Context, v *Visor, log *logging.Logger) error {
+	if v.conf.Transport == nil || v.conf.Transport.QUICPort == 0 {
+		return nil
+	}
+	log.Infof("Initializing QUIC transport on UDP port %d", v.conf.Transport.QUICPort)
+	v.tpM.InitClient(ctx, types.QUIC, v.conf.Transport.QUICPort)
+	return nil
+}
+
 func initStcpClient(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	if v.conf.STCP != nil {
 		v.tpM.InitClient(ctx, types.STCP, 0)

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -395,6 +395,11 @@ type Transport struct {
 	LogStore              *LogStore       `json:"log_store"`
 	StcprPort             int             `json:"stcpr_port"`
 	SudphPort             int             `json:"sudph_port"`
+	// QUICPort enables the experimental QUIC transport on the given UDP port
+	// (#2607 QUIC follow-on). 0 (default/omitted) disables it — QUIC is opt-in
+	// until proven on the fleet. A fixed port is preferable to ephemeral so the
+	// address-resolver registration + any firewall rule are stable.
+	QUICPort int `json:"quic_port,omitempty"`
 	// ARTransportLimit controls address resolver registration for privacy:
 	//   0 (default): stay registered indefinitely
 	//   N > 0: deregister from AR after N transports are established


### PR DESCRIPTION
Adds a **QUIC-over-UDP skynet transport** and uses its RFC 9221 datagram channel to make the merged faithful-UDP path **wire-real** (no head-of-line blocking, genuine loss tolerance). QUIC gives reliable streams *and* unreliable datagrams over one connection — mirroring skywire's existing `DataPacket`/`DatagramPacket` split exactly.

## Step 1 — QUIC reliable-stream transport
- **Option-A identity** (`quic_identity.go`): QUIC mandates TLS 1.3, but skywire authenticates with secp256k1 keys, not a CA. Following the libp2p-tls pattern, each side presents a self-signed cert with an ephemeral ed25519 key, and a custom X.509 extension carries the skywire PK + a signature (by the skywire SK) over the TLS key. `VerifyPeerCertificate` checks the binding and pins the expected remote PK — a wrong-PK peer is rejected at the TLS handshake. `SessionTicketsDisabled` so the check runs every time.
- **`quic.go`**: `quicClient`/`quicStreamConn`/`quicListener`, mirroring sudph/stcpr (AR-resolved) — dial → `quic.Dial` → stream → reuse the existing handshake + noise machinery; listen → `quic.Listen` → per-conn stream-accept. One stream = one transport (v1). STCPR-style AR re-register.
- **Wiring**: `types.QUIC`, factory case, AR client `BindQUIC` + **AR server `/bind/quic`** (safe refactor of the STCPR bind handler — STCPR path unchanged), `Transport.QUICPort` config (opt-in; 0 disables), `initQuicClient` module.

## Step 2 — faithful UDP over QUIC datagrams
- `network.DatagramConn` interface; `*quicStreamConn` implements it over `quic.Conn` `SendDatagram`/`ReceiveDatagram`. `transport.encrypt` captures the raw conn's datagram channel **before** the stream-only noise wrapper replaces it (datagram rides the raw QUIC conn — its TLS = hop-by-hop encryption; the payload is already end-to-end AEAD-sealed by the `DatagramRouteGroup`).
- `ManagedTransport.WriteDatagram` (native QUIC datagram, **falls back to the reliable stream** on non-QUIC transports or oversized datagrams — always correct) + `datagramReadLoop` (started from `Serve` for datagram-capable transports, drains QUIC datagrams into the same `readCh` → the existing `DatagramPacket` dispatch).
- `DatagramRouteGroup.WriteTo` now uses `WriteDatagram`.

## Safety / scope
- **Opt-in**: QUIC is off unless `quic_port` is set, so this is inert on existing visors. The `transport.encrypt` capture + `Serve` datagram loop only activate for QUIC transports; reliable transports (stcp/sudph/dmsg) are unaffected (the `Datagram()` capability is a concrete-type assertion, not a `Transport` interface change — no mock/impl churn).
- **Live use needs**: the AR redeployed with `/bind/quic`, and two visors with `quic_port` set. NAT hole-punching is a follow-up (v1 targets publicly-reachable nodes via the HTTP-POST bind).

## Tests
Identity (bind/recover, dialer pinning, listener learns peer, tampered-sig + missing-ext rejected); a real `quic.Dial`/`quic.Listen` connection with mutual PK auth + wrong-PK-rejected + stream round-trip; a real-QUIC RFC 9221 datagram round-trip. Router + transport + AR-api suites green; build/vet/lint clean. `quic-go` promoted to a direct dep.

Follow-ups: dmsg-over-QUIC (dmsg sessions over this transport → dmsg gains a datagram channel) and optional WebSocket fronting.