### PR TITLE
feat(tinygo): dmsg client compiles under TinyGo (wasip1/IoT) — Phase 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,10 @@ tpviz-wasm-tinygo: ## Build transport visualizer WASM binary with tinygo (smalle
 	tinygo build -o ./pkg/tpviz/dist/main.wasm -target wasm -no-debug -opt=z -panic=trap ./pkg/tpviz/wasm
 	cp "$$(tinygo env TINYGOROOT)/targets/wasm_exec.js" ./pkg/tpviz/dist/
 
+tinygo-dmsg: ## Build-check the dmsg client under TinyGo (IoT target wasip1); ~2.2MB -opt=z
+	tinygo build -target wasip1 -no-debug -opt=z -o ./build/dmsg-tinygo.wasm ./cmd/dmsg-tinygo-probe
+	@echo "built ./build/dmsg-tinygo.wasm — the dmsg client compiles under TinyGo (see docs/design/tinygo-dmsg-client.md)"
+
 dmsg-wasm: ## Build the browser WASM dmsg client + dev harness into build/dmsg-wasm
 	mkdir -p ./build/dmsg-wasm
 	GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o ./build/dmsg-wasm/dmsg.wasm ./cmd/dmsg-wasm

--- a/cmd/dmsg-tinygo-probe/main.go
+++ b/cmd/dmsg-tinygo-probe/main.go
@@ -1,0 +1,23 @@
+// Command dmsg-tinygo-probe is a minimal build-check that the dmsg client core
+// compiles under TinyGo (IoT / embedded targets). It constructs a dmsg.Client
+// and exits — it does not dial (a real IoT build supplies its own transport and
+// discovery). Its purpose is to keep the TinyGo build green in CI:
+//
+//	tinygo build -target wasip1 -o /dev/null ./cmd/dmsg-tinygo-probe
+//
+// (see the `tinygo-dmsg` Makefile target). It also builds and runs as a normal
+// Go program. See docs/design/tinygo-dmsg-client.md for the port.
+package main
+
+import (
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+)
+
+func main() {
+	pk, sk := cipher.GenerateKeyPair()
+	var dc disc.APIClient // a real IoT build supplies a dmsg-only disc client
+	c := dmsg.NewClient(pk, sk, dc, dmsg.DefaultConfig())
+	_ = c
+}

--- a/deployment/config.go
+++ b/deployment/config.go
@@ -17,6 +17,7 @@ package deployment
 
 import (
 	_ "embed"
+	"encoding/json"
 	"net/url"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -41,6 +42,18 @@ custom deployment configuration (e.g., for private networks or testing).
 //
 //go:embed services-config.json
 var ServicesJSON []byte
+
+// EnvServices is the wrapper struct for the outer JSON — i.e. the 'prod' or
+// 'test' deployment config. It lives in this untagged file (importing
+// encoding/json, which compiles under TinyGo 0.41) so consumers like
+// pkg/dmsg/dmsg's InitConfig can unmarshal the embedded config on every target,
+// including a TinyGo dmsg client. The native init() in config_native.go and the
+// static-literal init() in config_js.go both populate Prod/Test; this type is
+// just the shared shape they (and dmsg) decode into.
+type EnvServices struct {
+	Test json.RawMessage `json:"test"`
+	Prod json.RawMessage `json:"prod"`
+}
 
 // EnvServices is defined in config_native.go (lives there because
 // its json.RawMessage fields need encoding/json, which is

--- a/deployment/config_native.go
+++ b/deployment/config_native.go
@@ -15,13 +15,8 @@ import (
 	"os"
 )
 
-// EnvServices is the wrapper struct for the outer JSON — i.e. 'prod'
-// or 'test' deployment config. Lives in the !js file because its
-// json.RawMessage fields require the encoding/json import.
-type EnvServices struct {
-	Test json.RawMessage `json:"test"`
-	Prod json.RawMessage `json:"prod"`
-}
+// EnvServices now lives in config.go (untagged) so it builds on all targets,
+// including TinyGo (encoding/json compiles under TinyGo 0.41).
 
 func init() {
 	// SKYDEPLOY overrides the embedded deployment config with a

--- a/docs/design/tinygo-dmsg-client.md
+++ b/docs/design/tinygo-dmsg-client.md
@@ -97,21 +97,37 @@ destination stream via a smux/else-yamux branch (nil-deref panic for a QUIC
 destination), and the client accept loop never treated a QUIC `AcceptStream`
 error as terminal (spun forever → hung `Close()`).
 
-### Phase 3 — finish the peripheral deps, then prove it + a build target
+### Phase 3 — peripheral deps + a build target *(done)*
 
-The remaining TinyGo blocker (for the `wasip1`/IoT target) is **`pkg/netutil`**:
-`net.go` uses `net.Interface.Addrs()` (absent in TinyGo's `net`) and the
-GOOS-split `DefaultNetworkInterface` has no wasip1 variant. The dmsg client only
-needs `netutil`'s Porter + retrier, not the interface-enumeration helpers, so the
-fix is a `!tinygo` split + a small tinygo stub for the enum functions (the same
-pattern used for QUIC/metrics). Expect a short tail of similar peripheral
-packages after it.
+**The dmsg client now compiles under TinyGo for the `wasip1` (IoT) target.**
+`tinygo build -target wasip1 -no-debug -opt=z` produces a **~2.2 MB** wasm binary
+(`make tinygo-dmsg`; build-check main at `cmd/dmsg-tinygo-probe`).
 
-Then: a `cmd/` probe (or a `_test` build) and a `Makefile` `dmsg-tinygo` target
-(`tinygo build -target wasip1`) that compiles the client, wired into CI so the
-TinyGo build can't silently regress. For the browser, a TinyGo `wasm` build
-additionally needs `net/http` out of the graph (drop the server serve paths +
-metrics http from the client subset) — lower priority than the IoT target.
+The peripheral blockers cleared, each with the same `!tinygo`-split-plus-stub or
+de-tag-the-obsolete-`!tinygo` pattern:
+
+- **`pkg/netutil`** — `net.go` used `net.Interface.Addrs()` (absent in TinyGo's
+  `net`) and a GOOS-split `DefaultNetworkInterface` with no wasip1 variant. Pure
+  helpers stay in `net.go`; the interface-enumeration + ipinfo HTTP probe move to
+  `net_native.go` (`!tinygo`) with stubs in `net_tinygo.go`.
+- **`pkg/dmsg/disc`** — `Entry.Sign` / `VerifySignature` were `!tinygo` (stale
+  "json can't run under TinyGo" assumption); de-tagged, with a stdlib
+  `encoding/json` codec shim (`interface_tinygo.go`) replacing the jsoniter one.
+- **`pkg/dmsg/dmsg`** — `*net.TCPConn.SetNoDelay` (absent in TinyGo) wrapped in a
+  build-tagged `setTCPNoDelay` helper (no-op on TinyGo).
+- **`deployment`** — `EnvServices` moved from `config_native.go` (`!tinygo`) to
+  the untagged `config.go` so `pkg/dmsg/dmsg`'s `InitConfig` can decode the
+  embedded config on TinyGo too.
+
+Plus the Phase-2 carry-overs: real logrus on all targets, the QUIC/WebTransport
+`!tinygo` split, and the VictoriaMetrics impl tagged server-only.
+
+**Next:** wire `make tinygo-dmsg` into CI so the TinyGo build can't silently
+regress. For the browser, a TinyGo `wasm` (js) build additionally needs
+`net/http` out of the graph (drop the server serve paths + metrics http from the
+client subset) — lower priority than the IoT target. And the real embedded work
+beyond *compiling*: a transport (W5500 hardware TCP offload or a userspace stack)
++ tuned yamux window sizes for MCU RAM (see the hardware notes).
 
 ### Beyond
 

--- a/pkg/dmsg/disc/entry_sign.go
+++ b/pkg/dmsg/disc/entry_sign.go
@@ -1,12 +1,11 @@
-//go:build !tinygo
-
-// Package disc pkg/dmsg/disc/entry_native.go
+// Package disc pkg/dmsg/disc/entry_sign.go
 //
-// Sign + VerifySignature use json.Marshal on the Entry to produce
-// the canonical signed payload. encoding/json drags reflect runtime
-// helpers TinyGo's stdlib doesn't ship, so the methods are split
-// off the WASM build. The install-page WASM never signs or verifies
-// discovery entries — those operations are visor-runtime only.
+// Sign + VerifySignature use the package-wide `json` codec on the Entry to
+// produce the canonical signed payload. They build on all targets: the codec is
+// jsoniter on native (interface_native.go) and stdlib encoding/json on TinyGo
+// (interface_tinygo.go), so a TinyGo dmsg client can sign + register its own
+// discovery entry. (Previously //go:build !tinygo, on the now-stale assumption
+// that encoding/json couldn't run under TinyGo.)
 package disc
 
 import (

--- a/pkg/dmsg/disc/interface_tinygo.go
+++ b/pkg/dmsg/disc/interface_tinygo.go
@@ -1,0 +1,22 @@
+//go:build tinygo
+
+// Package disc pkg/dmsg/disc/interface_tinygo.go
+//
+// TinyGo build of the package-wide `json` codec. The native build uses
+// jsoniter.ConfigFastest (interface_native.go); under TinyGo we use the
+// standard library's encoding/json, which compiles under TinyGo 0.41 (the
+// reflect helpers it needs are now shipped — unlike when the jsoniter split was
+// introduced). Wrapped in a tiny value so `json.Marshal` / `json.Unmarshal`
+// read identically to the jsoniter path, letting Sign / VerifySignature compile
+// for a TinyGo dmsg client (which registers + signs its own discovery entry).
+// See docs/design/tinygo-dmsg-client.md.
+package disc
+
+import stdjson "encoding/json"
+
+var json = jsonCodec{}
+
+type jsonCodec struct{}
+
+func (jsonCodec) Marshal(v interface{}) ([]byte, error)   { return stdjson.Marshal(v) }
+func (jsonCodec) Unmarshal(b []byte, v interface{}) error { return stdjson.Unmarshal(b, v) }

--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -209,7 +209,7 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 		// gains of Nagle aren't material for skywire's mix, and the
 		// interactive-latency loss is severe.
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+			setTCPNoDelay(tcpConn)
 		}
 
 		if dSes, err = makeClientSession(&ce.EntityCommon, ce.porter, conn, entry.Static); err != nil {

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -287,7 +287,7 @@ func (s *Server) Serve(lis net.Listener, addr string) error {
 		// here, response packets from server to visor would still
 		// Nagle-batch even if the visor's outbound side was clean.
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+			setTCPNoDelay(tcpConn)
 		}
 
 		if s.SessionCount() >= s.maxSessions {
@@ -530,7 +530,7 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer PeerEntry) {
 		// routed across the dmsg mesh shouldn't pay 40–200ms of
 		// Nagle batching at each hop.
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			_ = tcpConn.SetNoDelay(true) //nolint:errcheck
+			setTCPNoDelay(tcpConn)
 		}
 
 		ses := new(SessionCommon)

--- a/pkg/dmsg/dmsg/tcpnodelay_native.go
+++ b/pkg/dmsg/dmsg/tcpnodelay_native.go
@@ -1,0 +1,13 @@
+//go:build !tinygo
+
+// Package dmsg pkg/dmsg/tcpnodelay_native.go
+package dmsg
+
+import "net"
+
+// setTCPNoDelay disables Nagle's algorithm on a TCP conn (TCP_NODELAY). dmsg
+// multiplexes many small logical streams (pty keystrokes, dmsg-HTTP, RPC) over
+// one TCP conn, where Nagle adds 40–200ms of per-write latency. TinyGo's
+// net.TCPConn has no SetNoDelay method, so this is a no-op there
+// (tcpnodelay_tinygo.go) — a TinyGo client's transport is rarely raw TCP anyway.
+func setTCPNoDelay(c *net.TCPConn) { _ = c.SetNoDelay(true) } //nolint:errcheck

--- a/pkg/dmsg/dmsg/tcpnodelay_tinygo.go
+++ b/pkg/dmsg/dmsg/tcpnodelay_tinygo.go
@@ -1,0 +1,10 @@
+//go:build tinygo
+
+// Package dmsg pkg/dmsg/tcpnodelay_tinygo.go
+package dmsg
+
+import "net"
+
+// setTCPNoDelay is a no-op under TinyGo: net.TCPConn has no SetNoDelay method.
+// See tcpnodelay_native.go.
+func setTCPNoDelay(_ *net.TCPConn) {}

--- a/pkg/netutil/net.go
+++ b/pkg/netutil/net.go
@@ -1,77 +1,14 @@
 // Package netutil pkg/netutil/net.go
+//
+// The TinyGo-safe (pure) helpers. Network-interface enumeration + the
+// ipinfo.io HTTP probe live in net_native.go (//go:build !tinygo); their
+// TinyGo stubs are in net_tinygo.go.
 package netutil
 
 import (
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 )
-
-// LocalNetworkInterfaceIPs gets IPs of all local interfaces.
-func LocalNetworkInterfaceIPs() ([]net.IP, error) {
-	ips, _, err := localNetworkInterfaceIPs("")
-	return ips, err
-}
-
-// NetworkInterfaceIPs gets IPs of network interface with name `name`.
-func NetworkInterfaceIPs(name string) ([]net.IP, error) {
-	_, ifcIPs, err := localNetworkInterfaceIPs(name)
-	return ifcIPs, err
-}
-
-// localNetworkInterfaceIPs gets IPs of all local interfaces. Separately returns list of IPs
-// of interface `ifcName`.
-func localNetworkInterfaceIPs(ifcName string) ([]net.IP, []net.IP, error) {
-	var ifcIPs []net.IP
-
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting network interfaces: %w", err)
-	}
-
-	var ips []net.IP
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagUp == 0 {
-			continue // interface down
-		}
-		if iface.Flags&net.FlagLoopback != 0 {
-			continue // loopback interface
-		}
-
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return nil, nil, fmt.Errorf("error getting addresses for interface %s: %w", iface.Name, err)
-		}
-
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-
-			if ip == nil || ip.IsLoopback() {
-				continue
-			}
-
-			ip = ip.To4()
-			if ip == nil {
-				continue // not an ipv4 address
-			}
-
-			ips = append(ips, ip)
-
-			if ifcName != "" && iface.Name == ifcName {
-				ifcIPs = append(ifcIPs, ip)
-			}
-		}
-	}
-
-	return ips, ifcIPs, nil
-}
 
 // IsPublicIP returns true if the provided IP is public.
 // Obtained from: https://stackoverflow.com/questions/41670155/get-public-ip-in-golang
@@ -94,34 +31,6 @@ func IsPublicIP(IP net.IP) bool {
 	return false
 }
 
-// DefaultNetworkInterfaceIPs returns IP addresses for the default network interface
-func DefaultNetworkInterfaceIPs() ([]net.IP, error) {
-	networkIfc, err := DefaultNetworkInterface()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default network interface: %w", err)
-	}
-	localIPs, err := NetworkInterfaceIPs(networkIfc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get IPs of %s: %w", networkIfc, err)
-	}
-	return localIPs, nil
-}
-
-// HasPublicIP returns true if this machine has at least one
-// publically available IP address
-func HasPublicIP() (bool, error) {
-	localIPs, err := LocalNetworkInterfaceIPs()
-	if err != nil {
-		return false, err
-	}
-	for _, IP := range localIPs {
-		if IsPublicIP(IP) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // ExtractPort returns port of the given UDP or TCP address
 func ExtractPort(addr net.Addr) (uint16, error) {
 	switch address := addr.(type) {
@@ -136,46 +45,6 @@ func ExtractPort(addr net.Addr) (uint16, error) {
 	}
 }
 
-// LocalAddresses returns a list of all local addresses
-func LocalAddresses() ([]string, error) {
-	result := make([]string, 0)
-
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, iface := range ifaces {
-		// Skip loopback and down interfaces
-		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
-			continue
-		}
-		// Skip Docker/container bridge interfaces
-		if IsVirtualInterface(iface.Name) {
-			continue
-		}
-
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip != nil && ip.IsGlobalUnicast() {
-				result = append(result, ip.String())
-			}
-		}
-	}
-
-	return result, nil
-}
-
 // IsVirtualInterface returns true for Docker bridges, veth pairs, and other
 // virtual interfaces that shouldn't be registered with the address resolver.
 func IsVirtualInterface(name string) bool {
@@ -184,22 +53,6 @@ func IsVirtualInterface(name string) bool {
 		if len(name) >= len(p) && name[:len(p)] == p {
 			return true
 		}
-	}
-	return false
-}
-
-// LocalProtocol check a condition to use dmsghttp or direct url
-func LocalProtocol() bool {
-	resp, err := http.Get("https://ipinfo.io/country")
-	if err != nil {
-		return false
-	}
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false
-	}
-	if string(respBody)[:2] == "CN" {
-		return true
 	}
 	return false
 }

--- a/pkg/netutil/net_native.go
+++ b/pkg/netutil/net_native.go
@@ -1,0 +1,167 @@
+//go:build !tinygo
+
+// Package netutil pkg/netutil/net_native.go
+//
+// Network-interface enumeration + the ipinfo.io HTTP probe. Split out of net.go
+// behind //go:build !tinygo because TinyGo's net.Interface has no Addrs()
+// method and net/http doesn't compile on the TinyGo wasm (js) target. A TinyGo
+// dmsg client needs none of these (it has no host NICs to enumerate); the
+// stubs in net_tinygo.go satisfy any transitive linker reference. See
+// docs/design/tinygo-dmsg-client.md.
+package netutil
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+// LocalNetworkInterfaceIPs gets IPs of all local interfaces.
+func LocalNetworkInterfaceIPs() ([]net.IP, error) {
+	ips, _, err := localNetworkInterfaceIPs("")
+	return ips, err
+}
+
+// NetworkInterfaceIPs gets IPs of network interface with name `name`.
+func NetworkInterfaceIPs(name string) ([]net.IP, error) {
+	_, ifcIPs, err := localNetworkInterfaceIPs(name)
+	return ifcIPs, err
+}
+
+// localNetworkInterfaceIPs gets IPs of all local interfaces. Separately returns list of IPs
+// of interface `ifcName`.
+func localNetworkInterfaceIPs(ifcName string) ([]net.IP, []net.IP, error) {
+	var ifcIPs []net.IP
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting network interfaces: %w", err)
+	}
+
+	var ips []net.IP
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, nil, fmt.Errorf("error getting addresses for interface %s: %w", iface.Name, err)
+		}
+
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+
+			ip = ip.To4()
+			if ip == nil {
+				continue // not an ipv4 address
+			}
+
+			ips = append(ips, ip)
+
+			if ifcName != "" && iface.Name == ifcName {
+				ifcIPs = append(ifcIPs, ip)
+			}
+		}
+	}
+
+	return ips, ifcIPs, nil
+}
+
+// DefaultNetworkInterfaceIPs returns IP addresses for the default network interface
+func DefaultNetworkInterfaceIPs() ([]net.IP, error) {
+	networkIfc, err := DefaultNetworkInterface()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default network interface: %w", err)
+	}
+	localIPs, err := NetworkInterfaceIPs(networkIfc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get IPs of %s: %w", networkIfc, err)
+	}
+	return localIPs, nil
+}
+
+// HasPublicIP returns true if this machine has at least one
+// publically available IP address
+func HasPublicIP() (bool, error) {
+	localIPs, err := LocalNetworkInterfaceIPs()
+	if err != nil {
+		return false, err
+	}
+	for _, IP := range localIPs {
+		if IsPublicIP(IP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// LocalAddresses returns a list of all local addresses
+func LocalAddresses() ([]string, error) {
+	result := make([]string, 0)
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, iface := range ifaces {
+		// Skip loopback and down interfaces
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		// Skip Docker/container bridge interfaces
+		if IsVirtualInterface(iface.Name) {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip != nil && ip.IsGlobalUnicast() {
+				result = append(result, ip.String())
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// LocalProtocol check a condition to use dmsghttp or direct url
+func LocalProtocol() bool {
+	resp, err := http.Get("https://ipinfo.io/country")
+	if err != nil {
+		return false
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	if string(respBody)[:2] == "CN" {
+		return true
+	}
+	return false
+}

--- a/pkg/netutil/net_tinygo.go
+++ b/pkg/netutil/net_tinygo.go
@@ -1,0 +1,36 @@
+//go:build tinygo
+
+// Package netutil pkg/netutil/net_tinygo.go
+//
+// TinyGo stubs for the network-interface-enumeration + HTTP-probe helpers in
+// net_native.go. TinyGo's net.Interface has no Addrs() and net/http doesn't
+// compile on the wasm (js) target, so a TinyGo build can't enumerate host NICs.
+// A TinyGo dmsg client doesn't need any of this (it has no host interfaces); the
+// stubs exist so transitive linker references resolve. See
+// docs/design/tinygo-dmsg-client.md.
+package netutil
+
+import (
+	"errors"
+	"net"
+)
+
+var errNoNetInterfaces = errors.New("netutil: network-interface enumeration unsupported in this build (TinyGo)")
+
+// LocalNetworkInterfaceIPs returns the no-interfaces sentinel under TinyGo.
+func LocalNetworkInterfaceIPs() ([]net.IP, error) { return nil, errNoNetInterfaces }
+
+// NetworkInterfaceIPs returns the no-interfaces sentinel under TinyGo.
+func NetworkInterfaceIPs(string) ([]net.IP, error) { return nil, errNoNetInterfaces }
+
+// DefaultNetworkInterfaceIPs returns the no-interfaces sentinel under TinyGo.
+func DefaultNetworkInterfaceIPs() ([]net.IP, error) { return nil, errNoNetInterfaces }
+
+// HasPublicIP reports false under TinyGo (no way to enumerate interfaces).
+func HasPublicIP() (bool, error) { return false, nil }
+
+// LocalAddresses returns an empty list under TinyGo.
+func LocalAddresses() ([]string, error) { return nil, nil }
+
+// LocalProtocol reports false under TinyGo (no HTTP probe).
+func LocalProtocol() bool { return false }


### PR DESCRIPTION
## What

**The dmsg client now compiles under TinyGo for the `wasip1` (IoT) target.** `make tinygo-dmsg` (`tinygo build -target wasip1 -no-debug -opt=z`) produces a **~2.2 MB** wasm binary — a realistic IoT footprint (fits ESP32-S3 + PSRAM, RP2350, STM32H7, etc.). Build-check main at `cmd/dmsg-tinygo-probe`.

Completes the TinyGo port started in #3197 (logging stub) and #3198 (QUIC extraction).

## Peripheral blockers cleared

Each with the same `!tinygo`-split-plus-stub, or de-tag-the-now-obsolete-`!tinygo`, pattern:

- **`pkg/netutil`** — `net.go` used `net.Interface.Addrs()` (absent in TinyGo's `net`) + a GOOS-split `DefaultNetworkInterface` with no wasip1 variant. Pure helpers (`IsPublicIP`/`ExtractPort`/`IsVirtualInterface`) stay in `net.go`; interface-enumeration + the ipinfo HTTP probe move to `net_native.go` (`!tinygo`) with stubs in `net_tinygo.go`.
- **`pkg/dmsg/disc`** — `Entry.Sign` / `VerifySignature` were `!tinygo` on the stale "`encoding/json` can't run under TinyGo" assumption (false since 0.41). De-tagged (`entry_native.go` → `entry_sign.go`) with a stdlib `encoding/json` codec shim (`interface_tinygo.go`) standing in for jsoniter under TinyGo.
- **`pkg/dmsg/dmsg`** — `*net.TCPConn.SetNoDelay` (absent in TinyGo) wrapped in a build-tagged `setTCPNoDelay` helper (no-op on TinyGo).
- **`deployment`** — `EnvServices` moved from `config_native.go` (`!tinygo`) to the untagged `config.go` so `pkg/dmsg/dmsg`'s `InitConfig` can decode the embedded config on TinyGo too.

## Why this matters

dmsg authenticates with **Noise over plain TCP — no TLS** — which is exactly what makes it embedded-friendly (no X.509/TLS stack). A 2.2 MB TinyGo binary + that design opens dmsg to microcontrollers (ESP32-S3, RP2350, STM32H7 — with a W5500 hardware-TCP-offload or a userspace TCP stack), and the same reflection-light core is the seam for a future FPGA / Rust / Zig port of the routing concepts.

## Verification

- `make tinygo-dmsg` succeeds (2.18 MB).
- `go build ./...` green; `pkg/dmsg/dmsg`, `disc`, `netutil`, `logging`, `deployment` test suites green.
- gofmt + lint clean (only the pre-existing `util.go` G709).

## Next

Wire `make tinygo-dmsg` into CI so the TinyGo build can't silently regress. The real embedded work *beyond compiling* (a transport — W5500 offload or userspace stack — and tuned yamux windows for MCU RAM) is noted in `docs/design/tinygo-dmsg-client.md`.