### PR TITLE
feat(wasmhv): inline runtime assets into the standalone hypervisor.html

### DIFF
--- a/pkg/wasmhv/generate.go
+++ b/pkg/wasmhv/generate.go
@@ -125,7 +125,12 @@ func GenerateStandalone(uiFS fs.FS, wasmExecJS, wasm, overrideJS []byte, cfg Sta
 	if err != nil {
 		return nil, err
 	}
+	assetsJS, err := assetMapJS(uiFS)
+	if err != nil {
+		return nil, err
+	}
 	head := "\n<script>" + cfgJS + "</script>\n" +
+		"<script>" + assetsJS + "</script>\n" +
 		"<script>" + jsSafe(wasmExecJS) + "</script>\n" +
 		"<script>" + wasmJS + "</script>\n" +
 		"<script>" + jsSafe(overrideJS) + "</script>\n"
@@ -220,6 +225,88 @@ func wasmBootstrap(wasm []byte) (string, error) {
   var res = await WebAssembly.instantiate(buf, go.importObject);
   go.run(res.instance);
 })();`, nil
+}
+
+// assetMapJS inlines the UI's runtime assets (everything under assets/ — i18n
+// JSON, images, fonts) into a JS object the standalone file serves locally:
+//
+//	self.__SKYWIRE_ASSETS__ = {"/assets/i18n/en.json":{ct:"application/json",b:"<base64>"}, ...}
+//
+// override.js's serve() returns these directly (no backend, no dmsg round-trip),
+// so a file:// hypervisor.html shows translations + images. Empty string when the
+// FS has no assets/ dir. The base64 inflates the file ~33% over the raw asset
+// size (gzip / excluding the country-flag PNGs are future size levers).
+func assetMapJS(uiFS fs.FS) (string, error) {
+	if _, err := fs.Stat(uiFS, "assets"); err != nil {
+		return "self.__SKYWIRE_ASSETS__={};", nil //nolint:nilerr // no assets dir → empty map
+	}
+	var b strings.Builder
+	b.WriteString("self.__SKYWIRE_ASSETS__={")
+	first := true
+	err := fs.WalkDir(uiFS, "assets", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, rErr := fs.ReadFile(uiFS, path)
+		if rErr != nil {
+			return rErr
+		}
+		if !first {
+			b.WriteByte(',')
+		}
+		first = false
+		b.WriteString(jsString("/" + path))
+		b.WriteString(":{ct:")
+		b.WriteString(jsString(assetContentType(path)))
+		b.WriteString(",b:")
+		b.WriteString(jsString(base64.StdEncoding.EncodeToString(data)))
+		b.WriteByte('}')
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("inline assets: %w", err)
+	}
+	b.WriteString("};")
+	return b.String(), nil
+}
+
+// assetContentType maps a file extension to a MIME type for the inlined assets.
+func assetContentType(path string) string {
+	dot := strings.LastIndexByte(path, '.')
+	if dot < 0 {
+		return "application/octet-stream"
+	}
+	switch strings.ToLower(path[dot+1:]) {
+	case "json":
+		return "application/json"
+	case "png":
+		return "image/png"
+	case "svg":
+		return "image/svg+xml"
+	case "jpg", "jpeg":
+		return "image/jpeg"
+	case "gif":
+		return "image/gif"
+	case "webp":
+		return "image/webp"
+	case "css":
+		return "text/css"
+	case "js":
+		return "text/javascript"
+	case "woff2":
+		return "font/woff2"
+	case "woff":
+		return "font/woff"
+	case "ttf":
+		return "font/ttf"
+	case "eot":
+		return "application/vnd.ms-fontobject"
+	default:
+		return "application/octet-stream"
+	}
 }
 
 // jsSafe prevents an inlined script's bytes from prematurely closing the

--- a/pkg/wasmhv/generate_test.go
+++ b/pkg/wasmhv/generate_test.go
@@ -22,9 +22,11 @@ func fakeUI() fstest.MapFS {
 		`<script src="main.def.js" type="module"></script>` +
 		`</head><body><app-root></app-root></body></html>`
 	return fstest.MapFS{
-		"index.html":     {Data: []byte(index)},
-		"main.def.js":    {Data: []byte("console.log('app'); var x='</script>';")},
-		"styles.abc.css": {Data: []byte("body{margin:0}")},
+		"index.html":          {Data: []byte(index)},
+		"main.def.js":         {Data: []byte("console.log('app'); var x='</script>';")},
+		"styles.abc.css":      {Data: []byte("body{margin:0}")},
+		"assets/i18n/en.json": {Data: []byte(`{"hello":"world"}`)},
+		"assets/img/logo.png": {Data: []byte("\x89PNG\x00binary")},
 	}
 }
 
@@ -64,6 +66,14 @@ func TestGenerateStandalone_Structure(t *testing.T) {
 	require.Contains(t, s, "/*override*/")
 	require.Less(t, strings.Index(s, "/*override*/"), strings.Index(s, "console.log('app')"),
 		"override.js must precede the Angular app chunk")
+
+	// Runtime assets inlined into the served map with the right path + content
+	// type, base64-encoded.
+	require.Contains(t, s, "self.__SKYWIRE_ASSETS__={")
+	require.Contains(t, s, `"/assets/i18n/en.json":{ct:"application/json",b:"`+
+		base64.StdEncoding.EncodeToString([]byte(`{"hello":"world"}`))+`"}`)
+	require.Contains(t, s, `"/assets/img/logo.png":{ct:"image/png",b:"`+
+		base64.StdEncoding.EncodeToString([]byte("\x89PNG\x00binary"))+`"}`)
 }
 
 func TestGenerateStandalone_ViewerMode(t *testing.T) {

--- a/pkg/wasmhv/override.js
+++ b/pkg/wasmhv/override.js
@@ -99,6 +99,29 @@
     catch (e) { return url; }
   }
 
+  // assetResponse serves a runtime asset (i18n JSON, images, fonts) inlined into
+  // a standalone file by `cli hv gen` (self.__SKYWIRE_ASSETS__: path -> {ct,b}).
+  // This lets the UI render translations + images with NO backend and NO dmsg
+  // round-trip. Returns null for anything not in the map (e.g. /api/*).
+  function assetResponse(path) {
+    var m = self.__SKYWIRE_ASSETS__;
+    if (!m) return null;
+    var p = path.split('?')[0].split('#')[0];
+    var bare = p.replace(/^\//, '');
+    var a = m[p] || m[bare] || m['/' + bare];
+    if (!a) return null;
+    var bytes = Uint8Array.from(atob(a.b), function (c) { return c.charCodeAt(0); });
+    return { status: 200, body: bytes, headers: { 'Content-Type': a.ct } };
+  }
+
+  // serve resolves one same-origin request: an inlined asset first (instant, no
+  // dmsg), else the dmsg/hvApi dispatch once the client is up.
+  function serve(method, path, body, headers) {
+    var a = assetResponse(path);
+    if (a) return Promise.resolve(a);
+    return ensure().then(function () { return dispatch(method, path, body, headers); });
+  }
+
   // --- XMLHttpRequest shim (Angular HttpClient's default backend) ---
   var RealXHR = window.XMLHttpRequest;
   function ShimXHR() {
@@ -135,9 +158,7 @@
       };
       real.send(body); return;
     }
-    ensure().then(function () {
-      return dispatch(self_._m, pathOf(self_._u), body, self_._h);
-    }).then(function (r) {
+    serve(self_._m, pathOf(self_._u), body, self_._h).then(function (r) {
       self_.status = r.status; self_.statusText = '';
       var txt = new TextDecoder().decode(r.body);
       self_.responseText = txt;
@@ -167,9 +188,7 @@
       if (init.headers.forEach) init.headers.forEach(function (v, k) { headers[k] = v; });
       else for (var k in init.headers) headers[k] = init.headers[k];
     }
-    return ensure().then(function () {
-      return dispatch(init.method || 'GET', pathOf(url), init.body, headers);
-    }).then(function (r) {
+    return serve(init.method || 'GET', pathOf(url), init.body, headers).then(function (r) {
       var h = new Headers();
       for (var k in r.headers) { try { h.set(k, r.headers[k]); } catch (e) {} }
       return new Response(r.body, { status: r.status, headers: h });


### PR DESCRIPTION
## What

A generated standalone `hypervisor.html` previously showed **untranslated strings + broken images** — the Angular app fetches its runtime assets (i18n JSON, flag/logo images, fonts under `assets/`) at load, and from `file://` there's no backend to serve them.

The generator now **inlines everything under `assets/`** into a JS map:
```
self.__SKYWIRE_ASSETS__ = {"/assets/i18n/en.json":{ct:"application/json",b:"<base64>"}, ...}
```
and `override.js` serves them locally. A new `serve()` checks `assetResponse()` **first — before `ensure()`** — so assets resolve **instantly, with no dmsg round-trip**, and the UI renders translations + images even before the dmsg client connects. Non-asset paths (`/api/*`) fall through to the dmsg/hvApi dispatch as before. Works in both standalone and viewer modes (inlined assets beat a remote fetch either way).

## Cost

base64 adds ~33% over the raw asset size (~3.5 MB assets → ~4.7 MB), so a generated file grows accordingly. **gzip** (like the wasm) and **excluding the 1 MB of country-flag PNGs** are noted size levers for later.

## Tests

`generate_test.go` asserts the asset map is inlined with the correct path + content-type + base64 (i18n JSON + a PNG). Build + JS-syntax + lint clean.

## Remaining

Headless-browser validation of a real bundle — this PR covers structure (no external refs, correct inlining); confirming actual in-browser execution (wasm boots, dmsg connects, UI renders) is the last step before this is a genuinely droppable file.