### PR TITLE
feat(wasmhv): single-file standalone hypervisor.html generator (core assembler)

### DIFF
--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -1,0 +1,11 @@
+package wasmhv
+
+import _ "embed"
+
+// OverrideJS is pkg/wasmhv/override.js — the classic <script> that, in a
+// generated standalone file, boots the WASM dmsg client and routes the UI's
+// /api over dmsg (or to the in-wasm core in standalone mode). Embedded so
+// GenerateStandalone consumers don't need to locate it on disk.
+//
+//go:embed override.js
+var OverrideJS []byte

--- a/pkg/wasmhv/generate.go
+++ b/pkg/wasmhv/generate.go
@@ -1,0 +1,238 @@
+package wasmhv
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// generate.go assembles a self-contained, serverless hypervisor.html from the
+// built Angular UI + the WASM dmsg client + override.js. The output is a single
+// file with NO external references: the Angular chunk scripts and stylesheets
+// are inlined, the WASM binary is gzip+base64 embedded (decompressed in-browser
+// via DecompressionStream), override.js is injected, and the dmsg config +
+// (optionally password-encrypted) secret key are baked into window.__SKYWIRE_HV__.
+//
+// Opening the file from file:// boots the WASM dmsg client and runs the
+// hypervisor UI serverlessly — see docs/design/unified-wasm-hypervisor-ui.md.
+// The plaintext key never touches disk: with a password, only the AES-GCM
+// ciphertext is embedded and the page prompts to decrypt it (override.js
+// resolveSK). NEVER serve a generated (key-bearing) file from a domain.
+//
+// Known gap (tracked): runtime Angular assets (i18n JSON, flag/logo images under
+// /assets) are not yet inlined, so a generated file shows untranslated strings +
+// broken images until the asset-FS inlining lands. Scripts/styles/app logic work.
+
+// StandaloneConfig is the dmsg + identity config baked into a generated file.
+type StandaloneConfig struct {
+	// Standalone, when true, emits CFG.standalone (this tab IS the hypervisor —
+	// visors dial in). Otherwise HypervisorPK must be set (viewer mode — dial a
+	// remote hypervisor).
+	Standalone   bool
+	HypervisorPK string // CFG.pk for viewer mode
+
+	// dmsg bootstrap: a seed server (PK + ws:// URL) the browser connects to
+	// first, then upgrades discovery to run over dmsg.
+	SeedPK string
+	SeedWS string
+	Disc   string
+
+	// SecretKey is the hypervisor identity secret key (hex). When Password is
+	// set it is AES-GCM encrypted into CFG.encsk (the plaintext is never
+	// embedded); without a password it is embedded as CFG.sk (testing only);
+	// empty yields an ephemeral identity.
+	SecretKey string
+	Password  string
+}
+
+var (
+	reScriptSrc = regexp.MustCompile(`(?s)<script\b([^>]*?)\bsrc="([^"]+)"([^>]*?)>\s*</script>`)
+	reLinkCSS   = regexp.MustCompile(`(?s)<link\b[^>]*?\brel="stylesheet"[^>]*?\bhref="([^"]+)"[^>]*?>`)
+	reHeadOpen  = regexp.MustCompile(`(?i)<head\b[^>]*>`)
+)
+
+// GenerateStandalone assembles the single-file hypervisor.html. uiFS is the
+// built Angular FS (must contain index.html and the referenced chunk JS/CSS);
+// wasmExecJS is Go's lib/wasm/wasm_exec.js; wasm is the raw js/wasm dmsg-client
+// binary; overrideJS is pkg/wasmhv/override.js.
+func GenerateStandalone(uiFS fs.FS, wasmExecJS, wasm, overrideJS []byte, cfg StandaloneConfig) ([]byte, error) {
+	indexB, err := fs.ReadFile(uiFS, "index.html")
+	if err != nil {
+		return nil, fmt.Errorf("read index.html: %w", err)
+	}
+	html := string(indexB)
+
+	// Inline every <script src="X"> (preserving its other attrs, e.g.
+	// type="module", so the deferred/ordered execution semantics are kept) with
+	// the chunk's contents.
+	var inlineErr error
+	html = reScriptSrc.ReplaceAllStringFunc(html, func(tag string) string {
+		m := reScriptSrc.FindStringSubmatch(tag)
+		src := strings.TrimPrefix(m[2], "/")
+		body, rErr := fs.ReadFile(uiFS, src)
+		if rErr != nil {
+			inlineErr = fmt.Errorf("inline script %q: %w", src, rErr)
+			return tag
+		}
+		return "<script" + m[1] + m[3] + ">" + jsSafe(body) + "</script>"
+	})
+	if inlineErr != nil {
+		return nil, inlineErr
+	}
+
+	// Inline every <link rel="stylesheet" href="X"> as a <style>, deduping by
+	// href (Angular emits the same stylesheet twice: an async-load <link> + a
+	// <noscript> fallback).
+	seenCSS := map[string]bool{}
+	html = reLinkCSS.ReplaceAllStringFunc(html, func(tag string) string {
+		m := reLinkCSS.FindStringSubmatch(tag)
+		href := strings.TrimPrefix(m[1], "/")
+		if seenCSS[href] {
+			return ""
+		}
+		seenCSS[href] = true
+		body, rErr := fs.ReadFile(uiFS, href)
+		if rErr != nil {
+			inlineErr = fmt.Errorf("inline stylesheet %q: %w", href, rErr)
+			return tag
+		}
+		return "<style>" + string(body) + "</style>"
+	})
+	if inlineErr != nil {
+		return nil, inlineErr
+	}
+
+	// Build the head block: dmsg config, then the WASM bootstrap (wasm_exec.js +
+	// gzip-base64 binary decompressed via DecompressionStream + instantiate),
+	// then override.js. All classic <script>s in <head>, so they run before the
+	// deferred Angular module scripts — override.js must shim XHR/fetch before
+	// Angular's HttpClient is constructed.
+	cfgJS, err := configJS(cfg)
+	if err != nil {
+		return nil, err
+	}
+	wasmJS, err := wasmBootstrap(wasm)
+	if err != nil {
+		return nil, err
+	}
+	head := "\n<script>" + cfgJS + "</script>\n" +
+		"<script>" + jsSafe(wasmExecJS) + "</script>\n" +
+		"<script>" + wasmJS + "</script>\n" +
+		"<script>" + jsSafe(overrideJS) + "</script>\n"
+
+	loc := reHeadOpen.FindStringIndex(html)
+	if loc == nil {
+		return nil, fmt.Errorf("no <head> in index.html")
+	}
+	html = html[:loc[1]] + head + html[loc[1]:]
+
+	return []byte(html), nil
+}
+
+// configJS renders window.__SKYWIRE_HV__ from cfg, encrypting the secret key
+// when a password is set.
+func configJS(cfg StandaloneConfig) (string, error) {
+	fields := []string{}
+	add := func(k, v string) {
+		if v != "" {
+			fields = append(fields, fmt.Sprintf("%s:%s", k, jsString(v)))
+		}
+	}
+	if cfg.Standalone {
+		fields = append(fields, "standalone:true")
+	} else {
+		add("pk", cfg.HypervisorPK)
+	}
+	add("seedpk", cfg.SeedPK)
+	add("seedws", cfg.SeedWS)
+	add("disc", cfg.Disc)
+
+	switch {
+	case cfg.SecretKey != "" && cfg.Password != "":
+		enc, err := encryptKey(cfg.SecretKey, cfg.Password)
+		if err != nil {
+			return "", err
+		}
+		add("encsk", enc)
+	case cfg.SecretKey != "":
+		add("sk", cfg.SecretKey)
+	}
+	return "window.__SKYWIRE_HV__ = {" + strings.Join(fields, ",") + "};", nil
+}
+
+// encryptKey AES-GCM-encrypts the secret-key hex string under a
+// PBKDF2-SHA256(200000) key, returning base64([16-salt | 12-iv | ciphertext]) —
+// the exact format override.js resolveSK() decrypts.
+func encryptKey(secretKeyHex, password string) (string, error) {
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	iv := make([]byte, 12)
+	if _, err := rand.Read(iv); err != nil {
+		return "", err
+	}
+	key := pbkdf2.Key([]byte(password), salt, 200000, 32, sha256.New)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	ct := gcm.Seal(nil, iv, []byte(secretKeyHex), nil)
+	out := append(append(append([]byte{}, salt...), iv...), ct...)
+	return base64.StdEncoding.EncodeToString(out), nil
+}
+
+// wasmBootstrap gzips the wasm, base64s it, and emits the JS that decompresses
+// it in-browser (DecompressionStream) and instantiates + runs it. Go's wasm sets
+// globalThis.skywireDmsg and then blocks, so go.run is fired (not awaited).
+func wasmBootstrap(wasm []byte) (string, error) {
+	var gz bytes.Buffer
+	w, err := gzip.NewWriterLevel(&gz, gzip.BestCompression)
+	if err != nil {
+		return "", err
+	}
+	if _, err := w.Write(wasm); err != nil {
+		return "", err
+	}
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+	b64 := base64.StdEncoding.EncodeToString(gz.Bytes())
+	return `(async function(){
+  var b64 = "` + b64 + `";
+  var bin = Uint8Array.from(atob(b64), function(c){ return c.charCodeAt(0); });
+  var buf = await new Response(new Blob([bin]).stream().pipeThrough(new DecompressionStream("gzip"))).arrayBuffer();
+  var go = new Go();
+  var res = await WebAssembly.instantiate(buf, go.importObject);
+  go.run(res.instance);
+})();`, nil
+}
+
+// jsSafe prevents an inlined script's bytes from prematurely closing the
+// enclosing <script> element (the standard </script -> <\/script transform;
+// "</script" is never a valid JS token outside a string/regex, where the escape
+// is equivalent).
+func jsSafe(b []byte) string {
+	return strings.ReplaceAll(string(b), "</script", `<\/script`)
+}
+
+// jsString renders s as a JSON-ish double-quoted JS string literal (the values
+// here are PKs / URLs / base64, so only quote + backslash need escaping).
+func jsString(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return `"` + r.Replace(s) + `"`
+}

--- a/pkg/wasmhv/generate_test.go
+++ b/pkg/wasmhv/generate_test.go
@@ -1,0 +1,112 @@
+package wasmhv
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// fakeUI is a minimal Angular-build-shaped FS: an index.html that references a
+// module chunk + a stylesheet (twice, like the real build), plus those files.
+func fakeUI() fstest.MapFS {
+	index := `<!doctype html><html><head><title>t</title>` +
+		`<link rel="stylesheet" href="styles.abc.css" media="print" onload="this.media='all'">` +
+		`<link rel="stylesheet" href="styles.abc.css">` +
+		`<script src="main.def.js" type="module"></script>` +
+		`</head><body><app-root></app-root></body></html>`
+	return fstest.MapFS{
+		"index.html":     {Data: []byte(index)},
+		"main.def.js":    {Data: []byte("console.log('app'); var x='</script>';")},
+		"styles.abc.css": {Data: []byte("body{margin:0}")},
+	}
+}
+
+func TestGenerateStandalone_Structure(t *testing.T) {
+	out, err := GenerateStandalone(fakeUI(),
+		[]byte("globalThis.Go=function(){};"), // fake wasm_exec.js
+		[]byte("\x00asm-fake-binary"),         // fake wasm
+		[]byte("/*override*/"),                // fake override.js
+		StandaloneConfig{
+			Standalone: true,
+			SeedPK:     "0371ab",
+			SeedWS:     "ws://1.2.3.4/dmsg",
+			Disc:       "dmsg://022e:80",
+		})
+	require.NoError(t, err)
+	s := string(out)
+
+	// No external script/style references survive (single-file).
+	require.NotContains(t, s, `src="main.def.js"`, "script not inlined")
+	require.NotContains(t, s, `href="styles.abc.css"`, "stylesheet not inlined")
+	require.NotContains(t, s, "<link", "a <link> survived")
+
+	// App chunk inlined, with </script> neutralized so it can't break out.
+	require.Contains(t, s, "console.log('app')")
+	require.NotContains(t, s, "var x='</script>'", "raw </script> would break the inline script")
+	require.Contains(t, s, `<\/script`)
+
+	// CSS inlined as <style>, deduped (only one copy despite two <link>s).
+	require.Equal(t, 1, strings.Count(s, "body{margin:0}"), "stylesheet should be inlined once")
+
+	// Config + wasm bootstrap + override all present, before the app chunk.
+	require.Contains(t, s, "window.__SKYWIRE_HV__ = {")
+	require.Contains(t, s, "standalone:true")
+	require.Contains(t, s, `seedws:"ws://1.2.3.4/dmsg"`)
+	require.Contains(t, s, "DecompressionStream")
+	require.Contains(t, s, "globalThis.Go=function(){}")
+	require.Contains(t, s, "/*override*/")
+	require.Less(t, strings.Index(s, "/*override*/"), strings.Index(s, "console.log('app')"),
+		"override.js must precede the Angular app chunk")
+}
+
+func TestGenerateStandalone_ViewerMode(t *testing.T) {
+	out, err := GenerateStandalone(fakeUI(),
+		[]byte("globalThis.Go=function(){};"), []byte("w"), []byte("o"),
+		StandaloneConfig{HypervisorPK: "03abcd"})
+	require.NoError(t, err)
+	require.Contains(t, string(out), `pk:"03abcd"`)
+	require.NotContains(t, string(out), "standalone:true")
+}
+
+// TestGenerateStandalone_EncryptedKey verifies the baked-in encsk decrypts with
+// the exact PBKDF2-SHA256(200000) + AES-GCM scheme override.js resolveSK uses:
+// base64([16-salt | 12-iv | ciphertext]).
+func TestGenerateStandalone_EncryptedKey(t *testing.T) {
+	const sk = "1de8a5e6c7cce88afb77b13279465fce2c6c3a29cfbdcde7c5b109348ca065e2"
+	const pw = "correct horse battery staple"
+	out, err := GenerateStandalone(fakeUI(),
+		[]byte("globalThis.Go=function(){};"), []byte("w"), []byte("o"),
+		StandaloneConfig{Standalone: true, SecretKey: sk, Password: pw})
+	require.NoError(t, err)
+	s := string(out)
+	require.NotContains(t, s, sk, "plaintext secret key must NOT be embedded")
+	require.NotContains(t, s, `{sk:`, "must use encsk, not a bare sk, when a password is set")
+	require.NotContains(t, s, `,sk:`, "must use encsk, not a bare sk, when a password is set")
+	require.Contains(t, s, `encsk:"`, "encrypted key must be embedded")
+
+	// Extract encsk:"..." and decrypt it the way the browser would.
+	i := strings.Index(s, `encsk:"`)
+	require.GreaterOrEqual(t, i, 0)
+	rest := s[i+len(`encsk:"`):]
+	enc := rest[:strings.IndexByte(rest, '"')]
+
+	raw, err := base64.StdEncoding.DecodeString(enc)
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 28)
+	salt, iv, ct := raw[:16], raw[16:28], raw[28:]
+	key := pbkdf2.Key([]byte(pw), salt, 200000, 32, sha256.New)
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+	pt, err := gcm.Open(nil, iv, ct, nil)
+	require.NoError(t, err)
+	require.Equal(t, sk, string(pt), "decrypted key must match the original")
+}


### PR DESCRIPTION
## What

`GenerateStandalone` assembles a **self-contained, serverless `hypervisor.html`** from the built Angular UI + the WASM dmsg client + `override.js` — one file, no external references, that boots the in-browser dmsg client and runs the hypervisor UI from `file://`. This is the keystone of the unified-UI plan (`docs/design/unified-wasm-hypervisor-ui.md`): *"save the hypervisor UI to an HTML file and open it serverless."*

## How

- **Inlines** every Angular chunk `<script src>` (preserving `type="module"` so deferred/ordered execution is kept) and every `<link rel=stylesheet>` as a `<style>` (deduped — Angular emits the sheet twice). Confirmed safe because the eager chunks don't cross-reference by URL (they share via window globals).
- **Embeds the wasm** gzip+base64 and decompresses it in-browser via `DecompressionStream`, then instantiates + runs it (21 MB raw → ~6 MB gzipped).
- **Injects** `override.js` + `window.__SKYWIRE_HV__` (dmsg seed/disc + identity) as classic `<head>` scripts **before** the Angular module scripts, so the XHR/fetch shim is installed before `HttpClient` is constructed.
- **Bakes the secret key in password-encrypted** — PBKDF2-SHA256(200000) + AES-GCM, `base64[salt|iv|ct]`, the exact format `override.js` `resolveSK` decrypts. The plaintext key never touches the file. Without a password: ephemeral, or (testing only) a bare `sk`.

`override.js` is embedded (`embed.go`) so consumers only supply the UI FS + wasm + `wasm_exec.js`.

## Tests

`generate_test.go` covers: structure (no external refs survive, CSS dedup, override-before-app ordering, `</script>` neutralization), viewer vs standalone CFG, and an **`encsk` encrypt→decrypt round-trip** that decrypts the baked-in key with the same PBKDF2+AES-GCM the browser uses. Host + `GOOS=js GOARCH=wasm` builds green; lint clean.

## Follow-ups (scoped in the design doc)

1. A **CLI / visor consumer** that supplies the UI FS + a built wasm (and the embed-vs-flags decision).
2. **Inlining the runtime Angular assets** (i18n JSON + flag/logo PNGs) into a virtual FS that `override.js` serves — until then a generated file shows untranslated strings + broken images (scripts/app logic work).
3. **Headless-browser validation** of a real bundle.