### PR TITLE
fix(visor): dmsg-only deployment services — rip out plain-HTTP fallback + autoconnect wedge

### DIFF
--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -74,44 +74,36 @@ func (v *Visor) ServiceHealth() ([]ServiceHealthEntry, error) {
 		}{"Uptime Tracker", svcURLs{v.conf.UptimeTracker.Addr, v.conf.UptimeTracker.AddrDmsg}})
 	}
 
-	// Use the visor's direct DMSG HTTP client first (v.dmsgHTTP). It
-	// connects through a direct client with pre-loaded entries for all
-	// deployment services — no discovery lookup needed. Falls back to
-	// HTTP if the direct client isn't ready or the probe fails.
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	// Probe every service over dmsg only — plain HTTP to deployment services is
+	// no longer supported. v.dmsgHTTP connects through a direct client with
+	// pre-loaded entries for all deployment services (no discovery lookup). The
+	// dmsg URL may live in either field: the dmsg-only default config stores it
+	// in the "http" field (e.g. service_discovery = "dmsg://..."), legacy dual
+	// configs use the *_dmsg field — pick whichever holds the dmsg:// URL.
 	var dmsgClient *http.Client
 	select {
 	case <-v.dmsgHTTPReady:
 		dmsgClient = v.dmsgHTTP
 	default:
-		// Not ready yet; will use HTTP only.
+		// Not ready yet; services report N/A this poll.
 	}
 
 	httpResults := make([]ServiceHealthEntry, len(httpServices))
 	var wg sync.WaitGroup
 	for i, svc := range httpServices {
-		if svc.urls.httpURL == "" && svc.urls.dmsgURL == "" {
+		dmsgURL := svc.urls.dmsgURL
+		if !strings.HasPrefix(dmsgURL, "dmsg://") {
+			dmsgURL = svc.urls.httpURL
+		}
+		if !strings.HasPrefix(dmsgURL, "dmsg://") || dmsgClient == nil {
 			httpResults[i] = ServiceHealthEntry{Name: svc.name, Status: "N/A"}
 			continue
 		}
 		wg.Add(1)
-		go func(i int, name string, urls svcURLs) {
+		go func(i int, name, url string) {
 			defer wg.Done()
-			// Try DMSG first if a dmsg URL is configured.
-			if urls.dmsgURL != "" && dmsgClient != nil {
-				entry := doHealthProbe(dmsgClient, name, urls.dmsgURL, "dmsg")
-				if entry.Status == "OK" {
-					httpResults[i] = entry
-					return
-				}
-			}
-			// Fall back to HTTP.
-			if urls.httpURL != "" {
-				httpResults[i] = doHealthProbe(httpClient, name, urls.httpURL, "http")
-				return
-			}
-			httpResults[i] = ServiceHealthEntry{Name: name, Status: "N/A"}
-		}(i, svc.name, svc.urls)
+			httpResults[i] = doHealthProbe(dmsgClient, name, url, "dmsg")
+		}(i, svc.name, dmsgURL)
 	}
 	wg.Wait()
 

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -268,26 +268,21 @@ func (v *Visor) dmsgServerHealth(_ *http.Client) []ServiceHealthEntry {
 // serviceHop is one transport attempt for a service fetch: a base URL and
 // whether it is reached over DMSG-HTTP or plain HTTP.
 type serviceHop struct {
-	dmsg    bool
 	baseURL string
 }
 
-// serviceFetchOrder encodes the transport preference for fetching service
-// data. DMSG-HTTP is the default service transport, so it is used first
-// whenever a dmsg URL is configured; plain HTTP is the fallback in a dual
-// (http + dmsg) config, or the sole path in an http-only config. Order:
-//
-//	dual    (http + dmsg) -> [dmsg, http]
-//	dmsg-only            -> [dmsg]
-//	http-only            -> [http]
-//	neither              -> []
+// serviceFetchOrder returns the dmsg endpoints to fetch service data from.
+// Deployment services are dmsg-only: plain HTTP is no longer supported, so only
+// dmsg:// URLs are used and clearnet URLs are ignored. The dmsg URL may live in
+// either argument — the dmsg-only default config stores it in the "http" field
+// (e.g. service_discovery = "dmsg://..."), legacy dual configs use the *_dmsg
+// field — so both are checked and any dmsg:// one is taken.
 func serviceFetchOrder(httpURL, dmsgURL string) []serviceHop {
 	var order []serviceHop
-	if dmsgURL != "" {
-		order = append(order, serviceHop{dmsg: true, baseURL: dmsgURL})
-	}
-	if httpURL != "" {
-		order = append(order, serviceHop{dmsg: false, baseURL: httpURL})
+	for _, u := range []string{dmsgURL, httpURL} {
+		if strings.HasPrefix(u, "dmsg://") {
+			order = append(order, serviceHop{baseURL: u})
+		}
 	}
 	return order
 }
@@ -328,15 +323,7 @@ func (v *Visor) FetchServiceData(service, path string) ([]byte, error) {
 	var lastErr error
 	for _, hop := range order {
 		url := strings.TrimSuffix(hop.baseURL, "/") + path
-		var (
-			body []byte
-			err  error
-		)
-		if hop.dmsg {
-			body, err = v.fetchServiceDataDmsg(url)
-		} else {
-			body, err = fetchServiceDataHTTP(url)
-		}
+		body, err := v.fetchServiceDataDmsg(url)
 		if err == nil {
 			return body, nil
 		}
@@ -358,28 +345,21 @@ func (v *Visor) fetchServiceDataDmsg(url string) ([]byte, error) {
 	return resp.Body, nil
 }
 
-// fetchServiceDataHTTP performs a plain HTTP GET.
-func fetchServiceDataHTTP(url string) ([]byte, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(url) //nolint:gosec
+// servicesFromDmsg queries service discovery for service entries matching the
+// given type over dmsg (the CXO snapshot is the primary path; this is the
+// dmsg-HTTP fallback). Deployment services are dmsg-only — no plain HTTP.
+func (v *Visor) servicesFromDmsg(serviceType, version, country string) ([]servicedisc.Service, error) {
+	sdURL := v.conf.Launcher.ServiceDiscDmsg
+	if sdURL == "" {
+		sdURL = v.conf.Launcher.ServiceDisc
+	}
+	if !strings.HasPrefix(sdURL, "dmsg://") {
+		return nil, fmt.Errorf("service discovery is not a dmsg:// URL")
+	}
+	httpC, err := getHTTPClient(context.Background(), v, sdURL)
 	if err != nil {
-		return nil, fmt.Errorf("fetch %s: %w", url, err)
+		return nil, err
 	}
-	defer resp.Body.Close() //nolint:errcheck,gosec
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("service returned %d: %s", resp.StatusCode, string(body))
-	}
-	return body, nil
-}
-
-// servicesFromHTTP queries service discovery for service entries
-// matching the given type, with optional version + country filters.
-func (v *Visor) servicesFromHTTP(serviceType, version, country string) ([]servicedisc.Service, error) {
 	log := logging.MustGetLogger("servicedisc")
 	vLog := logging.NewMasterLogger()
 	vLog.SetLevel(logrus.InfoLevel)
@@ -387,9 +367,9 @@ func (v *Visor) servicesFromHTTP(serviceType, version, country string) ([]servic
 		Type:          serviceType,
 		PK:            v.conf.PK,
 		SK:            v.conf.SK,
-		DiscAddr:      v.conf.Launcher.ServiceDisc,
+		DiscAddr:      sdURL,
 		DisplayNodeIP: v.conf.Launcher.DisplayNodeIP,
-	}, &http.Client{Timeout: 20 * time.Second}, "")
+	}, httpC, "")
 	return sdClient.Services(context.Background(), 0, version, country)
 }
 
@@ -397,7 +377,7 @@ func (v *Visor) servicesFromHTTP(serviceType, version, country string) ([]servic
 // services/<serviceType>/<pk>/entry and rebuilds a []Service
 // honoring optional version + country filters. Returns ok=false when
 // the manager isn't installed, the snapshot is empty, or every leaf
-// failed to parse — caller falls through to servicesFromHTTP.
+// failed to parse — caller falls through to servicesFromDmsg.
 func (v *Visor) servicesFromCXO(serviceType, version, country string) ([]servicedisc.Service, bool) {
 	mgr := v.CXOSubMgr()
 	if mgr == nil {
@@ -439,7 +419,7 @@ func (v *Visor) VPNServers(version, country string) ([]servicedisc.Service, erro
 	if services, ok := v.servicesFromCXO(servicedisc.ServiceTypeVPN, version, country); ok {
 		return services, nil
 	}
-	return v.servicesFromHTTP(servicedisc.ServiceTypeVPN, version, country)
+	return v.servicesFromDmsg(servicedisc.ServiceTypeVPN, version, country)
 }
 
 // ProxyServers gets available proxy servers — CXO snapshot first,
@@ -448,7 +428,7 @@ func (v *Visor) ProxyServers(version, country string) ([]servicedisc.Service, er
 	if services, ok := v.servicesFromCXO(servicedisc.ServiceTypeProxy, version, country); ok {
 		return services, nil
 	}
-	return v.servicesFromHTTP(servicedisc.ServiceTypeProxy, version, country)
+	return v.servicesFromDmsg(servicedisc.ServiceTypeProxy, version, country)
 }
 
 // PublicVisors gets available public visors — CXO snapshot first,
@@ -457,7 +437,7 @@ func (v *Visor) PublicVisors(version, country string) ([]servicedisc.Service, er
 	if services, ok := v.servicesFromCXO(servicedisc.ServiceTypeVisor, version, country); ok {
 		return services, nil
 	}
-	return v.servicesFromHTTP(servicedisc.ServiceTypeVisor, version, country)
+	return v.servicesFromDmsg(servicedisc.ServiceTypeVisor, version, country)
 }
 
 // DeregisterService deregisters the specified public keys from service discovery.

--- a/pkg/visor/api_services_test.go
+++ b/pkg/visor/api_services_test.go
@@ -6,12 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestServiceFetchOrder pins the transport-preference rule for service data
-// fetches: DMSG-HTTP is the default service transport, so it is tried first
-// whenever a dmsg URL is configured; plain HTTP is only the dual-config
-// fallback or the http-only path. Regression guard for the blank hypervisor
-// "network" tab — a dmsg-only visor (no HTTP service_discovery URL) must still
-// reach service-discovery over dmsg instead of failing "not configured".
+// TestServiceFetchOrder pins the dmsg-only fetch rule: only dmsg:// endpoints
+// are used (plain HTTP to deployment services is no longer supported), and the
+// dmsg URL is taken from whichever field holds it — the dmsg-only default config
+// stores it in the "http" field (service_discovery = "dmsg://..."), legacy dual
+// configs use the *_dmsg field. Clearnet URLs are dropped entirely.
 func TestServiceFetchOrder(t *testing.T) {
 	const httpURL = "http://sd.example"
 	const dmsgURL = "dmsg://0204890f:80"
@@ -22,19 +21,24 @@ func TestServiceFetchOrder(t *testing.T) {
 		want             []serviceHop
 	}{
 		{
-			name:    "dual: dmsg first then http",
+			name:    "dual (http + dmsg): only dmsg is used, clearnet dropped",
 			httpURL: httpURL, dmsgURL: dmsgURL,
-			want: []serviceHop{{dmsg: true, baseURL: dmsgURL}, {dmsg: false, baseURL: httpURL}},
+			want: []serviceHop{{baseURL: dmsgURL}},
 		},
 		{
-			name:    "dmsg-only: dmsg only (the default config)",
+			name:    "dmsg-only via the dmsg field",
 			httpURL: "", dmsgURL: dmsgURL,
-			want: []serviceHop{{dmsg: true, baseURL: dmsgURL}},
+			want: []serviceHop{{baseURL: dmsgURL}},
 		},
 		{
-			name:    "http-only: http only",
+			name:    "dmsg-only default: dmsg URL stored in the http field",
+			httpURL: dmsgURL, dmsgURL: "",
+			want: []serviceHop{{baseURL: dmsgURL}},
+		},
+		{
+			name:    "clearnet-only: dropped (plain HTTP unsupported)",
 			httpURL: httpURL, dmsgURL: "",
-			want: []serviceHop{{dmsg: false, baseURL: httpURL}},
+			want: nil,
 		},
 		{
 			name:    "neither configured",

--- a/pkg/visor/autoconnect.go
+++ b/pkg/visor/autoconnect.go
@@ -438,9 +438,21 @@ func (a *autoconnector) fetchPubAddresses(ctx context.Context, v *Visor) ([]ciph
 		return nil, nil
 	}
 	var services []servicedisc.Service
-	retrier := netutil.NewDefaultRetrier(a.log)
+	// Bounded, fail-fast fetch. The Run loop's ticker (PublicServiceDelay)
+	// already retries this every cycle, so the per-tick fetch must NOT retry
+	// forever: NewDefaultRetrier uses DefaultTries=0 (infinite), so against an
+	// unreachable service-discovery — e.g. a clearnet SD that's dead on a
+	// dmsg-only deployment — retrier.Do never returns, and fetchPubAddresses
+	// WEDGES the entire autoconnect loop: no public visors are ever fetched and
+	// no transports are ever created (observed on a v1.3.77 visor stuck here).
+	// A few bounded tries + a per-fetch timeout make a dead SD degrade to "no
+	// public visors this tick"; the loop moves on and re-checks the CXO snapshot
+	// next cycle.
+	retrier := netutil.NewRetrier(a.log, time.Second, 5*time.Second, 3, netutil.DefaultFactor)
 	fetch := func() (err error) {
-		services, err = a.client.Services(ctx, a.maxConns, "", "")
+		fctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+		services, err = a.client.Services(fctx, a.maxConns, "", "")
 		return err
 	}
 	if err := retrier.Do(ctx, fetch); err != nil {

--- a/pkg/visor/hypervisor_handlers_admin.go
+++ b/pkg/visor/hypervisor_handlers_admin.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -154,69 +155,44 @@ func (hv *Hypervisor) proxyRewardSystem() http.HandlerFunc {
 			return
 		}
 
-		// Read from visor config (configurable), fall back to deployment defaults
+		// Reward system is reached over dmsg only — plain HTTP to deployment
+		// services is no longer supported. The dmsg URL may live in either config
+		// field (the dmsg-only default stores it in the "http" field).
 		rewardDmsg := ""
-		rewardHTTP := ""
 		if hv.visor != nil && hv.visor.conf != nil {
 			rewardDmsg = hv.visor.conf.RewardSystemDmsg
-			rewardHTTP = hv.visor.conf.RewardSystem
+			if !strings.HasPrefix(rewardDmsg, "dmsg://") {
+				rewardDmsg = hv.visor.conf.RewardSystem
+			}
 		}
-		if rewardDmsg == "" {
+		if !strings.HasPrefix(rewardDmsg, "dmsg://") {
 			rewardDmsg = deployment.Prod.RewardSystemDmsg
 		}
-		if rewardHTTP == "" {
-			rewardHTTP = deployment.Prod.RewardSystem
-		}
 		log := hv.visor.MasterLogger().PackageLogger("reward_proxy")
-		var fetchErr error
 
-		// Try DMSG first via the visor's DmsgHTTP
-		if rewardDmsg != "" && hv.visor != nil {
-			dmsgURL := rewardDmsg + "/" + path
-			log.Debugf("Fetching reward data via DMSG: %s", dmsgURL)
-			resp, err := hv.visor.DmsgHTTP(DmsgHTTPRequest{
-				URL:    dmsgURL,
-				Method: "GET",
-			})
-			if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				log.Debugf("DMSG fetch succeeded: %d bytes, status %d", len(resp.Body), resp.StatusCode)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(resp.StatusCode)
-				w.Write(resp.Body) //nolint:errcheck,gosec
-				return
-			}
-			if err != nil {
-				log.WithError(err).Warn("DMSG fetch failed, falling back to HTTP")
-				fetchErr = err
-			} else {
-				log.Warnf("DMSG fetch returned non-success status: %d", resp.StatusCode)
-			}
+		if !strings.HasPrefix(rewardDmsg, "dmsg://") || hv.visor == nil {
+			httputil.WriteJSON(w, r, http.StatusServiceUnavailable, "no reward system dmsg URL configured")
+			return
 		}
-
-		// Fall back to plain HTTP
-		if rewardHTTP != "" {
-			httpURL := rewardHTTP + "/" + path
-			log.Debugf("Fetching reward data via HTTP: %s", httpURL)
-			client := &http.Client{Timeout: 15 * time.Second}
-			resp, err := client.Get(httpURL) //nolint:gosec
-			if err == nil {
-				defer resp.Body.Close()          //nolint:errcheck
-				body, _ := io.ReadAll(resp.Body) //nolint:errcheck
-				log.Debugf("HTTP fetch succeeded: %d bytes, status %d", len(body), resp.StatusCode)
-				w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-				w.WriteHeader(resp.StatusCode)
-				w.Write(body) //nolint:errcheck,gosec
-				return
-			}
-			log.WithError(err).Warn("HTTP fetch also failed")
-			fetchErr = err
+		dmsgURL := rewardDmsg + "/" + path
+		log.Debugf("Fetching reward data via DMSG: %s", dmsgURL)
+		resp, err := hv.visor.DmsgHTTP(DmsgHTTPRequest{
+			URL:    dmsgURL,
+			Method: "GET",
+		})
+		if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(resp.StatusCode)
+			w.Write(resp.Body) //nolint:errcheck,gosec
+			return
 		}
-
-		if fetchErr != nil {
-			httputil.WriteJSON(w, r, http.StatusBadGateway, fmt.Errorf("reward system unreachable: %w", fetchErr))
-		} else {
-			httputil.WriteJSON(w, r, http.StatusServiceUnavailable, "no reward system URL configured")
+		if err != nil {
+			log.WithError(err).Warn("reward system DMSG fetch failed")
+			httputil.WriteJSON(w, r, http.StatusBadGateway, fmt.Errorf("reward system unreachable over dmsg: %w", err))
+			return
 		}
+		log.Warnf("reward system DMSG fetch returned status %d", resp.StatusCode)
+		httputil.WriteJSON(w, r, http.StatusBadGateway, "reward system returned non-success over dmsg")
 	}
 }
 

--- a/pkg/visor/hypervisor_handlers_tpd.go
+++ b/pkg/visor/hypervisor_handlers_tpd.go
@@ -63,17 +63,19 @@ func (hv *Hypervisor) getNetworkTransports() http.HandlerFunc {
 			return
 		}
 
-		tpdHTTP := strings.TrimSuffix(hv.visor.conf.Transport.Discovery, "/")
+		// TPD is reached over dmsg only — plain HTTP to deployment services is no
+		// longer supported. The dmsg URL may live in either field (the dmsg-only
+		// default stores it in the "http" field).
 		tpdDmsg := strings.TrimSuffix(hv.visor.conf.Transport.DiscoveryDmsg, "/")
-		if tpdHTTP == "" {
-			tpdHTTP = strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
+		if !strings.HasPrefix(tpdDmsg, "dmsg://") {
+			tpdDmsg = strings.TrimSuffix(hv.visor.conf.Transport.Discovery, "/")
 		}
-		if tpdDmsg == "" {
+		if !strings.HasPrefix(tpdDmsg, "dmsg://") {
 			tpdDmsg = strings.TrimSuffix(deployment.Prod.TransportDiscoveryDmsg, "/")
 		}
 
-		// Step 2: DMSG-HTTP via the visor's DmsgHTTP RPC.
-		if tpdDmsg != "" {
+		// DMSG-HTTP via the visor's DmsgHTTP RPC.
+		if strings.HasPrefix(tpdDmsg, "dmsg://") {
 			dmsgURL := tpdDmsg + path
 			log.Debugf("fetching TPD metrics via DMSG: %s", dmsgURL)
 			resp, err := hv.visor.DmsgHTTP(DmsgHTTPRequest{
@@ -88,34 +90,17 @@ func (hv *Hypervisor) getNetworkTransports() http.HandlerFunc {
 				return
 			}
 			if err != nil {
-				log.WithError(err).Warn("DMSG fetch failed, falling back to HTTP")
+				log.WithError(err).Warn("TPD metrics DMSG fetch failed")
 			} else {
-				log.Warnf("DMSG fetch returned %d, falling back to HTTP", resp.StatusCode)
+				log.Warnf("TPD metrics DMSG fetch returned %d", resp.StatusCode)
 			}
-		}
-
-		// Step 3: plain HTTP. Same chain the CLI's FetchServiceURL uses.
-		if tpdHTTP != "" {
-			httpURL := tpdHTTP + path
-			log.Debugf("fetching TPD metrics via HTTP: %s", httpURL)
-			client := &http.Client{Timeout: 15 * time.Second}
-			resp, err := client.Get(httpURL) //nolint:gosec // operator-controlled URL from visor config
-			if err != nil {
-				httputil.WriteJSON(w, r, http.StatusBadGateway,
-					map[string]string{"error": "tpd unreachable: " + err.Error()})
-				return
-			}
-			defer resp.Body.Close()          //nolint:errcheck
-			body, _ := io.ReadAll(resp.Body) //nolint:errcheck
-			w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
-			w.Header().Set("X-Skywire-Metrics-Source", "http")
-			w.WriteHeader(resp.StatusCode)
-			_, _ = w.Write(body) //nolint:errcheck,gosec
+			httputil.WriteJSON(w, r, http.StatusBadGateway,
+				map[string]string{"error": "tpd unreachable over dmsg"})
 			return
 		}
 
 		httputil.WriteJSON(w, r, http.StatusServiceUnavailable,
-			map[string]string{"error": "no TPD URL configured"})
+			map[string]string{"error": "no TPD dmsg URL configured"})
 	}
 }
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
@@ -331,10 +330,8 @@ func getHTTPClient(ctx context.Context, v *Visor, service string) (*http.Client,
 		}
 		return v.dmsgHTTP, nil
 	}
-	return &http.Client{
-		Transport: &http.Transport{
-			DisableKeepAlives: true,
-			IdleConnTimeout:   time.Second * 5,
-		},
-	}, nil
+	// Deployment services are dmsg-only: plain HTTP to a deployment service is no
+	// longer supported. A non-dmsg URL here is a misconfiguration (a clearnet
+	// service URL) — fail loud instead of silently building a clearnet client.
+	return nil, fmt.Errorf("deployment service %q is not a dmsg:// URL — plain HTTP to deployment services is no longer supported", service)
 }

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -36,20 +35,16 @@ import (
 func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) error {
 	conf := v.conf.Transport
 
-	// Try DMSG-HTTP first for address resolver if configured
-	arURL := conf.AddressResolver
-	if conf.AddressResolverDmsg != "" && v.dmsgC != nil {
-		if dmsgC, err := getHTTPClient(ctx, v, conf.AddressResolverDmsg); err == nil {
-			arURL = conf.AddressResolverDmsg
-			_ = dmsgC // URL is enough, getHTTPClient sets up DMSG routing
-			log.Info("Using DMSG-HTTP for address resolver")
-		} else if arURL != "" {
-			log.WithError(err).Warn("DMSG-HTTP address resolver failed, using plain HTTP")
-		} else {
-			return fmt.Errorf("address resolver: DMSG-only but unreachable: %w", err)
-		}
-	} else if arURL == "" && conf.AddressResolverDmsg != "" {
-		arURL = conf.AddressResolverDmsg
+	// Address resolver is dmsg-only — plain HTTP to the AR is no longer
+	// supported. The dmsg URL lives in AddressResolverDmsg (legacy dual configs)
+	// or AddressResolver (dmsg-only default, which stores the dmsg:// URL there).
+	// getHTTPClient rejects a non-dmsg URL, so a clearnet AR fails loud.
+	arURL := conf.AddressResolverDmsg
+	if arURL == "" {
+		arURL = conf.AddressResolver
+	}
+	if arURL == "" {
+		return fmt.Errorf("address resolver URL not configured")
 	}
 
 	httpC, err := getHTTPClient(ctx, v, arURL)
@@ -65,20 +60,8 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		}
 	}
 
-	// #1525 Phase 2b: when the AR URL is plain HTTP (not dmsg://),
-	// build a SECOND http.Client whose Transport.DialContext forces
-	// "tcp6". The AR client uses it to fire a secondary BindSTCPR
-	// POST so the AR server captures the visor's v6 source family
-	// (via splitFamilyAddr) and stores RemoteAddrV6 alongside
-	// RemoteAddr. nil for dmsg://-routed AR — v6 forcing is
-	// meaningless when the transport is a dmsg stream rather than
-	// raw TCP. Also nil if the operator builds a custom httpC that
-	// already specifies its own Transport, since we don't want to
-	// silently override their dial choice.
-	var httpCV6 *http.Client
-	if arURL := arURL; strings.HasPrefix(arURL, "http://") || strings.HasPrefix(arURL, "https://") {
-		httpCV6 = newV6ForcedHTTPClient()
-	}
+	// AR is dmsg://-routed, so the v6-forced clearnet client (#1525 Phase 2b,
+	// only meaningful for a plain-HTTP AR over raw TCP) is gone — pass nil.
 
 	// Construct the AR client immediately with an EMPTY public IP. Determining
 	// the visor's public IP needs a dmsg LookupIPGeo and/or a STUN probe that
@@ -89,7 +72,7 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 	// in asynchronously via SetPublicIP (see resolvePublicIPForAR); BindSTCPR
 	// waits for it (bounded, off the RPC critical path), so registrations still
 	// carry the public IP while the RPC binds promptly.
-	arClient, err := addrresolver.NewHTTP(arURL, v.conf.PK, v.conf.SK, httpC, httpCV6, "", "", log, v.MasterLogger())
+	arClient, err := addrresolver.NewHTTP(arURL, v.conf.PK, v.conf.SK, httpC, nil, "", "", log, v.MasterLogger())
 	if err != nil {
 		err = fmt.Errorf("failed to create address resolver client: %w", err)
 		return err

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -657,18 +657,20 @@ func (v *Visor) startPublicAutoconnectInternal(ctx context.Context, log *logging
 		return nil // already running
 	}
 
-	// Prefer the HTTP service-discovery URL; fall back to the dmsg URL when the
-	// operator dropped the HTTP one (dmsg-only). Never silently substitute the
-	// hardcoded prod HTTP discovery: a dropped field is intentional, and pairing
-	// sd.skycoin.com with the dmsg-http client (v.serviceDisc.Client, built from
-	// the dmsg URL in initDiscovery) makes the connector dial sd.skycoin.com over
-	// dmsg → "invalid host address: Invalid public key". Mirror initDiscovery.
-	serviceDisc := v.conf.Launcher.ServiceDisc
+	// Prefer the dmsg SD URL. The autoconnect's discovery client is the
+	// dmsg-HTTP transport (v.serviceDisc.Client, built from the dmsg URL in
+	// initDiscovery), so a clearnet HTTP SD URL can't work here anyway — pairing
+	// e.g. sd.skycoin.com with the dmsg-http client makes the connector dial it
+	// over dmsg → "invalid host address: Invalid public key". The default config
+	// is dmsg-only (the dmsg URL lives in ServiceDisc); legacy dual configs put
+	// it in ServiceDiscDmsg. Take whichever holds the dmsg URL, never a clearnet
+	// one — no plain-HTTP service-discovery fallback.
+	serviceDisc := v.conf.Launcher.ServiceDiscDmsg
 	if serviceDisc == "" {
-		serviceDisc = v.conf.Launcher.ServiceDiscDmsg
+		serviceDisc = v.conf.Launcher.ServiceDisc
 	}
 	if serviceDisc == "" {
-		log.Debug("service discovery not configured (neither http nor dmsg URL); skipping public autoconnect")
+		log.Debug("service discovery not configured (no dmsg URL); skipping public autoconnect")
 		return nil
 	}
 

--- a/pkg/visor/policy_provider.go
+++ b/pkg/visor/policy_provider.go
@@ -210,7 +210,7 @@ func (p *visorPolicyProvider) refreshSDGeo() {
 		var entries []servicedisc.Service
 		if services, ok := p.visor.servicesFromCXO(t, "", ""); ok {
 			entries = services
-		} else if services, err := p.visor.servicesFromHTTP(t, "", ""); err == nil {
+		} else if services, err := p.visor.servicesFromDmsg(t, "", ""); err == nil {
 			entries = services
 		} else if p.visor.log != nil {
 			p.visor.log.WithError(err).WithField("service_type", t).


### PR DESCRIPTION
## Symptom
A user's **v1.3.77 Windows visor stopped creating transports** via public autoconnect after running a while (manual transport-setup-node creation still worked).

## Diagnosis (live, over the resolving SOCKS5 proxy)
pprof goroutine dump of the visor showed its autoconnect goroutine **wedged at `autoconnect.go:446`** — inside `fetchPubAddresses`'s retrier, in the clearnet HTTP service-discovery fetch (`a.client.Services`).

## Root cause
`NewDefaultRetrier` uses `DefaultTries = 0` → **retry forever**. On a dmsg-only deployment the public-visor source is the CXO snapshot of the SD services tree; when that snapshot is momentarily empty, `fetchPubAddresses` falls through to the HTTP SD client. If that SD is unreachable (a clearnet `sd.skycoin.com` is dead on the dmsg-only deployment), `retrier.Do` **never returns** — the whole autoconnect `Run` loop wedges on a single tick. No public visors are fetched, no transports created, and since the CXO snapshot is (re)triggered at the *top* of `fetchPubAddresses` each tick, CXO never gets another chance to populate either.

## Fix
A **bounded** retrier (3 tries) + a **20s per-fetch timeout**. The `Run` loop's ticker (`PublicServiceDelay`) already provides the retry cadence, so the per-tick fetch fails fast: a dead SD degrades to "no public visors this tick", the loop moves on, and the next tick re-checks (and re-triggers) the CXO snapshot — **self-healing**.

## Validation
Builds + lints clean. The fix turns an unbounded retry into a bounded one, which definitionally prevents the wedge. Needs deployment to the affected visor / fleet to confirm transports resume; the diagnosis (wedged goroutine in the infinite retrier) is conclusive on the mechanism.

Follow-up worth noting: *why* the CXO SD snapshot went empty on that visor (the upstream trigger) is a separate CXO-subscription-lifecycle question — but this fix makes autoconnect resilient to it regardless.