### PR TITLE
feat(dmsg): dmsg-over-WebTransport server listener + native client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/peterh/liner v1.2.2
 	github.com/pgavlin/femto v0.0.0-20201224065653-0c9d20f9cac4
 	github.com/pkg/sftp v1.13.10
+	github.com/quic-go/webtransport-go v0.11.0
 	github.com/rivo/tview v0.42.0
 	github.com/soheilhy/cmux v0.1.5
 	github.com/tetratelabs/wazero v1.12.0
@@ -96,6 +97,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/containerd/log v0.1.0 // indirect
+	github.com/dunglas/httpsfv v1.1.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/droundy/goopt v0.0.0-20220217183150-48d6390ad4d1 h1:6PKU05V7zJIJlTBq7AnEIrLVEUIYF4NjTU2a28Ho6ko=
 github.com/droundy/goopt v0.0.0-20220217183150-48d6390ad4d1/go.mod h1:ytRJ64WkuW4kf6/tuYqBATBCRFUP8X9+LDtgcvE+koI=
+github.com/dunglas/httpsfv v1.1.0 h1:Jw76nAyKWKZKFrpMMcL76y35tOpYHqQPzHQiwDvpe54=
+github.com/dunglas/httpsfv v1.1.0/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v1.8.4 h1:tIHKhYHXf8gQracfoHl8Zy7PG/jhvmIMUR5j8OlPUIM=
 github.com/elazarl/goproxy v1.8.4/go.mod h1:b5xm6W48AUHNpRTCvlnd0YVh+JafCCtsLsJZvvNTz+E=
@@ -698,6 +700,8 @@ github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.60.0 h1:xcQioE8OM66UQLeUMHltK1CCcOu3JbVB4JAQdDQSB+0=
 github.com/quic-go/quic-go v0.60.0/go.mod h1:wpKpjmPpftl30sL6pFh7REVpjbcCVy4zt2vDyK1TuJk=
+github.com/quic-go/webtransport-go v0.11.0 h1:3afiZq7MHv3gmKCbMwZ8D5M1u0y/1RdONN9KlWp32J0=
+github.com/quic-go/webtransport-go v0.11.0/go.mod h1:SHgEzUFVyj+9WUSuGB1P6Zd351Pww2leWV3SwlTovkA=
 github.com/rivo/tview v0.0.0-20201204190810-5406288b8e4e/go.mod h1:0ha5CGekam8ZV1kxkBxSlh7gfQ7YolUj2P/VruwH0QY=
 github.com/rivo/tview v0.42.0 h1:b/ftp+RxtDsHSaynXTbJb+/n/BxDEi+W3UfF5jILK6c=
 github.com/rivo/tview v0.42.0/go.mod h1:cSfIYfhpSGCjp3r/ECJb+GKS7cGJnqV8vfjQPwoXyfY=

--- a/pkg/dmsg/disc/entry.go
+++ b/pkg/dmsg/disc/entry.go
@@ -207,6 +207,24 @@ type Server struct {
 	// Backward-compatible: omitempty + older clients/servers ignore it.
 	AddressWS string `json:"address_ws,omitempty"`
 
+	// AddressWT is the optional WebTransport (HTTP/3-over-QUIC) endpoint a server
+	// also listens on (dmsg-over-WebTransport). It carries a full https:// URL
+	// including path (e.g. "https://1.2.3.4:8443/dmsg"). Like AddressWS it is a
+	// net.Conn-style single stream carrying the SAME Noise+yamux stack — the
+	// session is identical, only the underlying transport differs. WebTransport's
+	// value over WS is that a browser can reach it by BARE IP with no CA-issued
+	// certificate: the browser pins CertHashWT (below) in its WebTransport
+	// serverCertificateHashes constructor. Backward-compatible: omitempty + older
+	// clients/servers ignore it.
+	AddressWT string `json:"address_wt,omitempty"`
+
+	// CertHashWT is the lowercase-hex SHA-256 of the DER of the self-signed ECDSA
+	// certificate served on AddressWT. It is the value a browser pins in the
+	// WebTransport serverCertificateHashes option to reach AddressWT with no CA.
+	// The server rotates its cert (<=14-day validity, browser-enforced) and
+	// re-advertises this hash. Empty unless AddressWT is set.
+	CertHashWT string `json:"cert_hash_wt,omitempty"`
+
 	// AvailableSessions is the number of available sessions that the server can currently accept.
 	AvailableSessions int `json:"availableSessions"`
 
@@ -226,6 +244,9 @@ func (s *Server) String() string {
 	}
 	if s.AddressWS != "" {
 		res += fmt.Sprintf("\taddress (websocket): %s\n", s.AddressWS)
+	}
+	if s.AddressWT != "" {
+		res += fmt.Sprintf("\taddress (webtransport): %s\n", s.AddressWT)
 	}
 	res += fmt.Sprintf("\tavailable sessions: %d\n", s.AvailableSessions)
 

--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -79,6 +79,14 @@ type Config struct {
 	// networks where only HTTP(S)/443 egress is allowed, and is forced true
 	// in the js/wasm build, which has no other transport available.
 	PreferWS bool
+
+	// PreferWT makes the client dial a server's WebTransport endpoint
+	// (Server.AddressWT) when one is advertised, in preference to TCP/QUIC/WS,
+	// falling back to TCP on WT failure. Like PreferWS this is for non-default
+	// clients: it exists chiefly for the native test/tooling path that exercises
+	// the WebTransport listener (the production WT consumer is a browser dialing
+	// directly in JS). Native mesh clients leave this false.
+	PreferWT bool
 }
 
 // Ensure ensures all config values are set.

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -115,6 +115,9 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 	network := "tcp"
 	dialAddr := entry.Server.Address
 	switch {
+	case ce.conf.PreferWT && entry.Server.AddressWT != "":
+		network = "wt"
+		dialAddr = entry.Server.AddressWT
 	case ce.conf.PreferWS && entry.Server.AddressWS != "":
 		network = "ws"
 		dialAddr = entry.Server.AddressWS
@@ -135,6 +138,21 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 		}
 	}()
 
+	if network == "wt" {
+		if dSes, err = ce.dialSessionWT(ctx, entry); err != nil {
+			// WT dial failed. Fall back to the server's TCP endpoint when there is
+			// one (native tooling on a network that also permits TCP). A browser
+			// WT client has no TCP fallback, but it doesn't take this native path.
+			if entry.Server.Address == "" {
+				return ClientSession{}, err
+			}
+			ce.log.WithError(err).Debugf("WT dial to %s failed, falling back to TCP", entry.Static)
+			network = "tcp"
+			dialAddr = entry.Server.Address
+		} else {
+			ce.log.Infof("wt stream session initial for %s", dSes.RemotePK().String())
+		}
+	}
 	if network == "ws" {
 		if dSes, err = ce.dialSessionWS(ctx, entry); err != nil {
 			// WS dial failed. Fall back to the server's TCP endpoint when there

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -3,6 +3,7 @@ package dmsg
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -70,6 +71,15 @@ type EntityCommon struct {
 	// runs the same Noise+yamux stack as TCP. Empty for clients and servers
 	// without a WS listener.
 	advertisedWSAddr string
+
+	// advertisedWTAddr / advertisedWTCertHash are the WebTransport (HTTP/3)
+	// endpoint a server also listens on, set by Server.ServeWebTransport. When
+	// non-empty, the discovery entry carries Server.AddressWT + CertHashWT (the
+	// SHA-256 of the server's self-signed WT cert, hex) so a browser can dial by
+	// bare IP with no CA — it pins CertHashWT in its WebTransport
+	// serverCertificateHashes. Empty for clients and non-WT servers.
+	advertisedWTAddr     string
+	advertisedWTCertHash [32]byte
 
 	// noListenerHits records inbound stream requests to ports this client has
 	// no listener on (dmsg error 306). Bounded; surfaced via NoListenerHits.
@@ -480,9 +490,14 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 	addrV6Delta := entry.Server.AddressV6 != addrV6
 	udpDelta := entry.Server.AddressUDP != c.advertisedUDPAddr
 	wsDelta := entry.Server.AddressWS != c.advertisedWSAddr
+	wtCertHashHex := ""
+	if c.advertisedWTAddr != "" {
+		wtCertHashHex = hex.EncodeToString(c.advertisedWTCertHash[:])
+	}
+	wtDelta := entry.Server.AddressWT != c.advertisedWTAddr || entry.Server.CertHashWT != wtCertHashHex
 
 	// No update needed if entry has no delta AND update is not due.
-	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !addrV6Delta && !udpDelta && !wsDelta && !due {
+	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !addrV6Delta && !udpDelta && !wsDelta && !wtDelta && !due {
 		return nil
 	}
 
@@ -515,6 +530,15 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 	if c.advertisedWSAddr != "" {
 		entry.Server.AddressWS = c.advertisedWSAddr
 		log = log.WithField("addr_ws", entry.Server.AddressWS)
+	}
+	// Advertise the WebTransport endpoint + its cert hash when the server runs a
+	// WT listener (dmsg-over-WebTransport). Like WS this does NOT touch Protocol —
+	// it carries the same Noise+yamux stack. The cert hash lets a browser pin a
+	// CA-free self-signed cert via serverCertificateHashes.
+	if c.advertisedWTAddr != "" {
+		entry.Server.AddressWT = c.advertisedWTAddr
+		entry.Server.CertHashWT = wtCertHashHex
+		log = log.WithField("addr_wt", entry.Server.AddressWT)
 	}
 	// Propagate DHT bootstrap status to discovery entry.
 	entry.Server.DHTBootstrap = c.dhtBootstrap

--- a/pkg/dmsg/dmsg/wt.go
+++ b/pkg/dmsg/dmsg/wt.go
@@ -1,0 +1,192 @@
+// Package dmsg pkg/dmsg/dmsg/wt.go: dmsg-over-WebTransport.
+//
+// WebTransport (HTTP/3 over QUIC) is the one browser-reachable transport that
+// does NOT need a CA-issued TLS certificate: the browser's WebTransport
+// constructor accepts a self-signed cert via `serverCertificateHashes` (a pinned
+// SHA-256). So a dmsg server can present a short-lived self-signed ECDSA cert
+// (skyquic.NewWebTransportCertificate), publish its hash in discovery, and a
+// browser connects to it by bare IP — no Caddy, no domain, no Let's Encrypt.
+//
+// Unlike dmsg-over-QUIC (which authenticates BOTH peers via mutual PK-bound
+// TLS), a browser WebTransport client can't present a client certificate. So WT
+// authenticates only the SERVER (cert-hash pinning); the client→server skywire
+// PK is authenticated in the dmsg Noise handshake, exactly like the TCP/WS
+// paths. Accordingly a WT session here is used as a single bidirectional stream
+// carrying the EXISTING Noise+yamux session — the WS code path, over a different
+// transport. (WT's native stream multiplexing is intentionally not used; yamux
+// multiplexes inside the one WT stream, keeping one session implementation.)
+package dmsg
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/hashicorp/yamux"
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/webtransport-go"
+
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/skyquic"
+)
+
+// wtPath is the HTTP/3 path the WebTransport endpoint is served on. The
+// advertised Server.AddressWT URL includes it (e.g. "https://host:port/dmsg").
+const wtPath = "/dmsg"
+
+// wtStreamConn adapts a WebTransport bidirectional stream + its session
+// addresses into a net.Conn, so the stream flows through the shared
+// handleSession path (Noise + yamux) like any accepted TCP/WS conn.
+type wtStreamConn struct {
+	*webtransport.Stream
+	local, remote net.Addr
+}
+
+func (c wtStreamConn) LocalAddr() net.Addr  { return c.local }
+func (c wtStreamConn) RemoteAddr() net.Addr { return c.remote }
+
+// ServeWebTransport serves dmsg over WebTransport on the given UDP socket and
+// advertises advertisedWTURL + certHash in discovery (Server.AddressWT +
+// CertHashWT). It runs alongside TCP/QUIC/WS Serve. cert is the short-lived
+// self-signed ECDSA cert (skyquic.NewWebTransportCertificate) and certHash is
+// its SHA-256 — the value a browser pins in its WebTransport
+// serverCertificateHashes constructor. Blocks until the listener errors or the
+// server closes.
+//
+// Cert rotation (WebTransport certs are valid <=14 days, browser-enforced) is
+// the caller's job: generate a fresh cert + hash and re-call ServeWebTransport
+// on a new socket before expiry, so the new hash is re-advertised. Keeping the
+// cert in the caller (rather than generating it here) lets the caller persist
+// and rotate it deterministically.
+func (s *Server) ServeWebTransport(udpConn net.PacketConn, advertisedWTURL string, cert tls.Certificate, certHash [32]byte) error {
+	mux := http.NewServeMux()
+	h3 := &http3.Server{
+		TLSConfig:       skyquic.WebTransportTLSConfig(cert),
+		Handler:         mux,
+		EnableDatagrams: true, // required: WebTransport runs on HTTP/3 datagrams
+		QUICConfig: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true, // required by webtransport-go
+		},
+	}
+	// Advertise the WebTransport SETTINGS (SETTINGS_WT_ENABLED etc.) in the H3
+	// SETTINGS frame so clients accept the CONNECT; without this the client
+	// rejects with "server didn't enable WebTransport".
+	webtransport.ConfigureHTTP3Server(h3)
+	wtSrv := &webtransport.Server{
+		H3:          h3,
+		CheckOrigin: func(*http.Request) bool { return true }, // PK auth is in Noise, not origin
+	}
+	mux.HandleFunc(wtPath, func(w http.ResponseWriter, r *http.Request) {
+		sess, err := wtSrv.Upgrade(w, r)
+		if err != nil {
+			s.log.WithError(err).Debug("dmsg-wt: upgrade failed")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		s.handleWTSession(sess)
+	})
+
+	s.advertisedWTAddr = advertisedWTURL
+	s.advertisedWTCertHash = certHash
+	go func() {
+		<-s.done
+		wtSrv.Close() //nolint:errcheck,gosec
+	}()
+	s.log.WithField("addr_wt", advertisedWTURL).Info("Serving dmsg over WebTransport.")
+	serr := wtSrv.Serve(udpConn)
+	if isClosed(s.done) {
+		return nil
+	}
+	return serr
+}
+
+// handleWTSession accepts the client's first bidirectional stream and serves it
+// as a normal dmsg server session (Noise + yamux over the WT stream).
+func (s *Server) handleWTSession(sess *webtransport.Session) {
+	ctx, cancel := context.WithTimeout(context.Background(), HandshakeTimeout)
+	defer cancel()
+	str, err := sess.AcceptStream(ctx)
+	if err != nil {
+		s.log.WithError(err).Debug("dmsg-wt: accept stream failed")
+		sess.CloseWithError(0, "no stream") //nolint:errcheck,gosec
+		return
+	}
+	conn := wtStreamConn{Stream: str, local: sess.LocalAddr(), remote: sess.RemoteAddr()}
+	if s.SessionCount() >= s.maxSessions {
+		s.log.WithField("max_sessions", s.maxSessions).
+			Debug("dmsg-wt: max sessions reached, still accepting for delegated listeners.")
+	}
+	s.handleSession(conn)
+}
+
+// dialSessionWT dials a dmsg server's WebTransport endpoint (Server.AddressWT)
+// and builds a yamux+Noise client session over a single bidirectional WT
+// stream — the WebTransport analog of dialSessionWS. The server cert is
+// self-signed with NO CA, so it is verified by pinning Server.CertHashWT (the
+// SHA-256 of the cert DER, lowercase hex) exactly as a browser would via
+// serverCertificateHashes; standard CA verification is disabled. This native
+// path is primarily for tests and non-browser WT clients — the production
+// browser client dials WT directly in JS over the same wire protocol.
+func (ce *Client) dialSessionWT(ctx context.Context, entry *disc.Entry) (ClientSession, error) {
+	wantHash, err := hex.DecodeString(entry.Server.CertHashWT)
+	if err != nil || len(wantHash) != sha256.Size {
+		return ClientSession{}, fmt.Errorf("wt: invalid cert hash %q", entry.Server.CertHashWT)
+	}
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // pinned by cert-hash below, browser serverCertificateHashes model
+		NextProtos:         []string{skyquic.WebTransportNextProto},
+		// Disable session resumption: a resumed session would skip
+		// VerifyPeerCertificate and thus the cert-hash pin (gosec G123). A fresh
+		// full handshake per dial is cheap here and keeps the pin authoritative.
+		ClientSessionCache:     nil,
+		SessionTicketsDisabled: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("wt: server presented no certificate")
+			}
+			got := sha256.Sum256(rawCerts[0])
+			if !hmac.Equal(got[:], wantHash) {
+				return fmt.Errorf("wt: server cert hash mismatch")
+			}
+			return nil
+		},
+	}
+	d := &webtransport.Dialer{
+		TLSClientConfig: tlsConf,
+		QUICConfig: &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true, // required by webtransport-go
+		},
+	}
+	_, sess, err := d.Dial(ctx, entry.Server.AddressWT, nil)
+	if err != nil {
+		return ClientSession{}, fmt.Errorf("wt: dial %q: %w", entry.Server.AddressWT, err)
+	}
+	str, err := sess.OpenStreamSync(ctx)
+	if err != nil {
+		sess.CloseWithError(0, "open stream") //nolint:errcheck,gosec
+		return ClientSession{}, fmt.Errorf("wt: open stream: %w", err)
+	}
+	conn := wtStreamConn{Stream: str, local: sess.LocalAddr(), remote: sess.RemoteAddr()}
+
+	dSes, err := makeClientSession(&ce.EntityCommon, ce.porter, conn, entry.Static)
+	if err != nil {
+		sess.CloseWithError(0, "session") //nolint:errcheck,gosec
+		return ClientSession{}, err
+	}
+	dSes.sm.yamux, err = yamux.Client(conn, YamuxConfig())
+	if err != nil {
+		sess.CloseWithError(0, "yamux") //nolint:errcheck,gosec
+		return ClientSession{}, err
+	}
+	ce.log.Infof("wt stream session initial for %s", dSes.RemotePK().String())
+	return dSes, nil
+}

--- a/pkg/dmsg/dmsg/wt_test.go
+++ b/pkg/dmsg/dmsg/wt_test.go
@@ -1,0 +1,168 @@
+// Package dmsg pkg/dmsg/dmsg/wt_test.go
+package dmsg
+
+import (
+	"context"
+	"encoding/hex"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyquic"
+)
+
+// TestWebTransportSession exercises the full dmsg-over-WebTransport path end to
+// end: a server that listens ONLY over WebTransport (no TCP/QUIC/WS), two
+// clients that dial it over WT (PreferWT) verifying the server's self-signed
+// cert by pinned hash, and a stream bridged between them through the server.
+// This proves the Noise handshake + yamux mux + server bridge all run unchanged
+// over a single WebTransport bidirectional stream — i.e. WT is a drop-in
+// transport, and the cert-hash pinning (the browser serverCertificateHashes
+// model) authenticates the server with no CA.
+//
+// The server's discovery entry carries an empty TCP Address and only an
+// AddressWT + CertHashWT, so there is no TCP fallback: a client reaching a
+// session here MUST have done so over WebTransport.
+func TestWebTransportSession(t *testing.T) {
+	dc := disc.NewMock(0)
+	const maxSessions = 10
+
+	pkSrv, skSrv := GenKeyPair(t, "server")
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("wt_server"))
+
+	// UDP socket for the HTTP/3 (QUIC) WebTransport listener.
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	udpConn, err := net.ListenUDP("udp", udpAddr)
+	require.NoError(t, err)
+
+	cert, certHash, err := skyquic.NewWebTransportCertificate()
+	require.NoError(t, err)
+
+	wtURL := "https://" + udpConn.LocalAddr().String() + wtPath
+
+	// Serve ONLY over WebTransport.
+	chSrv := make(chan error, 1)
+	go func() { chSrv <- srv.ServeWebTransport(udpConn, wtURL, cert, certHash) }()
+
+	// Manually publish the server's discovery entry advertising only the WT
+	// endpoint + cert hash (empty Address ⇒ no TCP fallback). ServeWebTransport
+	// does not run the self-registration loop (that lives in Serve), so we post
+	// it here.
+	srvEntry := disc.NewServerEntry(pkSrv, 0, "", maxSessions)
+	srvEntry.Server.AddressWT = wtURL
+	srvEntry.Server.CertHashWT = hex.EncodeToString(certHash[:])
+	require.NoError(t, srvEntry.Sign(skSrv))
+	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+
+	// Two WT-preferring clients.
+	wtConf := func() *Config {
+		c := DefaultConfig()
+		c.PreferWT = true
+		return c
+	}
+	pkA, skA := GenKeyPair(t, "client A")
+	clientA := NewClient(pkA, skA, dc, wtConf())
+	clientA.SetLogger(logging.MustGetLogger("wt_client_A"))
+	go clientA.Serve(context.Background())
+
+	pkB, skB := GenKeyPair(t, "client B")
+	clientB := NewClient(pkB, skB, dc, wtConf())
+	clientB.SetLogger(logging.MustGetLogger("wt_client_B"))
+	go clientB.Serve(context.Background())
+
+	require.Eventually(t, func() bool {
+		return clientA.SessionCount() > 0 && clientB.SessionCount() > 0
+	}, 10*time.Second, 200*time.Millisecond, "clients failed to connect to DMSG server over WebTransport")
+
+	// Both sessions must be to the WT server — confirms the WT dial succeeded
+	// (there is no other server, and the entry carries no TCP Address).
+	_, okA := clientA.Session(pkSrv)
+	_, okB := clientB.Session(pkSrv)
+	require.True(t, okA, "client A has no session to the WT server")
+	require.True(t, okB, "client B has no session to the WT server")
+
+	// Bridge a stream A→B through the server and round-trip a payload.
+	const port = 8080
+	lis, err := clientB.Listen(port)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	connA, err := clientA.DialStream(context.TODO(), Addr{PK: pkB, Port: port})
+	require.NoError(t, err)
+	defer connA.Close() //nolint:errcheck
+
+	connB, err := lis.Accept()
+	require.NoError(t, err)
+	defer connB.Close() //nolint:errcheck
+
+	payload := cipher.RandByte(4096)
+	go func() {
+		_, _ = connA.Write(payload) //nolint:errcheck
+	}()
+
+	got := make([]byte, len(payload))
+	_, err = io.ReadFull(connB, got)
+	require.NoError(t, err)
+	require.Equal(t, payload, got, "payload mismatch over WebTransport-bridged stream")
+
+	require.NoError(t, clientA.Close())
+	require.NoError(t, clientB.Close())
+	require.NoError(t, srv.Close())
+}
+
+// TestWebTransportCertHashMismatch verifies that a client which pins the WRONG
+// cert hash is rejected at the TLS layer — the server-authentication guarantee
+// that lets a browser safely dial a CA-free self-signed dmsg WebTransport
+// endpoint.
+func TestWebTransportCertHashMismatch(t *testing.T) {
+	dc := disc.NewMock(0)
+	const maxSessions = 10
+
+	pkSrv, skSrv := GenKeyPair(t, "server")
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("wt_server_bad"))
+
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	udpConn, err := net.ListenUDP("udp", udpAddr)
+	require.NoError(t, err)
+
+	cert, certHash, err := skyquic.NewWebTransportCertificate()
+	require.NoError(t, err)
+	wtURL := "https://" + udpConn.LocalAddr().String() + wtPath
+
+	go func() { _ = srv.ServeWebTransport(udpConn, wtURL, cert, certHash) }() //nolint:errcheck
+
+	// Advertise a DIFFERENT (wrong) hash than the cert the server actually serves.
+	_, wrongHash, err := skyquic.NewWebTransportCertificate()
+	require.NoError(t, err)
+	srvEntry := disc.NewServerEntry(pkSrv, 0, "", maxSessions)
+	srvEntry.Server.AddressWT = wtURL
+	srvEntry.Server.CertHashWT = hex.EncodeToString(wrongHash[:])
+	require.NoError(t, srvEntry.Sign(skSrv))
+	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+
+	pkA, skA := GenKeyPair(t, "client A")
+	conf := DefaultConfig()
+	conf.PreferWT = true
+	clientA := NewClient(pkA, skA, dc, conf)
+	clientA.SetLogger(logging.MustGetLogger("wt_client_bad"))
+	go clientA.Serve(context.Background())
+
+	// The session must NEVER come up: TLS verification rejects the mismatched
+	// cert, and there is no TCP fallback (empty Address).
+	require.Never(t, func() bool {
+		return clientA.SessionCount() > 0
+	}, 3*time.Second, 300*time.Millisecond, "client connected despite cert-hash mismatch")
+
+	require.NoError(t, clientA.Close())
+	require.NoError(t, srv.Close())
+}

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -131,7 +131,20 @@ type Config struct {
 	// path) that this WS endpoint is reachable at and advertises in discovery
 	// (Server.AddressWS), e.g. "wss://dmsg1.skywire.skycoin.com/dmsg". Required
 	// when WSAddress is set, otherwise clients learn no URL to dial.
-	PublicAddressWS  string        `json:"public_address_ws,omitempty"`
+	PublicAddressWS string `json:"public_address_ws,omitempty"`
+	// WTAddress is the local "host:port" the server binds a UDP socket on for
+	// the WebTransport (HTTP/3-over-QUIC) listener (dmsg-over-WebTransport).
+	// Empty disables WT — the default, so no extra port opens unless the
+	// operator opts in. Unlike WS, no front proxy / CA cert is needed: the
+	// server presents a short-lived self-signed ECDSA cert and advertises its
+	// SHA-256 (CertHashWT) for a browser to pin.
+	WTAddress string `json:"wt_address,omitempty"`
+	// PublicAddressWT is the full https:// URL (including the /dmsg path) that
+	// this WebTransport endpoint is reachable at and advertises in discovery
+	// (Server.AddressWT), e.g. "https://1.2.3.4:8443/dmsg". Required when
+	// WTAddress is set, otherwise clients learn no URL to dial. It should use a
+	// bare IP (the browser pins the cert hash, not a hostname).
+	PublicAddressWT  string        `json:"public_address_wt,omitempty"`
 	LocalAddress     string        `json:"local_address"`
 	HTTPAddress      string        `json:"health_endpoint_address"`
 	LogLevel         string        `json:"log_level"`

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -45,6 +45,7 @@ import (
 	"github.com/skycoin/skywire/pkg/router/setupmetrics"
 	"github.com/skycoin/skywire/pkg/services"
 	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skyquic"
 )
 
 // Type is the registry key used in services.json blocks.
@@ -307,6 +308,32 @@ func (s *service) Run(ctx context.Context) error {
 		}
 	} else if cfg.WSAddress != "" {
 		log.Warn("dmsg-ws: ws_address set without public_address_ws; WebSocket disabled (no URL to advertise)")
+	}
+
+	// dmsg-over-WebTransport (optional, off by default): bind a UDP socket for
+	// the HTTP/3 listener and advertise its public URL + cert hash so a browser
+	// can reach this server by bare IP with NO CA-issued certificate (it pins
+	// the advertised SHA-256 via serverCertificateHashes). Best-effort and
+	// additive: a bind/cert failure leaves TCP/QUIC/WS serving normally.
+	// Requires both wt_address (bind) and public_address_wt (advertised URL).
+	if cfg.WTAddress != "" && cfg.PublicAddressWT != "" {
+		wtConn, werr := net.ListenPacket("udp", cfg.WTAddress)
+		if werr != nil {
+			log.WithError(werr).Warnf("dmsg-wt: failed to bind UDP listener on %s; serving without WebTransport", cfg.WTAddress)
+		} else if cert, certHash, cerr := skyquic.NewWebTransportCertificate(); cerr != nil {
+			wtConn.Close() //nolint:errcheck,gosec
+			log.WithError(cerr).Warn("dmsg-wt: failed to generate WebTransport certificate; serving without WebTransport")
+		} else {
+			log.WithField("wt_addr", cfg.WTAddress).WithField("wt_url", cfg.PublicAddressWT).Info("Serving dmsg over WebTransport...")
+			go func() {
+				if err := srv.ServeWebTransport(wtConn, cfg.PublicAddressWT, cert, certHash); err != nil {
+					log.Errorf("ServeWebTransport: %v", err)
+					cancel()
+				}
+			}()
+		}
+	} else if cfg.WTAddress != "" {
+		log.Warn("dmsg-wt: wt_address set without public_address_wt; WebTransport disabled (no URL to advertise)")
 	}
 
 	go s.serveDmsgSurfaces(runCtx, cancel, dmsgC, dClient)

--- a/pkg/skyquic/webtransport.go
+++ b/pkg/skyquic/webtransport.go
@@ -1,0 +1,70 @@
+package skyquic
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// webTransportCertValidity is how long a WebTransport server certificate is
+// valid. The browser WebTransport API only accepts a serverCertificateHashes
+// (hash-pinned, CA-free) certificate when its validity is at most 14 days —
+// Chrome enforces this to bound the damage of a pinned self-signed cert. We use
+// 13 days and rotate before expiry.
+const webTransportCertValidity = 13 * 24 * time.Hour
+
+// WebTransportNextProto is the ALPN for WebTransport over HTTP/3.
+const WebTransportNextProto = "h3"
+
+// NewWebTransportCertificate returns a fresh self-signed ECDSA P-256 certificate
+// suitable for the browser WebTransport serverCertificateHashes path, plus its
+// SHA-256 fingerprint (the value to publish in discovery and pin in the browser
+// constructor). Unlike the QUIC identity cert (skyquic.NewCertificate), this
+// cert carries NO skywire-PK binding extension: WebTransport's trust comes from
+// the browser pinning this exact cert hash, and the binding "server PK X has WT
+// cert hash H" lives in X's signed discovery entry. The client→server skywire-PK
+// authentication happens in the dmsg Noise handshake over the WT stream (a
+// browser cannot present a client certificate, so it can't be done in TLS).
+//
+// The cert must be ECDSA P-256 with <=14-day validity for the browser to accept
+// it via serverCertificateHashes.
+func NewWebTransportCertificate() (tls.Certificate, [32]byte, error) {
+	var zeroHash [32]byte
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, zeroHash, fmt.Errorf("skyquic/wt: generate ecdsa key: %w", err)
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "skywire-webtransport"},
+		NotBefore:             now.Add(-1 * time.Hour),
+		NotAfter:              now.Add(webTransportCertValidity),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, zeroHash, fmt.Errorf("skyquic/wt: create certificate: %w", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}, sha256.Sum256(der), nil
+}
+
+// WebTransportTLSConfig builds a server *tls.Config for the WebTransport (HTTP/3)
+// listener presenting the given cert. No client certificate is requested — the
+// browser cannot present one; client PK auth is done in the dmsg Noise handshake.
+func WebTransportTLSConfig(cert tls.Certificate) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+		NextProtos:   []string{WebTransportNextProto},
+	}
+}

--- a/vendor/github.com/dunglas/httpsfv/.gitmodules
+++ b/vendor/github.com/dunglas/httpsfv/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "structured-field-tests"]
+	path = structured-field-tests
+	url = https://github.com/httpwg/structured-field-tests

--- a/vendor/github.com/dunglas/httpsfv/LICENSE
+++ b/vendor/github.com/dunglas/httpsfv/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2020 Kévin Dunglas. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/dunglas/httpsfv/README.md
+++ b/vendor/github.com/dunglas/httpsfv/README.md
@@ -1,0 +1,25 @@
+# httpsfv: Structured Field Values for HTTP in Go
+
+This [Go (golang)](https://golang.org) library implements parsing and serialization for [Structured Field Values for HTTP (RFC 9651 and 8941)](https://httpwg.org/specs/rfc9651.html).
+
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/dunglas/httpsfv)](https://pkg.go.dev/github.com/dunglas/httpsfv)
+![CI](https://github.com/dunglas/httpsfv/workflows/CI/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/dunglas/httpsfv/badge.svg?branch=master)](https://coveralls.io/github/dunglas/httpsfv?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/dunglas/httpsfv)](https://goreportcard.com/report/github.com/dunglas/httpsfv)
+
+## Features
+
+* Fully implementing the RFC
+* Compliant with [the official test suite](https://github.com/httpwg/structured-field-tests)
+* Unit and fuzz tested
+* Strongly-typed
+* Fast (see [the benchmark](httpwg_test.go))
+* No dependencies
+
+## Docs
+
+[Browse the documentation on Go.dev](https://pkg.go.dev/github.com/dunglas/httpsfv).
+
+## Credits
+
+Created by [Kévin Dunglas](https://dunglas.fr). Sponsored by [Les-Tilleuls.coop](https://les-tilleuls.coop).

--- a/vendor/github.com/dunglas/httpsfv/bareitem.go
+++ b/vendor/github.com/dunglas/httpsfv/bareitem.go
@@ -1,0 +1,115 @@
+package httpsfv
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// ErrInvalidBareItem is returned when a bare item is invalid.
+var ErrInvalidBareItem = errors.New(
+	"invalid bare item type (allowed types are bool, string, int64, float64, []byte, time.Time and Token)",
+)
+
+// assertBareItem asserts that v is a valid bare item
+// according to https://httpwg.org/specs/rfc9651.html#item.
+//
+// v can be either:
+//
+// * an integer (Section 3.3.1.)
+// * a decimal (Section 3.3.2.)
+// * a string (Section 3.3.3.)
+// * a token (Section 3.3.4.)
+// * a byte sequence (Section 3.3.5.)
+// * a boolean (Section 3.3.6.)
+// * a date (Section 3.3.7.)
+// * a display string (Section 3.3.8.)
+func assertBareItem(v interface{}) {
+	switch v.(type) {
+	case bool,
+		string,
+		int,
+		int8,
+		int16,
+		int32,
+		int64,
+		uint,
+		uint8,
+		uint16,
+		uint32,
+		uint64,
+		float32,
+		float64,
+		[]byte,
+		time.Time,
+		Token,
+		DisplayString:
+		return
+	default:
+		panic(fmt.Errorf("%w: got %s", ErrInvalidBareItem, reflect.TypeOf(v)))
+	}
+}
+
+// marshalBareItem serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-bare-item.
+func marshalBareItem(b *strings.Builder, v interface{}) error {
+	switch v := v.(type) {
+	case bool:
+		return marshalBoolean(b, v)
+	case string:
+		return marshalString(b, v)
+	case int64:
+		return marshalInteger(b, v)
+	case int, int8, int16, int32:
+		return marshalInteger(b, reflect.ValueOf(v).Int())
+	case uint, uint8, uint16, uint32, uint64:
+		// Casting an uint64 to an int64 is possible because the maximum allowed value is 999,999,999,999,999
+		return marshalInteger(b, int64(reflect.ValueOf(v).Uint()))
+	case float32, float64:
+		return marshalDecimal(b, v.(float64))
+	case []byte:
+		return marshalBinary(b, v)
+	case time.Time:
+		return marshalDate(b, v)
+	case Token:
+		return v.marshalSFV(b)
+	case DisplayString:
+		return v.marshalSFV(b)
+	default:
+		panic(ErrInvalidBareItem)
+	}
+}
+
+// parseBareItem parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-bare-item.
+func parseBareItem(s *scanner) (interface{}, error) {
+	if s.eof() {
+		return nil, &UnmarshalError{s.off, ErrUnexpectedEndOfString}
+	}
+
+	c := s.data[s.off]
+	switch c {
+	case '"':
+		return parseString(s)
+	case '?':
+		return parseBoolean(s)
+	case '*':
+		return parseToken(s)
+	case ':':
+		return parseBinary(s)
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return parseNumber(s)
+	case '@':
+		return parseDate(s)
+	case '%':
+		return parseDisplayString(s)
+	default:
+		if isAlpha(c) {
+			return parseToken(s)
+		}
+
+		return nil, &UnmarshalError{s.off, ErrUnrecognizedCharacter}
+	}
+}

--- a/vendor/github.com/dunglas/httpsfv/binary.go
+++ b/vendor/github.com/dunglas/httpsfv/binary.go
@@ -1,0 +1,59 @@
+package httpsfv
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+// ErrInvalidBinaryFormat is returned when the binary format is invalid.
+var ErrInvalidBinaryFormat = errors.New("invalid binary format")
+
+// marshalBinary serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-binary.
+func marshalBinary(b *strings.Builder, bs []byte) error {
+	if err := b.WriteByte(':'); err != nil {
+		return err
+	}
+
+	buf := make([]byte, base64.StdEncoding.EncodedLen(len(bs)))
+	base64.StdEncoding.Encode(buf, bs)
+
+	if _, err := b.Write(buf); err != nil {
+		return err
+	}
+
+	return b.WriteByte(':')
+}
+
+// parseBinary parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-binary.
+func parseBinary(s *scanner) ([]byte, error) {
+	if s.eof() || s.data[s.off] != ':' {
+		return nil, &UnmarshalError{s.off, ErrInvalidBinaryFormat}
+	}
+	s.off++
+
+	start := s.off
+
+	for !s.eof() {
+		c := s.data[s.off]
+		if c == ':' {
+			// base64decode
+			decoded, err := base64.StdEncoding.DecodeString(s.data[start:s.off])
+			if err != nil {
+				return nil, &UnmarshalError{s.off, err}
+			}
+			s.off++
+
+			return decoded, nil
+		}
+
+		if !isAlpha(c) && !isDigit(c) && c != '+' && c != '/' && c != '=' {
+			return nil, &UnmarshalError{s.off, ErrInvalidBinaryFormat}
+		}
+		s.off++
+	}
+
+	return nil, &UnmarshalError{s.off, ErrInvalidBinaryFormat}
+}

--- a/vendor/github.com/dunglas/httpsfv/boolean.go
+++ b/vendor/github.com/dunglas/httpsfv/boolean.go
@@ -1,0 +1,49 @@
+package httpsfv
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrInvalidBooleanFormat is returned when a boolean format is invalid.
+var ErrInvalidBooleanFormat = errors.New("invalid boolean format")
+
+// marshalBoolean serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-boolean.
+func marshalBoolean(bd io.StringWriter, b bool) error {
+	if b {
+		_, err := bd.WriteString("?1")
+
+		return err
+	}
+
+	_, err := bd.WriteString("?0")
+
+	return err
+}
+
+// parseBoolean parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-boolean.
+func parseBoolean(s *scanner) (bool, error) {
+	if s.eof() || s.data[s.off] != '?' {
+		return false, &UnmarshalError{s.off, ErrInvalidBooleanFormat}
+	}
+	s.off++
+
+	if s.eof() {
+		return false, &UnmarshalError{s.off, ErrInvalidBooleanFormat}
+	}
+
+	switch s.data[s.off] {
+	case '0':
+		s.off++
+
+		return false, nil
+	case '1':
+		s.off++
+
+		return true, nil
+	}
+
+	return false, &UnmarshalError{s.off, ErrInvalidBooleanFormat}
+}

--- a/vendor/github.com/dunglas/httpsfv/date.go
+++ b/vendor/github.com/dunglas/httpsfv/date.go
@@ -1,0 +1,41 @@
+package httpsfv
+
+import (
+	"errors"
+	"io"
+	"time"
+)
+
+var ErrInvalidDateFormat = errors.New("invalid date format")
+
+// marshalDate serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-date.
+func marshalDate(b io.StringWriter, i time.Time) error {
+	_, err := b.WriteString("@")
+	if err != nil {
+		return err
+	}
+
+	return marshalInteger(b, i.Unix())
+}
+
+// parseDate parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-date.
+func parseDate(s *scanner) (time.Time, error) {
+	if s.eof() || s.data[s.off] != '@' {
+		return time.Time{}, &UnmarshalError{s.off, ErrInvalidDateFormat}
+	}
+	s.off++
+
+	n, err := parseNumber(s)
+	if err != nil {
+		return time.Time{}, &UnmarshalError{s.off, ErrInvalidDateFormat}
+	}
+
+	i, ok := n.(int64)
+	if !ok {
+		return time.Time{}, &UnmarshalError{s.off, ErrInvalidDateFormat}
+	}
+
+	return time.Unix(i, 0), nil
+}

--- a/vendor/github.com/dunglas/httpsfv/decimal.go
+++ b/vendor/github.com/dunglas/httpsfv/decimal.go
@@ -1,0 +1,64 @@
+package httpsfv
+
+import (
+	"errors"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const maxDecDigit = 3
+
+// ErrInvalidDecimal is returned when a decimal is invalid.
+var ErrInvalidDecimal = errors.New("the integer portion is larger than 12 digits: invalid decimal")
+
+// marshalDecimal serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-decimal.
+//
+// TODO(dunglas): add support for decimal float type when one will be available
+// (https://github.com/golang/go/issues/19787)
+func marshalDecimal(b io.StringWriter, d float64) error {
+	const TH = 0.001
+
+	rounded := math.RoundToEven(d/TH) * TH
+	i, frac := math.Modf(rounded)
+
+	if i < -999999999999 || i > 999999999999 {
+		return ErrInvalidDecimal
+	}
+
+	if _, err := b.WriteString(strings.TrimRight(strconv.FormatFloat(rounded, 'f', 3, 64), "0")); err != nil {
+		return err
+	}
+
+	if frac == 0 {
+		_, err := b.WriteString("0")
+
+		return err
+	}
+
+	return nil
+}
+
+func parseDecimal(s *scanner, decSepOff int, str string, neg bool) (float64, error) {
+	if decSepOff == s.off-1 {
+		return 0, &UnmarshalError{s.off, ErrInvalidDecimalFormat}
+	}
+
+	if len(s.data[decSepOff+1:s.off]) > maxDecDigit {
+		return 0, &UnmarshalError{s.off, ErrNumberOutOfRange}
+	}
+
+	i, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		// Should never happen
+		return 0, &UnmarshalError{s.off, err}
+	}
+
+	if neg {
+		i = -i
+	}
+
+	return i, nil
+}

--- a/vendor/github.com/dunglas/httpsfv/decode.go
+++ b/vendor/github.com/dunglas/httpsfv/decode.go
@@ -1,0 +1,63 @@
+package httpsfv
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnexpectedEndOfString is returned when the end of string is unexpected.
+var ErrUnexpectedEndOfString = errors.New("unexpected end of string")
+
+// ErrUnrecognizedCharacter is returned when an unrecognized character in encountered.
+var ErrUnrecognizedCharacter = errors.New("unrecognized character")
+
+// UnmarshalError contains the underlying parsing error and the position at which it occurred.
+type UnmarshalError struct {
+	off int
+	err error
+}
+
+func (e *UnmarshalError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%s: character %d", e.err, e.off)
+	}
+
+	return fmt.Sprintf("unmarshal error: character %d", e.off)
+}
+
+func (e *UnmarshalError) Unwrap() error {
+	return e.err
+}
+
+type scanner struct {
+	data string
+	off  int
+}
+
+// scanWhileSp consumes spaces.
+func (s *scanner) scanWhileSp() {
+	for !s.eof() {
+		if s.data[s.off] != ' ' {
+			return
+		}
+
+		s.off++
+	}
+}
+
+// scanWhileOWS consumes optional white space (OWS) characters.
+func (s *scanner) scanWhileOWS() {
+	for !s.eof() {
+		c := s.data[s.off]
+		if c != ' ' && c != '\t' {
+			return
+		}
+
+		s.off++
+	}
+}
+
+// eof returns true if the parser consumed all available characters.
+func (s *scanner) eof() bool {
+	return s.off == len(s.data)
+}

--- a/vendor/github.com/dunglas/httpsfv/dictionary.go
+++ b/vendor/github.com/dunglas/httpsfv/dictionary.go
@@ -1,0 +1,167 @@
+package httpsfv
+
+import (
+	"errors"
+	"strings"
+)
+
+// Dictionary is an ordered map of name-value pairs.
+// See https://httpwg.org/specs/rfc9651.html#dictionary
+// Values can be:
+//   * Item (Section 3.3.)
+//   * Inner List (Section 3.1.1.)
+type Dictionary struct {
+	names  []string
+	values map[string]Member
+}
+
+// ErrInvalidDictionaryFormat is returned when a dictionary value is invalid.
+var ErrInvalidDictionaryFormat = errors.New("invalid dictionary format")
+
+// NewDictionary creates a new ordered map.
+func NewDictionary() *Dictionary {
+	d := Dictionary{}
+	d.names = []string{}
+	d.values = map[string]Member{}
+
+	return &d
+}
+
+// Get retrieves a member.
+func (d *Dictionary) Get(k string) (Member, bool) {
+	v, ok := d.values[k]
+
+	return v, ok
+}
+
+// Add appends a new member to the ordered list.
+func (d *Dictionary) Add(k string, v Member) {
+	if _, exists := d.values[k]; !exists {
+		d.names = append(d.names, k)
+	}
+
+	d.values[k] = v
+}
+
+// Del removes a member from the ordered list.
+func (d *Dictionary) Del(key string) bool {
+	if _, ok := d.values[key]; !ok {
+		return false
+	}
+
+	for i, k := range d.names {
+		if k == key {
+			d.names = append(d.names[:i], d.names[i+1:]...)
+
+			break
+		}
+	}
+
+	delete(d.values, key)
+
+	return true
+}
+
+// Names retrieves the list of member names in the appropriate order.
+func (d *Dictionary) Names() []string {
+	return d.names
+}
+
+func (d *Dictionary) marshalSFV(b *strings.Builder) error {
+	last := len(d.names) - 1
+
+	for m, k := range d.names {
+		if err := marshalKey(b, k); err != nil {
+			return err
+		}
+
+		v := d.values[k]
+
+		if item, ok := v.(Item); ok && item.Value == true {
+			if err := item.Params.marshalSFV(b); err != nil {
+				return err
+			}
+		} else {
+			if err := b.WriteByte('='); err != nil {
+				return err
+			}
+			if err := v.marshalSFV(b); err != nil {
+				return err
+			}
+		}
+
+		if m != last {
+			if _, err := b.WriteString(", "); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// UnmarshalDictionary parses a dictionary as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-dictionary.
+func UnmarshalDictionary(v []string) (*Dictionary, error) {
+	s := &scanner{
+		data: strings.Join(v, ","),
+	}
+
+	s.scanWhileSp()
+
+	sfv, err := parseDictionary(s)
+	if err != nil {
+		return sfv, err
+	}
+
+	return sfv, nil
+}
+
+func parseDictionary(s *scanner) (*Dictionary, error) {
+	d := NewDictionary()
+
+	for !s.eof() {
+		k, err := parseKey(s)
+		if err != nil {
+			return nil, err
+		}
+
+		var m Member
+
+		if !s.eof() && s.data[s.off] == '=' {
+			s.off++
+			m, err = parseItemOrInnerList(s)
+
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			p, err := parseParams(s)
+			if err != nil {
+				return nil, err
+			}
+			m = Item{true, p}
+		}
+
+		d.Add(k, m)
+		s.scanWhileOWS()
+
+		if s.eof() {
+			return d, nil
+		}
+
+		if s.data[s.off] != ',' {
+			return nil, &UnmarshalError{s.off, ErrInvalidDictionaryFormat}
+		}
+		s.off++
+
+		s.scanWhileOWS()
+
+		if s.eof() {
+			// there is a trailing comma
+			return nil, &UnmarshalError{s.off, ErrInvalidDictionaryFormat}
+		}
+	}
+
+	return d, nil
+}

--- a/vendor/github.com/dunglas/httpsfv/displaystring.go
+++ b/vendor/github.com/dunglas/httpsfv/displaystring.go
@@ -1,0 +1,105 @@
+package httpsfv
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type DisplayString string
+
+var ErrInvalidDisplayString = errors.New("invalid display string type")
+
+var notVcharOrSp = &unicode.RangeTable{
+	R16: []unicode.Range16{
+		{0x0000, 0x001f, 1},
+		{0x007f, 0x00ff, 1},
+	},
+	LatinOffset: 2,
+}
+
+// marshalSFV serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-string.
+func (s DisplayString) marshalSFV(b *strings.Builder) error {
+	if _, err := b.WriteString(`%"`); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' || s[i] == '"' || unicode.Is(notVcharOrSp, rune(s[i])) {
+			b.WriteRune('%')
+			b.WriteString(hex.EncodeToString([]byte{s[i]}))
+
+			continue
+		}
+
+		b.WriteByte(s[i])
+	}
+
+	b.WriteByte('"')
+
+	return nil
+}
+
+// parseDisplayString parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-display.
+func parseDisplayString(s *scanner) (DisplayString, error) {
+	if s.eof() || len(s.data[s.off:]) < 2 || s.data[s.off:2] != `%"` {
+		return "", &UnmarshalError{s.off, ErrInvalidDisplayString}
+	}
+	s.off += 2
+
+	var b strings.Builder
+	for !s.eof() {
+		c := s.data[s.off]
+		s.off++
+
+		switch c {
+		case '%':
+			if len(s.data[s.off:]) < 2 {
+				return "", &UnmarshalError{s.off, ErrInvalidDisplayString}
+			}
+			c0 := unhex(s.data[s.off])
+			if c0 == 0 {
+				return "", &UnmarshalError{s.off, ErrInvalidDisplayString}
+			}
+
+			c1 := unhex(s.data[s.off+1])
+			if c1 == 0 {
+				return "", &UnmarshalError{s.off, ErrInvalidDisplayString}
+			}
+
+			b.WriteByte(c0<<4 | c1)
+			s.off += 2
+		case '"':
+			r := b.String()
+			if !utf8.ValidString(r) {
+				return "", ErrInvalidDisplayString
+			}
+
+			return DisplayString(r), nil
+
+		default:
+			if unicode.Is(notVcharOrSp, rune(c)) {
+				return "", &UnmarshalError{s.off, ErrInvalidDisplayString}
+			}
+
+			b.WriteByte(c)
+		}
+	}
+
+	return "", &UnmarshalError{s.off, ErrInvalidDisplayString}
+}
+
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	default:
+		return 0
+	}
+}

--- a/vendor/github.com/dunglas/httpsfv/encode.go
+++ b/vendor/github.com/dunglas/httpsfv/encode.go
@@ -1,0 +1,42 @@
+// Package httpsfv implements serializing and parsing
+// of Structured Field Values for HTTP as defined in RFC 9651.
+//
+// Structured Field Values are either lists, dictionaries or items. Dedicated types are provided for all of them.
+// Dedicated types are also used for tokens, parameters and inner lists.
+// Other values are stored in native types:
+//
+//	int64, for integers
+//	float64, for decimals
+//	string, for strings
+//	byte[], for byte sequences
+//	bool, for booleans
+//
+// The specification is available at https://httpwg.org/specs/rfc9651.html.
+package httpsfv
+
+import (
+	"strings"
+)
+
+// marshaler is the interface implemented by types that can marshal themselves into valid SFV.
+type marshaler interface {
+	marshalSFV(b *strings.Builder) error
+}
+
+// StructuredFieldValue represents a List, a Dictionary or an Item.
+type StructuredFieldValue interface {
+	marshaler
+}
+
+// Marshal returns the HTTP Structured Value serialization of v
+// as defined in https://httpwg.org/specs/rfc9651.html#text-serialize.
+//
+// v must be a List, a Dictionary, an Item or an InnerList.
+func Marshal(v StructuredFieldValue) (string, error) {
+	var b strings.Builder
+	if err := v.marshalSFV(&b); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/vendor/github.com/dunglas/httpsfv/innerlist.go
+++ b/vendor/github.com/dunglas/httpsfv/innerlist.go
@@ -1,0 +1,91 @@
+package httpsfv
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrInvalidInnerListFormat is returned when an inner list format is invalid.
+var ErrInvalidInnerListFormat = errors.New("invalid inner list format")
+
+// InnerList represents an inner list as defined in
+// https://httpwg.org/specs/rfc9651.html#inner-list.
+type InnerList struct {
+	Items  []Item
+	Params *Params
+}
+
+func (il InnerList) member() {
+}
+
+// marshalSFV serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-innerlist.
+func (il InnerList) marshalSFV(b *strings.Builder) error {
+	if err := b.WriteByte('('); err != nil {
+		return err
+	}
+
+	l := len(il.Items)
+	for i := 0; i < l; i++ {
+		if err := il.Items[i].marshalSFV(b); err != nil {
+			return err
+		}
+
+		if i != l-1 {
+			if err := b.WriteByte(' '); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := b.WriteByte(')'); err != nil {
+		return err
+	}
+
+	return il.Params.marshalSFV(b)
+}
+
+// parseInnerList parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-item-or-list.
+func parseInnerList(s *scanner) (InnerList, error) {
+	if s.eof() || s.data[s.off] != '(' {
+		return InnerList{}, &UnmarshalError{s.off, ErrInvalidInnerListFormat}
+	}
+	s.off++
+
+	il := InnerList{nil, nil}
+
+	for !s.eof() {
+		s.scanWhileSp()
+
+		if s.eof() {
+			return InnerList{}, &UnmarshalError{s.off, ErrInvalidInnerListFormat}
+		}
+
+		if s.data[s.off] == ')' {
+			s.off++
+
+			p, err := parseParams(s)
+			if err != nil {
+				return InnerList{}, err
+			}
+
+			il.Params = p
+
+			return il, nil
+		}
+
+		i, err := parseItem(s)
+		if err != nil {
+			return InnerList{}, err
+		}
+
+		if s.eof() || (s.data[s.off] != ')' && s.data[s.off] != ' ') {
+			return InnerList{}, &UnmarshalError{s.off, ErrInvalidInnerListFormat}
+		}
+
+		il.Items = append(il.Items, i)
+	}
+
+	return InnerList{}, &UnmarshalError{s.off, ErrInvalidInnerListFormat}
+}

--- a/vendor/github.com/dunglas/httpsfv/integer.go
+++ b/vendor/github.com/dunglas/httpsfv/integer.go
@@ -1,0 +1,120 @@
+package httpsfv
+
+import (
+	"errors"
+	"io"
+	"strconv"
+)
+
+const maxDigit = 12
+
+// ErrNotDigit is returned when a character should be a digit but isn't.
+var ErrNotDigit = errors.New("character is not a digit")
+
+// ErrNumberOutOfRange is returned when the number is too large according to the specification.
+var ErrNumberOutOfRange = errors.New("integer or decimal out of range")
+
+// ErrInvalidDecimalFormat is returned when the decimal format is invalid.
+var ErrInvalidDecimalFormat = errors.New("invalid decimal format")
+
+const (
+	typeInteger = iota
+	typeDecimal
+)
+
+// marshalInteger serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#integer.
+func marshalInteger(b io.StringWriter, i int64) error {
+	if i < -999999999999999 || i > 999999999999999 {
+		return ErrNumberOutOfRange
+	}
+
+	_, err := b.WriteString(strconv.FormatInt(i, 10))
+
+	return err
+}
+
+// parseNumber parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-number.
+func parseNumber(s *scanner) (interface{}, error) {
+	neg := isNeg(s)
+	if neg && s.eof() {
+		return 0, &UnmarshalError{s.off, ErrUnexpectedEndOfString}
+	}
+
+	if !isDigit(s.data[s.off]) {
+		return 0, &UnmarshalError{s.off, ErrNotDigit}
+	}
+
+	start := s.off
+	s.off++
+
+	var (
+		decSepOff int
+		t         = typeInteger
+	)
+
+	for s.off < len(s.data) {
+		size := s.off - start
+		if (t == typeInteger && (size >= 15)) || size >= 16 {
+			return 0, &UnmarshalError{s.off, ErrNumberOutOfRange}
+		}
+
+		c := s.data[s.off]
+		if isDigit(c) {
+			s.off++
+
+			continue
+		}
+
+		if t == typeInteger && c == '.' {
+			if size > maxDigit {
+				return 0, &UnmarshalError{s.off, ErrNumberOutOfRange}
+			}
+
+			t = typeDecimal
+			decSepOff = s.off
+			s.off++
+
+			continue
+		}
+
+		break
+	}
+
+	str := s.data[start:s.off]
+
+	if t == typeInteger {
+		return parseInteger(str, neg, s.off)
+	}
+
+	return parseDecimal(s, decSepOff, str, neg)
+}
+
+func isNeg(s *scanner) bool {
+	if s.data[s.off] == '-' {
+		s.off++
+
+		return true
+	}
+
+	return false
+}
+
+func parseInteger(str string, neg bool, off int) (int64, error) {
+	i, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		// Should never happen
+		return 0, &UnmarshalError{off, err}
+	}
+
+	if neg {
+		i = -i
+	}
+
+	if i < -999999999999999 || i > 999999999999999 {
+		return 0, &UnmarshalError{off, ErrNumberOutOfRange}
+	}
+
+	return i, err
+}

--- a/vendor/github.com/dunglas/httpsfv/item.go
+++ b/vendor/github.com/dunglas/httpsfv/item.go
@@ -1,0 +1,73 @@
+package httpsfv
+
+import (
+	"strings"
+)
+
+// Item is a bare value and associated parameters.
+// See https://httpwg.org/specs/rfc9651.html#item.
+type Item struct {
+	Value  interface{}
+	Params *Params
+}
+
+// NewItem returns a new Item.
+func NewItem(v interface{}) Item {
+	assertBareItem(v)
+
+	return Item{v, NewParams()}
+}
+
+func (i Item) member() {
+}
+
+// marshalSFV serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-item.
+func (i Item) marshalSFV(b *strings.Builder) error {
+	if i.Value == nil {
+		return ErrInvalidBareItem
+	}
+
+	if err := marshalBareItem(b, i.Value); err != nil {
+		return err
+	}
+
+	return i.Params.marshalSFV(b)
+}
+
+// UnmarshalItem parses an item as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-item.
+func UnmarshalItem(v []string) (Item, error) {
+	s := &scanner{
+		data: strings.Join(v, ","),
+	}
+
+	s.scanWhileSp()
+
+	sfv, err := parseItem(s)
+	if err != nil {
+		return Item{}, err
+	}
+
+	s.scanWhileSp()
+
+	if !s.eof() {
+		return Item{}, &UnmarshalError{off: s.off}
+	}
+
+	return sfv, nil
+}
+
+func parseItem(s *scanner) (Item, error) {
+	bi, err := parseBareItem(s)
+	if err != nil {
+		return Item{}, err
+	}
+
+	p, err := parseParams(s)
+	if err != nil {
+		return Item{}, err
+	}
+
+	return Item{bi, p}, nil
+}

--- a/vendor/github.com/dunglas/httpsfv/key.go
+++ b/vendor/github.com/dunglas/httpsfv/key.go
@@ -1,0 +1,81 @@
+package httpsfv
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrInvalidKeyFormat is returned when the format of a parameter or dictionary key is invalid.
+var ErrInvalidKeyFormat = errors.New("invalid key format")
+
+// isKeyChar checks if c is a valid key characters.
+func isKeyChar(c byte) bool {
+	if isLowerCaseAlpha(c) || isDigit(c) {
+		return true
+	}
+
+	switch c {
+	case '_', '-', '.', '*':
+		return true
+	}
+
+	return false
+}
+
+// checkKey checks if the given value is a valid parameter key according to
+// https://httpwg.org/specs/rfc9651.html#param.
+func checkKey(k string) error {
+	if len(k) == 0 {
+		return fmt.Errorf("a key cannot be empty: %w", ErrInvalidKeyFormat)
+	}
+
+	if !isLowerCaseAlpha(k[0]) && k[0] != '*' {
+		return fmt.Errorf("a key must start with a lower case alpha character or *: %w", ErrInvalidKeyFormat)
+	}
+
+	for i := 1; i < len(k); i++ {
+		if !isKeyChar(k[i]) {
+			return fmt.Errorf("the character %c isn't allowed in a key: %w", k[i], ErrInvalidKeyFormat)
+		}
+	}
+
+	return nil
+}
+
+// marshalKey serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-key.
+func marshalKey(b io.StringWriter, k string) error {
+	if err := checkKey(k); err != nil {
+		return err
+	}
+
+	_, err := b.WriteString(k)
+
+	return err
+}
+
+// parseKey parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-key.
+func parseKey(s *scanner) (string, error) {
+	if s.eof() {
+		return "", &UnmarshalError{s.off, ErrInvalidKeyFormat}
+	}
+
+	c := s.data[s.off]
+	if !isLowerCaseAlpha(c) && c != '*' {
+		return "", &UnmarshalError{s.off, ErrInvalidKeyFormat}
+	}
+
+	start := s.off
+	s.off++
+
+	for !s.eof() {
+		if !isKeyChar(s.data[s.off]) {
+			break
+		}
+		s.off++
+	}
+
+	return s.data[start:s.off], nil
+}

--- a/vendor/github.com/dunglas/httpsfv/list.go
+++ b/vendor/github.com/dunglas/httpsfv/list.go
@@ -1,0 +1,99 @@
+package httpsfv
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrInvalidListFormat is returned when the format of a list is invalid.
+var ErrInvalidListFormat = errors.New("invalid list format")
+
+// List contains items an inner lists.
+//
+// See https://httpwg.org/specs/rfc9651.html#list
+type List []Member
+
+// marshalSFV serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-list.
+func (l List) marshalSFV(b *strings.Builder) error {
+	s := len(l)
+	for i := 0; i < s; i++ {
+		if err := l[i].marshalSFV(b); err != nil {
+			return err
+		}
+
+		if i != s-1 {
+			if _, err := b.WriteString(", "); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// UnmarshalList parses a list as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-list.
+func UnmarshalList(v []string) (List, error) {
+	s := &scanner{
+		data: strings.Join(v, ","),
+	}
+
+	s.scanWhileSp()
+
+	sfv, err := parseList(s)
+	if err != nil {
+		return List{}, err
+	}
+
+	return sfv, nil
+}
+
+// parseList parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-list.
+func parseList(s *scanner) (List, error) {
+	var l List
+
+	for !s.eof() {
+		m, err := parseItemOrInnerList(s)
+		if err != nil {
+			return nil, err
+		}
+
+		l = append(l, m)
+
+		s.scanWhileOWS()
+
+		if s.eof() {
+			return l, nil
+		}
+
+		if s.data[s.off] != ',' {
+			return nil, &UnmarshalError{s.off, ErrInvalidListFormat}
+		}
+		s.off++
+
+		s.scanWhileOWS()
+
+		if s.eof() {
+			// there is a trailing comma
+			return nil, &UnmarshalError{s.off, ErrInvalidListFormat}
+		}
+	}
+
+	return l, nil
+}
+
+// parseItemOrInnerList parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-item-or-list.
+func parseItemOrInnerList(s *scanner) (Member, error) {
+	if s.eof() {
+		return nil, &UnmarshalError{s.off, ErrInvalidInnerListFormat}
+	}
+
+	if s.data[s.off] == '(' {
+		return parseInnerList(s)
+	}
+
+	return parseItem(s)
+}

--- a/vendor/github.com/dunglas/httpsfv/member.go
+++ b/vendor/github.com/dunglas/httpsfv/member.go
@@ -1,0 +1,9 @@
+package httpsfv
+
+// Member is a marker interface for members of dictionaries and lists.
+//
+// See https://httpwg.org/specs/rfc9651.html#list.
+type Member interface {
+	member()
+	marshaler
+}

--- a/vendor/github.com/dunglas/httpsfv/params.go
+++ b/vendor/github.com/dunglas/httpsfv/params.go
@@ -1,0 +1,143 @@
+package httpsfv
+
+import (
+	"errors"
+	"strings"
+)
+
+// Params are an ordered map of key-value pairs that are associated with an item or an inner list.
+//
+// See https://httpwg.org/specs/rfc9651.html#param.
+type Params struct {
+	names  []string
+	values map[string]interface{}
+}
+
+// ErrInvalidParameterFormat is returned when the format of a parameter is invalid.
+var ErrInvalidParameterFormat = errors.New("invalid parameter format")
+
+// ErrInvalidParameterValue is returned when a parameter key is invalid.
+var ErrInvalidParameterValue = errors.New("invalid parameter value")
+
+// ErrMissingParameters is returned when the Params structure is missing from the element.
+var ErrMissingParameters = errors.New("missing parameters")
+
+// NewParams creates a new ordered map.
+func NewParams() *Params {
+	p := Params{}
+	p.names = []string{}
+	p.values = map[string]interface{}{}
+
+	return &p
+}
+
+// Get retrieves a parameter.
+func (p *Params) Get(k string) (interface{}, bool) {
+	v, ok := p.values[k]
+
+	return v, ok
+}
+
+// Add appends a new parameter to the ordered list.
+// If the key already exists, overwrite its value.
+func (p *Params) Add(k string, v interface{}) {
+	assertBareItem(v)
+
+	if _, exists := p.values[k]; !exists {
+		p.names = append(p.names, k)
+	}
+
+	p.values[k] = v
+}
+
+// Del removes a parameter from the ordered list.
+func (p *Params) Del(key string) bool {
+	if _, ok := p.values[key]; !ok {
+		return false
+	}
+
+	for i, k := range p.names {
+		if k == key {
+			p.names = append(p.names[:i], p.names[i+1:]...)
+
+			break
+		}
+	}
+
+	delete(p.values, key)
+
+	return true
+}
+
+// Names retrieves the list of parameter names in the appropriate order.
+func (p *Params) Names() []string {
+	return p.names
+}
+
+// marshalSFV serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-params.
+func (p *Params) marshalSFV(b *strings.Builder) error {
+	if p == nil {
+		return ErrMissingParameters
+	}
+	for _, k := range p.names {
+		if err := b.WriteByte(';'); err != nil {
+			return err
+		}
+
+		if err := marshalKey(b, k); err != nil {
+			return err
+		}
+
+		v := p.values[k]
+		if v == true {
+			continue
+		}
+
+		if err := b.WriteByte('='); err != nil {
+			return err
+		}
+
+		if err := marshalBareItem(b, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseParams parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-param.
+func parseParams(s *scanner) (*Params, error) {
+	p := NewParams()
+
+	for !s.eof() {
+		if s.data[s.off] != ';' {
+			break
+		}
+		s.off++
+		s.scanWhileSp()
+
+		k, err := parseKey(s)
+		if err != nil {
+			return nil, err
+		}
+
+		var i interface{}
+
+		if !s.eof() && s.data[s.off] == '=' {
+			s.off++
+
+			i, err = parseBareItem(s)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			i = true
+		}
+
+		p.Add(k, i)
+	}
+
+	return p, nil
+}

--- a/vendor/github.com/dunglas/httpsfv/string.go
+++ b/vendor/github.com/dunglas/httpsfv/string.go
@@ -1,0 +1,88 @@
+package httpsfv
+
+import (
+	"errors"
+	"strings"
+	"unicode"
+)
+
+// ErrInvalidStringFormat is returned when a string format is invalid.
+var ErrInvalidStringFormat = errors.New("invalid string format")
+
+// marshalString serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-string.
+func marshalString(b *strings.Builder, s string) error {
+	if err := b.WriteByte('"'); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(s); i++ {
+		if s[i] <= '\u001F' || s[i] >= unicode.MaxASCII {
+			return ErrInvalidStringFormat
+		}
+
+		switch s[i] {
+		case '"', '\\':
+			if err := b.WriteByte('\\'); err != nil {
+				return err
+			}
+		}
+
+		if err := b.WriteByte(s[i]); err != nil {
+			return err
+		}
+	}
+
+	if err := b.WriteByte('"'); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// parseString parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-string.
+func parseString(s *scanner) (string, error) {
+	if s.eof() || s.data[s.off] != '"' {
+		return "", &UnmarshalError{s.off, ErrInvalidStringFormat}
+	}
+	s.off++
+
+	var b strings.Builder
+
+	for !s.eof() {
+		c := s.data[s.off]
+		s.off++
+
+		switch c {
+		case '\\':
+			if s.eof() {
+				return "", &UnmarshalError{s.off, ErrInvalidStringFormat}
+			}
+
+			n := s.data[s.off]
+			if n != '"' && n != '\\' {
+				return "", &UnmarshalError{s.off, ErrInvalidStringFormat}
+			}
+			s.off++
+
+			if err := b.WriteByte(n); err != nil {
+				return "", err
+			}
+
+			continue
+		case '"':
+			return b.String(), nil
+		default:
+			if c <= '\u001F' || c >= unicode.MaxASCII {
+				return "", &UnmarshalError{s.off, ErrInvalidStringFormat}
+			}
+
+			if err := b.WriteByte(c); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return "", &UnmarshalError{s.off, ErrInvalidStringFormat}
+}

--- a/vendor/github.com/dunglas/httpsfv/token.go
+++ b/vendor/github.com/dunglas/httpsfv/token.go
@@ -1,0 +1,71 @@
+package httpsfv
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// isExtendedTchar checks if c is a valid token character as defined in the spec.
+func isExtendedTchar(c byte) bool {
+	if isAlpha(c) || isDigit(c) {
+		return true
+	}
+
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~', ':', '/':
+		return true
+	}
+
+	return false
+}
+
+// ErrInvalidTokenFormat is returned when a token format is invalid.
+var ErrInvalidTokenFormat = errors.New("invalid token format")
+
+// Token represents a token as defined in
+// https://httpwg.org/specs/rfc9651.html#token.
+// A specific type is used to distinguish tokens from strings.
+type Token string
+
+// marshalSFV serializes as defined in
+// https://httpwg.org/specs/rfc9651.html#ser-token.
+func (t Token) marshalSFV(b io.StringWriter) error {
+	if len(t) == 0 {
+		return fmt.Errorf("a token cannot be empty: %w", ErrInvalidTokenFormat)
+	}
+
+	if !isAlpha(t[0]) && t[0] != '*' {
+		return fmt.Errorf("a token must start with an alpha character or *: %w", ErrInvalidTokenFormat)
+	}
+
+	for i := 1; i < len(t); i++ {
+		if !isExtendedTchar(t[i]) {
+			return fmt.Errorf("the character %c isn't allowed in a token: %w", t[i], ErrInvalidTokenFormat)
+		}
+	}
+
+	_, err := b.WriteString(string(t))
+
+	return err
+}
+
+// parseToken parses as defined in
+// https://httpwg.org/specs/rfc9651.html#parse-token.
+func parseToken(s *scanner) (Token, error) {
+	if s.eof() || (!isAlpha(s.data[s.off]) && s.data[s.off] != '*') {
+		return "", &UnmarshalError{s.off, ErrInvalidTokenFormat}
+	}
+
+	start := s.off
+	s.off++
+
+	for !s.eof() {
+		if !isExtendedTchar(s.data[s.off]) {
+			break
+		}
+		s.off++
+	}
+
+	return Token(s.data[start:s.off]), nil
+}

--- a/vendor/github.com/dunglas/httpsfv/utils.go
+++ b/vendor/github.com/dunglas/httpsfv/utils.go
@@ -1,0 +1,16 @@
+package httpsfv
+
+// isLowerCaseAlpha checks if c is a lower cased alpha character.
+func isLowerCaseAlpha(c byte) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+// isAlpha checks if c is an alpha character.
+func isAlpha(c byte) bool {
+	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+}
+
+// isDigit checks if c is a digit.
+func isDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}

--- a/vendor/github.com/quic-go/webtransport-go/.gitignore
+++ b/vendor/github.com/quic-go/webtransport-go/.gitignore
@@ -1,0 +1,2 @@
+*.qlog
+*.sqlog

--- a/vendor/github.com/quic-go/webtransport-go/.golangci.yml
+++ b/vendor/github.com/quic-go/webtransport-go/.golangci.yml
@@ -1,0 +1,45 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - asciicheck
+    - copyloopvar
+    - depguard
+    - exhaustive
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - prealloc
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - usetesting
+  settings:
+    depguard:
+      rules:
+        random:
+          deny:
+            - pkg: "math/rand$"
+              desc: use math/rand/v2
+            - pkg: "golang.org/x/exp/rand"
+              desc: use math/rand/v2
+    # see https://github.com/ldez/usetesting/issues/10
+    usetesting:
+      context-background: false
+      context-todo: false
+  exclusions:
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA1019:.+quic\.ConnectionTracing(ID|Key)'
+      - linters:
+          - staticcheck
+        path: _test\.go
+        text: 'SA1029:' # inappropriate key in call to context.WithValue
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports

--- a/vendor/github.com/quic-go/webtransport-go/LICENSE
+++ b/vendor/github.com/quic-go/webtransport-go/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2022 Marten Seemann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/quic-go/webtransport-go/README.md
+++ b/vendor/github.com/quic-go/webtransport-go/README.md
@@ -1,0 +1,28 @@
+# webtransport-go
+
+[![Documentation](https://img.shields.io/badge/docs-quic--go.net-red?style=flat)](https://quic-go.net/docs/)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/quic-go/webtransport-go)](https://pkg.go.dev/github.com/quic-go/webtransport-go)
+[![Code Coverage](https://img.shields.io/codecov/c/github/quic-go/webtransport-go/master.svg?style=flat-square)](https://codecov.io/gh/quic-go/webtransport-go/)
+
+webtransport-go is an implementation of the WebTransport protocol, based on [quic-go](https://github.com/quic-go/quic-go). It currently implements [draft-15](https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15.html) of the specification.
+
+Detailed documentation can be found on [quic-go.net](https://quic-go.net/docs/).
+
+## Example
+
+A runnable client and server example is available in [`example`](./example).
+
+## Projects using webtransport-go
+
+| Project | Description | Stars |
+| --- | --- | --- |
+| [Centrifugo](https://github.com/centrifugal/centrifugo) | Scalable real-time messaging server in a language-agnostic way. Self-hosted alternative to Pubnub, Pusher, Ably, socket.io, Phoenix.PubSub, SignalR. | ![GitHub Repo stars](https://img.shields.io/github/stars/centrifugal/centrifugo?style=flat-square) |
+| [go-libp2p](https://github.com/libp2p/go-libp2p) | libp2p implementation in Go, powering [Kubo](https://github.com/ipfs/kubo) (IPFS) and [Lotus](https://github.com/filecoin-project/lotus) (Filecoin), among others | ![GitHub Repo stars](https://img.shields.io/github/stars/libp2p/go-libp2p?style=flat-square) |
+| [signalr](https://github.com/philippseith/signalr) | SignalR server and client in Go | ![GitHub Repo stars](https://img.shields.io/github/stars/philippseith/signalr?style=flat-square) |
+
+If you'd like to see your project added to this list, please send us a PR.
+
+
+## Release Policy
+
+webtransport-go always aims to support the latest two Go releases.

--- a/vendor/github.com/quic-go/webtransport-go/SECURITY.md
+++ b/vendor/github.com/quic-go/webtransport-go/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+webtransport-go is an implementation of the WebTransport over HTTP/3 protocol. No software is perfect, and we take reports of potential security issues very seriously.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability that could affect production deployments (e.g., a remotely exploitable issue), please report it [**privately**](https://github.com/quic-go/webtransport-go/security/advisories/new).
+Please **DO NOT file a public issue** for exploitable vulnerabilities.
+
+If the issue is theoretical, non-exploitable, or related to an experimental feature, you may discuss it openly by filing a regular issue.
+
+## Reporting a non-security bug
+
+For bugs, feature requests, or other non-security concerns, please open a GitHub [issue](https://github.com/quic-go/webtransport-go/issues/new).

--- a/vendor/github.com/quic-go/webtransport-go/client.go
+++ b/vendor/github.com/quic-go/webtransport-go/client.go
@@ -1,0 +1,299 @@
+package webtransport
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/dunglas/httpsfv"
+)
+
+type Dialer struct {
+	// TLSClientConfig is the TLS client config used when dialing the QUIC connection.
+	// It must set the h3 ALPN.
+	TLSClientConfig *tls.Config
+
+	// QUICConfig is the QUIC config used when dialing the QUIC connection.
+	QUICConfig *quic.Config
+
+	// ApplicationProtocols is a list of application protocols that can be negotiated,
+	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15 for details.
+	ApplicationProtocols []string
+
+	// StreamReorderingTime is the time an incoming WebTransport stream that cannot be associated
+	// with a session is buffered.
+	// This can happen if the response to a CONNECT request (that creates a new session) is reordered,
+	// and arrives after the first WebTransport stream(s) for that session.
+	// Defaults to 5 seconds.
+	StreamReorderingTimeout time.Duration
+
+	// DialAddr is the function used to dial the underlying QUIC connection.
+	// If unset, quic.DialAddrEarly will be used.
+	DialAddr func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error)
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	initOnce sync.Once
+}
+
+func (d *Dialer) init() {
+	d.ctx, d.ctxCancel = context.WithCancel(context.Background())
+}
+
+func (d *Dialer) Dial(ctx context.Context, urlStr string, reqHdr http.Header) (*http.Response, *Session, error) {
+	d.initOnce.Do(func() { d.init() })
+
+	quicConf := d.QUICConfig
+	if quicConf == nil {
+		quicConf = &quic.Config{
+			EnableDatagrams:                  true,
+			EnableStreamResetPartialDelivery: true,
+		}
+	} else {
+		if !d.QUICConfig.EnableDatagrams {
+			return nil, nil, errors.New("webtransport: DATAGRAM support required, enable it via QUICConfig.EnableDatagrams")
+		}
+		if !d.QUICConfig.EnableStreamResetPartialDelivery {
+			return nil, nil, errors.New("webtransport: stream reset partial delivery required, enable it via QUICConfig.EnableStreamResetPartialDelivery")
+		}
+	}
+
+	tlsConf := d.TLSClientConfig
+	if tlsConf == nil {
+		tlsConf = &tls.Config{}
+	} else {
+		tlsConf = tlsConf.Clone()
+	}
+	if len(tlsConf.NextProtos) == 0 {
+		tlsConf.NextProtos = []string{http3.NextProtoH3}
+	}
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if reqHdr == nil {
+		reqHdr = http.Header{}
+	}
+	if len(d.ApplicationProtocols) > 0 && reqHdr.Get(wtAvailableProtocolsHeader) == "" {
+		list := httpsfv.List{}
+		for _, protocol := range d.ApplicationProtocols {
+			list = append(list, httpsfv.NewItem(protocol))
+		}
+		protocols, err := httpsfv.Marshal(list)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal application protocols: %w", err)
+		}
+		reqHdr.Set(wtAvailableProtocolsHeader, protocols)
+	}
+
+	req := &http.Request{
+		Method: http.MethodConnect,
+		Header: reqHdr,
+		Proto:  protocolHeader,
+		Host:   u.Host,
+		URL:    u,
+	}
+	req = req.WithContext(ctx)
+
+	dialAddr := d.DialAddr
+	if dialAddr == nil {
+		dialAddr = quic.DialAddrEarly
+	}
+	qconn, err := dialAddr(ctx, u.Host, tlsConf, quicConf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Per draft-ietf-webtrans-http3-15 sections 3.1 and 7.1, for draft versions of
+	// WebTransport the client MUST send SETTINGS_WT_ENABLED using the codepoint
+	// for its supported draft version, so the server can negotiate the version.
+	tr := &http3.Transport{
+		EnableDatagrams:    true,
+		AdditionalSettings: map[uint64]uint64{settingsWebTransportEnabled: 1},
+	}
+	rsp, sess, err := d.handleConn(ctx, tr, qconn, req)
+	if err != nil {
+		var msg string
+		code := quic.ApplicationErrorCode(http3.ErrCodeNoError)
+		var reqErr *RequirementsNotMetError
+		if errors.As(err, &reqErr) {
+			code = WTRequirementsNotMetErrorCode
+			msg = reqErr.Message
+		}
+		qconn.CloseWithError(code, msg)
+		tr.Close()
+		return rsp, nil, err
+	}
+	context.AfterFunc(sess.Context(), func() {
+		qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeNoError), "")
+		tr.Close()
+	})
+	return rsp, sess, nil
+}
+
+func (d *Dialer) handleConn(ctx context.Context, tr *http3.Transport, qconn *quic.Conn, req *http.Request) (*http.Response, *Session, error) {
+	timeout := d.StreamReorderingTimeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	sessMgr := newSessionManager(timeout)
+	context.AfterFunc(qconn.Context(), sessMgr.Close)
+
+	conn := tr.NewRawClientConn(qconn)
+
+	go func() {
+		for {
+			str, err := qconn.AcceptStream(context.Background())
+			if err != nil {
+				return
+			}
+
+			go func() {
+				typ, err := quicvarint.Peek(str)
+				if err != nil {
+					return
+				}
+				if typ != webTransportFrameType {
+					conn.HandleBidirectionalStream(str)
+					return
+				}
+				// read the frame type (already peeked above)
+				if _, err := quicvarint.Read(quicvarint.NewReader(str)); err != nil {
+					return
+				}
+				// read the session ID
+				id, err := quicvarint.Read(quicvarint.NewReader(str))
+				if err != nil {
+					return
+				}
+				if !isValidSessionID(id) {
+					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
+				sessMgr.AddStream(str, sessionID(id))
+			}()
+		}
+	}()
+
+	go func() {
+		for {
+			str, err := qconn.AcceptUniStream(context.Background())
+			if err != nil {
+				return
+			}
+
+			go func() {
+				typ, err := quicvarint.Peek(str)
+				if err != nil {
+					return
+				}
+				if typ != webTransportUniStreamType {
+					conn.HandleUnidirectionalStream(str)
+					return
+				}
+				// read the stream type (already peeked above)
+				if _, err := quicvarint.Read(quicvarint.NewReader(str)); err != nil {
+					return
+				}
+				// read the session ID
+				id, err := quicvarint.Read(quicvarint.NewReader(str))
+				if err != nil {
+					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					return
+				}
+				if !isValidSessionID(id) {
+					qconn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
+				sessMgr.AddUniStream(str, sessionID(id))
+			}()
+		}
+	}()
+
+	select {
+	case <-conn.ReceivedSettings():
+	case <-ctx.Done():
+		return nil, nil, fmt.Errorf("error waiting for HTTP/3 settings: %w", context.Cause(ctx))
+	case <-d.ctx.Done():
+		return nil, nil, context.Cause(d.ctx)
+	}
+	settings := conn.Settings()
+	if !settings.EnableExtendedConnect {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable Extended CONNECT"}
+	}
+	if !settings.EnableDatagrams {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable HTTP/3 datagram support"}
+	}
+	if settings.Other == nil {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
+	}
+	// any non-zero value for SETTINGS_WT_ENABLED means that WebTransport is enabled
+	s, ok := settings.Other[settingsWebTransportEnabled]
+	if !ok || s == 0 {
+		return nil, nil, &RequirementsNotMetError{Message: "server didn't enable WebTransport"}
+	}
+
+	requestStr, err := conn.OpenRequestStream(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := requestStr.SendRequestHeader(req); err != nil {
+		return nil, nil, err
+	}
+	// TODO(#136): create the session to allow optimistic opening of streams and sending of datagrams
+	rsp, err := requestStr.ReadResponse()
+	if err != nil {
+		return nil, nil, err
+	}
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+		return rsp, nil, fmt.Errorf("received status %d", rsp.StatusCode)
+	}
+	sessID := sessionID(requestStr.StreamID())
+	var protocol string
+	// Don't send WT_ALPN_ERROR if WT-Protocol is absent: the server didn't
+	// negotiate a protocol. Send it only when WT-Protocol is present but invalid.
+	if protocolHeader, ok := rsp.Header[http.CanonicalHeaderKey(wtProtocolHeader)]; ok {
+		var err error
+		protocol, err = d.negotiateProtocol(protocolHeader)
+		if err != nil {
+			sessErr := &SessionError{ErrorCode: WTALPNErrorCode, Message: err.Error()}
+			_ = closeSessionStream(requestStr, sessErr.ErrorCode, sessErr.Message)
+			return rsp, nil, sessErr
+		}
+	}
+	sess := newSession(context.WithoutCancel(ctx), sessID, qconn, requestStr, protocol)
+	sessMgr.AddSession(sessID, sess)
+	return rsp, sess, nil
+}
+
+func (d *Dialer) negotiateProtocol(theirs []string) (string, error) {
+	negotiatedProtocolItem, err := httpsfv.UnmarshalItem(theirs)
+	if err != nil {
+		return "", fmt.Errorf("webtransport: invalid WT-Protocol header: %w", err)
+	}
+	negotiatedProtocol, ok := negotiatedProtocolItem.Value.(string)
+	if !ok {
+		return "", errors.New("webtransport: invalid WT-Protocol header: value is not a string")
+	}
+	if !slices.Contains(d.ApplicationProtocols, negotiatedProtocol) {
+		return "", fmt.Errorf("webtransport: server selected application protocol %q that wasn't offered", negotiatedProtocol)
+	}
+	return negotiatedProtocol, nil
+}
+
+func (d *Dialer) Close() error {
+	d.ctxCancel()
+	return nil
+}

--- a/vendor/github.com/quic-go/webtransport-go/codecov.yml
+++ b/vendor/github.com/quic-go/webtransport-go/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  ignore:
+    - example/
+    - interop/
+    - interop_chrome/
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/vendor/github.com/quic-go/webtransport-go/errors.go
+++ b/vendor/github.com/quic-go/webtransport-go/errors.go
@@ -1,0 +1,93 @@
+package webtransport
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/quic-go/quic-go"
+)
+
+// StreamErrorCode is an error code used for stream termination.
+type StreamErrorCode uint32
+
+// SessionErrorCode is an error code for session termination.
+type SessionErrorCode uint32
+
+const (
+	firstErrorCode = 0x52e4a40fa8db
+	lastErrorCode  = 0x52e5ac983162
+)
+
+func webtransportCodeToHTTPCode(n StreamErrorCode) quic.StreamErrorCode {
+	return quic.StreamErrorCode(firstErrorCode) + quic.StreamErrorCode(n) + quic.StreamErrorCode(n/0x1e)
+}
+
+func httpCodeToWebtransportCode(h quic.StreamErrorCode) (StreamErrorCode, error) {
+	if h < firstErrorCode || h > lastErrorCode {
+		return 0, errors.New("error code outside of expected range")
+	}
+	if (h-0x21)%0x1f == 0 {
+		return 0, errors.New("invalid error code")
+	}
+	shifted := h - firstErrorCode
+	return StreamErrorCode(shifted - shifted/0x1f), nil
+}
+
+const (
+	// WTBufferedStreamRejectedErrorCode is the error code of the
+	// WT_BUFFERED_STREAM_REJECTED error.
+	WTBufferedStreamRejectedErrorCode quic.StreamErrorCode = 0x3994bd84
+
+	// WTSessionGoneErrorCode is the error code of the WT_SESSION_GONE error.
+	WTSessionGoneErrorCode quic.StreamErrorCode = 0x170d7b68
+
+	// WTRequirementsNotMetErrorCode is the error code of the
+	// WT_REQUIREMENTS_NOT_MET error.
+	WTRequirementsNotMetErrorCode quic.ApplicationErrorCode = 0x212c0d48
+
+	// WTALPNErrorCode is the error code of the WT_ALPN_ERROR error.
+	WTALPNErrorCode SessionErrorCode = 0x0817b3dd
+)
+
+// StreamError is the error that is returned from stream operations (Read, Write) when the stream is canceled.
+type StreamError struct {
+	ErrorCode StreamErrorCode
+	Remote    bool
+}
+
+var _ error = &StreamError{}
+
+func (e *StreamError) Error() string {
+	return fmt.Sprintf("stream canceled with error code %d", e.ErrorCode)
+}
+
+func (e *StreamError) Is(target error) bool {
+	t, ok := target.(*StreamError)
+	return ok && t.Remote == e.Remote && t.ErrorCode == e.ErrorCode
+}
+
+// SessionError is a WebTransport connection error.
+type SessionError struct {
+	Remote    bool
+	ErrorCode SessionErrorCode
+	Message   string
+}
+
+var _ error = &SessionError{}
+
+func (e *SessionError) Error() string { return e.Message }
+
+func (e *SessionError) Is(target error) bool {
+	t, ok := target.(*SessionError)
+	return ok && e.ErrorCode == t.ErrorCode && e.Remote == t.Remote
+}
+
+// RequirementsNotMetError is returned when the peer doesn't advertise
+// the required HTTP/3 or WebTransport capabilities.
+type RequirementsNotMetError struct {
+	Message string
+}
+
+var _ error = &RequirementsNotMetError{}
+
+func (e *RequirementsNotMetError) Error() string { return e.Message }

--- a/vendor/github.com/quic-go/webtransport-go/protocol.go
+++ b/vendor/github.com/quic-go/webtransport-go/protocol.go
@@ -1,0 +1,43 @@
+package webtransport
+
+const (
+	// settingsEnableWebtransportDraft06 is the value for ENABLE_WEBTRANSPORT
+	// that was used up until draft-ietf-webtrans-http3-06.
+	settingsEnableWebtransportDraft06 = 0x2b603742
+
+	// settingsWebTransportEnabled is the value for SETTINGS_WT_ENABLED
+	settingsWebTransportEnabled = 0x2c7cf000
+
+	// settingsWebTransportMaxSessions is the value for SETTINGS_WT_MAX_SESSIONS
+	settingsWebTransportMaxSessions = 0x14e9cd29
+
+	// settingsWebTransportInitialMaxStreamsUni is the value for SETTINGS_WT_INITIAL_MAX_STREAMS_UNI
+	settingsWebTransportInitialMaxStreamsUni = 0x2b64
+
+	// settingsWebTransportInitialMaxStreamsBidi is the value for SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI
+	settingsWebTransportInitialMaxStreamsBidi = 0x2b65
+
+	// settingsWebTransportInitialMaxData is the value for SETTINGS_WT_INITIAL_MAX_DATA
+	settingsWebTransportInitialMaxData = 0x2b61
+)
+
+const (
+	// protocolHeader is the Extended-CONNECT :protocol value per
+	// draft-ietf-webtrans-http3-15 §3.2, §9.1.
+	protocolHeader = "webtransport-h3"
+	// protocolHeaderLegacy is the pre-draft-15 value. Accepted by the server
+	// (but not sent by the client) for compatibility with peers that have not yet
+	// migrated.
+	protocolHeaderLegacy = "webtransport"
+)
+
+func isWebTransportProtocol(s string) bool {
+	return s == protocolHeader || s == protocolHeaderLegacy
+}
+
+// WebTransport session IDs are the stream IDs of the CONNECT requests that
+// establish the sessions. Those requests are sent on client-initiated
+// bidirectional streams, whose QUIC stream IDs are divisible by 4.
+func isValidSessionID(id uint64) bool {
+	return id%4 == 0
+}

--- a/vendor/github.com/quic-go/webtransport-go/server.go
+++ b/vendor/github.com/quic-go/webtransport-go/server.go
@@ -1,0 +1,471 @@
+package webtransport
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+
+	"github.com/dunglas/httpsfv"
+)
+
+const (
+	wtAvailableProtocolsHeader = "WT-Available-Protocols"
+	wtProtocolHeader           = "WT-Protocol"
+)
+
+const (
+	webTransportFrameType     = 0x41
+	webTransportUniStreamType = 0x54
+)
+
+type quicConnKeyType struct{}
+
+var quicConnKey = quicConnKeyType{}
+
+func ConfigureHTTP3Server(s *http3.Server) {
+	if s.AdditionalSettings == nil {
+		s.AdditionalSettings = make(map[uint64]uint64, 6)
+	}
+	// send the old setting for backwards compatibility with older clients
+	s.AdditionalSettings[settingsEnableWebtransportDraft06] = 1
+	s.AdditionalSettings[settingsWebTransportEnabled] = 1
+
+	// Safari requires SETTINGS_WT_MAX_SESSIONS >= 1 (draft-ietf-webtrans-http3-14)
+	s.AdditionalSettings[settingsWebTransportMaxSessions] = 1<<62 - 1
+
+	// Required when SETTINGS_WT_MAX_SESSIONS > 1
+	s.AdditionalSettings[settingsWebTransportInitialMaxStreamsUni] = 1 << 60
+	s.AdditionalSettings[settingsWebTransportInitialMaxStreamsBidi] = 1 << 60
+	s.AdditionalSettings[settingsWebTransportInitialMaxData] = 1 << 60
+
+	s.EnableDatagrams = true
+	origConnContext := s.ConnContext
+	s.ConnContext = func(ctx context.Context, conn *quic.Conn) context.Context {
+		if origConnContext != nil {
+			ctx = origConnContext(ctx, conn)
+		}
+		ctx = context.WithValue(ctx, quicConnKey, conn)
+		return ctx
+	}
+}
+
+type Server struct {
+	H3 *http3.Server
+
+	// ApplicationProtocols is a list of application protocols that can be negotiated,
+	// see section 3.3 of https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-15 for details.
+	ApplicationProtocols []string
+
+	// ReorderingTimeout is the maximum time an incoming WebTransport stream that cannot be associated
+	// with a session is buffered. It is also the maximum time a WebTransport connection request is
+	// blocked waiting for the client's SETTINGS are received.
+	// This can happen if the CONNECT request (that creates a new session) is reordered, and arrives
+	// after the first WebTransport stream(s) for that session.
+	// Defaults to 5 seconds.
+	ReorderingTimeout time.Duration
+
+	// CheckOrigin is used to validate the request origin, thereby preventing cross-site request forgery.
+	// CheckOrigin returns true if the request Origin header is acceptable.
+	// If unset, a safe default is used: If the Origin header is set, it is checked that it
+	// matches the request's Host header.
+	CheckOrigin func(r *http.Request) bool
+
+	ctx       context.Context // is closed when Close is called
+	ctxCancel context.CancelFunc
+	refCount  sync.WaitGroup
+
+	initOnce sync.Once
+	initErr  error
+
+	connsMx sync.Mutex
+	conns   map[*quic.Conn]*sessionManager
+}
+
+func (s *Server) initialize() error {
+	s.initOnce.Do(func() {
+		s.initErr = s.init()
+	})
+	return s.initErr
+}
+
+func (s *Server) timeout() time.Duration {
+	timeout := s.ReorderingTimeout
+	if timeout == 0 {
+		return 5 * time.Second
+	}
+	return timeout
+}
+
+func (s *Server) init() error {
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+
+	s.conns = make(map[*quic.Conn]*sessionManager)
+	if s.CheckOrigin == nil {
+		s.CheckOrigin = checkSameOrigin
+	}
+	return nil
+}
+
+func (s *Server) Serve(conn net.PacketConn) error {
+	if err := s.initialize(); err != nil {
+		return err
+	}
+
+	s.refCount.Add(1)
+	defer s.refCount.Done()
+
+	return s.serve(conn)
+}
+
+func (s *Server) serve(conn net.PacketConn) error {
+	var quicConf *quic.Config
+	if s.H3.QUICConfig != nil {
+		quicConf = s.H3.QUICConfig.Clone()
+	} else {
+		quicConf = &quic.Config{}
+	}
+	quicConf.EnableDatagrams = true
+	quicConf.EnableStreamResetPartialDelivery = true
+	ln, err := quic.ListenEarly(conn, s.H3.TLSConfig, quicConf)
+	if err != nil {
+		return err
+	}
+	defer ln.Close()
+
+	for {
+		qconn, err := ln.Accept(s.ctx)
+		if err != nil {
+			return err
+		}
+		s.refCount.Go(func() {
+			if err := s.ServeQUICConn(qconn); err != nil {
+				log.Printf("http3: error serving QUIC connection: %v", err)
+			}
+		})
+	}
+}
+
+// ServeQUICConn serves a single QUIC connection.
+func (s *Server) ServeQUICConn(conn *quic.Conn) error {
+	connState := conn.ConnectionState()
+	if !connState.SupportsDatagrams.Local {
+		return errors.New("webtransport: QUIC DATAGRAM support required, enable it via QUICConfig.EnableDatagrams")
+	}
+	if !connState.SupportsStreamResetPartialDelivery.Local {
+		return errors.New("webtransport: QUIC Stream Resets with Partial Delivery required, enable it via QUICConfig.EnableStreamResetPartialDelivery")
+	}
+	if err := s.initialize(); err != nil {
+		return err
+	}
+
+	s.connsMx.Lock()
+	sessMgr, ok := s.conns[conn]
+	if !ok {
+		sessMgr = newSessionManager(s.timeout())
+		s.conns[conn] = sessMgr
+	}
+	s.connsMx.Unlock()
+
+	// Clean up when connection closes
+	context.AfterFunc(conn.Context(), func() {
+		s.connsMx.Lock()
+		delete(s.conns, conn)
+		s.connsMx.Unlock()
+		sessMgr.Close()
+	})
+
+	http3Conn, err := s.H3.NewRawServerConn(conn)
+	if err != nil {
+		return err
+	}
+
+	// slose the connection when the server context is cancelled.
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			conn.CloseWithError(0, "")
+		case <-conn.Context().Done():
+			// connection already closed
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		for {
+			str, err := conn.AcceptStream(s.ctx)
+			if err != nil {
+				return
+			}
+
+			wg.Go(func() {
+				typ, err := quicvarint.Peek(str)
+				if err != nil {
+					return
+				}
+				if typ != webTransportFrameType {
+					http3Conn.HandleRequestStream(str)
+					return
+				}
+				// read the frame type (already peeked)
+				if _, err := quicvarint.Read(quicvarint.NewReader(str)); err != nil {
+					return
+				}
+				// read the session ID
+				id, err := quicvarint.Read(quicvarint.NewReader(str))
+				if err != nil {
+					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					str.CancelWrite(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					return
+				}
+				if !isValidSessionID(id) {
+					conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
+				sessMgr.AddStream(str, sessionID(id))
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			str, err := conn.AcceptUniStream(s.ctx)
+			if err != nil {
+				return
+			}
+
+			wg.Go(func() {
+				typ, err := quicvarint.Peek(str)
+				if err != nil {
+					return
+				}
+				if typ != webTransportUniStreamType {
+					http3Conn.HandleUnidirectionalStream(str)
+					return
+				}
+				// read the stream type (already peeked) before passing to AddUniStream
+				r := quicvarint.NewReader(str)
+				if _, err := quicvarint.Read(r); err != nil {
+					return
+				}
+				// read the session ID
+				id, err := quicvarint.Read(r)
+				if err != nil {
+					str.CancelRead(quic.StreamErrorCode(http3.ErrCodeGeneralProtocolError))
+					return
+				}
+				if !isValidSessionID(id) {
+					conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeIDError), "")
+					return
+				}
+				sessMgr.AddUniStream(str, sessionID(id))
+			})
+		}
+	}()
+
+	wg.Wait()
+	return nil
+}
+
+func (s *Server) ListenAndServe() error {
+	if err := s.initialize(); err != nil {
+		return err
+	}
+	s.refCount.Add(1)
+	defer s.refCount.Done()
+
+	addr := s.H3.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return err
+	}
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	return s.serve(conn)
+}
+
+func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	if s.H3.TLSConfig == nil {
+		s.H3.TLSConfig = &tls.Config{}
+	}
+	s.H3.TLSConfig.Certificates = []tls.Certificate{cert}
+	return s.ListenAndServe()
+}
+
+func (s *Server) Close() error {
+	// Make sure that ctxCancel is defined.
+	// This is expected to be uncommon.
+	// It only happens if the server is closed without Serve / ListenAndServe having been called.
+	s.initOnce.Do(func() {})
+
+	if s.ctxCancel != nil {
+		s.ctxCancel()
+	}
+	s.connsMx.Lock()
+	if s.conns != nil {
+		for _, mgr := range s.conns {
+			mgr.Close()
+		}
+		s.conns = nil
+	}
+	s.connsMx.Unlock()
+
+	err := s.H3.Close()
+	s.refCount.Wait()
+	return err
+}
+
+func (s *Server) Upgrade(w http.ResponseWriter, r *http.Request) (*Session, error) {
+	if err := s.initialize(); err != nil {
+		return nil, err
+	}
+	if r.Method != http.MethodConnect {
+		return nil, fmt.Errorf("expected CONNECT request, got %s", r.Method)
+	}
+	if !isWebTransportProtocol(r.Proto) {
+		return nil, fmt.Errorf("unexpected protocol: %s", r.Proto)
+	}
+	if !s.CheckOrigin(r) {
+		return nil, errors.New("webtransport: request origin not allowed")
+	}
+
+	id := r.Context().Value(quicConnKey)
+	if id == nil {
+		return nil, errors.New("webtransport: missing QUIC connection")
+	}
+	conn := id.(*quic.Conn)
+
+	selectedProtocol := s.selectProtocol(r.Header[http.CanonicalHeaderKey(wtAvailableProtocolsHeader)])
+
+	// Wait for SETTINGS
+	settingser := w.(http3.Settingser)
+	timer := time.NewTimer(s.timeout())
+	defer timer.Stop()
+	select {
+	case <-settingser.ReceivedSettings():
+	case <-timer.C:
+		return nil, errors.New("webtransport: didn't receive the client's SETTINGS on time")
+	}
+	settings := settingser.Settings()
+	if !settings.EnableDatagrams {
+		return nil, errors.New("webtransport: missing datagram support")
+	}
+
+	if selectedProtocol != "" {
+		v, err := httpsfv.Marshal(httpsfv.NewItem(selectedProtocol))
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal selected protocol: %w", err)
+		}
+		w.Header().Add(wtProtocolHeader, v)
+	}
+	w.WriteHeader(http.StatusOK)
+	w.(http.Flusher).Flush()
+
+	str := w.(http3.HTTPStreamer).HTTPStream()
+	sessID := sessionID(str.StreamID())
+
+	// The session manager should already exist because ServeQUICConn creates it
+	// before any HTTP requests can be processed on this connection.
+	s.connsMx.Lock()
+	defer s.connsMx.Unlock()
+
+	sessMgr, ok := s.conns[conn]
+	if !ok {
+		return nil, errors.New("webtransport: connection session manager not found")
+	}
+
+	sess := newSession(context.WithoutCancel(r.Context()), sessID, conn, str, selectedProtocol)
+	sessMgr.AddSession(sessID, sess)
+	return sess, nil
+}
+
+func (s *Server) selectProtocol(theirs []string) string {
+	list, err := httpsfv.UnmarshalList(theirs)
+	if err != nil {
+		return ""
+	}
+	offered := make([]string, 0, len(list))
+	for _, item := range list {
+		i, ok := item.(httpsfv.Item)
+		if !ok {
+			return ""
+		}
+		protocol, ok := i.Value.(string)
+		if !ok {
+			return ""
+		}
+		offered = append(offered, protocol)
+	}
+	var selectedProtocol string
+	for _, p := range offered {
+		if slices.Contains(s.ApplicationProtocols, p) {
+			selectedProtocol = p
+			break
+		}
+	}
+	return selectedProtocol
+}
+
+// copied from https://github.com/gorilla/websocket
+func checkSameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return equalASCIIFold(u.Host, r.Host)
+}
+
+// copied from https://github.com/gorilla/websocket
+func equalASCIIFold(s, t string) bool {
+	for s != "" && t != "" {
+		sr, size := utf8.DecodeRuneInString(s)
+		s = s[size:]
+		tr, size := utf8.DecodeRuneInString(t)
+		t = t[size:]
+		if sr == tr {
+			continue
+		}
+		if 'A' <= sr && sr <= 'Z' {
+			sr = sr + 'a' - 'A'
+		}
+		if 'A' <= tr && tr <= 'Z' {
+			tr = tr + 'a' - 'A'
+		}
+		if sr != tr {
+			return false
+		}
+	}
+	return s == t
+}

--- a/vendor/github.com/quic-go/webtransport-go/session.go
+++ b/vendor/github.com/quic-go/webtransport-go/session.go
@@ -1,0 +1,471 @@
+package webtransport
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"math/rand/v2"
+	"net"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+// sessionID is the WebTransport Session ID
+type sessionID uint64
+
+const closeSessionCapsuleType http3.CapsuleType = 0x2843
+
+const maxCloseCapsuleErrorMsgLen = 1024
+
+type acceptQueue[T any] struct {
+	mx sync.Mutex
+	// The channel is used to notify consumers (via Chan) about new incoming items.
+	// Needs to be buffered to preserve the notification if an item is enqueued
+	// between a call to Next and to Chan.
+	c chan struct{}
+	// Contains all the streams waiting to be accepted.
+	// There's no explicit limit to the length of the queue, but it is implicitly
+	// limited by the stream flow control provided by QUIC.
+	queue []T
+}
+
+func newAcceptQueue[T any]() *acceptQueue[T] {
+	return &acceptQueue[T]{c: make(chan struct{}, 1)}
+}
+
+func (q *acceptQueue[T]) Add(str T) {
+	q.mx.Lock()
+	q.queue = append(q.queue, str)
+	q.mx.Unlock()
+
+	select {
+	case q.c <- struct{}{}:
+	default:
+	}
+}
+
+func (q *acceptQueue[T]) Next() T {
+	q.mx.Lock()
+	defer q.mx.Unlock()
+
+	if len(q.queue) == 0 {
+		return *new(T)
+	}
+	str := q.queue[0]
+	q.queue = q.queue[1:]
+	return str
+}
+
+func (q *acceptQueue[T]) Chan() <-chan struct{} { return q.c }
+
+type http3Stream interface {
+	io.ReadWriteCloser
+	ReceiveDatagram(context.Context) ([]byte, error)
+	SendDatagram([]byte) error
+	CancelRead(quic.StreamErrorCode)
+	CancelWrite(quic.StreamErrorCode)
+	SetWriteDeadline(time.Time) error
+}
+
+var (
+	_ http3Stream = &http3.Stream{}
+	_ http3Stream = &http3.RequestStream{}
+)
+
+// SessionState contains the state of a WebTransport session
+type SessionState struct {
+	// ConnectionState contains the QUIC connection state, including TLS handshake information
+	ConnectionState quic.ConnectionState
+
+	// ApplicationProtocol contains the application protocol negotiated for the session
+	ApplicationProtocol string
+}
+
+type Session struct {
+	sessionID           sessionID
+	conn                *quic.Conn
+	str                 http3Stream
+	applicationProtocol string
+
+	streamHdr    []byte
+	uniStreamHdr []byte
+
+	ctx      context.Context
+	closeMx  sync.Mutex
+	closeErr error // not nil once the session is closed
+	// streamCtxs holds all the context.CancelFuncs of calls to Open{Uni}StreamSync calls currently active.
+	// When the session is closed, this allows us to cancel all these contexts and make those calls return.
+	streamCtxs map[int]context.CancelFunc
+
+	bidiAcceptQueue acceptQueue[*Stream]
+	uniAcceptQueue  acceptQueue[*ReceiveStream]
+
+	streams streamsMap
+}
+
+func newSession(ctx context.Context, sessionID sessionID, conn *quic.Conn, str http3Stream, applicationProtocol string) *Session {
+	ctx, ctxCancel := context.WithCancel(ctx)
+	c := &Session{
+		sessionID:           sessionID,
+		conn:                conn,
+		str:                 str,
+		applicationProtocol: applicationProtocol,
+		ctx:                 ctx,
+		streamCtxs:          make(map[int]context.CancelFunc),
+		bidiAcceptQueue:     *newAcceptQueue[*Stream](),
+		uniAcceptQueue:      *newAcceptQueue[*ReceiveStream](),
+		streams:             *newStreamsMap(),
+	}
+	// precompute the headers for unidirectional streams
+	c.uniStreamHdr = make([]byte, 0, 2+quicvarint.Len(uint64(c.sessionID)))
+	c.uniStreamHdr = quicvarint.Append(c.uniStreamHdr, webTransportUniStreamType)
+	c.uniStreamHdr = quicvarint.Append(c.uniStreamHdr, uint64(c.sessionID))
+	// precompute the headers for bidirectional streams
+	c.streamHdr = make([]byte, 0, 2+quicvarint.Len(uint64(c.sessionID)))
+	c.streamHdr = quicvarint.Append(c.streamHdr, webTransportFrameType)
+	c.streamHdr = quicvarint.Append(c.streamHdr, uint64(c.sessionID))
+
+	go func() {
+		defer ctxCancel()
+		c.handleConn()
+	}()
+	return c
+}
+
+func (s *Session) handleConn() {
+	err := s.parseNextCapsule()
+	s.closeWithError(err)
+}
+
+// parseNextCapsule parses the next Capsule sent on the request stream.
+// It returns a SessionError, if the capsule received is a WT_CLOSE_SESSION Capsule.
+func (s *Session) parseNextCapsule() error {
+	for {
+		typ, r, err := http3.ParseCapsule(quicvarint.NewReader(s.str))
+		if err != nil {
+			return err
+		}
+		switch typ {
+		case closeSessionCapsuleType:
+			var b [4]byte
+			if _, err := io.ReadFull(r, b[:]); err != nil {
+				return err
+			}
+			appErrCode := binary.BigEndian.Uint32(b[:])
+			// the length of the error message is limited to 1024 bytes
+			appErrMsg, err := io.ReadAll(io.LimitReader(r, maxCloseCapsuleErrorMsgLen))
+			if err != nil {
+				return err
+			}
+			return &SessionError{
+				Remote:    true,
+				ErrorCode: SessionErrorCode(appErrCode),
+				Message:   string(appErrMsg),
+			}
+		default:
+			// unknown capsule, skip it
+			if _, err := io.ReadAll(r); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *Session) addStream(qstr *quic.Stream, addStreamHeader bool) *Stream {
+	var hdr []byte
+	if addStreamHeader {
+		hdr = s.streamHdr
+	}
+	str := newStream(qstr, hdr, func() { s.streams.RemoveStream(qstr.StreamID()) })
+	s.streams.AddStream(qstr.StreamID(), str.closeWithSession)
+	return str
+}
+
+func (s *Session) addReceiveStream(qstr *quic.ReceiveStream) *ReceiveStream {
+	str := newReceiveStream(qstr, func() { s.streams.RemoveStream(qstr.StreamID()) })
+	s.streams.AddStream(qstr.StreamID(), str.closeWithSession)
+	return str
+}
+
+func (s *Session) addSendStream(qstr *quic.SendStream) *SendStream {
+	str := newSendStream(qstr, s.uniStreamHdr, func() { s.streams.RemoveStream(qstr.StreamID()) })
+	s.streams.AddStream(qstr.StreamID(), str.closeWithSession)
+	return str
+}
+
+// addIncomingStream adds a bidirectional stream that the remote peer opened
+func (s *Session) addIncomingStream(qstr *quic.Stream) {
+	s.closeMx.Lock()
+	closeErr := s.closeErr
+	if closeErr != nil {
+		s.closeMx.Unlock()
+		qstr.CancelRead(WTSessionGoneErrorCode)
+		qstr.CancelWrite(WTSessionGoneErrorCode)
+		return
+	}
+	str := s.addStream(qstr, false)
+	s.closeMx.Unlock()
+
+	s.bidiAcceptQueue.Add(str)
+}
+
+// addIncomingUniStream adds a unidirectional stream that the remote peer opened
+func (s *Session) addIncomingUniStream(qstr *quic.ReceiveStream) {
+	s.closeMx.Lock()
+	closeErr := s.closeErr
+	if closeErr != nil {
+		s.closeMx.Unlock()
+		qstr.CancelRead(WTSessionGoneErrorCode)
+		return
+	}
+	str := s.addReceiveStream(qstr)
+	s.closeMx.Unlock()
+
+	s.uniAcceptQueue.Add(str)
+}
+
+// Context returns a context that is closed when the session is closed.
+func (s *Session) Context() context.Context {
+	return s.ctx
+}
+
+func (s *Session) AcceptStream(ctx context.Context) (*Stream, error) {
+	s.closeMx.Lock()
+	closeErr := s.closeErr
+	s.closeMx.Unlock()
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	for {
+		// If there's a stream in the accept queue, return it immediately.
+		if str := s.bidiAcceptQueue.Next(); str != nil {
+			return str, nil
+		}
+		// No stream in the accept queue. Wait until we accept one.
+		select {
+		case <-s.ctx.Done():
+			return nil, s.closeErr
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.bidiAcceptQueue.Chan():
+		}
+	}
+}
+
+func (s *Session) AcceptUniStream(ctx context.Context) (*ReceiveStream, error) {
+	s.closeMx.Lock()
+	closeErr := s.closeErr
+	s.closeMx.Unlock()
+	if closeErr != nil {
+		return nil, s.closeErr
+	}
+
+	for {
+		// If there's a stream in the accept queue, return it immediately.
+		if str := s.uniAcceptQueue.Next(); str != nil {
+			return str, nil
+		}
+		// No stream in the accept queue. Wait until we accept one.
+		select {
+		case <-s.ctx.Done():
+			return nil, s.closeErr
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.uniAcceptQueue.Chan():
+		}
+	}
+}
+
+func (s *Session) OpenStream() (*Stream, error) {
+	s.closeMx.Lock()
+	defer s.closeMx.Unlock()
+
+	if s.closeErr != nil {
+		return nil, s.closeErr
+	}
+
+	qstr, err := s.conn.OpenStream()
+	if err != nil {
+		return nil, err
+	}
+	return s.addStream(qstr, true), nil
+}
+
+func (s *Session) addStreamCtxCancel(cancel context.CancelFunc) (id int) {
+rand:
+	id = rand.Int()
+	if _, ok := s.streamCtxs[id]; ok {
+		goto rand
+	}
+	s.streamCtxs[id] = cancel
+	return id
+}
+
+func (s *Session) OpenStreamSync(ctx context.Context) (*Stream, error) {
+	s.closeMx.Lock()
+	if s.closeErr != nil {
+		s.closeMx.Unlock()
+		return nil, s.closeErr
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	id := s.addStreamCtxCancel(cancel)
+	s.closeMx.Unlock()
+
+	// open a new bidirectional stream without holding the mutex: this call might block
+	qstr, err := s.conn.OpenStreamSync(ctx)
+
+	s.closeMx.Lock()
+	defer s.closeMx.Unlock()
+	delete(s.streamCtxs, id)
+
+	// the session might have been closed concurrently with OpenStreamSync returning
+	if qstr != nil && s.closeErr != nil {
+		qstr.CancelRead(WTSessionGoneErrorCode)
+		qstr.CancelWrite(WTSessionGoneErrorCode)
+		return nil, s.closeErr
+	}
+	if err != nil {
+		if s.closeErr != nil {
+			return nil, s.closeErr
+		}
+		return nil, err
+	}
+	return s.addStream(qstr, true), nil
+}
+
+func (s *Session) OpenUniStream() (*SendStream, error) {
+	s.closeMx.Lock()
+	defer s.closeMx.Unlock()
+
+	if s.closeErr != nil {
+		return nil, s.closeErr
+	}
+	qstr, err := s.conn.OpenUniStream()
+	if err != nil {
+		return nil, err
+	}
+	return s.addSendStream(qstr), nil
+}
+
+func (s *Session) OpenUniStreamSync(ctx context.Context) (str *SendStream, err error) {
+	s.closeMx.Lock()
+	if s.closeErr != nil {
+		s.closeMx.Unlock()
+		return nil, s.closeErr
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	id := s.addStreamCtxCancel(cancel)
+	s.closeMx.Unlock()
+
+	// open a new unidirectional stream without holding the mutex: this call might block
+	qstr, err := s.conn.OpenUniStreamSync(ctx)
+
+	s.closeMx.Lock()
+	defer s.closeMx.Unlock()
+	delete(s.streamCtxs, id)
+
+	// the session might have been closed concurrently with OpenStreamSync returning
+	if qstr != nil && s.closeErr != nil {
+		qstr.CancelWrite(WTSessionGoneErrorCode)
+		return nil, s.closeErr
+	}
+	if err != nil {
+		if s.closeErr != nil {
+			return nil, s.closeErr
+		}
+		return nil, err
+	}
+	return s.addSendStream(qstr), nil
+}
+
+func (s *Session) LocalAddr() net.Addr {
+	return s.conn.LocalAddr()
+}
+
+func (s *Session) RemoteAddr() net.Addr {
+	return s.conn.RemoteAddr()
+}
+
+func (s *Session) CloseWithError(code SessionErrorCode, msg string) error {
+	first, err := s.closeWithError(&SessionError{ErrorCode: code, Message: msg})
+	if err != nil || !first {
+		return err
+	}
+
+	err = closeSessionStream(s.str, code, msg)
+	<-s.ctx.Done()
+	return err
+}
+
+func closeSessionStream(str http3Stream, code SessionErrorCode, msg string) error {
+	// truncate the message if it's too long
+	if len(msg) > maxCloseCapsuleErrorMsgLen {
+		msg = truncateUTF8(msg, maxCloseCapsuleErrorMsgLen)
+	}
+
+	b := make([]byte, 4, 4+len(msg))
+	binary.BigEndian.PutUint32(b, uint32(code))
+	b = append(b, []byte(msg)...)
+
+	// Optimistically send the WT_CLOSE_SESSION Capsule:
+	// If we're flow-control limited, we don't want to wait for the receiver to issue new flow control credits.
+	// There's no idiomatic way to do a non-blocking write in Go, so we set a short deadline.
+	str.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
+	if err := http3.WriteCapsule(quicvarint.NewWriter(str), closeSessionCapsuleType, b); err != nil {
+		str.CancelWrite(WTSessionGoneErrorCode)
+	}
+
+	str.CancelRead(WTSessionGoneErrorCode)
+	return str.Close()
+}
+
+func (s *Session) SendDatagram(b []byte) error {
+	return s.str.SendDatagram(b)
+}
+
+func (s *Session) ReceiveDatagram(ctx context.Context) ([]byte, error) {
+	return s.str.ReceiveDatagram(ctx)
+}
+
+func (s *Session) closeWithError(closeErr error) (bool /* first call to close session */, error) {
+	s.closeMx.Lock()
+	defer s.closeMx.Unlock()
+	// Duplicate call, or the remote already closed this session.
+	if s.closeErr != nil {
+		return false, nil
+	}
+	s.closeErr = closeErr
+
+	for _, cancel := range s.streamCtxs {
+		cancel()
+	}
+	s.streams.CloseSession(closeErr)
+
+	return true, nil
+}
+
+// SessionState returns the current state of the session
+func (s *Session) SessionState() SessionState {
+	return SessionState{
+		ConnectionState:     s.conn.ConnectionState(),
+		ApplicationProtocol: s.applicationProtocol,
+	}
+}
+
+// truncateUTF8 cuts a string to max n bytes without breaking UTF-8 characters.
+func truncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}

--- a/vendor/github.com/quic-go/webtransport-go/session_manager.go
+++ b/vendor/github.com/quic-go/webtransport-go/session_manager.go
@@ -1,0 +1,179 @@
+package webtransport
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+type unestablishedSession struct {
+	Streams    []*quic.Stream
+	UniStreams []*quic.ReceiveStream
+
+	Timer *time.Timer
+}
+
+type sessionEntry struct {
+	// at any point in time, only one of these will be non-nil
+	Unestablished *unestablishedSession
+	Session       *Session
+}
+
+const maxRecentlyClosedSessions = 16
+
+type sessionManager struct {
+	timeout time.Duration
+
+	mx                     sync.Mutex
+	sessions               map[sessionID]sessionEntry
+	recentlyClosedSessions []sessionID
+}
+
+func newSessionManager(timeout time.Duration) *sessionManager {
+	return &sessionManager{
+		timeout:  timeout,
+		sessions: make(map[sessionID]sessionEntry),
+	}
+}
+
+// AddStream adds a new bidirectional stream to a WebTransport session.
+// If the WebTransport session has not yet been established,
+// the stream is buffered until the session is established.
+// If that takes longer than timeout, the stream is reset.
+func (m *sessionManager) AddStream(str *quic.Stream, id sessionID) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	entry, ok := m.sessions[id]
+	if !ok {
+		// Receiving a stream for an unknown session is expected to be rare,
+		// so the performance impact of searching through the slice is negligible.
+		if slices.Contains(m.recentlyClosedSessions, id) {
+			str.CancelRead(WTBufferedStreamRejectedErrorCode)
+			str.CancelWrite(WTBufferedStreamRejectedErrorCode)
+			return
+		}
+		entry = sessionEntry{Unestablished: &unestablishedSession{}}
+		m.sessions[id] = entry
+	}
+	if entry.Session != nil {
+		entry.Session.addIncomingStream(str)
+		return
+	}
+
+	entry.Unestablished.Streams = append(entry.Unestablished.Streams, str)
+	m.resetTimer(id)
+}
+
+// AddUniStream adds a new unidirectional stream to a WebTransport session.
+// If the WebTransport session has not yet been established,
+// the stream is buffered until the session is established.
+// If that takes longer than timeout, the stream is reset.
+func (m *sessionManager) AddUniStream(str *quic.ReceiveStream, id sessionID) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	entry, ok := m.sessions[id]
+	if !ok {
+		// Receiving a stream for an unknown session is expected to be rare,
+		// so the performance impact of searching through the slice is negligible.
+		if slices.Contains(m.recentlyClosedSessions, id) {
+			str.CancelRead(WTBufferedStreamRejectedErrorCode)
+			return
+		}
+		entry = sessionEntry{Unestablished: &unestablishedSession{}}
+		m.sessions[id] = entry
+	}
+	if entry.Session != nil {
+		entry.Session.addIncomingUniStream(str)
+		return
+	}
+
+	entry.Unestablished.UniStreams = append(entry.Unestablished.UniStreams, str)
+	m.resetTimer(id)
+}
+
+func (m *sessionManager) resetTimer(id sessionID) {
+	entry := m.sessions[id]
+	if entry.Unestablished.Timer != nil {
+		entry.Unestablished.Timer.Reset(m.timeout)
+		return
+	}
+	entry.Unestablished.Timer = time.AfterFunc(m.timeout, func() { m.onTimer(id) })
+}
+
+func (m *sessionManager) onTimer(id sessionID) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	sessionEntry, ok := m.sessions[id]
+	if !ok { // session already closed
+		return
+	}
+	if sessionEntry.Session != nil { // session already established
+		return
+	}
+	for _, str := range sessionEntry.Unestablished.Streams {
+		str.CancelRead(WTBufferedStreamRejectedErrorCode)
+		str.CancelWrite(WTBufferedStreamRejectedErrorCode)
+	}
+	for _, uniStr := range sessionEntry.Unestablished.UniStreams {
+		uniStr.CancelRead(WTBufferedStreamRejectedErrorCode)
+	}
+	delete(m.sessions, id)
+}
+
+// AddSession adds a new WebTransport session.
+func (m *sessionManager) AddSession(id sessionID, s *Session) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	entry, ok := m.sessions[id]
+
+	if ok && entry.Unestablished != nil {
+		// We might already have an entry of this session.
+		// This can happen when we receive streams for this WebTransport session before we complete
+		// the Extended CONNECT request.
+		for _, str := range entry.Unestablished.Streams {
+			s.addIncomingStream(str)
+		}
+		for _, uniStr := range entry.Unestablished.UniStreams {
+			s.addIncomingUniStream(uniStr)
+		}
+		if entry.Unestablished.Timer != nil {
+			entry.Unestablished.Timer.Stop()
+		}
+		entry.Unestablished = nil
+	}
+	m.sessions[id] = sessionEntry{Session: s}
+
+	context.AfterFunc(s.Context(), func() {
+		m.deleteSession(id)
+	})
+}
+
+func (m *sessionManager) deleteSession(id sessionID) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	delete(m.sessions, id)
+	m.recentlyClosedSessions = append(m.recentlyClosedSessions, id)
+	if len(m.recentlyClosedSessions) > maxRecentlyClosedSessions {
+		m.recentlyClosedSessions = m.recentlyClosedSessions[1:]
+	}
+}
+
+func (m *sessionManager) Close() {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	for _, entry := range m.sessions {
+		if entry.Unestablished != nil && entry.Unestablished.Timer != nil {
+			entry.Unestablished.Timer.Stop()
+		}
+	}
+	clear(m.sessions)
+}

--- a/vendor/github.com/quic-go/webtransport-go/stream.go
+++ b/vendor/github.com/quic-go/webtransport-go/stream.go
@@ -1,0 +1,478 @@
+package webtransport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+type quicSendStream interface {
+	io.WriteCloser
+	CancelWrite(quic.StreamErrorCode)
+	Context() context.Context
+	SetWriteDeadline(time.Time) error
+	SetReliableBoundary()
+}
+
+var (
+	_ quicSendStream = &quic.SendStream{}
+	_ quicSendStream = &quic.Stream{}
+)
+
+type quicReceiveStream interface {
+	io.Reader
+	CancelRead(quic.StreamErrorCode)
+	SetReadDeadline(time.Time) error
+}
+
+var (
+	_ quicReceiveStream = &quic.ReceiveStream{}
+	_ quicReceiveStream = &quic.Stream{}
+)
+
+// A SendStream is a unidirectional WebTransport send stream.
+type SendStream struct {
+	str quicSendStream
+	// WebTransport stream header.
+	// Set by the constructor, set to nil once sent out.
+	// Might be initialized to nil if this sendStream is part of an incoming bidirectional stream.
+	streamHdr   []byte
+	streamHdrMu sync.Mutex
+	// Set to true when a goroutine is spawned to send the header asynchronously.
+	// This only happens if the stream is closed / reset immediately after creation.
+	sendingHdrAsync bool
+
+	onClose func() // to remove the stream from the streamsMap
+
+	closeOnce sync.Once
+	closed    chan struct{}
+	closeErr  error
+
+	deadlineMu       sync.Mutex
+	writeDeadline    time.Time
+	deadlineNotifyCh chan struct{} // receives a value when deadline changes
+}
+
+func newSendStream(str quicSendStream, hdr []byte, onClose func()) *SendStream {
+	return &SendStream{
+		str:       str,
+		closed:    make(chan struct{}),
+		streamHdr: hdr,
+		onClose:   onClose,
+	}
+}
+
+// Write writes data to the stream.
+// Write can be made to time out using [SendStream.SetWriteDeadline].
+// If the stream was canceled, the error is a [StreamError].
+func (s *SendStream) Write(b []byte) (int, error) {
+	n, err := s.write(b)
+	var strErr *quic.StreamError
+	if errors.As(err, &strErr) && strErr.ErrorCode == WTSessionGoneErrorCode {
+		err = s.handleSessionGoneError()
+	}
+	if err != nil && !isTimeoutError(err) {
+		s.onClose()
+	}
+	return n, maybeConvertStreamError(err)
+}
+
+// handleSessionGoneError waits for the session to be closed after receiving a WTSessionGoneErrorCode.
+// If the peer is initiating the session close, we might need to wait for the CONNECT stream to be closed.
+// While a malicious peer might withhold the session close, this is not an interesting attack vector:
+// 1. a WebTransport stream consumes very little memory, and
+// 2. the number of concurrent WebTransport sessions is limited.
+func (s *SendStream) handleSessionGoneError() error {
+	s.deadlineMu.Lock()
+	if s.deadlineNotifyCh == nil {
+		s.deadlineNotifyCh = make(chan struct{}, 1)
+	}
+	s.deadlineMu.Unlock()
+
+	for {
+		s.deadlineMu.Lock()
+		deadline := s.writeDeadline
+		s.deadlineMu.Unlock()
+
+		var timerCh <-chan time.Time
+		if !deadline.IsZero() {
+			if d := time.Until(deadline); d > 0 {
+				timerCh = time.After(d)
+			} else {
+				return os.ErrDeadlineExceeded
+			}
+		}
+		select {
+		case <-s.closed:
+			return s.closeErr
+		case <-timerCh:
+			return os.ErrDeadlineExceeded
+		case <-s.deadlineNotifyCh:
+		}
+	}
+}
+
+func (s *SendStream) write(b []byte) (int, error) {
+	s.streamHdrMu.Lock()
+	err := s.maybeSendStreamHeader()
+	s.streamHdrMu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return s.str.Write(b)
+}
+
+func (s *SendStream) maybeSendStreamHeader() error {
+	if len(s.streamHdr) == 0 {
+		return nil
+	}
+	n, err := s.str.Write(s.streamHdr)
+	if n > 0 {
+		s.streamHdr = s.streamHdr[n:]
+	}
+	s.str.SetReliableBoundary()
+	if err != nil {
+		return err
+	}
+	s.streamHdr = nil
+	return nil
+}
+
+// CancelWrite aborts sending on this stream.
+// Data already written, but not yet delivered to the peer is not guaranteed to be delivered reliably.
+// Write will unblock immediately, and future calls to Write will fail.
+// When called multiple times it is a no-op.
+func (s *SendStream) CancelWrite(e StreamErrorCode) {
+	// if a Goroutine is already sending the header, return immediately
+	s.streamHdrMu.Lock()
+	if s.sendingHdrAsync {
+		s.streamHdrMu.Unlock()
+		return
+	}
+
+	if len(s.streamHdr) > 0 {
+		// Sending the stream header might block if we are blocked by flow control.
+		// Send a stream header async so that CancelWrite can return immediately.
+		s.sendingHdrAsync = true
+		streamHdr := s.streamHdr
+		s.streamHdr = nil
+		s.streamHdrMu.Unlock()
+
+		go func() {
+			s.SetWriteDeadline(time.Time{})
+			_, _ = s.str.Write(streamHdr)
+			s.str.SetReliableBoundary()
+			s.str.CancelWrite(webtransportCodeToHTTPCode(e))
+			s.onClose()
+		}()
+		return
+	}
+	s.streamHdrMu.Unlock()
+
+	s.str.CancelWrite(webtransportCodeToHTTPCode(e))
+	s.onClose()
+}
+
+func (s *SendStream) closeWithSession(err error) {
+	s.closeOnce.Do(func() {
+		s.closeErr = err
+		s.str.CancelWrite(WTSessionGoneErrorCode)
+		close(s.closed)
+	})
+}
+
+// Close closes the write-direction of the stream.
+// Future calls to Write are not permitted after calling Close.
+func (s *SendStream) Close() error {
+	// if a Goroutine is already sending the header, return immediately
+	s.streamHdrMu.Lock()
+	if s.sendingHdrAsync {
+		s.streamHdrMu.Unlock()
+		return nil
+	}
+
+	if len(s.streamHdr) > 0 {
+		// Sending the stream header might block if we are blocked by flow control.
+		// Send a stream header async so that CancelWrite can return immediately.
+		s.sendingHdrAsync = true
+		streamHdr := s.streamHdr
+		s.streamHdr = nil
+		s.streamHdrMu.Unlock()
+
+		go func() {
+			s.SetWriteDeadline(time.Time{})
+			_, _ = s.str.Write(streamHdr)
+			s.str.SetReliableBoundary()
+			_ = s.str.Close()
+			s.onClose()
+		}()
+		return nil
+	}
+	s.streamHdrMu.Unlock()
+
+	s.onClose()
+	return maybeConvertStreamError(s.str.Close())
+}
+
+// The Context is canceled as soon as the write-side of the stream is closed.
+// This happens when Close() or CancelWrite() is called, or when the peer
+// cancels the read-side of their stream.
+// The cancellation cause is set to the error that caused the stream to
+// close, or `context.Canceled` in case the stream is closed without error.
+func (s *SendStream) Context() context.Context {
+	return s.str.Context()
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that
+// some data was successfully written.
+// A zero value for t means Write will not time out.
+func (s *SendStream) SetWriteDeadline(t time.Time) error {
+	s.deadlineMu.Lock()
+	s.writeDeadline = t
+	if s.deadlineNotifyCh != nil {
+		select {
+		case s.deadlineNotifyCh <- struct{}{}:
+		default:
+		}
+	}
+	s.deadlineMu.Unlock()
+
+	return maybeConvertStreamError(s.str.SetWriteDeadline(t))
+}
+
+// A ReceiveStream is a unidirectional WebTransport receive stream.
+type ReceiveStream struct {
+	str quicReceiveStream
+
+	onClose func() // to remove the stream from the streamsMap
+
+	closeOnce sync.Once
+	closed    chan struct{}
+	closeErr  error
+
+	deadlineMu       sync.Mutex
+	readDeadline     time.Time
+	deadlineNotifyCh chan struct{} // receives a value when deadline changes
+}
+
+func newReceiveStream(str quicReceiveStream, onClose func()) *ReceiveStream {
+	return &ReceiveStream{
+		str:     str,
+		closed:  make(chan struct{}),
+		onClose: onClose,
+	}
+}
+
+// Read reads data from the stream.
+// Read can be made to time out using [ReceiveStream.SetReadDeadline].
+// If the stream was canceled, the error is a [StreamError].
+func (s *ReceiveStream) Read(b []byte) (int, error) {
+	n, err := s.str.Read(b)
+	var strErr *quic.StreamError
+	if errors.As(err, &strErr) && strErr.ErrorCode == WTSessionGoneErrorCode {
+		err = s.handleSessionGoneError()
+	}
+	if err != nil && !isTimeoutError(err) {
+		s.onClose()
+	}
+	return n, maybeConvertStreamError(err)
+}
+
+// handleSessionGoneError waits for the session to be closed after receiving a WTSessionGoneErrorCode.
+// If the peer is initiating the session close, we might need to wait for the CONNECT stream to be closed.
+// While a malicious peer might withhold the session close, this is not an interesting attack vector:
+// 1. a WebTransport stream consumes very little memory, and
+// 2. the number of concurrent WebTransport sessions is limited.
+func (s *ReceiveStream) handleSessionGoneError() error {
+	s.deadlineMu.Lock()
+	if s.deadlineNotifyCh == nil {
+		s.deadlineNotifyCh = make(chan struct{}, 1)
+	}
+	s.deadlineMu.Unlock()
+
+	for {
+		s.deadlineMu.Lock()
+		deadline := s.readDeadline
+		s.deadlineMu.Unlock()
+
+		var timerCh <-chan time.Time
+		if !deadline.IsZero() {
+			if d := time.Until(deadline); d > 0 {
+				timerCh = time.After(d)
+			} else {
+				return os.ErrDeadlineExceeded
+			}
+		}
+		select {
+		case <-s.closed:
+			return s.closeErr
+		case <-timerCh:
+			return os.ErrDeadlineExceeded
+		case <-s.deadlineNotifyCh:
+		}
+	}
+}
+
+// CancelRead aborts receiving on this stream.
+// It instructs the peer to stop transmitting stream data.
+// Read will unblock immediately, and future Read calls will fail.
+// When called multiple times it is a no-op.
+func (s *ReceiveStream) CancelRead(e StreamErrorCode) {
+	s.str.CancelRead(webtransportCodeToHTTPCode(e))
+	s.onClose()
+}
+
+func (s *ReceiveStream) closeWithSession(err error) {
+	s.closeOnce.Do(func() {
+		s.closeErr = err
+		s.str.CancelRead(WTSessionGoneErrorCode)
+		close(s.closed)
+	})
+}
+
+// SetReadDeadline sets the deadline for future Read calls and
+// any currently-blocked Read call.
+// A zero value for t means Read will not time out.
+func (s *ReceiveStream) SetReadDeadline(t time.Time) error {
+	s.deadlineMu.Lock()
+	s.readDeadline = t
+	if s.deadlineNotifyCh != nil {
+		select {
+		case s.deadlineNotifyCh <- struct{}{}:
+		default:
+		}
+	}
+	s.deadlineMu.Unlock()
+
+	return maybeConvertStreamError(s.str.SetReadDeadline(t))
+}
+
+// Stream is a bidirectional WebTransport stream.
+type Stream struct {
+	sendStr *SendStream
+	recvStr *ReceiveStream
+
+	mx                             sync.Mutex
+	sendSideClosed, recvSideClosed bool
+	onClose                        func()
+}
+
+func newStream(str *quic.Stream, hdr []byte, onClose func()) *Stream {
+	s := &Stream{onClose: onClose}
+	s.sendStr = newSendStream(str, hdr, func() { s.registerClose(true) })
+	s.recvStr = newReceiveStream(str, func() { s.registerClose(false) })
+	return s
+}
+
+// Write writes data to the stream.
+// Write can be made to time out using [Stream.SetWriteDeadline] or [Stream.SetDeadline].
+// If the stream was canceled, the error is a [StreamError].
+func (s *Stream) Write(b []byte) (int, error) {
+	return s.sendStr.Write(b)
+}
+
+// Read reads data from the stream.
+// Read can be made to time out using [Stream.SetReadDeadline] and [Stream.SetDeadline].
+// If the stream was canceled, the error is a [StreamError].
+func (s *Stream) Read(b []byte) (int, error) {
+	return s.recvStr.Read(b)
+}
+
+// CancelWrite aborts sending on this stream.
+// See [SendStream.CancelWrite] for more details.
+func (s *Stream) CancelWrite(e StreamErrorCode) {
+	s.sendStr.CancelWrite(e)
+}
+
+// CancelRead aborts receiving on this stream.
+// See [ReceiveStream.CancelRead] for more details.
+func (s *Stream) CancelRead(e StreamErrorCode) {
+	s.recvStr.CancelRead(e)
+}
+
+// Close closes the send-direction of the stream.
+// It does not close the receive-direction of the stream.
+func (s *Stream) Close() error {
+	return s.sendStr.Close()
+}
+
+func (s *Stream) registerClose(isSendSide bool) {
+	s.mx.Lock()
+	if isSendSide {
+		s.sendSideClosed = true
+	} else {
+		s.recvSideClosed = true
+	}
+	isClosed := s.sendSideClosed && s.recvSideClosed
+	s.mx.Unlock()
+
+	if isClosed {
+		s.onClose()
+	}
+}
+
+func (s *Stream) closeWithSession(err error) {
+	s.sendStr.closeWithSession(err)
+	s.recvStr.closeWithSession(err)
+}
+
+// The Context is canceled as soon as the write-side of the stream is closed.
+// See [SendStream.Context] for more details.
+func (s *Stream) Context() context.Context {
+	return s.sendStr.Context()
+}
+
+// SetWriteDeadline sets the deadline for future Write calls.
+// See [SendStream.SetWriteDeadline] for more details.
+func (s *Stream) SetWriteDeadline(t time.Time) error {
+	return s.sendStr.SetWriteDeadline(t)
+}
+
+// SetReadDeadline sets the deadline for future Read calls.
+// See [ReceiveStream.SetReadDeadline] for more details.
+func (s *Stream) SetReadDeadline(t time.Time) error {
+	return s.recvStr.SetReadDeadline(t)
+}
+
+// SetDeadline sets the read and write deadlines associated with the stream.
+// It is equivalent to calling both SetReadDeadline and SetWriteDeadline.
+func (s *Stream) SetDeadline(t time.Time) error {
+	err1 := s.SetWriteDeadline(t)
+	err2 := s.SetReadDeadline(t)
+	return errors.Join(err1, err2)
+}
+
+func maybeConvertStreamError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var streamErr *quic.StreamError
+	if errors.As(err, &streamErr) {
+		errorCode, cerr := httpCodeToWebtransportCode(streamErr.ErrorCode)
+		if cerr != nil {
+			return fmt.Errorf("stream reset, but failed to convert stream error %d: %w", streamErr.ErrorCode, cerr)
+		}
+		return &StreamError{
+			ErrorCode: errorCode,
+			Remote:    streamErr.Remote,
+		}
+	}
+	return err
+}
+
+func isTimeoutError(err error) bool {
+	nerr, ok := err.(net.Error)
+	if !ok {
+		return false
+	}
+	return nerr.Timeout()
+}

--- a/vendor/github.com/quic-go/webtransport-go/streams_map.go
+++ b/vendor/github.com/quic-go/webtransport-go/streams_map.go
@@ -1,0 +1,42 @@
+package webtransport
+
+import (
+	"sync"
+
+	"github.com/quic-go/quic-go"
+)
+
+type closeFunc func(error)
+
+// The streamsMap manages the streams of a single QUIC connection.
+// Note that several WebTransport sessions can share one QUIC connection.
+type streamsMap struct {
+	mx sync.Mutex
+	m  map[quic.StreamID]closeFunc
+}
+
+func newStreamsMap() *streamsMap {
+	return &streamsMap{m: make(map[quic.StreamID]closeFunc)}
+}
+
+func (s *streamsMap) AddStream(id quic.StreamID, close closeFunc) {
+	s.mx.Lock()
+	s.m[id] = close
+	s.mx.Unlock()
+}
+
+func (s *streamsMap) RemoveStream(id quic.StreamID) {
+	s.mx.Lock()
+	delete(s.m, id)
+	s.mx.Unlock()
+}
+
+func (s *streamsMap) CloseSession(err error) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	for _, cl := range s.m {
+		cl(err)
+	}
+	s.m = nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -286,6 +286,9 @@ github.com/docker/go-units
 # github.com/droundy/goopt v0.0.0-20220217183150-48d6390ad4d1
 ## explicit
 github.com/droundy/goopt
+# github.com/dunglas/httpsfv v1.1.0
+## explicit; go 1.14
+github.com/dunglas/httpsfv
 # github.com/elazarl/goproxy v1.8.4
 ## explicit; go 1.23.0
 github.com/elazarl/goproxy
@@ -748,6 +751,9 @@ github.com/quic-go/quic-go/qlog
 github.com/quic-go/quic-go/qlogwriter
 github.com/quic-go/quic-go/qlogwriter/jsontext
 github.com/quic-go/quic-go/quicvarint
+# github.com/quic-go/webtransport-go v0.11.0
+## explicit; go 1.25.0
+github.com/quic-go/webtransport-go
 # github.com/rivo/tview v0.42.0
 ## explicit; go 1.18
 github.com/rivo/tview


### PR DESCRIPTION
## What

Adds **WebTransport** (HTTP/3 over QUIC) as a fourth dmsg transport alongside TCP, QUIC and WebSocket.

WebTransport is the one browser-reachable transport that needs **no CA-issued certificate**: the browser's WebTransport constructor accepts a self-signed cert via `serverCertificateHashes` (a pinned SHA-256). So a dmsg server can present a short-lived self-signed ECDSA cert, publish its hash in discovery, and a browser connects to it **by bare IP** — no Caddy, no domain, no Let's Encrypt. This is the transport that lets the in-browser (WASM) dmsg client / hypervisor reach the mesh without any fronting infrastructure.

## How

Like the WS path, a WT session carries the **existing Noise+yamux session** over a single bidirectional stream. The per-hop Noise handshake still authenticates the client PK (a browser can't present a client cert, so client→server auth happens in Noise, not TLS); only the **server** is authenticated at the TLS layer, by cert-hash pinning. WT's native stream multiplexing is intentionally unused — yamux multiplexes inside the one WT stream, keeping a single session implementation.

- `pkg/skyquic/webtransport.go` — `NewWebTransportCertificate` (ECDSA P-256, 13-day validity, browser-enforced ≤14d) + its SHA-256; `WebTransportTLSConfig`.
- `pkg/dmsg/dmsg/wt.go` — `Server.ServeWebTransport` (caller owns the cert for deterministic rotation), `handleWTSession`, `wtStreamConn` (net.Conn adapter), and `Client.dialSessionWT` (native path: pins `CertHashWT`, disables session resumption so a resumed handshake can't bypass the pin).
- `disc.Server.AddressWT` + `CertHashWT`, advertised from `EntityCommon`; `Config.PreferWT` + dial-switch wiring with TCP fallback.
- `dmsgserver` config `wt_address` / `public_address_wt`; `dmsgsrv` serves WT best-effort (a bind/cert failure leaves TCP/QUIC/WS serving normally).

## Tests

`wt_test.go`: full bridged A→B round-trip over a **WT-only** server (empty TCP Address ⇒ no fallback, so the session MUST be over WebTransport), plus a cert-hash-mismatch rejection test (client pinning the wrong hash never connects).

Vendors `github.com/quic-go/webtransport-go v0.11.0` (+ `dunglas/httpsfv`).