### PR TITLE
feat(wasmhv): apps + transports control endpoints for the standalone hypervisor

### DIFF
--- a/pkg/wasmhv/control.go
+++ b/pkg/wasmhv/control.go
@@ -1,0 +1,188 @@
+package wasmhv
+
+import (
+	"bytes"
+	"encoding/gob"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// This file adds the WRITE / control surface of the wasm hypervisor core:
+// apps (list / start / stop / autostart) and transports (list / add / remove).
+// As in core.go, it deliberately avoids importing pkg/visor (non-wasm) and
+// instead declares MINIMAL MIRROR TYPES of the visor's RPC request/reply
+// structs. gob matches struct fields BY NAME and ignores fields it can't map,
+// so a partial mirror decodes the fields the UI reads and encodes the fields a
+// control call needs.
+
+// --- app mirror types (gob field names + json tags match pkg/visor/appserver) ---
+
+// AppConfig mirrors the subset of appserver/spec.AppConfig the UI reads. It is
+// embedded anonymously in AppState so both gob (field name "AppConfig") and
+// json (promoted/flattened fields) line up with the real AppState.
+type AppConfig struct {
+	Name         string   `json:"name"`
+	Binary       string   `json:"binary,omitempty"`
+	Args         []string `json:"args,omitempty"`
+	AutoStart    bool     `json:"auto_start"`
+	Port         uint16   `json:"port"`
+	LauncherMode string   `json:"launcher_mode,omitempty"`
+}
+
+// AppState mirrors appserver.AppState (AppConfig embedded + Status fields).
+type AppState struct {
+	AppConfig
+	Status         int    `json:"status"`
+	DetailedStatus string `json:"detailed_status"`
+}
+
+// startAppIn mirrors visor.StartAppIn (the StartApp RPC argument).
+type startAppIn struct {
+	AppName      string
+	LauncherMode string
+}
+
+// setAutoStartIn mirrors visor.SetAutoStartIn (the SetAutoStart RPC argument).
+type setAutoStartIn struct {
+	AppName   string
+	AutoStart bool
+}
+
+// --- transport mirror types ---
+
+// TransportLogEntry mirrors transport.LogEntry on the wire. The real type uses
+// a custom Gob/JSON codec (two uint64s; json {"recv":..,"sent":..}), so this
+// mirror reproduces BOTH: GobDecode reads the two counters the server's
+// GobEncode wrote, and MarshalJSON emits the {recv,sent} shape the UI reads.
+type TransportLogEntry struct {
+	RecvBytes uint64
+	SentBytes uint64
+}
+
+// GobDecode mirrors transport.LogEntry.GobEncode: two separately-encoded uint64s.
+func (le *TransportLogEntry) GobDecode(b []byte) error {
+	dec := gob.NewDecoder(bytes.NewReader(b))
+	var rb, sb uint64
+	if err := dec.Decode(&rb); err != nil {
+		return err
+	}
+	if err := dec.Decode(&sb); err != nil {
+		return err
+	}
+	atomic.StoreUint64(&le.RecvBytes, rb)
+	atomic.StoreUint64(&le.SentBytes, sb)
+	return nil
+}
+
+// MarshalJSON emits {"recv":N,"sent":N} to match transport.LogEntry.MarshalJSON.
+func (le TransportLogEntry) MarshalJSON() ([]byte, error) {
+	return []byte(`{"recv":` + strconv.FormatUint(le.RecvBytes, 10) +
+		`,"sent":` + strconv.FormatUint(le.SentBytes, 10) + `}`), nil
+}
+
+// TransportSummary mirrors visor.TransportSummary.
+type TransportSummary struct {
+	ID        uuid.UUID          `json:"id"`
+	Local     cipher.PubKey      `json:"local_pk"`
+	Remote    cipher.PubKey      `json:"remote_pk"`
+	Type      string             `json:"type"`
+	Log       *TransportLogEntry `json:"log,omitempty"`
+	IsSetup   bool               `json:"is_setup"`
+	Label     string             `json:"label"`
+	LatencyMS float64            `json:"latency_ms,omitempty"`
+}
+
+// transportsIn mirrors visor.TransportsIn (the Transports RPC argument).
+type transportsIn struct {
+	FilterTypes   []string
+	FilterPubKeys []cipher.PubKey
+	ShowLogs      bool
+}
+
+// addTransportIn mirrors visor.AddTransportIn (the AddTransport RPC argument).
+type addTransportIn struct {
+	RemotePK         cipher.PubKey
+	TpType           string
+	Timeout          time.Duration
+	Label            string
+	NoRegister       bool
+	SkipLatencyProbe bool
+}
+
+// --- control calls ---
+
+// apps fetches a visor's app list.
+func (c *Core) apps(pk cipher.PubKey) ([]*AppState, error) {
+	var reply []*AppState
+	if err := c.call(pk, "Apps", &struct{}{}, &reply); err != nil {
+		return nil, err
+	}
+	return reply, nil
+}
+
+// app fetches a single app's state by name.
+func (c *Core) app(pk cipher.PubKey, name string) (*AppState, error) {
+	var reply AppState
+	if err := c.call(pk, "App", &name, &reply); err != nil {
+		return nil, err
+	}
+	return &reply, nil
+}
+
+// startApp starts an app (default launcher mode).
+func (c *Core) startApp(pk cipher.PubKey, name string) error {
+	return c.call(pk, "StartApp", &startAppIn{AppName: name}, &struct{}{})
+}
+
+// stopApp stops an app.
+func (c *Core) stopApp(pk cipher.PubKey, name string) error {
+	return c.call(pk, "StopApp", &name, &struct{}{})
+}
+
+// setAutoStart sets an app's autostart flag.
+func (c *Core) setAutoStart(pk cipher.PubKey, name string, autostart bool) error {
+	return c.call(pk, "SetAutoStart", &setAutoStartIn{AppName: name, AutoStart: autostart}, &struct{}{})
+}
+
+// transports fetches a visor's transport list (with logs).
+func (c *Core) transports(pk cipher.PubKey) ([]*TransportSummary, error) {
+	var reply []*TransportSummary
+	if err := c.call(pk, "Transports", &transportsIn{ShowLogs: true}, &reply); err != nil {
+		return nil, err
+	}
+	return reply, nil
+}
+
+// transportTypes fetches the transport types a visor supports.
+func (c *Core) transportTypes(pk cipher.PubKey) ([]string, error) {
+	var reply []string
+	if err := c.call(pk, "TransportTypes", &struct{}{}, &reply); err != nil {
+		return nil, err
+	}
+	return reply, nil
+}
+
+// addTransport creates a transport from the visor to remote of the given type.
+func (c *Core) addTransport(pk cipher.PubKey, in addTransportIn) (*TransportSummary, error) {
+	if in.TpType == "" {
+		in.TpType = "skywire" // visor default when unspecified
+	}
+	if in.Timeout == 0 {
+		in.Timeout = 30 * time.Second
+	}
+	var reply TransportSummary
+	if err := c.call(pk, "AddTransport", &in, &reply); err != nil {
+		return nil, err
+	}
+	return &reply, nil
+}
+
+// removeTransport deletes a transport by ID.
+func (c *Core) removeTransport(pk cipher.PubKey, tid uuid.UUID) error {
+	return c.call(pk, "RemoveTransport", &tid, &struct{}{})
+}

--- a/pkg/wasmhv/gob_mirror_test.go
+++ b/pkg/wasmhv/gob_mirror_test.go
@@ -1,0 +1,129 @@
+//go:build !js
+
+// Package wasmhv gob_mirror_test.go: validates that the wasm-core MIRROR types
+// (which deliberately do not import pkg/visor, so they compile to js/wasm)
+// gob-decode faithfully from the REAL visor RPC types — and that the mirror
+// argument types gob-encode into the real RPC argument types. This is the
+// safety net for the "gob matches by field name" assumption the wasm
+// hypervisor core relies on: a field rename on either side breaks a test here
+// instead of silently returning zero values to the browser UI.
+//
+// Host-only (`!js`): it imports pkg/visor / appserver, which don't build for
+// wasm — exactly why the mirror types exist.
+package wasmhv
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/app/appserver"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+func gobRoundTrip(t *testing.T, src, dst interface{}) {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(src))
+	require.NoError(t, gob.NewDecoder(&buf).Decode(dst))
+}
+
+// TestMirrorAppStateDecodes confirms appserver.AppState → wasmhv.AppState.
+func TestMirrorAppStateDecodes(t *testing.T) {
+	real := &appserver.AppState{
+		Status:         appserver.AppStatusRunning,
+		DetailedStatus: "Running",
+	}
+	real.Name = "skysocks-client"
+	real.Binary = "skysocks-client"
+	real.Args = []string{"-srv", "abc"}
+	real.AutoStart = true
+	real.Port = 3
+	real.LauncherMode = "external"
+
+	var got AppState
+	gobRoundTrip(t, real, &got)
+
+	require.Equal(t, "skysocks-client", got.Name)
+	require.Equal(t, "skysocks-client", got.Binary)
+	require.Equal(t, []string{"-srv", "abc"}, got.Args)
+	require.True(t, got.AutoStart)
+	require.Equal(t, uint16(3), got.Port)
+	require.Equal(t, "external", got.LauncherMode)
+	require.Equal(t, int(appserver.AppStatusRunning), got.Status)
+	require.Equal(t, "Running", got.DetailedStatus)
+}
+
+// TestMirrorTransportSummaryDecodes confirms visor.TransportSummary (including
+// the custom-gob *transport.LogEntry) → wasmhv.TransportSummary.
+func TestMirrorTransportSummaryDecodes(t *testing.T) {
+	pkL, _ := cipher.GenerateKeyPair()
+	pkR, _ := cipher.GenerateKeyPair()
+	rb, sb := uint64(111), uint64(222)
+	real := &visor.TransportSummary{
+		ID:        uuid.New(),
+		Local:     pkL,
+		Remote:    pkR,
+		Type:      "dmsg",
+		Log:       &transport.LogEntry{RecvBytes: &rb, SentBytes: &sb},
+		IsSetup:   false,
+		Label:     "skycoin",
+		LatencyMS: 42.5,
+	}
+
+	var got TransportSummary
+	gobRoundTrip(t, real, &got)
+
+	require.Equal(t, real.ID, got.ID)
+	require.Equal(t, pkL, got.Local)
+	require.Equal(t, pkR, got.Remote)
+	require.Equal(t, "dmsg", got.Type)
+	require.Equal(t, "skycoin", got.Label)
+	require.Equal(t, 42.5, got.LatencyMS)
+	require.NotNil(t, got.Log)
+	require.Equal(t, uint64(111), got.Log.RecvBytes)
+	require.Equal(t, uint64(222), got.Log.SentBytes)
+}
+
+// TestMirrorArgsEncode confirms the mirror RPC ARGUMENT types gob-encode into
+// the real visor.* argument types (the direction a control call travels).
+func TestMirrorArgsEncode(t *testing.T) {
+	t.Run("StartAppIn", func(t *testing.T) {
+		var got visor.StartAppIn
+		gobRoundTrip(t, &startAppIn{AppName: "vpn-client", LauncherMode: "internal"}, &got)
+		require.Equal(t, "vpn-client", got.AppName)
+		require.Equal(t, "internal", got.LauncherMode)
+	})
+	t.Run("SetAutoStartIn", func(t *testing.T) {
+		var got visor.SetAutoStartIn
+		gobRoundTrip(t, &setAutoStartIn{AppName: "vpn-client", AutoStart: true}, &got)
+		require.Equal(t, "vpn-client", got.AppName)
+		require.True(t, got.AutoStart)
+	})
+	t.Run("TransportsIn", func(t *testing.T) {
+		pk, _ := cipher.GenerateKeyPair()
+		var got visor.TransportsIn
+		gobRoundTrip(t, &transportsIn{FilterTypes: []string{"dmsg"}, FilterPubKeys: []cipher.PubKey{pk}, ShowLogs: true}, &got)
+		require.Equal(t, []string{"dmsg"}, got.FilterTypes)
+		require.Equal(t, []cipher.PubKey{pk}, got.FilterPubKeys)
+		require.True(t, got.ShowLogs)
+	})
+	t.Run("AddTransportIn", func(t *testing.T) {
+		pk, _ := cipher.GenerateKeyPair()
+		var got visor.AddTransportIn
+		gobRoundTrip(t, &addTransportIn{
+			RemotePK: pk, TpType: "stcpr", Timeout: 30 * time.Second, Label: "user", NoRegister: true,
+		}, &got)
+		require.Equal(t, pk, got.RemotePK)
+		require.Equal(t, "stcpr", got.TpType)
+		require.Equal(t, 30*time.Second, got.Timeout)
+		require.Equal(t, "user", got.Label)
+		require.True(t, got.NoRegister)
+	})
+}

--- a/pkg/wasmhv/override.js
+++ b/pkg/wasmhv/override.js
@@ -36,15 +36,38 @@
 
   // ensure boots the wasm client + connects (once). The first shimmed request
   // awaits this, so the app's initial /api call blocks until dmsg is up.
+  //
+  // Two modes:
+  //  - viewer (default): route /api over dmsg to a REMOTE hypervisor CFG.pk.
+  //  - standalone (CFG.standalone): THIS tab IS the hypervisor — start
+  //    serveHypervisor() so visors listing this PK dial in, and route /api to
+  //    the in-wasm core (hvApi) instead of a remote fetch.
   function ensure() {
     if (readyP) return readyP;
     readyP = (async function () {
       while (!self.skywireDmsg) { await new Promise(function (r) { setTimeout(r, 10); }); }
       var sk = await resolveSK();
       var pk = await self.skywireDmsg.connect(sk, CFG.seedpk, CFG.seedws, CFG.disc);
-      log('connected over dmsg as ' + pk + ' → hypervisor ' + CFG.pk);
+      if (CFG.standalone) {
+        await self.skywireDmsg.serveHypervisor();
+        log('standalone hypervisor serving as ' + pk + ' (visors dial in on port 46)');
+      } else {
+        log('connected over dmsg as ' + pk + ' → hypervisor ' + CFG.pk);
+      }
     })();
     return readyP;
+  }
+
+  // dispatch routes one same-origin request: in standalone mode to the in-wasm
+  // hypervisor core (hvApi), else over dmsg to the remote hypervisor (fetch).
+  // Both resolve to {status, body:Uint8Array, headers}; hvApi has no response
+  // headers of its own, so we synthesize a JSON content-type for the UI.
+  function dispatch(method, path, body, headers) {
+    if (CFG.standalone) {
+      return self.skywireDmsg.hvApi(method, path, body == null ? null : String(body))
+        .then(function (r) { return { status: r.status, body: r.body, headers: { 'Content-Type': 'application/json' } }; });
+    }
+    return self.skywireDmsg.fetch(CFG.pk, method, path, body == null ? null : String(body), headers);
   }
 
   function isLocal(url) {
@@ -96,7 +119,7 @@
       real.send(body); return;
     }
     ensure().then(function () {
-      return self.skywireDmsg.fetch(CFG.pk, self_._m, pathOf(self_._u), body == null ? null : String(body), self_._h);
+      return dispatch(self_._m, pathOf(self_._u), body, self_._h);
     }).then(function (r) {
       self_.status = r.status; self_.statusText = '';
       var txt = new TextDecoder().decode(r.body);
@@ -128,7 +151,7 @@
       else for (var k in init.headers) headers[k] = init.headers[k];
     }
     return ensure().then(function () {
-      return self.skywireDmsg.fetch(CFG.pk, init.method || 'GET', pathOf(url), init.body == null ? null : String(init.body), headers);
+      return dispatch(init.method || 'GET', pathOf(url), init.body, headers);
     }).then(function (r) {
       var h = new Headers();
       for (var k in r.headers) { try { h.set(k, r.headers[k]); } catch (e) {} }

--- a/pkg/wasmhv/router.go
+++ b/pkg/wasmhv/router.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
+
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/cipher"
 )
@@ -18,9 +20,9 @@ var (
 // ServeHTTP routes a hypervisor /api request and returns (status, jsonBody).
 // It is the in-wasm equivalent of the binary hypervisor's HTTP handler — the
 // browser's fetch/XHR override (override.js) calls this instead of going over
-// dmsg to a remote hypervisor. Only the read endpoints needed for the node
-// dashboard are implemented so far; unknown routes 404.
-func (c *Core) ServeHTTP(method, path string, _ []byte) (int, []byte) {
+// dmsg to a remote hypervisor. The read dashboard endpoints plus the apps /
+// transports control endpoints are implemented; unknown routes 404.
+func (c *Core) ServeHTTP(method, path string, body []byte) (int, []byte) {
 	p := strings.TrimPrefix(path, "/api")
 	p = strings.SplitN(p, "?", 2)[0]
 	p = strings.TrimSuffix(p, "/")
@@ -56,13 +58,13 @@ func (c *Core) ServeHTTP(method, path string, _ []byte) (int, []byte) {
 		return jsonResp(c.allSummaries())
 
 	case strings.HasPrefix(p, "/visors/"):
-		return c.visorRoute(strings.TrimPrefix(p, "/visors/"))
+		return c.visorRoute(method, strings.TrimPrefix(p, "/visors/"), body)
 	}
 	return 404, []byte(`{"error":"not found in wasm hypervisor core"}`)
 }
 
-// visorRoute handles /visors/<pk>[/sub].
-func (c *Core) visorRoute(rest string) (int, []byte) {
+// visorRoute handles /visors/<pk>[/sub] for all HTTP methods.
+func (c *Core) visorRoute(method, rest string, body []byte) (int, []byte) {
 	parts := strings.SplitN(rest, "/", 2)
 	var pk cipher.PubKey
 	if err := pk.UnmarshalText([]byte(parts[0])); err != nil {
@@ -72,20 +74,128 @@ func (c *Core) visorRoute(rest string) (int, []byte) {
 	if len(parts) == 2 {
 		sub = parts[1]
 	}
-	switch sub {
-	case "":
-		ov := c.overviewOf(pk)
-		return jsonResp(ov)
-	case "summary":
+	switch {
+	case sub == "":
+		return jsonResp(c.overviewOf(pk))
+	case sub == "summary":
 		return jsonResp(c.summaryOf(pk))
-	case "health":
+	case sub == "health":
 		var h HealthInfo
 		if err := c.call(pk, "Health", &struct{}{}, &h); err != nil {
 			return jsonResp(HealthInfo{})
 		}
 		return jsonResp(h)
+
+	// --- apps ---
+	case sub == "apps":
+		apps, err := c.apps(pk)
+		if err != nil {
+			return errResp(err)
+		}
+		return jsonResp(apps)
+	case strings.HasPrefix(sub, "apps/"):
+		return c.appRoute(method, pk, strings.TrimPrefix(sub, "apps/"), body)
+
+	// --- transports ---
+	case sub == "transport-types":
+		types, err := c.transportTypes(pk)
+		if err != nil {
+			return errResp(err)
+		}
+		return jsonResp(types)
+	case sub == "transports":
+		return c.transportsRoute(method, pk, body)
+	case strings.HasPrefix(sub, "transports/"):
+		return c.transportRoute(method, pk, strings.TrimPrefix(sub, "transports/"))
 	}
 	return 404, []byte(`{"error":"visor subroute not implemented in wasm core"}`)
+}
+
+// appRoute handles /visors/<pk>/apps/<app>: GET returns the app, PUT applies
+// status (start/stop) and/or autostart changes then returns the fresh state.
+func (c *Core) appRoute(method string, pk cipher.PubKey, appName string, body []byte) (int, []byte) {
+	// The app name is the remaining path segment; sub-routes like
+	// apps/<app>/logs|stats|connections aren't implemented in the wasm core yet.
+	appName = strings.SplitN(appName, "/", 2)[0]
+	if method == "PUT" {
+		var req struct {
+			Status    *int  `json:"status,omitempty"`
+			AutoStart *bool `json:"autostart,omitempty"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return 400, []byte(`{"error":"bad request body"}`)
+		}
+		if req.AutoStart != nil {
+			if err := c.setAutoStart(pk, appName, *req.AutoStart); err != nil {
+				return errResp(err)
+			}
+		}
+		if req.Status != nil {
+			switch *req.Status {
+			case 0:
+				if err := c.stopApp(pk, appName); err != nil {
+					return errResp(err)
+				}
+			case 1:
+				if err := c.startApp(pk, appName); err != nil {
+					return errResp(err)
+				}
+			default:
+				return 400, []byte(`{"error":"status must be 0 (stop) or 1 (start)"}`)
+			}
+		}
+	}
+	app, err := c.app(pk, appName)
+	if err != nil {
+		return errResp(err)
+	}
+	return jsonResp(app)
+}
+
+// transportsRoute handles /visors/<pk>/transports: GET lists, POST adds.
+func (c *Core) transportsRoute(method string, pk cipher.PubKey, body []byte) (int, []byte) {
+	if method == "POST" {
+		var req struct {
+			TpType     string        `json:"transport_type"`
+			Remote     cipher.PubKey `json:"remote_pk"`
+			Label      string        `json:"label,omitempty"`
+			NoRegister bool          `json:"no_register,omitempty"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return 400, []byte(`{"error":"bad request body"}`)
+		}
+		ts, err := c.addTransport(pk, addTransportIn{
+			RemotePK:   req.Remote,
+			TpType:     req.TpType,
+			Label:      req.Label,
+			NoRegister: req.NoRegister,
+		})
+		if err != nil {
+			return errResp(err)
+		}
+		return jsonResp(ts)
+	}
+	tps, err := c.transports(pk)
+	if err != nil {
+		return errResp(err)
+	}
+	return jsonResp(tps)
+}
+
+// transportRoute handles /visors/<pk>/transports/<tid>: DELETE removes it.
+func (c *Core) transportRoute(method string, pk cipher.PubKey, tid string) (int, []byte) {
+	tid = strings.SplitN(tid, "/", 2)[0]
+	id, err := uuid.Parse(tid)
+	if err != nil {
+		return 400, []byte(`{"error":"bad transport id"}`)
+	}
+	if method == "DELETE" {
+		if err := c.removeTransport(pk, id); err != nil {
+			return errResp(err)
+		}
+		return jsonResp(true)
+	}
+	return 404, []byte(`{"error":"transport subroute not implemented in wasm core"}`)
 }
 
 // allOverviews concurrently fetches every connected visor's Overview.
@@ -120,4 +230,15 @@ func jsonResp(v interface{}) (int, []byte) {
 		return 500, []byte(`{"error":"marshal"}`)
 	}
 	return 200, b
+}
+
+// errResp renders an error as the hypervisor's {"error":"..."} shape with a 500.
+// A not-connected / timeout error is the common case (the visor dropped its dial
+// since the last poll); the UI surfaces the message as-is.
+func errResp(err error) (int, []byte) {
+	b, mErr := json.Marshal(map[string]string{"error": err.Error()})
+	if mErr != nil {
+		return 500, []byte(`{"error":"internal"}`)
+	}
+	return 500, b
 }


### PR DESCRIPTION
## What

Extends the wasm hypervisor core (#3190) from a **read-only dashboard** to a **controllable** one — the daily hypervisor operations: **apps** (list / start / stop / autostart) and **transports** (list / types / add / remove).

This is the management surface for the standalone, serverless hypervisor that visors dial into (a browser tab is the hypervisor; no domain, no server).

## How

As with the read path, the core does **not** import `pkg/visor` (which doesn't compile to js/wasm — bbolt/godbus/router). Instead it declares **minimal mirror types** of the visor RPC request/reply structs. gob matches struct fields **by name** and skips the rest, so a partial mirror decodes the fields the UI reads and encodes the fields a control call needs.

- **`control.go`** — mirror types (`AppState`, `TransportSummary` + its custom-gob `TransportLogEntry`, and the `StartApp`/`SetAutoStart`/`Transports`/`AddTransport` argument structs) + the control calls. `TransportLogEntry` reproduces `transport.LogEntry`'s custom Gob/JSON codec so per-transport bandwidth still renders.
- **`router.go`** — method-aware `/visors/<pk>` routing: `GET apps|transports|transport-types`, `PUT apps/<app>` (status + autostart), `POST transports`, `DELETE transports/<id>`.
- **`override.js`** — **standalone mode** (`CFG.standalone`): route `/api` to the in-wasm core (`hvApi`) and call `serveHypervisor()` on connect, instead of proxying to a remote hypervisor over dmsg. One shared `dispatch()` picks viewer-vs-standalone.

## Tests

**`gob_mirror_test.go`** (host-only `//go:build !js`): gob round-trips the **real** `appserver.AppState` / `visor.TransportSummary` / `visor.*In` types through the mirror types in **both** directions — so a field rename on either side fails a test here instead of silently zeroing a value in the browser. The host build can't import `pkg/visor` from a wasm-target file, which is exactly why the mirrors exist; the test validates them on the host.

Builds clean for both host and `GOOS=js GOARCH=wasm`.

## Follow-up

The single-file `hypervisor.html` generator (inlined wasm + Angular UI + password-encrypted key) is the remaining piece of the build-out and will land separately.