### PR TITLE
feat(visorconfig)+cli: wallet-like KeyRing for deterministic derived keys

### DIFF
--- a/cmd/skywire-cli/commands/hv/gen.go
+++ b/cmd/skywire-cli/commands/hv/gen.go
@@ -2,14 +2,13 @@
 package clihv
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/visor"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 	"github.com/skycoin/skywire/pkg/wasmhv"
 )
 
@@ -30,7 +29,7 @@ func init() {
 	genCmd.Flags().StringVar(&genWasm, "wasm", "", "path to the js/wasm dmsg-client binary (build: make dmsg-wasm) [required]")
 	genCmd.Flags().StringVarP(&genOut, "out", "o", "hypervisor.html", "output file")
 	genCmd.Flags().StringVarP(&genConf, "conf", "c", "", "visor config to derive the standalone key from (uses its sk)")
-	genCmd.Flags().Uint32Var(&genIndex, "index", 0, "derivation index — distinct indices mint distinct standalone identities from one root")
+	genCmd.Flags().Uint32Var(&genIndex, "index", 0, "with -c: re-derive keyring entry at this index (read-only); omit to mint+record the next one")
 	genCmd.Flags().StringVar(&genSK, "sk", "", "explicit standalone secret key (hex) — skips derivation")
 	genCmd.Flags().StringVar(&genPassword, "password", "", "encrypt the baked-in key with this password (recommended)")
 	genCmd.Flags().StringVar(&genViewerPK, "viewer-pk", "", "viewer mode: dial this remote hypervisor PK (default: standalone — visors dial in)")
@@ -105,52 +104,45 @@ train users to type secret keys into pages from external hosts.`,
 }
 
 // resolveKey returns the standalone secret-key hex to bake in: explicit (--sk),
-// derived from the config's visor key (-c [+--index]), or "" (ephemeral). When
-// deriving, it prints the derived public key — the PK to set as the visors'
-// remote hypervisor (standalone mode).
+// minted from the visor config's KeyRing (-c), or "" (ephemeral).
+//
+// With -c and no explicit --index, it MINTS the next keyring key (deterministic,
+// derived one-way from the visor key), records it in the config's KeyRing, and
+// flushes — the wallet "derive a new address" behavior. With --index N it
+// re-derives entry N read-only (idempotent regeneration; no config write).
+// Either way it prints the derived address + PK (the PK to set as the visors'
+// remote hypervisor in standalone mode).
 func resolveKey(cmd *cobra.Command) (string, error) {
 	switch {
 	case genSK != "":
 		var sk cipher.SecKey
 		if err := sk.Set(genSK); err != nil {
-			return "", fmt.Errorf("bad --sk: %w", err)
+			return "", err
 		}
 		return genSK, nil
 	case genConf != "":
-		parentSK, err := configSK(genConf)
+		conf, err := visorconfig.ReadFile(genConf)
 		if err != nil {
 			return "", err
 		}
-		pk, sk, err := wasmhv.DeriveStandaloneKey(parentSK, genIndex)
-		if err != nil {
-			return "", err
+		var entry visorconfig.KeyEntry
+		if cmd.Flags().Changed("index") {
+			if entry, err = conf.DeriveKeyEntry(wasmhv.StandaloneKeyLabel, genIndex); err != nil {
+				return "", err
+			}
+			cmd.Printf("re-derived keyring entry %d — address %s, PK %s\n", entry.Index, entry.Address, entry.PublicKey)
+		} else {
+			if entry, err = conf.MintKey(wasmhv.StandaloneKeyLabel); err != nil {
+				return "", err
+			}
+			if err = conf.Flush(); err != nil {
+				return "", err
+			}
+			cmd.Printf("minted keyring entry %d (recorded in %s) — address %s, PK %s\n", entry.Index, genConf, entry.Address, entry.PublicKey)
 		}
-		cmd.Printf("derived standalone hypervisor PK (index %d): %s\n", genIndex, pk.Hex())
-		return sk.Hex(), nil
+		return entry.SecretKey, nil
 	default:
 		cmd.PrintErrln("note: no --sk or -c given; the file uses an ephemeral identity (a fresh key each load)")
 		return "", nil
 	}
-}
-
-// configSK reads the visor secret key from a config file's top-level "sk".
-func configSK(path string) (cipher.SecKey, error) {
-	b, err := os.ReadFile(path) //nolint:gosec // operator-supplied path
-	if err != nil {
-		return cipher.SecKey{}, fmt.Errorf("read config %q: %w", path, err)
-	}
-	var c struct {
-		SK string `json:"sk"`
-	}
-	if err := json.Unmarshal(b, &c); err != nil {
-		return cipher.SecKey{}, fmt.Errorf("parse config %q: %w", path, err)
-	}
-	if c.SK == "" {
-		return cipher.SecKey{}, fmt.Errorf("config %q has no \"sk\"", path)
-	}
-	var sk cipher.SecKey
-	if err := sk.Set(c.SK); err != nil {
-		return cipher.SecKey{}, fmt.Errorf("config %q has invalid sk: %w", path, err)
-	}
-	return sk, nil
 }

--- a/pkg/cipher/cipher.go
+++ b/pkg/cipher/cipher.go
@@ -4,7 +4,11 @@ package cipher
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -123,6 +127,25 @@ func GenerateKeyPair() (PubKey, SecKey) {
 func GenerateDeterministicKeyPair(seed []byte) (PubKey, SecKey, error) {
 	pk, sk, err := cipher.GenerateDeterministicKeyPair(seed)
 	return PubKey(pk), SecKey(sk), err
+}
+
+// DeriveChildKey derives a child keypair from a parent secret key, deterministic
+// and one-way: the seed is HMAC-SHA256(parentSK, label||index), a PRF whose
+// output reveals nothing about parentSK, fed to GenerateDeterministicKeyPair. So
+// a leaked child key can't expose the parent, the same (parentSK, label, index)
+// always yields the same key (regenerable — no separate backup), and label +
+// index namespace distinct child identities from one root. The label should be a
+// purpose-scoped domain string (e.g. "skywire-standalone-hypervisor:v1:").
+func DeriveChildKey(parentSK SecKey, label string, index uint32) (PubKey, SecKey, error) {
+	if parentSK.Null() {
+		return PubKey{}, SecKey{}, errors.New("cipher: DeriveChildKey: parent secret key is null")
+	}
+	var idx [4]byte
+	binary.BigEndian.PutUint32(idx[:], index)
+	mac := hmac.New(sha256.New, parentSK[:])
+	_, _ = mac.Write([]byte(label)) //nolint:errcheck // hash.Write never errors
+	_, _ = mac.Write(idx[:])        //nolint:errcheck
+	return GenerateDeterministicKeyPair(mac.Sum(nil))
 }
 
 // NewPubKey converts []byte to a PubKey

--- a/pkg/visor/visorconfig/config_compat.go
+++ b/pkg/visor/visorconfig/config_compat.go
@@ -55,6 +55,7 @@ type v1JSON struct {
 	UserSurveyWhitelist []cipher.PubKey `json:"user_survey_whitelist,omitempty"`
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
 	CLIAddr             string          `json:"cli_addr"`
+	KeyRing             *KeyRing        `json:"keyring,omitempty"`
 
 	LogLevel             string                       `json:"log_level"`
 	LocalPath            string                       `json:"local_path"`
@@ -112,6 +113,7 @@ func (v *V1) UnmarshalJSON(data []byte) error {
 	v.UserSurveyWhitelist = mirror.UserSurveyWhitelist
 	v.Hypervisors = mirror.Hypervisors
 	v.CLIAddr = mirror.CLIAddr
+	v.KeyRing = mirror.KeyRing
 	v.LogLevel = mirror.LogLevel
 	v.LocalPath = mirror.LocalPath
 	v.StunServers = mirror.StunServers

--- a/pkg/visor/visorconfig/keyring.go
+++ b/pkg/visor/visorconfig/keyring.go
@@ -1,0 +1,82 @@
+package visorconfig
+
+import (
+	scoincipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// KeyRingTypeDeterministic is the only KeyRing.Type today: keys are derived from
+// the visor secret key (the implicit seed) by a one-way HMAC chain, in the
+// spirit of a skycoin deterministic wallet.
+const KeyRingTypeDeterministic = "deterministic"
+
+// KeyEntry is one deterministically-derived key in the visor KeyRing — shaped
+// like a skycoin wallet entry (address / public_key / secret_key) plus the
+// derivation index and a purpose label.
+type KeyEntry struct {
+	Index     uint32 `json:"index"`
+	Label     string `json:"label,omitempty"`
+	Address   string `json:"address"`
+	PublicKey string `json:"public_key"`
+	SecretKey string `json:"secret_key"`
+}
+
+// KeyRing is a small wallet-like set of deterministically-derived keys recorded
+// in the visor config, shaped loosely like a skycoin deterministic wallet (a
+// type + tracked next-index + entries with address/public_key/secret_key).
+//
+// The keys are derived ONE-WAY from the visor secret key (the implicit seed) via
+// cipher.DeriveChildKey, so they are regenerable from the one visor key (no
+// separate backup) and a leaked child can't expose the visor key. This is used
+// to mint standalone-hypervisor identities (cli hv gen) deterministically
+// instead of random, unrelated keys — so the standalone hypervisor is provably a
+// child of the visor and recoverable.
+type KeyRing struct {
+	Type      string     `json:"type"`
+	NextIndex uint32     `json:"next_index"`
+	Entries   []KeyEntry `json:"entries,omitempty"`
+}
+
+// deriveKeyEntry derives (read-only, no mutation) the entry for label+index from
+// the visor secret key.
+func (v1 *V1) deriveKeyEntry(label string, index uint32) (KeyEntry, error) {
+	pk, sk, err := cipher.DeriveChildKey(v1.SK, label, index)
+	if err != nil {
+		return KeyEntry{}, err
+	}
+	return KeyEntry{
+		Index:     index,
+		Label:     label,
+		Address:   scoincipher.AddressFromPubKey(scoincipher.PubKey(pk)).String(),
+		PublicKey: pk.Hex(),
+		SecretKey: sk.Hex(),
+	}, nil
+}
+
+// DeriveKeyEntry derives the keyring entry for label+index from the visor secret
+// key, deterministic and without mutating the config — for regenerating a known
+// entry (same input → same key).
+func (v1 *V1) DeriveKeyEntry(label string, index uint32) (KeyEntry, error) {
+	v1.mu.RLock()
+	defer v1.mu.RUnlock()
+	return v1.deriveKeyEntry(label, index)
+}
+
+// MintKey derives the NEXT keyring entry (at KeyRing.NextIndex) for the given
+// label, appends it, and advances NextIndex — the wallet "derive a new address"
+// operation. The caller persists with Flush(). Returns the minted entry.
+func (v1 *V1) MintKey(label string) (KeyEntry, error) {
+	v1.mu.Lock()
+	defer v1.mu.Unlock()
+	if v1.KeyRing == nil {
+		v1.KeyRing = &KeyRing{Type: KeyRingTypeDeterministic}
+	}
+	entry, err := v1.deriveKeyEntry(label, v1.KeyRing.NextIndex)
+	if err != nil {
+		return KeyEntry{}, err
+	}
+	v1.KeyRing.Entries = append(v1.KeyRing.Entries, entry)
+	v1.KeyRing.NextIndex++
+	return entry, nil
+}

--- a/pkg/visor/visorconfig/keyring_test.go
+++ b/pkg/visor/visorconfig/keyring_test.go
@@ -1,0 +1,56 @@
+package visorconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func testV1(t *testing.T, sk cipher.SecKey) *V1 {
+	pk, err := sk.PubKey()
+	require.NoError(t, err)
+	return &V1{Common: &Common{SK: sk, PK: pk}}
+}
+
+func TestKeyRingMintAndDerive(t *testing.T) {
+	const label = "skywire-standalone-hypervisor:v1:"
+	_, sk := cipher.GenerateKeyPair()
+	v1 := testV1(t, sk)
+
+	// Mint advances NextIndex and records entries.
+	e0, err := v1.MintKey(label)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), e0.Index)
+	e1, err := v1.MintKey(label)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), e1.Index)
+
+	require.NotNil(t, v1.KeyRing)
+	require.Equal(t, KeyRingTypeDeterministic, v1.KeyRing.Type)
+	require.Equal(t, uint32(2), v1.KeyRing.NextIndex)
+	require.Len(t, v1.KeyRing.Entries, 2)
+	require.NotEqual(t, e0.PublicKey, e1.PublicKey, "distinct indices → distinct keys")
+
+	// Read-only derive reproduces a minted entry exactly (deterministic).
+	got, err := v1.DeriveKeyEntry(label, 0)
+	require.NoError(t, err)
+	require.Equal(t, e0, got)
+
+	// Entry is self-consistent: the recorded PK matches the recorded SK, and
+	// matches the shared cipher.DeriveChildKey primitive (the one
+	// wasmhv.DeriveStandaloneKey also delegates to).
+	var esk cipher.SecKey
+	require.NoError(t, esk.Set(e0.SecretKey))
+	derivedPK, err := esk.PubKey()
+	require.NoError(t, err)
+	require.Equal(t, e0.PublicKey, derivedPK.Hex())
+
+	wantPK, _, err := cipher.DeriveChildKey(sk, label, 0)
+	require.NoError(t, err)
+	require.Equal(t, wantPK.Hex(), e0.PublicKey)
+
+	// A non-empty skycoin address was recorded.
+	require.NotEmpty(t, e0.Address)
+}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -44,6 +44,11 @@ type V1 struct {
 	Hypervisors         []cipher.PubKey `json:"hypervisors"`
 	CLIAddr             string          `json:"cli_addr"`
 
+	// KeyRing is a small wallet-like set of deterministically-derived keys (from
+	// the visor secret key). Currently mints standalone-hypervisor identities
+	// (cli hv gen). Optional; absent on visors that never derived one.
+	KeyRing *KeyRing `json:"keyring,omitempty"`
+
 	LogLevel             string                       `json:"log_level"`
 	LocalPath            string                       `json:"local_path"`
 	StunServers          []string                     `json:"stun_servers"`

--- a/pkg/wasmhv/derive.go
+++ b/pkg/wasmhv/derive.go
@@ -1,17 +1,14 @@
 package wasmhv
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/binary"
-	"fmt"
-
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-// deriveLabel namespaces the standalone-hypervisor key derivation so the seed
-// can't collide with any other use of the parent key.
-const deriveLabel = "skywire-standalone-hypervisor:v1:"
+// StandaloneKeyLabel namespaces the standalone-hypervisor key derivation so the
+// seed can't collide with any other use of the parent key. It is the label
+// passed to cipher.DeriveChildKey; a visor KeyRing minting standalone-HV
+// identities uses the same label so its entries match DeriveStandaloneKey.
+const StandaloneKeyLabel = "skywire-standalone-hypervisor:v1:"
 
 // DeriveStandaloneKey deterministically derives a standalone-hypervisor keypair
 // from the parent (visor / hypervisor) secret key.
@@ -27,20 +24,5 @@ const deriveLabel = "skywire-standalone-hypervisor:v1:"
 // back up), and distinct indices mint distinct standalone identities (one per
 // device / tab) from the single root.
 func DeriveStandaloneKey(parentSK cipher.SecKey, index uint32) (cipher.PubKey, cipher.SecKey, error) {
-	if parentSK.Null() {
-		return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("derive standalone key: parent secret key is null")
-	}
-	var idx [4]byte
-	binary.BigEndian.PutUint32(idx[:], index)
-
-	mac := hmac.New(sha256.New, parentSK[:])
-	_, _ = mac.Write([]byte(deriveLabel)) //nolint:errcheck // hash.Write never errors
-	_, _ = mac.Write(idx[:])              //nolint:errcheck
-	seed := mac.Sum(nil)
-
-	pk, sk, err := cipher.GenerateDeterministicKeyPair(seed)
-	if err != nil {
-		return cipher.PubKey{}, cipher.SecKey{}, fmt.Errorf("derive standalone key: %w", err)
-	}
-	return pk, sk, nil
+	return cipher.DeriveChildKey(parentSK, StandaloneKeyLabel, index)
 }


### PR DESCRIPTION
## What

Gives the visor config a small **wallet-like keyring** so the standalone hypervisor uses a **deterministically-derived child of the visor key** instead of a random, unrelated one — and so derived keys are *tracked* (no index reuse), in the spirit of a skycoin deterministic wallet. Deliberately minimal.

## Pieces

- **`cipher.DeriveChildKey(parentSK, label, index)`** — the shared one-way derivation primitive: `seed = HMAC-SHA256(parentSK, label‖index)` → `GenerateDeterministicKeyPair`. One-way (a leaked child can't expose the parent), deterministic (regenerable from the one visor key — no separate backup), label+index namespaced. `wasmhv.DeriveStandaloneKey` now delegates to it (output-preserving) and exports `StandaloneKeyLabel`.
- **`visorconfig.KeyRing` / `KeyEntry`** (config field `"keyring"`) — wallet-shaped: `type` + `next_index` + `entries{index,label,address,public_key,secret_key}`, with the **skycoin address derived from the public key**. `V1.MintKey(label)` derives the next entry and advances `next_index` (the "derive a new address" op); `DeriveKeyEntry` re-derives a known entry read-only. Added `KeyRing` to the custom-`UnmarshalJSON` mirror (`config_compat`) so it round-trips.
- **`cli hv gen`** — with `-c <config>` it mints the next keyring key, **records it, and flushes the config** (prints the derived address + PK to set as the visors' remote hypervisor); `--index N` re-derives a known entry read-only (no write); `--sk` still overrides.

## Validation

End-to-end on a config *copy* (never the live one): minting advances 0→1 with distinct keys/addresses, the keyring round-trips through load→mint→flush, and the rest of the config is preserved (sk/pk/launcher/dmsg/… intact). Tests cover derivation determinism + keyring mint/derive consistency with the shared primitive. Build + lint clean.

## Scope

Intentionally just the keyring + deterministic derivation for the standalone hypervisor. Fleet provisioning, xpub watch-only, and any activity-ledger ideas are **out of scope** pending a clear problem to solve (per discussion).