### PR TITLE
feat(wasmhv)+cli: hv gen — standalone hypervisor.html with one-way derived key

### DIFF
--- a/cmd/skywire-cli/commands/hv/gen.go
+++ b/cmd/skywire-cli/commands/hv/gen.go
@@ -1,0 +1,156 @@
+// Package clihv cmd/skywire-cli/commands/hv/gen.go
+package clihv
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/wasmhv"
+)
+
+var (
+	genWasm     string
+	genOut      string
+	genConf     string
+	genSK       string
+	genIndex    uint32
+	genPassword string
+	genViewerPK string
+	genSeedPK   string
+	genSeedWS   string
+	genDisc     string
+)
+
+func init() {
+	genCmd.Flags().StringVar(&genWasm, "wasm", "", "path to the js/wasm dmsg-client binary (build: make dmsg-wasm) [required]")
+	genCmd.Flags().StringVarP(&genOut, "out", "o", "hypervisor.html", "output file")
+	genCmd.Flags().StringVarP(&genConf, "conf", "c", "", "visor config to derive the standalone key from (uses its sk)")
+	genCmd.Flags().Uint32Var(&genIndex, "index", 0, "derivation index — distinct indices mint distinct standalone identities from one root")
+	genCmd.Flags().StringVar(&genSK, "sk", "", "explicit standalone secret key (hex) — skips derivation")
+	genCmd.Flags().StringVar(&genPassword, "password", "", "encrypt the baked-in key with this password (recommended)")
+	genCmd.Flags().StringVar(&genViewerPK, "viewer-pk", "", "viewer mode: dial this remote hypervisor PK (default: standalone — visors dial in)")
+	genCmd.Flags().StringVar(&genSeedPK, "seed-pk", "", "seed dmsg server PK the browser connects to first")
+	genCmd.Flags().StringVar(&genSeedWS, "seed-ws", "", "seed dmsg server ws:// URL")
+	genCmd.Flags().StringVar(&genDisc, "disc", "", "dmsg discovery (dmsg://<pk>:80)")
+}
+
+var genCmd = &cobra.Command{
+	Use:   "gen",
+	Short: "Generate a self-contained standalone hypervisor.html",
+	Long: `Generate a self-contained, serverless hypervisor.html.
+
+The output is a single file (Angular UI + WASM dmsg client + override.js + your
+config, all inlined) you can open from file:// — no server. By default it is a
+STANDALONE hypervisor (visors dial in); --viewer-pk makes it dial a remote
+hypervisor instead.
+
+Identity: --sk sets an explicit key; otherwise -c <config> derives a standalone
+key from the visor's secret key (one-way + deterministic — regenerable, and a
+compromised standalone key can't expose the parent). Use --password to encrypt
+the baked-in key (the plaintext never touches the file).
+
+SECURITY: never serve a generated (key-bearing) file from a domain — it would
+train users to type secret keys into pages from external hosts.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if genWasm == "" {
+			cmd.PrintErrln("--wasm is required (build it with `make dmsg-wasm`)")
+			os.Exit(1)
+		}
+
+		skHex, err := resolveKey(cmd)
+		if err != nil {
+			cmd.PrintErrln("identity:", err)
+			os.Exit(1)
+		}
+		if skHex != "" && genPassword == "" {
+			cmd.PrintErrln("warning: the secret key is baked in WITHOUT a password (plaintext on disk); pass --password to encrypt it")
+		}
+
+		wasm, err := os.ReadFile(genWasm) //nolint:gosec // operator-supplied path
+		if err != nil {
+			cmd.PrintErrln("read --wasm:", err)
+			os.Exit(1)
+		}
+		uiFS, err := visor.HypervisorUIFS()
+		if err != nil {
+			cmd.PrintErrln("hypervisor UI assets:", err)
+			os.Exit(1)
+		}
+
+		cfg := wasmhv.StandaloneConfig{
+			Standalone:   genViewerPK == "",
+			HypervisorPK: genViewerPK,
+			SeedPK:       genSeedPK,
+			SeedWS:       genSeedWS,
+			Disc:         genDisc,
+			SecretKey:    skHex,
+			Password:     genPassword,
+		}
+		html, err := wasmhv.GenerateStandalone(uiFS, wasmhv.WasmExecJS, wasm, wasmhv.OverrideJS, cfg)
+		if err != nil {
+			cmd.PrintErrln("generate:", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(genOut, html, 0o600); err != nil {
+			cmd.PrintErrln("write:", err)
+			os.Exit(1)
+		}
+		cmd.Printf("wrote %s (%d bytes)\n", genOut, len(html))
+	},
+}
+
+// resolveKey returns the standalone secret-key hex to bake in: explicit (--sk),
+// derived from the config's visor key (-c [+--index]), or "" (ephemeral). When
+// deriving, it prints the derived public key — the PK to set as the visors'
+// remote hypervisor (standalone mode).
+func resolveKey(cmd *cobra.Command) (string, error) {
+	switch {
+	case genSK != "":
+		var sk cipher.SecKey
+		if err := sk.Set(genSK); err != nil {
+			return "", fmt.Errorf("bad --sk: %w", err)
+		}
+		return genSK, nil
+	case genConf != "":
+		parentSK, err := configSK(genConf)
+		if err != nil {
+			return "", err
+		}
+		pk, sk, err := wasmhv.DeriveStandaloneKey(parentSK, genIndex)
+		if err != nil {
+			return "", err
+		}
+		cmd.Printf("derived standalone hypervisor PK (index %d): %s\n", genIndex, pk.Hex())
+		return sk.Hex(), nil
+	default:
+		cmd.PrintErrln("note: no --sk or -c given; the file uses an ephemeral identity (a fresh key each load)")
+		return "", nil
+	}
+}
+
+// configSK reads the visor secret key from a config file's top-level "sk".
+func configSK(path string) (cipher.SecKey, error) {
+	b, err := os.ReadFile(path) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return cipher.SecKey{}, fmt.Errorf("read config %q: %w", path, err)
+	}
+	var c struct {
+		SK string `json:"sk"`
+	}
+	if err := json.Unmarshal(b, &c); err != nil {
+		return cipher.SecKey{}, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	if c.SK == "" {
+		return cipher.SecKey{}, fmt.Errorf("config %q has no \"sk\"", path)
+	}
+	var sk cipher.SecKey
+	if err := sk.Set(c.SK); err != nil {
+		return cipher.SecKey{}, fmt.Errorf("config %q has invalid sk: %w", path, err)
+	}
+	return sk, nil
+}

--- a/cmd/skywire-cli/commands/hv/root.go
+++ b/cmd/skywire-cli/commands/hv/root.go
@@ -1,0 +1,17 @@
+// Package clihv cmd/skywire-cli/commands/hv/root.go
+package clihv
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// RootCmd is the `hv` command group: tools for the hypervisor UI, including the
+// standalone single-file generator.
+var RootCmd = &cobra.Command{
+	Use:   "hv",
+	Short: "Hypervisor UI tools",
+}
+
+func init() {
+	RootCmd.AddCommand(genCmd)
+}

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -16,6 +16,7 @@ import (
 	clidmsg "github.com/skycoin/skywire/cmd/skywire-cli/commands/dmsg"
 	cligot "github.com/skycoin/skywire/cmd/skywire-cli/commands/got"
 	cligotop "github.com/skycoin/skywire/cmd/skywire-cli/commands/gotop"
+	clihv "github.com/skycoin/skywire/cmd/skywire-cli/commands/hv"
 	clilog "github.com/skycoin/skywire/cmd/skywire-cli/commands/log"
 	climail "github.com/skycoin/skywire/cmd/skywire-cli/commands/mail"
 	climdisc "github.com/skycoin/skywire/cmd/skywire-cli/commands/mdisc"
@@ -118,6 +119,7 @@ func init() {
 	RootCmd.AddCommand(
 		cliconfig.RootCmd,
 		clidmsg.RootCmd,
+		clihv.RootCmd,
 		cligotop.RootCmd,
 		clivisor.RootCmd,
 		clivpn.RootCmd,

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -1033,6 +1033,13 @@ func (v *Visor) FetchAllTransportEntries(ctx context.Context) ([]*transport.Entr
 //go:embed static
 var ui embed.FS
 
+// HypervisorUIFS returns the embedded Angular hypervisor UI filesystem (the
+// built static/ assets). Exposed for consumers like the standalone-html
+// generator (cli hv gen) that need to read index.html + the chunk JS/CSS.
+func HypervisorUIFS() (fs.FS, error) {
+	return fs.Sub(ui, "static")
+}
+
 func initUI() *fs.FS {
 	//initialize the ui
 	uiFS, err := fs.Sub(ui, "static")

--- a/pkg/wasmhv/derive.go
+++ b/pkg/wasmhv/derive.go
@@ -1,0 +1,46 @@
+package wasmhv
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// deriveLabel namespaces the standalone-hypervisor key derivation so the seed
+// can't collide with any other use of the parent key.
+const deriveLabel = "skywire-standalone-hypervisor:v1:"
+
+// DeriveStandaloneKey deterministically derives a standalone-hypervisor keypair
+// from the parent (visor / hypervisor) secret key.
+//
+// The derivation is ONE-WAY: the seed is HMAC-SHA256(parentSK, label||index), a
+// PRF whose output reveals nothing about parentSK. So a compromised standalone
+// key (e.g. a cracked password on a generated hypervisor.html) can never be used
+// to recover the parent — the worst case is "remove that one PK from your
+// visors' hypervisors[]".
+//
+// It is also deterministic and indexed: the same parentSK + index always yields
+// the same keypair (regenerable from the one root key — no separate secret to
+// back up), and distinct indices mint distinct standalone identities (one per
+// device / tab) from the single root.
+func DeriveStandaloneKey(parentSK cipher.SecKey, index uint32) (cipher.PubKey, cipher.SecKey, error) {
+	if parentSK.Null() {
+		return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("derive standalone key: parent secret key is null")
+	}
+	var idx [4]byte
+	binary.BigEndian.PutUint32(idx[:], index)
+
+	mac := hmac.New(sha256.New, parentSK[:])
+	_, _ = mac.Write([]byte(deriveLabel)) //nolint:errcheck // hash.Write never errors
+	_, _ = mac.Write(idx[:])              //nolint:errcheck
+	seed := mac.Sum(nil)
+
+	pk, sk, err := cipher.GenerateDeterministicKeyPair(seed)
+	if err != nil {
+		return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("derive standalone key: %w", err)
+	}
+	return pk, sk, nil
+}

--- a/pkg/wasmhv/derive_test.go
+++ b/pkg/wasmhv/derive_test.go
@@ -1,0 +1,45 @@
+package wasmhv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestDeriveStandaloneKey(t *testing.T) {
+	_, parentSK := cipher.GenerateKeyPair()
+
+	// Deterministic: same parent + index → same key, every time.
+	pk0a, sk0a, err := DeriveStandaloneKey(parentSK, 0)
+	require.NoError(t, err)
+	pk0b, sk0b, err := DeriveStandaloneKey(parentSK, 0)
+	require.NoError(t, err)
+	require.Equal(t, pk0a, pk0b)
+	require.Equal(t, sk0a, sk0b)
+
+	// The derived keypair is valid + self-consistent (pk matches sk).
+	got, err := sk0a.PubKey()
+	require.NoError(t, err)
+	require.Equal(t, pk0a, got)
+
+	// Indexed: distinct indices → distinct identities.
+	pk1, _, err := DeriveStandaloneKey(parentSK, 1)
+	require.NoError(t, err)
+	require.NotEqual(t, pk0a, pk1)
+
+	// Bound to the parent: a different parent → a different derived key.
+	_, otherParent := cipher.GenerateKeyPair()
+	pkOther, _, err := DeriveStandaloneKey(otherParent, 0)
+	require.NoError(t, err)
+	require.NotEqual(t, pk0a, pkOther)
+
+	// One-way: the derived secret key must NOT equal the parent (it's a PRF
+	// output, not the parent itself), so it can't trivially leak the parent.
+	require.NotEqual(t, parentSK, sk0a)
+
+	// Null parent is rejected.
+	_, _, err = DeriveStandaloneKey(cipher.SecKey{}, 0)
+	require.Error(t, err)
+}

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -9,3 +9,11 @@ import _ "embed"
 //
 //go:embed override.js
 var OverrideJS []byte
+
+// WasmExecJS is Go's lib/wasm/wasm_exec.js, vendored here so a generated file is
+// self-contained. It MUST match the Go toolchain that built the embedded/passed
+// dmsg.wasm — refresh it with the wasm build (the Makefile bundle target copies
+// it from $(go env GOROOT)/lib/wasm/wasm_exec.js).
+//
+//go:embed wasm_exec.js
+var WasmExecJS []byte

--- a/pkg/wasmhv/wasm_exec.js
+++ b/pkg/wasmhv/wasm_exec.js
@@ -1,0 +1,575 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+"use strict";
+
+(() => {
+	const enosys = () => {
+		const err = new Error("not implemented");
+		err.code = "ENOSYS";
+		return err;
+	};
+
+	if (!globalThis.fs) {
+		let outputBuf = "";
+		globalThis.fs = {
+			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1, O_DIRECTORY: -1 }, // unused
+			writeSync(fd, buf) {
+				outputBuf += decoder.decode(buf);
+				const nl = outputBuf.lastIndexOf("\n");
+				if (nl != -1) {
+					console.log(outputBuf.substring(0, nl));
+					outputBuf = outputBuf.substring(nl + 1);
+				}
+				return buf.length;
+			},
+			write(fd, buf, offset, length, position, callback) {
+				if (offset !== 0 || length !== buf.length || position !== null) {
+					callback(enosys());
+					return;
+				}
+				const n = this.writeSync(fd, buf);
+				callback(null, n);
+			},
+			chmod(path, mode, callback) { callback(enosys()); },
+			chown(path, uid, gid, callback) { callback(enosys()); },
+			close(fd, callback) { callback(enosys()); },
+			fchmod(fd, mode, callback) { callback(enosys()); },
+			fchown(fd, uid, gid, callback) { callback(enosys()); },
+			fstat(fd, callback) { callback(enosys()); },
+			fsync(fd, callback) { callback(null); },
+			ftruncate(fd, length, callback) { callback(enosys()); },
+			lchown(path, uid, gid, callback) { callback(enosys()); },
+			link(path, link, callback) { callback(enosys()); },
+			lstat(path, callback) { callback(enosys()); },
+			mkdir(path, perm, callback) { callback(enosys()); },
+			open(path, flags, mode, callback) { callback(enosys()); },
+			read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
+			readdir(path, callback) { callback(enosys()); },
+			readlink(path, callback) { callback(enosys()); },
+			rename(from, to, callback) { callback(enosys()); },
+			rmdir(path, callback) { callback(enosys()); },
+			stat(path, callback) { callback(enosys()); },
+			symlink(path, link, callback) { callback(enosys()); },
+			truncate(path, length, callback) { callback(enosys()); },
+			unlink(path, callback) { callback(enosys()); },
+			utimes(path, atime, mtime, callback) { callback(enosys()); },
+		};
+	}
+
+	if (!globalThis.process) {
+		globalThis.process = {
+			getuid() { return -1; },
+			getgid() { return -1; },
+			geteuid() { return -1; },
+			getegid() { return -1; },
+			getgroups() { throw enosys(); },
+			pid: -1,
+			ppid: -1,
+			umask() { throw enosys(); },
+			cwd() { throw enosys(); },
+			chdir() { throw enosys(); },
+		}
+	}
+
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
+			}
+		}
+	}
+
+	if (!globalThis.crypto) {
+		throw new Error("globalThis.crypto is not available, polyfill required (crypto.getRandomValues only)");
+	}
+
+	if (!globalThis.performance) {
+		throw new Error("globalThis.performance is not available, polyfill required (performance.now only)");
+	}
+
+	if (!globalThis.TextEncoder) {
+		throw new Error("globalThis.TextEncoder is not available, polyfill required");
+	}
+
+	if (!globalThis.TextDecoder) {
+		throw new Error("globalThis.TextDecoder is not available, polyfill required");
+	}
+
+	const encoder = new TextEncoder("utf-8");
+	const decoder = new TextDecoder("utf-8");
+
+	globalThis.Go = class {
+		constructor() {
+			this.argv = ["js"];
+			this.env = {};
+			this.exit = (code) => {
+				if (code !== 0) {
+					console.warn("exit code:", code);
+				}
+			};
+			this._exitPromise = new Promise((resolve) => {
+				this._resolveExitPromise = resolve;
+			});
+			this._pendingEvent = null;
+			this._scheduledTimeouts = new Map();
+			this._nextCallbackTimeoutID = 1;
+
+			const setInt64 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
+			}
+
+			const setInt32 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+			}
+
+			const getInt64 = (addr) => {
+				const low = this.mem.getUint32(addr + 0, true);
+				const high = this.mem.getInt32(addr + 4, true);
+				return low + high * 4294967296;
+			}
+
+			const loadValue = (addr) => {
+				const f = this.mem.getFloat64(addr, true);
+				if (f === 0) {
+					return undefined;
+				}
+				if (!isNaN(f)) {
+					return f;
+				}
+
+				const id = this.mem.getUint32(addr, true);
+				return this._values[id];
+			}
+
+			const storeValue = (addr, v) => {
+				const nanHead = 0x7FF80000;
+
+				if (typeof v === "number" && v !== 0) {
+					if (isNaN(v)) {
+						this.mem.setUint32(addr + 4, nanHead, true);
+						this.mem.setUint32(addr, 0, true);
+						return;
+					}
+					this.mem.setFloat64(addr, v, true);
+					return;
+				}
+
+				if (v === undefined) {
+					this.mem.setFloat64(addr, 0, true);
+					return;
+				}
+
+				let id = this._ids.get(v);
+				if (id === undefined) {
+					id = this._idPool.pop();
+					if (id === undefined) {
+						id = this._values.length;
+					}
+					this._values[id] = v;
+					this._goRefCounts[id] = 0;
+					this._ids.set(v, id);
+				}
+				this._goRefCounts[id]++;
+				let typeFlag = 0;
+				switch (typeof v) {
+					case "object":
+						if (v !== null) {
+							typeFlag = 1;
+						}
+						break;
+					case "string":
+						typeFlag = 2;
+						break;
+					case "symbol":
+						typeFlag = 3;
+						break;
+					case "function":
+						typeFlag = 4;
+						break;
+				}
+				this.mem.setUint32(addr + 4, nanHead | typeFlag, true);
+				this.mem.setUint32(addr, id, true);
+			}
+
+			const loadSlice = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+			}
+
+			const loadSliceOfValues = (addr) => {
+				const array = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				const a = new Array(len);
+				for (let i = 0; i < len; i++) {
+					a[i] = loadValue(array + i * 8);
+				}
+				return a;
+			}
+
+			const loadString = (addr) => {
+				const saddr = getInt64(addr + 0);
+				const len = getInt64(addr + 8);
+				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
+			}
+
+			const testCallExport = (a, b) => {
+				this._inst.exports.testExport0();
+				return this._inst.exports.testExport(a, b);
+			}
+
+			const timeOrigin = Date.now() - performance.now();
+			this.importObject = {
+				_gotest: {
+					add: (a, b) => a + b,
+					callExport: testCallExport,
+				},
+				gojs: {
+					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
+					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
+					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
+					// This changes the SP, thus we have to update the SP used by the imported function.
+
+					// func wasmExit(code int32)
+					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
+						const code = this.mem.getInt32(sp + 8, true);
+						this.exited = true;
+						delete this._inst;
+						delete this._values;
+						delete this._goRefCounts;
+						delete this._ids;
+						delete this._idPool;
+						this.exit(code);
+					},
+
+					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
+					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
+						const fd = getInt64(sp + 8);
+						const p = getInt64(sp + 16);
+						const n = this.mem.getInt32(sp + 24, true);
+						fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+					},
+
+					// func resetMemoryDataView()
+					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
+						this.mem = new DataView(this._inst.exports.mem.buffer);
+					},
+
+					// func nanotime1() int64
+					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
+					},
+
+					// func walltime() (sec int64, nsec int32)
+					"runtime.walltime": (sp) => {
+						sp >>>= 0;
+						const msec = (new Date).getTime();
+						setInt64(sp + 8, msec / 1000);
+						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
+					},
+
+					// func scheduleTimeoutEvent(delay int64) int32
+					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this._nextCallbackTimeoutID;
+						this._nextCallbackTimeoutID++;
+						this._scheduledTimeouts.set(id, setTimeout(
+							() => {
+								this._resume();
+								while (this._scheduledTimeouts.has(id)) {
+									// for some reason Go failed to register the timeout event, log and try again
+									// (temporary workaround for https://github.com/golang/go/issues/28975)
+									console.warn("scheduleTimeoutEvent: missed timeout event");
+									this._resume();
+								}
+							},
+							getInt64(sp + 8),
+						));
+						this.mem.setInt32(sp + 16, id, true);
+					},
+
+					// func clearTimeoutEvent(id int32)
+					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getInt32(sp + 8, true);
+						clearTimeout(this._scheduledTimeouts.get(id));
+						this._scheduledTimeouts.delete(id);
+					},
+
+					// func getRandomData(r []byte)
+					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
+						crypto.getRandomValues(loadSlice(sp + 8));
+					},
+
+					// func finalizeRef(v ref)
+					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
+						const id = this.mem.getUint32(sp + 8, true);
+						this._goRefCounts[id]--;
+						if (this._goRefCounts[id] === 0) {
+							const v = this._values[id];
+							this._values[id] = null;
+							this._ids.delete(v);
+							this._idPool.push(id);
+						}
+					},
+
+					// func stringVal(value string) ref
+					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, loadString(sp + 8));
+					},
+
+					// func valueGet(v ref, p string) ref
+					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
+						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
+						storeValue(sp + 32, result);
+					},
+
+					// func valueSet(v ref, p string, x ref)
+					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
+					},
+
+					// func valueDelete(v ref, p string)
+					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
+						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
+					},
+
+					// func valueIndex(v ref, i int) ref
+					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
+						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
+					},
+
+					// valueSetIndex(v ref, i int, x ref)
+					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
+						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
+					},
+
+					// func valueCall(v ref, m string, args []ref) (ref, bool)
+					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const m = Reflect.get(v, loadString(sp + 16));
+							const args = loadSliceOfValues(sp + 32);
+							const result = Reflect.apply(m, v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, result);
+							this.mem.setUint8(sp + 64, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 56, err);
+							this.mem.setUint8(sp + 64, 0);
+						}
+					},
+
+					// func valueInvoke(v ref, args []ref) (ref, bool)
+					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.apply(v, undefined, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueNew(v ref, args []ref) (ref, bool)
+					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
+						try {
+							const v = loadValue(sp + 8);
+							const args = loadSliceOfValues(sp + 16);
+							const result = Reflect.construct(v, args);
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, result);
+							this.mem.setUint8(sp + 48, 1);
+						} catch (err) {
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
+							storeValue(sp + 40, err);
+							this.mem.setUint8(sp + 48, 0);
+						}
+					},
+
+					// func valueLength(v ref) int
+					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
+						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
+					},
+
+					// valuePrepareString(v ref) (ref, int)
+					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
+						const str = encoder.encode(String(loadValue(sp + 8)));
+						storeValue(sp + 16, str);
+						setInt64(sp + 24, str.length);
+					},
+
+					// valueLoadString(v ref, b []byte)
+					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
+						const str = loadValue(sp + 8);
+						loadSlice(sp + 16).set(str);
+					},
+
+					// func valueInstanceOf(v ref, t ref) bool
+					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
+						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
+					},
+
+					// func copyBytesToGo(dst []byte, src ref) (int, bool)
+					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
+						const dst = loadSlice(sp + 8);
+						const src = loadValue(sp + 32);
+						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					// func copyBytesToJS(dst ref, src []byte) (int, bool)
+					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
+						const dst = loadValue(sp + 8);
+						const src = loadSlice(sp + 16);
+						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
+							this.mem.setUint8(sp + 48, 0);
+							return;
+						}
+						const toCopy = src.subarray(0, dst.length);
+						dst.set(toCopy);
+						setInt64(sp + 40, toCopy.length);
+						this.mem.setUint8(sp + 48, 1);
+					},
+
+					"debug": (value) => {
+						console.log(value);
+					},
+				}
+			};
+		}
+
+		async run(instance) {
+			if (!(instance instanceof WebAssembly.Instance)) {
+				throw new Error("Go.run: WebAssembly.Instance expected");
+			}
+			this._inst = instance;
+			this.mem = new DataView(this._inst.exports.mem.buffer);
+			this._values = [ // JS values that Go currently has references to, indexed by reference id
+				NaN,
+				0,
+				null,
+				true,
+				false,
+				globalThis,
+				this,
+			];
+			this._goRefCounts = new Array(this._values.length).fill(Infinity); // number of references that Go has to a JS value, indexed by reference id
+			this._ids = new Map([ // mapping from JS values to reference ids
+				[0, 1],
+				[null, 2],
+				[true, 3],
+				[false, 4],
+				[globalThis, 5],
+				[this, 6],
+			]);
+			this._idPool = [];   // unused ids that have been garbage collected
+			this.exited = false; // whether the Go program has exited
+
+			// Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
+			let offset = 4096;
+
+			const strPtr = (str) => {
+				const ptr = offset;
+				const bytes = encoder.encode(str + "\0");
+				new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes);
+				offset += bytes.length;
+				if (offset % 8 !== 0) {
+					offset += 8 - (offset % 8);
+				}
+				return ptr;
+			};
+
+			const argc = this.argv.length;
+
+			const argvPtrs = [];
+			this.argv.forEach((arg) => {
+				argvPtrs.push(strPtr(arg));
+			});
+			argvPtrs.push(0);
+
+			const keys = Object.keys(this.env).sort();
+			keys.forEach((key) => {
+				argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+			});
+			argvPtrs.push(0);
+
+			const argv = offset;
+			argvPtrs.forEach((ptr) => {
+				this.mem.setUint32(offset, ptr, true);
+				this.mem.setUint32(offset + 4, 0, true);
+				offset += 8;
+			});
+
+			// The linker guarantees global data starts from at least wasmMinDataAddr.
+			// Keep in sync with cmd/link/internal/ld/data.go:wasmMinDataAddr.
+			const wasmMinDataAddr = 4096 + 8192;
+			if (offset >= wasmMinDataAddr) {
+				throw new Error("total length of command line and environment variables exceeds limit");
+			}
+
+			this._inst.exports.run(argc, argv);
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+			await this._exitPromise;
+		}
+
+		_resume() {
+			if (this.exited) {
+				throw new Error("Go program has already exited");
+			}
+			this._inst.exports.resume();
+			if (this.exited) {
+				this._resolveExitPromise();
+			}
+		}
+
+		_makeFuncWrapper(id) {
+			const go = this;
+			return function () {
+				const event = { id: id, this: this, args: arguments };
+				go._pendingEvent = event;
+				go._resume();
+				return event.result;
+			};
+		}
+	}
+})();


### PR DESCRIPTION
## What

Turns the standalone generator (#3200) into a usable command and adds **one-way key derivation**.

`skywire cli hv gen` produces a **self-contained, serverless `hypervisor.html`** — the embedded Angular UI + the (`--wasm`) js/wasm dmsg client + `override.js` + your config, all inlined, openable from `file://`. Default = **standalone** (visors dial in); `--viewer-pk` = dial a remote hypervisor.

## Key derivation (the interesting part)

`DeriveStandaloneKey(parentSK, index)` = `HMAC-SHA256(parentSK, label‖index)` → `GenerateDeterministicKeyPair`. It is:
- **One-way** — the child reveals nothing about the parent (PRF), so a cracked password on a generated file can't expose your hypervisor seckey; worst case is "remove that PK from your visors' `hypervisors[]`".
- **Deterministic + indexed** — same `parentSK`+`index` → same key (regenerable from the one root, **no separate secret to back up**); distinct indices mint distinct standalone identities.

`-c <config> [--index N]` derives from the visor's `sk` and prints the derived PK (the one to set as the visors' remote hypervisor). `--sk` overrides; neither = ephemeral. `--password` encrypts the baked-in key (PBKDF2/AES-GCM — the exact format `override.js` decrypts); **the plaintext key never touches the file** (a bare key warns).

## Plumbing

`pkg/wasmhv` embeds `wasm_exec.js` (`WasmExecJS`) so a generated file is self-contained (must match the Go toolchain that built the wasm); `pkg/visor` exports `HypervisorUIFS()` for the embedded Angular assets.

## Validation

End-to-end: `hv gen --wasm dmsg.wasm -c config --password …` derived the key (`02fe928e…`) and wrote a **9.6 MB** fully-inlined `hypervisor.html` (21.6 MB wasm → ~6 MB gzipped). Verified: no external script/style refs survive, `standalone:true`, encrypted `encsk` **only** (no plaintext-key leak), `DecompressionStream` wasm bootstrap. `derive_test.go` covers deterministic / indexed / parent-bound / one-way. Build + lint clean.

## Follow-ups (scoped)

1. **Inline the runtime Angular assets** (i18n JSON + flag/logo PNGs) into a virtual FS `override.js` serves — until then a generated file is untranslated + missing images (app logic works).
2. **Headless-browser validation** of a real bundle (this PR validates structure, not in-browser execution).
3. Optional **tagged 6 MB wasm embed** + `--extract-wasm` so `hv gen` works out-of-box (and an in-UI "save standalone" button).