### PR TITLE
fix(dmsg-disc): coarsen clients-by-server CXO publish window (1s→30s) — fixes ~2.8-core GC overload

### DIFF
--- a/pkg/dmsg/discovery/api/cxo_publisher.go
+++ b/pkg/dmsg/discovery/api/cxo_publisher.go
@@ -49,6 +49,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -59,6 +60,26 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
+
+// clientsByServerCXOBatchWindow coalesces the publisher's tree mutations before
+// it re-encodes + publishes the clients-by-server tree.
+//
+// Why override the treestore default (1s): publishIfDirty clones AND re-encodes
+// the ENTIRE in-memory tree per publish (cloneMemNode / encodeNode / delRoot —
+// O(tree size), independent of how many leaves changed). The clients-by-server
+// tree spans every delegated (server, client) pair across the whole network, so
+// at the 1s default, under the steady register + heartbeat churn there is always
+// something dirty and the full tree is re-cloned+encoded every second. That made
+// dmsg-discovery GC-bound at ~2.8 cores (observed 2026-06-22: 286% CPU, ~55% in
+// scanObject/sweep, ~1.5 TB cumulative alloc under cxo clone/encode).
+//
+// A larger window does NOT make any single publish more expensive (the encode
+// cost is the tree's CURRENT size, not the mutation count since last publish) —
+// it just publishes less often. This feed only drives the hypervisor's network
+// visualizer, where 30s staleness is imperceptible, so a coarse window cuts the
+// whole-tree re-encode frequency ~30x for no meaningful loss. (TPD's CXO
+// publishers run 60s; this sits between that and the old 1s.)
+const clientsByServerCXOBatchWindow = 30 * time.Second
 
 // json is the package-scope jsoniter.ConfigFastest value declared
 // in api.go. We reuse it here to avoid pulling in encoding/json
@@ -103,9 +124,10 @@ func StartClientsByServerCXOPublisher(dmsgC *dmsg.Client, sk cipher.SecKey, logg
 	log := logging.MustGetLogger("dmsgd-cxo-clients-pub")
 
 	pub, err := treestore.NewWithDMSG(dmsgC, sk, treestore.PubConfig{
-		Logger:     log,
-		InMemoryDB: true, // recomputed from redis on every mutation
-		DmsgPort:   skyenv.DmsgDMSGDClientsByServerCXOPort,
+		Logger:      log,
+		InMemoryDB:  true, // recomputed from redis on every mutation
+		DmsgPort:    skyenv.DmsgDMSGDClientsByServerCXOPort,
+		BatchWindow: clientsByServerCXOBatchWindow, // coarse: this feed only drives network-viz; avoids per-second whole-tree re-encode (see const doc)
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Symptom
dmsg-discovery sustained at **~286% CPU (~2.8 cores), ~55% in GC** on the deployment box. SD and the co-located visor are healthy.

## Diagnosis (pprof via the resolving proxy)
- CPU is **not** request-handling — secp256k1 sig-verify is only ~7%.
- Allocation profile (~**1.5 TB** cumulative) is dominated by `cxo/skyobject.(*Index).delRoot` (16.8%), `cxo/treestore.cloneMemNode` (13.2%), `cxo/treestore.encodeNode` (9.6%) → GC-bound on CXO churn.
- Source: the `ClientsByServerCXOPublisher`. `publishIfDirty` **clones + re-encodes the entire clients-by-server tree per publish** (O(tree size), not O(changed leaves)). The tree spans every delegated `(server, client)` pair network-wide.
- It never set `PubConfig.BatchWindow`, so it defaulted to **1s**. Under the network's steady register + heartbeat churn there is always something dirty → the whole tree was re-cloned + re-encoded **every second**.

## Fix
Set `BatchWindow = 30s` for this publisher. A larger window does **not** make any single publish more expensive (encode cost = the tree's *current size*, not the coalesced mutation count) — it just publishes ~30× less often. This feed only drives the hypervisor's network visualizer, where 30s staleness is imperceptible. TPD's CXO publishers already run 60s; the 1s default was simply un-overridden here. The existing heartbeat short-circuit + per-event diff are unchanged.

## Deploy note
Needs the **dmsg-discovery service redeployed** to take effect.