### PR TITLE
refactor(visorconfig): drop the skycoin address from KeyRing entries

### DIFF
--- a/cmd/skywire-cli/commands/hv/gen.go
+++ b/cmd/skywire-cli/commands/hv/gen.go
@@ -130,7 +130,7 @@ func resolveKey(cmd *cobra.Command) (string, error) {
 			if entry, err = conf.DeriveKeyEntry(wasmhv.StandaloneKeyLabel, genIndex); err != nil {
 				return "", err
 			}
-			cmd.Printf("re-derived keyring entry %d — address %s, PK %s\n", entry.Index, entry.Address, entry.PublicKey)
+			cmd.Printf("re-derived keyring entry %d — PK %s\n", entry.Index, entry.PublicKey)
 		} else {
 			if entry, err = conf.MintKey(wasmhv.StandaloneKeyLabel); err != nil {
 				return "", err
@@ -138,7 +138,7 @@ func resolveKey(cmd *cobra.Command) (string, error) {
 			if err = conf.Flush(); err != nil {
 				return "", err
 			}
-			cmd.Printf("minted keyring entry %d (recorded in %s) — address %s, PK %s\n", entry.Index, genConf, entry.Address, entry.PublicKey)
+			cmd.Printf("minted keyring entry %d (recorded in %s) — PK %s\n", entry.Index, genConf, entry.PublicKey)
 		}
 		return entry.SecretKey, nil
 	default:

--- a/pkg/visor/visorconfig/keyring.go
+++ b/pkg/visor/visorconfig/keyring.go
@@ -1,8 +1,6 @@
 package visorconfig
 
 import (
-	scoincipher "github.com/skycoin/skycoin/src/cipher"
-
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
@@ -11,20 +9,20 @@ import (
 // spirit of a skycoin deterministic wallet.
 const KeyRingTypeDeterministic = "deterministic"
 
-// KeyEntry is one deterministically-derived key in the visor KeyRing — shaped
-// like a skycoin wallet entry (address / public_key / secret_key) plus the
-// derivation index and a purpose label.
+// KeyEntry is one deterministically-derived keypair in the visor KeyRing — the
+// derivation index, a purpose label, and the public/secret key. (No skycoin
+// address: the keyring's only use is the standalone-hypervisor identity keypair,
+// not a payment wallet.)
 type KeyEntry struct {
 	Index     uint32 `json:"index"`
 	Label     string `json:"label,omitempty"`
-	Address   string `json:"address"`
 	PublicKey string `json:"public_key"`
 	SecretKey string `json:"secret_key"`
 }
 
 // KeyRing is a small wallet-like set of deterministically-derived keys recorded
 // in the visor config, shaped loosely like a skycoin deterministic wallet (a
-// type + tracked next-index + entries with address/public_key/secret_key).
+// type + tracked next-index + entries with public/secret keys).
 //
 // The keys are derived ONE-WAY from the visor secret key (the implicit seed) via
 // cipher.DeriveChildKey, so they are regenerable from the one visor key (no
@@ -48,7 +46,6 @@ func (v1 *V1) deriveKeyEntry(label string, index uint32) (KeyEntry, error) {
 	return KeyEntry{
 		Index:     index,
 		Label:     label,
-		Address:   scoincipher.AddressFromPubKey(scoincipher.PubKey(pk)).String(),
 		PublicKey: pk.Hex(),
 		SecretKey: sk.Hex(),
 	}, nil

--- a/pkg/visor/visorconfig/keyring_test.go
+++ b/pkg/visor/visorconfig/keyring_test.go
@@ -50,7 +50,4 @@ func TestKeyRingMintAndDerive(t *testing.T) {
 	wantPK, _, err := cipher.DeriveChildKey(sk, label, 0)
 	require.NoError(t, err)
 	require.Equal(t, wantPK.Hex(), e0.PublicKey)
-
-	// A non-empty skycoin address was recorded.
-	require.NotEmpty(t, e0.Address)
 }


### PR DESCRIPTION
The KeyRing's only purpose is the **standalone-hypervisor identity keypair**, not a payment wallet, so the derived skycoin address on each entry was vestigial — a leftover of the deferred wallet/ledger idea.

Removes `KeyEntry.Address` + its derivation (and the `skycoin/src/cipher` import). `cli hv gen` now prints just the derived PK. Build + test + lint clean.